### PR TITLE
Update comment about how we use redirects & add reminder in user story template

### DIFF
--- a/.github/ISSUE_TEMPLATE/story.md
+++ b/.github/ISSUE_TEMPLATE/story.md
@@ -26,7 +26,7 @@ It is [planned and ready](https://fleetdm.com/handbook/company/development-group
 - [ ] CLI usage changes: TODO <!-- Specify what changes to the CLI usage are required. Remove this checkbox if there are no changes to the CLI. -->
 - [ ] REST API changes: TODO <!-- Specify what changes to the API are required.  Remove this checkbox if there are no changes necessary. The product manager may move this item to the engineering list below if they decide that engineering will design the API changes. -->
 - [ ] Permissions changes: TODO <!-- Specify what changes to the permissions are required.  Remove this checkbox if there are no changes necessary. -->
-- [ ] Outdated documentation changes: TODO <!-- Specify required documentation changes & add redirects to routes.js. -->
+- [ ] Outdated documentation changes: TODO <!-- Specify required documentation changes & redirects to add  to /website/config/routes.js. -->
 - [ ] Changes to paid features or tiers: TODO  <!-- Specify "Fleet Free" or "Fleet Premium".  If only certain parts of the user story involve paid features, specify which parts.  Implementation of paid features should live in the `ee/` directory. -->
 - [ ] Scalability testing: TODO  <!-- List any required scalability testing to be conducted.  Remove this checkbox if there is no scalability testing required. -->
 

--- a/.github/ISSUE_TEMPLATE/story.md
+++ b/.github/ISSUE_TEMPLATE/story.md
@@ -26,7 +26,7 @@ It is [planned and ready](https://fleetdm.com/handbook/company/development-group
 - [ ] CLI usage changes: TODO <!-- Specify what changes to the CLI usage are required. Remove this checkbox if there are no changes to the CLI. -->
 - [ ] REST API changes: TODO <!-- Specify what changes to the API are required.  Remove this checkbox if there are no changes necessary. The product manager may move this item to the engineering list below if they decide that engineering will design the API changes. -->
 - [ ] Permissions changes: TODO <!-- Specify what changes to the permissions are required.  Remove this checkbox if there are no changes necessary. -->
-- [ ] Outdated documentation changes: TODO <!-- Specify required documentation changes. If none, state why. -->
+- [ ] Outdated documentation changes: TODO <!-- Specify required documentation changes & add redirects to routes.js. -->
 - [ ] Changes to paid features or tiers: TODO  <!-- Specify "Fleet Free" or "Fleet Premium".  If only certain parts of the user story involve paid features, specify which parts.  Implementation of paid features should live in the `ee/` directory. -->
 - [ ] Scalability testing: TODO  <!-- List any required scalability testing to be conducted.  Remove this checkbox if there is no scalability testing required. -->
 

--- a/.github/ISSUE_TEMPLATE/story.md
+++ b/.github/ISSUE_TEMPLATE/story.md
@@ -26,7 +26,7 @@ It is [planned and ready](https://fleetdm.com/handbook/company/development-group
 - [ ] CLI usage changes: TODO <!-- Specify what changes to the CLI usage are required. Remove this checkbox if there are no changes to the CLI. -->
 - [ ] REST API changes: TODO <!-- Specify what changes to the API are required.  Remove this checkbox if there are no changes necessary. The product manager may move this item to the engineering list below if they decide that engineering will design the API changes. -->
 - [ ] Permissions changes: TODO <!-- Specify what changes to the permissions are required.  Remove this checkbox if there are no changes necessary. -->
-- [ ] Outdated documentation changes: TODO <!-- Specify required documentation changes & redirects to add  to /website/config/routes.js. -->
+- [ ] Outdated documentation changes: TODO <!-- Specify required documentation changes & redirects to add to /website/config/routes.js. -->
 - [ ] Changes to paid features or tiers: TODO  <!-- Specify "Fleet Free" or "Fleet Premium".  If only certain parts of the user story involve paid features, specify which parts.  Implementation of paid features should live in the `ee/` directory. -->
 - [ ] Scalability testing: TODO  <!-- List any required scalability testing to be conducted.  Remove this checkbox if there is no scalability testing required. -->
 

--- a/website/config/routes.js
+++ b/website/config/routes.js
@@ -492,8 +492,8 @@ module.exports.routes = {
 
   // Fleet UI
   // =============================================================================================================
-  // Redirects for external links from the Fleet UI, including to fleetdm.com and to external websites not maintained 
-  // by Fleet. These help avoid broken links by reducing surface area of links to maintain in the UI.
+  // Redirects for external links from the Fleet UI & CLI, including to fleetdm.com and to external websites not 
+  // maintained by Fleet. These help avoid broken links by reducing surface area of links to maintain in the UI.
   'GET /learn-more-about/chromeos-updates': 'https://support.google.com/chrome/a/answer/6220366',
 
   // Sitemap

--- a/website/config/routes.js
+++ b/website/config/routes.js
@@ -492,7 +492,7 @@ module.exports.routes = {
 
   // Fleet UI
   // =============================================================================================================
-  // Redirects for external links from the Fleet UI & CLI, including to fleetdm.com and to external websites not 
+  // Redirects for external links from the Fleet UI & CLI, including to fleetdm.com and to external websites not
   // maintained by Fleet. These help avoid broken links by reducing surface area of links to maintain in the UI.
   'GET /learn-more-about/chromeos-updates': 'https://support.google.com/chrome/a/answer/6220366',
 

--- a/website/config/routes.js
+++ b/website/config/routes.js
@@ -492,8 +492,8 @@ module.exports.routes = {
 
   // Fleet UI
   // =============================================================================================================
-  // These are external links not maintained by Fleet. We can point the Fleet UI to redirects here instead of the
-  // original sources to help avoid broken links.
+  // Redirects for external links from the Fleet UI, including to fleetdm.com and to external websites not maintained 
+  // by Fleet. These help avoid broken links by reducing surface area of links to maintain in the UI.
   'GET /learn-more-about/chromeos-updates': 'https://support.google.com/chrome/a/answer/6220366',
 
   // Sitemap


### PR DESCRIPTION
Per discussion with @noahtalerman and @marko-lisica today: we're going to aim to always add redirects in `/website/config/routes.js` for any docs/external pages we link to in the Fleet UI & CLI, to reduce surface areas of PRs when doc headings change or things are moved around...
