### PR TITLE
fix ui bug for showing os updates table with no team

### DIFF
--- a/frontend/pages/ManageControlsPage/OSUpdates/components/CurrentVersionSection/CurrentVersionSection.tsx
+++ b/frontend/pages/ManageControlsPage/OSUpdates/components/CurrentVersionSection/CurrentVersionSection.tsx
@@ -55,18 +55,19 @@ const CurrentVersionSection = ({
     );
   };
 
-  if (!data) {
-    return null;
-  }
-
   const renderTable = () => {
     if (isError) {
       return (
         <DataError
+          className={`${baseClass}__error`}
           description="Refresh the page to try again."
           excludeIssueLink
         />
       );
+    }
+
+    if (!data) {
+      return null;
     }
 
     if (!data.os_versions) {

--- a/frontend/pages/ManageControlsPage/OSUpdates/components/CurrentVersionSection/_styles.scss
+++ b/frontend/pages/ManageControlsPage/OSUpdates/components/CurrentVersionSection/_styles.scss
@@ -15,4 +15,8 @@
       font-size: 18px;
     }
   }
+
+  &__error {
+    padding: $pad-xxlarge;
+  }
 }

--- a/frontend/services/entities/operating_systems.ts
+++ b/frontend/services/entities/operating_systems.ts
@@ -4,6 +4,7 @@ import endpoints from "utilities/endpoints";
 import { IOperatingSystemVersion } from "interfaces/operating_system";
 import { OsqueryPlatform } from "interfaces/platform";
 import { buildQueryStringFromParams } from "utilities/url";
+import { API_NO_TEAM_ID } from "interfaces/team";
 
 // TODO: add platforms to this constant as new ones are supported
 export const OS_VERSIONS_API_SUPPORTED_PLATFORMS = [
@@ -49,6 +50,11 @@ export interface IOSVersionResponse {
   os_version: IOperatingSystemVersion;
 }
 
+type IGetOSVersionsRequestQueryParams = Record<
+  string,
+  string | number | undefined
+>;
+
 export const getOSVersions = ({
   platform,
   teamId,
@@ -62,16 +68,21 @@ export const getOSVersions = ({
   const { OS_VERSIONS } = endpoints;
   let path = OS_VERSIONS;
 
-  const queryString = buildQueryStringFromParams({
+  const params: IGetOSVersionsRequestQueryParams = {
     platform,
-    team_id: teamId,
     os_name,
     os_version,
     order_key,
     order_direction,
     page,
     per_page,
-  });
+  };
+
+  if (teamId !== API_NO_TEAM_ID) {
+    params.team_id = teamId;
+  }
+
+  const queryString = buildQueryStringFromParams(params);
 
   if (queryString) path += `?${queryString}`;
 


### PR DESCRIPTION
quick fix to correctly show the os versions for "no teams" on os updates page

**before:**

<img width="1688" alt="image" src="https://github.com/fleetdm/fleet/assets/1153709/6867e62f-48a0-4020-9760-86c6f62af207">

**after:**

<img width="1687" alt="image" src="https://github.com/fleetdm/fleet/assets/1153709/6d5245e4-bb46-466a-ba9f-7752ea1b0997">

- [x] Manual QA for all new/changed functionality
