### PR TITLE
[Released bug] Fleet UI: Fix my device page last restarted date

### DIFF
--- a/changes/16681-device-last-restarted-bug
+++ b/changes/16681-device-last-restarted-bug
@@ -1,0 +1,1 @@
+- Fix device page showing invalid date for last restarted

--- a/frontend/pages/hosts/details/DeviceUserPage/DeviceUserPage.tsx
+++ b/frontend/pages/hosts/details/DeviceUserPage/DeviceUserPage.tsx
@@ -29,6 +29,7 @@ import {
   DOCUMENT_TITLE_SUFFIX,
   HOST_ABOUT_DATA,
   HOST_TITLE_DATA,
+  HOST_TITLE_DATA_DEVICE_ONLY,
 } from "utilities/constants";
 
 import HostSummaryCard from "../cards/HostSummary";
@@ -209,7 +210,9 @@ const DeviceUserPage = ({
     }
   );
 
-  const titleData = normalizeEmptyValues(pick(host, HOST_TITLE_DATA));
+  const titleData = normalizeEmptyValues(
+    pick(host, [...HOST_TITLE_DATA, ...HOST_TITLE_DATA_DEVICE_ONLY])
+  );
 
   const aboutData = normalizeEmptyValues(pick(host, HOST_ABOUT_DATA));
 
@@ -367,7 +370,6 @@ const DeviceUserPage = ({
             )}
             <HostSummaryCard
               titleData={titleData}
-              diskEncryptionEnabled={host?.disk_encryption_enabled}
               bootstrapPackageData={bootstrapPackageData}
               isPremiumTier={isPremiumTier}
               toggleOSSettingsModal={toggleOSSettingsModal}

--- a/frontend/pages/hosts/details/DeviceUserPage/DeviceUserPage.tsx
+++ b/frontend/pages/hosts/details/DeviceUserPage/DeviceUserPage.tsx
@@ -29,7 +29,6 @@ import {
   DOCUMENT_TITLE_SUFFIX,
   HOST_ABOUT_DATA,
   HOST_TITLE_DATA,
-  HOST_TITLE_DATA_DEVICE_ONLY,
 } from "utilities/constants";
 
 import HostSummaryCard from "../cards/HostSummary";
@@ -210,9 +209,7 @@ const DeviceUserPage = ({
     }
   );
 
-  const titleData = normalizeEmptyValues(
-    pick(host, [...HOST_TITLE_DATA, ...HOST_TITLE_DATA_DEVICE_ONLY])
-  );
+  const titleData = normalizeEmptyValues(pick(host, HOST_TITLE_DATA));
 
   const aboutData = normalizeEmptyValues(pick(host, HOST_ABOUT_DATA));
 

--- a/frontend/pages/hosts/details/DeviceUserPage/DeviceUserPage.tsx
+++ b/frontend/pages/hosts/details/DeviceUserPage/DeviceUserPage.tsx
@@ -28,7 +28,7 @@ import PATHS from "router/paths";
 import {
   DOCUMENT_TITLE_SUFFIX,
   HOST_ABOUT_DATA,
-  HOST_TITLE_DATA,
+  HOST_SUMMARY_DATA,
 } from "utilities/constants";
 
 import HostSummaryCard from "../cards/HostSummary";
@@ -209,7 +209,7 @@ const DeviceUserPage = ({
     }
   );
 
-  const titleData = normalizeEmptyValues(pick(host, HOST_TITLE_DATA));
+  const summaryData = normalizeEmptyValues(pick(host, HOST_SUMMARY_DATA));
 
   const aboutData = normalizeEmptyValues(pick(host, HOST_ABOUT_DATA));
 
@@ -366,7 +366,7 @@ const DeviceUserPage = ({
               </InfoBanner>
             )}
             <HostSummaryCard
-              titleData={titleData}
+              summaryData={summaryData}
               bootstrapPackageData={bootstrapPackageData}
               isPremiumTier={isPremiumTier}
               toggleOSSettingsModal={toggleOSSettingsModal}

