### PR TITLE
UI - align issues icons on manage hosts page

### DIFF
--- a/frontend/components/TableContainer/DataTable/IssueCell/IssueCell.tsx
+++ b/frontend/components/TableContainer/DataTable/IssueCell/IssueCell.tsx
@@ -4,6 +4,8 @@ import { isEmpty } from "lodash";
 
 import Icon from "components/Icon";
 
+const baseClass = "issue-cell";
+
 interface IIssueCellProps<T> {
   issues: {
     total_issues_count: number;
@@ -20,7 +22,7 @@ const IssueCell = ({ issues, rowId }: IIssueCellProps<any>): JSX.Element => {
   return (
     <>
       <span
-        className={`host-issue tooltip tooltip__tooltip-icon`}
+        className={`${baseClass}__icon tooltip tooltip__tooltip-icon`}
         data-tip
         data-for={`host-issue__${rowId.toString()}`}
         data-tip-disable={false}

--- a/frontend/pages/hosts/ManageHostsPage/_styles.scss
+++ b/frontend/pages/hosts/ManageHostsPage/_styles.scss
@@ -219,9 +219,15 @@
             }
 
             tbody {
-              .issues__cell {
-                display: flex;
-                align-items: center;
+              .issues {
+                &__cell {
+                  display: flex;
+                  align-items: center;
+                  .issue-cell__icon {
+                    display: flex;
+                    align-items: center;
+                  }
+                }
               }
 
               .device_mapping__cell,


### PR DESCRIPTION
Chrome:
<img width="179" alt="Screenshot 2023-11-06 at 2 22 36 PM" src="https://github.com/fleetdm/fleet/assets/61553566/b8cde487-cf41-4db0-920d-178a59939217">

FF:
<img width="135" alt="Screenshot 2023-11-06 at 9 53 05 AM" src="https://github.com/fleetdm/fleet/assets/61553566/b42eb365-d246-40c3-b08d-0a093bd18db7">

## Checklist for submitter

- [x] Manual QA for all new/changed functionality