### PR TITLE
Fix typo in example query

### DIFF
--- a/schema/tables/user_ssh_keys.yml
+++ b/schema/tables/user_ssh_keys.yml
@@ -4,7 +4,7 @@ examples: >-
   
   ```
   
-  SELECT * FROM users JOIN user_ssh_keys USING (uid) WHERE encrypted = 0;,
+  SELECT * FROM users JOIN user_ssh_keys USING (uid) WHERE encrypted = 0;
   
   ```
 columns:


### PR DESCRIPTION
Fix typo in example query for user_ssh_keys table