### PR TITLE
Fleet UI/docs: Update notes about public IP address

### DIFF
--- a/changes/11102-update-public-ip-message
+++ b/changes/11102-update-public-ip-message
@@ -1,0 +1,1 @@
+- Update UI tooltip and website note about public IP addresse

--- a/docs/Deploy/public-ip.md
+++ b/docs/Deploy/public-ip.md
@@ -1,8 +1,5 @@
 # Public IPs of devices
 
-> IMPORTANT: In order for this feature to work properly, devices must connect to Fleet via the public internet.
-> If the agent connects to Fleet via a private network then the "Public IP address" for such device will not be set.
-
 Fleet attempts to deduce the public IP of devices from well-known HTTP headers received on requests made by the osquery agent.
 
 The HTTP request headers are checked in the following order:

--- a/docs/Deploy/public-ip.md
+++ b/docs/Deploy/public-ip.md
@@ -1,5 +1,8 @@
 # Public IPs of devices
 
+> IMPORTANT: In order for this feature to work properly, devices must connect to Fleet via the public internet.
+> If the agent connects to Fleet via a private network then the "Public IP address" for such device will not be set.
+
 Fleet attempts to deduce the public IP of devices from well-known HTTP headers received on requests made by the osquery agent.
 
 The HTTP request headers are checked in the following order:

--- a/frontend/pages/hosts/ManageHostsPage/HostTableConfig.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/HostTableConfig.tsx
@@ -440,43 +440,18 @@ const allHostTableHeaders: IDataColumn[] = [
     title: "Public IP address",
     Header: (cellProps: IHeaderProps) => (
       <HeaderCell
-        value={cellProps.column.title}
+        value={
+          <TooltipWrapper tipContent="The IP address the host uses to connect to Fleet.">
+            Public IP address
+          </TooltipWrapper>
+        }
         isSortedDesc={cellProps.column.isSortedDesc}
       />
     ),
     accessor: "public_ip",
     Cell: (cellProps: ICellProps) => {
-      if (cellProps.cell.value) {
-        return <TextCell value={cellProps.cell.value} />;
-      }
       return (
-        <>
-          <span
-            className="text-cell text-muted tooltip"
-            data-tip
-            data-for={`public-ip__${cellProps.row.original.id}`}
-          >
-            {DEFAULT_EMPTY_CELL_VALUE}
-          </span>
-          <ReactTooltip
-            place="top"
-            effect="solid"
-            backgroundColor={COLORS["tooltip-bg"]}
-            id={`public-ip__${cellProps.row.original.id}`}
-            data-html
-            clickable
-            delayHide={200} // need delay set to hover using clickable
-          >
-            Public IP address could not be
-            <br /> determined.{" "}
-            <CustomLink
-              url="https://fleetdm.com/docs/deploying/configuration#public-i-ps-of-devices"
-              text="Learn more"
-              newTab
-              iconColor="core-fleet-white"
-            />
-          </ReactTooltip>
-        </>
+        <TextCell value={cellProps.cell.value ?? DEFAULT_EMPTY_CELL_VALUE} />
       );
     },
   },

--- a/frontend/pages/hosts/ManageHostsPage/HostTableConfig.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/HostTableConfig.tsx
@@ -17,7 +17,6 @@ import TextCell from "components/TableContainer/DataTable/TextCell/TextCell";
 import TooltipTruncatedTextCell from "components/TableContainer/DataTable/TooltipTruncatedTextCell";
 import TooltipWrapper from "components/TooltipWrapper";
 import { HumanTimeDiffWithFleetLaunchCutoff } from "components/HumanTimeDiffWithDateTip";
-import CustomLink from "components/CustomLink";
 import NotSupported from "components/NotSupported";
 
 import {

--- a/frontend/pages/hosts/details/cards/About/About.tsx
+++ b/frontend/pages/hosts/details/cards/About/About.tsx
@@ -1,9 +1,7 @@
 import React from "react";
 
-import ReactTooltip from "react-tooltip";
 import { HumanTimeDiffWithFleetLaunchCutoff } from "components/HumanTimeDiffWithDateTip";
 import TooltipWrapper from "components/TooltipWrapper";
-import CustomLink from "components/CustomLink";
 import Card from "components/Card";
 
 import {
@@ -16,7 +14,6 @@ import {
   DEFAULT_EMPTY_CELL_VALUE,
   MDM_STATUS_TOOLTIP,
 } from "utilities/constants";
-import { COLORS } from "styles/var/colors";
 import DataSet from "components/DataSet";
 
 const getDeviceUserTipContent = (deviceMapping: IDeviceUser[]) => {

--- a/frontend/pages/hosts/details/cards/About/About.tsx
+++ b/frontend/pages/hosts/details/cards/About/About.tsx
@@ -49,47 +49,19 @@ const About = ({
   munki,
   mdm,
 }: IAboutProps): JSX.Element => {
-  const renderPublicIp = () => {
-    if (aboutData.public_ip !== DEFAULT_EMPTY_CELL_VALUE) {
-      return aboutData.public_ip;
-    }
-    return (
-      <>
-        <span
-          className="text-cell text-muted tooltip"
-          data-tip
-          data-for="public-ip-tooltip"
-        >
-          {aboutData.public_ip}
-        </span>
-        <ReactTooltip
-          place="bottom"
-          effect="solid"
-          backgroundColor={COLORS["tooltip-bg"]}
-          id="public-ip-tooltip"
-          data-html
-          clickable
-          delayHide={200} // need delay set to hover using clickable
-        >
-          Public IP address could not be
-          <br /> determined.{" "}
-          <CustomLink
-            url="https://fleetdm.com/docs/deploying/configuration#public-i-ps-of-devices"
-            text="Learn more"
-            newTab
-            iconColor="core-fleet-white"
-          />
-        </ReactTooltip>
-      </>
-    );
-  };
-
   const renderSerialAndIPs = () => {
     return (
       <>
         <DataSet title="Serial number" value={aboutData.hardware_serial} />
         <DataSet title="Private IP address" value={aboutData.primary_ip} />
-        <DataSet title="Public IP address" value={renderPublicIp()} />
+        <DataSet
+          title={
+            <TooltipWrapper tipContent="The IP address the host uses to connect to Fleet.">
+              Public IP address
+            </TooltipWrapper>
+          }
+          value={aboutData.public_ip}
+        />
       </>
     );
   };


### PR DESCRIPTION
## Issue
Frontend/docs of #11102 which is a bug issue

## Description
- Move tooltip onto the header and update copy
- Remove callout on docs

## Note
- Added to manage host page and host details page

## Screenshots
<img width="414" alt="Screenshot 2024-03-05 at 4 06 28 PM" src="https://github.com/fleetdm/fleet/assets/71795832/8c0131dd-a2f8-4c94-b0bb-a0e5dbe8df73">
<img width="325" alt="Screenshot 2024-03-05 at 4 06 24 PM" src="https://github.com/fleetdm/fleet/assets/71795832/7e06aa79-7889-4457-8b3f-d6a8818b1939">


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
- [x] Manual QA for all new/changed functionality
