### PR TITLE
Fleet UI: Fix policy automations from resetting automations on other pages

### DIFF
--- a/changes/16504-policy-automation-bug
+++ b/changes/16504-policy-automation-bug
@@ -1,0 +1,1 @@
+- Fix a bug where policy automations when saved were resetting automations on other pages

--- a/frontend/pages/policies/ManagePoliciesPage/components/ManagePolicyAutomationsModal/ManagePolicyAutomationsModal.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/components/ManagePolicyAutomationsModal/ManagePolicyAutomationsModal.tsx
@@ -238,11 +238,11 @@ const ManagePolicyAutomationsModal = ({
         );
 
         // Concatenate with array of policies enabled on the page
-        const allEnabledPolices = enabledPoliciesOnOtherPages.concat(
+        const allEnabledPolicies = enabledPoliciesOnOtherPages.concat(
           newPolicyIds
         );
 
-        return allEnabledPolices;
+        return allEnabledPolicies;
       }
 
       return [];

--- a/frontend/pages/policies/ManagePoliciesPage/components/ManagePolicyAutomationsModal/ManagePolicyAutomationsModal.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/components/ManagePolicyAutomationsModal/ManagePolicyAutomationsModal.tsx
@@ -225,11 +225,34 @@ const ManagePolicyAutomationsModal = ({
     //   newPolicyIds = [];
     // }
 
+    const updatedEnabledPoliciesAcrossPages = () => {
+      if (webhook.policy_ids) {
+        // Array of policy ids on the page
+        const availablePoliciesIds = availablePolicies.map(
+          (policy) => policy.id
+        );
+
+        // Array of policy ids enabled NOT on the page
+        const enabledPoliciesOnOtherPages = webhook.policy_ids.filter(
+          (policyId) => !availablePoliciesIds.includes(policyId)
+        );
+
+        // Concatenate with array of policies enabled on the page
+        const allEnabledPolices = enabledPoliciesOnOtherPages.concat(
+          newPolicyIds
+        );
+
+        return allEnabledPolices;
+      }
+
+      return [];
+    };
+
     // NOTE: backend uses webhook_settings to store automated policy ids for both webhooks and integrations
     const newWebhook = {
       failing_policies_webhook: {
         destination_url: destinationUrl,
-        policy_ids: newPolicyIds,
+        policy_ids: updatedEnabledPoliciesAcrossPages(),
         enable_failing_policies_webhook:
           isPolicyAutomationsEnabled && isWebhookEnabled,
       },


### PR DESCRIPTION
## Issue
Cerra #16504 

## Description
- Fix updated policy automations array from replacing all policy automations

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
- [x] Manual QA for all new/changed functionality
