### PR TITLE
Fixed unreleased fleetd-chrome bug with sticky errors showing up after querying privacy_preferences table.

### DIFF
--- a/changes/16292-fleetd-chrome-privacy_preferences
+++ b/changes/16292-fleetd-chrome-privacy_preferences
@@ -1,0 +1,1 @@
+Fixed unreleased fleetd-chrome bug with sticky errors showing up after querying privacy_preferences table.

--- a/ee/fleetd-chrome/package.json
+++ b/ee/fleetd-chrome/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fleetd-for-chrome",
   "description": "Extension for Fleetd on ChromeOS",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "dependencies": {
     "dotenv": "^16.0.3",
     "wa-sqlite": "github:rhashimoto/wa-sqlite#buildless"

--- a/ee/fleetd-chrome/src/db.test.ts
+++ b/ee/fleetd-chrome/src/db.test.ts
@@ -3,5 +3,5 @@ import VirtualDatabase from "./db";
 test("Simple query", async () => {
   const db = await VirtualDatabase.init();
   const res = await db.query("select 1");
-  expect(res).toEqual({"data": [{ "1": 1 }], "warnings": undefined});
+  expect(res).toEqual({"data": [{ "1": 1 }], "warnings": null});
 });

--- a/ee/fleetd-chrome/src/db.ts
+++ b/ee/fleetd-chrome/src/db.ts
@@ -76,6 +76,7 @@ export default class VirtualDatabase {
   }
 
   async query(sql: string): Promise<ChromeResponse> {
+    this.warnings = null; // clear warnings
     let rows = [];
     await this.sqlite3.exec(this.db, sql, (row, columns) => {
       // map each row to object

--- a/ee/fleetd-chrome/src/tables/disk_info.test.ts
+++ b/ee/fleetd-chrome/src/tables/disk_info.test.ts
@@ -25,6 +25,6 @@ describe("disk_info", () => {
     const db = await VirtualDatabase.init();
 
     const res = await db.query("select * from disk_info");
-    expect(res).toEqual({"data":DISK_INFO_MOCK, "warnings": undefined});
+    expect(res).toEqual({"data":DISK_INFO_MOCK, "warnings": null});
   });
 });

--- a/ee/fleetd-chrome/src/tables/geolocation.test.ts
+++ b/ee/fleetd-chrome/src/tables/geolocation.test.ts
@@ -54,7 +54,7 @@ describe("geolocation", () => {
           region: "British Columbia",
         },
       ],
-      warnings: undefined,
+      warnings: null,
     });
   });
 
@@ -78,7 +78,7 @@ describe("geolocation", () => {
           region: "",
         },
       ],
-      warnings: undefined,
+      warnings: null,
     });
   });
 

--- a/ee/fleetd-chrome/src/tables/os_version.test.ts
+++ b/ee/fleetd-chrome/src/tables/os_version.test.ts
@@ -55,6 +55,7 @@ describe("os_version", () => {
           codename: "ChromeOS 13.2.1",
         },
       ],
+      warnings: null,
     });
   });
 
@@ -98,6 +99,7 @@ describe("os_version", () => {
           codename: "ChromeOS 13.2.1",
         },
       ],
+      warnings: null,
     });
     expect(console.warn).toHaveBeenCalledWith(
       expect.stringContaining("expected 4 segments")

--- a/ee/fleetd-chrome/src/tables/privacy_preferences.ts
+++ b/ee/fleetd-chrome/src/tables/privacy_preferences.ts
@@ -1,4 +1,5 @@
 import Table from "./Table";
+import ChromeSettingGetResultDetails = chrome.types.ChromeSettingGetResultDetails;
 
 export default class TablePrivacyPreferences extends Table {
   // expose properties available from the chrome.privacy API as a virtual osquery "table"
@@ -65,18 +66,22 @@ export default class TablePrivacyPreferences extends Table {
       results.push(
         new Promise((resolve) => {
           try {
-            propertyAPI.get({}, (details) => {
-              if (property === "web_rtc_ip_handling_policy") {
-                resolve({ [property]: details.value });
-              } else {
-                // convert bool response to string binary flag
-                if (details.value === true) {
-                  resolve({ [property]: "1" });
+            if (propertyAPI === undefined) {
+              resolve({ [property]: "" });
+            } else {
+              propertyAPI.get({}, (details: ChromeSettingGetResultDetails) => {
+                if (property === "web_rtc_ip_handling_policy") {
+                  resolve({[property]: details.value});
                 } else {
-                  resolve({ [property]: "0" });
+                  // convert bool response to string binary flag
+                  if (details.value === true) {
+                    resolve({ [property]: "1" });
+                  } else {
+                    resolve({ [property]: "0" });
+                  }
                 }
-              }
-            });
+              });
+            }
           } catch (error) {
             errors.push({ [property]: error });
             warningsArray.push({

--- a/ee/fleetd-chrome/src/tables/screenlock.test.ts
+++ b/ee/fleetd-chrome/src/tables/screenlock.test.ts
@@ -14,7 +14,7 @@ describe("screenlock", () => {
           grace_period: "600",
         },
       ],
-      warnings: undefined,
+      warnings: null,
     });
   });
 });

--- a/ee/fleetd-chrome/src/tables/system_state.test.ts
+++ b/ee/fleetd-chrome/src/tables/system_state.test.ts
@@ -14,7 +14,7 @@ describe("screenlock", () => {
           idle_state: "active",
         },
       ],
-      warnings: undefined,
+      warnings: null,
     });
   });
 });

--- a/ee/fleetd-chrome/updates-beta.xml
+++ b/ee/fleetd-chrome/updates-beta.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <gupdate xmlns='http://www.google.com/update2/response' protocol='2.0'>
   <app appid='bfleegjcoffelppfmadimianphbcdjkb'>
-    <updatecheck codebase='https://chrome-beta.fleetdm.com/fleetd.crx' version='1.1.0' />
+    <updatecheck codebase='https://chrome-beta.fleetdm.com/fleetd.crx' version='1.1.1' />
   </app>
 </gupdate>

--- a/ee/fleetd-chrome/updates.xml
+++ b/ee/fleetd-chrome/updates.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <gupdate xmlns='http://www.google.com/update2/response' protocol='2.0'>
   <app appid='fleeedmmihkfkeemmipgmhhjemlljidg'>
-    <updatecheck codebase='https://chrome.fleetdm.com/fleetd.crx' version='1.0.3' />
+    <updatecheck codebase='https://chrome.fleetdm.com/fleetd.crx' version='1.1.1' />
   </app>
 </gupdate>


### PR DESCRIPTION
Fixed unreleased fleetd-chrome bug with sticky errors showing up after querying privacy_preferences table.
#16292
# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [x] Added/updated tests
- [x] Manual QA for all new/changed functionality
