### PR TITLE
Website: Update edit page button on article pages

### DIFF
--- a/website/views/pages/articles/basic-article.ejs
+++ b/website/views/pages/articles/basic-article.ejs
@@ -4,16 +4,16 @@
       <h1><%=thisPage.meta.articleTitle %></h1>
       <h2 v-if="articleHasSubtitle && articleSubtitle !== undefined">{{articleSubtitle}}</h2>
     </div>
-    <div class="d-flex flex-sm-row flex-column justify-content-between">
+    <div class="d-flex flex-sm-row flex-column justify-content-between align-items-sm-center">
       <div purpose="article-details" class="d-flex flex-row align-items-center">
       <span><js-timestamp format="billing" :at="thisPage.meta.publishedOn"></js-timestamp></span>
       <span class="px-2">|</span>
       <img style="height: 28px; width: 28px; border-radius: 100%;" alt="The author's GitHub profile picture" :src="'https://github.com/'+thisPage.meta.authorGitHubUsername+'.png?size=200'">
       <p class="pl-2 font-weight-bold"><%=thisPage.meta.authorFullName %></p>
       </div>
-      <div class="d-flex flex-row align-items-center pt-3 pt-sm-1">
+      <div class="d-flex flex-row align-items-center justify-content-sm-end pt-3 pt-sm-1">
       <a purpose="rss-button" target="_blank" :href="'/rss/'+articleCategorySlug"><span>Subscribe</span></a>
-      <a purpose="edit-button" class="d-flex flex-row align-items-center" target="_blank" :href="'https://github.com/fleetdm/fleet/edit/main/articles/'+thisPage.sectionRelativeRepoPath"><img alt="A pencil icon" src="/images/pencil-16x16@2x.png">Edit page</a>
+      <a purpose="edit-button" class="d-flex flex-row align-items-center text-nowrap" target="_blank" :href="'https://github.com/fleetdm/fleet/edit/main/articles/'+thisPage.sectionRelativeRepoPath"><img alt="A pencil icon" src="/images/pencil-16x16@2x.png">Edit page</a>
       </div>
     </div>
     <div purpose="article-content" class="d-flex flex-column" parasails-has-no-page-script>


### PR DESCRIPTION
Closes: #15020

Changes:
- Updated the "edit page" button on article pages to prevent line breaks on Firefox v103.