### PR TITLE
Website: update `create-issues-from-todays-rituals` script to work in production

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -15,8 +15,7 @@
     "sails-hook-organics": "^2.2.2",
     "sails-hook-orm": "^4.0.2",
     "sails-hook-sockets": "^3.0.0",
-    "sails-postgresql": "^5.0.0",
-    "yaml": "1.10.2"
+    "sails-postgresql": "^5.0.0"
   },
   "devDependencies": {
     "eslint": "5.16.0",
@@ -24,7 +23,8 @@
     "htmlhint": "0.11.0",
     "lesshint": "6.3.6",
     "marked": "4.0.10",
-    "sails-hook-grunt": "^4.0.0"
+    "sails-hook-grunt": "^4.0.0",
+    "yaml": "1.10.2"
   },
   "scripts": {
     "custom-tests": "echo \"(No other custom tests yet.)\" && echo",


### PR DESCRIPTION
Closes: #17678

Changes:
- Updated the `create-issues-from-todays-rituals` to create GH issues using rituals from website's configuration instead of the ritual.yml files in the `handbook/` folder
- Moved `yaml` to `devDependencies` in `webiste/package.json`