--- a/frontend/pages/hosts/details/DeviceUserPage/DeviceUserPage.tsx
+++ b/frontend/pages/hosts/details/DeviceUserPage/DeviceUserPage.tsx
@@ -25,7 +25,11 @@ import InfoBanner from "components/InfoBanner";
 import Icon from "components/Icon/Icon";
 import { normalizeEmptyValues } from "utilities/helpers";
 import PATHS from "router/paths";
-import { DOCUMENT_TITLE_SUFFIX } from "utilities/constants";
+import {
+  DOCUMENT_TITLE_SUFFIX,
+  HOST_ABOUT_DATA,
+  HOST_TITLE_DATA,
+} from "utilities/constants";
 
 import HostSummaryCard from "../cards/HostSummary";
 import AboutCard from "../cards/About";
@@ -205,39 +209,9 @@ const DeviceUserPage = ({
     }
   );
 
-  const titleData = normalizeEmptyValues(
-    pick(host, [
-      "id",
-      "status",
-      "issues",
-      "memory",
-      "cpu_type",
-      "os_version",
-      "osquery_version",
-      "enroll_secret_name",
-      "detail_updated_at",
-      "percent_disk_space_available",
-      "gigs_disk_space_available",
-      "team_name",
-      "platform",
-      "mdm",
-    ])
-  );
+  const titleData = normalizeEmptyValues(pick(host, HOST_TITLE_DATA));
 
