### PR TITLE
Fleet UI: Remove repeated version number on os details page

### DIFF
--- a/frontend/pages/SoftwarePage/SoftwareOSDetailsPage/SoftwareOSDetailsPage.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareOSDetailsPage/SoftwareOSDetailsPage.tsx
@@ -94,7 +94,7 @@ const SoftwareOSDetailsPage = ({ location }: ISoftwareOSDetailsPageProps) => {
     return (
       <>
         <SoftwareDetailsSummary
-          title={`${osVersionDetails.name} ${osVersionDetails.version}`}
+          title={osVersionDetails.name}
           hosts={osVersionDetails.hosts_count}
           queryParams={{
             os_name: osVersionDetails.name_only,


### PR DESCRIPTION
## Issue
- Unreleased bug fix for #4345 

## Description
- Version number was repeating twice in the header

## Screenshot of fix
<img width="1328" alt="Screenshot 2024-01-26 at 10 24 43 AM" src="https://github.com/fleetdm/fleet/assets/71795832/9966c75d-44c6-4b89-9f3c-f95fe454e1fd">


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Manual QA for all new/changed functionality

