### PR TITLE
prevent baseClient from trying to decode 204 responses

### DIFF
--- a/changes/15916-client-errors
+++ b/changes/15916-client-errors
@@ -1,0 +1,1 @@
+* improve the HTTP client used by `fleetctl` and `fleetd` to prevent errors for 204 responses.

--- a/orbit/changes/15916-client-errors
+++ b/orbit/changes/15916-client-errors
@@ -1,0 +1,1 @@
+* improve the HTTP client used by `fleetctl` and `fleetd` to prevent errors for 204 responses.

--- a/server/service/base_client.go
+++ b/server/service/base_client.go
@@ -63,7 +63,7 @@ func (bc *baseClient) parseResponse(verb, path string, response *http.Response, 
 
 	bc.setServerCapabilities(response)
 
-	if responseDest != nil {
+	if responseDest != nil && response.StatusCode != http.StatusNoContent {
 		b, err := io.ReadAll(response.Body)
 		if err != nil {
 			return fmt.Errorf("reading response body: %w", err)

--- a/server/service/base_client_test.go
+++ b/server/service/base_client_test.go
@@ -70,6 +70,20 @@ func TestParseResponseOK(t *testing.T) {
 	require.Equal(t, "ok", resDest.Test)
 }
 
+func TestParseResponseOKNoContent(t *testing.T) {
+	bc, err := newBaseClient("https://test.com", true, "", "", nil, fleet.CapabilityMap{})
+	require.NoError(t, err)
+	response := &http.Response{
+		StatusCode: http.StatusNoContent,
+		Body:       io.NopCloser(bytes.NewBufferString("")),
+	}
+
+	var resDest struct{ Err error }
+	err = bc.parseResponse("", "", response, &resDest)
+	require.NoError(t, err)
+	require.Nil(t, resDest.Err)
+}
+
 func TestParseResponseGeneralErrors(t *testing.T) {
 	t.Run("general HTTP errors", func(t *testing.T) {
 		bc, err := newBaseClient("https://test.com", true, "", "", nil, fleet.CapabilityMap{})


### PR DESCRIPTION
noticed while working on #15916, we do a request that, when successful, returns a 204 response (with no content)

currently the client will fail to parse the contents of the response and return an error "response: unexpected end of JSON input, body" even if the request was succesful.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [x] Added/updated tests
- [x] Manual QA for all new/changed functionality
  - For Orbit and Fleet Desktop changes:
    - [x] Manual QA must be performed in the three main OSs, macOS, Windows and Linux.
    - [ ] Auto-update manual QA, from released version of component to new version (see [tools/tuf/test](../tools/tuf/test/README.md)).
