### PR TITLE
Fixing SSL certificates to make them valid.

### DIFF
--- a/tools/test-orbit-mtls/gen.sh
+++ b/tools/test-orbit-mtls/gen.sh
@@ -20,9 +20,9 @@ openssl genrsa 2048 > client-ca.key
 openssl req -new -x509 -nodes -days 1000 -key client-ca.key > client-ca.crt
 
 # Generate a client certificate signing request
-openssl req -newkey rsa:2048 -days 1000 -nodes -keyout client.key > client.req
+openssl req -newkey rsa:2048 -days 398 -nodes -keyout client.key > client.req
 
 # Have the CA sign the client certificate request and output the client certificate.
-openssl x509 -req -in client.req -days 1000 -CA client-ca.crt -CAkey client-ca.key -set_serial 01 > client.crt
+openssl x509 -req -in client.req -days 398 -CA client-ca.crt -CAkey client-ca.key -set_serial 01 > client.crt
 
 rm client.req


### PR DESCRIPTION
SSL certificates have a maximum lifetime of 398 days right now (13 months).

It took me a while to figure out why these were not working via the macOS keychain (specifically curl and Safari).
It appears the CA certificate can have a longer lifetime, but the SSL certificates it issues must have a limited lifetime.
