### PR TITLE
Website: Update macOS link on /try-fleet

### DIFF
--- a/website/views/pages/try-fleet/explore-data.ejs
+++ b/website/views/pages/try-fleet/explore-data.ejs
@@ -5,7 +5,7 @@
       <p>See live data collected from a real  device enrolled in Fleet.</p>
     </div>
     <div class="d-flex flex-md-row flex-column justify-content-center align-items-center">
-      <a href="/try-fleet/explore-data/macos/apps">
+      <a href="/try-fleet/explore-data/macos/account_policy_data">
       <div purpose="explore-data-card" class="card">
         <div purpose="card-body">
           <img src="/images/logo-macos-muted-48x60@2x.png" alt="macOS logo">


### PR DESCRIPTION
Changes:
- Updated the link to the macOS host on /try-fleet/explore-data to go to results for the `account_policy_data` table.