### PR TITLE
Remote wipe: add API endpoint and activity

### DIFF
--- a/changes/10488-remote-wipe
+++ b/changes/10488-remote-wipe
@@ -1,0 +1,1 @@
+* Added the `POST /api/v1/fleet/hosts/:id/wipe` Fleet Premium API endpoint to support remote wiping a host.

--- a/cmd/fleetctl/get_test.go
+++ b/cmd/fleetctl/get_test.go
@@ -360,7 +360,7 @@ func TestGetHosts(t *testing.T) {
 		}, nil
 	}
 
-	ds.GetHostLockWipeStatusFunc = func(ctx context.Context, hostID uint, fleetPlatform string) (*fleet.HostLockWipeStatus, error) {
+	ds.GetHostLockWipeStatusFunc = func(ctx context.Context, host *fleet.Host) (*fleet.HostLockWipeStatus, error) {
 		return &fleet.HostLockWipeStatus{}, nil
 	}
 

--- a/cmd/fleetctl/mdm_test.go
+++ b/cmd/fleetctl/mdm_test.go
@@ -196,7 +196,7 @@ func TestMDMRunCommand(t *testing.T) {
 			ds.GetHostMDMMacOSSetupFunc = func(ctx context.Context, hostID uint) (*fleet.HostMDMMacOSSetup, error) {
 				return nil, nil
 			}
-			ds.GetHostLockWipeStatusFunc = func(ctx context.Context, hostID uint, fleetPlatform string) (*fleet.HostLockWipeStatus, error) {
+			ds.GetHostLockWipeStatusFunc = func(ctx context.Context, host *fleet.Host) (*fleet.HostLockWipeStatus, error) {
 				return &fleet.HostLockWipeStatus{}, nil
 			}
 			ds.ListHostsLiteByUUIDsFunc = func(ctx context.Context, filter fleet.TeamFilter, uuids []string) ([]*fleet.Host, error) {
@@ -440,11 +440,13 @@ func TestMDMLockCommand(t *testing.T) {
 	ds.GetHostMDMMacOSSetupFunc = func(ctx context.Context, hostID uint) (*fleet.HostMDMMacOSSetup, error) {
 		return nil, nil
 	}
-	ds.GetHostLockWipeStatusFunc = func(ctx context.Context, hostID uint, fleetPlatform string) (*fleet.HostLockWipeStatus, error) {
+	ds.GetHostLockWipeStatusFunc = func(ctx context.Context, host *fleet.Host) (*fleet.HostLockWipeStatus, error) {
+		fleetPlatform := host.FleetPlatform()
+
 		var status fleet.HostLockWipeStatus
 		status.HostFleetPlatform = fleetPlatform
 
-		if _, ok := unlockPending[hostID]; ok {
+		if _, ok := unlockPending[host.ID]; ok {
 			if fleetPlatform == "darwin" {
 				status.UnlockPIN = "1234"
 				status.UnlockRequestedAt = time.Now()
@@ -454,7 +456,7 @@ func TestMDMLockCommand(t *testing.T) {
 			status.UnlockScript = &fleet.HostScriptResult{}
 		}
 
-		if _, ok := lockPending[hostID]; ok {
+		if _, ok := lockPending[host.ID]; ok {
 			if fleetPlatform == "darwin" {
 				status.LockMDMCommand = &fleet.MDMCommand{}
 				return &status, nil
@@ -710,10 +712,12 @@ func TestMDMUnlockCommand(t *testing.T) {
 	ds.GetHostMDMMacOSSetupFunc = func(ctx context.Context, hostID uint) (*fleet.HostMDMMacOSSetup, error) {
 		return nil, nil
 	}
-	ds.GetHostLockWipeStatusFunc = func(ctx context.Context, hostID uint, fleetPlatform string) (*fleet.HostLockWipeStatus, error) {
+	ds.GetHostLockWipeStatusFunc = func(ctx context.Context, host *fleet.Host) (*fleet.HostLockWipeStatus, error) {
+		fleetPlatform := host.FleetPlatform()
+
 		var status fleet.HostLockWipeStatus
 		status.HostFleetPlatform = fleetPlatform
-		if _, ok := locked[hostID]; ok {
+		if _, ok := locked[host.ID]; ok {
 			if fleetPlatform == "darwin" {
 				status.LockMDMCommand = &fleet.MDMCommand{}
 				status.LockMDMCommandResult = &fleet.MDMCommandResult{Status: fleet.MDMAppleStatusAcknowledged}
@@ -723,7 +727,7 @@ func TestMDMUnlockCommand(t *testing.T) {
 			status.LockScript = &fleet.HostScriptResult{ExitCode: ptr.Int64(0)}
 		}
 
-		if _, ok := unlockPending[hostID]; ok {
+		if _, ok := unlockPending[host.ID]; ok {
 			if fleetPlatform == "darwin" {
 				status.UnlockPIN = "1234"
 				status.UnlockRequestedAt = time.Now()
@@ -733,7 +737,7 @@ func TestMDMUnlockCommand(t *testing.T) {
 			status.UnlockScript = &fleet.HostScriptResult{}
 		}
 
-		if _, ok := lockPending[hostID]; ok {
+		if _, ok := lockPending[host.ID]; ok {
 			if fleetPlatform == "darwin" {
 				status.LockMDMCommand = &fleet.MDMCommand{}
 				return &status, nil

--- a/cmd/fleetctl/scripts_test.go
+++ b/cmd/fleetctl/scripts_test.go
@@ -240,7 +240,7 @@ Fleet records the last 10,000 characters to prevent downtime.
 			}
 			return &fleet.HostScriptResult{}, nil
 		}
-		ds.GetHostLockWipeStatusFunc = func(ctx context.Context, hostID uint, fleetPlatform string) (*fleet.HostLockWipeStatus, error) {
+		ds.GetHostLockWipeStatusFunc = func(ctx context.Context, host *fleet.Host) (*fleet.HostLockWipeStatus, error) {
 			return &fleet.HostLockWipeStatus{}, nil
 		}
 		ds.NewHostScriptExecutionRequestFunc = func(ctx context.Context, req *fleet.HostScriptRequestPayload) (*fleet.HostScriptResult, error) {

--- a/docs/Using Fleet/Audit-logs.md
+++ b/docs/Using Fleet/Audit-logs.md
@@ -1032,6 +1032,23 @@ This activity contains the following fields:
 }
 ```
 
+## wiped_host
+
+Generated when a user sends a request to wipe a host.
+
+This activity contains the following fields:
+- "host_id": ID of the host.
+- "host_display_name": Display name of the host.
+
+#### Example
+
+```json
+{
+  "host_id": 1,
+  "host_display_name": "Anna's MacBook Pro"
+}
+```
+
 
 <meta name="title" value="Audit logs">
 <meta name="pageOrderInSection" value="1400">

--- a/ee/server/service/embedded_scripts/linux_wipe.sh
+++ b/ee/server/service/embedded_scripts/linux_wipe.sh
@@ -1,0 +1,46 @@
+#!/bin/sh
+
+# Function to log out all users and lock their passwords except root
+logout_users() {
+    for user in $(who | awk '{print $1}' | sort | uniq)
+    do
+        if [ "$user" != "root" ]; then
+            echo "Logging out $user"
+            pkill -KILL -u "$user"
+            passwd -l "$user"
+        fi
+    done
+}
+
+# Function to wipe non-essential data
+wipe_non_essential_data() {
+    # Define non-essential paths
+    non_essential_paths="/home/* /tmp /var/tmp /var/log /home/*/.cache /var/cache /home/*/.local/share/Trash"
+
+    for path in $non_essential_paths
+    do
+        if [ -e "$path" ]; then
+            echo "Wiping $path"
+            rm -rf "$path"
+        fi
+    done
+}
+
+# Function to wipe system files - Warning: This will render the system inoperable
+wipe_system_files() {
+    # Define essential system paths
+    essential_system_paths="/bin /sbin /usr /lib"
+
+    for path in $essential_system_paths
+    do
+        echo "Wiping $path"
+        rm -rf "$path"
+    done
+}
+
+# Start the wiping process
+logout_users
+wipe_non_essential_data
+wipe_system_files
+
+echo "Wiping process completed."

--- a/ee/server/service/hosts.go
+++ b/ee/server/service/hosts.go
@@ -404,22 +404,8 @@ func (svc *Service) enqueueWipeHostRequest(ctx context.Context, host *fleet.Host
 	case "windows":
 		wipeCmdUUID := uuid.NewString()
 		wipeCmd := &fleet.MDMWindowsCommand{
-			CommandUUID: wipeCmdUUID,
-			RawCommand: []byte(fmt.Sprintf(`
-				<Exec>
-					<CmdID>%s</CmdID>
-					<Item>
-						<Target>
-							<LocURI>./Device/Vendor/MSFT/RemoteWipe/doWipeProtected</LocURI>
-						</Target>
-						<Meta>
-							<Format xmlns="syncml:metinf">chr</Format>
-							<Type>text/plain</Type>
-						</Meta>
-						<Data></Data>
-					</Item>
-				</Exec>
-		`, wipeCmdUUID)),
+			CommandUUID:  wipeCmdUUID,
+			RawCommand:   []byte(fmt.Sprintf(windowsWipeCommand, wipeCmdUUID)),
 			TargetLocURI: "./Device/Vendor/MSFT/RemoteWipe/doWipeProtected",
 		}
 		if err := svc.ds.WipeHostViaWindowsMDM(ctx, host, wipeCmd); err != nil {
@@ -472,4 +458,19 @@ var (
 	linuxUnlockScript []byte
 	//go:embed embedded_scripts/linux_wipe.sh
 	linuxWipeScript []byte
+
+	windowsWipeCommand = `
+		<Exec>
+			<CmdID>%s</CmdID>
+			<Item>
+				<Target>
+					<LocURI>./Device/Vendor/MSFT/RemoteWipe/doWipeProtected</LocURI>
+				</Target>
+				<Meta>
+					<Format xmlns="syncml:metinf">chr</Format>
+					<Type>text/plain</Type>
+				</Meta>
+				<Data></Data>
+			</Item>
+		</Exec>`
 )

--- a/ee/server/service/hosts.go
+++ b/ee/server/service/hosts.go
@@ -69,6 +69,9 @@ func (svc *Service) LockHost(ctx context.Context, hostID uint) error {
 		// on macOS, the lock command requires the host to be MDM-enrolled in Fleet
 		hostMDM, err := svc.ds.GetHostMDM(ctx, host.ID)
 		if err != nil {
+			if fleet.IsNotFound(err) {
+				return ctxerr.Wrap(ctx, fleet.NewInvalidArgumentError("host_id", "Can't lock the host because it doesn't have MDM turned on."))
+			}
 			return ctxerr.Wrap(ctx, err, "get host MDM information")
 		}
 		if !hostMDM.IsFleetEnrolled() {
@@ -250,6 +253,9 @@ func (svc *Service) WipeHost(ctx context.Context, hostID uint) error {
 		// the wipe command requires the host to be MDM-enrolled in Fleet
 		hostMDM, err := svc.ds.GetHostMDM(ctx, host.ID)
 		if err != nil {
+			if fleet.IsNotFound(err) {
+				return ctxerr.Wrap(ctx, fleet.NewInvalidArgumentError("host_id", "Can't wipe the host because it doesn't have MDM turned on."))
+			}
 			return ctxerr.Wrap(ctx, err, "get host MDM information")
 		}
 		if !hostMDM.IsFleetEnrolled() {

--- a/ee/server/service/hosts.go
+++ b/ee/server/service/hosts.go
@@ -396,11 +396,11 @@ func (svc *Service) enqueueWipeHostRequest(ctx context.Context, host *fleet.Host
 
 	switch wipeStatus.HostFleetPlatform {
 	case "darwin":
-		// TODO(mna): must update host_mdm_actions accordingly...
 		wipeCommandUUID := uuid.NewString()
-		if err := svc.mdmAppleCommander.EraseDevice(ctx, []string{host.UUID}, wipeCommandUUID); err != nil {
+		if err := svc.mdmAppleCommander.EraseDevice(ctx, host, wipeCommandUUID); err != nil {
 			return ctxerr.Wrap(ctx, err, "enqueuing wipe request for darwin")
 		}
+
 	case "windows":
 		panic("unimplemented")
 	case "linux":

--- a/ee/server/service/hosts.go
+++ b/ee/server/service/hosts.go
@@ -100,7 +100,7 @@ func (svc *Service) LockHost(ctx context.Context, hostID uint) error {
 
 	// if there's a lock, unlock or wipe action pending, do not accept the lock
 	// request.
-	lockWipe, err := svc.ds.GetHostLockWipeStatus(ctx, host.ID, host.FleetPlatform())
+	lockWipe, err := svc.ds.GetHostLockWipeStatus(ctx, host)
 	if err != nil {
 		return ctxerr.Wrap(ctx, err, "get host lock/wipe status")
 	}
@@ -166,7 +166,7 @@ func (svc *Service) UnlockHost(ctx context.Context, hostID uint) (string, error)
 		return "", ctxerr.Wrap(ctx, fleet.NewInvalidArgumentError("host_id", fmt.Sprintf("Unsupported host platform: %s", host.Platform)))
 	}
 
-	lockWipe, err := svc.ds.GetHostLockWipeStatus(ctx, host.ID, host.FleetPlatform())
+	lockWipe, err := svc.ds.GetHostLockWipeStatus(ctx, host)
 	if err != nil {
 		return "", ctxerr.Wrap(ctx, err, "get host lock/wipe status")
 	}
@@ -258,7 +258,7 @@ func (svc *Service) WipeHost(ctx context.Context, hostID uint) error {
 	}
 
 	// validations based on host's actions status (pending lock, unlock, wipe)
-	lockWipe, err := svc.ds.GetHostLockWipeStatus(ctx, host.ID, host.FleetPlatform())
+	lockWipe, err := svc.ds.GetHostLockWipeStatus(ctx, host)
 	if err != nil {
 		return ctxerr.Wrap(ctx, err, "get host lock/wipe status")
 	}
@@ -403,6 +403,7 @@ func (svc *Service) enqueueWipeHostRequest(ctx context.Context, host *fleet.Host
 
 	case "windows":
 		panic("unimplemented")
+
 	case "linux":
 		// TODO(mna): svc.RunHostScript should be refactored so that we can reuse the
 		// part starting with the validation of the script (just in case), the checks

--- a/ee/server/service/mdm.go
+++ b/ee/server/service/mdm.go
@@ -139,13 +139,6 @@ func (svc *Service) MDMAppleEraseDevice(ctx context.Context, hostID uint) error 
 		return err
 	}
 
-	// TODO: save the pin (first return value) in the database
-	// TODO(mna): same here for when we implement the Wipe story, assuming this
-	// implementation (which is for the deprecated /mdm/hosts/:id/wipe endpoint)
-	// should work as the new endpoint, then this should call
-	// svc.enqueueWipeHostRequest so that it behaves like the new endpoint. And
-	// yes, we do need to save the generated PIN so the EraseDevice method
-	// signature must change to return it.
 	err = svc.mdmAppleCommander.EraseDevice(ctx, []string{host.UUID}, uuid.New().String())
 	if err != nil {
 		return err

--- a/ee/server/service/mdm.go
+++ b/ee/server/service/mdm.go
@@ -139,7 +139,7 @@ func (svc *Service) MDMAppleEraseDevice(ctx context.Context, hostID uint) error 
 		return err
 	}
 
-	err = svc.mdmAppleCommander.EraseDevice(ctx, []string{host.UUID}, uuid.New().String())
+	err = svc.mdmAppleCommander.EraseDevice(ctx, host, uuid.New().String())
 	if err != nil {
 		return err
 	}

--- a/server/datastore/mysql/hosts.go
+++ b/server/datastore/mysql/hosts.go
@@ -778,8 +778,6 @@ const hostMDMSelect = `,
 	) mdm_host_data
 	`
 
-// TODO(mna): add integration tests with Get host with locked/wiped/unlocked (+pending) to ensure proper marshaling.
-
 // hostMDMJoin is the SQL fragment used to join MDM-related tables to the hosts table. It is a
 // dependency of the hostMDMSelect fragment.
 const hostMDMJoin = `

--- a/server/datastore/mysql/microsoft_mdm_test.go
+++ b/server/datastore/mysql/microsoft_mdm_test.go
@@ -1266,7 +1266,8 @@ func testMDMWindowsCommandResults(t *testing.T, ds *Datastore) {
 	require.Empty(t, results)
 }
 
-func windowsEnroll(t *testing.T, ds fleet.Datastore, h *fleet.Host) {
+// enrolls the host in Windows MDM and returns the device's enrollment ID.
+func windowsEnroll(t *testing.T, ds fleet.Datastore, h *fleet.Host) string {
 	ctx := context.Background()
 	d1 := &fleet.MDMWindowsEnrolledDevice{
 		MDMDeviceID:            uuid.New().String(),
@@ -1285,6 +1286,7 @@ func windowsEnroll(t *testing.T, ds fleet.Datastore, h *fleet.Host) {
 	require.NoError(t, err)
 	err = ds.UpdateMDMWindowsEnrollmentsHostUUID(ctx, d1.HostUUID, d1.MDMDeviceID)
 	require.NoError(t, err)
+	return d1.MDMDeviceID
 }
 
 func testMDMWindowsProfileManagement(t *testing.T, ds *Datastore) {

--- a/server/datastore/mysql/mysql.go
+++ b/server/datastore/mysql/mysql.go
@@ -1120,8 +1120,6 @@ func insertOnDuplicateDidUpdate(res sql.Result) bool {
 	// time of the Exec call, and the result simply returns the integers it
 	// already holds:
 	// https://github.com/go-sql-driver/mysql/blob/bcc459a906419e2890a50fc2c99ea6dd927a88f2/result.go
-	//
-	// TODO(mna): would that work on mariadb too?
 
 	lastID, _ := res.LastInsertId()
 	aff, _ := res.RowsAffected()

--- a/server/datastore/mysql/nanomdm_storage.go
+++ b/server/datastore/mysql/nanomdm_storage.go
@@ -92,23 +92,45 @@ func (s *NanoMDMStorage) EnqueueDeviceLockCommand(
 			return err
 		}
 
-		// TODO(roberto): call @mna's transactionable method to update
-		// these tables when it's ready.
 		stmt := `
-                          INSERT INTO host_mdm_actions (
-			    host_id,
-			    lock_ref,
-			    unlock_pin
-			  )
-                          VALUES (?, ?, ?)
-                          ON DUPLICATE KEY UPDATE
-			        wipe_ref   = NULL,
-                                unlock_ref = NULL,
+			INSERT INTO host_mdm_actions (
+				host_id,
+				lock_ref,
+				unlock_pin
+			)
+			VALUES (?, ?, ?)
+			ON DUPLICATE KEY UPDATE
+				wipe_ref   = NULL,
+				unlock_ref = NULL,
 				unlock_pin = VALUES(unlock_pin),
-                                lock_ref   = VALUES(lock_ref)`
+				lock_ref   = VALUES(lock_ref)`
 
 		if _, err := tx.ExecContext(ctx, stmt, host.ID, cmd.CommandUUID, pin); err != nil {
 			return ctxerr.Wrap(ctx, err, "modifying host_mdm_actions for DeviceLock")
+		}
+
+		return nil
+	}, s.logger)
+}
+
+// EnqueueDeviceWipeCommand enqueues a EraseDevice command for the given host.
+func (s *NanoMDMStorage) EnqueueDeviceWipeCommand(ctx context.Context, host *fleet.Host, cmd *mdm.Command) error {
+	return withRetryTxx(ctx, s.db, func(tx sqlx.ExtContext) error {
+		if err := enqueueCommandDB(ctx, tx, []string{host.UUID}, cmd); err != nil {
+			return err
+		}
+
+		stmt := `
+			INSERT INTO host_mdm_actions (
+				host_id,
+				wipe_ref
+			)
+			VALUES (?, ?)
+			ON DUPLICATE KEY UPDATE
+				wipe_ref   = VALUES(wipe_ref)`
+
+		if _, err := tx.ExecContext(ctx, stmt, host.ID, cmd.CommandUUID); err != nil {
+			return ctxerr.Wrap(ctx, err, "modifying host_mdm_actions for DeviceWipe")
 		}
 
 		return nil

--- a/server/datastore/mysql/nanomdm_storage_test.go
+++ b/server/datastore/mysql/nanomdm_storage_test.go
@@ -78,7 +78,7 @@ func testEnqueueDeviceLockCommand(t *testing.T, ds *Datastore) {
 		},
 	}, res)
 
-	status, err := ds.GetHostLockWipeStatus(ctx, host.ID, "darwin")
+	status, err := ds.GetHostLockWipeStatus(ctx, host)
 	require.NoError(t, err)
 	require.Equal(t, "cmd-uuid", status.LockMDMCommand.CommandUUID)
 	require.Equal(t, "123456", status.UnlockPIN)

--- a/server/datastore/mysql/scripts.go
+++ b/server/datastore/mysql/scripts.go
@@ -843,9 +843,8 @@ func (ds *Datastore) UnlockHostManually(ctx context.Context, hostID uint, ts tim
 	// entering a PIN on the device). The /unlock endpoint can be called multiple
 	// times, so we record the timestamp of the first time it was requested and
 	// from then on, the host is marked as "pending unlock" until the device is
-	// actually unlocked with the PIN.
-	// TODO(mna): to be determined how we then get notified that it has been
-	// unlocked, so that it can transition to unlocked (not pending).
+	// actually unlocked with the PIN. The actual unlocking happens when the
+	// device sends an Idle MDM request.
 	unlockRef := ts.Format(time.DateTime)
 	_, err := ds.writer(ctx).ExecContext(ctx, stmt, hostID, unlockRef)
 	return ctxerr.Wrap(ctx, err, "record manual unlock host request")

--- a/server/datastore/mysql/scripts.go
+++ b/server/datastore/mysql/scripts.go
@@ -873,10 +873,6 @@ func buildHostLockWipeStatusUpdateStmt(refCol string, succeeded bool, joinPart s
 			// around once it's confirmed.
 			stmt += fmt.Sprintf("%slock_ref = NULL, %[1]sunlock_ref = NULL, %[1]sunlock_pin = NULL, %[1]swipe_ref = NULL", alias)
 		case "wipe_ref":
-			// TODO(mna): can a wiped device still be locked? If so we'd need to keep
-			// the pin/lock_ref, but this would mean that both IsLocked and IsWiped
-			// would be true, we'd need to ensure we check wipe first (I think we
-			// always assumed those 3 states were exclusive).
 			stmt += fmt.Sprintf("%slock_ref = NULL, %[1]sunlock_ref = NULL, %[1]sunlock_pin = NULL", alias)
 		}
 	} else {

--- a/server/datastore/mysql/scripts.go
+++ b/server/datastore/mysql/scripts.go
@@ -832,7 +832,10 @@ func (ds *Datastore) updateHostLockWipeStatusFromResult(ctx context.Context, tx 
 			// around once it's confirmed.
 			stmt = fmt.Sprintf(stmt, "lock_ref = NULL, unlock_ref = NULL, unlock_pin = NULL")
 		case "wipe_ref":
-			// TODO(mna): can a wiped device still be locked?
+			// TODO(mna): can a wiped device still be locked? If so we'd need to keep
+			// the pin/lock_ref, but this would mean that both IsLocked and IsWiped
+			// would be true, we'd need to ensure we check wipe first (I think we
+			// always assumed those 3 states were exclusive).
 			stmt = fmt.Sprintf(stmt, "lock_ref = NULL, unlock_ref = NULL, unlock_pin = NULL")
 		default:
 			return ctxerr.Errorf(ctx, "unknown reference column %q", refCol)

--- a/server/datastore/mysql/scripts_test.go
+++ b/server/datastore/mysql/scripts_test.go
@@ -724,7 +724,7 @@ func testLockHostViaScript(t *testing.T, ds *Datastore) {
 	require.NoError(t, err)
 
 	// verify that we have created entries in host_mdm_actions and host_script_results
-	status, err := ds.GetHostLockWipeStatus(ctx, windowsHostID, "windows")
+	status, err := ds.GetHostLockWipeStatus(ctx, &fleet.Host{ID: windowsHostID, Platform: "windows", UUID: "uuid"})
 	require.NoError(t, err)
 	require.Equal(t, "windows", status.HostFleetPlatform)
 	require.NotNil(t, status.LockScript)
@@ -745,7 +745,7 @@ func testLockHostViaScript(t *testing.T, ds *Datastore) {
 	})
 	require.NoError(t, err)
 
-	status, err = ds.GetHostLockWipeStatus(ctx, windowsHostID, "windows")
+	status, err = ds.GetHostLockWipeStatus(ctx, &fleet.Host{ID: windowsHostID, Platform: "windows", UUID: "uuid"})
 	require.NoError(t, err)
 	require.True(t, status.IsLocked())
 	require.False(t, status.IsPendingLock())
@@ -775,7 +775,7 @@ func testUnlockHostViaScript(t *testing.T, ds *Datastore) {
 	require.NoError(t, err)
 
 	// verify that we have created entries in host_mdm_actions and host_script_results
-	status, err := ds.GetHostLockWipeStatus(ctx, hostID, "windows")
+	status, err := ds.GetHostLockWipeStatus(ctx, &fleet.Host{ID: hostID, Platform: "windows", UUID: "uuid"})
 	require.NoError(t, err)
 	require.Equal(t, "windows", status.HostFleetPlatform)
 	require.NotNil(t, status.UnlockScript)
@@ -796,7 +796,7 @@ func testUnlockHostViaScript(t *testing.T, ds *Datastore) {
 	})
 	require.NoError(t, err)
 
-	status, err = ds.GetHostLockWipeStatus(ctx, hostID, "windows")
+	status, err = ds.GetHostLockWipeStatus(ctx, &fleet.Host{ID: hostID, Platform: "windows", UUID: "uuid"})
 	require.NoError(t, err)
 	require.True(t, status.IsUnlocked())
 	require.False(t, status.IsPendingUnlock())
@@ -811,7 +811,7 @@ func testLockUnlockViaScripts(t *testing.T, ds *Datastore) {
 		hostID := uint(i + 1)
 
 		t.Run(platform, func(t *testing.T) {
-			status, err := ds.GetHostLockWipeStatus(ctx, hostID, platform)
+			status, err := ds.GetHostLockWipeStatus(ctx, &fleet.Host{ID: hostID, Platform: platform, UUID: "uuid"})
 			require.NoError(t, err)
 
 			// default state
@@ -826,7 +826,7 @@ func testLockUnlockViaScripts(t *testing.T, ds *Datastore) {
 			})
 			require.NoError(t, err)
 
-			status, err = ds.GetHostLockWipeStatus(ctx, hostID, platform)
+			status, err = ds.GetHostLockWipeStatus(ctx, &fleet.Host{ID: hostID, Platform: platform, UUID: "uuid"})
 			require.NoError(t, err)
 			checkLockWipeState(t, status, true, false, false, false, true, false)
 
@@ -838,7 +838,7 @@ func testLockUnlockViaScripts(t *testing.T, ds *Datastore) {
 			})
 			require.NoError(t, err)
 
-			status, err = ds.GetHostLockWipeStatus(ctx, hostID, platform)
+			status, err = ds.GetHostLockWipeStatus(ctx, &fleet.Host{ID: hostID, Platform: platform, UUID: "uuid"})
 			require.NoError(t, err)
 			checkLockWipeState(t, status, false, true, false, false, false, false)
 
@@ -851,7 +851,7 @@ func testLockUnlockViaScripts(t *testing.T, ds *Datastore) {
 			})
 			require.NoError(t, err)
 
-			status, err = ds.GetHostLockWipeStatus(ctx, hostID, platform)
+			status, err = ds.GetHostLockWipeStatus(ctx, &fleet.Host{ID: hostID, Platform: platform, UUID: "uuid"})
 			require.NoError(t, err)
 			checkLockWipeState(t, status, false, true, false, true, false, false)
 
@@ -864,7 +864,7 @@ func testLockUnlockViaScripts(t *testing.T, ds *Datastore) {
 			require.NoError(t, err)
 
 			// still locked
-			status, err = ds.GetHostLockWipeStatus(ctx, hostID, platform)
+			status, err = ds.GetHostLockWipeStatus(ctx, &fleet.Host{ID: hostID, Platform: platform, UUID: "uuid"})
 			require.NoError(t, err)
 			checkLockWipeState(t, status, false, true, false, false, false, false)
 
@@ -877,7 +877,7 @@ func testLockUnlockViaScripts(t *testing.T, ds *Datastore) {
 			})
 			require.NoError(t, err)
 
-			status, err = ds.GetHostLockWipeStatus(ctx, hostID, platform)
+			status, err = ds.GetHostLockWipeStatus(ctx, &fleet.Host{ID: hostID, Platform: platform, UUID: "uuid"})
 			require.NoError(t, err)
 			checkLockWipeState(t, status, false, true, false, true, false, false)
 
@@ -890,7 +890,7 @@ func testLockUnlockViaScripts(t *testing.T, ds *Datastore) {
 			require.NoError(t, err)
 
 			// host is now unlocked
-			status, err = ds.GetHostLockWipeStatus(ctx, hostID, platform)
+			status, err = ds.GetHostLockWipeStatus(ctx, &fleet.Host{ID: hostID, Platform: platform, UUID: "uuid"})
 			require.NoError(t, err)
 			checkLockWipeState(t, status, true, false, false, false, false, false)
 
@@ -903,7 +903,7 @@ func testLockUnlockViaScripts(t *testing.T, ds *Datastore) {
 			})
 			require.NoError(t, err)
 
-			status, err = ds.GetHostLockWipeStatus(ctx, hostID, platform)
+			status, err = ds.GetHostLockWipeStatus(ctx, &fleet.Host{ID: hostID, Platform: platform, UUID: "uuid"})
 			require.NoError(t, err)
 			checkLockWipeState(t, status, true, false, false, false, true, false)
 
@@ -915,7 +915,7 @@ func testLockUnlockViaScripts(t *testing.T, ds *Datastore) {
 			})
 			require.NoError(t, err)
 
-			status, err = ds.GetHostLockWipeStatus(ctx, hostID, platform)
+			status, err = ds.GetHostLockWipeStatus(ctx, &fleet.Host{ID: hostID, Platform: platform, UUID: "uuid"})
 			require.NoError(t, err)
 			checkLockWipeState(t, status, true, false, false, false, false, false)
 		})
@@ -930,7 +930,7 @@ func testLockUnlockManually(t *testing.T, ds *Datastore) {
 	err := ds.UnlockHostManually(ctx, 1, twoDaysAgo)
 	require.NoError(t, err)
 
-	status, err := ds.GetHostLockWipeStatus(ctx, 1, "darwin")
+	status, err := ds.GetHostLockWipeStatus(ctx, &fleet.Host{ID: 1, Platform: "darwin", UUID: "uuid"})
 	require.NoError(t, err)
 	require.False(t, status.UnlockRequestedAt.IsZero())
 	require.WithinDuration(t, twoDaysAgo, status.UnlockRequestedAt, 1*time.Second)
@@ -939,7 +939,7 @@ func testLockUnlockManually(t *testing.T, ds *Datastore) {
 	// requests
 	err = ds.UnlockHostManually(ctx, 1, today)
 	require.NoError(t, err)
-	status, err = ds.GetHostLockWipeStatus(ctx, 1, "darwin")
+	status, err = ds.GetHostLockWipeStatus(ctx, &fleet.Host{ID: 1, Platform: "darwin", UUID: "uuid"})
 	require.NoError(t, err)
 	require.False(t, status.UnlockRequestedAt.IsZero())
 	require.WithinDuration(t, twoDaysAgo, status.UnlockRequestedAt, 1*time.Second)
@@ -952,7 +952,7 @@ func testLockUnlockManually(t *testing.T, ds *Datastore) {
 	})
 	err = ds.UnlockHostManually(ctx, 2, today)
 	require.NoError(t, err)
-	status, err = ds.GetHostLockWipeStatus(ctx, 2, "darwin")
+	status, err = ds.GetHostLockWipeStatus(ctx, &fleet.Host{ID: 2, Platform: "darwin", UUID: "uuid"})
 	require.NoError(t, err)
 	require.False(t, status.UnlockRequestedAt.IsZero())
 	require.WithinDuration(t, today, status.UnlockRequestedAt, 1*time.Second)

--- a/server/fleet/activities.go
+++ b/server/fleet/activities.go
@@ -83,6 +83,7 @@ var ActivityDetailsList = []ActivityDetails{
 
 	ActivityTypeLockedHost{},
 	ActivityTypeUnlockedHost{},
+	ActivityTypeWipedHost{},
 }
 
 type ActivityDetails interface {
@@ -1234,6 +1235,20 @@ type ActivityTypeEditedWindowsProfile struct {
 	TeamName *string `json:"team_name"`
 }
 
+func (a ActivityTypeEditedWindowsProfile) ActivityName() string {
+	return "edited_windows_profile"
+}
+
+func (a ActivityTypeEditedWindowsProfile) Documentation() (activity, details, detailsExample string) {
+	return `Generated when a user edits the Windows profiles of a team (or no team) via the fleetctl CLI.`,
+		`This activity contains the following fields:
+- "team_id": The ID of the team that the profiles apply to, ` + "`null`" + ` if they apply to devices that are not in a team.
+- "team_name": The name of the team that the profiles apply to, ` + "`null`" + ` if they apply to devices that are not in a team.`, `{
+  "team_id": 123,
+  "team_name": "Workstations"
+}`
+}
+
 type ActivityTypeLockedHost struct {
 	HostID          uint   `json:"host_id"`
 	HostDisplayName string `json:"host_display_name"`
@@ -1283,17 +1298,22 @@ func (a ActivityTypeUnlockedHost) Documentation() (activity, details, detailsExa
 }`
 }
 
-func (a ActivityTypeEditedWindowsProfile) ActivityName() string {
-	return "edited_windows_profile"
+type ActivityTypeWipedHost struct {
+	HostID          uint   `json:"host_id"`
+	HostDisplayName string `json:"host_display_name"`
 }
 
-func (a ActivityTypeEditedWindowsProfile) Documentation() (activity, details, detailsExample string) {
-	return `Generated when a user edits the Windows profiles of a team (or no team) via the fleetctl CLI.`,
+func (a ActivityTypeWipedHost) ActivityName() string {
+	return "wiped_host"
+}
+
+func (a ActivityTypeWipedHost) Documentation() (activity, details, detailsExample string) {
+	return `Generated when a user sends a request to wipe a host.`,
 		`This activity contains the following fields:
-- "team_id": The ID of the team that the profiles apply to, ` + "`null`" + ` if they apply to devices that are not in a team.
-- "team_name": The name of the team that the profiles apply to, ` + "`null`" + ` if they apply to devices that are not in a team.`, `{
-  "team_id": 123,
-  "team_name": "Workstations"
+- "host_id": ID of the host.
+- "host_display_name": Display name of the host.`, `{
+  "host_id": 1,
+  "host_display_name": "Anna's MacBook Pro"
 }`
 }
 

--- a/server/fleet/apple_mdm.go
+++ b/server/fleet/apple_mdm.go
@@ -19,7 +19,7 @@ type MDMAppleCommandIssuer interface {
 	InstallProfile(ctx context.Context, hostUUIDs []string, profile mobileconfig.Mobileconfig, uuid string) error
 	RemoveProfile(ctx context.Context, hostUUIDs []string, identifier string, uuid string) error
 	DeviceLock(ctx context.Context, host *Host, uuid string) error
-	EraseDevice(ctx context.Context, hostUUIDs []string, uuid string) error
+	EraseDevice(ctx context.Context, host *Host, uuid string) error
 	InstallEnterpriseApplication(ctx context.Context, hostUUIDs []string, uuid string, manifestURL string) error
 }
 

--- a/server/fleet/datastore.go
+++ b/server/fleet/datastore.go
@@ -1290,6 +1290,10 @@ type Datastore interface {
 	// states in host_mdm_actions.
 	WipeHostViaScript(ctx context.Context, request *HostScriptRequestPayload) error
 
+	// WipeHostViaWindowsMDM sends a Windows MDM command to wipe a host and
+	// updates the states in host_mdm_actions.
+	WipeHostViaWindowsMDM(ctx context.Context, host *Host, cmd *MDMWindowsCommand) error
+
 	// UpdateHostLockWipeStatusFromAppleMDMResult updates the host_mdm_actions
 	// table to reflect the result of the corresponding lock/wipe MDM command for
 	// Apple hosts. It is optimized to update using only the information

--- a/server/fleet/datastore.go
+++ b/server/fleet/datastore.go
@@ -1296,6 +1296,7 @@ type Datastore interface {
 type MDMAppleStore interface {
 	storage.AllStorage
 	EnqueueDeviceLockCommand(ctx context.Context, host *Host, cmd *mdm.Command, pin string) error
+	EnqueueDeviceWipeCommand(ctx context.Context, host *Host, cmd *mdm.Command) error
 }
 
 // Cloner represents any type that can clone itself. Used for the cached_mysql

--- a/server/fleet/datastore.go
+++ b/server/fleet/datastore.go
@@ -1285,6 +1285,10 @@ type Datastore interface {
 	// CleanMacOSMDMLock cleans the lock status and pin for a macOS device
 	// after it has been unlocked.
 	CleanMacOSMDMLock(ctx context.Context, hostUUID string) error
+
+	// WipeHostViaScript sends a script to wipe a host and updates the
+	// states in host_mdm_actions.
+	WipeHostViaScript(ctx context.Context, request *HostScriptRequestPayload) error
 }
 
 // MDMAppleStore wraps nanomdm's storage and adds methods to deal with

--- a/server/fleet/datastore.go
+++ b/server/fleet/datastore.go
@@ -1289,6 +1289,12 @@ type Datastore interface {
 	// WipeHostViaScript sends a script to wipe a host and updates the
 	// states in host_mdm_actions.
 	WipeHostViaScript(ctx context.Context, request *HostScriptRequestPayload) error
+
+	// UpdateHostLockWipeStatusFromAppleMDMResult updates the host_mdm_actions
+	// table to reflect the result of the corresponding lock/wipe MDM command for
+	// Apple hosts. It is optimized to update using only the information
+	// available in the Apple MDM protocol.
+	UpdateHostLockWipeStatusFromAppleMDMResult(ctx context.Context, hostUUID, cmdUUID, requestType string, succeeded bool) error
 }
 
 // MDMAppleStore wraps nanomdm's storage and adds methods to deal with

--- a/server/fleet/datastore.go
+++ b/server/fleet/datastore.go
@@ -1267,7 +1267,7 @@ type Datastore interface {
 	BatchSetScripts(ctx context.Context, tmID *uint, scripts []*Script) error
 
 	// GetHostLockWipeStatus gets the lock/unlock and wipe status for the host.
-	GetHostLockWipeStatus(ctx context.Context, hostID uint, fleetPlatform string) (*HostLockWipeStatus, error)
+	GetHostLockWipeStatus(ctx context.Context, host *Host) (*HostLockWipeStatus, error)
 
 	// LockHostViaScript sends a script to lock a host and updates the
 	// states in host_mdm_actions

--- a/server/fleet/mdm.go
+++ b/server/fleet/mdm.go
@@ -192,7 +192,8 @@ type MDMCommandResult struct {
 	HostUUID string `json:"host_uuid" db:"host_uuid"`
 	// CommandUUID is the unique identifier of the command.
 	CommandUUID string `json:"command_uuid" db:"command_uuid"`
-	// Status is the command status. One of Acknowledged, Error, or NotNow.
+	// Status is the command status. One of Acknowledged, Error, or NotNow for
+	// Apple, or 200, 400, etc for Windows.
 	Status string `json:"status" db:"status"`
 	// UpdatedAt is the last update timestamp of the command result.
 	UpdatedAt time.Time `json:"updated_at" db:"updated_at"`

--- a/server/fleet/scripts.go
+++ b/server/fleet/scripts.go
@@ -368,13 +368,20 @@ func (s HostLockWipeStatus) IsUnlocked() bool {
 }
 
 func (s HostLockWipeStatus) IsWiped() bool {
-	if s.HostFleetPlatform == "linux" {
+	switch s.HostFleetPlatform {
+	case "linux":
 		// wiped if script was sent and succeeded
 		return s.WipeScript != nil && s.WipeScript.ExitCode != nil &&
 			*s.WipeScript.ExitCode == 0
+	case "windows":
+		// wiped if an MDM command was sent and succeeded
+		return s.WipeMDMCommand != nil && s.WipeMDMCommandResult != nil &&
+			strings.HasPrefix(s.WipeMDMCommandResult.Status, "2")
+	case "darwin":
+		// wiped if an MDM command was sent and succeeded
+		return s.WipeMDMCommand != nil && s.WipeMDMCommandResult != nil &&
+			s.WipeMDMCommandResult.Status == MDMAppleStatusAcknowledged
+	default:
+		return false
 	}
-	// wiped if an MDM command was sent and succeeded
-	return s.WipeMDMCommand != nil && s.WipeMDMCommandResult != nil &&
-		// TODO(mna): what's the success status on Windows, I think it's 200?
-		s.WipeMDMCommandResult.Status == MDMAppleStatusAcknowledged
 }

--- a/server/fleet/scripts.go
+++ b/server/fleet/scripts.go
@@ -312,7 +312,12 @@ type HostLockWipeStatus struct {
 	// windows and linux hosts use a script to unlock
 	UnlockScript *HostScriptResult
 
-	// TODO: add wipe status when implementing the Wipe story.
+	// macOS and Windows use MDM commands for Wipe
+	WipeMDMCommand       *MDMCommand
+	WipeMDMCommandResult *MDMCommandResult
+
+	// Linux uses a script for Wipe
+	WipeScript *HostScriptResult
 }
 
 func (s *HostLockWipeStatus) IsPendingLock() bool {
@@ -334,8 +339,12 @@ func (s HostLockWipeStatus) IsPendingUnlock() bool {
 }
 
 func (s HostLockWipeStatus) IsPendingWipe() bool {
-	// TODO(mna): implement when addressing Wipe story, for now wipe is never pending
-	return false
+	if s.HostFleetPlatform == "linux" {
+		// pending wipe if script execution request is queued but no result yet
+		return s.WipeScript != nil && s.WipeScript.ExitCode == nil
+	}
+	// pending wipe if an MDM command is queued but no result received yet
+	return s.WipeMDMCommand != nil && s.WipeMDMCommandResult == nil
 }
 
 func (s HostLockWipeStatus) IsLocked() bool {
@@ -359,6 +368,13 @@ func (s HostLockWipeStatus) IsUnlocked() bool {
 }
 
 func (s HostLockWipeStatus) IsWiped() bool {
-	// TODO(mna): implement when addressing Wipe story, for now never wiped
-	return false
+	if s.HostFleetPlatform == "linux" {
+		// wiped if script was sent and succeeded
+		return s.WipeScript != nil && s.WipeScript.ExitCode != nil &&
+			*s.WipeScript.ExitCode == 0
+	}
+	// wiped if an MDM command was sent and succeeded
+	return s.WipeMDMCommand != nil && s.WipeMDMCommandResult != nil &&
+		// TODO(mna): what's the success status on Windows, I think it's 200?
+		s.WipeMDMCommandResult.Status == MDMAppleStatusAcknowledged
 }

--- a/server/fleet/service.go
+++ b/server/fleet/service.go
@@ -942,4 +942,5 @@ type Service interface {
 	// Script-based methods (at least for some platforms, MDM-based for others)
 	LockHost(ctx context.Context, hostID uint) error
 	UnlockHost(ctx context.Context, hostID uint) (unlockPIN string, err error)
+	WipeHost(ctx context.Context, hostID uint) error
 }

--- a/server/mdm/apple/commander.go
+++ b/server/mdm/apple/commander.go
@@ -119,13 +119,6 @@ func (svc *MDMAppleCommander) DeviceLock(ctx context.Context, host *fleet.Host, 
 }
 
 func (svc *MDMAppleCommander) EraseDevice(ctx context.Context, host *fleet.Host, uuid string) error {
-	// TODO(mna): do we need this PIN, and if so should it be saved somewhere? It
-	// doesn't appear in the Wipe host's spec/figma like we need one and it
-	// doesn't look like it is required by Apple:
-	// https://developer.apple.com/documentation/devicemanagement/erasedevicecommand/command.
-	// Although it does mention that this is for "Find my device", so maybe we
-	// don't have to store it but if the user is an admin on Apple's website they
-	// can view the PIN somewhere in there so it's still useful?
 	pin := GenerateRandomPin(6)
 	raw := fmt.Sprintf(`<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">

--- a/server/mdm/apple/commander.go
+++ b/server/mdm/apple/commander.go
@@ -119,6 +119,13 @@ func (svc *MDMAppleCommander) DeviceLock(ctx context.Context, host *fleet.Host, 
 }
 
 func (svc *MDMAppleCommander) EraseDevice(ctx context.Context, hostUUIDs []string, uuid string) error {
+	// TODO(mna): do we need this PIN, and if so should it be saved somewhere? It
+	// doesn't appear in the Wipe host's spec/figma like we need one and it
+	// doesn't look like it is required by Apple:
+	// https://developer.apple.com/documentation/devicemanagement/erasedevicecommand/command.
+	// Although it does mention that this is for "Find my device", so maybe we
+	// don't have to store it but if the user is an admin on Apple's website they
+	// can view the PIN somewhere in there so it's still useful?
 	pin := GenerateRandomPin(6)
 	raw := fmt.Sprintf(`<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -132,6 +139,8 @@ func (svc *MDMAppleCommander) EraseDevice(ctx context.Context, hostUUIDs []strin
       <string>EraseDevice</string>
       <key>PIN</key>
       <string>%s</string>
+      <key>ObliterationBehavior</key>
+      <string>Default</string>
     </dict>
   </dict>
 </plist>`, uuid, pin)

--- a/server/mock/datastore_mdm_mock.go
+++ b/server/mock/datastore_mdm_mock.go
@@ -55,6 +55,8 @@ type RetrieveTokenUpdateTallyFunc func(ctx context.Context, id string) (int, err
 
 type EnqueueDeviceLockCommandFunc func(ctx context.Context, host *fleet.Host, cmd *mdm.Command, pin string) error
 
+type EnqueueDeviceWipeCommandFunc func(ctx context.Context, host *fleet.Host, cmd *mdm.Command) error
+
 type MDMAppleStore struct {
 	StoreAuthenticateFunc        StoreAuthenticateFunc
 	StoreAuthenticateFuncInvoked bool
@@ -118,6 +120,9 @@ type MDMAppleStore struct {
 
 	EnqueueDeviceLockCommandFunc        EnqueueDeviceLockCommandFunc
 	EnqueueDeviceLockCommandFuncInvoked bool
+
+	EnqueueDeviceWipeCommandFunc        EnqueueDeviceWipeCommandFunc
+	EnqueueDeviceWipeCommandFuncInvoked bool
 
 	mu sync.Mutex
 }
@@ -267,4 +272,11 @@ func (fs *MDMAppleStore) EnqueueDeviceLockCommand(ctx context.Context, host *fle
 	fs.EnqueueDeviceLockCommandFuncInvoked = true
 	fs.mu.Unlock()
 	return fs.EnqueueDeviceLockCommandFunc(ctx, host, cmd, pin)
+}
+
+func (fs *MDMAppleStore) EnqueueDeviceWipeCommand(ctx context.Context, host *fleet.Host, cmd *mdm.Command) error {
+	fs.mu.Lock()
+	fs.EnqueueDeviceWipeCommandFuncInvoked = true
+	fs.mu.Unlock()
+	return fs.EnqueueDeviceWipeCommandFunc(ctx, host, cmd)
 }

--- a/server/mock/datastore_mock.go
+++ b/server/mock/datastore_mock.go
@@ -820,6 +820,8 @@ type UnlockHostManuallyFunc func(ctx context.Context, hostID uint, ts time.Time)
 
 type CleanMacOSMDMLockFunc func(ctx context.Context, hostUUID string) error
 
+type WipeHostViaScriptFunc func(ctx context.Context, request *fleet.HostScriptRequestPayload) error
+
 type DataStore struct {
 	HealthCheckFunc        HealthCheckFunc
 	HealthCheckFuncInvoked bool
@@ -2023,6 +2025,9 @@ type DataStore struct {
 
 	CleanMacOSMDMLockFunc        CleanMacOSMDMLockFunc
 	CleanMacOSMDMLockFuncInvoked bool
+
+	WipeHostViaScriptFunc        WipeHostViaScriptFunc
+	WipeHostViaScriptFuncInvoked bool
 
 	mu sync.Mutex
 }
@@ -4832,4 +4837,11 @@ func (s *DataStore) CleanMacOSMDMLock(ctx context.Context, hostUUID string) erro
 	s.CleanMacOSMDMLockFuncInvoked = true
 	s.mu.Unlock()
 	return s.CleanMacOSMDMLockFunc(ctx, hostUUID)
+}
+
+func (s *DataStore) WipeHostViaScript(ctx context.Context, request *fleet.HostScriptRequestPayload) error {
+	s.mu.Lock()
+	s.WipeHostViaScriptFuncInvoked = true
+	s.mu.Unlock()
+	return s.WipeHostViaScriptFunc(ctx, request)
 }

--- a/server/mock/datastore_mock.go
+++ b/server/mock/datastore_mock.go
@@ -822,6 +822,8 @@ type CleanMacOSMDMLockFunc func(ctx context.Context, hostUUID string) error
 
 type WipeHostViaScriptFunc func(ctx context.Context, request *fleet.HostScriptRequestPayload) error
 
+type UpdateHostLockWipeStatusFromAppleMDMResultFunc func(ctx context.Context, hostUUID string, cmdUUID string, requestType string, succeeded bool) error
+
 type DataStore struct {
 	HealthCheckFunc        HealthCheckFunc
 	HealthCheckFuncInvoked bool
@@ -2028,6 +2030,9 @@ type DataStore struct {
 
 	WipeHostViaScriptFunc        WipeHostViaScriptFunc
 	WipeHostViaScriptFuncInvoked bool
+
+	UpdateHostLockWipeStatusFromAppleMDMResultFunc        UpdateHostLockWipeStatusFromAppleMDMResultFunc
+	UpdateHostLockWipeStatusFromAppleMDMResultFuncInvoked bool
 
 	mu sync.Mutex
 }
@@ -4844,4 +4849,11 @@ func (s *DataStore) WipeHostViaScript(ctx context.Context, request *fleet.HostSc
 	s.WipeHostViaScriptFuncInvoked = true
 	s.mu.Unlock()
 	return s.WipeHostViaScriptFunc(ctx, request)
+}
+
+func (s *DataStore) UpdateHostLockWipeStatusFromAppleMDMResult(ctx context.Context, hostUUID string, cmdUUID string, requestType string, succeeded bool) error {
+	s.mu.Lock()
+	s.UpdateHostLockWipeStatusFromAppleMDMResultFuncInvoked = true
+	s.mu.Unlock()
+	return s.UpdateHostLockWipeStatusFromAppleMDMResultFunc(ctx, hostUUID, cmdUUID, requestType, succeeded)
 }

--- a/server/mock/datastore_mock.go
+++ b/server/mock/datastore_mock.go
@@ -810,7 +810,7 @@ type GetHostScriptDetailsFunc func(ctx context.Context, hostID uint, teamID *uin
 
 type BatchSetScriptsFunc func(ctx context.Context, tmID *uint, scripts []*fleet.Script) error
 
-type GetHostLockWipeStatusFunc func(ctx context.Context, hostID uint, fleetPlatform string) (*fleet.HostLockWipeStatus, error)
+type GetHostLockWipeStatusFunc func(ctx context.Context, host *fleet.Host) (*fleet.HostLockWipeStatus, error)
 
 type LockHostViaScriptFunc func(ctx context.Context, request *fleet.HostScriptRequestPayload) error
 
@@ -4804,11 +4804,11 @@ func (s *DataStore) BatchSetScripts(ctx context.Context, tmID *uint, scripts []*
 	return s.BatchSetScriptsFunc(ctx, tmID, scripts)
 }
 
-func (s *DataStore) GetHostLockWipeStatus(ctx context.Context, hostID uint, fleetPlatform string) (*fleet.HostLockWipeStatus, error) {
+func (s *DataStore) GetHostLockWipeStatus(ctx context.Context, host *fleet.Host) (*fleet.HostLockWipeStatus, error) {
 	s.mu.Lock()
 	s.GetHostLockWipeStatusFuncInvoked = true
 	s.mu.Unlock()
-	return s.GetHostLockWipeStatusFunc(ctx, hostID, fleetPlatform)
+	return s.GetHostLockWipeStatusFunc(ctx, host)
 }
 
 func (s *DataStore) LockHostViaScript(ctx context.Context, request *fleet.HostScriptRequestPayload) error {

--- a/server/mock/datastore_mock.go
+++ b/server/mock/datastore_mock.go
@@ -822,6 +822,8 @@ type CleanMacOSMDMLockFunc func(ctx context.Context, hostUUID string) error
 
 type WipeHostViaScriptFunc func(ctx context.Context, request *fleet.HostScriptRequestPayload) error
 
+type WipeHostViaWindowsMDMFunc func(ctx context.Context, host *fleet.Host, cmd *fleet.MDMWindowsCommand) error
+
 type UpdateHostLockWipeStatusFromAppleMDMResultFunc func(ctx context.Context, hostUUID string, cmdUUID string, requestType string, succeeded bool) error
 
 type DataStore struct {
@@ -2030,6 +2032,9 @@ type DataStore struct {
 
 	WipeHostViaScriptFunc        WipeHostViaScriptFunc
 	WipeHostViaScriptFuncInvoked bool
+
+	WipeHostViaWindowsMDMFunc        WipeHostViaWindowsMDMFunc
+	WipeHostViaWindowsMDMFuncInvoked bool
 
 	UpdateHostLockWipeStatusFromAppleMDMResultFunc        UpdateHostLockWipeStatusFromAppleMDMResultFunc
 	UpdateHostLockWipeStatusFromAppleMDMResultFuncInvoked bool
@@ -4849,6 +4854,13 @@ func (s *DataStore) WipeHostViaScript(ctx context.Context, request *fleet.HostSc
 	s.WipeHostViaScriptFuncInvoked = true
 	s.mu.Unlock()
 	return s.WipeHostViaScriptFunc(ctx, request)
+}
+
+func (s *DataStore) WipeHostViaWindowsMDM(ctx context.Context, host *fleet.Host, cmd *fleet.MDMWindowsCommand) error {
+	s.mu.Lock()
+	s.WipeHostViaWindowsMDMFuncInvoked = true
+	s.mu.Unlock()
+	return s.WipeHostViaWindowsMDMFunc(ctx, host, cmd)
 }
 
 func (s *DataStore) UpdateHostLockWipeStatusFromAppleMDMResult(ctx context.Context, hostUUID string, cmdUUID string, requestType string, succeeded bool) error {

--- a/server/service/apple_mdm.go
+++ b/server/service/apple_mdm.go
@@ -2407,6 +2407,13 @@ func (svc *MDMAppleCheckinAndCommandService) CommandAndReportResults(r *mdm.Requ
 			Detail:        apple_mdm.FmtErrorChain(cmdResult.ErrorChain),
 			OperationType: fleet.MDMOperationTypeRemove,
 		})
+	case "DeviceLock", "EraseDevice":
+		// call into our datastore to update host_mdm_actions if the status is terminal
+		if cmdResult.Status == fleet.MDMAppleStatusAcknowledged ||
+			cmdResult.Status == fleet.MDMAppleStatusError ||
+			cmdResult.Status == fleet.MDMAppleStatusCommandFormatError {
+			return nil, svc.ds.UpdateHostLockWipeStatusFromAppleMDMResult(r.Context, cmdResult.UDID, cmdResult.CommandUUID, requestType, cmdResult.Status == fleet.MDMAppleStatusAcknowledged)
+		}
 	}
 	return nil, nil
 }

--- a/server/service/apple_mdm_test.go
+++ b/server/service/apple_mdm_test.go
@@ -751,7 +751,7 @@ func TestHostDetailsMDMProfiles(t *testing.T) {
 	ds.GetHostMDMMacOSSetupFunc = func(ctx context.Context, hostID uint) (*fleet.HostMDMMacOSSetup, error) {
 		return nil, nil
 	}
-	ds.GetHostLockWipeStatusFunc = func(ctx context.Context, hostID uint, fleetPlatform string) (*fleet.HostLockWipeStatus, error) {
+	ds.GetHostLockWipeStatusFunc = func(ctx context.Context, host *fleet.Host) (*fleet.HostLockWipeStatus, error) {
 		return &fleet.HostLockWipeStatus{}, nil
 	}
 

--- a/server/service/handler.go
+++ b/server/service/handler.go
@@ -474,6 +474,7 @@ func attachFleetAPIRoutes(r *mux.Router, svc fleet.Service, config config.FleetC
 	ue.GET("/api/_version_/fleet/hosts/{id:[0-9]+}/activities", listHostPastActivitiesEndpoint, listHostPastActivitiesRequest{})
 	ue.POST("/api/_version_/fleet/hosts/{id:[0-9]+}/lock", lockHostEndpoint, lockHostRequest{})
 	ue.POST("/api/_version_/fleet/hosts/{id:[0-9]+}/unlock", unlockHostEndpoint, unlockHostRequest{})
+	ue.POST("/api/_version_/fleet/hosts/{id:[0-9]+}/wipe", wipeHostEndpoint, wipeHostRequest{})
 
 	// Only Fleet MDM specific endpoints should be within the root /mdm/ path.
 	// NOTE: remember to update

--- a/server/service/hosts.go
+++ b/server/service/hosts.go
@@ -1093,7 +1093,7 @@ func (svc *Service) getHostDetails(ctx context.Context, host *fleet.Host, opts f
 	}
 	host.MDM.MacOSSetup = macOSSetup
 
-	mdmActions, err := svc.ds.GetHostLockWipeStatus(ctx, host.ID, host.FleetPlatform())
+	mdmActions, err := svc.ds.GetHostLockWipeStatus(ctx, host)
 	if err != nil {
 		return nil, ctxerr.Wrap(ctx, err, "get host mdm lock/wipe status")
 	}

--- a/server/service/hosts.go
+++ b/server/service/hosts.go
@@ -1104,10 +1104,10 @@ func (svc *Service) getHostDetails(ctx context.Context, host *fleet.Host, opts f
 	host.MDM.PendingAction = ptr.String("")
 	// device status
 	switch {
-	case mdmActions.IsLocked():
-		host.MDM.DeviceStatus = ptr.String("locked")
 	case mdmActions.IsWiped():
 		host.MDM.DeviceStatus = ptr.String("wiped")
+	case mdmActions.IsLocked():
+		host.MDM.DeviceStatus = ptr.String("locked")
 	}
 
 	// pending action, if any

--- a/server/service/hosts_test.go
+++ b/server/service/hosts_test.go
@@ -67,7 +67,7 @@ func TestHostDetails(t *testing.T) {
 	ds.ListHostBatteriesFunc = func(ctx context.Context, hostID uint) ([]*fleet.HostBattery, error) {
 		return dsBats, nil
 	}
-	ds.GetHostLockWipeStatusFunc = func(ctx context.Context, hostID uint, fleetPlatform string) (*fleet.HostLockWipeStatus, error) {
+	ds.GetHostLockWipeStatusFunc = func(ctx context.Context, host *fleet.Host) (*fleet.HostLockWipeStatus, error) {
 		return &fleet.HostLockWipeStatus{}, nil
 	}
 	// Health should be replaced at the service layer with custom values determined by the cycle count. See https://github.com/fleetdm/fleet/issues/6763.
@@ -108,7 +108,7 @@ func TestHostDetailsMDMAppleDiskEncryption(t *testing.T) {
 	ds.ListHostBatteriesFunc = func(ctx context.Context, hostID uint) ([]*fleet.HostBattery, error) {
 		return nil, nil
 	}
-	ds.GetHostLockWipeStatusFunc = func(ctx context.Context, hostID uint, fleetPlatform string) (*fleet.HostLockWipeStatus, error) {
+	ds.GetHostLockWipeStatusFunc = func(ctx context.Context, host *fleet.Host) (*fleet.HostLockWipeStatus, error) {
 		return &fleet.HostLockWipeStatus{}, nil
 	}
 
@@ -385,7 +385,7 @@ func TestHostDetailsOSSettings(t *testing.T) {
 	ds.GetHostMDMMacOSSetupFunc = func(ctx context.Context, hid uint) (*fleet.HostMDMMacOSSetup, error) {
 		return nil, nil
 	}
-	ds.GetHostLockWipeStatusFunc = func(ctx context.Context, hostID uint, fleetPlatform string) (*fleet.HostLockWipeStatus, error) {
+	ds.GetHostLockWipeStatusFunc = func(ctx context.Context, host *fleet.Host) (*fleet.HostLockWipeStatus, error) {
 		return &fleet.HostLockWipeStatus{}, nil
 	}
 
@@ -497,7 +497,7 @@ func TestHostDetailsOSSettingsWindowsOnly(t *testing.T) {
 	ds.GetHostMDMWindowsProfilesFunc = func(ctx context.Context, uuid string) ([]fleet.HostMDMWindowsProfile, error) {
 		return nil, nil
 	}
-	ds.GetHostLockWipeStatusFunc = func(ctx context.Context, hostID uint, fleetPlatform string) (*fleet.HostLockWipeStatus, error) {
+	ds.GetHostLockWipeStatusFunc = func(ctx context.Context, host *fleet.Host) (*fleet.HostLockWipeStatus, error) {
 		return &fleet.HostLockWipeStatus{}, nil
 	}
 
@@ -600,7 +600,7 @@ func TestHostAuth(t *testing.T) {
 	ds.ListHostUpcomingActivitiesFunc = func(ctx context.Context, hostID uint, opt fleet.ListOptions) ([]*fleet.Activity, *fleet.PaginationMetadata, error) {
 		return nil, nil, nil
 	}
-	ds.GetHostLockWipeStatusFunc = func(ctx context.Context, hostID uint, fleetPlatform string) (*fleet.HostLockWipeStatus, error) {
+	ds.GetHostLockWipeStatusFunc = func(ctx context.Context, host *fleet.Host) (*fleet.HostLockWipeStatus, error) {
 		return &fleet.HostLockWipeStatus{}, nil
 	}
 
@@ -1383,7 +1383,7 @@ func TestHostMDMProfileDetail(t *testing.T) {
 	ds.GetHostMDMMacOSSetupFunc = func(ctx context.Context, hid uint) (*fleet.HostMDMMacOSSetup, error) {
 		return nil, nil
 	}
-	ds.GetHostLockWipeStatusFunc = func(ctx context.Context, hostID uint, fleetPlatform string) (*fleet.HostLockWipeStatus, error) {
+	ds.GetHostLockWipeStatusFunc = func(ctx context.Context, host *fleet.Host) (*fleet.HostLockWipeStatus, error) {
 		return &fleet.HostLockWipeStatus{}, nil
 	}
 	ds.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {
@@ -1483,7 +1483,7 @@ func TestLockUnlockHostAuth(t *testing.T) {
 	ds.GetHostMDMMacOSSetupFunc = func(ctx context.Context, hostID uint) (*fleet.HostMDMMacOSSetup, error) {
 		return nil, nil
 	}
-	ds.GetHostLockWipeStatusFunc = func(ctx context.Context, hostID uint, fleetPlatform string) (*fleet.HostLockWipeStatus, error) {
+	ds.GetHostLockWipeStatusFunc = func(ctx context.Context, host *fleet.Host) (*fleet.HostLockWipeStatus, error) {
 		return &fleet.HostLockWipeStatus{}, nil
 	}
 	ds.LockHostViaScriptFunc = func(ctx context.Context, request *fleet.HostScriptRequestPayload) error {
@@ -1602,8 +1602,8 @@ func TestLockUnlockHostAuth(t *testing.T) {
 			checkAuthErr(t, tt.shouldFailTeamWrite, err)
 
 			// Pretend we locked the host
-			ds.GetHostLockWipeStatusFunc = func(ctx context.Context, hostID uint, fleetPlatform string) (*fleet.HostLockWipeStatus, error) {
-				return &fleet.HostLockWipeStatus{HostFleetPlatform: fleetPlatform, LockMDMCommand: &fleet.MDMCommand{}, LockMDMCommandResult: &fleet.MDMCommandResult{Status: fleet.MDMAppleStatusAcknowledged}}, nil
+			ds.GetHostLockWipeStatusFunc = func(ctx context.Context, host *fleet.Host) (*fleet.HostLockWipeStatus, error) {
+				return &fleet.HostLockWipeStatus{HostFleetPlatform: host.FleetPlatform(), LockMDMCommand: &fleet.MDMCommand{}, LockMDMCommandResult: &fleet.MDMCommandResult{Status: fleet.MDMAppleStatusAcknowledged}}, nil
 			}
 
 			_, err = svc.UnlockHost(ctx, 2)
@@ -1612,7 +1612,7 @@ func TestLockUnlockHostAuth(t *testing.T) {
 			checkAuthErr(t, tt.shouldFailTeamWrite, err)
 
 			// Reset so we're now pretending host is unlocked
-			ds.GetHostLockWipeStatusFunc = func(ctx context.Context, hostID uint, fleetPlatform string) (*fleet.HostLockWipeStatus, error) {
+			ds.GetHostLockWipeStatusFunc = func(ctx context.Context, host *fleet.Host) (*fleet.HostLockWipeStatus, error) {
 				return &fleet.HostLockWipeStatus{}, nil
 			}
 		})

--- a/server/service/integration_core_test.go
+++ b/server/service/integration_core_test.go
@@ -5350,9 +5350,10 @@ func (s *integrationTestSuite) TestPremiumEndpointsWithoutLicense() {
 		"team_id", "1",
 	)
 
-	// lock/unlock a host
+	// lock/unlock/wipe a host
 	s.Do("POST", "/api/v1/fleet/hosts/123/lock", nil, http.StatusPaymentRequired)
 	s.Do("POST", "/api/v1/fleet/hosts/123/unlock", nil, http.StatusPaymentRequired)
+	s.Do("POST", "/api/v1/fleet/hosts/123/wipe", nil, http.StatusPaymentRequired)
 }
 
 func (s *integrationTestSuite) TestScriptsEndpointsWithoutLicense() {

--- a/server/service/integration_enterprise_test.go
+++ b/server/service/integration_enterprise_test.go
@@ -6571,7 +6571,7 @@ func (s *integrationEnterpriseTestSuite) TestLockUnlockWindowsLinux() {
 	s.Do("POST", fmt.Sprintf("/api/latest/fleet/hosts/%d/lock", linuxHost.ID), nil, http.StatusNoContent)
 
 	// simulate a successful script result for the lock command
-	status, err := s.ds.GetHostLockWipeStatus(ctx, linuxHost.ID, linuxHost.FleetPlatform())
+	status, err := s.ds.GetHostLockWipeStatus(ctx, linuxHost)
 	require.NoError(t, err)
 
 	var orbitScriptResp orbitPostScriptResultResponse

--- a/server/service/integration_enterprise_test.go
+++ b/server/service/integration_enterprise_test.go
@@ -6537,7 +6537,7 @@ func (s *integrationEnterpriseTestSuite) TestAllSoftwareTitles() {
 	}, []fleet.SoftwareTitle{*stResp.SoftwareTitle})
 }
 
-func (s *integrationEnterpriseTestSuite) TestLockUnlockWindowsLinux() {
+func (s *integrationEnterpriseTestSuite) TestLockUnlockWipeWindowsLinux() {
 	ctx := context.Background()
 	t := s.T()
 
@@ -6559,15 +6559,18 @@ func (s *integrationEnterpriseTestSuite) TestLockUnlockWindowsLinux() {
 	require.NotNil(t, getHostResp.Host.MDM.PendingAction)
 	require.Equal(t, "", *getHostResp.Host.MDM.PendingAction)
 
-	// try to lock/unlock the Windows host, fails because Windows MDM must be enabled
+	// try to lock/unlock/wipe the Windows host, fails because Windows MDM must be enabled
 	res := s.DoRaw("POST", fmt.Sprintf("/api/latest/fleet/hosts/%d/lock", winHost.ID), nil, http.StatusBadRequest)
 	errMsg := extractServerErrorText(res.Body)
 	require.Contains(t, errMsg, "Windows MDM isn't turned on.")
 	res = s.DoRaw("POST", fmt.Sprintf("/api/latest/fleet/hosts/%d/unlock", winHost.ID), nil, http.StatusBadRequest)
 	errMsg = extractServerErrorText(res.Body)
 	require.Contains(t, errMsg, "Windows MDM isn't turned on.")
+	res = s.DoRaw("POST", fmt.Sprintf("/api/latest/fleet/hosts/%d/wipe", winHost.ID), nil, http.StatusBadRequest)
+	errMsg = extractServerErrorText(res.Body)
+	require.Contains(t, errMsg, "Windows MDM isn't turned on.")
 
-	// try to lock/unlock the Linux host succeeds, no MDM constraints
+	// try to lock/unlock/wipe the Linux host succeeds, no MDM constraints
 	s.Do("POST", fmt.Sprintf("/api/latest/fleet/hosts/%d/lock", linuxHost.ID), nil, http.StatusNoContent)
 
 	// simulate a successful script result for the lock command
@@ -6593,6 +6596,12 @@ func (s *integrationEnterpriseTestSuite) TestLockUnlockWindowsLinux() {
 	require.Equal(t, "locked", *getHostResp.Host.MDM.DeviceStatus)
 	require.NotNil(t, getHostResp.Host.MDM.PendingAction)
 	require.Equal(t, "unlock", *getHostResp.Host.MDM.PendingAction)
+
+	// attempting to Wipe the linux host fails due to pending unlock, not because
+	// of MDM not enabled
+	res = s.DoRaw("POST", fmt.Sprintf("/api/latest/fleet/hosts/%d/wipe", linuxHost.ID), nil, http.StatusUnprocessableEntity)
+	errMsg = extractServerErrorText(res.Body)
+	require.Contains(t, errMsg, "Host cannot be wiped until unlock is complete.")
 }
 
 // checks that the specified team/no-team has the Windows OS Updates profile with

--- a/server/service/integration_mdm_test.go
+++ b/server/service/integration_mdm_test.go
@@ -11038,7 +11038,7 @@ func (s *integrationMDMTestSuite) TestLockUnlockWindowsLinux() {
 			require.Contains(t, errMsg, "Host has pending lock request.")
 
 			// simulate a successful script result for the lock command
-			status, err := s.ds.GetHostLockWipeStatus(ctx, host.ID, host.FleetPlatform())
+			status, err := s.ds.GetHostLockWipeStatus(ctx, host)
 			require.NoError(t, err)
 
 			var orbitScriptResp orbitPostScriptResultResponse
@@ -11072,7 +11072,7 @@ func (s *integrationMDMTestSuite) TestLockUnlockWindowsLinux() {
 			require.Contains(t, errMsg, "Host has pending unlock request.")
 
 			// simulate a failed script result for the unlock command
-			status, err = s.ds.GetHostLockWipeStatus(ctx, host.ID, host.FleetPlatform())
+			status, err = s.ds.GetHostLockWipeStatus(ctx, host)
 			require.NoError(t, err)
 
 			s.DoJSON("POST", "/api/fleet/orbit/scripts/result",

--- a/server/service/integration_mdm_test.go
+++ b/server/service/integration_mdm_test.go
@@ -11000,12 +11000,15 @@ func (s *integrationMDMTestSuite) TestManualEnrollmentCommands() {
 	checkInstallFleetdCommandSent(mdmDevice, false)
 }
 
-func (s *integrationMDMTestSuite) TestLockUnlockWindowsLinux() {
+func (s *integrationMDMTestSuite) TestLockUnlockWipeWindowsLinux() {
 	t := s.T()
 	ctx := context.Background()
 
 	// create an MDM-enrolled Windows host
-	winHost, _ := createWindowsHostThenEnrollMDM(s.ds, s.server.URL, t)
+	winHost, winMDMClient := createWindowsHostThenEnrollMDM(s.ds, s.server.URL, t)
+	// set its MDM data so it shows as MDM-enrolled in the backend
+	err := s.ds.SetOrUpdateMDMData(ctx, winHost.ID, false, true, s.server.URL, false, fleet.WellKnownMDMFleet, "")
+	require.NoError(t, err)
 	linuxHost := createOrbitEnrolledHost(t, "linux", "lock_unlock_linux", s.ds)
 
 	for _, host := range []*fleet.Host{winHost, linuxHost} {
@@ -11085,8 +11088,217 @@ func (s *integrationMDMTestSuite) TestLockUnlockWindowsLinux() {
 			require.Equal(t, "locked", *getHostResp.Host.MDM.DeviceStatus)
 			require.NotNil(t, getHostResp.Host.MDM.PendingAction)
 			require.Equal(t, "", *getHostResp.Host.MDM.PendingAction)
+
+			// unlock the host, simulate success
+			s.Do("POST", fmt.Sprintf("/api/latest/fleet/hosts/%d/unlock", host.ID), nil, http.StatusNoContent)
+			status, err = s.ds.GetHostLockWipeStatus(ctx, host)
+			require.NoError(t, err)
+			s.DoJSON("POST", "/api/fleet/orbit/scripts/result",
+				json.RawMessage(fmt.Sprintf(`{"orbit_node_key": %q, "execution_id": %q, "exit_code": 0, "output": "ok"}`, *host.OrbitNodeKey, status.UnlockScript.ExecutionID)),
+				http.StatusOK, &orbitScriptResp)
+
+			// refresh the host's status, it is unlocked, no pending action
+			s.DoJSON("GET", fmt.Sprintf("/api/latest/fleet/hosts/%d", host.ID), nil, http.StatusOK, &getHostResp)
+			require.NotNil(t, getHostResp.Host.MDM.DeviceStatus)
+			require.Equal(t, "unlocked", *getHostResp.Host.MDM.DeviceStatus)
+			require.NotNil(t, getHostResp.Host.MDM.PendingAction)
+			require.Equal(t, "", *getHostResp.Host.MDM.PendingAction)
+
+			// wipe the host
+			s.Do("POST", fmt.Sprintf("/api/latest/fleet/hosts/%d/wipe", host.ID), nil, http.StatusNoContent)
+			wipeActID := s.lastActivityOfTypeMatches(fleet.ActivityTypeWipedHost{}.ActivityName(), fmt.Sprintf(`{"host_id": %d, "host_display_name": %q}`, host.ID, host.DisplayName()), 0)
+
+			// try to wipe the host again, already have it pending
+			res = s.DoRaw("POST", fmt.Sprintf("/api/latest/fleet/hosts/%d/wipe", host.ID), nil, http.StatusUnprocessableEntity)
+			errMsg = extractServerErrorText(res.Body)
+			require.Contains(t, errMsg, "Host has pending wipe request.")
+			// no activity created
+			s.lastActivityOfTypeMatches(fleet.ActivityTypeWipedHost{}.ActivityName(), fmt.Sprintf(`{"host_id": %d, "host_display_name": %q}`, host.ID, host.DisplayName()), wipeActID)
+
+			// refresh the host's status, it is unlocked, pending wipe
+			s.DoJSON("GET", fmt.Sprintf("/api/latest/fleet/hosts/%d", host.ID), nil, http.StatusOK, &getHostResp)
+			require.NotNil(t, getHostResp.Host.MDM.DeviceStatus)
+			require.Equal(t, "unlocked", *getHostResp.Host.MDM.DeviceStatus)
+			require.NotNil(t, getHostResp.Host.MDM.PendingAction)
+			require.Equal(t, "wipe", *getHostResp.Host.MDM.PendingAction)
+
+			status, err = s.ds.GetHostLockWipeStatus(ctx, host)
+			require.NoError(t, err)
+			if host.FleetPlatform() == "linux" {
+				// simulate a successful wipe for the Linux host's script response
+				s.DoJSON("POST", "/api/fleet/orbit/scripts/result",
+					json.RawMessage(fmt.Sprintf(`{"orbit_node_key": %q, "execution_id": %q, "exit_code": 0, "output": "ok"}`, *host.OrbitNodeKey, status.WipeScript.ExecutionID)),
+					http.StatusOK, &orbitScriptResp)
+			} else {
+				// simulate a successful wipe from the Windows device's MDM response
+				cmds, err := winMDMClient.StartManagementSession()
+				require.NoError(t, err)
+
+				// two status + the wipe command we enqueued
+				require.Len(t, cmds, 3)
+				wipeCmd := cmds[status.WipeMDMCommand.CommandUUID]
+				require.NotNil(t, wipeCmd)
+				require.Equal(t, wipeCmd.Verb, fleet.CmdExec)
+				require.Len(t, wipeCmd.Cmd.Items, 1)
+				require.EqualValues(t, "./Device/Vendor/MSFT/RemoteWipe/doWipeProtected", *wipeCmd.Cmd.Items[0].Target)
+
+				msgID, err := winMDMClient.GetCurrentMsgID()
+				require.NoError(t, err)
+
+				winMDMClient.AppendResponse(fleet.SyncMLCmd{
+					XMLName: xml.Name{Local: mdm_types.CmdStatus},
+					MsgRef:  &msgID,
+					CmdRef:  &status.WipeMDMCommand.CommandUUID,
+					Cmd:     ptr.String("Exec"),
+					Data:    ptr.String("200"),
+					Items:   nil,
+					CmdID:   fleet.CmdID{Value: uuid.NewString()},
+				})
+				cmds, err = winMDMClient.SendResponse()
+				require.NoError(t, err)
+				// the ack of the message should be the only returned command
+				require.Len(t, cmds, 1)
+			}
+
+			// refresh the host's status, it is wiped
+			s.DoJSON("GET", fmt.Sprintf("/api/latest/fleet/hosts/%d", host.ID), nil, http.StatusOK, &getHostResp)
+			require.NotNil(t, getHostResp.Host.MDM.DeviceStatus)
+			require.Equal(t, "wiped", *getHostResp.Host.MDM.DeviceStatus)
+			require.NotNil(t, getHostResp.Host.MDM.PendingAction)
+			require.Equal(t, "", *getHostResp.Host.MDM.PendingAction)
+
+			// try to wipe the host again, conflict (already wiped)
+			s.Do("POST", fmt.Sprintf("/api/latest/fleet/hosts/%d/wipe", host.ID), nil, http.StatusConflict)
+			// no activity created
+			s.lastActivityOfTypeMatches(fleet.ActivityTypeWipedHost{}.ActivityName(), fmt.Sprintf(`{"host_id": %d, "host_display_name": %q}`, host.ID, host.DisplayName()), wipeActID)
 		})
 	}
+}
+
+func (s *integrationMDMTestSuite) TestLockUnlockWipeMacOS() {
+	t := s.T()
+	host, mdmClient := createHostThenEnrollMDM(s.ds, s.server.URL, t)
+
+	// get the host's information
+	var getHostResp getHostResponse
+	s.DoJSON("GET", fmt.Sprintf("/api/latest/fleet/hosts/%d", host.ID), nil, http.StatusOK, &getHostResp)
+	require.NotNil(t, getHostResp.Host.MDM.DeviceStatus)
+	require.Equal(t, "unlocked", *getHostResp.Host.MDM.DeviceStatus)
+	require.NotNil(t, getHostResp.Host.MDM.PendingAction)
+	require.Equal(t, "", *getHostResp.Host.MDM.PendingAction)
+
+	// try to unlock the host (which is already its status)
+	var unlockResp unlockHostResponse
+	s.DoJSON("POST", fmt.Sprintf("/api/latest/fleet/hosts/%d/unlock", host.ID), nil, http.StatusConflict, &unlockResp)
+
+	// lock the host
+	s.Do("POST", fmt.Sprintf("/api/latest/fleet/hosts/%d/lock", host.ID), nil, http.StatusNoContent)
+
+	// refresh the host's status, it is now pending lock
+	s.DoJSON("GET", fmt.Sprintf("/api/latest/fleet/hosts/%d", host.ID), nil, http.StatusOK, &getHostResp)
+	require.NotNil(t, getHostResp.Host.MDM.DeviceStatus)
+	require.Equal(t, "unlocked", *getHostResp.Host.MDM.DeviceStatus)
+	require.NotNil(t, getHostResp.Host.MDM.PendingAction)
+	require.Equal(t, "lock", *getHostResp.Host.MDM.PendingAction)
+
+	// try locking the host while it is pending lock fails
+	res := s.DoRaw("POST", fmt.Sprintf("/api/latest/fleet/hosts/%d/lock", host.ID), nil, http.StatusUnprocessableEntity)
+	errMsg := extractServerErrorText(res.Body)
+	require.Contains(t, errMsg, "Host has pending lock request.")
+
+	// simulate a successful MDM result for the lock command
+	cmd, err := mdmClient.Idle()
+	require.NoError(t, err)
+	require.NotNil(t, cmd)
+	require.Equal(t, "DeviceLock", cmd.Command.RequestType)
+	cmd, err = mdmClient.Acknowledge(cmd.CommandUUID)
+	require.NoError(t, err)
+
+	// refresh the host's status, it is now locked
+	s.DoJSON("GET", fmt.Sprintf("/api/latest/fleet/hosts/%d", host.ID), nil, http.StatusOK, &getHostResp)
+	require.NotNil(t, getHostResp.Host.MDM.DeviceStatus)
+	require.Equal(t, "locked", *getHostResp.Host.MDM.DeviceStatus)
+	require.NotNil(t, getHostResp.Host.MDM.PendingAction)
+	require.Equal(t, "", *getHostResp.Host.MDM.PendingAction)
+
+	// try to lock the host again
+	s.Do("POST", fmt.Sprintf("/api/latest/fleet/hosts/%d/lock", host.ID), nil, http.StatusConflict)
+
+	// unlock the host
+	unlockResp = unlockHostResponse{}
+	s.DoJSON("POST", fmt.Sprintf("/api/latest/fleet/hosts/%d/unlock", host.ID), nil, http.StatusOK, &unlockResp)
+	require.NotNil(t, unlockResp.HostID)
+	require.Equal(t, host.ID, *unlockResp.HostID)
+	require.Len(t, unlockResp.UnlockPIN, 6)
+	unlockPIN := unlockResp.UnlockPIN
+	unlockActID := s.lastActivityOfTypeMatches(fleet.ActivityTypeUnlockedHost{}.ActivityName(),
+		fmt.Sprintf(`{"host_id": %d, "host_display_name": %q, "host_platform": %q}`, host.ID, host.DisplayName(), host.FleetPlatform()), 0)
+
+	// refresh the host's status, it is locked pending unlock
+	s.DoJSON("GET", fmt.Sprintf("/api/latest/fleet/hosts/%d", host.ID), nil, http.StatusOK, &getHostResp)
+	require.NotNil(t, getHostResp.Host.MDM.DeviceStatus)
+	require.Equal(t, "locked", *getHostResp.Host.MDM.DeviceStatus)
+	require.NotNil(t, getHostResp.Host.MDM.PendingAction)
+	require.Equal(t, "unlock", *getHostResp.Host.MDM.PendingAction)
+
+	// try unlocking the host again simply returns the PIN again
+	unlockResp = unlockHostResponse{}
+	s.DoJSON("POST", fmt.Sprintf("/api/latest/fleet/hosts/%d/unlock", host.ID), nil, http.StatusOK, &unlockResp)
+	require.Equal(t, unlockPIN, unlockResp.UnlockPIN)
+	// a new unlock host activity is created every time the unlock PIN is viewed
+	newUnlockActID := s.lastActivityOfTypeMatches(fleet.ActivityTypeUnlockedHost{}.ActivityName(),
+		fmt.Sprintf(`{"host_id": %d, "host_display_name": %q, "host_platform": %q}`, host.ID, host.DisplayName(), host.FleetPlatform()), 0)
+	require.NotEqual(t, unlockActID, newUnlockActID)
+
+	// as soon as the host sends an Idle MDM request, it is maked as unlocked
+	cmd, err = mdmClient.Idle()
+	require.NoError(t, err)
+	require.Nil(t, cmd)
+
+	// refresh the host's status, it is unlocked
+	s.DoJSON("GET", fmt.Sprintf("/api/latest/fleet/hosts/%d", host.ID), nil, http.StatusOK, &getHostResp)
+	require.NotNil(t, getHostResp.Host.MDM.DeviceStatus)
+	require.Equal(t, "unlocked", *getHostResp.Host.MDM.DeviceStatus)
+	require.NotNil(t, getHostResp.Host.MDM.PendingAction)
+	require.Equal(t, "", *getHostResp.Host.MDM.PendingAction)
+
+	// wipe the host
+	s.Do("POST", fmt.Sprintf("/api/latest/fleet/hosts/%d/wipe", host.ID), nil, http.StatusNoContent)
+	wipeActID := s.lastActivityOfTypeMatches(fleet.ActivityTypeWipedHost{}.ActivityName(), fmt.Sprintf(`{"host_id": %d, "host_display_name": %q}`, host.ID, host.DisplayName()), 0)
+
+	// try to wipe the host again, already have it pending
+	res = s.DoRaw("POST", fmt.Sprintf("/api/latest/fleet/hosts/%d/wipe", host.ID), nil, http.StatusUnprocessableEntity)
+	errMsg = extractServerErrorText(res.Body)
+	require.Contains(t, errMsg, "Host has pending wipe request.")
+	// no activity created
+	s.lastActivityOfTypeMatches(fleet.ActivityTypeWipedHost{}.ActivityName(), fmt.Sprintf(`{"host_id": %d, "host_display_name": %q}`, host.ID, host.DisplayName()), wipeActID)
+
+	// refresh the host's status, it is unlocked, pending wipe
+	s.DoJSON("GET", fmt.Sprintf("/api/latest/fleet/hosts/%d", host.ID), nil, http.StatusOK, &getHostResp)
+	require.NotNil(t, getHostResp.Host.MDM.DeviceStatus)
+	require.Equal(t, "unlocked", *getHostResp.Host.MDM.DeviceStatus)
+	require.NotNil(t, getHostResp.Host.MDM.PendingAction)
+	require.Equal(t, "wipe", *getHostResp.Host.MDM.PendingAction)
+
+	// simulate a successful MDM result for the wipe command
+	cmd, err = mdmClient.Idle()
+	require.NoError(t, err)
+	require.NotNil(t, cmd)
+	require.Equal(t, "EraseDevice", cmd.Command.RequestType)
+	cmd, err = mdmClient.Acknowledge(cmd.CommandUUID)
+	require.NoError(t, err)
+
+	// refresh the host's status, it is wiped
+	s.DoJSON("GET", fmt.Sprintf("/api/latest/fleet/hosts/%d", host.ID), nil, http.StatusOK, &getHostResp)
+	require.NotNil(t, getHostResp.Host.MDM.DeviceStatus)
+	require.Equal(t, "wiped", *getHostResp.Host.MDM.DeviceStatus)
+	require.NotNil(t, getHostResp.Host.MDM.PendingAction)
+	require.Equal(t, "", *getHostResp.Host.MDM.PendingAction)
+
+	// try to wipe the host again, conflict (already wiped)
+	s.Do("POST", fmt.Sprintf("/api/latest/fleet/hosts/%d/wipe", host.ID), nil, http.StatusConflict)
+	// no activity created
+	s.lastActivityOfTypeMatches(fleet.ActivityTypeWipedHost{}.ActivityName(), fmt.Sprintf(`{"host_id": %d, "host_display_name": %q}`, host.ID, host.DisplayName()), wipeActID)
 }
 
 func (s *integrationMDMTestSuite) TestZCustomConfigurationWebURL() {

--- a/server/service/mdm.go
+++ b/server/service/mdm.go
@@ -545,24 +545,6 @@ func (svc *Service) enqueueAppleMDMCommand(ctx context.Context, rawXMLCmd []byte
 		return nil, ctxerr.Wrap(ctx, err, "decode plist command")
 	}
 
-	// TODO(mna): as per the story's spec:
-	//   Make macOS and Windows MDM, low-level lock command available for free
-	//   users. Remove validation where we check for Premium for custom MDM
-	//   commands that contain the lock command
-	//
-	// So we'd need to not only remove this validation to allow DeviceLock (and
-	// eventually EraseDevice for the Wipe story), but it needs to behave
-	// similarly to how the /lock endpoint would've:
-	//
-	// see https://fleetdm.slack.com/archives/C03C41L5YEL/p1707169116154199?thread_ts=1707162619.655219&cid=C03C41L5YEL
-	//   Regarding Free use of “lock” command as custom command, remove the validation but does that behave the same as if /lock had been used?
-	//				@Martin Angers
-	//				 that’s right.
-	//
-	// So it looks like we'd need to parse the command's XML to get the unlock
-	// PIN, and TBD how to behave if there is no PIN or if it's larger than
-	// supported.
-
 	if appleMDMPremiumCommands[strings.TrimSpace(cmd.Command.RequestType)] {
 		lic, err := svc.License(ctx)
 		if err != nil {
@@ -620,15 +602,6 @@ func (svc *Service) enqueueMicrosoftMDMCommand(ctx context.Context, rawXMLCmd []
 		err = fleet.NewInvalidArgumentError("command", err.Error())
 		return nil, ctxerr.Wrap(ctx, err, "decode SyncML command")
 	}
-
-	// TODO(mna): as per the story's spec:
-	//   Make macOS and Windows MDM, low-level lock command available for Free
-	//   users. Remove validation where we check for Premium for custom MDM
-	//   commands that contain the lock command
-	//
-	// However for Windows, it looks like we only prevent the RemoteWipe command,
-	// nothing for lock, so looks like nothing to do here for now (will need a
-	// change for the wipe command).
 
 	if cmdMsg.IsPremium() {
 		lic, err := svc.License(ctx)

--- a/server/service/scripts.go
+++ b/server/service/scripts.go
@@ -917,3 +917,34 @@ func (svc *Service) UnlockHost(ctx context.Context, hostID uint) (string, error)
 
 	return "", fleet.ErrMissingLicense
 }
+
+////////////////////////////////////////////////////////////////////////////////
+// Wipe host
+////////////////////////////////////////////////////////////////////////////////
+
+type wipeHostRequest struct {
+	HostID uint `url:"id"`
+}
+
+type wipeHostResponse struct {
+	Err error `json:"error,omitempty"`
+}
+
+func (r wipeHostResponse) Status() int  { return http.StatusNoContent }
+func (r wipeHostResponse) error() error { return r.Err }
+
+func wipeHostEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (errorer, error) {
+	req := request.(*wipeHostRequest)
+	if err := svc.WipeHost(ctx, req.HostID); err != nil {
+		return wipeHostResponse{Err: err}, nil
+	}
+	return wipeHostResponse{}, nil
+}
+
+func (svc *Service) WipeHost(ctx context.Context, hostID uint) error {
+	// skipauth: No authorization check needed due to implementation returning
+	// only license error.
+	svc.authz.SkipAuthorization(ctx)
+
+	return fleet.ErrMissingLicense
+}


### PR DESCRIPTION
#10488

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [x] Added/updated tests
