### PR TITLE
Orbit to kill pre-existing osqueryd processes during startup

### DIFF
--- a/cmd/fleetctl/debug_test.go
+++ b/cmd/fleetctl/debug_test.go
@@ -148,7 +148,7 @@ func TestDebugCheckAPIEndpoint(t *testing.T) {
 		case res.code == 0:
 			panic(res.body)
 		case res.code < 0:
-			time.Sleep(timeout + time.Millisecond)
+			time.Sleep(timeout + timeout/10)
 			res.code = -res.code
 		}
 		w.WriteHeader(res.code)

--- a/orbit/changes/16006-kill-pre-existing-osqueryd-processes-at-startup
+++ b/orbit/changes/16006-kill-pre-existing-osqueryd-processes-at-startup
@@ -1,0 +1,1 @@
+* Orbit will now kill pre-existing osqueryd processes during startup.

--- a/orbit/pkg/osquery/osquery.go
+++ b/orbit/pkg/osquery/osquery.go
@@ -111,7 +111,7 @@ func WithDataPath(path string) Option {
 		}
 
 		r.cmd.Args = append(r.cmd.Args,
-			"--pidfile="+filepath.Join(path, "osquery.pid"),
+			"--pidfile="+filepath.Join(path, constant.OsqueryPidfile),
 			"--database_path="+filepath.Join(path, "osquery.db"),
 			"--extensions_socket="+r.ExtensionSocketPath(),
 		)
@@ -128,7 +128,7 @@ func WithDataPathAndExtensionPathPostfix(path string, extensionPathPostfix strin
 		}
 
 		r.cmd.Args = append(r.cmd.Args,
-			"--pidfile="+filepath.Join(path, "osquery.pid"),
+			"--pidfile="+filepath.Join(path, constant.OsqueryPidfile),
 			"--database_path="+filepath.Join(path, "osquery.db"),
 			"--extensions_socket="+r.ExtensionSocketPath()+extensionPathPostfix,
 		)

--- a/orbit/pkg/platform/platform.go
+++ b/orbit/pkg/platform/platform.go
@@ -3,12 +3,8 @@ package platform
 import (
 	"errors"
 	"fmt"
-	"os"
-	"path/filepath"
-	"strconv"
 	"strings"
 
-	"github.com/mitchellh/go-ps"
 	gopsutil_process "github.com/shirou/gopsutil/v3/process"
 )
 
@@ -25,78 +21,8 @@ const (
 	UUIDSourceHardware = "UUID_Source_Hardware"
 )
 
