### PR TITLE
Adjust tooltip style for query page side panel

### DIFF
--- a/frontend/components/side_panels/QuerySidePanel/QueryTableColumns/ColumnListItem/_styles.scss
+++ b/frontend/components/side_panels/QuerySidePanel/QueryTableColumns/ColumnListItem/_styles.scss
@@ -23,6 +23,12 @@
       max-width: 180px;
       overflow-wrap: anywhere;
     }
+
+    .component__tooltip-wrapper__underline {
+      border-bottom: none;
+      text-decoration: underline dashed $ui-fleet-black-50;
+      text-underline-offset: 5px;
+    }
   }
 
   // this is to override the tooltip text style from TooltipWrapper. When we


### PR DESCRIPTION
Issue #14526 

Before:

<img width="656" alt="Screenshot 2023-12-12 at 6 09 16 PM" src="https://github.com/fleetdm/fleet/assets/73313222/b6b9f8d6-86e4-48e0-b838-ad5ada1fb9ab">


After:

<img width="344" alt="Screenshot 2023-12-12 at 6 05 13 PM" src="https://github.com/fleetdm/fleet/assets/73313222/c3604cc3-db96-4c05-96d4-230e26f7cfe2">
<img width="344" alt="Screenshot 2023-12-12 at 6 04 17 PM" src="https://github.com/fleetdm/fleet/assets/73313222/2d0b87b7-3781-4d87-b152-827c05f43553">
