### PR TITLE
Dynamically set copyright year in email templates

### DIFF
--- a/server/mail/invite.go
+++ b/server/mail/invite.go
@@ -3,6 +3,7 @@ package mail
 import (
 	"bytes"
 	"html/template"
+	"time"
 
 	"github.com/fleetdm/fleet/v4/server"
 	"github.com/fleetdm/fleet/v4/server/fleet"
@@ -15,9 +16,11 @@ type InviteMailer struct {
 	AssetURL  template.URL
 	InvitedBy string
 	OrgName   string
+	CurrentYear	 int
 }
 
 func (i *InviteMailer) Message() ([]byte, error) {
+	i.CurrentYear = time.Now().Year()
 	t, err := server.GetTemplate("server/mail/templates/invite_token.html", "email_template")
 	if err != nil {
 		return nil, err

--- a/server/mail/invite.go
+++ b/server/mail/invite.go
@@ -12,11 +12,11 @@ import (
 // InviteMailer is used to build an email template for the invite email.
 type InviteMailer struct {
 	*fleet.Invite
-	BaseURL   template.URL
-	AssetURL  template.URL
-	InvitedBy string
-	OrgName   string
-	CurrentYear	 int
+	BaseURL     template.URL
+	AssetURL    template.URL
+	InvitedBy   string
+	OrgName     string
+	CurrentYear int
 }
 
 func (i *InviteMailer) Message() ([]byte, error) {

--- a/server/mail/mail.go
+++ b/server/mail/mail.go
@@ -277,9 +277,11 @@ func dialTimeout(addr string, tlsConfig *tls.Config) (client *smtp.Client, err e
 type SMTPTestMailer struct {
 	BaseURL  template.URL
 	AssetURL template.URL
+	CurrentYear     int
 }
 
 func (m *SMTPTestMailer) Message() ([]byte, error) {
+	m.CurrentYear = time.Now().Year()
 	t, err := server.GetTemplate("server/mail/templates/smtp_setup.html", "email_template")
 	if err != nil {
 		return nil, err

--- a/server/mail/mail.go
+++ b/server/mail/mail.go
@@ -275,9 +275,9 @@ func dialTimeout(addr string, tlsConfig *tls.Config) (client *smtp.Client, err e
 // SMTPTestMailer is used to build an email message that will be used as
 // a test message when testing SMTP configuration
 type SMTPTestMailer struct {
-	BaseURL  template.URL
-	AssetURL template.URL
-	CurrentYear     int
+	BaseURL     template.URL
+	AssetURL    template.URL
+	CurrentYear int
 }
 
 func (m *SMTPTestMailer) Message() ([]byte, error) {

--- a/server/mail/templates/change_email_confirmation.html
+++ b/server/mail/templates/change_email_confirmation.html
@@ -162,7 +162,7 @@
                   </a>
                 </div>
                 <p style="font-size: 12px; line-height: 16px; padding: 0">
-                  © 2022 Fleet Device Management Inc. <br />
+                  © {{.CurrentYear}} Fleet Device Management Inc. <br />
                   All trademarks, service marks, and company names are the
                   property of their respective owners.
                 </p>

--- a/server/mail/templates/invite_token.html
+++ b/server/mail/templates/invite_token.html
@@ -192,7 +192,7 @@
                   </a>
                 </div>
                 <p style="font-size: 12px; line-height: 16px; padding: 0">
-                  © 2022 Fleet Device Management Inc. <br />
+                  © {{.CurrentYear}} Fleet Device Management Inc. <br />
                   All trademarks, service marks, and company names are the
                   property of their respective owners.
                 </p>

--- a/server/mail/templates/password_reset.html
+++ b/server/mail/templates/password_reset.html
@@ -167,7 +167,7 @@
                   </a>
                 </div>
                 <p style="font-size: 12px; line-height: 16px; padding: 0">
-                  © 2022 Fleet Device Management Inc. <br />
+                  © {{.CurrentYear}} Fleet Device Management Inc. <br />
                   All trademarks, service marks, and company names are the
                   property of their respective owners.
                 </p>

--- a/server/mail/templates/smtp_setup.html
+++ b/server/mail/templates/smtp_setup.html
@@ -141,7 +141,7 @@
                   </a>
                 </div>
                 <p style="font-size: 12px; line-height: 16px; padding: 0;">
-                  © 2022 Fleet Device Management Inc. <br />
+                  © {{.CurrentYear}} Fleet Device Management Inc. <br />
                   All trademarks, service marks, and company names are the
                   property of their respective owners.
                 </p>

--- a/server/mail/users.go
+++ b/server/mail/users.go
@@ -9,10 +9,10 @@ import (
 )
 
 type ChangeEmailMailer struct {
-	BaseURL  template.URL
-	AssetURL template.URL
-	Token    string
-	CurrentYear  int
+	BaseURL     template.URL
+	AssetURL    template.URL
+	Token       string
+	CurrentYear int
 }
 
 func (cem *ChangeEmailMailer) Message() ([]byte, error) {
@@ -37,7 +37,7 @@ type PasswordResetMailer struct {
 	// Token password reset token
 	Token string
 	// Current year for copyright year
-	CurrentYear  int
+	CurrentYear int
 }
 
 func (r PasswordResetMailer) Message() ([]byte, error) {

--- a/server/mail/users.go
+++ b/server/mail/users.go
@@ -3,6 +3,7 @@ package mail
 import (
 	"bytes"
 	"html/template"
+	"time"
 
 	"github.com/fleetdm/fleet/v4/server"
 )
@@ -11,9 +12,11 @@ type ChangeEmailMailer struct {
 	BaseURL  template.URL
 	AssetURL template.URL
 	Token    string
+	CurrentYear  int
 }
 
 func (cem *ChangeEmailMailer) Message() ([]byte, error) {
+	cem.CurrentYear = time.Now().Year()
 	t, err := server.GetTemplate("server/mail/templates/change_email_confirmation.html", "email_template")
 	if err != nil {
 		return nil, err
@@ -33,9 +36,12 @@ type PasswordResetMailer struct {
 	AssetURL template.URL
 	// Token password reset token
 	Token string
+	// Current year for copyright year
+	CurrentYear  int
 }
 
 func (r PasswordResetMailer) Message() ([]byte, error) {
+	r.CurrentYear = time.Now().Year()
 	t, err := server.GetTemplate("server/mail/templates/password_reset.html", "email_template")
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Related to #15758

Changes:
- Updated the copyright year in email templates to be set to the current year when the email is sent.


Testing steps:
1. Configure a local Fleet instance to send emails to Mailpit
2. Activate SMTP to send a test email.
3. Invite a new user to the Fleet instance.
4. Change the email address of a user.
5. Log out of the Fleet instance and send a password reset email.
6. Go to the Mailpit dashboard and look at the copyright years in the emails sent by the Fleet instance