### PR TITLE
Standardize where to specify design changes in the bug report template 

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -28,3 +28,6 @@ TODO
 N/A
 
 <!-- If this is a performance issue, follow these steps to generate and attach a debug archive: https://fleetdm.com/docs/using-fleet/monitoring-fleet#debugging-performance-issues -->
+
+<!-- ### 🛠️ To fix ### -->
+<!-- If this bug requires additional product design work, uncomment the heading above and add instructions to fix, Figma link, etc. here once design changes are settled. -->


### PR DESCRIPTION
Since a lot of bugs end up needing additional product design work, I propose adding a (commented-out by default) section to this template to standardize where to add design changes, once settled.

Reasoning: in estimation sessions, it can sometimes be hard to find this information: sometimes it's in the comments, sometimes it's been added to the description... either way, its not always obvious to spot. I think it will help us move quicker if there's a consistent heading to look for.

(Also, open to suggestions for other ways of wording that heading! This is just the way I've been adding it to issue descriptions lately.)