### PR TITLE
UI – Refrain from clearing the auth_token and redirecting to login for errors specific to this scenario

### DIFF
--- a/frontend/components/AddHostsModal/DownloadInstallers/DownloadInstallers.tsx
+++ b/frontend/components/AddHostsModal/DownloadInstallers/DownloadInstallers.tsx
@@ -7,14 +7,13 @@ import {
   INSTALLER_TYPE_BY_PLATFORM,
 } from "interfaces/installer";
 import ENDPOINTS from "utilities/endpoints";
-import local from "utilities/local";
+import { authToken } from "utilities/local";
 import URL_PREFIX from "router/url_prefix";
 import installerAPI from "services/entities/installers";
 
 import Button from "components/buttons/Button";
 import Checkbox from "components/forms/fields/Checkbox";
 import DataError from "components/DataError";
-import Spinner from "components/Spinner";
 import TooltipWrapper from "components/TooltipWrapper";
 import Icon from "components/Icon";
 
@@ -126,7 +125,7 @@ const DownloadInstallers = ({
   const path = `${ENDPOINTS.DOWNLOAD_INSTALLER}/${selectedInstaller}`;
   const { origin } = global.window.location;
   const url = `${origin}${URL_PREFIX}/api${path}`;
-  const token = local.getItem("auth_token");
+  const token = authToken();
 
   const downloadInstaller = async (event: React.FormEvent<HTMLFormElement>) => {
     if (!selectedInstaller) {

--- a/frontend/components/App/App.tsx
+++ b/frontend/components/App/App.tsx
@@ -85,9 +85,12 @@ const App = ({ children, location }: IAppProps): JSX.Element => {
       if (
         // reseting a user's password requires the current token
         location?.pathname.includes("/login/reset") ||
-        // this can occur when the user refreshes their page at certain intervals,
+        // these errors can occur when user refreshes their page at certain intervals,
         // in which case we don't want to log them out
-        (typeof error === "string" && error.match(/request aborted/i))
+        (typeof error === "string" &&
+          // in Firefox and Chrome, this error is "Request aborted"
+          // in Safari, it's "Network Error"
+          error.match(/request aborted|network error/i))
       ) {
         return true;
       }

--- a/frontend/components/App/App.tsx
+++ b/frontend/components/App/App.tsx
@@ -8,7 +8,7 @@ import QueryProvider from "context/query";
 import PolicyProvider from "context/policy";
 import NotificationProvider from "context/notification";
 import { AppContext } from "context/app";
-import local, { authToken } from "utilities/local";
+import { authToken, clearToken } from "utilities/local";
 import useDeepEffect from "hooks/useDeepEffect";
 
 import usersAPI from "services/entities/users";
@@ -24,6 +24,8 @@ import Fleet404 from "pages/errors/Fleet404";
 import Fleet500 from "pages/errors/Fleet500";
 import Spinner from "components/Spinner";
 import { QueryParams } from "utilities/url";
+import { randomUUID } from "crypto";
+import { uniqueId } from "lodash";
 
 interface IAppProps {
   children: JSX.Element;
@@ -53,7 +55,27 @@ const App = ({ children, location }: IAppProps): JSX.Element => {
     setNoSandboxHosts,
   } = useContext(AppContext);
 
+  const curUUID = crypto.randomUUID();
+
   const [isLoading, setIsLoading] = useState(false);
+
+  // // approach 1 - keep track of, then delete the promise
+  // const promises = [];
+  // const handleBeforeUnload = (event) => {
+  //   // delete all promise objects
+  //   promises.forEach(promise => { delete promise; });
+  // };
+
+  // useEffect(() => {
+  //   window.addEventListener("beforeunload", handleBeforeUnload);
+  //   return () => {
+  //     window.removeEventListener("beforeUnload", handleBeforeUnload);
+  //   };
+  // });
+
+  // const foo = async () => {
+  //   return Promise.reject("baz");
+  // };
 
   const fetchConfig = async () => {
     try {
@@ -76,15 +98,31 @@ const App = ({ children, location }: IAppProps): JSX.Element => {
   };
 
   const fetchCurrentUser = async () => {
+    console.log(curUUID, "entered fetchCurrentUser");
     try {
+      // throw undefined;
+      console.log(curUUID, "fetch me");
+      // const bar = await foo();
+      // console.log("bar: ", bar);
+      // const { user, available_teams } = await usersAPI
+      //   .me()
+      //   .then((r) => r)
+      //   .catch((e) => {
+      //     console.log(curUUID, "usersAPI.me error: ", e);
+      //     throw e;
+      //   });
       const { user, available_teams } = await usersAPI.me();
+      console.log(curUUID, "set user");
       setCurrentUser(user);
+      console.log(curUUID, "set user available teams");
       setAvailableTeams(user, available_teams);
+      console.log(curUUID, "fetch config");
       fetchConfig();
     } catch (error) {
+      // if (!location?.pathname.includes("/login/reset") error !== undefined) {
       if (!location?.pathname.includes("/login/reset")) {
-        console.log(error);
-        local.removeItem("auth_token");
+        console.log(curUUID, "fetchCurrentUser error:", error);
+        clearToken();
 
         // if this is not the device user page,
         // redirect to login
@@ -97,7 +135,9 @@ const App = ({ children, location }: IAppProps): JSX.Element => {
   };
 
   useEffect(() => {
+    console.log(curUUID, "inside useEffect to refetch current user");
     if (authToken() && !location?.pathname.includes("/device/")) {
+      console.log("inside 'if' of useEffect to refetch current user");
       fetchCurrentUser();
     }
   }, [location?.pathname]);

--- a/frontend/pages/admin/TeamManagementPage/TeamDetailsWrapper/MembersPage/components/AutocompleteDropdown/AutocompleteDropdown.tsx
+++ b/frontend/pages/admin/TeamManagementPage/TeamDetailsWrapper/MembersPage/components/AutocompleteDropdown/AutocompleteDropdown.tsx
@@ -7,7 +7,7 @@ import React, { useCallback } from "react";
 import { Async, OnChangeHandler, Option } from "react-select";
 import classnames from "classnames";
 
-import local from "utilities/local";
+import { authToken } from "utilities/local";
 import debounce from "utilities/debounce";
 import permissionUtils from "utilities/permissions";
 import { IDropdownOption } from "interfaces/dropdownOption";
@@ -97,7 +97,7 @@ const AutocompleteDropdown = ({
 
     fetch(createUrl(resourceUrl, input), {
       headers: {
-        authorization: `Bearer ${local.getItem("auth_token")}`,
+        authorization: `Bearer ${authToken()}`,
       },
     })
       .then((res) => {

--- a/frontend/pages/policies/PolicyPage/screens/RunQuery.tsx
+++ b/frontend/pages/policies/PolicyPage/screens/RunQuery.tsx
@@ -9,7 +9,8 @@ import campaignHelpers from "utilities/campaign_helpers";
 import queryAPI from "services/entities/queries";
 import debounce from "utilities/debounce";
 import { BASE_URL, DEFAULT_CAMPAIGN_STATE } from "utilities/constants";
-import local from "utilities/local";
+import { authToken } from "utilities/local";
+
 import { ICampaign, ICampaignState } from "interfaces/campaign";
 import { IPolicy } from "interfaces/policy";
 import { ITarget } from "interfaces/target";
@@ -99,7 +100,7 @@ const RunQuery = ({
       websocket?.send(
         JSON.stringify({
           type: "auth",
-          data: { token: local.getItem("auth_token") },
+          data: { token: authToken() },
         })
       );
       websocket?.send(

--- a/frontend/pages/queries/live/screens/RunQuery.tsx
+++ b/frontend/pages/queries/live/screens/RunQuery.tsx
@@ -10,7 +10,8 @@ import campaignHelpers from "utilities/campaign_helpers";
 import debounce from "utilities/debounce";
 import { BASE_URL, DEFAULT_CAMPAIGN_STATE } from "utilities/constants";
 
-import local from "utilities/local";
+import { authToken } from "utilities/local";
+
 import { ICampaign, ICampaignState } from "interfaces/campaign";
 import { IQuery } from "interfaces/query";
 import { ITarget } from "interfaces/target";
@@ -102,7 +103,7 @@ const RunQuery = ({
       websocket?.send(
         JSON.stringify({
           type: "auth",
-          data: { token: local.getItem("auth_token") },
+          data: { token: authToken() },
         })
       );
       websocket?.send(

--- a/frontend/router/components/AuthenticatedRoutes/AuthenticatedRoutes.tsx
+++ b/frontend/router/components/AuthenticatedRoutes/AuthenticatedRoutes.tsx
@@ -5,7 +5,7 @@ import paths from "router/paths";
 import { AppContext } from "context/app";
 import { RoutingContext } from "context/routing";
 import useDeepEffect from "hooks/useDeepEffect";
-import local, { authToken } from "utilities/local";
+import { authToken, clearToken } from "utilities/local";
 import { useErrorHandler } from "react-error-boundary";
 import permissions from "utilities/permissions";
 
@@ -95,7 +95,7 @@ export const AuthenticatedRoutes = ({
     }
 
     if (currentUser && permissions.isNoAccess(currentUser)) {
-      local.removeItem("auth_token");
+      clearToken();
       return handlePageError({ status: 403 });
     }
   }, [currentUser]);

--- a/frontend/services/index.ts
+++ b/frontend/services/index.ts
@@ -13,7 +13,7 @@ const sendRequest = async (
   data?: unknown,
   responseType: AxiosResponseType = "json",
   timeout?: number
-): Promise<any> => {
+) => {
   const { origin } = global.window.location;
 
   const url = `${origin}${URL_PREFIX}/api${path}`;

--- a/frontend/services/index.ts
+++ b/frontend/services/index.ts
@@ -3,7 +3,8 @@ import axios, {
   AxiosResponse,
   ResponseType as AxiosResponseType,
 } from "axios";
-import local from "utilities/local";
+import { authToken } from "utilities/local";
+
 import URL_PREFIX from "router/url_prefix";
 
 const sendRequest = async (
@@ -16,7 +17,7 @@ const sendRequest = async (
   const { origin } = global.window.location;
 
   const url = `${origin}${URL_PREFIX}/api${path}`;
-  const token = local.getItem("auth_token");
+  const token = authToken();
 
   try {
     const response = await axios({
@@ -30,10 +31,15 @@ const sendRequest = async (
       },
     });
 
-    return Promise.resolve(response.data);
+    return response.data;
   } catch (error) {
     const axiosError = error as AxiosError;
-    return Promise.reject(axiosError.response);
+    return Promise.reject(
+      axiosError.response ||
+        axiosError.message ||
+        axiosError.code ||
+        "unknown axios error"
+    );
   }
 };
 

--- a/frontend/utilities/local.ts
+++ b/frontend/utilities/local.ts
@@ -1,24 +1,18 @@
-const { window } = global;
+const {
+  window: { localStorage },
+} = global;
 
 const local = {
   clear: (): void => {
-    const { localStorage } = window;
-
     localStorage.clear();
   },
   getItem: (itemName: string): string | null => {
-    const { localStorage } = window;
-
     return localStorage.getItem(`FLEET::${itemName}`);
   },
   setItem: (itemName: string, value: string): void => {
-    const { localStorage } = window;
-
     return localStorage.setItem(`FLEET::${itemName}`, value);
   },
   removeItem: (itemName: string): void => {
-    const { localStorage } = window;
-
     localStorage.removeItem(`FLEET::${itemName}`);
   },
 };


### PR DESCRIPTION
## Addresses #12968

https://www.loom.com/share/37aaaa36936b47079ff3088c3430e36b?sid=c249306b-a32e-4a33-be83-aae2d13c98aa

- Improve the implementation of error reporting by `sendRequest` to handle when AxiosError information is being provided in different fields (`response`, `message`, `code`, or nowhere), as opposed to relying on only the `response` field, which is empty in some (including this) situations
- Using the more fine-grained reporting above, exempt `Request aborted` errors when fetching a user's data,  which is what occurs here, from triggering a token clear and login page redirect.
- Use dedicated token handling utilities everywhere

## Checklist for submitter
- [x] Manual QA for all new/changed functionality
