### PR TITLE
Fix a bug that didn't allow to enable team disk encryption if macOS MDM is not configured

### DIFF
--- a/changes/15817-disk-encryption
+++ b/changes/15817-disk-encryption
@@ -1,0 +1,1 @@
+* Fix a bug that didn't allow to enable team disk encryption if macOS MDM was not configured.

--- a/cmd/fleet/cron.go
+++ b/cmd/fleet/cron.go
@@ -848,7 +848,7 @@ func verifyDiskEncryptionKeys(
 	config *config.FleetConfig,
 ) error {
 	if !config.MDM.IsAppleSCEPSet() {
-		logger.Log("inf", "skipping verification of encryption keys as MDM is not fully configured")
+		logger.Log("inf", "skipping verification of macOS encryption keys as MDM is not fully configured")
 		return nil
 	}
 

--- a/ee/server/service/teams.go
+++ b/ee/server/service/teams.go
@@ -1127,7 +1127,18 @@ func (svc *Service) updateTeamMDMAppleSettings(ctx context.Context, tm *fleet.Te
 		if _, err := svc.ds.SaveTeam(ctx, tm); err != nil {
 			return err
 		}
-		if didUpdateMacOSDiskEncryption {
+
+		appCfg, err := svc.ds.AppConfig(ctx)
+		if err != nil {
+			return err
+		}
+
+		// macOS-specific stuff. For legacy reasons we check if apple is configured
+		// via `appCfg.MDM.EnabledAndConfigured`
+		//
+		// TODO: is there a missing bitlocker activity feed item? (see same TODO on
+		// other methods that deal with disk encryption)
+		if appCfg.MDM.EnabledAndConfigured && didUpdateMacOSDiskEncryption {
 			var act fleet.ActivityDetails
 			if tm.Config.MDM.EnableDiskEncryption {
 				act = fleet.ActivityTypeEnabledMacosDiskEncryption{TeamID: &tm.ID, TeamName: &tm.Name}

--- a/server/service/handler.go
+++ b/server/service/handler.go
@@ -531,7 +531,6 @@ func attachFleetAPIRoutes(r *mux.Router, svc fleet.Service, config config.FleetC
 	mdmAppleMW.POST("/api/_version_/fleet/mdm/hosts/{id:[0-9]+}/wipe", deviceWipeEndpoint, deviceWipeRequest{})
 	mdmAppleMW.GET("/api/_version_/fleet/mdm/hosts/{id:[0-9]+}/profiles", getHostProfilesEndpoint, getHostProfilesRequest{})
 
-	mdmAppleMW.PATCH("/api/_version_/fleet/mdm/apple/settings", updateMDMAppleSettingsEndpoint, updateMDMAppleSettingsRequest{})
 	mdmAppleMW.PATCH("/api/_version_/fleet/mdm/apple/setup", updateMDMAppleSetupEndpoint, updateMDMAppleSetupRequest{})
 	mdmAppleMW.GET("/api/_version_/fleet/mdm/apple", getAppleMDMEndpoint, nil)
 
@@ -554,6 +553,10 @@ func attachFleetAPIRoutes(r *mux.Router, svc fleet.Service, config config.FleetC
 	mdmAnyMW.GET("/api/_version_/fleet/mdm/profiles/{profile_uuid}", getMDMConfigProfileEndpoint, getMDMConfigProfileRequest{})
 	mdmAnyMW.DELETE("/api/_version_/fleet/mdm/profiles/{profile_uuid}", deleteMDMConfigProfileEndpoint, deleteMDMConfigProfileRequest{})
 	mdmAnyMW.GET("/api/_version_/fleet/mdm/profiles", listMDMConfigProfilesEndpoint, listMDMConfigProfilesRequest{})
+	// TODO: this endpoint is being used as a platform-agnostic endpoint, but it
+	// contains "apple" in the path and the implementation is possibly very
+	// apple-biased. See issue #15884
+	mdmAnyMW.PATCH("/api/_version_/fleet/mdm/apple/settings", updateMDMAppleSettingsEndpoint, updateMDMAppleSettingsRequest{})
 
 	// the following set of mdm endpoints must always be accessible (even
 	// if MDM is not configured) as it bootstraps the setup of MDM

--- a/server/service/integration_mdm_test.go
+++ b/server/service/integration_mdm_test.go
@@ -3616,9 +3616,15 @@ func (s *integrationMDMTestSuite) TestAppConfigMDMAppleDiskEncryption() {
 		require.NoError(s.T(), err)
 	}()
 
-	// set and verify the value
+	// flip and verify the value
 	s.Do("PATCH", "/api/latest/fleet/mdm/apple/settings",
 		fleet.MDMAppleSettingsPayload{EnableDiskEncryption: ptr.Bool(false)}, http.StatusNoContent)
+	acResp = appConfigResponse{}
+	s.DoJSON("GET", "/api/latest/fleet/config", nil, http.StatusOK, &acResp)
+	assert.False(t, acResp.MDM.EnableDiskEncryption.Value)
+
+	s.Do("PATCH", "/api/latest/fleet/mdm/apple/settings",
+		fleet.MDMAppleSettingsPayload{EnableDiskEncryption: ptr.Bool(true)}, http.StatusNoContent)
 	acResp = appConfigResponse{}
 	s.DoJSON("GET", "/api/latest/fleet/config", nil, http.StatusOK, &acResp)
 	assert.True(t, acResp.MDM.EnableDiskEncryption.Value)


### PR DESCRIPTION
for #15817

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [x] Added/updated tests
- [x] Manual QA for all new/changed functionality
