### PR TITLE
make query table doc dropdown truncation consistant

### DIFF
--- a/changes/issue-14441-add-truncation-query-docs
+++ b/changes/issue-14441-add-truncation-query-docs
@@ -1,0 +1,1 @@
+- add truncation to the dropdown options on the query tables documentation

--- a/frontend/components/side_panels/QuerySidePanel/_styles.scss
+++ b/frontend/components/side_panels/QuerySidePanel/_styles.scss
@@ -78,6 +78,14 @@
           display: inline-block;
         }
       }
+
+      // styles to truncate table names in the dropdown options
+      .Select-option .dropdown__option {
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        display: block;
+      }
     }
   }
 

--- a/frontend/components/side_panels/QuerySidePanel/_styles.scss
+++ b/frontend/components/side_panels/QuerySidePanel/_styles.scss
@@ -85,6 +85,9 @@
         overflow: hidden;
         text-overflow: ellipsis;
         display: block;
+        // this width makes the dropdown option truncation consistant regardless
+        // if the scrollbar is showing or not.
+        width: 225px;
       }
     }
   }


### PR DESCRIPTION
relates to #14441

Makes the truncation consistent for the dropdown options on the query table selector.

- [x] Manual QA for all new/changed functionality
