### PR TITLE
Software Aggregation bug in vuln processing command

### DIFF
--- a/changes/15930-bugfix-vuln-cmd
+++ b/changes/15930-bugfix-vuln-cmd
@@ -1,0 +1,2 @@
+- fixed issue where software title aggregation was not running when triggering a vulnerability scan
+  via `fleet vuln_processing`


### PR DESCRIPTION
#15930 

As mentioned in comments of #15930, the `fleet vuln_processing` command was missing 2 datastore methods that currently exist in the vuln cron job.  In addition to adding the missing functions, there is a refactor to ensure both the cron and the command use the same  functions.

- [X] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [ ] Added/updated tests
- [X] Manual QA for all new/changed functionality