### PR TITLE
render the windows disk encryption error details message as a plain text

### DIFF
--- a/frontend/pages/hosts/details/OSSettingsModal/OSSettingsTable/OSSettingsTableConfig.tsx
+++ b/frontend/pages/hosts/details/OSSettingsModal/OSSettingsTable/OSSettingsTableConfig.tsx
@@ -63,6 +63,15 @@ const generateFormattedTooltip = (detail: string) => {
   const keyValuePairs = detail.split(/, */);
   const formattedElements: JSX.Element[] = [];
 
+  // Special case to handle bitlocker error message. It does not follow the
+  // expected string format so we will just render the error message as is.
+  if (
+    detail.includes("BitLocker") ||
+    detail.includes("preparing volume for encryption")
+  ) {
+    return detail;
+  }
+
   keyValuePairs.forEach((pair, i) => {
     const [key, value] = pair.split(/: */);
     if (key && value) {


### PR DESCRIPTION
relates to #16417

renders the Windows host disk encryption error messages as standard text. These messages do not follow the expected format (e.g. `/foo/bar/baz: status 200`), so we will just render them as standard text.

![image](https://github.com/fleetdm/fleet/assets/1153709/7ed1ce39-56b0-4be2-885a-3e73af31fc9f)

- [x] Manual QA for all new/changed functionality