### PR TITLE
Update name for workflow

### DIFF
--- a/.github/workflows/fleetctl-workstations-canary.yml
+++ b/.github/workflows/fleetctl-workstations-canary.yml
@@ -1,4 +1,4 @@
-# This workflow applies the latest MDM profiles to the workstations team.
+# This workflow applies the latest configuration profiles (macOS settings) and macOS updates minimum version and deadline to the workstations (canary) team.
 # It uses a fleet instance also built and executed from source.
 #
 # It runs automatically when a file is changed in /mdm_profiles.

--- a/.github/workflows/fleetctl-workstations-canary.yml
+++ b/.github/workflows/fleetctl-workstations-canary.yml
@@ -2,7 +2,7 @@
 # It uses a fleet instance also built and executed from source.
 #
 # It runs automatically when a file is changed in /mdm_profiles.
-name: Apply latest MDM profiles (Canary)
+name: Apply latest configuration profiles and macOS updates (Canary)
 
 on:
   push:


### PR DESCRIPTION
Update name to "Apply latest configuration profiles and macOS updates"
Because it used to say update MDM (workflow is for more than MDM), and keeps it in line with workstation group.
