### PR TITLE
API docs: Remove `mdm.device_status` and `mdm.pending_action` from list hosts response

### DIFF
--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -2027,7 +2027,7 @@ If `after` is being used with `created_at` or `updated_at`, the table must be sp
         "encryption_key_available": false,
         "enrollment_status": null,
         "name": "",
-        "server_url": null,
+        "server_url": null
       },
       "software": [
         {

--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -2028,8 +2028,6 @@ If `after` is being used with `created_at` or `updated_at`, the table must be sp
         "enrollment_status": null,
         "name": "",
         "server_url": null,
-        "device_status": "unlocked",
-        "pending_action": ""
       },
       "software": [
         {


### PR DESCRIPTION
The "List hosts" endpoint doesn't actually include this information.