### PR TITLE
Tools: Choose Enrollment VM base image using environment variable

### DIFF
--- a/tools/mdm/apple/macos-vm-auto-enroll/README.md
+++ b/tools/mdm/apple/macos-vm-auto-enroll/README.md
@@ -9,6 +9,7 @@ The script takes no arguments, but can be configured through three environment v
 - `FLEET_ENROLL_SECRET` (required) The fleet enrollment secret
 - `FLEET_URL` (required) The fleet base url
 - `MACOS_ENROLLMENT_VM_NAME` (optional) The name of the VM. If nothing is specified, the default name is `enrollment-test`.
+- `MACOS_ENROLLMENT_VM_IMAGE` (optional) The image to use for the VM. If nothing is specified, the default image is `ghcr.io/cirruslabs/macos-sonoma-base:latest`
 
 The entire process from the generation of the `pkg` file to the installation is automated. The only part that requires user intervention is installing the MDM profile.
 

--- a/tools/mdm/apple/macos-vm-auto-enroll/macos-vm-auto-enroll.sh
+++ b/tools/mdm/apple/macos-vm-auto-enroll/macos-vm-auto-enroll.sh
@@ -6,9 +6,10 @@ set -m
 # Fleet enroll secret placed in $FLEET_ENROLL_SECRET
 # Fleet URL placed in $FLEET_URL
 # Optional VM name in $MACOS_ENROLLMENT_VM_NAME
+# Optional VM image in $MACOS_ENROLLMENT_VM_IMAGE
 
 vm_name="${MACOS_ENROLLMENT_VM_NAME:-enrollment-test}"
-image_name="ghcr.io/cirruslabs/macos-sonoma-base:latest"
+image_name="${MACOS_ENROLLMENT_VM_IMAGE:-ghcr.io/cirruslabs/macos-sonoma-base:latest}"
 
 alias ssh_cmd="sshpass -p admin ssh -o \"StrictHostKeyChecking no\" admin@\$(tart ip $vm_name)"
 alias ssh_interactive_cmd="sshpass -p admin ssh -o \"StrictHostKeyChecking no\" -t admin@\$(tart ip $vm_name)"

--- a/tools/mdm/apple/macos-vm-auto-enroll/macos-vm-auto-enroll.sh
+++ b/tools/mdm/apple/macos-vm-auto-enroll/macos-vm-auto-enroll.sh
@@ -7,6 +7,9 @@ set -m
 # Fleet URL placed in $FLEET_URL
 # Optional VM name in $MACOS_ENROLLMENT_VM_NAME
 # Optional VM image in $MACOS_ENROLLMENT_VM_IMAGE
+#  For others see https://tart.run/quick-start/
+#  - ghcr.io/cirruslabs/macos-ventura-base:latest
+#  - ghcr.io/cirruslabs/macos-monterey-base:latest
 
 vm_name="${MACOS_ENROLLMENT_VM_NAME:-enrollment-test}"
 image_name="${MACOS_ENROLLMENT_VM_IMAGE:-ghcr.io/cirruslabs/macos-sonoma-base:latest}"


### PR DESCRIPTION
Good for running out older versions of macOS during an semi-automated test