### PR TITLE
Small grammatical fix

### DIFF
--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -4718,7 +4718,7 @@ List all configuration profiles for macOS and Windows hosts enrolled to Fleet's 
 }
 ```
 
-If one or more assigned labels are deleted profile is broken (`broken: true`). It won’t be applied to new hosts.
+If one or more assigned labels are deleted the profile is considered broken (`broken: true`). It won’t be applied to new hosts.
 
 ### Get or download custom OS setting (configuration profile)
 


### PR DESCRIPTION
Missing "the" in a note in the REST API docs and tweaked wording a little bit.
