### PR TITLE
Website: Update Vanta sync script to catch errors thrown from `.retry()` method.

### DIFF
--- a/website/scripts/send-data-to-vanta.js
+++ b/website/scripts/send-data-to-vanta.js
@@ -351,12 +351,9 @@ module.exports = {
             'content-type': 'application/json',
           },
         })
-        .retry()
-        .tolerate((err)=>{// If an error occurs while sending a request to Vanta, we'll add the error to the errorReportById object, with this connections ID set as the key.
-          errorReportById[connectionIdAsString] = new Error(`vantaError: When sending a PUT request to the Vanta's '/user_account/sync_all' endpoint for a Vanta connection (id: ${connectionIdAsString}), an error occurred: ${err}`);
-        });
+        .retry();
       } catch(error) {
-        errorReportById[connectionIdAsString] = new Error(`vantaError: When sending a PUT request to the Vanta's '/user_account/sync_all' endpoint for a Vanta connection (id: ${connectionIdAsString}), an error occurred: ${error}`);
+        errorReportById[connectionIdAsString] = new Error(`vantaError: When sending a PUT request to the Vanta's '/user_account/sync_all' endpoint for a Vanta connection (id: ${connectionIdAsString}), an error occurred: ${error.stack}`);
       }
 
       if(errorReportById[connectionIdAsString]){// If an error occured in the previous request, we'll bail early for this connection.
@@ -382,12 +379,9 @@ module.exports = {
             'content-type': 'application/json',
           },
         })
-        .retry()
-        .tolerate((err)=>{// If an error occurs while sending a request to Vanta, we'll add the error to the errorReportById object, with this connections ID set as the key.
-          errorReportById[connectionIdAsString] = new Error(`vantaError: When sending a PUT request to the Vanta's '/macos_user_computer/sync_all' endpoint for a Vanta connection (id: ${connectionIdAsString}), an error occurred: ${err}`);
-        });
+        .retry();
       } catch (error) {
-        errorReportById[connectionIdAsString] = new Error(`vantaError: When sending a PUT request to the Vanta's '/macos_user_computer/sync_all' endpoint for a Vanta connection (id: ${connectionIdAsString}), an error occurred: ${error}`)
+        errorReportById[connectionIdAsString] = new Error(`vantaError: When sending a PUT request to the Vanta's '/macos_user_computer/sync_all' endpoint for a Vanta connection (id: ${connectionIdAsString}), an error occurred: ${error.stack}`);
       }
 
       if(errorReportById[connectionIdAsString]){// If an error occured in the previous request, we'll bail early for this connection.
@@ -413,12 +407,9 @@ module.exports = {
             'content-type': 'application/json',
           },
         })
