### PR TITLE
Bump minimum osquery versions

### DIFF
--- a/changes/14991-bump-minimum-osquery-versions
+++ b/changes/14991-bump-minimum-osquery-versions
@@ -1,0 +1,1 @@
+- - Updated the list of minimum osquery versions to include the latest releases up to 5.10.2

--- a/frontend/utilities/constants.ts
+++ b/frontend/utilities/constants.ts
@@ -55,6 +55,8 @@ export const MAX_OSQUERY_SCHEDULED_QUERY_INTERVAL = 604800;
 
 export const MIN_OSQUERY_VERSION_OPTIONS = [
   { label: "All", value: "" },
+  { label: "5.10.2 +", value: "5.10.2" },
+  { label: "5.9.1 +", value: "5.9.1" },
   { label: "5.8.2 +", value: "5.8.2" },
   { label: "5.8.1 +", value: "5.8.1" },
   { label: "5.7.0 +", value: "5.7.0" },


### PR DESCRIPTION
### Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [x] Manual QA for all new/changed functionality

### Summary

This PR adds the [latest osquery versions](https://github.com/osquery/osquery/releases) to the list of versions suitable for use in a query's "minimum osquery version" setting.

As far as I could tell, this was solely a frontend bug and did not require any backend changes.

ref: https://github.com/fleetdm/fleet/issues/14991

### Test Plan

I updated a standard query to include:

```yaml
  min_osquery_version: 5.10.2
```

And then applied the query with `fleetctl apply`.

I then saw the version reflected in the UI:

<img width="1381" alt="Screenshot 2023-11-12 at 10 01 32 PM" src="https://github.com/fleetdm/fleet/assets/1317288/4c9922aa-5afc-4c54-8929-1f64e3931e34">

I also manually set the minimum osquery version in the UI and confirmed it was reflected in the API response and when refreshing the page.

Longer term, I'd encourage considering whether setting up some kind of GH Action or, easier but more manual, an engineering ritual might make sense here to update this list as osquery releases happen. 🤷 