### PR TITLE
lock in macOS version for Fleet Desktop workers

### DIFF
--- a/.github/workflows/fleet-and-orbit.yml
+++ b/.github/workflows/fleet-and-orbit.yml
@@ -203,7 +203,13 @@ jobs:
     strategy:
       matrix:
         go-version: ['${{ vars.GO_VERSION }}']
-    runs-on: macos-latest
+    # Set macOS version to '12' (current equivalent to macos-latest) for
+    # building the binary. This ensures compatibility with macOS version 13 and
+    # later, avoiding runtime errors on systems using macOS 13 or newer.
+    #
+    # Note: Update this version to '13' once GitHub marks macOS 13 as stable
+    # or if we revise our minimum supported macOS version.
+    runs-on: macos-12
     steps:
 
     - name: Install Go

--- a/.github/workflows/generate-desktop-targets.yml
+++ b/.github/workflows/generate-desktop-targets.yml
@@ -31,7 +31,13 @@ permissions:
 
 jobs:
   desktop-macos:
-    runs-on: macos-latest
+    # Set macOS version to '12' (current equivalent to macos-latest) for
+    # building the binary. This ensures compatibility with macOS version 13 and
+    # later, avoiding runtime errors on systems using macOS 13 or newer.
+    #
+    # Note: Update this version to '13' once GitHub marks macOS 13 as stable
+    # or if we revise our minimum supported macOS version.
+    runs-on: macos-12
     steps:
 
       - name: Install Go

--- a/tools/tuf/test/README.md
+++ b/tools/tuf/test/README.md
@@ -83,3 +83,19 @@ make desktop-app-tar-gz
 # Push the desktop target as a new version
 ./tools/tuf/test/push_target.sh macos desktop desktop.app.tar.gz 43
 ```
+
+### Troubleshooting
+
+#### Fleet Desktop Startup Issue on macOS
+
+When running Fleet Desktop on an older macOS version than it was compiled on, Orbit may not launch it due to an error:
+
+```
+_LSOpenURLsWithCompletionHandler() failed with error -10825
+```
+
+Solution: `Set the MACOSX_DEPLOYMENT_TARGET` environment variable to the lowest macOS version you intend to support:
+
+```
+export MACOSX_DEPLOYMENT_TARGET=13 # replace '13' with your target macOS version
+```


### PR DESCRIPTION
Implementing a safety measure to prevent issues like #15910 in production.

Setting the macOS version explicitly avoids unexpected changes in the builder runtime, ensuring the Fleet Desktop executable remains compatible.

As of this commit, 'macos-latest' refers to 'macos-12'. We're aligning the worker to this version, although building on macOS 13.x (presently in GitHub workers' beta) should also be viable.
