### PR TITLE
Add redirect for use in CLI

### DIFF
--- a/website/config/routes.js
+++ b/website/config/routes.js
@@ -508,8 +508,9 @@ module.exports.routes = {
   // Redirects for external links from the Fleet UI & CLI, including to fleetdm.com and to external websites not
   // maintained by Fleet. These help avoid broken links by reducing surface area of links to maintain in the UI.
   'GET /learn-more-about/chromeos-updates': 'https://support.google.com/chrome/a/answer/6220366',
-  'GET /learn-more-about/just-in-time-provisioning': 'https://fleetdm.com/docs/deploy/single-sign-on-sso#just-in-time-jit-user-provisioning',
+  'GET /learn-more-about/just-in-time-provisioning': '/docs/deploy/single-sign-on-sso#just-in-time-jit-user-provisioning',
   'GET /sign-in-to/microsoft-automatic-enrollment-tool': 'https://portal.azure.com',
+  'GET /learn-more-about/enrolling-hosts': '/docs/using-fleet/adding-hosts',
 
   // Sitemap
   // =============================================================================================================

--- a/website/config/routes.js
+++ b/website/config/routes.js
@@ -508,7 +508,7 @@ module.exports.routes = {
   // Redirects for external links from the Fleet UI & CLI, including to fleetdm.com and to external websites not
   // maintained by Fleet. These help avoid broken links by reducing surface area of links to maintain in the UI.
   'GET /learn-more-about/chromeos-updates': 'https://support.google.com/chrome/a/answer/6220366',
-  'GET /learn-more-about/just-in-time-provisioning': '/docs/deploy/single-sign-on-sso#just-in-time-jit-user-provisioning',
+  'GET /learn-more-about/just-in-time-provisioning': 'https://fleetdm.com/docs/deploy/single-sign-on-sso#just-in-time-jit-user-provisioning',
   'GET /sign-in-to/microsoft-automatic-enrollment-tool': 'https://portal.azure.com',
   'GET /learn-more-about/enrolling-hosts': '/docs/using-fleet/adding-hosts',
 


### PR DESCRIPTION
Add redirect for a "more info" link printed to the CLI (so if the docs URL changes, we don't need to update it in the product as well).

For https://github.com/fleetdm/fleet/issues/16382 (subtask of #9949)