### PR TITLE
Update bootstrap package endpoints

### DIFF
--- a/changes/15082-update-download-endpoints
+++ b/changes/15082-update-download-endpoints
@@ -1,0 +1,4 @@
+- Added `GET /mdm/apple/bootstrap/{team_id:[0-9]+}` API endpoint to support getting bootstrap
+  package metadata or downloading bootstrap package.
+- Removed `GET /mdm/apple/bootstrap/{team_id:[0-9]+}/metadata` API endpoint, which is replaced by
+  `GET /mdm/apple/bootstrap/{team_id:[0-9]+}`.

--- a/frontend/pages/ManageControlsPage/SetupExperience/cards/BootstrapPackage/components/BootstrapPackageListItem/BootstrapPackageListItem.tsx
+++ b/frontend/pages/ManageControlsPage/SetupExperience/cards/BootstrapPackage/components/BootstrapPackageListItem/BootstrapPackageListItem.tsx
@@ -1,9 +1,9 @@
 import React from "react";
 import { formatDistanceToNow } from "date-fns";
-import URL_PREFIX from "router/url_prefix";
+import FileSaver from "file-saver";
 
 import { IBootstrapPackageMetadata } from "interfaces/mdm";
-import endpoints from "utilities/endpoints";
+import mdmAPI from "services/entities/mdm";
 
 import Icon from "components/Icon";
 import Button from "components/buttons/Button";
@@ -16,47 +16,17 @@ interface IBootstrapPackageListItemProps {
   onDelete: (bootstrapPackage: IBootstrapPackageMetadata) => void;
 }
 
