### PR TITLE
Bug-15430 change timeout errror code to 408

### DIFF
--- a/changes/15430-change-script-timeout-error-code-to-408
+++ b/changes/15430-change-script-timeout-error-code-to-408
@@ -1,0 +1,1 @@
+- POST /api/v1/fleet/scripts/run/sync timeout (longer than 60 seconds) will now return error code: 408 instead of 504

--- a/server/service/scripts.go
+++ b/server/service/scripts.go
@@ -64,7 +64,10 @@ type runScriptSyncResponse struct {
 func (r runScriptSyncResponse) error() error { return r.Err }
 func (r runScriptSyncResponse) Status() int {
 	if r.HostTimeout {
-		return http.StatusGatewayTimeout
+		// The more proper response for a timeout on the server would be: StatusGatewayTimeout
+		// However, as described in https://github.com/fleetdm/fleet/issues/15430 we will send 408 response.
+		// StatusRequestTimeout = 408 // RFC 9110, 15.5.9
+		return http.StatusRequestTimeout
 	}
 	return http.StatusOK
 }

--- a/server/service/scripts.go
+++ b/server/service/scripts.go
@@ -64,8 +64,8 @@ type runScriptSyncResponse struct {
 func (r runScriptSyncResponse) error() error { return r.Err }
 func (r runScriptSyncResponse) Status() int {
 	if r.HostTimeout {
-		// The more proper response for a timeout on the server would be: StatusGatewayTimeout
-		// However, as described in https://github.com/fleetdm/fleet/issues/15430 we will send 408 response.
+		// The more proper response for a timeout on the server would be: StatusGatewayTimeout = 504
+		// However, as described in https://github.com/fleetdm/fleet/issues/15430 we will send:
 		// StatusRequestTimeout = 408 // RFC 9110, 15.5.9
 		return http.StatusRequestTimeout
 	}

--- a/server/service/scripts.go
+++ b/server/service/scripts.go
@@ -67,6 +67,7 @@ func (r runScriptSyncResponse) Status() int {
 		// The more proper response for a timeout on the server would be: StatusGatewayTimeout = 504
 		// However, as described in https://github.com/fleetdm/fleet/issues/15430 we will send:
 		// StatusRequestTimeout = 408 // RFC 9110, 15.5.9
+		// See: https://github.com/fleetdm/fleet/issues/15430#issuecomment-1847345617
 		return http.StatusRequestTimeout
 	}
 	return http.StatusOK


### PR DESCRIPTION
POST /api/v1/fleet/scripts/run/sync timeout (longer than 60 seconds) will now return error code: 408 instead of 504

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [ ] Manual QA for all new/changed functionality
