### PR TITLE
Cleanup Query Results Cron

### DIFF
--- a/changes/14780-orphaned-query-results
+++ b/changes/14780-orphaned-query-results
@@ -1,0 +1,1 @@
+- resolved issue where some query results were still reporting after Discard Data is enabled on a Query

--- a/cmd/fleet/cron.go
+++ b/cmd/fleet/cron.go
@@ -834,6 +834,10 @@ func newCleanupsAndAggregationSchedule(
 				}
 			}
 
+			if err = ds.CleanupDiscardedQueryResults(ctx); err != nil {
+				return err
+			}
+
 			return nil
 		}),
 	)

--- a/server/datastore/mysql/query_results.go
+++ b/server/datastore/mysql/query_results.go
@@ -146,3 +146,16 @@ func (ds *Datastore) QueryResultRowsForHost(ctx context.Context, queryID, hostID
 
 	return results, nil
 }
+
+func (ds *Datastore) CleanupDiscardedQueryResults(ctx context.Context) error {
+	deleteStmt := `
+		DELETE FROM query_results 
+		WHERE query_id IN 
+			(SELECT id FROM queries WHERE discard_data = true)
+		`
+	_, err := ds.writer(ctx).ExecContext(ctx, deleteStmt)
+	if err != nil {
+		return ctxerr.Wrap(ctx, err, "cleaning up discarded query results")
+	}
+	return nil
+}

