### PR TITLE
Add redirect from GitOps article => GitOps repo

### DIFF
--- a/website/config/routes.js
+++ b/website/config/routes.js
@@ -462,6 +462,7 @@ module.exports.routes = {
   'GET /handbook/company/software-engineer': '/handbook/company/open-positions/software-engineer',
   'GET /handbook/company/software-engineer-windows-go': '/handbook/company/open-positions/software-engineer-windows-go',
   'GET /osquery-management': '/endpoint-ops',
+  'GET /guides/using-github-actions-to-apply-configuration-profiles-with-fleet': 'https://github.com/fleetdm/fleet-gitops',
 
   //  ╔╦╗╦╔═╗╔═╗  ╦═╗╔═╗╔╦╗╦╦═╗╔═╗╔═╗╔╦╗╔═╗   ┬   ╔╦╗╔═╗╦ ╦╔╗╔╦  ╔═╗╔═╗╔╦╗╔═╗
   //  ║║║║╚═╗║    ╠╦╝║╣  ║║║╠╦╝║╣ ║   ║ ╚═╗  ┌┼─   ║║║ ║║║║║║║║  ║ ║╠═╣ ║║╚═╗


### PR DESCRIPTION
- Almost the entire article is invalid because we took down the GitHub action while we’re working on updating it.
- Keep the heavily trafficked link up 
- Point folks to repo so they know that Fleet GitOps is coming soon.
