### PR TITLE
show full formatted results for windows commands in fleetctl

### DIFF
--- a/cmd/fleetctl/get_test.go
+++ b/cmd/fleetctl/get_test.go
@@ -2182,33 +2182,43 @@ func TestGetMDMCommandResults(t *testing.T) {
 
 	t.Run("command results", func(t *testing.T) {
 		expectedOutput := strings.TrimSpace(`
-+-----------+----------------------+------+--------------+----------+---------------------------------------------------+
-|    ID     |         TIME         | TYPE |    STATUS    | HOSTNAME |                      RESULTS                      |
-+-----------+----------------------+------+--------------+----------+---------------------------------------------------+
-| valid-cmd | 2023-04-04T15:29:00Z | test | Acknowledged | host1    | <?xml version="1.0" encoding="UTF-8"?> <!DOCTYPE  |
-|           |                      |      |              |          | plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"        |
-|           |                      |      |              |          | "http://www.apple.com/DTDs/PropertyList-1.0.dtd"> |
-|           |                      |      |              |          | <plist version="1.0"> <dict>                      |
-|           |                      |      |              |          | <key>Command</key>     <dict>                     |
-|           |                      |      |              |          | <key>ManagedOnly</key>         <false/>           |
-|           |                      |      |              |          |         <key>RequestType</key>                    |
-|           |                      |      |              |          |    <string>ProfileList</string>                   |
-|           |                      |      |              |          | </dict>     <key>CommandUUID</key>                |
-|           |                      |      |              |          | <string>0001_ProfileList</string> </dict>         |
-|           |                      |      |              |          | </plist>                                          |
-+-----------+----------------------+------+--------------+----------+---------------------------------------------------+
-| valid-cmd | 2023-04-04T15:29:00Z | test | Error        | host2    | <?xml version="1.0" encoding="UTF-8"?> <!DOCTYPE  |
-|           |                      |      |              |          | plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"        |
-|           |                      |      |              |          | "http://www.apple.com/DTDs/PropertyList-1.0.dtd"> |
-|           |                      |      |              |          | <plist version="1.0"> <dict>                      |
-|           |                      |      |              |          | <key>Command</key>     <dict>                     |
-|           |                      |      |              |          | <key>ManagedOnly</key>         <false/>           |
-|           |                      |      |              |          |         <key>RequestType</key>                    |
-|           |                      |      |              |          |    <string>ProfileList</string>                   |
-|           |                      |      |              |          | </dict>     <key>CommandUUID</key>                |
-|           |                      |      |              |          | <string>0001_ProfileList</string> </dict>         |
-|           |                      |      |              |          | </plist>                                          |
-+-----------+----------------------+------+--------------+----------+---------------------------------------------------+
++-----------+----------------------+------+--------------+----------+--------------------------------------------------------------------------------------------------------+
+|    ID     |         TIME         | TYPE |    STATUS    | HOSTNAME |                                                RESULTS                                                 |
++-----------+----------------------+------+--------------+----------+--------------------------------------------------------------------------------------------------------+
+| valid-cmd | 2023-04-04T15:29:00Z | test | Acknowledged | host1    | <?xml version="1.0" encoding="UTF-8"?>                                                                 |
+|           |                      |      |              |          | <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd"> |
+|           |                      |      |              |          | <plist version="1.0">                                                                                  |
+|           |                      |      |              |          |   <dict>                                                                                               |
+|           |                      |      |              |          |     <key>Command</key>                                                                                 |
+|           |                      |      |              |          |     <dict>                                                                                             |
+|           |                      |      |              |          |       <key>ManagedOnly</key>                                                                           |
+|           |                      |      |              |          |       <false/>                                                                                         |
+|           |                      |      |              |          |       <key>RequestType</key>                                                                           |
+|           |                      |      |              |          |       <string>ProfileList</string>                                                                     |
+|           |                      |      |              |          |     </dict>                                                                                            |
+|           |                      |      |              |          |     <key>CommandUUID</key>                                                                             |
+|           |                      |      |              |          |     <string>0001_ProfileList</string>                                                                  |
+|           |                      |      |              |          |   </dict>                                                                                              |
+|           |                      |      |              |          | </plist>                                                                                               |
+|           |                      |      |              |          |                                                                                                        |
++-----------+----------------------+------+--------------+----------+--------------------------------------------------------------------------------------------------------+
+| valid-cmd | 2023-04-04T15:29:00Z | test | Error        | host2    | <?xml version="1.0" encoding="UTF-8"?>                                                                 |
+|           |                      |      |              |          | <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd"> |
+|           |                      |      |              |          | <plist version="1.0">                                                                                  |
+|           |                      |      |              |          |   <dict>                                                                                               |
+|           |                      |      |              |          |     <key>Command</key>                                                                                 |
+|           |                      |      |              |          |     <dict>                                                                                             |
+|           |                      |      |              |          |       <key>ManagedOnly</key>                                                                           |
+|           |                      |      |              |          |       <false/>                                                                                         |
+|           |                      |      |              |          |       <key>RequestType</key>                                                                           |
+|           |                      |      |              |          |       <string>ProfileList</string>                                                                     |
+|           |                      |      |              |          |     </dict>                                                                                            |
+|           |                      |      |              |          |     <key>CommandUUID</key>                                                                             |
+|           |                      |      |              |          |     <string>0001_ProfileList</string>                                                                  |
+|           |                      |      |              |          |   </dict>                                                                                              |
+|           |                      |      |              |          | </plist>                                                                                               |
+|           |                      |      |              |          |                                                                                                        |
++-----------+----------------------+------+--------------+----------+--------------------------------------------------------------------------------------------------------+
 `)
 
 		platform = "darwin"
@@ -2463,6 +2473,59 @@ func TestGetConfigAgentOptionsSSOAndSMTP(t *testing.T) {
 
 			ok := tc.checkOutput(runAppForTest(t, []string{"get", "config"}))
 			require.True(t, ok)
+		})
+	}
+}
+
+func TestFormatXML(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   []byte
+		want    []byte
+		wantErr bool
+	}{
+		{
+			name:    "Basic XML",
+			input:   []byte(`<root><element>content</element></root>`),
+			want:    []byte("<root>\n  <element>content</element>\n</root>\n"),
+			wantErr: false,
+		},
+		{
+			name:    "Empty XML",
+			input:   []byte(""),
+			want:    nil,
+			wantErr: false,
+		},
+		{
+			name:    "Invalid XML",
+			input:   []byte(`<root><element>content</root`),
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name:    "XML With Attributes",
+			input:   []byte(`<root attr="value"><element key="val">content</element></root>`),
+			want:    []byte("<root attr=\"value\">\n  <element key=\"val\">content</element>\n</root>\n"),
+			wantErr: false,
+		},
+		{
+			name:    "Nested XML",
+			input:   []byte(`<root><parent><child>data</child></parent></root>`),
+			want:    []byte("<root>\n  <parent>\n    <child>data</child>\n  </parent>\n</root>\n"),
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := formatXML(tt.input)
+
+			if tt.wantErr {
+				require.Error(t, err, "Expected error but got none")
+			} else {
+				require.NoError(t, err, "Unexpected error")
+				require.Equal(t, tt.want, got, "Output XML does not match expected")
+			}
 		})
 	}
 }

