### PR TITLE
Fix "Team policies" API docs heading

### DIFF
--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -5917,7 +5917,7 @@ Triggers [automations](https://fleetdm.com/docs/using-fleet/automations#policy-a
 
 ---
 
-### Team policies
+## Team policies
 
 - [List team policies](#list-team-policies)
 - [Count team policies](#count-team-policies)


### PR DESCRIPTION
Change from h3 to h2 so it's visible in the side navigation.