### PR TITLE
Website: Update how meta tags are parsed in `build-static-content` script

### DIFF
--- a/website/scripts/build-static-content.js
+++ b/website/scripts/build-static-content.js
@@ -362,9 +362,11 @@ module.exports = {
               // >   <meta name="foo" value="bar">
               // >   <meta name="title" value="Sth with punctuATION and weird CAPS ... but never this long, please">
               // >   ```
+              // > Note: These meta tags are parsed from the HTML generated from markdown to prevent reading <meta> tags in code examples.
+              // > This works because HTML in Markdown files is added as-is, while any <meta> tags in codeblocks would have their brackets replaced with HTML entities when they are converted to HTML.
               let embeddedMetadata = {};
               try {
-                for (let tag of (mdString.match(/<meta[^>]*>/igm)||[])) {
+                for (let tag of (htmlString.match(/<meta[^>]*>/igm)||[])) {
                   let name = tag.match(/name="([^">]+)"/i)[1];
                   let value = tag.match(/value="([^">]+)"/i)[1];
                   embeddedMetadata[name] = value;


### PR DESCRIPTION
Changes:
- Updated `build-static-content` to parse `<meta>` tags from HTML generated from a Markdown file, instead of the Markdown file.  Parsing them after the Markdown is converted to HTML will prevent any `<meta>` tags inside code blocks from being seen as a `<meta>` tag containing information about the page because angle brackets inside code blocks are changed into HTML entities (`&lt;` & `&gt;`) when the Markdown is converted to HTML.