### PR TITLE
Prevent MDM migration without assigned ADE profile

### DIFF
--- a/changes/15929-migration-rate-limit
+++ b/changes/15929-migration-rate-limit
@@ -1,0 +1,1 @@
+* Do not allow an MDM migration to start if the device doesn't have the right ADE JSON profile already assigned.

--- a/server/datastore/mysql/apple_mdm.go
+++ b/server/datastore/mysql/apple_mdm.go
@@ -985,7 +985,10 @@ func upsertHostDEPAssignmentsDB(ctx context.Context, tx sqlx.ExtContext, hosts [
 	stmt := `
 		INSERT INTO host_dep_assignments (host_id)
 		VALUES %s
-		ON DUPLICATE KEY UPDATE added_at = CURRENT_TIMESTAMP, deleted_at = NULL`
+		ON DUPLICATE KEY UPDATE
+		  added_at = CURRENT_TIMESTAMP,
+		  deleted_at = NULL,
+		  assign_profile_response = NULL`
 
 	args := []interface{}{}
 	values := []string{}

--- a/server/datastore/mysql/apple_mdm.go
+++ b/server/datastore/mysql/apple_mdm.go
@@ -987,8 +987,7 @@ func upsertHostDEPAssignmentsDB(ctx context.Context, tx sqlx.ExtContext, hosts [
 		VALUES %s
 		ON DUPLICATE KEY UPDATE
 		  added_at = CURRENT_TIMESTAMP,
-		  deleted_at = NULL,
-		  assign_profile_response = NULL`
+		  deleted_at = NULL`
 
 	args := []interface{}{}
 	values := []string{}

--- a/server/datastore/mysql/hosts.go
+++ b/server/datastore/mysql/hosts.go
@@ -16,8 +16,8 @@ import (
 	"github.com/fleetdm/fleet/v4/server/config"
 	"github.com/fleetdm/fleet/v4/server/contexts/ctxerr"
 	"github.com/fleetdm/fleet/v4/server/fleet"
-	"github.com/go-kit/kit/log"
-	"github.com/go-kit/kit/log/level"
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
 	"github.com/jmoiron/sqlx"
 )
 
@@ -1092,7 +1092,7 @@ func (ds *Datastore) applyHostFilters(
 		if errors.Is(err, sql.ErrNoRows) {
 			return "", nil, ctxerr.Wrap(
 				ctx, &fleet.BadRequestError{
-					Message:     fmt.Sprintf("team is invalid"),
+					Message:     "team is invalid",
 					InternalErr: err,
 				},
 			)
@@ -2090,6 +2090,7 @@ type hostWithMDMInfo struct {
 	MDMID                  *uint   `db:"mdm_id"`
 	Name                   *string `db:"name"`
 	EncryptionKeyAvailable *bool   `db:"encryption_key_available"`
+	DEPProfileAssignStatus *string `db:"dep_profile_assign_status"`
 }
 
 // LoadHostByOrbitNodeKey loads the whole host identified by the node key.
@@ -2148,7 +2149,8 @@ func (ds *Datastore) LoadHostByOrbitNodeKey(ctx context.Context, nodeKey string)
       COALESCE(hdek.decryptable, false) as encryption_key_available,
       IF(hdep.host_id AND ISNULL(hdep.deleted_at), true, false) AS dep_assigned_to_fleet,
       hd.encrypted as disk_encryption_enabled,
-      t.name as team_name
+      t.name as team_name,
+      hdep.assign_profile_response AS dep_profile_assign_status
     FROM
       hosts h
     LEFT OUTER JOIN
@@ -2158,7 +2160,7 @@ func (ds *Datastore) LoadHostByOrbitNodeKey(ctx context.Context, nodeKey string)
     LEFT OUTER JOIN
       host_dep_assignments hdep
     ON
-      hdep.host_id = h.id
+      hdep.host_id = h.id AND hdep.deleted_at IS NULL
     LEFT OUTER JOIN
       mobile_device_management_solutions mdms
     ON
@@ -2185,13 +2187,14 @@ func (ds *Datastore) LoadHostByOrbitNodeKey(ctx context.Context, nodeKey string)
 		// leave MDMInfo nil unless it has mdm information
 		if hostWithMDM.HostID != nil {
 			host.MDMInfo = &fleet.HostMDM{
-				HostID:           *hostWithMDM.HostID,
-				Enrolled:         *hostWithMDM.Enrolled,
-				ServerURL:        *hostWithMDM.ServerURL,
-				InstalledFromDep: *hostWithMDM.InstalledFromDep,
-				IsServer:         *hostWithMDM.IsServer,
-				MDMID:            hostWithMDM.MDMID,
-				Name:             *hostWithMDM.Name,
+				HostID:                 *hostWithMDM.HostID,
+				Enrolled:               *hostWithMDM.Enrolled,
+				ServerURL:              *hostWithMDM.ServerURL,
+				InstalledFromDep:       *hostWithMDM.InstalledFromDep,
+				IsServer:               *hostWithMDM.IsServer,
+				MDMID:                  hostWithMDM.MDMID,
+				Name:                   *hostWithMDM.Name,
+				DEPProfileAssignStatus: hostWithMDM.DEPProfileAssignStatus,
 			}
 
 			host.MDM = fleet.MDMHostData{
@@ -2260,7 +2263,8 @@ func (ds *Datastore) LoadHostByDeviceAuthToken(ctx context.Context, authToken st
       hm.mdm_id,
       COALESCE(hm.is_server, false) AS is_server,
       COALESCE(mdms.name, ?) AS name,
-      IF(hdep.host_id AND ISNULL(hdep.deleted_at), true, false) AS dep_assigned_to_fleet
+      IF(hdep.host_id AND ISNULL(hdep.deleted_at), true, false) AS dep_assigned_to_fleet,
+      hdep.assign_profile_response AS dep_profile_assign_status
     FROM
       host_device_auth hda
     INNER JOIN
@@ -2272,7 +2276,7 @@ func (ds *Datastore) LoadHostByDeviceAuthToken(ctx context.Context, authToken st
     LEFT OUTER JOIN
       host_mdm hm  ON hm.host_id = h.id
     LEFT OUTER JOIN
-      host_dep_assignments hdep ON hdep.host_id = h.id
+      host_dep_assignments hdep ON hdep.host_id = h.id AND hdep.deleted_at IS NULL
     LEFT OUTER JOIN
       mobile_device_management_solutions mdms ON hm.mdm_id = mdms.id
     WHERE
@@ -2286,13 +2290,14 @@ func (ds *Datastore) LoadHostByDeviceAuthToken(ctx context.Context, authToken st
 		// leave MDMInfo nil unless it has mdm information
 		if hostWithMDM.HostID != nil {
 			host.MDMInfo = &fleet.HostMDM{
-				HostID:           *hostWithMDM.HostID,
-				Enrolled:         *hostWithMDM.Enrolled,
-				ServerURL:        *hostWithMDM.ServerURL,
-				InstalledFromDep: *hostWithMDM.InstalledFromDep,
-				IsServer:         *hostWithMDM.IsServer,
-				MDMID:            hostWithMDM.MDMID,
-				Name:             *hostWithMDM.Name,
+				HostID:                 *hostWithMDM.HostID,
+				Enrolled:               *hostWithMDM.Enrolled,
+				ServerURL:              *hostWithMDM.ServerURL,
+				InstalledFromDep:       *hostWithMDM.InstalledFromDep,
+				IsServer:               *hostWithMDM.IsServer,
+				MDMID:                  hostWithMDM.MDMID,
+				Name:                   *hostWithMDM.Name,
+				DEPProfileAssignStatus: hostWithMDM.DEPProfileAssignStatus,
 			}
 		}
 		return &host, nil

--- a/server/fleet/hosts.go
+++ b/server/fleet/hosts.go
@@ -201,7 +201,7 @@ type HostListOptions struct {
 // TODO(Sarah): Are we missing any filters here? Should all MDM filters be included?
 func (h HostListOptions) Empty() bool {
 	return h.ListOptions.Empty() &&
-		h.DeviceMapping &&
+		h.DeviceMapping == false &&
 		len(h.AdditionalFilters) == 0 &&
 		h.StatusFilter == "" &&
 		h.TeamFilter == nil &&
@@ -213,7 +213,7 @@ func (h HostListOptions) Empty() bool {
 		h.OSIDFilter == nil &&
 		h.OSNameFilter == nil &&
 		h.OSVersionFilter == nil &&
-		h.DisableFailingPolicies &&
+		h.DisableFailingPolicies == false &&
 		h.MacOSSettingsFilter == "" &&
 		h.MacOSSettingsDiskEncryptionFilter == "" &&
 		h.MDMBootstrapPackageFilter == nil &&

--- a/server/fleet/hosts.go
+++ b/server/fleet/hosts.go
@@ -201,7 +201,7 @@ type HostListOptions struct {
 // TODO(Sarah): Are we missing any filters here? Should all MDM filters be included?
 func (h HostListOptions) Empty() bool {
 	return h.ListOptions.Empty() &&
-		h.DeviceMapping == false &&
+		h.DeviceMapping &&
 		len(h.AdditionalFilters) == 0 &&
 		h.StatusFilter == "" &&
 		h.TeamFilter == nil &&
@@ -213,7 +213,7 @@ func (h HostListOptions) Empty() bool {
 		h.OSIDFilter == nil &&
 		h.OSNameFilter == nil &&
 		h.OSVersionFilter == nil &&
-		h.DisableFailingPolicies == false &&
+		h.DisableFailingPolicies &&
 		h.MacOSSettingsFilter == "" &&
 		h.MacOSSettingsDiskEncryptionFilter == "" &&
 		h.MDMBootstrapPackageFilter == nil &&
@@ -382,6 +382,8 @@ type MDMHostData struct {
 	// DEPProfileError is a boolean representing whether Fleet received a "FAILED" response when
 	// attempting to assign a DEP profile for the host.
 	// See https://developer.apple.com/documentation/devicemanagement/assignprofileresponse
+	//
+	// It is not filled in by all host-returning datastore methods.
 	DEPProfileError bool `json:"dep_profile_error" db:"dep_profile_error" csv:"mdm.dep_profile_error"`
 	// ServerURL is the server_url stored in the host_mdm table, loaded by
 	// JOIN in datastore
@@ -650,6 +652,7 @@ func (h *Host) IsDEPAssignedToFleet() bool {
 func (h *Host) IsEligibleForDEPMigration() bool {
 	return h.IsOsqueryEnrolled() &&
 		h.IsDEPAssignedToFleet() &&
+		h.MDMInfo.HasJSONProfileAssigned() &&
 		h.MDMInfo.IsEnrolledInThirdPartyMDM()
 }
 
@@ -899,13 +902,14 @@ type HostMunkiInfo struct {
 // used by a host. Note that it uses a different JSON representation than its
 // struct - it implements a custom JSON marshaler.
 type HostMDM struct {
-	HostID           uint   `db:"host_id" json:"-" csv:"-"`
-	Enrolled         bool   `db:"enrolled" json:"-" csv:"-"`
-	ServerURL        string `db:"server_url" json:"-" csv:"-"`
-	InstalledFromDep bool   `db:"installed_from_dep" json:"-" csv:"-"`
-	IsServer         bool   `db:"is_server" json:"-" csv:"-"`
-	MDMID            *uint  `db:"mdm_id" json:"-" csv:"-"`
-	Name             string `db:"name" json:"-" csv:"-"`
+	HostID                 uint    `db:"host_id" json:"-" csv:"-"`
+	Enrolled               bool    `db:"enrolled" json:"-" csv:"-"`
+	ServerURL              string  `db:"server_url" json:"-" csv:"-"`
+	InstalledFromDep       bool    `db:"installed_from_dep" json:"-" csv:"-"`
+	IsServer               bool    `db:"is_server" json:"-" csv:"-"`
+	MDMID                  *uint   `db:"mdm_id" json:"-" csv:"-"`
+	Name                   string  `db:"name" json:"-" csv:"-"`
+	DEPProfileAssignStatus *string `db:"dep_profile_assign_status" json:"-" csv:"-"`
 }
 
 // IsPendingDEPFleetEnrollment returns true if the host's MDM information
@@ -927,6 +931,17 @@ func (h *HostMDM) IsEnrolledInThirdPartyMDM() bool {
 		return false
 	}
 	return h.Enrolled && h.Name != WellKnownMDMFleet
+}
+
+// HasJSONProfileAssigned returns true if Fleet has assigned an ADE/DEP JSON
+// profile to the host, and it'll be enrolled into Fleet the next time the host
+// performs automatic enrollment.
+func (h *HostMDM) HasJSONProfileAssigned() bool {
+	// TODO: get rid of h != nil with a better solution once we stablish
+	// the pattern for dealing with a nil HostMDM
+	return h != nil &&
+		h.DEPProfileAssignStatus != nil &&
+		*h.DEPProfileAssignStatus == string(DEPAssignProfileResponseSuccess)
 }
 
 // IsDEPCapable returns true if and only if the host's MDM information

--- a/server/service/devices.go
+++ b/server/service/devices.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	"github.com/fleetdm/fleet/v4/server/contexts/authz"
-	authzctx "github.com/fleetdm/fleet/v4/server/contexts/authz"
 	"github.com/fleetdm/fleet/v4/server/contexts/ctxerr"
 	hostctx "github.com/fleetdm/fleet/v4/server/contexts/host"
 	"github.com/fleetdm/fleet/v4/server/contexts/logging"
@@ -176,7 +175,7 @@ func getDeviceHostEndpoint(ctx context.Context, request interface{}, svc fleet.S
 }
 
 func (svc *Service) GetHostDEPAssignment(ctx context.Context, host *fleet.Host) (*fleet.HostDEPAssignment, error) {
-	alreadyAuthd := svc.authz.IsAuthenticatedWith(ctx, authzctx.AuthnDeviceToken)
+	alreadyAuthd := svc.authz.IsAuthenticatedWith(ctx, authz.AuthnDeviceToken)
 	if !alreadyAuthd {
 		if err := svc.authz.Authorize(ctx, host, fleet.ActionRead); err != nil {
 			return nil, err

--- a/server/service/devices_test.go
+++ b/server/service/devices_test.go
@@ -114,10 +114,11 @@ func TestGetFleetDesktopSummary(t *testing.T) {
 				OsqueryHostID:      ptr.String("test"),
 				DEPAssignedToFleet: &c.depAssigned,
 				MDMInfo: &fleet.HostMDM{
-					IsServer:         false,
-					InstalledFromDep: true,
-					Enrolled:         true,
-					Name:             fleet.WellKnownMDMIntune,
+					IsServer:               false,
+					InstalledFromDep:       true,
+					Enrolled:               true,
+					Name:                   fleet.WellKnownMDMIntune,
+					DEPProfileAssignStatus: ptr.String(string(fleet.DEPAssignProfileResponseSuccess)),
 				}})
 			sum, err := svc.GetFleetDesktopSummary(ctx)
 			require.NoError(t, err)
@@ -206,10 +207,11 @@ func TestGetFleetDesktopSummary(t *testing.T) {
 				OsqueryHostID:      ptr.String("test"),
 				DEPAssignedToFleet: &c.depAssigned,
 				MDMInfo: &fleet.HostMDM{
-					IsServer:         false,
-					InstalledFromDep: true,
-					Enrolled:         false,
-					Name:             fleet.WellKnownMDMFleet,
+					IsServer:               false,
+					InstalledFromDep:       true,
+					Enrolled:               false,
+					Name:                   fleet.WellKnownMDMFleet,
+					DEPProfileAssignStatus: ptr.String(string(fleet.DEPAssignProfileResponseSuccess)),
 				}})
 			sum, err := svc.GetFleetDesktopSummary(ctx)
 			require.NoError(t, err)
@@ -262,10 +264,11 @@ func TestGetFleetDesktopSummary(t *testing.T) {
 					OsqueryHostID:      ptr.String("test"),
 					DEPAssignedToFleet: ptr.Bool(false),
 					MDMInfo: &fleet.HostMDM{
-						IsServer:         false,
-						InstalledFromDep: false,
-						Enrolled:         true,
-						Name:             fleet.WellKnownMDMIntune,
+						IsServer:               false,
+						InstalledFromDep:       false,
+						Enrolled:               true,
+						Name:                   fleet.WellKnownMDMIntune,
+						DEPProfileAssignStatus: ptr.String(string(fleet.DEPAssignProfileResponseSuccess)),
 					}},
 				err: nil,
 				out: fleet.DesktopNotifications{
@@ -279,10 +282,11 @@ func TestGetFleetDesktopSummary(t *testing.T) {
 					DEPAssignedToFleet: ptr.Bool(true),
 					OsqueryHostID:      ptr.String("test"),
 					MDMInfo: &fleet.HostMDM{
-						IsServer:         false,
-						InstalledFromDep: true,
-						Enrolled:         false,
-						Name:             fleet.WellKnownMDMFleet,
+						IsServer:               false,
+						InstalledFromDep:       true,
+						Enrolled:               false,
+						Name:                   fleet.WellKnownMDMFleet,
+						DEPProfileAssignStatus: ptr.String(string(fleet.DEPAssignProfileResponseSuccess)),
 					}},
 				err: nil,
 				out: fleet.DesktopNotifications{
@@ -296,10 +300,83 @@ func TestGetFleetDesktopSummary(t *testing.T) {
 					DEPAssignedToFleet: ptr.Bool(true),
 					OsqueryHostID:      ptr.String("test"),
 					MDMInfo: &fleet.HostMDM{
-						IsServer:         false,
-						InstalledFromDep: true,
-						Enrolled:         true,
-						Name:             fleet.WellKnownMDMFleet,
+						IsServer:               false,
+						InstalledFromDep:       true,
+						Enrolled:               true,
+						Name:                   fleet.WellKnownMDMFleet,
+						DEPProfileAssignStatus: ptr.String(string(fleet.DEPAssignProfileResponseSuccess)),
+					}},
+				err: nil,
+				out: fleet.DesktopNotifications{
+					NeedsMDMMigration:      false,
+					RenewEnrollmentProfile: false,
+				},
+			},
+			{
+				name: "failed ADE assignment status",
+				host: &fleet.Host{
+					DEPAssignedToFleet: ptr.Bool(true),
+					OsqueryHostID:      ptr.String("test"),
+					MDMInfo: &fleet.HostMDM{
+						IsServer:               false,
+						InstalledFromDep:       true,
+						Enrolled:               true,
+						Name:                   fleet.WellKnownMDMIntune,
+						DEPProfileAssignStatus: ptr.String(string(fleet.DEPAssignProfileResponseFailed)),
+					}},
+				err: nil,
+				out: fleet.DesktopNotifications{
+					NeedsMDMMigration:      false,
+					RenewEnrollmentProfile: false,
+				},
+			},
+			{
+				name: "not accessible ADE assignment status",
+				host: &fleet.Host{
+					DEPAssignedToFleet: ptr.Bool(true),
+					OsqueryHostID:      ptr.String("test"),
+					MDMInfo: &fleet.HostMDM{
+						IsServer:               false,
+						InstalledFromDep:       true,
+						Enrolled:               true,
+						Name:                   fleet.WellKnownMDMIntune,
+						DEPProfileAssignStatus: ptr.String(string(fleet.DEPAssignProfileResponseNotAccessible)),
+					}},
+				err: nil,
+				out: fleet.DesktopNotifications{
+					NeedsMDMMigration:      false,
+					RenewEnrollmentProfile: false,
+				},
+			},
+			{
+				name: "empty ADE assignment status",
+				host: &fleet.Host{
+					DEPAssignedToFleet: ptr.Bool(true),
+					OsqueryHostID:      ptr.String("test"),
+					MDMInfo: &fleet.HostMDM{
+						IsServer:               false,
+						InstalledFromDep:       true,
+						Enrolled:               true,
+						Name:                   fleet.WellKnownMDMIntune,
+						DEPProfileAssignStatus: ptr.String(""),
+					}},
+				err: nil,
+				out: fleet.DesktopNotifications{
+					NeedsMDMMigration:      false,
+					RenewEnrollmentProfile: false,
+				},
+			},
+			{
+				name: "nil ADE assignment status",
+				host: &fleet.Host{
+					DEPAssignedToFleet: ptr.Bool(true),
+					OsqueryHostID:      ptr.String("test"),
+					MDMInfo: &fleet.HostMDM{
+						IsServer:               false,
+						InstalledFromDep:       true,
+						Enrolled:               true,
+						Name:                   fleet.WellKnownMDMIntune,
+						DEPProfileAssignStatus: nil,
 					}},
 				err: nil,
 				out: fleet.DesktopNotifications{
@@ -313,10 +390,11 @@ func TestGetFleetDesktopSummary(t *testing.T) {
 					DEPAssignedToFleet: ptr.Bool(true),
 					OsqueryHostID:      ptr.String("test"),
 					MDMInfo: &fleet.HostMDM{
-						IsServer:         false,
-						InstalledFromDep: true,
-						Enrolled:         true,
-						Name:             fleet.WellKnownMDMIntune,
+						IsServer:               false,
+						InstalledFromDep:       true,
+						Enrolled:               true,
+						Name:                   fleet.WellKnownMDMIntune,
+						DEPProfileAssignStatus: ptr.String(string(fleet.DEPAssignProfileResponseSuccess)),
 					}},
 				err: nil,
 				out: fleet.DesktopNotifications{

--- a/server/service/integration_core_test.go
+++ b/server/service/integration_core_test.go
@@ -8254,11 +8254,8 @@ func (s *integrationTestSuite) TestOrbitConfigNotifications() {
 	require.False(t, resp.Notifications.RenewEnrollmentProfile)
 
 	// simulate ABM assignment
-	mysql.ExecAdhocSQL(t, s.ds, func(q sqlx.ExtContext) error {
-		insertAppConfigQuery := `INSERT INTO host_dep_assignments (host_id) VALUES (?)`
-		_, err = q.ExecContext(context.Background(), insertAppConfigQuery, hFleetMDM.ID)
-		return err
-	})
+	err = s.ds.UpsertMDMAppleHostDEPAssignments(ctx, []fleet.Host{*hFleetMDM})
+	require.NoError(t, err)
 	err = s.ds.SetOrUpdateMDMData(context.Background(), hSimpleMDM.ID, false, true, "https://simplemdm.com", false, fleet.WellKnownMDMSimpleMDM, "")
 	require.NoError(t, err)
 	resp = orbitGetConfigResponse{}

--- a/server/service/integration_mdm_test.go
+++ b/server/service/integration_mdm_test.go
@@ -7119,6 +7119,7 @@ func (s *integrationMDMTestSuite) TestMDMMigration() {
 		require.False(t, orbitConfigResp.Notifications.RenewEnrollmentProfile)
 
 		// simulate that the device is assigned to Fleet in ABM
+		profileAssignmentStatusResponse := fleet.DEPAssignProfileResponseSuccess
 		s.mockDEPResponse(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusOK)
 			switch r.URL.Path {
@@ -7141,9 +7142,21 @@ func (s *integrationMDMTestSuite) TestMDMMigration() {
 					},
 				})
 				require.NoError(t, err)
+			case "/profile/devices":
+				b, err := io.ReadAll(r.Body)
+				require.NoError(t, err)
+				var prof profileAssignmentReq
+				require.NoError(t, json.Unmarshal(b, &prof))
+				var resp godep.ProfileResponse
+				resp.ProfileUUID = prof.ProfileUUID
+				resp.Devices = map[string]string{
+					prof.Devices[0]: string(profileAssignmentStatusResponse),
+				}
+				encoder := json.NewEncoder(w)
+				err = encoder.Encode(resp)
+				require.NoError(t, err)
 			}
 		}))
-		s.runDEPSchedule()
 
 		// simulate that the device is enrolled in a third-party MDM and DEP capable
 		err := s.ds.SetOrUpdateMDMData(
@@ -7158,21 +7171,63 @@ func (s *integrationMDMTestSuite) TestMDMMigration() {
 		)
 		require.NoError(t, err)
 
+		// simulate a response before we have the chance to assign the profile
 		getDesktopResp = fleetDesktopResponse{}
 		res = s.DoRawNoAuth("GET", "/api/latest/fleet/device/"+token+"/desktop", nil, http.StatusOK)
 		require.NoError(t, json.NewDecoder(res.Body).Decode(&getDesktopResp))
 		require.NoError(t, res.Body.Close())
 		require.NoError(t, getDesktopResp.Err)
 		require.Zero(t, *getDesktopResp.FailingPolicies)
-		require.True(t, getDesktopResp.Notifications.NeedsMDMMigration)
+		require.False(t, getDesktopResp.Notifications.NeedsMDMMigration)
 		require.False(t, getDesktopResp.Notifications.RenewEnrollmentProfile)
 		require.Equal(t, acResp.OrgInfo.OrgLogoURL, getDesktopResp.Config.OrgInfo.OrgLogoURL)
 		require.Equal(t, acResp.OrgInfo.OrgLogoURLLightBackground, getDesktopResp.Config.OrgInfo.OrgLogoURLLightBackground)
 		require.Equal(t, acResp.OrgInfo.ContactURL, getDesktopResp.Config.OrgInfo.ContactURL)
 		require.Equal(t, acResp.OrgInfo.OrgName, getDesktopResp.Config.OrgInfo.OrgName)
 		require.Equal(t, acResp.MDM.MacOSMigration.Mode, getDesktopResp.Config.MDM.MacOSMigration.Mode)
-
 		orbitConfigResp = orbitGetConfigResponse{}
+		s.DoJSON("POST", "/api/fleet/orbit/config", json.RawMessage(fmt.Sprintf(`{"orbit_node_key": %q}`, *host.OrbitNodeKey)), http.StatusOK, &orbitConfigResp)
+		require.False(t, orbitConfigResp.Notifications.NeedsMDMMigration)
+		require.False(t, orbitConfigResp.Notifications.RenewEnrollmentProfile)
+
+		// simulate a "FAILED" JSON profile assignment
+		profileAssignmentStatusResponse = fleet.DEPAssignProfileResponseFailed
+		s.runDEPSchedule()
+		getDesktopResp = fleetDesktopResponse{}
+		res = s.DoRawNoAuth("GET", "/api/latest/fleet/device/"+token+"/desktop", nil, http.StatusOK)
+		require.NoError(t, json.NewDecoder(res.Body).Decode(&getDesktopResp))
+		require.NoError(t, res.Body.Close())
+		require.False(t, getDesktopResp.Notifications.NeedsMDMMigration)
+		require.False(t, orbitConfigResp.Notifications.RenewEnrollmentProfile)
+		orbitConfigResp = orbitGetConfigResponse{}
+		s.DoJSON("POST", "/api/fleet/orbit/config", json.RawMessage(fmt.Sprintf(`{"orbit_node_key": %q}`, *host.OrbitNodeKey)), http.StatusOK, &orbitConfigResp)
+		require.False(t, orbitConfigResp.Notifications.NeedsMDMMigration)
+		require.False(t, orbitConfigResp.Notifications.RenewEnrollmentProfile)
+		require.NoError(t, s.ds.DeleteHostDEPAssignments(ctx, []string{host.HardwareSerial}))
+
+		// simulate a "NOT_ACCESSIBLE" JSON profile assignment
+		profileAssignmentStatusResponse = fleet.DEPAssignProfileResponseNotAccessible
+		s.runDEPSchedule()
+		getDesktopResp = fleetDesktopResponse{}
+		res = s.DoRawNoAuth("GET", "/api/latest/fleet/device/"+token+"/desktop", nil, http.StatusOK)
+		require.NoError(t, json.NewDecoder(res.Body).Decode(&getDesktopResp))
+		require.NoError(t, res.Body.Close())
+		require.False(t, getDesktopResp.Notifications.NeedsMDMMigration)
+		require.False(t, orbitConfigResp.Notifications.RenewEnrollmentProfile)
+		s.DoJSON("POST", "/api/fleet/orbit/config", json.RawMessage(fmt.Sprintf(`{"orbit_node_key": %q}`, *host.OrbitNodeKey)), http.StatusOK, &orbitConfigResp)
+		require.False(t, orbitConfigResp.Notifications.NeedsMDMMigration)
+		require.False(t, orbitConfigResp.Notifications.RenewEnrollmentProfile)
+		require.NoError(t, s.ds.DeleteHostDEPAssignments(ctx, []string{host.HardwareSerial}))
+
+		// simulate a "SUCCESS" JSON profile assignment
+		profileAssignmentStatusResponse = fleet.DEPAssignProfileResponseSuccess
+		s.runDEPSchedule()
+		getDesktopResp = fleetDesktopResponse{}
+		res = s.DoRawNoAuth("GET", "/api/latest/fleet/device/"+token+"/desktop", nil, http.StatusOK)
+		require.NoError(t, json.NewDecoder(res.Body).Decode(&getDesktopResp))
+		require.NoError(t, res.Body.Close())
+		require.True(t, getDesktopResp.Notifications.NeedsMDMMigration)
+		require.False(t, orbitConfigResp.Notifications.RenewEnrollmentProfile)
 		s.DoJSON("POST", "/api/fleet/orbit/config", json.RawMessage(fmt.Sprintf(`{"orbit_node_key": %q}`, *host.OrbitNodeKey)), http.StatusOK, &orbitConfigResp)
 		require.True(t, orbitConfigResp.Notifications.NeedsMDMMigration)
 		require.False(t, orbitConfigResp.Notifications.RenewEnrollmentProfile)
@@ -7245,6 +7300,7 @@ func (s *integrationMDMTestSuite) TestMDMMigration() {
 	host := createOrbitEnrolledHost(t, "darwin", "h", s.ds)
 	createDeviceTokenForHost(t, s.ds, host.ID, token)
 	checkMigrationResponses(host, token)
+	require.NoError(t, s.ds.DeleteHostDEPAssignments(ctx, []string{host.HardwareSerial}))
 
 	tm, err := s.ds.NewTeam(ctx, &fleet.Team{Name: "team-1"})
 	require.NoError(t, err)

--- a/server/worker/apple_mdm_test.go
+++ b/server/worker/apple_mdm_test.go
@@ -75,12 +75,8 @@ func TestAppleMDM(t *testing.T) {
 			return err
 		})
 		if depAssignedToFleet {
-			mysql.ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
-				_, err := q.ExecContext(ctx, `
-					INSERT INTO host_dep_assignments (host_id) VALUES (?) ON DUPLICATE KEY UPDATE host_id = host_id, deleted_at = NULL
-				`, h.ID)
-				return err
-			})
+			err := ds.UpsertMDMAppleHostDEPAssignments(ctx, []fleet.Host{*h})
+			require.NoError(t, err)
 		}
 		err = ds.SetOrUpdateMDMData(ctx, h.ID, false, true, "http://example.com", depAssignedToFleet, fleet.WellKnownMDMFleet, "")
 		require.NoError(t, err)


### PR DESCRIPTION
for #15929 this prevents us sending the notification to start the MDM migration if the device doesn't have the right JSON profile assigned.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [x] Added/updated tests
- [x] Manual QA for all new/changed functionality
