### PR TITLE
Fleet UI: Surface VS code extensions in UI

### DIFF
--- a/changes/15997-vscode-extensions
+++ b/changes/15997-vscode-extensions
@@ -1,0 +1,1 @@
+- Surface VS code extensions in the software inventory

--- a/frontend/interfaces/software.ts
+++ b/frontend/interfaces/software.ts
@@ -105,6 +105,7 @@ export const SOURCE_TYPE_CONVERSION: Record<string, string> = {
   ie_extensions: "Browser plugin (IE)",
   chocolatey_packages: "Package (Chocolatey)",
   pkg_packages: "Package (pkg)",
+  vscode_extensions: "IDE extension (VS Code)",
 } as const;
 
 const BROWSER_TYPE_CONVERSION: Record<string, string> = {

--- a/frontend/pages/SoftwarePage/components/icons/index.ts
+++ b/frontend/pages/SoftwarePage/components/icons/index.ts
@@ -59,6 +59,7 @@ export const SOFTWARE_SOURCE_TO_ICON_MAP = {
   ie_extensions: Extension,
   chocolatey_packages: Package,
   pkg_packages: Package,
+  vscode_extensions: Extension,
 } as const;
 
 export const SOFTWARE_ICON_SIZES: Record<string, string> = {

--- a/frontend/pages/hosts/details/cards/Software/SoftwareTableConfig.tsx
+++ b/frontend/pages/hosts/details/cards/Software/SoftwareTableConfig.tsx
@@ -86,6 +86,7 @@ const TYPE_CONVERSION: Record<string, string> = {
   ie_extensions: "Browser plugin (IE)",
   chocolatey_packages: "Package (Chocolatey)",
   pkg_packages: "Package (pkg)",
+  vscode_extensions: "IDE extension (VS Code)",
 };
 
 const formatSoftwareType = (source: string) => {

--- a/frontend/pages/hosts/details/cards/Software/SoftwareTableConfig.tsx
+++ b/frontend/pages/hosts/details/cards/Software/SoftwareTableConfig.tsx
@@ -4,7 +4,7 @@ import ReactTooltip from "react-tooltip";
 
 import { formatDistanceToNow } from "date-fns";
 
-import { ISoftware } from "interfaces/software";
+import { ISoftware, SOURCE_TYPE_CONVERSION } from "interfaces/software";
 import PATHS from "router/paths";
 
 import HeaderCell from "components/TableContainer/DataTable/HeaderCell/HeaderCell";
@@ -68,29 +68,8 @@ interface IDataColumn {
   // or one of the custom `filterTypes` defined for the `useTable` instance (see `DataTable`)
 }
 
-const TYPE_CONVERSION: Record<string, string> = {
-  apt_sources: "Package (APT)",
-  deb_packages: "Package (deb)",
-  portage_packages: "Package (Portage)",
-  rpm_packages: "Package (RPM)",
-  yum_sources: "Package (YUM)",
-  npm_packages: "Package (NPM)",
-  atom_packages: "Package (Atom)", // Atom packages were removed from software inventory. Mapping is maintained for backwards compatibility. (2023-12-04)
-  python_packages: "Package (Python)",
-  apps: "Application (macOS)",
-  chrome_extensions: "Browser plugin (Chrome)",
-  firefox_addons: "Browser plugin (Firefox)",
-  safari_extensions: "Browser plugin (Safari)",
-  homebrew_packages: "Package (Homebrew)",
-  programs: "Program (Windows)",
-  ie_extensions: "Browser plugin (IE)",
-  chocolatey_packages: "Package (Chocolatey)",
-  pkg_packages: "Package (pkg)",
-  vscode_extensions: "IDE extension (VS Code)",
-};
-
 const formatSoftwareType = (source: string) => {
-  const DICT = TYPE_CONVERSION;
+  const DICT = SOURCE_TYPE_CONVERSION;
   return DICT[source] || "Unknown";
 };
 


### PR DESCRIPTION
## Issue
Cerra #17004 (Frontend part of #15997)

## Description
- Add `vscode_extensions` to software pages
- Use Extensions icon
- Update type for `vscode_extensions`

### Other
`SOURCE_TYPE_CONVERSIONS` and `TYPE_CONVERSIONS` was same object. Kept `SOURCE_TYPE_CONVERSIONS` on `interfaces/software.ts`only

## Screenshots
<img width="1360" alt="Screenshot 2024-03-04 at 9 50 40 AM" src="https://github.com/fleetdm/fleet/assets/71795832/4ef593bd-8c01-4b26-9afa-1192352fd4c1">


## Note
- Do not merge until backend is merged #17003 

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
- [x] Manual QA for all new/changed functionality
