### PR TITLE
Update password policy configuration profile

### DIFF
--- a/mdm_profiles/password_policy.mobileconfig
+++ b/mdm_profiles/password_policy.mobileconfig
@@ -30,7 +30,7 @@
 			<key>maxInactivity</key>
 			<integer>15</integer>
 			<key>minLength</key>
-			<integer>11</integer>
+			<integer>10</integer>
 			<key>requireAlphanumeric</key>
 			<true/>
 		</dict>
@@ -38,7 +38,7 @@
 	<key>PayloadDescription</key>
 	<string>Configures our Macs to require passwords that are 10 character long</string>
 	<key>PayloadDisplayName</key>
-	<string>Enforce password length (11 characters)</string>
+	<string>Enforce password length (10 characters)</string>
 	<key>PayloadIdentifier</key>
 	<string>com.github.erikberglund.ProfileCreator.F7CF282E-D91B-44E9-922F-A719634F9C8E</string>
 	<key>PayloadOrganization</key>


### PR DESCRIPTION
- Update password policy from 11 characters to 10. Policy was updated to 11 during a demo of Fleet's GitOps feature (PR [here](https://github.com/fleetdm/fleet/pull/15191))

After merge, check dogfood to see if hosts are no longer stuck in "Pending" status. More info here: https://github.com/fleetdm/fleet/issues/15311#issuecomment-1843222438
