### PR TITLE
[released bug/s] Fleet UI: Live query sort updates

### DIFF
--- a/frontend/interfaces/osquery_table.ts
+++ b/frontend/interfaces/osquery_table.ts
@@ -19,7 +19,9 @@ export type ColumnType =
   | "bigint"
   | "double"
   | "text"
-  | "unsigned_bigint";
+  | "unsigned_bigint"
+  | "STRING"
+  | "string"; // TODO: Why do we have type string, STRING, and text in schema.json?
 
 export interface IQueryTableColumn {
   name: string;

--- a/frontend/pages/policies/PolicyPage/components/PolicyQueriesTable/PolicyQueriesTableConfig.tsx
+++ b/frontend/pages/policies/PolicyPage/components/PolicyQueriesTable/PolicyQueriesTableConfig.tsx
@@ -53,6 +53,7 @@ const generateTableHeaders = (): IDataColumn[] => {
       Cell: (cellProps: ICellProps): JSX.Element => (
         <TextCell value={cellProps.cell.value} />
       ),
+      sortType: "caseInsensitive",
     },
     {
       title: "Status",

--- a/frontend/pages/queries/edit/EditQueryPage.tsx
+++ b/frontend/pages/queries/edit/EditQueryPage.tsx
@@ -289,7 +289,7 @@ const EditQueryPage = ({
   const onOsqueryTableSelect = (tableName: string) => {
     setSelectedOsqueryTable(tableName);
   };
-  console.log("selectedOsqueryTable", selectedOsqueryTable);
+
   const onCloseSchemaSidebar = () => {
     setIsSidebarOpen(false);
   };

--- a/frontend/pages/queries/edit/EditQueryPage.tsx
+++ b/frontend/pages/queries/edit/EditQueryPage.tsx
@@ -289,7 +289,7 @@ const EditQueryPage = ({
   const onOsqueryTableSelect = (tableName: string) => {
     setSelectedOsqueryTable(tableName);
   };
-
+  console.log("selectedOsqueryTable", selectedOsqueryTable);
   const onCloseSchemaSidebar = () => {
     setIsSidebarOpen(false);
   };

--- a/frontend/pages/queries/edit/components/QueryResults/QueryResults.tsx
+++ b/frontend/pages/queries/edit/components/QueryResults/QueryResults.tsx
@@ -113,7 +113,6 @@ const QueryResults = ({
   }, [lastEditedQueryBody]);
 
   useEffect(() => {
-    console.log("queryResults", queryResults);
     if (queryResults && queryResults.length > 0) {
       const newResultsColumnConfigs = generateColumnConfigsFromRows(
         queryResults,

--- a/frontend/pages/queries/edit/components/QueryResults/QueryResults.tsx
+++ b/frontend/pages/queries/edit/components/QueryResults/QueryResults.tsx
@@ -5,13 +5,16 @@ import classnames from "classnames";
 import FileSaver from "file-saver";
 import { QueryContext } from "context/query";
 import { useDebouncedCallback } from "use-debounce";
+import { find } from "lodash";
 
 import {
   generateCSVFilename,
   generateCSVQueryResults,
 } from "utilities/generate_csv";
+import { osqueryTables } from "utilities/osquery_tables";
 import { ICampaign, ICampaignError } from "interfaces/campaign";
 import { ITarget } from "interfaces/target";
+import { IQueryTableColumn } from "interfaces/osquery_table";
 
 import Button from "components/buttons/Button";
 import Icon from "components/Icon/Icon";
@@ -22,6 +25,7 @@ import QueryResultsHeading from "components/queries/queryResults/QueryResultsHea
 import AwaitingResults from "components/queries/queryResults/AwaitingResults";
 import InfoBanner from "components/InfoBanner";
 import CustomLink from "components/CustomLink";
+import { checkTable } from "utilities/sql_tools";
 
 import generateColumnConfigsFromRows from "./QueryResultsTableConfig";
 
@@ -73,6 +77,9 @@ const QueryResults = ({
   const [queryResultsForTableRender, setQueryResultsForTableRender] = useState(
     queryResults
   );
+  const [osqueryTableColumns, setOsqueryTableColumns] = useState<
+    IQueryTableColumn[] | []
+  >([]);
 
   // immediately reset results
   const onRunAgain = useCallback(() => {
@@ -91,10 +98,26 @@ const QueryResults = ({
     debounceQueryResults(queryResults);
   }, [queryResults, debounceQueryResults]);
 
+  // Set table/s columns from SQL
   useEffect(() => {
+    const tableNames =
+      (lastEditedQueryBody && checkTable(lastEditedQueryBody).tables) || [];
+
+    let columns: IQueryTableColumn[] | [] = [];
+    tableNames.forEach((tableName: string) => {
+      const tableColumns =
+        find(osqueryTables, { name: tableName })?.columns || [];
+      columns = [...columns, ...tableColumns];
+    });
+    setOsqueryTableColumns(columns);
+  }, [lastEditedQueryBody]);
+
+  useEffect(() => {
+    console.log("queryResults", queryResults);
     if (queryResults && queryResults.length > 0) {
       const newResultsColumnConfigs = generateColumnConfigsFromRows(
-        queryResults
+        queryResults,
+        osqueryTableColumns
       );
       // Update tableHeaders if new headers are found
       if (newResultsColumnConfigs !== resultsColumnConfigs) {

--- a/frontend/pages/queries/edit/components/QueryResults/QueryResultsTableConfig.tsx
+++ b/frontend/pages/queries/edit/components/QueryResults/QueryResultsTableConfig.tsx
@@ -34,20 +34,18 @@ const _unshiftHostname = <T extends object>(columns: Column<T>[]) => {
   return newHeaders;
 };
 
+// Sorts numerical columns correctly while perserving case insensitive sort for text columns
 const sortType = (
   colName: string | number | symbol,
-  osqueryTableColumns: IQueryTableColumn[] | []
+  osqueryTableColumns?: IQueryTableColumn[] | []
 ) => {
-  if (typeof colName === "string") {
+  if (typeof colName === "string" && !!osqueryTableColumns) {
+    const numberTypes = ["integer", "bigint", "unsigned_bigint", "double"];
+
     const type = find(osqueryTableColumns, { name: colName })?.type;
 
-    switch (type) {
-      case "integer" || "bigint" || "unsigned_bigint" || "double":
-        console.log("type bigint or integer:", colName, type);
-        return "alphanumeric";
-      default:
-        console.log("default because type", colName, type);
-        return "caseInsensitive";
+    if (type && numberTypes.includes(type)) {
+      return "alphanumeric";
     }
   }
   return "caseInsensitive";
@@ -57,7 +55,7 @@ const generateColumnConfigsFromRows = <T extends Record<keyof T, unknown>>(
   // TODO - narrow typing down this entire chain of logic
   // typed as any[] to accomodate loose typing of websocket API
   results: T[], // {col:val, ...} for each row of query results
-  osqueryTableColumns: IQueryTableColumn[] | []
+  osqueryTableColumns?: IQueryTableColumn[] | []
 ): Column<T>[] => {
   const uniqueColumnNames = getUniqueColumnNamesFromRows(results);
   const columnsConfigs = uniqueColumnNames.map<Column<T>>((colName) => {


### PR DESCRIPTION
## Issue
Cerra #17288 

## Description
- Updates to live query sort
  - Sorting by a number type now uses `alphanumeric` sort
- Update to live policy sort:
  - Sorting by host is now case insensitive

NOTE: The newer react-table looks like "alphanumeric" type is case insensitive and should work for all column types. https://tanstack.com/table/v8/docs/api/features/sorting

## Screenrecording
- Update to live query sort
TODO 
- Update to live policy sort
https://www.loom.com/share/5f62298a93f04689960dea9a4b9a8292?sid=61467da2-9862-4759-b354-aa3c83fc5ab6


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [ ] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
- [x] Manual QA for all new/changed functionality

