### PR TITLE
Fleet UI: Update os version detail page to use os_version_id in URL and call API

### DIFF
--- a/frontend/__mocks__/operatingSystemsMock.ts
+++ b/frontend/__mocks__/operatingSystemsMock.ts
@@ -3,6 +3,7 @@ import { IOSVersionsResponse } from "services/entities/operating_systems";
 import { createMockSoftwareVulnerability } from "./softwareMock";
 
 const DEFAULT_OS_VERSION: IOperatingSystemVersion = {
+  os_version_id: 1,
   name: "Mac OS X",
   name_only: "Mac OS X",
   version: "10.15.7",

--- a/frontend/components/TableContainer/TableContainer.tsx
+++ b/frontend/components/TableContainer/TableContainer.tsx
@@ -29,8 +29,7 @@ export interface ITableQueryData {
 interface IRowProps extends Row {
   original: {
     id?: number;
-    name_only?: string; // Required for onSelectSingleRow of SoftwareOSTable.tsx
-    version?: string; // Required for onSelectSingleRow of SoftwareOSTable.tsx
+    os_version_id?: string; // Required for onSelectSingleRow of SoftwareOSTable.tsx
   };
 }
 

--- a/frontend/interfaces/operating_system.ts
+++ b/frontend/interfaces/operating_system.ts
@@ -1,6 +1,7 @@
 import { ISoftwareVulnerability } from "./software";
 
 export interface IOperatingSystemVersion {
+  os_version_id: number;
   name: string;
   name_only: string;
   version: string;

--- a/frontend/pages/DashboardPage/cards/OperatingSystems/OperatingSystemsTableConfig.tsx
+++ b/frontend/pages/DashboardPage/cards/OperatingSystems/OperatingSystemsTableConfig.tsx
@@ -129,7 +129,7 @@ const generateDefaultTableHeaders = (
     disableSortBy: false,
     accessor: "hosts_count",
     Cell: (cellProps: INumberCellProps): JSX.Element => {
-      const { hosts_count, name_only, version } = cellProps.row.original;
+      const { hosts_count, os_version_id } = cellProps.row.original;
       return (
         <span className="hosts-cell__wrapper">
           <span className="hosts-cell__count">
@@ -138,8 +138,7 @@ const generateDefaultTableHeaders = (
           <span className="hosts-cell__link">
             <ViewAllHostsLink
               queryParams={{
-                os_name: name_only,
-                os_version: version,
+                os_version_id,
                 team_id: teamId,
               }}
               className="os-hosts-link"

--- a/frontend/pages/DashboardPage/cards/OperatingSystems/OperatingSystemsTableConfig.tsx
+++ b/frontend/pages/DashboardPage/cards/OperatingSystems/OperatingSystemsTableConfig.tsx
@@ -76,19 +76,17 @@ const generateDefaultTableHeaders = (
         );
       }
 
-      const { name, name_only, version } = cellProps.row.original;
-      console.log("cellProps.row.original", cellProps.row.original);
-      console.log("name_only, version", name_only, version);
+      const { name, os_version_id } = cellProps.row.original;
       const onClickSoftware = (e: React.MouseEvent) => {
         // Allows for button to be clickable in a clickable row
         e.stopPropagation();
 
-        router?.push(PATHS.SOFTWARE_OS_DETAILS(name_only, version));
+        router?.push(PATHS.SOFTWARE_OS_DETAILS(os_version_id));
       };
 
       return (
         <LinkCell
-          path={PATHS.SOFTWARE_OS_DETAILS(name_only, version)}
+          path={PATHS.SOFTWARE_OS_DETAILS(os_version_id)}
           customOnClick={onClickSoftware}
           value={
             <>

--- a/frontend/pages/SoftwarePage/SoftwareOS/SoftwareOSTable/SoftwareOSTable.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareOS/SoftwareOSTable/SoftwareOSTable.tsx
@@ -23,8 +23,7 @@ const baseClass = "software-os-table";
 
 interface IRowProps extends Row {
   original: {
-    version?: string;
-    name_only?: string;
+    os_version_id?: string;
   };
 }
 
@@ -116,8 +115,7 @@ const SoftwareOSTable = ({
 
   const handleRowSelect = (row: IRowProps) => {
     const hostsBySoftwareParams = {
-      os_version: row.original.version,
-      os_name: row.original.name_only,
+      os_version_id: row.original.os_version_id,
       team_id: teamId,
     };
 

--- a/frontend/pages/SoftwarePage/SoftwareOSDetailsPage/SoftwareOSDetailsPage.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareOSDetailsPage/SoftwareOSDetailsPage.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { useQuery } from "react-query";
-import { Params } from "react-router/lib/Router";
+import { RouteComponentProps } from "react-router/lib/Router";
 
 import osVersionsAPI, {
   IOSVersionResponse,
@@ -38,14 +38,19 @@ const NotSupportedVuln = ({ platform }: INotSupportedVulnProps) => {
   );
 };
 
-interface ISoftwareOSDetailsPageProps {
-  params: Params;
+interface ISoftwareOSDetailsRouteParams {
+  id: string;
 }
 
+type ISoftwareOSDetailsPageProps = RouteComponentProps<
+  undefined,
+  ISoftwareOSDetailsRouteParams
+>;
+
 const SoftwareOSDetailsPage = ({
-  params: { os_version_id },
+  routeParams,
 }: ISoftwareOSDetailsPageProps) => {
-  const osVersionIdFromURL = parseInt(os_version_id, 10);
+  const osVersionIdFromURL = parseInt(routeParams.id, 10);
 
   const { data: osVersionDetails, isLoading, isError } = useQuery<
     IOSVersionResponse,
@@ -55,6 +60,7 @@ const SoftwareOSDetailsPage = ({
     ["osVersionDetails", osVersionIdFromURL],
     () => osVersionsAPI.getOSVersion(osVersionIdFromURL),
     {
+      enabled: !!osVersionIdFromURL,
       select: (data) => data.os_version,
     }
   );

--- a/frontend/pages/SoftwarePage/SoftwareOSDetailsPage/SoftwareOSDetailsPage.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareOSDetailsPage/SoftwareOSDetailsPage.tsx
@@ -1,8 +1,9 @@
 import React from "react";
 import { useQuery } from "react-query";
+import { Params } from "react-router/lib/Router";
 
 import osVersionsAPI, {
-  IOSVersionsResponse,
+  IOSVersionResponse,
 } from "services/entities/operating_systems";
 import { IOperatingSystemVersion } from "interfaces/operating_system";
 import { SUPPORT_LINK } from "utilities/constants";
@@ -38,22 +39,23 @@ const NotSupportedVuln = ({ platform }: INotSupportedVulnProps) => {
 };
 
 interface ISoftwareOSDetailsPageProps {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  location: { query: { name: string; version: string } }; // no type in react-router v3
+  params: Params;
 }
 
-const SoftwareOSDetailsPage = ({ location }: ISoftwareOSDetailsPageProps) => {
-  const name = location.query.name;
-  const osVersion = location.query.version;
+const SoftwareOSDetailsPage = ({
+  params: { os_version_id },
+}: ISoftwareOSDetailsPageProps) => {
+  const osVersionIdFromURL = parseInt(os_version_id, 10);
+
   const { data: osVersionDetails, isLoading, isError } = useQuery<
-    IOSVersionsResponse,
+    IOSVersionResponse,
     Error,
     IOperatingSystemVersion
   >(
-    ["osVersionDetails", name, osVersion],
-    () => osVersionsAPI.getOSVersion({ os_name: name, os_version: osVersion }),
+    ["osVersionDetails", osVersionIdFromURL],
+    () => osVersionsAPI.getOSVersion(osVersionIdFromURL),
     {
-      select: (res) => res.os_versions[0],
+      select: (data) => data.os_version,
     }
   );
 

--- a/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
@@ -236,7 +236,11 @@ const ManageHostsPage = ({
       ? parseInt(queryParams.mdm_id, 10)
       : undefined;
   const mdmEnrollmentStatus = queryParams?.mdm_enrollment_status;
-  const { os_id: osId, os_name: osName, os_version: osVersion } = queryParams;
+  const {
+    os_version_id: osVersionId,
+    os_name: osName,
+    os_version: osVersion,
+  } = queryParams;
   const munkiIssueId =
     queryParams?.munki_issue_id !== undefined
       ? parseInt(queryParams.munki_issue_id, 10)
@@ -342,7 +346,7 @@ const ManageHostsPage = ({
   >([{ scope: "os_versions" }], () => getOSVersions(), {
     enabled:
       isRouteOk &&
-      (!!queryParams?.os_id ||
+      (!!queryParams?.os_version_id ||
         (!!queryParams?.os_name && !!queryParams?.os_version)),
     keepPreviousData: true,
     select: (data) => data.os_versions,
@@ -376,7 +380,7 @@ const ManageHostsPage = ({
         mdmEnrollmentStatus,
         munkiIssueId,
         lowDiskSpaceHosts,
-        osId,
+        osVersionId,
         osName,
         osVersion,
         page: tableQueryData ? tableQueryData.pageIndex : 0,
@@ -418,7 +422,7 @@ const ManageHostsPage = ({
         mdmEnrollmentStatus,
         munkiIssueId,
         lowDiskSpaceHosts,
-        osId,
+        osVersionId,
         osName,
         osVersion,
         osSettings: osSettingsStatus,
@@ -824,8 +828,8 @@ const ManageHostsPage = ({
       } else if (lowDiskSpaceHosts && isPremiumTier) {
         // Premium feature only
         newQueryParams.low_disk_space = lowDiskSpaceHosts;
-      } else if (osId || (osName && osVersion)) {
-        newQueryParams.os_id = osId;
+      } else if (osVersionId || (osName && osVersion)) {
+        newQueryParams.os_version_id = osVersionId;
         newQueryParams.os_name = osName;
         newQueryParams.os_version = osVersion;
       } else if (osSettingsStatus) {
@@ -865,7 +869,7 @@ const ManageHostsPage = ({
       missingHosts,
       lowDiskSpaceHosts,
       isPremiumTier,
-      osId,
+      osVersionId,
       osName,
       osVersion,
       page,
@@ -1282,7 +1286,7 @@ const ManageHostsPage = ({
       mdmEnrollmentStatus,
       munkiIssueId,
       lowDiskSpaceHosts,
-      os_id: osId,
+      os_version_id: osVersionId,
       os_name: osName,
       os_version: osVersion,
       visibleColumns,
@@ -1595,7 +1599,7 @@ const ManageHostsPage = ({
               mdmId,
               mdmEnrollmentStatus,
               lowDiskSpaceHosts,
-              osId,
+              osVersionId,
               osName,
               osVersion,
               osVersions,

--- a/frontend/pages/hosts/ManageHostsPage/components/HostsFilterBlock/HostsFilterBlock.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/components/HostsFilterBlock/HostsFilterBlock.tsx
@@ -200,326 +200,326 @@ const HostsFilterBlock = ({
         />
       );
     }
+  };
 
-    // NOTE: good example of filter dropdown with pill
-    const renderPoliciesFilterBlock = () => (
+  // NOTE: good example of filter dropdown with pill
+  const renderPoliciesFilterBlock = () => (
+    <>
+      <PoliciesFilter
+        policyResponse={policyResponse}
+        onChange={onChangePoliciesFilter}
+      />
+      <FilterPill
+        icon="policy"
+        label={policy?.name ?? "..."}
+        onClear={() => handleClearFilter(["policy_id", "policy_response"])}
+        className={`${baseClass}__policies-filter-pill`}
+      />
+    </>
+  );
+
+  const renderMacSettingsStatusFilterBlock = () => {
+    const label = "macOS settings";
+    return (
       <>
-        <PoliciesFilter
-          policyResponse={policyResponse}
-          onChange={onChangePoliciesFilter}
+        <Dropdown
+          value={macSettingsStatus}
+          className={`${baseClass}__macsettings-dropdown`}
+          options={OS_SETTINGS_FILTER_OPTIONS}
+          onChange={onChangeMacSettingsFilter}
         />
         <FilterPill
-          icon="policy"
-          label={policy?.name ?? "..."}
-          onClear={() => handleClearFilter(["policy_id", "policy_response"])}
-          className={`${baseClass}__policies-filter-pill`}
+          label={label}
+          onClear={() => handleClearFilter(["macos_settings"])}
         />
       </>
     );
+  };
 
-    const renderMacSettingsStatusFilterBlock = () => {
-      const label = "macOS settings";
-      return (
-        <>
-          <Dropdown
-            value={macSettingsStatus}
-            className={`${baseClass}__macsettings-dropdown`}
-            options={OS_SETTINGS_FILTER_OPTIONS}
-            onChange={onChangeMacSettingsFilter}
-          />
-          <FilterPill
-            label={label}
-            onClear={() => handleClearFilter(["macos_settings"])}
-          />
-        </>
-      );
-    };
+  const renderSoftwareFilterBlock = () => {
+    if (!softwareDetails) return null;
 
-    const renderSoftwareFilterBlock = () => {
-      if (!softwareDetails) return null;
+    const { name, version } = softwareDetails;
+    let label = name;
+    if (version) {
+      label += ` ${version}`;
+    }
+    label = label.trim() || "Unknown software";
 
-      const { name, version } = softwareDetails;
-      let label = name;
-      if (version) {
-        label += ` ${version}`;
-      }
-      label = label.trim() || "Unknown software";
+    // const TooltipDescription = (
+    //   <span>
+    //     Hosts with {name || "Unknown software"},
+    //     <br />
+    //     {version || "version unknown"} installed
+    //   </span>
+    // );
 
-      // const TooltipDescription = (
-      //   <span>
-      //     Hosts with {name || "Unknown software"},
-      //     <br />
-      //     {version || "version unknown"} installed
-      //   </span>
-      // );
-
-      return (
-        <FilterPill
-          label={label}
-          onClear={() =>
-            handleClearFilter([
-              "software_id",
-              "software_version_id",
-              "software_title_id",
-            ])
-          }
-          // tooltipDescription={TooltipDescription}
-        />
-      );
-    };
-
-    const renderMDMSolutionFilterBlock = () => {
-      if (!mdmSolutionDetails) return null;
-
-      const { name, server_url } = mdmSolutionDetails;
-      const label = name ? `${name} ${server_url}` : `${server_url}`;
-
-      const TooltipDescription = (
-        <span>
-          Host enrolled
-          {name !== "Unknown" && ` to ${name}`}
-          <br /> at {server_url}
-        </span>
-      );
-
-      return (
-        <FilterPill
-          label={label}
-          tooltipDescription={TooltipDescription}
-          onClear={() => handleClearFilter(["mdm_id"])}
-        />
-      );
-    };
-
-    const renderMDMEnrollmentFilterBlock = () => {
-      if (!mdmEnrollmentStatus) return null;
-
-      const label = `MDM status: ${
-        invert(MDM_ENROLLMENT_STATUS)[mdmEnrollmentStatus]
-      }`;
-
-      // More narrow tooltip than other MDM tooltip
-      const MDM_STATUS_PILL_TOOLTIP: Record<string, JSX.Element> = {
-        automatic: (
-          <span>
-            MDM was turned on <br />
-            automatically using Apple <br />
-            Automated Device <br />
-            Enrollment (DEP), <br />
-            Windows Autopilot, or <br />
-            Windows Azure AD Join. <br />
-            Administrators can block <br />
-            device users from turning
-            <br /> MDM off.
-          </span>
-        ),
-        manual: (
-          <span>
-            MDM was turned on <br />
-            manually. Device users <br />
-            can turn MDM off.
-          </span>
-        ),
-        unenrolled: (
-          <span>
-            Hosts with MDM off <br />
-            don&apos;t receive macOS <br />
-            settings and macOS <br />
-            update encouragement.
-          </span>
-        ),
-        pending: (
-          <span>
-            Hosts ordered using Apple <br />
-            Business Manager (ABM). <br />
-            They will automatically enroll <br />
-            to Fleet and turn on MDM <br />
-            when they&apos;re unboxed.
-          </span>
-        ),
-      };
-
-      return (
-        <FilterPill
-          label={label}
-          tooltipDescription={MDM_STATUS_PILL_TOOLTIP[mdmEnrollmentStatus]}
-          onClear={() => handleClearFilter(["mdm_enrollment_status"])}
-        />
-      );
-    };
-
-    const renderMunkiIssueFilterBlock = () => {
-      if (munkiIssueDetails) {
-        return (
-          <FilterPill
-            label={munkiIssueDetails.name}
-            tooltipDescription={
-              <span>
-                Hosts that reported this Munki issue <br />
-                the last time Munki ran on each host.
-              </span>
-            }
-            onClear={() => handleClearFilter(["munki_issue_id"])}
-          />
-        );
-      }
-      return null;
-    };
-
-    const renderLowDiskSpaceFilterBlock = () => {
-      const TooltipDescription = (
-        <span>
-          Hosts that have {lowDiskSpaceHosts} GB or less <br />
-          disk space available.
-        </span>
-      );
-
-      return (
-        <FilterPill
-          label="Low disk space"
-          tooltipDescription={TooltipDescription}
-          premiumFeatureTooltipDelayHide={1000}
-          onClear={() => handleClearFilter(["low_disk_space"])}
-          isSandboxMode={isSandboxMode}
-          sandboxPremiumOnlyIcon
-        />
-      );
-    };
-
-    const renderOsSettingsBlock = () => {
-      const label = "OS settings";
-      return (
-        <>
-          <Dropdown
-            value={osSettingsStatus}
-            className={`${baseClass}__os_settings-dropdown`}
-            options={OS_SETTINGS_FILTER_OPTIONS}
-            onChange={onChangeOsSettingsFilter}
-          />
-          <FilterPill
-            label={label}
-            onClear={() => handleClearFilter([HOSTS_QUERY_PARAMS.OS_SETTINGS])}
-          />
-        </>
-      );
-    };
-
-    const renderDiskEncryptionStatusBlock = () => {
-      if (!diskEncryptionStatus) return null;
-
-      return (
-        <>
-          <DiskEncryptionStatusFilter
-            diskEncryptionStatus={diskEncryptionStatus}
-            onChange={onChangeDiskEncryptionStatusFilter}
-          />
-          <FilterPill
-            label="OS settings: Disk encryption"
-            onClear={() =>
-              handleClearFilter([HOSTS_QUERY_PARAMS.DISK_ENCRYPTION])
-            }
-          />
-        </>
-      );
-    };
-
-    const renderBootstrapPackageStatusBlock = () => {
-      if (!bootstrapPackageStatus) return null;
-
-      return (
-        <>
-          <BootstrapPackageStatusFilter
-            bootstrapPackageStatus={bootstrapPackageStatus}
-            onChange={onChangeBootstrapPackageStatusFilter}
-          />
-          <FilterPill
-            label="macOS settings: bootstrap package"
-            onClear={() => handleClearFilter(["bootstrap_package"])}
-          />
-        </>
-      );
-    };
-
-    const showSelectedLabel = selectedLabel && selectedLabel.type !== "all";
-
-    if (
-      showSelectedLabel ||
-      policyId ||
-      macSettingsStatus ||
-      softwareId ||
-      softwareTitleId ||
-      softwareVersionId ||
-      mdmId ||
-      mdmEnrollmentStatus ||
-      lowDiskSpaceHosts ||
-      osVersionId ||
-      (osName && osVersion) ||
-      munkiIssueId ||
-      osSettingsStatus ||
-      diskEncryptionStatus ||
-      bootstrapPackageStatus
-    ) {
-      const renderFilterPill = () => {
-        switch (true) {
-          // backend allows for pill combos (label + low disk space) OR
-          // (label + mdm solution) OR (label + mdm enrollment status)
-          case showSelectedLabel && !!lowDiskSpaceHosts:
-            return (
-              <>
-                {renderLabelFilterPill()} {renderLowDiskSpaceFilterBlock()}
-              </>
-            );
-          case showSelectedLabel && !!mdmId:
-            return (
-              <>
-                {renderLabelFilterPill()} {renderMDMSolutionFilterBlock()}
-              </>
-            );
-
-          case showSelectedLabel && !!mdmEnrollmentStatus:
-            return (
-              <>
-                {renderLabelFilterPill()} {renderMDMEnrollmentFilterBlock()}
-              </>
-            );
-          case showSelectedLabel:
-            return renderLabelFilterPill();
-          case !!policyId:
-            return renderPoliciesFilterBlock();
-          case !!macSettingsStatus:
-            return renderMacSettingsStatusFilterBlock();
-          case !!softwareId || !!softwareVersionId || !!softwareTitleId:
-            return renderSoftwareFilterBlock();
-          case !!mdmId:
-            return renderMDMSolutionFilterBlock();
-          case !!mdmEnrollmentStatus:
-            return renderMDMEnrollmentFilterBlock();
-          case !!osVersionId || (!!osName && !!osVersion):
-            return renderOSFilterBlock();
-          case !!munkiIssueId:
-            return renderMunkiIssueFilterBlock();
-          case !!lowDiskSpaceHosts:
-            return renderLowDiskSpaceFilterBlock();
-          case !!osSettingsStatus:
-            return renderOsSettingsBlock();
-          case !!diskEncryptionStatus:
-            return renderDiskEncryptionStatusBlock();
-          case !!bootstrapPackageStatus:
-            return renderBootstrapPackageStatusBlock();
-          default:
-            return null;
+    return (
+      <FilterPill
+        label={label}
+        onClear={() =>
+          handleClearFilter([
+            "software_id",
+            "software_version_id",
+            "software_title_id",
+          ])
         }
-      };
+        // tooltipDescription={TooltipDescription}
+      />
+    );
+  };
 
+  const renderMDMSolutionFilterBlock = () => {
+    if (!mdmSolutionDetails) return null;
+
+    const { name, server_url } = mdmSolutionDetails;
+    const label = name ? `${name} ${server_url}` : `${server_url}`;
+
+    const TooltipDescription = (
+      <span>
+        Host enrolled
+        {name !== "Unknown" && ` to ${name}`}
+        <br /> at {server_url}
+      </span>
+    );
+
+    return (
+      <FilterPill
+        label={label}
+        tooltipDescription={TooltipDescription}
+        onClear={() => handleClearFilter(["mdm_id"])}
+      />
+    );
+  };
+
+  const renderMDMEnrollmentFilterBlock = () => {
+    if (!mdmEnrollmentStatus) return null;
+
+    const label = `MDM status: ${
+      invert(MDM_ENROLLMENT_STATUS)[mdmEnrollmentStatus]
+    }`;
+
+    // More narrow tooltip than other MDM tooltip
+    const MDM_STATUS_PILL_TOOLTIP: Record<string, JSX.Element> = {
+      automatic: (
+        <span>
+          MDM was turned on <br />
+          automatically using Apple <br />
+          Automated Device <br />
+          Enrollment (DEP), <br />
+          Windows Autopilot, or <br />
+          Windows Azure AD Join. <br />
+          Administrators can block <br />
+          device users from turning
+          <br /> MDM off.
+        </span>
+      ),
+      manual: (
+        <span>
+          MDM was turned on <br />
+          manually. Device users <br />
+          can turn MDM off.
+        </span>
+      ),
+      unenrolled: (
+        <span>
+          Hosts with MDM off <br />
+          don&apos;t receive macOS <br />
+          settings and macOS <br />
+          update encouragement.
+        </span>
+      ),
+      pending: (
+        <span>
+          Hosts ordered using Apple <br />
+          Business Manager (ABM). <br />
+          They will automatically enroll <br />
+          to Fleet and turn on MDM <br />
+          when they&apos;re unboxed.
+        </span>
+      ),
+    };
+
+    return (
+      <FilterPill
+        label={label}
+        tooltipDescription={MDM_STATUS_PILL_TOOLTIP[mdmEnrollmentStatus]}
+        onClear={() => handleClearFilter(["mdm_enrollment_status"])}
+      />
+    );
+  };
+
+  const renderMunkiIssueFilterBlock = () => {
+    if (munkiIssueDetails) {
       return (
-        <div className={`${baseClass}__labels-active-filter-wrap`}>
-          {renderFilterPill()}
-        </div>
+        <FilterPill
+          label={munkiIssueDetails.name}
+          tooltipDescription={
+            <span>
+              Hosts that reported this Munki issue <br />
+              the last time Munki ran on each host.
+            </span>
+          }
+          onClear={() => handleClearFilter(["munki_issue_id"])}
+        />
       );
     }
-
     return null;
   };
+
+  const renderLowDiskSpaceFilterBlock = () => {
+    const TooltipDescription = (
+      <span>
+        Hosts that have {lowDiskSpaceHosts} GB or less <br />
+        disk space available.
+      </span>
+    );
+
+    return (
+      <FilterPill
+        label="Low disk space"
+        tooltipDescription={TooltipDescription}
+        premiumFeatureTooltipDelayHide={1000}
+        onClear={() => handleClearFilter(["low_disk_space"])}
+        isSandboxMode={isSandboxMode}
+        sandboxPremiumOnlyIcon
+      />
+    );
+  };
+
+  const renderOsSettingsBlock = () => {
+    const label = "OS settings";
+    return (
+      <>
+        <Dropdown
+          value={osSettingsStatus}
+          className={`${baseClass}__os_settings-dropdown`}
+          options={OS_SETTINGS_FILTER_OPTIONS}
+          onChange={onChangeOsSettingsFilter}
+        />
+        <FilterPill
+          label={label}
+          onClear={() => handleClearFilter([HOSTS_QUERY_PARAMS.OS_SETTINGS])}
+        />
+      </>
+    );
+  };
+
+  const renderDiskEncryptionStatusBlock = () => {
+    if (!diskEncryptionStatus) return null;
+
+    return (
+      <>
+        <DiskEncryptionStatusFilter
+          diskEncryptionStatus={diskEncryptionStatus}
+          onChange={onChangeDiskEncryptionStatusFilter}
+        />
+        <FilterPill
+          label="OS settings: Disk encryption"
+          onClear={() =>
+            handleClearFilter([HOSTS_QUERY_PARAMS.DISK_ENCRYPTION])
+          }
+        />
+      </>
+    );
+  };
+
+  const renderBootstrapPackageStatusBlock = () => {
+    if (!bootstrapPackageStatus) return null;
+
+    return (
+      <>
+        <BootstrapPackageStatusFilter
+          bootstrapPackageStatus={bootstrapPackageStatus}
+          onChange={onChangeBootstrapPackageStatusFilter}
+        />
+        <FilterPill
+          label="macOS settings: bootstrap package"
+          onClear={() => handleClearFilter(["bootstrap_package"])}
+        />
+      </>
+    );
+  };
+
+  const showSelectedLabel = selectedLabel && selectedLabel.type !== "all";
+
+  if (
+    showSelectedLabel ||
+    policyId ||
+    macSettingsStatus ||
+    softwareId ||
+    softwareTitleId ||
+    softwareVersionId ||
+    mdmId ||
+    mdmEnrollmentStatus ||
+    lowDiskSpaceHosts ||
+    osVersionId ||
+    (osName && osVersion) ||
+    munkiIssueId ||
+    osSettingsStatus ||
+    diskEncryptionStatus ||
+    bootstrapPackageStatus
+  ) {
+    const renderFilterPill = () => {
+      switch (true) {
+        // backend allows for pill combos (label + low disk space) OR
+        // (label + mdm solution) OR (label + mdm enrollment status)
+        case showSelectedLabel && !!lowDiskSpaceHosts:
+          return (
+            <>
+              {renderLabelFilterPill()} {renderLowDiskSpaceFilterBlock()}
+            </>
+          );
+        case showSelectedLabel && !!mdmId:
+          return (
+            <>
+              {renderLabelFilterPill()} {renderMDMSolutionFilterBlock()}
+            </>
+          );
+
+        case showSelectedLabel && !!mdmEnrollmentStatus:
+          return (
+            <>
+              {renderLabelFilterPill()} {renderMDMEnrollmentFilterBlock()}
+            </>
+          );
+        case showSelectedLabel:
+          return renderLabelFilterPill();
+        case !!policyId:
+          return renderPoliciesFilterBlock();
+        case !!macSettingsStatus:
+          return renderMacSettingsStatusFilterBlock();
+        case !!softwareId || !!softwareVersionId || !!softwareTitleId:
+          return renderSoftwareFilterBlock();
+        case !!mdmId:
+          return renderMDMSolutionFilterBlock();
+        case !!mdmEnrollmentStatus:
+          return renderMDMEnrollmentFilterBlock();
+        case !!osVersionId || (!!osName && !!osVersion):
+          return renderOSFilterBlock();
+        case !!munkiIssueId:
+          return renderMunkiIssueFilterBlock();
+        case !!lowDiskSpaceHosts:
+          return renderLowDiskSpaceFilterBlock();
+        case !!osSettingsStatus:
+          return renderOsSettingsBlock();
+        case !!diskEncryptionStatus:
+          return renderDiskEncryptionStatusBlock();
+        case !!bootstrapPackageStatus:
+          return renderBootstrapPackageStatusBlock();
+        default:
+          return null;
+      }
+    };
+
+    return (
+      <div className={`${baseClass}__labels-active-filter-wrap`}>
+        {renderFilterPill()}
+      </div>
+    );
+  }
+
+  return null;
 };
 
 export default HostsFilterBlock;

--- a/frontend/pages/hosts/ManageHostsPage/components/HostsFilterBlock/HostsFilterBlock.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/components/HostsFilterBlock/HostsFilterBlock.tsx
@@ -58,7 +58,7 @@ interface IHostsFilterBlockProps {
     mdmId?: number;
     mdmEnrollmentStatus?: any;
     lowDiskSpaceHosts?: number;
-    osId?: any;
+    osVersionId?: any;
     osName?: any;
     osVersion?: any;
     munkiIssueId?: number;
@@ -101,7 +101,7 @@ const HostsFilterBlock = ({
     mdmId,
     mdmEnrollmentStatus,
     lowDiskSpaceHosts,
-    osId,
+    osVersionId,
     osName,
     osVersion,
     munkiIssueId,
@@ -159,9 +159,12 @@ const HostsFilterBlock = ({
   };
 
   const renderOSFilterBlock = () => {
-    if (!osId && !(osName && osVersion)) return null;
+    if (!osVersionId && !(osName && osVersion)) return null;
 
     let os: IOperatingSystemVersion | undefined;
+       if (osVersionId) {
+      os = osVersions?.find((v) => v.os_version_id === osVersionId);
+    } else if (osName && osVersion) {
     if (osName && osVersion) {
       const name: string = osName;
       const vers: string = osVersion;
@@ -449,7 +452,7 @@ const HostsFilterBlock = ({
     mdmId ||
     mdmEnrollmentStatus ||
     lowDiskSpaceHosts ||
-    osId ||
+    osVersionId ||
     (osName && osVersion) ||
     munkiIssueId ||
     osSettingsStatus ||
@@ -491,7 +494,7 @@ const HostsFilterBlock = ({
           return renderMDMSolutionFilterBlock();
         case !!mdmEnrollmentStatus:
           return renderMDMEnrollmentFilterBlock();
-        case !!osId || (!!osName && !!osVersion):
+        case !!osVersionId || (!!osName && !!osVersion):
           return renderOSFilterBlock();
         case !!munkiIssueId:
           return renderMunkiIssueFilterBlock();

--- a/frontend/pages/hosts/ManageHostsPage/components/HostsFilterBlock/HostsFilterBlock.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/components/HostsFilterBlock/HostsFilterBlock.tsx
@@ -58,9 +58,9 @@ interface IHostsFilterBlockProps {
     mdmId?: number;
     mdmEnrollmentStatus?: any;
     lowDiskSpaceHosts?: number;
-    osVersionId?: any;
-    osName?: any;
-    osVersion?: any;
+    osVersionId?: string;
+    osName?: string;
+    osVersion?: string;
     munkiIssueId?: number;
     osVersions?: IOperatingSystemVersion[];
     softwareDetails: { name: string; version?: string } | null;
@@ -159,47 +159,48 @@ const HostsFilterBlock = ({
   };
 
   const renderOSFilterBlock = () => {
-    if (!osVersionId && !(osName && osVersion)) return null;
-
     let os: IOperatingSystemVersion | undefined;
     if (osVersionId) {
-      os = osVersions?.find((v) => v.os_version_id === osVersionId);
+      os = osVersions?.find(
+        (v) => v.os_version_id === parseInt(osVersionId, 10)
+      );
     } else if (osName && osVersion) {
-      if (osName && osVersion) {
-        const name: string = osName;
-        const vers: string = osVersion;
+      const name: string = osName;
+      const vers: string = osVersion;
 
-        os = osVersions?.find(
-          ({ name_only, version }) =>
-            name_only.toLowerCase() === name.toLowerCase() &&
-            version.toLowerCase() === vers.toLowerCase()
-        );
-      }
-      if (!os) return null;
-
-      const { name, name_only, version } = os;
-      // TODO: Move formatOperatingSystemDisplayName into utils file
-      const label = formatOperatingSystemDisplayName(
-        name_only || version
-          ? `${name_only || ""} ${version || ""}`
-          : `${name || ""}`
-      );
-      const TooltipDescription = (
-        <span>
-          Hosts with {formatOperatingSystemDisplayName(name_only || name)},
-          <br />
-          {version && `${version} installed`}
-        </span>
-      );
-
-      return (
-        <FilterPill
-          label={label}
-          tooltipDescription={TooltipDescription}
-          onClear={() => handleClearFilter(["os_id", "os_name", "os_version"])}
-        />
+      os = osVersions?.find(
+        ({ name_only, version }) =>
+          name_only.toLowerCase() === name.toLowerCase() &&
+          version.toLowerCase() === vers.toLowerCase()
       );
     }
+
+    if (!os) return null;
+
+    const { name, name_only, version } = os;
+    // TODO: Move formatOperatingSystemDisplayName into utils file
+    const label = formatOperatingSystemDisplayName(
+      name_only || version
+        ? `${name_only || ""} ${version || ""}`
+        : `${name || ""}`
+    );
+    const TooltipDescription = (
+      <span>
+        Hosts with {formatOperatingSystemDisplayName(name_only || name)},
+        <br />
+        {version && `${version} installed`}
+      </span>
+    );
+
+    return (
+      <FilterPill
+        label={label}
+        tooltipDescription={TooltipDescription}
+        onClear={() =>
+          handleClearFilter(["os_version_id", "os_name", "os_version"])
+        }
+      />
+    );
   };
 
   // NOTE: good example of filter dropdown with pill

--- a/frontend/pages/hosts/ManageHostsPage/components/HostsFilterBlock/HostsFilterBlock.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/components/HostsFilterBlock/HostsFilterBlock.tsx
@@ -162,363 +162,364 @@ const HostsFilterBlock = ({
     if (!osVersionId && !(osName && osVersion)) return null;
 
     let os: IOperatingSystemVersion | undefined;
-       if (osVersionId) {
+    if (osVersionId) {
       os = osVersions?.find((v) => v.os_version_id === osVersionId);
     } else if (osName && osVersion) {
-    if (osName && osVersion) {
-      const name: string = osName;
-      const vers: string = osVersion;
+      if (osName && osVersion) {
+        const name: string = osName;
+        const vers: string = osVersion;
 
-      os = osVersions?.find(
-        ({ name_only, version }) =>
-          name_only.toLowerCase() === name.toLowerCase() &&
-          version.toLowerCase() === vers.toLowerCase()
+        os = osVersions?.find(
+          ({ name_only, version }) =>
+            name_only.toLowerCase() === name.toLowerCase() &&
+            version.toLowerCase() === vers.toLowerCase()
+        );
+      }
+      if (!os) return null;
+
+      const { name, name_only, version } = os;
+      // TODO: Move formatOperatingSystemDisplayName into utils file
+      const label = formatOperatingSystemDisplayName(
+        name_only || version
+          ? `${name_only || ""} ${version || ""}`
+          : `${name || ""}`
       );
-    }
-    if (!os) return null;
-
-    const { name, name_only, version } = os;
-    // TODO: Move formatOperatingSystemDisplayName into utils file
-    const label = formatOperatingSystemDisplayName(
-      name_only || version
-        ? `${name_only || ""} ${version || ""}`
-        : `${name || ""}`
-    );
-    const TooltipDescription = (
-      <span>
-        Hosts with {formatOperatingSystemDisplayName(name_only || name)},
-        <br />
-        {version && `${version} installed`}
-      </span>
-    );
-
-    return (
-      <FilterPill
-        label={label}
-        tooltipDescription={TooltipDescription}
-        onClear={() => handleClearFilter(["os_id", "os_name", "os_version"])}
-      />
-    );
-  };
-
-  // NOTE: good example of filter dropdown with pill
-  const renderPoliciesFilterBlock = () => (
-    <>
-      <PoliciesFilter
-        policyResponse={policyResponse}
-        onChange={onChangePoliciesFilter}
-      />
-      <FilterPill
-        icon="policy"
-        label={policy?.name ?? "..."}
-        onClear={() => handleClearFilter(["policy_id", "policy_response"])}
-        className={`${baseClass}__policies-filter-pill`}
-      />
-    </>
-  );
-
-  const renderMacSettingsStatusFilterBlock = () => {
-    const label = "macOS settings";
-    return (
-      <>
-        <Dropdown
-          value={macSettingsStatus}
-          className={`${baseClass}__macsettings-dropdown`}
-          options={OS_SETTINGS_FILTER_OPTIONS}
-          onChange={onChangeMacSettingsFilter}
-        />
-        <FilterPill
-          label={label}
-          onClear={() => handleClearFilter(["macos_settings"])}
-        />
-      </>
-    );
-  };
-
-  const renderSoftwareFilterBlock = () => {
-    if (!softwareDetails) return null;
-
-    const { name, version } = softwareDetails;
-    let label = name;
-    if (version) {
-      label += ` ${version}`;
-    }
-    label = label.trim() || "Unknown software";
-
-    // const TooltipDescription = (
-    //   <span>
-    //     Hosts with {name || "Unknown software"},
-    //     <br />
-    //     {version || "version unknown"} installed
-    //   </span>
-    // );
-
-    return (
-      <FilterPill
-        label={label}
-        onClear={() =>
-          handleClearFilter([
-            "software_id",
-            "software_version_id",
-            "software_title_id",
-          ])
-        }
-        // tooltipDescription={TooltipDescription}
-      />
-    );
-  };
-
-  const renderMDMSolutionFilterBlock = () => {
-    if (!mdmSolutionDetails) return null;
-
-    const { name, server_url } = mdmSolutionDetails;
-    const label = name ? `${name} ${server_url}` : `${server_url}`;
-
-    const TooltipDescription = (
-      <span>
-        Host enrolled
-        {name !== "Unknown" && ` to ${name}`}
-        <br /> at {server_url}
-      </span>
-    );
-
-    return (
-      <FilterPill
-        label={label}
-        tooltipDescription={TooltipDescription}
-        onClear={() => handleClearFilter(["mdm_id"])}
-      />
-    );
-  };
-
-  const renderMDMEnrollmentFilterBlock = () => {
-    if (!mdmEnrollmentStatus) return null;
-
-    const label = `MDM status: ${
-      invert(MDM_ENROLLMENT_STATUS)[mdmEnrollmentStatus]
-    }`;
-
-    // More narrow tooltip than other MDM tooltip
-    const MDM_STATUS_PILL_TOOLTIP: Record<string, JSX.Element> = {
-      automatic: (
+      const TooltipDescription = (
         <span>
-          MDM was turned on <br />
-          automatically using Apple <br />
-          Automated Device <br />
-          Enrollment (DEP), <br />
-          Windows Autopilot, or <br />
-          Windows Azure AD Join. <br />
-          Administrators can block <br />
-          device users from turning
-          <br /> MDM off.
+          Hosts with {formatOperatingSystemDisplayName(name_only || name)},
+          <br />
+          {version && `${version} installed`}
         </span>
-      ),
-      manual: (
-        <span>
-          MDM was turned on <br />
-          manually. Device users <br />
-          can turn MDM off.
-        </span>
-      ),
-      unenrolled: (
-        <span>
-          Hosts with MDM off <br />
-          don&apos;t receive macOS <br />
-          settings and macOS <br />
-          update encouragement.
-        </span>
-      ),
-      pending: (
-        <span>
-          Hosts ordered using Apple <br />
-          Business Manager (ABM). <br />
-          They will automatically enroll <br />
-          to Fleet and turn on MDM <br />
-          when they&apos;re unboxed.
-        </span>
-      ),
-    };
+      );
 
-    return (
-      <FilterPill
-        label={label}
-        tooltipDescription={MDM_STATUS_PILL_TOOLTIP[mdmEnrollmentStatus]}
-        onClear={() => handleClearFilter(["mdm_enrollment_status"])}
-      />
-    );
-  };
-
-  const renderMunkiIssueFilterBlock = () => {
-    if (munkiIssueDetails) {
       return (
         <FilterPill
-          label={munkiIssueDetails.name}
-          tooltipDescription={
-            <span>
-              Hosts that reported this Munki issue <br />
-              the last time Munki ran on each host.
-            </span>
-          }
-          onClear={() => handleClearFilter(["munki_issue_id"])}
+          label={label}
+          tooltipDescription={TooltipDescription}
+          onClear={() => handleClearFilter(["os_id", "os_name", "os_version"])}
         />
       );
     }
-    return null;
-  };
 
-  const renderLowDiskSpaceFilterBlock = () => {
-    const TooltipDescription = (
-      <span>
-        Hosts that have {lowDiskSpaceHosts} GB or less <br />
-        disk space available.
-      </span>
-    );
-
-    return (
-      <FilterPill
-        label="Low disk space"
-        tooltipDescription={TooltipDescription}
-        premiumFeatureTooltipDelayHide={1000}
-        onClear={() => handleClearFilter(["low_disk_space"])}
-        isSandboxMode={isSandboxMode}
-        sandboxPremiumOnlyIcon
-      />
-    );
-  };
-
-  const renderOsSettingsBlock = () => {
-    const label = "OS settings";
-    return (
+    // NOTE: good example of filter dropdown with pill
+    const renderPoliciesFilterBlock = () => (
       <>
-        <Dropdown
-          value={osSettingsStatus}
-          className={`${baseClass}__os_settings-dropdown`}
-          options={OS_SETTINGS_FILTER_OPTIONS}
-          onChange={onChangeOsSettingsFilter}
+        <PoliciesFilter
+          policyResponse={policyResponse}
+          onChange={onChangePoliciesFilter}
         />
         <FilterPill
-          label={label}
-          onClear={() => handleClearFilter([HOSTS_QUERY_PARAMS.OS_SETTINGS])}
+          icon="policy"
+          label={policy?.name ?? "..."}
+          onClear={() => handleClearFilter(["policy_id", "policy_response"])}
+          className={`${baseClass}__policies-filter-pill`}
         />
       </>
     );
-  };
 
-  const renderDiskEncryptionStatusBlock = () => {
-    if (!diskEncryptionStatus) return null;
-
-    return (
-      <>
-        <DiskEncryptionStatusFilter
-          diskEncryptionStatus={diskEncryptionStatus}
-          onChange={onChangeDiskEncryptionStatusFilter}
-        />
-        <FilterPill
-          label="OS settings: Disk encryption"
-          onClear={() =>
-            handleClearFilter([HOSTS_QUERY_PARAMS.DISK_ENCRYPTION])
-          }
-        />
-      </>
-    );
-  };
-
-  const renderBootstrapPackageStatusBlock = () => {
-    if (!bootstrapPackageStatus) return null;
-
-    return (
-      <>
-        <BootstrapPackageStatusFilter
-          bootstrapPackageStatus={bootstrapPackageStatus}
-          onChange={onChangeBootstrapPackageStatusFilter}
-        />
-        <FilterPill
-          label="macOS settings: bootstrap package"
-          onClear={() => handleClearFilter(["bootstrap_package"])}
-        />
-      </>
-    );
-  };
-
-  const showSelectedLabel = selectedLabel && selectedLabel.type !== "all";
-
-  if (
-    showSelectedLabel ||
-    policyId ||
-    macSettingsStatus ||
-    softwareId ||
-    softwareTitleId ||
-    softwareVersionId ||
-    mdmId ||
-    mdmEnrollmentStatus ||
-    lowDiskSpaceHosts ||
-    osVersionId ||
-    (osName && osVersion) ||
-    munkiIssueId ||
-    osSettingsStatus ||
-    diskEncryptionStatus ||
-    bootstrapPackageStatus
-  ) {
-    const renderFilterPill = () => {
-      switch (true) {
-        // backend allows for pill combos (label + low disk space) OR
-        // (label + mdm solution) OR (label + mdm enrollment status)
-        case showSelectedLabel && !!lowDiskSpaceHosts:
-          return (
-            <>
-              {renderLabelFilterPill()} {renderLowDiskSpaceFilterBlock()}
-            </>
-          );
-        case showSelectedLabel && !!mdmId:
-          return (
-            <>
-              {renderLabelFilterPill()} {renderMDMSolutionFilterBlock()}
-            </>
-          );
-
-        case showSelectedLabel && !!mdmEnrollmentStatus:
-          return (
-            <>
-              {renderLabelFilterPill()} {renderMDMEnrollmentFilterBlock()}
-            </>
-          );
-        case showSelectedLabel:
-          return renderLabelFilterPill();
-        case !!policyId:
-          return renderPoliciesFilterBlock();
-        case !!macSettingsStatus:
-          return renderMacSettingsStatusFilterBlock();
-        case !!softwareId || !!softwareVersionId || !!softwareTitleId:
-          return renderSoftwareFilterBlock();
-        case !!mdmId:
-          return renderMDMSolutionFilterBlock();
-        case !!mdmEnrollmentStatus:
-          return renderMDMEnrollmentFilterBlock();
-        case !!osVersionId || (!!osName && !!osVersion):
-          return renderOSFilterBlock();
-        case !!munkiIssueId:
-          return renderMunkiIssueFilterBlock();
-        case !!lowDiskSpaceHosts:
-          return renderLowDiskSpaceFilterBlock();
-        case !!osSettingsStatus:
-          return renderOsSettingsBlock();
-        case !!diskEncryptionStatus:
-          return renderDiskEncryptionStatusBlock();
-        case !!bootstrapPackageStatus:
-          return renderBootstrapPackageStatusBlock();
-        default:
-          return null;
-      }
+    const renderMacSettingsStatusFilterBlock = () => {
+      const label = "macOS settings";
+      return (
+        <>
+          <Dropdown
+            value={macSettingsStatus}
+            className={`${baseClass}__macsettings-dropdown`}
+            options={OS_SETTINGS_FILTER_OPTIONS}
+            onChange={onChangeMacSettingsFilter}
+          />
+          <FilterPill
+            label={label}
+            onClear={() => handleClearFilter(["macos_settings"])}
+          />
+        </>
+      );
     };
 
-    return (
-      <div className={`${baseClass}__labels-active-filter-wrap`}>
-        {renderFilterPill()}
-      </div>
-    );
-  }
+    const renderSoftwareFilterBlock = () => {
+      if (!softwareDetails) return null;
 
-  return null;
+      const { name, version } = softwareDetails;
+      let label = name;
+      if (version) {
+        label += ` ${version}`;
+      }
+      label = label.trim() || "Unknown software";
+
+      // const TooltipDescription = (
+      //   <span>
+      //     Hosts with {name || "Unknown software"},
+      //     <br />
+      //     {version || "version unknown"} installed
+      //   </span>
+      // );
+
+      return (
+        <FilterPill
+          label={label}
+          onClear={() =>
+            handleClearFilter([
+              "software_id",
+              "software_version_id",
+              "software_title_id",
+            ])
+          }
+          // tooltipDescription={TooltipDescription}
+        />
+      );
+    };
+
+    const renderMDMSolutionFilterBlock = () => {
+      if (!mdmSolutionDetails) return null;
+
+      const { name, server_url } = mdmSolutionDetails;
+      const label = name ? `${name} ${server_url}` : `${server_url}`;
+
+      const TooltipDescription = (
+        <span>
+          Host enrolled
+          {name !== "Unknown" && ` to ${name}`}
+          <br /> at {server_url}
+        </span>
+      );
+
+      return (
+        <FilterPill
+          label={label}
+          tooltipDescription={TooltipDescription}
+          onClear={() => handleClearFilter(["mdm_id"])}
+        />
+      );
+    };
+
+    const renderMDMEnrollmentFilterBlock = () => {
+      if (!mdmEnrollmentStatus) return null;
+
+      const label = `MDM status: ${
+        invert(MDM_ENROLLMENT_STATUS)[mdmEnrollmentStatus]
+      }`;
+
+      // More narrow tooltip than other MDM tooltip
+      const MDM_STATUS_PILL_TOOLTIP: Record<string, JSX.Element> = {
+        automatic: (
+          <span>
+            MDM was turned on <br />
+            automatically using Apple <br />
+            Automated Device <br />
+            Enrollment (DEP), <br />
+            Windows Autopilot, or <br />
+            Windows Azure AD Join. <br />
+            Administrators can block <br />
+            device users from turning
+            <br /> MDM off.
+          </span>
+        ),
+        manual: (
+          <span>
+            MDM was turned on <br />
+            manually. Device users <br />
+            can turn MDM off.
+          </span>
+        ),
+        unenrolled: (
+          <span>
+            Hosts with MDM off <br />
+            don&apos;t receive macOS <br />
+            settings and macOS <br />
+            update encouragement.
+          </span>
+        ),
+        pending: (
+          <span>
+            Hosts ordered using Apple <br />
+            Business Manager (ABM). <br />
+            They will automatically enroll <br />
+            to Fleet and turn on MDM <br />
+            when they&apos;re unboxed.
+          </span>
+        ),
+      };
+
+      return (
+        <FilterPill
+          label={label}
+          tooltipDescription={MDM_STATUS_PILL_TOOLTIP[mdmEnrollmentStatus]}
+          onClear={() => handleClearFilter(["mdm_enrollment_status"])}
+        />
+      );
+    };
+
+    const renderMunkiIssueFilterBlock = () => {
+      if (munkiIssueDetails) {
+        return (
+          <FilterPill
+            label={munkiIssueDetails.name}
+            tooltipDescription={
+              <span>
+                Hosts that reported this Munki issue <br />
+                the last time Munki ran on each host.
+              </span>
+            }
+            onClear={() => handleClearFilter(["munki_issue_id"])}
+          />
+        );
+      }
+      return null;
+    };
+
+    const renderLowDiskSpaceFilterBlock = () => {
+      const TooltipDescription = (
+        <span>
+          Hosts that have {lowDiskSpaceHosts} GB or less <br />
+          disk space available.
+        </span>
+      );
+
+      return (
+        <FilterPill
+          label="Low disk space"
+          tooltipDescription={TooltipDescription}
+          premiumFeatureTooltipDelayHide={1000}
+          onClear={() => handleClearFilter(["low_disk_space"])}
+          isSandboxMode={isSandboxMode}
+          sandboxPremiumOnlyIcon
+        />
+      );
+    };
+
+    const renderOsSettingsBlock = () => {
+      const label = "OS settings";
+      return (
+        <>
+          <Dropdown
+            value={osSettingsStatus}
+            className={`${baseClass}__os_settings-dropdown`}
+            options={OS_SETTINGS_FILTER_OPTIONS}
+            onChange={onChangeOsSettingsFilter}
+          />
+          <FilterPill
+            label={label}
+            onClear={() => handleClearFilter([HOSTS_QUERY_PARAMS.OS_SETTINGS])}
+          />
+        </>
+      );
+    };
+
+    const renderDiskEncryptionStatusBlock = () => {
+      if (!diskEncryptionStatus) return null;
+
+      return (
+        <>
+          <DiskEncryptionStatusFilter
+            diskEncryptionStatus={diskEncryptionStatus}
+            onChange={onChangeDiskEncryptionStatusFilter}
+          />
+          <FilterPill
+            label="OS settings: Disk encryption"
+            onClear={() =>
+              handleClearFilter([HOSTS_QUERY_PARAMS.DISK_ENCRYPTION])
+            }
+          />
+        </>
+      );
+    };
+
+    const renderBootstrapPackageStatusBlock = () => {
+      if (!bootstrapPackageStatus) return null;
+
+      return (
+        <>
+          <BootstrapPackageStatusFilter
+            bootstrapPackageStatus={bootstrapPackageStatus}
+            onChange={onChangeBootstrapPackageStatusFilter}
+          />
+          <FilterPill
+            label="macOS settings: bootstrap package"
+            onClear={() => handleClearFilter(["bootstrap_package"])}
+          />
+        </>
+      );
+    };
+
+    const showSelectedLabel = selectedLabel && selectedLabel.type !== "all";
+
+    if (
+      showSelectedLabel ||
+      policyId ||
+      macSettingsStatus ||
+      softwareId ||
+      softwareTitleId ||
+      softwareVersionId ||
+      mdmId ||
+      mdmEnrollmentStatus ||
+      lowDiskSpaceHosts ||
+      osVersionId ||
+      (osName && osVersion) ||
+      munkiIssueId ||
+      osSettingsStatus ||
+      diskEncryptionStatus ||
+      bootstrapPackageStatus
+    ) {
+      const renderFilterPill = () => {
+        switch (true) {
+          // backend allows for pill combos (label + low disk space) OR
+          // (label + mdm solution) OR (label + mdm enrollment status)
+          case showSelectedLabel && !!lowDiskSpaceHosts:
+            return (
+              <>
+                {renderLabelFilterPill()} {renderLowDiskSpaceFilterBlock()}
+              </>
+            );
+          case showSelectedLabel && !!mdmId:
+            return (
+              <>
+                {renderLabelFilterPill()} {renderMDMSolutionFilterBlock()}
+              </>
+            );
+
+          case showSelectedLabel && !!mdmEnrollmentStatus:
+            return (
+              <>
+                {renderLabelFilterPill()} {renderMDMEnrollmentFilterBlock()}
+              </>
+            );
+          case showSelectedLabel:
+            return renderLabelFilterPill();
+          case !!policyId:
+            return renderPoliciesFilterBlock();
+          case !!macSettingsStatus:
+            return renderMacSettingsStatusFilterBlock();
+          case !!softwareId || !!softwareVersionId || !!softwareTitleId:
+            return renderSoftwareFilterBlock();
+          case !!mdmId:
+            return renderMDMSolutionFilterBlock();
+          case !!mdmEnrollmentStatus:
+            return renderMDMEnrollmentFilterBlock();
+          case !!osVersionId || (!!osName && !!osVersion):
+            return renderOSFilterBlock();
+          case !!munkiIssueId:
+            return renderMunkiIssueFilterBlock();
+          case !!lowDiskSpaceHosts:
+            return renderLowDiskSpaceFilterBlock();
+          case !!osSettingsStatus:
+            return renderOsSettingsBlock();
+          case !!diskEncryptionStatus:
+            return renderDiskEncryptionStatusBlock();
+          case !!bootstrapPackageStatus:
+            return renderBootstrapPackageStatusBlock();
+          default:
+            return null;
+        }
+      };
+
+      return (
+        <div className={`${baseClass}__labels-active-filter-wrap`}>
+          {renderFilterPill()}
+        </div>
+      );
+    }
+
+    return null;
+  };
 };
 
 export default HostsFilterBlock;

--- a/frontend/router/index.tsx
+++ b/frontend/router/index.tsx
@@ -227,7 +227,7 @@ const routes = (
             </Route>
             <Route path="titles/:id" component={SoftwareTitleDetailsPage} />
             <Route path="versions/:id" component={SoftwareVersionDetailsPage} />
-            <Route path="os/details" component={SoftwareOSDetailsPage} />
+            <Route path="os/:id" component={SoftwareOSDetailsPage} />
           </Route>
           <Route component={AuthGlobalAdminMaintainerRoutes}>
             <Route path="packs">

--- a/frontend/router/paths.ts
+++ b/frontend/router/paths.ts
@@ -55,8 +55,8 @@ export default {
   SOFTWARE_VERSION_DETAILS: (id: string): string => {
     return `${URL_PREFIX}/software/versions/${id}`;
   },
-  SOFTWARE_OS_DETAILS: (name: string, version: string): string => {
-    return `${URL_PREFIX}/software/os/details?name=${name}&version=${version}`;
+  SOFTWARE_OS_DETAILS: (id: number): string => {
+    return `${URL_PREFIX}/software/os/${id}`;
   },
 
   EDIT_PACK: (packId: number): string => {

--- a/frontend/services/entities/host_count.ts
+++ b/frontend/services/entities/host_count.ts
@@ -46,7 +46,7 @@ export interface IHostCountLoadOptions {
   mdmId?: number;
   mdmEnrollmentStatus?: string;
   munkiIssueId?: number;
-  osId?: number;
+  osVersionId?: number;
   osName?: string;
   osVersion?: string;
   osSettings?: MdmProfileStatus;
@@ -73,7 +73,7 @@ export default {
     const munkiIssueId = options?.munkiIssueId;
     const lowDiskSpaceHosts = options?.lowDiskSpaceHosts;
     const label = getLabelParam(selectedLabels);
-    const osId = options?.osId;
+    const osVersionId = options?.osVersionId;
     const osName = options?.osName;
     const osVersion = options?.osVersion;
     const osSettings = options?.osSettings;
@@ -99,7 +99,7 @@ export default {
         softwareVersionId,
         lowDiskSpaceHosts,
         osName,
-        osId,
+        osVersionId,
         osVersion,
         osSettings,
         diskEncryptionStatus,

--- a/frontend/services/entities/hosts.ts
+++ b/frontend/services/entities/hosts.ts
@@ -62,7 +62,7 @@ export interface ILoadHostsOptions {
   mdmId?: number;
   mdmEnrollmentStatus?: string;
   lowDiskSpaceHosts?: number;
-  osId?: number;
+  osVersionId?: number;
   osName?: string;
   osVersion?: string;
   munkiIssueId?: number;
@@ -250,7 +250,7 @@ export default {
     mdmEnrollmentStatus,
     munkiIssueId,
     lowDiskSpaceHosts,
-    osId,
+    osVersionId,
     osName,
     osVersion,
     device_mapping,
@@ -287,7 +287,7 @@ export default {
         softwareTitleId,
         softwareVersionId,
         lowDiskSpaceHosts,
-        osId,
+        osVersionId,
         osName,
         osVersion,
         diskEncryptionStatus,

--- a/frontend/services/entities/operating_systems.ts
+++ b/frontend/services/entities/operating_systems.ts
@@ -23,11 +23,6 @@ export interface IGetOSVersionsQueryParams {
   per_page?: number;
 }
 
-export interface IGetOSVersionsDetailsQueryParams {
-  os_name?: string;
-  os_version?: string;
-}
-
 export interface IGetOSVersionsQueryKey extends IGetOSVersionsQueryParams {
   scope: string;
 }
@@ -40,6 +35,10 @@ export interface IOSVersionsResponse {
     has_next_results: boolean;
     has_previous_results: boolean;
   };
+}
+
+export interface IOSVersionResponse {
+  os_version: IOperatingSystemVersion;
 }
 
 export const getOSVersions = ({
@@ -71,20 +70,10 @@ export const getOSVersions = ({
   return sendRequest("GET", path);
 };
 
-const getOSVersion = ({
-  os_name,
-  os_version,
-}: IGetOSVersionsDetailsQueryParams): Promise<IOSVersionsResponse> => {
+const getOSVersion = (os_version_id: number): Promise<IOSVersionResponse> => {
   const { OS_VERSIONS } = endpoints;
-  let path = OS_VERSIONS;
 
-  const queryString = buildQueryStringFromParams({
-    os_name,
-    os_version,
-  });
-
-  if (queryString) path += `?${queryString}`;
-  return sendRequest("GET", path);
+  return sendRequest("GET", OS_VERSIONS, os_version_id);
 };
 
 export default {

--- a/frontend/services/entities/operating_systems.ts
+++ b/frontend/services/entities/operating_systems.ts
@@ -71,9 +71,9 @@ export const getOSVersions = ({
 };
 
 const getOSVersion = (os_version_id: number): Promise<IOSVersionResponse> => {
-  const { OS_VERSIONS } = endpoints;
+  const { OS_VERSION } = endpoints;
 
-  return sendRequest("GET", OS_VERSIONS, os_version_id);
+  return sendRequest("GET", OS_VERSION(os_version_id));
 };
 
 export default {

--- a/frontend/utilities/url/index.ts
+++ b/frontend/utilities/url/index.ts
@@ -32,7 +32,7 @@ interface IMutuallyExclusiveHostParams {
   softwareId?: number;
   softwareVersionId?: number;
   softwareTitleId?: number;
-  osId?: number;
+  osVersionId?: number;
   osName?: string;
   osVersion?: string;
   osSettings?: MdmProfileStatus;
@@ -104,7 +104,7 @@ export const reconcileMutuallyExclusiveHostParams = ({
   softwareId,
   softwareVersionId,
   softwareTitleId,
-  osId,
+  osVersionId,
   osName,
   osVersion,
   osSettings,
@@ -141,8 +141,8 @@ export const reconcileMutuallyExclusiveHostParams = ({
       return { software_version_id: softwareVersionId };
     case !!softwareId:
       return { software_id: softwareId };
-    case !!osId:
-      return { os_id: osId };
+    case !!osVersionId:
+      return { os_version_id: osVersionId };
     case !!osName && !!osVersion:
       return { os_name: osName, os_version: osVersion };
     case !!lowDiskSpaceHosts:


### PR DESCRIPTION
## Issue
Updates to #15736 
Frontend part of #16419

## Description
- Create `os_version_id` in the URL bar for os version page
- Reroute all links to os version page to use `os_version_id`
- Call API using `os_version_id`
- Filter hosts on manage host page using `os_version_id`

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Manual QA for all new/changed functionality

