### PR TITLE
Website: (docs) Fix indentation of code blocks nested in ordered lists

### DIFF
--- a/website/assets/styles/pages/docs/basic-documentation.less
+++ b/website/assets/styles/pages/docs/basic-documentation.less
@@ -644,6 +644,9 @@
           code:not(.nohighlight):not(.mermaid) {
             display: inline;
           }
+          > pre {
+            text-indent: 0px;
+          }
           p {
             display: inline;
             margin-bottom: 0px;


### PR DESCRIPTION
Closes: #17475

Changes:
- Updated `basic-documentation.less` to fix the indentation of the text content inside code blocks that are nested in ordered lists