### PR TITLE
fix: filter out software from parallels vm

### DIFF
--- a/changes/15855-vm-software
+++ b/changes/15855-vm-software
@@ -1,0 +1,2 @@
+- Fixes issue where software from a Parallels VM on a MacOS host would show up in Fleet as if it
+  were the host's software.

--- a/server/service/osquery_utils/queries.go
+++ b/server/service/osquery_utils/queries.go
@@ -1267,6 +1267,10 @@ func directIngestSoftware(ctx context.Context, logger log.Logger, host *fleet.Ho
 
 		sanitizeSoftware(host, s, logger)
 
+		if shouldRemove := shouldRemoveSoftware(host, s); shouldRemove {
+			continue
+		}
+
 		software = append(software, *s)
 
 		installedPath := strings.TrimSpace(row["installed_path"])
@@ -1392,6 +1396,32 @@ func sanitizeSoftware(h *fleet.Host, s *fleet.Software, logger log.Logger) {
 			return
 		}
 	}
+}
+
+// shouldRemoveSoftware returns whether or not we should remove the given Software item from this
+// host's software list.
+func shouldRemoveSoftware(h *fleet.Host, s *fleet.Software) bool {
+	checkers := []struct {
+		shouldRemove func(h *fleet.Host, s *fleet.Software) bool
+	}{
+		// Parallels is a common VM software for MacOS. Parallels makes the VM's applications
+		// visible in the host as MacOS applications, which leads to confusing output (e.g. a MacOS
+		// host reporting that it has Notepad installed when this is just an app from the Windows VM
+		// under Parallels). We want to filter out those "applications" to avoid confusion.
+		{
+			shouldRemove: func(h *fleet.Host, s *fleet.Software) bool {
+				return h.Platform == "darwin" && strings.HasPrefix(s.BundleIdentifier, "com.parallels.winapp")
+			},
+		},
+	}
+
+	for _, c := range checkers {
+		if remove := c.shouldRemove(h, s); remove {
+			return true
+		}
+	}
+
+	return false
 }
 
 func directIngestUsers(ctx context.Context, logger log.Logger, host *fleet.Host, ds fleet.Datastore, rows []map[string]string) error {

--- a/server/service/osquery_utils/queries.go
+++ b/server/service/osquery_utils/queries.go
@@ -1267,7 +1267,7 @@ func directIngestSoftware(ctx context.Context, logger log.Logger, host *fleet.Ho
 
 		sanitizeSoftware(host, s, logger)
 
-		if shouldRemove := shouldRemoveSoftware(host, s); shouldRemove {
+		if shouldRemoveSoftware(host, s) {
 			continue
 		}
 

--- a/server/service/osquery_utils/queries.go
+++ b/server/service/osquery_utils/queries.go
@@ -1401,27 +1401,11 @@ func sanitizeSoftware(h *fleet.Host, s *fleet.Software, logger log.Logger) {
 // shouldRemoveSoftware returns whether or not we should remove the given Software item from this
 // host's software list.
 func shouldRemoveSoftware(h *fleet.Host, s *fleet.Software) bool {
-	checkers := []struct {
-		shouldRemove func(h *fleet.Host, s *fleet.Software) bool
-	}{
-		// Parallels is a common VM software for MacOS. Parallels makes the VM's applications
-		// visible in the host as MacOS applications, which leads to confusing output (e.g. a MacOS
-		// host reporting that it has Notepad installed when this is just an app from the Windows VM
-		// under Parallels). We want to filter out those "applications" to avoid confusion.
-		{
-			shouldRemove: func(h *fleet.Host, s *fleet.Software) bool {
-				return h.Platform == "darwin" && strings.HasPrefix(s.BundleIdentifier, "com.parallels.winapp")
-			},
-		},
-	}
-
-	for _, c := range checkers {
-		if remove := c.shouldRemove(h, s); remove {
-			return true
-		}
-	}
-
-	return false
+	// Parallels is a common VM software for MacOS. Parallels makes the VM's applications
+	// visible in the host as MacOS applications, which leads to confusing output (e.g. a MacOS
+	// host reporting that it has Notepad installed when this is just an app from the Windows VM
+	// under Parallels). We want to filter out those "applications" to avoid confusion.
+	return h.Platform == "darwin" && strings.HasPrefix(s.BundleIdentifier, "com.parallels.winapp")
 }
 
 func directIngestUsers(ctx context.Context, logger log.Logger, host *fleet.Host, ds fleet.Datastore, rows []map[string]string) error {

--- a/server/service/osquery_utils/queries_test.go
+++ b/server/service/osquery_utils/queries_test.go
@@ -1747,3 +1747,30 @@ func TestDirectIngestWindowsProfiles(t *testing.T) {
 		}
 	}
 }
+
+func TestShouldRemoveSoftware(t *testing.T) {
+	tests := []struct {
+		name string
+		want bool
+		s    *fleet.Software
+		h    *fleet.Host
+	}{
+		{
+			name: "parallels windows software on MacOS host",
+			want: true,
+			h:    &fleet.Host{Platform: "darwin"},
+			s:    &fleet.Software{BundleIdentifier: "com.parallels.winapp.notepad", Name: "Notepad.app"},
+		},
+		{
+			name: "regular macos software",
+			want: false,
+			h:    &fleet.Host{Platform: "darwin"},
+			s:    &fleet.Software{BundleIdentifier: "com.apple.dock", Name: "Dock.app"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, shouldRemoveSoftware(tt.h, tt.s))
+		})
+	}
+}


### PR DESCRIPTION
> Related issue: #15855

I followed a similar pattern to `sanitizeSoftware`, a function that modifies the `Software`.  I was originally going to update `sanitizeSoftware` itself, but decided against it 
1. to avoid making lots of changes to the function signature and internals
2. because the logic this issue requires is pretty different from what `sanitizeSoftware` is trying to do, so seemed to warrant its own function.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [x] Added/updated tests
- [x] Manual QA for all new/changed functionality
