### PR TITLE
UI – restore arrow and full opacity to left-positioned dropdown tooltip

### DIFF
--- a/frontend/pages/policies/ManagePoliciesPage/ManagePoliciesPage.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/ManagePoliciesPage.tsx
@@ -788,7 +788,9 @@ const ManagePolicyPage = ({
             place="left"
             positionStrategy="fixed"
             offset={24}
+            opacity={1}
             disableStyleInjection
+            classNameArrow="tooltip-arrow"
           >
             Available in Fleet Premium
           </ReactTooltip5>
@@ -806,7 +808,9 @@ const ManagePolicyPage = ({
             place="left"
             positionStrategy="fixed"
             offset={24}
+            opacity={1}
             disableStyleInjection
+            classNameArrow="tooltip-arrow"
           >
             Select a team to manage
             <br />

--- a/frontend/pages/policies/ManagePoliciesPage/_styles.scss
+++ b/frontend/pages/policies/ManagePoliciesPage/_styles.scss
@@ -42,6 +42,15 @@
           font-style: normal;
           text-align: center;
         }
+
+        // arrow styles directly from react-tooltip-5 css
+        .tooltip-arrow {
+          width: 8px;
+          height: 8px;
+        }
+        [class*="react-tooltip__place-left"] > .tooltip-arrow {
+          transform: rotate(315deg);
+        }
       }
     }
     .Select-control {


### PR DESCRIPTION
## Addresses #17949 
<img width="705" alt="Screenshot 2024-03-28 at 5 18 35 PM" src="https://github.com/fleetdm/fleet/assets/61553566/9e33c768-8687-4201-8961-b2f8839a2b71">


- [x] Manual QA for all new/changed functionality