### PR TITLE
remove active column from windows commands tables

### DIFF
--- a/server/datastore/mysql/apple_mdm_test.go
+++ b/server/datastore/mysql/apple_mdm_test.go
@@ -2971,7 +2971,7 @@ func testGetMDMAppleCommandResults(t *testing.T, ds *Datastore) {
 
 	// enqueue a command for an unenrolled host fails with a foreign key error (no enrollment)
 	uuid1 := uuid.New().String()
-	err = commander.EnqueueCommand(ctx, []string{unenrolledHost.UUID}, createRawAppleCmd(uuid1))
+	err = commander.EnqueueCommand(ctx, []string{unenrolledHost.UUID}, createRawAppleCmd("ProfileList", uuid1))
 	require.Error(t, err)
 	var mysqlErr *mysql.MySQLError
 	require.ErrorAs(t, err, &mysqlErr)
@@ -2988,7 +2988,7 @@ func testGetMDMAppleCommandResults(t *testing.T, ds *Datastore) {
 
 	// enqueue a command for a couple of enrolled hosts
 	uuid2 := uuid.New().String()
-	rawCmd2 := createRawAppleCmd(uuid2)
+	rawCmd2 := createRawAppleCmd("ProfileList", uuid2)
 	err = commander.EnqueueCommand(ctx, []string{enrolledHosts[0].UUID, enrolledHosts[1].UUID}, rawCmd2)
 	require.NoError(t, err)
 
@@ -3234,24 +3234,6 @@ func testMDMAppleBootstrapPackageCRUD(t *testing.T, ds *Datastore) {
 
 func testListMDMAppleCommands(t *testing.T, ds *Datastore) {
 	ctx := context.Background()
-
-	createRawAppleCmd := func(reqType, cmdUUID string) string {
-		return fmt.Sprintf(`<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-    <key>Command</key>
-    <dict>
-        <key>ManagedOnly</key>
-        <false/>
-        <key>RequestType</key>
-        <string>%s</string>
-    </dict>
-    <key>CommandUUID</key>
-    <string>%s</string>
-</dict>
-</plist>`, reqType, cmdUUID)
-	}
 
 	// create some enrolled hosts
 	enrolledHosts := make([]*fleet.Host, 3)
@@ -5215,7 +5197,7 @@ func TestRestorePendingDEPHost(t *testing.T) {
 	})
 }
 
-func createRawAppleCmd(cmdUUID string) string {
+func createRawAppleCmd(reqType, cmdUUID string) string {
 	return fmt.Sprintf(`<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
@@ -5225,10 +5207,10 @@ func createRawAppleCmd(cmdUUID string) string {
         <key>ManagedOnly</key>
         <false/>
         <key>RequestType</key>
-        <string>ProfileList</string>
+        <string>%s</string>
     </dict>
     <key>CommandUUID</key>
     <string>%s</string>
 </dict>
-</plist>`, cmdUUID)
+</plist>`, reqType, cmdUUID)
 }

--- a/server/datastore/mysql/mdm.go
+++ b/server/datastore/mysql/mdm.go
@@ -53,12 +53,6 @@ WHERE
    nvq.active = 1
 `
 
-	// TODO(roberto): note how we're not filtering by `active = 1` on windows.
-	// Nano behaves like this:
-	// - When a device is unenrolled, all pending commands are set `active = 0`
-	// - When a command is delivered, the entry is removed from the table
-	//
-	// In Windows, we set `active = 0` when we get the results of the command. What we should do?
 	windowsStmt := `
 SELECT
     mwe.host_uuid,

--- a/server/datastore/mysql/mdm_test.go
+++ b/server/datastore/mysql/mdm_test.go
@@ -98,7 +98,7 @@ func testMDMCommands(t *testing.T, ds *Datastore) {
 	require.Equal(t, "Pending", cmds[0].Status)
 
 	appleCmdUUID := uuid.New().String()
-	appleCmd := createRawAppleCmd(appleCmdUUID)
+	appleCmd := createRawAppleCmd("ProfileList", appleCmdUUID)
 	commander, _ := createMDMAppleCommanderAndStorage(t, ds)
 	err = commander.EnqueueCommand(ctx, []string{macH.UUID}, appleCmd)
 	require.NoError(t, err)

--- a/server/datastore/mysql/microsoft_mdm.go
+++ b/server/datastore/mysql/microsoft_mdm.go
@@ -200,7 +200,6 @@ ON
 	wmc.command_uuid = wmcq.command_uuid
 WHERE
 	mwe.mdm_device_id = ? AND
-	wmcq.active AND
 	NOT EXISTS (
 		SELECT 1
 		FROM
@@ -227,7 +226,7 @@ func (ds *Datastore) MDMWindowsSaveResponse(ctx context.Context, deviceID string
 
 	const saveFullRespStmt = `INSERT INTO windows_mdm_responses (enrollment_id, raw_response) VALUES (?, ?)`
 
-	const dequeueCommandsStmt = `UPDATE windows_mdm_command_queue SET active = 0 WHERE command_uuid IN (?)`
+	const dequeueCommandsStmt = `DELETE FROM windows_mdm_command_queue WHERE command_uuid IN (?)`
 
 	// raw_results and status_code values might be inserted on different requests?
 	// TODO: which response_id should we be tracking then? for now, using

--- a/server/datastore/mysql/migrations/tables/20231024105026_AddWindowsMDMTables.go
+++ b/server/datastore/mysql/migrations/tables/20231024105026_AddWindowsMDMTables.go
@@ -34,9 +34,6 @@ CREATE TABLE windows_mdm_command_queue (
 	enrollment_id INT(10) UNSIGNED NOT NULL,
 	command_uuid  VARCHAR(127) NOT NULL,
 
-	-- whether the command should be processed or not (can be deactivated to be ignored)
-	active        BOOLEAN NOT NULL DEFAULT 1,
-
 	created_at    TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
 	updated_at    TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
 

--- a/server/datastore/mysql/schema.sql
+++ b/server/datastore/mysql/schema.sql
@@ -1275,7 +1275,6 @@ CREATE TABLE `users` (
 CREATE TABLE `windows_mdm_command_queue` (
   `enrollment_id` int(10) unsigned NOT NULL,
   `command_uuid` varchar(127) COLLATE utf8mb4_unicode_ci NOT NULL,
-  `active` tinyint(1) NOT NULL DEFAULT '1',
   `created_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
   `updated_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
   PRIMARY KEY (`enrollment_id`,`command_uuid`),

--- a/server/fleet/mdm.go
+++ b/server/fleet/mdm.go
@@ -196,7 +196,7 @@ type MDMCommandResult struct {
 // MDMCommand represents an MDM command that has been enqueued for
 // execution.
 type MDMCommand struct {
-	// DeviceID is the MDM enrollment ID. This is the same as the host UUID.
+	// HostUUID is the UUID of the host targeted by the command.
 	HostUUID string `json:"host_uuid" db:"host_uuid"`
 	// CommandUUID is the unique identifier of the command.
 	CommandUUID string `json:"command_uuid" db:"command_uuid"`
@@ -205,7 +205,7 @@ type MDMCommand struct {
 	// RequestType is the command's request type, which is basically the
 	// command name.
 	RequestType string `json:"request_type" db:"request_type"`
-	// Status is the command status. One of Acknowledged, Error, or NotNow.
+	// Status is the command status. One of Pending, Acknowledged, Error, or NotNow.
 	Status string `json:"status" db:"status"`
 	// Hostname is the hostname of the host that executed the command.
 	Hostname string `json:"hostname" db:"hostname"`

--- a/server/service/client_apple_mdm.go
+++ b/server/service/client_apple_mdm.go
@@ -79,22 +79,3 @@ func (c *Client) MDMGetCommandResults(commandUUID string) ([]*fleet.MDMCommandRe
 
 	return responseBody.Results, nil
 }
-
-func (c *Client) MDMListCommands() ([]*fleet.MDMCommand, error) {
-	const defaultCommandsPerPage = 1000
-
-	verb, path := http.MethodGet, "/api/latest/fleet/mdm/commands"
-
-	query := url.Values{}
-	query.Set("per_page", fmt.Sprint(defaultCommandsPerPage))
-	query.Set("order_key", "updated_at")
-	query.Set("order_direction", "desc")
-
-	var responseBody listMDMCommandsResponse
-	err := c.authenticatedRequestWithQuery(nil, verb, path, &responseBody, query.Encode())
-	if err != nil {
-		return nil, fmt.Errorf("send request: %w", err)
-	}
-
-	return responseBody.Results, nil
-}

--- a/server/service/client_mdm.go
+++ b/server/service/client_mdm.go
@@ -265,3 +265,22 @@ func (c *Client) uploadMacOSSetupAssistant(data []byte, teamID *uint, name strin
 	}
 	return c.authenticatedRequest(request, verb, path, nil)
 }
+
+func (c *Client) MDMListCommands() ([]*fleet.MDMCommand, error) {
+	const defaultCommandsPerPage = 1000
+
+	verb, path := http.MethodGet, "/api/latest/fleet/mdm/commands"
+
+	query := url.Values{}
+	query.Set("per_page", fmt.Sprint(defaultCommandsPerPage))
+	query.Set("order_key", "updated_at")
+	query.Set("order_direction", "desc")
+
+	var responseBody listMDMCommandsResponse
+	err := c.authenticatedRequestWithQuery(nil, verb, path, &responseBody, query.Encode())
+	if err != nil {
+		return nil, fmt.Errorf("send request: %w", err)
+	}
+
+	return responseBody.Results, nil
+}


### PR DESCRIPTION
a follow up from this conversation: https://github.com/fleetdm/fleet/pull/14823#discussion_r1377853033

removing the column as it's not actually used. Alternatively we could replace the column with a `deleted_at` if we want to soft-delete commands

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Added/updated tests
- [x] Manual QA for all new/changed functionality
