### PR TITLE
Update scripts docs

### DIFF
--- a/docs/Contributing/API-for-contributors.md
+++ b/docs/Contributing/API-for-contributors.md
@@ -2703,6 +2703,39 @@ If the Fleet instance is provided required parameters to complete setup.
 
 ## Scripts
 
+### Run script asynchronously
+
+_Available in Fleet Premium_
+
+Creates a script execution request and returns the execution identifier to retrieve results at a later time.
+
+`POST /api/v1/fleet/scripts/run`
+
+#### Parameters
+
+| Name            | Type    | In   | Description                                                                                    |
+| ----            | ------- | ---- | --------------------------------------------                                                   |
+| host_id         | integer | body | **Required**. The ID of the host to run the script on.                                                |
+| script_id       | integer | body | The ID of the existing saved script to run. Only one of either `script_id` or `script_contents` can be included in the request; omit this parameter if using `script_contents`.  |
+| script_contents | string  | body | The contents of the script to run. Only one of either `script_id` or `script_contents` can be included in the request; omit this parameter if using `script_id`. |
+
+> Note that if both `script_id` and `script_contents` are included in the request, this endpoint will respond with an error.
+
+#### Example
+
+`POST /api/v1/fleet/scripts/run`
+
+##### Default response
+
+`Status: 202`
+
+```json
+{
+  "host_id": 1227,
+  "execution_id": "e797d6c6-3aae-11ee-be56-0242ac120002"
+}
+```
+
 ### Batch-apply scripts 
 
 _Available in Fleet Premium_

--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -6546,8 +6546,7 @@ This allows you to easily configure scheduled queries that will impact a whole t
 
 ## Scripts
 
