### PR TITLE
Update broken URL to `fleet-deployment.yml` on "Deploy Fleet on Kubernetes" docs

### DIFF
--- a/docs/Deploy/Deploy-Fleet-on-Kubernetes.md
+++ b/docs/Deploy/Deploy-Fleet-on-Kubernetes.md
@@ -8,7 +8,7 @@ There are 2 primary ways to deploy the Fleet server to a Kubernetes cluster. The
 
 We will assume you have `kubectl` and MySQL and Redis are all set up and running. Optionally you have minikube to test your deployment locally on your machine.
 
-To deploy the Fleet server and connect to its dependencies (MySQL and Redis), we will use [Fleet's best practice `fleet-deployment.yml` file](https://github.com/fleetdm/fleet/blob/main/docs/Deploy/Deploy-Fleet-on-Kubernetes.md).
+To deploy the Fleet server and connect to its dependencies (MySQL and Redis), we will use [Fleet's best practice `fleet-deployment.yml` file](https://github.com/fleetdm/fleet/blob/main/docs/Deploy/kubernetes/fleet-deployment.yml).
 
 Let's tell Kubernetes to create the cluster by running the below command.
 


### PR DESCRIPTION
The _"Fleet's best practice `fleet-deployment.yml` file"_ link on the ["Deploy Fleet on Kubernetes" docs page](https://fleetdm.com/docs/deploy/deploy-fleet-on-kubernetes) doesn't actually target the YAML file it purports to and, instead, it just points to the Markdown version of the "Deploy Fleet on Kubernetes" docs on GitHub.

This PR changes the target URL so that link actually goes to the place where one would expect it to (the YAML file).