### PR TITLE
don't run SCEP test in parallel to avoid race in dependency

### DIFF
--- a/server/mdm/scep/scep/scep_test.go
+++ b/server/mdm/scep/scep/scep_test.go
@@ -163,7 +163,6 @@ func TestNewCSRRequest(t *testing.T) {
 	} {
 		test := test
 		t.Run(test.testName, func(t *testing.T) {
-			t.Parallel()
 			key, err := newRSAKey(2048)
 			if err != nil {
 				t.Fatal(err)


### PR DESCRIPTION
The https://pkg.go.dev/go.mozilla.org/pkcs7 package uses an unguarded package-level variable:

https://github.com/mozilla-services/pkcs7/blob/33d05740a3526e382af6395d3513e73d4e66d1cb/ber.go#L19-L21

This was causing this data race during tests:

```
==================
WARNING: DATA RACE
Read at 0x0000009b89b0 by goroutine 22:
  go.mozilla.org/pkcs7.asn1Structured.EncodeTo()
      /home/runner/go/pkg/mod/go.mozilla.org/pkcs7@v0.0.0-20210826202110-33d05740a352/ber.go:21 +0x56
  go.mozilla.org/pkcs7.(*asn1Structured).EncodeTo()
      <autogenerated>:1 +0xa5
  go.mozilla.org/pkcs7.ber2der()
      /home/runner/go/pkg/mod/go.mozilla.org/pkcs7@v0.0.0-20210826202110-33d05740a352/ber.go:68 +0xdb
  go.mozilla.org/pkcs7.Parse()
      /home/runner/go/pkg/mod/go.mozilla.org/pkcs7@v0.0.0-20210826202110-33d05740a352/pkcs7.go:160 +0x12f
  github.com/fleetdm/fleet/v4/server/mdm/scep/scep.ParsePKIMessage()
      /home/runner/work/fleet/fleet/server/mdm/scep/scep/scep.go:234 +0x1d2
  github.com/fleetdm/fleet/v4/server/mdm/scep/scep_test.testParsePKIMessage()
      /home/runner/work/fleet/fleet/server/mdm/scep/scep/scep_test.go:21 +0x56
  github.com/fleetdm/fleet/v4/server/mdm/scep/scep_test.TestNewCSRRequest.func1()
      /home/runner/work/fleet/fleet/server/mdm/scep/scep/scep_test.go:198 +0x7e5
  testing.tRunner()
      /opt/hostedtoolcache/go/1.21.7/x64/src/testing/testing.go:1595 +0x261
  testing.(*T).Run.func1()
      /opt/hostedtoolcache/go/1.21.7/x64/src/testing/testing.go:1648 +0x44

Previous write at 0x0000009b89b0 by goroutine 23:
  go.mozilla.org/pkcs7.asn1Structured.EncodeTo()
      /home/runner/go/pkg/mod/go.mozilla.org/pkcs7@v0.0.0-20210826202110-33d05740a352/ber.go:21 +0x6e
  go.mozilla.org/pkcs7.(*asn1Structured).EncodeTo()
      <autogenerated>:1 +0xa5
  go.mozilla.org/pkcs7.ber2der()
      /home/runner/go/pkg/mod/go.mozilla.org/pkcs7@v0.0.0-20210826202110-33d05740a352/ber.go:68 +0xdb
  go.mozilla.org/pkcs7.Parse()
      /home/runner/go/pkg/mod/go.mozilla.org/pkcs7@v0.0.0-20210826202110-33d05740a352/pkcs7.go:160 +0x12f
  github.com/fleetdm/fleet/v4/server/mdm/scep/scep.(*PKIMessage).DecryptPKIEnvelope()
      /home/runner/work/fleet/fleet/server/mdm/scep/scep/scep.go:344 +0xde
  github.com/fleetdm/fleet/v4/server/mdm/scep/scep_test.TestNewCSRRequest.func1()
      /home/runner/work/fleet/fleet/server/mdm/scep/scep/scep_test.go:199 +0x7fa
  testing.tRunner()
      /opt/hostedtoolcache/go/1.21.7/x64/src/testing/testing.go:1595 +0x261
  testing.(*T).Run.func1()
      /opt/hostedtoolcache/go/1.21.7/x64/src/testing/testing.go:1648 +0x44

Goroutine 22 (running) created at:
  testing.(*T).Run()
      /opt/hostedtoolcache/go/1.21.7/x64/src/testing/testing.go:1648 +0x845
  github.com/fleetdm/fleet/v4/server/mdm/scep/scep_test.TestNewCSRRequest()
      /home/runner/work/fleet/fleet/server/mdm/scep/scep/scep_test.go:165 +0x3ac
  testing.tRunner()
      /opt/hostedtoolcache/go/1.21.7/x64/src/testing/testing.go:1595 +0x261
  testing.(*T).Run.func1()
      /opt/hostedtoolcache/go/1.21.7/x64/src/testing/testing.go:1648 +0x44

Goroutine 23 (running) created at:
  testing.(*T).Run()
      /opt/hostedtoolcache/go/1.21.7/x64/src/testing/testing.go:1648 +0x845
  github.com/fleetdm/fleet/v4/server/mdm/scep/scep_test.TestNewCSRRequest()
      /home/runner/work/fleet/fleet/server/mdm/scep/scep/scep_test.go:165 +0x3ac
  testing.tRunner()
      /opt/hostedtoolcache/go/1.21.7/x64/src/testing/testing.go:1595 +0x261
  testing.(*T).Run.func1()
      /opt/hostedtoolcache/go/1.21.7/x64/src/testing/testing.go:1648 +0x44
==================
    testing.go:1465: race detected during execution of test
=== NAME  TestNewCSRRequest/KeyEncipherment_not_set_with_NOP_certificates_selector
```

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Added/updated tests
