### PR TITLE
Website: Update tagline on homepage and endpoint ops page, update order of calls to action.

### DIFF
--- a/website/views/pages/endpoint-ops.ejs
+++ b/website/views/pages/endpoint-ops.ejs
@@ -186,7 +186,7 @@
         <h2>Focus on data, not vendors</h2>
         <div purpose="button-row" style="margin-top: 32px;" class="d-flex flex-md-row flex-column justify-content-center align-items-center mx-auto">
           <a purpose="cta-button" @click="clickOpenChatWidget()">Show me</a>
-          <a href="/try-fleet/register?tryitnow" purpose="animated-arrow-button-red">Explore real data</a>
+          <a href="/try-fleet/register?tryitnow" purpose="animated-arrow-button-red">See real data</a>
         </div>
       </div>
     </div>

--- a/website/views/pages/endpoint-ops.ejs
+++ b/website/views/pages/endpoint-ops.ejs
@@ -4,7 +4,7 @@
     <div purpose="hero">
       <div purpose="page-headline">
         <h4>Endpoint operations</h4>
-        <h2>Focus on data not vendors</h2>
+        <h2>Focus on data, not vendors</h2>
       </div>
       <div purpose="hero-content" class="d-flex flex-md-row flex-column align-items-center justify-content-between">
         <div purpose="hero-image">
@@ -183,10 +183,10 @@
 
       <div purpose="section-heading" class="text-center">
         <h4>Open-source endpoint ops</h4>
-        <h2>Focus on data not vendors</h2>
+        <h2>Focus on data, not vendors</h2>
         <div purpose="button-row" style="margin-top: 32px;" class="d-flex flex-md-row flex-column justify-content-center align-items-center mx-auto">
-          <a purpose="cta-button" href="/try-fleet/register?tryitnow">Try it out</a>
-          <a @click="clickOpenChatWidget()" purpose="animated-arrow-button-red">Show me</a>
+          <a purpose="cta-button" @click="clickOpenChatWidget()">Show me</a>
+          <a href="/try-fleet/register?tryitnow" purpose="animated-arrow-button-red">Explore real data</a>
         </div>
       </div>
     </div>

--- a/website/views/pages/endpoint-ops.ejs
+++ b/website/views/pages/endpoint-ops.ejs
@@ -186,7 +186,7 @@
         <h2>Focus on data, not vendors</h2>
         <div purpose="button-row" style="margin-top: 32px;" class="d-flex flex-md-row flex-column justify-content-center align-items-center mx-auto">
           <a purpose="cta-button" @click="clickOpenChatWidget()">Show me</a>
-          <a href="/try-fleet/register?tryitnow" purpose="animated-arrow-button-red">See real data</a>
+          <a purpose="animated-arrow-button-red" href="/try-fleet">See real data</a>
         </div>
       </div>
     </div>

--- a/website/views/pages/homepage.ejs
+++ b/website/views/pages/homepage.ejs
@@ -7,7 +7,7 @@
           <%/* Hero text */%>
           <div purpose="hero-text"  class="d-flex flex-column justify-content-center">
             <h4>For teams with lots of endpoints</h4>
-            <h1>Focus on data not vendors</h1>
+            <h1>Focus on data, not vendors</h1>
             <p>Replace the sprawl you inherited with open-source code that works the way you want.</p>
             <div purpose="button-row" class="d-flex flex-sm-row flex-column justify-content-center align-items-center">
               <a purpose="cta-button" href="/try-fleet">Try it out</a>
@@ -95,7 +95,7 @@
     <%/* Endpoint ops block */%>
     <div purpose="platform-block" class="d-flex flex-lg-row flex-column justify-content-between mx-auto align-items-lg-center align-items-start" :class="[selectedCategory === 'endpoint-ops' ? ' show' : 'hidden']">
       <div purpose="category-text-block" class="d-flex flex-column">
-        <h3>Focus on data not vendors</h3>
+        <h3>Focus on data, not vendors</h3>
         <p>Use a consistent interface to deploy, update, and manage thousands of workstations and servers with open standards and data.</p>
         <a purpose="animated-arrow-button-red" href="/endpoint-ops">More about endpoint ops</a>
       </div>
