### PR TITLE
Website: update ritual validation to allow for multiple assignees

### DIFF
--- a/website/assets/js/components/rituals.component.js
+++ b/website/assets/js/components/rituals.component.js
@@ -30,8 +30,8 @@ parasails.registerComponent('rituals', {
   //  ╠═╣ ║ ║║║║
   //  ╩ ╩ ╩ ╩ ╩╩═╝
   template: `
-  <div>
-    <table class="table table-responsive">
+  <div class="table-responsive">
+    <table class="table">
       <thead>
         <tr>
           <td>Task name</td>
@@ -46,9 +46,10 @@ parasails.registerComponent('rituals', {
           <td>{{ritual.task}}</td>
           <td>{{ritual.startedOn}}</td>
           <td>{{ritual.frequency}}</td>
-          <td v-if="!ritual.moreInfoUrl">{{ritual.description}}</td>
-          <td v-else><a :href="ritual.moreInfoUrl">{{ritual.description}}</a></td>
-          <td>{{ritual.dri}}</td>
+          <td style="max-width: 200px" v-if="!ritual.moreInfoUrl">{{ritual.description}}</td>
+          <td style="max-width: 200px" v-else><a :href="ritual.moreInfoUrl">{{ritual.description}}</a></td>
+          <td v-if="!Array.isArray(ritual.dri)">{{ritual.dri}}</td>
+          <td v-else><p v-for="dri in ritual.dri">{{dri}}</p></td>
         </tr>
       </tbody>
     </table>

--- a/website/scripts/create-issues-for-todays-rituals.js
+++ b/website/scripts/create-issues-for-todays-rituals.js
@@ -103,12 +103,18 @@ module.exports = {
         // Create an issue with right labels and assignee, in the right repo.
         if (!dry) {
           let owner = 'fleetdm';
+          let issueAssignee;
+          if(Array.isArray(ritual.dri)){// If there are multiple DRIs for this ritual, we'll send the array of assignees in the request to create the issue.
+            issueAssignee = ritual.dri;
+          } else {// Otherwise, wrap the DRI value in an array.
+            issueAssignee = [ritual.dri];
+          }
           // [?] https://docs.github.com/en/rest/issues/issues#create-an-issue
           await sails.helpers.http.post(`https://api.github.com/repos/${owner}/${ritual.autoIssue.repo}/issues`, {
             title: ritual.task,
             body: ritual.description + (ritual.moreInfoUrl ? ('\n\n> Read more at '+ritual.moreInfoUrl) : ''),
             labels: ritual.autoIssue.labels,
-            assignees: [ ritual.dri ]
+            assignees: issueAssignee
           }, baseHeaders);
         } else {
           sails.log('Dry run: Would have created an issue for ritual:', ritual);


### PR DESCRIPTION
Changes:
- Updated the ritual validation in the `build-static-content` script to allow multiple assignees in rituals YAML files.
- Updated the rituals component to support multiple DRIs
- Updated the `create-issues-for-todays-rituals` script to create issues with multiple assignees.