### PR TITLE
Handbook: Fix broken links

### DIFF
--- a/handbook/business-operations/security.md
+++ b/handbook/business-operations/security.md
@@ -366,8 +366,8 @@ is kept up to date.
 
 ## Hardware security keys
 
-If you do not already have a pair of hardware security keys, order [YubiKey 5C NFC security
-keys](https://www.yubico.com/ca/product/yubikey-5c-nfc-pack-of-2/) with your company card, or ask
+If you do not already have a pair of hardware security keys, order [two YubiKey 5C NFC security
+keys](https://www.yubico.com/us/product/yubikey-5-nfc/) with your company card, or ask
 for help in [#help-login](https://fleetdm.com/handbook/security#slack-channels) to get one if you do not have a company card.
 
 ### Are they YubiKeys or security keys?

--- a/handbook/company/README.md
+++ b/handbook/company/README.md
@@ -143,7 +143,7 @@ To provide clarity about decision-making, [responsibility](https://fleetdm.com/h
 - 🐋 [Sales](https://fleetdm.com/handbook/sales): The Sales department is directly responsible for attaining the revenue goals of Fleet and helping customers deliver on their objectives.
 - 🫧 [Demand](https://fleetdm.com/handbook/demand): The Demand department is directly responsible for growing awareness of Fleet and nurturing the community through participation in events, conversations, and other programs.
 - 🚀 [Engineering](https://fleetdm.com/handbook/engineering): The Engineering department at Fleet is directly responsible for writing and maintaining the code for Fleet's core product.
-- 🦢 [Product Design](https://fleetdm.com/handbook/product): The Product Design department is directly responsible for defining and prioritizing the changes made to the core product.
+- 🦢 [Product Design](https://fleetdm.com/handbook/product-design): The Product Design department is directly responsible for defining and prioritizing the changes made to the core product.
 - 🌐 [Digital Experience](https://fleetdm.com/handbook/digital-experience): The Digital Experience department is directly responsible for the framework, content design, and technology behind Fleet's remote work culture, including fleetdm.com, the handbook, issue templates, UI style guides, internal tooling, Zapier flows, Docusign templates, key spreadsheets, and project management processes. 
 
 ## Advisors

--- a/handbook/company/communications.md
+++ b/handbook/company/communications.md
@@ -257,7 +257,7 @@ Our handbook and docs pages are written in Markdown and are editable from our we
 ### Merging changes
 When merging a PR to the master branch of the [Fleet repo](https://github.com/fleetdm/fleet), remember that whatever you merge gets deployed live immediately. Ensure that the appropriate quality checks have been completed before merging. [Learn about the website QA process](#quality).
 
-When merging changes to the [docs](https://fleetdm.com/docs), [handbook](https://fleetdm.com/handbook), and articles, make sure that the PR’s changes do not contain inappropriate content (goes without saying) or confidential information, and that the content represents our [brand](#brand) accordingly. When in doubt reach out to the product manager of the [website group](https://fleetdm.com/handbook/digital-expericnce) in the [#g-digital-experience](https://fleetdm.slack.com/archives/C058S8PFSK0) channel on Slack.
+When merging changes to the [docs](https://fleetdm.com/docs), [handbook](https://fleetdm.com/handbook), and articles, make sure that the PR’s changes do not contain inappropriate content (goes without saying) or confidential information, and that the content represents our [brand](#brand) accordingly. When in doubt reach out to the product manager of the [website group](https://fleetdm.com/handbook/digital-experience) in the [#g-digital-experience](https://fleetdm.slack.com/archives/C058S8PFSK0) channel on Slack.
 
 ### Editing a merged pull requests 
 We approach editing retrospectively for pull requests (PRs) to handbook pages. Remember our goal above about moving quickly and reducing time to value for our contributors? We avoid the editor becoming a bottleneck for merging quickly by editing for typos and grammatical errors after-the-fact. Here's how to do it:
@@ -320,7 +320,7 @@ The images used in the docs live in `docs/images/`. Note that you must provide t
 > Note that the instructions above also apply to adding images in the Fleet handbook.
 
 ### Audit logs
-The [Audit logs doc page](https://fleetdm.com/docs/Using%20Fleet/Audit-logs.md) has a page generator that is used to speed up doc writing when Fleet adds new activity types.
+The [Audit logs doc page](https://fleetdm.com/docs/Using-Fleet/Audit-logs) has a page generator that is used to speed up doc writing when Fleet adds new activity types.
 
 - If you're making a copy change to an exiting activity type, edit the `activities.go` file [here](https://github.com/fleetdm/fleet/blob/main/server/fleet/activities.go).
 - If you're making a change to the top section or meta tags, edit the `gen_activity_doc.go` file [here](https://github.com/fleetdm/fleet/blob/main/server/fleet/gen_activity_doc.go).
@@ -360,7 +360,7 @@ For non-travel purchases that would require an increase in the Brex cardholder's
 - For one time purchases where payment via credit card is the most convenient then the card limit will be temporarily increased to accomodate the purchase.  
 
 #### Reimbursements
-Fleet does not reimburse expenses. We provide all of our team members with Brex cards for making purchases for the company. For company expenses, **use your Brex card.**  If there was an extreme accident, [get help]((https://fleetdm.com/handbook/business-operations#contact-us).
+Fleet does not reimburse expenses. We provide all of our team members with Brex cards for making purchases for the company. For company expenses, **use your Brex card.**  If there was an extreme accident, [get help](https://fleetdm.com/handbook/business-operations#contact-us).
 
 <!-- 
 No longer supported.  -mike, CEO, 2023-04-26.
@@ -1116,9 +1116,6 @@ graph TD;
 ## Website
 
 This page details processes related to maintaining and updating the Fleet website ([fleetdm.com](https://fleetdm.com)).
-
-Website-related topics that are NOT included on this page:
-- [Publishing an article](https://fleetdm.com/handbook/marketing/how-to-submit-and-publish-an-article)
 
 ### Responsibilities
 

--- a/handbook/company/product-groups.md
+++ b/handbook/company/product-groups.md
@@ -64,7 +64,7 @@ Fleet's highest product ambition is to create experiences that users want.
 
 To deliver on this mission, we need a clear, repeatable process for turning an idea into a set of cohesively-designed changes in the product. We also need to allow [open source contributions](https://fleetdm.com/handbook/company#open-source) at any point in the process from the wider Fleet community - these won't necessarily follow this process.
 
-> Learn more about Fleet's philosophy and process for making interface changes to the product, and [why we use a wireframe-first approach](https://fleetdm.com/handbook/company/why-this-way/why-do-we-use-a-wireframe-first-approach).
+> Learn more about Fleet's philosophy and process for making interface changes to the product, and [why we use a wireframe-first approach](https://fleetdm.com/handbook/company/why-this-way#why-do-we-use-a-wireframe-first-approach).
 
 To make a change to Fleet:
 - First, [get it prioritized](https://fleetdm.com/handbook/product).


### PR DESCRIPTION

Changes:
- Updated broken links in the handbook
- Removed a section that linked to a handbook page that no longer exists.