### PR TITLE
Fleet UI: Platform compatibility checker hides unsupported osquery tables

### DIFF
--- a/changes/16435-platform-compatibility-fix
+++ b/changes/16435-platform-compatibility-fix
@@ -1,0 +1,1 @@
+- Platform compatibility checker hides deprecated osquery tables from being checked

--- a/frontend/utilities/osquery_tables.ts
+++ b/frontend/utilities/osquery_tables.ts
@@ -13,6 +13,11 @@ export const osqueryTables = queryTable.sort((a, b) => {
 });
 
 // Note: Hiding tables where key hidden is set to true
+export const osqueryTablesAvailable = osqueryTables.filter(
+  (table) => !table.hidden
+);
+
+// Note: Hiding tables where key hidden is set to true
 export const osqueryTableNames = flatMap(osqueryTables, (table) => {
   return table.hidden ? [] : table.name;
 });

--- a/frontend/utilities/sql_tools.ts
+++ b/frontend/utilities/sql_tools.ts
@@ -1,7 +1,7 @@
 // @ts-ignore
 import sqliteParser from "sqlite-parser";
 import { intersection, isPlainObject } from "lodash";
-import { osqueryTables } from "utilities/osquery_tables";
+import { osqueryTablesAvailable } from "utilities/osquery_tables";
 import {
   OsqueryPlatform,
   MACADMINS_EXTENSION_TABLES,
@@ -18,10 +18,10 @@ interface IOsqueryTable {
   platforms: OsqueryPlatform[];
 }
 
-type IPlatformDictionay = Record<string, OsqueryPlatform[]>;
+type IPlatformDictionary = Record<string, OsqueryPlatform[]>;
 
-const platformsByTableDictionary: IPlatformDictionay = (osqueryTables as IOsqueryTable[]).reduce(
-  (dictionary: IPlatformDictionay, osqueryTable) => {
+const platformsByTableDictionary: IPlatformDictionary = (osqueryTablesAvailable as IOsqueryTable[]).reduce(
+  (dictionary: IPlatformDictionary, osqueryTable) => {
     dictionary[osqueryTable.name] = osqueryTable.platforms;
     return dictionary;
   },


### PR DESCRIPTION
## Issue
Cerra #16204 

## Description
- Like the website, platform compatibility checker uses hidden key to hide platforms that are no longer supported
- Fixes 4 platforms were not being hidden on the compatibility checker

## Screenshot of atom_packages hidden
<img width="948" alt="Screenshot 2024-01-29 at 5 08 55 PM" src="https://github.com/fleetdm/fleet/assets/71795832/605190cb-6b35-4272-971a-94242013fa31">


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
- [x] Manual QA for all new/changed functionality
