### PR TITLE
Screen specified serial from DEP assign profile operations

### DIFF
--- a/server/service/hosts.go
+++ b/server/service/hosts.go
@@ -22,6 +22,7 @@ import (
 	"github.com/fleetdm/fleet/v4/server/mdm"
 	"github.com/fleetdm/fleet/v4/server/mdm/apple/mobileconfig"
 	"github.com/fleetdm/fleet/v4/server/worker"
+	"github.com/go-kit/kit/log/level"
 	"github.com/gocarina/gocsv"
 )
 
@@ -701,6 +702,7 @@ func (svc *Service) AddHostsToTeam(ctx context.Context, teamID *uint, hostIDs []
 	if err := svc.authz.Authorize(ctx, &fleet.Host{TeamID: teamID}, fleet.ActionWrite); err != nil {
 		return err
 	}
+	level.Info(svc.logger).Log("msg", "add hosts to team called", "team_id", teamID, "host_ids", fmt.Sprintf("%+v", hostIDs))
 
 	if err := svc.ds.AddHostsToTeam(ctx, teamID, hostIDs); err != nil {
 		return err
@@ -711,10 +713,12 @@ func (svc *Service) AddHostsToTeam(ctx context.Context, teamID *uint, hostIDs []
 		}
 	}
 	serials, err := svc.ds.ListMDMAppleDEPSerialsInHostIDs(ctx, hostIDs)
+	level.Info(svc.logger).Log("msg", "list DEP serials in host ids", "host_ids", fmt.Sprintf("%+v", hostIDs), "serials", fmt.Sprintf("%+v", serials))
 	if err != nil {
 		return ctxerr.Wrap(ctx, err, "list mdm dep serials in host ids")
 	}
 	if len(serials) > 0 {
+		level.Info(svc.logger).Log("msg", "queuing assistant job", "team_id", teamID, "serials", fmt.Sprintf("%+v", serials))
 		if err := worker.QueueMacosSetupAssistantJob(
 			ctx,
 			svc.ds,

--- a/server/worker/macos_setup_assistant.go
+++ b/server/worker/macos_setup_assistant.go
@@ -112,8 +112,9 @@ func (m *MacosSetupAssistant) runProfileChanged(ctx context.Context, args macosS
 	if err != nil {
 		return ctxerr.Wrap(ctx, err, "list mdm dep serials in team")
 	}
-	if len(serials) > 0 {
-		if _, err := m.DEPClient.AssignProfile(ctx, apple_mdm.DEPName, profUUID, serials...); err != nil {
+	screenedSerials := apple_mdm.ApplyDEPScreenToSerials(ctx, m.Log, profUUID, serials...)
+	if len(screenedSerials) > 0 {
+		if _, err := m.DEPClient.AssignProfile(ctx, apple_mdm.DEPName, profUUID, screenedSerials...); err != nil {
 			return ctxerr.Wrap(ctx, err, "assign profile")
 		}
 	}
@@ -162,8 +163,9 @@ func (m *MacosSetupAssistant) runProfileDeleted(ctx context.Context, args macosS
 	if err != nil {
 		return ctxerr.Wrap(ctx, err, "list mdm dep serials in team")
 	}
-	if len(serials) > 0 {
-		if _, err := m.DEPClient.AssignProfile(ctx, apple_mdm.DEPName, profUUID, serials...); err != nil {
+	screenedSerials := apple_mdm.ApplyDEPScreenToSerials(ctx, m.Log, profUUID, serials...)
+	if len(screenedSerials) > 0 {
+		if _, err := m.DEPClient.AssignProfile(ctx, apple_mdm.DEPName, profUUID, screenedSerials...); err != nil {
 			return ctxerr.Wrap(ctx, err, "assign profile")
 		}
 	}
@@ -205,9 +207,11 @@ func (m *MacosSetupAssistant) runHostsTransferred(ctx context.Context, args maco
 		}
 	}
 
-	_, err = m.DEPClient.AssignProfile(ctx, apple_mdm.DEPName, profUUID, args.HostSerialNumbers...)
-	if err != nil {
-		return ctxerr.Wrap(ctx, err, "assign profile")
+	screenedSerials := apple_mdm.ApplyDEPScreenToSerials(ctx, m.Log, profUUID, args.HostSerialNumbers...)
+	if len(screenedSerials) > 0 {
+		if _, err := m.DEPClient.AssignProfile(ctx, apple_mdm.DEPName, profUUID, screenedSerials...); err != nil {
+			return ctxerr.Wrap(ctx, err, "assign profile")
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
Issue #14957 

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [ ] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [ ] Documented any permissions changes (docs/Using Fleet/manage-access.md)
- [ ] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [ ] Added support on fleet's osquery simulator `cmd/osquery-perf` for new osquery data ingestion features.
- [ ] Added/updated tests
- [ ] Manual QA for all new/changed functionality
  - For Orbit and Fleet Desktop changes:
    - [ ] Manual QA must be performed in the three main OSs, macOS, Windows and Linux.
    - [ ] Auto-update manual QA, from released version of component to new version (see [tools/tuf/test](../tools/tuf/test/README.md)).
