### PR TITLE
Fix windows installer orbit delete pending

### DIFF
--- a/changes/issue-14958-installer-windows-delete-pending
+++ b/changes/issue-14958-installer-windows-delete-pending
@@ -1,0 +1,1 @@
+* Fixes delete pending issue on orbit.exe during installation


### PR DESCRIPTION
Relates to #14958 

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [X] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [ ] Manual QA for all new/changed functionality
  - For Orbit and Fleet Desktop changes:
    - [X] Manual QA must be performed in the three main OSs, macOS, Windows and Linux.
    - [ ] Auto-update manual QA, from released version of component to new version (see [tools/tuf/test](../tools/tuf/test/README.md)).
