### PR TITLE
rollup the mdm solutions by name on the dashboard page

### DIFF
--- a/changes/issue-16837-rollup-of-mdm-solutions
+++ b/changes/issue-16837-rollup-of-mdm-solutions
@@ -1,0 +1,1 @@
+- rollup the mdm solutions by name on the dashboard mdm card

--- a/frontend/components/TableContainer/DataTable/DataTable.tsx
+++ b/frontend/components/TableContainer/DataTable/DataTable.tsx
@@ -56,6 +56,7 @@ interface IDataTableProps {
   searchQueryColumn?: string;
   selectedDropdownFilter?: string;
   onSelectSingleRow?: (value: Row) => void;
+  onClickRow?: (value: any) => void;
   onResultsCountChange?: (value: number) => void;
   renderFooter?: () => JSX.Element | null;
   renderPagination?: () => JSX.Element | null;
@@ -96,6 +97,7 @@ const DataTable = ({
   searchQueryColumn,
   selectedDropdownFilter,
   onSelectSingleRow,
+  onClickRow,
   onResultsCountChange,
   renderFooter,
   renderPagination,
@@ -313,7 +315,7 @@ const DataTable = ({
     toggleAllPagesSelected(false);
   }, [toggleAllPagesSelected, toggleAllRowsSelected]);
 
-  const onSingleRowClick = useCallback(
+  const onSelectRowClick = useCallback(
     (row) => {
       if (disableMultiRowSelect) {
         row.toggleRowSelected();
@@ -524,9 +526,10 @@ const DataTable = ({
                   {...row.getRowProps({
                     // @ts-ignore // TS complains about prop not existing
                     onClick: () => {
-                      onSingleRowClick &&
+                      (onSelectRowClick &&
                         disableMultiRowSelect &&
-                        onSingleRowClick(row);
+                        onSelectRowClick(row)) ||
+                        (onClickRow && onClickRow(row));
                     },
                   })}
                 >

--- a/frontend/components/TableContainer/DataTable/InternalLinkCell/InternalLinkCell.tsx
+++ b/frontend/components/TableContainer/DataTable/InternalLinkCell/InternalLinkCell.tsx
@@ -1,0 +1,43 @@
+import React from "react";
+import classnames from "classnames";
+import { noop } from "lodash";
+
+import Icon from "components/Icon";
+
+const baseClass = "internal-link-cell";
+
+interface IInternalLinkCellProps {
+  value: string;
+  onClick?: () => void;
+  className?: string;
+}
+
+/** This cell is used when you want a clickable cell value that does not link
+ * to an url. This can be used when you'd like to trigger an action when the
+ * cell is clicked such as opening a modal.
+ *
+ * TODO: can we find a way to combine this with LinkCell. Would we want to do that?
+ * Also we can improve naming of this component.
+ */
+const InternalLinkCell = ({
+  value,
+  onClick = noop,
+  className,
+}: IInternalLinkCellProps) => {
+  const classNames = classnames(baseClass, className);
+
+  return (
+    <div className={classNames}>
+      {/* The content div is to ensure that the clickable area is contained to
+          the text and icon. This is to prevent the entire cell from being
+          clickable. TODO: Figure out if this is product wants to hand this.
+       */}
+      <div className={`${baseClass}__content`} onClick={onClick}>
+        <span>{value}</span>
+        <Icon name="arrow-internal-link" />
+      </div>
+    </div>
+  );
+};
+
+export default InternalLinkCell;

--- a/frontend/components/TableContainer/DataTable/InternalLinkCell/_styles.scss
+++ b/frontend/components/TableContainer/DataTable/InternalLinkCell/_styles.scss
@@ -1,0 +1,14 @@
+.internal-link-cell {
+
+  &__content {
+    font: $x-small;
+    color: $core-vibrant-blue;
+    font-weight: $bold;
+    display: inline-flex;
+
+    &:hover {
+      cursor: pointer;
+      text-decoration: underline;
+    }
+  }
+}

--- a/frontend/components/TableContainer/DataTable/InternalLinkCell/index.ts
+++ b/frontend/components/TableContainer/DataTable/InternalLinkCell/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./InternalLinkCell";

--- a/frontend/components/TableContainer/TableContainer.tsx
+++ b/frontend/components/TableContainer/TableContainer.tsx
@@ -87,9 +87,13 @@ interface ITableContainerProps<T = any> {
   customControl?: () => JSX.Element;
   stackControls?: boolean;
   onSelectSingleRow?: (value: Row | IRowProps) => void;
+  /** This is called when you click on a row. This was added as `onSelectSingleRow`
+   * only work if `disableMultiRowSelect` is also set to `true`. TODO: figure out
+   * if we want to keep this
+   */
+  onClickRow?: (row: T) => void;
   /** Use for clientside filtering: Use key global for filtering on any column, or use column id as
    * key */
-  onClickRow?: (row: T) => void;
   filters?: Record<string, string | number | boolean>;
   renderCount?: () => JSX.Element | null;
   renderFooter?: () => JSX.Element | null;

--- a/frontend/components/TableContainer/TableContainer.tsx
+++ b/frontend/components/TableContainer/TableContainer.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useCallback, useRef, useEffect } from "react";
 import classnames from "classnames";
-import { Row } from "react-table";
+import { Row, UseExpandedRowProps } from "react-table";
 import ReactTooltip from "react-tooltip";
 import useDeepEffect from "hooks/useDeepEffect";
 
@@ -34,7 +34,7 @@ interface IRowProps extends Row {
   };
 }
 
-interface ITableContainerProps {
+interface ITableContainerProps<T = any> {
   columnConfigs: any; // TODO: Figure out type
   data: any; // TODO: Figure out type
   isLoading: boolean;
@@ -87,7 +87,9 @@ interface ITableContainerProps {
   customControl?: () => JSX.Element;
   stackControls?: boolean;
   onSelectSingleRow?: (value: Row | IRowProps) => void;
-  /** Use for clientside filtering: Use key global for filtering on any column, or use column id as key */
+  /** Use for clientside filtering: Use key global for filtering on any column, or use column id as
+   * key */
+  onClickRow?: (row: T) => void;
   filters?: Record<string, string | number | boolean>;
   renderCount?: () => JSX.Element | null;
   renderFooter?: () => JSX.Element | null;
@@ -101,7 +103,7 @@ const baseClass = "table-container";
 const DEFAULT_PAGE_SIZE = 20;
 const DEFAULT_PAGE_INDEX = 0;
 
-const TableContainer = ({
+const TableContainer = <T,>({
   columnConfigs,
   data,
   filters,
@@ -144,12 +146,13 @@ const TableContainer = ({
   customControl,
   stackControls,
   onSelectSingleRow,
+  onClickRow,
   renderCount,
   renderFooter,
   setExportRows,
   resetPageIndex,
   disableTableHeader,
-}: ITableContainerProps): JSX.Element => {
+}: ITableContainerProps<T>) => {
   const [searchQuery, setSearchQuery] = useState(defaultSearchQuery);
   const [sortHeader, setSortHeader] = useState(defaultSortHeader || "");
   const [sortDirection, setSortDirection] = useState(
@@ -437,6 +440,7 @@ const TableContainer = ({
                 primarySelectAction={primarySelectAction}
                 secondarySelectActions={secondarySelectActions}
                 onSelectSingleRow={onSelectSingleRow}
+                onClickRow={onClickRow}
                 onResultsCountChange={onResultsCountChange}
                 isClientSidePagination={isClientSidePagination}
                 onClientSidePaginationChange={onClientSidePaginationChange}

--- a/frontend/pages/DashboardPage/DashboardPage.tsx
+++ b/frontend/pages/DashboardPage/DashboardPage.tsx
@@ -139,7 +139,7 @@ const DashboardPage = ({ router, location }: IDashboardProps): JSX.Element => {
   const [mdmStatusData, setMdmStatusData] = useState<IMdmStatusCardData[]>([]);
   const [mdmSolutions, setMdmSolutions] = useState<IMdmSolution[] | null>([]);
 
-  const selectedMdmSolution = useRef<string>("");
+  const selectedMdmSolution = useRef<string | null>(null);
 
   const [munkiIssuesData, setMunkiIssuesData] = useState<
     IMunkiIssuesAggregate[]
@@ -618,8 +618,8 @@ const DashboardPage = ({ router, location }: IDashboardProps): JSX.Element => {
             mdmSolutions={mdmSolutions}
             selectedPlatformLabelId={selectedPlatformLabelId}
             selectedTeamId={currentTeamId}
-            onClickMdmSolution={(solutionName) => {
-              selectedMdmSolution.current = solutionName;
+            onClickMdmSolution={(mdmSolution) => {
+              selectedMdmSolution.current = mdmSolution.name;
               setShowMdmSolutionModal(true);
             }}
           />
@@ -722,7 +722,23 @@ const DashboardPage = ({ router, location }: IDashboardProps): JSX.Element => {
   };
 
   const renderMdmSolutionModal = () => {
-    // return <MdmSolutionModal mdmSolution={} />;
+    if (!mdmSolutions) {
+      return null;
+    }
+
+    const selectedMdmSolutions = mdmSolutions?.filter(
+      (solution) => solution.name === selectedMdmSolution.current
+    );
+
+    return (
+      <MdmSolutionModal
+        mdmSolutions={selectedMdmSolutions}
+        onCancel={() => {
+          setShowMdmSolutionModal(false);
+          selectedMdmSolution.current = null;
+        }}
+      />
+    );
   };
 
   const renderDashboardHeader = () => {

--- a/frontend/pages/DashboardPage/DashboardPage.tsx
+++ b/frontend/pages/DashboardPage/DashboardPage.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useState, useEffect } from "react";
+import React, { useContext, useState, useEffect, useRef } from "react";
 import { InjectedRouter } from "react-router";
 import { useQuery } from "react-query";
 
@@ -61,6 +61,7 @@ import Mdm from "./cards/MDM";
 import Munki from "./cards/Munki";
 import OperatingSystems from "./cards/OperatingSystems";
 import AddHostsModal from "../../components/AddHostsModal";
+import MdmSolutionModal from "./components/MdmSolutionModal";
 
 const baseClass = "dashboard-page";
 
@@ -132,10 +133,13 @@ const DashboardPage = ({ router, location }: IDashboardProps): JSX.Element => {
   const [showMdmCard, setShowMdmCard] = useState(true);
   const [showSoftwareCard, setShowSoftwareCard] = useState(false);
   const [showAddHostsModal, setShowAddHostsModal] = useState(false);
+  const [showMdmSolutionModal, setShowMdmSolutionModal] = useState(false);
   const [showOperatingSystemsUI, setShowOperatingSystemsUI] = useState(false);
   const [showHostsUI, setShowHostsUI] = useState(false); // Hides UI on first load only
   const [mdmStatusData, setMdmStatusData] = useState<IMdmStatusCardData[]>([]);
   const [mdmSolutions, setMdmSolutions] = useState<IMdmSolution[] | null>([]);
+
+  const selectedMdmSolution = useRef<string>("");
 
   const [munkiIssuesData, setMunkiIssuesData] = useState<
     IMunkiIssuesAggregate[]
@@ -614,6 +618,10 @@ const DashboardPage = ({ router, location }: IDashboardProps): JSX.Element => {
             mdmSolutions={mdmSolutions}
             selectedPlatformLabelId={selectedPlatformLabelId}
             selectedTeamId={currentTeamId}
+            onClickMdmSolution={(solutionName) => {
+              selectedMdmSolution.current = solutionName;
+              setShowMdmSolutionModal(true);
+            }}
           />
         ),
       })}
@@ -713,6 +721,10 @@ const DashboardPage = ({ router, location }: IDashboardProps): JSX.Element => {
     );
   };
 
+  const renderMdmSolutionModal = () => {
+    // return <MdmSolutionModal mdmSolution={} />;
+  };
+
   const renderDashboardHeader = () => {
     if (isPremiumTier) {
       if (userTeams) {
@@ -785,6 +797,7 @@ const DashboardPage = ({ router, location }: IDashboardProps): JSX.Element => {
         </div>
         {renderCards()}
         {showAddHostsModal && renderAddHostsModal()}
+        {showMdmSolutionModal && renderMdmSolutionModal()}
       </div>
     </MainContent>
   );

--- a/frontend/pages/DashboardPage/DashboardPage.tsx
+++ b/frontend/pages/DashboardPage/DashboardPage.tsx
@@ -733,6 +733,8 @@ const DashboardPage = ({ router, location }: IDashboardProps): JSX.Element => {
     return (
       <MdmSolutionModal
         mdmSolutions={selectedMdmSolutions}
+        selectedPlatformLabelId={selectedPlatformLabelId}
+        selectedTeamId={currentTeamId}
         onCancel={() => {
           setShowMdmSolutionModal(false);
           selectedMdmSolution.current = null;

--- a/frontend/pages/DashboardPage/cards/MDM/MDM.tests.tsx
+++ b/frontend/pages/DashboardPage/cards/MDM/MDM.tests.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { noop } from "lodash";
 import { render, screen } from "@testing-library/react";
 import { renderWithSetup } from "test/test-utils";
 
@@ -10,6 +11,7 @@ describe("MDM Card", () => {
   it("render the correct number of MDM solutions", () => {
     render(
       <MDM
+        onClickMdmSolution={noop}
         error={null}
         isFetching={false}
         mdmStatusData={[]}
@@ -26,6 +28,7 @@ describe("MDM Card", () => {
   it("render the correct number of Enrollment status", async () => {
     const { user } = renderWithSetup(
       <MDM
+        onClickMdmSolution={noop}
         error={null}
         isFetching={false}
         mdmStatusData={[

--- a/frontend/pages/DashboardPage/cards/MDM/MDM.tests.tsx
+++ b/frontend/pages/DashboardPage/cards/MDM/MDM.tests.tsx
@@ -8,8 +8,8 @@ import { createMockMdmSolution } from "__mocks__/mdmMock";
 import MDM from "./MDM";
 
 describe("MDM Card", () => {
-  it("render the correct number of MDM solutions", () => {
-    render(
+  it("rolls up the data by mdm solution name and render the correct number of MDM solutions", () => {
+    const { debug } = render(
       <MDM
         onClickMdmSolution={noop}
         error={null}
@@ -18,11 +18,18 @@ describe("MDM Card", () => {
         mdmSolutions={[
           createMockMdmSolution(),
           createMockMdmSolution({ id: 2 }),
+          createMockMdmSolution({ name: "Test Solution", id: 3 }),
+          createMockMdmSolution({ name: "Test Solution", id: 4 }),
+          createMockMdmSolution({ name: "Test Solution 2", id: 5 }),
         ]}
       />
     );
 
-    expect(screen.getAllByText("MDM Solution").length).toBe(2);
+    debug();
+
+    expect(screen.getAllByText("MDM Solution").length).toBe(1);
+    expect(screen.getAllByText("Test Solution").length).toBe(1);
+    expect(screen.getAllByText("Test Solution 2").length).toBe(1);
   });
 
   it("render the correct number of Enrollment status", async () => {

--- a/frontend/pages/DashboardPage/cards/MDM/MDM.tsx
+++ b/frontend/pages/DashboardPage/cards/MDM/MDM.tsx
@@ -93,8 +93,6 @@ const Mdm = ({
     }, []);
   }, [mdmSolutions]);
 
-  console.log(rolledupMdmSolutionsData);
-
   const solutionsTableHeaders = useMemo(
     () => generateSolutionsTableHeaders(),
     []

--- a/frontend/pages/DashboardPage/cards/MDM/MDM.tsx
+++ b/frontend/pages/DashboardPage/cards/MDM/MDM.tsx
@@ -73,16 +73,38 @@ const Mdm = ({
     setNavTabIndex(index);
   };
 
+  const rolledupMdmSolutionsData = useMemo(() => {
+    if (!mdmSolutions) {
+      return [];
+    }
+
+    return mdmSolutions.reduce<IMdmSolution[]>((acc, nextSolution) => {
+      const existingSolution = acc.find(
+        (solution) => solution.name === nextSolution.name
+      );
+
+      if (existingSolution) {
+        existingSolution.hosts_count += nextSolution.hosts_count;
+      } else {
+        acc.push(nextSolution);
+      }
+
+      return acc;
+    }, []);
+  }, [mdmSolutions]);
+
+  console.log(rolledupMdmSolutionsData);
+
   const solutionsTableHeaders = useMemo(
-    () => generateSolutionsTableHeaders(selectedTeamId),
-    [selectedTeamId]
+    () => generateSolutionsTableHeaders(),
+    []
   );
   const statusTableHeaders = useMemo(
     () => generateStatusTableHeaders(selectedTeamId),
     [selectedTeamId]
   );
   const solutionsDataSet = generateSolutionsDataSet(
-    mdmSolutions,
+    rolledupMdmSolutionsData,
     selectedPlatformLabelId
   );
   const statusDataSet = generateStatusDataSet(
@@ -121,8 +143,8 @@ const Mdm = ({
                   emptyComponent={EmptyMdmSolutions}
                   showMarkAllPages={false}
                   isAllPagesSelected={false}
-                  isClientSidePagination
                   disableCount
+                  disablePagination
                   pageSize={PAGE_SIZE}
                 />
               )}

--- a/frontend/pages/DashboardPage/cards/MDM/MDM.tsx
+++ b/frontend/pages/DashboardPage/cards/MDM/MDM.tsx
@@ -1,5 +1,6 @@
 import React, { useMemo, useState } from "react";
 import { Tab, Tabs, TabList, TabPanel } from "react-tabs";
+import { Row } from "react-table";
 
 import { IMdmStatusCardData, IMdmSolution } from "interfaces/mdm";
 
@@ -19,6 +20,10 @@ import {
   generateStatusDataSet,
 } from "./MDMStatusTableConfig";
 
+interface IRowProps extends Row {
+  original: IMdmSolution;
+}
+
 interface IMdmCardProps {
   error: Error | null;
   isFetching: boolean;
@@ -26,6 +31,7 @@ interface IMdmCardProps {
   mdmSolutions: IMdmSolution[] | null;
   selectedPlatformLabelId?: number;
   selectedTeamId?: number;
+  onClickMdmSolution: (solution: IMdmSolution) => void;
 }
 
 const DEFAULT_SORT_DIRECTION = "desc";
@@ -66,6 +72,7 @@ const Mdm = ({
   mdmSolutions,
   selectedPlatformLabelId,
   selectedTeamId,
+  onClickMdmSolution,
 }: IMdmCardProps): JSX.Element => {
   const [navTabIndex, setNavTabIndex] = useState(0);
 
@@ -113,6 +120,10 @@ const Mdm = ({
   // Renders opaque information as host information is loading
   const opacity = isFetching ? { opacity: 0 } : { opacity: 1 };
 
+  const handleSolutionRowClick = (row: IRowProps) => {
+    onClickMdmSolution(row.original);
+  };
+
   return (
     <div className={baseClass}>
       {isFetching && (
@@ -131,7 +142,7 @@ const Mdm = ({
               {error ? (
                 <TableDataError card />
               ) : (
-                <TableContainer
+                <TableContainer<IRowProps>
                   columnConfigs={solutionsTableHeaders}
                   data={solutionsDataSet}
                   isLoading={isFetching}
@@ -143,7 +154,7 @@ const Mdm = ({
                   isAllPagesSelected={false}
                   disableCount
                   disablePagination
-                  pageSize={PAGE_SIZE}
+                  onClickRow={handleSolutionRowClick}
                 />
               )}
             </TabPanel>

--- a/frontend/pages/DashboardPage/cards/MDM/MDMSolutionsTableConfig.tsx
+++ b/frontend/pages/DashboardPage/cards/MDM/MDMSolutionsTableConfig.tsx
@@ -46,9 +46,7 @@ interface IDataColumn {
   disableSortBy?: boolean;
 }
 
-export const generateSolutionsTableHeaders = (
-  teamId?: number
-): IDataColumn[] => [
+export const generateSolutionsTableHeaders = (): IDataColumn[] => [
   {
     title: "Name",
     Header: "Name",
@@ -61,41 +59,37 @@ export const generateSolutionsTableHeaders = (
       />
     ),
   },
-  {
-    title: "Server URL",
-    Header: "Server URL",
-    disableSortBy: true,
-    accessor: "server_url",
-    Cell: (cellProps: ICellProps) => <TextCell value={cellProps.cell.value} />,
-  },
+  // {
+  //   title: "Server URL",
+  //   Header: "Server URL",
+  //   disableSortBy: true,
+  //   accessor: "server_url",
+  //   Cell: (cellProps: ICellProps) => <TextCell value={cellProps.cell.value} />,
+  // },
   {
     title: "Hosts",
-    Header: (cellProps: IHeaderProps) => (
-      <HeaderCell
-        value={cellProps.column.title}
-        isSortedDesc={cellProps.column.isSortedDesc}
-      />
-    ),
+    Header: "Hosts",
+    disableSortBy: true,
     accessor: "hosts_count",
     Cell: (cellProps: ICellProps) => <TextCell value={cellProps.cell.value} />,
   },
-  {
-    title: "",
-    Header: "",
-    disableSortBy: true,
-    disableGlobalFilter: true,
-    accessor: "linkToFilteredHosts",
-    Cell: (cellProps: IStringCellProps) => {
-      return (
-        <ViewAllHostsLink
-          queryParams={{ mdm_id: cellProps.row.original.id, team_id: teamId }}
-          className="mdm-solution-link"
-          platformLabelId={cellProps.row.original.selectedPlatformLabelId}
-        />
-      );
-    },
-    disableHidden: true,
-  },
+  // {
+  //   title: "",
+  //   Header: "",
+  //   disableSortBy: true,
+  //   disableGlobalFilter: true,
+  //   accessor: "linkToFilteredHosts",
+  //   Cell: (cellProps: IStringCellProps) => {
+  //     return (
+  //       <ViewAllHostsLink
+  //         queryParams={{ mdm_id: cellProps.row.original.id, team_id: teamId }}
+  //         className="mdm-solution-link"
+  //         platformLabelId={cellProps.row.original.selectedPlatformLabelId}
+  //       />
+  //     );
+  //   },
+  //   disableHidden: true,
+  // },
 ];
 
 const enhanceSolutionsData = (

--- a/frontend/pages/DashboardPage/cards/MDM/MDMSolutionsTableConfig.tsx
+++ b/frontend/pages/DashboardPage/cards/MDM/MDMSolutionsTableConfig.tsx
@@ -32,12 +32,6 @@ interface IHeaderProps {
   };
 }
 
-interface IStringCellProps extends ICellProps {
-  cell: {
-    value: string;
-  };
-}
-
 interface IDataColumn {
   title: string;
   Header: ((props: IHeaderProps) => JSX.Element) | string;

--- a/frontend/pages/DashboardPage/cards/MDM/MDMSolutionsTableConfig.tsx
+++ b/frontend/pages/DashboardPage/cards/MDM/MDMSolutionsTableConfig.tsx
@@ -6,6 +6,8 @@ import { greyCell } from "utilities/helpers";
 import HeaderCell from "components/TableContainer/DataTable/HeaderCell";
 import TextCell from "components/TableContainer/DataTable/TextCell";
 import ViewAllHostsLink from "components/ViewAllHostsLink";
+import LinkCell from "components/TableContainer/DataTable/LinkCell";
+import InternalLinkCell from "../../../../components/TableContainer/DataTable/InternalLinkCell";
 
 // NOTE: cellProps come from react-table
 // more info here https://react-table.tanstack.com/docs/api/useTable#cell-properties
@@ -53,10 +55,7 @@ export const generateSolutionsTableHeaders = (): IDataColumn[] => [
     disableSortBy: true,
     accessor: "name",
     Cell: (cellProps: ICellProps) => (
-      <TextCell
-        greyed={greyCell(cellProps.cell.value)}
-        value={cellProps.cell.value}
-      />
+      <InternalLinkCell value={cellProps.cell.value} />
     ),
   },
   // {

--- a/frontend/pages/DashboardPage/components/MdmSolutionModal/MdmSolutionModal.tsx
+++ b/frontend/pages/DashboardPage/components/MdmSolutionModal/MdmSolutionModal.tsx
@@ -1,25 +1,63 @@
-import React from "react";
+import React, { useMemo } from "react";
 
 import { IMdmSolution } from "interfaces/mdm";
 
 import Modal from "components/Modal";
+import TableContainer from "components/TableContainer";
+
+import {
+  generateSolutionsDataSet,
+  generateSolutionsTableHeaders,
+} from "./MdmSolutionModalTableConfig";
 
 const baseClass = "mdm-solution-modal";
 
+const SOLUTIONS_DEFAULT_SORT_HEADER = "hosts_count";
+const DEFAULT_SORT_DIRECTION = "desc";
+
 interface IMdmSolutionModalProps {
   mdmSolutions: IMdmSolution[];
+  selectedPlatformLabelId?: number;
+  selectedTeamId?: number;
   onCancel: () => void;
 }
 
 const MdmSolutionsModal = ({
   mdmSolutions,
+  selectedPlatformLabelId,
+  selectedTeamId,
   onCancel,
 }: IMdmSolutionModalProps) => {
   console.log(mdmSolutions);
 
+  const solutionsTableHeaders = useMemo(
+    () => generateSolutionsTableHeaders(selectedTeamId),
+    [selectedTeamId]
+  );
+  const solutionsDataSet = generateSolutionsDataSet(
+    mdmSolutions,
+    selectedPlatformLabelId
+  );
+
   return (
-    <Modal className={baseClass} title="test" onExit={onCancel}>
-      <div>test</div>
+    <Modal
+      className={baseClass}
+      title={mdmSolutions[0].name ?? "Mdm solution"}
+      width="large"
+      onExit={onCancel}
+    >
+      <TableContainer
+        isLoading={false}
+        emptyComponent={() => null} // if this modal is shown, this table should never be empty
+        columnConfigs={solutionsTableHeaders}
+        data={solutionsDataSet}
+        defaultSortHeader={SOLUTIONS_DEFAULT_SORT_HEADER}
+        defaultSortDirection={DEFAULT_SORT_DIRECTION}
+        resultsTitle="MDM"
+        showMarkAllPages={false}
+        isAllPagesSelected={false}
+        disableCount
+      />
     </Modal>
   );
 };

--- a/frontend/pages/DashboardPage/components/MdmSolutionModal/MdmSolutionModal.tsx
+++ b/frontend/pages/DashboardPage/components/MdmSolutionModal/MdmSolutionModal.tsx
@@ -4,6 +4,7 @@ import { IMdmSolution } from "interfaces/mdm";
 
 import Modal from "components/Modal";
 import TableContainer from "components/TableContainer";
+import Button from "components/buttons/Button";
 
 import {
   generateSolutionsDataSet,
@@ -46,18 +47,29 @@ const MdmSolutionsModal = ({
       width="large"
       onExit={onCancel}
     >
-      <TableContainer
-        isLoading={false}
-        emptyComponent={() => null} // if this modal is shown, this table should never be empty
-        columnConfigs={solutionsTableHeaders}
-        data={solutionsDataSet}
-        defaultSortHeader={SOLUTIONS_DEFAULT_SORT_HEADER}
-        defaultSortDirection={DEFAULT_SORT_DIRECTION}
-        resultsTitle="MDM"
-        showMarkAllPages={false}
-        isAllPagesSelected={false}
-        disableCount
-      />
+      <>
+        <div className={`${baseClass}__modal-content`}>
+          <TableContainer
+            isLoading={false}
+            emptyComponent={() => null} // if this modal is shown, this table should never be empty
+            columnConfigs={solutionsTableHeaders}
+            data={solutionsDataSet}
+            defaultSortHeader={SOLUTIONS_DEFAULT_SORT_HEADER}
+            defaultSortDirection={DEFAULT_SORT_DIRECTION}
+            resultsTitle="MDM"
+            showMarkAllPages={false}
+            isAllPagesSelected={false}
+            disableCount
+            disablePagination
+            disableTableHeader
+          />
+        </div>
+        <div className="modal-cta-wrap">
+          <Button type="button" onClick={onCancel} variant="brand">
+            Done
+          </Button>
+        </div>
+      </>
     </Modal>
   );
 };

--- a/frontend/pages/DashboardPage/components/MdmSolutionModal/MdmSolutionModal.tsx
+++ b/frontend/pages/DashboardPage/components/MdmSolutionModal/MdmSolutionModal.tsx
@@ -1,0 +1,27 @@
+import React from "react";
+
+import { IMdmSolution } from "interfaces/mdm";
+
+import Modal from "components/Modal";
+
+const baseClass = "mdm-solution-modal";
+
+interface IMdmSolutionModalProps {
+  mdmSolutions: IMdmSolution[];
+  onCancel: () => void;
+}
+
+const MdmSolutionsModal = ({
+  mdmSolutions,
+  onCancel,
+}: IMdmSolutionModalProps) => {
+  console.log(mdmSolutions);
+
+  return (
+    <Modal className={baseClass} title="test" onExit={onCancel}>
+      <div>test</div>
+    </Modal>
+  );
+};
+
+export default MdmSolutionsModal;

--- a/frontend/pages/DashboardPage/components/MdmSolutionModal/MdmSolutionModalTableConfig.tsx
+++ b/frontend/pages/DashboardPage/components/MdmSolutionModal/MdmSolutionModalTableConfig.tsx
@@ -2,12 +2,8 @@ import React from "react";
 
 import { IMdmSolution } from "interfaces/mdm";
 
-import { greyCell } from "utilities/helpers";
-import HeaderCell from "components/TableContainer/DataTable/HeaderCell";
 import TextCell from "components/TableContainer/DataTable/TextCell";
 import ViewAllHostsLink from "components/ViewAllHostsLink";
-import LinkCell from "components/TableContainer/DataTable/LinkCell";
-import InternalLinkCell from "../../../../components/TableContainer/DataTable/InternalLinkCell";
 
 // NOTE: cellProps come from react-table
 // more info here https://react-table.tanstack.com/docs/api/useTable#cell-properties
@@ -48,22 +44,31 @@ interface IDataColumn {
   disableSortBy?: boolean;
 }
 
-export const generateSolutionsTableHeaders = (): IDataColumn[] => [
+export const generateSolutionsTableHeaders = (
+  teamId?: number
+): IDataColumn[] => [
   {
-    title: "Name",
-    Header: "Name",
+    title: "Server URL",
+    Header: "Server URL",
     disableSortBy: true,
-    accessor: "name",
-    Cell: (cellProps: ICellProps) => (
-      <InternalLinkCell value={cellProps.cell.value} />
-    ),
+    accessor: "server_url",
+    Cell: (cellProps: ICellProps) => <TextCell value={cellProps.cell.value} />,
   },
   {
     title: "Hosts",
     Header: "Hosts",
     disableSortBy: true,
     accessor: "hosts_count",
-    Cell: (cellProps: ICellProps) => <TextCell value={cellProps.cell.value} />,
+    Cell: (cellProps: ICellProps) => (
+      <div className="host-count-cell">
+        <TextCell value={cellProps.cell.value} classes="" />
+        <ViewAllHostsLink
+          queryParams={{ mdm_id: cellProps.row.original.id, team_id: teamId }}
+          className="mdm-solution-link"
+          platformLabelId={cellProps.row.original.selectedPlatformLabelId}
+        />
+      </div>
+    ),
   },
 ];
 

--- a/frontend/pages/DashboardPage/components/MdmSolutionModal/MdmSolutionModalTableConfig.tsx
+++ b/frontend/pages/DashboardPage/components/MdmSolutionModal/MdmSolutionModalTableConfig.tsx
@@ -4,6 +4,8 @@ import { IMdmSolution } from "interfaces/mdm";
 
 import TextCell from "components/TableContainer/DataTable/TextCell";
 import ViewAllHostsLink from "components/ViewAllHostsLink";
+import TooltipWrapper from "components/TooltipWrapper";
+import HeaderCell from "components/TableContainer/DataTable/HeaderCell";
 
 // NOTE: cellProps come from react-table
 // more info here https://react-table.tanstack.com/docs/api/useTable#cell-properties
@@ -28,12 +30,6 @@ interface IHeaderProps {
   };
 }
 
-interface IStringCellProps extends ICellProps {
-  cell: {
-    value: string;
-  };
-}
-
 interface IDataColumn {
   title: string;
   Header: ((props: IHeaderProps) => JSX.Element) | string;
@@ -49,7 +45,24 @@ export const generateSolutionsTableHeaders = (
 ): IDataColumn[] => [
   {
     title: "Server URL",
-    Header: "Server URL",
+    Header: (): JSX.Element => {
+      const titleWithToolTip = (
+        <TooltipWrapper
+          position="top-start"
+          tipContent={
+            <>
+              The MDM server URL is used to connect hosts with the MDM service.
+              For cross-platform MDM solutions, each operating system has a
+              different URL.
+            </>
+          }
+          className="server-url-header"
+        >
+          Status
+        </TooltipWrapper>
+      );
+      return <HeaderCell value={titleWithToolTip} disableSortBy />;
+    },
     disableSortBy: true,
     accessor: "server_url",
     Cell: (cellProps: ICellProps) => <TextCell value={cellProps.cell.value} />,

--- a/frontend/pages/DashboardPage/components/MdmSolutionModal/MdmSolutionModalTableConfig.tsx
+++ b/frontend/pages/DashboardPage/components/MdmSolutionModal/MdmSolutionModalTableConfig.tsx
@@ -77,8 +77,9 @@ export const generateSolutionsTableHeaders = (
         <TextCell value={cellProps.cell.value} classes="" />
         <ViewAllHostsLink
           queryParams={{ mdm_id: cellProps.row.original.id, team_id: teamId }}
-          className="mdm-solution-link"
+          className="view-mdm-solution-link"
           platformLabelId={cellProps.row.original.selectedPlatformLabelId}
+          rowHover
         />
       </div>
     ),

--- a/frontend/pages/DashboardPage/components/MdmSolutionModal/_styles.scss
+++ b/frontend/pages/DashboardPage/components/MdmSolutionModal/_styles.scss
@@ -1,0 +1,7 @@
+.mdm-solution-modal {
+  .host-count-cell {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+  }
+}

--- a/frontend/pages/DashboardPage/components/MdmSolutionModal/index.ts
+++ b/frontend/pages/DashboardPage/components/MdmSolutionModal/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./MdmSolutionModal";


### PR DESCRIPTION
relates to #16837 

This rolls up the mdm solutions by name so that we only see one instance of the mdm name. Clicking on this will then open a modal that shows the server URLs and # of hosts for the mdm solution.

**Before:**

<img width="759" alt="image" src="https://github.com/fleetdm/fleet/assets/1153709/2e8e6187-d987-42c3-8b8f-aa0552869578">

**After:**

<img width="768" alt="image" src="https://github.com/fleetdm/fleet/assets/1153709/ff92199a-a9f8-4e42-8bb7-b626979c79d5">

**New modal:**

<img width="822" alt="image" src="https://github.com/fleetdm/fleet/assets/1153709/88891630-352a-4aa6-999c-e25907a27ad0">


- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
- [x] Manual QA for all new/changed functionality
