### PR TITLE
UI – negate global form field width for host page filters; help text update

### DIFF
--- a/frontend/pages/admin/IntegrationsPage/cards/AutomaticEnrollment/components/EditTeamModal/EditTeamModal.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/AutomaticEnrollment/components/EditTeamModal/EditTeamModal.tsx
@@ -67,11 +67,8 @@ const EditTeamModal = ({
             onChange={setSelectedTeam}
             value={selectedTeam}
             label="Team"
+            helpText="macOS hosts will be added to this team when they're first unboxed."
           />
-          <p>
-            macOS hosts will be added to this team when they&apos;re first
-            unboxed.
-          </p>
         </div>
         <div className="modal-cta-wrap">
           <Button type="submit" variant="brand" isLoading={isLoading}>

--- a/frontend/pages/hosts/ManageHostsPage/components/HostsFilterBlock/HostsFilterBlock.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/components/HostsFilterBlock/HostsFilterBlock.tsx
@@ -498,7 +498,6 @@ const HostsFilterBlock = ({
         case !!lowDiskSpaceHosts:
           return renderLowDiskSpaceFilterBlock();
         case !!osSettingsStatus:
-          console.log("renderOsSettingsBlock");
           return renderOsSettingsBlock();
         case !!diskEncryptionStatus:
           return renderDiskEncryptionStatusBlock();

--- a/frontend/pages/hosts/ManageHostsPage/components/HostsFilterBlock/_styles.scss
+++ b/frontend/pages/hosts/ManageHostsPage/components/HostsFilterBlock/_styles.scss
@@ -12,12 +12,6 @@
     }
   }
 
-  // NOTE: can probably be removed and placed anytime we have a dropdown. Need to
-  // go through other filter dropdowns and see if thats the case
-  &__policies-filter-pill {
-    margin-left: $pad-medium;
-  }
-
   // NOTE: Look more into this styling
   &__os_settings-dropdown,
   &__macsettings-dropdown {

--- a/frontend/pages/hosts/ManageHostsPage/components/HostsFilterBlock/_styles.scss
+++ b/frontend/pages/hosts/ManageHostsPage/components/HostsFilterBlock/_styles.scss
@@ -4,6 +4,12 @@
     align-items: center;
     margin-bottom: $pad-small;
     gap: $pad-small; // between multiple filter pills
+
+    .form-field {
+      // negate global .form-field {width: 100%} for use of Dropdown
+      // and other "form-fields" in the filter block
+      width: initial;
+    }
   }
 
   // NOTE: can probably be removed and placed anytime we have a dropdown. Need to


### PR DESCRIPTION
## Follow-up to #16159 - part of form field spot checks

- Negate `.form-field {width: 100%}` for `.form-field`s used within the manage hosts page filter block

<img width="1276" alt="Screenshot 2024-01-26 at 6 10 58 PM" src="https://github.com/fleetdm/fleet/assets/61553566/da0b4de0-6131-4e84-adca-86d48c1335f3">
<img width="1276" alt="Screenshot 2024-01-26 at 6 10 01 PM" src="https://github.com/fleetdm/fleet/assets/61553566/9076a04f-946f-461a-b279-1efba26e7caf">
<img width="1276" alt="Screenshot 2024-01-26 at 6 50 40 PM" src="https://github.com/fleetdm/fleet/assets/61553566/0faa4329-727b-4031-8d1a-2259487ce957">


Follow form field help text pattern in edit team modal
<img width="654" alt="Screenshot 2024-01-26 at 4 50 58 PM" src="https://github.com/fleetdm/fleet/assets/61553566/fbd8b736-cabf-468e-8270-3d1f3257d905">
# Checklist for submitter

- [x] Manual QA for all new/changed functionality
