### PR TITLE
Add back Windows Profiles documentation changes

### DIFF
--- a/docs/Configuration/configuration-files/README.md
+++ b/docs/Configuration/configuration-files/README.md
@@ -249,6 +249,10 @@ spec:
           - path/to/profile1.mobileconfig
           - path/to/profile2.mobileconfig
         enable_disk_encryption: true
+      windows_settings:
+        custom_settings:
+          - path/to/profile3.xml
+          - path/to/profile4.xml
     scripts:
         - path/to/script1.sh
         - path/to/script2.sh
@@ -460,6 +464,10 @@ spec:
         - path/to/profile1.mobileconfig
         - path/to/profile2.mobileconfig
       enable_disk_encryption: true
+    windows_settings:
+      custom_settings:
+        - path/to/profile3.xml
+        - path/to/profile4.xml
 ```
 
 ### Settings
@@ -1185,6 +1193,28 @@ If you're using Fleet Premium, this enforces disk encryption on all hosts assign
   mdm:
     macos_settings:
       enable_disk_encryption: true
+  ```
+
+##### mdm.windows_settings
+
+The following settings are Windows-specific settings for Fleet's MDM solution.
+
+##### mdm.windows_settings.custom_settings
+
+List of configuration profile files to apply to all hosts.
+
+If you're using Fleet Premium, these profiles apply to all hosts assigned to no team.
+
+> If you want to add profiles to all Windows hosts on a specific team in Fleet, use the `team` YAML document. Learn how to create one [here](#teams).
+
+- Default value: none
+- Config file format:
+  ```yaml
+  mdm:
+    windows_settings:
+      custom_settings:
+        - path/to/profile1.xml
+        - path/to/profile2.xml
   ```
 
 #### Scripts 

--- a/docs/Contributing/API-for-contributors.md
+++ b/docs/Contributing/API-for-contributors.md
@@ -1283,6 +1283,8 @@ If the `name` is not already associated with an existing team, this API route cr
 | mdm.macos_settings.custom_settings        | list   | body  | The list of .mobileconfig files to apply to hosts that belong to this team.                                                                                                                                                         |
 | scripts                                   | list   | body  | A list of script files to add to this team so they can be executed at a later time.                                                                                                                                                 |
 | mdm.macos_settings.enable_disk_encryption | bool   | body  | Whether disk encryption should be enabled for hosts that belong to this team.                                                                                                                                                       |
+| mdm.windows_settings                      | object | body  | The Windows-specific MDM settings.                                                                                                                                                                                                  |
+| mdm.windows_settings.custom_settings      | list   | body  | The list of .xml files to apply to hosts that belong to this team.                                                                                                                                                                  |
 | force                                     | bool   | query | Force apply the spec even if there are (ignorable) validation errors. Those are unknown keys and agent options-related validations.                                                                                                 |
 | dry_run                                   | bool   | query | Validate the provided JSON for unknown keys and invalid value types and return any validation errors, but do not apply the changes.                                                                                                 |
 
@@ -1342,6 +1344,9 @@ If the `name` is not already associated with an existing team, this API route cr
         "macos_settings": {
           "custom_settings": ["path/to/profile1.mobileconfig"],
           "enable_disk_encryption": true
+        },
+        "windows_settings": {
+          "custom_settings": ["path/to/profile2.xml"],
         }
       },
       "scripts": ["path/to/script.sh"],

--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -883,6 +883,9 @@ None.
       "custom_settings": ["path/to/profile1.mobileconfig"],
       "enable_disk_encryption": true
     },
