### PR TITLE
Update macos-device-health.policies.yml

### DIFF
--- a/it-and-security/lib/macos-device-health.policies.yml
+++ b/it-and-security/lib/macos-device-health.policies.yml
@@ -11,12 +11,6 @@
   resolution: An an IT admin, deploy a macOS, Firewall profile with the EnableFirewall option set to true.
   platform: darwin
 - name: macOS - Disable guest account
-  query: SELECT 1 FROM managed_policies WHERE domain='com.apple.loginwindow' AND username = '' AND name='DisableGuestAccount' AND CAST(value AS INT) = 1;
-  critical: false
-  description: This policy checks if the guest account is disabled.
-  resolution: An an IT admin, deploy a macOS, login window profile with the DisableGuestAccount option set to true.
-  platform: darwin
-- name: macOS - Require 10 character password
   query: SELECT 1 WHERE
     EXISTS (
       SELECT 1 FROM plist WHERE 
@@ -29,6 +23,24 @@
         path='/Library/Preferences/com.apple.MCX.plist' AND 
         key='DisableGuestAccount' AND 
         value = 1
+    );
+  critical: false
+  description: This policy checks if the guest account is disabled.
+  resolution: An an IT admin, deploy a macOS, login window profile with the DisableGuestAccount option set to true.
+  platform: darwin
+- name: macOS - Require 10 character password
+  query: SELECT 1 WHERE 
+    EXISTS (
+      SELECT 1 FROM managed_policies WHERE 
+        domain='com.apple.screensaver' AND 
+        name='askForPassword' AND 
+        CAST(value AS INT)
+    ) 
+    AND EXISTS (
+      SELECT 1 FROM managed_policies WHERE 
+        domain='com.apple.screensaver' AND 
+        name='minLength' AND 
+        CAST(value AS INT) <= 10
     );
   critical: false
   description: This policy checks if the end user is required to enter a password, with at least 10 characters, to unlock the host.

--- a/it-and-security/lib/macos-device-health.policies.yml
+++ b/it-and-security/lib/macos-device-health.policies.yml
@@ -17,18 +17,18 @@
   resolution: An an IT admin, deploy a macOS, login window profile with the DisableGuestAccount option set to true.
   platform: darwin
 - name: macOS - Require 10 character password
-  query: SELECT 1 WHERE 
+  query: SELECT 1 WHERE
     EXISTS (
-      SELECT 1 FROM managed_policies WHERE 
-        domain='com.apple.screensaver' AND 
-        name='askForPassword' AND 
-        CAST(value AS INT)
-    ) 
-    AND EXISTS (
-      SELECT 1 FROM managed_policies WHERE 
-        domain='com.apple.screensaver' AND 
-        name='minLength' AND 
-        CAST(value AS INT) <= 10
+      SELECT 1 FROM plist WHERE 
+        path='/Library/Preferences/com.apple.loginwindow.plist' AND 
+        key='GuestEnabled' AND 
+        value = 0
+    )
+    OR EXISTS ( 
+      SELECT 1 FROM plist WHERE 
+        path='/Library/Preferences/com.apple.MCX.plist' AND 
+        key='DisableGuestAccount' AND 
+        value = 1
     );
   critical: false
   description: This policy checks if the end user is required to enter a password, with at least 10 characters, to unlock the host.


### PR DESCRIPTION
Related to #17196

- Update the "macOS - Disable guest account policy" to check for the actual status of guest account instead of checking whether a configuration profile was installed.
