### PR TITLE
Update Windows automatic enrollment instructions

### DIFF
--- a/frontend/pages/admin/IntegrationsPage/cards/AutomaticEnrollment/WindowsAutomaticEnrollmentPage/WindowsAutomaticEnrollmentPage.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/AutomaticEnrollment/WindowsAutomaticEnrollmentPage/WindowsAutomaticEnrollmentPage.tsx
@@ -58,8 +58,8 @@ const WindowsAutomaticEnrollmentPage = () => {
             <p>
               At the top of the page, search “Domain names“ and select{" "}
               <b>Domain names</b>. Then select <b>+ Add custom domain</b>, type
-              your Fleet URL (e.g. fleet.acme.com), and select{" "}
-              <b>Add domain</b>.
+              your Fleet URL (e.g. fleet.acme.com), and select <b>Add domain</b>
+              .
             </p>
           </li>
           <li>

--- a/frontend/pages/admin/IntegrationsPage/cards/AutomaticEnrollment/WindowsAutomaticEnrollmentPage/WindowsAutomaticEnrollmentPage.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/AutomaticEnrollment/WindowsAutomaticEnrollmentPage/WindowsAutomaticEnrollmentPage.tsx
@@ -58,7 +58,7 @@ const WindowsAutomaticEnrollmentPage = () => {
             <p>
               At the top of the page, search “Domain names“ and select{" "}
               <b>Domain names</b>. Then select <b>+ Add custom domain</b>, type
-              your organization&apos;s domain name (e.g. acme.com), and select{" "}
+              your Fleet URL (e.g. fleet.acme.com), and select{" "}
               <b>Add domain</b>.
             </p>
           </li>


### PR DESCRIPTION
- Change instructions

During Windows MDM testing, we discovered that the **Application ID URI** field in Azure AD must be a verified domain.

For example if your **Application ID URI** is `example.fleetdm.com`, `fleetdm.com `must be a verified domain in the Azure AD instance.

I think this means that for managed-cloud customers who want to use Windows automatic enrollment features (e.g. Autopilot) and who have Fleet URLs like `customer-name.fleetdm.com`, we'll have to help verify the domain for them.
