### PR TITLE
Website: Update searchbar on osquery schema table pages.

### DIFF
--- a/website/assets/styles/pages/osquery-table-details.less
+++ b/website/assets/styles/pages/osquery-table-details.less
@@ -33,6 +33,7 @@
     [purpose='search'] {
       // Note: We're using classes here to override the default Docsearch styles;
       width: 260px;
+      height: 40px;
       border-radius: 8px;
       button {
         width: 260px;
@@ -46,8 +47,8 @@
         border-bottom-right-radius: 6px;
         border: 1px solid @core-fleet-black-25;
         background-color: #FFF;
-        height: 42px;
-        padding: 8px 15px;
+        height: 40px;
+        padding: 9px 16px;
         margin: 0;
       }
       .DocSearch-Button:hover {

--- a/website/assets/styles/pages/osquery-table-details.less
+++ b/website/assets/styles/pages/osquery-table-details.less
@@ -33,7 +33,6 @@
     [purpose='search'] {
       // Note: We're using classes here to override the default Docsearch styles;
       width: 260px;
-      height: 40px;
       border-radius: 8px;
       button {
         width: 260px;


### PR DESCRIPTION
Closes: #16108

Changes:
- Updated the styles for the search bar on `/tables/*` pages to make it have the same height and padding as the platform selector