### PR TITLE
Fix deadlock when deleting software during data ingestion

### DIFF
--- a/changes/14779-fix-software-deadlock
+++ b/changes/14779-fix-software-deadlock
@@ -1,0 +1,1 @@
+* Fix possible deadlocks when deleting `software` during data ingestion (found during load test).

--- a/server/datastore/mysql/hosts_test.go
+++ b/server/datastore/mysql/hosts_test.go
@@ -6077,8 +6077,8 @@ func testHostsReplaceHostBatteriesDeadlock(t *testing.T, ds *Datastore) {
 	// We are keeping them low to not cause CI issues ("too many connections" errors
 	// due to concurrent tests).
 	const (
-		hostCount    = 100
-		replaceCount = 100
+		hostCount    = 10
+		replaceCount = 10
 	)
 	ctx := context.Background()
 	var hosts []*fleet.Host

--- a/server/datastore/mysql/software_test.go
+++ b/server/datastore/mysql/software_test.go
@@ -2782,9 +2782,16 @@ func TestReconcileSoftwareTitles(t *testing.T) {
 }
 
 func testUpdateHostSoftwareDeadlock(t *testing.T, ds *Datastore) {
+	// To increase chance of deadlock increase these numbers.
+	// We are keeping them low to not cause CI issues ("too many connections" errors
+	// due to concurrent tests).
+	const (
+		hostCount   = 100
+		updateCount = 100
+	)
 	ctx := context.Background()
 	var hosts []*fleet.Host
-	for i := 1; i <= 100; i++ {
+	for i := 1; i <= hostCount; i++ {
 		h, err := ds.NewHost(ctx, &fleet.Host{
 			ID:              uint(i),
 			OsqueryHostID:   ptr.String(fmt.Sprintf("id-%d", i)),
@@ -2803,7 +2810,7 @@ func testUpdateHostSoftwareDeadlock(t *testing.T, ds *Datastore) {
 	for _, h := range hosts {
 		hostID := h.ID
 		g.Go(func() error {
-			for i := 0; i < 100; i++ {
+			for i := 0; i < updateCount; i++ {
 				software := []fleet.Software{
 					{Name: "foo", Version: "0.0.1", Source: "test", GenerateCPE: "cpe_foo"},
 					{Name: "bar", Version: "0.0.2", Source: "test", GenerateCPE: "cpe_bar"},

--- a/server/datastore/mysql/software_test.go
+++ b/server/datastore/mysql/software_test.go
@@ -1955,7 +1955,6 @@ func testSoftwareByIDNoDuplicatedVulns(t *testing.T, ds *Datastore) {
 		require.NoError(t, ds.LoadHostSoftware(ctx, hostB, false))
 
 		// Add one vulnerability to each software
-		var vulns []fleet.SoftwareVulnerability
 		for i, s := range hostA.Software {
 			inserted, err := ds.InsertSoftwareVulnerability(ctx, fleet.SoftwareVulnerability{
 				SoftwareID: s.ID,
@@ -1963,7 +1962,6 @@ func testSoftwareByIDNoDuplicatedVulns(t *testing.T, ds *Datastore) {
 			}, fleet.UbuntuOVALSource)
 			require.NoError(t, err)
 			require.True(t, inserted)
-			vulns = append(vulns)
 		}
 
 		for _, s := range hostA.Software {
@@ -2786,8 +2784,8 @@ func testUpdateHostSoftwareDeadlock(t *testing.T, ds *Datastore) {
 	// We are keeping them low to not cause CI issues ("too many connections" errors
 	// due to concurrent tests).
 	const (
-		hostCount   = 100
-		updateCount = 100
+		hostCount   = 10
+		updateCount = 10
 	)
 	ctx := context.Background()
 	var hosts []*fleet.Host


### PR DESCRIPTION
This fixes the deadlock reported in #14779.

We found a deadlock in software ingestion during load tests performed in October:
```
2023-10-26T17:20:41.719627Z 0 [Note] [MY-012468] [InnoDB] Transactions deadlock detected, dumping detailed information. (lock0lock.cc:6482)
2023-10-26T17:20:41.719661Z 0 [Note] [MY-012469] [InnoDB]  *** (1) TRANSACTION:  (lock0lock.cc:6496)
TRANSACTION 3069866646, ACTIVE 0 sec starting index read
mysql tables in use 2, locked 2
LOCK WAIT 8 lock struct(s), heap size 1136, 18 row lock(s), undo log entries 10
MySQL thread id 95, OS thread handle 70431326097136, query id 340045 10.12.3.105 fleet executing
DELETE FROM software WHERE id IN (165, 79, 344, 47, 212, 21, 60, 127, 173, 145) AND
        NOT EXISTS (
                SELECT 1 FROM host_software hsw WHERE hsw.software_id = software.id
        )
2023-10-26T17:20:41.719700Z 0 [Note] [MY-012469] [InnoDB]  *** (1) HOLDS THE LOCK(S):  (lock0lock.cc:6496)
RECORD LOCKS space id 932 page no 8 n bits 256 index PRIMARY of table `fleet`.`software` trx id 3069866646 lock_mode X locks rec but not gap
Record lock, heap no 22 PHYSICAL RECORD: n_fields 11; compact format; info bits 0
 0: len 8; hex 0000000000000015; asc         ;;
 1: len 6; hex 0000a74c4a7c; asc    LJ|;;
 2: len 7; hex 82000000d00264; asc       d;;
 3: len 26; hex 616e74692d76697275735f666f725f736f70686f735f686f6d65; asc anti-virus_for_sophos_home;;
 4: len 5; hex 322e322e36; asc 2.2.6;;
 5: len 4; hex 61707073; asc apps;;
 6: len 0; hex ; asc ;;
 7: len 0; hex ; asc ;;
 8: len 0; hex ; asc ;;
 9: len 0; hex ; asc ;;
 10: len 0; hex ; asc ;;

Record lock, heap no 48 PHYSICAL RECORD: n_fields 11; compact format; info bits 0
 0: len 8; hex 000000000000002f; asc        /;;
 1: len 6; hex 0000a74c4aad; asc    LJ ;;
 2: len 7; hex 81000000e30220; asc        ;;
 3: len 10; hex 7265616c706c61796572; asc realplayer;;
 4: len 11; hex 31322e302e312e31373338; asc 12.0.1.1738;;
 5: len 4; hex 61707073; asc apps;;
6: len 0; hex ; asc ;;
 7: len 0; hex ; asc ;;
 8: len 0; hex ; asc ;;
 9: len 0; hex ; asc ;;
 10: len 0; hex ; asc ;;

Record lock, heap no 61 PHYSICAL RECORD: n_fields 11; compact format; info bits 0
 0: len 8; hex 000000000000003c; asc        <;;
 1: len 6; hex 0000a74c4afb; asc    LJ ;;
 2: len 7; hex 820000017501ba; asc     u  ;;
 3: len 7; hex 636f6e6e656374; asc connect;;
 4: len 5; hex 332e322e37; asc 3.2.7;;
 5: len 4; hex 61707073; asc apps;;
 6: len 0; hex ; asc ;;
 7: len 0; hex ; asc ;;
 8: len 0; hex ; asc ;;
 9: len 0; hex ; asc ;;
 10: len 0; hex ; asc ;;

Record lock, heap no 80 PHYSICAL RECORD: n_fields 11; compact format; info bits 0
 0: len 8; hex 000000000000004f; asc        O;;
 1: len 6; hex 0000a74c4b32; asc    LK2;;
 2: len 7; hex 820000008a01cb; asc        ;;
 3: len 7; hex 68697063686174; asc hipchat;;
 4: len 4; hex 342e3330; asc 4.30;;
 5: len 4; hex 61707073; asc apps;;
 6: len 0; hex ; asc ;;
 7: len 0; hex ; asc ;;
 8: len 0; hex ; asc ;;
 9: len 0; hex ; asc ;;
 10: len 0; hex ; asc ;;

2023-10-26T17:20:41.720564Z 0 [Note] [MY-012469] [InnoDB]  *** (1) WAITING FOR THIS LOCK TO BE GRANTED:  (lock0lock.cc:6496)
RECORD LOCKS space id 695 page no 5994 n bits 1000 index host_software_software_id_fk of table `fleet`.`host_software` trx id 3069866646 lock mode S waiting
Record lock, heap no 31 PHYSICAL RECORD: n_fields 2; compact format; info bits 32
 0: len 8; hex 000000000000004f; asc        O;;
 1: len 4; hex 0000000c; asc     ;;

2023-10-26T17:20:41.720650Z 0 [Note] [MY-012469] [InnoDB]  *** (2) TRANSACTION:  (lock0lock.cc:6496)
TRANSACTION 3069866680, ACTIVE 0 sec starting index read
mysql tables in use 2, locked 2
LOCK WAIT 7 lock struct(s), heap size 1136, 12 row lock(s), undo log entries 8
MySQL thread id 98, OS thread handle 70375801900784, query id 340524 10.12.3.9 fleet executing
DELETE FROM software WHERE id IN (49, 113, 183, 187, 223, 79, 81, 116) AND
        NOT EXISTS (
                SELECT 1 FROM host_software hsw WHERE hsw.software_id = software.id
        )
2023-10-26T17:20:41.720682Z 0 [Note] [MY-012469] [InnoDB]  *** (2) HOLDS THE LOCK(S):  (lock0lock.cc:6496)
RECORD LOCKS space id 695 page no 5994 n bits 1000 index host_software_software_id_fk of table `fleet`.`host_software` trx id 3069866680 lock_mode X locks rec but not gap
Record lock, heap no 31 PHYSICAL RECORD: n_fields 2; compact format; info bits 32
 0: len 8; hex 000000000000004f; asc        O;;
 1: len 4; hex 0000000c; asc     ;;

2023-10-26T17:20:41.720760Z 0 [Note] [MY-012469] [InnoDB]  *** (2) WAITING FOR THIS LOCK TO BE GRANTED:  (lock0lock.cc:6496)
RECORD LOCKS space id 932 page no 8 n bits 256 index PRIMARY of table `fleet`.`software` trx id 3069866680 lock_mode X locks rec but not gap waiting
Record lock, heap no 80 PHYSICAL RECORD: n_fields 11; compact format; info bits 0
 0: len 8; hex 000000000000004f; asc        O;;
 1: len 6; hex 0000a74c4b32; asc    LK2;;
 2: len 7; hex 820000008a01cb; asc        ;;
 3: len 7; hex 68697063686174; asc hipchat;;
 4: len 4; hex 342e3330; asc 4.30;;
 5: len 4; hex 61707073; asc apps;;
 6: len 0; hex ; asc ;;
 7: len 0; hex ; asc ;;
 8: len 0; hex ; asc ;;
 9: len 0; hex ; asc ;;
 10: len 0; hex ; asc ;;

2023-10-26T17:20:41.720984Z 0 [Note] [MY-012469] [InnoDB] *** WE ROLL BACK TRANSACTION (2)  (lock0lock.cc:6496)
```

I was able to reproduce this issue on `main` with the added test. The solution is to remove the deletion (cleanup) of `software` to a separate transaction after the main transaction is done.

- [X] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [X] Added/updated tests
- [X] Manual QA for all new/changed functionality