### PR TITLE
Automate skipping of old database migration tests

### DIFF
--- a/server/datastore/mysql/migrations/tables/20220208144831_AddSoftwareReleaseArchVendorColumns_test.go
+++ b/server/datastore/mysql/migrations/tables/20220208144831_AddSoftwareReleaseArchVendorColumns_test.go
@@ -7,9 +7,6 @@ import (
 )
 
 func TestUp_20220208144831(t *testing.T) {
-	// skipping old migration tests as migrations don't change and we're getting
-	// timeouts in CI
-	t.Skip("old migration test, not longer required to run")
 	db := applyUpToPrev(t)
 
 	_, err := db.Exec(`INSERT INTO software (name, version, source) VALUES ("authconfig", "6.2.8", "rpm_packages")`)

--- a/server/datastore/mysql/migrations/tables/20220215152203_AddMunkiDeletedAt_test.go
+++ b/server/datastore/mysql/migrations/tables/20220215152203_AddMunkiDeletedAt_test.go
@@ -8,9 +8,6 @@ import (
 )
 
 func TestUp_20220215152203(t *testing.T) {
-	// skipping old migration tests as migrations don't change and we're getting
-	// timeouts in CI
-	t.Skip("old migration test, not longer required to run")
 	db := applyUpToPrev(t)
 
 	execNoErr(t, db, `INSERT INTO host_munki_info (host_id, version) VALUES (1, "6.2.8")`)

--- a/server/datastore/mysql/migrations/tables/20220223113157_UpdateSoftwareHostCountsTable_test.go
+++ b/server/datastore/mysql/migrations/tables/20220223113157_UpdateSoftwareHostCountsTable_test.go
@@ -8,9 +8,6 @@ import (
 )
 
 func TestUp_20220223113157(t *testing.T) {
-	// skipping old migration tests as migrations don't change and we're getting
-	// timeouts in CI
-	t.Skip("old migration test, not longer required to run")
 	db := applyUpToPrev(t)
 
 	execNoErr(t, db, `INSERT INTO software_host_counts (software_id, hosts_count) VALUES (1, 1)`)

--- a/server/datastore/mysql/migrations/tables/20220309133956_AddTeamConfig_test.go
+++ b/server/datastore/mysql/migrations/tables/20220309133956_AddTeamConfig_test.go
@@ -39,9 +39,6 @@ func (t TeamConfig20220309133956) Value() (driver.Value, error) {
 }
 
 func TestUp_20220309133956(t *testing.T) {
-	// skipping old migration tests as migrations don't change and we're getting
-	// timeouts in CI
-	t.Skip("old migration test, not longer required to run")
 	db := applyUpToPrev(t)
 
 	teams := []Team20220309133956{

--- a/server/datastore/mysql/migrations/tables/20220323152301_CleanupHostRelatedTables_test.go
+++ b/server/datastore/mysql/migrations/tables/20220323152301_CleanupHostRelatedTables_test.go
@@ -13,9 +13,6 @@ import (
 )
 
 func TestUp_20220323152301(t *testing.T) {
-	// skipping old migration tests as migrations don't change and we're getting
-	// timeouts in CI
-	t.Skip("old migration test, not longer required to run")
 	db := applyUpToPrev(t)
 
 	hosts := createHostsWithSoftware(t, db)

--- a/server/datastore/mysql/migrations/tables/20220330100659_AddJobsTable_test.go
+++ b/server/datastore/mysql/migrations/tables/20220330100659_AddJobsTable_test.go
@@ -7,9 +7,6 @@ import (
 )
 
 func TestUp_20220330100659(t *testing.T) {
-	// skipping old migration tests as migrations don't change and we're getting
-	// timeouts in CI
-	t.Skip("old migration test, not longer required to run")
 	db := applyUpToPrev(t)
 
 	applyNext(t, db)

--- a/server/datastore/mysql/migrations/tables/20220404091216_UpdateAppConfigLogEndpoint_test.go
+++ b/server/datastore/mysql/migrations/tables/20220404091216_UpdateAppConfigLogEndpoint_test.go
@@ -9,9 +9,6 @@ import (
 )
 
 func TestUp_20220404091216(t *testing.T) {
-	// skipping old migration tests as migrations don't change and we're getting
-	// timeouts in CI
-	t.Skip("old migration test, not longer required to run")
 	db := applyUpToPrev(t) // must be done in top-level test as the migration comes from the test name
 	t.Run("no entry", func(t *testing.T) {
 		_, err := db.Exec(`DELETE FROM app_config_json`)

--- a/server/datastore/mysql/migrations/tables/20220419140750_AddHostSoftwareLastOpenedAt_test.go
+++ b/server/datastore/mysql/migrations/tables/20220419140750_AddHostSoftwareLastOpenedAt_test.go
@@ -9,9 +9,6 @@ import (
 )
 
 func TestUp_20220419140750(t *testing.T) {
-	// skipping old migration tests as migrations don't change and we're getting
-	// timeouts in CI
-	t.Skip("old migration test, not longer required to run")
 	db := applyUpToPrev(t)
 
 	_, err := db.Exec(`INSERT INTO host_software (host_id, software_id) VALUES (1, 1)`)

--- a/server/datastore/mysql/migrations/tables/20220428140039_CleanupEmptyHostEmails_test.go
+++ b/server/datastore/mysql/migrations/tables/20220428140039_CleanupEmptyHostEmails_test.go
@@ -7,9 +7,6 @@ import (
 )
 
 func TestUp_20220428140039(t *testing.T) {
-	// skipping old migration tests as migrations don't change and we're getting
-	// timeouts in CI
-	t.Skip("old migration test, not longer required to run")
 	db := applyUpToPrev(t)
 
 	const insStmt = `INSERT INTO host_emails (host_id, email, source) VALUES (?, ?, ?)`

--- a/server/datastore/mysql/migrations/tables/20220503134048_AddCVEScoresTable_test.go
+++ b/server/datastore/mysql/migrations/tables/20220503134048_AddCVEScoresTable_test.go
@@ -7,9 +7,6 @@ import (
 )
 
 func TestUp_20220503134048(t *testing.T) {
-	// skipping old migration tests as migrations don't change and we're getting
-	// timeouts in CI
-	t.Skip("old migration test, not longer required to run")
 	db := applyUpToPrev(t)
 
 	applyNext(t, db)

--- a/server/datastore/mysql/migrations/tables/20220524102918_CleanupOrphanedPolicyMemberships_test.go
+++ b/server/datastore/mysql/migrations/tables/20220524102918_CleanupOrphanedPolicyMemberships_test.go
@@ -7,9 +7,6 @@ import (
 )
 
 func TestUp_20220524102918(t *testing.T) {
-	// skipping old migration tests as migrations don't change and we're getting
-	// timeouts in CI
-	t.Skip("old migration test, not longer required to run")
 	db := applyUpToPrev(t)
 
 	res, err := db.Exec(`

--- a/server/datastore/mysql/migrations/tables/20220526123327_RenameCVEScoresToCVEMeta_test.go
+++ b/server/datastore/mysql/migrations/tables/20220526123327_RenameCVEScoresToCVEMeta_test.go
@@ -8,9 +8,6 @@ import (
 )
 
 func TestUp_20220526123327(t *testing.T) {
-	// skipping old migration tests as migrations don't change and we're getting
-	// timeouts in CI
-	t.Skip("old migration test, not longer required to run")
 	db := applyUpToPrev(t)
 
 	applyNext(t, db)

--- a/server/datastore/mysql/migrations/tables/20220608113128_AddTransparencyURLToAppConfig_test.go
+++ b/server/datastore/mysql/migrations/tables/20220608113128_AddTransparencyURLToAppConfig_test.go
@@ -9,9 +9,6 @@ import (
 )
 
 func TestUp_20220608113128(t *testing.T) {
-	// skipping old migration tests as migrations don't change and we're getting
-	// timeouts in CI
-	t.Skip("old migration test, not longer required to run")
 	db := applyUpToPrev(t)
 
 	var prevRaw []byte

--- a/server/datastore/mysql/migrations/tables/20220627104817_AddHostBatteriesTable_test.go
+++ b/server/datastore/mysql/migrations/tables/20220627104817_AddHostBatteriesTable_test.go
@@ -7,9 +7,6 @@ import (
 )
 
 func TestUp_20220627104817(t *testing.T) {
-	// skipping old migration tests as migrations don't change and we're getting
-	// timeouts in CI
-	t.Skip("old migration test, not longer required to run")
 	db := applyUpToPrev(t)
 
 	applyNext(t, db)

--- a/server/datastore/mysql/migrations/tables/20220704101843_AddSoftwareIDInSoftwareCVE_test.go
+++ b/server/datastore/mysql/migrations/tables/20220704101843_AddSoftwareIDInSoftwareCVE_test.go
@@ -7,16 +7,13 @@ import (
 )
 
 func TestUp_20220704101843(t *testing.T) {
-	// skipping old migration tests as migrations don't change and we're getting
-	// timeouts in CI
-	t.Skip("old migration test, not longer required to run")
 	db := applyUpToPrev(t)
 
 	_, err := db.Exec(`INSERT INTO software (id, name, version, source, bundle_identifier, vendor, arch)
 	VALUES (1, 'zchunk-libs', '1.2.1', 'rpm_packages', '', 'Fedora Project','x86_64');`)
 	require.NoError(t, err)
 
-	_, err = db.Exec(`INSERT INTO software_cpe (id, software_id, created_at, updated_at, cpe) 
+	_, err = db.Exec(`INSERT INTO software_cpe (id, software_id, created_at, updated_at, cpe)
 	VALUES (2, 1, '2022-06-19 18:01:14', '2022-06-19 18:01:14', 'none:1704');`)
 	require.NoError(t, err)
 

--- a/server/datastore/mysql/migrations/tables/20220708095046_AddUniqconstraintSoftwareIDOnSoftwareCVE_test.go
+++ b/server/datastore/mysql/migrations/tables/20220708095046_AddUniqconstraintSoftwareIDOnSoftwareCVE_test.go
@@ -7,9 +7,6 @@ import (
 )
 
 func TestUp_20220708095046(t *testing.T) {
-	// skipping old migration tests as migrations don't change and we're getting
-	// timeouts in CI
-	t.Skip("old migration test, not longer required to run")
 	db := applyUpToPrev(t)
 	_, err := db.Exec(`INSERT INTO software (id, name, version, source, bundle_identifier, vendor, arch)
 	VALUES (1, 'zchunk-libs', '1.2.1', 'rpm_packages', '', 'Fedora Project','x86_64');`)

--- a/server/datastore/mysql/migrations/tables/20220713091130_AddOperatingSystemsTable_test.go
+++ b/server/datastore/mysql/migrations/tables/20220713091130_AddOperatingSystemsTable_test.go
@@ -7,9 +7,6 @@ import (
 )
 
 func TestUp_20220713091130(t *testing.T) {
-	// skipping old migration tests as migrations don't change and we're getting
-	// timeouts in CI
-	t.Skip("old migration test, not longer required to run")
 	db := applyUpToPrev(t)
 
 	applyNext(t, db)

--- a/server/datastore/mysql/migrations/tables/20220802135510_AddMobileDeviceManagementTable_test.go
+++ b/server/datastore/mysql/migrations/tables/20220802135510_AddMobileDeviceManagementTable_test.go
@@ -7,9 +7,6 @@ import (
 )
 
 func TestUp_20220802135510(t *testing.T) {
-	// skipping old migration tests as migrations don't change and we're getting
-	// timeouts in CI
-	t.Skip("old migration test, not longer required to run")
 	db := applyUpToPrev(t)
 
 	applyNext(t, db)

--- a/server/datastore/mysql/migrations/tables/20220818101352_ChangeSoftwareVendorWidth_test.go
+++ b/server/datastore/mysql/migrations/tables/20220818101352_ChangeSoftwareVendorWidth_test.go
@@ -7,15 +7,12 @@ import (
 )
 
 func TestUp_20220818101352(t *testing.T) {
-	// skipping old migration tests as migrations don't change and we're getting
-	// timeouts in CI
-	t.Skip("old migration test, not longer required to run")
 	db := applyUpToPrev(t)
 
 	_, err := db.Exec(`INSERT INTO software (name, version, source, bundle_identifier, vendor, arch)
-	VALUES 
-	('zchunk-libs', '1.2.1', 'rpm_packages', '', 'Fedora Project', 'x86_64'), 
-	('zchunk-libs', '1.2.1', 'rpm_packages', '', 'Fedora Project II', 'x86_64'), 
+	VALUES
+	('zchunk-libs', '1.2.1', 'rpm_packages', '', 'Fedora Project', 'x86_64'),
+	('zchunk-libs', '1.2.1', 'rpm_packages', '', 'Fedora Project II', 'x86_64'),
 	('word', '1.2.1', 'rpm_packages', '', 'Fake MS', 'x86_64'),
 	('word', '1.2.2', 'rpm_packages', '', 'Fake MS', 'x86_64'),
 	('excel', '1.2.1', 'rpm_packages', '', '', 'x86_64')

--- a/server/datastore/mysql/migrations/tables/20220822161445_CreateMunkiIssuesTable_test.go
+++ b/server/datastore/mysql/migrations/tables/20220822161445_CreateMunkiIssuesTable_test.go
@@ -9,9 +9,6 @@ import (
 )
 
 func TestUp_20220822161445(t *testing.T) {
-	// skipping old migration tests as migrations don't change and we're getting
-	// timeouts in CI
-	t.Skip("old migration test, not longer required to run")
 	db := applyUpToPrev(t)
 	applyNext(t, db)
 

--- a/server/datastore/mysql/migrations/tables/20220831100151_AddWindowsUpdatesTable_test.go
+++ b/server/datastore/mysql/migrations/tables/20220831100151_AddWindowsUpdatesTable_test.go
@@ -7,9 +7,6 @@ import (
 )
 
 func TestUp_20220831100151(t *testing.T) {
-	// skipping old migration tests as migrations don't change and we're getting
-	// timeouts in CI
-	t.Skip("old migration test, not longer required to run")
 	db := applyUpToPrev(t)
 
 	applyNext(t, db)

--- a/server/datastore/mysql/migrations/tables/20220908181826_AddOrbitNodeKeyToHosts_test.go
+++ b/server/datastore/mysql/migrations/tables/20220908181826_AddOrbitNodeKeyToHosts_test.go
@@ -8,9 +8,6 @@ import (
 )
 
 func TestUp_20220908181826(t *testing.T) {
-	// skipping old migration tests as migrations don't change and we're getting
-	// timeouts in CI
-	t.Skip("old migration test, not longer required to run")
 	db := applyUpToPrev(t)
 
 	zeroTime := time.Unix(0, 0).Add(24 * time.Hour)

--- a/server/datastore/mysql/migrations/tables/20220915165116_HostDisplayName_test.go
+++ b/server/datastore/mysql/migrations/tables/20220915165116_HostDisplayName_test.go
@@ -7,9 +7,6 @@ import (
 )
 
 func TestUp_20220915165116(t *testing.T) {
-	// skipping old migration tests as migrations don't change and we're getting
-	// timeouts in CI
-	t.Skip("old migration test, not longer required to run")
 	db := applyUpToPrev(t)
 
 	_, err := db.Exec(`

--- a/server/datastore/mysql/migrations/tables/20220928100158_AddHostDeviceAuthTimestamps_test.go
+++ b/server/datastore/mysql/migrations/tables/20220928100158_AddHostDeviceAuthTimestamps_test.go
@@ -8,9 +8,6 @@ import (
 )
 
 func TestUp_20220928100158(t *testing.T) {
-	// skipping old migration tests as migrations don't change and we're getting
-	// timeouts in CI
-	t.Skip("old migration test, not longer required to run")
 	db := applyUpToPrev(t)
 
 	_, err := db.Exec(`INSERT INTO host_device_auth (host_id, token) VALUES (1, 'abcd')`)

--- a/server/datastore/mysql/migrations/tables/20221014084130_CreateHostOrbitInfoTable_test.go
+++ b/server/datastore/mysql/migrations/tables/20221014084130_CreateHostOrbitInfoTable_test.go
@@ -7,9 +7,6 @@ import (
 )
 
 func TestUp_20221014084130(t *testing.T) {
-	// skipping old migration tests as migrations don't change and we're getting
-	// timeouts in CI
-	t.Skip("old migration test, not longer required to run")
 	db := applyUpToPrev(t)
 
 	applyNext(t, db)

--- a/server/datastore/mysql/migrations/tables/20221101103952_AddHostDisksEncryption_test.go
+++ b/server/datastore/mysql/migrations/tables/20221101103952_AddHostDisksEncryption_test.go
@@ -7,9 +7,6 @@ import (
 )
 
 func TestUp_20221101103952(t *testing.T) {
-	// skipping old migration tests as migrations don't change and we're getting
-	// timeouts in CI
-	t.Skip("old migration test, not longer required to run")
 	db := applyUpToPrev(t)
 
 	_, err := db.Exec(`INSERT INTO host_disks (host_id, gigs_disk_space_available, percent_disk_space_available) VALUES (1, 35, 70.5)`)

--- a/server/datastore/mysql/migrations/tables/20221109100749_RemoveHostsDiskSpaceColumns_test.go
+++ b/server/datastore/mysql/migrations/tables/20221109100749_RemoveHostsDiskSpaceColumns_test.go
@@ -7,9 +7,6 @@ import (
 )
 
 func TestUp_20221109100749(t *testing.T) {
-	// skipping old migration tests as migrations don't change and we're getting
-	// timeouts in CI
-	t.Skip("old migration test, not longer required to run")
 	db := applyUpToPrev(t)
 
 	_, err := db.Exec(`INSERT INTO hosts (hostname, osquery_host_id, gigs_disk_space_available, percent_disk_space_available) VALUES ('h1', 'ohid', 35, 70.5)`)

--- a/server/datastore/mysql/migrations/tables/20221115104546_AddCronStatsTable_test.go
+++ b/server/datastore/mysql/migrations/tables/20221115104546_AddCronStatsTable_test.go
@@ -7,9 +7,6 @@ import (
 )
 
 func TestUp_20221115104546(t *testing.T) {
-	// skipping old migration tests as migrations don't change and we're getting
-	// timeouts in CI
-	t.Skip("old migration test, not longer required to run")
 	db := applyUpToPrev(t)
 
 	applyNext(t, db)

--- a/server/datastore/mysql/migrations/tables/20221205112142_AddErrorToCarveMetadata_test.go
+++ b/server/datastore/mysql/migrations/tables/20221205112142_AddErrorToCarveMetadata_test.go
@@ -8,15 +8,12 @@ import (
 )
 
 func TestUp_20221205112142(t *testing.T) {
-	// skipping old migration tests as migrations don't change and we're getting
-	// timeouts in CI
-	t.Skip("old migration test, not longer required to run")
 	db := applyUpToPrev(t)
 	query := `
 INSERT INTO carve_metadata
   (host_id, block_count, block_size, carve_size, carve_id, request_id, session_id)
 VALUES
-  (1, 10, 1000, 10000, "carve_id", "request_id", ?) 
+  (1, 10, 1000, 10000, "carve_id", "request_id", ?)
 `
 
 	execNoErr(t, db, "INSERT INTO hosts (hostname, osquery_host_id) VALUES ('foo.example.com', 'foo')")
@@ -33,7 +30,7 @@ VALUES
 INSERT INTO carve_metadata
   (host_id, block_count, block_size, carve_size, carve_id, request_id, session_id, error)
 VALUES
-  (1, 10, 1000, 10000, "carve_id", "request_id", 4, "made_up_error") 
+  (1, 10, 1000, 10000, "carve_id", "request_id", 4, "made_up_error")
 `)
 	// Update an existing row to add an error
 	execNoErr(t, db, `UPDATE carve_metadata SET error = "updated_error" WHERE session_id = 3`)

--- a/server/datastore/mysql/migrations/tables/20221220195934_SetSCEPSerialsAutoIncrement_test.go
+++ b/server/datastore/mysql/migrations/tables/20221220195934_SetSCEPSerialsAutoIncrement_test.go
@@ -7,9 +7,6 @@ import (
 )
 
 func TestUp_20221220195934(t *testing.T) {
-	// skipping old migration tests as migrations don't change and we're getting
-	// timeouts in CI
-	t.Skip("old migration test, not longer required to run")
 	db := applyUpToPrev(t)
 	var count int
 	err := db.Get(&count, "SELECT COUNT(*) FROM scep_serials")

--- a/server/datastore/mysql/migrations/tables/20221223174807_AlterHostsTablePendingMDMEnrollments_test.go
+++ b/server/datastore/mysql/migrations/tables/20221223174807_AlterHostsTablePendingMDMEnrollments_test.go
@@ -9,9 +9,6 @@ import (
 )
 
 func TestUp_20221223174807(t *testing.T) {
-	// skipping old migration tests as migrations don't change and we're getting
-	// timeouts in CI
-	t.Skip("old migration test, not longer required to run")
 	db := applyUpToPrev(t)
 
 	someString := func() string {

--- a/server/datastore/mysql/migrations/tables/20221227163855_CleanupEmptyMobileDeviceManagementSolutions_test.go
+++ b/server/datastore/mysql/migrations/tables/20221227163855_CleanupEmptyMobileDeviceManagementSolutions_test.go
@@ -8,9 +8,6 @@ import (
 )
 
 func TestUp_20221227163855(t *testing.T) {
-	// skipping old migration tests as migrations don't change and we're getting
-	// timeouts in CI
-	t.Skip("old migration test, not longer required to run")
 	db := applyUpToPrev(t)
 
 	execNoErr(t, db, `

--- a/server/datastore/mysql/migrations/tables/20230202224725_CreateHostDiskEncryptionKeysTable_test.go
+++ b/server/datastore/mysql/migrations/tables/20230202224725_CreateHostDiskEncryptionKeysTable_test.go
@@ -7,9 +7,6 @@ import (
 )
 
 func TestUp_20230202224725(t *testing.T) {
-	// skipping old migration tests as migrations don't change and we're getting
-	// timeouts in CI
-	t.Skip("old migration test, not longer required to run")
 	db := applyUpToPrev(t)
 
 	applyNext(t, db)

--- a/server/datastore/mysql/migrations/tables/20230206163608_AddTableMDMAppleConfigProfiles_test.go
+++ b/server/datastore/mysql/migrations/tables/20230206163608_AddTableMDMAppleConfigProfiles_test.go
@@ -7,9 +7,6 @@ import (
 )
 
 func TestUp_20230206163608(t *testing.T) {
-	// skipping old migration tests as migrations don't change and we're getting
-	// timeouts in CI
-	t.Skip("old migration test, not longer required to run")
 	db := applyUpToPrev(t)
 
 	applyNext(t, db)

--- a/server/datastore/mysql/migrations/tables/20230214131519_AddHostMDMAppleProfilesTable_test.go
+++ b/server/datastore/mysql/migrations/tables/20230214131519_AddHostMDMAppleProfilesTable_test.go
@@ -7,9 +7,6 @@ import (
 )
 
 func TestUp_20230214131519(t *testing.T) {
-	// skipping old migration tests as migrations don't change and we're getting
-	// timeouts in CI
-	t.Skip("old migration test, not longer required to run")
 	db := applyUpToPrev(t)
 	applyNext(t, db)
 

--- a/server/datastore/mysql/migrations/tables/20230303135738_AddMDMIdPAccountsTable_test.go
+++ b/server/datastore/mysql/migrations/tables/20230303135738_AddMDMIdPAccountsTable_test.go
@@ -8,9 +8,6 @@ import (
 )
 
 func TestUp_20230303135738(t *testing.T) {
-	// skipping old migration tests as migrations don't change and we're getting
-	// timeouts in CI
-	t.Skip("old migration test, not longer required to run")
 	db := applyUpToPrev(t)
 	applyNext(t, db)
 

--- a/server/datastore/mysql/migrations/tables/20230313135301_AddProfileNameColumnToHostMDMAppleProfilesTable_test.go
+++ b/server/datastore/mysql/migrations/tables/20230313135301_AddProfileNameColumnToHostMDMAppleProfilesTable_test.go
@@ -9,9 +9,6 @@ import (
 )
 
 func TestUp_20230313135301(t *testing.T) {
-	// skipping old migration tests as migrations don't change and we're getting
-	// timeouts in CI
-	t.Skip("old migration test, not longer required to run")
 	db := applyUpToPrev(t)
 
 	stmt := `
@@ -49,16 +46,16 @@ VALUES
 
 	var rows []fleet.HostMDMAppleProfile
 	err = db.SelectContext(context.Background(), &rows, `
-SELECT 
-	profile_id, 
-	profile_identifier AS identifier, 
-	host_uuid, 
-	command_uuid, 
-	status, 
-	operation_type, 
-	detail, 
-	profile_name AS name 
-FROM 
+SELECT
+	profile_id,
+	profile_identifier AS identifier,
+	host_uuid,
+	command_uuid,
+	status,
+	operation_type,
+	detail,
+	profile_name AS name
+FROM
 	host_mdm_apple_profiles`)
 
 	require.NoError(t, err)

--- a/server/datastore/mysql/migrations/tables/20230313141819_AlterAggregatedStats_test.go
+++ b/server/datastore/mysql/migrations/tables/20230313141819_AlterAggregatedStats_test.go
@@ -8,9 +8,6 @@ import (
 )
 
 func TestUp_20230313141819(t *testing.T) {
-	// skipping old migration tests as migrations don't change and we're getting
-	// timeouts in CI
-	t.Skip("old migration test, not longer required to run")
 	db := applyUpToPrev(t)
 
 	oldInsertStmt := `

--- a/server/datastore/mysql/migrations/tables/20230315104937_EnsureUniformCollation_test.go
+++ b/server/datastore/mysql/migrations/tables/20230315104937_EnsureUniformCollation_test.go
@@ -9,9 +9,6 @@ import (
 )
 
 func TestUp_20230315104937(t *testing.T) {
-	// skipping old migration tests as migrations don't change and we're getting
-	// timeouts in CI
-	t.Skip("old migration test, not longer required to run")
 	db := applyUpToPrev(t)
 	_, err := db.Exec("SET FOREIGN_KEY_CHECKS = 0")
 	require.NoError(t, err)

--- a/server/datastore/mysql/migrations/tables/20230317173844_CleanupHostMDMAppleProfiles_test.go
+++ b/server/datastore/mysql/migrations/tables/20230317173844_CleanupHostMDMAppleProfiles_test.go
@@ -9,9 +9,6 @@ import (
 )
 
 func TestUp_20230317173844(t *testing.T) {
-	// skipping old migration tests as migrations don't change and we're getting
-	// timeouts in CI
-	t.Skip("old migration test, not longer required to run")
 	db := applyUpToPrev(t)
 
 	insertStmt := `
@@ -26,16 +23,16 @@ VALUES
 	execNoErr(t, db, insertStmt, 1, "JKL", "failed", "remove", "MDMClientError (96): Cannot replace profile 'p2' because it was not installed by the MDM server.")
 
 	selectStmt := `
-SELECT 
-	profile_id, 
-	profile_identifier AS identifier, 
-	host_uuid, 
-	command_uuid, 
-	status, 
-	operation_type, 
-	detail, 
-	profile_name AS name 
-FROM 
+SELECT
+	profile_id,
+	profile_identifier AS identifier,
+	host_uuid,
+	command_uuid,
+	status,
+	operation_type,
+	detail,
+	profile_name AS name
+FROM
 	host_mdm_apple_profiles`
 
 	var rows []fleet.HostMDMAppleProfile

--- a/server/datastore/mysql/migrations/tables/20230320133602_AddResetRequestedToHostDiskEncryptionKeys_test.go
+++ b/server/datastore/mysql/migrations/tables/20230320133602_AddResetRequestedToHostDiskEncryptionKeys_test.go
@@ -7,9 +7,6 @@ import (
 )
 
 func TestUp_20230320133602(t *testing.T) {
-	// skipping old migration tests as migrations don't change and we're getting
-	// timeouts in CI
-	t.Skip("old migration test, not longer required to run")
 	db := applyUpToPrev(t)
 	_, err := db.Exec(`INSERT INTO host_disk_encryption_keys (host_id, base64_encrypted, decryptable) VALUES (1, 'asdf', 0)
 `)

--- a/server/datastore/mysql/migrations/tables/20230330100011_CleanupHostDiskEncryptionKeysTable_test.go
+++ b/server/datastore/mysql/migrations/tables/20230330100011_CleanupHostDiskEncryptionKeysTable_test.go
@@ -9,9 +9,6 @@ import (
 )
 
 func TestUp_20230330100011(t *testing.T) {
-	// skipping old migration tests as migrations don't change and we're getting
-	// timeouts in CI
-	t.Skip("old migration test, not longer required to run")
 	db := applyUpToPrev(t)
 
 	//

--- a/server/datastore/mysql/migrations/tables/20230330134823_AddSoftwareCPEUniqueConstraint_test.go
+++ b/server/datastore/mysql/migrations/tables/20230330134823_AddSoftwareCPEUniqueConstraint_test.go
@@ -7,9 +7,6 @@ import (
 )
 
 func TestUp_20230330134823(t *testing.T) {
-	// skipping old migration tests as migrations don't change and we're getting
-	// timeouts in CI
-	t.Skip("old migration test, not longer required to run")
 	db := applyUpToPrev(t)
 
 	_, err := db.Exec(`INSERT INTO software (id, name, version, source, bundle_identifier, vendor, arch)

--- a/server/datastore/mysql/migrations/tables/20230405232025_AddBootstrapPackagesTable_test.go
+++ b/server/datastore/mysql/migrations/tables/20230405232025_AddBootstrapPackagesTable_test.go
@@ -8,9 +8,6 @@ import (
 )
 
 func TestUp_20230405232025(t *testing.T) {
-	// skipping old migration tests as migrations don't change and we're getting
-	// timeouts in CI
-	t.Skip("old migration test, not longer required to run")
 	db := applyUpToPrev(t)
 	applyNext(t, db)
 

--- a/server/datastore/mysql/migrations/tables/20230408084104_AddChecksumToProfiles_test.go
+++ b/server/datastore/mysql/migrations/tables/20230408084104_AddChecksumToProfiles_test.go
@@ -9,9 +9,6 @@ import (
 )
 
 func TestUp_20230408084104(t *testing.T) {
-	// skipping old migration tests as migrations don't change and we're getting
-	// timeouts in CI
-	t.Skip("old migration test, not longer required to run")
 	db := applyUpToPrev(t)
 	stmt := `
 INSERT INTO

--- a/server/datastore/mysql/migrations/tables/20230411102858_CreateHostBootstrapPackagesTable_test.go
+++ b/server/datastore/mysql/migrations/tables/20230411102858_CreateHostBootstrapPackagesTable_test.go
@@ -7,9 +7,6 @@ import (
 )
 
 func TestUp_20230411102858(t *testing.T) {
-	// skipping old migration tests as migrations don't change and we're getting
-	// timeouts in CI
-	t.Skip("old migration test, not longer required to run")
 	db := applyUpToPrev(t)
 	applyNext(t, db)
 

--- a/server/datastore/mysql/migrations/tables/20230421155932_UpdateMdmAppleDeliveryStatusTable_test.go
+++ b/server/datastore/mysql/migrations/tables/20230421155932_UpdateMdmAppleDeliveryStatusTable_test.go
@@ -7,9 +7,6 @@ import (
 )
 
 func TestUp_20230421155932(t *testing.T) {
-	// skipping old migration tests as migrations don't change and we're getting
-	// timeouts in CI
-	t.Skip("old migration test, not longer required to run")
 	db := applyUpToPrev(t)
 
 	var statuses []string

--- a/server/datastore/mysql/migrations/tables/20230425082126_AddMDMAppleSetupAssistants_test.go
+++ b/server/datastore/mysql/migrations/tables/20230425082126_AddMDMAppleSetupAssistants_test.go
@@ -9,9 +9,6 @@ import (
 )
 
 func TestUp_20230425082126(t *testing.T) {
-	// skipping old migration tests as migrations don't change and we're getting
-	// timeouts in CI
-	t.Skip("old migration test, not longer required to run")
 	db := applyUpToPrev(t)
 
 	// Apply current migration.

--- a/server/datastore/mysql/migrations/tables/20230425105727_AddEulasTable_test.go
+++ b/server/datastore/mysql/migrations/tables/20230425105727_AddEulasTable_test.go
@@ -7,9 +7,6 @@ import (
 )
 
 func TestUp_20230425105727(t *testing.T) {
-	// skipping old migration tests as migrations don't change and we're getting
-	// timeouts in CI
-	t.Skip("old migration test, not longer required to run")
 	db := applyUpToPrev(t)
 	applyNext(t, db)
 

--- a/server/datastore/mysql/migrations/tables/20230501154913_AlterMDMAppleSetupAssistantsAddProfileUUID_test.go
+++ b/server/datastore/mysql/migrations/tables/20230501154913_AlterMDMAppleSetupAssistantsAddProfileUUID_test.go
@@ -7,9 +7,6 @@ import (
 )
 
 func TestUp_20230501154913(t *testing.T) {
-	// skipping old migration tests as migrations don't change and we're getting
-	// timeouts in CI
-	t.Skip("old migration test, not longer required to run")
 	db := applyUpToPrev(t)
 
 	r, err := db.Exec(`INSERT INTO mdm_apple_setup_assistants (name, profile) VALUES (?, ?)`, "Test", "{}")

--- a/server/datastore/mysql/migrations/tables/20230503101418_AlterJobsAddNotBefore_test.go
+++ b/server/datastore/mysql/migrations/tables/20230503101418_AlterJobsAddNotBefore_test.go
@@ -8,9 +8,6 @@ import (
 )
 
 func TestUp_20230503101418(t *testing.T) {
-	// skipping old migration tests as migrations don't change and we're getting
-	// timeouts in CI
-	t.Skip("old migration test, not longer required to run")
 	db := applyUpToPrev(t)
 
 	r, err := db.Exec(`INSERT INTO jobs (name, args, state) VALUES (?, ?, ?)`, "Test", "{}", "queued")

--- a/server/datastore/mysql/migrations/tables/20230515144206_AddMDMAppleDefaultSetupAssistants_test.go
+++ b/server/datastore/mysql/migrations/tables/20230515144206_AddMDMAppleDefaultSetupAssistants_test.go
@@ -7,9 +7,6 @@ import (
 )
 
 func TestUp_20230515144206(t *testing.T) {
-	// skipping old migration tests as migrations don't change and we're getting
-	// timeouts in CI
-	t.Skip("old migration test, not longer required to run")
 	db := applyUpToPrev(t)
 
 	// Apply current migration.

--- a/server/datastore/mysql/migrations/tables/20230517152807_AddRefetchCriticalQueriesUntilToHosts_test.go
+++ b/server/datastore/mysql/migrations/tables/20230517152807_AddRefetchCriticalQueriesUntilToHosts_test.go
@@ -9,9 +9,6 @@ import (
 )
 
 func TestUp_20230517152807(t *testing.T) {
-	// skipping old migration tests as migrations don't change and we're getting
-	// timeouts in CI
-	t.Skip("old migration test, not longer required to run")
 	db := applyUpToPrev(t)
 
 	someString := func() string {

--- a/server/datastore/mysql/migrations/tables/20230518114155_AddFullnameToMDMIdPAccountsTable_test.go
+++ b/server/datastore/mysql/migrations/tables/20230518114155_AddFullnameToMDMIdPAccountsTable_test.go
@@ -8,9 +8,6 @@ import (
 )
 
 func TestUp_20230518114155(t *testing.T) {
-	// skipping old migration tests as migrations don't change and we're getting
-	// timeouts in CI
-	t.Skip("old migration test, not longer required to run")
 	db := applyUpToPrev(t)
 
 	insertStmt := `

--- a/server/datastore/mysql/migrations/tables/20230520153236_AddHostDepAssignmentsTable_test.go
+++ b/server/datastore/mysql/migrations/tables/20230520153236_AddHostDepAssignmentsTable_test.go
@@ -8,9 +8,6 @@ import (
 )
 
 func TestUp_20230520153236(t *testing.T) {
-	// skipping old migration tests as migrations don't change and we're getting
-	// timeouts in CI
-	t.Skip("old migration test, not longer required to run")
 	db := applyUpToPrev(t)
 	applyNext(t, db)
 

--- a/server/datastore/mysql/migrations/tables/20230530122103_InsertVerifiedMdmAppleDeliveryStatusTable_test.go
+++ b/server/datastore/mysql/migrations/tables/20230530122103_InsertVerifiedMdmAppleDeliveryStatusTable_test.go
@@ -7,9 +7,6 @@ import (
 )
 
 func TestUp_20230530122103(t *testing.T) {
-	// skipping old migration tests as migrations don't change and we're getting
-	// timeouts in CI
-	t.Skip("old migration test, not longer required to run")
 	db := applyUpToPrev(t)
 
 	var statuses []string

--- a/server/datastore/mysql/migrations/tables/20230602111827_RemoveQueryParamsFromMDMServerURL_test.go
+++ b/server/datastore/mysql/migrations/tables/20230602111827_RemoveQueryParamsFromMDMServerURL_test.go
@@ -7,9 +7,6 @@ import (
 )
 
 func TestUp_20230602111827(t *testing.T) {
-	// skipping old migration tests as migrations don't change and we're getting
-	// timeouts in CI
-	t.Skip("old migration test, not longer required to run")
 	db := applyUpToPrev(t)
 	insertMDMSolutionStmt := `INSERT INTO mobile_device_management_solutions (id, name, server_url) VALUES (?, ?, ?)`
 	_, err := db.Exec(insertMDMSolutionStmt, 1, "foo", "https://test.example.com?test=1")

--- a/server/datastore/mysql/migrations/tables/20230608103123_CleanupOrphanedMDMAppleConfigurationProfiles_test.go
+++ b/server/datastore/mysql/migrations/tables/20230608103123_CleanupOrphanedMDMAppleConfigurationProfiles_test.go
@@ -7,9 +7,6 @@ import (
 )
 
 func TestUp_20230608103123(t *testing.T) {
-	// skipping old migration tests as migrations don't change and we're getting
-	// timeouts in CI
-	t.Skip("old migration test, not longer required to run")
 	db := applyUpToPrev(t)
 
 	insertProfStmt := "INSERT INTO mdm_apple_configuration_profiles (team_id, identifier, name, mobileconfig, checksum) VALUES (?, ?, ?, ?, 'made up')"

--- a/server/datastore/mysql/migrations/tables/20230629140530_AddMDMWindowsEnrollmentsTable_test.go
+++ b/server/datastore/mysql/migrations/tables/20230629140530_AddMDMWindowsEnrollmentsTable_test.go
@@ -9,9 +9,6 @@ import (
 )
 
 func TestUp_20230629140530(t *testing.T) {
-	// skipping old migration tests as migrations don't change and we're getting
-	// timeouts in CI
-	t.Skip("old migration test, not longer required to run")
 	db := applyUpToPrev(t)
 	applyNext(t, db)
 

--- a/server/datastore/mysql/migrations/tables/20230711144622_SetFileVaultMaxBypassAttempts_test.go
+++ b/server/datastore/mysql/migrations/tables/20230711144622_SetFileVaultMaxBypassAttempts_test.go
@@ -8,9 +8,6 @@ import (
 )
 
 func TestUp_20230711144622(t *testing.T) {
-	// skipping old migration tests as migrations don't change and we're getting
-	// timeouts in CI
-	t.Skip("old migration test, not longer required to run")
 	db := applyUpToPrev(t)
 
 	stmt := `

--- a/server/datastore/mysql/migrations/tables/20230721161508_QueriesDataMigrator_test.go
+++ b/server/datastore/mysql/migrations/tables/20230721161508_QueriesDataMigrator_test.go
@@ -7,34 +7,31 @@ import (
 )
 
 func TestUp_20230721161508(t *testing.T) {
-	// skipping old migration tests as migrations don't change and we're getting
-	// timeouts in CI
-	t.Skip("old migration test, not longer required to run")
 	db := applyUpToPrev(t)
 
 	dataStmts := `
-		INSERT INTO users VALUES 
+		INSERT INTO users VALUES
 			(1,'2023-07-21 20:32:32','2023-07-21 20:32:32',_binary '$2a$12$n6hwsD7OU2bAXX94551DQOBcNNhfsEPS3Y6JEuLDjsLNvry3lgJjy','0fF81xRQIriYzm5fdXouk3V3tRwsZJhV','admin','admin@email.com',0,'','',0,'admin',0),
 			(2,'2023-07-21 20:33:13','2023-07-21 20:35:26',_binary '$2a$12$YxPPOd5TOmYhDlH5CfGIfuxBe4GJ78gbwvtxoBHTTw.symxpVcEZS','JPDLcBcv4j1QwIU+rHoRWBt3HVJC8hnf','User 1','user1@email.com',0,'','',0,NULL,0),
 			(3,'2023-07-21 20:33:31','2023-07-21 20:36:42',_binary '$2a$12$u3kuHl44jMojsols1NayLu0pPBwZvnWH6j6ZuDk6HsN4r0jgg7BRu','MoWlTEHH9zR7blcJ0l7/1c4EMnkh/dxq','User2','user2@email.com',0,'','',0,NULL,0);
 
-		INSERT INTO teams VALUES 
+		INSERT INTO teams VALUES
 			(1,'2023-07-21 20:32:42','Team 1','','{\"mdm\": {\"macos_setup\": {\"bootstrap_package\": null, \"macos_setup_assistant\": null, \"enable_end_user_authentication\": false}, \"macos_updates\": {\"deadline\": null, \"minimum_version\": null}, \"macos_settings\": {\"custom_settings\": null, \"enable_disk_encryption\": false}}, \"features\": {\"enable_host_users\": true, \"enable_software_inventory\": true}, \"integrations\": {\"jira\": null, \"zendesk\": null}, \"agent_options\": {\"config\": {\"options\": {\"pack_delimiter\": \"/\", \"logger_tls_period\": 10, \"distributed_plugin\": \"tls\", \"disable_distributed\": false, \"logger_tls_endpoint\": \"/api/osquery/log\", \"distributed_interval\": 10, \"distributed_tls_max_attempts\": 3}, \"decorators\": {\"load\": [\"SELECT uuid AS host_uuid FROM system_info;\", \"SELECT hostname AS hostname FROM system_info;\"]}}, \"overrides\": {}}, \"webhook_settings\": {\"failing_policies_webhook\": {\"policy_ids\": null, \"destination_url\": \"\", \"host_batch_size\": 0, \"enable_failing_policies_webhook\": false}}}'),
 			(2,'2023-07-21 20:32:47','Team 2','','{\"mdm\": {\"macos_setup\": {\"bootstrap_package\": null, \"macos_setup_assistant\": null, \"enable_end_user_authentication\": false}, \"macos_updates\": {\"deadline\": null, \"minimum_version\": null}, \"macos_settings\": {\"custom_settings\": null, \"enable_disk_encryption\": false}}, \"features\": {\"enable_host_users\": true, \"enable_software_inventory\": true}, \"integrations\": {\"jira\": null, \"zendesk\": null}, \"agent_options\": {\"config\": {\"options\": {\"pack_delimiter\": \"/\", \"logger_tls_period\": 10, \"distributed_plugin\": \"tls\", \"disable_distributed\": false, \"logger_tls_endpoint\": \"/api/osquery/log\", \"distributed_interval\": 10, \"distributed_tls_max_attempts\": 3}, \"decorators\": {\"load\": [\"SELECT uuid AS host_uuid FROM system_info;\", \"SELECT hostname AS hostname FROM system_info;\"]}}, \"overrides\": {}}, \"webhook_settings\": {\"failing_policies_webhook\": {\"policy_ids\": null, \"destination_url\": \"\", \"host_batch_size\": 0, \"enable_failing_policies_webhook\": false}}}');
 
-		INSERT INTO user_teams (user_id, team_id, role) VALUES 
+		INSERT INTO user_teams (user_id, team_id, role) VALUES
 			(2,1,'admin'),
 			(2,2,'admin'),
 			(3,2,'admin'),
 			(3,1,'observer');
 
-		INSERT INTO packs (id, created_at, updated_at, disabled, name, description, platform, pack_type) VALUES 
+		INSERT INTO packs (id, created_at, updated_at, disabled, name, description, platform, pack_type) VALUES
 			(1,'2023-07-21 20:33:49','2023-07-21 20:33:49',0,'Global','Global pack','','global'),
 			(2,'2023-07-21 20:34:34','2023-07-21 20:34:34',0,'performance-metrics','','',NULL),
 			(3,'2023-07-21 20:36:03','2023-07-21 20:36:03',0,'Team: Team 1','Schedule additional queries for all hosts assigned to this team.','','team-1'),
 			(4,'2023-07-21 20:36:45','2023-07-21 20:36:45',0,'Team: Team 2','Schedule additional queries for all hosts assigned to this team.','','team-2');
- 
-		INSERT INTO queries (id, created_at, updated_at, saved, name, description, query, author_id, observer_can_run, team_id, team_id_char, platform, min_osquery_version, schedule_interval, automations_enabled, logging_type) VALUES 
+
+		INSERT INTO queries (id, created_at, updated_at, saved, name, description, query, author_id, observer_can_run, team_id, team_id_char, platform, min_osquery_version, schedule_interval, automations_enabled, logging_type) VALUES
 			(1,'2023-07-21 20:33:47','2023-07-21 20:33:47',1,'Admin Global Query','Admin desc','SELECT * FROM osquery_info;',1,1,NULL,'','','',0,0,''),
 			(2,'2023-07-21 20:34:34','2023-07-21 20:34:34',1,'per_query_perf','Records the CPU time and memory usage for each individual query. Helpful for identifying queries that may impact performance.','SELECT name, interval, executions, output_size, wall_time, (user_time/executions) AS avg_user_time, (system_time/executions) AS avg_system_time, average_memory FROM osquery_schedule;',1,0,NULL,'','','',0,0,''),
 			(3,'2023-07-21 20:34:34','2023-07-21 20:34:34',1,'runtime_perf','Track the amount of CPU time used by osquery.','SELECT ov.version AS os_version, ov.platform AS os_platform, ov.codename AS os_codename, i.*, p.resident_size, p.user_time, p.system_time, time.minutes AS counter, db.db_size_mb AS database_size FROM osquery_info i, os_version ov, processes p, time, (SELECT (sum(size) / 1024) / 1024.0 AS db_size_mb FROM (SELECT value FROM osquery_flags WHERE name = \'database_path\' LIMIT 1) flags, file WHERE path LIKE flags.value || \'%%\' AND type = \'regular\') db WHERE p.pid = i.pid;',1,0,NULL,'','','',0,0,''),
@@ -45,7 +42,7 @@ func TestUp_20230721161508(t *testing.T) {
 			(8,'2023-07-21 20:37:01','2023-07-21 20:37:01',1,'User 2 Query','Some desc','SELECT * FROM osquery_info;',3,1,NULL,'','','',0,0,''),
 			(9,'2023-07-21 20:37:01','2023-07-21 20:37:01',1,'User 2 Query 2','Some desc','SELECT * FROM osquery_info;',3,1,NULL,'','','',0,0,'');
 
-		INSERT INTO scheduled_queries VALUES 
+		INSERT INTO scheduled_queries VALUES
 			-- Global pack
 			(1,'2023-07-21 20:33:54','2023-07-21 20:33:54',1,1,86400,1,0,'','',NULL,'Admin Global Query','Admin Global Query','',NULL,''),
 			(2,'2023-07-21 20:34:00','2023-07-21 20:34:00',1,1,3600,1,0,'','',NULL,'Admin Global Query','Admin Global Query-1','',NULL,''),
@@ -125,18 +122,18 @@ func TestUp_20230721161508(t *testing.T) {
 	// 'per_query_perf' <- Original (kept because is referenced by an 2017 pack)
 	// 'per_query_perf - 7 - $timestamp' <- For schedule with id 7
 	// 'per_query_perf - 8 - $timestamp' <- For schedule with id 8
-	stmt = `SELECT 
-				name, 
-				description, 
-				query, 
-				author_id, 
-				saved, 
-				observer_can_run, 
+	stmt = `SELECT
+				name,
+				description,
+				query,
+				author_id,
+				saved,
+				observer_can_run,
 				platform,
 				min_osquery_version,
 				schedule_interval,
 				logging_type,
-				automations_enabled 
+				automations_enabled
 			FROM queries WHERE name LIKE ? AND team_id IS NULL
 	`
 
@@ -240,19 +237,19 @@ func TestUp_20230721161508(t *testing.T) {
 	//   - 'per_query_perf - 11 - $timestamp' for schedule#11
 	// For Team-2, we only have one schedule on 'backup_tool_perf', so I expect to see on team#2:
 	// 	 - 'backup_tool_perf - 12 - $timestamp'
-	stmt = `SELECT 
-		name, 
-		description, 
-		query, 
-		author_id, 
-		saved, 
-		observer_can_run, 
-		platform, 
-		min_osquery_version, 
-		schedule_interval, 
-		logging_type, 
-		automations_enabled 
-	FROM queries 
+	stmt = `SELECT
+		name,
+		description,
+		query,
+		author_id,
+		saved,
+		observer_can_run,
+		platform,
+		min_osquery_version,
+		schedule_interval,
+		logging_type,
+		automations_enabled
+	FROM queries
 	WHERE name LIKE ? AND team_id = ? AND name <> 'User 1 Query 2'`
 
 	rows, err = db.Query(stmt, "per_query_perf%", 1)

--- a/server/datastore/mysql/migrations/tables/20230814150442_AddHostScriptResultsTable_test.go
+++ b/server/datastore/mysql/migrations/tables/20230814150442_AddHostScriptResultsTable_test.go
@@ -10,9 +10,6 @@ import (
 )
 
 func TestUp_20230814150442(t *testing.T) {
-	// skipping old migration tests as migrations don't change and we're getting
-	// timeouts in CI
-	t.Skip("old migration test, not longer required to run")
 	db := applyUpToPrev(t)
 
 	// Apply current migration.

--- a/server/datastore/mysql/migrations/tables/20230823122728_AddEmailToIdPAccountsTable_test.go
+++ b/server/datastore/mysql/migrations/tables/20230823122728_AddEmailToIdPAccountsTable_test.go
@@ -8,9 +8,6 @@ import (
 )
 
 func TestUp_20230823122728(t *testing.T) {
-	// skipping old migration tests as migrations don't change and we're getting
-	// timeouts in CI
-	t.Skip("old migration test, not longer required to run")
 	db := applyUpToPrev(t)
 	insertStmt := `
           INSERT INTO  mdm_idp_accounts

--- a/server/datastore/mysql/migrations/tables/20230906152143_AddScriptsTable_test.go
+++ b/server/datastore/mysql/migrations/tables/20230906152143_AddScriptsTable_test.go
@@ -9,9 +9,6 @@ import (
 )
 
 func TestUp_20230906152143(t *testing.T) {
-	// skipping old migration tests as migrations don't change and we're getting
-	// timeouts in CI
-	t.Skip("old migration test, not longer required to run")
 	db := applyUpToPrev(t)
 
 	const (

--- a/server/datastore/mysql/migrations/tables/20230911163618_AddRetriesColumnHostMdmAppleProfilesTable_test.go
+++ b/server/datastore/mysql/migrations/tables/20230911163618_AddRetriesColumnHostMdmAppleProfilesTable_test.go
@@ -9,20 +9,17 @@ import (
 )
 
 func TestUp_20230911163618(t *testing.T) {
-	// skipping old migration tests as migrations don't change and we're getting
-	// timeouts in CI
-	t.Skip("old migration test, not longer required to run")
 	db := applyUpToPrev(t)
 	insertStmt := `
 INSERT INTO  host_mdm_apple_profiles (
-	profile_id, 
-	profile_identifier, 
-	host_uuid, 
-	status, 
-	operation_type, 
-	detail, 
-	command_uuid, 
-	profile_name, 
+	profile_id,
+	profile_identifier,
+	host_uuid,
+	status,
+	operation_type,
+	detail,
+	command_uuid,
+	profile_name,
 	checksum)
 VALUES
 	(?, ?, ?, ?, ?, ?, ?, ?, ?)`
@@ -71,14 +68,14 @@ VALUES
 
 	insertStmt = `
 INSERT INTO  host_mdm_apple_profiles (
-	profile_id, 
-	profile_identifier, 
-	host_uuid, 
-	status, 
-	operation_type, 
-	detail, 
-	command_uuid, 
-	profile_name, 
+	profile_id,
+	profile_identifier,
+	host_uuid,
+	status,
+	operation_type,
+	detail,
+	command_uuid,
+	profile_name,
 	checksum,
 	retries)
 VALUES

--- a/server/datastore/mysql/migrations/tables/20230912101759_AddDescToCveMetaTable_test.go
+++ b/server/datastore/mysql/migrations/tables/20230912101759_AddDescToCveMetaTable_test.go
@@ -7,9 +7,6 @@ import (
 )
 
 func TestUp_20230912101759(t *testing.T) {
-	// skipping old migration tests as migrations don't change and we're getting
-	// timeouts in CI
-	t.Skip("old migration test, not longer required to run")
 	db := applyUpToPrev(t)
 	insertStmt := `
           INSERT INTO cve_meta

--- a/server/datastore/mysql/migrations/tables/20230915101341_AddColumnClientErrorToHostDiskEncryptionKeys_test.go
+++ b/server/datastore/mysql/migrations/tables/20230915101341_AddColumnClientErrorToHostDiskEncryptionKeys_test.go
@@ -8,9 +8,6 @@ import (
 )
 
 func TestUp_20230915101341(t *testing.T) {
-	// skipping old migration tests as migrations don't change and we're getting
-	// timeouts in CI
-	t.Skip("old migration test, not longer required to run")
 	db := applyUpToPrev(t)
 	insertStmt := `
           INSERT INTO host_disk_encryption_keys

--- a/server/datastore/mysql/migrations/tables/20230918132351_AddResolvedInVersionToSoftwareCVE_test.go
+++ b/server/datastore/mysql/migrations/tables/20230918132351_AddResolvedInVersionToSoftwareCVE_test.go
@@ -8,15 +8,12 @@ import (
 )
 
 func TestUp_20230918132351(t *testing.T) {
-	// skipping old migration tests as migrations don't change and we're getting
-	// timeouts in CI
-	t.Skip("old migration test, not longer required to run")
 	db := applyUpToPrev(t)
 
 	insertStmt := `
 		INSERT INTO software_cve (
-			software_id, 
-			source, 
+			software_id,
+			source,
 			cve
 		)
 		VALUES (?, ?, ?)
@@ -38,8 +35,8 @@ func TestUp_20230918132351(t *testing.T) {
 	// Update the resolved_in_version and verify
 	updateVersion := "6.0.2-76060002.202210150739~1666289067~22.04~fe0ce53" // long string to test the capacity of the new column
 	updateStmt := `
-		UPDATE software_cve 
-		SET resolved_in_version = ? 
+		UPDATE software_cve
+		SET resolved_in_version = ?
 		WHERE software_id = ? AND source = ? AND cve = ?
 		`
 

--- a/server/datastore/mysql/migrations/tables/20231004144339_MoveDiskEncryptionSetting_test.go
+++ b/server/datastore/mysql/migrations/tables/20231004144339_MoveDiskEncryptionSetting_test.go
@@ -9,13 +9,10 @@ import (
 )
 
 func TestUp_20231004144339(t *testing.T) {
-	// skipping old migration tests as migrations don't change and we're getting
-	// timeouts in CI
-	t.Skip("old migration test, not longer required to run")
 	db := applyUpToPrev(t)
 
 	dataStmts := `
-		INSERT INTO teams VALUES 
+		INSERT INTO teams VALUES
 			(1,'2023-07-21 20:32:42','Team 1','','{\"mdm\": {\"macos_setup\": {\"bootstrap_package\": null, \"macos_setup_assistant\": null, \"enable_end_user_authentication\": false}, \"macos_updates\": {\"deadline\": null, \"minimum_version\": null}, \"macos_settings\": {\"custom_settings\": null, \"enable_disk_encryption\": false}}, \"features\": {\"enable_host_users\": true, \"enable_software_inventory\": true}, \"integrations\": {\"jira\": null, \"zendesk\": null}, \"agent_options\": {\"config\": {\"options\": {\"pack_delimiter\": \"/\", \"logger_tls_period\": 10, \"distributed_plugin\": \"tls\", \"disable_distributed\": false, \"logger_tls_endpoint\": \"/api/osquery/log\", \"distributed_interval\": 10, \"distributed_tls_max_attempts\": 3}, \"decorators\": {\"load\": [\"SELECT uuid AS host_uuid FROM system_info;\", \"SELECT hostname AS hostname FROM system_info;\"]}}, \"overrides\": {}}, \"webhook_settings\": {\"failing_policies_webhook\": {\"policy_ids\": null, \"destination_url\": \"\", \"host_batch_size\": 0, \"enable_failing_policies_webhook\": false}}}'),
 			(2,'2023-07-21 20:32:47','Team 2','','{\"mdm\": {\"macos_setup\": {\"bootstrap_package\": null, \"macos_setup_assistant\": null, \"enable_end_user_authentication\": false}, \"macos_updates\": {\"deadline\": null, \"minimum_version\": null}, \"macos_settings\": {\"custom_settings\": null, \"enable_disk_encryption\": true}}, \"features\": {\"enable_host_users\": true, \"enable_software_inventory\": true}, \"integrations\": {\"jira\": null, \"zendesk\": null}, \"agent_options\": {\"config\": {\"options\": {\"pack_delimiter\": \"/\", \"logger_tls_period\": 10, \"distributed_plugin\": \"tls\", \"disable_distributed\": false, \"logger_tls_endpoint\": \"/api/osquery/log\", \"distributed_interval\": 10, \"distributed_tls_max_attempts\": 3}, \"decorators\": {\"load\": [\"SELECT uuid AS host_uuid FROM system_info;\", \"SELECT hostname AS hostname FROM system_info;\"]}}, \"overrides\": {}}, \"webhook_settings\": {\"failing_policies_webhook\": {\"policy_ids\": null, \"destination_url\": \"\", \"host_batch_size\": 0, \"enable_failing_policies_webhook\": false}}}');
 	`

--- a/server/datastore/mysql/migrations/tables/20231009094542_AddIndexesToScriptContents_test.go
+++ b/server/datastore/mysql/migrations/tables/20231009094542_AddIndexesToScriptContents_test.go
@@ -7,9 +7,6 @@ import (
 )
 
 func TestUp_20231009094542(t *testing.T) {
-	// skipping old migration tests as migrations don't change and we're getting
-	// timeouts in CI
-	t.Skip("old migration test, not longer required to run")
 	db := applyUpToPrev(t)
 
 	idxExists := indexExists(db, "scripts", "idx_scripts_team_name")

--- a/server/datastore/mysql/migrations/tables/20231009094543_AddDiscardToQueries_test.go
+++ b/server/datastore/mysql/migrations/tables/20231009094543_AddDiscardToQueries_test.go
@@ -8,9 +8,6 @@ import (
 )
 
 func TestUp_20231009094543(t *testing.T) {
-	// skipping old migration tests as migrations don't change and we're getting
-	// timeouts in CI
-	t.Skip("old migration test, not longer required to run")
 	db := applyUpToPrev(t)
 	applyNext(t, db)
 

--- a/server/datastore/mysql/migrations/tables/20231009094544_CreateTableQueryReports_test.go
+++ b/server/datastore/mysql/migrations/tables/20231009094544_CreateTableQueryReports_test.go
@@ -9,9 +9,6 @@ import (
 )
 
 func TestUp_20231009094544(t *testing.T) {
-	// skipping old migration tests as migrations don't change and we're getting
-	// timeouts in CI
-	t.Skip("old migration test, not longer required to run")
 	db := applyUpToPrev(t)
 
 	// Apply current migration.

--- a/server/datastore/mysql/migrations/tables/20231016091915_FixQueriesWithEmptyLoggingType_test.go
+++ b/server/datastore/mysql/migrations/tables/20231016091915_FixQueriesWithEmptyLoggingType_test.go
@@ -8,9 +8,6 @@ import (
 )
 
 func TestUp_20231016091915(t *testing.T) {
-	// skipping old migration tests as migrations don't change and we're getting
-	// timeouts in CI
-	t.Skip("old migration test, not longer required to run")
 	db := applyUpToPrev(t)
 
 	insertStmt := `INSERT INTO queries (

--- a/server/datastore/mysql/migrations/tables/20231024174135_RemoveQueryResultsForeignKey_test.go
+++ b/server/datastore/mysql/migrations/tables/20231024174135_RemoveQueryResultsForeignKey_test.go
@@ -9,9 +9,6 @@ import (
 )
 
 func TestUp_20231024174135(t *testing.T) {
-	// skipping old migration tests as migrations don't change and we're getting
-	// timeouts in CI
-	t.Skip("old migration test, not longer required to run")
 	db := applyUpToPrev(t)
 
 	//

--- a/server/datastore/mysql/migrations/tables/20231025120016_UniqueEmailInIdpAccounts_test.go
+++ b/server/datastore/mysql/migrations/tables/20231025120016_UniqueEmailInIdpAccounts_test.go
@@ -7,9 +7,6 @@ import (
 )
 
 func TestUp_20231025120016(t *testing.T) {
-	// skipping old migration tests as migrations don't change and we're getting
-	// timeouts in CI
-	t.Skip("old migration test, not longer required to run")
 	db := applyUpToPrev(t)
 
 	type idpAcc struct {


### PR DESCRIPTION
As discussed on Slack: https://fleetdm.slack.com/archives/C019WG4GH0A/p1699392601715529

# Checklist for submitter

- [x] Added/updated tests
