### PR TITLE
Fleet UI: Changing pages, filters, or search query clears checkbox selections

### DIFF
--- a/changes/14596-reset-selected-rows
+++ b/changes/14596-reset-selected-rows
@@ -1,0 +1,1 @@
+- All Fleet tables in the UI will reset rows selected if user changes filters, search query, or paginates

--- a/frontend/components/TableContainer/DataTable/DataTable.tsx
+++ b/frontend/components/TableContainer/DataTable/DataTable.tsx
@@ -253,7 +253,7 @@ const DataTable = ({
 
   useEffect(() => {
     if (isClientSideFilter && searchQueryColumn) {
-      toggleAllRowsSelected(false); // Resets row selection on filter change (client-side)
+      toggleAllRowsSelected(false); // Resets row selection on query change (client-side)
       setDebouncedClientFilter(searchQueryColumn, searchQuery || "");
     }
   }, [searchQuery, searchQueryColumn]);

--- a/frontend/components/TableContainer/DataTable/DataTable.tsx
+++ b/frontend/components/TableContainer/DataTable/DataTable.tsx
@@ -102,7 +102,6 @@ const DataTable = ({
   renderPagination,
   setExportRows,
 }: IDataTableProps): JSX.Element => {
-  const { resetSelectedRows } = useContext(TableContext);
   const { isOnlyObserver } = useContext(AppContext);
 
   const columns = useMemo(() => {
@@ -152,8 +151,8 @@ const DataTable = ({
       disableMultiSort: true,
       disableSortRemove: true,
       manualSortBy,
-      // Initializes as false, but changes briefly to true on successful notification
-      autoResetSelectedRows: resetSelectedRows,
+      // Resets row selection on (server-side) pagination
+      autoResetSelectedRows: true,
       // Expands the enumerated `filterTypes` for react-table
       // (see https://github.com/TanStack/react-table/blob/alpha/packages/react-table/src/filterTypes.ts)
       // with custom `filterTypes` defined for this `useTable` instance
@@ -260,6 +259,7 @@ const DataTable = ({
 
   useEffect(() => {
     if (isClientSideFilter && selectedDropdownFilter) {
+      toggleAllRowsSelected(false); // Resets row selection on filter change (client-side)
       selectedDropdownFilter === "all"
         ? setDebouncedClientFilter("platforms", "")
         : setDebouncedClientFilter("platforms", selectedDropdownFilter);
@@ -575,6 +575,7 @@ const DataTable = ({
             <Button
               variant="unstyled"
               onClick={() => {
+                toggleAllRowsSelected(false); // Resets row selection on pagination (client-side)
                 onClientSidePaginationChange &&
                   onClientSidePaginationChange(pageIndex - 1);
                 previousPage();
@@ -586,6 +587,7 @@ const DataTable = ({
             <Button
               variant="unstyled"
               onClick={() => {
+                toggleAllRowsSelected(false); // Resets row selection on pagination (client-side)
                 onClientSidePaginationChange &&
                   onClientSidePaginationChange(pageIndex + 1);
                 nextPage();

--- a/frontend/components/TableContainer/DataTable/DataTable.tsx
+++ b/frontend/components/TableContainer/DataTable/DataTable.tsx
@@ -253,6 +253,7 @@ const DataTable = ({
 
   useEffect(() => {
     if (isClientSideFilter && searchQueryColumn) {
+      toggleAllRowsSelected(false); // Resets row selection on filter change (client-side)
       setDebouncedClientFilter(searchQueryColumn, searchQuery || "");
     }
   }, [searchQuery, searchQueryColumn]);


### PR DESCRIPTION
## Issue
Cerra #14596 

## Description
- All Fleet tables in the UI will reset rows selected if user changes filters, search query, or paginates

## Dev tested
- Host table, queries table (clientside), policies table

## Screen recording
### Manage hosts page

https://github.com/fleetdm/fleet/assets/71795832/f12961a1-cdc4-4428-ba51-85f4d8919cce

### Manage queries page

https://github.com/fleetdm/fleet/assets/71795832/15b5b663-e4bd-4b58-bbde-3a69181f9150

### Manage policies page

https://github.com/fleetdm/fleet/assets/71795832/e3645283-ba3b-4d87-a72d-a48c2048a279


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
- [x] Manual QA for all new/changed functionality

