### PR TITLE
string match on the resource report key instead of the keyval pair

### DIFF
--- a/ee/tools/puppet/fleetdm/lib/puppet/reports/fleetdm.rb
+++ b/ee/tools/puppet/fleetdm/lib/puppet/reports/fleetdm.rb
@@ -10,7 +10,7 @@ Puppet::Reports.register_report(:fleetdm) do
     return if noop
 
     node_name = Puppet[:node_name_value]
-    if resource_statuses.any? { |r| r.include?('error pre-setting fleetdm::profile') }
+    if resource_statuses.any? { |r, _| r.downcase.include?('error pre-setting fleetdm::profile') }
       Puppet.err("Some resources failed to be assigned, not matching profiles for #{node_name}")
       return
     end

--- a/ee/tools/puppet/fleetdm/spec/unit/reports/fleetdm_spec.rb
+++ b/ee/tools/puppet/fleetdm/spec/unit/reports/fleetdm_spec.rb
@@ -32,7 +32,7 @@ describe 'Puppet::Reports::Fleetdm' do
   end
 
   it 'logs an error if resources failed to be assigned' do
-    allow(report).to receive(:resource_statuses).and_return({ 'myresource' => 'error pre-setting fleetdm::profile' })
+    allow(report).to receive(:resource_statuses).and_return({ 'error pre-setting fleetdm::profile com.apple.SoftwareUpdate as present: forbidden : base forbidden' => 'anything' })
     expect(Puppet).to receive(:err).with(%r{Some resources failed to be assigned})
     expect(fleet_client_mock).not_to receive(:match_profiles)
     report.process


### PR DESCRIPTION
for #16954, this fixes an issue found during testing

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Added/updated tests
- [x] Manual QA for all new/changed functionality
