### PR TITLE
Adding backend support for running live queries with team_id=0 (No team)

### DIFF
--- a/changes/16350-target-no-team-for-live-query
+++ b/changes/16350-target-no-team-for-live-query
@@ -1,0 +1,2 @@
+- API endpoint GET fleet/targets/count can target 'No team' with team_id=0
+- API endpoint POST fleet/queries/run (for async live queries) can target 'No team' with team_id=0

--- a/server/datastore/mysql/targets_test.go
+++ b/server/datastore/mysql/targets_test.go
@@ -153,6 +153,23 @@ func testTargetsCountHosts(t *testing.T, ds *Datastore) {
 	assert.Equal(t, uint(0), metrics.OfflineHosts)
 	assert.Equal(t, uint(0), metrics.MissingInActionHosts)
 
+	// Get 'No team' hosts
+	metrics, err = ds.CountHostsInTargets(context.Background(), filter, fleet.HostTargets{TeamIDs: []uint{0}}, mockClock.Now())
+	require.Nil(t, err)
+	assert.Equal(t, uint(2), metrics.TotalHosts)
+	assert.Equal(t, uint(1), metrics.OnlineHosts)
+	assert.Equal(t, uint(1), metrics.OfflineHosts)
+	assert.Equal(t, uint(1), metrics.MissingInActionHosts)
+
+	metrics, err = ds.CountHostsInTargets(
+		context.Background(), filter, fleet.HostTargets{TeamIDs: []uint{team1.ID, team3.ID, 0}}, mockClock.Now(),
+	)
+	require.Nil(t, err)
+	assert.Equal(t, uint(3), metrics.TotalHosts)
+	assert.Equal(t, uint(2), metrics.OnlineHosts)
+	assert.Equal(t, uint(1), metrics.OfflineHosts)
+	assert.Equal(t, uint(1), metrics.MissingInActionHosts)
+
 	metrics, err = ds.CountHostsInTargets(context.Background(), filter, fleet.HostTargets{TeamIDs: []uint{team1.ID, team3.ID}}, mockClock.Now())
 	require.Nil(t, err)
 	assert.Equal(t, uint(1), metrics.TotalHosts)
@@ -592,6 +609,16 @@ func testTargetsHostIDsInTargets(t *testing.T, ds *Datastore) {
 		{
 			name:            "No selection",
 			expectedHostIDs: []uint{},
+		},
+		{
+			name:            "'No Team' team selection",
+			targetTeamIDs:   []uint{0},
+			expectedHostIDs: []uint{h5.ID, h6.ID},
+		},
+		{
+			name:            "'No Team' team, one team, and an empty team selection",
+			targetTeamIDs:   []uint{t1.ID, 0, t3.ID},
+			expectedHostIDs: []uint{h1.ID, h5.ID, h6.ID},
 		},
 		{
 			name:          "One team and an empty team selection",

--- a/server/service/integration_core_test.go
+++ b/server/service/integration_core_test.go
@@ -6369,6 +6369,16 @@ func (s *integrationTestSuite) TestCountTargets() {
 	require.Equal(t, uint(1), countResp.TargetsOnline)
 	require.Equal(t, uint(0), countResp.TargetsOffline)
 
+	// 'No team' selected
+	countResp = countTargetsResponse{}
+	s.DoJSON(
+		"POST", "/api/latest/fleet/targets/count", countTargetsRequest{Selected: fleet.HostTargets{TeamIDs: []uint{0}}},
+		http.StatusOK, &countResp,
+	)
+	assert.Equal(t, uint(2), countResp.TargetsCount)
+	assert.Equal(t, uint(0), countResp.TargetsOnline)
+	assert.Equal(t, uint(2), countResp.TargetsOffline)
+
 	// host id selected
 	countResp = countTargetsResponse{}
 	s.DoJSON("POST", "/api/latest/fleet/targets/count", countTargetsRequest{Selected: fleet.HostTargets{HostIDs: []uint{hosts[1].ID}}}, http.StatusOK, &countResp)

--- a/server/service/integration_live_queries_test.go
+++ b/server/service/integration_live_queries_test.go
@@ -986,6 +986,7 @@ func (s *liveQueriesTestSuite) TestCreateDistributedQueryCampaign() {
 		},
 	}
 	s.DoJSON("POST", "/api/latest/fleet/queries/run", req, http.StatusOK, &createResp)
+	assert.NotEqual(t, camp1.ID, createResp.Campaign.ID)
 	camp1 = *createResp.Campaign
 	assert.Equal(t, uint(len(s.hosts)), createResp.Campaign.Metrics.TotalHosts)
 

--- a/server/service/integration_live_queries_test.go
+++ b/server/service/integration_live_queries_test.go
@@ -961,8 +961,8 @@ func (s *liveQueriesTestSuite) TestCreateDistributedQueryCampaign() {
 	}
 	s.DoJSON("POST", "/api/latest/fleet/queries/run", req, http.StatusBadRequest, &createResp)
 
-	// wait a second to prevent duplicate name for new query
-	time.Sleep(time.Second)
+	// wait to prevent duplicate name for new query
+	time.Sleep(200 * time.Millisecond)
 
 	// create with new query for specific hosts
 	req = createDistributedQueryCampaignRequest{
@@ -975,8 +975,22 @@ func (s *liveQueriesTestSuite) TestCreateDistributedQueryCampaign() {
 	camp1 := *createResp.Campaign
 	assert.Equal(t, uint(2), createResp.Campaign.Metrics.TotalHosts)
 
-	// wait a second to prevent duplicate name for new query
-	time.Sleep(time.Second)
+	// wait to prevent duplicate name for new query
+	time.Sleep(200 * time.Millisecond)
+
+	// create with new query for 'No team'
+	req = createDistributedQueryCampaignRequest{
+		QuerySQL: "SELECT 2.5",
+		Selected: fleet.HostTargets{
+			TeamIDs: []uint{0},
+		},
+	}
+	s.DoJSON("POST", "/api/latest/fleet/queries/run", req, http.StatusOK, &createResp)
+	camp1 = *createResp.Campaign
+	assert.Equal(t, uint(len(s.hosts)), createResp.Campaign.Metrics.TotalHosts)
+
+	// wait to prevent duplicate name for new query
+	time.Sleep(200 * time.Millisecond)
 
 	// create by host name
 	req2 := createDistributedQueryCampaignByNamesRequest{
@@ -989,8 +1003,8 @@ func (s *liveQueriesTestSuite) TestCreateDistributedQueryCampaign() {
 	assert.NotEqual(t, camp1.ID, createResp.Campaign.ID)
 	assert.Equal(t, uint(1), createResp.Campaign.Metrics.TotalHosts)
 
-	// wait a second to prevent duplicate name for new query
-	time.Sleep(time.Second)
+	// wait to prevent duplicate name for new query
+	time.Sleep(200 * time.Millisecond)
 
 	// create by unknown host name - it ignores the unknown names. Must have at least 1 valid host
 	req2 = createDistributedQueryCampaignByNamesRequest{


### PR DESCRIPTION
- API endpoint GET fleet/targets/count can target 'No team' with team_id=0
- API endpoint POST fleet/queries/run (for async live queries) can target 'No team' with team_id=0
#16350

API doc changes PR: https://github.com/fleetdm/fleet/pull/17267

# Checklist for submitter

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
- [x] Added/updated tests
- [x] Manual QA for all new/changed functionality
