### PR TITLE
Vulnerability dashboard: Add a way to start a local vulnerability dashboard with Docker

### DIFF
--- a/ee/vulnerability-dashboard/.dockerignore
+++ b/ee/vulnerability-dashboard/.dockerignore
@@ -1,0 +1,2 @@
+node_modules/
+npm-debug.log

--- a/ee/vulnerability-dashboard/Dockerfile
+++ b/ee/vulnerability-dashboard/Dockerfile
@@ -28,7 +28,7 @@ COPY entrypoint.sh /usr/src/app/entrypoint.sh
 # Make sure the entrypoint script is executable
 RUN chmod +x /usr/src/app/entrypoint.sh
 
-# Expose the port the app runs on
+# Expose the port the vulnerability dashboard runs on
 EXPOSE 1337
 
 # Set the entrypoint script as the entry point

--- a/ee/vulnerability-dashboard/Dockerfile
+++ b/ee/vulnerability-dashboard/Dockerfile
@@ -1,0 +1,35 @@
+# Use the official Node.js 14 image as a base
+FROM node:20
+
+# Set the working directory in the container
+WORKDIR /usr/src/app
+
+# Copy the package.json
+COPY package.json ./
+
+# Install vulnerability dashboard dependencies
+RUN npm install
+
+# Copy the vulnerability dashboard into the container
+COPY . .
+
+# Install cron on the Docker image
+RUN apt-get update && apt-get install -y cron
+
+# Add the crontab file for the update reports script to the cron directory
+ADD crontab /etc/cron.d/update-reports-cron
+
+# Give execution rights on the cron job and apply it
+RUN chmod 0644 /etc/cron.d/update-reports-cron && crontab /etc/cron.d/update-reports-cron
+
+# Copy the entrypoint script into the container
+COPY entrypoint.sh /usr/src/app/entrypoint.sh
+
+# Make sure the entrypoint script is executable
+RUN chmod +x /usr/src/app/entrypoint.sh
+
+# Expose the port the app runs on
+EXPOSE 1337
+
+# Set the entrypoint script as the entry point
+ENTRYPOINT ["/usr/src/app/entrypoint.sh"]

