### PR TITLE
UI – Handle missing / `null` `smtp_settings`

### DIFF
--- a/changes/17065-null-smtp_settings
+++ b/changes/17065-null-smtp_settings
@@ -1,0 +1,1 @@
+- Fix a bug where `null` or excluded `smtp_settings` caused a UI 500.

--- a/frontend/interfaces/config.ts
+++ b/frontend/interfaces/config.ts
@@ -122,7 +122,7 @@ export interface IConfig {
   };
   sandbox_enabled: boolean;
   server_settings: IConfigServerSettings;
-  smtp_settings: {
+  smtp_settings?: {
     enable_smtp: boolean;
     configured: boolean;
     sender_address: string;

--- a/frontend/pages/AccountPage/AccountPage.tsx
+++ b/frontend/pages/AccountPage/AccountPage.tsx
@@ -91,7 +91,11 @@ const AccountPage = ({ router }: IAccountPageProps): JSX.Element | null => {
       await usersAPI.update(currentUser.id, updated);
       let accountUpdatedFlashMessage = "Account updated";
       if (updated.email) {
-        accountUpdatedFlashMessage += `: A confirmation email was sent from ${config?.smtp_settings.sender_address} to ${updated.email}`;
+        // always present, this for typing
+        const senderAddressMessage = config?.smtp_settings?.sender_address
+          ? ` from ${config?.smtp_settings?.sender_address}`
+          : "";
+        accountUpdatedFlashMessage += `: A confirmation email was sent${senderAddressMessage} to ${updated.email}`;
         setPendingEmail(updated.email);
       }
 

--- a/frontend/pages/admin/OrgSettingsPage/cards/Advanced/Advanced.tsx
+++ b/frontend/pages/admin/OrgSettingsPage/cards/Advanced/Advanced.tsx
@@ -20,9 +20,9 @@ const Advanced = ({
   isUpdatingSettings,
 }: IAppConfigFormProps): JSX.Element => {
   const [formData, setFormData] = useState({
-    domain: appConfig.smtp_settings.domain || "",
-    verifySSLCerts: appConfig.smtp_settings.verify_ssl_certs || false,
-    enableStartTLS: appConfig.smtp_settings.enable_start_tls,
+    domain: appConfig.smtp_settings?.domain || "",
+    verifySSLCerts: appConfig.smtp_settings?.verify_ssl_certs || false,
+    enableStartTLS: appConfig.smtp_settings?.enable_start_tls,
     enableHostExpiry:
       appConfig.host_expiry_settings.host_expiry_enabled || false,
     hostExpiryWindow: appConfig.host_expiry_settings.host_expiry_window || 0,
@@ -74,16 +74,16 @@ const Advanced = ({
         scripts_disabled: disableScripts,
       },
       smtp_settings: {
-        enable_smtp: appConfig.smtp_settings.enable_smtp || false,
-        sender_address: appConfig.smtp_settings.sender_address || "",
-        server: appConfig.smtp_settings.server || "",
-        port: Number(appConfig.smtp_settings.port),
-        authentication_type: appConfig.smtp_settings.authentication_type || "",
-        user_name: appConfig.smtp_settings.user_name || "",
-        password: appConfig.smtp_settings.password || "",
-        enable_ssl_tls: appConfig.smtp_settings.enable_ssl_tls || false,
+        enable_smtp: appConfig.smtp_settings?.enable_smtp || false,
+        sender_address: appConfig.smtp_settings?.sender_address || "",
+        server: appConfig.smtp_settings?.server || "",
+        port: Number(appConfig.smtp_settings?.port),
+        authentication_type: appConfig.smtp_settings?.authentication_type || "",
+        user_name: appConfig.smtp_settings?.user_name || "",
+        password: appConfig.smtp_settings?.password || "",
+        enable_ssl_tls: appConfig.smtp_settings?.enable_ssl_tls || false,
         authentication_method:
-          appConfig.smtp_settings.authentication_method || "",
+          appConfig.smtp_settings?.authentication_method || "",
         domain,
         verify_ssl_certs: verifySSLCerts,
         enable_start_tls: enableStartTLS,

--- a/frontend/pages/admin/OrgSettingsPage/cards/Smtp/Smtp.tsx
+++ b/frontend/pages/admin/OrgSettingsPage/cards/Smtp/Smtp.tsx
@@ -31,16 +31,16 @@ const Smtp = ({
   const { isPremiumTier } = useContext(AppContext);
 
   const [formData, setFormData] = useState<any>({
-    enableSMTP: appConfig.smtp_settings.enable_smtp || false,
-    smtpSenderAddress: appConfig.smtp_settings.sender_address || "",
-    smtpServer: appConfig.smtp_settings.server || "",
-    smtpPort: appConfig.smtp_settings.port,
-    smtpEnableSSLTLS: appConfig.smtp_settings.enable_ssl_tls || false,
-    smtpAuthenticationType: appConfig.smtp_settings.authentication_type || "",
-    smtpUsername: appConfig.smtp_settings.user_name || "",
-    smtpPassword: appConfig.smtp_settings.password || "",
+    enableSMTP: appConfig.smtp_settings?.enable_smtp || false,
+    smtpSenderAddress: appConfig.smtp_settings?.sender_address || "",
+    smtpServer: appConfig.smtp_settings?.server || "",
+    smtpPort: appConfig.smtp_settings?.port,
+    smtpEnableSSLTLS: appConfig.smtp_settings?.enable_ssl_tls || false,
+    smtpAuthenticationType: appConfig.smtp_settings?.authentication_type || "",
+    smtpUsername: appConfig.smtp_settings?.user_name || "",
+    smtpPassword: appConfig.smtp_settings?.password || "",
     smtpAuthenticationMethod:
-      appConfig.smtp_settings.authentication_method || "",
+      appConfig.smtp_settings?.authentication_method || "",
   });
 
   const {
@@ -116,9 +116,9 @@ const Smtp = ({
         password: smtpPassword,
         enable_ssl_tls: smtpEnableSSLTLS,
         authentication_method: smtpAuthenticationMethod,
-        domain: appConfig.smtp_settings.domain || "",
-        verify_ssl_certs: appConfig.smtp_settings.verify_ssl_certs || false,
-        enable_start_tls: appConfig.smtp_settings.enable_start_tls,
+        domain: appConfig.smtp_settings?.domain || "",
+        verify_ssl_certs: appConfig.smtp_settings?.verify_ssl_certs || false,
+        enable_start_tls: appConfig.smtp_settings?.enable_start_tls,
       },
     };
 
@@ -282,13 +282,13 @@ const Smtp = ({
             !sesConfigured ? (
               <small
                 className={`smtp-options smtp-options--${
-                  appConfig.smtp_settings.configured
+                  appConfig.smtp_settings?.configured
                     ? "configured"
                     : "notconfigured"
                 }`}
               >
                 <em>
-                  {appConfig.smtp_settings.configured
+                  {appConfig.smtp_settings?.configured
                     ? "CONFIGURED"
                     : "NOT CONFIGURED"}
                 </em>

--- a/frontend/pages/admin/TeamManagementPage/TeamDetailsWrapper/UsersPage/UsersPage.tsx
+++ b/frontend/pages/admin/TeamManagementPage/TeamDetailsWrapper/UsersPage/UsersPage.tsx
@@ -217,9 +217,12 @@ const UsersPage = ({ location, router }: ITeamSubnavProps): JSX.Element => {
       inviteAPI
         .create(requestData)
         .then(() => {
+          const senderAddressMessage = config?.smtp_settings?.sender_address
+            ? ` from ${config?.smtp_settings?.sender_address}`
+            : "";
           renderFlash(
             "success",
-            `An invitation email was sent from ${config?.smtp_settings.sender_address} to ${formData.email}.`
+            `An invitation email was sent${senderAddressMessage} to ${formData.email}.`
           );
           refetchUsers();
           toggleCreateUserModal();

--- a/frontend/pages/admin/UserManagementPage/components/UsersTable/UsersTable.tsx
+++ b/frontend/pages/admin/UserManagementPage/components/UsersTable/UsersTable.tsx
@@ -225,9 +225,12 @@ const UsersTable = ({ router }: IUsersTableProps): JSX.Element => {
       invitesAPI
         .create(requestData)
         .then(() => {
+          const senderAddressMessage = config?.smtp_settings?.sender_address
+            ? ` from ${config?.smtp_settings?.sender_address}`
+            : "";
           renderFlash(
             "success",
-            `An invitation email was sent from ${config?.smtp_settings.sender_address} to ${formData.email}.`
+            `An invitation email was sent${senderAddressMessage} to ${formData.email}.`
           );
           toggleCreateUserModal();
           refetchInvites();
@@ -302,7 +305,10 @@ const UsersTable = ({ router }: IUsersTableProps): JSX.Element => {
 
     let userUpdatedFlashMessage = `Successfully edited ${formData.name}`;
     if (userData?.email !== formData.email) {
-      userUpdatedFlashMessage += `: A confirmation email was sent from ${config?.smtp_settings.sender_address} to ${formData.email}`;
+      const senderAddressMessage = config?.smtp_settings?.sender_address
+        ? ` from ${config?.smtp_settings?.sender_address}`
+        : "";
+      userUpdatedFlashMessage += `: A confirmation email was sent${senderAddressMessage} to ${formData.email}`;
     }
     const userUpdatedEmailError =
       "A user with this email address already exists";
@@ -463,7 +469,7 @@ const UsersTable = ({ router }: IUsersTableProps): JSX.Element => {
         onSubmit={onEditUser}
         availableTeams={teams || []}
         isPremiumTier={isPremiumTier || false}
-        smtpConfigured={config?.smtp_settings.configured || false}
+        smtpConfigured={config?.smtp_settings?.configured || false}
         sesConfigured={config?.email?.backend === "ses" || false}
         canUseSso={config?.sso_settings.enable_sso || false}
         isSsoEnabled={userData?.sso_enabled}
@@ -486,7 +492,7 @@ const UsersTable = ({ router }: IUsersTableProps): JSX.Element => {
         defaultGlobalRole="observer"
         defaultTeams={[]}
         isPremiumTier={isPremiumTier || false}
-        smtpConfigured={config?.smtp_settings.configured || false}
+        smtpConfigured={config?.smtp_settings?.configured || false}
         sesConfigured={config?.email?.backend === "ses" || false}
         canUseSso={config?.sso_settings.enable_sso || false}
         isUpdatingUsers={isUpdatingUsers}


### PR DESCRIPTION
## Addresses #17065

Settings cleanly renders as empty and disabled despite nonexistent `smtp_settings` from config response: 
![Screenshot 2024-03-25 at 3 52 05 PM](https://github.com/fleetdm/fleet/assets/61553566/85c2a9af-7cc2-48b7-9ecf-604496813204)

- [x] Changes file added for user-visible changes in `changes/`
- [x] Manual QA for all new/changed functionality
