### PR TITLE
Don't create a nudge config if macos is above version 14

### DIFF
--- a/changes/17418-macos-14-nudge
+++ b/changes/17418-macos-14-nudge
@@ -1,0 +1,1 @@
+* macOS 14 and higher no longer display nudge notifications

--- a/server/datastore/mysql/operating_systems_test.go
+++ b/server/datastore/mysql/operating_systems_test.go
@@ -295,10 +295,17 @@ func TestGetHostOperatingSystem(t *testing.T) {
 	_, err = getHostOperatingSystemDB(ctx, ds.writer(ctx), testHostID)
 	require.ErrorIs(t, err, sql.ErrNoRows)
 
+	_, err = ds.GetHostOperatingSystem(ctx, testHostID)
+	require.ErrorIs(t, err, sql.ErrNoRows)
+
 	// insert test host and os id
 	err = upsertHostOperatingSystemDB(ctx, ds.writer(ctx), testHostID, osList[0].ID)
 	require.NoError(t, err)
 	os, err := getHostOperatingSystemDB(ctx, ds.writer(ctx), testHostID)
+	require.NoError(t, err)
+	require.Equal(t, osList[0], *os)
+
+	os, err = ds.GetHostOperatingSystem(ctx, testHostID)
 	require.NoError(t, err)
 	require.Equal(t, osList[0], *os)
 
@@ -309,10 +316,18 @@ func TestGetHostOperatingSystem(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, osList[1], *os)
 
+	os, err = ds.GetHostOperatingSystem(ctx, testHostID)
+	require.NoError(t, err)
+	require.Equal(t, osList[1], *os)
+
 	// no change
 	err = upsertHostOperatingSystemDB(ctx, ds.writer(ctx), testHostID, osList[1].ID)
 	require.NoError(t, err)
 	os, err = getHostOperatingSystemDB(ctx, ds.writer(ctx), testHostID)
+	require.NoError(t, err)
+	require.Equal(t, osList[1], *os)
+
+	os, err = ds.GetHostOperatingSystem(ctx, testHostID)
 	require.NoError(t, err)
 	require.Equal(t, osList[1], *os)
 }

--- a/server/datastore/mysql/operating_systems_test.go
+++ b/server/datastore/mysql/operating_systems_test.go
@@ -3,6 +3,7 @@ package mysql
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"sync"
 	"testing"
