### PR TITLE
Fix links to the website containing anchors and URL params

### DIFF
--- a/frontend/pages/ForgotPasswordPage/ForgotPasswordPage.tsx
+++ b/frontend/pages/ForgotPasswordPage/ForgotPasswordPage.tsx
@@ -59,7 +59,7 @@ const ForgotPasswordPage = ({ router }: IForgotPasswordPage) => {
             <br />
             You can find more information on resetting passwords at the{" "}
             <CustomLink
-              url="https://fleetdm.com/docs/using-fleet/fleetctl-cli#using-fleetctl-with-an-api-only-user?utm_medium=fleetui&utm_campaign=get-api-token"
+              url="https://fleetdm.com/docs/using-fleet/fleetctl-cli?utm_medium=fleetui&utm_campaign=get-api-token#using-fleetctl-with-an-api-only-user"
               text="Password reset FAQ"
               newTab
             />

--- a/frontend/pages/UserSettingsPage/UserSettingsPage.tsx
+++ b/frontend/pages/UserSettingsPage/UserSettingsPage.tsx
@@ -187,7 +187,7 @@ const UserSettingsPage = ({
               <strong>This token expires.</strong> If you want an API key for a
               permanent integration, create an&nbsp;
               <CustomLink
-                url="https://fleetdm.com/docs/using-fleet/fleetctl-cli#using-fleetctl-with-an-api-only-user?utm_medium=fleetui&utm_campaign=get-api-token"
+                url="https://fleetdm.com/docs/using-fleet/fleetctl-cli?utm_medium=fleetui&utm_campaign=get-api-token#using-fleetctl-with-an-api-only-user"
                 text="API-only user"
                 newTab
               />
@@ -201,7 +201,7 @@ const UserSettingsPage = ({
             This token is intended for SSO users to authenticate in the fleetctl
             CLI. It expires based on the{" "}
             <CustomLink
-              url="https://fleetdm.com/docs/deploying/configuration#session-duration?utm_medium=fleetui&utm_campaign=get-api-token"
+              url="https://fleetdm.com/docs/deploying/configuration?utm_medium=fleetui&utm_campaign=get-api-token#session-duration"
               text="session duration configuration"
               newTab
             />

--- a/frontend/pages/admin/OrgSettingsPage/cards/Sso/Sso.tsx
+++ b/frontend/pages/admin/OrgSettingsPage/cards/Sso/Sso.tsx
@@ -228,7 +228,7 @@ const Sso = ({
               <>
                 Create user and sync permissions on login{" "}
                 <CustomLink
-                  url="https://fleetdm.com/docs/deploying/configuration?utm_medium=fleetui&utm_source=sso-settings#just-in-time-jit-user-provisioning"
+                  url="https://fleetdm.com/docs/deploy/single-sign-on-sso?utm_medium=fleetui&utm_source=sso-settings#just-in-time-jit-user-provisioning"
                   text="Learn more"
                   newTab
                 />


### PR DESCRIPTION
I noticed that anchor links containing URL params weren't properly linking to the in-page anchor. That's because the `#` anchor has to be at the end of the URL. 