### PR TITLE
Orbit to detect 5XX alongside network errors

### DIFF
--- a/orbit/cmd/orbit/orbit.go
+++ b/orbit/cmd/orbit/orbit.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
-	"net"
 	"net/url"
 	"os"
 	"os/exec"
@@ -783,8 +782,13 @@ func main() {
 			enrollSecret,
 			fleetClientCertificate,
 			orbitHostInfo,
-			func(err net.Error) {
-				log.Info().Err(err).Msg("network error")
+			&service.OnGetConfigErrFuncs{
+				DebugErrFunc: func(err error) {
+					log.Debug().Err(err).Msg("get config")
+				},
+				OnNetErrFunc: func(err error) {
+					log.Info().Err(err).Msg("network error")
+				},
 			},
 		)
 		if err != nil {
@@ -1058,8 +1062,13 @@ func main() {
 			enrollSecret,
 			fleetClientCertificate,
 			orbitHostInfo,
-			func(err net.Error) {
-				log.Info().Err(err).Msg("network error")
+			&service.OnGetConfigErrFuncs{
+				DebugErrFunc: func(err error) {
+					log.Debug().Err(err).Msg("get config")
+				},
+				OnNetErrFunc: func(err error) {
+					log.Info().Err(err).Msg("network error")
+				},
 			},
 		)
 		if err != nil {

--- a/server/service/base_client.go
+++ b/server/service/base_client.go
@@ -58,7 +58,7 @@ func (bc *baseClient) parseResponse(verb, path string, response *http.Response, 
 			code: response.StatusCode,
 			body: extractServerErrorText(response.Body),
 		}
-		return fmt.Errorf("%s %s received status %w", verb, path, e)
+		return fmt.Errorf("%s %s received status: %w", verb, path, e)
 	}
 
 	bc.setServerCapabilities(response)

--- a/server/service/base_client.go
+++ b/server/service/base_client.go
@@ -58,7 +58,7 @@ func (bc *baseClient) parseResponse(verb, path string, response *http.Response, 
 			code: response.StatusCode,
 			body: extractServerErrorText(response.Body),
 		}
-		return fmt.Errorf("%s %s received status: %w", verb, path, e)
+		return fmt.Errorf("%s %s received status %w", verb, path, e)
 	}
 
 	bc.setServerCapabilities(response)

--- a/tools/tuf/test/README.md
+++ b/tools/tuf/test/README.md
@@ -35,6 +35,7 @@ GENERATE_MSI=1 \
 ENROLL_SECRET=6/EzU/+jPkxfTamWnRv1+IJsO4T9Etju \
 FLEET_DESKTOP=1 \
 USE_FLEET_SERVER_CERTIFICATE=1 \
+DEBUG=1 \
 ./tools/tuf/test/main.sh
 ```
 

--- a/tools/tuf/test/gen_pkgs.sh
+++ b/tools/tuf/test/gen_pkgs.sh
@@ -29,6 +29,7 @@ set -ex
 # USE_FLEET_SERVER_CERTIFICATE: Whether to use a custom certificate bundle.
 # USE_UPDATE_SERVER_CERTIFICATE: Whether to use a custom certificate bundle.
 # FLEET_DESKTOP_ALTERNATIVE_BROWSER_HOST: Alternative host:port to use for the Fleet Desktop browser URLs.
+# DEBUG: Whether or not to build the package with --debug.
 
 if [ -n "$GENERATE_PKG" ]; then
     echo "Generating pkg..."
@@ -40,7 +41,7 @@ if [ -n "$GENERATE_PKG" ]; then
         ${USE_FLEET_SERVER_CERTIFICATE:+--fleet-certificate=./tools/osquery/fleet.crt} \
         ${USE_UPDATE_SERVER_CERTIFICATE:+--update-tls-certificate=./tools/osquery/fleet.crt} \
         ${INSECURE:+--insecure} \
-        --debug \
+        ${DEBUG:+--debug} \
         --update-roots="$ROOT_KEYS" \
         --update-interval=10s \
         --disable-open-folder \
@@ -64,7 +65,7 @@ if [ -n "$GENERATE_DEB" ]; then
         ${USE_FLEET_SERVER_CERTIFICATE:+--fleet-certificate=./tools/osquery/fleet.crt} \
         ${USE_UPDATE_SERVER_CERTIFICATE:+--update-tls-certificate=./tools/osquery/fleet.crt} \
         ${INSECURE:+--insecure} \
-        --debug \
+        ${DEBUG:+--debug} \
         --update-roots="$ROOT_KEYS" \
         --update-interval=10s \
         --disable-open-folder \
@@ -87,7 +88,7 @@ if [ -n "$GENERATE_RPM" ]; then
         ${USE_FLEET_SERVER_CERTIFICATE:+--fleet-certificate=./tools/osquery/fleet.crt} \
         ${USE_UPDATE_SERVER_CERTIFICATE:+--update-tls-certificate=./tools/osquery/fleet.crt} \
         ${INSECURE:+--insecure} \
-        --debug \
+        ${DEBUG:+--debug} \
         --update-roots="$ROOT_KEYS" \
         --update-interval=10s \
         --disable-open-folder \
@@ -110,7 +111,7 @@ if [ -n "$GENERATE_MSI" ]; then
         ${USE_FLEET_SERVER_CERTIFICATE:+--fleet-certificate=./tools/osquery/fleet.crt} \
         ${USE_UPDATE_SERVER_CERTIFICATE:+--update-tls-certificate=./tools/osquery/fleet.crt} \
         ${INSECURE:+--insecure} \
-        --debug \
+        ${DEBUG:+--debug} \
         --update-roots="$ROOT_KEYS" \
         --update-interval=10s \
         --disable-open-folder \


### PR DESCRIPTION
#16423, #16326 

On the [original PR](https://github.com/fleetdm/fleet/pull/16968) we missed detecting 5XX errors. Fleet usually runs behind load balancers, so when bringing Fleet down, orbit connects successfully but gets 5XX errors, so we need to detect those too.