### PR TITLE
Fleet UI: Clicking an active nav link will navigate/reset to default page

### DIFF
--- a/changes/15783-active-link-returns-default
+++ b/changes/15783-active-link-returns-default
@@ -1,0 +1,1 @@
+- Fleet UI: Clicking an active nav link will reset to the default page navigation

--- a/frontend/components/top_nav/SiteTopNav/SiteTopNav.tsx
+++ b/frontend/components/top_nav/SiteTopNav/SiteTopNav.tsx
@@ -149,21 +149,19 @@ const SiteTopNav = ({
         ? navItem.location.pathname
         : currentPath;
 
-      // TODO: confirm link should be noop and find best pattern (one that doesn't dispatch a
+      // Clicking an active link returns user to default page
+      // TODO: Find best pattern(one that doesn't dispatch a
       // replace to the same url, which triggers a re-render)
       return (
         <li className={navItemClasses} key={`nav-item-${name}`}>
-          <Link
-            className={`${navItemBaseClass}__link`}
-            to={path.concat(search).concat(hash)}
-          >
+          <a className={`${navItemBaseClass}__link`} href={path}>
             <span
               className={`${navItemBaseClass}__name`}
               data-text={navItem.name}
             >
               {name}
             </span>
-          </Link>
+          </a>
         </li>
       );
     }


### PR DESCRIPTION
## Issue
Cerra #15783

## Description
- Quick fix hard reloads the correct nav link 
- Long fix that we can look into is having react render the specific components only with the default states (requires untangling hairiness for all table pages individually with states within the page typescript states as well as the table container typescript states and how they interact with the pathname )

## Screenrecording of fix
TODO


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
- [x] Manual QA for all new/changed functionality
