### PR TITLE
UI – refactor custom dropdown option logic, apply it to the global and team host status webhook settings

### DIFF
--- a/changes/17496-custom-dropdown-values
+++ b/changes/17496-custom-dropdown-values
@@ -1,0 +1,1 @@
+* Support custom options set via CLI in the UI for team and global host status webhook settings.

--- a/frontend/interfaces/dropdownOption.ts
+++ b/frontend/interfaces/dropdownOption.ts
@@ -7,7 +7,7 @@ export default PropTypes.shape({
 });
 
 export interface IDropdownOption {
-  disabled: boolean;
+  disabled?: boolean;
   label: string | JSX.Element;
   value: string | number;
   premiumOnly?: boolean;

--- a/frontend/pages/admin/OrgSettingsPage/OrgSettingsNavItems.tsx
+++ b/frontend/pages/admin/OrgSettingsPage/OrgSettingsNavItems.tsx
@@ -7,7 +7,7 @@ import Info from "./cards/Info";
 import WebAddress from "./cards/WebAddress";
 import Sso from "./cards/Sso";
 import Smtp from "./cards/Smtp";
-import HostStatusWebhook from "./cards/HostStatusWebhook";
+import GlobalHostStatusWebhook from "./cards/GlobalHostStatusWebhook";
 import Statistics from "./cards/Statistics";
 import FleetDesktop from "./cards/FleetDesktop";
 import Advanced from "./cards/Advanced";
@@ -48,7 +48,7 @@ const ORG_SETTINGS_NAV_ITEMS: ISideNavItem<IAppConfigFormProps>[] = [
     title: "Host status webhook",
     urlSection: "host-status-webhook",
     path: PATHS.ADMIN_ORGANIZATION_HOST_STATUS_WEBHOOK,
-    Card: HostStatusWebhook,
+    Card: GlobalHostStatusWebhook,
   },
   {
     title: "Usage statistics",

--- a/frontend/pages/admin/OrgSettingsPage/cards/GlobalHostStatusWebhook/GlobalHostStatusWebhook.tsx
+++ b/frontend/pages/admin/OrgSettingsPage/cards/GlobalHostStatusWebhook/GlobalHostStatusWebhook.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useMemo } from "react";
 
 import {
-  WEBHOOK_HOST_PERCENTAGE_DROPDOWN_OPTIONS,
+  HOST_STATUS_WEBHOOK_HOST_PERCENTAGE_DROPDOWN_OPTIONS,
   HOST_STATUS_WEBHOOK_WINDOW_DROPDOWN_OPTIONS,
 } from "utilities/constants";
 
@@ -112,9 +112,20 @@ const GlobalHostStatusWebhook = ({
   const percentageHostsOptions = useMemo(
     () =>
       getCustomDropdownOptions(
-        WEBHOOK_HOST_PERCENTAGE_DROPDOWN_OPTIONS,
+        HOST_STATUS_WEBHOOK_HOST_PERCENTAGE_DROPDOWN_OPTIONS,
         hostStatusWebhookHostPercentage,
         (val) => `${val}%`
+      ),
+    // intentionally omit formData so options only computed initially
+    []
+  );
+
+  const windowOptions = useMemo(
+    () =>
+      getCustomDropdownOptions(
+        HOST_STATUS_WEBHOOK_WINDOW_DROPDOWN_OPTIONS,
+        hostStatusWebhookWindow,
+        (val) => `${val} day${val !== 1 ? "s" : ""}`
       ),
     // intentionally omit formData so options only computed initially
     []
@@ -188,9 +199,9 @@ const GlobalHostStatusWebhook = ({
               />
               <Dropdown
                 label="Number of days"
-                options={HOST_STATUS_WEBHOOK_WINDOW_DROPDOWN_OPTIONS}
+                options={windowOptions}
                 onChange={handleInputChange}
-                name="hostStatusWebhookDaysCount"
+                name="hostStatusWebhookWindow"
                 value={hostStatusWebhookWindow}
                 parseTarget
                 searchable={false}

--- a/frontend/pages/admin/OrgSettingsPage/cards/GlobalHostStatusWebhook/GlobalHostStatusWebhook.tsx
+++ b/frontend/pages/admin/OrgSettingsPage/cards/GlobalHostStatusWebhook/GlobalHostStatusWebhook.tsx
@@ -1,5 +1,10 @@
 import React, { useState, useEffect } from "react";
 
+import {
+  WEBHOOK_HOST_PERCENTAGE_DROPDOWN_OPTIONS,
+  WEBHOOK_NUMBER_OF_DAYS_DROPDOWN_OPTIONS,
+} from "utilities/constants";
+
 import HostStatusWebhookPreviewModal from "pages/admin/components/HostStatusWebhookPreviewModal";
 
 import Button from "components/buttons/Button";
@@ -15,8 +20,6 @@ import {
   IAppConfigFormProps,
   IFormField,
   IAppConfigFormErrors,
-  percentageOfHosts,
-  numberOfDays,
 } from "../constants";
 
 const baseClass = "app-config-form";
@@ -154,7 +157,7 @@ const GlobalHostStatusWebhook = ({
           />
           <Dropdown
             label="Percentage of hosts"
-            options={percentageOfHosts}
+            options={WEBHOOK_HOST_PERCENTAGE_DROPDOWN_OPTIONS}
             onChange={handleInputChange}
             name="hostStatusWebhookHostPercentage"
             value={hostStatusWebhookHostPercentage}
@@ -173,7 +176,7 @@ const GlobalHostStatusWebhook = ({
           />
           <Dropdown
             label="Number of days"
-            options={numberOfDays}
+            options={WEBHOOK_NUMBER_OF_DAYS_DROPDOWN_OPTIONS}
             onChange={handleInputChange}
             name="hostStatusWebhookDaysCount"
             value={hostStatusWebhookDaysCount}

--- a/frontend/pages/admin/OrgSettingsPage/cards/GlobalHostStatusWebhook/GlobalHostStatusWebhook.tsx
+++ b/frontend/pages/admin/OrgSettingsPage/cards/GlobalHostStatusWebhook/GlobalHostStatusWebhook.tsx
@@ -21,7 +21,7 @@ import {
 
 const baseClass = "app-config-form";
 
-const HostStatusWebhook = ({
+const GlobalHostStatusWebhook = ({
   appConfig,
   handleSubmit,
   isUpdatingSettings,
@@ -212,4 +212,4 @@ const HostStatusWebhook = ({
   );
 };
 
-export default HostStatusWebhook;
+export default GlobalHostStatusWebhook;

--- a/frontend/pages/admin/OrgSettingsPage/cards/GlobalHostStatusWebhook/GlobalHostStatusWebhook.tsx
+++ b/frontend/pages/admin/OrgSettingsPage/cards/GlobalHostStatusWebhook/GlobalHostStatusWebhook.tsx
@@ -116,7 +116,7 @@ const GlobalHostStatusWebhook = ({
         hostStatusWebhookHostPercentage,
         (val) => `${val}%`
       ),
-    // intentionally omit formData so options only computed initially
+    // intentionally omit dependency so options only computed initially
     []
   );
 
@@ -127,7 +127,7 @@ const GlobalHostStatusWebhook = ({
         hostStatusWebhookWindow,
         (val) => `${val} day${val !== 1 ? "s" : ""}`
       ),
-    // intentionally omit formData so options only computed initially
+    // intentionally omit dependency so options only computed initially
     []
   );
   return (

--- a/frontend/pages/admin/OrgSettingsPage/cards/GlobalHostStatusWebhook/index.ts
+++ b/frontend/pages/admin/OrgSettingsPage/cards/GlobalHostStatusWebhook/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./GlobalHostStatusWebhook";

--- a/frontend/pages/admin/OrgSettingsPage/cards/HostStatusWebhook/index.ts
+++ b/frontend/pages/admin/OrgSettingsPage/cards/HostStatusWebhook/index.ts
@@ -1,1 +1,0 @@
-export { default } from "./HostStatusWebhook";

--- a/frontend/pages/admin/OrgSettingsPage/cards/constants.ts
+++ b/frontend/pages/admin/OrgSettingsPage/cards/constants.ts
@@ -49,23 +49,7 @@ export const authTypeOptions = [
   { label: "None", value: "authtype_none" },
 ];
 
-export const percentageOfHosts = [
-  { label: "1%", value: 1 },
-  { label: "5%", value: 5 },
-  { label: "10%", value: 10 },
-  { label: "25%", value: 25 },
-];
-
-export const numberOfDays = [
-  { label: "1 day", value: 1 },
-  { label: "3 days", value: 3 },
-  { label: "7 days", value: 7 },
-  { label: "14 days", value: 14 },
-];
-
 export default {
   authMethodOptions,
   authTypeOptions,
-  percentageOfHosts,
-  numberOfDays,
 };

--- a/frontend/pages/admin/TeamManagementPage/TeamDetailsWrapper/TeamSettings/TeamSettings.tsx
+++ b/frontend/pages/admin/TeamManagementPage/TeamDetailsWrapper/TeamSettings/TeamSettings.tsx
@@ -9,7 +9,7 @@ import useTeamIdParam from "hooks/useTeamIdParam";
 import {
   DEFAULT_USE_QUERY_OPTIONS,
   WEBHOOK_HOST_PERCENTAGE_DROPDOWN_OPTIONS,
-  WEBHOOK_NUMBER_OF_DAYS_DROPDOWN_OPTIONS,
+  HOST_STATUS_WEBHOOK_WINDOW_DROPDOWN_OPTIONS,
 } from "utilities/constants";
 
 import { IApiError } from "interfaces/errors";
@@ -308,7 +308,7 @@ const TeamSettings = ({ location, router }: ITeamSubnavProps) => {
             />
             <Dropdown
               label="Host status webhook window"
-              options={WEBHOOK_NUMBER_OF_DAYS_DROPDOWN_OPTIONS}
+              options={HOST_STATUS_WEBHOOK_WINDOW_DROPDOWN_OPTIONS}
               onChange={onInputChange}
               name="teamHostStatusWebhookWindow"
               value={formData.teamHostStatusWebhookWindow}

--- a/frontend/pages/admin/TeamManagementPage/TeamDetailsWrapper/TeamSettings/TeamSettings.tsx
+++ b/frontend/pages/admin/TeamManagementPage/TeamDetailsWrapper/TeamSettings/TeamSettings.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useContext, useMemo, useState } from "react";
+import React, { useCallback, useContext, useEffect, useState } from "react";
 
 import { useQuery } from "react-query";
 
@@ -16,6 +16,7 @@ import { IApiError } from "interfaces/errors";
 import { IConfig } from "interfaces/config";
 import { ITeamConfig } from "interfaces/team";
 import { ITeamSubnavProps } from "interfaces/team_subnav";
+import { IDropdownOption } from "interfaces/dropdownOption";
 
 import configAPI from "services/entities/config";
 import teamsAPI, { ILoadTeamResponse } from "services/entities/teams";
@@ -97,6 +98,15 @@ const TeamSettings = ({ location, router }: ITeamSubnavProps) => {
     teamHostStatusWebhookHostPercentage: 1,
     teamHostStatusWebhookWindow: 1,
   });
+  // stateful approach required since initial options come from team config api response
+  const [isInitialTeamConfig, setIsInitialTeamConfig] = useState(true);
+  const [
+    percentageHostsDropdownOptions,
+    setPercentageHostsDropdownOptions,
+  ] = useState<IDropdownOption[]>([]);
+  const [windowDropdownOptions, setWindowDropdownOptions] = useState<
+    IDropdownOption[]
+  >([]);
   const [updatingTeamSettings, setUpdatingTeamSettings] = useState(false);
   const [formErrors, setFormErrors] = useState<Record<string, string | null>>(
     {}
@@ -153,53 +163,49 @@ const TeamSettings = ({ location, router }: ITeamSubnavProps) => {
       ...DEFAULT_USE_QUERY_OPTIONS,
       enabled: isRouteOk && !!teamIdForApi,
       select: (data) => data.team,
-      onSuccess: (teamConfig) => {
+      onSuccess: (tC) => {
         setFormData({
           // host expiry settings
           teamHostExpiryEnabled:
-            teamConfig?.host_expiry_settings?.host_expiry_enabled ?? false,
+            tC?.host_expiry_settings?.host_expiry_enabled ?? false,
           teamHostExpiryWindow:
-            teamConfig?.host_expiry_settings?.host_expiry_window ?? "",
+            tC?.host_expiry_settings?.host_expiry_window ?? "",
           // host status webhook settings
           teamHostStatusWebhookEnabled:
-            teamConfig?.webhook_settings?.host_status_webhook
+            tC?.webhook_settings?.host_status_webhook
               ?.enable_host_status_webhook ?? false,
           teamHostStatusWebhookDestinationUrl:
-            teamConfig?.webhook_settings?.host_status_webhook
-              ?.destination_url ?? "",
+            tC?.webhook_settings?.host_status_webhook?.destination_url ?? "",
           teamHostStatusWebhookHostPercentage:
-            teamConfig?.webhook_settings?.host_status_webhook
-              ?.host_percentage ?? 1,
+            tC?.webhook_settings?.host_status_webhook?.host_percentage ?? 1,
           teamHostStatusWebhookWindow:
-            teamConfig?.webhook_settings?.host_status_webhook?.days_count ?? 1,
+            tC?.webhook_settings?.host_status_webhook?.days_count ?? 1,
         });
       },
     }
   );
 
-  const percentageHostsOptions = useMemo(
-    () =>
-      getCustomDropdownOptions(
-        HOST_STATUS_WEBHOOK_HOST_PERCENTAGE_DROPDOWN_OPTIONS,
-        formData.teamHostStatusWebhookHostPercentage,
-        (val) => `${val}%`
-      ),
-    // depend on teamConfig so that options are recomputed when teamConfig loads
-    // omit formData dependency so options only computed on teamConfig load, not on user interaction
-    [teamConfig]
-  );
+  useEffect(() => {
+    if (isInitialTeamConfig) {
+      setPercentageHostsDropdownOptions(
+        getCustomDropdownOptions(
+          HOST_STATUS_WEBHOOK_HOST_PERCENTAGE_DROPDOWN_OPTIONS,
+          teamConfig?.webhook_settings.host_status_webhook.host_percentage ?? 1,
+          (val) => `${val}%`
+        )
+      );
 
-  const windowOptions = useMemo(
-    () =>
-      getCustomDropdownOptions(
-        HOST_STATUS_WEBHOOK_WINDOW_DROPDOWN_OPTIONS,
-        formData.teamHostStatusWebhookWindow,
-        (val) => `${val} day${val !== 1 ? "s" : ""}`
-      ),
-    // depend on teamConfig so that options are recomputed when teamConfig loads
-    // omit formData dependency so options only computed on teamConfig load, not on user interaction
-    [teamConfig]
-  );
+      setWindowDropdownOptions(
+        getCustomDropdownOptions(
+          HOST_STATUS_WEBHOOK_WINDOW_DROPDOWN_OPTIONS,
+          teamConfig?.webhook_settings.host_status_webhook.days_count ?? 1,
+          (val) => `${val} day${val !== 1 ? "s" : ""}`
+        )
+      );
+    }
+    // no need for isInitialTeamConfig dependence, since this effect should only run on initial
+    // config load
+  }, [teamConfig]);
 
   const onInputChange = useCallback(
     (newVal: { name: FormNames; value: string | number | boolean }) => {
@@ -251,6 +257,7 @@ const TeamSettings = ({ location, router }: ITeamSubnavProps) => {
         .then(() => {
           renderFlash("success", "Successfully updated settings.");
           refetchTeamConfig();
+          setIsInitialTeamConfig(false);
         })
         .catch((errorResponse: { data: IApiError }) => {
           renderFlash(
@@ -317,7 +324,7 @@ const TeamSettings = ({ location, router }: ITeamSubnavProps) => {
             />
             <Dropdown
               label="Host status webhook %"
-              options={percentageHostsOptions}
+              options={percentageHostsDropdownOptions}
               onChange={onInputChange}
               name="teamHostStatusWebhookHostPercentage"
               value={formData.teamHostStatusWebhookHostPercentage}
@@ -335,7 +342,7 @@ const TeamSettings = ({ location, router }: ITeamSubnavProps) => {
             />
             <Dropdown
               label="Host status webhook window"
-              options={windowOptions}
+              options={windowDropdownOptions}
               onChange={onInputChange}
               name="teamHostStatusWebhookWindow"
               value={formData.teamHostStatusWebhookWindow}

--- a/frontend/pages/admin/TeamManagementPage/TeamDetailsWrapper/TeamSettings/TeamSettings.tsx
+++ b/frontend/pages/admin/TeamManagementPage/TeamDetailsWrapper/TeamSettings/TeamSettings.tsx
@@ -6,7 +6,11 @@ import { NotificationContext } from "context/notification";
 
 import useTeamIdParam from "hooks/useTeamIdParam";
 
-import { DEFAULT_USE_QUERY_OPTIONS } from "utilities/constants";
+import {
+  DEFAULT_USE_QUERY_OPTIONS,
+  WEBHOOK_HOST_PERCENTAGE_DROPDOWN_OPTIONS,
+  WEBHOOK_NUMBER_OF_DAYS_DROPDOWN_OPTIONS,
+} from "utilities/constants";
 
 import { IApiError } from "interfaces/errors";
 import { IConfig } from "interfaces/config";
@@ -17,10 +21,6 @@ import configAPI from "services/entities/config";
 import teamsAPI, { ILoadTeamResponse } from "services/entities/teams";
 
 import HostStatusWebhookPreviewModal from "pages/admin/components/HostStatusWebhookPreviewModal";
-import {
-  numberOfDays,
-  percentageOfHosts,
-} from "pages/admin/OrgSettingsPage/cards/constants";
 
 import validURL from "components/forms/validators/valid_url";
 
@@ -290,7 +290,7 @@ const TeamSettings = ({ location, router }: ITeamSubnavProps) => {
             />
             <Dropdown
               label="Host status webhook %"
-              options={percentageOfHosts}
+              options={WEBHOOK_HOST_PERCENTAGE_DROPDOWN_OPTIONS}
               onChange={onInputChange}
               name="teamHostStatusWebhookHostPercentage"
               value={formData.teamHostStatusWebhookHostPercentage}
@@ -308,7 +308,7 @@ const TeamSettings = ({ location, router }: ITeamSubnavProps) => {
             />
             <Dropdown
               label="Host status webhook window"
-              options={numberOfDays}
+              options={WEBHOOK_NUMBER_OF_DAYS_DROPDOWN_OPTIONS}
               onChange={onInputChange}
               name="teamHostStatusWebhookWindow"
               value={formData.teamHostStatusWebhookWindow}

--- a/frontend/pages/admin/TeamManagementPage/TeamDetailsWrapper/TeamSettings/TeamSettings.tsx
+++ b/frontend/pages/admin/TeamManagementPage/TeamDetailsWrapper/TeamSettings/TeamSettings.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useContext, useState } from "react";
+import React, { useCallback, useContext, useMemo, useState } from "react";
 
 import { useQuery } from "react-query";
 
@@ -19,6 +19,8 @@ import { ITeamSubnavProps } from "interfaces/team_subnav";
 
 import configAPI from "services/entities/config";
 import teamsAPI, { ILoadTeamResponse } from "services/entities/teams";
+
+import { getCustomDropdownOptions } from "utilities/helpers";
 
 import HostStatusWebhookPreviewModal from "pages/admin/components/HostStatusWebhookPreviewModal";
 
@@ -140,6 +142,7 @@ const TeamSettings = ({ location, router }: ITeamSubnavProps) => {
   } = appConfig ?? { host_expiry_settings: {} };
 
   const {
+    data: teamConfig,
     isLoading: isLoadingTeamConfig,
     refetch: refetchTeamConfig,
     error: errorLoadTeamConfig,
@@ -172,6 +175,30 @@ const TeamSettings = ({ location, router }: ITeamSubnavProps) => {
         });
       },
     }
+  );
+
+  const percentageHostsOptions = useMemo(
+    () =>
+      getCustomDropdownOptions(
+        HOST_STATUS_WEBHOOK_HOST_PERCENTAGE_DROPDOWN_OPTIONS,
+        formData.teamHostStatusWebhookHostPercentage,
+        (val) => `${val}%`
+      ),
+    // depend on teamConfig so that options are recomputed when teamConfig loads
+    // omit formData dependency so options only computed on teamConfig load, not on user interaction
+    [teamConfig]
+  );
+
+  const windowOptions = useMemo(
+    () =>
+      getCustomDropdownOptions(
+        HOST_STATUS_WEBHOOK_WINDOW_DROPDOWN_OPTIONS,
+        formData.teamHostStatusWebhookWindow,
+        (val) => `${val} day${val !== 1 ? "s" : ""}`
+      ),
+    // depend on teamConfig so that options are recomputed when teamConfig loads
+    // omit formData dependency so options only computed on teamConfig load, not on user interaction
+    [teamConfig]
   );
 
   const onInputChange = useCallback(
@@ -290,7 +317,7 @@ const TeamSettings = ({ location, router }: ITeamSubnavProps) => {
             />
             <Dropdown
               label="Host status webhook %"
-              options={HOST_STATUS_WEBHOOK_HOST_PERCENTAGE_DROPDOWN_OPTIONS}
+              options={percentageHostsOptions}
               onChange={onInputChange}
               name="teamHostStatusWebhookHostPercentage"
               value={formData.teamHostStatusWebhookHostPercentage}
@@ -308,7 +335,7 @@ const TeamSettings = ({ location, router }: ITeamSubnavProps) => {
             />
             <Dropdown
               label="Host status webhook window"
-              options={HOST_STATUS_WEBHOOK_WINDOW_DROPDOWN_OPTIONS}
+              options={windowOptions}
               onChange={onInputChange}
               name="teamHostStatusWebhookWindow"
               value={formData.teamHostStatusWebhookWindow}

--- a/frontend/pages/admin/TeamManagementPage/TeamDetailsWrapper/TeamSettings/TeamSettings.tsx
+++ b/frontend/pages/admin/TeamManagementPage/TeamDetailsWrapper/TeamSettings/TeamSettings.tsx
@@ -8,7 +8,7 @@ import useTeamIdParam from "hooks/useTeamIdParam";
 
 import {
   DEFAULT_USE_QUERY_OPTIONS,
-  WEBHOOK_HOST_PERCENTAGE_DROPDOWN_OPTIONS,
+  HOST_STATUS_WEBHOOK_HOST_PERCENTAGE_DROPDOWN_OPTIONS,
   HOST_STATUS_WEBHOOK_WINDOW_DROPDOWN_OPTIONS,
 } from "utilities/constants";
 
@@ -290,7 +290,7 @@ const TeamSettings = ({ location, router }: ITeamSubnavProps) => {
             />
             <Dropdown
               label="Host status webhook %"
-              options={WEBHOOK_HOST_PERCENTAGE_DROPDOWN_OPTIONS}
+              options={HOST_STATUS_WEBHOOK_HOST_PERCENTAGE_DROPDOWN_OPTIONS}
               onChange={onInputChange}
               name="teamHostStatusWebhookHostPercentage"
               value={formData.teamHostStatusWebhookHostPercentage}

--- a/frontend/utilities/constants.tsx
+++ b/frontend/utilities/constants.tsx
@@ -3,6 +3,7 @@ import { OsqueryPlatform } from "interfaces/platform";
 import paths from "router/paths";
 import { ISchedulableQuery } from "interfaces/schedulable_query";
 import React from "react";
+import { IDropdownOption } from "interfaces/dropdownOption";
 
 const { origin } = global.window.location;
 export const BASE_URL = `${origin}${URL_PREFIX}/api`;
@@ -24,7 +25,7 @@ export const DEFAULT_GRAVATAR_LINK_FALLBACK =
 export const DEFAULT_GRAVATAR_LINK_DARK_FALLBACK =
   "/assets/images/icon-avatar-default-dark-24x24%402x.png";
 
-export const FREQUENCY_DROPDOWN_OPTIONS = [
+export const FREQUENCY_DROPDOWN_OPTIONS: IDropdownOption[] = [
   { value: 0, label: "Never" },
   { value: 300, label: "Every 5 minutes" },
   { value: 600, label: "Every 10 minutes" },
@@ -35,6 +36,19 @@ export const FREQUENCY_DROPDOWN_OPTIONS = [
   { value: 43200, label: "Every 12 hours" },
   { value: 86400, label: "Every day" },
   { value: 604800, label: "Every week" },
+];
+export const WEBHOOK_HOST_PERCENTAGE_DROPDOWN_OPTIONS: IDropdownOption[] = [
+  { label: "1%", value: 1 },
+  { label: "5%", value: 5 },
+  { label: "10%", value: 10 },
+  { label: "25%", value: 25 },
+];
+
+export const WEBHOOK_NUMBER_OF_DAYS_DROPDOWN_OPTIONS: IDropdownOption[] = [
+  { label: "1 day", value: 1 },
+  { label: "3 days", value: 3 },
+  { label: "7 days", value: 7 },
+  { label: "14 days", value: 14 },
 ];
 
 export const GITHUB_NEW_ISSUE_LINK =

--- a/frontend/utilities/constants.tsx
+++ b/frontend/utilities/constants.tsx
@@ -44,7 +44,7 @@ export const WEBHOOK_HOST_PERCENTAGE_DROPDOWN_OPTIONS: IDropdownOption[] = [
   { label: "25%", value: 25 },
 ];
 
-export const WEBHOOK_NUMBER_OF_DAYS_DROPDOWN_OPTIONS: IDropdownOption[] = [
+export const HOST_STATUS_WEBHOOK_WINDOW_DROPDOWN_OPTIONS: IDropdownOption[] = [
   { label: "1 day", value: 1 },
   { label: "3 days", value: 3 },
   { label: "7 days", value: 7 },

--- a/frontend/utilities/constants.tsx
+++ b/frontend/utilities/constants.tsx
@@ -37,7 +37,7 @@ export const FREQUENCY_DROPDOWN_OPTIONS: IDropdownOption[] = [
   { value: 86400, label: "Every day" },
   { value: 604800, label: "Every week" },
 ];
-export const WEBHOOK_HOST_PERCENTAGE_DROPDOWN_OPTIONS: IDropdownOption[] = [
+export const HOST_STATUS_WEBHOOK_HOST_PERCENTAGE_DROPDOWN_OPTIONS: IDropdownOption[] = [
   { label: "1%", value: 1 },
   { label: "5%", value: 5 },
   { label: "10%", value: 10 },

--- a/frontend/utilities/helpers.tsx
+++ b/frontend/utilities/helpers.tsx
@@ -49,6 +49,7 @@ import {
   PLATFORM_LABEL_DISPLAY_TYPES,
 } from "utilities/constants";
 import { IScheduledQueryStats } from "interfaces/scheduled_query_stats";
+import { IDropdownOption } from "interfaces/dropdownOption";
 
 const ORG_INFO_ATTRS = ["org_name", "org_logo_url"];
 const ADMIN_ATTRS = ["email", "name", "password", "password_confirmation"];
@@ -880,6 +881,22 @@ export const getUniqueColumnNamesFromRows = (rows: any[]) =>
     )
   );
 
+// can allow additional dropdown value types in the future
+type DropdownOptionValue = IDropdownOption["value"];
+
+export function getCustomDropdownOptions(
+  defaultOptions: IDropdownOption[],
+  customValue: DropdownOptionValue,
+  labelFormatter: (value: DropdownOptionValue) => string
+): IDropdownOption[] {
+  return defaultOptions.some((option) => option.value === customValue)
+    ? defaultOptions
+    : [
+        { label: labelFormatter(customValue), value: customValue },
+        ...defaultOptions,
+      ];
+}
+
 export default {
   addGravatarUrlToResource,
   formatConfigDataForServer,
@@ -898,6 +915,7 @@ export default {
   generateRole,
   generateTeam,
   getUniqueColumnNamesFromRows,
+  getCustomDropdownOptions,
   greyCell,
   humanHostLastSeen,
   humanHostEnrolled,


### PR DESCRIPTION
## Addresses #17496
- Encapsulate logic for generating custom dropdown options
- Apply that logic to the team and global host status webhook settings forms, as well as the edit query form
- Hide and show global host status webhook setting fields to match the fresher UX of the team setting

![Screenshot 2024-03-08 at 5 56 39 PM](https://github.com/fleetdm/fleet/assets/61553566/59c618f1-e955-4ee8-abfe-ca9a3a7c7362)

- [x] Changes file added for user-visible changes in `changes/`
- [x] Manual QA for all new/changed functionality
