### PR TITLE
Adding fleetctl gitops workflow

### DIFF
--- a/.github/workflows/fleetctl-gitops.yml
+++ b/.github/workflows/fleetctl-gitops.yml
@@ -1,0 +1,103 @@
+# This workflow tests `fleetctl gitops` command against https://github.com/fleetdm/fleet-gitops repository.
+# It uses a fleet instance also built and executed from source.
+name: Test fleetctl gitops
+
+on:
+  push:
+    branches:
+      - main
+      - patch-*
+      - prepare-*
+    paths:
+      - 'orbit/**.go'
+      - '.github/workflows/fleetctl-gitops.yml'
+  pull_request:
+    paths:
+      - 'orbit/**.go'
+      - '.github/workflows/fleetctl-gitops.yml'
+  workflow_dispatch: # Manual
+
+# This allows a subsequently queued workflow run to interrupt previous runs
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id}}
+  cancel-in-progress: true
+
+defaults:
+  run:
+    # fail-fast using bash -eo pipefail. See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#exit-codes-and-error-action-preference
+    shell: bash
+
+permissions:
+  contents: read
+
+jobs:
+  run-server:
+    timeout-minutes: 60
+    strategy:
+      matrix:
+        go-version: [ '${{ vars.GO_VERSION }}' ]
+        mysql: [ 'mysql:5.7' ]
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: Install Go
+        uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
+        with:
+          go-version: ${{ matrix.go-version }}
+
+      - name: Checkout
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+
+      - name: Checkout fleet-gitops
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+        with:
+          repository: fleetdm/fleet-gitops
+          ref: main
+          path: fleet-gitops
+
+      - name: Start Infra Dependencies
+        run: FLEET_MYSQL_IMAGE=${{ matrix.mysql }} docker-compose up -d mysql redis &
+
+      - name: Install JS Dependencies
+        run: make deps-js
+
+      - name: Generate and bundle go & js code
+        run: make generate
+
+      - name: Build fleet and fleetctl
+        # fleet-dev builds fleet with "race" enabled.
+        run: make fleet-dev fleetctl
+
+      - name: Run Fleet server
+        env:
+          FLEET_OSQUERY_HOST_IDENTIFIER: instance # use instance identifier to allow for duplicate UUIDs
+          FLEET_SERVER_ADDRESS: 0.0.0.0:1337
+          FLEET_SERVER_TLS: false
+          FLEET_LOGGING_DEBUG: true
+        run: |
+          mkdir ./fleet_log
+          make db-reset
+          ./build/fleet serve --dev --dev_license 1>./fleet_log/stdout.log 2>./fleet_log/stderr.log &
+          ./build/fleetctl config set --address http://localhost:1337 --tls-skip-verify
+          until ./build/fleetctl setup --email admin@example.com --name Admin --password preview1337# --org-name Example
+          do
+            echo "Retrying setup in 5s..."
+            sleep 5
+          done
+
+      - name: Run fleetctl gitops
+        env:
+          FLEETCTL: ../fleet/build/fleetctl
+          FLEET_GLOBAL_ENROLL_SECRET: global_secret
+          FLEET_WORKSTATIONS_ENROLL_SECRET: workstations_secret
+          FLEET_WORKSTATIONS_CANARY_ENROLL_SECRET: workstations_canary_secret
+        working-directory: ../fleet-gitops
+        run: ./workflow.sh
+
+      - name: Upload fleet logs
+        if: always()
+        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v2
+        with:
+          name: fleet-logs
+          path: |
+            fleet_log

--- a/.github/workflows/fleetctl-gitops.yml
+++ b/.github/workflows/fleetctl-gitops.yml
@@ -87,11 +87,11 @@ jobs:
 
       - name: Run fleetctl gitops
         env:
-          FLEETCTL: ../fleet/build/fleetctl
+          FLEETCTL: ../build/fleetctl
           FLEET_GLOBAL_ENROLL_SECRET: global_secret
           FLEET_WORKSTATIONS_ENROLL_SECRET: workstations_secret
           FLEET_WORKSTATIONS_CANARY_ENROLL_SECRET: workstations_canary_secret
-        working-directory: ../fleet-gitops
+        working-directory: fleet-gitops
         run: ./workflow.sh
 
       - name: Upload fleet logs


### PR DESCRIPTION
CI workflow for testing latest fleet/fleetctl builds against https://github.com/fleetdm/fleet-gitops settings.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [ ] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [ ] Documented any permissions changes (docs/Using Fleet/manage-access.md)
- [ ] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [ ] Added support on fleet's osquery simulator `cmd/osquery-perf` for new osquery data ingestion features.
- [ ] Added/updated tests
- [ ] If database migrations are included, checked table schema to confirm autoupdate 
- For database migrations:
  - [ ] Checked schema for all modified table for columns that will auto-update timestamps during migration.
  - [ ] Confirmed that updating the timestamps is acceptable, and will not cause unwanted side effects.
- [ ] Manual QA for all new/changed functionality
  - For Orbit and Fleet Desktop changes:
    - [ ] Manual QA must be performed in the three main OSs, macOS, Windows and Linux.
    - [ ] Auto-update manual QA, from released version of component to new version (see [tools/tuf/test](../tools/tuf/test/README.md)).
