### PR TITLE
Implement windows os updates activities UI

### DIFF
--- a/changes/issue-14045-add-windows-update-activites
+++ b/changes/issue-14045-add-windows-update-activites
@@ -1,0 +1,1 @@
+- add window os updates activites to Fleet UI.

--- a/frontend/interfaces/activity.ts
+++ b/frontend/interfaces/activity.ts
@@ -52,6 +52,7 @@ export enum ActivityType {
   AddedScript = "added_script",
   DeletedScript = "deleted_script",
   EditedScript = "edited_script",
+  EditedWindowsUpdates = "edited_windows_updates",
 }
 export interface IActivity {
   created_at: string;
@@ -95,4 +96,6 @@ export interface IActivityDetails {
   name?: string;
   script_execution_id?: string;
   script_name?: string;
+  deadline_days?: number;
+  grace_period_days?: number;
 }

--- a/frontend/pages/DashboardPage/cards/ActivityFeed/ActivityItem/ActivityItem.tsx
+++ b/frontend/pages/DashboardPage/cards/ActivityFeed/ActivityItem/ActivityItem.tsx
@@ -584,6 +584,27 @@ const TAGGED_TEMPLATES = {
       </>
     );
   },
+  editedWindowsUpdates: (activity: IActivity) => {
+    return (
+      <>
+        {" "}
+        updated the Windows OS update options (
+        <b>
+          Deadline: {activity.details?.deadline_days} days / Grace period:{" "}
+          {activity.details?.grace_period_days} days
+        </b>
+        ) on hosts assigned to{" "}
+        {activity.details?.team_name ? (
+          <>
+            the <b>{activity.details.team_name}</b> team
+          </>
+        ) : (
+          "no team"
+        )}
+        .
+      </>
+    );
+  },
 };
 
 const getDetail = (
@@ -708,6 +729,9 @@ const getDetail = (
     }
     case ActivityType.EditedScript: {
       return TAGGED_TEMPLATES.editedScript(activity);
+    }
+    case ActivityType.EditedWindowsUpdates: {
+      return TAGGED_TEMPLATES.editedWindowsUpdates(activity);
     }
     default: {
       return TAGGED_TEMPLATES.defaultActivityTemplate(activity);


### PR DESCRIPTION
relates to #14045

This implements the UI for the windows os updates activities

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [x] Manual QA for all new/changed functionality
