### PR TITLE
Bump osqueryd version to 5.12.1

### DIFF
--- a/.github/workflows/generate-osqueryd-targets.yml
+++ b/.github/workflows/generate-osqueryd-targets.yml
@@ -24,7 +24,7 @@ defaults:
     shell: bash
 
 env:
-  OSQUERY_VERSION: 5.12.0
+  OSQUERY_VERSION: 5.12.1
 
 permissions:
   contents: read


### PR DESCRIPTION
Bumping version of osqueryd for releasing 5.12.1 to the `edge` channel.