### PR TITLE
UI – Fix 2 small unreleased bugs

### DIFF
--- a/frontend/pages/hosts/details/HostQueryReport/HQRTable/HQRTable.tsx
+++ b/frontend/pages/hosts/details/HostQueryReport/HQRTable/HQRTable.tsx
@@ -53,7 +53,8 @@ const HQRTable = ({
               ? `'${queryName}' query report results for host '${hostName}'`
               : DEFAULT_CSV_TITLE
           ),
-          columnConfigs
+          columnConfigs,
+          true
         )
       );
     };

--- a/frontend/pages/hosts/details/HostQueryReport/HostQueryReport.tsx
+++ b/frontend/pages/hosts/details/HostQueryReport/HostQueryReport.tsx
@@ -90,7 +90,6 @@ const HostQueryReport = ({
     discard_data: queryDiscardData,
   } = queryResponse || {};
 
-  // TODO - finalize local setting reroute conditions
   // previous reroute can be done before API call, not this one, hence 2
   if (queryDiscardData) {
     router.push(PATHS.HOST_QUERIES(hostId));

--- a/frontend/pages/queries/ManageQueriesPage/ManageQueriesPage.tsx
+++ b/frontend/pages/queries/ManageQueriesPage/ManageQueriesPage.tsx
@@ -124,6 +124,16 @@ const ManageQueriesPage = ({
   const [showInheritedQueries, setShowInheritedQueries] = useState(false);
   const [isUpdatingAutomations, setIsUpdatingAutomations] = useState(false);
 
+  const filterGlobalQueriesForObserverUI = (queries: any) => {
+    if (isGlobalObserver) {
+      return queries
+        .filter((q: ISchedulableQuery) => q.observer_can_run)
+        .map(enhanceQuery);
+    }
+
+    return queries.map(enhanceQuery);
+  };
+
   const {
     data: curTeamEnhancedQueries,
     error: curTeamQueriesError,
@@ -137,15 +147,9 @@ const ManageQueriesPage = ({
   >(
     [{ scope: "queries", teamId: teamIdForApi }],
     ({ queryKey: [{ teamId }] }) =>
-      queriesAPI.loadAll(teamId).then(({ queries }) => {
-        if (isGlobalObserver) {
-          return queries
-            .filter((q: ISchedulableQuery) => q.observer_can_run)
-            .map(enhanceQuery);
-        }
-
-        return queries.map(enhanceQuery);
-      }),
+      queriesAPI
+        .loadAll(teamId)
+        .then(({ queries }) => filterGlobalQueriesForObserverUI(queries)),
     {
       refetchOnWindowFocus: false,
       enabled: isRouteOk,
@@ -167,9 +171,9 @@ const ManageQueriesPage = ({
   >(
     [{ scope: "queries", teamId: API_ALL_TEAMS_ID }],
     ({ queryKey: [{ teamId }] }) =>
-      queriesAPI.loadAll(teamId).then(({ queries }) => {
-        return queries.map(enhanceQuery);
-      }),
+      queriesAPI
+        .loadAll(teamId)
+        .then(({ queries }) => filterGlobalQueriesForObserverUI(queries)),
     {
       refetchOnWindowFocus: false,
       enabled: isRouteOk && isAnyTeamSelected,

--- a/frontend/utilities/generate_csv/index.ts
+++ b/frontend/utilities/generate_csv/index.ts
@@ -18,13 +18,14 @@ export const generateCSVFilename = (descriptor: string) => {
 export const generateCSVQueryResults = (
   rows: Row[],
   filename: string,
-  tableHeaders: Column[] | string[]
+  tableHeaders: Column[] | string[],
+  omitHostDisplayName?: boolean
 ) => {
   return new global.window.File(
     [
       convertToCSV({
         objArray: rows.map((r) => r.original),
-        fieldSortFunc: reorderCSVFields,
+        fieldSortFunc: omitHostDisplayName ? undefined : reorderCSVFields,
         tableHeaders,
       }),
     ],


### PR DESCRIPTION
Fix bugs where:
- global queries cache would be set unfiltered and then overridden filtered as desired – filtered them in the same way whether fetched as inherited or current team
- avoid blindly adding the `host_display_name` column to query report exports if not desired