### PR TITLE
Enabled support and validation of 'after' parameter for several endpoints

### DIFF
--- a/changes/14571-carves-after-parameter
+++ b/changes/14571-carves-after-parameter
@@ -1,0 +1,14 @@
+Enabled support and validation of 'after' parameter for the following endpoints:
+- GET /api/v1/fleet/carves
+
+Setting 'after' parameter no longer returns error for the following endpoints:
+- GET /api/v1/fleet/carves
+- GET /api/v1/fleet/invites
+- GET /api/v1/fleet/labels
+- GET /api/v1/fleet/packs
+- GET /api/v1/fleet/global/policies
+- GET /api/v1/fleet/teams/{id}/policies
+- GET /api/v1/fleet/queries
+- GET /api/v1/fleet/packs/{id}/scheduled
+- GET /api/v1/fleet/teams
+- GET /api/v1/fleet/users

--- a/changes/14571-carves-after-parameter
+++ b/changes/14571-carves-after-parameter
@@ -1,7 +1,7 @@
 Enabled support and validation of 'after' parameter for the following endpoints:
 - GET /api/v1/fleet/carves
 
-Setting 'after' parameter no longer returns error for the following endpoints:
+Setting 'after' parameter no longer returns SQL syntax error for the following endpoints:
 - GET /api/v1/fleet/carves
 - GET /api/v1/fleet/invites
 - GET /api/v1/fleet/labels

--- a/server/datastore/mysql/carves.go
+++ b/server/datastore/mysql/carves.go
@@ -234,9 +234,9 @@ func (ds *Datastore) ListCarves(ctx context.Context, opt fleet.CarveListOptions)
 	if !opt.Expired {
 		stmt += ` WHERE NOT expired `
 	}
-	stmt = appendListOptionsToSQL(stmt, &opt.ListOptions)
+	stmt, params := appendListOptionsToSQL(stmt, &opt.ListOptions)
 	carves := []*fleet.CarveMetadata{}
