### PR TITLE
UmbrellaMenu.app no longer matches Cisco Umbrella

### DIFF
--- a/changes/15143-CPE-false-matches-on-bundle-id
+++ b/changes/15143-CPE-false-matches-on-bundle-id
@@ -1,3 +1,4 @@
 Previous fix for #13889 caused false positives on software with similar names. Tightening the matching to reduce false positive rate.
 - Google Chrome Helper.app no longer matches Google Chrome.app
 - Acrobat Uninstaller.app no longer matches Acrobat.app
+- UmbrellaMenu.app no longer matches Cisco Umbrella

--- a/server/vulnerabilities/nvd/cpe_test.go
+++ b/server/vulnerabilities/nvd/cpe_test.go
@@ -1352,6 +1352,17 @@ func TestCPEFromSoftwareIntegration(t *testing.T) {
 			// DO NOT MATCH with Adobe Acrobat
 			cpe: "",
 		},
+		{
+			software: fleet.Software{
+				Name:             "UmbrellaMenu.app",
+				Source:           "apps",
+				Version:          "1.0",
+				Vendor:           "",
+				BundleIdentifier: "com.cisco.umbrella.menu.UmbrellaMenu",
+			},
+			// DO NOT MATCH with Cisco Umbrella
+			cpe: "",
+		},
 	}
 
 	tempDir := t.TempDir()


### PR DESCRIPTION
#15176 
This was already fixed earlier in the sprint by https://github.com/fleetdm/fleet/pull/15187
Adding docs and a test.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [x] Added/updated tests
