### PR TITLE
UI – add "No team" option when targeting live queries

### DIFF
--- a/changes/16350-no-team-live-queries
+++ b/changes/16350-no-team-live-queries
@@ -1,0 +1,1 @@
+* Add a "No team" team option when running live queries from the UI

--- a/frontend/components/LiveQuery/SelectTargets.tsx
+++ b/frontend/components/LiveQuery/SelectTargets.tsx
@@ -120,7 +120,6 @@ const TargetPillSelector = ({
     >
       <Icon name={isSelected ? "check" : "plus"} />
       <span className="selector-name">{displayText()}</span>
-      {/* <span className="selector-count">{entity.count}</span> */}
     </button>
   );
 };
@@ -395,8 +394,9 @@ const SelectTargets = ({
 
     return (
       <>
-        <b>{total.toLocaleString()}</b>&nbsp;host{total > 1 ? `s` : ``}{" "}
-        targeted&nbsp; ({onlinePercentage()}
+        <b>{total.toLocaleString()}</b>&nbsp;host
+        {total > 1 || total === 0 ? `s` : ``} targeted&nbsp; (
+        {onlinePercentage()}
         %&nbsp;
         <TooltipWrapper
           tipContent={
@@ -442,7 +442,11 @@ const SelectTargets = ({
           renderTargetEntityList("", labels.allHosts)}
         {!!labels?.platforms?.length &&
           renderTargetEntityList("Platforms", labels.platforms)}
-        {!!teams?.length && renderTargetEntityList("Teams", teams)}
+        {!!teams?.length &&
+          renderTargetEntityList("Teams", [
+            { id: 0, name: "No team" },
+            ...teams,
+          ])}
         {!!labels?.other?.length &&
           renderTargetEntityList("Labels", labels.other)}
       </div>


### PR DESCRIPTION
## ➡️ #16350 

https://www.loom.com/share/dfc5ea298e4342f286ed5945507403c1?sid=a0d3b9d6-8a05-4919-990e-5121d0deac3e

<img width="999" alt="Screenshot 2024-03-04 at 4 15 24 PM" src="https://github.com/fleetdm/fleet/assets/61553566/a5271f8c-119d-4ed7-bcd5-538640e8a1f6">


- [x] Changes file added for user-visible changes in `changes/` 
- [x] Manual QA for all new/changed functionality