### PR TITLE
Update error message when scripts are disabled for a host

### DIFF
--- a/cmd/fleetctl/scripts_test.go
+++ b/cmd/fleetctl/scripts_test.go
@@ -179,7 +179,7 @@ Oh no!
 				Message:  fleet.RunScriptDisabledErrMsg,
 			},
 			expectOutput: `
-Error: Scripts are disabled for this host. To run scripts, deploy a Fleet installer with scripts enabled.
+Error: Scripts are disabled for this host. To run scripts, deploy the fleetd agent with scripts enabled.
 
 `,
 		},

--- a/frontend/pages/DashboardPage/cards/ActivityFeed/components/ScriptDetailsModal/ScriptDetailsModal.tsx
+++ b/frontend/pages/DashboardPage/cards/ActivityFeed/components/ScriptDetailsModal/ScriptDetailsModal.tsx
@@ -86,7 +86,7 @@ const StatusMessage = ({
         <StatusMessageError message={message} />
       );
     case -2:
-      // Expected API message: "Scripts are disabled for this host. To run scripts, deploy a Fleet installer with scripts enabled."
+      // Expected API message: "Scripts are disabled for this host. To run scripts, deploy the fleetd agent with scripts enabled."
       return <StatusMessageError message={message} />;
     case -1:
       // Expected API message: "Timeout. Fleet stopped the script after 5 minutes to protect host performance."

--- a/server/fleet/errors.go
+++ b/server/fleet/errors.go
@@ -544,7 +544,7 @@ const (
 	RunScriptAlreadyRunningErrMsg          = "A script is already running on this host. Please wait about 5 minutes to let it finish."
 	RunScriptHostTimeoutErrMsg             = "Fleet hasn’t heard from the host in over 5 minutes. Fleet doesn’t know if the script ran because the host went offline."
 	RunScriptScriptsDisabledGloballyErrMsg = "Running scripts is disabled in organization settings."
-	RunScriptDisabledErrMsg                = "Scripts are disabled for this host. To run scripts, deploy a Fleet installer with scripts enabled."
+	RunScriptDisabledErrMsg                = "Scripts are disabled for this host. To run scripts, deploy the fleetd agent with scripts enabled."
 	RunScriptScriptTimeoutErrMsg           = "Timeout. Fleet stopped the script after 5 minutes to protect host performance."
 
 	// End user authentication


### PR DESCRIPTION
In newer designs, we are moving toward always using the phrase "the fleetd agent" in place of "a Fleet installer", so updating  this existing error message to reflect that.