### PR TITLE
Website: update `get-extended-osquery-schema` helper

### DIFF
--- a/schema/osquery_fleet_schema.json
+++ b/schema/osquery_fleet_schema.json
@@ -3698,9 +3698,7 @@
     "evented": false,
     "cacheable": false,
     "notes": "",
-    "examples": [
-      "SELECT chrome_extension_content_scripts.* FROM users JOIN chrome_extension_content_scripts USING (uid) GROUP BY identifier, match"
-    ],
+    "examples": "```\nSELECT chrome_extension_content_scripts.* FROM users JOIN chrome_extension_content_scripts USING (uid) GROUP BY identifier, match\n```",
     "columns": [
       {
         "name": "browser_type",
@@ -8933,10 +8931,7 @@
     "evented": false,
     "cacheable": false,
     "notes": "",
-    "examples": [
-      "select * from docker_volumes",
-      "select * from docker_volumes where name = 'btrfs'"
-    ],
+    "examples": "```\nselect * from docker_volumes where name = 'btrfs'\n```",
     "columns": [
       {
         "name": "name",
@@ -11881,11 +11876,7 @@
     "evented": false,
     "cacheable": true,
     "notes": "",
-    "examples": [
-      "select interface, mac, type, idrops as input_drops from interface_details;",
-      "select interface, mac, type, flags, (1<<8) as promisc_flag from interface_details where (flags & promisc_flag) > 0;",
-      "select interface, mac, type, flags, (1<<3) as loopback_flag from interface_details where (flags & loopback_flag) > 0;"
-    ],
+    "examples": "```\nselect interface, mac, type, flags, (1<<3) as loopback_flag from interface_details where (flags & loopback_flag) > 0;\n```",
     "columns": [
       {
         "name": "interface",
@@ -13343,9 +13334,7 @@
     "evented": false,
     "cacheable": false,
     "notes": "",
-    "examples": [
-      "select * from users join known_hosts using (uid)"
-    ],
+    "examples": "```\nselect * from users join known_hosts using (uid)\n```",
     "columns": [
       {
         "name": "uid",
@@ -22907,10 +22896,7 @@
     "evented": false,
     "cacheable": false,
     "notes": "- Includes installed extensions for all system users.",
-    "examples": [
-      "select * from safari_extensions where uid=501",
-      "select count(*) from users JOIN safari_extensions using (uid)"
-    ],
+    "examples": "```\nselect count(*) from users JOIN safari_extensions using (uid)\n```",
     "columns": [
       {
         "name": "uid",

--- a/website/api/helpers/get-extended-osquery-schema.js
+++ b/website/api/helpers/get-extended-osquery-schema.js
@@ -159,6 +159,13 @@ module.exports = {
           } else {
             expandedTableToPush.examples = _.clone(fleetOverridesForTable.examples);
           }
+        } else {
+          // If the override file does not contain an 'examples' value, we'll use the last example from the osquery schema (See above for more information about the reasoning behind this)
+          let examplesFromOsquerySchema = expandedTableToPush.examples;
+          if (examplesFromOsquerySchema.length > 0) {
+            // Examples are parsed as markdown, so we wrap the example in a code fence so it renders as a code block.
+            expandedTableToPush.examples = '```\n' + examplesFromOsquerySchema[examplesFromOsquerySchema.length - 1] + '\n```';
+          }
         }
         if(fleetOverridesForTable.notes !== undefined) {
           if(typeof fleetOverridesForTable.notes !== 'string') {


### PR DESCRIPTION
Closes: https://github.com/fleetdm/fleet/issues/17188

Changes:
- Updated `get-extended-osquery-schema.js` to only include the last example from the osquery schema if a table has an override file that does not contain an `examples` value.
- Regenerated osquery_fleet_schema.json with the correct `examples` values
