### PR TITLE
Docs: Add pageOrderInSection meta tag to high-level-architecture.md

### DIFF
--- a/docs/Contributing/high-level-architecture.md
+++ b/docs/Contributing/high-level-architecture.md
@@ -190,3 +190,4 @@ graph LR;
     vulnServer --> fleetServer;
 ```
 
+<meta name="pageOrderInSection" value="1201">


### PR DESCRIPTION
Changes:
- Added a pageOrderInSection meta tag to the high level architecture page in the contributing docs. The missing meta tag is currently preventing the Fleet website from deploying and causing the website tests to fail.