### PR TITLE
Update Supported-host-operating-systems.md

### DIFF
--- a/docs/Using Fleet/Supported-host-operating-systems.md
+++ b/docs/Using Fleet/Supported-host-operating-systems.md
@@ -1,5 +1,3 @@
-
-
 # Supported host operating systems
 
 Fleet supports the following operating system versions on hosts. 
@@ -26,6 +24,8 @@ The osquery installer generated for MacOS by `fleetctl package` does not include
 ### Linux
 The osquery installer will run on Linux distributions where `glibc` is >= 2.2 (there is ongoing work to make osquery work with `glibc` 2.12+).
 If you aren't sure what version of `glibc` your distribution is using, [DistroWatch](https://distrowatch.com/) is a great resource. 
+
+> On Ubuntu, Fleet Desktop only supports display `0`.
 
 > Fedora, CentOS 8 and 9 require a [gnome extension](https://extensions.gnome.org/extension/615/appindicator-support/) and Google Chrome set to the default browser for Fleet Desktop.
 

--- a/docs/Using Fleet/Supported-host-operating-systems.md
+++ b/docs/Using Fleet/Supported-host-operating-systems.md
@@ -25,7 +25,7 @@ The osquery installer generated for MacOS by `fleetctl package` does not include
 The osquery installer will run on Linux distributions where `glibc` is >= 2.2 (there is ongoing work to make osquery work with `glibc` 2.12+).
 If you aren't sure what version of `glibc` your distribution is using, [DistroWatch](https://distrowatch.com/) is a great resource. 
 
-> On Ubuntu, Fleet Desktop only supports display `0`.
+> On Linux, Fleet Desktop only supports $DISPLAY `:0`.
 
 > Fedora, CentOS 8 and 9 require a [gnome extension](https://extensions.gnome.org/extension/615/appindicator-support/) and Google Chrome set to the default browser for Fleet Desktop.
 


### PR DESCRIPTION
For the following bug: #12334

- Call out that, currently on Ubuntu, Fleet Desktop only supports display number of `0`

We tracked a separate [user story here](https://github.com/fleetdm/fleet/issues/17660) to add support for other display numbers (ex. `1`).
