### PR TITLE
Website: Update order product category sections on homepage

### DIFF
--- a/website/views/pages/homepage.ejs
+++ b/website/views/pages/homepage.ejs
@@ -86,26 +86,8 @@
         </div>
       </div>
 
-      <%/* Device management block */%>
-      <div purpose="platform-block" class="d-flex flex-md-row flex-column-reverse justify-content-md-between mx-auto align-items-center">
-        <div purpose="category-text-block" class="d-flex flex-column">
-          <h4>Device management</h4>
-          <h3>Manage everything in one place</h3>
-          <p>Modernize your device management practice with a single, open platform for Apple, Windows, and Linux. De-risk config changes, automate security audits, and clear the way for “zero trust access” in your org.</p>
-          <div>
-            <a purpose="category-button" class="text-nowrap btn btn-primary" href="/device-management">Start with device management</a>
-          </div>
-        </div>
-        <div purpose="device-management-image">
-          <img alt="Operating systems entering a glass device management dome" src="/images/device-management-hero-380x293@2x.png">
-        </div>
-      </div>
-
       <%/* Endpoint ops block */%>
-      <div purpose="platform-block" class="d-flex flex-md-row flex-column justify-content-md-between mx-auto align-items-center">
-        <div purpose="endpoint-ops-image">
-          <img alt="Endpoint ops" src="images/endpoint-operations-hero-image-380x383@2x.png">
-        </div>
+      <div purpose="platform-block" class="d-flex flex-md-row flex-column-reverse justify-content-md-between mx-auto align-items-center">
         <div purpose="category-text-block" class="d-flex flex-column">
           <h4>Endpoint ops</h4>
           <h3>A consistent interface</h3>
@@ -114,7 +96,26 @@
             <a purpose="category-button" class="text-nowrap btn btn-primary" href="/endpoint-ops">Start with endpoint ops</a>
           </div>
         </div>
+        <div purpose="endpoint-ops-image">
+          <img alt="Endpoint ops" src="images/endpoint-operations-hero-image-380x383@2x.png">
+        </div>
       </div>
+
+      <%/* Device management block */%>
+      <div purpose="platform-block" class="d-flex flex-md-row flex-column justify-content-md-between mx-auto align-items-center">
+        <div purpose="device-management-image">
+          <img alt="Operating systems entering a glass device management dome" src="/images/device-management-hero-380x293@2x.png">
+        </div>
+        <div purpose="category-text-block" class="d-flex flex-column">
+          <h4>Device management</h4>
+          <h3>Manage everything in one place</h3>
+          <p>Modernize your device management practice with a single, open platform for Apple, Windows, and Linux. De-risk config changes, automate security audits, and clear the way for “zero trust access” in your org.</p>
+          <div>
+            <a purpose="category-button" class="text-nowrap btn btn-primary" href="/device-management">Start with device management</a>
+          </div>
+        </div>
+      </div>
+
 
       <%/* Vulnerability management block */%>
       <div purpose="platform-block" class="d-flex flex-md-row flex-column-reverse justify-content-md-between mx-auto align-items-center">


### PR DESCRIPTION
Closes: https://github.com/fleetdm/confidential/issues/5557

Changes:
- Moved the endpoint ops section to the top of the product categories on the homepage.