### PR TITLE
New yarn configuration: Sets installing a dependency to a specific semantic versioning instead of latest stable

### DIFF
--- a/.yarnrc
+++ b/.yarnrc
@@ -1,0 +1,1 @@
+save-prefix ""


### PR DESCRIPTION
## Issue
Bug fix during frontend sync with @ghernandez345 and @jacobshandling 

- Installing a new dependency auto populates a `^version` for the package.json file when we want to peg down the version (sans caret)
- This updates our yarn configuration to update the package json to automatically not use a `^`

e.g. Before `yarn add is-url` and `yarn add is-url-http` would add: 
```
   "is-url": "^1.2.4",
    "is-url-http": "^2.3.8",
```
Now it will automatically be added as:
```
   "is-url": "1.2.4",
    "is-url-http": "2.3.8",
```

## Video for more detail
https://www.loom.com/share/5306d1ff039c4fd0b66c702ec3c4448f?sid=09a64068-e495-45d8-b5da-c6c956cfd42f

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Manual QA for all new/changed functionality

