### PR TITLE
UI – Render Query Report 'No Results' state when `discard_data` is enabled, regardless of contents/presence of `results`; cleanup tooltip content

### DIFF
--- a/frontend/pages/queries/details/QueryDetailsPage/QueryDetailsPage.tsx
+++ b/frontend/pages/queries/details/QueryDetailsPage/QueryDetailsPage.tsx
@@ -342,7 +342,7 @@ const QueryDetailsPage = ({
     }
 
     // Empty state with varying messages explaining why there's no results
-    if (emptyCache) {
+    if (emptyCache || lastEditedQueryDiscardData) {
       return (
         <NoResults
           queryInterval={storedQuery?.interval}

--- a/frontend/pages/queries/details/components/NoResults/NoResults.tsx
+++ b/frontend/pages/queries/details/components/NoResults/NoResults.tsx
@@ -75,7 +75,6 @@ const NoResults = ({
                 The following setting prevents saving this query&apos;s results
                 in Fleet:
               </div>
-              \
               <div>
                 &nbsp; • Query reports are globally disabled in organization
                 settings.
@@ -90,7 +89,6 @@ const NoResults = ({
                 The following setting prevents saving this query&apos;s results
                 in Fleet:
               </div>
-              \
               <div>
                 &nbsp; • This query has <b>Discard data</b> enabled.
               </div>
@@ -104,7 +102,6 @@ const NoResults = ({
                 The following setting prevents saving this query&apos;s results
                 in Fleet:
               </div>
-              \
               <div>
                 &nbsp; • The logging setting for this query is not{" "}
                 <b>Snapshot</b>.


### PR DESCRIPTION
## Addresses #15778 and part of #15608 

## Checklist for submitter
- [x] Manual QA for all new/changed functionality
