### PR TITLE
Update categorization of Windows OS updates to exclude from user-defined Windows MDM profiles in API responses 

### DIFF
--- a/changes/15714-windows-os-updates-profile-summary
+++ b/changes/15714-windows-os-updates-profile-summary
@@ -1,0 +1,3 @@
+- Modified hosts and labels endpoints so that only user-defined Windows MDM profiles are included in
+  filtered results, host details, and profiles summaries API responses (more specifically,
+  "Windows OS updates" is excluded from these responses).

--- a/server/datastore/mysql/hosts.go
+++ b/server/datastore/mysql/hosts.go
@@ -1090,14 +1090,6 @@ func (ds *Datastore) applyHostFilters(
 	sqlStmt, params, _ = hostSearchLike(sqlStmt, params, opt.MatchQuery, append(hostSearchColumns, "display_name")...)
 	sqlStmt, params = appendListOptionsWithCursorToSQL(sqlStmt, params, &opt.ListOptions)
 
-	// fmt.Println(sqlStmt)
-	// ps := "["
-	// for _, param := range params {
-	// 	ps += fmt.Sprintf("%q, ", param)
-	// }
-	// ps = strings.Trim(ps, ", ")
-	// fmt.Println(ps)
-
 	return sqlStmt, params, nil
 }
 

