### PR TITLE
Website: Update /try-fleet/explore-data redirect

### DIFF
--- a/website/api/controllers/try-fleet/view-query-report.js
+++ b/website/api/controllers/try-fleet/view-query-report.js
@@ -56,7 +56,7 @@ module.exports = {
 
     // If the requesting user is not logged in, redirect them to the /try-fleet/login page with the specified hostPlatform added as a query parameter.
     if(!this.req.me){
-      throw {redirect: `/try-fleet/login?targetPlatform=${encodeURIComponent(hostPlatform)}` };
+      throw {redirect: `/try-fleet/register?targetPlatform=${encodeURIComponent(hostPlatform)}` };
     }
 
     if(!sails.config.custom.queryIdsByTableName){

--- a/website/api/controllers/try-fleet/view-query-report.js
+++ b/website/api/controllers/try-fleet/view-query-report.js
@@ -54,7 +54,7 @@ module.exports = {
       throw {badConfig: 'builtStaticContent.osqueryTables'};
     }
 
-    // If the requesting user is not logged in, redirect them to the /try-fleet/login page with the specified hostPlatform added as a query parameter.
+    // If the requesting user is not logged in, redirect them to the /try-fleet/register page with the specified hostPlatform added as a query parameter.
     if(!this.req.me){
       throw {redirect: `/try-fleet/register?targetPlatform=${encodeURIComponent(hostPlatform)}` };
     }


### PR DESCRIPTION
Closes: #15728

Changes:
- Updated `view-query-report.js` to redirect non-logged in users who visit `/try-fleet/explore-data/*` to `/try-fleet/register`