### PR TITLE
Fleet UI: Persist toast messages after a modal closes

### DIFF
--- a/changes/17624-modal-flash-message-error
+++ b/changes/17624-modal-flash-message-error
@@ -1,0 +1,1 @@
+* Fix flash message from closing when a modal closes

--- a/frontend/components/Modal/Modal.tsx
+++ b/frontend/components/Modal/Modal.tsx
@@ -1,6 +1,5 @@
-import React, { useContext, useEffect } from "react";
+import React, { useEffect } from "react";
 import classnames from "classnames";
-import { NotificationContext } from "context/notification";
 import Button from "components/buttons/Button/Button";
 import Icon from "components/Icon/Icon";
 
@@ -32,8 +31,6 @@ const Modal = ({
   isLoading = false,
   className,
 }: IModalProps): JSX.Element => {
-  const { hideFlash } = useContext(NotificationContext);
-
   useEffect(() => {
     const closeWithEscapeKey = (e: KeyboardEvent) => {
       if (e.key === "Escape") {

--- a/frontend/components/Modal/Modal.tsx
+++ b/frontend/components/Modal/Modal.tsx
@@ -41,7 +41,6 @@ const Modal = ({
       }
     };
 
-    hideFlash();
     document.addEventListener("keydown", closeWithEscapeKey);
 
     return () => {


### PR DESCRIPTION
## Issue
Cerra #17624 

## Description
- Persist flash message even when a modal closes

Note: I don't know why this recently broke, maybe the update to React, but the hide flash shouldn't have been in the onExit a modal call anywho.


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
- [x] Manual QA for all new/changed functionality
