### PR TITLE
Fleet UI: Surface orbit version and fleetd version to host details page

### DIFF
--- a/changes/17361-host-details-updates
+++ b/changes/17361-host-details-updates
@@ -1,0 +1,1 @@
+- UI: Surface fleet desktop and orbit version to the host details page

--- a/frontend/__mocks__/hostMock.ts
+++ b/frontend/__mocks__/hostMock.ts
@@ -1,4 +1,4 @@
-import { IHost } from "interfaces/host";
+import { IHost, IHostResponse } from "interfaces/host";
 import { IHostMdmProfile } from "interfaces/mdm";
 
 const DEFAULT_HOST_PROFILE_MOCK: IHostMdmProfile = {
@@ -32,8 +32,10 @@ const DEFAULT_HOST_MOCK: IHost = {
   display_name: "9b20fc72a247",
   display_text: "mock host 1",
   uuid: "09b244f8-0000-0000-b5cc-791a15f11073",
-  platform: "ubuntu",
+  platform: "chrome",
   osquery_version: "4.9.0",
+  orbit_version: "1.22.0",
+  fleet_desktop_version: "1.22.0",
   os_version: "Ubuntu 18.4.0",
   build: "",
   platform_like: "debian",
@@ -100,5 +102,7 @@ const DEFAULT_HOST_MOCK: IHost = {
 const createMockHost = (overrides?: Partial<IHost>): IHost => {
   return { ...DEFAULT_HOST_MOCK, ...overrides };
 };
+
+export const createMockHostResponse = { host: createMockHost() };
 
 export default createMockHost;

--- a/frontend/__mocks__/hostMock.ts
+++ b/frontend/__mocks__/hostMock.ts
@@ -32,7 +32,7 @@ const DEFAULT_HOST_MOCK: IHost = {
   display_name: "9b20fc72a247",
   display_text: "mock host 1",
   uuid: "09b244f8-0000-0000-b5cc-791a15f11073",
-  platform: "chrome",
+  platform: "ubuntu",
   osquery_version: "4.9.0",
   orbit_version: "1.22.0",
   fleet_desktop_version: "1.22.0",

--- a/frontend/interfaces/host.ts
+++ b/frontend/interfaces/host.ts
@@ -29,6 +29,8 @@ export default PropTypes.shape({
   uuid: PropTypes.string,
   platform: PropTypes.string,
   osquery_version: PropTypes.string,
+  orbit_version: PropTypes.string,
+  fleet_desktop_version: PropTypes.string,
   os_version: PropTypes.string,
   build: PropTypes.string,
   platform_like: PropTypes.string,
@@ -267,6 +269,8 @@ export interface IHost {
   uuid: string;
   platform: string;
   osquery_version: string;
+  orbit_version?: string;
+  fleet_desktop_version?: string;
   os_version: string;
   build: string;
   platform_like: string; // TODO: replace with more specific union type

--- a/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
@@ -52,7 +52,6 @@ import {
   HOST_ABOUT_DATA,
   HOST_OSQUERY_DATA,
 } from "utilities/constants";
-import { createMockHostMdmProfile } from "__mocks__/hostMock";
 
 import Spinner from "components/Spinner";
 import TabsWrapper from "components/TabsWrapper";

--- a/frontend/pages/hosts/details/cards/HostSummary/HostSummary.tsx
+++ b/frontend/pages/hosts/details/cards/HostSummary/HostSummary.tsx
@@ -317,6 +317,39 @@ const HostSummary = ({
     );
   };
 
+  const renderAgentSummary = () => {
+    if (platform === "chrome") {
+      return <DataSet title="Agent" value={summaryData.osquery_version} />;
+    }
+    if (summaryData.orbit_version) {
+      return (
+        <DataSet
+          title="Agent"
+          value={
+            <TooltipWrapper
+              tipContent={
+                <>
+                  osquery: {summaryData.osquery_version}
+                  <br />
+                  Orbit: {summaryData.orbit_version}
+                  {summaryData.fleet_desktop_version && (
+                    <>
+                      <br />
+                      Fleet Desktop: {summaryData.fleet_desktop_version}
+                    </>
+                  )}
+                </>
+              }
+            >
+              {summaryData.orbit_version}
+            </TooltipWrapper>
+          }
+        />
+      );
+    }
+    return <DataSet title="Osquery" value={summaryData.osquery_version} />;
+  };
+
   const renderSummary = () => {
     // for windows hosts we have to manually add a profile for disk encryption
     // as this is not currently included in the `profiles` value from the API
@@ -401,7 +434,8 @@ const HostSummary = ({
         />
         <DataSet title="Processor type" value={summaryData.cpu_type} />
         <DataSet title="Operating system" value={summaryData.os_version} />
-        <DataSet title="Osquery" value={summaryData.osquery_version} />
+
+        {renderAgentSummary()}
       </Card>
     );
   };

--- a/frontend/services/entities/hosts.ts
+++ b/frontend/services/entities/hosts.ts
@@ -1,7 +1,7 @@
 /* eslint-disable  @typescript-eslint/explicit-module-boundary-types */
 import sendRequest from "services";
 import endpoints from "utilities/endpoints";
-import { IHost, HostStatus, IHostResponse } from "interfaces/host";
+import { IHost, HostStatus } from "interfaces/host";
 import {
   buildQueryStringFromParams,
   getLabelParam,

--- a/frontend/services/entities/hosts.ts
+++ b/frontend/services/entities/hosts.ts
@@ -1,7 +1,7 @@
 /* eslint-disable  @typescript-eslint/explicit-module-boundary-types */
 import sendRequest from "services";
 import endpoints from "utilities/endpoints";
-import { IHost, HostStatus } from "interfaces/host";
+import { IHost, HostStatus, IHostResponse } from "interfaces/host";
 import {
   buildQueryStringFromParams,
   getLabelParam,

--- a/frontend/utilities/constants.tsx
+++ b/frontend/utilities/constants.tsx
@@ -341,6 +341,8 @@ export const HOST_SUMMARY_DATA = [
   "platform",
   "os_version",
   "osquery_version",
+  "orbit_version",
+  "fleet_desktop_version",
   "enroll_secret_name",
   "detail_updated_at",
   "percent_disk_space_available",


### PR DESCRIPTION
## Issue
Cerra #17361 

## Description
- Frontend part of #17361 
- Note: This feature does not break anything without the backend. The correct dataset will just appear based on the 4 dependencies `platform`, `osquery_version`, `orbit_version`, and `fleet_desktop_version`.

## Screenrecording (Showing 4 scenarios of mocked data intercepted at the API call show up correctly on the page) 
https://www.loom.com/share/ea790e92974a4570b5cdbc5b40d22743?sid=e2e27946-b6ec-4d1d-9ae4-e31e89b71198

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
- [x] Manual QA for all new/changed functionality

