### PR TITLE
support dynamic host status tooltip based on platform

### DIFF
--- a/frontend/pages/hosts/details/cards/HostSummary/HostSummary.tsx
+++ b/frontend/pages/hosts/details/cards/HostSummary/HostSummary.tsx
@@ -415,7 +415,7 @@ const HostSummary = ({
           backgroundColor={COLORS["tooltip-bg"]}
         >
           <span className={`${baseClass}__tooltip-text`}>
-            {tag.generateTooltip()}
+            {tag.generateTooltip(platform)}
           </span>
         </ReactTooltip>
       </>

--- a/frontend/pages/hosts/details/cards/HostSummary/helpers.tsx
+++ b/frontend/pages/hosts/details/cards/HostSummary/helpers.tsx
@@ -4,7 +4,7 @@ import { HostMdmDeviceStatusUIState } from "../../helpers";
 interface IDeviceStatusTag {
   title: string;
   tagType: "warning" | "error";
-  generateTooltip: (platform?: string) => string;
+  generateTooltip: (platform: string) => string;
 }
 
 type HostMdmDeviceStatusUIStateNoUnlock = Exclude<
@@ -30,13 +30,13 @@ export const DEVICE_STATUS_TAGS: DeviceStatusTagConfig = {
   unlocking: {
     title: "UNLOCK PENDING",
     tagType: "warning",
-    generateTooltip: () =>
+    generateTooltip: (platform) =>
       "Host will unlock when it comes online.  If the host is online, it will unlock the next time it checks in to Fleet.",
   },
   locking: {
     title: "LOCK PENDING",
     tagType: "warning",
-    generateTooltip: () =>
+    generateTooltip: (platform) =>
       "Host will lock when it comes online.  If the host is online, it will lock the next time it checks in to Fleet.",
   },
 };


### PR DESCRIPTION
relates to #10477

takes into account platform for the host device status tag tooltip. macOS shows a different tooltip then the other platforms.

**macos:**

![image](https://github.com/fleetdm/fleet/assets/1153709/d0217811-f008-4bc7-95fa-4538580dafab)

**non mac:**

![image](https://github.com/fleetdm/fleet/assets/1153709/fa24f174-3b96-43a3-97d8-97281a4359e8)

- [x] Manual QA for all new/changed functionality
