### PR TITLE
increase TUF expiration warning by one day

### DIFF
--- a/.github/workflows/check-tuf-timestamps.yml
+++ b/.github/workflows/check-tuf-timestamps.yml
@@ -38,11 +38,11 @@ jobs:
       run: |
         expires=$(curl -s http://tuf.fleetctl.com/timestamp.json | jq -r '.signed.expires' | cut -c 1-10)
         today=$(date "+%Y-%m-%d")
-        tomorrow=$(date -d "$today + 1 day" "+%Y-%m-%d")
+        warning_at=$(date -d "$today + 2 day" "+%Y-%m-%d")
         expires_sec=$(date -d "$expires" "+%s")
-        tomorrow_sec=$(date -d "$tomorrow" "+%s")
+        warning_at_sec=$(date -d "$warning_at" "+%s")
         
-        if [ "$expires_sec" -le "$tomorrow_sec" ]; then
+        if [ "$expires_sec" -le "$warning_at_sec" ]; then
             exit 1
         else
             exit 0


### PR DESCRIPTION
hopefully this will get obsolete before we have time to use it, but just in case this increments the warning time to give us more leeway.
