### PR TITLE
Fleet UI: Rename team modal aptly named rename team

### DIFF
--- a/changes/15968-rename-team
+++ b/changes/15968-rename-team
@@ -1,0 +1,1 @@
+- UI Edit team more properly labeled as rename team

--- a/frontend/pages/admin/IntegrationsPage/cards/AutomaticEnrollment/components/RenameTeamModal/RenameTeamModal.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/AutomaticEnrollment/components/RenameTeamModal/RenameTeamModal.tsx
@@ -1,0 +1,86 @@
+import React, { useState, useContext, FormEvent } from "react";
+
+import { AppContext } from "context/app";
+import {
+  APP_CONTEXT_NO_TEAM_ID,
+  APP_CONTEX_NO_TEAM_SUMMARY,
+} from "interfaces/team";
+import configAPI from "services/entities/config";
+
+// @ts-ignore
+import Dropdown from "components/forms/fields/Dropdown";
+import Modal from "components/Modal";
+import Button from "components/buttons/Button";
+
+interface IRenameTeamModal {
+  onCancel: () => void;
+  defaultTeamName: string;
+  onUpdateSuccess: (newName: string) => void;
+}
+
+const baseClass = "edit-team-modal";
+
+const RenameTeamModal = ({
+  onCancel,
+  defaultTeamName,
+  onUpdateSuccess,
+}: IRenameTeamModal): JSX.Element => {
+  const { availableTeams } = useContext(AppContext);
+
+  const [selectedTeam, setSelectedTeam] = useState(defaultTeamName);
+
+  const teamNameOptions = availableTeams
+    ?.filter((t) => t.id >= APP_CONTEXT_NO_TEAM_ID)
+    .map((teamSummary) => {
+      return {
+        value:
+          teamSummary.name === APP_CONTEX_NO_TEAM_SUMMARY.name
+            ? ""
+            : teamSummary.name,
+        label: teamSummary.name,
+      };
+    });
+
+  const [isLoading, setIsLoading] = useState(false);
+
+  const onFormSubmit = async (event: FormEvent) => {
+    event.preventDefault();
+    try {
+      setIsLoading(true);
+      const configData = await configAPI.update({
+        mdm: { apple_bm_default_team: selectedTeam },
+      });
+      setIsLoading(false);
+      onUpdateSuccess(configData.mdm.apple_bm_default_team);
+    } finally {
+      onCancel();
+    }
+  };
+
+  return (
+    <Modal title="Rename team" onExit={onCancel} className={baseClass}>
+      <form className={`${baseClass}__form`} onSubmit={onFormSubmit}>
+        <div className="bottom-label">
+          <Dropdown
+            placeholder={selectedTeam}
+            options={teamNameOptions}
+            onChange={setSelectedTeam}
+            value={selectedTeam}
+            label="Team"
+            helpText="macOS hosts will be added to this team when they're first unboxed."
+          />
+        </div>
+        <div className="modal-cta-wrap">
+          <Button type="submit" variant="brand" isLoading={isLoading}>
+            Save
+          </Button>
+          <Button onClick={onCancel} variant="inverse">
+            Cancel
+          </Button>
+        </div>
+      </form>
+    </Modal>
+  );
+};
+
+export default RenameTeamModal;

--- a/frontend/pages/admin/IntegrationsPage/cards/AutomaticEnrollment/components/RenameTeamModal/index.ts
+++ b/frontend/pages/admin/IntegrationsPage/cards/AutomaticEnrollment/components/RenameTeamModal/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./RenameTeamModal";

--- a/frontend/pages/admin/TeamManagementPage/TeamDetailsWrapper/TeamDetailsWrapper.tsx
+++ b/frontend/pages/admin/TeamManagementPage/TeamDetailsWrapper/TeamDetailsWrapper.tsx
@@ -29,7 +29,7 @@ import BackLink from "components/BackLink";
 import TeamsDropdown from "components/TeamsDropdown";
 import MainContent from "components/MainContent";
 import DeleteTeamModal from "../components/DeleteTeamModal";
-import EditTeamModal from "../components/EditTeamModal";
+import RenameTeamModal from "../components/RenameTeamModal";
 import DeleteSecretModal from "../../../../components/EnrollSecrets/DeleteSecretModal";
 import SecretEditorModal from "../../../../components/EnrollSecrets/SecretEditorModal";
 import AddHostsModal from "../../../../components/AddHostsModal";
