### PR TITLE
Fleet UI: Consistent loading spinner when using search filter on tables

### DIFF
--- a/changes/15732-table-loading
+++ b/changes/15732-table-loading
@@ -1,0 +1,1 @@
+- Consistent loading states when using searchfilter

--- a/frontend/components/TableContainer/TableContainer.tsx
+++ b/frontend/components/TableContainer/TableContainer.tsx
@@ -383,7 +383,10 @@ const TableContainer = ({
       <div className={`${baseClass}__data-table-block`}>
         {/* No entities for this result. */}
         {(!isLoading && data.length === 0 && !isMultiColumnFilter) ||
-        (searchQuery.length && data.length === 0 && !isMultiColumnFilter) ? (
+        (searchQuery.length &&
+          data.length === 0 &&
+          !isMultiColumnFilter &&
+          !isLoading) ? (
           <>
             <EmptyComponent pageIndex={pageIndex} />
             {pageIndex !== 0 && (
@@ -403,7 +406,7 @@ const TableContainer = ({
           <>
             {/* TODO: Fix this hacky solution to clientside search being 0 rendering emptycomponent but
             no longer accesses rows.length because DataTable is not rendered */}
-            {clientFilterCount === 0 && !isMultiColumnFilter && (
+            {!isLoading && clientFilterCount === 0 && !isMultiColumnFilter && (
               <EmptyComponent pageIndex={pageIndex} />
             )}
             <div


### PR DESCRIPTION
## Issue
Cerra #15732

## Description
- Consistent loading spinners when using search filter on tables
- Fix: Never render empty state if data is currently being fetched

## Screenrecording
https://github.com/fleetdm/fleet/assets/71795832/bfd860d4-f3d2-40b6-9949-005354d32c89


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
- [x] Manual QA for all new/changed functionality
