### PR TITLE
[released bug] Fleet UI: Fix ability to bulk delete hosts 

### DIFF
--- a/changes/17621-bulk-delete-hosts-all-teams
+++ b/changes/17621-bulk-delete-hosts-all-teams
@@ -1,0 +1,1 @@
+- Fix UI's ability to bulk delete hosts when "All teams" is selected

--- a/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
@@ -1089,8 +1089,6 @@ const ManageHostsPage = ({
   const onDeleteHostSubmit = async () => {
     setIsUpdatingHosts(true);
 
-    const teamId = isAnyTeamSelected ? currentTeamId ?? null : null;
-
     try {
       await (isAllMatchingHostsSelected
         ? hostsAPI.destroyByFilter({

--- a/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
@@ -1094,7 +1094,7 @@ const ManageHostsPage = ({
     try {
       await (isAllMatchingHostsSelected
         ? hostsAPI.destroyByFilter({
-            teamId,
+            teamId: teamIdForApi,
             query: searchQuery,
             status,
             labelId: selectedLabel?.id,

--- a/frontend/services/entities/hosts.ts
+++ b/frontend/services/entities/hosts.ts
@@ -116,7 +116,7 @@ export interface IExportHostsOptions {
 }
 
 export interface IActionByFilter {
-  teamId: number | null;
+  teamId?: number | null;
   query: string;
   status: string;
   labelId?: number;


### PR DESCRIPTION
## Issue
Cerra #17621 

## Description
- Somehow missed testing this with new backend change that blocks unrecognized filters
- Fix filters so we pass the correct teamIdForApi

## Screenrecording
https://www.loom.com/share/b9c6d04fe36b4f0fab2df12b49ca25fe?sid=66938a3a-639a-4988-98f6-eb8ed0a1fa43

## Screenshot
Sets no team filter for bulk delete for "All teams"
<img width="1389" alt="Screenshot 2024-03-27 at 4 37 16 PM" src="https://github.com/fleetdm/fleet/assets/71795832/d888ba69-cd17-4fc2-a1c3-303cfa1d7be8">


- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
- [x] Manual QA for all new/changed functionality
