### PR TITLE
Refine host eligibility check for DEP migration flow

### DIFF
--- a/server/service/orbit.go
+++ b/server/service/orbit.go
@@ -193,6 +193,9 @@ func (svc *Service) GetOrbitConfig(ctx context.Context) (fleet.OrbitConfig, erro
 			notifs.RenewEnrollmentProfile = true
 		}
 
+		// TODO: consider if notification should be conditioned on the state of refetch critical
+		// queries to mitigate potential race conditions that could cause migrate option to be shown
+		// when migration is already started (see also order of switch cases in TriggerMigrateMDMDevice)
 		if appConfig.MDM.MacOSMigration.Enable &&
 			host.IsEligibleForDEPMigration() {
 			notifs.NeedsMDMMigration = true


### PR DESCRIPTION
Issue #14444 

- Includes tentative fix and additional logging for DEP migration flow

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [ ] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [ ] Documented any permissions changes (docs/Using Fleet/manage-access.md)
- [ ] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [ ] Added support on fleet's osquery simulator `cmd/osquery-perf` for new osquery data ingestion features.
- [ ] Added/updated tests
- [ ] Manual QA for all new/changed functionality
  - For Orbit and Fleet Desktop changes:
    - [ ] Manual QA must be performed in the three main OSs, macOS, Windows and Linux.
    - [ ] Auto-update manual QA, from released version of component to new version (see [tools/tuf/test](../tools/tuf/test/README.md)).
