### PR TITLE
Revert "Enforce codecov requirements"

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,22 +1,16 @@
 coverage:
   status:
-    project:
-      default:
-        target: auto  # aim for the same coverage as the base of the PR
-        threshold: 1%  # allow a decrease of up to 1%
-    patch:
-      default:
-        target: auto  # aim for the same coverage as the base of the PR
-        threshold: 1%  # allow a decrease of up to 1%
+    project: false
+    patch: false
 
 flag_management:
   default_rules:
     carryforward: true
     statuses:
       - type: project
-        informational: false  # change this to true if you do not want to enforce covergae requirement
+        informational: true
       - type: patch
-        informational: false  # change this to true if you do not want to enforce covergae requirement
+        informational: true
   individual_flags:
     - name: backend
       paths:


### PR DESCRIPTION
Looks like ` codecov` is [still not correctly picking up all tests](https://fleetdm.slack.com/archives/C019WG4GH0A/p1702392845887739?thread_ts=1702320827.667749&cid=C019WG4GH0A). As long as we know we're adding tests, this isn't a high priority right now. We can dig into it more next year.  

Reverts fleetdm/fleet#13931