### PR TITLE
Adjust icon styles for new software titles UI

### DIFF
--- a/frontend/pages/SoftwarePage/components/icons/SoftwareIcon/_styles.scss
+++ b/frontend/pages/SoftwarePage/components/icons/SoftwareIcon/_styles.scss
@@ -1,0 +1,3 @@
+.software-icon {
+  flex-shrink: 0;
+}


### PR DESCRIPTION
Issue #15657 

Fixes unreleased UI bug where overflow text was causing flex layout to shrink SVG width

Before:

<img width="448" alt="Screenshot 2023-12-14 at 3 46 38 PM" src="https://github.com/fleetdm/fleet/assets/73313222/c0f8636a-7770-4176-bd87-2a694f42c368">

After:

<img width="448" alt="Screenshot 2023-12-14 at 3 46 18 PM" src="https://github.com/fleetdm/fleet/assets/73313222/458f77bc-47e7-447b-bfad-de1cad3bed33">

