### PR TITLE
Repurpose policies

### DIFF
--- a/ee/cis/macos-13/cis-policy-queries.yml
+++ b/ee/cis/macos-13/cis-policy-queries.yml
@@ -2110,10 +2110,7 @@ spec:
         3. Select the i next to the Guest User
         4. Verify that Allow guests to log in to this computer is disable
   query: |
-    SELECT 1 WHERE
-    EXISTS(SELECT 1 FROM plist WHERE path='/Library/Preferences/com.apple.loginwindow.plist' AND key='GuestEnabled' AND value = 0)
-    OR
-    EXISTS(select 1 FROM plist WHERE path='/Library/Preferences/com.apple.MCX.plist' AND key='DisableGuestAccount' AND value = 1);
+    SELECT 1 FROM plist WHERE path='/Library/Preferences/com.apple.loginwindow.plist' AND key='GuestEnabled' AND value = 0;
   purpose: Informational
   tags: compliance, CIS, CIS_Level1, CIS-macos-13-2.12.1
   contributors: sharon-fdm

--- a/ee/cis/macos-14/cis-policy-queries.yml
+++ b/ee/cis/macos-14/cis-policy-queries.yml
@@ -2110,10 +2110,7 @@ spec:
         3. Select the i next to the Guest User
         4. Verify that Allow guests to log in to this computer is disable
   query: |
-    SELECT 1 WHERE
-    EXISTS(SELECT 1 FROM plist WHERE path='/Library/Preferences/com.apple.loginwindow.plist' AND key='GuestEnabled' AND value = 0)
-    OR
-    EXISTS(select 1 FROM plist WHERE path='/Library/Preferences/com.apple.MCX.plist' AND key='DisableGuestAccount' AND value = 1);
+    SELECT 1 FROM plist WHERE path='/Library/Preferences/com.apple.loginwindow.plist' AND key='GuestEnabled' AND value = 0;
   purpose: Informational
   tags: compliance, CIS, CIS_Level1
   contributors: sharon-fdm

--- a/it-and-security/lib/macos-device-health.policies.yml
+++ b/it-and-security/lib/macos-device-health.policies.yml
@@ -17,19 +17,7 @@
   resolution: An an IT admin, deploy a macOS, login window profile with the DisableGuestAccount option set to true.
   platform: darwin
 - name: macOS - Require 10 character password
-  query: SELECT 1 WHERE 
-    EXISTS (
-      SELECT 1 FROM managed_policies WHERE 
-        domain='com.apple.screensaver' AND 
-        name='askForPassword' AND 
-        CAST(value AS INT)
-    ) 
-    AND EXISTS (
-      SELECT 1 FROM managed_policies WHERE 
-        domain='com.apple.screensaver' AND 
-        name='minLength' AND 
-        CAST(value AS INT) <= 10
-    );
+  query: SELECT 1 FROM plist WHERE path='/Library/Preferences/com.apple.loginwindow.plist' AND key='GuestEnabled' AND value = 0;
   critical: false
   description: This policy checks if the end user is required to enter a password, with at least 10 characters, to unlock the host.
   resolution: An an IT admin, deploy a macOS, screensaver profile with the askForPassword option set to true and minLength option set to 10.

--- a/it-and-security/lib/macos-device-health.policies.yml
+++ b/it-and-security/lib/macos-device-health.policies.yml
@@ -10,7 +10,7 @@
   description: This policy checks if Firewall is enabled.
   resolution: An an IT admin, deploy a macOS, Firewall profile with the EnableFirewall option set to true.
   platform: darwin
-- name: macOS - Guest user account is disabled by profile
+- name: macOS - Disable guest account
   query: SELECT 1 FROM managed_policies WHERE domain='com.apple.loginwindow' AND username = '' AND name='DisableGuestAccount' AND CAST(value AS INT) = 1;
   critical: false
   description: This policy checks if the guest account is disabled.

--- a/it-and-security/lib/macos-device-health.policies.yml
+++ b/it-and-security/lib/macos-device-health.policies.yml
@@ -10,7 +10,7 @@
   description: This policy checks if Firewall is enabled.
   resolution: An an IT admin, deploy a macOS, Firewall profile with the EnableFirewall option set to true.
   platform: darwin
-- name: macOS - Disable guest account
+- name: macOS - Guest user account is disabled by profile
   query: SELECT 1 FROM managed_policies WHERE domain='com.apple.loginwindow' AND username = '' AND name='DisableGuestAccount' AND CAST(value AS INT) = 1;
   critical: false
   description: This policy checks if the guest account is disabled.


### PR DESCRIPTION
# Checklist for submitter

~~[This](https://github.com/fleetdm/fleet/blob/main/it-and-security/lib/macos-device-health.policies.yml#L13-L18) policy was renamed to "**Guest user account is disabled by profile**"~~

[CIS](https://github.com/fleetdm/fleet/blob/main/ee/cis/macos-13/cis-policy-queries.yml#L2099) policy was modified to check the real status of the Guest User and not whether a profile or rule exists to block it.

Same change was applied to the policy in dogfood.