### PR TITLE
Fix fleetd-chrome release workflows

### DIFF
--- a/.github/workflows/release-fleetd-chrome-beta.yml
+++ b/.github/workflows/release-fleetd-chrome-beta.yml
@@ -31,7 +31,7 @@ jobs:
         working-directory: ./ee/fleetd-chrome
         run: |
           echo -e 'FLEET_URL=""\nFLEET_ENROLL_SECRET=""' > .env
-          npm install && npm run test
+          npm install && npm test
 
       - name: Build & sign extension
         working-directory: ./ee/fleetd-chrome

--- a/.github/workflows/release-fleetd-chrome.yml
+++ b/.github/workflows/release-fleetd-chrome.yml
@@ -32,7 +32,7 @@ jobs:
         working-directory: ./ee/fleetd-chrome
         run: |
           echo -e 'FLEET_URL=""\nFLEET_ENROLL_SECRET=""' > .env
-          npm install && npm run test
+          npm install && npm test
 
       - name: Build & sign extension
         working-directory: ./ee/fleetd-chrome


### PR DESCRIPTION
Use `npm test` instead of `npm run test`.