### PR TITLE
Add redirects for calendar integration setup

### DIFF
--- a/website/config/routes.js
+++ b/website/config/routes.js
@@ -478,6 +478,10 @@ module.exports.routes = {
   'GET /learn-more-about/setup-assistant': '/docs/using-fleet/mdm-macos-setup-experience#macos-setup-assistant',
   'GET /learn-more-about/policy-automations': '/docs/using-fleet/automations',
   'GET /install-wine': 'https://github.com/fleetdm/fleet/blob/main/scripts/macos-install-wine.sh',
+  'GET /learn-more-about/creating-service-accounts': 'https://console.cloud.google.com/projectselector2/iam-admin/serviceaccounts/create?walkthrough_id=iam--create-service-account&pli=1#step_index=1',
+  'GET /learn-more-about/google-workspace-domains': 'https://admin.google.com/ac/domains/manage',
+  'GET /learn-more-about/domain-wide-delegation': 'https://admin.google.com/ac/owl/domainwidedelegation',
+  'GET /learn-more-about/enabling-calendar-api': 'https://console.cloud.google.com/apis/library/calendar-json.googleapis.com',
 
   // Sitemap
   // =============================================================================================================


### PR DESCRIPTION
Adds redirects used in the Fleet UI for [calendar integration setup](https://www.figma.com/file/p81nWodxL04YD7iNyr9xVa/%2317230-Fleet-in-your-calendar?type=design&node-id=362%3A3864&mode=design&t=p2gszo7V6sbbI2nF-1).