### PR TITLE
Enroll secret in macOS keychain and Windows Credential Manager

### DIFF
--- a/changes/13832-enroll-secret-in-keychain
+++ b/changes/13832-enroll-secret-in-keychain
@@ -1,4 +1,4 @@
-For macOS hosts, fleetd now stores and retrieves enroll secret from macOS keychain.
+For macOS hosts, fleetd now stores and retrieves enroll secret from macOS keychain. This feature is enabled for non-MDM flow. The MDM profile flow will be supported in a future release.
 - this feature must use the official signed and notarized version of fleetd
 - for contributors, this feature can disabled with either:
   - fleetctl package flag: --disable-keystore

--- a/changes/13832-enroll-secret-in-keychain
+++ b/changes/13832-enroll-secret-in-keychain
@@ -1,0 +1,5 @@
+For macOS hosts, fleetd now stores and retrieves enroll secret from macOS keychain.
+- this feature must use the official signed and notarized version of fleetd
+- for contributors, this feature can disabled with either:
+  - fleetctl package flag: --disable-keystore
+  - fleetd runtime flag: --disable-keystore

--- a/changes/13832-enroll-secret-in-keychain
+++ b/changes/13832-enroll-secret-in-keychain
@@ -3,3 +3,5 @@ For macOS hosts, fleetd now stores and retrieves enroll secret from macOS keycha
 - for contributors, this feature can disabled with either:
   - fleetctl package flag: --disable-keystore
   - fleetd runtime flag: --disable-keystore
+
+For Windows hosts, fleetd now stores and retrieves enroll secret from Windows Credential Manager.

--- a/cmd/fleetctl/package.go
+++ b/cmd/fleetctl/package.go
@@ -235,6 +235,12 @@ func packageCommand() *cli.Command {
 				EnvVars:     []string{"FLEETCTL_END_USER_EMAIL"},
 				Destination: &opt.EndUserEmail,
 			},
