### PR TITLE
Tweak custom OS settings docs

### DIFF
--- a/docs/Using Fleet/MDM-custom-OS-settings.md
+++ b/docs/Using Fleet/MDM-custom-OS-settings.md
@@ -32,7 +32,7 @@ In the top box, with "Verified," "Verifying," "Pending," and "Failed" statuses, 
 
 * Pending: hosts that will receive MDM commands to install configuration profiles when the hosts come online.
 
-* Failed: hosts that failed to install configuration profiles.
+* Failed: hosts that failed to install configuration profiles. For Windows profiles, the status codes are documented in Microsoft's documentation [here](https://learn.microsoft.com/en-us/windows/client-management/oma-dm-protocol-support#syncml-response-status-codes).
 
 In the list of hosts, click on an individual host and click the **OS settings** item to see the status for a specific setting.
 


### PR DESCRIPTION
As a user who has failed Windows profiles, it's unclear what the status codes in the error message mean. 

More context [here in Slack](https://fleetdm.slack.com/archives/C03C41L5YEL/p1709230363759049?thread_ts=1709228049.511119&cid=C03C41L5YEL) (internal).

- Add a link to Microsoft's docs that explain the error codes. We link to the same page on the [MDM commands doc page](https://fleetdm.com/docs/using-fleet/mdm-commands):

![Screenshot 2024-02-29 at 3 21 07 PM](https://github.com/fleetdm/fleet/assets/47070608/972f043c-1f40-4e54-8544-23eda8d0ece4)