### PR TITLE
Fleet UI: Adding a policy modal can filter by platform

### DIFF
--- a/changes/12292-policies-filter-by-platform
+++ b/changes/12292-policies-filter-by-platform
@@ -1,0 +1,1 @@
+* Add filters by platform to select a new policy modal

--- a/frontend/pages/policies/ManagePoliciesPage/components/AddPolicyModal/AddPolicyModal.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/components/AddPolicyModal/AddPolicyModal.tsx
@@ -5,6 +5,7 @@ import { InjectedRouter } from "react-router/lib/Router";
 import { DEFAULT_POLICY, DEFAULT_POLICIES } from "pages/policies/constants";
 
 import { IPolicyNew } from "interfaces/policy";
+import { SelectedPlatform } from "interfaces/platform";
 
 import { PolicyContext } from "context/policy";
 
@@ -102,7 +103,7 @@ const AddPolicyModal = ({
     teamId,
   ]);
 
-  const onPlatformFilterChange = (platformSelected: string) => {
+  const onPlatformFilterChange = (platformSelected: SelectedPlatform) => {
     if (platformSelected === "all") {
       setFilteredPolicies(DEFAULT_POLICIES);
     } else {

--- a/frontend/pages/policies/ManagePoliciesPage/components/AddPolicyModal/AddPolicyModal.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/components/AddPolicyModal/AddPolicyModal.tsx
@@ -105,6 +105,7 @@ const AddPolicyModal = ({
     if (platformSelected === "all") {
       setFilteredPolicies(DEFAULT_POLICIES);
     } else {
+      // Note: Default policies currently map to a single platform
       const policiesFilteredByPlatform = DEFAULT_POLICIES.filter((policy) => {
         return policy.platform === platformSelected;
       });
@@ -154,23 +155,21 @@ const AddPolicyModal = ({
       width="large"
     >
       <>
-        <div className={`${baseClass}__create-policy`}>
+        <div className={`${baseClass}__description`}>
           Choose a policy template to get started or{" "}
           <Button variant="text-link" onClick={onCreateYourOwnPolicyClick}>
             create your own policy
           </Button>
           .
         </div>
-        <div className={`${baseClass}__platform-filter`}>
-          <Dropdown
-            value={platform}
-            className={`${baseClass}__platform-dropdown`}
-            options={PLATFORM_FILTER_OPTIONS}
-            searchable={false}
-            onChange={onPlatformFilterChange}
-            tableFilterDropdown
-          />
-        </div>
+        <Dropdown
+          value={platform}
+          className={`${baseClass}__platform-dropdown`}
+          options={PLATFORM_FILTER_OPTIONS}
+          searchable={false}
+          onChange={onPlatformFilterChange}
+          tableFilterDropdown
+        />
         <div className={`${baseClass}__policy-selection`}>
           {filteredPolicies.length > 0 ? policiesAvailable : renderNoResults()}
         </div>

--- a/frontend/pages/policies/ManagePoliciesPage/components/AddPolicyModal/AddPolicyModal.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/components/AddPolicyModal/AddPolicyModal.tsx
@@ -116,7 +116,9 @@ const AddPolicyModal = ({
     setPlatform(platformSelected);
   };
 
-  const renderFilteredPolicies = filteredPolicies.map((policy: IPolicyNew) => {
+  const filteredPoliciesCount = filteredPolicies.length;
+
+  const filteredPoliciesList = filteredPolicies.map((policy: IPolicyNew) => {
     return (
       <Button
         key={policy.key}
@@ -137,16 +139,18 @@ const AddPolicyModal = ({
     );
   });
 
-  const renderNoResults: JSX.Element = (
-    <>
-      There are no results that match your filters.{" "}
-      <CustomLink
-        text="Everyone can contribute"
-        url={CONTRIBUTE_TO_POLICIES_DOCS_URL}
-        newTab
-      />
-    </>
-  );
+  const renderNoResults = () => {
+    return (
+      <>
+        There are no results that match your filters.{" "}
+        <CustomLink
+          text="Everyone can contribute"
+          url={CONTRIBUTE_TO_POLICIES_DOCS_URL}
+          newTab
+        />
+      </>
+    );
+  };
 
   return (
     <Modal
@@ -172,9 +176,7 @@ const AddPolicyModal = ({
           tableFilterDropdown
         />
         <div className={`${baseClass}__policy-selection`}>
-          {renderFilteredPolicies.length > 0
-            ? renderFilteredPolicies
-            : renderNoResults}
+          {filteredPoliciesCount > 0 ? filteredPoliciesList : renderNoResults()}
         </div>
       </>
     </Modal>

--- a/frontend/pages/policies/ManagePoliciesPage/components/AddPolicyModal/AddPolicyModal.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/components/AddPolicyModal/AddPolicyModal.tsx
@@ -21,7 +21,8 @@ export interface IAddPolicyModalProps {
   teamName?: string;
 }
 
-const CONTRIBUTE_TO_POLICIES = "https://www.fleetdm.com/contribute-to/policies";
+const CONTRIBUTE_TO_POLICIES_DOCS_URL =
+  "https://www.fleetdm.com/contribute-to/policies";
 
 const PLATFORM_FILTER_OPTIONS = [
   {
@@ -114,7 +115,7 @@ const AddPolicyModal = ({
     setPlatform(platformSelected);
   };
 
-  const policiesAvailable = filteredPolicies.map((policy: IPolicyNew) => {
+  const renderFilteredPolicies = filteredPolicies.map((policy: IPolicyNew) => {
     return (
       <Button
         key={policy.key}
@@ -135,18 +136,17 @@ const AddPolicyModal = ({
     );
   });
 
-  const renderNoResults = (): JSX.Element => {
-    return (
-      <>
-        There are no results that match your filters.{" "}
-        <CustomLink
-          text="Everyone can contribute"
-          url={CONTRIBUTE_TO_POLICIES}
-          newTab
-        />
-      </>
-    );
-  };
+  const renderNoResults: JSX.Element = (
+    <>
+      There are no results that match your filters.{" "}
+      <CustomLink
+        text="Everyone can contribute"
+        url={CONTRIBUTE_TO_POLICIES_DOCS_URL}
+        newTab
+      />
+    </>
+  );
+
   return (
     <Modal
       title="Add a policy"
@@ -171,7 +171,9 @@ const AddPolicyModal = ({
           tableFilterDropdown
         />
         <div className={`${baseClass}__policy-selection`}>
-          {filteredPolicies.length > 0 ? policiesAvailable : renderNoResults()}
+          {renderFilteredPolicies.length > 0
+            ? renderFilteredPolicies
+            : renderNoResults}
         </div>
       </>
     </Modal>

--- a/frontend/pages/policies/ManagePoliciesPage/components/AddPolicyModal/AddPolicyModal.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/components/AddPolicyModal/AddPolicyModal.tsx
@@ -69,7 +69,7 @@ const AddPolicyModal = ({
   } = useContext(PolicyContext);
 
   const [filteredPolicies, setFilteredPolicies] = useState(DEFAULT_POLICIES);
-  const [platform, setPlatform] = useState("all");
+  const [platform, setPlatform] = useState<SelectedPlatform>("all");
 
   const onAddPolicy = (selectedPolicy: IPolicyNew) => {
     setDefaultPolicy(true);

--- a/frontend/pages/policies/ManagePoliciesPage/components/AddPolicyModal/_styles.scss
+++ b/frontend/pages/policies/ManagePoliciesPage/components/AddPolicyModal/_styles.scss
@@ -1,17 +1,22 @@
 .add-policy-modal {
-  height: 80%;
+  height: 90%;
   overflow: hidden;
+  min-height: 460px;
+  max-height: fit-content;
+
   .modal__content {
-    height: 100%;
+    height: 90%;
     overflow: scroll;
-    margin-top: 0;
+    display: flex;
+    flex-direction: column;
+    gap: $pad-large;
   }
-  &__create-policy {
-    padding-top: 1.5rem;
+
+  .Select-multi-value-wrapper {
+    display: flex;
   }
-  &__policy-selection {
-    padding: $pad-large 0;
-    height: 100%;
+  .Select-menu-outer {
+    max-height: 220px;
   }
 
   &__policy-name {


### PR DESCRIPTION
## Issue
Cerra #12292 

## Description
- Add a platform filter to the "Add a policy" modal

## Screenrecording
https://www.loom.com/share/2071c869dcc742289429b59a7d6a5655?sid=878fbdf1-a92d-41f4-b286-d25db3df49eb

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
- [x] Manual QA for all new/changed functionality

