### PR TITLE
UI - compensate for tooltipwrappers in field labels

### DIFF
--- a/frontend/styles/global/_global.scss
+++ b/frontend/styles/global/_global.scss
@@ -129,8 +129,13 @@ form,
     font-weight: $bold;
     color: $core-fleet-black;
 
+    // compensate for height added by tooltip wrapper underline
+    .component__tooltip-wrapper__underline {
+      margin-top: -2.5px;
+      padding-bottom: 0;
+    }
+
     &--error {
-      font-weight: $bold;
       color: $core-vibrant-red;
     }
   }


### PR DESCRIPTION
Fixes a small discrepancy in label styling caused by tooltip wrapper children:

**Before:**
![Screenshot-2024-01-18-at-115039A](https://github.com/fleetdm/fleet/assets/61553566/ebde5fe0-3d2b-4639-b48a-43c4ca0c11cd)

**Now:**
![Screenshot-2024-01-18-at-115510A](https://github.com/fleetdm/fleet/assets/61553566/cf8600b2-92de-45ca-934a-20a569150203)

