### PR TITLE
Use info-level logging for cases where a custom enrollment profile is not found by fleetd

### DIFF
--- a/orbit/cmd/orbit/orbit.go
+++ b/orbit/cmd/orbit/orbit.go
@@ -1009,6 +1009,7 @@ func main() {
 			email, err := profiles.GetCustomEnrollmentProfileEndUserEmail()
 			if err != nil {
 				if errors.Is(err, profiles.ErrNotFound) {
+					// This is fine. Many hosts will not have this profile so just log and continue.
 					log.Info().Msg(fmt.Sprintf("get custom enrollment profile end user email: %s", err))
 				} else {
 					log.Error().Err(err).Msg("get custom enrollment profile end user email")

--- a/orbit/cmd/orbit/orbit.go
+++ b/orbit/cmd/orbit/orbit.go
@@ -1008,8 +1008,13 @@ func main() {
 			log.Info().Msg("checking for custom mdm enrollment profile with end user email")
 			email, err := profiles.GetCustomEnrollmentProfileEndUserEmail()
 			if err != nil {
-				log.Error().Err(err).Msg("get custom enrollment profile end user email")
+				if errors.Is(err, profiles.ErrNotFound) {
+					log.Info().Msg(fmt.Sprintf("get custom enrollment profile end user email: %s", err))
+				} else {
+					log.Error().Err(err).Msg("get custom enrollment profile end user email")
+				}
 			}
+
 			if email != "" {
 				log.Info().Msg(fmt.Sprintf("found custom end user email: %s", email))
 				if err := orbitClient.SetOrUpdateDeviceMappingEmail(email); err != nil {


### PR DESCRIPTION
Related #15057 

Use info-level logging for cases where a custom enrollment profile is not found. Many hosts will not have this profile so just log and continue.