### PR TITLE
Update dogfood to use new downtime migrations

### DIFF
--- a/infrastructure/dogfood/terraform/aws-tf-module/free.tf
+++ b/infrastructure/dogfood/terraform/aws-tf-module/free.tf
@@ -15,7 +15,7 @@ locals {
 }
 
 module "free" {
-  source = "github.com/fleetdm/fleet//terraform/byo-vpc?ref=tf-mod-byo-vpc-v1.7.1"
+  source = "github.com/fleetdm/fleet//terraform/byo-vpc?ref=tf-mod-byo-vpc-v1.8.0"
   vpc_config = {
     name   = local.customer_free
     vpc_id = module.main.vpc.vpc_id
@@ -131,10 +131,13 @@ module "migrations_free" {
   depends_on = [
     module.geolite2
   ]
-  source                   = "github.com/fleetdm/fleet//terraform/addons/migrations?ref=tf-mod-addon-migrations-v1.0.0"
+  source                   = "github.com/fleetdm/fleet//terraform/addons/migrations?ref=tf-mod-addon-migrations-v2.0.0"
   ecs_cluster              = module.free.byo-db.byo-ecs.service.cluster
   task_definition          = module.free.byo-db.byo-ecs.task_definition.family
   task_definition_revision = module.free.byo-db.byo-ecs.task_definition.revision
   subnets                  = module.free.byo-db.byo-ecs.service.network_configuration[0].subnets
   security_groups          = module.free.byo-db.byo-ecs.service.network_configuration[0].security_groups
+  ecs_service              = module.main.byo-vpc.byo-db.byo-ecs.service.name
+  desired_count            = module.main.byo-vpc.byo-db.byo-ecs.appautoscaling_target.min_capacity
+  min_capacity             = module.main.byo-vpc.byo-db.byo-ecs.appautoscaling_target.min_capacity
 }

--- a/infrastructure/dogfood/terraform/aws-tf-module/free.tf
+++ b/infrastructure/dogfood/terraform/aws-tf-module/free.tf
@@ -137,7 +137,7 @@ module "migrations_free" {
   task_definition_revision = module.free.byo-db.byo-ecs.task_definition.revision
   subnets                  = module.free.byo-db.byo-ecs.service.network_configuration[0].subnets
   security_groups          = module.free.byo-db.byo-ecs.service.network_configuration[0].security_groups
-  ecs_service              = module.main.byo-vpc.byo-db.byo-ecs.service.name
-  desired_count            = module.main.byo-vpc.byo-db.byo-ecs.appautoscaling_target.min_capacity
-  min_capacity             = module.main.byo-vpc.byo-db.byo-ecs.appautoscaling_target.min_capacity
+  ecs_service              = module.free.byo-db.byo-ecs.service.name
+  desired_count            = module.free.byo-db.byo-ecs.appautoscaling_target.min_capacity
+  min_capacity             = module.free.byo-db.byo-ecs.appautoscaling_target.min_capacity
 }

--- a/infrastructure/dogfood/terraform/aws-tf-module/main.tf
+++ b/infrastructure/dogfood/terraform/aws-tf-module/main.tf
@@ -63,7 +63,7 @@ locals {
 }
 
 module "main" {
-  source          = "github.com/fleetdm/fleet//terraform?ref=tf-mod-root-v1.6.1"
+  source          = "github.com/fleetdm/fleet//terraform?ref=tf-mod-root-v1.7.0"
   certificate_arn = module.acm.acm_certificate_arn
   vpc = {
     name = local.customer
@@ -243,12 +243,15 @@ module "migrations" {
   depends_on = [
     module.geolite2
   ]
-  source                   = "github.com/fleetdm/fleet//terraform/addons/migrations?ref=tf-mod-addon-migrations-v1.0.0"
+  source                   = "github.com/fleetdm/fleet//terraform/addons/migrations?ref=tf-mod-addon-migrations-v2.0.0"
   ecs_cluster              = module.main.byo-vpc.byo-db.byo-ecs.service.cluster
   task_definition          = module.main.byo-vpc.byo-db.byo-ecs.task_definition.family
   task_definition_revision = module.main.byo-vpc.byo-db.byo-ecs.task_definition.revision
   subnets                  = module.main.byo-vpc.byo-db.byo-ecs.service.network_configuration[0].subnets
   security_groups          = module.main.byo-vpc.byo-db.byo-ecs.service.network_configuration[0].security_groups
+  ecs_service              = module.main.byo-vpc.byo-db.byo-ecs.service.name
+  desired_count            = module.main.byo-vpc.byo-db.byo-ecs.appautoscaling_target.min_capacity
+  min_capacity             = module.main.byo-vpc.byo-db.byo-ecs.appautoscaling_target.min_capacity
 }
 
 module "mdm" {


### PR DESCRIPTION
This should be put in place prior to pushing the release or an RC to dogfood.