### PR TITLE
Add `parse_json`, `parse_jsonl`, `parse_xml`, and `parse_ini` tables to fleetd

### DIFF
--- a/orbit/changes/dataflatten-tables
+++ b/orbit/changes/dataflatten-tables
@@ -1,0 +1,1 @@
+- Add `parse_json`, `parse_jsonl`, `parse_xml`, and `parse_ini` tables.

--- a/orbit/pkg/table/extension.go
+++ b/orbit/pkg/table/extension.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/fleetdm/fleet/v4/orbit/pkg/table/cryptoinfotable"
+	"github.com/fleetdm/fleet/v4/orbit/pkg/table/dataflattentable"
 	"github.com/fleetdm/fleet/v4/orbit/pkg/table/firefox_preferences"
 	"github.com/fleetdm/fleet/v4/orbit/pkg/table/sntp_request"
 	"github.com/macadmins/osquery-extension/tables/chromeuserprofiles"
@@ -134,6 +135,13 @@ func OrbitDefaultTables() []osquery.OsqueryPlugin {
 
 		firefox_preferences.TablePlugin(osqueryLogger),
 		cryptoinfotable.TablePlugin(osqueryLogger),
+
+		// Additional data format tables
+		dataflattentable.TablePlugin(osqueryLogger, dataflattentable.JsonType),  // table name is "parse_json"
+		dataflattentable.TablePlugin(osqueryLogger, dataflattentable.JsonlType), // table name is "parse_jsonl"
+		dataflattentable.TablePlugin(osqueryLogger, dataflattentable.XmlType),   // table name is "parse_xml"
+		dataflattentable.TablePlugin(osqueryLogger, dataflattentable.IniType),   // table name is "parse_ini"
+
 	}
 	return plugins
 }

