### PR TITLE
Allow `context` and `debug` flags after `fleetctl generate` subcommands

### DIFF
--- a/changes/15436-fleetctl-generate-context
+++ b/changes/15436-fleetctl-generate-context
@@ -1,0 +1,1 @@
+- Fixed bug where fleetctl did not allow placement of `--context` and `--debug` flages following the `generate mdm-apple` and `generate mdm-apple-bm` commands.

--- a/cmd/fleetctl/generate.go
+++ b/cmd/fleetctl/generate.go
@@ -38,6 +38,8 @@ func generateMDMAppleCommand() *cli.Command {
 		Aliases: []string{"mdm_apple"},
 		Usage:   "Generates certificate signing request (CSR) and key for Apple Push Notification Service (APNs) and certificate and key for Simple Certificate Enrollment Protocol (SCEP) to turn on MDM features.",
 		Flags: []cli.Flag{
+			contextFlag(),
+			debugFlag(),
 			&cli.StringFlag{
 				Name:     "email",
 				Usage:    "The email address to send the signed APNS csr to.",
@@ -132,6 +134,8 @@ func generateMDMAppleBMCommand() *cli.Command {
 		Aliases: []string{"mdm_apple_bm"},
 		Usage:   "Generate Apple Business Manager public and private keys to enable automatic enrollment for macOS hosts.",
 		Flags: []cli.Flag{
+			contextFlag(),
+			debugFlag(),
 			&cli.StringFlag{
 				Name:  "public-key",
 				Usage: "The output path for the Apple Business Manager public key certificate.",

--- a/cmd/fleetctl/generate_test.go
+++ b/cmd/fleetctl/generate_test.go
@@ -86,6 +86,8 @@ func TestGenerateMDMApple(t *testing.T) {
 			"--apns-key", apnsKeyPath,
 			"--scep-cert", scepCertPath,
 			"--scep-key", scepKeyPath,
+			"--debug",
+			"--context", "default",
 		})
 
 		require.Contains(t, out, fmt.Sprintf("Generated your APNs key at %s", apnsKeyPath))


### PR DESCRIPTION
Issue #15436

# Checklist for submitter
<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
- [x] Added/updated tests
- [x] Manual QA for all new/changed functionality

