### PR TITLE
Fix duplicate activities created when running lock/unlocking scripts on hosts with scripts disabled

### DIFF
--- a/changes/16856-fix-duplicate-activities-lock-unlock-scripts
+++ b/changes/16856-fix-duplicate-activities-lock-unlock-scripts
@@ -1,0 +1,1 @@
+* Fixed generating duplicate activities when locking or unlocking a host with scripts disabled.

--- a/server/datastore/mysql/scripts_test.go
+++ b/server/datastore/mysql/scripts_test.go
@@ -90,6 +90,17 @@ func testHostScriptResult(t *testing.T, ds *Datastore) {
 	})
 	require.NoError(t, err)
 
+	// record a duplicate result for this execution, will be ignored
+	hsr, err := ds.SetHostScriptExecutionResult(ctx, &fleet.HostScriptResultPayload{
+		HostID:      1,
+		ExecutionID: createdScript.ExecutionID,
+		Output:      "foobarbaz",
+		Runtime:     22,
+		ExitCode:    1,
+	})
+	require.NoError(t, err)
+	require.Nil(t, hsr)
+
 	// it is not pending anymore
 	pending, err = ds.ListPendingHostScriptExecutions(ctx, 1)
 	require.NoError(t, err)


### PR DESCRIPTION
#16856 

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [x] Added/updated tests
- [ ] Manual QA for all new/changed functionality
