### PR TITLE
Add redirect for use in the policies UI

### DIFF
--- a/website/config/routes.js
+++ b/website/config/routes.js
@@ -516,6 +516,7 @@ module.exports.routes = {
   'GET /learn-more-about/custom-os-settings': '/docs/using-fleet/mdm-custom-os-settings',
   'GET /learn-more-about/enrolling-hosts': '/docs/using-fleet/adding-hosts',
   'GET /learn-more-about/setup-assistant': '/docs/using-fleet/mdm-macos-setup-experience#macos-setup-assistant',
+  'GET /learn-more-about/policy-automations': '/docs/using-fleet/automations',
 
   // Sitemap
   // =============================================================================================================


### PR DESCRIPTION
Currently the policies UI links directly to the docs, but going forward we're adding redirects for pages linked to from the Fleet UI, to make it easier to keep those links up-to-date.

Since we're making changes to the policies UI right now, updating this one.