### PR TITLE
Update fleetd.md

### DIFF
--- a/docs/Using Fleet/fleetd.md
+++ b/docs/Using Fleet/fleetd.md
@@ -43,31 +43,7 @@
 Fleetd is the bundle of agents that includes:
 
 - [osquery](https://osquery.io/)
-- [Orbit](#orbit)
 - [Fleet Desktop](./fleet-desktop.md)
-
-## Components
-
-```mermaid
-graph LR;
-    tuf["<a href=https://theupdateframework.io/>TUF</a> file server<br>(default: <a href=https://tuf.fleetctl.com>tuf.fleetctl.com</a>)"];
-    fleet_server[Fleet<br>Server];
-
-    subgraph Fleetd
-        orbit[orbit];
-        desktop[Fleet Desktop<br>Tray App];
-        osqueryd[osqueryd];
-
-        desktop_browser[Fleet Desktop<br> from Browser];
-    end
-
-    orbit -- "Fleet Orbit API (TLS)" --> fleet_server;
-    desktop -- "Fleet Desktop API (TLS)" --> fleet_server;
-    osqueryd -- "osquery<br>remote API (TLS)" --> fleet_server;
-    desktop_browser -- "My Device API (TLS)" --> fleet_server;
-
-    orbit -- "Auto Update (TLS)" --> tuf;
-```
 
 
 ## Capabilities


### PR DESCRIPTION
Removed Orbit from top header list and the Components diagram. There is a lot of additional Orbit content throughout this doc that needs to be purged over time, especially when fleetctl commands are changed as the Orbit object is eliminated.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [ ] Documented any API changes (docs/REST API/rest-api.md or docs/Contributing/API-for-contributors.md)
- [ ] Documented any permissions changes (docs/Using Fleet/manage-access.md)
- [ ] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [ ] Added support on fleet's osquery simulator `cmd/osquery-perf` for new osquery data ingestion features.
- [ ] Added/updated tests
- [ ] Manual QA for all new/changed functionality
  - For Orbit and Fleet Desktop changes:
    - [ ] Manual QA must be performed in the three main OSs, macOS, Windows and Linux.
    - [ ] Auto-update manual QA, from released version of component to new version (see [tools/tuf/test](../tools/tuf/test/README.md)).