--- a/server/datastore/mysql/query_results_test.go
+++ b/server/datastore/mysql/query_results_test.go
@@ -680,12 +680,12 @@ func testCleanupQueryResultRows(t *testing.T, ds *Datastore) {
 	err = ds.CleanupDiscardedQueryResults(context.Background())
 	require.NoError(t, err)
 
-	// Verify that the rows with discard data set to false are removed
+	// Verify that the rows with discard data set to false are not removed
 	results, err := ds.QueryResultRows(context.Background(), queryNoDiscard.ID, fleet.TeamFilter{User: user})
 	require.NoError(t, err)
 	require.Len(t, results, 2)
 
-	// Verify that the rows with discard data set to true are not removed
+	// Verify that the rows with discard data set to true are removed
 	results, err = ds.QueryResultRows(context.Background(), queryDiscardTrue.ID, fleet.TeamFilter{User: user})
 	require.NoError(t, err)
 	require.Len(t, results, 0)

--- a/server/datastore/mysql/query_results_test.go
+++ b/server/datastore/mysql/query_results_test.go
@@ -27,6 +27,7 @@ func TestQueryResults(t *testing.T) {
 		{"MaxRows", testQueryResultRowsDoNotExceedMaxRows},
 		{"QueryResultRows", testQueryResultRows},
 		{"QueryResultRowsFilter", testQueryResultRowsTeamFilter},
+		{"CleanupQueryResultRows", testCleanupQueryResultRows},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
@@ -627,4 +628,65 @@ func testQueryResultRows(t *testing.T, ds *Datastore) {
 	results, err := ds.QueryResultRows(context.Background(), query.ID, filter)
 	require.NoError(t, err)
 	require.Len(t, results, 1)
+}
+
+func testCleanupQueryResultRows(t *testing.T, ds *Datastore) {
+	user := test.NewUser(t, ds, "Test User", "test@example.com", true)
+	queryNoDiscard := test.NewQuery(t, ds, nil, "Query No Discard", "SELECT 1", user.ID, true)
+	queryDiscardTrue := test.NewQuery(t, ds, nil, "Query Discard True", "SELECT 1", user.ID, true)
+	queryDiscardTrue.DiscardData = true
+	err := ds.SaveQuery(context.Background(), queryDiscardTrue, false, false)
+	require.NoError(t, err)
+
+	mockTime := time.Now().UTC().Truncate(time.Second)
+
+	// Insert query result rows
+	rows := []*fleet.ScheduledQueryResultRow{
+		{
+			QueryID:     queryNoDiscard.ID,
+			HostID:      1,
+			LastFetched: mockTime,
+			Data:        ptr.RawMessage([]byte(`{"model": "USB Mouse", "vendor": "Logitech"}`)),
+		},
+		{
+			QueryID:     queryNoDiscard.ID,
+			HostID:      1,
+			LastFetched: mockTime,
+			Data:        ptr.RawMessage([]byte(`{"model": "Keyboard", "vendor": "Microsoft"}`)),
+		},
+	}
+	err = ds.OverwriteQueryResultRows(context.Background(), rows)
+	require.NoError(t, err)
+
+	// Call OverwriteQueryResultRows again with different rows
+	overwriteRows := []*fleet.ScheduledQueryResultRow{
+		{
+			QueryID:     queryDiscardTrue.ID,
+			HostID:      1,
+			LastFetched: mockTime,
+			Data:        ptr.RawMessage([]byte(`{"model": "Headphones", "vendor": "Sony"}`)),
+		},
+		{
+			QueryID:     queryDiscardTrue.ID,
+			HostID:      1,
+			LastFetched: mockTime,
+			Data:        ptr.RawMessage([]byte(`{"model": "Speakers", "vendor": "Bose"}`)),
+		},
+	}
+	err = ds.OverwriteQueryResultRows(context.Background(), overwriteRows)
+	require.NoError(t, err)
+
+	// Cleanup query result rows
+	err = ds.CleanupDiscardedQueryResults(context.Background())
+	require.NoError(t, err)
+
+	// Verify that the rows with discard data set to false are removed
+	results, err := ds.QueryResultRows(context.Background(), queryNoDiscard.ID, fleet.TeamFilter{User: user})
+	require.NoError(t, err)
+	require.Len(t, results, 2)
+
+	// Verify that the rows with discard data set to true are not removed
+	results, err = ds.QueryResultRows(context.Background(), queryDiscardTrue.ID, fleet.TeamFilter{User: user})
+	require.NoError(t, err)
+	require.Len(t, results, 0)
 }

--- a/server/fleet/datastore.go
+++ b/server/fleet/datastore.go
@@ -416,6 +416,10 @@ type Datastore interface {
 	ResultCountForQuery(ctx context.Context, queryID uint) (int, error)
 	ResultCountForQueryAndHost(ctx context.Context, queryID, hostID uint) (int, error)
 	OverwriteQueryResultRows(ctx context.Context, rows []*ScheduledQueryResultRow) error
+	// CleanupDiscardedQueryResults deletes all query results for queries with DiscardData enabled.
+	// Used in cleanups_then_aggregation cron to cleanup rows that were inserted immediately
+	// after DiscardData was set to true due to query caching.
+	CleanupDiscardedQueryResults(ctx context.Context) error
 
 	///////////////////////////////////////////////////////////////////////////////
 	// TeamStore

--- a/server/mock/datastore_mock.go
+++ b/server/mock/datastore_mock.go
@@ -318,6 +318,8 @@ type ResultCountForQueryAndHostFunc func(ctx context.Context, queryID uint, host
 
 type OverwriteQueryResultRowsFunc func(ctx context.Context, rows []*fleet.ScheduledQueryResultRow) error
 
+type CleanupDiscardedQueryResultsFunc func(ctx context.Context) error
+
 type NewTeamFunc func(ctx context.Context, team *fleet.Team) (*fleet.Team, error)
 
 type SaveTeamFunc func(ctx context.Context, team *fleet.Team) (*fleet.Team, error)
@@ -1236,6 +1238,9 @@ type DataStore struct {
 
 	OverwriteQueryResultRowsFunc        OverwriteQueryResultRowsFunc
 	OverwriteQueryResultRowsFuncInvoked bool
+
+	CleanupDiscardedQueryResultsFunc        CleanupDiscardedQueryResultsFunc
+	CleanupDiscardedQueryResultsFuncInvoked bool
 
 	NewTeamFunc        NewTeamFunc
 	NewTeamFuncInvoked bool
@@ -2990,6 +2995,13 @@ func (s *DataStore) OverwriteQueryResultRows(ctx context.Context, rows []*fleet.
 	s.OverwriteQueryResultRowsFuncInvoked = true
 	s.mu.Unlock()
 	return s.OverwriteQueryResultRowsFunc(ctx, rows)
+}
+
+func (s *DataStore) CleanupDiscardedQueryResults(ctx context.Context) error {
+	s.mu.Lock()
+	s.CleanupDiscardedQueryResultsFuncInvoked = true
+	s.mu.Unlock()
+	return s.CleanupDiscardedQueryResultsFunc(ctx)
 }
 
 func (s *DataStore) NewTeam(ctx context.Context, team *fleet.Team) (*fleet.Team, error) {


### PR DESCRIPTION
#14780 

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [X] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [X] Added/updated tests
- [ ] Manual QA for all new/changed functionality