### PR TITLE
UI – set textarea columns based on placeholder length

### DIFF
--- a/changes/13095-cutoff-query-policy-description
+++ b/changes/13095-cutoff-query-policy-description
@@ -1,0 +1,1 @@
+- Fixed a bug where the placeholder text for policy and query descriptions was cut off.

--- a/frontend/components/forms/fields/AutoSizeInputField/AutoSizeInputField.tsx
+++ b/frontend/components/forms/fields/AutoSizeInputField/AutoSizeInputField.tsx
@@ -16,9 +16,6 @@ interface IAutoSizeInputFieldProps {
   hasError?: boolean;
   isDisabled?: boolean;
   isFocused?: boolean;
-  /** The minimum number of columns the input is. This is ignored if the input
-   * has a value. Useful if you'd like to show placeholder text without the
-   * input cutting off the text. defaults to `12` */
   onFocus: () => void;
   onBlur: () => void;
   onChange: (newSelectedValue: string) => void;

--- a/frontend/components/forms/fields/AutoSizeInputField/AutoSizeInputField.tsx
+++ b/frontend/components/forms/fields/AutoSizeInputField/AutoSizeInputField.tsx
@@ -19,7 +19,6 @@ interface IAutoSizeInputFieldProps {
   /** The minimum number of columns the input is. This is ignored if the input
    * has a value. Useful if you'd like to show placeholder text without the
    * input cutting off the text. defaults to `12` */
-  minColumns?: number;
   onFocus: () => void;
   onBlur: () => void;
   onChange: (newSelectedValue: string) => void;
@@ -37,7 +36,6 @@ const AutoSizeInputField = ({
   hasError,
   isDisabled,
   isFocused,
-  minColumns = 12,
   onFocus,
   onBlur,
   onChange,
@@ -94,7 +92,7 @@ const AutoSizeInputField = ({
           value={inputValue}
           maxLength={parseInt(maxLength, 10)}
           className={inputClasses}
-          cols={value ? 1 : minColumns}
+          cols={value ? value.length : placeholder.length - 2}
           rows={1}
           tabIndex={0}
           onFocus={onInputFocus}


### PR DESCRIPTION
## Addresses #13095 

<img width="501" alt="Screenshot 2023-12-15 at 1 52 05 PM" src="https://github.com/fleetdm/fleet/assets/61553566/37fa6d41-e7d0-4324-93c8-d3d7ce4e0d33">


- [x] Changes file added for user-visible changes in `changes/`
- [x] Manual QA for all new/changed functionality

