### PR TITLE
Ensure salt for saltAndHash password is no longer than keySize

### DIFF
--- a/server/fleet/users.go
+++ b/server/fleet/users.go
@@ -403,6 +403,7 @@ func saltAndHashPassword(keySize int, plaintext string, cost int) (hashed []byte
 	if err != nil {
 		return nil, "", err
 	}
+	salt = salt[:keySize]
 
 	withSalt := []byte(fmt.Sprintf("%s%s", plaintext, salt))
 	hashed, err = bcrypt.GenerateFromPassword(withSalt, cost)

--- a/server/fleet/users.go
+++ b/server/fleet/users.go
@@ -409,7 +409,7 @@ func saltAndHashPassword(keySize int, plaintext string, cost int) (hashed []byte
 	hashed, err = bcrypt.GenerateFromPassword(withSalt, cost)
 	if err != nil {
 		if errors.Is(err, bcrypt.ErrPasswordTooLong) {
-			return nil, "", NewInvalidArgumentError("Could not create user. Password is over the 48 characters limit. If the password is under 48 characters, please check the auth_salt_key_size in your Fleet server config.", "password too long")
+			return nil, "", NewInvalidArgumentError("Password is over the 48-byte limit. If the password is under 48 bytes, please check the auth_salt_key_size in your Fleet server config.", "Password too long")
 		}
 		return nil, "", err
 	}

--- a/server/service/integration_core_test.go
+++ b/server/service/integration_core_test.go
@@ -210,7 +210,7 @@ func (s *integrationTestSuite) TestUserPasswordLengthValidation() {
 	newUPars := fleet.UserPayload{
 		Name:  ptr.String("Justin A Test"),
 		Email: ptr.String("justin@test.com"),
-		// // This is 73 characters long
+		// This is 73 characters long
 		Password:   ptr.String("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaX@1"),
 		GlobalRole: ptr.String(fleet.RoleObserver),
 	}

--- a/server/service/integration_core_test.go
+++ b/server/service/integration_core_test.go
@@ -259,7 +259,7 @@ func (s *integrationTestSuite) TestUserPasswordLengthValidation() {
 		OldPassword: justRightPw,
 		NewPassword: longPw,
 	}
-	changePwPath := "/api/latest/fleet/change_password"
+	changePwPath := "/api/latest/fleet/change_password" // #nosec G101
 
 	badRespChangePw := s.Do("POST", changePwPath, &longPwParams, http.StatusUnprocessableEntity)
 	assertBodyContains(s.T(), badRespChangePw, longPwError)


### PR DESCRIPTION
## Addresses #16487 
- Ensure salt.length <= keysize (24 bytes by default), so that salt.length + password length limit(48 bytes) <= 72 bytes, the limit for the hashing package we use.
- Update integration tests
- Add integration test for password length when salt size is not the default

- [x] Added/updated tests
- [x] Manual QA for all new/changed functionality
