### PR TITLE
Use exponential backoff in device_client request

### DIFF
--- a/server/service/device_client.go
+++ b/server/service/device_client.go
@@ -76,7 +76,7 @@ func (dc *DeviceClient) request(verb, pathFmt, token, query string, params inter
 			return reqErr
 		}
 
-		delay := time.Duration(attempt) * time.Second
+		delay := time.Duration(attempt*attempt) * time.Second
 		log.Debug().Msgf("retrying API error in %s", delay)
 		time.Sleep(delay)
 		newToken := dc.invalidTokenRetryFunc()


### PR DESCRIPTION
Issue found with code inspection. We should use exponential backoff when doing retries. The fleet server may be having issues, and reducing traffic from agents is helpful in those cases.