-// readPidFromFile reads a PID from a file
-func readPidFromFile(destDir string, destFile string) (int32, error) {
-	// Defense programming - sanity checks on inputs
-	if destDir == "" {
-		return 0, errors.New(" destination directory should not be empty")
-	}
-
-	if destFile == "" {
-		return 0, errors.New(" destination file should not be empty")
-	}
-
-	pidFilePath := filepath.Join(destDir, destFile)
-	data, err := os.ReadFile(pidFilePath)
-	if err != nil {
-		return 0, fmt.Errorf("error reading pidfile %s: %w", pidFilePath, err)
-	}
-
-	intNumber, err := strconv.ParseInt(strings.TrimSpace(string(data)), 10, 32)
-	if err != nil {
-		return 0, fmt.Errorf("error converting pidfile %s: %w", pidFilePath, err)
-	}
-
-	return int32(intNumber), err
-}
-
-// processNameMatches returns whether the process running with the given pid matches
-// the executable name (case insensitive).
-// If there's no process running with the given pid then (false, nil) is returned.
-func processNameMatches(pid int, expectedPrefix string) (bool, error) {
-	if pid == 0 {
-		return false, errors.New("process id should not be zero")
-	}
-
-	if expectedPrefix == "" {
-		return false, errors.New("expected prefix should not be empty")
-	}
-
-	process, err := ps.FindProcess(pid)
-	if err != nil {
-		return false, fmt.Errorf("find process: %d: %w", pid, err)
-	}
-
-	if process == nil {
-		return false, nil
-	}
-
-	return strings.HasPrefix(strings.ToLower(process.Executable()), strings.ToLower(expectedPrefix)), nil
-}
-
-// killPID kills a process by PID
-func killPID(pid int32) error {
-	if pid == 0 {
-		return errors.New("process id should not be zero")
-	}
-
-	processes, err := gopsutil_process.Processes()
-	if err != nil {
-		return err
-	}
-
-	for _, process := range processes {
-		if pid == process.Pid {
-			process.Kill() //nolint:errcheck
-			break
-		}
-	}
-
-	return nil
-}
-
-// KillProcessByName kills a single process by its name
-func KillProcessByName(name string) error {
+// killProcessByName kills a single process by its name.
+func killProcessByName(name string) error {
 	if name == "" {
 		return errors.New("process name should not be empty")
 	}
@@ -113,10 +39,10 @@ func KillProcessByName(name string) error {
 	return nil
 }
 
-// getProcessesByName gets a single process object by its name
-func getProcessesByName(name string) ([]*gopsutil_process.Process, error) {
-	if name == "" {
-		return nil, errors.New("process name should not be empty")
+// getProcessesByName returns all the running processes with the given prefix in their name.
+func getProcessesByName(namePrefix string) ([]*gopsutil_process.Process, error) {
+	if namePrefix == "" {
+		return nil, errors.New("process name prefix should not be empty")
 	}
 
 	processes, err := gopsutil_process.Processes()
@@ -132,77 +58,46 @@ func getProcessesByName(name string) ([]*gopsutil_process.Process, error) {
 			continue
 		}
 
-		if strings.HasPrefix(processName, name) {
+		if strings.HasPrefix(processName, namePrefix) {
 			foundProcesses = append(foundProcesses, process)
 		}
-	}
-
-	if len(foundProcesses) == 0 {
-		return nil, ErrProcessNotFound
 	}
 
 	return foundProcesses, nil
 }
 
-// KillAllProcessByName kills all process found by their name
-func KillAllProcessByName(name string) error {
-	if name == "" {
-		return errors.New("process name should not be empty")
-	}
-
-	foundProcesses, err := getProcessesByName(name)
-	if err != nil {
-		return fmt.Errorf("get process: %w", err)
-	}
-
-	// Killing found processes
-	for _, foundProcess := range foundProcesses {
-		if err := foundProcess.Kill(); err != nil {
-			return fmt.Errorf("kill process %d: %w", foundProcess.Pid, err)
-		}
-	}
-
-	return nil
+// Process holds basic information of a process.
+type Process struct {
+	// Name is the name of the process.
+	Name string
+	// PID is the process identifier.
+	PID int32
 }
 
-// KillFromPIDFile kills a process taking the PID value from a file
-func KillFromPIDFile(destDir string, pidFileName string, expectedExecName string) error {
-	if destDir == "" {
-		return errors.New("destination directory should not be empty")
+// KillAllProcessByName kills all the running processes with the given prefix in their name.
+// It returns the processes that were killed. It returns `nil, nil` if there were no processes
+// running with such name prefix.
+func KillAllProcessByName(namePrefix string) ([]Process, error) {
+	if namePrefix == "" {
+		return nil, errors.New("process name prefix should not be empty")
 	}
 
-	if pidFileName == "" {
-		return errors.New("PID file name should not be empty")
-	}
-
-	if expectedExecName == "" {
-		return errors.New("expected executable name should not be empty")
-	}
-
-	pid, err := readPidFromFile(destDir, pidFileName)
-	switch {
-	case err == nil:
-		// OK
-	case errors.Is(err, os.ErrNotExist):
-		return nil // we assume it's not running
-	default:
-		return fmt.Errorf("reading pid from: %s: %w", destDir, err)
-	}
-
-	matches, err := processNameMatches(int(pid), expectedExecName)
+	foundProcesses, err := getProcessesByName(namePrefix)
 	if err != nil {
-		return fmt.Errorf("inspecting process %d: %w", pid, err)
+		return nil, fmt.Errorf("get processes by name: %w", err)
 	}
 
-	if !matches {
-		// Nothing to do, another process may be running with this pid
-		// (e.g. could happen after a restart).
-		return nil
+	var killedProcesses []Process
+	for _, foundProcess := range foundProcesses {
+		processName, _ := foundProcess.Name()
+		if err := foundProcess.Kill(); err != nil {
+			return nil, fmt.Errorf("kill process %d: %w", foundProcess.Pid, err)
+		}
+		killedProcesses = append(killedProcesses, Process{
+			Name: processName,
+			PID:  foundProcess.Pid,
+		})
 	}
 
-	if err := killPID(pid); err != nil {
-		return fmt.Errorf("killing %d: %w", pid, err)
-	}
-
-	return nil
+	return killedProcesses, nil
 }

--- a/orbit/pkg/platform/platform_notwindows.go
+++ b/orbit/pkg/platform/platform_notwindows.go
@@ -47,7 +47,7 @@ func SignalProcessBeforeTerminate(processName string) error {
 		return errors.New("processName should not be empty")
 	}
 
-	if err := KillProcessByName(constant.DesktopAppExecName); err != nil && !errors.Is(err, ErrProcessNotFound) {
+	if err := killProcessByName(constant.DesktopAppExecName); err != nil && !errors.Is(err, ErrProcessNotFound) {
 		return fmt.Errorf("There was an error kill target process %s: %w", processName, err)
 	}
 


### PR DESCRIPTION
This should fix #16006.

On Windows when a process is killed by the Task Manager, it is killed without any signaling, thus the osqueryd processes are left orphaned. Executing osqueryd (which we do to get host information) was failing because the lingering processes had a lock on the database file. The solution implemented in this PR is to kill any pre-existing osqueryd processes before running osqueryd.

- [X] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
- [X] Manual QA for all new/changed functionality
  - For Orbit and Fleet Desktop changes:
    - [X] Manual QA must be performed in the three main OSs, macOS, Windows and Linux.
    - [X] Auto-update manual QA, from released version of component to new version (see [tools/tuf/test](../tools/tuf/test/README.md)).

PS: I added a log of the stdout+stderr of osqueryd execution when such command fails to execute. (This helped me find the root cause.)
```
2024-01-25T11:57:56-08:00 ERR getHostInfo via osquery output= stderr="E0125 11:57:56.744843
7860 shutdown.cpp:79] IO error: Failed to create lock file:
C:\\Program Files\\Orbit\\osquery.db/LOCK: The process cannot access the file because it is
being used by another process.\r\r\n"
```

PPS: I removed some unused exported methods in the `orbit/pkg/platform` package.