### PR TITLE
Fleet UI: Icon alignment

### DIFF
--- a/frontend/components/LiveQuery/TargetsInput/_styles.scss
+++ b/frontend/components/LiveQuery/TargetsInput/_styles.scss
@@ -21,8 +21,16 @@
         min-height: 89px;
       }
 
+      // Properly vertically aligns host issue icon
       .display_name__cell {
+        display: inline-flex;
+        align-items: center;
         white-space: nowrap;
+
+        .host-issue {
+          margin-left: $pad-xsmall;
+          display: inline-flex;
+        }
       }
 
       .data-table-block {
@@ -64,9 +72,16 @@
       &__wrapper {
         margin: 0;
       }
-      .host-issue {
-        .icon {
-          vertical-align: inherit;
+
+      // Properly vertically aligns host issue icon
+      .display_name__cell {
+        display: inline-flex;
+        align-items: center;
+        white-space: nowrap;
+
+        .host-issue {
+          margin-left: $pad-xsmall;
+          display: inline-flex;
         }
       }
     }

--- a/frontend/components/TableContainer/DataTable/IssueCell/IssueCell.tsx
+++ b/frontend/components/TableContainer/DataTable/IssueCell/IssueCell.tsx
@@ -25,7 +25,7 @@ const IssueCell = ({ issues, rowId }: IIssueCellProps<any>): JSX.Element => {
         data-for={`host-issue__${rowId.toString()}`}
         data-tip-disable={false}
       >
-        <Icon name="error-outline" color="ui-fleet-black-50" />
+        <Icon name="error-outline" color="ui-fleet-black-50" size="small" />
       </span>
       <ReactTooltip
         place="top"

--- a/frontend/components/icons/ErrorOutline.tsx
+++ b/frontend/components/icons/ErrorOutline.tsx
@@ -1,16 +1,21 @@
 import React from "react";
 
 import { COLORS, Colors } from "styles/var/colors";
+import { ICON_SIZES, IconSizes } from "styles/var/icon_sizes";
 
 interface IErrorOutlineProps {
   color?: Colors;
+  size?: IconSizes;
 }
 
-const ErrorOutline = ({ color = "status-error" }: IErrorOutlineProps) => {
+const ErrorOutline = ({
+  color = "status-error",
+  size = "medium",
+}: IErrorOutlineProps) => {
   return (
     <svg
-      width="16"
-      height="16"
+      width={ICON_SIZES[size]}
+      height={ICON_SIZES[size]}
       fill="none"
       xmlns="http://www.w3.org/2000/svg"
       viewBox="0 0 16 16"


### PR DESCRIPTION
## Issue
#14351 

## Description
- Aligns host issue icon vertically in the cell (Should be same pixel spacing above and below icon in the cell)

## Screenrecording

https://github.com/fleetdm/fleet/assets/71795832/0fb933d8-7fe2-4f5a-837c-1feafc0b6e33

## Testing
- Tested on Chrome, Safari, FF


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

No change file as this is not worth the seconds reading
- [x] Manual QA for all new/changed functionality

