### PR TITLE
Update macos-disable-guest-account config profile

### DIFF
--- a/it-and-security/lib/configuration-profiles/macos-disable-guest-account.mobileconfig
+++ b/it-and-security/lib/configuration-profiles/macos-disable-guest-account.mobileconfig
@@ -18,9 +18,9 @@
         </dict>
     </array>
     <key>PayloadDisplayName</key>
-    <string>Accounts</string>
+    <string>Disable guest account</string>
     <key>PayloadIdentifier</key>
-    <string>com.example.myprofile</string>
+    <string>com.fleet.disable-guest-account</string>
     <key>PayloadType</key>
     <string>Configuration</string>
     <key>PayloadUUID</key>

--- a/it-and-security/lib/configuration-profiles/macos-disable-guest-account.mobileconfig
+++ b/it-and-security/lib/configuration-profiles/macos-disable-guest-account.mobileconfig
@@ -1,6 +1,6 @@
-<?xml version=”1.0” encoding=”UTF-8”?>
-<!DOCTYPE plist PUBLIC “-//Apple//DTD PLIST 1.0//EN” “http://www.apple.com/DTDs/PropertyList-1.0.dtd”>
-<plist version=”1.0”>
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
 <dict>
     <key>PayloadContent</key>
     <array>

--- a/it-and-security/lib/configuration-profiles/macos-disable-guest-account.mobileconfig
+++ b/it-and-security/lib/configuration-profiles/macos-disable-guest-account.mobileconfig
@@ -1,45 +1,31 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
+<?xml version=”1.0” encoding=”UTF-8”?>
+<!DOCTYPE plist PUBLIC “-//Apple//DTD PLIST 1.0//EN” “http://www.apple.com/DTDs/PropertyList-1.0.dtd”>
+<plist version=”1.0”>
 <dict>
-	<key>PayloadDescription</key>
-	<string>This profile configuration is designed to apply the CIS Benchmark for macOS 10.14 (v2.0.0), 10.15 (v2.0.0), 11.0 (v2.0.0), and 12.0 (v1.0.0)</string>
-	<key>PayloadDisplayName</key>
-	<string>Disable guest account</string>
-	<key>PayloadIdentifier</key>
-	<string>cis.macOSBenchmark.section5.GuestAccess</string>
-	<key>PayloadOrganization</key>
-	<string>Center for Internet Security</string>
-	<key>PayloadScope</key>
-	<string>System</string>
-	<key>PayloadType</key>
-	<string>Configuration</string>
-	<key>PayloadUUID</key>
-	<string>E7775451-8672-4F26-ACB5-A81103A81524</string>
-	<key>PayloadVersion</key>
-	<integer>1</integer>
-	<key>TargetDeviceType</key>
-	<integer>5</integer>
-    <key>PayloadRemovalDisallowed</key>
-    <true/>
-	<key>PayloadContent</key>
-	<array>
-		<dict>
-			<key>PayloadDisplayName</key>
-			<string>6.1.3 - Ensure Guest Account Is Disabled</string>
-			<key>PayloadIdentifier</key>
-			<string>CIS.macOS.showpasswordhint</string>
-			<key>PayloadType</key>
-			<string>com.apple.loginwindow</string>
-			<key>PayloadUUID</key>
-			<string>2C04F112-824E-4A74-90AF-D51270691CC5</string>
-			<key>PayloadVersion</key>
-			<integer>1</integer>
-			<key>DisableGuestAccount</key>
-			<true/>
-			<key>EnableGuestAccount</key>
-			<false/>
-		</dict>
-	</array>
+    <key>PayloadContent</key>
+    <array>
+        <dict>
+            <key>DisableGuestAccount</key>
+            <true/>
+            <key>PayloadIdentifier</key>
+            <string>com.example.myaccountpayload</string>
+            <key>PayloadType</key>
+            <string>com.apple.MCX</string>
+            <key>PayloadUUID</key>
+            <string>5d4e377c-108c-44af-a46e-97a5aac1e270</string>
+            <key>PayloadVersion</key>
+            <integer>1</integer>
+        </dict>
+    </array>
+    <key>PayloadDisplayName</key>
+    <string>Accounts</string>
+    <key>PayloadIdentifier</key>
+    <string>com.example.myprofile</string>
+    <key>PayloadType</key>
+    <string>Configuration</string>
+    <key>PayloadUUID</key>
+    <string>8cd28a9d-625e-4056-bbd0-43617bb8efb7</string>
+    <key>PayloadVersion</key>
+    <integer>1</integer>
 </dict>
 </plist>


### PR DESCRIPTION
- Update configuration profile to actually disable the guest account

The old profile uses deprecated key/vals. More info in [Slack here](https://fleetdm.slack.com/archives/C02A8BRABB5/p1710435126972869?thread_ts=1710434915.735249&cid=C02A8BRABB5) (internal).
