### PR TITLE
[released bug] Fleet Full stack: Allow teams filter when transferring hosts by filters

### DIFF
--- a/changes/16950-transfer-selected-all-hosts
+++ b/changes/16950-transfer-selected-all-hosts
@@ -1,0 +1,1 @@
+- Bug fix: Correctly transfer hosts on multiple pages between teams

--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -2994,7 +2994,7 @@ _Available in Fleet Premium_
 | Name    | Type    | In   | Description                                                                                                                                                                                                                                                                                                                        |
 | ------- | ------- | ---- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | team_id | integer | body | **Required**. The ID of the team you'd like to transfer the host(s) to.                                                                                                                                                                                                                                                            |
-| filters | object  | body | **Required** Contains any of the following three properties: `query` for search query keywords. Searchable fields include `hostname`, `hardware_serial`, `uuid`, and `ipv4`. `status` to indicate the status of the hosts to return. Can either be `new`, `online`, `offline`, `mia` or `missing`. `label_id` to indicate the selected label. `label_id` and `status` cannot be used at the same time. |
+| filters | object  | body | **Required** Contains any of the following four properties: `query` for search query keywords. Searchable fields include `hostname`, `hardware_serial`, `uuid`, and `ipv4`. `status` to indicate the status of the hosts to return. Can either be `new`, `online`, `offline`, `mia` or `missing`. `label_id` to indicate the selected label. `team_id` to indicate the selected team. Note: `label_id` and `status` cannot be used at the same time. |
 
 #### Example
 
@@ -3006,7 +3006,8 @@ _Available in Fleet Premium_
 {
   "team_id": 1,
   "filters": {
-    "status": "online"
+    "status": "online",
+    "team_id": 2,
   }
 }
 ```

--- a/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
@@ -1034,6 +1034,8 @@ const ManageHostsPage = ({
     setIsUpdatingHosts(true);
 
     const teamId = typeof transferTeam.id === "number" ? transferTeam.id : null;
+    const currentTeam = teamIdForApi;
+
     let action = hostsAPI.transferToTeam(teamId, selectedHostIds);
 
     if (isAllMatchingHostsSelected) {
@@ -1044,6 +1046,7 @@ const ManageHostsPage = ({
         query: searchQuery,
         status,
         labelId,
+        currentTeam,
       });
     }
 

--- a/frontend/services/entities/hosts.ts
+++ b/frontend/services/entities/hosts.ts
@@ -116,6 +116,7 @@ export interface IActionByFilter {
   query: string;
   status: string;
   labelId?: number;
+  currentTeam?: number | null;
 }
 
 export type ILoadHostDetailsExtension = "device_mapping" | "macadmins";
@@ -359,6 +360,7 @@ export default {
     query,
     status,
     labelId,
+    currentTeam,
   }: IActionByFilter) => {
     const { HOSTS_TRANSFER_BY_FILTER } = endpoints;
     return sendRequest("POST", HOSTS_TRANSFER_BY_FILTER, {
@@ -367,6 +369,7 @@ export default {
         query,
         status,
         label_id: labelId,
+        team_id: currentTeam,
       },
     });
   },

--- a/server/service/client_hosts.go
+++ b/server/service/client_hosts.go
@@ -126,7 +126,9 @@ func (c *Client) TransferHosts(hosts []string, label string, status, searchQuery
 			MatchQuery string           `json:"query"`
 			Status     fleet.HostStatus `json:"status"`
 			LabelID    *uint            `json:"label_id"`
-		}{MatchQuery: searchQuery, Status: fleet.HostStatus(status), LabelID: labelIDPtr}}
+			TeamID     *uint            `json:"team_id"`
+		}{MatchQuery: searchQuery, Status: fleet.HostStatus(status), LabelID: labelIDPtr},
+	}
 	return c.authenticatedRequest(params, verb, path, &responseBody)
 }
 

--- a/server/service/hosts.go
+++ b/server/service/hosts.go
@@ -857,6 +857,7 @@ type addHostsToTeamByFilterRequest struct {
 		MatchQuery string           `json:"query"`
 		Status     fleet.HostStatus `json:"status"`
 		LabelID    *uint            `json:"label_id"`
+		TeamID     *uint            `json:"team_id"`
 	} `json:"filters"`
 }
 
@@ -873,6 +874,7 @@ func addHostsToTeamByFilterEndpoint(ctx context.Context, request interface{}, sv
 			MatchQuery: req.Filters.MatchQuery,
 		},
 		StatusFilter: req.Filters.Status,
+		TeamFilter:   req.Filters.TeamID,
 	}
 	err := svc.AddHostsToTeamByFilter(ctx, req.TeamID, listOpt, req.Filters.LabelID)
 	if err != nil {


### PR DESCRIPTION
## Issue
Cerra #16950 

## Description
- Fix transfer by filter when selecting all hosts on a team to transfer, it doesn't accidentally transfer hosts not on that team

## TODO
- Ask product if we want to include all the filter pills as well -- Separate ticket?

## Screenrecording
https://www.loom.com/share/7f332be3969e415dabb90738b9df88ab?sid=a7021fa2-af6d-4861-ba8b-176a63b3a051

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
- [x] Manual QA for all new/changed functionality

