### PR TITLE
Add macOS DDM protocol endpoints for `tokens`, `declaration-items`, and `declaration/.../...`

### DIFF
--- a/pkg/mdm/mdmtest/apple.go
+++ b/pkg/mdm/mdmtest/apple.go
@@ -391,7 +391,7 @@ func (c *TestAppleMDMClient) TokenUpdate() error {
 // The endpoint argument is used as the value for the `Endpoint` key in the request payload.
 //
 // For more details check https://developer.apple.com/documentation/devicemanagement/declarativemanagementrequest
-func (c *TestAppleMDMClient) DeclarativeManagement(endpoint string) error {
+func (c *TestAppleMDMClient) DeclarativeManagement(endpoint string) (*http.Response, error) {
 	payload := map[string]any{
 		"MessageType":  "DeclarativeManagement",
 		"UDID":         c.UUID,
@@ -399,8 +399,8 @@ func (c *TestAppleMDMClient) DeclarativeManagement(endpoint string) error {
 		"EnrollmentID": "testenrollmentid-" + c.UUID,
 		"Endpoint":     endpoint,
 	}
-	_, err := c.request("application/x-apple-aspen-mdm-checkin", payload)
-	return err
+	r, err := c.request("application/x-apple-aspen-mdm-checkin", payload)
+	return r, err
 }
 
 // Checkout sends the CheckOut message to the MDM server.

--- a/server/datastore/mysql/apple_mdm.go
+++ b/server/datastore/mysql/apple_mdm.go
@@ -3080,3 +3080,22 @@ WHERE h.uuid = ?
 
 	return nil
 }
+
+func (ds *Datastore) MDMAppleDDMSynchronizationTokens(ctx context.Context, teamID uint) (*fleet.MDMAppleDDMSynchronizationTokens, error) {
+	const stmt = `
+SELECT
+	md5_checksum,
+	latest_created_timestamp
+FROM
+	team_declaration_checksum_view
+WHERE
+	team_id = ?
+`
+
+	var res fleet.MDMAppleDDMSynchronizationTokens
+	if err := sqlx.GetContext(ctx, ds.reader(ctx), &res, stmt, teamID); err != nil {
+		return nil, ctxerr.Wrap(ctx, err, "get DDM checksum by team id")
+	}
+
+	return &res, nil
+}

--- a/server/datastore/mysql/apple_mdm.go
+++ b/server/datastore/mysql/apple_mdm.go
@@ -3081,7 +3081,7 @@ WHERE h.uuid = ?
 	return nil
 }
 
-func (ds *Datastore) MDMAppleDDMSynchronizationTokens(ctx context.Context, teamID uint) (*fleet.MDMAppleDDMSynchronizationTokens, error) {
+func (ds *Datastore) MDMAppleDDMSynchronizationTokens(ctx context.Context, teamID uint) (*fleet.MDMAppleDDMSyncTokens, error) {
 	const stmt = `
 SELECT
 	md5_checksum,
@@ -3092,10 +3092,34 @@ WHERE
 	team_id = ?
 `
 
-	var res fleet.MDMAppleDDMSynchronizationTokens
+	var res fleet.MDMAppleDDMSyncTokens
 	if err := sqlx.GetContext(ctx, ds.reader(ctx), &res, stmt, teamID); err != nil {
 		return nil, ctxerr.Wrap(ctx, err, "get DDM checksum by team id")
 	}
 
 	return &res, nil
+}
+
+func (ds *Datastore) MDMAppleDDMDeclarationItems(ctx context.Context, teamID uint) ([]fleet.MDMAppleDDMDeclarationItemDB, error) {
+	// TODO: Confirm whether we can use JSON functions in the query (if 5.7 officially unsupported
+	// by Fleet)
+	const stmt = `
+SELECT
+	mad.md5_checksum as server_token,
+	identifier,
+	declaration_type,
+	tv.md5_checksum as declarations_token
+FROM
+	mdm_apple_declarations mad
+	JOIN team_declaration_checksum_view tv ON mad.team_id = tv.team_id
+WHERE
+	mad.team_id = ?
+`
+
+	var res []fleet.MDMAppleDDMDeclarationItemDB
+	if err := sqlx.SelectContext(ctx, ds.reader(ctx), &res, stmt, teamID); err != nil {
+		return nil, ctxerr.Wrap(ctx, err, "get DDM checksum by team id")
+	}
+
+	return res, nil
 }

--- a/server/fleet/apple_mdm.go
+++ b/server/fleet/apple_mdm.go
@@ -609,3 +609,11 @@ type MDMAppleHostDeclaration struct {
 	// either by the MDM protocol or the Fleet server.
 	Detail string `db:"detail" json:"detail"`
 }
+
+// MDMAppleDDMSynchronizationTokens represent tokens used to synchorize declarations.
+//
+// https://developer.apple.com/documentation/devicemanagement/synchronizationtokens
+type MDMAppleDDMSynchronizationTokens struct {
+	DeclarationsToken string    `db:"md5_checksum"`
+	Timestamp         time.Time `db:"latest_created_timestamp"`
+}

--- a/server/fleet/apple_mdm.go
+++ b/server/fleet/apple_mdm.go
@@ -610,10 +610,52 @@ type MDMAppleHostDeclaration struct {
 	Detail string `db:"detail" json:"detail"`
 }
 
-// MDMAppleDDMSynchronizationTokens represent tokens used to synchorize declarations.
+// MDMAppleDDMTokensResponse is the response from the DDM tokens endpoint.
+//
+// https://developer.apple.com/documentation/devicemanagement/tokensresponse
+type MDMAppleDDMTokensResponse struct {
+	SyncTokens MDMAppleDDMSyncTokens
+}
+
+// MDMAppleDDMSyncTokens is dictionary describes the state of declarations on the server.
 //
 // https://developer.apple.com/documentation/devicemanagement/synchronizationtokens
-type MDMAppleDDMSynchronizationTokens struct {
+type MDMAppleDDMSyncTokens struct {
 	DeclarationsToken string    `db:"md5_checksum"`
 	Timestamp         time.Time `db:"latest_created_timestamp"`
+}
+
+// MDMAppleDDMDeclarationItemsResponse is the response from the DDM declaration items endpoint.
+//
+// https://developer.apple.com/documentation/devicemanagement/declarationitemsresponse
+type MDMAppleDDMDeclarationItemsResponse struct {
+	Declarations      MDMAppleDDMManifestItems
+	DeclarationsToken string
+}
+
+// MDMAppleDDMManifestItems is a dictionary that contains the lists of declarations available on the
+// server.
+//
+// https://developer.apple.com/documentation/devicemanagement/declarationitemsresponse/manifestdeclarationitems
+type MDMAppleDDMManifestItems struct {
+	Activations    []MDMAppleDDMManifest
+	Assets         []MDMAppleDDMManifest
+	Configurations []MDMAppleDDMManifest
+	Management     []MDMAppleDDMManifest
+}
+
+// MDMAppleDDMManifest is a dictionary that describes a declaration.
+//
+// https://developer.apple.com/documentation/devicemanagement/declarationitemsresponse/manifestdeclarationitems
+type MDMAppleDDMManifest struct {
+	Identifier  string
+	ServerToken string
+}
+
+// MDMAppleDDMDeclarationItemDB represents a declaration item in the datastore.
+type MDMAppleDDMDeclarationItemDB struct {
+	Identifier        string `db:"identifier"`
+	DeclarationType   string `db:"declaration_type"`
+	DeclarationsToken string `db:"declarations_token"`
+	ServerToken       string `db:"server_token"`
 }

--- a/server/fleet/apple_mdm.go
+++ b/server/fleet/apple_mdm.go
@@ -652,10 +652,24 @@ type MDMAppleDDMManifest struct {
 	ServerToken string
 }
 
-// MDMAppleDDMDeclarationItemDB represents a declaration item in the datastore.
-type MDMAppleDDMDeclarationItemDB struct {
+// MDMAppleDDMDeclarationItem represents a declaration item in the datastore. It is used to
+// construct the DDM `declaration-items` endpoint response.
+//
+// https://developer.apple.com/documentation/devicemanagement/declarationitemsresponse
+type MDMAppleDDMDeclarationItem struct {
 	Identifier        string `db:"identifier"`
 	DeclarationType   string `db:"declaration_type"`
 	DeclarationsToken string `db:"declarations_token"`
 	ServerToken       string `db:"server_token"`
+}
+
+// MDMAppleDDMDeclarationResponse represents a declaration in the datastore. It is used for the DDM
+// `declaration/.../...` enpoint response.
+//
+// https://developer.apple.com/documentation/devicemanagement/declarationresponse
+type MDMAppleDDMDeclarationResponse struct {
+	Identifier  string          `db:"identifier"`
+	Type        string          `db:"type"`
+	Payload     json.RawMessage `db:"payload"`
+	ServerToken string          `db:"server_token"`
 }

--- a/server/fleet/datastore.go
+++ b/server/fleet/datastore.go
@@ -1154,7 +1154,9 @@ type Datastore interface {
 
 	// MDMAppleDDMSynchronizationTokens returns the token used to synchronize declarations for the
 	// specified team or no team.
-	MDMAppleDDMSynchronizationTokens(ctx context.Context, teamID uint) (*MDMAppleDDMSynchronizationTokens, error)
+	MDMAppleDDMSynchronizationTokens(ctx context.Context, teamID uint) (*MDMAppleDDMSyncTokens, error)
+
+	MDMAppleDDMDeclarationItems(ctx context.Context, teamID uint) ([]MDMAppleDDMDeclarationItemDB, error)
 
 	///////////////////////////////////////////////////////////////////////////////
 	// Microsoft MDM

--- a/server/fleet/datastore.go
+++ b/server/fleet/datastore.go
@@ -1152,6 +1152,10 @@ type Datastore interface {
 	// serials.
 	UpdateDEPAssignProfileRetryPending(ctx context.Context, jobID uint, serials []string) error
 
+	// MDMAppleDDMSynchronizationTokens returns the token used to synchronize declarations for the
+	// specified team or no team.
+	MDMAppleDDMSynchronizationTokens(ctx context.Context, teamID uint) (*MDMAppleDDMSynchronizationTokens, error)
+
 	///////////////////////////////////////////////////////////////////////////////
 	// Microsoft MDM
 

--- a/server/fleet/datastore.go
+++ b/server/fleet/datastore.go
@@ -1160,8 +1160,10 @@ type Datastore interface {
 	// MDMAppleDDMSynchronizationTokens returns the token used to synchronize declarations for the
 	// specified team or no team.
 	MDMAppleDDMSynchronizationTokens(ctx context.Context, teamID uint) (*MDMAppleDDMSyncTokens, error)
-
-	MDMAppleDDMDeclarationItems(ctx context.Context, teamID uint) ([]MDMAppleDDMDeclarationItemDB, error)
+	// MDMAppleDDMDeclarationItems returns the declaration items for the specified team or no team.
+	MDMAppleDDMDeclarationItems(ctx context.Context, teamID uint) ([]MDMAppleDDMDeclarationItem, error)
+	// MDMAppleDDMDeclarationPayload returns the declaration payload for the specified identifier and team.
+	MDMAppleDDMDeclarationPayload(ctx context.Context, declarationType MDMAppleDeclarationType, identifier string, teamID uint) (json.RawMessage, error)
 
 	///////////////////////////////////////////////////////////////////////////////
 	// Microsoft MDM

--- a/server/mock/datastore_mock.go
+++ b/server/mock/datastore_mock.go
@@ -760,7 +760,9 @@ type UpdateDEPAssignProfileRetryPendingFunc func(ctx context.Context, jobID uint
 
 type MDMAppleDDMSynchronizationTokensFunc func(ctx context.Context, teamID uint) (*fleet.MDMAppleDDMSyncTokens, error)
 
-type MDMAppleDDMDeclarationItemsFunc func(ctx context.Context, teamID uint) ([]fleet.MDMAppleDDMDeclarationItemDB, error)
+type MDMAppleDDMDeclarationItemsFunc func(ctx context.Context, teamID uint) ([]fleet.MDMAppleDDMDeclarationItem, error)
+
+type MDMAppleDDMDeclarationPayloadFunc func(ctx context.Context, declarationType fleet.MDMAppleDeclarationType, identifier string, teamID uint) (json.RawMessage, error)
 
 type WSTEPStoreCertificateFunc func(ctx context.Context, name string, crt *x509.Certificate) error
 
@@ -1980,6 +1982,9 @@ type DataStore struct {
 
 	MDMAppleDDMDeclarationItemsFunc        MDMAppleDDMDeclarationItemsFunc
 	MDMAppleDDMDeclarationItemsFuncInvoked bool
+
+	MDMAppleDDMDeclarationPayloadFunc        MDMAppleDDMDeclarationPayloadFunc
+	MDMAppleDDMDeclarationPayloadFuncInvoked bool
 
 	WSTEPStoreCertificateFunc        WSTEPStoreCertificateFunc
 	WSTEPStoreCertificateFuncInvoked bool
@@ -4734,11 +4739,18 @@ func (s *DataStore) MDMAppleDDMSynchronizationTokens(ctx context.Context, teamID
 	return s.MDMAppleDDMSynchronizationTokensFunc(ctx, teamID)
 }
 
-func (s *DataStore) MDMAppleDDMDeclarationItems(ctx context.Context, teamID uint) ([]fleet.MDMAppleDDMDeclarationItemDB, error) {
+func (s *DataStore) MDMAppleDDMDeclarationItems(ctx context.Context, teamID uint) ([]fleet.MDMAppleDDMDeclarationItem, error) {
 	s.mu.Lock()
 	s.MDMAppleDDMDeclarationItemsFuncInvoked = true
 	s.mu.Unlock()
 	return s.MDMAppleDDMDeclarationItemsFunc(ctx, teamID)
+}
+
+func (s *DataStore) MDMAppleDDMDeclarationPayload(ctx context.Context, declarationType fleet.MDMAppleDeclarationType, identifier string, teamID uint) (json.RawMessage, error) {
+	s.mu.Lock()
+	s.MDMAppleDDMDeclarationPayloadFuncInvoked = true
+	s.mu.Unlock()
+	return s.MDMAppleDDMDeclarationPayloadFunc(ctx, declarationType, identifier, teamID)
 }
 
 func (s *DataStore) WSTEPStoreCertificate(ctx context.Context, name string, crt *x509.Certificate) error {

--- a/server/mock/datastore_mock.go
+++ b/server/mock/datastore_mock.go
@@ -756,6 +756,10 @@ type GetDEPAssignProfileExpiredCooldownsFunc func(ctx context.Context) (map[uint
 
 type UpdateDEPAssignProfileRetryPendingFunc func(ctx context.Context, jobID uint, serials []string) error
 
+type MDMAppleDDMSynchronizationTokensFunc func(ctx context.Context, teamID uint) (*fleet.MDMAppleDDMSyncTokens, error)
+
+type MDMAppleDDMDeclarationItemsFunc func(ctx context.Context, teamID uint) ([]fleet.MDMAppleDDMDeclarationItemDB, error)
+
 type WSTEPStoreCertificateFunc func(ctx context.Context, name string, crt *x509.Certificate) error
 
 type WSTEPNewSerialFunc func(ctx context.Context) (*big.Int, error)
@@ -857,8 +861,6 @@ type WipeHostViaScriptFunc func(ctx context.Context, request *fleet.HostScriptRe
 type WipeHostViaWindowsMDMFunc func(ctx context.Context, host *fleet.Host, cmd *fleet.MDMWindowsCommand) error
 
 type UpdateHostLockWipeStatusFromAppleMDMResultFunc func(ctx context.Context, hostUUID string, cmdUUID string, requestType string, succeeded bool) error
-
-type MDMAppleDDMSynchronizationTokensFunc func(ctx context.Context, teamID uint) (*fleet.MDMAppleDDMSynchronizationTokens, error)
 
 type DataStore struct {
 	HealthCheckFunc        HealthCheckFunc
@@ -1968,6 +1970,12 @@ type DataStore struct {
 	UpdateDEPAssignProfileRetryPendingFunc        UpdateDEPAssignProfileRetryPendingFunc
 	UpdateDEPAssignProfileRetryPendingFuncInvoked bool
 
+	MDMAppleDDMSynchronizationTokensFunc        MDMAppleDDMSynchronizationTokensFunc
+	MDMAppleDDMSynchronizationTokensFuncInvoked bool
+
+	MDMAppleDDMDeclarationItemsFunc        MDMAppleDDMDeclarationItemsFunc
+	MDMAppleDDMDeclarationItemsFuncInvoked bool
+
 	WSTEPStoreCertificateFunc        WSTEPStoreCertificateFunc
 	WSTEPStoreCertificateFuncInvoked bool
 
@@ -2120,9 +2128,6 @@ type DataStore struct {
 
 	UpdateHostLockWipeStatusFromAppleMDMResultFunc        UpdateHostLockWipeStatusFromAppleMDMResultFunc
 	UpdateHostLockWipeStatusFromAppleMDMResultFuncInvoked bool
-
-	MDMAppleDDMSynchronizationTokensFunc        MDMAppleDDMSynchronizationTokensFunc
-	MDMAppleDDMSynchronizationTokensFuncInvoked bool
 
 	mu sync.Mutex
 }
@@ -4710,6 +4715,20 @@ func (s *DataStore) UpdateDEPAssignProfileRetryPending(ctx context.Context, jobI
 	return s.UpdateDEPAssignProfileRetryPendingFunc(ctx, jobID, serials)
 }
 
+func (s *DataStore) MDMAppleDDMSynchronizationTokens(ctx context.Context, teamID uint) (*fleet.MDMAppleDDMSyncTokens, error) {
+	s.mu.Lock()
+	s.MDMAppleDDMSynchronizationTokensFuncInvoked = true
+	s.mu.Unlock()
+	return s.MDMAppleDDMSynchronizationTokensFunc(ctx, teamID)
+}
+
+func (s *DataStore) MDMAppleDDMDeclarationItems(ctx context.Context, teamID uint) ([]fleet.MDMAppleDDMDeclarationItemDB, error) {
+	s.mu.Lock()
+	s.MDMAppleDDMDeclarationItemsFuncInvoked = true
+	s.mu.Unlock()
+	return s.MDMAppleDDMDeclarationItemsFunc(ctx, teamID)
+}
+
 func (s *DataStore) WSTEPStoreCertificate(ctx context.Context, name string, crt *x509.Certificate) error {
 	s.mu.Lock()
 	s.WSTEPStoreCertificateFuncInvoked = true
@@ -5065,11 +5084,4 @@ func (s *DataStore) UpdateHostLockWipeStatusFromAppleMDMResult(ctx context.Conte
 	s.UpdateHostLockWipeStatusFromAppleMDMResultFuncInvoked = true
 	s.mu.Unlock()
 	return s.UpdateHostLockWipeStatusFromAppleMDMResultFunc(ctx, hostUUID, cmdUUID, requestType, succeeded)
-}
-
-func (s *DataStore) MDMAppleDDMSynchronizationTokens(ctx context.Context, teamID uint) (*fleet.MDMAppleDDMSynchronizationTokens, error) {
-	s.mu.Lock()
-	s.MDMAppleDDMSynchronizationTokensFuncInvoked = true
-	s.mu.Unlock()
-	return s.MDMAppleDDMSynchronizationTokensFunc(ctx, teamID)
 }

--- a/server/mock/datastore_mock.go
+++ b/server/mock/datastore_mock.go
@@ -858,6 +858,8 @@ type WipeHostViaWindowsMDMFunc func(ctx context.Context, host *fleet.Host, cmd *
 
 type UpdateHostLockWipeStatusFromAppleMDMResultFunc func(ctx context.Context, hostUUID string, cmdUUID string, requestType string, succeeded bool) error
 
+type MDMAppleDDMSynchronizationTokensFunc func(ctx context.Context, teamID uint) (*fleet.MDMAppleDDMSynchronizationTokens, error)
+
 type DataStore struct {
 	HealthCheckFunc        HealthCheckFunc
 	HealthCheckFuncInvoked bool
@@ -2118,6 +2120,9 @@ type DataStore struct {
 
 	UpdateHostLockWipeStatusFromAppleMDMResultFunc        UpdateHostLockWipeStatusFromAppleMDMResultFunc
 	UpdateHostLockWipeStatusFromAppleMDMResultFuncInvoked bool
+
+	MDMAppleDDMSynchronizationTokensFunc        MDMAppleDDMSynchronizationTokensFunc
+	MDMAppleDDMSynchronizationTokensFuncInvoked bool
 
 	mu sync.Mutex
 }
@@ -5060,4 +5065,11 @@ func (s *DataStore) UpdateHostLockWipeStatusFromAppleMDMResult(ctx context.Conte
 	s.UpdateHostLockWipeStatusFromAppleMDMResultFuncInvoked = true
 	s.mu.Unlock()
 	return s.UpdateHostLockWipeStatusFromAppleMDMResultFunc(ctx, hostUUID, cmdUUID, requestType, succeeded)
+}
+
+func (s *DataStore) MDMAppleDDMSynchronizationTokens(ctx context.Context, teamID uint) (*fleet.MDMAppleDDMSynchronizationTokens, error) {
+	s.mu.Lock()
+	s.MDMAppleDDMSynchronizationTokensFuncInvoked = true
+	s.mu.Unlock()
+	return s.MDMAppleDDMSynchronizationTokensFunc(ctx, teamID)
 }

--- a/server/service/apple_mdm.go
+++ b/server/service/apple_mdm.go
@@ -2990,6 +2990,11 @@ func (svc *MDMAppleDDMService) DeclarativeManagement(r *mdm.Request, dm *mdm.Dec
 	switch {
 	case dm.Endpoint == "tokens":
 		level.Debug(svc.logger).Log("msg", "received tokens request")
+		// TODO: Should we record the checkin for all endpoints or just tokens?
+		if err := svc.ds.MDMAppleRecordDeclarativeCheckIn(r.Context, dm.UDID, dm.Raw); err != nil {
+			return nil, ctxerr.Wrap(r.Context, err, "recording declarative checkin")
+		}
+
 		return svc.handleTokens(r.Context, tid)
 
 	case dm.Endpoint == "declaration-items":
@@ -2998,9 +3003,7 @@ func (svc *MDMAppleDDMService) DeclarativeManagement(r *mdm.Request, dm *mdm.Dec
 
 	case dm.Endpoint == "status":
 		level.Debug(svc.logger).Log("msg", "received status request")
-		if err := svc.ds.MDMAppleRecordDeclarativeCheckIn(r.Context, dm.UDID, dm.Raw); err != nil {
-			return nil, ctxerr.Wrap(r.Context, err, "recording declarative checkin")
-		}
+		// TODO(roberto): handle status
 
 		return nil, nil
 

--- a/server/service/apple_mdm.go
+++ b/server/service/apple_mdm.go
@@ -2974,43 +2974,6 @@ func (svc *MDMAppleDDMService) DeclarativeManagement(r *mdm.Request, dm *mdm.Dec
 	}
 	level.Debug(svc.logger).Log("msg", "ddm request received", "endpoint", dm.Endpoint)
 
-	switch {
-	case dm.Endpoint == "tokens":
-		// TODO(sarah): handle tokens
-		level.Debug(svc.logger).Log("msg", "received tokens request")
-		return svc.handleTokens(r, dm)
-
-	case dm.Endpoint == "declaration-items":
-		// TODO(sarah): handle declaration-items
-		level.Debug(svc.logger).Log("msg", "received declaration-items request")
-		return nil, nil
-
-	case dm.Endpoint == "status":
-		// TODO(roberto): handle status
-		level.Debug(svc.logger).Log("msg", "received status request")
-		return nil, nil
-
-	case strings.HasPrefix(dm.Endpoint, "declarations"):
-		// TODO(sarah): handle declarations
-		level.Debug(svc.logger).Log("msg", "received declarations request")
-		parts := strings.Split(dm.Endpoint, "/")
-		if len(parts) != 3 {
-			return nil, ctxerr.New(r.Context, "unrecognized declarations endpoint")
-		}
-		declarationType := parts[1]
-		declarationIdentifier := parts[2]
-		level.Debug(svc.logger).Log("msg", "parsed declarations request", "type", declarationType, "identifier", declarationIdentifier)
-		return nil, nil
-
-	default:
-		return nil, ctxerr.New(r.Context, "unrecognized ddm endpoint")
-	}
-}
-
-func (svc *MDMAppleDDMService) handleTokens(r *mdm.Request, dm *mdm.DeclarativeManagement) ([]byte, error) {
-	if dm == nil {
-		return nil, ctxerr.New(r.Context, "missing ddm payload")
-	}
 	if dm.UDID == "" {
 		return nil, ctxerr.New(r.Context, "missing device id")
 	}
@@ -3023,14 +2986,95 @@ func (svc *MDMAppleDDMService) handleTokens(r *mdm.Request, dm *mdm.DeclarativeM
 	if h.TeamID != nil {
 		tid = *h.TeamID
 	}
-	tok, err := svc.ds.MDMAppleDDMSynchronizationTokens(r.Context, tid)
+
+	switch {
+	case dm.Endpoint == "tokens":
+		level.Debug(svc.logger).Log("msg", "received tokens request")
+		return svc.handleTokens(r.Context, tid)
+
+	case dm.Endpoint == "declaration-items":
+		level.Debug(svc.logger).Log("msg", "received declaration-items request")
+		return svc.handleDeclarationItems(r.Context, tid)
+
+	case dm.Endpoint == "status":
+		level.Debug(svc.logger).Log("msg", "received status request")
+		// TODO(roberto): handle status
+
+		return nil, nil
+
+	case strings.HasPrefix(dm.Endpoint, "declarations"):
+		level.Debug(svc.logger).Log("msg", "received declarations request")
+		parts := strings.Split(dm.Endpoint, "/")
+		if len(parts) != 3 {
+			return nil, ctxerr.New(r.Context, "unrecognized declarations endpoint")
+		}
+		declarationType := parts[1]
+		declarationIdentifier := parts[2]
+		level.Debug(svc.logger).Log("msg", "parsed declarations request", "type", declarationType, "identifier", declarationIdentifier)
+		// TODO(sarah): handle declarations
+
+		return nil, nil
+
+	default:
+		return nil, ctxerr.New(r.Context, "unrecognized ddm endpoint")
+	}
+}
+
+func (svc *MDMAppleDDMService) handleTokens(ctx context.Context, teamID uint) ([]byte, error) {
+	tok, err := svc.ds.MDMAppleDDMSynchronizationTokens(ctx, teamID)
 	if err != nil {
-		return nil, ctxerr.Wrap(r.Context, err, "getting synchronization tokens")
+		return nil, ctxerr.Wrap(ctx, err, "getting synchronization tokens")
 	}
 
-	b, err := json.Marshal(tok)
+	b, err := json.Marshal(fleet.MDMAppleDDMTokensResponse{
+		SyncTokens: *tok,
+	})
 	if err != nil {
-		return nil, ctxerr.Wrap(r.Context, err, "marshaling synchronization tokens")
+		return nil, ctxerr.Wrap(ctx, err, "marshaling synchronization tokens")
+	}
+
+	return b, nil
+}
+
+func (svc *MDMAppleDDMService) handleDeclarationItems(ctx context.Context, teamID uint) ([]byte, error) {
+	di, err := svc.ds.MDMAppleDDMDeclarationItems(ctx, teamID)
+	if err != nil {
+		return nil, ctxerr.Wrap(ctx, err, "getting synchronization tokens")
+	}
+
+	var dTok string
+	activations := []fleet.MDMAppleDDMManifest{}
+	configuations := []fleet.MDMAppleDDMManifest{}
+	for _, d := range di {
+		if dTok == "" {
+			dTok = d.DeclarationsToken
+		} else if dTok != d.DeclarationsToken {
+			level.Debug(svc.logger).Log("msg", "inconsistent declarations token", "expected", dTok, "got", d.DeclarationsToken)
+		}
+
+		manifest := fleet.MDMAppleDDMManifest{Identifier: d.Identifier, ServerToken: d.ServerToken}
+		switch d.DeclarationType {
+		case string(fleet.MDMAppleDeclarativeActivation):
+			activations = append(activations, manifest)
+		case string(fleet.MDMAppleDeclarativeConfiguration):
+			configuations = append(configuations, manifest)
+		default:
+			level.Debug(svc.logger).Log("msg", "unrecognized declaration type", "type", d.DeclarationType)
+			return nil, ctxerr.New(ctx, "unrecognized declaration type")
+		}
+	}
+
+	b, err := json.Marshal(fleet.MDMAppleDDMDeclarationItemsResponse{
+		Declarations: fleet.MDMAppleDDMManifestItems{
+			Activations:    activations,
+			Configurations: configuations,
+			Assets:         []fleet.MDMAppleDDMManifest{},
+			Management:     []fleet.MDMAppleDDMManifest{},
+		},
+		DeclarationsToken: dTok,
+	})
+	if err != nil {
+		return nil, ctxerr.Wrap(ctx, err, "marshaling synchronization tokens")
 	}
 
 	return b, nil

--- a/server/service/integration_mdm_test.go
+++ b/server/service/integration_mdm_test.go
@@ -12531,25 +12531,42 @@ INSERT INTO mdm_apple_declarations (
 		return err
 	})
 
-	r, err := mdmDevice.DeclarativeManagement("tokens")
-	require.NoError(t, err)
-	require.NotNil(t, r)
-	b, err := io.ReadAll(r.Body)
-	require.NoError(t, err)
-	defer r.Body.Close()
-	r.Body = io.NopCloser(bytes.NewBuffer(b))
-	fmt.Println("body", string(b))
+	t.Run("Tokens", func(t *testing.T) {
+		r, err := mdmDevice.DeclarativeManagement("tokens")
+		require.NoError(t, err)
+		require.NotNil(t, r)
+		b, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		defer r.Body.Close()
+		r.Body = io.NopCloser(bytes.NewBuffer(b))
+		fmt.Println("body", string(b))
 
-	// unmarsal the response to make sure it's valid
-	var tok fleet.MDMAppleDDMSynchronizationTokens
-	err = json.NewDecoder(r.Body).Decode(&tok)
-	require.NoError(t, err)
-	fmt.Println("decoded", tok)
+		// unmarsal the response to make sure it's valid
+		var tok fleet.MDMAppleDDMTokensResponse
+		err = json.NewDecoder(r.Body).Decode(&tok)
+		require.NoError(t, err)
+		fmt.Println("decoded", tok)
+	})
 
-	_, err = mdmDevice.DeclarativeManagement("declaration-items")
-	require.NoError(t, err)
+	t.Run("DeclarationItems", func(t *testing.T) {
+		r, err := mdmDevice.DeclarativeManagement("declaration-items")
+		require.NoError(t, err)
+		require.NoError(t, err)
+		require.NotNil(t, r)
+		b, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		defer r.Body.Close()
+		r.Body = io.NopCloser(bytes.NewBuffer(b))
+		fmt.Println("body", string(b))
 
-	_, err = mdmDevice.DeclarativeManagement("status")
+		// unmarsal the response to make sure it's valid
+		var di fleet.MDMAppleDDMDeclarationItemsResponse
+		err = json.NewDecoder(r.Body).Decode(&di)
+		require.NoError(t, err)
+		fmt.Println("decoded", di)
+	})
+
+	_, err := mdmDevice.DeclarativeManagement("status")
 	require.NoError(t, err)
 
 	_, err = mdmDevice.DeclarativeManagement("declarations/foo/bar")


### PR DESCRIPTION
# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [ ] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [ ] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [ ] Added support on fleet's osquery simulator `cmd/osquery-perf` for new osquery data ingestion features.
- [ ] Added/updated tests
- [ ] If database migrations are included, checked table schema to confirm autoupdate 
- For database migrations:
  - [ ] Checked schema for all modified table for columns that will auto-update timestamps during migration.
  - [ ] Confirmed that updating the timestamps is acceptable, and will not cause unwanted side effects.
- [ ] Manual QA for all new/changed functionality
  - For Orbit and Fleet Desktop changes:
    - [ ] Manual QA must be performed in the three main OSs, macOS, Windows and Linux.
    - [ ] Auto-update manual QA, from released version of component to new version (see [tools/tuf/test](../tools/tuf/test/README.md)).
