### PR TITLE
Website: Handle scrolling to in-page links when query parameters are provided.

### DIFF
--- a/website/assets/js/pages/docs/basic-documentation.page.js
+++ b/website/assets/js/pages/docs/basic-documentation.page.js
@@ -109,13 +109,8 @@ parasails.registerPage('basic-documentation', {
     // Handle hashes in urls when coming from an external page.
     if(window.location.hash){
       // If a hash was provided, we'll remove the # and any query parameters from it. (e.g., #create-an-api-only-user?utm_medium=fleetui&utm_campaign=get-api-token » create-an-api-only-user)
-      let possibleHashToScrollTo = _.trimLeft(window.location.hash, '#');
-      // find any query parameters after the hash link and remove them.
-      let possibleHashToScrollToContainQueryParameters = possibleHashToScrollTo.match(/\?.*=.*$/);
-      if(possibleHashToScrollToContainQueryParameters){
-        possibleHashToScrollTo = possibleHashToScrollTo.replace(/\?.*=.*$/, '');
-      }
-      // Look for an element that matches the provided hash.
+      // Note: Hash links for headings in markdown content will never have a '?' beacause they are removed when convereted to kebab-case, so we can safely strip everything after one if a url contains a query parameter.
+      let possibleHashToScrollTo = _.trimLeft(window.location.hash.split('?')[0], '#');
       let elementWithMatchingId = document.getElementById(possibleHashToScrollTo);
       // If the hash matches a header's ID, we'll scroll to that section.
       if(elementWithMatchingId){

--- a/website/assets/js/pages/docs/basic-documentation.page.js
+++ b/website/assets/js/pages/docs/basic-documentation.page.js
@@ -108,11 +108,23 @@ parasails.registerPage('basic-documentation', {
 
     // Handle hashes in urls when coming from an external page.
     if(window.location.hash){
+      // If a hash was provided, we'll remove the # and any query parameters from it. (e.g., #create-an-api-only-user?utm_medium=fleetui&utm_campaign=get-api-token » create-an-api-only-user)
       let possibleHashToScrollTo = _.trimLeft(window.location.hash, '#');
-      let hashToScrollTo = document.getElementById(possibleHashToScrollTo);
+      // find any query parameters after the hash link and remove them.
+      let possibleHashToScrollToContainQueryParameters = possibleHashToScrollTo.match(/\?.*=.*$/);
+      if(possibleHashToScrollToContainQueryParameters){
+        possibleHashToScrollTo = possibleHashToScrollTo.replace(/\?.*=.*$/, '');
+      }
+      // Look for an element that matches the provided hash.
+      let elementWithMatchingId = document.getElementById(possibleHashToScrollTo);
       // If the hash matches a header's ID, we'll scroll to that section.
-      if(hashToScrollTo){
-        hashToScrollTo.scrollIntoView();
+      if(elementWithMatchingId){
+        // Get the distance of the specified element, and reduce it by 90 so the section is not hidden by the page header.
+        let amountToScroll = elementWithMatchingId.offsetTop - 90;
+        window.scrollTo({
+          top: amountToScroll,
+          left: 0,
+        });
       }
     }
 

--- a/website/assets/js/pages/handbook/basic-handbook.page.js
+++ b/website/assets/js/pages/handbook/basic-handbook.page.js
@@ -53,13 +53,8 @@ parasails.registerPage('basic-handbook', {
     // Handle hashes in urls when coming from an external page.
     if(window.location.hash){
       // If a hash was provided, we'll remove the # and any query parameters from it. (e.g., #create-an-api-only-user?utm_medium=fleetui&utm_campaign=get-api-token » create-an-api-only-user)
-      let possibleHashToScrollTo = _.trimLeft(window.location.hash, '#');
-      // find any query parameters after the hash link and remove them.
-      let possibleHashToScrollToContainQueryParameters = possibleHashToScrollTo.match(/\?.*=.*$/);
-      if(possibleHashToScrollToContainQueryParameters){
-        possibleHashToScrollTo = possibleHashToScrollTo.replace(/\?.*=.*$/, '');
-      }
-      // Look for an element that matches the provided hash.
+      // Note: Hash links for headings in markdown content will never have a '?' beacause they are removed when convereted to kebab-case, so we can safely strip everything after one if a url contains a query parameter.
+      let possibleHashToScrollTo = _.trimLeft(window.location.hash.split('?')[0], '#');
       let elementWithMatchingId = document.getElementById(possibleHashToScrollTo);
       // If the hash matches a header's ID, we'll scroll to that section.
       if(elementWithMatchingId){

--- a/website/assets/js/pages/handbook/basic-handbook.page.js
+++ b/website/assets/js/pages/handbook/basic-handbook.page.js
@@ -52,11 +52,23 @@ parasails.registerPage('basic-handbook', {
 
     // Handle hashes in urls when coming from an external page.
     if(window.location.hash){
+      // If a hash was provided, we'll remove the # and any query parameters from it. (e.g., #create-an-api-only-user?utm_medium=fleetui&utm_campaign=get-api-token » create-an-api-only-user)
       let possibleHashToScrollTo = _.trimLeft(window.location.hash, '#');
-      let hashToScrollTo = document.getElementById(possibleHashToScrollTo);
+      // find any query parameters after the hash link and remove them.
+      let possibleHashToScrollToContainQueryParameters = possibleHashToScrollTo.match(/\?.*=.*$/);
+      if(possibleHashToScrollToContainQueryParameters){
+        possibleHashToScrollTo = possibleHashToScrollTo.replace(/\?.*=.*$/, '');
+      }
+      // Look for an element that matches the provided hash.
+      let elementWithMatchingId = document.getElementById(possibleHashToScrollTo);
       // If the hash matches a header's ID, we'll scroll to that section.
-      if(hashToScrollTo){
-        hashToScrollTo.scrollIntoView();
+      if(elementWithMatchingId){
+        // Get the distance of the specified element, and reduce it by 90 so the section is not hidden by the page header.
+        let amountToScroll = elementWithMatchingId.offsetTop - 90;
+        window.scrollTo({
+          top: amountToScroll,
+          left: 0,
+        });
       }
     }
 


### PR DESCRIPTION
Closes: #15415

Changes:
- Updated the documentation and handbook page scripts to navigate users who visit a URL with a hash link with query parameters attached to the correct section.