### PR TITLE
Mark critical policies in standard query library.

### DIFF
--- a/docs/01-Using-Fleet/standard-query-library/standard-query-library.yml
+++ b/docs/01-Using-Fleet/standard-query-library/standard-query-library.yml
@@ -480,7 +480,7 @@ spec:
   query: SELECT 1 FROM gatekeeper WHERE assessments_enabled = 1;
   description: Checks to make sure that the Gatekeeper feature is enabled on macOS devices. Gatekeeper tries to ensure only trusted software is run on a mac machine.
   resolution: "To enable Gatekeeper, on the failing device, run the following command in the Terminal app: /usr/sbin/spctl --master-enable."
-  tags: compliance, hardening, built-in, CIS, CIS2.5.2.1
+  tags: compliance, hardening, built-in, CIS, CIS2.5.2.1, critical
   platform: darwin
   contributors: groob
 ---
@@ -496,7 +496,7 @@ spec:
     considered unprotected. Use the additional results (percent_encrypted, conversion_status, etc.) to
     help narrow down the specific reason why Windows considers the volume unprotected."
   platform: windows
-  tags: compliance, hardening, built-in
+  tags: compliance, hardening, built-in, critical
   contributors: defensivedepth
 ---
 apiVersion: v1
@@ -506,7 +506,7 @@ spec:
   query: SELECT 1 FROM disk_encryption WHERE user_uuid IS NOT "" AND filevault_status = 'on' LIMIT 1;
   description: Checks to make sure that full disk encryption (FileVault) is enabled on macOS devices.
   resolution: To enable full disk encryption, on the failing device, select System Preferences > Security & Privacy > FileVault > Turn On FileVault.
-  tags: compliance, hardening, built-in, CIS, CIS2.5.1.1
+  tags: compliance, hardening, built-in, CIS, CIS2.5.1.1, critical
   platform: darwin
   contributors: groob
 ---
@@ -518,7 +518,7 @@ spec:
   description: Checks if the root drive is encrypted. There are many ways to encrypt Linux systems. This is the default on distributions such as Ubuntu.
   resolution: "Ensure the image deployed to your Linux workstation includes full disk encryption."
   platform: linux
-  tags: compliance, hardening, built-in
+  tags: compliance, hardening, built-in, critical
   contributors: GuillaumeRoss
 ---
 apiVersion: v1
@@ -539,7 +539,7 @@ spec:
   query: SELECT 1 FROM managed_policies WHERE domain = 'com.apple.loginwindow' AND name = 'com.apple.login.mcx.DisableAutoLoginClient' AND value = 1 LIMIT 1;
   description: "Checks that a mobile device management (MDM) solution configures the Mac to prevent login in without a password."
   resolution: "Contact your IT administrator to ensure your Mac is receiving a profile that disables automatic login."
-  tags: MDM required, compliance, hardening, built-in
+  tags: MDM required, compliance, hardening, built-in, critical
   platform: darwin
   contributors: groob
 ---
@@ -626,11 +626,11 @@ spec:
 apiVersion: v1
 kind: policy
 spec:
-  name: MDM Enrolled (macOS)
+  name: MDM enrolled (macOS)
   query: SELECT 1 from mdm WHERE enrolled='true';
   description: "Required: osquery deployed with Orbit, or manual installation of macadmins/osquery-extension. Checks that a mac is enrolled to MDM. Add a AND on identity_certificate_uuid to check for a specific MDM."
   resolution: "Enroll device to MDM"
-  tags: compliance, hardening, built-in
+  tags: compliance, hardening, built-in, critical
   platform: darwin
   contributors: GuillaumeRoss
 ---
@@ -715,10 +715,10 @@ apiVersion: v1
 kind: policy
 spec:
   name: Operating system up to date (macOS)
-  query: SELECT 1 FROM os_version WHERE version >= '12.5.1';
+  query: SELECT 1 FROM os_version WHERE version >= '14.1.1';
   description: "Checks that the operating system is up to date."
   resolution: "From the Apple menu () in the corner of your screen choose System Preferences. Then select Software Update and select Upgrade Now. You might be asked to restart or enter your password."
-  tags: compliance, CIS, template, CIS1.1
+  tags: compliance, CIS, template, CIS1.1, critical
   platform: darwin
   contributors: GuillaumeRoss
 ---

--- a/website/assets/styles/pages/query-library.less
+++ b/website/assets/styles/pages/query-library.less
@@ -48,6 +48,18 @@
     color: #FFF;
     text-decoration: none;
   }
+  [purpose='critical-badge'] {
+    text-transform: uppercase;
+    background: #FF5C83;
+    border-radius: 4px;
+    padding: 4px;
+    font-weight: 700;
+    font-size: 10px;
+    line-height: 10px;
+    display: inline;
+    color: #FFF;
+    text-decoration: none;
+  }
 
   [purpose='query-tag'] {
     font-size: 12px;

--- a/website/scripts/build-static-content.js
+++ b/website/scripts/build-static-content.js
@@ -69,6 +69,8 @@ module.exports = {
                   // If a query has a 'requires MDM' tag, we'll set requiresMDM to true for this query, and we'll ingore this tag.
                   if(_.trim(tag.toLowerCase()) === 'mdm required'){
                     query.requiresMdm = true;
+                  } else if(_.trim(tag.toLowerCase()) === 'critical') {
+                    query.critical = true;
                   } else {
                     // Removing any extra whitespace from tags and changing them to be in lower case.
                     formattedTags.push(_.trim(tag.toLowerCase()));

--- a/website/views/pages/query-library.ejs
+++ b/website/views/pages/query-library.ejs
@@ -101,6 +101,7 @@
                   <div class="col-12">
                     <div class="d-flex flex-row align-items-center flex-wrap">
                       <h5 class="card-title m-0 mb-1 mr-2">{{query.name}}</h5>
+                      <a purpose="critical-badge" class="mr-2" v-if="query.critical">Critical</a>
                       <a purpose="requires-mdm-badge" class="mr-2" v-if="query.requiresMdm">Requires MDM</a>
                       <span class="mr-2 my-sm-0 my-1 text-nowrap d-inline-flex" purpose="query-tag" v-for="tag in query.tags" @click.stop="clickSelectTag(tag)">{{tag}}</span>
                     </div>


### PR DESCRIPTION
Closes: #14812 

Changes:
- Added a "critical" tag to critical policies in the standard query library.
- Updated the macOS version used in the "Operating system up to date (macOS)" policy.
- Updated the name of a policy to be in sentence case ("MDM Enrolled (macOS)" » "MDM enrolled (macOS)")
- Updated the build-static-content script to add a `critical` attribute to queries that have the "critical" tag.
- Updated the /queries page to add a "critical" badge to queries that have the critical attribute.