### PR TITLE
Feature/CIS-Controls-Sonoma

### DIFF
--- a/ee/cis/macos-14/cis-policy-queries.yml
+++ b/ee/cis/macos-14/cis-policy-queries.yml
@@ -1252,7 +1252,7 @@ spec:
     /*CIS does not make a hard recommendation for this policy. Fleet has provided two policies (one failing, one succeeding). 
       Depending on your organization's decision, you can delete this policy or its counterpart.*/
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1
+  tags: compliance, CIS, CIS_Level1, decision-needed
   contributors: sharon-fdm
 ---
 apiVersion: v1

--- a/ee/cis/macos-14/cis-policy-queries.yml
+++ b/ee/cis/macos-14/cis-policy-queries.yml
@@ -227,7 +227,7 @@ spec:
     /*CIS does not make a hard recommendation for this policy. Fleet has provided two policies (one failing, one succeeding). 
       Depending on your organization's decision, you can delete this policy or its counterpart.*/
   purpose: Informational
-  tags: compliance, CIS, CIS_Level2
+  tags: compliance, CIS, CIS_Level2, decision-needed
   contributors: sharon-fdm
 ---
 apiVersion: v1

--- a/ee/cis/macos-14/cis-policy-queries.yml
+++ b/ee/cis/macos-14/cis-policy-queries.yml
@@ -264,7 +264,7 @@ spec:
     /*CIS does not make a hard recommendation for this policy. Fleet has provided two policies (one failing, one succeeding). 
       Depending on your organization's decision, you can delete this policy or its counterpart.*/
   purpose: Informational
-  tags: compliance, CIS, CIS_Level2
+  tags: compliance, CIS, CIS_Level2, decision-needed
   contributors: sharon-fdm
 ---
 apiVersion: v1

--- a/ee/cis/macos-14/cis-policy-queries.yml
+++ b/ee/cis/macos-14/cis-policy-queries.yml
@@ -3371,7 +3371,7 @@ spec:
       p.value IS NULL
     );
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1
+  tags: compliance, CIS, CIS_Level1, decision-needed
   contributors: artemist-work
 ---
 apiVersion: v1

--- a/ee/cis/macos-14/cis-policy-queries.yml
+++ b/ee/cis/macos-14/cis-policy-queries.yml
@@ -1470,7 +1470,7 @@ spec:
             )
         );
   purpose: Informational
-  tags: compliance, CIS, CIS_Level2
+  tags: compliance, CIS, CIS_Level2, decision-needed
   contributors: sharon-fdm
 ---
 apiVersion: v1

--- a/ee/cis/macos-14/cis-policy-queries.yml
+++ b/ee/cis/macos-14/cis-policy-queries.yml
@@ -302,7 +302,7 @@ spec:
     /*CIS does not make a hard recommendation for this policy. Fleet has provided two policies (one failing, one succeeding). 
       Depending on your organization's decision, you can delete this policy or its counterpart.*/
   purpose: Informational
-  tags: compliance, CIS, CIS_Level2
+  tags: compliance, CIS, CIS_Level2, decision-needed
   contributors: sharon-fdm
 ---
 apiVersion: v1

--- a/ee/cis/macos-14/cis-policy-queries.yml
+++ b/ee/cis/macos-14/cis-policy-queries.yml
@@ -1,0 +1,3486 @@
+---
+# The latest version of CIS Benchmarks for macOS as of January 2024 for macOS 14.
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure All Apple-provided Software Is Current (Fleetd Required)
+  platforms: macOS
+  platform: darwin
+  description: |
+    Software vendors release security patches and software updates for their products when security vulnerabilities are discovered. There is no simple way to complete this action without a network connection to an Apple software repository. Please ensure appropriate access for this control. This check is only for what Apple provides through software update.
+    Note: This query may be longer than the avg query and may take more than 10 seconds to run.
+  resolution: |
+    Graphical Method:
+    Perform the following to install all available software updates:
+      1. Open System Settings 
+      2. Select General
+      3. Select Software Update
+      4. Select Update All
+  query: SELECT 1 FROM software_update WHERE software_update_required = '0';
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1, CIS-macos-13-1.1
+  contributors: sharon-fdm
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure Auto Update Is Enabled (MDM Required)
+  platforms: macOS
+  platform: darwin
+  description: Checks that the system is configured via MDM to automatically install updates.
+  resolution: "Ask your system administrator to deploy an MDM profile that enables automatic updates."
+  query: |
+    SELECT 1 WHERE 
+      EXISTS (
+        SELECT 1 FROM managed_policies WHERE 
+            domain='com.apple.SoftwareUpdate' AND 
+            name='AutomaticCheckEnabled' AND 
+            (value = 1 OR value = 'true') AND 
+            username = ''
+        )
+      AND NOT EXISTS (
+        SELECT 1 FROM managed_policies WHERE 
+            domain='com.apple.SoftwareUpdate' AND 
+            name='AutomaticCheckEnabled' AND 
+            (value != 1 AND value != 'true')
+        );  
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1, CIS-macos-13-1.2
+  contributors: sharon-fdm
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure Download New Updates When Available Is Enabled (MDM Required)
+  platforms: macOS
+  platform: darwin
+  description: Checks that the system is configured via MDM to automatically download updates.
+  resolution: "Ask your system administrator to deploy an MDM profile that enables automatic update downloads."
+  query: |
+    SELECT 1 WHERE 
+      EXISTS (
+        SELECT 1 FROM managed_policies WHERE 
+            domain='com.apple.SoftwareUpdate' AND 
+            name='AutomaticDownload' AND 
+            (value = 1 OR value = 'true') AND 
+            username = ''
+        )
+      AND NOT EXISTS (
+        SELECT 1 FROM managed_policies WHERE 
+            domain='com.apple.SoftwareUpdate' AND 
+            name='AutomaticDownload' AND 
+            (value != 1 AND value != 'true')
+        );  
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1, CIS-macos-13-1.3
+  contributors: sharon-fdm
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure Install of macOS Updates Is Enabled (MDM Required)
+  platforms: macOS
+  platform: darwin
+  description: Ensure that macOS updates are installed after they are available from Apple.
+  resolution: "Ask your system administrator to deploy an MDM profile that enables automatic install of macOS updates."
+  query: |
+    SELECT 1 WHERE 
+      EXISTS (
+        SELECT 1 FROM managed_policies WHERE 
+            domain='com.apple.SoftwareUpdate' AND 
+            name='AutomaticallyInstallMacOSUpdates' AND 
+            (value = 1 OR value = 'true') AND 
+            username = ''
+        )
+      AND NOT EXISTS (
+        SELECT 1 FROM managed_policies WHERE 
+            domain='com.apple.SoftwareUpdate' AND 
+            name='AutomaticallyInstallMacOSUpdates' AND 
+            (value != 1 AND value != 'true')
+        );  
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1, CIS-macos-13-1.4
+  contributors: sharon-fdm
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure Install Application Updates from the App Store Is Enabled (MDM Required)
+  platforms: macOS
+  platform: darwin
+  description: Ensure that application updates are installed after they are available from Apple.
+  resolution: Ask your system administrator to deploy an MDM profile that enables automatic updates of Apple apps.
+  query: |
+    SELECT 1 WHERE 
+      EXISTS (
+        SELECT 1 FROM managed_policies WHERE 
+            domain='com.apple.SoftwareUpdate' AND 
+            name='AutomaticallyInstallAppUpdates' AND 
+            (value = 1 OR value = 'true') AND 
+            username = ''
+        )
+      AND NOT EXISTS (
+        SELECT 1 FROM managed_policies WHERE 
+            domain='com.apple.SoftwareUpdate' AND 
+            name='AutomaticallyInstallAppUpdates' AND 
+            (value != 1 AND value != 'true')
+        );  
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1, CIS-macos-13-1.5
+  contributors: lucasmrod
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure Install Security Responses and System Files Is Enabled (MDM Required)
+  platforms: macOS
+  platform: darwin
+  description: |
+    Ensure that system and security updates are installed after they are available from
+    Apple. This setting enables definition updates for XProtect and Gatekeeper. With this
+    setting in place, new malware and adware that Apple has added to the list of malware or
+    untrusted software will not execute.
+  resolution: "Ask your system administrator to deploy an MDM profile that enables automatic critical system and security updates."
+  query: |
+    SELECT 1 WHERE 
+      EXISTS (
+        SELECT 1 FROM managed_policies WHERE 
+            domain='com.apple.SoftwareUpdate' AND 
+            name='CriticalUpdateInstall' AND 
+            (value = 1 OR value = 'true') AND 
+            username = ''
+        )
+      AND NOT EXISTS (
+        SELECT 1 FROM managed_policies WHERE 
+            domain='com.apple.SoftwareUpdate' AND 
+            name='CriticalUpdateInstall' AND 
+            (value != 1 AND value != 'true')
+        );  
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1, CIS-macos-13-1.6
+  contributors: sharon-fdm
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure Software Update Deferment Is Less Than or Equal to 30 Days (MDM Required)
+  platforms: macOS
+  platform: darwin
+  description: |
+    Apple provides the capability to manage software updates on Apple devices through
+    mobile device management. Part of those capabilities permit organizations to defer
+    software updates and allow for testing. Many organizations have specialized software
+    and configurations that may be negatively impacted by Apple updates. If software
+    updates are deferred, they should not be deferred for more than 30 days.
+    This control only verifies that deferred software updates are not deferred for more than 30 days.
+  resolution: "Ask your system administrator to deploy an MDM profile configures update deferment to a value of 30 days or less."
+  query: |
+    SELECT 1 WHERE 
+      EXISTS (
+        SELECT 1 FROM managed_policies WHERE 
+            domain='com.apple.applicationaccess' AND 
+            name='enforcedSoftwareUpdateDelay' AND 
+            value <= 30 AND 
+            username = ''
+        )
+      AND NOT EXISTS (
+        SELECT 1 FROM managed_policies WHERE 
+            domain='com.apple.applicationaccess' AND 
+            name='enforcedSoftwareUpdateDelay' AND 
+            value > 30
+        );  
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1, CIS-macos-13-1.7
+  contributors: lucasmrod
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure iCloud Drive storage solution is disabled (MDM Required)
+  platforms: macOS
+  platform: darwin
+  description: |
+    iCloud Drive is Apple's storage solution for applications on both macOS and iOS to use the same files that are resident in Apple's cloud storage. The iCloud Drive folder is available much like Dropbox, Microsoft OneDrive, or Google Drive.
+    One of the concerns in public cloud storage is that proprietary data may be inappropriately stored in an end user's personal repository. Organizations that need specific controls on information should ensure that this service is turned off or the user knows what information must be stored on services that are approved for storage of controlled information.
+    This query will check for the existance of the policy not its value (That should be set per organization's decision)
+  resolution: |
+    The administrator should configure this via MDM profile.
+    Create or edit a configuration profile with the following information:
+      1. The PayloadType string is com.apple.applicationaccess.
+      2. The key to include is allowCloudDocumentSync.
+      3. The key must be set to <false/>.
+  query: |
+    SELECT 1 WHERE 
+      EXISTS (
+        SELECT 1 FROM managed_policies WHERE 
+            domain='com.apple.applicationaccess' AND 
+            name='allowCloudDocumentSync' AND 
+            (value = 0 OR value = 'false') AND 
+            username = ''
+        )
+      AND NOT EXISTS (
+        SELECT 1 FROM managed_policies WHERE 
+            domain='com.apple.applicationaccess' AND 
+            name='allowCloudDocumentSync' AND 
+            (value != 0 AND value != 'false')
+        );  
+    /*CIS does not make a hard recommendation for this policy. Fleet has provided two policies (one failing, one succeeding). 
+      Depending on your organization's decision, you can delete this policy or its counterpart.*/
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level2, CIS-macos-13-2.1.1.2-disabled, decision-needed
+  contributors: sharon-fdm
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure iCloud Drive storage solution is enabled (MDM Required)
+  platforms: macOS
+  platform: darwin
+  description: |
+    iCloud Drive is Apple's storage solution for applications on both macOS and iOS to use the same files that are resident in Apple's cloud storage. The iCloud Drive folder is available much like Dropbox, Microsoft OneDrive, or Google Drive.
+    One of the concerns in public cloud storage is that proprietary data may be inappropriately stored in an end user's personal repository. Organizations that need specific controls on information should ensure that this service is turned off or the user knows what information must be stored on services that are approved for storage of controlled information.
+    This query will check for the existance of the policy not its value (That should be set per organization's decision)
+  resolution: |
+    The administrator should configure this via MDM profile.
+    Create or edit a configuration profile with the following information:
+      1. The PayloadType string is com.apple.applicationaccess.
+      2. The key to include is allowCloudDocumentSync.
+      3. The key must be set to <true/>.
+  query: |
+    SELECT 1 WHERE 
+      EXISTS (
+        SELECT 1 FROM managed_policies WHERE 
+            domain='com.apple.applicationaccess' AND 
+            name='allowCloudDocumentSync' AND 
+            (value = 1 OR value = 'true') AND 
+            username = ''
+        )
+      AND NOT EXISTS (
+        SELECT 1 FROM managed_policies WHERE 
+            domain='com.apple.applicationaccess' AND 
+            name='allowCloudDocumentSync' AND 
+            (value != 1 AND value != 'true')
+        );  
+    /*CIS does not make a hard recommendation for this policy. Fleet has provided two policies (one failing, one succeeding). 
+      Depending on your organization's decision, you can delete this policy or its counterpart.*/
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level2, CIS-macos-13-2.1.1.2-enabled, decision-needed
+  contributors: sharon-fdm
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure iCloud Keychain is disabled (if your org policy is to disable it) (MDM Required)
+  platforms: macOS
+  platform: darwin
+  description: |
+    The iCloud keychain is Apple's password manager that works with macOS and iOS. The capability allows users to store passwords in either iOS or macOS for use in Safari on both platforms and other iOS-integrated applications. The most pervasive use is driven by iOS use rather than macOS. The passwords stored in a macOS keychain on an Enterprise-managed computer could be stored in Apple's cloud and then be available on a personal computer using the same account. The stored passwords could be for organizational as well as for personal accounts.
+    If passwords are no longer being used as organizational tokens, they are not in scope for iCloud keychain storage.
+    Rationale:
+    Ensure that the iCloud keychain is used consistently with organizational requirements.
+  resolution: |
+    The administrator should configure this via MDM profile.
+    Create or edit a configuration profile with the following information:
+      1. The PayloadType string is com.apple.applicationaccess.
+      2. The key to include is allowCloudKeychainSync.
+      3. The key must be set to <false/>.
+  query: |
+    SELECT 1 WHERE 
+      EXISTS (
+        SELECT 1 FROM managed_policies WHERE 
+            domain='com.apple.applicationaccess' AND 
+            name='allowCloudKeychainSync' AND 
+            (value = 0 OR value = 'false') AND 
+            username = ''
+        )
+      AND NOT EXISTS (
+        SELECT 1 FROM managed_policies WHERE 
+            domain='com.apple.applicationaccess' AND 
+            name='allowCloudKeychainSync' AND 
+            (value != 0 AND value != 'false')
+        );  
+    /*CIS does not make a hard recommendation for this policy. Fleet has provided two policies (one failing, one succeeding). 
+      Depending on your organization's decision, you can delete this policy or its counterpart.*/
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level2, CIS-macos-13-2.1.1.1-disable, decision-needed
+  contributors: sharon-fdm
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure iCloud Keychain is enabled (if your org policy is to enable it) (MDM Required)
+  platforms: macOS
+  platform: darwin
+  description: |
+    The iCloud keychain is Apple's password manager that works with macOS and iOS. The capability allows users to store passwords in either iOS or macOS for use in Safari on both platforms and other iOS-integrated applications. The most pervasive use is driven by iOS use rather than macOS. The passwords stored in a macOS keychain on an Enterprise-managed computer could be stored in Apple's cloud and then be available on a personal computer using the same account. The stored passwords could be for organizational as well as for personal accounts.
+    If passwords are no longer being used as organizational tokens, they are not in scope for iCloud keychain storage.
+    Rationale:
+    Ensure that the iCloud keychain is used consistently with organizational requirements.
+  resolution: |
+    The administrator should configure this via MDM profile.
+    Create or edit a configuration profile with the following information:
+      1. The PayloadType string is com.apple.applicationaccess.
+      2. The key to include is allowCloudKeychainSync.
+      3. The key must be set to <true/>.
+  query: |
+    SELECT 1 WHERE 
+      EXISTS (
+        SELECT 1 FROM managed_policies WHERE 
+            domain='com.apple.applicationaccess' AND 
+            name='allowCloudKeychainSync' AND 
+            (value = 1 OR value = 'true') AND 
+            username = ''
+        )
+      AND NOT EXISTS (
+        SELECT 1 FROM managed_policies WHERE 
+            domain='com.apple.applicationaccess' AND 
+            name='allowCloudKeychainSync' AND 
+            (value != 1 AND value != 'true')
+        );  
+    /*CIS does not make a hard recommendation for this policy. Fleet has provided two policies (one failing, one succeeding). 
+      Depending on your organization's decision, you can delete this policy or its counterpart.*/
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level2, CIS-macos-13-2.1.1.1-enable, decision-needed
+  contributors: sharon-fdm
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure iCloud Drive Document and Desktop Sync Is Disabled (MDM Required)
+  platforms: macOS
+  platform: darwin
+  description: Automated Document synchronization should be planned and controlled to approved storage.
+  resolution: |
+    The administrator should configure this via MDM profile.
+    Create or edit a configuration profile with the following information:
+      1. The PayloadType string is com.apple.applicationaccess.
+      2. The key to include is allowCloudDesktopAndDocuments.
+      3. The key must be set to <false/>.
+  query: |
+    SELECT 1 WHERE 
+      EXISTS (
+        SELECT 1 FROM managed_policies WHERE 
+            domain='com.apple.applicationaccess' AND 
+            name='allowCloudDesktopAndDocuments' AND 
+            (value = 0 OR value = 'false') AND 
+            username = ''
+        )
+      AND NOT EXISTS (
+        SELECT 1 FROM managed_policies WHERE 
+            domain='com.apple.applicationaccess' AND 
+            name='allowCloudDesktopAndDocuments' AND 
+            (value != 0 AND value != 'false')
+        );  
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level2, CIS-macos-13-2.1.1.3
+  contributors: zwass
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure Firewall Is Enabled
+  platforms: macOS
+  platform: darwin
+  description: A firewall minimizes the threat of unauthorized users gaining access to your system while connected to a network or the Internet.
+  resolution: "Go to the Network pane in System Settings and ensure Firewall is active."
+  query: SELECT 1 FROM alf WHERE global_state >= 1;
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1, CIS-macos-13-2.2.1
+  contributors: sharon-fdm
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure Firewall Stealth Mode Is Enabled
+  platforms: macOS
+  platform: darwin
+  description: |
+    While in Stealth mode, the computer will not respond to unsolicited probes, dropping that traffic.
+    Stealth mode on the firewall minimizes the threat of system discovery tools while connected to a network or the Internet.
+  resolution: |
+    Perform the following steps to enable firewall stealth mode:
+      1. Open System Settings
+      2. Select Network
+      3. Select Firewall
+      4. Select Options...
+      5. Set Enabled stealth mode to enabled
+  query: SELECT 1 FROM alf WHERE global_state >= 1 AND stealth_enabled = 1;
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1, CIS-macos-13-2.2.2
+  contributors: lucasmrod
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure AirDrop Is Disabled (MDM Required)
+  platforms: macOS
+  platform: darwin
+  description: |
+    AirDrop can allow malicious files to be downloaded from unknown sources.
+    Contacts Only limits may expose personal information to devices in the same area.
+  resolution: |
+    Ask your system administrator to deploy an MDM profile that disables AirDrop.
+    Create or edit a configuration profile with the following information:
+      1. The PayloadType string is com.apple.applicationaccess
+      2. The key to include is allowAirDrop
+      3. The key must be set to <false/>
+  query: |
+    SELECT 1 WHERE 
+      EXISTS (
+        SELECT 1 FROM managed_policies WHERE 
+            domain='com.apple.applicationaccess' AND 
+            name='allowAirDrop' AND 
+            (value = 0 OR value = 'false') AND 
+            username = ''
+        )
+      AND NOT EXISTS (
+        SELECT 1 FROM managed_policies WHERE 
+            domain='com.apple.applicationaccess' AND 
+            name='allowAirDrop' AND 
+            (value != 0 AND value != 'false')
+        );  
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1, CIS-macos-13-2.3.1.1
+  contributors: lucasmrod
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure AirPlay Receiver Is Disabled (MDM Required)
+  platforms: macOS
+  platform: darwin
+  description: |
+    In macOS Monterey (12.0), Apple has added the capability to share content from
+    another Apple device to the screen of a host Mac. While there are many valuable uses
+    of this capability, such sharing on a standard Mac user workstation should be enabled
+    ad hoc as required rather than allowing a continuous sharing service. The feature can
+    be restricted by Apple ID or network and is configured to use by accepting the
+    connection on the Mac. Part of the concern is frequent connection requests may
+    function as a denial-of-service and access control limits may provide too much
+    information to an attacker.
+  resolution: |
+    The administrator should configure this via MDM profile.
+    Create or edit a configuration profile with the following information:
+      1. The PayloadType string is com.apple.applicationaccess
+      2. The key to include is allowAirPlayIncomingRequests
+      3. The key must be set to <false/>
+  query: |
+    SELECT 1 WHERE 
+      EXISTS (
+        SELECT 1 FROM managed_policies WHERE 
+            domain='com.apple.applicationaccess' AND 
+            name='allowAirPlayIncomingRequests' AND 
+            (value = 0 OR value = 'false') AND 
+            username = ''
+        )
+      AND NOT EXISTS (
+        SELECT 1 FROM managed_policies WHERE 
+            domain='com.apple.applicationaccess' AND 
+            name='allowAirPlayIncomingRequests' AND 
+            (value != 0 AND value != 'false')
+        );  
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1, CIS-macos-13-2.3.1.2
+  contributors: lucasmrod
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure Set Time and Date Automatically Is Enabled (MDM Required)
+  platforms: macOS
+  platform: darwin
+  description: 
+  resolution: |
+      The administrator should configure this via MDM profile.
+      Create or edit a configuration profile with the following information:
+        1. The PayloadType string is com.apple.applicationaccess.
+        2. The key to include is forceAutomaticDateAndTime.
+        3. The key must be set to <true/>.
+  query: |
+    SELECT 1 WHERE 
+      EXISTS (
+        SELECT 1 FROM managed_policies WHERE 
+            domain='com.apple.applicationaccess' AND 
+            name='forceAutomaticDateAndTime' AND 
+            (value = 1 OR value = 'true') AND 
+            username = ''
+        )
+      AND NOT EXISTS (
+        SELECT 1 FROM managed_policies WHERE 
+            domain='com.apple.applicationaccess' AND 
+            name='forceAutomaticDateAndTime' AND 
+            (value != 1 AND value != 'true')
+        );  
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1, CIS-macos-13-2.3.2.1
+  contributors: sharon-fdm
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure Time Is Set Within Appropriate Limits (Fleetd Required)
+  platforms: macOS
+  platform: darwin
+  description: |
+    Correct date and time settings are required for authentication protocols, file creation, modification dates and log entries.
+    The time offset compared to time.apple.com must be between -270.x and 270.x seconds.
+  resolution: Make sure the device can connect to time.apple.com to synchronize time.
+  query: SELECT * FROM sntp_request WHERE server = 'time.apple.com' AND clock_offset_ms <= 270000 AND clock_offset_ms >= -270000;
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1, CIS-macos-13-2.3.2.2
+  contributors: lucasmrod 
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure DVD or CD Sharing Is Disabled
+  platforms: macOS
+  platform: darwin
+  description: |
+    DVD or CD Sharing allows users to remotely access the system's optical drive.
+    Disabling DVD or CD Sharing minimizes the risk of an attacker using the optical drive as
+    a vector for attack and exposure of sensitive data.
+  resolution: |
+    Graphical Method:
+    1. Open System Settings
+    2. Select General
+    3. Select Sharing
+    4. Set CD/DVD Sharing to disabled
+  query: |
+    SELECT 1 WHERE NOT EXISTS (
+      SELECT * FROM plist WHERE
+        path = '/var/db/com.apple.xpc.launchd/disabled.plist' AND
+        key = 'com.apple.ODSAgent' AND
+        value = '0'
+    );
+  # We are not using the launchd table because it does not check if services
+  # are disabled via disabled.plist, which the preference pane uses whenever
+  # a service is disabled after it has been enabled in the past.
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1, CIS-macos-13-2.3.3.1
+  contributors: artemist-work
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure Screen Sharing Is Disabled 
+  platforms: macOS
+  platform: darwin
+  description: |
+    Screen Sharing allows a computer to connect to another computer on a network and
+    display the computer’s screen. While sharing the computer’s screen, the user can
+    control what happens on that computer, such as opening documents or applications,
+    opening, moving, or closing windows, and even shutting down the computer.
+    Disabling Screen Sharing mitigates the risk of remote connections being made without
+    the user of the console knowing that they are sharing the computer.
+  resolution: |
+    Graphical Method:
+    1. Open System Settings
+    2. Select General
+    3. Select Sharing
+    4. Set Screen Sharing to disabled
+  query: |
+    SELECT 1 WHERE NOT EXISTS (
+      SELECT * FROM plist WHERE
+        path = '/var/db/com.apple.xpc.launchd/disabled.plist' AND
+        key = 'com.apple.screensharing' AND
+        value = '0'
+    );
+  # We are not using the launchd table because it does not check if services
+  # are disabled via disabled.plist, which the preference pane uses whenever
+  # a service is disabled after it has been enabled in the past.
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1, CIS-macos-13-2.3.3.2
+  contributors: artemist-work
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure File Sharing Is Disabled
+  platforms: macOS
+  platform: darwin
+  description: |
+    File sharing from a user workstation creates additional risks by
+    increasing complexity and making security more difficult. Hardened
+    file servers should be used instead of workstations
+  resolution: |
+    Graphical Method:
+    1. Open System Settings
+    2. Select General
+    3. Select Sharing
+    4. Set File Sharing to disabled
+  query: |
+    SELECT 1 WHERE NOT EXISTS (
+      SELECT * FROM plist WHERE
+        path = '/var/db/com.apple.xpc.launchd/disabled.plist' AND
+        key = 'com.apple.smbd' AND
+        value = '0'
+    );
+  # We are not using the launchd table because it does not check if services
+  # are disabled via disabled.plist, which the preference pane uses whenever
+  # a service is disabled after it has been enabled in the past.
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1, CIS-macos-13-2.3.3.3
+  contributors: artemist-work
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure Printer Sharing is Disabled
+  platforms: macOS
+  platform: darwin
+  description: |
+    By enabling Printer Sharing, the computer is set up as a
+    print server to accept print jobs from other computers.
+    Dedicated print servers or direct IP printing should be used instead.
+    Disabling Printer Sharing mitigates the risk of attackers
+    attempting to exploit the print server to gain access to the system.
+  resolution: |
+    Graphical Method:
+    1. Open System Settings
+    2. Select General
+    3. Select Sharing
+    4. Set Printer Sharing to disabled
+  query: |
+    SELECT 1 WHERE NOT EXISTS (
+      SELECT * FROM file_lines WHERE
+        path = '/etc/cups/cupsd.conf' AND
+        line LIKE '%Allow @LOCAL%'
+      );
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1, CIS-macos-13-2.3.3.4
+  contributors: artemist-work
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure Remote Login Is Disabled
+  platforms: macOS
+  platform: darwin
+  description: |
+    Remote Login allows an interactive terminal session to a computer.
+    The SSH server built into macOS should not be enabled on a standard user computer,
+    particularly one that changes locations and IP addresses.
+    A standard user that runs local applications, including email, web browser,
+    and productivity tools, should not use the same device as a server
+
+  resolution: |
+    Graphical Method:
+    1. Open System Settings
+    2. Select General
+    3. Select Sharing
+    4. Set Remote Login to disabled
+  query: |
+    SELECT 1 WHERE NOT EXISTS (
+      SELECT * FROM plist WHERE
+        path = '/var/db/com.apple.xpc.launchd/disabled.plist' AND
+        key = 'com.openssh.sshd' AND
+        value = '0'
+    );
+  # We are not using the launchd table because it does not check if services
+  # are disabled via disabled.plist, which the preference pane uses whenever
+  # a service is disabled after it has been enabled in the past.
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1, CIS-macos-13-2.3.3.5
+  contributors: artemist-work
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure Remote Management is Disabled
+  platforms: macOS
+  platform: darwin
+  description: |
+    Remote Management is the client portion of Apple Remote Desktop (ARD).
+    Remote Management can be used by remote administrators to view the current screen,
+    install software, report on, and generally manage client Macs.
+    Remote Management should only be enabled on trusted networks with strong
+    user controls present in a Directory system.
+    Mobile devices without strict controls are vulnerable to exploit and monitoring.
+  resolution: |
+    Graphical Method:
+    1. Open System Settings
+    2. Select General
+    3. Select Sharing
+    4. Set Remote Management to disabled
+  query: |
+    SELECT 1 WHERE NOT EXISTS (
+      SELECT * FROM processes WHERE
+        path = '/System/Library/CoreServices/RemoteManagement/ARDAgent.app/Contents/MacOS/ARDAgent'
+    );
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1, CIS-macos-13-2.3.3.6
+  contributors: artemist-work
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure Remote Apple Events is Disabled
+  platforms: macOS
+  platform: darwin
+  description: |
+    Apple Events is a technology that allows one program to communicate with other programs.
+    Remote Apple Events allows a program on one computer to communicate with a program on a
+    different computer. Disabling Remote Apple Events mitigates the risk of an unauthorized
+    program gaining access to the system.
+  resolution: |
+    Graphical Method:
+    1. Open System Settings
+    2. Select General
+    3. Select Sharing
+    4. Set Remote Apple Events to disabled
+  query: |
+    SELECT 1 WHERE NOT EXISTS (
+      SELECT * FROM plist WHERE
+        path = '/var/db/com.apple.xpc.launchd/disabled.plist' AND
+        key = 'com.apple.AEServer' AND
+        value = '0'
+    );
+  # We are not using the launchd table because it does not check if services
+  # are disabled via disabled.plist, which the preference pane uses whenever
+  # a service is disabled after it has been enabled in the past.
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1, CIS-macos-13-2.3.3.7
+  contributors: artemist-work
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure Internet Sharing Is Disabled
+  platforms: macOS
+  platform: darwin
+  description: |
+    Internet Sharing uses the open source natd process to share an internet connection with other
+    computers and devices on a local network. This allows the Mac to function as a router and share
+    the connection to other, possibly unauthorized, devices.
+  resolution: |
+    Graphical Method:
+    1. Open System Settings
+    2. Select General
+    3. Select Sharing
+    4. Set Internet Sharing to disabled
+  query: |
+    SELECT 1 WHERE NOT EXISTS (
+      SELECT 1 FROM plist WHERE
+        path = '/Library/Preferences/SystemConfiguration/com.apple.nat.plist' AND
+        key = 'NAT' AND
+        subkey = 'Enabled' AND
+        value = '1'
+    );
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1, CIS-macos-13-2.3.3.8
+  contributors: artemist-work
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure Content Caching Is Disabled (MDM Required)
+  platforms: macOS
+  platform: darwin
+  description: |
+    Starting with 10.13 (macOS High Sierra), Apple introduced a service to make it easier to deploy data from Apple, including software updates, where there are bandwidth constraints to the Internet and fewer constraints or greater bandwidth exist on the local subnet. This capability can be very valuable for organizations that have throttled and possibly metered Internet connections. In heterogeneous enterprise networks with multiple subnets, the effectiveness of this capability would be determined by how many Macs were on each subnet at the time new, large updates were made available upstream. This capability requires the use of mac OS clients as P2P nodes for updated Apple content. Unless there is a business requirement to manage operational Internet connectivity and bandwidth user endpoints should not store content and act as a cluster to provision data.
+  resolution: |
+    Graphical Method:
+      Perform the following steps to disable Content Caching:
+        1. Open System Settings
+        2. SelectGeneral
+        3. SelectSharing
+        4. Set Content Caching to disabled
+    Profile Method:
+    Create or edit a configuration profile with the following information:
+      1. The PayloadType string is com.apple.applicationaccess 
+      2. The key to include is allowContentCaching
+      3. The key must be set to <false/>
+  query: |
+    SELECT 1 WHERE 
+      EXISTS (
+        SELECT 1 FROM managed_policies WHERE 
+            domain='com.apple.applicationaccess' AND 
+            name='allowContentCaching' AND 
+            (value = 0 OR value = 'false') AND 
+            username = ''
+        )
+      AND NOT EXISTS (
+        SELECT 1 FROM managed_policies WHERE 
+            domain='com.apple.applicationaccess' AND 
+            name='allowContentCaching' AND 
+            (value != 0 AND value != 'false')
+        );  
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level2, CIS-macos-13-2.3.3.9
+  contributors: sharon-fdm
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure Bluetooth Sharing Is Disabled
+  platforms: macOS
+  platform: darwin
+  description: |
+    Bluetooth Sharing allows files to be exchanged with Bluetooth-enabled devices.
+    Disabling Bluetooth Sharing minimizes the risk of an attacker using Bluetooth
+    to remotely attack the system.
+  resolution: |
+    Graphical Method:
+    1. Open System Settings
+    2. Select General
+    3. Select Sharing
+    4. Set Bluetooth Sharing to disabled
+  query: |
+    SELECT 1 WHERE NOT EXISTS (
+      SELECT * FROM plist WHERE
+        path LIKE '/Users/%/Library/Preferences/ByHost/com.apple.Bluetooth.%.plist' AND
+        key = 'PrefKeyServicesEnabled' AND
+        value = '1'
+    );
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1, CIS-macos-13-2.3.3.11
+  contributors: artemist-work
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure Media Sharing Is Disabled (MDM Required)
+  platforms: macOS
+  platform: darwin
+  description: |
+    Starting with macOS 10.15, Apple has provided a control which permits a user to share
+    Apple downloaded content on all Apple devices that are signed in with the same Apple ID.
+    This allows users to share downloaded Movies, Music, or TV shows with other
+    controlled macOS, iOS and iPadOS devices, as well as photos with Apple TVs.
+    Disabling Media Sharing reduces the remote attack surface of the system
+  resolution: |
+    Profile Method:
+    Ask your administrator to deploy a profile that sets
+    homeSharingUIStatus, legacySharingUIStatus, and mediaSharingUIStatus to 0
+    for com.apple.preferences.sharing.SharingPrefsExtension
+  query: |
+    SELECT 1 WHERE EXISTS(
+      SELECT 1 FROM managed_policies WHERE
+        domain = 'com.apple.preferences.sharing.SharingPrefsExtension' AND
+        name = 'homeSharingUIStatus' AND
+        value = '0' AND 
+        username = ''
+    ) AND EXISTS (
+      SELECT 1 FROM managed_policies WHERE
+        domain = 'com.apple.preferences.sharing.SharingPrefsExtension' AND
+        name = 'legacySharingUIStatus' AND
+        value = '0' AND 
+        username = ''
+    ) AND EXISTS (
+      SELECT 1 FROM managed_policies WHERE
+        domain = 'com.apple.preferences.sharing.SharingPrefsExtension' AND
+        name = 'mediaSharingUIStatus' AND
+        value = '0' AND 
+        username = ''
+    ) AND NOT EXISTS (
+      SELECT 1 FROM managed_policies WHERE
+        domain = 'com.apple.preferences.sharing.SharingPrefsExtension' AND
+        name = 'homeSharingUIStatus' AND
+        value != '0'
+    ) AND NOT EXISTS (
+      SELECT 1 FROM managed_policies WHERE
+        domain = 'com.apple.preferences.sharing.SharingPrefsExtension' AND
+        name = 'legacySharingUIStatus' AND
+        value != '0'
+    ) AND NOT EXISTS (
+      SELECT 1 FROM managed_policies WHERE
+        domain = 'com.apple.preferences.sharing.SharingPrefsExtension' AND
+        name = 'mediaSharingUIStatus' AND
+        value != '0'
+    );
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1, CIS-macos-13-2.3.3.10
+  contributors: artemist-work
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure Backup Automatically is Enabled If Time Machine Is Enabled (FDA Required)
+  platforms: macOS
+  platform: darwin
+  description: |
+    Backup solutions are only effective if the backups run on a regular basis.
+    The time to check for backups is before the hard drive fails or the computer goes missing.
+    In order to simplify the user experience so that backups are more likely to occur,
+    Time Machine should be on and set to Back Up Automatically whenever the target volume is available.
+
+    FDA (Full Disk Access) is required to read the /Library/Preferences/com.apple.TimeMachine.plist
+    file that contains the Time Machine configuration and backup destinations.
+  resolution: |
+    Ask your system administrator to deploy an MDM profile that enables automatic backup if Time Machine is enabled.
+    The system administrator can do one of:
+    A. Disable Time Machine on the device.
+    B. Run the following command to enable automatic backup on Time Machine destinations:
+      /usr/bin/sudo /usr/bin/defaults write /Library/Preferences/com.apple.TimeMachine.plist AutoBackup -bool true
+  query: |
+    SELECT 'no time machine backups' as output
+    FROM (SELECT COUNT(*) as c FROM time_machine_backups) t1 WHERE t1.c = 0
+    UNION
+    SELECT 'time machine automatic backup set to true' as output
+    FROM plist WHERE path='/Library/Preferences/com.apple.TimeMachine.plist'
+    AND key='AutoBackup' AND (value = 1 OR value = 'true');
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level2, CIS-macos-13-2.3.4.1
+  contributors: lucasmrod
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure Time Machine Volumes Are Encrypted If Time Machine Is Enabled (FDA Required)
+  platforms: macOS
+  platform: darwin
+  description: |
+    Backup solutions are only effective if the backups run on a regular basis.
+    The time to check for backups is before the hard drive fails or the computer goes missing.
+    In order to simplify the user experience so that backups are more likely to occur,
+    Time Machine should be on and set to Back Up Automatically whenever the target volume is available.
+
+    FDA (Full Disk Access) is required to read the /Library/Preferences/com.apple.TimeMachine.plist
+    file that contains the Time Machine configuration and backup destinations.
+  resolution: |
+    Graphical Method:
+    Perform the following steps to enable encryption on the Time Machine drive:
+      1. Open `System Settings`.
+      2. Select `General`.
+      3. Select `Time Machine`.
+      4. Select the unencrypted drive.
+      5. Select `-` to forget that drive as a destination.
+      6. Select `+` to add a different drive as the destination.
+      7. Select `Set Up Disk...`.
+      8. Set Encrypt Backup to enabled.
+      9. Enter a password in the `New Password` and the same password in the `Re-enter Password` fields.
+      10. A password hint is required, but it is recommended that you do not use any identifying information for the password
+  query: |
+    SELECT 'no time machine destinations configured' as output
+    FROM (SELECT COUNT(*) as c FROM time_machine_destinations) t1 WHERE t1.c = 0
+    UNION
+    SELECT 'time machines destinations with encryption with automatic backup' as output
+    FROM (SELECT COUNT(*) as c FROM time_machine_destinations WHERE encryption <> 'Encrypted') t2 WHERE t2.c = 0;
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1, CIS-macos-13-2.3.4.2
+  contributors: lucasmrod
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure Show Wi-Fi status in Menu Bar Is Enabled (MDM Required)
+  platforms: macOS
+  platform: darwin
+  description: |
+    The Wi-Fi status in the menu bar indicates if the system's wireless internet capabilities are enabled.
+    If so, the system will scan for available wireless networks in order to connect.
+    Enabling "Show Wi-Fi status in menu bar" is a security awareness method that helps mitigate public area
+    wireless exploits by making the user aware of their wireless connectivity status.
+  resolution: |
+    Automated method:
+    Ask your system administrator to deploy an MDM profile that enables the Wi-Fi status in the menu bar.
+    Create or edit a configuration profile with the following information:
+    1. The `PayloadType` string is `com.apple.controlcenter`.
+    2. The key to include is `WiFi`.
+    3. The key must be set to `<integer>18</integer>`.
+  query: |
+    SELECT 1 WHERE 
+      EXISTS (
+        SELECT 1 FROM managed_policies WHERE 
+            domain='com.apple.controlcenter' AND 
+            name='WiFi' AND 
+            value = 18 AND 
+            username = ''
+        )
+      AND NOT EXISTS (
+        SELECT 1 FROM managed_policies WHERE 
+            domain='com.apple.controlcenter' AND 
+            name='WiFi' AND 
+            value != 18
+        );  
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1, CIS-macos-13-2.4.1
+  contributors: lucasmrod
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure Show Bluetooth Status in Menu Bar Is Enabled (MDM Required)
+  platforms: macOS
+  platform: darwin
+  description: |
+    Enabling "Show Bluetooth status in menu bar" is a security awareness method that
+    helps understand the current state of Bluetooth, including whether it is enabled,
+    discoverable, what paired devices exist, and what paired devices are currently active.
+  resolution: |
+    Automated method:
+    Ask your system administrator to deploy an MDM profile that enables the Bluetooth status in the menu bar.
+    Create or edit a configuration profile with the following information:
+    1. The `PayloadType` string is `com.apple.controlcenter`.
+    2. The key to include is `Bluetooth`.
+    3. The key must be set to `<integer>18</integer>`.
+  query: |
+    SELECT 1 WHERE 
+      EXISTS (
+        SELECT 1 FROM managed_policies WHERE 
+            domain='com.apple.controlcenter' AND 
+            name='Bluetooth' AND 
+            value = 18 AND 
+            username = ''
+        )
+      AND NOT EXISTS (
+        SELECT 1 FROM managed_policies WHERE 
+            domain='com.apple.controlcenter' AND 
+            name='Bluetooth' AND 
+            value != 18
+        );  
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1, CIS-macos-13-2.4.2
+  contributors: lucasmrod
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure Siri is enabled (Based on organization's policy) (MDM Required)
+  platforms: macOS
+  platform: darwin
+  description: |
+    With macOS 10.12 Sierra, Apple has introduced Siri from iOS to macOS. While there are data spillage concerns with the use of data-gathering personal assistant software, the risk here does not seem greater in sending queries to Apple through Siri than in sending search terms in a browser to Google or Microsoft. While it is possible that Siri will be used for local actions rather than Internet searches, Siri could, in theory, tell Apple about confidential Programs and Projects that should not be revealed. This appears be a usage edge case.
+    In cases where sensitive or protected data is processed and Siri could expose that information through assisting a user in navigating their machine, it should be disabled. Siri does need to phone home to Apple, so it should not be available from air-gapped networks as part of its requirements.
+    Most of the use case data published has shown that Siri is a tremendous time saver on iOS where multiple screens and menus need to be navigated through. Information like sports scores, weather, movie times, and simple to-do items on existing calendars can be easily found with Siri. None of the standard use cases should be more risky than already approved activity.
+  resolution: |
+    Automated method:
+    Ask your system administrator to deploy an MDM profile that enables the Bluetooth status in the menu bar.
+    Create or edit a configuration profile with the following information:
+    1. The `PayloadType` string is com.apple.applicationaccess.
+    2. The key to include is allowAssistant.
+    3. The key must be set to <true/>.
+  query: |
+    SELECT 1 WHERE 
+      EXISTS (
+        SELECT 1 FROM managed_policies WHERE 
+            domain='com.apple.applicationaccess' AND 
+            name='allowAssistant' AND 
+            (value = 1 OR value = 'true') AND 
+            username = ''
+        )
+      AND NOT EXISTS (
+        SELECT 1 FROM managed_policies WHERE 
+            domain='com.apple.applicationaccess' AND 
+            name='allowAssistant' AND 
+            (value != 1 AND value != 'true')
+        );  
+     /*CIS does not make a hard recommendation for this policy. Fleet has provided two policies (one failing, one succeeding). 
+      Depending on your organization's decision, you can delete this policy or its counterpart.*/
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1, CIS-macos-13-2.5.1-enabled, decision-needed
+  contributors: sharon-fdm
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure Siri is disabled (Based on organization's policy) (MDM Required)
+  platforms: macOS
+  platform: darwin
+  description: |
+    With macOS 10.12 Sierra, Apple has introduced Siri from iOS to macOS. While there are data spillage concerns with the use of data-gathering personal assistant software, the risk here does not seem greater in sending queries to Apple through Siri than in sending search terms in a browser to Google or Microsoft. While it is possible that Siri will be used for local actions rather than Internet searches, Siri could, in theory, tell Apple about confidential Programs and Projects that should not be revealed. This appears be a usage edge case.
+    In cases where sensitive or protected data is processed and Siri could expose that information through assisting a user in navigating their machine, it should be disabled. Siri does need to phone home to Apple, so it should not be available from air-gapped networks as part of its requirements.
+    Most of the use case data published has shown that Siri is a tremendous time saver on iOS where multiple screens and menus need to be navigated through. Information like sports scores, weather, movie times, and simple to-do items on existing calendars can be easily found with Siri. None of the standard use cases should be more risky than already approved activity.
+  resolution: |
+    Automated method:
+    Ask your system administrator to deploy an MDM profile that enables the Bluetooth status in the menu bar.
+    Create or edit a configuration profile with the following information:
+    1. The `PayloadType` string is com.apple.applicationaccess.
+    2. The key to include is allowAssistant.
+    3. The key must be set to <false/>.
+  query: |
+    SELECT 1 WHERE 
+      EXISTS (
+        SELECT 1 FROM managed_policies WHERE 
+            domain='com.apple.applicationaccess' AND 
+            name='allowAssistant' AND 
+            (value = 0 OR value = 'false') AND 
+            username = ''
+        )
+      AND NOT EXISTS (
+        SELECT 1 FROM managed_policies WHERE 
+            domain='com.apple.applicationaccess' AND 
+            name='allowAssistant' AND 
+            (value != 0 AND value != 'false')
+        );  
+    /*CIS does not make a hard recommendation for this policy. Fleet has provided two policies (one failing, one succeeding). 
+      Depending on your organization's decision, you can delete this policy or its counterpart.*/
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1, CIS-macos-13-2.5.1-disabled, decision-needed
+  contributors: sharon-fdm
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure Siri field TypeToSiriEnabled is true (Based on organization's policy)
+  platforms: macOS
+  platform: darwin
+  description: |
+    Extention of CIS-2.5.1. This will check that Siri TypeToSiriEnabled field is true.
+  resolution: |
+        Ask your system administrator to deploy a script that will configure
+        $ /usr/bin/sudo -u <username> /usr/bin/defaults write com.apple.Siri.plist TypeToSiriEnabled -bool true
+  query: |
+    SELECT 1 WHERE NOT EXISTS (
+      SELECT 1 FROM users AS u
+      LEFT JOIN (
+        SELECT * FROM plist WHERE
+          path LIKE '/Users/%/Library/Preferences/com.apple.Siri.plist' AND
+          key = 'TypeToSiriEnabled' AND
+          value = '1') AS p
+      ON p.path = CONCAT(u.directory, '/Library/Preferences/com.apple.Siri.plist')
+      WHERE u.directory LIKE '/Users/%' AND
+      p.value IS NULL
+    );
+    /*CIS does not make a hard recommendation for this policy. Fleet has provided two policies (one failing, one succeeding). 
+      Depending on your organization's decision, you can delete this policy or its counterpart.*/
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1, CIS-macos-13-2.5.1-TypeToSiriEnabled-true, decision-needed
+  contributors: sharon-fdm
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure Siri field TypeToSiriEnabled is false (Based on organization's policy)
+  platforms: macOS
+  platform: darwin
+  description: |
+    Extention of CIS-2.5.1. This will check that Siri TypeToSiriEnabled field is false.
+  resolution: |
+        Ask your system administrator to deploy a script that will configure
+        $ /usr/bin/sudo -u <username> /usr/bin/defaults write com.apple.Siri.plist TypeToSiriEnabled -bool false
+  query: |
+    SELECT 1 WHERE NOT EXISTS (
+      SELECT 1 FROM users AS u
+      LEFT JOIN (
+        SELECT * FROM plist WHERE
+          path LIKE '/Users/%/Library/Preferences/com.apple.Siri.plist' AND
+          key = 'TypeToSiriEnabled' AND
+          value = '0') AS p
+      ON p.path = CONCAT(u.directory, '/Library/Preferences/com.apple.Siri.plist')
+      WHERE u.directory LIKE '/Users/%' AND
+      p.value IS NULL
+    );
+    /*CIS does not make a hard recommendation for this policy. Fleet has provided two policies (one failing, one succeeding). 
+      Depending on your organization's decision, you can delete this policy or its counterpart.*/
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1, CIS-macos-13-2.5.1-TypeToSiriEnabled-false, decision-needed
+  contributors: sharon-fdm
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure Siri field StatusMenuVisible is true (Based on organization's policy)
+  platforms: macOS
+  platform: darwin
+  description: |
+    Extention of CIS-2.5.1. This will check that Siri StatusMenuVisible field is true.
+  resolution: |
+        Ask your system administrator to deploy a script that will configure
+        $ /usr/bin/sudo -u <username> /usr/bin/defaults write com.apple.Siri.plist StatusMenuVisible -bool true
+  query: |
+    SELECT 1 WHERE NOT EXISTS (
+      SELECT 1 FROM users AS u
+      LEFT JOIN (
+        SELECT * FROM plist WHERE
+          path LIKE '/Users/%/Library/Preferences/com.apple.Siri.plist' AND
+          key = 'StatusMenuVisible' AND
+          value = '1') AS p
+      ON p.path = CONCAT(u.directory, '/Library/Preferences/com.apple.Siri.plist')
+      WHERE u.directory LIKE '/Users/%' AND
+      p.value IS NULL
+    );
+    /*CIS does not make a hard recommendation for this policy. Fleet has provided two policies (one failing, one succeeding). 
+      Depending on your organization's decision, you can delete this policy or its counterpart.*/
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1, CIS-macos-13-2.5.1-StatusMenuVisible-true, decision-needed
+  contributors: sharon-fdm
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure Siri field StatusMenuVisible is false (Based on organization's policy)
+  platforms: macOS
+  platform: darwin
+  description: |
+    Extention of CIS-2.5.1. This will check that Siri StatusMenuVisible field is false.
+  resolution: |
+        Ask your system administrator to deploy a script that will configure
+        $ /usr/bin/sudo -u <username> /usr/bin/defaults write com.apple.Siri.plist StatusMenuVisible -bool false
+  query: |
+    SELECT 1 WHERE NOT EXISTS (
+      SELECT 1 FROM users AS u
+      LEFT JOIN (
+        SELECT * FROM plist WHERE
+          path LIKE '/Users/%/Library/Preferences/com.apple.Siri.plist' AND
+          key = 'StatusMenuVisible' AND
+          value = '0') AS p
+      ON p.path = CONCAT(u.directory, '/Library/Preferences/com.apple.Siri.plist')
+      WHERE u.directory LIKE '/Users/%' AND
+      p.value IS NULL
+    );
+    /*CIS does not make a hard recommendation for this policy. Fleet has provided two policies (one failing, one succeeding). 
+      Depending on your organization's decision, you can delete this policy or its counterpart.*/
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1, CIS-macos-13-2.5.1-StatusMenuVisible-false, decision-needed
+  contributors: sharon-fdm
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure Siri field VoiceTriggerUserEnabled is true (Based on organization's policy)
+  platforms: macOS
+  platform: darwin
+  description: |
+    Extention of CIS-2.5.1. This will check that Siri VoiceTriggerUserEnabled field is true.
+  resolution: |
+        Ask your system administrator to deploy a script that will configure
+        $ /usr/bin/sudo -u <username> /usr/bin/defaults write com.apple.Siri.plist VoiceTriggerUserEnabled -bool true
+  query: |
+    SELECT 1 WHERE NOT EXISTS (
+      SELECT 1 FROM users AS u
+      LEFT JOIN (
+        SELECT * FROM plist WHERE
+          path LIKE '/Users/%/Library/Preferences/com.apple.Siri.plist' AND
+          key = 'VoiceTriggerUserEnabled' AND
+          value = '1') AS p
+      ON p.path = CONCAT(u.directory, '/Library/Preferences/com.apple.Siri.plist')
+      WHERE u.directory LIKE '/Users/%' AND
+      p.value IS NULL
+    );
+    /*CIS does not make a hard recommendation for this policy. Fleet has provided two policies (one failing, one succeeding). 
+      Depending on your organization's decision, you can delete this policy or its counterpart.*/
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1, CIS-macos-13-2.5.1-VoiceTriggerUserEnabled-true, decision-needed
+  contributors: sharon-fdm
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure Siri field VoiceTriggerUserEnabled is false (Based on organization's policy)
+  platforms: macOS
+  platform: darwin
+  description: |
+    Extention of CIS-2.5.1. This will check that Siri VoiceTriggerUserEnabled field is false.
+  resolution: |
+        Ask your system administrator to deploy a script that will configure
+        $ /usr/bin/sudo -u <username> /usr/bin/defaults write com.apple.Siri.plist VoiceTriggerUserEnabled -bool false
+  query: |
+    SELECT 1 WHERE NOT EXISTS (
+      SELECT 1 FROM users AS u
+      LEFT JOIN (
+        SELECT * FROM plist WHERE
+          path LIKE '/Users/%/Library/Preferences/com.apple.Siri.plist' AND
+          key = 'VoiceTriggerUserEnabled' AND
+          value = '0') AS p
+      ON p.path = CONCAT(u.directory, '/Library/Preferences/com.apple.Siri.plist')
+      WHERE u.directory LIKE '/Users/%' AND
+      p.value IS NULL
+    );
+    /*CIS does not make a hard recommendation for this policy. Fleet has provided two policies (one failing, one succeeding). 
+      Depending on your organization's decision, you can delete this policy or its counterpart.*/
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1, CIS-macos-13-2.5.1-VoiceTriggerUserEnabled-false, decision-needed
+  contributors: sharon-fdm
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure Siri field LockscreenEnabled is true (Based on organization's policy)
+  platforms: macOS
+  platform: darwin
+  description: |
+    Extention of CIS-2.5.1. This will check that Siri LockscreenEnabled field is true.
+  resolution: |
+        Ask your system administrator to deploy a script that will configure
+        $ /usr/bin/sudo -u <username> /usr/bin/defaults write com.apple.Siri.plist LockscreenEnabled -bool true
+  query: |
+    SELECT 1 WHERE NOT EXISTS (
+      SELECT 1 FROM users AS u
+      LEFT JOIN (
+        SELECT * FROM plist WHERE
+          path LIKE '/Users/%/Library/Preferences/com.apple.Siri.plist' AND
+          key = 'LockscreenEnabled' AND
+          value = '1') AS p
+      ON p.path = CONCAT(u.directory, '/Library/Preferences/com.apple.Siri.plist')
+      WHERE u.directory LIKE '/Users/%' AND
+      p.value IS NULL
+    );
+    /*CIS does not make a hard recommendation for this policy. Fleet has provided two policies (one failing, one succeeding). 
+      Depending on your organization's decision, you can delete this policy or its counterpart.*/
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1, CIS-macos-13-2.5.1-LockscreenEnabled-true, decision-needed
+  contributors: sharon-fdm
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure Siri field LockscreenEnabled is false (Based on organization's policy)
+  platforms: macOS
+  platform: darwin
+  description: |
+    Extention of CIS-2.5.1. This will check that Siri LockscreenEnabled field is false.
+  resolution: |
+        Ask your system administrator to deploy a script that will configure
+        $ /usr/bin/sudo -u <username> /usr/bin/defaults write com.apple.Siri.plist LockscreenEnabled -bool false
+  query: |
+    SELECT 1 WHERE NOT EXISTS (
+      SELECT 1 FROM users AS u
+      LEFT JOIN (
+        SELECT * FROM plist WHERE
+          path LIKE '/Users/%/Library/Preferences/com.apple.Siri.plist' AND
+          key = 'LockscreenEnabled' AND
+          value = '0') AS p
+      ON p.path = CONCAT(u.directory, '/Library/Preferences/com.apple.Siri.plist')
+      WHERE u.directory LIKE '/Users/%' AND
+      p.value IS NULL
+    );
+    /*CIS does not make a hard recommendation for this policy. Fleet has provided two policies (one failing, one succeeding). 
+      Depending on your organization's decision, you can delete this policy or its counterpart.*/
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1, CIS-macos-13-2.5.1-LockscreenEnabled-false, decision-needed
+  contributors: sharon-fdm
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure Location Services Is Enabled
+  platforms: macOS
+  platform: darwin
+  description: Checks that Location Services option is enabled.
+  resolution: |
+    Automated method:
+    Ask your system administrator to deploy an MDM profile that enables automatic updates of Apple apps.
+    Graphical method:
+      Perform the following steps to enable Location Services:
+        1. Open System Settings
+        2. Select Privacy & Security
+        3. Select Location Services
+        4. Verify Location Services is enabled
+  query: SELECT 1 FROM location_services where enabled=1;
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level2, CIS-macos-13-2.6.1.1
+  contributors: sharon-fdm
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure Location Services Is in the Menu Bar
+  platforms: macOS
+  platform: darwin
+  description: Checks that Location Services option is presented in the Menu Bar.
+  resolution: |
+    Automated method:
+    Ask your system administrator to deploy an MDM profile that enables the "location services" icon in menu bar when System Services request your location.
+    Graphical method:
+      Perform the following steps to enable Location Services:
+        1. Open System Settings
+        2. Select Privacy & Security
+        3. Select Location Services
+        4. Select Details...
+        5. Verify Show location icon in menu bar when System Services request your
+        location is set to your organization's parameters
+  query:  SELECT 1 FROM plist WHERE path='/Library/Preferences/com.apple.locationmenu.plist' AND key='ShowSystemServices' AND value=1;
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level2, CIS-macos-13-2.6.1.2
+  contributors: sharon-fdm
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure Location Services Is Disabled to all applications (Based on organization's policy)
+  platforms: macOS
+  platform: darwin
+  description: |
+    macOS uses location information gathered through local Wi-Fi networks to enable applications to supply relevant information to users. While Location Services may be very useful, it may not be desirable to allow all applications that can use Location Services to use your location for Internet queries in order to provide tailored content based on your current location.
+    Ensure applications that can use Location Services are authorized and provide that information where the application interacts with external systems. Apple offers feedback within System Preferences and may be enabled to supply information on the menu bar when Location Services are used.
+    Safari can deny access from websites or prompt for access.
+    Applications that support Location Services can be individually controlled in the Privacy tab in Security & Privacy under System Preferences.
+    Access should be evaluated to ensure that privacy controls are as expected.
+    This query verifies that location services is disabled for all apps.    
+  resolution: |
+    Graphical Method:
+        Perform the following steps to disable unnecessary applications from accessing Location Services:
+        1. Open System Settings
+        2. Select Privacy & Security
+        3. Select Location Services
+        4. Set Location Services to disabled.
+  query:  SELECT 1 FROM location_services WHERE enabled = 0;
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level2, CIS-macos-13-2.6.1.3-Location-Service-disabled
+  contributors: sharon-fdm
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure Location Services Is Enabled for a specific list of applications (Based on organization's policy)
+  platforms: macOS
+  platform: darwin
+  description: |
+    macOS uses location information gathered through local Wi-Fi networks to enable applications to supply relevant information to users. While Location Services may be very useful, it may not be desirable to allow all applications that can use Location Services to use your location for Internet queries in order to provide tailored content based on your current location.
+    Ensure applications that can use Location Services are authorized and provide that information where the application interacts with external systems. Apple offers feedback within System Preferences and may be enabled to supply information on the menu bar when Location Services are used.
+    Safari can deny access from websites or prompt for access.
+    Applications that support Location Services can be individually controlled in the Privacy tab in Security & Privacy under System Preferences.
+    Access should be evaluated to ensure that privacy controls are as expected.
+    This query verifies that location services is enabled and a specific list of application can use it.
+  resolution: |
+    Graphical Method:
+        Perform the following steps to disable unnecessary applications from accessing Location Services:
+        1. Open System Settings
+        2. Select Privacy & Security
+        3. Select Location Services
+        4. Set any applications listed to your organization's requirements
+        5. Select System Services
+        6. Set any System Services listed to your organization's requirements
+  query: |
+    -----------------------------------------------------------------------------------------------------------
+    -- Instructions for running and modifying this query:
+    -- Put the list of allowed applications in the designated area below.
+    -- To see what apps are currently allowed (and get the exact name format of the app name), use this query:
+    --    SELECT * FROM plist WHERE 
+    --    path='/var/db/locationd/clients.plist'  
+    --    AND subkey = "Authorized"  
+    --    AND value = '1'; 
+    -----------------------------------------------------------------------------------------------------------
+    SELECT 1 WHERE 
+        -- If location_services is not allowed at all, we are good. 
+        EXISTS(
+          SELECT 1 FROM location_services WHERE enabled = 0
+        )
+        OR 
+        -- If location_services is allowed, make sure allowed apps are approved. 
+        NOT EXISTS(
+          SELECT 1 FROM plist WHERE 
+            path='/var/db/locationd/clients.plist'  
+            AND subkey = "Authorized"  
+            AND value = '1'  
+            AND NOT(
+                ------------------------------------------------------------------------------------
+                -- Designated area to add applications allowed to use location-services
+                ------------------------------------------------------------------------------------
+                -- Typical app name
+                key LIKE "%:com.apple.TV"
+                OR 
+                -- Typical system service name
+                key LIKE "%com.apple.locationd.bundle-/System/Library/PrivateFrameworks/CoreParsec.framework"
+                OR 
+                key LIKE "%:com.apple.locationd.bundle-/System/Library/LocationBundles/DoNotDisturb.bundle"
+                ------------------------------------------------------------------------------------
+            )
+        );
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level2, CIS-macos-13-2.6.1.3-Location-Service-specifc-app-enabled, decision-needed
+  contributors: sharon-fdm
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure Limit Ad Tracking Is Enabled (MDM Required)
+  platforms: macOS
+  platform: darwin
+  description: Checks that Ensure Limit Ad Tracking Is Enabled.
+  resolution: |
+    Automated method:
+    Ask your system administrator to deploy an MDM profile that disables apple personalized advertising.
+    Graphical method:
+      Perform the following steps to ensure Limit Ad Tracking Is Enabled:
+        1. Open Privacy & Security
+        2. Select Apple Advertising
+        3. Verify that Personalized Ads is not enabled
+  query: |
+    SELECT 1 WHERE 
+      EXISTS (
+        SELECT 1 FROM managed_policies WHERE 
+            domain='com.apple.applicationaccess' AND 
+            name='allowApplePersonalizedAdvertising' AND 
+            (value = 0 OR value = 'false') AND 
+            username = ''
+        )
+      AND NOT EXISTS (
+        SELECT 1 FROM managed_policies WHERE 
+            domain='com.apple.applicationaccess' AND 
+            name='allowApplePersonalizedAdvertising' AND 
+            (value != 0 AND value != 'false')
+        );  
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1, CIS-macos-13-2.6.3
+  contributors: sharon-fdm
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure an Administrator Password Is Required to Access System-Wide Preferences (Fleetd required)
+  platforms: macOS
+  platform: darwin
+  description: Checks that an Administrator Password Is Required to Access System-Wide Preferences
+  resolution: |
+    Graphical method:
+      Perform the following steps to ensure an administrator password is required to access system-wide preferences:
+        1. Open System Settings
+        2. Open Privacy & Security
+        3. Select Advanced
+        4. Set Require an administrator password to access system-wide settings to enabled
+  query: SELECT 1 FROM authdb WHERE right_name = 'system.preferences' AND json_extract(json_result, '$.shared') == 0;
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1, CIS-macos-13-2.6.7
+  contributors: artemist-work
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure Screen Saver Corners Are Secure (FDA Required)
+  platforms: macOS
+  platform: darwin
+  description: |
+    Setting a hot corner to disable the screen saver poses a potential security risk since an
+    unauthorized person could use this to bypass the login screen and gain access to the system.
+
+    FDA (Full Disk Access) is required to read the configuration of all the users in the device
+    ('/Users/*/Library/Preferences/com.apple.dock.plist')
+  resolution: |
+    Ask your system administrator to deploy a script that will configure
+    `wvous-tl-corner`, `wvous-bl-corner`, `wvous-tr-corner`, and `wvous-br-corner` in
+    domain `com.apple.dock` to a value that is not 6 (for all users of the device).
+
+    Graphical Method:
+      Perform the following steps to ensure that a Hot Corner is not set to Disable Screen Saver:
+        1. Open System Settings
+        2. Select Desktop & Dock
+        3. Select`Hot Corners...`
+        4. Verify that `Disable Screen Saver` is not set to any of the corners.
+  query: |
+    SELECT 1 WHERE NOT EXISTS(
+      SELECT 1 FROM plist
+      WHERE path LIKE '/Users/%/Library/Preferences/com.apple.dock.plist' AND (
+        key = 'wvous-br-corner' OR
+        key = 'wvous-bl-corner' OR
+        key = 'wvous-tr-corner' OR
+        key = 'wvous-tl-corner'
+    ) AND value = 6);
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level2, CIS-macos-13-2.7.1
+  contributors: lucasmrod
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure Universal Control is enabled (Based on organization's policy) (MDM Required)
+  platforms: macOS
+  platform: darwin
+  description: |
+    Universal Control is an Apple feature that allows Mac users to control multiple other Macs and iPads with the same keyboard, mouse, and trackpad using the same Apple ID. The technology relies on already available iCloud services, particularly Handoff.
+    Universal Control simplifies the use of iCloud connectivity of multiple computers using the same Apple ID. This may simplify data transfer from organizationally-managed and personal devices. The use of the same iCloud account and Handoff is the underlying concern that should be evaluated. The use of the same keyboard or mouse across multiple devices does not by itself decrease organizational security.
+  resolution: |
+    Automated method:
+    Ask your system administrator to deploy an MDM profile that enables the Bluetooth status in the menu bar.
+    Create or edit a configuration profile with the following information:
+    1. The `PayloadType` string is com.apple.universalcontrol.
+    2. The key to include is 'Disable'.
+    3. The key must be set to <false/>.
+  query: |
+    SELECT 1 WHERE 
+      EXISTS (
+        SELECT 1 FROM managed_policies WHERE 
+            domain='com.apple.universalcontrol' AND 
+            name='Disable' AND 
+            (value = 0 OR value = 'false') AND 
+            username = ''
+        )
+      AND NOT EXISTS (
+        SELECT 1 FROM managed_policies WHERE 
+            domain='com.apple.universalcontrol' AND 
+            name='Disable' AND 
+            (value != 0 AND value != 'false')
+        );  
+    /*CIS does not make a hard recommendation for this policy. Fleet has provided two policies (one failing, one succeeding). 
+      Depending on your organization's decision, you can delete this policy or its counterpart.*/
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1, CIS-macos-13-2.8.1-enabled, decision-needed
+  contributors: sharon-fdm
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure Universal Control is disabled (Based on organization's policy) (MDM Required)
+  platforms: macOS
+  platform: darwin
+  description: |
+    Universal Control is an Apple feature that allows Mac users to control multiple other Macs and iPads with the same keyboard, mouse, and trackpad using the same Apple ID. The technology relies on already available iCloud services, particularly Handoff.
+    Universal Control simplifies the use of iCloud connectivity of multiple computers using the same Apple ID. This may simplify data transfer from organizationally-managed and personal devices. The use of the same iCloud account and Handoff is the underlying concern that should be evaluated. The use of the same keyboard or mouse across multiple devices does not by itself decrease organizational security.
+  resolution: |
+    Automated method:
+    Ask your system administrator to deploy an MDM profile that enables the Bluetooth status in the menu bar.
+    Create or edit a configuration profile with the following information:
+    1. The `PayloadType` string is com.apple.universalcontrol.
+    2. The key to include is 'Disable'.
+    3. The key must be set to <true/>.
+  query: |
+    SELECT 1 WHERE 
+      EXISTS (
+        SELECT 1 FROM managed_policies WHERE 
+            domain='com.apple.universalcontrol' AND 
+            name='Disable' AND 
+            (value = 1 OR value = 'true') AND 
+            username = ''
+        )
+      AND NOT EXISTS (
+        SELECT 1 FROM managed_policies WHERE 
+            domain='com.apple.universalcontrol' AND 
+            name='Disable' AND 
+            (value != 1 AND value != 'true')
+        );  
+    /*CIS does not make a hard recommendation for this policy. Fleet has provided two policies (one failing, one succeeding). 
+      Depending on your organization's decision, you can delete this policy or its counterpart.*/
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1, CIS-macos-13-2.8.1-disabled, decision-needed
+  contributors: sharon-fdm
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure Power Nap Is Disabled for Intel Macs (Fleetd Required)
+  platforms: macOS
+  platform: darwin
+  description: |
+    Power Nap allows the system to stay in low power mode, especially while on battery power, and periodically
+    connect to previously known networks with stored credentials for user applications to phone home and get updates.
+    This capability requires FileVault to remain unlocked and the use of previously joined networks to be risk accepted
+    based on the SSID without user input.
+    Disabling this feature mitigates the risk of an attacker remotely waking the system and gaining access.
+  resolution: |
+    Automated method:
+    Ask your system administrator to deploy a script that runs the following command to turn off
+    Power Nap on the device:
+    /usr/bin/sudo /usr/bin/pmset -a powernap 0
+  query: |
+    SELECT 1 FROM (SELECT
+      COALESCE(JSON_EXTRACT(
+          JSON_EXTRACT(json_result, '$.AC Power:'),
+          '$.powernap'
+      ), '') AS powernap_ac,
+      COALESCE(JSON_EXTRACT(
+          JSON_EXTRACT(json_result, '$.Battery Power:'),
+          '$.powernap'
+      ), '') AS powernap_battery
+    FROM pmset WHERE getting = 'custom' AND powernap_battery != '1' AND powernap_ac != '1');
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1, CIS-macos-13-2.9.1
+  contributors: lucasmrod
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure Wake for Network Access Is Disabled (Fleetd Required)
+  platforms: macOS
+  platform: darwin
+  description: |
+    Wake for Network Access allows the computer to take action when the user is not present and the computer
+    is in energy saving mode. These tools require FileVault to remain unlocked and fully rejoin known networks.
+
+    Disabling this feature mitigates the risk of an attacker remotely waking the system and gaining access.
+  resolution: |
+    Automated method:
+    Ask your system administrator to deploy a script that runs the following command to turn off
+    Wake on  on the device:
+    /usr/bin/sudo /usr/bin/pmset -a womp 0
+  query: |
+    SELECT 1 FROM (SELECT
+      COALESCE(JSON_EXTRACT(
+          JSON_EXTRACT(json_result, '$.AC Power:'),
+          '$.womp'
+      ), '') AS womp_ac,
+      COALESCE(JSON_EXTRACT(
+          JSON_EXTRACT(json_result, '$.Battery Power:'),
+          '$.womp'
+      ), '') AS womp_battery
+    FROM pmset WHERE getting = 'custom' AND womp_battery != '1' AND womp_ac != '1');
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1, CIS-macos-13-2.9.2
+  contributors: lucasmrod
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure the OS is not Activate When Resuming from Sleep (Fleetd, FDA Required)
+  platforms: macOS
+  platform: darwin
+  description: |
+    In order to use a computer with Full Disk Encryption (FDE), macOS must keep encryption keys in memory to allow
+    the use of the disk that has been FileVault protected. When the system is not in use, the volume is protected
+    through encryption. When the system is sleeping and available to quickly resume, the encryption keys remain in memory.
+    If an unauthorized party has possession of the computer and the computer is only slept, there are known attack vectors
+    that can be attempted against the RAM that has the encryption keys or the running operating system protected
+    by a login screen.
+
+    Mac systems should be set to hibernate after sleeping for a risk-acceptable time period.
+    MacBooks should be set so that the `standbydelay` is 15 minutes (900 seconds) or less.
+  resolution: |
+    Ask your system administrator to deploy the following script to Macbook devices:
+    if [[ $(uname -m) == 'arm64' ]]; then
+            # Apple silicon
+            /usr/bin/sudo /usr/bin/pmset -a standby 900
+            /usr/bin/sudo /usr/bin/pmset -a destroyfvkeyonstandby 1
+            /usr/bin/sudo /usr/bin/pmset -a hibernatemode 25
+    else
+            # Intel
+            /usr/bin/sudo /usr/bin/pmset -a standbydelaylow 900
+            /usr/bin/sudo /usr/bin/pmset -a standbydelayhigh 900
+            /usr/bin/sudo /usr/bin/pmset -a highstandbythreshold 90
+            /usr/bin/sudo /usr/bin/pmset -a destroyfvkeyonstandby 1
+            /usr/bin/sudo /usr/bin/pmset -a hibernatemode 25
+    fi
+  query: |
+    SELECT 1 WHERE EXISTS(
+      SELECT 1 FROM system_info WHERE
+      regex_match(hardware_model, '^Mac[0-9,]+$', 0) != '' OR regex_match(hardware_model, '^MacBook', 0) != 0
+    )
+    AND EXISTS(
+      SELECT JSON_EXTRACT(system_wide_power_settings, '$.DestroyFVKeyOnStandby') AS destroy_fv_key_on_standby
+      FROM (
+        SELECT JSON_EXTRACT(json_result, '$.System-wide power settings:') AS system_wide_power_settings FROM pmset
+      )
+      WHERE destroy_fv_key_on_standby = '1'
+    )
+    AND EXISTS(
+        SELECT 1 WHERE EXISTS(
+          SELECT 1 WHERE EXISTS(
+            SELECT 1 FROM system_info WHERE cpu_type = 'x86_64h' OR cpu_type = 'x86_64'
+          ) AND EXISTS(
+            SELECT
+                CAST(JSON_EXTRACT(battery, '$.standbydelaylow') AS INTEGER) AS standbydelaylow,
+                CAST(JSON_EXTRACT(battery, '$.standbydelayhigh') AS INTEGER) AS standbydelayhigh,
+                CAST(JSON_EXTRACT(battery, '$.highstandbythreshold') AS INTEGER) AS highstandbythreshold,
+                CAST(JSON_EXTRACT(battery, '$.hibernatemode') AS INTEGER) AS hibernatemode
+            FROM (
+                SELECT JSON_EXTRACT(json_result, '$.Battery Power:') as battery FROM pmset WHERE getting = 'custom'
+            )
+            WHERE standbydelaylow <= 900 AND standbydelayhigh <= 900 AND highstandbythreshold >= 90 AND hibernatemode = 25
+          )
+        ) OR EXISTS(
+          SELECT 1 WHERE EXISTS(
+            SELECT 1 FROM system_info WHERE cpu_type = 'arm64e'
+          ) AND EXISTS (
+            SELECT
+                CAST(JSON_EXTRACT(battery, '$.standby') AS INTEGER) AS standby,
+                CAST(JSON_EXTRACT(battery, '$.hibernatemode') AS INTEGER) AS hibernatemode
+            FROM (
+                SELECT JSON_EXTRACT(json_result, '$.Battery Power:') AS battery FROM pmset WHERE getting = 'custom'
+            )
+            WHERE standby <= 900 AND hibernatemode = 25
+          )
+        )
+    );
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level2, CIS-macos-13-2.9.3
+  contributors: lucasmrod
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure a Password is Required to Wake the Computer From Sleep or Screen Saver Is Enabled (MDM Required)
+  platforms: macOS
+  platform: darwin
+  description: Checks that Password is Required to Wake the Computer From Sleep or Screen Saver Is Enabled.
+  resolution: |
+    Automated method:
+    Ask your system administrator to deploy an MDM profile that Ensure a Password is Required to Wake the Computer From Sleep or Screen Saver Is Enabled.
+    Graphical method:
+      Perform the following steps to ensure a Password is Required to Wake the Computer From Sleep or Screen Saver Is Enabled:
+        1. Open System Settings
+        2. Select Lock Screen
+        3. Verify that Require password after screensaver begins or display is turned
+        off is set with After 0 seconds or After 5 seconds
+  query: |
+    SELECT 1 WHERE 
+      EXISTS (
+        SELECT 1 FROM managed_policies WHERE 
+            domain='com.apple.screensaver' AND 
+            name='askForPassword' AND 
+            (value = 1 OR value = 'true') AND 
+            username = ''
+        )
+      AND EXISTS (
+        SELECT 1 FROM managed_policies WHERE 
+            domain='com.apple.screensaver' AND 
+            name='askForPasswordDelay' AND 
+            value <= 5 AND 
+            username = ''
+        )
+      AND NOT EXISTS (
+        SELECT 1 FROM managed_policies WHERE 
+            domain='com.apple.screensaver' AND 
+            name='askForPassword' AND 
+            (value != 1 AND value != 'true')
+        )
+      AND NOT EXISTS (
+        SELECT 1 FROM managed_policies WHERE 
+            domain='com.apple.screensaver' AND 
+            name='askForPasswordDelay' AND 
+            value > 5
+        );  
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1, CIS-macos-13-2.10.2
+  contributors: sharon-fdm
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure Gatekeeper Is Enabled
+  platforms: macOS
+  platform: darwin
+  description: |
+    Checks that Gatekeeper Is Enabled. Gatekeeper is Apple’s application that utilizes allowlisting to restrict downloaded applications from launching. It functions as a control to limit applications from unverified sources from running without authorization. In an update to Gatekeeper in macOS 13 Ventura, Gatekeeper checks every application on every launch, not just quarantined apps.
+  resolution: |
+    Automated method:
+    Ask your system administrator to deploy an MDM profile that Ensure Gatekeeper Is Enabled
+    Graphical method:
+      Perform the following steps to ensure Gatekeeper Is Enabled:
+        1. Open System Settings
+        2. Select Privacy & Security
+        3. Verify that 'Allow apps downloaded from' is set to' App Store and identified developers'
+  query: SELECT 1 FROM gatekeeper WHERE assessments_enabled = 1 AND dev_id_enabled = 1;
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1, CIS-macos-13-2.6.4
+  contributors: sharon-fdm
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure Sending Diagnostic and Usage Data to Apple Is Disabled (MDM Required)
+  platforms: macOS
+  platform: darwin
+  description: Checks that Sending Diagnostic and Usage Data to Apple Is Disabled.
+  resolution: |
+    Automated method:
+    Ask your system administrator to deploy an MDM profile that disables Sending Diagnostic and Usage Data to Apple.
+    Graphical method:
+      Perform the following steps to ensure Sending Diagnostic and Usage Data to Apple Is Disabled:
+        1. Open System Settings
+        2. Select Privacy & Security
+        3. Select Analytics & Improvements
+        4. Verify that Share Mac Analytics is not enabled
+        5. Verify that Share with App Developers is not enabled
+        6. Verify that Improve Siri & Dictation is not enabled
+  query: |
+    SELECT 1 WHERE 
+      EXISTS (
+        SELECT 1 FROM managed_policies WHERE 
+            domain='com.apple.SubmitDiagInfo' AND 
+            name='AutoSubmit' AND 
+            (value = 0 OR value = 'false') AND 
+            username = ''
+        )
+      AND EXISTS (
+        SELECT 1 FROM managed_policies WHERE 
+            domain='com.apple.applicationaccess' AND 
+            name='allowDiagnosticSubmission' AND 
+            (value = 0 OR value = 'false') AND 
+            username = ''
+        )
+      AND EXISTS (
+        SELECT 1 FROM managed_policies WHERE 
+            domain='com.apple.applicationaccess' AND 
+            name='Siri Data Sharing Opt-In Status' AND 
+            value = 2 AND 
+            username = ''
+        )
+      AND NOT EXISTS (
+        SELECT 1 FROM managed_policies WHERE 
+            domain='com.apple.SubmitDiagInfo' AND 
+            name='Disable' AND 
+            (value != 0 AND value != 'false')
+        )
+      AND NOT EXISTS (
+        SELECT 1 FROM managed_policies WHERE 
+            domain='com.apple.applicationaccess' AND 
+            name='Disable' AND 
+            (value != 0 AND value != 'false')
+        )
+      AND NOT EXISTS (
+        SELECT 1 FROM managed_policies WHERE 
+            domain='com.apple.applicationaccess' AND 
+            name='Disable' AND 
+            value != 2
+        );  
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level2, CIS-macos-13-2.6.2
+  contributors: sharon-fdm
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure an Inactivity Interval of 20 Minutes Or Less for the Screen Saver Is Enabled (MDM Required)
+  platforms: macOS
+  platform: darwin
+  description: A locking screen saver is one of the standard security controls to limit access to a computer and the current user's session when the computer is temporarily unused or unattended. In macOS, the screen saver starts after a value is selected in the drop- down menu. 20 minutes or less is an acceptable value. Any value can be selected through the command line or script, but a number that is not reflected in the GUI can be problematic. 20 minutes is the default for new accounts.
+  resolution: |
+    Automated method:
+    Ask your system administrator to deploy an MDM profile that ensure an Inactivity Interval of 20 Minutes Or Less for the Screen Saver to be Enabled.
+    Graphical method:
+      Perform the following steps to ensure an Inactivity Interval of 20 Minutes Or Less for the Screen Saver Is Enabled:
+        1. Open System Settings
+        2. Select Lock Screen
+        3. Verify that Start Screen Saver when inactive is set for 20 minutes or less (≤1200 seconds)
+  query: |
+    SELECT 1 WHERE 
+      EXISTS (
+        SELECT 1 FROM managed_policies WHERE 
+            domain='com.apple.screensaver' AND 
+            name='idleTime' AND 
+            value <= 1200 AND 
+            username = ''
+        )
+      AND NOT EXISTS (
+        SELECT 1 FROM managed_policies WHERE 
+            domain='com.apple.screensaver' AND 
+            name='idleTime' AND 
+            value > 1200
+        );  
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1, CIS-macos-13-2.10.1
+  contributors: sharon-fdm
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure a Custom Message for the Login Screen Is Enabled
+  platforms: macOS
+  platform: darwin
+  description: An access warning informs the user that the system is reserved for authorized use only, and that the use of the system may be monitored
+  resolution: |
+    Graphical method:
+      Perform the following steps to ensure a Custom Message for the Login Screen Is Enabled:
+        1. Open System Settings
+        2. Select Lock Screen
+        3. Verify Show message when locked is enabled
+        4. Select Set
+        5. Verify that the message displayed is configured to your organization's required text
+  query: SELECT 1 FROM plist WHERE path='/Library/Preferences/com.apple.loginwindow.plist' AND key='LoginwindowText' AND value != "";
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1, CIS-macos-13-2.10.3
+  contributors: sharon-fdm
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure FileVault Is Enabled (MDM Required)
+  platforms: macOS
+  platform: darwin
+  description: Checks that FileVault Is Enabled. FileVault secures a system's data by automatically encrypting its boot volume and requiring a password or recovery key to access it. This policy checks that filevault is enabled on the device and that the user is not allowed to disable it.
+  resolution: |
+    Automated method:
+    Ask your system administrator to deploy an MDM profile that enables FileVault and disables turning it off.
+    Graphical method:
+      Perform the following steps to ensure FileVault Is Enabled:
+        1. Open System Settings
+        2. Select Privacy & Privacy
+        3. Verify that FileVault states FileVault is turned on for the disk "<disk name>"
+        4. Select Privacy & Security
+        5. Select Profile
+        6. Verify that an installed profile has FileVault Can't Disable set to True
+  query: |
+    SELECT 1 WHERE 
+      EXISTS (
+        SELECT 1 FROM managed_policies WHERE 
+            domain='com.apple.MCX' AND 
+            name='dontAllowFDEDisable' AND 
+            (value = 1 OR value = 'true') AND 
+            username = ''
+        )
+      AND NOT EXISTS (
+        SELECT 1 FROM managed_policies WHERE 
+            domain='com.apple.MCX' AND 
+            name='dontAllowFDEDisable' AND 
+            (value != 1 AND value != 'true')
+        )
+      AND EXISTS (
+        SELECT 1 FROM disk_encryption WHERE 
+            user_uuid IS NOT "" AND 
+            filevault_status = 'on' 
+        );  
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1, CIS-macos-13-2.6.5
+  contributors: sharon-fdm
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure Login Window Displays as Name and Password Is Enabled (MDM Required)
+  platforms: macOS
+  platform: darwin
+  description: Checks Login Window Displays as Name and Password Is Enabled.
+  resolution: |
+    Automated method:
+    Ask your system administrator to deploy an MDM profile that Ensure Login Window Displays as Name and Password Is Enabled.
+    Graphical method:
+      Perform the following steps to ensure Login Window Displays as Name and Password Is Enabled:
+        1. Open System Settings
+        2. Select Lock Screen
+        3. Verify that Login window shows is set to Name and Password
+  query: |
+    SELECT 1 WHERE 
+      EXISTS (
+        SELECT 1 FROM managed_policies WHERE 
+            domain='com.apple.loginwindow' AND 
+            name='SHOWFULLNAME' AND 
+            (value = 1 OR value = 'true') AND 
+            username = ''
+        )
+      AND NOT EXISTS (
+        SELECT 1 FROM managed_policies WHERE 
+            domain='com.apple.loginwindow' AND 
+            name='SHOWFULLNAME' AND 
+            (value != 1 AND value != 'true')
+        );  
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1, CIS-macos-13-2.10.4
+  contributors: sharon-fdm
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure Show Password Hints Is Disabled (MDM Required)
+  platforms: macOS
+  platform: darwin
+  description: Checks Show Password Hints Is Disabled.
+  resolution: |
+    Automated method:
+    Ask your system administrator to deploy an MDM profile that Ensures Show Password Hints Is Disabled.
+    Graphical method:
+      Perform the following steps to ensure Show Password Hints Is Disabled:
+        1. OpenSystemSettings
+        2. Select Lock Screen
+        3. Verify that Show password hints is disabled
+  query: |
+    SELECT 1 WHERE 
+      EXISTS (
+        SELECT 1 FROM managed_policies WHERE 
+            domain='com.apple.loginwindow' AND 
+            name='RetriesUntilHint' AND 
+            (value = 0 OR value = 'false') AND 
+            username = ''
+        )
+      AND NOT EXISTS (
+        SELECT 1 FROM managed_policies WHERE 
+            domain='com.apple.loginwindow' AND 
+            name='RetriesUntilHint' AND 
+            (value != 0 AND value != 'false')
+        );  
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1, CIS-macos-13-2.10.5
+  contributors: sharon-fdm
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure Users' Accounts Do Not Have a Password Hint (Fleetd Required)
+  platforms: macOS
+  platform: darwin
+  description: |
+    Password hints help the user recall their passwords for various systems and/or accounts. In most cases, password hints are simple and closely related to the user's password.
+  resolution: |
+    Automated method:
+    Ask your system administrator to deploy an MDM profile that disables apple personalized advertising.
+    Graphical method:
+      Perform the following steps to ensure Users' Accounts Do Not Have a Password Hint:
+        1. Open System Settings
+        2. Select Touch ID & Passwords (or Login Password on non-Touch ID Macs)
+        3. Select Change...
+        4. Change the password and ensure that no text is entered in the Password hint box
+  query: SELECT 1 FROM user_login_settings WHERE password_hint_enabled = 0;
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1, CIS-macos-13-2.11.1
+  contributors: sharon-fdm
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure Guest Account Is Disabled
+  platforms: macOS
+  platform: darwin
+  description: Checks that Guest Account Is Disabled.
+  resolution: |
+    Automated method:
+    Ask your system administrator to deploy an MDM profile that disables Guest Account.
+    Graphical method:
+      Perform the following steps to ensure Guest Account Is Disabled:
+        1. Open System Settings
+        2. Select Users & Groups
+        3. Select the i next to the Guest User
+        4. Verify that Allow guests to log in to this computer is disable
+  query: |
+    SELECT 1 WHERE
+    EXISTS(SELECT 1 FROM plist WHERE path='/Library/Preferences/com.apple.loginwindow.plist' AND key='GuestEnabled' AND value = 0)
+    OR
+    EXISTS(select 1 FROM plist WHERE path='/Library/Preferences/com.apple.MCX.plist' AND key='DisableGuestAccount' AND value = 1);
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1, CIS-macos-13-2.12.1
+  contributors: sharon-fdm
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure Guest Access to Shared Folders Is Disabled
+  platforms: macOS
+  platform: darwin
+  description: Allowing guests to connect to shared folders enables users to access selected shared folders and their contents from different computers on a network
+  resolution: |
+    Automated method:
+      Ask your system administrator to deploy the following script which will disable guest users from access to shared folders:
+      /usr/bin/sudo /usr/sbin/sysadminctl -smbGuestAccess off
+    Graphical Method:
+      Perform the following steps to no longer allow guest user access to shared folders:
+        1. Open System Settings
+        2. Select Users & Groups
+        3. Select the i next to the Guest User
+        4. Set Allow guests to connect to shared folders to disabled
+  query: SELECT 1 from plist where path = '/Library/Preferences/SystemConfiguration/com.apple.smb.server.plist' AND key = 'AllowGuestAccess' AND value = 0;
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1, CIS-macos-13-2.12.2
+  contributors: sharon-fdm
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure Automatic Login Is Disabled (MDM Required)
+  platforms: macOS
+  platform: darwin
+  description: |
+    The automatic login feature saves a user's system access credentials and bypasses the login screen. Instead, the system automatically loads to the user's desktop screen
+  resolution: |
+    Automated method:
+    Ask your system administrator to deploy an MDM profile that Ensure Automatic Login Is Disabled
+    Graphical method:
+      Perform the following steps to ensure Automatic Login Is Disabled:
+        1. Open System Settings
+        2. Select Users & Groups
+        3. Set Automatic login in as... to Off
+    Profile Method:
+        Create or edit a configuration profile with the following information:
+        1. The Payload Type string is com.apple.loginwindow
+        2. The key to include is com.apple.login.mcx.DisableAutoLoginClient 
+        3. The key must be set to <true/>
+  query: |
+    SELECT 1 WHERE 
+      EXISTS (
+        SELECT 1 FROM managed_policies WHERE 
+            domain='com.apple.login.mcx.DisableAutoLoginClient' AND 
+            name='Disable' AND 
+            (value = 1 OR value = 'true') AND 
+            username = ''
+        )
+      AND NOT EXISTS (
+        SELECT 1 FROM managed_policies WHERE 
+            domain='com.apple.login.mcx.DisableAutoLoginClient' AND 
+            name='Disable' AND 
+            (value != 1 AND value != 'true')
+        );  
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1, CIS-macos-13-2.12.3
+  contributors: sharon-fdm
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure Security Auditing Is Enabled
+  platforms: macOS
+  platform: darwin
+  description: |
+    macOS's audit facility, auditd, receives notifications from the kernel when certain system calls, such as open, fork, and exit, are made. These notifications are captured and written to an audit log.
+  resolution: |
+    Automated method:
+    Ask your system administrator to deploy the following script which will enable security auditing:
+    /usr/bin/sudo /bin/launchctl load -w /System/Library/LaunchDaemons/com.apple.auditd.plist
+  query: | 
+    SELECT 1 WHERE EXISTS (
+      SELECT
+        l.program, l.label, l.program_arguments,
+        p.path, p.name , p.cmdline
+      FROM
+        launchd AS l
+        INNER JOIN processes AS p
+      ON (l.program = p.path)
+      WHERE
+      (l.label = "com.apple.auditd")
+      AND
+      (l.program_arguments = p.cmdline)
+    );
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1, CIS-macos-13-3.1
+  contributors: sharon-fdm
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure Security Auditing Flags For User-Attributable Events Are Configured Per Local Organizational Requirements
+  platforms: macOS
+  platform: darwin
+  description: |
+    Auditing is the capture and maintenance of information about security-related events. Auditable events often depend on differing organizational requirements.
+  resolution: |
+    Automated method:
+    Ask your system administrator to deploy an MDM profile that disables Bonjour advertising service.
+    Terminal Method: 
+      Perform the following to set the required Security Auditing Flags:
+      Edit the /etc/security/audit_control file and add -fm, ad, -ex, aa, -fr, lo, and -fw to flags. You can also substitute -all for -fm, -ex, -fr, and -fw.
+  query: |
+    SELECT 1 WHERE EXISTS (    
+      SELECT line
+      FROM file_lines WHERE path = '/etc/security/audit_control' 
+      AND 
+      (
+            (
+              line LIKE 'flags:%' 
+              AND 
+              line LIKE "%-fm%"
+              AND 
+              line LIKE "%ad%"
+              AND 
+              line LIKE "%-ex%"
+              AND 
+              line LIKE "%aa%"
+              AND 
+              line LIKE "%-fr%"
+              AND 
+              line LIKE "%lo%"
+              AND 
+              line LIKE "%-fw%" 
+            ) 
+            OR 
+            (
+              line LIKE 'flags:%' 
+              AND 
+              line LIKE "%-all%" 
+              AND 
+              line LIKE "%ad%"
+              AND 
+              line LIKE "%aa%"
+              AND 
+              line LIKE "%lo%"
+            )
+      )
+    );
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level2, CIS-macos-13-3.2
+  contributors: sharon-fdm
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure install.log Is Retained for 365 or More Days and No Maximum Size
+  platforms: macOS
+  platform: darwin
+  description: |
+    macOS writes information pertaining to system-related events to the file /var/log/install.log and has a configurable retention policy for this file. The default logging setting limits the file size of the logs and the maximum size for all logs. The default allows for an errant application to fill the log files and does not enforce sufficient log retention. The Benchmark recommends a value based on standard use cases. The value should align with local requirements within the organization.
+  resolution: |
+    Automated method:
+      Ask your system administrator to deploy a script which will ensure proper retention for install.log.
+    Terminal Method:
+      Perform the following to ensure that install logs are retained for at least 365 days:
+      Edit the /etc/asl/com.apple.install file and add or modify the ttl value to 365 or greater on the file line. Also, remove the all_max= setting and value from the file line.
+  query: |
+    SELECT 1 WHERE
+    EXISTS ( SELECT line, 
+             CAST ( regex_match(line, 'ttl=(\d+)', 1) AS INTEGER ) AS val 
+             FROM file_lines 
+             WHERE path = '/etc/asl/com.apple.install' 
+             AND val >=365 )
+    AND
+    NOT EXISTS ( SELECT line  
+             FROM file_lines 
+             WHERE path = '/etc/asl/com.apple.install'  
+             AND  line  LIKE "%all_max=%" );
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1, CIS-macos-13-3.3
+  contributors: sharon-fdm
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure Security Auditing Retention Is Enabled
+  platforms: macOS
+  platform: darwin
+  description: |
+    The macOS audit capability contains important information to investigate security or operational issues. This resource is only completely useful if it is retained long enough to allow technical staff to find the root cause of anomalies in the records.
+    Retention can be set to respect both size and longevity. To retain as much as possible under a certain size, the recommendation is to use the following:
+    expire-after:60d OR 5G
+    This recomendation is based on minimum storage for review and investigation. When a third party tool is in use to allow remote logging or the store and forwarding of logs, this local storage requirement is not required.
+  resolution: |
+    Automated method:
+    Ask your system administrator to deploy the following script which will ensure proper Security Auditing Retention:
+    cp /etc/security/audit_control ./tmp.txt; origExpire=$(cat ./tmp.txt  | grep expire-after);  sed "s/${origExpire}/expire-after:60d OR 5G/" ./tmp.txt > /etc/security/audit_control; rm ./tmp.txt;
+  query: |
+    SELECT 1 WHERE EXISTS (
+      SELECT line,
+      CAST(regex_match(line, 'expire-after:(\d+)d OR (\d+)G', 1) AS INTEGER) AS days,
+      CAST(regex_match(line, 'expire-after:(\d+)d OR (\d+)G', 2) AS INTEGER) AS size
+      FROM file_lines
+      WHERE path = '/etc/security/audit_control'
+      AND days >=60
+      AND size >=5
+    );
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1, CIS-macos-13-3.4
+  contributors: sharon-fdm
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure Access to Audit Records Is Controlled
+  platforms: macOS
+  platform: darwin
+  description: |
+    The audit system on macOS writes important operational and security information that can be both useful for an attacker and a place for an attacker to attempt to obfuscate unwanted changes that were recorded. As part of defense-in-depth the /etc/security/audit_control configuration and the files in /var/audit should be owned only by root with group wheel with read-only rights and no other access allowed. macOS ACLs should not be used for these files.
+  resolution: |
+    Automated method:
+    Ask your system administrator to deploy the following script which will Ensure Access to Audit Records Is Controlled:
+      /usr/bin/sudo /usr/sbin/chown -R root:wheel /etc/security/audit_control
+      /usr/bin/sudo /bin/chmod -R o-rw /etc/security/audit_control
+      /usr/bin/sudo /usr/sbin/chown -R root:wheel /var/audit/
+      /usr/bin/sudo /bin/chmod -R o-rw /var/audit/
+  query: |
+    SELECT 1 WHERE 
+      -- For all files in /var/audit:
+      -- UID, GID should be owned by root.
+      -- MODE should be 0440 ("-r--r-----")
+      NOT EXISTS ( SELECT 1 FROM file WHERE path LIKE '/var/audit/%' AND (uid !=0 OR gid !=0 OR mode != "0440") )
+      AND 
+      NOT EXISTS ( select 1 from file 
+                        where path LIKE 
+                        ( 
+                            SELECT dir FROM 
+                            ( 
+                              -- The path we are looking for is written inside /etc/security/audit_control in a line that starts with "dir:"
+                              -- Looking immediately at this and REGEX-ing the path after it (and concatenating "/%")
+                              -- Same explanation for queries below.
+                              select line, CONCAT(regex_match(line, '^dir:(.+)',1 ), '/%') AS dir 
+                              FROM file_lines 
+                              WHERE path = '/etc/security/audit_control' 
+                              AND line LIKE "dir:%"
+                            )
+                        ) 
+                        AND ( uid !=0 OR gid !=0 OR mode != "0440" )
+                  ) 
+      AND 
+      -- For /etc/security/audit_control the MODE should be 0400 ("-r--------")
+      NOT EXISTS ( select 1 from file where path = "/etc/security/audit_control" AND mode != "0400" );
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1, CIS-macos-13-3.5
+  contributors: sharon-fdm
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure Firewall Logging Is Enabled and Configured (MDM Required)
+  platforms: macOS
+  platform: darwin
+  description: |
+    The socketfilter Firewall is what is used when the Firewall is turned on in the Security & Privacy Preference Pane. In order to appropriately monitor what access is allowed and denied, logging must be enabled. The logging level must be set to "detailed" to be useful in monitoring connection attempts that the firewall detects. Throttled login is not sufficient for examine Firewall connection attempts.
+  resolution: |
+    Profile Method:
+    Create or edit a configuration profile with the following information:
+    1. The Payload Type string is com.apple.security.firewall 
+    2. The key to include is EnableFirewall
+    3. The key must be set to<true/>
+    4. The key to also include is EnableLogging
+    5. The key must be set to<true/>
+    6. The key to also include is LoggingOption
+    7. The key must be set to <string>detail</string>
+  query: |
+    SELECT 1 WHERE
+    (
+      EXISTS (
+        SELECT 1 FROM managed_policies WHERE 
+            domain='com.apple.security.firewall' AND 
+            name='EnableLogging' AND 
+            (value = 1 OR value = 'true') AND 
+            username = ''
+        )
+      AND EXISTS (
+        SELECT 1 FROM managed_policies WHERE 
+            domain='com.apple.security.firewall' AND 
+            name='LoggingOption' AND 
+            value = "detail" AND 
+            username = ''
+        )
+      AND NOT EXISTS (
+        SELECT 1 FROM managed_policies WHERE 
+            domain='com.apple.security.firewall' AND 
+            name='EnableLogging' AND 
+            (value != 1 AND value != 'true')
+        )
+      AND NOT EXISTS (
+        SELECT 1 FROM managed_policies WHERE 
+            domain='com.apple.security.firewall' AND 
+            name='LoggingOption' AND 
+            value != "detail"
+        )
+    )
+    OR
+    (
+      EXISTS ( 
+        SELECT 1 FROM plist WHERE 
+            path='/Library/Preferences/com.apple.alf.plist' AND 
+            key='loggingenabled' AND 
+            value = 1 
+        )
+      AND EXISTS ( 
+        SELECT 1 FROM plist WHERE 
+        path='/Library/Preferences/com.apple.alf.plist' AND 
+        key='loggingoption' AND 
+        value = 2 
+        )
+    );
+
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1, CIS-macos-13-3.6
+  contributors: sharon-fdm
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure Bonjour Advertising Services Is Disabled (MDM Required)
+  platforms: macOS
+  platform: darwin
+  description: |
+    Bonjour is an auto-discovery mechanism for TCP/IP devices which enumerate devices and services within a local subnet.
+    DNS on macOS is integrated with Bonjour and should not be turned off, but the Bonjour advertising service can be disabled.
+  resolution: |
+    Automated method:
+    Ask your system administrator to deploy an MDM profile that disables Bonjour advertising service.
+    Profile Method:
+        Create or edit a configuration profile with the following information:
+        1. The Payload Type string is `com.apple.mDNSResponder`.
+        2. The key to include is `NoMulticastAdvertisements`.
+        3. The key must be set to `<true/>`.
+  query: |
+    SELECT 1 WHERE 
+      EXISTS (
+        SELECT 1 FROM managed_policies WHERE 
+            domain='com.apple.mDNSResponder' AND 
+            name='NoMulticastAdvertisements' AND 
+            (value = 1 OR value = 'true') AND 
+            username = ''
+        )
+      AND NOT EXISTS (
+        SELECT 1 FROM managed_policies WHERE 
+            domain='com.apple.mDNSResponder' AND 
+            name='NoMulticastAdvertisements' AND 
+            (value != 1 AND value != 'true')
+        );  
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level2, CIS-macos-13-4.1
+  contributors: lucasmrod
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure HTTP Server Is Disabled
+  platforms: macOS
+  platform: darwin
+  description: |
+    Personal web sharing could be enabled to allow someone on another computer to download files or information from the user's computer.
+    Apache is still part of the Operating System and can be easily turned on to share files and provide remote connectivity
+    to an end-user computer. Web serving should not be done from a user desktop. Open ports make it easier to exploit the computer.
+  resolution: |
+    Automated method:
+    Ask your system administrator to deploy the following script which will disable the Apache service:
+    /usr/bin/sudo /bin/launchctl unload -w /System/Library/LaunchDaemons/org.apache.httpd.plist
+  query: SELECT 1 WHERE NOT EXISTS(SELECT * FROM processes WHERE path = '/usr/sbin/httpd');
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1, CIS-macos-13-4.2
+  contributors: lucasmrod
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure NFS Server Is Disabled
+  platforms: macOS
+  platform: darwin
+  description: |
+    MacOS can act as an NFS fileserver. NFS sharing could be enabled to allow someone on another computer to mount
+    shares and gain access to information from the user's computer.
+  resolution: |
+    Automated method:
+    Ask your system administrator to deploy the following script which will disable the NFS service
+    and its directory listing:
+    /usr/bin/sudo /bin/launchctl disable system/com.apple.nfsd
+    /usr/bin/sudo /bin/rm /etc/exports
+  query: |
+    SELECT 1 WHERE
+    NOT EXISTS(SELECT 1 FROM processes WHERE path = '/sbin/nfsd')
+    AND
+    NOT EXISTS(SELECT 1 FROM file WHERE path = '/etc/exports');
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1, CIS-macos-13-4.3
+  contributors: lucasmrod
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure Home Folders Are Secure
+  platforms: macOS
+  platform: darwin
+  description: |
+    By default, macOS allows all valid users into the top level of every other user's home folder and restricts access to the Apple default folders within. Another user on the same system can see you have a "Documents" folder but cannot see inside it. This configuration does work for personal file sharing but can expose user files to standard accounts on the system.
+    The best parallel for Enterprise environments is that everyone who has a Dropbox account can see everything that is at the top level but can't see your pictures. Similarly with macOS, users can see into every new Directory that is created because of the default permissions.
+    Home folders should be restricted to access only by the user. Sharing should be used on dedicated servers or cloud instances that are managing access controls. Some environments may encounter problems if execute rights are removed as well as read and write. Either no access or execute only for group or others is acceptable.
+  resolution: |
+    Automated method:
+    Ask your system administrator to deploy a script that will go over all users and set the mode for all of them either like this:
+    /usr/bin/sudo /bin/chmod -R og-rwx /Users/<username>
+    Or like this if there is a need for excutable access:
+    /usr/bin/sudo /bin/chmod -R og-rw /Users/<username>
+  query: SELECT 1 WHERE NOT EXISTS (
+    SELECT 1 FROM file WHERE (
+    path LIKE '/Users/%'
+    AND path != '/Users/Shared/'
+    AND mode != "0700"
+    AND mode !="0701"
+    AND mode !="0710"
+    AND mode !="0711"
+    ));
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1, CIS-macos-13-5.1.1
+  contributors: sharon-fdm
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure System Integrity Protection Status (SIP) Is Enabled
+  platforms: macOS
+  platform: darwin
+  description: |
+    System Integrity Protection is a security feature introduced in OS X 10.11 El Capitan. System Integrity Protection restricts access to System domain locations and restricts runtime attachment to system processes. Any attempt to inspect or attach to a system process will fail. Kernel Extensions are now restricted to /Library/Extensions and are required to be signed with a Developer ID.
+  resolution: |
+    Terminal Method:
+    Perform the following steps to enable System Integrity Protection:
+      1. Reboot into the Recovery Partition (reboot and hold down Command (⌘) + R)
+      2. Select Utilities
+      3. Select Terminal
+      4. Run the following command:
+          /usr/bin/sudo /usr/bin/csrutil enable
+  query: SELECT 1 FROM sip_config WHERE config_flag="sip" and enabled=1;
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1, CIS-macos-13-5.1.2
+  contributors: sharon-fdm
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure Apple Mobile File Integrity (AMFI) Is Enabled (fleetd required)
+  platforms: macOS
+  platform: darwin
+  description: |
+    Apple Mobile File Integrity (AMFI) was first released in macOS 10.12. The daemon and service block attempts to run unsigned code. AMFI uses launchd, code signatures, certificates, entitlements, and provisioning profiles to create a filtered entitlement dictionary for an app. AMFI is the macOS kernel module that enforces code-signing and library validation.
+    Note: AMFI cannot be disabled with SIP enabled, but a change attempt can be made that will appear successful, and report incorrectly as successful. If the AMFI audit fails, and the SIP audit passes, this is still an issue the admin should research.
+  resolution: |
+    Automated method:
+      Ask your system administrator to deploy the following script which will Ensure Apple Mobile File Integrity (AMFI) Is Enabled:
+      /usr/bin/sudo /usr/sbin/nvram boot-args=""
+  query: SELECT 1 FROM nvram_info WHERE amfi_enabled="1";
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1, CIS-macos-13-5.1.3
+  contributors: sharon-fdm
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure Sealed System Volume (SSV) Is Enabled (fleetd required)
+  platforms: macOS
+  platform: darwin
+  description: |
+    Sealed System Volume is a security feature introduced in macOS 11.0 Big Sur.
+    During system installation, a SHA-256 cryptographic hash is calculated for all immutable system files and stored in a Merkle tree which itself is hashed as the Seal. Both are stored in the metadata of the snapshot created of the System volume.
+    The seal is verified by the boot loader at startup. macOS will not boot if system files have been tampered with. If validation fails, the user will be instructed to reinstall the operating system.
+    During read operations for files located in the Sealed System Volume, a hash is calculated and compared to the value stored in the Merkle tree.
+  resolution: |
+    If SSV has been disabled, assume that the operating system has been compromised. Back up any files, and do a clean install to a known good Operating System.
+  query: SELECT 1 FROM csrutil_info WHERE ssv_enabled="1";
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1, CIS-macos-13-5.1.4
+  contributors: sharon-fdm
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure Appropriate Permissions Are Enabled for System Wide Applications
+  platforms: macOS
+  platform: darwin
+  description: |
+    Applications in the System Applications Directory (/Applications) should be world- executable since that is their reason to be on the system. They should not be world- writable and allow any process or user to alter them for other processes or users to then execute modified versions.
+  resolution: |
+    Ask your system administrator to deploy a script that will configure all *.app under /Applications folders to have no write permissions for 'others'. 
+    $ /usr/bin/sudo IFS=$'\n'
+      for apps in $( /usr/bin/find /Applications -iname "*\.app" -type d -perm -2 ); 
+      do
+        /bin/chmod -R o-w "$apps"
+      done
+  query: |
+    SELECT 1 WHERE NOT EXISTS (
+      SELECT apps.path FROM apps
+      LEFT JOIN file on file.path = apps.path
+      WHERE apps.path LIKE '/Applications/%' AND
+      -- file.mode's last character are the permissions for 'other',
+      -- bitwise && with '0x2' selects the write permission,
+      -- which we do not want here.
+      CAST(SUBSTRING(file.mode, -1) AS INTEGER) & 0x2 != 0
+    );
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1, CIS-macos-13-5.1.5
+  contributors: sharon-fdm
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure No World Writable Files Exist in the System Folder
+  platforms: macOS
+  platform: darwin
+  description: |
+    Software sometimes insists on being installed in the /System/Volumes/Data/System Directory and has inappropriate world-writable permissions.
+    Macs with writable files in System should be investigated forensically. A file with open writable permissions is a sign of at best a rogue application.
+    It could also be a sign of a computer compromise and a persistent presence on the system.
+    The audit check excludes the "Drop Box" folder that is part of Apple's default user template.
+  resolution: |
+    Ask your system administrator to deploy a script that will ensure folders are not world-writable in the /System folder. 
+    /usr/bin/sudo IFS=$'\n'
+    for sysPermissions in $( /usr/bin/find /System/Volumes/Data/System -type d -perm -2 | /usr/bin/grep -v "Drop Box" ); 
+    do
+      /bin/chmod -R o-w "$sysPermissions"
+    done
+  query: |
+    SELECT 1 WHERE NOT EXISTS (
+      SELECT 1 FROM find_cmd WHERE
+        directory = '/System/Volumes/Data/System'
+        AND type = 'd'
+        AND perm = '-2'
+        AND path NOT LIKE '%Drop Box%'
+    );
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1, CIS-macos-13-5.1.6
+  contributors: sharon-fdm
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure No World Writable Files Exist in the Library Folder
+  platforms: macOS
+  platform: darwin
+  description: |
+    Software sometimes insists on being installed in the /System/Volumes/Data/Library Directory and has inappropriate world-writable permissions.  
+    Folders in /System/Volumes/Data/Library should not be world-writable. The audit check excludes the /System/Volumes/Data/Library/Caches and /System/Volumes/Data/Library/Preferences/Audio/Data folders where the sticky bit is set.
+  resolution: |
+    Ask your system administrator to deploy a script that will ensure folders are not world-writable in the /System folder. 
+    /usr/bin/sudo IFS=$'\n'
+    for libPermissions in $( /usr/bin/find /System/Volumes/Data/Library -type d -perm -2 | /usr/bin/grep -v Caches | /usr/bin/grep -v /Preferences/Audio/Data); 
+    do
+      /bin/chmod -R o-w "$libPermissions"
+    done
+  query: |
+    SELECT 1 WHERE NOT EXISTS (
+      SELECT 1 FROM find_cmd WHERE
+        directory = '/System/Volumes/Data/Library'
+        AND type = 'd'
+        AND perm = '-2'
+        AND path NOT LIKE '%Caches%'
+        AND path NOT LIKE '%/Preferences/Audio/Data%'
+    );
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level2, CIS-macos-13-5.1.7
+  contributors: sharon-fdm
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure Password Account Lockout Threshold Is Configured (Fleetd required)
+  platforms: macOS
+  platform: darwin
+  description: |
+    The account lockout threshold specifies the amount of times a user can enter an incorrect password before a lockout will occur.
+  resolution: |
+    Automated method:
+    Ask your system administrator to deploy an MDM profile that Ensure Password Account Lockout Threshold.
+    Profile Method:
+    Create or edit a configuration profile with the following information:
+      1. The PayloadType string is com.apple.mobiledevice.passwordpolicy 
+      2. The key to include is maxFailedAttempts
+      3. The key must be set to <integer><value≤5></integer>
+  query: SELECT 1 FROM  pwd_policy where max_failed_attempts <= 5;
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1, CIS-macos-13-5.2.1
+  contributors: sharon-fdm
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure Password Minimum Length Is Configured
+  platforms: macOS
+  platform: darwin
+  description: |
+    A minimum password length is the fewest number of characters a password can contain to meet a system's requirements. Ensure that a minimum of a 15-character password is part of the password policy on the computer. Where the confidentiality of encrypted information in FileVault is more of a concern, requiring a longer password or passphrase may be sufficient rather than imposing additional complexity requirements that may be self-defeating.
+  resolution: |
+    Automated method:
+    Ask your system administrator to deploy an MDM profile that disables Guest Account.
+    Profile Method:
+    Create or edit a configuration profile with the following information:
+      1. The PayloadType string is com.apple.mobiledevice.passwordpolicy 
+      2. The key to include is minLength
+      3. The key must be set to <integer><value≥15></integer>
+  query: |
+    SELECT 1 
+    FROM (
+    SELECT cast(lengthtxt as integer(2)) minlength 
+    FROM (
+    SELECT SUBSTRING(length, 1, 2) AS lengthtxt 
+    FROM (
+    SELECT policy_description, policy_identifier, split(policy_content, '{', 1) AS length 
+    FROM password_policy 
+    WHERE policy_identifier LIKE '%minLength')) 
+    WHERE minlength >= 15);
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1, CIS-macos-13-5.2.2
+  contributors: sharon-fdm
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure Complex Password Must Contain Alphabetic Characters AND Numeric Characters Is Configured (MDM Required)
+  platforms: macOS
+  platform: darwin
+  description: |
+    CIS - 5.2.3 - Complex passwords contain one character from each of the following classes: English uppercase letters, English lowercase letters, Westernized Arabic numerals, and non- alphanumeric characters.
+    Ensure that an Alphabetic character is part of the password policy on the computer.
+    CIS - 5.2.4 - Complex passwords contain one character from each of the following classes: English uppercase letters, English lowercase letters, Westernized Arabic numerals, and non- alphanumeric characters.
+    Ensure that a number or numeric value is part of the password policy on the computer.
+  resolution: |
+    Ask your system administrator to deploy an MDM profile that ensures Complex Password Must Contain Alphabetic Characters
+  query: |
+    SELECT 1 WHERE 
+      EXISTS (
+        SELECT 1 FROM managed_policies WHERE 
+            domain='com.apple.mobiledevice.passwordpolicy' AND 
+            name='requireAlphanumeric' AND 
+            (value = 1 OR value = 'true') AND 
+            username = ''
+        )
+      AND NOT EXISTS (
+        SELECT 1 FROM managed_policies WHERE 
+            domain='com.apple.mobiledevice.passwordpolicy' AND 
+            name='requireAlphanumeric' AND 
+            (value != 1 AND value != 'true')
+        );  
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level2, CIS-macos-13-5.2.3, CIS-macos-13-5.2.4
+  contributors: sharon-fdm
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure Complex Password Must Contain Special Character Is Configured (MDM Required)
+  platforms: macOS
+  platform: darwin
+  description: |
+    Complex passwords contain one character from each of the following classes: English uppercase letters, English lowercase letters, Westernized Arabic numerals, and non- alphanumeric characters. Ensure that a special character is part of the password policy on the computer.
+  resolution: |
+    Ask your system administrator to deploy an MDM profile that ensures Complex Password Must Contain Special Characters
+  query: |
+    SELECT 1 WHERE 
+      EXISTS (
+        SELECT 1 FROM managed_policies WHERE 
+            domain='com.apple.mobiledevice.passwordpolicy' AND 
+            name='minComplexChars' AND 
+            value >= 1 AND 
+            username = ''
+        )
+      AND NOT EXISTS (
+        SELECT 1 FROM managed_policies WHERE 
+            domain='com.apple.mobiledevice.passwordpolicy' AND 
+            name='minComplexChars' AND 
+            value < 1
+        );  
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level2, CIS-macos-13-5.2.5
+  contributors: sharon-fdm
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure Complex Password Must Contain Uppercase and Lowercase Characters Is Configured (Fleetd required)
+  platforms: macOS
+  platform: darwin
+  description: |
+    Complex passwords contain one character from each of the following classes: English uppercase letters, English lowercase letters, Westernized Arabic numerals, and non- alphanumeric characters.
+    Ensure that both uppercase and lowercase letters are part of the password policy on the computer.
+  resolution: |
+    Ask your system administrator to deploy the following script:
+    /usr/bin/sudo /usr/bin/pwpolicy -n /Local/Default -setglobalpolicy "requiresMixedCase=<value>=1>"
+  query: SELECT 1 FROM  pwd_policy where min_mixed_case_characters >= 1;
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1, CIS-macos-13-5.2.6
+  contributors: sharon-fdm
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure Password Age Is Configured (Fleetd Required)
+  platforms: macOS
+  platform: darwin
+  description: |
+    Over time, passwords can be captured by third parties through mistakes, phishing attacks, third-party breaches, or merely brute-force attacks. To reduce the risk of exposure and to decrease the incentives of password reuse (passwords that are not forced to be changed periodically generally are not ever changed), users should reset passwords periodically. This control uses 365 days as the acceptable value. Some organizations may be more or less restrictive. This control mainly exists to mitigate against password reuse of the macOS account password in other realms that may be more prone to compromise. Attackers take advantage of exposed information to attack other accounts.
+  resolution: |
+    Automated method:
+    Ask your system administrator to deploy an MDM profile that disables Guest Account.
+    Profile Method:
+    Create or edit a configuration profile with the following information:
+      1. The Payload Type string is com.apple.mobiledevice.passwordpolicy 
+      2. The key to include is maxPINAgeInDays
+      3. The key must be set to <integer><value<=365></integer>
+  query: |
+    SELECT 1 WHERE
+    EXISTS(SELECT 1 FROM pwd_policy WHERE expires_every_n_days <= 365)
+    OR
+    EXISTS(SELECT 1 FROM pwd_policy WHERE days_to_expiration <= 365);
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1, CIS-macos-13-5.2.7
+  contributors: sharon-fdm
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure Password History Is Configured (Fleetd Required)
+  platforms: macOS
+  platform: darwin
+  description: |
+    Over time, passwords can be captured by third parties through mistakes, phishing attacks, third-party breaches, or merely brute-force attacks. To reduce the risk of exposure and to decrease the incentives of password reuse (passwords that are not forced to be changed periodically generally are not ever changed), users must reset passwords periodically. This control ensures that previous passwords are not reused immediately by keeping a history of previous password hashes. Ensure that password history checks are part of the password policy on the computer. This control checks whether a new password is different than the previous 15. The latest NIST guidance based on exploit research referenced in this section details how one of the greatest risks is password exposure rather than password cracking. Passwords should be changed to a new unique value whenever a password might have been exposed to anyone other than the account holder. Attackers have maintained persistent control based on predictable password change patterns and substantially different patterns should be used in case of a leak.
+  resolution: |
+    Automated method:
+    Ask your system administrator to deploy an MDM profile with the following information:
+      1. The Payload Type string is com.apple.mobiledevice.passwordpolicy 
+      2. The key to include is pinHistory
+      3. The key must be set to <integer><value≥15></integer>
+  query: SELECT 1 FROM  pwd_policy where history_depth >= 15;
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1, CIS-macos-13-5.2.8
+  contributors: sharon-fdm
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure all user storage APFS volumes are encrypted (Fleetd Required)
+  platforms: macOS
+  platform: darwin
+  description: |
+    Apple developed a new file system which was first made available in 10.12 and then became the
+    default in 10.13. The file system is optimized for Flash and Solid-State storage and encryption.
+    https://en.wikipedia.org/wiki/Apple_File_System macOS computers generally have several volumes
+    created as part of APFS formatting, including Preboot, Recovery and Virtual Memory (VM), as well
+    as traditional user disks.
+    All APFS volumes that do not have specific roles and do not require encryption should be
+    encrypted. "Role" disks include Preboot, Recovery and VM. User disks are labelled with "(No
+    specific role)" by default.
+  resolution: |
+    Manual method:
+    Use Disk Utility to erase a user disk and format as APFS (Encrypted).
+    Note: APFS Encrypted disks will be described as "FileVault" whether they are the boot volume or not in the ap list.
+  query: |
+    SELECT 1 WHERE NOT EXISTS (
+      SELECT 1 FROM apfs_volumes WHERE
+        role != "VM" AND
+        role != "Update" AND
+        role != "Recovery" AND
+        role != "Preboot" AND
+        role != "xART" AND
+        role != "Hardware" AND
+        filevault != 1
+    );
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1, CIS-macos-13-5.3.1
+  contributors: artemist-work
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure all user storage CoreStorage volumes are encrypted (Fleetd Required)
+  platforms: macOS
+  platform: darwin
+  description: |
+    Apple introduced CoreStorage with 10.7. It is used as the default for formatting on macOS volumes prior to 10.13.
+    While FileVault protects the boot volume, data may be copied to other attached storage and reduce the protection afforded by FileVault.
+    Ensure all user volumes are encrypted to protect data.
+  resolution: |
+    Manual method:
+      Use Disk Utility to convert volumes to APFS or delete them.
+      It is no longer possible to encrypt CoreStorage volumes without converting them.
+  query: |
+    SELECT 1 WHERE NOT EXISTS (
+      SELECT 1 FROM corestorage_logical_volume_families WHERE EncryptionType != "AES-XTS"
+    );
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1, CIS-macos-13-5.3.2
+  contributors: artemist-work
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure the Sudo Timeout Period Is Set to Zero (Fleetd Required)
+  platforms: macOS
+  platform: darwin
+  description: |
+    The sudo command stays logged in as the root user for five minutes before timing out and re-requesting a password.
+    This five-minute window should be eliminated since it leaves the system extremely vulnerable.
+  resolution: |
+    Automated method:
+    Ask your system administrator to deploy the following script:
+    echo 'Defaults timestamp_timeout=0' | sudo tee -a /etc/sudoers.d/CIS_54_sudoconfiguration
+    /usr/bin/sudo /usr/sbin/chown -R root:wheel /etc/sudoers.d/
+  query: |
+    SELECT 1 WHERE EXISTS(
+      SELECT * FROM file WHERE path = '/etc/sudoers.d' AND uid = 0 AND gid = 0
+    ) AND EXISTS(
+      SELECT
+        COALESCE(JSON_EXTRACT(
+          json_result, '$.Authentication timestamp timeout'
+        ), '') AS authentication_timestamp_timeout
+      FROM sudo_info WHERE authentication_timestamp_timeout = '0.0 minutes'
+    );
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1, CIS-macos-13-5.4
+  contributors: lucasmrod
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure a Separate Timestamp Is Enabled for Each User/tty (Fleetd Required)
+  platforms: macOS
+  platform: darwin
+  description: |
+    Using tty tickets ensures that a user must enter the sudo password in each Terminal session.
+    With sudo versions 1.8 and higher, introduced in 10.12, the default value is to have tty tickets
+    for each interface so that root access is limited to a specific terminal.
+    The default configuration can be overwritten or not configured correctly on earlier versions of macOS.
+  resolution: |
+    Automated method:
+    Ask your system administrator to deploy the following script:
+    echo 'Defaults timestamp_type=tty' | sudo tee /etc/sudoers.d/CIS_55_sudoconfiguration
+  query: |
+    SELECT 1 WHERE EXISTS(
+      SELECT
+        COALESCE(JSON_EXTRACT(
+          json_result, '$.Type of authentication timestamp record'
+        ), '') AS type_of_auth_timestamp_record
+      FROM sudo_info WHERE type_of_auth_timestamp_record = 'tty'
+    );
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1, CIS-macos-13-5.5
+  contributors: lucasmrod
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure the "root" Account Is Disabled (Fleetd Required)
+  platforms: macOS
+  platform: darwin
+  description: |
+    Enabling and using the root account puts the system at risk since any successful exploit or mistake
+    while the root account is in use could have unlimited access privileges within the system.
+    Using the sudo command allows users to perform functions as a root user while limiting and password
+    protecting the access privileges. By default the root account is not enabled on a macOS computer.
+    An administrator can escalate privileges using the sudo command (use -s or -i to get a root shell).
+  resolution: |
+    Automated method:
+    Ask your system administrator to deploy the following script:
+      /usr/bin/sudo /usr/sbin/dsenableroot -d
+  query: |
+    SELECT 1 from dscl WHERE command = 'read' AND path = '/Users/root' AND key = 'AuthenticationAuthority' AND value = '';
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1, CIS-macos-13-5.6
+  contributors: lucasmrod
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure an Administrator Account Cannot Login to Another User's Active and Locked Session (Fleetd Required)
+  platforms: macOS
+  platform: darwin
+  description: |
+    Disabling the administrator's and/or user's ability to log into another user's active and locked session prevents
+    unauthorized persons from viewing potentially sensitive and/or personal information.
+  resolution: |
+    Automated method:
+    Ask your system administrator to deploy a script that runs the following:
+      /usr/bin/sudo /usr/bin/security authorizationdb write system.login.screensaver use-login-window-ui
+  query: |
+    SELECT 1 WHERE EXISTS (
+      SELECT JSON_EXTRACT(json_result, '$.rule') AS rule
+      FROM authdb
+      WHERE right_name = 'system.login.screensaver' AND 
+      rule LIKE '%use-login-window-ui%'
+    );
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1, CIS-macos-13-5.7
+  contributors: lucasmrod
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure a Login Window Banner Exists
+  platforms: macOS
+  platform: darwin
+  description: |
+    An access warning may reduce a casual attacker's tendency to target the system. Access warnings may also aid
+    in the prosecution of an attacker by evincing the attacker's knowledge of the system's private status,
+    acceptable use policy, and authorization requirements.
+  resolution: |
+    Automated method:
+    Ask your system administrator to deploy the following script:
+      echo "Content of the banner" | sudo tee /Library/Security/PolicyBanner.txt
+      /usr/bin/sudo /usr/sbin/chown root:wheel /Library/Security/PolicyBanner.txt
+      /usr/bin/sudo /bin/chmod o+r /Library/Security/PolicyBanner.txt
+  query: |
+    SELECT 1 FROM file
+    WHERE (path = '/Library/Security/PolicyBanner.txt' OR
+    path = '/Library/Security/PolicyBanner.rtf') AND mode = '0644'
+    AND uid = 0 AND gid = 0;
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level2, CIS-macos-13-5.8
+  contributors: lucasmrod
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure Legacy EFI Is Valid and Updating (Fleetd Required)
+  platforms: macOS
+  platform: darwin
+  description: |
+    In order to mitigate firmware attacks, Apple has created an automated Firmware check to ensure that the EFI version
+    running is a known good version from Apple. There is also an automated process to check it every seven days.
+    This check is only valid on T1 chips and prior. Neither T2 chips nor Apple silicon require this control check
+    If the Firmware of a computer has been compromised, the Operating System that the Firmware loads cannot be trusted, either.
+  resolution: |
+    If EFI does not pass the integrity check, you may send a report to Apple. Backing up files and clean installing a
+    known good Operating System and Firmware is recommended.
+  query: |
+    SELECT 1 FROM firmware_eficheck_integrity_check
+    WHERE chip != 'intel-t1' OR (
+      chip = 'intel-t1' AND
+      output LIKE '%Primary allowlist version match found. No changes detected in primary hashes%' AND
+      NOT EXISTS (
+          SELECT * FROM plist WHERE
+          path = '/var/db/com.apple.xpc.launchd/disabled.plist' AND
+          key = 'com.apple.driver.eficheck' AND
+          value = '0'
+      )
+    );
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1, CIS-macos-13-5.9
+  contributors: lucasmrod
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure the Guest Home Folder Does Not Exist
+  platforms: macOS
+  platform: darwin
+  description: |
+    The Guest home folders are unneeded after the Guest account is disabled and could be used inappropriately.
+  resolution: |
+    Automated method:
+    Ask your system administrator to deploy the following script:
+      /usr/bin/sudo /bin/rm -R /Users/Guest
+  query: |
+    SELECT 1 WHERE NOT EXISTS (SELECT * FROM file WHERE path = '/Users/Guest');
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1, CIS-macos-13-5.10
+  contributors: lucasmrod
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure Show All Filename Extensions Setting is Enabled
+  platforms: macOS
+  platform: darwin
+  description: |
+    A filename extension is a suffix added to a base filename that indicates the base filename's
+    file format. Visible filename extensions allow the user to identify the file type and the
+    application it is associated with which leads to quick identification of misrepresented malicious files.
+  resolution: |
+    Automated method:
+    Ask your system administrator to deploy a script that will ensure Show All Filename Extensions Setting is Enabled
+        For each user run:
+        /usr/bin/sudo -u <username> /usr/bin/defaults write /Users/<username>/Library/Preferences/.GlobalPreferences.plist AppleShowAllExtensions -bool true
+  query: |
+    SELECT 1 WHERE NOT EXISTS (
+      SELECT 1 FROM users AS u
+      LEFT JOIN (
+        SELECT * FROM plist WHERE
+          path LIKE '/Users/%/Library/Preferences/.GlobalPreferences.plist' AND
+          key = 'AppleShowAllExtensions' AND
+          value = '1') AS p
+      ON p.path = CONCAT(u.directory, '/Library/Preferences/.GlobalPreferences.plist')
+        WHERE u.directory LIKE '/Users/%' AND
+        p.value IS NULL
+    );
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1, CIS-macos-13-6.1.1
+  contributors: artemist-work
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure Automatic Opening of Safe Files in Safari Is Disabled (MDM Required)
+  platforms: macOS
+  platform: darwin
+  description: |
+    Safari will automatically run or execute what it considers safe files. This can include
+    installers and other files that execute on the operating system. Safari evaluates file safety by
+    using a list of filetypes maintained by Apple. The list of files include text, image, video and
+    archive formats that would be run in the context of the OS rather than the browser.
+    Hackers have taken advantage of this setting via drive-by attacks. These attacks occur when a
+    user visits a legitimate website that has been corrupted. The user unknowingly downloads a
+    malicious file either by closing an infected pop-up or hovering over a malicious banner. An
+    attacker can create a malicious file that will fall within Safari's safe file list that will
+    download and execute without user input.
+  resolution: |
+    Payload Method:
+    Ask your administrator to deploy a profile which disables AutoOpenSafeDownloads in Safari
+  query: |
+    SELECT 1 WHERE 
+      EXISTS (
+        SELECT 1 FROM managed_policies WHERE 
+            domain='com.apple.Safari' AND 
+            name='AutoOpenSafeDownloads' AND 
+            (value = 0 OR value = 'false') AND 
+            username = ''
+        )
+      AND NOT EXISTS (
+        SELECT 1 FROM managed_policies WHERE 
+            domain='com.apple.Safari' AND 
+            name='AutoOpenSafeDownloads' AND 
+            (value != 0 AND value != 'false')
+        );  
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1, CIS-macos-13-6.3.1
+  contributors: artemist-work
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Audit Safari Web Browser History and Remove History Items (organization decision needed)(MDM Required)
+  platforms: macOS
+  platform: darwin
+  description: |
+    Organizational management of user web browsing history is a challenge effected by multiple facets. Organizations should decide whether to manage browser history and how much history should be maintained.
+    Rationale:
+    There are conflicting concerns in the retention of browser history. Unlimited retention:
+    - Consumes disk space
+    - Preferred by on disk forensics teams
+    - User searchable for old visited pages
+    - User privacy concerns
+    - Security concerns to retain old links that may be stale or lead to compromised
+    pages or pages with changes or inappropriate content
+    Old browser history becomes stale and the use or misuse of the data can lead to unwanted outcomes. Search engine results are maintained and often provide much more relevant current information than old website visit information.
+  resolution: |
+    Ask your system administrator to deploy an MDM profile that set the history per organization decision
+    Profile Method:
+      Create or edit a configuration profile with the following information:
+      1. The PayloadType string is com.apple.Safari
+      2. The key to include is HistoryAgeInDaysLimit
+      3. The key must be set to: <integer><1,7,14,31,365,36500></integer>
+  query: |
+    SELECT 1 WHERE 
+      EXISTS (
+        SELECT 1 FROM managed_policies WHERE 
+            domain='com.apple.Safari' AND 
+            name='HistoryAgeInDaysLimit' AND 
+              /*
+              Please replace the checked value bellow to match the one decided by your organization.
+              1 - After one day
+              7 - After one week
+              14 - After two weeks
+              31 - After one month
+              365 - After one year
+              36500 - Set Manually
+              */
+            value = 1 AND 
+            username = ''
+        )
+      AND NOT EXISTS (
+        SELECT 1 FROM managed_policies WHERE 
+            domain='com.apple.Safari' AND 
+            name='HistoryAgeInDaysLimit' AND 
+            value != 1
+        );  
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level2, CIS-macos-13-6.3.2, decision-needed
+  contributors: sharon-fdm
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure Warn When Visiting A Fraudulent Website in Safari Is Enabled (MDM Required)
+  platforms: macOS
+  platform: darwin
+  description: |
+    Apple uses the Google Safe Browsing API to check for fraudulent websites and report them to the
+    user attempting visit one. Attackers use crafted web pages to social engineer users to load
+    unwanted content. Warning users prior to loading the content enables better security.
+  resolution: |
+    Payload Method:
+    Ask your administrator to deploy a profile which enableds WarnAboutFraudulentWebsites in Safari
+  query: |
+    SELECT 1 WHERE 
+      EXISTS (
+        SELECT 1 FROM managed_policies WHERE 
+            domain='com.apple.Safari' AND 
+            name='WarnAboutFraudulentWebsites' AND 
+            (value = 1 OR value = 'true') AND 
+            username = ''
+        )
+      AND NOT EXISTS (
+        SELECT 1 FROM managed_policies WHERE 
+            domain='com.apple.loginwindow' AND 
+            name='WarnAboutFraudulentWebsites' AND 
+            (value != 1 AND value != 'true')
+        );  
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1, CIS-macos-13-6.3.3
+  contributors: artemist-work
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure Prevent Cross-site Tracking in Safari Is Enabled (MDM Required)
+  platforms: macOS
+  platform: darwin
+  description: |
+    Cross-tracking allows data-brokers to follow you across the Internet to enable their business model of
+    selling personal data. Users should protect their data and not volunteer it to marketing companies.
+  resolution: |
+    Automated method:
+    Ask your system administrator to deploy a profile via MDM with the following information:
+      1. The PayloadType string is com.apple.Safari.
+      2. The key to include is BlockStoragePolicy.
+      3. The key must be set to: 2
+      4. The key to also include is WebKitPreferences.storageBlockingPolicy
+      5. The key must be set to: 1
+      6. The key to also include is WebKitStorageBlockingPolicy
+      7. The key must be set to: 1
+  query: |
+    SELECT 1 WHERE 
+      EXISTS (
+        SELECT 1 FROM managed_policies WHERE 
+            domain='com.apple.Safari' AND 
+            name='BlockStoragePolicy' AND 
+            value = '2' AND 
+            username = ''
+        )
+      AND EXISTS (
+        SELECT 1 FROM managed_policies WHERE 
+            domain='com.apple.Safari' AND 
+            name='WebKitPreferences.storageBlockingPolicy' AND 
+            value = '1' AND 
+            username = ''
+        )
+      AND EXISTS (
+        SELECT 1 FROM managed_policies WHERE 
+            domain='com.apple.Safari' AND 
+            name='WebKitStorageBlockingPolicy' AND 
+            value = '1' AND 
+            username = ''
+        )
+      AND NOT EXISTS (
+        SELECT 1 FROM managed_policies WHERE 
+            domain='com.apple.Safari' AND 
+            name='BlockStoragePolicy' AND 
+            value != '2' 
+        )
+      AND NOT EXISTS (
+        SELECT 1 FROM managed_policies WHERE 
+            domain='com.apple.Safari' AND 
+            name='WebKitPreferences.storageBlockingPolicy' AND 
+            value != '1' 
+        )
+      AND NOT EXISTS (
+        SELECT 1 FROM managed_policies WHERE 
+            domain='com.apple.Safari' AND 
+            name='WebKitStorageBlockingPolicy' AND 
+            value != '1' 
+        );  
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1, CIS-macos-13-6.3.4
+  contributors: lucasmrod
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure the Hide IP Address in Safari is Enabled (Based on organization's policy)
+  platforms: macOS
+  platform: darwin
+  description: |
+    Public (Routable) IP addresses can be used to track people to their current location, including
+    home and business addresses. While a valid IP addess is necessary to load the site the valid
+    address does not need to be provided to known trackers and should be hidden.
+  resolution: |
+    Ask your system administrator to deploy a script that will configure "Hide IP Address in Safari" to Enabled
+      $ /usr/bin/sudo -u <username> /usr/bin/defaults write
+      /Users/<username>/Library/Containers/com.apple.Safari/Data/Library/Preferences
+      /com.apple.Safari WBSPrivacyProxyAvailabilityTraffic -int 130276
+  query: |
+    SELECT 1 WHERE NOT EXISTS (
+      SELECT 1 FROM users AS u
+      LEFT JOIN (
+        SELECT * FROM plist WHERE
+          path LIKE '/Users/%/Library/Containers/com.apple.Safari/Data/Library/Preferences/com.apple.Safari.plist' AND
+          key = 'WBSPrivacyProxyAvailabilityTraffic' AND
+           ((value >> 2) & 1) = 1) AS p
+      ON p.path = CONCAT(u.directory, '/Library/Containers/com.apple.Safari/Data/Library/Preferences/com.apple.Safari.plist')
+      WHERE u.directory LIKE '/Users/%' AND
+      p.value IS NULL
+    );
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1, CIS-macos-13-6.3.5-enabled, decision-needed
+  contributors: artemist-work
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure the Hide IP Address in Safari is Disabled (Based on organization's policy)
+  platforms: macOS
+  platform: darwin
+  description: |
+    Public (Routable) IP addresses can be used to track people to their current location, including
+    home and business addresses. While a valid IP addess is necessary to load the site the valid
+    address does not need to be provided to known trackers and should be hidden.
+    However, enabling this setting will proxy web information through a 3rd party service, which may
+    not be allowed by your organization's policy.
+  resolution: |
+    Ask your system administrator to deploy a script that will configure "Hide IP Address in Safari" to Enabled
+      $ /usr/bin/sudo -u <username> /usr/bin/defaults write
+      /Users/<username>/Library/Containers/com.apple.Safari/Data/Library/Preferences
+      /com.apple.Safari WBSPrivacyProxyAvailabilityTraffic -int 130272
+  query: |
+    SELECT 1 WHERE NOT EXISTS (
+      SELECT 1 FROM users AS u
+      LEFT JOIN (
+        SELECT * FROM plist WHERE
+          path LIKE '/Users/%/Library/Containers/com.apple.Safari/Data/Library/Preferences/com.apple.Safari.plist' AND
+          key = 'WBSPrivacyProxyAvailabilityTraffic' AND
+           ((value >> 2) & 1) = 0) AS p
+      ON p.path = CONCAT(u.directory, '/Library/Containers/com.apple.Safari/Data/Library/Preferences/com.apple.Safari.plist')
+      WHERE u.directory LIKE '/Users/%' AND
+      p.value IS NULL
+    );
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1, CIS-macos-13-6.3.5-disabled, decision-needed
+  contributors: artemist-work
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure Advertising Privacy Protection in Safari Is Enabled (FDA Required)
+  platforms: macOS
+  platform: darwin
+  description: |
+    Apple provides a framework that allows advertisers to target Apple users and end-users with advertisements.
+    While many people prefer that when they see advertising it is relevant to them and their interests, the detailed
+    information that is data mining collected, correlated, and available to advertisers in repositories is often disconcerting.
+    This information is valuable to both advertisers and attackers and has been used with other metadata to reveal users' identities.
+  resolution: |
+    Automated method:
+    Ask your system administrator to deploy the following script:
+      # For each user run:
+      /usr/bin/sudo -u <username> /usr/bin/defaults write \
+        /Users/<username>/Library/Containers/com.apple.Safari/Data/Library/Preferences/com.apple.Safari \
+        WebKitPreferences.privateClickMeasurementEnabled -bool true
+  query: |
+    SELECT 1 WHERE NOT EXISTS (
+      SELECT 1 FROM users AS u
+      LEFT JOIN (
+        SELECT * FROM plist WHERE
+          path LIKE '/Users/%/Library/Containers/com.apple.Safari/Data/Library/Preferences/com.apple.Safari.plist' AND
+          key = 'WebKitPreferences.privateClickMeasurementEnabled' AND
+          value = '1') AS p
+      ON p.path = CONCAT(u.directory, '/Library/Containers/com.apple.Safari/Data/Library/Preferences/com.apple.Safari.plist')
+      WHERE u.directory LIKE '/Users/%' AND
+      p.value IS NULL
+    );
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1, CIS-macos-13-6.3.6
+  contributors: artemist-work
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure Show Full Website Address in Safari Is Enabled (MDM Required)
+  platforms: macOS
+  platform: darwin
+  description: |
+    Attackers use websites with malicious or unwanted content to exploit the user or the computer. Part of the attack chain is to lure someone to load their content rather than the desired content. In order to reduce the risk in interacting with unwanted content the full website address should always be displayed in Safari.
+  resolution: |
+    Graphical Method:
+    Perform the following steps to set Safari to show full website addresses:
+      1. Open Safari
+      2. Select Safari from the menu bar
+      3. Select Settings
+      4. Select Security
+      5. Set Show full website address to enabled
+    Automated method:
+    Profile Method:
+    Create or edit a configuration profile with the following information:
+      1. The PayloadType string is com.apple.Safari
+      2. The key to include is ShowFullURLInSmartSearchField 
+      3. The key must be set to: <true/>
+  query: |
+    SELECT 1 WHERE 
+      EXISTS (
+        SELECT 1 FROM managed_policies WHERE 
+            domain='com.apple.Safari' AND 
+            name='ShowFullURLInSmartSearchField' AND 
+            (value = 1 OR value = 'true') AND 
+            username = ''
+        )
+      AND NOT EXISTS (
+        SELECT 1 FROM managed_policies WHERE 
+            domain='com.apple.Safari' AND 
+            name='ShowFullURLInSmartSearchField' AND 
+            (value != 1 AND value != 'true')
+        );  
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1, CIS-macos-13-6.3.7
+  contributors: sharon-fdm
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure Secure Keyboard Entry Terminal.app Is Enabled (MDM Required)
+  platforms: macOS
+  platform: darwin
+  description: |
+    Secure Keyboard Entry prevents other applications on the system and/or network from detecting and recording what is typed into Terminal. Unauthorized applications and malicious code could intercept keystrokes entered in the Terminal.
+    Enabling Secure Keyboard Entry minimizes the risk of a key logger from detecting what is entered in Terminal.
+  resolution: |
+    Profile Method:
+    Create or edit a configuration profile with the following information:
+      1. The PayloadType string is com.apple.Terminal 
+      2. The key to include is SecureKeyboardEntry
+      3. The key must be set to
+      <true/>
+  query: |
+    SELECT 1 WHERE 
+      EXISTS (
+        SELECT 1 FROM managed_policies WHERE 
+            domain='com.apple.Terminal' AND 
+            name='SecureKeyboardEntry' AND 
+            (value = 1 OR value = 'true') AND 
+            username = ''
+        )
+      AND NOT EXISTS (
+        SELECT 1 FROM managed_policies WHERE 
+            domain='com.apple.Terminal' AND 
+            name='SecureKeyboardEntry' AND 
+            (value != 1 AND value != 'true')
+        );  
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1, CIS-macos-13-6.4.1
+  contributors: sharon-fdm

--- a/ee/cis/macos-14/cis-policy-queries.yml
+++ b/ee/cis/macos-14/cis-policy-queries.yml
@@ -1281,7 +1281,7 @@ spec:
     /*CIS does not make a hard recommendation for this policy. Fleet has provided two policies (one failing, one succeeding). 
       Depending on your organization's decision, you can delete this policy or its counterpart.*/
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1
+  tags: compliance, CIS, CIS_Level1, decision-needed
   contributors: sharon-fdm
 ---
 apiVersion: v1

--- a/ee/cis/macos-14/cis-policy-queries.yml
+++ b/ee/cis/macos-14/cis-policy-queries.yml
@@ -3338,7 +3338,7 @@ spec:
       p.value IS NULL
     );
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1
+  tags: compliance, CIS, CIS_Level1, decision-needed
   contributors: artemist-work
 ---
 apiVersion: v1

--- a/ee/cis/macos-14/cis-policy-queries.yml
+++ b/ee/cis/macos-14/cis-policy-queries.yml
@@ -1165,7 +1165,7 @@ spec:
     /*CIS does not make a hard recommendation for this policy. Fleet has provided two policies (one failing, one succeeding). 
       Depending on your organization's decision, you can delete this policy or its counterpart.*/
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1
+  tags: compliance, CIS, CIS_Level1, decision-needed
   contributors: sharon-fdm
 ---
 apiVersion: v1

--- a/ee/cis/macos-14/cis-policy-queries.yml
+++ b/ee/cis/macos-14/cis-policy-queries.yml
@@ -3049,36 +3049,6 @@ spec:
 apiVersion: v1
 kind: policy
 spec:
-  name: CIS - Ensure Legacy EFI Is Valid and Updating (Fleetd Required)
-  platforms: macOS
-  platform: darwin
-  description: |
-    In order to mitigate firmware attacks, Apple has created an automated Firmware check to ensure that the EFI version
-    running is a known good version from Apple. There is also an automated process to check it every seven days.
-    This check is only valid on T1 chips and prior. Neither T2 chips nor Apple silicon require this control check
-    If the Firmware of a computer has been compromised, the Operating System that the Firmware loads cannot be trusted, either.
-  resolution: |
-    If EFI does not pass the integrity check, you may send a report to Apple. Backing up files and clean installing a
-    known good Operating System and Firmware is recommended.
-  query: |
-    SELECT 1 FROM firmware_eficheck_integrity_check
-    WHERE chip != 'intel-t1' OR (
-      chip = 'intel-t1' AND
-      output LIKE '%Primary allowlist version match found. No changes detected in primary hashes%' AND
-      NOT EXISTS (
-          SELECT * FROM plist WHERE
-          path = '/var/db/com.apple.xpc.launchd/disabled.plist' AND
-          key = 'com.apple.driver.eficheck' AND
-          value = '0'
-      )
-    );
-  purpose: Informational
-  tags: compliance, CIS, CIS_Level1, CIS-macos-14-5.9
-  contributors: lucasmrod
----
-apiVersion: v1
-kind: policy
-spec:
   name: CIS - Ensure the Guest Home Folder Does Not Exist
   platforms: macOS
   platform: darwin

--- a/ee/cis/macos-14/cis-policy-queries.yml
+++ b/ee/cis/macos-14/cis-policy-queries.yml
@@ -2183,6 +2183,35 @@ spec:
 apiVersion: v1
 kind: policy
 spec:
+  name: CIS - Ensure On-Device Dictation Is Enabled (MDM Required)
+  platforms: macOS
+  platform: darwin
+  description: |
+    In macOS 14.0 Sonoma, Apple released the ability to limit dictation to staying on-device and not sending data to the Siri severs. The use of dictation is likely to include editing
+    documents with confidential information. While Apple does have controls to obfuscate voice data that exists on their servers it is recommended that Dictation collected information does not leave the local Mac.
+  resolution: "Ask your system administrator to deploy an MDM profile that enables On-Device Dictation."
+  query: |
+    SELECT 1 WHERE 
+      EXISTS (
+        SELECT 1 FROM managed_policies WHERE 
+            domain='com.apple.applicationaccess' AND 
+            name='forceOnDeviceOnlyDictation' AND 
+            (value = 1 OR value = 'true') AND 
+            username = ''
+        )
+      AND NOT EXISTS (
+        SELECT 1 FROM managed_policies WHERE 
+            domain='com.apple.applicationaccess' AND 
+            name='forceOnDeviceOnlyDictation' AND 
+            (value != 1 AND value != 'true')
+        );
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1, CIS-macos-2-18.1, NEEDS_TESTING
+  contributors: DefensiveDepth
+---
+apiVersion: v1
+kind: policy
+spec:
   name: CIS - Ensure Security Auditing Is Enabled
   platforms: macOS
   platform: darwin

--- a/ee/cis/macos-14/cis-policy-queries.yml
+++ b/ee/cis/macos-14/cis-policy-queries.yml
@@ -18,7 +18,7 @@ spec:
       4. Select Update All
   query: SELECT 1 FROM software_update WHERE software_update_required = '0';
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1, CIS-macos-14-1.1
+  tags: compliance, CIS, CIS_Level1
   contributors: sharon-fdm
 ---
 apiVersion: v1
@@ -45,7 +45,7 @@ spec:
             (value != 1 AND value != 'true')
         );  
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1, CIS-macos-14-1.2
+  tags: compliance, CIS, CIS_Level1
   contributors: sharon-fdm
 ---
 apiVersion: v1
@@ -72,7 +72,7 @@ spec:
             (value != 1 AND value != 'true')
         );  
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1, CIS-macos-14-1.3
+  tags: compliance, CIS, CIS_Level1
   contributors: sharon-fdm
 ---
 apiVersion: v1
@@ -99,7 +99,7 @@ spec:
             (value != 1 AND value != 'true')
         );  
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1, CIS-macos-14-1.4
+  tags: compliance, CIS, CIS_Level1
   contributors: sharon-fdm
 ---
 apiVersion: v1
@@ -126,7 +126,7 @@ spec:
             (value != 1 AND value != 'true')
         );  
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1, CIS-macos-14-1.5
+  tags: compliance, CIS, CIS_Level1
   contributors: lucasmrod
 ---
 apiVersion: v1
@@ -157,7 +157,7 @@ spec:
             (value != 1 AND value != 'true')
         );  
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1, CIS-macos-14-1.6
+  tags: compliance, CIS, CIS_Level1
   contributors: sharon-fdm
 ---
 apiVersion: v1
@@ -190,7 +190,7 @@ spec:
             value > 30
         );  
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1, CIS-macos-14-1.7
+  tags: compliance, CIS, CIS_Level1
   contributors: lucasmrod
 ---
 apiVersion: v1
@@ -227,7 +227,7 @@ spec:
     /*CIS does not make a hard recommendation for this policy. Fleet has provided two policies (one failing, one succeeding). 
       Depending on your organization's decision, you can delete this policy or its counterpart.*/
   purpose: Informational
-  tags: compliance, CIS, CIS_Level2, CIS-macos-14-2.1.1.2-disabled, decision-needed
+  tags: compliance, CIS, CIS_Level2
   contributors: sharon-fdm
 ---
 apiVersion: v1
@@ -264,7 +264,7 @@ spec:
     /*CIS does not make a hard recommendation for this policy. Fleet has provided two policies (one failing, one succeeding). 
       Depending on your organization's decision, you can delete this policy or its counterpart.*/
   purpose: Informational
-  tags: compliance, CIS, CIS_Level2, CIS-macos-14-2.1.1.2-enabled, decision-needed
+  tags: compliance, CIS, CIS_Level2
   contributors: sharon-fdm
 ---
 apiVersion: v1
@@ -302,7 +302,7 @@ spec:
     /*CIS does not make a hard recommendation for this policy. Fleet has provided two policies (one failing, one succeeding). 
       Depending on your organization's decision, you can delete this policy or its counterpart.*/
   purpose: Informational
-  tags: compliance, CIS, CIS_Level2, CIS-macos-14-2.1.1.1-disable, decision-needed
+  tags: compliance, CIS, CIS_Level2
   contributors: sharon-fdm
 ---
 apiVersion: v1
@@ -340,7 +340,7 @@ spec:
     /*CIS does not make a hard recommendation for this policy. Fleet has provided two policies (one failing, one succeeding). 
       Depending on your organization's decision, you can delete this policy or its counterpart.*/
   purpose: Informational
-  tags: compliance, CIS, CIS_Level2, CIS-macos-14-2.1.1.1-enable, decision-needed
+  tags: compliance, CIS, CIS_Level2
   contributors: sharon-fdm
 ---
 apiVersion: v1
@@ -372,7 +372,7 @@ spec:
             (value != 0 AND value != 'false')
         );  
   purpose: Informational
-  tags: compliance, CIS, CIS_Level2, CIS-macos-14-2.1.1.3
+  tags: compliance, CIS, CIS_Level2
   contributors: zwass
 ---
 apiVersion: v1
@@ -385,7 +385,7 @@ spec:
   resolution: "Go to the Network pane in System Settings and ensure Firewall is active."
   query: SELECT 1 FROM alf WHERE global_state >= 1;
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1, CIS-macos-14-2.2.1
+  tags: compliance, CIS, CIS_Level1
   contributors: sharon-fdm
 ---
 apiVersion: v1
@@ -406,7 +406,7 @@ spec:
       5. Set Enabled stealth mode to enabled
   query: SELECT 1 FROM alf WHERE global_state >= 1 AND stealth_enabled = 1;
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1, CIS-macos-14-2.2.2
+  tags: compliance, CIS, CIS_Level1
   contributors: lucasmrod
 ---
 apiVersion: v1
@@ -440,7 +440,7 @@ spec:
             (value != 0 AND value != 'false')
         );  
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1, CIS-macos-14-2.3.1.1
+  tags: compliance, CIS, CIS_Level1
   contributors: lucasmrod
 ---
 apiVersion: v1
@@ -480,7 +480,7 @@ spec:
             (value != 0 AND value != 'false')
         );  
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1, CIS-macos-14-2.3.1.2
+  tags: compliance, CIS, CIS_Level1
   contributors: lucasmrod
 ---
 apiVersion: v1
@@ -512,7 +512,7 @@ spec:
             (value != 1 AND value != 'true')
         );  
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1, CIS-macos-14-2.3.2.1
+  tags: compliance, CIS, CIS_Level1
   contributors: sharon-fdm
 ---
 apiVersion: v1
@@ -527,7 +527,7 @@ spec:
   resolution: Make sure the device can connect to time.apple.com to synchronize time.
   query: SELECT * FROM sntp_request WHERE server = 'time.apple.com' AND clock_offset_ms <= 270000 AND clock_offset_ms >= -270000;
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1, CIS-macos-14-2.3.2.2
+  tags: compliance, CIS, CIS_Level1
   contributors: lucasmrod 
 ---
 apiVersion: v1
@@ -557,7 +557,7 @@ spec:
   # are disabled via disabled.plist, which the preference pane uses whenever
   # a service is disabled after it has been enabled in the past.
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1, CIS-macos-14-2.3.3.1
+  tags: compliance, CIS, CIS_Level1
   contributors: artemist-work
 ---
 apiVersion: v1
@@ -590,7 +590,7 @@ spec:
   # are disabled via disabled.plist, which the preference pane uses whenever
   # a service is disabled after it has been enabled in the past.
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1, CIS-macos-14-2.3.3.2
+  tags: compliance, CIS, CIS_Level1
   contributors: artemist-work
 ---
 apiVersion: v1
@@ -620,7 +620,7 @@ spec:
   # are disabled via disabled.plist, which the preference pane uses whenever
   # a service is disabled after it has been enabled in the past.
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1, CIS-macos-14-2.3.3.3
+  tags: compliance, CIS, CIS_Level1
   contributors: artemist-work
 ---
 apiVersion: v1
@@ -648,7 +648,7 @@ spec:
         line LIKE '%Allow @LOCAL%'
       );
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1, CIS-macos-14-2.3.3.4
+  tags: compliance, CIS, CIS_Level1
   contributors: artemist-work
 ---
 apiVersion: v1
@@ -681,7 +681,7 @@ spec:
   # are disabled via disabled.plist, which the preference pane uses whenever
   # a service is disabled after it has been enabled in the past.
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1, CIS-macos-14-2.3.3.5
+  tags: compliance, CIS, CIS_Level1
   contributors: artemist-work
 ---
 apiVersion: v1
@@ -709,7 +709,7 @@ spec:
         path = '/System/Library/CoreServices/RemoteManagement/ARDAgent.app/Contents/MacOS/ARDAgent'
     );
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1, CIS-macos-14-2.3.3.6
+  tags: compliance, CIS, CIS_Level1
   contributors: artemist-work
 ---
 apiVersion: v1
@@ -740,7 +740,7 @@ spec:
   # are disabled via disabled.plist, which the preference pane uses whenever
   # a service is disabled after it has been enabled in the past.
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1, CIS-macos-14-2.3.3.7
+  tags: compliance, CIS, CIS_Level1
   contributors: artemist-work
 ---
 apiVersion: v1
@@ -768,7 +768,7 @@ spec:
         value = '1'
     );
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1, CIS-macos-14-2.3.3.8
+  tags: compliance, CIS, CIS_Level1
   contributors: artemist-work
 ---
 apiVersion: v1
@@ -807,7 +807,7 @@ spec:
             (value != 0 AND value != 'false')
         );  
   purpose: Informational
-  tags: compliance, CIS, CIS_Level2, CIS-macos-14-2.3.3.9
+  tags: compliance, CIS, CIS_Level2
   contributors: sharon-fdm
 ---
 apiVersion: v1
@@ -834,7 +834,7 @@ spec:
         value = '1'
     );
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1, CIS-macos-14-2.3.3.11
+  tags: compliance, CIS, CIS_Level1
   contributors: artemist-work
 ---
 apiVersion: v1
@@ -890,7 +890,7 @@ spec:
         value != '0'
     );
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1, CIS-macos-14-2.3.3.10
+  tags: compliance, CIS, CIS_Level1
   contributors: artemist-work
 ---
 apiVersion: v1
@@ -921,7 +921,7 @@ spec:
     FROM plist WHERE path='/Library/Preferences/com.apple.TimeMachine.plist'
     AND key='AutoBackup' AND (value = 1 OR value = 'true');
   purpose: Informational
-  tags: compliance, CIS, CIS_Level2, CIS-macos-14-2.3.4.1
+  tags: compliance, CIS, CIS_Level2
   contributors: lucasmrod
 ---
 apiVersion: v1
@@ -958,7 +958,7 @@ spec:
     SELECT 'time machines destinations with encryption with automatic backup' as output
     FROM (SELECT COUNT(*) as c FROM time_machine_destinations WHERE encryption <> 'Encrypted') t2 WHERE t2.c = 0;
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1, CIS-macos-14-2.3.4.2
+  tags: compliance, CIS, CIS_Level1
   contributors: lucasmrod
 ---
 apiVersion: v1
@@ -995,7 +995,7 @@ spec:
             value != 18
         );  
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1, CIS-macos-14-2.4.1
+  tags: compliance, CIS, CIS_Level1
   contributors: lucasmrod
 ---
 apiVersion: v1
@@ -1031,7 +1031,7 @@ spec:
             value != 18
         );  
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1, CIS-macos-14-2.4.2
+  tags: compliance, CIS, CIS_Level1
   contributors: lucasmrod
 ---
 apiVersion: v1
@@ -1069,7 +1069,7 @@ spec:
      /*CIS does not make a hard recommendation for this policy. Fleet has provided two policies (one failing, one succeeding). 
       Depending on your organization's decision, you can delete this policy or its counterpart.*/
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1, CIS-macos-14-2.5.1-enabled, decision-needed
+  tags: compliance, CIS, CIS_Level1
   contributors: sharon-fdm
 ---
 apiVersion: v1
@@ -1107,7 +1107,7 @@ spec:
     /*CIS does not make a hard recommendation for this policy. Fleet has provided two policies (one failing, one succeeding). 
       Depending on your organization's decision, you can delete this policy or its counterpart.*/
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1, CIS-macos-14-2.5.1-disabled, decision-needed
+  tags: compliance, CIS, CIS_Level1
   contributors: sharon-fdm
 ---
 apiVersion: v1
@@ -1136,7 +1136,7 @@ spec:
     /*CIS does not make a hard recommendation for this policy. Fleet has provided two policies (one failing, one succeeding). 
       Depending on your organization's decision, you can delete this policy or its counterpart.*/
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1, CIS-macos-14-2.5.1-TypeToSiriEnabled-true, decision-needed
+  tags: compliance, CIS, CIS_Level1
   contributors: sharon-fdm
 ---
 apiVersion: v1
@@ -1165,7 +1165,7 @@ spec:
     /*CIS does not make a hard recommendation for this policy. Fleet has provided two policies (one failing, one succeeding). 
       Depending on your organization's decision, you can delete this policy or its counterpart.*/
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1, CIS-macos-14-2.5.1-TypeToSiriEnabled-false, decision-needed
+  tags: compliance, CIS, CIS_Level1
   contributors: sharon-fdm
 ---
 apiVersion: v1
@@ -1194,7 +1194,7 @@ spec:
     /*CIS does not make a hard recommendation for this policy. Fleet has provided two policies (one failing, one succeeding). 
       Depending on your organization's decision, you can delete this policy or its counterpart.*/
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1, CIS-macos-14-2.5.1-StatusMenuVisible-true, decision-needed
+  tags: compliance, CIS, CIS_Level1
   contributors: sharon-fdm
 ---
 apiVersion: v1
@@ -1223,7 +1223,7 @@ spec:
     /*CIS does not make a hard recommendation for this policy. Fleet has provided two policies (one failing, one succeeding). 
       Depending on your organization's decision, you can delete this policy or its counterpart.*/
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1, CIS-macos-14-2.5.1-StatusMenuVisible-false, decision-needed
+  tags: compliance, CIS, CIS_Level1
   contributors: sharon-fdm
 ---
 apiVersion: v1
@@ -1252,7 +1252,7 @@ spec:
     /*CIS does not make a hard recommendation for this policy. Fleet has provided two policies (one failing, one succeeding). 
       Depending on your organization's decision, you can delete this policy or its counterpart.*/
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1, CIS-macos-14-2.5.1-VoiceTriggerUserEnabled-true, decision-needed
+  tags: compliance, CIS, CIS_Level1
   contributors: sharon-fdm
 ---
 apiVersion: v1
@@ -1281,7 +1281,7 @@ spec:
     /*CIS does not make a hard recommendation for this policy. Fleet has provided two policies (one failing, one succeeding). 
       Depending on your organization's decision, you can delete this policy or its counterpart.*/
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1, CIS-macos-14-2.5.1-VoiceTriggerUserEnabled-false, decision-needed
+  tags: compliance, CIS, CIS_Level1
   contributors: sharon-fdm
 ---
 apiVersion: v1
@@ -1310,7 +1310,7 @@ spec:
     /*CIS does not make a hard recommendation for this policy. Fleet has provided two policies (one failing, one succeeding). 
       Depending on your organization's decision, you can delete this policy or its counterpart.*/
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1, CIS-macos-14-2.5.1-LockscreenEnabled-true, decision-needed
+  tags: compliance, CIS, CIS_Level1
   contributors: sharon-fdm
 ---
 apiVersion: v1
@@ -1339,7 +1339,7 @@ spec:
     /*CIS does not make a hard recommendation for this policy. Fleet has provided two policies (one failing, one succeeding). 
       Depending on your organization's decision, you can delete this policy or its counterpart.*/
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1, CIS-macos-14-2.5.1-LockscreenEnabled-false, decision-needed
+  tags: compliance, CIS, CIS_Level1
   contributors: sharon-fdm
 ---
 apiVersion: v1
@@ -1360,7 +1360,7 @@ spec:
         4. Verify Location Services is enabled
   query: SELECT 1 FROM location_services where enabled=1;
   purpose: Informational
-  tags: compliance, CIS, CIS_Level2, CIS-macos-14-2.6.1.1
+  tags: compliance, CIS, CIS_Level2
   contributors: sharon-fdm
 ---
 apiVersion: v1
@@ -1383,7 +1383,7 @@ spec:
         location is set to your organization's parameters
   query:  SELECT 1 FROM plist WHERE path='/Library/Preferences/com.apple.locationmenu.plist' AND key='ShowSystemServices' AND value=1;
   purpose: Informational
-  tags: compliance, CIS, CIS_Level2, CIS-macos-14-2.6.1.2
+  tags: compliance, CIS, CIS_Level2
   contributors: sharon-fdm
 ---
 apiVersion: v1
@@ -1408,7 +1408,7 @@ spec:
         4. Set Location Services to disabled.
   query:  SELECT 1 FROM location_services WHERE enabled = 0;
   purpose: Informational
-  tags: compliance, CIS, CIS_Level2, CIS-macos-14-2.6.1.3-Location-Service-disabled
+  tags: compliance, CIS, CIS_Level2
   contributors: sharon-fdm
 ---
 apiVersion: v1
@@ -1470,7 +1470,7 @@ spec:
             )
         );
   purpose: Informational
-  tags: compliance, CIS, CIS_Level2, CIS-macos-14-2.6.1.3-Location-Service-specifc-app-enabled, decision-needed
+  tags: compliance, CIS, CIS_Level2
   contributors: sharon-fdm
 ---
 apiVersion: v1
@@ -1504,7 +1504,7 @@ spec:
             (value != 0 AND value != 'false')
         );  
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1, CIS-macos-14-2.6.3
+  tags: compliance, CIS, CIS_Level1
   contributors: sharon-fdm
 ---
 apiVersion: v1
@@ -1523,7 +1523,7 @@ spec:
         4. Set Require an administrator password to access system-wide settings to enabled
   query: SELECT 1 FROM authdb WHERE right_name = 'system.preferences' AND json_extract(json_result, '$.shared') == 0;
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1, CIS-macos-14-2.6.7
+  tags: compliance, CIS, CIS_Level1
   contributors: artemist-work
 ---
 apiVersion: v1
@@ -1559,7 +1559,7 @@ spec:
         key = 'wvous-tl-corner'
     ) AND value = 6);
   purpose: Informational
-  tags: compliance, CIS, CIS_Level2, CIS-macos-14-2.7.1
+  tags: compliance, CIS, CIS_Level2
   contributors: lucasmrod
 ---
 apiVersion: v1
@@ -1596,7 +1596,7 @@ spec:
     /*CIS does not make a hard recommendation for this policy. Fleet has provided two policies (one failing, one succeeding). 
       Depending on your organization's decision, you can delete this policy or its counterpart.*/
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1, CIS-macos-14-2.8.1-enabled, decision-needed
+  tags: compliance, CIS, CIS_Level1
   contributors: sharon-fdm
 ---
 apiVersion: v1
@@ -1633,7 +1633,7 @@ spec:
     /*CIS does not make a hard recommendation for this policy. Fleet has provided two policies (one failing, one succeeding). 
       Depending on your organization's decision, you can delete this policy or its counterpart.*/
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1, CIS-macos-14-2.8.1-disabled, decision-needed
+  tags: compliance, CIS, CIS_Level1
   contributors: sharon-fdm
 ---
 apiVersion: v1
@@ -1665,7 +1665,7 @@ spec:
       ), '') AS powernap_battery
     FROM pmset WHERE getting = 'custom' AND powernap_battery != '1' AND powernap_ac != '1');
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1, CIS-macos-14-2.9.1
+  tags: compliance, CIS, CIS_Level1
   contributors: lucasmrod
 ---
 apiVersion: v1
@@ -1696,7 +1696,7 @@ spec:
       ), '') AS womp_battery
     FROM pmset WHERE getting = 'custom' AND womp_battery != '1' AND womp_ac != '1');
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1, CIS-macos-14-2.9.2
+  tags: compliance, CIS, CIS_Level1
   contributors: lucasmrod
 ---
 apiVersion: v1
@@ -1772,7 +1772,7 @@ spec:
         )
     );
   purpose: Informational
-  tags: compliance, CIS, CIS_Level2, CIS-macos-14-2.9.3
+  tags: compliance, CIS, CIS_Level2
   contributors: lucasmrod
 ---
 apiVersion: v1
@@ -1820,7 +1820,7 @@ spec:
             value > 5
         );  
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1, CIS-macos-14-2.10.2
+  tags: compliance, CIS, CIS_Level1
   contributors: sharon-fdm
 ---
 apiVersion: v1
@@ -1841,7 +1841,7 @@ spec:
         3. Verify that 'Allow apps downloaded from' is set to' App Store and identified developers'
   query: SELECT 1 FROM gatekeeper WHERE assessments_enabled = 1 AND dev_id_enabled = 1;
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1, CIS-macos-14-2.6.4
+  tags: compliance, CIS, CIS_Level1
   contributors: sharon-fdm
 ---
 apiVersion: v1
@@ -1904,7 +1904,7 @@ spec:
             value != 2
         );  
   purpose: Informational
-  tags: compliance, CIS, CIS_Level2, CIS-macos-14-2.6.2
+  tags: compliance, CIS, CIS_Level2
   contributors: sharon-fdm
 ---
 apiVersion: v1
@@ -1938,7 +1938,7 @@ spec:
             value > 1200
         );  
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1, CIS-macos-14-2.10.1
+  tags: compliance, CIS, CIS_Level1
   contributors: sharon-fdm
 ---
 apiVersion: v1
@@ -1958,7 +1958,7 @@ spec:
         5. Verify that the message displayed is configured to your organization's required text
   query: SELECT 1 FROM plist WHERE path='/Library/Preferences/com.apple.loginwindow.plist' AND key='LoginwindowText' AND value != "";
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1, CIS-macos-14-2.10.3
+  tags: compliance, CIS, CIS_Level1
   contributors: sharon-fdm
 ---
 apiVersion: v1
@@ -2000,7 +2000,7 @@ spec:
             filevault_status = 'on' 
         );  
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1, CIS-macos-14-2.6.5
+  tags: compliance, CIS, CIS_Level1
   contributors: sharon-fdm
 ---
 apiVersion: v1
@@ -2034,7 +2034,7 @@ spec:
             (value != 1 AND value != 'true')
         );  
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1, CIS-macos-14-2.10.4
+  tags: compliance, CIS, CIS_Level1
   contributors: sharon-fdm
 ---
 apiVersion: v1
@@ -2068,7 +2068,7 @@ spec:
             (value != 0 AND value != 'false')
         );  
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1, CIS-macos-14-2.10.5
+  tags: compliance, CIS, CIS_Level1
   contributors: sharon-fdm
 ---
 apiVersion: v1
@@ -2090,7 +2090,7 @@ spec:
         4. Change the password and ensure that no text is entered in the Password hint box
   query: SELECT 1 FROM user_login_settings WHERE password_hint_enabled = 0;
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1, CIS-macos-14-2.11.1
+  tags: compliance, CIS, CIS_Level1
   contributors: sharon-fdm
 ---
 apiVersion: v1
@@ -2115,7 +2115,7 @@ spec:
     OR
     EXISTS(select 1 FROM plist WHERE path='/Library/Preferences/com.apple.MCX.plist' AND key='DisableGuestAccount' AND value = 1);
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1, CIS-macos-14-2.12.1
+  tags: compliance, CIS, CIS_Level1
   contributors: sharon-fdm
 ---
 apiVersion: v1
@@ -2137,7 +2137,7 @@ spec:
         4. Set Allow guests to connect to shared folders to disabled
   query: SELECT 1 from plist where path = '/Library/Preferences/SystemConfiguration/com.apple.smb.server.plist' AND key = 'AllowGuestAccess' AND value = 0;
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1, CIS-macos-14-2.12.2
+  tags: compliance, CIS, CIS_Level1
   contributors: sharon-fdm
 ---
 apiVersion: v1
@@ -2177,7 +2177,7 @@ spec:
             (value != 1 AND value != 'true')
         );  
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1, CIS-macos-14-2.12.3
+  tags: compliance, CIS, CIS_Level1
   contributors: sharon-fdm
 ---
 apiVersion: v1
@@ -2236,7 +2236,7 @@ spec:
       (l.program_arguments = p.cmdline)
     );
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1, CIS-macos-14-3.1
+  tags: compliance, CIS, CIS_Level1
   contributors: sharon-fdm
 ---
 apiVersion: v1
@@ -2291,7 +2291,7 @@ spec:
       )
     );
   purpose: Informational
-  tags: compliance, CIS, CIS_Level2, CIS-macos-14-3.2
+  tags: compliance, CIS, CIS_Level2
   contributors: sharon-fdm
 ---
 apiVersion: v1
@@ -2321,7 +2321,7 @@ spec:
              WHERE path = '/etc/asl/com.apple.install'  
              AND  line  LIKE "%all_max=%" );
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1, CIS-macos-14-3.3
+  tags: compliance, CIS, CIS_Level1
   contributors: sharon-fdm
 ---
 apiVersion: v1
@@ -2350,7 +2350,7 @@ spec:
       AND size >=5
     );
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1, CIS-macos-14-3.4
+  tags: compliance, CIS, CIS_Level1
   contributors: sharon-fdm
 ---
 apiVersion: v1
@@ -2395,7 +2395,7 @@ spec:
       -- For /etc/security/audit_control the MODE should be 0400 ("-r--------")
       NOT EXISTS ( select 1 from file where path = "/etc/security/audit_control" AND mode != "0400" );
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1, CIS-macos-14-3.5
+  tags: compliance, CIS, CIS_Level1
   contributors: sharon-fdm
 ---
 apiVersion: v1
@@ -2463,7 +2463,7 @@ spec:
     );
 
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1, CIS-macos-14-3.6
+  tags: compliance, CIS, CIS_Level1
   contributors: sharon-fdm
 ---
 apiVersion: v1
@@ -2499,7 +2499,7 @@ spec:
             (value != 1 AND value != 'true')
         );  
   purpose: Informational
-  tags: compliance, CIS, CIS_Level2, CIS-macos-14-4.1
+  tags: compliance, CIS, CIS_Level2
   contributors: lucasmrod
 ---
 apiVersion: v1
@@ -2518,7 +2518,7 @@ spec:
     /usr/bin/sudo /bin/launchctl unload -w /System/Library/LaunchDaemons/org.apache.httpd.plist
   query: SELECT 1 WHERE NOT EXISTS(SELECT * FROM processes WHERE path = '/usr/sbin/httpd');
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1, CIS-macos-14-4.2
+  tags: compliance, CIS, CIS_Level1
   contributors: lucasmrod
 ---
 apiVersion: v1
@@ -2542,7 +2542,7 @@ spec:
     AND
     NOT EXISTS(SELECT 1 FROM file WHERE path = '/etc/exports');
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1, CIS-macos-14-4.3
+  tags: compliance, CIS, CIS_Level1
   contributors: lucasmrod
 ---
 apiVersion: v1
@@ -2571,7 +2571,7 @@ spec:
     AND mode !="0711"
     ));
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1, CIS-macos-14-5.1.1
+  tags: compliance, CIS, CIS_Level1
   contributors: sharon-fdm
 ---
 apiVersion: v1
@@ -2592,7 +2592,7 @@ spec:
           /usr/bin/sudo /usr/bin/csrutil enable
   query: SELECT 1 FROM sip_config WHERE config_flag="sip" and enabled=1;
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1, CIS-macos-14-5.1.2
+  tags: compliance, CIS, CIS_Level1
   contributors: sharon-fdm
 ---
 apiVersion: v1
@@ -2610,7 +2610,7 @@ spec:
       /usr/bin/sudo /usr/sbin/nvram boot-args=""
   query: SELECT 1 FROM nvram_info WHERE amfi_enabled="1";
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1, CIS-macos-14-5.1.3
+  tags: compliance, CIS, CIS_Level1
   contributors: sharon-fdm
 ---
 apiVersion: v1
@@ -2628,7 +2628,7 @@ spec:
     If SSV has been disabled, assume that the operating system has been compromised. Back up any files, and do a clean install to a known good Operating System.
   query: SELECT 1 FROM csrutil_info WHERE ssv_enabled="1";
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1, CIS-macos-14-5.1.4
+  tags: compliance, CIS, CIS_Level1
   contributors: sharon-fdm
 ---
 apiVersion: v1
@@ -2657,7 +2657,7 @@ spec:
       CAST(SUBSTRING(file.mode, -1) AS INTEGER) & 0x2 != 0
     );
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1, CIS-macos-14-5.1.5
+  tags: compliance, CIS, CIS_Level1
   contributors: sharon-fdm
 ---
 apiVersion: v1
@@ -2687,7 +2687,7 @@ spec:
         AND path NOT LIKE '%Drop Box%'
     );
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1, CIS-macos-14-5.1.6
+  tags: compliance, CIS, CIS_Level1
   contributors: sharon-fdm
 ---
 apiVersion: v1
@@ -2716,7 +2716,7 @@ spec:
         AND path NOT LIKE '%/Preferences/Audio/Data%'
     );
   purpose: Informational
-  tags: compliance, CIS, CIS_Level2, CIS-macos-14-5.1.7
+  tags: compliance, CIS, CIS_Level2
   contributors: sharon-fdm
 ---
 apiVersion: v1
@@ -2737,7 +2737,7 @@ spec:
       3. The key must be set to <integer><value≤5></integer>
   query: SELECT 1 FROM  pwd_policy where max_failed_attempts <= 5;
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1, CIS-macos-14-5.2.1
+  tags: compliance, CIS, CIS_Level1
   contributors: sharon-fdm
 ---
 apiVersion: v1
@@ -2768,7 +2768,7 @@ spec:
     WHERE policy_identifier LIKE '%minLength')) 
     WHERE minlength >= 15);
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1, CIS-macos-14-5.2.2
+  tags: compliance, CIS, CIS_Level1
   contributors: sharon-fdm
 ---
 apiVersion: v1
@@ -2800,7 +2800,7 @@ spec:
             (value != 1 AND value != 'true')
         );  
   purpose: Informational
-  tags: compliance, CIS, CIS_Level2, CIS-macos-14-5.2.3, CIS-macos-14-5.2.4
+  tags: compliance, CIS, CIS_Level2
   contributors: sharon-fdm
 ---
 apiVersion: v1
@@ -2829,7 +2829,7 @@ spec:
             value < 1
         );  
   purpose: Informational
-  tags: compliance, CIS, CIS_Level2, CIS-macos-14-5.2.5
+  tags: compliance, CIS, CIS_Level2
   contributors: sharon-fdm
 ---
 apiVersion: v1
@@ -2846,7 +2846,7 @@ spec:
     /usr/bin/sudo /usr/bin/pwpolicy -n /Local/Default -setglobalpolicy "requiresMixedCase=<value>=1>"
   query: SELECT 1 FROM  pwd_policy where min_mixed_case_characters >= 1;
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1, CIS-macos-14-5.2.6
+  tags: compliance, CIS, CIS_Level1
   contributors: sharon-fdm
 ---
 apiVersion: v1
@@ -2871,7 +2871,7 @@ spec:
     OR
     EXISTS(SELECT 1 FROM pwd_policy WHERE days_to_expiration <= 365);
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1, CIS-macos-14-5.2.7
+  tags: compliance, CIS, CIS_Level1
   contributors: sharon-fdm
 ---
 apiVersion: v1
@@ -2890,7 +2890,7 @@ spec:
       3. The key must be set to <integer><value≥15></integer>
   query: SELECT 1 FROM  pwd_policy where history_depth >= 15;
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1, CIS-macos-14-5.2.8
+  tags: compliance, CIS, CIS_Level1
   contributors: sharon-fdm
 ---
 apiVersion: v1
@@ -2924,7 +2924,7 @@ spec:
         filevault != 1
     );
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1, CIS-macos-14-5.3.1
+  tags: compliance, CIS, CIS_Level1
   contributors: artemist-work
 ---
 apiVersion: v1
@@ -2946,7 +2946,7 @@ spec:
       SELECT 1 FROM corestorage_logical_volume_families WHERE EncryptionType != "AES-XTS"
     );
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1, CIS-macos-14-5.3.2
+  tags: compliance, CIS, CIS_Level1
   contributors: artemist-work
 ---
 apiVersion: v1
@@ -2974,7 +2974,7 @@ spec:
       FROM sudo_info WHERE authentication_timestamp_timeout = '0.0 minutes'
     );
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1, CIS-macos-14-5.4
+  tags: compliance, CIS, CIS_Level1
   contributors: lucasmrod
 ---
 apiVersion: v1
@@ -3001,7 +3001,7 @@ spec:
       FROM sudo_info WHERE type_of_auth_timestamp_record = 'tty'
     );
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1, CIS-macos-14-5.5
+  tags: compliance, CIS, CIS_Level1
   contributors: lucasmrod
 ---
 apiVersion: v1
@@ -3023,7 +3023,7 @@ spec:
   query: |
     SELECT 1 from dscl WHERE command = 'read' AND path = '/Users/root' AND key = 'AuthenticationAuthority' AND value = '';
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1, CIS-macos-14-5.6
+  tags: compliance, CIS, CIS_Level1
   contributors: lucasmrod
 ---
 apiVersion: v1
@@ -3047,7 +3047,7 @@ spec:
       rule LIKE '%use-login-window-ui%'
     );
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1, CIS-macos-14-5.7
+  tags: compliance, CIS, CIS_Level1
   contributors: lucasmrod
 ---
 apiVersion: v1
@@ -3072,7 +3072,7 @@ spec:
     path = '/Library/Security/PolicyBanner.rtf') AND mode = '0644'
     AND uid = 0 AND gid = 0;
   purpose: Informational
-  tags: compliance, CIS, CIS_Level2, CIS-macos-14-5.8
+  tags: compliance, CIS, CIS_Level2
   contributors: lucasmrod
 ---
 apiVersion: v1
@@ -3090,7 +3090,7 @@ spec:
   query: |
     SELECT 1 WHERE NOT EXISTS (SELECT * FROM file WHERE path = '/Users/Guest');
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1, CIS-macos-14-5.10
+  tags: compliance, CIS, CIS_Level1
   contributors: lucasmrod
 ---
 apiVersion: v1
@@ -3121,7 +3121,7 @@ spec:
         p.value IS NULL
     );
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1, CIS-macos-14-6.1.1
+  tags: compliance, CIS, CIS_Level1
   contributors: artemist-work
 ---
 apiVersion: v1
@@ -3159,7 +3159,7 @@ spec:
             (value != 0 AND value != 'false')
         );  
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1, CIS-macos-14-6.3.1
+  tags: compliance, CIS, CIS_Level1
   contributors: artemist-work
 ---
 apiVersion: v1
@@ -3211,7 +3211,7 @@ spec:
             value != 1
         );  
   purpose: Informational
-  tags: compliance, CIS, CIS_Level2, CIS-macos-14-6.3.2, decision-needed
+  tags: compliance, CIS, CIS_Level2
   contributors: sharon-fdm
 ---
 apiVersion: v1
@@ -3243,7 +3243,7 @@ spec:
             (value != 1 AND value != 'true')
         );  
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1, CIS-macos-14-6.3.3
+  tags: compliance, CIS, CIS_Level1
   contributors: artemist-work
 ---
 apiVersion: v1
@@ -3307,7 +3307,7 @@ spec:
             value != '1' 
         );  
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1, CIS-macos-14-6.3.4
+  tags: compliance, CIS, CIS_Level1
   contributors: lucasmrod
 ---
 apiVersion: v1
@@ -3338,7 +3338,7 @@ spec:
       p.value IS NULL
     );
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1, CIS-macos-14-6.3.5-enabled, decision-needed
+  tags: compliance, CIS, CIS_Level1
   contributors: artemist-work
 ---
 apiVersion: v1
@@ -3371,7 +3371,7 @@ spec:
       p.value IS NULL
     );
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1, CIS-macos-14-6.3.5-disabled, decision-needed
+  tags: compliance, CIS, CIS_Level1
   contributors: artemist-work
 ---
 apiVersion: v1
@@ -3405,7 +3405,7 @@ spec:
       p.value IS NULL
     );
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1, CIS-macos-14-6.3.6
+  tags: compliance, CIS, CIS_Level1
   contributors: artemist-work
 ---
 apiVersion: v1
@@ -3446,7 +3446,7 @@ spec:
             (value != 1 AND value != 'true')
         );  
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1, CIS-macos-14-6.3.7
+  tags: compliance, CIS, CIS_Level1
   contributors: sharon-fdm
 ---
 apiVersion: v1
@@ -3481,5 +3481,5 @@ spec:
             (value != 1 AND value != 'true')
         );  
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1, CIS-macos-14-6.4.1
+  tags: compliance, CIS, CIS_Level1
   contributors: sharon-fdm

--- a/ee/cis/macos-14/cis-policy-queries.yml
+++ b/ee/cis/macos-14/cis-policy-queries.yml
@@ -1633,7 +1633,7 @@ spec:
     /*CIS does not make a hard recommendation for this policy. Fleet has provided two policies (one failing, one succeeding). 
       Depending on your organization's decision, you can delete this policy or its counterpart.*/
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1
+  tags: compliance, CIS, CIS_Level1, decision-needed
   contributors: sharon-fdm
 ---
 apiVersion: v1

--- a/ee/cis/macos-14/cis-policy-queries.yml
+++ b/ee/cis/macos-14/cis-policy-queries.yml
@@ -1339,7 +1339,7 @@ spec:
     /*CIS does not make a hard recommendation for this policy. Fleet has provided two policies (one failing, one succeeding). 
       Depending on your organization's decision, you can delete this policy or its counterpart.*/
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1
+  tags: compliance, CIS, CIS_Level1, decision-needed
   contributors: sharon-fdm
 ---
 apiVersion: v1

--- a/ee/cis/macos-14/cis-policy-queries.yml
+++ b/ee/cis/macos-14/cis-policy-queries.yml
@@ -1310,7 +1310,7 @@ spec:
     /*CIS does not make a hard recommendation for this policy. Fleet has provided two policies (one failing, one succeeding). 
       Depending on your organization's decision, you can delete this policy or its counterpart.*/
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1
+  tags: compliance, CIS, CIS_Level1, decision-needed
   contributors: sharon-fdm
 ---
 apiVersion: v1

--- a/ee/cis/macos-14/cis-policy-queries.yml
+++ b/ee/cis/macos-14/cis-policy-queries.yml
@@ -1194,7 +1194,7 @@ spec:
     /*CIS does not make a hard recommendation for this policy. Fleet has provided two policies (one failing, one succeeding). 
       Depending on your organization's decision, you can delete this policy or its counterpart.*/
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1
+  tags: compliance, CIS, CIS_Level1, decision-needed
   contributors: sharon-fdm
 ---
 apiVersion: v1

--- a/ee/cis/macos-14/cis-policy-queries.yml
+++ b/ee/cis/macos-14/cis-policy-queries.yml
@@ -340,7 +340,7 @@ spec:
     /*CIS does not make a hard recommendation for this policy. Fleet has provided two policies (one failing, one succeeding). 
       Depending on your organization's decision, you can delete this policy or its counterpart.*/
   purpose: Informational
-  tags: compliance, CIS, CIS_Level2
+  tags: compliance, CIS, CIS_Level2, decision-needed
   contributors: sharon-fdm
 ---
 apiVersion: v1

--- a/ee/cis/macos-14/cis-policy-queries.yml
+++ b/ee/cis/macos-14/cis-policy-queries.yml
@@ -18,7 +18,7 @@ spec:
       4. Select Update All
   query: SELECT 1 FROM software_update WHERE software_update_required = '0';
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1, CIS-macos-13-1.1
+  tags: compliance, CIS, CIS_Level1, CIS-macos-14-1.1
   contributors: sharon-fdm
 ---
 apiVersion: v1
@@ -45,7 +45,7 @@ spec:
             (value != 1 AND value != 'true')
         );  
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1, CIS-macos-13-1.2
+  tags: compliance, CIS, CIS_Level1, CIS-macos-14-1.2
   contributors: sharon-fdm
 ---
 apiVersion: v1
@@ -72,7 +72,7 @@ spec:
             (value != 1 AND value != 'true')
         );  
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1, CIS-macos-13-1.3
+  tags: compliance, CIS, CIS_Level1, CIS-macos-14-1.3
   contributors: sharon-fdm
 ---
 apiVersion: v1
@@ -99,7 +99,7 @@ spec:
             (value != 1 AND value != 'true')
         );  
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1, CIS-macos-13-1.4
+  tags: compliance, CIS, CIS_Level1, CIS-macos-14-1.4
   contributors: sharon-fdm
 ---
 apiVersion: v1
@@ -126,7 +126,7 @@ spec:
             (value != 1 AND value != 'true')
         );  
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1, CIS-macos-13-1.5
+  tags: compliance, CIS, CIS_Level1, CIS-macos-14-1.5
   contributors: lucasmrod
 ---
 apiVersion: v1
@@ -157,7 +157,7 @@ spec:
             (value != 1 AND value != 'true')
         );  
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1, CIS-macos-13-1.6
+  tags: compliance, CIS, CIS_Level1, CIS-macos-14-1.6
   contributors: sharon-fdm
 ---
 apiVersion: v1
@@ -190,7 +190,7 @@ spec:
             value > 30
         );  
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1, CIS-macos-13-1.7
+  tags: compliance, CIS, CIS_Level1, CIS-macos-14-1.7
   contributors: lucasmrod
 ---
 apiVersion: v1
@@ -227,7 +227,7 @@ spec:
     /*CIS does not make a hard recommendation for this policy. Fleet has provided two policies (one failing, one succeeding). 
       Depending on your organization's decision, you can delete this policy or its counterpart.*/
   purpose: Informational
-  tags: compliance, CIS, CIS_Level2, CIS-macos-13-2.1.1.2-disabled, decision-needed
+  tags: compliance, CIS, CIS_Level2, CIS-macos-14-2.1.1.2-disabled, decision-needed
   contributors: sharon-fdm
 ---
 apiVersion: v1
@@ -264,7 +264,7 @@ spec:
     /*CIS does not make a hard recommendation for this policy. Fleet has provided two policies (one failing, one succeeding). 
       Depending on your organization's decision, you can delete this policy or its counterpart.*/
   purpose: Informational
-  tags: compliance, CIS, CIS_Level2, CIS-macos-13-2.1.1.2-enabled, decision-needed
+  tags: compliance, CIS, CIS_Level2, CIS-macos-14-2.1.1.2-enabled, decision-needed
   contributors: sharon-fdm
 ---
 apiVersion: v1
@@ -302,7 +302,7 @@ spec:
     /*CIS does not make a hard recommendation for this policy. Fleet has provided two policies (one failing, one succeeding). 
       Depending on your organization's decision, you can delete this policy or its counterpart.*/
   purpose: Informational
-  tags: compliance, CIS, CIS_Level2, CIS-macos-13-2.1.1.1-disable, decision-needed
+  tags: compliance, CIS, CIS_Level2, CIS-macos-14-2.1.1.1-disable, decision-needed
   contributors: sharon-fdm
 ---
 apiVersion: v1
@@ -340,7 +340,7 @@ spec:
     /*CIS does not make a hard recommendation for this policy. Fleet has provided two policies (one failing, one succeeding). 
       Depending on your organization's decision, you can delete this policy or its counterpart.*/
   purpose: Informational
-  tags: compliance, CIS, CIS_Level2, CIS-macos-13-2.1.1.1-enable, decision-needed
+  tags: compliance, CIS, CIS_Level2, CIS-macos-14-2.1.1.1-enable, decision-needed
   contributors: sharon-fdm
 ---
 apiVersion: v1
@@ -372,7 +372,7 @@ spec:
             (value != 0 AND value != 'false')
         );  
   purpose: Informational
-  tags: compliance, CIS, CIS_Level2, CIS-macos-13-2.1.1.3
+  tags: compliance, CIS, CIS_Level2, CIS-macos-14-2.1.1.3
   contributors: zwass
 ---
 apiVersion: v1
@@ -385,7 +385,7 @@ spec:
   resolution: "Go to the Network pane in System Settings and ensure Firewall is active."
   query: SELECT 1 FROM alf WHERE global_state >= 1;
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1, CIS-macos-13-2.2.1
+  tags: compliance, CIS, CIS_Level1, CIS-macos-14-2.2.1
   contributors: sharon-fdm
 ---
 apiVersion: v1
@@ -406,7 +406,7 @@ spec:
       5. Set Enabled stealth mode to enabled
   query: SELECT 1 FROM alf WHERE global_state >= 1 AND stealth_enabled = 1;
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1, CIS-macos-13-2.2.2
+  tags: compliance, CIS, CIS_Level1, CIS-macos-14-2.2.2
   contributors: lucasmrod
 ---
 apiVersion: v1
@@ -440,7 +440,7 @@ spec:
             (value != 0 AND value != 'false')
         );  
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1, CIS-macos-13-2.3.1.1
+  tags: compliance, CIS, CIS_Level1, CIS-macos-14-2.3.1.1
   contributors: lucasmrod
 ---
 apiVersion: v1
@@ -480,7 +480,7 @@ spec:
             (value != 0 AND value != 'false')
         );  
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1, CIS-macos-13-2.3.1.2
+  tags: compliance, CIS, CIS_Level1, CIS-macos-14-2.3.1.2
   contributors: lucasmrod
 ---
 apiVersion: v1
@@ -512,7 +512,7 @@ spec:
             (value != 1 AND value != 'true')
         );  
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1, CIS-macos-13-2.3.2.1
+  tags: compliance, CIS, CIS_Level1, CIS-macos-14-2.3.2.1
   contributors: sharon-fdm
 ---
 apiVersion: v1
@@ -527,7 +527,7 @@ spec:
   resolution: Make sure the device can connect to time.apple.com to synchronize time.
   query: SELECT * FROM sntp_request WHERE server = 'time.apple.com' AND clock_offset_ms <= 270000 AND clock_offset_ms >= -270000;
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1, CIS-macos-13-2.3.2.2
+  tags: compliance, CIS, CIS_Level1, CIS-macos-14-2.3.2.2
   contributors: lucasmrod 
 ---
 apiVersion: v1
@@ -557,7 +557,7 @@ spec:
   # are disabled via disabled.plist, which the preference pane uses whenever
   # a service is disabled after it has been enabled in the past.
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1, CIS-macos-13-2.3.3.1
+  tags: compliance, CIS, CIS_Level1, CIS-macos-14-2.3.3.1
   contributors: artemist-work
 ---
 apiVersion: v1
@@ -590,7 +590,7 @@ spec:
   # are disabled via disabled.plist, which the preference pane uses whenever
   # a service is disabled after it has been enabled in the past.
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1, CIS-macos-13-2.3.3.2
+  tags: compliance, CIS, CIS_Level1, CIS-macos-14-2.3.3.2
   contributors: artemist-work
 ---
 apiVersion: v1
@@ -620,7 +620,7 @@ spec:
   # are disabled via disabled.plist, which the preference pane uses whenever
   # a service is disabled after it has been enabled in the past.
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1, CIS-macos-13-2.3.3.3
+  tags: compliance, CIS, CIS_Level1, CIS-macos-14-2.3.3.3
   contributors: artemist-work
 ---
 apiVersion: v1
@@ -648,7 +648,7 @@ spec:
         line LIKE '%Allow @LOCAL%'
       );
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1, CIS-macos-13-2.3.3.4
+  tags: compliance, CIS, CIS_Level1, CIS-macos-14-2.3.3.4
   contributors: artemist-work
 ---
 apiVersion: v1
@@ -681,7 +681,7 @@ spec:
   # are disabled via disabled.plist, which the preference pane uses whenever
   # a service is disabled after it has been enabled in the past.
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1, CIS-macos-13-2.3.3.5
+  tags: compliance, CIS, CIS_Level1, CIS-macos-14-2.3.3.5
   contributors: artemist-work
 ---
 apiVersion: v1
@@ -709,7 +709,7 @@ spec:
         path = '/System/Library/CoreServices/RemoteManagement/ARDAgent.app/Contents/MacOS/ARDAgent'
     );
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1, CIS-macos-13-2.3.3.6
+  tags: compliance, CIS, CIS_Level1, CIS-macos-14-2.3.3.6
   contributors: artemist-work
 ---
 apiVersion: v1
@@ -740,7 +740,7 @@ spec:
   # are disabled via disabled.plist, which the preference pane uses whenever
   # a service is disabled after it has been enabled in the past.
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1, CIS-macos-13-2.3.3.7
+  tags: compliance, CIS, CIS_Level1, CIS-macos-14-2.3.3.7
   contributors: artemist-work
 ---
 apiVersion: v1
@@ -768,7 +768,7 @@ spec:
         value = '1'
     );
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1, CIS-macos-13-2.3.3.8
+  tags: compliance, CIS, CIS_Level1, CIS-macos-14-2.3.3.8
   contributors: artemist-work
 ---
 apiVersion: v1
@@ -807,7 +807,7 @@ spec:
             (value != 0 AND value != 'false')
         );  
   purpose: Informational
-  tags: compliance, CIS, CIS_Level2, CIS-macos-13-2.3.3.9
+  tags: compliance, CIS, CIS_Level2, CIS-macos-14-2.3.3.9
   contributors: sharon-fdm
 ---
 apiVersion: v1
@@ -834,7 +834,7 @@ spec:
         value = '1'
     );
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1, CIS-macos-13-2.3.3.11
+  tags: compliance, CIS, CIS_Level1, CIS-macos-14-2.3.3.11
   contributors: artemist-work
 ---
 apiVersion: v1
@@ -890,7 +890,7 @@ spec:
         value != '0'
     );
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1, CIS-macos-13-2.3.3.10
+  tags: compliance, CIS, CIS_Level1, CIS-macos-14-2.3.3.10
   contributors: artemist-work
 ---
 apiVersion: v1
@@ -921,7 +921,7 @@ spec:
     FROM plist WHERE path='/Library/Preferences/com.apple.TimeMachine.plist'
     AND key='AutoBackup' AND (value = 1 OR value = 'true');
   purpose: Informational
-  tags: compliance, CIS, CIS_Level2, CIS-macos-13-2.3.4.1
+  tags: compliance, CIS, CIS_Level2, CIS-macos-14-2.3.4.1
   contributors: lucasmrod
 ---
 apiVersion: v1
@@ -958,7 +958,7 @@ spec:
     SELECT 'time machines destinations with encryption with automatic backup' as output
     FROM (SELECT COUNT(*) as c FROM time_machine_destinations WHERE encryption <> 'Encrypted') t2 WHERE t2.c = 0;
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1, CIS-macos-13-2.3.4.2
+  tags: compliance, CIS, CIS_Level1, CIS-macos-14-2.3.4.2
   contributors: lucasmrod
 ---
 apiVersion: v1
@@ -995,7 +995,7 @@ spec:
             value != 18
         );  
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1, CIS-macos-13-2.4.1
+  tags: compliance, CIS, CIS_Level1, CIS-macos-14-2.4.1
   contributors: lucasmrod
 ---
 apiVersion: v1
@@ -1031,7 +1031,7 @@ spec:
             value != 18
         );  
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1, CIS-macos-13-2.4.2
+  tags: compliance, CIS, CIS_Level1, CIS-macos-14-2.4.2
   contributors: lucasmrod
 ---
 apiVersion: v1
@@ -1069,7 +1069,7 @@ spec:
      /*CIS does not make a hard recommendation for this policy. Fleet has provided two policies (one failing, one succeeding). 
       Depending on your organization's decision, you can delete this policy or its counterpart.*/
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1, CIS-macos-13-2.5.1-enabled, decision-needed
+  tags: compliance, CIS, CIS_Level1, CIS-macos-14-2.5.1-enabled, decision-needed
   contributors: sharon-fdm
 ---
 apiVersion: v1
@@ -1107,7 +1107,7 @@ spec:
     /*CIS does not make a hard recommendation for this policy. Fleet has provided two policies (one failing, one succeeding). 
       Depending on your organization's decision, you can delete this policy or its counterpart.*/
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1, CIS-macos-13-2.5.1-disabled, decision-needed
+  tags: compliance, CIS, CIS_Level1, CIS-macos-14-2.5.1-disabled, decision-needed
   contributors: sharon-fdm
 ---
 apiVersion: v1
@@ -1136,7 +1136,7 @@ spec:
     /*CIS does not make a hard recommendation for this policy. Fleet has provided two policies (one failing, one succeeding). 
       Depending on your organization's decision, you can delete this policy or its counterpart.*/
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1, CIS-macos-13-2.5.1-TypeToSiriEnabled-true, decision-needed
+  tags: compliance, CIS, CIS_Level1, CIS-macos-14-2.5.1-TypeToSiriEnabled-true, decision-needed
   contributors: sharon-fdm
 ---
 apiVersion: v1
@@ -1165,7 +1165,7 @@ spec:
     /*CIS does not make a hard recommendation for this policy. Fleet has provided two policies (one failing, one succeeding). 
       Depending on your organization's decision, you can delete this policy or its counterpart.*/
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1, CIS-macos-13-2.5.1-TypeToSiriEnabled-false, decision-needed
+  tags: compliance, CIS, CIS_Level1, CIS-macos-14-2.5.1-TypeToSiriEnabled-false, decision-needed
   contributors: sharon-fdm
 ---
 apiVersion: v1
@@ -1194,7 +1194,7 @@ spec:
     /*CIS does not make a hard recommendation for this policy. Fleet has provided two policies (one failing, one succeeding). 
       Depending on your organization's decision, you can delete this policy or its counterpart.*/
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1, CIS-macos-13-2.5.1-StatusMenuVisible-true, decision-needed
+  tags: compliance, CIS, CIS_Level1, CIS-macos-14-2.5.1-StatusMenuVisible-true, decision-needed
   contributors: sharon-fdm
 ---
 apiVersion: v1
@@ -1223,7 +1223,7 @@ spec:
     /*CIS does not make a hard recommendation for this policy. Fleet has provided two policies (one failing, one succeeding). 
       Depending on your organization's decision, you can delete this policy or its counterpart.*/
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1, CIS-macos-13-2.5.1-StatusMenuVisible-false, decision-needed
+  tags: compliance, CIS, CIS_Level1, CIS-macos-14-2.5.1-StatusMenuVisible-false, decision-needed
   contributors: sharon-fdm
 ---
 apiVersion: v1
@@ -1252,7 +1252,7 @@ spec:
     /*CIS does not make a hard recommendation for this policy. Fleet has provided two policies (one failing, one succeeding). 
       Depending on your organization's decision, you can delete this policy or its counterpart.*/
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1, CIS-macos-13-2.5.1-VoiceTriggerUserEnabled-true, decision-needed
+  tags: compliance, CIS, CIS_Level1, CIS-macos-14-2.5.1-VoiceTriggerUserEnabled-true, decision-needed
   contributors: sharon-fdm
 ---
 apiVersion: v1
@@ -1281,7 +1281,7 @@ spec:
     /*CIS does not make a hard recommendation for this policy. Fleet has provided two policies (one failing, one succeeding). 
       Depending on your organization's decision, you can delete this policy or its counterpart.*/
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1, CIS-macos-13-2.5.1-VoiceTriggerUserEnabled-false, decision-needed
+  tags: compliance, CIS, CIS_Level1, CIS-macos-14-2.5.1-VoiceTriggerUserEnabled-false, decision-needed
   contributors: sharon-fdm
 ---
 apiVersion: v1
@@ -1310,7 +1310,7 @@ spec:
     /*CIS does not make a hard recommendation for this policy. Fleet has provided two policies (one failing, one succeeding). 
       Depending on your organization's decision, you can delete this policy or its counterpart.*/
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1, CIS-macos-13-2.5.1-LockscreenEnabled-true, decision-needed
+  tags: compliance, CIS, CIS_Level1, CIS-macos-14-2.5.1-LockscreenEnabled-true, decision-needed
   contributors: sharon-fdm
 ---
 apiVersion: v1
@@ -1339,7 +1339,7 @@ spec:
     /*CIS does not make a hard recommendation for this policy. Fleet has provided two policies (one failing, one succeeding). 
       Depending on your organization's decision, you can delete this policy or its counterpart.*/
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1, CIS-macos-13-2.5.1-LockscreenEnabled-false, decision-needed
+  tags: compliance, CIS, CIS_Level1, CIS-macos-14-2.5.1-LockscreenEnabled-false, decision-needed
   contributors: sharon-fdm
 ---
 apiVersion: v1
@@ -1360,7 +1360,7 @@ spec:
         4. Verify Location Services is enabled
   query: SELECT 1 FROM location_services where enabled=1;
   purpose: Informational
-  tags: compliance, CIS, CIS_Level2, CIS-macos-13-2.6.1.1
+  tags: compliance, CIS, CIS_Level2, CIS-macos-14-2.6.1.1
   contributors: sharon-fdm
 ---
 apiVersion: v1
@@ -1383,7 +1383,7 @@ spec:
         location is set to your organization's parameters
   query:  SELECT 1 FROM plist WHERE path='/Library/Preferences/com.apple.locationmenu.plist' AND key='ShowSystemServices' AND value=1;
   purpose: Informational
-  tags: compliance, CIS, CIS_Level2, CIS-macos-13-2.6.1.2
+  tags: compliance, CIS, CIS_Level2, CIS-macos-14-2.6.1.2
   contributors: sharon-fdm
 ---
 apiVersion: v1
@@ -1408,7 +1408,7 @@ spec:
         4. Set Location Services to disabled.
   query:  SELECT 1 FROM location_services WHERE enabled = 0;
   purpose: Informational
-  tags: compliance, CIS, CIS_Level2, CIS-macos-13-2.6.1.3-Location-Service-disabled
+  tags: compliance, CIS, CIS_Level2, CIS-macos-14-2.6.1.3-Location-Service-disabled
   contributors: sharon-fdm
 ---
 apiVersion: v1
@@ -1470,7 +1470,7 @@ spec:
             )
         );
   purpose: Informational
-  tags: compliance, CIS, CIS_Level2, CIS-macos-13-2.6.1.3-Location-Service-specifc-app-enabled, decision-needed
+  tags: compliance, CIS, CIS_Level2, CIS-macos-14-2.6.1.3-Location-Service-specifc-app-enabled, decision-needed
   contributors: sharon-fdm
 ---
 apiVersion: v1
@@ -1504,7 +1504,7 @@ spec:
             (value != 0 AND value != 'false')
         );  
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1, CIS-macos-13-2.6.3
+  tags: compliance, CIS, CIS_Level1, CIS-macos-14-2.6.3
   contributors: sharon-fdm
 ---
 apiVersion: v1
@@ -1523,7 +1523,7 @@ spec:
         4. Set Require an administrator password to access system-wide settings to enabled
   query: SELECT 1 FROM authdb WHERE right_name = 'system.preferences' AND json_extract(json_result, '$.shared') == 0;
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1, CIS-macos-13-2.6.7
+  tags: compliance, CIS, CIS_Level1, CIS-macos-14-2.6.7
   contributors: artemist-work
 ---
 apiVersion: v1
@@ -1559,7 +1559,7 @@ spec:
         key = 'wvous-tl-corner'
     ) AND value = 6);
   purpose: Informational
-  tags: compliance, CIS, CIS_Level2, CIS-macos-13-2.7.1
+  tags: compliance, CIS, CIS_Level2, CIS-macos-14-2.7.1
   contributors: lucasmrod
 ---
 apiVersion: v1
@@ -1596,7 +1596,7 @@ spec:
     /*CIS does not make a hard recommendation for this policy. Fleet has provided two policies (one failing, one succeeding). 
       Depending on your organization's decision, you can delete this policy or its counterpart.*/
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1, CIS-macos-13-2.8.1-enabled, decision-needed
+  tags: compliance, CIS, CIS_Level1, CIS-macos-14-2.8.1-enabled, decision-needed
   contributors: sharon-fdm
 ---
 apiVersion: v1
@@ -1633,7 +1633,7 @@ spec:
     /*CIS does not make a hard recommendation for this policy. Fleet has provided two policies (one failing, one succeeding). 
       Depending on your organization's decision, you can delete this policy or its counterpart.*/
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1, CIS-macos-13-2.8.1-disabled, decision-needed
+  tags: compliance, CIS, CIS_Level1, CIS-macos-14-2.8.1-disabled, decision-needed
   contributors: sharon-fdm
 ---
 apiVersion: v1
@@ -1665,7 +1665,7 @@ spec:
       ), '') AS powernap_battery
     FROM pmset WHERE getting = 'custom' AND powernap_battery != '1' AND powernap_ac != '1');
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1, CIS-macos-13-2.9.1
+  tags: compliance, CIS, CIS_Level1, CIS-macos-14-2.9.1
   contributors: lucasmrod
 ---
 apiVersion: v1
@@ -1696,7 +1696,7 @@ spec:
       ), '') AS womp_battery
     FROM pmset WHERE getting = 'custom' AND womp_battery != '1' AND womp_ac != '1');
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1, CIS-macos-13-2.9.2
+  tags: compliance, CIS, CIS_Level1, CIS-macos-14-2.9.2
   contributors: lucasmrod
 ---
 apiVersion: v1
@@ -1772,7 +1772,7 @@ spec:
         )
     );
   purpose: Informational
-  tags: compliance, CIS, CIS_Level2, CIS-macos-13-2.9.3
+  tags: compliance, CIS, CIS_Level2, CIS-macos-14-2.9.3
   contributors: lucasmrod
 ---
 apiVersion: v1
@@ -1820,7 +1820,7 @@ spec:
             value > 5
         );  
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1, CIS-macos-13-2.10.2
+  tags: compliance, CIS, CIS_Level1, CIS-macos-14-2.10.2
   contributors: sharon-fdm
 ---
 apiVersion: v1
@@ -1841,7 +1841,7 @@ spec:
         3. Verify that 'Allow apps downloaded from' is set to' App Store and identified developers'
   query: SELECT 1 FROM gatekeeper WHERE assessments_enabled = 1 AND dev_id_enabled = 1;
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1, CIS-macos-13-2.6.4
+  tags: compliance, CIS, CIS_Level1, CIS-macos-14-2.6.4
   contributors: sharon-fdm
 ---
 apiVersion: v1
@@ -1904,7 +1904,7 @@ spec:
             value != 2
         );  
   purpose: Informational
-  tags: compliance, CIS, CIS_Level2, CIS-macos-13-2.6.2
+  tags: compliance, CIS, CIS_Level2, CIS-macos-14-2.6.2
   contributors: sharon-fdm
 ---
 apiVersion: v1
@@ -1938,7 +1938,7 @@ spec:
             value > 1200
         );  
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1, CIS-macos-13-2.10.1
+  tags: compliance, CIS, CIS_Level1, CIS-macos-14-2.10.1
   contributors: sharon-fdm
 ---
 apiVersion: v1
@@ -1958,7 +1958,7 @@ spec:
         5. Verify that the message displayed is configured to your organization's required text
   query: SELECT 1 FROM plist WHERE path='/Library/Preferences/com.apple.loginwindow.plist' AND key='LoginwindowText' AND value != "";
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1, CIS-macos-13-2.10.3
+  tags: compliance, CIS, CIS_Level1, CIS-macos-14-2.10.3
   contributors: sharon-fdm
 ---
 apiVersion: v1
@@ -2000,7 +2000,7 @@ spec:
             filevault_status = 'on' 
         );  
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1, CIS-macos-13-2.6.5
+  tags: compliance, CIS, CIS_Level1, CIS-macos-14-2.6.5
   contributors: sharon-fdm
 ---
 apiVersion: v1
@@ -2034,7 +2034,7 @@ spec:
             (value != 1 AND value != 'true')
         );  
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1, CIS-macos-13-2.10.4
+  tags: compliance, CIS, CIS_Level1, CIS-macos-14-2.10.4
   contributors: sharon-fdm
 ---
 apiVersion: v1
@@ -2068,7 +2068,7 @@ spec:
             (value != 0 AND value != 'false')
         );  
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1, CIS-macos-13-2.10.5
+  tags: compliance, CIS, CIS_Level1, CIS-macos-14-2.10.5
   contributors: sharon-fdm
 ---
 apiVersion: v1
@@ -2090,7 +2090,7 @@ spec:
         4. Change the password and ensure that no text is entered in the Password hint box
   query: SELECT 1 FROM user_login_settings WHERE password_hint_enabled = 0;
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1, CIS-macos-13-2.11.1
+  tags: compliance, CIS, CIS_Level1, CIS-macos-14-2.11.1
   contributors: sharon-fdm
 ---
 apiVersion: v1
@@ -2115,7 +2115,7 @@ spec:
     OR
     EXISTS(select 1 FROM plist WHERE path='/Library/Preferences/com.apple.MCX.plist' AND key='DisableGuestAccount' AND value = 1);
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1, CIS-macos-13-2.12.1
+  tags: compliance, CIS, CIS_Level1, CIS-macos-14-2.12.1
   contributors: sharon-fdm
 ---
 apiVersion: v1
@@ -2137,7 +2137,7 @@ spec:
         4. Set Allow guests to connect to shared folders to disabled
   query: SELECT 1 from plist where path = '/Library/Preferences/SystemConfiguration/com.apple.smb.server.plist' AND key = 'AllowGuestAccess' AND value = 0;
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1, CIS-macos-13-2.12.2
+  tags: compliance, CIS, CIS_Level1, CIS-macos-14-2.12.2
   contributors: sharon-fdm
 ---
 apiVersion: v1
@@ -2177,7 +2177,7 @@ spec:
             (value != 1 AND value != 'true')
         );  
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1, CIS-macos-13-2.12.3
+  tags: compliance, CIS, CIS_Level1, CIS-macos-14-2.12.3
   contributors: sharon-fdm
 ---
 apiVersion: v1
@@ -2207,7 +2207,7 @@ spec:
       (l.program_arguments = p.cmdline)
     );
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1, CIS-macos-13-3.1
+  tags: compliance, CIS, CIS_Level1, CIS-macos-14-3.1
   contributors: sharon-fdm
 ---
 apiVersion: v1
@@ -2262,7 +2262,7 @@ spec:
       )
     );
   purpose: Informational
-  tags: compliance, CIS, CIS_Level2, CIS-macos-13-3.2
+  tags: compliance, CIS, CIS_Level2, CIS-macos-14-3.2
   contributors: sharon-fdm
 ---
 apiVersion: v1
@@ -2292,7 +2292,7 @@ spec:
              WHERE path = '/etc/asl/com.apple.install'  
              AND  line  LIKE "%all_max=%" );
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1, CIS-macos-13-3.3
+  tags: compliance, CIS, CIS_Level1, CIS-macos-14-3.3
   contributors: sharon-fdm
 ---
 apiVersion: v1
@@ -2321,7 +2321,7 @@ spec:
       AND size >=5
     );
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1, CIS-macos-13-3.4
+  tags: compliance, CIS, CIS_Level1, CIS-macos-14-3.4
   contributors: sharon-fdm
 ---
 apiVersion: v1
@@ -2366,7 +2366,7 @@ spec:
       -- For /etc/security/audit_control the MODE should be 0400 ("-r--------")
       NOT EXISTS ( select 1 from file where path = "/etc/security/audit_control" AND mode != "0400" );
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1, CIS-macos-13-3.5
+  tags: compliance, CIS, CIS_Level1, CIS-macos-14-3.5
   contributors: sharon-fdm
 ---
 apiVersion: v1
@@ -2434,7 +2434,7 @@ spec:
     );
 
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1, CIS-macos-13-3.6
+  tags: compliance, CIS, CIS_Level1, CIS-macos-14-3.6
   contributors: sharon-fdm
 ---
 apiVersion: v1
@@ -2470,7 +2470,7 @@ spec:
             (value != 1 AND value != 'true')
         );  
   purpose: Informational
-  tags: compliance, CIS, CIS_Level2, CIS-macos-13-4.1
+  tags: compliance, CIS, CIS_Level2, CIS-macos-14-4.1
   contributors: lucasmrod
 ---
 apiVersion: v1
@@ -2489,7 +2489,7 @@ spec:
     /usr/bin/sudo /bin/launchctl unload -w /System/Library/LaunchDaemons/org.apache.httpd.plist
   query: SELECT 1 WHERE NOT EXISTS(SELECT * FROM processes WHERE path = '/usr/sbin/httpd');
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1, CIS-macos-13-4.2
+  tags: compliance, CIS, CIS_Level1, CIS-macos-14-4.2
   contributors: lucasmrod
 ---
 apiVersion: v1
@@ -2513,7 +2513,7 @@ spec:
     AND
     NOT EXISTS(SELECT 1 FROM file WHERE path = '/etc/exports');
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1, CIS-macos-13-4.3
+  tags: compliance, CIS, CIS_Level1, CIS-macos-14-4.3
   contributors: lucasmrod
 ---
 apiVersion: v1
@@ -2542,7 +2542,7 @@ spec:
     AND mode !="0711"
     ));
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1, CIS-macos-13-5.1.1
+  tags: compliance, CIS, CIS_Level1, CIS-macos-14-5.1.1
   contributors: sharon-fdm
 ---
 apiVersion: v1
@@ -2563,7 +2563,7 @@ spec:
           /usr/bin/sudo /usr/bin/csrutil enable
   query: SELECT 1 FROM sip_config WHERE config_flag="sip" and enabled=1;
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1, CIS-macos-13-5.1.2
+  tags: compliance, CIS, CIS_Level1, CIS-macos-14-5.1.2
   contributors: sharon-fdm
 ---
 apiVersion: v1
@@ -2581,7 +2581,7 @@ spec:
       /usr/bin/sudo /usr/sbin/nvram boot-args=""
   query: SELECT 1 FROM nvram_info WHERE amfi_enabled="1";
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1, CIS-macos-13-5.1.3
+  tags: compliance, CIS, CIS_Level1, CIS-macos-14-5.1.3
   contributors: sharon-fdm
 ---
 apiVersion: v1
@@ -2599,7 +2599,7 @@ spec:
     If SSV has been disabled, assume that the operating system has been compromised. Back up any files, and do a clean install to a known good Operating System.
   query: SELECT 1 FROM csrutil_info WHERE ssv_enabled="1";
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1, CIS-macos-13-5.1.4
+  tags: compliance, CIS, CIS_Level1, CIS-macos-14-5.1.4
   contributors: sharon-fdm
 ---
 apiVersion: v1
@@ -2628,7 +2628,7 @@ spec:
       CAST(SUBSTRING(file.mode, -1) AS INTEGER) & 0x2 != 0
     );
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1, CIS-macos-13-5.1.5
+  tags: compliance, CIS, CIS_Level1, CIS-macos-14-5.1.5
   contributors: sharon-fdm
 ---
 apiVersion: v1
@@ -2658,7 +2658,7 @@ spec:
         AND path NOT LIKE '%Drop Box%'
     );
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1, CIS-macos-13-5.1.6
+  tags: compliance, CIS, CIS_Level1, CIS-macos-14-5.1.6
   contributors: sharon-fdm
 ---
 apiVersion: v1
@@ -2687,7 +2687,7 @@ spec:
         AND path NOT LIKE '%/Preferences/Audio/Data%'
     );
   purpose: Informational
-  tags: compliance, CIS, CIS_Level2, CIS-macos-13-5.1.7
+  tags: compliance, CIS, CIS_Level2, CIS-macos-14-5.1.7
   contributors: sharon-fdm
 ---
 apiVersion: v1
@@ -2708,7 +2708,7 @@ spec:
       3. The key must be set to <integer><value≤5></integer>
   query: SELECT 1 FROM  pwd_policy where max_failed_attempts <= 5;
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1, CIS-macos-13-5.2.1
+  tags: compliance, CIS, CIS_Level1, CIS-macos-14-5.2.1
   contributors: sharon-fdm
 ---
 apiVersion: v1
@@ -2739,7 +2739,7 @@ spec:
     WHERE policy_identifier LIKE '%minLength')) 
     WHERE minlength >= 15);
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1, CIS-macos-13-5.2.2
+  tags: compliance, CIS, CIS_Level1, CIS-macos-14-5.2.2
   contributors: sharon-fdm
 ---
 apiVersion: v1
@@ -2771,7 +2771,7 @@ spec:
             (value != 1 AND value != 'true')
         );  
   purpose: Informational
-  tags: compliance, CIS, CIS_Level2, CIS-macos-13-5.2.3, CIS-macos-13-5.2.4
+  tags: compliance, CIS, CIS_Level2, CIS-macos-14-5.2.3, CIS-macos-14-5.2.4
   contributors: sharon-fdm
 ---
 apiVersion: v1
@@ -2800,7 +2800,7 @@ spec:
             value < 1
         );  
   purpose: Informational
-  tags: compliance, CIS, CIS_Level2, CIS-macos-13-5.2.5
+  tags: compliance, CIS, CIS_Level2, CIS-macos-14-5.2.5
   contributors: sharon-fdm
 ---
 apiVersion: v1
@@ -2817,7 +2817,7 @@ spec:
     /usr/bin/sudo /usr/bin/pwpolicy -n /Local/Default -setglobalpolicy "requiresMixedCase=<value>=1>"
   query: SELECT 1 FROM  pwd_policy where min_mixed_case_characters >= 1;
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1, CIS-macos-13-5.2.6
+  tags: compliance, CIS, CIS_Level1, CIS-macos-14-5.2.6
   contributors: sharon-fdm
 ---
 apiVersion: v1
@@ -2842,7 +2842,7 @@ spec:
     OR
     EXISTS(SELECT 1 FROM pwd_policy WHERE days_to_expiration <= 365);
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1, CIS-macos-13-5.2.7
+  tags: compliance, CIS, CIS_Level1, CIS-macos-14-5.2.7
   contributors: sharon-fdm
 ---
 apiVersion: v1
@@ -2861,7 +2861,7 @@ spec:
       3. The key must be set to <integer><value≥15></integer>
   query: SELECT 1 FROM  pwd_policy where history_depth >= 15;
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1, CIS-macos-13-5.2.8
+  tags: compliance, CIS, CIS_Level1, CIS-macos-14-5.2.8
   contributors: sharon-fdm
 ---
 apiVersion: v1
@@ -2895,7 +2895,7 @@ spec:
         filevault != 1
     );
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1, CIS-macos-13-5.3.1
+  tags: compliance, CIS, CIS_Level1, CIS-macos-14-5.3.1
   contributors: artemist-work
 ---
 apiVersion: v1
@@ -2917,7 +2917,7 @@ spec:
       SELECT 1 FROM corestorage_logical_volume_families WHERE EncryptionType != "AES-XTS"
     );
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1, CIS-macos-13-5.3.2
+  tags: compliance, CIS, CIS_Level1, CIS-macos-14-5.3.2
   contributors: artemist-work
 ---
 apiVersion: v1
@@ -2945,7 +2945,7 @@ spec:
       FROM sudo_info WHERE authentication_timestamp_timeout = '0.0 minutes'
     );
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1, CIS-macos-13-5.4
+  tags: compliance, CIS, CIS_Level1, CIS-macos-14-5.4
   contributors: lucasmrod
 ---
 apiVersion: v1
@@ -2972,7 +2972,7 @@ spec:
       FROM sudo_info WHERE type_of_auth_timestamp_record = 'tty'
     );
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1, CIS-macos-13-5.5
+  tags: compliance, CIS, CIS_Level1, CIS-macos-14-5.5
   contributors: lucasmrod
 ---
 apiVersion: v1
@@ -2994,7 +2994,7 @@ spec:
   query: |
     SELECT 1 from dscl WHERE command = 'read' AND path = '/Users/root' AND key = 'AuthenticationAuthority' AND value = '';
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1, CIS-macos-13-5.6
+  tags: compliance, CIS, CIS_Level1, CIS-macos-14-5.6
   contributors: lucasmrod
 ---
 apiVersion: v1
@@ -3018,7 +3018,7 @@ spec:
       rule LIKE '%use-login-window-ui%'
     );
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1, CIS-macos-13-5.7
+  tags: compliance, CIS, CIS_Level1, CIS-macos-14-5.7
   contributors: lucasmrod
 ---
 apiVersion: v1
@@ -3043,7 +3043,7 @@ spec:
     path = '/Library/Security/PolicyBanner.rtf') AND mode = '0644'
     AND uid = 0 AND gid = 0;
   purpose: Informational
-  tags: compliance, CIS, CIS_Level2, CIS-macos-13-5.8
+  tags: compliance, CIS, CIS_Level2, CIS-macos-14-5.8
   contributors: lucasmrod
 ---
 apiVersion: v1
@@ -3073,7 +3073,7 @@ spec:
       )
     );
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1, CIS-macos-13-5.9
+  tags: compliance, CIS, CIS_Level1, CIS-macos-14-5.9
   contributors: lucasmrod
 ---
 apiVersion: v1
@@ -3091,7 +3091,7 @@ spec:
   query: |
     SELECT 1 WHERE NOT EXISTS (SELECT * FROM file WHERE path = '/Users/Guest');
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1, CIS-macos-13-5.10
+  tags: compliance, CIS, CIS_Level1, CIS-macos-14-5.10
   contributors: lucasmrod
 ---
 apiVersion: v1
@@ -3122,7 +3122,7 @@ spec:
         p.value IS NULL
     );
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1, CIS-macos-13-6.1.1
+  tags: compliance, CIS, CIS_Level1, CIS-macos-14-6.1.1
   contributors: artemist-work
 ---
 apiVersion: v1
@@ -3160,7 +3160,7 @@ spec:
             (value != 0 AND value != 'false')
         );  
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1, CIS-macos-13-6.3.1
+  tags: compliance, CIS, CIS_Level1, CIS-macos-14-6.3.1
   contributors: artemist-work
 ---
 apiVersion: v1
@@ -3212,7 +3212,7 @@ spec:
             value != 1
         );  
   purpose: Informational
-  tags: compliance, CIS, CIS_Level2, CIS-macos-13-6.3.2, decision-needed
+  tags: compliance, CIS, CIS_Level2, CIS-macos-14-6.3.2, decision-needed
   contributors: sharon-fdm
 ---
 apiVersion: v1
@@ -3244,7 +3244,7 @@ spec:
             (value != 1 AND value != 'true')
         );  
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1, CIS-macos-13-6.3.3
+  tags: compliance, CIS, CIS_Level1, CIS-macos-14-6.3.3
   contributors: artemist-work
 ---
 apiVersion: v1
@@ -3308,7 +3308,7 @@ spec:
             value != '1' 
         );  
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1, CIS-macos-13-6.3.4
+  tags: compliance, CIS, CIS_Level1, CIS-macos-14-6.3.4
   contributors: lucasmrod
 ---
 apiVersion: v1
@@ -3339,7 +3339,7 @@ spec:
       p.value IS NULL
     );
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1, CIS-macos-13-6.3.5-enabled, decision-needed
+  tags: compliance, CIS, CIS_Level1, CIS-macos-14-6.3.5-enabled, decision-needed
   contributors: artemist-work
 ---
 apiVersion: v1
@@ -3372,7 +3372,7 @@ spec:
       p.value IS NULL
     );
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1, CIS-macos-13-6.3.5-disabled, decision-needed
+  tags: compliance, CIS, CIS_Level1, CIS-macos-14-6.3.5-disabled, decision-needed
   contributors: artemist-work
 ---
 apiVersion: v1
@@ -3406,7 +3406,7 @@ spec:
       p.value IS NULL
     );
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1, CIS-macos-13-6.3.6
+  tags: compliance, CIS, CIS_Level1, CIS-macos-14-6.3.6
   contributors: artemist-work
 ---
 apiVersion: v1
@@ -3447,7 +3447,7 @@ spec:
             (value != 1 AND value != 'true')
         );  
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1, CIS-macos-13-6.3.7
+  tags: compliance, CIS, CIS_Level1, CIS-macos-14-6.3.7
   contributors: sharon-fdm
 ---
 apiVersion: v1
@@ -3482,5 +3482,5 @@ spec:
             (value != 1 AND value != 'true')
         );  
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1, CIS-macos-13-6.4.1
+  tags: compliance, CIS, CIS_Level1, CIS-macos-14-6.4.1
   contributors: sharon-fdm

--- a/ee/cis/macos-14/cis-policy-queries.yml
+++ b/ee/cis/macos-14/cis-policy-queries.yml
@@ -1107,7 +1107,7 @@ spec:
     /*CIS does not make a hard recommendation for this policy. Fleet has provided two policies (one failing, one succeeding). 
       Depending on your organization's decision, you can delete this policy or its counterpart.*/
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1
+  tags: compliance, CIS, CIS_Level1, decision-needed
   contributors: sharon-fdm
 ---
 apiVersion: v1

--- a/ee/cis/macos-14/cis-policy-queries.yml
+++ b/ee/cis/macos-14/cis-policy-queries.yml
@@ -1223,7 +1223,7 @@ spec:
     /*CIS does not make a hard recommendation for this policy. Fleet has provided two policies (one failing, one succeeding). 
       Depending on your organization's decision, you can delete this policy or its counterpart.*/
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1
+  tags: compliance, CIS, CIS_Level1, decision-needed
   contributors: sharon-fdm
 ---
 apiVersion: v1

--- a/ee/cis/macos-14/cis-policy-queries.yml
+++ b/ee/cis/macos-14/cis-policy-queries.yml
@@ -1596,7 +1596,7 @@ spec:
     /*CIS does not make a hard recommendation for this policy. Fleet has provided two policies (one failing, one succeeding). 
       Depending on your organization's decision, you can delete this policy or its counterpart.*/
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1
+  tags: compliance, CIS, CIS_Level1, decision-needed
   contributors: sharon-fdm
 ---
 apiVersion: v1

--- a/ee/cis/macos-14/cis-policy-queries.yml
+++ b/ee/cis/macos-14/cis-policy-queries.yml
@@ -1136,7 +1136,7 @@ spec:
     /*CIS does not make a hard recommendation for this policy. Fleet has provided two policies (one failing, one succeeding). 
       Depending on your organization's decision, you can delete this policy or its counterpart.*/
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1
+  tags: compliance, CIS, CIS_Level1, decision-needed
   contributors: sharon-fdm
 ---
 apiVersion: v1

--- a/ee/cis/macos-14/test/manual_tests/CIS_2.6.1.3
+++ b/ee/cis/macos-14/test/manual_tests/CIS_2.6.1.3
@@ -1,0 +1,21 @@
+Instructions for validating CIS 2.6.1.3
+
+
+Go to settings / Privacy & Security / Location Services
+
+Test 1: 
+    Disable the main switch for Location Services 
+result: 
+    The query should pass.
+
+Test 2: 
+    Enable the main switch for Location Services 
+    Enable only Apple TV app
+result: 
+    The query should pass.
+
+Test 3: 
+    Enable the main switch for Location Services 
+    Enable any app other than Apple TV
+result: 
+    The query should fail.    

--- a/ee/cis/macos-14/test/profiles/1.2.mobileconfig
+++ b/ee/cis/macos-14/test/profiles/1.2.mobileconfig
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>PayloadContent</key>
+	<array>
+		<dict>
+			<key>PayloadDisplayName</key>
+			<string>test</string>
+			<key>PayloadType</key>
+			<string>com.apple.SoftwareUpdate</string>
+			<key>PayloadIdentifier</key>
+			<string>com.fleetdm.cis-1.2.check</string>
+			<key>PayloadUUID</key>
+			<string>4DC539B5-837E-4DC3-B60B-43A8C556A8F0</string>
+			<key>AutomaticCheckEnabled</key>
+			<true/>
+		</dict>
+	</array>
+	<key>PayloadDescription</key>
+	<string>test</string>
+	<key>PayloadDisplayName</key>
+	<string>Ensure Auto Update Is Enabled</string>
+	<key>PayloadIdentifier</key>
+	<string>com.fleetdm.cis-1.2</string>
+	<key>PayloadRemovalDisallowed</key>
+	<false/>
+	<key>PayloadScope</key>
+	<string>System</string>
+	<key>PayloadType</key>
+	<string>Configuration</string>
+	<key>PayloadUUID</key>
+	<string>03E69A02-02CE-4CA0-8F17-3BAAD5D3852F</string>
+	<key>PayloadVersion</key>
+	<integer>1</integer>
+</dict>
+</plist>

--- a/ee/cis/macos-14/test/profiles/1.3.mobileconfig
+++ b/ee/cis/macos-14/test/profiles/1.3.mobileconfig
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>PayloadContent</key>
+	<array>
+		<dict>
+			<key>PayloadDisplayName</key>
+			<string>test</string>
+			<key>PayloadType</key>
+			<string>com.apple.SoftwareUpdate</string>
+			<key>PayloadIdentifier</key>
+			<string>com.fleetdm.cis-1.3.check</string>
+			<key>PayloadUUID</key>
+			<string>5FDE6D58-79CD-447A-AFB0-BA32D889C396</string>
+			<key>AutomaticDownload</key>
+			<true/>
+		</dict>
+	</array>
+	<key>PayloadDescription</key>
+	<string>test</string>
+	<key>PayloadDisplayName</key>
+	<string>Ensure Download New Updates When Available Is Enabled</string>
+	<key>PayloadIdentifier</key>
+	<string>com.fleetdm.cis-1.3</string>
+	<key>PayloadRemovalDisallowed</key>
+	<false/>
+	<key>PayloadScope</key>
+	<string>System</string>
+	<key>PayloadType</key>
+	<string>Configuration</string>
+	<key>PayloadUUID</key>
+	<string>0A1C2F97-D6FA-4CDB-ABB6-47DF2B151F4F</string>
+	<key>PayloadVersion</key>
+	<integer>1</integer>
+</dict>
+</plist>

--- a/ee/cis/macos-14/test/profiles/1.4.mobileconfig
+++ b/ee/cis/macos-14/test/profiles/1.4.mobileconfig
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>PayloadContent</key>
+	<array>
+		<dict>
+			<key>PayloadDisplayName</key>
+			<string>test</string>
+			<key>PayloadType</key>
+			<string>com.apple.SoftwareUpdate</string>
+			<key>PayloadIdentifier</key>
+			<string>com.fleetdm.cis-1.4.check</string>
+			<key>PayloadUUID</key>
+			<string>15BF7634-276A-411B-8C4E-52D89B4ED82C</string>
+			<key>AutomaticallyInstallMacOSUpdates</key>
+			<true/>
+		</dict>
+	</array>
+	<key>PayloadDescription</key>
+	<string>test</string>
+	<key>PayloadDisplayName</key>
+	<string>Ensure Install of macOS Updates Is Enabled</string>
+	<key>PayloadIdentifier</key>
+	<string>com.fleetdm.cis-1.4</string>
+	<key>PayloadRemovalDisallowed</key>
+	<false/>
+	<key>PayloadScope</key>
+	<string>System</string>
+	<key>PayloadType</key>
+	<string>Configuration</string>
+	<key>PayloadUUID</key>
+	<string>7DB8733E-BD11-4E88-9AE0-273EF2D0974B</string>
+	<key>PayloadVersion</key>
+	<integer>1</integer>
+</dict>
+</plist>

--- a/ee/cis/macos-14/test/profiles/1.5.mobileconfig
+++ b/ee/cis/macos-14/test/profiles/1.5.mobileconfig
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>PayloadContent</key>
+	<array>
+		<dict>
+			<key>PayloadDisplayName</key>
+			<string>test</string>
+			<key>PayloadType</key>
+			<string>com.apple.SoftwareUpdate</string>
+			<key>PayloadIdentifier</key>
+			<string>com.fleetdm.cis-1.5.check</string>
+			<key>PayloadUUID</key>
+			<string>6B0285F8-5DB8-4F68-AA6E-2333CCD6CE04</string>
+			<key>AutomaticallyInstallAppUpdates</key>
+			<true/>
+		</dict>
+	</array>
+	<key>PayloadDescription</key>
+	<string>test</string>
+	<key>PayloadDisplayName</key>
+	<string>Ensure Install Application Updates from the App Store Is Enabled</string>
+	<key>PayloadIdentifier</key>
+	<string>com.fleetdm.cis-1.5</string>
+	<key>PayloadRemovalDisallowed</key>
+	<false/>
+	<key>PayloadScope</key>
+	<string>System</string>
+	<key>PayloadType</key>
+	<string>Configuration</string>
+	<key>PayloadUUID</key>
+	<string>1C4C0EC4-64A7-4AF0-8807-A3DD44A6DC76</string>
+	<key>PayloadVersion</key>
+	<integer>1</integer>
+</dict>
+</plist>

--- a/ee/cis/macos-14/test/profiles/1.6.mobileconfig
+++ b/ee/cis/macos-14/test/profiles/1.6.mobileconfig
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>PayloadContent</key>
+	<array>
+		<dict>
+			<key>PayloadDisplayName</key>
+			<string>test</string>
+			<key>PayloadType</key>
+			<string>com.apple.SoftwareUpdate</string>
+			<key>PayloadIdentifier</key>
+			<string>com.fleetdm.cis-1.6.check</string>
+			<key>PayloadUUID</key>
+			<string>0D8F676A-A705-4F57-8FF8-3118360EFDEB</string>
+			<key>ConfigDataInstall</key>
+			<true/>
+			<key>CriticalUpdateInstall</key>
+			<true/>
+		</dict>
+	</array>
+	<key>PayloadDescription</key>
+	<string>test</string>
+	<key>PayloadDisplayName</key>
+	<string>Ensure Install Security Responses and System Files Is Enabled</string>
+	<key>PayloadIdentifier</key>
+	<string>com.fleetdm.cis-1.6</string>
+	<key>PayloadRemovalDisallowed</key>
+	<false/>
+	<key>PayloadScope</key>
+	<string>System</string>
+	<key>PayloadType</key>
+	<string>Configuration</string>
+	<key>PayloadUUID</key>
+	<string>EBEE9B81-9D33-477F-AFBE-9691360B7A74</string>
+	<key>PayloadVersion</key>
+	<integer>1</integer>
+</dict>
+</plist>

--- a/ee/cis/macos-14/test/profiles/1.7.mobileconfig
+++ b/ee/cis/macos-14/test/profiles/1.7.mobileconfig
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>PayloadContent</key>
+	<array>
+		<dict>
+			<key>PayloadDisplayName</key>
+			<string>test</string>
+			<key>PayloadType</key>
+			<string>com.apple.applicationaccess</string>
+			<key>PayloadIdentifier</key>
+			<string>com.fleetdm.cis-1.7.check</string>
+			<key>PayloadUUID</key>
+			<string>123FD592-D1C3-41FD-BC41-F91F3E1E2CF4</string>
+			<key>enforcedSoftwareUpdateDelay</key>
+			<integer>29</integer>
+		</dict>
+	</array>
+	<key>PayloadDescription</key>
+	<string>test</string>
+	<key>PayloadDisplayName</key>
+	<string>Ensure Software Update Deferment Is Less Than or Equal to 30 Days</string>
+	<key>PayloadIdentifier</key>
+	<string>com.zwass.cis-1.7</string>
+	<key>PayloadRemovalDisallowed</key>
+	<false/>
+	<key>PayloadScope</key>
+	<string>System</string>
+	<key>PayloadType</key>
+	<string>Configuration</string>
+	<key>PayloadUUID</key>
+	<string>385A0C13-2472-41B3-851C-1311FA12EB49</string>
+	<key>PayloadVersion</key>
+	<integer>1</integer>
+</dict>
+</plist>

--- a/ee/cis/macos-14/test/profiles/2.1.1.1-enable.mobileconfig
+++ b/ee/cis/macos-14/test/profiles/2.1.1.1-enable.mobileconfig
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>PayloadContent</key>
+	<array>
+		<dict>
+			<key>PayloadDisplayName</key>
+			<string>test</string>
+			<key>PayloadType</key>
+			<string>com.apple.applicationaccess</string>
+			<key>PayloadIdentifier</key>
+			<string>com.fleetdm.cis-2.1.1.1.check-enable</string>
+			<key>PayloadUUID</key>
+			<string>68D8C498-FB81-4262-9EF4-E689B5A6B40F</string>
+			<key>allowCloudKeychainSync</key>
+			<true/>
+		</dict>
+	</array>
+	<key>PayloadDescription</key>
+	<string>test</string>
+	<key>PayloadDisplayName</key>
+	<string>Ensure iCloud Keychain is enabled</string>
+	<key>PayloadIdentifier</key>
+	<string>com.fleetdm.cis-2.1.1.1-enable</string>
+	<key>PayloadRemovalDisallowed</key>
+	<false/>
+	<key>PayloadScope</key>
+	<string>System</string>
+	<key>PayloadType</key>
+	<string>Configuration</string>
+	<key>PayloadUUID</key>
+	<string>EE1BA83A-E145-4F5B-9597-836DC357BBE7</string>
+	<key>PayloadVersion</key>
+	<integer>1</integer>
+</dict>
+</plist>

--- a/ee/cis/macos-14/test/profiles/2.1.1.2-disable.mobileconfig
+++ b/ee/cis/macos-14/test/profiles/2.1.1.2-disable.mobileconfig
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>PayloadContent</key>
+	<array>
+		<dict>
+			<key>PayloadDisplayName</key>
+			<string>test</string>
+			<key>PayloadType</key>
+			<string>com.apple.applicationaccess</string>
+			<key>PayloadIdentifier</key>
+			<string>com.fleetdm.cis-2.1.1.2.check-disable</string>
+			<key>PayloadUUID</key>
+			<string>1028E002-9AFE-446A-84E0-27DA5DA39B4A</string>
+			<key>allowCloudDocumentSync</key>
+			<false/>
+		</dict>
+	</array>
+	<key>PayloadDescription</key>
+	<string>test</string>
+	<key>PayloadDisplayName</key>
+	<string>Disable iCloud Drive storage solution usage</string>
+	<key>PayloadIdentifier</key>
+	<string>com.fleetdm.cis-2.1.1.2-disable</string>
+	<key>PayloadRemovalDisallowed</key>
+	<false/>
+	<key>PayloadScope</key>
+	<string>System</string>
+	<key>PayloadType</key>
+	<string>Configuration</string>
+	<key>PayloadUUID</key>
+	<string>7B3DE4EA-0AFA-44F5-9716-37526EE441EA</string>
+	<key>PayloadVersion</key>
+	<integer>1</integer>
+</dict>
+</plist>

--- a/ee/cis/macos-14/test/profiles/2.1.1.2-enable.mobileconfig
+++ b/ee/cis/macos-14/test/profiles/2.1.1.2-enable.mobileconfig
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>PayloadContent</key>
+	<array>
+		<dict>
+			<key>PayloadDisplayName</key>
+			<string>test</string>
+			<key>PayloadType</key>
+			<string>com.apple.applicationaccess</string>
+			<key>PayloadIdentifier</key>
+			<string>com.fleetdm.cis-2.1.1.2.check-enable</string>
+			<key>PayloadUUID</key>
+			<string>8618AA0E-B6AC-4D1C-AE01-C46956EC1926</string>
+			<key>allowCloudDocumentSync</key>
+			<true/>
+		</dict>
+	</array>
+	<key>PayloadDescription</key>
+	<string>test</string>
+	<key>PayloadDisplayName</key>
+	<string>Enable iCloud Drive storage solution usage</string>
+	<key>PayloadIdentifier</key>
+	<string>com.fleetdm.cis-2.1.1.2-enable</string>
+	<key>PayloadRemovalDisallowed</key>
+	<false/>
+	<key>PayloadScope</key>
+	<string>System</string>
+	<key>PayloadType</key>
+	<string>Configuration</string>
+	<key>PayloadUUID</key>
+	<string>2C2FC587-14E8-4A52-98B5-30BA1C975BBA</string>
+	<key>PayloadVersion</key>
+	<integer>1</integer>
+</dict>
+</plist>

--- a/ee/cis/macos-14/test/profiles/2.1.1.3.mobileconfig
+++ b/ee/cis/macos-14/test/profiles/2.1.1.3.mobileconfig
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>PayloadContent</key>
+	<array>
+		<dict>
+			<key>PayloadDisplayName</key>
+			<string>test</string>
+			<key>PayloadType</key>
+			<string>com.apple.applicationaccess</string>
+			<key>PayloadIdentifier</key>
+			<string>com.fleetdm.cis-2.1.1.3.check</string>
+			<key>PayloadUUID</key>
+			<string>5F0EF767-200C-4E10-A43D-04204A4A8E06</string>
+			<key>allowCloudDesktopAndDocuments</key>
+			<false/>
+		</dict>
+	</array>
+	<key>PayloadDescription</key>
+	<string>test</string>
+	<key>PayloadDisplayName</key>
+	<string>Ensure iCloud Drive Document and Desktop Sync Is Disabled</string>
+	<key>PayloadIdentifier</key>
+	<string>com.fleetdm.cis-2.1.1.3</string>
+	<key>PayloadRemovalDisallowed</key>
+	<false/>
+	<key>PayloadScope</key>
+	<string>System</string>
+	<key>PayloadType</key>
+	<string>Configuration</string>
+	<key>PayloadUUID</key>
+	<string>2EAF168E-3DC9-4375-AA37-501EDB3C8422</string>
+	<key>PayloadVersion</key>
+	<integer>1</integer>
+</dict>
+</plist>

--- a/ee/cis/macos-14/test/profiles/2.10.3.mobileconfig
+++ b/ee/cis/macos-14/test/profiles/2.10.3.mobileconfig
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>PayloadContent</key>
+	<array>
+		<dict>
+			<key>PayloadDisplayName</key>
+			<string>test</string>
+			<key>PayloadType</key>
+			<string>com.apple.loginwindow</string>
+			<key>PayloadIdentifier</key>
+			<string>com.fleetdm.cis-2.10.3.check</string>
+			<key>PayloadUUID</key>
+			<string>3E4C4ED8-ADB6-4EFB-8198-58027B94DF86</string>
+			<key>LoginwindowText</key>
+			<string>Some Test Message</string>
+		</dict>
+	</array>
+	<key>PayloadDescription</key>
+	<string>test</string>
+	<key>PayloadDisplayName</key>
+	<string>Ensure a Custom Message for the Login Screen Is Enabled</string>
+	<key>PayloadIdentifier</key>
+	<string>com.fleetdm.cis-2.10.3</string>
+	<key>PayloadRemovalDisallowed</key>
+	<false/>
+	<key>PayloadScope</key>
+	<string>System</string>
+	<key>PayloadType</key>
+	<string>Configuration</string>
+	<key>PayloadUUID</key>
+	<string>9359CA59-D3C1-4A0D-8595-9E5F1F0CAE12</string>
+	<key>PayloadVersion</key>
+	<integer>1</integer>
+</dict>
+</plist>

--- a/ee/cis/macos-14/test/profiles/2.12.3.mobileconfig
+++ b/ee/cis/macos-14/test/profiles/2.12.3.mobileconfig
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>PayloadContent</key>
+	<array>
+		<dict>
+			<key>PayloadDisplayName</key>
+			<string>test</string>
+			<key>PayloadType</key>
+			<string>com.apple.loginwindow</string>
+			<key>PayloadIdentifier</key>
+			<string>com.fleetdm.cis-2.12.3.check</string>
+			<key>PayloadUUID</key>
+			<string>CB576629-19E2-4649-84FC-C007826732A0</string>
+			<key>com.apple.login.mcx.DisableAutoLoginClient</key>
+			<true/>
+		</dict>
+	</array>
+	<key>PayloadDescription</key>
+	<string>test</string>
+	<key>PayloadDisplayName</key>
+	<string>Ensure Automatic Login Is Disabled</string>
+	<key>PayloadIdentifier</key>
+	<string>com.fleetdm.cis-2.12.3</string>
+	<key>PayloadRemovalDisallowed</key>
+	<false/>
+	<key>PayloadScope</key>
+	<string>System</string>
+	<key>PayloadType</key>
+	<string>Configuration</string>
+	<key>PayloadUUID</key>
+	<string>0AEDE730-9466-47D1-B322-3C6F325B3737</string>
+	<key>PayloadVersion</key>
+	<integer>1</integer>
+</dict>
+</plist>

--- a/ee/cis/macos-14/test/profiles/2.2.1.mobileconfig
+++ b/ee/cis/macos-14/test/profiles/2.2.1.mobileconfig
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>PayloadContent</key>
+	<array>
+		<dict>
+			<key>PayloadDisplayName</key>
+			<string>test</string>
+			<key>PayloadType</key>
+			<string>com.apple.security.firewall</string>
+			<key>PayloadIdentifier</key>
+			<string>com.fleetdm.cis-2.2.1.check</string>
+			<key>PayloadUUID</key>
+			<string>D12965C1-12BD-4CAD-A55A-E7F020B0DAAF</string>
+			<key>EnableFirewall</key>
+			<true/>
+		</dict>
+	</array>
+	<key>PayloadDescription</key>
+	<string>test</string>
+	<key>PayloadDisplayName</key>
+	<string>Ensure Firewall Is Enabled</string>
+	<key>PayloadIdentifier</key>
+	<string>com.fleetdm.cis-2.2.1</string>
+	<key>PayloadRemovalDisallowed</key>
+	<false/>
+	<key>PayloadScope</key>
+	<string>System</string>
+	<key>PayloadType</key>
+	<string>Configuration</string>
+	<key>PayloadUUID</key>
+	<string>F0BFF592-1CB7-4922-B2D4-583415DC4A0B</string>
+	<key>PayloadVersion</key>
+	<integer>1</integer>
+</dict>
+</plist>

--- a/ee/cis/macos-14/test/profiles/2.2.2.mobileconfig
+++ b/ee/cis/macos-14/test/profiles/2.2.2.mobileconfig
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>PayloadContent</key>
+	<array>
+		<dict>
+			<key>PayloadDisplayName</key>
+			<string>test</string>
+			<key>PayloadType</key>
+			<string>com.apple.security.firewall</string>
+			<key>PayloadIdentifier</key>
+			<string>com.fleetdm.cis-2.2.2.check</string>
+			<key>PayloadUUID</key>
+			<string>2D2A07FB-3700-4ED8-AF06-6A2213F4C634</string>
+			<key>EnableFirewall</key>
+			<true/>
+			<key>EnableStealthMode</key>
+			<true/>
+		</dict>
+	</array>
+	<key>PayloadDescription</key>
+	<string>test</string>
+	<key>PayloadDisplayName</key>
+	<string>Ensure Firewall Stealth Mode Is Enabled</string>
+	<key>PayloadIdentifier</key>
+	<string>com.fleetdm.cis-2.2.2</string>
+	<key>PayloadRemovalDisallowed</key>
+	<false/>
+	<key>PayloadScope</key>
+	<string>System</string>
+	<key>PayloadType</key>
+	<string>Configuration</string>
+	<key>PayloadUUID</key>
+	<string>E0B831D6-F214-4F1F-967C-B75B38B26708</string>
+	<key>PayloadVersion</key>
+	<integer>1</integer>
+</dict>
+</plist>

--- a/ee/cis/macos-14/test/profiles/2.3.1.1.mobileconfig
+++ b/ee/cis/macos-14/test/profiles/2.3.1.1.mobileconfig
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>PayloadContent</key>
+	<array>
+		<dict>
+			<key>PayloadDisplayName</key>
+			<string>test</string>
+			<key>PayloadType</key>
+			<string>com.apple.applicationaccess</string>
+			<key>PayloadIdentifier</key>
+			<string>com.fleetdm.cis-2.3.1.1.check</string>
+			<key>PayloadUUID</key>
+			<string>22F2E52E-E593-40F7-8635-E067EDEE4F60</string>
+			<key>allowAirDrop</key>
+			<false/>
+		</dict>
+	</array>
+	<key>PayloadDescription</key>
+	<string>test</string>
+	<key>PayloadDisplayName</key>
+	<string>Ensure AirDrop Is Disabled</string>
+	<key>PayloadIdentifier</key>
+	<string>com.fleetdm.cis-2.3.1.1</string>
+	<key>PayloadRemovalDisallowed</key>
+	<false/>
+	<key>PayloadScope</key>
+	<string>System</string>
+	<key>PayloadType</key>
+	<string>Configuration</string>
+	<key>PayloadUUID</key>
+	<string>55DC048E-1490-4A26-8A97-4A4EA91A7302</string>
+	<key>PayloadVersion</key>
+	<integer>1</integer>
+</dict>
+</plist>

--- a/ee/cis/macos-14/test/profiles/2.3.1.2.mobileconfig
+++ b/ee/cis/macos-14/test/profiles/2.3.1.2.mobileconfig
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>PayloadContent</key>
+	<array>
+		<dict>
+			<key>PayloadDisplayName</key>
+			<string>test</string>
+			<key>PayloadType</key>
+			<string>com.apple.applicationaccess</string>
+			<key>PayloadIdentifier</key>
+			<string>com.fleetdm.cis-2.3.1.2.check</string>
+			<key>PayloadUUID</key>
+			<string>BF58FD50-E4EC-4427-A549-1BCD7B88FCEB</string>
+			<key>allowAirPlayIncomingRequests</key>
+			<false/>
+		</dict>
+	</array>
+	<key>PayloadDescription</key>
+	<string>test</string>
+	<key>PayloadDisplayName</key>
+	<string>Ensure AirPlay Receiver Is Disabled</string>
+	<key>PayloadIdentifier</key>
+	<string>com.fleetdm.cis-2.3.1.2</string>
+	<key>PayloadRemovalDisallowed</key>
+	<false/>
+	<key>PayloadScope</key>
+	<string>System</string>
+	<key>PayloadType</key>
+	<string>Configuration</string>
+	<key>PayloadUUID</key>
+	<string>633BD4E3-849E-485E-A784-AA80D86E83A3</string>
+	<key>PayloadVersion</key>
+	<integer>1</integer>
+</dict>
+</plist>

--- a/ee/cis/macos-14/test/profiles/2.3.2.1.mobileconfig
+++ b/ee/cis/macos-14/test/profiles/2.3.2.1.mobileconfig
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>PayloadContent</key>
+	<array>
+		<dict>
+			<key>PayloadDisplayName</key>
+			<string>test</string>
+			<key>PayloadType</key>
+			<string>com.apple.applicationaccess</string>
+			<key>PayloadIdentifier</key>
+			<string>com.fleetdm.cis-2.3.2.1.check</string>
+			<key>PayloadUUID</key>
+			<string>C5CFF95F-7E77-4B0E-8136-2729A481D60A</string>
+			<key>forceAutomaticDateAndTime</key>
+			<true/>
+		</dict>
+	</array>
+	<key>PayloadDescription</key>
+	<string>test</string>
+	<key>PayloadDisplayName</key>
+	<string>Ensure Set Time and Date Automatically Is Enabled</string>
+	<key>PayloadIdentifier</key>
+	<string>com.fleetdm.cis-2.3.2.1</string>
+	<key>PayloadRemovalDisallowed</key>
+	<false/>
+	<key>PayloadScope</key>
+	<string>System</string>
+	<key>PayloadType</key>
+	<string>Configuration</string>
+	<key>PayloadUUID</key>
+	<string>CEA7E3A6-E5DF-4A93-ABB7-45F36BF3D3E8</string>
+	<key>PayloadVersion</key>
+	<integer>1</integer>
+</dict>
+</plist>

--- a/ee/cis/macos-14/test/profiles/2.3.3.10.mobileconfig
+++ b/ee/cis/macos-14/test/profiles/2.3.3.10.mobileconfig
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>PayloadContent</key>
+	<array>
+		<dict>
+			<key>PayloadDisplayName</key>
+			<string>test</string>
+			<key>PayloadType</key>
+			<string>com.apple.preferences.sharing.SharingPrefsExtension</string>
+			<key>PayloadIdentifier</key>
+			<string>com.fleetdm.cis-2.3.3.10-check</string>
+			<key>PayloadUUID</key>
+			<string>DC34D1FA-3D14-4AEA-844B-FDEC49CD73BB</string>
+			<key>homeSharingUIStatus</key>
+			<integer>0</integer>
+			<key>legacySharingUIStatus</key>
+			<integer>0</integer>
+			<key>mediaSharingUIStatus</key>
+			<integer>0</integer>
+		</dict>
+	</array>
+	<key>PayloadDescription</key>
+	<string>test</string>
+	<key>PayloadDisplayName</key>
+	<string>Ensure Media Sharing is Disabled</string>
+	<key>PayloadIdentifier</key>
+	<string>com.fleetdm.cis-2.3.3.10</string>
+	<key>PayloadRemovalDisallowed</key>
+	<false/>
+	<key>PayloadScope</key>
+	<string>System</string>
+	<key>PayloadType</key>
+	<string>Configuration</string>
+	<key>PayloadUUID</key>
+	<string>9FD8A0FB-2F7C-41C4-A3FB-90E953BCD433</string>
+	<key>PayloadVersion</key>
+	<integer>1</integer>
+</dict>
+</plist>

--- a/ee/cis/macos-14/test/profiles/2.3.3.9.mobileconfig
+++ b/ee/cis/macos-14/test/profiles/2.3.3.9.mobileconfig
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>PayloadContent</key>
+	<array>
+		<dict>
+			<key>PayloadDisplayName</key>
+			<string>test</string>
+			<key>PayloadType</key>
+			<string>com.apple.applicationaccess</string>
+			<key>PayloadIdentifier</key>
+			<string>com.fleetdm.cis-2.3.3.9.check</string>
+			<key>PayloadUUID</key>
+			<string>85956359-CF0A-46C8-BD7C-26060ABB9119</string>
+			<key>allowContentCaching</key>
+			<false/>
+		</dict>
+	</array>
+	<key>PayloadDescription</key>
+	<string>test</string>
+	<key>PayloadDisplayName</key>
+	<string>Ensure Content Caching Is Disabled</string>
+	<key>PayloadIdentifier</key>
+	<string>com.fleetdm.cis-2.3.3.9</string>
+	<key>PayloadRemovalDisallowed</key>
+	<false/>
+	<key>PayloadScope</key>
+	<string>System</string>
+	<key>PayloadType</key>
+	<string>Configuration</string>
+	<key>PayloadUUID</key>
+	<string>AA4372B4-5D36-4660-A2FC-07067C94A91F</string>
+	<key>PayloadVersion</key>
+	<integer>1</integer>
+</dict>
+</plist>

--- a/ee/cis/macos-14/test/profiles/2.4.1.mobileconfig
+++ b/ee/cis/macos-14/test/profiles/2.4.1.mobileconfig
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>PayloadContent</key>
+	<array>
+		<dict>
+			<key>PayloadDisplayName</key>
+			<string>test</string>
+			<key>PayloadType</key>
+			<string>com.apple.controlcenter</string>
+			<key>PayloadIdentifier</key>
+			<string>com.fleetdm.cis-2.4.1.check</string>
+			<key>PayloadUUID</key>
+			<string>B97CBDF6-1EB7-424C-86DE-E11892B223F3</string>
+			<key>WiFi</key>
+			<integer>18</integer>
+		</dict>
+	</array>
+	<key>PayloadDescription</key>
+	<string>test</string>
+	<key>PayloadDisplayName</key>
+	<string>Ensure Show Wi-Fi status in Menu Bar Is Enabled</string>
+	<key>PayloadIdentifier</key>
+	<string>com.fleetdm.cis-2.4.1</string>
+	<key>PayloadRemovalDisallowed</key>
+	<false/>
+	<key>PayloadScope</key>
+	<string>System</string>
+	<key>PayloadType</key>
+	<string>Configuration</string>
+	<key>PayloadUUID</key>
+	<string>2357BB9E-FD15-4E1D-A1CC-12C7798E1483</string>
+	<key>PayloadVersion</key>
+	<integer>1</integer>
+</dict>
+</plist>

--- a/ee/cis/macos-14/test/profiles/2.4.2.mobileconfig
+++ b/ee/cis/macos-14/test/profiles/2.4.2.mobileconfig
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>PayloadContent</key>
+	<array>
+		<dict>
+			<key>PayloadDisplayName</key>
+			<string>test</string>
+			<key>PayloadType</key>
+			<string>com.apple.controlcenter</string>
+			<key>PayloadIdentifier</key>
+			<string>com.fleetdm.cis-2.4.2.check</string>
+			<key>PayloadUUID</key>
+			<string>FC6045C3-FFD7-4C0A-A3D5-ED0ADB9FF391</string>
+			<key>Bluetooth</key>
+			<integer>18</integer>
+		</dict>
+	</array>
+	<key>PayloadDescription</key>
+	<string>test</string>
+	<key>PayloadDisplayName</key>
+	<string>Ensure Show Bluetooth Status in Menu Bar Is Enabled</string>
+	<key>PayloadIdentifier</key>
+	<string>com.fleetdm.cis-2.4.2</string>
+	<key>PayloadRemovalDisallowed</key>
+	<false/>
+	<key>PayloadScope</key>
+	<string>System</string>
+	<key>PayloadType</key>
+	<string>Configuration</string>
+	<key>PayloadUUID</key>
+	<string>F997FFD6-7E39-48C7-A451-B12A79B6FA22</string>
+	<key>PayloadVersion</key>
+	<integer>1</integer>
+</dict>
+</plist>

--- a/ee/cis/macos-14/test/profiles/2.5.1-disable.mobileconfig
+++ b/ee/cis/macos-14/test/profiles/2.5.1-disable.mobileconfig
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>PayloadContent</key>
+	<array>
+		<dict>
+			<key>PayloadDisplayName</key>
+			<string>test</string>
+			<key>PayloadType</key>
+			<string>com.apple.applicationaccess</string>
+			<key>PayloadIdentifier</key>
+			<string>com.fleetdm.cis-2.5.1.check-disable</string>
+			<key>PayloadUUID</key>
+			<string>4B56DF79-ECAF-4175-AACC-95F08A980B6C</string>
+			<key>allowAssistant</key>
+			<false/>
+		</dict>
+	</array>
+	<key>PayloadDescription</key>
+	<string>test</string>
+	<key>PayloadDisplayName</key>
+	<string>Disable Siri</string>
+	<key>PayloadIdentifier</key>
+	<string>com.fleetdm.cis-2.5.1-disable</string>
+	<key>PayloadRemovalDisallowed</key>
+	<false/>
+	<key>PayloadScope</key>
+	<string>System</string>
+	<key>PayloadType</key>
+	<string>Configuration</string>
+	<key>PayloadUUID</key>
+	<string>FB3E1980-5FE2-4C8F-BCF8-6FFF4117C962</string>
+	<key>PayloadVersion</key>
+	<integer>1</integer>
+</dict>
+</plist>

--- a/ee/cis/macos-14/test/profiles/2.5.1-enable.mobileconfig
+++ b/ee/cis/macos-14/test/profiles/2.5.1-enable.mobileconfig
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>PayloadContent</key>
+	<array>
+		<dict>
+			<key>PayloadDisplayName</key>
+			<string>test</string>
+			<key>PayloadType</key>
+			<string>com.apple.applicationaccess</string>
+			<key>PayloadIdentifier</key>
+			<string>com.fleetdm.cis-2.5.1.check-enable</string>
+			<key>PayloadUUID</key>
+			<string>DC0652C5-E996-408F-84A0-9F09657FD771</string>
+			<key>allowAssistant</key>
+			<true/>
+		</dict>
+	</array>
+	<key>PayloadDescription</key>
+	<string>test</string>
+	<key>PayloadDisplayName</key>
+	<string>Enable Siri</string>
+	<key>PayloadIdentifier</key>
+	<string>com.fleetdm.cis-2.5.1-enable</string>
+	<key>PayloadRemovalDisallowed</key>
+	<false/>
+	<key>PayloadScope</key>
+	<string>System</string>
+	<key>PayloadType</key>
+	<string>Configuration</string>
+	<key>PayloadUUID</key>
+	<string>F5001E34-CC4D-4951-A7A3-A95DC02F0090</string>
+	<key>PayloadVersion</key>
+	<integer>1</integer>
+</dict>
+</plist>

--- a/ee/cis/macos-14/test/profiles/2.6.1.1.mobileconfig
+++ b/ee/cis/macos-14/test/profiles/2.6.1.1.mobileconfig
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>PayloadContent</key>
+	<array>
+		<dict>
+			<key>PayloadDisplayName</key>
+			<string>test</string>
+			<key>PayloadType</key>
+			<string>com.apple.locationd</string>
+			<key>PayloadIdentifier</key>
+			<string>com.fleetdm.cis-2.6.1.1.check</string>
+			<key>PayloadUUID</key>
+			<string>25D6B210-E8BB-465F-94D7-474073F4A892</string>
+			<key>LocationServicesEnabled</key>
+			<true/>
+		</dict>
+	</array>
+	<key>PayloadDescription</key>
+	<string>test</string>
+	<key>PayloadDisplayName</key>
+	<string>Ensure Location Services Is Enabled</string>
+	<key>PayloadIdentifier</key>
+	<string>com.fleetdm.cis-2.6.1.1</string>
+	<key>PayloadRemovalDisallowed</key>
+	<false/>
+	<key>PayloadScope</key>
+	<string>System</string>
+	<key>PayloadType</key>
+	<string>Configuration</string>
+	<key>PayloadUUID</key>
+	<string>8FC698D7-9EF8-427E-8E52-4B928A7437B0</string>
+	<key>PayloadVersion</key>
+	<integer>1</integer>
+</dict>
+</plist>

--- a/ee/cis/macos-14/test/profiles/2.6.2-part1.mobileconfig
+++ b/ee/cis/macos-14/test/profiles/2.6.2-part1.mobileconfig
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>PayloadContent</key>
+	<array>
+		<dict>
+			<key>PayloadDisplayName</key>
+			<string>test</string>
+			<key>PayloadType</key>
+			<string>com.apple.applicationaccess</string>
+			<key>PayloadIdentifier</key>
+			<string>com.fleetdm.cis-2.6.2-part1.check</string>
+			<key>PayloadUUID</key>
+			<string>9A6BF497-B715-453A-A7F7-D27C325EB5B3</string>
+			<key>allowDiagnosticSubmission</key>
+			<false/>
+		</dict>
+	</array>
+	<key>PayloadDescription</key>
+	<string>test</string>
+	<key>PayloadDisplayName</key>
+	<string>Ensure Ensure Sending Diagnostic and Usage Data to Apple Is Disabled(part 1)</string>
+	<key>PayloadIdentifier</key>
+	<string>com.fleetdm.cis-2.6.2-part1</string>
+	<key>PayloadRemovalDisallowed</key>
+	<false/>
+	<key>PayloadScope</key>
+	<string>System</string>
+	<key>PayloadType</key>
+	<string>Configuration</string>
+	<key>PayloadUUID</key>
+	<string>7D03459B-AA53-41AB-85C4-AAED7CE95EE9</string>
+	<key>PayloadVersion</key>
+	<integer>1</integer>
+</dict>
+</plist>

--- a/ee/cis/macos-14/test/profiles/2.6.2-part2.mobileconfig
+++ b/ee/cis/macos-14/test/profiles/2.6.2-part2.mobileconfig
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>PayloadContent</key>
+	<array>
+		<dict>
+			<key>PayloadDisplayName</key>
+			<string>test</string>
+			<key>PayloadType</key>
+			<string>com.apple.SubmitDiagInfo</string>
+			<key>PayloadIdentifier</key>
+			<string>com.fleetdm.cis-2.6.2-part2.check</string>
+			<key>PayloadUUID</key>
+			<string>756EF527-5F37-4685-9A0F-21B596D1F895</string>
+			<key>AutoSubmit</key>
+			<false/>
+		</dict>
+	</array>
+	<key>PayloadDescription</key>
+	<string>test</string>
+	<key>PayloadDisplayName</key>
+	<string>Ensure Sending Diagnostic and Usage Data to Apple Is Disabled(part 2)</string>
+	<key>PayloadIdentifier</key>
+	<string>com.fleetdm.cis-2.6.2-part2</string>
+	<key>PayloadRemovalDisallowed</key>
+	<false/>
+	<key>PayloadScope</key>
+	<string>System</string>
+	<key>PayloadType</key>
+	<string>Configuration</string>
+	<key>PayloadUUID</key>
+	<string>C720744B-BBF2-4FE2-B8A9-4638CECC8BB2</string>
+	<key>PayloadVersion</key>
+	<integer>1</integer>
+</dict>
+</plist>

--- a/ee/cis/macos-14/test/profiles/2.6.2-part3.mobileconfig
+++ b/ee/cis/macos-14/test/profiles/2.6.2-part3.mobileconfig
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>PayloadContent</key>
+	<array>
+		<dict>
+			<key>PayloadDisplayName</key>
+			<string>test</string>
+			<key>PayloadType</key>
+			<string>com.apple.applicationaccess</string>
+			<key>PayloadIdentifier</key>
+			<string>com.fleetdm.cis-2.6.2-part3.check</string>
+			<key>PayloadUUID</key>
+			<string>0FD378F2-B497-42D9-AEAE-C58D855E56FD</string>
+			<key>Siri Data Sharing Opt-In Status</key>
+			<integer>2</integer>
+		</dict>
+	</array>
+	<key>PayloadDescription</key>
+	<string>test</string>
+	<key>PayloadDisplayName</key>
+	<string>Ensure Ensure Sending Diagnostic and Usage Data to Apple Is Disabled(part 3)</string>
+	<key>PayloadIdentifier</key>
+	<string>com.fleetdm.cis-2.6.2-part3</string>
+	<key>PayloadRemovalDisallowed</key>
+	<false/>
+	<key>PayloadScope</key>
+	<string>System</string>
+	<key>PayloadType</key>
+	<string>Configuration</string>
+	<key>PayloadUUID</key>
+	<string>49A101C5-3401-47E7-90AF-9071D4D65E5D</string>
+	<key>PayloadVersion</key>
+	<integer>1</integer>
+</dict>
+</plist>

--- a/ee/cis/macos-14/test/profiles/2.6.3.mobileconfig
+++ b/ee/cis/macos-14/test/profiles/2.6.3.mobileconfig
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>PayloadContent</key>
+	<array>
+		<dict>
+			<key>PayloadDisplayName</key>
+			<string>test</string>
+			<key>PayloadType</key>
+			<string>com.apple.applicationaccess</string>
+			<key>PayloadIdentifier</key>
+			<string>com.fleetdm.cis-2.6.3.check</string>
+			<key>PayloadUUID</key>
+			<string>6C5400FF-BBB3-471F-B139-59D86ADA9A3A</string>
+			<key>allowApplePersonalizedAdvertising</key>
+			<false/>
+		</dict>
+	</array>
+	<key>PayloadDescription</key>
+	<string>test</string>
+	<key>PayloadDisplayName</key>
+	<string>Ensure Limit Ad Tracking Is Enabled</string>
+	<key>PayloadIdentifier</key>
+	<string>com.fleetdm.cis-2.6.3</string>
+	<key>PayloadRemovalDisallowed</key>
+	<false/>
+	<key>PayloadScope</key>
+	<string>System</string>
+	<key>PayloadType</key>
+	<string>Configuration</string>
+	<key>PayloadUUID</key>
+	<string>C215AA26-C3D0-4A77-B884-8B8C918FD197</string>
+	<key>PayloadVersion</key>
+	<integer>1</integer>
+</dict>
+</plist>

--- a/ee/cis/macos-14/test/profiles/2.6.4.mobileconfig
+++ b/ee/cis/macos-14/test/profiles/2.6.4.mobileconfig
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>PayloadContent</key>
+	<array>
+		<dict>
+			<key>PayloadDisplayName</key>
+			<string>test</string>
+			<key>PayloadType</key>
+			<string>com.apple.systempolicy.control</string>
+			<key>PayloadIdentifier</key>
+			<string>com.fleetdm.cis-2.6.4.check</string>
+			<key>PayloadUUID</key>
+			<string>D9E7B5EA-8DA3-4AF1-99CD-30ED18EF47F1</string>
+			<key>EnableAssessment</key>
+			<true/>
+			<key>AllowIdentifiedDevelopers</key>
+			<true/>
+		</dict>
+	</array>
+	<key>PayloadDescription</key>
+	<string>test</string>
+	<key>PayloadDisplayName</key>
+	<string>Ensure Gatekeeper Is Enabled</string>
+	<key>PayloadIdentifier</key>
+	<string>com.fleetdm.cis-2.6.4</string>
+	<key>PayloadRemovalDisallowed</key>
+	<false/>
+	<key>PayloadScope</key>
+	<string>System</string>
+	<key>PayloadType</key>
+	<string>Configuration</string>
+	<key>PayloadUUID</key>
+	<string>1991574F-155E-4FC1-AD47-FDC4DC3B07B4</string>
+	<key>PayloadVersion</key>
+	<integer>1</integer>
+</dict>
+</plist>

--- a/ee/cis/macos-14/test/profiles/2.6.5.mobileconfig
+++ b/ee/cis/macos-14/test/profiles/2.6.5.mobileconfig
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>PayloadContent</key>
+	<array>
+		<dict>
+			<key>PayloadDisplayName</key>
+			<string>test</string>
+			<key>PayloadType</key>
+			<string>com.apple.MCX</string>
+			<key>PayloadIdentifier</key>
+			<string>com.fleetdm.cis-2.6.5.check</string>
+			<key>PayloadUUID</key>
+			<string>D56F90DC-6F90-4BEB-8D0F-263D062EC612</string>
+			<key>dontAllowFDEDisable</key>
+			<true/>
+		</dict>
+	</array>
+	<key>PayloadDescription</key>
+	<string>test</string>
+	<key>PayloadDisplayName</key>
+	<string>Ensure FileVault Is Enabled</string>
+	<key>PayloadIdentifier</key>
+	<string>com.fleetdm.cis-2.6.5</string>
+	<key>PayloadRemovalDisallowed</key>
+	<false/>
+	<key>PayloadScope</key>
+	<string>System</string>
+	<key>PayloadType</key>
+	<string>Configuration</string>
+	<key>PayloadUUID</key>
+	<string>804CCF1F-2814-4B73-95EE-DB0B4FF67103</string>
+	<key>PayloadVersion</key>
+	<integer>1</integer>
+</dict>
+</plist>

--- a/ee/cis/macos-14/test/profiles/2.8.1.disable.mobileconfig
+++ b/ee/cis/macos-14/test/profiles/2.8.1.disable.mobileconfig
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>PayloadContent</key>
+	<array>
+		<dict>
+			<key>PayloadDisplayName</key>
+			<string>test</string>
+			<key>PayloadType</key>
+			<string>com.apple.universalcontrol</string>
+			<key>PayloadIdentifier</key>
+			<string>com.fleetdm.cis-2.8.1.check-disabled</string>
+			<key>PayloadUUID</key>
+			<string>A6481AEB-354C-4718-9E01-B4562C7F341A</string>
+			<key>Disable</key>
+			<true/>
+		</dict>
+	</array>
+	<key>PayloadDescription</key>
+	<string>test</string>
+	<key>PayloadDisplayName</key>
+	<string>Ensure Universal Control is disabled</string>
+	<key>PayloadIdentifier</key>
+	<string>com.fleetdm.cis-2.8.1-disabled</string>
+	<key>PayloadRemovalDisallowed</key>
+	<false/>
+	<key>PayloadScope</key>
+	<string>System</string>
+	<key>PayloadType</key>
+	<string>Configuration</string>
+	<key>PayloadUUID</key>
+	<string>8EA6B5B4-A0EF-49B3-8A6E-C8F02C27456B</string>
+	<key>PayloadVersion</key>
+	<integer>1</integer>
+</dict>
+</plist>

--- a/ee/cis/macos-14/test/profiles/2.8.1.enable.mobileconfig
+++ b/ee/cis/macos-14/test/profiles/2.8.1.enable.mobileconfig
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>PayloadContent</key>
+	<array>
+		<dict>
+			<key>PayloadDisplayName</key>
+			<string>test</string>
+			<key>PayloadType</key>
+			<string>com.apple.universalcontrol</string>
+			<key>PayloadIdentifier</key>
+			<string>com.fleetdm.cis-2.8.1.check-enabled</string>
+			<key>PayloadUUID</key>
+			<string>F39058CB-027B-453D-B2DF-414F9B84D241</string>
+			<key>Disable</key>
+			<false/>
+		</dict>
+	</array>
+	<key>PayloadDescription</key>
+	<string>test</string>
+	<key>PayloadDisplayName</key>
+	<string>Ensure Universal Control is enabled</string>
+	<key>PayloadIdentifier</key>
+	<string>com.fleetdm.cis-2.8.1-enabled</string>
+	<key>PayloadRemovalDisallowed</key>
+	<false/>
+	<key>PayloadScope</key>
+	<string>System</string>
+	<key>PayloadType</key>
+	<string>Configuration</string>
+	<key>PayloadUUID</key>
+	<string>ECC41516-FFD8-4321-9696-63B1939CB956</string>
+	<key>PayloadVersion</key>
+	<integer>1</integer>
+</dict>
+</plist>

--- a/ee/cis/macos-14/test/profiles/3.6.mobileconfig
+++ b/ee/cis/macos-14/test/profiles/3.6.mobileconfig
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>PayloadContent</key>
+	<array>
+		<dict>
+			<key>PayloadDisplayName</key>
+			<string>test</string>
+			<key>PayloadType</key>
+			<string>com.apple.security.firewall</string>
+			<key>PayloadIdentifier</key>
+			<string>com.fleetdm.cis-3.6.check</string>
+			<key>PayloadUUID</key>
+			<string>604D8218-D7B6-43B1-95E6-DFCA4C25D73D</string>
+			<key>EnableFirewall</key>
+			<true/>
+			<key>EnableLogging</key>
+			<true/>
+			<key>LoggingOption</key>
+			<string>detail</string>
+		</dict>
+	</array>
+	<key>PayloadDescription</key>
+	<string>test</string>
+	<key>PayloadDisplayName</key>
+	<string>Ensure Firewall Logging Is Enabled and Configured</string>
+	<key>PayloadIdentifier</key>
+	<string>com.fleetdm.cis-3.6</string>
+	<key>PayloadRemovalDisallowed</key>
+	<false/>
+	<key>PayloadScope</key>
+	<string>System</string>
+	<key>PayloadType</key>
+	<string>Configuration</string>
+	<key>PayloadUUID</key>
+	<string>5E27501E-50DF-4804-9DEC-0E63C34E8831</string>
+	<key>PayloadVersion</key>
+	<integer>1</integer>
+</dict>
+</plist>

--- a/ee/cis/macos-14/test/profiles/4.1.mobileconfig
+++ b/ee/cis/macos-14/test/profiles/4.1.mobileconfig
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>PayloadContent</key>
+	<array>
+		<dict>
+			<key>PayloadDisplayName</key>
+			<string>test</string>
+			<key>PayloadType</key>
+			<string>com.apple.mDNSResponder</string>
+			<key>PayloadIdentifier</key>
+			<string>com.fleetdm.cis-4.1.check</string>
+			<key>PayloadUUID</key>
+			<string>08FEA43B-CE9B-4098-804C-11459D109992</string>
+			<key>NoMulticastAdvertisements</key>
+			<true/>
+		</dict>
+	</array>
+	<key>PayloadDescription</key>
+	<string>test</string>
+	<key>PayloadDisplayName</key>
+	<string>Ensure Bonjour Advertising Services Is Disabled</string>
+	<key>PayloadIdentifier</key>
+	<string>com.fleetdm.cis-4.1</string>
+	<key>PayloadRemovalDisallowed</key>
+	<false/>
+	<key>PayloadScope</key>
+	<string>System</string>
+	<key>PayloadType</key>
+	<string>Configuration</string>
+	<key>PayloadUUID</key>
+	<string>25BD1312-2B79-40C7-99FA-E60B49A1883E</string>
+	<key>PayloadVersion</key>
+	<integer>1</integer>
+</dict>
+</plist>

--- a/ee/cis/macos-14/test/profiles/5.2.1.mobileconfig
+++ b/ee/cis/macos-14/test/profiles/5.2.1.mobileconfig
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>PayloadContent</key>
+	<array>
+		<dict>
+			<key>PayloadDisplayName</key>
+			<string>test</string>
+			<key>PayloadType</key>
+			<string>com.apple.mobiledevice.passwordpolicy</string>
+			<key>PayloadIdentifier</key>
+			<string>com.fleetdm.cis-5.2.1.check</string>
+			<key>PayloadUUID</key>
+			<string>749F9F38-7AD2-4FC6-8F88-672F3AB79F82</string>
+			<key>maxFailedAttempts</key>
+			<integer>5</integer>
+		</dict>
+	</array>
+	<key>PayloadDescription</key>
+	<string>test</string>
+	<key>PayloadDisplayName</key>
+	<string>Ensure Password Account Lockout Threshold Is Configured</string>
+	<key>PayloadIdentifier</key>
+	<string>com.fleetdm.cis-5.2.1</string>
+	<key>PayloadRemovalDisallowed</key>
+	<false/>
+	<key>PayloadScope</key>
+	<string>System</string>
+	<key>PayloadType</key>
+	<string>Configuration</string>
+	<key>PayloadUUID</key>
+	<string>F886BF2C-12D2-428B-BCF0-55823908F426</string>
+	<key>PayloadVersion</key>
+	<integer>1</integer>
+</dict>
+</plist>

--- a/ee/cis/macos-14/test/profiles/5.2.2.mobileconfig
+++ b/ee/cis/macos-14/test/profiles/5.2.2.mobileconfig
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>PayloadContent</key>
+	<array>
+		<dict>
+			<key>PayloadDisplayName</key>
+			<string>test</string>
+			<key>PayloadType</key>
+			<string>com.apple.mobiledevice.passwordpolicy</string>
+			<key>PayloadIdentifier</key>
+			<string>com.fleetdm.cis-5.2.2.check</string>
+			<key>PayloadUUID</key>
+			<string>A7C54C32-6519-4335-A673-B20D3015B432</string>
+			<key>minLength</key>
+			<integer>15</integer>
+		</dict>
+	</array>
+	<key>PayloadDescription</key>
+	<string>test</string>
+	<key>PayloadDisplayName</key>
+	<string>Ensure Password Minimum Length Is Configured</string>
+	<key>PayloadIdentifier</key>
+	<string>com.fleetdm.cis-5.2.2</string>
+	<key>PayloadRemovalDisallowed</key>
+	<false/>
+	<key>PayloadScope</key>
+	<string>System</string>
+	<key>PayloadType</key>
+	<string>Configuration</string>
+	<key>PayloadUUID</key>
+	<string>415F567D-83F4-4AB5-BCFA-7AC8B707DCFD</string>
+	<key>PayloadVersion</key>
+	<integer>1</integer>
+</dict>
+</plist>

--- a/ee/cis/macos-14/test/profiles/5.2.3-and-5.2.4.mobileconfig
+++ b/ee/cis/macos-14/test/profiles/5.2.3-and-5.2.4.mobileconfig
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>PayloadContent</key>
+	<array>
+		<dict>
+			<key>PayloadDisplayName</key>
+			<string>test</string>
+			<key>PayloadType</key>
+			<string>com.apple.mobiledevice.passwordpolicy</string>
+			<key>PayloadIdentifier</key>
+			<string>com.fleetdm.cis-5.2.3-and-5.2.4.check</string>
+			<key>PayloadUUID</key>
+			<string>207388F7-0144-4518-9CCD-9E488EF9C5D7</string>
+			<key>requireAlphanumeric</key>
+			<true/>
+		</dict>
+	</array>
+	<key>PayloadDescription</key>
+	<string>test</string>
+	<key>PayloadDisplayName</key>
+	<string>Require AlphaNumeric characters in password</string>
+	<key>PayloadIdentifier</key>
+	<string>com.fleetdm.cis-5.2.3-and-5.2.4</string>
+	<key>PayloadRemovalDisallowed</key>
+	<false/>
+	<key>PayloadScope</key>
+	<string>System</string>
+	<key>PayloadType</key>
+	<string>Configuration</string>
+	<key>PayloadUUID</key>
+	<string>19BDCDC8-7E9E-48A6-9468-F87EE865F677</string>
+	<key>PayloadVersion</key>
+	<integer>1</integer>
+</dict>
+</plist>

--- a/ee/cis/macos-14/test/profiles/5.2.5.mobileconfig
+++ b/ee/cis/macos-14/test/profiles/5.2.5.mobileconfig
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>PayloadContent</key>
+	<array>
+		<dict>
+			<key>PayloadDisplayName</key>
+			<string>test</string>
+			<key>PayloadType</key>
+			<string>com.apple.mobiledevice.passwordpolicy</string>
+			<key>PayloadIdentifier</key>
+			<string>com.fleetdm.cis-5.2.5.check</string>
+			<key>PayloadUUID</key>
+			<string>46BD11BD-116C-4E95-9575-6EDFDE0F110F</string>
+			<key>minComplexChars</key>
+			<integer>1</integer>
+		</dict>
+	</array>
+	<key>PayloadDescription</key>
+	<string>test</string>
+	<key>PayloadDisplayName</key>
+	<string>Require Special characters in password</string>
+	<key>PayloadIdentifier</key>
+	<string>com.fleetdm.cis-5.2.5</string>
+	<key>PayloadRemovalDisallowed</key>
+	<false/>
+	<key>PayloadScope</key>
+	<string>System</string>
+	<key>PayloadType</key>
+	<string>Configuration</string>
+	<key>PayloadUUID</key>
+	<string>C8CEE953-50F3-48E6-B462-FA98D931A906</string>
+	<key>PayloadVersion</key>
+	<integer>1</integer>
+</dict>
+</plist>

--- a/ee/cis/macos-14/test/profiles/5.2.7.mobileconfig
+++ b/ee/cis/macos-14/test/profiles/5.2.7.mobileconfig
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>PayloadContent</key>
+	<array>
+		<dict>
+			<key>PayloadDisplayName</key>
+			<string>test</string>
+			<key>PayloadType</key>
+			<string>com.apple.mobiledevice.passwordpolicy</string>
+			<key>PayloadIdentifier</key>
+			<string>com.fleetdm.cis-5.2.7.check</string>
+			<key>PayloadUUID</key>
+			<string>F5515451-97EC-4CCB-B442-CDF0C546BC27</string>
+			<key>maxPINAgeInDays</key>
+			<integer>365</integer>
+		</dict>
+	</array>
+	<key>PayloadDescription</key>
+	<string>test</string>
+	<key>PayloadDisplayName</key>
+	<string>Ensure Password Age Is Configured</string>
+	<key>PayloadIdentifier</key>
+	<string>com.fleetdm.cis-5.2.7</string>
+	<key>PayloadRemovalDisallowed</key>
+	<false/>
+	<key>PayloadScope</key>
+	<string>System</string>
+	<key>PayloadType</key>
+	<string>Configuration</string>
+	<key>PayloadUUID</key>
+	<string>AEF56396-50CC-4E5A-9C6D-CBAE6A5E13B5</string>
+	<key>PayloadVersion</key>
+	<integer>1</integer>
+</dict>
+</plist>

--- a/ee/cis/macos-14/test/profiles/5.2.8.mobileconfig
+++ b/ee/cis/macos-14/test/profiles/5.2.8.mobileconfig
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>PayloadContent</key>
+	<array>
+		<dict>
+			<key>PayloadDisplayName</key>
+			<string>test</string>
+			<key>PayloadType</key>
+			<string>com.apple.mobiledevice.passwordpolicy</string>
+			<key>PayloadIdentifier</key>
+			<string>com.fleetdm.cis-5.2.8.check</string>
+			<key>PayloadUUID</key>
+			<string>5227E361-F971-44B3-B706-B04BA0D3B186</string>
+			<key>pinHistory</key>
+			<integer>15</integer>
+		</dict>
+	</array>
+	<key>PayloadDescription</key>
+	<string>test</string>
+	<key>PayloadDisplayName</key>
+	<string>Ensure Password History Is Configured</string>
+	<key>PayloadIdentifier</key>
+	<string>com.fleetdm.cis-5.2.8</string>
+	<key>PayloadRemovalDisallowed</key>
+	<false/>
+	<key>PayloadScope</key>
+	<string>System</string>
+	<key>PayloadType</key>
+	<string>Configuration</string>
+	<key>PayloadUUID</key>
+	<string>0AD34391-5C19-4229-AA10-EB6A169D15EB</string>
+	<key>PayloadVersion</key>
+	<integer>1</integer>
+</dict>
+</plist>

--- a/ee/cis/macos-14/test/profiles/6.3.1.mobileconfig
+++ b/ee/cis/macos-14/test/profiles/6.3.1.mobileconfig
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+	<dict>
+		<key>PayloadContent</key>
+		<array>
+			<dict>
+				<key>PayloadDisplayName</key>
+				<string>test</string>
+				<key>PayloadType</key>
+				<string>com.apple.Safari</string>
+				<key>PayloadIdentifier</key>
+				<string>com.fleetdm.cis-6.3.1.check</string>
+				<key>PayloadUUID</key>
+				<string>3CAAC721-D492-45AC-95E4-8ECBF81EA21E</string>
+				<key>AutoOpenSafeDownloads</key>
+				<false/>
+			</dict>
+		</array>
+		<key>PayloadDescription</key>
+		<string>test</string>
+		<key>PayloadDisplayName</key>
+		<string>Ensure Automatic Opening of Safe Files in Safari Is Disabled</string>
+		<key>PayloadIdentifier</key>
+		<string>com.fleetdm.cis-6.3.1</string>
+		<key>PayloadRemovalDisallowed</key>
+		<false/>
+		<key>PayloadScope</key>
+		<string>System</string>
+		<key>PayloadType</key>
+		<string>Configuration</string>
+		<key>PayloadUUID</key>
+		<string>2556F162-9AE5-4163-92C1-F89A2847C80E</string>
+		<key>PayloadVersion</key>
+		<integer>1</integer>
+	</dict>
+</plist>

--- a/ee/cis/macos-14/test/profiles/6.3.2.mobileconfig
+++ b/ee/cis/macos-14/test/profiles/6.3.2.mobileconfig
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>PayloadContent</key>
+	<array>
+		<dict>
+			<key>PayloadDisplayName</key>
+			<string>test</string>
+			<key>PayloadType</key>
+			<string>com.apple.Safari</string>
+			<key>PayloadIdentifier</key>
+			<string>com.fleetdm.cis-6.3.2.check</string>
+			<key>PayloadUUID</key>
+			<string>61BC98A2-9482-4EB3-9184-FB6A8B8E33E8</string>
+			<key>HistoryAgeInDaysLimit</key>
+			<integer>1</integer>
+		</dict>
+	</array>
+	<key>PayloadDescription</key>
+	<string>test</string>
+	<key>PayloadDisplayName</key>
+	<string>Audit History and Remove History Items</string>
+	<key>PayloadIdentifier</key>
+	<string>com.fleetdm.cis-6.3.2</string>
+	<key>PayloadRemovalDisallowed</key>
+	<false/>
+	<key>PayloadScope</key>
+	<string>System</string>
+	<key>PayloadType</key>
+	<string>Configuration</string>
+	<key>PayloadUUID</key>
+	<string>1D6C407D-8C28-4BDC-9837-DF5ED49E8059</string>
+	<key>PayloadVersion</key>
+	<integer>1</integer>
+</dict>
+</plist>
+

--- a/ee/cis/macos-14/test/profiles/6.3.3.mobileconfig
+++ b/ee/cis/macos-14/test/profiles/6.3.3.mobileconfig
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+	<dict>
+		<key>PayloadContent</key>
+		<array>
+			<dict>
+				<key>PayloadDisplayName</key>
+				<string>test</string>
+				<key>PayloadType</key>
+				<string>com.apple.Safari</string>
+				<key>PayloadIdentifier</key>
+				<string>com.fleetdm.cis-6.3.3.check</string>
+				<key>PayloadUUID</key>
+				<string>AA1CF4AE-446C-41B0-8B06-ADEAEF9F0505</string>
+				<key>WarnAboutFraudulentWebsites</key>
+				<true/>
+			</dict>
+		</array>
+		<key>PayloadDescription</key>
+		<string>test</string>
+		<key>PayloadDisplayName</key>
+		<string>Ensure Warn When Visiting A Fraudulent Website in Safari Is Enabled</string>
+		<key>PayloadIdentifier</key>
+		<string>com.fleetdm.cis-6.3.3</string>
+		<key>PayloadRemovalDisallowed</key>
+		<false/>
+		<key>PayloadScope</key>
+		<string>System</string>
+		<key>PayloadType</key>
+		<string>Configuration</string>
+		<key>PayloadUUID</key>
+		<string>130308F8-916A-449D-9711-34A31DCCD39D</string>
+		<key>PayloadVersion</key>
+		<integer>1</integer>
+	</dict>
+</plist>

--- a/ee/cis/macos-14/test/profiles/6.3.4.mobileconfig
+++ b/ee/cis/macos-14/test/profiles/6.3.4.mobileconfig
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>PayloadContent</key>
+	<array>
+		<dict>
+			<key>PayloadDisplayName</key>
+			<string>test</string>
+			<key>PayloadType</key>
+			<string>com.apple.Safari</string>
+			<key>PayloadIdentifier</key>
+			<string>com.fleetdm.cis-6.3.4.check</string>
+			<key>PayloadUUID</key>
+			<string>E0560069-04EF-4985-815E-987A304F8EB7</string>
+			<key>BlockStoragePolicy</key>
+			<integer>2</integer>
+			<key>WebKitPreferences.storageBlockingPolicy</key>
+			<integer>1</integer>
+			<key>WebKitStorageBlockingPolicy</key>
+			<integer>1</integer>
+		</dict>
+	</array>
+	<key>PayloadDescription</key>
+	<string>test</string>
+	<key>PayloadDisplayName</key>
+	<string>Ensure Prevent Cross-site Tracking in Safari Is Enabled</string>
+	<key>PayloadIdentifier</key>
+	<string>com.fleetdm.cis-6.3.4</string>
+	<key>PayloadRemovalDisallowed</key>
+	<false/>
+	<key>PayloadScope</key>
+	<string>System</string>
+	<key>PayloadType</key>
+	<string>Configuration</string>
+	<key>PayloadUUID</key>
+	<string>E1D04566-15CE-458C-A0D1-5F6C7B9A6472</string>
+	<key>PayloadVersion</key>
+	<integer>1</integer>
+</dict>
+</plist>

--- a/ee/cis/macos-14/test/profiles/6.3.7.mobileconfig
+++ b/ee/cis/macos-14/test/profiles/6.3.7.mobileconfig
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>PayloadContent</key>
+	<array>
+		<dict>
+			<key>PayloadDisplayName</key>
+			<string>test</string>
+			<key>PayloadType</key>
+			<string>com.apple.Safari</string>
+			<key>PayloadIdentifier</key>
+			<string>com.fleetdm.cis-6.3.7.check</string>
+			<key>PayloadUUID</key>
+			<string>A78B534C-0E6D-46C0-97F1-D50178AC5AD0</string>
+			<key>ShowFullURLInSmartSearchField</key>
+			<true/>
+		</dict>
+	</array>
+	<key>PayloadDescription</key>
+	<string>test</string>
+	<key>PayloadDisplayName</key>
+	<string>Ensure Show Full Website Address in Safari Is Enabled</string>
+	<key>PayloadIdentifier</key>
+	<string>com.fleetdm.cis-6.3.7</string>
+	<key>PayloadRemovalDisallowed</key>
+	<false/>
+	<key>PayloadScope</key>
+	<string>System</string>
+	<key>PayloadType</key>
+	<string>Configuration</string>
+	<key>PayloadUUID</key>
+	<string>5A412D8E-5951-42A3-95ED-BD82AD6D3038</string>
+	<key>PayloadVersion</key>
+	<integer>1</integer>
+</dict>
+</plist>

--- a/ee/cis/macos-14/test/profiles/6.4.1.mobileconfig
+++ b/ee/cis/macos-14/test/profiles/6.4.1.mobileconfig
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+	<dict>
+		<key>PayloadContent</key>
+		<array>
+			<dict>
+				<key>PayloadDisplayName</key>
+				<string>test</string>
+				<key>PayloadType</key>
+				<string>com.apple.Terminal</string>
+				<key>PayloadIdentifier</key>
+				<string>com.fleetdm.cis-6.4.1.check</string>
+				<key>PayloadUUID</key>
+				<string>E8D36749-D7F8-4280-9B17-D6224B67B63B</string>
+				<key>SecureKeyboardEntry</key>
+				<true/>
+			</dict>
+		</array>
+		<key>PayloadDescription</key>
+		<string>test</string>
+		<key>PayloadDisplayName</key>
+		<string>Ensure Secure Keyboard Entry Terminal.app Is Enabled</string>
+		<key>PayloadIdentifier</key>
+		<string>com.fleetdm.cis-6.4.1</string>
+		<key>PayloadRemovalDisallowed</key>
+		<false/>
+		<key>PayloadScope</key>
+		<string>System</string>
+		<key>PayloadType</key>
+		<string>Configuration</string>
+		<key>PayloadUUID</key>
+		<string>D4C0B4CC-D39A-4F0F-AF8A-AB5A73D02B3F</string>
+		<key>PayloadVersion</key>
+		<integer>1</integer>
+	</dict>
+</plist>

--- a/ee/cis/macos-14/test/profiles/README.md
+++ b/ee/cis/macos-14/test/profiles/README.md
@@ -1,0 +1,64 @@
+# CIS Profiles
+
+On this directory we store the profiles for each CIS benchmark check that will allow us to apply them automatically on macOS VMs.
+
+## How to create one
+
+Let's assume you are creating a profile for CIS 1.6, "Ensure Install Security Responses and System Files Is Enabled".
+
+1. Copy an existing profile:
+```sh
+cp compliance/profiles/2.1.1.3.mobileconfig compliance/profiles/1.6.mobileconfig
+```
+
+2. Generate two unique UUIDs:
+```sh
+$ uuidgen
+380B8EF9-B5E8-4967-A102-52F78EA03AB9
+$ uuidgen
+3C4F942C-C716-48F3-A2E9-52AD7DBE55E0
+```
+
+3. Open the created copy with a text editor and modify the following fields:
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>PayloadContent</key>
+	<array>
+		<dict>
+			<key>PayloadDisplayName</key>
+			<string>test</string>
+			<key>PayloadType</key>
+			<string><!--- Domain of the setting, e.g. com.apple.SoftwareUpdate --></string>
+			<key>PayloadIdentifier</key>
+			<string>com.fleetdm.cis-1.6.check <!--- This must be unique and a sub domain of the main profile, thus we add the cis number at the end + ".check" --></string>
+			<key>PayloadUUID</key>
+			<string><!--- Paste one of the generated UUID here, in this case 380B8EF9-B5E8-4967-A102-52F78EA03AB9 --></string>
+			<key><!--- Setting, e.g. CriticalUpdateInstall --></key>
+			<false/>
+		</dict>
+	</array>
+	<key>PayloadDescription</key>
+	<string>test</string>
+	<key>PayloadDisplayName</key>
+	<string><!-- Title of the CIS here, e.g. Ensure Install Security Responses and System Files Is Enabled --></string>
+	<key>PayloadIdentifier</key>
+	<string>com.fleetdm.cis-1.6</string> <!--- This must be unique, thus we add the cis number at the end -->
+	<key>PayloadRemovalDisallowed</key>
+	<false/>
+	<key>PayloadScope</key>
+	<string>System</string>
+	<key>PayloadType</key>
+	<string>Configuration</string>
+	<key>PayloadUUID</key>
+	<string><!--- Paste the other generated UUID here, in this case 3C4F942C-C716-48F3-A2E9-52AD7DBE55E0 --></string>
+	<key>PayloadVersion</key>
+	<integer>1</integer>
+</dict>
+</plist>
+```
+
+4. Place the `.mobileconfig` on the VM and double click the profile.
+5. Go to `System Settings > Profiles` and then install the profile.

--- a/ee/cis/macos-14/test/profiles/not_always_working_2.10.1.mobileconfig
+++ b/ee/cis/macos-14/test/profiles/not_always_working_2.10.1.mobileconfig
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>PayloadContent</key>
+	<array>
+		<dict>
+			<key>PayloadDisplayName</key>
+			<string>test</string>
+			<key>PayloadType</key>
+			<string>com.apple.screensaver</string>
+			<key>PayloadIdentifier</key>
+			<string>com.fleetdm.cis-2.10.1.check</string>
+			<key>PayloadUUID</key>
+			<string>7A3B69E3-9E7D-4797-88A7-1043AE70E7DC</string>
+			<key>idleTime</key>
+			<integer>1200</integer>
+		</dict>
+	</array>
+	<key>PayloadDescription</key>
+	<string>test</string>
+	<key>PayloadDisplayName</key>
+	<string>Ensure an Inactivity Interval of 20 Minutes Or Less for the Screen Saver Is Enabled</string>
+	<key>PayloadIdentifier</key>
+	<string>com.fleetdm.cis-2.10.1</string>
+	<key>PayloadRemovalDisallowed</key>
+	<false/>
+	<key>PayloadScope</key>
+	<string>System</string>
+	<key>PayloadType</key>
+	<string>Configuration</string>
+	<key>PayloadUUID</key>
+	<string>B5B76088-248C-4755-BF2F-73BA6C05B5E9</string>
+	<key>PayloadVersion</key>
+	<integer>1</integer>
+</dict>
+</plist>

--- a/ee/cis/macos-14/test/profiles/not_always_working_2.10.2.mobileconfig
+++ b/ee/cis/macos-14/test/profiles/not_always_working_2.10.2.mobileconfig
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>PayloadContent</key>
+	<array>
+		<dict>
+			<key>PayloadDisplayName</key>
+			<string>test</string>
+			<key>PayloadType</key>
+			<string>com.apple.screensaver</string>
+			<key>PayloadIdentifier</key>
+			<string>com.fleetdm.cis-2.10.2.check</string>
+			<key>PayloadUUID</key>
+			<string>A33F821F-A138-42A0-B657-9F25A0F5ABD5</string>
+			<key>askForPassword</key>
+			<true/>
+			<key>askForPasswordDelay</key>
+			<integer>5</integer>
+		</dict>
+	</array>
+	<key>PayloadDescription</key>
+	<string>test</string>
+	<key>PayloadDisplayName</key>
+	<string>Ensure a Password is Required to Wake the Computer From Sleep or Screen Saver Is Enabled</string>
+	<key>PayloadIdentifier</key>
+	<string>com.fleetdm.cis-2.10.2</string>
+	<key>PayloadRemovalDisallowed</key>
+	<false/>
+	<key>PayloadScope</key>
+	<string>System</string>
+	<key>PayloadType</key>
+	<string>Configuration</string>
+	<key>PayloadUUID</key>
+	<string>BF81079A-0A4A-476B-9318-F4105F3745D9</string>
+	<key>PayloadVersion</key>
+	<integer>1</integer>
+</dict>
+</plist>

--- a/ee/cis/macos-14/test/profiles/not_always_working_2.10.4.mobileconfig
+++ b/ee/cis/macos-14/test/profiles/not_always_working_2.10.4.mobileconfig
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>PayloadContent</key>
+	<array>
+		<dict>
+			<key>PayloadDisplayName</key>
+			<string>test</string>
+			<key>PayloadType</key>
+			<string>com.apple.loginwindow</string>
+			<key>PayloadIdentifier</key>
+			<string>com.fleetdm.cis-2.10.4.check</string>
+			<key>PayloadUUID</key>
+			<string>C8D63845-92B8-421D-AD17-00D25DEF626A</string>
+			<key>SHOWFULLNAME</key>
+			<true/>
+		</dict>
+	</array>
+	<key>PayloadDescription</key>
+	<string>test</string>
+	<key>PayloadDisplayName</key>
+	<string>Ensure Login Window Displays as Name and Password Is Enabled</string>
+	<key>PayloadIdentifier</key>
+	<string>com.fleetdm.cis-2.10.4</string>
+	<key>PayloadRemovalDisallowed</key>
+	<false/>
+	<key>PayloadScope</key>
+	<string>System</string>
+	<key>PayloadType</key>
+	<string>Configuration</string>
+	<key>PayloadUUID</key>
+	<string>43D5AAB6-F9DB-4F7F-A665-43DF4915C7E1</string>
+	<key>PayloadVersion</key>
+	<integer>1</integer>
+</dict>
+</plist>

--- a/ee/cis/macos-14/test/profiles/not_always_working_2.10.5.mobileconfig
+++ b/ee/cis/macos-14/test/profiles/not_always_working_2.10.5.mobileconfig
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>PayloadContent</key>
+	<array>
+		<dict>
+			<key>PayloadDisplayName</key>
+			<string>test</string>
+			<key>PayloadType</key>
+			<string>com.apple.loginwindow</string>
+			<key>PayloadIdentifier</key>
+			<string>com.fleetdm.cis-2.10.5.check</string>
+			<key>PayloadUUID</key>
+			<string>21BB3EDD-BE67-42DC-B8CE-C493D01C0296</string>
+			<key>RetriesUntilHint</key>
+			<integer>0</integer>
+		</dict>
+	</array>
+	<key>PayloadDescription</key>
+	<string>test</string>
+	<key>PayloadDisplayName</key>
+	<string>Ensure Show Password Hints Is Disabled</string>
+	<key>PayloadIdentifier</key>
+	<string>com.fleetdm.cis-2.10.5</string>
+	<key>PayloadRemovalDisallowed</key>
+	<false/>
+	<key>PayloadScope</key>
+	<string>System</string>
+	<key>PayloadType</key>
+	<string>Configuration</string>
+	<key>PayloadUUID</key>
+	<string>22FEDF5B-8D93-48F7-AE71-E1E2F8C96C30</string>
+	<key>PayloadVersion</key>
+	<integer>1</integer>
+</dict>
+</plist>

--- a/ee/cis/macos-14/test/profiles/not_always_working_2.6.1.2.mobileconfig
+++ b/ee/cis/macos-14/test/profiles/not_always_working_2.6.1.2.mobileconfig
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>PayloadContent</key>
+	<array>
+		<dict>
+			<key>PayloadDisplayName</key>
+			<string>test</string>
+			<key>PayloadType</key>
+			<string>com.apple.locationmenu</string>
+			<key>PayloadIdentifier</key>
+			<string>com.fleetdm.cis-2.6.1.2.check</string>
+			<key>PayloadUUID</key>
+			<string>25D6B210-E8BB-465F-94D7-474073F4A892</string>
+			<key>ShowSystemServices</key>
+			<true/>
+		</dict>
+	</array>
+	<key>PayloadDescription</key>
+	<string>test</string>
+	<key>PayloadDisplayName</key>
+	<string>Ensure Location Services Is Enabled</string>
+	<key>PayloadIdentifier</key>
+	<string>com.fleetdm.cis-2.6.1.2</string>
+	<key>PayloadRemovalDisallowed</key>
+	<false/>
+	<key>PayloadScope</key>
+	<string>System</string>
+	<key>PayloadType</key>
+	<string>Configuration</string>
+	<key>PayloadUUID</key>
+	<string>8FC698D7-9EF8-427E-8E52-4B928A7437B0</string>
+	<key>PayloadVersion</key>
+	<integer>1</integer>
+</dict>
+</plist>

--- a/ee/cis/macos-14/test/profiles/not_working_2.3.4.1.mobileconfig
+++ b/ee/cis/macos-14/test/profiles/not_working_2.3.4.1.mobileconfig
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+        <key>PayloadContent</key>
+        <array>
+                <dict>
+                        <key>PayloadDisplayName</key>
+                        <string>test</string>
+                        <key>PayloadType</key>
+                        <string>com.apple.TimeMachine</string>
+                        <key>PayloadIdentifier</key>
+                        <string>com.fleetdm.cis-2.3.4.1.check</string>
+                        <key>PayloadUUID</key>
+                        <string>D884A50B-C73C-4955-B042-9B6DAF23FAF0</string>
+                        <key>Forced</key>
+                        <array>
+                                <dict>
+                                        <key>mcx_preference_settings</key>
+                                                <dict>
+                                                        <key>AutoBackup</key>
+                                                        <true/>
+                                                </dict>
+                                </dict>
+                        </array>
+                </dict>
+        </array>
+        <key>PayloadDescription</key>
+        <string>test</string>
+        <key>PayloadDisplayName</key>
+        <string>Ensure Backup Automatically is Enabled If Time Machine Is Enabled</string>
+        <key>PayloadIdentifier</key>
+        <string>com.fleetdm.cis-2.3.4.1</string>
+        <key>PayloadRemovalDisallowed</key>
+        <false/>
+        <key>PayloadScope</key>
+        <string>System</string>
+        <key>PayloadType</key>
+        <string>Configuration</string>
+        <key>PayloadUUID</key>
+        <string>582492F2-34C8-4C1C-A264-1885955A3E19</string>
+        <key>PayloadVersion</key>
+        <integer>1</integer>
+</dict>
+</plist>

--- a/ee/cis/macos-14/test/profiles/on-device-dictiation-enabled.mobileconfig
+++ b/ee/cis/macos-14/test/profiles/on-device-dictiation-enabled.mobileconfig
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>PayloadContent</key>
+	<array>
+		<dict>
+			<key>PayloadDisplayName</key>
+			<string>test</string>
+			<key>PayloadType</key>
+			<string>com.apple.applicationaccess</string>
+			<key>PayloadIdentifier</key>
+			<string>com.fleetdm.cis.check-cis-on-device-dictation-enabled</string>
+			<key>PayloadUUID</key>
+			<string>4E203BCD-CAFB-4248-B6B0-F2A1AEC55EB1</string>
+			<key>forceOnDeviceOnlyDictation</key>
+			<true/>
+		</dict>
+	</array>
+	<key>PayloadDescription</key>
+	<string>test</string>
+	<key>PayloadDisplayName</key>
+	<string>Ensure On-Device Dictation Is Enabled</string>
+	<key>PayloadIdentifier</key>
+	<string>com.fleetdm.cis-on-device-dictation-enabled</string>
+	<key>PayloadRemovalDisallowed</key>
+	<false/>
+	<key>PayloadScope</key>
+	<string>System</string>
+	<key>PayloadType</key>
+	<string>Configuration</string>
+	<key>PayloadUUID</key>
+	<string>E155A81F-DCF0-467B-B177-972E67562BFF</string>
+	<key>PayloadVersion</key>
+	<integer>1</integer>
+</dict>
+</plist>

--- a/ee/cis/macos-14/test/scripts/CIS_2.10.3.sh
+++ b/ee/cis/macos-14/test/scripts/CIS_2.10.3.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+sudo /usr/bin/defaults write /Library/Preferences/com.apple.loginwindow LoginwindowText "Test Message 1"

--- a/ee/cis/macos-14/test/scripts/CIS_2.10.4.sh
+++ b/ee/cis/macos-14/test/scripts/CIS_2.10.4.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+sudo /usr/bin/defaults write /Library/Preferences/com.apple.loginwindow SHOWFULLNAME -bool true

--- a/ee/cis/macos-14/test/scripts/CIS_2.10.5.sh
+++ b/ee/cis/macos-14/test/scripts/CIS_2.10.5.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+sudo /usr/bin/defaults write /Library/Preferences/com.apple.loginwindow RetriesUntilHint -int 0

--- a/ee/cis/macos-14/test/scripts/CIS_2.11.1.sh
+++ b/ee/cis/macos-14/test/scripts/CIS_2.11.1.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+sudo dscl . -list /Users hint . -delete /Users/<username>

--- a/ee/cis/macos-14/test/scripts/CIS_2.12.1.sh
+++ b/ee/cis/macos-14/test/scripts/CIS_2.12.1.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+sudo /usr/bin/defaults write /Library/Preferences/com.apple.loginwindow GuestEnabled -bool false
+sudo /usr/bin/defaults write /Library/Preferences/com.apple.MCX DisableGuestAccount  -bool true

--- a/ee/cis/macos-14/test/scripts/CIS_2.12.2.sh
+++ b/ee/cis/macos-14/test/scripts/CIS_2.12.2.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+/usr/bin/sudo /usr/sbin/sysadminctl -smbGuestAccess off
+
+
+# For testing
+# Get Status: /usr/bin/sudo /usr/sbin/sysadminctl -smbGuestAccess status
+# Set to enabled: /usr/bin/sudo /usr/sbin/sysadminctl -smbGuestAccess on
+

--- a/ee/cis/macos-14/test/scripts/CIS_2.12.3.sh
+++ b/ee/cis/macos-14/test/scripts/CIS_2.12.3.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+sudo /usr/bin/defaults delete /Library/Preferences/com.apple.loginwindow autoLoginUser

--- a/ee/cis/macos-14/test/scripts/CIS_2.3.3.1.sh
+++ b/ee/cis/macos-14/test/scripts/CIS_2.3.3.1.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+/usr/bin/sudo /bin/launchctl disable system/com.apple.ODSAgent

--- a/ee/cis/macos-14/test/scripts/CIS_2.3.3.2.sh
+++ b/ee/cis/macos-14/test/scripts/CIS_2.3.3.2.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+/usr/bin/sudo /bin/launchctl disable system/com.apple.screensharing

--- a/ee/cis/macos-14/test/scripts/CIS_2.3.3.3.sh
+++ b/ee/cis/macos-14/test/scripts/CIS_2.3.3.3.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+/usr/bin/sudo /bin/launchctl disable system/com.apple.smbd

--- a/ee/cis/macos-14/test/scripts/CIS_2.3.3.4.sh
+++ b/ee/cis/macos-14/test/scripts/CIS_2.3.3.4.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+/usr/bin/sudo /usr/sbin/cupsctl --no-share-printers

--- a/ee/cis/macos-14/test/scripts/CIS_2.3.3.5.sh
+++ b/ee/cis/macos-14/test/scripts/CIS_2.3.3.5.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+/usr/bin/sudo /bin/launchctl disable system/com.openssh.sshd

--- a/ee/cis/macos-14/test/scripts/CIS_2.3.3.6.sh
+++ b/ee/cis/macos-14/test/scripts/CIS_2.3.3.6.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+/usr/bin/sudo /System/Library/CoreServices/RemoteManagement/ARDAgent.app/Contents/Resources/kickstart -deactivate -stop

--- a/ee/cis/macos-14/test/scripts/CIS_2.3.3.7.sh
+++ b/ee/cis/macos-14/test/scripts/CIS_2.3.3.7.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+/usr/bin/sudo /usr/sbin/systemsetup -setremoteappleevents off

--- a/ee/cis/macos-14/test/scripts/CIS_2.3.3.8.sh
+++ b/ee/cis/macos-14/test/scripts/CIS_2.3.3.8.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+/usr/bin/sudo /usr/bin/defaults write /Library/Preferences/SystemConfiguration/com.apple.nat NAT -dict Enabled -int 0

--- a/ee/cis/macos-14/test/scripts/CIS_2.3.4.1.sh
+++ b/ee/cis/macos-14/test/scripts/CIS_2.3.4.1.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# NOTE(lucas): I was not able to set `com.apple.TimeMachine`'s `AutoBackup` via a configuration profile.
+# I tried the profile method documented on the CIS Benchmarks document and after applying it successfully
+# it did not update the value of `AutoBackup`.
+#
+# So for now we are using the following shell command to enable automatic backup of Time Machine destinations.
+/usr/bin/sudo /usr/bin/defaults write /Library/Preferences/com.apple.TimeMachine.plist AutoBackup -bool true

--- a/ee/cis/macos-14/test/scripts/CIS_2.6.1.2.sh
+++ b/ee/cis/macos-14/test/scripts/CIS_2.6.1.2.sh
@@ -1,0 +1,1 @@
+sudo /usr/bin/defaults write /Library/Preferences/com.apple.locationmenu.plist ShowSystemServices -bool true

--- a/ee/cis/macos-14/test/scripts/CIS_2.6.2.sh
+++ b/ee/cis/macos-14/test/scripts/CIS_2.6.2.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+sudo /usr/bin/defaults write /Library/Application\
+Support/CrashReporter/DiagnosticMessagesHistory.plist AutoSubmit -bool false
+
+sudo /usr/bin/defaults write /Library/Application\
+Support/CrashReporter/DiagnosticMessagesHistory.plist ThirdPartyDataSubmit -bool false
+
+sudo /bin/chmod 644 /Library/Application\
+Support/CrashReporter/DiagnosticMessagesHistory.plist
+
+sudo /usr/sbin/chgrp admin /Library/Application\
+Support/CrashReporter/DiagnosticMessagesHistory.plist
+
+
+echo "This needs modification"
+sudo -u <username> /usr/bin/defaults write
+/Users/<username>/Library/Preferences/com.apple.assistant.support "Siri DataSharing Opt-In Status" -int 2
+
+# Example:
+# sudo -u sharonkatz /usr/bin/defaults write  /Users/sharonkatz/Library/Preferences/com.apple.assistant.support "Siri Data Sharing Opt-In Status" -int 2

--- a/ee/cis/macos-14/test/scripts/CIS_2.6.4.sh
+++ b/ee/cis/macos-14/test/scripts/CIS_2.6.4.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+sudo /usr/sbin/spctl --master-enable

--- a/ee/cis/macos-14/test/scripts/CIS_2.6.7.sh
+++ b/ee/cis/macos-14/test/scripts/CIS_2.6.7.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -eu
+
+sudo security authorizationdb read system.preferences > /tmp/system.preferences.plist
+defaults write /tmp/system.preferences.plist shared -bool false
+sudo security authorizationdb write system.preferences < /tmp/system.preferences.plist

--- a/ee/cis/macos-14/test/scripts/CIS_2.7.1.sh
+++ b/ee/cis/macos-14/test/scripts/CIS_2.7.1.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# Set corner action to 0 (no-op).
+# If you wish to not comply with the policy, set any of them to 6.
+
+/usr/bin/sudo -u $USER /usr/bin/defaults write com.apple.dock wvous-br-corner -integer 0
+/usr/bin/sudo -u $USER /usr/bin/defaults write com.apple.dock wvous-bl-corner -integer 0
+/usr/bin/sudo -u $USER /usr/bin/defaults write com.apple.dock wvous-tr-corner -integer 0
+/usr/bin/sudo -u $USER /usr/bin/defaults write com.apple.dock wvous-tl-corner -integer 0

--- a/ee/cis/macos-14/test/scripts/CIS_2.9.1.sh
+++ b/ee/cis/macos-14/test/scripts/CIS_2.9.1.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+/usr/bin/sudo /usr/bin/pmset -a powernap 0

--- a/ee/cis/macos-14/test/scripts/CIS_2.9.2.sh
+++ b/ee/cis/macos-14/test/scripts/CIS_2.9.2.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+/usr/bin/sudo /usr/bin/pmset -a womp 0

--- a/ee/cis/macos-14/test/scripts/CIS_2.9.3.sh
+++ b/ee/cis/macos-14/test/scripts/CIS_2.9.3.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+if [[ $(uname -m) == 'arm64' ]]; then
+	# Apple silicon
+	/usr/bin/sudo /usr/bin/pmset -a standby 900
+	/usr/bin/sudo /usr/bin/pmset -a destroyfvkeyonstandby 1
+	/usr/bin/sudo /usr/bin/pmset -a hibernatemode 25
+else
+	# Intel
+	/usr/bin/sudo /usr/bin/pmset -a standbydelaylow 900
+	/usr/bin/sudo /usr/bin/pmset -a standbydelayhigh 900
+	/usr/bin/sudo /usr/bin/pmset -a highstandbythreshold 90
+	/usr/bin/sudo /usr/bin/pmset -a destroyfvkeyonstandby 1
+	/usr/bin/sudo /usr/bin/pmset -a hibernatemode 25
+fi

--- a/ee/cis/macos-14/test/scripts/CIS_3.1.sh
+++ b/ee/cis/macos-14/test/scripts/CIS_3.1.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+/usr/bin/sudo /bin/launchctl load -w /System/Library/LaunchDaemons/com.apple.auditd.plist
+
+# For Testing: After the above command executed:
+#   This will stop the service: /usr/bin/sudo /bin/launchctl stop com.apple.auditd
+#   This will start the service: /usr/bin/sudo /bin/launchctl start com.apple.auditd

--- a/ee/cis/macos-14/test/scripts/CIS_3.2.sh
+++ b/ee/cis/macos-14/test/scripts/CIS_3.2.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+cp /etc/security/audit_control ./tmp.txt;
+origFlags=$(cat ./tmp.txt  | grep flags: | grep -v naflags);
+sed "s/${origFlags}/flags:-fm,ad,-ex,aa,-fr,lo,-fw/" ./tmp.txt > /etc/security/audit_control;
+rm ./tmp.txt;
+
+

--- a/ee/cis/macos-14/test/scripts/CIS_3.3.sh
+++ b/ee/cis/macos-14/test/scripts/CIS_3.3.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+
+# For QA:
+# Open /etc/asl/com.apple.install for edit and look for a line starting with "* file"
+# If exist delete all_max=XXX
+# If not exist add ttl=365
+
+
+# This section will delete the all_max 
+/usr/bin/sudo sed -E 's/all_max=[0-9]+M//g' /etc/asl/com.apple.install  > ./tmp.txt
+/usr/bin/sudo cp ./tmp.txt /etc/asl/com.apple.install
+/usr/bin/sudo rm ./tmp.txt
+
+/usr/bin/sudo sed -E 's/all_max=[0-9]+G//g' /etc/asl/com.apple.install  > ./tmp.txt
+/usr/bin/sudo cp ./tmp.txt /etc/asl/com.apple.install
+/usr/bin/sudo rm ./tmp.txt
+

--- a/ee/cis/macos-14/test/scripts/CIS_3.4.sh
+++ b/ee/cis/macos-14/test/scripts/CIS_3.4.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+cp /etc/security/audit_control ./tmp.txt;
+origExpire=$(cat ./tmp.txt  | grep expire-after);
+sed "s/${origExpire}/expire-after:60d OR 5G/" ./tmp.txt > /etc/security/audit_control;
+rm ./tmp.txt;
+
+
+# Explanation:
+# In your /etc/security/audit_control , look for a line starting at: expire-after
+# Cases to test:
+# SHOULD PASS:   expire-after:60d OR 5G
+# SHOULD PASS:   expire-after:61d OR 5G
+# SHOULD PASS:   expire-after:60d OR 6G
+# SHOULD PASS:   expire-after:61d OR 6G
+
+# SHOULD FAIL:   expire-after:60d
+# SHOULD FAIL:   expire-after:5G
+# SHOULD FAIL:   expire-after:59d OR 5G
+# SHOULD FAIL:   expire-after:60d OR 4G
+# SHOULD FAIL:   expire-after:60D
+# SHOULD FAIL:   expire-after:6g
+# SHOULD FAIL:   expire-after:60D OR 5G
+# SHOULD FAIL:   expire-after:60d OR 5g
+# SHOULD FAIL:   expire-after:60D OR 5g

--- a/ee/cis/macos-14/test/scripts/CIS_3.5.sh
+++ b/ee/cis/macos-14/test/scripts/CIS_3.5.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+/usr/bin/sudo /usr/sbin/chown -R root:wheel /etc/security/audit_control
+/usr/bin/sudo /bin/chmod -R o-rw /etc/security/audit_control
+/usr/bin/sudo /usr/sbin/chown -R root:wheel /var/audit/
+/usr/bin/sudo /bin/chmod -R o-rw /var/audit/
+

--- a/ee/cis/macos-14/test/scripts/CIS_4.2.sh
+++ b/ee/cis/macos-14/test/scripts/CIS_4.2.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+/usr/bin/sudo /bin/launchctl unload -w /System/Library/LaunchDaemons/org.apache.httpd.plist

--- a/ee/cis/macos-14/test/scripts/CIS_4.3.sh
+++ b/ee/cis/macos-14/test/scripts/CIS_4.3.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+/usr/bin/sudo /bin/launchctl disable system/com.apple.nfsd
+/usr/bin/sudo /bin/rm /etc/exports

--- a/ee/cis/macos-14/test/scripts/CIS_5.1.1.sh
+++ b/ee/cis/macos-14/test/scripts/CIS_5.1.1.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+for i in $(/usr/bin/sudo dscl . list /Users | grep -v "^_"); do
+    /usr/bin/sudo /bin/chmod -R og-rwx /Users/"$i"
+done

--- a/ee/cis/macos-14/test/scripts/CIS_5.1.5.sh
+++ b/ee/cis/macos-14/test/scripts/CIS_5.1.5.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+/usr/bin/sudo IFS=$'\n'
+for apps in $( /usr/bin/find /Applications -iname "*\.app" -type d -perm -2 );
+do
+  /bin/chmod -R o-w "$apps"
+done

--- a/ee/cis/macos-14/test/scripts/CIS_5.1.6.sh
+++ b/ee/cis/macos-14/test/scripts/CIS_5.1.6.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+/usr/bin/sudo IFS=$'\n'
+for sysPermissions in $( /usr/bin/find /System/Volumes/Data/System -type d -perm -2 | /usr/bin/grep -v "Drop Box" );
+do
+  /bin/chmod -R o-w "$sysPermissions"
+done

--- a/ee/cis/macos-14/test/scripts/CIS_5.1.7.sh
+++ b/ee/cis/macos-14/test/scripts/CIS_5.1.7.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+/usr/bin/sudo IFS=$'\n'
+for libPermissions in $( /usr/bin/find /System/Volumes/Data/Library -type d -perm -2 | /usr/bin/grep -v Caches | /usr/bin/grep -v /Preferences/Audio/Data);
+do
+  /bin/chmod -R o-w "$libPermissions"
+done

--- a/ee/cis/macos-14/test/scripts/CIS_5.10.sh
+++ b/ee/cis/macos-14/test/scripts/CIS_5.10.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+/usr/bin/sudo /bin/rm -R /Users/Guest

--- a/ee/cis/macos-14/test/scripts/CIS_5.4.sh
+++ b/ee/cis/macos-14/test/scripts/CIS_5.4.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+echo 'Defaults timestamp_timeout=0' | sudo tee /etc/sudoers.d/CIS_54_sudoconfiguration
+/usr/bin/sudo /usr/sbin/chown -R root:wheel /etc/sudoers.d/

--- a/ee/cis/macos-14/test/scripts/CIS_5.5.sh
+++ b/ee/cis/macos-14/test/scripts/CIS_5.5.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+echo 'Defaults timestamp_type=tty' | sudo tee /etc/sudoers.d/CIS_55_sudoconfiguration

--- a/ee/cis/macos-14/test/scripts/CIS_5.6.sh
+++ b/ee/cis/macos-14/test/scripts/CIS_5.6.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+/usr/bin/sudo /usr/sbin/dsenableroot -d

--- a/ee/cis/macos-14/test/scripts/CIS_5.7.sh
+++ b/ee/cis/macos-14/test/scripts/CIS_5.7.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+/usr/bin/sudo /usr/bin/security authorizationdb write system.login.screensaver use-login-window-ui

--- a/ee/cis/macos-14/test/scripts/CIS_5.8.sh
+++ b/ee/cis/macos-14/test/scripts/CIS_5.8.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+echo "Content of the banner" | sudo tee /Library/Security/PolicyBanner.txt
+/usr/bin/sudo /usr/sbin/chown root:wheel /Library/Security/PolicyBanner.txt
+/usr/bin/sudo /bin/chmod o+r /Library/Security/PolicyBanner.txt

--- a/ee/cis/macos-14/test/scripts/CIS_6.1.1.sh
+++ b/ee/cis/macos-14/test/scripts/CIS_6.1.1.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+
+# For QA: Replace <username> with your test user
+/usr/bin/sudo -u <username> /usr/bin/defaults write /Users/<username>/Library/Preferences/.GlobalPreferences.plist AppleShowAllExtensions -bool true

--- a/ee/cis/macos-14/test/scripts/CIS_6.3.6.sh
+++ b/ee/cis/macos-14/test/scripts/CIS_6.3.6.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+/usr/bin/sudo -u <username> /usr/bin/defaults write /Users/<username>/Library/Containers/com.apple.Safari/Data/Library/Preferences/com.apple.Safari WebKitPreferences.privateClickMeasurementEnabled -bool true

--- a/ee/cis/macos-14/test/scripts/not_always_working_CIS_2.10.1.sh
+++ b/ee/cis/macos-14/test/scripts/not_always_working_CIS_2.10.1.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+#replace username
+sudo -u <username> /usr/bin/defaults -currentHost write com.apple.screensaver idleTime -int 1200

--- a/ee/cis/macos-14/test/scripts/not_always_working_CIS_2.10.2.sh
+++ b/ee/cis/macos-14/test/scripts/not_always_working_CIS_2.10.2.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+sudo /usr/sbin/sysadminctl -screenLock immediate -password <administrator password>
+sudo /usr/sbin/sysadminctl -screenLock 5 seconds -password <administrator password>


### PR DESCRIPTION
This PR adds support for CIS Controls for macOS 14 - Sonoma.

The CIS Control changes from macOS 13 to 14 was minimal:

- Removed 5.9
- Added 2.18.1