### PR TITLE
Update osquery-perf template for simulated Windows host

### DIFF
--- a/cmd/osquery-perf/windows_11.tmpl
+++ b/cmd/osquery-perf/windows_11.tmpl
@@ -87,8 +87,7 @@
 [
   {
     "name":"Microsoft Windows 11 Enterprise",
-    "display_version":"21H2",
-    "release_id":"2009"
+    "version":"10.0.22000"
   }
 ]
 {{- end }}
@@ -99,8 +98,7 @@
     "platform":"windows",
     "arch":"x86_64",
     "kernel_version":"10.0.22000.1098",
-    "display_version":"21H2",
-    "release_id":"2009"
+    "version":"10.0.22000"
   }
 ]
 {{- end }}


### PR DESCRIPTION
Issue #15384 

- Update response templates used by osquery-perf for simulated Windows hosts to track current `os_version_windows` and `os_windows` [detail queries](https://github.com/fleetdm/fleet/blob/2d9eb94e8dc59b66387ca38e88fe650f3a709a4d/server/service/osquery_utils/queries.go#L519)

# Checklist for submitter
- [x] Added support on fleet's osquery simulator `cmd/osquery-perf` for new osquery data ingestion features.
