### PR TITLE
update host profile status when we get a Windows MDM response

### DIFF
--- a/server/fleet/microsoft_mdm.go
+++ b/server/fleet/microsoft_mdm.go
@@ -921,13 +921,14 @@ type ProtoCmdOperation struct {
 
 // Protocol Command
 type SyncMLCmd struct {
-	XMLName xml.Name  `xml:",omitempty"`
-	CmdID   string    `xml:"CmdID"`
-	MsgRef  *string   `xml:"MsgRef,omitempty"`
-	CmdRef  *string   `xml:"CmdRef,omitempty"`
-	Cmd     *string   `xml:"Cmd,omitempty"`
-	Data    *string   `xml:"Data,omitempty"`
-	Items   []CmdItem `xml:"Item,omitempty"`
+	XMLName         xml.Name    `xml:",omitempty"`
+	CmdID           string      `xml:"CmdID"`
+	MsgRef          *string     `xml:"MsgRef,omitempty"`
+	CmdRef          *string     `xml:"CmdRef,omitempty"`
+	Cmd             *string     `xml:"Cmd,omitempty"`
+	Data            *string     `xml:"Data,omitempty"`
+	Items           []CmdItem   `xml:"Item,omitempty"`
+	ReplaceCommands []SyncMLCmd `xml:"Replace,omitempty"`
 }
 
 // ParseWindowsMDMCommand parses the raw XML as a single Windows MDM command.
@@ -1376,4 +1377,110 @@ func GetEncodedBinarySecurityToken(typeID WindowsMDMEnrollmentType, payload stri
 	}
 
 	return base64.URLEncoding.EncodeToString(rawBytes), nil
+}
+
+// BuildMDMWindowsProfilePayloadFromMDMResponse builds a
+// MDMWindowsProfilePayload for a command that was used to deliver a
+// configuration profile.
+//
+// Profiles are groups of `<Replace>` commands wrapped in an `<Atomic>`, both
+// the top-level atomic and each replace have different CmdID values and Status
+// responses. For example a profile might look like:
+//
+// <Atomic>
+//
+//	<CmdID>foo</CmdID>
+//	<Replace>
+//	  <CmdID>bar</CmdID>
+//	  ...
+//	</Replace>
+//	<Replace>
+//	  <CmdID>baz</CmdID>
+//	  ...
+//	</Replace>
+//
+// </Atomic>
+//
+// And the response from the MDM server will be something like:
+//
+// <SyncBody>
+// <Status>
+//
+//	<CmdID>foo</CmdID>
+//	<Cmd>Atomic</Cmd>
+//	<Data>200</Data>
+//	...
+//
+// </Status>
+// <Status>
+//
+//	<CmdID>bar</CmdID>
+//	<Cmd>Replace</Cmd>
+//	<Data>200</Data>
+//	...
+//
+// </Status>
+// <Status>
+//
+//	<CmdID>baz</CmdID>
+//	<Cmd>Replace</Cmd>
+//	<Data>200</Data>
+//	...
+//
+// </Status>
+// ...
+// </SyncBody>
+//
+// As currently specified:
+//   - The status of the resulting command should be the status of the
+//     top-level `<Atomic>` operation
+//   - The detail of the resulting command should be an aggregate of all the
+//     status responses of every nested `Replace` operation
+func BuildMDMWindowsProfilePayloadFromMDMResponse(
+	cmd MDMWindowsCommand,
+	statuses map[string]SyncMLCmd,
+	hostUUID string,
+) (*MDMWindowsProfilePayload, error) {
+	status, ok := statuses[cmd.CommandUUID]
+	if !ok {
+		return nil, fmt.Errorf("missing status for root command %s", cmd.CommandUUID)
+	}
+	commandStatus := WindowsResponseToDeliveryStatus(*status.Data)
+	var details []string
+	if status.Data != nil && commandStatus == MDMDeliveryFailed {
+		syncML := new(SyncMLCmd)
+		if err := xml.Unmarshal(cmd.RawCommand, syncML); err != nil {
+			return nil, err
+		}
+		for _, nested := range syncML.ReplaceCommands {
+			if status, ok := statuses[nested.CmdID]; ok && status.Data != nil {
+				details = append(details, fmt.Sprintf("CmdID %s: status %s", nested.CmdID, *status.Data))
+			}
+		}
+	}
+	detail := strings.Join(details, ", ")
+	return &MDMWindowsProfilePayload{
+		HostUUID:      hostUUID,
+		Status:        &commandStatus,
+		OperationType: "",
+		Detail:        detail,
+		CommandUUID:   cmd.CommandUUID,
+	}, nil
+}
+
+// WindowsResponseToDeliveryStatus converts a response string from Windows MDM
+// into an MDMDeliveryStatus.
+//
+// If the response starts with "2" (any 2xx response), it returns
+// MDMDeliveryVerifying, otherwise, it returns MDMDeliveryFailed.
+func WindowsResponseToDeliveryStatus(resp string) MDMDeliveryStatus {
+	if len(resp) == 0 {
+		return MDMDeliveryPending
+	}
+
+	if strings.HasPrefix(resp, "2") {
+		return MDMDeliveryVerifying
+	}
+
+	return MDMDeliveryFailed
 }

