### PR TITLE
Pricing page: Add "Variable agent versions"

### DIFF
--- a/handbook/company/pricing-features-table.yml
+++ b/handbook/company/pricing-features-table.yml
@@ -352,6 +352,13 @@
   productCategories: [Endpoint operations]
   pricingTableCategories: [Endpoint operations]
   usualDepartment: Security
+- industryName: Variable agent versions
+  descrption: Manage agents remotely by setting different versions per-baseline.
+  documentationUrl: https://fleetdm.com/docs/configuration/agent-configuration#configure-fleetd-update-channels
+  tier: Premium
+  productCategories: [Endpoint operations]
+  pricingTableCategories: [Endpoint operations]
+  usualDepartment: IT
 #  ╔═╗╦ ╦╔═╗╔╦╗╔═╗╔╦╗  ╔╦╗╔═╗╔╗ ╦  ╔═╗╔═╗
 #  ║  ║ ║╚═╗ ║ ║ ║║║║   ║ ╠═╣╠╩╗║  ║╣ ╚═╗
 #  ╚═╝╚═╝╚═╝ ╩ ╚═╝╩ ╩   ╩ ╩ ╩╚═╝╩═╝╚═╝╚═╝


### PR DESCRIPTION
- Add item for pricing page for the "Remotely configure fleetd update channels in agent options" (#13825) feature
  - Fleet Premium only
