### PR TITLE
Added --server_frequent_cleanups_enabled (FLEET_SERVER_FREQUENT_CLEANUPS_ENABLED) flag 

### DIFF
--- a/changes/17197-frequent-cleanups-enabled
+++ b/changes/17197-frequent-cleanups-enabled
@@ -1,1 +1,1 @@
-Added --server_frequent_cleanups_enabled (FLEET_SERVER_FREQUENT_CLEANUPS_ENABLED) flag to enable 15 minute cron job to clean up stale data. Currently disabled by default.
+Added --server_frequent_cleanups_enabled (FLEET_SERVER_FREQUENT_CLEANUPS_ENABLED) flag to enable cron job to clean up stale data running every 15 minutes. Currently disabled by default.

--- a/changes/17197-frequent-cleanups-enabled
+++ b/changes/17197-frequent-cleanups-enabled
@@ -1,0 +1,1 @@
+Added --server_frequent_cleanups_enabled (FLEET_SERVER_FREQUENT_CLEANUPS_ENABLED) flag to enable 15 minute cron job to clean up stale data. Currently disabled by default.

--- a/cmd/fleet/serve.go
+++ b/cmd/fleet/serve.go
@@ -680,10 +680,14 @@ the way that the Fleet server works.
 				}
 			}()
 
-			if err := cronSchedules.StartCronSchedule(func() (fleet.CronSchedule, error) {
-				return newFrequentCleanupsSchedule(ctx, instanceID, ds, liveQueryStore, logger)
-			}); err != nil {
-				initFatal(err, "failed to register frequent_cleanups schedule")
+			if config.Server.FrequentCleanupsEnabled {
+				if err := cronSchedules.StartCronSchedule(
+					func() (fleet.CronSchedule, error) {
+						return newFrequentCleanupsSchedule(ctx, instanceID, ds, liveQueryStore, logger)
+					},
+				); err != nil {
+					initFatal(err, "failed to register frequent_cleanups schedule")
+				}
 			}
 
 			if err := cronSchedules.StartCronSchedule(

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -94,6 +94,7 @@ type ServerConfig struct {
 	Keepalive                   bool   `yaml:"keepalive"`
 	SandboxEnabled              bool   `yaml:"sandbox_enabled"`
 	WebsocketsAllowUnsafeOrigin bool   `yaml:"websockets_allow_unsafe_origin"`
+	FrequentCleanupsEnabled     bool   `yaml:"frequent_cleanups_enabled"`
 }
 
 func (s *ServerConfig) DefaultHTTPServer(ctx context.Context, handler http.Handler) *http.Server {
@@ -841,6 +842,7 @@ func (man Manager) addConfigs() {
 	man.addConfigBool("server.sandbox_enabled", false,
 		"When enabled, Fleet limits some features for the Sandbox")
 	man.addConfigBool("server.websockets_allow_unsafe_origin", false, "Disable checking the origin header on websocket connections, this is sometimes necessary when proxies rewrite origin headers between the client and the Fleet webserver")
+	man.addConfigBool("server.frequent_cleanups_enabled", false, "Enable frequent cleanups of expired data (15 minute interval)")
 
 	// Hide the sandbox flag as we don't want it to be discoverable for users for now
 	sandboxFlag := man.command.PersistentFlags().Lookup(flagNameFromConfigKey("server.sandbox_enabled"))
@@ -1191,6 +1193,7 @@ func (man Manager) LoadConfig() FleetConfig {
 			Keepalive:                   man.getConfigBool("server.keepalive"),
 			SandboxEnabled:              man.getConfigBool("server.sandbox_enabled"),
 			WebsocketsAllowUnsafeOrigin: man.getConfigBool("server.websockets_allow_unsafe_origin"),
+			FrequentCleanupsEnabled:     man.getConfigBool("server.frequent_cleanups_enabled"),
 		},
 		Auth: AuthConfig{
 			BcryptCost:  man.getConfigInt("auth.bcrypt_cost"),


### PR DESCRIPTION
Added --server_frequent_cleanups_enabled (FLEET_SERVER_FREQUENT_CLEANUPS_ENABLED) flag to enable 15 minute cron job to clean up stale data. Currently disabled by default.

#17197 

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [ ] Added/updated tests
- [x] Manual QA for all new/changed functionality