-- [Run script asynchronously](#run-script-asynchronously)
-- [Run script synchronously](#run-script-synchronously)
+- [Run script](#run-script)
 - [Get script result](#get-script-result)
 - [Upload a script](#upload-a-script)
 - [Delete a script](#delete-a-script)
@@ -6555,44 +6554,11 @@ This allows you to easily configure scheduled queries that will impact a whole t
 - [Get or download a script](#get-or-download-a-script)
 - [Get script details by host](#get-script-details-by-host)
 
-### Run script asynchronously
+### Run script
 
 _Available in Fleet Premium_
 
-Creates a script execution request and returns the execution identifier to retrieve results at a later time.
-
-`POST /api/v1/fleet/scripts/run`
-
-#### Parameters
-
-| Name            | Type    | In   | Description                                                                                    |
-| ----            | ------- | ---- | --------------------------------------------                                                   |
-| host_id         | integer | body | **Required**. The ID of the host to run the script on.                                                |
-| script_id       | integer | body | The ID of the existing saved script to run. Only one of either `script_id` or `script_contents` can be included in the request; omit this parameter if using `script_contents`.  |
-| script_contents | string  | body | The contents of the script to run. Only one of either `script_id` or `script_contents` can be included in the request; omit this parameter if using `script_id`. |
-
-> Note that if both `script_id` and `script_contents` are included in the request, this endpoint will respond with an error.
-
-#### Example
-
-`POST /api/v1/fleet/scripts/run`
-
-##### Default response
-
-`Status: 202`
-
-```json
-{
-  "host_id": 1227,
-  "execution_id": "e797d6c6-3aae-11ee-be56-0242ac120002"
-}
-```
-
-### Run script synchronously
-
-_Available in Fleet Premium_
-
-Creates a script execution request and waits for a result to return (up to a 1 minute timeout).
+Execute a script and see script results (1 minute timeout).
 
 `POST /api/v1/fleet/scripts/run/sync`
 

--- a/docs/Using Fleet/Scripts.md
+++ b/docs/Using Fleet/Scripts.md
@@ -10,16 +10,7 @@ PowerShell scripts are supported on Windows. Other types of scripts are not supp
 
 Script execution is disabled by default. Continue reading to learn how to enable scripts.
 
-## Execute a script
-
-You can execute a script using the `fleetctl` command-line interface.
-
-To execute a script, we will do the following steps:
-1. Enable script execution
-2. Write a script
-3. Run the script
-
-### Step 1: Enable script execution
+## Enable scripts
 
 If you use Fleet's macOS MDM features, scripts are automatically enabled for macOS hosts that have MDM turned on. You're set!
 
@@ -31,38 +22,33 @@ If you don't use MDM features, to enable scripts, we'll deploy a fleetd agent wi
 
 Learn more about generating a fleetd agent and deploying it [here](./enroll-hosts.md).
 
-### Step 2: Write a script
-
-As an example, we'll write a shell script for a macOS host that downloads a Fleet wallpaper and set the host's wallpaper to it.
-
-To run the script, we'll need to create a `set-wallpaper-to-fleet.sh` file locally and copy and paste this script into this `.sh` file:
-
-```sh
-wallpaper="/tmp/wallpaper.png" 
-
-curl --fail https://fleetdm.com/images/wallpaper-cloud-city-1920x1080.png -o $wallpaper
-
-osascript -e 'tell application "Finder" to set desktop picture to POSIX file "'"$wallpaper"'"' 
-```
-
-### Step 3: Run the script
-
-1. Run this fleetctl command:
-```sh
-fleetctl run-script --script-path=set-wallpaper-to-fleet.sh --host=hostname
-```
-
-> Replace --host flag with your target host's hostname.
-
-2. Look at the on-screen information. In the output you'll see the script's exit code and output.
-
-Each time a Fleet user runs a script an entry is created in [Fleet's activity feed](./Audit-logs.md#type-code-ran-script-code).
-
-## Security considerations
+### Security considerations
 
 Script execution can only be enabled by someone with root access to the host.
 
 Turning MDM on for a macOS host or pushing a new fleetd agent qualify as root access.
+
+## Execute a script
+
+You can execute a script in the Fleet UI, with Fleet API, or with the fleetctl command-line interface (CLI).
+
+Fleet UI:
+
+1. In Fleet, head to the **Controls > Scripts** tab and upload your script.
+
+2. Head to the Hosts page and select the host you want to run the script on.
+
+3. On your target host's host details page, select the Scripts tab and select Actions to run the script.
+
+> Currently, you can only run scripts on macOS and Windows hosts in the Fleet UI. To run a script on a Linux host, use the Fleet API or fleetctl CLI.
+
+Fleet API: API documentation is [here](https://fleetdm.com/docs/rest-api/rest-api#run-script]
+
+fleetctl CLI:
+
+```sh
+fleetctl run-script --script-path=/path/to/script --host=hostname
+```
 
 <meta name="pageOrderInSection" value="1508">
 <meta name="title" value="Scripts">

--- a/docs/Using Fleet/Scripts.md
+++ b/docs/Using Fleet/Scripts.md
@@ -22,12 +22,6 @@ If you don't use MDM features, to enable scripts, we'll deploy a fleetd agent wi
 
 Learn more about generating a fleetd agent and deploying it [here](./enroll-hosts.md).
 
-### Security considerations
-
-Script execution can only be enabled by someone with root access to the host.
-
-Turning MDM on for a macOS host or pushing a new fleetd agent qualify as root access.
-
 ## Execute a script
 
 You can execute a script in the Fleet UI, with Fleet API, or with the fleetctl command-line interface (CLI).
@@ -36,9 +30,9 @@ Fleet UI:
 
 1. In Fleet, head to the **Controls > Scripts** tab and upload your script.
 
-2. Head to the Hosts page and select the host you want to run the script on.
+2. Head to the **Hosts** page and select the host you want to run the script on.
 
-3. On your target host's host details page, select the Scripts tab and select Actions to run the script.
+3. On your target host's host details page, select the **Scripts** tab and select **Actions** to run the script.
 
 > Currently, you can only run scripts on macOS and Windows hosts in the Fleet UI. To run a script on a Linux host, use the Fleet API or fleetctl CLI.
 

--- a/frontend/services/entities/scripts.ts
+++ b/frontend/services/entities/scripts.ts
@@ -75,7 +75,7 @@ export interface IHostScriptsResponse {
 /**
  * Request body for POST /scripts/run
  *
- * https://fleetdm.com/docs/rest-api/rest-api#run-script-asynchronously
+ * https://github.com/fleetdm/fleet/blob/main/docs/Contributing/API-for-contributors.md#run-script-asynchronously
  */
 export interface IScriptRunRequest {
   host_id: number;
@@ -86,7 +86,7 @@ export interface IScriptRunRequest {
 /**
  * Response body for POST /scripts/run
  *
- * https://fleetdm.com/docs/rest-api/rest-api#run-script-asynchronously
+ * https://github.com/fleetdm/fleet/blob/main/docs/Contributing/API-for-contributors.md#run-script-asynchronously
  */
 export interface IScriptRunResponse {
   host_id: number;


### PR DESCRIPTION
- Simplify usage instructions to make it more like a reference
- Move "Run script asynchronously" to contributor docs so that user facing API docs have one best practice API endpoint for scripts. Call synchronous endpoint "Run script"
