### PR TITLE
Fleet UI: Update Observer+ CTA for live query button

### DIFF
--- a/changes/14984-observer-plus-cta-wording
+++ b/changes/14984-observer-plus-cta-wording
@@ -1,0 +1,1 @@
+- Clearer CTA for Observer+

--- a/frontend/pages/queries/ManageQueriesPage/ManageQueriesPage.tsx
+++ b/frontend/pages/queries/ManageQueriesPage/ManageQueriesPage.tsx
@@ -461,7 +461,7 @@ const ManageQueriesPage = ({
                     className={`${baseClass}__create-button`}
                     onClick={onCreateQueryClick}
                   >
-                    Add query
+                    {isObserverPlus ? "Live query" : "Add query"}
                   </Button>
                 </>
               )}


### PR DESCRIPTION
## Issue
Cerra #14984

## Description
- For observer + only, change copy on manage queries page from "Add query" to "Live query"

## Screenrecording (Viewing: global observer+)

https://github.com/fleetdm/fleet/assets/71795832/b47ce733-7b7e-4844-a122-358510420ba8

## Dev self tested
- [x] Global observer+
- [x] Team observer+

## Updates to QA Wolf
IFAICT two tests need tiny copy changes:
 - `Queries - Observer+: Observer+ Global can create and run a live query`
 - `Queries - Observer+: Observer+ Team role can create and run a live query`

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
- [x] Manual QA for all new/changed functionality