@@ -131,7 +131,7 @@ const TeamDetailsWrapper = ({
   const [showEnrollSecretModal, setShowEnrollSecretModal] = useState(false);
   const [showSecretEditorModal, setShowSecretEditorModal] = useState(false);
   const [showDeleteTeamModal, setShowDeleteTeamModal] = useState(false);
-  const [showEditTeamModal, setShowEditTeamModal] = useState(false);
+  const [showRenameTeamModal, setShowRenameTeamModal] = useState(false);
   const [backendValidators, setBackendValidators] = useState<{
     [key: string]: string;
   }>({});
@@ -224,10 +224,10 @@ const TeamDetailsWrapper = ({
     setShowDeleteTeamModal(!showDeleteTeamModal);
   }, [showDeleteTeamModal, setShowDeleteTeamModal]);
 
-  const toggleEditTeamModal = useCallback(() => {
-    setShowEditTeamModal(!showEditTeamModal);
+  const toggleRenameTeamModal = useCallback(() => {
+    setShowRenameTeamModal(!showRenameTeamModal);
     setBackendValidators({});
-  }, [showEditTeamModal, setShowEditTeamModal, setBackendValidators]);
+  }, [showRenameTeamModal, setShowRenameTeamModal, setBackendValidators]);
 
   const onSaveSecret = async (enrollSecretString: string) => {
     // Creates new list of secrets removing selected secret and adding new secret
@@ -316,7 +316,7 @@ const TeamDetailsWrapper = ({
       const updatedAttrs = generateUpdateData(currentTeamDetails, formData);
       // no updates, so no need for a request.
       if (!updatedAttrs) {
-        toggleEditTeamModal();
+        toggleRenameTeamModal();
         return;
       }
 
@@ -341,13 +341,13 @@ const TeamDetailsWrapper = ({
           renderFlash("error", "Could not create team. Please try again.");
         }
       } finally {
-        toggleEditTeamModal();
+        toggleRenameTeamModal();
         setIsUpdatingTeams(false);
       }
     },
     [
       currentTeamDetails,
-      toggleEditTeamModal,
+      toggleRenameTeamModal,
       teamIdForApi,
       renderFlash,
       refetchTeams,
@@ -423,10 +423,10 @@ const TeamDetailsWrapper = ({
                 },
                 {
                   type: "secondary",
-                  label: "Edit team",
+                  label: "Rename team",
                   buttonVariant: "text-icon",
                   iconSvg: "pencil",
-                  onClick: toggleEditTeamModal,
+                  onClick: toggleRenameTeamModal,
                 },
                 {
                   type: "secondary",
@@ -511,9 +511,9 @@ const TeamDetailsWrapper = ({
             isUpdatingTeams={isUpdatingTeams}
           />
         )}
-        {showEditTeamModal && (
-          <EditTeamModal
-            onCancel={toggleEditTeamModal}
+        {showRenameTeamModal && (
+          <RenameTeamModal
+            onCancel={toggleRenameTeamModal}
             onSubmit={onEditSubmit}
             defaultName={currentTeamDetails.name}
             backendValidators={backendValidators}

--- a/frontend/pages/admin/TeamManagementPage/TeamManagementPage.tsx
+++ b/frontend/pages/admin/TeamManagementPage/TeamManagementPage.tsx
@@ -19,7 +19,7 @@ import SandboxMessage from "components/Sandbox/SandboxMessage";
 
 import CreateTeamModal from "./components/CreateTeamModal";
 import DeleteTeamModal from "./components/DeleteTeamModal";
-import EditTeamModal from "./components/EditTeamModal";
+import RenameTeamModal from "./components/RenameTeamModal";
 import EmptyTeamsTable from "./components/EmptyTeamsTable";
 
 import { generateTableHeaders, generateDataSet } from "./TeamTableConfig";
@@ -38,7 +38,7 @@ const TeamManagementPage = (): JSX.Element => {
   const [isUpdatingTeams, setIsUpdatingTeams] = useState(false);
   const [showCreateTeamModal, setShowCreateTeamModal] = useState(false);
   const [showDeleteTeamModal, setShowDeleteTeamModal] = useState(false);
-  const [showEditTeamModal, setShowEditTeamModal] = useState(false);
+  const [showRenameTeamModal, setShowRenameTeamModal] = useState(false);
   const [teamEditing, setTeamEditing] = useState<ITeam>();
   const [backendValidators, setBackendValidators] = useState<{
     [key: string]: string;
@@ -84,15 +84,15 @@ const TeamManagementPage = (): JSX.Element => {
     [showDeleteTeamModal, setShowDeleteTeamModal, setTeamEditing]
   );
 
-  const toggleEditTeamModal = useCallback(
+  const toggleRenameTeamModal = useCallback(
     (team?: ITeam) => {
-      setShowEditTeamModal(!showEditTeamModal);
+      setShowRenameTeamModal(!showRenameTeamModal);
       setBackendValidators({});
       team ? setTeamEditing(team) : setTeamEditing(undefined);
     },
     [
-      showEditTeamModal,
-      setShowEditTeamModal,
+      showRenameTeamModal,
+      setShowRenameTeamModal,
       setTeamEditing,
       setBackendValidators,
     ]
@@ -161,10 +161,10 @@ const TeamManagementPage = (): JSX.Element => {
     toggleDeleteTeamModal,
   ]);
 
-  const onEditSubmit = useCallback(
+  const onRenameSubmit = useCallback(
     (formData: ITeamFormData) => {
       if (formData.name === teamEditing?.name) {
-        toggleEditTeamModal();
+        toggleRenameTeamModal();
       } else if (teamEditing) {
         setIsUpdatingTeams(true);
         teamsAPI
@@ -175,7 +175,7 @@ const TeamManagementPage = (): JSX.Element => {
               `Successfully updated team name to ${formData.name}.`
             );
             setBackendValidators({});
-            toggleEditTeamModal();
+            toggleRenameTeamModal();
             refetchTeams();
           })
           .catch((updateError: { data: IApiError }) => {
@@ -187,7 +187,7 @@ const TeamManagementPage = (): JSX.Element => {
             } else {
               renderFlash(
                 "error",
-                `Could not edit ${teamEditing.name}. Please try again.`
+                `Could not rename ${teamEditing.name}. Please try again.`
               );
             }
           })
@@ -196,14 +196,14 @@ const TeamManagementPage = (): JSX.Element => {
           });
       }
     },
-    [teamEditing, toggleEditTeamModal, refetchTeams, renderFlash]
+    [teamEditing, toggleRenameTeamModal, refetchTeams, renderFlash]
   );
 
   const onActionSelection = useCallback(
     (action: string, team: ITeam): void => {
       switch (action) {
-        case "edit":
-          toggleEditTeamModal(team);
+        case "rename":
+          toggleRenameTeamModal(team);
           break;
         case "delete":
           toggleDeleteTeamModal(team);
@@ -211,7 +211,7 @@ const TeamManagementPage = (): JSX.Element => {
         default:
       }
     },
-    [toggleEditTeamModal, toggleDeleteTeamModal]
+    [toggleRenameTeamModal, toggleDeleteTeamModal]
   );
 
   const tableHeaders = useMemo(() => generateTableHeaders(onActionSelection), [
@@ -280,10 +280,10 @@ const TeamManagementPage = (): JSX.Element => {
             isUpdatingTeams={isUpdatingTeams}
           />
         )}
-        {showEditTeamModal && (
-          <EditTeamModal
-            onCancel={toggleEditTeamModal}
-            onSubmit={onEditSubmit}
+        {showRenameTeamModal && (
+          <RenameTeamModal
+            onCancel={toggleRenameTeamModal}
+            onSubmit={onRenameSubmit}
             defaultName={teamEditing?.name || ""}
             backendValidators={backendValidators}
             isUpdatingTeams={isUpdatingTeams}

--- a/frontend/pages/admin/TeamManagementPage/TeamTableConfig.tsx
+++ b/frontend/pages/admin/TeamManagementPage/TeamTableConfig.tsx
@@ -107,9 +107,9 @@ const generateTableHeaders = (
 const generateActionDropdownOptions = (): IDropdownOption[] => {
   return [
     {
-      label: "Edit",
+      label: "Rename",
       disabled: false,
-      value: "edit",
+      value: "rename",
     },
     {
       label: "Delete",

--- a/frontend/pages/admin/TeamManagementPage/components/EditTeamModal/index.ts
+++ b/frontend/pages/admin/TeamManagementPage/components/EditTeamModal/index.ts
@@ -1,1 +1,0 @@
-export { default } from "./EditTeamModal";

--- a/frontend/pages/admin/TeamManagementPage/components/RenameTeamModal/RenameTeamModal.tsx
+++ b/frontend/pages/admin/TeamManagementPage/components/RenameTeamModal/RenameTeamModal.tsx
@@ -9,7 +9,7 @@ import Button from "components/buttons/Button";
 
 const baseClass = "edit-team-modal";
 
-interface IEditTeamModalProps {
+interface IRenameTeamModalProps {
   onCancel: () => void;
   onSubmit: (formData: ITeamFormData) => void;
   defaultName: string;
@@ -17,13 +17,13 @@ interface IEditTeamModalProps {
   isUpdatingTeams: boolean;
 }
 
-const EditTeamModal = ({
+const RenameTeamModal = ({
   onCancel,
   onSubmit,
   defaultName,
   backendValidators,
   isUpdatingTeams,
-}: IEditTeamModalProps): JSX.Element => {
+}: IRenameTeamModalProps): JSX.Element => {
   const [name, setName] = useState(defaultName);
   const [errors, setErrors] = useState<{ [key: string]: string }>(
     backendValidators
@@ -47,7 +47,7 @@ const EditTeamModal = ({
   };
 
   return (
-    <Modal title={"Edit team"} onExit={onCancel} className={baseClass}>
+    <Modal title={"Rename team"} onExit={onCancel} className={baseClass}>
       <form
         className={`${baseClass}__form`}
         onSubmit={onFormSubmit}
@@ -82,4 +82,4 @@ const EditTeamModal = ({
   );
 };
 
-export default EditTeamModal;
+export default RenameTeamModal;

--- a/frontend/pages/admin/TeamManagementPage/components/RenameTeamModal/index.ts
+++ b/frontend/pages/admin/TeamManagementPage/components/RenameTeamModal/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./RenameTeamModal";


### PR DESCRIPTION
## Issue
Cerra #15968 

## Description
- Change edit team modal name to rename team modal name everywhere in the UI

## Screen recording
https://www.loom.com/share/e4c72ce067494c9799f89b44dc678a6e?sid=f102f625-b406-4fb6-adcf-1503adebf118

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
- [x] Manual QA for all new/changed functionality