--- a/server/datastore/mysql/labels.go
+++ b/server/datastore/mysql/labels.go
@@ -593,7 +593,10 @@ func (ds *Datastore) applyHostLabelFilters(ctx context.Context, filter fleet.Tea
 	if enableDiskEncryption, err := ds.getConfigEnableDiskEncryption(ctx, opt.TeamFilter); err != nil {
 		return "", nil, err
 	} else if opt.OSSettingsFilter.IsValid() {
-		query, params = ds.filterHostsByOSSettingsStatus(query, opt, params, enableDiskEncryption)
+		query, params, err = ds.filterHostsByOSSettingsStatus(query, opt, params, enableDiskEncryption)
+		if err != nil {
+			return "", nil, err
+		}
 	} else if opt.OSSettingsDiskEncryptionFilter.IsValid() {
 		query, params = ds.filterHostsByOSSettingsDiskEncryptionStatus(query, opt, params, enableDiskEncryption)
 	}

--- a/server/datastore/mysql/microsoft_mdm.go
+++ b/server/datastore/mysql/microsoft_mdm.go
@@ -729,40 +729,46 @@ func (ds *Datastore) DeleteMDMWindowsConfigProfileByTeamAndName(ctx context.Cont
 	return nil
 }
 
-func subqueryHostsMDMWindowsOSSettingsStatusFailed() (string, []interface{}) {
+func subqueryHostsMDMWindowsOSSettingsStatusFailed() (string, []interface{}, error) {
 	sql := `
             SELECT
                 1 FROM host_mdm_windows_profiles hmwp
             WHERE
                 h.uuid = hmwp.host_uuid
-                AND hmwp.status = ?`
+                AND hmwp.status = ?
+                AND hmwp.profile_name NOT IN(?)`
 	args := []interface{}{
 		fleet.MDMDeliveryFailed,
+		mdm.ListFleetReservedWindowsProfileNames(),
 	}
 
-	return sql, args
+	return sqlx.In(sql, args...)
 }
 
-func subqueryHostsMDMWindowsOSSettingsStatusPending() (string, []interface{}) {
+func subqueryHostsMDMWindowsOSSettingsStatusPending() (string, []interface{}, error) {
 	sql := `
             SELECT
                 1 FROM host_mdm_windows_profiles hmwp
             WHERE
                 h.uuid = hmwp.host_uuid
                 AND (hmwp.status IS NULL OR hmwp.status = ?)
+				AND hmwp.profile_name NOT IN(?)
                 AND NOT EXISTS (
                     SELECT
                         1 FROM host_mdm_windows_profiles hmwp2
                     WHERE (h.uuid = hmwp2.host_uuid
-                        AND hmwp2.status = ?))`
+                        AND hmwp2.status = ?
+                        AND hmwp2.profile_name NOT IN(?)))`
 	args := []interface{}{
 		fleet.MDMDeliveryPending,
+		mdm.ListFleetReservedWindowsProfileNames(),
 		fleet.MDMDeliveryFailed,
+		mdm.ListFleetReservedWindowsProfileNames(),
 	}
-	return sql, args
+	return sqlx.In(sql, args...)
 }
 
-func subqueryHostsMDMWindowsOSSettingsStatusVerifying() (string, []interface{}) {
+func subqueryHostsMDMWindowsOSSettingsStatusVerifying() (string, []interface{}, error) {
 	sql := `
             SELECT
                 1 FROM host_mdm_windows_profiles hmwp
@@ -770,25 +776,28 @@ func subqueryHostsMDMWindowsOSSettingsStatusVerifying() (string, []interface{}) 
                 h.uuid = hmwp.host_uuid
                 AND hmwp.operation_type = ?
                 AND hmwp.status = ?
+                AND hmwp.profile_name NOT IN(?)
                 AND NOT EXISTS (
                     SELECT
                         1 FROM host_mdm_windows_profiles hmwp2
                     WHERE (h.uuid = hmwp2.host_uuid
                         AND hmwp2.operation_type = ?
+                        AND hmwp2.profile_name NOT IN(?)
                         AND(hmwp2.status IS NULL
-                            OR hmwp2.status NOT IN(?, ?))))`
+                            OR hmwp2.status NOT IN(?))))`
 
 	args := []interface{}{
 		fleet.MDMOperationTypeInstall,
 		fleet.MDMDeliveryVerifying,
+		mdm.ListFleetReservedWindowsProfileNames(),
 		fleet.MDMOperationTypeInstall,
-		fleet.MDMDeliveryVerifying,
-		fleet.MDMDeliveryVerified,
+		mdm.ListFleetReservedWindowsProfileNames(),
+		[]interface{}{fleet.MDMDeliveryVerifying, fleet.MDMDeliveryVerified},
 	}
-	return sql, args
+	return sqlx.In(sql, args...)
 }
 
-func subqueryHostsMDMWindowsOSSettingsStatusVerified() (string, []interface{}) {
+func subqueryHostsMDMWindowsOSSettingsStatusVerified() (string, []interface{}, error) {
 	sql := `
             SELECT
                 1 FROM host_mdm_windows_profiles hmwp
@@ -796,20 +805,24 @@ func subqueryHostsMDMWindowsOSSettingsStatusVerified() (string, []interface{}) {
                 h.uuid = hmwp.host_uuid
                 AND hmwp.operation_type = ?
                 AND hmwp.status = ?
+                AND hmwp.profile_name NOT IN(?)
                 AND NOT EXISTS (
                     SELECT
                         1 FROM host_mdm_windows_profiles hmwp2
                     WHERE (h.uuid = hmwp2.host_uuid
                         AND hmwp2.operation_type = ?
+                        AND hmwp2.profile_name NOT IN(?)
                         AND(hmwp2.status IS NULL
                             OR hmwp2.status != ?)))`
 	args := []interface{}{
 		fleet.MDMOperationTypeInstall,
 		fleet.MDMDeliveryVerified,
+		mdm.ListFleetReservedWindowsProfileNames(),
 		fleet.MDMOperationTypeInstall,
+		mdm.ListFleetReservedWindowsProfileNames(),
 		fleet.MDMDeliveryVerified,
 	}
-	return sql, args
+	return sqlx.In(sql, args...)
 }
 
 func (ds *Datastore) GetMDMWindowsProfilesSummary(ctx context.Context, teamID *uint) (*fleet.MDMProfilesSummary, error) {
@@ -856,13 +869,25 @@ type statusCounts struct {
 
 func getMDMWindowsStatusCountsProfilesOnlyDB(ctx context.Context, ds *Datastore, teamID *uint) ([]statusCounts, error) {
 	var args []interface{}
-	subqueryFailed, subqueryFailedArgs := subqueryHostsMDMWindowsOSSettingsStatusFailed()
+	subqueryFailed, subqueryFailedArgs, err := subqueryHostsMDMWindowsOSSettingsStatusFailed()
+	if err != nil {
+		return nil, ctxerr.Wrap(ctx, err, "subqueryHostsMDMWindowsOSSettingsStatusFailed")
+	}
 	args = append(args, subqueryFailedArgs...)
-	subqueryPending, subqueryPendingArgs := subqueryHostsMDMWindowsOSSettingsStatusPending()
+	subqueryPending, subqueryPendingArgs, err := subqueryHostsMDMWindowsOSSettingsStatusPending()
+	if err != nil {
+		return nil, ctxerr.Wrap(ctx, err, "subqueryHostsMDMWindowsOSSettingsStatusPending")
+	}
 	args = append(args, subqueryPendingArgs...)
-	subqueryVerifying, subqueryVeryingingArgs := subqueryHostsMDMWindowsOSSettingsStatusVerifying()
+	subqueryVerifying, subqueryVeryingingArgs, err := subqueryHostsMDMWindowsOSSettingsStatusVerifying()
+	if err != nil {
+		return nil, ctxerr.Wrap(ctx, err, "subqueryHostsMDMWindowsOSSettingsStatusVerifying")
+	}
 	args = append(args, subqueryVeryingingArgs...)
-	subqueryVerified, subqueryVerifiedArgs := subqueryHostsMDMWindowsOSSettingsStatusVerified()
+	subqueryVerified, subqueryVerifiedArgs, err := subqueryHostsMDMWindowsOSSettingsStatusVerified()
+	if err != nil {
+		return nil, ctxerr.Wrap(ctx, err, "subqueryHostsMDMWindowsOSSettingsStatusVerified")
+	}
 	args = append(args, subqueryVerifiedArgs...)
 
 	teamFilter := "h.team_id IS NULL"
@@ -907,7 +932,7 @@ GROUP BY
 	)
 
 	var counts []statusCounts
-	err := sqlx.SelectContext(ctx, ds.reader(ctx), &counts, stmt, args...)
+	err = sqlx.SelectContext(ctx, ds.reader(ctx), &counts, stmt, args...)
 	if err != nil {
 		return nil, err
 	}
@@ -916,13 +941,25 @@ GROUP BY
 
 func getMDMWindowsStatusCountsProfilesAndBitLockerDB(ctx context.Context, ds *Datastore, teamID *uint) ([]statusCounts, error) {
 	var args []interface{}
-	subqueryFailed, subqueryFailedArgs := subqueryHostsMDMWindowsOSSettingsStatusFailed()
+	subqueryFailed, subqueryFailedArgs, err := subqueryHostsMDMWindowsOSSettingsStatusFailed()
+	if err != nil {
+		return nil, ctxerr.Wrap(ctx, err, "subqueryHostsMDMWindowsOSSettingsStatusFailed")
+	}
 	args = append(args, subqueryFailedArgs...)
-	subqueryPending, subqueryPendingArgs := subqueryHostsMDMWindowsOSSettingsStatusPending()
+	subqueryPending, subqueryPendingArgs, err := subqueryHostsMDMWindowsOSSettingsStatusPending()
+	if err != nil {
+		return nil, ctxerr.Wrap(ctx, err, "subqueryHostsMDMWindowsOSSettingsStatusPending")
+	}
 	args = append(args, subqueryPendingArgs...)
-	subqueryVerifying, subqueryVeryingingArgs := subqueryHostsMDMWindowsOSSettingsStatusVerifying()
+	subqueryVerifying, subqueryVeryingingArgs, err := subqueryHostsMDMWindowsOSSettingsStatusVerifying()
+	if err != nil {
+		return nil, ctxerr.Wrap(ctx, err, "subqueryHostsMDMWindowsOSSettingsStatusVerifying")
+	}
 	args = append(args, subqueryVeryingingArgs...)
-	subqueryVerified, subqueryVerifiedArgs := subqueryHostsMDMWindowsOSSettingsStatusVerified()
+	subqueryVerified, subqueryVerifiedArgs, err := subqueryHostsMDMWindowsOSSettingsStatusVerified()
+	if err != nil {
+		return nil, ctxerr.Wrap(ctx, err, "subqueryHostsMDMWindowsOSSettingsStatusVerified")
+	}
 	args = append(args, subqueryVerifiedArgs...)
 
 	profilesStatus := fmt.Sprintf(`
@@ -1030,7 +1067,7 @@ GROUP BY
 	)
 
 	var counts []statusCounts
-	err := sqlx.SelectContext(ctx, ds.reader(ctx), &counts, stmt, args...)
+	err = sqlx.SelectContext(ctx, ds.reader(ctx), &counts, stmt, args...)
 	if err != nil {
 		return nil, err
 	}
@@ -1651,7 +1688,7 @@ SELECT
 FROM
 	host_mdm_windows_profiles
 WHERE
-host_uuid = ? AND NOT (operation_type = '%s' AND COALESCE(status, '%s') IN('%s', '%s'))`,
+host_uuid = ? AND profile_name NOT IN(?) AND NOT (operation_type = '%s' AND COALESCE(status, '%s') IN('%s', '%s'))`,
 		fleet.MDMDeliveryPending,
 		fleet.MDMOperationTypeRemove,
 		fleet.MDMDeliveryPending,
@@ -1659,8 +1696,13 @@ host_uuid = ? AND NOT (operation_type = '%s' AND COALESCE(status, '%s') IN('%s',
 		fleet.MDMDeliveryVerified,
 	)
 
+	stmt, args, err := sqlx.In(stmt, hostUUID, mdm.ListFleetReservedWindowsProfileNames())
+	if err != nil {
+		return nil, ctxerr.Wrap(ctx, err, "building in statement")
+	}
+
 	var profiles []fleet.HostMDMWindowsProfile
-	if err := sqlx.SelectContext(ctx, ds.reader(ctx), &profiles, stmt, hostUUID); err != nil {
+	if err := sqlx.SelectContext(ctx, ds.reader(ctx), &profiles, stmt, args...); err != nil {
 		return nil, err
 	}
 	return profiles, nil

--- a/server/mdm/mdm.go
+++ b/server/mdm/mdm.go
@@ -80,3 +80,9 @@ func FleetReservedProfileNames() map[string]struct{} {
 		FleetWindowsOSUpdatesProfileName: {},
 	}
 }
+
+// ListFleetReservedWindowsProfileNames returns a list of PayloadDisplayName strings
+// that are reserved by Fleet for Windows.
+func ListFleetReservedWindowsProfileNames() []string {
+	return []string{FleetWindowsOSUpdatesProfileName}
+}

--- a/server/service/integration_mdm_test.go
+++ b/server/service/integration_mdm_test.go
@@ -10116,7 +10116,7 @@ func (s *integrationMDMTestSuite) TestWindowsProfileManagement() {
 
 	// simulate osquery reporting host mdm details (host_mdm.enrolled = 1 is condition for
 	// hosts filtering by os settings status and generating mdm profiles summaries)
-	s.ds.SetOrUpdateMDMData(ctx, host.ID, false, true, s.server.URL, false, fleet.WellKnownMDMFleet, "")
+	require.NoError(t, s.ds.SetOrUpdateMDMData(ctx, host.ID, false, true, s.server.URL, false, fleet.WellKnownMDMFleet, ""))
 	checkHostsFilteredByOSSettingsStatus(t, []string{host.Hostname}, fleet.MDMDeliveryVerifying, nil, label)
 	s.checkMDMProfilesSummaries(t, nil, fleet.MDMProfilesSummary{
 		Verifying: 1,


### PR DESCRIPTION
Issue #15714

- Modify hosts and labels endpoints so that only user-defined Windows MDM profiles are included in filtered results, host details, and profiles summaries API responses (more specifically, the "Windows OS updates" profile should be excluded from these responses).

# Checklist for submitter
- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
- [x] Added/updated tests
- [x] Manual QA for all new/changed functionality

