### PR TITLE
Fleet UI: Update page titles

### DIFF
--- a/changes/15902-update-page-titles
+++ b/changes/15902-update-page-titles
@@ -1,0 +1,1 @@
+- Clearer browser page titles

--- a/frontend/components/App/App.tsx
+++ b/frontend/components/App/App.tsx
@@ -24,7 +24,6 @@ import Fleet404 from "pages/errors/Fleet404";
 import Fleet500 from "pages/errors/Fleet500";
 import Spinner from "components/Spinner";
 import { QueryParams } from "utilities/url";
-import { DOCUMENT_TITLE_SUFFIX } from "utilities/constants";
 
 interface IAppProps {
   children: JSX.Element;
@@ -118,14 +117,6 @@ const App = ({ children, location }: IAppProps): JSX.Element => {
     const curTitle = page_titles.find((item) =>
       location?.pathname.includes(item.path)
     );
-
-    // Override Controls page title if MDM not configured
-    if (
-      !config?.mdm.enabled_and_configured &&
-      curTitle?.path === "/controls/os-updates"
-    ) {
-      curTitle.title = `Manage OS hosts | ${DOCUMENT_TITLE_SUFFIX}`;
-    }
 
     if (curTitle && curTitle.title) {
       document.title = curTitle.title;

--- a/frontend/pages/hosts/details/DeviceUserPage/DeviceUserPage.tsx
+++ b/frontend/pages/hosts/details/DeviceUserPage/DeviceUserPage.tsx
@@ -294,18 +294,6 @@ const DeviceUserPage = ({
 
   // Updates title that shows up on browser tabs
   useEffect(() => {
-    const hostTab = () => {
-      if (location.pathname.includes("software")) {
-        return "software";
-      }
-      if (location.pathname.includes("schedule")) {
-        return "schedule";
-      }
-      if (location.pathname.includes("policies")) {
-        return "policies";
-      }
-      return "";
-    };
     document.title = `My device | ${DOCUMENT_TITLE_SUFFIX}`;
   }, [location.pathname, host]);
 

--- a/frontend/pages/hosts/details/DeviceUserPage/DeviceUserPage.tsx
+++ b/frontend/pages/hosts/details/DeviceUserPage/DeviceUserPage.tsx
@@ -307,7 +307,7 @@ const DeviceUserPage = ({
       return "";
     };
 
-    // e.g., Rachel's Macbook Pro schedule details | Fleet for osquery
+    // e.g., Rachel's Macbook Pro schedule details | Fleet
     document.title = `My device ${hostTab()} details | ${
       host?.display_name || "Unknown host"
     } | ${DOCUMENT_TITLE_SUFFIX}`;

--- a/frontend/pages/hosts/details/DeviceUserPage/DeviceUserPage.tsx
+++ b/frontend/pages/hosts/details/DeviceUserPage/DeviceUserPage.tsx
@@ -306,11 +306,7 @@ const DeviceUserPage = ({
       }
       return "";
     };
-
-    // e.g., Rachel's Macbook Pro schedule details | Fleet
-    document.title = `My device ${hostTab()} details | ${
-      host?.display_name || "Unknown host"
-    } | ${DOCUMENT_TITLE_SUFFIX}`;
+    document.title = `My device | ${DOCUMENT_TITLE_SUFFIX}`;
   }, [location.pathname, host]);
 
   const renderActionButtons = () => {

--- a/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
@@ -348,6 +348,8 @@ const HostDetailsPage = ({
     if (host?.display_name) {
       // e.g., Rachel's Macbook Pro | Hosts | Fleet
       document.title = `${host?.display_name} | Hosts | ${DOCUMENT_TITLE_SUFFIX}`;
+    } else {
+      document.title = `Hosts | ${DOCUMENT_TITLE_SUFFIX}`;
     }
   }, [location.pathname, host]);
 

--- a/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
@@ -52,7 +52,6 @@ import {
 } from "utilities/helpers";
 import permissions from "utilities/permissions";
 import ScriptDetailsModal from "pages/DashboardPage/cards/ActivityFeed/components/ScriptDetailsModal";
-import { DOCUMENT_TITLE_SUFFIX } from "utilities/constants";
 
 import HostSummaryCard from "../cards/HostSummary";
 import AboutCard from "../cards/About";

--- a/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
@@ -345,23 +345,10 @@ const HostDetailsPage = ({
 
   // Updates title that shows up on browser tabs
   useEffect(() => {
-    const hostTab = () => {
-      if (location.pathname.includes("software")) {
-        return "software";
-      }
-      if (location.pathname.includes("schedule")) {
-        return "schedule";
-      }
-      if (location.pathname.includes("policies")) {
-        return "policies";
-      }
-      return "";
-    };
-
-    // e.g., Rachel's Macbook Pro schedule details | Fleet for osquery
-    document.title = `${
-      host?.display_name ? `${host?.display_name} | ` : ""
-    }Hosts | ${DOCUMENT_TITLE_SUFFIX}`;
+    if (host?.display_name) {
+      // e.g., Rachel's Macbook Pro | Hosts | Fleet
+      document.title = `${host?.display_name} | Hosts | ${DOCUMENT_TITLE_SUFFIX}`;
+    }
   }, [location.pathname, host]);
 
   // Used for back to software pathname

--- a/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
@@ -52,6 +52,7 @@ import {
 } from "utilities/helpers";
 import permissions from "utilities/permissions";
 import ScriptDetailsModal from "pages/DashboardPage/cards/ActivityFeed/components/ScriptDetailsModal";
+import { DOCUMENT_TITLE_SUFFIX } from "utilities/constants";
 
 import HostSummaryCard from "../cards/HostSummary";
 import AboutCard from "../cards/About";
@@ -356,6 +357,11 @@ const HostDetailsPage = ({
       }
       return "";
     };
+
+    // e.g., Rachel's Macbook Pro schedule details | Fleet for osquery
+    document.title = `${
+      host?.display_name ? `${host?.display_name} | ` : ""
+    }Hosts | ${DOCUMENT_TITLE_SUFFIX}`;
   }, [location.pathname, host]);
 
   // Used for back to software pathname

--- a/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
@@ -357,11 +357,6 @@ const HostDetailsPage = ({
       }
       return "";
     };
-
-    // e.g., Rachel's Macbook Pro schedule details | Fleet for osquery
-    document.title = `Host ${hostTab()} details ${
-      host?.display_name ? `| ${host?.display_name} |` : "|"
-    } ${DOCUMENT_TITLE_SUFFIX}`;
   }, [location.pathname, host]);
 
   // Used for back to software pathname

--- a/frontend/pages/hosts/details/HostQueryReport/HostQueryReport.tsx
+++ b/frontend/pages/hosts/details/HostQueryReport/HostQueryReport.tsx
@@ -95,7 +95,9 @@ const HostQueryReport = ({
     router.push(PATHS.HOST_QUERIES(hostId));
   }
 
-  document.title = `Host query report | ${queryName} | ${hostName} | ${DOCUMENT_TITLE_SUFFIX}`;
+  document.title = ` ${
+    queryName && hostName ? `${queryName} (${hostName}) |` : ""
+  } Hosts | ${DOCUMENT_TITLE_SUFFIX}`;
 
   const HQRHeader = useCallback(() => {
     const fullReportPath = PATHS.QUERY_DETAILS(queryId);

--- a/frontend/pages/hosts/details/HostQueryReport/HostQueryReport.tsx
+++ b/frontend/pages/hosts/details/HostQueryReport/HostQueryReport.tsx
@@ -95,9 +95,12 @@ const HostQueryReport = ({
     router.push(PATHS.HOST_QUERIES(hostId));
   }
 
-  document.title = ` ${
-    queryName && hostName ? `${queryName} (${hostName}) |` : ""
-  } Hosts | ${DOCUMENT_TITLE_SUFFIX}`;
+  // Updates title that shows up on browser tabs
+  if (queryName && hostName) {
+    // e.g., Discover TLS certificates (Rachel's MacBook Pro) | Hosts | Fleet
+    document.title = `${queryName} (${hostName}) |
+   Hosts | ${DOCUMENT_TITLE_SUFFIX}`;
+  }
 
   const HQRHeader = useCallback(() => {
     const fullReportPath = PATHS.QUERY_DETAILS(queryId);

--- a/frontend/pages/hosts/details/HostQueryReport/HostQueryReport.tsx
+++ b/frontend/pages/hosts/details/HostQueryReport/HostQueryReport.tsx
@@ -100,6 +100,8 @@ const HostQueryReport = ({
     // e.g., Discover TLS certificates (Rachel's MacBook Pro) | Hosts | Fleet
     document.title = `${queryName} (${hostName}) |
    Hosts | ${DOCUMENT_TITLE_SUFFIX}`;
+  } else {
+    document.title = `Hosts | ${DOCUMENT_TITLE_SUFFIX}`;
   }
 
   const HQRHeader = useCallback(() => {

--- a/frontend/pages/policies/PolicyPage/PolicyPage.tsx
+++ b/frontend/pages/policies/PolicyPage/PolicyPage.tsx
@@ -209,6 +209,8 @@ const PolicyPage = ({
     // e.g., Antivirus healthy (Linux) | Policies | Fleet
     if (storedPolicy?.name) {
       document.title = `${storedPolicy.name} | Policies | ${DOCUMENT_TITLE_SUFFIX}`;
+    } else {
+      document.title = `Policies | ${DOCUMENT_TITLE_SUFFIX}`;
     }
   }, [location.pathname, storedPolicy?.name]);
 

--- a/frontend/pages/policies/PolicyPage/PolicyPage.tsx
+++ b/frontend/pages/policies/PolicyPage/PolicyPage.tsx
@@ -19,7 +19,7 @@ import globalPoliciesAPI from "services/entities/global_policies";
 import teamPoliciesAPI from "services/entities/team_policies";
 import hostAPI from "services/entities/hosts";
 import statusAPI from "services/entities/status";
-import { DOCUMENT_TITLE_SUFFIX, LIVE_POLICY_STEPS } from "utilities/constants";
+import { LIVE_POLICY_STEPS } from "utilities/constants";
 
 import QuerySidePanel from "components/side_panels/QuerySidePanel";
 import QueryEditor from "pages/policies/PolicyPage/screens/QueryEditor";
@@ -203,12 +203,6 @@ const PolicyPage = ({
   useEffect(() => {
     detectIsFleetQueryRunnable();
   }, []);
-
-  // Updates title that shows up on browser tabs
-  useEffect(() => {
-    // e.g., Policy details | Antivirus healthy (Linux) | Fleet for osquery
-    document.title = `Policy details | ${storedPolicy?.name} | ${DOCUMENT_TITLE_SUFFIX}`;
-  }, [location.pathname, storedPolicy?.name]);
 
   useEffect(() => {
     setShowOpenSchemaActionText(!isSidebarOpen);

--- a/frontend/pages/policies/PolicyPage/PolicyPage.tsx
+++ b/frontend/pages/policies/PolicyPage/PolicyPage.tsx
@@ -19,7 +19,7 @@ import globalPoliciesAPI from "services/entities/global_policies";
 import teamPoliciesAPI from "services/entities/team_policies";
 import hostAPI from "services/entities/hosts";
 import statusAPI from "services/entities/status";
-import { LIVE_POLICY_STEPS } from "utilities/constants";
+import { DOCUMENT_TITLE_SUFFIX, LIVE_POLICY_STEPS } from "utilities/constants";
 
 import QuerySidePanel from "components/side_panels/QuerySidePanel";
 import QueryEditor from "pages/policies/PolicyPage/screens/QueryEditor";
@@ -203,6 +203,14 @@ const PolicyPage = ({
   useEffect(() => {
     detectIsFleetQueryRunnable();
   }, []);
+
+  // Updates title that shows up on browser tabs
+  useEffect(() => {
+    // e.g., Antivirus healthy (Linux) | Policies | Fleet
+    if (storedPolicy?.name) {
+      document.title = `${storedPolicy.name} | Policies | ${DOCUMENT_TITLE_SUFFIX}`;
+    }
+  }, [location.pathname, storedPolicy?.name]);
 
   useEffect(() => {
     setShowOpenSchemaActionText(!isSidebarOpen);

--- a/frontend/pages/queries/details/QueryDetailsPage/QueryDetailsPage.tsx
+++ b/frontend/pages/queries/details/QueryDetailsPage/QueryDetailsPage.tsx
@@ -21,6 +21,7 @@ import {
   isGlobalObserver,
   isTeamObserver,
 } from "utilities/permissions/permissions";
+import { DEFAULT_QUERY, DOCUMENT_TITLE_SUFFIX } from "utilities/constants";
 
 import Spinner from "components/Spinner/Spinner";
 import Button from "components/buttons/Button";
@@ -172,6 +173,16 @@ const QueryDetailsPage = ({
       setCurrentTeam(querysTeam);
     }
   }, [storedQuery]);
+
+  // Updates title that shows up on browser tabs
+  useEffect(() => {
+    // e.g., Editing Discover TLS certificates | Queries | Fleet
+    const storedQueryTitleCopy = storedQuery?.name
+      ? `${storedQuery.name} | `
+      : "";
+    document.title = `${storedQueryTitleCopy}Queries | ${DOCUMENT_TITLE_SUFFIX}`;
+    // }
+  }, [location.pathname, storedQuery?.name]);
 
   const isLoading = isStoredQueryLoading || isQueryReportLoading;
   const isApiError = storedQueryError || queryReportError;

--- a/frontend/pages/queries/details/QueryDetailsPage/QueryDetailsPage.tsx
+++ b/frontend/pages/queries/details/QueryDetailsPage/QueryDetailsPage.tsx
@@ -176,12 +176,10 @@ const QueryDetailsPage = ({
 
   // Updates title that shows up on browser tabs
   useEffect(() => {
-    // e.g., Editing Discover TLS certificates | Queries | Fleet
-    const storedQueryTitleCopy = storedQuery?.name
-      ? `${storedQuery.name} | `
-      : "";
-    document.title = `${storedQueryTitleCopy}Queries | ${DOCUMENT_TITLE_SUFFIX}`;
-    // }
+    // e.g., Discover TLS certificates | Queries | Fleet
+    if (storedQuery?.name) {
+      document.title = `${storedQuery.name} | Queries | ${DOCUMENT_TITLE_SUFFIX}`;
+    }
   }, [location.pathname, storedQuery?.name]);
 
   const isLoading = isStoredQueryLoading || isQueryReportLoading;

--- a/frontend/pages/queries/details/QueryDetailsPage/QueryDetailsPage.tsx
+++ b/frontend/pages/queries/details/QueryDetailsPage/QueryDetailsPage.tsx
@@ -179,6 +179,8 @@ const QueryDetailsPage = ({
     // e.g., Discover TLS certificates | Queries | Fleet
     if (storedQuery?.name) {
       document.title = `${storedQuery.name} | Queries | ${DOCUMENT_TITLE_SUFFIX}`;
+    } else {
+      document.title = `Queries | ${DOCUMENT_TITLE_SUFFIX}`;
     }
   }, [location.pathname, storedQuery?.name]);
 

--- a/frontend/pages/queries/details/QueryDetailsPage/QueryDetailsPage.tsx
+++ b/frontend/pages/queries/details/QueryDetailsPage/QueryDetailsPage.tsx
@@ -17,7 +17,6 @@ import { IQueryReport } from "interfaces/query_report";
 
 import queryAPI from "services/entities/queries";
 import queryReportAPI, { ISortOption } from "services/entities/query_report";
-import { DOCUMENT_TITLE_SUFFIX } from "utilities/constants";
 import {
   isGlobalObserver,
   isTeamObserver,
@@ -108,15 +107,6 @@ const QueryDetailsPage = ({
     setLastEditedQueryPlatforms,
     setLastEditedQueryDiscardData,
   } = useContext(QueryContext);
-
-  // Title that shows up on browser tabs (e.g., Query details | Discover TLS certificates | Fleet for osquery)
-
-  useEffect(() => {
-    const queryNameCopy = lastEditedQueryName
-      ? `${lastEditedQueryName} | `
-      : "";
-    document.title = `Query details | ${queryNameCopy}${DOCUMENT_TITLE_SUFFIX}`;
-  }, [lastEditedQueryName]);
 
   const [disabledCachingGlobally, setDisabledCachingGlobally] = useState(true);
 

--- a/frontend/pages/queries/details/QueryDetailsPage/QueryDetailsPage.tsx
+++ b/frontend/pages/queries/details/QueryDetailsPage/QueryDetailsPage.tsx
@@ -21,7 +21,7 @@ import {
   isGlobalObserver,
   isTeamObserver,
 } from "utilities/permissions/permissions";
-import { DEFAULT_QUERY, DOCUMENT_TITLE_SUFFIX } from "utilities/constants";
+import { DOCUMENT_TITLE_SUFFIX } from "utilities/constants";
 
 import Spinner from "components/Spinner/Spinner";
 import Button from "components/buttons/Button";

--- a/frontend/pages/queries/edit/EditQueryPage.tsx
+++ b/frontend/pages/queries/edit/EditQueryPage.tsx
@@ -202,11 +202,11 @@ const EditQueryPage = ({
 
   // Updates title that shows up on browser tabs
   useEffect(() => {
-    // e.g., Query details | Discover TLS certificates | Fleet
+    // e.g., Editing Discover TLS certificates | Queries | Fleet
     const storedQueryTitleCopy = storedQuery?.name
-      ? `${storedQuery.name} | `
+      ? `Editing ${storedQuery.name} | `
       : "";
-    document.title = `Edit query | ${storedQueryTitleCopy} ${DOCUMENT_TITLE_SUFFIX}`;
+    document.title = `${storedQueryTitleCopy} Queries | ${DOCUMENT_TITLE_SUFFIX}`;
     // }
   }, [location.pathname, storedQuery?.name]);
 

--- a/frontend/pages/queries/edit/EditQueryPage.tsx
+++ b/frontend/pages/queries/edit/EditQueryPage.tsx
@@ -203,11 +203,9 @@ const EditQueryPage = ({
   // Updates title that shows up on browser tabs
   useEffect(() => {
     // e.g., Editing Discover TLS certificates | Queries | Fleet
-    const storedQueryTitleCopy = storedQuery?.name
-      ? `Editing ${storedQuery.name} | `
-      : "";
-    document.title = `${storedQueryTitleCopy} Queries | ${DOCUMENT_TITLE_SUFFIX}`;
-    // }
+    if (storedQuery?.name) {
+      document.title = `Editing ${storedQuery.name} | Queries | ${DOCUMENT_TITLE_SUFFIX}`;
+    }
   }, [location.pathname, storedQuery?.name]);
 
   useEffect(() => {

--- a/frontend/pages/queries/edit/EditQueryPage.tsx
+++ b/frontend/pages/queries/edit/EditQueryPage.tsx
@@ -202,7 +202,7 @@ const EditQueryPage = ({
 
   // Updates title that shows up on browser tabs
   useEffect(() => {
-    // e.g., Query details | Discover TLS certificates | Fleet for osquery
+    // e.g., Query details | Discover TLS certificates | Fleet
     const storedQueryTitleCopy = storedQuery?.name
       ? `${storedQuery.name} | `
       : "";

--- a/frontend/pages/queries/edit/EditQueryPage.tsx
+++ b/frontend/pages/queries/edit/EditQueryPage.tsx
@@ -205,6 +205,8 @@ const EditQueryPage = ({
     // e.g., Editing Discover TLS certificates | Queries | Fleet
     if (storedQuery?.name) {
       document.title = `Editing ${storedQuery.name} | Queries | ${DOCUMENT_TITLE_SUFFIX}`;
+    } else {
+      document.title = `Queries | ${DOCUMENT_TITLE_SUFFIX}`;
     }
   }, [location.pathname, storedQuery?.name]);
 

--- a/frontend/pages/queries/live/LiveQueryPage/LiveQueryPage.tsx
+++ b/frontend/pages/queries/live/LiveQueryPage/LiveQueryPage.tsx
@@ -139,7 +139,7 @@ const RunQueryPage = ({
   // Updates title that shows up on browser tabs
   useEffect(() => {
     const queryNameCopy = storedQuery?.name ? `${storedQuery?.name} | ` : "";
-    // e.g., Run live query | Discover TLS certificates | Fleet for osquery
+    // e.g., Run live query | Discover TLS certificates | Fleet
     document.title = `Run live query | ${queryNameCopy}${DOCUMENT_TITLE_SUFFIX}`;
   }, [location.pathname, storedQuery?.name]);
 

--- a/frontend/pages/queries/live/LiveQueryPage/LiveQueryPage.tsx
+++ b/frontend/pages/queries/live/LiveQueryPage/LiveQueryPage.tsx
@@ -138,9 +138,12 @@ const RunQueryPage = ({
 
   // Updates title that shows up on browser tabs
   useEffect(() => {
-    const queryNameCopy = storedQuery?.name ? `${storedQuery?.name} | ` : "";
     // e.g., Run Discover TLS certificates | Queries | Fleet
-    document.title = `Run ${queryNameCopy} | Queries | ${DOCUMENT_TITLE_SUFFIX}`;
+    if (storedQuery?.name) {
+      document.title = `Run ${storedQuery.name} | Queries | ${DOCUMENT_TITLE_SUFFIX}`;
+    } else {
+      document.title = `Queries | ${DOCUMENT_TITLE_SUFFIX}`;
+    }
   }, [location.pathname, storedQuery?.name]);
 
   const goToQueryEditor = useCallback(

--- a/frontend/pages/queries/live/LiveQueryPage/LiveQueryPage.tsx
+++ b/frontend/pages/queries/live/LiveQueryPage/LiveQueryPage.tsx
@@ -139,8 +139,8 @@ const RunQueryPage = ({
   // Updates title that shows up on browser tabs
   useEffect(() => {
     const queryNameCopy = storedQuery?.name ? `${storedQuery?.name} | ` : "";
-    // e.g., Run live query | Discover TLS certificates | Fleet
-    document.title = `Run live query | ${queryNameCopy}${DOCUMENT_TITLE_SUFFIX}`;
+    // e.g., Run Discover TLS certificates | Queries | Fleet
+    document.title = `Run ${queryNameCopy} | Queries | ${DOCUMENT_TITLE_SUFFIX}`;
   }, [location.pathname, storedQuery?.name]);
 
   const goToQueryEditor = useCallback(

--- a/frontend/router/page_titles.ts
+++ b/frontend/router/page_titles.ts
@@ -8,24 +8,12 @@ export default [
   { path: PATHS.DASHBOARD, title: `Dashboard | ${DOCUMENT_TITLE_SUFFIX}` },
   { path: "/hosts/manage", title: `Hosts | ${DOCUMENT_TITLE_SUFFIX}` },
   {
-    path: PATHS.CONTROLS_OS_UPDATES,
-    title: `Controls (OS updates) | ${DOCUMENT_TITLE_SUFFIX}`,
-  },
-  {
-    path: PATHS.CONTROLS_OS_SETTINGS,
-    title: `Controls (OS settings) | ${DOCUMENT_TITLE_SUFFIX}`,
-  },
-  {
-    path: PATHS.CONTROLS_SETUP_EXPERIENCE,
-    title: `Controls (Setup experience) | ${DOCUMENT_TITLE_SUFFIX}`,
+    path: "/controls",
+    title: `Controls | ${DOCUMENT_TITLE_SUFFIX}`,
   },
   {
     path: "/software/",
     title: `Software | ${DOCUMENT_TITLE_SUFFIX}`,
-  },
-  {
-    path: "/packs/",
-    title: `Packs | ${DOCUMENT_TITLE_SUFFIX}`,
   },
   {
     path: PATHS.MANAGE_QUERIES,
@@ -40,5 +28,9 @@ export default [
   {
     path: "/settings/",
     title: `Settings | ${DOCUMENT_TITLE_SUFFIX}`,
+  },
+  {
+    path: PATHS.USER_SETTINGS,
+    title: `Settings | My account | ${DOCUMENT_TITLE_SUFFIX}`,
   },
 ];

--- a/frontend/router/page_titles.ts
+++ b/frontend/router/page_titles.ts
@@ -6,13 +6,13 @@ import PATHS from "router/paths";
 // Note: Order matters for use of array.find() (specific subpaths must be listed before their parent path)
 export default [
   { path: PATHS.DASHBOARD, title: `Dashboard | ${DOCUMENT_TITLE_SUFFIX}` },
-  { path: "/hosts/manage", title: `Hosts | ${DOCUMENT_TITLE_SUFFIX}` },
+  { path: PATHS.MANAGE_HOSTS, title: `Hosts | ${DOCUMENT_TITLE_SUFFIX}` },
   {
-    path: "/controls",
+    path: PATHS.CONTROLS,
     title: `Controls | ${DOCUMENT_TITLE_SUFFIX}`,
   },
   {
-    path: "/software/",
+    path: PATHS.SOFTWARE,
     title: `Software | ${DOCUMENT_TITLE_SUFFIX}`,
   },
   {
@@ -26,7 +26,7 @@ export default [
   },
   { path: PATHS.NEW_POLICY, title: `New policy | ${DOCUMENT_TITLE_SUFFIX}` },
   {
-    path: "/settings/",
+    path: PATHS.ADMIN_SETTINGS,
     title: `Settings | ${DOCUMENT_TITLE_SUFFIX}`,
   },
   {

--- a/frontend/router/page_titles.ts
+++ b/frontend/router/page_titles.ts
@@ -6,67 +6,39 @@ import PATHS from "router/paths";
 // Note: Order matters for use of array.find() (specific subpaths must be listed before their parent path)
 export default [
   { path: PATHS.DASHBOARD, title: `Dashboard | ${DOCUMENT_TITLE_SUFFIX}` },
-  { path: "/hosts/manage", title: `Manage hosts | ${DOCUMENT_TITLE_SUFFIX}` },
+  { path: "/hosts/manage", title: `Hosts | ${DOCUMENT_TITLE_SUFFIX}` },
   {
     path: PATHS.CONTROLS_OS_UPDATES,
-    title: `Manage OS updates | ${DOCUMENT_TITLE_SUFFIX}`,
+    title: `Controls (OS updates) | ${DOCUMENT_TITLE_SUFFIX}`,
   },
   {
     path: PATHS.CONTROLS_OS_SETTINGS,
-    title: `Manage OS settings | ${DOCUMENT_TITLE_SUFFIX}`,
+    title: `Controls (OS settings) | ${DOCUMENT_TITLE_SUFFIX}`,
   },
   {
     path: PATHS.CONTROLS_SETUP_EXPERIENCE,
-    title: `Manage setup experience | ${DOCUMENT_TITLE_SUFFIX}`,
+    title: `Controls (Setup experience) | ${DOCUMENT_TITLE_SUFFIX}`,
   },
   {
-    path: PATHS.SOFTWARE_TITLES,
-    title: `Software titles | ${DOCUMENT_TITLE_SUFFIX}`,
+    path: "/software/",
+    title: `Software | ${DOCUMENT_TITLE_SUFFIX}`,
   },
   {
-    path: PATHS.SOFTWARE_VERSIONS,
-    title: `Software versions | ${DOCUMENT_TITLE_SUFFIX}`,
+    path: "/packs/",
+    title: `Packs | ${DOCUMENT_TITLE_SUFFIX}`,
   },
   {
     path: PATHS.MANAGE_QUERIES,
-    title: `Manage queries | ${DOCUMENT_TITLE_SUFFIX}`,
+    title: `Queries | ${DOCUMENT_TITLE_SUFFIX}`,
   },
   { path: PATHS.NEW_QUERY(), title: `New query | ${DOCUMENT_TITLE_SUFFIX}` },
   {
     path: PATHS.MANAGE_POLICIES,
-    title: `Manage policies | ${DOCUMENT_TITLE_SUFFIX}`,
+    title: `Policies | ${DOCUMENT_TITLE_SUFFIX}`,
   },
   { path: PATHS.NEW_POLICY, title: `New policy | ${DOCUMENT_TITLE_SUFFIX}` },
   {
-    path: PATHS.ADMIN_ORGANIZATION,
-    title: `Manage organization settings | ${DOCUMENT_TITLE_SUFFIX}`,
-  },
-  {
-    path: PATHS.ADMIN_INTEGRATIONS,
-    title: `Manage integration settings | ${DOCUMENT_TITLE_SUFFIX}`,
-  },
-  {
-    path: PATHS.ADMIN_USERS,
-    title: `Manage user settings | ${DOCUMENT_TITLE_SUFFIX}`,
-  },
-  {
-    path: "/settings/teams/members",
-    // TODO
-    // path: PATHS.TEAM_DETAILS_MEMBERS(), needs params
-    title: `Manage team members | ${DOCUMENT_TITLE_SUFFIX}`,
-  },
-  {
-    path: "/settings/teams/options",
-    // TODO
-    // path: PATHS.TEAM_DETAILS_OPTIONS(), needs params
-    title: `Manage team options | ${DOCUMENT_TITLE_SUFFIX}`,
-  },
-  {
-    path: PATHS.ADMIN_TEAMS,
-    title: `Manage team settings | ${DOCUMENT_TITLE_SUFFIX}`,
-  },
-  {
-    path: PATHS.USER_SETTINGS,
-    title: `Manage my account | ${DOCUMENT_TITLE_SUFFIX}`,
+    path: "/settings/",
+    title: `Settings | ${DOCUMENT_TITLE_SUFFIX}`,
   },
 ];

--- a/frontend/router/paths.ts
+++ b/frontend/router/paths.ts
@@ -23,6 +23,7 @@ export default {
   DASHBOARD_CHROME: `${URL_PREFIX}/dashboard/chrome`,
 
   // Admin pages
+  ADMIN_SETTINGS: `${URL_PREFIX}/settings`,
   ADMIN_USERS: `${URL_PREFIX}/settings/users`,
   ADMIN_INTEGRATIONS: `${URL_PREFIX}/settings/integrations`,
   ADMIN_INTEGRATIONS_TICKET_DESTINATIONS: `${URL_PREFIX}/settings/integrations/ticket-destinations`,
@@ -44,6 +45,7 @@ export default {
   ADMIN_ORGANIZATION_FLEET_DESKTOP: `${URL_PREFIX}/settings/organization/fleet-desktop`,
 
   // Software pages
+  SOFTWARE: `${URL_PREFIX}/software`,
   SOFTWARE_TITLES: `${URL_PREFIX}/software/titles`,
   SOFTWARE_VERSIONS: `${URL_PREFIX}/software/versions`,
   SOFTWARE_TITLE_DETAILS: (id: string): string => {

--- a/frontend/templates/react.ejs
+++ b/frontend/templates/react.ejs
@@ -63,7 +63,7 @@
     />
     <link rel="shortcut icon" href="{{.URLPrefix}}/assets/favicon.ico" />
 
-    <title>Fleet for osquery</title>
+    <title>Fleet</title>
     <script type="text/javascript">
       var urlPrefix = "{{.URLPrefix}}";
     </script>

--- a/frontend/utilities/constants.tsx
+++ b/frontend/utilities/constants.tsx
@@ -303,4 +303,4 @@ export const EMPTY_AGENT_OPTIONS = {
 
 export const DEFAULT_EMPTY_CELL_VALUE = "---";
 
-export const DOCUMENT_TITLE_SUFFIX = "Fleet for osquery";
+export const DOCUMENT_TITLE_SUFFIX = "Fleet";

--- a/website/api/controllers/docs/view-basic-documentation.js
+++ b/website/api/controllers/docs/view-basic-documentation.js
@@ -69,7 +69,7 @@ module.exports = {
       compiledPagePartialsAppPath: sails.config.builtStaticContent.compiledPagePartialsAppPath,
       pageTitleForMeta: (
         thisPage.title !== 'Readme.md' ? thisPage.title + ' | Fleet documentation'// « custom meta title for this page, if provided in markdown
-        : 'Documentation | Fleet for osquery' // « otherwise we're on the landing page for this section of the site, so we'll follow the title format of other top-level pages
+        : 'Documentation | Fleet' // « otherwise we're on the landing page for this section of the site, so we'll follow the title format of other top-level pages
       ),
       pageDescriptionForMeta: (
         thisPage.meta.description ? thisPage.meta.description // « custom meta description for this page, if provided in markdown

--- a/website/api/controllers/download-rss-feed.js
+++ b/website/api/controllers/download-rss-feed.js
@@ -87,7 +87,7 @@ module.exports = {
         categoryDescription = '';
         break;
       case 'articles':
-        articleCategoryTitle = 'Fleet blog | Fleet for osquery';
+        articleCategoryTitle = 'Fleet blog | Fleet';
         categoryDescription = 'Read all articles from Fleet\'s blog.';
     }
 

--- a/website/api/controllers/handbook/view-basic-handbook.js
+++ b/website/api/controllers/handbook/view-basic-handbook.js
@@ -64,7 +64,7 @@ module.exports = {
       compiledPagePartialsAppPath: sails.config.builtStaticContent.compiledPagePartialsAppPath,
       pageTitleForMeta: (
         thisPage.title !== 'Readme.md' ? thisPage.title + ' | Fleet handbook'// « custom meta title for this page, if provided in markdown
-        : 'Handbook | Fleet for osquery' // « otherwise we're on the landing page for this section of the site, so we'll follow the title format of other top-level pages
+        : 'Handbook | Fleet' // « otherwise we're on the landing page for this section of the site, so we'll follow the title format of other top-level pages
       ),
       pageDescriptionForMeta: (
         thisPage.meta.description ? thisPage.meta.description // « custom meta description for this page, if provided in markdown


### PR DESCRIPTION
## Issue
Cerra #15902 

## Description
- Update app's browser page titles to be more clear
- Includes removing "for osquery" on page titles that include "Fleet for osquery" throughout website as well

## Screenshot example
<img width="1085" alt="Screenshot 2024-01-09 at 10 59 22 AM" src="https://github.com/fleetdm/fleet/assets/71795832/f6a1aa54-aaac-41be-81ea-53d66d1e2b8b">

## Dev QA
Can be found on column A of the [Issue 15902's spreadsheet](https://docs.google.com/spreadsheets/d/1MGof3GwhMe6-I_ejhWuxDpWuRwukEBYar2nsHlVSWFE/edit?usp=sharing)

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
- [x] Manual QA for all new/changed functionality

