### PR TITLE
Fleet UI: Add advanced setting to set expiry window for activity log

### DIFF
--- a/changes/16989-ui-to-delete-old-activities
+++ b/changes/16989-ui-to-delete-old-activities
@@ -1,0 +1,1 @@
+- Add advanced setting to set expiry window for activity log

--- a/frontend/__mocks__/configMock.ts
+++ b/frontend/__mocks__/configMock.ts
@@ -46,6 +46,10 @@ const DEFAULT_CONFIG_MOCK: IConfig = {
     host_expiry_enabled: false,
     host_expiry_window: 0,
   },
+  activity_expiry_settings: {
+    activity_expiry_enabled: true,
+    activity_expiry_window: 90,
+  },
   agent_options: "",
   license: {
     tier: "free",

--- a/frontend/interfaces/config.ts
+++ b/frontend/interfaces/config.ts
@@ -65,48 +65,6 @@ export interface IFleetDesktopSettings {
   transparency_url: string;
 }
 
-export interface IConfigFormData {
-  smtpAuthenticationMethod: string;
-  smtpAuthenticationType: string;
-  domain: string;
-  smtpEnableSSLTLS: boolean;
-  enableStartTLS?: boolean;
-  serverURL: string;
-  orgLogoURL: string;
-  orgName: string;
-  orgLogoURLLightBackground: string;
-  orgSupportURL: string;
-  smtpPassword: string;
-  smtpPort?: number;
-  smtpSenderAddress: string;
-  smtpServer: string;
-  smtpUsername: string;
-  verifySSLCerts: boolean;
-  entityId: string;
-  idpImageUrl: string;
-  metadata: string;
-  metadataUrl: string;
-  idpName: string;
-  enableSso: boolean;
-  enableSsoIdpLogin: boolean;
-  enableSMTP: boolean;
-  enableHostExpiry: boolean;
-  hostExpiryWindow: number;
-  deleteActivities: boolean;
-  activityExpiryWindow: number;
-  disableLiveQuery: boolean;
-  agentOptions?: any;
-  enableHostStatusWebhook: boolean;
-  destination_url?: string;
-  hostStatusWebhookHostPercentage: number;
-  hostStatusWebhookWindow: number;
-  enableUsageStatistics: boolean;
-  transparencyUrl: string;
-  disableScripts: boolean;
-  disableQueryReports: boolean;
-  enableJitProvisioning: boolean;
-}
-
 export interface IConfigFeatures {
   enable_host_users: boolean;
   enable_software_inventory: boolean;

--- a/frontend/interfaces/config.ts
+++ b/frontend/interfaces/config.ts
@@ -90,6 +90,8 @@ export interface IConfigFormData {
   enableSmtp: boolean;
   enableHostExpiry: boolean;
   hostExpiryWindow: number;
+  deleteActivities: boolean;
+  activityExpiryWindow: boolean;
   disableLiveQuery: boolean;
   agentOptions: any;
   enableHostStatusWebhook: boolean;
@@ -153,6 +155,10 @@ export interface IConfig {
   host_expiry_settings: {
     host_expiry_enabled: boolean;
     host_expiry_window: number;
+  };
+  activity_expiry_settings: {
+    activity_expiry_enabled: boolean;
+    activity_expiry_window: number;
   };
   features: IConfigFeatures;
   agent_options: string;

--- a/frontend/interfaces/config.ts
+++ b/frontend/interfaces/config.ts
@@ -69,17 +69,19 @@ export interface IConfigFormData {
   smtpAuthenticationMethod: string;
   smtpAuthenticationType: string;
   domain: string;
-  smtpEnableSslTls: boolean;
-  enableStartTls: boolean;
-  serverUrl: string;
-  orgLogoUrl: string;
+  smtpEnableSSLTLS: boolean;
+  enableStartTLS?: boolean;
+  serverURL: string;
+  orgLogoURL: string;
   orgName: string;
+  orgLogoURLLightBackground: string;
+  orgSupportURL: string;
   smtpPassword: string;
   smtpPort?: number;
   smtpSenderAddress: string;
   smtpServer: string;
   smtpUsername: string;
-  verifySslCerts: boolean;
+  verifySSLCerts: boolean;
   entityId: string;
   idpImageUrl: string;
   metadata: string;
@@ -87,19 +89,22 @@ export interface IConfigFormData {
   idpName: string;
   enableSso: boolean;
   enableSsoIdpLogin: boolean;
-  enableSmtp: boolean;
+  enableSMTP: boolean;
   enableHostExpiry: boolean;
   hostExpiryWindow: number;
   deleteActivities: boolean;
-  activityExpiryWindow: boolean;
+  activityExpiryWindow: number;
   disableLiveQuery: boolean;
-  agentOptions: any;
+  agentOptions?: any;
   enableHostStatusWebhook: boolean;
-  hostStatusWebhookDestinationUrl?: string;
-  hostStatusWebhookHostPercentage?: number;
-  hostStatusWebhookDaysCount?: number;
+  destination_url?: string;
+  hostStatusWebhookHostPercentage: number;
+  hostStatusWebhookWindow: number;
   enableUsageStatistics: boolean;
   transparencyUrl: string;
+  disableScripts: boolean;
+  disableQueryReports: boolean;
+  enableJitProvisioning: boolean;
 }
 
 export interface IConfigFeatures {

--- a/frontend/interfaces/config.ts
+++ b/frontend/interfaces/config.ts
@@ -90,7 +90,7 @@ export interface IConfig {
   server_settings: IConfigServerSettings;
   smtp_settings?: {
     enable_smtp: boolean;
-    configured: boolean;
+    configured?: boolean;
     sender_address: string;
     server: string;
     port?: number;
@@ -117,14 +117,14 @@ export interface IConfig {
   };
   host_expiry_settings: {
     host_expiry_enabled: boolean;
-    host_expiry_window: number;
+    host_expiry_window?: number;
   };
   activity_expiry_settings: {
     activity_expiry_enabled: boolean;
-    activity_expiry_window: number;
+    activity_expiry_window?: number;
   };
   features: IConfigFeatures;
-  agent_options: string;
+  agent_options: unknown; // Can pass empty object
   update_interval: {
     osquery_detail: number;
     osquery_policy: number;

--- a/frontend/pages/admin/OrgSettingsPage/cards/Advanced/Advanced.tsx
+++ b/frontend/pages/admin/OrgSettingsPage/cards/Advanced/Advanced.tsx
@@ -1,7 +1,5 @@
 import React, { useState, useEffect, useCallback, useMemo } from "react";
 
-import { IConfigFormData } from "interfaces/config";
-
 import Button from "components/buttons/Button";
 import Checkbox from "components/forms/fields/Checkbox";
 // @ts-ignore
@@ -13,32 +11,26 @@ import Dropdown from "components/forms/fields/Dropdown";
 import { ACTIVITY_EXPIRY_WINDOW_DROPDOWN_OPTIONS } from "utilities/constants";
 import { getCustomDropdownOptions } from "utilities/helpers";
 
-import {
-  IAppConfigFormProps,
-  IFormField,
-  IAppConfigFormErrors,
-} from "../constants";
+import { IAppConfigFormProps, IFormField } from "../constants";
 
 const baseClass = "app-config-form";
 
-type IAdvancedConfigFormData = Pick<
-  IConfigFormData,
-  | "domain"
-  | "verifySSLCerts"
-  | "enableStartTLS"
-  | "enableHostExpiry"
-  | "hostExpiryWindow"
-  | "deleteActivities"
-  | "activityExpiryWindow"
-  | "disableLiveQuery"
-  | "disableScripts"
-  | "disableQueryReports"
->;
+interface IAdvancedConfigFormData {
+  domain: string;
+  verifySSLCerts: boolean;
+  enableStartTLS?: boolean;
+  enableHostExpiry: boolean;
+  hostExpiryWindow: number;
+  deleteActivities: boolean;
+  activityExpiryWindow: number;
+  disableLiveQuery: boolean;
+  disableScripts: boolean;
+  disableQueryReports: boolean;
+}
 
-type IAdvancedConfigFormErrors = Pick<
-  IAppConfigFormErrors,
-  "host_expiry_window"
->;
+interface IAdvancedConfigFormErrors {
+  host_expiry_window?: string | null;
+}
 
 const Advanced = ({
   appConfig,
@@ -103,7 +95,7 @@ const Advanced = ({
 
   useEffect(() => {
     // validate desired form fields
-    const errors: IAppConfigFormErrors = {};
+    const errors: IAdvancedConfigFormErrors = {};
 
     if (enableHostExpiry && (!hostExpiryWindow || hostExpiryWindow <= 0)) {
       errors.host_expiry_window =

--- a/frontend/pages/admin/OrgSettingsPage/cards/Advanced/Advanced.tsx
+++ b/frontend/pages/admin/OrgSettingsPage/cards/Advanced/Advanced.tsx
@@ -1,10 +1,15 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useCallback, useMemo } from "react";
 
 import Button from "components/buttons/Button";
 import Checkbox from "components/forms/fields/Checkbox";
 // @ts-ignore
 import InputField from "components/forms/fields/InputField";
 import SectionHeader from "components/SectionHeader";
+// @ts-ignore
+import Dropdown from "components/forms/fields/Dropdown";
+
+import { ACTIVITY_EXPIRY_WINDOW } from "utilities/constants";
+import { getCustomDropdownOptions } from "utilities/helpers";
 
 import {
   IAppConfigFormProps,
@@ -26,6 +31,10 @@ const Advanced = ({
     enableHostExpiry:
       appConfig.host_expiry_settings.host_expiry_enabled || false,
     hostExpiryWindow: appConfig.host_expiry_settings.host_expiry_window || 0,
+    deleteActivities:
+      appConfig.activity_expiry_settings?.activity_expiry_enabled || false,
+    activityExpiryWindow:
+      appConfig.activity_expiry_settings?.activity_expiry_window || 30,
     disableLiveQuery: appConfig.server_settings.live_query_disabled || false,
     disableQueryReports:
       appConfig.server_settings.query_reports_disabled || false,
@@ -38,6 +47,8 @@ const Advanced = ({
     enableStartTLS,
     enableHostExpiry,
     hostExpiryWindow,
+    deleteActivities,
+    activityExpiryWindow,
     disableLiveQuery,
     disableScripts,
     disableQueryReports,
@@ -45,9 +56,29 @@ const Advanced = ({
 
   const [formErrors, setFormErrors] = useState<IAppConfigFormErrors>({});
 
+  const activityExpiryWindowOptions = useMemo(
+    () =>
+      getCustomDropdownOptions(
+        ACTIVITY_EXPIRY_WINDOW,
+        activityExpiryWindow,
+        // it's safe to assume that frequency is a number
+        (frequency: number | string) => `${frequency as number} days`
+      ),
+    // intentionally leave activityExpiryWindow out of the dependencies, so that the custom
+    // options are maintained even if the user changes the frequency in the UI
+    [deleteActivities]
+  );
+
   const handleInputChange = ({ name, value }: IFormField) => {
     setFormData({ ...formData, [name]: value });
   };
+
+  const onChangeSelectActivityExpiryWindow = useCallback(
+    (option: { value: number; name: string }) => {
+      setFormData({ ...formData, activityExpiryWindow: option.value });
+    },
+    [formData]
+  );
 
   useEffect(() => {
     // validate desired form fields
@@ -91,6 +122,10 @@ const Advanced = ({
       host_expiry_settings: {
         host_expiry_enabled: enableHostExpiry,
         host_expiry_window: Number(hostExpiryWindow),
+      },
+      activity_expiry_settings: {
+        activity_expiry_enabled: deleteActivities,
+        activity_expiry_window: Number(activityExpiryWindow),
       },
     };
 
@@ -192,6 +227,38 @@ const Advanced = ({
               value={hostExpiryWindow}
               parseTarget
               error={formErrors.host_expiry_window}
+            />
+          )}
+          <Checkbox
+            onChange={handleInputChange}
+            name="deleteActivities"
+            value={deleteActivities}
+            parseTarget
+            tooltipContent={
+              <>
+                When enabled, allows automatic cleanup of audit logs older than
+                the number of days specified in the{" "}
+                <em>Audit log retention window</em>
+                setting.
+                <em>
+                  (Default: <strong>Off</strong>)
+                </em>
+              </>
+            }
+          >
+            Delete activities
+          </Checkbox>
+          {deleteActivities && (
+            <Dropdown
+              searchable={false}
+              options={activityExpiryWindowOptions}
+              onChange={onChangeSelectActivityExpiryWindow}
+              placeholder="Select"
+              value={activityExpiryWindow}
+              label="Max activity age"
+              name="Max activity age"
+              parseTarget
+              error={formErrors.activity_expiry_window}
             />
           )}
           <Checkbox

--- a/frontend/pages/admin/OrgSettingsPage/cards/Advanced/Advanced.tsx
+++ b/frontend/pages/admin/OrgSettingsPage/cards/Advanced/Advanced.tsx
@@ -238,8 +238,7 @@ const Advanced = ({
               <>
                 When enabled, allows automatic cleanup of audit logs older than
                 the number of days specified in the{" "}
-                <em>Audit log retention window</em>
-                setting.
+                <em>Audit log retention window</em> setting.
                 <em>
                   (Default: <strong>Off</strong>)
                 </em>

--- a/frontend/pages/admin/OrgSettingsPage/cards/Advanced/Advanced.tsx
+++ b/frontend/pages/admin/OrgSettingsPage/cards/Advanced/Advanced.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback, useMemo } from "react";
+import React, { useState, useEffect, useMemo } from "react";
 
 import Button from "components/buttons/Button";
 import Checkbox from "components/forms/fields/Checkbox";
@@ -82,16 +82,9 @@ const Advanced = ({
     [deleteActivities]
   );
 
-  const handleInputChange = ({ name, value }: IFormField) => {
+  const onInputChange = ({ name, value }: IFormField) => {
     setFormData({ ...formData, [name]: value });
   };
-
-  const onChangeSelectActivityExpiryWindow = useCallback(
-    (option: { value: number; name: string }) => {
-      setFormData({ ...formData, activityExpiryWindow: option.value });
-    },
-    [formData]
-  );
 
   useEffect(() => {
     // validate desired form fields
@@ -116,12 +109,13 @@ const Advanced = ({
         enable_analytics: appConfig.server_settings.enable_analytics,
         query_reports_disabled: disableQueryReports,
         scripts_disabled: disableScripts,
+        deferred_save_host: appConfig.server_settings.deferred_save_host,
       },
       smtp_settings: {
         enable_smtp: appConfig.smtp_settings?.enable_smtp || false,
         sender_address: appConfig.smtp_settings?.sender_address || "",
         server: appConfig.smtp_settings?.server || "",
-        port: Number(appConfig.smtp_settings?.port),
+        port: appConfig.smtp_settings?.port || undefined,
         authentication_type: appConfig.smtp_settings?.authentication_type || "",
         user_name: appConfig.smtp_settings?.user_name || "",
         password: appConfig.smtp_settings?.password || "",
@@ -130,15 +124,15 @@ const Advanced = ({
           appConfig.smtp_settings?.authentication_method || "",
         domain,
         verify_ssl_certs: verifySSLCerts,
-        enable_start_tls: enableStartTLS,
+        enable_start_tls: enableStartTLS || false,
       },
       host_expiry_settings: {
         host_expiry_enabled: enableHostExpiry,
-        host_expiry_window: Number(hostExpiryWindow),
+        host_expiry_window: hostExpiryWindow || undefined,
       },
       activity_expiry_settings: {
         activity_expiry_enabled: deleteActivities,
-        activity_expiry_window: Number(activityExpiryWindow),
+        activity_expiry_window: activityExpiryWindow || undefined,
       },
     };
 
@@ -155,7 +149,7 @@ const Advanced = ({
           </p>
           <InputField
             label="Domain"
-            onChange={handleInputChange}
+            onChange={onInputChange}
             name="domain"
             value={domain}
             parseTarget
@@ -170,7 +164,7 @@ const Advanced = ({
             }
           />
           <Checkbox
-            onChange={handleInputChange}
+            onChange={onInputChange}
             name="verifySSLCerts"
             value={verifySSLCerts}
             parseTarget
@@ -188,7 +182,7 @@ const Advanced = ({
             Verify SSL certs
           </Checkbox>
           <Checkbox
-            onChange={handleInputChange}
+            onChange={onInputChange}
             name="enableStartTLS"
             value={enableStartTLS}
             parseTarget
@@ -206,7 +200,7 @@ const Advanced = ({
             Enable STARTTLS
           </Checkbox>
           <Checkbox
-            onChange={handleInputChange}
+            onChange={onInputChange}
             name="enableHostExpiry"
             value={enableHostExpiry}
             parseTarget
@@ -235,7 +229,7 @@ const Advanced = ({
             <InputField
               label="Host expiry window"
               type="number"
-              onChange={handleInputChange}
+              onChange={onInputChange}
               name="hostExpiryWindow"
               value={hostExpiryWindow}
               parseTarget
@@ -243,7 +237,7 @@ const Advanced = ({
             />
           )}
           <Checkbox
-            onChange={handleInputChange}
+            onChange={onInputChange}
             name="deleteActivities"
             value={deleteActivities}
             parseTarget
@@ -264,7 +258,7 @@ const Advanced = ({
             <Dropdown
               searchable={false}
               options={activityExpiryWindowOptions}
-              onChange={onChangeSelectActivityExpiryWindow}
+              onChange={onInputChange}
               placeholder="Select"
               value={activityExpiryWindow}
               label="Max activity age"
@@ -273,7 +267,7 @@ const Advanced = ({
             />
           )}
           <Checkbox
-            onChange={handleInputChange}
+            onChange={onInputChange}
             name="disableLiveQuery"
             value={disableLiveQuery}
             parseTarget
@@ -290,7 +284,7 @@ const Advanced = ({
             Disable live queries
           </Checkbox>
           <Checkbox
-            onChange={handleInputChange}
+            onChange={onInputChange}
             name="disableScripts"
             value={disableScripts}
             parseTarget
@@ -307,7 +301,7 @@ const Advanced = ({
             Disable scripts
           </Checkbox>
           <Checkbox
-            onChange={handleInputChange}
+            onChange={onInputChange}
             name="disableQueryReports"
             value={disableQueryReports}
             parseTarget

--- a/frontend/pages/admin/OrgSettingsPage/cards/Advanced/Advanced.tsx
+++ b/frontend/pages/admin/OrgSettingsPage/cards/Advanced/Advanced.tsx
@@ -1,5 +1,7 @@
 import React, { useState, useEffect, useCallback, useMemo } from "react";
 
+import { IConfigFormData } from "interfaces/config";
+
 import Button from "components/buttons/Button";
 import Checkbox from "components/forms/fields/Checkbox";
 // @ts-ignore
@@ -8,7 +10,7 @@ import SectionHeader from "components/SectionHeader";
 // @ts-ignore
 import Dropdown from "components/forms/fields/Dropdown";
 
-import { ACTIVITY_EXPIRY_WINDOW } from "utilities/constants";
+import { ACTIVITY_EXPIRY_WINDOW_DROPDOWN_OPTIONS } from "utilities/constants";
 import { getCustomDropdownOptions } from "utilities/helpers";
 
 import {
@@ -19,12 +21,31 @@ import {
 
 const baseClass = "app-config-form";
 
+type IAdvancedConfigFormData = Pick<
+  IConfigFormData,
+  | "domain"
+  | "verifySSLCerts"
+  | "enableStartTLS"
+  | "enableHostExpiry"
+  | "hostExpiryWindow"
+  | "deleteActivities"
+  | "activityExpiryWindow"
+  | "disableLiveQuery"
+  | "disableScripts"
+  | "disableQueryReports"
+>;
+
+type IAdvancedConfigFormErrors = Pick<
+  IAppConfigFormErrors,
+  "host_expiry_window"
+>;
+
 const Advanced = ({
   appConfig,
   handleSubmit,
   isUpdatingSettings,
 }: IAppConfigFormProps): JSX.Element => {
-  const [formData, setFormData] = useState({
+  const [formData, setFormData] = useState<IAdvancedConfigFormData>({
     domain: appConfig.smtp_settings?.domain || "",
     verifySSLCerts: appConfig.smtp_settings?.verify_ssl_certs || false,
     enableStartTLS: appConfig.smtp_settings?.enable_start_tls,
@@ -54,12 +75,12 @@ const Advanced = ({
     disableQueryReports,
   } = formData;
 
-  const [formErrors, setFormErrors] = useState<IAppConfigFormErrors>({});
+  const [formErrors, setFormErrors] = useState<IAdvancedConfigFormErrors>({});
 
   const activityExpiryWindowOptions = useMemo(
     () =>
       getCustomDropdownOptions(
-        ACTIVITY_EXPIRY_WINDOW,
+        ACTIVITY_EXPIRY_WINDOW_DROPDOWN_OPTIONS,
         activityExpiryWindow,
         // it's safe to assume that frequency is a number
         (frequency: number | string) => `${frequency as number} days`
@@ -257,7 +278,6 @@ const Advanced = ({
               label="Max activity age"
               name="Max activity age"
               parseTarget
-              error={formErrors.activity_expiry_window}
             />
           )}
           <Checkbox

--- a/frontend/pages/admin/OrgSettingsPage/cards/Agents/Agents.tsx
+++ b/frontend/pages/admin/OrgSettingsPage/cards/Agents/Agents.tsx
@@ -18,7 +18,7 @@ import { IAppConfigFormProps } from "../constants";
 const baseClass = "app-config-form";
 
 interface IAgentOptionsFormData {
-  agentOptions?: any;
+  agentOptions?: string;
 }
 
 interface IAgentOptionsFormErrors {
@@ -66,7 +66,7 @@ const Agents = ({
     evt.preventDefault();
 
     // Formatting of API not UI and allows empty agent options
-    const formDataToSubmit = agentOptions
+    const formDataToSubmit: any = agentOptions
       ? {
           agent_options: yaml.load(agentOptions),
         }

--- a/frontend/pages/admin/OrgSettingsPage/cards/Agents/Agents.tsx
+++ b/frontend/pages/admin/OrgSettingsPage/cards/Agents/Agents.tsx
@@ -13,6 +13,7 @@ import YamlAce from "components/YamlAce";
 import CustomLink from "components/CustomLink";
 import SectionHeader from "components/SectionHeader";
 
+import { IConfigFormData } from "interfaces/config";
 import { IAppConfigFormProps, IAppConfigFormErrors } from "../constants";
 
 const baseClass = "app-config-form";
@@ -25,10 +26,14 @@ const Agents = ({
 }: IAppConfigFormProps): JSX.Element => {
   const { ADMIN_TEAMS } = paths;
 
-  const [formData, setFormData] = useState<any>({
+  const [formData, setFormData] = useState<
+    Pick<IConfigFormData, "agentOptions">
+  >({
     agentOptions: agentOptionsToYaml(appConfig.agent_options),
   });
-  const [formErrors, setFormErrors] = useState<IAppConfigFormErrors>({});
+  const [formErrors, setFormErrors] = useState<
+    Pick<IAppConfigFormErrors, "agent_options">
+  >({});
 
   const { agentOptions } = formData;
 
@@ -37,7 +42,7 @@ const Agents = ({
   };
 
   const validateForm = () => {
-    const errors: IAppConfigFormErrors = {};
+    const errors: Pick<IAppConfigFormErrors, "agent_options"> = {};
 
     if (agentOptions) {
       const { error: yamlError, valid: yamlValid } = validateYaml(agentOptions);

--- a/frontend/pages/admin/OrgSettingsPage/cards/Agents/Agents.tsx
+++ b/frontend/pages/admin/OrgSettingsPage/cards/Agents/Agents.tsx
@@ -13,10 +13,17 @@ import YamlAce from "components/YamlAce";
 import CustomLink from "components/CustomLink";
 import SectionHeader from "components/SectionHeader";
 
-import { IConfigFormData } from "interfaces/config";
-import { IAppConfigFormProps, IAppConfigFormErrors } from "../constants";
+import { IAppConfigFormProps } from "../constants";
 
 const baseClass = "app-config-form";
+
+interface IAgentOptionsFormData {
+  agentOptions?: any;
+}
+
+interface IAgentOptionsFormErrors {
+  agent_options?: string | null;
+}
 
 const Agents = ({
   appConfig,
@@ -26,14 +33,10 @@ const Agents = ({
 }: IAppConfigFormProps): JSX.Element => {
   const { ADMIN_TEAMS } = paths;
 
-  const [formData, setFormData] = useState<
-    Pick<IConfigFormData, "agentOptions">
-  >({
+  const [formData, setFormData] = useState<IAgentOptionsFormData>({
     agentOptions: agentOptionsToYaml(appConfig.agent_options),
   });
-  const [formErrors, setFormErrors] = useState<
-    Pick<IAppConfigFormErrors, "agent_options">
-  >({});
+  const [formErrors, setFormErrors] = useState<IAgentOptionsFormErrors>({});
 
   const { agentOptions } = formData;
 
@@ -42,7 +45,7 @@ const Agents = ({
   };
 
   const validateForm = () => {
-    const errors: Pick<IAppConfigFormErrors, "agent_options"> = {};
+    const errors: IAgentOptionsFormErrors = {};
 
     if (agentOptions) {
       const { error: yamlError, valid: yamlValid } = validateYaml(agentOptions);

--- a/frontend/pages/admin/OrgSettingsPage/cards/FleetDesktop/FleetDesktop.tsx
+++ b/frontend/pages/admin/OrgSettingsPage/cards/FleetDesktop/FleetDesktop.tsx
@@ -36,7 +36,7 @@ const FleetDesktop = ({
 
   const [formErrors, setFormErrors] = useState<IFleetDesktopFormErrors>({});
 
-  const handleInputChange = ({ value }: IFormField) => {
+  const onInputChange = ({ value }: IFormField) => {
     setFormData({ transparencyUrl: value.toString() });
     setFormErrors({});
   };
@@ -75,7 +75,7 @@ const FleetDesktop = ({
         <form onSubmit={onFormSubmit} autoComplete="off">
           <InputField
             label="Custom transparency URL"
-            onChange={handleInputChange}
+            onChange={onInputChange}
             name="transparency_url"
             value={formData.transparencyUrl}
             parseTarget

--- a/frontend/pages/admin/OrgSettingsPage/cards/FleetDesktop/FleetDesktop.tsx
+++ b/frontend/pages/admin/OrgSettingsPage/cards/FleetDesktop/FleetDesktop.tsx
@@ -31,7 +31,9 @@ const FleetDesktop = ({
       appConfig.fleet_desktop?.transparency_url || DEFAULT_TRANSPARENCY_URL,
   });
 
-  const [formErrors, setFormErrors] = useState<IAppConfigFormErrors>({});
+  const [formErrors, setFormErrors] = useState<
+    Pick<IAppConfigFormErrors, "transparency_url">
+  >({});
 
   const handleInputChange = ({ value }: IFormField) => {
     setFormData({ transparencyUrl: value.toString() });

--- a/frontend/pages/admin/OrgSettingsPage/cards/FleetDesktop/FleetDesktop.tsx
+++ b/frontend/pages/admin/OrgSettingsPage/cards/FleetDesktop/FleetDesktop.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 
-import { IConfig, IConfigFormData } from "interfaces/config";
+import { IConfig } from "interfaces/config";
 
 import Button from "components/buttons/Button";
 // @ts-ignore
@@ -13,9 +13,14 @@ import {
   DEFAULT_TRANSPARENCY_URL,
   IAppConfigFormProps,
   IFormField,
-  IAppConfigFormErrors,
 } from "../constants";
 
+interface IFleetDesktopFormData {
+  transparencyUrl: string;
+}
+interface IFleetDesktopFormErrors {
+  transparency_url?: string | null;
+}
 const baseClass = "app-config-form";
 
 const FleetDesktop = ({
@@ -24,16 +29,12 @@ const FleetDesktop = ({
   isPremiumTier,
   isUpdatingSettings,
 }: IAppConfigFormProps): JSX.Element => {
-  const [formData, setFormData] = useState<
-    Pick<IConfigFormData, "transparencyUrl">
-  >({
+  const [formData, setFormData] = useState<IFleetDesktopFormData>({
     transparencyUrl:
       appConfig.fleet_desktop?.transparency_url || DEFAULT_TRANSPARENCY_URL,
   });
 
-  const [formErrors, setFormErrors] = useState<
-    Pick<IAppConfigFormErrors, "transparency_url">
-  >({});
+  const [formErrors, setFormErrors] = useState<IFleetDesktopFormErrors>({});
 
   const handleInputChange = ({ value }: IFormField) => {
     setFormData({ transparencyUrl: value.toString() });
@@ -43,7 +44,7 @@ const FleetDesktop = ({
   const validateForm = () => {
     const { transparencyUrl } = formData;
 
-    const errors: IAppConfigFormErrors = {};
+    const errors: IFleetDesktopFormErrors = {};
     if (transparencyUrl && !validUrl({ url: transparencyUrl })) {
       errors.transparency_url = `${transparencyUrl} is not a valid URL`;
     }

--- a/frontend/pages/admin/OrgSettingsPage/cards/GlobalHostStatusWebhook/GlobalHostStatusWebhook.tsx
+++ b/frontend/pages/admin/OrgSettingsPage/cards/GlobalHostStatusWebhook/GlobalHostStatusWebhook.tsx
@@ -66,7 +66,7 @@ const GlobalHostStatusWebhook = ({
     setFormErrors,
   ] = useState<IGlobalHostStatusWebhookFormErrors>({});
 
-  const handleInputChange = ({ name, value }: IFormField) => {
+  const onInputChange = ({ name, value }: IFormField) => {
     setFormData({ ...formData, [name]: value });
     setFormErrors({});
   };
@@ -106,6 +106,10 @@ const GlobalHostStatusWebhook = ({
           host_percentage: hostStatusWebhookHostPercentage,
           days_count: hostStatusWebhookWindow,
         },
+        failing_policies_webhook:
+          appConfig.webhook_settings.failing_policies_webhook,
+        vulnerabilities_webhook:
+          appConfig.webhook_settings.vulnerabilities_webhook,
       },
     };
 
@@ -142,7 +146,7 @@ const GlobalHostStatusWebhook = ({
             Send an alert if a portion of your hosts go offline.
           </p>
           <Checkbox
-            onChange={handleInputChange}
+            onChange={onInputChange}
             name="enableHostStatusWebhook"
             value={enableHostStatusWebhook}
             parseTarget
@@ -168,7 +172,7 @@ const GlobalHostStatusWebhook = ({
               <InputField
                 placeholder="https://server.com/example"
                 label="Destination URL"
-                onChange={handleInputChange}
+                onChange={onInputChange}
                 name="destination_url"
                 value={destination_url}
                 parseTarget
@@ -184,7 +188,7 @@ const GlobalHostStatusWebhook = ({
               <Dropdown
                 label="Percentage of hosts"
                 options={percentageHostsOptions}
-                onChange={handleInputChange}
+                onChange={onInputChange}
                 name="hostStatusWebhookHostPercentage"
                 value={hostStatusWebhookHostPercentage}
                 parseTarget
@@ -203,7 +207,7 @@ const GlobalHostStatusWebhook = ({
               <Dropdown
                 label="Number of days"
                 options={windowOptions}
-                onChange={handleInputChange}
+                onChange={onInputChange}
                 name="hostStatusWebhookWindow"
                 value={hostStatusWebhookWindow}
                 parseTarget

--- a/frontend/pages/admin/OrgSettingsPage/cards/GlobalHostStatusWebhook/GlobalHostStatusWebhook.tsx
+++ b/frontend/pages/admin/OrgSettingsPage/cards/GlobalHostStatusWebhook/GlobalHostStatusWebhook.tsx
@@ -9,6 +9,8 @@ import { getCustomDropdownOptions } from "utilities/helpers";
 
 import HostStatusWebhookPreviewModal from "pages/admin/components/HostStatusWebhookPreviewModal";
 
+import { IConfigFormData } from "interfaces/config";
+
 import Button from "components/buttons/Button";
 import Checkbox from "components/forms/fields/Checkbox";
 // @ts-ignore
@@ -26,12 +28,13 @@ import {
 
 const baseClass = "app-config-form";
 
-export type IGlobalHostStatusWebhookFormData = {
-  enableHostStatusWebhook: boolean;
-  destination_url: string;
-  hostStatusWebhookHostPercentage: number;
-  hostStatusWebhookWindow: number;
-};
+export type IGlobalHostStatusWebhookFormData = Pick<
+  IConfigFormData,
+  | "enableHostStatusWebhook"
+  | "destination_url"
+  | "hostStatusWebhookHostPercentage"
+  | "hostStatusWebhookWindow"
+>;
 
 const GlobalHostStatusWebhook = ({
   appConfig,
@@ -61,7 +64,9 @@ const GlobalHostStatusWebhook = ({
     hostStatusWebhookWindow,
   } = formData;
 
-  const [formErrors, setFormErrors] = useState<IAppConfigFormErrors>({});
+  const [formErrors, setFormErrors] = useState<
+    Pick<IAppConfigFormErrors, "destination_url">
+  >({});
 
   const handleInputChange = ({ name, value }: IFormField) => {
     setFormData({ ...formData, [name]: value });

--- a/frontend/pages/admin/OrgSettingsPage/cards/GlobalHostStatusWebhook/GlobalHostStatusWebhook.tsx
+++ b/frontend/pages/admin/OrgSettingsPage/cards/GlobalHostStatusWebhook/GlobalHostStatusWebhook.tsx
@@ -9,8 +9,6 @@ import { getCustomDropdownOptions } from "utilities/helpers";
 
 import HostStatusWebhookPreviewModal from "pages/admin/components/HostStatusWebhookPreviewModal";
 
-import { IConfigFormData } from "interfaces/config";
-
 import Button from "components/buttons/Button";
 import Checkbox from "components/forms/fields/Checkbox";
 // @ts-ignore
@@ -20,21 +18,20 @@ import InputField from "components/forms/fields/InputField";
 import validUrl from "components/forms/validators/valid_url";
 import SectionHeader from "components/SectionHeader";
 
-import {
-  IAppConfigFormProps,
-  IFormField,
-  IAppConfigFormErrors,
-} from "../constants";
+import { IAppConfigFormProps, IFormField } from "../constants";
+
+interface IGlobalHostStatusWebhookFormData {
+  enableHostStatusWebhook: boolean;
+  destination_url?: string;
+  hostStatusWebhookHostPercentage: number;
+  hostStatusWebhookWindow: number;
+}
+
+interface IGlobalHostStatusWebhookFormErrors {
+  destination_url?: string;
+}
 
 const baseClass = "app-config-form";
-
-export type IGlobalHostStatusWebhookFormData = Pick<
-  IConfigFormData,
-  | "enableHostStatusWebhook"
-  | "destination_url"
-  | "hostStatusWebhookHostPercentage"
-  | "hostStatusWebhookWindow"
->;
 
 const GlobalHostStatusWebhook = ({
   appConfig,
@@ -64,9 +61,10 @@ const GlobalHostStatusWebhook = ({
     hostStatusWebhookWindow,
   } = formData;
 
-  const [formErrors, setFormErrors] = useState<
-    Pick<IAppConfigFormErrors, "destination_url">
-  >({});
+  const [
+    formErrors,
+    setFormErrors,
+  ] = useState<IGlobalHostStatusWebhookFormErrors>({});
 
   const handleInputChange = ({ name, value }: IFormField) => {
     setFormData({ ...formData, [name]: value });
@@ -74,7 +72,7 @@ const GlobalHostStatusWebhook = ({
   };
 
   const validateForm = () => {
-    const errors: IAppConfigFormErrors = {};
+    const errors: IGlobalHostStatusWebhookFormErrors = {};
 
     if (enableHostStatusWebhook) {
       if (!destination_url) {

--- a/frontend/pages/admin/OrgSettingsPage/cards/Info/Info.tsx
+++ b/frontend/pages/admin/OrgSettingsPage/cards/Info/Info.tsx
@@ -1,7 +1,5 @@
 import React, { useState } from "react";
 
-import { IConfigFormData } from "interfaces/config";
-
 import Button from "components/buttons/Button";
 // @ts-ignore
 import InputField from "components/forms/fields/InputField";
@@ -10,24 +8,21 @@ import OrgLogoIcon from "components/icons/OrgLogoIcon";
 import validUrl from "components/forms/validators/valid_url";
 import SectionHeader from "components/SectionHeader";
 
-import {
-  IAppConfigFormProps,
-  IFormField,
-  IAppConfigFormErrors,
-} from "../constants";
+import { IAppConfigFormProps, IFormField } from "../constants";
 
-type IOrgInfoFormData = Pick<
-  IConfigFormData,
-  "orgName" | "orgLogoURL" | "orgLogoURLLightBackground" | "orgSupportURL"
->;
+interface IOrgInfoFormData {
+  orgLogoURL: string;
+  orgName: string;
+  orgLogoURLLightBackground: string;
+  orgSupportURL: string;
+}
 
-type IOrgInfoFormErrors = Pick<
-  IAppConfigFormErrors,
-  | "org_name"
-  | "org_logo_url"
-  | "org_logo_url_light_background"
-  | "org_support_url"
->;
+interface IOrgInfoFormErrors {
+  org_name?: string | null;
+  org_logo_url?: string | null;
+  org_logo_url_light_background?: string | null;
+  org_support_url?: string | null;
+}
 
 // TODO: change base classes to these cards to follow the same pattern as the
 // other components in the app.
@@ -63,7 +58,7 @@ const Info = ({
   };
 
   const validateForm = () => {
-    const errors: IAppConfigFormErrors = {};
+    const errors: IOrgInfoFormErrors = {};
 
     if (!orgName) {
       errors.org_name = "Organization name must be present";

--- a/frontend/pages/admin/OrgSettingsPage/cards/Info/Info.tsx
+++ b/frontend/pages/admin/OrgSettingsPage/cards/Info/Info.tsx
@@ -1,5 +1,7 @@
 import React, { useState } from "react";
 
+import { IConfigFormData } from "interfaces/config";
+
 import Button from "components/buttons/Button";
 // @ts-ignore
 import InputField from "components/forms/fields/InputField";
@@ -14,12 +16,18 @@ import {
   IAppConfigFormErrors,
 } from "../constants";
 
-interface IOrgInfoFormData {
-  orgName: string;
-  orgLogoURL: string;
-  orgLogoURLLightBackground: string;
-  orgSupportURL: string;
-}
+type IOrgInfoFormData = Pick<
+  IConfigFormData,
+  "orgName" | "orgLogoURL" | "orgLogoURLLightBackground" | "orgSupportURL"
+>;
+
+type IOrgInfoFormErrors = Pick<
+  IAppConfigFormErrors,
+  | "org_name"
+  | "org_logo_url"
+  | "org_logo_url_light_background"
+  | "org_support_url"
+>;
 
 // TODO: change base classes to these cards to follow the same pattern as the
 // other components in the app.
@@ -47,7 +55,7 @@ const Info = ({
     orgSupportURL,
   } = formData;
 
-  const [formErrors, setFormErrors] = useState<IAppConfigFormErrors>({});
+  const [formErrors, setFormErrors] = useState<IOrgInfoFormErrors>({});
 
   const handleInputChange = ({ name, value }: IFormField) => {
     setFormData({ ...formData, [name]: value });

--- a/frontend/pages/admin/OrgSettingsPage/cards/Info/Info.tsx
+++ b/frontend/pages/admin/OrgSettingsPage/cards/Info/Info.tsx
@@ -52,7 +52,7 @@ const Info = ({
 
   const [formErrors, setFormErrors] = useState<IOrgInfoFormErrors>({});
 
-  const handleInputChange = ({ name, value }: IFormField) => {
+  const onInputChange = ({ name, value }: IFormField) => {
     setFormData({ ...formData, [name]: value });
     setFormErrors({});
   };
@@ -99,7 +99,7 @@ const Info = ({
         <form onSubmit={onFormSubmit} autoComplete="off">
           <InputField
             label="Organization name"
-            onChange={handleInputChange}
+            onChange={onInputChange}
             name="orgName"
             value={orgName}
             parseTarget
@@ -108,7 +108,7 @@ const Info = ({
           />
           <InputField
             label="Organization support URL"
-            onChange={handleInputChange}
+            onChange={onInputChange}
             name="orgSupportURL"
             value={orgSupportURL}
             parseTarget
@@ -118,7 +118,7 @@ const Info = ({
           <div className={`${cardClass}__logo-field-set`}>
             <InputField
               label="Organization avatar URL (for dark backgrounds)"
-              onChange={handleInputChange}
+              onChange={onInputChange}
               name="orgLogoURL"
               value={orgLogoURL}
               parseTarget
@@ -140,7 +140,7 @@ const Info = ({
           <div className={`${cardClass}__logo-field-set`}>
             <InputField
               label="Organization avatar URL (for light backgrounds)"
-              onChange={handleInputChange}
+              onChange={onInputChange}
               name="orgLogoURLLightBackground"
               value={orgLogoURLLightBackground}
               parseTarget

--- a/frontend/pages/admin/OrgSettingsPage/cards/Smtp/Smtp.tsx
+++ b/frontend/pages/admin/OrgSettingsPage/cards/Smtp/Smtp.tsx
@@ -1,7 +1,5 @@
 import React, { useState, useEffect, useContext } from "react";
 
-import { IConfigFormData } from "interfaces/config";
-
 import { AppContext } from "context/app";
 import Button from "components/buttons/Button";
 import Checkbox from "components/forms/fields/Checkbox";
@@ -18,28 +16,29 @@ import SectionHeader from "components/SectionHeader";
 import {
   IAppConfigFormProps,
   IFormField,
-  IAppConfigFormErrors,
   authMethodOptions,
   authTypeOptions,
 } from "../constants";
 
-type ISmtpConfigFormData = Pick<
-  IConfigFormData,
-  | "enableSMTP"
-  | "smtpSenderAddress"
-  | "smtpServer"
-  | "smtpPort"
-  | "smtpEnableSSLTLS"
-  | "smtpAuthenticationType"
-  | "smtpUsername"
-  | "smtpPassword"
-  | "smtpAuthenticationMethod"
->;
+interface ISmtpConfigFormData {
+  enableSMTP: boolean;
+  smtpSenderAddress: string;
+  smtpServer: string;
+  smtpPort?: number;
+  smtpEnableSSLTLS: boolean;
+  smtpAuthenticationType: string;
+  smtpUsername: string;
+  smtpPassword: string;
+  smtpAuthenticationMethod: string;
+}
 
-type ISmtpConfigFormErrors = Pick<
-  IAppConfigFormErrors,
-  "sender_address" | "server" | "server_port" | "user_name" | "password"
->;
+interface ISmtpConfigFormErrors {
+  sender_address?: string | null;
+  server?: string | null;
+  server_port?: string | null;
+  user_name?: string | null;
+  password?: string | null;
+}
 
 const baseClass = "app-config-form";
 

--- a/frontend/pages/admin/OrgSettingsPage/cards/Smtp/Smtp.tsx
+++ b/frontend/pages/admin/OrgSettingsPage/cards/Smtp/Smtp.tsx
@@ -1,5 +1,7 @@
 import React, { useState, useEffect, useContext } from "react";
 
+import { IConfigFormData } from "interfaces/config";
+
 import { AppContext } from "context/app";
 import Button from "components/buttons/Button";
 import Checkbox from "components/forms/fields/Checkbox";
@@ -21,6 +23,24 @@ import {
   authTypeOptions,
 } from "../constants";
 
+type ISmtpConfigFormData = Pick<
+  IConfigFormData,
+  | "enableSMTP"
+  | "smtpSenderAddress"
+  | "smtpServer"
+  | "smtpPort"
+  | "smtpEnableSSLTLS"
+  | "smtpAuthenticationType"
+  | "smtpUsername"
+  | "smtpPassword"
+  | "smtpAuthenticationMethod"
+>;
+
+type ISmtpConfigFormErrors = Pick<
+  IAppConfigFormErrors,
+  "sender_address" | "server" | "server_port" | "user_name" | "password"
+>;
+
 const baseClass = "app-config-form";
 
 const Smtp = ({
@@ -30,7 +50,7 @@ const Smtp = ({
 }: IAppConfigFormProps): JSX.Element => {
   const { isPremiumTier } = useContext(AppContext);
 
-  const [formData, setFormData] = useState<any>({
+  const [formData, setFormData] = useState<ISmtpConfigFormData>({
     enableSMTP: appConfig.smtp_settings?.enable_smtp || false,
     smtpSenderAddress: appConfig.smtp_settings?.sender_address || "",
     smtpServer: appConfig.smtp_settings?.server || "",
@@ -55,7 +75,7 @@ const Smtp = ({
     smtpAuthenticationMethod,
   } = formData;
 
-  const [formErrors, setFormErrors] = useState<IAppConfigFormErrors>({});
+  const [formErrors, setFormErrors] = useState<ISmtpConfigFormErrors>({});
 
   const sesConfigured = appConfig.email?.backend === "ses" || false;
 
@@ -64,7 +84,7 @@ const Smtp = ({
   };
 
   const validateForm = () => {
-    const errors: IAppConfigFormErrors = {};
+    const errors: ISmtpConfigFormErrors = {};
 
     if (enableSMTP) {
       if (!smtpSenderAddress) {

--- a/frontend/pages/admin/OrgSettingsPage/cards/Smtp/Smtp.tsx
+++ b/frontend/pages/admin/OrgSettingsPage/cards/Smtp/Smtp.tsx
@@ -78,7 +78,7 @@ const Smtp = ({
 
   const sesConfigured = appConfig.email?.backend === "ses" || false;
 
-  const handleInputChange = ({ name, value }: IFormField) => {
+  const onInputChange = ({ name, value }: IFormField) => {
     setFormData({ ...formData, [name]: value });
   };
 
@@ -137,7 +137,8 @@ const Smtp = ({
         authentication_method: smtpAuthenticationMethod,
         domain: appConfig.smtp_settings?.domain || "",
         verify_ssl_certs: appConfig.smtp_settings?.verify_ssl_certs || false,
-        enable_start_tls: appConfig.smtp_settings?.enable_start_tls,
+        enable_start_tls: appConfig.smtp_settings?.enable_start_tls || false,
+        configured: appConfig.smtp_settings?.configured || false,
       },
     };
 
@@ -153,7 +154,7 @@ const Smtp = ({
       <>
         <InputField
           label="SMTP username"
-          onChange={handleInputChange}
+          onChange={onInputChange}
           name="smtpUsername"
           value={smtpUsername}
           parseTarget
@@ -164,7 +165,7 @@ const Smtp = ({
         <InputField
           label="SMTP password"
           type="password"
-          onChange={handleInputChange}
+          onChange={onInputChange}
           name="smtpPassword"
           value={smtpPassword}
           parseTarget
@@ -176,7 +177,7 @@ const Smtp = ({
           label="Auth method"
           options={authMethodOptions}
           placeholder=""
-          onChange={handleInputChange}
+          onChange={onInputChange}
           name="smtpAuthenticationMethod"
           value={smtpAuthenticationMethod}
           parseTarget
@@ -208,7 +209,7 @@ const Smtp = ({
     return (
       <form onSubmit={onFormSubmit} autoComplete="off">
         <Checkbox
-          onChange={handleInputChange}
+          onChange={onInputChange}
           name="enableSMTP"
           value={enableSMTP}
           parseTarget
@@ -217,7 +218,7 @@ const Smtp = ({
         </Checkbox>
         <InputField
           label="Sender address"
-          onChange={handleInputChange}
+          onChange={onInputChange}
           name="smtpSenderAddress"
           value={smtpSenderAddress}
           parseTarget
@@ -228,7 +229,7 @@ const Smtp = ({
         <div className="smtp-server-inputs">
           <InputField
             label="SMTP server"
-            onChange={handleInputChange}
+            onChange={onInputChange}
             name="smtpServer"
             value={smtpServer}
             parseTarget
@@ -239,7 +240,7 @@ const Smtp = ({
           <InputField
             label="&nbsp;"
             type="number"
-            onChange={handleInputChange}
+            onChange={onInputChange}
             name="smtpPort"
             value={smtpPort}
             parseTarget
@@ -248,7 +249,7 @@ const Smtp = ({
           />
         </div>
         <Checkbox
-          onChange={handleInputChange}
+          onChange={onInputChange}
           name="smtpEnableSSLTLS"
           value={smtpEnableSSLTLS}
           parseTarget
@@ -258,7 +259,7 @@ const Smtp = ({
         <Dropdown
           label="Authentication type"
           options={authTypeOptions}
-          onChange={handleInputChange}
+          onChange={onInputChange}
           name="smtpAuthenticationType"
           value={smtpAuthenticationType}
           parseTarget

--- a/frontend/pages/admin/OrgSettingsPage/cards/Sso/Sso.tsx
+++ b/frontend/pages/admin/OrgSettingsPage/cards/Sso/Sso.tsx
@@ -1,7 +1,5 @@
 import React, { useState, useEffect } from "react";
 
-import { IConfigFormData } from "interfaces/config";
-
 import Button from "components/buttons/Button";
 import Checkbox from "components/forms/fields/Checkbox";
 import CustomLink from "components/CustomLink";
@@ -10,30 +8,28 @@ import InputField from "components/forms/fields/InputField";
 import validUrl from "components/forms/validators/valid_url";
 import SectionHeader from "components/SectionHeader";
 
-import {
-  IAppConfigFormProps,
-  IFormField,
-  IAppConfigFormErrors,
-} from "../constants";
+import { IAppConfigFormProps, IFormField } from "../constants";
 
 const baseClass = "app-config-form";
 
-type ISsoFormData = Pick<
-  IConfigFormData,
-  | "enableSso"
-  | "idpName"
-  | "entityId"
-  | "idpImageUrl"
-  | "metadata"
-  | "metadataUrl"
-  | "enableSsoIdpLogin"
-  | "enableJitProvisioning"
->;
+interface ISsoFormData {
+  idpName: string;
+  enableSso: boolean;
+  entityId: string;
+  idpImageUrl: string;
+  metadata: string;
+  metadataUrl: string;
+  enableSsoIdpLogin: boolean;
+  enableJitProvisioning: boolean;
+}
 
-type ISsoFormErrors = Pick<
-  IAppConfigFormErrors,
-  "idp_image_url" | "metadata" | "metadata_url" | "entity_id" | "idp_name"
->;
+interface ISsoFormErrors {
+  idp_image_url?: string | null;
+  metadata?: string | null;
+  metadata_url?: string | null;
+  entity_id?: string | null;
+  idp_name?: string | null;
+}
 
 const Sso = ({
   appConfig,

--- a/frontend/pages/admin/OrgSettingsPage/cards/Sso/Sso.tsx
+++ b/frontend/pages/admin/OrgSettingsPage/cards/Sso/Sso.tsx
@@ -1,5 +1,7 @@
 import React, { useState, useEffect } from "react";
 
+import { IConfigFormData } from "interfaces/config";
+
 import Button from "components/buttons/Button";
 import Checkbox from "components/forms/fields/Checkbox";
 import CustomLink from "components/CustomLink";
@@ -16,16 +18,22 @@ import {
 
 const baseClass = "app-config-form";
 
-interface ISsoFormData {
-  enableSso?: boolean;
-  idpName?: string;
-  entityId?: string;
-  idpImageUrl?: string;
-  metadata?: string;
-  metadataUrl?: string;
-  enableSsoIdpLogin?: boolean;
-  enableJitProvisioning?: boolean;
-}
+type ISsoFormData = Pick<
+  IConfigFormData,
+  | "enableSso"
+  | "idpName"
+  | "entityId"
+  | "idpImageUrl"
+  | "metadata"
+  | "metadataUrl"
+  | "enableSsoIdpLogin"
+  | "enableJitProvisioning"
+>;
+
+type ISsoFormErrors = Pick<
+  IAppConfigFormErrors,
+  "idp_image_url" | "metadata" | "metadata_url" | "entity_id" | "idp_name"
+>;
 
 const Sso = ({
   appConfig,
@@ -56,14 +64,14 @@ const Sso = ({
     enableJitProvisioning,
   } = formData;
 
-  const [formErrors, setFormErrors] = useState<IAppConfigFormErrors>({});
+  const [formErrors, setFormErrors] = useState<ISsoFormErrors>({});
 
   const handleInputChange = ({ name, value }: IFormField) => {
     setFormData({ ...formData, [name]: value });
   };
 
   const validateForm = () => {
-    const errors: IAppConfigFormErrors = {};
+    const errors: ISsoFormErrors = {};
 
     if (enableSso) {
       if (idpImageUrl && !validUrl({ url: idpImageUrl })) {

--- a/frontend/pages/admin/OrgSettingsPage/cards/Sso/Sso.tsx
+++ b/frontend/pages/admin/OrgSettingsPage/cards/Sso/Sso.tsx
@@ -62,7 +62,7 @@ const Sso = ({
 
   const [formErrors, setFormErrors] = useState<ISsoFormErrors>({});
 
-  const handleInputChange = ({ name, value }: IFormField) => {
+  const onInputChange = ({ name, value }: IFormField) => {
     setFormData({ ...formData, [name]: value });
   };
 
@@ -117,6 +117,8 @@ const Sso = ({
         enable_sso: enableSso,
         enable_sso_idp_login: enableSsoIdpLogin,
         enable_jit_provisioning: enableJitProvisioning,
+        issuer_uri: appConfig.sso_settings.issuer_uri,
+        enable_jit_role_sync: appConfig.sso_settings.enable_jit_role_sync,
       },
     };
 
@@ -129,7 +131,7 @@ const Sso = ({
         <SectionHeader title="Single sign-on options" />
         <form onSubmit={onFormSubmit} autoComplete="off">
           <Checkbox
-            onChange={handleInputChange}
+            onChange={onInputChange}
             name="enableSso"
             value={enableSso}
             parseTarget
@@ -138,7 +140,7 @@ const Sso = ({
           </Checkbox>
           <InputField
             label="Identity provider name"
-            onChange={handleInputChange}
+            onChange={onInputChange}
             name="idpName"
             value={idpName}
             parseTarget
@@ -149,7 +151,7 @@ const Sso = ({
           <InputField
             label="Entity ID"
             helpText="The URI you provide here must exactly match the Entity ID field used in identity provider configuration."
-            onChange={handleInputChange}
+            onChange={onInputChange}
             name="entityId"
             value={entityId}
             parseTarget
@@ -159,7 +161,7 @@ const Sso = ({
           />
           <InputField
             label="IDP image URL"
-            onChange={handleInputChange}
+            onChange={onInputChange}
             name="idpImageUrl"
             value={idpImageUrl}
             parseTarget
@@ -171,7 +173,7 @@ const Sso = ({
           <InputField
             label="Metadata"
             type="textarea"
-            onChange={handleInputChange}
+            onChange={onInputChange}
             name="metadata"
             value={metadata}
             parseTarget
@@ -183,7 +185,7 @@ const Sso = ({
           <InputField
             label="Metadata URL"
             helpText="If available from the identity provider, this is the preferred means of providing metadata."
-            onChange={handleInputChange}
+            onChange={onInputChange}
             name="metadataUrl"
             value={metadataUrl}
             parseTarget
@@ -192,7 +194,7 @@ const Sso = ({
             tooltip="A URL that references the identity provider metadata."
           />
           <Checkbox
-            onChange={handleInputChange}
+            onChange={onInputChange}
             name="enableSsoIdpLogin"
             value={enableSsoIdpLogin}
             parseTarget
@@ -201,7 +203,7 @@ const Sso = ({
           </Checkbox>
           {isPremiumTier && (
             <Checkbox
-              onChange={handleInputChange}
+              onChange={onInputChange}
               name="enableJitProvisioning"
               value={enableJitProvisioning}
               parseTarget

--- a/frontend/pages/admin/OrgSettingsPage/cards/Statistics/Statistics.tsx
+++ b/frontend/pages/admin/OrgSettingsPage/cards/Statistics/Statistics.tsx
@@ -1,7 +1,5 @@
 import React, { useState } from "react";
 
-import { IConfigFormData } from "interfaces/config";
-
 import Button from "components/buttons/Button";
 import Checkbox from "components/forms/fields/Checkbox";
 import SectionHeader from "components/SectionHeader";
@@ -11,15 +9,17 @@ import { IAppConfigFormProps, IFormField } from "../constants";
 
 const baseClass = "app-config-form";
 
+interface IStatisticsFormData {
+  enableUsageStatistics: boolean;
+}
+
 const Statistics = ({
   appConfig,
   handleSubmit,
   isPremiumTier,
   isUpdatingSettings,
 }: IAppConfigFormProps): JSX.Element => {
-  const [formData, setFormData] = useState<
-    Pick<IConfigFormData, "enableUsageStatistics">
-  >({
+  const [formData, setFormData] = useState<IStatisticsFormData>({
     enableUsageStatistics: appConfig.server_settings.enable_analytics,
   });
 

--- a/frontend/pages/admin/OrgSettingsPage/cards/Statistics/Statistics.tsx
+++ b/frontend/pages/admin/OrgSettingsPage/cards/Statistics/Statistics.tsx
@@ -1,5 +1,7 @@
 import React, { useState } from "react";
 
+import { IConfigFormData } from "interfaces/config";
+
 import Button from "components/buttons/Button";
 import Checkbox from "components/forms/fields/Checkbox";
 import SectionHeader from "components/SectionHeader";
@@ -15,7 +17,9 @@ const Statistics = ({
   isPremiumTier,
   isUpdatingSettings,
 }: IAppConfigFormProps): JSX.Element => {
-  const [formData, setFormData] = useState<any>({
+  const [formData, setFormData] = useState<
+    Pick<IConfigFormData, "enableUsageStatistics">
+  >({
     enableUsageStatistics: appConfig.server_settings.enable_analytics,
   });
 

--- a/frontend/pages/admin/OrgSettingsPage/cards/Statistics/Statistics.tsx
+++ b/frontend/pages/admin/OrgSettingsPage/cards/Statistics/Statistics.tsx
@@ -25,7 +25,7 @@ const Statistics = ({
 
   const { enableUsageStatistics } = formData;
 
-  const handleInputChange = ({ name, value }: IFormField) => {
+  const onInputChange = ({ name, value }: IFormField) => {
     setFormData({ ...formData, [name]: value });
   };
 
@@ -39,6 +39,10 @@ const Statistics = ({
         live_query_disabled:
           appConfig.server_settings.live_query_disabled || false,
         enable_analytics: enableUsageStatistics,
+        deferred_save_host: appConfig.server_settings.deferred_save_host,
+        query_reports_disabled:
+          appConfig.server_settings.query_reports_disabled,
+        scripts_disabled: appConfig.server_settings.scripts_disabled,
       },
     };
 
@@ -67,7 +71,7 @@ const Statistics = ({
             />
           </p>
           <Checkbox
-            onChange={handleInputChange}
+            onChange={onInputChange}
             name="enableUsageStatistics"
             value={isPremiumTier ? true : enableUsageStatistics} // Set to true for all premium customers
             parseTarget

--- a/frontend/pages/admin/OrgSettingsPage/cards/WebAddress/WebAddress.tsx
+++ b/frontend/pages/admin/OrgSettingsPage/cards/WebAddress/WebAddress.tsx
@@ -1,5 +1,7 @@
 import React, { useState } from "react";
 
+import { IConfigFormData } from "interfaces/config";
+
 import Button from "components/buttons/Button";
 // @ts-ignore
 import InputField from "components/forms/fields/InputField";
@@ -19,13 +21,15 @@ const WebAddress = ({
   handleSubmit,
   isUpdatingSettings,
 }: IAppConfigFormProps): JSX.Element => {
-  const [formData, setFormData] = useState<any>({
+  const [formData, setFormData] = useState<Pick<IConfigFormData, "serverURL">>({
     serverURL: appConfig.server_settings.server_url || "",
   });
 
   const { serverURL } = formData;
 
-  const [formErrors, setFormErrors] = useState<IAppConfigFormErrors>({});
+  const [formErrors, setFormErrors] = useState<
+    Pick<IAppConfigFormErrors, "server_url">
+  >({});
 
   const handleInputChange = ({ name, value }: IFormField) => {
     setFormData({ ...formData, [name]: value });

--- a/frontend/pages/admin/OrgSettingsPage/cards/WebAddress/WebAddress.tsx
+++ b/frontend/pages/admin/OrgSettingsPage/cards/WebAddress/WebAddress.tsx
@@ -1,18 +1,20 @@
 import React, { useState } from "react";
 
-import { IConfigFormData } from "interfaces/config";
-
 import Button from "components/buttons/Button";
 // @ts-ignore
 import InputField from "components/forms/fields/InputField";
 import validUrl from "components/forms/validators/valid_url";
 import SectionHeader from "components/SectionHeader";
 
-import {
-  IAppConfigFormProps,
-  IFormField,
-  IAppConfigFormErrors,
-} from "../constants";
+import { IAppConfigFormProps, IFormField } from "../constants";
+
+interface IWebAddressFormData {
+  serverURL: string;
+}
+
+interface IWebAddressFormErrors {
+  server_url?: string | null;
+}
 
 const baseClass = "app-config-form";
 
@@ -21,15 +23,13 @@ const WebAddress = ({
   handleSubmit,
   isUpdatingSettings,
 }: IAppConfigFormProps): JSX.Element => {
-  const [formData, setFormData] = useState<Pick<IConfigFormData, "serverURL">>({
+  const [formData, setFormData] = useState<IWebAddressFormData>({
     serverURL: appConfig.server_settings.server_url || "",
   });
 
   const { serverURL } = formData;
 
-  const [formErrors, setFormErrors] = useState<
-    Pick<IAppConfigFormErrors, "server_url">
-  >({});
+  const [formErrors, setFormErrors] = useState<IWebAddressFormErrors>({});
 
   const handleInputChange = ({ name, value }: IFormField) => {
     setFormData({ ...formData, [name]: value });
@@ -37,7 +37,7 @@ const WebAddress = ({
   };
 
   const validateForm = () => {
-    const errors: IAppConfigFormErrors = {};
+    const errors: IWebAddressFormErrors = {};
     if (!serverURL) {
       errors.server_url = "Fleet server URL must be present";
     } else if (!validUrl({ url: serverURL, protocol: "http" })) {

--- a/frontend/pages/admin/OrgSettingsPage/cards/WebAddress/WebAddress.tsx
+++ b/frontend/pages/admin/OrgSettingsPage/cards/WebAddress/WebAddress.tsx
@@ -31,7 +31,7 @@ const WebAddress = ({
 
   const [formErrors, setFormErrors] = useState<IWebAddressFormErrors>({});
 
-  const handleInputChange = ({ name, value }: IFormField) => {
+  const onInputChange = ({ name, value }: IFormField) => {
     setFormData({ ...formData, [name]: value });
     setFormErrors({});
   };
@@ -56,6 +56,10 @@ const WebAddress = ({
         server_url: serverURL,
         live_query_disabled: appConfig.server_settings.live_query_disabled,
         enable_analytics: appConfig.server_settings.enable_analytics,
+        deferred_save_host: appConfig.server_settings.deferred_save_host,
+        query_reports_disabled:
+          appConfig.server_settings.query_reports_disabled,
+        scripts_disabled: appConfig.server_settings.scripts_disabled,
       },
     };
 
@@ -74,7 +78,7 @@ const WebAddress = ({
                 Include base path only (eg. no <code>/latest</code>)
               </>
             }
-            onChange={handleInputChange}
+            onChange={onInputChange}
             name="serverURL"
             value={serverURL}
             parseTarget

--- a/frontend/pages/admin/OrgSettingsPage/cards/constants.ts
+++ b/frontend/pages/admin/OrgSettingsPage/cards/constants.ts
@@ -34,6 +34,7 @@ export interface IAppConfigFormErrors {
   days_count?: string | null;
   host_percentage?: string | null;
   host_expiry_window?: string | null;
+  activity_expiry_window?: string | null;
   agent_options?: string | null;
   transparency_url?: string | null;
 }

--- a/frontend/pages/admin/OrgSettingsPage/cards/constants.ts
+++ b/frontend/pages/admin/OrgSettingsPage/cards/constants.ts
@@ -34,7 +34,6 @@ export interface IAppConfigFormErrors {
   days_count?: string | null;
   host_percentage?: string | null;
   host_expiry_window?: string | null;
-  activity_expiry_window?: string | null;
   agent_options?: string | null;
   transparency_url?: string | null;
 }

--- a/frontend/pages/admin/OrgSettingsPage/cards/constants.ts
+++ b/frontend/pages/admin/OrgSettingsPage/cards/constants.ts
@@ -6,7 +6,7 @@ export interface IAppConfigFormProps {
   appConfig: IConfig;
   isPremiumTier?: boolean;
   isUpdatingSettings?: boolean;
-  handleSubmit: any;
+  handleSubmit: (formUpdates: Partial<IConfig>) => false | undefined;
 }
 
 export interface IFormField {

--- a/frontend/pages/admin/OrgSettingsPage/cards/constants.ts
+++ b/frontend/pages/admin/OrgSettingsPage/cards/constants.ts
@@ -14,30 +14,6 @@ export interface IFormField {
   value: string | boolean | number;
 }
 
-export interface IAppConfigFormErrors {
-  metadata?: string | null;
-  metadata_url?: string | null;
-  entity_id?: string | null;
-  idp_name?: string | null;
-  server_url?: string | null;
-  org_name?: string | null;
-  org_logo_url?: string | null;
-  org_logo_url_light_background?: string | null;
-  org_support_url?: string | null;
-  idp_image_url?: string | null;
-  sender_address?: string | null;
-  server?: string | null;
-  server_port?: string | null;
-  user_name?: string | null;
-  password?: string | null;
-  destination_url?: string | null;
-  days_count?: string | null;
-  host_percentage?: string | null;
-  host_expiry_window?: string | null;
-  agent_options?: string | null;
-  transparency_url?: string | null;
-}
-
 export const authMethodOptions = [
   { label: "Plain", value: "authmethod_plain" },
   { label: "Cram MD5", value: "authmethod_cram_md5" },

--- a/frontend/utilities/constants.tsx
+++ b/frontend/utilities/constants.tsx
@@ -25,7 +25,7 @@ export const DEFAULT_GRAVATAR_LINK_FALLBACK =
 export const DEFAULT_GRAVATAR_LINK_DARK_FALLBACK =
   "/assets/images/icon-avatar-default-dark-24x24%402x.png";
 
-export const ACTIVITY_EXPIRY_WINDOW: IDropdownOption[] = [
+export const ACTIVITY_EXPIRY_WINDOW_DROPDOWN_OPTIONS: IDropdownOption[] = [
   { value: 30, label: "30 days" },
   { value: 60, label: "60 days" },
   { value: 90, label: "90 days" },

--- a/frontend/utilities/constants.tsx
+++ b/frontend/utilities/constants.tsx
@@ -25,6 +25,12 @@ export const DEFAULT_GRAVATAR_LINK_FALLBACK =
 export const DEFAULT_GRAVATAR_LINK_DARK_FALLBACK =
   "/assets/images/icon-avatar-default-dark-24x24%402x.png";
 
+export const ACTIVITY_EXPIRY_WINDOW: IDropdownOption[] = [
+  { value: 30, label: "30 days" },
+  { value: 60, label: "60 days" },
+  { value: 90, label: "90 days" },
+];
+
 export const FREQUENCY_DROPDOWN_OPTIONS: IDropdownOption[] = [
   { value: 0, label: "Never" },
   { value: 300, label: "Every 5 minutes" },


### PR DESCRIPTION
## Issue
Cerra #16989 

## Description
- UI portion of #16989 
- Allows users to enable a setting that sets the activity expiry window to 30, 60 or 90 days
- Clean up all settings page `formData` and `formErrors` types to `Pick` keys from `IConfigFormData` and `IAppConfigFormErrors` interfaces
- TODO: Needs Backend PR to work with API

## Screenshot
<img width="1406" alt="Screenshot 2024-04-01 at 5 03 38 PM" src="https://github.com/fleetdm/fleet/assets/71795832/fc082d16-6843-41a1-abe4-1f80e0164efd">
<img width="831" alt="Screenshot 2024-04-01 at 5 03 19 PM" src="https://github.com/fleetdm/fleet/assets/71795832/bc282350-63fb-4e4a-85bf-bc13e3cead26">


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
- [x] Manual QA for all new/changed functionality