--- a/server/fleet/microsoft_mdm_test.go
+++ b/server/fleet/microsoft_mdm_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/xml"
 	"testing"
 
+	microsoft_mdm "github.com/fleetdm/fleet/v4/server/mdm/microsoft"
 	"github.com/fleetdm/fleet/v4/server/ptr"
 	"github.com/stretchr/testify/require"
 )
@@ -61,6 +62,135 @@ func TestParseWindowsMDMCommand(t *testing.T) {
 				require.NotNil(t, got)
 				require.Equal(t, c.wantCmd, *got)
 			}
+		})
+	}
+}
+
+func TestBuildMDMWindowsProfilePayloadFromMDMResponse(t *testing.T) {
+	tests := []struct {
+		name            string
+		cmd             MDMWindowsCommand
+		statuses        map[string]SyncMLCmd
+		hostUUID        string
+		expectedError   string
+		expectedPayload *MDMWindowsProfilePayload
+	}{
+		{
+			name: "missing status for command",
+			cmd: MDMWindowsCommand{
+				CommandUUID: "foo",
+			},
+			statuses:      map[string]SyncMLCmd{},
+			hostUUID:      "host-uuid",
+			expectedError: "missing status for root command",
+		},
+		{
+			name: "bad xml",
+			cmd: MDMWindowsCommand{
+				CommandUUID: "foo",
+				RawCommand:  []byte(`<Atomic><Replace><</Atomic>`),
+			},
+			statuses: map[string]SyncMLCmd{
+				"foo": {CmdID: "foo", Data: ptr.String(microsoft_mdm.CmdStatusAtomicFailed)},
+			},
+			hostUUID:      "host-uuid",
+			expectedError: "XML syntax error",
+		},
+		{
+			name: "all operations succeded",
+			cmd: MDMWindowsCommand{
+				CommandUUID: "foo",
+				RawCommand: []byte(`
+				<Atomic>
+					<CmdID>foo</CmdID>
+					<Replace><CmdID>bar</CmdID><Target><LocURI>./Device/Baz</LocURI></Target></Replace>
+				</Atomic>`),
+			},
+			statuses: map[string]SyncMLCmd{
+				"foo": {CmdID: "foo", Data: ptr.String("200")},
+				"bar": {CmdID: "bar", Data: ptr.String("200")},
+			},
+			hostUUID: "host-uuid",
+			expectedPayload: &MDMWindowsProfilePayload{
+				HostUUID:    "host-uuid",
+				Status:      &MDMDeliveryVerifying,
+				Detail:      "",
+				CommandUUID: "foo",
+			},
+		},
+		{
+			name: "one operation failed",
+			cmd: MDMWindowsCommand{
+				CommandUUID: "foo",
+				RawCommand: []byte(`
+				<Atomic>
+					<CmdID>foo</CmdID>
+					<Replace><CmdID>bar</CmdID><Target><LocURI>./Device/Baz</LocURI></Target></Replace>
+					<Replace><CmdID>baz</CmdID><Target><LocURI>./Bad/Loc</LocURI></Target></Replace>
+				</Atomic>`),
+			},
+			statuses: map[string]SyncMLCmd{
+				"foo": {CmdID: "foo", Data: ptr.String(microsoft_mdm.CmdStatusAtomicFailed)},
+				"bar": {CmdID: "bar", Data: ptr.String(microsoft_mdm.CmdStatusOK)},
+				"baz": {CmdID: "baz", Data: ptr.String(microsoft_mdm.CmdStatusBadRequest)},
+			},
+			hostUUID: "host-uuid",
+			expectedPayload: &MDMWindowsProfilePayload{
+				HostUUID:    "host-uuid",
+				Status:      &MDMDeliveryFailed,
+				Detail:      "CmdID bar: status 200, CmdID baz: status 400",
+				CommandUUID: "foo",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			payload, err := BuildMDMWindowsProfilePayloadFromMDMResponse(tt.cmd, tt.statuses, tt.hostUUID)
+
+			if tt.expectedError != "" {
+				require.Error(t, err)
+				require.ErrorContains(t, err, tt.expectedError)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tt.expectedPayload, payload)
+			}
+		})
+	}
+}
+
+func TestWindowsResponseToDeliveryStatus(t *testing.T) {
+	tests := []struct {
+		name     string
+		resp     string
+		expected MDMDeliveryStatus
+	}{
+		{
+			name:     "response starts with 2",
+			resp:     "202",
+			expected: MDMDeliveryVerifying,
+		},
+		{
+			name:     "bad requests",
+			resp:     "400",
+			expected: MDMDeliveryFailed,
+		},
+		{
+			name:     "errors",
+			resp:     "500",
+			expected: MDMDeliveryFailed,
+		},
+		{
+			name:     "empty response",
+			resp:     "",
+			expected: MDMDeliveryPending,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := WindowsResponseToDeliveryStatus(tt.resp)
+			require.Equal(t, tt.expected, result)
 		})
 	}
 }


### PR DESCRIPTION
related to #14364, this adds logic to update the `status` and `detail` columns of `host_mdm_windows_profiles` when we get a management response.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [x] Added/updated tests
- [x] Manual QA for all new/changed functionality
