### PR TITLE
Dogfood github actions and monitoring module fixes

### DIFF
--- a/.github/workflows/dogfood-deploy.yml
+++ b/.github/workflows/dogfood-deploy.yml
@@ -50,7 +50,7 @@ jobs:
           aws-region: ${{ env.AWS_REGION }}
       - uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
         with:
-          terraform_version: 1.3.8
+          terraform_version: 1.6.3
           terraform_wrapper: false
       - name: Terraform Init
         id: init

--- a/.github/workflows/dogfood-deploy.yml
+++ b/.github/workflows/dogfood-deploy.yml
@@ -48,6 +48,10 @@ jobs:
         with:
           role-to-assume: ${{env.AWS_IAM_ROLE}}
           aws-region: ${{ env.AWS_REGION }}
+      - name: Set up Go
+        uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
+        with:
+          go-version: ${{ vars.GO_VERSION }}
       - uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
         with:
           terraform_version: 1.6.3

--- a/.github/workflows/dogfood-deploy.yml
+++ b/.github/workflows/dogfood-deploy.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
         with:
-          go-version: ${{ vars.GO_VERSION }}
+          go-version: '1.21'
       - uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
         with:
           terraform_version: 1.6.3

--- a/infrastructure/dogfood/terraform/aws-tf-module/github.tf
+++ b/infrastructure/dogfood/terraform/aws-tf-module/github.tf
@@ -97,7 +97,7 @@ data "aws_iam_policy_document" "gha-permissions" {
       "glue:*",
       "ses:*",
       "wafv2:*",
-      "eventbridge:*",
+      "events:*",
     ]
     resources = ["*"]
   }

--- a/infrastructure/dogfood/terraform/aws-tf-module/github.tf
+++ b/infrastructure/dogfood/terraform/aws-tf-module/github.tf
@@ -97,6 +97,7 @@ data "aws_iam_policy_document" "gha-permissions" {
       "glue:*",
       "ses:*",
       "wafv2:*",
+      "eventbridge:*",
     ]
     resources = ["*"]
   }

--- a/infrastructure/dogfood/terraform/aws-tf-module/main.tf
+++ b/infrastructure/dogfood/terraform/aws-tf-module/main.tf
@@ -264,7 +264,7 @@ module "osquery-carve" {
 }
 
 module "monitoring" {
-  source                      = "github.com/fleetdm/fleet//terraform/addons/monitoring?ref=test-dogfood-action-upgrade"
+  source                      = "github.com/fleetdm/fleet//terraform/addons/monitoring?ref=tf-mod-addon-monitoring-v1.1.1"
   customer_prefix             = local.customer
   fleet_ecs_service_name      = module.main.byo-vpc.byo-db.byo-ecs.service.name
   fleet_min_containers        = module.main.byo-vpc.byo-db.byo-ecs.service.desired_count

--- a/infrastructure/dogfood/terraform/aws-tf-module/main.tf
+++ b/infrastructure/dogfood/terraform/aws-tf-module/main.tf
@@ -264,7 +264,7 @@ module "osquery-carve" {
 }
 
 module "monitoring" {
-  source                      = "github.com/fleetdm/fleet//terraform/addons/monitoring?ref=tf-mod-addon-monitoring-v1.1.0"
+  source                      = "github.com/fleetdm/fleet//terraform/addons/monitoring?ref=test-dogfood-action-upgrade"
   customer_prefix             = local.customer
   fleet_ecs_service_name      = module.main.byo-vpc.byo-db.byo-ecs.service.name
   fleet_min_containers        = module.main.byo-vpc.byo-db.byo-ecs.service.desired_count

--- a/terraform/addons/monitoring/main.tf
+++ b/terraform/addons/monitoring/main.tf
@@ -279,7 +279,8 @@ resource "null_resource" "cron_monitoring_build" {
     main_go_changes = filesha256("${path.module}/lambda/main.go"),
     go_mod_changes  = filesha256("${path.module}/lambda/go.mod")
     go_sum_changes  = filesha256("${path.module}/lambda/go.sum")
-    binary_exists   = fileexists(local.cron_lambda_binary)
+    # Make sure to always have a unique trigger if the file doesn't exist
+    binary_exists   = fileexists(local.cron_lambda_binary) ? true : timestamp()
   }
   provisioner "local-exec" {
     working_dir = "${path.module}/lambda"

--- a/terraform/addons/monitoring/main.tf
+++ b/terraform/addons/monitoring/main.tf
@@ -285,7 +285,7 @@ resource "null_resource" "cron_monitoring_build" {
     working_dir = "${path.module}/lambda"
     command     = <<-EOT
       go get
-      GOOS=linux GOARCH=amd64 go build -tags lambda.norpc -o "${local.cron_lambda_binary}" main.go
+      GOOS=linux GOARCH=amd64 go build -tags lambda.norpc -o bootstrap main.go
     EOT
   }
 }


### PR DESCRIPTION
These items fix the github action for use with the updates to the monitoring module.

Additionally there were some changes needed to the monitoring module to make it behave inside the GH action.

Once this is approved/merged, the new tag for them monitoring module will be created as `tf-mod-addon-monitoring-v1.1.1`