### PR TITLE
API design: Update live query endpoint to allow custom queries

### DIFF
--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -6554,7 +6554,7 @@ If some targeted hosts haven't responded, the live query will stop and return al
 > Either `query` or `query_id` must be specified when using this endpoint.
 
 
-#### Example (running saved query)
+#### Example (run saved query)
 
 `POST /api/v1/fleet/queries/live`
 
@@ -6606,7 +6606,7 @@ If some targeted hosts haven't responded, the live query will stop and return al
 }
 ```
 
-#### Example (running custom query)
+#### Example (run custom query)
 
 `POST /api/v1/fleet/queries/live`
 
@@ -6616,6 +6616,7 @@ If some targeted hosts haven't responded, the live query will stop and return al
 {
   "host_ids": [ 1, 4, 34, 27 ],
   "query": "SELECT model, vendor FROM usb_devices;"
+}
 ```
 
 ##### Default response

--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -5983,8 +5983,7 @@ Either `query` or `query_id` must be provided.
 - [Delete query by name](#delete-query-by-name)
 - [Delete query by ID](#delete-query-by-id)
 - [Delete queries](#delete-queries)
-- [Live query on one host](#run-live-query-on-one-host)
-- [Run live query on multiple hosts](#run-live-query-on-multiple-hosts)
+- [Run live query](#run-live-query)
 
 
 

--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -5983,7 +5983,8 @@ Either `query` or `query_id` must be provided.
 - [Delete query by name](#delete-query-by-name)
 - [Delete query by ID](#delete-query-by-id)
 - [Delete queries](#delete-queries)
-- [Run live query](#run-live-query)
+- [Live query on one host](#run-live-query-on-one-host)
+- [Run live query on multiple hosts](#run-live-query-on-multiple-hosts)
 
 
 
@@ -6531,15 +6532,53 @@ Deletes the queries specified by ID. Returns the count of queries successfully d
 }
 ```
 
-### Run live query
+### Run live query on one host
+
+Runs a live query against the specified host and responds with the results.
+
+If the targeted host hasn't responded, the live query will stop after 25 seconds (or whatever time period is configured via environment variable, e.g. `FLEET_LIVE_QUERY_REST_PERIOD=90s`).
+
+`POST /api/v1/fleet/hosts/:host_id/query`
+
+#### Parameters
+
+| Name      | Type  | In   | Description                                                                                                                                                        |
+|-----------|-------|------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| host_id  | integer | path | **Required**. The ID of the host to target. |
+| sql    | string  | body | The query SQL if running a custom query. May not be used with `query_id`. |
+| query_id | integer | body | The ID of a saved query to run. May not be used with `sql`. Required if running query as an observer. |
+
+> Either `sql` or `query_id` must be specified when using this endpoint.
+
+#### Example (custom query)
+
+`POST /api/v1/fleet/hosts/123/query`
+
+##### Request body
+
+```json
+{
+  "sql": "SELECT model, vendor FROM usb_devices;"
+}
+```
+
+##### Default response
+
+`Status: 200`
+
+```json
+// TODO
+```
+
+
+
+### Run live query on multiple hosts
 
 > This updated API endpoint replaced `GET /api/v1/fleet/queries/run` in Fleet 4.43.0, for improved compatibility with many HTTP clients. The [deprecated endpoint](https://github.com/fleetdm/fleet/blob/fleet-v4.42.0/docs/REST%20API/rest-api.md#run-live-query) is maintained for backwards compatibility.
 
 Runs a live query against the specified hosts and responds with the results.
 
-If some targeted hosts haven't responded, the live query will stop after 25 seconds (or whatever time period is configured), and all collected results are returned.
-
-The timeout period is configurable via environment variable on the Fleet server (e.g. `FLEET_LIVE_QUERY_REST_PERIOD=90s`). If setting a higher value than the default, be sure not to exceed your load balancer timeout.
+If some targeted hosts haven't responded, the live query will stop and return all collected results after 25 seconds (or whatever time period is configured via environment variable, e.g. `FLEET_LIVE_QUERY_REST_PERIOD=90s`).
 
 
 `POST /api/v1/fleet/queries/:id/run`
@@ -6548,7 +6587,7 @@ The timeout period is configurable via environment variable on the Fleet server 
 
 | Name      | Type  | In   | Description                                                                                                                                                        |
 |-----------|-------|------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| query_id | integer | path | **Required**. The ID of the saved query to run. |
+| id | integer | path | **Required**. The ID of the saved query to run. |
 | host_ids  | array | body | **Required**. The IDs of the hosts to target. User must be authorized to target all of these hosts.                                                                |
 
 #### Example
@@ -6564,6 +6603,8 @@ The timeout period is configurable via environment variable on the Fleet server 
 ```
 
 ##### Default response
+
+`Status: 200`
 
 ```json
 {

--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -6621,8 +6621,6 @@ If some targeted hosts haven't responded, the live query will stop and return al
 
 `Status: 200`
 
-
-
 ```json
 {
   "query": "SELECT model, vendor FROM usb_devices;",

--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -6531,7 +6531,6 @@ Deletes the queries specified by ID. Returns the count of queries successfully d
 }
 ```
 
-
 ### Run live query
 
 > This updated API endpoint replaced `GET /api/v1/fleet/queries/run` in Fleet 4.43.0, for improved compatibility with many HTTP clients. The [deprecated endpoint](https://github.com/fleetdm/fleet/blob/fleet-v4.42.0/docs/REST%20API/rest-api.md#run-live-query) is maintained for backwards compatibility.


### PR DESCRIPTION
This replaces the existing `POST /api/v1/fleet/queries/:id/run` endpoint with a new endpoint that allows either a query ID _**or**_ custom SQL. 

`POST /api/v1/fleet/queries/:id/run` would need to be maintained for backwards compatibility (redirect to the new endpoint with the query ID in the body?)