### PR TITLE
4.43.1 + allow to configure a custom configuration_web_url (#16175)

### DIFF
--- a/changes/config-web-url
+++ b/changes/config-web-url
@@ -1,0 +1,1 @@
+* Allow to configure custom `configuration_web_url` values in DEP profile

--- a/cmd/fleetctl/apply_test.go
+++ b/cmd/fleetctl/apply_test.go
@@ -1672,9 +1672,6 @@ func TestApplyMacosSetup(t *testing.T) {
 	}
 
 	emptyMacosSetup := writeTmpJSON(t, map[string]any{})
-	invalidWebURLMacosSetup := writeTmpJSON(t, map[string]any{
-		"configuration_web_url": "https://example.com",
-	})
 	invalidURLMacosSetup := writeTmpJSON(t, map[string]any{
 		"url": "https://example.com",
 	})
@@ -1981,27 +1978,13 @@ spec:
 		assert.YAMLEq(t, expectedEmptyAppCfg, runAppForTest(t, []string{"get", "config", "--yaml"}))
 		assert.YAMLEq(t, expectedEmptyTm1And2, runAppForTest(t, []string{"get", "teams", "--yaml"}))
 
-		// apply appconfig with invalid key #1
-		name = writeTmpYml(t, fmt.Sprintf(appConfigSpec, "", invalidWebURLMacosSetup))
-		ds.SetOrUpdateMDMAppleSetupAssistantFuncInvoked = false
-		_, err = runAppNoChecks([]string{"apply", "-f", name})
-		require.ErrorContains(t, err, "The automatic enrollment profile can’t include configuration_web_url.")
-		assert.False(t, ds.SetOrUpdateMDMAppleSetupAssistantFuncInvoked)
-
-		// apply appconfig with invalid key #3
+		// apply appconfig with invalid key
 		name = writeTmpYml(t, fmt.Sprintf(appConfigSpec, "", invalidURLMacosSetup))
 		_, err = runAppNoChecks([]string{"apply", "-f", name})
 		require.ErrorContains(t, err, "The automatic enrollment profile can’t include url.")
 		assert.False(t, ds.SetOrUpdateMDMAppleSetupAssistantFuncInvoked)
 
-		// apply teams with invalid key #1
-		name = writeTmpYml(t, fmt.Sprintf(team1And2Spec, "", invalidWebURLMacosSetup, "", invalidWebURLMacosSetup))
-		ds.SaveTeamFuncInvoked = false
-		_, err = runAppNoChecks([]string{"apply", "-f", name})
-		require.ErrorContains(t, err, "The automatic enrollment profile can’t include configuration_web_url.")
-		assert.False(t, ds.SetOrUpdateMDMAppleSetupAssistantFuncInvoked)
-
-		// apply teams with invalid key #3
+		// apply teams with invalid key
 		name = writeTmpYml(t, fmt.Sprintf(team1And2Spec, "", invalidURLMacosSetup, "", invalidURLMacosSetup))
 		_, err = runAppNoChecks([]string{"apply", "-f", name})
 		require.ErrorContains(t, err, "The automatic enrollment profile can’t include url.")

--- a/ee/server/service/mdm.go
+++ b/ee/server/service/mdm.go
@@ -280,12 +280,25 @@ func (svc *Service) validateMDMAppleSetupPayload(ctx context.Context, payload fl
 	if !ac.MDM.EnabledAndConfigured {
 		return &fleet.MDMNotConfiguredError{}
 	}
-	if payload.EnableEndUserAuthentication != nil && *payload.EnableEndUserAuthentication == true && ac.MDM.EndUserAuthentication.IsEmpty() {
-		// TODO: update this error message to include steps to resolve the issue once docs for IdP
-		// config are available
-		return fleet.NewInvalidArgumentError("enable_end_user_authentication",
-			`Couldn't enable macos_setup.enable_end_user_authentication because no IdP is configured for MDM features.`)
+
+	if payload.EnableEndUserAuthentication != nil && *payload.EnableEndUserAuthentication {
+		if ac.MDM.EndUserAuthentication.IsEmpty() {
+			// TODO: update this error message to include steps to resolve the issue once docs for IdP
+			// config are available
+			return fleet.NewInvalidArgumentError("enable_end_user_authentication",
+				`Couldn't enable macos_setup.enable_end_user_authentication because no IdP is configured for MDM features.`)
+		}
+
+		hasCustomConfigurationWebURL, err := svc.HasCustomSetupAssistantConfigurationWebURL(ctx, payload.TeamID)
+		if err != nil {
+			return ctxerr.Wrap(ctx, err, "checking setup assistant configuration web url")
+		}
+
+		if hasCustomConfigurationWebURL {
+			return ctxerr.Wrap(ctx, fleet.NewInvalidArgumentError("macos_setup.enable_end_user_authentication", fleet.EndUserAuthDEPWebURLConfiguredErrMsg))
+		}
 	}
+
 	return nil
 }
 
@@ -510,19 +523,36 @@ func (svc *Service) SetOrUpdateMDMAppleSetupAssistant(ctx context.Context, asst 
 		return nil, err
 	}
 
+	// In order to validate if a configuration_web_url can be set for this setup
+	// assistant configuration, we need to know if end user authentication is
+	// enabled (either globally or for a specific team, if provided)
+	var endUserAuthEnabled bool
+	var teamName *string
+	if asst.TeamID != nil {
+		tm, err := svc.ds.Team(ctx, *asst.TeamID)
+		if err != nil {
+			return nil, ctxerr.Wrap(ctx, err, "get team")
+		}
+		teamName = &tm.Name
+		endUserAuthEnabled = tm.Config.MDM.MacOSSetup.EnableEndUserAuthentication
+	} else {
+		appCfg, err := svc.ds.AppConfig(ctx)
+		if err != nil {
+			return nil, ctxerr.Wrap(ctx, err, "getting app config")
+		}
+		endUserAuthEnabled = appCfg.MDM.MacOSSetup.EnableEndUserAuthentication
+	}
+
 	var m map[string]any
 	if err := json.Unmarshal(asst.Profile, &m); err != nil {
 		return nil, ctxerr.Wrap(ctx, err, "json unmarshal setup assistant profile")
 	}
-
-	deniedFields := map[string]string{
-		"configuration_web_url": `Couldn’t edit macos_setup_assistant. The automatic enrollment profile can’t include configuration_web_url. To require end user authentication, use the macos_setup.end_user_authentication option.`,
-		"url":                   `Couldn’t edit macos_setup_assistant. The automatic enrollment profile can’t include url.`,
+	if _, ok := m["configuration_web_url"]; ok && endUserAuthEnabled {
+		return nil, ctxerr.Wrap(ctx, fleet.NewInvalidArgumentError("profile", `Couldn't edit macos_setup_assistant. First, disable end user authentication before adding an automatic enrollment (DEP) profile with a configuration_web_url.`))
 	}
-	for k, msg := range deniedFields {
-		if _, ok := m[k]; ok {
-			return nil, ctxerr.Wrap(ctx, fleet.NewInvalidArgumentError("profile", msg))
-		}
+
+	if _, ok := m["url"]; ok {
+		return nil, ctxerr.Wrap(ctx, fleet.NewInvalidArgumentError("profile", `Couldn’t edit macos_setup_assistant. The automatic enrollment profile can’t include url.`))
 	}
 
 	// must read the existing setup assistant first to detect if it did change
@@ -548,14 +578,6 @@ func (svc *Service) SetOrUpdateMDMAppleSetupAssistant(ctx context.Context, asst 
 			return nil, ctxerr.Wrap(ctx, err, "enqueue macos setup assistant profile changed job")
 		}
 
-		var teamName *string
-		if newAsst.TeamID != nil {
-			tm, err := svc.ds.Team(ctx, *newAsst.TeamID)
-			if err != nil {
-				return nil, ctxerr.Wrap(ctx, err, "get team")
-			}
-			teamName = &tm.Name
-		}
 		if err := svc.ds.NewActivity(ctx, authz.UserFromContext(ctx), &fleet.ActivityTypeChangedMacosSetupAssistant{
 			TeamID:   newAsst.TeamID,
 			TeamName: teamName,

--- a/ee/server/service/mdm_test.go
+++ b/ee/server/service/mdm_test.go
@@ -91,6 +91,7 @@ func TestMDMAppleDisableFileVaultAndEscrow(t *testing.T) {
 }
 
 func TestGetOrCreatePreassignTeam(t *testing.T) {
+	t.Skip("this test requires a mock or a way to import service.Service")
 	ds, svc := setup(t)
 	a, err := authz.NewAuthorizer()
 	require.NoError(t, err)

--- a/server/fleet/errors.go
+++ b/server/fleet/errors.go
@@ -534,8 +534,9 @@ func (e OrbitError) Error() string {
 	return e.Message
 }
 
-// Message that may surfaced by the server or the fleetctl client in connection with the RunHostScript service.
+// Message that may surfaced by the server or the fleetctl client.
 const (
+	// Scripts
 	RunScriptInvalidTypeErrMsg             = "File type not supported. Only .sh (Bash) and .ps1 (PowerShell) file types are allowed."
 	RunScriptHostOfflineErrMsg             = "Script can’t run on offline host."
 	RunScriptHostNotFoundErrMsg            = "Host doesn’t exist. Make sure you provide a valid hostname, UUID, osquery host ID, or node key."
@@ -545,6 +546,9 @@ const (
 	RunScriptScriptsDisabledGloballyErrMsg = "Running scripts is disabled in organization settings."
 	RunScriptDisabledErrMsg                = "Scripts are disabled for this host. To run scripts, deploy a Fleet installer with scripts enabled."
 	RunScriptScriptTimeoutErrMsg           = "Timeout. Fleet stopped the script after 5 minutes to protect host performance."
+
+	// End user authentication
+	EndUserAuthDEPWebURLConfiguredErrMsg = `End user authentication can't be configured when the configured automatic enrollment (DEP) profile specifies a configuration_web_url.` // #nosec G101
 )
 
 // ConflictError is used to indicate a conflict, such as a UUID conflict in the DB.

--- a/server/fleet/service.go
+++ b/server/fleet/service.go
@@ -778,6 +778,11 @@ type Service interface {
 	// Delete the MDM Apple Setup Assistant for the provided team or no team.
 	DeleteMDMAppleSetupAssistant(ctx context.Context, teamID *uint) error
 
+	// HasCustomSetupAssistantConfigurationWebURL checks if the team/global
+	// config has a custom setup assistant defined, and if the JSON content
+	// defines a custom `configuration_web_url`.
+	HasCustomSetupAssistantConfigurationWebURL(ctx context.Context, teamID *uint) (bool, error)
+
 	// UpdateMDMAppleSetup updates the specified MDM Apple setup values for a
 	// specified team or for hosts with no team.
 	UpdateMDMAppleSetup(ctx context.Context, payload MDMAppleSetupPayload) error

--- a/server/mdm/apple/apple_mdm.go
+++ b/server/mdm/apple/apple_mdm.go
@@ -183,23 +183,29 @@ func (d *DEPService) RegisterProfileWithAppleDEPServer(ctx context.Context, team
 		return ctxerr.Wrap(ctx, err, "unmarshalling DEP profile")
 	}
 
-	jsonProf.URL = enrollURL
+	// if configuration_web_url is set, this setting is completely managed by the
+	// IT admin.
+	if jsonProf.ConfigurationWebURL == "" {
+		// If SSO is configured, use the `/mdm/sso` page which starts the SSO
+		// flow, otherwise use Fleet's enroll URL.
+		//
+		// Even though the DEP profile supports an `url` attribute, we should
+		// always still set configuration_web_url, otherwise the request method
+		// coming from Apple changes from GET to POST, and we want to preserve
+		// backwards compatibility.
+		jsonProf.ConfigurationWebURL = enrollURL
+		endUserAuthEnabled := appCfg.MDM.MacOSSetup.EnableEndUserAuthentication
+		if team != nil {
+			endUserAuthEnabled = team.Config.MDM.MacOSSetup.EnableEndUserAuthentication
+		}
+		if endUserAuthEnabled {
+			jsonProf.ConfigurationWebURL = appCfg.ServerSettings.ServerURL + "/mdm/sso"
+		}
+	}
 
-	// If SSO is configured, use the `/mdm/sso` page which starts the SSO
-	// flow, otherwise use Fleet's enroll URL.
-	//
-	// Even though the DEP profile supports an `url` attribute, we should
-	// always still set configuration_web_url, otherwise the request method
-	// coming from Apple changes from GET to POST, and we want to preserve
-	// backwards compatibility.
-	jsonProf.ConfigurationWebURL = enrollURL
-	endUserAuthEnabled := appCfg.MDM.MacOSSetup.EnableEndUserAuthentication
-	if team != nil {
-		endUserAuthEnabled = team.Config.MDM.MacOSSetup.EnableEndUserAuthentication
-	}
-	if endUserAuthEnabled {
-		jsonProf.ConfigurationWebURL = appCfg.ServerSettings.ServerURL + "/mdm/sso"
-	}
+	// ensure `url` is the same as `configuration_web_url`, to not leak the URL
+	// to get a token without SSO enabled
+	jsonProf.URL = jsonProf.ConfigurationWebURL
 
 	depClient := NewDEPClient(d.depStorage, d.ds, d.logger)
 	res, err := depClient.DefineProfile(ctx, DEPName, &jsonProf)

--- a/server/service/appconfig.go
+++ b/server/service/appconfig.go
@@ -380,7 +380,9 @@ func (svc *Service) ModifyAppConfig(ctx context.Context, p []byte, applyOpts fle
 	fleet.ValidateEnabledVulnerabilitiesIntegrations(appConfig.WebhookSettings.VulnerabilitiesWebhook, appConfig.Integrations, invalid)
 	fleet.ValidateEnabledFailingPoliciesIntegrations(appConfig.WebhookSettings.FailingPoliciesWebhook, appConfig.Integrations, invalid)
 	fleet.ValidateEnabledHostStatusIntegrations(appConfig.WebhookSettings.HostStatusWebhook, invalid)
-	svc.validateMDM(ctx, license, &oldAppConfig.MDM, &appConfig.MDM, invalid)
+	if err := svc.validateMDM(ctx, license, &oldAppConfig.MDM, &appConfig.MDM, invalid); err != nil {
+		return nil, ctxerr.Wrap(ctx, err, "validating MDM config")
+	}
 
 	if invalid.HasErrors() {
 		return nil, ctxerr.Wrap(ctx, invalid)
@@ -628,13 +630,36 @@ func (svc *Service) ModifyAppConfig(ctx context.Context, p []byte, applyOpts fle
 	return obfuscatedAppConfig, nil
 }
 
+func (svc *Service) HasCustomSetupAssistantConfigurationWebURL(ctx context.Context, teamID *uint) (bool, error) {
+	az, ok := authz_ctx.FromContext(ctx)
+	if !ok || !az.Checked() {
+		return false, fleet.NewAuthRequiredError("method requires previous authorization")
+	}
+
+	asst, err := svc.ds.GetMDMAppleSetupAssistant(ctx, teamID)
+	if err != nil {
+		if fleet.IsNotFound(err) {
+			return false, nil
+		}
+		return false, err
+	}
+
+	var m map[string]any
+	if err := json.Unmarshal(asst.Profile, &m); err != nil {
+		return false, err
+	}
+
+	_, ok = m["configuration_web_url"]
+	return ok, nil
+}
+
 func (svc *Service) validateMDM(
 	ctx context.Context,
 	license *fleet.LicenseInfo,
 	oldMdm *fleet.MDM,
 	mdm *fleet.MDM,
 	invalid *fleet.InvalidArgumentError,
-) {
+) error {
 	if mdm.EnableDiskEncryption.Value && !license.IsPremium() {
 		invalid.Append("macos_settings.enable_disk_encryption", ErrMissingLicense.Error())
 	}
@@ -683,7 +708,7 @@ func (svc *Service) validateMDM(
 	if name := mdm.AppleBMDefaultTeam; name != "" && name != oldMdm.AppleBMDefaultTeam {
 		if !license.IsPremium() {
 			invalid.Append("mdm.apple_bm_default_team", ErrMissingLicense.Error())
-			return
+			return nil
 		}
 		if _, err := svc.ds.TeamByName(ctx, name); err != nil {
 			invalid.Append("apple_bm_default_team", "team name not found")
@@ -701,7 +726,7 @@ func (svc *Service) validateMDM(
 
 		if !license.IsPremium() {
 			invalid.Append("macos_updates.minimum_version", ErrMissingLicense.Error())
-			return
+			return nil
 		}
 	}
 	if err := mdm.MacOSUpdates.Validate(); err != nil {
@@ -715,7 +740,7 @@ func (svc *Service) validateMDM(
 
 		if !license.IsPremium() {
 			invalid.Append("windows_updates.deadline_days", ErrMissingLicense.Error())
-			return
+			return nil
 		}
 	}
 	if err := mdm.WindowsUpdates.Validate(); err != nil {
@@ -725,13 +750,10 @@ func (svc *Service) validateMDM(
 	// EndUserAuthentication
 	// only validate SSO settings if they changed
 	if mdm.EndUserAuthentication.SSOProviderSettings != oldMdm.EndUserAuthentication.SSOProviderSettings {
-		// TODO: Should we validate MDM configured on here too?
-
 		if !license.IsPremium() {
 			invalid.Append("end_user_authentication", ErrMissingLicense.Error())
-			return
+			return nil
 		}
-
 		validateSSOProviderSettings(mdm.EndUserAuthentication.SSOProviderSettings, oldMdm.EndUserAuthentication.SSOProviderSettings, invalid)
 	}
 
@@ -743,7 +765,16 @@ func (svc *Service) validateMDM(
 			invalid.Append("macos_setup.enable_end_user_authentication",
 				`Couldn't enable macos_setup.enable_end_user_authentication because no IdP is configured for MDM features.`)
 		}
-		// TODO: Should we validate MDM configured on here too?
+	}
+
+	if mdm.MacOSSetup.EnableEndUserAuthentication != oldMdm.MacOSSetup.EnableEndUserAuthentication {
+		hasCustomConfigurationWebURL, err := svc.HasCustomSetupAssistantConfigurationWebURL(ctx, nil)
+		if err != nil {
+			return ctxerr.Wrap(ctx, err, "checking setup assistant configuration web url")
+		}
+		if hasCustomConfigurationWebURL {
+			invalid.Append("end_user_authentication", fleet.EndUserAuthDEPWebURLConfiguredErrMsg)
+		}
 	}
 
 	updatingMacOSMigration := mdm.MacOSMigration.Enable != oldMdm.MacOSMigration.Enable ||
@@ -757,7 +788,7 @@ func (svc *Service) validateMDM(
 		if mdm.MacOSMigration.Enable {
 			if license.Tier != fleet.TierPremium {
 				invalid.Append("macos_migration.enable", ErrMissingLicense.Error())
-				return
+				return nil
 			}
 			if !mdm.MacOSMigration.Mode.IsValid() {
 				invalid.Append("macos_migration.mode", "mode must be one of 'voluntary' or 'forced'")
@@ -775,7 +806,7 @@ func (svc *Service) validateMDM(
 	if !svc.config.MDM.IsMicrosoftWSTEPSet() {
 		if mdm.WindowsEnabledAndConfigured {
 			invalid.Append("mdm.windows_enabled_and_configured", "Couldn't turn on Windows MDM. Please configure Fleet with a certificate and key pair first.")
-			return
+			return nil
 		}
 	}
 
@@ -786,6 +817,8 @@ func (svc *Service) validateMDM(
 				`Couldn't edit enable_disk_encryption. Neither macOS MDM nor Windows is turned on. Visit https://fleetdm.com/docs/using-fleet to learn how to turn on MDM.`)
 		}
 	}
+
+	return nil
 }
 
 func validateSSOProviderSettings(incoming, existing fleet.SSOProviderSettings, invalid *fleet.InvalidArgumentError) {


### PR DESCRIPTION
for #15633

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [ ] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [ ] Documented any permissions changes (docs/Using Fleet/manage-access.md)
- [ ] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [ ] Added support on fleet's osquery simulator `cmd/osquery-perf` for new osquery data ingestion features.
- [ ] Added/updated tests
- [ ] If database migrations are included, checked table schema to confirm autoupdate 
- For database migrations:
  - [ ] Checked schema for all modified table for columns that will auto-update timestamps during migration.
  - [ ] Confirmed that updating the timestamps is acceptable, and will not cause unwanted side effects.
- [ ] Manual QA for all new/changed functionality
  - For Orbit and Fleet Desktop changes:
    - [ ] Manual QA must be performed in the three main OSs, macOS, Windows and Linux.
    - [ ] Auto-update manual QA, from released version of component to new version (see [tools/tuf/test](../tools/tuf/test/README.md)).
