### PR TITLE
Fleet UI: Fix empty state width causing center misalignment

### DIFF
--- a/changes/15998-empty-state-styling
+++ b/changes/15998-empty-state-styling
@@ -1,0 +1,1 @@
+- Fix center styling for empty states

--- a/frontend/components/EmptyTable/_styles.scss
+++ b/frontend/components/EmptyTable/_styles.scss
@@ -36,9 +36,6 @@
       }
     }
   }
-  &__info {
-    max-width: 350px;
-  }
 
   &__info,
   &__additional-info {

--- a/frontend/pages/queries/details/components/NoResults/NoResults.tsx
+++ b/frontend/pages/queries/details/components/NoResults/NoResults.tsx
@@ -70,7 +70,6 @@ const NoResults = ({
         if (disabledCachingGlobally) {
           return (
             <>
-              {" "}
               <div>
                 The following setting prevents saving this query&apos;s results
                 in Fleet:


### PR DESCRIPTION
## Issue
Cerra #15998 

## Description
- Remove empty state info global width set to 350px so it will take up 100% of the empty state width

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
- [x] Manual QA for all new/changed functionality
