### PR TITLE
Added warning/info messages when downgrading/upgrading fleetd or osquery.

### DIFF
--- a/changes/15890-warning-when-downgrading
+++ b/changes/15890-warning-when-downgrading
@@ -1,0 +1,1 @@
+Added warning/info messages when downgrading/upgrading fleetd or osquery.

--- a/orbit/cmd/orbit/orbit.go
+++ b/orbit/cmd/orbit/orbit.go
@@ -418,6 +418,18 @@ func main() {
 				return err
 			}
 
+			// Get current version of osquery
+			osquerydPath, err = updater.ExecutableLocalPath("osqueryd")
+			if err != nil {
+				log.Info().Err(err).Msg("Could not find local osqueryd executable")
+			} else {
+				version := update.GetVersion(osquerydPath)
+				if version != "" {
+					log.Info().Msgf("Found osquery version: %s", version)
+					updateRunner.OsqueryVersion = version
+				}
+			}
+
 			// Perform early check for updates before starting any sub-system.
 			// This is to prevent bugs in other sub-systems to mess up with
 			// the download of available updates.

--- a/orbit/pkg/update/runner.go
+++ b/orbit/pkg/update/runner.go
@@ -337,7 +337,7 @@ func compareVersion(path string, oldVersion string, targetDisplayName string) *i
 		case 1:
 			log.Warn().Msgf("Downgrading %s from %s to %s", targetDisplayName, oldVersion, newVersion)
 		case 0:
-			log.Warn().Msgf("Updating %s to the same version %s", targetDisplayName, newVersion)
+			log.Warn().Msgf("Updating %s to the same version (%s == %s)", targetDisplayName, oldVersion, newVersion)
 		case -1:
 			log.Info().Msgf("Upgrading %s from %s to %s", targetDisplayName, oldVersion, newVersion)
 		}

--- a/orbit/pkg/update/runner_test.go
+++ b/orbit/pkg/update/runner_test.go
@@ -67,6 +67,7 @@ func TestGetVersion(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("Skipping test on Windows")
 	}
+	t.Parallel()
 	testCases := map[string]struct {
 		cmd     string
 		version string
@@ -89,8 +90,10 @@ func TestGetVersion(t *testing.T) {
 		},
 	}
 	for name, tc := range testCases {
+		tc := tc // capture range variable, needed for parallel tests
 		t.Run(
 			name, func(t *testing.T) {
+				t.Parallel()
 				// create a temp executable file
 				dir := t.TempDir()
 				file, err := os.CreateTemp(dir, "binary")
@@ -112,6 +115,7 @@ func TestCompareVersion(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("Skipping test on Windows")
 	}
+	t.Parallel()
 	testCases := map[string]struct {
 		cmd        string
 		oldVersion string
@@ -154,8 +158,10 @@ func TestCompareVersion(t *testing.T) {
 		},
 	}
 	for name, tc := range testCases {
+		tc := tc // capture range variable, needed for parallel tests
 		t.Run(
 			name, func(t *testing.T) {
+				t.Parallel()
 				// create a temp executable file
 				dir := t.TempDir()
 				file, err := os.CreateTemp(dir, "binary")

--- a/orbit/pkg/update/runner_test.go
+++ b/orbit/pkg/update/runner_test.go
@@ -96,6 +96,7 @@ func TestGetVersion(t *testing.T) {
 				file, err := os.CreateTemp(dir, "binary")
 				require.NoError(t, err)
 				_, err = file.WriteString(tc.cmd)
+				require.NoError(t, err)
 				err = file.Chmod(0755)
 				require.NoError(t, err)
 				_ = file.Close()
@@ -126,6 +127,11 @@ func TestCompareVersion(t *testing.T) {
 			oldVersion: "5.10.2-26-gc396d07b4-dirty",
 			expected:   ptr.Int(0),
 		},
+		"same 2": {
+			cmd:        "#!/bin/bash\n/bin/echo osquery version 5.10",
+			oldVersion: "5.10.0",
+			expected:   ptr.Int(0),
+		},
 		"upgrade": {
 			cmd:        "#!/bin/bash\n/bin/echo osquery version 5.10.10",
 			oldVersion: "5.10.9",
@@ -141,6 +147,11 @@ func TestCompareVersion(t *testing.T) {
 			oldVersion: "",
 			expected:   nil,
 		},
+		"invalid old version 2": {
+			cmd:        "#!/bin/bash\n/bin/echo orbit 1",
+			oldVersion: "1.01", // invalid, needs to be 1.1
+			expected:   nil,
+		},
 	}
 	for name, tc := range testCases {
 		t.Run(
@@ -150,6 +161,7 @@ func TestCompareVersion(t *testing.T) {
 				file, err := os.CreateTemp(dir, "binary")
 				require.NoError(t, err)
 				_, err = file.WriteString(tc.cmd)
+				require.NoError(t, err)
 				err = file.Chmod(0755)
 				require.NoError(t, err)
 				_ = file.Close()


### PR DESCRIPTION
Added warning/info messages when downgrading/upgrading fleetd or osquery. No other functional changes.
#15890 

Tested with fleetd and osquery on windows, linux, and macOS.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [x] Added/updated tests
- [x] Manual QA for all new/changed functionality
  - For Orbit and Fleet Desktop changes:
    - [x] Manual QA must be performed in the three main OSs, macOS, Windows and Linux.
    - [x] Auto-update manual QA, from released version of component to new version (see [tools/tuf/test](../tools/tuf/test/README.md)).
