### PR TITLE
UI – Uncover the "Done" button on Add hosts > advanced > plain osquery

### DIFF
--- a/changes/16998-covered-done-button
+++ b/changes/16998-covered-done-button
@@ -1,0 +1,1 @@
+- Fix a bug where the "Done" button on the add hosts modal for plain osquery could be covered.

--- a/frontend/components/AddHostsModal/PlatformWrapper/_styles.scss
+++ b/frontend/components/AddHostsModal/PlatformWrapper/_styles.scss
@@ -2,9 +2,14 @@
 
 .platform-wrapper {
   padding: 0; // different to pad sticky subnav properly
-  .react-tabs {
-    &__tab-list {
-      margin: 0 0 1.25rem;
+
+  .component__tabs-wrapper {
+    // negate problematic sticky positioning
+    position: initial;
+    .react-tabs {
+      &__tab-list {
+        margin: 0 0 1.25rem;
+      }
     }
   }
 


### PR DESCRIPTION
## –> #16998 
<img width="966" alt="Screenshot 2024-02-20 at 11 23 20 AM" src="https://github.com/fleetdm/fleet/assets/61553566/2d15afe2-acfa-4e50-9877-eace26cbb3e2">


- [x] Changes file added for user-visible changes in `changes/`
- [x] Manual QA for all new/changed functionality