### PR TITLE
Website: update osquery table schema documentation to show hidden columns

### DIFF
--- a/website/scripts/build-static-content.js
+++ b/website/scripts/build-static-content.js
@@ -734,7 +734,7 @@ module.exports = {
                 let platformString = '<br> **Only available on ';// start building a string to add to the column's description
 
                 if(column.platforms.length > 3) {// FUTURE: add support for more than three platform values in columns.
-                  throw new Error('Support for more than three platforms has not been implemented yet.');
+                  throw new Error('Support for more than three platforms in columns has not been implemented yet. If this column is supported on all platforms, you can omit the platforms array entirely.');
                 }
 
                 if(column.platforms.length === 3) { // Because there are only four options for platform, we can safely assume that there will be at most 3 platforms, so we'll just handle this one of three ways

--- a/website/scripts/build-static-content.js
+++ b/website/scripts/build-static-content.js
@@ -705,51 +705,52 @@ module.exports = {
 
             // Iterate through the columns of the table, we'll add a row to the markdown table element for each column in this schema table
             for(let column of _.sortBy(table.columns, 'name')) {
-              if(!column.hidden) { // If the column is hidden, we won't add it to the final table.
-                // Create an object for this column to add to the osqueryTables config.
-                let columnInfoForQueryReports = {
-                  name: column.name
-                };
-                let columnDescriptionForTable = '';// Set the initial value of the description that will be added to the table for this column.
-                if(column.description) {
-                  columnDescriptionForTable = column.description;
-                  // Convert the markdown description for this table into HTML for tooltips on /try-fleet/explore-data/* pages
-                  columnInfoForQueryReports.description = await sails.helpers.strings.toHtml.with({mdString: column.description, addIdsToHeadings: false});
-                }
-                tableInfoForQueryReports.columns.push(columnInfoForQueryReports);
-                // Replacing pipe characters and newlines with html entities in column descriptions to keep it from breaking markdown tables.
-                columnDescriptionForTable = columnDescriptionForTable.replace(/\|/g, '&#124;').replace(/\n/gm, '&#10;');
-
-                keywordsForSyntaxHighlighting.push(column.name);
-                if(column.required) { // If a column has `"required": true`, we'll add a note to the description that will be added to the table
-                  columnDescriptionForTable += '<br> **Required in `WHERE` clause** ';
-                }
-                if(column.requires_user_context) { // If a column has `"requires_user_context": true`, we'll add a note to the description that will be added to the table
-                  columnDescriptionForTable += '<br> **Defaults to root** &nbsp;&nbsp;[Learn more](https://fleetdm.com/guides/osquery-consider-joining-against-the-users-table?utm_source=fleetdm.com&utm_content=table-'+encodeURIComponent(table.name)+')';
-                }
-                if(column.platforms) { // If a column has an array of platforms, we'll add a note to the final column description
-
-                  let platformString = '<br> **Only available on ';// start building a string to add to the column's description
-
-                  if(column.platforms.length > 3) {// FUTURE: add support for more than three platform values in columns.
-                    throw new Error('Support for more than three platforms has not been implemented yet.');
-                  }
-
-                  if(column.platforms.length === 3) { // Because there are only four options for platform, we can safely assume that there will be at most 3 platforms, so we'll just handle this one of three ways
-                    // If there are three, we'll add a string with an oxford comma. e.g., "On macOS, Windows, and Linux"
-                    platformString += `${column.platforms[0]}, ${column.platforms[1]}, and ${column.platforms[2]}`;
-                  } else if(column.platforms.length === 2) {
-                    // If there are two values in the platforms array, it will be formated as "[Platform 1] and [Platform 2]"
-                    platformString += `${column.platforms[0]} and ${column.platforms[1]}`;
-                  } else {
-                    // Otherwise, there is only one value in the platform array and we'll add that value to the column's description
-                    platformString += column.platforms[0];
-                  }
-                  platformString += '** ';
-                  columnDescriptionForTable += platformString; // Add the platform string to the column's description.
-                }
-                tableMdString += ' | '+column.name+' | '+ column.type +' | '+columnDescriptionForTable+'|\n';
+              // Create an object for this column to add to the osqueryTables config.
+              let columnInfoForQueryReports = {
+                name: column.name
+              };
+              let columnDescriptionForTable = '';// Set the initial value of the description that will be added to the table for this column.
+              if(column.description) {
+                columnDescriptionForTable = column.description;
+                // Convert the markdown description for this table into HTML for tooltips on /try-fleet/explore-data/* pages
+                columnInfoForQueryReports.description = await sails.helpers.strings.toHtml.with({mdString: column.description, addIdsToHeadings: false});
               }
+              tableInfoForQueryReports.columns.push(columnInfoForQueryReports);
+              // Replacing pipe characters and newlines with html entities in column descriptions to keep it from breaking markdown tables.
+              columnDescriptionForTable = columnDescriptionForTable.replace(/\|/g, '&#124;').replace(/\n/gm, '&#10;');
+
+              keywordsForSyntaxHighlighting.push(column.name);
+              if(column.required) { // If a column has `"required": true`, we'll add a note to the description that will be added to the table
+                columnDescriptionForTable += '<br> **Required in `WHERE` clause** ';
+              }
+              if(column.requires_user_context) { // If a column has `"requires_user_context": true`, we'll add a note to the description that will be added to the table
+                columnDescriptionForTable += '<br> **Defaults to root** &nbsp;&nbsp;[Learn more](https://fleetdm.com/guides/osquery-consider-joining-against-the-users-table?utm_source=fleetdm.com&utm_content=table-'+encodeURIComponent(table.name)+')';
+              }
+              if(column.hidden) { // If a column has `"hidden": true`, we'll add a note to the description that will be added to the table
+                columnDescriptionForTable += '<br> **Not returned in `SELECT * FROM '+table.name+'`.**';
+              }
+              if(column.platforms) { // If a column has an array of platforms, we'll add a note to the final column description
+
+                let platformString = '<br> **Only available on ';// start building a string to add to the column's description
+
+                if(column.platforms.length > 3) {// FUTURE: add support for more than three platform values in columns.
+                  throw new Error('Support for more than three platforms has not been implemented yet.');
+                }
+
+                if(column.platforms.length === 3) { // Because there are only four options for platform, we can safely assume that there will be at most 3 platforms, so we'll just handle this one of three ways
+                  // If there are three, we'll add a string with an oxford comma. e.g., "On macOS, Windows, and Linux"
+                  platformString += `${column.platforms[0]}, ${column.platforms[1]}, and ${column.platforms[2]}`;
+                } else if(column.platforms.length === 2) {
+                  // If there are two values in the platforms array, it will be formated as "[Platform 1] and [Platform 2]"
+                  platformString += `${column.platforms[0]} and ${column.platforms[1]}`;
+                } else {
+                  // Otherwise, there is only one value in the platform array and we'll add that value to the column's description
+                  platformString += column.platforms[0];
+                }
+                platformString += '** ';
+                columnDescriptionForTable += platformString; // Add the platform string to the column's description.
+              }
+              tableMdString += ' | '+column.name+' | '+ column.type +' | '+columnDescriptionForTable+'|\n';
             }
             if(table.examples) { // If this table has a examples value (These will be in the Fleet schema JSON) We'll add the examples to the markdown string.
               tableMdString += '\n### Example\n\n'+table.examples+'\n';


### PR DESCRIPTION
Related to: #17787

Changes:
- Updated build-static-content not to hide columns of tables with `hidden: true`, and instead add a note about the column not being returned in results from a `SELECT * FROM [table]` query. 

Note: These columns will still be hidden in the Fleet UI. This PR only changes the table documentation on fleetdm.com/tables