### PR TITLE
[GCP] Fixed typo in terraform instructions - readme.md

### DIFF
--- a/infrastructure/dogfood/terraform/gcp/readme.md
+++ b/infrastructure/dogfood/terraform/gcp/readme.md
@@ -11,8 +11,7 @@ dns_name   = "<the domain you want to host fleet at>" // eg. myfleet.fleetdm.com
 
 #### Fleet server
 The fleet webserver is running as [Google Cloud Run](https://cloud.google.com/run) containers, this is very similar to how the existing terraform for AWS runs fleet as Fargate compute.
-_NOTE: Cloud Run has [limitations](https://cloud.google.com/run/docs/deploying#images) on what container images it will run_. In our deployment we create
-and Artifact Registry and deploy the public fleet container image into Artifact Registry.
+_NOTE: Cloud Run has [limitations](https://cloud.google.com/run/docs/deploying#images) on what container images it will run_. In our deployment we create and deploy the public fleet container image into Artifact Registry.
 
 #### MySQL
 We are running MySQL using [Google Cloud SQL](https://cloud.google.com/sql/docs/mysql/introduction) only reachable via [CloudSQLProxy](https://cloud.google.com/sql/docs/mysql/connect-admin-proxy) and from Cloud Run


### PR DESCRIPTION
Fixed typo in GCP's terraform instructions.