### PR TITLE
Improved error message when Fleet cannot write osquery log results to logging destination.

### DIFF
--- a/changes/15455-logging-issues
+++ b/changes/15455-logging-issues
@@ -1,0 +1,1 @@
+Improved error message when Fleet cannot write osquery log results to logging destination.

--- a/server/service/osquery.go
+++ b/server/service/osquery.go
@@ -1578,7 +1578,11 @@ func (svc *Service) SubmitResultLogs(ctx context.Context, logs []json.RawMessage
 	}
 
 	if err := svc.osqueryLogWriter.Result.Write(ctx, filteredLogs); err != nil {
-		return newOsqueryError("error writing result logs: " + err.Error())
+		return newOsqueryError(
+			"error writing result logs " +
+				"(if the logging destination is down, you can reduce frequency/size of osquery logs by " +
+				"increasing logger_tls_period and decreasing logger_tls_max_lines): " + err.Error(),
+		)
 	}
 	return nil
 }


### PR DESCRIPTION
Improved error message when Fleet cannot write osquery log results to logging destination.
#15455 



# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
