### PR TITLE
UI – Restore clickability to entirety of sort headers except in filter text inputs

### DIFF
--- a/changes/14519-header-clickability
+++ b/changes/14519-header-clickability
@@ -1,0 +1,1 @@
+* Enable the entirety of all sort headers to be clickable, except for in filter text inputs

--- a/frontend/components/TableContainer/DataTable/DataTable.tsx
+++ b/frontend/components/TableContainer/DataTable/DataTable.tsx
@@ -2,7 +2,6 @@
 // disable this rule as it was throwing an error in Header and Cell component
 // definitions for the selection row for some reason when we dont really need it.
 import React, { useMemo, useEffect, useCallback, useContext } from "react";
-import { TableContext } from "context/table";
 import classnames from "classnames";
 import {
   Column,
@@ -15,7 +14,7 @@ import {
   useSortBy,
   useTable,
 } from "react-table";
-import { kebabCase, noop, omit, pick } from "lodash";
+import { kebabCase, noop } from "lodash";
 import { useDebouncedCallback } from "use-debounce";
 
 import useDeepEffect from "hooks/useDeepEffect";
@@ -326,16 +325,9 @@ const DataTable = ({
   );
 
   const renderColumnHeader = (column: IHeaderGroup) => {
-    // if there is a column filter, we want the `onClick` event listener attached
-    // just to the child title span so that clicking into the column filter input
-    // doesn't also sort the column
-    const spanProps = column.Filter
-      ? pick(column.getSortByToggleProps(), "onClick")
-      : {};
-
     return (
       <div className="column-header">
-        <span {...spanProps}>{column.render("Header")}</span>
+        {column.render("Header")}
         {column.Filter && column.render("Filter")}
       </div>
     );
@@ -505,21 +497,10 @@ const DataTable = ({
             {headerGroups.map((headerGroup) => (
               <tr {...headerGroup.getHeaderGroupProps()}>
                 {headerGroup.headers.map((column) => {
-                  let thProps = column.getSortByToggleProps({
-                    title: undefined,
-                  });
-                  if (column.Filter) {
-                    // if there is a column filter, we want the `onClick` event listener attached
-                    // just to the child title span so that clicking into the column filter input
-                    // doesn't also sort the column
-                    thProps = omit(thProps, "onClick");
-                  }
-
                   return (
                     <th
-                      key={column.id}
                       className={column.id ? `${column.id}__header` : ""}
-                      {...thProps}
+                      {...column.getHeaderProps(column.getSortByToggleProps())}
                     >
                       {renderColumnHeader(column)}
                     </th>

--- a/frontend/components/TableContainer/DataTable/DefaultColumnFilter/DefaultColumnFilter.tsx
+++ b/frontend/components/TableContainer/DataTable/DefaultColumnFilter/DefaultColumnFilter.tsx
@@ -14,9 +14,10 @@ const DefaultColumnFilter = ({
   }
 
   return (
-    <div className={"filter-cell"}>
+    <div className="filter-cell">
       <SearchField
         placeholder=""
+        onClick={(e) => e.stopPropagation()}
         onChange={(searchString) => {
           setFilter(searchString || undefined); // Set undefined to remove the filter entirely
         }}

--- a/frontend/components/forms/fields/InputFieldWithIcon/InputFieldWithIcon.jsx
+++ b/frontend/components/forms/fields/InputFieldWithIcon/InputFieldWithIcon.jsx
@@ -19,6 +19,7 @@ class InputFieldWithIcon extends InputField {
     label: PropTypes.string,
     name: PropTypes.string,
     onChange: PropTypes.func,
+    onClick: PropTypes.func,
     placeholder: PropTypes.string,
     tabIndex: PropTypes.number,
     type: PropTypes.string,
@@ -80,6 +81,7 @@ class InputFieldWithIcon extends InputField {
       iconPosition,
       inputOptions,
       ignore1Password,
+      onClick,
     } = this.props;
     const { onInputChange, renderHint } = this;
 
@@ -112,6 +114,7 @@ class InputFieldWithIcon extends InputField {
           id={name}
           name={name}
           onChange={onInputChange}
+          onClick={onClick}
           className={inputClasses}
           placeholder={placeholder}
           ref={(r) => {

--- a/frontend/components/forms/fields/SearchField/SearchField.tsx
+++ b/frontend/components/forms/fields/SearchField/SearchField.tsx
@@ -10,6 +10,7 @@ export interface ISearchFieldProps {
   placeholder: string;
   defaultValue?: string;
   onChange: (value: string) => void;
+  onClick?: (e: React.MouseEvent) => void;
   icon?: IconNames;
 }
 
@@ -17,6 +18,7 @@ const SearchField = ({
   placeholder,
   defaultValue = "",
   onChange,
+  onClick,
   icon = "search",
 }: ISearchFieldProps): JSX.Element => {
   const [searchQueryInput, setSearchQueryInput] = useState(defaultValue);
@@ -37,6 +39,7 @@ const SearchField = ({
       value={searchQueryInput}
       // inputWrapperClass={`${baseClass}__input-wrapper`}
       onChange={onInputChange}
+      onClick={onClick}
       iconPosition="start"
       iconSvg={icon}
     />


### PR DESCRIPTION
## Addresses #14519 

- Applies anywhere there is a sort header, including the query results and query report tables

https://github.com/fleetdm/fleet/assets/61553566/5bf0db8f-3d13-434d-b811-914fdded02df



- [x] Changes file added for user-visible changes in `changes/`
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [x] Manual QA for all new/changed functionality