### PR TITLE
Website: Update license dispenser and contact page redirect

### DIFF
--- a/website/assets/js/pages/contact.page.js
+++ b/website/assets/js/pages/contact.page.js
@@ -71,9 +71,9 @@ parasails.registerPage('contact', {
     submittedTalkToUsForm: async function() {
       this.syncing = true;
       if(this.formData.numberOfHosts > 700){
-        window.location = `https://calendly.com/fleetdm/talk-to-us?email=${encodeURIComponent(this.formData.emailAddress)}&name=${this.formData.firstName}+${this.formData.lastName}`;
+        window.location = `https://calendly.com/fleetdm/talk-to-us?email=${encodeURIComponent(this.formData.emailAddress)}&name=${encodeURIComponent(this.formData.firstName+' '+this.formData.lastName)}`;
       } else {
-        window.location = `https://calendly.com/fleetdm/chat?email=${encodeURIComponent(this.formData.emailAddress)}&name=${this.formData.firstName}+${this.formData.lastName}`;
+        window.location = `https://calendly.com/fleetdm/chat?email=${encodeURIComponent(this.formData.emailAddress)}&name=${encodeURIComponent(this.formData.firstName+' '+this.formData.lastName)}`;
       }
     },
 

--- a/website/assets/js/pages/customers/new-license.page.js
+++ b/website/assets/js/pages/customers/new-license.page.js
@@ -83,7 +83,7 @@ parasails.registerPage('new-license', {
     clickScheduleDemo: async function() {
       this.syncing = true;
       // Note: we keep loading spinner present indefinitely so that it is apparent that a new page is loading
-      window.location = '/contact';
+      window.location = `https://calendly.com/fleetdm/talk-to-us?email=${encodeURIComponent(this.me.emailAddress)}&name=${this.me.firstName}+${this.me.lastName}`;
     },
 
     clickResetForm: async function() {

--- a/website/assets/js/pages/customers/new-license.page.js
+++ b/website/assets/js/pages/customers/new-license.page.js
@@ -83,7 +83,7 @@ parasails.registerPage('new-license', {
     clickScheduleDemo: async function() {
       this.syncing = true;
       // Note: we keep loading spinner present indefinitely so that it is apparent that a new page is loading
-      window.location = `https://calendly.com/fleetdm/talk-to-us?email=${encodeURIComponent(this.me.emailAddress)}&name=${this.me.firstName}+${this.me.lastName}`;
+      window.location = `https://calendly.com/fleetdm/talk-to-us?email=${encodeURIComponent(this.me.emailAddress)}&name=${encodeURIComponent(this.me.firstName+' '+this.me.lastName)}`;
     },
 
     clickResetForm: async function() {


### PR DESCRIPTION
Closes: #17521

Changes:
- Updated the /customers/new-license page to direct users who want to purchase a license for >700 hosts to the "Talk to us" calendly event.
- Updated the Calendly redirect on the /contact page to use encodeURIComponent for the user's name.