-interface ITestFormProps {
-  url: string;
-  token: string;
-  className?: string;
-}
-
-/**
- * This component abstracts away the downloading of the package. It implements this
- * with a browser form that calls the correct url to initiate the package download.
- * We do it this way as this allows us to take advantage of the browsers native
- * downloading UI instead of having to handle this in the Fleet UI.
- * TODO: make common component and use here and in DownloadInstallers.tsx.
- */
-const DownloadPackageButton = ({ url, token, className }: ITestFormProps) => {
-  return (
-    <form
-      key="form"
-      method="GET"
-      action={url}
-      target="_self"
-      className={className}
-    >
-      <input type="hidden" name="token" value={token || ""} />
-      <Button
-        variant="text-icon"
-        type="submit"
-        className={`${baseClass}__list-item-button`}
-      >
-        <Icon name="download" />
-      </Button>
-    </form>
-  );
-};
-
 const BootstrapPackageListItem = ({
   bootstrapPackage,
   onDelete,
 }: IBootstrapPackageListItemProps) => {
-  const { origin } = global.window.location;
-  const path = `${endpoints.MDM_BOOTSTRAP_PACKAGE}`;
-  const url = `${origin}${URL_PREFIX}/api${path}`;
+  const onClickDownload = async () => {
+    const fileContent = await mdmAPI.downloadBootstrapPackage(bootstrapPackage);
+    // const formatDate = format(new Date(), "yyyy-MM-dd");
+    // const filename = `${formatDate}_${bootstrapPackage.name}`;
+    const file = new File([fileContent], bootstrapPackage.name);
+    FileSaver.saveAs(file);
+  };
 
   return (
     <div className={baseClass}>
@@ -77,11 +47,14 @@ const BootstrapPackageListItem = ({
       <div
         className={`${baseClass}__value-group ${baseClass}__list-item-actions`}
       >
-        <DownloadPackageButton
+        <Button
           className={`${baseClass}__list-item-button`}
-          url={url}
-          token={bootstrapPackage.token}
-        />
+          variant="text-icon"
+          onClick={onClickDownload}
+        >
+          <Icon name="download" />
+        </Button>
+
         <Button
           className={`${baseClass}__list-item-button`}
           variant="text-icon"

--- a/frontend/services/entities/mdm.ts
+++ b/frontend/services/entities/mdm.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/explicit-module-boundary-types */
 import {
   DiskEncryptionStatus,
+  IBootstrapPackageMetadata,
   IMdmProfile,
   MdmProfileStatus,
 } from "interfaces/mdm";
@@ -152,14 +153,10 @@ const mdmService = {
   },
 
   getBootstrapPackageMetadata: (teamId: number) => {
-    const { MDM_BOOTSTRAP_PACKAGE_METADATA } = endpoints;
-
-    return sendRequest("GET", MDM_BOOTSTRAP_PACKAGE_METADATA(teamId));
+    return sendRequest("GET", endpoints.MDM_BOOTSTRAP_PACKAGE_METADATA(teamId));
   },
 
   uploadBootstrapPackage: (file: File, teamId?: number) => {
-    const { MDM_BOOTSTRAP_PACKAGE } = endpoints;
-
     const formData = new FormData();
     formData.append("package", file);
 
@@ -167,12 +164,24 @@ const mdmService = {
       formData.append("team_id", teamId.toString());
     }
 
-    return sendRequest("POST", MDM_BOOTSTRAP_PACKAGE, formData);
+    return sendRequest(
+      "POST",
+      endpoints.MDM_BOOTSTRAP_PACKAGE_UPLOAD,
+      formData
+    );
+  },
+
+  downloadBootstrapPackage: (
+    params: Pick<IBootstrapPackageMetadata, "team_id" | "token">
+  ) => {
+    return sendRequest("GET", endpoints.MDM_BOOTSTRAP_PACKAGE_DOWNLOAD(params));
   },
 
   deleteBootstrapPackage: (teamId: number) => {
-    const { MDM_BOOTSTRAP_PACKAGE } = endpoints;
-    return sendRequest("DELETE", `${MDM_BOOTSTRAP_PACKAGE}/${teamId}`);
+    return sendRequest(
+      "DELETE",
+      endpoints.MDM_BOOTSTRAP_PACKAGE_DELETE(teamId)
+    );
   },
 
   getBootstrapPackageAggregate: (teamId?: number) => {

--- a/frontend/utilities/endpoints.ts
+++ b/frontend/utilities/endpoints.ts
@@ -1,3 +1,5 @@
+import { IBootstrapPackageMetadata } from "interfaces/mdm";
+
 const API_VERSION = "latest";
 
 export default {
@@ -66,8 +68,17 @@ export default {
     return `/api/mdm/apple/enroll?${query}`;
   },
   MDM_BOOTSTRAP_PACKAGE_METADATA: (teamId: number) =>
-    `/${API_VERSION}/fleet/mdm/apple/bootstrap/${teamId}/metadata`,
-  MDM_BOOTSTRAP_PACKAGE: `/${API_VERSION}/fleet/mdm/apple/bootstrap`,
+    `/${API_VERSION}/fleet/mdm/apple/bootstrap/${teamId}`,
+  MDM_BOOTSTRAP_PACKAGE_DOWNLOAD: ({
+    team_id,
+    token,
+  }: Pick<IBootstrapPackageMetadata, "team_id" | "token">) => {
+    const query = new URLSearchParams({ token, alt: "media" });
+    return `/${API_VERSION}/fleet/mdm/apple/bootstrap/${team_id}?${query}`;
+  },
+  MDM_BOOTSTRAP_PACKAGE_UPLOAD: `/${API_VERSION}/fleet/mdm/apple/bootstrap`,
+  MDM_BOOTSTRAP_PACKAGE_DELETE: (teamId: number) =>
+    `/${API_VERSION}/fleet/mdm/apple/bootstrap/${teamId}`,
   MDM_BOOTSTRAP_PACKAGE_SUMMARY: `/${API_VERSION}/fleet/mdm/apple/bootstrap/summary`,
   MDM_SETUP: `/${API_VERSION}/fleet/mdm/apple/setup`,
   MDM_EULA: (token: string) =>

--- a/server/service/client_mdm.go
+++ b/server/service/client_mdm.go
@@ -55,9 +55,9 @@ func (c *Client) RequestAppleCSR(email, org string) (*fleet.AppleCSR, error) {
 }
 
 func (c *Client) GetBootstrapPackageMetadata(teamID uint, forUpdate bool) (*fleet.MDMAppleBootstrapPackage, error) {
-	verb, path := "GET", fmt.Sprintf("/api/latest/fleet/mdm/apple/bootstrap/%d/metadata", teamID)
-	request := bootstrapPackageMetadataRequest{}
-	var responseBody bootstrapPackageMetadataResponse
+	verb, path := "GET", fmt.Sprintf("/api/latest/fleet/mdm/apple/bootstrap/%d", teamID)
+	request := getBootstrapPackageRequest{}
+	var responseBody getBootstrapPackageResponse
 	var err error
 	if forUpdate {
 		err = c.authenticatedRequestWithQuery(request, verb, path, &responseBody, "for_update=true")

--- a/server/service/handler.go
+++ b/server/service/handler.go
@@ -519,7 +519,7 @@ func attachFleetAPIRoutes(r *mux.Router, svc fleet.Service, config config.FleetC
 
 	// bootstrap-package routes
 	mdmAppleMW.POST("/api/_version_/fleet/mdm/apple/bootstrap", uploadBootstrapPackageEndpoint, uploadBootstrapPackageRequest{})
-	mdmAppleMW.GET("/api/_version_/fleet/mdm/apple/bootstrap/{team_id:[0-9]+}/metadata", bootstrapPackageMetadataEndpoint, bootstrapPackageMetadataRequest{})
+	mdmAppleMW.GET("/api/_version_/fleet/mdm/apple/bootstrap/{team_id:[0-9]+}", getBootstrapPackageEndpoint, getBootstrapPackageRequest{})
 	mdmAppleMW.DELETE("/api/_version_/fleet/mdm/apple/bootstrap/{team_id:[0-9]+}", deleteBootstrapPackageEndpoint, deleteBootstrapPackageRequest{})
 	mdmAppleMW.GET("/api/_version_/fleet/mdm/apple/bootstrap/summary", getMDMAppleBootstrapPackageSummaryEndpoint, getMDMAppleBootstrapPackageSummaryRequest{})
 
@@ -674,7 +674,7 @@ func attachFleetAPIRoutes(r *mux.Router, svc fleet.Service, config config.FleetC
 	neAppleMDM.GET(apple_mdm.EnrollPath, mdmAppleEnrollEndpoint, mdmAppleEnrollRequest{})
 	neAppleMDM.GET(apple_mdm.InstallerPath, mdmAppleGetInstallerEndpoint, mdmAppleGetInstallerRequest{})
 	neAppleMDM.HEAD(apple_mdm.InstallerPath, mdmAppleHeadInstallerEndpoint, mdmAppleHeadInstallerRequest{})
-	neAppleMDM.GET("/api/_version_/fleet/mdm/apple/bootstrap", downloadBootstrapPackageEndpoint, downloadBootstrapPackageRequest{})
+	neAppleMDM.GET("/api/_version_/fleet/mdm/apple/bootstrap/{team_id:[0-9]+}", getBootstrapPackageEndpoint, getBootstrapPackageRequest{})
 	neAppleMDM.GET("/api/_version_/fleet/mdm/apple/setup/eula/{token}", getMDMAppleEULAEndpoint, getMDMAppleEULARequest{})
 
 	// These endpoint are used by Microsoft devices during MDM device enrollment phase


### PR DESCRIPTION
Issue #15668

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [ ] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [ ] Documented any permissions changes (docs/Using Fleet/manage-access.md)
- [ ] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [ ] Added support on fleet's osquery simulator `cmd/osquery-perf` for new osquery data ingestion features.
- [ ] Added/updated tests
- [ ] Manual QA for all new/changed functionality
  - For Orbit and Fleet Desktop changes:
    - [ ] Manual QA must be performed in the three main OSs, macOS, Windows and Linux.
    - [ ] Auto-update manual QA, from released version of component to new version (see [tools/tuf/test](../tools/tuf/test/README.md)).
