### PR TITLE
Website: Remove note from /fleetctl-preview page.

### DIFF
--- a/website/views/pages/fleetctl-preview.ejs
+++ b/website/views/pages/fleetctl-preview.ejs
@@ -2,7 +2,6 @@
   <div style="max-width: 800px; padding-top: 80px; padding-bottom: 80px;" class="container-fluid px-3">
     <h1 class="pb-4 m-0">Get started</h1>
     <p>Try out a preview of Fleet and osquery on your laptop before deploying at scale by following the guide below.</p>
-    <p>You can also <a href="/docs/deploying">deploy to a server</a>.</p>
     <div class="pt-4 pb-4">
       <h2 class="mb-3">1. Install Node (optional) and Docker</h2>
       <p>The quickest way to install Fleet is with Node.js and Docker.</p>


### PR DESCRIPTION
Closes: #15121
Changes:
- Removed the note about deploying to a server on the fleetctl preview page.