-	if err := sqlx.SelectContext(ctx, ds.reader(ctx), &carves, stmt); err != nil && err != sql.ErrNoRows {
+	if err := sqlx.SelectContext(ctx, ds.reader(ctx), &carves, stmt, params...); err != nil && err != sql.ErrNoRows {
 		return nil, ctxerr.Wrap(ctx, err, "list carves")
 	}
 

--- a/server/datastore/mysql/invites.go
+++ b/server/datastore/mysql/invites.go
@@ -67,7 +67,7 @@ func (ds *Datastore) ListInvites(ctx context.Context, opt fleet.ListOptions) ([]
 	invites := []*fleet.Invite{}
 	query := "SELECT * FROM invites WHERE true"
 	query, params := searchLike(query, nil, opt.MatchQuery, inviteSearchColumns...)
-	query = appendListOptionsToSQL(query, &opt)
+	query, params = appendListOptionsWithCursorToSQL(query, params, &opt)
 
 	err := sqlx.SelectContext(ctx, ds.reader(ctx), &invites, query, params...)
 	if err == sql.ErrNoRows {

--- a/server/datastore/mysql/labels.go
+++ b/server/datastore/mysql/labels.go
@@ -282,6 +282,9 @@ func labelDB(ctx context.Context, lid uint, q sqlx.QueryerContext) (*fleet.Label
 
 // ListLabels returns all labels limited or sorted by fleet.ListOptions.
 func (ds *Datastore) ListLabels(ctx context.Context, filter fleet.TeamFilter, opt fleet.ListOptions) ([]*fleet.Label, error) {
+	if opt.After != "" {
+		return nil, &fleet.BadRequestError{Message: "'after' parameter is not supported"}
+	}
 	query := fmt.Sprintf(`
 			SELECT *,
 				(SELECT COUNT(1) FROM label_membership lm JOIN hosts h ON (lm.host_id = h.id) WHERE label_id = l.id AND %s) AS host_count

--- a/server/datastore/mysql/labels.go
+++ b/server/datastore/mysql/labels.go
@@ -283,7 +283,7 @@ func labelDB(ctx context.Context, lid uint, q sqlx.QueryerContext) (*fleet.Label
 // ListLabels returns all labels limited or sorted by fleet.ListOptions.
 func (ds *Datastore) ListLabels(ctx context.Context, filter fleet.TeamFilter, opt fleet.ListOptions) ([]*fleet.Label, error) {
 	if opt.After != "" {
-		return nil, &fleet.BadRequestError{Message: "'after' parameter is not supported"}
+		return nil, &fleet.BadRequestError{Message: "after parameter is not supported"}
 	}
 	query := fmt.Sprintf(`
 			SELECT *,

--- a/server/datastore/mysql/labels.go
+++ b/server/datastore/mysql/labels.go
@@ -289,10 +289,10 @@ func (ds *Datastore) ListLabels(ctx context.Context, filter fleet.TeamFilter, op
 		`, ds.whereFilterHostsByTeams(filter, "h"),
 	)
 
-	query = appendListOptionsToSQL(query, &opt)
+	query, params := appendListOptionsToSQL(query, &opt)
 	labels := []*fleet.Label{}
 
-	if err := sqlx.SelectContext(ctx, ds.reader(ctx), &labels, query); err != nil {
+	if err := sqlx.SelectContext(ctx, ds.reader(ctx), &labels, query, params...); err != nil {
 		// it's ok if no labels exist
 		if err == sql.ErrNoRows {
 			return labels, nil

--- a/server/datastore/mysql/mysql.go
+++ b/server/datastore/mysql/mysql.go
@@ -796,9 +796,8 @@ func appendLimitOffsetToSelect(ds *goqu.SelectDataset, opts fleet.ListOptions) *
 //
 // NOTE: this method will mutate the options argument if no explicit PerPage
 // option is set (a default value will be provided) or if the cursor approach is used.
-func appendListOptionsToSQL(sql string, opts *fleet.ListOptions) string {
-	sql, _ = appendListOptionsWithCursorToSQL(sql, nil, opts)
-	return sql
+func appendListOptionsToSQL(sql string, opts *fleet.ListOptions) (string, []interface{}) {
+	return appendListOptionsWithCursorToSQL(sql, nil, opts)
 }
 
 // Appends the list options SQL to the passed in SQL string. This appended

--- a/server/datastore/mysql/mysql_test.go
+++ b/server/datastore/mysql/mysql_test.go
@@ -363,7 +363,7 @@ func TestAppendListOptionsToSQL(t *testing.T) {
 		OrderKey: "***name***",
 	}
 
-	actual := appendListOptionsToSQL(sql, &opts)
+	actual, _ := appendListOptionsToSQL(sql, &opts)
 	expected := "SELECT * FROM my_table ORDER BY `name` ASC LIMIT 1000000"
 	if actual != expected {
 		t.Error("Expected", expected, "Actual", actual)
@@ -371,7 +371,7 @@ func TestAppendListOptionsToSQL(t *testing.T) {
 
 	sql = "SELECT * FROM my_table"
 	opts.OrderDirection = fleet.OrderDescending
-	actual = appendListOptionsToSQL(sql, &opts)
+	actual, _ = appendListOptionsToSQL(sql, &opts)
 	expected = "SELECT * FROM my_table ORDER BY `name` DESC LIMIT 1000000"
 	if actual != expected {
 		t.Error("Expected", expected, "Actual", actual)
@@ -382,7 +382,7 @@ func TestAppendListOptionsToSQL(t *testing.T) {
 	}
 
 	sql = "SELECT * FROM my_table"
-	actual = appendListOptionsToSQL(sql, &opts)
+	actual, _ = appendListOptionsToSQL(sql, &opts)
 	expected = "SELECT * FROM my_table LIMIT 10"
 	if actual != expected {
 		t.Error("Expected", expected, "Actual", actual)
@@ -390,7 +390,7 @@ func TestAppendListOptionsToSQL(t *testing.T) {
 
 	sql = "SELECT * FROM my_table"
 	opts.Page = 2
-	actual = appendListOptionsToSQL(sql, &opts)
+	actual, _ = appendListOptionsToSQL(sql, &opts)
 	expected = "SELECT * FROM my_table LIMIT 10 OFFSET 20"
 	if actual != expected {
 		t.Error("Expected", expected, "Actual", actual)
@@ -398,7 +398,7 @@ func TestAppendListOptionsToSQL(t *testing.T) {
 
 	opts = fleet.ListOptions{}
 	sql = "SELECT * FROM my_table"
-	actual = appendListOptionsToSQL(sql, &opts)
+	actual, _ = appendListOptionsToSQL(sql, &opts)
 	expected = "SELECT * FROM my_table LIMIT 1000000"
 
 	if actual != expected {

--- a/server/datastore/mysql/packs.go
+++ b/server/datastore/mysql/packs.go
@@ -455,7 +455,8 @@ func (ds *Datastore) ListPacks(ctx context.Context, opt fleet.PackListOptions) (
 		query = `SELECT * FROM packs`
 	}
 	var packs []*fleet.Pack
-	err := sqlx.SelectContext(ctx, ds.reader(ctx), &packs, appendListOptionsToSQL(query, &opt.ListOptions))
+	query, params := appendListOptionsToSQL(query, &opt.ListOptions)
+	err := sqlx.SelectContext(ctx, ds.reader(ctx), &packs, query, params...)
 	if err != nil && err != sql.ErrNoRows {
 		return nil, ctxerr.Wrap(ctx, err, "listing packs")
 	}

--- a/server/datastore/mysql/policies.go
+++ b/server/datastore/mysql/policies.go
@@ -345,7 +345,7 @@ func listPoliciesDB(ctx context.Context, q sqlx.QueryerContext, teamID, countsFo
 	}
 
 	initialQuery, args = searchLike(initialQuery, args, opts.MatchQuery, policySearchColumns...)
-	initialQuery = appendListOptionsToSQL(initialQuery, &opts)
+	initialQuery, args = appendListOptionsWithCursorToSQL(initialQuery, args, &opts)
 
 	var ids []uint
 	err := sqlx.SelectContext(ctx, q, &ids, initialQuery, args...)
@@ -391,7 +391,7 @@ func listPoliciesDB(ctx context.Context, q sqlx.QueryerContext, teamID, countsFo
 	opts.Page = 0
 	opts.PerPage = 0
 
-	query = appendListOptionsToSQL(query, &opts)
+	query, args = appendListOptionsWithCursorToSQL(query, args, &opts)
 
 	var policies []*fleet.Policy
 	err = sqlx.SelectContext(ctx, q, &policies, query, args...)

--- a/server/datastore/mysql/queries.go
+++ b/server/datastore/mysql/queries.go
@@ -478,7 +478,7 @@ func (ds *Datastore) ListQueries(ctx context.Context, opt fleet.ListQueryOptions
 	}
 
 	sql += whereClauses
-	sql = appendListOptionsToSQL(sql, &opt.ListOptions)
+	sql, args = appendListOptionsWithCursorToSQL(sql, args, &opt.ListOptions)
 
 	results := []*fleet.Query{}
 	if err := sqlx.SelectContext(ctx, ds.reader(ctx), &results, sql, args...); err != nil {

--- a/server/datastore/mysql/scheduled_queries.go
+++ b/server/datastore/mysql/scheduled_queries.go
@@ -41,10 +41,11 @@ func (ds *Datastore) ListScheduledQueriesInPackWithStats(ctx context.Context, id
 		LEFT JOIN aggregated_stats ag ON (ag.id = sq.id AND ag.global_stats = ? AND ag.type = ?)
 		WHERE sq.pack_id = ?
 	`
-	query = appendListOptionsToSQL(query, &opts)
+	params := []interface{}{false, aggregatedStatsTypeScheduledQuery, id}
+	query, params = appendListOptionsWithCursorToSQL(query, params, &opts)
 	results := []*fleet.ScheduledQuery{}
 
-	if err := sqlx.SelectContext(ctx, ds.reader(ctx), &results, query, false, aggregatedStatsTypeScheduledQuery, id); err != nil {
+	if err := sqlx.SelectContext(ctx, ds.reader(ctx), &results, query, params...); err != nil {
 		return nil, ctxerr.Wrap(ctx, err, "listing scheduled queries")
 	}
 

--- a/server/datastore/mysql/teams.go
+++ b/server/datastore/mysql/teams.go
@@ -253,7 +253,7 @@ func (ds *Datastore) ListTeams(ctx context.Context, filter fleet.TeamFilter, opt
 		ds.whereFilterTeams(filter, "t"),
 	)
 	query, params := searchLike(query, nil, opt.MatchQuery, teamSearchColumns...)
-	query = appendListOptionsToSQL(query, &opt)
+	query, params = appendListOptionsWithCursorToSQL(query, params, &opt)
 	teams := []*fleet.Team{}
 	if err := sqlx.SelectContext(ctx, ds.reader(ctx), &teams, query, params...); err != nil {
 		return nil, ctxerr.Wrap(ctx, err, "list teams")

--- a/server/datastore/mysql/users.go
+++ b/server/datastore/mysql/users.go
@@ -109,7 +109,7 @@ func (ds *Datastore) ListUsers(ctx context.Context, opt fleet.UserListOptions) (
 	}
 
 	sqlStatement, params = searchLike(sqlStatement, params, opt.MatchQuery, userSearchColumns...)
-	sqlStatement = appendListOptionsToSQL(sqlStatement, &opt.ListOptions)
+	sqlStatement, params = appendListOptionsWithCursorToSQL(sqlStatement, params, &opt.ListOptions)
 	users := []*fleet.User{}
 
 	if err := sqlx.SelectContext(ctx, ds.reader(ctx), &users, sqlStatement, params...); err != nil {

--- a/server/service/integration_core_test.go
+++ b/server/service/integration_core_test.go
@@ -2389,6 +2389,14 @@ func (s *integrationTestSuite) TestListGetCarves() {
 	assert.Equal(t, c1.ID, listResp.Carves[0].ID)
 	assert.Equal(t, c3.ID, listResp.Carves[1].ID)
 
+	// with 'after' param
+	s.DoJSON(
+		"GET", "/api/latest/fleet/carves", nil, http.StatusOK, &listResp, "per_page", "2", "order_key", "id", "after",
+		strconv.FormatInt(c1.ID, 10),
+	)
+	require.Len(t, listResp.Carves, 1)
+	assert.Equal(t, c3.ID, listResp.Carves[0].ID)
+
 	// include expired
 	s.DoJSON("GET", "/api/latest/fleet/carves", nil, http.StatusOK, &listResp, "per_page", "2", "order_key", "id", "expired", "1")
 	require.Len(t, listResp.Carves, 2)

--- a/server/service/integration_core_test.go
+++ b/server/service/integration_core_test.go
@@ -1777,6 +1777,9 @@ func (s *integrationTestSuite) TestGetHostSummary() {
 	}
 	assert.Equal(t, len(listResp.Labels), builtinsCount)
 
+	// 'after' param is not supported for labels
+	s.DoJSON("GET", "/api/latest/fleet/labels", nil, http.StatusBadRequest, &listResp, "order_key", "id", "after", "1")
+
 	// team filter, no host
 	s.DoJSON("GET", "/api/latest/fleet/host_summary", nil, http.StatusOK, &resp, "team_id", fmt.Sprint(team2.ID))
 	require.Equal(t, resp.TotalsHostsCount, uint(0))

--- a/server/service/transport.go
+++ b/server/service/transport.go
@@ -161,6 +161,10 @@ func listOptionsFromRequest(r *http.Request) (fleet.ListOptions, error) {
 		return fleet.ListOptions{}, ctxerr.Wrap(r.Context(), badRequest("order_key must be specified with order_direction"))
 	}
 
+	if orderKey == "" && afterString != "" {
+		return fleet.ListOptions{}, ctxerr.Wrap(r.Context(), badRequest("order_key must be specified with after"))
+	}
+
 	var orderDirection fleet.OrderDirection
 	switch orderDirectionString {
 	case "desc":

--- a/server/service/transport_test.go
+++ b/server/service/transport_test.go
@@ -61,12 +61,13 @@ func TestListOptionsFromRequest(t *testing.T) {
 
 		// All params defined
 		{
-			url: "/foo?order_key=foo&order_direction=desc&page=1&per_page=100",
+			url: "/foo?order_key=foo&order_direction=desc&page=1&per_page=100&after=bar",
 			listOptions: fleet.ListOptions{
 				OrderKey:       "foo",
 				OrderDirection: fleet.OrderDescending,
 				Page:           1,
 				PerPage:        100,
+				After:          "bar",
 			},
 		},
 
@@ -95,6 +96,11 @@ func TestListOptionsFromRequest(t *testing.T) {
 		// bad order_direction
 		{
 			url:          "/foo?&order_direction=foo&order_key=foo",
+			shouldErr400: true,
+		},
+		// after without order_key
+		{
+			url:          "/foo?page=1&after=foo",
 			shouldErr400: true,
 		},
 	}


### PR DESCRIPTION
Loom explaining changes: https://www.loom.com/share/f05f241a77304c19bc6ba1d0702c7bd8?sid=ea86b282-0bda-4ba4-a6cf-4520f0db610d

#14571 

Enabled support and validation of 'after' parameter for the following endpoints:
- GET /api/v1/fleet/carves

Setting 'after' parameter no longer returns SQL syntax error for the following endpoints:
- GET /api/v1/fleet/carves
- GET /api/v1/fleet/invites
- GET /api/v1/fleet/labels
- GET /api/v1/fleet/packs
- GET /api/v1/fleet/global/policies
- GET /api/v1/fleet/teams/{id}/policies
- GET /api/v1/fleet/queries
- GET /api/v1/fleet/packs/{id}/scheduled
- GET /api/v1/fleet/teams
- GET /api/v1/fleet/users

API doc changes PR: https://github.com/fleetdm/fleet/pull/15061

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [x] Added/updated tests
- [x] Manual QA for all new/changed functionality
