### PR TITLE
osquery-perf to return expected win version data

### DIFF
--- a/changes/15268-osquery-perf-fix
+++ b/changes/15268-osquery-perf-fix
@@ -1,0 +1,1 @@
+- osquery-perf Windows 11 agents now return expected `os_version` detail query responses

--- a/cmd/osquery-perf/windows_11.tmpl
+++ b/cmd/osquery-perf/windows_11.tmpl
@@ -87,8 +87,7 @@
 [
   {
     "name":"Microsoft Windows 11 Enterprise",
-    "display_version":"21H2",
-    "release_id":"2009"
+    "version":"10.0.22000"
   }
 ]
 {{- end }}
@@ -99,8 +98,7 @@
     "platform":"windows",
     "arch":"x86_64",
     "kernel_version":"10.0.22000.1098",
-    "display_version":"21H2",
-    "release_id":"2009"
+    "version":"10.0.22000"
   }
 ]
 {{- end }}


### PR DESCRIPTION
#15268 

This change updates the detail query responses for osquery_perf `os_version` to return expected fields from the queries on Windows 11. 

- [X] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
