### PR TITLE
Reduce server load for fleetd upgrade

### DIFF
--- a/changes/15540-reduce-server-load-from-fleetd-upgrade
+++ b/changes/15540-reduce-server-load-from-fleetd-upgrade
@@ -1,0 +1,1 @@
+Added fleet/device/{token}/ping endpoint to be used by agents to check their token.

--- a/docs/Contributing/API-for-contributors.md
+++ b/docs/Contributing/API-for-contributors.md
@@ -2316,6 +2316,24 @@ Same as [Get host's mobile device management and Munki information](https://flee
 | ----- | ------ | ---- | ---------------------------------- |
 | token | string | path | The device's authentication token. |
 
+#### Ping Server with Device Token
+Ping the server. OK response expected if the device token is still valid.
+
+`HEAD /api/v1/fleet/device/{token}/ping`
+
+##### Parameters
+
+| Name  | Type   | In   | Description                        |
+| ----- | ------ | ---- | ---------------------------------- |
+| token | string | path | The device's authentication token. |
+
+##### Example
+
+`HEAD /api/v1/fleet/device/abcdef012456789/ping`
+
+##### Default response
+
+`Status: 200`
 
 #### Get Fleet Desktop information
 _Available in Fleet Premium_

--- a/orbit/changes/15540-reduce-server-load-from-fleetd-upgrade
+++ b/orbit/changes/15540-reduce-server-load-from-fleetd-upgrade
@@ -1,0 +1,4 @@
+At fleetd startup/upgrade, reduced the number of API calls to the server.
+- Removed call to fleet/orbit/device_token unless token needs to be updated.
+- Changed call to fleet/device/{token}/desktop with a less resource intensive call to fleet/device/{token}/ping
+- Removed call to fleet/orbit/ping

--- a/server/fleet/capabilities.go
+++ b/server/fleet/capabilities.go
@@ -53,6 +53,15 @@ func (c CapabilityMap) Has(capability Capability) bool {
 	return ok
 }
 
+// Copy copies the capabilities from another map to this map.
+func (c CapabilityMap) Copy(from CapabilityMap) {
+	mu.Lock()
+	defer mu.Unlock()
+	for capability := range from {
+		c[capability] = struct{}{}
+	}
+}
+
 // The following are the capabilities that Fleet supports. These can be used by
 // the Fleet server, Orbit or Fleet Desktop to communicate that a given feature
 // is supported.

--- a/server/service/device_client.go
+++ b/server/service/device_client.go
@@ -137,7 +137,14 @@ func (dc *DeviceClient) BrowserDeviceURL(token string) string {
 // CheckToken checks if a token is valid by making an authenticated request to
 // the server
 func (dc *DeviceClient) CheckToken(token string) error {
-	_, err := dc.DesktopSummary(token)
+	verb, path := "HEAD", "/api/latest/fleet/device/%s/ping"
+	err := dc.request(verb, path, token, "", nil, nil)
+
+	if errors.As(err, &notFoundErr{}) {
+		// notFound is ok, it means an old server without the auth ping endpoint,
+		// so we fall back to previously-used endpoint
+		_, err = dc.DesktopSummary(token)
+	}
 	return err
 }
 

--- a/server/service/devices.go
+++ b/server/service/devices.go
@@ -26,6 +26,14 @@ import (
 
 type devicePingRequest struct{}
 
+type deviceAuthPingRequest struct {
+	Token string `url:"token"`
+}
+
+func (r *deviceAuthPingRequest) deviceAuthToken() string {
+	return r.Token
+}
+
 type devicePingResponse struct{}
 
 func (r devicePingResponse) error() error { return nil }

--- a/server/service/handler.go
+++ b/server/service/handler.go
@@ -587,6 +587,9 @@ func attachFleetAPIRoutes(r *mux.Router, svc fleet.Service, config config.FleetC
 		errorLimiter.Limit("get_fleet_desktop", desktopQuota),
 	).GET("/api/_version_/fleet/device/{token}/desktop", getFleetDesktopEndpoint, getFleetDesktopRequest{})
 	de.WithCustomMiddleware(
+		errorLimiter.Limit("ping_device_auth", desktopQuota),
+	).HEAD("/api/_version_/fleet/device/{token}/ping", devicePingEndpoint, deviceAuthPingRequest{})
+	de.WithCustomMiddleware(
 		errorLimiter.Limit("refetch_device_host", desktopQuota),
 	).POST("/api/_version_/fleet/device/{token}/refetch", refetchDeviceHostEndpoint, refetchDeviceHostRequest{})
 	de.WithCustomMiddleware(

--- a/server/service/integration_core_test.go
+++ b/server/service/integration_core_test.go
@@ -7107,6 +7107,8 @@ func (s *integrationTestSuite) TestOSVersions() {
 }
 
 func (s *integrationTestSuite) TestPingEndpoints() {
+	t := s.T()
+
 	s.DoRaw("HEAD", "/api/fleet/orbit/ping", nil, http.StatusOK)
 	// unauthenticated works too
 	s.DoRawNoAuth("HEAD", "/api/fleet/orbit/ping", nil, http.StatusOK)
@@ -7114,6 +7116,13 @@ func (s *integrationTestSuite) TestPingEndpoints() {
 	s.DoRaw("HEAD", "/api/fleet/device/ping", nil, http.StatusOK)
 	// unauthenticated works too
 	s.DoRawNoAuth("HEAD", "/api/fleet/device/ping", nil, http.StatusOK)
+
+	// device authenticated ping
+	createHostAndDeviceToken(t, s.ds, "ping-token")
+	s.DoRaw("HEAD", fmt.Sprintf("/api/v1/fleet/device/%s/ping", "ping-token"), nil, http.StatusOK)
+	s.DoRawNoAuth("HEAD", fmt.Sprintf("/api/v1/fleet/device/%s/ping", "ping-token"), nil, http.StatusOK)
+	s.DoRaw("HEAD", fmt.Sprintf("/api/v1/fleet/device/%s/ping", "bozo-token"), nil, http.StatusUnauthorized)
+	s.DoRawNoAuth("HEAD", fmt.Sprintf("/api/v1/fleet/device/%s/ping", "bozo-token"), nil, http.StatusUnauthorized)
 }
 
 func (s *integrationTestSuite) TestMDMNotConfiguredEndpoints() {


### PR DESCRIPTION
📺 Loom: https://www.loom.com/share/9e17848963574af3aa10d426b450bcd0?sid=f8078293-c7e1-4864-a8a3-4cec996971f5

#15476 
#15540 
#15542

After upgrading fleetd, customer-blanco saw a spike in traffic and a spike in DB connections. These fixes attempt to reduce the traffic and DB load when fleetd is upgraded.

On the server, added fleet/device/{token}/ping endpoint to be used by agents to check their token.

On the agent:
- Removed call to fleet/orbit/device_token unless token needs to be updated.
- Changed call to fleet/device/{token}/desktop with a less resource intensive call to fleet/device/{token}/ping
- Removed call to fleet/orbit/ping

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [x] Manual QA for all new/changed functionality
  - For Orbit and Fleet Desktop changes:
    - [x] Manual QA must be performed in the three main OSs, macOS, Windows and Linux.
    - [x] Auto-update manual QA, from released version of component to new version (see [tools/tuf/test](../tools/tuf/test/README.md)).
