### PR TITLE
Bugfix: Use CVE struct in Vuln Responses

### DIFF
--- a/ee/server/service/vulnerabilities.go
+++ b/ee/server/service/vulnerabilities.go
@@ -12,7 +12,7 @@ var eeValidVulnSortColumns = []string{
 	"created_at",
 	"cvss_score",
 	"epss_probability",
-	"published",
+	"cve_published",
 }
 
 func (svc *Service) ListVulnerabilities(ctx context.Context, opt fleet.VulnListOptions) ([]fleet.VulnerabilityWithMetadata, *fleet.PaginationMetadata, error) {

--- a/server/datastore/mysql/vulnerabilities.go
+++ b/server/datastore/mysql/vulnerabilities.go
@@ -23,7 +23,7 @@ func (ds *Datastore) Vulnerability(ctx context.Context, cve string, teamID *uint
 			cm.cvss_score,
 			cm.epss_probability,
 			cm.cisa_known_exploit,
-			cm.published,
+			cm.published as cve_published,
 			cm.description,
 			COALESCE(vhc.host_count, 0) as hosts_count,
 			COALESCE(vhc.updated_at, NOW()) as hosts_count_updated_at
@@ -196,8 +196,8 @@ func (ds *Datastore) ListVulnerabilities(ctx context.Context, opt fleet.VulnList
 			cm.cvss_score,
 			cm.epss_probability,
 			cm.cisa_known_exploit,
-			cm.published,
-			COALESCE(cm.description, '') AS description,
+			cm.published as cve_published,
+			cm.description,
 			vhc.host_count as hosts_count,
 			vhc.updated_at as hosts_count_updated_at
 		FROM
@@ -236,7 +236,7 @@ func (ds *Datastore) ListVulnerabilities(ctx context.Context, opt fleet.VulnList
 			cm.cvss_score, 
 			cm.epss_probability, 
 			cm.cisa_known_exploit, 
-			cm.published, 
+			cve_published, 
 			description, 
 			hosts_count,
 			hosts_count_updated_at

--- a/server/datastore/mysql/vulnerabilities.go
+++ b/server/datastore/mysql/vulnerabilities.go
@@ -190,9 +190,9 @@ func (ds *Datastore) ListVulnerabilities(ctx context.Context, opt fleet.VulnList
 	// Define base select statements for EE and Free versions
 	eeSelectStmt := `
 		SELECT
-			combined.cve as cve,
-			MIN(combined.created_at) as created_at,
-			MIN(combined.source) as source,
+			vhc.cve,
+			MIN(COALESCE(osv.created_at, sc.created_at, NOW())) AS created_at,
+			COALESCE(osv.source, sc.source, 0) AS source,
 			cm.cvss_score,
 			cm.epss_probability,
 			cm.cisa_known_exploit,
@@ -200,28 +200,24 @@ func (ds *Datastore) ListVulnerabilities(ctx context.Context, opt fleet.VulnList
 			cm.description,
 			vhc.host_count as hosts_count,
 			vhc.updated_at as hosts_count_updated_at
-		FROM (
-			SELECT cve, created_at, source FROM software_cve
-			UNION
-			SELECT cve, created_at, source FROM operating_system_vulnerabilities
-		) AS combined
-		INNER JOIN vulnerability_host_counts vhc ON vhc.cve = combined.cve
-		LEFT JOIN cve_meta cm ON cm.cve = combined.cve
+		FROM
+			vulnerability_host_counts vhc
+		LEFT JOIN cve_meta cm ON cm.cve = vhc.cve
+		LEFT JOIN operating_system_vulnerabilities osv ON osv.cve = vhc.cve
+		LEFT JOIN software_cve sc ON sc.cve = vhc.cve
 		WHERE vhc.host_count > 0
 		`
 	freeSelectStmt := `
 		SELECT
-			combined.cve as cve,
-			MIN(combined.created_at) as created_at,
-			MIN(combined.source) as source,
+			vhc.cve,
+			MIN(COALESCE(osv.created_at, sc.created_at, NOW())) AS created_at,
+			COALESCE(osv.source, sc.source, 0) AS source,
 			vhc.host_count as hosts_count,
 			vhc.updated_at as hosts_count_updated_at
-		FROM (
-			SELECT cve, created_at, source FROM software_cve
-			UNION
-			SELECT cve, created_at, source FROM operating_system_vulnerabilities
-		) AS combined
-		INNER JOIN vulnerability_host_counts vhc ON vhc.cve = combined.cve
+		FROM
+			vulnerability_host_counts vhc
+		LEFT JOIN operating_system_vulnerabilities osv ON osv.cve = vhc.cve
+		LEFT JOIN software_cve sc ON sc.cve = vhc.cve
 		WHERE vhc.host_count > 0
 		`
 
@@ -231,6 +227,28 @@ func (ds *Datastore) ListVulnerabilities(ctx context.Context, opt fleet.VulnList
 		selectStmt = eeSelectStmt
 	} else {
 		selectStmt = freeSelectStmt
+	}
+
+	// Define group by statements for EE and Free
+	eeGroupBy := ` GROUP BY 
+			vhc.cve, 
+			source,
+			cm.cvss_score, 
+			cm.epss_probability, 
+			cm.cisa_known_exploit, 
+			cve_published, 
+			description, 
+			hosts_count,
+			hosts_count_updated_at
+	`
+	freeGroupBy := " GROUP BY vhc.cve, source, hosts_count, hosts_count_updated_at"
+
+	// Choose the appropriate group by statement based on EE or Free
+	var groupBy string
+	if opt.IsEE {
+		groupBy = eeGroupBy
+	} else {
+		groupBy = freeGroupBy
 	}
 
 	// Prepare arguments for the query
@@ -251,7 +269,7 @@ func (ds *Datastore) ListVulnerabilities(ctx context.Context, opt fleet.VulnList
 	}
 
 	// Append group by statement
-	selectStmt += " GROUP BY cve, host_count, updated_at"
+	selectStmt += groupBy
 
 	opt.ListOptions.IncludeMetadata = !(opt.ListOptions.UsesCursorPagination())
 	selectStmt, args = appendListOptionsWithCursorToSQL(selectStmt, args, &opt.ListOptions)
@@ -277,17 +295,13 @@ func (ds *Datastore) ListVulnerabilities(ctx context.Context, opt fleet.VulnList
 
 func (ds *Datastore) CountVulnerabilities(ctx context.Context, opt fleet.VulnListOptions) (uint, error) {
 	selectStmt := `
-		SELECT
-			COUNT(*)
-		FROM (
-			SELECT cve, created_at, source FROM software_cve
-			UNION
-			SELECT cve, created_at, source FROM operating_system_vulnerabilities
-		) AS combined
-		INNER JOIN vulnerability_host_counts vhc ON vhc.cve = combined.cve
-		LEFT JOIN cve_meta cm ON cm.cve = combined.cve
+		SELECT COUNT(*)
+		FROM vulnerability_host_counts vhc
+		LEFT JOIN cve_meta cm ON cm.cve = vhc.cve
+		LEFT JOIN operating_system_vulnerabilities osv ON osv.cve = vhc.cve
+		LEFT JOIN software_cve sc ON sc.cve = vhc.cve
 		WHERE vhc.host_count > 0
-	`
+		`
 	var args []interface{}
 	if opt.TeamID == 0 {
 		selectStmt = selectStmt + " AND vhc.team_id = 0"

--- a/server/datastore/mysql/vulnerabilities_test.go
+++ b/server/datastore/mysql/vulnerabilities_test.go
@@ -60,9 +60,10 @@ func testListVulnerabilities(t *testing.T, ds *Datastore) {
 	_, err = ds.writer(context.Background()).Exec(insertStmt, "CVE-2020-1236", 0, 20)
 	require.NoError(t, err)
 
+	// No Vulns unless OS or Software Vulns are inserted
 	list, _, err = ds.ListVulnerabilities(context.Background(), opts)
 	require.NoError(t, err)
-	require.Len(t, list, 3)
+	require.Len(t, list, 0)
 
 	// insert OS Vuln
 	_, err = ds.InsertOSVulnerabilities(context.Background(), []fleet.OSVulnerability{

--- a/server/datastore/mysql/vulnerabilities_test.go
+++ b/server/datastore/mysql/vulnerabilities_test.go
@@ -100,24 +100,24 @@ func testListVulnerabilities(t *testing.T, ds *Datastore) {
 
 	expected := map[string]fleet.VulnerabilityWithMetadata{
 		"CVE-2020-1234": {
-			CVEMeta: fleet.CVEMeta{
+			CVE: fleet.CVE{
 				CVE:              "CVE-2020-1234",
-				CVSSScore:        ptr.Float64(7.5),
-				EPSSProbability:  ptr.Float64(0.5),
-				CISAKnownExploit: ptr.Bool(true),
-				Published:        ptr.Time(mockTime),
-				Description:      "Test CVE 2020-1234",
+				CVSSScore:        ptr.Float64Ptr(7.5),
+				EPSSProbability:  ptr.Float64Ptr(0.5),
+				CISAKnownExploit: ptr.BoolPtr(true),
+				CVEPublished:     ptr.TimePtr(mockTime),
+				Description:      ptr.StringPtr("Test CVE 2020-1234"),
 			},
 			HostsCount: 10,
 			Source:     fleet.MSRCSource,
 		},
 		"CVE-2020-1235": {
-			CVEMeta:    fleet.CVEMeta{CVE: "CVE-2020-1235"},
+			CVE:        fleet.CVE{CVE: "CVE-2020-1235"},
 			HostsCount: 15,
 			Source:     fleet.MSRCSource,
 		},
 		"CVE-2020-1236": {
-			CVEMeta:    fleet.CVEMeta{CVE: "CVE-2020-1236"},
+			CVE:        fleet.CVE{CVE: "CVE-2020-1236"},
 			HostsCount: 20,
 			Source:     fleet.NVDSource,
 		},
@@ -126,26 +126,26 @@ func testListVulnerabilities(t *testing.T, ds *Datastore) {
 	require.NoError(t, err)
 	require.Len(t, list, 3)
 	for _, vuln := range list {
-		expectedVuln, ok := expected[vuln.CVE]
+		expectedVuln, ok := expected[vuln.CVE.CVE]
 		require.True(t, ok)
-		require.Equal(t, expectedVuln.CVEMeta, vuln.CVEMeta)
+		require.Equal(t, expectedVuln.CVE, vuln.CVE)
 		require.Equal(t, expectedVuln.HostsCount, vuln.HostsCount)
 	}
 
 	// Test Fleet Free
 	expected = map[string]fleet.VulnerabilityWithMetadata{
 		"CVE-2020-1234": {
-			CVEMeta:    fleet.CVEMeta{CVE: "CVE-2020-1234"},
+			CVE:        fleet.CVE{CVE: "CVE-2020-1234"},
 			HostsCount: 10,
 			Source:     fleet.MSRCSource,
 		},
 		"CVE-2020-1235": {
-			CVEMeta:    fleet.CVEMeta{CVE: "CVE-2020-1235"},
+			CVE:        fleet.CVE{CVE: "CVE-2020-1235"},
 			HostsCount: 15,
 			Source:     fleet.MSRCSource,
 		},
 		"CVE-2020-1236": {
-			CVEMeta:    fleet.CVEMeta{CVE: "CVE-2020-1236"},
+			CVE:        fleet.CVE{CVE: "CVE-2020-1236"},
 			HostsCount: 20,
 			Source:     fleet.NVDSource,
 		},
@@ -154,9 +154,9 @@ func testListVulnerabilities(t *testing.T, ds *Datastore) {
 	require.NoError(t, err)
 	require.Len(t, list, 3)
 	for _, vuln := range list {
-		expectedVuln, ok := expected[vuln.CVE]
+		expectedVuln, ok := expected[vuln.CVE.CVE]
 		require.True(t, ok)
-		require.Equal(t, expectedVuln.CVEMeta, vuln.CVEMeta)
+		require.Equal(t, expectedVuln.CVE, vuln.CVE)
 		require.Equal(t, expectedVuln.HostsCount, vuln.HostsCount)
 	}
 }
@@ -206,7 +206,7 @@ func testVulnerabilityWithOS(t *testing.T, ds *Datastore) {
 	require.NoError(t, err)
 
 	expected := fleet.VulnerabilityWithMetadata{
-		CVEMeta: fleet.CVEMeta{
+		CVE: fleet.CVE{
 			CVE: "CVE-2020-1234",
 		},
 		HostsCount: 10,
@@ -216,7 +216,7 @@ func testVulnerabilityWithOS(t *testing.T, ds *Datastore) {
 	// No CVSSScores
 	v, err = ds.Vulnerability(ctx, "CVE-2020-1234", nil, false)
 	require.NoError(t, err)
-	require.Equal(t, expected.CVEMeta, v.CVEMeta)
+	require.Equal(t, expected.CVE, v.CVE)
 	require.Equal(t, expected.HostsCount, v.HostsCount)
 	require.Equal(t, expected.Source, v.Source)
 
@@ -224,18 +224,18 @@ func testVulnerabilityWithOS(t *testing.T, ds *Datastore) {
 	expected.HostsCount = 4
 	v, err = ds.Vulnerability(ctx, "CVE-2020-1234", ptr.Uint(1), false)
 	require.NoError(t, err)
-	require.Equal(t, expected.CVEMeta, v.CVEMeta)
+	require.Equal(t, expected.CVE, v.CVE)
 	require.Equal(t, expected.HostsCount, v.HostsCount)
 	require.Equal(t, expected.Source, v.Source)
 
 	expected = fleet.VulnerabilityWithMetadata{
-		CVEMeta: fleet.CVEMeta{
+		CVE: fleet.CVE{
 			CVE:              "CVE-2020-1234",
-			CVSSScore:        ptr.Float64(7.5),
-			EPSSProbability:  ptr.Float64(0.5),
-			CISAKnownExploit: ptr.Bool(true),
-			Published:        ptr.Time(mockTime),
-			Description:      "Test CVE 2020-1234",
+			CVSSScore:        ptr.Float64Ptr(7.5),
+			EPSSProbability:  ptr.Float64Ptr(0.5),
+			CISAKnownExploit: ptr.BoolPtr(true),
+			CVEPublished:     ptr.TimePtr(mockTime),
+			Description:      ptr.StringPtr("Test CVE 2020-1234"),
 		},
 		HostsCount: 10,
 		Source:     fleet.MSRCSource,
@@ -244,7 +244,7 @@ func testVulnerabilityWithOS(t *testing.T, ds *Datastore) {
 	// With CVSSScores
 	v, err = ds.Vulnerability(ctx, "CVE-2020-1234", nil, true)
 	require.NoError(t, err)
-	require.Equal(t, expected.CVEMeta, v.CVEMeta)
+	require.Equal(t, expected.CVE, v.CVE)
 	require.Equal(t, expected.HostsCount, v.HostsCount)
 	require.Equal(t, expected.Source, v.Source)
 }
@@ -290,7 +290,7 @@ func testVulnerabilityWithSoftware(t *testing.T, ds *Datastore) {
 
 	// No CVSSScores
 	expected := fleet.VulnerabilityWithMetadata{
-		CVEMeta: fleet.CVEMeta{
+		CVE: fleet.CVE{
 			CVE: "CVE-2020-1234",
 		},
 		HostsCount: 10,
@@ -299,19 +299,19 @@ func testVulnerabilityWithSoftware(t *testing.T, ds *Datastore) {
 
 	v, err = ds.Vulnerability(ctx, "CVE-2020-1234", nil, false)
 	require.NoError(t, err)
-	require.Equal(t, expected.CVEMeta, v.CVEMeta)
+	require.Equal(t, expected.CVE, v.CVE)
 	require.Equal(t, expected.HostsCount, v.HostsCount)
 	require.Equal(t, expected.Source, v.Source)
 
 	// With CVSSScores
 	expected = fleet.VulnerabilityWithMetadata{
-		CVEMeta: fleet.CVEMeta{
+		CVE: fleet.CVE{
 			CVE:              "CVE-2020-1234",
-			CVSSScore:        ptr.Float64(7.5),
-			EPSSProbability:  ptr.Float64(0.5),
-			CISAKnownExploit: ptr.Bool(true),
-			Published:        ptr.Time(mockTime),
-			Description:      "Test CVE 2020-1234",
+			CVSSScore:        ptr.Float64Ptr(7.5),
+			EPSSProbability:  ptr.Float64Ptr(0.5),
+			CISAKnownExploit: ptr.BoolPtr(true),
+			CVEPublished:     ptr.TimePtr(mockTime),
+			Description:      ptr.StringPtr("Test CVE 2020-1234"),
 		},
 		HostsCount: 10,
 		Source:     fleet.NVDSource,
@@ -319,7 +319,7 @@ func testVulnerabilityWithSoftware(t *testing.T, ds *Datastore) {
 
 	v, err = ds.Vulnerability(ctx, "CVE-2020-1234", nil, true)
 	require.NoError(t, err)
-	require.Equal(t, expected.CVEMeta, v.CVEMeta)
+	require.Equal(t, expected.CVE, v.CVE)
 	require.Equal(t, expected.HostsCount, v.HostsCount)
 	require.Equal(t, expected.Source, v.Source)
 }
@@ -372,7 +372,7 @@ func testVulnerabilitiesTeamFilter(t *testing.T, ds *Datastore) {
 	}
 
 	for _, vuln := range list {
-		require.Equal(t, checkCounts[vuln.CVE], int(vuln.HostsCount), vuln.CVE)
+		require.Equal(t, checkCounts[vuln.CVE.CVE], int(vuln.HostsCount), vuln.CVE)
 	}
 }
 
@@ -392,22 +392,22 @@ func testListVulnerabilitiesSort(t *testing.T, ds *Datastore) {
 	list, _, err := ds.ListVulnerabilities(context.Background(), opts)
 	require.NoError(t, err)
 	require.Len(t, list, 5)
-	require.Equal(t, "CVE-2020-1241", list[0].CVE)
-	require.Equal(t, "CVE-2020-1239", list[1].CVE)
-	require.Equal(t, "CVE-2020-1238", list[2].CVE)
-	require.Equal(t, "CVE-2020-1237", list[3].CVE)
-	require.Equal(t, "CVE-2020-1236", list[4].CVE)
+	require.Equal(t, "CVE-2020-1241", list[0].CVE.CVE)
+	require.Equal(t, "CVE-2020-1239", list[1].CVE.CVE)
+	require.Equal(t, "CVE-2020-1238", list[2].CVE.CVE)
+	require.Equal(t, "CVE-2020-1237", list[3].CVE.CVE)
+	require.Equal(t, "CVE-2020-1236", list[4].CVE.CVE)
 
 	opts.OrderKey = "published"
 	opts.OrderDirection = fleet.OrderAscending
 	list, _, err = ds.ListVulnerabilities(context.Background(), opts)
 	require.NoError(t, err)
 	require.Len(t, list, 5)
-	require.Equal(t, "CVE-2020-1241", list[0].CVE) // NULL dates are sorted first
-	require.Equal(t, "CVE-2020-1234", list[1].CVE)
-	require.Equal(t, "CVE-2020-1236", list[2].CVE)
-	require.Equal(t, "CVE-2020-1235", list[3].CVE)
-	require.Equal(t, "CVE-2020-1237", list[4].CVE)
+	require.Equal(t, "CVE-2020-1241", list[0].CVE.CVE) // NULL dates are sorted first
+	require.Equal(t, "CVE-2020-1234", list[1].CVE.CVE)
+	require.Equal(t, "CVE-2020-1236", list[2].CVE.CVE)
+	require.Equal(t, "CVE-2020-1235", list[3].CVE.CVE)
+	require.Equal(t, "CVE-2020-1237", list[4].CVE.CVE)
 }
 
 func testVulnerabilitiesFilters(t *testing.T, ds *Datastore) {
@@ -424,7 +424,7 @@ func testVulnerabilitiesFilters(t *testing.T, ds *Datastore) {
 	require.Len(t, list, 3)
 	expected := []string{"CVE-2020-1234", "CVE-2020-1236", "CVE-2020-1238"}
 	for _, vuln := range list {
-		require.Contains(t, expected, vuln.CVE)
+		require.Contains(t, expected, vuln.CVE.CVE)
 	}
 
 	// Test CVE LIKE filter
@@ -436,7 +436,7 @@ func testVulnerabilitiesFilters(t *testing.T, ds *Datastore) {
 	list, _, err = ds.ListVulnerabilities(context.Background(), opts)
 	require.NoError(t, err)
 	require.Len(t, list, 1)
-	require.Equal(t, "CVE-2020-1234", list[0].CVE)
+	require.Equal(t, "CVE-2020-1234", list[0].CVE.CVE)
 }
 
 func testCountVulnerabilities(t *testing.T, ds *Datastore) {
@@ -874,7 +874,7 @@ func assertHostCounts(t *testing.T, expected []hostCount, actual []fleet.Vulnera
 	t.Helper()
 	require.Len(t, actual, len(expected))
 	for i, vuln := range actual {
-		require.Equal(t, expected[i].CVE, vuln.CVE)
+		require.Equal(t, expected[i].CVE, vuln.CVE.CVE)
 		require.Equal(t, expected[i].HostCount, vuln.HostsCount)
 	}
 }

--- a/server/datastore/mysql/vulnerabilities_test.go
+++ b/server/datastore/mysql/vulnerabilities_test.go
@@ -60,10 +60,9 @@ func testListVulnerabilities(t *testing.T, ds *Datastore) {
 	_, err = ds.writer(context.Background()).Exec(insertStmt, "CVE-2020-1236", 0, 20)
 	require.NoError(t, err)
 
-	// No Vulns unless OS or Software Vulns are inserted
 	list, _, err = ds.ListVulnerabilities(context.Background(), opts)
 	require.NoError(t, err)
-	require.Len(t, list, 0)
+	require.Len(t, list, 3)
 
 	// insert OS Vuln
 	_, err = ds.InsertOSVulnerabilities(context.Background(), []fleet.OSVulnerability{

--- a/server/fleet/vulnerabilities.go
+++ b/server/fleet/vulnerabilities.go
@@ -128,11 +128,10 @@ const (
 )
 
 type VulnerabilityWithMetadata struct {
-	CVEMeta
+	CVE
 	HostsCount          uint                `db:"hosts_count" json:"hosts_count"`
 	HostsCountUpdatedAt time.Time           `db:"hosts_count_updated_at" json:"hosts_count_updated_at"`
 	CreatedAt           time.Time           `db:"created_at" json:"created_at"`
-	DetailsLink         string              `json:"details_link"`
 	Source              VulnerabilitySource `db:"source" json:"-"`
 }
 

--- a/server/service/integration_core_test.go
+++ b/server/service/integration_core_test.go
@@ -7572,7 +7572,7 @@ func (s *integrationTestSuite) TestListVulnerabilities() {
 	}
 
 	for _, vuln := range resp.Vulnerabilities {
-		expectedVuln, ok := expected[vuln.CVE]
+		expectedVuln, ok := expected[vuln.CVE.CVE]
 		require.True(t, ok)
 		require.Equal(t, expectedVuln.HostCount, vuln.HostsCount)
 		require.Equal(t, expectedVuln.DetailsLink, vuln.DetailsLink)
@@ -7599,7 +7599,7 @@ func (s *integrationTestSuite) TestListVulnerabilities() {
 	require.Empty(t, resp.Err)
 
 	for _, vuln := range resp.Vulnerabilities {
-		expectedVuln, ok := expected[vuln.CVE]
+		expectedVuln, ok := expected[vuln.CVE.CVE]
 		require.True(t, ok)
 		require.Equal(t, expectedVuln.HostCount, vuln.HostsCount)
 		require.Equal(t, expectedVuln.DetailsLink, vuln.DetailsLink)
@@ -7619,14 +7619,14 @@ func (s *integrationTestSuite) TestListVulnerabilities() {
 	// Valid Global Request
 	s.DoJSON("GET", "/api/latest/fleet/vulnerabilities/CVE-2021-1234", nil, http.StatusOK, &gResp)
 	require.Empty(t, gResp.Err)
-	require.Equal(t, "CVE-2021-1234", gResp.Vulnerability.CVE)
+	require.Equal(t, "CVE-2021-1234", gResp.Vulnerability.CVE.CVE)
 	require.Equal(t, uint(1), gResp.Vulnerability.HostsCount)
 	require.Equal(t, "https://msrc.microsoft.com/update-guide/en-US/vulnerability/CVE-2021-1234", gResp.Vulnerability.DetailsLink)
 	require.Empty(t, gResp.Vulnerability.Description)
 	require.Empty(t, gResp.Vulnerability.CVSSScore)
 	require.Empty(t, gResp.Vulnerability.CISAKnownExploit)
 	require.Empty(t, gResp.Vulnerability.EPSSProbability)
-	require.Empty(t, gResp.Vulnerability.Published)
+	require.Empty(t, gResp.Vulnerability.CVEPublished)
 	require.Len(t, gResp.OSVersions, 1)
 	require.Equal(t, "Windows 11 Enterprise 22H2 10.0.19042.1234", gResp.OSVersions[0].Name)
 	require.Equal(t, "Windows 11 Enterprise 22H2", gResp.OSVersions[0].NameOnly)
@@ -7637,14 +7637,14 @@ func (s *integrationTestSuite) TestListVulnerabilities() {
 
 	s.DoJSON("GET", "/api/latest/fleet/vulnerabilities/CVE-2021-1235", nil, http.StatusOK, &gResp)
 	require.Empty(t, gResp.Err)
-	require.Equal(t, "CVE-2021-1235", gResp.Vulnerability.CVE)
+	require.Equal(t, "CVE-2021-1235", gResp.Vulnerability.CVE.CVE)
 	require.Equal(t, uint(1), gResp.Vulnerability.HostsCount)
 	require.Equal(t, "https://nvd.nist.gov/vuln/detail/CVE-2021-1235", gResp.Vulnerability.DetailsLink)
 	require.Empty(t, gResp.Vulnerability.Description)
 	require.Empty(t, gResp.Vulnerability.CVSSScore)
 	require.Empty(t, gResp.Vulnerability.CISAKnownExploit)
 	require.Empty(t, gResp.Vulnerability.EPSSProbability)
-	require.Empty(t, gResp.Vulnerability.Published)
+	require.Empty(t, gResp.Vulnerability.CVEPublished)
 	require.Len(t, gResp.Software, 1)
 	require.Equal(t, "Google Chrome", gResp.Software[0].Name)
 	require.Equal(t, "0.0.1", gResp.Software[0].Version)

--- a/server/service/vulnerabilities.go
+++ b/server/service/vulnerabilities.go
@@ -75,9 +75,9 @@ func (svc *Service) ListVulnerabilities(ctx context.Context, opt fleet.VulnListO
 
 	for i, vuln := range vulns {
 		if vuln.Source == fleet.MSRCSource {
-			vulns[i].DetailsLink = fmt.Sprintf("https://msrc.microsoft.com/update-guide/en-US/vulnerability/%s", vuln.CVE)
+			vulns[i].DetailsLink = fmt.Sprintf("https://msrc.microsoft.com/update-guide/en-US/vulnerability/%s", vuln.CVE.CVE)
 		} else {
-			vulns[i].DetailsLink = fmt.Sprintf("https://nvd.nist.gov/vuln/detail/%s", vuln.CVE)
+			vulns[i].DetailsLink = fmt.Sprintf("https://nvd.nist.gov/vuln/detail/%s", vuln.CVE.CVE)
 		}
 	}
 
@@ -117,17 +117,17 @@ func getVulnerabilityEndpoint(ctx context.Context, req interface{}, svc fleet.Se
 	}
 
 	if vuln.Source == fleet.MSRCSource {
-		vuln.DetailsLink = fmt.Sprintf("https://msrc.microsoft.com/update-guide/en-US/vulnerability/%s", vuln.CVE)
+		vuln.DetailsLink = fmt.Sprintf("https://msrc.microsoft.com/update-guide/en-US/vulnerability/%s", vuln.CVE.CVE)
 	} else {
-		vuln.DetailsLink = fmt.Sprintf("https://nvd.nist.gov/vuln/detail/%s", vuln.CVE)
+		vuln.DetailsLink = fmt.Sprintf("https://nvd.nist.gov/vuln/detail/%s", vuln.CVE.CVE)
 	}
 
-	osVersions, _, err := svc.ListOSVersionsByCVE(ctx, vuln.CVE, request.TeamID)
+	osVersions, _, err := svc.ListOSVersionsByCVE(ctx, vuln.CVE.CVE, request.TeamID)
 	if err != nil {
 		return getVulnerabilityResponse{Err: err}, nil
 	}
 
-	software, _, err := svc.ListSoftwareByCVE(ctx, vuln.CVE, request.TeamID)
+	software, _, err := svc.ListSoftwareByCVE(ctx, vuln.CVE.CVE, request.TeamID)
 	if err != nil {
 		return getVulnerabilityResponse{Err: err}, nil
 	}

--- a/server/service/vulnerabilities_test.go
+++ b/server/service/vulnerabilities_test.go
@@ -20,9 +20,9 @@ func TestListVulnerabilities(t *testing.T) {
 	ds.ListVulnerabilitiesFunc = func(cxt context.Context, opt fleet.VulnListOptions) ([]fleet.VulnerabilityWithMetadata, *fleet.PaginationMetadata, error) {
 		return []fleet.VulnerabilityWithMetadata{
 			{
-				CVEMeta: fleet.CVEMeta{
+				CVE: fleet.CVE{
 					CVE:         "CVE-2019-1234",
-					Description: "A vulnerability",
+					Description: ptr.StringPtr("A vulnerability"),
 				},
 				CreatedAt:  time.Now(),
 				HostsCount: 10,


### PR DESCRIPTION
#17135

Using the existing `CVE` struct in vulnerability responses to ensure consistency between responses in the software APIs.  Primary goal is to rename `cve_published` and `cve_description` in the API response for `/vulnerabilities`

- [X] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [X] Added/updated tests
- [X] Manual QA for all new/changed functionality
 