### PR TITLE
Website: Update tooltips on pricing page

### DIFF
--- a/website/assets/js/pages/pricing.page.js
+++ b/website/assets/js/pages/pricing.page.js
@@ -18,7 +18,7 @@ parasails.registerPage('pricing', {
     // Tooltips for desktop users are opened by a user hovering their cursor over them.
     $('[data-toggle="tooltip"]').tooltip({
       container: '#pricing',
-      trigger: 'hover focus',
+      trigger: 'hover',
     });
   },
 


### PR DESCRIPTION
Closes: https://github.com/fleetdm/confidential/issues/5759

Changes:
- Updated the tooltips on the pricing page to close when a user is no longer hovering their cursor over them.