### PR TITLE
Fleet FE: Do not pass empty search string to API for bulk transfer/delete hosts

### DIFF
--- a/frontend/services/entities/hosts.ts
+++ b/frontend/services/entities/hosts.ts
@@ -218,7 +218,7 @@ export default {
     const { HOSTS_DELETE } = endpoints;
     return sendRequest("POST", HOSTS_DELETE, {
       filters: {
-        query: query || undefined, // Critical: Prevents empty string passed to API
+        query: query || undefined, // Prevents empty string passed to API which as of 4.47 will return an error
         status,
         label_id: labelId,
         team_id: teamId,
@@ -441,7 +441,7 @@ export default {
     return sendRequest("POST", HOSTS_TRANSFER_BY_FILTER, {
       team_id: teamId,
       filters: {
-        query: query || undefined, // Critical: Prevents empty string passed to API
+        query: query || undefined, // Prevents empty string passed to API which as of 4.47 will return an error
         status,
         label_id: labelId,
         team_id: currentTeam,

--- a/frontend/services/entities/hosts.ts
+++ b/frontend/services/entities/hosts.ts
@@ -218,7 +218,7 @@ export default {
     const { HOSTS_DELETE } = endpoints;
     return sendRequest("POST", HOSTS_DELETE, {
       filters: {
-        query,
+        query: query || undefined, // Critical: Prevents empty string passed to API
         status,
         label_id: labelId,
         team_id: teamId,
@@ -441,7 +441,7 @@ export default {
     return sendRequest("POST", HOSTS_TRANSFER_BY_FILTER, {
       team_id: teamId,
       filters: {
-        query,
+        query: query || undefined, // Critical: Prevents empty string passed to API
         status,
         label_id: labelId,
         team_id: currentTeam,


### PR DESCRIPTION
## Issue
Part of #17257 

## Description
- Replace `query` key default `""` with `undefined` for API calls to bulk transfer and bulk delete

NOTE: This change is because the API should error filters that are not supported which now includes empty string


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Manual QA for all new/changed functionality

