### PR TITLE
Website: Update styles for "tip" block quotes in the handbook

### DIFF
--- a/website/assets/styles/pages/handbook/basic-handbook.less
+++ b/website/assets/styles/pages/handbook/basic-handbook.less
@@ -402,12 +402,9 @@
       padding: 16px;
       border-radius: 8px;
       display: flex;
-      div.d-block {
-        margin-left: 12px;
-      }
       img {
         display: flex;
-        margin-top: 4px;
+        margin: 4px 12px 0 0;
         height: 16px;
         width: 16px;
         padding: 0px;


### PR DESCRIPTION
Closes: #18161

Changes:
- Updated `basic-handbook.less` to fix a style issue with "tip" blockquotes