### PR TITLE
Fleet UI: Users can see a tooltip on a disabled checkbox

### DIFF
--- a/changes/16345-disabled-checkbox-tooltip
+++ b/changes/16345-disabled-checkbox-tooltip
@@ -1,0 +1,1 @@
+- UI fix: users can see a tooltip on a disabled checkbox

--- a/frontend/components/forms/fields/Checkbox/Checkbox.tsx
+++ b/frontend/components/forms/fields/Checkbox/Checkbox.tsx
@@ -55,21 +55,26 @@ const Checkbox = (props: ICheckboxProps) => {
     className,
     baseClass
   );
+
+  const checkBoxTickClass = classnames(`${baseClass}__tick`, {
+    [`${baseClass}__tick--disabled`]: disabled,
+    [`${baseClass}__tick--indeterminate`]: indeterminate,
+  });
+
+  const checkBoxLabelClass = classnames(checkBoxClass, {
+    [`${baseClass}__label--disabled`]: disabled,
+  });
+
   const formFieldProps = {
     ...pick(props, ["helpText", "label", "error", "name"]),
     className: wrapperClassName,
     type: "checkbox",
   } as IFormFieldProps;
 
-  const checkBoxTickClass = classnames(`${checkBoxClass}__tick`, {
-    [`${checkBoxClass}__tick--disabled`]: disabled,
-    [`${checkBoxClass}__tick--indeterminate`]: indeterminate,
-  });
-
   return (
     <FormField {...formFieldProps}>
       <>
-        <label htmlFor={name} className={checkBoxClass}>
+        <label htmlFor={name} className={checkBoxLabelClass}>
           <input
             checked={value}
             className={`${baseClass}__input`}

--- a/frontend/components/forms/fields/Checkbox/_styles.scss
+++ b/frontend/components/forms/fields/Checkbox/_styles.scss
@@ -29,7 +29,7 @@
           
       &--disabled {
         &::after {
-          @include disabled;
+          @include disabled-checkbox;
         }
       }
 

--- a/frontend/components/forms/fields/Checkbox/_styles.scss
+++ b/frontend/components/forms/fields/Checkbox/_styles.scss
@@ -26,10 +26,12 @@
         &::after {
           background-color: $core-vibrant-blue-over;
           border: solid 2px $core-vibrant-blue-over;
-          
-      &--disabled {
-        &::after {
-          @include disabled-checkbox;
+
+          &--disabled {
+            &::after {
+              @include disabled-checkbox;
+            }
+          }
         }
       }
 

--- a/frontend/components/forms/fields/Checkbox/_styles.scss
+++ b/frontend/components/forms/fields/Checkbox/_styles.scss
@@ -26,6 +26,10 @@
         &::after {
           background-color: $core-vibrant-blue-over;
           border: solid 2px $core-vibrant-blue-over;
+          
+      &--disabled {
+        &::after {
+          @include disabled;
         }
       }
 
@@ -109,6 +113,10 @@
     padding-left: $pad-small;
     display: inline-block;
     vertical-align: top;
+
+    &--disabled {
+      color: $ui-fleet-black-50;
+    }
   }
 
   &__label-tooltip {

--- a/frontend/components/forms/fields/Checkbox/_styles.scss
+++ b/frontend/components/forms/fields/Checkbox/_styles.scss
@@ -45,6 +45,7 @@
         border-top: 0;
         border-left: 0;
         content: "";
+        z-index: 9;
       }
     }
   }

--- a/frontend/components/forms/fields/Checkbox/_styles.scss
+++ b/frontend/components/forms/fields/Checkbox/_styles.scss
@@ -26,11 +26,17 @@
         &::after {
           background-color: $core-vibrant-blue-over;
           border: solid 2px $core-vibrant-blue-over;
+        }
+      }
 
