### PR TITLE
Enabling calendar clean up job to delete Google calendar events in parallel.

### DIFF
--- a/cmd/fleet/calendar_cron.go
+++ b/cmd/fleet/calendar_cron.go
@@ -17,6 +17,8 @@ import (
 	"github.com/go-kit/log/level"
 )
 
+const calendarConsumers = 18
+
 func newCalendarSchedule(
 	ctx context.Context,
 	instanceID string,
@@ -200,11 +202,10 @@ func processCalendarFailingHosts(
 ) {
 	hosts = filterHostsWithSameEmail(hosts)
 
-	const consumers = 20
 	hostsCh := make(chan fleet.HostPolicyMembershipData)
 	var wg sync.WaitGroup
 
-	for i := 0; i < consumers; i++ {
+	for i := 0; i < calendarConsumers; i++ {
 		wg.Add(+1)
 		go func() {
 			defer wg.Done()
@@ -500,11 +501,10 @@ func removeCalendarEventsFromPassingHosts(
 		})
 	}
 
-	const consumers = 20
 	emailsCh := make(chan emailWithHosts)
 	var wg sync.WaitGroup
 
-	for i := 0; i < consumers; i++ {
+	for i := 0; i < calendarConsumers; i++ {
 		wg.Add(+1)
 		go func() {
 			defer wg.Done()
@@ -669,10 +669,9 @@ func deleteCalendarEventsInParallel(
 	logger kitlog.Logger,
 ) {
 	if len(calendarEvents) > 0 {
-		const consumers = 20
 		calendarEventCh := make(chan *fleet.CalendarEvent)
 		var wg sync.WaitGroup
-		for i := 0; i < consumers; i++ {
+		for i := 0; i < calendarConsumers; i++ {
 			wg.Add(+1)
 			go func() {
 				defer wg.Done()


### PR DESCRIPTION
#17230 

This fix addresses the unreleased bug where calendar cleanup job can take too long, causing the subsequent job to miss a calendar event. The event deletions now occur in parallel.

Also, reducing max bandwidth for accessing Google calendar by 10% to prevent potential rate-limiting corner cases.

# Checklist for submitter

- [ ] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [ ] Added/updated tests
- [x] Manual QA for all new/changed functionality
