### PR TITLE
Website: Update footer styles

### DIFF
--- a/website/assets/styles/layout.less
+++ b/website/assets/styles/layout.less
@@ -324,6 +324,8 @@ html, body {
     padding-bottom: 32px;
     padding-top: 40px;
     max-width: 1248px;
+    position: relative;
+    z-index: 9999;
   }
   [purpose='footer-nav'] {
     display: flex;


### PR DESCRIPTION
Closes: #16329

Changes:
- Updated the website footer to have a higher z-index than the parallax image layers on the homepage and product landing pages to prevent the layers of the image from covering the links in the footer. 