### PR TITLE
Fix fleetdm.com/docs

### DIFF
--- a/docs/Get started/why-fleet.md
+++ b/docs/Get started/why-fleet.md
@@ -60,10 +60,9 @@ Please join us in [MacAdmins Slack](https://www.macadmins.org/) or [osquery Slac
 
 The Fleet community is full of [kind and helpful people](https://fleetdm.com/handbook/company#empathy).  Whether or not you are a paying customer, if you need help, just ask.
 
-
-
 <!-- - Great contributions are motivated by real-world use cases or learning.
 - Some of the most valuable contributions might not touch any code at all.
+Small, iterative, simple (boring) changes are the easiest to merge. -->
 
 ## What's next?
 


### PR DESCRIPTION
caused by a typo introduced during a live @mike-j-thomas + Mike M product marketing session on Zoom: https://github.com/fleetdm/fleet/commit/22af47aa923f15023186f9e14ee32f00877d2436#r131737251
