### PR TITLE
Website: Update usage statistics webhook inputs and `HistoricalUsageSnapshot` model.

### DIFF
--- a/docs/Using Fleet/Usage-statistics.md
+++ b/docs/Using Fleet/Usage-statistics.md
@@ -24,7 +24,7 @@ Below is the JSON payload that is sent to Fleet Device Management Inc:
   "softwareInventoryEnabled": true,
   "vulnDetectionEnabled": true,
   "systemUsersEnabled": true,
-  "hostStatusWebhookEnabled": true,
+  "hostsStatusWebHookEnabled": true,
   "numWeeklyActiveUsers": 999,
   "numWeeklyPolicyViolationDaysActual": 999,
   "numWeeklyPolicyViolationDaysPossible": 999,

--- a/website/api/controllers/webhooks/receive-usage-analytics.js
+++ b/website/api/controllers/webhooks/receive-usage-analytics.js
@@ -19,7 +19,7 @@ module.exports = {
     softwareInventoryEnabled: { type: 'boolean', defaultsTo: false },
     vulnDetectionEnabled: { type: 'boolean', defaultsTo: false },
     systemUsersEnabled: { type: 'boolean', defaultsTo: false },
-    hostStatusWebhookEnabled: { type: 'boolean', defaultsTo: false },
+    hostsStatusWebHookEnabled: { type: 'boolean', defaultsTo: false },
     numWeeklyActiveUsers: { type: 'number', defaultsTo: 0 },
     numWeeklyPolicyViolationDaysActual: { type: 'number', defaultsTo: 0 },
     numWeeklyPolicyViolationDaysPossible: { type: 'number', defaultsTo: 0 },
@@ -53,7 +53,7 @@ module.exports = {
       `software_inventory_enabled:${inputs.softwareInventoryEnabled}`,
       `vuln_detection_enabled:${inputs.vulnDetectionEnabled}`,
       `system_users_enabled:${inputs.systemUsersEnabled}`,
-      `host_status_webhook_enabled:${inputs.hostStatusWebhookEnabled}`,
+      `host_status_webhook_enabled:${inputs.hostsStatusWebHookEnabled}`,
     ];
 
     // Create a timestamp in seconds for these metrics

--- a/website/api/models/HistoricalUsageSnapshot.js
+++ b/website/api/models/HistoricalUsageSnapshot.js
@@ -23,7 +23,7 @@ module.exports = {
     softwareInventoryEnabled: { required: true, type: 'boolean' },
     vulnDetectionEnabled: { required: true, type: 'boolean' },
     systemUsersEnabled: { required: true, type: 'boolean' },
-    hostStatusWebhookEnabled: { required: true, type: 'boolean' },
+    hostsStatusWebHookEnabled: { required: true, type: 'boolean' },
     numWeeklyActiveUsers: { required: true, type: 'number' },
     numWeeklyPolicyViolationDaysActual: { required: true, type: 'number' },
     numWeeklyPolicyViolationDaysPossible: { required: true, type: 'number'},

--- a/website/api/models/HistoricalUsageSnapshot.js
+++ b/website/api/models/HistoricalUsageSnapshot.js
@@ -23,7 +23,7 @@ module.exports = {
     softwareInventoryEnabled: { required: true, type: 'boolean' },
     vulnDetectionEnabled: { required: true, type: 'boolean' },
     systemUsersEnabled: { required: true, type: 'boolean' },
-    hostsStatusWebHookEnabled: { required: true, type: 'boolean' },
+    hostsStatusWebHookEnabled: { required: true, type: 'boolean', columnName: 'hostStatusWebhookEnabled'},
     numWeeklyActiveUsers: { required: true, type: 'number' },
     numWeeklyPolicyViolationDaysActual: { required: true, type: 'number' },
     numWeeklyPolicyViolationDaysPossible: { required: true, type: 'number'},

--- a/website/api/models/HistoricalUsageSnapshot.js
+++ b/website/api/models/HistoricalUsageSnapshot.js
@@ -23,7 +23,7 @@ module.exports = {
     softwareInventoryEnabled: { required: true, type: 'boolean' },
     vulnDetectionEnabled: { required: true, type: 'boolean' },
     systemUsersEnabled: { required: true, type: 'boolean' },
-    hostsStatusWebHookEnabled: { required: true, type: 'boolean', columnName: 'hostStatusWebhookEnabled'},
+    hostsStatusWebHookEnabled: { required: true, type: 'boolean', columnName: 'hostStatusWebhookEnabled'},// Note: We are specifying a columnName for this attribute to avoid migrating the exsiting records when the name of this attribute was changed. FUTURE: Next time we add attributes to this model, change the column name in the database and remove the columnName from this attribute.
     numWeeklyActiveUsers: { required: true, type: 'number' },
     numWeeklyPolicyViolationDaysActual: { required: true, type: 'number' },
     numWeeklyPolicyViolationDaysPossible: { required: true, type: 'number'},


### PR DESCRIPTION
Closes: #11812

Changes:
- Renamed the `hostStatusWebhookEnabled` attribute of the `HistoricalUsageSnapshot` model to `hostsStatusWebHookEnabled` and updated the definition to use the existing database column name.
- Updated the inputs of the `receive-usage-analytics` webhook to accept a `hostsStatusWebHookEnabled` input.
- Updated the usage statistics documentation to have the [correct variable name](https://github.com/fleetdm/fleet/blob/36e12d02e3c4e9dc741a7d5828ac74136f1f404d/server/fleet/statistics.go#L21).
