### PR TITLE
Part 2: Windows OS Display Version Matching

### DIFF
--- a/cmd/fleet/cron.go
+++ b/cmd/fleet/cron.go
@@ -275,6 +275,7 @@ func checkWinVulnerabilities(
 				"msg", "msrc-analysis-done",
 				"os name", o.Name,
 				"os version", o.Version,
+				"display version", o.DisplayVersion,
 				"elapsed", elapsed,
 				"found new", len(r))
 			results = append(results, r...)

--- a/server/service/osquery_utils/queries.go
+++ b/server/service/osquery_utils/queries.go
@@ -520,7 +520,7 @@ var extraDetailQueries = map[string]DetailQuery{
 		os.platform,
 		os.arch,
 		k.version as kernel_version,
-		os.version
+		os.version,
 		r.data as display_version
 	FROM
 		os_version os,

--- a/server/vulnerabilities/msrc/parsed/product.go
+++ b/server/vulnerabilities/msrc/parsed/product.go
@@ -38,7 +38,7 @@ func (p Products) GetMatchForOS(ctx context.Context, os fleet.OperatingSystem) (
 			break
 		}
 
-		// This rule ensures that we match an unknown os.DisplayVersion to
+		// Ensure a match against an unknown or blank os.DisplayVersion to
 		// a MSRC product that does not have a display version (eg. The initial release
 		// of Windows 11 is 21H2, which does not appear in the MSRC data)
 		if !product.HasDisplayVersion() {
@@ -51,8 +51,6 @@ func (p Products) GetMatchForOS(ctx context.Context, os fleet.OperatingSystem) (
 		return "", ctxerr.Wrap(ctx, ErrNoMatch)
 	}
 
-	// unknown display version will match the first product
-	// without a display version
 	if dvMatch == "" {
 		return noDvMatch, nil
 	}

--- a/server/vulnerabilities/msrc/parsed/product.go
+++ b/server/vulnerabilities/msrc/parsed/product.go
@@ -37,7 +37,7 @@ func (p Products) GetMatchForOS(ctx context.Context, os fleet.OperatingSystem) (
 			dvMatch = pID
 			break
 		}
-		
+
 		// This rule ensures that we match an unknown os.DisplayVersion to
 		// a MSRC product that does not have a display version (eg. The initial release
 		// of Windows 11 is 21H2, which does not appear in the MSRC data)
@@ -93,12 +93,12 @@ func (p Product) Arch() string {
 	}
 }
 
-// HasDisplayVersion returns true if the current Microsoft product 
-// has a display version in the name.  
-// Display Version refers to the version of the product that is 
+// HasDisplayVersion returns true if the current Microsoft product
+// has a display version in the name.
+// Display Version refers to the version of the product that is
 // displayed to the user: eg. 22H2
 // Year/Half refers to the year and half of the year that the product
-// was released: eg. 2nd Half of 2022 
+// was released: eg. 2nd Half of 2022
 func (p Product) HasDisplayVersion() bool {
 	keywords := []string{"version", "edition"}
 	for _, k := range keywords {

--- a/server/vulnerabilities/msrc/parsed/product_test.go
+++ b/server/vulnerabilities/msrc/parsed/product_test.go
@@ -1,6 +1,7 @@
 package parsed
 
 import (
+	"context"
 	"testing"
 
 	"github.com/fleetdm/fleet/v4/server/fleet"
@@ -430,4 +431,116 @@ func TestFullProductName(t *testing.T) {
 			require.Equal(t, tCase.prodName, sut.Name(), tCase)
 		}
 	})
+}
+
+func TestProductHasDisplayVersion(t *testing.T) {
+	tc := []struct {
+		name   Product
+		result bool
+	}{
+		{
+			name:   "Windows 11 for x64-based Systems",
+			result: false,
+		},
+		{
+			name:   "Windows 11 Version 22H2 for x64-based Systems",
+			result: true,
+		},
+		{
+			name:   "Windows Server 2022, 23H2 Edition (Server Core installation)",
+			result: true,
+		},
+		{
+			name:   "Windows Server 2022 (Server Core installation)",
+			result: false,
+		},
+		{
+			name:   "Windows Server 2022",
+			result: false,
+		},
+		{
+			name:   "Windows Server, version 1803  (Server Core Installation)",
+			result: true,
+		},
+	}
+
+	for _, tt := range tc {
+		require.Equal(t, tt.result, tt.name.HasDisplayVersion(), tt.name)
+	}
+}
+
+var msrcWinProducts = Products{
+	"11926": "Windows 11 for x64-based Systems",
+	"11927": "Windows 11 for ARM64-based Systems",
+	"12085": "Windows 11 Version 22H2 for ARM64-based Systems",
+	"12086": "Windows 11 Version 22H2 for x64-based Systems",
+	"12242": "Windows 11 Version 23H2 for ARM64-based Systems",
+	"12243": "Windows 11 Version 23H2 for x64-based Systems",
+	"11923": "Windows Server 2022",
+	"11924": "Windows Server 2022 (Server Core installation)",
+	"12244": "Windows Server 2022, 23H2 Edition (Server Core installation)",
+}
+
+func TestMatchesOperatingSystem(t *testing.T) {
+	ctx := context.Background()
+	tc := []struct {
+		name string
+		os   fleet.OperatingSystem
+		want string
+		err  error
+	}{
+		{
+			name: "OS with known Display Version Match x64",
+			os: fleet.OperatingSystem{
+				Name:           "Windows 11 Pro 22H2",
+				Arch:           "x86_64",
+				DisplayVersion: "22H2",
+			},
+			want: "12086",
+			err:  nil,
+		},
+		{
+			name: "OS with known Display Version Match ARM64",
+			os: fleet.OperatingSystem{
+				Name:           "Windows 11 Pro 22H2",
+				Arch:           "ARM 64-bit Processor",
+				DisplayVersion: "22H2",
+			},
+			want: "12085",
+			err:  nil,
+		},
+		{
+			name: "OS with no Display Version",
+			os: fleet.OperatingSystem{
+				Name: "Windows 11 Pro",
+				Arch: "64-bit",
+			},
+			want: "11926",
+		},
+		{
+			name: "Product contains 'Edition' keyword",
+			os: fleet.OperatingSystem{
+				Name:           "Windows Server 2022 23H2",
+				Arch:           "64-bit",
+				DisplayVersion: "23H2",
+			},
+			want: "12244",
+			err:  nil,
+		},
+		{
+			name: "unknown OS",
+			os: fleet.OperatingSystem{
+				Name: "Windows Foo Bar",
+				Arch: "arm64",
+			},
+			want: "",
+			err:  ErrNoMatch,
+		},
+	}
+
+	for _, tt := range tc {
+		match, err := msrcWinProducts.GetMatchForOS(ctx, tt.os)
+		require.ErrorIs(t, err, tt.err, tt.name)
+		require.Equal(t, tt.want, match, tt.name)
+	}
 }

--- a/server/vulnerabilities/msrc/parsed/security_bulletin.go
+++ b/server/vulnerabilities/msrc/parsed/security_bulletin.go
@@ -15,7 +15,7 @@ type SecurityBulletin struct {
 	// We can have many different 'products' under a single name, for example, for 'Windows 10':
 	// - Windows 10 Version 1809 for 32-bit Systems
 	// - Windows 10 Version 1909 for x64-based Systems
-	Products map[string]Product
+	Products
 	// All vulnerabilities contained in this bulletin, by CVE
 	Vulnerabities map[string]Vulnerability
 	// All vendor fixes for remediating the vulnerabilities contained in this bulletin, by KBID

--- a/server/vulnerabilities/msrc/parsed/security_bulletin.go
+++ b/server/vulnerabilities/msrc/parsed/security_bulletin.go
@@ -15,7 +15,7 @@ type SecurityBulletin struct {
 	// We can have many different 'products' under a single name, for example, for 'Windows 10':
 	// - Windows 10 Version 1809 for 32-bit Systems
 	// - Windows 10 Version 1909 for x64-based Systems
-	Products
+	Products Products
 	// All vulnerabilities contained in this bulletin, by CVE
 	Vulnerabities map[string]Vulnerability
 	// All vendor fixes for remediating the vulnerabilities contained in this bulletin, by KBID

--- a/server/vulnerabilities/msrc/parser_test.go
+++ b/server/vulnerabilities/msrc/parser_test.go
@@ -40,7 +40,7 @@ func TestParser(t *testing.T) {
 	require.NoError(t, err)
 
 	// All the products we expect to see, grouped by their product name
-	expectedProducts := map[string]map[string]parsed.Product{
+	expectedProducts := map[string]parsed.Products{
 		"Windows 10": {
 			"11568": parsed.NewProductFromFullName("Windows 10 Version 1809 for 32-bit Systems"),
 			"11569": parsed.NewProductFromFullName("Windows 10 Version 1809 for x64-based Systems"),
@@ -1195,7 +1195,7 @@ func TestParser(t *testing.T) {
 
 		t.Run("each bulletin should have the right products", func(t *testing.T) {
 			for _, g := range bulletins {
-				require.Equal(t, g.Products, expectedProducts[g.ProductName], g.ProductName)
+				require.Equal(t, expectedProducts[g.ProductName], g.Products, g.ProductName)
 			}
 		})
 


### PR DESCRIPTION
#15801 

Building upon the [now stored "display_version" ](https://github.com/fleetdm/fleet/pull/16049)

This PR is using `display_version` to match against Products in the MSRC feed.  If the host's "display version" (eg. 22H2) does not exist in the MSRC product list (possibly due to an empty display version), then we match against the MSRC product that also does not have a display version.