### PR TITLE
API design: Pre-fill and lock local account creation screen during out-of-the-box macOS setup

### DIFF
--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -906,7 +906,10 @@ None.
     "macos_setup": {
       "bootstrap_package": "",
       "enable_end_user_authentication": false,
-      "macos_setup_assistant": "path/to/config.json"
+      "macos_setup_assistant": "path/to/config.json",
+      "advanced": {
+        "manual_release_command": true
+      }
     }
   },
   "agent_options": {

--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -907,9 +907,7 @@ None.
       "bootstrap_package": "",
       "enable_end_user_authentication": false,
       "macos_setup_assistant": "path/to/config.json",
-      "advanced": {
-        "manual_release_command": true
-      }
+      "enable_release_device_manually": true
     }
   },
   "agent_options": {

--- a/tools/mdm/apple/dep_sample_profile.json
+++ b/tools/mdm/apple/dep_sample_profile.json
@@ -2,7 +2,6 @@
   "profile_name": "Fleet Device Management Inc.",
   "allow_pairing": true,
   "auto_advance_setup": false,
-  "await_device_configured": false,
   "department": "it@fleetdm.com",
   "is_supervised": false,
   "is_multi_user": false,


### PR DESCRIPTION
API design for:
- #9147