### PR TITLE
Fixing Syncml cmd nested command data

### DIFF
--- a/changes/issue-15107-windows-automatic-enrollment
+++ b/changes/issue-15107-windows-automatic-enrollment
@@ -1,0 +1,1 @@
+* Syncml cmd data now supports raw data

--- a/server/fleet/microsoft_mdm.go
+++ b/server/fleet/microsoft_mdm.go
@@ -1001,10 +1001,15 @@ func (cmd SyncMLCmd) DataType() SyncMLDataType {
 }
 
 type CmdItem struct {
-	Source *string `xml:"Source>LocURI,omitempty"`
-	Target *string `xml:"Target>LocURI,omitempty"`
-	Meta   *Meta   `xml:"Meta,omitempty"`
-	Data   *string `xml:"Data"`
+	Source *string     `xml:"Source>LocURI,omitempty"`
+	Target *string     `xml:"Target>LocURI,omitempty"`
+	Meta   *Meta       `xml:"Meta,omitempty"`
+	Data   *RawXmlData `xml:"Data"`
+}
+
+type RawXmlData struct {
+	Attrs   []xml.Attr `xml:",any,attr"`
+	Content string     `xml:",innerxml"`
 }
 
 type Meta struct {
@@ -1334,7 +1339,7 @@ func (cmd *SyncMLCmd) GetTargetData() string {
 	}
 
 	if cmd.Items[0].Data != nil {
-		return *cmd.Items[0].Data
+		return cmd.Items[0].Data.Content
 	}
 
 	return ""

--- a/server/mdm/microsoft/profile_verifier_test.go
+++ b/server/mdm/microsoft/profile_verifier_test.go
@@ -53,7 +53,6 @@ func TestLoopHostMDMLocURIs(t *testing.T) {
 		},
 		got,
 	)
-
 }
 
 func TestHashLocURI(t *testing.T) {
@@ -257,7 +256,7 @@ func TestVerifyHostMDMProfilesHappyPaths(t *testing.T) {
 						CmdID:   uuid.NewString(),
 						CmdRef:  &ref,
 						Items: []fleet.CmdItem{
-							{Target: ptr.String(p.LocURI), Data: ptr.String(p.Data)},
+							{Target: ptr.String(p.LocURI), Data: &fleet.RawXmlData{Content: p.Data}},
 						},
 					})
 				}

--- a/server/service/integration_mdm_test.go
+++ b/server/service/integration_mdm_test.go
@@ -1007,7 +1007,7 @@ func (s *integrationMDMTestSuite) TestWindowsProfileRetries() {
 						CmdID:   uuid.NewString(),
 						CmdRef:  &ref,
 						Items: []mdm_types.CmdItem{
-							{Target: ptr.String(p.LocURI), Data: ptr.String(p.Data)},
+							{Target: ptr.String(p.LocURI), Data: &fleet.RawXmlData{Content: p.Data}},
 						},
 					})
 				}
@@ -7873,7 +7873,7 @@ func (s *integrationMDMTestSuite) TestWindowsMDM() {
 		Items: []fleet.CmdItem{
 			{
 				Source: ptr.String("./Device/Vendor/MSFT/DMClient/Provider/DEMO%20MDM/SignedEntDMID"),
-				Data:   ptr.String("0"),
+				Data:   &fleet.RawXmlData{Content: "0"},
 			},
 		},
 		CmdID: cmdTwoRespUUID,

--- a/server/service/microsoft_mdm.go
+++ b/server/service/microsoft_mdm.go
@@ -1848,6 +1848,7 @@ func newSyncMLItem(cmdSource *string, cmdTarget *string, cmdDataType *string, cm
 	var metaFormat *mdm_types.MetaAttr
 	var metaType *mdm_types.MetaAttr
 	var meta *mdm_types.Meta
+	var data *mdm_types.RawXmlData
 
 	if cmdDataFormat != nil && len(*cmdDataFormat) > 0 {
 		metaFormat = &mdm_types.MetaAttr{
@@ -1870,9 +1871,15 @@ func newSyncMLItem(cmdSource *string, cmdTarget *string, cmdDataType *string, cm
 		}
 	}
 
+	if cmdDataValue != nil {
+		data = &mdm_types.RawXmlData{
+			Content: *cmdDataValue,
+		}
+	}
+
 	return &mdm_types.CmdItem{
 		Meta:   meta,
-		Data:   cmdDataValue,
+		Data:   data,
 		Target: cmdTarget,
 		Source: cmdSource,
 	}


### PR DESCRIPTION
This relates to #15107 

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [X] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
- [X] Manual QA for all new/changed functionality

