### PR TITLE
Various document title fixes

### DIFF
--- a/frontend/components/App/App.tsx
+++ b/frontend/components/App/App.tsx
@@ -114,6 +114,7 @@ const App = ({ children, location }: IAppProps): JSX.Element => {
   // Updates title that shows up on browser tabs
   useEffect(() => {
     // Also applies title to subpaths such as settings/organization/webaddress
+    // TODO - handle different kinds of paths from PATHS - string, function w/params
     const curTitle = page_titles.find((item) =>
       location?.pathname.includes(item.path)
     );

--- a/frontend/pages/queries/details/QueryDetailsPage/QueryDetailsPage.tsx
+++ b/frontend/pages/queries/details/QueryDetailsPage/QueryDetailsPage.tsx
@@ -112,10 +112,10 @@ const QueryDetailsPage = ({
   // Title that shows up on browser tabs (e.g., Query details | Discover TLS certificates | Fleet for osquery)
 
   useEffect(() => {
-    const queryNameTitle = lastEditedQueryName
-      ? `${lastEditedQueryName} |`
-      : null;
-    document.title = `Query details | ${queryNameTitle} ${DOCUMENT_TITLE_SUFFIX}`;
+    const queryNameCopy = lastEditedQueryName
+      ? `${lastEditedQueryName} | `
+      : "";
+    document.title = `Query details | ${queryNameCopy}${DOCUMENT_TITLE_SUFFIX}`;
   }, [lastEditedQueryName]);
 
   const [disabledCachingGlobally, setDisabledCachingGlobally] = useState(true);

--- a/frontend/pages/queries/details/QueryDetailsPage/QueryDetailsPage.tsx
+++ b/frontend/pages/queries/details/QueryDetailsPage/QueryDetailsPage.tsx
@@ -110,7 +110,13 @@ const QueryDetailsPage = ({
   } = useContext(QueryContext);
 
   // Title that shows up on browser tabs (e.g., Query details | Discover TLS certificates | Fleet for osquery)
-  document.title = `Query details | ${lastEditedQueryName} | ${DOCUMENT_TITLE_SUFFIX}`;
+
+  useEffect(() => {
+    const queryNameTitle = lastEditedQueryName
+      ? `${lastEditedQueryName} |`
+      : null;
+    document.title = `Query details | ${queryNameTitle} ${DOCUMENT_TITLE_SUFFIX}`;
+  }, [lastEditedQueryName]);
 
   const [disabledCachingGlobally, setDisabledCachingGlobally] = useState(true);
 

--- a/frontend/pages/queries/edit/EditQueryPage.tsx
+++ b/frontend/pages/queries/edit/EditQueryPage.tsx
@@ -203,7 +203,11 @@ const EditQueryPage = ({
   // Updates title that shows up on browser tabs
   useEffect(() => {
     // e.g., Query details | Discover TLS certificates | Fleet for osquery
-    document.title = `Edit query | ${storedQuery?.name} | ${DOCUMENT_TITLE_SUFFIX}`;
+    const storedQueryTitleCopy = storedQuery?.name
+      ? `${storedQuery.name} | `
+      : "";
+    document.title = `Edit query | ${storedQueryTitleCopy} ${DOCUMENT_TITLE_SUFFIX}`;
+    // }
   }, [location.pathname, storedQuery?.name]);
 
   useEffect(() => {

--- a/frontend/pages/queries/live/LiveQueryPage/LiveQueryPage.tsx
+++ b/frontend/pages/queries/live/LiveQueryPage/LiveQueryPage.tsx
@@ -167,8 +167,9 @@ const RunQueryPage = ({
 
   // Updates title that shows up on browser tabs
   useEffect(() => {
+    const queryNameCopy = storedQuery?.name ? `${storedQuery?.name} | ` : "";
     // e.g., Run live query | Discover TLS certificates | Fleet for osquery
-    document.title = `Run live query | ${storedQuery?.name} | ${DOCUMENT_TITLE_SUFFIX}`;
+    document.title = `Run live query | ${queryNameCopy}${DOCUMENT_TITLE_SUFFIX}`;
   }, [location.pathname, storedQuery?.name]);
 
   const goToQueryEditor = useCallback(

--- a/frontend/router/page_titles.ts
+++ b/frontend/router/page_titles.ts
@@ -5,18 +5,18 @@ import PATHS from "router/paths";
 
 // Note: Order matters for use of array.find() (specific subpaths must be listed before their parent path)
 export default [
-  { path: "/dashboard", title: `Dashboard | ${DOCUMENT_TITLE_SUFFIX}` },
+  { path: PATHS.DASHBOARD, title: `Dashboard | ${DOCUMENT_TITLE_SUFFIX}` },
   { path: "/hosts/manage", title: `Manage hosts | ${DOCUMENT_TITLE_SUFFIX}` },
   {
-    path: "/controls/os-updates",
+    path: PATHS.CONTROLS_OS_UPDATES,
     title: `Manage OS updates | ${DOCUMENT_TITLE_SUFFIX}`,
   },
   {
-    path: "/controls/os-settings",
+    path: PATHS.CONTROLS_OS_SETTINGS,
     title: `Manage OS settings | ${DOCUMENT_TITLE_SUFFIX}`,
   },
   {
-    path: "/controls/setup-experience",
+    path: PATHS.CONTROLS_SETUP_EXPERIENCE,
     title: `Manage setup experience | ${DOCUMENT_TITLE_SUFFIX}`,
   },
   {
@@ -28,33 +28,33 @@ export default [
     title: `Software versions | ${DOCUMENT_TITLE_SUFFIX}`,
   },
   {
-    path: "/queries/manage",
+    path: PATHS.MANAGE_QUERIES,
     title: `Manage queries | ${DOCUMENT_TITLE_SUFFIX}`,
   },
-  { path: "/queries/new", title: `New query | ${DOCUMENT_TITLE_SUFFIX}` },
+  { path: PATHS.NEW_QUERY(), title: `New query | ${DOCUMENT_TITLE_SUFFIX}` },
   {
-    path: "/policies/manage",
+    path: PATHS.MANAGE_POLICIES,
     title: `Manage policies | ${DOCUMENT_TITLE_SUFFIX}`,
   },
-  { path: "/policies/new", title: `New policy | ${DOCUMENT_TITLE_SUFFIX}` },
+  { path: PATHS.NEW_POLICY, title: `New policy | ${DOCUMENT_TITLE_SUFFIX}` },
   {
-    path: "/settings/organization",
+    path: PATHS.ADMIN_ORGANIZATION,
     title: `Manage organization settings | ${DOCUMENT_TITLE_SUFFIX}`,
   },
   {
-    path: "/settings/integrations",
+    path: PATHS.ADMIN_INTEGRATIONS,
     title: `Manage integration settings | ${DOCUMENT_TITLE_SUFFIX}`,
   },
   {
-    path: "/settings/users",
+    path: PATHS.ADMIN_USERS,
     title: `Manage user settings | ${DOCUMENT_TITLE_SUFFIX}`,
   },
   {
-    path: "/settings/teams/members",
+    path: PATHS.TEAM_DETAILS_MEMBERS(),
     title: `Manage team members | ${DOCUMENT_TITLE_SUFFIX}`,
   },
   {
-    path: "/settings/teams/options",
+    path: PATHS.TEAM_DETAILS_OPTIONS(),
     title: `Manage team options | ${DOCUMENT_TITLE_SUFFIX}`,
   },
   {

--- a/frontend/router/page_titles.ts
+++ b/frontend/router/page_titles.ts
@@ -50,19 +50,23 @@ export default [
     title: `Manage user settings | ${DOCUMENT_TITLE_SUFFIX}`,
   },
   {
-    path: PATHS.TEAM_DETAILS_MEMBERS(),
+    path: "/settings/teams/members",
+    // TODO
+    // path: PATHS.TEAM_DETAILS_MEMBERS(), needs params
     title: `Manage team members | ${DOCUMENT_TITLE_SUFFIX}`,
   },
   {
-    path: PATHS.TEAM_DETAILS_OPTIONS(),
+    path: "/settings/teams/options",
+    // TODO
+    // path: PATHS.TEAM_DETAILS_OPTIONS(), needs params
     title: `Manage team options | ${DOCUMENT_TITLE_SUFFIX}`,
   },
   {
-    path: "/settings/teams",
+    path: PATHS.ADMIN_TEAMS,
     title: `Manage team settings | ${DOCUMENT_TITLE_SUFFIX}`,
   },
   {
-    path: "/profile",
+    path: PATHS.USER_SETTINGS,
     title: `Manage my account | ${DOCUMENT_TITLE_SUFFIX}`,
   },
 ];

--- a/frontend/router/page_titles.ts
+++ b/frontend/router/page_titles.ts
@@ -1,6 +1,7 @@
 // Note: Dynamic page titles are constructed for host, software, query, and policy details on their respective *DetailsPage.tsx file
 
 import { DOCUMENT_TITLE_SUFFIX } from "utilities/constants";
+import PATHS from "router/paths";
 
 // Note: Order matters for use of array.find() (specific subpaths must be listed before their parent path)
 export default [
@@ -19,16 +20,23 @@ export default [
     title: `Manage setup experience | ${DOCUMENT_TITLE_SUFFIX}`,
   },
   {
-    path: `/software/manage", title: "Manage software | ${DOCUMENT_TITLE_SUFFIX}`,
+    path: PATHS.SOFTWARE_TITLES,
+    title: `Software titles | ${DOCUMENT_TITLE_SUFFIX}`,
   },
   {
-    path: `/queries/manage", title: "Manage queries | ${DOCUMENT_TITLE_SUFFIX}`,
+    path: PATHS.SOFTWARE_VERSIONS,
+    title: `Software versions | ${DOCUMENT_TITLE_SUFFIX}`,
   },
-  { path: `/queries/new", title: "New query | ${DOCUMENT_TITLE_SUFFIX}` },
   {
-    path: `/policies/manage", title: "Manage policies | ${DOCUMENT_TITLE_SUFFIX}`,
+    path: "/queries/manage",
+    title: `Manage queries | ${DOCUMENT_TITLE_SUFFIX}`,
   },
-  { path: `/policies/new", title: "New policy | ${DOCUMENT_TITLE_SUFFIX}` },
+  { path: "/queries/new", title: `New query | ${DOCUMENT_TITLE_SUFFIX}` },
+  {
+    path: "/policies/manage",
+    title: `Manage policies | ${DOCUMENT_TITLE_SUFFIX}`,
+  },
+  { path: "/policies/new", title: `New policy | ${DOCUMENT_TITLE_SUFFIX}` },
   {
     path: "/settings/organization",
     title: `Manage organization settings | ${DOCUMENT_TITLE_SUFFIX}`,


### PR DESCRIPTION
## Addresses #15692 

https://github.com/fleetdm/fleet/assets/61553566/373df35f-0de5-4c71-84fc-c181a0a5dd07

- Also addresses title not being updated by the Software page due to new routes and hard-coded paths that no longer matched the new routes
- Also make this area more flexible to avoid these kinds of bugs in the future

- [x] Manual QA for all new/changed functionality