@@ -367,7 +368,7 @@ func TestCleanupHostOperatingSystems(t *testing.T) {
 	assertDeletedHostOS := func(expectDeletedIDs []uint) {
 		for _, h := range testHosts {
 			os, err := getHostOperatingSystemDB(ctx, ds.writer(ctx), h.ID)
-			if err == sql.ErrNoRows {
+			if errors.Is(err, sql.ErrNoRows) {
 				require.Contains(t, expectDeletedIDs, h.ID)
 				return
 			}

--- a/server/fleet/datastore.go
+++ b/server/fleet/datastore.go
@@ -530,6 +530,9 @@ type Datastore interface {
 	///////////////////////////////////////////////////////////////////////////////
 	// OperatingSystemsStore
 
+	// GetHostOperatingSystem returns the operating system information
+	// for a given host.
+	GetHostOperatingSystem(ctx context.Context, hostID uint) (*OperatingSystem, error)
 	// ListOperationsSystems returns all operating systems (id, name, version)
 	ListOperatingSystems(ctx context.Context) ([]OperatingSystem, error)
 	// ListOperatingSystemsForPlatform returns all operating systems for the given platform.

--- a/server/fleet/operating_systems.go
+++ b/server/fleet/operating_systems.go
@@ -1,6 +1,10 @@
 package fleet
 
-import "strings"
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
 
 // OperatingSystem is an operating system uniquely identified according to its name and version.
 type OperatingSystem struct {
@@ -26,4 +30,24 @@ type OperatingSystem struct {
 // IsWindows returns whether the OperatingSystem record references a Windows OS
 func (os OperatingSystem) IsWindows() bool {
 	return strings.ToLower(os.Platform) == "windows"
+}
+
+// RequiresNudge returns whether the target platform is darwin and
+// below version 14. Starting at macOS 14 nudge is no longer required,
+// as the mechanism to notify users about updates is built in.
+func (os *OperatingSystem) RequiresNudge() (bool, error) {
+	if os.Platform != "darwin" {
+		return false, nil
+	}
+
+	versionFloat, err := strconv.ParseFloat(os.Version, 32)
+	if err != nil {
+		return false, fmt.Errorf("parsing macos version \"%s\": %w", os.Version, err)
+	}
+
+	if float32(versionFloat) < 14 {
+		return true, nil
+	}
+
+	return false, nil
 }

--- a/server/fleet/operating_systems_test.go
+++ b/server/fleet/operating_systems_test.go
@@ -24,10 +24,10 @@ func TestOperatingSystemIsWindows(t *testing.T) {
 
 func TestOperatingSystemRequiresNudge(t *testing.T) {
 	testCases := []struct {
-		platform  string
-		version string
+		platform      string
+		version       string
 		requiresNudge bool
-		parseError bool
+		parseError    bool
 	}{
 		{platform: "chrome"},
 		{platform: "chrome", version: "12.1"},

--- a/server/fleet/operating_systems_test.go
+++ b/server/fleet/operating_systems_test.go
@@ -21,3 +21,35 @@ func TestOperatingSystemIsWindows(t *testing.T) {
 		require.Equal(t, tc.isWindows, sut.IsWindows())
 	}
 }
+
+func TestOperatingSystemRequiresNudge(t *testing.T) {
+	testCases := []struct {
+		platform  string
+		version string
+		requiresNudge bool
+		parseError bool
+	}{
+		{platform: "chrome"},
+		{platform: "chrome", version: "12.1"},
+		{platform: "chrome", version: "15"},
+		{platform: "darwin", parseError: true},
+		{platform: "darwin", version: "12.0", requiresNudge: true},
+		{platform: "darwin", version: "11", requiresNudge: true},
+		{platform: "darwin", version: "14.0"},
+		{platform: "darwin", version: "14.3"},
+		{platform: "windows"},
+		{platform: "windows", version: "12.2"},
+		{platform: "windows", version: "15.4"},
+	}
+
+	for _, tc := range testCases {
+		os := OperatingSystem{Platform: tc.platform, Version: tc.version}
+		req, err := os.RequiresNudge()
+		if tc.parseError {
+			require.Error(t, err)
+		} else {
+			require.NoError(t, err)
+		}
+		require.Equal(t, tc.requiresNudge, req)
+	}
+}

--- a/server/mock/datastore_mock.go
+++ b/server/mock/datastore_mock.go
@@ -392,6 +392,8 @@ type InsertCVEMetaFunc func(ctx context.Context, cveMeta []fleet.CVEMeta) error
 
 type ListCVEsFunc func(ctx context.Context, maxAge time.Duration) ([]fleet.CVEMeta, error)
 
+type GetHostOperatingSystemFunc func(ctx context.Context, hostID uint) (*fleet.OperatingSystem, error)
+
 type ListOperatingSystemsFunc func(ctx context.Context) ([]fleet.OperatingSystem, error)
 
 type ListOperatingSystemsForPlatformFunc func(ctx context.Context, platform string) ([]fleet.OperatingSystem, error)
@@ -1459,6 +1461,9 @@ type DataStore struct {
 
 	ListCVEsFunc        ListCVEsFunc
 	ListCVEsFuncInvoked bool
+
+	GetHostOperatingSystemFunc        GetHostOperatingSystemFunc
+	GetHostOperatingSystemFuncInvoked bool
 
 	ListOperatingSystemsFunc        ListOperatingSystemsFunc
 	ListOperatingSystemsFuncInvoked bool
@@ -3529,6 +3534,13 @@ func (s *DataStore) ListCVEs(ctx context.Context, maxAge time.Duration) ([]fleet
 	s.ListCVEsFuncInvoked = true
 	s.mu.Unlock()
 	return s.ListCVEsFunc(ctx, maxAge)
+}
+
+func (s *DataStore) GetHostOperatingSystem(ctx context.Context, hostID uint) (*fleet.OperatingSystem, error) {
+	s.mu.Lock()
+	s.GetHostOperatingSystemFuncInvoked = true
+	s.mu.Unlock()
+	return s.GetHostOperatingSystemFunc(ctx, hostID)
 }
 
 func (s *DataStore) ListOperatingSystems(ctx context.Context) ([]fleet.OperatingSystem, error) {

--- a/server/service/integration_core_test.go
+++ b/server/service/integration_core_test.go
@@ -1667,10 +1667,6 @@ func (s *integrationTestSuite) TestListHosts() {
 	})
 	require.Greater(t, osID, uint(0))
 
-	host2OS, err := s.ds.GetHostOperatingSystem(context.Background(), host2.ID)
-	require.NoError(t, err)
-	require.Equal(t, testOS, host2OS)
-
 	// generate aggregated stats
 	require.NoError(t, s.ds.UpdateOSVersions(context.Background()))
 

--- a/server/service/integration_core_test.go
+++ b/server/service/integration_core_test.go
@@ -1667,6 +1667,10 @@ func (s *integrationTestSuite) TestListHosts() {
 	})
 	require.Greater(t, osID, uint(0))
 
+	host2OS, err := s.ds.GetHostOperatingSystem(context.Background(), host2.ID)
+	require.NoError(t, err)
+	require.Equal(t, testOS, host2OS)
+
 	// generate aggregated stats
 	require.NoError(t, s.ds.UpdateOSVersions(context.Background()))
 

--- a/server/service/integration_mdm_test.go
+++ b/server/service/integration_mdm_test.go
@@ -7374,6 +7374,10 @@ func (s *integrationMDMTestSuite) TestOrbitConfigNudgeSettings() {
 
 	// nudge config is empty if macos_updates is not set, and Windows MDM notifications are unset
 	h := createOrbitEnrolledHost(t, "darwin", "h", s.ds)
+
+	err := s.ds.UpdateHostOperatingSystem(context.Background(), h.ID, fleet.OperatingSystem{Platform: "darwin", Version: "12.0"})
+	require.NoError(t, err)
+
 	resp = orbitGetConfigResponse{}
 	s.DoJSON("POST", "/api/fleet/orbit/config", json.RawMessage(fmt.Sprintf(`{"orbit_node_key": %q}`, *h.OrbitNodeKey)), http.StatusOK, &resp)
 	require.Empty(t, resp.NudgeConfig)
@@ -7402,7 +7406,7 @@ func (s *integrationMDMTestSuite) TestOrbitConfigNudgeSettings() {
 	})
 	mdmDevice.SerialNumber = h.HardwareSerial
 	mdmDevice.UUID = h.UUID
-	err := mdmDevice.Enroll()
+	err = mdmDevice.Enroll()
 	require.NoError(t, err)
 
 	resp = orbitGetConfigResponse{}
@@ -7459,12 +7463,24 @@ func (s *integrationMDMTestSuite) TestOrbitConfigNudgeSettings() {
 	mdmDevice.UUID = h2.UUID
 	err = mdmDevice.Enroll()
 	require.NoError(t, err)
+
+	err = s.ds.UpdateHostOperatingSystem(context.Background(), h2.ID, fleet.OperatingSystem{Platform: "darwin", Version: "12.0"})
+	require.NoError(t, err)
+
 	resp = orbitGetConfigResponse{}
 	s.DoJSON("POST", "/api/fleet/orbit/config", json.RawMessage(fmt.Sprintf(`{"orbit_node_key": %q}`, *h2.OrbitNodeKey)), http.StatusOK, &resp)
 	wantCfg, err = fleet.NewNudgeConfig(fleet.MacOSUpdates{Deadline: optjson.SetString("2022-01-04"), MinimumVersion: optjson.SetString("12.1.3")})
 	require.NoError(t, err)
 	require.Equal(t, wantCfg, resp.NudgeConfig)
 	require.Equal(t, wantCfg.OSVersionRequirements[0].RequiredInstallationDate.String(), "2022-01-04 04:00:00 +0000 UTC")
+
+	// host on macos > 14, shouldn't be receiving nudge configs
+	h3 := createOrbitEnrolledHost(t, "darwin", "h3", s.ds)
+	err = s.ds.UpdateHostOperatingSystem(context.Background(), h3.ID, fleet.OperatingSystem{Platform: "darwin", Version: "14.1"})
+	require.NoError(t, err)
+	resp = orbitGetConfigResponse{}
+	s.DoJSON("POST", "/api/fleet/orbit/config", json.RawMessage(fmt.Sprintf(`{"orbit_node_key": %q}`, *h3.OrbitNodeKey)), http.StatusOK, &resp)
+	require.Nil(t, resp.NudgeConfig)
 }
 
 func (s *integrationMDMTestSuite) TestValidDiscoveryRequest() {
@@ -8935,7 +8951,7 @@ func (s *integrationMDMTestSuite) TestMDMConfigProfileCRUD() {
 	mysql.ExecAdhocSQL(t, s.ds, func(q sqlx.ExtContext) error {
 		stmt := `
 		SELECT COALESCE(apple_profile_uuid, windows_profile_uuid) as profile_uuid, label_name, COALESCE(label_id, 0) as label_id
-		FROM mdm_configuration_profile_labels 
+		FROM mdm_configuration_profile_labels
 		UNION SELECT apple_declaration_uuid as profile_uuid, label_name, COALESCE(label_id, 0) as label_id
 		FROM mdm_declaration_labels ORDER BY profile_uuid, label_name;`
 		return sqlx.SelectContext(context.Background(), q, &profileLabels, stmt)

--- a/server/service/orbit.go
+++ b/server/service/orbit.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -269,9 +270,11 @@ func (svc *Service) GetOrbitConfig(ctx context.Context) (fleet.OrbitConfig, erro
 			mdmConfig != nil &&
 			mdmConfig.MacOSUpdates.EnabledForHost(host) {
 			hostOS, err := svc.ds.GetHostOperatingSystem(ctx, host.ID)
-			if err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
 				// host os has not been collected yet (no details query)
 				hostOS = &fleet.OperatingSystem{}
+			} else if err != nil {
+				return fleet.OrbitConfig{}, err
 			}
 			requiresNudge, err := hostOS.RequiresNudge()
 			if err != nil {
@@ -326,9 +329,11 @@ func (svc *Service) GetOrbitConfig(ctx context.Context) (fleet.OrbitConfig, erro
 	if appConfig.MDM.EnabledAndConfigured &&
 		appConfig.MDM.MacOSUpdates.EnabledForHost(host) {
 		hostOS, err := svc.ds.GetHostOperatingSystem(ctx, host.ID)
-		if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
 			// host os has not been collected yet (no details query)
 			hostOS = &fleet.OperatingSystem{}
+		} else if err != nil {
+			return fleet.OrbitConfig{}, err
 		}
 		requiresNudge, err := hostOS.RequiresNudge()
 		if err != nil {

--- a/server/service/orbit.go
+++ b/server/service/orbit.go
@@ -265,11 +265,15 @@ func (svc *Service) GetOrbitConfig(ctx context.Context) (fleet.OrbitConfig, erro
 			return fleet.OrbitConfig{}, err
 		}
 
-		hostOS, err := svc.ds.GetHostOperatingSystem(ctx, host.ID)
-		if err != nil {
-			return fleet.OrbitConfig{}, ctxerr.Wrap(ctx, err, "get orbit config")
+		var hostOS *fleet.OperatingSystem
+		if host.ID != 0 {
+			hostOS, err = svc.ds.GetHostOperatingSystem(ctx, host.ID)
+			if err != nil {
+				return fleet.OrbitConfig{}, ctxerr.Wrap(ctx, err, "get orbit config")
+			}
+		} else {
+			hostOS = &fleet.OperatingSystem{}
 		}
-
 
 		var macOsVersionFloat float32
 		if hostOS.Platform == "darwin" {

--- a/server/service/orbit.go
+++ b/server/service/orbit.go
@@ -270,7 +270,8 @@ func (svc *Service) GetOrbitConfig(ctx context.Context) (fleet.OrbitConfig, erro
 			mdmConfig.MacOSUpdates.EnabledForHost(host) {
 			hostOS, err := svc.ds.GetHostOperatingSystem(ctx, host.ID)
 			if err != nil {
-				return fleet.OrbitConfig{}, err
+				// host os has not been collected yet (no details query)
+				hostOS = &fleet.OperatingSystem{}
 			}
 			requiresNudge, err := hostOS.RequiresNudge()
 			if err != nil {
@@ -326,7 +327,8 @@ func (svc *Service) GetOrbitConfig(ctx context.Context) (fleet.OrbitConfig, erro
 		appConfig.MDM.MacOSUpdates.EnabledForHost(host) {
 		hostOS, err := svc.ds.GetHostOperatingSystem(ctx, host.ID)
 		if err != nil {
-			return fleet.OrbitConfig{}, err
+			// host os has not been collected yet (no details query)
+			hostOS = &fleet.OperatingSystem{}
 		}
 		requiresNudge, err := hostOS.RequiresNudge()
 		if err != nil {

--- a/server/service/orbit.go
+++ b/server/service/orbit.go
@@ -270,11 +270,14 @@ func (svc *Service) GetOrbitConfig(ctx context.Context) (fleet.OrbitConfig, erro
 			return fleet.OrbitConfig{}, ctxerr.Wrap(ctx, err, "get orbit config")
 		}
 
+
 		var macOsVersionFloat float32
 		if hostOS.Platform == "darwin" {
 			versionFloat, err := strconv.ParseFloat(hostOS.Version, 32)
 			macOsVersionFloat = float32(versionFloat)
-			return fleet.OrbitConfig{}, ctxerr.Wrap(ctx, err, "parsing macos version float")
+			if err != nil {
+				return fleet.OrbitConfig{}, ctxerr.Wrap(ctx, err, "parsing macos version float")
+			}
 		}
 
 		// Newer versions of macOS have a builtin version update

--- a/server/service/orbit.go
+++ b/server/service/orbit.go
@@ -287,7 +287,7 @@ func (svc *Service) GetOrbitConfig(ctx context.Context) (fleet.OrbitConfig, erro
 		// Newer versions of macOS have a builtin version update
 		// notifyer and don't require nudge, so we don't produce a
 		// nudge config
-		macOsRequiresNudge := hostOS.Platform == "darwin" && macOsVersionFloat < 14
+		macOsRequiresNudge := macOsVersionFloat < 14
 
 		var nudgeConfig *fleet.NudgeConfig
 		if appConfig.MDM.EnabledAndConfigured &&

--- a/server/service/orbit.go
+++ b/server/service/orbit.go
@@ -201,9 +201,6 @@ func (svc *Service) GetOrbitConfig(ctx context.Context) (fleet.OrbitConfig, erro
 		}
 	}
 
-	fmt.Printf("==== hostOS: %+v\n", hostOS)
-	fmt.Printf("==== macOsVersionFloat: %v\n", macOsVersionFloat)
-
 	// Newer versions of macOS have a builtin version update
 	// notifyer and don't require nudge, so we don't produce a
 	// nudge config

--- a/server/service/orbit_test.go
+++ b/server/service/orbit_test.go
@@ -24,7 +24,7 @@ func TestGetOrbitConfigNudge(t *testing.T) {
 		}
 		os := &fleet.OperatingSystem{
 			Platform: "darwin",
-			Version: "12.2",
+			Version:  "12.2",
 		}
 		ds.GetHostOperatingSystemFunc = func(ctx context.Context, hostID uint) (*fleet.OperatingSystem, error) {
 			return os, nil
@@ -34,7 +34,7 @@ func TestGetOrbitConfigNudge(t *testing.T) {
 		}
 		ctx = test.HostContext(ctx, &fleet.Host{
 			OsqueryHostID: ptr.String("test"),
-			ID: 1,
+			ID:            1,
 			MDMInfo: &fleet.HostMDM{
 				IsServer:         false,
 				InstalledFromDep: true,
@@ -75,7 +75,7 @@ func TestGetOrbitConfigNudge(t *testing.T) {
 		}
 		os := &fleet.OperatingSystem{
 			Platform: "darwin",
-			Version: "12.2",
+			Version:  "12.2",
 		}
 		ds.GetHostOperatingSystemFunc = func(ctx context.Context, hostID uint) (*fleet.OperatingSystem, error) {
 			return os, nil
@@ -95,7 +95,7 @@ func TestGetOrbitConfigNudge(t *testing.T) {
 
 		ctx = test.HostContext(ctx, &fleet.Host{
 			OsqueryHostID: ptr.String("test"),
-			ID: 1,
+			ID:            1,
 			TeamID:        ptr.Uint(team.ID),
 			MDMInfo: &fleet.HostMDM{
 				IsServer:         false,
@@ -137,7 +137,7 @@ func TestGetOrbitConfigNudge(t *testing.T) {
 		svc, ctx := newTestService(t, ds, nil, nil, &TestServerOpts{License: license, SkipCreateTestUsers: true})
 		os := &fleet.OperatingSystem{
 			Platform: "darwin",
-			Version: "12.2",
+			Version:  "12.2",
 		}
 		ds.GetHostOperatingSystemFunc = func(ctx context.Context, hostID uint) (*fleet.OperatingSystem, error) {
 			return os, nil
@@ -222,11 +222,11 @@ func TestGetOrbitConfigNudge(t *testing.T) {
 		svc, ctx := newTestService(t, ds, nil, nil, &TestServerOpts{License: license, SkipCreateTestUsers: true})
 		os := &fleet.OperatingSystem{
 			Platform: "darwin",
-			Version: "12.2",
+			Version:  "12.2",
 		}
 		host := &fleet.Host{
 			OsqueryHostID: ptr.String("test"),
-			ID: 0,
+			ID:            0,
 			MDMInfo: &fleet.HostMDM{
 				IsServer:         false,
 				InstalledFromDep: true,
@@ -268,7 +268,6 @@ func TestGetOrbitConfigNudge(t *testing.T) {
 		require.NoError(t, err)
 		require.Empty(t, cfg.NudgeConfig)
 		require.False(t, ds.GetHostOperatingSystemFuncInvoked)
-
 
 		// Version < 14 gets nudge
 		host.ID = 1

--- a/server/service/orbit_test.go
+++ b/server/service/orbit_test.go
@@ -226,7 +226,7 @@ func TestGetOrbitConfigNudge(t *testing.T) {
 		}
 		host := &fleet.Host{
 			OsqueryHostID: ptr.String("test"),
-			ID:            0,
+			ID:            1,
 			MDMInfo: &fleet.HostMDM{
 				IsServer:         false,
 				InstalledFromDep: true,
@@ -263,15 +263,9 @@ func TestGetOrbitConfigNudge(t *testing.T) {
 		}
 		ctx = test.HostContext(ctx, host)
 
-		// No hostId, can't get platform info, no nudge
-		cfg, err := svc.GetOrbitConfig(ctx)
-		require.NoError(t, err)
-		require.Empty(t, cfg.NudgeConfig)
-		require.False(t, ds.GetHostOperatingSystemFuncInvoked)
-
 		// Version < 14 gets nudge
 		host.ID = 1
-		cfg, err = svc.GetOrbitConfig(ctx)
+		cfg, err := svc.GetOrbitConfig(ctx)
 		require.NoError(t, err)
 		require.NotEmpty(t, cfg.NudgeConfig)
 		require.True(t, ds.GetHostOperatingSystemFuncInvoked)

--- a/server/service/orbit_test.go
+++ b/server/service/orbit_test.go
@@ -22,11 +22,19 @@ func TestGetOrbitConfigNudge(t *testing.T) {
 		ds.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {
 			return appCfg, nil
 		}
+		os := &fleet.OperatingSystem{
+			Platform: "darwin",
+			Version: "12.2",
+		}
+		ds.GetHostOperatingSystemFunc = func(ctx context.Context, hostID uint) (*fleet.OperatingSystem, error) {
+			return os, nil
+		}
 		ds.ListPendingHostScriptExecutionsFunc = func(ctx context.Context, hostID uint) ([]*fleet.HostScriptResult, error) {
 			return nil, nil
 		}
 		ctx = test.HostContext(ctx, &fleet.Host{
 			OsqueryHostID: ptr.String("test"),
+			ID: 1,
 			MDMInfo: &fleet.HostMDM{
 				IsServer:         false,
 				InstalledFromDep: true,
@@ -65,7 +73,13 @@ func TestGetOrbitConfigNudge(t *testing.T) {
 		ds.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {
 			return appCfg, nil
 		}
-
+		os := &fleet.OperatingSystem{
+			Platform: "darwin",
+			Version: "12.2",
+		}
+		ds.GetHostOperatingSystemFunc = func(ctx context.Context, hostID uint) (*fleet.OperatingSystem, error) {
+			return os, nil
+		}
 		team := fleet.Team{ID: 1}
 		teamMDM := fleet.TeamMDM{}
 		ds.TeamMDMConfigFunc = func(ctx context.Context, teamID uint) (*fleet.TeamMDM, error) {
@@ -81,6 +95,7 @@ func TestGetOrbitConfigNudge(t *testing.T) {
 
 		ctx = test.HostContext(ctx, &fleet.Host{
 			OsqueryHostID: ptr.String("test"),
+			ID: 1,
 			TeamID:        ptr.Uint(team.ID),
 			MDMInfo: &fleet.HostMDM{
 				IsServer:         false,
@@ -120,6 +135,13 @@ func TestGetOrbitConfigNudge(t *testing.T) {
 		ds := new(mock.Store)
 		license := &fleet.LicenseInfo{Tier: fleet.TierPremium}
 		svc, ctx := newTestService(t, ds, nil, nil, &TestServerOpts{License: license, SkipCreateTestUsers: true})
+		os := &fleet.OperatingSystem{
+			Platform: "darwin",
+			Version: "12.2",
+		}
+		ds.GetHostOperatingSystemFunc = func(ctx context.Context, hostID uint) (*fleet.OperatingSystem, error) {
+			return os, nil
+		}
 		appCfg := &fleet.AppConfig{MDM: fleet.MDM{EnabledAndConfigured: true}}
 		appCfg.MDM.MacOSUpdates.Deadline = optjson.SetString("2022-04-01")
 		appCfg.MDM.MacOSUpdates.MinimumVersion = optjson.SetString("2022-04-01")
@@ -192,5 +214,111 @@ func TestGetOrbitConfigNudge(t *testing.T) {
 				Name:             fleet.WellKnownMDMFleet,
 			}})
 
+	})
+
+	t.Run("no-nudge on macos versions greater than 14", func(t *testing.T) {
+		ds := new(mock.Store)
+		license := &fleet.LicenseInfo{Tier: fleet.TierPremium}
+		svc, ctx := newTestService(t, ds, nil, nil, &TestServerOpts{License: license, SkipCreateTestUsers: true})
+		os := &fleet.OperatingSystem{
+			Platform: "darwin",
+			Version: "12.2",
+		}
+		host := &fleet.Host{
+			OsqueryHostID: ptr.String("test"),
+			ID: 0,
+			MDMInfo: &fleet.HostMDM{
+				IsServer:         false,
+				InstalledFromDep: true,
+				Enrolled:         true,
+				Name:             fleet.WellKnownMDMFleet,
+			}}
+
+		team := fleet.Team{ID: 1}
+		teamMDM := fleet.TeamMDM{}
+		teamMDM.MacOSUpdates.Deadline = optjson.SetString("2022-04-01")
+		teamMDM.MacOSUpdates.MinimumVersion = optjson.SetString("12.1")
+		ds.TeamMDMConfigFunc = func(ctx context.Context, teamID uint) (*fleet.TeamMDM, error) {
+			require.Equal(t, team.ID, teamID)
+			return &teamMDM, nil
+		}
+		ds.TeamAgentOptionsFunc = func(ctx context.Context, id uint) (*json.RawMessage, error) {
+			return ptr.RawMessage(json.RawMessage(`{}`)), nil
+		}
+		ds.ListPendingHostScriptExecutionsFunc = func(ctx context.Context, hostID uint) ([]*fleet.HostScriptResult, error) {
+			return nil, nil
+		}
+
+		appCfg := &fleet.AppConfig{MDM: fleet.MDM{EnabledAndConfigured: true}}
+		appCfg.MDM.MacOSUpdates.Deadline = optjson.SetString("2022-04-01")
+		appCfg.MDM.MacOSUpdates.MinimumVersion = optjson.SetString("12.3")
+		ds.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {
+			return appCfg, nil
+		}
+		ds.ListPendingHostScriptExecutionsFunc = func(ctx context.Context, hostID uint) ([]*fleet.HostScriptResult, error) {
+			return nil, nil
+		}
+		ds.GetHostOperatingSystemFunc = func(ctx context.Context, hostID uint) (*fleet.OperatingSystem, error) {
+			return os, nil
+		}
+		ctx = test.HostContext(ctx, host)
+
+		// No hostId, can't get platform info, no nudge
+		cfg, err := svc.GetOrbitConfig(ctx)
+		require.NoError(t, err)
+		require.Empty(t, cfg.NudgeConfig)
+		require.False(t, ds.GetHostOperatingSystemFuncInvoked)
+
+
+		// Version < 14 gets nudge
+		host.ID = 1
+		cfg, err = svc.GetOrbitConfig(ctx)
+		require.NoError(t, err)
+		require.NotEmpty(t, cfg.NudgeConfig)
+		require.True(t, ds.GetHostOperatingSystemFuncInvoked)
+
+		// Version > 14 gets no nudge
+		os.Version = "14.1"
+		ds.GetHostOperatingSystemFuncInvoked = false
+		cfg, err = svc.GetOrbitConfig(ctx)
+		require.NoError(t, err)
+		require.Empty(t, cfg.NudgeConfig)
+		require.True(t, ds.GetHostOperatingSystemFuncInvoked)
+
+		// windows gets no nudge
+		os.Platform = "windows"
+		ds.GetHostOperatingSystemFuncInvoked = false
+		cfg, err = svc.GetOrbitConfig(ctx)
+		require.NoError(t, err)
+		require.Empty(t, cfg.NudgeConfig)
+		require.True(t, ds.GetHostOperatingSystemFuncInvoked)
+
+		//// team section below
+		host.TeamID = ptr.Uint(team.ID)
+		os.Platform = "darwin"
+		os.Version = "12.1"
+
+		// Version < 14 gets nudge
+		host.ID = 1
+		cfg, err = svc.GetOrbitConfig(ctx)
+		require.NoError(t, err)
+		require.NotEmpty(t, cfg.NudgeConfig)
+		require.True(t, ds.GetHostOperatingSystemFuncInvoked)
+
+		// Version > 14 gets no nudge
+		os.Version = "14.1"
+		ds.GetHostOperatingSystemFuncInvoked = false
+		cfg, err = svc.GetOrbitConfig(ctx)
+		require.NoError(t, err)
+		require.Empty(t, cfg.NudgeConfig)
+		require.True(t, ds.GetHostOperatingSystemFuncInvoked)
+
+		// windows gets no nudge
+		os.Platform = "windows"
+		ds.GetHostOperatingSystemFuncInvoked = false
+		cfg, err = svc.GetOrbitConfig(ctx)
+		require.NoError(t, err)
+		require.Empty(t, cfg.NudgeConfig)
+		require.True(t, ds.GetHostOperatingSystemFuncInvoked)
 	})
 }


### PR DESCRIPTION
#17418

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [x] Added/updated tests
- [ ] Manual QA for all new/changed functionality
