### PR TITLE
Fix panic due to nil calendar config.

### DIFF
--- a/changes/18065-calendar-config-panic
+++ b/changes/18065-calendar-config-panic
@@ -1,0 +1,1 @@
+Fixing potential server panic when events are created with calendar integration, but then global calendar integration is disabled.

--- a/server/cron/calendar_cron.go
+++ b/server/cron/calendar_cron.go
@@ -671,7 +671,10 @@ func deleteCalendarEventsInParallel(
 			go func() {
 				defer wg.Done()
 				for calEvent := range calendarEventCh {
-					userCalendar := createUserCalendarFromConfig(ctx, calendarConfig, logger)
+					var userCalendar fleet.UserCalendar
+					if calendarConfig != nil {
+						userCalendar = createUserCalendarFromConfig(ctx, calendarConfig, logger)
+					}
 					if err := deleteCalendarEvent(ctx, ds, userCalendar, calEvent); err != nil {
 						level.Error(logger).Log("msg", "delete user calendar event", "err", err)
 						continue


### PR DESCRIPTION
#18063

Fixing potential server panic when events are created with calendar integration, but then global calendar integration is disabled.

Could not do a PR directly from [fleet-v4.48.0](https://github.com/fleetdm/fleet/releases/tag/fleet-v4.48.0) due to merge conflicts.

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [ ] Added/updated tests
- [x] Manual QA for all new/changed functionality
