### PR TITLE
Website: Change type of JS timestamp attributes to prevent logged warnings

### DIFF
--- a/website/api/models/User.js
+++ b/website/api/models/User.js
@@ -179,8 +179,8 @@ without necessarily having a billing card.`
 
     fleetSandboxExpiresAt: {
       type: 'string',
-      description: 'A JS timestamp (epoch ms) representing when this user\'s fleet sandbox instance will expire',
       columnType: 'bigint',
+      description: 'A JS timestamp (epoch ms) representing when this user\'s fleet sandbox instance will expire',
       example: '1502844074211',
       extendedDescription: 'As of Oct. 2023, new user records will not have this value set.'
     },

--- a/website/api/models/User.js
+++ b/website/api/models/User.js
@@ -178,8 +178,9 @@ without necessarily having a billing card.`
     },
 
     fleetSandboxExpiresAt: {
-      type: 'number',
-      description: 'An JS timestamp (epoch ms) representing when this user\'s fleet sandbox instance will expire',
+      type: 'string',
+      description: 'A JS timestamp (epoch ms) representing when this user\'s fleet sandbox instance will expire',
+      columnType: 'bigint',
       example: '1502844074211',
       extendedDescription: 'As of Oct. 2023, new user records will not have this value set.'
     },

--- a/website/api/models/VantaConnection.js
+++ b/website/api/models/VantaConnection.js
@@ -48,7 +48,8 @@ module.exports = {
     },
 
     vantaAuthTokenExpiresAt: {
-      type: 'number',
+      type: 'string',
+      columnType: 'bigint',
       description: 'A JS timestamp of when this connection\'s authorization token will expire.'
     },
 


### PR DESCRIPTION
Related to: #17195

Changes:
- Updated the `fleetSandboxExpiresAt` attribute of the `User` model to be `type: 'string'` with `columnType: 'bigint'` to resolve the logged warning about this value being returned from the DB as a string.
- Updated the `vantaAuthTokenExpiresAt` attribute of the `VantaConnection` model to be `type: 'string'` with `columnType: 'bigint'` to resolve the logged warning about this value being returned from the DB as a string.