### PR TITLE
Website: Update order of columns on osquery schema table pages.

### DIFF
--- a/website/scripts/build-static-content.js
+++ b/website/scripts/build-static-content.js
@@ -700,7 +700,7 @@ module.exports = {
             }
 
             // Iterate through the columns of the table, we'll add a row to the markdown table element for each column in this schema table
-            for(let column of table.columns) {
+            for(let column of _.sortBy(table.columns, 'name')) {
               if(!column.hidden) { // If the column is hidden, we won't add it to the final table.
                 // Create an object for this column to add to the osqueryTables config.
                 let columnInfoForQueryReports = {


### PR DESCRIPTION
Related to: #17727
Changes:
- Updated the `build-static-content` script to sort the columns of tables alphabetically by the name of the column when the pages for fleetdm.com/tables are generated.