### PR TITLE
Website: update relative link validation in markdown content

### DIFF
--- a/docs/Contributing/API-for-contributors.md
+++ b/docs/Contributing/API-for-contributors.md
@@ -2578,7 +2578,7 @@ Notifies the server about an agent error, resulting in two outcomes:
 - The error gets saved in Redis and can later be accessed using `fleetctl debug archive`.
 - The server consistently replies with a `500` status code, which can serve as a signal to activate an alarm through a monitoring tool.
 
-> Note: to allow `fleetd` agents to use this endpoint, you need to set a [custom environment variable](./Configuration-for-contributors#fleet_enable_post_client_debug_errors)
+> Note: to allow `fleetd` agents to use this endpoint, you need to set a [custom environment variable](./Configuration-for-contributors.md#fleet_enable_post_client_debug_errors)
 
 `POST /api/v1/fleet/device/{token}/debug/errors`
 

--- a/docs/Contributing/Configuration-for-contributors.md
+++ b/docs/Contributing/Configuration-for-contributors.md
@@ -366,7 +366,7 @@ Whether the SMTP server's SSL certificates should be verified. This can be turne
 
 ### FLEET_ENABLE_POST_CLIENT_DEBUG_ERRORS
 
-Use this environment variable to allow `fleetd` to report errors to the server using the [endpoint to report an agent error](./API-for-contributors#report-an-agent-error).
+Use this environment variable to allow `fleetd` to report errors to the server using the [endpoint to report an agent error](./API-for-contributors.md#report-an-agent-error).
 
 <meta name="pageOrderInSection" value="1100">
 <meta name="description" value="Learn about the configuration files and settings that are helpful when developing or contributing to Fleet.">

--- a/website/scripts/build-static-content.js
+++ b/website/scripts/build-static-content.js
@@ -276,6 +276,11 @@ module.exports = {
                 // ```
                 let referencedPageSourcePath = path.resolve(path.join(topLvlRepoPath, sectionRepoPath, pageRelSourcePath), '../', oldRelPath);
                 let possibleReferencedUrlHash = oldRelPath.match(/(\.md#)([^/]*$)/) ? oldRelPath.match(/(\.md#)([^/]*$)/)[2] : false;
+                // Throw an error if any relative links containing hash links are missing the Markdown page's extension.
+                let pageContainsInvalidRelativeHashLink = oldRelPath.match(/[^(\.md)]#([^/]*$)/);
+                if(pageContainsInvalidRelativeHashLink){
+                  throw new Error(`Could not build HTML partials from Markdown. A page (${pageRelSourcePath}) contains an invalid relative Markdown link (${hrefString.replace(/^href=/, '')}). To resolve, make sure all relative links on this page that link to a specific section include the Markdown page extension (.md) and try running this script again.`);
+                }
                 let referencedPageNewUrl = 'https://fleetdm.com/' + (
                   (path.relative(topLvlRepoPath, referencedPageSourcePath).replace(/(^|\/)([^/]+)\.[^/]*$/, '$1$2').split(/\//).map((fileOrFolderName) => fileOrFolderName.toLowerCase().replace(/\s+/g, '-')).join('/'))
                   .split(/\//).map((fileOrFolderName) => encodeURIComponent(fileOrFolderName.replace(/^[0-9]+[\-]+/,''))).join('/')


### PR DESCRIPTION
Closes: #16797

Changes:
- Updated `build-static-content` to throw an error if an extensionless Markdown link containing a hash link is found.
- Fixed two broken relative links in the contributing documentation