### PR TITLE
UI - fix position of `Copied!` in enroll secrets table

### DIFF
--- a/frontend/components/EnrollSecrets/EnrollSecretTable/EnrollSecretRow/_styles.scss
+++ b/frontend/components/EnrollSecrets/EnrollSecretTable/EnrollSecretRow/_styles.scss
@@ -31,8 +31,6 @@
   }
 
   &__copy-message {
-    position: absolute;
-    right: 65px;
     background-color: $ui-light-grey;
     border: solid 1px #e2e4ea;
     border-radius: 10px;

--- a/frontend/components/EnrollSecrets/EnrollSecretTable/_styles.scss
+++ b/frontend/components/EnrollSecrets/EnrollSecretTable/_styles.scss
@@ -3,7 +3,9 @@
     .buttons {
       display: flex;
       position: absolute;
-      left: 475px;
+      left: 410px;
+      justify-content: flex-end;
+      min-width: 130px;
     }
   }
 }


### PR DESCRIPTION
<img width="786" alt="Screenshot 2024-01-23 at 5 25 51 PM" src="https://github.com/fleetdm/fleet/assets/61553566/944b4ef6-e059-4e68-bef9-4f23b454f488">
