### PR TITLE
Fix fleet desktop linux build

### DIFF
--- a/Dockerfile-desktop-linux
+++ b/Dockerfile-desktop-linux
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 golang:1.20.5-bullseye@sha256:419bc8954c0e08c539830c8669ccd116a063303481c748fabd09d8fd6d4e2c5f
+FROM --platform=linux/amd64 golang:1.21.3-bullseye@sha256:bea700cb2a4b3df3add033cea317d5e1dd7a59412d1b6fe25ceb257bcfdc6a1d
 LABEL maintainer="Fleet Developers"
 
 RUN apt-get update && apt-get install -y \


### PR DESCRIPTION
https://github.com/fleetdm/fleet/actions/runs/6724300262/job/18276393893?pr=14613

```
go: downloading github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb
go: downloading github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da
server/service/osquery_utils/queries.go:11:2: package slices is not in GOROOT (/usr/local/go/src/slices)
note: imported by a module that requires go 1.21
make: *** [desktop-linux] Error 1
```