### PR TITLE
Add example of profiles table with numeric id and uuid as pk

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -248,6 +248,7 @@ require (
 	github.com/jonboulle/clockwork v0.2.2 // indirect
 	github.com/kevinburke/ssh_config v1.1.0 // indirect
 	github.com/klauspost/compress v1.15.11 // indirect
+	github.com/lib/pq v1.10.9 // indirect
 	github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 // indirect
 	github.com/magiconair/properties v1.8.5 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
@@ -296,6 +297,7 @@ require (
 	github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673 // indirect
 	github.com/yashtewari/glob-intersection v0.1.0 // indirect
 	github.com/yusufpapurcu/wmi v1.2.2 // indirect
+	github.com/ziutek/mymysql v1.5.4 // indirect
 	go.elastic.co/apm/module/apmhttp/v2 v2.3.0 // indirect
 	go.elastic.co/fastjson v1.1.0 // indirect
 	go.opencensus.io v0.24.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1222,6 +1222,7 @@ github.com/yusufpapurcu/wmi v1.2.2 h1:KBNDSne4vP5mbSWnJbO+51IMOXJB67QiYCSBrubbPR
 github.com/yusufpapurcu/wmi v1.2.2/go.mod h1:SBZ9tNy3G9/m5Oi98Zks0QjeHVDvuK0qfxQmPyzfmi0=
 github.com/zclconf/go-cty v1.1.0/go.mod h1:xnAOWiHeOqg2nWS62VtQ7pbOu17FtxJNW8RLEih+O3s=
 github.com/zenazn/goji v0.9.0/go.mod h1:7S9M489iMyHBNxwZnk9/EHS098H4/F6TATF2mIxtB1Q=
+github.com/ziutek/mymysql v1.5.4 h1:GB0qdRGsTwQSBVYuVShFBKaXSnSnYYC2d9knnE1LHFs=
 github.com/ziutek/mymysql v1.5.4/go.mod h1:LMSpPZ6DbqWFxNCHW77HeMg9I646SAhApZ/wKdgO/C0=
 go.elastic.co/apm/module/apmgorilla/v2 v2.3.0 h1:jHw8N252UTwKTk945+Am8AaawhHC6DWpFVeTXQO8Gko=
 go.elastic.co/apm/module/apmgorilla/v2 v2.3.0/go.mod h1:2LXDBbVhFf9rF65jZecvl78IZMuvSRldQ+9A/fjfIo0=

--- a/server/datastore/mysql/migrations/tables/20231121140727_AlterMacOSProfiles.go
+++ b/server/datastore/mysql/migrations/tables/20231121140727_AlterMacOSProfiles.go
@@ -1,0 +1,38 @@
+package tables
+
+import (
+	"database/sql"
+)
+
+func init() {
+	MigrationClient.AddMigration(Up_20231121140727, Down_20231121140727)
+}
+
+func Up_20231121140727(tx *sql.Tx) error {
+	_, err := tx.Exec(`
+CREATE TABLE mock_profiles (
+	-- 37 and not 36, to leave 1 char for 'A' or 'W' prefix (Apple/Windows)
+	profile_uuid VARCHAR(37) NOT NULL DEFAULT '' PRIMARY KEY,
+	profile_id INT(10) NOT NULL DEFAULT 0,
+	name VARCHAR(255) NOT NULL DEFAULT '',
+
+	UNIQUE KEY (profile_id)
+)`)
+	if err != nil {
+		return err
+	}
+	// And then to insert into that table, must be something like that:
+	// INSERT INTO mock_profiles
+	//  (profile_uuid, profile_id, name)
+	// SELECT
+	//   concat('A', uuid()),
+	//   coalesce(max(profile_id), 0) + 1,
+	//   'test'
+	// FROM mock_profiles;
+
+	return nil
+}
+
+func Down_20231121140727(tx *sql.Tx) error {
+	return nil
+}

--- a/server/datastore/mysql/migrations/tables/20231121140727_AlterMacOSProfiles_test.go
+++ b/server/datastore/mysql/migrations/tables/20231121140727_AlterMacOSProfiles_test.go
@@ -1,0 +1,20 @@
+package tables
+
+import "testing"
+
+func TestUp_20231121140727(t *testing.T) {
+	db := applyUpToPrev(t)
+
+	//
+	// Insert data to test the migration
+	//
+	// ...
+
+	// Apply current migration.
+	applyNext(t, db)
+
+	//
+	// Check data, insert new entries, e.g. to verify migration is safe.
+	//
+	// ...
+}


### PR DESCRIPTION
Just an experiment to see how we could preserve macos' numerical id while moving to a prefixed uuid.