### PR TITLE
Website: update personalization

### DIFF
--- a/website/api/hooks/custom/index.js
+++ b/website/api/hooks/custom/index.js
@@ -156,6 +156,9 @@ will be disabled and/or hidden in the UI.
               // FUTURE: Auto-redirect without the querystring after absorbtion to make it prettier in the URL bar.
               // (except this probably messes up analytics so before doing that, figure out how to solve that problem)
             }//ﬁ
+            if(req.param('utm_content') === 'clear'){
+              req.session.primaryBuyingSituation = undefined;
+            }
             if (req.method === 'GET' || req.method === 'HEAD') {
               // Include information about the primary buying situation
               // If set in the session (e.g. from an ad), use the primary buying situation for personalization.
@@ -279,7 +282,6 @@ will be disabled and/or hidden in the UI.
               // Include information about the primary buying situation
               // If set in the session (e.g. from an ad), use the primary buying situation for personalization.
               res.locals.primaryBuyingSituation = req.session.primaryBuyingSituation || undefined;
-
             }//ﬁ
 
             return next();

--- a/website/assets/js/pages/pricing.page.js
+++ b/website/assets/js/pages/pricing.page.js
@@ -12,7 +12,13 @@ parasails.registerPage('pricing', {
   //  ║  ║╠╣ ║╣ ║  ╚╦╝║  ║  ║╣
   //  ╩═╝╩╚  ╚═╝╚═╝ ╩ ╚═╝╩═╝╚═╝
   beforeMount: function() {
-    //…
+    if(this.primaryBuyingSituation){
+      if(['eo-security', 'vm'].includes(this.primaryBuyingSituation)){
+        this.pricingMode = 'Security';
+      } else {
+        this.pricingMode = 'IT';
+      }
+    }
   },
   mounted: async function(){
     // Tooltips for desktop users are opened by a user hovering their cursor over them.

--- a/website/assets/styles/pages/support.less
+++ b/website/assets/styles/pages/support.less
@@ -73,6 +73,7 @@
 
 
   [purpose='community-cards'] {
+    margin-bottom: 30px;
     [purpose='support-card'] {
       width: 100%;
       height: 200px;
@@ -91,7 +92,7 @@
       width: 50%;
     }
 
-    margin-bottom: 30px;
+
   }
 
   @media (min-width: 1201px) {
@@ -104,7 +105,6 @@
 
     [purpose='support-cards'] {
       flex-direction: row;
-      margin-bottom: 50px;
       max-width: 1120px;
       [purpose='support-row'] {
         flex-direction: row;
@@ -119,6 +119,7 @@
     }
 
     [purpose='community-cards'] {
+      margin-bottom: 50px;
       [purpose='support-card'] {
         width: 384px;
         height: 178px;
@@ -151,9 +152,6 @@
     }
   }
   @media (max-width: 991px) {
-    [purpose='support-card'] {
-      margin-bottom: 30px;
-    }
     [purpose='support-cards'] {
       [purpose='support-card'] {
         height: 221px;

--- a/website/config/routes.js
+++ b/website/config/routes.js
@@ -263,7 +263,7 @@ module.exports.routes = {
     action: 'view-support',
     locals: {
       pageTitleForMeta: 'Support | Fleet',
-      pageDescriptionForMeta: 'Ask a question, chat with other engineers, or get in touch with the Fleet team.',
+      pageDescriptionForMeta: 'Ask a question, chat with engineers, or get in touch with the Fleet team.',
       currentSection: 'documentation',
     }
   },

--- a/website/config/routes.js
+++ b/website/config/routes.js
@@ -238,7 +238,7 @@ module.exports.routes = {
     action: 'view-device-management',
     locals: {
       pageTitleForMeta: 'Device management (MDM) | Fleet',
-      pageDescriptionForMeta: 'Configure your devices with sensible defaults, or customize MDM features exactly how you want. Manage your IT infrastructure in any browser or use git to make changes as code.',
+      pageDescriptionForMeta: 'Manage your devices in any browser or use git to make changes as code.',
       currentSection: 'platform',
     }
   },
@@ -247,7 +247,7 @@ module.exports.routes = {
     action: 'view-endpoint-ops',
     locals: {
       pageTitleForMeta: 'Endpoint ops | Fleet',
-      pageDescriptionForMeta: 'Simplify your security tooling, ship data to any platform, and pulse check anything with Fleet.',
+      pageDescriptionForMeta: 'Pulse check anything, build reports, and ship data to any platform with Fleet.',
     }
   },
 
@@ -255,7 +255,7 @@ module.exports.routes = {
     action: 'view-vulnerability-management',
     locals: {
       pageTitleForMeta: 'Vulnerability management | Fleet',
-      pageDescriptionForMeta: 'Instant, lightweight visibility down to the chipset of any endpoint. Consolidate your security stack and build the vulnerability program you actually want with Fleet.',
+      pageDescriptionForMeta: 'Report CVEs, software inventory, security posture, and other risks down to the chipset of any endpoint with Fleet.',
     }
   },
 
@@ -283,7 +283,7 @@ module.exports.routes = {
       hideFooterLinks: true,
       hideGetStartedButton: true,
       pageTitleForMeta: 'Start | Fleet',
-      pageDescriptionForMeta: 'Get Started with Fleet. Spin up a local demo or get your premium license key.',
+      pageDescriptionForMeta: 'Get Started with Fleet. Spin up a local demo or get your Premium license key.',
     }
   },
 

--- a/website/views/pages/contact.ejs
+++ b/website/views/pages/contact.ejs
@@ -79,8 +79,8 @@
             <div class="selectbox">
             <select class="form-control" id="primaryBuyingSituation" name="primaryBuyingSituation" :class="[formErrors.primaryBuyingSituation ? 'is-invalid' : '']" v-model="formData.primaryBuyingSituation">
               <option disabled hidden value="undefined">Choose an option</option>
-              <option value="eo-security">Endpoint operations for security engineers</option>
-              <option value="eo-it">Endpoint operations for IT admins</option>
+              <option value="eo-security">Endpoint operations for security engineering</option>
+              <option value="eo-it">Endpoint ops for identity engineers and IT admins</option>
               <option value="mdm">Device management (MDM)</option>
               <option value="vm">Vulnerability management</option>
             </select>
@@ -90,7 +90,11 @@
          <div class="form-group">
            <label for="number-of-hosts">How many <%= primaryBuyingSituation === 'mdm' ? 'devices' : 'hosts' %> do you have? *</label>
            <input class="form-control" id="number-of-hosts" name="number-of-hosts" type="number" :class="[formErrors.numberOfHosts ? 'is-invalid' : '']" min="1" v-model.trim="formData.numberOfHosts">
-           <p purpose="devices-note" class="mt-3 mb-0">Includes computers, servers, containers, and other hosts.</p>
+           <p purpose="devices-note" class="mt-3 mb-0" v-if="!primaryBuyingSituation">Includes computers, servers, containers, and other hosts.</p>
+           <p purpose="devices-note" class="mt-3 mb-0" v-if="primaryBuyingSituation === 'eo-security'">Includes servers, containers, workstations, and other hosts.</p>
+           <p purpose="devices-note" class="mt-3 mb-0" v-if="primaryBuyingSituation === 'eo-it'">Includes macOS, Windows, Linux workstations, Chromebooks, servers, and other hosts.</p>
+           <p purpose="devices-note" class="mt-3 mb-0" v-if="primaryBuyingSituation === 'vm'">Includes computers, servers, OT/ICS, containers, and other hosts.</p>
+           <p purpose="devices-note" class="mt-3 mb-0" v-if="primaryBuyingSituation === 'mdm'">Includes macOS, Windows, and most flavors of Linux.</p>
            <div class="invalid-feedback" v-if="formErrors.numberOfHosts">Please enter a number of <%= primaryBuyingSituation === 'mdm' ? 'devices' : 'hosts' %></div>
          </div>
          <cloud-error v-if="cloudError && cloudError === 'invalidEmailDomain'">

--- a/website/views/pages/device-management.ejs
+++ b/website/views/pages/device-management.ejs
@@ -195,7 +195,7 @@
     <div purpose="tweets-container" class="container-fluid px-md-0 pb-0 d-flex flex-column justify-content-center">
       <div purpose="section-heading" class="mx-auto text-center">
         <h4>Who else uses Fleet?</h4>
-        <h2>Empowering security and IT teams, globally</h2>
+        <h2>Empowering <%= ['vm', 'eo-security'].includes(primaryBuyingSituation) ? 'security and IT' : 'IT' %> teams, globally</h2>
       </div>
     </div>
 

--- a/website/views/pages/endpoint-ops.ejs
+++ b/website/views/pages/endpoint-ops.ejs
@@ -183,7 +183,7 @@
     <div purpose="tweets-container" class="container-fluid px-md-0 pb-0 d-flex flex-column justify-content-center">
       <div purpose="section-heading" class="mx-auto text-center">
         <h4>Who else uses Fleet?</h4>
-        <h3>Empowering security and IT teams, globally</h3>
+        <h3>Empowering <%= ['mdm', 'eo-it'].includes(primaryBuyingSituation) ? 'IT and security' : 'security and IT' %> teams, globally</h3>
       </div>
     </div>
 

--- a/website/views/pages/query-library.ejs
+++ b/website/views/pages/query-library.ejs
@@ -2,7 +2,10 @@
 
   <div class="d-flex justify-content-center">
     <div class="container justify-content-center library">
-      <h2 class="mb-3">Device health checks</h2>
+      <h2 class="mb-3">
+        <%= ['eo-it', 'mdm'].includes(primaryBuyingSituation) ? 'Device health checks' : 'Built-in queries' %>
+
+      </h2>
       <p class="pb-3 description">Fleet's standard query library includes a growing collection of useful queries for organizations deploying Fleet and osquery. Want to add your own query? Please contribute <a target="_blank" href="https://github.com/fleetdm/fleet/edit/main/docs/01-Using-Fleet/standard-query-library/standard-query-library.yml">over on GitHub</a>.</p>
       <div class="p-0 m-0">
         <div class="d-md-none">

--- a/website/views/pages/support.ejs
+++ b/website/views/pages/support.ejs
@@ -1,12 +1,50 @@
 <div id="support" v-cloak>
   <div purpose="page-container" class="container">
+
+    <div purpose="page-title" class="mx-auto">
+      <h1>Ask the community</h1>
+      <p>Fleet has an active open-source community of kind and helpful people. If you have a question about something that isn't in the documentation, we hang out in:</p>
+      <%primaryBuyingSituation%>
+    </div>
+    <div purpose="community-cards" class="d-flex justify-content-center flex-sm-row flex-column">
+      <a href="https://chat.osquery.io/c/fleet" target="_blank" class="<%= primaryBuyingSituation === 'mdm' ? 'd-none' : 'd-flex'%>">
+        <div purpose="support-card" class="card d-flex justify-content-center">
+          <div class="d-flex flex-row align-items-center">
+            <img alt="Osquery logo" src="/images/logo-osquery-48x48@2x.png">
+            <h3>Osquery Slack</h3>
+          </div>
+          <p><%= primaryBuyingSituation === 'eo-it' ? 'Chat about IT visibility, secripting, access, and identity.' :
+                primaryBuyingSituation === 'eo-security' ? 'Chat securing servers, laptops, and more.' :
+                primaryBuyingSituation === 'vm' ? 'Chat about the future of vulnerability management, OT/ICS, cybersecurity, and more.' :
+                'Chat about using Fleet to secure servers, laptops, and more'
+              %>
+          </p>
+        </div>
+      </a>
+      <a href="https://macadmins.org" target="_blank" class="<%= primaryBuyingSituation === 'mdm' || !primaryBuyingSituation ? 'd-flex' : 'd-none' %>">
+        <div purpose="support-card" class="card d-flex justify-content-center" >
+          <div class="d-flex flex-row align-items-center">
+            <img alt="Macadmins logo" src="/images/logo-macadmins-48x48@2x.png">
+            <h3>MacAdmins Slack</h3>
+          </div>
+          <p>Chat about using Fleet to manage devices.</p>
+        </div>
+      </a>
+    </div>
     <div purpose="page-title" class="mx-auto">
       <h1>Support</h1>
-      <p>Ask a question, chat with other engineers, or get in touch with the Fleet team.</p>
+      <p>Ask a question, chat with engineers, or get in touch with the Fleet team.</p>
     </div>
+
     <div purpose="support-cards" class="d-flex mx-auto justify-content-center">
       <div purpose="support-row" class="d-flex">
-
+        <a href="/handbook/company/communications#customer-support-service-level-agreements-slas">
+          <div purpose="support-card" class="card d-flex justify-content-center">
+            <img alt="Premium support" src="/images/icon-premium-support-64x64@2x.png">
+            <h3>Premium support</h3>
+            <p>Dedicated support from the Fleet team.</p>
+          </div>
+        </a>
         <a href="https://github.com/fleetdm/fleet/issues/new?assignees=&labels=bug%2C%3Areproduce&projects=&template=bug-report.md&title=" target="_blank">
           <div purpose="support-card" class="card d-flex justify-content-center">
             <img alt="Bug report" src="/images/icon-bug-64x64@2x.png">
@@ -14,19 +52,15 @@
             <p>Report a bug to help us improve.</p>
           </div>
         </a>
-
+      </div>
+      <div purpose="support-row" class="d-flex">
         <a href="https://github.com/fleetdm/fleet/issues/new?assignees=&labels=~customer+request&projects=&template=feature-request.md&title=" target="_blank">
           <div purpose="support-card" class="card d-flex justify-content-center">
             <img alt="Suggestions" src="/images/icon-suggestion-64x64@2x.png" class="mx-auto mx-sm-0">
-            <h3>Suggestions</h3>
+            <h3>Suggest a feature</h3>
             <p>Propose a new feature or enhancement in Fleet.</p>
           </div>
         </a>
-
-      </div>
-
-      <div purpose="support-row" class="d-flex">
-
         <a href="/contact">
           <div purpose="support-card" class="card d-flex justify-content-center" >
             <img alt="Ask us anything" src="/images/icon-ask-anything-64x64@2x.png">
@@ -34,41 +68,9 @@
             <p>Can’t find what you’re looking for? Get in touch.</p>
           </div>
         </a>
-
-        <a href="/handbook/company/communications#customer-support-service-level-agreements-slas">
-          <div purpose="support-card" class="card d-flex justify-content-center">
-            <img alt="Premium support" src="/images/icon-premium-support-64x64@2x.png">
-            <h3>Premium support</h3>
-            <p>Dedicated Slack channel and support from the Fleet team.</p>
-          </div>
-        </a>
-
       </div>
     </div>
-    <div purpose="page-title" class="mx-auto">
-      <h1>Ask the community</h1>
-      <p>Fleet has an active open-source community of knowledgeable and helpful users. If you have a question about something that isn't in the documentation, try one of these places:</p>
-    </div>
-    <div purpose="community-cards" class="d-flex justify-content-center flex-sm-row flex-column">
-      <a href="https://chat.osquery.io/c/fleet" target="_blank" class="d-flex">
-        <div purpose="support-card" class="card d-flex justify-content-center">
-          <div class="d-flex flex-row align-items-center">
-            <img alt="Osquery logo" src="/images/logo-osquery-48x48@2x.png">
-            <h3>Osquery Slack</h3>
-          </div>
-          <p>Chat about using Fleet or osquery to secure servers, laptops, and more.</p>
-        </div>
-      </a>
-      <a href="https://macadmins.org" target="_blank" class="d-flex">
-        <div purpose="support-card" class="card d-flex justify-content-center" >
-          <div class="d-flex flex-row align-items-center">
-            <img alt="Macadmins logo" src="/images/logo-macadmins-48x48@2x.png">
-            <h3>MacAdmins Slack</h3>
-          </div>
-          <p>Chat about using Fleet to manage workstations.</p>
-        </div>
-      </a>
-    </div>
+
   </div>
 </div>
 <%- /* Expose server-rendered data as window.SAILS_LOCALS :: */ exposeLocalsToBrowser() %>

--- a/website/views/pages/vulnerability-management.ejs
+++ b/website/views/pages/vulnerability-management.ejs
@@ -131,7 +131,7 @@
     <div purpose="tweets-container" class="container-fluid px-md-0 pb-0 d-flex flex-column justify-content-center">
       <div purpose="section-heading" class="mx-auto text-center">
         <h4>Who else uses Fleet?</h4>
-        <h2>Empowering security and IT teams, globally</h2>
+        <h2>Empowering <%= ['mdm', 'eo-it'].includes(primaryBuyingSituation) ? 'security and IT' : 'security' %> teams, globally</h2>
       </div>
     </div>
 


### PR DESCRIPTION
Changes:
- updated the custom hook to support clearing the `primaryBuyingSituation` with a query string (`?utm_content=clear`)
- Updated the pricing page to pre-select a pricing table mode based on a user's `primaryBuyingSituation`
- reordered content on and updated the /support page to personalize/hide community slack links based on a user's `primaryBuyingSituation`
- Updated the meta description of the product category landing pages
- updated personalization based on `primaryBuyingSituation` on the  /contact page.
-  Updated the title of the /queries page based on the user's `primaryBuyingSituation`
- Added personalization to the product category landing pages.