### PR TITLE
Release fleetctl for macOS as a universal binary (native support for both amd64 and arm64 architectures).

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -40,7 +40,6 @@ builds:
     env:
       - CGO_ENABLED=0
     goos:
-      - darwin
       - linux
       - windows
     goarch:
@@ -54,6 +53,32 @@ builds:
       - -X github.com/fleetdm/fleet/v4/server/version.revision={{ .FullCommit }}
       - -X github.com/fleetdm/fleet/v4/server/version.buildDate={{ time "2006-01-02" }}
       - -X github.com/fleetdm/fleet/v4/server/version.buildUser={{ .Env.USER }}
+
+  - id: fleetctl-macos
+    dir: ./cmd/fleetctl/
+    binary: fleetctl
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - darwin
+    goarch:
+      - amd64
+      - arm64
+    flags:
+      - -trimpath
+    ldflags:
+      - -X github.com/fleetdm/fleet/v4/server/version.appName={{ .ArtifactName }}
+      - -X github.com/fleetdm/fleet/v4/server/version.version={{ .Version }}
+      - -X github.com/fleetdm/fleet/v4/server/version.branch={{ .Branch }}
+      - -X github.com/fleetdm/fleet/v4/server/version.revision={{ .FullCommit }}
+      - -X github.com/fleetdm/fleet/v4/server/version.buildDate={{ time "2006-01-02" }}
+      - -X github.com/fleetdm/fleet/v4/server/version.buildUser={{ .Env.USER }}
+
+universal_binaries:
+  - id: fleetctl # resulting binary id
+    ids: [fleetctl-macos] # source binaries
+    replace: true
+    name_template: fleetctl # resulting binary name
 
 archives:
   - id: fleet

--- a/changes/9047-fleetctl-universal-binary
+++ b/changes/9047-fleetctl-universal-binary
@@ -1,0 +1,1 @@
+Release fleetctl for macOS as a universal binary (native support for both amd64 and arm64 architectures).


### PR DESCRIPTION
Release fleetctl for macOS as a universal binary (native support for both amd64 and arm64 architectures).
#9047

Tested goreleaser locally.
