### PR TITLE
In dogfood, collect expiration for MDM SCEP certificates

### DIFF
--- a/it-and-security/teams/workstations.yml
+++ b/it-and-security/teams/workstations.yml
@@ -62,7 +62,7 @@ queries:
   - path: ../lib/collect-usb-devices.queries.yml
   - path: ../lib/collect-vs-code-extensions.queries.yml
   - name: Collect hosts with expired SCEP certs
-    description: "For the following issue: https://github.com/fleetdm/confidential/issues/4518. Returns expiration date for macOS hosts's with expired SCEP certs. If a host has a valid (non-expired) SCEP cert, it won't return any results."
+    description: "For the following issue: https://github.com/fleetdm/confidential/issues/4518. Returns expiration date for macOS hosts's MDM SCEP certs."
     query: "SELECT common_name, datetime(not_valid_after,'unixepoch') AS expires FROM certificates WHERE 'common_name' LIKE '%FleetDM Identity%';"
     platform: darwin
     interval: 300

--- a/it-and-security/teams/workstations.yml
+++ b/it-and-security/teams/workstations.yml
@@ -61,7 +61,7 @@ queries:
   - path: ../lib/collect-failed-login-attempts.queries.yml
   - path: ../lib/collect-usb-devices.queries.yml
   - path: ../lib/collect-vs-code-extensions.queries.yml
-  - name: Collect hosts with expired SCEP certs
+  - name: Collect expiration date for MDM SCEP certifcates
     description: "For the following issue: https://github.com/fleetdm/confidential/issues/4518. Returns expiration date for macOS hosts's MDM SCEP certs."
     query: "SELECT common_name, datetime(not_valid_after,'unixepoch') AS expires FROM certificates WHERE 'common_name' LIKE '%FleetDM Identity%';"
     platform: darwin

--- a/it-and-security/teams/workstations.yml
+++ b/it-and-security/teams/workstations.yml
@@ -61,3 +61,11 @@ queries:
   - path: ../lib/collect-failed-login-attempts.queries.yml
   - path: ../lib/collect-usb-devices.queries.yml
   - path: ../lib/collect-vs-code-extensions.queries.yml
+  - name: Collect hosts with expired SCEP certs
+    description: "For the following issue: https://github.com/fleetdm/confidential/issues/4518. Returns expiration date for macOS hosts's with expired SCEP certs. If a host has a valid (non-expired) SCEP cert, it won't return any results."
+    query: "SELECT common_name, datetime(not_valid_after,'unixepoch') AS expires FROM certificates WHERE 'common_name' LIKE '%FleetDM Identity%';"
+    platform: darwin
+    interval: 300
+    automations_enabled: false
+    observer_can_run: true
+

--- a/it-and-security/teams/workstations.yml
+++ b/it-and-security/teams/workstations.yml
@@ -61,7 +61,7 @@ queries:
   - path: ../lib/collect-failed-login-attempts.queries.yml
   - path: ../lib/collect-usb-devices.queries.yml
   - path: ../lib/collect-vs-code-extensions.queries.yml
-  - name: Collect expiration date for MDM SCEP certifcates
+  - name: Collect expiration date for MDM SCEP certificates
     description: "For the following issue: https://github.com/fleetdm/confidential/issues/4518. Returns expiration date for macOS hosts's MDM SCEP certs."
     query: "SELECT common_name, datetime(not_valid_after,'unixepoch') AS expires FROM certificates WHERE 'common_name' LIKE '%FleetDM Identity%';"
     platform: darwin


### PR DESCRIPTION
For the following issue: https://github.com/fleetdm/confidential/issues/4518

- Add query that runs every 5 minutes to the workstations team
- Plan is to remove the query after the issue tracking renewing all SCEP certs is closed: https://github.com/fleetdm/confidential/issues/4518
