### PR TITLE
Website: fix incorrect conditional statement in Datadog script

### DIFF
--- a/website/scripts/send-aggregated-metrics-to-datadog.js
+++ b/website/scripts/send-aggregated-metrics-to-datadog.js
@@ -128,7 +128,7 @@ module.exports = {
     }
 
     for(let version of combinedHostsEnrolledByOsqueryVersion) {
-      if(version.osqueryVersion === ''){
+      if(version.osqueryVersion !== ''){
         let metricToAdd = {
           metric: 'usage_statistics_v2.host_count_by_osquery_version',
           type: 3,


### PR DESCRIPTION
Changes:
- Updated a conditional statement in the `send-aggregated-metrics-to-datadog` script. (`===` » `!==`)