### PR TITLE
GET /hosts API endpoint can now populate policies with populate_policies=true query parameter.

### DIFF
--- a/changes/16242-policy-data-for-hosts
+++ b/changes/16242-policy-data-for-hosts
@@ -1,0 +1,1 @@
+GET /hosts API endpoint can now populate policies with populate_policies=true query parameter.

--- a/server/fleet/hosts.go
+++ b/server/fleet/hosts.go
@@ -344,7 +344,7 @@ type Host struct {
 	LastRestartedAt time.Time `json:"last_restarted_at" db:"last_restarted_at" csv:"last_restarted_at"`
 
 	// Policies is the list of policies and whether it passes for the host
-	Policies *[]*HostPolicy `json:"policies,omitempty"`
+	Policies *[]*HostPolicy `json:"policies,omitempty" csv:"-"`
 }
 
 // HostHealth contains a subset of Host data that indicates how healthy a Host is. For fields with

--- a/server/fleet/hosts.go
+++ b/server/fleet/hosts.go
@@ -182,6 +182,9 @@ type HostListOptions struct {
 	// PopulateSoftware adds the `Software` field to all Hosts returned.
 	PopulateSoftware bool
 
+	// PopulatePolicies adds the `Policies` array field to all Hosts returned.
+	PopulatePolicies bool
+
 	// VulnerabilityFilter filters the hosts by the presence of a vulnerability (CVE)
 	VulnerabilityFilter *string
 }
@@ -339,6 +342,9 @@ type Host struct {
 
 	// LastRestartedAt is a UNIX timestamp that indicates when the Host was last restarted.
 	LastRestartedAt time.Time `json:"last_restarted_at" db:"last_restarted_at" csv:"last_restarted_at"`
+
+	// Policies is the list of policies and whether it passes for the host
+	Policies *[]*HostPolicy `json:"policies,omitempty"`
 }
 
 // HostHealth contains a subset of Host data that indicates how healthy a Host is. For fields with
@@ -718,8 +724,6 @@ type HostDetail struct {
 	Labels []*Label `json:"labels"`
 	// Packs is the list of packs the host is a member of.
 	Packs []*Pack `json:"packs"`
-	// Policies is the list of policies and whether it passes for the host
-	Policies *[]*HostPolicy `json:"policies,omitempty"`
 	// Batteries is the list of batteries for the host. It is a pointer to a
 	// slice so that when set, it gets marhsaled even if the slice is empty,
 	// but when unset, it doesn't get marshaled (e.g. we don't return that

--- a/server/service/hosts.go
+++ b/server/service/hosts.go
@@ -200,9 +200,6 @@ func (svc *Service) ListHosts(ctx context.Context, opt fleet.HostListOptions) ([
 			if err != nil {
 				return nil, ctxerr.Wrap(ctx, err, fmt.Sprintf("get policies for host %d", host.ID))
 			}
-			if hp == nil {
-				hp = []*fleet.HostPolicy{}
-			}
 			host.Policies = &hp
 		}
 	}

--- a/server/service/hosts.go
+++ b/server/service/hosts.go
@@ -194,6 +194,19 @@ func (svc *Service) ListHosts(ctx context.Context, opt fleet.HostListOptions) ([
 		}
 	}
 
+	if opt.PopulatePolicies {
+		for _, host := range hosts {
+			hp, err := svc.ds.ListPoliciesForHost(ctx, host)
+			if err != nil {
+				return nil, ctxerr.Wrap(ctx, err, fmt.Sprintf("get policies for host %d", host.ID))
+			}
+			if hp == nil {
+				hp = []*fleet.HostPolicy{}
+			}
+			host.Policies = &hp
+		}
+	}
+
 	return hosts, nil
 }
 
@@ -1120,11 +1133,11 @@ func (svc *Service) getHostDetails(ctx context.Context, host *fleet.Host, opts f
 		host.MDM.PendingAction = ptr.String("wipe")
 	}
 
+	host.Policies = policies
 	return &fleet.HostDetail{
 		Host:      *host,
 		Labels:    labels,
 		Packs:     packs,
-		Policies:  policies,
 		Batteries: &bats,
 	}, nil
 }

--- a/server/service/transport.go
+++ b/server/service/transport.go
@@ -506,6 +506,16 @@ func hostListOptionsFromRequest(r *http.Request) (fleet.HostListOptions, error) 
 		}
 		hopt.PopulateSoftware = ps
 	}
+	populatePolicies := r.URL.Query().Get("populate_policies")
+	if populatePolicies != "" {
+		pp, err := strconv.ParseBool(populatePolicies)
+		if err != nil {
+			return hopt, ctxerr.Wrap(
+				r.Context(), badRequest(fmt.Sprintf("Invalid boolean parameter populate_policies: %s", populateSoftware)),
+			)
+		}
+		hopt.PopulatePolicies = pp
+	}
 
 	// cannot combine software_id, software_version_id, and software_title_id
 	var softwareErrorLabel []string

--- a/server/service/transport_test.go
+++ b/server/service/transport_test.go
@@ -158,7 +158,7 @@ func TestHostListOptionsFromRequest(t *testing.T) {
 				"&os_name=osName&os_version=osVersion&os_version_id=5&disable_failing_policies=1&macos_settings=verified" +
 				"&macos_settings_disk_encryption=enforcing&os_settings=pending&os_settings_disk_encryption=failed" +
 				"&bootstrap_package=installed&mdm_id=6&mdm_name=mdmName&mdm_enrollment_status=automatic" +
-				"&munki_issue_id=7&low_disk_space=99&vulnerability=CVE-2023-42887",
+				"&munki_issue_id=7&low_disk_space=99&vulnerability=CVE-2023-42887&populate_policies=true",
 			hostListOptions: fleet.HostListOptions{
 				ListOptions: fleet.ListOptions{
 					OrderKey:       "foo",
@@ -189,6 +189,7 @@ func TestHostListOptionsFromRequest(t *testing.T) {
 				MunkiIssueIDFilter:                ptr.Uint(7),
 				LowDiskSpaceFilter:                ptr.Int(99),
 				VulnerabilityFilter:               ptr.String("CVE-2023-42887"),
+				PopulatePolicies:                  true,
 			},
 		},
 		"policy_id and policy_response params (for coverage)": {
@@ -335,6 +336,10 @@ func TestHostListOptionsFromRequest(t *testing.T) {
 		"invalid combination software_id and software_version_id": {
 			url:          "/foo?software_id=1&software_version_id=2",
 			errorMessage: "The combination of software_id and software_version_id is not allowed",
+		},
+		"invalid populate_policies": {
+			url:          "/foo?populate_policies=foo",
+			errorMessage: "populate_policies",
 		},
 	}
 


### PR DESCRIPTION
GET /hosts API endpoint can now populate policies with populate_policies=true query parameter.
#16242

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [x] Added/updated tests
- [x] Manual QA for all new/changed functionality
