### PR TITLE
Handbook: Add ritual for checking osquery Slack invitation link.

### DIFF
--- a/handbook/engineering/engineering.rituals.yml
+++ b/handbook/engineering/engineering.rituals.yml
@@ -85,10 +85,10 @@
   moreInfoUrl:
   dri: "xpkoala"
 - 
-  task: "Check osquery slack invitation"
+  task: "Check osquery Slack invitation"
   startedOn: "2023-11-10" 
   frequency: "Monthly"
-  description: "Check the osquery slack invitation that is linked to from Fleet and the [Fleet website](https://fleetdm.com/slack) to make sure it is valid."
+  description: "Check the osquery Slack invitation that is linked to from Fleet and the Fleet website to make sure it is valid."
   moreInfoUrl: "https://fleetdm.com/slack"
   dri: "eashaw"
 

--- a/handbook/engineering/engineering.rituals.yml
+++ b/handbook/engineering/engineering.rituals.yml
@@ -84,6 +84,13 @@
   description: "Every release cycle, by end of day Friday of release week, all issues move to Ready for release on the #g-mdm and #g-cx sprint boards."
   moreInfoUrl:
   dri: "xpkoala"
+- 
+  task: "Check osquery slack invitation"
+  startedOn: "2023-11-10" 
+  frequency: "Monthly"
+  description: "Check the osquery slack invitation that is linked to from Fleet and the [Fleet website](https://fleetdm.com/slack) to make sure it is valid."
+  moreInfoUrl: "https://fleetdm.com/slack"
+  dri: "eashaw"
 
 
 


### PR DESCRIPTION
Related issue: https://github.com/fleetdm/fleet/issues/15089

Changes:
- Added a new engineering ritual to check the Slack invitation linked to from Fleet and the Fleet website. (Slack invitations expire after 400 people have accepted the invitation)