### PR TITLE
Update workstations-canary.yml

### DIFF
--- a/it-and-security/teams/workstations-canary.yml
+++ b/it-and-security/teams/workstations-canary.yml
@@ -100,12 +100,6 @@ policies:
   - path: ../lib/macos-device-health.policies.yml
   - path: ../lib/windows-device-health.policies.yml
   - path: ../lib/linux-device-health.policies.yml
-  - name: chromeOS/macOS - Screenlock enabled
-    query: SELECT 1 FROM screenlock WHERE enabled = 1;
-    critical: false
-    description: ""
-    resolution: ""
-    platform: darwin,chrome
 queries:
   - path: ../lib/collect-failed-login-attempts.queries.yml
   - path: ../lib/collect-usb-devices.queries.yml


### PR DESCRIPTION
- Remove "chromeOS/macOS - Screenlock enabled"
  - We already check screen lock on macOS w/ "Enable screen saver after 20 minutes" policy
  - It also fails on my macOS host ([Noah Talerman's MacBook Pro](https://dogfood.fleetdm.com/hosts/545)). Maybe because osquery is running as root? From the [`screenlock` table docs](https://fleetdm.com/tables/screenlock):
    - ![Screenshot 2024-04-04 at 11 04 17 AM](https://github.com/fleetdm/fleet/assets/47070608/9197a01c-0df2-4e1f-a4de-8113d878385b)
