### PR TITLE
Enabling setting host status webhook at the team level via REST API and fleetctl apply/gitops.

### DIFF
--- a/changes/17094-per-team-host-status-webhook
+++ b/changes/17094-per-team-host-status-webhook
@@ -1,0 +1,1 @@
+Enabling setting host status webhook at the team level via REST API and fleetctl apply/gitops.

--- a/cmd/fleet/serve_test.go
+++ b/cmd/fleet/serve_test.go
@@ -255,7 +255,7 @@ func TestAutomationsSchedule(t *testing.T) {
 
 	calledOnce := make(chan struct{})
 	calledTwice := make(chan struct{})
-	ds.TotalAndUnseenHostsSinceFunc = func(ctx context.Context, daysCount int) (int, int, error) {
+	ds.TotalAndUnseenHostsSinceFunc = func(ctx context.Context, teamID *uint, daysCount int) (int, []uint, error) {
 		defer func() {
 			select {
 			case <-calledOnce:
@@ -268,7 +268,7 @@ func TestAutomationsSchedule(t *testing.T) {
 				close(calledOnce)
 			}
 		}()
-		return 10, 6, nil
+		return 10, []uint{1, 2, 3, 4, 5, 6}, nil
 	}
 
 	ctx, cancelFunc := context.WithCancel(context.Background())

--- a/cmd/fleetctl/testdata/expectedGetTeamsJson.json
+++ b/cmd/fleetctl/testdata/expectedGetTeamsJson.json
@@ -12,6 +12,12 @@
 				"host_expiry_window": 0
 			},
 			"webhook_settings": {
+				"host_status_webhook": {
+					"enable_host_status_webhook": false,
+					"destination_url": "",
+					"host_percentage": 0,
+					"days_count": 0
+				},
 				"failing_policies_webhook": {
 					"enable_failing_policies_webhook": false,
 					"destination_url": "",
@@ -81,6 +87,12 @@
 				"host_expiry_window": 15
 			},
 			"webhook_settings": {
+				"host_status_webhook": {
+					"enable_host_status_webhook": false,
+					"destination_url": "",
+					"host_percentage": 0,
+					"days_count": 0
+				},
 				"failing_policies_webhook": {
 					"enable_failing_policies_webhook": false,
 					"destination_url": "",

--- a/cmd/fleetctl/testdata/expectedGetTeamsYaml.yml
+++ b/cmd/fleetctl/testdata/expectedGetTeamsYaml.yml
@@ -26,6 +26,8 @@ spec:
         enable_end_user_authentication: false
         macos_setup_assistant:
     scripts: null
+    webhook_settings:
+      host_status_webhook: null
     name: team1
 ---
 apiVersion: v1
@@ -64,4 +66,6 @@ spec:
         enable_end_user_authentication: false
         macos_setup_assistant:
     scripts: null
+    webhook_settings:
+      host_status_webhook: null
     name: team2

--- a/cmd/fleetctl/testdata/gitops/team_config_no_paths.yml
+++ b/cmd/fleetctl/testdata/gitops/team_config_no_paths.yml
@@ -4,10 +4,11 @@ team_settings:
     - secret: "SampleSecret123"
     - secret: "ABC"
   webhook_settings:
-    failing_policies_webhook:
-      enable_failing_policies_webhook: true
-      destination_url: https://example.tines.com/webhook
-      policy_ids: [1, 2, 3, 4, 5, 6 ,7, 8, 9]
+    host_status_webhook:
+      days_count: 14
+      destination_url: https://example.com/host_status_webhook
+      enable_host_status_webhook: true
+      host_percentage: 25
   features:
     enable_host_users: true
     enable_software_inventory: true

--- a/cmd/fleetctl/testdata/macosSetupExpectedTeam1And2Empty.yml
+++ b/cmd/fleetctl/testdata/macosSetupExpectedTeam1And2Empty.yml
@@ -26,6 +26,8 @@ spec:
         deadline_days: null
         grace_period_days: null
     scripts: null
+    webhook_settings:
+      host_status_webhook: null
     name: tm1
 ---
 apiVersion: v1
@@ -54,4 +56,6 @@ spec:
         deadline_days: null
         grace_period_days: null
     scripts: null
+    webhook_settings:
+      host_status_webhook: null
     name: tm2

--- a/cmd/fleetctl/testdata/macosSetupExpectedTeam1And2Set.yml
+++ b/cmd/fleetctl/testdata/macosSetupExpectedTeam1And2Set.yml
@@ -26,6 +26,8 @@ spec:
         deadline_days: null
         grace_period_days: null
     scripts: null
+    webhook_settings:
+      host_status_webhook: null
     name: tm1
 ---
 apiVersion: v1
@@ -54,4 +56,6 @@ spec:
         deadline_days: null
         grace_period_days: null
     scripts: null
+    webhook_settings:
+      host_status_webhook: null
     name: tm2

--- a/cmd/fleetctl/testdata/macosSetupExpectedTeam1Empty.yml
+++ b/cmd/fleetctl/testdata/macosSetupExpectedTeam1Empty.yml
@@ -26,5 +26,7 @@ spec:
       windows_settings:
         custom_settings: null
     scripts: null
+    webhook_settings:
+      host_status_webhook: null
     name: tm1
 

--- a/ee/server/service/teams.go
+++ b/ee/server/service/teams.go
@@ -886,11 +886,8 @@ func (svc *Service) createTeamFromSpec(
 
 	hostStatusWebhook := fleet.HostStatusWebhookSettings{}
 	if spec.WebhookSettings.HostStatusWebhook != nil {
-		fmt.Println("VICTOR setting hostStatusWebhook")
 		fleet.ValidateEnabledHostStatusIntegrations(*spec.WebhookSettings.HostStatusWebhook, invalid)
 		hostStatusWebhook = *spec.WebhookSettings.HostStatusWebhook
-	} else {
-		fmt.Println("VICTOR hostStatusWebhook is nil")
 	}
 	if invalid.HasErrors() {
 		return nil, ctxerr.Wrap(ctx, invalid)
@@ -1065,11 +1062,8 @@ func (svc *Service) editTeamFromSpec(
 
 	// If host status webhook is not provided, do not change it
 	if spec.WebhookSettings.HostStatusWebhook != nil {
-		fmt.Println("VICTOR setting hostStatusWebhook")
 		fleet.ValidateEnabledHostStatusIntegrations(*spec.WebhookSettings.HostStatusWebhook, invalid)
 		team.Config.WebhookSettings.HostStatusWebhook = *spec.WebhookSettings.HostStatusWebhook
-	} else {
-		fmt.Println("VICTOR hostStatusWebhook is nil")
 	}
 	if invalid.HasErrors() {
 		return ctxerr.Wrap(ctx, invalid)

--- a/ee/server/service/teams.go
+++ b/ee/server/service/teams.go
@@ -866,22 +866,34 @@ func (svc *Service) createTeamFromSpec(
 		}
 	}
 
+	invalid := &fleet.InvalidArgumentError{}
 	if enableDiskEncryption && !appCfg.MDM.AtLeastOnePlatformEnabledAndConfigured() {
-		return nil, ctxerr.Wrap(ctx, fleet.NewInvalidArgumentError("mdm",
-			`Couldn't edit enable_disk_encryption. Neither macOS MDM nor Windows is turned on. Visit https://fleetdm.com/docs/using-fleet to learn how to turn on MDM.`))
+		invalid.Append(
+			"mdm",
+			`Couldn't edit enable_disk_encryption. Neither macOS MDM nor Windows is turned on. Visit https://fleetdm.com/docs/using-fleet to learn how to turn on MDM.`,
+		)
 	}
 
 	var hostExpirySettings fleet.HostExpirySettings
 	if spec.HostExpirySettings != nil {
 		if spec.HostExpirySettings.HostExpiryEnabled && spec.HostExpirySettings.HostExpiryWindow <= 0 {
-			return nil, ctxerr.Wrap(
-				ctx, fleet.NewInvalidArgumentError(
-					"host_expiry_settings.host_expiry_window",
-					`When enabling host expiry, host expiry window must be a positive number.`,
-				),
+			invalid.Append(
+				"host_expiry_settings.host_expiry_window", "When enabling host expiry, host expiry window must be a positive number.",
 			)
 		}
 		hostExpirySettings = *spec.HostExpirySettings
+	}
+
+	hostStatusWebhook := fleet.HostStatusWebhookSettings{}
+	if spec.WebhookSettings.HostStatusWebhook != nil {
+		fmt.Println("VICTOR setting hostStatusWebhook")
+		fleet.ValidateEnabledHostStatusIntegrations(*spec.WebhookSettings.HostStatusWebhook, invalid)
+		hostStatusWebhook = *spec.WebhookSettings.HostStatusWebhook
+	} else {
+		fmt.Println("VICTOR hostStatusWebhook is nil")
+	}
+	if invalid.HasErrors() {
+		return nil, ctxerr.Wrap(ctx, invalid)
 	}
 
 	if dryRun {
@@ -901,6 +913,9 @@ func (svc *Service) createTeamFromSpec(
 				MacOSSetup:           macOSSetup,
 			},
 			HostExpirySettings: hostExpirySettings,
+			WebhookSettings: fleet.TeamWebhookSettings{
+				HostStatusWebhook: hostStatusWebhook,
+			},
 		},
 		Secrets: secrets,
 	})
@@ -1038,16 +1053,26 @@ func (svc *Service) editTeamFromSpec(
 	}
 
 	// if host_expiry_settings are not provided, do not change them
+	invalid := &fleet.InvalidArgumentError{}
 	if spec.HostExpirySettings != nil {
 		if spec.HostExpirySettings.HostExpiryEnabled && spec.HostExpirySettings.HostExpiryWindow <= 0 {
-			return ctxerr.Wrap(
-				ctx, fleet.NewInvalidArgumentError(
-					"host_expiry_settings.host_expiry_window",
-					`When enabling host expiry, host expiry window must be a positive number.`,
-				),
+			invalid.Append(
+				"host_expiry_settings.host_expiry_window", "When enabling host expiry, host expiry window must be a positive number.",
 			)
 		}
 		team.Config.HostExpirySettings = *spec.HostExpirySettings
+	}
+
+	// If host status webhook is not provided, do not change it
+	if spec.WebhookSettings.HostStatusWebhook != nil {
+		fmt.Println("VICTOR setting hostStatusWebhook")
+		fleet.ValidateEnabledHostStatusIntegrations(*spec.WebhookSettings.HostStatusWebhook, invalid)
+		team.Config.WebhookSettings.HostStatusWebhook = *spec.WebhookSettings.HostStatusWebhook
+	} else {
+		fmt.Println("VICTOR hostStatusWebhook is nil")
+	}
+	if invalid.HasErrors() {
+		return ctxerr.Wrap(ctx, invalid)
 	}
 
 	if dryRun {

--- a/server/datastore/mysql/hosts.go
+++ b/server/datastore/mysql/hosts.go
@@ -2793,30 +2793,41 @@ func saveHostUsersDB(ctx context.Context, tx sqlx.ExtContext, hostID uint, users
 	return nil
 }
 
-func (ds *Datastore) TotalAndUnseenHostsSince(ctx context.Context, daysCount int) (total int, unseen int, err error) {
-	var counts struct {
-		Total  int `db:"total"`
-		Unseen int `db:"unseen"`
+func (ds *Datastore) TotalAndUnseenHostsSince(ctx context.Context, teamID *uint, daysCount int) (total int, unseen []uint, err error) {
+	// convert daysCount to integer number of seconds for more precision in sql query
+	var args []interface{}
+	totalQuery := `SELECT COUNT(*) as total`
+	if teamID != nil {
+		totalQuery += " WHERE team_id = ?"
+		args = append(args, *teamID)
 	}
 
-	// convert daysCount to integer number of seconds for more precision in sql query
-	unseenSeconds := daysCount * 24 * 60 * 60
-
-	err = sqlx.GetContext(ctx, ds.reader(ctx), &counts,
-		`SELECT
-			COUNT(*) as total,
-			SUM(IF(TIMESTAMPDIFF(SECOND, COALESCE(hst.seen_time, h.created_at), CURRENT_TIMESTAMP) >= ?, 1, 0)) as unseen
-		FROM hosts h
-		LEFT JOIN host_seen_times hst
-		ON h.id = hst.host_id`,
-		unseenSeconds,
-	)
+	err = sqlx.GetContext(ctx, ds.reader(ctx), &total, totalQuery, args...)
 
 	if err != nil {
-		return 0, 0, ctxerr.Wrap(ctx, err, "getting total and unseen host counts")
+		return 0, nil, ctxerr.Wrap(ctx, err, "getting total host counts")
 	}
 
-	return counts.Total, counts.Unseen, nil
+	unseenSeconds := daysCount * 24 * 60 * 60
+	args = []interface{}{unseenSeconds}
+	unseenQuery := `SELECT id
+		FROM hosts h
+		LEFT JOIN host_seen_times hst
+		ON h.id = hst.host_id
+		WHERE TIMESTAMPDIFF(SECOND, COALESCE(hst.seen_time, h.created_at), CURRENT_TIMESTAMP) >= ?`
+
+	if teamID != nil {
+		unseenQuery += " AND team_id = ?"
+		args = append(args, *teamID)
+	}
+
+	err = sqlx.GetContext(ctx, ds.reader(ctx), &unseen, unseenQuery, args...)
+
+	if err != nil {
+		return total, nil, ctxerr.Wrap(ctx, err, "getting unseen host counts")
+	}
+
+	return
 }
 
 func (ds *Datastore) DeleteHosts(ctx context.Context, ids []uint) error {

--- a/server/datastore/mysql/hosts.go
+++ b/server/datastore/mysql/hosts.go
@@ -2796,7 +2796,7 @@ func saveHostUsersDB(ctx context.Context, tx sqlx.ExtContext, hostID uint, users
 func (ds *Datastore) TotalAndUnseenHostsSince(ctx context.Context, teamID *uint, daysCount int) (total int, unseen []uint, err error) {
 	// convert daysCount to integer number of seconds for more precision in sql query
 	var args []interface{}
-	totalQuery := `SELECT COUNT(*) as total`
+	totalQuery := `SELECT COUNT(*) FROM hosts`
 	if teamID != nil {
 		totalQuery += " WHERE team_id = ?"
 		args = append(args, *teamID)
@@ -2821,7 +2821,7 @@ func (ds *Datastore) TotalAndUnseenHostsSince(ctx context.Context, teamID *uint,
 		args = append(args, *teamID)
 	}
 
-	err = sqlx.GetContext(ctx, ds.reader(ctx), &unseen, unseenQuery, args...)
+	err = sqlx.SelectContext(ctx, ds.reader(ctx), &unseen, unseenQuery, args...)
 
 	if err != nil {
 		return total, nil, ctxerr.Wrap(ctx, err, "getting unseen host counts")

--- a/server/fleet/datastore.go
+++ b/server/fleet/datastore.go
@@ -266,7 +266,7 @@ type Datastore interface {
 	// AddHostsToTeam adds hosts to an existing team, clearing their team settings if teamID is nil.
 	AddHostsToTeam(ctx context.Context, teamID *uint, hostIDs []uint) error
 
-	TotalAndUnseenHostsSince(ctx context.Context, daysCount int) (total int, unseen int, err error)
+	TotalAndUnseenHostsSince(ctx context.Context, teamID *uint, daysCount int) (total int, unseen []uint, err error)
 
 	// DeleteHosts deletes associated tables for multiple hosts.
 	//

--- a/server/fleet/teams.go
+++ b/server/fleet/teams.go
@@ -148,6 +148,7 @@ type TeamConfig struct {
 }
 
 type TeamWebhookSettings struct {
+	HostStatusWebhook      HostStatusWebhookSettings      `json:"host_status_webhook"`
 	FailingPoliciesWebhook FailingPoliciesWebhookSettings `json:"failing_policies_webhook"`
 }
 
@@ -395,12 +396,17 @@ type TeamSpec struct {
 	// If the agent_options key is present but empty in the YAML, will be set to
 	// "null" (JSON null). Otherwise, if the key is present and set, it will be
 	// set to the agent options JSON object.
-	AgentOptions       json.RawMessage       `json:"agent_options,omitempty"` // marshals as "null" if omitempty is not set
-	HostExpirySettings *HostExpirySettings   `json:"host_expiry_settings,omitempty"`
-	Secrets            []EnrollSecret        `json:"secrets,omitempty"`
-	Features           *json.RawMessage      `json:"features"`
-	MDM                TeamSpecMDM           `json:"mdm"`
-	Scripts            optjson.Slice[string] `json:"scripts"`
+	AgentOptions       json.RawMessage         `json:"agent_options,omitempty"` // marshals as "null" if omitempty is not set
+	HostExpirySettings *HostExpirySettings     `json:"host_expiry_settings,omitempty"`
+	Secrets            []EnrollSecret          `json:"secrets,omitempty"`
+	Features           *json.RawMessage        `json:"features"`
+	MDM                TeamSpecMDM             `json:"mdm"`
+	Scripts            optjson.Slice[string]   `json:"scripts"`
+	WebhookSettings    TeamSpecWebhookSettings `json:"webhook_settings"`
+}
+
+type TeamSpecWebhookSettings struct {
+	HostStatusWebhook *HostStatusWebhookSettings `json:"host_status_webhook"`
 }
 
 // TeamSpecFromTeam returns a TeamSpec constructed from the given Team.

--- a/server/mock/datastore_mock.go
+++ b/server/mock/datastore_mock.go
@@ -198,7 +198,7 @@ type HostLiteByIDFunc func(ctx context.Context, id uint) (*fleet.HostLite, error
 
 type AddHostsToTeamFunc func(ctx context.Context, teamID *uint, hostIDs []uint) error
 
-type TotalAndUnseenHostsSinceFunc func(ctx context.Context, daysCount int) (total int, unseen int, err error)
+type TotalAndUnseenHostsSinceFunc func(ctx context.Context, teamID *uint, daysCount int) (total int, unseen []uint, err error)
 
 type DeleteHostsFunc func(ctx context.Context, ids []uint) error
 
@@ -2702,11 +2702,11 @@ func (s *DataStore) AddHostsToTeam(ctx context.Context, teamID *uint, hostIDs []
 	return s.AddHostsToTeamFunc(ctx, teamID, hostIDs)
 }
 
-func (s *DataStore) TotalAndUnseenHostsSince(ctx context.Context, daysCount int) (total int, unseen int, err error) {
+func (s *DataStore) TotalAndUnseenHostsSince(ctx context.Context, teamID *uint, daysCount int) (total int, unseen []uint, err error) {
 	s.mu.Lock()
 	s.TotalAndUnseenHostsSinceFuncInvoked = true
 	s.mu.Unlock()
-	return s.TotalAndUnseenHostsSinceFunc(ctx, daysCount)
+	return s.TotalAndUnseenHostsSinceFunc(ctx, teamID, daysCount)
 }
 
 func (s *DataStore) DeleteHosts(ctx context.Context, ids []uint) error {

--- a/server/service/client.go
+++ b/server/service/client.go
@@ -909,6 +909,18 @@ func (c *Client) DoGitOps(
 		}
 		team["scripts"] = scripts
 		team["secrets"] = config.TeamSettings["secrets"]
+		team["webhook_settings"] = map[string]interface{}{}
+		clearHostStatusWebhook := true
+		if webhookSettings, ok := config.TeamSettings["webhook_settings"]; ok {
+			if hostStatusWebhook, ok := webhookSettings.(map[string]interface{})["host_status_webhook"]; ok {
+				clearHostStatusWebhook = false
+				team["webhook_settings"].(map[string]interface{})["host_status_webhook"] = hostStatusWebhook
+			}
+		}
+		if clearHostStatusWebhook {
+			// Clear out any existing host_status_webhook settings
+			team["webhook_settings"].(map[string]interface{})["host_status_webhook"] = map[string]interface{}{}
+		}
 		team["mdm"] = map[string]interface{}{}
 		mdmAppConfig = team["mdm"].(map[string]interface{})
 	}

--- a/server/service/integration_enterprise_test.go
+++ b/server/service/integration_enterprise_test.go
@@ -1313,9 +1313,15 @@ func (s *integrationEnterpriseTestSuite) TestExternalIntegrationsTeamConfig() {
 			Enable:         true,
 			DestinationURL: "http://example.com",
 		},
+		HostStatusWebhook: fleet.HostStatusWebhookSettings{
+			Enable:         true,
+			DestinationURL: "http://example.com/host_status_webhook",
+		},
 	}}, http.StatusOK, &tmResp)
 	require.True(t, tmResp.Team.Config.WebhookSettings.FailingPoliciesWebhook.Enable)
 	require.Equal(t, "http://example.com", tmResp.Team.Config.WebhookSettings.FailingPoliciesWebhook.DestinationURL)
+	require.True(t, tmResp.Team.Config.WebhookSettings.HostStatusWebhook.Enable)
+	require.Equal(t, "http://example.com/host_status_webhook", tmResp.Team.Config.WebhookSettings.HostStatusWebhook.DestinationURL)
 
 	// add an unknown automation - does not exist at the global level
 	s.DoJSON("PATCH", fmt.Sprintf("/api/latest/fleet/teams/%d", team.ID), fleet.TeamPayload{Integrations: &fleet.TeamIntegrations{

--- a/server/webhooks/host_status.go
+++ b/server/webhooks/host_status.go
@@ -87,7 +87,7 @@ func triggerTeamHostStatusWebhook(ctx context.Context, ds fleet.Datastore, logge
 		if err != nil {
 			return ctxerr.Wrap(ctx, err, "getting team")
 		}
-		if !team.Config.WebhookSettings.FailingPoliciesWebhook.Enable {
+		if !team.Config.WebhookSettings.HostStatusWebhook.Enable {
 			continue
 		}
 		level.Debug(logger).Log("team", teamSummary.ID, "enable_host_status_webhook", "true")

--- a/server/webhooks/host_status.go
+++ b/server/webhooks/host_status.go
@@ -16,6 +16,14 @@ func TriggerHostStatusWebhook(
 	ds fleet.Datastore,
 	logger kitlog.Logger,
 ) error {
+	err := triggerGlobalHostStatusWebhook(ctx, ds, logger)
+	if err != nil {
+		return err
+	}
+	return triggerTeamHostStatusWebhook(ctx, ds, logger)
+}
+
+func triggerGlobalHostStatusWebhook(ctx context.Context, ds fleet.Datastore, logger kitlog.Logger) error {
 	appConfig, err := ds.AppConfig(ctx)
 	if err != nil {
 		return ctxerr.Wrap(ctx, err, "getting app config")
@@ -25,34 +33,67 @@ func TriggerHostStatusWebhook(
 		return nil
 	}
 
-	level.Debug(logger).Log("enabled", "true")
+	level.Debug(logger).Log("global", "true", "enable_host_status_webhook", "true")
 
-	total, unseen, err := ds.TotalAndUnseenHostsSince(ctx, appConfig.WebhookSettings.HostStatusWebhook.DaysCount)
+	return processWebhook(ctx, ds, nil, appConfig.WebhookSettings.HostStatusWebhook)
+}
+
+func processWebhook(ctx context.Context, ds fleet.Datastore, teamID *uint, settings fleet.HostStatusWebhookSettings) error {
+	total, unseen, err := ds.TotalAndUnseenHostsSince(ctx, teamID, settings.DaysCount)
 	if err != nil {
 		return ctxerr.Wrap(ctx, err, "getting total and unseen hosts")
 	}
 
-	percentUnseen := float64(unseen) * 100.0 / float64(total)
-	if percentUnseen >= appConfig.WebhookSettings.HostStatusWebhook.HostPercentage {
-		url := appConfig.WebhookSettings.HostStatusWebhook.DestinationURL
+	unseenCount := len(unseen)
+	percentUnseen := float64(unseenCount) * 100.0 / float64(total)
+	if percentUnseen >= settings.HostPercentage {
+		url := settings.DestinationURL
 
 		message := fmt.Sprintf(
 			"More than %.2f%% of your hosts have not checked into Fleet for more than %d days. "+
 				"You've been sent this message because the Host status webhook is enabled in your Fleet instance.",
-			percentUnseen, appConfig.WebhookSettings.HostStatusWebhook.DaysCount,
+			percentUnseen, settings.DaysCount,
 		)
 		payload := map[string]interface{}{
 			"text": message,
 			"data": map[string]interface{}{
-				"unseen_hosts": unseen,
+				"unseen_hosts": unseenCount,
 				"total_hosts":  total,
-				"days_unseen":  appConfig.WebhookSettings.HostStatusWebhook.DaysCount,
+				"days_unseen":  settings.DaysCount,
+				"host_ids":     unseen,
 			},
+		}
+		if teamID != nil {
+			payload["data"].(map[string]interface{})["team_id"] = *teamID
 		}
 
 		err = server.PostJSONWithTimeout(ctx, url, &payload)
 		if err != nil {
 			return ctxerr.Wrapf(ctx, err, "posting to %s", url)
+		}
+	}
+
+	return nil
+}
+
+func triggerTeamHostStatusWebhook(ctx context.Context, ds fleet.Datastore, logger kitlog.Logger) error {
+
+	teams, err := ds.TeamsSummary(ctx)
+	if err != nil {
+		return ctxerr.Wrap(ctx, err, "getting teams summary")
+	}
+	for _, teamSummary := range teams {
+		team, err := ds.Team(ctx, teamSummary.ID)
+		if err != nil {
+			return ctxerr.Wrap(ctx, err, "getting team")
+		}
+		if !team.Config.WebhookSettings.FailingPoliciesWebhook.Enable {
+			continue
+		}
+		level.Debug(logger).Log("team", teamSummary.ID, "enable_host_status_webhook", "true")
+		err = processWebhook(ctx, ds, &teamSummary.ID, team.Config.WebhookSettings.HostStatusWebhook)
+		if err != nil {
+			return err
 		}
 	}
 

--- a/server/webhooks/host_status_test.go
+++ b/server/webhooks/host_status_test.go
@@ -41,22 +41,26 @@ func TestTriggerHostStatusWebhook(t *testing.T) {
 		return ac, nil
 	}
 
-	ds.TotalAndUnseenHostsSinceFunc = func(ctx context.Context, daysCount int) (int, int, error) {
+	ds.TotalAndUnseenHostsSinceFunc = func(ctx context.Context, teamID *uint, daysCount int) (int, []uint, error) {
 		assert.Equal(t, 2, daysCount)
-		return 10, 6, nil
+		return 10, []uint{1, 2, 3, 4, 5, 6}, nil
+	}
+
+	ds.TeamsSummaryFunc = func(ctx context.Context) ([]*fleet.TeamSummary, error) {
+		return nil, nil
 	}
 
 	require.NoError(t, TriggerHostStatusWebhook(context.Background(), ds, kitlog.NewNopLogger()))
 	assert.Equal(
 		t,
-		`{"data":{"days_unseen":2,"total_hosts":10,"unseen_hosts":6},"text":"More than 60.00% of your hosts have not checked into Fleet for more than 2 days. You've been sent this message because the Host status webhook is enabled in your Fleet instance."}`,
+		`{"data":{"days_unseen":2,"host_ids":[1,2,3,4,5,6],"total_hosts":10,"unseen_hosts":6},"text":"More than 60.00% of your hosts have not checked into Fleet for more than 2 days. You've been sent this message because the Host status webhook is enabled in your Fleet instance."}`,
 		requestBody,
 	)
 	requestBody = ""
 
-	ds.TotalAndUnseenHostsSinceFunc = func(ctx context.Context, daysCount int) (int, int, error) {
+	ds.TotalAndUnseenHostsSinceFunc = func(ctx context.Context, teamID *uint, daysCount int) (int, []uint, error) {
 		assert.Equal(t, 2, daysCount)
-		return 10, 1, nil
+		return 10, []uint{1}, nil
 	}
 
 	require.NoError(t, TriggerHostStatusWebhook(context.Background(), ds, kitlog.NewNopLogger()))

--- a/server/webhooks/host_status_test.go
+++ b/server/webhooks/host_status_test.go
@@ -18,11 +18,13 @@ func TestTriggerHostStatusWebhook(t *testing.T) {
 	ds := new(mock.Store)
 
 	requestBody := ""
+	count := 0
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestBodyBytes, err := io.ReadAll(r.Body)
 		require.NoError(t, err)
 		requestBody = string(requestBodyBytes)
+		count++
 	}))
 	defer ts.Close()
 
@@ -56,8 +58,9 @@ func TestTriggerHostStatusWebhook(t *testing.T) {
 		`{"data":{"days_unseen":2,"host_ids":[1,2,3,4,5,6],"total_hosts":10,"unseen_hosts":6},"text":"More than 60.00% of your hosts have not checked into Fleet for more than 2 days. You've been sent this message because the Host status webhook is enabled in your Fleet instance."}`,
 		requestBody,
 	)
-	requestBody = ""
+	assert.Equal(t, 1, count)
 
+	requestBody = ""
 	ds.TotalAndUnseenHostsSinceFunc = func(ctx context.Context, teamID *uint, daysCount int) (int, []uint, error) {
 		assert.Equal(t, 2, daysCount)
 		return 10, []uint{1}, nil
@@ -65,4 +68,85 @@ func TestTriggerHostStatusWebhook(t *testing.T) {
 
 	require.NoError(t, TriggerHostStatusWebhook(context.Background(), ds, kitlog.NewNopLogger()))
 	assert.Equal(t, "", requestBody)
+	assert.Equal(t, 1, count)
+}
+
+func TestTriggerHostStatusWebhookTeam(t *testing.T) {
+	ds := new(mock.Store)
+
+	requestBody := ""
+	count := 0
+
+	ts := httptest.NewServer(
+		http.HandlerFunc(
+			func(w http.ResponseWriter, r *http.Request) {
+				requestBodyBytes, err := io.ReadAll(r.Body)
+				require.NoError(t, err)
+				requestBody = string(requestBodyBytes)
+				count++
+			},
+		),
+	)
+	defer ts.Close()
+
+	ac := &fleet.AppConfig{
+		WebhookSettings: fleet.WebhookSettings{
+			HostStatusWebhook: fleet.HostStatusWebhookSettings{
+				Enable:         false,
+				DestinationURL: ts.URL,
+				HostPercentage: 43,
+				DaysCount:      3,
+			},
+		},
+	}
+	teamSettings := fleet.HostStatusWebhookSettings{
+		Enable:         true,
+		DestinationURL: ts.URL,
+		HostPercentage: 43,
+		DaysCount:      2,
+	}
+
+	ds.AppConfigFunc = func(context.Context) (*fleet.AppConfig, error) {
+		return ac, nil
+	}
+
+	ds.TotalAndUnseenHostsSinceFunc = func(ctx context.Context, teamID *uint, daysCount int) (int, []uint, error) {
+		assert.Equal(t, 2, daysCount)
+		assert.Equal(t, uint(1), *teamID)
+		return 10, []uint{1, 2, 3, 4, 5, 6}, nil
+	}
+
+	ds.TeamsSummaryFunc = func(ctx context.Context) ([]*fleet.TeamSummary, error) {
+		return []*fleet.TeamSummary{{ID: 1}}, nil
+	}
+	ds.TeamFunc = func(ctx context.Context, id uint) (*fleet.Team, error) {
+		assert.Equal(t, uint(1), id)
+		return &fleet.Team{
+			ID: 1,
+			Config: fleet.TeamConfig{
+				WebhookSettings: fleet.TeamWebhookSettings{
+					HostStatusWebhook: teamSettings,
+				},
+			},
+		}, nil
+	}
+
+	require.NoError(t, TriggerHostStatusWebhook(context.Background(), ds, kitlog.NewNopLogger()))
+	assert.Equal(
+		t,
+		`{"data":{"days_unseen":2,"host_ids":[1,2,3,4,5,6],"team_id":1,"total_hosts":10,"unseen_hosts":6},"text":"More than 60.00% of your hosts have not checked into Fleet for more than 2 days. You've been sent this message because the Host status webhook is enabled in your Fleet instance."}`,
+		requestBody,
+	)
+	assert.Equal(t, 1, count)
+
+	requestBody = ""
+	ds.TotalAndUnseenHostsSinceFunc = func(ctx context.Context, teamID *uint, daysCount int) (int, []uint, error) {
+		assert.Equal(t, 2, daysCount)
+		assert.Equal(t, uint(1), *teamID)
+		return 10, []uint{1}, nil
+	}
+
+	require.NoError(t, TriggerHostStatusWebhook(context.Background(), ds, kitlog.NewNopLogger()))
+	assert.Equal(t, "", requestBody)
+	assert.Equal(t, 1, count)
 }


### PR DESCRIPTION
Enabling setting host status webhook at the team level via REST API and fleetctl apply/gitops.
#14916

Example payload:
```json
{
    "data": {
        "days_unseen": 3,
        "host_ids": [
            10724,
            10726,
            10738,
            10739,
            10740,
            10741,
            10742,
            10744,
            10745,
            10746,
            10747,
            10748,
            10749
        ],
        "team_id": 3,
        "total_hosts": 15,
        "unseen_hosts": 13
    },
    "text": "More than 86.67% of your hosts have not checked into Fleet for more than 3 days. You've been sent this message because the Host status webhook is enabled in your Fleet instance."
}
```

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [x] Added/updated tests
- [x] Manual QA for all new/changed functionality
