### PR TITLE
Update macos-install-wine.sh with codesign warning

### DIFF
--- a/.github/workflows/test-packaging.yml
+++ b/.github/workflows/test-packaging.yml
@@ -85,7 +85,7 @@ jobs:
     - name: Install wine and wix
       if: matrix.os == 'macos-latest'
       run: |
-        ./scripts/macos-install-wine.sh
+        ./scripts/macos-install-wine.sh -n
         wget https://github.com/wixtoolset/wix3/releases/download/wix3112rtm/wix311-binaries.zip -nv -O wix.zip
         mkdir wix
         unzip wix.zip -d wix

--- a/docs/Using Fleet/enroll-hosts.md
+++ b/docs/Using Fleet/enroll-hosts.md
@@ -340,7 +340,7 @@ so:
      ```
      If the provided path doesn't contain all 3 binaries, the command will fail.
 
->**Note:** Creating a fleetd agent for Windows (.msi) on macOS also requires Wine. To install Wine see the script [here](https://github.com/fleetdm/fleet/blob/fleet-v4.44.0/scripts/macos-install-wine.sh).
+>**Note:** Creating a fleetd agent for Windows (.msi) on macOS also requires Wine. To install Wine see the script [here](https://fleetdm.com/install-wine).
 
 ### Experimental features
 

--- a/scripts/macos-install-wine.sh
+++ b/scripts/macos-install-wine.sh
@@ -4,30 +4,56 @@
 set -eo pipefail
 
 
-# Run this script in user context (not root)
-if [ "$EUID" = 0 ]
-then
-	printf "To prevent unnecessary privilege elevation do not execute this script as the root user.\nExiting..."; exit 1
-fi
+brew_wine(){
+# Wine reference: https://wiki.winehq.org/MacOS
+# Wine can be installed without brew via a distribution such as https://github.com/Gcenx/macOS_Wine_builds/releases/tag/9.0 or by building from source.
+brew install --cask --no-quarantine https://raw.githubusercontent.com/Homebrew/homebrew-cask/1ecfe82f84e0f3c3c6b741d3ddc19a164c2cb18d/Casks/w/wine-stable.rb; exit 0
+}
 
 
-# Check if brew is installed
-if ! command -v brew >/dev/null 2>&1
-then
-    printf "Homebrew is not installed.\nPlease install Homebrew.\nFor instructions, see https://brew.sh/"; exit 1
-fi
-
-
-# Reference: https://wiki.winehq.org/MacOS
-# Wine can be installed without brew via a distribution such as https://github.com/Gcenx/macOS_Wine_builds/releases/tag/9.0, or by building from source.
-# Install wine via brew with warning
+warn_wine(){
 printf "\nWARNING: The Wine app developer has an Apple Developer certificate but the\napp bundle post-installation will not be code-signed or notarized.\n\nDo you wish to proceed?\n\n"
 while true
 do
     read -r -p "install> " install
     case "$install" in
-        y|yes|Y|YES ) brew install --cask --no-quarantine https://raw.githubusercontent.com/Homebrew/homebrew-cask/1ecfe82f84e0f3c3c6b741d3ddc19a164c2cb18d/Casks/w/wine-stable.rb ;;
-          n|no|N|NO ) printf "\nExiting...\n\n"; exit 1 ;;
-                  * ) printf "\nPlease enter yes or no at the prompt...\n\n" ;;
+        y|yes|Y|YES) brew_wine ;;
+          n|no|N|NO) printf "\nExiting...\n\n"; exit 1 ;;
+                  *) printf "\nPlease enter yes or no at the prompt...\n\n" ;;
     esac
 done
+}
+
+
+# option to execute script in non-interactive mode
+while getopts 'n' option
+do
+    case "$option" in
+        n) mode=auto ;;
+        *) : ;;
+    esac
+done
+
+
+# prevent root execution
+if [ "$EUID" = 0 ]
+then
+    printf "\nTo prevent unnecessary privilege elevation do not execute this script as the root user.\nExiting...\n\n"; exit 1
+fi
+
+
+# check if Homebrew is installed
+if ! command -v brew > /dev/null 2>&1
+then
+    printf "\nHomebrew is not installed.\nPlease install Homebrew.\nFor instructions, see https://brew.sh/\n\n"; exit 1
+fi
+
+
+# install Wine
+if [ "$mode" = 'auto' ]
+then
+    printf "\n%s executed in non-interactive mode.\n\n" "$0"; brew_wine
+else
+    warn_wine
+fi
+

--- a/scripts/macos-install-wine.sh
+++ b/scripts/macos-install-wine.sh
@@ -1,16 +1,33 @@
 #!/usr/bin/env bash
 
+
 set -eo pipefail
 
-# Run this script in user context (not root).
-# Reference: https://wiki.winehq.org/MacOS
-# Wine can be installed without brew via a distribution such as https://github.com/Gcenx/macOS_Wine_builds/releases/tag/9.0, or by building from source.
 
-# Check if brew is installed
-if ! command -v brew >/dev/null 2>&1 ; then
-    echo "Homebrew is not installed. Please install Homebrew first. For instructions, see https://brew.sh/"
-    exit 1
+# Run this script in user context (not root)
+if [ "$EUID" = 0 ]
+then
+	printf "To prevent unnecessary privilege elevation do not execute this script as the root user.\nExiting..."; exit 1
 fi
 
-# Install wine via brew
-brew install --cask --no-quarantine https://raw.githubusercontent.com/Homebrew/homebrew-cask/1ecfe82f84e0f3c3c6b741d3ddc19a164c2cb18d/Casks/w/wine-stable.rb
+
+# Check if brew is installed
+if ! command -v brew >/dev/null 2>&1
+then
+    printf "Homebrew is not installed.\nPlease install Homebrew.\nFor instructions, see https://brew.sh/"; exit 1
+fi
+
+
+# Reference: https://wiki.winehq.org/MacOS
+# Wine can be installed without brew via a distribution such as https://github.com/Gcenx/macOS_Wine_builds/releases/tag/9.0, or by building from source.
+# Install wine via brew with warning
+printf "\nWARNING: The Wine app developer has an Apple Developer certificate but the\napp bundle post-installation will not be code-signed or notarized.\n\nDo you wish to proceed?\n\n"
+while true
+do
+    read -r -p "install> " install
+    case "$install" in
+        y|yes|Y|YES ) brew install --cask --no-quarantine https://raw.githubusercontent.com/Homebrew/homebrew-cask/1ecfe82f84e0f3c3c6b741d3ddc19a164c2cb18d/Casks/w/wine-stable.rb ;;
+          n|no|N|NO ) printf "\nExiting...\n\n"; exit 1 ;;
+                  * ) printf "\nPlease enter yes or no at the prompt...\n\n" ;;
+    esac
+done


### PR DESCRIPTION
The Wine developer does have an Apple Develeoper certificate but the "Wine Stable" app bundle is not code-signed or notarized post-install & disables Gatekeeper for the install. This adds a warning to the script user about the app not being signed. post-install