### PR TITLE
Docs: update backticks in parameter description

### DIFF
--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -5785,7 +5785,7 @@ Creates a global query or team query.
 | platform                        | string  | body | The OS platforms where this query will run (other platforms ignored). Comma-separated string. If omitted, runs on all compatible platforms.                        |
 | min_osquery_version             | string  | body | The minimum required osqueryd version installed on a host. If omitted, all osqueryd versions are acceptable.                                                                          |
 | automations_enabled             | boolean | body | Whether to send data to the configured log destination according to the query's `interval`. |
-| logging             | string  | body | The type of log output for this query. Valid values: `"snapshot"`(default), `"differential", or "differential_ignore_removals"`.                        |
+| logging             | string  | body | The type of log output for this query. Valid values: `"snapshot"`(default), `"differential"`, or `"differential_ignore_removals"`.                        |
 | discard_data        | bool    | body | Whether to skip saving the latest query results for each host. Default: `false`. |
 
 


### PR DESCRIPTION
Changes:
- added backticks to a parameter description ("`"differential", or "differential_ignore_removals"`" » "`"differential"`, or `"differential_ignore_removals"`")...