### PR TITLE
Add exponential backoff to orbit enroll retries

### DIFF
--- a/Dockerfile-desktop-linux
+++ b/Dockerfile-desktop-linux
@@ -1,12 +1,6 @@
 FROM --platform=linux/amd64 golang:1.21.7-bullseye@sha256:447afe790df28e0bc19d782a9f776a105ce3b8417cdd21f33affc4ed6d38f9d5
 LABEL maintainer="Fleet Developers"
 
-RUN apt-get update && apt-get install -y \
-	gcc \
-	libgtk-3-dev \
-	libayatana-appindicator3-dev \
-	&& rm -rf /var/lib/apt/lists/*
-
 RUN mkdir -p /usr/src/fleet
 RUN mkdir -p /output
 

--- a/orbit/changes/16594-orbit-enroll-backoff
+++ b/orbit/changes/16594-orbit-enroll-backoff
@@ -1,0 +1,1 @@
+* Add exponential backoff to orbit enroll retries.

--- a/orbit/pkg/constant/constant.go
+++ b/orbit/pkg/constant/constant.go
@@ -19,10 +19,13 @@ const (
 	DesktopAppExecName = "fleet-desktop"
 	// OrbitNodeKeyFileName is the filename on disk where we write the orbit node key to
 	OrbitNodeKeyFileName = "secret-orbit-node-key.txt"
-	// OrbitEnrollMaxRetries is the max retries when doing an enroll request
-	OrbitEnrollMaxRetries = 3
-	// OrbitEnrollRetrySleep is the time duration to sleep between retries
-	OrbitEnrollRetrySleep = 5 * time.Second
+	// OrbitEnrollMaxRetries is the max number of retries when doing an enroll request.
+	// We set it to 6 to allow the retry backoff to take effect.
+	OrbitEnrollMaxRetries = 6
+	// OrbitEnrollBackoffMultiplier is the multiplier to use for backing off between enroll retries.
+	OrbitEnrollBackoffMultiplier = 2
+	// OrbitEnrollRetrySleep is the duration to sleep between enroll retries.
+	OrbitEnrollRetrySleep = 10 * time.Second
 	// OsquerydName is the name of osqueryd binary
 	// We use osqueryd as name to properly identify the process when listing
 	// running processes/tasks.

--- a/server/service/orbit_client.go
+++ b/server/service/orbit_client.go
@@ -302,6 +302,9 @@ func (oc *OrbitClient) getNodeKeyOrEnroll() (string, error) {
 				return err
 			}
 		},
+		// The below configuration means the following retry intervals (exponential backoff):
+		// 10s, 20s, 40s, 80s, 160s and then return the failure (max attempts = 6)
+		// thus executing no more than ~6 enroll request failures every ~5 minutes.
 		retry.WithInterval(orbitEnrollRetryInterval()),
 		retry.WithMaxAttempts(constant.OrbitEnrollMaxRetries),
 		retry.WithBackoffMultiplier(constant.OrbitEnrollBackoffMultiplier),

--- a/server/service/orbit_client.go
+++ b/server/service/orbit_client.go
@@ -302,8 +302,9 @@ func (oc *OrbitClient) getNodeKeyOrEnroll() (string, error) {
 				return err
 			}
 		},
-		retry.WithInterval(OrbitRetryInterval()),
+		retry.WithInterval(orbitEnrollRetryInterval()),
 		retry.WithMaxAttempts(constant.OrbitEnrollMaxRetries),
+		retry.WithBackoffMultiplier(constant.OrbitEnrollBackoffMultiplier),
 	); err != nil {
 		return "", fmt.Errorf("orbit node key enroll failed, attempts=%d", constant.OrbitEnrollMaxRetries)
 	}
@@ -402,7 +403,7 @@ func (oc *OrbitClient) setLastRecordedError(err error) {
 	oc.lastRecordedErr = fmt.Errorf("%s: %w", time.Now().UTC().Format("2006-01-02T15:04:05Z"), err)
 }
 
-func OrbitRetryInterval() time.Duration {
+func orbitEnrollRetryInterval() time.Duration {
 	interval := os.Getenv("FLEETD_ENROLL_RETRY_INTERVAL")
 	if interval != "" {
 		d, err := time.ParseDuration(interval)

--- a/tools/tuf/test/create_repository.sh
+++ b/tools/tuf/test/create_repository.sh
@@ -73,7 +73,9 @@ for system in $SYSTEMS; do
     # compiling a macOS-arm64 binary requires CGO and a macOS computer (for
     # Apple keychain, some tables, etc), if this is the case, compile an
     # universal binary.
-    if [ $system == "macos" ] && [ "$(uname -s)" = "Darwin" ]; then
+    #
+    # NOTE(lucas): Cross-compiling orbit for arm64 from Intel macOS currently fails (CGO error).
+    if [ $system == "macos" ] && [ "$(uname -s)" = "Darwin" ] && [ "$(uname -m)" = "arm64" ]; then
        CGO_ENABLED=1 \
        CODESIGN_IDENTITY=$CODESIGN_IDENTITY \
        ORBIT_VERSION=42 \


### PR DESCRIPTION
#16594

- [X] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [X] Added/updated tests
- [X] Manual QA for all new/changed functionality
  - For Orbit and Fleet Desktop changes:
    - [X] Manual QA must be performed in the three main OSs, macOS, Windows and Linux.
    - [X] Auto-update manual QA, from released version of component to new version (see [tools/tuf/test](../tools/tuf/test/README.md)).
