### PR TITLE
add truncation to dropdown options for the query table documentation sidebar

### DIFF
--- a/changes/issue-14441-add-truncation-query-docs
+++ b/changes/issue-14441-add-truncation-query-docs
@@ -1,0 +1,1 @@
+- add truncation to the dropdown options on the query tables documentation

--- a/frontend/components/side_panels/QuerySidePanel/_styles.scss
+++ b/frontend/components/side_panels/QuerySidePanel/_styles.scss
@@ -78,6 +78,14 @@
           display: inline-block;
         }
       }
+
+      // styles to truncate table names in the dropdown options
+      .Select-option .dropdown__option {
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        display: block;
+      }
     }
   }
 


### PR DESCRIPTION
relates to #14441

add truncation to dropdown options for the query table documentation sidebar

![image](https://github.com/fleetdm/fleet/assets/1153709/d7100090-c636-4bba-88c7-370ce6426e99)

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [x] Manual QA for all new/changed functionality
