### PR TITLE
Fleet UI: Fix several flows where team ID is not being preserved

### DIFF
--- a/changes/17194-fix-edge-cases-team-id-lost
+++ b/changes/17194-fix-edge-cases-team-id-lost
@@ -1,0 +1,1 @@
+Fleet UI: Fix edge cases of team ID being lost in various flows

--- a/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
@@ -137,6 +137,9 @@ const ManageHostsPage = ({
     isFreeTier,
     isSandboxMode,
     setFilteredHostsPath,
+    setFilteredPoliciesPath,
+    setFilteredQueriesPath,
+    setFilteredSoftwarePath,
   } = useContext(AppContext);
   const { renderFlash } = useContext(NotificationContext);
 
@@ -886,6 +889,11 @@ const ManageHostsPage = ({
       // tableQueryData)
       handleTeamChange(teamId);
       handleResetPageIndex();
+      // Must clear other page paths or the team might accidentally switch
+      // When navigating from host details
+      setFilteredSoftwarePath("");
+      setFilteredQueriesPath("");
+      setFilteredPoliciesPath("");
     },
     [handleTeamChange]
   );

--- a/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
@@ -577,7 +577,7 @@ const HostDetailsPage = ({
     setSelectedQueryTargetsByType(DEFAULT_TARGETS_BY_TYPE);
     router.push(
       PATHS.EDIT_QUERY(selectedQuery.id) +
-        TAGGED_TEMPLATES.queryByHostRoute(host?.id)
+        TAGGED_TEMPLATES.queryByHostRoute(host?.id, currentTeam?.id)
     );
   };
 

--- a/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
@@ -147,6 +147,7 @@ const HostDetailsPage = ({
     isSandboxMode,
     isOnlyObserver,
     filteredHostsPath,
+    currentTeam,
   } = useContext(AppContext);
   const { setSelectedQueryTargetsByType } = useContext(QueryContext);
   const { renderFlash } = useContext(NotificationContext);
@@ -567,7 +568,8 @@ const HostDetailsPage = ({
   const onQueryHostCustom = () => {
     setSelectedQueryTargetsByType(DEFAULT_TARGETS_BY_TYPE);
     router.push(
-      PATHS.NEW_QUERY() + TAGGED_TEMPLATES.queryByHostRoute(host?.id)
+      PATHS.NEW_QUERY() +
+        TAGGED_TEMPLATES.queryByHostRoute(host?.id, currentTeam?.id)
     );
   };
 

--- a/frontend/pages/queries/details/QueryDetailsPage/QueryDetailsPage.tsx
+++ b/frontend/pages/queries/details/QueryDetailsPage/QueryDetailsPage.tsx
@@ -22,6 +22,8 @@ import {
   isTeamObserver,
 } from "utilities/permissions/permissions";
 import { DOCUMENT_TITLE_SUFFIX } from "utilities/constants";
+import { buildQueryStringFromParams } from "utilities/url";
+import useTeamIdParam from "hooks/useTeamIdParam";
 
 import Spinner from "components/Spinner/Spinner";
 import Button from "components/buttons/Button";
@@ -65,9 +67,13 @@ const QueryDetailsPage = ({
     router.push(PATHS.MANAGE_QUERIES);
   }
   const queryParams = location.query;
-  const teamId = location.query.team_id
-    ? parseInt(location.query.team_id, 10)
-    : undefined;
+
+  const { currentTeamId } = useTeamIdParam({
+    location,
+    router,
+    includeAllTeams: true,
+    includeNoTeam: false,
+  });
 
   // Functions to avoid race conditions
   const serverSortBy: ISortOption[] = (() => {
@@ -203,7 +209,12 @@ const QueryDetailsPage = ({
 
     // Function instead of constant eliminates race condition with filteredQueriesPath
     const backToQueriesPath = () => {
-      return filteredQueriesPath || PATHS.MANAGE_QUERIES;
+      return (
+        filteredQueriesPath ||
+        `${PATHS.MANAGE_QUERIES}?${buildQueryStringFromParams({
+          team_id: currentTeamId,
+        })}`
+      );
     };
 
     return (
@@ -233,7 +244,8 @@ const QueryDetailsPage = ({
                 {canEditQuery && (
                   <Button
                     onClick={() => {
-                      queryId && router.push(PATHS.EDIT_QUERY(queryId, teamId));
+                      queryId &&
+                        router.push(PATHS.EDIT_QUERY(queryId, currentTeamId));
                     }}
                     className={`${baseClass}__manage-automations button`}
                     variant="brand"
@@ -332,7 +344,7 @@ const QueryDetailsPage = ({
           // Exclude below message for global and team observers/observer+s
           !(
             (currentUser && isGlobalObserver(currentUser)) ||
-            isTeamObserver(currentUser, teamId ?? null)
+            isTeamObserver(currentUser, currentTeamId ?? null)
           ) &&
             " You can still use query automations to complete this report in your log destination."
         }

--- a/frontend/pages/queries/edit/EditQueryPage.tsx
+++ b/frontend/pages/queries/edit/EditQueryPage.tsx
@@ -329,7 +329,9 @@ const EditQueryPage = ({
         team_id: currentTeamId,
       })}`;
 
-    return queryId ? PATHS.QUERY_DETAILS(queryId) : manageQueryPage;
+    return queryId
+      ? PATHS.QUERY_DETAILS(queryId, currentTeamId)
+      : manageQueryPage;
   };
 
   const showSidebar =

--- a/frontend/pages/queries/edit/EditQueryPage.tsx
+++ b/frontend/pages/queries/edit/EditQueryPage.tsx
@@ -30,6 +30,7 @@ import { NotificationContext } from "context/notification";
 import PATHS from "router/paths";
 import debounce from "utilities/debounce";
 import deepDifference from "utilities/deep_difference";
+import { buildQueryStringFromParams } from "utilities/url";
 
 import EditQueryForm from "./components/EditQueryForm";
 
@@ -38,7 +39,7 @@ interface IEditQueryPageProps {
   params: Params;
   location: {
     pathname: string;
-    query: { host_ids: string; team_id?: string };
+    query: { host_id: string; team_id?: string };
     search: string;
   };
 }
@@ -51,9 +52,11 @@ const EditQueryPage = ({
   location,
 }: IEditQueryPageProps): JSX.Element => {
   const queryId = paramsQueryId ? parseInt(paramsQueryId, 10) : null;
+
   const {
     currentTeamName: teamNameForQuery,
     teamIdForApi: apiTeamIdForQuery,
+    currentTeamId,
   } = useTeamIdParam({
     location,
     router,
@@ -70,6 +73,7 @@ const EditQueryPage = ({
     isObserverPlus,
     isAnyTeamObserverPlus,
     config,
+    filteredQueriesPath,
   } = useContext(AppContext);
   const {
     editingExistingQuery,
@@ -319,7 +323,13 @@ const EditQueryPage = ({
 
   // Function instead of constant eliminates race condition
   const backToQueriesPath = () => {
-    return queryId ? PATHS.QUERY_DETAILS(queryId) : PATHS.MANAGE_QUERIES;
+    const manageQueryPage =
+      filteredQueriesPath ||
+      `${PATHS.MANAGE_QUERIES}?${buildQueryStringFromParams({
+        team_id: currentTeamId,
+      })}`;
+
+    return queryId ? PATHS.QUERY_DETAILS(queryId) : manageQueryPage;
   };
 
   const showSidebar =
@@ -348,6 +358,7 @@ const EditQueryPage = ({
             storedQuery={storedQuery}
             queryIdForEdit={queryId}
             apiTeamIdForQuery={apiTeamIdForQuery}
+            currentTeamId={currentTeamId}
             teamNameForQuery={teamNameForQuery}
             isStoredQueryLoading={isStoredQueryLoading}
             showOpenSchemaActionText={showOpenSchemaActionText}
@@ -356,7 +367,7 @@ const EditQueryPage = ({
             backendValidators={backendValidators}
             isQuerySaving={isQuerySaving}
             isQueryUpdating={isQueryUpdating}
-            hostId={parseInt(location.query.host_ids as string, 10)}
+            hostId={parseInt(location.query.host_id as string, 10)}
             queryReportsDisabled={
               appConfig?.server_settings.query_reports_disabled
             }

--- a/frontend/pages/queries/edit/components/EditQueryForm/EditQueryForm.tsx
+++ b/frontend/pages/queries/edit/components/EditQueryForm/EditQueryForm.tsx
@@ -63,6 +63,7 @@ interface IEditQueryFormProps {
   router: InjectedRouter;
   queryIdForEdit: number | null;
   apiTeamIdForQuery?: number;
+  currentTeamId?: number;
   teamNameForQuery?: string;
   showOpenSchemaActionText: boolean;
   storedQuery: ISchedulableQuery | undefined;
@@ -97,6 +98,7 @@ const EditQueryForm = ({
   router,
   queryIdForEdit,
   apiTeamIdForQuery,
+  currentTeamId,
   teamNameForQuery,
   showOpenSchemaActionText,
   storedQuery,
@@ -601,7 +603,7 @@ const EditQueryForm = ({
               onClick={() => {
                 router.push(
                   PATHS.LIVE_QUERY(queryIdForEdit) +
-                    TAGGED_TEMPLATES.queryByHostRoute(hostId)
+                    TAGGED_TEMPLATES.queryByHostRoute(hostId, apiTeamIdForQuery)
                 );
               }}
               disabled={disabledLiveQuery}
@@ -680,7 +682,6 @@ const EditQueryForm = ({
     const disableSaveFormErrors =
       (lastEditedQueryName === "" && !!lastEditedQueryId) || !!size(errors);
 
-    console.log("lastEditedQueryPlatforms", lastEditedQueryPlatforms);
     return (
       <>
         <form className={`${baseClass}`} autoComplete="off">
@@ -846,7 +847,7 @@ const EditQueryForm = ({
                   setEditingExistingQuery(true); // Persists edited query data through live query flow
                   router.push(
                     PATHS.LIVE_QUERY(queryIdForEdit) +
-                      TAGGED_TEMPLATES.queryByHostRoute(hostId)
+                      TAGGED_TEMPLATES.queryByHostRoute(hostId, currentTeamId)
                   );
                 }}
                 disabled={disabledLiveQuery}

--- a/frontend/pages/queries/live/LiveQueryPage/LiveQueryPage.tsx
+++ b/frontend/pages/queries/live/LiveQueryPage/LiveQueryPage.tsx
@@ -27,7 +27,7 @@ interface IRunQueryPageProps {
   params: Params;
   location: {
     pathname: string;
-    query: { host_ids: string; team_id?: string };
+    query: { host_id: string; team_id?: string };
     search: string;
   };
 }
@@ -109,9 +109,9 @@ const RunQueryPage = ({
   useQuery<IHostResponse, Error, IHost>(
     "hostFromURL",
     () =>
-      hostAPI.loadHostDetails(parseInt(location.query.host_ids as string, 10)),
+      hostAPI.loadHostDetails(parseInt(location.query.host_id as string, 10)),
     {
-      enabled: !!location.query.host_ids && !queryParamHostsAdded,
+      enabled: !!location.query.host_id && !queryParamHostsAdded,
       select: (data: IHostResponse) => data.host,
       onSuccess: (host) => {
         setTargetedHosts((prevHosts) =>

--- a/frontend/utilities/helpers.tsx
+++ b/frontend/utilities/helpers.tsx
@@ -853,8 +853,13 @@ export const getSoftwareBundleTooltipJSX = (bundle: string) => (
 );
 
 export const TAGGED_TEMPLATES = {
-  queryByHostRoute: (hostId: number | undefined | null) => {
-    return `${hostId ? `?host_ids=${hostId}` : ""}`;
+  queryByHostRoute: (hostId?: number | null, teamId?: number | null) => {
+    const queryString = buildQueryStringFromParams({
+      host_id: hostId || undefined,
+      team_id: teamId,
+    });
+
+    return queryString && `?${queryString}`;
   },
 };
 


### PR DESCRIPTION
## Issue
#17194 

## Description
Fixes:
- Switching to a team, going to run a live query, go back to any page, FIX still preserves team (bug was returning to all teams)
- Go to a online host from looking at a specific team, click run query on that host, click back to queries, FIX still preserves team (bug was returning to all teams)
- Switching to a team, going to run a live query of an existing query, click Hosts, change team, click on a host, click query, click on an existing query, click Back to queries, FIX still preserves team (bug was returning to previous team seen on queries page even though we changed the team when we went back to Hosts page)

## Screenrecording
https://www.loom.com/share/718258db0cc3421d8f99dbc70c957d58?sid=5f96ee54-9481-4346-8668-abd74ecbda73

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
- [x] Manual QA for all new/changed functionality

