### PR TITLE
Website: Update receive-from-github webhook.

### DIFF
--- a/website/api/controllers/webhooks/receive-from-github.js
+++ b/website/api/controllers/webhooks/receive-from-github.js
@@ -429,7 +429,7 @@ module.exports = {
         } else if (!isPRStillDependentOnAndReadyForCeoReview && existingLabels.includes('#g-ceo')) {
           // [?] https://docs.github.com/en/rest/issues/labels?apiVersion=2022-11-28#remove-a-label-from-an-issue
           await sails.helpers.http.del(`https://api.github.com/repos/${owner}/${repo}/issues/${prNumber}/labels/${encodeURIComponent('#g-ceo')}`, {}, baseHeaders)
-          .tolerate({ exit: 'non200Response', raw {statusCode: 404} }, (err)=>{// if the PR has gone missing, swallow the error and warn instead.
+          .tolerate({ exit: 'non200Response', raw: {statusCode: 404} }, (err)=>{// if the PR has gone missing, swallow the error and warn instead.
             sails.log.warn(`When trying to send a request to remove the #g-ceo label from PR #${prNumber} in the ${owner}/${repo} repo, an error occured. Raw error: ${require('util').inspect(err)}`);
           });
         }//ﬁ

--- a/website/api/controllers/webhooks/receive-from-github.js
+++ b/website/api/controllers/webhooks/receive-from-github.js
@@ -413,8 +413,7 @@ module.exports = {
         } else if (!isHandbookPR && existingLabels.includes('#handbook')) {
           // [?] https://docs.github.com/en/rest/issues/labels?apiVersion=2022-11-28#remove-a-label-from-an-issue
           await sails.helpers.http.del(`https://api.github.com/repos/${owner}/${repo}/issues/${prNumber}/labels/${encodeURIComponent('#handbook')}`, {}, baseHeaders)
-          .tolerate('non200Response', (err)=>{
-            // If a label could not be removed, log a warning.
+          .tolerate({ exit: 'non200Response', statusCode: 404 }, (err)=>{// if the PR has gone missing, swallow the error and warn instead.
             sails.log.warn(`When trying to send a request to remove the #handbook label from PR #${prNumber} in the ${owner}/${repo} repo, an error occured. Raw error: ${require('util').inspect(err)}`);
           });
         }//ﬁ
@@ -430,8 +429,7 @@ module.exports = {
         } else if (!isPRStillDependentOnAndReadyForCeoReview && existingLabels.includes('#g-ceo')) {
           // [?] https://docs.github.com/en/rest/issues/labels?apiVersion=2022-11-28#remove-a-label-from-an-issue
           await sails.helpers.http.del(`https://api.github.com/repos/${owner}/${repo}/issues/${prNumber}/labels/${encodeURIComponent('#g-ceo')}`, {}, baseHeaders)
-          .tolerate('non200Response', (err)=>{
-            // If a label could not be removed, log a warning.
+          .tolerate({ exit: 'non200Response', statusCode: 404 }, (err)=>{// if the PR has gone missing, swallow the error and warn instead.
             sails.log.warn(`When trying to send a request to remove the #g-ceo label from PR #${prNumber} in the ${owner}/${repo} repo, an error occured. Raw error: ${require('util').inspect(err)}`);
           });
         }//ﬁ

--- a/website/api/controllers/webhooks/receive-from-github.js
+++ b/website/api/controllers/webhooks/receive-from-github.js
@@ -412,7 +412,11 @@ module.exports = {
           }, baseHeaders);
         } else if (!isHandbookPR && existingLabels.includes('#handbook')) {
           // [?] https://docs.github.com/en/rest/issues/labels?apiVersion=2022-11-28#remove-a-label-from-an-issue
-          await sails.helpers.http.del(`https://api.github.com/repos/${owner}/${repo}/issues/${prNumber}/labels/${encodeURIComponent('#handbook')}`, {}, baseHeaders);
+          await sails.helpers.http.del(`https://api.github.com/repos/${owner}/${repo}/issues/${prNumber}/labels/${encodeURIComponent('#handbook')}`, {}, baseHeaders)
+          .tolerate('non200Response', (err)=>{
+            // If a label could not be removed, log a warning.
+            sails.log.warn(`When trying to send a request to remove the #handbook label from PR #${prNumber} in the ${owner}/${repo} repo, an error occured. Raw error: ${require('util').inspect(err)}`);
+          });
         }//ﬁ
 
         // Add the appropriate label to PRs awaiting review from the CEO so that these PRs show up in kanban.
@@ -425,7 +429,11 @@ module.exports = {
           }, baseHeaders);
         } else if (!isPRStillDependentOnAndReadyForCeoReview && existingLabels.includes('#g-ceo')) {
           // [?] https://docs.github.com/en/rest/issues/labels?apiVersion=2022-11-28#remove-a-label-from-an-issue
-          await sails.helpers.http.del(`https://api.github.com/repos/${owner}/${repo}/issues/${prNumber}/labels/${encodeURIComponent('#g-ceo')}`, {}, baseHeaders);
+          await sails.helpers.http.del(`https://api.github.com/repos/${owner}/${repo}/issues/${prNumber}/labels/${encodeURIComponent('#g-ceo')}`, {}, baseHeaders)
+          .tolerate('non200Response', (err)=>{
+            // If a label could not be removed, log a warning.
+            sails.log.warn(`When trying to send a request to remove the #g-ceo label from PR #${prNumber} in the ${owner}/${repo} repo, an error occured. Raw error: ${require('util').inspect(err)}`);
+          });
         }//ﬁ
 
         //  ┌─┐┬ ┬┌┬┐┌─┐   ┌─┐┌─┐┌─┐┬─┐┌─┐┬  ┬┌─┐   ┬   ┬ ┬┌┐┌┌─┐┬─┐┌─┐┌─┐┌─┐┌─┐
@@ -448,6 +456,10 @@ module.exports = {
         });
         sails.log.verbose('#'+prNumber+' is under consideration...  The MergeFreeze API claims that it current main branch "frozen" status is:',mergeFreezeMainBranchStatusReport.frozen);
         let isMainBranchFrozen = mergeFreezeMainBranchStatusReport.frozen;
+        // If the "main" branch is not currently frozen and we still have PR numbers in our pocketOfPrNumbersUnfrozen array. Clear out the values in the platform record.
+        if(!isMainBranchFrozen && pocketOfPrNumbersUnfrozen.length > 0) {
+          await Platform.updateOne({id: platformRecord.id}).set({currentUnfrozenGitHubPrNumbers: []});
+        }
         if (isAutoApprovalExpected) {
           // [?] https://docs.github.com/en/rest/reference/pulls#create-a-review-for-a-pull-request
           await sails.helpers.http.post(`https://api.github.com/repos/${owner}/${repo}/pulls/${prNumber}/reviews`, {

--- a/website/api/controllers/webhooks/receive-from-github.js
+++ b/website/api/controllers/webhooks/receive-from-github.js
@@ -413,7 +413,7 @@ module.exports = {
         } else if (!isHandbookPR && existingLabels.includes('#handbook')) {
           // [?] https://docs.github.com/en/rest/issues/labels?apiVersion=2022-11-28#remove-a-label-from-an-issue
           await sails.helpers.http.del(`https://api.github.com/repos/${owner}/${repo}/issues/${prNumber}/labels/${encodeURIComponent('#handbook')}`, {}, baseHeaders)
-          .tolerate({ exit: 'non200Response', statusCode: 404 }, (err)=>{// if the PR has gone missing, swallow the error and warn instead.
+          .tolerate({ exit: 'non200Response', raw: {statusCode: 404} }, (err)=>{// if the PR has gone missing, swallow the error and warn instead.
             sails.log.warn(`When trying to send a request to remove the #handbook label from PR #${prNumber} in the ${owner}/${repo} repo, an error occured. Raw error: ${require('util').inspect(err)}`);
           });
         }//ﬁ
@@ -429,7 +429,7 @@ module.exports = {
         } else if (!isPRStillDependentOnAndReadyForCeoReview && existingLabels.includes('#g-ceo')) {
           // [?] https://docs.github.com/en/rest/issues/labels?apiVersion=2022-11-28#remove-a-label-from-an-issue
           await sails.helpers.http.del(`https://api.github.com/repos/${owner}/${repo}/issues/${prNumber}/labels/${encodeURIComponent('#g-ceo')}`, {}, baseHeaders)
-          .tolerate({ exit: 'non200Response', statusCode: 404 }, (err)=>{// if the PR has gone missing, swallow the error and warn instead.
+          .tolerate({ exit: 'non200Response', raw {statusCode: 404} }, (err)=>{// if the PR has gone missing, swallow the error and warn instead.
             sails.log.warn(`When trying to send a request to remove the #g-ceo label from PR #${prNumber} in the ${owner}/${repo} repo, an error occured. Raw error: ${require('util').inspect(err)}`);
           });
         }//ﬁ


### PR DESCRIPTION
Closes: #14900
Closes: #15666

Changes:
- Updated the receive-from-github webhook to:
  - Log a warning if a label cannot be deleted from a pull request.
  - Reset the array of unfrozen PR numbers when the main branch of fleetdm/fleet is unfrozen