### PR TITLE
fix formatting of script output

### DIFF
--- a/changes/issue-15515-fix-script-output-formatting
+++ b/changes/issue-15515-fix-script-output-formatting
@@ -1,0 +1,1 @@
+- improve script output text formatting.

--- a/frontend/components/Textarea/Textarea.tsx
+++ b/frontend/components/Textarea/Textarea.tsx
@@ -10,7 +10,7 @@ interface ITextareaProps {
 
 // A textarea component that encapsulates common styles and functionality.
 const Textarea = ({ children, className }: ITextareaProps) => {
-  // this is preserve line breaks when we encounter a carriage return character.
+  // this is to preserve line breaks when we encounter a carriage return character.
   // We could not find a way to preserve line breaks in the CSS alone for this
   // character.
   if (typeof children === "string") {

--- a/frontend/components/Textarea/Textarea.tsx
+++ b/frontend/components/Textarea/Textarea.tsx
@@ -10,6 +10,13 @@ interface ITextareaProps {
 
 // A textarea component that encapsulates common styles and functionality.
 const Textarea = ({ children, className }: ITextareaProps) => {
+  // this is preserve line breaks when we encounter a carriage return character.
+  // We could not find a way to preserve line breaks in the CSS alone for this
+  // character.
+  if (typeof children === "string") {
+    children = children.replace(/\r/g, "\n");
+  }
+
   const classNames = classnames(baseClass, className);
   return <div className={classNames}>{children}</div>;
 };


### PR DESCRIPTION
relates to #15515

fix the formatting of the script output by replacing the `\r` characters with `\n` characters.

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
- [x] Manual QA for all new/changed functionality
