### PR TITLE
UI – Fix alignment of empty states on 2 Software details pages

### DIFF
--- a/changes/16942-empty-swversion-swos-details-tables
+++ b/changes/16942-empty-swversion-swos-details-tables
@@ -1,0 +1,2 @@
+* Fix alignment bugs on the Software > OS > details and Software > Versions > details empty table
+states.

--- a/frontend/pages/SoftwarePage/components/SoftwareVulnerabilitiesTable/SoftwareVulnerabilitiesTable.tsx
+++ b/frontend/pages/SoftwarePage/components/SoftwareVulnerabilitiesTable/SoftwareVulnerabilitiesTable.tsx
@@ -63,14 +63,15 @@ const SoftwareVulnerabilitiesTable = ({
         columnConfigs={tableHeaders}
         data={data}
         defaultSortHeader={isPremiumTier ? "epss_probability" : "cve"}
-        defaultSortDirection={"desc"}
+        defaultSortDirection="desc"
         emptyComponent={() => <NoVulnsDetected itemName={itemName} />}
         isAllPagesSelected={false}
         isLoading={isLoading}
         isClientSidePagination
         pageSize={20}
-        resultsTitle={"vulnerabilities"}
+        resultsTitle="vulnerabilities"
         showMarkAllPages={false}
+        disableTableHeader={data.length === 0}
       />
     </div>
   );

--- a/frontend/pages/SoftwarePage/components/SoftwareVulnerabilitiesTable/_styles.scss
+++ b/frontend/pages/SoftwarePage/components/SoftwareVulnerabilitiesTable/_styles.scss
@@ -1,10 +1,13 @@
 .software-vulnerabilities-table {
-
   // keeps table data within the table container at smaller screen sizes
   .data-table {
     &__wrapper {
       overflow-x: auto;
     }
+  }
+
+  .empty-table__container {
+    margin: 1.5rem auto;
   }
 
   // used to position header text with premium icon correctly


### PR DESCRIPTION
## Addresses #16942 
- Disable header on empty table
- make vertical margin even
- also addresses same issue on Software version details tables
<img width="1912" alt="Screenshot 2024-02-19 at 1 56 34 PM" src="https://github.com/fleetdm/fleet/assets/61553566/8605a7a8-5538-407e-94ba-6e3ee33aefa5">

- [x] Changes file added for user-visible changes in `changes/`
- [x] Manual QA for all new/changed functionality