### PR TITLE
Handbook: Open position: Typo fix: Upper-case the 'e' in 'experience'.

### DIFF
--- a/handbook/company/open-positions.yml
+++ b/handbook/company/open-positions.yml
@@ -50,7 +50,7 @@
       - 🗓️ Schedule travel arrangements for the CEO and other executives as needed.
       - ✍️ Help implement and drive change management for any new or modified processes and tools across the team and/or the organization.
       - 📣 Record and communicate relevant information and decisions to the Digital Experience team and other departments. 
-      - 📈 Collect and report Digital experience KPIs.
+      - 📈 Collect and report Digital Experience KPIs.
   experience: |
       - 🏃‍♂️ Strong desire to build a technical and operational-based skill set.
       - 🚀 Detail-oriented, highly organized, and able to move quickly to solve complex problems using boring solutions.


### PR DESCRIPTION
Updated line# 53: Upper-case the 'e' in 'experience'.


