### PR TITLE
Update product groups handbook

### DIFF
--- a/handbook/company/product-groups.md
+++ b/handbook/company/product-groups.md
@@ -248,7 +248,6 @@ The simplest way to manage work is to use a single user story issue, then pass i
 A user story is estimated to fit within 1 sprint and drives business value when released, independent of other stories.  Sub-tasks are not.
 
 Sub-tasks:
-- are NOT estimated
 - can be created by anyone
 - add extra management overhead and should be used sparingly
 - do NOT have nested sub-tasks


### PR DESCRIPTION
This keeps [causing confusion ](https://fleetdm.slack.com/archives/C02HWSTJ17Z/p1699307273524859)because we do estimate sub-tasks in ZenHub, and then they are rolled up to the user story, which is where we count them. As the handbook documents, all planning, QA, and business activities happen exclusively at the user story level.

...