### PR TITLE
[released bug] Fleet UI: Fix numerical type sort on Query Report

### DIFF
--- a/changes/17288-fix-sort-of-sql-results
+++ b/changes/17288-fix-sort-of-sql-results
@@ -1,0 +1,1 @@
+* UI fix of sql result sort for both string and numerical columns on live query results, live policy results, and query report

--- a/frontend/pages/queries/details/components/QueryReport/QueryReport.tsx
+++ b/frontend/pages/queries/details/components/QueryReport/QueryReport.tsx
@@ -8,6 +8,7 @@ import {
   generateCSVFilename,
   generateCSVQueryResults,
 } from "utilities/generate_csv";
+import { getTableColumnsFromSql } from "utilities/helpers";
 import { IQueryReport, IQueryReportResultRow } from "interfaces/query_report";
 
 import Button from "components/buttons/Button";
@@ -52,9 +53,13 @@ const QueryReport = ({
 
   useEffect(() => {
     if (queryReport && queryReport.results && queryReport.results.length > 0) {
+      const tableColumns = getTableColumnsFromSql(lastEditedQueryBody);
+
       const newColumnConfigs = generateReportColumnConfigsFromResults(
-        flattenResults(queryReport.results)
+        flattenResults(queryReport.results),
+        tableColumns
       );
+
       // Update tableHeaders if new headers are found
       if (newColumnConfigs !== columnConfigs) {
         setColumnConfigs(newColumnConfigs);

--- a/frontend/pages/queries/details/components/QueryReport/QueryReportTableConfig.tsx
+++ b/frontend/pages/queries/details/components/QueryReport/QueryReportTableConfig.tsx
@@ -9,10 +9,12 @@ import DefaultColumnFilter from "components/TableContainer/DataTable/DefaultColu
 import HeaderCell from "components/TableContainer/DataTable/HeaderCell/HeaderCell";
 
 import {
+  getSortTypeFromColumnType,
   getUniqueColumnNamesFromRows,
   humanHostLastSeen,
   internallyTruncateText,
 } from "utilities/helpers";
+import { IQueryTableColumn } from "interfaces/osquery_table";
 import { IHeaderProps, IWebSocketData } from "interfaces/datatable_config";
 
 type IQueryReportTableColumnConfig = Column<IWebSocketData>;
@@ -40,7 +42,8 @@ const _unshiftHostname = (headers: IQueryReportTableColumnConfig[]) => {
 };
 
 const generateReportColumnConfigsFromResults = (
-  results: IWebSocketData[]
+  results: IWebSocketData[],
+  tableColumns?: IQueryTableColumn[] | []
 ): IQueryReportTableColumnConfig[] => {
   /* Results include an array of objects, each representing a table row
   Each key value pair in an object represents a column name and value
@@ -79,7 +82,7 @@ const generateReportColumnConfigsFromResults = (
         Filter: DefaultColumnFilter, // Component hides filter for last_fetched
         filterType: "text",
         disableSortBy: false,
-        sortType: "caseInsensitive",
+        sortType: getSortTypeFromColumnType(key, tableColumns),
       };
     }
   );

--- a/frontend/pages/queries/edit/components/QueryResults/QueryResults.tsx
+++ b/frontend/pages/queries/edit/components/QueryResults/QueryResults.tsx
@@ -10,6 +10,7 @@ import {
   generateCSVFilename,
   generateCSVQueryResults,
 } from "utilities/generate_csv";
+import { getTableColumnsFromSql } from "utilities/helpers";
 import { ICampaign, ICampaignError } from "interfaces/campaign";
 import { ITarget } from "interfaces/target";
 
@@ -24,7 +25,6 @@ import InfoBanner from "components/InfoBanner";
 import CustomLink from "components/CustomLink";
 
 import generateColumnConfigsFromRows from "./QueryResultsTableConfig";
-import { getTableColumnsFromSql } from "utilities/helpers";
 
 interface IQueryResultsProps {
   campaign: ICampaign;

--- a/frontend/pages/queries/edit/components/QueryResults/QueryResults.tsx
+++ b/frontend/pages/queries/edit/components/QueryResults/QueryResults.tsx
@@ -5,16 +5,13 @@ import classnames from "classnames";
 import FileSaver from "file-saver";
 import { QueryContext } from "context/query";
 import { useDebouncedCallback } from "use-debounce";
-import { find } from "lodash";
 
 import {
   generateCSVFilename,
   generateCSVQueryResults,
 } from "utilities/generate_csv";
-import { osqueryTables } from "utilities/osquery_tables";
 import { ICampaign, ICampaignError } from "interfaces/campaign";
 import { ITarget } from "interfaces/target";
-import { IQueryTableColumn } from "interfaces/osquery_table";
 
 import Button from "components/buttons/Button";
 import Icon from "components/Icon/Icon";
@@ -25,9 +22,9 @@ import QueryResultsHeading from "components/queries/queryResults/QueryResultsHea
 import AwaitingResults from "components/queries/queryResults/AwaitingResults";
 import InfoBanner from "components/InfoBanner";
 import CustomLink from "components/CustomLink";
-import { checkTable } from "utilities/sql_tools";
 
 import generateColumnConfigsFromRows from "./QueryResultsTableConfig";
+import { getTableColumnsFromSql } from "utilities/helpers";
 
 interface IQueryResultsProps {
   campaign: ICampaign;
@@ -77,9 +74,6 @@ const QueryResults = ({
   const [queryResultsForTableRender, setQueryResultsForTableRender] = useState(
     queryResults
   );
-  const [osqueryTableColumns, setOsqueryTableColumns] = useState<
-    IQueryTableColumn[] | []
-  >([]);
 
   // immediately reset results
   const onRunAgain = useCallback(() => {
@@ -98,32 +92,20 @@ const QueryResults = ({
     debounceQueryResults(queryResults);
   }, [queryResults, debounceQueryResults]);
 
-  // Set table/s columns from SQL
-  useEffect(() => {
-    const tableNames =
-      (lastEditedQueryBody && checkTable(lastEditedQueryBody).tables) || [];
-
-    let columns: IQueryTableColumn[] | [] = [];
-    tableNames.forEach((tableName: string) => {
-      const tableColumns =
-        find(osqueryTables, { name: tableName })?.columns || [];
-      columns = [...columns, ...tableColumns];
-    });
-    setOsqueryTableColumns(columns);
-  }, [lastEditedQueryBody]);
-
   useEffect(() => {
     if (queryResults && queryResults.length > 0) {
+      const tableColumns = getTableColumnsFromSql(lastEditedQueryBody);
+
       const newResultsColumnConfigs = generateColumnConfigsFromRows(
         queryResults,
-        osqueryTableColumns
+        tableColumns
       );
       // Update tableHeaders if new headers are found
       if (newResultsColumnConfigs !== resultsColumnConfigs) {
         setResultsColumnConfigs(newResultsColumnConfigs);
       }
     }
-  }, [queryResults]); // Cannot use tableHeaders as it will cause infinite loop with setTableHeaders
+  }, [queryResults, lastEditedQueryBody]); // Cannot use tableHeaders as it will cause infinite loop with setTableHeaders
 
   useEffect(() => {
     if (errorColumnConfigs?.length === 0 && !!errors?.length) {

--- a/frontend/pages/queries/edit/components/QueryResults/QueryResultsTableConfig.tsx
+++ b/frontend/pages/queries/edit/components/QueryResults/QueryResultsTableConfig.tsx
@@ -4,11 +4,11 @@
 import React from "react";
 
 import { CellProps, Column, HeaderProps } from "react-table";
-import { find } from "lodash";
 
 import DefaultColumnFilter from "components/TableContainer/DataTable/DefaultColumnFilter";
 import HeaderCell from "components/TableContainer/DataTable/HeaderCell/HeaderCell";
 import {
+  getSortTypeFromColumnType,
   getUniqueColumnNamesFromRows,
   internallyTruncateText,
 } from "utilities/helpers";
@@ -34,28 +34,11 @@ const _unshiftHostname = <T extends object>(columns: Column<T>[]) => {
   return newHeaders;
 };
 
-// Sorts numerical columns correctly while perserving case insensitive sort for text columns
-const sortType = (
-  colName: string | number | symbol,
-  osqueryTableColumns?: IQueryTableColumn[] | []
-) => {
-  if (typeof colName === "string" && !!osqueryTableColumns) {
-    const numberTypes = ["integer", "bigint", "unsigned_bigint", "double"];
-
-    const type = find(osqueryTableColumns, { name: colName })?.type;
-
-    if (type && numberTypes.includes(type)) {
-      return "alphanumeric";
-    }
-  }
-  return "caseInsensitive";
-};
-
 const generateColumnConfigsFromRows = <T extends Record<keyof T, unknown>>(
   // TODO - narrow typing down this entire chain of logic
   // typed as any[] to accomodate loose typing of websocket API
   results: T[], // {col:val, ...} for each row of query results
-  osqueryTableColumns?: IQueryTableColumn[] | []
+  tableColumns?: IQueryTableColumn[] | []
 ): Column<T>[] => {
   const uniqueColumnNames = getUniqueColumnNamesFromRows(results);
   const columnsConfigs = uniqueColumnNames.map<Column<T>>((colName) => {
@@ -76,7 +59,7 @@ const generateColumnConfigsFromRows = <T extends Record<keyof T, unknown>>(
       },
       Filter: DefaultColumnFilter,
       disableSortBy: false,
-      sortType: sortType(colName, osqueryTableColumns),
+      sortType: getSortTypeFromColumnType(colName, tableColumns),
     };
   });
   return _unshiftHostname(columnsConfigs);

--- a/frontend/utilities/helpers.tsx
+++ b/frontend/utilities/helpers.tsx
@@ -956,6 +956,7 @@ export default {
   generateRole,
   generateTeam,
   getUniqueColumnNamesFromRows,
+  getTableColumnsFromSql,
   getSortTypeFromColumnType,
   getCustomDropdownOptions,
   greyCell,

--- a/frontend/utilities/helpers.tsx
+++ b/frontend/utilities/helpers.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import {
   isEmpty,
   flatMap,
+  find,
   omit,
   pick,
   size,
@@ -25,6 +26,7 @@ import { buildQueryStringFromParams } from "utilities/url";
 import { IHost } from "interfaces/host";
 import { ILabel } from "interfaces/label";
 import { IPack } from "interfaces/pack";
+import { IQueryTableColumn } from "interfaces/osquery_table";
 import {
   IScheduledQuery,
   IPackQueryFormData,
@@ -39,6 +41,8 @@ import { UserRole } from "interfaces/user";
 
 import stringUtils from "utilities/strings";
 import sortUtils from "utilities/sort";
+import { checkTable } from "utilities/sql_tools";
+import { osqueryTables } from "utilities/osquery_tables";
 import {
   DEFAULT_EMPTY_CELL_VALUE,
   DEFAULT_GRAVATAR_LINK,
@@ -887,6 +891,39 @@ export const getUniqueColumnNamesFromRows = <
 // can allow additional dropdown value types in the future
 type DropdownOptionValue = IDropdownOption["value"];
 
+/** */
+export const getTableColumnsFromSql = (
+  sql: string
+): IQueryTableColumn[] | [] => {
+  const tableNames = (sql && checkTable(sql).tables) || [];
+
+  let sqlColumns: IQueryTableColumn[] | [] = [];
+  tableNames.forEach((tableName: string) => {
+    const tableColumns =
+      find(osqueryTables, { name: tableName })?.columns || [];
+    sqlColumns = [...sqlColumns, ...tableColumns];
+  });
+
+  return sqlColumns;
+};
+
+/** Sorts sql results numerical columns correctly while perserving case insensitive sort for text columns */
+export const getSortTypeFromColumnType = (
+  colName: string | number | symbol,
+  tableColumns?: IQueryTableColumn[] | []
+) => {
+  if (typeof colName === "string") {
+    const numberTypes = ["integer", "bigint", "unsigned_bigint", "double"];
+
+    const type = find(tableColumns, { name: colName })?.type;
+
+    if (type && numberTypes.includes(type)) {
+      return "alphanumeric";
+    }
+  }
+  return "caseInsensitive";
+};
+
 export function getCustomDropdownOptions(
   defaultOptions: IDropdownOption[],
   customValue: DropdownOptionValue,
@@ -918,6 +955,7 @@ export default {
   generateRole,
   generateTeam,
   getUniqueColumnNamesFromRows,
+  getSortTypeFromColumnType,
   getCustomDropdownOptions,
   greyCell,
   humanHostLastSeen,

--- a/frontend/utilities/helpers.tsx
+++ b/frontend/utilities/helpers.tsx
@@ -891,7 +891,7 @@ export const getUniqueColumnNamesFromRows = <
 // can allow additional dropdown value types in the future
 type DropdownOptionValue = IDropdownOption["value"];
 
-/** */
+/** Generates the column schema for a sql query */
 export const getTableColumnsFromSql = (
   sql: string
 ): IQueryTableColumn[] | [] => {
@@ -903,6 +903,7 @@ export const getTableColumnsFromSql = (
       find(osqueryTables, { name: tableName })?.columns || [];
     sqlColumns = [...sqlColumns, ...tableColumns];
   });
+  // TODO: Edge case of tables sharing column names with different typing not considered
 
   return sqlColumns;
 };


### PR DESCRIPTION
## Issue 
Continuation of #17288 

## Description
Since I found the same issue on Query Reports...
- Made Live Query Results bug solution reusable
- Use solution on Query Report bug
Now sorts numbers and strings appropriately
- Add changefile since forgot change file 

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
- [x] Manual QA for all new/changed functionality

