### PR TITLE
Update standard-query-library.yml

### DIFF
--- a/docs/01-Using-Fleet/standard-query-library/standard-query-library.yml
+++ b/docs/01-Using-Fleet/standard-query-library/standard-query-library.yml
@@ -880,7 +880,7 @@ apiVersion: v1
 kind: policy
 spec:
   name: No 1Password emergency kit stored on desktop or in downloads (macOS)
-  query: SELECT EXISTS(SELECT 1 FROM file WHERE filename like '%Emergency Kit%.pdf' AND (path LIKE '/Users/%%/Downloads/%%' OR path LIKE '/Users/%%/Desktop/%%')) as does_1p_ek_exist;
+  query: SELECT EXISTS (SELECT 1 FROM file WHERE filename LIKE '%Emergency Kit%.pdf' AND (path LIKE '/Users/%%/Downloads/%%' OR path LIKE '/Users/%%/Desktop/%%'));
   description: "Looks for PDF files with file names typically used by 1Password for emergency recovery kits."
   resolution: "Delete 1Password emergency kits from your computer, and empty the trash. 1Password emergency kits should only be printed and stored in a physically secure location."
   platform: darwin


### PR DESCRIPTION
It is very easy for data collection like this to veer into double / triple negative mulitverse of madness stuff...

That said, I may have a lack of understanding about how the product works, i.e., that a query literally must return a 0 value & not null in order to "pass" in a policy. If so, then this works as expected.

However, if a query just needs to return empty (null) & 0 is implied in the logic that sets a policy flag to green or red, then, as a rule, queries like this should be always be simplified & should default to using "positive" as opposed to "negative" logic, i.e., check if something exists, never check if a thing does NOT exist.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)

- [x] Added/updated tests: Tested by adding dummy Emergency Kit.pdf files to Desktop & Downloads, running query, then, removing files & running query.