### PR TITLE
Update edit columns modal to have two columns

### DIFF
--- a/changes/issue-11665-two-column-edit-columns-modal
+++ b/changes/issue-11665-two-column-edit-columns-modal
@@ -1,0 +1,1 @@
+- change the edit columns modal on the hosts page to show the table headers names in two columns.

--- a/frontend/pages/hosts/ManageHostsPage/components/EditColumnsModal/EditColumnsModal.jsx
+++ b/frontend/pages/hosts/ManageHostsPage/components/EditColumnsModal/EditColumnsModal.jsx
@@ -5,6 +5,8 @@ import Modal from "components/Modal";
 import Checkbox from "../../../../../components/forms/fields/Checkbox";
 import Button from "../../../../../components/buttons/Button";
 
+const baseClass = "edit-columns-modal";
+
 const useCheckboxListStateManagement = (allColumns, hiddenColumns) => {
   const [columnItems, setColumnItems] = useState(() => {
     return allColumns.map((column) => {
@@ -58,14 +60,10 @@ const EditColumnsModal = ({
   );
 
   return (
-    <Modal
-      title="Edit columns"
-      onExit={onCancelColumns}
-      className={"edit-columns-modal"}
-    >
+    <Modal title="Edit columns" onExit={onCancelColumns} className={baseClass}>
       <>
         <p>Choose which columns you see:</p>
-        <div className={"modal-items"}>
+        <div className={`${baseClass}__column-headers`}>
           {columnItems.map((column) => {
             if (column.disableHidden) return null;
             return (

--- a/frontend/pages/hosts/ManageHostsPage/components/EditColumnsModal/_styles.scss
+++ b/frontend/pages/hosts/ManageHostsPage/components/EditColumnsModal/_styles.scss
@@ -1,0 +1,7 @@
+.edit-columns-modal {
+  &__column-headers {
+    display: grid;
+    grid-template-columns: 1fr 1fr ;
+    grid-column-gap: $pad-medium;
+  }
+}


### PR DESCRIPTION
relates to #11665

This updates the edit column modal on the manage host page to have two columns.

![image](https://github.com/fleetdm/fleet/assets/1153709/20d0b7fc-b3cd-4caf-84d7-27e1af00fbb3)

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [x] Manual QA for all new/changed functionality
