### PR TITLE
Add script to workstations and canary

### DIFF
--- a/it-and-security/lib/macos-remove-old-nudge.sh
+++ b/it-and-security/lib/macos-remove-old-nudge.sh
@@ -1,0 +1,3 @@
+/bin/launchctl unload -w /Library/LaunchAgents/com.github.macadmins.Nudge.plist
+
+# Remove the old Nudge launch agent that was deployed by SimpleMDM. More info here: https://github.com/fleetdm/confidential/issues/5274

--- a/it-and-security/teams/workstations-canary.yml
+++ b/it-and-security/teams/workstations-canary.yml
@@ -50,6 +50,7 @@ controls:
   scripts:
     - path: ../lib/collect-fleetd-logs.sh
     - path: ../lib/macos-see-automatic-enrollment-profile.sh
+    - path: ../lib/macos-remove-old-nudge.sh
     - path: ../lib/windows-remove-fleetd.ps1
     - path: ../lib/windows-turn-off-mdm.ps1
 policies:

--- a/it-and-security/teams/workstations.yml
+++ b/it-and-security/teams/workstations.yml
@@ -50,6 +50,7 @@ controls:
   scripts:
     - path: ../lib/collect-fleetd-logs.sh
     - path: ../lib/macos-see-automatic-enrollment-profile.sh
+    - path: ../lib/macos-remove-old-nudge.sh
     - path: ../lib/windows-remove-fleetd.ps1
     - path: ../lib/windows-turn-off-mdm.ps1
 policies:


### PR DESCRIPTION
- Add script to remove the old Nudge launch agent (deployed by SimpleMDM)

Related to this "Some Fleet computers still have an old Nudge launcher from back when we used SimpleMDM" issue: #5274
