### PR TITLE
fix query to get windows MDM enrollment

### DIFF
--- a/changes/16332-windows-mdm-unenroll
+++ b/changes/16332-windows-mdm-unenroll
@@ -1,0 +1,1 @@
+* Fix queries that report MDM enrollment status in Windows.


### PR DESCRIPTION
for #16332, this updates the windows mdm query to always return at least one row, so we can detect windows unenrollments

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [x] Manual QA for all new/changed functionality
