### PR TITLE
Fleet UI: Fix overlap of enroll secrets

### DIFF
--- a/frontend/components/EnrollSecrets/EnrollSecretTable/EnrollSecretRow/_styles.scss
+++ b/frontend/components/EnrollSecrets/EnrollSecretTable/EnrollSecretRow/_styles.scss
@@ -30,6 +30,7 @@
     .input-field {
       &--disabled {
         letter-spacing: 0;
+        padding-right: 66px; // Text box does not overlap with icons
       }
 
       &--password {


### PR DESCRIPTION
## Issue
#16155

## Description
- When disabled, we can see icons, that take up 66px of room, added 66px padding to the right of the text input

## Screenrecording of fix
https://www.loom.com/share/8d3c66bed53b4f05b5e263115ca943bb?sid=ccdde81d-55e8-4220-9a01-fec866a6b9e3

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Manual QA for all new/changed functionality

