### PR TITLE
(Vulnerabilities feature) Fleet UI: Mock API responses wired up

### DIFF
--- a/frontend/__mocks__/vulnerabilitiesMock.ts
+++ b/frontend/__mocks__/vulnerabilitiesMock.ts
@@ -1,0 +1,45 @@
+import { IVulnerability } from "interfaces/vulnerability";
+import {
+  IVulnerabilitiesResponse,
+  IVulnerabilityResponse,
+} from "services/entities/vulnerabilities";
+
+const DEFAULT_VULNERABILITY: IVulnerability = {
+  cve: "CVE-2022-30190",
+  created_at: "2022-06-01T00:15:00Z",
+  host_count: 1234,
+  host_count_updated_at: "2023-12-20T15:23:57Z",
+  details_link: "https://nvd.nist.gov/vuln/detail/CVE-2022-30190",
+  cvss_score: 7.8, // Available in Fleet Premium
+  epss_probability: 0.9729, // Available in Fleet Premium
+  cisa_known_exploit: false, // Available in Fleet Premium
+  cve_published: "2022-06-01T00:15:00Z", // Available in Fleet Premium
+  cve_description:
+    "Microsoft Windows Support Diagnostic Tool (MSDT) Remote Code Execution Vulnerability.", // Available in Fleet Premium
+  resolved_in_version: "", // Available in Fleet Premium
+};
+
+export const createMockVulnerability = (
+  overrides?: Partial<IVulnerability>
+): IVulnerability => {
+  return { ...DEFAULT_VULNERABILITY, ...overrides };
+};
+
+const DEFAULT_VULNERABILITIES_RESPONSE: IVulnerabilitiesResponse = {
+  count: 1, // Confirm this will be on API
+  counts_updated_at: "2024-02-01T00:00:00Z", // Confirm this will be on API
+  vulnerabilities: [createMockVulnerability()],
+};
+
+export const createMockVulnerabilityResponse = (
+  overrides?: Partial<IVulnerability>
+): IVulnerabilityResponse => {
+  return { vulnerability: { ...DEFAULT_VULNERABILITY, ...overrides } };
+};
+
+// eslint-disable-next-line import/prefer-default-export
+export const createMockVulnerabilitiesResponse = (
+  overrides?: Partial<IVulnerabilitiesResponse>
+): IVulnerabilitiesResponse => {
+  return { ...DEFAULT_VULNERABILITIES_RESPONSE, ...overrides };
+};

