### PR TITLE
Further clarify observer permissions to view queries & query reports

### DIFF
--- a/docs/Using Fleet/manage-access.md
+++ b/docs/Using Fleet/manage-access.md
@@ -95,7 +95,7 @@ GitOps is an API-only and write-only role that can be used on CI/CD pipelines.
 
 \* Applies only to Fleet Premium
 
-\** Global observers can view all queries but the UI and fleetctl only list the ones they can run (**observer can run**).
+\** Global observers can view all queries via the API. The UI and fleetctl only list the ones they can run (**observer can run**).
 
 \*** Applies only to [Fleet REST API](https://fleetdm.com/docs/using-fleet/rest-api)
 
@@ -163,7 +163,7 @@ Users that are members of multiple teams can be assigned different roles for eac
 
 \* Applies only to [Fleet REST API](https://fleetdm.com/docs/using-fleet/rest-api)
 
-\** Team observers can view all queries but the UI and fleetctl only list the ones they can run (**observer can run**).
+\** Team observers can view all queries via the API. The UI and fleetctl only list the ones they can run (**observer can run**).
 
 <meta name="pageOrderInSection" value="900">
 <meta name="description" value="Learn about the different roles and permissions in Fleet.">


### PR DESCRIPTION
It's a bit unclear from the permissions docs _how_ observers are able to view all queries & their reports, leading to bug reports like [this](https://github.com/fleetdm/fleet/issues/15009).
I think the intended behavior is that observers can view all queries and their reports **via the API** but not in the UI or fleetctl. Updated notes to clarify. (Let me know if my interpretation is incorrect!)