### PR TITLE
Calendar interface updates and mock calendar

### DIFF
--- a/cmd/fleet/calendar_cron.go
+++ b/cmd/fleet/calendar_cron.go
@@ -231,9 +231,10 @@ func processFailingHostExistingCalendarEvent(
 	calendarEvent *fleet.CalendarEvent,
 	host fleet.HostPolicyMembershipData,
 ) error {
-	updatedEvent, updated, err := calendar.GetAndUpdateEvent(calendarEvent, func() string {
-		return generateCalendarEventBody(orgName, host.HostDisplayName)
-	})
+	updatedEvent, updated, err := calendar.GetAndUpdateEvent(
+		calendarEvent, func(bool) string {
+			return generateCalendarEventBody(orgName, host.HostDisplayName)
+		})
 	if err != nil {
 		return fmt.Errorf("get event calendar on db: %w", err)
 	}
@@ -325,9 +326,12 @@ func attemptCreatingEventOnUserCalendar(
 	// - If it’s the 3rd Tuesday, Weds, Thurs, etc. of the month and it’s past the last slot, schedule the call for the next business day.
 	year, month, today := time.Now().Date()
 	preferredDate := getPreferredCalendarEventDate(year, month, today)
-	body := generateCalendarEventBody(orgName, host.HostDisplayName)
 	for {
-		calendarEvent, err := userCalendar.CreateEvent(preferredDate, body)
+		calendarEvent, err := userCalendar.CreateEvent(
+			preferredDate, func(bool) string {
+				return generateCalendarEventBody(orgName, host.HostDisplayName)
+			},
+		)
 		var dee fleet.DayEndedError
 		switch {
 		case err == nil:

--- a/ee/server/calendar/google_calendar.go
+++ b/ee/server/calendar/google_calendar.go
@@ -50,8 +50,12 @@ type GoogleCalendar struct {
 
 func NewGoogleCalendar(config *GoogleCalendarConfig) *GoogleCalendar {
 	if config.API == nil {
-		var lowLevelAPI GoogleCalendarAPI = &GoogleCalendarLowLevelAPI{}
-		config.API = lowLevelAPI
+		if config.IntegrationConfig.Email == "calendar-mock@example.com" {
+			// Assumes that only 1 Fleet server accesses the calendar, since all mock events are held in memory
+			config.API = &GoogleCalendarMockAPI{}
+		} else {
+			config.API = &GoogleCalendarLowLevelAPI{}
+		}
 	}
 	return &GoogleCalendar{
 		config: config,
@@ -444,9 +448,6 @@ func (c *GoogleCalendar) googleEventToFleetEvent(startTime time.Time, endTime ti
 }
 
 func (c *GoogleCalendar) DeleteEvent(event *fleet.CalendarEvent) error {
-	if c.config == nil {
-		return errors.New("the Google calendar is not connected. Please call Configure first")
-	}
 	details, err := c.unmarshalDetails(event)
 	if err != nil {
 		return err

--- a/ee/server/calendar/google_calendar.go
+++ b/ee/server/calendar/google_calendar.go
@@ -173,6 +173,10 @@ func (c *GoogleCalendar) GetAndUpdateEvent(event *fleet.CalendarEvent, genBodyFn
 		if gEvent.End.DateTime == "" {
 			// User has modified the event to be an all-day event. All-day events are problematic because they depend on the user's timezone.
 			// We won't handle all-day events at this time, and treat the event as deleted.
+			err = c.DeleteEvent(event)
+			if err != nil {
+				level.Warn(c.config.Logger).Log("msg", "deleting Google calendar event which was changed to all-day event", "err", err)
+			}
 			deleted = true
 		}
 
@@ -200,6 +204,10 @@ func (c *GoogleCalendar) GetAndUpdateEvent(event *fleet.CalendarEvent, genBodyFn
 			if gEvent.Start.DateTime == "" {
 				// User has modified the event to be an all-day event. All-day events are problematic because they depend on the user's timezone.
 				// We won't handle all-day events at this time, and treat the event as deleted.
+				err = c.DeleteEvent(event)
+				if err != nil {
+					level.Warn(c.config.Logger).Log("msg", "deleting Google calendar event which was changed to all-day event", "err", err)
+				}
 				deleted = true
 			}
 		}

--- a/ee/server/calendar/google_calendar_mock.go
+++ b/ee/server/calendar/google_calendar_mock.go
@@ -19,7 +19,7 @@ type GoogleCalendarMockAPI struct {
 
 var events = make(map[string]*calendar.Event)
 var mu sync.Mutex
-var id uint64 = 0
+var id uint64
 
 const latency = 500 * time.Millisecond
 

--- a/ee/server/calendar/google_calendar_mock.go
+++ b/ee/server/calendar/google_calendar_mock.go
@@ -1,0 +1,81 @@
+package calendar
+
+import (
+	"context"
+	"errors"
+	kitlog "github.com/go-kit/log"
+	"google.golang.org/api/calendar/v3"
+	"google.golang.org/api/googleapi"
+	"net/http"
+	"os"
+	"strconv"
+	"sync"
+	"time"
+)
+
+type GoogleCalendarMockAPI struct {
+	logger kitlog.Logger
+}
+
+var events = make(map[string]*calendar.Event)
+var mu sync.Mutex
+var id uint64 = 0
+
+const latency = 500 * time.Millisecond
+
+// Configure creates a new Google Calendar service using the provided credentials.
+func (lowLevelAPI *GoogleCalendarMockAPI) Configure(_ context.Context, _ string, _ string, userToImpersonate string) error {
+	if lowLevelAPI.logger == nil {
+		lowLevelAPI.logger = kitlog.With(kitlog.NewLogfmtLogger(os.Stderr), "mock", "GoogleCalendarMockAPI", "user", userToImpersonate)
+	}
+	return nil
+}
+
+func (lowLevelAPI *GoogleCalendarMockAPI) GetSetting(name string) (*calendar.Setting, error) {
+	time.Sleep(latency)
+	lowLevelAPI.logger.Log("msg", "GetSetting", "name", name)
+	if name == "timezone" {
+		return &calendar.Setting{
+			Id:    "timezone",
+			Value: "America/Chicago",
+		}, nil
+	}
+	return nil, errors.New("setting not supported")
+}
+
+func (lowLevelAPI *GoogleCalendarMockAPI) CreateEvent(event *calendar.Event) (*calendar.Event, error) {
+	mu.Lock()
+	defer mu.Unlock()
+	id += 1
+	event.Id = strconv.FormatUint(id, 10)
+	lowLevelAPI.logger.Log("msg", "CreateEvent", "id", event.Id, "start", event.Start.DateTime)
+	events[event.Id] = event
+	return event, nil
+}
+
+func (lowLevelAPI *GoogleCalendarMockAPI) GetEvent(id, _ string) (*calendar.Event, error) {
+	time.Sleep(latency)
+	mu.Lock()
+	defer mu.Unlock()
+	event, ok := events[id]
+	if !ok {
+		return nil, &googleapi.Error{Code: http.StatusNotFound}
+	}
+	lowLevelAPI.logger.Log("msg", "GetEvent", "id", id, "start", event.Start.DateTime)
+	return event, nil
+}
+
+func (lowLevelAPI *GoogleCalendarMockAPI) ListEvents(string, string) (*calendar.Events, error) {
+	time.Sleep(latency)
+	lowLevelAPI.logger.Log("msg", "ListEvents")
+	return &calendar.Events{}, nil
+}
+
+func (lowLevelAPI *GoogleCalendarMockAPI) DeleteEvent(id string) error {
+	time.Sleep(latency)
+	mu.Lock()
+	defer mu.Unlock()
+	lowLevelAPI.logger.Log("msg", "DeleteEvent", "id", id)
+	delete(events, id)
+	return nil
+}

--- a/ee/server/calendar/google_calendar_test.go
+++ b/ee/server/calendar/google_calendar_test.go
@@ -346,6 +346,10 @@ func TestGoogleCalendar_GetAndUpdateEvent(t *testing.T) {
 	assert.True(t, eventCreated)
 
 	// all day event (deleted)
+	mockAPI.DeleteEventFunc = func(id string) error {
+		assert.Equal(t, baseEventID, id)
+		return nil
+	}
 	mockAPI.GetEventFunc = func(id, eTag string) (*calendar.Event, error) {
 		return &calendar.Event{
 			Id:    baseEventID,
@@ -374,10 +378,6 @@ func TestGoogleCalendar_GetAndUpdateEvent(t *testing.T) {
 		}, nil
 	}
 	eventCreated = false
-	mockAPI.DeleteEventFunc = func(id string) error {
-		assert.Equal(t, baseEventID, id)
-		return nil
-	}
 	retrievedEvent, updated, err = cal.GetAndUpdateEvent(event, genBodyFn)
 	require.NoError(t, err)
 	assert.True(t, updated)

--- a/server/fleet/calendar.go
+++ b/server/fleet/calendar.go
@@ -21,11 +21,11 @@ type UserCalendar interface {
 	// CreateEvent, GetAndUpdateEvent and DeleteEvent reference the user's calendar.
 	Configure(userEmail string) error
 	// CreateEvent creates a new event on the calendar on the given date. DayEndedError is returned if there is no time left on the given date to schedule event.
-	CreateEvent(dateOfEvent time.Time, body string) (event *CalendarEvent, err error)
+	CreateEvent(dateOfEvent time.Time, genBodyFn func(conflict bool) string) (event *CalendarEvent, err error)
 	// GetAndUpdateEvent retrieves the event from the calendar.
 	// If the event has been modified, it returns the updated event.
 	// If the event has been deleted, it schedules a new event with given body callback and returns the new event.
-	GetAndUpdateEvent(event *CalendarEvent, genBodyFn func() string) (updatedEvent *CalendarEvent, updated bool, err error)
+	GetAndUpdateEvent(event *CalendarEvent, genBodyFn func(conflict bool) string) (updatedEvent *CalendarEvent, updated bool, err error)
 	// DeleteEvent deletes the event with the given ID.
 	DeleteEvent(event *CalendarEvent) error
 }


### PR DESCRIPTION
- Updated calendar interface to use updated `genBodyFn`
- The mock calendar is enabled by specifying `calendar-mock@example.com` as the service account email.

