### PR TITLE
Fix link on Windows automatic enrollment page

### DIFF
--- a/frontend/pages/admin/IntegrationsPage/cards/AutomaticEnrollment/WindowsAutomaticEnrollmentPage/WindowsAutomaticEnrollmentPage.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/AutomaticEnrollment/WindowsAutomaticEnrollmentPage/WindowsAutomaticEnrollmentPage.tsx
@@ -50,7 +50,7 @@ const WindowsAutomaticEnrollmentPage = () => {
             <CustomLink
               newTab
               text="Sign in to Azure portal"
-              url="https://portal.azure.com"
+              url="https://fleetdm.com/sign-in-to/microsoft-automatic-enrollment-tool"
             />
           </li>
           <li>

--- a/frontend/pages/admin/IntegrationsPage/cards/AutomaticEnrollment/WindowsAutomaticEnrollmentPage/WindowsAutomaticEnrollmentPage.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/AutomaticEnrollment/WindowsAutomaticEnrollmentPage/WindowsAutomaticEnrollmentPage.tsx
@@ -50,7 +50,7 @@ const WindowsAutomaticEnrollmentPage = () => {
             <CustomLink
               newTab
               text="Sign in to Azure portal"
-              url="portal.azure.com"
+              url="https://portal.azure.com"
             />
           </li>
           <li>

--- a/website/config/routes.js
+++ b/website/config/routes.js
@@ -511,6 +511,7 @@ module.exports.routes = {
   // These are external links not maintained by Fleet. We can point the Fleet UI to redirects here instead of the
   // original sources to help avoid broken links.
   'GET /learn-more-about/chromeos-updates': 'https://support.google.com/chrome/a/answer/6220366',
+  'GET /sign-in-to/microsoft-automatic-enrollment-tool': 'https://portal.azure.com'
 
   // Sitemap
   // =============================================================================================================

--- a/website/config/routes.js
+++ b/website/config/routes.js
@@ -511,7 +511,7 @@ module.exports.routes = {
   // These are external links not maintained by Fleet. We can point the Fleet UI to redirects here instead of the
   // original sources to help avoid broken links.
   'GET /learn-more-about/chromeos-updates': 'https://support.google.com/chrome/a/answer/6220366',
-  'GET /sign-in-to/microsoft-automatic-enrollment-tool': 'https://portal.azure.com'
+  'GET /sign-in-to/microsoft-automatic-enrollment-tool': 'https://portal.azure.com',
 
   // Sitemap
   // =============================================================================================================


### PR DESCRIPTION
For this bug: #15566

- Add redirect so that we can change the link later w/o breaking it
