### PR TITLE
Add macos-vm-auto-enroll script

### DIFF
--- a/tools/macos-vm-auto-enroll/auto-enroll.sh
+++ b/tools/macos-vm-auto-enroll/auto-enroll.sh
@@ -1,0 +1,95 @@
+#!/bin/sh
+
+# Enable job control in shell script
+set -m
+
+# Fleet enroll secret placed in $FLEET_ENROLL_SECRET
+# Fleet URL placed in $FLEET_URL
+# Optional VM name in $MACOS_ENROLLMENT_VM_NAME
+
+vm_name="${MACOS_ENROLLMENT_VM_NAME:-enrollment-test}"
+image_name="ghcr.io/cirruslabs/macos-sonoma-base:latest"
+
+alias ssh_cmd="sshpass -p admin ssh -o \"StrictHostKeyChecking no\" admin@\$(tart ip $vm_name)"
+alias ssh_interactive_cmd="sshpass -p admin ssh -o \"StrictHostKeyChecking no\" -t admin@\$(tart ip $vm_name)"
+alias scp_cmd="sshpass -p admin scp -o \"StrictHostKeyChecking no\""
+
+# Make sure we're in the script directory
+cd "$(dirname "$0")"
+
+# cd to the git root
+cd "$(git rev-parse --show-toplevel)"
+
+
+if [ "$FLEET_URL" = "" ]; then
+    echo "FLEET_URL missing"
+    exit 1
+fi
+
+# Remove the trailing slash if present
+FLEET_URL=${FLEET_URL%/}
+
+if [ "$FLEET_ENROLL_SECRET" = "" ]; then
+    echo "FLEET_ENROLL_SECRET missing"
+    exit 1
+fi
+
+echo "Deleting old fleet package"
+[ -f fleet-osquery.pkg ] && rm fleet-osquery.pkg
+
+echo "Creating fleet package..."
+./build/fleetctl package --type=pkg --enable-scripts --fleet-desktop --fleet-url="$FLEET_URL" --enroll-secret="$FLEET_ENROLL_SECRET"
+
+
+if tart list | grep $vm_name >/dev/null 2>&1; then
+    echo 'Enrollment test VM exists, deleting...'
+    tart stop $vm_name
+    tart delete $vm_name
+fi
+
+echo "Creating new $image_name VM called $vm_name..."
+tart clone $image_name $vm_name
+
+echo "Starting VM $vm_name and detatching"
+tart run $vm_name &
+
+# Wait a second for the VM to start
+sleep 2
+
+echo "Running uname"
+ssh_cmd "uname -a"
+
+echo "Copying package to VM"
+scp_cmd fleet-osquery.pkg admin@$(tart ip $vm_name):
+
+echo "Installing fleet in VM"
+ssh_cmd "echo admin | sudo -S installer -pkg fleet-osquery.pkg -target /"
+
+echo "Waiting for identifier to appear"
+ssh_cmd "while true; do echo 'checking for identifier'; [ -f /opt/orbit/identifier ] && echo 'identifier found' && exit; sleep 5; done"
+
+echo "Waiting for registration to be complete"
+ssh_cmd "while true; do echo 'checking server'; curl -f $FLEET_URL/device/\$(cat /opt/orbit/identifier) > /dev/null 2>&1; [ \$? -eq 0 ] && exit; sleep 5; done"
+
+echo "Fetching MDM profile"
+ssh_cmd "echo $FLEET_URL/api/latest/fleet/device/\$(cat /opt/orbit/identifier)/mdm/apple/manual_enrollment_profile"
+ssh_cmd "curl -o mdm_profile.mobileconfig $FLEET_URL/api/latest/fleet/device/\$(cat /opt/orbit/identifier)/mdm/apple/manual_enrollment_profile"
+
+echo "Opening MDM profile"
+ssh_cmd "open mdm_profile.mobileconfig"
+
+ssh_cmd "open ."
+
+sleep 1
+
+echo "Opening profile settings"
+ssh_cmd "open x-apple.systempreferences:com.apple.preferences.configurationprofiles"
+
+echo "Complete the MDM certificate enrolment with the GUI"
+echo "The default password for user 'admin' is 'admin'"
+
+echo "Opening shell"
+ssh_interactive_cmd "zsh"
+
+echo "Reattaching to VM process"
+fg

--- a/tools/mdm/apple/macos-vm-auto-enroll/README.md
+++ b/tools/mdm/apple/macos-vm-auto-enroll/README.md
@@ -1,0 +1,32 @@
+# macOS VM Auto Enroll
+
+A script to automate the manual enrollment process in a macOS virtual machine.
+
+## Usage
+
+The script takes no arguments, but can be configured through three environment variables.
+
+- `FLEET_ENROLL_SECRET` (required) The fleet enrollment secret
+- `FLEET_URL` (required) The fleet base url
+- `MACOS_ENROLLMENT_VM_NAME` (optional) The name of the VM. If nothing is specified, the default name is `enrollment-test`.
+
+The entire process from the generation of the `pkg` file to the installation is automated. The only part that requires user intervention is installing the MDM profile.
+
+## Steps
+
+The script goes through the following steps.
+
+1. Change to the correct directory
+2. Delete the old `pkg` file if one exists
+3. Build a new `pkg` file using the supplied variables
+4. Delete the existing VM if one with the same name exists
+5. Create a new VM with the chosen name
+6. Launch the VM
+7. Copy the `pkg` file into the VM
+8. Install the fleet and orbit
+9. Fetch the MDM profile from the fleet server after registration is complete
+10. Open the MDM profile, adding it to the profile list
+11. Open the settings app to the profile page
+12. [ACTION REQUIRED] The user has to double click on the new profile and then click `Enroll`.
+13. Open a shell in the terminal running the script
+14. Once the shell is exited, the VM process is reattached to the terminal

--- a/tools/mdm/apple/macos-vm-auto-enroll/macos-vm-auto-enroll.sh
+++ b/tools/mdm/apple/macos-vm-auto-enroll/macos-vm-auto-enroll.sh
@@ -34,6 +34,11 @@ if [ "$FLEET_ENROLL_SECRET" = "" ]; then
     exit 1
 fi
 
+if ! which tart >/dev/null; then
+    echo "install tart VM https://tart.run/"
+    exit 1
+fi
+
 echo "Deleting old fleet package"
 [ -f fleet-osquery.pkg ] && rm fleet-osquery.pkg
 

--- a/tools/mdm/apple/macos-vm-auto-enroll/macos-vm-auto-enroll.sh
+++ b/tools/mdm/apple/macos-vm-auto-enroll/macos-vm-auto-enroll.sh
@@ -43,7 +43,7 @@ echo "Deleting old fleet package"
 [ -f fleet-osquery.pkg ] && rm fleet-osquery.pkg
 
 echo "Creating fleet package..."
-./build/fleetctl package --type=pkg --enable-scripts --fleet-desktop --fleet-url="$FLEET_URL" --enroll-secret="$FLEET_ENROLL_SECRET"
+./build/fleetctl package --type=pkg --enable-scripts --fleet-desktop --disable-open-folder --fleet-url="$FLEET_URL" --enroll-secret="$FLEET_ENROLL_SECRET"
 
 
 if tart list | grep $vm_name >/dev/null 2>&1; then


### PR DESCRIPTION
Script will build a fleet-osquery package, launch a fresh macos VM and install it. It will also download the correct MDM profile and prepare it to be enabled