### PR TITLE
Website: update layout and personalization in website navigation

### DIFF
--- a/website/views/layouts/layout.ejs
+++ b/website/views/layouts/layout.ejs
@@ -104,11 +104,11 @@
     </script>
     <% /* Snitcher analytics code */ %>
     <script>
-      !function(i,s,o,g,r,a,m){i.Ip2cObject=o;i[o]||(i[o]=function(){
-      (i[o].q=i[o].q||[]).push(arguments)});i[o].l=+new Date;r=s.createElement(g);
-      a=s.getElementsByTagName(g)[0];r.src='//reveal.ip2c.net/8416878.js';
-      a.parentNode.insertBefore(r,a)}(window,document,'ip2c','script');
-      ip2c('verify', '8416878');
+        !function(s,n,i,t,c,h){s.SnitchObject=i;s[i]||(s[i]=function(){
+        (s[i].q=s[i].q||[]).push(arguments)});s[i].l=+new Date;c=n.createElement(t);
+        h=n.getElementsByTagName(t)[0];c.src='//snid.snitcher.com/8416878.js';
+        h.parentNode.insertBefore(c,h)}(window,document,'snid','script');
+        snid('verify', '8416878');
     </script>
     <% /* HubSpot Embed Code  */ %>
     <script type="text/javascript" id="hs-script-loader" async defer src="//js-na1.hs-scripts.com/24385138.js"></script>

--- a/website/views/layouts/layout.ejs
+++ b/website/views/layouts/layout.ejs
@@ -179,7 +179,7 @@
                   <div id="mobileNavbarToggleDocumentation" purpose="mobile-dropdown" class="collapse" data-parent="#mobileDropdowns">
                     <a purpose="mobile-dropdown-link" href="/docs">Docs</a>
                     <a purpose="mobile-dropdown-link" href="/docs/rest-api">REST API</a>
-                    <a purpose="mobile-dropdown-link" href="/queries">Built-in queries</a>
+                    <a purpose="mobile-dropdown-link" href="/queries"><%= ['eo-it', 'mdm'].includes(primaryBuyingSituation) ? 'Device health checks' : 'Built-in queries' %></a>
                     <a purpose="mobile-dropdown-link" href="/tables">Data tables</a>
                     <span>SUPPORT</span>
                     <div purpose="indented-mobile-links">
@@ -239,7 +239,7 @@
                   <div purpose="header-dropdown" class="dropdown-menu">
                     <a class="dropdown-item" href="/docs">Docs</a>
                     <a class="dropdown-item" href="/docs/rest-api">REST API</a>
-                    <a class="dropdown-item" href="/queries">Built-in queries</a>
+                    <a class="dropdown-item" href="/queries"><%= ['eo-it', 'mdm'].includes(primaryBuyingSituation) ? 'Device health checks' : 'Built-in queries' %></a>
                     <a class="dropdown-item" href="/tables">Data tables</a>
                     <span class="muted dropdown-header">SUPPORT</span>
                     <a class="dropdown-item" href="/support">Chat</a>

--- a/website/views/pages/docs/basic-documentation.ejs
+++ b/website/views/pages/docs/basic-documentation.ejs
@@ -114,7 +114,7 @@
               </ul>
               <ul class="px-0 mb-0 pt-3" purpose="mobile-docs-nav-other-links">
                 <li class="px-0 mb-3"><a href="/tables">Data tables</a></li>
-                <li class="px-0 mb-3"><a href="/queries">Built-in queries</a></li>
+                <li class="px-0 mb-3"><a href="/queries"><%= ['eo-it', 'mdm'].includes(primaryBuyingSituation) ? 'Device health checks' : 'Built-in queries' %></a></li>
                 <li class="px-0 mb-3"><a href="https://github.com/fleetdm/fleet/releases" target="_blank">Releases</a></li>
                 <li class="px-0 mb-3"><a href="/support">Support</a></li>
               </ul>
@@ -152,10 +152,10 @@
               </div>
             </li>
           </ul>
-          <a class="pt-4 pb-3" target="_blank" href="https://fleetdm.com/tables">Data tables</a>
-          <a class="pb-3" target="_blank" href="https://fleetdm.com/queries">Built-in queries</a>
+          <a class="pt-4 pb-3" target="_blank" href="/tables">Data tables</a>
+          <a class="pb-3" target="_blank" href="/queries"><%= ['eo-it', 'mdm'].includes(primaryBuyingSituation) ? 'Device health checks' : 'Built-in queries' %></a>
           <a class="pb-3" target="_blank" href="https://github.com/fleetdm/fleet/releases">Releases</a>
-          <a class="pb-3" target="_blank" href="https://fleetdm.com/support">Support</a>
+          <a class="pb-3" target="_blank" href="/support">Support</a>
           <div class="d-none d-lg-block" purpose="swag-cta" v-if="showSwagForm">
             <a class="d-flex align-items-center justify-content-center" href="https://kqphpqst851.typeform.com/to/ZfA3sOu0" target="_blank">
               <div class="d-flex flex-column align-items-center">


### PR DESCRIPTION
Changes:
- Updated the link to the queries page in the website header navigation menu and docs navigation menu to say "Device health checks" for users who have a primaryBuyingSituation set to `eo-it` or `mdm`.
- Updated links in the docs side nav to be relative
- Replaced the snitcher script tag with an updated version from snitcher's website.