### PR TITLE
Update rest-api.md

### DIFF
--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -2518,7 +2518,7 @@ Returns the information of the specified host.
 Returns the information of the host specified using the `uuid`, `hardware_serial`, `osquery_host_id`, `hostname`, or
 `node_key` as an identifier.
 
-If `hostname` is specified when there is more than one host with the same hostname, the endpoint returns the first matching host.
+If `hostname` is specified when there is more than one host with the same hostname, the endpoint returns the first matching host. In Fleet, hostnames are fully qualified domain names (FQDNs).
 
 `GET /api/v1/fleet/hosts/identifier/:identifier`
 


### PR DESCRIPTION
- Clarify that hostnames are fully qualified domain names (FQDNs). FQDN =  hostname + domain.

For the following issue: #16895
