### PR TITLE
[idea] use github actions for freezes (unfreeze by adding a label to the PR)

### DIFF
--- a/.github/workflows/mergefreeze.yml
+++ b/.github/workflows/mergefreeze.yml
@@ -1,0 +1,47 @@
+name: Mergefreeze
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled]
+
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+jobs:
+  validate-pr:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Unfreeze if all modified files are OK to merge.
+        id: modified-files
+        run: |
+          ALLOWED_PATHS=(docs/**/*.md handbook/**/*.md mdm_profiles/** website/**)
+          CHANGED_FILES=$(gh pr view $PR_NUMBER --json files --jq '.files[].path')
+
+          for FILE in $CHANGED_FILES; do
+            for PATTERN in "${ALLOWED_PATHS[@]}"; do
+              if [[ ! $FILE == $PATTERN ]]; then
+                echo "file $FILE is not in the allowed paths, PR can't be automatically unfrozen."
+                exit 0
+              fi
+            done
+
+          echo "all changed files are in the allowed paths. Automatically unfreezing."
+          echo "all_files_allowed=true" >> $GITHUB_OUTPUT
+
+      - name: Unfreeze if the PR has the unfrozen tag
+        if: ${{ steps.modified-files.outputs.all_files_allowed }}
+        run: |
+          PR_NUMBER=${{ github.event.pull_request.number }}
+          REQUIRED_TAG="~timebox"
+      
+          LABELS=$(gh pr view $PR_NUMBER --json labels --jq '.labels[].name')
+      
+          for LABEL in $LABELS; do
+            if [ "$LABEL" == "$REQUIRED_TAG" ]; then
+              exit 0
+            fi
+          done
+      
+          echo "☃️❄️ merge freeze is on! to unfreeze your PR tag, add the '$REQUIRED_TAG' tag."
+          exit 1
+    

--- a/.github/workflows/mergefreeze.yml
+++ b/.github/workflows/mergefreeze.yml
@@ -15,7 +15,7 @@ jobs:
         id: modified-files
         run: |
           ALLOWED_PATHS=(docs/**/*.md handbook/**/*.md mdm_profiles/** website/**)
-          CHANGED_FILES=$(gh pr view $PR_NUMBER --json files --jq '.files[].path')
+          CHANGED_FILES=$(gh pr view $PR_NUMBER --repo fleetdm/fleet --json files --jq '.files[].path')
 
           for FILE in $CHANGED_FILES; do
             for PATTERN in "${ALLOWED_PATHS[@]}"; do
@@ -34,7 +34,7 @@ jobs:
           PR_NUMBER=${{ github.event.pull_request.number }}
           REQUIRED_TAG="~timebox"
       
-          LABELS=$(gh pr view $PR_NUMBER --json labels --jq '.labels[].name')
+          LABELS=$(gh pr view $PR_NUMBER --repo fleetdm/fleet --json labels --jq '.labels[].name')
       
           for LABEL in $LABELS; do
             if [ "$LABEL" == "$REQUIRED_TAG" ]; then

--- a/.github/workflows/mergefreeze.yml
+++ b/.github/workflows/mergefreeze.yml
@@ -25,6 +25,7 @@ jobs:
                 exit 0
               fi
             done
+          done
 
           echo "all changed files are in the allowed paths. Automatically unfreezing."
           echo "all_files_allowed=true" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/mergefreeze.yml
+++ b/.github/workflows/mergefreeze.yml
@@ -15,19 +15,25 @@ jobs:
         id: modified-files
         run: |
           PR_NUMBER=${{ github.event.pull_request.number }}
-          ALLOWED_PATHS=(docs/**/*.md handbook/**/*.md mdm_profiles/** website/**)
+          ALLOWED_PATHS=("docs/**/*.md" "handbook/**/*.md" "mdm_profiles/** website/**")
           CHANGED_FILES=$(gh pr view $PR_NUMBER --repo fleetdm/fleet --json files --jq '.files[].path')
+
+          OLD_IFS="$IFS"
+          IFS=$'\n'
 
           for FILE in $CHANGED_FILES; do
             for PATTERN in "${ALLOWED_PATHS[@]}"; do
-              if [[ ! "$FILE" == $PATTERN ]]; then
-                echo "file $FILE is not in the allowed paths, PR can't be automatically unfrozen."
-                echo "files_with_frozen_changes=true" >> "$GITHUB_OUTPUT"
-                exit 0
-              fi
+            echo $FILE, $PATTERN
+                if [[ $FILE == $PATTERN ]]; then
+                  break
+                else
+                  echo "file $FILE is not in the allowed paths, PR can't be automatically unfrozen."
+                  exit 0
+                fi
             done
           done
 
+          IFS="$OLD_IFS"
           echo "all changed files are in the allowed paths. Automatically unfreezing."
 
       - name: Unfreeze if the PR has the unfrozen tag

--- a/.github/workflows/mergefreeze.yml
+++ b/.github/workflows/mergefreeze.yml
@@ -28,6 +28,7 @@ jobs:
                   break
                 else
                   echo "file $FILE is not in the allowed paths, PR can't be automatically unfrozen."
+                  echo "files_with_frozen_changes=true" >> "$GITHUB_OUTPUT"
                   exit 0
                 fi
             done

--- a/.github/workflows/mergefreeze.yml
+++ b/.github/workflows/mergefreeze.yml
@@ -22,16 +22,16 @@ jobs:
             for PATTERN in "${ALLOWED_PATHS[@]}"; do
               if [[ ! $FILE == $PATTERN ]]; then
                 echo "file $FILE is not in the allowed paths, PR can't be automatically unfrozen."
+                echo "files_with_frozen_changes=true" >> "$GITHUB_OUTPUT"
                 exit 0
               fi
             done
           done
 
           echo "all changed files are in the allowed paths. Automatically unfreezing."
-          echo "all_files_allowed=true" >> "$GITHUB_OUTPUT"
 
       - name: Unfreeze if the PR has the unfrozen tag
-        if: ${{ steps.modified-files.outputs.all_files_allowed }}
+        if: ${{ steps.modified-files.outputs.files_with_frozen_changes }}
         run: |
           PR_NUMBER=${{ github.event.pull_request.number }}
           REQUIRED_TAG="~timebox"

--- a/.github/workflows/mergefreeze.yml
+++ b/.github/workflows/mergefreeze.yml
@@ -27,7 +27,7 @@ jobs:
             done
 
           echo "all changed files are in the allowed paths. Automatically unfreezing."
-          echo "all_files_allowed=true" >> $GITHUB_OUTPUT
+          echo "all_files_allowed=true" >> "$GITHUB_OUTPUT"
 
       - name: Unfreeze if the PR has the unfrozen tag
         if: ${{ steps.modified-files.outputs.all_files_allowed }}

--- a/.github/workflows/mergefreeze.yml
+++ b/.github/workflows/mergefreeze.yml
@@ -7,6 +7,16 @@ on:
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+# This allows a subsequently queued workflow run to interrupt previous runs
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id}}
+  cancel-in-progress: true
+
+defaults:
+  run:
+    # fail-fast using bash -eo pipefail. See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#exit-codes-and-error-action-preference
+    shell: bash
+
 jobs:
   validate-pr:
     runs-on: ubuntu-latest

--- a/.github/workflows/mergefreeze.yml
+++ b/.github/workflows/mergefreeze.yml
@@ -20,7 +20,7 @@ jobs:
 
           for FILE in $CHANGED_FILES; do
             for PATTERN in "${ALLOWED_PATHS[@]}"; do
-              if [[ ! $FILE == $PATTERN ]]; then
+              if [[ ! "$FILE" == $PATTERN ]]; then
                 echo "file $FILE is not in the allowed paths, PR can't be automatically unfrozen."
                 echo "files_with_frozen_changes=true" >> "$GITHUB_OUTPUT"
                 exit 0

--- a/.github/workflows/mergefreeze.yml
+++ b/.github/workflows/mergefreeze.yml
@@ -14,6 +14,7 @@ jobs:
       - name: Unfreeze if all modified files are OK to merge.
         id: modified-files
         run: |
+          PR_NUMBER=${{ github.event.pull_request.number }}
           ALLOWED_PATHS=(docs/**/*.md handbook/**/*.md mdm_profiles/** website/**)
           CHANGED_FILES=$(gh pr view $PR_NUMBER --repo fleetdm/fleet --json files --jq '.files[].path')
 

--- a/.github/workflows/mergefreeze.yml
+++ b/.github/workflows/mergefreeze.yml
@@ -2,7 +2,7 @@ name: Mergefreeze
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, labeled]
+    types: [opened, synchronize, reopened, labeled, unlabeled]
 
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
An idea to manage freezes on our own without depending on external services. The idea is to:

1. Prevent people indavertingly unfreezing `main`
2. Make easier/faster for people to unfreeze PRs.
3. By having all unfrozen PR tagged, we can easily measure how many PRs we unfroze during a milestone, how many of them were for bugs, features, etc.

Here's a video showcasing how things work:

<div>
    <a href="https://www.loom.com/share/de6d38bd36a74d3cb956ffa696d06b4b">
      <p>Managing Freezes via GitHub actions - Watch Video</p>
    </a>
    <a href="https://www.loom.com/share/de6d38bd36a74d3cb956ffa696d06b4b">
      <img style="max-width:300px;" src="https://cdn.loom.com/sessions/thumbnails/de6d38bd36a74d3cb956ffa696d06b4b-with-play.gif">
    </a>
  </div>