### PR TITLE
[released bug] Fleet UI: standard query library platforms render prop…

### DIFF
--- a/changes/17662-render-standard-query-platforms-correctly
+++ b/changes/17662-render-standard-query-platforms-correctly
@@ -1,0 +1,1 @@
+- Fixes UI bug to render the query platform correctly for queries imported from the standard query library

--- a/frontend/pages/queries/edit/components/EditQueryForm/EditQueryForm.tsx
+++ b/frontend/pages/queries/edit/components/EditQueryForm/EditQueryForm.tsx
@@ -724,7 +724,7 @@ const EditQueryForm = ({
                     placeholder="Select"
                     label="Platform"
                     onChange={onChangeSelectPlatformOptions}
-                    value={lastEditedQueryPlatforms}
+                    value={lastEditedQueryPlatforms.replace(/\s/g, "")} // NOTE: FE requires no whitespace to render UI
                     multi
                     wrapperClassName={`${baseClass}__form-field form-field--platform`}
                     helpText="By default, your query collects data on all compatible platforms."


### PR DESCRIPTION
## Issue
Cerra #17662 
This fix is also in Feature PR https://github.com/fleetdm/fleet/pull/17663 but added here so if we want to include it in a patch

## Description
- The FE doesn't recognize whitespaces in it's multiple dropdown menu
- Removes whitespace between platform names to render the dropdown

Alternative was to modify the `Dropdown` component to allow joins with `", "` and `","` but that was complicating the component for a one-off issue.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
- [x] Manual QA for all new/changed functionality