--- a/server/datastore/mysql/microsoft_mdm.go
+++ b/server/datastore/mysql/microsoft_mdm.go
@@ -347,7 +347,7 @@ SELECT
     wmcr.status_code as status,
     wmcr.updated_at,
     wmc.target_loc_uri as request_type,
-    wmcr.raw_result as result
+    wmr.raw_response as result
 FROM
     windows_mdm_command_results wmcr
 INNER JOIN
@@ -358,6 +358,10 @@ INNER JOIN
     mdm_windows_enrollments mwe
 ON
     wmcr.enrollment_id = mwe.id
+INNER JOIN
+    windows_mdm_responses wmr
+ON
+    wmr.id = wmcr.response_id
 WHERE
     wmcr.command_uuid = ?
 `

--- a/server/datastore/mysql/microsoft_mdm_test.go
+++ b/server/datastore/mysql/microsoft_mdm_test.go
@@ -635,7 +635,8 @@ func testMDMWindowsCommandResults(t *testing.T, ds *Datastore) {
 	_, err = insertDB(t, `INSERT INTO windows_mdm_commands (command_uuid, raw_command, target_loc_uri) VALUES (?, ?, ?)`, cmdUUID, rawCmd, cmdTarget)
 	require.NoError(t, err)
 
-	responseID, err := insertDB(t, `INSERT INTO windows_mdm_responses (enrollment_id, raw_response) VALUES (?, ?)`, enrollmentID, "some-response")
+	rawResponse := []byte("some-response")
+	responseID, err := insertDB(t, `INSERT INTO windows_mdm_responses (enrollment_id, raw_response) VALUES (?, ?)`, enrollmentID, rawResponse)
 	require.NoError(t, err)
 
 	rawResult := []byte("some-result")
@@ -652,7 +653,7 @@ func testMDMWindowsCommandResults(t *testing.T, ds *Datastore) {
 	require.Len(t, results, 1)
 	require.Equal(t, dev.HostUUID, results[0].HostUUID)
 	require.Equal(t, cmdUUID, results[0].CommandUUID)
-	require.Equal(t, rawResult, results[0].Result)
+	require.Equal(t, rawResponse, results[0].Result)
 	require.Equal(t, cmdTarget, results[0].RequestType)
 	require.Equal(t, statusCode, results[0].Status)
 	require.Empty(t, results[0].Hostname) // populated only at the service layer


### PR DESCRIPTION
for #14912 this adds the full results to the "RESULTS" column of `fleetctl get mdm-command-results`.

Additionally I included formatting of the XML output to improve readability.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Added/updated tests
- [x] Manual QA for all new/changed functionality