--- a/schema/osquery_fleet_schema.json
+++ b/schema/osquery_fleet_schema.json
@@ -18787,6 +18787,186 @@
     "fleetRepoUrl": "https://github.com/fleetdm/fleet/blob/main/schema/tables/package_receipts.yml"
   },
   {
+    "name": "parse_ini",
+    "notes": "This table is not a core osquery table. It is included as part of [Fleetd](https://fleetdm.com/docs/using-fleet/orbit), the osquery manager from Fleet. Fleetd can be built with [fleetctl](https://fleetdm.com/docs/using-fleet/adding-hosts#osquery-installer).",
+    "description": "Parse a file as INI configuration.",
+    "platforms": [
+      "darwin",
+      "windows",
+      "linux"
+    ],
+    "evented": false,
+    "columns": [
+      {
+        "name": "path",
+        "description": "Path of the file to read.",
+        "required": true,
+        "type": "text"
+      },
+      {
+        "name": "fullkey",
+        "description": "Key including any parent keys.",
+        "type": "text",
+        "required": false
+      },
+      {
+        "name": "parent",
+        "description": "Parent key when keys are nested in the document.",
+        "required": false,
+        "type": "text"
+      },
+      {
+        "name": "key",
+        "description": "JSON key or array index.",
+        "required": false,
+        "type": "text"
+      },
+      {
+        "name": "value",
+        "description": "JSON value",
+        "required": false,
+        "type": "text"
+      }
+    ],
+    "url": "https://fleetdm.com/tables/parse_ini",
+    "fleetRepoUrl": "https://github.com/fleetdm/fleet/blob/main/schema/tables/parse_ini.yml"
+  },
+  {
+    "name": "parse_json",
+    "notes": "This table is not a core osquery table. It is included as part of [Fleetd](https://fleetdm.com/docs/using-fleet/orbit), the osquery manager from Fleet. Fleetd can be built with [fleetctl](https://fleetdm.com/docs/using-fleet/adding-hosts#osquery-installer).",
+    "description": "Parses an entire file as JSON. See `parse_jsonl` where multiple JSON documents are supported.",
+    "platforms": [
+      "darwin",
+      "windows",
+      "linux"
+    ],
+    "evented": false,
+    "columns": [
+      {
+        "name": "path",
+        "description": "Path of the file to read.",
+        "required": true,
+        "type": "text"
+      },
+      {
+        "name": "fullkey",
+        "description": "Same as `key` in this table. See `parse_jsonl` where multiple JSON documents are supported.",
+        "required": false,
+        "type": "text"
+      },
+      {
+        "name": "parent",
+        "description": "Parent key when keys are nested in the document.",
+        "required": false,
+        "type": "text"
+      },
+      {
+        "name": "key",
+        "description": "JSON key or array index.",
+        "required": false,
+        "type": "text"
+      },
+      {
+        "name": "value",
+        "description": "JSON value",
+        "required": false,
+        "type": "text"
+      }
+    ],
+    "url": "https://fleetdm.com/tables/parse_json",
+    "fleetRepoUrl": "https://github.com/fleetdm/fleet/blob/main/schema/tables/parse_json.yml"
+  },
+  {
+    "name": "parse_jsonl",
+    "notes": "This table is not a core osquery table. It is included as part of [Fleetd](https://fleetdm.com/docs/using-fleet/orbit), the osquery manager from Fleet. Fleetd can be built with [fleetctl](https://fleetdm.com/docs/using-fleet/adding-hosts#osquery-installer).",
+    "description": "Parses each line of a file as a separate JSON document. See `parse_json` to treat an entire file as a single JSON document.",
+    "platforms": [
+      "darwin",
+      "windows",
+      "linux"
+    ],
+    "evented": false,
+    "columns": [
+      {
+        "name": "path",
+        "description": "Path of the file to read.",
+        "required": true,
+        "type": "text"
+      },
+      {
+        "name": "fullkey",
+        "description": "Key including any parent keys or document indices.",
+        "required": false,
+        "type": "text"
+      },
+      {
+        "name": "parent",
+        "description": "Parent key when keys are nested in the document.",
+        "required": false,
+        "type": "text"
+      },
+      {
+        "name": "key",
+        "description": "INI key",
+        "required": false,
+        "type": "text"
+      },
+      {
+        "name": "value",
+        "description": "INI value",
+        "required": false,
+        "type": "text"
+      }
+    ],
+    "url": "https://fleetdm.com/tables/parse_jsonl",
+    "fleetRepoUrl": "https://github.com/fleetdm/fleet/blob/main/schema/tables/parse_jsonl.yml"
+  },
+  {
+    "name": "parse_xml",
+    "notes": "This table is not a core osquery table. It is included as part of [Fleetd](https://fleetdm.com/docs/using-fleet/orbit), the osquery manager from Fleet. Fleetd can be built with [fleetctl](https://fleetdm.com/docs/using-fleet/adding-hosts#osquery-installer).",
+    "description": "Parses a file as an XML document.",
+    "platforms": [
+      "darwin",
+      "windows",
+      "linux"
+    ],
+    "evented": false,
+    "columns": [
+      {
+        "name": "path",
+        "description": "Path of the file to read.",
+        "required": true,
+        "type": "text"
+      },
+      {
+        "name": "fullkey",
+        "description": "Key including any parent keys.",
+        "required": false,
+        "type": "text"
+      },
+      {
+        "name": "parent",
+        "description": "Parent key when keys are nested in the document.",
+        "required": false,
+        "type": "text"
+      },
+      {
+        "name": "key",
+        "description": "XML key",
+        "required": false,
+        "type": "text"
+      },
+      {
+        "name": "value",
+        "description": "XML value",
+        "required": false,
+        "type": "text"
+      }
+    ],
+    "url": "https://fleetdm.com/tables/parse_xml",
+    "fleetRepoUrl": "https://github.com/fleetdm/fleet/blob/main/schema/tables/parse_xml.yml"
+  },
+  {
     "name": "password_policy",
     "description": "Password Policies for macOS.",
     "url": "https://fleetdm.com/tables/password_policy",

--- a/schema/tables/parse_ini.yml
+++ b/schema/tables/parse_ini.yml
@@ -14,6 +14,7 @@ columns:
   - name: fullkey
     description: Key including any parent keys.
     type: text
+    required: false
   - name: parent
     description: Parent key when keys are nested in the document.
     required: false

--- a/schema/tables/parse_ini.yml
+++ b/schema/tables/parse_ini.yml
@@ -12,8 +12,7 @@ columns:
     required: true
     type: text
   - name: fullkey
-    description: Same as `key` in this table. See `parse_jsonl` where multiple JSON documents are supported.
-    required: false
+    description: Key including any parent keys.
     type: text
   - name: parent
     description: Parent key when keys are nested in the document.

--- a/schema/tables/parse_ini.yml
+++ b/schema/tables/parse_ini.yml
@@ -1,0 +1,29 @@
+name: parse_ini
+notes: This table is not a core osquery table. It is included as part of [Fleetd](https://fleetdm.com/docs/using-fleet/orbit), the osquery manager from Fleet. Fleetd can be built with [fleetctl](https://fleetdm.com/docs/using-fleet/adding-hosts#osquery-installer).
+description: Parse a file as INI configuration.
+platforms: 
+  - darwin
+  - windows
+  - linux
+evented: false
+columns:
+  - name: path
+    description: Path of the file to read.
+    required: true
+    type: text
+  - name: fullkey
+    description: Same as `key` in this table. See `parse_jsonl` where multiple JSON documents are supported.
+    required: false
+    type: text
+  - name: parent
+    description: Parent key when keys are nested in the document.
+    required: false
+    type: text
+  - name: key
+    description: JSON key or array index.
+    required: false
+    type: text
+  - name: value
+    description: JSON value
+    required: false
+    type: text  

--- a/schema/tables/parse_json.yml
+++ b/schema/tables/parse_json.yml
@@ -1,0 +1,29 @@
+name: parse_json
+notes: This table is not a core osquery table. It is included as part of [Fleetd](https://fleetdm.com/docs/using-fleet/orbit), the osquery manager from Fleet. Fleetd can be built with [fleetctl](https://fleetdm.com/docs/using-fleet/adding-hosts#osquery-installer).
+description: Parses an entire file as JSON. See `parse_jsonl` where multiple JSON documents are supported.
+platforms: 
+  - darwin
+  - windows
+  - linux
+evented: false
+columns:
+  - name: path
+    description: Path of the file to read.
+    required: true
+    type: text
+  - name: fullkey
+    description: Same as `key` in this table. See `parse_jsonl` where multiple JSON documents are supported.
+    required: false
+    type: text
+  - name: parent
+    description: Parent key when keys are nested in the document.
+    required: false
+    type: text
+  - name: key
+    description: JSON key or array index.
+    required: false
+    type: text
+  - name: value
+    description: JSON value
+    required: false
+    type: text  

--- a/schema/tables/parse_jsonl.yml
+++ b/schema/tables/parse_jsonl.yml
@@ -1,0 +1,29 @@
+name: parse_jsonl
+notes: This table is not a core osquery table. It is included as part of [Fleetd](https://fleetdm.com/docs/using-fleet/orbit), the osquery manager from Fleet. Fleetd can be built with [fleetctl](https://fleetdm.com/docs/using-fleet/adding-hosts#osquery-installer).
+description: Parses each line of a file as a separate JSON document. See `parse_json` to treat an entire file as a single JSON document.
+platforms: 
+  - darwin
+  - windows
+  - linux
+evented: false
+columns:
+  - name: path
+    description: Path of the file to read.
+    required: true
+    type: text
+  - name: fullkey
+    description: Key including any parent keys or document indices.
+    required: false
+    type: text
+  - name: parent
+    description: Parent key when keys are nested in the document.
+    required: false
+    type: text
+  - name: key
+    description: INI key
+    required: false
+    type: text
+  - name: value
+    description: INI value
+    required: false
+    type: text  

--- a/schema/tables/parse_xml.yml
+++ b/schema/tables/parse_xml.yml
@@ -12,7 +12,7 @@ columns:
     required: true
     type: text
   - name: fullkey
-    description: Key including any parent keys or document indices.
+    description: Key including any parent keys.
     required: false
     type: text
   - name: parent

--- a/schema/tables/parse_xml.yml
+++ b/schema/tables/parse_xml.yml
@@ -1,0 +1,29 @@
+name: parse_xml
+notes: This table is not a core osquery table. It is included as part of [Fleetd](https://fleetdm.com/docs/using-fleet/orbit), the osquery manager from Fleet. Fleetd can be built with [fleetctl](https://fleetdm.com/docs/using-fleet/adding-hosts#osquery-installer).
+description: Parses a file as an XML document.
+platforms: 
+  - darwin
+  - windows
+  - linux
+evented: false
+columns:
+  - name: path
+    description: Path of the file to read.
+    required: true
+    type: text
+  - name: fullkey
+    description: Key including any parent keys or document indices.
+    required: false
+    type: text
+  - name: parent
+    description: Parent key when keys are nested in the document.
+    required: false
+    type: text
+  - name: key
+    description: XML key
+    required: false
+    type: text
+  - name: value
+    description: XML value
+    required: false
+    type: text  


### PR DESCRIPTION
For #17577

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [x] Manual QA for all new/changed functionality
  - For Orbit and Fleet Desktop changes:
    - [x] Manual QA must be performed in the three main OSs, macOS, Windows and Linux. (performed only on macOS)