### PR TITLE
Support status and label filters in bulk opts

### DIFF
--- a/changes/17513-bulk-host-opts-filters
+++ b/changes/17513-bulk-host-opts-filters
@@ -1,0 +1,1 @@
+- Bulk Host Delete and Transfer now support status and labelID filters together

--- a/server/service/hosts.go
+++ b/server/service/hosts.go
@@ -373,10 +373,11 @@ func (svc *Service) CountHosts(ctx context.Context, labelID *uint, opts fleet.Ho
 }
 
 func (svc *Service) countHostFromFilters(ctx context.Context, labelID *uint, opt fleet.HostListOptions) (int, error) {
-	filter, err := processHostFilters(ctx, opt, nil)
-	if err != nil {
-		return 0, err
+	vc, ok := viewer.FromContext(ctx)
+	if !ok {
+		return 0, fleet.ErrNoContext
 	}
+	filter := fleet.TeamFilter{User: vc.User, IncludeObserver: true}
 
 	if !license.IsPremium(ctx) {
 		// the low disk space filter is premium-only
@@ -384,6 +385,7 @@ func (svc *Service) countHostFromFilters(ctx context.Context, labelID *uint, opt
 	}
 
 	var count int
+	var err error
 	if labelID != nil {
 		count, err = svc.ds.CountHostsInLabel(ctx, filter, *labelID, opt)
 	} else {
@@ -1276,13 +1278,15 @@ func (svc *Service) GetHostQueryReportResults(ctx context.Context, hostID uint, 
 }
 
 func (svc *Service) hostIDsAndNamesFromFilters(ctx context.Context, opt fleet.HostListOptions, lid *uint) ([]uint, []string, []*fleet.Host, error) {
-	filter, err := processHostFilters(ctx, opt, lid)
-	if err != nil {
-		return nil, nil, nil, err
+	vc, ok := viewer.FromContext(ctx)
+	if !ok {
+		return nil, nil, nil, fleet.ErrNoContext
 	}
+	filter := fleet.TeamFilter{User: vc.User, IncludeObserver: true}
 
 	// Load hosts, either from label if provided or from all hosts.
 	var hosts []*fleet.Host
+	var err error
 	if lid != nil {
 		hosts, err = svc.ds.ListHostsInLabel(ctx, filter, *lid, opt)
 	} else {
@@ -1304,21 +1308,6 @@ func (svc *Service) hostIDsAndNamesFromFilters(ctx context.Context, opt fleet.Ho
 		hostNames = append(hostNames, h.DisplayName())
 	}
 	return hostIDs, hostNames, hosts, nil
-}
-
-func processHostFilters(ctx context.Context, opt fleet.HostListOptions, lid *uint) (fleet.TeamFilter, error) {
-	vc, ok := viewer.FromContext(ctx)
-	if !ok {
-		return fleet.TeamFilter{}, fleet.ErrNoContext
-	}
-	filter := fleet.TeamFilter{User: vc.User, IncludeObserver: true}
-
-	if opt.StatusFilter != "" && lid != nil {
-		return fleet.TeamFilter{}, fleet.NewInvalidArgumentError("status", "may not be provided with label_id")
-	}
-
-	opt.PerPage = fleet.PerPageUnlimited
-	return filter, nil
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/server/service/integration_core_test.go
+++ b/server/service/integration_core_test.go
@@ -3032,7 +3032,8 @@ func (s *integrationTestSuite) TestHostsAddToTeam() {
 	labelID := lblIDs["All Hosts"]
 
 	// Add label to host0
-	s.ds.RecordLabelQueryExecutions(context.Background(), hosts[0], map[uint]*bool{labelID: ptr.Bool(true)}, time.Now(), false)
+	err = s.ds.RecordLabelQueryExecutions(context.Background(), hosts[0], map[uint]*bool{labelID: ptr.Bool(true)}, time.Now(), false)
+	require.NoError(t, err)
 
 	// offline status filter request should not move hosts
 	req = addHostsToTeamByFilterRequest{

--- a/server/service/integration_core_test.go
+++ b/server/service/integration_core_test.go
@@ -3046,7 +3046,6 @@ func (s *integrationTestSuite) TestHostsAddToTeam() {
 	require.Equal(t, tm1.ID, *hostsResp.Hosts[0].TeamID)
 	require.Equal(t, tm1.ID, *hostsResp.Hosts[1].TeamID)
 	require.Equal(t, tm2.ID, *hostsResp.Hosts[2].TeamID)
-	
 
 	// assign host0 to team 2 with filter
 	req = addHostsToTeamByFilterRequest{


### PR DESCRIPTION
#17513

removed validation limiting simultaneous status and labelID filters.

- [X] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
- [ ] Added/updated tests
- [X] Manual QA for all new/changed functionality