### PR TITLE
Optim `osquery-perf` buffering

### DIFF
--- a/cmd/osquery-perf/agent.go
+++ b/cmd/osquery-perf/agent.go
@@ -1719,9 +1719,11 @@ func rows(num int) string {
 }
 
 func main() {
+	// Start HTTP server for pprof. See https://pkg.go.dev/net/http/pprof.
 	go func() {
 		log.Println(http.ListenAndServe("localhost:6060", nil))
 	}()
+
 	validTemplateNames := map[string]bool{
 		"macos_13.6.2.tmpl":         true,
 		"macos_14.1.2.tmpl":         true,

--- a/cmd/osquery-perf/agent.go
+++ b/cmd/osquery-perf/agent.go
@@ -15,6 +15,7 @@ import (
 	"log"
 	"math/rand"
 	"net/http"
+	_ "net/http/pprof"
 	"os"
 	"strconv"
 	"strings"
@@ -958,12 +959,13 @@ func (a *agent) config() error {
 	res := fasthttp.AcquireResponse()
 
 	err := a.fastClient.Do(req, res)
-	if err != nil {
-		return fmt.Errorf("config request failed to run: %w", err)
-	}
 
 	fasthttp.ReleaseRequest(req)
 	defer fasthttp.ReleaseResponse(res)
+
+	if err != nil {
+		return fmt.Errorf("config request failed to run: %w", err)
+	}
 
 	a.stats.IncrementConfigRequests()
 
@@ -1146,12 +1148,13 @@ func (a *agent) DistributedRead() (*distributedReadResponse, error) {
 	res := fasthttp.AcquireResponse()
 
 	err := a.fastClient.Do(req, res)
-	if err != nil {
-		return nil, fmt.Errorf("distributed/read request failed to run: %w", err)
-	}
 
 	fasthttp.ReleaseRequest(req)
 	defer fasthttp.ReleaseResponse(res)
+
+	if err != nil {
+		return nil, fmt.Errorf("distributed/read request failed to run: %w", err)
+	}
 
 	a.stats.IncrementDistributedReads()
 
@@ -1602,12 +1605,13 @@ func (a *agent) DistributedWrite(queries map[string]string) error {
 	res := fasthttp.AcquireResponse()
 
 	err = a.fastClient.Do(req, res)
-	if err != nil {
-		return fmt.Errorf("distributed/write request failed to run: %w", err)
-	}
 
 	fasthttp.ReleaseRequest(req)
 	defer fasthttp.ReleaseResponse(res)
+
+	if err != nil {
+		return fmt.Errorf("distributed/write request failed to run: %w", err)
+	}
 
 	a.stats.IncrementDistributedWrites()
 
@@ -1669,12 +1673,13 @@ func (a *agent) submitLogs(results []json.RawMessage) error {
 	res := fasthttp.AcquireResponse()
 
 	err = a.fastClient.Do(req, res)
-	if err != nil {
-		return fmt.Errorf("log request failed to run: %w", err)
-	}
 
 	fasthttp.ReleaseRequest(req)
 	defer fasthttp.ReleaseResponse(res)
+
+	if err != nil {
+		return fmt.Errorf("log request failed to run: %w", err)
+	}
 
 	a.stats.IncrementResultLogRequests()
 
@@ -1714,6 +1719,9 @@ func rows(num int) string {
 }
 
 func main() {
+	go func() {
+		log.Println(http.ListenAndServe("localhost:6060", nil))
+	}()
 	validTemplateNames := map[string]bool{
 		"macos_13.6.2.tmpl":         true,
 		"macos_14.1.2.tmpl":         true,


### PR DESCRIPTION
#16423

- We need to consume less memory while Fleet is down (otherwise we might bring the load test environment down, local tests showed that in 30m I got to 600 MB of memory usage) so am generating the results when needed only.
- Also fixing the release of fasthttp requests and responses (according to their docs).