### PR TITLE
UI – Apply missing truncation and overflow styles to SW OS table

### DIFF
--- a/changes/16941-sw-os-table-overflows
+++ b/changes/16941-sw-os-table-overflows
@@ -1,0 +1,1 @@
+- Fix a bug where long OS names caused the table to render outside its bounds with smaller viewports

--- a/frontend/pages/SoftwarePage/SoftwareOS/SoftwareOSTable/_styles.scss
+++ b/frontend/pages/SoftwarePage/SoftwareOS/SoftwareOSTable/_styles.scss
@@ -25,12 +25,31 @@
   .table-container {
     &__data-table-block {
       .data-table-block {
-        .data-table__table {
-          tbody {
-            .link-cell {
-              display: flex;
-              align-items: center;
-              gap: $pad-small;
+        .data-table {
+          &__wrapper {
+            overflow-x: auto;
+          }
+          &__table {
+            tbody {
+              .name_only__cell {
+                max-width: $col-md;
+
+                // Tooltip does not get cut off
+                .children-wrapper {
+                  overflow: initial;
+                }
+
+                // ellipsis for software name
+                .software-name {
+                  overflow: hidden;
+                  text-overflow: ellipsis;
+                }
+              }
+              .link-cell {
+                display: flex;
+                align-items: center;
+                gap: $pad-small;
+              }
             }
           }
         }


### PR DESCRIPTION
## –> #16941 

<img width="968" alt="Screenshot 2024-02-19 at 2 20 12 PM" src="https://github.com/fleetdm/fleet/assets/61553566/461d7eab-57ac-45e9-aa36-1310118caacd">


- [x] Changes file added for user-visible changes in `changes/` 
- [x] Manual QA