### PR TITLE
update osquery image in db migration testing tool

### DIFF
--- a/test/upgrade/docker-compose.yaml
+++ b/test/upgrade/docker-compose.yaml
@@ -58,7 +58,7 @@ services:
     image: fleetdm/fleet:${FLEET_VERSION_B:-latest}
 
   osquery:
-    image: "osquery/osquery:4.6.0-ubuntu20.04"
+    image: "osquery/osquery:4.7.0-ubuntu20.04"
     volumes:
       - ./fleet.crt:/etc/osquery/fleet.crt
       - ./osquery.flags:/etc/osquery/osquery.flags


### PR DESCRIPTION
In this release we're introducing a query that makes use of `browser_type` which was introduced in a newer osquery version.

In our docs we officially support "the latest" osquery, but doing a soft bump for now.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Added/updated tests
- [x] Manual QA for all new/changed functionality
