### PR TITLE
Fleet UI: Align  number in host target count when selecting targets

### DIFF
--- a/frontend/components/LiveQuery/SelectTargets.tsx
+++ b/frontend/components/LiveQuery/SelectTargets.tsx
@@ -395,7 +395,7 @@ const SelectTargets = ({
 
     return (
       <>
-        <span>{total}</span>&nbsp;host{total > 1 ? `s` : ``} targeted&nbsp; (
+        <b>{total}</b>&nbsp;host{total > 1 ? `s` : ``} targeted&nbsp; (
         {onlinePercentage()}
         %&nbsp;
         <TooltipWrapper

--- a/frontend/pages/policies/PolicyPage/_styles.scss
+++ b/frontend/pages/policies/PolicyPage/_styles.scss
@@ -106,10 +106,6 @@
     display: flex;
     align-items: center;
 
-    span {
-      font-weight: $bold;
-    }
-
     .icon-tooltip {
       margin-left: $pad-small;
     }

--- a/frontend/pages/queries/live/LiveQueryPage/_styles.scss
+++ b/frontend/pages/queries/live/LiveQueryPage/_styles.scss
@@ -81,10 +81,6 @@
     display: flex;
     align-items: center;
 
-    span {
-      font-weight: $bold;
-    }
-
     .icon-tooltip {
       margin-left: $pad-small;
     }


### PR DESCRIPTION
## Issue
Cerra #14580 

## Description
- `<span>` for host count number was rendering the host target number slightly lower/higher than the rest of the text
- Revert to basic `<b>` tag

## Screenshots of fix
<img width="995" alt="Screenshot 2023-11-01 at 9 44 24 AM" src="https://github.com/fleetdm/fleet/assets/71795832/7a83e013-9426-4b17-8270-6778147a0372">
<img width="1327" alt="Screenshot 2023-11-01 at 9 44 13 AM" src="https://github.com/fleetdm/fleet/assets/71795832/6ed42366-c7d1-4138-ab76-1c621c31a79d">

## Test instructions
Compare to current dogfood where the number part is slightly higher or lower on FF and Safari

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- No change file as this is sooo minor and not worth the seconds reading
- [x] Manual QA for all new/changed functionality

