### PR TITLE
UI – Add help text, modularize help text styling, misc cleanup

### DIFF
--- a/frontend/components/forms/FormField/_styles.scss
+++ b/frontend/components/forms/FormField/_styles.scss
@@ -37,6 +37,10 @@
   }
 
   &--checkbox {
+    // flex properties only have an effect when checkbox help text is present
+    display: flex;
+    flex-direction: column;
+    gap: $pad-small;
     margin-bottom: $pad-medium;
   }
 

--- a/frontend/components/forms/fields/Checkbox/Checkbox.tsx
+++ b/frontend/components/forms/fields/Checkbox/Checkbox.tsx
@@ -84,7 +84,7 @@ const Checkbox = (props: ICheckboxProps) => {
           {tooltipContent ? (
             <span className={`${baseClass}__label-tooltip tooltip`}>
               <TooltipWrapper tipContent={tooltipContent}>
-                {children as string}
+                {children}
               </TooltipWrapper>
             </span>
           ) : (

--- a/frontend/components/forms/fields/Checkbox/Checkbox.tsx
+++ b/frontend/components/forms/fields/Checkbox/Checkbox.tsx
@@ -21,6 +21,7 @@ export interface ICheckboxProps {
   parseTarget?: boolean;
   tooltipContent?: React.ReactNode;
   isLeftLabel?: boolean;
+  helpText?: string;
 }
 
 const Checkbox = (props: ICheckboxProps) => {
@@ -37,6 +38,7 @@ const Checkbox = (props: ICheckboxProps) => {
     parseTarget,
     tooltipContent,
     isLeftLabel,
+    helpText,
   } = props;
 
   const handleChange = () => {
@@ -66,28 +68,33 @@ const Checkbox = (props: ICheckboxProps) => {
 
   return (
     <FormField {...formFieldProps}>
-      <label htmlFor={name} className={checkBoxClass}>
-        <input
-          checked={value}
-          className={`${baseClass}__input`}
-          disabled={disabled}
-          id={name}
-          name={name}
-          onChange={handleChange}
-          onBlur={onBlur}
-          type="checkbox"
-        />
-        <span className={checkBoxTickClass} />
-        {tooltipContent ? (
-          <span className={`${baseClass}__label-tooltip tooltip`}>
-            <TooltipWrapper tipContent={tooltipContent}>
-              {children as string}
-            </TooltipWrapper>
-          </span>
-        ) : (
-          <span className={`${baseClass}__label`}>{children} </span>
+      <>
+        <label htmlFor={name} className={checkBoxClass}>
+          <input
+            checked={value}
+            className={`${baseClass}__input`}
+            disabled={disabled}
+            id={name}
+            name={name}
+            onChange={handleChange}
+            onBlur={onBlur}
+            type="checkbox"
+          />
+          <span className={checkBoxTickClass} />
+          {tooltipContent ? (
+            <span className={`${baseClass}__label-tooltip tooltip`}>
+              <TooltipWrapper tipContent={tooltipContent}>
+                {children as string}
+              </TooltipWrapper>
+            </span>
+          ) : (
+            <span className={`${baseClass}__label`}>{children} </span>
+          )}
+        </label>
+        {helpText && (
+          <span className={`${baseClass}__help-text`}>{helpText}</span>
         )}
-      </label>
+      </>
     </FormField>
   );
 };

--- a/frontend/components/forms/fields/Checkbox/_styles.scss
+++ b/frontend/components/forms/fields/Checkbox/_styles.scss
@@ -94,6 +94,10 @@
     display: inherit;
     vertical-align: top;
   }
+
+  &__help-text {
+    @include help-text;
+  }
 }
 
 .inverse {

--- a/frontend/pages/admin/OrgSettingsPage/_styles.scss
+++ b/frontend/pages/admin/OrgSettingsPage/_styles.scss
@@ -119,6 +119,7 @@
       }
 
       &__inputs {
+        margin-top: 1.1rem;
         width: 100%;
         float: left;
         padding-right: $pad-small;

--- a/frontend/pages/admin/OrgSettingsPage/cards/Advanced/Advanced.tsx
+++ b/frontend/pages/admin/OrgSettingsPage/cards/Advanced/Advanced.tsx
@@ -221,18 +221,21 @@ const Advanced = ({
                   <>
                     <p>
                       Disabling query reports will decrease database usage,{" "}
-                      <br />\ but will prevent you from accessing query results
-                      in
-                      <br /> \ Fleet and will delete existing reports. This can
-                      also be
-                      <br />\ disabled on a per-query basis by enabling
-                      &quot;Discard <br />\ data&quot;.{" "}
+                      <br />
+                      but will prevent you from accessing query results in
+                      <br />
+                      Fleet and will delete existing reports. This can also be{" "}
+                      <br />
+                      disabled on a per-query basis by enabling &quot;Discard{" "}
+                      <br />
+                      data&quot;.{" "}
                       <em>
                         (Default: <b>Off</b>)
                       </em>
                     </p>
                   </>
                 }
+                helpText="Enabling this setting will delete all existing query reports in Fleet."
               >
                 Disable query reports
               </Checkbox>

--- a/frontend/pages/hosts/ManageHostsPage/components/LabelFilterSelect/LabelFilterSelect.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/components/LabelFilterSelect/LabelFilterSelect.tsx
@@ -167,11 +167,10 @@ const LabelFilterSelect = ({
   };
 
   return (
-    <div onClick={toggleMenu}>
+    <div className={classes} onClick={toggleMenu}>
       <Select<ILabel | IEmptyOption, false, IGroupOption>
         ref={selectRef}
         name="input-filter-select"
-        className={classes}
         classNamePrefix={baseClass}
         defaultMenuIsOpen={false}
         placeholder="Filter by platform or label"

--- a/frontend/styles/var/mixins.scss
+++ b/frontend/styles/var/mixins.scss
@@ -116,3 +116,8 @@ $max-width: 2560px;
   pointer-events: none;
   cursor: default;
 }
+
+@mixin help-text {
+  font-size: $xx-small;
+  color: $ui-fleet-black-75;
+}


### PR DESCRIPTION
## Addresses #14882 

- Add help text
- Align heading of Advanced section
- Add `help-text` mixin for improved modularity/reusability
- Fix responsive styles on LabelFilterSelect

<img width="721" alt="Screenshot 2023-11-21 at 9 52 45 AM" src="https://github.com/fleetdm/fleet/assets/61553566/216112f8-de9d-4ee3-acb5-376e6ccd3b4e">

- [x] Manual QA for all new/changed functionality
