### PR TITLE
[unreleased nits] Vuln feature: missing tooltips, wrong software view…

### DIFF
--- a/frontend/pages/SoftwarePage/SoftwareVulnerabilities/SoftwareVulnerabilitiesTable/VulnerabilitiesTableConfig.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareVulnerabilities/SoftwareVulnerabilitiesTable/VulnerabilitiesTableConfig.tsx
@@ -106,7 +106,7 @@ const generateTableHeaders = (
       accessor: "cvss_score",
       disableSortBy: false,
       Header: (headerProps: IHeaderProps): JSX.Element => {
-        const titleWithToolTip = (
+        const titleWithTooltip = (
           <TooltipWrapper
             tipContent={
               <>
@@ -121,7 +121,7 @@ const generateTableHeaders = (
         return (
           <>
             <HeaderCell
-              value={titleWithToolTip}
+              value={titleWithTooltip}
               isSortedDesc={headerProps.column.isSortedDesc}
             />
             {isSandboxMode && <PremiumFeatureIconWithTooltip />}
@@ -137,7 +137,7 @@ const generateTableHeaders = (
       accessor: "epss_probability",
       disableSortBy: false,
       Header: (headerProps: IHeaderProps): JSX.Element => {
-        const titleWithToolTip = (
+        const titleWithTooltip = (
           <TooltipWrapper
             className="epss_probability"
             tipContent={
@@ -154,7 +154,7 @@ const generateTableHeaders = (
         return (
           <>
             <HeaderCell
-              value={titleWithToolTip}
+              value={titleWithTooltip}
               isSortedDesc={headerProps.column.isSortedDesc}
             />
             {isSandboxMode && <PremiumFeatureIconWithTooltip />}
@@ -173,7 +173,7 @@ const generateTableHeaders = (
       accessor: "cve_published",
       disableSortBy: false,
       Header: (headerProps: IHeaderProps): JSX.Element => {
-        const titleWithToolTip = (
+        const titleWithTooltip = (
           <TooltipWrapper
             tipContent={
               <>
@@ -188,7 +188,7 @@ const generateTableHeaders = (
         return (
           <>
             <HeaderCell
-              value={titleWithToolTip}
+              value={titleWithTooltip}
               isSortedDesc={headerProps.column.isSortedDesc}
             />
             {isSandboxMode && <PremiumFeatureIconWithTooltip />}
@@ -210,10 +210,19 @@ const generateTableHeaders = (
       accessor: "created_at",
       disableSortBy: false,
       Header: (headerProps: IHeaderProps): JSX.Element => {
+        const titleWithTooltip = (
+          <TooltipWrapper
+            tipContent={
+              <>The date this vulnerability first appeared on a host.</>
+            }
+          >
+            Detected
+          </TooltipWrapper>
+        );
         return (
           <>
             <HeaderCell
-              value="Detected"
+              value={titleWithTooltip}
               isSortedDesc={headerProps.column.isSortedDesc}
             />
             {isSandboxMode && <PremiumFeatureIconWithTooltip />}

--- a/frontend/pages/SoftwarePage/SoftwareVulnerabilityDetailsPage/SoftwareVulnOSVersions/_styles.scss
+++ b/frontend/pages/SoftwarePage/SoftwareVulnerabilityDetailsPage/SoftwareVulnOSVersions/_styles.scss
@@ -1,0 +1,5 @@
+.software-vuln-os-versions {
+  display: flex;
+  flex-direction: column;
+  gap: $large;
+}

--- a/frontend/pages/SoftwarePage/SoftwareVulnerabilityDetailsPage/SoftwareVulnOSVersions/_styles.scss
+++ b/frontend/pages/SoftwarePage/SoftwareVulnerabilityDetailsPage/SoftwareVulnOSVersions/_styles.scss
@@ -1,5 +1,3 @@
 .software-vuln-os-versions {
-  display: flex;
-  flex-direction: column;
   gap: $large;
 }

--- a/frontend/pages/SoftwarePage/SoftwareVulnerabilityDetailsPage/SoftwareVulnSoftwareVersions/SoftwareVulnSoftwareVersions.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareVulnerabilityDetailsPage/SoftwareVulnSoftwareVersions/SoftwareVulnSoftwareVersions.tsx
@@ -35,14 +35,14 @@ const SoftwareVulnSoftwareVersions = ({
   );
 
   const onSelectSingleRow = useCallback(
-    ({ original: { id: software_title_id } }) => {
-      if (!software_title_id) {
+    ({ original: { id: software_version_id } }) => {
+      if (!software_version_id) {
         return;
       }
 
       router.push(
         `${PATHS.MANAGE_HOSTS}?${buildQueryStringFromParams({
-          software_title_id,
+          software_version_id,
           team_id: teamIdForApi,
         })}`
       );

--- a/frontend/pages/SoftwarePage/SoftwareVulnerabilityDetailsPage/SoftwareVulnSoftwareVersions/_styles.scss
+++ b/frontend/pages/SoftwarePage/SoftwareVulnerabilityDetailsPage/SoftwareVulnSoftwareVersions/_styles.scss
@@ -1,0 +1,5 @@
+.software-vuln-software-versions {
+  display: flex;
+  flex-direction: column;
+  gap: $large;
+}

--- a/frontend/pages/SoftwarePage/SoftwareVulnerabilityDetailsPage/SoftwareVulnSoftwareVersions/_styles.scss
+++ b/frontend/pages/SoftwarePage/SoftwareVulnerabilityDetailsPage/SoftwareVulnSoftwareVersions/_styles.scss
@@ -1,5 +1,3 @@
 .software-vuln-software-versions {
-  display: flex;
-  flex-direction: column;
   gap: $large;
 }

--- a/frontend/pages/SoftwarePage/SoftwareVulnerabilityDetailsPage/SoftwareVulnSummary/SoftwareVulnSummary.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareVulnerabilityDetailsPage/SoftwareVulnSummary/SoftwareVulnSummary.tsx
@@ -92,14 +92,33 @@ const SoftwareVulnSummary = ({
             )}
             {cve_published && (
               <DataSet
-                title="Published"
+                title={
+                  <TooltipWrapper
+                    tipContent={
+                      <>
+                        The date this vulnerability was published in the
+                        National Vulnerability Database (NVD).
+                      </>
+                    }
+                  >
+                    Published
+                  </TooltipWrapper>
+                }
                 value={<HumanTimeDiffWithDateTip timeString={cve_published} />}
               />
             )}
           </>
         )}
         <DataSet
-          title="Detected"
+          title={
+            <TooltipWrapper
+              tipContent={
+                <>The date this vulnerability first appeared on a host.</>
+              }
+            >
+              Detected
+            </TooltipWrapper>
+          }
           value={<HumanTimeDiffWithDateTip timeString={created_at} />}
         />
         <DataSet title="Affected hosts" value={hosts_count} />

--- a/frontend/pages/SoftwarePage/components/SoftwareVulnerabilitiesTable/SoftwareVulnerabilitiesTableConfig.tsx
+++ b/frontend/pages/SoftwarePage/components/SoftwareVulnerabilitiesTable/SoftwareVulnerabilitiesTableConfig.tsx
@@ -90,7 +90,7 @@ const generateTableConfig = (
       accessor: "cvss_score",
       disableSortBy: false,
       Header: (headerProps: IHeaderProps): JSX.Element => {
-        const titleWithToolTip = (
+        const titleWithTooltip = (
           <TooltipWrapper
             tipContent={
               <>
@@ -105,7 +105,7 @@ const generateTableConfig = (
         return (
           <>
             <HeaderCell
-              value={titleWithToolTip}
+              value={titleWithTooltip}
               isSortedDesc={headerProps.column.isSortedDesc}
             />
             {isSandboxMode && <PremiumFeatureIconWithTooltip />}
@@ -121,7 +121,7 @@ const generateTableConfig = (
       accessor: "epss_probability",
       disableSortBy: false,
       Header: (headerProps: IHeaderProps): JSX.Element => {
-        const titleWithToolTip = (
+        const titleWithTooltip = (
           <TooltipWrapper
             className="epss_probability"
             tipContent={
@@ -138,7 +138,7 @@ const generateTableConfig = (
         return (
           <>
             <HeaderCell
-              value={titleWithToolTip}
+              value={titleWithTooltip}
               isSortedDesc={headerProps.column.isSortedDesc}
             />
             {isSandboxMode && <PremiumFeatureIconWithTooltip />}
@@ -157,7 +157,7 @@ const generateTableConfig = (
       accessor: "cve_published",
       disableSortBy: false,
       Header: (headerProps: IHeaderProps): JSX.Element => {
-        const titleWithToolTip = (
+        const titleWithTooltip = (
           <TooltipWrapper
             tipContent={
               <>
@@ -172,7 +172,7 @@ const generateTableConfig = (
         return (
           <>
             <HeaderCell
-              value={titleWithToolTip}
+              value={titleWithTooltip}
               isSortedDesc={headerProps.column.isSortedDesc}
             />
             {isSandboxMode && <PremiumFeatureIconWithTooltip />}
@@ -194,10 +194,19 @@ const generateTableConfig = (
       accessor: "created_at",
       disableSortBy: false,
       Header: (headerProps: IHeaderProps): JSX.Element => {
+        const titleWithTooltip = (
+          <TooltipWrapper
+            tipContent={
+              <>The date this vulnerability first appeared on a host.</>
+            }
+          >
+            Detected
+          </TooltipWrapper>
+        );
         return (
           <>
             <HeaderCell
-              value="Detected"
+              value={titleWithTooltip}
               isSortedDesc={headerProps.column.isSortedDesc}
             />
             {isSandboxMode && <PremiumFeatureIconWithTooltip />}


### PR DESCRIPTION
## Issue
Related to #15919 

## Description
- Vuln details page: Add 24 px between headers and tables
- Vuln details page: Add missing Published tooltip, Add missing dataset for Detected
- Vuln details page: Clicking Vulnerable software "View all hosts" link goes to correct host filter (software_version_id not software_title_id)
- All vuln tables (3 spots): Add missing tooltip to "Detected" header

## Some screenshots of fixes
<img width="1472" alt="Screenshot 2024-03-08 at 4 17 00 PM" src="https://github.com/fleetdm/fleet/assets/71795832/74761842-8604-4b25-b07f-5feaf7d10d4c">
<img width="500" alt="Screenshot 2024-03-08 at 3 59 49 PM" src="https://github.com/fleetdm/fleet/assets/71795832/6b8b8b25-89e9-44d2-8e4f-5e2ec9c849da">


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Manual QA for all new/changed functionality

