### PR TITLE
Website: Remove sandbox-related routes, add redirects

### DIFF
--- a/website/assets/js/pages/try-fleet/sandbox-login.page.js
+++ b/website/assets/js/pages/try-fleet/sandbox-login.page.js
@@ -44,8 +44,7 @@ parasails.registerPage('sandbox-login', {
 
     submittedLoginForm: async function() {
       this.syncing = true;
-      // FUTURE: once all Sandbox instances have expired, redirect users to the fleetctl-preview page.
-      window.location = '/try-fleet/sandbox';
+      window.location = '/try-fleet/fleetctl-preview';
     },
 
     clickOpenVideoModal: function() {

--- a/website/config/routes.js
+++ b/website/config/routes.js
@@ -180,21 +180,6 @@ module.exports.routes = {
     }
   },
 
-  'GET /try-fleet/sandbox': {
-    action: 'try-fleet/view-sandbox-teleporter-or-redirect-because-expired-or-waitlist',
-    locals: {
-      layout: 'layouts/layout-sandbox',
-    },
-  },
-
-  'GET /try-fleet/waitlist': {
-    action: 'try-fleet/view-waitlist',
-    locals: {
-      layout: 'layouts/layout-sandbox',
-      pageTitleForMeta: 'Fleet Sandbox waitlist | Fleet for osquery',
-    }
-  },
-
   'GET /admin/email-preview': {
     action: 'admin/view-email-templates',
     locals: {
@@ -502,6 +487,8 @@ module.exports.routes = {
   'GET /blackhat2023':   'https://github.com/fleetdm/fleet/tree/main/tools/blackhat-mdm', // Assets from @marcosd4h & @zwass Black Hat 2023 talk
   'GET /fleetctl-preview':   '/try-fleet/fleetctl-preview',
   'GET /try-fleet/sandbox-expired':   '/try-fleet/fleetctl-preview',
+  'GET /try-fleet/sandbox':   '/try-fleet/fleetctl-preview',
+  'GET /try-fleet/waitlist':   '/try-fleet/fleetctl-preview',
 
   // Fleet UI
   // =============================================================================================================


### PR DESCRIPTION
Closes: #14767

Changes:
- Removed the routes for `/try-fleet/sandbox` and `/try-fleet/waitlist` and added redirects to go to `/try-fleet/fleetctl-preview`
- Updated the login form on `/try-fleet/login` to take users to `/try-fleet/fleetctl-preview`