### PR TITLE
Fix unreleased UI bug when parsing API errors for lock and unlock modals

### DIFF
--- a/frontend/pages/hosts/details/HostDetailsPage/modals/LockModal/LockModal.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/modals/LockModal/LockModal.tsx
@@ -1,12 +1,12 @@
 import React, { useContext } from "react";
 
+import { NotificationContext } from "context/notification";
+import { getErrorReason } from "interfaces/errors";
 import hostAPI from "services/entities/hosts";
 
 import Modal from "components/Modal";
 import Button from "components/buttons/Button";
 import Checkbox from "components/forms/fields/Checkbox";
-import { NotificationContext } from "context/notification";
-import { AxiosError } from "axios";
 
 const baseClass = "lock-modal";
 
@@ -35,9 +35,8 @@ const LockModal = ({
       await hostAPI.lockHost(id);
       onSuccess();
       renderFlash("success", "Host is locking!");
-    } catch (error) {
-      const err = error as AxiosError;
-      renderFlash("error", err.message);
+    } catch (e) {
+      renderFlash("error", getErrorReason(e));
     }
     onClose();
     setIsLocking(false);

--- a/frontend/pages/hosts/details/HostDetailsPage/modals/RunScriptModal/RunScriptModal.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/modals/RunScriptModal/RunScriptModal.tsx
@@ -1,19 +1,18 @@
 import React, { useCallback, useContext, useMemo, useState } from "react";
 import { useQuery } from "react-query";
-import { AxiosResponse } from "axios";
 
 import { AppContext } from "context/app";
 import { NotificationContext } from "context/notification";
 
-import { IApiError } from "interfaces/errors";
+import { getErrorReason, IApiError } from "interfaces/errors";
 import { IHost } from "interfaces/host";
+import { IHostScript } from "interfaces/script";
 import { IUser } from "interfaces/user";
 
 import scriptsAPI, {
   IHostScriptsQueryKey,
   IHostScriptsResponse,
 } from "services/entities/scripts";
-import { IHostScript } from "interfaces/script";
 
 import Button from "components/buttons/Button";
 import DataError from "components/DataError/DataError";
@@ -96,9 +95,7 @@ const RunScriptModal = ({
             );
             refetchHostScripts();
           } catch (e) {
-            const error = e as AxiosResponse<IApiError>;
-            console.log(error);
-            renderFlash("error", error.data.errors[0].reason);
+            renderFlash("error", getErrorReason(e));
             setRunScriptRequested(false);
           }
           break;

--- a/frontend/pages/hosts/details/HostDetailsPage/modals/UnlockModal/UnlockModal.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/modals/UnlockModal/UnlockModal.tsx
@@ -3,6 +3,7 @@ import { AxiosError } from "axios";
 import { useQuery } from "react-query";
 
 import { NotificationContext } from "context/notification";
+import { getErrorReason } from "interfaces/errors";
 import hostAPI, { IUnlockHostResponse } from "services/entities/hosts";
 
 import Modal from "components/Modal";
@@ -51,9 +52,8 @@ const UnlockModal = ({
       await hostAPI.unlockHost(id);
       onSuccess();
       renderFlash("success", "Host is unlocking!");
-    } catch (error) {
-      const err = error as AxiosError;
-      renderFlash("error", err.message);
+    } catch (e) {
+      renderFlash("error", getErrorReason(e));
     }
     onClose();
     setIsUnlocking(false);


### PR DESCRIPTION
Issue #16851 

Note: In the interest of uniformity, the UI will display the error text verbatim as it comes from the backend response, which matches the spec for the [CLI](https://www.figma.com/file/FCmmIh1y1DTzlRF5JsH3wh/%239949-%26-%239951-Remote-lock-and-remote-wipe-for-macOS%2C-Windows%2C-and-Linux?type=design&node-id=479-4345&mode=design&t=ScScmRPaxtzhEW3c-0) but is a slight departure from the text specified [here](https://www.figma.com/file/FCmmIh1y1DTzlRF5JsH3wh/%239949-%26-%239951-Remote-lock-and-remote-wipe-for-macOS%2C-Windows%2C-and-Linux?type=design&node-id=422-7396&mode=design&t=ScScmRPaxtzhEW3c-0).