### PR TITLE
15801 Add Windows Display Version to Host Version

### DIFF
--- a/cmd/osquery-perf/windows_11.tmpl
+++ b/cmd/osquery-perf/windows_11.tmpl
@@ -87,7 +87,7 @@
 [
   {
     "name":"Microsoft Windows 11 Enterprise",
-    "version":"10.0.22000"
+    "display_version":"22H2"
   }
 ]
 {{- end }}

--- a/server/service/osquery_utils/queries.go
+++ b/server/service/osquery_utils/queries.go
@@ -198,6 +198,7 @@ var hostDetailQueries = map[string]DetailQuery{
 			s := fmt.Sprintf("%v %v", rows[0]["name"], version)
 			// Shorten "Microsoft Windows" to "Windows" to facilitate display and sorting in UI
 			s = strings.Replace(s, "Microsoft Windows", "Windows", 1)
+			s = strings.TrimSpace(s)
 			host.OSVersion = s
 
 			return nil

--- a/server/service/osquery_utils/queries.go
+++ b/server/service/osquery_utils/queries.go
@@ -187,15 +187,7 @@ var hostDetailQueries = map[string]DetailQuery{
 				return nil
 			}
 
-			version := rows[0]["display_version"]
-			if version == "" {
-				level.Debug(logger).Log(
-					"msg", "unable to identify windows display version",
-					"host", host.Hostname,
-				)
-			}
-
-			s := fmt.Sprintf("%v %v", rows[0]["name"], version)
+			s := fmt.Sprintf("%v %v", rows[0]["name"], rows[0]["display_version"])
 			// Shorten "Microsoft Windows" to "Windows" to facilitate display and sorting in UI
 			s = strings.Replace(s, "Microsoft Windows", "Windows", 1)
 			s = strings.TrimSpace(s)

--- a/server/service/osquery_utils/queries.go
+++ b/server/service/osquery_utils/queries.go
@@ -173,11 +173,12 @@ var hostDetailQueries = map[string]DetailQuery{
 	},
 	"os_version_windows": {
 		Query: `
-	SELECT
-		os.name,
-		os.version
-	FROM
-		os_version os`,
+		SELECT os.name, r.data as display_version
+		FROM 
+			registry r,
+			os_version os
+		WHERE path = 'HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\DisplayVersion'
+		`,
 		Platforms: []string{"windows"},
 		IngestFunc: func(ctx context.Context, logger log.Logger, host *fleet.Host, rows []map[string]string) error {
 			if len(rows) != 1 {
@@ -186,10 +187,10 @@ var hostDetailQueries = map[string]DetailQuery{
 				return nil
 			}
 
-			version := rows[0]["version"]
+			version := rows[0]["display_version"]
 			if version == "" {
 				level.Debug(logger).Log(
-					"msg", "unable to identify windows version",
+					"msg", "unable to identify windows display version",
 					"host", host.Hostname,
 				)
 			}

--- a/server/service/osquery_utils/queries_test.go
+++ b/server/service/osquery_utils/queries_test.go
@@ -421,7 +421,7 @@ func TestDetailQueriesOSVersionWindows(t *testing.T) {
 	))
 
 	assert.NoError(t, ingest(context.Background(), log.NewNopLogger(), &host, rows))
-	assert.Equal(t, "Windows 11 Enterprise 10.0.22000", host.OSVersion)
+	assert.Equal(t, "Windows 11 Enterprise 21H2", host.OSVersion)
 
 	require.NoError(t, json.Unmarshal([]byte(`
 [{
@@ -443,7 +443,7 @@ func TestDetailQueriesOSVersionWindows(t *testing.T) {
 	))
 
 	assert.NoError(t, ingest(context.Background(), log.NewNopLogger(), &host, rows))
-	assert.Equal(t, "Windows 10 Enterprise LTSC 10.0.17763", host.OSVersion)
+	assert.Equal(t, "Windows 10 Enterprise LTSC", host.OSVersion)
 }
 
 func TestDetailQueriesOSVersionChrome(t *testing.T) {


### PR DESCRIPTION
#15801
**This merges into the OS Vulnerabilities backend feature branch**

This change modifies the host.OSVersion attribute to use the Windows "Display Version" instead of the "Build Version" ie.

`Windows 11 Pro 10.0.22000` (old)
`Windows 11 Pro 21H2` (new)

as specified in the OS Vulnerabilities [Figma](https://www.figma.com/file/wDVOWR8ZHLvyZBFung6iMH/%234345-Surface-macOS-and-Windows-OS-vulnerabilities?type=design&node-id=2-130&mode=design&t=DLIZ0QDiSgk5lkVs-0)
