### PR TITLE
UI – Replace `overflow-x: scroll` with ...`auto`; remove redundant local declarations

### DIFF
--- a/changes/11753-scrollbars
+++ b/changes/11753-scrollbars
@@ -1,0 +1,1 @@
+- Fix a UI bug in data tables where scrollbars would continue to be present despite no overflowing content

--- a/frontend/components/TableContainer/DataTable/_styles.scss
+++ b/frontend/components/TableContainer/DataTable/_styles.scss
@@ -14,6 +14,7 @@ $shadow-transition-width: 10px;
       margin-top: $pad-small;
       flex-grow: 1;
       width: 100%;
+      overflow-x: auto;
 
       // Shadow
       background-image:

--- a/frontend/pages/DashboardPage/cards/Munki/_styles.scss
+++ b/frontend/pages/DashboardPage/cards/Munki/_styles.scss
@@ -2,9 +2,6 @@
   margin-top: $pad-large;
   position: relative;
 
-  .data-table__wrapper {
-    overflow-x: auto;
-  }
   .component__tabs-wrapper .table-container__header {
     display: none;
   }

--- a/frontend/pages/DashboardPage/cards/OperatingSystems/_styles.scss
+++ b/frontend/pages/DashboardPage/cards/OperatingSystems/_styles.scss
@@ -2,10 +2,6 @@
   margin-top: $pad-large;
   position: relative;
 
-  .data-table__wrapper {
-    overflow-x: auto;
-  }
-
   .hosts-cell__wrapper {
     display: flex;
     align-items: center;
@@ -33,6 +29,6 @@
 
   &__os-empty-table.empty-table__container {
     // overriding base component styles so this look correct for this card
-    margin-top: $pad-large
+    margin-top: $pad-large;
   }
 }

--- a/frontend/pages/DashboardPage/cards/Software/_styles.scss
+++ b/frontend/pages/DashboardPage/cards/Software/_styles.scss
@@ -13,9 +13,6 @@
       outline: 1px solid $core-vibrant-blue;
     }
   }
-  .data-table__wrapper {
-    overflow-x: auto;
-  }
   .form-field--dropdown {
     margin: 0;
   }

--- a/frontend/pages/hosts/ManageHostsPage/_styles.scss
+++ b/frontend/pages/hosts/ManageHostsPage/_styles.scss
@@ -196,9 +196,6 @@
     .table-container__data-table-block {
       .data-table-block {
         .data-table {
-          &__wrapper {
-            overflow-x: scroll;
-          }
           &__table {
             tbody {
               .issues {

--- a/frontend/pages/policies/PolicyPage/components/QueryResults/_styles.scss
+++ b/frontend/pages/policies/PolicyPage/components/QueryResults/_styles.scss
@@ -1,5 +1,4 @@
 .query-results {
-
   .info-banner {
     margin: 2rem auto 1.25rem;
   }
@@ -12,10 +11,6 @@
       position: relative;
       bottom: 2px;
     }
-  }
-
-  .data-table__wrapper {
-    overflow-x: scroll;
   }
 
   .data-table-block .data-table thead th {

--- a/frontend/pages/queries/ManageQueriesPage/_styles.scss
+++ b/frontend/pages/queries/ManageQueriesPage/_styles.scss
@@ -98,7 +98,6 @@
     .data-table-block {
       .data-table {
         &__wrapper {
-          overflow-x: scroll;
           overflow-y: hidden;
         }
         &__table {

--- a/frontend/pages/queries/details/components/QueryReport/_styles.scss
+++ b/frontend/pages/queries/details/components/QueryReport/_styles.scss
@@ -9,10 +9,6 @@
         margin-bottom: 44px; // Fills space where filter is removed
       }
     }
-
-    .data-table__wrapper {
-      overflow-x: scroll;
-    }
   }
 
   &__results-cta {

--- a/frontend/pages/queries/edit/components/QueryResults/_styles.scss
+++ b/frontend/pages/queries/edit/components/QueryResults/_styles.scss
@@ -23,10 +23,6 @@
     }
   }
 
-  .data-table__wrapper {
-    overflow-x: scroll;
-  }
-
   .data-table-block .data-table thead th {
     min-width: 140px;
     padding-left: 0px;


### PR DESCRIPTION
## Addresses #11753 

Fixed:
![Screenshot 2023-11-08 at 5 45 09 PM](https://github.com/fleetdm/fleet/assets/61553566/55570f5b-eb7d-4974-96e3-0304eef30b87)
(Was also occurring on queries page)
![Screenshot 2023-11-08 at 5 45 16 PM](https://github.com/fleetdm/fleet/assets/61553566/139d1ac6-e1e7-4b22-87d5-8cb43d00005d)

## Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`
- [x] Manual QA for all new/changed functionality