### PR TITLE
record declarative checkin command responses

### DIFF
--- a/server/datastore/mysql/apple_mdm_test.go
+++ b/server/datastore/mysql/apple_mdm_test.go
@@ -69,6 +69,7 @@ func TestMDMApple(t *testing.T) {
 		{"TestMDMAppleDeleteHostDEPAssignments", testMDMAppleDeleteHostDEPAssignments},
 		{"LockUnlockWipeMacOS", testLockUnlockWipeMacOS},
 		{"ScreenDEPAssignProfileSerialsForCooldown", testScreenDEPAssignProfileSerialsForCooldown},
+		{"MDMAppleRecordDeclarativeCheckIn", testMDMAppleRecordDeclarativeCheckIn},
 	}
 
 	for _, c := range cases {
@@ -4568,6 +4569,49 @@ func testScreenDEPAssignProfileSerialsForCooldown(t *testing.T, ds *Datastore) {
 	require.NoError(t, err)
 	require.Empty(t, skip)
 	require.Empty(t, assign)
+}
+
+func testMDMAppleRecordDeclarativeCheckIn(t *testing.T, ds *Datastore) {
+	ctx := context.Background()
+
+	host, err := ds.NewHost(ctx, &fleet.Host{
+		Hostname:      "test-host1-name",
+		OsqueryHostID: ptr.String("1337"),
+		NodeKey:       ptr.String("1337"),
+		UUID:          "test-uuid-1",
+		TeamID:        nil,
+		Platform:      "darwin",
+	})
+	require.NoError(t, err)
+
+	// error if the host is not enrolled
+	err = ds.MDMAppleRecordDeclarativeCheckIn(ctx, host.UUID, []byte{})
+	require.Error(t, err)
+
+	// enroll the host
+	nanoEnroll(t, ds, host, true)
+
+	// it's okay if the host doesn't have matching command enqueued, the
+	// check-in could be initiated by the device.
+	err = ds.MDMAppleRecordDeclarativeCheckIn(ctx, host.UUID, []byte{})
+	require.NoError(t, err)
+
+	// enqueue a declarative checkin request
+	commander, _ := createMDMAppleCommanderAndStorage(t, ds)
+	cmdUUID := uuid.New().String()
+	err = commander.DeclarativeManagement(ctx, []string{host.UUID}, cmdUUID)
+	require.NoError(t, err)
+
+	// record a response from the host
+	err = ds.MDMAppleRecordDeclarativeCheckIn(ctx, host.UUID, []byte("foo"))
+	require.NoError(t, err)
+
+	res, err := ds.GetMDMAppleCommandResults(ctx, cmdUUID)
+	require.NoError(t, err)
+	require.Len(t, res, 1)
+	require.Equal(t, host.UUID, res[0].HostUUID)
+	require.Equal(t, fleet.MDMAppleStatusAcknowledged, res[0].Status)
+	require.EqualValues(t, []byte("foo"), res[0].Result)
 }
 
 func TestMDMAppleProfileVerification(t *testing.T) {

--- a/server/fleet/datastore.go
+++ b/server/fleet/datastore.go
@@ -1137,6 +1137,11 @@ type Datastore interface {
 	// host_dep_assignments for host with matching serials.
 	DeleteHostDEPAssignments(ctx context.Context, serials []string) error
 
+	// MDMAppleRecordDeclarativeCheckIn records a DeclarativeManagement
+	// checking from a host, so we know the host received the command to
+	// start the declarative management sync.
+	MDMAppleRecordDeclarativeCheckIn(ctx context.Context, hostUUID string, response []byte) error
+
 	// UpdateHostDEPAssignProfileResponses receives a profile UUID and threes lists of serials, each representing
 	// one of the three possible responses, and updates the host_dep_assignments table with the corresponding responses.
 	UpdateHostDEPAssignProfileResponses(ctx context.Context, resp *godep.ProfileResponse) error

--- a/server/mdm/apple/commander.go
+++ b/server/mdm/apple/commander.go
@@ -226,6 +226,28 @@ func (svc *MDMAppleCommander) AccountConfiguration(ctx context.Context, hostUUID
 	return svc.EnqueueCommand(ctx, hostUUIDs, raw)
 }
 
+// DeclarativeManagement sends the homonym [command][1] to the device to enable DDM or start a new DDM session.
+//
+// [1]: https://developer.apple.com/documentation/devicemanagement/declarativemanagementcommand
+func (svc *MDMAppleCommander) DeclarativeManagement(ctx context.Context, hostUUIDs []string, uuid string) error {
+	raw := fmt.Sprintf(`<?xml version="1.0" encoding="UTF-8"?>
+ <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+ <plist version="1.0">
+   <dict>
+     <key>Command</key>
+     <dict>
+       <key>RequestType</key>
+       <string>DeclarativeManagement</string>
+     </dict>
+
+     <key>CommandUUID</key>
+     <string>%s</string>
+   </dict>
+ </plist>`, uuid)
+
+	return svc.EnqueueCommand(ctx, hostUUIDs, raw)
+}
+
 // EnqueueCommand takes care of enqueuing the commands and sending push
 // notifications to the devices.
 //

--- a/server/mock/datastore_mock.go
+++ b/server/mock/datastore_mock.go
@@ -748,6 +748,8 @@ type GetMatchingHostSerialsFunc func(ctx context.Context, serials []string) (map
 
 type DeleteHostDEPAssignmentsFunc func(ctx context.Context, serials []string) error
 
+type MDMAppleRecordDeclarativeCheckInFunc func(ctx context.Context, hostUUID string, response []byte) error
+
 type UpdateHostDEPAssignProfileResponsesFunc func(ctx context.Context, resp *godep.ProfileResponse) error
 
 type ScreenDEPAssignProfileSerialsForCooldownFunc func(ctx context.Context, serials []string) (skipSerials []string, assignSerials []string, err error)
@@ -1953,6 +1955,9 @@ type DataStore struct {
 
 	DeleteHostDEPAssignmentsFunc        DeleteHostDEPAssignmentsFunc
 	DeleteHostDEPAssignmentsFuncInvoked bool
+
+	MDMAppleRecordDeclarativeCheckInFunc        MDMAppleRecordDeclarativeCheckInFunc
+	MDMAppleRecordDeclarativeCheckInFuncInvoked bool
 
 	UpdateHostDEPAssignProfileResponsesFunc        UpdateHostDEPAssignProfileResponsesFunc
 	UpdateHostDEPAssignProfileResponsesFuncInvoked bool
@@ -4675,6 +4680,13 @@ func (s *DataStore) DeleteHostDEPAssignments(ctx context.Context, serials []stri
 	s.DeleteHostDEPAssignmentsFuncInvoked = true
 	s.mu.Unlock()
 	return s.DeleteHostDEPAssignmentsFunc(ctx, serials)
+}
+
+func (s *DataStore) MDMAppleRecordDeclarativeCheckIn(ctx context.Context, hostUUID string, response []byte) error {
+	s.mu.Lock()
+	s.MDMAppleRecordDeclarativeCheckInFuncInvoked = true
+	s.mu.Unlock()
+	return s.MDMAppleRecordDeclarativeCheckInFunc(ctx, hostUUID, response)
 }
 
 func (s *DataStore) UpdateHostDEPAssignProfileResponses(ctx context.Context, resp *godep.ProfileResponse) error {

--- a/server/service/apple_mdm.go
+++ b/server/service/apple_mdm.go
@@ -2976,6 +2976,9 @@ func (svc *MDMAppleDDMService) DeclarativeManagement(r *mdm.Request, dm *mdm.Dec
 
 	switch {
 	case dm.Endpoint == "tokens":
+		if err := svc.ds.MDMAppleRecordDeclarativeCheckIn(r.Context, dm.UDID, dm.Raw); err != nil {
+			return nil, ctxerr.Wrap(r.Context, err, "recording declarative checkin")
+		}
 		// TODO(sarah): handle tokens
 		level.Debug(svc.logger).Log("msg", "received tokens request")
 		return nil, nil


### PR DESCRIPTION
this is to prevent nanomdm to send the DeclarativeManagement command every time the host checks in.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [x] Added/updated tests
- [x] Manual QA for all new/changed functionality
