### PR TITLE
Fleet UI: Only team ID query param persists between software tables

### DIFF
--- a/frontend/pages/SoftwarePage/SoftwarePage.tsx
+++ b/frontend/pages/SoftwarePage/SoftwarePage.tsx
@@ -256,7 +256,14 @@ const SoftwarePage = ({ children, router, location }: ISoftwarePageProps) => {
 
   const navigateToNav = useCallback(
     (i: number): void => {
-      const navPath = softwareSubNav[i].pathname.concat(location?.hash || "");
+      // Only query param to persist between tabs is team id
+      const teamIdParam = location?.query.team_id
+        ? `?team_id=${location.query.team_id}`
+        : "";
+
+      const navPath = softwareSubNav[i].pathname
+        .concat(teamIdParam)
+        .concat(location?.hash || "");
       router.replace(navPath);
     },
     [location, router]

--- a/frontend/pages/SoftwarePage/SoftwarePage.tsx
+++ b/frontend/pages/SoftwarePage/SoftwarePage.tsx
@@ -20,6 +20,7 @@ import teamsAPI, { ILoadTeamResponse } from "services/entities/teams";
 import { AppContext } from "context/app";
 import { NotificationContext } from "context/notification";
 import useTeamIdParam from "hooks/useTeamIdParam";
+import { buildQueryStringFromParams } from "utilities/url";
 
 import Button from "components/buttons/Button";
 import MainContent from "components/MainContent";
@@ -257,13 +258,12 @@ const SoftwarePage = ({ children, router, location }: ISoftwarePageProps) => {
   const navigateToNav = useCallback(
     (i: number): void => {
       // Only query param to persist between tabs is team id
-      const teamIdParam = location?.query.team_id
-        ? `?team_id=${location.query.team_id}`
-        : "";
+      const teamIdParam = buildQueryStringFromParams({
+        team_id: location?.query.team_id,
+      });
 
-      const navPath = softwareSubNav[i].pathname
-        .concat(teamIdParam)
-        .concat(location?.hash || "");
+      const navPath = softwareSubNav[i].pathname.concat(`?${teamIdParam}`);
+
       router.replace(navPath);
     },
     [location, router]


### PR DESCRIPTION
## Issue
Cerra #16672 

## Description 
- I removed all query params between software tabs, but since URL is source of truth, it removed the team ID when switching tabs as well
- Only persist team ID when switching between tabs

## Screenrecording of fix
https://www.loom.com/share/bb5e260011ca4889a028993db2d42c04?sid=afcd95cd-3f69-4fcd-bd74-91a7c2d26871


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Manual QA for all new/changed functionality

