### PR TITLE
Cleaned up error logs when config fails.

### DIFF
--- a/orbit/changes/16326-config-err-logs
+++ b/orbit/changes/16326-config-err-logs
@@ -1,0 +1,1 @@
+Removed duplicated error logs when fetching config failed.

--- a/orbit/cmd/orbit/orbit.go
+++ b/orbit/cmd/orbit/orbit.go
@@ -877,7 +877,6 @@ func main() {
 				event := log.Debug()
 				if !configErrSeen {
 					event = log.Warn()
-					configErrSeen = true
 				}
 				logging.LogErrIfEnvNotSetWithEvent(
 					constant.SilenceEnrollLogErrorEnvVar, err, "initial update to fetch extensions from /config API failed", event,

--- a/orbit/pkg/logging/logging.go
+++ b/orbit/pkg/logging/logging.go
@@ -1,6 +1,7 @@
 package logging
 
 import (
+	"github.com/rs/zerolog"
 	"os"
 
 	"github.com/rs/zerolog/log"
@@ -8,8 +9,13 @@ import (
 
 // LogErrIfEnvNotSet logs if the environment variable is not set to "1".
 func LogErrIfEnvNotSet(envVarName string, err error, message string) {
+	LogErrIfEnvNotSetWithEvent(envVarName, err, message, log.Info())
+}
+
+// LogErrIfEnvNotSetWithEvent logs if the environment variable is not set to "1".
+func LogErrIfEnvNotSetWithEvent(envVarName string, err error, message string, event *zerolog.Event) {
 	actualValue := os.Getenv(envVarName)
 	if actualValue != "1" {
-		log.Info().Err(err).Msg(message)
+		event.Err(err).Msg(message)
 	}
 }

--- a/orbit/pkg/update/disk_encryption.go
+++ b/orbit/pkg/update/disk_encryption.go
@@ -22,7 +22,7 @@ func ApplyDiskEncryptionRunnerMiddleware(f OrbitConfigFetcher) *DiskEncryptionRu
 func (d *DiskEncryptionRunner) GetConfig() (*fleet.OrbitConfig, error) {
 	cfg, err := d.fetcher.GetConfig()
 	if err != nil {
-		log.Info().Err(err).Msg("calling GetConfig from DiskEncryptionFetcher")
+		log.Debug().Err(err).Msg("calling GetConfig from DiskEncryptionFetcher")
 		return nil, err
 	}
 

--- a/orbit/pkg/update/nudge.go
+++ b/orbit/pkg/update/nudge.go
@@ -69,7 +69,7 @@ func (n *NudgeConfigFetcher) GetConfig() (*fleet.OrbitConfig, error) {
 	log.Debug().Msg("running nudge config fetcher middleware")
 	cfg, err := n.Fetcher.GetConfig()
 	if err != nil {
-		log.Info().Err(err).Msg("calling GetConfig from NudgeConfigFetcher")
+		log.Debug().Err(err).Msg("calling GetConfig from NudgeConfigFetcher")
 		return nil, err
 	}
 

--- a/server/service/orbit_client.go
+++ b/server/service/orbit_client.go
@@ -128,8 +128,15 @@ func (oc *OrbitClient) GetConfig() (*fleet.OrbitConfig, error) {
 		oc.configCache.config = &resp
 		oc.configCache.err = err
 		oc.configCache.lastUpdated = now
+		return oc.configCache.config, oc.configCache.err
 	}
-	return oc.configCache.config, oc.configCache.err
+	// If time-to-live did not pass, we return the cached config.
+	// We update the error text to reduce duplicated error logging.
+	err := oc.configCache.err
+	if err != nil {
+		err = errors.New("no valid config: see previous error")
+	}
+	return oc.configCache.config, err
 }
 
 // SetOrUpdateDeviceToken sends a request to the server to set or update the


### PR DESCRIPTION
#16326 
- Replaced duplicate config error with: `no valid config: see previous error`
- Also, at startup orbit fetches config 3 times. Now the first error is printed as WRN, and subsequent as DBG.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [x] Manual QA for all new/changed functionality
