### PR TITLE
Website: Add meta tag to exclude docs pages from fleetdm.com/docs

### DIFF
--- a/docs/Deploy/kubernetes/README.md
+++ b/docs/Deploy/kubernetes/README.md
@@ -1,1 +1,4 @@
 This folder includes the best practice YAML files for [deploying Fleet on Kubernetes](https://fleetdm.com/docs/deploy/deploy-fleet-on-kubernetes). 
+
+
+<meta name="hiddenOnFleetWebsite" value="true">

--- a/website/scripts/build-static-content.js
+++ b/website/scripts/build-static-content.js
@@ -407,6 +407,10 @@ module.exports = {
               let pageOrderInSection;
               let docNavCategory;
               if(sectionRepoPath === 'docs/') {
+                // If a page has a hiddenOnFleetWebsite meta tag set to "true", we won't add this page to the builtStaticContent.markdownPages array.
+                if(embeddedMetadata.hiddenOnFleetWebsite && embeddedMetadata.hiddenOnFleetWebsite === 'true'){
+                  continue;
+                }
                 // Set a flag to determine if the page is a readme (e.g. /docs/Using-Fleet/configuration-files/readme.md) or a FAQ page.
                 // READMEs in subfolders and FAQ pages don't have pageOrderInSection values, they are always sorted at the end of sections.
                 let isPageAReadmeOrFAQ = (_.last(pageUnextensionedUnwhitespacedLowercasedRelPath.split(/\//)) === 'faq' || _.last(pageUnextensionedUnwhitespacedLowercasedRelPath.split(/\//)) === 'readme');


### PR DESCRIPTION
Closes: #17582

Changes:
- Updated the `build-static-content` script to add support for a new meta tag on docs pages: `hiddenOnFleetWebsite`, a tag that, if set to `true`, will not add the Markdown page to the website's `builtStaticContent.markdownPages` configuration.
- Added a `hiddenOnFleetWebsite` meta tag to docs/deploy/kubernetes folder README.