### PR TITLE
Website: Add /try-fleet/fleetctl-preview link to explore data pages

### DIFF
--- a/website/assets/styles/pages/try-fleet/query-report.less
+++ b/website/assets/styles/pages/try-fleet/query-report.less
@@ -268,7 +268,28 @@
         font-size: 16px;
         font-weight: 700;
         line-height: 21px;
+        margin-bottom: 24px;
       }
+      [purpose='fleetctl-link'] {
+        a {
+          color: @core-vibrant-blue;
+          font-size: 14px;
+          font-weight: 400;
+          line-height: 21px;
+          text-align: center;
+          margin-bottom: 4px;
+          height: auto;
+        }
+        p {
+          font-size: 12px;
+          font-weight: 400;
+          line-height: 18px;
+          text-align: center;
+          margin-bottom: 8px;
+        }
+
+      }
+
     }
     [purpose='banner-image'] {
       height: auto;

--- a/website/views/pages/try-fleet/query-report.ejs
+++ b/website/views/pages/try-fleet/query-report.ejs
@@ -115,6 +115,10 @@
           <h3 class="d-none d-md-block">This is not Fleet</h3>
           <p>This is a simple app built on the Fleet API to get a taste of the data. Get in our calendar to see what you can do with multiple hosts in the Fleet UI.</p>
           <a class="d-flex align-items-center justify-content-center btn btn-primary w-100" @click="clickOpenChatWidget()">Book a demo</a>
+          <div purpose="fleetctl-link" class="d-flex flex-column align-items-center">
+            <a href="/try-fleet/fleetctl-preview">Run Fleet locally</a>
+            <p>(Requires Docker)</p>
+          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Closes: https://github.com/fleetdm/confidential/issues/4752

Changes:
- Updated the CTA on `/try-fleet/explore-data/*` pages to link to the `/try-fleet/fleetctl-preview` page