### PR TITLE
Update schema overrides to clarify which tables require joining against users

### DIFF
--- a/schema/tables/authorized_keys.yml
+++ b/schema/tables/authorized_keys.yml
@@ -5,9 +5,9 @@ examples: >-
   SELECT * FROM users CROSS JOIN authorized_keys USING (uid);
 
   ```
-
 columns:
   - name: pid_with_namespace
     platforms:
       - linux
   - name: uid
+notes: Querying this table requires joining against the `users` table. [Learn more](https://fleetdm.com/guides/osquery-consider-joining-against-the-users-table)

--- a/schema/tables/authorized_keys.yml
+++ b/schema/tables/authorized_keys.yml
@@ -1,15 +1,13 @@
 name: authorized_keys
 examples: >-
-  List the SSH keys allowed to connect to this host.
-  
   ```
-  
-  SELECT key FROM authorized_keys;
-  
+
+  SELECT * FROM users CROSS JOIN authorized_keys USING (uid);
+
   ```
+
 columns:
   - name: pid_with_namespace
     platforms:
       - linux
   - name: uid
-    requires_user_context: true

--- a/schema/tables/browser_plugins.yml
+++ b/schema/tables/browser_plugins.yml
@@ -10,3 +10,4 @@ examples: >-
   SELECT bp.name, bp.identifier, bp.version FROM browser_plugins bp JOIN users u on bp.uid = u.uid ;
 
   ```
+notes: Querying this table requires joining against the `users` table.

--- a/schema/tables/browser_plugins.yml
+++ b/schema/tables/browser_plugins.yml
@@ -1,13 +1,15 @@
 name: browser_plugins
 hidden: true
 examples: >-
+
   See classic browser plugins (C/NPAPI) installed by users. These plugins have
   been deprecated for a long time, so this query will usually not return
   anything.
 
   ```
 
-  SELECT bp.name, bp.identifier, bp.version FROM browser_plugins bp JOIN users u on bp.uid = u.uid ;
+  SELECT * FROM users CROSS JOIN browser_plugins USING (uid);
 
   ```
