### PR TITLE
Website: Update instructions on fleetctl preview page

### DIFF
--- a/website/assets/styles/pages/fleetctl-preview.less
+++ b/website/assets/styles/pages/fleetctl-preview.less
@@ -28,7 +28,7 @@
     padding: 24px;
     border: 1px solid @core-fleet-black-25;
     border-radius: 4px;
-    margin: 16px 0px 32px;
+    margin: 16px 0px 0px;
     background: @ui-off-white;
     p {
       color: @core-fleet-black;

--- a/website/views/pages/fleetctl-preview.ejs
+++ b/website/views/pages/fleetctl-preview.ejs
@@ -28,21 +28,10 @@
       <p>Install the <code>fleetctl</code> command line tool and start the Fleet preview experience:</p>
       <div purpose="terminal-commands">
         <p class="text-muted"># Install the Fleet command-line tool</p>
-        <p>sudo npm install -g fleetctl</p>
+        <p>npm install -global fleetctl</p>
         <p class="text-muted"># Run a local demo of the Fleet server</p>
-        <p>sudo fleetctl preview</p>
+        <p>fleetctl preview</p>
       </div>
-
-      <p class="mb-0"><img alt="A small circle with an 'I' inside of it"
-          style="width: 16px; display: inline; margin-right: 8px; margin-bottom: 3px"
-          src="/images/info-16x16@2x.png"><code>sudo</code> can be omitted on many Node/Docker installations.</p>
-      <p class="mb-0"><img alt="A small circle with an 'I' inside of it"
-          style="width: 16px; display: inline; margin-right: 8px; margin-bottom: 3px"
-          src="/images/info-16x16@2x.png">M1 macOS users must have <a href="https://support.apple.com/en-us/HT211861" target="_blank">Rosetta</a> installed in order to
-          run Fleet preview.</p>
-      <p class="mb-0"><img alt="A small circle with an 'I' inside of it"
-          style="width: 16px; display: inline; margin-right: 8px; margin-bottom: 3px"
-          src="/images/info-16x16@2x.png">Windows users should omit <code>sudo</code> and run the commands in <code>Cmd</code>/<code>PowerShell</code> as administrators.</p>
     </div>
     <div style="padding-top: 60px;">
       <h2 class="mb-3">3. Log in to Fleet</h2>


### PR DESCRIPTION
Closes: https://github.com/fleetdm/fleet/issues/14985


Changes:
- Removed `sudo` from the commands on the /fleetctl-preview page and removed the notes about Rosetta and `sudo`