--- a/ee/vulnerability-dashboard/README.md
+++ b/ee/vulnerability-dashboard/README.md
@@ -26,7 +26,6 @@ f.k.a. "scooper"
 Original raw notes and context: (private google doc since it contains competitor information: https://docs.google.com/document/d/1ByNWY6n_C-rvL75lI6jca2OniHt5FqA5_nYMf61S0pM/edit#)
 
 
-
 ## Running the vulnerability dashboard with Docker.
 
 To run a local vulnerability dashboard with docker, you can follow these instructions.
@@ -52,3 +51,13 @@ To run a local vulnerability dashboard with docker, you can follow these instruc
   >- Email address: `admin@example.com`
   >
   >- Password: `abc123`
+
+## How it's made
+
+This is a [Sails v1](https://sailsjs.com) application:
++ [Sails framework documentation](https://sailsjs.com/get-started)
++ [Version notes / upgrading](https://sailsjs.com/documentation/upgrading)
++ [Deployment tips](https://sailsjs.com/documentation/concepts/deployment)
++ [Community support options](https://sailsjs.com/support)
++ **Version info**: This app was originally generated on Sat Dec 10 2022 15:56:06 GMT-0600 (Central Standard Time) using Sails v1.5.3.  <!-- Internally, Sails used [`sails-generate@2.0.7`](https://github.com/balderdashy/sails-generate/tree/v2.0.7/lib/core-generators/new). -->
++ This project's boilerplate is based on an expanded seed app provided by the [Sails core team](https://sailsjs.com/about) to make it easier for you to build on top of ready-made features like authentication, enrollment, email verification, and billing.  <!-- Note:  Generators are usually run using the globally-installed `sails` CLI (command-line interface).  This CLI version is _environment-specific_ rather than app-specific, thus over time, as a project's dependencies are upgraded or the project is worked on by different developers on different computers using different versions of Node.js, the Sails dependency in its package.json file may differ from the globally-installed Sails CLI release it was originally generated with.  (Be sure to always check out the relevant [upgrading guides](https://sailsjs.com/upgrading) before upgrading the version of Sails used by your app.  If you're stuck, [get help here](https://sailsjs.com/support).) -->

--- a/ee/vulnerability-dashboard/README.md
+++ b/ee/vulnerability-dashboard/README.md
@@ -26,13 +26,22 @@ f.k.a. "scooper"
 Original raw notes and context: (private google doc since it contains competitor information: https://docs.google.com/document/d/1ByNWY6n_C-rvL75lI6jca2OniHt5FqA5_nYMf61S0pM/edit#)
 
 
-## How it's made
 
-This is a [Sails v1](https://sailsjs.com) application:
-+ [Sails framework documentation](https://sailsjs.com/get-started)
-+ [Version notes / upgrading](https://sailsjs.com/documentation/upgrading)
-+ [Deployment tips](https://sailsjs.com/documentation/concepts/deployment)
-+ [Community support options](https://sailsjs.com/support)
-+ **Version info**: This app was originally generated on Sat Dec 10 2022 15:56:06 GMT-0600 (Central Standard Time) using Sails v1.5.3.  <!-- Internally, Sails used [`sails-generate@2.0.7`](https://github.com/balderdashy/sails-generate/tree/v2.0.7/lib/core-generators/new). -->
-+ This project's boilerplate is based on an expanded seed app provided by the [Sails core team](https://sailsjs.com/about) to make it easier for you to build on top of ready-made features like authentication, enrollment, email verification, and billing.  <!-- Note:  Generators are usually run using the globally-installed `sails` CLI (command-line interface).  This CLI version is _environment-specific_ rather than app-specific, thus over time, as a project's dependencies are upgraded or the project is worked on by different developers on different computers using different versions of Node.js, the Sails dependency in its package.json file may differ from the globally-installed Sails CLI release it was originally generated with.  (Be sure to always check out the relevant [upgrading guides](https://sailsjs.com/upgrading) before upgrading the version of Sails used by your app.  If you're stuck, [get help here](https://sailsjs.com/support).) -->
+## Running a vulnerability dashboard with Docker.
 
+To run a local vulnerability dashboard with docker, you can follow these instructions.
+
+1. Clone this repo
+2. Update the following ENV variables `ee/vulnerability-dashboard/docker-compose.yml` file:
+  1. `sails_custom__fleetBaseUrl`: The full URL of your Fleet instance. (e.g., https://fleet.example.com)
+  2. `sails_custom__fleetApiToken`: AN API token for an API-only user on your Fleet instance.
+  > You can read about how to create an API-only user and get it's token [here](https://fleetdm.com/docs/using-fleet/fleetctl-cli#create-api-only-user)
+3. Open the `ee/vulnerability-dashboard/` folder in your terminal
+4. Run `docker compose up --build` to build the vulnerability dashboard's Docker image.
+> The first time the vulnerability dashboard starts it will:
+  1. Initalize the database
+  2. Run the `update-reports` script.
+5. Once the container is done building, the vulnerability dashboard will be available at http://localhost:1337
+  You can login with the default admin login:
+    - Email address: `admin@example.com`
+    - Password: `abc123`

--- a/ee/vulnerability-dashboard/README.md
+++ b/ee/vulnerability-dashboard/README.md
@@ -27,7 +27,7 @@ Original raw notes and context: (private google doc since it contains competitor
 
 
 
-## Running a vulnerability dashboard with Docker.
+## Running the vulnerability dashboard with Docker.
 
 To run a local vulnerability dashboard with docker, you can follow these instructions.
 
@@ -43,11 +43,7 @@ To run a local vulnerability dashboard with docker, you can follow these instruc
 3. Open the `ee/vulnerability-dashboard/` folder in your terminal
 4. Run `docker compose up --build` to build the vulnerability dashboard's Docker image.
 
-  > The first time the vulnerability dashboard starts it will:
-
-  1. Initalize the database
-
-  2. Run the `update-reports` script.
+  > The first time the vulnerability dashboard starts it will Initalize the database and run the `update-reports` script before the server starts.
 
 5. Once the container is done building, the vulnerability dashboard will be available at http://localhost:1337
 

--- a/ee/vulnerability-dashboard/README.md
+++ b/ee/vulnerability-dashboard/README.md
@@ -33,15 +33,21 @@ To run a local vulnerability dashboard with docker, you can follow these instruc
 
 1. Clone this repo
 2. Update the following ENV variables `ee/vulnerability-dashboard/docker-compose.yml` file:
+
   1. `sails_custom__fleetBaseUrl`: The full URL of your Fleet instance. (e.g., https://fleet.example.com)
+
   2. `sails_custom__fleetApiToken`: AN API token for an API-only user on your Fleet instance.
-  > You can read about how to create an API-only user and get it's token [here](https://fleetdm.com/docs/using-fleet/fleetctl-cli#create-api-only-user)
+
+    > You can read about how to create an API-only user and get it's token [here](https://fleetdm.com/docs/using-fleet/fleetctl-cli#create-api-only-user)
+
 3. Open the `ee/vulnerability-dashboard/` folder in your terminal
 4. Run `docker compose up --build` to build the vulnerability dashboard's Docker image.
-> The first time the vulnerability dashboard starts it will:
-  1. Initalize the database
-  2. Run the `update-reports` script.
+
+  > The first time the vulnerability dashboard starts it will:
+    1. Initalize the database
+    2. Run the `update-reports` script.
 5. Once the container is done building, the vulnerability dashboard will be available at http://localhost:1337
+
   You can login with the default admin login:
     - Email address: `admin@example.com`
     - Password: `abc123`

--- a/ee/vulnerability-dashboard/README.md
+++ b/ee/vulnerability-dashboard/README.md
@@ -44,8 +44,11 @@ To run a local vulnerability dashboard with docker, you can follow these instruc
 4. Run `docker compose up --build` to build the vulnerability dashboard's Docker image.
 
   > The first time the vulnerability dashboard starts it will:
+
     1. Initalize the database
+
     2. Run the `update-reports` script.
+
 5. Once the container is done building, the vulnerability dashboard will be available at http://localhost:1337
 
   You can login with the default admin login:

--- a/ee/vulnerability-dashboard/README.md
+++ b/ee/vulnerability-dashboard/README.md
@@ -45,9 +45,9 @@ To run a local vulnerability dashboard with docker, you can follow these instruc
 
   > The first time the vulnerability dashboard starts it will:
 
-    1. Initalize the database
+  1. Initalize the database
 
-    2. Run the `update-reports` script.
+  2. Run the `update-reports` script.
 
 5. Once the container is done building, the vulnerability dashboard will be available at http://localhost:1337
 

--- a/ee/vulnerability-dashboard/README.md
+++ b/ee/vulnerability-dashboard/README.md
@@ -48,5 +48,9 @@ To run a local vulnerability dashboard with docker, you can follow these instruc
 5. Once the container is done building, the vulnerability dashboard will be available at http://localhost:1337
 
   You can login with the default admin login:
-    - Email address: `admin@example.com`
-    - Password: `abc123`
+
+  - Email address: `admin@example.com`
+
+  - Password: `abc123`
+
+6. To start the vulnerability dashboard container after it is built, run `docker compose up` in the `ee/vulnerability-dashboard/` folder.

--- a/ee/vulnerability-dashboard/README.md
+++ b/ee/vulnerability-dashboard/README.md
@@ -52,5 +52,3 @@ To run a local vulnerability dashboard with docker, you can follow these instruc
   >- Email address: `admin@example.com`
   >
   >- Password: `abc123`
-
-6. To start the vulnerability dashboard container after it is built, run `docker compose up` in the `ee/vulnerability-dashboard/` folder.

--- a/ee/vulnerability-dashboard/README.md
+++ b/ee/vulnerability-dashboard/README.md
@@ -38,7 +38,7 @@ To run a local vulnerability dashboard with docker, you can follow these instruc
 
   2. `sails_custom__fleetApiToken`: AN API token for an API-only user on your Fleet instance.
 
-    > You can read about how to create an API-only user and get it's token [here](https://fleetdm.com/docs/using-fleet/fleetctl-cli#create-api-only-user)
+  >You can read about how to create an API-only user and get it's token [here](https://fleetdm.com/docs/using-fleet/fleetctl-cli#create-api-only-user)
 
 3. Open the `ee/vulnerability-dashboard/` folder in your terminal
 4. Run `docker compose up --build` to build the vulnerability dashboard's Docker image.

--- a/ee/vulnerability-dashboard/README.md
+++ b/ee/vulnerability-dashboard/README.md
@@ -47,10 +47,10 @@ To run a local vulnerability dashboard with docker, you can follow these instruc
 
 5. Once the container is done building, the vulnerability dashboard will be available at http://localhost:1337
 
-  You can login with the default admin login:
-
-  - Email address: `admin@example.com`
-
-  - Password: `abc123`
+  > You can login with the default admin login:
+  >
+  >- Email address: `admin@example.com`
+  >
+  >- Password: `abc123`
 
 6. To start the vulnerability dashboard container after it is built, run `docker compose up` in the `ee/vulnerability-dashboard/` folder.

--- a/ee/vulnerability-dashboard/crontab
+++ b/ee/vulnerability-dashboard/crontab
@@ -1,0 +1,1 @@
+0 * * * * cd /usr/src/app && /usr/local/bin/node ./node_modules/.bin/sails run update-reports >> /usr/src/app/cron.log 2>&1

--- a/ee/vulnerability-dashboard/docker-compose.yml
+++ b/ee/vulnerability-dashboard/docker-compose.yml
@@ -7,7 +7,6 @@ services:
     depends_on:
       - redis
       - postgres
-    command: sh -c "node ./node_modules/sails/bin/sails run update-reports && node app.js"
     environment:
       sails_datastores__default__url: postgres://user:password@postgres:5432/dbname
       sails_datastores__default__adapter: sails-postgresql

--- a/ee/vulnerability-dashboard/docker-compose.yml
+++ b/ee/vulnerability-dashboard/docker-compose.yml
@@ -1,0 +1,32 @@
+version: '3'
+services:
+  vuln-dash:
+    build: .
+    ports:
+      - "1337:1337"
+    depends_on:
+      - redis
+      - postgres
+    command: sh -c "node ./node_modules/sails/bin/sails run update-reports && node app.js"
+    environment:
+      sails_datastores__default__url: postgres://user:password@postgres:5432/dbname
+      sails_datastores__default__adapter: sails-postgresql
+      sails_sockets__url: redis://redis:6379
+      sails_session__url: redis://redis:6379
+      sails_custom__fleetBaseUrl: '' #Add the base url of your Fleet instance: ex: https://fleet.example.com
+      sails_custom__fleetApiToken: '' # Add the API token of an API-only user [?] Here's how you get one: https://fleetdm.com/docs/using-fleet/fleetctl-cli#get-the-api-token-of-an-api-only-user
+
+  redis:
+    image: "redis:alpine"
+
+  postgres:
+    image: "postgres:alpine"
+    environment:
+      POSTGRES_USER: user
+      POSTGRES_PASSWORD: password
+      POSTGRES_DB: dbname
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+
+volumes:
+  pgdata:

--- a/ee/vulnerability-dashboard/entrypoint.sh
+++ b/ee/vulnerability-dashboard/entrypoint.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# Check if the vulnerability dashboard has been initialized before
+if [ ! -f "/usr/src/app/.initialized" ]; then
+  # if it hasn't, lift the app with in console mode with the --drop flag to create our databsae tables.
+  echo '.exit' | node ./node_modules/sails/bin/sails console --drop
+
+  touch /usr/src/app/.initialized
+  # run the `update-reports` script
+  node ./node_modules/sails/bin/sails run update-reports
+fi
+
+# Expose the container's ENV variables to cron
+printenv >> /etc/environment
+
+# Start cron
+cron
+
+# Start the vulnerability dashboard
+exec node app.js

--- a/ee/vulnerability-dashboard/entrypoint.sh
+++ b/ee/vulnerability-dashboard/entrypoint.sh
@@ -1,5 +1,16 @@
 #!/bin/bash
 
+if [ -z "$sails_custom__fleetBaseUrl" ] && [ -z "$sails_custom__fleetApiToken" ]; then
+  echo 'ERROR: Missing environment variables. Please set "sails_custom__fleetApiToken" and "sails_custom__fleetBaseUrl" and and try starting this container again'
+  exit 1
+elif [ -z "$sails_custom__fleetBaseUrl" ]; then
+  echo 'ERROR: Missing environment variables. Please set "sails_custom__fleetBaseUrl" and try starting this container again'
+  exit 1
+elif [ -z "$sails_custom__fleetApiToken" ]; then
+  echo 'ERROR: Missing environment variables. Please set "sails_custom__fleetApiToken" and and try starting this container again'
+  exit 1
+fi
+
 # Check if the vulnerability dashboard has been initialized before
 if [ ! -f "/usr/src/app/.initialized" ]; then
   # if it hasn't, lift the app with in console mode with the --drop flag to create our databsae tables.


### PR DESCRIPTION
Related to: https://github.com/fleetdm/confidential/issues/5637

Changes:
- Added a way to start a vulnerability dashboard with Docker.
- Updated the folder readme to include instructions for starting the vulnerability dashboard with docker