### PR TITLE
Update heading position on why-fleet.md

### DIFF
--- a/docs/Get started/why-fleet.md
+++ b/docs/Get started/why-fleet.md
@@ -33,7 +33,7 @@ Here are the platforms Fleet currently supports:
 ## Lighter than air
 Fleet is lightweight and modular.  You can use it for security without using it for MDM, and vice versa.  You can turn off features you are not using.
 
-### Openness
+### Open by design
 Fleet is dedicated to flexibility, accessibility, and clarity.  We think [everyone can contribute](https://fleetdm.com/handbook/company#openness) and that tools should be as easy as possible for everyone to understand.
 
 ### Good neighbors

--- a/docs/Get started/why-fleet.md
+++ b/docs/Get started/why-fleet.md
@@ -60,7 +60,6 @@ Please join us in [MacAdmins Slack](https://www.macadmins.org/) or [osquery Slac
 
 The Fleet community is full of [kind and helpful people](https://fleetdm.com/handbook/company#empathy).  Whether or not you are a paying customer, if you need help, just ask.
 
-## Contributing 
 
 Contributions are welcome, whether you answer questions on [Slack](#chat) / [GitHub](https://github.com/fleetdm/fleet/issues) / [StackOverflow](https://stackoverflow.com/search?q=osquery) / [LinkedIn](https://linkedin.com/company/fleetdm) / [Twitter](https://twitter.com/fleetctl), improve the documentation or [website](https://github.com/fleetdm/fleet/tree/main/website), write a tutorial, give a talk at a conference or local meetup, give an [interview on a podcast](https://fleetdm.com/podcasts), troubleshoot reported issues, or [submit a patch](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/Committing-Changes.md).  The Fleet code of conduct is [on GitHub](https://github.com/fleetdm/fleet/blob/main/CODE_OF_CONDUCT.md).
 

--- a/docs/Get started/why-fleet.md
+++ b/docs/Get started/why-fleet.md
@@ -72,6 +72,6 @@ The Fleet community is full of [kind and helpful people](https://fleetdm.com/han
 [Try out Fleet](https://fleetdm.com/try-fleet) to see what it can do, grab time with one of the maintainers to discuss, or explore the rest of the docs and roll it out to your organization.
 
 ### Questions?
-Fleet is simple enough to [spin up for yourself](https://fleetdm.com/docs/deploy/deploy-on-aws-with-terraform).  Or you can have us [host it for you](https://fleetdm.com/pricing).  Premium features are [available](https://fleetdm.com/pricing) either way.
+We have answers to the most [common questions](https://fleetdm.com/docs/get-started/faq).
 
 <meta name="pageOrderInSection" value="100">

--- a/docs/Get started/why-fleet.md
+++ b/docs/Get started/why-fleet.md
@@ -46,7 +46,7 @@ Fleet plays well with Munki, Chef, Puppet, and Ansible, as well as with security
 The free version of Fleet will [always be free](https://fleetdm.com/pricing).  Fleet is [independently backed](https://linkedin.com/company/fleetdm) and actively maintained with the help of many amazing [contributors](https://github.com/fleetdm/fleet/graphs/contributors).
 
 ### Longevity
-The [company behind Fleet](https://fleetdm.com/handbook/company) is founded (and majority-owned) by [true believers in open source](https://fleetdm.com/handbook/company/why-this-way#why-open-source).  The company's business model is influenced by GitLab (NYSE: GTLB), with great investors, happy customers, and the capacity to become profitable anytime.
+The [company behind Fleet](https://fleetdm.com/handbook/company) is founded (and majority-owned) by [true believers in open source](https://fleetdm.com/handbook/company/why-this-way#why-open-source).  The company's business model is influenced by GitLab (NYSE: GTLB), with great investors, happy customers, and the capacity to become profitable at any time.
 
 In keeping with Fleet's value of openness, [Fleet Device Management's company handbook](https://fleetdm.com/handbook/company) is public and open source.  You can read about the [history of Fleet and osquery](https://fleetdm.com/handbook/company#history) and our commitment to improving the product.
 

--- a/docs/Get started/why-fleet.md
+++ b/docs/Get started/why-fleet.md
@@ -64,7 +64,6 @@ The Fleet community is full of [kind and helpful people](https://fleetdm.com/han
 
 <!-- - Great contributions are motivated by real-world use cases or learning.
 - Some of the most valuable contributions might not touch any code at all.
-- Small, iterative, simple (boring) changes are the easiest to merge. -->
 
 ## What's next?
 

--- a/docs/Get started/why-fleet.md
+++ b/docs/Get started/why-fleet.md
@@ -27,7 +27,7 @@ Here are the platforms Fleet currently supports:
 - Google Cloud (GCP)
 - Azure (Microsoft cloud)
 - Data centers
-- Containers (Kube, etc)
+- Containers (kube, etc)
 - Linux-based IoT devices
 
 ## Lighter than air

--- a/docs/Get started/why-fleet.md
+++ b/docs/Get started/why-fleet.md
@@ -41,7 +41,6 @@ Ready-to-use, enterprise-friendly [integrations](https://fleetdm.com/integration
 
 Fleet plays well with Munki, Chef, Puppet, and Ansible, as well as with security tools like Crowdstrike and SentinelOne.  For example, you can use the free version of Fleet to quickly report on what hosts are _actually_ running your EDR agent.
 
-While most folks prefer to use one or the other, Fleet can coexist peacefully with Rapid7 and other agent-based vulnerability scanners.  This can be useful during migrations.
 
 ### Free as in free
 The free version of Fleet will [always be free](https://fleetdm.com/pricing).  Fleet is [independently backed](https://linkedin.com/company/fleetdm) and actively maintained with the help of many amazing [contributors](https://github.com/fleetdm/fleet/graphs/contributors).

--- a/docs/Get started/why-fleet.md
+++ b/docs/Get started/why-fleet.md
@@ -61,7 +61,6 @@ Please join us in [MacAdmins Slack](https://www.macadmins.org/) or [osquery Slac
 The Fleet community is full of [kind and helpful people](https://fleetdm.com/handbook/company#empathy).  Whether or not you are a paying customer, if you need help, just ask.
 
 ## Contributing 
-The landscape of cybersecurity and IT needs to be simplified.  Let's open it up.
 
 Contributions are welcome, whether you answer questions on [Slack](#chat) / [GitHub](https://github.com/fleetdm/fleet/issues) / [StackOverflow](https://stackoverflow.com/search?q=osquery) / [LinkedIn](https://linkedin.com/company/fleetdm) / [Twitter](https://twitter.com/fleetctl), improve the documentation or [website](https://github.com/fleetdm/fleet/tree/main/website), write a tutorial, give a talk at a conference or local meetup, give an [interview on a podcast](https://fleetdm.com/podcasts), troubleshoot reported issues, or [submit a patch](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/Committing-Changes.md).  The Fleet code of conduct is [on GitHub](https://github.com/fleetdm/fleet/blob/main/CODE_OF_CONDUCT.md).
 

--- a/docs/Get started/why-fleet.md
+++ b/docs/Get started/why-fleet.md
@@ -37,7 +37,7 @@ Fleet is lightweight and modular.  You can use it for security without using it 
 Fleet is dedicated to flexibility, accessibility, and clarity.  We think [everyone can contribute](https://fleetdm.com/handbook/company#openness) and that tools should be as easy as possible for everyone to understand.
 
 ### Good neighbors
-Fleet has no ambition to replace all of your other tools.  (Though it might replace some if you want it to.)  Ready-to-use, enterprise-friendly [integrations](https://fleetdm.com/integrations) exist for Snowflake, Splunk, GitHub Actions, Vanta, Elastic Jira, Zendesk, and more.
+Ready-to-use, enterprise-friendly [integrations](https://fleetdm.com/integrations) exist for Snowflake, Splunk, GitHub Actions, Vanta, Elastic Jira, Zendesk, and more.
 
 Fleet plays well with Munki, Chef, Puppet, and Ansible, as well as with security tools like Crowdstrike and SentinelOne.  For example, you can use the free version of Fleet to quickly report on what hosts are _actually_ running your EDR agent.
 

--- a/docs/Get started/why-fleet.md
+++ b/docs/Get started/why-fleet.md
@@ -1,22 +1,22 @@
 # Why Fleet
 
-In an industry that views security and IT as a shopping spree rather than a process, it’s little wonder that IT and security teams get stuck with bolt-on solutions, misconfigured tools, and disparate workflows. 
-
 ## What's it for?
+
+In an industry that views security and IT as a shopping spree rather than a process, it's little wonder that IT and security teams get stuck with bolt-on solutions, misconfigured tools, and disparate workflows. 
+
 Fleet helps organizations like Fastly and Gusto reimagine the "easy button." 
 
 By simplifying how they do device health, FIM, HIDS, posture assessment, malware detection, vulnerability management, MDM, and the rest, Fleet's API enables teams with thousands of computers to build an IT and security program that works.
 
+### Explore data
+To see what kind of data you can use Fleet to gather, you can check out the [table reference documentation](https://fleetdm.com/tables).
 
-#### Explore data
-To see what kind of data you can use Fleet to gather, check out the [table reference documentation](https://fleetdm.com/tables).
-
-#### Out-of-the-box policies
-Fleet includes out-of-the box support for all [CIS benchmarks for macOS and Windows](https://fleetdm.com/pricing), as well as many [simpler queries](https://fleetdm.com/queries).
+### Out-of-the-box policies
+Fleet includes out-of-the-box support for all [CIS benchmarks for macOS and Windows](https://fleetdm.com/pricing), as well as many [simpler queries](https://fleetdm.com/queries).
 
 Take as much or as little as you need for your organization.
 
-#### Supported platforms
+### Supported platforms
 Here are the platforms Fleet currently supports:
 
 - Linux (all distros)
@@ -27,46 +27,42 @@ Here are the platforms Fleet currently supports:
 - Google Cloud (GCP)
 - Azure (Microsoft cloud)
 - Data centers
-- Containers (kube, etc)
+- Containers (Kube, etc)
 - Linux-based IoT devices
 
 ## Lighter than air
-Fleet is lightweight and modular.  You can use it for security without using it for MDM, and vice versa.  You can turn off features you are not using.
+Fleet is lightweight and modular.  You can use it for security without MDM and vice versa.  You can turn off features you are not using.
 
-#### Openness
+### Openness
 Fleet is dedicated to flexibility, accessibility, and clarity.  We think [everyone can contribute](https://fleetdm.com/handbook/company#openness) and that tools should be as easy as possible for everyone to understand.
 
-#### Good neighbors
-Fleet has no ambition to replace all of your other tools.  (Though it might replace some, if you want it to.)  Ready-to-use, enterprise-friendly [integrations](https://fleetdm.com/integrations) exist for Snowflake, Splunk, GitHub Actions, Vanta, Elastic Jira, Zendesk, and more.
+### Good neighbors
+Fleet has no ambition to replace all of your other tools.  (Though it might replace some if you want it to.)  Ready-to-use, enterprise-friendly [integrations](https://fleetdm.com/integrations) exist for Snowflake, Splunk, GitHub Actions, Vanta, Elastic Jira, Zendesk, and more.
 
 Fleet plays well with Munki, Chef, Puppet, and Ansible, as well as with security tools like Crowdstrike and SentinelOne.  For example, you can use the free version of Fleet to quickly report on what hosts are _actually_ running your EDR agent.
 
-While most folks prefer to use one or the other, Fleet can also coexist peacefully with Rapid7 and other agent-based vulnerability scanners.  This can be useful during migrations.
+While most folks prefer to use one or the other, Fleet can coexist peacefully with Rapid7 and other agent-based vulnerability scanners.  This can be useful during migrations.
 
-#### Free as in free
+### Free as in free
 The free version of Fleet will [always be free](https://fleetdm.com/pricing).  Fleet is [independently backed](https://linkedin.com/company/fleetdm) and actively maintained with the help of many amazing [contributors](https://github.com/fleetdm/fleet/graphs/contributors).
 
-#### Longevity
-The [company behind Fleet](https://fleetdm.com/handbook/company) is founded (and majority-owned) by [true believers in open source](https://fleetdm.com/handbook/company/why-this-way#why-open-source).  The company's business model is influenced by GitLab (NYSE: GTLB), with great investors, happy customers, and the capacity to become profitable at any time.
+### Longevity
+The [company behind Fleet](https://fleetdm.com/handbook/company) is founded (and majority-owned) by [true believers in open source](https://fleetdm.com/handbook/company/why-this-way#why-open-source).  The company's business model is influenced by GitLab (NYSE: GTLB), with great investors, happy customers, and the capacity to become profitable anytime.
 
 In keeping with Fleet's value of openness, [Fleet Device Management's company handbook](https://fleetdm.com/handbook/company) is public and open source.  You can read about the [history of Fleet and osquery](https://fleetdm.com/handbook/company#history) and our commitment to improving the product.
 
-<!-- > To upgrade from Fleet ≤3.2.0, just follow the upgrading steps for the earliest subsequent major release from this repository (it'll work out of the box until the release of Fleet 5.0). -->
-
+<!-- > To upgrade from Fleet ≤3.2.0, follow the upgrading steps for the earliest subsequent major release from this repository (it'll work out of the box until the release of Fleet 5.0). -->
 
 ## Is it any good?
 Fleet is used in production by IT and security teams with thousands of laptops and servers.  Many deployments support tens of thousands of hosts, and a few large organizations manage deployments as large as 400,000+ hosts.
 
-
-
 ## Chat
-Please join us in [MacAdmins Slack](https://www.macadmins.org/) or in [osquery Slack](https://fleetdm.com/slack).
+Please join us in [MacAdmins Slack](https://www.macadmins.org/) or [osquery Slack](https://fleetdm.com/slack).
 
 The Fleet community is full of [kind and helpful people](https://fleetdm.com/handbook/company#empathy).  Whether or not you are a paying customer, if you need help, just ask.
 
-
 ## Contributing 
-The landscape of cybersecurity and IT is too complex.  Let's open it up.
+The landscape of cybersecurity and IT needs to be simplified.  Let's open it up.
 
 Contributions are welcome, whether you answer questions on [Slack](#chat) / [GitHub](https://github.com/fleetdm/fleet/issues) / [StackOverflow](https://stackoverflow.com/search?q=osquery) / [LinkedIn](https://linkedin.com/company/fleetdm) / [Twitter](https://twitter.com/fleetctl), improve the documentation or [website](https://github.com/fleetdm/fleet/tree/main/website), write a tutorial, give a talk at a conference or local meetup, give an [interview on a podcast](https://fleetdm.com/podcasts), troubleshoot reported issues, or [submit a patch](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/Committing-Changes.md).  The Fleet code of conduct is [on GitHub](https://github.com/fleetdm/fleet/blob/main/CODE_OF_CONDUCT.md).
 
@@ -75,9 +71,12 @@ Contributions are welcome, whether you answer questions on [Slack](#chat) / [Git
 - Small, iterative, simple (boring) changes are the easiest to merge. -->
 
 ## What's next?
-[Try out Fleet](https://fleetdm.com/try-fleet) for yourself to see what it can do, grab time with one of the maintainers to discuss, or explore the rest of the docs and roll it out to your organization.
 
-#### Production deployment
+### Try it out
+
+[Try out Fleet](https://fleetdm.com/try-fleet) to see what it can do, grab time with one of the maintainers to discuss, or explore the rest of the docs and roll it out to your organization.
+
+### Production deployment
 Fleet is simple enough to [spin up for yourself](https://fleetdm.com/docs/deploy/deploy-on-aws-with-terraform).  Or you can have us [host it for you](https://fleetdm.com/pricing).  Premium features are [available](https://fleetdm.com/pricing) either way.
 
 <meta name="pageOrderInSection" value="100">

--- a/docs/Get started/why-fleet.md
+++ b/docs/Get started/why-fleet.md
@@ -71,7 +71,7 @@ The Fleet community is full of [kind and helpful people](https://fleetdm.com/han
 
 [Try out Fleet](https://fleetdm.com/try-fleet) to see what it can do, grab time with one of the maintainers to discuss, or explore the rest of the docs and roll it out to your organization.
 
-### Production deployment
+### Questions?
 Fleet is simple enough to [spin up for yourself](https://fleetdm.com/docs/deploy/deploy-on-aws-with-terraform).  Or you can have us [host it for you](https://fleetdm.com/pricing).  Premium features are [available](https://fleetdm.com/pricing) either way.
 
 <meta name="pageOrderInSection" value="100">

--- a/docs/Get started/why-fleet.md
+++ b/docs/Get started/why-fleet.md
@@ -31,7 +31,7 @@ Here are the platforms Fleet currently supports:
 - Linux-based IoT devices
 
 ## Lighter than air
-Fleet is lightweight and modular.  You can use it for security without MDM and vice versa.  You can turn off features you are not using.
+Fleet is lightweight and modular.  You can use it for security without using it for MDM, and vice versa.  You can turn off features you are not using.
 
 ### Openness
 Fleet is dedicated to flexibility, accessibility, and clarity.  We think [everyone can contribute](https://fleetdm.com/handbook/company#openness) and that tools should be as easy as possible for everyone to understand.

--- a/docs/Get started/why-fleet.md
+++ b/docs/Get started/why-fleet.md
@@ -61,7 +61,6 @@ Please join us in [MacAdmins Slack](https://www.macadmins.org/) or [osquery Slac
 The Fleet community is full of [kind and helpful people](https://fleetdm.com/handbook/company#empathy).  Whether or not you are a paying customer, if you need help, just ask.
 
 
-Contributions are welcome, whether you answer questions on [Slack](#chat) / [GitHub](https://github.com/fleetdm/fleet/issues) / [StackOverflow](https://stackoverflow.com/search?q=osquery) / [LinkedIn](https://linkedin.com/company/fleetdm) / [Twitter](https://twitter.com/fleetctl), improve the documentation or [website](https://github.com/fleetdm/fleet/tree/main/website), write a tutorial, give a talk at a conference or local meetup, give an [interview on a podcast](https://fleetdm.com/podcasts), troubleshoot reported issues, or [submit a patch](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/Committing-Changes.md).  The Fleet code of conduct is [on GitHub](https://github.com/fleetdm/fleet/blob/main/CODE_OF_CONDUCT.md).
 
 <!-- - Great contributions are motivated by real-world use cases or learning.
 - Some of the most valuable contributions might not touch any code at all.


### PR DESCRIPTION
I moved the "What's it for?" heading.  After seeing it on the site (rather than Markdown) I feel that placing it between the new paragraphs disrupts the message.

I also addressed some grammar and formatting issues.  Removed some redundant words and rephrased a couple of sentences to give a more personable tone.

### Original

<img width="541" alt="image" src="https://github.com/fleetdm/fleet/assets/78363703/1e67d9f2-4912-43db-846e-1f9b8d5803f6">

### vs this PR

<img width="741" alt="image" src="https://github.com/fleetdm/fleet/assets/78363703/4a362eec-f871-4612-a46e-1fbdfe72f21e">

