### PR TITLE
Added ListOptions validation to fleet/software endpoint.

### DIFF
--- a/changes/14554-software-endpoint-validation
+++ b/changes/14554-software-endpoint-validation
@@ -1,0 +1,4 @@
+For the following endpoints:
+/api/v1/fleet/software
+/api/v1/fleet/software/count
+  - added validation on `page`, `per_page`, `order_key`, `order_direction` -- invalid values will now return 400 HTTP status code

--- a/server/datastore/mysql/software.go
+++ b/server/datastore/mysql/software.go
@@ -723,7 +723,7 @@ func selectSoftwareSQL(opts fleet.SoftwareListOptions) (string, []interface{}, e
 			)
 	}
 
-	if match := opts.MatchQuery; match != "" {
+	if match := opts.ListOptions.MatchQuery; match != "" {
 		match = likePattern(match)
 		ds = ds.Where(
 			goqu.Or(
@@ -817,7 +817,7 @@ func countSoftwareDB(
 	opts fleet.SoftwareListOptions,
 ) (int, error) {
 	opts.ListOptions = fleet.ListOptions{
-		MatchQuery: opts.MatchQuery,
+		MatchQuery: opts.ListOptions.MatchQuery,
 	}
 
 	sql, args, err := selectSoftwareSQL(opts)

--- a/server/datastore/mysql/software_test.go
+++ b/server/datastore/mysql/software_test.go
@@ -737,19 +737,19 @@ func testSoftwareList(t *testing.T, ds *Datastore) {
 		expected := []fleet.Software{foo001}
 		test.ElementsMatchSkipID(t, software, expected)
 
-		opts.MatchQuery = "CVE-2022-0002"
+		opts.ListOptions.MatchQuery = "CVE-2022-0002"
 		software = listSoftwareCheckCount(t, ds, 1, 1, opts, true)
 		expected = []fleet.Software{foo001}
 		test.ElementsMatchSkipID(t, software, expected)
 
 		// partial CVE
-		opts.MatchQuery = "0002"
+		opts.ListOptions.MatchQuery = "0002"
 		software = listSoftwareCheckCount(t, ds, 1, 1, opts, true)
 		expected = []fleet.Software{foo001}
 		test.ElementsMatchSkipID(t, software, expected)
 
 		// unknown CVE
-		opts.MatchQuery = "CVE-2022-0000"
+		opts.ListOptions.MatchQuery = "CVE-2022-0000"
 		listSoftwareCheckCount(t, ds, 0, 0, opts, true)
 	})
 
@@ -765,13 +765,13 @@ func testSoftwareList(t *testing.T, ds *Datastore) {
 		test.ElementsMatchSkipID(t, software, expected)
 
 		// query by version
-		opts.MatchQuery = "0.0.3"
+		opts.ListOptions.MatchQuery = "0.0.3"
 		software = listSoftwareCheckCount(t, ds, 2, 2, opts, true)
 		expected = []fleet.Software{foo003, bar003}
 		test.ElementsMatchSkipID(t, software, expected)
 
 		// query by version (case insensitive)
-		opts.MatchQuery = "V0.0.2"
+		opts.ListOptions.MatchQuery = "V0.0.2"
 		software = listSoftwareCheckCount(t, ds, 1, 1, opts, true)
 		expected = []fleet.Software{foo002}
 		test.ElementsMatchSkipID(t, software, expected)

--- a/server/fleet/software.go
+++ b/server/fleet/software.go
@@ -123,7 +123,8 @@ type SoftwareIterator interface {
 }
 
 type SoftwareListOptions struct {
-	ListOptions
+	// ListOptions cannot be embedded in order to unmarshall with validation.
+	ListOptions ListOptions `url:"list_options"`
 
 	// HostID filters software to the specified host if not nil.
 	HostID           *uint

--- a/server/service/integration_core_test.go
+++ b/server/service/integration_core_test.go
@@ -765,6 +765,9 @@ func (s *integrationTestSuite) TestVulnerableSoftware() {
 	s.DoJSON("GET", "/api/latest/fleet/software", nil, http.StatusOK, &lsResp, "per_page", "2", "page", "2", "order_key", "hosts_count", "order_direction", "desc")
 	require.Len(t, lsResp.Software, 0)
 	require.Nil(t, lsResp.CountsUpdatedAt)
+
+	// request with invalid parameters
+	s.DoJSON("GET", "/api/latest/fleet/software", nil, http.StatusBadRequest, &lsResp, "per_page", "2", "page", "-10")
 }
 
 func (s *integrationTestSuite) TestGlobalPolicies() {

--- a/server/service/integration_core_test.go
+++ b/server/service/integration_core_test.go
@@ -766,8 +766,8 @@ func (s *integrationTestSuite) TestVulnerableSoftware() {
 	require.Len(t, lsResp.Software, 0)
 	require.Nil(t, lsResp.CountsUpdatedAt)
 
-	// request with invalid parameters
 	s.DoJSON("GET", "/api/latest/fleet/software", nil, http.StatusBadRequest, &lsResp, "per_page", "2", "page", "-10")
+	s.DoJSON("GET", "/api/latest/fleet/software/count", nil, http.StatusBadRequest, &lsResp, "per_page", "-2", "page", "2")
 }
 
 func (s *integrationTestSuite) TestGlobalPolicies() {

--- a/server/service/software.go
+++ b/server/service/software.go
@@ -53,9 +53,9 @@ func (svc *Service) ListSoftware(ctx context.Context, opt fleet.SoftwareListOpti
 	}
 
 	// default sort order to hosts_count descending
-	if opt.OrderKey == "" {
-		opt.OrderKey = "hosts_count"
-		opt.OrderDirection = fleet.OrderDescending
+	if opt.ListOptions.OrderKey == "" {
+		opt.ListOptions.OrderKey = "hosts_count"
+		opt.ListOptions.OrderDirection = fleet.OrderDescending
 	}
 	opt.WithHostCounts = true
 


### PR DESCRIPTION
#14554 

For the following endpoints:
/api/v1/fleet/software
/api/v1/fleet/software/count
  - added validation on `page`, `per_page`, `order_key`, `order_direction` -- invalid values will now return 400 HTTP status code

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [x] Added/updated tests
- [x] Manual QA for all new/changed functionality
