### PR TITLE
Ignore pending DDM profiles when waiting to release a device

### DIFF
--- a/changes/18160-fix-release-device-with-pending-ddm-profiles
+++ b/changes/18160-fix-release-device-with-pending-ddm-profiles
@@ -1,0 +1,1 @@
+* Fixed an issue with automatic release of the device after setup when a DDM profile is pending.

--- a/server/worker/apple_mdm.go
+++ b/server/worker/apple_mdm.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/fleetdm/fleet/v4/server/contexts/ctxerr"
@@ -238,6 +239,13 @@ func (a *AppleMDM) runPostDEPReleaseDevice(ctx context.Context, args appleMDMArg
 		return ctxerr.Wrap(ctx, err, "failed to get host MDM profiles")
 	}
 	for _, prof := range profs {
+		// NOTE: DDM profiles (declarations) are ignored because while a device is
+		// awaiting to be released, it cannot process a DDM session (at least
+		// that's what we noticed during testing).
+		if strings.HasPrefix(prof.ProfileUUID, fleet.MDMAppleDeclarationUUIDPrefix) {
+			continue
+		}
+
 		// if it has any pending profiles, then its profiles are not done being
 		// delivered (installed or removed).
 		if prof.Status == nil || *prof.Status == fleet.MDMDeliveryPending {


### PR DESCRIPTION
#18160 

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [ ] Added/updated tests
- [x] Manual QA for all new/changed functionality
