### PR TITLE
Fix wrong number of host in mdm solutions modal and fix mdm solutions table UI to work for null named solutions

### DIFF
--- a/frontend/pages/DashboardPage/DashboardPage.tsx
+++ b/frontend/pages/DashboardPage/DashboardPage.tsx
@@ -62,7 +62,6 @@ import Munki from "./cards/Munki";
 import OperatingSystems from "./cards/OperatingSystems";
 import AddHostsModal from "../../components/AddHostsModal";
 import MdmSolutionModal from "./components/MdmSolutionModal";
-import { createMockMdmSolution } from "__mocks__/mdmMock";
 
 const baseClass = "dashboard-page";
 
@@ -369,17 +368,7 @@ const DashboardPage = ({ router, location }: IDashboardProps): JSX.Element => {
             hosts: pending_hosts_count || 0,
           });
         setMdmStatusData(statusData);
-
-        let test: any[] = [];
-        if (mobile_device_management_solution !== null) {
-          test = mobile_device_management_solution;
-        }
-
-        setMdmSolutions([
-          ...test,
-          createMockMdmSolution({ name: null }),
-          createMockMdmSolution({ name: null }),
-        ]);
+        setMdmSolutions(mobile_device_management_solution);
         setShowMdmCard(true);
       },
     }

--- a/frontend/pages/DashboardPage/DashboardPage.tsx
+++ b/frontend/pages/DashboardPage/DashboardPage.tsx
@@ -62,6 +62,7 @@ import Munki from "./cards/Munki";
 import OperatingSystems from "./cards/OperatingSystems";
 import AddHostsModal from "../../components/AddHostsModal";
 import MdmSolutionModal from "./components/MdmSolutionModal";
+import { createMockMdmSolution } from "__mocks__/mdmMock";
 
 const baseClass = "dashboard-page";
 
@@ -368,7 +369,17 @@ const DashboardPage = ({ router, location }: IDashboardProps): JSX.Element => {
             hosts: pending_hosts_count || 0,
           });
         setMdmStatusData(statusData);
-        setMdmSolutions(mobile_device_management_solution);
+
+        let test: any[] = [];
+        if (mobile_device_management_solution !== null) {
+          test = mobile_device_management_solution;
+        }
+
+        setMdmSolutions([
+          ...test,
+          createMockMdmSolution({ name: null }),
+          createMockMdmSolution({ name: null }),
+        ]);
         setShowMdmCard(true);
       },
     }

--- a/frontend/pages/DashboardPage/cards/MDM/MDM.tests.tsx
+++ b/frontend/pages/DashboardPage/cards/MDM/MDM.tests.tsx
@@ -21,6 +21,8 @@ describe("MDM Card", () => {
           createMockMdmSolution({ name: "Test Solution", id: 3 }),
           createMockMdmSolution({ name: "Test Solution", id: 4 }),
           createMockMdmSolution({ name: "Test Solution 2", id: 5 }),
+          createMockMdmSolution({ name: null, id: 6 }),
+          createMockMdmSolution({ name: null, id: 7 }),
         ]}
       />
     );
