### PR TITLE
fix: use other field for checking vuln scanning status

### DIFF
--- a/changes/15213-vuln-enabled
+++ b/changes/15213-vuln-enabled
@@ -1,0 +1,1 @@
+- Fixes a bug that caused vulnerability scanning status to be misreported in analytics.

--- a/server/datastore/mysql/statistics.go
+++ b/server/datastore/mysql/statistics.go
@@ -81,7 +81,7 @@ func (ds *Datastore) ShouldSendStatistics(ctx context.Context, frequency time.Du
 		stats.NumPolicies = amountPolicies
 		stats.NumLabels = amountLabels
 		stats.SoftwareInventoryEnabled = appConfig.Features.EnableSoftwareInventory
-		stats.VulnDetectionEnabled = appConfig.VulnerabilitySettings.DatabasesPath != ""
+		stats.VulnDetectionEnabled = config.Vulnerabilities.DatabasesPath != "" || appConfig.VulnerabilitySettings.DatabasesPath != ""
 		stats.SystemUsersEnabled = appConfig.Features.EnableHostUsers
 		stats.HostsStatusWebHookEnabled = appConfig.WebhookSettings.HostStatusWebhook.Enable
 		stats.MDMMacOsEnabled = appConfig.MDM.EnabledAndConfigured

--- a/server/datastore/mysql/statistics_test.go
+++ b/server/datastore/mysql/statistics_test.go
@@ -3,6 +3,7 @@ package mysql
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"testing"
 	"time"
 
@@ -51,6 +52,7 @@ func testStatisticsShouldSend(t *testing.T, ds *Datastore) {
 
 	// First time running with no hosts
 	stats, shouldSend, err := ds.ShouldSendStatistics(license.NewContext(ctx, premiumLicense), time.Millisecond, fleetConfig)
+	fmt.Println("hello, ", fleetConfig)
 	require.NoError(t, err)
 	assert.True(t, shouldSend)
 	assert.Equal(t, "premium", stats.LicenseTier)
@@ -145,8 +147,8 @@ func testStatisticsShouldSend(t *testing.T, ds *Datastore) {
 	})
 	require.NoError(t, err)
 
-	// Create new app config for test
-	config, err := ds.NewAppConfig(ctx, &fleet.AppConfig{
+	// Create new app cfg for test
+	cfg, err := ds.NewAppConfig(ctx, &fleet.AppConfig{
 		OrgInfo: fleet.OrgInfo{
 			OrgName:    "Test",
 			OrgLogoURL: "localhost:8080/logo.png",
@@ -168,15 +170,15 @@ func testStatisticsShouldSend(t *testing.T, ds *Datastore) {
 	require.NoError(t, err)
 
 	require.NoError(t, err)
-	config.Features.EnableSoftwareInventory = false
-	config.Features.EnableHostUsers = false
-	config.VulnerabilitySettings.DatabasesPath = ""
-	config.WebhookSettings.HostStatusWebhook.Enable = true
-	config.MDM.EnabledAndConfigured = true
-	config.HostExpirySettings.HostExpiryEnabled = true
-	config.MDM.WindowsEnabledAndConfigured = true
-	config.ServerSettings.LiveQueryDisabled = true
-	err = ds.SaveAppConfig(ctx, config)
+	cfg.Features.EnableSoftwareInventory = false
+	cfg.Features.EnableHostUsers = false
+	cfg.VulnerabilitySettings.DatabasesPath = ""
+	cfg.WebhookSettings.HostStatusWebhook.Enable = true
+	cfg.MDM.EnabledAndConfigured = true
+	cfg.HostExpirySettings.HostExpiryEnabled = true
+	cfg.MDM.WindowsEnabledAndConfigured = true
+	cfg.ServerSettings.LiveQueryDisabled = true
+	err = ds.SaveAppConfig(ctx, cfg)
 	require.NoError(t, err)
 
 	time.Sleep(1100 * time.Millisecond) // ensure the DB timestamp is not in the same second
@@ -364,4 +366,10 @@ func testStatisticsShouldSend(t *testing.T, ds *Datastore) {
 	assert.Equal(t, firstIdentifier, stats.AnonymousIdentifier)
 	assert.Equal(t, "free", stats.LicenseTier)
 	assert.Equal(t, "unknown", stats.Organization)
+
+	fleetConfig.Vulnerabilities = config.VulnerabilitiesConfig{DatabasesPath: "some/path/vulns"}
+	stats, shouldSend, err = ds.ShouldSendStatistics(license.NewContext(ctx, freeLicense), time.Millisecond, fleetConfig)
+	require.NoError(t, err)
+	assert.True(t, shouldSend)
+	assert.True(t, stats.VulnDetectionEnabled)
 }

--- a/server/datastore/mysql/statistics_test.go
+++ b/server/datastore/mysql/statistics_test.go
@@ -3,7 +3,6 @@ package mysql
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"testing"
 	"time"
 
@@ -52,7 +51,6 @@ func testStatisticsShouldSend(t *testing.T, ds *Datastore) {
 
 	// First time running with no hosts
 	stats, shouldSend, err := ds.ShouldSendStatistics(license.NewContext(ctx, premiumLicense), time.Millisecond, fleetConfig)
-	fmt.Println("hello, ", fleetConfig)
 	require.NoError(t, err)
 	assert.True(t, shouldSend)
 	assert.Equal(t, "premium", stats.LicenseTier)


### PR DESCRIPTION
# Checklist for submitter

To test, go through the repro steps in the issue; you should see that the field is true instead of false!

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [x] Added/updated tests
- [x] Manual QA for all new/changed functionality
