### PR TITLE
Website: Update GH webhook to not send requests to Zapier for patch releases.

### DIFF
--- a/website/api/controllers/webhooks/receive-from-github.js
+++ b/website/api/controllers/webhooks/receive-from-github.js
@@ -618,7 +618,7 @@ module.exports = {
       if(owner === 'fleetdm' && repo === 'fleet') {
         if(release
           && _.startsWith(release.tag_name, 'fleet-v')// Only send requests for releases with tag names that start with 'fleet'
-          && _.endsWith(release.tag_name, '.0')// Only send requests if the release is a major or minor version. This works because all Fleet semvers have 2 periods. 
+          && _.endsWith(release.tag_name, '.0')// Only send requests if the release is a major or minor version. This works because all Fleet semvers have 2 periods.
         ) {
           // Send a POST request to Zapier with the release object.
           await sails.helpers.http.post.with({

--- a/website/api/controllers/webhooks/receive-from-github.js
+++ b/website/api/controllers/webhooks/receive-from-github.js
@@ -618,7 +618,7 @@ module.exports = {
       if(owner === 'fleetdm' && repo === 'fleet') {
         if(release
           && _.startsWith(release.tag_name, 'fleet-v')// Only send requests for releases with tag names that start with 'fleet'
-          && _.endsWith(release.tag_name, '.0')// Only send requests if the release is a major or minor versions.
+          && _.endsWith(release.tag_name, '.0')// Only send requests if the release is a major or minor version. This works because all Fleet semvers have 2 periods. 
         ) {
           // Send a POST request to Zapier with the release object.
           await sails.helpers.http.post.with({

--- a/website/api/controllers/webhooks/receive-from-github.js
+++ b/website/api/controllers/webhooks/receive-from-github.js
@@ -616,8 +616,10 @@ module.exports = {
 
       // Only continue if this release came from the fleetdm/fleet repo,
       if(owner === 'fleetdm' && repo === 'fleet') {
-        // Only send requests for releases with tag names that start with 'fleet'
-        if(release && _.startsWith(release.tag_name, 'fleet-v')) {
+        if(release
+          && _.startsWith(release.tag_name, 'fleet-v')// Only send requests for releases with tag names that start with 'fleet'
+          && _.endsWith(release.tag_name, '.0')// Only send requests if the release is a major or minor versions.
+        ) {
           // Send a POST request to Zapier with the release object.
           await sails.helpers.http.post.with({
             url: 'https://hooks.zapier.com/hooks/catch/3627242/3ozw6bk/',


### PR DESCRIPTION
Closes: #16135

Changes:
- Updated the `receive-from-github` webhook to not send requests to Zapier when a patch version of Fleet is released.

For context: The request to Zapier triggers an automation that updates Slack channel topics with information about the latest release of Fleet.