### PR TITLE
Part 3: Bugfix - replace MSRC OS Version compare

### DIFF
--- a/server/vulnerabilities/msrc/analyzer.go
+++ b/server/vulnerabilities/msrc/analyzer.go
@@ -2,6 +2,7 @@ package msrc
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -201,7 +202,7 @@ func loadBulletin(os fleet.OperatingSystem, dir string) (*msrc.SecurityBulletin,
 
 func winBuildVersionGreaterOrEqual(feed, os string) (bool, error) {
 	if feed == "" {
-		return false, fmt.Errorf("empty feed version")
+		return false, errors.New("empty feed version")
 	}
 
 	feedBuild, feedParts, err := getBuildNumber(feed)

--- a/server/vulnerabilities/msrc/analyzer.go
+++ b/server/vulnerabilities/msrc/analyzer.go
@@ -2,6 +2,9 @@ package msrc
 
 import (
 	"context"
+	"fmt"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/fleetdm/fleet/v4/server/contexts/ctxerr"
@@ -159,8 +162,16 @@ func patched(
 			continue
 		}
 
-		// Check if the kernel build already contains the fix
-		if utils.Rpmvercmp(os.KernelVersion, fix.FixedBuild) >= 0 {
+		if fix.FixedBuild == "" {
+			continue
+		}
+
+		isGreater, err := winBuildVersionGreaterOrEqual(fix.FixedBuild, os.KernelVersion)
+		if err != nil {
+			// TODO Log Debug Error
+			continue
+		}
+		if isGreater {
 			return true
 		}
 
@@ -186,4 +197,46 @@ func loadBulletin(os fleet.OperatingSystem, dir string) (*msrc.SecurityBulletin,
 	}
 
 	return msrc.UnmarshalBulletin(latest)
+}
+
+func winBuildVersionGreaterOrEqual(feed, os string) (bool, error) {
+	if feed == "" {
+		return false, fmt.Errorf("empty feed version")
+	}
+
+	feedBuild, feedParts, err := getBuildNumber(feed)
+	if err != nil {
+		return false, fmt.Errorf("invalid feed version: %w", err)
+	}
+
+	osBuild, osParts, err := getBuildNumber(os)
+	if err != nil {
+		return false, fmt.Errorf("invalid os version: %w", err)
+	}
+
+	for i := 0; i < 3; i++ {
+		if feedParts[i] != osParts[i] {
+			return false, fmt.Errorf("comparing different product versions: %s, %s", feed, os)
+		}
+	}
+
+	return osBuild >= feedBuild, nil
+}
+
+func getBuildNumber(version string) (int, []string, error) {
+	if version == "" {
+		return 0, nil, fmt.Errorf("empty version string %s", version)
+	}
+
+	parts := strings.Split(version, ".")
+	if len(parts) != 4 {
+		return 0, nil, fmt.Errorf("parts count mismatch %s", version)
+	}
+
+	build, err := strconv.Atoi(parts[3])
+	if err != nil {
+		return 0, nil, fmt.Errorf("unable to parse build number %s", version)
+	}
+
+	return build, parts, nil
 }

--- a/server/vulnerabilities/msrc/analyzer.go
+++ b/server/vulnerabilities/msrc/analyzer.go
@@ -163,6 +163,9 @@ func patched(
 			continue
 		}
 
+		// An empty FixBuild is a bug in the MSRC feed, last
+		// seen around apr-2021.  Ignoring it to avoid false
+		// positive vulnerabilities.
 		if fix.FixedBuild == "" {
 			continue
 		}


### PR DESCRIPTION
#15801 

Found a bug in version matching between Windows "kernel_version" and the "FixedBuild" version strings in Windows OS Vuln matching when end-to-end testing against Windows 11.

Instead of debuging `utils.Rpmvercmp` which is used elsewhere (modifying may also cause regressions), since the version compare is a fairly simple parse and integer compare, a new compare func if implemented here which should be easier to maintain.