@@ -30,6 +32,7 @@ describe("MDM Card", () => {
     expect(screen.getAllByText("MDM Solution").length).toBe(1);
     expect(screen.getAllByText("Test Solution").length).toBe(1);
     expect(screen.getAllByText("Test Solution 2").length).toBe(1);
+    expect(screen.getAllByText("Unknown").length).toBe(1);
   });
 
   it("render the correct number of Enrollment status", async () => {

--- a/frontend/pages/DashboardPage/cards/MDM/MDM.tests.tsx
+++ b/frontend/pages/DashboardPage/cards/MDM/MDM.tests.tsx
@@ -27,8 +27,6 @@ describe("MDM Card", () => {
       />
     );
 
-    debug();
-
     expect(screen.getAllByText("MDM Solution").length).toBe(1);
     expect(screen.getAllByText("Test Solution").length).toBe(1);
     expect(screen.getAllByText("Test Solution 2").length).toBe(1);

--- a/frontend/pages/DashboardPage/cards/MDM/MDM.tsx
+++ b/frontend/pages/DashboardPage/cards/MDM/MDM.tsx
@@ -10,7 +10,6 @@ import Spinner from "components/Spinner";
 import TableDataError from "components/DataError";
 import EmptyTable from "components/EmptyTable";
 import CustomLink from "components/CustomLink";
-import { createMockMdmSolution } from "__mocks__/mdmMock";
 
 import {
   generateSolutionsTableHeaders,
@@ -154,6 +153,7 @@ const Mdm = ({
                 <TableDataError card />
               ) : (
                 <TableContainer<IRowProps>
+                  className={`${baseClass}__mdm-solutions-table`}
                   columnConfigs={solutionsTableHeaders}
                   data={solutionsDataSet}
                   isLoading={isFetching}
@@ -174,6 +174,7 @@ const Mdm = ({
                 <TableDataError card />
               ) : (
                 <TableContainer
+                  className={`${baseClass}__mdm-status-table`}
                   columnConfigs={statusTableHeaders}
                   data={statusDataSet}
                   isLoading={isFetching}

--- a/frontend/pages/DashboardPage/cards/MDM/MDM.tsx
+++ b/frontend/pages/DashboardPage/cards/MDM/MDM.tsx
@@ -75,12 +75,12 @@ const reduceSolutionsToObj = (mdmSolutions: IMdmSolution[]) => {
       if (acc.Unknown) {
         acc.Unknown.hosts_count += nextSolution.hosts_count;
       } else {
-        acc.Unknown = nextSolution;
+        acc.Unknown = Object.assign({ ...nextSolution });
       }
     } else if (acc[nextSolution.name]) {
       acc[nextSolution.name].hosts_count += nextSolution.hosts_count;
     } else {
-      acc[nextSolution.name] = nextSolution;
+      acc[nextSolution.name] = Object.assign({ ...nextSolution });
     }
 
     return acc;
@@ -118,10 +118,7 @@ const Mdm = ({
     () => generateStatusTableHeaders(selectedTeamId),
     [selectedTeamId]
   );
-  const solutionsDataSet = generateSolutionsDataSet(
-    rolledupMdmSolutionsData,
-    selectedPlatformLabelId
-  );
+  const solutionsDataSet = generateSolutionsDataSet(rolledupMdmSolutionsData);
   const statusDataSet = generateStatusDataSet(
     mdmStatusData,
     selectedPlatformLabelId

--- a/frontend/pages/DashboardPage/cards/MDM/MDMSolutionsTableConfig.tsx
+++ b/frontend/pages/DashboardPage/cards/MDM/MDMSolutionsTableConfig.tsx
@@ -58,8 +58,7 @@ export const generateSolutionsTableHeaders = (): IDataColumn[] => [
 ];
 
 export const generateSolutionsDataSet = (
-  solutions: IMdmSolution[] | null,
-  selectedPlatformLabelId?: number
+  solutions: IMdmSolution[] | null
 ): IMdmSolution[] => {
   if (!solutions) {
     return [];
@@ -69,7 +68,6 @@ export const generateSolutionsDataSet = (
     return {
       ...solution,
       displayName: solution.name ?? "Unknown",
-      selectedPlatformLabelId,
     };
   });
 };

--- a/frontend/pages/DashboardPage/cards/MDM/MDMSolutionsTableConfig.tsx
+++ b/frontend/pages/DashboardPage/cards/MDM/MDMSolutionsTableConfig.tsx
@@ -2,11 +2,7 @@ import React from "react";
 
 import { IMdmSolution } from "interfaces/mdm";
 
-import { greyCell } from "utilities/helpers";
-import HeaderCell from "components/TableContainer/DataTable/HeaderCell";
 import TextCell from "components/TableContainer/DataTable/TextCell";
-import ViewAllHostsLink from "components/ViewAllHostsLink";
-import LinkCell from "components/TableContainer/DataTable/LinkCell";
 import InternalLinkCell from "../../../../components/TableContainer/DataTable/InternalLinkCell";
 
 // NOTE: cellProps come from react-table
@@ -47,7 +43,7 @@ export const generateSolutionsTableHeaders = (): IDataColumn[] => [
     title: "Name",
     Header: "Name",
     disableSortBy: true,
-    accessor: "name",
+    accessor: "displayName",
     Cell: (cellProps: ICellProps) => (
       <InternalLinkCell value={cellProps.cell.value} />
     ),
@@ -61,21 +57,6 @@ export const generateSolutionsTableHeaders = (): IDataColumn[] => [
   },
 ];
 
-const enhanceSolutionsData = (
-  solutions: IMdmSolution[],
-  selectedPlatformLabelId?: number
-): IMdmSolution[] => {
-  return Object.values(solutions).map((solution) => {
-    return {
-      id: solution.id,
-      name: solution.name || "Unknown",
-      server_url: solution.server_url,
-      hosts_count: solution.hosts_count,
-      selectedPlatformLabelId,
-    };
-  });
-};
-
 export const generateSolutionsDataSet = (
   solutions: IMdmSolution[] | null,
   selectedPlatformLabelId?: number
@@ -83,5 +64,12 @@ export const generateSolutionsDataSet = (
   if (!solutions) {
     return [];
   }
-  return [...enhanceSolutionsData(solutions, selectedPlatformLabelId)];
+
+  return solutions.map((solution) => {
+    return {
+      ...solution,
+      displayName: solution.name ?? "Unknown",
+      selectedPlatformLabelId,
+    };
+  });
 };

--- a/frontend/pages/DashboardPage/cards/MDM/_styles.scss
+++ b/frontend/pages/DashboardPage/cards/MDM/_styles.scss
@@ -7,47 +7,39 @@
     display: none;
   }
 
-  .data-table-block {
-    .data-table__table {
-      table-layout: fixed;
+  &__mdm-status-table {
+    .data-table-block {
+      .data-table__table {
+        thead {
+          .status__header {
+            width: 30%;
+          }
 
-      thead {
-        .name__header,
-        .status__header {
-          width: 30%;
-        }
-        .server_url__header {
-          width: 30%;
-        }
-        .hosts_count__header,
-        .hosts__header {
-          border-right: 0;
-          padding-right: 0;
-          width: 60px;
-        }
-        .linkToFilteredHosts__header {
-          width: 140px;
-        }
-      }
+          .hosts__header {
+            border-right: 0;
+            padding-right: 0;
+            width: 60px;
+          }
 
-      tbody {
-        .mdm-solution-link {
-          opacity: 0;
-          transition: 250ms;
-          text-overflow: none;
-        }
-        tr:hover {
-          .mdm-solution-link {
-            opacity: 1;
+          .linkToFilteredHosts__header {
+            width: 140px;
           }
         }
       }
     }
-  }
-  .count-loading {
-    color: $ui-fleet-black-50;
-  }
-  .count-error {
-    color: $ui-error;
+
+    tbody {
+      .mdm-solution-link {
+        opacity: 0;
+        transition: 250ms;
+        text-overflow: none;
+      }
+      tr:hover {
+        .mdm-solution-link {
+          opacity: 1;
+        }
+      }
+    }
+
   }
 }

--- a/frontend/pages/DashboardPage/components/MdmSolutionModal/MdmSolutionModal.tsx
+++ b/frontend/pages/DashboardPage/components/MdmSolutionModal/MdmSolutionModal.tsx
@@ -43,7 +43,7 @@ const MdmSolutionsModal = ({
   return (
     <Modal
       className={baseClass}
-      title={mdmSolutions[0].name ?? "Mdm solution"}
+      title={mdmSolutions[0].name ?? "Unknown mdm solution"}
       width="large"
       onExit={onCancel}
     >

--- a/frontend/pages/DashboardPage/components/MdmSolutionModal/MdmSolutionModal.tsx
+++ b/frontend/pages/DashboardPage/components/MdmSolutionModal/MdmSolutionModal.tsx
@@ -29,8 +29,6 @@ const MdmSolutionsModal = ({
   selectedTeamId,
   onCancel,
 }: IMdmSolutionModalProps) => {
-  console.log(mdmSolutions);
-
   const solutionsTableHeaders = useMemo(
     () => generateSolutionsTableHeaders(selectedTeamId),
     [selectedTeamId]

--- a/frontend/pages/DashboardPage/components/MdmSolutionModal/MdmSolutionModalTableConfig.tsx
+++ b/frontend/pages/DashboardPage/components/MdmSolutionModal/MdmSolutionModalTableConfig.tsx
@@ -86,21 +86,6 @@ export const generateSolutionsTableHeaders = (
   },
 ];
 
-const enhanceSolutionsData = (
-  solutions: IMdmSolution[],
-  selectedPlatformLabelId?: number
-): IMdmSolution[] => {
-  return Object.values(solutions).map((solution) => {
-    return {
-      id: solution.id,
-      name: solution.name || "Unknown",
-      server_url: solution.server_url,
-      hosts_count: solution.hosts_count,
-      selectedPlatformLabelId,
-    };
-  });
-};
-
 export const generateSolutionsDataSet = (
   solutions: IMdmSolution[] | null,
   selectedPlatformLabelId?: number
@@ -108,5 +93,11 @@ export const generateSolutionsDataSet = (
   if (!solutions) {
     return [];
   }
-  return [...enhanceSolutionsData(solutions, selectedPlatformLabelId)];
+
+  return solutions.map((solution) => {
+    return {
+      ...solution,
+      selectedPlatformLabelId,
+    };
+  });
 };


### PR DESCRIPTION
relates to #16837, #17334, #17335

This fixes a UI bug for the case where the mdm solution name can be null. We now handle this case properly and show the mdm solution data in the modal.

This also fixes a UI bug where we showed the incorrect number of hosts in the mdm solutions modal.

There is various cleanup here to the js and scss code in this PR too. 

- [x] Added/updated tests
- [x] Manual QA for all new/changed functionality