-  const aboutData = normalizeEmptyValues(
-    pick(host, [
-      "seen_time",
-      "uptime",
-      "last_enrolled_at",
-      "hardware_model",
-      "hardware_serial",
-      "primary_ip",
-      "public_ip",
-      "geolocation",
-      "batteries",
-      "detail_updated_at",
-    ])
-  );
+  const aboutData = normalizeEmptyValues(pick(host, HOST_ABOUT_DATA));
 
   const toggleInfoModal = useCallback(() => {
     setShowInfoModal(!showInfoModal);

--- a/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
@@ -49,7 +49,6 @@ import permissions from "utilities/permissions";
 import {
   DOCUMENT_TITLE_SUFFIX,
   HOST_TITLE_DATA,
-  HOST_TITLE_DATA_HDP_ONLY,
   HOST_ABOUT_DATA,
   HOST_OSQUERY_DATA,
 } from "utilities/constants";
@@ -463,9 +462,7 @@ const HostDetailsPage = ({
     setPathname(location.pathname + location.search);
   }, [location]);
 
-  const titleData = normalizeEmptyValues(
-    pick(host, [...HOST_TITLE_DATA, ...HOST_TITLE_DATA_HDP_ONLY])
-  );
+  const titleData = normalizeEmptyValues(pick(host, HOST_TITLE_DATA));
 
   const aboutData = normalizeEmptyValues(pick(host, HOST_ABOUT_DATA));
 

--- a/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
@@ -46,7 +46,12 @@ import {
   TAGGED_TEMPLATES,
 } from "utilities/helpers";
 import permissions from "utilities/permissions";
-import { DOCUMENT_TITLE_SUFFIX } from "utilities/constants";
+import {
+  DOCUMENT_TITLE_SUFFIX,
+  HOST_TITLE_DATA,
+  HOST_ABOUT_DATA,
+  HOST_OSQUERY_DATA,
+} from "utilities/constants";
 
 import Spinner from "components/Spinner";
 import TabsWrapper from "components/TabsWrapper";
@@ -457,48 +462,11 @@ const HostDetailsPage = ({
     setPathname(location.pathname + location.search);
   }, [location]);
 
-  const titleData = normalizeEmptyValues(
-    pick(host, [
-      "id",
-      "status",
-      "issues",
-      "memory",
-      "cpu_type",
-      "platform",
-      "os_version",
-      "osquery_version",
-      "enroll_secret_name",
-      "detail_updated_at",
-      "percent_disk_space_available",
-      "gigs_disk_space_available",
-      "team_name",
-      "display_name",
-    ])
-  );
+  const titleData = normalizeEmptyValues(pick(host, HOST_TITLE_DATA));
 
-  const aboutData = normalizeEmptyValues(
-    pick(host, [
-      "seen_time",
-      "uptime",
-      "last_enrolled_at",
-      "hardware_model",
-      "hardware_serial",
-      "primary_ip",
-      "public_ip",
-      "geolocation",
-      "batteries",
-      "detail_updated_at",
-      "last_restarted_at",
-    ])
-  );
+  const aboutData = normalizeEmptyValues(pick(host, HOST_ABOUT_DATA));
 
-  const osqueryData = normalizeEmptyValues(
-    pick(host, [
-      "config_tls_refresh",
-      "logger_tls_period",
-      "distributed_interval",
-    ])
-  );
+  const osqueryData = normalizeEmptyValues(pick(host, HOST_OSQUERY_DATA));
 
   const togglePolicyDetailsModal = useCallback(
     (policy: IHostPolicy) => {

--- a/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
@@ -49,6 +49,7 @@ import permissions from "utilities/permissions";
 import {
   DOCUMENT_TITLE_SUFFIX,
   HOST_TITLE_DATA,
+  HOST_TITLE_DATA_HDP_ONLY,
   HOST_ABOUT_DATA,
   HOST_OSQUERY_DATA,
 } from "utilities/constants";
@@ -462,7 +463,9 @@ const HostDetailsPage = ({
     setPathname(location.pathname + location.search);
   }, [location]);
 
-  const titleData = normalizeEmptyValues(pick(host, HOST_TITLE_DATA));
+  const titleData = normalizeEmptyValues(
+    pick(host, [...HOST_TITLE_DATA, ...HOST_TITLE_DATA_HDP_ONLY])
+  );
 
   const aboutData = normalizeEmptyValues(pick(host, HOST_ABOUT_DATA));
 
@@ -764,7 +767,6 @@ const HostDetailsPage = ({
         </div>
         <HostSummaryCard
           titleData={titleData}
-          diskEncryptionEnabled={host?.disk_encryption_enabled}
           bootstrapPackageData={bootstrapPackageData}
           isPremiumTier={isPremiumTier}
           isSandboxMode={isSandboxMode}

--- a/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
@@ -48,7 +48,7 @@ import {
 import permissions from "utilities/permissions";
 import {
   DOCUMENT_TITLE_SUFFIX,
-  HOST_TITLE_DATA,
+  HOST_SUMMARY_DATA,
   HOST_ABOUT_DATA,
   HOST_OSQUERY_DATA,
 } from "utilities/constants";
@@ -462,7 +462,7 @@ const HostDetailsPage = ({
     setPathname(location.pathname + location.search);
   }, [location]);
 
-  const titleData = normalizeEmptyValues(pick(host, HOST_TITLE_DATA));
+  const summaryData = normalizeEmptyValues(pick(host, HOST_SUMMARY_DATA));
 
   const aboutData = normalizeEmptyValues(pick(host, HOST_ABOUT_DATA));
 
@@ -763,7 +763,7 @@ const HostDetailsPage = ({
           />
         </div>
         <HostSummaryCard
-          titleData={titleData}
+          summaryData={summaryData}
           bootstrapPackageData={bootstrapPackageData}
           isPremiumTier={isPremiumTier}
           isSandboxMode={isSandboxMode}

--- a/frontend/pages/hosts/details/cards/HostSummary/HostSummary.tsx
+++ b/frontend/pages/hosts/details/cards/HostSummary/HostSummary.tsx
@@ -102,7 +102,7 @@ interface IBootstrapPackageData {
 }
 
 interface IHostSummaryProps {
-  titleData: any; // TODO: create interfaces for this and use consistently across host pages and related helpers
+  summaryData: any; // TODO: create interfaces for this and use consistently across host pages and related helpers
   bootstrapPackageData?: IBootstrapPackageData;
   isPremiumTier?: boolean;
   isSandboxMode?: boolean;
@@ -163,7 +163,7 @@ const getHostDiskEncryptionTooltipMessage = (
 };
 
 const HostSummary = ({
-  titleData,
+  summaryData,
   bootstrapPackageData,
   isPremiumTier,
   isSandboxMode = false,
@@ -182,10 +182,10 @@ const HostSummary = ({
     status,
     platform,
     disk_encryption_enabled: diskEncryptionEnabled,
-  } = titleData;
+  } = summaryData;
 
   const renderRefetch = () => {
-    const isOnline = titleData.status === "online";
+    const isOnline = summaryData.status === "online";
     let isDisabled = false;
     let tooltip: React.ReactNode = <></>;
 
@@ -239,11 +239,11 @@ const HostSummary = ({
           data-html
         >
           <span className={`tooltip__tooltip-text`}>
-            Failing policies ({titleData.issues.failing_policies_count})
+            Failing policies ({summaryData.issues.failing_policies_count})
           </span>
         </ReactTooltip>
         <span className={"info-flex__data__text"}>
-          {titleData.issues.total_issues_count}
+          {summaryData.issues.total_issues_count}
         </span>
       </span>
     </div>
@@ -253,8 +253,8 @@ const HostSummary = ({
     <div className="info-flex__item info-flex__item--title">
       <span className="info-flex__header">Team</span>
       <span className={`info-flex__data`}>
-        {titleData.team_name ? (
-          `${titleData.team_name}`
+        {summaryData.team_name ? (
+          `${summaryData.team_name}`
         ) : (
           <span className="info-flex__no-team">No team</span>
         )}
@@ -318,7 +318,7 @@ const HostSummary = ({
           />
         </div>
 
-        {(titleData.issues?.total_issues_count > 0 || isSandboxMode) &&
+        {(summaryData.issues?.total_issues_count > 0 || isSandboxMode) &&
           isPremiumTier &&
           renderIssues()}
 
@@ -354,9 +354,11 @@ const HostSummary = ({
             <span className="info-flex__header">Disk space</span>
             <DiskSpaceGraph
               baseClass="info-flex"
-              gigsDiskSpaceAvailable={titleData.gigs_disk_space_available}
-              percentDiskSpaceAvailable={titleData.percent_disk_space_available}
-              id={`disk-space-tooltip-${titleData.id}`}
+              gigsDiskSpaceAvailable={summaryData.gigs_disk_space_available}
+              percentDiskSpaceAvailable={
+                summaryData.percent_disk_space_available
+              }
+              id={`disk-space-tooltip-${summaryData.id}`}
               platform={platform}
               tooltipPosition="bottom"
             />
@@ -368,28 +370,28 @@ const HostSummary = ({
         <div className="info-flex__item info-flex__item--title">
           <span className="info-flex__header">Memory</span>
           <span className="info-flex__data">
-            {wrapFleetHelper(humanHostMemory, titleData.memory)}
+            {wrapFleetHelper(humanHostMemory, summaryData.memory)}
           </span>
         </div>
         <div className="info-flex__item info-flex__item--title">
           <span className="info-flex__header">Processor type</span>
-          <span className="info-flex__data">{titleData.cpu_type}</span>
+          <span className="info-flex__data">{summaryData.cpu_type}</span>
         </div>
         <div className="info-flex__item info-flex__item--title">
           <span className="info-flex__header">Operating system</span>
-          <span className="info-flex__data">{titleData.os_version}</span>
+          <span className="info-flex__data">{summaryData.os_version}</span>
         </div>
         <div className="info-flex__item info-flex__item--title">
           <span className="info-flex__header">Osquery</span>
-          <span className="info-flex__data">{titleData.osquery_version}</span>
+          <span className="info-flex__data">{summaryData.osquery_version}</span>
         </div>
       </div>
     );
   };
 
-  const lastFetched = titleData.detail_updated_at ? (
+  const lastFetched = summaryData.detail_updated_at ? (
     <HumanTimeDiffWithFleetLaunchCutoff
-      timeString={titleData.detail_updated_at}
+      timeString={summaryData.detail_updated_at}
     />
   ) : (
     ": unavailable"
@@ -432,7 +434,7 @@ const HostSummary = ({
             <h1 className="display-name">
               {deviceUser
                 ? "My device"
-                : titleData.display_name || DEFAULT_EMPTY_CELL_VALUE}
+                : summaryData.display_name || DEFAULT_EMPTY_CELL_VALUE}
             </h1>
 
             {renderDeviceStatusTag()}

--- a/frontend/pages/hosts/details/cards/HostSummary/HostSummary.tsx
+++ b/frontend/pages/hosts/details/cards/HostSummary/HostSummary.tsx
@@ -104,7 +104,6 @@ interface IBootstrapPackageData {
 interface IHostSummaryProps {
   titleData: any; // TODO: create interfaces for this and use consistently across host pages and related helpers
   bootstrapPackageData?: IBootstrapPackageData;
-  diskEncryptionEnabled?: boolean;
   isPremiumTier?: boolean;
   isSandboxMode?: boolean;
   toggleOSSettingsModal?: () => void;
@@ -166,7 +165,6 @@ const getHostDiskEncryptionTooltipMessage = (
 const HostSummary = ({
   titleData,
   bootstrapPackageData,
-  diskEncryptionEnabled,
   isPremiumTier,
   isSandboxMode = false,
   toggleOSSettingsModal,
@@ -180,7 +178,11 @@ const HostSummary = ({
   osSettings,
   hostMdmDeviceStatus,
 }: IHostSummaryProps): JSX.Element => {
-  const { status, platform } = titleData;
+  const {
+    status,
+    platform,
+    disk_encryption_enabled: diskEncryptionEnabled,
+  } = titleData;
 
   const renderRefetch = () => {
     const isOnline = titleData.status === "online";

--- a/frontend/utilities/constants.tsx
+++ b/frontend/utilities/constants.tsx
@@ -323,11 +323,8 @@ export const HOST_TITLE_DATA = [
   "gigs_disk_space_available",
   "team_name",
   "disk_encryption_enabled",
+  "display_name", // Not rendered on my device page
 ];
-
-export const HOST_TITLE_DATA_DEVICE_ONLY = ["platform", "mdm"];
-
-export const HOST_TITLE_DATA_HDP_ONLY = ["display_name"];
 
 export const HOST_ABOUT_DATA = [
   "seen_time",

--- a/frontend/utilities/constants.tsx
+++ b/frontend/utilities/constants.tsx
@@ -307,3 +307,40 @@ export const EMPTY_AGENT_OPTIONS = {
 export const DEFAULT_EMPTY_CELL_VALUE = "---";
 
 export const DOCUMENT_TITLE_SUFFIX = "Fleet";
+
+export const HOST_TITLE_DATA = [
+  "id",
+  "status",
+  "issues",
+  "memory",
+  "cpu_type",
+  "platform",
+  "os_version",
+  "osquery_version",
+  "enroll_secret_name",
+  "detail_updated_at",
+  "percent_disk_space_available",
+  "gigs_disk_space_available",
+  "team_name",
+  "display_name",
+];
+
+export const HOST_ABOUT_DATA = [
+  "seen_time",
+  "uptime",
+  "last_enrolled_at",
+  "hardware_model",
+  "hardware_serial",
+  "primary_ip",
+  "public_ip",
+  "geolocation",
+  "batteries",
+  "detail_updated_at",
+  "last_restarted_at",
+];
+
+export const HOST_OSQUERY_DATA = [
+  "config_tls_refresh",
+  "logger_tls_period",
+  "distributed_interval",
+];

--- a/frontend/utilities/constants.tsx
+++ b/frontend/utilities/constants.tsx
@@ -308,7 +308,7 @@ export const DEFAULT_EMPTY_CELL_VALUE = "---";
 
 export const DOCUMENT_TITLE_SUFFIX = "Fleet";
 
-export const HOST_TITLE_DATA = [
+export const HOST_SUMMARY_DATA = [
   "id",
   "status",
   "issues",

--- a/frontend/utilities/constants.tsx
+++ b/frontend/utilities/constants.tsx
@@ -322,8 +322,12 @@ export const HOST_TITLE_DATA = [
   "percent_disk_space_available",
   "gigs_disk_space_available",
   "team_name",
-  "display_name",
+  "disk_encryption_enabled",
 ];
+
+export const HOST_TITLE_DATA_DEVICE_ONLY = ["platform", "mdm"];
+
+export const HOST_TITLE_DATA_HDP_ONLY = ["display_name"];
 
 export const HOST_ABOUT_DATA = [
   "seen_time",


### PR DESCRIPTION
## Issue
Cerra #16681

## Description
- Found problem: `last_restarted_at` was not being passed into the my device page about section
- Solution: Use reusable constants to pass in correct data to each section on both host details page and my device page

## Screenrecording of fix
https://www.loom.com/share/17726bbf5f2e4931bf02578ddc5de63e?sid=0880f5bd-77a1-49ba-9d7b-e963837a78c5

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
- [x] Manual QA for all new/changed functionality
