### PR TITLE
Website: Remove CTAs in older release articles

### DIFF
--- a/articles/fleet-4.26.0.md
+++ b/articles/fleet-4.26.0.md
@@ -48,8 +48,6 @@ You already have a lot of raw data to sift through in your data lake, especially
 
 Fleet 4.26.0 reduces the number of calls you have to make to pull software data with the REST API. Each time a host has software added, updated, or deleted, a `host_software_updated_at` timestamp gets updated for that host. The `host_software_updated_at` timestamp is exposed through the API. This lets you send the latest software data to your data lake, so you can avoid drowning in outdated information.
 
-<call-to-action preset="mdm-beta"></call-to-action>
-
 ## Fleet MDM
 **MDM features are not ready for production and are currently in development. These features are disabled by default.**
 

--- a/articles/fleet-4.27.0.md
+++ b/articles/fleet-4.27.0.md
@@ -21,8 +21,6 @@ In the UI an account administrator will see the following information:
 
 If you pair this new login activity with the audit improvements from [release 4.26](https://fleetdm.com/releases/fleet-4.26.0) you can now set up an alert if multiple failed login attempts occur. 
 
-<call-to-action preset="premium-upgrade"></call-to-action>
-
 ## Better search filters on the ‘Select Targets’ screen in Fleet
 
 **Available in Fleet Free and Fleet Premium**

--- a/articles/fleet-4.28.0.md
+++ b/articles/fleet-4.28.0.md
@@ -32,8 +32,6 @@ Premium and Ultimate Fleet plans have the ability to import the CIS benchmarks i
 
 For more information on adding CIS Benchmarks, check out the [documentation here](https://fleetdm.com/docs/using-fleet/cis-benchmarks#how-to-add-cis-benchmarks).
 
-<call-to-action preset="premium-upgrade"></call-to-action>
-
 ## Reduced false negatives from MS Office products related to vulnerabilities reported in the NVD
 
 A false negative occurs when a policy reports there is not a vulnerability, but there actually is a vulnerability. Even if a policy reports zero vulnerabilities, that does not imply there are no vulnerabilities present. Both of these types of errors can cause problems when trying to identify vulnerabilities that need attention.
@@ -68,8 +66,6 @@ For more information on enabling this functionality, check out the [documentati
 *   Added "edited macOS profiles" activity when updating a team's (or no team's) custom macOS settings via fleetctl apply.
 *   Enabled installation and auto-updates of Nudge via Orbit.
 *   Added support for providing macos\_settings.custom\_settings profiles for team (with Fleet Premium) and no-team levels via fleetctl apply.
-
-<call-to-action preset="mdm-beta"></call-to-action>
 
 #### List of other features
 

--- a/articles/fleet-4.29.0.md
+++ b/articles/fleet-4.29.0.md
@@ -27,8 +27,6 @@ Users created via JIT provisioning can be assigned Fleet roles using SAML custom
 
 Learn more about [JIT user role setting](https://fleetdm.com/docs/deploying/configuration#just-in-time-jit-user-provisioning).
 
-<call-to-action preset="premium-upgrade"></call-to-action>
-
 ## CIS benchmarks manual intervention
 
 _Available in Fleet Premium and Fleet Ultimate_
@@ -64,8 +62,6 @@ Fleet updated translation rules to provide better 🟢 Results and avoid false p
 * Adjusted the `aggregated_stats` table to compute and store statistics for "no team" in addition to per-team and for all teams.
 * Added MDM profiles status filter to hosts endpoints.
 * Added indicators of aggregate host count for each possible status of MDM-enforced mac settings (hidden until 4.30.0).
-
-<call-to-action preset="mdm-beta"></call-to-action>
 
 #### List of other features
 

--- a/articles/using-fleet-and-tines-together.md
+++ b/articles/using-fleet-and-tines-together.md
@@ -74,8 +74,6 @@ The final email with the above definition looks like this:
 
 The Fleet API is very flexible, but with the addition of Tines, the options for data transformation are endless. In the above example, we easily connected to the Fleet API and transformed the data response with a single Tines Transform function, and allowed the end user to receive a customized report of vulnerable software on an individual host.
 
-<call-to-action preset="premium-upgrade"></call-to-action>
-
 <meta name="category" value="guides">
 <meta name="authorFullName" value="Dave Herder">
 <meta name="authorGitHubUsername" value="dherder">

--- a/website/assets/js/components/call-to-action.component.js
+++ b/website/assets/js/components/call-to-action.component.js
@@ -19,7 +19,6 @@ parasails.registerComponent('callToAction', {
     'primaryButtonHref', // Required: the url that the call to action button leads
     'secondaryButtonText', // Optional: if provided with a `secondaryButtonHref`, a second button will be added to the call to action with this value as the button text
     'secondaryButtonHref', // Optional: if provided with a `secondaryButtonText`, a second button will be added to the call to action with this value as the href
-    'preset',// Optional: if provided, all other values will be ignored, and this component will display a specified varient, can be set to 'premium-upgrade' or 'mdm-beta'.
   ],
 
   //  ╦╔╗╔╦╔╦╗╦╔═╗╦    ╔═╗╔╦╗╔═╗╔╦╗╔═╗
@@ -50,7 +49,7 @@ parasails.registerComponent('callToAction', {
   //  ╩ ╩ ╩ ╩ ╩╩═╝
   template: `
   <div id="cta-component">
-    <div v-if="!callToActionPreset" purpose="custom-cta">
+    <div purpose="custom-cta">
       <div purpose="custom-cta-content" class="text-white text-center">
         <div purpose="custom-cta-title">{{callToActionTitle}}</div>
         <div purpose="custom-cta-text">{{callToActionText}}</div>
@@ -60,32 +59,6 @@ parasails.registerComponent('callToAction', {
         <span class="d-flex" v-if="secondaryButtonHref && secondaryButtonText">
           <a purpose="secondary-button" class="btn btn-lg text-white btn-white mr-2 pl-0 mx-auto mx-sm-0 mt-2 mt-sm-0" target="_blank" :href="calltoActionSecondaryBtnHref">{{calltoActionSecondaryBtnText}}</a>
         </span>
-      </div>
-    </div>
-    <div v-else>
-      <div v-if="callToActionPreset === 'premium-upgrade'" purpose="fleet-premium-cta" class="d-flex flex-column flex-sm-row align-items-center justify-content-center">
-        <div class="order-2 order-sm-1 justify-content-center" purpose="premium-cta-text">
-          <h2>Get even more control <br>with <span>Fleet Premium</span></h2>
-          <a style="color: #fff; text-decoration: none;" purpose="premium-cta-btn" href="/upgrade">Learn more</a>
-        </div>
-        <div class="order-1 order-sm-2" purpose="premium-cta-image">
-          <img alt="A computer reporting it's disk encryption status" src="/images/premium-landing-feature-4.svg">
-        </div>
-      </div>
-      <div v-else-if="callToActionPreset === 'mdm-beta'" purpose="mdm-beta-cta-container">
-        <div purpose="mdm-beta-cta-background">
-          <div purpose="mdm-beta-cta" class="d-flex flex-column flex-sm-row">
-            <div purpose="mdm-small-banner" class="d-flex d-sm-none">
-              <img class="p-0" alt="Fleet city (on a cloud)" src="/images/banner-small-fleet-city-327x257@2x.png">
-            </div>
-            <div purpose="mdm-cta-text">
-              <span purpose="mdm-cta-subtitle">Limited beta</span>
-              <span purpose="mdm-cta-title">A better MDM</span>
-              <span>Fleet’s cross-platform MDM gives IT teams more visibility out of the box.</span>
-              <a style="color: #fff; text-decoration: none;" purpose="mdm-cta-btn" href="/device-management">Request access</a>
-            </div>
-          </div>
-        </div>
       </div>
     </div>
   </div>
@@ -98,39 +71,31 @@ parasails.registerComponent('callToAction', {
 
   },
   mounted: async function() {
-    if(this.preset){
-      if(_.contains(['premium-upgrade', 'mdm-beta'], this.preset)){
-        this.callToActionPreset = this.preset;
-      } else {
-        throw new Error('Incomplete usage of <call-to-action>: If providing a type, it must be either \'premium-upgrade\' or \'mdm-beta\'');
-      }
+    if (this.title) {
+      this.callToActionTitle = this.title;
     } else {
-      if (this.title) {
-        this.callToActionTitle = this.title;
-      } else {
-        throw new Error('Incomplete usage of <call-to-action>: Please provide a `title` example: title="Secure laptops & servers"');
-      }
-      if (this.text) {
-        this.callToActionText = this.text;
-      } else {
-        throw new Error('Incomplete usage of <call-to-action>: Please provide a `text` example: text="Get up and running with a test environment of Fleet within minutes"');
-      }
-      if (this.primaryButtonText) {
-        this.calltoActionPrimaryBtnText = this.primaryButtonText;
-      } else {
-        throw new Error('Incomplete usage of <call-to-action>: Please provide a `primaryButtonText`. example: primary-button-text="Get started"');
-      }
-      if (this.primaryButtonHref) {
-        this.calltoActionPrimaryBtnHref = this.primaryButtonHref;
-      } else {
-        throw new Error('Incomplete usage of <call-to-action>: Please provide a `primaryButtonHref` example: primary-button-href="/get-started?try-it-now"');
-      }
-      if (this.secondaryButtonText) {
-        this.calltoActionSecondaryBtnText = this.secondaryButtonText;
-      }
-      if (this.secondaryButtonHref) {
-        this.calltoActionSecondaryBtnHref = this.secondaryButtonHref;
-      }
+      throw new Error('Incomplete usage of <call-to-action>: Please provide a `title` example: title="Secure laptops & servers"');
+    }
+    if (this.text) {
+      this.callToActionText = this.text;
+    } else {
+      throw new Error('Incomplete usage of <call-to-action>: Please provide a `text` example: text="Get up and running with a test environment of Fleet within minutes"');
+    }
+    if (this.primaryButtonText) {
+      this.calltoActionPrimaryBtnText = this.primaryButtonText;
+    } else {
+      throw new Error('Incomplete usage of <call-to-action>: Please provide a `primaryButtonText`. example: primary-button-text="Get started"');
+    }
+    if (this.primaryButtonHref) {
+      this.calltoActionPrimaryBtnHref = this.primaryButtonHref;
+    } else {
+      throw new Error('Incomplete usage of <call-to-action>: Please provide a `primaryButtonHref` example: primary-button-href="/get-started?try-it-now"');
+    }
+    if (this.secondaryButtonText) {
+      this.calltoActionSecondaryBtnText = this.secondaryButtonText;
+    }
+    if (this.secondaryButtonHref) {
+      this.calltoActionSecondaryBtnHref = this.secondaryButtonHref;
     }
   },
   watch: {


### PR DESCRIPTION
Related to: https://github.com/fleetdm/fleet/issues/16903

Changes:
- Removed CTAs for the Fleet premium upgrade page in articles
- Removed CTAs for the MDM beta in articles
- removed the presets for those CTAs in the `<call-to-action>` component 