### PR TITLE
Update docs link for deploying generated Apple CSR

### DIFF
--- a/website/views/emails/email-signed-csr-for-apns.ejs
+++ b/website/views/emails/email-signed-csr-for-apns.ejs
@@ -11,7 +11,7 @@
     In Apple Push Certificates Portal, select <span style="font-style: italic;">Create a Certificate</span>, upload your CSR, and download your APNS certificate.
   </li>
   <li style="margin-bottom: 0px;">
-    Deploy Fleet using this certificate. <a style="color: #6A67FE; text-decoration: none;" href="https://fleetdm.com/docs/deploying/configuration#apple-apns-cert" target="_blank">Click here to see how</a>.
+    Deploy Fleet using this certificate. <a style="color: #6A67FE; text-decoration: none;" href="https://fleetdm.com/docs/using-fleet/mdm-macos-setup#step-3-configure-fleet-with-the-generated-files" target="_blank">Click here to see how</a>.
   </li>
 </ol>
 


### PR DESCRIPTION
The old anchor link no longer exists and this new URL provides more of a step-by-step instruction.