### PR TITLE
make os updates take up full width of the viewport

### DIFF
--- a/frontend/pages/ManageControlsPage/OSUpdates/_styles.scss
+++ b/frontend/pages/ManageControlsPage/OSUpdates/_styles.scss
@@ -7,7 +7,6 @@
 
   &__content {
     display: grid;
-    max-width: $break-xxl;
     gap: $pad-xxlarge;
     margin: 0 auto;
 


### PR DESCRIPTION
relates to #16763

makes os updates page take up the full width of the viewport

- [ ] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [x] Manual QA for all new/changed functionality