### PR TITLE
Live query stats are cleared when query SQL is modified.

### DIFF
--- a/changes/15709-live-query-stats-cleared
+++ b/changes/15709-live-query-stats-cleared
@@ -1,0 +1,1 @@
+Live query stats are cleared when query SQL is modified.

--- a/server/datastore/mysql/queries.go
+++ b/server/datastore/mysql/queries.go
@@ -245,7 +245,7 @@ func (ds *Datastore) NewQuery(
 	return query, nil
 }
 
-func (ds *Datastore) SaveQuery(ctx context.Context, q *fleet.Query, shouldDiscardResults bool) (err error) {
+func (ds *Datastore) SaveQuery(ctx context.Context, q *fleet.Query, shouldDiscardResults bool, shouldDeleteStats bool) (err error) {
 	if err := q.Verify(); err != nil {
 		return ctxerr.Wrap(ctx, err)
 	}
@@ -295,6 +295,11 @@ func (ds *Datastore) SaveQuery(ctx context.Context, q *fleet.Query, shouldDiscar
 	}
 	if rows == 0 {
 		return ctxerr.Wrap(ctx, notFound("Query").WithID(q.ID))
+	}
+
+	if shouldDeleteStats {
+		// Delete any associated stats asynchronously.
+		go ds.deleteQueryStats(context.WithoutCancel(ctx), []uint{q.ID})
 	}
 
 	// Opportunistically delete associated query_results.
@@ -349,14 +354,7 @@ func (ds *Datastore) DeleteQuery(ctx context.Context, teamID *uint, name string)
 	}
 
 	// Delete any associated stats asynchronously.
-	ctxWithoutCancel := context.WithoutCancel(ctx)
-	go func() {
-		stmt := "DELETE FROM scheduled_query_stats WHERE scheduled_query_id = ?"
-		_, err := ds.writer(ctxWithoutCancel).ExecContext(ctxWithoutCancel, stmt, queryID)
-		if err != nil {
-			level.Error(ds.logger).Log("msg", "error deleting query stats", "err", err)
-		}
-	}()
+	go ds.deleteQueryStats(context.WithoutCancel(ctx), []uint{queryID})
 
 	// Opportunistically delete associated query_results.
 	//
@@ -378,19 +376,7 @@ func (ds *Datastore) DeleteQueries(ctx context.Context, ids []uint) (uint, error
 	}
 
 	// Delete any associated stats asynchronously.
-	ctxWithoutCancel := context.WithoutCancel(ctx)
-	go func() {
-		stmt := "DELETE FROM scheduled_query_stats WHERE scheduled_query_id IN (?)"
-		stmt, args, err := sqlx.In(stmt, ids)
-		if err != nil {
-			level.Error(ds.logger).Log("msg", "error creating delete query statement", "err", err)
-			return
-		}
-		_, err = ds.writer(ctxWithoutCancel).ExecContext(ctxWithoutCancel, stmt, args...)
-		if err != nil {
-			level.Error(ds.logger).Log("msg", "error deleting multiple query stats", "err", err)
-		}
-	}()
+	go ds.deleteQueryStats(context.WithoutCancel(ctx), ids)
 
 	// Opportunistically delete associated query_results.
 	//
@@ -400,6 +386,35 @@ func (ds *Datastore) DeleteQueries(ctx context.Context, ids []uint) (uint, error
 		return deleted, ctxerr.Wrap(ctx, err, "delete multiple query_results")
 	}
 	return deleted, nil
+}
+
+// deleteQueryStats deletes query stats and aggregated stats for saved queries.
+// Errors are logged and not returned.
+func (ds *Datastore) deleteQueryStats(ctx context.Context, queryIDs []uint) {
+	// Delete stats for each host.
+	stmt := "DELETE FROM scheduled_query_stats WHERE scheduled_query_id IN (?)"
+	stmt, args, err := sqlx.In(stmt, queryIDs)
+	if err != nil {
+		level.Error(ds.logger).Log("msg", "error creating delete query stats statement", "err", err)
+	} else {
+		_, err = ds.writer(ctx).ExecContext(ctx, stmt, args...)
+		if err != nil {
+			level.Error(ds.logger).Log("msg", "error deleting query stats", "err", err)
+		}
+	}
+
+	// Delete aggregated stats
+	stmt = fmt.Sprintf("DELETE FROM aggregated_stats WHERE type = '%s' AND id IN (?)", fleet.AggregatedStatsTypeScheduledQuery)
+	stmt, args, err = sqlx.In(stmt, queryIDs)
+	if err != nil {
+		level.Error(ds.logger).Log("msg", "error creating delete aggregated stats statement", "err", err)
+	} else {
+		_, err = ds.writer(ctx).ExecContext(ctx, stmt, args...)
+		if err != nil {
+			level.Error(ds.logger).Log("msg", "error deleting aggregated stats", "err", err)
+		}
+	}
+
 }
 
 // Query returns a single Query identified by id, if such exists.

