### PR TITLE
Small docs fixes

### DIFF
--- a/docs/Configuration/configuration-files/README.md
+++ b/docs/Configuration/configuration-files/README.md
@@ -792,7 +792,7 @@ For additional information on SSO configuration, including just-in-time (JIT) us
 
 ##### sso_settings.enable_jit_provisioning
 
-**Available in Fleet Premium**. Enables [just-in-time user provisioning](https://fleetdm.com/docs/deploying/configuration#just-in-time-jit-user-provisioning).
+**Available in Fleet Premium**. Enables [just-in-time user provisioning](https://fleetdm.com/docs/deploy/single-sign-on-sso#just-in-time-jit-user-provisioning).
 
 - Optional setting (boolean)
 - Default value: `false`

--- a/docs/Deploy/single-sign-on-sso.md
+++ b/docs/Deploy/single-sign-on-sso.md
@@ -81,7 +81,7 @@ The new account's email and full name are copied from the user data in the SSO r
 By default, accounts created via JIT provisioning are assigned the [Global Observer role](https://fleetdm.com/docs/using-fleet/permissions).
 To assign different roles for accounts created via JIT provisioning see [Customization of user roles](#customization-of-user-roles) below.
 
-To enable this option, go to **Settings > Organization settings > single sign-on options** and check "_Create user and sync permissions on login_" or [adjust your config](#sso-settings-enable-jit-provisioning).
+To enable this option, go to **Settings > Organization settings > Single sign-on options** and check "_Create user and sync permissions on login_" or [adjust your config](#sso-settings-enable-jit-provisioning).
 
 For this to work correctly make sure that:
 


### PR DESCRIPTION
- Fix the link to SSO Just-in-time (JIT) provisioning docs from the config files docs
- "Settings > Organization settings > **s**ingle sign-on options" –> "... > **S**ingle sign-on options"