### PR TITLE
Align lowercasing of display text and query text when generating label filter options

### DIFF
--- a/changes/15894-label-filter-case-bug
+++ b/changes/15894-label-filter-case-bug
@@ -1,0 +1,1 @@
+- Fix a bug where capital characters would not match labels containing them

--- a/frontend/interfaces/label.ts
+++ b/frontend/interfaces/label.ts
@@ -30,7 +30,7 @@ export interface ILabel extends ILabelSummary {
   uuid?: string;
   query: string;
   label_membership_type: LabelMembershipType;
-  hosts_count: number;
+  host_count?: number; // returned for built-in labels but not custom labels
   display_text: string;
   count: number; // seems to be a repeat of hosts_count issue #1618
   host_ids: number[] | null;

--- a/frontend/pages/hosts/ManageHostsPage/components/LabelFilterSelect/helpers.ts
+++ b/frontend/pages/hosts/ManageHostsPage/components/LabelFilterSelect/helpers.ts
@@ -34,7 +34,7 @@ const createCustomLabelOptions = (labels: ILabel[], query: string) => {
     customLabelGroupOptions = [NO_LABELS_OPTION];
   } else {
     const matchingLabels = customLabels.filter((label) =>
-      label.display_text.toLowerCase().includes(query)
+      label.display_text.includes(query)
     );
     customLabelGroupOptions =
       matchingLabels.length !== 0 ? matchingLabels : [EMPTY_OPTION];

--- a/frontend/pages/hosts/ManageHostsPage/components/LabelFilterSelect/helpers.ts
+++ b/frontend/pages/hosts/ManageHostsPage/components/LabelFilterSelect/helpers.ts
@@ -34,7 +34,8 @@ const createCustomLabelOptions = (labels: ILabel[], query: string) => {
     customLabelGroupOptions = [NO_LABELS_OPTION];
   } else {
     const matchingLabels = customLabels.filter((label) =>
-      label.display_text.includes(query)
+      // case-insensitive matching
+      label.display_text.toLowerCase().includes(query.toLowerCase())
     );
     customLabelGroupOptions =
       matchingLabels.length !== 0 ? matchingLabels : [EMPTY_OPTION];


### PR DESCRIPTION
## Addresses #15894 

<img width="329" alt="Screenshot 2024-01-18 at 1 23 20 PM" src="https://github.com/fleetdm/fleet/assets/61553566/00de2df1-43f8-4231-a1dc-73c8fb461151">

<img width="329" alt="Screenshot 2024-01-18 at 1 23 25 PM" src="https://github.com/fleetdm/fleet/assets/61553566/6eb0b66b-8831-4777-8bac-0811ddd66c28">
<img width="329" alt="Screenshot 2024-01-18 at 1 23 29 PM" src="https://github.com/fleetdm/fleet/assets/61553566/861cd837-43ed-455f-b3bc-a85eb5ac8087">



## Checklist for submitter
- [x] Changes file added for user-visible changes in `changes/`
- [x] Manual QA for all new/changed functionality