### PR TITLE
Add endpoint to get or download a profile (Windows and macOS)

### DIFF
--- a/changes/issue-14363-api-windows-profiles
+++ b/changes/issue-14363-api-windows-profiles
@@ -1,1 +1,2 @@
 * Added endpoint `DELETE /mdm/profiles/{id}` to delete an existing MDM profile (Windows and macOS).
+* Added endpoint `GET /mdm/profiles/{id}` to get or download an existing MDM profile (Windows and macOS).

--- a/server/datastore/mysql/apple_mdm.go
+++ b/server/datastore/mysql/apple_mdm.go
@@ -118,6 +118,7 @@ SELECT
 	name,
 	identifier,
 	mobileconfig,
+	checksum,
 	created_at,
 	updated_at
 FROM

--- a/server/fleet/mdm.go
+++ b/server/fleet/mdm.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/url"
+	"strconv"
 	"time"
 )
 
@@ -304,4 +305,49 @@ type MDMConfigProfileAuthz struct {
 // AuthzType implements authz.AuthzTyper.
 func (m MDMConfigProfileAuthz) AuthzType() string {
 	return "mdm_config_profile"
+}
+
+// MDMConfigProfilePayload is the platform-agnostic struct returned by
+// endpoints that return MDM configuration profiles (get/list profiles).
+type MDMConfigProfilePayload struct {
+	ProfileID  string    `json:"profile_id"` // is a uuid string for Windows
+	TeamID     *uint     `json:"team_id"`    // null for no-team
+	Name       string    `json:"name"`
+	Platform   string    `json:"platform"`             // "windows" or "darwin"
+	Identifier string    `json:"identifier,omitempty"` // only set for macOS
+	Checksum   []byte    `json:"checksum,omitempty"`   // only set for macOS
+	CreatedAt  time.Time `json:"created_at"`
+	UpdatedAt  time.Time `json:"updated_at"`
+}
+
+func NewMDMConfigProfilePayloadFromWindows(cp *MDMWindowsConfigProfile) *MDMConfigProfilePayload {
+	var tid *uint
+	if cp.TeamID != nil && *cp.TeamID > 0 {
+		tid = cp.TeamID
+	}
+	return &MDMConfigProfilePayload{
+		ProfileID: cp.ProfileUUID,
+		TeamID:    tid,
+		Name:      cp.Name,
+		Platform:  "windows",
+		CreatedAt: cp.CreatedAt,
+		UpdatedAt: cp.UpdatedAt,
+	}
+}
+
+func NewMDMConfigProfilePayloadFromApple(cp *MDMAppleConfigProfile) *MDMConfigProfilePayload {
+	var tid *uint
+	if cp.TeamID != nil && *cp.TeamID > 0 {
+		tid = cp.TeamID
+	}
+	return &MDMConfigProfilePayload{
+		ProfileID:  strconv.FormatUint(uint64(cp.ProfileID), 10),
+		TeamID:     tid,
+		Name:       cp.Name,
+		Identifier: cp.Identifier,
+		Platform:   "darwin",
+		Checksum:   cp.Checksum,
+		CreatedAt:  cp.CreatedAt,
+		UpdatedAt:  cp.UpdatedAt,
+	}
 }

--- a/server/fleet/service.go
+++ b/server/fleet/service.go
@@ -810,6 +810,9 @@ type Service interface {
 	// Set or update the disk encryption key for a host.
 	SetOrUpdateDiskEncryptionKey(ctx context.Context, encryptionKey, clientError string) error
 
+	// GetMDMWindowsConfigProfile retrieves the specified configuration profile.
+	GetMDMWindowsConfigProfile(ctx context.Context, profileUUID string) (*MDMWindowsConfigProfile, error)
+
 	// DeleteMDMWindowsConfigProfile deletes the specified windows profile.
 	DeleteMDMWindowsConfigProfile(ctx context.Context, profileUUID string) error
 

--- a/server/service/handler.go
+++ b/server/service/handler.go
@@ -529,6 +529,8 @@ func attachFleetAPIRoutes(r *mux.Router, svc fleet.Service, config config.FleetC
 	mdmAnyMW.GET("/api/_version_/fleet/mdm/commands", listMDMCommandsEndpoint, listMDMCommandsRequest{})
 	mdmAnyMW.GET("/api/_version_/fleet/mdm/disk_encryption/summary", getMDMDiskEncryptionSummaryEndpoint, getMDMDiskEncryptionSummaryRequest{})
 	mdmAnyMW.GET("/api/_version_/fleet/mdm/hosts/{id:[0-9]+}/encryption_key", getHostEncryptionKey, getHostEncryptionKeyRequest{})
+
+	mdmAnyMW.GET("/api/_version_/fleet/mdm/profiles/{profile_id_or_uuid}", getMDMConfigProfileEndpoint, getMDMConfigProfileRequest{})
 	mdmAnyMW.DELETE("/api/_version_/fleet/mdm/profiles/{profile_id_or_uuid}", deleteMDMConfigProfileEndpoint, deleteMDMConfigProfileRequest{})
 
 	// the following set of mdm endpoints must always be accessible (even

--- a/server/service/mdm.go
+++ b/server/service/mdm.go
@@ -1076,8 +1076,6 @@ func (svc *Service) DeleteMDMWindowsConfigProfile(ctx context.Context, profileUU
 		return ctxerr.Wrap(ctx, err)
 	}
 
-	// TODO: do we have Fleet-specific profiles for Windows that we'd want to prevent the user from deleting?
-
 	if err := svc.ds.DeleteMDMWindowsConfigProfile(ctx, profileUUID); err != nil {
 		return ctxerr.Wrap(ctx, err)
 	}

--- a/server/service/mdm.go
+++ b/server/service/mdm.go
@@ -967,7 +967,7 @@ func getMDMConfigProfileEndpoint(ctx context.Context, request interface{}, svc f
 		}
 
 		if downloadRequested {
-			return downloadScriptResponse{
+			return downloadFileResponse{
 				content:     cp.Mobileconfig,
 				contentType: "application/x-apple-aspen-config",
 				filename:    fmt.Sprintf("%s_%s.mobileconfig", time.Now().Format("2006-01-02"), strings.ReplaceAll(cp.Name, " ", "_")),
@@ -985,7 +985,7 @@ func getMDMConfigProfileEndpoint(ctx context.Context, request interface{}, svc f
 	}
 
 	if downloadRequested {
-		return downloadScriptResponse{
+		return downloadFileResponse{
 			content:     cp.SyncML,
 			contentType: "application/octet-stream", // not using the XML MIME type as a profile is not valid XML (a list of <Replace> elements)
 			filename:    fmt.Sprintf("%s_%s.xml", time.Now().Format("2006-01-02"), strings.ReplaceAll(cp.Name, " ", "_")),

--- a/server/service/scripts.go
+++ b/server/service/scripts.go
@@ -325,16 +325,16 @@ type getScriptResponse struct {
 
 func (r getScriptResponse) error() error { return r.Err }
 
-type downloadScriptResponse struct {
+type downloadFileResponse struct {
 	Err         error `json:"error,omitempty"`
 	filename    string
 	content     []byte
 	contentType string // optional, defaults to application/octet-stream
 }
 
-func (r downloadScriptResponse) error() error { return r.Err }
+func (r downloadFileResponse) error() error { return r.Err }
 
-func (r downloadScriptResponse) hijackRender(ctx context.Context, w http.ResponseWriter) {
+func (r downloadFileResponse) hijackRender(ctx context.Context, w http.ResponseWriter) {
 	w.Header().Set("Content-Length", strconv.Itoa(len(r.content)))
 	if r.contentType == "" {
 		r.contentType = "application/octet-stream"
@@ -362,7 +362,7 @@ func getScriptEndpoint(ctx context.Context, request interface{}, svc fleet.Servi
 	}
 
 	if downloadRequested {
-		return downloadScriptResponse{
+		return downloadFileResponse{
 			content:  content,
 			filename: fmt.Sprintf("%s %s", time.Now().Format(time.DateOnly), script.Name),
 		}, nil

--- a/server/service/scripts.go
+++ b/server/service/scripts.go
@@ -326,16 +326,20 @@ type getScriptResponse struct {
 func (r getScriptResponse) error() error { return r.Err }
 
 type downloadScriptResponse struct {
-	Err      error `json:"error,omitempty"`
-	filename string
-	content  []byte
+	Err         error `json:"error,omitempty"`
+	filename    string
+	content     []byte
+	contentType string // optional, defaults to application/octet-stream
 }
 
 func (r downloadScriptResponse) error() error { return r.Err }
 
 func (r downloadScriptResponse) hijackRender(ctx context.Context, w http.ResponseWriter) {
 	w.Header().Set("Content-Length", strconv.Itoa(len(r.content)))
-	w.Header().Set("Content-Type", "application/octet-stream")
+	if r.contentType == "" {
+		r.contentType = "application/octet-stream"
+	}
+	w.Header().Set("Content-Type", r.contentType)
 	w.Header().Set("Content-Disposition", fmt.Sprintf(`attachment;filename="%s"`, r.filename))
 	w.Header().Set("X-Content-Type-Options", "nosniff")
 

--- a/server/service/testing_utils.go
+++ b/server/service/testing_utils.go
@@ -636,6 +636,7 @@ func mdmConfigurationRequiredEndpoints() []struct {
 		{"GET", "/api/latest/fleet/mdm/commands", false, false},
 		{"POST", "/api/fleet/orbit/disk_encryption_key", false, false},
 		{"GET", "/api/latest/fleet/mdm/disk_encryption/summary", false, true},
+		{"GET", "/api/latest/fleet/mdm/profiles/1", false, false},
 		{"DELETE", "/api/latest/fleet/mdm/profiles/1", false, false},
 	}
 }


### PR DESCRIPTION
Final PR for #14363 

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [x] Added/updated tests
