### PR TITLE
Fleet UI Software pages: Add team id params onto various software detail pages

### DIFF
--- a/frontend/components/EmptyTable/_styles.scss
+++ b/frontend/components/EmptyTable/_styles.scss
@@ -3,7 +3,7 @@
     display: flex;
     flex-direction: column;
     align-items: center;
-    margin: 96px auto $pad-large; // 96px to top of div
+    margin: 96px auto; // 96px to top of div
     max-width: 450px; // standard empty state width
     gap: $pad-medium; // 16px between image, text, and buttons
   }

--- a/frontend/pages/SoftwarePage/SoftwareOS/SoftwareOS.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareOS/SoftwareOS.tsx
@@ -1,3 +1,5 @@
+/** software/os OS tab */
+
 import React from "react";
 import { useQuery } from "react-query";
 import { InjectedRouter } from "react-router";

--- a/frontend/pages/SoftwarePage/SoftwareOS/SoftwareOSTable/SoftwareOSTable.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareOS/SoftwareOSTable/SoftwareOSTable.tsx
@@ -1,4 +1,4 @@
-/** software/os OS tab */
+/** software/os OS tab > Table */
 
 import React, { useCallback, useContext, useMemo } from "react";
 import { InjectedRouter } from "react-router";

--- a/frontend/pages/SoftwarePage/SoftwareOSDetailsPage/SoftwareOSDetailsPage.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareOSDetailsPage/SoftwareOSDetailsPage.tsx
@@ -46,14 +46,21 @@ interface ISoftwareOSDetailsRouteParams {
 
 interface ISoftwareOSDetailsPageProps {
   routeParams: ISoftwareOSDetailsRouteParams;
+  location: {
+    query: { team_id?: string };
+  };
   router: InjectedRouter;
 }
 
 const SoftwareOSDetailsPage = ({
   routeParams,
   router,
+  location,
 }: ISoftwareOSDetailsPageProps) => {
   const osVersionIdFromURL = parseInt(routeParams.id, 10);
+  const teamId = location.query.team_id
+    ? parseInt(location.query.team_id, 10)
+    : undefined;
 
   const { data: osVersionDetails, isLoading, isError } = useQuery<
     IOSVersionResponse,
@@ -86,6 +93,7 @@ const SoftwareOSDetailsPage = ({
         itemName="version"
         isLoading={isLoading}
         router={router}
+        teamId={teamId}
       />
     );
   };
@@ -111,6 +119,7 @@ const SoftwareOSDetailsPage = ({
           queryParams={{
             os_name: osVersionDetails.name_only,
             os_version: osVersionDetails.version,
+            team_id: teamId,
           }}
           name={osVersionDetails.platform}
         />

--- a/frontend/pages/SoftwarePage/SoftwareOSDetailsPage/SoftwareOSDetailsPage.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareOSDetailsPage/SoftwareOSDetailsPage.tsx
@@ -1,20 +1,29 @@
 /** software/os/:id */
 
-import React from "react";
+import React, { useCallback, useContext } from "react";
 import { useQuery } from "react-query";
-import { InjectedRouter } from "react-router";
+import { RouteComponentProps } from "react-router";
+import { AxiosError } from "axios";
+
+import useTeamIdParam from "hooks/useTeamIdParam";
+
+import { AppContext } from "context/app";
 
 import osVersionsAPI, {
   IOSVersionResponse,
+  IGetOsVersionQueryKey,
 } from "services/entities/operating_systems";
 import { IOperatingSystemVersion } from "interfaces/operating_system";
 import { SUPPORT_LINK } from "utilities/constants";
 
 import Spinner from "components/Spinner";
 import TableDataError from "components/DataError";
+import Fleet404 from "pages/errors/Fleet404";
 import MainContent from "components/MainContent";
 import EmptyTable from "components/EmptyTable";
 import CustomLink from "components/CustomLink";
+import TeamsHeader from "components/TeamsHeader";
+import Card from "components/Card";
 
 import SoftwareDetailsSummary from "../components/SoftwareDetailsSummary";
 import SoftwareVulnerabilitiesTable from "../components/SoftwareVulnerabilitiesTable";
@@ -42,37 +51,65 @@ const NotSupportedVuln = ({ platform }: INotSupportedVulnProps) => {
 
 interface ISoftwareOSDetailsRouteParams {
   id: string;
+  team_id?: string;
 }
 
-interface ISoftwareOSDetailsPageProps {
-  routeParams: ISoftwareOSDetailsRouteParams;
-  location: {
-    query: { team_id?: string };
-  };
-  router: InjectedRouter;
-}
+type ISoftwareOSDetailsPageProps = RouteComponentProps<
+  undefined,
+  ISoftwareOSDetailsRouteParams
+>;
 
 const SoftwareOSDetailsPage = ({
   routeParams,
   router,
   location,
 }: ISoftwareOSDetailsPageProps) => {
-  const osVersionIdFromURL = parseInt(routeParams.id, 10);
-  const teamId = location.query.team_id
-    ? parseInt(location.query.team_id, 10)
-    : undefined;
+  const { isPremiumTier, isOnGlobalTeam } = useContext(AppContext);
 
-  const { data: osVersionDetails, isLoading, isError } = useQuery<
+  const osVersionIdFromURL = parseInt(routeParams.id, 10);
+
+  const {
+    currentTeamId,
+    teamIdForApi,
+    userTeams,
+    handleTeamChange,
+  } = useTeamIdParam({
+    location,
+    router,
+    includeAllTeams: true,
+    includeNoTeam: false,
+  });
+
+  const {
+    data: osVersionDetails,
+    isLoading,
+    isError: isOsVersionError,
+    error: osVersionError,
+  } = useQuery<
     IOSVersionResponse,
-    Error,
-    IOperatingSystemVersion
+    AxiosError,
+    IOperatingSystemVersion,
+    IGetOsVersionQueryKey[]
   >(
-    ["osVersionDetails", osVersionIdFromURL],
-    () => osVersionsAPI.getOSVersion(osVersionIdFromURL),
+    [
+      {
+        scope: "osVersionDetails",
+        os_version_id: osVersionIdFromURL,
+        teamId: teamIdForApi,
+      },
+    ],
+    ({ queryKey }) => osVersionsAPI.getOSVersion(queryKey[0]),
     {
       enabled: !!osVersionIdFromURL,
       select: (data) => data.os_version,
     }
+  );
+
+  const onTeamChange = useCallback(
+    (teamId: number) => {
+      handleTeamChange(teamId);
+    },
+    [handleTeamChange]
   );
 
   const renderTable = () => {
@@ -93,7 +130,7 @@ const SoftwareOSDetailsPage = ({
         itemName="version"
         isLoading={isLoading}
         router={router}
-        teamId={teamId}
+        teamIdForApi={teamIdForApi}
       />
     );
   };
@@ -103,7 +140,11 @@ const SoftwareOSDetailsPage = ({
       return <Spinner />;
     }
 
-    if (isError) {
+    if (isOsVersionError) {
+      // confirm okay to cast to AxiosError like this
+      if (osVersionError.status === 404) {
+        return <Fleet404 />;
+      }
       return <TableDataError className={`${baseClass}__table-error`} />;
     }
 
@@ -113,21 +154,32 @@ const SoftwareOSDetailsPage = ({
 
     return (
       <>
+        {isPremiumTier && (
+          <TeamsHeader
+            isOnGlobalTeam={isOnGlobalTeam}
+            currentTeamId={currentTeamId}
+            userTeams={userTeams}
+            onTeamChange={onTeamChange}
+          />
+        )}
         <SoftwareDetailsSummary
           title={osVersionDetails.name}
           hosts={osVersionDetails.hosts_count}
           queryParams={{
             os_name: osVersionDetails.name_only,
             os_version: osVersionDetails.version,
-            team_id: teamId,
+            team_id: teamIdForApi,
           }}
           name={osVersionDetails.platform}
         />
-        {/* TODO: can we use Card here for card styles */}
-        <div className={`${baseClass}__vulnerabilities-section`}>
+        <Card
+          borderRadiusSize="large"
+          includeShadow
+          className={`${baseClass}__vulnerabilities-section`}
+        >
           <h2>Vulnerabilities</h2>
           {renderTable()}
-        </div>
+        </Card>
       </>
     );
   };

--- a/frontend/pages/SoftwarePage/SoftwareOSDetailsPage/_styles.scss
+++ b/frontend/pages/SoftwarePage/SoftwareOSDetailsPage/_styles.scss
@@ -3,4 +3,8 @@
   display: flex;
   flex-direction: column;
   gap: $pad-medium;
+
+  h2 {
+    font-size: $small;
+  }
 }

--- a/frontend/pages/SoftwarePage/SoftwareOSDetailsPage/_styles.scss
+++ b/frontend/pages/SoftwarePage/SoftwareOSDetailsPage/_styles.scss
@@ -3,17 +3,4 @@
   display: flex;
   flex-direction: column;
   gap: $pad-medium;
-
-  &__vulnerabilities-section {
-    background-color: $core-white;
-    padding: $pad-xxlarge;
-    border: 1px solid $ui-fleet-black-10;
-    border-radius: $border-radius-xxlarge;
-    box-shadow: $box-shadow;
-
-    h2 {
-      margin: 0;
-      font-size: $medium;
-    }
-  }
 }

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwareTitleDetailsPage.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwareTitleDetailsPage.tsx
@@ -1,7 +1,7 @@
 /** software/titles/:id */
 
 import React from "react";
-import { RouteComponentProps } from "react-router";
+import { InjectedRouter } from "react-router";
 import { useQuery } from "react-query";
 
 import { ISoftwareTitle, formatSoftwareType } from "interfaces/software";
@@ -22,17 +22,24 @@ interface ISoftwareTitleDetailsRouteParams {
   id: string;
 }
 
-type ISoftwareTitleDetailsPageProps = RouteComponentProps<
-  undefined,
-  ISoftwareTitleDetailsRouteParams
->;
+interface ISoftwareTitleDetailsPageProps {
+  router: InjectedRouter;
+  routeParams: ISoftwareTitleDetailsRouteParams;
+  location: {
+    query: { team_id?: string };
+  };
+}
 
 const SoftwareTitleDetailsPage = ({
   router,
   routeParams,
+  location,
 }: ISoftwareTitleDetailsPageProps) => {
   // TODO: handle non integer values
   const softwareId = parseInt(routeParams.id, 10);
+  const teamId = location.query.team_id
+    ? parseInt(location.query.team_id, 10)
+    : undefined;
 
   const {
     data: softwareTitle,
@@ -66,7 +73,7 @@ const SoftwareTitleDetailsPage = ({
           type={formatSoftwareType(softwareTitle)}
           versions={softwareTitle.versions.length}
           hosts={softwareTitle.hosts_count}
-          queryParams={{ software_title_id: softwareId }}
+          queryParams={{ software_title_id: softwareId, team_id: teamId }}
           name={softwareTitle.name}
           source={softwareTitle.source}
         />
@@ -77,6 +84,7 @@ const SoftwareTitleDetailsPage = ({
             router={router}
             data={softwareTitle.versions}
             isLoading={isSoftwareTitleLoading}
+            teamId={teamId}
           />
         </div>
       </>

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwareTitleDetailsTable/SoftwareTitleDetailsTable.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwareTitleDetailsTable/SoftwareTitleDetailsTable.tsx
@@ -42,7 +42,7 @@ interface ISoftwareTitleDetailsTableProps {
   router: InjectedRouter;
   data: ISoftwareTitleVersion[];
   isLoading: boolean;
-  teamId?: number;
+  teamIdForApi?: number;
 }
 
 interface IRowProps extends Row {
@@ -55,7 +55,7 @@ const SoftwareTitleDetailsTable = ({
   router,
   data,
   isLoading,
-  teamId,
+  teamIdForApi,
 }: ISoftwareTitleDetailsTableProps) => {
   const handleRowSelect = (row: IRowProps) => {
     const hostsBySoftwareParams = {
@@ -72,8 +72,9 @@ const SoftwareTitleDetailsTable = ({
   };
 
   const softwareTableHeaders = useMemo(
-    () => generateSoftwareTitleDetailsTableConfig({ router, teamId }),
-    [router]
+    () =>
+      generateSoftwareTitleDetailsTableConfig({ router, teamId: teamIdForApi }),
+    [router, teamIdForApi]
   );
 
   return (

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwareTitleDetailsTable/SoftwareTitleDetailsTable.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwareTitleDetailsTable/SoftwareTitleDetailsTable.tsx
@@ -42,6 +42,7 @@ interface ISoftwareTitleDetailsTableProps {
   router: InjectedRouter;
   data: ISoftwareTitleVersion[];
   isLoading: boolean;
+  teamId?: number;
 }
 
 interface IRowProps extends Row {
@@ -54,6 +55,7 @@ const SoftwareTitleDetailsTable = ({
   router,
   data,
   isLoading,
+  teamId,
 }: ISoftwareTitleDetailsTableProps) => {
   const handleRowSelect = (row: IRowProps) => {
     const hostsBySoftwareParams = {
@@ -70,7 +72,7 @@ const SoftwareTitleDetailsTable = ({
   };
 
   const softwareTableHeaders = useMemo(
-    () => generateSoftwareTitleDetailsTableConfig(router),
+    () => generateSoftwareTitleDetailsTableConfig({ router, teamId }),
     [router]
   );
 

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwareTitleDetailsTable/SoftwareTitleDetailsTableConfig.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwareTitleDetailsTable/SoftwareTitleDetailsTableConfig.tsx
@@ -6,6 +6,7 @@ import {
   ISoftwareVulnerability,
 } from "interfaces/software";
 import PATHS from "router/paths";
+import { buildQueryStringFromParams } from "utilities/url";
 
 import TextCell from "components/TableContainer/DataTable/TextCell";
 import ViewAllHostsLink from "components/ViewAllHostsLink";
@@ -13,6 +14,10 @@ import LinkCell from "components/TableContainer/DataTable/LinkCell";
 
 import VulnerabilitiesCell from "../../components/VulnerabilitiesCell";
 
+interface ISoftwareTitleDetailsTableConfigProps {
+  router: InjectedRouter;
+  teamId?: number;
+}
 interface ICellProps {
   cell: {
     value: number | string | ISoftwareVulnerability[];
@@ -40,7 +45,10 @@ interface IVulnCellProps extends ICellProps {
   };
 }
 
-const generateSoftwareTitleDetailsTableConfig = (router: InjectedRouter) => {
+const generateSoftwareTitleDetailsTableConfig = ({
+  router,
+  teamId,
+}: ISoftwareTitleDetailsTableConfigProps) => {
   const tableHeaders = [
     {
       title: "Version",
@@ -49,17 +57,22 @@ const generateSoftwareTitleDetailsTableConfig = (router: InjectedRouter) => {
       accessor: "version",
       Cell: (cellProps: IVersionCellProps): JSX.Element => {
         const { id } = cellProps.row.original;
+        const teamQueryParam = buildQueryStringFromParams({ team_id: teamId });
+        const softwareVersionDetailsPath = `${PATHS.SOFTWARE_VERSION_DETAILS(
+          id.toString()
+        )}?${teamQueryParam}`;
+
         const onClickSoftware = (e: React.MouseEvent) => {
           // Allows for button to be clickable in a clickable row
           e.stopPropagation();
-          router?.push(PATHS.SOFTWARE_VERSION_DETAILS(id.toString()));
+          router?.push(softwareVersionDetailsPath);
         };
 
         // TODO: make only text clickable
         return (
           <LinkCell
             className="name-link"
-            path={PATHS.SOFTWARE_VERSION_DETAILS(id.toString())}
+            path={softwareVersionDetailsPath}
             customOnClick={onClickSoftware}
             value={cellProps.cell.value}
           />
@@ -103,6 +116,7 @@ const generateSoftwareTitleDetailsTableConfig = (router: InjectedRouter) => {
               <ViewAllHostsLink
                 queryParams={{
                   software_version_id: cellProps.row.original.id,
+                  team_id: teamId,
                 }}
                 className="software-link"
                 rowHover

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/_styles.scss
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/_styles.scss
@@ -4,16 +4,7 @@
   flex-direction: column;
   gap: $pad-medium;
 
-  &__versions-section {
-    background-color: $core-white;
-    padding: $pad-xxlarge;
-    border: 1px solid $ui-fleet-black-10;
-    border-radius: $border-radius-xxlarge;
-    box-shadow: $box-shadow;
-
-    h2 {
-      margin: 0;
-      font-size: $medium;
-    }
+  h2 {
+    font-size: $small;
   }
 }

--- a/frontend/pages/SoftwarePage/SoftwareTitles/SoftwareTable/SoftwareTitlesTableConfig.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitles/SoftwareTable/SoftwareTitlesTableConfig.tsx
@@ -8,6 +8,7 @@ import {
   formatSoftwareType,
 } from "interfaces/software";
 import PATHS from "router/paths";
+import { buildQueryStringFromParams } from "utilities/url";
 
 import HeaderCell from "components/TableContainer/DataTable/HeaderCell";
 import TextCell from "components/TableContainer/DataTable/TextCell";
@@ -91,16 +92,21 @@ const generateTableHeaders = (
       Cell: (cellProps: IStringCellProps): JSX.Element => {
         const { id, name, source } = cellProps.row.original;
 
+        const teamQueryParam = buildQueryStringFromParams({ team_id: teamId });
+        const softwareTitleDetailsPath = `${PATHS.SOFTWARE_TITLE_DETAILS(
+          id.toString()
+        )}?${teamQueryParam}`;
+
         const onClickSoftware = (e: React.MouseEvent) => {
           // Allows for button to be clickable in a clickable row
           e.stopPropagation();
 
-          router?.push(PATHS.SOFTWARE_TITLE_DETAILS(id.toString()));
+          router?.push(softwareTitleDetailsPath);
         };
 
         return (
           <LinkCell
-            path={PATHS.SOFTWARE_TITLE_DETAILS(id.toString())}
+            path={softwareTitleDetailsPath}
             customOnClick={onClickSoftware}
             value={
               <>

--- a/frontend/pages/SoftwarePage/SoftwareTitles/SoftwareTable/SoftwareVersionsTableConfig.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitles/SoftwareTable/SoftwareVersionsTableConfig.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { Column } from "react-table";
 import { InjectedRouter } from "react-router";
 
+import { buildQueryStringFromParams } from "utilities/url";
 import {
   formatSoftwareType,
   ISoftwareVersion,
@@ -74,15 +75,23 @@ const generateTableHeaders = (
       Cell: (cellProps: IStringCellProps): JSX.Element => {
         const { id, name, source } = cellProps.row.original;
 
+        const teamQueryParam = buildQueryStringFromParams({
+          team_id: teamId,
+        });
+        const softwareVersionDetailsPath = `${PATHS.SOFTWARE_VERSION_DETAILS(
+          id.toString()
+        )}?${teamQueryParam}`;
+
         const onClickSoftware = (e: React.MouseEvent) => {
           // Allows for button to be clickable in a clickable row
           e.stopPropagation();
-          router?.push(PATHS.SOFTWARE_VERSION_DETAILS(id.toString()));
+
+          router?.push(softwareVersionDetailsPath);
         };
 
         return (
           <LinkCell
-            path={PATHS.SOFTWARE_VERSION_DETAILS(id.toString())}
+            path={softwareVersionDetailsPath}
             customOnClick={onClickSoftware}
             value={
               <>

--- a/frontend/pages/SoftwarePage/SoftwareVersionDetailsPage/SoftwareVersionDetailsPage.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareVersionDetailsPage/SoftwareVersionDetailsPage.tsx
@@ -27,18 +27,18 @@ interface ISoftwareVersionDetailsRouteParams {
   team_id?: string;
 }
 
-interface ISoftwareOSDetailsPageProps {
+interface ISoftwareTitleDetailsPageProps {
   routeParams: ISoftwareVersionDetailsRouteParams;
-  router: InjectedRouter;
+  location: { query: { team_id?: string } };
 }
 
 const SoftwareVersionDetailsPage = ({
   routeParams,
-  router,
-}: ISoftwareOSDetailsPageProps) => {
+  location,
+}: ISoftwareTitleDetailsPageProps) => {
   const versionId = parseInt(routeParams.id, 10);
-  const teamId = routeParams.team_id
-    ? parseInt(routeParams.team_id, 10)
+  const teamId = location.query.team_id
+    ? parseInt(location.query.team_id, 10)
     : undefined;
 
   const {
@@ -80,14 +80,16 @@ const SoftwareVersionDetailsPage = ({
     if (!softwareVersion) {
       return null;
     }
-
     return (
       <>
         <SoftwareDetailsSummary
           title={`${softwareVersion.name}, ${softwareVersion.version}`}
           type={formatSoftwareType(softwareVersion)}
           hosts={hostsCount ?? 0}
-          queryParams={{ software_version_id: softwareVersion.id }}
+          queryParams={{
+            software_version_id: softwareVersion.id,
+            team_id: teamId,
+          }}
           name={softwareVersion.name}
           source={softwareVersion.source}
         />

--- a/frontend/pages/SoftwarePage/SoftwareVersionDetailsPage/SoftwareVersionDetailsPage.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareVersionDetailsPage/SoftwareVersionDetailsPage.tsx
@@ -29,11 +29,13 @@ interface ISoftwareVersionDetailsRouteParams {
 
 interface ISoftwareTitleDetailsPageProps {
   routeParams: ISoftwareVersionDetailsRouteParams;
+  router: InjectedRouter;
   location: { query: { team_id?: string } };
 }
 
 const SoftwareVersionDetailsPage = ({
   routeParams,
+  router,
   location,
 }: ISoftwareTitleDetailsPageProps) => {
   const versionId = parseInt(routeParams.id, 10);

--- a/frontend/pages/SoftwarePage/SoftwareVersionDetailsPage/_styles.scss
+++ b/frontend/pages/SoftwarePage/SoftwareVersionDetailsPage/_styles.scss
@@ -4,16 +4,7 @@
   flex-direction: column;
   gap: $pad-medium;
 
-  &__vulnerabilities-section {
-    background-color: $core-white;
-    padding: $pad-xxlarge;
-    border: 1px solid $ui-fleet-black-10;
-    border-radius: $border-radius-xxlarge;
-    box-shadow: $box-shadow;
-
-    h2 {
-      margin: 0;
-      font-size: $medium;
-    }
+  h2 {
+    font-size: $small;
   }
 }

--- a/frontend/pages/SoftwarePage/SoftwareVulnerabilities/SoftwareVulnerabilitiesTable/SoftwareVulnerabilitiesTable.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareVulnerabilities/SoftwareVulnerabilitiesTable/SoftwareVulnerabilitiesTable.tsx
@@ -136,12 +136,18 @@ const SoftwareVulnerabilitiesTable = ({
 
   const vulnerabilitiesTableHeaders = useMemo(() => {
     if (!data) return [];
-    return generateTableConfig(isPremiumTier, isSandboxMode, router, {
-      includeName: true,
-      includeVulnerabilities: true,
-      includeIcon: true,
-    });
-  }, [data, router]);
+    return generateTableConfig(
+      isPremiumTier,
+      isSandboxMode,
+      router,
+      {
+        includeName: true,
+        includeVulnerabilities: true,
+        includeIcon: true,
+      },
+      teamId
+    );
+  }, [data, router, teamId]);
 
   const handleExploitedVulnFilterDropdownChange = (
     isFilterExploited: boolean

--- a/frontend/pages/SoftwarePage/SoftwareVulnerabilities/SoftwareVulnerabilitiesTable/VulnerabilitiesTableConfig.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareVulnerabilities/SoftwareVulnerabilitiesTable/VulnerabilitiesTableConfig.tsx
@@ -4,6 +4,7 @@ import { InjectedRouter } from "react-router";
 
 import PATHS from "router/paths";
 import { formatSeverity } from "utilities/helpers";
+import { buildQueryStringFromParams } from "utilities/url";
 import { formatOperatingSystemDisplayName } from "interfaces/operating_system";
 import { IVulnerability } from "interfaces/vulnerability";
 
@@ -78,16 +79,22 @@ const generateTableHeaders = (
         }
 
         const { cve } = cellProps.row.original;
+
+        const teamQueryParam = buildQueryStringFromParams({ team_id: teamId });
+        const softwareVulnerabilitiesDetailsPath = `${PATHS.SOFTWARE_VULNERABILITY_DETAILS(
+          cve
+        )}?${teamQueryParam}`;
+
         const onClickVulnerability = (e: React.MouseEvent) => {
           // Allows for button to be clickable in a clickable row
           e.stopPropagation();
 
-          router?.push(PATHS.SOFTWARE_VULNERABILITY_DETAILS(cve));
+          router?.push(softwareVulnerabilitiesDetailsPath);
         };
 
         return (
           <LinkCell
-            path={PATHS.SOFTWARE_VULNERABILITY_DETAILS(cve)}
+            path={softwareVulnerabilitiesDetailsPath}
             customOnClick={onClickVulnerability}
             value={cve}
           />
@@ -246,7 +253,6 @@ const generateTableHeaders = (
       accessor: "linkToFilteredHosts",
       disableSortBy: true,
       Cell: (cellProps: ICellProps) => {
-        console.log("teamId", teamId);
         return (
           <>
             {cellProps.row.original && (

--- a/frontend/pages/SoftwarePage/SoftwareVulnerabilities/SoftwareVulnerabilitiesTable/VulnerabilitiesTableConfig.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareVulnerabilities/SoftwareVulnerabilitiesTable/VulnerabilitiesTableConfig.tsx
@@ -58,7 +58,8 @@ const generateTableHeaders = (
   isPremiumTier?: boolean,
   isSandboxMode?: boolean,
   router?: InjectedRouter,
-  configOptions?: IVulnerabilitiesTableConfigOptions
+  configOptions?: IVulnerabilitiesTableConfigOptions,
+  teamId?: number
 ): IDataColumn[] => {
   const tableHeaders: IDataColumn[] = [
     {
@@ -245,12 +246,14 @@ const generateTableHeaders = (
       accessor: "linkToFilteredHosts",
       disableSortBy: true,
       Cell: (cellProps: ICellProps) => {
+        console.log("teamId", teamId);
         return (
           <>
             {cellProps.row.original && (
               <ViewAllHostsLink
                 queryParams={{
                   vulnerability: cellProps.row.original.cve,
+                  team_id: teamId,
                 }}
                 className="vulnerabilities-link"
                 rowHover

--- a/frontend/pages/SoftwarePage/SoftwareVulnerabilityDetailsPage/SoftwareVulnerabilityDetailsPage.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareVulnerabilityDetailsPage/SoftwareVulnerabilityDetailsPage.tsx
@@ -1,6 +1,6 @@
-/* software/vulnerabilities/:cve */
-import React, { useCallback, useContext } from "react";
+/** software/vulnerabilities/:cve */
 
+import React, { useCallback, useContext } from "react";
 import { useQuery } from "react-query";
 import { RouteComponentProps } from "react-router";
 import { AxiosError } from "axios";

--- a/frontend/pages/SoftwarePage/components/SoftwareVulnerabilitiesTable/SoftwareVulnerabilitiesTable.tsx
+++ b/frontend/pages/SoftwarePage/components/SoftwareVulnerabilitiesTable/SoftwareVulnerabilitiesTable.tsx
@@ -51,7 +51,7 @@ interface ISoftwareVulnerabilitiesTableProps {
   isLoading: boolean;
   className?: string;
   router: InjectedRouter;
-  teamId?: number;
+  teamIdForApi?: number;
 }
 
 interface IRowProps extends Row {
@@ -66,14 +66,17 @@ const SoftwareVulnerabilitiesTable = ({
   isLoading,
   className,
   router,
-  teamId,
+  teamIdForApi,
 }: ISoftwareVulnerabilitiesTableProps) => {
   const { isPremiumTier, isSandboxMode } = useContext(AppContext);
 
   const classNames = classnames(baseClass, className);
 
   const handleRowSelect = (row: IRowProps) => {
-    const hostsBySoftwareParams = { cve: row.original.cve, team_id: teamId };
+    const hostsBySoftwareParams = {
+      cve: row.original.cve,
+      team_id: teamIdForApi,
+    };
 
     const path = hostsBySoftwareParams
       ? `${PATHS.MANAGE_HOSTS}?${buildQueryStringFromParams(
@@ -90,7 +93,7 @@ const SoftwareVulnerabilitiesTable = ({
         Boolean(isPremiumTier),
         Boolean(isSandboxMode),
         router,
-        teamId
+        teamIdForApi
       ),
     [isPremiumTier, isSandboxMode]
   );

--- a/frontend/pages/SoftwarePage/components/SoftwareVulnerabilitiesTable/SoftwareVulnerabilitiesTable.tsx
+++ b/frontend/pages/SoftwarePage/components/SoftwareVulnerabilitiesTable/SoftwareVulnerabilitiesTable.tsx
@@ -85,7 +85,13 @@ const SoftwareVulnerabilitiesTable = ({
   };
 
   const tableHeaders = useMemo(
-    () => generateTableConfig(Boolean(isPremiumTier), Boolean(isSandboxMode)),
+    () =>
+      generateTableConfig(
+        Boolean(isPremiumTier),
+        Boolean(isSandboxMode),
+        router,
+        teamId
+      ),
     [isPremiumTier, isSandboxMode]
   );
   return (

--- a/frontend/pages/SoftwarePage/components/SoftwareVulnerabilitiesTable/SoftwareVulnerabilitiesTableConfig.tsx
+++ b/frontend/pages/SoftwarePage/components/SoftwareVulnerabilitiesTable/SoftwareVulnerabilitiesTableConfig.tsx
@@ -1,6 +1,8 @@
 import React from "react";
+import { InjectedRouter } from "react-router";
 
 import { formatSeverity } from "utilities/helpers";
+import { buildQueryStringFromParams } from "utilities/url";
 import { ISoftwareVulnerability } from "interfaces/software";
 
 import paths from "router/paths";
@@ -47,7 +49,9 @@ interface IDataColumn {
 
 const generateTableConfig = (
   isPremiumTier: boolean,
-  isSandboxMode: boolean
+  isSandboxMode: boolean,
+  router: InjectedRouter,
+  teamId?: number
 ): IDataColumn[] => {
   const tableHeaders: IDataColumn[] = [
     {
@@ -57,10 +61,26 @@ const generateTableConfig = (
       Header: "Vulnerability",
       Cell: ({ cell: { value } }: ITextCellProps) => {
         const cveName = value.toString();
+        const teamQueryParam = buildQueryStringFromParams({
+          team_id: teamId,
+        });
+
+        const softwareVulnerabilityDetailsPath = `${paths.SOFTWARE_VULNERABILITY_DETAILS(
+          cveName
+        )}?${teamQueryParam}`;
+
+        const onClickCVE = (e: React.MouseEvent) => {
+          // Allows for button to be clickable in a clickable row
+          e.stopPropagation();
+
+          router?.push(softwareVulnerabilityDetailsPath);
+        };
+
         return (
           <LinkCell
             value={cveName}
-            path={paths.SOFTWARE_VULNERABILITY_DETAILS(cveName)}
+            path={softwareVulnerabilityDetailsPath}
+            customOnClick={onClickCVE}
           />
         );
       },
@@ -207,6 +227,7 @@ const generateTableConfig = (
               <ViewAllHostsLink
                 queryParams={{
                   vulnerability: cellProps.row.original.cve,
+                  team_id: teamId,
                 }}
                 className="vulnerabilities-link"
                 rowHover

--- a/frontend/services/entities/operating_systems.ts
+++ b/frontend/services/entities/operating_systems.ts
@@ -36,6 +36,14 @@ export interface IOSVersionsResponse {
     has_previous_results: boolean;
   };
 }
+interface IGetOsVersionOptions {
+  os_version_id: number;
+  teamId?: number;
+}
+
+export interface IGetOsVersionQueryKey extends IGetOsVersionOptions {
+  scope: "osVersionDetails";
+}
 
 export interface IOSVersionResponse {
   os_version: IOperatingSystemVersion;
@@ -70,10 +78,14 @@ export const getOSVersions = ({
   return sendRequest("GET", path);
 };
 
-const getOSVersion = (os_version_id: number): Promise<IOSVersionResponse> => {
-  const { OS_VERSION } = endpoints;
+const getOSVersion = ({
+  os_version_id,
+  teamId,
+}: IGetOsVersionOptions): Promise<IOSVersionResponse> => {
+  const endpoint = endpoints.OS_VERSION(os_version_id);
+  const path = teamId ? `${endpoint}?team_id=${teamId}` : endpoint;
 
-  return sendRequest("GET", OS_VERSION(os_version_id));
+  return sendRequest("GET", path);
 };
 
 export default {

--- a/frontend/services/entities/software.ts
+++ b/frontend/services/entities/software.ts
@@ -58,6 +58,16 @@ export interface ISoftwareCountQueryKey
   scope: "softwareCount";
 }
 
+export interface IGetSoftwareTitleQueryParams {
+  softwareId: number;
+  teamId?: number;
+}
+
+export interface IGetSoftwareTitleQueryKey
+  extends IGetSoftwareTitleQueryParams {
+  scope: "softwareById";
+}
+
 export interface IGetSoftwareVersionQueryParams {
   versionId: number;
   teamId?: number;
@@ -152,9 +162,11 @@ export default {
     return sendRequest("GET", path);
   },
 
-  getSoftwareTitle: (id: number) => {
-    const { SOFTWARE_TITLE } = endpoints;
-    return sendRequest("GET", SOFTWARE_TITLE(id));
+  getSoftwareTitle: ({ softwareId, teamId }: IGetSoftwareTitleQueryParams) => {
+    const endpoint = endpoints.SOFTWARE_TITLE(softwareId);
+    const path = teamId ? `${endpoint}?team_id=${teamId}` : endpoint;
+
+    return sendRequest("GET", path);
   },
 
   getSoftwareVersions: (params: ISoftwareApiParams) => {

--- a/frontend/services/entities/software.ts
+++ b/frontend/services/entities/software.ts
@@ -58,6 +58,16 @@ export interface ISoftwareCountQueryKey
   scope: "softwareCount";
 }
 
+export interface IGetSoftwareVersionQueryParams {
+  versionId: number;
+  teamId?: number;
+}
+
+export interface IGetSoftwareVersionQueryKey
+  extends IGetSoftwareVersionQueryParams {
+  scope: "softwareVersion";
+}
+
 const ORDER_KEY = "name";
 const ORDER_DIRECTION = "asc";
 
@@ -155,8 +165,13 @@ export default {
     return sendRequest("GET", path);
   },
 
-  getSoftwareVersion: (id: number) => {
-    const { SOFTWARE_VERSION } = endpoints;
-    return sendRequest("GET", SOFTWARE_VERSION(id));
+  getSoftwareVersion: ({
+    versionId,
+    teamId,
+  }: IGetSoftwareVersionQueryParams) => {
+    const endpoint = endpoints.SOFTWARE_VERSION(versionId);
+    const path = teamId ? `${endpoint}?team_id=${teamId}` : endpoint;
+
+    return sendRequest("GET", path);
   },
 };


### PR DESCRIPTION
## Issue
Issue #16786
Updates to #15919

## Description
### Pages updated:
- Software Title Details Page
- Software Versions Details Page
- OS Versions Details Page

### Updates
- For premium, Add team dropdown / team name for
- Update to show 404 if API error is 404
- Clean up some styling nits/frontend patterns around styling (e.g. use of Card, empty state)
- URL is source of truth for team_id param
- Pass all links the team_id param

## Screenrecording
https://www.loom.com/share/e2790ad9f2264450b37bc425caaac602?sid=c87733c7-57b7-4b6c-b734-2983ed904a55

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->


- [x] Manual QA for all new/changed functionality

