### PR TITLE
Update bug-report.md

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -2,7 +2,7 @@
 name: 🦟  Bug report
 about: Report a bug to help us improve.
 title: ''
-labels: 'bug,:reproduce'
+labels: 'bug,:reproduce,:incoming'
 assignees: ''
 
 ---


### PR DESCRIPTION
This new `:incoming` label is used by engineers to filter down to _new_ bugs on their sprint board during each standup. They will remove the label, indicating they have triaged the issue. 

QA removes `:reproduce`, EM removes `:incoming`. 