### PR TITLE
Fix UI re-renders when notification flash context changes

### DIFF
--- a/frontend/context/notification.tsx
+++ b/frontend/context/notification.tsx
@@ -1,4 +1,10 @@
-import React, { createContext, useReducer, ReactNode } from "react";
+import React, {
+  createContext,
+  useReducer,
+  ReactNode,
+  useCallback,
+  useMemo,
+} from "react";
 import { INotification } from "interfaces/notification";
 import { noop } from "lodash";
 
@@ -55,9 +61,8 @@ export const NotificationContext = createContext<InitialStateType>(
 const NotificationProvider = ({ children }: Props) => {
   const [state, dispatch] = useReducer(reducer, initialState);
 
-  const value = {
-    notification: state.notification,
-    renderFlash: (
+  const renderFlash = useCallback(
+    (
       alertType: "success" | "error" | "warning-filled" | null,
       message: JSX.Element | string | null,
       undoAction?: (evt: React.MouseEvent<HTMLButtonElement>) => void
@@ -69,10 +74,21 @@ const NotificationProvider = ({ children }: Props) => {
         undoAction,
       });
     },
-    hideFlash: () => {
-      dispatch({ type: actions.HIDE_FLASH });
-    },
-  };
+    []
+  );
+
+  const hideFlash = useCallback(() => {
+    dispatch({ type: actions.HIDE_FLASH });
+  }, []);
+
+  const value = useMemo(
+    () => ({
+      notification: state.notification,
+      renderFlash,
+      hideFlash,
+    }),
+    [state.notification, renderFlash, hideFlash]
+  );
 
   return (
     <NotificationContext.Provider value={value}>


### PR DESCRIPTION
# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [ ] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [ ] Documented any permissions changes (docs/Using Fleet/manage-access.md)
- [ ] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [ ] Added support on fleet's osquery simulator `cmd/osquery-perf` for new osquery data ingestion features.
- [ ] Added/updated tests
- [ ] If database migrations are included, checked table schema to confirm autoupdate 
- For database migrations:
  - [ ] Checked schema for all modified table for columns that will auto-update timestamps during migration.
  - [ ] Confirmed that updating the timestamps is acceptable, and will not cause unwanted side effects.
- [ ] Manual QA for all new/changed functionality
  - For Orbit and Fleet Desktop changes:
    - [ ] Manual QA must be performed in the three main OSs, macOS, Windows and Linux.
    - [ ] Auto-update manual QA, from released version of component to new version (see [tools/tuf/test](../tools/tuf/test/README.md)).
