### PR TITLE
Add priority rating labels to product groups handbook

### DIFF
--- a/handbook/company/communications.md
+++ b/handbook/company/communications.md
@@ -253,6 +253,7 @@ Labels with a `#g-` prefix refer to a kanban board. Since it is best practice to
 > - `bug-` Defect category. For example, `bug-enrollment`, `bug-profiles-sync`, `bug-policies`. This allows us to track the areas of the product producing the most bugs.
 > - `story` A user story.
 > -  `prospect-` A customer prospect.
+> - `P-` A (priority level)[https://fleetdm.com/handbook/company/product-groups#high-priority-user-stories-and-bugs].
 > - `Epic` Do not use. _(TODO: ZenHub automatically recreates this label when we group sub-tasks inside of a user story. Find a way to remove this. It is an artifact from Zenhub and not something we actually want to exist or use, as it is confusing.)_
 
 ### Process new requests

--- a/handbook/company/product-groups.md
+++ b/handbook/company/product-groups.md
@@ -141,17 +141,6 @@ User stories are small and independently valuable.
 - Is it small enough? Will this task be likely to fit in 1 sprint when estimated?
 - Is it valuable enough? Will this task drive business value when released, independent of other tasks?
 
-
-#### Engineering-initiated stories
-<!-- TODO: Move steps to "Create an Engineering-initiated story" to handbook/engineering#responsibilities -->
-Engineering-initiated stories are types of user stories created by engineers to make technical changes to Fleet. Technical changes should improve the user experience or contributor experience. For example, optimizing SQL that improves the response time of an API endpoint improves user experience by reducing latency. A script that generates common boilerplate, or automated tests to cover important business logic, improves the quality of life for contributors, making them happier and more productive, resulting in faster delivery of features to our customers.
-
-It is important to frame engineering-initiated user stories the same way we frame all user stories. Stay focused on how this technical change will drive value for our users.
-
-To [create an engineering-initiated user story](https://fleetdm.com/handbook/engineering#creating-an-engineering-initiated-story), follow the [user story drafting process](https://fleetdm.com/handbook/company/development-groups#drafting). Once your user story is created using the [new story template](https://github.com/fleetdm/fleet/issues/new?assignees=&labels=story,~engineering-initiated&projects=&template=story.md&title=), add the `~engineering-initiated` label, assign it to yourself, and bring to your EM to be considered for future prioritization into a sprint. The engineering output and architecture DRI is responsible for prioritizing engineering-initiated stories.
-
-> We prefer the term engineering-initiated stories over technical debt because the user story format helps keep us focused on our users.
-
 #### Defining "done"
 To successfully deliver a user story, the people working on it need to know what "done" means.
 
@@ -428,6 +417,28 @@ Fleet [always prioritizes bugs](https://fleetdm.com/handbook/product#prioritizin
 #### Awaiting QA
 Bugs will be verified as fixed by QA when they are placed in the "Awaiting QA" column of the relevant product group's sprint board. If the bug is verified as fixed, it is moved to the "Ready for release" column of the sprint board. Otherwise, the remaining issues are noted in a comment, and it is moved back to the "In progress" column of the sprint board.
 
+## High priority user stories and bugs
+All issues are treated as standard priority by default, but some user stories and bugs are assigned a priority level as a GitHub label to indicate urgency for the business.
+
+1. Emergency: `P0`
+- Examples: Customer outage, security vulnerability, a new feature is required to address an immediate business emergency.
+- Response: Immediately stop all other work to swarm the issue. Work 24/7 in shifts until resolved.
+- Impact: Significant impact. May void current sprint.
+
+2. Critical: `P1`
+- Examples: A supported workflow is broken, a potential security vulnerability, a new feature is required to address an immediate critical business need.
+- Response: Issue brought to next standup for estimation and immediately brought into the sprint. Necessary team members are assigned as their top priority.
+- Impact: High impact. Does not void sprint, but reduces overall velocity and requires deprioritizing other work.
+
+3. Urgent: `P2`
+- Examples: A supported workflow is not functioning as intended, a newly drafted feature has an associated urgent business need.
+- Response: Issue is prioritized at the top of the next sprint. If opporunity cost of waiting for the next sprint is too high, it may be considered for current sprint.
+- Impact: Low to medium impact. If prioritized into current sprint, reduces overall velocity and requires deprioritizing other work.
+
+Add as much context as possible to the issue to help the team understand the problem and what is driving the urgency. All issues with a `P0`, `P1`, or `P2` label should be assigned to the (DRI for what goes in a release)[https://fleetdm.com/handbook/company/communications#directly-responsible-individuals-dris]. For immediate action, follow up on Slack or by phone.
+
+Once the release DRI is aware of the issue, they will determine if the ticket qualifies for the assigned priority level, then contact the PM and EM of the appropriate product group to immediately action the issue.
+
 ## How to reach the developer on-call
 Oncall engineers do not need to actively monitor Slack channels, except when called in by the Community or Customer teams. Members of those teams are instructed to `@oncall` in `#help-engineering` to get the attention of the on-call engineer to continue discussing any issues that come up. In some cases, the Community or Customer representative will continue to communicate with the requestor. In others, the on-call engineer will communicate directly (team members should use their judgment and discuss on a case-by-case basis how to best communicate with community members and customers).
 
@@ -464,12 +475,10 @@ The on-call developer is encouraged to attend some of the customer success meeti
 
 This has a dual purpose of providing more context for how our customers use Fleet. The developer should actively participate and provide input where appropriate (if not sure, please ask your manager or organizer of the call).
 
-
 - **Documentation for contributors**
 Fleet's documentation for contributors can be found in the [Fleet GitHub repo](https://github.com/fleetdm/fleet/tree/main/docs/Contributing).
 
 The on-call developer is asked to read, understand, test, correct, and improve at least one doc page per week. Our goal is to 1, ensure accuracy and verify that our deployment guides and tutorials are up to date and work as expected. And 2, improve the readability, consistency, and simplicity of our documentation – with empathy towards first-time users. See [Writing documentation](https://fleetdm.com/handbook/marketing#writing-documentation) for writing guidelines, and don't hesitate to reach out to [#g-digital-experience](https://fleetdm.slack.com/archives/C01GQUZ91TN) on Slack for writing support. A backlog of documentation improvement needs is kept [here](https://github.com/fleetdm/fleet/issues?q=is%3Aopen+is%3Aissue+label%3A%22%3Aimprove+documentation%22).
-
 
 ### Escalations
 When the on-call developer is unsure of the answer, they should follow this process for escalation.
@@ -481,7 +490,6 @@ How to escalate:
 1. Spend 30 minutes digging into the relevant code ([osquery](https://github.com/osquery/osquery), [Fleet](https://github.com/fleetdm/fleet)) and/or documentation ([osquery](https://osquery.readthedocs.io/en/latest/), [Fleet](https://fleetdm.com/docs)). Even if you don't know the codebase (or even the programming language), you can sometimes find good answers this way. At the least, you'll become more familiar with each project. Try searching the code for relevant keywords, or filenames.
 
 2. Create a new thread in the [#help-engineering channel](https://fleetdm.slack.com/archives/C019WG4GH0A), tagging `@zwass` and provide the information turned up in your research. Please include possibly relevant links (even if you didn't find what you were looking for there). Zach will work with you to craft an appropriate answer or find another team member who can help.
-
 
 ### Changing of the guard
 The on-call developer changes each week on Wednesday.
@@ -509,8 +517,7 @@ In the Slack reminder thread, the on-call developer includes their retrospective
 
 ## Wireframes 
 - Showing these principles and ideas, to help remember the pros and cons and conceptualize the above visually.
-
-   - Figma: [⚗️ Fleet product project](https://www.figma.com/files/project/17318630/%E2%9A%97%EF%B8%8F-Fleet-product?fuid=1234929285759903870)
+- Figma: [⚗️ Fleet product project](https://www.figma.com/files/project/17318630/%E2%9A%97%EF%B8%8F-Fleet-product?fuid=1234929285759903870)
 
 We have certain design conventions that we include in Fleet. We will document more of these over time.
 
@@ -581,22 +588,6 @@ OPTIONS
 
 ## Meetings
 
-<!-- TODO: Find out what to do with this stuff. Delete?
-### Eng Together
-This meeting is to disseminate engineering-wide announcements, promote cohesion across groups within the engineering team, and connect with engineers (and the "engineering-curious") in other departments. Held monthly for one hour.
-
-**Participants:** Everyone at the company is welcome to attend. All engineers are asked to attend. The subject matter is focused on engineering.
-
-**Agenda:**
-- Announcements
-- Engineering KPIs review
-- “Tech talks”
-  - At least one engineer from each product group demos or discusses a technical aspect of their recent work.
-  - Everyone is welcome to present on a technical topic. Add your name and tech talk subject in the agenda doc included in the Eng Together calendar event.
-- Social
-  - Structured and/or unstructured social activities
-
-
 ### User story discovery
 User story discovery meetings are scheduled as needed to align on large or complicated user stories. Before a discovery meeting is scheduled, the user story must be prioritized for product drafting and go through the design and specification process. When the user story is ready to be estimated, a user story discovery meeting may be scheduled to provide more dedicated, synchronous time for the team to discuss the user story than is available during weekly estimation sessions.
 
@@ -616,18 +607,6 @@ All participants are expected to review the user story and associated designs an
 - Engineering Manager: Review specifications and any defined sub-tasks
 - Software Engineers: Clarifying questions and implementation details
 - Product Quality Specialist: Testing plan
-
-
-### Group weeklies
-A chance for deeper, synchronous discussion on topics relevant across product groups like “Frontend weekly”, “Backend weekly”, etc.
-
-**Participants:** Anyone who wishes to participate.
-
-**Sample agenda (Frontend weekly)**
-- Discuss common patterns and conventions in the codebase
-- Review difficult frontend bugs
-- Write engineering-initiated stories
--->
 
 ### Design consultation
 Design consultations are scheduled as needed with the relevant participants, typically product designers and frontend engineers. It is an opportunity to collaborate and discuss design, implementation, and story requirements. The meeting is scheduled as needed by the product designer or frontend engineer when a user story is in the "Prioritized" column on the [drafting board](https://app.zenhub.com/workspaces/-drafting-ships-in-6-weeks-6192dd66ea2562000faea25c/board). 
@@ -661,6 +640,30 @@ Here are some tips for making this meeting effective:
 QA has weekly check-in with product to go over the inbox items. QA is responsible for proposing “not a bug”, closing due to lack of response (with a nice message), or raising other relevant questions. All requires product agreement
 
 QA may also propose that a reported bug is not actually a bug. A bug is defined as “behavior that is not according to spec or implied by spec.” If agreed that it is not a bug, then it's assigned to the relevant product manager to determine its priority.
+
+### Group weeklies
+A chance for deeper, synchronous discussion on topics relevant across product groups like “Frontend weekly”, “Backend weekly”, etc.
+
+**Participants:** Anyone who wishes to participate.
+
+**Sample agenda from frontend weekly**
+- Discuss common patterns and conventions in the codebase
+- Review difficult frontend bugs
+- Write engineering-initiated stories
+
+### Eng Together
+This meeting is to disseminate engineering-wide announcements, promote cohesion across groups within the engineering team, and connect with engineers (and the "engineering-curious") in other departments. Held monthly for one hour.
+
+**Participants:** Everyone at the company is welcome to attend. All engineers are asked to attend. The subject matter is focused on engineering.
+
+**Agenda:**
+- Announcements
+- Engineering KPIs review
+- “Tech talks”
+  - At least one engineer from each product group demos or discusses a technical aspect of their recent work.
+  - Everyone is welcome to present on a technical topic. Add your name and tech talk subject in the agenda doc included in the Eng Together calendar event.
+- Social
+  - Structured and/or unstructured social activities
 
 ## Development best practices
 - Remember the user.  What would you do if you saw that error message? [🔴](https://fleetdm.com/handbook/company#empathy)

--- a/handbook/company/product-groups.md
+++ b/handbook/company/product-groups.md
@@ -660,7 +660,7 @@ This meeting is to disseminate engineering-wide announcements, promote cohesion 
 - Announcements
 - Engineering KPIs review
 - “Tech talks”
-  - At least one engineer from each product group demos or discusses a technical aspect of their recent work.
+  - At least one member from each product group demos or discusses a technical subject relevant to engineering at Fleet.
   - Everyone is welcome to present on a technical topic. Add your name and tech talk subject in the agenda doc included in the Eng Together calendar event.
 - Social
   - Structured and/or unstructured social activities

--- a/handbook/company/product-groups.md
+++ b/handbook/company/product-groups.md
@@ -418,26 +418,26 @@ Fleet [always prioritizes bugs](https://fleetdm.com/handbook/product#prioritizin
 Bugs will be verified as fixed by QA when they are placed in the "Awaiting QA" column of the relevant product group's sprint board. If the bug is verified as fixed, it is moved to the "Ready for release" column of the sprint board. Otherwise, the remaining issues are noted in a comment, and it is moved back to the "In progress" column of the sprint board.
 
 ## High priority user stories and bugs
-All issues are treated as standard priority by default, but some user stories and bugs are assigned a priority level as a GitHub label to indicate urgency for the business.
+All issues are treated as standard priority by default. Some issues are assigned a priority label to indicate urgency for the business.
 
 1. Emergency: `P0`
-- Examples: Customer outage, security vulnerability, a new feature is required to address an immediate business emergency.
-- Response: Immediately stop all other work to swarm the issue. Work 24/7 in shifts until resolved.
+- Examples: Customer outage, confirmed security vulnerability ([critical bug](https://fleetdm.com/handbook/company/product-groups#release-testing)), a new feature is needed to address an immediate business emergency.
+- Response: Immediately stop other work to swarm the issue. Work 24/7 in shifts until resolved.
 - Impact: Significant impact. May void current sprint.
 
 2. Critical: `P1`
-- Examples: A supported workflow is broken, a potential security vulnerability, a new feature is required to address an immediate critical business need.
+- Examples: A supported workflow is broken ([critical bug](https://fleetdm.com/handbook/company/product-groups#release-testing)), a potential security vulnerability, a new feature is required to address an immediate critical business need.
 - Response: Issue brought to next standup for estimation and immediately brought into the sprint. Necessary team members are assigned as their top priority.
 - Impact: High impact. Does not void sprint, but reduces overall velocity and requires deprioritizing other work.
 
 3. Urgent: `P2`
 - Examples: A supported workflow is not functioning as intended, a newly drafted feature has an associated urgent business need.
 - Response: Issue is prioritized at the top of the next sprint. If opporunity cost of waiting for the next sprint is too high, it may be considered for current sprint.
-- Impact: Low to medium impact. If prioritized into current sprint, reduces overall velocity and requires deprioritizing other work.
+- Impact: Low to medium impact. If prioritized into current sprint, may reduce overall velocity and require deprioritizing other work.
 
-Add as much context as possible to the issue to help the team understand the problem and what is driving the urgency. All issues with a `P0`, `P1`, or `P2` label should be assigned to the (DRI for what goes in a release)[https://fleetdm.com/handbook/company/communications#directly-responsible-individuals-dris]. For immediate action, follow up on Slack or by phone.
+Add as much context as possible to the issue description and assign labels to help the team understand the problem and what is driving the urgency. All issues with a `P0`, `P1`, or `P2` label should be assigned to the (DRI for what goes in a release)[https://fleetdm.com/handbook/company/communications#directly-responsible-individuals-dris]. For immediate action, follow up on Slack or by phone.
 
-Once the release DRI is aware of the issue, they will determine if the ticket qualifies for the assigned priority level, then contact the PM and EM of the appropriate product group to immediately action the issue.
+Once the release DRI is aware of the issue, they will adjust the labels as needed and assign to the PM and EM of the appropriate product group. If they disagree with the priority label applied to the issue, they will contact the requestor to discuss further.
 
 ## How to reach the developer on-call
 Oncall engineers do not need to actively monitor Slack channels, except when called in by the Community or Customer teams. Members of those teams are instructed to `@oncall` in `#help-engineering` to get the attention of the on-call engineer to continue discussing any issues that come up. In some cases, the Community or Customer representative will continue to communicate with the requestor. In others, the on-call engineer will communicate directly (team members should use their judgment and discuss on a case-by-case basis how to best communicate with community members and customers).

--- a/handbook/engineering/README.md
+++ b/handbook/engineering/README.md
@@ -34,7 +34,7 @@ It is important to frame engineering-initiated user stories the same way we fram
 
 To [create an engineering-initiated user story](https://fleetdm.com/handbook/engineering#creating-an-engineering-initiated-story), follow the [user story drafting process](https://fleetdm.com/handbook/company/development-groups#drafting). Once your user story is created using the [new story template](https://github.com/fleetdm/fleet/issues/new?assignees=&labels=story,~engineering-initiated&projects=&template=story.md&title=), add the `~engineering-initiated` label, assign it to yourself, and bring to your EM to be considered for future prioritization into a sprint. The engineering output and architecture DRI is responsible for prioritizing engineering-initiated stories.
 
-> We prefer the term engineering-initiated stories over technical debt because the user story format helps keep us focused on our users.
+> We prefer the term engineering-initiated stories over technical debt because the user story format helps keep us focused on our users and contributors.
 
 ### Begin a merge freeze
 To ensure release quality, Fleet has a freeze period for testing beginning the Tuesday before the release at 9:00 AM Pacific. Effective at the start of the freeze period, new feature work will not be merged into `main`.

--- a/handbook/engineering/README.md
+++ b/handbook/engineering/README.md
@@ -27,6 +27,15 @@ The metrics are:
 
 Each week these are tracked and shared in the weekly KPI sheet by Luke Heath.
 
+#### Create an engineering-initiated story
+Engineering-initiated stories are types of user stories created by engineers to make technical changes to Fleet. Technical changes should improve the user experience or contributor experience. For example, optimizing SQL that improves the response time of an API endpoint improves user experience by reducing latency. A script that generates common boilerplate, or automated tests to cover important business logic, improves the quality of life for contributors, making them happier and more productive, resulting in faster delivery of features to our customers.
+
+It is important to frame engineering-initiated user stories the same way we frame all user stories. Stay focused on how this technical change will drive value for our users.
+
+To [create an engineering-initiated user story](https://fleetdm.com/handbook/engineering#creating-an-engineering-initiated-story), follow the [user story drafting process](https://fleetdm.com/handbook/company/development-groups#drafting). Once your user story is created using the [new story template](https://github.com/fleetdm/fleet/issues/new?assignees=&labels=story,~engineering-initiated&projects=&template=story.md&title=), add the `~engineering-initiated` label, assign it to yourself, and bring to your EM to be considered for future prioritization into a sprint. The engineering output and architecture DRI is responsible for prioritizing engineering-initiated stories.
+
+> We prefer the term engineering-initiated stories over technical debt because the user story format helps keep us focused on our users.
+
 ### Begin a merge freeze
 To ensure release quality, Fleet has a freeze period for testing beginning the Tuesday before the release at 9:00 AM Pacific. Effective at the start of the freeze period, new feature work will not be merged into `main`.
 
@@ -179,7 +188,6 @@ When merging a pull request from a community contributor:
 - Merge the PR.
 - Thank and congratulate the contributor.
 - Share the merged PR with the team in the #help-promote channel of Fleet Slack to be publicized on social media. Those who contribute to Fleet and are recognized for their contributions often become great champions for the project.
-
 
 ### Schedule developer on-call workload
 Engineering managers are asked to be aware of the [on-call rotation](https://docs.google.com/document/d/1FNQdu23wc1S9Yo6x5k04uxT2RwT77CIMzLLeEI2U7JA/edit#) and schedule a light workload for engineers while they are on-call. While it varies week to week considerably, the on-call responsibilities can sometimes take up a substantial portion of the engineer's time.
@@ -334,40 +342,40 @@ Please see [handbook/engineering#notify-community-members-about-a-critical-bug](
 Please see [handbook/engineering#run-fleet-locally-for-qa-purposes](https://fleetdm.com/handbook/engineering#run-fleet-localy-for-qa-purposes)
 
 ##### Scrum at Fleet
-Please see [handbook/company/product-groups#engineering-initiated-stories](https://fleetdm.com/handbook/company/product-groups#scrum-at-fleet)
+Please see [handbook/company/engineering#create-an-engineering-initiated-story](https://fleetdm.com/handbook/company/product-groups#scrum-at-fleet)
 
 ##### Scrum items
-Please see [handbook/company/product-groups#engineering-initiated-stories](https://fleetdm.com/handbook/company/product-groups#scrum-items)
+Please see [handbook/company/engineering#create-an-engineering-initiated-story](https://fleetdm.com/handbook/company/product-groups#scrum-items)
 
 ##### Sprint ceremonies
-Please see [handbook/company/product-groups#engineering-initiated-stories](https://fleetdm.com/handbook/company/product-groups#sprint-ceremonies)
+Please see [handbook/company/engineering#create-an-engineering-initiated-story](https://fleetdm.com/handbook/company/product-groups#sprint-ceremonies)
 
 ##### Meetings
-Please see [handbook/company/product-groups#engineering-initiated-stories](https://fleetdm.com/handbook/company/product-groups#meetings)
+Please see [handbook/company/engineering#create-an-engineering-initiated-story](https://fleetdm.com/handbook/company/product-groups#meetings)
 
 ##### Principles
-Please see [handbook/company/product-groups#engineering-initiated-stories](https://fleetdm.com/handbook/company/product-groups#principles)
+Please see [handbook/company/engineering#create-an-engineering-initiated-story](https://fleetdm.com/handbook/company/product-groups#principles)
 
-Please see [handbook/company/product-groups#engineering-initiated-stories](https://fleetdm.com/handbook/company/product-groups#eng-together) for **below**
+Please see [handbook/company/engineering#create-an-engineering-initiated-story](https://fleetdm.com/handbook/company/product-groups#eng-together) for **below**
 ##### Eng Together
 ##### Participants
 ##### Agenda
-Please see [handbook/company/product-groups#engineering-initiated-stories](https://fleetdm.com/handbook/company/product-groups#eng-together) for **above**
+Please see [handbook/company/engineering#create-an-engineering-initiated-story](https://fleetdm.com/handbook/company/product-groups#eng-together) for **above**
 
-Please see [handbook/company/product-groups#engineering-initiated-stories](https://fleetdm.com/handbook/company/product-groups#group-weeklies) for **below**
+Please see [handbook/company/engineering#create-an-engineering-initiated-story](https://fleetdm.com/handbook/company/product-groups#group-weeklies) for **below**
 ##### User story discovery
 ##### Participants
 ##### Agenda
-Please see [handbook/company/product-groups#engineering-initiated-stories](https://fleetdm.com/handbook/company/product-groups#group-weeklies) for **above**
+Please see [handbook/company/engineering#create-an-engineering-initiated-story](https://fleetdm.com/handbook/company/product-groups#group-weeklies) for **above**
 
-Please see [handbook/company/product-groups#engineering-initiated-stories](https://fleetdm.com/handbook/company/product-groups#group-weeklies) for **below**
+Please see [handbook/company/engineering#create-an-engineering-initiated-story](https://fleetdm.com/handbook/company/product-groups#group-weeklies) for **below**
 ##### Group weeklies
 ##### Participants
 ##### Sample agenda (Frontend weekly)
-Please see [handbook/company/product-groups#engineering-initiated-stories](https://fleetdm.com/handbook/company/product-groups#group-weeklies) for **above**
+Please see [handbook/company/engineering#create-an-engineering-initiated-story](https://fleetdm.com/handbook/company/product-groups#group-weeklies) for **above**
 
 ##### Engineering-initiated stories
-Please see [handbook/company/product-groups#engineering-initiated-stories](https://fleetdm.com/handbook/company/product-groups#engineering-initiated-stories)
+Please see [handbook/company/engineering#create-an-engineering-initiated-story](https://fleetdm.com/handbook/company/engineering#create-an-engineering-initiated-story)
 
 ##### Creating an engineering-initiated story
 Please see [handbook/engineering#create-an-engineering-initiated-user-story](https://fleetdm.com/handbook/engineering#create-an-engineering-initiated-user-story)


### PR DESCRIPTION
I'm taking a first stab at what the priorities could look like. I'm happy to collaborate, so everyone, please add suggestions. 

Once this merges, we'll want to share widely and regularly to keep it front of mind for everyone. That way, anyone can see a P-rated issue and know what it means and what our response is. And, anyone can create one. 

I waffled a lot on the labels. `~p1` vs `p1` vs `P1`. Ultimately I went with the big capital P because all of our other labels are lowercase, so this will stand out as an exception. As for label color... is hot pink too much? 

We have an existing section for [priority ratings on the communications page](https://fleetdm.com/handbook/company/communications#customer-support-service-level-agreements-slas), but that's specific to our customer SLAs. So those are external priority rating agreements, and these are internal priority rating agreements. But, there could be some confusion there. Any ideas on how to resolve the potential confusion? 