### PR TITLE
Remove broken link in Enroll hosts docs

### DIFF
--- a/docs/Using Fleet/enroll-hosts.md
+++ b/docs/Using Fleet/enroll-hosts.md
@@ -108,7 +108,6 @@ In the Google Admin console:
 - [Signing fleetd installer](#signing-fleetd-installer)
 - [Generating Windows installers using local WiX toolset](#generating-windows-installers-using-local-wix-toolset)
 - [fleetd configuration options](#fleetd-configuration-options)
-- [Enroll hosts with plain osquery](#enroll-hosts-with-plain-osquery)
 
 ### Grant full disk access to osquery on macOS
 


### PR DESCRIPTION
- Remove anchor link for section that was removed in a separate PR here: #15279 