### PR TITLE
Update API and CLI to enable running scripts by name and team id

### DIFF
--- a/cmd/fleetctl/scripts_test.go
+++ b/cmd/fleetctl/scripts_test.go
@@ -45,15 +45,27 @@ func TestRunScriptCommand(t *testing.T) {
 	ds.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {
 		return &fleet.AppConfig{ServerSettings: fleet.ServerSettings{ScriptsDisabled: false}}, nil
 	}
+	ds.GetScriptIDByNameFunc = func(ctx context.Context, name string, teamID *uint) (uint, error) {
+		return 1, nil
+	}
+	ds.IsExecutionPendingForHostFunc = func(ctx context.Context, hid uint, scriptID uint) ([]*uint, error) {
+		return []*uint{}, nil
+	}
+	ds.GetScriptContentsFunc = func(ctx context.Context, id uint) ([]byte, error) {
+		return []byte("echo hello world"), nil
+	}
 
 	generateValidPath := func() string {
 		return writeTmpScriptContents(t, "echo hello world", ".sh")
 	}
 	maxChars := strings.Repeat("a", 10001)
+	// maxCharsSavedScriptContents := strings.Repeat("a", 500001)
 
 	type testCase struct {
 		name           string
 		scriptPath     func() string
+		scriptName     string
+		teamID         *uint
 		scriptResult   *fleet.HostScriptResult
 		expectOutput   string
 		expectErrMsg   string
@@ -86,11 +98,27 @@ func TestRunScriptCommand(t *testing.T) {
 			expectErrMsg: `Interpreter not supported. Bash scripts must run in "#!/bin/sh”.`,
 		},
 		{
-			name: "script too long",
+			name: "script too long (unsaved)",
 			scriptPath: func() string {
 				return writeTmpScriptContents(t, maxChars, ".sh")
 			},
-			expectErrMsg: `Script is too large. It's limited to 10,000 characters (approximately 125 lines).`,
+			expectErrMsg: "Script is too large. Script referenced by '--script-path' is limited to 10,000 characters. To run larger script save it to Fleet and use '--script-name'.",
+		},
+		{
+			name:         "script-path and script-name disallowed",
+			scriptPath:   generateValidPath,
+			scriptName:   "foo",
+			expectErrMsg: `Only one of --script-path or --script-name is allowed.`,
+		},
+		{
+			name:         "missing one of script-path and script-nqme",
+			expectErrMsg: `One of --script-path or --script-name must be specified.`,
+		},
+		{
+			name:         "script-path and team-id disallowed",
+			scriptPath:   generateValidPath,
+			teamID:       ptr.Uint(1),
+			expectErrMsg: `Only one of --script-path or --team-id is allowed.`,
 		},
 		{
 			name:         "script empty",
@@ -255,18 +283,33 @@ Fleet records the last 10,000 characters to prevent downtime.
 			ds.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {
 				return &fleet.AppConfig{ServerSettings: fleet.ServerSettings{ScriptsDisabled: true}}, nil
 			}
+		} else {
+			ds.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {
+				return &fleet.AppConfig{ServerSettings: fleet.ServerSettings{ScriptsDisabled: false}}, nil
+			}
 		}
 	}
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			setupDS(t, c)
-			scriptPath := c.scriptPath()
-			defer os.Remove(scriptPath)
+			args := []string{"run-script", "--host", "host1"}
 
-			b, err := runAppNoChecks([]string{
-				"run-script", "--host", "host1", "--script-path", scriptPath,
-			})
+			if c.scriptPath != nil {
+				scriptPath := c.scriptPath()
+				defer os.Remove(scriptPath)
+				args = append(args, "--script-path", scriptPath)
+			}
+
+			if c.scriptName != "" {
+				args = append(args, "--script-name", c.scriptName)
+			}
+
+			if c.teamID != nil {
+				args = append(args, "--team-id", fmt.Sprintf("%d", *c.teamID))
+			}
+
+			b, err := runAppNoChecks(args)
 			if c.expectErrMsg != "" {
 				require.Error(t, err)
 				require.Contains(t, err.Error(), c.expectErrMsg)

--- a/server/fleet/datastore.go
+++ b/server/fleet/datastore.go
@@ -1289,6 +1289,9 @@ type Datastore interface {
 	// criteria.
 	ListScripts(ctx context.Context, teamID *uint, opt ListOptions) ([]*Script, *PaginationMetadata, error)
 
+	// GetScriptIDByName returns the id of the script with the given name and team id.
+	GetScriptIDByName(ctx context.Context, name string, teamID *uint) (uint, error)
+
 	// GetHostScriptDetails returns the list of host script details for saved scripts applicable to
 	// a given host.
 	GetHostScriptDetails(ctx context.Context, hostID uint, teamID *uint, opts ListOptions, hostPlatform string) ([]*HostScriptDetail, *PaginationMetadata, error)

--- a/server/fleet/errors.go
+++ b/server/fleet/errors.go
@@ -547,6 +547,8 @@ const (
 	RunScriptDisabledErrMsg                = "Scripts are disabled for this host. To run scripts, deploy the fleetd agent with scripts enabled."
 	RunScriptScriptTimeoutErrMsg           = "Timeout. Fleet stopped the script after 5 minutes to protect host performance."
 	RunScriptAsyncScriptEnqueuedErrMsg     = "Script is running or will run when the host comes online."
+	RunScripSavedMaxLenErrMsg              = "Script is too large. It's limited to 500,000 characters (approximately 10,000 lines)."
+	RunScripUnsavedMaxLenErrMsg            = "Script is too large. It's limited to 10,000 characters (approximately 125 lines)."
 
 	// End user authentication
 	EndUserAuthDEPWebURLConfiguredErrMsg = `End user authentication can't be configured when the configured automatic enrollment (DEP) profile specifies a configuration_web_url.` // #nosec G101

--- a/server/fleet/scripts.go
+++ b/server/fleet/scripts.go
@@ -135,12 +135,12 @@ func (hs *HostScriptDetail) setLastExecution(executionID *string, executedAt *ti
 }
 
 type HostScriptRequestPayload struct {
-	HostID         uint   `json:"host_id"`
-	ScriptID       *uint  `json:"script_id"`
-	ScriptContents string `json:"script_contents"`
-  ScriptContentID uint   `json:"-"`
-	ScriptName     string `json:"script_name"`
-	TeamID         uint   `json:"team_id,omitempty"`
+	HostID          uint   `json:"host_id"`
+	ScriptID        *uint  `json:"script_id"`
+	ScriptContents  string `json:"script_contents"`
+	ScriptContentID uint   `json:"-"`
+	ScriptName      string `json:"script_name"`
+	TeamID          uint   `json:"team_id,omitempty"`
 	// UserID is filled automatically from the context's user (the authenticated
 	// user that made the API request).
 	UserID *uint `json:"-"`

--- a/server/fleet/scripts_test.go
+++ b/server/fleet/scripts_test.go
@@ -52,7 +52,7 @@ func TestScriptValidate(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := tt.script.Validate()
+			err := tt.script.ValidateNewScript()
 			require.Equal(t, tt.wantErr, err)
 		})
 	}
@@ -60,9 +60,10 @@ func TestScriptValidate(t *testing.T) {
 
 func TestValidateHostScriptContents(t *testing.T) {
 	tests := []struct {
-		name    string
-		script  string
-		wantErr error
+		name      string
+		script    string
+		isUnsaved bool
+		wantErr   error
 	}{
 		{
 			name:    "empty script",
@@ -70,14 +71,26 @@ func TestValidateHostScriptContents(t *testing.T) {
 			wantErr: errors.New("Script contents must not be empty."),
 		},
 		{
-			name:    "too large by byte count",
-			script:  strings.Repeat("a", utf8.UTFMax*MaxScriptRuneLen+1),
-			wantErr: errors.New("Script is too large. It's limited to 10,000 characters (approximately 125 lines)."),
+			name:    "too large by byte count (saved)",
+			script:  strings.Repeat("a", utf8.UTFMax*SavedScriptMaxRuneLen+1),
+			wantErr: errors.New("Script is too large. It's limited to 500,000 characters (approximately 10,000 lines)."),
 		},
 		{
-			name:    "too large by rune count",
-			script:  strings.Repeat("🙂", MaxScriptRuneLen+1),
-			wantErr: errors.New("Script is too large. It's limited to 10,000 characters (approximately 125 lines)."),
+			name:      "too large by byte count (unsaved)",
+			script:    strings.Repeat("a", utf8.UTFMax*UnsavedScriptMaxRuneLen+1),
+			isUnsaved: true,
+			wantErr:   errors.New("Script is too large. It's limited to 10,000 characters (approximately 125 lines)."),
+		},
+		{
+			name:    "too large by rune count (saved)",
+			script:  strings.Repeat("🙂", SavedScriptMaxRuneLen+1),
+			wantErr: errors.New("Script is too large. It's limited to 500,000 characters (approximately 10,000 lines)."),
+		},
+		{
+			name:      "too large by byte count (unsaved)",
+			script:    strings.Repeat("a", utf8.UTFMax*UnsavedScriptMaxRuneLen+1),
+			isUnsaved: true,
+			wantErr:   errors.New("Script is too large. It's limited to 10,000 characters (approximately 125 lines)."),
 		},
 		{
 			name:    "invalid utf8 encoding",
@@ -98,7 +111,7 @@ func TestValidateHostScriptContents(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := ValidateHostScriptContents(tt.script)
+			err := ValidateHostScriptContents(tt.script, !tt.isUnsaved)
 			require.Equal(t, tt.wantErr, err)
 		})
 	}

--- a/server/fleet/service.go
+++ b/server/fleet/service.go
@@ -923,6 +923,11 @@ type Service interface {
 	// fails with a 504 Gateway Timeout error.
 	RunHostScript(ctx context.Context, request *HostScriptRequestPayload, waitForResult time.Duration) (*HostScriptResult, error)
 
+	// GetScriptIDByName returns the ID of a script matching the provided name and team. If no team
+	// is provided, it will return the ID of the script with the provided name that is not
+	// associated with any team.
+	GetScriptIDByName(ctx context.Context, name string, teamID *uint) (uint, error)
+
 	// GetHostScript returns information about a host script execution.
 	GetHostScript(ctx context.Context, execID string) (*HostScriptResult, error)
 

--- a/server/mock/datastore_mock.go
+++ b/server/mock/datastore_mock.go
@@ -824,6 +824,8 @@ type DeleteScriptFunc func(ctx context.Context, id uint) error
 
 type ListScriptsFunc func(ctx context.Context, teamID *uint, opt fleet.ListOptions) ([]*fleet.Script, *fleet.PaginationMetadata, error)
 
+type GetScriptIDByNameFunc func(ctx context.Context, name string, teamID *uint) (uint, error)
+
 type GetHostScriptDetailsFunc func(ctx context.Context, hostID uint, teamID *uint, opts fleet.ListOptions, hostPlatform string) ([]*fleet.HostScriptDetail, *fleet.PaginationMetadata, error)
 
 type BatchSetScriptsFunc func(ctx context.Context, tmID *uint, scripts []*fleet.Script) error
@@ -2047,6 +2049,9 @@ type DataStore struct {
 
 	ListScriptsFunc        ListScriptsFunc
 	ListScriptsFuncInvoked bool
+
+	GetScriptIDByNameFunc        GetScriptIDByNameFunc
+	GetScriptIDByNameFuncInvoked bool
 
 	GetHostScriptDetailsFunc        GetHostScriptDetailsFunc
 	GetHostScriptDetailsFuncInvoked bool
@@ -4891,6 +4896,13 @@ func (s *DataStore) ListScripts(ctx context.Context, teamID *uint, opt fleet.Lis
 	s.ListScriptsFuncInvoked = true
 	s.mu.Unlock()
 	return s.ListScriptsFunc(ctx, teamID, opt)
+}
+
+func (s *DataStore) GetScriptIDByName(ctx context.Context, name string, teamID *uint) (uint, error) {
+	s.mu.Lock()
+	s.GetScriptIDByNameFuncInvoked = true
+	s.mu.Unlock()
+	return s.GetScriptIDByNameFunc(ctx, name, teamID)
 }
 
 func (s *DataStore) GetHostScriptDetails(ctx context.Context, hostID uint, teamID *uint, opts fleet.ListOptions, hostPlatform string) ([]*fleet.HostScriptDetail, *fleet.PaginationMetadata, error) {

--- a/server/service/handler.go
+++ b/server/service/handler.go
@@ -466,7 +466,7 @@ func attachFleetAPIRoutes(r *mux.Router, svc fleet.Service, config config.FleetC
 	ue.GET("/api/_version_/fleet/status/live_query", statusLiveQueryEndpoint, nil)
 
 	ue.POST("/api/_version_/fleet/scripts/run", runScriptEndpoint, runScriptRequest{})
-	ue.POST("/api/_version_/fleet/scripts/run/sync", runScriptSyncEndpoint, runScriptRequest{})
+	ue.POST("/api/_version_/fleet/scripts/run/sync", runScriptSyncEndpoint, runScriptSyncRequest{})
 	ue.GET("/api/_version_/fleet/scripts/results/{execution_id}", getScriptResultEndpoint, getScriptResultRequest{})
 	ue.POST("/api/_version_/fleet/scripts", createScriptEndpoint, createScriptRequest{})
 	ue.GET("/api/_version_/fleet/scripts", listScriptsEndpoint, listScriptsRequest{})

--- a/server/service/integration_core_test.go
+++ b/server/service/integration_core_test.go
@@ -5377,6 +5377,16 @@ func (s *integrationTestSuite) TestScriptsEndpointsWithoutLicense() {
 		"myscript.sh", []byte(`echo "hello"`), s.token, nil)
 	s.DoRawWithHeaders("POST", "/api/latest/fleet/scripts", body.Bytes(), http.StatusOK, headers)
 
+	// run a saved script by name without team id (should fail host not found)
+	res := s.Do("POST", "/api/latest/fleet/scripts/run/sync", runScriptSyncRequest{ScriptName: "myscript.sh"}, http.StatusNotFound)
+	errMsg := extractServerErrorText(res.Body)
+	require.Contains(t, errMsg, "Host was not found in the datastore")
+
+	// run a saved script by name with team id (should fail script not found)
+	res = s.Do("POST", "/api/latest/fleet/scripts/run/sync", runScriptSyncRequest{ScriptName: "myscript.sh", TeamID: ptr.Uint(1)}, http.StatusNotFound)
+	errMsg = extractServerErrorText(res.Body)
+	require.Contains(t, errMsg, "myscript.sh was not found in the datastore")
+
 	// delete a saved script
 	var delScriptResp deleteScriptResponse
 	s.DoJSON("DELETE", "/api/latest/fleet/scripts/123", nil, http.StatusNotFound, &delScriptResp)

--- a/server/service/integration_core_test.go
+++ b/server/service/integration_core_test.go
@@ -5382,10 +5382,10 @@ func (s *integrationTestSuite) TestScriptsEndpointsWithoutLicense() {
 	errMsg := extractServerErrorText(res.Body)
 	require.Contains(t, errMsg, "Host was not found in the datastore")
 
-	// run a saved script by name with team id (should fail script not found)
-	res = s.Do("POST", "/api/latest/fleet/scripts/run/sync", runScriptSyncRequest{ScriptName: "myscript.sh", TeamID: ptr.Uint(1)}, http.StatusNotFound)
+	// run a saved script by name with team id (should fail with license error)
+	res = s.Do("POST", "/api/latest/fleet/scripts/run/sync", runScriptSyncRequest{ScriptName: "myscript.sh", TeamID: 1}, http.StatusPaymentRequired)
 	errMsg = extractServerErrorText(res.Body)
-	require.Contains(t, errMsg, "myscript.sh was not found in the datastore")
+	require.Contains(t, errMsg, "Requires Fleet Premium license")
 
 	// delete a saved script
 	var delScriptResp deleteScriptResponse

--- a/server/service/integration_enterprise_test.go
+++ b/server/service/integration_enterprise_test.go
@@ -4964,7 +4964,7 @@ func (s *integrationEnterpriseTestSuite) TestRunHostSavedScript() {
 	// attempt to run with both script contents and id
 	res := s.Do("POST", "/api/latest/fleet/scripts/run", fleet.HostScriptRequestPayload{HostID: host.ID, ScriptContents: "echo", ScriptID: ptr.Uint(savedTmScript.ID + 999)}, http.StatusUnprocessableEntity)
 	errMsg := extractServerErrorText(res.Body)
-	require.Contains(t, errMsg, `Only one of "script_id" or "script_contents" can be provided.`)
+	require.Contains(t, errMsg, `Only one of 'script_id' or 'script_contents' is allowed.`)
 
 	// attempt to run with unknown script id
 	res = s.Do("POST", "/api/latest/fleet/scripts/run", fleet.HostScriptRequestPayload{HostID: host.ID, ScriptID: ptr.Uint(savedTmScript.ID + 999)}, http.StatusNotFound)

--- a/server/service/scripts.go
+++ b/server/service/scripts.go
@@ -158,6 +158,7 @@ func (svc *Service) RunHostScript(ctx context.Context, request *fleet.HostScript
 	if request.TeamID > 0 {
 		lic, _ := license.FromContext(ctx)
 		if !lic.IsPremium() {
+			svc.authz.SkipAuthorization(ctx)
 			return nil, fleet.ErrMissingLicense
 		}
 	}
@@ -242,7 +243,7 @@ func (svc *Service) RunHostScript(ctx context.Context, request *fleet.HostScript
 		}
 		request.ScriptContents = string(contents)
 		request.ScriptContentID = script.ScriptContentID
-    isSavedScript = true
+		isSavedScript = true
 	}
 
 	if err := fleet.ValidateHostScriptContents(request.ScriptContents, isSavedScript); err != nil {

--- a/server/service/scripts_test.go
+++ b/server/service/scripts_test.go
@@ -289,9 +289,9 @@ func TestHostRunScript(t *testing.T) {
 					ds.GetScriptIDByNameFunc = func(ctx context.Context, name string, teamID *uint) (uint, error) {
 						return *tt.scriptID, nil
 					}
-					_, err = svc.RunHostScript(ctx, &fleet.HostScriptRequestPayload{HostID: noTeamHost.ID, ScriptContents: "", ScriptID: nil, ScriptName: "Foo", TeamID: ptr.Uint(1)}, 1)
+					_, err = svc.RunHostScript(ctx, &fleet.HostScriptRequestPayload{HostID: noTeamHost.ID, ScriptContents: "", ScriptID: nil, ScriptName: "Foo", TeamID: 1}, 1)
 					checkAuthErr(t, tt.shouldFailGlobalWrite, err)
-					_, err = svc.RunHostScript(ctx, &fleet.HostScriptRequestPayload{HostID: teamHost.ID, ScriptContents: "", ScriptID: nil, ScriptName: "Foo", TeamID: ptr.Uint(1)}, 1)
+					_, err = svc.RunHostScript(ctx, &fleet.HostScriptRequestPayload{HostID: teamHost.ID, ScriptContents: "", ScriptID: nil, ScriptName: "Foo", TeamID: 1}, 1)
 					checkAuthErr(t, tt.shouldFailTeamWrite, err)
 				}
 			})

--- a/server/service/scripts_test.go
+++ b/server/service/scripts_test.go
@@ -305,8 +305,8 @@ func TestHostRunScript(t *testing.T) {
 			wantErr string
 		}{
 			{"empty script", "", "Script contents must not be empty."},
-			{"overly long script", strings.Repeat("a", 500001), "Script is too large."},
-			{"large script", strings.Repeat("a", 500000), ""},
+			{"overly long script", strings.Repeat("a", fleet.UnsavedScriptMaxRuneLen+1), "Script is too large."},
+			{"large script", strings.Repeat("a", fleet.UnsavedScriptMaxRuneLen), ""},
 			{"invalid utf8", "\xff\xfa", "Wrong data format."},
 			{"valid without hashbang", "echo 'a'", ""},
 			{"valid with hashbang", "#!/bin/sh\necho 'a'", ""},

--- a/server/service/scripts_test.go
+++ b/server/service/scripts_test.go
@@ -283,6 +283,17 @@ func TestHostRunScript(t *testing.T) {
 					_, err = svc.RunHostScript(ctx, &fleet.HostScriptRequestPayload{HostID: nonExistingHost.ID, ScriptContents: "abc"}, 0)
 					checkAuthErr(t, tt.shouldFailGlobalWrite, err)
 				}
+
+				// test auth for run sync saved script by name
+				if tt.scriptID != nil {
+					ds.GetScriptIDByNameFunc = func(ctx context.Context, name string, teamID *uint) (uint, error) {
+						return *tt.scriptID, nil
+					}
+					_, err = svc.RunHostScript(ctx, &fleet.HostScriptRequestPayload{HostID: noTeamHost.ID, ScriptContents: "", ScriptID: nil, ScriptName: "Foo", TeamID: ptr.Uint(1)}, 1)
+					checkAuthErr(t, tt.shouldFailGlobalWrite, err)
+					_, err = svc.RunHostScript(ctx, &fleet.HostScriptRequestPayload{HostID: teamHost.ID, ScriptContents: "", ScriptID: nil, ScriptName: "Foo", TeamID: ptr.Uint(1)}, 1)
+					checkAuthErr(t, tt.shouldFailTeamWrite, err)
+				}
 			})
 		}
 	})


### PR DESCRIPTION
TODO:
- Integration tests

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [ ] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [ ] Documented any permissions changes (docs/Using Fleet/manage-access.md)
- [ ] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [ ] Added support on fleet's osquery simulator `cmd/osquery-perf` for new osquery data ingestion features.
- [ ] Added/updated tests
- [ ] If database migrations are included, checked table schema to confirm autoupdate 
- For database migrations:
  - [ ] Checked schema for all modified table for columns that will auto-update timestamps during migration.
  - [ ] Confirmed that updating the timestamps is acceptable, and will not cause unwanted side effects.
- [ ] Manual QA for all new/changed functionality
  - For Orbit and Fleet Desktop changes:
    - [ ] Manual QA must be performed in the three main OSs, macOS, Windows and Linux.
    - [ ] Auto-update manual QA, from released version of component to new version (see [tools/tuf/test](../tools/tuf/test/README.md)).
