### PR TITLE
Remote Lock: track host status via script results (Windows/Linux)

### DIFF
--- a/changes/10476-lock-unlock-api-changes
+++ b/changes/10476-lock-unlock-api-changes
@@ -1,0 +1,1 @@
+* Added tracking of Windows and Linux' scripts to lock or unlock the host, report the proper current and pending states.

--- a/server/datastore/mysql/scripts.go
+++ b/server/datastore/mysql/scripts.go
@@ -3,6 +3,7 @@ package mysql
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"time"
 	"unicode/utf8"
@@ -62,6 +63,20 @@ func (ds *Datastore) SetHostScriptExecutionResult(ctx context.Context, result *f
     host_id = ? AND
     execution_id = ?`
 
+	// TODO(mna): add wipe_ref check when we implement wipe story
+	const hostMDMActionsStmt = `
+  SELECT
+    CASE
+      WHEN lock_ref = ? THEN 'lock_ref'
+      WHEN unlock_ref = ? THEN 'unlock_ref'
+      ELSE ''
+    END AS ref_col
+  FROM
+    host_mdm_actions
+  WHERE
+    host_id = ?
+`
+
 	const maxOutputRuneLen = 10000
 	output := result.Output
 	if len(output) > utf8.UTFMax*maxOutputRuneLen {
@@ -74,24 +89,45 @@ func (ds *Datastore) SetHostScriptExecutionResult(ctx context.Context, result *f
 		output = string(outputRunes[len(outputRunes)-maxOutputRuneLen:])
 	}
 
-	res, err := ds.writer(ctx).ExecContext(ctx, updStmt,
-		output,
-		result.Runtime,
-		result.ExitCode,
-		result.HostID,
-		result.ExecutionID,
-	)
-	if err != nil {
-		return nil, ctxerr.Wrap(ctx, err, "update host script result")
-	}
-
 	var hsr *fleet.HostScriptResult
-	if n, _ := res.RowsAffected(); n > 0 {
-		// it did update, so return the updated result
-		hsr, err = ds.getHostScriptExecutionResultDB(ctx, ds.writer(ctx), result.ExecutionID)
+	err := ds.withRetryTxx(ctx, func(tx sqlx.ExtContext) error {
+		res, err := tx.ExecContext(ctx, updStmt,
+			output,
+			result.Runtime,
+			result.ExitCode,
+			result.HostID,
+			result.ExecutionID,
+		)
 		if err != nil {
-			return nil, ctxerr.Wrap(ctx, err, "load updated host script result")
+			return ctxerr.Wrap(ctx, err, "update host script result")
 		}
+
+		if n, _ := res.RowsAffected(); n > 0 {
+			// it did update, so return the updated result
+			hsr, err = ds.getHostScriptExecutionResultDB(ctx, tx, result.ExecutionID)
+			if err != nil {
+				return ctxerr.Wrap(ctx, err, "load updated host script result")
+			}
+
+			// look up if that script was a lock/unlock/wipe script for that host,
+			// and if so update the host_mdm_actions table accordingly.
+			var refCol string
+			err = sqlx.GetContext(ctx, tx, &refCol, hostMDMActionsStmt, result.ExecutionID, result.ExecutionID, result.HostID)
+			if err != nil && !errors.Is(err, sql.ErrNoRows) { // ignore ErrNoRows, scriptAction will be empty
+				return ctxerr.Wrap(ctx, err, "lookup host script corresponding mdm action")
+			}
+			if refCol != "" {
+				err = ds.updateHostLockWipeStatusFromResult(ctx, tx, result.HostID, refCol, result.ExitCode == 0)
+				if err != nil {
+					return ctxerr.Wrap(ctx, err, "update host mdm action based on script result")
+				}
+			}
+		}
+		return nil
+	})
+
+	if err != nil {
+		return nil, err
 	}
 	return hsr, nil
 }
@@ -663,4 +699,28 @@ func (ds *Datastore) UnlockHostViaScript(ctx context.Context, request *fleet.Hos
 
 		return err
 	})
+}
+
+func (ds *Datastore) updateHostLockWipeStatusFromResult(ctx context.Context, tx sqlx.ExtContext, hostID uint, refCol string, succeeded bool) error {
+	stmt := `UPDATE host_mdm_actions SET %s WHERE host_id = ?`
+
+	if succeeded {
+		switch refCol {
+		case "lock_ref":
+			stmt = fmt.Sprintf(stmt, "unlock_ref = NULL, unlock_pin = NULL")
+		case "unlock_ref":
+			stmt = fmt.Sprintf(stmt, "lock_ref = NULL")
+		case "wipe_ref":
+			// TODO(mna): implement when implementing the wipe story
+		default:
+			return ctxerr.Errorf(ctx, "unknown reference column %q", refCol)
+		}
+	} else {
+		// if the action failed, then we clear the reference to that action itself so
+		// the host stays in the previous state (it doesn't transition to the new
+		// state).
+		stmt = fmt.Sprintf(stmt, refCol+" = NULL")
+	}
+	_, err := tx.ExecContext(ctx, stmt, hostID)
+	return ctxerr.Wrap(ctx, err, "update host lock/wipe status from result")
 }

--- a/server/service/integration_enterprise_test.go
+++ b/server/service/integration_enterprise_test.go
@@ -6525,6 +6525,64 @@ func (s *integrationEnterpriseTestSuite) TestAllSoftwareTitles() {
 	}, []fleet.SoftwareTitle{*stResp.SoftwareTitle})
 }
 
+func (s *integrationEnterpriseTestSuite) TestLockUnlockWindowsLinux() {
+	ctx := context.Background()
+	t := s.T()
+
+	// create a Windows and a Linux hosts
+	winHost := createOrbitEnrolledHost(t, "windows", "win_lock_unlock", s.ds)
+	linuxHost := createOrbitEnrolledHost(t, "linux", "linux_lock_unlock", s.ds)
+
+	// get the host's information
+	var getHostResp getHostResponse
+	s.DoJSON("GET", fmt.Sprintf("/api/latest/fleet/hosts/%d", winHost.ID), nil, http.StatusOK, &getHostResp)
+	require.NotNil(t, getHostResp.Host.MDM.DeviceStatus)
+	require.Equal(t, "unlocked", *getHostResp.Host.MDM.DeviceStatus)
+	require.NotNil(t, getHostResp.Host.MDM.PendingAction)
+	require.Equal(t, "", *getHostResp.Host.MDM.PendingAction)
+
+	s.DoJSON("GET", fmt.Sprintf("/api/latest/fleet/hosts/%d", linuxHost.ID), nil, http.StatusOK, &getHostResp)
+	require.NotNil(t, getHostResp.Host.MDM.DeviceStatus)
+	require.Equal(t, "unlocked", *getHostResp.Host.MDM.DeviceStatus)
+	require.NotNil(t, getHostResp.Host.MDM.PendingAction)
+	require.Equal(t, "", *getHostResp.Host.MDM.PendingAction)
+
+	// try to lock/unlock the Windows host, fails because Windows MDM must be enabled
+	res := s.DoRaw("POST", fmt.Sprintf("/api/latest/fleet/hosts/%d/lock", winHost.ID), nil, http.StatusBadRequest)
+	errMsg := extractServerErrorText(res.Body)
+	require.Contains(t, errMsg, "Windows MDM isn't turned on.")
+	res = s.DoRaw("POST", fmt.Sprintf("/api/latest/fleet/hosts/%d/unlock", winHost.ID), nil, http.StatusBadRequest)
+	errMsg = extractServerErrorText(res.Body)
+	require.Contains(t, errMsg, "Windows MDM isn't turned on.")
+
+	// try to lock/unlock the Linux host succeeds, no MDM constraints
+	s.Do("POST", fmt.Sprintf("/api/latest/fleet/hosts/%d/lock", linuxHost.ID), nil, http.StatusNoContent)
+
+	// simulate a successful script result for the lock command
+	status, err := s.ds.GetHostLockWipeStatus(ctx, linuxHost.ID, linuxHost.FleetPlatform())
+	require.NoError(t, err)
+
+	var orbitScriptResp orbitPostScriptResultResponse
+	s.DoJSON("POST", "/api/fleet/orbit/scripts/result",
+		json.RawMessage(fmt.Sprintf(`{"orbit_node_key": %q, "execution_id": %q, "exit_code": 0, "output": "ok"}`, *linuxHost.OrbitNodeKey, status.LockScript.ExecutionID)),
+		http.StatusOK, &orbitScriptResp)
+
+	s.Do("POST", fmt.Sprintf("/api/latest/fleet/hosts/%d/unlock", linuxHost.ID), nil, http.StatusNoContent)
+
+	// windows host status is unchanged, linux is locked pending unlock
+	s.DoJSON("GET", fmt.Sprintf("/api/latest/fleet/hosts/%d", winHost.ID), nil, http.StatusOK, &getHostResp)
+	require.NotNil(t, getHostResp.Host.MDM.DeviceStatus)
+	require.Equal(t, "unlocked", *getHostResp.Host.MDM.DeviceStatus)
+	require.NotNil(t, getHostResp.Host.MDM.PendingAction)
+	require.Equal(t, "", *getHostResp.Host.MDM.PendingAction)
+
+	s.DoJSON("GET", fmt.Sprintf("/api/latest/fleet/hosts/%d", linuxHost.ID), nil, http.StatusOK, &getHostResp)
+	require.NotNil(t, getHostResp.Host.MDM.DeviceStatus)
+	require.Equal(t, "locked", *getHostResp.Host.MDM.DeviceStatus)
+	require.NotNil(t, getHostResp.Host.MDM.PendingAction)
+	require.Equal(t, "unlock", *getHostResp.Host.MDM.PendingAction)
+}
+
 // checks that the specified team/no-team has the Windows OS Updates profile with
 // the specified deadline/grace settings (or checks that it doesn't have the
 // profile if wantSettings is nil). It returns the profile_uuid if it exists,

--- a/server/service/integration_mdm_test.go
+++ b/server/service/integration_mdm_test.go
@@ -11000,6 +11000,95 @@ func (s *integrationMDMTestSuite) TestManualEnrollmentCommands() {
 	checkInstallFleetdCommandSent(mdmDevice, false)
 }
 
+func (s *integrationMDMTestSuite) TestLockUnlockWindowsLinux() {
+	t := s.T()
+	ctx := context.Background()
+
+	// create an MDM-enrolled Windows host
+	winHost, _ := createWindowsHostThenEnrollMDM(s.ds, s.server.URL, t)
+	linuxHost := createOrbitEnrolledHost(t, "linux", "lock_unlock_linux", s.ds)
+
+	for _, host := range []*fleet.Host{winHost, linuxHost} {
+		t.Run(host.FleetPlatform(), func(t *testing.T) {
+			// get the host's information
+			var getHostResp getHostResponse
+			s.DoJSON("GET", fmt.Sprintf("/api/latest/fleet/hosts/%d", host.ID), nil, http.StatusOK, &getHostResp)
+			require.NotNil(t, getHostResp.Host.MDM.DeviceStatus)
+			require.Equal(t, "unlocked", *getHostResp.Host.MDM.DeviceStatus)
+			require.NotNil(t, getHostResp.Host.MDM.PendingAction)
+			require.Equal(t, "", *getHostResp.Host.MDM.PendingAction)
+
+			// try to unlock the host (which is already its status)
+			var unlockResp unlockHostResponse
+			s.DoJSON("POST", fmt.Sprintf("/api/latest/fleet/hosts/%d/unlock", host.ID), nil, http.StatusConflict, &unlockResp)
+
+			// lock the host
+			s.Do("POST", fmt.Sprintf("/api/latest/fleet/hosts/%d/lock", host.ID), nil, http.StatusNoContent)
+
+			// refresh the host's status, it is now pending lock
+			s.DoJSON("GET", fmt.Sprintf("/api/latest/fleet/hosts/%d", host.ID), nil, http.StatusOK, &getHostResp)
+			require.NotNil(t, getHostResp.Host.MDM.DeviceStatus)
+			require.Equal(t, "unlocked", *getHostResp.Host.MDM.DeviceStatus)
+			require.NotNil(t, getHostResp.Host.MDM.PendingAction)
+			require.Equal(t, "lock", *getHostResp.Host.MDM.PendingAction)
+
+			// try locking the host while it is pending lock fails
+			res := s.DoRaw("POST", fmt.Sprintf("/api/latest/fleet/hosts/%d/lock", host.ID), nil, http.StatusUnprocessableEntity)
+			errMsg := extractServerErrorText(res.Body)
+			require.Contains(t, errMsg, "Host has pending lock request.")
+
+			// simulate a successful script result for the lock command
+			status, err := s.ds.GetHostLockWipeStatus(ctx, host.ID, host.FleetPlatform())
+			require.NoError(t, err)
+
+			var orbitScriptResp orbitPostScriptResultResponse
+			s.DoJSON("POST", "/api/fleet/orbit/scripts/result",
+				json.RawMessage(fmt.Sprintf(`{"orbit_node_key": %q, "execution_id": %q, "exit_code": 0, "output": "ok"}`, *host.OrbitNodeKey, status.LockScript.ExecutionID)),
+				http.StatusOK, &orbitScriptResp)
+
+			// refresh the host's status, it is now locked
+			s.DoJSON("GET", fmt.Sprintf("/api/latest/fleet/hosts/%d", host.ID), nil, http.StatusOK, &getHostResp)
+			require.NotNil(t, getHostResp.Host.MDM.DeviceStatus)
+			require.Equal(t, "locked", *getHostResp.Host.MDM.DeviceStatus)
+			require.NotNil(t, getHostResp.Host.MDM.PendingAction)
+			require.Equal(t, "", *getHostResp.Host.MDM.PendingAction)
+
+			// try to lock the host again
+			s.Do("POST", fmt.Sprintf("/api/latest/fleet/hosts/%d/lock", host.ID), nil, http.StatusConflict)
+
+			// unlock the host
+			s.Do("POST", fmt.Sprintf("/api/latest/fleet/hosts/%d/unlock", host.ID), nil, http.StatusNoContent)
+
+			// refresh the host's status, it is locked pending unlock
+			s.DoJSON("GET", fmt.Sprintf("/api/latest/fleet/hosts/%d", host.ID), nil, http.StatusOK, &getHostResp)
+			require.NotNil(t, getHostResp.Host.MDM.DeviceStatus)
+			require.Equal(t, "locked", *getHostResp.Host.MDM.DeviceStatus)
+			require.NotNil(t, getHostResp.Host.MDM.PendingAction)
+			require.Equal(t, "unlock", *getHostResp.Host.MDM.PendingAction)
+
+			// try unlocking the host while it is pending unlock fails
+			res = s.DoRaw("POST", fmt.Sprintf("/api/latest/fleet/hosts/%d/unlock", host.ID), nil, http.StatusUnprocessableEntity)
+			errMsg = extractServerErrorText(res.Body)
+			require.Contains(t, errMsg, "Host has pending unlock request.")
+
+			// simulate a failed script result for the unlock command
+			status, err = s.ds.GetHostLockWipeStatus(ctx, host.ID, host.FleetPlatform())
+			require.NoError(t, err)
+
+			s.DoJSON("POST", "/api/fleet/orbit/scripts/result",
+				json.RawMessage(fmt.Sprintf(`{"orbit_node_key": %q, "execution_id": %q, "exit_code": -1, "output": "fail"}`, *host.OrbitNodeKey, status.UnlockScript.ExecutionID)),
+				http.StatusOK, &orbitScriptResp)
+
+			// refresh the host's status, it is still locked, no pending action
+			s.DoJSON("GET", fmt.Sprintf("/api/latest/fleet/hosts/%d", host.ID), nil, http.StatusOK, &getHostResp)
+			require.NotNil(t, getHostResp.Host.MDM.DeviceStatus)
+			require.Equal(t, "locked", *getHostResp.Host.MDM.DeviceStatus)
+			require.NotNil(t, getHostResp.Host.MDM.PendingAction)
+			require.Equal(t, "", *getHostResp.Host.MDM.PendingAction)
+		})
+	}
+}
+
 func (s *integrationMDMTestSuite) TestZCustomConfigurationWebURL() {
 	t := s.T()
 


### PR DESCRIPTION
#10476 

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [x] Added/updated tests