--- a/frontend/__mocks__/vulnerabilitiesMock.ts
+++ b/frontend/__mocks__/vulnerabilitiesMock.ts
@@ -29,6 +29,10 @@ const DEFAULT_VULNERABILITIES_RESPONSE: IVulnerabilitiesResponse = {
   count: 1, // Confirm this will be on API
   counts_updated_at: "2024-02-01T00:00:00Z", // Confirm this will be on API
   vulnerabilities: [createMockVulnerability()],
+  meta: {
+    has_next_results: true,
+    has_previous_results: false,
+  },
 };
 
 export const createMockVulnerabilityResponse = (

--- a/frontend/__mocks__/vulnerabilitiesMock.ts
+++ b/frontend/__mocks__/vulnerabilitiesMock.ts
@@ -26,8 +26,8 @@ export const createMockVulnerability = (
 };
 
 const DEFAULT_VULNERABILITIES_RESPONSE: IVulnerabilitiesResponse = {
-  count: 1, // Confirm this will be on API
-  counts_updated_at: "2024-02-01T00:00:00Z", // Confirm this will be on API
+  count: 1,
+  counts_updated_at: "2024-02-01T00:00:00Z",
   vulnerabilities: [createMockVulnerability()],
   meta: {
     has_next_results: true,

--- a/frontend/interfaces/vulnerability.ts
+++ b/frontend/interfaces/vulnerability.ts
@@ -1,6 +1,13 @@
-import PropTypes from "prop-types";
-
-export default PropTypes.shape({
-  cve: PropTypes.string,
-  details_link: PropTypes.string,
-});
+export interface IVulnerability {
+  cve: string;
+  created_at: string;
+  host_count: number;
+  host_count_updated_at: string;
+  details_link: string;
+  cvss_score?: number; // Available in Fleet Premium
+  epss_probability?: number; // Available in Fleet Premium
+  cisa_known_exploit?: boolean; // Available in Fleet Premium
+  cve_published?: string; // Available in Fleet Premium
+  cve_description?: string; // Available in Fleet Premium
+  resolved_in_version?: string; // Available in Fleet Premium
+}

--- a/frontend/services/entities/vulnerabilities.ts
+++ b/frontend/services/entities/vulnerabilities.ts
@@ -22,8 +22,8 @@ export interface IGetVulnerabilitiesQueryKey
 }
 
 export interface IVulnerabilitiesResponse {
-  count: number; // confirm since it's not on draft API
-  counts_updated_at: string; // confirm since it's not on draft API
+  count: number;
+  counts_updated_at: string;
   vulnerabilities: IVulnerability[];
   meta: {
     has_next_results: boolean;

--- a/frontend/services/entities/vulnerabilities.ts
+++ b/frontend/services/entities/vulnerabilities.ts
@@ -1,0 +1,77 @@
+/* eslint-disable @typescript-eslint/explicit-module-boundary-types */
+import sendRequest from "services";
+import endpoints from "utilities/endpoints";
+import { IVulnerability } from "interfaces/vulnerability";
+import { buildQueryStringFromParams } from "utilities/url";
+import {
+  createMockVulnerabilitiesResponse,
+  createMockVulnerabilityResponse,
+} from "__mocks__/vulnerabilitiesMock";
+
+export interface IGetVulnerabilitiesQueryParams {
+  teamId?: number;
+  order_key?: string;
+  order_direction?: string;
+  page?: number;
+  per_page?: number;
+}
+
+export interface IGetVulnerabilitiesQueryKey
+  extends IGetVulnerabilitiesQueryParams {
+  scope: string;
+}
+
+export interface IVulnerabilitiesResponse {
+  count: number; // confirm since it's not on draft API
+  counts_updated_at: string; // confirm since it's not on draft API
+  vulnerabilities: IVulnerability[];
+  // Tim requested to remove meta since we're paginating on frontend
+  // meta: {
+  //   has_next_results: boolean;
+  //   has_previous_results: boolean;
+  // };
+}
+
+export interface IVulnerabilityResponse {
+  vulnerability: IVulnerability;
+}
+
+export const getVulnerabilities = ({
+  teamId,
+  order_key,
+  order_direction,
+  page,
+  per_page,
+}: IGetVulnerabilitiesQueryParams = {}): Promise<IVulnerabilitiesResponse> => {
+  const { VULNERABILITIES } = endpoints;
+  let path = VULNERABILITIES;
+
+  const queryString = buildQueryStringFromParams({
+    team_id: teamId,
+    order_key,
+    order_direction,
+    page,
+    per_page,
+  });
+
+  if (queryString) path += `?${queryString}`;
+
+  // return sendRequest("GET", path); // TODO: API INTEGRATION: uncomment when API is ready
+  return new Promise((resolve, reject) => {
+    resolve(createMockVulnerabilitiesResponse());
+  });
+};
+
+const getVulnerability = (id: number): Promise<IVulnerabilityResponse> => {
+  const { VULNERABILITY } = endpoints;
+
+  // return sendRequest("GET", VULNERABILITY(id)); // TODO: API INTEGRATION: uncomment when API is ready
+  return new Promise((resolve, reject) => {
+    resolve(createMockVulnerabilityResponse());
+  });
+};
+
+export default {
+  getVulnerabilities,
+  getVulnerability,
+};

--- a/frontend/services/entities/vulnerabilities.ts
+++ b/frontend/services/entities/vulnerabilities.ts
@@ -25,11 +25,10 @@ export interface IVulnerabilitiesResponse {
   count: number; // confirm since it's not on draft API
   counts_updated_at: string; // confirm since it's not on draft API
   vulnerabilities: IVulnerability[];
-  // Tim requested to remove meta since we're paginating on frontend
-  // meta: {
-  //   has_next_results: boolean;
-  //   has_previous_results: boolean;
-  // };
+  meta: {
+    has_next_results: boolean;
+    has_previous_results: boolean;
+  };
 }
 
 export interface IVulnerabilityResponse {

--- a/frontend/utilities/endpoints.ts
+++ b/frontend/utilities/endpoints.ts
@@ -149,6 +149,10 @@ export default {
   USERS_ADMIN: `/${API_VERSION}/fleet/users/admin`,
   VERSION: `/${API_VERSION}/fleet/version`,
 
+  // Vulnerabilities endpoints
+  VULNERABILITIES: `/${API_VERSION}/fleet/vulnerabilities`,
+  VULNERABILITY: (id: number) => `/${API_VERSION}/fleet/vulnerabilities/${id}`,
+
   // Script endpoints
   HOST_SCRIPTS: (id: number) => `/${API_VERSION}/fleet/hosts/${id}/scripts`,
   SCRIPTS: `/${API_VERSION}/fleet/scripts`,


### PR DESCRIPTION
## Issue
Addresses #16470

## Description 
- Build Mocks `__mocks__/vulnerabiltiesMock.tsx`
  - Mock vulnerability
  - Mock API vulnerability response
  - Mock API vulnerabilities response
- Create API callers `entities/vulnerabilities.tsx` and response interfaces
  - `getVulnerability(id)` response `IVulnerabilityResponse`
  - `getVulnerabilities` response `IVulnerabilitiesResponse`
- Create interfaces `interfaces/vulnerability`
  - `IVulnerability`
- Define endpoints to call API at in `utilities/endpoints.ts`
  - ```VULNERABILITIES: `/${API_VERSION}/fleet/vulnerabilities` ```
  - ```VULNERABILITY: (id: number) => `/${API_VERSION}/fleet/vulnerabilities/${id}` ```

## TODO
- [x] Confirm all interface types
- [x] Confirm mock responses
- [ ] Make a mock for edge case responses
- [x] Point this PR to our feature branch

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [ ] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [ ] Documented any permissions changes (docs/Using Fleet/manage-access.md)
- [ ] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [ ] Added support on fleet's osquery simulator `cmd/osquery-perf` for new osquery data ingestion features.
- [ ] Added/updated tests
- [ ] If database migrations are included, checked table schema to confirm autoupdate 
- For database migrations:
  - [ ] Checked schema for all modified table for columns that will auto-update timestamps during migration.
  - [ ] Confirmed that updating the timestamps is acceptable, and will not cause unwanted side effects.
- [ ] Manual QA for all new/changed functionality
  - For Orbit and Fleet Desktop changes:
    - [ ] Manual QA must be performed in the three main OSs, macOS, Windows and Linux.
    - [ ] Auto-update manual QA, from released version of component to new version (see [tools/tuf/test](../tools/tuf/test/README.md)).
