### PR TITLE
REST API docs: Consistent URL parameter formatting

### DIFF
--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -699,7 +699,7 @@ Retrieves a list of the non expired carves. Carve contents remain available for 
 
 Retrieves the specified carve.
 
-`GET /api/v1/fleet/carves/{id}`
+`GET /api/v1/fleet/carves/:id`
 
 #### Parameters
 
@@ -738,7 +738,7 @@ Retrieves the specified carve.
 
 Retrieves the specified carve block. This endpoint retrieves the data that was carved.
 
-`GET /api/v1/fleet/carves/{id}/block/{block_id}`
+`GET /api/v1/fleet/carves/:id/block/:block_id`
 
 #### Parameters
 
@@ -1394,7 +1394,7 @@ Delete all global enroll secrets.
 
 Returns the valid team enroll secrets.
 
-`GET /api/v1/fleet/teams/{id}/secrets`
+`GET /api/v1/fleet/teams/:id/secrets`
 
 #### Parameters
 
@@ -1425,7 +1425,7 @@ None.
 
 Replaces all existing team enroll secrets.
 
-`PATCH /api/v1/fleet/teams/{id}/secrets`
+`PATCH /api/v1/fleet/teams/:id/secrets`
 
 #### Parameters
 
@@ -1623,7 +1623,7 @@ Returns a list of the active invitations in Fleet.
 
 Delete the specified invite from Fleet.
 
-`DELETE /api/v1/fleet/invites/{id}`
+`DELETE /api/v1/fleet/invites/:id`
 
 #### Parameters
 
@@ -1633,7 +1633,7 @@ Delete the specified invite from Fleet.
 
 #### Example
 
-`DELETE /api/v1/fleet/invites/{id}`
+`DELETE /api/v1/fleet/invites/123`
 
 ##### Default response
 
@@ -1644,7 +1644,7 @@ Delete the specified invite from Fleet.
 
 Verify the specified invite.
 
-`GET /api/v1/fleet/invites/{token}`
+`GET /api/v1/fleet/invites/:token`
 
 #### Parameters
 
@@ -1654,7 +1654,7 @@ Verify the specified invite.
 
 #### Example
 
-`GET /api/v1/fleet/invites/{token}`
+`GET /api/v1/fleet/invites/abcdef012456789`
 
 ##### Default response
 
@@ -1693,7 +1693,7 @@ Verify the specified invite.
 
 ### Update invite
 
-`PATCH /api/v1/fleet/invites/{id}`
+`PATCH /api/v1/fleet/invites/:id`
 
 #### Parameters
 
@@ -2180,7 +2180,7 @@ Returns the count of all hosts organized by status. `online_count` includes all 
 
 Returns the information of the specified host.
 
-`GET /api/v1/fleet/hosts/{id}`
+`GET /api/v1/fleet/hosts/:id`
 
 #### Parameters
 
@@ -2421,7 +2421,7 @@ Returns the information of the specified host.
 Returns the information of the host specified using the `uuid`, `osquery_host_id`, `hostname`, or
 `node_key` as an identifier
 
-`GET /api/v1/fleet/hosts/identifier/{identifier}`
+`GET /api/v1/fleet/hosts/identifier/:identifier`
 
 #### Parameters
 
@@ -2628,7 +2628,7 @@ Returns a subset of information about the host specified by `token`. To get all 
 
 This is the API route used by the **My device** page in Fleet desktop to display information about the host to the end user.
 
-`GET /api/v1/fleet/device/{token}`
+`GET /api/v1/fleet/device/:token`
 
 ##### Parameters
 
@@ -2826,7 +2826,7 @@ This is the API route used by the **My device** page in Fleet desktop to display
 
 Deletes the specified host from Fleet. Note that a deleted host will fail authentication with the previous node key, and in most osquery configurations will attempt to re-enroll automatically. If the host still has a valid enroll secret, it will re-enroll successfully.
 
-`DELETE /api/v1/fleet/hosts/{id}`
+`DELETE /api/v1/fleet/hosts/:id`
 
 #### Parameters
 