+			&cli.BoolFlag{
+				Name:        "disable-keystore",
+				Usage:       "Disables the use of the keychain on macOS and Credentials Manager on Windows",
+				EnvVars:     []string{"FLEETCTL_DISABLE_KEYSTORE"},
+				Destination: &opt.DisableKeystore,
+			},
 		},
 		Action: func(c *cli.Context) error {
 			if opt.FleetURL != "" || opt.EnrollSecret != "" {

--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/cenkalti/backoff v2.2.1+incompatible
 	github.com/cenkalti/backoff/v4 v4.2.1
 	github.com/clbanning/mxj v1.8.4
+	github.com/danieljoos/wincred v1.2.1
 	github.com/davecgh/go-spew v1.1.1
 	github.com/dgraph-io/badger/v2 v2.2007.2
 	github.com/digitalocean/go-smbios v0.0.0-20180907143718-390a4f403a8e

--- a/go.sum
+++ b/go.sum
@@ -362,6 +362,8 @@ github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ3
 github.com/crewjam/saml v0.0.0-20190521120225-344d075952c9/go.mod h1:w5eu+HNtubx+kRpQL6QFT2F3yIFfYVe6+EzOFVU7Hko=
 github.com/cyphar/filepath-securejoin v0.2.4 h1:Ugdm7cg7i6ZK6x3xDF1oEu1nfkyfH53EtKeQYTC3kyg=
 github.com/cyphar/filepath-securejoin v0.2.4/go.mod h1:aPGpWjXOXUn2NCNjFvBE6aRxGGx79pTxQpKOJNYHHl4=
+github.com/danieljoos/wincred v1.2.1 h1:dl9cBrupW8+r5250DYkYxocLeZ1Y4vB1kxgtjxw8GQs=
+github.com/danieljoos/wincred v1.2.1/go.mod h1:uGaFL9fDn3OLTvzCGulzE+SzjEe5NGlh5FdCcyfPwps=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/orbit/cmd/orbit/orbit.go
+++ b/orbit/cmd/orbit/orbit.go
@@ -1102,6 +1102,7 @@ func main() {
 func deleteIfExists(err error, enrollSecretPath string) {
 	// Since the secret is in the key store, we can delete the original secret file if it exists
 	if _, err = os.Stat(enrollSecretPath); err == nil {
+		log.Warn().Msgf("VICTOR deleting secret file: %v", enrollSecretPath)
 		err = os.Remove(enrollSecretPath)
 		if err != nil {
 			log.Warn().Err(err).Msgf("failed to delete secret file: %v", enrollSecretPath)

--- a/orbit/pkg/keystore/keystore_darwin.go
+++ b/orbit/pkg/keystore/keystore_darwin.go
@@ -102,14 +102,13 @@ func GetSecret() (string, error) {
 
 	var data C.CFTypeRef
 	status := C.SecItemCopyMatching(C.CFDictionaryRef(query), &data)
-	defer C.CFRelease(data)
-
 	if status != C.errSecSuccess {
 		if status == C.errSecItemNotFound {
 			return "", nil
 		}
 		return "", fmt.Errorf("failed to retrieve %v from keychain: %v", service, status)
 	}
+	defer C.CFRelease(data)
 
 	secret := C.CFDataGetBytePtr(C.CFDataRef(data))
 	return C.GoString((*C.char)(unsafe.Pointer(secret))), nil

--- a/orbit/pkg/keystore/keystore_darwin.go
+++ b/orbit/pkg/keystore/keystore_darwin.go
@@ -102,6 +102,7 @@ func GetSecret() (string, error) {
 
 	var data C.CFTypeRef
 	status := C.SecItemCopyMatching(C.CFDictionaryRef(query), &data)
+	defer C.CFRelease(data)
 
 	if status != C.errSecSuccess {
 		if status == C.errSecItemNotFound {
@@ -140,4 +141,9 @@ func stringToCFString(s string) C.CFStringRef {
 	bytes := []byte(s)
 	ptr := (*C.UInt8)(&bytes[0])
 	return C.CFStringCreateWithBytes(C.kCFAllocatorDefault, ptr, C.CFIndex(len(bytes)), C.kCFStringEncodingUTF8, C.false)
+}
+
+// releaseCFString will release memory allocated for a CFStringRef
+func releaseCFString(s C.CFStringRef) {
+	C.CFRelease(C.CFTypeRef(s))
 }

--- a/orbit/pkg/keystore/keystore_darwin.go
+++ b/orbit/pkg/keystore/keystore_darwin.go
@@ -1,0 +1,92 @@
+//go:build darwin && cgo
+
+package keystore
+
+/*
+   #cgo LDFLAGS: -framework CoreFoundation -framework Security
+   #include <CoreFoundation/CoreFoundation.h>
+   #include <Security/Security.h>
+*/
+import "C"
+import (
+	"fmt"
+	"unsafe"
+)
+
+const service = "com.fleetdm.fleetd.enroll.secret"
+
+var serviceStringRef = stringToCFString(service)
+
+func Exists() bool {
+	return true
+}
+
+func Name() string {
+	return "default keychain"
+}
+
+// AddSecret will add a secret to the keychain. This secret can be retrieved by this application without any user authorization.
+func AddSecret(secret string) error {
+
+	query := C.CFDictionaryCreateMutable(
+		C.kCFAllocatorDefault,
+		0,
+		&C.kCFTypeDictionaryKeyCallBacks,
+		&C.kCFTypeDictionaryValueCallBacks,
+	)
+	defer C.CFRelease(C.CFTypeRef(query))
+
+	data := C.CFDataCreate(C.kCFAllocatorDefault, (*C.UInt8)(unsafe.Pointer(C.CString(secret))), C.CFIndex(len(secret)))
+	defer C.CFRelease(C.CFTypeRef(data))
+
+	C.CFDictionaryAddValue(query, unsafe.Pointer(C.kSecClass), unsafe.Pointer(C.kSecClassGenericPassword))
+	C.CFDictionaryAddValue(query, unsafe.Pointer(C.kSecAttrService), unsafe.Pointer(serviceStringRef))
+	C.CFDictionaryAddValue(query, unsafe.Pointer(C.kSecValueData), unsafe.Pointer(data))
+
+	status := C.SecItemAdd(C.CFDictionaryRef(query), nil)
+	if status != C.errSecSuccess {
+		return fmt.Errorf("failed to add %v to keychain: %v", service, status)
+	}
+	return nil
+}
+
+// RetrieveSecret will retrieve a secret from the keychain. If the secret was added by user or another application,
+// then this application needs to be authorized to retrieve the secret.
+func RetrieveSecret() (string, error) {
+	var query C.CFMutableDictionaryRef
+	query = C.CFDictionaryCreateMutable(
+		C.kCFAllocatorDefault,
+		0,
+		&C.kCFTypeDictionaryKeyCallBacks,
+		&C.kCFTypeDictionaryValueCallBacks,
+	)
+	defer C.CFRelease(C.CFTypeRef(query))
+
+	C.CFDictionaryAddValue(query, unsafe.Pointer(C.kSecClass), unsafe.Pointer(C.kSecClassGenericPassword))
+	C.CFDictionaryAddValue(query, unsafe.Pointer(C.kSecReturnData), unsafe.Pointer(C.kCFBooleanTrue))
+	C.CFDictionaryAddValue(query, unsafe.Pointer(C.kSecMatchLimit), unsafe.Pointer(C.kSecMatchLimitOne))
+	C.CFDictionaryAddValue(query, unsafe.Pointer(C.kSecAttrLabel), unsafe.Pointer(serviceStringRef))
+
+	var data C.CFTypeRef
+	status := C.SecItemCopyMatching(C.CFDictionaryRef(query), &data)
+
+	if status != C.errSecSuccess {
+		if status == C.errSecItemNotFound {
+			return "", nil
+		}
+		return "", fmt.Errorf("failed to retrieve %v from keychain: %v", service, status)
+	}
+
+	secret := C.CFDataGetBytePtr(C.CFDataRef(data))
+	return C.GoString((*C.char)(unsafe.Pointer(secret))), nil
+}
+
+// stringToCFString will return a CFStringRef
+func stringToCFString(s string) C.CFStringRef {
+	bytes := []byte(s)
+	var ptr *C.UInt8
+	if len(bytes) > 0 {
+		ptr = (*C.UInt8)(&bytes[0])
+	}
+	return C.CFStringCreateWithBytes(C.kCFAllocatorDefault, ptr, C.CFIndex(len(bytes)), C.kCFStringEncodingUTF8, C.false)
+}

--- a/orbit/pkg/keystore/keystore_darwin.go
+++ b/orbit/pkg/keystore/keystore_darwin.go
@@ -9,7 +9,9 @@ package keystore
 */
 import "C"
 import (
+	"errors"
 	"fmt"
+	"strings"
 	"unsafe"
 )
 
@@ -27,6 +29,10 @@ func Name() string {
 
 // AddSecret will add a secret to the keychain. This secret can be retrieved by this application without any user authorization.
 func AddSecret(secret string) error {
+	secret = strings.TrimSpace(secret)
+	if secret == "" {
+		return errors.New("secret cannot be empty")
+	}
 
 	query := C.CFDictionaryCreateMutable(
 		C.kCFAllocatorDefault,
@@ -52,6 +58,10 @@ func AddSecret(secret string) error {
 
 // UpdateSecret will update a secret in the keychain. This secret can be retrieved by this application without any user authorization.
 func UpdateSecret(secret string) error {
+	secret = strings.TrimSpace(secret)
+	if secret == "" {
+		return errors.New("secret cannot be empty")
+	}
 
 	query := C.CFDictionaryCreateMutable(
 		C.kCFAllocatorDefault,

--- a/orbit/pkg/keystore/keystore_darwin_test.go
+++ b/orbit/pkg/keystore/keystore_darwin_test.go
@@ -1,0 +1,45 @@
+//go:build darwin && cgo
+
+package keystore
+
+import (
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"strings"
+	"testing"
+)
+
+func TestExists(t *testing.T) {
+	t.Parallel()
+	assert.True(t, Exists())
+}
+
+func TestName(t *testing.T) {
+	t.Parallel()
+	assert.True(t, strings.Contains(Name(), "keychain"))
+}
+
+func TestSecret(t *testing.T) {
+	t.Parallel()
+	t.Cleanup(
+		func() {
+			_ = deleteSecret()
+		},
+	)
+
+	serviceStringRef = stringToCFString("com.fleetdm.fleetd.enroll.secret.test")
+
+	// Add secret
+	secret := "testSecret"
+	require.NoError(t, AddSecret(secret))
+	result, err := GetSecret()
+	require.NoError(t, err)
+	assert.Equal(t, secret, result)
+
+	// Update secret
+	secret = "updatedSecret"
+	require.NoError(t, UpdateSecret(secret))
+	result, err = GetSecret()
+	require.NoError(t, err)
+	assert.Equal(t, secret, result)
+}

--- a/orbit/pkg/keystore/keystore_darwin_test.go
+++ b/orbit/pkg/keystore/keystore_darwin_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestExists(t *testing.T) {
 	t.Parallel()
-	assert.True(t, Exists())
+	assert.True(t, Supported())
 }
 
 func TestName(t *testing.T) {
@@ -52,6 +52,9 @@ func TestSecret(t *testing.T) {
 	result, err = GetSecret()
 	require.NoError(t, err)
 	assert.Equal(t, secret, result)
+
+	// Try to add a secret again -- fails for macOS keychain
+	assert.Error(t, AddSecret("willFail"))
 
 	// Update empty secret
 	assert.Error(t, UpdateSecret(""))

--- a/orbit/pkg/keystore/keystore_darwin_test.go
+++ b/orbit/pkg/keystore/keystore_darwin_test.go
@@ -35,10 +35,18 @@ func TestSecret(t *testing.T) {
 		},
 	)
 
+	// Make sure secret doesn't exist
+	_ = deleteSecret()
+
+	// Get secret -- should be empty
+	result, err := GetSecret()
+	require.NoError(t, err)
+	assert.Equal(t, "", result)
+
 	// Add secret
 	secret := "testSecret"
 	require.NoError(t, AddSecret(secret))
-	result, err := GetSecret()
+	result, err = GetSecret()
 	require.NoError(t, err)
 	assert.Equal(t, secret, result)
 

--- a/orbit/pkg/keystore/keystore_darwin_test.go
+++ b/orbit/pkg/keystore/keystore_darwin_test.go
@@ -43,12 +43,18 @@ func TestSecret(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "", result)
 
+	// Add empty secret
+	assert.Error(t, AddSecret(""))
+
 	// Add secret
 	secret := "testSecret"
 	require.NoError(t, AddSecret(secret))
 	result, err = GetSecret()
 	require.NoError(t, err)
 	assert.Equal(t, secret, result)
+
+	// Update empty secret
+	assert.Error(t, UpdateSecret(""))
 
 	// Update secret
 	secret = "updatedSecret"

--- a/orbit/pkg/keystore/keystore_darwin_test.go
+++ b/orbit/pkg/keystore/keystore_darwin_test.go
@@ -21,13 +21,19 @@ func TestName(t *testing.T) {
 
 func TestSecret(t *testing.T) {
 	t.Parallel()
+
+	// Use a different service name for testing
+	origServiceStringRef := serviceStringRef
+	serviceStringRef = stringToCFString("com.fleetdm.fleetd.enroll.secret.test")
+
 	t.Cleanup(
 		func() {
+			// Delete test secret from keychain, and deallocate memory.
 			_ = deleteSecret()
+			releaseCFString(serviceStringRef)
+			serviceStringRef = origServiceStringRef
 		},
 	)
-
-	serviceStringRef = stringToCFString("com.fleetdm.fleetd.enroll.secret.test")
 
 	// Add secret
 	secret := "testSecret"

--- a/orbit/pkg/keystore/keystore_stub.go
+++ b/orbit/pkg/keystore/keystore_stub.go
@@ -1,4 +1,4 @@
-//go:build (!darwin && !windows) || !cgo
+//go:build !(darwin && cgo) && !windows
 
 package keystore
 

--- a/orbit/pkg/keystore/keystore_stub.go
+++ b/orbit/pkg/keystore/keystore_stub.go
@@ -4,7 +4,7 @@ package keystore
 
 import "errors"
 
-func Exists() bool {
+func Supported() bool {
 	return false
 }
 

--- a/orbit/pkg/keystore/keystore_stub.go
+++ b/orbit/pkg/keystore/keystore_stub.go
@@ -1,0 +1,24 @@
+//go:build !darwin || !cgo
+
+package keystore
+
+import "errors"
+
+func Exists() bool {
+	return false
+}
+
+func Name() string {
+	return "not implemented"
+}
+
+// AddSecret will add a secret to the keychain. This secret can be retrieved by this application without any user authorization.
+func AddSecret(secret string) error {
+	return errors.New("not implemented")
+}
+
+// RetrieveSecret will retrieve a secret from the keychain. If the secret was added by user or another application,
+// then this application needs to be authorized to retrieve the secret.
+func RetrieveSecret() (string, error) {
+	return "", errors.New("not implemented")
+}

--- a/orbit/pkg/keystore/keystore_stub.go
+++ b/orbit/pkg/keystore/keystore_stub.go
@@ -17,8 +17,8 @@ func AddSecret(secret string) error {
 	return errors.New("not implemented")
 }
 
-// RetrieveSecret will retrieve a secret from the keychain. If the secret was added by user or another application,
+// GetSecret will retrieve a secret from the keychain. If the secret was added by user or another application,
 // then this application needs to be authorized to retrieve the secret.
-func RetrieveSecret() (string, error) {
+func GetSecret() (string, error) {
 	return "", errors.New("not implemented")
 }

--- a/orbit/pkg/keystore/keystore_stub.go
+++ b/orbit/pkg/keystore/keystore_stub.go
@@ -17,6 +17,11 @@ func AddSecret(secret string) error {
 	return errors.New("not implemented")
 }
 
+// UpdateSecret will update a secret in the keychain. This secret can be retrieved by this application without any user authorization.
+func UpdateSecret(secret string) error {
+	return errors.New("not implemented")
+}
+
 // GetSecret will retrieve a secret from the keychain. If the secret was added by user or another application,
 // then this application needs to be authorized to retrieve the secret.
 func GetSecret() (string, error) {

--- a/orbit/pkg/keystore/keystore_windows.go
+++ b/orbit/pkg/keystore/keystore_windows.go
@@ -3,7 +3,9 @@
 package keystore
 
 import (
+	"errors"
 	"github.com/danieljoos/wincred"
+	"syscall"
 )
 
 // Using a var instead of const so that it can be overridden in tests.
@@ -35,6 +37,11 @@ func UpdateSecret(secret string) error {
 func GetSecret() (string, error) {
 	cred, err := wincred.GetGenericCredential(service)
 	if err != nil {
+		var errno syscall.Errno
+		ok := errors.As(err, &errno)
+		if ok && errors.Is(errno, syscall.ERROR_NOT_FOUND) {
+			return "", nil
+		}
 		return "", err
 	}
 	return string(cred.CredentialBlob), nil

--- a/orbit/pkg/keystore/keystore_windows.go
+++ b/orbit/pkg/keystore/keystore_windows.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"github.com/danieljoos/wincred"
 	"strings"
+	"sync"
 	"syscall"
 )
 

--- a/orbit/pkg/keystore/keystore_windows.go
+++ b/orbit/pkg/keystore/keystore_windows.go
@@ -1,29 +1,41 @@
-//go:build (!darwin && !windows) || !cgo
+//go:build windows && cgo
 
 package keystore
 
-import "errors"
+import (
+	"github.com/danieljoos/wincred"
+)
+
+// Using a var instead of const so that it can be overridden in tests.
+var service = "com.fleetdm.fleetd.enroll.secret"
 
 func Exists() bool {
-	return false
+	return true
 }
 
 func Name() string {
-	return "not implemented"
+	return "Credential Manager"
 }
 
 // AddSecret will add a secret to the keychain. This secret can be retrieved by this application without any user authorization.
 func AddSecret(secret string) error {
-	return errors.New("not implemented")
+	cred := wincred.NewGenericCredential(service)
+	cred.CredentialBlob = []byte(secret)
+	err := cred.Write()
+	return err
 }
 
 // UpdateSecret will update a secret in the keychain. This secret can be retrieved by this application without any user authorization.
 func UpdateSecret(secret string) error {
-	return errors.New("not implemented")
+	return AddSecret(secret)
 }
 
 // GetSecret will retrieve a secret from the keychain. If the secret was added by user or another application,
 // then this application needs to be authorized to retrieve the secret.
 func GetSecret() (string, error) {
-	return "", errors.New("not implemented")
+	cred, err := wincred.GetGenericCredential(service)
+	if err != nil {
+		return "", err
+	}
+	return string(cred.CredentialBlob), nil
 }

--- a/orbit/pkg/keystore/keystore_windows.go
+++ b/orbit/pkg/keystore/keystore_windows.go
@@ -1,10 +1,11 @@
-//go:build windows && cgo
+//go:build windows
 
 package keystore
 
 import (
 	"errors"
 	"github.com/danieljoos/wincred"
+	"strings"
 	"syscall"
 )
 
@@ -21,6 +22,10 @@ func Name() string {
 
 // AddSecret will add a secret to the keychain. This secret can be retrieved by this application without any user authorization.
 func AddSecret(secret string) error {
+	secret = strings.TrimSpace(secret)
+	if secret == "" {
+		return errors.New("secret cannot be empty")
+	}
 	cred := wincred.NewGenericCredential(service)
 	cred.CredentialBlob = []byte(secret)
 	err := cred.Write()

--- a/orbit/pkg/keystore/keystore_windows_test.go
+++ b/orbit/pkg/keystore/keystore_windows_test.go
@@ -22,9 +22,15 @@ func TestName(t *testing.T) {
 
 func TestSecret(t *testing.T) {
 	t.Parallel()
+
+	// Use a different service name for testing
+	origService := service
+	service = "com.fleetdm.fleetd.enroll.secret.test"
+
 	t.Cleanup(
 		func() {
 			cred, err := wincred.GetGenericCredential(service)
+			service = origService
 			if err != nil {
 				t.Log(err)
 				return
@@ -32,8 +38,6 @@ func TestSecret(t *testing.T) {
 			_ = cred.Delete()
 		},
 	)
-
-	service = "com.fleetdm.fleetd.enroll.secret.test"
 
 	// Add secret
 	secret := "testSecret"

--- a/orbit/pkg/keystore/keystore_windows_test.go
+++ b/orbit/pkg/keystore/keystore_windows_test.go
@@ -1,0 +1,51 @@
+//go:build windows && cgo
+
+package keystore
+
+import (
+	"github.com/danieljoos/wincred"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"strings"
+	"testing"
+)
+
+func TestExists(t *testing.T) {
+	t.Parallel()
+	assert.True(t, Exists())
+}
+
+func TestName(t *testing.T) {
+	t.Parallel()
+	assert.True(t, strings.Contains(Name(), "Credential Manager"))
+}
+
+func TestSecret(t *testing.T) {
+	t.Parallel()
+	t.Cleanup(
+		func() {
+			cred, err := wincred.GetGenericCredential(service)
+			if err != nil {
+				t.Log(err)
+				return
+			}
+			_ = cred.Delete()
+		},
+	)
+
+	service = "com.fleetdm.fleetd.enroll.secret.test"
+
+	// Add secret
+	secret := "testSecret"
+	require.NoError(t, AddSecret(secret))
+	result, err := GetSecret()
+	require.NoError(t, err)
+	assert.Equal(t, secret, result)
+
+	// Update secret
+	secret = "updatedSecret"
+	require.NoError(t, UpdateSecret(secret))
+	result, err = GetSecret()
+	require.NoError(t, err)
+	assert.Equal(t, secret, result)
+}

--- a/orbit/pkg/keystore/keystore_windows_test.go
+++ b/orbit/pkg/keystore/keystore_windows_test.go
@@ -1,4 +1,4 @@
-//go:build windows && cgo
+//go:build windows
 
 package keystore
 
@@ -50,12 +50,18 @@ func TestSecret(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "", result)
 
+	// Add empty secret
+	assert.Error(t, AddSecret(""))
+
 	// Add secret
 	secret := "testSecret"
 	require.NoError(t, AddSecret(secret))
 	result, err = GetSecret()
 	require.NoError(t, err)
 	assert.Equal(t, secret, result)
+
+	// Update empty secret
+	assert.Error(t, UpdateSecret(""))
 
 	// Update secret
 	secret = "updatedSecret"

--- a/orbit/pkg/keystore/keystore_windows_test.go
+++ b/orbit/pkg/keystore/keystore_windows_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestExists(t *testing.T) {
 	t.Parallel()
-	assert.True(t, Exists())
+	assert.True(t, Supported())
 }
 
 func TestName(t *testing.T) {
@@ -28,6 +28,8 @@ func TestSecret(t *testing.T) {
 	service = "com.fleetdm.fleetd.enroll.secret.test"
 
 	deleteSecret := func() {
+		mu.Lock()
+		defer mu.Unlock()
 		cred, err := wincred.GetGenericCredential(service)
 		if err != nil {
 			return

--- a/orbit/pkg/keystore/keystore_windows_test.go
+++ b/orbit/pkg/keystore/keystore_windows_test.go
@@ -27,22 +27,33 @@ func TestSecret(t *testing.T) {
 	origService := service
 	service = "com.fleetdm.fleetd.enroll.secret.test"
 
+	deleteSecret := func() {
+		cred, err := wincred.GetGenericCredential(service)
+		if err != nil {
+			return
+		}
+		_ = cred.Delete()
+	}
+
 	t.Cleanup(
 		func() {
-			cred, err := wincred.GetGenericCredential(service)
+			deleteSecret()
 			service = origService
-			if err != nil {
-				t.Log(err)
-				return
-			}
-			_ = cred.Delete()
 		},
 	)
+
+	// Make sure the secret doesn't exist
+	deleteSecret()
+
+	// Get secret -- should be empty
+	result, err := GetSecret()
+	require.NoError(t, err)
+	assert.Equal(t, "", result)
 
 	// Add secret
 	secret := "testSecret"
 	require.NoError(t, AddSecret(secret))
-	result, err := GetSecret()
+	result, err = GetSecret()
 	require.NoError(t, err)
 	assert.Equal(t, secret, result)
 

--- a/orbit/pkg/packaging/macos_templates.go
+++ b/orbit/pkg/packaging/macos_templates.go
@@ -157,6 +157,10 @@ var macosLaunchdTemplate = template.Must(template.New("").Option("missingkey=err
 		<key>ORBIT_HOST_IDENTIFIER</key>
 		<string>{{ .HostIdentifier }}</string>
 		{{- end }}
+		{{- if .DisableKeystore }}
+		<key>ORBIT_DISABLE_KEYSTORE</key>
+		<string>true</string>
+		{{- end }}
 	</dict>
 	<key>KeepAlive</key>
 	<true/>

--- a/orbit/pkg/packaging/packaging.go
+++ b/orbit/pkg/packaging/packaging.go
@@ -120,6 +120,8 @@ type Options struct {
 	// EndUserEmail is the email address of the end user that uses the host on
 	// which the agent is going to be installed.
 	EndUserEmail string
+	// DisableKeystore disables the use of the keychain on macOS and Credentials Manager on Windows
+	DisableKeystore bool
 }
 
 func initializeTempDir() (string, error) {

--- a/tools/tuf/test/gen_pkgs.sh
+++ b/tools/tuf/test/gen_pkgs.sh
@@ -49,7 +49,8 @@ if [ -n "$GENERATE_PKG" ]; then
         ${USE_UPDATE_CLIENT_CERTIFICATE:+--update-tls-client-certificate=./tools/test-orbit-mtls/client.crt} \
         ${USE_UPDATE_CLIENT_CERTIFICATE:+--update-tls-client-key=./tools/test-orbit-mtls/client.key} \
         ${FLEET_DESKTOP_ALTERNATIVE_BROWSER_HOST:+--fleet-desktop-alternative-browser-host=$FLEET_DESKTOP_ALTERNATIVE_BROWSER_HOST} \
-        --update-url=$PKG_TUF_URL
+        --update-url=$PKG_TUF_URL \
+        --disable-keystore
 fi
 
 if [ -n "$GENERATE_DEB" ]; then
@@ -115,7 +116,8 @@ if [ -n "$GENERATE_MSI" ]; then
         ${USE_UPDATE_CLIENT_CERTIFICATE:+--update-tls-client-certificate=./tools/test-orbit-mtls/client.crt} \
         ${USE_UPDATE_CLIENT_CERTIFICATE:+--update-tls-client-key=./tools/test-orbit-mtls/client.key} \
         ${FLEET_DESKTOP_ALTERNATIVE_BROWSER_HOST:+--fleet-desktop-alternative-browser-host=$FLEET_DESKTOP_ALTERNATIVE_BROWSER_HOST} \
-        --update-url=$MSI_TUF_URL
+        --update-url=$MSI_TUF_URL \
+        --disable-keystore
 fi
 
 echo "Packages generated."

--- a/tools/tuf/test/gen_pkgs.sh
+++ b/tools/tuf/test/gen_pkgs.sh
@@ -116,8 +116,7 @@ if [ -n "$GENERATE_MSI" ]; then
         ${USE_UPDATE_CLIENT_CERTIFICATE:+--update-tls-client-certificate=./tools/test-orbit-mtls/client.crt} \
         ${USE_UPDATE_CLIENT_CERTIFICATE:+--update-tls-client-key=./tools/test-orbit-mtls/client.key} \
         ${FLEET_DESKTOP_ALTERNATIVE_BROWSER_HOST:+--fleet-desktop-alternative-browser-host=$FLEET_DESKTOP_ALTERNATIVE_BROWSER_HOST} \
-        --update-url=$MSI_TUF_URL \
-        --disable-keystore
+        --update-url=$MSI_TUF_URL
 fi
 
 echo "Packages generated."


### PR DESCRIPTION
#13832

For macOS hosts, fleetd now stores and retrieves enroll secret from macOS keychain.
- this feature must use the official signed and notarized version of fleetd
- for contributors, this feature can disabled with either:
  - fleetctl package flag: --disable-keystore
  - fleetd runtime flag: --disable-keystore

This feature does not cover the MDM usecase where enroll secret is stored in the MDM profile. This usecase will hopefully be worked on next sprint with the MDM team.

For Windows hosts, fleetd now stores and retrieves enroll secret from Windows Credential Manager.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [x] Added/updated tests
- [x] Manual QA for all new/changed functionality
  - For Orbit and Fleet Desktop changes:
    - [x] Manual QA must be performed in the three main OSs, macOS, Windows and Linux.
    - [x] Auto-update manual QA, from released version of component to new version (see [tools/tuf/test](../tools/tuf/test/README.md)).
