### PR TITLE
Website: Fix object mutation in receive-usage-analytics webhook.

### DIFF
--- a/website/api/controllers/webhooks/receive-usage-analytics.js
+++ b/website/api/controllers/webhooks/receive-usage-analytics.js
@@ -39,8 +39,10 @@ module.exports = {
 
   fn: async function (inputs) {
 
+    // Clone the inputs to prevent them from being mutated when we create a database record.
+    let newHistoricalUsageSnapshotRecord = _.clone(inputs);
     // Create a database record for these usage statistics
-    await HistoricalUsageSnapshot.create(inputs);
+    await HistoricalUsageSnapshot.create(newHistoricalUsageSnapshotRecord);
 
     if(!sails.config.custom.datadogApiKey) {
       throw new Error('No Datadog API key configured! (Please set sails.config.custom.datadogApiKey)');

--- a/website/api/controllers/webhooks/receive-usage-analytics.js
+++ b/website/api/controllers/webhooks/receive-usage-analytics.js
@@ -39,10 +39,8 @@ module.exports = {
 
   fn: async function (inputs) {
 
-    // Clone the inputs to prevent them from being mutated when we create a database record.
-    let newHistoricalUsageSnapshotRecord = _.clone(inputs);
-    // Create a database record for these usage statistics
-    await HistoricalUsageSnapshot.create(newHistoricalUsageSnapshotRecord);
+    // Create a database record for these usage statistics.
+    await HistoricalUsageSnapshot.create(Object.assign({}, inputs));
 
     if(!sails.config.custom.datadogApiKey) {
       throw new Error('No Datadog API key configured! (Please set sails.config.custom.datadogApiKey)');


### PR DESCRIPTION
Closes: #15182

Changes:
- Updated the receive-usage-analytics webhook to create new database records with a cloned `inputs` object. This prevents the JSON attributes from being mutated into strings.