### PR TITLE
Website: Fix broken docs and handbook links

### DIFF
--- a/docs/Using Fleet/MDM-macOS-updates.md
+++ b/docs/Using Fleet/MDM-macOS-updates.md
@@ -79,7 +79,7 @@ To trigger these reminders, we will do the following steps:
 
 ### Step 1: force a macOS update scan
 
-Use the request payload below when running a custom MDM command with Fleet. Documentation on how to run a custom command is [here](./MDM-commands#custom-commands).
+Use the request payload below when running a custom MDM command with Fleet. Documentation on how to run a custom command is [here](https://fleetdm.com/docs/using-fleet/mdm-commands#custom-commands).
 
 Request payload:
 
@@ -119,7 +119,7 @@ Request payload:
 </plist>
 ```
 
-2. Copy the `ProductKey` from the command's results. Documentation on how to view a command's results is [here](./MDM-commands#step-4-view-the-commands-results).
+2. Copy the `ProductKey` from the command's results. Documentation on how to view a command's results is [here](https://fleetdm.com/docs/using-fleet/mdm-commands#step-4-view-the-commands-results).
 
 Example product key: `MSU_UPDATE_22F770820d_patch_13.4.1_rsr`
 

--- a/website/config/routes.js
+++ b/website/config/routes.js
@@ -406,6 +406,7 @@ module.exports.routes = {
   'GET /handbook/business-operations/people-operations': '/handbook/company/communications#hiring',
   'GET /handbook/marketing': '/handbook/demand/',
   'GET /handbook/customers': '/handbook/sales/',
+  'GET /handbook/product': '/handbook/product-design',
 
   'GET /docs': '/docs/get-started/why-fleet',
   'GET /docs/get-started': '/docs/get-started/why-fleet',


### PR DESCRIPTION
Changes:
- Updated two (broken) relative links on the "macOS updates" documentation page to point to the documentation page on fleetdm.com
- Added a redirect to fix broken links to the product design handbook page (/handbook/product » /handbook/product-design)