### PR TITLE
On My device and Host details pages, failing policies are now listed first.

### DIFF
--- a/changes/10379-list-failing-policies-first
+++ b/changes/10379-list-failing-policies-first
@@ -1,1 +1,1 @@
-On My device and Host details pages, failing policies are now listed first.
+On My device, Host details pages, and GET /api/v1/fleet/hosts/:id API endpoint, failing policies are now listed first.

--- a/changes/10379-list-failing-policies-first
+++ b/changes/10379-list-failing-policies-first
@@ -1,0 +1,1 @@
+On My device and Host details pages, failing policies are now listed first.

--- a/frontend/pages/hosts/details/cards/Policies/Policies.tsx
+++ b/frontend/pages/hosts/details/cards/Policies/Policies.tsx
@@ -71,7 +71,7 @@ const Policies = ({
             columnConfigs={tableHeaders}
             data={generatePolicyDataSet(policies)}
             isLoading={isLoading}
-            manualSortBy={true}
+            manualSortBy
             resultsTitle={"policy items"}
             emptyComponent={() => <></>}
             showMarkAllPages={false}

--- a/frontend/pages/hosts/details/cards/Policies/Policies.tsx
+++ b/frontend/pages/hosts/details/cards/Policies/Policies.tsx
@@ -71,8 +71,7 @@ const Policies = ({
             columnConfigs={tableHeaders}
             data={generatePolicyDataSet(policies)}
             isLoading={isLoading}
-            defaultSortHeader={"name"}
-            defaultSortDirection={"asc"}
+            manualSortBy={true}
             resultsTitle={"policy items"}
             emptyComponent={() => <></>}
             showMarkAllPages={false}

--- a/server/datastore/mysql/hosts.go
+++ b/server/datastore/mysql/hosts.go
@@ -2835,7 +2835,7 @@ func (ds *Datastore) ListPoliciesForHost(ctx context.Context, host *fleet.Host) 
 	LEFT JOIN users u ON p.author_id = u.id
 	WHERE (p.team_id IS NULL OR p.team_id = (select team_id from hosts WHERE id = ?))
 	AND (p.platforms IS NULL OR p.platforms = '' OR FIND_IN_SET(?, p.platforms) != 0)
-    ORDER BY FIELD(response, 'fail', '', 'pass'), p.name`
+	ORDER BY FIELD(response, 'fail', '', 'pass'), p.name`
 
 	var policies []*fleet.HostPolicy
 	if err := sqlx.SelectContext(ctx, ds.reader(ctx), &policies, query, host.ID, host.ID, host.FleetPlatform()); err != nil {

--- a/server/datastore/mysql/hosts.go
+++ b/server/datastore/mysql/hosts.go
@@ -2834,7 +2834,8 @@ func (ds *Datastore) ListPoliciesForHost(ctx context.Context, host *fleet.Host) 
 	LEFT JOIN policy_membership pm ON (p.id=pm.policy_id AND host_id=?)
 	LEFT JOIN users u ON p.author_id = u.id
 	WHERE (p.team_id IS NULL OR p.team_id = (select team_id from hosts WHERE id = ?))
-	AND (p.platforms IS NULL OR p.platforms = '' OR FIND_IN_SET(?, p.platforms) != 0)`
+	AND (p.platforms IS NULL OR p.platforms = '' OR FIND_IN_SET(?, p.platforms) != 0)
+    ORDER BY FIELD(response, 'fail', '', 'pass'), p.name`
 
 	var policies []*fleet.HostPolicy
 	if err := sqlx.SelectContext(ctx, ds.reader(ctx), &policies, query, host.ID, host.ID, host.FleetPlatform()); err != nil {

--- a/server/service/integration_core_test.go
+++ b/server/service/integration_core_test.go
@@ -2573,11 +2573,12 @@ func (s *integrationTestSuite) TestHostDetailsPolicies() {
 	hd := r.Host.HostDetail
 	policies := *hd.Policies
 	require.Len(t, policies, 2)
-	require.True(t, reflect.DeepEqual(gpResp.Policy.PolicyData, policies[0].PolicyData))
-	require.Equal(t, policies[0].Response, "pass")
+	// Policies that did not run are listed before passing policies
+	require.True(t, reflect.DeepEqual(tpResp.Policy.PolicyData, policies[0].PolicyData))
+	require.Equal(t, policies[0].Response, "") // policy didn't "run"
 
-	require.True(t, reflect.DeepEqual(tpResp.Policy.PolicyData, policies[1].PolicyData))
-	require.Equal(t, policies[1].Response, "") // policy didn't "run"
+	require.True(t, reflect.DeepEqual(gpResp.Policy.PolicyData, policies[1].PolicyData))
+	require.Equal(t, policies[1].Response, "pass")
 
 	// Try to create a global policy with an existing name.
 	s.DoJSON("POST", "/api/latest/fleet/policies", gpParams, http.StatusConflict, &gpResp)


### PR DESCRIPTION
On My device, Host details pages, and `GET /api/v1/fleet/hosts/:id` API endpoint, failing policies are now listed first.
#10379 

REST API change to be documented in a separate PR.

# Checklist for submitter

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [x] Added/updated tests
- [x] Manual QA for all new/changed functionality
