### PR TITLE
Document how performance indicator text is determined

### DIFF
--- a/articles/fleet-4.5.0.md
+++ b/articles/fleet-4.5.0.md
@@ -55,6 +55,12 @@ When creating or editing a query in Fleet (either a live query, schedule, or pol
 
 This new feature allows users to see an indication of the performance impact of scheduled queries across all devices. This is useful for mitigating the potential risk of disruption to end-users when running queries.
 
+The level of performance impact is derived from [a query's `stats` object](https://fleetdm.com/docs/rest-api/rest-api#get-query), by totaling up `stats.system_time_p50` and `stats.user_time_p50`:
+
++ **Minimal:** less than 2000
++ **Considerable:** 2000-3999
++ **Excessive:** 4000+
+
 ## First steps towards aggregated device data on the Fleet UI dashboard
 **Available in Fleet Free & Fleet Premium**
 

--- a/articles/fleet-4.5.0.md
+++ b/articles/fleet-4.5.0.md
@@ -55,7 +55,7 @@ When creating or editing a query in Fleet (either a live query, schedule, or pol
 
 This new feature allows users to see an indication of the performance impact of scheduled queries across all devices. This is useful for mitigating the potential risk of disruption to end-users when running queries.
 
-The level of performance impact is derived from [a query's `stats` object](https://fleetdm.com/docs/rest-api/rest-api#get-query), by totaling up `stats.system_time_p50` and `stats.user_time_p50`:
+The level of performance impact is derived from [a query's `stats` object](https://fleetdm.com/docs/rest-api/rest-api#get-query), by totaling up milliseconds `stats.system_time_p50` and `stats.user_time_p50`:
 
 + **Minimal:** less than 2000
 + **Considerable:** 2000-3999


### PR DESCRIPTION
Proposing this as a potential resolution for https://github.com/fleetdm/fleet/issues/16123.
 
The only place we talk about performance impact in the docs is [here](https://fleetdm.com/docs/get-started/faq#will-fleet-slow-down-my-servers-what-about-my-employee-laptops), and it feels too high-level to include these details.

Since that FAQ section links to this article for more information about performance impact, this seems like the most appropriate place to document that info without adding surface area to the conceptual docs.

Code for displaying performance impact: https://github.com/fleetdm/fleet/blob/7da9019f4d06fe088fca8dab1bb39e30a42d04bb/frontend/utilities/helpers.tsx#L691-L706