### PR TITLE
(Released Bugs) Fleet UI: Fix software query params bugs

### DIFF
--- a/changes/16672-software-url-states-bug
+++ b/changes/16672-software-url-states-bug
@@ -1,0 +1,2 @@
+- Fix URL query params to reset when switching tabs
+- Fix vulnerable software dropdown from switching back to all teams

--- a/frontend/pages/SoftwarePage/SoftwarePage.tsx
+++ b/frontend/pages/SoftwarePage/SoftwarePage.tsx
@@ -256,10 +256,8 @@ const SoftwarePage = ({ children, router, location }: ISoftwarePageProps) => {
 
   const navigateToNav = useCallback(
     (i: number): void => {
-      const navPath = softwareSubNav[i].pathname;
-      router.replace(
-        navPath.concat(location?.search || "").concat(location?.hash || "")
-      );
+      const navPath = softwareSubNav[i].pathname.concat(location?.hash || "");
+      router.replace(navPath);
     },
     [location, router]
   );

--- a/frontend/pages/SoftwarePage/SoftwareTitles/SoftwareTable/SoftwareTable.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitles/SoftwareTable/SoftwareTable.tsx
@@ -207,9 +207,9 @@ const SoftwareTable = ({
         routeTemplate: "",
         queryParams: {
           query,
-          teamId,
-          orderDirection,
-          orderKey,
+          team_id: teamId,
+          order_direction: orderDirection,
+          order_key: orderKey,
           vulnerable: isFilterVulnerable,
           page: 0, // resets page index
         },


### PR DESCRIPTION
## Issue
Cerra #16672 

## Description
Found more related bugs when I was fixing one bug
- Query params in URL bar appropriately rendering as `snake_case` instead of `camelCase`
- Switching to vulnerable software filter on a specific team was resetting to all teams (because it reads `team_id` from URL but it was being set as `teamId`)
- Switching between tabs resets the table query params because you are looking at a new table 

## Screen recording
https://www.loom.com/share/e7e77f679af9417e95d65827c967a040?sid=5263bd50-142f-4935-b85d-4160ee45f4da

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
- [x] Manual QA for all new/changed functionality

