### PR TITLE
Website: update custom hook to prevent 500 error from HEAD requests.

### DIFF
--- a/website/api/hooks/custom/index.js
+++ b/website/api/hooks/custom/index.js
@@ -156,7 +156,7 @@ will be disabled and/or hidden in the UI.
               // FUTURE: Auto-redirect without the querystring after absorbtion to make it prettier in the URL bar.
               // (except this probably messes up analytics so before doing that, figure out how to solve that problem)
             }//ﬁ
-            if (req.method === 'GET') {
+            if (req.method === 'GET' || req.method === 'HEAD') {
               // Include information about the primary buying situation
               // If set in the session (e.g. from an ad), use the primary buying situation for personalization.
               res.locals.primaryBuyingSituation = req.session.primaryBuyingSituation || undefined;


### PR DESCRIPTION
Changes:
- Updated the custom hook to set `res.locals.primaryBuyingSituation` for HEAD requests to prevent 500 errors when `primaryBuyingSituation` is not set to `undefined`.