### PR TITLE
fix clipping svg for pdf graphic on chrome

### DIFF
--- a/frontend/components/graphics/FilePdf.tsx
+++ b/frontend/components/graphics/FilePdf.tsx
@@ -3,7 +3,7 @@ import React from "react";
 const FilePdf = () => {
   return (
     <svg xmlns="http://www.w3.org/2000/svg" width="34" height="40" fill="none">
-      <g clipPath="url(#a)">
+      <g>
         <path
           fill="#fff"
           stroke="#192147"


### PR DESCRIPTION
related to #14691

fix pdf graphic svg clipping on chrome

**before:**

![image](https://github.com/fleetdm/fleet/assets/1153709/46d80349-ea42-4c8a-9d66-fc1d8b7a1bb5)

**after:**

![image](https://github.com/fleetdm/fleet/assets/1153709/d32f73d2-33ea-4c2a-a25a-415e5735ff2c)

- [x] Manual QA for all new/changed functionality