### PR TITLE
Update Fleet server configuration docs

### DIFF
--- a/docs/Configuration/fleet-server-configuration.md
+++ b/docs/Configuration/fleet-server-configuration.md
@@ -1,46 +1,14 @@
 # Fleet server configuration
 
-## Configuring the Fleet binary
+You can specify configuration options in the following formats:
 
-For information on how to run the `fleet` binary, find detailed usage information by running `fleet --help`. This document is a more detailed version of the data presented in the help output text. If you prefer to use a CLI instead of a web browser, we hope  you like the binary interface of the Fleet application!
+1. YAML file
+2. Environment variables
+3. Command-line flags
 
-### High-level configuration overview
+All duration-based settings accept valid time units of `s`, `m`, `h`.
 
-In order to get the most out of running the Fleet server, it is helpful to establish a mutual understanding of what the desired architecture looks like and what it's trying to accomplish.
-
-Your Fleet server's two main purposes are:
-
-- To serve as your [osquery TLS server](https://osquery.readthedocs.io/en/stable/deployment/remote/)
-- To serve the Fleet web UI, which allows you to manage osquery configuration, query hosts, etc.
-
-The Fleet server allows you to persist configuration, manage users, etc. Thus, it needs a database. Fleet uses MySQL and requires you to supply configurations to connect to a MySQL server. It is also possible to configure your connection to a MySQL replica in addition to the primary. This is for reading only. Fleet also uses Redis to perform more high-speed data access action throughout the applications lifecycle (for example, distributed query result ingestion). Thus, Fleet also requires that you supply Redis connection configurations.
-
-Fleet can scale to hundreds of thousands of devices with a single Redis instance and is also compatible with Redis Cluster. Fleet does not support Redis Sentinel.
-
-Since Fleet is a web application, when you run it there are other configurations that must be defined, such as:
-
-- The TLS certificates that Fleet should use to terminate TLS.
-
-When deploying Fleet, mitigate DoS attacks as you would when deploying any app.
-
-Since Fleet is an osquery TLS server, you are also able to define configurations that can customize your experience there, such as:
-
-- The destination of the osquery status and result logs on the local filesystem
-- Various details about the refresh/check-in intervals for your hosts
-
-### Options
-
-#### How do you specify options?
-
-You can specify options in the order of precedence via
-
-1. a configuration file (in YAML format)
-2. environment variables
-3. command-line flags
-
-For example, all of the following ways of launching Fleet are equivalent:
-
-##### 1. Using a YAML config file
+## YAML file
 
 ```sh
 echo '
@@ -61,9 +29,7 @@ logging:
 fleet serve --config /tmp/fleet.yml
 ```
 
-For more information on using YAML configuration files with fleet, please see the [configuration files](https://fleetdm.com/docs/using-fleet/configuration-files) documentation.
-
-##### 2. Using only environment variables
+## Environment variables
 
 ```sh
 FLEET_MYSQL_ADDRESS=127.0.0.1:3306 \
@@ -77,7 +43,7 @@ FLEET_LOGGING_JSON=true \
 /usr/bin/fleet serve
 ```
 
-##### 3. Using only CLI flags
+## Command-line flags
 
 ```sh
 /usr/bin/fleet serve \
@@ -92,25 +58,7 @@ FLEET_LOGGING_JSON=true \
 ```
 
 
-### What are the options?
-
-Note that all option names can be converted consistently from flag name to environment variable and visa-versa. For example, the `--mysql_address` flag would be the `FLEET_MYSQL_ADDRESS`. Further, specifying the `mysql_address` option in the config would follow the pattern:
-
-```yaml
-mysql:
-  address: 127.0.0.1:3306
-```
-
-And `mysql_read_replica_address` would be:
-
-```yaml
-mysql_read_replica:
-  address: 127.0.0.1:3307
-```
-
-Basically, just capitalize the option and prepend `FLEET_` to it to get the environment variable. The conversion works the same the opposite way.
-
-All duration-based settings accept valid time units of `s`, `m`, `h`.
+## Configuration options
 
 #### MySQL
 

--- a/docs/Configuration/fleet-server-configuration.md
+++ b/docs/Configuration/fleet-server-configuration.md
@@ -4,7 +4,7 @@ Fleet server configuration options update the internals of the Fleet server (MyS
 
 Only self-managed users and customers can modify this configuration. If you're a managed-cloud customer, please reach out to Fleet about modifying the configuration.
 
-You can Fleet server specify configuration options in the following formats:
+You can specify configuration options in the following formats:
 
 1. YAML file
 2. Environment variables

--- a/docs/Configuration/fleet-server-configuration.md
+++ b/docs/Configuration/fleet-server-configuration.md
@@ -1,6 +1,10 @@
 # Fleet server configuration
 
-You can specify configuration options in the following formats:
+Fleet server configuration options update the internals of the Fleet server (MySQL database, Redis, etc.). Modifying these options requires restarting your Fleet server.
+
+Only self-managed users and customers can modify this configuration. If you're a managed-cloud customer, please reach out to Fleet about modifying the configuration.
+
+You can Fleet server specify configuration options in the following formats:
 
 1. YAML file
 2. Environment variables


### PR DESCRIPTION
- Pull info about duration-based settings to the top to make it clear. For this bug: #15926
- Add info about self-managed v. managed-cloud customers
- Cut content
