### PR TITLE
Reduce orbit logging when the server is down

### DIFF
--- a/cmd/osquery-perf/agent.go
+++ b/cmd/osquery-perf/agent.go
@@ -629,6 +629,7 @@ func (a *agent) runOrbitLoop() {
 			HardwareSerial: a.SerialNumber,
 			Hostname:       a.CachedString("hostname"),
 		},
+		nil,
 	)
 	if err != nil {
 		log.Println("creating orbit client: ", err)

--- a/orbit/changes/16423-reduce-orbit-logging
+++ b/orbit/changes/16423-reduce-orbit-logging
@@ -1,0 +1,1 @@
+* Reduce error logs when orbit cannot connect to Fleet.

--- a/orbit/cmd/orbit/orbit.go
+++ b/orbit/cmd/orbit/orbit.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
+	"net"
 	"net/url"
 	"os"
 	"os/exec"
@@ -782,7 +783,7 @@ func main() {
 			enrollSecret,
 			fleetClientCertificate,
 			orbitHostInfo,
-			func(err error) {
+			func(err net.Error) {
 				log.Info().Err(err).Msg("network error")
 			},
 		)
@@ -1057,7 +1058,7 @@ func main() {
 			enrollSecret,
 			fleetClientCertificate,
 			orbitHostInfo,
-			func(err error) {
+			func(err net.Error) {
 				log.Info().Err(err).Msg("network error")
 			},
 		)

--- a/orbit/pkg/logging/logging.go
+++ b/orbit/pkg/logging/logging.go
@@ -3,13 +3,24 @@ package logging
 import (
 	"os"
 
+	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 )
 
-// LogErrIfEnvNotSet logs if the environment variable is not set to "1".
+// LogErrIfEnvNotSet logs an info error if the environment variable is not set to "1".
 func LogErrIfEnvNotSet(envVarName string, err error, message string) {
+	LogErrIfEnvNotSetWithEvent(envVarName, err, message, log.Info())
+}
+
+// LogErrIfEnvNotSetDebug logs a debug error if the environment variable is not set to "1".
+func LogErrIfEnvNotSetDebug(envVarName string, err error, message string) {
+	LogErrIfEnvNotSetWithEvent(envVarName, err, message, log.Debug())
+}
+
+// LogErrIfEnvNotSetWithEvent logs if the environment variable is not set to "1".
+func LogErrIfEnvNotSetWithEvent(envVarName string, err error, message string, event *zerolog.Event) {
 	actualValue := os.Getenv(envVarName)
 	if actualValue != "1" {
-		log.Info().Err(err).Msg(message)
+		event.Err(err).Msg(message)
 	}
 }

--- a/orbit/pkg/update/disk_encryption.go
+++ b/orbit/pkg/update/disk_encryption.go
@@ -22,7 +22,7 @@ func ApplyDiskEncryptionRunnerMiddleware(f OrbitConfigFetcher) *DiskEncryptionRu
 func (d *DiskEncryptionRunner) GetConfig() (*fleet.OrbitConfig, error) {
 	cfg, err := d.fetcher.GetConfig()
 	if err != nil {
-		log.Info().Err(err).Msg("calling GetConfig from DiskEncryptionFetcher")
+		log.Debug().Err(err).Msg("calling GetConfig from DiskEncryptionFetcher")
 		return nil, err
 	}
 

--- a/orbit/pkg/update/nudge.go
+++ b/orbit/pkg/update/nudge.go
@@ -69,7 +69,7 @@ func (n *NudgeConfigFetcher) GetConfig() (*fleet.OrbitConfig, error) {
 	log.Debug().Msg("running nudge config fetcher middleware")
 	cfg, err := n.Fetcher.GetConfig()
 	if err != nil {
-		log.Info().Err(err).Msg("calling GetConfig from NudgeConfigFetcher")
+		log.Debug().Err(err).Msg("calling GetConfig from NudgeConfigFetcher")
 		return nil, err
 	}
 

--- a/server/service/orbit_client.go
+++ b/server/service/orbit_client.go
@@ -146,7 +146,7 @@ func (oc *OrbitClient) GetConfig() (*fleet.OrbitConfig, error) {
 		)
 		verb, path := "POST", "/api/fleet/orbit/config"
 		// Retry until we don't get a network error.
-		retry.Do(func() error {
+		_ = retry.Do(func() error {
 			err = oc.authenticatedRequest(verb, path, &orbitGetConfigRequest{}, &resp)
 			var netErr net.Error
 			if errors.As(err, &netErr) {


### PR DESCRIPTION
Orbit changes for #16423. 
Should also fix #16326 (in case of network errors).

Orbit will log the following every 5 minutes:
```
2024-02-20T14:27:40-03:00 INF network error error="Post \"https://localhost:8080/api/fleet/orbit/config\": dial tcp [::1]:8080: connect: connection refused"
```

- [X] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [x] Manual QA for all new/changed functionality
  - For Orbit and Fleet Desktop changes:
    - [x] Manual QA must be performed in the three main OSs, macOS, Windows and Linux.
    - [x] Auto-update manual QA, from released version of component to new version (see [tools/tuf/test](../tools/tuf/test/README.md)).
