### PR TITLE
OS updates w/ DDM coming soon!

### DIFF
--- a/server/fleet/apple_mdm.go
+++ b/server/fleet/apple_mdm.go
@@ -597,7 +597,7 @@ func (r *MDMAppleRawDeclaration) ValidateUserProvided() error {
 
 	// Check against types we don't allow
 	if r.Type == `com.apple.configuration.softwareupdate.enforcement.specific` {
-		return NewInvalidArgumentError(r.Type, "Declaration profile can’t include OS updates settings. To control these settings, go to OS updates.")
+		return NewInvalidArgumentError(r.Type, "Declaration profile can’t include OS updates settings. OS updates coming soon!")
 	}
 
 	if _, forbidden := ForbiddenDeclTypes[r.Type]; forbidden {

--- a/server/service/integration_ddm_test.go
+++ b/server/service/integration_ddm_test.go
@@ -62,7 +62,7 @@ func (s *integrationMDMTestSuite) TestAppleDDMBatchUpload() {
 	}}, http.StatusUnprocessableEntity)
 
 	errMsg = extractServerErrorText(res.Body)
-	require.Contains(t, errMsg, "Declaration profile can’t include OS updates settings. To control these settings, go to OS updates.")
+	require.Contains(t, errMsg, "Declaration profile can’t include OS updates settings. OS updates coming soon!")
 
 	// Types from our list of forbidden types should fail
 	for ft := range fleet.ForbiddenDeclTypes {

--- a/server/service/integration_mdm_test.go
+++ b/server/service/integration_mdm_test.go
@@ -10919,7 +10919,7 @@ func (s *integrationMDMTestSuite) TestBatchSetMDMProfiles() {
 		{Name: "N4", Contents: declarationForTestWithType("D1", "com.apple.configuration.softwareupdate.enforcement.specific")},
 	}}, http.StatusUnprocessableEntity, "team_id", strconv.Itoa(int(tm.ID)))
 	errMsg := extractServerErrorText(res.Body)
-	require.Contains(t, errMsg, "Declaration profile can’t include OS updates settings. To control these settings, go to OS updates.")
+	require.Contains(t, errMsg, "Declaration profile can’t include OS updates settings. OS updates coming soon!")
 
 	// invalid JSON
 	res = s.Do("POST", "/api/v1/fleet/mdm/profiles/batch", batchSetMDMProfilesRequest{Profiles: []fleet.MDMProfileBatchPayload{


### PR DESCRIPTION
- In Fleet 4.48, we'll ship declaration (DDM) profiles (#14550)
- OS updates w/ DDM (#17230) will ship in 4.49
- Update error message so users know OS updates w/ DDM are coming soon. Figma is also updated [here](https://www.figma.com/file/t3j8CGAHR1x1YGjuFLlMst/%2314550-Add-declaration-(DDM)-profiles-for-macOS?type=design&node-id=476%3A11294&mode=design&t=aMjkgv7PGEbePjmH-1).
- In the [Figma wireframes here](https://www.figma.com/file/JDbJcLRGRs7c7gKDxAfios/%2317295-Use-new-Software-Update-(DDM)-for-macOS-Sonoma-(14)-and-higher?type=design&node-id=348%3A892&mode=design&t=kkpRKOYrvJxfFbM5-1) for (#17295) add designs for new error message copy so we make the change when we ship OS updates w/ DDM.
