### PR TITLE
Website: Update community edition link on pricing page

### DIFF
--- a/website/views/pages/pricing.ejs
+++ b/website/views/pages/pricing.ejs
@@ -20,7 +20,7 @@
               </div>
             </div>
           </div>
-          <a purpose="card-button" class="btn btn-block btn-lg btn-primary mx-auto" href="https://github.com/fleetdm/fleet">View source code</a>
+          <a purpose="card-button" class="btn btn-block btn-lg btn-primary mx-auto" target="_blank" href="https://github.com/fleetdm/fleet">View source code</a>
         </div>
         <%// Fleet Premium tier card %>
         <div purpose="premium-card" class="d-flex flex-column justify-content-center">


### PR DESCRIPTION
Closes: https://github.com/fleetdm/confidential/issues/5014

Changes:
- Updated the link on the pricing page for the community edition of Fleet to open in a new tab.