### PR TITLE
[unreleased bug] Fleet UI: Button container min-width = max-content

### DIFF
--- a/frontend/pages/queries/details/QueryDetailsPage/_styles.scss
+++ b/frontend/pages/queries/details/QueryDetailsPage/_styles.scss
@@ -8,6 +8,7 @@
     display: flex;
     justify-content: space-between;
     margin-top: $pad-small;
+    gap: $pad-medium;
 
     .name-description {
       display: flex;
@@ -19,7 +20,7 @@
   &__action-button-container {
     display: flex;
     justify-content: flex-end;
-    min-width: 266px;
+    min-width: max-content;
     gap: $pad-medium;
   }
 


### PR DESCRIPTION
## Issue 
Cerra #17083 

## Description
- Button wrapper min width = max content
- Add gap: 16px between buttons and description so they don't run into each other

## Screenrecording

https://www.loom.com/share/1d33af783e4f40a2ad61bf5721873203?sid=1e58390e-b2cf-41e0-9bc5-3a9736a0e739

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] No change file as it is unreleased
- [x] Manual QA for all new/changed functionality
