### PR TITLE
Tightening the CPE matching to reduce false positive rate.

### DIFF
--- a/changes/15143-CPE-false-matches-on-bundle-id
+++ b/changes/15143-CPE-false-matches-on-bundle-id
@@ -1,0 +1,3 @@
+Previous fix for #13889 caused false positives on software with similar names. Tightening the matching to reduce false positive rate.
+- Google Chrome Helper.app no longer matches Google Chrome.app
+- Acrobat Uninstaller.app no longer matches Acrobat.app

--- a/server/vulnerabilities/nvd/cpe.go
+++ b/server/vulnerabilities/nvd/cpe.go
@@ -152,11 +152,11 @@ func cpeGeneralSearchQuery(software *fleet.Software) (string, []interface{}, err
 
 	// 4 - Try vendor/product from bundle identifier, like tld.vendor.product
 	bundleParts := strings.Split(software.BundleIdentifier, ".")
-	if len(bundleParts) >= 3 {
+	if len(bundleParts) == 3 {
 		search4 := dialect.From(goqu.I("cpe_2").As("c")).
 			Select("c.rowid", "c.product", "c.vendor", "c.deprecated", goqu.L("4 as weight")).
 			Where(
-				goqu.Or(goqu.L("c.vendor = ?", strings.ToLower(bundleParts[1]))), goqu.L("c.product = ?", strings.ToLower(bundleParts[2])),
+				goqu.L("c.vendor = ?", strings.ToLower(bundleParts[1])), goqu.L("c.product = ?", strings.ToLower(bundleParts[2])),
 			)
 		datasets = append(datasets, search4)
 	}

--- a/server/vulnerabilities/nvd/cpe_test.go
+++ b/server/vulnerabilities/nvd/cpe_test.go
@@ -1330,6 +1330,28 @@ func TestCPEFromSoftwareIntegration(t *testing.T) {
 			},
 			cpe: "cpe:2.3:a:jetbrains:pycharm:2022.1:*:*:*:*:macos:*:*",
 		},
+		{
+			software: fleet.Software{
+				Name:             "Google Chrome Helper.app",
+				Source:           "apps",
+				Version:          "111.0.5563.64",
+				Vendor:           "",
+				BundleIdentifier: "com.google.Chrome.helper",
+			},
+			// DO NOT MATCH with Google Chrome
+			cpe: "",
+		},
+		{
+			software: fleet.Software{
+				Name:             "Acrobat Uninstaller.app",
+				Source:           "apps",
+				Version:          "6.0",
+				Vendor:           "",
+				BundleIdentifier: "com.adobe.Acrobat.Uninstaller",
+			},
+			// DO NOT MATCH with Adobe Acrobat
+			cpe: "",
+		},
 	}
 
 	tempDir := t.TempDir()

--- a/server/vulnerabilities/nvd/cpe_translations.json
+++ b/server/vulnerabilities/nvd/cpe_translations.json
@@ -129,5 +129,15 @@
       "product": ["intellij_idea"],
       "vendor": ["jetbrains"]
     }
+  },
+  {
+    "software": {
+      "bundle_identifier": ["/^com\\.jetbrains\\.pycharm/"],
+      "source": ["apps"]
+    },
+    "filter": {
+      "product": ["pycharm"],
+      "vendor": ["jetbrains"]
+    }
   }
 ]


### PR DESCRIPTION
#15143 and #15162 

Previous fix for #13889 caused false positives on software with similar names. Tightening the matching to reduce false positive rate.
- Google Chrome Helper.app no longer matches Google Chrome.app
- Acrobat Uninstaller.app no longer matches Acrobat.app

# Checklist for submitter
- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [x] Added/updated tests
