### PR TITLE
Remove atom_packages table from software inventory query

### DIFF
--- a/changes/15135-remove-atom-packages
+++ b/changes/15135-remove-atom-packages
@@ -1,0 +1,1 @@
+* Stop reporting Atom editor packages in software inventory. The Atom editor is retired and the relevant tables are being removed from osquery.

--- a/server/service/osquery_utils/queries.go
+++ b/server/service/osquery_utils/queries.go
@@ -718,16 +718,6 @@ UNION
 SELECT
   name AS name,
   version AS version,
-  'Package (Atom)' AS type,
-  '' AS bundle_identifier,
-  'atom_packages' AS source,
-  0 AS last_opened_at,
-  path AS installed_path
-FROM cached_users CROSS JOIN atom_packages USING (uid)
-UNION
-SELECT
-  name AS name,
-  version AS version,
   'Package (Homebrew)' AS type,
   '' AS bundle_identifier,
   'homebrew_packages' AS source,
@@ -819,17 +809,6 @@ UNION
 SELECT
   name AS name,
   version AS version,
-  'Package (Atom)' AS type,
-  'atom_packages' AS source,
-  '' AS release,
-  '' AS vendor,
-  '' AS arch,
-  path AS installed_path
-FROM cached_users CROSS JOIN atom_packages USING (uid)
-UNION
-SELECT
-  name AS name,
-  version AS version,
   'Package (Python)' AS type,
   'python_packages' AS source,
   '' AS release,
@@ -897,15 +876,6 @@ SELECT
   '' AS vendor,
   path AS installed_path
 FROM chocolatey_packages
-UNION
-SELECT
-  name AS name,
-  version AS version,
-  'Package (Atom)' AS type,
-  'atom_packages' AS source,
-  '' AS vendor,
-  path AS installed_path
-FROM cached_users CROSS JOIN atom_packages USING (uid);
 `),
 	Platforms:        []string{"windows"},
 	DirectIngestFunc: directIngestSoftware,


### PR DESCRIPTION
Part of #15135

This needs to be removed ASAP because software inventory queries will start failing when the table is removed from osquery and the agent updates to that new version.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [x] Manual QA for all new/changed functionality
  - For Orbit and Fleet Desktop changes:
    - [x] Manual QA must be performed in the three main OSs, macOS, Windows and Linux. (macOS only)
