### PR TITLE
UI – render all global queries on queries page

### DIFF
--- a/changes/show-all-global-queries-for-global-users
+++ b/changes/show-all-global-queries-for-global-users
@@ -1,0 +1,2 @@
+- Global observers and global observers+ are now shown all global queries on the Queries page, now
+  including those that are not marked "Observers can run"

--- a/frontend/pages/queries/ManageQueriesPage/ManageQueriesPage.tsx
+++ b/frontend/pages/queries/ManageQueriesPage/ManageQueriesPage.tsx
@@ -124,16 +124,6 @@ const ManageQueriesPage = ({
   const [showInheritedQueries, setShowInheritedQueries] = useState(false);
   const [isUpdatingAutomations, setIsUpdatingAutomations] = useState(false);
 
-  const filterGlobalQueriesForObserverUI = (queries: any) => {
-    if (isGlobalObserver) {
-      return queries
-        .filter((q: ISchedulableQuery) => q.observer_can_run)
-        .map(enhanceQuery);
-    }
-
-    return queries.map(enhanceQuery);
-  };
-
   const {
     data: curTeamEnhancedQueries,
     error: curTeamQueriesError,
@@ -149,7 +139,7 @@ const ManageQueriesPage = ({
     ({ queryKey: [{ teamId }] }) =>
       queriesAPI
         .loadAll(teamId)
-        .then(({ queries }) => filterGlobalQueriesForObserverUI(queries)),
+        .then(({ queries }) => queries.map(enhanceQuery)),
     {
       refetchOnWindowFocus: false,
       enabled: isRouteOk,
@@ -173,7 +163,7 @@ const ManageQueriesPage = ({
     ({ queryKey: [{ teamId }] }) =>
       queriesAPI
         .loadAll(teamId)
-        .then(({ queries }) => filterGlobalQueriesForObserverUI(queries)),
+        .then(({ queries }) => queries.map(enhanceQuery)),
     {
       refetchOnWindowFocus: false,
       enabled: isRouteOk && isAnyTeamSelected,


### PR DESCRIPTION
## Addresses [this clarification](https://github.com/fleetdm/fleet/issues/14415#issuecomment-1854432825)

- For Observers and Observers+ (that is, all global users), render _all_ global queries, which are returned from the API, instead of filtering out those without "Observer can run"
<img width="998" alt="Screenshot 2023-12-13 at 11 09 02 AM" src="https://github.com/fleetdm/fleet/assets/61553566/e3fd19ba-5907-43c6-a67e-c4f1310b27c5">

- [x] Changes file added for user-visible changes in `changes/`
- [x] Manual QA for all new/changed functionality