### PR TITLE
Remove daily schedule so it only gets triggered by security alerts

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,8 +6,6 @@ updates:
 # Maintain dependencies for GitHub Actions
   - package-ecosystem: "github-actions"
     directory: "/"
-    schedule:
-      interval: "daily"
     pull-request-branch-name:
       # Default is "/" which makes "docker tag" fail with
       # "not a valid repository/tag: invalid reference format".
@@ -19,8 +17,6 @@ updates:
 # Maintain dependencies for Dockerfiles
   - package-ecosystem: "docker"
     directory: "/"
-    schedule:
-      interval: "daily"
     reviewers:
       - "fleetdm/go"
       - "fleetdm/infra"
@@ -38,8 +34,6 @@ updates:
     directory: "/website"
     labels:
       - "website"
-    schedule:
-      interval: "daily"
     # Disable version updates
     open-pull-requests-limit: 0
     allow:
@@ -56,8 +50,6 @@ updates:
 # Maintain dependencies for Go
   - package-ecosystem: "gomod"
     directory: "/"
-    schedule:
-      interval: "daily"
     # Disable version updates
     open-pull-requests-limit: 0
     reviewers:
@@ -73,8 +65,6 @@ updates:
 # Maintain dependencies for npm
   - package-ecosystem: "npm"
     directory: "/"
-    schedule:
-      interval: "daily"
     # Disable version updates
     open-pull-requests-limit: 0
     reviewers:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,10 @@ updates:
 # Maintain dependencies for GitHub Actions
   - package-ecosystem: "github-actions"
     directory: "/"
+    schedule:
+      interval: "daily"
+    # Disable version updates for npm dependencies
+    open-pull-requests-limit: 0
     pull-request-branch-name:
       # Default is "/" which makes "docker tag" fail with
       # "not a valid repository/tag: invalid reference format".
@@ -17,6 +21,10 @@ updates:
 # Maintain dependencies for Dockerfiles
   - package-ecosystem: "docker"
     directory: "/"
+    schedule:
+      interval: "daily"
+    # Disable version updates for npm dependencies
+    open-pull-requests-limit: 0
     reviewers:
       - "fleetdm/go"
       - "fleetdm/infra"
@@ -34,6 +42,8 @@ updates:
     directory: "/website"
     labels:
       - "website"
+    schedule:
+      interval: "daily"
     # Disable version updates
     open-pull-requests-limit: 0
     allow:
@@ -50,6 +60,8 @@ updates:
 # Maintain dependencies for Go
   - package-ecosystem: "gomod"
     directory: "/"
+    schedule:
+      interval: "daily"
     # Disable version updates
     open-pull-requests-limit: 0
     reviewers:
@@ -65,6 +77,8 @@ updates:
 # Maintain dependencies for npm
   - package-ecosystem: "npm"
     directory: "/"
+    schedule:
+      interval: "daily"
     # Disable version updates
     open-pull-requests-limit: 0
     reviewers:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,7 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-    # Disable version updates for npm dependencies
+    # Disable version updates for github-actions dependencies
     open-pull-requests-limit: 0
     pull-request-branch-name:
       # Default is "/" which makes "docker tag" fail with

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,7 +23,7 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-    # Disable version updates for npm dependencies
+    # Disable version updates for docker dependencies
     open-pull-requests-limit: 0
     reviewers:
       - "fleetdm/go"


### PR DESCRIPTION
This is an attempt to stop version bump PRs without associated security alerts. Removing the `schedule` config may stop dependabot from running automatically each day. Instead, it will only run when triggered by a security alert. 