### PR TITLE
Fix Incorrect Helm Chart Keys in MySQL Installation Documentation

### DIFF
--- a/docs/Deploy/Deploy-Fleet-on-Kubernetes.md
+++ b/docs/Deploy/Deploy-Fleet-on-Kubernetes.md
@@ -128,14 +128,14 @@ Helm v2
 ```sh
 helm install \
   --name fleet-database \
-  --set mysqlUser=fleet,mysqlDatabase=fleet \
+  --set auth.username=fleet,auth.database=fleet \
   oci://registry-1.docker.io/bitnamicharts/mysql
 ```
 
 Helm v3
 ```sh
 helm install fleet-database \
-  --set mysqlUser=fleet,mysqlDatabase=fleet \
+  --set auth.username=fleet,auth.database=fleet \
   oci://registry-1.docker.io/bitnamicharts/mysql 
 ```
 


### PR DESCRIPTION
This PR addresses an issue in the documentation for installing the MySQL chart using Helm. Previously, the documentation provided a Helm install command that incorrectly referenced mysqlUser and mysqlDatabase. However, these keys don't exist in the chart's values.yaml file anymore.