### PR TITLE
[tiny released bug] Fleet UI: Fix Munki issues tooltip wrapping

### DIFF
--- a/changes/17138-fix-truncated-wrapping
+++ b/changes/17138-fix-truncated-wrapping
@@ -1,0 +1,1 @@
+- Munki issues truncated tooltip bug fix

--- a/frontend/pages/hosts/details/cards/MunkiIssues/_styles.scss
+++ b/frontend/pages/hosts/details/cards/MunkiIssues/_styles.scss
@@ -15,13 +15,6 @@
           width: $col-md;
         }
       }
-
-      tbody {
-        .name__cell {
-          white-space: nowrap;
-          text-overflow: ellipsis;
-        }
-      }
     }
   }
 }


### PR DESCRIPTION
## Issue
Cerra #17138 

## Description
- Fix broken wrapping

## Solution
- Wrapping should only be in the truncated text component layer and not on the table cell layer
- Dashboard page was fixed already so no need to update

## Screenshots of working UI
<img width="1047" alt="Screenshot 2024-03-06 at 11 42 43 AM" src="https://github.com/fleetdm/fleet/assets/71795832/9d2698d0-caec-4d75-8327-09a83aee99eb">
<img width="1219" alt="Screenshot 2024-03-06 at 11 42 27 AM" src="https://github.com/fleetdm/fleet/assets/71795832/6e418549-ec16-46b3-8b6c-2625e83a030b">


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
- [x] Manual QA for all new/changed functionality

