### PR TITLE
fix for tooltip wrapper text alignment

### DIFF
--- a/changes/issue-15435-tooltip-text-alignment-fix
+++ b/changes/issue-15435-tooltip-text-alignment-fix
@@ -1,0 +1,1 @@
+- fix tooltip text alignment ui bug.

--- a/frontend/components/TooltipWrapper/_styles.scss
+++ b/frontend/components/TooltipWrapper/_styles.scss
@@ -7,15 +7,27 @@
   }
 
   &__underline {
-    position: relative;
     width: fit-content;
-    // compensate for bottom border and padding to maintain centering
-    top: 2px;
     border-bottom: 1px dashed $ui-fleet-black-50;
     padding-bottom: 1px;
   }
 
   &__tip-text {
     @include tooltip-text;
+  }
+}
+
+// for firefox we need to slightly shift the tooltip text to fit in line with the
+// other text next to the tooltip. This is because firefox renders the layout
+// slightly differently than webkit and edge, which makes it appear higher
+// than text next to it.
+// TODO: investigate more to see if there is a solution that will work
+// cross browser.
+@-moz-document url-prefix() {
+  .component__tooltip-wrapper {
+    &__underline {
+      position: relative;
+      top: 2px;
+    }
   }
 }

--- a/frontend/components/TooltipWrapper/_styles.scss
+++ b/frontend/components/TooltipWrapper/_styles.scss
@@ -9,7 +9,6 @@
   &__underline {
     width: fit-content;
     border-bottom: 1px dashed $ui-fleet-black-50;
-    padding-bottom: 1px;
   }
 
   &__tip-text {
@@ -28,6 +27,7 @@
     &__underline {
       position: relative;
       top: 2px;
+      padding-bottom: 1px;
     }
   }
 }


### PR DESCRIPTION
relates to #15435

fix for tooltip text alignment across multiple browsers. Firefox needs additional styles to make the tooltip text appear correct.

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
- [x] Manual QA for all new/changed functionality
