### PR TITLE
On Software page, CVE tooltip no longer has bullets.

### DIFF
--- a/changes/15724-remove-bullets-from-CVEs
+++ b/changes/15724-remove-bullets-from-CVEs
@@ -1,0 +1,1 @@
+On Software page, CVE tooltip no longer has bullets.

--- a/frontend/pages/SoftwarePage/components/VulnerabilitiesCell/VulnerabilitiesCell.tsx
+++ b/frontend/pages/SoftwarePage/components/VulnerabilitiesCell/VulnerabilitiesCell.tsx
@@ -74,7 +74,7 @@ const generateTooltip = (
     >
       <ul className={`${baseClass}__vulnerability-list`}>
         {condensedVulnerabilties.map((vulnerability) => {
-          return <li>&bull; {vulnerability}</li>;
+          return <li>{vulnerability}</li>;
         })}
       </ul>
     </ReactTooltip>


### PR DESCRIPTION
On Software page, CVE tooltip no longer has bullets.
#15724 

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [x] Manual QA for all new/changed functionality
