### PR TITLE
bugfixes, integration and cleanup for DDM

### DIFF
--- a/server/datastore/mysql/apple_mdm.go
+++ b/server/datastore/mysql/apple_mdm.go
@@ -3323,13 +3323,13 @@ func batchSetDeclarationLabelAssociationsDB(ctx context.Context, tx sqlx.ExtCont
 	// unrelated profile+label tuples)
 	deleteStmt := `
 	  DELETE FROM mdm_declaration_labels
-	  WHERE (declaration_uuid, label_id) NOT IN (%s) AND
-	  declaration_uuid IN (?)
+	  WHERE (apple_declaration_uuid, label_id) NOT IN (%s) AND
+	  apple_declaration_uuid IN (?)
 	`
 
 	upsertStmt := `
 	  INSERT INTO mdm_declaration_labels
-              (declaration_uuid, label_id, label_name)
+              (apple_declaration_uuid, label_id, label_name)
           VALUES
               %s
           ON DUPLICATE KEY UPDATE

--- a/server/datastore/mysql/apple_mdm.go
+++ b/server/datastore/mysql/apple_mdm.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"database/sql"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
@@ -109,15 +108,15 @@ func formatErrorDuplicateConfigProfile(err error, cp *fleet.MDMAppleConfigProfil
 
 func formatErrorDuplicateDeclaration(err error, decl *fleet.MDMAppleDeclaration) error {
 	switch {
-	case strings.Contains(err.Error(), "idx_mdm_apple_config_prof_team_identifier"):
+	case strings.Contains(err.Error(), "idx_mdm_apple_declaration_team_identifier"):
 		return &existsError{
-			ResourceType: "MDMAppleConfigProfile.PayloadIdentifier",
+			ResourceType: "MDMAppleDeclaration.Identifier",
 			Identifier:   decl.Identifier,
 			TeamID:       decl.TeamID,
 		}
-	case strings.Contains(err.Error(), "idx_mdm_apple_config_prof_team_name"):
+	case strings.Contains(err.Error(), "idx_mdm_apple_declaration_team_name"):
 		return &existsError{
-			ResourceType: "MDMAppleConfigProfile.PayloadDisplayName",
+			ResourceType: "MDMAppleDeclaration.Name",
 			Identifier:   decl.Name,
 			TeamID:       decl.TeamID,
 		}
@@ -3107,9 +3106,9 @@ INSERT INTO mdm_apple_declarations (
 	declaration_uuid,
 	identifier,
 	name,
-	declaration_type,
-	declaration,
-	md5_checksum,
+	category,
+	raw_json,
+	checksum,
 	uploaded_at,
 	team_id
 )
@@ -3117,10 +3116,10 @@ VALUES (
 	?,?,?,?,?,UNHEX(?),CURRENT_TIMESTAMP(),?
 )
 ON DUPLICATE KEY UPDATE
-  uploaded_at = IF(md5_checksum = VALUES(md5_checksum) AND name = VALUES(name), uploaded_at, CURRENT_TIMESTAMP()),
-  md5_checksum = VALUES(md5_checksum),
+  uploaded_at = IF(checksum = VALUES(checksum) AND name = VALUES(name), uploaded_at, CURRENT_TIMESTAMP()),
+  checksum = VALUES(checksum),
   name = VALUES(name),
-  declaration = VALUES(declaration)
+  raw_json = VALUES(raw_json)
 `
 
 	fmtDeleteStmt := `
@@ -3135,7 +3134,7 @@ WHERE
 SELECT
   identifier,
   declaration_uuid,
-  declaration
+  raw_json
 FROM
   mdm_apple_declarations
 WHERE
@@ -3218,14 +3217,14 @@ WHERE
 	}
 
 	for _, d := range declarations {
-		checksum := md5ChecksumScriptContent(string(d.Declaration))
+		checksum := md5ChecksumScriptContent(string(d.RawJSON))
 		declUUID := "x" + uuid.NewString()
 		if _, err := tx.ExecContext(ctx, insertStmt,
 			declUUID,
 			d.Identifier,
 			d.Name,
-			d.DeclarationType,
-			d.Declaration,
+			d.Category,
+			d.RawJSON,
 			checksum,
 			declTeamID); err != nil || strings.HasPrefix(ds.testBatchSetMDMAppleProfilesErr, "insert") {
 			if err == nil {
@@ -3253,7 +3252,7 @@ WHERE
 
 func (ds *Datastore) NewMDMAppleDeclaration(ctx context.Context, declaration *fleet.MDMAppleDeclaration) (*fleet.MDMAppleDeclaration, error) {
 	declUUID := "x" + uuid.NewString()
-	checksum := md5ChecksumScriptContent(string(declaration.Declaration))
+	checksum := md5ChecksumScriptContent(string(declaration.RawJSON))
 
 	stmt := `
 INSERT INTO mdm_apple_declarations (
@@ -3261,9 +3260,9 @@ INSERT INTO mdm_apple_declarations (
 	team_id,
 	identifier,
 	name,
-	declaration_type,
-	declaration,
-	md5_checksum,
+	category,
+	raw_json,
+	checksum,
 	uploaded_at
 )
 VALUES (
@@ -3278,7 +3277,7 @@ VALUES (
 
 	err := ds.withTx(ctx, func(tx sqlx.ExtContext) error {
 		res, err := tx.ExecContext(ctx, stmt,
-			declUUID, tmID, declaration.Identifier, declaration.Name, declaration.DeclarationType, declaration.Declaration, checksum)
+			declUUID, tmID, declaration.Identifier, declaration.Name, declaration.Category, declaration.RawJSON, checksum)
 		if err != nil {
 			switch {
 			case isDuplicate(err):
@@ -3390,9 +3389,9 @@ func batchSetDeclarationLabelAssociationsDB(ctx context.Context, tx sqlx.ExtCont
 func (ds *Datastore) MDMAppleDDMDeclarationsToken(ctx context.Context, hostUUID string) (*fleet.MDMAppleDDMDeclarationsToken, error) {
 	const stmt = `
 SELECT
-	md5((count(0) + group_concat(hex(mad.md5_checksum)
+	md5((count(0) + group_concat(hex(mad.checksum)
 		ORDER BY
-			mad.uploaded_at DESC separator ''))) AS md5_checksum,
+			mad.uploaded_at DESC separator ''))) AS checksum,
 	max(mad.created_at) AS latest_created_timestamp
 FROM
 	host_mdm_apple_declarations hmad
@@ -3411,9 +3410,9 @@ WHERE
 func (ds *Datastore) MDMAppleDDMDeclarationItems(ctx context.Context, hostUUID string) ([]fleet.MDMAppleDDMDeclarationItem, error) {
 	const stmt = `
 SELECT
-	mad.md5_checksum,
+	HEX(mad.checksum) as checksum,
 	mad.identifier,
-	mad.declaration_type
+	mad.category
 FROM
 	host_mdm_apple_declarations hmad
 	JOIN mdm_apple_declarations mad ON mad.declaration_uuid = hmad.declaration_uuid
@@ -3428,100 +3427,24 @@ WHERE
 	return res, nil
 }
 
-func (ds *Datastore) MDMAppleDDMDeclarationsResponse(ctx context.Context, declarationType fleet.MDMAppleDeclarationType, identifier string, hostUUID string) (json.RawMessage, error) {
+func (ds *Datastore) MDMAppleDDMDeclarationsResponse(ctx context.Context, declarationType fleet.MDMAppleDeclarationCategory, identifier string, hostUUID string) (*fleet.MDMAppleDeclaration, error) {
 	// TODO: When hosts table is indexed by uuid, consider joining on hosts to ensure that the
 	// declaration for the host's current team is returned. In the case where the specified
 	// identifier is not unique to the team, the cron should ensure that any conflicting
 	// declarations are removed, but the join would provide an extra layer of safety.
 	const stmt = `
 SELECT
-	mad.declaration
+	mad.raw_json, HEX(mad.checksum) as checksum
 FROM
 	host_mdm_apple_declarations hmad
 	JOIN mdm_apple_declarations mad ON hmad.declaration_uuid = mad.declaration_uuid
 WHERE
-	host_uuid = ? AND identifier = ? AND declaration_type = ? AND operation_type = ?`
+	host_uuid = ? AND identifier = ? AND category = ? AND operation_type = ?`
 
-	var res json.RawMessage
+	var res fleet.MDMAppleDeclaration
 	if err := sqlx.GetContext(ctx, ds.reader(ctx), &res, stmt, hostUUID, identifier, declarationType, fleet.MDMOperationTypeInstall); err != nil {
 		return nil, ctxerr.Wrap(ctx, err, "get ddm declarations response")
 	}
 
-	return res, nil
-}
-
-func (ds *Datastore) MDMAppleRecordDeclarativeCheckIn(ctx context.Context, hostUUID string, result []byte) error {
-	err := ds.withRetryTxx(ctx, func(tx sqlx.ExtContext) error {
-		res, err := tx.ExecContext(
-			ctx,
-			`UPDATE nano_enrollments SET last_seen_at = CURRENT_TIMESTAMP WHERE id = ?`,
-			hostUUID,
-		)
-		if err != nil {
-			return ctxerr.Wrap(ctx, err, "updating last_seen times")
-		}
-		if n, _ := res.RowsAffected(); n == 0 {
-			return ctxerr.New(ctx, "host is not enrolled in MDM")
-		}
-
-		// NOTE: DeclarativeManagement checkin commands sent by the device
-		// don't carry a CommandUUID reference like commands in
-		// CommandAndReportResults messages do.
-		//
-		// In nanomdm's view of the world, a command is pending until
-		// it receives a result or is deactivated, so we'll grab the
-		// command_uuid of the oldest DeclarativeManagement command we
-		// sent and assume this is the response for it.
-		//
-		// Other DeclarativeManagement commands will still be in the
-		// queue and they will trigger DDM syncs when the device checks
-		// in, so eventually all DDM commands wil get acknowledged.
-		//
-		// Alternatively, we could mark all DDM commands as
-		// acknowledged here, TBD based on the behaviors we see.
-		var cmdUUID string
-		err = sqlx.GetContext(ctx, tx, &cmdUUID, `
-SELECT nc.command_uuid
-FROM nano_enrollment_queue neq
-JOIN nano_commands nc
-  ON neq.command_uuid = nc.command_uuid
-WHERE
-  id = ? AND
-  request_type = 'DeclarativeManagement'
-ORDER BY neq.created_at ASC
-LIMIT 1
-		`, hostUUID)
-		if err != nil {
-			// it's okay if the host doesn't have matching command enqueued, the
-			// check-in could be initiated by the device.
-			if err == sql.ErrNoRows {
-				return nil
-			}
-
-			return ctxerr.Wrap(ctx, err, "getting DDM command")
-		}
-
-		_, err = tx.ExecContext(
-			ctx, `
-INSERT INTO nano_command_results
-    (id, command_uuid, status, result)
-VALUES
-    (?, ?, ?, ?)
-ON DUPLICATE KEY
-UPDATE
-    status = VALUES(status),
-    result = VALUES(result)`,
-			hostUUID,
-			cmdUUID,
-			fleet.MDMAppleStatusAcknowledged,
-			result,
-		)
-
-		return ctxerr.Wrap(ctx, err, "updating nano_command_results")
-	})
-	if err != nil {
-		return ctxerr.Wrap(ctx, err, "saving declarative management response")
-	}
-
-	return nil
+	return &res, nil
 }

--- a/server/datastore/mysql/mdm.go
+++ b/server/datastore/mysql/mdm.go
@@ -272,15 +272,15 @@ func (ds *Datastore) listDeclarationLabelsForDeclarations(ctx context.Context, d
 
 	stmt := `
 SELECT
-	declaration_uuid AS profile_uuid,
+	apple_declaration_uuid AS profile_uuid,
 	label_name,
 	label_id
 FROM
 	mdm_declaration_labels
 WHERE
-	declaration_uuid IN (?)
+	apple_declaration_uuid IN (?)
 ORDER BY
-	declaration_uuid, label_name
+	apple_declaration_uuid, label_name
 	`
 
 	stmt, args, err := sqlx.In(stmt, declUUIDs)

--- a/server/datastore/mysql/mdm.go
+++ b/server/datastore/mysql/mdm.go
@@ -177,12 +177,12 @@ FROM (
 		name,
 		'darwin' AS platform,
 		identifier,
-		md5_checksum AS checksum,
+		checksum AS checksum,
 		created_at,
 		uploaded_at
 	FROM mdm_apple_declarations
 	WHERE team_id = ?
-	AND declaration_type <> ?
+	AND category <> ?
 ) as combined_profiles
 `
 

--- a/server/datastore/mysql/migrations/tables/20240314150853_AddDDMTables.go
+++ b/server/datastore/mysql/migrations/tables/20240314150853_AddDDMTables.go
@@ -70,8 +70,8 @@ CREATE TABLE mdm_declaration_labels (
     -- id is used as the primary key of this table
     id int(10) unsigned NOT NULL AUTO_INCREMENT,
 
-    -- declaration_uuid references a declaration
-    declaration_uuid varchar(37) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+    -- apple_declaration_uuid references a declaration
+    apple_declaration_uuid varchar(37) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
 
 
     -- label name is stored here because we need to list the labels in the UI
@@ -86,9 +86,9 @@ CREATE TABLE mdm_declaration_labels (
     uploaded_at timestamp NULL DEFAULT NULL,
 
     PRIMARY KEY (id),
-    UNIQUE KEY idx_mdm_declaration_labels_label_name (declaration_uuid, label_name),
+    UNIQUE KEY idx_mdm_declaration_labels_label_name (apple_declaration_uuid, label_name),
     KEY label_id (label_id),
-    CONSTRAINT mdm_declaration_labels_ibfk_1 FOREIGN KEY (declaration_uuid) REFERENCES mdm_apple_declarations (declaration_uuid) ON DELETE CASCADE,
+    CONSTRAINT mdm_declaration_labels_ibfk_1 FOREIGN KEY (apple_declaration_uuid) REFERENCES mdm_apple_declarations (declaration_uuid) ON DELETE CASCADE,
     CONSTRAINT mdm_declaration_labels_ibfk_3 FOREIGN KEY (label_id) REFERENCES labels (id) ON DELETE SET NULL
 )
     `)
@@ -132,6 +132,12 @@ CREATE TABLE host_mdm_apple_declarations (
 
     -- declaration_uuid references the declaration assigned to the host's team
     declaration_uuid varchar(37) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+
+   -- declaration_identifier is the identifier of the declaration
+    declaration_identifier varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+
+    -- declaration_name is the name of the declaration
+    declaration_name varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
 
     PRIMARY KEY (host_uuid, declaration_uuid),
     KEY status (status),

--- a/server/datastore/mysql/schema.sql
+++ b/server/datastore/mysql/schema.sql
@@ -312,6 +312,8 @@ CREATE TABLE `host_mdm_apple_declarations` (
   `detail` text COLLATE utf8mb4_unicode_ci,
   `checksum` binary(16) NOT NULL,
   `declaration_uuid` varchar(37) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `declaration_identifier` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `declaration_name` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   PRIMARY KEY (`host_uuid`,`declaration_uuid`),
   KEY `status` (`status`),
   KEY `operation_type` (`operation_type`),
@@ -764,15 +766,15 @@ CREATE TABLE `mdm_configuration_profile_labels` (
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `mdm_declaration_labels` (
   `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `declaration_uuid` varchar(37) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `apple_declaration_uuid` varchar(37) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   `label_name` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
   `label_id` int(10) unsigned DEFAULT NULL,
   `created_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
   `uploaded_at` timestamp NULL DEFAULT NULL,
   PRIMARY KEY (`id`),
-  UNIQUE KEY `idx_mdm_declaration_labels_label_name` (`declaration_uuid`,`label_name`),
+  UNIQUE KEY `idx_mdm_declaration_labels_label_name` (`apple_declaration_uuid`,`label_name`),
   KEY `label_id` (`label_id`),
-  CONSTRAINT `mdm_declaration_labels_ibfk_1` FOREIGN KEY (`declaration_uuid`) REFERENCES `mdm_apple_declarations` (`declaration_uuid`) ON DELETE CASCADE,
+  CONSTRAINT `mdm_declaration_labels_ibfk_1` FOREIGN KEY (`apple_declaration_uuid`) REFERENCES `mdm_apple_declarations` (`declaration_uuid`) ON DELETE CASCADE,
   CONSTRAINT `mdm_declaration_labels_ibfk_3` FOREIGN KEY (`label_id`) REFERENCES `labels` (`id`) ON DELETE SET NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;

--- a/server/datastore/mysql/schema.sql
+++ b/server/datastore/mysql/schema.sql
@@ -310,7 +310,7 @@ CREATE TABLE `host_mdm_apple_declarations` (
   `status` varchar(20) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `operation_type` varchar(20) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `detail` text COLLATE utf8mb4_unicode_ci,
-  `md5_checksum` binary(16) NOT NULL,
+  `checksum` binary(16) NOT NULL,
   `declaration_uuid` varchar(37) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   PRIMARY KEY (`host_uuid`,`declaration_uuid`),
   KEY `status` (`status`),
@@ -658,12 +658,12 @@ CREATE TABLE `mdm_apple_declaration_activation_references` (
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
-CREATE TABLE `mdm_apple_declaration_types` (
-  `declaration_type` varchar(50) COLLATE utf8mb4_unicode_ci NOT NULL,
-  PRIMARY KEY (`declaration_type`)
+CREATE TABLE `mdm_apple_declaration_categories` (
+  `declaration_category` varchar(50) COLLATE utf8mb4_unicode_ci NOT NULL,
+  PRIMARY KEY (`declaration_category`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
-INSERT INTO `mdm_apple_declaration_types` VALUES ('com.apple.activation'),('com.apple.configuration');
+INSERT INTO `mdm_apple_declaration_categories` VALUES ('com.apple.activation'),('com.apple.configuration');
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `mdm_apple_declarations` (
@@ -671,16 +671,16 @@ CREATE TABLE `mdm_apple_declarations` (
   `team_id` int(10) unsigned NOT NULL DEFAULT '0',
   `identifier` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
   `name` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
-  `declaration_type` varchar(50) COLLATE utf8mb4_unicode_ci NOT NULL,
-  `declaration` json NOT NULL,
-  `md5_checksum` binary(16) NOT NULL,
+  `category` varchar(50) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `raw_json` json NOT NULL,
+  `checksum` binary(16) NOT NULL,
   `created_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
   `uploaded_at` timestamp NULL DEFAULT NULL,
   PRIMARY KEY (`declaration_uuid`),
   UNIQUE KEY `idx_mdm_apple_declaration_team_identifier` (`team_id`,`identifier`),
   UNIQUE KEY `idx_mdm_apple_declaration_team_name` (`team_id`,`name`),
-  KEY `mdm_apple_declaration_declaration_type` (`declaration_type`),
-  CONSTRAINT `mdm_apple_declaration_declaration_type` FOREIGN KEY (`declaration_type`) REFERENCES `mdm_apple_declaration_types` (`declaration_type`) ON DELETE CASCADE
+  KEY `mdm_apple_declaration_category` (`category`),
+  CONSTRAINT `mdm_apple_declaration_category` FOREIGN KEY (`category`) REFERENCES `mdm_apple_declaration_categories` (`declaration_category`) ON DELETE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
@@ -1470,13 +1470,6 @@ CREATE TABLE `statistics` (
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
-SET @saved_cs_client     = @@character_set_client;
-SET character_set_client = utf8;
-/*!50001 CREATE VIEW `team_declaration_checksum_view` AS SELECT 
- 1 AS `team_id`,
- 1 AS `md5_checksum`,
- 1 AS `latest_created_timestamp`*/;
-SET character_set_client = @saved_cs_client;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `teams` (
@@ -1643,19 +1636,6 @@ CREATE TABLE `wstep_serials` (
 /*!50001 CREATE ALGORITHM=UNDEFINED */
 /*!50013 DEFINER=`root`@`%` SQL SECURITY DEFINER */
 /*!50001 VIEW `nano_view_queue` AS select `q`.`id` AS `id`,`q`.`created_at` AS `created_at`,`q`.`active` AS `active`,`q`.`priority` AS `priority`,`c`.`command_uuid` AS `command_uuid`,`c`.`request_type` AS `request_type`,`c`.`command` AS `command`,`r`.`updated_at` AS `result_updated_at`,`r`.`status` AS `status`,`r`.`result` AS `result` from ((`nano_enrollment_queue` `q` join `nano_commands` `c` on((`q`.`command_uuid` = `c`.`command_uuid`))) left join `nano_command_results` `r` on(((`r`.`command_uuid` = `q`.`command_uuid`) and (`r`.`id` = `q`.`id`)))) order by `q`.`priority` desc,`q`.`created_at` */;
-/*!50001 SET character_set_client      = @saved_cs_client */;
-/*!50001 SET character_set_results     = @saved_cs_results */;
-/*!50001 SET collation_connection      = @saved_col_connection */;
-/*!50001 DROP VIEW IF EXISTS `team_declaration_checksum_view`*/;
-/*!50001 SET @saved_cs_client          = @@character_set_client */;
-/*!50001 SET @saved_cs_results         = @@character_set_results */;
-/*!50001 SET @saved_col_connection     = @@collation_connection */;
-/*!50001 SET character_set_client      = utf8mb4 */;
-/*!50001 SET character_set_results     = utf8mb4 */;
-/*!50001 SET collation_connection      = utf8mb4_unicode_ci */;
-/*!50001 CREATE ALGORITHM=UNDEFINED */
-/*!50013 DEFINER=`root`@`%` SQL SECURITY DEFINER */
-/*!50001 VIEW `team_declaration_checksum_view` AS select `mdm_apple_declarations`.`team_id` AS `team_id`,md5((count(0) + group_concat(hex(`mdm_apple_declarations`.`md5_checksum`) order by `mdm_apple_declarations`.`uploaded_at` DESC separator ''))) AS `md5_checksum`,max(`mdm_apple_declarations`.`created_at`) AS `latest_created_timestamp` from `mdm_apple_declarations` group by `mdm_apple_declarations`.`team_id` */;
 /*!50001 SET character_set_client      = @saved_cs_client */;
 /*!50001 SET character_set_results     = @saved_cs_results */;
 /*!50001 SET collation_connection      = @saved_col_connection */;

--- a/server/datastore/mysql/testing_utils.go
+++ b/server/datastore/mysql/testing_utils.go
@@ -313,12 +313,12 @@ func TruncateTables(t testing.TB, ds *Datastore, tables ...string) {
 	// be truncated - a more precise approach must be used for those, e.g.
 	// delete where id > max before test, or something like that.
 	nonEmptyTables := map[string]bool{
-		"app_config_json":             true,
-		"migration_status_tables":     true,
-		"osquery_options":             true,
-		"mdm_delivery_status":         true,
-		"mdm_operation_types":         true,
-		"mdm_apple_declaration_types": true,
+		"app_config_json":                  true,
+		"migration_status_tables":          true,
+		"osquery_options":                  true,
+		"mdm_delivery_status":              true,
+		"mdm_operation_types":              true,
+		"mdm_apple_declaration_categories": true,
 	}
 	ctx := context.Background()
 

--- a/server/fleet/apple_mdm.go
+++ b/server/fleet/apple_mdm.go
@@ -533,19 +533,19 @@ type SCEPIdentityAssociation struct {
 	RenewCommandUUID string `db:"renew_command_uuid"`
 }
 
-// MDMAppleDeclarationType is the type for the supported declaration types.
-type MDMAppleDeclarationType string
+// MDMAppleDeclarationCategory is the type for the supported declaration types.
+type MDMAppleDeclarationCategory string
 
 const (
 	// MDMAppleConfigurationDeclaration is the value for [configuration][1] declarations
 	//
 	// [1]: https://developer.apple.com/documentation/devicemanagement/declarations#3813088
-	MDMAppleDeclarativeConfiguration MDMAppleDeclarationType = "com.apple.configuration"
+	MDMAppleDeclarativeConfiguration MDMAppleDeclarationCategory = "com.apple.configuration"
 
 	// MDMAppleActivationConfiguration is the value for [activation][1] declarations
 	//
 	// [1]: https://developer.apple.com/documentation/devicemanagement/declarations#3829708
-	MDMAppleDeclarativeActivation MDMAppleDeclarationType = "com.apple.activation"
+	MDMAppleDeclarativeActivation MDMAppleDeclarationCategory = "com.apple.activation"
 )
 
 // MDMAppleDeclaration represents a DDM JSON declaration.
@@ -568,15 +568,15 @@ type MDMAppleDeclaration struct {
 	// Fleet requires that Name must be unique in combination with the Identifier and TeamID.
 	Name string `db:"name" json:"name"`
 
-	// DeclarationType is the type of the declaration, at the moment we
+	// Category is the category of the declaration, at the moment we
 	// only support configurations and activations.
-	DeclarationType MDMAppleDeclarationType `db:"declaration_type"`
+	Category MDMAppleDeclarationCategory `db:"category"`
 
-	// Declaration is the raw JSON content of the declaration
-	Declaration json.RawMessage `db:"declaration" json:"-"`
+	// RawJSON is the raw JSON content of the declaration
+	RawJSON json.RawMessage `db:"raw_json" json:"-"`
 
-	// MD5Checksum is a checksum of the JSON contents
-	MD5Checksum string `db:"md5_checksum" json:"-"`
+	// Checksum is a checksum of the JSON contents
+	Checksum string `db:"checksum" json:"-"`
 
 	// Labels are the labels associated with this Declaration
 	Labels []DeclarationLabel `db:"labels" json:"labels,omitempty"`
@@ -683,10 +683,10 @@ type DeclarationLabel struct {
 func NewMDMAppleDeclaration(raw []byte, teamID *uint, name string, declType, ident string) *MDMAppleDeclaration {
 	var decl MDMAppleDeclaration
 
-	decl.DeclarationType = MDMAppleDeclarationType(strings.Join(strings.Split(declType, ".")[:3], "."))
+	decl.Category = MDMAppleDeclarationCategory(strings.Join(strings.Split(declType, ".")[:3], "."))
 	decl.Identifier = ident
 	decl.Name = name
-	decl.Declaration = raw
+	decl.RawJSON = raw
 	decl.TeamID = teamID
 
 	return &decl
@@ -703,7 +703,7 @@ type MDMAppleDDMTokensResponse struct {
 //
 // https://developer.apple.com/documentation/devicemanagement/synchronizationtokens
 type MDMAppleDDMDeclarationsToken struct {
-	DeclarationsToken string    `db:"md5_checksum"`
+	DeclarationsToken string    `db:"checksum"`
 	Timestamp         time.Time `db:"latest_created_timestamp"`
 }
 
@@ -739,9 +739,9 @@ type MDMAppleDDMManifest struct {
 //
 // https://developer.apple.com/documentation/devicemanagement/declarationitemsresponse
 type MDMAppleDDMDeclarationItem struct {
-	Identifier      string `db:"identifier"`
-	DeclarationType string `db:"declaration_type"`
-	ServerToken     string `db:"md5_checksum"`
+	Identifier  string `db:"identifier"`
+	Category    string `db:"category"`
+	ServerToken string `db:"checksum"`
 }
 
 // MDMAppleDDMDeclarationResponse represents a declaration in the datastore. It is used for the DDM

--- a/server/fleet/datastore.go
+++ b/server/fleet/datastore.go
@@ -1137,11 +1137,6 @@ type Datastore interface {
 	// host_dep_assignments for host with matching serials.
 	DeleteHostDEPAssignments(ctx context.Context, serials []string) error
 
-	// MDMAppleRecordDeclarativeCheckIn records a DeclarativeManagement
-	// checking from a host, so we know the host received the command to
-	// start the declarative management sync.
-	MDMAppleRecordDeclarativeCheckIn(ctx context.Context, hostUUID string, response []byte) error
-
 	// UpdateHostDEPAssignProfileResponses receives a profile UUID and threes lists of serials, each representing
 	// one of the three possible responses, and updates the host_dep_assignments table with the corresponding responses.
 	UpdateHostDEPAssignProfileResponses(ctx context.Context, resp *godep.ProfileResponse) error
@@ -1163,7 +1158,7 @@ type Datastore interface {
 	// MDMAppleDDMDeclarationItems returns the declaration items for the specified host UUID.
 	MDMAppleDDMDeclarationItems(ctx context.Context, hostUUID string) ([]MDMAppleDDMDeclarationItem, error)
 	// MDMAppleDDMDeclarationPayload returns the declaration payload for the specified identifier and team.
-	MDMAppleDDMDeclarationsResponse(ctx context.Context, declarationType MDMAppleDeclarationType, identifier string, hostUUID string) (json.RawMessage, error)
+	MDMAppleDDMDeclarationsResponse(ctx context.Context, declarationType MDMAppleDeclarationCategory, identifier string, hostUUID string) (*MDMAppleDeclaration, error)
 
 	///////////////////////////////////////////////////////////////////////////////
 	// Microsoft MDM

--- a/server/mock/datastore_mock.go
+++ b/server/mock/datastore_mock.go
@@ -748,8 +748,6 @@ type GetMatchingHostSerialsFunc func(ctx context.Context, serials []string) (map
 
 type DeleteHostDEPAssignmentsFunc func(ctx context.Context, serials []string) error
 
-type MDMAppleRecordDeclarativeCheckInFunc func(ctx context.Context, hostUUID string, response []byte) error
-
 type UpdateHostDEPAssignProfileResponsesFunc func(ctx context.Context, resp *godep.ProfileResponse) error
 
 type ScreenDEPAssignProfileSerialsForCooldownFunc func(ctx context.Context, serials []string) (skipSerials []string, assignSerials []string, err error)
@@ -762,7 +760,7 @@ type MDMAppleDDMDeclarationsTokenFunc func(ctx context.Context, hostUUID string)
 
 type MDMAppleDDMDeclarationItemsFunc func(ctx context.Context, hostUUID string) ([]fleet.MDMAppleDDMDeclarationItem, error)
 
-type MDMAppleDDMDeclarationsResponseFunc func(ctx context.Context, declarationType fleet.MDMAppleDeclarationType, identifier string, hostUUID string) (json.RawMessage, error)
+type MDMAppleDDMDeclarationsResponseFunc func(ctx context.Context, declarationType fleet.MDMAppleDeclarationCategory, identifier string, hostUUID string) (*fleet.MDMAppleDeclaration, error)
 
 type WSTEPStoreCertificateFunc func(ctx context.Context, name string, crt *x509.Certificate) error
 
@@ -1963,9 +1961,6 @@ type DataStore struct {
 
 	DeleteHostDEPAssignmentsFunc        DeleteHostDEPAssignmentsFunc
 	DeleteHostDEPAssignmentsFuncInvoked bool
-
-	MDMAppleRecordDeclarativeCheckInFunc        MDMAppleRecordDeclarativeCheckInFunc
-	MDMAppleRecordDeclarativeCheckInFuncInvoked bool
 
 	UpdateHostDEPAssignProfileResponsesFunc        UpdateHostDEPAssignProfileResponsesFunc
 	UpdateHostDEPAssignProfileResponsesFuncInvoked bool
@@ -4702,13 +4697,6 @@ func (s *DataStore) DeleteHostDEPAssignments(ctx context.Context, serials []stri
 	return s.DeleteHostDEPAssignmentsFunc(ctx, serials)
 }
 
-func (s *DataStore) MDMAppleRecordDeclarativeCheckIn(ctx context.Context, hostUUID string, response []byte) error {
-	s.mu.Lock()
-	s.MDMAppleRecordDeclarativeCheckInFuncInvoked = true
-	s.mu.Unlock()
-	return s.MDMAppleRecordDeclarativeCheckInFunc(ctx, hostUUID, response)
-}
-
 func (s *DataStore) UpdateHostDEPAssignProfileResponses(ctx context.Context, resp *godep.ProfileResponse) error {
 	s.mu.Lock()
 	s.UpdateHostDEPAssignProfileResponsesFuncInvoked = true
@@ -4751,7 +4739,7 @@ func (s *DataStore) MDMAppleDDMDeclarationItems(ctx context.Context, hostUUID st
 	return s.MDMAppleDDMDeclarationItemsFunc(ctx, hostUUID)
 }
 
-func (s *DataStore) MDMAppleDDMDeclarationsResponse(ctx context.Context, declarationType fleet.MDMAppleDeclarationType, identifier string, hostUUID string) (json.RawMessage, error) {
+func (s *DataStore) MDMAppleDDMDeclarationsResponse(ctx context.Context, declarationType fleet.MDMAppleDeclarationCategory, identifier string, hostUUID string) (*fleet.MDMAppleDeclaration, error) {
 	s.mu.Lock()
 	s.MDMAppleDDMDeclarationsResponseFuncInvoked = true
 	s.mu.Unlock()

--- a/server/service/integration_mdm_test.go
+++ b/server/service/integration_mdm_test.go
@@ -9414,9 +9414,9 @@ func (s *integrationMDMTestSuite) TestMDMConfigProfileCRUD() {
 	// add some macOS declarations
 	assertAppleDeclaration("apple-declaration.json", "", "test-declaration-ident", 0, nil, http.StatusOK, "")
 	// identifier must be unique, it conflicts with existing declaration
-	assertAppleDeclaration("apple-declaration.json", "", "test-declaration-ident", 0, nil, http.StatusConflict, "idx_mdm_apple_declaration_team_identifier")
+	assertAppleDeclaration("apple-declaration.json", "", "test-declaration-ident", 0, nil, http.StatusConflict, "Resource Already Exists: MDMAppleDeclaration.Identifier test-declaration-ident already exists")
 	// name is pulled from filename, it conflicts with existing declaration
-	assertAppleDeclaration("apple-declaration.json", "", "test-declaration-ident-2", 0, nil, http.StatusConflict, "idx_mdm_apple_declaration_team_name")
+	assertAppleDeclaration("apple-declaration.json", "", "test-declaration-ident-2", 0, nil, http.StatusConflict, "Resource Already Exists: MDMAppleDeclaration.Name apple-declaration already exists")
 	// uniqueness is checked only within team, so it's fine to have the same name and identifier in different teams
 	assertAppleDeclaration("apple-declaration.json", "", "test-declaration-ident", testTeam.ID, nil, http.StatusOK, "")
 	// name is pulled from filename, it conflicts with existing macOS config profile

--- a/server/service/integration_mdm_test.go
+++ b/server/service/integration_mdm_test.go
@@ -12841,8 +12841,6 @@ INSERT INTO host_mdm_apple_declarations (
 		require.Empty(t, r.Declarations.Management)
 		require.Len(t, r.Declarations.Configurations, len(expectedDeclsByChecksum))
 		for _, m := range r.Declarations.Configurations {
-			// look up the declaration by the server token (we trim the token to the first seven
-			// chars to match our keys because response is padded to length 16 with "\u000")
 			d, ok := expectedDeclsByChecksum[m.ServerToken]
 			require.True(t, ok)
 			require.Equal(t, d.Identifier, m.Identifier)
@@ -12927,7 +12925,7 @@ INSERT INTO host_mdm_apple_declarations (
 
 	t.Run("Declaration", func(t *testing.T) {
 		want := noTeamDeclsByUUID["123"]
-		r, err := mdmDevice.DeclarativeManagement(fmt.Sprintf("declarations/%s/%s", "configuration", want.Identifier))
+		r, err := mdmDevice.DeclarativeManagement(fmt.Sprintf("declaration/%s/%s", "configuration", want.Identifier))
 		require.NoError(t, err)
 
 		assertDeclarationResponse(r, want)
@@ -12950,7 +12948,7 @@ INSERT INTO host_mdm_apple_declarations (
 		insertDeclaration(t, noTeamDeclsByUUID["abc"])
 		insertHostDeclaration(t, mdmDevice.UUID, noTeamDeclsByUUID["abc"])
 		want = noTeamDeclsByUUID["abc"]
-		r, err = mdmDevice.DeclarativeManagement(fmt.Sprintf("declarations/%s/%s", "configuration", want.Identifier))
+		r, err = mdmDevice.DeclarativeManagement(fmt.Sprintf("declaration/%s/%s", "configuration", want.Identifier))
 		require.NoError(t, err)
 
 		assertDeclarationResponse(r, want)


### PR DESCRIPTION
Improvements and fixes I found while integrating this

- Renamed db columns to match the profile tables for consistency
- Added columns to `host_mdm_apple_declarations`
- Removed `team_declaration_checksum_view`
- Remove the ad-hoc `MDMAppleRecordDeclarativeCheckIn`, I confused myself by developing this using tests, the device actually sends an `Acknowledged`  response, which is recorded by nano
- Fixed bugs in the `declaration/../..` endpoints
    - The prefix for the endpoint is `declaration` without `s`
    - The response needs to include a `ServerToken`, otherwise the declaration fails

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [x] Added/updated tests
- [x] If database migrations are included, checked table schema to confirm autoupdate 
- For database migrations:
  - [x] Checked schema for all modified table for columns that will auto-update timestamps during migration.
  - [x] Confirmed that updating the timestamps is acceptable, and will not cause unwanted side effects.
- [x] Manual QA for all new/changed functionality
