### PR TITLE
use license.IsPremium to check for premium licenses

### DIFF
--- a/changes/license-comparison
+++ b/changes/license-comparison
@@ -1,0 +1,1 @@
+* Fixed license checks to allow migration and restoring DEP devices during trial

--- a/server/service/appconfig.go
+++ b/server/service/appconfig.go
@@ -821,7 +821,7 @@ func (svc *Service) validateMDM(
 		// TODO: Should we validate MDM configured on here too?
 
 		if mdm.MacOSMigration.Enable {
-			if license.Tier != fleet.TierPremium {
+			if !license.IsPremium() {
 				invalid.Append("macos_migration.enable", ErrMissingLicense.Error())
 				return nil
 			}

--- a/server/service/apple_mdm.go
+++ b/server/service/apple_mdm.go
@@ -3053,10 +3053,7 @@ func (svc *Service) maybeRestorePendingDEPHost(ctx context.Context, host *fleet.
 		return nil
 	}
 
-	license, ok := license.FromContext(ctx)
-	if !ok {
-		return ctxerr.New(ctx, "maybe restore pending DEP host: missing license")
-	} else if license.Tier != fleet.TierPremium {
+	if !license.IsPremium(ctx) {
 		// only premium tier supports DEP so nothing more to do
 		return nil
 	}


### PR DESCRIPTION
a license can be considered premium for trials, this replaces occurrences that used comparison operators to check for premium licences.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [ ] Added/updated tests
- [x] Manual QA for all new/changed functionality
