### PR TITLE
Fix pluralization in the "delete multiple queries" activity log

### DIFF
--- a/changes/issue-15050-pluralize-query-deletion-activity-log
+++ b/changes/issue-15050-pluralize-query-deletion-activity-log
@@ -1,0 +1,1 @@
+- * Pluralize the activity log rendered when multiple queries were deleted

--- a/frontend/interfaces/activity.ts
+++ b/frontend/interfaces/activity.ts
@@ -72,6 +72,7 @@ export interface IActivityDetails {
   query_id?: number;
   query_name?: string;
   query_sql?: string;
+  query_ids?: number[];
   team_id?: number | null;
   team_name?: string | null;
   teams?: ITeamSummary[];

--- a/frontend/interfaces/activity.ts
+++ b/frontend/interfaces/activity.ts
@@ -12,6 +12,7 @@ export enum ActivityType {
   EditedPolicy = "edited_policy",
   CreatedSavedQuery = "created_saved_query",
   DeletedSavedQuery = "deleted_saved_query",
+  DeletedMultipleSavedQuery = "deleted_multiple_saved_query",
   EditedSavedQuery = "edited_saved_query",
   CreatedTeam = "created_team",
   DeletedTeam = "deleted_team",

--- a/frontend/pages/DashboardPage/cards/ActivityFeed/ActivityItem/ActivityItem.tests.tsx
+++ b/frontend/pages/DashboardPage/cards/ActivityFeed/ActivityItem/ActivityItem.tests.tsx
@@ -882,4 +882,17 @@ describe("Activity Feed", () => {
       screen.getByText("for no team via fleetctl.", { exact: false })
     ).toBeInTheDocument();
   });
+  it("renders a pluralized 'deleted_multiple_saved_query' type activity when deleting multiple queries.", () => {
+    const activity = createMockActivity({
+      type: ActivityType.DeletedMultipleSavedQuery,
+      details: {
+        query_ids: [1, 2, 3],
+      },
+    });
+    render(<ActivityItem activity={activity} isPremiumTier />);
+
+    expect(
+      screen.getByText("deleted multiple queries", { exact: false })
+    ).toBeInTheDocument();
+  });
 });

--- a/frontend/pages/DashboardPage/cards/ActivityFeed/ActivityItem/ActivityItem.tsx
+++ b/frontend/pages/DashboardPage/cards/ActivityFeed/ActivityItem/ActivityItem.tsx
@@ -584,6 +584,9 @@ const TAGGED_TEMPLATES = {
       </>
     );
   },
+  deletedMultipleSavedQuery: (activity: IActivity) => {
+    return <> deleted multiple queries.</>;
+  },
 };
 
 const getDetail = (
@@ -708,6 +711,9 @@ const getDetail = (
     }
     case ActivityType.EditedScript: {
       return TAGGED_TEMPLATES.editedScript(activity);
+    }
+    case ActivityType.DeletedMultipleSavedQuery: {
+      return TAGGED_TEMPLATES.deletedMultipleSavedQuery(activity);
     }
     default: {
       return TAGGED_TEMPLATES.defaultActivityTemplate(activity);


### PR DESCRIPTION
### Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [x] Added/updated tests
- [x] Manual QA for all new/changed functionality

### Summary 

This PR creates a pluralized activity log in the case where a user deletes multiple saved queries.

I had considered updating the default template to better support pluralization, but when reviewing the various activity log types, I think queries are the only type that would benefit from this. So I chose the easier option here which felt less risky.

cc @sharon-fdm as the currently assigned person on the issue (just trying to save y'all some cycles by contributing and slowly ramping up on the codebase 😄)

ref: #15050 

### Test Plan

I added a unit test for this.

Additionally, I deleted multiple saved queries in my local installation. Here's the resulting log, showing the proper pluralization:

<img width="1381" alt="Screenshot 2023-11-10 at 9 54 40 PM" src="https://github.com/fleetdm/fleet/assets/1317288/f40414e2-7a9b-4478-b6cf-bb9d4ab6d8f0">