-notes: Querying this table requires joining against the `users` table.
+
+notes: Querying this table requires joining against the `users` table. [Learn more](https://fleetdm.com/guides/osquery-consider-joining-against-the-users-table)

--- a/schema/tables/browser_plugins.yml
+++ b/schema/tables/browser_plugins.yml
@@ -1,7 +1,6 @@
 name: browser_plugins
 hidden: true
 examples: >-
-
   See classic browser plugins (C/NPAPI) installed by users. These plugins have
   been deprecated for a long time, so this query will usually not return
   anything.

--- a/schema/tables/chrome_extension_content_scripts.yml
+++ b/schema/tables/chrome_extension_content_scripts.yml
@@ -1,5 +1,5 @@
 name: chrome_extension_content_scripts
-notes: Querying this table requires joining against the `users` table.
+notes: Querying this table requires joining against the `users` table. [Learn more](https://fleetdm.com/guides/osquery-consider-joining-against-the-users-table)
 columns:
   - name: uid
 examples: >-
@@ -8,6 +8,3 @@ examples: >-
   SELECT * FROM users CROSS JOIN chrome_extension_content_scripts USING (uid);
 
   ```
-
-notes: >-
-  - Querying this table requires joining against the `users` table. [Learn more](https://fleetdm.com/guides/osquery-consider-joining-against-the-users-table)

--- a/schema/tables/chrome_extension_content_scripts.yml
+++ b/schema/tables/chrome_extension_content_scripts.yml
@@ -2,4 +2,12 @@ name: chrome_extension_content_scripts
 notes: Querying this table requires joining against the `users` table.
 columns:
   - name: uid
-    requires_user_context: true
+examples: >-
+  ```
+
+  SELECT * FROM users CROSS JOIN chrome_extension_content_scripts USING (uid);
+
+  ```
+
+notes: >-
+  - Querying this table requires joining against the `users` table. [Learn more](https://fleetdm.com/guides/osquery-consider-joining-against-the-users-table)

--- a/schema/tables/chrome_extension_content_scripts.yml
+++ b/schema/tables/chrome_extension_content_scripts.yml
@@ -1,5 +1,4 @@
 name: chrome_extension_content_scripts
-notes: Querying this table requires joining against the `users` table. [Learn more](https://fleetdm.com/guides/osquery-consider-joining-against-the-users-table)
 columns:
   - name: uid
 examples: >-
@@ -8,3 +7,4 @@ examples: >-
   SELECT * FROM users CROSS JOIN chrome_extension_content_scripts USING (uid);
 
   ```
+notes: Querying this table requires joining against the `users` table. [Learn more](https://fleetdm.com/guides/osquery-consider-joining-against-the-users-table)

--- a/schema/tables/chrome_extension_content_scripts.yml
+++ b/schema/tables/chrome_extension_content_scripts.yml
@@ -1,4 +1,5 @@
 name: chrome_extension_content_scripts
+notes: Querying this table requires joining against the `users` table.
 columns:
   - name: uid
     requires_user_context: true

--- a/schema/tables/chrome_extensions.yml
+++ b/schema/tables/chrome_extensions.yml
@@ -14,6 +14,7 @@ examples: >-
   SELECT u.username, ce.name, ce.description, ce.version, ce.profile, ce.permissions FROM users u CROSS JOIN chrome_extensions ce USING (uid) WHERE ce.permissions LIKE '%%https://*/*%%';
 
   ```
+notes: Querying this table requires joining against the `users` table.
 columns:
   - name: uid
     requires_user_context: true

--- a/schema/tables/chrome_extensions.yml
+++ b/schema/tables/chrome_extensions.yml
@@ -6,6 +6,12 @@ platforms:
   - chrome
 description: Installed extensions (plugins) for [Chromium-based](https://en.wikipedia.org/wiki/Chromium_(web_browser)) browsers, including [Google Chrome](https://en.wikipedia.org/wiki/Google_Chrome), [Edge](https://en.wikipedia.org/wiki/Microsoft_Edge), [Brave](https://en.wikipedia.org/wiki/Brave_(web_browser)), [Opera](https://en.wikipedia.org/wiki/Opera_(web_browser)), and [Yandex](https://en.wikipedia.org/wiki/Yandex_Browser).
 examples: >-
+  ```
+
+  SELECT * FROM users CROSS JOIN chrome_extensions USING (uid);
+
+  ```
+
   List Chrome extensions by user and profile which have full access to HTTPS
   browsing.
 
@@ -14,10 +20,9 @@ examples: >-
   SELECT u.username, ce.name, ce.description, ce.version, ce.profile, ce.permissions FROM users u CROSS JOIN chrome_extensions ce USING (uid) WHERE ce.permissions LIKE '%%https://*/*%%';
 
   ```
-notes: Querying this table requires joining against the `users` table.
+notes: Querying this table requires joining against the `users` table. [Learn more](https://fleetdm.com/guides/osquery-consider-joining-against-the-users-table)
 columns:
   - name: uid
-    requires_user_context: true
     platforms: 
       - darwin
       - windows

--- a/schema/tables/chrome_extensions.yml
+++ b/schema/tables/chrome_extensions.yml
@@ -20,7 +20,10 @@ examples: >-
   SELECT u.username, ce.name, ce.description, ce.version, ce.profile, ce.permissions FROM users u CROSS JOIN chrome_extensions ce USING (uid) WHERE ce.permissions LIKE '%%https://*/*%%';
 
   ```
-notes: Querying this table requires joining against the `users` table. [Learn more](https://fleetdm.com/guides/osquery-consider-joining-against-the-users-table)
+notes: |
+  Querying this table requires joining against the `users` table. [Learn more](https://fleetdm.com/guides/osquery-consider-joining-against-the-users-table)
+
+  On ChromeOS, this table requires the [fleetd Chrome extension](https://fleetdm.com/docs/using-fleet/chromeos).
 columns:
   - name: uid
     platforms: 
@@ -112,5 +115,3 @@ columns:
       - darwin
       - windows
       - linux
-notes: |
-  - On ChromeOS, this table requires the [fleetd Chrome extension](https://fleetdm.com/docs/using-fleet/chromeos).

--- a/schema/tables/crashes.yml
+++ b/schema/tables/crashes.yml
@@ -8,6 +8,7 @@ examples: >-
   SELECT crash_path, identifier, responsible, exception_type FROM crashes;
 
   ```
+notes: Querying this table requires joining against the `users` table.
 columns:
   - name: uid
     requires_user_context: true

--- a/schema/tables/crashes.yml
+++ b/schema/tables/crashes.yml
@@ -1,14 +1,10 @@
 name: crashes
 examples: >-
-  See software responsible for crashes. This can be useful to detect what the
-  most problematic software in your environment is.
-
   ```
 
-  SELECT crash_path, identifier, responsible, exception_type FROM crashes;
+  SELECT * FROM users CROSS JOIN crashes USING (uid);
 
   ```
-notes: Querying this table requires joining against the `users` table.
+notes: Querying this table requires joining against the `users` table. [Learn more](https://fleetdm.com/guides/osquery-consider-joining-against-the-users-table)
 columns:
   - name: uid
-    requires_user_context: true

--- a/schema/tables/firefox_addons.yml
+++ b/schema/tables/firefox_addons.yml
@@ -1,6 +1,12 @@
 name: firefox_addons
 description: Firefox browser [add-ons](https://addons.mozilla.org/en-US/firefox/) (plugins).
 examples: >-
+  ```
+
+  SELECT * FROM users CROSS JOIN firefox_addons USING (uid);
+
+  ```
+
   See Firefox extensions by user as well as information about their creator and
   automatic update status.
 
@@ -9,7 +15,6 @@ examples: >-
   SELECT u.username, f.identifier, f.creator, f.description, f.version, f.autoupdate FROM users u CROSS JOIN firefox_addons f USING (uid) WHERE f.active='1';
 
   ```
-notes: Querying this table requires joining against the `users` table.
+notes: Querying this table requires joining against the `users` table. [Learn more](https://fleetdm.com/guides/osquery-consider-joining-against-the-users-table)
 columns:
   - name: uid
-    requires_user_context: true

--- a/schema/tables/firefox_addons.yml
+++ b/schema/tables/firefox_addons.yml
@@ -9,6 +9,7 @@ examples: >-
   SELECT u.username, f.identifier, f.creator, f.description, f.version, f.autoupdate FROM users u CROSS JOIN firefox_addons f USING (uid) WHERE f.active='1';
 
   ```
+notes: Querying this table requires joining against the `users` table.
 columns:
   - name: uid
     requires_user_context: true

--- a/schema/tables/known_hosts.yml
+++ b/schema/tables/known_hosts.yml
@@ -1,4 +1,12 @@
 name: known_hosts
 columns:
   - name: uid
-    requires_user_context: true
+examples: >-
+  ```
+
+  SELECT * FROM users CROSS JOIN known_hosts USING (uid);
+
+  ```
+
+notes: >-
+  - Querying this table requires joining against the `users` table. [Learn more](https://fleetdm.com/guides/osquery-consider-joining-against-the-users-table)

--- a/schema/tables/preferences.yml
+++ b/schema/tables/preferences.yml
@@ -9,6 +9,7 @@ examples: >-
 
   ```
 notes: >-
+  - Querying this table requires joining against the `users` table.
   - The `value` column will be empty for keys that contain binary data.
 columns:
   - name: username

--- a/schema/tables/preferences.yml
+++ b/schema/tables/preferences.yml
@@ -1,16 +1,13 @@
 name: preferences
 examples: >-
   This table reads a huge amount of preferences, including on third-party apps.
-  This query will show how many users are enrolled to TouchID.
-
   ```
 
-  SELECT * FROM preferences WHERE subkey='dailyEvents/2/enrolledUserCount';
+  SELECT * FROM users CROSS JOIN preferences USING (username);
 
   ```
 notes: >-
-  - Querying this table requires joining against the `users` table.
+  - Querying this table requires joining against the `users` table. [Learn more](https://fleetdm.com/guides/osquery-consider-joining-against-the-users-table)
   - The `value` column will be empty for keys that contain binary data.
 columns:
   - name: username
-    requires_user_context: true

--- a/schema/tables/preferences.yml
+++ b/schema/tables/preferences.yml
@@ -1,6 +1,7 @@
 name: preferences
 examples: >-
   This table reads a huge amount of preferences, including on third-party apps.
+  
   ```
 
   SELECT * FROM users CROSS JOIN preferences USING (username);
@@ -8,6 +9,7 @@ examples: >-
   ```
 notes: >-
   - Querying this table requires joining against the `users` table. [Learn more](https://fleetdm.com/guides/osquery-consider-joining-against-the-users-table)
+  
   - The `value` column will be empty for keys that contain binary data.
 columns:
   - name: username

--- a/schema/tables/safari_extensions.yml
+++ b/schema/tables/safari_extensions.yml
@@ -2,7 +2,12 @@ name: safari_extensions
 description: Installed Safari browser extensions (plugins).
 columns:
   - name: uid
-    requires_user_context: true
+examples: >-
+  ```
+
+  SELECT * FROM users CROSS JOIN safari_extensions USING (uid);
+
+  ```
 notes: >-
-  - Querying this table requires joining against the `users` table.
+  - Querying this table requires joining against the `users` table. [Learn more](https://fleetdm.com/guides/osquery-consider-joining-against-the-users-table)
   - Includes installed extensions for all system users.

--- a/schema/tables/safari_extensions.yml
+++ b/schema/tables/safari_extensions.yml
@@ -4,4 +4,5 @@ columns:
   - name: uid
     requires_user_context: true
 notes: >-
+  - Querying this table requires joining against the `users` table.
   - Includes installed extensions for all system users.

--- a/schema/tables/shell_history.yml
+++ b/schema/tables/shell_history.yml
@@ -1,5 +1,11 @@
 name: shell_history
 examples: >-
+  ```
+
+  SELECT * FROM users CROSS JOIN shell_history USING (uid);
+
+  ```
+
   See command line executions and related timestamps. Useful for threat hunting
   when a device is suspected of being compromised.
 
@@ -10,4 +16,7 @@ examples: >-
   ```
 columns:
   - name: uid
-    requires_user_context: true
+  
+
+notes: >-
+  - Querying this table requires joining against the `users` table. [Learn more](https://fleetdm.com/guides/osquery-consider-joining-against-the-users-table)

--- a/schema/tables/ssh_configs.yml
+++ b/schema/tables/ssh_configs.yml
@@ -1,5 +1,11 @@
 name: ssh_configs
 examples: >-
+  ```
+
+  SELECT * FROM users CROSS JOIN ssh_configs USING (uid);
+
+  ```
+
   Identify SSH clients configured to send their locales to the server.
   
   ```
@@ -9,4 +15,4 @@ examples: >-
   ```
 columns:
   - name: uid
-    requires_user_context: true
+notes: Querying this table requires joining against the `users` table. [Learn more](https://fleetdm.com/guides/osquery-consider-joining-against-the-users-table)

--- a/schema/tables/user_ssh_keys.yml
+++ b/schema/tables/user_ssh_keys.yml
@@ -1,5 +1,11 @@
 name: user_ssh_keys
 examples: >-
+  ```
+
+  SELECT * FROM users CROSS JOIN user_ssh_keys USING (uid);
+
+  ```
+
   Identify SSH keys stored in clear text in user directories
   
   ```
@@ -12,4 +18,4 @@ columns:
     platforms:
       - linux
   - name: uid
-    requires_user_context: true
+notes: Querying this table requires joining against the `users` table. [Learn more](https://fleetdm.com/guides/osquery-consider-joining-against-the-users-table)

--- a/schema/tables/vscode_extensions.yml
+++ b/schema/tables/vscode_extensions.yml
@@ -1,6 +1,13 @@
 name: vscode_extensions
 description: Installed extensions for [Visual Studio (VS) Code](https://code.visualstudio.com/). 
 examples: >-
+  ```
+
+  SELECT * FROM users CROSS JOIN vscode_extensions USING (uid);
+
+  ```
+
+
   List the name, publisher, and version of the Visual Studio (VS) Code extensions installed on hosts.
   
   ```
@@ -8,7 +15,7 @@ examples: >-
   SELECT extension.name, extension.publisher, extension.version FROM users JOIN vscode_extensions extension USING (uid);
 
   ```
-notes: Querying this table requires joining against the `users` table.
+notes: Querying this table requires joining against the `users` table. [Learn more](https://fleetdm.com/guides/osquery-consider-joining-against-the-users-table)
 columns:
 - name: name
   description: Extension Name


### PR DESCRIPTION
For #16784.

These tables require joining against `users`:
+ `chrome_extension_content_scripts`
+ `chrome_extensions`
+ `firefox_addons`
+ `vscode_extensions`
+ `browser_plugins`
+ `crashes`
+ `preferences`
+ `safari_extensions`
+ `ssh_configs`
+ `user_ssh_keys`
+ `authorized_keys`
+ `known_hosts`
+ `shell_history`