### PR TITLE
Mark calendar webhook as errored so that it doesn't get stuck in pending and keeps logging warnings.

### DIFF
--- a/server/fleet/calendar_events.go
+++ b/server/fleet/calendar_events.go
@@ -18,6 +18,7 @@ const (
 	CalendarWebhookStatusNone CalendarWebhookStatus = iota
 	CalendarWebhookStatusPending
 	CalendarWebhookStatusSent
+	CalendarWebhookStatusError
 )
 
 type HostCalendarEvent struct {


### PR DESCRIPTION
Mark calendar webhook as errored so that it doesn't get stuck in pending and keeps logging warnings.

This situation only occurs when webhook fired but returned an error. It will try to fire again, but if it tries after the event concluded, then we'll mark it as errored.
