### PR TITLE
UI – Fix bug with line breaks in example command

### DIFF
--- a/changes/14970-line-break-in-example-command
+++ b/changes/14970-line-break-in-example-command
@@ -1,0 +1,1 @@
+- Fix a bug where line breaks intended for clean UI broke functionality

--- a/frontend/components/AddHostsModal/PlatformWrapper/PlatformWrapper.tsx
+++ b/frontend/components/AddHostsModal/PlatformWrapper/PlatformWrapper.tsx
@@ -218,9 +218,7 @@ const PlatformWrapper = ({
 
   const renderInstallerString = (packageType: string) => {
     return packageType === "advanced"
-      ? `fleetctl package --type=YOUR_TYPE --fleet-url=${config?.server_settings.server_url}
---enroll-secret=${enrollSecret}
---fleet-certificate=PATH_TO_YOUR_CERTIFICATE/fleet.pem`
+      ? `fleetctl package --type=YOUR_TYPE --fleet-url=${config?.server_settings.server_url} --enroll-secret=${enrollSecret} --fleet-certificate=PATH_TO_YOUR_CERTIFICATE/fleet.pem`
       : `fleetctl package --type=${packageType} ${
           includeFleetDesktop ? "--fleet-desktop " : ""
         }--fleet-url=${


### PR DESCRIPTION
## Addresses #14970 

Command fails for correct reason (no real path provided), instead of reading it as multiple commands due to line breaks:

<img width="801" alt="Screenshot 2023-11-27 at 4 27 21 PM" src="https://github.com/fleetdm/fleet/assets/61553566/c30b183a-d8e4-4b90-85be-9097dcd7315c">

- [x] Changes file added for user-visible changes in `changes/`
- [x] Manual QA for all new/changed functionality