### PR TITLE
Handle null bitlocker status in datastore method

### DIFF
--- a/changes/issue-17476-get-bitlocker-status
+++ b/changes/issue-17476-get-bitlocker-status
@@ -1,0 +1,2 @@
+- Fixed issue where getting host details failed when attempting to read the host's bitlocker status
+  from the datastore.

--- a/server/datastore/mysql/microsoft_mdm.go
+++ b/server/datastore/mysql/microsoft_mdm.go
@@ -666,6 +666,7 @@ SELECT
 		WHEN (%s) THEN '%s'
 		WHEN (%s) THEN '%s'
 		WHEN (%s) THEN '%s'
+		ELSE ''
 	END AS status,
 	COALESCE(client_error, '') as detail
 FROM
@@ -694,6 +695,12 @@ WHERE
 		}
 		// At this point we know disk encryption is enabled so if there are no rows for the
 		// host then we treat it as enforcing and log for potential debugging
+		level.Debug(ds.logger).Log("msg", "no bitlocker status found for host", "host_id", host.ID)
+		dest.Status = fleet.DiskEncryptionEnforcing
+	}
+
+	if dest.Status == "" {
+		// If we have no status, we treat it as enforcing since we know disk encryption is enabled and log for potential debugging
 		level.Debug(ds.logger).Log("msg", "no bitlocker status found for host", "host_id", host.ID)
 		dest.Status = fleet.DiskEncryptionEnforcing
 	}

--- a/server/service/integration_mdm_test.go
+++ b/server/service/integration_mdm_test.go
@@ -12473,3 +12473,23 @@ func (s *integrationMDMTestSuite) TestMDMDiskEncryptionIssue16636() {
 	assert.False(t, acResp.MDM.EnableDiskEncryption.Value)
 	s.assertConfigProfilesByIdentifier(nil, mobileconfig.FleetFileVaultPayloadIdentifier, false)
 }
+
+func (s *integrationMDMTestSuite) TestIsServerBitlockerStatus() {
+	t := s.T()
+	ctx := context.Background()
+
+	// create a server host that is not enrolled in MDM
+	host := createOrbitEnrolledHost(t, "windows", "server-host", s.ds)
+	require.NoError(t, s.ds.SetOrUpdateMDMData(ctx, host.ID, true, false, "", false, "", ""))
+
+	acResp := appConfigResponse{}
+	s.DoJSON("PATCH", "/api/latest/fleet/config", json.RawMessage(`{
+		"mdm": { "enable_disk_encryption": true }
+  }`), http.StatusOK, &acResp)
+	assert.True(t, acResp.MDM.EnableDiskEncryption.Value)
+
+	var hr getHostResponse
+	s.DoJSON("GET", fmt.Sprintf("/api/latest/fleet/hosts/%d", host.ID), nil, http.StatusOK, &hr)
+
+	require.Equal(t, fleet.DiskEncryptionEnforcing, *hr.Host.MDM.OSSettings.DiskEncryption.Status)
+}

--- a/server/service/integration_mdm_test.go
+++ b/server/service/integration_mdm_test.go
@@ -12478,7 +12478,7 @@ func (s *integrationMDMTestSuite) TestIsServerBitlockerStatus() {
 	t := s.T()
 	ctx := context.Background()
 
-	// create a server host that is not enrolled in MDM
+	// create a Windows host and report it as a server
 	host := createOrbitEnrolledHost(t, "windows", "server-host", s.ds)
 	require.NoError(t, s.ds.SetOrUpdateMDMData(ctx, host.ID, true, false, "", false, "", ""))
 
@@ -12491,5 +12491,5 @@ func (s *integrationMDMTestSuite) TestIsServerBitlockerStatus() {
 	var hr getHostResponse
 	s.DoJSON("GET", fmt.Sprintf("/api/latest/fleet/hosts/%d", host.ID), nil, http.StatusOK, &hr)
 
-	require.Equal(t, fleet.DiskEncryptionEnforcing, *hr.Host.MDM.OSSettings.DiskEncryption.Status)
+	require.Nil(t, hr.Host.MDM.OSSettings.DiskEncryption.Status)
 }


### PR DESCRIPTION
Revises bugfix #17541 that was previously merged main