### PR TITLE
[P1] Fleet UI: Hide bulk selection when unsupported filter

### DIFF
--- a/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
@@ -1478,25 +1478,23 @@ const ManageHostsPage = ({
     // Shortterm fix for #17257
     const unsupportedFilter = () => {
       return !!(
-        (
-          policyId ||
-          policyResponse ||
-          softwareId ||
-          softwareTitleId ||
-          softwareVersionId ||
-          osName ||
-          osVersionId ||
-          osVersion ||
-          macSettingsStatus ||
-          bootstrapPackageStatus ||
-          mdmId ||
-          mdmEnrollmentStatus ||
-          munkiIssueId ||
-          lowDiskSpaceHosts ||
-          osSettingsStatus ||
-          diskEncryptionStatus
-        )
-        // || vulnerability TODO: Add for 4.47.0 feature #15919
+        policyId ||
+        policyResponse ||
+        softwareId ||
+        softwareTitleId ||
+        softwareVersionId ||
+        osName ||
+        osVersionId ||
+        osVersion ||
+        macSettingsStatus ||
+        bootstrapPackageStatus ||
+        mdmId ||
+        mdmEnrollmentStatus ||
+        munkiIssueId ||
+        lowDiskSpaceHosts ||
+        osSettingsStatus ||
+        diskEncryptionStatus ||
+        vulnerability
       );
     };
 

--- a/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
@@ -1030,6 +1030,7 @@ const ManageHostsPage = ({
     setSelectedHostIds(hostIds);
   };
 
+  // Bulk transfer is hidden for defined unsupportedFilters
   const onTransferHostSubmit = async (transferTeam: ITeam) => {
     setIsUpdatingHosts(true);
 
@@ -1071,6 +1072,7 @@ const ManageHostsPage = ({
     }
   };
 
+  // Bulk delete is hidden for defined unsupportedFilters
   const onDeleteHostSubmit = async () => {
     setIsUpdatingHosts(true);
 
@@ -1475,23 +1477,25 @@ const ManageHostsPage = ({
 
     const unsupportedFilter = () => {
       return !!(
-        policyId ||
-        policyResponse ||
-        softwareId ||
-        softwareTitleId ||
-        softwareVersionId ||
-        osName ||
-        osVersionId ||
-        osVersion ||
-        macSettingsStatus ||
-        bootstrapPackageStatus ||
-        mdmId ||
-        mdmEnrollmentStatus ||
-        munkiIssueId ||
-        lowDiskSpaceHosts ||
-        osSettingsStatus ||
-        diskEncryptionStatus ||
-        vulnerability
+        (
+          policyId ||
+          policyResponse ||
+          softwareId ||
+          softwareTitleId ||
+          softwareVersionId ||
+          osName ||
+          osVersionId ||
+          osVersion ||
+          macSettingsStatus ||
+          bootstrapPackageStatus ||
+          mdmId ||
+          mdmEnrollmentStatus ||
+          munkiIssueId ||
+          lowDiskSpaceHosts ||
+          osSettingsStatus ||
+          diskEncryptionStatus
+        )
+        // || vulnerability TODO: Add for 4.47.0 feature #15919
       );
     };
 

--- a/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
@@ -1473,6 +1473,28 @@ const ManageHostsPage = ({
       return emptyHosts;
     };
 
+    const unsupportedFilter = () => {
+      return !!(
+        policyId ||
+        policyResponse ||
+        softwareId ||
+        softwareTitleId ||
+        softwareVersionId ||
+        osName ||
+        osVersionId ||
+        osVersion ||
+        macSettingsStatus ||
+        bootstrapPackageStatus ||
+        mdmId ||
+        mdmEnrollmentStatus ||
+        munkiIssueId ||
+        lowDiskSpaceHosts ||
+        osSettingsStatus ||
+        diskEncryptionStatus ||
+        vulnerability
+      );
+    };
+
     return (
       <TableContainer
         resultsTitle="hosts"
@@ -1504,7 +1526,7 @@ const ManageHostsPage = ({
           onActionButtonClick: onDeleteHostsClick,
         }}
         secondarySelectActions={secondarySelectActions}
-        showMarkAllPages
+        showMarkAllPages={!unsupportedFilter}
         isAllPagesSelected={isAllMatchingHostsSelected}
         searchable
         renderCount={renderHostCount}

--- a/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
@@ -1531,7 +1531,7 @@ const ManageHostsPage = ({
           onActionButtonClick: onDeleteHostsClick,
         }}
         secondarySelectActions={secondarySelectActions}
-        showMarkAllPages={!unsupportedFilter} // Shortterm fix for #17257
+        showMarkAllPages={!unsupportedFilter()} // Shortterm fix for #17257
         isAllPagesSelected={isAllMatchingHostsSelected}
         searchable
         renderCount={renderHostCount}

--- a/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
@@ -1475,6 +1475,7 @@ const ManageHostsPage = ({
       return emptyHosts;
     };
 
+    // Shortterm fix for #17257
     const unsupportedFilter = () => {
       return !!(
         (
@@ -1530,7 +1531,7 @@ const ManageHostsPage = ({
           onActionButtonClick: onDeleteHostsClick,
         }}
         secondarySelectActions={secondarySelectActions}
-        showMarkAllPages={!unsupportedFilter}
+        showMarkAllPages={!unsupportedFilter} // Shortterm fix for #17257
         isAllPagesSelected={isAllMatchingHostsSelected}
         searchable
         renderCount={renderHostCount}

--- a/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
@@ -1476,27 +1476,25 @@ const ManageHostsPage = ({
     };
 
     // Shortterm fix for #17257
-    const unsupportedFilter = () => {
-      return !!(
-        policyId ||
-        policyResponse ||
-        softwareId ||
-        softwareTitleId ||
-        softwareVersionId ||
-        osName ||
-        osVersionId ||
-        osVersion ||
-        macSettingsStatus ||
-        bootstrapPackageStatus ||
-        mdmId ||
-        mdmEnrollmentStatus ||
-        munkiIssueId ||
-        lowDiskSpaceHosts ||
-        osSettingsStatus ||
-        diskEncryptionStatus ||
-        vulnerability
-      );
-    };
+    const unsupportedFilter = !!(
+      policyId ||
+      policyResponse ||
+      softwareId ||
+      softwareTitleId ||
+      softwareVersionId ||
+      osName ||
+      osVersionId ||
+      osVersion ||
+      macSettingsStatus ||
+      bootstrapPackageStatus ||
+      mdmId ||
+      mdmEnrollmentStatus ||
+      munkiIssueId ||
+      lowDiskSpaceHosts ||
+      osSettingsStatus ||
+      diskEncryptionStatus ||
+      vulnerability
+    );
 
     return (
       <TableContainer
@@ -1529,7 +1527,7 @@ const ManageHostsPage = ({
           onActionButtonClick: onDeleteHostsClick,
         }}
         secondarySelectActions={secondarySelectActions}
-        showMarkAllPages={!unsupportedFilter()} // Shortterm fix for #17257
+        showMarkAllPages={!unsupportedFilter} // Shortterm fix for #17257
         isAllPagesSelected={isAllMatchingHostsSelected}
         searchable
         renderCount={renderHostCount}


### PR DESCRIPTION
## Issue
#17257 

## Description
Note: This is a short term fix until the full stack fix can be implemented.
- Hides all bulk actions from 16 unsupported filters.

## Screen recording
https://www.loom.com/share/ae8a9d55cdb244ab829dd36c5b5771e7?sid=36437606-8314-4a41-8354-c0df1b23e47c

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [ ] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
- [x] Manual QA for all new/changed functionality

