### PR TITLE
Website - device management - "consolidate" to "simplify" text change

### DIFF
--- a/website/views/pages/device-management.ejs
+++ b/website/views/pages/device-management.ejs
@@ -13,7 +13,7 @@
           <div purpose="hero-text">
             <strong>Your last MDM migration</strong>
             <p>Even if you've never done an MDM migration, you've probably heard it's hard.  Fleet makes it easy to get your data in and get it out.</p>
-            <strong>Consolidate your tools</strong>
+            <strong>Simplify your tools</strong>
             <p>Deploy a modern Mac-first MDM that’s purpose-built to manage your Apple, Windows, and Linux computers.</p>
             <strong>Implement “zero trust” faster</strong>
             <p>Use Fleet to enforce conditional access checking at login. (It's pretty easy to customize whatever you need.)</p>
@@ -59,10 +59,10 @@
         </div>
       </div>
 
-      <%/* Consolidate your tools section */%>
+      <%/* Simplify your tools section */%>
       <div purpose="page-section">
         <div purpose="feature-headline">
-          <h2>Consolidate your tools</h2>
+          <h2>Simplify your tools</h2>
           <p>Deploy a modern Mac-first MDM that’s purpose-built to manage your Apple, Windows, and Linux computers.</p>
         </div>
 


### PR DESCRIPTION
In response to https://github.com/fleetdm/confidential/issues/5284.

I've always preferred "simplifying" to "consolidating." While consolidation is good, it sounds time-consuming and tough. "Simplifying" sounds easy by nature and tips a hat towards Fleet being a simple tool to use.

Not sure yet about the zero trust header, so will tackle that separately.


# Checklist for submitter

- [x] Manual QA for all new/changed functionality