### PR TITLE
Team host expiry.

### DIFF
--- a/changes/15609-team-host-expiry-backend
+++ b/changes/15609-team-host-expiry-backend
@@ -1,0 +1,3 @@
+Teams can configure their own host expiry setting. If global host expiry is enabled, teams cannot disable host expiry, but they can set a longer (or shorter) expiry time (in days).
+- Added `host_expiry_settings` to team spec, which can be used via fleetctl apply.
+- Added `host_expiry_settings` to PATH /fleet/teams/:id endpoint.

--- a/cmd/fleetctl/get_test.go
+++ b/cmd/fleetctl/get_test.go
@@ -156,6 +156,10 @@ func TestGetTeams(t *testing.T) {
 							Features: fleet.Features{
 								AdditionalQueries: &additionalQueries,
 							},
+							HostExpirySettings: fleet.HostExpirySettings{
+								HostExpiryEnabled: true,
+								HostExpiryWindow:  15,
+							},
 							MDM: fleet.TeamMDM{
 								MacOSUpdates: fleet.MacOSUpdates{
 									MinimumVersion: optjson.SetString("12.3.1"),

--- a/cmd/fleetctl/testdata/expectedGetTeamsJson.json
+++ b/cmd/fleetctl/testdata/expectedGetTeamsJson.json
@@ -7,6 +7,10 @@
 			"created_at": "1999-03-10T02:45:06.371Z",
 			"name": "team1",
 			"description": "team1 description",
+			"host_expiry_settings": {
+				"host_expiry_enabled": false,
+				"host_expiry_window": 0
+			},
 			"webhook_settings": {
 				"failing_policies_webhook": {
 					"enable_failing_policies_webhook": false,
@@ -71,6 +75,10 @@
 						}
 					}
 				}
+			},
+			"host_expiry_settings": {
+				"host_expiry_enabled": true,
+				"host_expiry_window": 15
 			},
 			"webhook_settings": {
 				"failing_policies_webhook": {

--- a/cmd/fleetctl/testdata/expectedGetTeamsYaml.yml
+++ b/cmd/fleetctl/testdata/expectedGetTeamsYaml.yml
@@ -6,6 +6,9 @@ spec:
     features:
       enable_host_users: true
       enable_software_inventory: true
+    host_expiry_settings:
+      host_expiry_enabled: false
+      host_expiry_window: 0
     mdm:
       enable_disk_encryption: false
       macos_updates:
@@ -41,6 +44,9 @@ spec:
         foo: bar
       enable_host_users: false
       enable_software_inventory: false
+    host_expiry_settings:
+      host_expiry_enabled: true
+      host_expiry_window: 15
     mdm:
       enable_disk_encryption: false
       macos_updates:

--- a/cmd/fleetctl/testdata/macosSetupExpectedTeam1And2Empty.yml
+++ b/cmd/fleetctl/testdata/macosSetupExpectedTeam1And2Empty.yml
@@ -6,6 +6,9 @@ spec:
     features:
       enable_host_users: true
       enable_software_inventory: true
+    host_expiry_settings:
+      host_expiry_enabled: false
+      host_expiry_window: 0
     mdm:
       enable_disk_encryption: false
       macos_settings:
@@ -32,6 +35,9 @@ spec:
     features:
       enable_host_users: true
       enable_software_inventory: true
+    host_expiry_settings:
+      host_expiry_enabled: false
+      host_expiry_window: 0
     mdm:
       enable_disk_encryption: false
       macos_settings:

--- a/cmd/fleetctl/testdata/macosSetupExpectedTeam1And2Set.yml
+++ b/cmd/fleetctl/testdata/macosSetupExpectedTeam1And2Set.yml
@@ -6,6 +6,9 @@ spec:
     features:
       enable_host_users: true
       enable_software_inventory: true
+    host_expiry_settings:
+      host_expiry_enabled: false
+      host_expiry_window: 0
     mdm:
       enable_disk_encryption: false
       macos_settings:
@@ -32,6 +35,9 @@ spec:
     features:
       enable_host_users: false
       enable_software_inventory: false
+    host_expiry_settings:
+      host_expiry_enabled: false
+      host_expiry_window: 0
     mdm:
       enable_disk_encryption: false
       macos_settings:

--- a/cmd/fleetctl/testdata/macosSetupExpectedTeam1Empty.yml
+++ b/cmd/fleetctl/testdata/macosSetupExpectedTeam1Empty.yml
@@ -3,6 +3,9 @@ apiVersion: v1
 kind: team
 spec:
   team:
+    host_expiry_settings:
+      host_expiry_enabled: false
+      host_expiry_window: 0
     features:
       enable_host_users: false
       enable_software_inventory: false

--- a/ee/server/service/teams.go
+++ b/ee/server/service/teams.go
@@ -90,6 +90,10 @@ func (svc *Service) NewTeam(ctx context.Context, p fleet.TeamPayload) (*fleet.Te
 		team.Secrets = []*fleet.EnrollSecret{{Secret: secret}}
 	}
 
+	if p.HostExpirySettings != nil && p.HostExpirySettings.HostExpiryEnabled && p.HostExpirySettings.HostExpiryWindow <= 0 {
+		return nil, fleet.NewInvalidArgumentError("host_expiry_window", "must be greater than 0")
+	}
+
 	team, err = svc.ds.NewTeam(ctx, team)
 	if err != nil {
 		return nil, err
@@ -221,6 +225,9 @@ func (svc *Service) ModifyTeam(ctx context.Context, teamID uint, payload fleet.T
 	}
 
 	if payload.HostExpirySettings != nil {
+		if payload.HostExpirySettings.HostExpiryEnabled && payload.HostExpirySettings.HostExpiryWindow <= 0 {
+			return nil, fleet.NewInvalidArgumentError("host_expiry_window", "must be greater than 0")
+		}
 		team.Config.HostExpirySettings = *payload.HostExpirySettings
 	}
 
@@ -866,6 +873,19 @@ func (svc *Service) createTeamFromSpec(
 			`Couldn't edit enable_disk_encryption. Neither macOS MDM nor Windows is turned on. Visit https://fleetdm.com/docs/using-fleet to learn how to turn on MDM.`))
 	}
 
+	var hostExpirySettings fleet.HostExpirySettings
+	if spec.HostExpirySettings != nil {
+		if spec.HostExpirySettings.HostExpiryEnabled && spec.HostExpirySettings.HostExpiryWindow <= 0 {
+			return nil, ctxerr.Wrap(
+				ctx, fleet.NewInvalidArgumentError(
+					"host_expiry_settings.host_expiry_window",
+					`When enabling host expiry, host expiry window must be a positive number.`,
+				),
+			)
+		}
+		hostExpirySettings = *spec.HostExpirySettings
+	}
+
 	if dryRun {
 		return &fleet.Team{Name: spec.Name}, nil
 	}
@@ -882,6 +902,7 @@ func (svc *Service) createTeamFromSpec(
 				MacOSSettings:        macOSSettings,
 				MacOSSetup:           macOSSetup,
 			},
+			HostExpirySettings: hostExpirySettings,
 		},
 		Secrets: secrets,
 	})
