### PR TITLE
[released bugs] Fleet UI: Fix 5 params for exporting hosts onto a file

### DIFF
--- a/changes/17273-fix-4-buggy-export-filters
+++ b/changes/17273-fix-4-buggy-export-filters
@@ -1,0 +1,1 @@
+Fix 4 buggy filters for exporting hosts onto a file on the manage host page

--- a/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
@@ -1317,9 +1317,10 @@ const ManageHostsPage = ({
       mdmEnrollmentStatus,
       munkiIssueId,
       lowDiskSpaceHosts,
-      os_version_id: osVersionId,
-      os_name: osName,
-      os_version: osVersion,
+      osName,
+      osVersionId,
+      osVersion,
+      bootstrapPackageStatus,
       vulnerability,
       visibleColumns,
     };

--- a/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
@@ -1320,6 +1320,7 @@ const ManageHostsPage = ({
       osName,
       osVersionId,
       osVersion,
+      osSettings: osSettingsStatus,
       bootstrapPackageStatus,
       vulnerability,
       visibleColumns,

--- a/frontend/services/entities/hosts.ts
+++ b/frontend/services/entities/hosts.ts
@@ -104,11 +104,13 @@ export interface IExportHostsOptions {
   lowDiskSpaceHosts?: number;
   osId?: number;
   osName?: string;
+  osVersionId?: number;
   osVersion?: string;
   vulnerability?: string;
   device_mapping?: boolean;
   columns?: string;
   visibleColumns?: string;
+  bootstrapPackageStatus?: BootstrapPackageStatus;
   osSettings?: MdmProfileStatus;
   diskEncryptionStatus?: DiskEncryptionStatus;
 }
@@ -253,10 +255,14 @@ export default {
     const softwareTitleId = options?.softwareTitleId;
     const softwareVersionId = options?.softwareVersionId;
     const macSettingsStatus = options?.macSettingsStatus;
+    const osName = options?.osName;
+    const osVersionId = options?.osVersionId;
+    const osVersion = options?.osVersion;
     const status = options?.status;
     const mdmId = options?.mdmId;
     const mdmEnrollmentStatus = options?.mdmEnrollmentStatus;
     const lowDiskSpaceHosts = options?.lowDiskSpaceHosts;
+    const bootstrapPackageStatus = options?.bootstrapPackageStatus;
     const visibleColumns = options?.visibleColumns;
     const label = getLabelParam(selectedLabels);
     const munkiIssueId = options?.munkiIssueId;
@@ -288,8 +294,12 @@ export default {
         softwareId,
         softwareTitleId,
         softwareVersionId,
+        osName,
+        osVersionId,
+        osVersion,
         lowDiskSpaceHosts,
         osSettings,
+        bootstrapPackageStatus,
         diskEncryptionStatus,
         vulnerability,
       }),


### PR DESCRIPTION
## Issue
Cerra #17273
PR with longer refactor to help prevent future bugs #17275 

## Description
- Fixes 4 buggy filters for exporting hosts on the manage host page (creates a data file that matches hosts shown)


## Dev self-QA
- [x] `os_name` `os_version` (passed together)
- [x] `os_version_id`
- [ ] ~~`bootstrap_package`~~ Cannot test since I don't have an MDM environment
- [ ] ~~`os_settings`~~ Cannot test since I don't have an MDM environment

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
- [x] Manual QA for all new/changed functionality
