### PR TITLE
(Released bugs) Fleet UI label bugs: Dynamic platform labels, chromeos dashboard filters for missing chromeos hosts

### DIFF
--- a/changes/16669-fix-hardcoded-label-bug
+++ b/changes/16669-fix-hardcoded-label-bug
@@ -1,0 +1,1 @@
+- Fixed built in platform labels bug

--- a/frontend/interfaces/host_summary.ts
+++ b/frontend/interfaces/host_summary.ts
@@ -1,13 +1,8 @@
+import { ILabelSummary } from "./label";
+
 export interface IHostSummaryPlatforms {
   platform: string;
   hosts_count: number;
-}
-
-export interface IHostSummaryLabel {
-  id: number;
-  name: string;
-  description: string;
-  label_type: "regular" | "builtin";
 }
 
 export interface IHostSummary {
@@ -20,5 +15,5 @@ export interface IHostSummary {
   new_count: number;
   missing_30_days_count?: number; // premium feature
   low_disk_space_count?: number; // premium feature
-  builtin_labels: IHostSummaryLabel[];
+  builtin_labels: ILabelSummary[];
 }

--- a/frontend/pages/DashboardPage/DashboardPage.tsx
+++ b/frontend/pages/DashboardPage/DashboardPage.tsx
@@ -447,6 +447,7 @@ const DashboardPage = ({ router, location }: IDashboardProps): JSX.Element => {
         linuxCount={linuxCount}
         chromeCount={chromeCount}
         isLoadingHostsSummary={isHostSummaryFetching}
+        builtInLabels={labels}
         showHostsUI={showHostsUI}
         selectedPlatform={selectedPlatform}
         errorHosts={!!errorHosts}

--- a/frontend/pages/DashboardPage/cards/HostsSummary/HostsSummary.tsx
+++ b/frontend/pages/DashboardPage/cards/HostsSummary/HostsSummary.tsx
@@ -48,47 +48,87 @@ const HostsSummary = ({
     select: ({ specs }) => specs.id,
   });
 
-  const renderMacCount = (teamId?: number) => (
-    <SummaryTile
-      iconName="darwin"
-      circledIcon
-      count={macCount}
-      isLoading={isLoadingHostsSummary}
-      showUI={showHostsUI}
-      title={`macOS host${macCount === 1 ? "" : "s"}`}
-      path={PATHS.MANAGE_HOSTS_LABEL(7).concat(
-        teamId !== undefined ? `?team_id=${teamId}` : ""
-      )}
-    />
-  );
+  const { isLoading: isLoadingLinuxLabelId, data: linuxLabelId } = useQuery<
+    ILabelSpecResponse,
+    Error,
+    number
+  >("linuxLabelId", () => labelsAPI.specByName("All Linux"), {
+    select: ({ specs }) => specs.id,
+  });
 
-  const renderWindowsCount = (teamId?: number) => (
-    <SummaryTile
-      iconName="windows"
-      circledIcon
-      count={windowsCount}
-      isLoading={isLoadingHostsSummary}
-      showUI={showHostsUI}
-      title={`Windows host${windowsCount === 1 ? "" : "s"}`}
-      path={PATHS.MANAGE_HOSTS_LABEL(10).concat(
-        teamId !== undefined ? `?team_id=${teamId}` : ""
-      )}
-    />
-  );
+  const { isLoading: isLoadingMacLabelId, data: macLabelId } = useQuery<
+    ILabelSpecResponse,
+    Error,
+    number
+  >("macLabelId", () => labelsAPI.specByName("macOS"), {
+    select: ({ specs }) => specs.id,
+  });
 
-  const renderLinuxCount = (teamId?: number) => (
-    <SummaryTile
-      iconName="linux"
-      circledIcon
-      count={linuxCount}
-      isLoading={isLoadingHostsSummary}
-      showUI={showHostsUI}
-      title={`Linux host${linuxCount === 1 ? "" : "s"}`}
-      path={PATHS.MANAGE_HOSTS_LABEL(12).concat(
-        teamId !== undefined ? `?team_id=${teamId}` : ""
-      )}
-    />
-  );
+  const { isLoading: isLoadingWindowsLabelId, data: windowsLabelId } = useQuery<
+    ILabelSpecResponse,
+    Error,
+    number
+  >("windowsLabelId", () => labelsAPI.specByName("MS Windows"), {
+    select: ({ specs }) => specs.id,
+  });
+
+  const renderMacCount = (teamId?: number) => {
+    if (isLoadingMacLabelId || macLabelId === undefined) {
+      return <></>;
+    }
+
+    return (
+      <SummaryTile
+        iconName="darwin"
+        circledIcon
+        count={macCount}
+        isLoading={isLoadingHostsSummary}
+        showUI={showHostsUI}
+        title={`macOS host${macCount === 1 ? "" : "s"}`}
+        path={PATHS.MANAGE_HOSTS_LABEL(macLabelId).concat(
+          teamId !== undefined ? `?team_id=${teamId}` : ""
+        )}
+      />
+    );
+  };
+
+  const renderWindowsCount = (teamId?: number) => {
+    if (isLoadingWindowsLabelId || windowsLabelId === undefined) {
+      return <></>;
+    }
+    return (
+      <SummaryTile
+        iconName="windows"
+        circledIcon
+        count={windowsCount}
+        isLoading={isLoadingHostsSummary}
+        showUI={showHostsUI}
+        title={`Windows host${windowsCount === 1 ? "" : "s"}`}
+        path={PATHS.MANAGE_HOSTS_LABEL(windowsLabelId).concat(
+          teamId !== undefined ? `?team_id=${teamId}` : ""
+        )}
+      />
+    );
+  };
+
+  const renderLinuxCount = (teamId?: number) => {
+    if (isLoadingLinuxLabelId || linuxLabelId === undefined) {
+      return <></>;
+    }
+    return (
+      <SummaryTile
+        iconName="linux"
+        circledIcon
+        count={linuxCount}
+        isLoading={isLoadingHostsSummary}
+        showUI={showHostsUI}
+        title={`Linux host${linuxCount === 1 ? "" : "s"}`}
+        path={PATHS.MANAGE_HOSTS_LABEL(linuxLabelId).concat(
+          teamId !== undefined ? `?team_id=${teamId}` : ""
+        )}
+      />
+    );
+  };
 
   const renderChromeCount = (teamId?: number) => {
     if (isLoadingChromeLabelId || chromeLabelId === undefined) {

--- a/frontend/pages/DashboardPage/cards/HostsSummary/HostsSummary.tsx
+++ b/frontend/pages/DashboardPage/cards/HostsSummary/HostsSummary.tsx
@@ -67,7 +67,7 @@ const HostsSummary = ({
 
   const renderWindowsCount = (teamId?: number) => {
     const windowsLabelId = builtInLabels?.find(
-      (builtin) => builtin.name === "MS Windows"
+      (builtin) => builtin.name === PLATFORM_NAME_TO_LABEL_NAME.windows
     )?.id;
 
     if (isLoadingHostsSummary || windowsLabelId === undefined) {
@@ -90,7 +90,7 @@ const HostsSummary = ({
 
   const renderLinuxCount = (teamId?: number) => {
     const linuxLabelId = builtInLabels?.find(
-      (builtin) => builtin.name === "All Linux"
+      (builtin) => builtin.name === PLATFORM_NAME_TO_LABEL_NAME.linux
     )?.id;
 
     if (isLoadingHostsSummary || linuxLabelId === undefined) {
@@ -113,7 +113,7 @@ const HostsSummary = ({
 
   const renderChromeCount = (teamId?: number) => {
     const chromeLabelId = builtInLabels?.find(
-      (builtin) => builtin.name === "chrome"
+      (builtin) => builtin.name === PLATFORM_NAME_TO_LABEL_NAME.chrome
     )?.id;
 
     if (isLoadingHostsSummary || chromeLabelId === undefined) {

--- a/frontend/pages/DashboardPage/cards/HostsSummary/HostsSummary.tsx
+++ b/frontend/pages/DashboardPage/cards/HostsSummary/HostsSummary.tsx
@@ -1,11 +1,10 @@
 import React from "react";
 import PATHS from "router/paths";
 
-import labelsAPI from "services/entities/labels";
+import { PLATFORM_NAME_TO_LABEL_NAME } from "utilities/constants";
 import DataError from "components/DataError";
 import { SelectedPlatform } from "interfaces/platform";
-import { useQuery } from "react-query";
-import { ILabelSpecResponse } from "interfaces/label";
+import { IHostSummary } from "interfaces/host_summary";
 
 import SummaryTile from "./SummaryTile";
 
@@ -18,6 +17,7 @@ interface IHostSummaryProps {
   linuxCount: number;
   chromeCount: number;
   isLoadingHostsSummary: boolean;
+  builtInLabels?: IHostSummary["builtin_labels"];
   showHostsUI: boolean;
   errorHosts: boolean;
   selectedPlatform?: SelectedPlatform;
@@ -30,6 +30,7 @@ const HostsSummary = ({
   linuxCount,
   chromeCount,
   isLoadingHostsSummary,
+  builtInLabels,
   showHostsUI,
   errorHosts,
   selectedPlatform,
@@ -39,41 +40,13 @@ const HostsSummary = ({
   if (showHostsUI) {
     opacity = isLoadingHostsSummary ? { opacity: 0.4 } : { opacity: 1 };
   }
-  // get the id for the label for chrome hosts - this will be unique to each Fleet instance
-  const { isLoading: isLoadingChromeLabelId, data: chromeLabelId } = useQuery<
-    ILabelSpecResponse,
-    Error,
-    number
-  >("chromeLabelId", () => labelsAPI.specByName("chrome"), {
-    select: ({ specs }) => specs.id,
-  });
-
-  const { isLoading: isLoadingLinuxLabelId, data: linuxLabelId } = useQuery<
-    ILabelSpecResponse,
-    Error,
-    number
-  >("linuxLabelId", () => labelsAPI.specByName("All Linux"), {
-    select: ({ specs }) => specs.id,
-  });
-
-  const { isLoading: isLoadingMacLabelId, data: macLabelId } = useQuery<
-    ILabelSpecResponse,
-    Error,
-    number
-  >("macLabelId", () => labelsAPI.specByName("macOS"), {
-    select: ({ specs }) => specs.id,
-  });
-
-  const { isLoading: isLoadingWindowsLabelId, data: windowsLabelId } = useQuery<
-    ILabelSpecResponse,
-    Error,
-    number
-  >("windowsLabelId", () => labelsAPI.specByName("MS Windows"), {
-    select: ({ specs }) => specs.id,
-  });
 
   const renderMacCount = (teamId?: number) => {
-    if (isLoadingMacLabelId || macLabelId === undefined) {
+    const macLabelId = builtInLabels?.find((builtin) => {
+      return builtin.name === PLATFORM_NAME_TO_LABEL_NAME.darwin;
+    })?.id;
+
+    if (isLoadingHostsSummary || macLabelId === undefined) {
       return <></>;
     }
 
@@ -93,7 +66,11 @@ const HostsSummary = ({
   };
 
   const renderWindowsCount = (teamId?: number) => {
-    if (isLoadingWindowsLabelId || windowsLabelId === undefined) {
+    const windowsLabelId = builtInLabels?.find(
+      (builtin) => builtin.name === "MS Windows"
+    )?.id;
+
+    if (isLoadingHostsSummary || windowsLabelId === undefined) {
       return <></>;
     }
     return (
@@ -112,7 +89,11 @@ const HostsSummary = ({
   };
 
   const renderLinuxCount = (teamId?: number) => {
-    if (isLoadingLinuxLabelId || linuxLabelId === undefined) {
+    const linuxLabelId = builtInLabels?.find(
+      (builtin) => builtin.name === "All Linux"
+    )?.id;
+
+    if (isLoadingHostsSummary || linuxLabelId === undefined) {
       return <></>;
     }
     return (
@@ -131,7 +112,11 @@ const HostsSummary = ({
   };
 
   const renderChromeCount = (teamId?: number) => {
-    if (isLoadingChromeLabelId || chromeLabelId === undefined) {
+    const chromeLabelId = builtInLabels?.find(
+      (builtin) => builtin.name === "chrome"
+    )?.id;
+
+    if (isLoadingHostsSummary || chromeLabelId === undefined) {
       return <></>;
     }
 

--- a/frontend/utilities/constants.tsx
+++ b/frontend/utilities/constants.tsx
@@ -234,12 +234,13 @@ export const SCHEDULE_PLATFORM_DROPDOWN_OPTIONS: IPlatformDropdownOptions[] = [
   { label: "Linux", value: "linux" },
 ];
 
+// Builtin label names returned from API
 export const PLATFORM_NAME_TO_LABEL_NAME = {
   all: "",
   darwin: "macOS",
   windows: "MS Windows",
   linux: "All Linux",
-  chrome: "ChromeOS",
+  chrome: "chrome",
 };
 
 export const HOSTS_SEARCH_BOX_PLACEHOLDER =


### PR DESCRIPTION
## Issue
Cerra #16669 
Cerra #16702 

## Description
- Remove hardcoded label IDs and use label name to find IDs to use)
- Looked through frontend and ensured there are no other places in our app do we hardcode label ids
- Fixed code that was searching for the label ID of `name: "ChromeOS"` when the API returns `name: "chrome"`

### User facing fixes
- Dashboard > Platform count now correctly links to Manage host page with platform filtered for users who have builtin label ids that were different than the hardcoded label id
- Dashboard > ChromeOS > missing hosts now correctly links to Manage host page with Chrome filtered

## Screen recording of fixes (Updated 2/9/24)
https://www.loom.com/share/8024219b85d04a4daac2ed7e04e42399?sid=f958c35f-1ea7-46f9-aeae-d36c63247765

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
- [x] Manual QA for all new/changed functionality