+    "windows_settings": {
+      "custom_settings": ["path/to/profile2.xml"],
+    },
     "scripts": ["path/to/script.sh"],
     "end_user_authentication": {
       "entity_id": "",
@@ -1084,6 +1087,7 @@ Modifies the Fleet's configuration with the supplied information.
 | webhook_url                          | string  | body  | _mdm.macos_migration settings_. The webhook url configured to receive requests to unenroll devices migrating from your old MDM solution. **Requires Fleet Premium license** |
 | custom_settings                   | list    | body  | _mdm.macos_settings settings_. Hosts that belong to no team and are enrolled into Fleet's MDM will have those custom profiles applied. |
 | enable_disk_encryption            | boolean | body  | _mdm.macos_settings settings_. Hosts that belong to no team and are enrolled into Fleet's MDM will have disk encryption enabled if set to true. **Requires Fleet Premium license** |
+| custom_settings                   | list    | body  | _mdm.windows_settings settings_. Hosts that belong to no team and are enrolled into Fleet's MDM will have those custom profiles applied. |
 | scripts                           | list    | body  | A list of script files to add so they can be executed at a later time.                                                                                                                                                 |
 | enable_end_user_authentication            | boolean | body  | _mdm.macos_setup settings_. If set to true, end user authentication will be required during automatic MDM enrollment of new macOS devices. Settings for your IdP provider must also be [configured](https://fleetdm.com/docs/using-fleet/mdm-macos-setup-experience#end-user-authentication-and-eula). **Requires Fleet Premium license** |
 | additional_queries                | boolean | body  | Whether or not additional queries are enabled on hosts.                                                                                                                                |
@@ -1177,6 +1181,9 @@ Note that when making changes to the `integrations` object, all integrations mus
     "macos_settings": {
       "custom_settings": ["path/to/profile1.mobileconfig"],
       "enable_disk_encryption": true
+    },
+    "windows_settings": {
+      "custom_settings": ["path/to/profile2.xml"],
     },
     "end_user_authentication": {
       "entity_id": "",
@@ -7382,6 +7389,9 @@ _Available in Fleet Premium_
         "custom_settings": ["path/to/profile1.mobileconfig"],
         "enable_disk_encryption": false
       },
+      "windows_settings": {
+        "custom_settings": ["path/to/profile2.xml"],
+      },
       "macos_setup": {
         "bootstrap_package": "",
         "enable_end_user_authentication": false,
@@ -7498,6 +7508,8 @@ _Available in Fleet Premium_
 | &nbsp;&nbsp;macos_settings                              | object  | body | macOS-specific settings.                                                                                                                                                                                  |
 | &nbsp;&nbsp;&nbsp;&nbsp;custom_settings                 | list    | body | The list of .mobileconfig files to apply to macOS hosts that belong to this team.                                                                                                                                        |
 | &nbsp;&nbsp;&nbsp;&nbsp;enable_disk_encryption          | boolean | body | Hosts that belong to this team and are enrolled into Fleet's MDM will have disk encryption enabled if set to true.                                                                                        |
+| &nbsp;&nbsp;windows_settings                            | object  | body | Windows-specific settings.                                                                                                                                                                                |
+| &nbsp;&nbsp;&nbsp;&nbsp;custom_settings                 | list    | body | The list of XML files to apply to Windows hosts that belong to this team.                                                                                                                                |
 | &nbsp;&nbsp;macos_setup                                 | object  | body | Setup for automatic MDM enrollment of macOS hosts.                                                                                                                                                      |
 | &nbsp;&nbsp;&nbsp;&nbsp;enable_end_user_authentication  | boolean | body | If set to true, end user authentication will be required during automatic MDM enrollment of new macOS hosts. Settings for your IdP provider must also be [configured](https://fleetdm.com/docs/using-fleet/mdm-macos-setup-experience#end-user-authentication-and-eula).                                                                                      |
 
@@ -7562,6 +7574,9 @@ _Available in Fleet Premium_
       "macos_settings": {
         "custom_settings": ["path/to/profile1.mobileconfig"],
         "enable_disk_encryption": false
+      },
+      "windows_settings": {
+        "custom_settings": ["path/to/profile2.xml"],
       },
       "macos_setup": {
         "bootstrap_package": "",


### PR DESCRIPTION
Those are the documentation changes only for the Windows Profiles feature that was reverted from the last release (and that we now bring back to `main`). The code changes have already been brought back to `main`.

#13281 