### PR TITLE
Use osqueryd edge on servers canary team

### DIFF
--- a/it-and-security/lib/servers-canary.agent-options.yml
+++ b/it-and-security/lib/servers-canary.agent-options.yml
@@ -1,0 +1,16 @@
+config:
+  decorators:
+    load:
+      - SELECT uuid AS host_uuid FROM system_info;
+      - SELECT hostname AS hostname FROM system_info;
+  options:
+    disable_distributed: false
+    distributed_interval: 10
+    distributed_plugin: tls
+    distributed_tls_max_attempts: 3
+    logger_tls_endpoint: /api/osquery/log
+    logger_tls_period: 10
+    pack_delimiter: /
+update_channels:
+  # We want to use these hosts to smoke test osquery releases.
+  osqueryd: edge

--- a/it-and-security/teams/servers-canary.yml
+++ b/it-and-security/teams/servers-canary.yml
@@ -9,7 +9,7 @@ team_settings:
   secrets:
     - secret: $DOGFOOD_SERVERS_CANARY_ENROLL_SECRET
 agent_options:
-  path: ../lib/servers.agent-options.yml
+  path: ../lib/servers-canary.agent-options.yml
 controls:
   enable_disk_encryption: false
   macos_settings:


### PR DESCRIPTION
I copied `it-and-security/lib/servers.agent-options.yml` and added the `update_channels` key.