### PR TITLE
Server configuration docs: `enable_scheduled_query_stats`

### DIFF
--- a/docs/Configuration/fleet-server-configuration.md
+++ b/docs/Configuration/fleet-server-configuration.md
@@ -758,7 +758,9 @@ How long invite tokens should be valid for.
 
 ##### app_enable_scheduled_query_stats
 
-Determines whether Fleet gets scheduled query statistics from hosts or not.
+Determines whether Fleet collects performance impact statistics for scheduled queries.
+
+If set to `false`, stats are still collected for live queries.
 
 - Default value: `true`
 - Environment variable: `FLEET_APP_ENABLE_SCHEDULED_QUERY_STATS`


### PR DESCRIPTION
- Clearly document the behavior for `enable_scheduled_query_stats`

For the following issue: #15915
