### PR TITLE
fix site nav software item to link to software/titles

### DIFF
--- a/frontend/components/top_nav/SiteTopNav/SiteTopNav.tsx
+++ b/frontend/components/top_nav/SiteTopNav/SiteTopNav.tsx
@@ -41,7 +41,8 @@ const REGEX_DETAIL_PAGES = {
   QUERIES_NEW: /\/queries\/new/i,
   POLICY_EDIT: /\/policies\/\d+/i,
   POLICY_NEW: /\/policies\/new/i,
-  SOFTWARE_DETAILS: /\/software\/\d+/i,
+  SOFTWARE_TITLES_DETAILS: /\/software\/titles\/\d+/i,
+  SOFTWARE_VERSIONS_DETAILS: /\/software\/versions\/\d+/i,
 };
 
 const REGEX_GLOBAL_PAGES = {
@@ -144,13 +145,17 @@ const SiteTopNav = ({
     }
 
     if (active && !isActiveDetailPage) {
+      const path = navItem.alwaysToPathname
+        ? navItem.location.pathname
+        : currentPath;
+
       // TODO: confirm link should be noop and find best pattern (one that doesn't dispatch a
       // replace to the same url, which triggers a re-render)
       return (
         <li className={navItemClasses} key={`nav-item-${name}`}>
           <Link
             className={`${navItemBaseClass}__link`}
-            to={currentPath.concat(search).concat(hash)}
+            to={path.concat(search).concat(hash)}
           >
             <span
               className={`${navItemBaseClass}__name`}

--- a/frontend/components/top_nav/SiteTopNav/navItems.ts
+++ b/frontend/components/top_nav/SiteTopNav/navItems.ts
@@ -11,6 +11,13 @@ export interface INavItem {
     pathname: string;
   };
   exclude?: boolean;
+  /** If `true`, this nav item will always navigate to the given `location.pathname`. This
+   * is useful when you always want to always naviate to a specific path no matter
+   * which child page you are on (e.g. always navigate to /sofware/titles/ when
+   * clicking on the software nav item even if on /software/versions,
+   * software/titles/:id, or /software/versions/:id). Defaults to `undefined`.
+   */
+  alwaysToPathname?: boolean;
   withParams?: { type: "query"; names: string[] };
 }
 
@@ -69,6 +76,7 @@ export default (
         regex: new RegExp(`^${URL_PREFIX}/software/`),
         pathname: PATHS.SOFTWARE_TITLES,
       },
+      alwaysToPathname: true,
       withParams: { type: "query", names: ["team_id"] },
     },
     {


### PR DESCRIPTION
relates to #15717

Fixes software navigation link to always navigate to /software/titles page.