### PR TITLE
Fleet UI: Textarea maintains extendability but prevent ability to make it skinnier

### DIFF
--- a/frontend/pages/admin/OrgSettingsPage/_styles.scss
+++ b/frontend/pages/admin/OrgSettingsPage/_styles.scss
@@ -103,6 +103,10 @@
         .input-field {
           width: 100%;
           max-width: 754px;
+
+          &__textarea {
+            min-width: 100%; // Cannot make textarea skinnier
+          }
         }
 
         &--smtp {


### PR DESCRIPTION
## Issue
Connected to #15896 

## Description
- This is not a part of the 15896 ticket but a related improvement/bug @xpkoala found in QAing #16002 
- Maintain text areas ability to extend but prevent ability to make it skinnier

## Screenrecording of fix

https://github.com/fleetdm/fleet/assets/71795832/2827936a-b70b-4e19-8668-a5a21af7f3ba



# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Manual QA for all new/changed functionality
