### PR TITLE
Add docs on how to rebuild osquery-perf for load testing

### DIFF
--- a/infrastructure/loadtesting/terraform/readme.md
+++ b/infrastructure/loadtesting/terraform/readme.md
@@ -111,6 +111,22 @@ docker images | grep 'BRANCH_NAME' | awk '{print $3}'
 terraform apply -var tag=BRANCH_NAME -var loadtest_containers=XXX -target=aws_ecs_service.fleet -target=aws_ecs_task_definition.backend -target=aws_ecs_task_definition.migration -target=aws_s3_bucket_acl.osquery-results -target=aws_s3_bucket_acl.osquery-status -target=docker_registry_image.fleet
 ```
 
+### Deploying code changes to osquery-perf
+
+Following are the steps to deploy new code changes to osquery-perf (known as `loadtest` image in ECS) on a running loadtest environment.
+
+> osquery-perf simulator in ECS doesn't keep state so you cannot change existing hosts to use new osquery-perf code.
+> The following is to add new hosts with new/modified osquery-perf code. (This happens if during a load test
+> the developer realizes there's bug in osquery-perf or if it's not simulating osquery properly.)
+
+> You don't need to push code changes because the `loadtest` image is built locally from your fleet repository source code.
+
+1. Bring all `loadtest` containers to `0` by running terraform apply with `loadtest_containers=0`.
+1. Delete all existing hosts (by selecting all on the UI).
+1. Delete all your local `loadtest` images, the image tags are of the form: `loadtest-$BRANCH_NAME-$TAG`.
+1. Log in to Amazon ECR (Elastic Container Registry) and delete the corresponding `loadtest` image.
+1. By executing the `terraform apply` with `-loadtest_containers=N` it will trigger a rebuild of the `loadtest` image.
+
 ### Troubleshooting
 
 #### Using a release tag instead of a branch


### PR DESCRIPTION
I had to run these steps for #16423. (To reduce memory footprint of osquery-perf.)