### PR TITLE
API design: Make configuration_web_url configurable (#15633)

### DIFF
--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -4598,6 +4598,44 @@ Deletes the custom MDM setup enrollment profile assigned to a team or no team.
 
 `Status: 204`
 
+### Validate user during automatic enrollment
+
+_Available in Fleet Premium_
+
+Only use this endpoint if you set a custom value for `configuration_web_url` in your automatic enrollment (DEP) profile.
+
+This endpoint validates the user and tells Fleet to allow the macOS host to continue to the next step of the new Mac setup flow.
+
+`POST /api/v1/fleet/mdm/automatic_enrollment/validate_user`
+
+#### Parameters
+
+| Name                      | Type    | In    | Description                                                                           |
+| ------------------------- | ------  | ----- | -------------------------------------------------------------------------             |
+| enrollment_reference        | string | query | **Required.** A reference that must be passed along with `profile_token` to the endpoint to download an enrollment profile. |
+| profile_token  | string | query | **Required.** Token that can be used to download an enrollment profile |
+| username                   | string | query | The username used to pre-populate the **Account name** field in the account creation screen for the end user. |
+| fullname                   | string | query | The full name used to pre-populate the **Full name** field in the account creation screen for the end user. |
+| password                   | string | query | The password used to pre-populate the **Password** field in the account creation screen for the end user. |
+
+
+#### Example
+
+`DELETE /api/v1/fleet/mdm/apple/enrollment_profile?team_id=123`
+
+##### Request body
+
+```json
+{
+  "team_id": 1,
+  "enabled_end_user_authentication": true
+}
+```
+
+##### Default response
+
+`Status: 200`
+
 ### Get Apple Push Notification service (APNs)
 
 `GET /api/v1/fleet/mdm/apple`

--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -4089,9 +4089,9 @@ These API endpoints are used to automate MDM features in Fleet. Read more about 
 - [Run custom MDM command](#run-custom-mdm-command)
 - [Get custom MDM command results](#get-custom-mdm-command-results)
 - [List custom MDM commands](#list-custom-mdm-commands)
-- [Set custom MDM setup enrollment profile](#set-custom-mdm-setup-enrollment-profile)
-- [Get custom MDM setup enrollment profile](#get-custom-mdm-setup-enrollment-profile)
-- [Delete custom MDM setup enrollment profile](#delete-custom-mdm-setup-enrollment-profile)
+- [Set custom automatic enrollment profile](#set-custom-automatic-enrollment-setup-enrollment-profile)
+- [Get custom automatic enrollment profile](#get-custom-automatic-enrollment-enrollment-profile)
+- [Delete custom automatic enrollment enrollment profile](#delete-custom-mdm-setup-enrollment-profile)
 - [Get Apple Push Notification service (APNs)](#get-apple-push-notification-service-apns)
 - [Get Apple Business Manager (ABM)](#get-apple-business-manager-abm)
 - [Turn off MDM for a host](#turn-off-mdm-for-a-host)
@@ -4506,11 +4506,11 @@ This endpoint returns the list of custom MDM commands that have been executed.
 }
 ```
 
-### Set custom MDM setup enrollment profile
+### Set custom automatic enrollment profile
 
 _Available in Fleet Premium_
 
-Sets the custom MDM setup enrollment profile for a team or no team.
+Sets the custom automatic enrollment profile for a team or no team.
 
 `POST /api/v1/fleet/mdm/apple/enrollment_profile`
 
@@ -4542,11 +4542,11 @@ Sets the custom MDM setup enrollment profile for a team or no team.
 }
 ```
 
-### Get custom MDM setup enrollment profile
+### Get custom automatic enrollment profile
 
 _Available in Fleet Premium_
 
-Gets the custom MDM setup enrollment profile for a team or no team.
+Gets the custom automatic enrollment profile for a team or no team.
 
 `GET /api/v1/fleet/mdm/apple/enrollment_profile`
 
@@ -4576,11 +4576,11 @@ Gets the custom MDM setup enrollment profile for a team or no team.
 }
 ```
 
-### Delete custom MDM setup enrollment profile
+### Delete custom automatic enrollment profile
 
 _Available in Fleet Premium_
 
-Deletes the custom MDM setup enrollment profile assigned to a team or no team.
+Deletes the custom automatic enrollment profile assigned to a team or no team.
 
 `DELETE /api/v1/fleet/mdm/apple/enrollment_profile`
 


### PR DESCRIPTION
API changes for the "Make configuration_web_url configurable" (#15633) story

Changes inspired by the "Complete SSO during DEP enrollment" API route: https://github.com/fleetdm/fleet/blob/main/docs/Contributing/API-for-contributors.md#complete-sso-during-dep-enrollment

Noah: Does this make sense?

Noah: Do we need `enrollment_reference` and/or `profile_token`? How will the user know what to set for these?
- Roberto: We could maybe drop `enrollment_reference` if the customer is providing the end user information in the endpoint. We use `enrollment_reference` in the end user auth flow because we get the end user info at a later stage.
- Roberto: Customer could use an API token instead of `profile_token` if they want to use a reverse proxy.

UPDATE: 

Roberto: The user can also send the enrollment profile to the device themselves. In this scenario, they don't need to hit a Fleet API. They won't get any additional Fleet features like pre-populating the user account.

Noah: Let's go w/ this. I think the customer might already know how to do this.

Roberto: There's some documentation w/ instructions on how to send a host an enrollment profile. I can send Noah this.


