### PR TITLE
16356 Unreleased bugfix for osversions filter

### DIFF
--- a/server/datastore/mysql/hosts.go
+++ b/server/datastore/mysql/hosts.go
@@ -4415,27 +4415,14 @@ WHERE
 		}
 	}
 
-	// filter counts by platform
-	if platform != nil {
-		var filtered []fleet.OSVersion
-		for _, os := range counts {
-			if *platform == os.Platform {
-				filtered = append(filtered, os)
-			}
+	// filter by platform, name, and version
+	var filtered []fleet.OSVersion
+	for _, os := range counts {
+		if (platform == nil || *platform == os.Platform) && (name == nil || version == nil || (*name == os.NameOnly && *version == os.Version)) {
+			filtered = append(filtered, os)
 		}
-		counts = filtered
 	}
-
-	// filter by name and version
-	if name != nil && version != nil {
-		var filtered []fleet.OSVersion
-		for _, os := range counts {
-			if *name == os.NameOnly && *version == os.Version {
-				filtered = append(filtered, os)
-			}
-		}
-		counts = filtered
-	}
+	counts = filtered
 
 	// aggregate counts by name and version
 	byNameVers := make(map[string]fleet.OSVersion)

--- a/server/datastore/mysql/hosts.go
+++ b/server/datastore/mysql/hosts.go
@@ -4426,15 +4426,20 @@ WHERE
 		counts = filtered
 	}
 
+	// filter by name and version
+	if name != nil && version != nil {
+		var filtered []fleet.OSVersion
+		for _, os := range counts {
+			if *name == os.NameOnly && *version == os.Version {
+				filtered = append(filtered, os)
+			}
+		}
+		counts = filtered
+	}
+
 	// aggregate counts by name and version
 	byNameVers := make(map[string]fleet.OSVersion)
 	for _, os := range counts {
-		if name != nil &&
-			version != nil &&
-			*name != os.NameOnly &&
-			*version != os.Version {
-			continue
-		}
 		key := fmt.Sprintf("%s %s", os.NameOnly, os.Version)
 		val, ok := byNameVers[key]
 		if !ok {

--- a/server/datastore/mysql/hosts_test.go
+++ b/server/datastore/mysql/hosts_test.go
@@ -6087,6 +6087,14 @@ func testOSVersions(t *testing.T, ds *Datastore) {
 	}
 	require.Equal(t, expected, osVersions.OSVersions)
 
+	// filter by operating system that has multiple versions
+	expected = []fleet.OSVersion{
+		{HostsCount: 3, Name: "macOS 12.3.0", NameOnly: "macOS", Version: "12.3.0", Platform: "darwin"},
+	}
+	osVersions, err = ds.OSVersions(ctx, nil, nil, ptr.String("macOS"), ptr.String("12.3.0"))
+	require.NoError(t, err)
+	require.Equal(t, expected, osVersions.OSVersions)
+
 	// team 1
 	osVersions, err = ds.OSVersions(ctx, &team1.ID, nil, nil, nil)
 	require.NoError(t, err)

--- a/server/service/integration_core_test.go
+++ b/server/service/integration_core_test.go
@@ -7391,7 +7391,6 @@ func (s *integrationTestSuite) TestOSVersions() {
 	// get OS versions
 	osv, err := s.ds.ListOperatingSystems(context.Background())
 	require.NoError(t, err)
-	require.Len(t, osv, 6) // includes fooOS from another test
 
 	osvMap := make(map[string]fleet.OperatingSystem)
 	for _, os := range osv {
@@ -7455,6 +7454,12 @@ func (s *integrationTestSuite) TestOSVersions() {
 			},
 		},
 	}, osVersionsResp.OSVersions[0])
+
+	// name and version filters
+	s.DoJSON("GET", "/api/latest/fleet/os_versions", nil, http.StatusOK, &osVersionsResp, "os_name", "Windows 11 Pro 21H2", "os_version", "10.0.22000.2")
+	require.Len(t, osVersionsResp.OSVersions, 1)
+	require.Equal(t, "Windows 11 Pro 21H2 10.0.22000.2", osVersionsResp.OSVersions[0].Name)
+	require.Len(t, osVersionsResp.OSVersions[0].Vulnerabilities, 2)
 
 	// name without version
 	s.DoJSON("GET", "/api/latest/fleet/os_versions", nil, http.StatusBadRequest, &osVersionsResp, "os_name", "Windows 11 Pro 21H2")

--- a/server/vulnerabilities/msrc/analyzer.go
+++ b/server/vulnerabilities/msrc/analyzer.go
@@ -138,10 +138,8 @@ func patched(
 		}
 
 		isGreater, err := winBuildVersionGreaterOrEqual(fix.FixedBuild, os.KernelVersion)
-		if err != nil {
-			continue
-		}
-		if isGreater {
+		// Return true on errors to prevent false positives
+		if err != nil || isGreater {
 			return true
 		}
 	}


### PR DESCRIPTION
#16356 Unreleased Bugs

- fixed and separated out name/version filter from aggregation for maintainability

Unrelated:
- fixed false positives when Windows CVE matching expected a different product version number