### PR TITLE
Re-deploy profiles is cross-platform

### DIFF
--- a/handbook/company/pricing-features-table.yml
+++ b/handbook/company/pricing-features-table.yml
@@ -533,7 +533,7 @@
       moreInfoUrl: https://github.com/fleetdm/fleet/issues/14550
     - description: Target profiles to specific hosts using SQL.
       moreInfoUrl: https://github.com/fleetdm/fleet/issues/14715
-    - description: Automatically re-deploy configuration profiles on macOS they're not installed.
+    - description: Automatically re-deploy configuration profiles when they're not installed.
   productCategories: [Device management]
   pricingTableCategories: [Device management]
 - industryName: Self service


### PR DESCRIPTION
- Fleet double checks and re-deploys profiles (1 retry) if the profile fails to install on macOS and Windows ...
