### PR TITLE
[styling bug] Fleet UI: Update live query disabled warning styling

### DIFF
--- a/changes/17927-fix-styling-for-live-query-disabled-warning
+++ b/changes/17927-fix-styling-for-live-query-disabled-warning
@@ -1,0 +1,1 @@
+- UI fix: styling of live query disabled warning

--- a/frontend/pages/queries/edit/EditQueryPage.tsx
+++ b/frontend/pages/queries/edit/EditQueryPage.tsx
@@ -14,11 +14,14 @@ import {
   ICreateQueryRequestBody,
   ISchedulableQuery,
 } from "interfaces/schedulable_query";
+import { IConfig } from "interfaces/config";
 
 import QuerySidePanel from "components/side_panels/QuerySidePanel";
 import MainContent from "components/MainContent";
 import SidePanelContent from "components/SidePanelContent";
 import CustomLink from "components/CustomLink";
+import BackLink from "components/BackLink";
+import InfoBanner from "components/InfoBanner";
 
 import useTeamIdParam from "hooks/useTeamIdParam";
 
@@ -28,9 +31,7 @@ import PATHS from "router/paths";
 import debounce from "utilities/debounce";
 import deepDifference from "utilities/deep_difference";
 
-import BackLink from "components/BackLink";
-import EditQueryForm from "pages/queries/edit/components/EditQueryForm";
-import { IConfig } from "interfaces/config";
+import EditQueryForm from "./components/EditQueryForm";
 
 interface IEditQueryPageProps {
   router: InjectedRouter;
@@ -304,19 +305,15 @@ const EditQueryPage = ({
     }
 
     return (
-      <div className={`${baseClass}__warning`}>
-        <div className={`${baseClass}__message`}>
-          <p>
-            Fleet is unable to run a live query. Refresh the page or log in
-            again. If this keeps happening please{" "}
-            <CustomLink
-              url="https://github.com/fleetdm/fleet/issues/new/choose"
-              text="file an issue"
-              newTab
-            />
-          </p>
-        </div>
-      </div>
+      <InfoBanner color="yellow">
+        Fleet is unable to run a live query. Refresh the page or log in again.
+        If this keeps happening please{" "}
+        <CustomLink
+          url="https://github.com/fleetdm/fleet/issues/new/choose"
+          text="file an issue"
+          newTab
+        />
+      </InfoBanner>
     );
   };
 

--- a/frontend/pages/queries/edit/_styles.scss
+++ b/frontend/pages/queries/edit/_styles.scss
@@ -1,22 +1,6 @@
 .edit-query-page {
   @include page;
 
-  &__warning {
-    padding: $pad-medium;
-    font-size: $x-small;
-    color: $core-fleet-black;
-    background-color: #fff0b9;
-    border: 1px solid #f2c94c;
-    border-radius: $border-radius;
-    margin: 0;
-    margin-top: $pad-large;
-
-    p {
-      margin: 0;
-      line-height: 20px;
-    }
-  }
-
   .ace_content {
     min-height: 500px !important;
   }


### PR DESCRIPTION
## Issue
Cerra #17927 

## Description
- Fix the warning banner of disabled live queries to not run off the page and be the new fleet yellow color (the original color hasn't been used for years)
- Use `<InfoBanner/>` reusable component
- Other code nits: Minor organization to imports based on directory grouping

## Screenshot of before and after
<img width="1456" alt="Screenshot 2024-03-28 at 9 57 24 AM" src="https://github.com/fleetdm/fleet/assets/71795832/48d710bd-3058-48da-8cd1-2a15df8373cf">

<img width="1374" alt="Screenshot 2024-03-28 at 10 23 48 AM" src="https://github.com/fleetdm/fleet/assets/71795832/d99523a9-977e-458d-8cd4-46754240279a">


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
- [x] Manual QA for all new/changed functionality

