### PR TITLE
UI - fix Host details offline status indicator color

### DIFF
--- a/frontend/pages/hosts/details/_styles.scss
+++ b/frontend/pages/hosts/details/_styles.scss
@@ -262,7 +262,7 @@
 
     &--offline {
       &:before {
-        background-color: $ui-fleet-black-25;
+        background-color: $ui-fleet-black-50;
         border-radius: 100%;
         content: " ";
         display: inline-block;


### PR DESCRIPTION
## Addresses #14358
Match offline indicator color on host details summary to those in the Manage hosts table:
<img width="1242" alt="Screenshot 2023-11-02 at 10 14 47 PM" src="https://github.com/fleetdm/fleet/assets/61553566/f8264ce2-958c-4344-af0e-cb7ab2f46330">

<img width="1247" alt="Screenshot 2023-11-02 at 10 17 10 PM" src="https://github.com/fleetdm/fleet/assets/61553566/6e69db56-42b8-4d03-8fb1-6d73aae864b9">

## Checklist for submitter
- [x] Manual QA for all new/changed functionality