### PR TITLE
Invalid SSO metadata now generates 400 error instead of 500

### DIFF
--- a/changes/12559-sso-metadata-url
+++ b/changes/12559-sso-metadata-url
@@ -1,0 +1,1 @@
+/fleet/sso endpoint now returns 400 status code (as opposed to 500) when SSO Metadata URL returns invalid data

--- a/changes/12559-sso-metadata-url
+++ b/changes/12559-sso-metadata-url
@@ -1,1 +1,1 @@
-/fleet/sso endpoint now returns 400 status code (as opposed to 500) when SSO Metadata URL returns invalid data
+/fleet/sso endpoint now returns 400 status code (as opposed to 500) when SSO Metadata URL returns invalid data or when SSO Metadata provided by user is invalid.

--- a/server/service/integration_sso_test.go
+++ b/server/service/integration_sso_test.go
@@ -104,8 +104,8 @@ func (s *integrationSSOTestSuite) TestSSOInvalidMetadataURL() {
 	)
 	require.NotNil(t, acResp)
 
-	var resGet ssoSettingsResponse
-	s.DoJSON("GET", "/api/v1/fleet/sso", nil, http.StatusBadRequest, &resGet)
+	var resIni initiateSSOResponse
+	s.DoJSON("POST", "/api/v1/fleet/sso", map[string]string{}, http.StatusBadRequest, &resIni)
 }
 
 func (s *integrationSSOTestSuite) TestSSOValidation() {

--- a/server/service/integration_sso_test.go
+++ b/server/service/integration_sso_test.go
@@ -96,7 +96,7 @@ func (s *integrationSSOTestSuite) TestSSOInvalidMetadataURL() {
 			"entity_id": "https://localhost:8080",
 			"issuer_uri": "http://localhost:8080/simplesaml/saml2/idp/SSOService.php",
 			"idp_name": "SimpleSAML",
-			"metadata_url": "https://localhost:8080",
+			"metadata_url": "https://www.fleetdm.com",
 			"enable_jit_provisioning": false
 		}
 	}`,

--- a/server/service/integration_sso_test.go
+++ b/server/service/integration_sso_test.go
@@ -83,6 +83,31 @@ func (s *integrationSSOTestSuite) TestGetSSOSettings() {
 	assert.True(t, strings.HasPrefix(authReq.ID, "id"), authReq.ID)
 }
 
+func (s *integrationSSOTestSuite) TestSSOInvalidMetadataURL() {
+	t := s.T()
+
+	acResp := appConfigResponse{}
+	// metadata_url below is BAD
+	s.DoJSON(
+		"PATCH", "/api/latest/fleet/config", json.RawMessage(
+			`{
+		"sso_settings": {
+			"enable_sso": true,
+			"entity_id": "https://localhost:8080",
+			"issuer_uri": "http://localhost:8080/simplesaml/saml2/idp/SSOService.php",
+			"idp_name": "SimpleSAML",
+			"metadata_url": "https://localhost:8080",
+			"enable_jit_provisioning": false
+		}
+	}`,
+		), http.StatusOK, &acResp,
+	)
+	require.NotNil(t, acResp)
+
+	var resGet ssoSettingsResponse
+	s.DoJSON("GET", "/api/v1/fleet/sso", nil, http.StatusBadRequest, &resGet)
+}
+
 func (s *integrationSSOTestSuite) TestSSOValidation() {
 	acResp := appConfigResponse{}
 	// Test we are validating metadata_url

--- a/server/service/integration_sso_test.go
+++ b/server/service/integration_sso_test.go
@@ -124,7 +124,7 @@ func (s *integrationSSOTestSuite) TestSSOInvalidMetadata() {
 			"issuer_uri": "http://localhost:8080/simplesaml/saml2/idp/SSOService.php",
 			"idp_name": "SimpleSAML",
 			"metadata": "`+badMetadata+`",
-            "metadata_url": "",
+			"metadata_url": "",
 			"enable_jit_provisioning": false
 		}
 	}`,

