### PR TITLE
allow fleetctl to configure windows mdm profiles for teams and "no team"

### DIFF
--- a/changes/14361-fleetctl-apply-changes
+++ b/changes/14361-fleetctl-apply-changes
@@ -1,0 +1,1 @@
+* Allow fleetctl to configure windows mdm profiles for teams and "no team".

--- a/cmd/fleetctl/apply_test.go
+++ b/cmd/fleetctl/apply_test.go
@@ -160,7 +160,7 @@ func TestApplyTeamSpecs(t *testing.T) {
 		return nil
 	}
 
-	ds.BatchSetMDMAppleProfilesFunc = func(ctx context.Context, tmID *uint, profiles []*fleet.MDMAppleConfigProfile) error {
+	ds.BatchSetMDMProfilesFunc = func(ctx context.Context, tmID *uint, macProfiles []*fleet.MDMAppleConfigProfile, winProfiles []*fleet.MDMWindowsConfigProfile) error {
 		return nil
 	}
 
@@ -906,7 +906,7 @@ func TestApplyAsGitOps(t *testing.T) {
 		teamEnrollSecrets = secrets
 		return nil
 	}
-	ds.BatchSetMDMAppleProfilesFunc = func(ctx context.Context, teamID *uint, profiles []*fleet.MDMAppleConfigProfile) error {
+	ds.BatchSetMDMProfilesFunc = func(ctx context.Context, tmID *uint, macProfiles []*fleet.MDMAppleConfigProfile, winProfiles []*fleet.MDMWindowsConfigProfile) error {
 		return nil
 	}
 	ds.BulkSetPendingMDMAppleHostProfilesFunc = func(ctx context.Context, hostIDs, teamIDs, profileIDs []uint, hostUUIDs []string) error {
@@ -1086,7 +1086,7 @@ spec:
 	}, savedTeam.Config.MDM)
 	assert.Equal(t, []*fleet.EnrollSecret{{Secret: "BBB"}}, teamEnrollSecrets)
 	assert.True(t, ds.ApplyEnrollSecretsFuncInvoked)
-	assert.True(t, ds.BatchSetMDMAppleProfilesFuncInvoked)
+	assert.True(t, ds.BatchSetMDMProfilesFuncInvoked)
 
 	// add macos setup assistant to team
 	name = writeTmpYml(t, fmt.Sprintf(`

--- a/cmd/fleetctl/get_test.go
+++ b/cmd/fleetctl/get_test.go
@@ -2015,7 +2015,7 @@ func TestGetTeamsYAMLAndApply(t *testing.T) {
 		}
 		return nil, fmt.Errorf("team not found: %s", name)
 	}
-	ds.BatchSetMDMAppleProfilesFunc = func(ctx context.Context, teamID *uint, profiles []*fleet.MDMAppleConfigProfile) error {
+	ds.BatchSetMDMProfilesFunc = func(ctx context.Context, tmID *uint, macProfiles []*fleet.MDMAppleConfigProfile, winProfiles []*fleet.MDMWindowsConfigProfile) error {
 		return nil
 	}
 	ds.BulkSetPendingMDMAppleHostProfilesFunc = func(ctx context.Context, hostIDs, teamIDs, profileIDs []uint, uuids []string) error {

--- a/server/fleet/teams.go
+++ b/server/fleet/teams.go
@@ -419,6 +419,7 @@ func TeamSpecFromTeam(t *Team) (*TeamSpec, error) {
 	delete(mdmSpec.MacOSSettings, "enable_disk_encryption")
 	mdmSpec.MacOSSetup = t.Config.MDM.MacOSSetup
 	mdmSpec.EnableDiskEncryption = optjson.SetBool(t.Config.MDM.EnableDiskEncryption)
+	mdmSpec.WindowsSettings = t.Config.MDM.WindowsSettings
 	return &TeamSpec{
 		Name:         t.Name,
 		AgentOptions: agentOptions,

--- a/server/service/client.go
+++ b/server/service/client.go
@@ -281,7 +281,7 @@ func (c *Client) runAppConfigChecks(fn func(ac *fleet.EnrichedAppConfig) error) 
 
 // getProfilesContents takes file paths and creates a map of profile contents
 // keyed by the name of the profile (the file name on Windows,
-// PayloadDisplaName on macOS)
+// PayloadDisplayName on macOS)
 func getProfilesContents(baseDir string, paths []string) (map[string][]byte, error) {
 	files := resolveApplyRelativePaths(baseDir, paths)
 	fileContents := make(map[string][]byte, len(files))

--- a/server/service/client.go
+++ b/server/service/client.go
@@ -10,12 +10,14 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/fleetdm/fleet/v4/pkg/optjson"
 	"github.com/fleetdm/fleet/v4/pkg/spec"
 	"github.com/fleetdm/fleet/v4/server/contexts/ctxerr"
 	"github.com/fleetdm/fleet/v4/server/fleet"
+	"github.com/fleetdm/fleet/v4/server/mdm"
 	kithttp "github.com/go-kit/kit/transport/http"
 )
 
@@ -277,6 +279,36 @@ func (c *Client) runAppConfigChecks(fn func(ac *fleet.EnrichedAppConfig) error) 
 	return fn(appCfg)
 }
 
+// getProfilesContents takes file paths and creates a map of profile contents
+// keyed by the name of the profile (the file name on Windows,
+// PayloadDisplaName on macOS)
+func getProfilesContents(baseDir string, paths []string) (map[string][]byte, error) {
+	files := resolveApplyRelativePaths(baseDir, paths)
+	fileContents := make(map[string][]byte, len(files))
+	for _, f := range files {
+		b, err := os.ReadFile(f)
+		if err != nil {
+			return nil, fmt.Errorf("applying fleet config: %w", err)
+		}
+
+		// by default, use the file name. macOS profiles use their PayloadDisplayName
+		name := strings.TrimSuffix(filepath.Base(f), filepath.Ext(f))
+		if mdm.GetRawProfilePlatform(b) == "darwin" {
+			mc, err := fleet.NewMDMAppleConfigProfile(b, nil)
+			if err != nil {
+				return nil, fmt.Errorf("applying fleet config: %w", err)
+			}
+			name = strings.TrimSpace(mc.Name)
+		}
+		if _, isDuplicate := fileContents[name]; isDuplicate {
+			return nil, errors.New("Couldn't edit windows_settings.custom_settings. More than one configuration profile have the same name (Windows .xml file name or macOS PayloadDisplayName).")
+		}
+		fileContents[name] = b
+	}
+
+	return fileContents, nil
+}
+
 // ApplyGroup applies the given spec group to Fleet.
 func (c *Client) ApplyGroup(
 	ctx context.Context,
@@ -348,16 +380,14 @@ func (c *Client) ApplyGroup(
 	}
 
 	if specs.AppConfig != nil {
-		if macosCustomSettings := extractAppCfgMacOSCustomSettings(specs.AppConfig); macosCustomSettings != nil {
-			files := resolveApplyRelativePaths(baseDir, macosCustomSettings)
+		windowsCustomSettings := extractAppCfgWindowsCustomSettings(specs.AppConfig)
+		macosCustomSettings := extractAppCfgMacOSCustomSettings(specs.AppConfig)
+		allCustomSettings := append(macosCustomSettings, windowsCustomSettings...)
 
-			fileContents := make([][]byte, len(files))
-			for i, f := range files {
-				b, err := os.ReadFile(f)
-				if err != nil {
-					return fmt.Errorf("applying fleet config: %w", err)
-				}
-				fileContents[i] = b
+		if len(allCustomSettings) > 0 {
+			fileContents, err := getProfilesContents(baseDir, allCustomSettings)
+			if err != nil {
+				return err
 			}
 			if err := c.ApplyNoTeamProfiles(fileContents, opts); err != nil {
 				return fmt.Errorf("applying custom settings: %w", err)
@@ -429,18 +459,13 @@ func (c *Client) ApplyGroup(
 	if len(specs.Teams) > 0 {
 		// extract the teams' custom settings and resolve the files immediately, so
 		// that any non-existing file error is found before applying the specs.
-		tmMacSettings := extractTmSpecsMacOSCustomSettings(specs.Teams)
+		tmMDMSettings := extractTmSpecsMDMCustomSettings(specs.Teams)
 
-		tmFileContents := make(map[string][][]byte, len(tmMacSettings))
-		for k, paths := range tmMacSettings {
-			files := resolveApplyRelativePaths(baseDir, paths)
-			fileContents := make([][]byte, len(files))
-			for i, f := range files {
-				b, err := os.ReadFile(f)
-				if err != nil {
-					return fmt.Errorf("applying teams: %w", err)
-				}
-				fileContents[i] = b
+		tmFileContents := make(map[string]map[string][]byte, len(tmMDMSettings))
+		for k, paths := range tmMDMSettings {
+			fileContents, err := getProfilesContents(baseDir, paths)
+			if err != nil {
+				return err
 			}
 			tmFileContents[k] = fileContents
 		}
@@ -618,6 +643,43 @@ func extractAppCfgMacOSCustomSettings(appCfg interface{}) []string {
 	return csStrings
 }
 
+func extractAppCfgWindowsCustomSettings(appCfg interface{}) []string {
+	asMap, ok := appCfg.(map[string]interface{})
+	if !ok {
+		return nil
+	}
+	mmdm, ok := asMap["mdm"].(map[string]interface{})
+	if !ok {
+		return nil
+	}
+	mos, ok := mmdm["windows_settings"].(map[string]interface{})
+	if !ok || mos == nil {
+		return nil
+	}
+
+	cs, ok := mos["custom_settings"]
+	if !ok {
+		// custom settings is not present
+		return nil
+	}
+
+	csAny, ok := cs.([]interface{})
+	if !ok || csAny == nil {
+		// return a non-nil, empty slice instead, so the caller knows that the
+		// custom_settings key was actually provided.
+		return []string{}
+	}
+
+	csStrings := make([]string, 0, len(csAny))
+	for _, v := range csAny {
+		s, _ := v.(string)
+		if s != "" {
+			csStrings = append(csStrings, s)
+		}
+	}
+	return csStrings
+}
+
 func extractAppCfgScripts(appCfg interface{}) []string {
 	asMap, ok := appCfg.(map[string]interface{})
 	if !ok {
@@ -647,8 +709,8 @@ func extractAppCfgScripts(appCfg interface{}) []string {
 	return scriptsStrings
 }
 
-// returns the custom settings keyed by team name.
-func extractTmSpecsMacOSCustomSettings(tmSpecs []json.RawMessage) map[string][]string {
+// returns the custom macOS and Windows settings keyed by team name.
+func extractTmSpecsMDMCustomSettings(tmSpecs []json.RawMessage) map[string][]string {
 	var m map[string][]string
 	for _, tm := range tmSpecs {
 		var spec struct {
@@ -657,27 +719,54 @@ func extractTmSpecsMacOSCustomSettings(tmSpecs []json.RawMessage) map[string][]s
 				MacOSSettings struct {
 					CustomSettings json.RawMessage `json:"custom_settings"`
 				} `json:"macos_settings"`
+				WindowsSettings struct {
+					CustomSettings json.RawMessage `json:"custom_settings"`
+				} `json:"windows_settings"`
 			} `json:"mdm"`
 		}
 		if err := json.Unmarshal(tm, &spec); err != nil {
 			// ignore, this will fail in the call to apply team specs
 			continue
 		}
-		if spec.Name != "" && len(spec.MDM.MacOSSettings.CustomSettings) > 0 {
-			if m == nil {
-				m = make(map[string][]string)
+		if spec.Name != "" {
+			var macOSSettings []string
+			var windowsSettings []string
+
+			// to keep existing bahavior, if any of the custom
+			// settings is provided, make the map a non-nil map
+			if len(spec.MDM.MacOSSettings.CustomSettings) > 0 ||
+				len(spec.MDM.WindowsSettings.CustomSettings) > 0 {
+				if m == nil {
+					m = make(map[string][]string)
+				}
 			}
-			var cs []string
-			if err := json.Unmarshal(spec.MDM.MacOSSettings.CustomSettings, &cs); err != nil {
-				// ignore, will fail in apply team specs call
-				continue
+
+			if len(spec.MDM.MacOSSettings.CustomSettings) > 0 {
+				if err := json.Unmarshal(spec.MDM.MacOSSettings.CustomSettings, &macOSSettings); err != nil {
+					// ignore, will fail in apply team specs call
+					continue
+				}
+				if macOSSettings == nil {
+					// to be consistent with the AppConfig custom settings, set it to an
+					// empty slice if the provided custom settings are present but empty.
+					macOSSettings = []string{}
+				}
 			}
-			if cs == nil {
-				// to be consistent with the AppConfig custom settings, set it to an
-				// empty slice if the provided custom settings are present but empty.
-				cs = []string{}
+			if len(spec.MDM.WindowsSettings.CustomSettings) > 0 {
+				if err := json.Unmarshal(spec.MDM.WindowsSettings.CustomSettings, &windowsSettings); err != nil {
+					// ignore, will fail in apply team specs call
+					continue
+				}
+				if windowsSettings == nil {
+					// to be consistent with the AppConfig custom settings, set it to an
+					// empty slice if the provided custom settings are present but empty.
+					windowsSettings = []string{}
+				}
 			}
-			m[spec.Name] = cs
+
+			if macOSSettings != nil || windowsSettings != nil {
+				m[spec.Name] = append(macOSSettings, windowsSettings...)
+			}
 		}
 	}
 	return m

--- a/server/service/client_appconfig.go
+++ b/server/service/client_appconfig.go
@@ -14,8 +14,8 @@ func (c *Client) ApplyAppConfig(payload interface{}, opts fleet.ApplySpecOptions
 
 // ApplyNoTeamProfiles sends the list of profiles to be applied for the hosts
 // in no team.
-func (c *Client) ApplyNoTeamProfiles(profiles [][]byte, opts fleet.ApplySpecOptions) error {
-	verb, path := "POST", "/api/latest/fleet/mdm/apple/profiles/batch"
+func (c *Client) ApplyNoTeamProfiles(profiles map[string][]byte, opts fleet.ApplySpecOptions) error {
+	verb, path := "POST", "/api/latest/fleet/mdm/profiles/batch"
 	return c.authenticatedRequestWithQuery(map[string]interface{}{"profiles": profiles}, verb, path, nil, opts.RawQuery())
 }
 

--- a/server/service/client_teams.go
+++ b/server/service/client_teams.go
@@ -64,8 +64,8 @@ func (c *Client) ApplyTeams(specs []json.RawMessage, opts fleet.ApplySpecOptions
 
 // ApplyTeamProfiles sends the list of profiles to be applied for the specified
 // team.
-func (c *Client) ApplyTeamProfiles(tmName string, profiles [][]byte, opts fleet.ApplySpecOptions) error {
-	verb, path := "POST", "/api/latest/fleet/mdm/apple/profiles/batch"
+func (c *Client) ApplyTeamProfiles(tmName string, profiles map[string][]byte, opts fleet.ApplySpecOptions) error {
+	verb, path := "POST", "/api/latest/fleet/mdm/profiles/batch"
 	query, err := url.ParseQuery(opts.RawQuery())
 	if err != nil {
 		return err

--- a/server/service/client_test.go
+++ b/server/service/client_test.go
@@ -398,7 +398,7 @@ func TestGetProfilesContents(t *testing.T) {
 			paths := []string{}
 			for _, fileSpec := range tt.setupFiles {
 				filePath := filepath.Join(tempDir, fileSpec[0])
-				require.NoError(t, os.WriteFile(filePath, []byte(fileSpec[1]), 0666))
+				require.NoError(t, os.WriteFile(filePath, []byte(fileSpec[1]), 0644))
 				paths = append(paths, filePath)
 			}
 

--- a/server/service/client_test.go
+++ b/server/service/client_test.go
@@ -1,6 +1,9 @@
 package service
 
 import (
+	"fmt"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/fleetdm/fleet/v4/pkg/spec"
@@ -96,7 +99,96 @@ spec:
 	}
 }
 
-func TestExtractTeamSpecsMacOSCustomSettings(t *testing.T) {
+func TestExtractAppConfigWindowsCustomSettings(t *testing.T) {
+	cases := []struct {
+		desc string
+		yaml string
+		want []string
+	}{
+		{
+			"no settings",
+			`
+apiVersion: v1
+kind: config
+spec:
+`,
+			nil,
+		},
+		{
+			"no custom settings",
+			`
+apiVersion: v1
+kind: config
+spec:
+  org_info:
+    org_name: "Fleet"
+  mdm:
+    windows_settings:
+`,
+			nil,
+		},
+		{
+			"empty custom settings",
+			`
+apiVersion: v1
+kind: config
+spec:
+  org_info:
+    org_name: "Fleet"
+  mdm:
+    windows_settings:
+      custom_settings:
+`,
+			[]string{},
+		},
+		{
+			"custom settings specified",
+			`
+apiVersion: v1
+kind: config
+spec:
+  org_info:
+    org_name: "Fleet"
+  mdm:
+    windows_settings:
+      custom_settings:
+        - "a"
+        - "b"
+`,
+			[]string{"a", "b"},
+		},
+		{
+			"empty and invalid custom settings",
+			`
+apiVersion: v1
+kind: config
+spec:
+  org_info:
+    org_name: "Fleet"
+  mdm:
+    windows_settings:
+      custom_settings:
+        - "a"
+        - ""
+        - 4
+        - "c"
+`,
+			[]string{"a", "c"},
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.desc, func(t *testing.T) {
+			specs, err := spec.GroupFromBytes([]byte(c.yaml))
+			require.NoError(t, err)
+			if specs.AppConfig != nil {
+				got := extractAppCfgWindowsCustomSettings(specs.AppConfig)
+				require.Equal(t, c.want, got)
+			}
+		})
+	}
+}
+
+func TestExtractTeamSpecsMDMCustomSettings(t *testing.T) {
 	cases := []struct {
 		desc string
 		yaml string
@@ -122,6 +214,7 @@ spec:
     name: Fleet
     mdm:
       macos_settings:
+      windows_settings:
 ---
 apiVersion: v1
 kind: team
@@ -130,6 +223,7 @@ spec:
     name: Fleet2
     mdm:
       macos_settings:
+      windows_settings:
 `,
 			nil,
 		},
@@ -144,6 +238,8 @@ spec:
     mdm:
       macos_settings:
         custom_settings:
+      windows_settings:
+        custom_settings:
 ---
 apiVersion: v1
 kind: team
@@ -152,6 +248,8 @@ spec:
     name: "Fleet2"
     mdm:
       macos_settings:
+        custom_settings:
+      windows_settings:
         custom_settings:
 `,
 			map[string][]string{"Fleet": {}, "Fleet2": {}},
@@ -169,8 +267,12 @@ spec:
         custom_settings:
           - "a"
           - "b"
+      windows_settings:
+        custom_settings:
+          - "c"
+          - "d"
 `,
-			map[string][]string{"Fleet": {"a", "b"}},
+			map[string][]string{"Fleet": {"a", "b", "c", "d"}},
 		},
 		{
 			"invalid custom settings",
@@ -187,6 +289,12 @@ spec:
           - ""
           - 42
           - "c"
+      windows_settings:
+        custom_settings:
+          - "x"
+          - ""
+          - 24
+          - "y"
 `,
 			map[string][]string{},
 		},
@@ -196,7 +304,7 @@ spec:
 			specs, err := spec.GroupFromBytes([]byte(c.yaml))
 			require.NoError(t, err)
 			if len(specs.Teams) > 0 {
-				got := extractTmSpecsMacOSCustomSettings(specs.Teams)
+				got := extractTmSpecsMDMCustomSettings(specs.Teams)
 				require.Equal(t, c.want, got)
 			}
 		})
@@ -223,5 +331,90 @@ func TestExtractFilenameFromPath(t *testing.T) {
 	for _, c := range cases {
 		got := extractFilenameFromPath(c.in)
 		require.Equalf(t, c.out, got, "for URL %s", c.in)
+	}
+}
+
+func TestGetProfilesContents(t *testing.T) {
+	tempDir := t.TempDir()
+
+	tests := []struct {
+		name         string
+		baseDir      string
+		setupFiles   [][2]string
+		expectError  bool
+		expectedKeys []string
+	}{
+		{
+			name:    "invalid darwin xml",
+			baseDir: tempDir,
+			setupFiles: [][2]string{
+				{"foo.mobileconfig", `<?xml version="1.0" encoding="UTF-8"?>`},
+			},
+			expectError:  true,
+			expectedKeys: []string{"foo"},
+		},
+		{
+			name:    "windows and darwin files",
+			baseDir: tempDir,
+			setupFiles: [][2]string{
+				{"foo.xml", string(syncMLForTest("./some/path"))},
+				{"bar.mobileconfig", string(mobileconfigForTest("bar", "I"))},
+			},
+			expectError:  false,
+			expectedKeys: []string{"foo", "bar"},
+		},
+		{
+			name:    "darwin files with file name != PayloadDisplayName",
+			baseDir: tempDir,
+			setupFiles: [][2]string{
+				{"foo.xml", string(syncMLForTest("./some/path"))},
+				{"bar.mobileconfig", string(mobileconfigForTest("fizz", "I"))},
+			},
+			expectError:  false,
+			expectedKeys: []string{"foo", "fizz"},
+		},
+		{
+			name:    "duplicate names across windows and darwin",
+			baseDir: tempDir,
+			setupFiles: [][2]string{
+				{"baz.xml", string(syncMLForTest("./some/path"))},
+				{"bar.mobileconfig", string(mobileconfigForTest("baz", "I"))},
+			},
+			expectError: true,
+		},
+		{
+			name:    "duplicate file names",
+			baseDir: tempDir,
+			setupFiles: [][2]string{
+				{"baz.xml", string(syncMLForTest("./some/path"))},
+				{"baz.xml", string(syncMLForTest("./some/path"))},
+			},
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			paths := []string{}
+			for _, fileSpec := range tt.setupFiles {
+				filePath := filepath.Join(tempDir, fileSpec[0])
+				require.NoError(t, os.WriteFile(filePath, []byte(fileSpec[1]), 0666))
+				paths = append(paths, filePath)
+			}
+
+			profileContents, err := getProfilesContents(tt.baseDir, paths)
+
+			if tt.expectError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, profileContents)
+				require.Len(t, profileContents, len(tt.expectedKeys))
+				for _, key := range tt.expectedKeys {
+					_, exists := profileContents[key]
+					require.True(t, exists, fmt.Sprintf("Expected key %s not found", key))
+				}
+			}
+		})
 	}
 }

--- a/tools/mdm/apple/loadtest/loadtest.go
+++ b/tools/mdm/apple/loadtest/loadtest.go
@@ -240,8 +240,8 @@ func main() {
 	}
 }
 
-var profiles = [][]byte{
-	[]byte(`<?xml version="1.0" encoding="UTF-8"?>
+var profiles = map[string][]byte{
+	"Disable Bluetooth sharing": []byte(`<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
@@ -301,7 +301,7 @@ var profiles = [][]byte{
         </array>
 </dict>
 </plist>`),
-	[]byte(`<?xml version="1.0" encoding="UTF-8"?>
+	"Ensure Auto Update Is Enabled": []byte(`<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
@@ -338,7 +338,7 @@ var profiles = [][]byte{
         <integer>1</integer>
 </dict>
 </plist>`),
-	[]byte(`<?xml version="1.0" encoding="UTF-8"?>
+	"Ensure Download New Updates When Available Is Enabled": []byte(`<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
@@ -375,7 +375,7 @@ var profiles = [][]byte{
         <integer>1</integer>
 </dict>
 </plist>`),
-	[]byte(`<?xml version="1.0" encoding="UTF-8"?>
+	"Ensure Install of macOS Updates Is Enabled": []byte(`<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
@@ -412,7 +412,7 @@ var profiles = [][]byte{
         <integer>1</integer>
 </dict>
 </plist>`),
-	[]byte(`<?xml version="1.0" encoding="UTF-8"?>
+	"Ensure Install Application Updates from the App Store Is Enabled": []byte(`<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
@@ -449,7 +449,7 @@ var profiles = [][]byte{
         <integer>1</integer>
 </dict>
 </plist>`),
-	[]byte(`<?xml version="1.0" encoding="UTF-8"?>
+	"Ensure Install Security Responses and System Files Is Enabled": []byte(`<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
@@ -488,7 +488,7 @@ var profiles = [][]byte{
         <integer>1</integer>
 </dict>
 </plist>`),
-	[]byte(`<?xml version="1.0" encoding="UTF-8"?>
+	"Ensure Software Update Deferment Is Less Than or Equal to 30 Days": []byte(`<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
@@ -525,7 +525,7 @@ var profiles = [][]byte{
         <integer>1</integer>
 </dict>
 </plist>`),
-	[]byte(`<?xml version="1.0" encoding="UTF-8"?>
+	"Disable iCloud Drive storage solution usage": []byte(`<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
@@ -562,7 +562,7 @@ var profiles = [][]byte{
         <integer>1</integer>
 </dict>
 </plist>`),
-	[]byte(`<?xml version="1.0" encoding="UTF-8"?>
+	"Ensure Firewall Logging Is Enabled and Configured": []byte(`<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
@@ -603,7 +603,7 @@ var profiles = [][]byte{
         <integer>1</integer>
 </dict>
 </plist>`),
-	[]byte(`<?xml version="1.0" encoding="UTF-8"?>
+	"Ensure Bonjour Advertising Services Is Disabled": []byte(`<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>


### PR DESCRIPTION
final step of #14361 , this integrates the work of the other PRs.

currently branched off `14361-windows-custom-settings-configs`

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [x] Added/updated tests
- [x] Manual QA for all new/changed functionality