@@ -1020,6 +1041,14 @@ func (svc *Service) editTeamFromSpec(
 
 	// if host_expiry_settings are not provided, do not change them
 	if spec.HostExpirySettings != nil {
+		if spec.HostExpirySettings.HostExpiryEnabled && spec.HostExpirySettings.HostExpiryWindow <= 0 {
+			return ctxerr.Wrap(
+				ctx, fleet.NewInvalidArgumentError(
+					"host_expiry_settings.host_expiry_window",
+					`When enabling host expiry, host expiry window must be a positive number.`,
+				),
+			)
+		}
 		team.Config.HostExpirySettings = *spec.HostExpirySettings
 	}
 

--- a/ee/server/service/teams.go
+++ b/ee/server/service/teams.go
@@ -220,6 +220,10 @@ func (svc *Service) ModifyTeam(ctx context.Context, teamID uint, payload fleet.T
 		}
 	}
 
+	if payload.HostExpirySettings != nil {
+		team.Config.HostExpirySettings = *payload.HostExpirySettings
+	}
+
 	team, err = svc.ds.SaveTeam(ctx, team)
 	if err != nil {
 		return nil, err
@@ -1012,6 +1016,11 @@ func (svc *Service) editTeamFromSpec(
 
 	if len(secrets) > 0 {
 		team.Secrets = secrets
+	}
+
+	// if host_expiry_settings are not provided, do not change them
+	if spec.HostExpirySettings != nil {
+		team.Config.HostExpirySettings = *spec.HostExpirySettings
 	}
 
 	if dryRun {

--- a/server/datastore/mysql/hosts.go
+++ b/server/datastore/mysql/hosts.go
@@ -2849,8 +2849,32 @@ func (ds *Datastore) CleanupExpiredHosts(ctx context.Context) ([]uint, error) {
 	if err != nil {
 		return nil, ctxerr.Wrap(ctx, err, "getting app config")
 	}
-	if !ac.HostExpirySettings.HostExpiryEnabled {
+
+	query := `SELECT id, config from teams`
+	var teams []*fleet.Team
+	if err := sqlx.SelectContext(ctx, ds.reader(ctx), &teams, query); err != nil {
+		return nil, ctxerr.Wrap(ctx, err, "get teams")
+	}
+
+	teamHostExpiryEnabled := false
+	for _, team := range teams {
+		if team.Config.HostExpirySettings.HostExpiryEnabled {
+			teamHostExpiryEnabled = true
+			break
+		}
+	}
+	if !ac.HostExpirySettings.HostExpiryEnabled && !teamHostExpiryEnabled {
 		return nil, nil
+	}
+
+	var teamsUsingHostExpiry []uint
+	teamsUsingCustomExpiry := map[uint]int{}
+	for _, team := range teams {
+		if !team.Config.HostExpirySettings.HostExpiryEnabled {
+			teamsUsingHostExpiry = append(teamsUsingHostExpiry, team.ID)
+		} else {
+			teamsUsingCustomExpiry[team.ID] = team.Config.HostExpirySettings.HostExpiryWindow
+		}
 	}
 
 	// Usual clean up queries used to be like this:
@@ -2858,33 +2882,71 @@ func (ds *Datastore) CleanupExpiredHosts(ctx context.Context) ([]uint, error) {
 	// This means a full table scan for hosts, and for big deployments, that's not ideal
 	// so instead, we get the ids one by one and delete things one by one
 	// it might take longer, but it should lock only the row we need
-
-	var ids []uint
-	err = ds.writer(ctx).SelectContext(
-		ctx,
-		&ids,
-		`SELECT h.id FROM hosts h
+	findHostsSql := `SELECT h.id FROM hosts h
 		LEFT JOIN host_seen_times hst
 		ON h.id = hst.host_id
-		WHERE COALESCE(hst.seen_time, h.created_at) < DATE_SUB(NOW(), INTERVAL ? DAY)`,
-		ac.HostExpirySettings.HostExpiryWindow,
-	)
-	if err != nil {
-		return nil, ctxerr.Wrap(ctx, err, "getting expired host ids")
+		WHERE COALESCE(hst.seen_time, h.created_at) < DATE_SUB(NOW(), INTERVAL ? DAY)`
+
+	var allIdsToDelete []uint
+	// Process hosts using global expiry
+	if ac.HostExpirySettings.HostExpiryEnabled {
+		sqlQuery := findHostsSql + " AND (team_id IS NULL"
+		args := []interface{}{ac.HostExpirySettings.HostExpiryWindow}
+		if len(teamsUsingHostExpiry) > 0 {
+			sqlQuery += " OR team_id IN (?)"
+			sqlQuery, args, err = sqlx.In(sqlQuery, args[0], teamsUsingHostExpiry)
+			if err != nil {
+				return nil, ctxerr.Wrap(ctx, err, "building query to get expired host ids")
+			}
+		}
+		sqlQuery += ")"
+		err = ds.writer(ctx).SelectContext(
+			ctx,
+			&allIdsToDelete,
+			sqlQuery,
+			args...,
+		)
+		if err != nil {
+			return nil, ctxerr.Wrap(ctx, err, "getting expired host allIdsToDelete")
+		}
 	}
 
-	for _, id := range ids {
+	// Process hosts using team expiry
+	for teamId, expiry := range teamsUsingCustomExpiry {
+		var ids []uint
+		sqlQuery := findHostsSql + " AND team_id = ?"
+		args := []interface{}{expiry, teamId}
+		err = ds.writer(ctx).SelectContext(
+			ctx,
+			&ids,
+			sqlQuery,
+			args...,
+		)
+		if err != nil {
+			return nil, ctxerr.Wrap(ctx, err, "getting expired host allIdsToDelete")
+		}
+		allIdsToDelete = append(allIdsToDelete, ids...)
+	}
+
+	for _, id := range allIdsToDelete {
 		err = ds.DeleteHost(ctx, id)
 		if err != nil {
 			return nil, err
 		}
 	}
 
-	_, err = ds.writer(ctx).ExecContext(ctx, `DELETE FROM host_seen_times WHERE seen_time < DATE_SUB(NOW(), INTERVAL ? DAY)`, ac.HostExpirySettings.HostExpiryWindow)
-	if err != nil {
-		return nil, ctxerr.Wrap(ctx, err, "deleting expired host seen times")
+	if len(allIdsToDelete) > 0 {
+		sqlQuery, args, err := sqlx.In(`DELETE FROM host_seen_times WHERE host_id in (?)`, allIdsToDelete)
+		if err != nil {
+			return nil, ctxerr.Wrap(ctx, err, "building query to delete host seen times")
+		}
+		_, err = ds.writer(ctx).ExecContext(ctx, sqlQuery, args...)
+		if err != nil {
+			return nil, ctxerr.Wrap(ctx, err, "deleting expired host seen times")
+		}
 	}
-	return ids, nil
+
+	return allIdsToDelete, nil
 }
 
 func (ds *Datastore) ListHostDeviceMapping(ctx context.Context, id uint) ([]*fleet.HostDeviceMapping, error) {

--- a/server/datastore/mysql/hosts_test.go
+++ b/server/datastore/mysql/hosts_test.go
@@ -3747,6 +3747,7 @@ func testHostsExpiration(t *testing.T, ds *Datastore) {
 	ac, err := ds.AppConfig(context.Background())
 	require.NoError(t, err)
 
+	ac.HostExpirySettings.HostExpiryEnabled = false
 	ac.HostExpirySettings.HostExpiryWindow = hostExpiryWindow
 
 	err = ds.SaveAppConfig(context.Background(), ac)
@@ -3810,6 +3811,7 @@ func testTeamHostsExpiration(t *testing.T, ds *Datastore) {
 	const team2HostExpiryWindow = 170
 	ac, err := ds.AppConfig(context.Background())
 	require.NoError(t, err)
+	ac.HostExpirySettings.HostExpiryEnabled = false
 	ac.HostExpirySettings.HostExpiryWindow = hostExpiryWindow
 	err = ds.SaveAppConfig(context.Background(), ac)
 	require.NoError(t, err)

--- a/server/fleet/teams.go
+++ b/server/fleet/teams.go
@@ -137,12 +137,13 @@ func (t *Team) UnmarshalJSON(b []byte) error {
 
 type TeamConfig struct {
 	// AgentOptions is the options for osquery and Orbit.
-	AgentOptions    *json.RawMessage      `json:"agent_options,omitempty"`
-	WebhookSettings TeamWebhookSettings   `json:"webhook_settings"`
-	Integrations    TeamIntegrations      `json:"integrations"`
-	Features        Features              `json:"features"`
-	MDM             TeamMDM               `json:"mdm"`
-	Scripts         optjson.Slice[string] `json:"scripts,omitempty"`
+	AgentOptions       *json.RawMessage      `json:"agent_options,omitempty"`
+	HostExpirySettings HostExpirySettings    `json:"host_expiry_settings"`
+	WebhookSettings    TeamWebhookSettings   `json:"webhook_settings"`
+	Integrations       TeamIntegrations      `json:"integrations"`
+	Features           Features              `json:"features"`
+	MDM                TeamMDM               `json:"mdm"`
+	Scripts            optjson.Slice[string] `json:"scripts,omitempty"`
 }
 
 type TeamWebhookSettings struct {

--- a/server/fleet/teams.go
+++ b/server/fleet/teams.go
@@ -19,12 +19,13 @@ const (
 )
 
 type TeamPayload struct {
-	Name            *string              `json:"name"`
-	Description     *string              `json:"description"`
-	Secrets         []*EnrollSecret      `json:"secrets"`
-	WebhookSettings *TeamWebhookSettings `json:"webhook_settings"`
-	Integrations    *TeamIntegrations    `json:"integrations"`
-	MDM             *TeamPayloadMDM      `json:"mdm"`
+	Name               *string              `json:"name"`
+	Description        *string              `json:"description"`
+	Secrets            []*EnrollSecret      `json:"secrets"`
+	WebhookSettings    *TeamWebhookSettings `json:"webhook_settings"`
+	Integrations       *TeamIntegrations    `json:"integrations"`
+	MDM                *TeamPayloadMDM      `json:"mdm"`
+	HostExpirySettings *HostExpirySettings  `json:"host_expiry_settings"`
 	// Note AgentOptions must be set by a separate endpoint.
 }
 
@@ -390,12 +391,12 @@ type TeamSpec struct {
 	// If the agent_options key is present but empty in the YAML, will be set to
 	// "null" (JSON null). Otherwise, if the key is present and set, it will be
 	// set to the agent options JSON object.
-	AgentOptions json.RawMessage `json:"agent_options,omitempty"` // marshals as "null" if omitempty is not set
-
-	Secrets  []EnrollSecret        `json:"secrets,omitempty"`
-	Features *json.RawMessage      `json:"features"`
-	MDM      TeamSpecMDM           `json:"mdm"`
-	Scripts  optjson.Slice[string] `json:"scripts"`
+	AgentOptions       json.RawMessage       `json:"agent_options,omitempty"` // marshals as "null" if omitempty is not set
+	HostExpirySettings *HostExpirySettings   `json:"host_expiry_settings,omitempty"`
+	Secrets            []EnrollSecret        `json:"secrets,omitempty"`
+	Features           *json.RawMessage      `json:"features"`
+	MDM                TeamSpecMDM           `json:"mdm"`
+	Scripts            optjson.Slice[string] `json:"scripts"`
 }
 
 // TeamSpecFromTeam returns a TeamSpec constructed from the given Team.
@@ -426,10 +427,11 @@ func TeamSpecFromTeam(t *Team) (*TeamSpec, error) {
 	mdmSpec.EnableDiskEncryption = optjson.SetBool(t.Config.MDM.EnableDiskEncryption)
 	mdmSpec.WindowsSettings = t.Config.MDM.WindowsSettings
 	return &TeamSpec{
-		Name:         t.Name,
-		AgentOptions: agentOptions,
-		Features:     &featuresJSON,
-		Secrets:      secrets,
-		MDM:          mdmSpec,
+		Name:               t.Name,
+		AgentOptions:       agentOptions,
+		Features:           &featuresJSON,
+		Secrets:            secrets,
+		MDM:                mdmSpec,
+		HostExpirySettings: &t.Config.HostExpirySettings,
 	}, nil
 }

--- a/server/service/integration_enterprise_test.go
+++ b/server/service/integration_enterprise_test.go
@@ -910,10 +910,21 @@ func (s *integrationEnterpriseTestSuite) TestTeamEndpoints() {
 	tmResp.Team = nil
 	s.DoJSON("PATCH", fmt.Sprintf("/api/latest/fleet/teams/%d", tm1ID), team, http.StatusOK, &tmResp)
 	assert.Equal(t, defaultFeatures, tmResp.Team.Config.Features)
+	assert.False(t, tmResp.Team.Config.HostExpirySettings.HostExpiryEnabled)
 
 	// modify non-existing team
 	tmResp.Team = nil
 	s.DoJSON("PATCH", fmt.Sprintf("/api/latest/fleet/teams/%d", tm1ID+1), team, http.StatusNotFound, &tmResp)
+
+	// modify team host expiry
+	modifyExpiry := fleet.TeamPayload{
+		HostExpirySettings: &fleet.HostExpirySettings{
+			HostExpiryEnabled: true,
+			HostExpiryWindow:  10,
+		},
+	}
+	s.DoJSON("PATCH", fmt.Sprintf("/api/latest/fleet/teams/%d", tm1ID), modifyExpiry, http.StatusOK, &tmResp)
+	assert.Equal(t, *modifyExpiry.HostExpirySettings, tmResp.Team.Config.HostExpirySettings)
 
 	// list team users
 	var usersResp listUsersResponse


### PR DESCRIPTION
Teams can configure their own host expiry setting. If global host expiry is enabled, teams cannot disable host expiry, but they can set a longer (or shorter) expiry time (in days).
- Added `host_expiry_settings` to team spec, which can be used via fleetctl apply.
- Added `host_expiry_settings` to PATH /fleet/teams/:id endpoint.


#15609 (parent)
#15966 (subtask)

PR for API docs change: added parameter to `PATCH /fleet/teams/:id` endpoint
#16254

# Checklist for submitter

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
- [x] Added/updated tests
- [x] Manual QA for all new/changed functionality
