### PR TITLE
Website: update heading on landing pages

### DIFF
--- a/website/views/pages/device-management.ejs
+++ b/website/views/pages/device-management.ejs
@@ -195,7 +195,7 @@
     <div purpose="tweets-container" class="container-fluid px-md-0 pb-0 d-flex flex-column justify-content-center">
       <div purpose="section-heading" class="mx-auto text-center">
         <h4>Who else uses Fleet?</h4>
-        <h2>Empowering IT teams</h2>
+        <h2>Empowering security and IT teams, globally</h2>
       </div>
     </div>
 

--- a/website/views/pages/endpoint-ops.ejs
+++ b/website/views/pages/endpoint-ops.ejs
@@ -183,7 +183,7 @@
     <div purpose="tweets-container" class="container-fluid px-md-0 pb-0 d-flex flex-column justify-content-center">
       <div purpose="section-heading" class="mx-auto text-center">
         <h4>Who else uses Fleet?</h4>
-        <h3>Empowering IT teams</h3>
+        <h3>Empowering security and IT teams, globally</h3>
       </div>
     </div>
 


### PR DESCRIPTION
changes:
- "Empowering IT teams" » "Empowering security and IT teams, globally"

@mikermcneil I went with "Empowering security and IT teams, globally" instead of "Empowering security and IT teams" because it was already used on the vulnerability management page.