--- a/server/service/integration_sso_test.go
+++ b/server/service/integration_sso_test.go
@@ -86,8 +86,8 @@ func (s *integrationSSOTestSuite) TestGetSSOSettings() {
 func (s *integrationSSOTestSuite) TestSSOInvalidMetadataURL() {
 	t := s.T()
 
+	badMetadataUrl := "https://www.fleetdm.com"
 	acResp := appConfigResponse{}
-	// metadata_url below is BAD
 	s.DoJSON(
 		"PATCH", "/api/latest/fleet/config", json.RawMessage(
 			`{
@@ -96,7 +96,7 @@ func (s *integrationSSOTestSuite) TestSSOInvalidMetadataURL() {
 			"entity_id": "https://localhost:8080",
 			"issuer_uri": "http://localhost:8080/simplesaml/saml2/idp/SSOService.php",
 			"idp_name": "SimpleSAML",
-			"metadata_url": "https://www.fleetdm.com",
+			"metadata_url": "`+badMetadataUrl+`",
 			"enable_jit_provisioning": false
 		}
 	}`,
@@ -105,7 +105,36 @@ func (s *integrationSSOTestSuite) TestSSOInvalidMetadataURL() {
 	require.NotNil(t, acResp)
 
 	var resIni initiateSSOResponse
-	s.DoJSON("POST", "/api/v1/fleet/sso", map[string]string{}, http.StatusBadRequest, &resIni)
+	expectedStatus := http.StatusBadRequest
+	t.Logf("Expecting 400 %v status when bad SSO metadata_url is set: %v", expectedStatus, badMetadataUrl)
+	s.DoJSON("POST", "/api/v1/fleet/sso", map[string]string{}, expectedStatus, &resIni)
+}
+
+func (s *integrationSSOTestSuite) TestSSOInvalidMetadata() {
+	t := s.T()
+
+	badMetadata := "<EntityDescriptor>foo</EntityDescriptor>"
+	acResp := appConfigResponse{}
+	s.DoJSON(
+		"PATCH", "/api/latest/fleet/config", json.RawMessage(
+			`{
+		"sso_settings": {
+			"enable_sso": true,
+			"entity_id": "https://localhost:8080",
+			"issuer_uri": "http://localhost:8080/simplesaml/saml2/idp/SSOService.php",
+			"idp_name": "SimpleSAML",
+			"metadata": "`+badMetadata+`",
+			"enable_jit_provisioning": false
+		}
+	}`,
+		), http.StatusOK, &acResp,
+	)
+	require.NotNil(t, acResp)
+
+	var resIni initiateSSOResponse
+	expectedStatus := http.StatusBadRequest
+	t.Logf("Expecting %v status when bad SSO metadata is provided: %v", expectedStatus, badMetadata)
+	s.DoJSON("POST", "/api/v1/fleet/sso", map[string]string{}, expectedStatus, &resIni)
 }
 
 func (s *integrationSSOTestSuite) TestSSOValidation() {

--- a/server/service/integration_sso_test.go
+++ b/server/service/integration_sso_test.go
@@ -124,6 +124,7 @@ func (s *integrationSSOTestSuite) TestSSOInvalidMetadata() {
 			"issuer_uri": "http://localhost:8080/simplesaml/saml2/idp/SSOService.php",
 			"idp_name": "SimpleSAML",
 			"metadata": "`+badMetadata+`",
+            "metadata_url": "",
 			"enable_jit_provisioning": false
 		}
 	}`,

--- a/server/service/sessions.go
+++ b/server/service/sessions.go
@@ -303,7 +303,7 @@ func (svc *Service) InitiateSSO(ctx context.Context, redirectURL string) (string
 
 	metadata, err := sso.GetMetadata(&appConfig.SSOSettings.SSOProviderSettings)
 	if err != nil {
-		return "", ctxerr.Wrap(ctx, err, "InitiateSSO getting metadata")
+		return "", ctxerr.Wrap(ctx, badRequestErr("Could not get SSO Metadata. Check your SSO settings.", err))
 	}
 
 	serverURL := appConfig.ServerSettings.ServerURL


### PR DESCRIPTION
/fleet/sso endpoint now returns 400 status code (as opposed to 500) when SSO Metadata URL returns invalid data

#12559

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [x] Added/updated tests
- [x] Manual QA for all new/changed functionality
