### PR TITLE
Remove references to unreleased filters

### DIFF
--- a/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
@@ -1053,7 +1053,6 @@ const ManageHostsPage = ({
           lowDiskSpaceHosts,
           osSettings: osSettingsStatus,
           diskEncryptionStatus,
-          vulnerability,
         })
       : hostsAPI.transferToTeam(teamId, selectedHostIds);
 
@@ -1106,7 +1105,6 @@ const ManageHostsPage = ({
             lowDiskSpaceHosts,
             osSettings: osSettingsStatus,
             diskEncryptionStatus,
-            vulnerability,
           })
         : hostsAPI.destroyBulk(selectedHostIds));
 


### PR DESCRIPTION
A bug fix that works in `main` referenced some variables that have not been released yet, which broke the build on the patch branch. This removes those references.

- [x] Manual QA for all new/changed functionality