### PR TITLE
add missing fields, restore legacy types for proper build

### DIFF
--- a/frontend/__mocks__/operatingSystemsMock.ts
+++ b/frontend/__mocks__/operatingSystemsMock.ts
@@ -9,7 +9,7 @@ const DEFAULT_OS_VERSION: IOperatingSystemVersion = {
   version: "10.15.7",
   platform: "darwin",
   hosts_count: 1,
-  generated_cpe: "cpe:/o:apple:mac_os_x:10.15.7",
+  generated_cpes: ["cpe:/o:apple:mac_os_x:10.15.7"],
   vulnerabilities: [createMockSoftwareVulnerability()],
 };
 

--- a/frontend/__mocks__/vulnerabilitiesMock.ts
+++ b/frontend/__mocks__/vulnerabilitiesMock.ts
@@ -17,6 +17,8 @@ const DEFAULT_VULNERABILITY: IVulnerability = {
   cve_description:
     "Microsoft Windows Support Diagnostic Tool (MSDT) Remote Code Execution Vulnerability.", // Available in Fleet Premium
   resolved_in_version: "", // Available in Fleet Premium
+  os_versions: [],
+  software: [],
 };
 
 export const createMockVulnerability = (

--- a/frontend/interfaces/operating_system.ts
+++ b/frontend/interfaces/operating_system.ts
@@ -7,7 +7,7 @@ export interface IOperatingSystemVersion {
   version: string;
   platform: string;
   hosts_count: number;
-  generated_cpe: string;
+  generated_cpes?: string[];
   vulnerabilities: ISoftwareVulnerability[];
 }
 

--- a/frontend/interfaces/vulnerability.ts
+++ b/frontend/interfaces/vulnerability.ts
@@ -1,13 +1,29 @@
+import { IOperatingSystemVersion } from "./operating_system";
+import { ISoftware } from "./software";
+
 export interface IVulnerability {
   cve: string;
   created_at: string;
   host_count: number;
   host_count_updated_at: string;
   details_link: string;
-  cvss_score?: number; // Available in Fleet Premium
-  epss_probability?: number; // Available in Fleet Premium
-  cisa_known_exploit?: boolean; // Available in Fleet Premium
-  cve_published?: string; // Available in Fleet Premium
-  cve_description?: string; // Available in Fleet Premium
-  resolved_in_version?: string; // Available in Fleet Premium
+  cvss_score?: number; // premium
+  epss_probability?: number; // premium
+  cisa_known_exploit?: boolean; // premium
+  cve_published?: string; // premium
+  cve_description?: string; // premium
+  resolved_in_version?: string; // premium
+
+  os_versions: Array<
+    Omit<
+      IOperatingSystemVersion,
+      "vulnerabilities" | "generated_cpe" | "hosts_count"
+    > & { host_count: number }
+  >;
+
+  software: Array<
+    Omit<ISoftware, "vulnerabilities" | "hosts_count"> & {
+      host_count: number;
+    }
+  >;
 }

--- a/frontend/interfaces/vulnerability.ts
+++ b/frontend/interfaces/vulnerability.ts
@@ -1,6 +1,12 @@
+import PropTypes from "prop-types";
+
 import { IOperatingSystemVersion } from "./operating_system";
 import { ISoftware } from "./software";
 
+export default PropTypes.shape({
+  cve: PropTypes.string,
+  details_link: PropTypes.string,
+});
 export interface IVulnerability {
   cve: string;
   created_at: string;
@@ -13,17 +19,6 @@ export interface IVulnerability {
   cve_published?: string; // premium
   cve_description?: string; // premium
   resolved_in_version?: string; // premium
-
-  os_versions: Array<
-    Omit<
-      IOperatingSystemVersion,
-      "vulnerabilities" | "generated_cpe" | "hosts_count"
-    > & { host_count: number }
-  >;
-
-  software: Array<
-    Omit<ISoftware, "vulnerabilities" | "hosts_count"> & {
-      host_count: number;
-    }
-  >;
+  os_versions: Omit<IOperatingSystemVersion, "vulnerabilities">[];
+  software: Omit<ISoftware, "vulnerabilities">[];
 }


### PR DESCRIPTION
- Add missing fields to `IVulnerability`
- Fix field on `IOperatingSystemVersion`, which is used by above interface
- Restore legacy props whose removal broke branch build (unrelated to this work, separate API)