### PR TITLE
Add more OS support in osquery perf

### DIFF
--- a/cmd/osquery-perf/agent.go
+++ b/cmd/osquery-perf/agent.go
@@ -1306,19 +1306,20 @@ func (a *agent) runLiveQuery(query string) (results []map[string]string, status 
 	if a.liveQueryNoResultsProb > 0.0 && rand.Float64() <= a.liveQueryNoResultsProb {
 		return []map[string]string{}, &ss, nil, nil
 	}
-	return []map[string]string{{
-			"admindir":   "/var/lib/dpkg",
-			"arch":       "amd64",
-			"maintainer": "foobar",
-			"name":       "netconf",
-			"priority":   "optional",
-			"revision":   "",
-			"section":    "default",
-			"size":       "112594",
-			"source":     "",
-			"status":     "install ok installed",
-			"version":    "20230224000000",
-		},
+	return []map[string]string{
+			{
+				"admindir":   "/var/lib/dpkg",
+				"arch":       "amd64",
+				"maintainer": "foobar",
+				"name":       "netconf",
+				"priority":   "optional",
+				"revision":   "",
+				"section":    "default",
+				"size":       "112594",
+				"source":     "",
+				"status":     "install ok installed",
+				"version":    "20230224000000",
+			},
 		}, &ss, nil, &fleet.Stats{
 			WallTimeMs: uint64(rand.Intn(1000) * 1000),
 			UserTime:   uint64(rand.Intn(1000)),
@@ -1584,9 +1585,12 @@ func results(num int, hostUUID string) string {
 
 func main() {
 	validTemplateNames := map[string]bool{
-		"mac10.14.6.tmpl":   true,
-		"windows_11.tmpl":   true,
-		"ubuntu_22.04.tmpl": true,
+		"macos_13.6.2.tmpl":         true,
+		"macos_14.1.2.tmpl":         true,
+		"windows_11.tmpl":           true,
+		"windows_11_22H2_2861.tmpl": true,
+		"windows_11_22H2_3007.tmpl": true,
+		"ubuntu_22.04.tmpl":         true,
 	}
 	allowedTemplateNames := make([]string, 0, len(validTemplateNames))
 	for k := range validTemplateNames {
@@ -1626,8 +1630,8 @@ func main() {
 		munkiIssueProb              = flag.Float64("munki_issue_prob", 0.5, "Probability of a host having munki issues (note that ~50% of hosts have munki installed) [0, 1]")
 		munkiIssueCount             = flag.Int("munki_issue_count", 10, "Number of munki issues reported by hosts identified to have munki issues")
 		// E.g. when running with `-host_count=10`, you can set host count for each template the following way:
-		// `-os_templates=windows_11.tmpl:3,mac10.14.6.tmpl:4,ubuntu_22.04.tmpl:3`
-		osTemplates     = flag.String("os_templates", "mac10.14.6", fmt.Sprintf("Comma separated list of host OS templates to use and optionally their host count separated by ':' (any of %v, with or without the .tmpl extension)", allowedTemplateNames))
+		// `-os_templates=windows_11.tmpl:3,macos_14.1.2.tmpl:4,ubuntu_22.04.tmpl:3`
+		osTemplates     = flag.String("os_templates", "macos_14.1.2", fmt.Sprintf("Comma separated list of host OS templates to use and optionally their host count separated by ':' (any of %v, with or without the .tmpl extension)", allowedTemplateNames))
 		emptySerialProb = flag.Float64("empty_serial_prob", 0.1, "Probability of a host having no serial number [0, 1]")
 
 		mdmProb          = flag.Float64("mdm_prob", 0.0, "Probability of a host enrolling via MDM (for macOS) [0, 1]")

--- a/cmd/osquery-perf/macos_13.6.2.tmpl
+++ b/cmd/osquery-perf/macos_13.6.2.tmpl
@@ -1,0 +1,218 @@
+{{ define "enroll" -}}
+{
+    "enroll_secret": "{{ .EnrollSecret  }}",
+    "host_details": {
+        "os_version": {
+            "build": "22G320",
+            "major": "13",
+            "minor": "6",
+            "name": "macOS",
+            "patch": "2",
+            "platform": "darwin",
+            "platform_like": "darwin",
+            "version": "13.6.2"
+        },
+        "osquery_info": {
+            "build_distro": "10.12",
+            "build_platform": "darwin",
+            "config_hash": "",
+            "config_valid": "0",
+            "extensions": "inactive",
+            "instance_id": "{{ .UUID }}",
+            "pid": "12947",
+            "platform_mask": "21",
+            "start_time": "1580931224",
+            "uuid": "{{ .UUID }}",
+            "version": "4.6.0",
+            "watcher": "12946"
+        },
+        "platform_info": {
+            "address": "0xff990000",
+            "date": "12/16/2019 ",
+            "extra": "MBP114; 196.0.0.0.0; root@xapp160; Mon Dec 16 15:55:18 PST 2019; 196 (B&I); F000_B00; Official Build, Release; Apple LLVM version 5.0 (clang-500.0.68) (based on LLVM 3.3svn)",
+            "revision": "196 (B&I)",
+            "size": "8388608",
+            "vendor": "Apple Inc. ",
+            "version": "196.0.0.0.0 ",
+            "volume_size": "1507328"
+        },
+        "system_info": {
+            "computer_name": "{{ .CachedString "hostname" }}",
+            "cpu_brand": "Intel(R) Core(TM) i7-4770HQ CPU @ 2.20GHz",
+            "cpu_logical_cores": "8",
+            "cpu_physical_cores": "4",
+            "cpu_subtype": "Intel x86-64h Haswell",
+            "cpu_type": "x86_64h",
+            "hardware_model": "MacBookPro11,4",
+            "hardware_serial": "{{ .SerialNumber }}",
+            "hardware_vendor": "Apple Inc.",
+            "hardware_version": "1.0",
+            "hostname": "{{ .CachedString "hostname" }}",
+            "local_hostname": "{{ .CachedString "hostname" }}",
+            "physical_memory": "17179869184",
+            "uuid": "{{ .UUID }}"
+        }
+    },
+    "host_identifier": "{{ .UUID }}",
+    "platform_type": "16"
+}
+{{- end }}
+
+{{ define "fleet_detail_query_network_interface_unix" -}}
+[
+  {
+    "address":"fe80::8cb:112d:ff51:1e5d%en0",
+    "mac":"f8:2d:88:93:56:5c"
+  }
+]
+{{- end }}
+{{ define "fleet_detail_query_os_version" -}}
+[
+  {
+    "name":"macOS",
+    "version":"13.6.2",
+    "major":"13",
+    "minor":"6",
+    "patch":"2",
+    "build":"22G320",
+    "platform":"darwin",
+    "platform_like":"darwin",
+    "arch":"x86_64"
+  }
+]
+{{- end }}
+{{ define "fleet_detail_query_os_unix_like" -}}
+[
+  {
+    "name":"macOS",
+    "version":"13.6.2",
+    "major":"13",
+    "minor":"6",
+    "patch":"2",
+    "build":"22G320",
+    "platform":"darwin",
+    "arch":"x86_64",
+    "kernel_version":"18.7.0"
+  }
+]
+{{- end }}
+{{ define "fleet_detail_query_osquery_flags" -}}
+[
+  {
+    "name":"config_refresh",
+    "value":"{{ printf "%.0f" .ConfigInterval.Seconds }}"
+  },
+  {
+    "name":"distributed_interval",
+    "value":"{{ printf "%.0f" .QueryInterval.Seconds }}"
+  },
+  {
+    "name":"logger_tls_period",
+    "value":"99999"
+  }
+]
+{{- end }}
+{{ define "fleet_detail_query_osquery_info" -}}
+[
+  {
+    "pid":"11287",
+    "uuid":"{{ .UUID }}",
+    "instance_id":"{{ .UUID }}",
+    "version":"4.1.2",
+    "config_hash":"b01efbf375ac6767f259ae98751154fef727ce35",
+    "config_valid":"1",
+    "extensions":"inactive",
+    "build_platform":"darwin",
+    "build_distro":"10.12",
+    "start_time":"1582857555",
+    "watcher":"11286",
+    "platform_mask":"21"
+  }
+]
+{{- end }}
+{{ define "fleet_detail_query_system_info" -}}
+[
+  {
+    "hostname":"{{ .CachedString "hostname" }}",
+    "uuid": "{{ .UUID }}",
+    "cpu_type":"x86_64h",
+    "cpu_subtype":"Intel x86-64h Haswell",
+    "cpu_brand":"Intel(R) Core(TM) i7-4770HQ CPU @ 2.20GHz",
+    "cpu_physical_cores":"4",
+    "cpu_logical_cores":"8",
+    "cpu_microcode":"",
+    "physical_memory":"17179869184",
+    "hardware_vendor":"Apple Inc.",
+    "hardware_model":"MacBookPro11,4",
+    "hardware_version":"1.0",
+    "hardware_serial":"{{ .SerialNumber }}",
+    "computer_name":"{{ .CachedString "hostname" }}",
+    "local_hostname":"{{ .CachedString "hostname" }}"
+  }
+]
+{{- end }}
+{{ define "fleet_detail_query_uptime" -}}
+[
+  {
+    "days":"0",
+    "hours":"4",
+    "minutes":"38",
+    "seconds":"11",
+    "total_seconds":"16691"
+  }
+]
+{{- end }}
+
+{{ define "fleet_detail_query_disk_encryption_key_darwin" -}}
+{{- if .DiskEncryptionEnabled }}
+[
+  {"line": "MIAGCSqGSIb3DQEHA6CAMIACAQAxggFtMIIBaQIBADBRMEgxHzAdBgNVBAMMFkZpbGVWYXVsdCBSZWNvdmVyeSBLZXkxJTAjBgNVBA0MHFJvYmVydG9zLU1hY0Jvb2stUHJvLTIubG9jYWwCBQCovxm3MA0GCSqGSIb3DQEBAQUABIIBAHiz8IGpXp+vqfTes7ejbvS11XpnaHCxDeaMYjmEJgZKtwdQhOJZy9clsypwqFv6h/Cva3/SuOEcwBoS2N/YY766jDP8nU4OcUaZWqEcMhRsSs1mil4T+rTnUfQEUKU9xW1j/iFq3xVWDTaBY+5cBgwUmdZb8XoWhXUVoF73OD0NpitnXxsxHokXv+UZzPoydlsCzhfAngl11hELAuFe6/mfq801E1hT+zvzDEDvfwSBMDC14OGDoFORVe/HCBS3NFGpVV+IrqpIpT1wbNx2dazmngduviErpXTgZG2vrCMQN1rN0OeLRtOMcjE6rer+ruuc5hfvTGMwWOgteqd2YQUwgAYJKoZIhvcNAQcBMBQGCCqGSIb3DQMHBAhwRO3eyigWMaCABBhy88Lm9qisQ9sOaf8u8GSzoWFdw2LkjRMECAKJG0H5K6iTAAAAAAAAAAAAAA=="},
+]
+{{- else }}
+[]
+{{- end }}
+{{- end }}
+
+{{/* all hosts */}}
+{{ define "fleet_label_query_6" -}}
+[
+  {
+    "1": "1"
+  }
+]
+{{- end }}
+
+{{/* All macOS hosts */}}
+{{ define "fleet_label_query_7" -}}
+[
+  {
+    "1": "1"
+  }
+]
+{{- end }}
+
+{{/* All Ubuntu hosts */}}
+{{ define "fleet_label_query_8" -}}
+[]
+{{- end }}
+
+{{/* All CentOS hosts */}}
+{{ define "fleet_label_query_9" -}}
+[]
+{{- end }}
+
+{{/* All Windows hosts */}}
+{{ define "fleet_label_query_10" -}}
+[]
+{{- end }}
+
+{{/* All Red Hat hosts */}}
+{{ define "fleet_label_query_11" -}}
+[]
+{{- end }}
+
+{{/* All Linux distributions */}}
+{{ define "fleet_label_query_12" -}}
+[]
+{{- end }}
+

--- a/cmd/osquery-perf/macos_14.1.2.tmpl
+++ b/cmd/osquery-perf/macos_14.1.2.tmpl
@@ -1,0 +1,219 @@
+{{ define "enroll" -}}
+{
+    "enroll_secret": "{{ .EnrollSecret  }}",
+    "host_details": {
+        "os_version": {
+            "build": "23B92",
+            "major": "14",
+            "minor": "1",
+            "name": "Mac OS X",
+            "patch": "2",
+            "platform": "darwin",
+            "platform_like": "darwin",
+            "version": "14.1.2"
+        },
+        "osquery_info": {
+            "build_distro": "10.12",
+            "build_platform": "darwin",
+            "config_hash": "",
+            "config_valid": "0",
+            "extensions": "inactive",
+            "instance_id": "{{ .UUID }}",
+            "pid": "12947",
+            "platform_mask": "21",
+            "start_time": "1580931224",
+            "uuid": "{{ .UUID }}",
+            "version": "4.6.0",
+            "watcher": "12946"
+        },
+        "platform_info": {
+            "address": "0xff990000",
+            "date": "12/16/2019 ",
+            "extra": "MBP114; 196.0.0.0.0; root@xapp160; Mon Dec 16 15:55:18 PST 2019; 196 (B&I); F000_B00; Official Build, Release; Apple LLVM version 5.0 (clang-500.0.68) (based on LLVM 3.3svn)",
+            "revision": "196 (B&I)",
+            "size": "8388608",
+            "vendor": "Apple Inc. ",
+            "version": "196.0.0.0.0 ",
+            "volume_size": "1507328"
+        },
+        "system_info": {
+            "computer_name": "{{ .CachedString "hostname" }}",
+            "cpu_brand": "Intel(R) Core(TM) i7-4770HQ CPU @ 2.20GHz",
+            "cpu_logical_cores": "8",
+            "cpu_physical_cores": "4",
+            "cpu_subtype": "Intel x86-64h Haswell",
+            "cpu_type": "x86_64h",
+            "hardware_model": "MacBookPro11,4",
+            "hardware_serial": "{{ .SerialNumber }}",
+            "hardware_vendor": "Apple Inc.",
+            "hardware_version": "1.0",
+            "hostname": "{{ .CachedString "hostname" }}",
+            "local_hostname": "{{ .CachedString "hostname" }}",
+            "physical_memory": "17179869184",
+            "uuid": "{{ .UUID }}"
+        }
+    },
+    "host_identifier": "{{ .UUID }}",
+    "platform_type": "16"
+}
+{{- end }}
+
+{{ define "fleet_detail_query_network_interface_unix" -}}
+[
+  {
+    "address":"fe80::8cb:112d:ff51:1e5d%en0",
+    "mac":"f8:2d:88:93:56:5c"
+  }
+]
+{{- end }}
+{{ define "fleet_detail_query_os_version" -}}
+[
+  {
+    "name":"macOS",
+    "version":"14.1.2",
+    "major":"14",
+    "minor":"1",
+    "patch":"2",
+    "build":"23B92",
+    "platform":"darwin",
+    "platform_like":"darwin",
+    "codename":"",
+    "arch":"x86_64"
+  }
+]
+{{- end }}
+{{ define "fleet_detail_query_os_unix_like" -}}
+[
+  {
+    "name":"macOS",
+    "version":"14.1.2",
+    "major":"14",
+    "minor":"1",
+    "patch":"2",
+    "build":"23B92",
+    "platform":"darwin",
+    "arch":"x86_64",
+    "kernel_version":"18.7.0"
+  }
+]
+{{- end }}
+{{ define "fleet_detail_query_osquery_flags" -}}
+[
+  {
+    "name":"config_refresh",
+    "value":"{{ printf "%.0f" .ConfigInterval.Seconds }}"
+  },
+  {
+    "name":"distributed_interval",
+    "value":"{{ printf "%.0f" .QueryInterval.Seconds }}"
+  },
+  {
+    "name":"logger_tls_period",
+    "value":"99999"
+  }
+]
+{{- end }}
+{{ define "fleet_detail_query_osquery_info" -}}
+[
+  {
+    "pid":"11287",
+    "uuid":"{{ .UUID }}",
+    "instance_id":"{{ .UUID }}",
+    "version":"4.1.2",
+    "config_hash":"b01efbf375ac6767f259ae98751154fef727ce35",
+    "config_valid":"1",
+    "extensions":"inactive",
+    "build_platform":"darwin",
+    "build_distro":"10.12",
+    "start_time":"1582857555",
+    "watcher":"11286",
+    "platform_mask":"21"
+  }
+]
+{{- end }}
+{{ define "fleet_detail_query_system_info" -}}
+[
+  {
+    "hostname":"{{ .CachedString "hostname" }}",
+    "uuid": "{{ .UUID }}",
+    "cpu_type":"x86_64h",
+    "cpu_subtype":"Intel x86-64h Haswell",
+    "cpu_brand":"Intel(R) Core(TM) i7-4770HQ CPU @ 2.20GHz",
+    "cpu_physical_cores":"4",
+    "cpu_logical_cores":"8",
+    "cpu_microcode":"",
+    "physical_memory":"17179869184",
+    "hardware_vendor":"Apple Inc.",
+    "hardware_model":"MacBookPro11,4",
+    "hardware_version":"1.0",
+    "hardware_serial":"{{ .SerialNumber }}",
+    "computer_name":"{{ .CachedString "hostname" }}",
+    "local_hostname":"{{ .CachedString "hostname" }}"
+  }
+]
+{{- end }}
+{{ define "fleet_detail_query_uptime" -}}
+[
+  {
+    "days":"0",
+    "hours":"4",
+    "minutes":"38",
+    "seconds":"11",
+    "total_seconds":"16691"
+  }
+]
+{{- end }}
+
+{{ define "fleet_detail_query_disk_encryption_key_darwin" -}}
+{{- if .DiskEncryptionEnabled }}
+[
+  {"line": "MIAGCSqGSIb3DQEHA6CAMIACAQAxggFtMIIBaQIBADBRMEgxHzAdBgNVBAMMFkZpbGVWYXVsdCBSZWNvdmVyeSBLZXkxJTAjBgNVBA0MHFJvYmVydG9zLU1hY0Jvb2stUHJvLTIubG9jYWwCBQCovxm3MA0GCSqGSIb3DQEBAQUABIIBAHiz8IGpXp+vqfTes7ejbvS11XpnaHCxDeaMYjmEJgZKtwdQhOJZy9clsypwqFv6h/Cva3/SuOEcwBoS2N/YY766jDP8nU4OcUaZWqEcMhRsSs1mil4T+rTnUfQEUKU9xW1j/iFq3xVWDTaBY+5cBgwUmdZb8XoWhXUVoF73OD0NpitnXxsxHokXv+UZzPoydlsCzhfAngl11hELAuFe6/mfq801E1hT+zvzDEDvfwSBMDC14OGDoFORVe/HCBS3NFGpVV+IrqpIpT1wbNx2dazmngduviErpXTgZG2vrCMQN1rN0OeLRtOMcjE6rer+ruuc5hfvTGMwWOgteqd2YQUwgAYJKoZIhvcNAQcBMBQGCCqGSIb3DQMHBAhwRO3eyigWMaCABBhy88Lm9qisQ9sOaf8u8GSzoWFdw2LkjRMECAKJG0H5K6iTAAAAAAAAAAAAAA=="},
+]
+{{- else }}
+[]
+{{- end }}
+{{- end }}
+
+{{/* all hosts */}}
+{{ define "fleet_label_query_6" -}}
+[
+  {
+    "1": "1"
+  }
+]
+{{- end }}
+
+{{/* All macOS hosts */}}
+{{ define "fleet_label_query_7" -}}
+[
+  {
+    "1": "1"
+  }
+]
+{{- end }}
+
+{{/* All Ubuntu hosts */}}
+{{ define "fleet_label_query_8" -}}
+[]
+{{- end }}
+
+{{/* All CentOS hosts */}}
+{{ define "fleet_label_query_9" -}}
+[]
+{{- end }}
+
+{{/* All Windows hosts */}}
+{{ define "fleet_label_query_10" -}}
+[]
+{{- end }}
+
+{{/* All Red Hat hosts */}}
+{{ define "fleet_label_query_11" -}}
+[]
+{{- end }}
+
+{{/* All Linux distributions */}}
+{{ define "fleet_label_query_12" -}}
+[]
+{{- end }}
+

--- a/cmd/osquery-perf/windows_11_22H2_2861.tmpl
+++ b/cmd/osquery-perf/windows_11_22H2_2861.tmpl
@@ -1,0 +1,416 @@
+{{ define "enroll" -}}
+{
+    "enroll_secret": "{{ .EnrollSecret  }}",
+    "host_details": {
+        "os_version": {
+          "build":"22621",
+          "major":"10",
+          "minor":"0",
+          "name":"Microsoft Windows 11 Pro",
+          "patch":"",
+          "platform":"windows",
+          "platform_like":"windows",
+          "version":"10.0.22621.2715"
+        },
+        "osquery_info": {
+          "build_distro": "10",
+          "build_platform": "windows",
+          "config_hash": "09d7386d20179cb1b725ed88f38c98e3b2e72c90",
+          "config_valid": "1",
+          "extensions": "inactive",
+          "instance_id": "caa2dc5b-f33f-4c57-a138-e4b96e8787cc",
+          "pid": "9072",
+          "platform_mask": "2",
+          "start_time": "1660223255",
+          "uuid": "{{ .UUID }}",
+          "version": "5.4.0",
+          "watcher": "-1"
+        },
+        "platform_info": {
+          "address": "",
+          "date": "1601-01-01",
+          "extra": "",
+          "revision": "255.255",
+          "size": "",
+          "vendor": "Microsoft Corporation",
+          "version": "139.3982.768",
+          "volume_size": ""
+        },
+        "system_info": {
+          "computer_name": "{{ .CachedString "hostname" }}",
+          "cpu_brand": "Intel(R) Core(TM) i7-8650U CPU @ 1.90GHz",
+          "cpu_logical_cores": "8",
+          "cpu_physical_cores": "4",
+          "cpu_subtype": "-1",
+          "cpu_type": "x86_64",
+          "hardware_model": "Surface Laptop 2",
+          "hardware_serial": "{{ .SerialNumber }}",
+          "hardware_vendor": "Microsoft Corporation",
+          "hardware_version": "-1",
+          "hostname": "{{ .CachedString "hostname" }}",
+          "local_hostname": "{{ .CachedString "hostname" }}",
+          "physical_memory": "17179869184",
+          "uuid": "{{ .UUID }}"
+        }
+    },
+    "host_identifier": "{{ .UUID }}",
+    "platform_type": "2"
+}
+{{- end }}
+
+{{ define "fleet_detail_query_network_interface_windows" -}}
+[
+  {
+    "address":"fe80::8cb:112d:ff51:1e5d%en0",
+    "mac":"f8:2d:88:93:56:5c"
+  }
+]
+{{- end }}
+{{ define "fleet_detail_query_os_version" -}}
+[
+  {
+    "name":"Microsoft Windows 11 Enterprise",
+    "version":"10.0.22621.2861",
+    "major":"10",
+    "minor":"0",
+    "patch":"",
+    "build":"22621",
+    "platform":"windows",
+    "platform_like":"windows",
+    "codename":"Microsoft Windows 11 Pro",
+    "arch":"x86_64",
+    "install_date":"1667847179"
+  }
+]
+{{- end }}
+{{ define "fleet_detail_query_os_version_windows" -}}
+[
+  {
+    "name":"Microsoft Windows 11 Pro",
+    "display_version":"22H2",
+    "version": "10.0.22621.2861"
+  }
+]
+{{- end }}
+{{ define "fleet_detail_query_os_windows" -}}
+[
+  {
+    "name":"Microsoft Windows 11 Pro",
+    "display_version":"22H2",
+    "platform":"windows",
+    "arch":"x86_64",
+    "kernel_version":"10.0.22621.2861",
+    "version":"10.0.22621"
+  }
+]
+{{- end }}
+{{ define "fleet_detail_query_osquery_flags" -}}
+[
+  {
+    "name":"config_refresh",
+    "value":"{{ printf "%.0f" .ConfigInterval.Seconds }}"
+  },
+  {
+    "name":"distributed_interval",
+    "value":"{{ printf "%.0f" .QueryInterval.Seconds }}"
+  },
+  {
+    "name":"logger_tls_period",
+    "value":"99999"
+  }
+]
+{{- end }}
+{{ define "fleet_detail_query_osquery_info" -}}
+[
+  {
+    "build_distro": "10",
+    "build_platform": "windows",
+    "config_hash": "09d7386d20179cb1b725ed88f38c98e3b2e72c90",
+    "config_valid": "1",
+    "extensions": "inactive",
+    "instance_id": "caa2dc5b-f33f-4c57-a138-e4b96e8787cc",
+    "pid": "9072",
+    "platform_mask": "2",
+    "start_time": "1660223255",
+    "version": "5.5.1",
+    "watcher": "-1",
+    "uuid":"{{ .UUID }}",
+    "instance_id":"{{ .UUID }}"
+  }
+]
+{{- end }}
+{{ define "fleet_detail_query_system_info" -}}
+[
+  {
+    "hostname":"{{ .CachedString "hostname" }}",
+    "computer_name": "{{ .CachedString "hostname" }}",
+    "cpu_brand": "Intel(R) Core(TM) i7-8650U CPU @ 1.90GHz",
+    "cpu_logical_cores": "8",
+    "cpu_physical_cores": "4",
+    "cpu_subtype": "-1",
+    "cpu_type": "x86_64",
+    "hardware_model": "Surface Laptop 2",
+    "hardware_serial": "{{ .SerialNumber }}",
+    "hardware_vendor": "Microsoft Corporation",
+    "hardware_version": "-1",
+    "local_hostname": "{{ .CachedString "hostname" }}",
+    "physical_memory": "17179869184",
+    "uuid":"{{ .UUID }}"
+  }
+]
+{{- end }}
+{{ define "fleet_detail_query_uptime" -}}
+[
+  {
+    "days":"0",
+    "hours":"4",
+    "minutes":"38",
+    "seconds":"11",
+    "total_seconds":"16691"
+  }
+]
+{{- end }}
+
+{{/* all hosts */}}
+{{ define "fleet_label_query_6" -}}
+[
+  {
+    "1": "1"
+  }
+]
+{{- end }}
+
+{{/* All macOS hosts */}}
+{{ define "fleet_label_query_7" -}}
+[]
+{{- end }}
+
+{{/* All Ubuntu hosts */}}
+{{ define "fleet_label_query_8" -}}
+[]
+{{- end }}
+
+{{/* All CentOS hosts */}}
+{{ define "fleet_label_query_9" -}}
+[]
+{{- end }}
+
+{{/* All Windows hosts */}}
+{{ define "fleet_label_query_10" -}}
+[
+  {
+    "1": "1"
+  }
+]
+{{- end }}
+
+{{/* All Red Hat hosts */}}
+{{ define "fleet_label_query_11" -}}
+[]
+{{- end }}
+
+{{/* All Linux distributions */}}
+{{ define "fleet_label_query_12" -}}
+[]
+{{- end }}
+
+{{ define "fleet_detail_query_windows_update_history" -}}
+[
+  {
+    "date": "1660227583",
+    "title": "Security Intelligence Update for Microsoft Defender Antivirus - KB2267602 (Version 1.373.144.0)"
+  },
+  {
+    "date": "1660227566",
+    "title": "Windows Malicious Software Removal Tool x64 - v5.104 (KB890830)"
+  },
+  {
+    "date": "1660173924",
+    "title": "2022-08 Cumulative Update for Windows 11 for x64-based Systems (KB5016629)"
+  },
+  {
+    "date": "1660169290",
+    "title": "2022-08 Security Update for Windows 11 for x64-based Systems (KB5012170)"
+  },
+  {
+    "date": "1660147454",
+    "title": "Security Intelligence Update for Microsoft Defender Antivirus - KB2267602 (Version 1.373.94.0)"
+  },
+  {
+    "date": "1660102200",
+    "title": "Security Intelligence Update for Microsoft Defender Antivirus - KB2267602 (Version 1.373.70.0)"
+  },
+  {
+    "date": "1660016612",
+    "title": "Security Intelligence Update for Microsoft Defender Antivirus - KB2267602 (Version 1.371.1673.0)"
+  },
+  {
+    "date": "1660016594",
+    "title": "Security Intelligence Update for Microsoft Defender Antivirus - KB2267602 (Version 1.371.1607.0)"
+  },
+  {
+    "date": "1659811407",
+    "title": "Security Intelligence Update for Microsoft Defender Antivirus - KB2267602 (Version 1.371.1544.0)"
+  },
+  {
+    "date": "1659713853",
+    "title": "Security Intelligence Update for Microsoft Defender Antivirus - KB2267602 (Version 1.371.1482.0)"
+  },
+  {
+    "date": "1659672608",
+    "title": "Security Intelligence Update for Microsoft Defender Antivirus - KB2267602 (Version 1.371.1459.0)"
+  },
+  {
+    "date": "1659643463",
+    "title": "Security Intelligence Update for Microsoft Defender Antivirus - KB2267602 (Version 1.371.1429.0)"
+  },
+  {
+    "date": "1659545734",
+    "title": "Security Intelligence Update for Microsoft Defender Antivirus - KB2267602 (Version 1.371.1359.0)"
+  },
+  {
+    "date": "1659498651",
+    "title": "Security Intelligence Update for Microsoft Defender Antivirus - KB2267602 (Version 1.371.1323.0)"
+  },
+  {
+    "date": "1659409977",
+    "title": "Security Intelligence Update for Microsoft Defender Antivirus - KB2267602 (Version 1.371.1261.0)"
+  },
+  {
+    "date": "1659409929",
+    "title": "Security Intelligence Update for Microsoft Defender Antivirus - KB2267602 (Version 1.371.1186.0)"
+  },
+  {
+    "date": "1659330382",
+    "title": "Security Intelligence Update for Microsoft Defender Antivirus - KB2267602 (Version 1.371.1186.0)"
+  },
+  {
+    "date": "1659330368",
+    "title": "Security Intelligence Update for Microsoft Defender Antivirus - KB2267602 (Version 1.371.1186.0)"
+  },
+  {
+    "date": "1659329478",
+    "title": "Security Intelligence Update for Microsoft Defender Antivirus - KB2267602 (Version 1.371.1089.0)"
+  },
+  {
+    "date": "1659207465",
+    "title": "Security Intelligence Update for Microsoft Defender Antivirus - KB2267602 (Version 1.371.1089.0)"
+  },
+  {
+    "date": "1659207451",
+    "title": "Security Intelligence Update for Microsoft Defender Antivirus - KB2267602 (Version 1.371.1089.0)"
+  },
+  {
+    "date": "1659121021",
+    "title": "Security Intelligence Update for Microsoft Defender Antivirus - KB2267602 (Version 1.371.1046.0)"
+  },
+  {
+    "date": "1659057815",
+    "title": "Security Intelligence Update for Microsoft Defender Antivirus - KB2267602 (Version 1.371.986.0)"
+  },
+  {
+    "date": "1658879639",
+    "title": "Security Intelligence Update for Microsoft Defender Antivirus - KB2267602 (Version 1.371.884.0)"
+  },
+  {
+    "date": "1658685407",
+    "title": "Security Intelligence Update for Microsoft Defender Antivirus - KB2267602 (Version 1.371.745.0)"
+  },
+  {
+    "date": "1658602293",
+    "title": "Security Intelligence Update for Microsoft Defender Antivirus - KB2267602 (Version 1.371.677.0)"
+  },
+  {
+    "date": "1658557946",
+    "title": "Security Intelligence Update for Microsoft Defender Antivirus - KB2267602 (Version 1.371.656.0)"
+  },
+  {
+    "date": "1658507073",
+    "title": "Security Intelligence Update for Microsoft Defender Antivirus - KB2267602 (Version 1.371.607.0)"
+  },
+  {
+    "date": "1658420173",
+    "title": "Security Intelligence Update for Microsoft Defender Antivirus - KB2267602 (Version 1.371.550.0)"
+  },
+  {
+    "date": "1658286565",
+    "title": "Security Intelligence Update for Microsoft Defender Antivirus - KB2267602 (Version 1.371.455.0)"
+  },
+  {
+    "date": "1658197038",
+    "title": "Security Intelligence Update for Microsoft Defender Antivirus - KB2267602 (Version 1.371.400.0)"
+  },
+  {
+    "date": "1658090554",
+    "title": "Security Intelligence Update for Microsoft Defender Antivirus - KB2267602 (Version 1.371.323.0)"
+  },
+  {
+    "date": "1658089986",
+    "title": "Security Intelligence Update for Microsoft Defender Antivirus - KB2267602 (Version 1.371.312.0)"
+  },
+  {
+    "date": "1658037571",
+    "title": "Security Intelligence Update for Microsoft Defender Antivirus - KB2267602 (Version 1.371.279.0)"
+  },
+  {
+    "date": "1658030188",
+    "title": "Security Intelligence Update for Microsoft Defender Antivirus - KB2267602 (Version 1.371.279.0)"
+  },
+  {
+    "date": "1658030178",
+    "title": "Security Intelligence Update for Microsoft Defender Antivirus - KB2267602 (Version 1.371.279.0)"
+  },
+  {
+    "date": "1657935991",
+    "title": "2022-07 Cumulative Update for Windows 11 for x64-based Systems (KB5015814)"
+  },
+  {
+    "date": "1657935299",
+    "title": "Security Intelligence Update for Microsoft Defender Antivirus - KB2267602 (Version 1.371.203.0)"
+  },
+  {
+    "date": "1657935289",
+    "title": "Windows Malicious Software Removal Tool x64 - v5.103 (KB890830)"
+  },
+  {
+    "date": "1657757470",
+    "title": "Security Intelligence Update for Microsoft Defender Antivirus - KB2267602 (Version 1.371.115.0)"
+  },
+  {
+    "date": "1657650109",
+    "title": "Security Intelligence Update for Microsoft Defender Antivirus - KB2267602 (Version 1.371.44.0)"
+  },
+  {
+    "date": "1657641156",
+    "title": "Security Intelligence Update for Microsoft Defender Antivirus - KB2267602 (Version 1.371.16.0)"
+  },
+  {
+    "date": "1657641137",
+    "title": "9NCBCSZSJRSB-SpotifyAB.SpotifyMusic"
+  },
+  {
+    "date": "1657557959",
+    "title": "Security Intelligence Update for Microsoft Defender Antivirus - KB2267602 (Version 1.369.1148.0)"
+  },
+  {
+    "date": "1657500736",
+    "title": "Security Intelligence Update for Microsoft Defender Antivirus - KB2267602 (Version 1.369.1114.0)"
+  },
+  {
+    "date": "1657393149",
+    "title": "Security Intelligence Update for Microsoft Defender Antivirus - KB2267602 (Version 1.369.1040.0)"
+  },
+  {
+    "date": "1657249086",
+    "title": "Security Intelligence Update for Microsoft Defender Antivirus - KB2267602 (Version 1.369.928.0)"
+  },
+  {
+    "date": "1657077995",
+    "title": "Security Intelligence Update for Microsoft Defender Antivirus - KB2267602 (Version 1.369.852.0)"
+  },
+  {
+    "date": "1656996720",
+    "title": "Security Intelligence Update for Microsoft Defender Antivirus - KB2267602 (Version 1.369.788.0)"
+  }
+]
+{{- end }}

--- a/cmd/osquery-perf/windows_11_22H2_3007.tmpl
+++ b/cmd/osquery-perf/windows_11_22H2_3007.tmpl
@@ -1,0 +1,416 @@
+{{ define "enroll" -}}
+{
+    "enroll_secret": "{{ .EnrollSecret  }}",
+    "host_details": {
+        "os_version": {
+          "build":"22621",
+          "major":"10",
+          "minor":"0",
+          "name":"Microsoft Windows 11 Enterprise",
+          "patch":"",
+          "platform":"windows",
+          "platform_like":"windows",
+          "version":"10.0.22621.3007"
+        },
+        "osquery_info": {
+          "build_distro": "10",
+          "build_platform": "windows",
+          "config_hash": "09d7386d20179cb1b725ed88f38c98e3b2e72c90",
+          "config_valid": "1",
+          "extensions": "inactive",
+          "instance_id": "caa2dc5b-f33f-4c57-a138-e4b96e8787cc",
+          "pid": "9072",
+          "platform_mask": "2",
+          "start_time": "1660223255",
+          "uuid": "{{ .UUID }}",
+          "version": "5.4.0",
+          "watcher": "-1"
+        },
+        "platform_info": {
+          "address": "",
+          "date": "1601-01-01",
+          "extra": "",
+          "revision": "255.255",
+          "size": "",
+          "vendor": "Microsoft Corporation",
+          "version": "139.3982.768",
+          "volume_size": ""
+        },
+        "system_info": {
+          "computer_name": "{{ .CachedString "hostname" }}",
+          "cpu_brand": "Intel(R) Core(TM) i7-8650U CPU @ 1.90GHz",
+          "cpu_logical_cores": "8",
+          "cpu_physical_cores": "4",
+          "cpu_subtype": "-1",
+          "cpu_type": "x86_64",
+          "hardware_model": "Surface Laptop 2",
+          "hardware_serial": "{{ .SerialNumber }}",
+          "hardware_vendor": "Microsoft Corporation",
+          "hardware_version": "-1",
+          "hostname": "{{ .CachedString "hostname" }}",
+          "local_hostname": "{{ .CachedString "hostname" }}",
+          "physical_memory": "17179869184",
+          "uuid": "{{ .UUID }}"
+        }
+    },
+    "host_identifier": "{{ .UUID }}",
+    "platform_type": "2"
+}
+{{- end }}
+
+{{ define "fleet_detail_query_network_interface_windows" -}}
+[
+  {
+    "address":"fe80::8cb:112d:ff51:1e5d%en0",
+    "mac":"f8:2d:88:93:56:5c"
+  }
+]
+{{- end }}
+{{ define "fleet_detail_query_os_version" -}}
+[
+  {
+    "name":"Microsoft Windows 11 Enterprise",
+    "version":"10.0.22621.3007",
+    "major":"10",
+    "minor":"0",
+    "patch":"",
+    "build":"22621",
+    "platform":"windows",
+    "platform_like":"windows",
+    "codename":"Microsoft Windows 11 Enterprise",
+    "arch":"x86_64",
+    "install_date":"1667847179"
+  }
+]
+{{- end }}
+{{ define "fleet_detail_query_os_version_windows" -}}
+[
+  {
+    "name":"Microsoft Windows 11 Enterprise",
+    "display_version":"22H2",
+    "version": "10.0.22621.3007"
+  }
+]
+{{- end }}
+{{ define "fleet_detail_query_os_windows" -}}
+[
+  {
+    "name":"Microsoft Windows 11 Enterprise",
+    "display_version":"22H2",
+    "platform":"windows",
+    "arch":"x86_64",
+    "kernel_version":"10.0.22621.3007",
+    "version":"10.0.22621"
+  }
+]
+{{- end }}
+{{ define "fleet_detail_query_osquery_flags" -}}
+[
+  {
+    "name":"config_refresh",
+    "value":"{{ printf "%.0f" .ConfigInterval.Seconds }}"
+  },
+  {
+    "name":"distributed_interval",
+    "value":"{{ printf "%.0f" .QueryInterval.Seconds }}"
+  },
+  {
+    "name":"logger_tls_period",
+    "value":"99999"
+  }
+]
+{{- end }}
+{{ define "fleet_detail_query_osquery_info" -}}
+[
+  {
+    "build_distro": "10",
+    "build_platform": "windows",
+    "config_hash": "09d7386d20179cb1b725ed88f38c98e3b2e72c90",
+    "config_valid": "1",
+    "extensions": "inactive",
+    "instance_id": "caa2dc5b-f33f-4c57-a138-e4b96e8787cc",
+    "pid": "9072",
+    "platform_mask": "2",
+    "start_time": "1660223255",
+    "version": "5.5.1",
+    "watcher": "-1",
+    "uuid":"{{ .UUID }}",
+    "instance_id":"{{ .UUID }}"
+  }
+]
+{{- end }}
+{{ define "fleet_detail_query_system_info" -}}
+[
+  {
+    "hostname":"{{ .CachedString "hostname" }}",
+    "computer_name": "{{ .CachedString "hostname" }}",
+    "cpu_brand": "Intel(R) Core(TM) i7-8650U CPU @ 1.90GHz",
+    "cpu_logical_cores": "8",
+    "cpu_physical_cores": "4",
+    "cpu_subtype": "-1",
+    "cpu_type": "x86_64",
+    "hardware_model": "Surface Laptop 2",
+    "hardware_serial": "{{ .SerialNumber }}",
+    "hardware_vendor": "Microsoft Corporation",
+    "hardware_version": "-1",
+    "local_hostname": "{{ .CachedString "hostname" }}",
+    "physical_memory": "17179869184",
+    "uuid":"{{ .UUID }}"
+  }
+]
+{{- end }}
+{{ define "fleet_detail_query_uptime" -}}
+[
+  {
+    "days":"0",
+    "hours":"4",
+    "minutes":"38",
+    "seconds":"11",
+    "total_seconds":"16691"
+  }
+]
+{{- end }}
+
+{{/* all hosts */}}
+{{ define "fleet_label_query_6" -}}
+[
+  {
+    "1": "1"
+  }
+]
+{{- end }}
+
+{{/* All macOS hosts */}}
+{{ define "fleet_label_query_7" -}}
+[]
+{{- end }}
+
+{{/* All Ubuntu hosts */}}
+{{ define "fleet_label_query_8" -}}
+[]
+{{- end }}
+
+{{/* All CentOS hosts */}}
+{{ define "fleet_label_query_9" -}}
+[]
+{{- end }}
+
+{{/* All Windows hosts */}}
+{{ define "fleet_label_query_10" -}}
+[
+  {
+    "1": "1"
+  }
+]
+{{- end }}
+
+{{/* All Red Hat hosts */}}
+{{ define "fleet_label_query_11" -}}
+[]
+{{- end }}
+
+{{/* All Linux distributions */}}
+{{ define "fleet_label_query_12" -}}
+[]
+{{- end }}
+
+{{ define "fleet_detail_query_windows_update_history" -}}
+[
+  {
+    "date": "1660227583",
+    "title": "Security Intelligence Update for Microsoft Defender Antivirus - KB2267602 (Version 1.373.144.0)"
+  },
+  {
+    "date": "1660227566",
+    "title": "Windows Malicious Software Removal Tool x64 - v5.104 (KB890830)"
+  },
+  {
+    "date": "1660173924",
+    "title": "2022-08 Cumulative Update for Windows 11 for x64-based Systems (KB5016629)"
+  },
+  {
+    "date": "1660169290",
+    "title": "2022-08 Security Update for Windows 11 for x64-based Systems (KB5012170)"
+  },
+  {
+    "date": "1660147454",
+    "title": "Security Intelligence Update for Microsoft Defender Antivirus - KB2267602 (Version 1.373.94.0)"
+  },
+  {
+    "date": "1660102200",
+    "title": "Security Intelligence Update for Microsoft Defender Antivirus - KB2267602 (Version 1.373.70.0)"
+  },
+  {
+    "date": "1660016612",
+    "title": "Security Intelligence Update for Microsoft Defender Antivirus - KB2267602 (Version 1.371.1673.0)"
+  },
+  {
+    "date": "1660016594",
+    "title": "Security Intelligence Update for Microsoft Defender Antivirus - KB2267602 (Version 1.371.1607.0)"
+  },
+  {
+    "date": "1659811407",
+    "title": "Security Intelligence Update for Microsoft Defender Antivirus - KB2267602 (Version 1.371.1544.0)"
+  },
+  {
+    "date": "1659713853",
+    "title": "Security Intelligence Update for Microsoft Defender Antivirus - KB2267602 (Version 1.371.1482.0)"
+  },
+  {
+    "date": "1659672608",
+    "title": "Security Intelligence Update for Microsoft Defender Antivirus - KB2267602 (Version 1.371.1459.0)"
+  },
+  {
+    "date": "1659643463",
+    "title": "Security Intelligence Update for Microsoft Defender Antivirus - KB2267602 (Version 1.371.1429.0)"
+  },
+  {
+    "date": "1659545734",
+    "title": "Security Intelligence Update for Microsoft Defender Antivirus - KB2267602 (Version 1.371.1359.0)"
+  },
+  {
+    "date": "1659498651",
+    "title": "Security Intelligence Update for Microsoft Defender Antivirus - KB2267602 (Version 1.371.1323.0)"
+  },
+  {
+    "date": "1659409977",
+    "title": "Security Intelligence Update for Microsoft Defender Antivirus - KB2267602 (Version 1.371.1261.0)"
+  },
+  {
+    "date": "1659409929",
+    "title": "Security Intelligence Update for Microsoft Defender Antivirus - KB2267602 (Version 1.371.1186.0)"
+  },
+  {
+    "date": "1659330382",
+    "title": "Security Intelligence Update for Microsoft Defender Antivirus - KB2267602 (Version 1.371.1186.0)"
+  },
+  {
+    "date": "1659330368",
+    "title": "Security Intelligence Update for Microsoft Defender Antivirus - KB2267602 (Version 1.371.1186.0)"
+  },
+  {
+    "date": "1659329478",
+    "title": "Security Intelligence Update for Microsoft Defender Antivirus - KB2267602 (Version 1.371.1089.0)"
+  },
+  {
+    "date": "1659207465",
+    "title": "Security Intelligence Update for Microsoft Defender Antivirus - KB2267602 (Version 1.371.1089.0)"
+  },
+  {
+    "date": "1659207451",
+    "title": "Security Intelligence Update for Microsoft Defender Antivirus - KB2267602 (Version 1.371.1089.0)"
+  },
+  {
+    "date": "1659121021",
+    "title": "Security Intelligence Update for Microsoft Defender Antivirus - KB2267602 (Version 1.371.1046.0)"
+  },
+  {
+    "date": "1659057815",
+    "title": "Security Intelligence Update for Microsoft Defender Antivirus - KB2267602 (Version 1.371.986.0)"
+  },
+  {
+    "date": "1658879639",
+    "title": "Security Intelligence Update for Microsoft Defender Antivirus - KB2267602 (Version 1.371.884.0)"
+  },
+  {
+    "date": "1658685407",
+    "title": "Security Intelligence Update for Microsoft Defender Antivirus - KB2267602 (Version 1.371.745.0)"
+  },
+  {
+    "date": "1658602293",
+    "title": "Security Intelligence Update for Microsoft Defender Antivirus - KB2267602 (Version 1.371.677.0)"
+  },
+  {
+    "date": "1658557946",
+    "title": "Security Intelligence Update for Microsoft Defender Antivirus - KB2267602 (Version 1.371.656.0)"
+  },
+  {
+    "date": "1658507073",
+    "title": "Security Intelligence Update for Microsoft Defender Antivirus - KB2267602 (Version 1.371.607.0)"
+  },
+  {
+    "date": "1658420173",
+    "title": "Security Intelligence Update for Microsoft Defender Antivirus - KB2267602 (Version 1.371.550.0)"
+  },
+  {
+    "date": "1658286565",
+    "title": "Security Intelligence Update for Microsoft Defender Antivirus - KB2267602 (Version 1.371.455.0)"
+  },
+  {
+    "date": "1658197038",
+    "title": "Security Intelligence Update for Microsoft Defender Antivirus - KB2267602 (Version 1.371.400.0)"
+  },
+  {
+    "date": "1658090554",
+    "title": "Security Intelligence Update for Microsoft Defender Antivirus - KB2267602 (Version 1.371.323.0)"
+  },
+  {
+    "date": "1658089986",
+    "title": "Security Intelligence Update for Microsoft Defender Antivirus - KB2267602 (Version 1.371.312.0)"
+  },
+  {
+    "date": "1658037571",
+    "title": "Security Intelligence Update for Microsoft Defender Antivirus - KB2267602 (Version 1.371.279.0)"
+  },
+  {
+    "date": "1658030188",
+    "title": "Security Intelligence Update for Microsoft Defender Antivirus - KB2267602 (Version 1.371.279.0)"
+  },
+  {
+    "date": "1658030178",
+    "title": "Security Intelligence Update for Microsoft Defender Antivirus - KB2267602 (Version 1.371.279.0)"
+  },
+  {
+    "date": "1657935991",
+    "title": "2022-07 Cumulative Update for Windows 11 for x64-based Systems (KB5015814)"
+  },
+  {
+    "date": "1657935299",
+    "title": "Security Intelligence Update for Microsoft Defender Antivirus - KB2267602 (Version 1.371.203.0)"
+  },
+  {
+    "date": "1657935289",
+    "title": "Windows Malicious Software Removal Tool x64 - v5.103 (KB890830)"
+  },
+  {
+    "date": "1657757470",
+    "title": "Security Intelligence Update for Microsoft Defender Antivirus - KB2267602 (Version 1.371.115.0)"
+  },
+  {
+    "date": "1657650109",
+    "title": "Security Intelligence Update for Microsoft Defender Antivirus - KB2267602 (Version 1.371.44.0)"
+  },
+  {
+    "date": "1657641156",
+    "title": "Security Intelligence Update for Microsoft Defender Antivirus - KB2267602 (Version 1.371.16.0)"
+  },
+  {
+    "date": "1657641137",
+    "title": "9NCBCSZSJRSB-SpotifyAB.SpotifyMusic"
+  },
+  {
+    "date": "1657557959",
+    "title": "Security Intelligence Update for Microsoft Defender Antivirus - KB2267602 (Version 1.369.1148.0)"
+  },
+  {
+    "date": "1657500736",
+    "title": "Security Intelligence Update for Microsoft Defender Antivirus - KB2267602 (Version 1.369.1114.0)"
+  },
+  {
+    "date": "1657393149",
+    "title": "Security Intelligence Update for Microsoft Defender Antivirus - KB2267602 (Version 1.369.1040.0)"
+  },
+  {
+    "date": "1657249086",
+    "title": "Security Intelligence Update for Microsoft Defender Antivirus - KB2267602 (Version 1.369.928.0)"
+  },
+  {
+    "date": "1657077995",
+    "title": "Security Intelligence Update for Microsoft Defender Antivirus - KB2267602 (Version 1.369.852.0)"
+  },
+  {
+    "date": "1656996720",
+    "title": "Security Intelligence Update for Microsoft Defender Antivirus - KB2267602 (Version 1.369.788.0)"
+  }
+]
+{{- end }}


### PR DESCRIPTION
Adding OS Support for: 
- macOS 14.1.2 (new default)
- macOS 13.6.2
- Windows 11 22H2 2861
- Windows 11 22H2 3007 

Helping to test: #16356 