### PR TITLE
Add mention of `distutils` in Building-Fleet

### DIFF
--- a/docs/Contributing/Building-Fleet.md
+++ b/docs/Contributing/Building-Fleet.md
@@ -87,6 +87,16 @@ To do this, run the following from the root of the repository:
 make deps
 ```
 
+Note: If you are using python >= `3.12`, you may have to install `distutils` using pip.
+
+```sh
+pip install setuptools
+```
+or 
+```sh
+pip3 install setuptools
+```
+
 When pulling changes, it may be necessary to re-run `make deps` if a new Go or JavaScript dependency was added.
 
 ### Generating the packaged JavaScript


### PR DESCRIPTION
Python >= 3.12 no longer ships with the `distutils` module out of the box. It can be installed using `pip install setuptools`.

This may be fixed when updating node packages that rely on python, but until then it may come up during `make deps`.

Reference: https://stackoverflow.com/a/76691103