### PR TITLE
Allow EnrollmentState to be in status '3' for MDM clients

### DIFF
--- a/changes/17692-enrollment-state-3.md
+++ b/changes/17692-enrollment-state-3.md
@@ -1,0 +1,1 @@
+- Fix a bug where valid MDM enrollments would show up as unmanaged (EnrollmentState 3)

--- a/server/service/osquery_utils/queries.go
+++ b/server/service/osquery_utils/queries.go
@@ -506,7 +506,7 @@ var extraDetailQueries = map[string]DetailQuery{
 		    -- coalesce to 'unknown' and keep that state in the list
 		    -- in order to account for hosts that might not have this
 		    -- key, and servers
-                    WHERE COALESCE(e.state, '0') IN ('0', '1', '2')
+                    WHERE COALESCE(e.state, '0') IN ('0', '1', '2', '3')
                     LIMIT 1;
 		`,
 		DirectIngestFunc: directIngestMDMWindows,


### PR DESCRIPTION
#17692

Recently there was a change that filtered out hosts in `EnrollmentState` 3. This change may cause some hosts that are in otherwise good health to appear unresponsive to MDM in the management UI.

This change will allow hosts with `EnrollmentStatus` 3 show as enrolled.

The root cause of some hosts being in state 3 is still not entirely clear, but may have to do with either trying to re-enroll once already enrolled, or windows updates causing some sort of issue with fleet.

Despite the "failed" `EnrollmentState` 3, the host will still display that the system is managed by Fleet, and will actively sync.

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.