### PR TITLE
[Released bug] Fleet UI: Update policy count on deletion of policies

### DIFF
--- a/changes/17029-update-policy-count
+++ b/changes/17029-update-policy-count
@@ -1,0 +1,1 @@
+- Deleting a policy updates the policy count

--- a/frontend/pages/policies/ManagePoliciesPage/ManagePoliciesPage.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/ManagePoliciesPage.tsx
@@ -249,6 +249,7 @@ const ManagePolicyPage = ({
     data: globalPoliciesCount,
 
     isFetching: isFetchingGlobalCount,
+    refetch: refetchGlobalPoliciesCount,
   } = useQuery<IPoliciesCountResponse, Error, number, IPoliciesCountQueryKey[]>(
     [
       {
@@ -303,7 +304,11 @@ const ManagePolicyPage = ({
     }
   );
 
-  const { data: teamPoliciesCount, isFetching: isFetchingTeamCount } = useQuery<
+  const {
+    data: teamPoliciesCount,
+    isFetching: isFetchingTeamCount,
+    refetch: refetchTeamPoliciesCount,
+  } = useQuery<
     IPoliciesCountResponse,
     Error,
     number,
@@ -364,8 +369,10 @@ const ManagePolicyPage = ({
   const refetchPolicies = (teamId?: number) => {
     if (teamId) {
       refetchTeamPolicies();
+      refetchTeamPoliciesCount();
     } else {
       refetchGlobalPolicies(); // Only call on global policies as this is expensive
+      refetchGlobalPoliciesCount();
     }
   };
 


### PR DESCRIPTION
## Issue
Cerra #17029

## Description
- Update policy count after deleting policies


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
- [x] Manual QA for all new/changed functionality
