### PR TITLE
Fleet UI: Clickable elements include cursor hover state

### DIFF
--- a/changes/17208-hover-states
+++ b/changes/17208-hover-states
@@ -1,0 +1,1 @@
+Fleet UI: Add hover states to clickable elements

--- a/frontend/components/forms/fields/Checkbox/_styles.scss
+++ b/frontend/components/forms/fields/Checkbox/_styles.scss
@@ -22,6 +22,13 @@
         border: solid 2px $core-vibrant-blue;
       }
 
+      &:hover {
+        &::after {
+          background-color: $core-vibrant-blue-over;
+          border: solid 2px $core-vibrant-blue-over;
+        }
+      }
+
       &::before {
         @include position(absolute, 50% null null 50%);
         transform: rotate(45deg);
@@ -42,6 +49,7 @@
     @include size(20px);
     @include position(absolute, 0 null null 0);
     display: inline-block;
+    cursor: pointer;
 
     &::after {
       @include size(20px);
@@ -54,17 +62,32 @@
       background-color: $core-white;
       visibility: visible;
     }
+    &:hover {
+      &::after {
+        border: solid 2px $core-vibrant-blue-over;
+      }
+    }
 
     &--disabled {
       &::after {
         background-color: $ui-fleet-black-25;
       }
+      cursor: default;
     }
 
     &--indeterminate {
       &::after {
         background-color: $core-vibrant-blue;
         border: solid 1px $core-vibrant-blue;
+      }
+
+      &:hover {
+        &::after {
+          &::after {
+            background-color: $core-vibrant-blue-over;
+            border: solid 1px $core-vibrant-blue-over;
+          }
+        }
       }
 
       &::before {

--- a/frontend/components/forms/fields/Dropdown/_styles.scss
+++ b/frontend/components/forms/fields/Dropdown/_styles.scss
@@ -75,6 +75,8 @@
     background-color: $ui-light-grey;
     border: 0;
     border-radius: $border-radius;
+    cursor: pointer;
+
     .Select-value {
       font-size: $small;
       background-color: $ui-light-grey;

--- a/frontend/pages/DashboardPage/cards/MDM/MDM.tsx
+++ b/frontend/pages/DashboardPage/cards/MDM/MDM.tsx
@@ -166,6 +166,7 @@ const Mdm = ({
                   isAllPagesSelected={false}
                   disableCount
                   disablePagination
+                  disableMultiRowSelect
                   onClickRow={handleSolutionRowClick}
                 />
               )}

--- a/frontend/pages/hosts/ManageHostsPage/components/LabelFilterSelect/_styles.scss
+++ b/frontend/pages/hosts/ManageHostsPage/components/LabelFilterSelect/_styles.scss
@@ -25,7 +25,10 @@
     background-color: $ui-light-grey;
     border-radius: $border-radius;
     height: 40px;
-    cursor: default;
+
+    :hover {
+      cursor: pointer;
+    }
 
     &--is-focused,
     &--menu-is-open,

--- a/frontend/pages/hosts/ManageHostsPage/components/LabelFilterSelect/_styles.scss
+++ b/frontend/pages/hosts/ManageHostsPage/components/LabelFilterSelect/_styles.scss
@@ -25,6 +25,7 @@
     background-color: $ui-light-grey;
     border-radius: $border-radius;
     height: 40px;
+    cursor: default;
 
     &--is-focused,
     &--menu-is-open,


### PR DESCRIPTION
## Issue 
Cerra #17208 

## Description
- Find all clickable elements in UI that do not have a hover state and add hoverstate
  - Checkbox hoverstates added: unchecked has outline, checked/indeterminate gets darker, cursor becomes pointer
  - Rows that are clickable should have pointer cursor
  - Dropdowns that are clickable should have pointer cursor

## Screenrecording of fixes

https://www.loom.com/share/00e3309b15ab4f7887c5741cbdeaf3ba?sid=610fe6c9-2a4c-4ac0-b2e2-682f47a94786

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
- [x] Manual QA for all new/changed functionality

