### PR TITLE
Fleet UI: Can run a live query on an edited (but not saved) existing query

### DIFF
--- a/changes/16067-bug-running-edited-query
+++ b/changes/16067-bug-running-edited-query
@@ -1,0 +1,1 @@
+- Ability to run a live query on an edited existing query before saving

--- a/frontend/__mocks__/queryMock.ts
+++ b/frontend/__mocks__/queryMock.ts
@@ -27,6 +27,7 @@ const DEFAULT_QUERY_MOCK: ISchedulableQuery = {
     system_time_p95: 1,
     total_executions: 6,
   },
+  editedQuerySql: false,
 };
 
 const createMockQuery = (

--- a/frontend/__mocks__/queryMock.ts
+++ b/frontend/__mocks__/queryMock.ts
@@ -27,7 +27,7 @@ const DEFAULT_QUERY_MOCK: ISchedulableQuery = {
     system_time_p95: 1,
     total_executions: 6,
   },
-  editedQuerySql: false,
+  editingExistingQuery: false,
 };
 
 const createMockQuery = (

--- a/frontend/__mocks__/scheduleableQueryMock.ts
+++ b/frontend/__mocks__/scheduleableQueryMock.ts
@@ -29,7 +29,7 @@ const DEFAULT_SCHEDULABLE_QUERY_MOCK: ISchedulableQuery = {
     user_time_p95: 251.4615,
     total_executions: 5746,
   },
-  editedQuerySql: false,
+  editingExistingQuery: false,
 };
 
 const createMockSchedulableQuery = (

--- a/frontend/__mocks__/scheduleableQueryMock.ts
+++ b/frontend/__mocks__/scheduleableQueryMock.ts
@@ -29,6 +29,7 @@ const DEFAULT_SCHEDULABLE_QUERY_MOCK: ISchedulableQuery = {
     user_time_p95: 251.4615,
     total_executions: 5746,
   },
+  editedQuerySql: false,
 };
 
 const createMockSchedulableQuery = (

--- a/frontend/context/query.tsx
+++ b/frontend/context/query.tsx
@@ -29,7 +29,7 @@ type InitialStateType = {
   lastEditedQueryMinOsqueryVersion: string;
   lastEditedQueryLoggingType: QueryLoggingOption;
   lastEditedQueryDiscardData: boolean;
-  editedQuerySql: boolean;
+  editingExistingQuery: boolean;
   selectedQueryTargets: ITarget[]; // Mimicks old selectedQueryTargets still used for policies for SelectTargets.tsx and running a live query
   selectedQueryTargetsByType: ISelectedTargetsByType; // New format by type for cleaner app wide state
   setLastEditedQueryId: (value: number | null) => void;
@@ -45,7 +45,7 @@ type InitialStateType = {
   setSelectedOsqueryTable: (tableName: string) => void;
   setSelectedQueryTargets: (value: ITarget[]) => void;
   setSelectedQueryTargetsByType: (value: ISelectedTargetsByType) => void;
-  setEditedQuerySql: (value: boolean) => void;
+  setEditingExistingQuery: (value: boolean) => void;
 };
 
 export type IQueryContext = InitialStateType;
@@ -63,7 +63,7 @@ const initialState = {
   lastEditedQueryMinOsqueryVersion: DEFAULT_QUERY.min_osquery_version,
   lastEditedQueryLoggingType: DEFAULT_QUERY.logging,
   lastEditedQueryDiscardData: DEFAULT_QUERY.discard_data,
-  editedQuerySql: DEFAULT_QUERY.editedQuerySql,
+  editingExistingQuery: DEFAULT_QUERY.editingExistingQuery,
   selectedQueryTargets: DEFAULT_TARGETS,
   selectedQueryTargetsByType: DEFAULT_TARGETS_BY_TYPE,
   setLastEditedQueryId: () => null,
@@ -79,7 +79,7 @@ const initialState = {
   setSelectedOsqueryTable: () => null,
   setSelectedQueryTargets: () => null,
   setSelectedQueryTargetsByType: () => null,
-  setEditedQuerySql: () => null,
+  setEditingExistingQuery: () => null,
 };
 
 const actions = {
@@ -141,10 +141,10 @@ const reducer = (state: InitialStateType, action: any) => {
           typeof action.lastEditedQueryDiscardData === "undefined"
             ? state.lastEditedQueryDiscardData
             : action.lastEditedQueryDiscardData,
-        editedQuerySql:
-          typeof action.editedQuerySql === "undefined"
-            ? state.editedQuerySql
-            : action.editedQuerySql,
+        editingExistingQuery:
+          typeof action.editingExistingQuery === "undefined"
+            ? state.editingExistingQuery
+            : action.editingExistingQuery,
       };
     case actions.SET_SELECTED_QUERY_TARGETS:
       return {
@@ -184,7 +184,7 @@ const QueryProvider = ({ children }: Props) => {
     lastEditedQueryMinOsqueryVersion: state.lastEditedQueryMinOsqueryVersion,
     lastEditedQueryLoggingType: state.lastEditedQueryLoggingType,
     lastEditedQueryDiscardData: state.lastEditedQueryDiscardData,
-    editedQuerySql: state.editedQuerySql,
+    editingExistingQuery: state.editingExistingQuery,
     selectedQueryTargets: state.selectedQueryTargets,
     selectedQueryTargetsByType: state.selectedQueryTargetsByType,
     setLastEditedQueryId: (lastEditedQueryId: number | null) => {
@@ -251,10 +251,10 @@ const QueryProvider = ({ children }: Props) => {
         lastEditedQueryDiscardData,
       });
     },
-    setEditedQuerySql: (editedQuerySql: boolean) => {
+    setEditingExistingQuery: (editingExistingQuery: boolean) => {
       dispatch({
         type: actions.SET_LAST_EDITED_QUERY_INFO,
-        editedQuerySql,
+        editingExistingQuery,
       });
     },
     setSelectedQueryTargets: (selectedQueryTargets: ITarget[]) => {

--- a/frontend/context/query.tsx
+++ b/frontend/context/query.tsx
@@ -29,6 +29,7 @@ type InitialStateType = {
   lastEditedQueryMinOsqueryVersion: string;
   lastEditedQueryLoggingType: QueryLoggingOption;
   lastEditedQueryDiscardData: boolean;
+  editedQuerySql: boolean;
   selectedQueryTargets: ITarget[]; // Mimicks old selectedQueryTargets still used for policies for SelectTargets.tsx and running a live query
   selectedQueryTargetsByType: ISelectedTargetsByType; // New format by type for cleaner app wide state
   setLastEditedQueryId: (value: number | null) => void;
@@ -44,6 +45,7 @@ type InitialStateType = {
   setSelectedOsqueryTable: (tableName: string) => void;
   setSelectedQueryTargets: (value: ITarget[]) => void;
   setSelectedQueryTargetsByType: (value: ISelectedTargetsByType) => void;
+  setEditedQuerySql: (value: boolean) => void;
 };
 
 export type IQueryContext = InitialStateType;
@@ -61,6 +63,7 @@ const initialState = {
   lastEditedQueryMinOsqueryVersion: DEFAULT_QUERY.min_osquery_version,
   lastEditedQueryLoggingType: DEFAULT_QUERY.logging,
   lastEditedQueryDiscardData: DEFAULT_QUERY.discard_data,
+  editedQuerySql: DEFAULT_QUERY.editedQuerySql,
   selectedQueryTargets: DEFAULT_TARGETS,
   selectedQueryTargetsByType: DEFAULT_TARGETS_BY_TYPE,
   setLastEditedQueryId: () => null,
@@ -76,6 +79,7 @@ const initialState = {
   setSelectedOsqueryTable: () => null,
   setSelectedQueryTargets: () => null,
   setSelectedQueryTargetsByType: () => null,
+  setEditedQuerySql: () => null,
 };
 
 const actions = {
@@ -137,6 +141,10 @@ const reducer = (state: InitialStateType, action: any) => {
           typeof action.lastEditedQueryDiscardData === "undefined"
             ? state.lastEditedQueryDiscardData
             : action.lastEditedQueryDiscardData,
+        editedQuerySql:
+          typeof action.editedQuerySql === "undefined"
+            ? state.editedQuerySql
+            : action.editedQuerySql,
       };
     case actions.SET_SELECTED_QUERY_TARGETS:
       return {
@@ -176,6 +184,7 @@ const QueryProvider = ({ children }: Props) => {
     lastEditedQueryMinOsqueryVersion: state.lastEditedQueryMinOsqueryVersion,
     lastEditedQueryLoggingType: state.lastEditedQueryLoggingType,
     lastEditedQueryDiscardData: state.lastEditedQueryDiscardData,
+    editedQuerySql: state.editedQuerySql,
     selectedQueryTargets: state.selectedQueryTargets,
     selectedQueryTargetsByType: state.selectedQueryTargetsByType,
     setLastEditedQueryId: (lastEditedQueryId: number | null) => {
@@ -240,6 +249,12 @@ const QueryProvider = ({ children }: Props) => {
       dispatch({
         type: actions.SET_LAST_EDITED_QUERY_INFO,
         lastEditedQueryDiscardData,
+      });
+    },
+    setEditedQuerySql: (editedQuerySql: boolean) => {
+      dispatch({
+        type: actions.SET_LAST_EDITED_QUERY_INFO,
+        editedQuerySql,
       });
     },
     setSelectedQueryTargets: (selectedQueryTargets: ITarget[]) => {

--- a/frontend/interfaces/schedulable_query.ts
+++ b/frontend/interfaces/schedulable_query.ts
@@ -24,7 +24,7 @@ export interface ISchedulableQuery {
   discard_data: boolean;
   packs: IPack[];
   stats: ISchedulableQueryStats;
-  editedQuerySql: boolean;
+  editingExistingQuery: boolean;
 }
 
 export interface IEnhancedQuery extends ISchedulableQuery {

--- a/frontend/interfaces/schedulable_query.ts
+++ b/frontend/interfaces/schedulable_query.ts
@@ -24,6 +24,7 @@ export interface ISchedulableQuery {
   discard_data: boolean;
   packs: IPack[];
   stats: ISchedulableQueryStats;
+  editedQuerySql: boolean;
 }
 
 export interface IEnhancedQuery extends ISchedulableQuery {

--- a/frontend/pages/queries/edit/EditQueryPage.tsx
+++ b/frontend/pages/queries/edit/EditQueryPage.tsx
@@ -71,6 +71,7 @@ const EditQueryPage = ({
     config,
   } = useContext(AppContext);
   const {
+    editedQuerySql,
     selectedOsqueryTable,
     setSelectedOsqueryTable,
     lastEditedQueryName,
@@ -127,7 +128,7 @@ const EditQueryPage = ({
     ["query", queryId],
     () => queryAPI.load(queryId as number),
     {
-      enabled: !!queryId,
+      enabled: !!queryId && !editedQuerySql,
       refetchOnWindowFocus: false,
       select: (data) => data.query,
       onSuccess: (returnedQuery) => {

--- a/frontend/pages/queries/edit/EditQueryPage.tsx
+++ b/frontend/pages/queries/edit/EditQueryPage.tsx
@@ -71,7 +71,7 @@ const EditQueryPage = ({
     config,
   } = useContext(AppContext);
   const {
-    editedQuerySql,
+    editingExistingQuery,
     selectedOsqueryTable,
     setSelectedOsqueryTable,
     lastEditedQueryName,
@@ -128,7 +128,7 @@ const EditQueryPage = ({
     ["query", queryId],
     () => queryAPI.load(queryId as number),
     {
-      enabled: !!queryId && !editedQuerySql,
+      enabled: !!queryId && !editingExistingQuery,
       refetchOnWindowFocus: false,
       select: (data) => data.query,
       onSuccess: (returnedQuery) => {

--- a/frontend/pages/queries/edit/components/EditQueryForm/EditQueryForm.tsx
+++ b/frontend/pages/queries/edit/components/EditQueryForm/EditQueryForm.tsx
@@ -150,7 +150,7 @@ const EditQueryForm = ({
     setLastEditedQueryMinOsqueryVersion,
     setLastEditedQueryLoggingType,
     setLastEditedQueryDiscardData,
-    setEditedQuerySql,
+    setEditingExistingQuery,
   } = useContext(QueryContext);
 
   const {
@@ -827,7 +827,7 @@ const EditQueryForm = ({
                 variant="blue-green"
                 onClick={() => {
                   if (changedSQL) {
-                    setEditedQuerySql(true);
+                    setEditingExistingQuery(true);
                   }
                   router.push(
                     PATHS.LIVE_QUERY(queryIdForEdit) +

--- a/frontend/pages/queries/edit/components/EditQueryForm/EditQueryForm.tsx
+++ b/frontend/pages/queries/edit/components/EditQueryForm/EditQueryForm.tsx
@@ -826,9 +826,7 @@ const EditQueryForm = ({
                 className={`${baseClass}__run`}
                 variant="blue-green"
                 onClick={() => {
-                  if (changedSQL) {
-                    setEditingExistingQuery(true);
-                  }
+                  setEditingExistingQuery(true); // Persists edited query data through live query flow
                   router.push(
                     PATHS.LIVE_QUERY(queryIdForEdit) +
                       TAGGED_TEMPLATES.queryByHostRoute(hostId)

--- a/frontend/pages/queries/edit/components/EditQueryForm/EditQueryForm.tsx
+++ b/frontend/pages/queries/edit/components/EditQueryForm/EditQueryForm.tsx
@@ -150,6 +150,7 @@ const EditQueryForm = ({
     setLastEditedQueryMinOsqueryVersion,
     setLastEditedQueryLoggingType,
     setLastEditedQueryDiscardData,
+    setEditedQuerySql,
   } = useContext(QueryContext);
 
   const {
@@ -825,6 +826,9 @@ const EditQueryForm = ({
                 className={`${baseClass}__run`}
                 variant="blue-green"
                 onClick={() => {
+                  if (changedSQL) {
+                    setEditedQuerySql(true);
+                  }
                   router.push(
                     PATHS.LIVE_QUERY(queryIdForEdit) +
                       TAGGED_TEMPLATES.queryByHostRoute(hostId)

--- a/frontend/pages/queries/live/LiveQueryPage/LiveQueryPage.tsx
+++ b/frontend/pages/queries/live/LiveQueryPage/LiveQueryPage.tsx
@@ -44,6 +44,7 @@ const RunQueryPage = ({
   const handlePageError = useErrorHandler();
   const { config } = useContext(AppContext);
   const {
+    editedQuerySql,
     selectedQueryTargets,
     setSelectedQueryTargets,
     selectedQueryTargetsByType,
@@ -88,7 +89,7 @@ const RunQueryPage = ({
     Error,
     ISchedulableQuery
   >(["query", queryId], () => queryAPI.load(queryId as number), {
-    enabled: !!queryId,
+    enabled: !!queryId && !editedQuerySql,
     refetchOnWindowFocus: false,
     select: (data) => data.query,
     onSuccess: (returnedQuery) => {

--- a/frontend/pages/queries/live/LiveQueryPage/LiveQueryPage.tsx
+++ b/frontend/pages/queries/live/LiveQueryPage/LiveQueryPage.tsx
@@ -44,7 +44,7 @@ const RunQueryPage = ({
   const handlePageError = useErrorHandler();
   const { config } = useContext(AppContext);
   const {
-    editedQuerySql,
+    editingExistingQuery,
     selectedQueryTargets,
     setSelectedQueryTargets,
     selectedQueryTargetsByType,
@@ -89,7 +89,7 @@ const RunQueryPage = ({
     Error,
     ISchedulableQuery
   >(["query", queryId], () => queryAPI.load(queryId as number), {
-    enabled: !!queryId && !editedQuerySql,
+    enabled: !!queryId && !editingExistingQuery,
     refetchOnWindowFocus: false,
     select: (data) => data.query,
     onSuccess: (returnedQuery) => {

--- a/frontend/pages/queries/live/screens/RunQuery.tsx
+++ b/frontend/pages/queries/live/screens/RunQuery.tsx
@@ -170,8 +170,6 @@ const RunQuery = ({
     destroyCampaign();
 
     try {
-      console.log("isStoredQueryEdited", isStoredQueryEdited);
-      console.log("lastEditedQueryBody", lastEditedQueryBody);
       const returnedCampaign = await queryAPI.run({
         query: lastEditedQueryBody,
         queryId: isStoredQueryEdited ? null : queryId, // we treat edited SQL as a new query

--- a/frontend/pages/queries/live/screens/RunQuery.tsx
+++ b/frontend/pages/queries/live/screens/RunQuery.tsx
@@ -47,6 +47,8 @@ const RunQuery = ({
     DEFAULT_CAMPAIGN_STATE
   );
 
+  const isStoredQueryEdited = storedQuery?.query !== lastEditedQueryBody;
+
   const ws = useRef(null);
   const runQueryInterval = useRef<any>(null);
   const globalSocket = useRef<any>(null);
@@ -168,8 +170,8 @@ const RunQuery = ({
     destroyCampaign();
 
     try {
-      const isStoredQueryEdited = storedQuery?.query !== lastEditedQueryBody;
-
+      console.log("isStoredQueryEdited", isStoredQueryEdited);
+      console.log("lastEditedQueryBody", lastEditedQueryBody);
       const returnedCampaign = await queryAPI.run({
         query: lastEditedQueryBody,
         queryId: isStoredQueryEdited ? null : queryId, // we treat edited SQL as a new query

--- a/frontend/utilities/constants.tsx
+++ b/frontend/utilities/constants.tsx
@@ -131,6 +131,7 @@ export const DEFAULT_QUERY: ISchedulableQuery = {
   team_id: 0,
   author_email: "",
   stats: {},
+  editedQuerySql: false,
 };
 
 export const DEFAULT_CAMPAIGN = {

--- a/frontend/utilities/constants.tsx
+++ b/frontend/utilities/constants.tsx
@@ -131,7 +131,7 @@ export const DEFAULT_QUERY: ISchedulableQuery = {
   team_id: 0,
   author_email: "",
   stats: {},
-  editedQuerySql: false,
+  editingExistingQuery: false,
 };
 
 export const DEFAULT_CAMPAIGN = {


### PR DESCRIPTION
## Issue
Cerra #16067

## Description
- [x] When editing a saved query, you can run a live query on the edit
- [x] When done running an edit on an existing query, you are returned to the unsaved edit page of the existing query

## Screen recording
- Show that you can edit an existing query, run a live query on the edit, return to editing that edit, and if you don't save the edit it will only reset back to the original query if you go back to reports and leave the edit/live query flow

https://github.com/fleetdm/fleet/assets/71795832/982bda5a-a254-4b26-96fe-5a25bc5fe182



# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
- [x] Manual QA for all new/changed functionality

