### PR TITLE
[tiny released bug] Fleet UI: Fix live query/policy host search icon

### DIFF
--- a/changes/16608-search-target-icon
+++ b/changes/16608-search-target-icon
@@ -1,0 +1,1 @@
+- Fix position of live query/poilcy host search icon

--- a/frontend/components/LiveQuery/TargetsInput/TargetsInput.tsx
+++ b/frontend/components/LiveQuery/TargetsInput/TargetsInput.tsx
@@ -7,7 +7,7 @@ import { HOSTS_SEARCH_BOX_PLACEHOLDER } from "utilities/constants";
 
 import DataError from "components/DataError";
 // @ts-ignore
-import Input from "components/forms/fields/InputFieldWithIcon";
+import InputFieldWithIcon from "components/forms/fields/InputFieldWithIcon/InputFieldWithIcon";
 import TableContainer from "components/TableContainer";
 import { generateTableHeaders } from "./TargetsInputHostsTableConfig";
 
@@ -47,7 +47,7 @@ const TargetsInput = ({
   return (
     <div>
       <div className={baseClass}>
-        <Input
+        <InputFieldWithIcon
           autofocus
           type="search"
           iconSvg="search"

--- a/frontend/components/LiveQuery/TargetsInput/_styles.scss
+++ b/frontend/components/LiveQuery/TargetsInput/_styles.scss
@@ -94,7 +94,4 @@
       overflow: auto;
     }
   }
-  .input-icon-field__icon {
-    top: 34px; // Override styling to include label header
-  }
 }

--- a/frontend/components/TableContainer/DataTable/DefaultColumnFilter/_styles.scss
+++ b/frontend/components/TableContainer/DataTable/DefaultColumnFilter/_styles.scss
@@ -1,4 +1,8 @@
 .filter-cell {
+  .input-icon-field__input-wrapper {
+    margin-top: $pad-xsmall;
+  }
+
   input {
     height: 40px;
     width: 100%;
@@ -8,7 +12,6 @@
     border-radius: 4px;
     padding: 4px;
     padding-left: 32px;
-    margin-top: $pad-xsmall;
   }
 
   .search-field__input-wrapper {
@@ -18,9 +21,6 @@
   }
 
   .icon {
-    left: 10px;
-    top: 17px;
-
     path {
       fill: $ui-fleet-black-33; // Override input icon color
     }

--- a/frontend/components/forms/fields/InputFieldWithIcon/InputFieldWithIcon.jsx
+++ b/frontend/components/forms/fields/InputFieldWithIcon/InputFieldWithIcon.jsx
@@ -114,25 +114,27 @@ class InputFieldWithIcon extends InputField {
     return (
       <div className={wrapperClasses}>
         {this.props.label && this.renderHeading()}
-        <input
-          id={name}
-          name={name}
-          onChange={onInputChange}
-          onClick={onClick}
-          className={inputClasses}
-          placeholder={placeholder}
-          ref={(r) => {
-            this.input = r;
-          }}
-          tabIndex={tabIndex}
-          type={type}
-          value={value}
-          disabled={disabled}
-          {...inputOptions}
-          data-1p-ignore={ignore1Password}
-        />
-        {iconSvg && <Icon name={iconSvg} className={iconClasses} />}
-        {iconName && <FleetIcon name={iconName} className={iconClasses} />}
+        <div className={`${baseClass}__input-wrapper`}>
+          <input
+            id={name}
+            name={name}
+            onChange={onInputChange}
+            onClick={onClick}
+            className={inputClasses}
+            placeholder={placeholder}
+            ref={(r) => {
+              this.input = r;
+            }}
+            tabIndex={tabIndex}
+            type={type}
+            value={value}
+            disabled={disabled}
+            {...inputOptions}
+            data-1p-ignore={ignore1Password}
+          />
+          {iconSvg && <Icon name={iconSvg} className={iconClasses} />}
+          {iconName && <FleetIcon name={iconName} className={iconClasses} />}
+        </div>
         {renderHelpText()}
       </div>
     );

--- a/frontend/components/forms/fields/InputFieldWithIcon/_styles.scss
+++ b/frontend/components/forms/fields/InputFieldWithIcon/_styles.scss
@@ -90,6 +90,11 @@
     &[data-has-tooltip="true"] {
       margin-bottom: $pad-small;
     }
+
+    // Overrides icon location only when a label exists e.g. TargetsInput.tsx
+    ~ .input-icon-field__icon {
+      top: 40px;
+    }
   }
 
   &__errors {

--- a/frontend/components/forms/fields/InputFieldWithIcon/_styles.scss
+++ b/frontend/components/forms/fields/InputFieldWithIcon/_styles.scss
@@ -18,6 +18,14 @@
     }
   }
 
+  // Relative input wrapper with absolute icon corrects icon alignment on all browsers
+  &__input-wrapper {
+    position: relative;
+    height: 40px;
+    display: flex;
+    align-items: center;
+  }
+
   // Refactor to include svg icons
   &--icon-start {
     margin-top: 0;
@@ -25,10 +33,11 @@
     .input-icon-field__icon {
       position: absolute;
       left: 12px;
-      top: 13px;
+      top: 0;
+      height: 40px;
       width: 16px;
-      font-size: $x-small;
-      color: $core-fleet-blue;
+      flex-wrap: wrap;
+      align-content: center;
       z-index: 1;
     }
   }
@@ -51,20 +60,6 @@
       color: $core-fleet-blue;
     }
 
-    &:hover,
-    &:focus {
-      border: 1px solid $core-vibrant-blue;
-
-      // Icon color matches border color on focus and on hover
-      + .input-icon-field__icon {
-        svg {
-          path {
-            fill: $core-vibrant-blue;
-          }
-        }
-      }
-    }
-
     &:focus {
       outline: none;
     }
@@ -82,6 +77,33 @@
     }
   }
 
+  &__input-wrapper:hover {
+    .input-icon-field__input {
+      border: 1px solid $core-vibrant-blue;
+    }
+
+    // Icon color matches border color on focus and on hover
+    .input-icon-field__icon {
+      svg {
+        path {
+          fill: $core-vibrant-blue;
+        }
+      }
+    }
+  }
+
+  .input-icon-field__input:focus {
+    border: 1px solid $core-vibrant-blue;
+
+    // Icon color matches border color on focus and on hover
+    + .input-icon-field__icon {
+      svg {
+        path {
+          fill: $core-vibrant-blue;
+        }
+      }
+    }
+  }
   &__label {
     display: block;
     font-size: $x-small;
@@ -89,11 +111,6 @@
 
     &[data-has-tooltip="true"] {
       margin-bottom: $pad-small;
-    }
-
-    // Overrides icon location only when a label exists e.g. TargetsInput.tsx
-    ~ .input-icon-field__icon {
-      top: 40px;
     }
   }
 


### PR DESCRIPTION
## Issue
Cerra #16608 

## Description
- Fix search icon bug
- Move CSS into `InputFieldWithIcon`
- Use `InputFieldWithIcon`
- Wrap input field part with a parent wrapper positioned relative and the child icon with in it as position absolute.
- Use display flex, align items center to position any height icon (e.g. caret/email envelope is a smaller height than a magnifying glass)
- Only reposition icon if label exists as icon is being pushed by the label

## Screen recording
https://www.loom.com/share/a6f527349b6f4632a1a9ce3913a9ad5f?sid=86166c00-d0f5-4198-a6af-abfde8132766

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
- [x] Manual QA for all new/changed functionality