-          &--disabled {
-            &::after {
-              @include disabled-checkbox;
-            }
+      &--disabled {
+        &::after {
+          @include disabled-checkbox;
+        }
+
+        &:hover {
+          &::after {
+            @include disabled-checkbox;
           }
         }
       }

--- a/frontend/pages/admin/TeamManagementPage/TeamDetailsWrapper/TeamSettings/components/TeamHostExpiryToggle/TeamHostExpiryToggle.tsx
+++ b/frontend/pages/admin/TeamManagementPage/TeamDetailsWrapper/TeamSettings/components/TeamHostExpiryToggle/TeamHostExpiryToggle.tsx
@@ -49,31 +49,25 @@ const TeamHostExpiryToggle = ({
         name="enableHostExpiry"
         onChange={setTeamExpiryEnabled}
         value={teamExpiryEnabled || globalHostExpiryEnabled}
-        wrapperClassName={
-          globalHostExpiryEnabled
-            ? `${baseClass}__disabled-team-host-expiry-toggle`
-            : ""
-        }
+        disabled={globalHostExpiryEnabled}
         helpText={renderHelpText()}
         tooltipContent={
-          !globalHostExpiryEnabled && (
-            <>
-              When enabled, allows automatic cleanup of
+          <>
+            When enabled, allows automatic cleanup of
+            <br />
+            hosts that have not communicated with Fleet in
+            <br />
+            the number of days specified in the{" "}
+            <strong>
+              Host expiry
               <br />
-              hosts that have not communicated with Fleet in
-              <br />
-              the number of days specified in the{" "}
-              <strong>
-                Host expiry
-                <br />
-                window
-              </strong>{" "}
-              setting.{" "}
-              <em>
-                (Default: <strong>Off</strong>)
-              </em>
-            </>
-          )
+              window
+            </strong>{" "}
+            setting.{" "}
+            <em>
+              (Default: <strong>Off</strong>)
+            </em>
+          </>
         }
       >
         Enable host expiry

--- a/frontend/pages/admin/TeamManagementPage/TeamDetailsWrapper/TeamSettings/components/TeamHostExpiryToggle/TeamHostExpiryToggle.tsx
+++ b/frontend/pages/admin/TeamManagementPage/TeamDetailsWrapper/TeamSettings/components/TeamHostExpiryToggle/TeamHostExpiryToggle.tsx
@@ -48,7 +48,7 @@ const TeamHostExpiryToggle = ({
       <Checkbox
         name="enableHostExpiry"
         onChange={setTeamExpiryEnabled}
-        value={teamExpiryEnabled || globalHostExpiryEnabled} // Disabled but still shows checkmark if global expiry is enabled.
+        value={teamExpiryEnabled || globalHostExpiryEnabled} // Still shows checkmark if global expiry is enabled though the checkbox will be disabled.
         disabled={globalHostExpiryEnabled}
         helpText={renderHelpText()}
         tooltipContent={

--- a/frontend/pages/admin/TeamManagementPage/TeamDetailsWrapper/TeamSettings/components/TeamHostExpiryToggle/TeamHostExpiryToggle.tsx
+++ b/frontend/pages/admin/TeamManagementPage/TeamDetailsWrapper/TeamSettings/components/TeamHostExpiryToggle/TeamHostExpiryToggle.tsx
@@ -48,7 +48,7 @@ const TeamHostExpiryToggle = ({
       <Checkbox
         name="enableHostExpiry"
         onChange={setTeamExpiryEnabled}
-        value={teamExpiryEnabled || globalHostExpiryEnabled}
+        value={teamExpiryEnabled || globalHostExpiryEnabled} // Disabled but still shows checkmark if global expiry is enabled.
         disabled={globalHostExpiryEnabled}
         helpText={renderHelpText()}
         tooltipContent={

--- a/frontend/pages/admin/TeamManagementPage/TeamDetailsWrapper/TeamSettings/components/TeamHostExpiryToggle/_styles.scss
+++ b/frontend/pages/admin/TeamManagementPage/TeamDetailsWrapper/TeamSettings/components/TeamHostExpiryToggle/_styles.scss
@@ -1,8 +1,4 @@
 .team-host-expiry-toggle {
-  &__disabled-team-host-expiry-toggle > .fleet-checkbox {
-    @include disabled;
-  }
-
   &__add-custom-window {
     display: inline-flex;
     align-items: center;

--- a/frontend/styles/var/mixins.scss
+++ b/frontend/styles/var/mixins.scss
@@ -117,6 +117,13 @@ $max-width: 2560px;
   cursor: default;
 }
 
+@mixin disabled-checkbox {
+  background-color: $ui-fleet-black-25;
+  border-color: $ui-fleet-black-25;
+  pointer-events: none;
+  cursor: default;
+}
+
 @mixin grey-text {
   color: $ui-fleet-black-75;
 }


### PR DESCRIPTION
## Issue
Cerra #16345 

## Description
- Update team expiry checkbox to be disabled but still see a tooltip
- Global fix to disabled checkbox

## Screenrecording

https://www.loom.com/share/1abb1219ead7454c8d61b219887e2d20?sid=30e9acfb-bfe7-4458-97f9-40dedf9266e6

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
- [x] Manual QA for all new/changed functionality

