### PR TITLE
Website: Update `build-static-content` script to ignore pages in the docs/contributing/ folder.

### DIFF
--- a/website/scripts/build-static-content.js
+++ b/website/scripts/build-static-content.js
@@ -202,6 +202,11 @@ module.exports = {
               .replace(/(^|\/)([^/]+)\.[^/]*$/, '$1$2')
               .split(/\//).map((fileOrFolderName) => fileOrFolderName.toLowerCase().replace(/\s+/g, '-')).join('/')
             );
+
+            // If this page is in the docs/contributing/ folder, skip it.
+            if(sectionRepoPath === 'docs/' && _.startsWith(pageUnextensionedUnwhitespacedLowercasedRelPath, 'contributing/')){
+              continue;
+            }
             let RX_README_FILENAME = /\/?readme\.?m?d?$/i;// « for matching `readme` or `readme.md` (case-insensitive) at the end of a file path
 
             // Determine this page's default (fallback) display title.


### PR DESCRIPTION
Closes: #17667

Changes:
- Updated `build-static-content` to skip pages in the docs/contributing folder when Markdown pages are converted to HTML partials.