### PR TITLE
Update features.yml w/ new timelines

### DIFF
--- a/handbook/company/pricing-features-table.yml
+++ b/handbook/company/pricing-features-table.yml
@@ -18,6 +18,8 @@
       moreInfoUrl: https://play.goconsensus.com/s4e490bb9
   buzzwords: [Device trust,Zero trust,Layer 7 device trust,Beyondcorp,Device attestation,Conditional access]
   waysToUse:
+    - description: Create a calendar event and auto-remediate all failing policies when users are free. Coming soon (2024-04-01).
+      moreInfoUrl: https://github.com/fleetdm/fleet/issues/17230 # Coming soon
     - description: Automatically manage the behavior of endpoints that are at higher risk of vulnerabilities or data loss due to their configuration or patch level.
     - description: Block access to corporate apps for users whose devices with unexpected settings, like disabled screen lock, passwords that are too short, unencrypted hard disks, and more
     - description: Quickly implement conditional access based on device health using osquery and a simple device health REST API.
@@ -604,11 +606,11 @@
   usualDepartment: IT
   productCategories: [Device management]
   pricingTableCategories: [Device management]
-- industryName: Deploy apps and packages on macOS, Windows, and Linux computers.
+- industryName: Deploy security agents on macOS, Windows, and Linux computers.
   description:
   moreInfoUrl: https://github.com/fleetdm/fleet/issues/14921
   tier: Premium
-  comingSoonOn: 2024-03-31 #Customer-reedtimmer
+  comingSoonOn: 2024-04-22 #Customer-reedtimmer
   usualDepartment: IT
   productCategories: [Device management]
   pricingTableCategories: [Device management]

--- a/handbook/company/pricing-features-table.yml
+++ b/handbook/company/pricing-features-table.yml
@@ -19,7 +19,7 @@
   buzzwords: [Device trust,Zero trust,Layer 7 device trust,Beyondcorp,Device attestation,Conditional access]
   waysToUse:
     - description: Create a calendar event and auto-remediate all failing policies when users are free. Coming soon (2024-04-01).
-      moreInfoUrl: https://github.com/fleetdm/fleet/issues/17230 # Coming soon
+      moreInfoUrl: https://github.com/fleetdm/fleet/issues/17230
     - description: Automatically manage the behavior of endpoints that are at higher risk of vulnerabilities or data loss due to their configuration or patch level.
     - description: Block access to corporate apps for users whose devices with unexpected settings, like disabled screen lock, passwords that are too short, unencrypted hard disks, and more
     - description: Quickly implement conditional access based on device health using osquery and a simple device health REST API.

--- a/handbook/company/pricing-features-table.yml
+++ b/handbook/company/pricing-features-table.yml
@@ -610,7 +610,7 @@
   description:
   moreInfoUrl: https://github.com/fleetdm/fleet/issues/14921
   tier: Premium
-  comingSoonOn: 2024-04-22 #Customer-reedtimmer
+  comingSoonOn: 2024-04-22 #customer-reedtimmer,customer-flacourtia 
   usualDepartment: IT
   productCategories: [Device management]
   pricingTableCategories: [Device management]


### PR DESCRIPTION
- Add "Fleet gets in your calendar" (#17230)
- "Declaration (DDM) profiles" (#14550) before "App deployment" (#14921) 
  - Deploy apps => Deploy security agents
  - Pushes deploy security agents to Q2 (2024-04-22)

Note: Upcoming activity (unified queue) won't guarantee first-in-first-out in Q1
...