### PR TITLE
fix background color of OS updates inputs

### DIFF
--- a/frontend/pages/ManageControlsPage/OSUpdates/components/MacOSTargetForm/_styles.scss
+++ b/frontend/pages/ManageControlsPage/OSUpdates/components/MacOSTargetForm/_styles.scss
@@ -3,4 +3,8 @@
     padding: $pad-large;
     background-color: $ui-fleet-blue-10;
   }
+
+  input {
+    background-color: $core-white;
+  }
 }


### PR DESCRIPTION
Unreleased bug for software updates, this sets the background color to white to match [the design](https://www.figma.com/file/47NY3lf808YJG3O72l7pEC/%2311951-Windows-OS-updates?type=design&node-id=140-2790&mode=design&t=B8cw9JqeT9t8arW2-0)

<img width="693" alt="image" src="https://github.com/fleetdm/fleet/assets/4419992/b5727179-1150-4ca1-84e8-e05b3c1744e3">