--- a/server/fleet/datastore.go
+++ b/server/fleet/datastore.go
@@ -70,7 +70,7 @@ type Datastore interface {
 	// NewQuery creates a new query object in thie datastore. The returned query should have the ID updated.
 	NewQuery(ctx context.Context, query *Query, opts ...OptionalArg) (*Query, error)
 	// SaveQuery saves changes to an existing query object.
-	SaveQuery(ctx context.Context, query *Query, shouldDiscardResults bool) error
+	SaveQuery(ctx context.Context, query *Query, shouldDiscardResults bool, shouldDeleteStats bool) error
 	// DeleteQuery deletes an existing query object on a team. If teamID is nil, then the query is
 	// looked up in the 'global' team.
 	DeleteQuery(ctx context.Context, teamID *uint, name string) error

--- a/server/mock/datastore_mock.go
+++ b/server/mock/datastore_mock.go
@@ -60,7 +60,7 @@ type ApplyQueriesFunc func(ctx context.Context, authorID uint, queries []*fleet.
 
 type NewQueryFunc func(ctx context.Context, query *fleet.Query, opts ...fleet.OptionalArg) (*fleet.Query, error)
 
-type SaveQueryFunc func(ctx context.Context, query *fleet.Query, shouldDiscardResults bool) error
+type SaveQueryFunc func(ctx context.Context, query *fleet.Query, shouldDiscardResults bool, shouldDeleteStats bool) error
 
 type DeleteQueryFunc func(ctx context.Context, teamID *uint, name string) error
 
@@ -2084,11 +2084,11 @@ func (s *DataStore) NewQuery(ctx context.Context, query *fleet.Query, opts ...fl
 	return s.NewQueryFunc(ctx, query, opts...)
 }
 
-func (s *DataStore) SaveQuery(ctx context.Context, query *fleet.Query, shouldDiscardResults bool) error {
+func (s *DataStore) SaveQuery(ctx context.Context, query *fleet.Query, shouldDiscardResults bool, shouldDeleteStats bool) error {
 	s.mu.Lock()
 	s.SaveQueryFuncInvoked = true
 	s.mu.Unlock()
-	return s.SaveQueryFunc(ctx, query, shouldDiscardResults)
+	return s.SaveQueryFunc(ctx, query, shouldDiscardResults, shouldDeleteStats)
 }
 
 func (s *DataStore) DeleteQuery(ctx context.Context, teamID *uint, name string) error {

--- a/server/service/global_schedule_test.go
+++ b/server/service/global_schedule_test.go
@@ -24,7 +24,7 @@ func TestGlobalScheduleAuth(t *testing.T) {
 			Query: "SELECT 1;",
 		}, nil
 	}
-	ds.SaveQueryFunc = func(ctx context.Context, query *fleet.Query, shouldDiscardResults bool) error {
+	ds.SaveQueryFunc = func(ctx context.Context, query *fleet.Query, shouldDiscardResults bool, shouldDeleteStats bool) error {
 		return nil
 	}
 	ds.NewActivityFunc = func(ctx context.Context, user *fleet.User, activity fleet.ActivityDetails) error {

--- a/server/service/queries.go
+++ b/server/service/queries.go
@@ -321,7 +321,7 @@ func modifyQueryEndpoint(ctx context.Context, request interface{}, svc fleet.Ser
 func (svc *Service) ModifyQuery(ctx context.Context, id uint, p fleet.QueryPayload) (*fleet.Query, error) {
 	// Load query first to determine if the user can modify it.
 	query, err := svc.ds.Query(ctx, id)
-	shouldDiscardQueryResults := false
+	shouldDiscardQueryResults, shouldDeleteStats := false, false
 	if err != nil {
 		setAuthCheckedOnPreAuthErr(ctx)
 		return nil, err
@@ -349,6 +349,7 @@ func (svc *Service) ModifyQuery(ctx context.Context, id uint, p fleet.QueryPaylo
 	if p.Query != nil {
 		if query.Query != *p.Query {
 			shouldDiscardQueryResults = true
+			shouldDeleteStats = true
 		}
 		query.Query = *p.Query
 	}
@@ -382,7 +383,7 @@ func (svc *Service) ModifyQuery(ctx context.Context, id uint, p fleet.QueryPaylo
 
 	logging.WithExtras(ctx, "name", query.Name, "sql", query.Query)
 
-	if err := svc.ds.SaveQuery(ctx, query, shouldDiscardQueryResults); err != nil {
+	if err := svc.ds.SaveQuery(ctx, query, shouldDiscardQueryResults, shouldDeleteStats); err != nil {
 		return nil, err
 	}
 

--- a/server/service/queries_test.go
+++ b/server/service/queries_test.go
@@ -137,7 +137,7 @@ func TestQueryPayloadValidationModify(t *testing.T) {
 			ObserverCanRun: false,
 		}, nil
 	}
-	ds.SaveQueryFunc = func(ctx context.Context, query *fleet.Query, shouldDiscardResults bool) error {
+	ds.SaveQueryFunc = func(ctx context.Context, query *fleet.Query, shouldDiscardResults bool, shouldDeleteStats bool) error {
 		assert.NotEmpty(t, query)
 		return nil
 	}
@@ -374,7 +374,7 @@ func TestQueryAuth(t *testing.T) {
 		return 0, nil
 	}
 
-	ds.SaveQueryFunc = func(ctx context.Context, query *fleet.Query, shouldDiscardResults bool) error {
+	ds.SaveQueryFunc = func(ctx context.Context, query *fleet.Query, shouldDiscardResults bool, shouldDeleteStats bool) error {
 		return nil
 	}
 	ds.DeleteQueryFunc = func(ctx context.Context, teamID *uint, name string) error {

--- a/server/service/team_schedule_test.go
+++ b/server/service/team_schedule_test.go
@@ -33,7 +33,7 @@ func TestTeamScheduleAuth(t *testing.T) {
 			TeamID: nil,
 		}, nil
 	}
-	ds.SaveQueryFunc = func(ctx context.Context, query *fleet.Query, shouldDiscardResults bool) error {
+	ds.SaveQueryFunc = func(ctx context.Context, query *fleet.Query, shouldDiscardResults bool, shouldDeleteStats bool) error {
 		return nil
 	}
 	ds.NewActivityFunc = func(ctx context.Context, user *fleet.User, activity fleet.ActivityDetails) error {


### PR DESCRIPTION
Live query stats are cleared when query SQL is modified.

Also, when deleting one or more queries, the associated aggregated stats are now deleted as well.

#15709

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [x] Added/updated tests
- [x] Manual QA for all new/changed functionality
