### PR TITLE
device_token endpoint improvements

### DIFF
--- a/changes/15832-device_token-improvements
+++ b/changes/15832-device_token-improvements
@@ -1,0 +1,4 @@
+Fixed badly formatted error message in /api/fleet/orbit/device_token endpoint and others.
+In /api/fleet/orbit/device_token:
+- Added token validation -- empty token not allowed
+- Replaced 500 error with 409 when token conflicts with another host

--- a/orbit/pkg/packaging/macos_rcodesign.go
+++ b/orbit/pkg/packaging/macos_rcodesign.go
@@ -16,7 +16,7 @@ func rSign(pkgPath, cert string) error {
 	defer os.Remove(pemPath)
 	err := os.WriteFile(pemPath, []byte(cert), 0o600)
 	if err != nil {
-		return fmt.Errorf("writing cert data: %e", err)
+		return fmt.Errorf("writing cert data: %s", err)
 	}
 
 	return retry.Do(func() error {
@@ -41,7 +41,7 @@ func rNotarizeStaple(pkg, apiKeyID, apiKeyIssuer, apiKeyContent string) error {
 	path, err := writeAPIKeys(apiKeyIssuer, apiKeyID, apiKeyContent)
 	defer os.Remove(path)
 	if err != nil {
-		return fmt.Errorf("writing API keys: %e", err)
+		return fmt.Errorf("writing API keys: %s", err)
 	}
 
 	return retry.Do(func() error {
@@ -66,19 +66,19 @@ func rNotarizeStaple(pkg, apiKeyID, apiKeyIssuer, apiKeyContent string) error {
 func writeAPIKeys(issuer, id, content string) (string, error) {
 	homedir, err := os.UserHomeDir()
 	if err != nil {
-		return "", fmt.Errorf("finding home dir: %e", err)
+		return "", fmt.Errorf("finding home dir: %s", err)
 	}
 
 	// The underliying tools (rcodesign and Transporter) expect to find a
 	// certificate key in this path.
 	path := filepath.Join(homedir, ".appstoreconnect", "private_keys")
 	if err = secure.MkdirAll(path, 0o600); err != nil {
-		return "", fmt.Errorf("finding home dir: %e", err)
+		return "", fmt.Errorf("finding home dir: %s", err)
 	}
 
 	keyPath := filepath.Join(path, fmt.Sprintf("AuthKey_%s.p8", id))
 	if err = os.WriteFile(keyPath, []byte(content), 0o600); err != nil {
-		return "", fmt.Errorf("writing api key contents: %e", err)
+		return "", fmt.Errorf("writing api key contents: %s", err)
 	}
 
 	return keyPath, nil

--- a/orbit/pkg/update/nudge.go
+++ b/orbit/pkg/update/nudge.go
@@ -121,7 +121,7 @@ func (n *NudgeConfigFetcher) setTargetsAndHashes() error {
 	// we don't want to keep nudge as a target if we failed to update the
 	// cached hashes in the runner.
 	if err := n.opt.UpdateRunner.StoreLocalHash("nudge"); err != nil {
-		log.Debug().Msgf("removing nudge from target options, error updating local hashes: %e", err)
+		log.Debug().Msgf("removing nudge from target options, error updating local hashes: %s", err)
 		n.opt.UpdateRunner.RemoveRunnerOptTarget("nudge")
 		n.opt.UpdateRunner.updater.RemoveTargetInfo("nudge")
 		return err

--- a/orbit/pkg/update/swift_dialog.go
+++ b/orbit/pkg/update/swift_dialog.go
@@ -54,7 +54,7 @@ func (s *SwiftDialogDownloader) GetConfig() (*fleet.OrbitConfig, error) {
 		// we don't want to keep swiftDialog as a target if we failed to update the
 		// cached hashes in the runner.
 		if err := s.UpdateRunner.StoreLocalHash("swiftDialog"); err != nil {
-			log.Debug().Msgf("removing swiftDialog from target options, error updating local hashes: %e", err)
+			log.Debug().Msgf("removing swiftDialog from target options, error updating local hashes: %s", err)
 			s.UpdateRunner.RemoveRunnerOptTarget("swiftDialog")
 			s.UpdateRunner.updater.RemoveTargetInfo("swiftDialog")
 			return cfg, err

--- a/server/datastore/mysql/hosts.go
+++ b/server/datastore/mysql/hosts.go
@@ -2266,7 +2266,7 @@ func (ds *Datastore) SetOrUpdateDeviceAuthToken(ctx context.Context, hostID uint
 `
 	_, err := ds.writer(ctx).ExecContext(ctx, stmt, hostID, authToken)
 	if err != nil {
-		if strings.Contains(err.Error(), "Duplicate entry 'token'") {
+		if isDuplicate(err) {
 			return fleet.ConflictError{Message: "auth token conflicts with another host"}
 		}
 		return ctxerr.Wrap(ctx, err, "upsert host's device auth token")

--- a/server/datastore/mysql/hosts.go
+++ b/server/datastore/mysql/hosts.go
@@ -2266,6 +2266,9 @@ func (ds *Datastore) SetOrUpdateDeviceAuthToken(ctx context.Context, hostID uint
 `
 	_, err := ds.writer(ctx).ExecContext(ctx, stmt, hostID, authToken)
 	if err != nil {
+		if strings.Contains(err.Error(), "Duplicate entry 'token'") {
+			return fleet.ConflictError{Message: "auth token conflicts with another host"}
+		}
 		return ctxerr.Wrap(ctx, err, "upsert host's device auth token")
 	}
 	return nil

--- a/server/fleet/errors.go
+++ b/server/fleet/errors.go
@@ -543,3 +543,18 @@ const (
 	RunScriptAlreadyRunningErrMsg = "A script is already running on this host. Please wait about 1 minute to let it finish."
 	RunScriptHostTimeoutErrMsg    = "Fleet hasn’t heard from the host in over 1 minute. Fleet doesn’t know if the script ran because the host went offline."
 )
+
+// ConflictError is used to indicate a conflict, such as a UUID conflict in the DB.
+type ConflictError struct {
+	Message string
+}
+
+// Error implements the error interface for the ConflictError.
+func (e ConflictError) Error() string {
+	return e.Message
+}
+
+// StatusCode implements the kithttp.StatusCoder interface.
+func (e ConflictError) StatusCode() int {
+	return http.StatusConflict
+}

--- a/server/mdm/apple/commander.go
+++ b/server/mdm/apple/commander.go
@@ -242,7 +242,7 @@ type APNSDeliveryError struct {
 }
 
 func (e *APNSDeliveryError) Error() string {
-	return fmt.Sprintf("APNS delivery failed with: %e, for UUIDs: %v", e.Err, e.FailedUUIDs)
+	return fmt.Sprintf("APNS delivery failed with: %s, for UUIDs: %v", e.Err, e.FailedUUIDs)
 }
 
 func (e *APNSDeliveryError) Unwrap() error { return e.Err }


### PR DESCRIPTION
Fixed badly formatted error messages in /api/fleet/orbit/device_token endpoint and others.
In /api/fleet/orbit/device_token:
- Added token validation -- empty token not allowed
- Replaced 500 error with 409 when token conflicts with another host

#15832 

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [x] Added/updated tests
- [x] Manual QA
