### PR TITLE
improve mdmtest package to handle any kind of command

### DIFF
--- a/pkg/mdm/mdmtest/apple.go
+++ b/pkg/mdm/mdmtest/apple.go
@@ -31,7 +31,6 @@ import (
 	httptransport "github.com/go-kit/kit/transport/http"
 	"github.com/google/uuid"
 	"github.com/groob/plist"
-	micromdm "github.com/micromdm/micromdm/mdm/mdm"
 	"go.mozilla.org/pkcs7"
 )
 
@@ -421,7 +420,7 @@ func (c *TestAppleMDMClient) Checkout() error {
 // receive commands. The server can signal back with either a command to run
 // or an empty (nil, nil) response body to end the communication
 // (i.e. no commands to run).
-func (c *TestAppleMDMClient) Idle() (*micromdm.CommandPayload, error) {
+func (c *TestAppleMDMClient) Idle() (*mdm.Command, error) {
 	payload := map[string]any{
 		"Status":       "Idle",
 		"Topic":        "com.apple.mgmt.External." + c.UUID,
@@ -437,7 +436,7 @@ func (c *TestAppleMDMClient) Idle() (*micromdm.CommandPayload, error) {
 // The server can signal back with either a command to run
 // or an empty (nil, nil) response body to end the communication
 // (i.e. no commands to run).
-func (c *TestAppleMDMClient) Acknowledge(cmdUUID string) (*micromdm.CommandPayload, error) {
+func (c *TestAppleMDMClient) Acknowledge(cmdUUID string) (*mdm.Command, error) {
 	payload := map[string]any{
 		"Status":       "Acknowledged",
 		"Topic":        "com.apple.mgmt.External." + c.UUID,
@@ -490,7 +489,7 @@ func (c *TestAppleMDMClient) GetBootstrapToken() ([]byte, error) {
 // The server can signal back with either a command to run
 // or an empty (nil, nil) response body to end the communication
 // (i.e. no commands to run).
-func (c *TestAppleMDMClient) Err(cmdUUID string, errChain []mdm.ErrorChain) (*micromdm.CommandPayload, error) {
+func (c *TestAppleMDMClient) Err(cmdUUID string, errChain []mdm.ErrorChain) (*mdm.Command, error) {
 	payload := map[string]any{
 		"Status":       "Error",
 		"Topic":        "com.apple.mgmt.External." + c.UUID,
@@ -502,7 +501,7 @@ func (c *TestAppleMDMClient) Err(cmdUUID string, errChain []mdm.ErrorChain) (*mi
 	return c.sendAndDecodeCommandResponse(payload)
 }
 
-func (c *TestAppleMDMClient) sendAndDecodeCommandResponse(payload map[string]any) (*micromdm.CommandPayload, error) {
+func (c *TestAppleMDMClient) sendAndDecodeCommandResponse(payload map[string]any) (*mdm.Command, error) {
 	res, err := c.request("", payload)
 	if err != nil {
 		return nil, fmt.Errorf("request error: %w", err)
@@ -527,7 +526,7 @@ func (c *TestAppleMDMClient) sendAndDecodeCommandResponse(payload map[string]any
 	if err != nil {
 		return nil, fmt.Errorf("decode command: %w", err)
 	}
-	var p micromdm.CommandPayload
+	var p mdm.Command
 	err = plist.Unmarshal(cmd.Raw, &p)
 	if err != nil {
 		return nil, fmt.Errorf("unmarshal command payload: %w", err)

--- a/pkg/mdm/mdmtest/apple.go
+++ b/pkg/mdm/mdmtest/apple.go
@@ -531,6 +531,7 @@ func (c *TestAppleMDMClient) sendAndDecodeCommandResponse(payload map[string]any
 	if err != nil {
 		return nil, fmt.Errorf("unmarshal command payload: %w", err)
 	}
+	p.Raw = cmd.Raw
 	return &p, nil
 }
 

--- a/server/service/apple_mdm_test.go
+++ b/server/service/apple_mdm_test.go
@@ -2705,6 +2705,17 @@ func TestMDMApplePreassignEndpoints(t *testing.T) {
 	}
 }
 
+func declarationForTest(identifier string) []byte {
+	return []byte(fmt.Sprintf(`
+{
+    "Type": "com.apple.configuration.management.test",
+    "Payload": {
+        "Echo": "foo"
+    },
+    "Identifier": "%s"
+}`, identifier))
+}
+
 func mobileconfigForTest(name, identifier string) []byte {
 	return []byte(fmt.Sprintf(`<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">

--- a/server/service/apple_mdm_test.go
+++ b/server/service/apple_mdm_test.go
@@ -2705,17 +2705,6 @@ func TestMDMApplePreassignEndpoints(t *testing.T) {
 	}
 }
 
-func declarationForTest(identifier string) []byte {
-	return []byte(fmt.Sprintf(`
-{
-    "Type": "com.apple.configuration.management.test",
-    "Payload": {
-        "Echo": "foo"
-    },
-    "Identifier": "%s"
-}`, identifier))
-}
-
 func mobileconfigForTest(name, identifier string) []byte {
 	return []byte(fmt.Sprintf(`<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">

--- a/server/service/integration_mdm_test.go
+++ b/server/service/integration_mdm_test.go
@@ -1273,7 +1273,7 @@ func checkNextPayloads(t *testing.T, mdmDevice *mdmtest.TestAppleMDMClient, forc
 			break
 		}
 
-		var fullCmd *micromdm.CommandPayload
+		var fullCmd micromdm.CommandPayload
 		require.NoError(t, plist.Unmarshal(cmd.Raw, &fullCmd))
 		switch cmd.Command.RequestType {
 		case "InstallProfile":
@@ -5875,7 +5875,7 @@ func (s *integrationMDMTestSuite) TestBootstrapPackageStatus() {
 		cmd, err := d.device.Idle()
 		require.NoError(t, err)
 		for cmd != nil {
-			var fullCmd *micromdm.CommandPayload
+			var fullCmd micromdm.CommandPayload
 			require.NoError(t, plist.Unmarshal(cmd.Raw, &fullCmd))
 
 			// if the command is to install the bootstrap package
@@ -11576,7 +11576,7 @@ func (s *integrationMDMTestSuite) TestManualEnrollmentCommands() {
 		cmd, err := mdmDevice.Idle()
 		require.NoError(t, err)
 		for cmd != nil {
-			var fullCmd *micromdm.CommandPayload
+			var fullCmd micromdm.CommandPayload
 			require.NoError(t, plist.Unmarshal(cmd.Raw, &fullCmd))
 			if manifest := fullCmd.Command.InstallEnterpriseApplication.ManifestURL; manifest != nil {
 				foundInstallFleetdCommand = true
@@ -12255,7 +12255,7 @@ func (s *integrationMDMTestSuite) TestDontIgnoreAnyProfileErrors() {
 	for cmd != nil {
 		if cmd.Command.RequestType == "RemoveProfile" {
 			var errChain []mdm.ErrorChain
-			var fullCmd *micromdm.CommandPayload
+			var fullCmd micromdm.CommandPayload
 			require.NoError(t, plist.Unmarshal(cmd.Raw, &fullCmd))
 
 			if fullCmd.Command.RemoveProfile.Identifier == "I1" {
@@ -12399,8 +12399,8 @@ func (s *integrationMDMTestSuite) TestSCEPCertExpiration() {
 			require.NoError(t, err)
 		}
 		require.NotNil(t, renewCmd)
-		var fullCmd *micromdm.CommandPayload
-		require.NoError(t, plist.Unmarshal(cmd.Raw, &fullCmd))
+		var fullCmd micromdm.CommandPayload
+		require.NoError(t, plist.Unmarshal(renewCmd.Raw, &fullCmd))
 		s.verifyEnrollmentProfile(fullCmd.Command.InstallProfile.Payload, enrollRef)
 	}
 

--- a/server/service/integration_mdm_test.go
+++ b/server/service/integration_mdm_test.go
@@ -11581,7 +11581,7 @@ func (s *integrationMDMTestSuite) TestManualEnrollmentCommands() {
 			if manifest := fullCmd.Command.InstallEnterpriseApplication.ManifestURL; manifest != nil {
 				foundInstallFleetdCommand = true
 				require.Equal(t, "InstallEnterpriseApplication", cmd.Command.RequestType)
-				require.Contains(t, manifest, apple_mdm.FleetdPublicManifestURL)
+				require.Contains(t, *fullCmd.Command.InstallEnterpriseApplication.ManifestURL, apple_mdm.FleetdPublicManifestURL)
 			}
 			cmd, err = mdmDevice.Acknowledge(cmd.CommandUUID)
 			require.NoError(t, err)


### PR DESCRIPTION
it delegates any extra unmarshaling to the caller. We might consider building our own types in the future instead of relying on micromdm, but these are used only for tests right now.