### PR TITLE
Update Fleet schema overrides (string » text) & regenerate `osquery_fleet_schema.json`

### DIFF
--- a/schema/osquery_fleet_schema.json
+++ b/schema/osquery_fleet_schema.json
@@ -3970,7 +3970,7 @@
       {
         "name": "path",
         "description": "Path to extension folder. Defaults to '' on ChromeOS",
-        "type": "STRING",
+        "type": "TEXT",
         "notes": "",
         "hidden": false,
         "required": false,
@@ -4067,7 +4067,7 @@
       {
         "name": "state",
         "description": "1 if this extension is enabled",
-        "type": "STRING",
+        "type": "TEXT",
         "notes": "",
         "hidden": false,
         "required": false,
@@ -15143,19 +15143,19 @@
         "name": "trace_id",
         "description": "The ID of a trace event",
         "required": false,
-        "type": "string"
+        "type": "text"
       },
       {
         "name": "event_type",
         "description": "The type of event, this can be logEvent, signpostEvent or stateEvent.",
         "required": false,
-        "type": "string"
+        "type": "text"
       },
       {
         "name": "format_string",
         "description": "The format string used to convert variable content into a string for output.",
         "required": false,
-        "type": "string"
+        "type": "text"
       },
       {
         "name": "activity_identifier",
@@ -15185,19 +15185,19 @@
         "name": "sender_image_uuid",
         "description": "The UUID of the library, framework, kernel extension, or mach-o image, that originated the event.",
         "required": false,
-        "type": "string"
+        "type": "text"
       },
       {
         "name": "sender_image_path",
         "description": "The full path of the library, framework, kernel extension, or mach-o image, that originated the event.",
         "required": false,
-        "type": "string"
+        "type": "text"
       },
       {
         "name": "boot_uuid",
         "description": "The boot UUID of the event.",
         "required": false,
-        "type": "string"
+        "type": "text"
       },
       {
         "name": "process_id",
@@ -15209,7 +15209,7 @@
         "name": "process_image_path",
         "description": "The full path of the process that originated the event.",
         "required": false,
-        "type": "string"
+        "type": "text"
       },
       {
         "name": "timestamp",
@@ -15221,7 +15221,7 @@
         "name": "event_message",
         "description": "The message of the log entry.",
         "required": false,
-        "type": "string"
+        "type": "text"
       },
       {
         "name": "sender_program_counter",
@@ -25617,7 +25617,7 @@
       {
         "name": "hostname",
         "description": "Network hostname including domain. For ChromeOS, this is only available if the extension was force-installed by an enterprise policy",
-        "type": "STRING",
+        "type": "TEXT",
         "notes": "",
         "hidden": false,
         "required": false,
@@ -25635,7 +25635,7 @@
       {
         "name": "cpu_type",
         "description": "CPU type",
-        "type": "STRING",
+        "type": "TEXT",
         "notes": "",
         "hidden": false,
         "required": false,
@@ -25658,7 +25658,7 @@
       {
         "name": "cpu_brand",
         "description": "CPU brand string, contains vendor and model",
-        "type": "STRING",
+        "type": "TEXT",
         "notes": "",
         "hidden": false,
         "required": false,
@@ -25718,7 +25718,7 @@
       {
         "name": "physical_memory",
         "description": "Total physical memory in bytes",
-        "type": "STRING",
+        "type": "TEXT",
         "notes": "",
         "hidden": false,
         "required": false,
@@ -25727,7 +25727,7 @@
       {
         "name": "hardware_vendor",
         "description": "Hardware vendor. For ChromeOS, this is only available if the extension was force-installed by an enterprise policy",
-        "type": "STRING",
+        "type": "TEXT",
         "notes": "",
         "hidden": false,
         "required": false,
@@ -25736,7 +25736,7 @@
       {
         "name": "hardware_model",
         "description": "Hardware model. For ChromeOS, this is only available if the extension was force-installed by an enterprise policy",
-        "type": "STRING",
+        "type": "TEXT",
         "notes": "",
         "hidden": false,
         "required": false,
@@ -25759,7 +25759,7 @@
       {
         "name": "hardware_serial",
         "description": "The device's serial number. For ChromeOS, this is only available if the extension was force-installed by an enterprise policy",
-        "type": "STRING",
+        "type": "TEXT",
         "notes": "",
         "hidden": false,
         "required": false,
@@ -25824,7 +25824,7 @@
       {
         "name": "computer_name",
         "description": "Friendly computer name (optional). For ChromeOS, if the extension wasn't force-installed by an enterprise policy this will default to 'ChromeOS' only",
-        "type": "STRING",
+        "type": "TEXT",
         "notes": "",
         "hidden": false,
         "required": false,
@@ -25857,7 +25857,7 @@
     "columns": [
       {
         "name": "idle_state",
-        "type": "string",
+        "type": "text",
         "description": "Returns \"locked\", \"idle\", or \"active\".",
         "required": false
       }
@@ -27254,7 +27254,7 @@
       {
         "name": "email",
         "required": false,
-        "type": "string",
+        "type": "text",
         "description": "Email",
         "platforms": [
           "chrome"

--- a/schema/tables/chrome_extensions.yml
+++ b/schema/tables/chrome_extensions.yml
@@ -57,7 +57,7 @@ columns:
       - windows
       - linux
   - name: path
-    type: string
+    type: text
     description: Path to extension folder. Defaults to '' on ChromeOS
   - name: optional_permissions
     platforms: 
@@ -85,7 +85,7 @@ columns:
       - windows
       - linux
   - name: state
-    type: string
+    type: text
   - name: install_time
     platforms: 
       - darwin

--- a/schema/tables/macadmins_unified_log.yml
+++ b/schema/tables/macadmins_unified_log.yml
@@ -16,15 +16,15 @@ columns:
   - name: trace_id
     description: The ID of a trace event
     required: false
-    type: string
+    type: text
   - name: event_type
     description: The type of event, this can be logEvent, signpostEvent or stateEvent.
     required: false
-    type: string
+    type: text
   - name: format_string
     description: The format string used to convert variable content into a string for output.
     required: false
-    type: string
+    type: text
   - name: activity_identifier
     description: The identifier of the log activity.
     required: false
@@ -44,15 +44,15 @@ columns:
   - name: sender_image_uuid
     description: The UUID of the library, framework, kernel extension, or mach-o image, that originated the event.
     required: false
-    type: string
+    type: text
   - name: sender_image_path
     description: The full path of the library, framework, kernel extension, or mach-o image, that originated the event.
     required: false
-    type: string
+    type: text
   - name: boot_uuid
     description: The boot UUID of the event.
     required: false
-    type: string
+    type: text
   - name: process_id
     description: Process ID of the process that generated this log item, which can be joined to multiple other tables including a *PID*.
     required: false
@@ -60,7 +60,7 @@ columns:
   - name: process_image_path
     description: The full path of the process that originated the event.
     required: false
-    type: string
+    type: text
   - name: timestamp
     description: Timestamp in [UNIX time format](https://en.wikipedia.org/wiki/Unix_time).
     required: false
@@ -68,7 +68,7 @@ columns:
   - name: event_message
     description: The message of the log entry.
     required: false
-    type: string
+    type: text
   - name: sender_program_counter
     description: The program counter of the library, framework, kernel extension, or mach-o image, that originated the event.
     required: false

--- a/schema/tables/system_info.yml
+++ b/schema/tables/system_info.yml
@@ -56,26 +56,26 @@ columns:
       - windows
       - linux
   - name: hostname
-    type: string
+    type: text
     description: Network hostname including domain. For ChromeOS, this is only available if the extension was force-installed by an enterprise policy
   - name: computer_name
-    type: string
+    type: text
     description: Friendly computer name (optional). For ChromeOS, if the extension wasn't force-installed by an enterprise policy this will default to 'ChromeOS' only
   - name: hardware_serial
-    type: string
+    type: text
     description: The device's serial number. For ChromeOS, this is only available if the extension was force-installed by an enterprise policy
   - name: hardware_vendor
-    type: string
+    type: text
     description: Hardware vendor. For ChromeOS, this is only available if the extension was force-installed by an enterprise policy
   - name: hardware_model
-    type: string
+    type: text
     description: Hardware model. For ChromeOS, this is only available if the extension was force-installed by an enterprise policy
   - name: cpu_brand
-    type: string
+    type: text
   - name: cpu_type
-    type: string
+    type: text
   - name: physical_memory
-    type: string
+    type: text
 
 examples: >-
   See the CPU architecture of a machine as well as who made it and what its

--- a/schema/tables/system_state.yml
+++ b/schema/tables/system_state.yml
@@ -12,7 +12,7 @@ examples: >-
   ```
 columns:
   - name: idle_state
-    type: string
+    type: text
     description: Returns "locked", "idle", or "active".
     required: false
 evented: false

--- a/schema/tables/users.yml
+++ b/schema/tables/users.yml
@@ -46,7 +46,7 @@ columns:
   - name: uuid
   - name: email
     required: false
-    type: string
+    type: text
     description: Email
     platforms:
       - chrome


### PR DESCRIPTION
Changes:
- Updated the type of all override columns with `type:string` to `type:text`
- Regenerated `osquery_fleet_schema.json`