### PR TITLE
Results for queries in 2017-packs should always log

### DIFF
--- a/server/service/osquery.go
+++ b/server/service/osquery.go
@@ -1694,14 +1694,9 @@ func getQueryNameAndTeamIDFromResult(path string) (*uint, string, error) {
 		return &teamNumber, parts[2], nil
 	}
 
-	// For pattern: pack/PackName/Query (legacy pack)
-	if strings.HasPrefix(path, "pack/") {
-		parts := strings.SplitN(path, "/", 3)
-		if len(parts) != 3 {
-			return nil, "", fmt.Errorf("unknown format: %q", path)
-		}
-		return nil, parts[2], nil
-	}
+	// 2017/legacy packs with the format "pack/<Pack name>/<Query name> are
+	// considered unknown format (they are not considered global or team
+	// scheduled queries).
 
 	// If none of the above patterns match, return error
 	return nil, "", fmt.Errorf("unknown format: %q", path)

--- a/server/service/osquery_test.go
+++ b/server/service/osquery_test.go
@@ -636,6 +636,7 @@ func TestSubmitResultLogs(t *testing.T) {
 		`{"snapshot":[{"hour":"20","minutes":"8"}],"action":"snapshot","name":"pack/Some Pack Name/query_not_automated","hostIdentifier":"1379f59d98f4","calendarTime":"Tue Jan 10 20:08:51 2017 UTC","unixTime":1484078931,"decorations":{"host_uuid":"EB714C9D-C1F8-A436-B6DA-3F853C5502EA"}}`,
 
 		// The "name" field has invalid format, so this result will be streamed as is (This is to support streaming results for osquery nodes that are configured outside of Fleet, e.g. `--config_plugin=filesystem`).
+		`{"name":"com.foo.bar","hostIdentifier":"52eb420a-2085-438a-abf0-5670e97588e2","calendarTime":"Thu Dec  7 15:15:20 2023 UTC","unixTime":1701962120,"epoch":0,"counter":0,"numerics":false,"columns":{"foo": "bar"},"action":"snapshot"}`,
 		`{"snapshot":[{"hour":"20","minutes":"8"}],"action":"snapshot","name":"some_name","hostIdentifier":"1379f59d98f4","calendarTime":"Tue Jan 10 20:08:51 2017 UTC","unixTime":1484078931,"decorations":{"host_uuid":"EB714C9D-C1F8-A436-B6DA-3F853C5502EA"}}`,
 		`{"snapshot":[{"hour":"20","minutes":"8"}],"action":"snapshot","name":"pack/team-foo/bar","hostIdentifier":"1379f59d98f4","calendarTime":"Tue Jan 10 20:08:51 2017 UTC","unixTime":1484078931,"decorations":{"host_uuid":"EB714C9D-C1F8-A436-B6DA-3F853C5502EA"}}`,
 		`{"snapshot":[{"hour":"20","minutes":"8"}],"action":"snapshot","name":"pack/team-","hostIdentifier":"1379f59d98f4","calendarTime":"Tue Jan 10 20:08:51 2017 UTC","unixTime":1484078931,"decorations":{"host_uuid":"EB714C9D-C1F8-A436-B6DA-3F853C5502EA"}}`,

--- a/server/service/osquery_test.go
+++ b/server/service/osquery_test.go
@@ -632,6 +632,9 @@ func TestSubmitResultLogs(t *testing.T) {
 		// Fleet doesn't know of this query, so this result should be streamed as is (This is to support streaming results for osquery nodes that are configured outside of Fleet, e.g. `--config_plugin=filesystem`).
 		`{"snapshot":[{"hour":"20","minutes":"8"}],"action":"snapshot","name":"pack/Global/doesntexist","hostIdentifier":"1379f59d98f4","calendarTime":"Tue Jan 10 20:08:51 2017 UTC","unixTime":1484078931,"decorations":{"host_uuid":"EB714C9D-C1F8-A436-B6DA-3F853C5502EA"}}`,
 
+		// If a global query belongs to a 2017/legacy pack, it should be automated even if the global query has automations turned off.
+		`{"snapshot":[{"hour":"20","minutes":"8"}],"action":"snapshot","name":"pack/Some Pack Name/query_not_automated","hostIdentifier":"1379f59d98f4","calendarTime":"Tue Jan 10 20:08:51 2017 UTC","unixTime":1484078931,"decorations":{"host_uuid":"EB714C9D-C1F8-A436-B6DA-3F853C5502EA"}}`,
+
 		// The "name" field has invalid format, so this result will be streamed as is (This is to support streaming results for osquery nodes that are configured outside of Fleet, e.g. `--config_plugin=filesystem`).
 		`{"snapshot":[{"hour":"20","minutes":"8"}],"action":"snapshot","name":"some_name","hostIdentifier":"1379f59d98f4","calendarTime":"Tue Jan 10 20:08:51 2017 UTC","unixTime":1484078931,"decorations":{"host_uuid":"EB714C9D-C1F8-A436-B6DA-3F853C5502EA"}}`,
 		`{"snapshot":[{"hour":"20","minutes":"8"}],"action":"snapshot","name":"pack/team-foo/bar","hostIdentifier":"1379f59d98f4","calendarTime":"Tue Jan 10 20:08:51 2017 UTC","unixTime":1484078931,"decorations":{"host_uuid":"EB714C9D-C1F8-A436-B6DA-3F853C5502EA"}}`,
@@ -756,13 +759,17 @@ func TestGetQueryNameAndTeamIDFromResult(t *testing.T) {
 		{"pack/Global/Query Name", nil, "Query Name", false},
 		{"pack/team-1/Query Name", ptr.Uint(1), "Query Name", false},
 		{"pack/team-12345/Another Query", ptr.Uint(12345), "Another Query", false},
-		{"pack/PackName/Query", nil, "Query", false}, // Legacy Pack support
 		{"pack/team-foo/Query", nil, "", true},
 		{"pack/Global/QueryWith/Slash", nil, "QueryWith/Slash", false},
 		{"pack/team-1/QueryWith/Slash", ptr.Uint(1), "QueryWith/Slash", false},
-		{"pack/PackName/QueryWith/Slash", nil, "QueryWith/Slash", false}, // Legacy Pack support
+
 		{"InvalidString", nil, "", true},
 		{"Invalid/Query", nil, "", true},
+
+		// Legacy 2017 packs should fail the parsing as they are separate
+		// from global or team queries.
+		{"pack/PackName/Query", nil, "", true},
+		{"pack/PackName/QueryWith/Slash", nil, "", true},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
#15168

- [X] Added/updated tests
- [X] Manual QA for all new/changed functionality