### PR TITLE
add pointer cursor to accordion button on os updates page

### DIFF
--- a/frontend/pages/ManageControlsPage/OSUpdates/components/PlatformsAccordion/_styles.scss
+++ b/frontend/pages/ManageControlsPage/OSUpdates/components/PlatformsAccordion/_styles.scss
@@ -16,6 +16,10 @@
       font-weight: $bold;
       font-size: $x-small;
     }
+
+    &:hover {
+      cursor: pointer;
+    }
   }
 
   &__accordion-panel {


### PR DESCRIPTION
relates to #15718

Updates the accordion buttons on OS updates to show a pointer cursor on hover

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
- [x] Manual QA for all new/changed functionality
