### PR TITLE
Website: update Vanta integration script

### DIFF
--- a/website/scripts/send-data-to-vanta.js
+++ b/website/scripts/send-data-to-vanta.js
@@ -35,7 +35,7 @@ module.exports = {
         },
         headers: { accept: 'application/json' }
       })
-      .retry({raw:{statusCode: 503}})
+      .retry({raw:{statusCode: 504}})
       .tolerate((err)=>{
         // If an error occurs while sending a request to Vanta, we'll add the error to the errorReportById object, with this connections ID set as the key.
         errorReportById[connectionIdAsString] = new Error(`Could not refresh the token for Vanta connection (id: ${connectionIdAsString}). Full error: ${err}`);

--- a/website/scripts/send-data-to-vanta.js
+++ b/website/scripts/send-data-to-vanta.js
@@ -35,7 +35,8 @@ module.exports = {
         },
         headers: { accept: 'application/json' }
       })
-      .retry({raw:{statusCode: 504}})
+      .retry({raw:{statusCode: 503}})// Retry requests that respond with "503: Service temporarily unavailable"
+      .retry({raw:{statusCode: 504}})// Retry requests that respond with "504: Endpoint request timed out"
       .tolerate((err)=>{
         // If an error occurs while sending a request to Vanta, we'll add the error to the errorReportById object, with this connections ID set as the key.
         errorReportById[connectionIdAsString] = new Error(`Could not refresh the token for Vanta connection (id: ${connectionIdAsString}). Full error: ${err}`);


### PR DESCRIPTION
Related to: #17699

Changes:
- Updated the `send-data-to-vanta` script to retry requests to Vanta's `https://api.vanta.com/oauth/token` API endpoint that return a `504` response.