@@ -2847,7 +2847,7 @@ Deletes the specified host from Fleet. Note that a deleted host will fail authen
 
 Flags the host details, labels and policies to be refetched the next time the host checks in for distributed queries. Note that we cannot be certain when the host will actually check in and update the query results. Further requests to the host APIs will indicate that the refetch has been requested through the `refetch_requested` field on the host object.
 
-`POST /api/v1/fleet/hosts/{id}/refetch`
+`POST /api/v1/fleet/hosts/:id/refetch`
 
 #### Parameters
 
@@ -2992,7 +2992,7 @@ Retrieves a host's Google Chrome profile information which can be used to link a
 
 Requires [Fleetd](https://fleetdm.com/docs/using-fleet/fleetd), the osquery manager from Fleet. Fleetd can be built with [fleetctl](https://fleetdm.com/docs/using-fleet/adding-hosts#osquery-installer).
 
-`GET /api/v1/fleet/hosts/{id}/device_mapping`
+`GET /api/v1/fleet/hosts/:id/device_mapping`
 
 #### Parameters
 
@@ -3032,7 +3032,7 @@ Retrieves a host's MDM enrollment status and MDM server URL.
 
 If the host exists but is not enrolled to an MDM server, then this API returns `null`.
 
-`GET /api/v1/fleet/hosts/{id}/mdm`
+`GET /api/v1/fleet/hosts/:id/mdm`
 
 #### Parameters
 
@@ -3124,7 +3124,7 @@ Currently supported only on macOS.
 
 Retrieves a host's MDM enrollment status, MDM server URL, and Munki version.
 
-`GET /api/v1/fleet/hosts/{id}/macadmins`
+`GET /api/v1/fleet/hosts/:id/macadmins`
 
 #### Parameters
 
@@ -3536,7 +3536,7 @@ Creates a dynamic label.
 
 Modifies the specified label. Note: Label queries and platforms are immutable. To change these, you must delete the label and create a new label.
 
-`PATCH /api/v1/fleet/labels/{id}`
+`PATCH /api/v1/fleet/labels/:id`
 
 #### Parameters
 
@@ -3587,7 +3587,7 @@ Modifies the specified label. Note: Label queries and platforms are immutable. T
 
 Returns the specified label.
 
-`GET /api/v1/fleet/labels/{id}`
+`GET /api/v1/fleet/labels/:id`
 
 #### Parameters
 
@@ -3776,7 +3776,7 @@ Returns a list of all the labels in Fleet.
 
 Returns a list of the hosts that belong to the specified label.
 
-`GET /api/v1/fleet/labels/{id}/hosts`
+`GET /api/v1/fleet/labels/:id/hosts`
 
 #### Parameters
 
@@ -3872,7 +3872,7 @@ If `mdm_id`, `mdm_name`, `mdm_enrollment_status`, `os_settings`, or `os_settings
 
 Deletes the label specified by name.
 
-`DELETE /api/v1/fleet/labels/{name}`
+`DELETE /api/v1/fleet/labels/:name`
 
 #### Parameters
 
@@ -3893,7 +3893,7 @@ Deletes the label specified by name.
 
 Deletes the label specified by ID.
 
-`DELETE /api/v1/fleet/labels/id/{id}`
+`DELETE /api/v1/fleet/labels/id/:id`
 
 #### Parameters
 
@@ -4061,7 +4061,7 @@ List all configuration profiles for macOS hosts enrolled to Fleet's MDM that are
 
 ### Download custom macOS setting (configuration profile)
 
-`GET /api/v1/fleet/mdm/apple/profiles/{profile_id}`
+`GET /api/v1/fleet/mdm/apple/profiles/:profile_id`
 
 #### Parameters
 
@@ -4113,7 +4113,7 @@ solely on the response status code returned by this endpoint.
 
 ### Delete custom macOS setting (configuration profile)
 
-`DELETE /api/v1/fleet/mdm/apple/profiles/{profile_id}`
+`DELETE /api/v1/fleet/mdm/apple/profiles/:profile_id`
 
 #### Parameters
 
@@ -4487,7 +4487,7 @@ None.
 
 ### Turn off MDM for a host
 
-`PATCH /api/v1/fleet/mdm/hosts/{id}/unenroll`
+`PATCH /api/v1/fleet/mdm/hosts/:id/unenroll`
 
 #### Parameters
 
@@ -4557,7 +4557,7 @@ _Available in Fleet Premium_
 
 Get information about a bootstrap package that was uploaded to Fleet.
 
-`GET /api/v1/fleet/mdm/apple/bootstrap/{team_id}/metadata`
+`GET /api/v1/fleet/mdm/apple/bootstrap/:team_id/metadata`
 
 #### Parameters
 
@@ -4595,7 +4595,7 @@ _Available in Fleet Premium_
 
 Delete a team's bootstrap package.
 
-`DELETE /api/v1/fleet/mdm/apple/bootstrap/{team_id}`
+`DELETE /api/v1/fleet/mdm/apple/bootstrap/:team_id`
 
 #### Parameters
 
@@ -4779,7 +4779,7 @@ _Available in Fleet Premium_
 
 Delete an EULA file.
 
-`DELETE /api/v1/fleet/mdm/apple/setup/eula/{token}`
+`DELETE /api/v1/fleet/mdm/apple/setup/eula/:token`
 
 #### Parameters
 
@@ -4801,7 +4801,7 @@ _Available in Fleet Premium_
 
 Download an EULA file
 
-`GET /api/v1/fleet/mdm/apple/setup/eula/{token}`
+`GET /api/v1/fleet/mdm/apple/setup/eula/:token`
 
 #### Parameters
 
@@ -4937,7 +4937,7 @@ For example, a policy might ask “Is Gatekeeper enabled on macOS devices?“ Th
 
 ### Get policy by ID
 
-`GET /api/v1/fleet/global/policies/{id}`
+`GET /api/v1/fleet/global/policies/:id`
 
 #### Parameters
 
@@ -5117,7 +5117,7 @@ Where `query_id` references an existing `query`.
 
 ### Edit policy
 
-`PATCH /api/v1/fleet/global/policies/{policy_id}`
+`PATCH /api/v1/fleet/global/policies/:id`
 
 #### Parameters
 
@@ -5226,13 +5226,13 @@ Team policies work the same as policies, but at the team level.
 
 ### List team policies
 
-`GET /api/v1/fleet/teams/{id}/policies`
+`GET /api/v1/fleet/teams/:id/policies`
 
 #### Parameters
 
 | Name               | Type    | In   | Description                                                                                                   |
 | ------------------ | ------- | ---- | ------------------------------------------------------------------------------------------------------------- |
-| id                 | integer | url  | Required. Defines what team ID to operate on                                                                            |
+| id                 | integer | path  | **Required.** Defines what team ID to operate on                                                                            |
 | page                    | integer | query | Page number of the results to fetch.                                                                                                                                                                                                                                                                                                        |
 | per_page                | integer | query | Results per page. |
 #### Example
@@ -5305,11 +5305,12 @@ Team policies work the same as policies, but at the team level.
 
 ### Count team policies
 
-`GET /api/v1/fleet/team/{team_id}/policies/count`
+`GET /api/v1/fleet/team/:team_id/policies/count`
 
 #### Parameters
 | Name               | Type    | In   | Description                                                                                                   |
 | ------------------ | ------- | ---- | ------------------------------------------------------------------------------------------------------------- |
+| team_id                 | integer | path  | **Required.** Defines what team ID to operate on   
 | query                 | string | query | Search query keywords. Searchable fields include `name`. |
 
 #### Example
@@ -5330,14 +5331,14 @@ Team policies work the same as policies, but at the team level.
 
 ### Get team policy by ID
 
-`GET /api/v1/fleet/teams/{team_id}/policies/{id}`
+`GET /api/v1/fleet/teams/:team_id/policies/:policy_id`
 
 #### Parameters
 
 | Name               | Type    | In   | Description                                                                                                   |
 | ------------------ | ------- | ---- | ------------------------------------------------------------------------------------------------------------- |
-| team_id            | integer | url  | Defines what team ID to operate on                                                                            |
-| id                 | integer | path | **Required.** The policy's ID.                                                                                |
+| team_id            | integer | path  | **Required.** Defines what team ID to operate on                                                                            |
+| policy_id                 | integer | path | **Required.** The policy's ID.                                                                                |
 
 #### Example
 
@@ -5373,13 +5374,13 @@ Team policies work the same as policies, but at the team level.
 
 The semantics for creating a team policy are the same as for global policies, see [Add policy](#add-policy).
 
-`POST /api/v1/fleet/teams/{team_id}/policies`
+`POST /api/v1/fleet/teams/:id/policies`
 
 #### Parameters
 
 | Name        | Type    | In   | Description                          |
 | ----------  | ------- | ---- | ------------------------------------ |
-| team_id     | integer | url  | Defines what team ID to operate on.  |
+| id         | integer | path | Defines what team ID to operate on.  |
 | name        | string  | body | The query's name.                    |
 | query       | string  | body | The query in SQL.                    |
 | description | string  | body | The query's description.             |
@@ -5435,13 +5436,13 @@ Either `query` or `query_id` must be provided.
 
 ### Remove team policies
 
-`POST /api/v1/fleet/teams/{team_id}/policies/delete`
+`POST /api/v1/fleet/teams/:team_id/policies/delete`
 
 #### Parameters
 
 | Name     | Type    | In   | Description                                       |
 | -------- | ------- | ---- | ------------------------------------------------- |
-| team_id  | integer | url  | Defines what team ID to operate on                |
+| team_id  | integer | path  | **Required.** Defines what team ID to operate on                |
 | ids      | list    | body | **Required.** The IDs of the policies to delete.  |
 
 #### Example
@@ -5468,7 +5469,7 @@ Either `query` or `query_id` must be provided.
 
 ### Edit team policy
 
-`PATCH /api/v1/fleet/teams/{team_id}/policies/{policy_id}`
+`PATCH /api/v1/fleet/teams/:team_id/policies/:policy_id`
 
 #### Parameters
 
@@ -5651,7 +5652,7 @@ Returns a list of global queries or team queries.
 
 Returns the query specified by ID.
 
-`GET /api/v1/fleet/queries/{id}`
+`GET /api/v1/fleet/queries/:id`
 
 #### Parameters
 
@@ -5714,7 +5715,7 @@ Returns the query specified by ID.
 
 Returns the query report specified by ID.
 
-`GET /api/v1/fleet/queries/{id}/report`
+`GET /api/v1/fleet/queries/:id/report`
 
 #### Parameters
 
@@ -5871,7 +5872,7 @@ Creates a global query or team query.
 
 Modifies the query specified by ID.
 
-`PATCH /api/v1/fleet/queries/{id}`
+`PATCH /api/v1/fleet/queries/:id`
 
 #### Parameters
 
@@ -5944,7 +5945,7 @@ Modifies the query specified by ID.
 
 Deletes the query specified by name.
 
-`DELETE /api/v1/fleet/queries/{name}`
+`DELETE /api/v1/fleet/queries/:name`
 
 #### Parameters
 
@@ -5955,7 +5956,7 @@ Deletes the query specified by name.
 
 #### Example
 
-`DELETE /api/v1/fleet/queries/{name}`
+`DELETE /api/v1/fleet/queries/foo`
 
 ##### Default response
 
@@ -5966,7 +5967,7 @@ Deletes the query specified by name.
 
 Deletes the query specified by ID.
 
-`DELETE /api/v1/fleet/queries/id/{id}`
+`DELETE /api/v1/fleet/queries/id/:id`
 
 #### Parameters
 
@@ -6257,7 +6258,7 @@ None.
 > The schedule API endpoints are deprecated as of Fleet 4.35. They are maintained for backwards compatibility.
 > Please use the [queries](#queries) endpoints, which as of 4.35 have attributes such as `interval` and `platform` that enable scheduling.
 
-`PATCH /api/v1/fleet/global/schedule/{id}`
+`PATCH /api/v1/fleet/global/schedule/:id`
 
 #### Parameters
 
@@ -6313,7 +6314,7 @@ None.
 > The schedule API endpoints are deprecated as of Fleet 4.35. They are maintained for backwards compatibility.
 > Please use the [queries](#queries) endpoints, which as of 4.35 have attributes such as `interval` and `platform` that enable scheduling.
 
-`DELETE /api/v1/fleet/global/schedule/{id}`
+`DELETE /api/v1/fleet/global/schedule/:id`
 
 #### Parameters
 
@@ -6347,7 +6348,7 @@ This allows you to easily configure scheduled queries that will impact a whole t
 > The schedule API endpoints are deprecated as of Fleet 4.35. They are maintained for backwards compatibility.
 > Please use the [queries](#queries) endpoints, which as of 4.35 have attributes such as `interval` and `platform` that enable scheduling.
 
-`GET /api/v1/fleet/teams/{id}/schedule`
+`GET /api/v1/fleet/teams/:id/schedule`
 
 #### Parameters
 
@@ -6427,7 +6428,7 @@ This allows you to easily configure scheduled queries that will impact a whole t
 > The schedule API endpoints are deprecated as of Fleet 4.35. They are maintained for backwards compatibility.
 > Please use the [queries](#queries) endpoints, which as of 4.35 have attributes such as `interval` and `platform` that enable scheduling.
 
-`POST /api/v1/fleet/teams/{id}/schedule`
+`POST /api/v1/fleet/teams/:id/schedule`
 
 #### Parameters
 
@@ -6485,7 +6486,7 @@ This allows you to easily configure scheduled queries that will impact a whole t
 > The schedule API endpoints are deprecated as of Fleet 4.35. They are maintained for backwards compatibility.
 > Please use the [queries](#queries) endpoints, which as of 4.35 have attributes such as `interval` and `platform` that enable scheduling.
 
-`PATCH /api/v1/fleet/teams/{team_id}/schedule/{scheduled_query_id}`
+`PATCH /api/v1/fleet/teams/:team_id/schedule/:scheduled_query_id`
 
 #### Parameters
 
@@ -6542,7 +6543,7 @@ This allows you to easily configure scheduled queries that will impact a whole t
 > The schedule API endpoints are deprecated as of Fleet 4.35. They are maintained for backwards compatibility.
 > Please use the [queries](#queries) endpoints, which as of 4.35 have attributes such as `interval` and `platform` that enable scheduling.
 
-`DELETE /api/v1/fleet/teams/{team_id}/schedule/{scheduled_query_id}`
+`DELETE /api/v1/fleet/teams/:team_id/schedule/:scheduled_query_id`
 
 #### Parameters
 
@@ -6624,7 +6625,7 @@ Gets the result of a script that was executed.
 
 #### Example
 
-`GET /api/v1/fleet/scripts/results/{execution_id}`
+`GET /api/v1/fleet/scripts/results/:execution_id`
 
 ##### Default Response
 
@@ -6704,7 +6705,7 @@ _Available in Fleet Premium_
 
 Deletes an existing script.
 
-`DELETE /api/v1/fleet/scripts/{id}`
+`DELETE /api/v1/fleet/scripts/:id`
 
 #### Parameters
 
@@ -6771,7 +6772,7 @@ _Available in Fleet Premium_
 
 _Available in Fleet Premium_
 
-`GET /api/v1/fleet/scripts/{id}`
+`GET /api/v1/fleet/scripts/:id`
 
 #### Parameters
 
@@ -6823,7 +6824,7 @@ echo "hello"
 
 _Available in Fleet Premium_
 
-`GET /api/v1/fleet/hosts/{id}/scripts`
+`GET /api/v1/fleet/hosts/:id/scripts`
 
 #### Parameters
 
@@ -6834,7 +6835,7 @@ _Available in Fleet Premium_
 
 #### Example
 
-`GET /api/v1/fleet/hosts/{id}/scripts`
+`GET /api/v1/fleet/hosts/123/scripts`
 
 ##### Default response
 
@@ -6890,7 +6891,7 @@ _Available in Fleet Premium_
 
 Returns the session information for the session specified by ID.
 
-`GET /api/v1/fleet/sessions/{id}`
+`GET /api/v1/fleet/sessions/:id`
 
 #### Parameters
 
@@ -6918,7 +6919,7 @@ Returns the session information for the session specified by ID.
 
 Deletes the session specified by ID. When the user associated with the session next attempts to access Fleet, they will be asked to log in.
 
-`DELETE /api/v1/fleet/sessions/{id}`
+`DELETE /api/v1/fleet/sessions/:id`
 
 #### Parameters
 
@@ -7304,7 +7305,7 @@ _Available in Fleet Premium_
 
 _Available in Fleet Premium_
 
-`GET /api/v1/fleet/teams/{id}`
+`GET /api/v1/fleet/teams/:id`
 
 #### Parameters
 
@@ -7456,7 +7457,7 @@ _Available in Fleet Premium_
 
 _Available in Fleet Premium_
 
-`PATCH /api/v1/fleet/teams/{id}`
+`PATCH /api/v1/fleet/teams/:id`
 
 #### Parameters
 
@@ -7635,7 +7636,7 @@ _Available in Fleet Premium_
 
 _Available in Fleet Premium_
 
-`POST /api/v1/fleet/teams/{id}/agent_options`
+`POST /api/v1/fleet/teams/:id/agent_options`
 
 #### Parameters
 
@@ -7724,7 +7725,7 @@ _Available in Fleet Premium_
 
 _Available in Fleet Premium_
 
-`DELETE /api/v1/fleet/teams/{id}`
+`DELETE /api/v1/fleet/teams/:id`
 
 #### Parameters
 
@@ -8135,7 +8136,7 @@ By default, the user will be forced to reset its password upon first login.
 
 Returns all information about a specific user.
 
-`GET /api/v1/fleet/users/{id}`
+`GET /api/v1/fleet/users/:id`
 
 #### Parameters
 
@@ -8195,7 +8196,7 @@ Returns all information about a specific user.
 
 ### Modify user
 
-`PATCH /api/v1/fleet/users/{id}`
+`PATCH /api/v1/fleet/users/:id`
 
 #### Parameters
 
@@ -8303,7 +8304,7 @@ Returns all information about a specific user.
 
 Delete the specified user from Fleet.
 
-`DELETE /api/v1/fleet/users/{id}`
+`DELETE /api/v1/fleet/users/:id`
 
 #### Parameters
 
@@ -8324,7 +8325,7 @@ Delete the specified user from Fleet.
 
 The selected user is logged out of Fleet and required to reset their password during the next attempt to log in. This also revokes all active Fleet API tokens for this user. Returns the user object.
 
-`POST /api/v1/fleet/users/{id}/require_password_reset`
+`POST /api/v1/fleet/users/:id/require_password_reset`
 
 #### Parameters
 
@@ -8335,7 +8336,7 @@ The selected user is logged out of Fleet and required to reset their password du
 
 #### Example
 
-`POST /api/v1/fleet/users/{id}/require_password_reset`
+`POST /api/v1/fleet/users/123/require_password_reset`
 
 ##### Request body
 
@@ -8370,7 +8371,7 @@ The selected user is logged out of Fleet and required to reset their password du
 
 Returns a list of the user's sessions in Fleet.
 
-`GET /api/v1/fleet/users/{id}/sessions`
+`GET /api/v1/fleet/users/:id/sessions`
 
 #### Parameters
 
@@ -8410,7 +8411,7 @@ None.
 
 Deletes the selected user's sessions in Fleet. Also deletes the user's API token.
 
-`DELETE /api/v1/fleet/users/{id}/sessions`
+`DELETE /api/v1/fleet/users/:id/sessions`
 
 #### Parameters
 
@@ -8488,7 +8489,7 @@ Returns information about the current state of the database; valid keys are:
 - `innodb-status`: returns InnoDB status information.
 - `process-list`: returns running processes (queries, etc).
 
-`GET /debug/db/{key}`
+`GET /debug/db/:key`
 
 #### Parameters
 
@@ -8500,7 +8501,7 @@ Returns runtime profiling data of the server in the format expected by `go tools
 
 Valid keys are: `cmdline`, `profile`, `symbol` and `trace`.
 
-`GET /debug/pprof/{key}`
+`GET /debug/pprof/:key`
 
 #### Parameters
 None.


### PR DESCRIPTION
Makes parameter formatting in documented REST API paths consistent.
Previously, we were using a mix of `/foo/:parameter/bar` and `/foo/{parameter}/bar`. This updates all URLs to use `:` instead of `{…}`.

Also, opportunistically fixed some other inconsistent formatting I noticed in a couple places.