### PR TITLE
ChromeOS tables: Surface ChromeOS errors in Fleet UI for privacy_preferences columns

### DIFF
--- a/changes/14105-surface-chrome-column-warnings
+++ b/changes/14105-surface-chrome-column-warnings
@@ -1,0 +1,1 @@
+* privacy_preferences table for chrome surfaces column errors

--- a/ee/fleetd-chrome/README.md
+++ b/ee/fleetd-chrome/README.md
@@ -55,7 +55,7 @@ The above command will generate an unpacked extension in `./dist`.
 
 3. Send the `./dist` folder to the target Chromebook.
 
-4. In the target Chromebook, go to `chrome://settings`, toggle `Developer mode` and click on `Load unpacked` and select the `dist` folder.
+4. In the target Chromebook, go to `chrome://extensions`, toggle `Developer mode` and click on `Load unpacked` and select the `dist` folder.
 
 ## Testing
 

--- a/ee/fleetd-chrome/src/tables/privacy_preferences.ts
+++ b/ee/fleetd-chrome/src/tables/privacy_preferences.ts
@@ -45,6 +45,8 @@ export default class TablePrivacyPreferences extends Table {
     fledge_enabled: chrome.privacy.websites.fledgeEnabled,
     hyperlink_auditing_enabled:
       chrome.privacy.websites.hyperlinkAuditingEnabled,
+    // @ts-ignore, DEPRECATED
+    privacy_sandbox_enabled: chrome.privacy.websites.privacySandboxEnabled,
     protected_content_enabled: chrome.privacy.websites.protectedContentEnabled,
     referrers_enabled: chrome.privacy.websites.referrersEnabled,
     third_party_cookies_allowed:

--- a/ee/fleetd-chrome/src/tables/privacy_preferences.ts
+++ b/ee/fleetd-chrome/src/tables/privacy_preferences.ts
@@ -45,8 +45,6 @@ export default class TablePrivacyPreferences extends Table {
     fledge_enabled: chrome.privacy.websites.fledgeEnabled,
     hyperlink_auditing_enabled:
       chrome.privacy.websites.hyperlinkAuditingEnabled,
-    // @ts-ignore, DEPRECATED
-    privacy_sandbox_enabled: chrome.privacy.websites.privacySandboxEnabled,
     protected_content_enabled: chrome.privacy.websites.protectedContentEnabled,
     referrers_enabled: chrome.privacy.websites.referrersEnabled,
     third_party_cookies_allowed:
@@ -60,6 +58,7 @@ export default class TablePrivacyPreferences extends Table {
   async generate() {
     const results = []; // Promise<{string: number | string}>[]
     const errors = [];
+    let warningsArray = [];
     for (const [property, propertyAPI] of Object.entries(this.propertyAPIs)) {
       results.push(
         new Promise((resolve) => {
@@ -78,6 +77,10 @@ export default class TablePrivacyPreferences extends Table {
             });
           } catch (error) {
             errors.push({ [property]: error });
+            warningsArray.push({
+              column: property,
+              error_message: error.stack.toString(),
+            });
             resolve({ [property]: "data unavailable" });
           }
         })
@@ -94,6 +97,7 @@ export default class TablePrivacyPreferences extends Table {
           return { ...resultRow, ...column };
         }, {}),
       ],
+      warnings: warningsArray,
     };
   }
 }


### PR DESCRIPTION
## Issue
Work for #15309 

## Description
- `privacy_preferences` table has multiple API calls, which don't surface the error message to the user in Fleet UI
- Update `privacy_preferences.ts` to surface errors in Fleet UI

### Other
- Update typo in `ee/fleetd-chrome/README.md`

## Screenshot 
- Surfaced errors (before it didn't show errors in UI even though columns were erroring out)
<img width="1175" alt="Screenshot 2024-01-18 at 10 24 00 AM" src="https://github.com/fleetdm/fleet/assets/71795832/556e2954-704d-461b-8f1e-42d47edf0652">



# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
- [x] Manual QA for all new/changed functionality

