### PR TITLE
API docs: Add note to Get host by identifier

### DIFF
--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -2493,7 +2493,9 @@ Returns the information of the specified host.
 ### Get host by identifier
 
 Returns the information of the host specified using the `uuid`, `hardware_serial`, `osquery_host_id`, `hostname`, or
-`node_key` as an identifier
+`node_key` as an identifier.
+
+If `hostname` is specified when there is more than one host with the same hostname, the endpoint returns the first matching host.
 
 `GET /api/v1/fleet/hosts/identifier/:identifier`
 


### PR DESCRIPTION
- `hostname` isn't unique
- Ideally, this endpoint would be “Get hosts by identifier” (plural) and return an array.
  - This is a breaking change so we can't make this change until the next major version of Fleet.
