### PR TITLE
Handbook: Add ritual for regenerating merged osquery schema.

### DIFF
--- a/handbook/digital-experience/digital-experience.rituals.yml
+++ b/handbook/digital-experience/digital-experience.rituals.yml
@@ -130,3 +130,12 @@
   moreInfoUrl: "https://fleetdm.com/handbook/digital-experience#check-linkedin-for-unread-messages"
   dri: "sampfluger88"
   autoIssue:
+- 
+  task: "Update merged schema JSON"
+  startedOn: "2024-02-13" 
+  frequency: "Weekly"
+  description: "Run the `generate-merged-schema` script to update the osqueyr schema tables."
+  dri: "eashaw"
+  autoIssue:   # Enables automation of GitHub issues
+    labels: [ "#g-digital-experience" ] # label to be applied to issue
+    repo: fleet

--- a/handbook/digital-experience/digital-experience.rituals.yml
+++ b/handbook/digital-experience/digital-experience.rituals.yml
@@ -136,6 +136,6 @@
   frequency: "Weekly"
   description: "Run the `generate-merged-schema` script to update the osqueyr schema tables."
   dri: "eashaw"
-  autoIssue:   # Enables automation of GitHub issues
-    labels: [ "#g-digital-experience" ] # label to be applied to issue
+  autoIssue:
+    labels: [ "#g-digital-experience" ]
     repo: fleet

--- a/handbook/digital-experience/digital-experience.rituals.yml
+++ b/handbook/digital-experience/digital-experience.rituals.yml
@@ -134,7 +134,7 @@
   task: "Update merged schema JSON"
   startedOn: "2024-02-13" 
   frequency: "Weekly"
-  description: "Run the `generate-merged-schema` script to update the osqueyr schema tables."
+  description: "Run the `generate-merged-schema` script to update the osquery schema tables."
   dri: "eashaw"
   autoIssue:
     labels: [ "#g-digital-experience" ]


### PR DESCRIPTION

Changes:
- Added a weekly digital experience ritual for regenerating  `/schema/osqeury_fleet_schema.json` with the latest changes