### PR TITLE
[unreleased bug] Fleet UI: Remove stack table controls on vulnerabili…

### DIFF
--- a/frontend/pages/SoftwarePage/SoftwareVulnerabilities/SoftwareVulnerabilitiesTable/SoftwareVulnerabilitiesTable.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareVulnerabilities/SoftwareVulnerabilitiesTable/SoftwareVulnerabilitiesTable.tsx
@@ -267,7 +267,6 @@ const SoftwareVulnerabilitiesTable = ({
         customControl={
           searchable ? renderExploitedVulnerabilitiesDropdown : undefined
         }
-        stackControls
         renderCount={renderVulnerabilityCount}
         renderFooter={renderTableFooter}
         disableMultiRowSelect

--- a/frontend/pages/SoftwarePage/SoftwareVulnerabilities/SoftwareVulnerabilitiesTable/SoftwareVulnerabilitiesTable.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareVulnerabilities/SoftwareVulnerabilitiesTable/SoftwareVulnerabilitiesTable.tsx
@@ -132,7 +132,9 @@ const SoftwareVulnerabilitiesTable = ({
   // determines if a user be able to search in the table
   const searchable =
     isSoftwareEnabled &&
-    (!!data || query !== "" || showExploitedVulnerabilitiesOnly);
+    (!!data?.vulnerabilities ||
+      query !== "" ||
+      showExploitedVulnerabilitiesOnly);
 
   const vulnerabilitiesTableHeaders = useMemo(() => {
     if (!data) return [];

--- a/frontend/pages/SoftwarePage/components/SoftwareVulnerabilitiesTable/_styles.scss
+++ b/frontend/pages/SoftwarePage/components/SoftwareVulnerabilitiesTable/_styles.scss
@@ -10,10 +10,6 @@
     }
   }
 
-  .empty-table__container {
-    margin: 1.5rem auto;
-  }
-
   // used to position header text with premium icon correctly
   .column-header {
     display: flex;


### PR DESCRIPTION
## Issue
Unreleased bug on my feature work #16471


## Description
- Remove unwanted stacking table filters 
- Update empty state vertical margin to match other tabs

## Screen recording
https://www.loom.com/share/e69c299ae0234afdb3a6cd8044c6c223?sid=cccb5590-ab10-4c12-92c3-d2cdd2c124c3

https://www.loom.com/share/d2e5b73804a34b0ea1fd08c62a965881?sid=1b550b46-8d89-4b21-9a14-a2c1b82bf61a


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] No change log for unrelease bugs
- [x] Manual QA for all new/changed functionality
