### PR TITLE
For fleetctl gitops, when MDM configs are not explicitly defined in gitops yml file, they are now set to default values.

### DIFF
--- a/changes/17209-fleetctl-gitops-mdm-configs
+++ b/changes/17209-fleetctl-gitops-mdm-configs
@@ -1,1 +1,2 @@
 For fleetctl gitops, when MDM configs are not explicitly defined in gitops yml file, they are now set to default values.
+- GitOps user can now read fleet config, which is needed to determine if Fleet Premium is being used.

--- a/changes/17209-fleetctl-gitops-mdm-configs
+++ b/changes/17209-fleetctl-gitops-mdm-configs
@@ -1,0 +1,1 @@
+For fleetctl gitops, when MDM configs are not explicitly defined in gitops yml file, they are now set to default values.

--- a/cmd/fleetctl/gitops.go
+++ b/cmd/fleetctl/gitops.go
@@ -56,7 +56,14 @@ func gitopsCommand() *cli.Command {
 			logf := func(format string, a ...interface{}) {
 				_, _ = fmt.Fprintf(c.App.Writer, format, a...)
 			}
-			err = fleetClient.DoGitOps(c.Context, config, baseDir, logf, flDryRun)
+			appConfig, err := fleetClient.GetAppConfig()
+			if err != nil {
+				return err
+			}
+			if appConfig.License == nil {
+				return errors.New("no license struct found in app config")
+			}
+			err = fleetClient.DoGitOps(c.Context, config, baseDir, logf, flDryRun, appConfig.License.IsPremium())
 			if err != nil {
 				return err
 			}

--- a/cmd/fleetctl/gitops.go
+++ b/cmd/fleetctl/gitops.go
@@ -63,7 +63,7 @@ func gitopsCommand() *cli.Command {
 			if appConfig.License == nil {
 				return errors.New("no license struct found in app config")
 			}
-			err = fleetClient.DoGitOps(c.Context, config, baseDir, logf, flDryRun, appConfig.License.IsPremium())
+			err = fleetClient.DoGitOps(c.Context, config, baseDir, logf, flDryRun, appConfig)
 			if err != nil {
 				return err
 			}

--- a/cmd/fleetctl/gitops_enterprise_integration_test.go
+++ b/cmd/fleetctl/gitops_enterprise_integration_test.go
@@ -39,7 +39,6 @@ func (s *enterpriseIntegrationGitopsTestSuite) SetupSuite() {
 	appConf, err := s.ds.AppConfig(context.Background())
 	require.NoError(s.T(), err)
 	appConf.MDM.EnabledAndConfigured = true
-	appConf.MDM.WindowsEnabledAndConfigured = true
 	appConf.MDM.AppleBMEnabledAndConfigured = true
 	err = s.ds.SaveAppConfig(context.Background(), appConf)
 	require.NoError(s.T(), err)

--- a/cmd/fleetctl/gitops_enterprise_no_mdm_integration_test.go
+++ b/cmd/fleetctl/gitops_enterprise_no_mdm_integration_test.go
@@ -175,6 +175,4 @@ func (s *enterpriseNoMdmIntegrationGitopsTestSuite) removeControls(file string) 
 	require.NoError(t, err)
 	err = os.WriteFile(file, dataToWrite, os.ModePerm)
 	require.NoError(t, err)
-	b, err = os.ReadFile(file)
-	require.NoError(t, err)
 }

--- a/cmd/fleetctl/gitops_enterprise_no_mdm_integration_test.go
+++ b/cmd/fleetctl/gitops_enterprise_no_mdm_integration_test.go
@@ -36,28 +36,9 @@ type enterpriseNoMdmIntegrationGitopsTestSuite struct {
 func (s *enterpriseNoMdmIntegrationGitopsTestSuite) SetupSuite() {
 	s.withDS.SetupSuite("enterpriseNoMdmIntegrationGitopsTestSuite")
 
-	//appConf, err := s.ds.AppConfig(context.Background())
-	//require.NoError(s.T(), err)
-	//appConf.MDM.EnabledAndConfigured = true
-	//appConf.MDM.AppleBMEnabledAndConfigured = true
-	//err = s.ds.SaveAppConfig(context.Background(), appConf)
-	//require.NoError(s.T(), err)
-	//
-	//testCert, testKey, err := appleMdm.NewSCEPCACertKey()
-	//require.NoError(s.T(), err)
-	//testCertPEM := tokenpki.PEMCertificate(testCert.Raw)
-	//testKeyPEM := tokenpki.PEMRSAPrivateKey(testKey)
-
 	fleetCfg := config.TestConfig()
-	//config.SetTestMDMConfig(s.T(), &fleetCfg, testCertPEM, testKeyPEM, testBMToken, "../../server/service/testdata")
 	fleetCfg.Osquery.EnrollCooldown = 0
 
-	//mdmStorage, err := s.ds.NewMDMAppleMDMStorage(testCertPEM, testKeyPEM)
-	//require.NoError(s.T(), err)
-	//depStorage, err := s.ds.NewMDMAppleDEPStorage(*testBMToken)
-	//require.NoError(s.T(), err)
-	//scepStorage, err := s.ds.NewSCEPDepot(testCertPEM, testKeyPEM)
-	//require.NoError(s.T(), err)
 	redisPool := redistest.SetupRedis(s.T(), "zz", false, false, false)
 
 	serverConfig := service.TestServerOpts{
@@ -65,11 +46,7 @@ func (s *enterpriseNoMdmIntegrationGitopsTestSuite) SetupSuite() {
 			Tier: fleet.TierPremium,
 		},
 		FleetConfig: &fleetCfg,
-		//MDMStorage:  mdmStorage,
-		//DEPStorage:  depStorage,
-		//SCEPStorage: scepStorage,
-		Pool: redisPool,
-		//APNSTopic:   "com.apple.mgmt.External.10ac3ce5-4668-4e58-b69a-b2b5ce667589",
+		Pool:        redisPool,
 	}
 	users, server := service.RunServerForTestsWithDS(s.T(), s.ds, &serverConfig)
 	s.T().Setenv("FLEET_SERVER_ADDRESS", server.URL) // fleetctl always uses this env var in tests

--- a/cmd/fleetctl/gitops_integration_test.go
+++ b/cmd/fleetctl/gitops_integration_test.go
@@ -37,7 +37,6 @@ func (s *integrationGitopsTestSuite) SetupSuite() {
 	appConf, err := s.ds.AppConfig(context.Background())
 	require.NoError(s.T(), err)
 	appConf.MDM.EnabledAndConfigured = true
-	appConf.MDM.WindowsEnabledAndConfigured = true
 	appConf.MDM.AppleBMEnabledAndConfigured = true
 	err = s.ds.SaveAppConfig(context.Background(), appConf)
 	require.NoError(s.T(), err)

--- a/cmd/fleetctl/gitops_test.go
+++ b/cmd/fleetctl/gitops_test.go
@@ -24,16 +24,6 @@ func TestBasicGlobalGitOps(t *testing.T) {
 	_, ds := runServerWithMockedDS(t)
 
 	ds.BatchSetScriptsFunc = func(ctx context.Context, tmID *uint, scripts []*fleet.Script) error { return nil }
-	ds.BatchSetMDMProfilesFunc = func(
-		ctx context.Context, tmID *uint, macProfiles []*fleet.MDMAppleConfigProfile, winProfiles []*fleet.MDMWindowsConfigProfile,
-	) error {
-		return nil
-	}
-	ds.BulkSetPendingMDMHostProfilesFunc = func(
-		ctx context.Context, hostIDs []uint, teamIDs []uint, profileUUIDs []string, hostUUIDs []string,
-	) error {
-		return nil
-	}
 	ds.NewActivityFunc = func(ctx context.Context, user *fleet.User, activity fleet.ActivityDetails) error {
 		return nil
 	}
@@ -569,4 +559,10 @@ team_settings:
 	assert.Equal(t, secret, enrolledSecrets[0].Secret)
 	assert.False(t, savedTeam.Config.WebhookSettings.HostStatusWebhook.Enable)
 	assert.Equal(t, "", savedTeam.Config.WebhookSettings.HostStatusWebhook.DestinationURL)
+	assert.Empty(t, savedTeam.Config.MDM.MacOSSettings.CustomSettings)
+	assert.Empty(t, savedTeam.Config.MDM.WindowsSettings.CustomSettings.Value)
+	assert.Empty(t, savedTeam.Config.MDM.MacOSUpdates.Deadline.Value)
+	assert.Empty(t, savedTeam.Config.MDM.MacOSUpdates.MinimumVersion.Value)
+	assert.Empty(t, savedTeam.Config.MDM.MacOSSetup.BootstrapPackage.Value)
+	assert.False(t, savedTeam.Config.MDM.EnableDiskEncryption)
 }

--- a/cmd/fleetctl/gitops_test.go
+++ b/cmd/fleetctl/gitops_test.go
@@ -24,6 +24,16 @@ func TestBasicGlobalGitOps(t *testing.T) {
 	_, ds := runServerWithMockedDS(t)
 
 	ds.BatchSetScriptsFunc = func(ctx context.Context, tmID *uint, scripts []*fleet.Script) error { return nil }
+	ds.BatchSetMDMProfilesFunc = func(
+		ctx context.Context, tmID *uint, macProfiles []*fleet.MDMAppleConfigProfile, winProfiles []*fleet.MDMWindowsConfigProfile,
+	) error {
+		return nil
+	}
+	ds.BulkSetPendingMDMHostProfilesFunc = func(
+		ctx context.Context, hostIDs []uint, teamIDs []uint, profileUUIDs []string, hostUUIDs []string,
+	) error {
+		return nil
+	}
 	ds.NewActivityFunc = func(ctx context.Context, user *fleet.User, activity fleet.ActivityDetails) error {
 		return nil
 	}
@@ -122,6 +132,16 @@ func TestBasicTeamGitOps(t *testing.T) {
 	const secret = "TestSecret"
 
 	ds.BatchSetScriptsFunc = func(ctx context.Context, tmID *uint, scripts []*fleet.Script) error { return nil }
+	ds.BatchSetMDMProfilesFunc = func(
+		ctx context.Context, tmID *uint, macProfiles []*fleet.MDMAppleConfigProfile, winProfiles []*fleet.MDMWindowsConfigProfile,
+	) error {
+		return nil
+	}
+	ds.BulkSetPendingMDMHostProfilesFunc = func(
+		ctx context.Context, hostIDs []uint, teamIDs []uint, profileUUIDs []string, hostUUIDs []string,
+	) error {
+		return nil
+	}
 	ds.NewActivityFunc = func(ctx context.Context, user *fleet.User, activity fleet.ActivityDetails) error {
 		return nil
 	}

--- a/cmd/fleetctl/gitops_test.go
+++ b/cmd/fleetctl/gitops_test.go
@@ -23,6 +23,16 @@ const teamName = "Team Test"
 func TestBasicGlobalGitOps(t *testing.T) {
 	_, ds := runServerWithMockedDS(t)
 
+	ds.BatchSetMDMProfilesFunc = func(
+		ctx context.Context, tmID *uint, macProfiles []*fleet.MDMAppleConfigProfile, winProfiles []*fleet.MDMWindowsConfigProfile,
+	) error {
+		return nil
+	}
+	ds.BulkSetPendingMDMHostProfilesFunc = func(
+		ctx context.Context, hostIDs []uint, teamIDs []uint, profileUUIDs []string, hostUUIDs []string,
+	) error {
+		return nil
+	}
 	ds.BatchSetScriptsFunc = func(ctx context.Context, tmID *uint, scripts []*fleet.Script) error { return nil }
 	ds.NewActivityFunc = func(ctx context.Context, user *fleet.User, activity fleet.ActivityDetails) error {
 		return nil

--- a/server/authz/policy.rego
+++ b/server/authz/policy.rego
@@ -50,10 +50,10 @@ team_role(subject, team_id) = role {
 # Global config
 ##
 
-# Global admin, maintainer, observer_plus and observer can read global config.
+# Global admin, gitops, maintainer, observer_plus and observer can read global config.
 allow {
   object.type == "app_config"
-  subject.global_role == [admin, maintainer, observer_plus, observer][_]
+  subject.global_role == [admin, gitops, maintainer, observer_plus, observer][_]
   action == read
 }
 

--- a/server/authz/policy_test.go
+++ b/server/authz/policy_test.go
@@ -65,7 +65,7 @@ func TestAuthorizeAppConfig(t *testing.T) {
 		{user: test.UserObserverPlus, object: config, action: read, allow: true},
 		{user: test.UserObserverPlus, object: config, action: write, allow: false},
 
-		{user: test.UserGitOps, object: config, action: read, allow: false},
+		{user: test.UserGitOps, object: config, action: read, allow: true},
 		{user: test.UserGitOps, object: config, action: write, allow: true},
 
 		{user: test.UserTeamAdminTeam1, object: config, action: read, allow: true},

--- a/server/service/appconfig_test.go
+++ b/server/service/appconfig_test.go
@@ -84,7 +84,7 @@ func TestAppConfigAuth(t *testing.T) {
 			"global gitops",
 			&fleet.User{GlobalRole: ptr.String(fleet.RoleGitOps)},
 			false,
-			true,
+			false,
 		},
 		{
 			"team admin",
@@ -521,7 +521,7 @@ func TestAppConfigSecretsObfuscated(t *testing.T) {
 		{
 			"global gitops",
 			&fleet.User{GlobalRole: ptr.String(fleet.RoleGitOps)},
-			true,
+			false,
 		},
 		{
 			"team admin",

--- a/server/service/client.go
+++ b/server/service/client.go
@@ -865,7 +865,7 @@ func (c *Client) DoGitOps(
 	baseDir string,
 	logf func(format string, args ...interface{}),
 	dryRun bool,
-	premium bool,
+	appConfig *fleet.EnrichedAppConfig,
 ) error {
 	var err error
 	logFn := func(format string, args ...interface{}) {
@@ -990,11 +990,9 @@ func (c *Client) DoGitOps(
 	} else {
 		mdmAppConfig["windows_settings"] = map[string]interface{}{}
 	}
-	if mdmAppConfig["windows_enabled_and_configured"] == true {
-		windowsSettings := mdmAppConfig["windows_settings"].(map[string]interface{})
-		if customSettings, ok := windowsSettings["custom_settings"]; !ok || customSettings == nil {
-			windowsSettings["custom_settings"] = []interface{}{}
-		}
+	windowsSettings := mdmAppConfig["windows_settings"].(map[string]interface{})
+	if customSettings, ok := windowsSettings["custom_settings"]; !ok || customSettings == nil {
+		windowsSettings["custom_settings"] = []interface{}{}
 	}
 	// Put in default values for windows_updates
 	if config.Controls.WindowsUpdates != nil {
@@ -1002,7 +1000,7 @@ func (c *Client) DoGitOps(
 	} else {
 		mdmAppConfig["windows_updates"] = map[string]interface{}{}
 	}
-	if premium {
+	if appConfig.License.IsPremium() {
 		windowsUpdates := mdmAppConfig["windows_updates"].(map[string]interface{})
 		if deadlineDays, ok := windowsUpdates["deadline_days"]; !ok || deadlineDays == nil {
 			windowsUpdates["deadline_days"] = 0

--- a/server/service/client.go
+++ b/server/service/client.go
@@ -898,8 +898,22 @@ func (c *Client) DoGitOps(
 			return errors.New("org_settings.mdm config is not a map")
 		}
 
-		mdmAppConfig["macos_migration"] = config.Controls.MacOSMigration
-		mdmAppConfig["windows_enabled_and_configured"] = config.Controls.WindowsEnabledAndConfigured
+		// Put in default values for macos_migration
+		if config.Controls.MacOSMigration != nil {
+			mdmAppConfig["macos_migration"] = config.Controls.MacOSMigration
+		} else {
+			mdmAppConfig["macos_migration"] = map[string]interface{}{}
+		}
+		macOSMigration := mdmAppConfig["macos_migration"].(map[string]interface{})
+		if enable, ok := macOSMigration["enable"]; !ok || enable == nil {
+			macOSMigration["enable"] = false
+		}
+		// Put in default values for windows_enabled_and_configured
+		if config.Controls.WindowsEnabledAndConfigured != nil {
+			mdmAppConfig["windows_enabled_and_configured"] = false
+		} else {
+			mdmAppConfig["windows_enabled_and_configured"] = config.Controls.WindowsEnabledAndConfigured
+		}
 		group.AppConfig.(map[string]interface{})["scripts"] = scripts
 	} else {
 		team = make(map[string]interface{})
@@ -929,12 +943,74 @@ func (c *Client) DoGitOps(
 		mdmAppConfig = team["mdm"].(map[string]interface{})
 	}
 	// Common controls settings between org and team settings
-	mdmAppConfig["macos_settings"] = config.Controls.MacOSSettings
-	mdmAppConfig["macos_updates"] = config.Controls.MacOSUpdates
-	mdmAppConfig["macos_setup"] = config.Controls.MacOSSetup
-	mdmAppConfig["windows_updates"] = config.Controls.WindowsUpdates
-	mdmAppConfig["windows_settings"] = config.Controls.WindowsSettings
-	mdmAppConfig["enable_disk_encryption"] = config.Controls.EnableDiskEncryption
+	// Put in default values for macos_settings
+	if config.Controls.MacOSSettings != nil {
+		mdmAppConfig["macos_settings"] = config.Controls.MacOSSettings
+	} else {
+		mdmAppConfig["macos_settings"] = map[string]interface{}{}
+	}
+	macOSSettings := mdmAppConfig["macos_settings"].(map[string]interface{})
+	if customSettings, ok := macOSSettings["custom_settings"]; !ok || customSettings == nil {
+		macOSSettings["custom_settings"] = []interface{}{}
+	}
+	// Put in default values for macos_updates
+	if config.Controls.MacOSUpdates != nil {
+		mdmAppConfig["macos_updates"] = config.Controls.MacOSUpdates
+	} else {
+		mdmAppConfig["macos_updates"] = map[string]interface{}{}
+	}
+	macOSUpdates := mdmAppConfig["macos_updates"].(map[string]interface{})
+	if minimumVersion, ok := macOSUpdates["minimum_version"]; !ok || minimumVersion == nil {
+		macOSUpdates["minimum_version"] = ""
+	}
+	if deadline, ok := macOSUpdates["deadline"]; !ok || deadline == nil {
+		macOSUpdates["deadline"] = ""
+	}
+	// Put in default values for macos_setup
+	if config.Controls.MacOSSetup != nil {
+		mdmAppConfig["macos_setup"] = config.Controls.MacOSSetup
+	} else {
+		mdmAppConfig["macos_setup"] = map[string]interface{}{}
+	}
+	macOSSetup := mdmAppConfig["macos_setup"].(map[string]interface{})
+	if bootstrapPackage, ok := macOSSetup["bootstrap_package"]; !ok || bootstrapPackage == nil {
+		macOSSetup["bootstrap_package"] = ""
+	}
+	if enableEndUserAuthentication, ok := macOSSetup["enable_end_user_authentication"]; !ok || enableEndUserAuthentication == nil {
+		macOSSetup["enable_end_user_authentication"] = false
+	}
+	if macOSSetupAssistant, ok := macOSSetup["macos_setup_assistant"]; !ok || macOSSetupAssistant == nil {
+		macOSSetup["macos_setup_assistant"] = ""
+	}
+	// Put in default values for windows_settings
+	if config.Controls.WindowsSettings != nil {
+		mdmAppConfig["windows_settings"] = config.Controls.WindowsSettings
+	} else {
+		mdmAppConfig["windows_settings"] = map[string]interface{}{}
+	}
+	windowsSettings := mdmAppConfig["windows_settings"].(map[string]interface{})
+	if customSettings, ok := windowsSettings["custom_settings"]; !ok || customSettings == nil {
+		windowsSettings["custom_settings"] = []interface{}{}
+	}
+	// Put in default values for windows_updates
+	if config.Controls.WindowsUpdates != nil {
+		mdmAppConfig["windows_updates"] = config.Controls.WindowsUpdates
+	} else {
+		mdmAppConfig["windows_updates"] = map[string]interface{}{}
+	}
+	windowsUpdates := mdmAppConfig["windows_updates"].(map[string]interface{})
+	if deadlineDays, ok := windowsUpdates["deadline_days"]; !ok || deadlineDays == nil {
+		windowsUpdates["deadline_days"] = 0
+	}
+	if gracePeriodDays, ok := windowsUpdates["grace_period_days"]; !ok || gracePeriodDays == nil {
+		windowsUpdates["grace_period_days"] = 0
+	}
+	// Put in default value for enable_disk_encryption
+	if config.Controls.EnableDiskEncryption != nil {
+		mdmAppConfig["enable_disk_encryption"] = config.Controls.EnableDiskEncryption
+	} else {
+		mdmAppConfig["enable_disk_encryption"] = false
+	}
 	if config.TeamName != nil {
 		rawTeam, err := json.Marshal(team)
 		if err != nil {

--- a/server/service/client.go
+++ b/server/service/client.go
@@ -911,12 +911,11 @@ func (c *Client) DoGitOps(
 		}
 		// Put in default values for windows_enabled_and_configured
 		mdmAppConfig["windows_enabled_and_configured"] = config.Controls.WindowsEnabledAndConfigured
-		// TODO: Need to update fleet-gitops repo before disabling by default.
-		//if config.Controls.WindowsEnabledAndConfigured != nil {
-		//	mdmAppConfig["windows_enabled_and_configured"] = config.Controls.WindowsEnabledAndConfigured
-		//} else {
-		//	mdmAppConfig["windows_enabled_and_configured"] = false
-		//}
+		if config.Controls.WindowsEnabledAndConfigured != nil {
+			mdmAppConfig["windows_enabled_and_configured"] = config.Controls.WindowsEnabledAndConfigured
+		} else {
+			mdmAppConfig["windows_enabled_and_configured"] = false
+		}
 		group.AppConfig.(map[string]interface{})["scripts"] = scripts
 	} else {
 		team = make(map[string]interface{})

--- a/server/service/integration_enterprise_test.go
+++ b/server/service/integration_enterprise_test.go
@@ -4094,8 +4094,8 @@ func (s *integrationEnterpriseTestSuite) TestGitOpsUserActions() {
 	s.DoJSON("GET", "/api/latest/fleet/software/1", getSoftwareRequest{}, http.StatusForbidden, &getSoftwareResponse{})
 	s.DoJSON("GET", "/api/latest/fleet/software/versions/1", getSoftwareRequest{}, http.StatusForbidden, &getSoftwareResponse{})
 
-	// Attempt to read app config, should fail.
-	s.DoJSON("GET", "/api/latest/fleet/config", nil, http.StatusForbidden, &appConfigResponse{})
+	// Attempt to read app config, should pass.
+	s.DoJSON("GET", "/api/latest/fleet/config", nil, http.StatusOK, &appConfigResponse{})
 
 	// Attempt to write app config, should allow.
 	acr = appConfigResponse{}

--- a/server/service/integration_enterprise_test.go
+++ b/server/service/integration_enterprise_test.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/fleetdm/fleet/v4/server/pubsub"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -60,6 +61,7 @@ func (s *integrationEnterpriseTestSuite) SetupSuite() {
 			Tier: fleet.TierPremium,
 		},
 		Pool:           s.redisPool,
+		Rs:             pubsub.NewInmemQueryResults(),
 		Lq:             s.lq,
 		Logger:         log.NewLogfmtLogger(os.Stdout),
 		EnableCachedDS: true,


### PR DESCRIPTION
For fleetctl gitops, when MDM configs are not explicitly defined in gitops yml file, they are now set to default values.
#17209

Gitops role can now read org config/settings. This is used to determine whether license is Premium.
Doc changes for permission access: https://github.com/fleetdm/fleet/pull/17238

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [x] Documented any permissions changes (docs/Using Fleet/manage-access.md)
- [x] Added/updated tests
- [x] Manual QA for all new/changed functionality
