### PR TITLE
Disabling calendar policies removes scheduled calendar events

### DIFF
--- a/server/datastore/mysql/calendar_events.go
+++ b/server/datastore/mysql/calendar_events.go
@@ -210,7 +210,6 @@ func (ds *Datastore) ListCalendarEvents(ctx context.Context, teamID *uint) ([]*f
 
 	var args []interface{}
 	if teamID != nil {
-		// TODO(lucas): Should we add a team_id column to calendar_events?
 		calendarEventsQuery += ` JOIN host_calendar_events hce ON ce.id=hce.calendar_event_id
 								 JOIN hosts h ON h.id=hce.host_id WHERE h.team_id = ?`
 		args = append(args, *teamID)


### PR DESCRIPTION
#17230

Fix for the following scenarios:
- Team has only one policy with calendar enabled. Events are created on user calendars. Then the user disables the calendar on such policy. Expected behavior: Events on the user calendar should be cleaned up in that scenario.
- Policy `platform` is edited (which removes `policy_membership` entries) and we'd like to have the calendar event removed for the hosts that do not apply anymore.

To cover these scenarios I changed `ds.GetTeamHostsPolicyMemberships` so that it also returns hosts that have a calendar event AND have no results on policies (returned as passing=1). 
E.g. this could happen if there ARE calendar events for a team but with a platform that doesn't match the host (so it has no results).