### PR TITLE
For `software/titles` and `software/versions` endpoints, the `browser` property is no longer included in the response when empty.

### DIFF
--- a/changes/16056-empty-browser-property
+++ b/changes/16056-empty-browser-property
@@ -1,0 +1,1 @@
+For `software/titles` and `software/versions` endpoints, the `browser` property is no longer included in the response when empty.

--- a/cmd/fleetctl/get_test.go
+++ b/cmd/fleetctl/get_test.go
@@ -667,7 +667,6 @@ spec:
   id: 0
   name: foo
   source: chrome_extensions
-  browser: ""
   versions:
   - id: 0
     version: 0.0.1
@@ -687,7 +686,6 @@ spec:
   id: 0
   name: bar
   source: deb_packages
-  browser: ""
   versions:
   - id: 0
     version: 0.0.3
@@ -704,7 +702,6 @@ spec:
       "id": 0,
       "name": "foo",
       "source": "chrome_extensions",
-	  "browser": "",
       "hosts_count": 2,
       "versions_count": 3,
       "versions": [
@@ -736,7 +733,6 @@ spec:
       "id": 0,
       "name": "bar",
       "source": "deb_packages",
-	  "browser": "",
       "hosts_count": 0,
       "versions_count": 1,
       "versions": [

--- a/server/fleet/software.go
+++ b/server/fleet/software.go
@@ -137,7 +137,7 @@ type SoftwareTitle struct {
 	// Source is the source reported by osquery.
 	Source string `json:"source" db:"source"`
 	// Browser is the browser type (e.g., "chrome", "firefox", "safari")
-	Browser string `json:"browser" db:"browser"`
+	Browser string `json:"browser,omitempty" db:"browser"`
 	// HostsCount is the number of hosts that use this software title.
 	HostsCount uint `json:"hosts_count" db:"hosts_count"`
 	// VesionsCount is the number of versions that have the same title.


### PR DESCRIPTION
For `software/titles` and `software/versions` endpoints, the `browser` property is no longer included in the response when empty.
#16056

# Checklist for submitter
<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [x] Added/updated tests
- [x] Manual QA for all new/changed functionality
