### PR TITLE
Additional backend support for DDM profiles

### DIFF
--- a/server/datastore/mysql/apple_mdm.go
+++ b/server/datastore/mysql/apple_mdm.go
@@ -3278,7 +3278,7 @@ WHERE
 
 	for _, d := range declarations {
 		checksum := md5ChecksumScriptContent(string(d.RawJSON))
-		declUUID := "x" + uuid.NewString()
+		declUUID := fleet.MDMAppleDeclarationUUIDPrefix + uuid.NewString()
 		if _, err := tx.ExecContext(ctx, insertStmt,
 			declUUID,
 			d.Identifier,
@@ -3311,7 +3311,7 @@ WHERE
 }
 
 func (ds *Datastore) NewMDMAppleDeclaration(ctx context.Context, declaration *fleet.MDMAppleDeclaration) (*fleet.MDMAppleDeclaration, error) {
-	declUUID := "x" + uuid.NewString()
+	declUUID := fleet.MDMAppleDeclarationUUIDPrefix + uuid.NewString()
 	checksum := md5ChecksumScriptContent(string(declaration.RawJSON))
 
 	stmt := `

--- a/server/datastore/mysql/apple_mdm.go
+++ b/server/datastore/mysql/apple_mdm.go
@@ -3505,6 +3505,9 @@ WHERE
 
 	var res fleet.MDMAppleDeclaration
 	if err := sqlx.GetContext(ctx, ds.reader(ctx), &res, stmt, hostUUID, identifier, declarationType, fleet.MDMOperationTypeInstall); err != nil {
+		if err == sql.ErrNoRows {
+			return nil, notFound(string(declarationType)).WithName(identifier)
+		}
 		return nil, ctxerr.Wrap(ctx, err, "get ddm declarations response")
 	}
 

--- a/server/datastore/mysql/apple_mdm_test.go
+++ b/server/datastore/mysql/apple_mdm_test.go
@@ -1264,7 +1264,7 @@ func declForTest(name, identifier, payloadContent string, labels ...*fleet.Label
 	}
 
 	for _, l := range labels {
-		decl.Labels = append(decl.Labels, fleet.DeclarationLabel{LabelName: l.Name, LabelID: l.ID})
+		decl.Labels = append(decl.Labels, fleet.ConfigurationProfileLabel{LabelName: l.Name, LabelID: l.ID})
 	}
 
 	return decl

--- a/server/datastore/mysql/apple_mdm_test.go
+++ b/server/datastore/mysql/apple_mdm_test.go
@@ -1035,10 +1035,10 @@ func expectAppleDeclarations(
 			gotD.TeamID = nil
 		}
 
-		// DeclarationUUID is non-empty and starts with "x", but otherwise we don't
+		// DeclarationUUID is non-empty and starts with "d", but otherwise we don't
 		// care about it for test assertions.
 		require.NotEmpty(t, gotD.DeclarationUUID)
-		require.True(t, strings.HasPrefix(gotD.DeclarationUUID, "x"))
+		require.True(t, strings.HasPrefix(gotD.DeclarationUUID, fleet.MDMAppleDeclarationUUIDPrefix))
 		gotD.DeclarationUUID = ""
 		gotD.Checksum = "" // don't care about md5checksum here
 

--- a/server/datastore/mysql/mdm.go
+++ b/server/datastore/mysql/mdm.go
@@ -229,7 +229,7 @@ FROM (
 		if prof.Platform == "windows" {
 			winProfUUIDs = append(winProfUUIDs, prof.ProfileUUID)
 		} else {
-			if strings.HasPrefix(prof.ProfileUUID, "x") {
+			if strings.HasPrefix(prof.ProfileUUID, fleet.MDMAppleDeclarationUUIDPrefix) {
 				macDeclUUIDs = append(macDeclUUIDs, prof.ProfileUUID)
 				continue
 			}
@@ -237,17 +237,18 @@ FROM (
 			macProfUUIDs = append(macProfUUIDs, prof.ProfileUUID)
 		}
 	}
-	labels, err := ds.listProfileLabelsForProfiles(ctx, winProfUUIDs, macProfUUIDs)
+	labels, err := ds.listProfileLabelsForProfiles(ctx, winProfUUIDs, macProfUUIDs, macDeclUUIDs)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	declLabels, err := ds.listDeclarationLabelsForDeclarations(ctx, macDeclUUIDs)
-	if err != nil {
-		return nil, nil, err
-	}
+	// // TODO: do we want to load labels separately for declarations?
+	// declLabels, err := ds.listDeclarationLabelsForDeclarations(ctx, macDeclUUIDs)
+	// if err != nil {
+	// 	return nil, nil, err
+	// }
 
-	labels = append(labels, declLabels...)
+	// labels = append(labels, declLabels...)
 
 	// match the labels with their profiles
 	profMap := make(map[string]*fleet.MDMConfigProfilePayload, len(profs))
@@ -263,39 +264,39 @@ FROM (
 	return profs, metaData, nil
 }
 
-// Note: we're using the ConfigurationProfileLabel type here since from the product perspective, MDM
-// profiles and declarations are both "profiles".
-func (ds *Datastore) listDeclarationLabelsForDeclarations(ctx context.Context, declUUIDs []string) ([]fleet.ConfigurationProfileLabel, error) {
-	if len(declUUIDs) == 0 {
-		return []fleet.ConfigurationProfileLabel{}, nil
-	}
+// // Note: we're using the ConfigurationProfileLabel type here since from the product perspective, MDM
+// // profiles and declarations are both "profiles".
+// func (ds *Datastore) listDeclarationLabelsForDeclarations(ctx context.Context, declUUIDs []string) ([]fleet.ConfigurationProfileLabel, error) {
+// 	if len(declUUIDs) == 0 {
+// 		return []fleet.ConfigurationProfileLabel{}, nil
+// 	}
 
-	stmt := `
-SELECT
-	apple_declaration_uuid AS profile_uuid,
-	label_name,
-	label_id
-FROM
-	mdm_declaration_labels
-WHERE
-	apple_declaration_uuid IN (?)
-ORDER BY
-	apple_declaration_uuid, label_name
-	`
+// 	stmt := `
+// SELECT
+// 	apple_declaration_uuid AS profile_uuid,
+// 	label_name,
+// 	label_id
+// FROM
+// 	mdm_declaration_labels
+// WHERE
+// 	apple_declaration_uuid IN (?)
+// ORDER BY
+// 	apple_declaration_uuid, label_name
+// 	`
 
-	stmt, args, err := sqlx.In(stmt, declUUIDs)
-	if err != nil {
-		return nil, ctxerr.Wrap(ctx, err, "sqlx.In to list labels for declarations")
-	}
+// 	stmt, args, err := sqlx.In(stmt, declUUIDs)
+// 	if err != nil {
+// 		return nil, ctxerr.Wrap(ctx, err, "sqlx.In to list labels for declarations")
+// 	}
 
-	var labels []fleet.ConfigurationProfileLabel
-	if err := sqlx.SelectContext(ctx, ds.reader(ctx), &labels, stmt, args...); err != nil {
-		return nil, ctxerr.Wrap(ctx, err, "select declaration labels")
-	}
-	return labels, nil
-}
+// 	var labels []fleet.ConfigurationProfileLabel
+// 	if err := sqlx.SelectContext(ctx, ds.reader(ctx), &labels, stmt, args...); err != nil {
+// 		return nil, ctxerr.Wrap(ctx, err, "select declaration labels")
+// 	}
+// 	return labels, nil
+// }
 
-func (ds *Datastore) listProfileLabelsForProfiles(ctx context.Context, winProfUUIDs, macProfUUIDs []string) ([]fleet.ConfigurationProfileLabel, error) {
+func (ds *Datastore) listProfileLabelsForProfiles(ctx context.Context, winProfUUIDs, macProfUUIDs, macDeclUUIDs []string) ([]fleet.ConfigurationProfileLabel, error) {
 	// load the labels associated with those profiles
 	const labelsStmt = `
 SELECT
@@ -308,6 +309,16 @@ FROM
 WHERE
 	mcpl.apple_profile_uuid IN (?) OR
 	mcpl.windows_profile_uuid IN (?)
+UNION ALL 
+SELECT
+	apple_declaration_uuid as profile_uuid,
+	label_name,
+	COALESCE(label_id, 0) as label_id,
+	IF(label_id IS NULL, 1, 0) as broken
+FROM
+	mdm_declaration_labels mdl
+WHERE
+	mdl.apple_declaration_uuid IN (?)
 ORDER BY
 	profile_uuid, label_name
 `
@@ -320,8 +331,11 @@ ORDER BY
 	if len(macProfUUIDs) == 0 {
 		macProfUUIDs = []string{"-"}
 	}
+	if len(macDeclUUIDs) == 0 {
+		macDeclUUIDs = []string{"-"}
+	}
 
-	stmt, args, err := sqlx.In(labelsStmt, macProfUUIDs, winProfUUIDs)
+	stmt, args, err := sqlx.In(labelsStmt, macProfUUIDs, winProfUUIDs, macDeclUUIDs)
 	if err != nil {
 		return nil, ctxerr.Wrap(ctx, err, "sqlx.In to list labels for profiles")
 	}

--- a/server/datastore/mysql/mdm.go
+++ b/server/datastore/mysql/mdm.go
@@ -242,14 +242,6 @@ FROM (
 		return nil, nil, err
 	}
 
-	// // TODO: do we want to load labels separately for declarations?
-	// declLabels, err := ds.listDeclarationLabelsForDeclarations(ctx, macDeclUUIDs)
-	// if err != nil {
-	// 	return nil, nil, err
-	// }
-
-	// labels = append(labels, declLabels...)
-
 	// match the labels with their profiles
 	profMap := make(map[string]*fleet.MDMConfigProfilePayload, len(profs))
 	for _, prof := range profs {
@@ -263,38 +255,6 @@ FROM (
 
 	return profs, metaData, nil
 }
-
-// // Note: we're using the ConfigurationProfileLabel type here since from the product perspective, MDM
-// // profiles and declarations are both "profiles".
-// func (ds *Datastore) listDeclarationLabelsForDeclarations(ctx context.Context, declUUIDs []string) ([]fleet.ConfigurationProfileLabel, error) {
-// 	if len(declUUIDs) == 0 {
-// 		return []fleet.ConfigurationProfileLabel{}, nil
-// 	}
-
-// 	stmt := `
-// SELECT
-// 	apple_declaration_uuid AS profile_uuid,
-// 	label_name,
-// 	label_id
-// FROM
-// 	mdm_declaration_labels
-// WHERE
-// 	apple_declaration_uuid IN (?)
-// ORDER BY
-// 	apple_declaration_uuid, label_name
-// 	`
-
-// 	stmt, args, err := sqlx.In(stmt, declUUIDs)
-// 	if err != nil {
-// 		return nil, ctxerr.Wrap(ctx, err, "sqlx.In to list labels for declarations")
-// 	}
-
-// 	var labels []fleet.ConfigurationProfileLabel
-// 	if err := sqlx.SelectContext(ctx, ds.reader(ctx), &labels, stmt, args...); err != nil {
-// 		return nil, ctxerr.Wrap(ctx, err, "select declaration labels")
-// 	}
-// 	return labels, nil
-// }
 
 func (ds *Datastore) listProfileLabelsForProfiles(ctx context.Context, winProfUUIDs, macProfUUIDs, macDeclUUIDs []string) ([]fleet.ConfigurationProfileLabel, error) {
 	// load the labels associated with those profiles

--- a/server/datastore/mysql/microsoft_mdm.go
+++ b/server/datastore/mysql/microsoft_mdm.go
@@ -734,7 +734,7 @@ WHERE
 		return nil, ctxerr.Wrap(ctx, err, "get mdm windows config profile")
 	}
 
-	labels, err := ds.listProfileLabelsForProfiles(ctx, []string{res.ProfileUUID}, nil)
+	labels, err := ds.listProfileLabelsForProfiles(ctx, []string{res.ProfileUUID}, nil, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/server/fleet/apple_mdm.go
+++ b/server/fleet/apple_mdm.go
@@ -549,7 +549,7 @@ const (
 
 	// MDMAppleDeclarationUUIDPrefix is the prefix used to differentiate declaration uuids
 	// from legacy Apple profile uuids and Windows profile uuids.
-	MDMAppleDeclarationUUIDPrefix = "x" // TODO: update to 'd'; add constants for other prefixes; move to mdm file
+	MDMAppleDeclarationUUIDPrefix = "d"
 )
 
 // MDMAppleDeclaration represents a DDM JSON declaration.

--- a/server/fleet/datastore.go
+++ b/server/fleet/datastore.go
@@ -910,6 +910,9 @@ type Datastore interface {
 	// profile uuid.
 	GetMDMAppleConfigProfile(ctx context.Context, profileUUID string) (*MDMAppleConfigProfile, error)
 
+	// GetMDMAppleDeclaration returns the declaration corresponding to the specified uuid.
+	GetMDMAppleDeclaration(ctx context.Context, declUUID string) (*MDMAppleDeclaration, error)
+
 	// ListMDMAppleConfigProfiles lists mdm config profiles associated with the specified team id.
 	// For global config profiles, specify nil as the team id.
 	ListMDMAppleConfigProfiles(ctx context.Context, teamID *uint) ([]*MDMAppleConfigProfile, error)

--- a/server/fleet/mdm.go
+++ b/server/fleet/mdm.go
@@ -413,6 +413,24 @@ func NewMDMConfigProfilePayloadFromApple(cp *MDMAppleConfigProfile) *MDMConfigPr
 	}
 }
 
+func NewMDMConfigProfilePayloadFromAppleDDM(decl *MDMAppleDeclaration) *MDMConfigProfilePayload {
+	var tid *uint
+	if decl.TeamID != nil && *decl.TeamID > 0 {
+		tid = decl.TeamID
+	}
+	return &MDMConfigProfilePayload{
+		ProfileUUID: decl.DeclarationUUID,
+		TeamID:      tid,
+		Name:        decl.Name,
+		Identifier:  decl.Identifier,
+		Platform:    "darwin",
+		Checksum:    []byte(decl.Checksum),
+		CreatedAt:   decl.CreatedAt,
+		UploadedAt:  decl.UploadedAt,
+		Labels:      decl.Labels,
+	}
+}
+
 // MDMProfileSpec represents the spec used to define configuration
 // profiles via yaml files.
 type MDMProfileSpec struct {

--- a/server/fleet/service.go
+++ b/server/fleet/service.go
@@ -654,18 +654,27 @@ type Service interface {
 	NewMDMAppleConfigProfile(ctx context.Context, teamID uint, r io.Reader, labels []string) (*MDMAppleConfigProfile, error)
 	// NewMDMAppleConfigProfileWithPayload creates a new declaration for the specified team.
 	NewMDMAppleDeclaration(ctx context.Context, teamID uint, r io.Reader, labels []string, name string) (*MDMAppleDeclaration, error)
+
 	// GetMDMAppleConfigProfileByDeprecatedID retrieves the specified Apple
 	// configuration profile via its numeric ID. This method is deprecated and
 	// should not be used for new endpoints.
 	GetMDMAppleConfigProfileByDeprecatedID(ctx context.Context, profileID uint) (*MDMAppleConfigProfile, error)
 	// GetMDMAppleConfigProfile retrieves the specified configuration profile.
 	GetMDMAppleConfigProfile(ctx context.Context, profileUUID string) (*MDMAppleConfigProfile, error)
+
+	// GetMDMAppleDeclaration retrieves the specified declaration.
+	GetMDMAppleDeclaration(ctx context.Context, declarationUUID string) (*MDMAppleDeclaration, error)
+
 	// DeleteMDMAppleConfigProfileByDeprecatedID deletes the specified Apple
 	// configuration profile via its numeric ID. This method is deprecated and
 	// should not be used for new endpoints.
 	DeleteMDMAppleConfigProfileByDeprecatedID(ctx context.Context, profileID uint) error
 	// DeleteMDMAppleConfigProfile deletes the specified configuration profile.
 	DeleteMDMAppleConfigProfile(ctx context.Context, profileUUID string) error
+
+	// DeleteMDMAppleDeclaration deletes the specified declaration.
+	DeleteMDMAppleDeclaration(ctx context.Context, declarationUUID string) error
+
 	// ListMDMAppleConfigProfiles returns the list of all the configuration profiles for the
 	// specified team.
 	ListMDMAppleConfigProfiles(ctx context.Context, teamID uint) ([]*MDMAppleConfigProfile, error)

--- a/server/mock/datastore_mock.go
+++ b/server/mock/datastore_mock.go
@@ -620,6 +620,8 @@ type GetMDMAppleConfigProfileByDeprecatedIDFunc func(ctx context.Context, profil
 
 type GetMDMAppleConfigProfileFunc func(ctx context.Context, profileUUID string) (*fleet.MDMAppleConfigProfile, error)
 
+type GetMDMAppleDeclarationFunc func(ctx context.Context, declUUID string) (*fleet.MDMAppleDeclaration, error)
+
 type ListMDMAppleConfigProfilesFunc func(ctx context.Context, teamID *uint) ([]*fleet.MDMAppleConfigProfile, error)
 
 type DeleteMDMAppleConfigProfileByDeprecatedIDFunc func(ctx context.Context, profileID uint) error
@@ -1769,6 +1771,9 @@ type DataStore struct {
 
 	GetMDMAppleConfigProfileFunc        GetMDMAppleConfigProfileFunc
 	GetMDMAppleConfigProfileFuncInvoked bool
+
+	GetMDMAppleDeclarationFunc        GetMDMAppleDeclarationFunc
+	GetMDMAppleDeclarationFuncInvoked bool
 
 	ListMDMAppleConfigProfilesFunc        ListMDMAppleConfigProfilesFunc
 	ListMDMAppleConfigProfilesFuncInvoked bool
@@ -4247,6 +4252,13 @@ func (s *DataStore) GetMDMAppleConfigProfile(ctx context.Context, profileUUID st
 	s.GetMDMAppleConfigProfileFuncInvoked = true
 	s.mu.Unlock()
 	return s.GetMDMAppleConfigProfileFunc(ctx, profileUUID)
+}
+
+func (s *DataStore) GetMDMAppleDeclaration(ctx context.Context, declUUID string) (*fleet.MDMAppleDeclaration, error) {
+	s.mu.Lock()
+	s.GetMDMAppleDeclarationFuncInvoked = true
+	s.mu.Unlock()
+	return s.GetMDMAppleDeclarationFunc(ctx, declUUID)
 }
 
 func (s *DataStore) ListMDMAppleConfigProfiles(ctx context.Context, teamID *uint) ([]*fleet.MDMAppleConfigProfile, error) {

--- a/server/service/apple_mdm.go
+++ b/server/service/apple_mdm.go
@@ -772,7 +772,9 @@ func (svc *Service) DeleteMDMAppleDeclaration(ctx context.Context, declUUID stri
 		}
 	}
 
-	// TODO: refine our approach to deleting restricted/forbidden types of declarations
+	// TODO: refine our approach to deleting restricted/forbidden types of declarations so that we
+	// can check that Fleet-managed aren't being deleted; this can be addressed once we add support
+	// for more types of declarations
 	var d fleet.MDMAppleRawDeclaration
 	if err := json.Unmarshal(decl.RawJSON, &d); err != nil {
 		return ctxerr.Wrap(ctx, err, "unmarshalling declaration")

--- a/server/service/integration_mdm_test.go
+++ b/server/service/integration_mdm_test.go
@@ -13040,6 +13040,11 @@ INSERT INTO host_mdm_apple_declarations (
 		r, err = mdmDevice.DeclarativeManagement(fmt.Sprintf("declaration/%s/%s", "configuration", want.Identifier))
 		require.NoError(t, err)
 
+		// try getting a non-existent declaration
+		_, err = mdmDevice.DeclarativeManagement(fmt.Sprintf("declaration/%s/%s", "configuration", "nonexistent"))
+		require.Error(t, err)
+		require.ErrorContains(t, err, "404 Not Found")
+
 		assertDeclarationResponse(r, want)
 	})
 }

--- a/server/service/integration_mdm_test.go
+++ b/server/service/integration_mdm_test.go
@@ -13040,10 +13040,15 @@ INSERT INTO host_mdm_apple_declarations (
 		r, err = mdmDevice.DeclarativeManagement(fmt.Sprintf("declaration/%s/%s", "configuration", want.Identifier))
 		require.NoError(t, err)
 
-		// try getting a non-existent declaration
+		// try getting a non-existent declaration, should fail 404
 		_, err = mdmDevice.DeclarativeManagement(fmt.Sprintf("declaration/%s/%s", "configuration", "nonexistent"))
 		require.Error(t, err)
 		require.ErrorContains(t, err, "404 Not Found")
+
+		// typo should fail as bad request
+		_, err = mdmDevice.DeclarativeManagement(fmt.Sprintf("declarations/%s/%s", "configurations", want.Identifier))
+		require.Error(t, err)
+		require.ErrorContains(t, err, "400 Bad Request")
 
 		assertDeclarationResponse(r, want)
 	})

--- a/server/service/integration_mdm_test.go
+++ b/server/service/integration_mdm_test.go
@@ -9326,7 +9326,7 @@ func (s *integrationMDMTestSuite) TestMDMConfigProfileCRUD() {
 		err := json.NewDecoder(res.Body).Decode(&resp)
 		require.NoError(t, err)
 		require.NotEmpty(t, resp.ProfileUUID)
-		require.Equal(t, "x", string(resp.ProfileUUID[0]))
+		require.Equal(t, fleet.MDMAppleDeclarationUUIDPrefix, string(resp.ProfileUUID[0]))
 		return resp.ProfileUUID
 	}
 
@@ -9556,7 +9556,6 @@ func (s *integrationMDMTestSuite) TestMDMConfigProfileCRUD() {
 	s.DoJSON("GET", fmt.Sprintf("/api/latest/fleet/configuration_profiles/%s", "ano-such-profile"), nil, http.StatusNotFound, &getResp)
 	s.Do("GET", fmt.Sprintf("/api/latest/fleet/configuration_profiles/%s", "ano-such-profile"), nil, http.StatusNotFound, "alt", "media")
 	// get an unknown Apple declaration
-	// TODO: update the 'x' prefix when we switch to 'd' prefix for declarations
 	s.DoJSON("GET", fmt.Sprintf("/api/latest/fleet/configuration_profiles/%s", fmt.Sprintf("%sno-such-profile", fleet.MDMAppleDeclarationUUIDPrefix)), nil, http.StatusNotFound, &getResp)
 	s.Do("GET", fmt.Sprintf("/api/latest/fleet/configuration_profiles/%s", fmt.Sprintf("%sno-such-profile", fleet.MDMAppleDeclarationUUIDPrefix)), nil, http.StatusNotFound, "alt", "media")
 	// get an unknown Windows profile

--- a/server/service/integration_mdm_test.go
+++ b/server/service/integration_mdm_test.go
@@ -12626,114 +12626,114 @@ func (s *integrationMDMTestSuite) TestAppleDDMBatchUpload() {
 		decls = append(decls, newDeclBytes(i))
 	}
 
-	// // Non-configuration type should fail
-	// res := s.Do("POST", "/api/latest/fleet/mdm/profiles/batch", batchSetMDMProfilesRequest{Profiles: []fleet.MDMProfileBatchPayload{
-	// 	{Name: "bad", Contents: []byte(`{"Type": "com.apple.activation"}`)},
-	// }}, http.StatusUnprocessableEntity)
+	// Non-configuration type should fail
+	res := s.Do("POST", "/api/latest/fleet/mdm/profiles/batch", batchSetMDMProfilesRequest{Profiles: []fleet.MDMProfileBatchPayload{
+		{Name: "bad", Contents: []byte(`{"Type": "com.apple.activation"}`)},
+	}}, http.StatusUnprocessableEntity)
 
-	// errMsg := extractServerErrorText(res.Body)
-	// require.Contains(t, errMsg, "Only configuration declarations (com.apple.configuration) are supported")
+	errMsg := extractServerErrorText(res.Body)
+	require.Contains(t, errMsg, "Only configuration declarations (com.apple.configuration) are supported")
 
-	// // "com.apple.configuration.softwareupdate.enforcement.specific" type should fail
-	// res = s.Do("POST", "/api/latest/fleet/mdm/profiles/batch", batchSetMDMProfilesRequest{Profiles: []fleet.MDMProfileBatchPayload{
-	// 	{Name: "bad2", Contents: []byte(`{"Type": "com.apple.configuration.softwareupdate.enforcement.specific"}`)},
-	// }}, http.StatusUnprocessableEntity)
+	// "com.apple.configuration.softwareupdate.enforcement.specific" type should fail
+	res = s.Do("POST", "/api/latest/fleet/mdm/profiles/batch", batchSetMDMProfilesRequest{Profiles: []fleet.MDMProfileBatchPayload{
+		{Name: "bad2", Contents: []byte(`{"Type": "com.apple.configuration.softwareupdate.enforcement.specific"}`)},
+	}}, http.StatusUnprocessableEntity)
 
-	// errMsg = extractServerErrorText(res.Body)
-	// require.Contains(t, errMsg, "Declaration profile can’t include OS updates settings. To control these settings, go to OS updates.")
+	errMsg = extractServerErrorText(res.Body)
+	require.Contains(t, errMsg, "Declaration profile can’t include OS updates settings. To control these settings, go to OS updates.")
 
-	// // Types from our list of forbidden types should fail
-	// for ft := range fleet.ForbiddenDeclTypes {
-	// 	res = s.Do("POST", "/api/latest/fleet/mdm/profiles/batch", batchSetMDMProfilesRequest{Profiles: []fleet.MDMProfileBatchPayload{
-	// 		{Name: "bad2", Contents: []byte(fmt.Sprintf(`{"Type": "%s"}`, ft))},
-	// 	}}, http.StatusUnprocessableEntity)
+	// Types from our list of forbidden types should fail
+	for ft := range fleet.ForbiddenDeclTypes {
+		res = s.Do("POST", "/api/latest/fleet/mdm/profiles/batch", batchSetMDMProfilesRequest{Profiles: []fleet.MDMProfileBatchPayload{
+			{Name: "bad2", Contents: []byte(fmt.Sprintf(`{"Type": "%s"}`, ft))},
+		}}, http.StatusUnprocessableEntity)
 
-	// 	errMsg = extractServerErrorText(res.Body)
-	// 	require.Contains(t, errMsg, "Only configuration declarations that don’t require an asset reference are supported.")
-	// }
+		errMsg = extractServerErrorText(res.Body)
+		require.Contains(t, errMsg, "Only configuration declarations that don’t require an asset reference are supported.")
+	}
 
-	// // "com.apple.configuration.management.status-subscriptions" type should fail
-	// res = s.Do("POST", "/api/latest/fleet/mdm/profiles/batch", batchSetMDMProfilesRequest{Profiles: []fleet.MDMProfileBatchPayload{
-	// 	{Name: "bad2", Contents: []byte(`{"Type": "com.apple.configuration.management.status-subscriptions"}`)},
-	// }}, http.StatusUnprocessableEntity)
+	// "com.apple.configuration.management.status-subscriptions" type should fail
+	res = s.Do("POST", "/api/latest/fleet/mdm/profiles/batch", batchSetMDMProfilesRequest{Profiles: []fleet.MDMProfileBatchPayload{
+		{Name: "bad2", Contents: []byte(`{"Type": "com.apple.configuration.management.status-subscriptions"}`)},
+	}}, http.StatusUnprocessableEntity)
 
-	// errMsg = extractServerErrorText(res.Body)
-	// require.Contains(t, errMsg, "Declaration profile can’t include status subscription type. To get host’s vitals, please use queries and policies.")
+	errMsg = extractServerErrorText(res.Body)
+	require.Contains(t, errMsg, "Declaration profile can’t include status subscription type. To get host’s vitals, please use queries and policies.")
 
-	// // Two different payloads with the same name should fail
-	// res = s.Do("POST", "/api/latest/fleet/mdm/profiles/batch", batchSetMDMProfilesRequest{Profiles: []fleet.MDMProfileBatchPayload{
-	// 	{Name: "bad2", Contents: newDeclBytes(1, `"foo": "bar"`)},
-	// 	{Name: "bad2", Contents: newDeclBytes(2, `"baz": "bing"`)},
-	// }}, http.StatusUnprocessableEntity)
-	// errMsg = extractServerErrorText(res.Body)
-	// require.Contains(t, errMsg, "A declaration profile with this name already exists.")
+	// Two different payloads with the same name should fail
+	res = s.Do("POST", "/api/latest/fleet/mdm/profiles/batch", batchSetMDMProfilesRequest{Profiles: []fleet.MDMProfileBatchPayload{
+		{Name: "bad2", Contents: newDeclBytes(1, `"foo": "bar"`)},
+		{Name: "bad2", Contents: newDeclBytes(2, `"baz": "bing"`)},
+	}}, http.StatusUnprocessableEntity)
+	errMsg = extractServerErrorText(res.Body)
+	require.Contains(t, errMsg, "A declaration profile with this name already exists.")
 
-	// // Same identifier should fail
-	// res = s.Do("POST", "/api/latest/fleet/mdm/profiles/batch", batchSetMDMProfilesRequest{Profiles: []fleet.MDMProfileBatchPayload{
-	// 	{Name: "N1", Contents: decls[0]},
-	// 	{Name: "N2", Contents: decls[0]},
-	// }}, http.StatusUnprocessableEntity)
-	// errMsg = extractServerErrorText(res.Body)
-	// require.Contains(t, errMsg, "A declaration profile with this identifier already exists.")
+	// Same identifier should fail
+	res = s.Do("POST", "/api/latest/fleet/mdm/profiles/batch", batchSetMDMProfilesRequest{Profiles: []fleet.MDMProfileBatchPayload{
+		{Name: "N1", Contents: decls[0]},
+		{Name: "N2", Contents: decls[0]},
+	}}, http.StatusUnprocessableEntity)
+	errMsg = extractServerErrorText(res.Body)
+	require.Contains(t, errMsg, "A declaration profile with this identifier already exists.")
 
-	// // Create 2 declarations
-	// s.Do("POST", "/api/latest/fleet/mdm/profiles/batch", batchSetMDMProfilesRequest{Profiles: []fleet.MDMProfileBatchPayload{
-	// 	{Name: "N1", Contents: decls[0]},
-	// 	{Name: "N2", Contents: decls[1]},
-	// }}, http.StatusNoContent)
+	// Create 2 declarations
+	s.Do("POST", "/api/latest/fleet/mdm/profiles/batch", batchSetMDMProfilesRequest{Profiles: []fleet.MDMProfileBatchPayload{
+		{Name: "N1", Contents: decls[0]},
+		{Name: "N2", Contents: decls[1]},
+	}}, http.StatusNoContent)
 
-	// var resp listMDMConfigProfilesResponse
-	// s.DoJSON("GET", "/api/latest/fleet/mdm/profiles", &listMDMConfigProfilesRequest{}, http.StatusOK, &resp)
+	var resp listMDMConfigProfilesResponse
+	s.DoJSON("GET", "/api/latest/fleet/mdm/profiles", &listMDMConfigProfilesRequest{}, http.StatusOK, &resp)
 
-	// require.Len(t, resp.Profiles, 2)
-	// require.Equal(t, "N1", resp.Profiles[0].Name)
-	// require.Equal(t, "darwin", resp.Profiles[0].Platform)
-	// require.Equal(t, "N2", resp.Profiles[1].Name)
-	// require.Equal(t, "darwin", resp.Profiles[1].Platform)
+	require.Len(t, resp.Profiles, 2)
+	require.Equal(t, "N1", resp.Profiles[0].Name)
+	require.Equal(t, "darwin", resp.Profiles[0].Platform)
+	require.Equal(t, "N2", resp.Profiles[1].Name)
+	require.Equal(t, "darwin", resp.Profiles[1].Platform)
 
-	// // Create 2 new declarations. These should take the place of the first two.
-	// s.Do("POST", "/api/latest/fleet/mdm/profiles/batch", batchSetMDMProfilesRequest{Profiles: []fleet.MDMProfileBatchPayload{
-	// 	{Name: "N3", Contents: decls[2]},
-	// 	{Name: "N4", Contents: decls[3]},
-	// }}, http.StatusNoContent)
+	// Create 2 new declarations. These should take the place of the first two.
+	s.Do("POST", "/api/latest/fleet/mdm/profiles/batch", batchSetMDMProfilesRequest{Profiles: []fleet.MDMProfileBatchPayload{
+		{Name: "N3", Contents: decls[2]},
+		{Name: "N4", Contents: decls[3]},
+	}}, http.StatusNoContent)
 
-	// s.DoJSON("GET", "/api/latest/fleet/mdm/profiles", &listMDMConfigProfilesRequest{}, http.StatusOK, &resp)
+	s.DoJSON("GET", "/api/latest/fleet/mdm/profiles", &listMDMConfigProfilesRequest{}, http.StatusOK, &resp)
 
-	// require.Len(t, resp.Profiles, 2)
-	// require.Equal(t, "N3", resp.Profiles[0].Name)
-	// require.Equal(t, "darwin", resp.Profiles[0].Platform)
-	// require.Equal(t, "N4", resp.Profiles[1].Name)
-	// require.Equal(t, "darwin", resp.Profiles[1].Platform)
+	require.Len(t, resp.Profiles, 2)
+	require.Equal(t, "N3", resp.Profiles[0].Name)
+	require.Equal(t, "darwin", resp.Profiles[0].Platform)
+	require.Equal(t, "N4", resp.Profiles[1].Name)
+	require.Equal(t, "darwin", resp.Profiles[1].Platform)
 
-	// // replace only 1 declaration, the other one should be the same
+	// replace only 1 declaration, the other one should be the same
 
-	// s.Do("POST", "/api/latest/fleet/mdm/profiles/batch", batchSetMDMProfilesRequest{Profiles: []fleet.MDMProfileBatchPayload{
-	// 	{Name: "N3", Contents: decls[2]},
-	// 	{Name: "N5", Contents: decls[4]},
-	// }}, http.StatusNoContent)
+	s.Do("POST", "/api/latest/fleet/mdm/profiles/batch", batchSetMDMProfilesRequest{Profiles: []fleet.MDMProfileBatchPayload{
+		{Name: "N3", Contents: decls[2]},
+		{Name: "N5", Contents: decls[4]},
+	}}, http.StatusNoContent)
 
-	// s.DoJSON("GET", "/api/latest/fleet/mdm/profiles", &listMDMConfigProfilesRequest{}, http.StatusOK, &resp)
+	s.DoJSON("GET", "/api/latest/fleet/mdm/profiles", &listMDMConfigProfilesRequest{}, http.StatusOK, &resp)
 
-	// require.Len(t, resp.Profiles, 2)
-	// require.Equal(t, "N3", resp.Profiles[0].Name)
-	// require.Equal(t, "darwin", resp.Profiles[0].Platform)
-	// require.Equal(t, "N5", resp.Profiles[1].Name)
-	// require.Equal(t, "darwin", resp.Profiles[1].Platform)
+	require.Len(t, resp.Profiles, 2)
+	require.Equal(t, "N3", resp.Profiles[0].Name)
+	require.Equal(t, "darwin", resp.Profiles[0].Platform)
+	require.Equal(t, "N5", resp.Profiles[1].Name)
+	require.Equal(t, "darwin", resp.Profiles[1].Platform)
 
-	// // update the declarations
+	// update the declarations
 
-	// s.Do("POST", "/api/latest/fleet/mdm/profiles/batch", batchSetMDMProfilesRequest{Profiles: []fleet.MDMProfileBatchPayload{
-	// 	{Name: "N3", Contents: newDeclBytes(2, `"foo": "bar"`)},
-	// 	{Name: "N5", Contents: newDeclBytes(4, `"bing": "baz"`)},
-	// }}, http.StatusNoContent)
+	s.Do("POST", "/api/latest/fleet/mdm/profiles/batch", batchSetMDMProfilesRequest{Profiles: []fleet.MDMProfileBatchPayload{
+		{Name: "N3", Contents: newDeclBytes(2, `"foo": "bar"`)},
+		{Name: "N5", Contents: newDeclBytes(4, `"bing": "baz"`)},
+	}}, http.StatusNoContent)
 
-	// s.DoJSON("GET", "/api/latest/fleet/mdm/profiles", &listMDMConfigProfilesRequest{}, http.StatusOK, &resp)
+	s.DoJSON("GET", "/api/latest/fleet/mdm/profiles", &listMDMConfigProfilesRequest{}, http.StatusOK, &resp)
 
-	// require.Len(t, resp.Profiles, 2)
-	// require.Equal(t, "N3", resp.Profiles[0].Name)
-	// require.Equal(t, "darwin", resp.Profiles[0].Platform)
-	// require.Equal(t, "N5", resp.Profiles[1].Name)
-	// require.Equal(t, "darwin", resp.Profiles[1].Platform)
+	require.Len(t, resp.Profiles, 2)
+	require.Equal(t, "N3", resp.Profiles[0].Name)
+	require.Equal(t, "darwin", resp.Profiles[0].Platform)
+	require.Equal(t, "N5", resp.Profiles[1].Name)
+	require.Equal(t, "darwin", resp.Profiles[1].Platform)
 
 	var createResp createLabelResponse
 	s.DoJSON("POST", "/api/latest/fleet/labels", &fleet.LabelPayload{Name: ptr.String("label_1"), Query: ptr.String("select 1")}, http.StatusOK, &createResp)
@@ -12752,7 +12752,6 @@ func (s *integrationMDMTestSuite) TestAppleDDMBatchUpload() {
 		{Name: "N6", Contents: decls[6], Labels: []string{lbl1.Name}},
 	}}, http.StatusNoContent)
 
-	var resp listMDMConfigProfilesResponse
 	s.DoJSON("GET", "/api/latest/fleet/mdm/profiles", &listMDMConfigProfilesRequest{}, http.StatusOK, &resp)
 
 	require.Len(t, resp.Profiles, 2)
@@ -12760,12 +12759,6 @@ func (s *integrationMDMTestSuite) TestAppleDDMBatchUpload() {
 	require.Equal(t, "darwin", resp.Profiles[0].Platform)
 	require.Equal(t, "N6", resp.Profiles[1].Name)
 	require.Equal(t, "darwin", resp.Profiles[1].Platform)
-	for _, p := range resp.Profiles[0].Labels {
-		fmt.Println("name", p.LabelName)
-		fmt.Println("lid", p.LabelID)
-		fmt.Println("uuid", p.ProfileUUID)
-		fmt.Println("broken", p.Broken)
-	}
 	require.Len(t, resp.Profiles[0].Labels, 2)
 	require.Equal(t, lbl1.Name, resp.Profiles[0].Labels[0].LabelName)
 	require.Equal(t, lbl2.Name, resp.Profiles[0].Labels[1].LabelName)

--- a/server/service/mdm_test.go
+++ b/server/service/mdm_test.go
@@ -753,6 +753,8 @@ func TestGetMDMDiskEncryptionSummary(t *testing.T) {
 	})
 }
 
+// TODO: Add tests for Apple DDM authz?
+
 func TestMDMWindowsConfigProfileAuthz(t *testing.T) {
 	ds := new(mock.Store)
 	// while the config profiles are not premium-only, teams are and we want to test with teams.


### PR DESCRIPTION
Follow up to #17402 

- Add get/download declaration by uuid
- Add delete declaration by uuid
- Refactor away from `DeclarationLabel` type to use platform-agnostic `ConfigurationProfileLabel` type
- Use 'd' instead of 'x' to prefix declaration uuid
- Update error handling for DDM protocol endpoints