### PR TITLE
Website: update IDs and `currentSection` values of landing pages

### DIFF
--- a/website/assets/js/pages/device-management.page.js
+++ b/website/assets/js/pages/device-management.page.js
@@ -1,4 +1,4 @@
-parasails.registerPage('device-management', {
+parasails.registerPage('device-management-page', {
   //  ╦╔╗╔╦╔╦╗╦╔═╗╦    ╔═╗╔╦╗╔═╗╔╦╗╔═╗
   //  ║║║║║ ║ ║╠═╣║    ╚═╗ ║ ╠═╣ ║ ║╣
   //  ╩╝╚╝╩ ╩ ╩╩ ╩╩═╝  ╚═╝ ╩ ╩ ╩ ╩ ╚═╝

--- a/website/assets/js/pages/endpoint-ops.page.js
+++ b/website/assets/js/pages/endpoint-ops.page.js
@@ -1,4 +1,4 @@
-parasails.registerPage('endpoint-ops', {
+parasails.registerPage('endpoint-ops-page', {
   //  ╦╔╗╔╦╔╦╗╦╔═╗╦    ╔═╗╔╦╗╔═╗╔╦╗╔═╗
   //  ║║║║║ ║ ║╠═╣║    ╚═╗ ║ ╠═╣ ║ ║╣
   //  ╩╝╚╝╩ ╩ ╩╩ ╩╩═╝  ╚═╝ ╩ ╩ ╩ ╩ ╚═╝

--- a/website/assets/js/pages/vulnerability-management.page.js
+++ b/website/assets/js/pages/vulnerability-management.page.js
@@ -1,4 +1,4 @@
-parasails.registerPage('vulnerability-management', {
+parasails.registerPage('vulnerability-management-page', {
   //  ╦╔╗╔╦╔╦╗╦╔═╗╦    ╔═╗╔╦╗╔═╗╔╦╗╔═╗
   //  ║║║║║ ║ ║╠═╣║    ╚═╗ ║ ╠═╣ ║ ║╣
   //  ╩╝╚╝╩ ╩ ╩╩ ╩╩═╝  ╚═╝ ╩ ╩ ╩ ╩ ╚═╝

--- a/website/assets/styles/pages/device-management.less
+++ b/website/assets/styles/pages/device-management.less
@@ -1,4 +1,4 @@
-#device-management {
+#device-management-page {
   @heading-lineheight: 120%;
   @text-lineheight: 150%;
 

--- a/website/assets/styles/pages/endpoint-ops.less
+++ b/website/assets/styles/pages/endpoint-ops.less
@@ -1,4 +1,4 @@
-#endpoint-ops {
+#endpoint-ops-page {
   @heading-line-height: 120%;
   @text-line-height: 150%;
 

--- a/website/assets/styles/pages/vulnerability-management.less
+++ b/website/assets/styles/pages/vulnerability-management.less
@@ -1,4 +1,5 @@
 #vulnerability-management-page {
+  background: linear-gradient(180deg, #E8F1F6 0%, #FFF 8.76%);
   h1 {
     font-size: 56px;
     font-weight: 800;

--- a/website/assets/styles/pages/vulnerability-management.less
+++ b/website/assets/styles/pages/vulnerability-management.less
@@ -1,5 +1,4 @@
-#vulnerability-management {
-  background: linear-gradient(180deg, #E8F1F6 0%, #FFF 8.76%);
+#vulnerability-management-page {
   h1 {
     font-size: 56px;
     font-weight: 800;

--- a/website/config/routes.js
+++ b/website/config/routes.js
@@ -248,6 +248,7 @@ module.exports.routes = {
     locals: {
       pageTitleForMeta: 'Endpoint ops | Fleet',
       pageDescriptionForMeta: 'Pulse check anything, build reports, and ship data to any platform with Fleet.',
+      currentSection: 'platform',
     }
   },
 
@@ -256,6 +257,7 @@ module.exports.routes = {
     locals: {
       pageTitleForMeta: 'Vulnerability management | Fleet',
       pageDescriptionForMeta: 'Report CVEs, software inventory, security posture, and other risks down to the chipset of any endpoint with Fleet.',
+      currentSection: 'platform',
     }
   },
 

--- a/website/views/pages/device-management.ejs
+++ b/website/views/pages/device-management.ejs
@@ -1,4 +1,4 @@
-<div id="device-management" v-cloak>
+<div id="device-management-page" v-cloak>
   <div purpose="page-container">
     <div purpose="page-content" class="mx-auto">
       <div purpose="hero">

--- a/website/views/pages/endpoint-ops.ejs
+++ b/website/views/pages/endpoint-ops.ejs
@@ -1,4 +1,4 @@
-<div id="endpoint-ops" v-cloak>
+<div id="endpoint-ops-page" v-cloak>
   <div purpose="page-container">
     <div purpose="page-content" class="mx-auto">
     <div purpose="hero">

--- a/website/views/pages/vulnerability-management.ejs
+++ b/website/views/pages/vulnerability-management.ejs
@@ -1,4 +1,4 @@
-<div id="vulnerability-management" v-cloak>
+<div id="vulnerability-management-page" v-cloak>
   <div purpose="page-container">
     <div purpose="page-content" class="mx-auto">
     <div purpose="hero">


### PR DESCRIPTION
Closes: #18072

Changes:
- Updated the IDs of landing pages to prevent auto-generated IDs of Markdown headings having the same ID as pages.
- Added a `currentSection` value to the /endpoint-ops and /vulnerability-management pages.