@@ -294,7 +294,7 @@
     <div purpose="homepage-content" class="container">
       <div class="text-center">
         <h4>For teams with lots of endpoints</h4>
-        <h1>Focus on data not vendors</h1>
+        <h1>Focus on data, not vendors</h1>
         <div purpose="button-row" style="margin-top: 60px;" class="d-flex flex-sm-row flex-column justify-content-center align-items-center mx-auto">
           <a purpose="cta-button" href="/try-fleet">Try it out</a>
           <a @click="clickOpenChatWidget()" purpose="animated-arrow-button-red">Show me</a>

--- a/website/views/pages/vulnerability-management.ejs
+++ b/website/views/pages/vulnerability-management.ejs
@@ -72,7 +72,7 @@
           <p>Lightweight enough for the most brittle environments (OT, data centers, embedded/BTS, low-latency gaming servers)</p>
           <p>Triage a high-urgency zero day in hours, not days. Get data on any vulnerability in your environment on demand</p>
         </div>
-        <a purpose="animated-arrow-button-red" href="/try-fleet">Explore real data</a>
+        <a purpose="animated-arrow-button-red" href="/try-fleet">See real data</a>
       </div>
       <div purpose="feature-image" class="left">
         <img alt="Up-to-date data without scans" src="/images/vuln-management-feature-image-2-380x323@2x.png">
@@ -104,7 +104,7 @@
           <p>Prioritize more efficiently with a thin, admin-level agent that has visibility down to the chipset of any endpoint</p>
           <p>Access over 300 tables of system state data. Use presets or create your own queries</p>
         </div>
-        <a purpose="animated-arrow-button-red" href="/try-fleet">Explore real data</a>
+        <a purpose="animated-arrow-button-red" href="/try-fleet">See real data</a>
       </div>
       <div purpose="feature-image" class="left">
         <img alt="Deep context from the environment" src="/images/vuln-management-feature-image-4-380x270@2x.png">
@@ -145,7 +145,7 @@
         <h2>Build the vulnerability program you actually want</h2>
         <div purpose="button-row" style="margin-top: 32px;" class="d-flex flex-md-row flex-column justify-content-center align-items-center mx-auto">
           <a purpose="cta-button" @click="clickOpenChatWidget()">Show me</a>
-          <a purpose="animated-arrow-button-red" href="/try-fleet/register?tryitnow">See real data</a>
+          <a purpose="animated-arrow-button-red" href="/try-fleet">See real data</a>
         </div>
       </div>
     </div>

--- a/website/views/pages/vulnerability-management.ejs
+++ b/website/views/pages/vulnerability-management.ejs
@@ -144,8 +144,8 @@
         <h4>Open-source vulnerability management</h4>
         <h2>Build the vulnerability program you actually want</h2>
         <div purpose="button-row" style="margin-top: 32px;" class="d-flex flex-md-row flex-column justify-content-center align-items-center mx-auto">
-          <a purpose="cta-button" href="/try-fleet/register?tryitnow">Try it out</a>
-          <a @click="clickOpenChatWidget()" purpose="animated-arrow-button-red">Show me</a>
+          <a purpose="cta-button" @click="clickOpenChatWidget()">Show me</a>
+          <a purpose="animated-arrow-button-red" href="/try-fleet/register?tryitnow">Explore real data</a>
         </div>
       </div>
     </div>

--- a/website/views/pages/vulnerability-management.ejs
+++ b/website/views/pages/vulnerability-management.ejs
@@ -145,7 +145,7 @@
         <h2>Build the vulnerability program you actually want</h2>
         <div purpose="button-row" style="margin-top: 32px;" class="d-flex flex-md-row flex-column justify-content-center align-items-center mx-auto">
           <a purpose="cta-button" @click="clickOpenChatWidget()">Show me</a>
-          <a purpose="animated-arrow-button-red" href="/try-fleet/register?tryitnow">Explore real data</a>
+          <a purpose="animated-arrow-button-red" href="/try-fleet/register?tryitnow">See real data</a>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Closes: #16154 

Changes:
- Reordered the calls to action at the bottom of the /vulnerability-management and /endpoint-ops pages and updated the button text
- Updated the secondary button on the bottom CTA on the /endpoint-ops and /vulnerability-management pages to link to /try-fleet
- Re-added a comma to the tagline on the homepage and endpoint ops page.