### PR TITLE
UI – Refactor edit query > name and description fields to allow reasonable control of pencil icons

### DIFF
--- a/changes/16663-pencil-icon-alignment
+++ b/changes/16663-pencil-icon-alignment
@@ -1,0 +1,2 @@
+- Fix a bug where the pencil icons next to the edit query name and description fields were
+  inconsistently spaced.

--- a/frontend/components/forms/fields/AutoSizeInputField/AutoSizeInputField.stories.tsx
+++ b/frontend/components/forms/fields/AutoSizeInputField/AutoSizeInputField.stories.tsx
@@ -11,7 +11,7 @@ interface IAutoSizeInputFieldProps {
   placeholder: string;
   value: string;
   inputClassName?: string;
-  maxLength: string;
+  maxLength: number;
   hasError?: boolean;
   isDisabled?: boolean;
   isFocused?: boolean;
@@ -36,7 +36,7 @@ export default {
     placeholder: "Type here...",
     type: "",
     value: "",
-    maxLength: "250",
+    maxLength: 250,
     onFocus: noop,
     onChange: noop,
     onKeyPress: noop,

--- a/frontend/components/forms/fields/AutoSizeInputField/AutoSizeInputField.tsx
+++ b/frontend/components/forms/fields/AutoSizeInputField/AutoSizeInputField.tsx
@@ -44,6 +44,7 @@ const AutoSizeInputField = ({
     [`${baseClass}--disabled`]: isDisabled,
     [`${baseClass}--error`]: hasError,
     [`${baseClass}__textarea`]: true,
+    "no-value": !inputValue,
   });
 
   const inputElement = useRef<any>(null);

--- a/frontend/components/forms/fields/AutoSizeInputField/AutoSizeInputField.tsx
+++ b/frontend/components/forms/fields/AutoSizeInputField/AutoSizeInputField.tsx
@@ -16,8 +16,8 @@ interface IAutoSizeInputFieldProps {
   hasError?: boolean;
   isDisabled?: boolean;
   isFocused?: boolean;
-  onFocus: () => void;
-  onBlur: () => void;
+  onFocus?: () => void;
+  onBlur?: () => void;
   onChange: (newSelectedValue: string) => void;
   onKeyPress: (event: KeyboardEvent<HTMLTextAreaElement>) => void;
 }
@@ -33,8 +33,8 @@ const AutoSizeInputField = ({
   hasError,
   isDisabled,
   isFocused,
-  onFocus,
-  onBlur,
+  onFocus = () => null,
+  onBlur = () => null,
   onChange,
   onKeyPress,
 }: IAutoSizeInputFieldProps): JSX.Element => {
@@ -91,7 +91,6 @@ const AutoSizeInputField = ({
           className={inputClasses}
           cols={value ? value.length : placeholder.length - 2}
           rows={1}
-          tabIndex={0}
           onFocus={onInputFocus}
           onBlur={onInputBlur}
           onKeyPress={onInputKeyPress}

--- a/frontend/components/forms/fields/AutoSizeInputField/AutoSizeInputField.tsx
+++ b/frontend/components/forms/fields/AutoSizeInputField/AutoSizeInputField.tsx
@@ -12,7 +12,7 @@ interface IAutoSizeInputFieldProps {
   placeholder: string;
   value: string;
   inputClassName?: string;
-  maxLength: string;
+  maxLength: number;
   hasError?: boolean;
   isDisabled?: boolean;
   isFocused?: boolean;
@@ -87,7 +87,7 @@ const AutoSizeInputField = ({
           onChange={onInputChange}
           placeholder={placeholder}
           value={inputValue}
-          maxLength={parseInt(maxLength, 10)}
+          maxLength={maxLength}
           className={inputClasses}
           cols={value ? value.length : placeholder.length - 2}
           rows={1}

--- a/frontend/components/forms/fields/AutoSizeInputField/_styles.scss
+++ b/frontend/components/forms/fields/AutoSizeInputField/_styles.scss
@@ -1,6 +1,7 @@
 .component__auto-size-input-field {
   box-sizing: border-box;
   color: $core-fleet-black;
+  width: fit-content;
 
   &::placeholder {
     color: $ui-fleet-black-50;

--- a/frontend/components/forms/fields/AutoSizeInputField/_styles.scss
+++ b/frontend/components/forms/fields/AutoSizeInputField/_styles.scss
@@ -20,6 +20,7 @@
     &::after,
     input,
     textarea {
+      white-space: pre-wrap;
       width: auto;
       max-width: 100%;
       grid-area: 1 / 2;

--- a/frontend/components/forms/fields/AutoSizeInputField/_styles.scss
+++ b/frontend/components/forms/fields/AutoSizeInputField/_styles.scss
@@ -1,7 +1,6 @@
 .component__auto-size-input-field {
   box-sizing: border-box;
   color: $core-fleet-black;
-  width: fit-content;
 
   &::placeholder {
     color: $ui-fleet-black-50;
@@ -22,6 +21,7 @@
     input,
     textarea {
       width: auto;
+      max-width: 100%;
       grid-area: 1 / 2;
       resize: none;
       background: none;

--- a/frontend/components/forms/fields/AutoSizeInputField/_styles.scss
+++ b/frontend/components/forms/fields/AutoSizeInputField/_styles.scss
@@ -3,7 +3,7 @@
   color: $core-fleet-black;
 
   &::placeholder {
-    color: $ui-fleet-black-50;
+    @include placeholder;
   }
 
   &:focus {

--- a/frontend/pages/policies/PolicyPage/components/PolicyForm/PolicyForm.tsx
+++ b/frontend/pages/policies/PolicyPage/components/PolicyForm/PolicyForm.tsx
@@ -327,7 +327,7 @@ const PolicyForm = ({
               value={lastEditedQueryName}
               hasError={errors && errors.name}
               inputClassName={`${baseClass}__policy-name`}
-              maxLength="160"
+              maxLength={160}
               onChange={setLastEditedQueryName}
               onFocus={() => setIsEditingName(true)}
               onBlur={() => setIsEditingName(false)}
@@ -368,7 +368,7 @@ const PolicyForm = ({
               placeholder="Add description here."
               value={lastEditedQueryDescription}
               inputClassName={`${baseClass}__policy-description`}
-              maxLength="250"
+              maxLength={250}
               onChange={setLastEditedQueryDescription}
               onFocus={() => setIsEditingDescription(true)}
               onBlur={() => setIsEditingDescription(false)}
@@ -404,7 +404,7 @@ const PolicyForm = ({
               placeholder="Add resolution here."
               value={lastEditedQueryResolution}
               inputClassName={`${baseClass}__policy-resolution`}
-              maxLength="500"
+              maxLength={500}
               onChange={setLastEditedQueryResolution}
               onFocus={() => setIsEditingResolution(true)}
               onBlur={() => setIsEditingResolution(false)}

--- a/frontend/pages/queries/edit/components/EditQueryForm/EditQueryForm.tsx
+++ b/frontend/pages/queries/edit/components/EditQueryForm/EditQueryForm.tsx
@@ -481,8 +481,8 @@ const EditQueryForm = ({
   const renderName = () => {
     if (savedQueryMode) {
       return (
-        <>
-          <div className={queryNameClasses}>
+        <div className={queryNameClasses}>
+          {isEditingName ? (
             <AutoSizeInputField
               name="query-name"
               placeholder="Add name here"
@@ -496,18 +496,22 @@ const EditQueryForm = ({
               onKeyPress={onInputKeypress}
               isFocused={isEditingName}
             />
-            <Button
-              variant="text-icon"
-              className="edit-link"
-              onClick={() => setIsEditingName(true)}
-            >
-              <Icon
-                name="pencil"
-                className={`edit-icon ${isEditingName ? "hide" : ""}`}
-              />
-            </Button>
-          </div>
-        </>
+          ) : (
+            <span className={`${baseClass}__query-name`}>
+              {lastEditedQueryName}
+            </span>
+          )}
+          <Button
+            variant="text-icon"
+            className="edit-link"
+            onClick={() => setIsEditingName(true)}
+          >
+            <Icon
+              name="pencil"
+              className={`edit-icon ${isEditingName ? "hide" : ""}`}
+            />
+          </Button>
+        </div>
       );
     }
 
@@ -517,8 +521,8 @@ const EditQueryForm = ({
   const renderDescription = () => {
     if (savedQueryMode) {
       return (
-        <>
-          <div className={queryDescriptionClasses}>
+        <div className={queryDescriptionClasses}>
+          {isEditingDescription ? (
             <AutoSizeInputField
               name="query-description"
               placeholder="Add description here."
@@ -531,18 +535,22 @@ const EditQueryForm = ({
               onKeyPress={onInputKeypress}
               isFocused={isEditingDescription}
             />
-            <Button
-              variant="text-icon"
-              className="edit-link"
-              onClick={() => setIsEditingDescription(true)}
-            >
-              <Icon
-                name="pencil"
-                className={`edit-icon ${isEditingDescription ? "hide" : ""}`}
-              />
-            </Button>
-          </div>
-        </>
+          ) : (
+            <span className={`${baseClass}__query-description`}>
+              {lastEditedQueryDescription}
+            </span>
+          )}
+          <Button
+            variant="text-icon"
+            className="edit-link"
+            onClick={() => setIsEditingDescription(true)}
+          >
+            <Icon
+              name="pencil"
+              className={`edit-icon ${isEditingDescription ? "hide" : ""}`}
+            />
+          </Button>
+        </div>
       );
     }
     return null;

--- a/frontend/pages/queries/edit/components/EditQueryForm/EditQueryForm.tsx
+++ b/frontend/pages/queries/edit/components/EditQueryForm/EditQueryForm.tsx
@@ -470,47 +470,60 @@ const EditQueryForm = ({
     return platformCompatibility.render();
   };
 
-  const queryNameClasses = classnames("query-name-wrapper", {
-    [`${baseClass}--editing`]: isEditingName,
-  });
+  const queryNameClasses = classnames(
+    `${baseClass}__query-name`,
+    "query-name-wrapper",
+    {
+      [`${baseClass}--editing`]: isEditingName,
+    }
+  );
 
   const queryDescriptionClasses = classnames("query-description-wrapper", {
     [`${baseClass}--editing`]: isEditingDescription,
   });
 
+  const editName = () => {
+    if (!isEditingName) {
+      setIsEditingName(true);
+    }
+  };
+
   const renderName = () => {
     if (savedQueryMode) {
       return (
-        <div className={queryNameClasses}>
+        <div className="query-name-wrapper">
           {isEditingName ? (
             <AutoSizeInputField
               name="query-name"
               placeholder="Add name here"
               value={lastEditedQueryName}
-              inputClassName={`${baseClass}__query-name`}
+              inputClassName={queryNameClasses}
               maxLength="160"
               hasError={errors && errors.name}
               onChange={setLastEditedQueryName}
-              onFocus={() => setIsEditingName(true)}
-              onBlur={() => setIsEditingName(false)}
               onKeyPress={onInputKeypress}
               isFocused={isEditingName}
+              onBlur={() => {
+                setIsEditingName(false);
+              }}
             />
           ) : (
-            <span className={`${baseClass}__query-name`}>
-              {lastEditedQueryName}
-            </span>
+            <div
+              className={queryNameClasses}
+              onClick={editName}
+              onFocus={editName}
+            >
+              <span className={`${baseClass}__query-name`}>
+                {lastEditedQueryName}
+              </span>
+              <Button variant="text-icon" className="edit-link">
+                <Icon
+                  name="pencil"
+                  className={`edit-icon ${isEditingName ? "hide" : ""}`}
+                />
+              </Button>
+            </div>
           )}
-          <Button
-            variant="text-icon"
-            className="edit-link"
-            onClick={() => setIsEditingName(true)}
-          >
-            <Icon
-              name="pencil"
-              className={`edit-icon ${isEditingName ? "hide" : ""}`}
-            />
-          </Button>
         </div>
       );
     }

--- a/frontend/pages/queries/edit/components/EditQueryForm/EditQueryForm.tsx
+++ b/frontend/pages/queries/edit/components/EditQueryForm/EditQueryForm.tsx
@@ -478,9 +478,13 @@ const EditQueryForm = ({
     }
   );
 
-  const queryDescriptionClasses = classnames("query-description-wrapper", {
-    [`${baseClass}--editing`]: isEditingDescription,
-  });
+  const queryDescriptionClasses = classnames(
+    "query-description-wrapper",
+    `${baseClass}__query-description`,
+    {
+      [`${baseClass}--editing`]: isEditingDescription,
+    }
+  );
 
   const editName = () => {
     if (!isEditingName) {
@@ -517,10 +521,7 @@ const EditQueryForm = ({
                 {lastEditedQueryName}
               </span>
               <Button variant="text-icon" className="edit-link">
-                <Icon
-                  name="pencil"
-                  className={`edit-icon ${isEditingName ? "hide" : ""}`}
-                />
+                <Icon name="pencil" className="edit-icon" />
               </Button>
             </div>
           )}
@@ -531,10 +532,16 @@ const EditQueryForm = ({
     return <h1 className={`${baseClass}__query-name no-hover`}>New query</h1>;
   };
 
+  const editDescription = () => {
+    if (!isEditingDescription) {
+      setIsEditingDescription(true);
+    }
+  };
+
   const renderDescription = () => {
     if (savedQueryMode) {
       return (
-        <div className={queryDescriptionClasses}>
+        <div className="query-description-wrapper">
           {isEditingDescription ? (
             <AutoSizeInputField
               name="query-description"
@@ -549,20 +556,19 @@ const EditQueryForm = ({
               isFocused={isEditingDescription}
             />
           ) : (
-            <span className={`${baseClass}__query-description`}>
-              {lastEditedQueryDescription}
-            </span>
+            <div
+              className={queryDescriptionClasses}
+              onClick={editDescription}
+              onFocus={editDescription}
+            >
+              <span className={`${baseClass}__query-description`}>
+                {lastEditedQueryDescription}
+              </span>
+              <Button variant="text-icon" className="edit-link">
+                <Icon name="pencil" className="edit-icon" />
+              </Button>
+            </div>
           )}
-          <Button
-            variant="text-icon"
-            className="edit-link"
-            onClick={() => setIsEditingDescription(true)}
-          >
-            <Icon
-              name="pencil"
-              className={`edit-icon ${isEditingDescription ? "hide" : ""}`}
-            />
-          </Button>
         </div>
       );
     }

--- a/frontend/pages/queries/edit/components/EditQueryForm/EditQueryForm.tsx
+++ b/frontend/pages/queries/edit/components/EditQueryForm/EditQueryForm.tsx
@@ -502,7 +502,7 @@ const EditQueryForm = ({
               placeholder="Add name here"
               value={lastEditedQueryName}
               inputClassName={queryNameClasses}
-              maxLength="160"
+              maxLength={160}
               hasError={errors && errors.name}
               onChange={setLastEditedQueryName}
               onKeyPress={onInputKeypress}
@@ -547,7 +547,7 @@ const EditQueryForm = ({
               name="query-description"
               placeholder="Add description here."
               value={lastEditedQueryDescription}
-              maxLength="250"
+              maxLength={250}
               inputClassName={`${baseClass}__query-description`}
               onChange={setLastEditedQueryDescription}
               onFocus={() => setIsEditingDescription(true)}
@@ -564,11 +564,14 @@ const EditQueryForm = ({
               <span className={`${baseClass}__query-description`}>
                 {lastEditedQueryDescription}
               </span>
-              <Button variant="text-icon" className="edit-link">
-                <Icon name="pencil" className="edit-icon" />
-              </Button>
             </div>
           )}
+          <Button variant="text-icon" className="edit-link">
+            <Icon
+              name="pencil"
+              className={`edit-icon ${isEditingDescription ? "hide" : ""}`}
+            />
+          </Button>
         </div>
       );
     }

--- a/frontend/pages/queries/edit/components/EditQueryForm/EditQueryForm.tsx
+++ b/frontend/pages/queries/edit/components/EditQueryForm/EditQueryForm.tsx
@@ -476,10 +476,14 @@ const EditQueryForm = ({
     }
   };
 
+  const queryNameWrapperClasses = classnames("query-name-wrapper", {
+    "query-name-wrapper__editing": isEditingName,
+  });
+
   const renderName = () => {
     if (savedQueryMode) {
       return (
-        <div className="query-name-wrapper">
+        <div className={queryNameWrapperClasses}>
           {isEditingName ? (
             <>
               <AutoSizeInputField

--- a/frontend/pages/queries/edit/components/EditQueryForm/EditQueryForm.tsx
+++ b/frontend/pages/queries/edit/components/EditQueryForm/EditQueryForm.tsx
@@ -470,13 +470,9 @@ const EditQueryForm = ({
     return platformCompatibility.render();
   };
 
-  const queryNameClasses = classnames(
-    `${baseClass}__query-name`,
-    "query-name-wrapper",
-    {
-      [`${baseClass}--editing`]: isEditingName,
-    }
-  );
+  // const queryNameClasses = classnames(, {
+  //   editing: isEditingName,
+  // });
 
   const queryDescriptionClasses = classnames(
     "query-description-wrapper",
@@ -501,7 +497,9 @@ const EditQueryForm = ({
               name="query-name"
               placeholder="Add name here"
               value={lastEditedQueryName}
-              inputClassName={queryNameClasses}
+              inputClassName={`${baseClass}__query-name ${
+                isEditingName ? "editing" : ""
+              }`}
               maxLength={160}
               hasError={errors && errors.name}
               onChange={setLastEditedQueryName}
@@ -512,15 +510,11 @@ const EditQueryForm = ({
               }}
             />
           ) : (
-            <button
-              className={queryNameClasses}
-              onClick={editName}
-              onFocus={editName}
-            >
-              <span className={`${baseClass}__query-name`}>
+            <button onClick={editName} onFocus={editName}>
+              <div className={`${baseClass}__query-name`}>
                 {lastEditedQueryName}
-              </span>
-              <Icon name="pencil" className="edit-icon" />
+              </div>
+              <Icon name="pencil" className="edit-icon" size="small-medium" />
             </button>
           )}
         </div>
@@ -558,10 +552,10 @@ const EditQueryForm = ({
               onClick={editDescription}
               onFocus={editDescription}
             >
-              <span className={`${baseClass}__query-description`}>
+              <div className={`${baseClass}__query-description`}>
                 {lastEditedQueryDescription}
-              </span>
-              <Icon name="pencil" className="edit-icon" />
+              </div>
+              <Icon name="pencil" className="edit-icon" size="small-medium" />
             </button>
           )}
         </div>

--- a/frontend/pages/queries/edit/components/EditQueryForm/EditQueryForm.tsx
+++ b/frontend/pages/queries/edit/components/EditQueryForm/EditQueryForm.tsx
@@ -481,22 +481,28 @@ const EditQueryForm = ({
       return (
         <div className="query-name-wrapper">
           {isEditingName ? (
-            <AutoSizeInputField
-              name="query-name"
-              placeholder="Add name here"
-              value={lastEditedQueryName}
-              inputClassName={`${baseClass}__query-name ${
-                isEditingName ? "editing" : ""
-              }`}
-              maxLength={160}
-              hasError={errors && errors.name}
-              onChange={setLastEditedQueryName}
-              onKeyPress={onInputKeypress}
-              isFocused={isEditingName}
-              onBlur={() => {
-                setIsEditingName(false);
-              }}
-            />
+            <>
+              <AutoSizeInputField
+                name="query-name"
+                placeholder="Add name here"
+                value={lastEditedQueryName}
+                inputClassName={`${baseClass}__query-name`}
+                maxLength={160}
+                hasError={errors && errors.name}
+                onChange={setLastEditedQueryName}
+                onKeyPress={onInputKeypress}
+                isFocused={isEditingName}
+                onBlur={() => {
+                  setIsEditingName(false);
+                }}
+              />
+              {/* yes, necessary in both places */}
+              <Icon
+                name="pencil"
+                className="edit-icon hide"
+                size="small-medium"
+              />
+            </>
           ) : (
             <button onClick={editName} onFocus={editName}>
               <div className={`${baseClass}__query-name`}>
@@ -504,6 +510,7 @@ const EditQueryForm = ({
                   <div className="placeholder">Add name here.</div>
                 )}
               </div>
+              {/* yes, necessary in both places */}
               <Icon name="pencil" className="edit-icon" size="small-medium" />
             </button>
           )}
@@ -530,9 +537,7 @@ const EditQueryForm = ({
                 name="query-description"
                 placeholder="Add description here."
                 value={lastEditedQueryDescription}
-                inputClassName={`${baseClass}__query-description ${
-                  isEditingName ? "editing" : ""
-                }`}
+                inputClassName={`${baseClass}__query-description`}
                 maxLength={250}
                 onChange={setLastEditedQueryDescription}
                 onKeyPress={onInputKeypress}

--- a/frontend/pages/queries/edit/components/EditQueryForm/EditQueryForm.tsx
+++ b/frontend/pages/queries/edit/components/EditQueryForm/EditQueryForm.tsx
@@ -482,7 +482,7 @@ const EditQueryForm = ({
     "query-description-wrapper",
     `${baseClass}__query-description`,
     {
-      [`${baseClass}--editing`]: isEditingDescription,
+      editing: isEditingDescription,
     }
   );
 
@@ -495,12 +495,7 @@ const EditQueryForm = ({
   const renderName = () => {
     if (savedQueryMode) {
       return (
-        <div
-          className="query-name-wrapper"
-          onClick={editName}
-          onFocus={editName}
-          tabIndex={0}
-        >
+        <div className="query-name-wrapper">
           {isEditingName ? (
             <AutoSizeInputField
               name="query-name"
@@ -517,16 +512,17 @@ const EditQueryForm = ({
               }}
             />
           ) : (
-            <div className={queryNameClasses}>
+            <button
+              className={queryNameClasses}
+              onClick={editName}
+              onFocus={editName}
+            >
               <span className={`${baseClass}__query-name`}>
                 {lastEditedQueryName}
               </span>
-            </div>
+              <Icon name="pencil" className="edit-icon" />
+            </button>
           )}
-          <Icon
-            name="pencil"
-            className={`edit-icon ${isEditingName ? "hide" : ""}`}
-          />
         </div>
       );
     }
@@ -543,12 +539,7 @@ const EditQueryForm = ({
   const renderDescription = () => {
     if (savedQueryMode) {
       return (
-        <div
-          className="query-description-wrapper"
-          onClick={editDescription}
-          onFocus={editDescription}
-          tabIndex={0}
-        >
+        <div className="query-description-wrapper">
           {isEditingDescription ? (
             <AutoSizeInputField
               name="query-description"
@@ -562,16 +553,17 @@ const EditQueryForm = ({
               onBlur={() => setIsEditingDescription(false)}
             />
           ) : (
-            <div className={queryDescriptionClasses}>
+            <button
+              className={queryDescriptionClasses}
+              onClick={editDescription}
+              onFocus={editDescription}
+            >
               <span className={`${baseClass}__query-description`}>
                 {lastEditedQueryDescription}
               </span>
-            </div>
+              <Icon name="pencil" className="edit-icon" />
+            </button>
           )}
-          <Icon
-            name="pencil"
-            className={`edit-icon ${isEditingDescription ? "hide" : ""}`}
-          />
         </div>
       );
     }

--- a/frontend/pages/queries/edit/components/EditQueryForm/EditQueryForm.tsx
+++ b/frontend/pages/queries/edit/components/EditQueryForm/EditQueryForm.tsx
@@ -495,7 +495,12 @@ const EditQueryForm = ({
   const renderName = () => {
     if (savedQueryMode) {
       return (
-        <div className="query-name-wrapper">
+        <div
+          className="query-name-wrapper"
+          onClick={editName}
+          onFocus={editName}
+          tabIndex={0}
+        >
           {isEditingName ? (
             <AutoSizeInputField
               name="query-name"
@@ -512,19 +517,18 @@ const EditQueryForm = ({
               }}
             />
           ) : (
-            <div
-              className={queryNameClasses}
-              onClick={editName}
-              onFocus={editName}
-            >
+            <div className={queryNameClasses}>
               <span className={`${baseClass}__query-name`}>
                 {lastEditedQueryName}
               </span>
-              <Button variant="text-icon" className="edit-link">
-                <Icon name="pencil" className="edit-icon" />
-              </Button>
             </div>
           )}
+          <Button variant="text-icon" className="edit-link" tabIndex={-1}>
+            <Icon
+              name="pencil"
+              className={`edit-icon ${isEditingName ? "hide" : ""}`}
+            />
+          </Button>
         </div>
       );
     }
@@ -541,32 +545,32 @@ const EditQueryForm = ({
   const renderDescription = () => {
     if (savedQueryMode) {
       return (
-        <div className="query-description-wrapper">
+        <div
+          className="query-description-wrapper"
+          onClick={editDescription}
+          onFocus={editDescription}
+          tabIndex={0}
+        >
           {isEditingDescription ? (
             <AutoSizeInputField
               name="query-description"
               placeholder="Add description here."
               value={lastEditedQueryDescription}
+              inputClassName={queryDescriptionClasses}
               maxLength={250}
-              inputClassName={`${baseClass}__query-description`}
               onChange={setLastEditedQueryDescription}
-              onFocus={() => setIsEditingDescription(true)}
-              onBlur={() => setIsEditingDescription(false)}
               onKeyPress={onInputKeypress}
               isFocused={isEditingDescription}
+              onBlur={() => setIsEditingDescription(false)}
             />
           ) : (
-            <div
-              className={queryDescriptionClasses}
-              onClick={editDescription}
-              onFocus={editDescription}
-            >
+            <div className={queryDescriptionClasses}>
               <span className={`${baseClass}__query-description`}>
                 {lastEditedQueryDescription}
               </span>
             </div>
           )}
-          <Button variant="text-icon" className="edit-link">
+          <Button variant="text-icon" className="edit-link" tabIndex={-1}>
             <Icon
               name="pencil"
               className={`edit-icon ${isEditingDescription ? "hide" : ""}`}

--- a/frontend/pages/queries/edit/components/EditQueryForm/EditQueryForm.tsx
+++ b/frontend/pages/queries/edit/components/EditQueryForm/EditQueryForm.tsx
@@ -511,7 +511,7 @@ const EditQueryForm = ({
             <button onClick={editName} onFocus={editName}>
               <div className={`${baseClass}__query-name`}>
                 {lastEditedQueryName || (
-                  <div className="placeholder">Add name here.</div>
+                  <div className="placeholder">Add name here</div>
                 )}
               </div>
               {/* yes, necessary in both places */}
@@ -539,7 +539,7 @@ const EditQueryForm = ({
             <>
               <AutoSizeInputField
                 name="query-description"
-                placeholder="Add description here."
+                placeholder="Add description here"
                 value={lastEditedQueryDescription}
                 inputClassName={`${baseClass}__query-description`}
                 maxLength={250}
@@ -559,7 +559,7 @@ const EditQueryForm = ({
             <button onClick={editDescription} onFocus={editDescription}>
               <div className={`${baseClass}__query-description`}>
                 {lastEditedQueryDescription || (
-                  <div className="placeholder">Add description here.</div>
+                  <div className="placeholder">Add description here</div>
                 )}
               </div>
               {/* yes, necessary in both places */}

--- a/frontend/pages/queries/edit/components/EditQueryForm/EditQueryForm.tsx
+++ b/frontend/pages/queries/edit/components/EditQueryForm/EditQueryForm.tsx
@@ -470,18 +470,6 @@ const EditQueryForm = ({
     return platformCompatibility.render();
   };
 
-  // const queryNameClasses = classnames(, {
-  //   editing: isEditingName,
-  // });
-
-  const queryDescriptionClasses = classnames(
-    "query-description-wrapper",
-    `${baseClass}__query-description`,
-    {
-      editing: isEditingDescription,
-    }
-  );
-
   const editName = () => {
     if (!isEditingName) {
       setIsEditingName(true);
@@ -512,7 +500,9 @@ const EditQueryForm = ({
           ) : (
             <button onClick={editName} onFocus={editName}>
               <div className={`${baseClass}__query-name`}>
-                {lastEditedQueryName}
+                {lastEditedQueryName || (
+                  <div className="placeholder">Add name here.</div>
+                )}
               </div>
               <Icon name="pencil" className="edit-icon" size="small-medium" />
             </button>
@@ -539,7 +529,9 @@ const EditQueryForm = ({
               name="query-description"
               placeholder="Add description here."
               value={lastEditedQueryDescription}
-              inputClassName={queryDescriptionClasses}
+              inputClassName={`${baseClass}__query-description ${
+                isEditingName ? "editing" : ""
+              }`}
               maxLength={250}
               onChange={setLastEditedQueryDescription}
               onKeyPress={onInputKeypress}
@@ -547,13 +539,11 @@ const EditQueryForm = ({
               onBlur={() => setIsEditingDescription(false)}
             />
           ) : (
-            <button
-              className={queryDescriptionClasses}
-              onClick={editDescription}
-              onFocus={editDescription}
-            >
+            <button onClick={editDescription} onFocus={editDescription}>
               <div className={`${baseClass}__query-description`}>
-                {lastEditedQueryDescription}
+                {lastEditedQueryDescription || (
+                  <div className="placeholder">Add description here.</div>
+                )}
               </div>
               <Icon name="pencil" className="edit-icon" size="small-medium" />
             </button>

--- a/frontend/pages/queries/edit/components/EditQueryForm/EditQueryForm.tsx
+++ b/frontend/pages/queries/edit/components/EditQueryForm/EditQueryForm.tsx
@@ -525,19 +525,27 @@ const EditQueryForm = ({
       return (
         <div className="query-description-wrapper">
           {isEditingDescription ? (
-            <AutoSizeInputField
-              name="query-description"
-              placeholder="Add description here."
-              value={lastEditedQueryDescription}
-              inputClassName={`${baseClass}__query-description ${
-                isEditingName ? "editing" : ""
-              }`}
-              maxLength={250}
-              onChange={setLastEditedQueryDescription}
-              onKeyPress={onInputKeypress}
-              isFocused={isEditingDescription}
-              onBlur={() => setIsEditingDescription(false)}
-            />
+            <>
+              <AutoSizeInputField
+                name="query-description"
+                placeholder="Add description here."
+                value={lastEditedQueryDescription}
+                inputClassName={`${baseClass}__query-description ${
+                  isEditingName ? "editing" : ""
+                }`}
+                maxLength={250}
+                onChange={setLastEditedQueryDescription}
+                onKeyPress={onInputKeypress}
+                isFocused={isEditingDescription}
+                onBlur={() => setIsEditingDescription(false)}
+              />
+              {/* yes, necessary in both places */}
+              <Icon
+                name="pencil"
+                className="edit-icon hide"
+                size="small-medium"
+              />
+            </>
           ) : (
             <button onClick={editDescription} onFocus={editDescription}>
               <div className={`${baseClass}__query-description`}>
@@ -545,6 +553,7 @@ const EditQueryForm = ({
                   <div className="placeholder">Add description here.</div>
                 )}
               </div>
+              {/* yes, necessary in both places */}
               <Icon name="pencil" className="edit-icon" size="small-medium" />
             </button>
           )}

--- a/frontend/pages/queries/edit/components/EditQueryForm/EditQueryForm.tsx
+++ b/frontend/pages/queries/edit/components/EditQueryForm/EditQueryForm.tsx
@@ -523,12 +523,10 @@ const EditQueryForm = ({
               </span>
             </div>
           )}
-          <Button variant="text-icon" className="edit-link" tabIndex={-1}>
-            <Icon
-              name="pencil"
-              className={`edit-icon ${isEditingName ? "hide" : ""}`}
-            />
-          </Button>
+          <Icon
+            name="pencil"
+            className={`edit-icon ${isEditingName ? "hide" : ""}`}
+          />
         </div>
       );
     }
@@ -570,12 +568,10 @@ const EditQueryForm = ({
               </span>
             </div>
           )}
-          <Button variant="text-icon" className="edit-link" tabIndex={-1}>
-            <Icon
-              name="pencil"
-              className={`edit-icon ${isEditingDescription ? "hide" : ""}`}
-            />
-          </Button>
+          <Icon
+            name="pencil"
+            className={`edit-icon ${isEditingDescription ? "hide" : ""}`}
+          />
         </div>
       );
     }

--- a/frontend/pages/queries/edit/components/EditQueryForm/_styles.scss
+++ b/frontend/pages/queries/edit/components/EditQueryForm/_styles.scss
@@ -63,6 +63,8 @@
       }
       .query-description-wrapper {
         display: flex;
+        align-items: flex-start;
+        gap: 0.5rem;
         &:not(.edit-query-form--editing) {
           textarea:hover {
             cursor: pointer;

--- a/frontend/pages/queries/edit/components/EditQueryForm/_styles.scss
+++ b/frontend/pages/queries/edit/components/EditQueryForm/_styles.scss
@@ -35,7 +35,6 @@
     .edit-link {
       margin: 0; // override margin intended for buttons being used as form-fields, which these are not
       cursor: pointer;
-      padding-left: $pad-small;
       height: 18px;
     }
 
@@ -47,6 +46,7 @@
       .query-name-wrapper {
         display: flex;
         align-items: center;
+        gap: 0.5rem;
 
         &:not(.edit-query-form--editing) {
           textarea:hover {
@@ -57,8 +57,6 @@
         .edit-query-form__query-name,
         .input-sizer::after {
           font-size: $large;
-        }
-        .component__auto-size-input-field {
           letter-spacing: -0.5px;
           line-height: 2.3rem;
         }
@@ -76,7 +74,6 @@
         width: 14px;
         height: 14px;
         opacity: 1;
-        transition: opacity 0.2s;
         &.hide {
           opacity: 0;
         }
@@ -105,9 +102,13 @@
     }
   }
 
+  &__textarea-content-display {
+    display: flex;
+    align-items: center;
+  }
+
   &__query-name,
   &__query-description {
-    width: 100%;
     margin: 0;
     padding: 0;
     border: 0;

--- a/frontend/pages/queries/edit/components/EditQueryForm/_styles.scss
+++ b/frontend/pages/queries/edit/components/EditQueryForm/_styles.scss
@@ -121,6 +121,9 @@
       outline: 0;
       cursor: text;
     }
+    .placeholder {
+      color: $ui-fleet-black-50;
+    }
   }
 
   &__query-name {

--- a/frontend/pages/queries/edit/components/EditQueryForm/_styles.scss
+++ b/frontend/pages/queries/edit/components/EditQueryForm/_styles.scss
@@ -55,18 +55,23 @@
           color: $core-vibrant-blue;
           cursor: pointer;
         }
-
-        .component__auto-size-input-field {
-          // width of edit icon
-          margin-right: 14px;
+        .hide {
+          opacity: 0;
         }
+        .icon {
+          align-self: initial;
+        }
+
+        // .component__auto-size-input-field {
+        //   // width of edit icon
+        //   margin-right: 14px;
+        // }
         button {
           all: unset;
           display: flex;
+          // must match gap of wrappers
+          gap: 0.5rem;
           align-items: baseline;
-          .icon {
-            align-self: initial;
-          }
         }
       }
       .query-name-wrapper {
@@ -79,15 +84,15 @@
           line-height: 2.3rem;
         }
       }
-      .query-description-wrapper {
-        // firefox only
-        @-moz-document url-prefix() {
-          .component__auto-size-input-field {
-            margin-top: 1.8px;
-            margin-bottom: 0.6px;
-          }
-        }
-      }
+      // .query-description-wrapper {
+      //   // firefox only
+      //   @-moz-document url-prefix() {
+      //     .component__auto-size-input-field {
+      //       margin-top: 1.8px;
+      //       margin-bottom: 0.6px;
+      //     }
+      //   }
+      // }
     }
 
     .author {

--- a/frontend/pages/queries/edit/components/EditQueryForm/_styles.scss
+++ b/frontend/pages/queries/edit/components/EditQueryForm/_styles.scss
@@ -1,3 +1,5 @@
+$edit-icon-width: 14px;
+
 .edit-query-form {
   position: relative;
   font-size: $x-small;
@@ -53,6 +55,10 @@
           color: $core-vibrant-blue;
           cursor: pointer;
         }
+
+        .button {
+          all: unset;
+        }
       }
       .query-name-wrapper {
         width: fit-content;
@@ -65,12 +71,11 @@
         }
       }
       .edit-icon {
-        width: 14px;
+        width: $edit-icon-width;
         height: 14px;
-        opacity: 1;
-        &.hide {
-          opacity: 0;
-        }
+      }
+      .editing {
+        margin-right: $edit-icon-width;
       }
     }
 
@@ -111,6 +116,7 @@
     white-space: pre-wrap;
     background-color: transparent;
     overflow: hidden;
+    text-align: left;
     &.focus-visible {
       outline: 0;
       cursor: text;

--- a/frontend/pages/queries/edit/components/EditQueryForm/_styles.scss
+++ b/frontend/pages/queries/edit/components/EditQueryForm/_styles.scss
@@ -43,10 +43,18 @@
       flex-direction: column;
       gap: 0.5rem;
 
-      .query-name-wrapper {
+      .query-name-wrapper,
+      .query-description-wrapper {
         display: flex;
         align-items: center;
         gap: 0.5rem;
+        outline: 0;
+        &:hover:not(.focus-visible):not(.no-hover) {
+          color: $core-vibrant-blue;
+          cursor: pointer;
+        }
+      }
+      .query-name-wrapper {
         width: fit-content;
 
         .edit-query-form__query-name,
@@ -55,11 +63,6 @@
           letter-spacing: -0.5px;
           line-height: 2.3rem;
         }
-      }
-      .query-description-wrapper {
-        display: flex;
-        align-items: flex-start;
-        gap: 0.5rem;
       }
       .edit-icon {
         width: 14px;
@@ -108,10 +111,6 @@
     white-space: pre-wrap;
     background-color: transparent;
     overflow: hidden;
-    &:hover:not(.focus-visible):not(.no-hover) {
-      color: $core-vibrant-blue;
-      cursor: pointer;
-    }
     &.focus-visible {
       outline: 0;
       cursor: text;

--- a/frontend/pages/queries/edit/components/EditQueryForm/_styles.scss
+++ b/frontend/pages/queries/edit/components/EditQueryForm/_styles.scss
@@ -49,8 +49,6 @@
         align-items: baseline;
         gap: 0.5rem;
         outline: 0;
-        // height of edit icon
-        min-height: 17px;
         &:hover:not(.focus-visible):not(.no-hover) {
           color: $core-vibrant-blue;
           cursor: pointer;
@@ -62,10 +60,6 @@
           align-self: initial;
         }
 
-        // .component__auto-size-input-field {
-        //   // width of edit icon
-        //   margin-right: 14px;
-        // }
         button {
           all: unset;
           display: flex;
@@ -84,15 +78,6 @@
           line-height: 2.3rem;
         }
       }
-      // .query-description-wrapper {
-      //   // firefox only
-      //   @-moz-document url-prefix() {
-      //     .component__auto-size-input-field {
-      //       margin-top: 1.8px;
-      //       margin-bottom: 0.6px;
-      //     }
-      //   }
-      // }
     }
 
     .author {

--- a/frontend/pages/queries/edit/components/EditQueryForm/_styles.scss
+++ b/frontend/pages/queries/edit/components/EditQueryForm/_styles.scss
@@ -47,6 +47,7 @@
         display: flex;
         align-items: center;
         gap: 0.5rem;
+        width: fit-content;
 
         &:not(.edit-query-form--editing) {
           textarea:hover {
@@ -78,6 +79,7 @@
         opacity: 1;
         &.hide {
           opacity: 0;
+          display: none;
         }
       }
     }

--- a/frontend/pages/queries/edit/components/EditQueryForm/_styles.scss
+++ b/frontend/pages/queries/edit/components/EditQueryForm/_styles.scss
@@ -1,5 +1,3 @@
-$edit-icon-width: 14px;
-
 .edit-query-form {
   position: relative;
   font-size: $x-small;
@@ -48,7 +46,7 @@ $edit-icon-width: 14px;
       .query-name-wrapper,
       .query-description-wrapper {
         display: flex;
-        align-items: center;
+        align-items: baseline;
         gap: 0.5rem;
         outline: 0;
         &:hover:not(.focus-visible):not(.no-hover) {
@@ -56,8 +54,13 @@ $edit-icon-width: 14px;
           cursor: pointer;
         }
 
-        .button {
+        button {
           all: unset;
+          display: flex;
+          align-items: baseline;
+          .icon {
+            align-self: initial;
+          }
         }
       }
       .query-name-wrapper {
@@ -70,12 +73,9 @@ $edit-icon-width: 14px;
           line-height: 2.3rem;
         }
       }
-      .edit-icon {
-        width: $edit-icon-width;
-        height: 14px;
-      }
       .editing {
-        margin-right: $edit-icon-width;
+        // width of edit icon
+        margin-right: 14px;
       }
     }
 

--- a/frontend/pages/queries/edit/components/EditQueryForm/_styles.scss
+++ b/frontend/pages/queries/edit/components/EditQueryForm/_styles.scss
@@ -77,10 +77,6 @@
         width: 14px;
         height: 14px;
         opacity: 1;
-        &.hide {
-          opacity: 0;
-          display: none;
-        }
       }
     }
 

--- a/frontend/pages/queries/edit/components/EditQueryForm/_styles.scss
+++ b/frontend/pages/queries/edit/components/EditQueryForm/_styles.scss
@@ -65,6 +65,9 @@
         width: 14px;
         height: 14px;
         opacity: 1;
+        &.hide {
+          opacity: 0;
+        }
       }
     }
 
@@ -101,7 +104,8 @@
     padding: 0;
     border: 0;
     resize: none;
-    white-space: normal;
+    // collapse not supported on Firefox, so pre-wrap for consistency across browsers
+    white-space: pre-wrap;
     background-color: transparent;
     overflow: hidden;
     &:hover:not(.focus-visible):not(.no-hover) {

--- a/frontend/pages/queries/edit/components/EditQueryForm/_styles.scss
+++ b/frontend/pages/queries/edit/components/EditQueryForm/_styles.scss
@@ -79,10 +79,11 @@
           line-height: 2.3rem;
         }
 
-        // compensate for FF added height
+        // compensate for FF weirdness with textarea line-height calculations
         @-moz-document url-prefix() {
+          line-height: 2.25rem;
           &__editing {
-            margin-top: -2.75px;
+            line-height: 2.3rem;
           }
         }
       }

--- a/frontend/pages/queries/edit/components/EditQueryForm/_styles.scss
+++ b/frontend/pages/queries/edit/components/EditQueryForm/_styles.scss
@@ -78,6 +78,13 @@
           letter-spacing: -0.5px;
           line-height: 2.3rem;
         }
+
+        // compensate for FF added height
+        @-moz-document url-prefix() {
+          &__editing {
+            margin-top: -2.75px;
+          }
+        }
       }
     }
 

--- a/frontend/pages/queries/edit/components/EditQueryForm/_styles.scss
+++ b/frontend/pages/queries/edit/components/EditQueryForm/_styles.scss
@@ -9,6 +9,7 @@
   &__title-bar {
     display: flex;
     justify-content: space-between;
+    gap: 1.5rem;
 
     .form-field {
       margin-bottom: 0px;

--- a/frontend/pages/queries/edit/components/EditQueryForm/_styles.scss
+++ b/frontend/pages/queries/edit/components/EditQueryForm/_styles.scss
@@ -49,12 +49,6 @@
         gap: 0.5rem;
         width: fit-content;
 
-        &:not(.edit-query-form--editing) {
-          textarea:hover {
-            cursor: pointer;
-            color: $core-vibrant-blue;
-          }
-        }
         .edit-query-form__query-name,
         .input-sizer::after {
           font-size: $large;
@@ -66,12 +60,6 @@
         display: flex;
         align-items: flex-start;
         gap: 0.5rem;
-        &:not(.edit-query-form--editing) {
-          textarea:hover {
-            cursor: pointer;
-            color: $core-vibrant-blue;
-          }
-        }
       }
       .edit-icon {
         width: 14px;

--- a/frontend/pages/queries/edit/components/EditQueryForm/_styles.scss
+++ b/frontend/pages/queries/edit/components/EditQueryForm/_styles.scss
@@ -71,6 +71,9 @@
       }
       .query-name-wrapper {
         width: fit-content;
+        .no-value {
+          min-width: 170px;
+        }
 
         .edit-query-form__query-name,
         .input-sizer::after {

--- a/frontend/pages/queries/edit/components/EditQueryForm/_styles.scss
+++ b/frontend/pages/queries/edit/components/EditQueryForm/_styles.scss
@@ -49,11 +49,17 @@
         align-items: baseline;
         gap: 0.5rem;
         outline: 0;
+        // height of edit icon
+        min-height: 17px;
         &:hover:not(.focus-visible):not(.no-hover) {
           color: $core-vibrant-blue;
           cursor: pointer;
         }
 
+        .component__auto-size-input-field {
+          // width of edit icon
+          margin-right: 14px;
+        }
         button {
           all: unset;
           display: flex;
@@ -73,9 +79,14 @@
           line-height: 2.3rem;
         }
       }
-      .editing {
-        // width of edit icon
-        margin-right: 14px;
+      .query-description-wrapper {
+        // firefox only
+        @-moz-document url-prefix() {
+          .component__auto-size-input-field {
+            margin-top: 1.8px;
+            margin-bottom: 0.6px;
+          }
+        }
       }
     }
 
@@ -122,7 +133,7 @@
       cursor: text;
     }
     .placeholder {
-      color: $ui-fleet-black-50;
+      @include placeholder;
     }
   }
 

--- a/frontend/styles/var/icon_sizes.ts
+++ b/frontend/styles/var/icon_sizes.ts
@@ -2,6 +2,7 @@ export type IconSizes = keyof typeof ICON_SIZES;
 
 export const ICON_SIZES = {
   small: "12",
+  "small-medium": "14",
   medium: "16",
   large: "24",
   "extra-large": "48",

--- a/frontend/styles/var/mixins.scss
+++ b/frontend/styles/var/mixins.scss
@@ -220,3 +220,8 @@ $max-width: 2560px;
   // compensate in layout for extra clickable area button height
   margin: -8px 0;
 }
+
+@mixin placeholder {
+  color: $ui-fleet-black-50;
+  opacity: 0.75;
+}


### PR DESCRIPTION
## –> #16663 
- Display text within `textarea` only when editing. Since the problematic pencil icons are hidden in this state, it is okay that their position varies depending on browser (see previous discussions).
- When not editing, text and icon are displayed in a `button` , removing the dependence of their position on the variable per browser`textarea` "col"s.
- Note that the wrapping behavior of these texts can affect how much space is placed after it _within_ its span/textarea – the distance of the icon from this element remains constant.

https://www.loom.com/share/105df09a447e42cc9e3a71668f5d1d2c?sid=244d0543-cc4b-43ed-83dd-22959cb08879


<img width="1284" alt="Screenshot 2024-02-27 at 2 15 12 PM" src="https://github.com/fleetdm/fleet/assets/61553566/7b8f7fea-bc57-4699-9d61-d93b19e8d922">



- [x] Changes file added for user-visible changes in `changes/`
- [x] Manual QA for all new/changed functionality