### PR TITLE
Website: Update /start questionnaire to update leads

### DIFF
--- a/website/assets/js/pages/start.page.js
+++ b/website/assets/js/pages/start.page.js
@@ -75,7 +75,7 @@ parasails.registerPage('start', {
     }
     // If this user has not completed the 'what are you using fleet for' step, and has a primaryBuyingSituation set by an ad. prefill the formData for this step.
     if(this.primaryBuyingSituation && _.isEmpty(this.formData['what-are-you-using-fleet-for'])){
-      this.formData['what-are-you-using-fleet-for'].primaryBuyingSituation = _.clone(this.primaryBuyingSituation);
+      this.formData['what-are-you-using-fleet-for'] = {primaryBuyingSituation: this.primaryBuyingSituation};
     }
   },
   mounted: async function() {


### PR DESCRIPTION

Changes: 
- Updated the `save-questionnaire-progress` to send a request to Zapier when a user completes the "What are you using Fleet for" step of the /start questionnaire.
