### PR TITLE
Simple fix for mdm module

### DIFF
--- a/terraform/addons/mdm/outputs.tf
+++ b/terraform/addons/mdm/outputs.tf
@@ -43,5 +43,5 @@ output "dep" {
 }
 
 output "apn" {
-  value = var.enable_apple_mdm == false ? null : aws_secretsmanager_secret.apn
+  value = var.enable_apple_mdm == false ? null : aws_secretsmanager_secret.apn[0]
 }


### PR DESCRIPTION
Since this was missing on the outputs, it broke apple mdm secret population in existing implementations.  This should re-assert backwards compatibility.