### PR TITLE
Change delete "multiple saved query" –> "...queries"

### DIFF
--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -503,7 +503,7 @@ for pagination. For a comprehensive list of activity types and detailed informat
       "actor_id": 1,
       "actor_gravatar": "",
       "actor_email": "name@example.com",
-      "type": "deleted_multiple_saved_query",
+      "type": "deleted_multiple_saved_queries",
       "details": {
         "query_ids": [
           2,

--- a/frontend/interfaces/activity.ts
+++ b/frontend/interfaces/activity.ts
@@ -12,7 +12,7 @@ export enum ActivityType {
   EditedPolicy = "edited_policy",
   CreatedSavedQuery = "created_saved_query",
   DeletedSavedQuery = "deleted_saved_query",
-  DeletedMultipleSavedQuery = "deleted_multiple_saved_query",
+  DeletedMultipleSavedQueries = "deleted_multiple_saved_queries",
   EditedSavedQuery = "edited_saved_query",
   CreatedTeam = "created_team",
   DeletedTeam = "deleted_team",

--- a/frontend/pages/DashboardPage/cards/ActivityFeed/ActivityItem/ActivityItem.tests.tsx
+++ b/frontend/pages/DashboardPage/cards/ActivityFeed/ActivityItem/ActivityItem.tests.tsx
@@ -882,9 +882,9 @@ describe("Activity Feed", () => {
       screen.getByText("for no team via fleetctl.", { exact: false })
     ).toBeInTheDocument();
   });
-  it("renders a pluralized 'deleted_multiple_saved_query' type activity when deleting multiple queries.", () => {
+  it("renders a pluralized 'deleted_multiple_saved_queries' type activity when deleting multiple queries.", () => {
     const activity = createMockActivity({
-      type: ActivityType.DeletedMultipleSavedQuery,
+      type: ActivityType.DeletedMultipleSavedQueries,
       details: {
         query_ids: [1, 2, 3],
       },

--- a/frontend/pages/DashboardPage/cards/ActivityFeed/ActivityItem/ActivityItem.tsx
+++ b/frontend/pages/DashboardPage/cards/ActivityFeed/ActivityItem/ActivityItem.tsx
@@ -712,7 +712,7 @@ const getDetail = (
     case ActivityType.EditedScript: {
       return TAGGED_TEMPLATES.editedScript(activity);
     }
-    case ActivityType.DeletedMultipleSavedQuery: {
+    case ActivityType.DeletedMultipleSavedQueries: {
       return TAGGED_TEMPLATES.deletedMultipleSavedQuery(activity);
     }
     default: {

--- a/server/fleet/activities.go
+++ b/server/fleet/activities.go
@@ -21,7 +21,7 @@ var ActivityDetailsList = []ActivityDetails{
 	ActivityTypeCreatedSavedQuery{},
 	ActivityTypeEditedSavedQuery{},
 	ActivityTypeDeletedSavedQuery{},
-	ActivityTypeDeletedMultipleSavedQuery{},
+	ActivityTypeDeletedMultipleSavedQueries{},
 	ActivityTypeAppliedSpecSavedQuery{},
 
 	ActivityTypeCreatedTeam{},
@@ -304,15 +304,15 @@ func (a ActivityTypeDeletedSavedQuery) Documentation() (activity string, details
 }`
 }
 
-type ActivityTypeDeletedMultipleSavedQuery struct {
+type ActivityTypeDeletedMultipleSavedQueries struct {
 	IDs []uint `json:"query_ids"`
 }
 
-func (a ActivityTypeDeletedMultipleSavedQuery) ActivityName() string {
-	return "deleted_multiple_saved_query"
+func (a ActivityTypeDeletedMultipleSavedQueries) ActivityName() string {
+	return "deleted_multiple_saved_queries"
 }
 
-func (a ActivityTypeDeletedMultipleSavedQuery) Documentation() (activity string, details string, detailsExample string) {
+func (a ActivityTypeDeletedMultipleSavedQueries) Documentation() (activity string, details string, detailsExample string) {
 	return `Generated when deleting multiple saved queries.`,
 		`This activity contains the following fields:
 - "query_ids": list of IDs of the deleted saved queries.`, `{

--- a/server/service/queries.go
+++ b/server/service/queries.go
@@ -542,7 +542,7 @@ func (svc *Service) DeleteQueries(ctx context.Context, ids []uint) (uint, error)
 	if err := svc.ds.NewActivity(
 		ctx,
 		authz.UserFromContext(ctx),
-		fleet.ActivityTypeDeletedMultipleSavedQuery{
+		fleet.ActivityTypeDeletedMultipleSavedQueries{
 			IDs: ids,
 		},
 	); err != nil {


### PR DESCRIPTION
## Follow-up to #15099 

- Change names from singular to plural
- Note that old activities which may still exist in the DB render with "deleted multiple query" (result of the default case in frontend rendering logic), though new instances of this activity type render correctly:
![Screenshot 2023-11-17 at 12 38 31 PM](https://github.com/fleetdm/fleet/assets/61553566/82e56486-18ac-46bf-8145-7e5ecfac98a4)

- [x] Manual QA for all new/changed functionality