### PR TITLE
Service layer to return nil query results if discard data is true

### DIFF
--- a/server/service/queries.go
+++ b/server/service/queries.go
@@ -152,6 +152,10 @@ func (svc *Service) GetQueryReportResults(ctx context.Context, id uint) ([]fleet
 		return nil, err
 	}
 
+	if query.DiscardData {
+		return nil, nil
+	}
+
 	vc, ok := viewer.FromContext(ctx)
 	if !ok {
 		return nil, fleet.ErrNoContext


### PR DESCRIPTION
#14780 

Part 1: Return empty results at service layer if DiscardData is true in query regardless if results exist in database.

- [ ] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [X] Added/updated tests
- [X] Manual QA for all new/changed functionality

