### PR TITLE
Remove Parallel Test Runners

### DIFF
--- a/orbit/pkg/update/runner_test.go
+++ b/orbit/pkg/update/runner_test.go
@@ -90,10 +90,8 @@ func TestGetVersion(t *testing.T) {
 		},
 	}
 	for name, tc := range testCases {
-		tc := tc // capture range variable, needed for parallel tests
 		t.Run(
 			name, func(t *testing.T) {
-				t.Parallel()
 				// create a temp executable file
 				dir := t.TempDir()
 				file, err := os.CreateTemp(dir, "binary")


### PR DESCRIPTION
# Checklist for submitter

`/orbit/pkg/update/runner_test/TestGetVersion` occasionally fails seemingly due to a file attempting to be executed while it's still being written to.  `t.Parallel()` is removed from the subtest runs, which still keeps the execution time <1s.
