### PR TITLE
Website: Update "Talk to us" form redirect

### DIFF
--- a/website/assets/js/pages/contact.page.js
+++ b/website/assets/js/pages/contact.page.js
@@ -70,7 +70,11 @@ parasails.registerPage('contact', {
     },
     submittedTalkToUsForm: async function() {
       this.syncing = true;
-      window.location = `https://calendly.com/fleetdm/talk-to-us?email=${encodeURIComponent(this.formData.emailAddress)}&name=${this.formData.firstName}+${this.formData.lastName}`;
+      if(this.formData.numberOfHosts > 700){
+        window.location = `https://calendly.com/fleetdm/talk-to-us?email=${encodeURIComponent(this.formData.emailAddress)}&name=${this.formData.firstName}+${this.formData.lastName}`;
+      } else {
+        window.location = `https://calendly.com/fleetdm/chat?email=${encodeURIComponent(this.formData.emailAddress)}&name=${this.formData.firstName}+${this.formData.lastName}`;
+      }
     },
 
     clickSwitchForms: function(form) {


### PR DESCRIPTION
Changes:
- Updated the "Talk to us" form on the /contact page to redirect users who have <700 hosts to the "Lets get you set up" Calendly event (https://calendly.com/fleetdm/chat)