### PR TITLE
Calendar config API endpoints bug fixes.

### DIFF
--- a/ee/server/service/teams.go
+++ b/ee/server/service/teams.go
@@ -209,6 +209,15 @@ func (svc *Service) ModifyTeam(ctx context.Context, teamID uint, payload fleet.T
 
 		team.Config.Integrations.Jira = payload.Integrations.Jira
 		team.Config.Integrations.Zendesk = payload.Integrations.Zendesk
+		// Only update the google calendar integration if it's not nil
+		if payload.Integrations.GoogleCalendar != nil {
+			invalid := &fleet.InvalidArgumentError{}
+			_ = svc.validateTeamCalendarIntegrations(ctx, team, payload.Integrations.GoogleCalendar, appCfg, invalid)
+			if invalid.HasErrors() {
+				return nil, ctxerr.Wrap(ctx, invalid)
+			}
+			team.Config.Integrations.GoogleCalendar = payload.Integrations.GoogleCalendar
+		}
 	}
 
 	if payload.WebhookSettings != nil || payload.Integrations != nil {

--- a/server/service/appconfig.go
+++ b/server/service/appconfig.go
@@ -478,6 +478,10 @@ func (svc *Service) ModifyAppConfig(ctx context.Context, p []byte, applyOpts fle
 			}
 		}
 	}
+	// If google_calendar is null, we keep the existing setting. If it's not null, we update.
+	if newAppConfig.Integrations.GoogleCalendar == nil {
+		appConfig.Integrations.GoogleCalendar = oldAppConfig.Integrations.GoogleCalendar
+	}
 
 	if !license.IsPremium() {
 		// reset transparency url to empty for downgraded licenses

--- a/server/service/integration_enterprise_test.go
+++ b/server/service/integration_enterprise_test.go
@@ -1029,6 +1029,21 @@ func (s *integrationEnterpriseTestSuite) TestTeamEndpoints() {
 	modifyExpiry.HostExpirySettings.HostExpiryWindow = 0
 	s.DoJSON("PATCH", fmt.Sprintf("/api/latest/fleet/teams/%d", tm1ID), modifyExpiry, http.StatusUnprocessableEntity, &tmResp)
 
+	// Modify team's calendar config
+	modifyCalendar := fleet.TeamPayload{
+		Integrations: &fleet.TeamIntegrations{
+			GoogleCalendar: &fleet.TeamGoogleCalendarIntegration{
+				Email: "calendar@example.com",
+			},
+		},
+	}
+	s.DoJSON("PATCH", fmt.Sprintf("/api/latest/fleet/teams/%d", tm1ID), modifyCalendar, http.StatusOK, &tmResp)
+	assert.Equal(t, modifyCalendar.Integrations.GoogleCalendar, tmResp.Team.Config.Integrations.GoogleCalendar)
+
+	// Illegal team calendar config
+	modifyCalendar.Integrations.GoogleCalendar.Enable = true
+	s.DoJSON("PATCH", fmt.Sprintf("/api/latest/fleet/teams/%d", tm1ID), modifyCalendar, http.StatusUnprocessableEntity, &tmResp)
+
 	// list team users
 	var usersResp listUsersResponse
 	s.DoJSON("GET", fmt.Sprintf("/api/latest/fleet/teams/%d/users", tm1ID), nil, http.StatusOK, &usersResp)


### PR DESCRIPTION
Bug fixes for frontend
- google_calendar can be nil for global config to indicate that it should not change
- `fleet/teams/:id` endpoint now working
