### PR TITLE
Website: Update license dispenser

### DIFF
--- a/website/assets/js/pages/customers/new-license.page.js
+++ b/website/assets/js/pages/customers/new-license.page.js
@@ -73,7 +73,7 @@ parasails.registerPage('new-license', {
       this.showQuotedPrice = true;
       this.quotedPrice = quote.quotedPrice;
       this.numberOfHostsQuoted = quote.numberOfHosts;
-      if(quote.numberOfHosts <= 999) {
+      if(quote.numberOfHosts <= 700) {
         this.formData.quoteId = quote.id;
         this.showBillingForm = true;
       }

--- a/website/views/pages/customers/new-license.ejs
+++ b/website/views/pages/customers/new-license.ejs
@@ -36,7 +36,7 @@
         </div>
         <div :class="[showBillingForm ? 'pt-2' : '' ]" v-if="!showBillingForm">
           <ajax-button purpose="submit-button" spinner="true" type="submit" :syncing="syncing" class="btn btn-block btn-lg btn-primary" v-if="!numberOfHostsQuoted">Continue</ajax-button>
-          <ajax-button spinner="true" purpose="submit-button" :syncing="syncing" class="btn btn-block btn-lg btn-primary" @click="clickScheduleDemo" v-if="showQuotedPrice && numberOfHostsQuoted >= 700">Talk to sales</ajax-button>
+          <ajax-button spinner="true" purpose="submit-button" :syncing="syncing" class="btn btn-block btn-lg btn-primary" @click="clickScheduleDemo" v-if="showQuotedPrice && numberOfHostsQuoted > 700">Talk to sales</ajax-button>
           <ajax-button spinner="true" purpose="submit-button" :syncing="syncing" class="btn btn-block btn-lg btn-primary" v-if="showQuotedPrice && numberOfHostsQuoted <= 700">Continue</ajax-button>
         </div>
       </ajax-form>

--- a/website/views/pages/customers/new-license.ejs
+++ b/website/views/pages/customers/new-license.ejs
@@ -36,8 +36,8 @@
         </div>
         <div :class="[showBillingForm ? 'pt-2' : '' ]" v-if="!showBillingForm">
           <ajax-button purpose="submit-button" spinner="true" type="submit" :syncing="syncing" class="btn btn-block btn-lg btn-primary" v-if="!numberOfHostsQuoted">Continue</ajax-button>
-          <ajax-button spinner="true" purpose="submit-button" :syncing="syncing" class="btn btn-block btn-lg btn-primary" @click="clickScheduleDemo" v-if="showQuotedPrice && numberOfHostsQuoted >= 1000">Show me</ajax-button>
-          <ajax-button spinner="true" purpose="submit-button" :syncing="syncing" class="btn btn-block btn-lg btn-primary" v-if="showQuotedPrice && numberOfHostsQuoted <= 999">Continue</ajax-button>
+          <ajax-button spinner="true" purpose="submit-button" :syncing="syncing" class="btn btn-block btn-lg btn-primary" @click="clickScheduleDemo" v-if="showQuotedPrice && numberOfHostsQuoted >= 700">Talk to sales</ajax-button>
+          <ajax-button spinner="true" purpose="submit-button" :syncing="syncing" class="btn btn-block btn-lg btn-primary" v-if="showQuotedPrice && numberOfHostsQuoted <= 700">Continue</ajax-button>
         </div>
       </ajax-form>
     </div>


### PR DESCRIPTION
Closes: #17161

Changes:
- Updated the license dispenser to direct users who want to purchase a license for >700 hosts to talk to sales (Previously >1000)
- Updated button text on the /customers/new-license page ("Show me" » "Talk to Sales")