### PR TITLE
Update Hosts page

### DIFF
--- a/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
@@ -1367,9 +1367,9 @@ const ManageHostsPage = ({
       const emptyState = () => {
         const emptyHosts: IEmptyTableProps = {
           graphicName: "empty-hosts",
-          header: "Devices will show up here once they’re added to Fleet.",
+          header: "Hosts will show up here once they’re added to Fleet.",
           info:
-            "Expecting to see devices? Try again in a few seconds as the system catches up.",
+            "Expecting to see hosts? Try again in a few seconds as the system catches up.",
         };
         if (includesFilterQueryParam) {
           delete emptyHosts.graphicName;
@@ -1377,8 +1377,8 @@ const ManageHostsPage = ({
           emptyHosts.info =
             "Expecting to see new hosts? Try again in a few seconds as the system catches up.";
         } else if (canEnrollHosts) {
-          emptyHosts.header = "Add your devices to Fleet";
-          emptyHosts.info = "Generate an installer to add your own devices.";
+          emptyHosts.header = "Add your hosts to Fleet";
+          emptyHosts.info = "Generate an installer to add your own hosts.";
           emptyHosts.primaryButton = (
             <Button variant="brand" onClick={toggleAddHostsModal} type="button">
               Add hosts


### PR DESCRIPTION
- Use "hosts" instead of "devices" in copy on **Hosts** page
- In future stories, the Fleet UI and docs will always use "hosts." This way, the copy becomes consistent overtime.
