### PR TITLE
Ensure macOS min version form is open by default on the os updates page

### DIFF
--- a/frontend/pages/ManageControlsPage/OSUpdates/components/PlatformsAccordion/PlatformsAccordion.tsx
+++ b/frontend/pages/ManageControlsPage/OSUpdates/components/PlatformsAccordion/PlatformsAccordion.tsx
@@ -43,7 +43,7 @@ const PlatformsAccordion = ({
   return (
     <Accordion
       className={`${baseClass}__accordion`}
-      preExpanded={["mac"]}
+      preExpanded={["darwin"]}
       onChange={(selected) =>
         onSelectAccordionItem(selected[0] as OSUpdatesSupportedPlatform)
       }


### PR DESCRIPTION
ensures the mac min version form is open by default on the os updates page

- [x] Manual QA for all new/changed functionality

