### PR TITLE
Website: Update mobile documentation navigation links

### DIFF
--- a/website/assets/styles/bootstrap-overrides.less
+++ b/website/assets/styles/bootstrap-overrides.less
@@ -205,6 +205,10 @@ a.text-danger:hover, a.text-danger:focus {
   }
 }
 
+.border-bottom {
+  border-bottom: 1px solid #C5C7D1 !important; //lesshint-disable-line importantRule
+}
+
 .card {
   box-shadow: 0px 6px 20px rgba(0, 0, 0, 0.05);
 }

--- a/website/assets/styles/pages/docs/basic-documentation.less
+++ b/website/assets/styles/pages/docs/basic-documentation.less
@@ -265,9 +265,16 @@
         &.active {
           color: @core-vibrant-blue;
         }
+        &:hover {
+          color: @core-vibrant-blue;
+        }
 
       }
 
+      [purpose='mobile-docs-nav-other-links'] {
+        border-top: 1px solid #C5C7D1;
+
+      }
       [purpose='docs-nav-button'] {
         color: @core-fleet-black;
         background-color: transparent;

--- a/website/views/pages/docs/basic-documentation.ejs
+++ b/website/views/pages/docs/basic-documentation.ejs
@@ -93,7 +93,7 @@
           <div class="border-bottom" v-if="!showDocsNav"></div>
           <div class="d-flex px-0 border-bottom mobile-docs-nav" v-if="showDocsNav">
             <div class="container-fluid px-0 pt-4">
-              <ul class="px-0 mb-0">
+              <ul class="px-0 mb-0 pb-3">
                 <li class="px-0 mb-2" v-for="page in findPagesByUrl()" :key="page.title">
                   <a :href="page.url" class="font-weight-bold">
                     {{page.title}}
@@ -111,6 +111,12 @@
                     </ul>
                   </div>
                 </li>
+              </ul>
+              <ul class="px-0 mb-0 pt-3" purpose="mobile-docs-nav-other-links">
+                <li class="px-0 mb-3"><a href="/tables">Data tables</a></li>
+                <li class="px-0 mb-3"><a href="/queries">Built-in queries</a></li>
+                <li class="px-0 mb-3"><a href="https://github.com/fleetdm/fleet/releases" target="_blank">Releases</a></li>
+                <li class="px-0 mb-3"><a href="/support">Support</a></li>
               </ul>
             </div>
           </div>


### PR DESCRIPTION
Changes:
- Added links to /tables, /queries, /support, and the releases page of the Fleet GitHub repo to the mobile documentation nav menu.
- Updated the color of the `.border-bottom` bootstrap class to match wireframes