### PR TITLE
Website: update signup and login pages

### DIFF
--- a/website/assets/js/pages/entrance/login.page.js
+++ b/website/assets/js/pages/entrance/login.page.js
@@ -25,17 +25,6 @@ parasails.registerPage('login', {
     // Server error state for the form
     cloudError: '',
     showCustomerLogin: true,
-
-    // For redirecting users who come to this page from a /try-fleet/explore-data/* page back to the page they were visiting before they were redirected.
-    exploreDataRedirectSlug: undefined,
-    // Used for the 'create an account' link
-    registrationSlug: '/register',
-    // Possible /try-fleet/explore-data/ redirects
-    redirectSlugsByTargetPlatform: {
-      'macos': 'macos/account_policy_data',
-      'windows': 'windows/appcompat_shims',
-      'linux': 'linux/apparmor_events',
-    },
   },
 
   //  ╦  ╦╔═╗╔═╗╔═╗╦ ╦╔═╗╦  ╔═╗
@@ -44,18 +33,6 @@ parasails.registerPage('login', {
   beforeMount: function() {
     if(window.location.search === '?admin') {
       this.showCustomerLogin = false;
-    }
-    // If the user navigated to this page from an /explore-data page, we'll keep track of the page this user came from so we can redirect them, and we'll strip all query parameters from the URL.
-    if(window.location.search) {
-      // https://caniuse.com/mdn-api_urlsearchparams_get
-      let possibleSearchParamsToFilterBy = new URLSearchParams(window.location.search);
-      let posibleRedirect = possibleSearchParamsToFilterBy.get('targetPlatform');
-      // If the provided platform matches a key in the userFriendlyPlatformNames array, we'll set this.selectedPlatform.
-      if(posibleRedirect && this.redirectSlugsByTargetPlatform[posibleRedirect] !== undefined){
-        this.registrationSlug +=`?targetPlatform=${posibleRedirect}`;
-        this.exploreDataRedirectSlug = `/try-fleet/explore-data/${this.redirectSlugsByTargetPlatform[posibleRedirect]}`;
-      }
-      window.history.replaceState({}, document.title, '/login' );
     }
   },
   mounted: async function() {
@@ -68,16 +45,11 @@ parasails.registerPage('login', {
   methods: {
 
     submittedForm: async function() {
-      // Redirect to the logged-in dashboard on success.
+      // Redirect to the /start page on success.
       // > (Note that we re-enable the syncing state here.  This is on purpose--
       // > to make sure the spinner stays there until the page navigation finishes.)
       this.syncing = true;
-      if(this.exploreDataRedirectSlug){
-        window.location = this.exploreDataRedirectSlug;
-      } else {
-        window.location = '/start';
-      }
-
+      window.location = '/start';
     },
 
   }

--- a/website/assets/js/pages/entrance/signup.page.js
+++ b/website/assets/js/pages/entrance/signup.page.js
@@ -25,31 +25,15 @@ parasails.registerPage('signup', {
     cloudError: '',
     // For displaying the full signup form.
     showFullForm: false,
-    exploreDataRedirectSlug: undefined,
-    // Used for the 'I have an account' link
-    loginSlug: '/login',
-    // Possible /try-fleet/explore-data/ redirects
-    redirectSlugsByTargetPlatform: {
-      'macos': 'macos/account_policy_data',
-      'windows': 'windows/appcompat_shims',
-      'linux': 'linux/apparmor_events',
-    },
   },
 
   //  ╦  ╦╔═╗╔═╗╔═╗╦ ╦╔═╗╦  ╔═╗
   //  ║  ║╠╣ ║╣ ║  ╚╦╝║  ║  ║╣
   //  ╩═╝╩╚  ╚═╝╚═╝ ╩ ╚═╝╩═╝╚═╝
   beforeMount: function() {
-    // If the user navigated to this page from an /explore-data page, we'll keep track of the page this user came from so we can redirect them, and we'll strip all query parameters from the URL.
+    // Removing the query string for users redirected to this page by the /try-fleet/explore-data pages.
+    // FUTURE: remove this when that view-query-report is updated.
     if(window.location.search){
-      // https://caniuse.com/mdn-api_urlsearchparams_get
-      let possibleSearchParamsToFilterBy = new URLSearchParams(window.location.search);
-      let posibleRedirect = possibleSearchParamsToFilterBy.get('targetPlatform');
-      // If the provided platform matches a key in the userFriendlyPlatformNames array, we'll set this.selectedPlatform.
-      if(posibleRedirect && this.redirectSlugsByTargetPlatform[posibleRedirect] !== undefined){
-        this.loginSlug +=`?targetPlatform=${posibleRedirect}`;
-        this.exploreDataRedirectSlug = `/try-fleet/explore-data/${this.redirectSlugsByTargetPlatform[posibleRedirect]}`;
-      }
       window.history.replaceState({}, document.title, '/register' );
     }
   },
@@ -81,11 +65,7 @@ parasails.registerPage('signup', {
       // > (Note that we re-enable the syncing state here.  This is on purpose--
       // > to make sure the spinner stays there until the page navigation finishes.)
       this.syncing = true;
-      if(this.exploreDataRedirectSlug){
-        window.location = this.exploreDataRedirectSlug;
-      } else {
-        window.location = '/start';
-      }
+      window.location = '/start';
     }
 
 

--- a/website/views/pages/entrance/login.ejs
+++ b/website/views/pages/entrance/login.ejs
@@ -1,7 +1,7 @@
 <div id="login" v-cloak>
   <div :purpose="[showCustomerLogin ? 'customer-login-container' : 'login-container']" class="container-fluid pb-5 px-lg-0 px-3">
     <div purpose="page-heading" v-if="showCustomerLogin">
-      <h1>Welcome to Premium</h1>
+      <h1>Welcome to Fleet</h1>
       <p class="pb-2">We just need a few details in order to get started.</p>
     </div>
     <div purpose="page-heading" v-else>
@@ -12,7 +12,7 @@
       <ajax-form class="customers-login" action="login" :syncing.sync="syncing" :cloud-error.sync="cloudError" :form-data="formData" :form-rules="formRules" :form-errors.sync="formErrors" @submitted="submittedForm()">
         <div class="form-group">
           <label for="email">Email</label>
-          <span style="float: right" class="text-right small" v-if="showCustomerLogin"><a :href="registrationSlug">Create an account</a></span>
+          <span style="float: right" class="text-right small" v-if="showCustomerLogin"><a href="/register">Create an account</a></span>
           <input type="email" class="form-control" :class="[formErrors.emailAddress ? 'is-invalid' : '']" v-model.trim="formData.emailAddress" autocomplete="email" focus-first>
           <div class="invalid-feedback" v-if="formErrors.emailAddress">Please provide a valid email address.</div>
         </div>

--- a/website/views/pages/entrance/signup.ejs
+++ b/website/views/pages/entrance/signup.ejs
@@ -8,7 +8,7 @@
       <ajax-form action="signup" class="self-service-register" :syncing.sync="syncing" :cloud-error.sync="cloudError" :form-errors.sync="formErrors" :form-data="formData" :form-rules="formRules" @submitted="submittedSignUpForm()">
         <div class="form-group">
           <label for="email-address">Work email *</label>
-          <span style="float: right" class="text-right small"><a href="/customers/login">I have an account</a></span>
+          <span style="float: right" class="text-right small"><a href="/login">I have an account</a></span>
           <input class="form-control" id="email-address"  :class="[formErrors.emailAddress ? 'is-invalid' : '']" v-model.trim="formData.emailAddress" @input="typeClearOneFormError('emailAddress')">
           <div class="invalid-feedback" v-if="formErrors.emailAddress" focus-first>This doesn’t appear to be a valid email address</div>
         </div>
@@ -56,7 +56,7 @@
           </div>
         </div>
         <cloud-error v-if="cloudError==='emailAlreadyInUse'">
-          <p>This email is already linked to a Fleet account.<br> Please <a href="/customers/login">sign in</a> with your email and password.</p>
+          <p>This email is already linked to a Fleet account.<br> Please <a href="/login">sign in</a> with your email and password.</p>
         </cloud-error>
         <cloud-error v-else-if="cloudError === 'invalidEmailDomain'">
           <p>Please enter a valid work email address</p>


### PR DESCRIPTION

Changes:
- Removed the /try-fleet/explore-data redirects from the /login and /register pages.
- Updated the login links on /register to go to /login (previously /customers/login)
- Updated text on the /login page to say "Welcome to Fleet"