### PR TITLE
Use `--team` flag for `run-script` command

### DIFF
--- a/changes/16841-run-script-name-team-id
+++ b/changes/16841-run-script-name-team-id
@@ -1,0 +1,3 @@
+- Updated `fleetctl run-script` to include new `--team` and `--script-name` flags that enable users
+  to run live script on a host using a previously saved script referenced by the script name and team ID.
+- Updated `POST /scripts/run/sync` API to receive new `script_name` and `team_id` parameters.

--- a/cmd/fleetctl/scripts.go
+++ b/cmd/fleetctl/scripts.go
@@ -38,7 +38,7 @@ func runScriptCommand() *cli.Command {
 				Required: false,
 			},
 			&cli.UintFlag{
-				Name:     "team-id",
+				Name:     "team",
 				Usage:    `Available in Fleet Premium. ID of the team that the saved script belongs to. 0 targets hosts assigned to “No team” (default: 0).`,
 				Required: false,
 			},
@@ -65,11 +65,11 @@ func runScriptCommand() *cli.Command {
 			name := c.String("script-name")
 
 			if path == "" && name == "" {
-				return errors.New("One of --script-path or --script-name must be specified.")
+				return errors.New("One of '--script-path' or '--script-name' must be specified.")
 			}
 
 			if path != "" && name != "" {
-				return errors.New("Only one of --script-path or --script-name is allowed.")
+				return errors.New("Only one of '--script-path' or '--script-name' is allowed.")
 			}
 
 			if path != "" {
@@ -117,10 +117,10 @@ func runScriptCommand() *cli.Command {
 
 			fmt.Println("\nScript is running. Please wait for it to finish...")
 
-			res, err := client.RunHostScriptSync(h.ID, b, name, c.Uint("team-id"))
+			res, err := client.RunHostScriptSync(h.ID, b, name, c.Uint("team"))
 			if err != nil {
 				if strings.Contains(err.Error(), `Only one of 'script_contents' or 'team_id' is allowed`) {
-					return errors.New("Only one of --script-path or --team-id is allowed.")
+					return errors.New("Only one of '--script-path' or '--team' is allowed.")
 				}
 				return err
 			}


### PR DESCRIPTION
Follow up to #17322 

This PR addresses product input regarding CLI flag naming conventions along with some test cleanup. Additional integration tests will follow in a subsequent PR.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [x] Added/updated tests
- [x] Manual QA for all new/changed functionality

