### PR TITLE
UI - center the host count within its container

### DIFF
--- a/frontend/pages/DashboardPage/components/InfoCard/_styles.scss
+++ b/frontend/pages/DashboardPage/components/InfoCard/_styles.scss
@@ -19,6 +19,8 @@
     display: flex;
     gap: $pad-xsmall;
     span {
+      display: flex;
+      align-items: center;
       background-color: $core-vibrant-blue;
       color: $core-white;
       font-size: $xx-small;


### PR DESCRIPTION
## Addresses a small unfiled bug:
before - visible on Firefox only:
<img width="148" alt="Screenshot 2024-02-06 at 2 15 14 PM" src="https://github.com/fleetdm/fleet/assets/61553566/4319df13-8836-4db9-9362-743ee280d086">

after:
<img width="148" alt="Screenshot 2024-02-06 at 2 15 03 PM" src="https://github.com/fleetdm/fleet/assets/61553566/33daef5b-c7dd-48de-a4b0-3671ebc21f06">


- [x] Manual QA for all new/changed functionality