-        .retry()
-        .tolerate((err)=>{// If an error occurs while sending a request to Vanta, we'll add the error to the errorReportById object, with this connections ID set as the key.
-          errorReportById[connectionIdAsString] = new Error(`vantaError: When sending a PUT request to the Vanta's '/macos_user_computer/sync_all' endpoint for a Vanta connection (id: ${connectionIdAsString}), an error occurred: ${err}`);
-        });
+        .retry();
       } catch (error) {
-        errorReportById[connectionIdAsString] = new Error(`vantaError: When sending a PUT request to the Vanta's '/macos_user_computer/sync_all' endpoint for a Vanta connection (id: ${connectionIdAsString}), an error occurred: ${error}`);
+        errorReportById[connectionIdAsString] = new Error(`vantaError: When sending a PUT request to the Vanta's '/macos_user_computer/sync_all' endpoint for a Vanta connection (id: ${connectionIdAsString}), an error occurred: ${error.stack}`);
       }
 
       if(errorReportById[connectionIdAsString]){// If an error occured in the previous request, we'll bail early for this connection.

--- a/website/scripts/send-data-to-vanta.js
+++ b/website/scripts/send-data-to-vanta.js
@@ -335,24 +335,29 @@ module.exports = {
       //  ┌─┐┬ ┬┌┐┌┌─┐  ┬ ┬┌─┐┌─┐┬─┐┌─┐  ┬ ┬┬┌┬┐┬ ┬  ╦  ╦┌─┐┌┐┌┌┬┐┌─┐
       //  └─┐└┬┘││││    │ │└─┐├┤ ├┬┘└─┐  ││││ │ ├─┤  ╚╗╔╝├─┤│││ │ ├─┤
       //  └─┘ ┴ ┘└┘└─┘  └─┘└─┘└─┘┴└─└─┘  └┴┘┴ ┴ ┴ ┴   ╚╝ ┴ ┴┘└┘ ┴ ┴ ┴
-      await sails.helpers.http.sendHttpRequest.with({
-        method: 'PUT',
-        url: 'https://api.vanta.com/v1/resources/user_account/sync_all',
-        body: {
-          sourceId: vantaConnection.sourceId,
-          resourceId: '63868a88d436911435a94035',
-          resources: usersToSyncWithVanta,
-        },
-        headers: {
-          'accept': 'application/json',
-          'authorization': 'Bearer '+updatedRecord.vantaAuthToken,
-          'content-type': 'application/json',
-        },
-      })
-      .retry()
-      .tolerate((err)=>{// If an error occurs while sending a request to Vanta, we'll add the error to the errorReportById object, with this connections ID set as the key.
-        errorReportById[connectionIdAsString] = new Error(`vantaError: When sending a PUT request to the Vanta's '/user_account/sync_all' endpoint for a Vanta connection (id: ${connectionIdAsString}), an error occurred: ${err}`);
-      });
+      // Note: this request is in a try-catch block so we can handle errors sent from the retry() method
+      try {
+        await sails.helpers.http.sendHttpRequest.with({
+          method: 'PUT',
+          url: 'https://api.vanta.com/v1/resources/user_account/sync_all',
+          body: {
+            sourceId: vantaConnection.sourceId,
+            resourceId: '63868a88d436911435a94035',
+            resources: usersToSyncWithVanta,
+          },
+          headers: {
+            'accept': 'application/json',
+            'authorization': 'Bearer '+updatedRecord.vantaAuthToken,
+            'content-type': 'application/json',
+          },
+        })
+        .retry()
+        .tolerate((err)=>{// If an error occurs while sending a request to Vanta, we'll add the error to the errorReportById object, with this connections ID set as the key.
+          errorReportById[connectionIdAsString] = new Error(`vantaError: When sending a PUT request to the Vanta's '/user_account/sync_all' endpoint for a Vanta connection (id: ${connectionIdAsString}), an error occurred: ${err}`);
+        });
+      } catch(error) {
+        errorReportById[connectionIdAsString] = new Error(`vantaError: When sending a PUT request to the Vanta's '/user_account/sync_all' endpoint for a Vanta connection (id: ${connectionIdAsString}), an error occurred: ${error}`);
+      }
 
       if(errorReportById[connectionIdAsString]){// If an error occured in the previous request, we'll bail early for this connection.
         return;
@@ -361,24 +366,29 @@ module.exports = {
       //  ╔═╗┬ ┬┌┐┌┌─┐  ┌┬┐┌─┐┌─┐╔═╗╔═╗  ┬ ┬┌─┐┌─┐┌┬┐┌─┐  ┬ ┬┬┌┬┐┬ ┬  ╦  ╦┌─┐┌┐┌┌┬┐┌─┐
       //  ╚═╗└┬┘││││    │││├─┤│  ║ ║╚═╗  ├─┤│ │└─┐ │ └─┐  ││││ │ ├─┤  ╚╗╔╝├─┤│││ │ ├─┤
       //  ╚═╝ ┴ ┘└┘└─┘  ┴ ┴┴ ┴└─┘╚═╝╚═╝  ┴ ┴└─┘└─┘ ┴ └─┘  └┴┘┴ ┴ ┴ ┴   ╚╝ ┴ ┴┘└┘ ┴ ┴ ┴
-      await sails.helpers.http.sendHttpRequest.with({
-        method: 'PUT',
-        url: 'https://api.vanta.com/v1/resources/macos_user_computer/sync_all',
-        body: {
-          sourceId: vantaConnection.vantaSourceId,
-          resourceId: '63868a569c18bd7adc6b7907',
-          resources: macHostsToSyncWithVanta,
-        },
-        headers: {
-          'accept': 'application/json',
-          'authorization': 'Bearer '+updatedRecord.vantaAuthToken,
-          'content-type': 'application/json',
-        },
-      })
-      .retry()
-      .tolerate((err)=>{// If an error occurs while sending a request to Vanta, we'll add the error to the errorReportById object, with this connections ID set as the key.
-        errorReportById[connectionIdAsString] = new Error(`vantaError: When sending a PUT request to the Vanta's '/macos_user_computer/sync_all' endpoint for a Vanta connection (id: ${connectionIdAsString}), an error occurred: ${err}`);
-      });
+      // Note: this request is in a try-catch block so we can handle errors sent from the retry() method
+      try {
+        await sails.helpers.http.sendHttpRequest.with({
+          method: 'PUT',
+          url: 'https://api.vanta.com/v1/resources/macos_user_computer/sync_all',
+          body: {
+            sourceId: vantaConnection.vantaSourceId,
+            resourceId: '63868a569c18bd7adc6b7907',
+            resources: macHostsToSyncWithVanta,
+          },
+          headers: {
+            'accept': 'application/json',
+            'authorization': 'Bearer '+updatedRecord.vantaAuthToken,
+            'content-type': 'application/json',
+          },
+        })
+        .retry()
+        .tolerate((err)=>{// If an error occurs while sending a request to Vanta, we'll add the error to the errorReportById object, with this connections ID set as the key.
+          errorReportById[connectionIdAsString] = new Error(`vantaError: When sending a PUT request to the Vanta's '/macos_user_computer/sync_all' endpoint for a Vanta connection (id: ${connectionIdAsString}), an error occurred: ${err}`);
+        });
+      } catch (error) {
+        errorReportById[connectionIdAsString] = new Error(`vantaError: When sending a PUT request to the Vanta's '/macos_user_computer/sync_all' endpoint for a Vanta connection (id: ${connectionIdAsString}), an error occurred: ${error}`)
+      }
 
       if(errorReportById[connectionIdAsString]){// If an error occured in the previous request, we'll bail early for this connection.
         return;
@@ -387,24 +397,29 @@ module.exports = {
       //  ╔═╗┬ ┬┌┐┌┌─┐  ╦ ╦┬┌┐┌┌┬┐┌─┐┬ ┬┌─┐  ┬ ┬┌─┐┌─┐┌┬┐┌─┐  ┬ ┬┬┌┬┐┬ ┬  ╦  ╦┌─┐┌┐┌┌┬┐┌─┐
       //  ╚═╗└┬┘││││    ║║║││││ │││ ││││└─┐  ├─┤│ │└─┐ │ └─┐  ││││ │ ├─┤  ╚╗╔╝├─┤│││ │ ├─┤
       //  ╚═╝ ┴ ┘└┘└─┘  ╚╩╝┴┘└┘─┴┘└─┘└┴┘└─┘  ┴ ┴└─┘└─┘ ┴ └─┘  └┴┘┴ ┴ ┴ ┴   ╚╝ ┴ ┴┘└┘ ┴ ┴ ┴
-      await sails.helpers.http.sendHttpRequest.with({
-        method: 'PUT',
-        url: 'https://api.vanta.com/v1/resources/windows_user_computer/sync_all',
-        body: {
-          sourceId: vantaConnection.vantaSourceId,
-          resourceId: '64012c3f4bd5adc73b133459',
-          resources: windowsHostsToSyncWithVanta,
-        },
-        headers: {
-          'accept': 'application/json',
-          'authorization': 'Bearer '+updatedRecord.vantaAuthToken,
-          'content-type': 'application/json',
-        },
-      })
-      .retry()
-      .tolerate((err)=>{// If an error occurs while sending a request to Vanta, we'll add the error to the errorReportById object, with this connections ID set as the key.
-        errorReportById[connectionIdAsString] = new Error(`vantaError: When sending a PUT request to the Vanta's '/macos_user_computer/sync_all' endpoint for a Vanta connection (id: ${connectionIdAsString}), an error occurred: ${err}`);
-      });
+      // Note: this request is in a try-catch block so we can handle errors sent from the retry() method
+      try {
+        await sails.helpers.http.sendHttpRequest.with({
+          method: 'PUT',
+          url: 'https://api.vanta.com/v1/resources/windows_user_computer/sync_all',
+          body: {
+            sourceId: vantaConnection.vantaSourceId,
+            resourceId: '64012c3f4bd5adc73b133459',
+            resources: windowsHostsToSyncWithVanta,
+          },
+          headers: {
+            'accept': 'application/json',
+            'authorization': 'Bearer '+updatedRecord.vantaAuthToken,
+            'content-type': 'application/json',
+          },
+        })
+        .retry()
+        .tolerate((err)=>{// If an error occurs while sending a request to Vanta, we'll add the error to the errorReportById object, with this connections ID set as the key.
+          errorReportById[connectionIdAsString] = new Error(`vantaError: When sending a PUT request to the Vanta's '/macos_user_computer/sync_all' endpoint for a Vanta connection (id: ${connectionIdAsString}), an error occurred: ${err}`);
+        });
+      } catch (error) {
+        errorReportById[connectionIdAsString] = new Error(`vantaError: When sending a PUT request to the Vanta's '/macos_user_computer/sync_all' endpoint for a Vanta connection (id: ${connectionIdAsString}), an error occurred: ${error}`);
+      }
 
       if(errorReportById[connectionIdAsString]){// If an error occured in the previous request, we'll bail early for this connection.
         return;


### PR DESCRIPTION
Changes:
- Wrapped requests that have `.retry()` in a try-catch block. Errors thrown by the `.retry()` method are not currently not being caught by the `intercept()` chained onto the request, and cause the script to stop running.