### PR TITLE
[unreleased bugs] Fleet UI: Missing vulnerability filter block / incorrect link param

### DIFF
--- a/frontend/pages/SoftwarePage/SoftwareVulnerabilities/SoftwareVulnerabilitiesTable/SoftwareVulnerabilitiesTable.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareVulnerabilities/SoftwareVulnerabilitiesTable/SoftwareVulnerabilitiesTable.tsx
@@ -172,7 +172,7 @@ const SoftwareVulnerabilitiesTable = ({
 
   const handleRowSelect = (row: IRowProps) => {
     const hostsByVulnerabilityParams = {
-      cve: row.original.cve,
+      vulnerability: row.original.cve,
       team_id: teamId,
     };
 

--- a/frontend/pages/SoftwarePage/SoftwareVulnerabilityDetailsPage/SoftwareVulnerabilityDetailsPage.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareVulnerabilityDetailsPage/SoftwareVulnerabilityDetailsPage.tsx
@@ -29,7 +29,7 @@ import DetailsNoHosts from "../components/DetailsNoHosts";
 const baseClass = "software-vulnerability-details-page";
 
 interface ISoftwareVulnerabilityDetailsRouteParams {
-  cve: string;
+  vulnerability: string;
   team_id?: string;
 }
 
@@ -71,7 +71,7 @@ const SoftwareVulnerabilityDetailsPage = ({
     [
       {
         scope: "softwareVulnByCVE",
-        cve: routeParams.cve,
+        vulnerability: routeParams.vulnerability,
         teamId: teamIdForApi,
       },
     ],

--- a/frontend/pages/SoftwarePage/components/SoftwareVulnerabilitiesTable/SoftwareVulnerabilitiesTable.tsx
+++ b/frontend/pages/SoftwarePage/components/SoftwareVulnerabilitiesTable/SoftwareVulnerabilitiesTable.tsx
@@ -74,7 +74,7 @@ const SoftwareVulnerabilitiesTable = ({
 
   const handleRowSelect = (row: IRowProps) => {
     const hostsBySoftwareParams = {
-      cve: row.original.cve,
+      vulnerability: row.original.cve,
       team_id: teamIdForApi,
     };
 

--- a/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
@@ -876,6 +876,7 @@ const ManageHostsPage = ({
       osSettingsStatus,
       diskEncryptionStatus,
       bootstrapPackageStatus,
+      vulnerability,
     ]
   );
 

--- a/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
@@ -1641,6 +1641,7 @@ const ManageHostsPage = ({
               osSettingsStatus,
               diskEncryptionStatus,
               bootstrapPackageStatus,
+              vulnerability,
             }}
             selectedLabel={selectedLabel}
             isOnlyObserver={isOnlyObserver}

--- a/frontend/pages/hosts/ManageHostsPage/components/HostsFilterBlock/HostsFilterBlock.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/components/HostsFilterBlock/HostsFilterBlock.tsx
@@ -208,16 +208,10 @@ const HostsFilterBlock = ({
   const renderVulnerabilityFilterBlock = () => {
     if (!vulnerability) return null;
 
-    // TODO: Move formatOperatingSystemDisplayName into utils file
-    const label = formatOperatingSystemDisplayName(vulnerability);
-    const TooltipDescription = (
-      <span>Hosts affected by the specified CVE.</span>
-    );
-
     return (
       <FilterPill
-        label={label}
-        tooltipDescription={TooltipDescription}
+        label={vulnerability}
+        tooltipDescription={<span>Hosts affected by the specified CVE.</span>}
         onClear={() => handleClearFilter(["vulnerability"])}
       />
     );
@@ -479,7 +473,8 @@ const HostsFilterBlock = ({
     munkiIssueId ||
     osSettingsStatus ||
     diskEncryptionStatus ||
-    bootstrapPackageStatus
+    bootstrapPackageStatus ||
+    vulnerability
   ) {
     const renderFilterPill = () => {
       switch (true) {

--- a/frontend/services/entities/vulnerabilities.ts
+++ b/frontend/services/entities/vulnerabilities.ts
@@ -20,7 +20,7 @@ export interface IGetVulnerabilitiesQueryKey
 }
 
 interface IGetVulnerabilityOptions {
-  cve: string;
+  vulnerability: string;
   teamId?: number;
 }
 
@@ -70,10 +70,10 @@ export const getVulnerabilities = ({
 };
 
 const getVulnerability = ({
-  cve,
+  vulnerability,
   teamId,
 }: IGetVulnerabilityOptions): Promise<IVulnerabilityResponse> => {
-  const endpoint = endpoints.VULNERABILITY(cve);
+  const endpoint = endpoints.VULNERABILITY(vulnerability);
   const path = teamId ? `${endpoint}?team_id=${teamId}` : endpoint;
 
   return sendRequest("GET", path);


### PR DESCRIPTION
## Issue
Small FE fixes for #15919 

## Description
- Was not passing vulnerability into filter pill
- Fix use of `cve` to `vulnerability` for "View all hosts" link param 

## Screenshot of fix
<img width="1122" alt="Screenshot 2024-03-07 at 3 05 10 PM" src="https://github.com/fleetdm/fleet/assets/71795832/9dd2f314-3ac8-4399-b6fe-0f1d309fa1d9">


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [ ] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [ ] Documented any permissions changes (docs/Using Fleet/manage-access.md)
- [ ] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [ ] Added support on fleet's osquery simulator `cmd/osquery-perf` for new osquery data ingestion features.
- [ ] Added/updated tests
- [ ] If database migrations are included, checked table schema to confirm autoupdate 
- For database migrations:
  - [ ] Checked schema for all modified table for columns that will auto-update timestamps during migration.
  - [ ] Confirmed that updating the timestamps is acceptable, and will not cause unwanted side effects.
- [ ] Manual QA for all new/changed functionality
  - For Orbit and Fleet Desktop changes:
    - [ ] Manual QA must be performed in the three main OSs, macOS, Windows and Linux.
    - [ ] Auto-update manual QA, from released version of component to new version (see [tools/tuf/test](../tools/tuf/test/README.md)).
