### PR TITLE
Website: Update Vanta integration script to retry failed requests to Vanta's authorization endpoint.

### DIFF
--- a/website/scripts/send-data-to-vanta.js
+++ b/website/scripts/send-data-to-vanta.js
@@ -34,7 +34,9 @@ module.exports = {
           grant_type: 'refresh_token',// eslint-disable-line camelcase
         },
         headers: { accept: 'application/json' }
-      }).tolerate((err)=>{
+      })
+      .retry({raw:{statusCode: 503}})
+      .tolerate((err)=>{
         // If an error occurs while sending a request to Vanta, we'll add the error to the errorReportById object, with this connections ID set as the key.
         errorReportById[connectionIdAsString] = new Error(`Could not refresh the token for Vanta connection (id: ${connectionIdAsString}). Full error: ${err}`);
       });


### PR DESCRIPTION
Changes:
- Chained a `.retry()` onto the post request that refreshes authorization tokens for Vanta connections, that will retry requests that return a `503 service unavailable` response.