### PR TITLE
Fleet UI: Add reset results warning for modifying platform or min osquery version

### DIFF
--- a/frontend/pages/queries/edit/components/EditQueryForm/EditQueryForm.tsx
+++ b/frontend/pages/queries/edit/components/EditQueryForm/EditQueryForm.tsx
@@ -637,10 +637,19 @@ const EditQueryForm = ({
     "differential",
     "differential_ignore_removals",
   ].includes(lastEditedQueryLoggingType);
-  // TODO: Account for equivalent platforms "linux,darwin" = "darwin,linux"
-  // TODO: Find out if "linux, darwin" is equivalent to "linux,darwin" and both work in backend
+
+  // Note: The backend is not resetting the query reports with equivalent platform strings
+  // so we are not showing a warning unless the platform combinations differ
+  const formatPlatformEquivalences = (platforms?: string) => {
+    // Remove white spaces allowed by API and format into a sorted string converted from a sorted array
+    return platforms?.replace(/\s/g, "").split(",").sort().toString();
+  };
+
   const changedPlatforms =
-    storedQuery && lastEditedQueryPlatforms !== storedQuery.platform;
+    storedQuery &&
+    formatPlatformEquivalences(lastEditedQueryPlatforms) !==
+      formatPlatformEquivalences(storedQuery?.platform);
+
   const changedMinOsqueryVersion =
     storedQuery &&
     lastEditedQueryMinOsqueryVersion !== storedQuery.min_osquery_version;
@@ -671,6 +680,7 @@ const EditQueryForm = ({
     const disableSaveFormErrors =
       (lastEditedQueryName === "" && !!lastEditedQueryId) || !!size(errors);
 
+    console.log("lastEditedQueryPlatforms", lastEditedQueryPlatforms);
     return (
       <>
         <form className={`${baseClass}`} autoComplete="off">
@@ -735,7 +745,7 @@ const EditQueryForm = ({
                     placeholder="Select"
                     label="Platform"
                     onChange={onChangeSelectPlatformOptions}
-                    value={lastEditedQueryPlatforms}
+                    value={lastEditedQueryPlatforms.replace(/\s/g, "")} // NOTE: FE requires no whitespace to render UI
                     multi
                     wrapperClassName={`${baseClass}__form-field form-field--platform`}
                     helpText="By default, your query collects data on all compatible platforms."


### PR DESCRIPTION
## Issue
FE of #17018

## Description
- Warning modal for users when updating the platform or minimum osquery version of a query

## Recording
https://www.loom.com/share/698e75a3d70f460799ed3c7458906cdc?sid=2133e4ae-04de-47ac-ad7c-77e78dbf5e06

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- Changes file on feature branch
- [x] Manual QA for all new/changed functionality
