### PR TITLE
Website: Update content on device management page

### DIFF
--- a/website/views/pages/device-management.ejs
+++ b/website/views/pages/device-management.ejs
@@ -157,11 +157,12 @@
       <div purpose="page-section">
         <div purpose="feature" class="d-flex flex-md-row flex-column-reverse justify-content-between mx-auto align-items-center">
           <div purpose="feature-text" class="d-flex flex-column">
-            <h2>Absolute certainty</h2>
-            <p>Reduce time wasted hunting down whether a change happened. Actually verify that settings are applied using real data pulled from your users' devices.</p>
+            <h2>Shorten the feedback loop</h2>
+            <p>Spend less time debugging whether changes actually happened. Auto-verify using real data pulled from your users' devices.</p>
             <div purpose="checklist" class="flex-column d-flex">
               <p>Use a git repo as the source of truth to reduce errors (submitting the wrong patch, configuration setting etc)</p>
               <p>Every change to a policy or security control is tracked and auditable in Fleet’s history, or via the repo commit log</p>
+              <p>Instantly reveal failed patches and broken settings with osquery to shorten the feedback loop and avoid tickets.</p>
             </div>
           </div>
           <div purpose="feature-image" class="right">


### PR DESCRIPTION
Closes: https://github.com/fleetdm/confidential/issues/5566

Changes:
- Updated the content of the "Absolute certainty" section of the /device-management page