### PR TITLE
Upload only orbit executable to ease future automation and reduce size of artifacts

### DIFF
--- a/.github/workflows/goreleaser-orbit.yaml
+++ b/.github/workflows/goreleaser-orbit.yaml
@@ -66,7 +66,7 @@ jobs:
         uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v2
         with:
           name: orbit-macos
-          path: dist
+          path: dist/orbit-macos_darwin_all/orbit
 
   goreleaser-linux:
     runs-on: ubuntu-20.04
@@ -94,7 +94,7 @@ jobs:
         uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v2
         with:
           name: orbit-linux
-          path: dist
+          path: dist/orbit_linux_amd64_v1/orbit
 
   goreleaser-windows:
     runs-on: windows-2022
@@ -122,4 +122,4 @@ jobs:
         uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v2
         with:
           name: orbit-windows
-          path: dist
+          path: dist/orbit_windows_amd64_v1/orbit.exe


### PR DESCRIPTION
Reasons:
- Smaller artifacts on https://github.com/fleetdm/fleet/actions/workflows/goreleaser-orbit.yaml (used when releasing fleetd).
- Less error prone (human performing the release has to be careful to not pick the macOS amd64 or arm64 version of orbit, and pick the universal one)
- Moves a small step forward to #16131