### PR TITLE
add a backoff during orbit enroll retries

### DIFF
--- a/changes/16594-orbit-enroll-backoff-retry
+++ b/changes/16594-orbit-enroll-backoff-retry
@@ -1,0 +1,1 @@
+- Add a backoff mechanism to enroll failures when orbit is enrolling into fleet.

--- a/orbit/pkg/constant/constant.go
+++ b/orbit/pkg/constant/constant.go
@@ -23,6 +23,9 @@ const (
 	OrbitEnrollMaxRetries = 3
 	// OrbitEnrollRetrySleep is the time duration to sleep between retries
 	OrbitEnrollRetrySleep = 5 * time.Second
+	// OrbitEnrollBackoff enables or disables backoff enrollment.
+	// At the moment this just doubles on each backoff to a max of 5*OrbitEnrollRetrySleep
+	OrbitEnrollBackoff = true
 	// OsquerydName is the name of osqueryd binary
 	// We use osqueryd as name to properly identify the process when listing
 	// running processes/tasks.

--- a/pkg/retry/retry_test.go
+++ b/pkg/retry/retry_test.go
@@ -24,6 +24,28 @@ func TestRetryDo(t *testing.T) {
 		require.Equal(t, max, count)
 	})
 
+	t.Run("retry backoff should only allow a 5x increase on interval") func(t *testing.T) {
+	  count := 0
+	  max := 10
+	  maxTime := time.Duration(1*time.Millisecond)
+	  expectedMaxTime := time.Duration(5*time.Millisecond)
+
+	  err := Do(func() error {
+				count++
+				if (time.Duration(count) * time.Millisecond) <= expectedMaxTime {
+					maxTime = time.Duration(count) * time.Millisecond
+				} else {
+					maxTime = expectedMaxTime
+				}
+				if maxTime > expectedMaxTime {
+					return errTest
+				}
+				return nil
+	  }), WithMaxAttempts(max), WithBackoff(true), WithInterval(1*time.Millisecond))
+	  require.NoError(t, err)
+	  require.Equal(t, maxTime, expectedMaxTime)
+	})
+
 	t.Run("operations are run an unlimited number of times by default", func(t *testing.T) {
 		count := 0
 		max := 10

--- a/server/service/orbit_client.go
+++ b/server/service/orbit_client.go
@@ -258,6 +258,7 @@ func (oc *OrbitClient) getNodeKeyOrEnroll() (string, error) {
 			}
 		},
 		retry.WithInterval(OrbitRetryInterval()),
+		retry.WithBackoff(OrbitRetryBackoff()),
 		retry.WithMaxAttempts(constant.OrbitEnrollMaxRetries),
 	); err != nil {
 		return "", fmt.Errorf("orbit node key enroll failed, attempts=%d", constant.OrbitEnrollMaxRetries)
@@ -366,6 +367,14 @@ func OrbitRetryInterval() time.Duration {
 		}
 	}
 	return constant.OrbitEnrollRetrySleep
+}
+
+func OrbitRetryBackoff() bool {
+	backoff := os.Getenv("FLEETD_ENROLL_BACKOFF")
+	if backoff != "" {
+	  return backoff
+	}
+	return constant.OrbitEnrollBackoff
 }
 
 // SetOrUpdateDiskEncryptionKey sends a request to the server to set or update the disk


### PR DESCRIPTION
# Checklist for submitter
- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [x] Added/updated tests
- [ ] Manual QA for all new/changed functionality
  - For Orbit and Fleet Desktop changes:
    - [ ] Manual QA must be performed in the three main OSs, macOS, Windows and Linux.
    - [ ] Auto-update manual QA, from released version of component to new version (see [tools/tuf/test](../tools/tuf/test/README.md)).

This is for #16594 