### PR TITLE
Fixing code review comments.

### DIFF
--- a/cmd/fleet/serve.go
+++ b/cmd/fleet/serve.go
@@ -697,7 +697,7 @@ the way that the Fleet server works.
 						commander = apple_mdm.NewMDMAppleCommander(mdmStorage, mdmPushService)
 					}
 					return newCleanupsAndAggregationSchedule(
-						ctx, instanceID, ds, liveQueryStore, logger, redisWrapperDS, &config, commander,
+						ctx, instanceID, ds, logger, redisWrapperDS, &config, commander,
 					)
 				},
 			); err != nil {


### PR DESCRIPTION
Fixing code review comments from https://github.com/fleetdm/fleet/pull/16855
Also, moving `CleanupDistributedQueryCampaigns` back to once an hour, so that it is not disabled.

