### PR TITLE
Generate NVD Feed with Vulncheck Data

### DIFF
--- a/cmd/cve/generate.go
+++ b/cmd/cve/generate.go
@@ -45,7 +45,7 @@ func main() {
 	}
 
 	// Sync the CVE files
-	if err := nvd.DownloadNVDCVEFeed(*dbDir, "", *debug, logger); err != nil {
+	if err := nvd.GenerateCVEFeeds(*dbDir, *debug, logger); err != nil {
 		panic(err)
 	}
 

--- a/cmd/cve/generate.go
+++ b/cmd/cve/generate.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"bufio"
 	"compress/gzip"
 	"crypto/sha256"
 	"encoding/hex"
@@ -15,6 +14,7 @@ import (
 	"time"
 
 	"github.com/fleetdm/fleet/v4/server/vulnerabilities/nvd"
+	nvdsync "github.com/fleetdm/fleet/v4/server/vulnerabilities/nvd/sync"
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 )
@@ -64,44 +64,13 @@ func main() {
 		fileNameRaw := filepath.Join(*dbDir, fileFmt(suffix, "json", ""))
 		fileName := filepath.Join(*dbDir, fileFmt(suffix, "json", "gz"))
 		metaName := filepath.Join(*dbDir, fileFmt(suffix, "meta", ""))
-		compressFile(fileNameRaw, fileName)
+		nvdsync.CompressFile(fileNameRaw, fileName)
 		createMetadata(fileName, metaName)
 	}
 
 	// Create modified and recent files
 	createEmptyFiles(*dbDir, "modified")
 	createEmptyFiles(*dbDir, "recent")
-}
-
-func compressFile(fileName string, newFileName string) {
-	// Read old file
-	file, err := os.Open(fileName)
-	if err != nil {
-		panic(err)
-	}
-	read := bufio.NewReader(file)
-	data, err := io.ReadAll(read)
-	if err != nil {
-		panic(err)
-	}
-	file.Close()
-
-	// Write new file
-	newFile, err := os.Create(newFileName)
-	if err != nil {
-		panic(err)
-	}
-	writer := gzip.NewWriter(newFile)
-	if _, err = writer.Write(data); err != nil {
-		panic(err)
-	}
-	writer.Close()
-	newFile.Close()
-
-	// Remove old file
-	if err = os.Remove(fileName); err != nil {
-		panic(err)
-	}
 }
 
 func createMetadata(fileName string, metaName string) {

--- a/cmd/cve/generate.go
+++ b/cmd/cve/generate.go
@@ -64,7 +64,10 @@ func main() {
 		fileNameRaw := filepath.Join(*dbDir, fileFmt(suffix, "json", ""))
 		fileName := filepath.Join(*dbDir, fileFmt(suffix, "json", "gz"))
 		metaName := filepath.Join(*dbDir, fileFmt(suffix, "meta", ""))
-		nvdsync.CompressFile(fileNameRaw, fileName)
+		err := nvdsync.CompressFile(fileNameRaw, fileName)
+		if err != nil {
+			panic(err)
+		}
 		createMetadata(fileName, metaName)
 	}
 

--- a/cmd/fleetctl/vulnerability_data_stream.go
+++ b/cmd/fleetctl/vulnerability_data_stream.go
@@ -59,7 +59,7 @@ Downloads (if needed) the data streams that can be used by the Fleet server to p
 			log(c, " Done\n")
 
 			log(c, "[-] Downloading NVD CVE feed...")
-			err = nvd.DownloadNVDCVEFeed(dir, "", false, klog.NewNopLogger())
+			err = nvd.DownloadCVEFeed(dir, "", false, klog.NewNopLogger())
 			if err != nil {
 				return err
 			}

--- a/cmd/fleetctl/vulnerability_data_stream_test.go
+++ b/cmd/fleetctl/vulnerability_data_stream_test.go
@@ -51,7 +51,7 @@ func TestVulnerabilityDataStream(t *testing.T) {
 	for y := 2008; y <= 2023; y++ {
 		files = append(
 			files,
-			fmt.Sprintf("nvdcve-1.1-%d.json", y),
+			fmt.Sprintf("nvdcve-1.1-%d.json.gz", y),
 		)
 	}
 	for _, file := range files {

--- a/server/vulnerabilities/nvd/cve.go
+++ b/server/vulnerabilities/nvd/cve.go
@@ -56,6 +56,27 @@ func DownloadNVDCVEFeed(vulnPath string, cveFeedPrefixURL string, debug bool, lo
 		return fmt.Errorf("download nvd cve feed: %w", err)
 	}
 
+	if err := cveSyncer.DoVulnCheck(context.Background()); err != nil {
+		return fmt.Errorf("download nvd cve feed: %w", err)
+	}
+
+	return nil
+}
+
+func DownloadVulnCheckFeed(vulnPath string, cveFeedPrefixURL string, debug bool, logger log.Logger) error {
+	cveSyncer, err := nvdsync.NewCVE(
+		vulnPath,
+		nvdsync.WithLogger(logger),
+		nvdsync.WithDebug(debug),
+	)
+	if err != nil {
+		return err
+	}
+
+	if err := cveSyncer.DoVulnCheck(context.Background()); err != nil {
+		return fmt.Errorf("download vulncheck cve feed: %w", err)
+	}
+
 	return nil
 }
 

--- a/server/vulnerabilities/nvd/cve.go
+++ b/server/vulnerabilities/nvd/cve.go
@@ -20,6 +20,7 @@ import (
 	"github.com/facebookincubator/nvdtools/cvefeed/nvd/schema"
 	"github.com/facebookincubator/nvdtools/providers/nvd"
 	"github.com/facebookincubator/nvdtools/wfn"
+	"github.com/fleetdm/fleet/v4/pkg/fleethttp"
 	"github.com/fleetdm/fleet/v4/server/contexts/ctxerr"
 	"github.com/fleetdm/fleet/v4/server/fleet"
 	"github.com/fleetdm/fleet/v4/server/ptr"
@@ -27,6 +28,11 @@ import (
 	"github.com/go-kit/log"
 	kitlog "github.com/go-kit/log"
 	"github.com/go-kit/log/level"
+	"github.com/google/go-github/v37/github"
+)
+
+const (
+	vulnRepo = "vulnerabilities"
 )
 
 // Define a regex pattern for semver (simplified)
@@ -35,14 +41,10 @@ var semverPattern = regexp.MustCompile(`^v?(\d+\.\d+\.\d+)`)
 // Define a regex pattern for splitting version strings into subparts
 var nonNumericPartRegex = regexp.MustCompile(`(\d+)(\D.*)`)
 
-// DownloadNVDCVEFeed downloads CVEs information from a CVE source.
-// If cveFeedPrefixURL is not set, the NVD API 2.0 is used to download CVE information to vulnPath.
-// If cveFeedPrefixURL is set, the CVE information will be downloaded assuming NVD's legacy feed format.
-func DownloadNVDCVEFeed(vulnPath string, cveFeedPrefixURL string, debug bool, logger log.Logger) error {
-	if cveFeedPrefixURL != "" {
-		return downloadNVDCVELegacy(vulnPath, cveFeedPrefixURL)
-	}
-
+// DownloadNVDCVEFeed downloads CVEs information from the NVD 2.0 API
+// and supplements the data with CPE information from the Vulncheck API.
+// This is used to download CVE information to vulnPath.
+func GenerateCVEFeeds(vulnPath string, debug bool, logger log.Logger) error {
 	cveSyncer, err := nvdsync.NewCVE(
 		vulnPath,
 		nvdsync.WithLogger(logger),
@@ -61,6 +63,59 @@ func DownloadNVDCVEFeed(vulnPath string, cveFeedPrefixURL string, debug bool, lo
 	}
 
 	return nil
+}
+
+func DownloadCVEFeed(vulnPath, cveFeedPrefixURL string, debug bool, logger log.Logger) error {
+	var err error
+
+	if cveFeedPrefixURL == "" {
+		cveFeedPrefixURL, err = getGitHubCVEAssetPath()
+		if err != nil {
+			return fmt.Errorf("get cve asset path: %w", err)
+		}
+	}
+
+	err = downloadNVDCVELegacy(vulnPath, cveFeedPrefixURL)
+	if err != nil {
+		return fmt.Errorf("download nvd cve feed: %w", err)
+	}
+
+	return nil
+}
+
+func getGitHubCVEAssetPath() (string, error) {
+	ghClient := github.NewClient(fleethttp.NewGithubClient())
+
+	releases, _, err := ghClient.Repositories.ListReleases(
+		context.Background(),
+		owner,
+		vulnRepo,
+		&github.ListOptions{Page: 0, PerPage: 10},
+	)
+	if err != nil {
+		return "", err
+	}
+
+	nvdregex := regexp.MustCompile(`cve-\d+`)
+	var found string
+
+	for _, release := range releases {
+		// Skip draft releases
+		if release.GetDraft() {
+			continue
+		}
+
+		if nvdregex.MatchString(release.GetTagName()) {
+			found = release.GetTagName()
+			break
+		}
+	}
+
+	if found == "" {
+		return "", errors.New("no CVE feed found")
+	}
+
+	return fmt.Sprintf("https://github.com/%s/%s/releases/download/%s/", owner, vulnRepo, found), nil
 }
 
 func downloadNVDCVELegacy(vulnPath string, cveFeedPrefixURL string) error {

--- a/server/vulnerabilities/nvd/cve.go
+++ b/server/vulnerabilities/nvd/cve.go
@@ -63,8 +63,6 @@ func DownloadNVDCVEFeed(vulnPath string, cveFeedPrefixURL string, debug bool, lo
 	return nil
 }
 
-
-
 func downloadNVDCVELegacy(vulnPath string, cveFeedPrefixURL string) error {
 	if cveFeedPrefixURL == "" {
 		return errors.New("missing cve_feed_prefix_url")

--- a/server/vulnerabilities/nvd/cve.go
+++ b/server/vulnerabilities/nvd/cve.go
@@ -63,22 +63,7 @@ func DownloadNVDCVEFeed(vulnPath string, cveFeedPrefixURL string, debug bool, lo
 	return nil
 }
 
-func DownloadVulnCheckFeed(vulnPath string, cveFeedPrefixURL string, debug bool, logger log.Logger) error {
-	cveSyncer, err := nvdsync.NewCVE(
-		vulnPath,
-		nvdsync.WithLogger(logger),
-		nvdsync.WithDebug(debug),
-	)
-	if err != nil {
-		return err
-	}
 
-	if err := cveSyncer.DoVulnCheck(context.Background()); err != nil {
-		return fmt.Errorf("download vulncheck cve feed: %w", err)
-	}
-
-	return nil
-}
 
 func downloadNVDCVELegacy(vulnPath string, cveFeedPrefixURL string) error {
 	if cveFeedPrefixURL == "" {

--- a/server/vulnerabilities/nvd/cve_test.go
+++ b/server/vulnerabilities/nvd/cve_test.go
@@ -136,15 +136,10 @@ func TestTranslateCPEToCVE(t *testing.T) {
 	// NVD_TEST_VULNDB_DIR can be used to speed up development (sync vulnerability data only once).
 	tempDir := os.Getenv("NVD_TEST_VULNDB_DIR")
 	if tempDir == "" {
-		nettest.Run(t)
 		// download the CVEs once for all sub-tests, and then disable syncing
 		tempDir = t.TempDir()
 		err := nettest.RunWithNetRetry(t, func() error {
-			// We use cveFeedPrefixURL="https://nvd.nist.gov/feeds/json/cve/1.1/" because a full sync
-			// with the NVD API 2.0 takes a long time (>15m). These feeds will be deprecated
-			// TBD during 2024 and this test will start failing then.
-			// For more information see: https://nvd.nist.gov/general/news/change-timeline.
-			return DownloadNVDCVEFeed(tempDir, "https://nvd.nist.gov/feeds/json/cve/1.1/", false, log.NewNopLogger())
+			return DownloadCVEFeed(tempDir, "", false, log.NewNopLogger())
 		})
 		require.NoError(t, err)
 	} else {
@@ -552,7 +547,7 @@ func TestSyncsCVEFromURL(t *testing.T) {
 
 	tempDir := t.TempDir()
 	cveFeedPrefixURL := ts.URL + "/feeds/json/cve/1.1/"
-	err := DownloadNVDCVEFeed(tempDir, cveFeedPrefixURL, false, log.NewNopLogger())
+	err := DownloadCVEFeed(tempDir, cveFeedPrefixURL, false, log.NewNopLogger())
 	require.Error(t, err)
 	require.Contains(t,
 		err.Error(),

--- a/server/vulnerabilities/nvd/sync.go
+++ b/server/vulnerabilities/nvd/sync.go
@@ -49,7 +49,7 @@ func Sync(opts SyncOptions, logger log.Logger) error {
 
 	level.Debug(logger).Log("msg", "syncing CVEs")
 	start = time.Now()
-	if err := DownloadNVDCVEFeed(opts.VulnPath, opts.CVEFeedPrefixURL, opts.Debug, logger); err != nil {
+	if err := DownloadCVEFeed(opts.VulnPath, opts.CVEFeedPrefixURL, opts.Debug, logger); err != nil {
 		return fmt.Errorf("sync NVD CVE feed: %w", err)
 	}
 	level.Debug(logger).Log("msg", "CVEs synced", "duration", time.Since(start))

--- a/server/vulnerabilities/nvd/sync/cve_syncer.go
+++ b/server/vulnerabilities/nvd/sync/cve_syncer.go
@@ -514,6 +514,9 @@ func (s *CVE) fetchVulnCheckDownloadURL(ctx context.Context, baseURL string) (st
 
 		resp, err = s.client.Do(req)
 		if err != nil {
+			if resp != nil {
+				resp.Body.Close()
+			}
 			s.logger.Log("msg", "VulnCheck API request failed", "attempt", attempt, "error", err)
 			if attempt == s.MaxTryAttempts {
 				return "", ctxerr.Wrap(ctx, err, "max retry attempts reached")

--- a/server/vulnerabilities/nvd/sync/cve_syncer.go
+++ b/server/vulnerabilities/nvd/sync/cve_syncer.go
@@ -1,5 +1,5 @@
-// Package nvdsync provides a CVE syncer that uses the NVD 2.0 API to download CVE information
-// and stores it in the legacy format. The reason we decided to store in the legacy format is because
+// Package nvdsync provides a CVE syncer that uses the NVD 2.0 API to download JSON formatted CVE information
+// and stores it in the legacy NVD 1.1 format. The reason we decided to store in the legacy format is because
 // the github.com/facebookincubator/nvdtools doesn't yet support parsing the new API 2.0 JSON format.
 package nvdsync
 
@@ -32,7 +32,8 @@ import (
 	"github.com/pandatix/nvdapi/v2"
 )
 
-// CVE syncs CVE information from the NVD database (nvd.nist.gov) using its API 2.0.
+// CVE syncs CVE information from the NVD database (nvd.nist.gov) using its API 2.0
+// to the directory specified in the dbDir field in the form of JSON files.
 // It stores the CVE information using the legacy feed format.
 // The reason we decided to store in the legacy format is because
 // the github.com/facebookincubator/nvdtools doesn't yet support parsing

--- a/server/vulnerabilities/nvd/sync/cve_syncer.go
+++ b/server/vulnerabilities/nvd/sync/cve_syncer.go
@@ -1083,6 +1083,9 @@ func convertVulnCheckCVEToLegacy(cve VulnCheckCVE, logger log.Logger) *schema.NV
 		if configuration.Operator != nil {
 			children := make([]*schema.NVDCVEFeedJSON10DefNode, 0, len(configuration.Nodes))
 			for _, node := range configuration.Nodes {
+				if node.Operator == "" {
+					node.Operator = nvdapi.OperatorOr // Default to OR operator if not set
+				}
 				cpeMatches := make([]*schema.NVDCVEFeedJSON10DefCPEMatch, 0, len(node.CPEMatch))
 				for _, cpeMatch := range node.CPEMatch {
 					cpeMatches = append(cpeMatches, &schema.NVDCVEFeedJSON10DefCPEMatch{
@@ -1111,6 +1114,9 @@ func convertVulnCheckCVEToLegacy(cve VulnCheckCVE, logger log.Logger) *schema.NV
 		} else {
 			for _, node := range configuration.Nodes {
 				cpeMatches := make([]*schema.NVDCVEFeedJSON10DefCPEMatch, 0, len(node.CPEMatch))
+				if node.Operator == "" {
+					node.Operator = nvdapi.OperatorOr // Default to OR operator if not set
+				}
 				for _, cpeMatch := range node.CPEMatch {
 					cpeMatches = append(cpeMatches, &schema.NVDCVEFeedJSON10DefCPEMatch{
 						CPEName:               []*schema.NVDCVEFeedJSON10DefCPEName{}, // All entries have this field with an empty array.

--- a/server/vulnerabilities/nvd/sync/cve_syncer.go
+++ b/server/vulnerabilities/nvd/sync/cve_syncer.go
@@ -236,13 +236,10 @@ func (s *CVE) updateVulnCheckYearFile(year int, cves []VulnCheckCVE, modCount, a
 		year = 2002
 	}
 
-	// Read the CVE file for the year.
-	// readStart := time.Now()
 	storedCVEFeed, err := readCVEsLegacyFormat(s.dbDir, year)
 	if err != nil {
 		return err
 	}
-	// level.Debug(s.logger).Log("msg", "read cves", "year", year, "duration", time.Since(readStart))
 
 	// Convert new API 2.0 format to legacy feed format and create map of new CVE information.
 	newLegacyCVEs := make(map[string]*schema.NVDCVEFeedJSON10DefCVEItem)
@@ -515,6 +512,10 @@ func (s *CVE) fetchVulnCheckDownloadURL(ctx context.Context, baseURL string) (st
 		req.Header.Add("Authorization", "Bearer "+apiKey)
 
 		resp, err = s.client.Do(req)
+		if resp != nil {
+			defer resp.Body.Close()
+		}
+
 		if err == nil && resp.StatusCode == http.StatusOK {
 			break
 		}
@@ -530,10 +531,7 @@ func (s *CVE) fetchVulnCheckDownloadURL(ctx context.Context, baseURL string) (st
 		time.Sleep(waitTimeForRetry)
 	}
 
-	defer resp.Body.Close()
-
 	var vcResponse VulnCheckBackupResponse
-
 	if err := json.NewDecoder(resp.Body).Decode(&vcResponse); err != nil {
 		return "", ctxerr.Wrap(ctx, err, "error decoding response")
 	}

--- a/server/vulnerabilities/nvd/sync/cve_syncer.go
+++ b/server/vulnerabilities/nvd/sync/cve_syncer.go
@@ -672,7 +672,7 @@ func (s *CVE) processVulnCheckFile(fileName string) error {
 		if stopProcessing {
 			break
 		}
-		
+
 		gReader.Close()
 		gzFile.Close()
 	}

--- a/server/vulnerabilities/nvd/sync/cve_syncer.go
+++ b/server/vulnerabilities/nvd/sync/cve_syncer.go
@@ -497,7 +497,7 @@ func (s *CVE) fetchVulnCheckDownloadURL(ctx context.Context, baseURL string) (st
 	apiKey := os.Getenv("VULNCHECK_API_KEY")
 
 	if apiKey == "" {
-		return "", fmt.Errorf("VULNCHECK_API_KEY environment variable not set")
+		return "", ctxerr.New(ctx, "VULNCHECK_API_KEY environment variable not set")
 	}
 
 	parsedURL, err := url.Parse(baseURL)

--- a/server/vulnerabilities/nvd/sync/cve_syncer.go
+++ b/server/vulnerabilities/nvd/sync/cve_syncer.go
@@ -849,7 +849,7 @@ func convertAPI20CVEToLegacy(cve nvdapi.CVE, logger log.Logger) *schema.NVDCVEFe
 				nodes = append(nodes, &schema.NVDCVEFeedJSON10DefNode{
 					CPEMatch: cpeMatches,
 					Children: []*schema.NVDCVEFeedJSON10DefNode{},
-					Negate:   *node.Negate,
+					Negate:   derefPtr(node.Negate),
 					Operator: string(node.Operator),
 				})
 			}

--- a/server/vulnerabilities/nvd/sync/cve_syncer_test.go
+++ b/server/vulnerabilities/nvd/sync/cve_syncer_test.go
@@ -56,7 +56,7 @@ func TestStoreCVEsLegacyFormat(t *testing.T) {
 			matched               = 0
 		)
 		for _, api20Vuln := range api20CVEs {
-			convertedLegacyVuln := convertAPI20CVEToLegacy(api20Vuln, log.NewNopLogger())
+			convertedLegacyVuln := convertAPI20CVEToLegacy(api20Vuln.CVE, log.NewNopLogger())
 			legacyVuln, ok := legacyVulns[*api20Vuln.CVE.ID]
 			if !ok {
 				vulnsNotFoundInLegacy = append(vulnsNotFoundInLegacy, *api20Vuln.CVE.ID)

--- a/server/vulnerabilities/nvd/sync/testdata/cve/vulncheck_test_data/nvdcve-1.1-2024-expected.json
+++ b/server/vulnerabilities/nvd/sync/testdata/cve/vulncheck_test_data/nvdcve-1.1-2024-expected.json
@@ -1,6 +1,6 @@
 {
   "CVE_data_format": "MITRE",
-  "CVE_data_numberOfCVEs": "3",
+  "CVE_data_numberOfCVEs": "4",
   "CVE_data_timestamp": "2024-04-08T12:01:42Z",
   "CVE_data_type": "CVE",
   "CVE_data_version": "4.0",
@@ -9,7 +9,7 @@
       "cve": {
         "affects": null,
         "CVE_data_meta": {
-          "ASSIGNER": "psirt@paloaltonetworks.com",
+          "ASSIGNER": "foo@example.com",
           "ID": "CVE-2024-0001"
         },
         "data_format": "MITRE",
@@ -29,8 +29,8 @@
         "references": {
           "reference_data": [
             {
-              "name": "https://security.paloaltonetworks.com/CVE-2024-0007",
-              "url": "https://security.paloaltonetworks.com/CVE-2024-0007"
+              "name": "https://foo.com/CVE-2024-0001",
+              "url": "https://foo.com/CVE-2024-0001"
             }
           ]
         }
@@ -41,7 +41,7 @@
           {
             "cpe_match": [
               {
-                "cpe23Uri": "cpe:2.3:a:dell:unity_operating_environment:*:*:*:*:*:*:*:*",
+                "cpe23Uri": "cpe:2.3:a:foo:bar:*:*:*:*:*:*:*:*",
                 "versionEndExcluding": "5.4.0.0.5.094",
                 "vulnerable": true
               }
@@ -78,8 +78,8 @@
         "references": {
           "reference_data": [
             {
-              "name": "https://security.paloaltonetworks.com/CVE-2024-0008",
-              "url": "https://security.paloaltonetworks.com/CVE-2024-0008"
+              "name": "https://foo.com/CVE-2024-0002",
+              "url": "https://foo.com/CVE-2024-0002"
             }
           ]
         }
@@ -90,19 +90,10 @@
           {
             "cpe_match": [
               {
-                "cpe23Uri": "cpe:2.3:a:concretecms:concrete_cms:*:*:*:*:*:*:*:*",
-                "versionEndExcluding": "8.5.16",
-                "versionStartIncluding": "5.0.0",
-                "vulnerable": true
-              },
-              {
-                "cpe23Uri": "cpe:2.3:a:concretecms:concrete_cms:*:*:*:*:*:*:*:*",
-                "versionEndExcluding": "9.2.8",
-                "versionStartIncluding": "9.0.0",
+                "cpe23Uri": "cpe:2.3:a:foo:bar:2023.2.0.21408:*:*:*:*:*:*:*",
                 "vulnerable": true
               }
-            ],
-            "operator": "OR"
+            ]
           }
         ]
       },
@@ -114,7 +105,7 @@
       "cve": {
         "affects": null,
         "CVE_data_meta": {
-          "ASSIGNER": "ff5b8ace-8b95-4078-9743-eac1ca5451de",
+          "ASSIGNER": "zdi-disclosures@trendmicro.com",
           "ID": "CVE-2024-0003"
         },
         "data_format": "MITRE",
@@ -124,7 +115,7 @@
           "description_data": [
             {
               "lang": "en",
-              "value": "Concrete CMS version 9 before 9.2.8 and previous versions before 8.5.16 are vulnerable to Stored XSS in the Custom Class page editing. Prior to the fix, a rogue administrator could insert malicious code in the custom class field due to insufficient validation of administrator provided data. The Concrete CMS security team gave this vulnerability a CVSS v3.1 score of 3.1 with a vector of  AV:N/AC:H/PR:H/UI:R/S:U/C:N/I:L/A:L https://nvd.nist.gov/vuln-metrics/cvss/v3-calculator . Thanks Alexey Solovyev for reporting. \n\n"
+              "value": "A CVE that doesn't exist in the NVD Feed"
             }
           ]
         },
@@ -134,12 +125,8 @@
         "references": {
           "reference_data": [
             {
-              "name": "https://documentation.concretecms.org/9-x/developers/introduction/version-history/928-release-notes?_gl=1*1bcxp5s*_ga*MTc1NDc0Njk2Mi4xNzA2ODI4MDU1*_ga_HFB3HPNNLS*MTcxMjE2NjYyNi4xMy4xLjE3MTIxNjY2ODEuMC4wLjA.",
-              "url": "https://documentation.concretecms.org/9-x/developers/introduction/version-history/928-release-notes?_gl=1*1bcxp5s*_ga*MTc1NDc0Njk2Mi4xNzA2ODI4MDU1*_ga_HFB3HPNNLS*MTcxMjE2NjYyNi4xMy4xLjE3MTIxNjY2ODEuMC4wLjA."
-            },
-            {
-              "name": "https://documentation.concretecms.org/developers/introduction/version-history/8516-release-notes?_gl=1*1oa3zn1*_ga*MTc1NDc0Njk2Mi4xNzA2ODI4MDU1*_ga_HFB3HPNNLS*MTcxMjE2NjYyNi4xMy4xLjE3MTIxNjY3MDcuMC4wLjA.",
-              "url": "https://documentation.concretecms.org/developers/introduction/version-history/8516-release-notes?_gl=1*1oa3zn1*_ga*MTc1NDc0Njk2Mi4xNzA2ODI4MDU1*_ga_HFB3HPNNLS*MTcxMjE2NjYyNi4xMy4xLjE3MTIxNjY3MDcuMC4wLjA."
+              "name": "https://www.foo.com/support/security-bulletins.html",
+              "url": "https://www.foo.com/support/security-bulletins.html"
             }
           ]
         }
@@ -150,25 +137,53 @@
           {
             "cpe_match": [
               {
-                "cpe23Uri": "cpe:2.3:a:concretecms:concrete_cms:*:*:*:*:*:*:*:*",
-                "versionEndExcluding": "8.5.16",
-                "versionStartIncluding": "5.0.0",
-                "vulnerable": true
-              },
-              {
-                "cpe23Uri": "cpe:2.3:a:concretecms:concrete_cms:*:*:*:*:*:*:*:*",
-                "versionEndExcluding": "9.2.8",
-                "versionStartIncluding": "9.0.0",
+                "cpe23Uri": "cpe:2.3:a:foo:bar:2023.2.0.21408:*:*:*:*:*:*:*",
                 "vulnerable": true
               }
-            ],
-            "operator": "OR"
+            ]
           }
         ]
       },
       "impact": {},
-      "lastModifiedDate": "2024-04-04T12:48Z",
-      "publishedDate": "2024-04-03T19:15Z"
+      "lastModifiedDate": "2024-04-03T17:24Z",
+      "publishedDate": "2024-04-03T17:15Z"
+    },
+    {
+      "cve": {
+        "affects": null,
+        "CVE_data_meta": {
+          "ASSIGNER": "zdi-disclosures@trendmicro.com",
+          "ID": "CVE-2024-0004"
+        },
+        "data_format": "MITRE",
+        "data_type": "CVE",
+        "data_version": "4.0",
+        "description": {
+          "description_data": [
+            {
+              "lang": "en",
+              "value": "A CVE without Configuration Nodes that doesn't exist in the NVD Feed"
+            }
+          ]
+        },
+        "problemtype": {
+          "problemtype_data": []
+        },
+        "references": {
+          "reference_data": [
+            {
+              "name": "https://www.foo.com/support/security-bulletins.html",
+              "url": "https://www.foo.com/support/security-bulletins.html"
+            }
+          ]
+        }
+      },
+      "configurations": {
+        "CVE_data_version": "4.0"
+      },
+      "impact": {},
+      "lastModifiedDate": "2024-04-03T17:24Z",
+      "publishedDate": "2024-04-03T17:15Z"
     }
   ]
 }

--- a/server/vulnerabilities/nvd/sync/testdata/cve/vulncheck_test_data/nvdcve-1.1-2024-expected.json
+++ b/server/vulnerabilities/nvd/sync/testdata/cve/vulncheck_test_data/nvdcve-1.1-2024-expected.json
@@ -1,6 +1,6 @@
 {
   "CVE_data_format": "MITRE",
-  "CVE_data_numberOfCVEs": "4",
+  "CVE_data_numberOfCVEs": "5",
   "CVE_data_timestamp": "2024-04-08T12:01:42Z",
   "CVE_data_type": "CVE",
   "CVE_data_version": "4.0",
@@ -93,7 +93,8 @@
                 "cpe23Uri": "cpe:2.3:a:foo:bar:2023.2.0.21408:*:*:*:*:*:*:*",
                 "vulnerable": true
               }
-            ]
+            ],
+            "operator": "OR"
           }
         ]
       },
@@ -140,7 +141,8 @@
                 "cpe23Uri": "cpe:2.3:a:foo:bar:2023.2.0.21408:*:*:*:*:*:*:*",
                 "vulnerable": true
               }
-            ]
+            ],
+            "operator": "OR"
           }
         ]
       },
@@ -180,6 +182,58 @@
       },
       "configurations": {
         "CVE_data_version": "4.0"
+      },
+      "impact": {},
+      "lastModifiedDate": "2024-04-03T17:24Z",
+      "publishedDate": "2024-04-03T17:15Z"
+    },
+    {
+      "cve": {
+        "affects": null,
+        "CVE_data_meta": {
+          "ASSIGNER": "zdi-disclosures@trendmicro.com",
+          "ID": "CVE-2024-0005"
+        },
+        "data_format": "MITRE",
+        "data_type": "CVE",
+        "data_version": "4.0",
+        "description": {
+          "description_data": [
+            {
+              "lang": "en",
+              "value": "A CVE with an AND operator in Configuration Nodes that doesn't exist in the NVD Feed"
+            }
+          ]
+        },
+        "problemtype": {
+          "problemtype_data": []
+        },
+        "references": {
+          "reference_data": [
+            {
+              "name": "https://www.foo.com/support/security-bulletins.html",
+              "url": "https://www.foo.com/support/security-bulletins.html"
+            }
+          ]
+        }
+      },
+      "configurations": {
+        "CVE_data_version": "4.0",
+        "nodes": [
+          {
+            "cpe_match": [
+              {
+                "cpe23Uri": "cpe:2.3:a:foo:bar:2023.2.0.21408:*:*:*:*:*:*:*",
+                "vulnerable": true
+              },
+              {
+                "cpe23Uri": "cpe:2.3:o:apple:macos:-:*:*:*:*:*:*:*",
+                "vulnerable": true
+              }
+            ],
+            "operator": "AND"
+          }
+        ]
       },
       "impact": {},
       "lastModifiedDate": "2024-04-03T17:24Z",

--- a/server/vulnerabilities/nvd/sync/testdata/cve/vulncheck_test_data/nvdcve-1.1-2024-expected.json
+++ b/server/vulnerabilities/nvd/sync/testdata/cve/vulncheck_test_data/nvdcve-1.1-2024-expected.json
@@ -1,0 +1,174 @@
+{
+  "CVE_data_format": "MITRE",
+  "CVE_data_numberOfCVEs": "3",
+  "CVE_data_timestamp": "2024-04-08T12:01:42Z",
+  "CVE_data_type": "CVE",
+  "CVE_data_version": "4.0",
+  "CVE_Items": [
+    {
+      "cve": {
+        "affects": null,
+        "CVE_data_meta": {
+          "ASSIGNER": "psirt@paloaltonetworks.com",
+          "ID": "CVE-2024-0001"
+        },
+        "data_format": "MITRE",
+        "data_type": "CVE",
+        "data_version": "4.0",
+        "description": {
+          "description_data": [
+            {
+              "lang": "en",
+              "value": "A CVE with Configuration Nodes"
+            }
+          ]
+        },
+        "problemtype": {
+          "problemtype_data": []
+        },
+        "references": {
+          "reference_data": [
+            {
+              "name": "https://security.paloaltonetworks.com/CVE-2024-0007",
+              "url": "https://security.paloaltonetworks.com/CVE-2024-0007"
+            }
+          ]
+        }
+      },
+      "configurations": {
+        "CVE_data_version": "4.0",
+        "nodes": [
+          {
+            "cpe_match": [
+              {
+                "cpe23Uri": "cpe:2.3:a:dell:unity_operating_environment:*:*:*:*:*:*:*:*",
+                "versionEndExcluding": "5.4.0.0.5.094",
+                "vulnerable": true
+              }
+            ],
+            "operator": "OR"
+          }
+        ]
+      },
+      "impact": {},
+      "lastModifiedDate": "2024-02-15T06:23Z",
+      "publishedDate": "2024-02-14T18:15Z"
+    },
+    {
+      "cve": {
+        "affects": null,
+        "CVE_data_meta": {
+          "ASSIGNER": "psirt@paloaltonetworks.com",
+          "ID": "CVE-2024-0002"
+        },
+        "data_format": "MITRE",
+        "data_type": "CVE",
+        "data_version": "4.0",
+        "description": {
+          "description_data": [
+            {
+              "lang": "en",
+              "value": "A CVE Without Congiguration Nodes"
+            }
+          ]
+        },
+        "problemtype": {
+          "problemtype_data": []
+        },
+        "references": {
+          "reference_data": [
+            {
+              "name": "https://security.paloaltonetworks.com/CVE-2024-0008",
+              "url": "https://security.paloaltonetworks.com/CVE-2024-0008"
+            }
+          ]
+        }
+      },
+      "configurations": {
+        "CVE_data_version": "4.0",
+        "nodes": [
+          {
+            "cpe_match": [
+              {
+                "cpe23Uri": "cpe:2.3:a:concretecms:concrete_cms:*:*:*:*:*:*:*:*",
+                "versionEndExcluding": "8.5.16",
+                "versionStartIncluding": "5.0.0",
+                "vulnerable": true
+              },
+              {
+                "cpe23Uri": "cpe:2.3:a:concretecms:concrete_cms:*:*:*:*:*:*:*:*",
+                "versionEndExcluding": "9.2.8",
+                "versionStartIncluding": "9.0.0",
+                "vulnerable": true
+              }
+            ],
+            "operator": "OR"
+          }
+        ]
+      },
+      "impact": {},
+      "lastModifiedDate": "2024-02-15T06:23Z",
+      "publishedDate": "2024-02-14T18:15Z"
+    },
+    {
+      "cve": {
+        "affects": null,
+        "CVE_data_meta": {
+          "ASSIGNER": "ff5b8ace-8b95-4078-9743-eac1ca5451de",
+          "ID": "CVE-2024-0003"
+        },
+        "data_format": "MITRE",
+        "data_type": "CVE",
+        "data_version": "4.0",
+        "description": {
+          "description_data": [
+            {
+              "lang": "en",
+              "value": "Concrete CMS version 9 before 9.2.8 and previous versions before 8.5.16 are vulnerable to Stored XSS in the Custom Class page editing. Prior to the fix, a rogue administrator could insert malicious code in the custom class field due to insufficient validation of administrator provided data. The Concrete CMS security team gave this vulnerability a CVSS v3.1 score of 3.1 with a vector of  AV:N/AC:H/PR:H/UI:R/S:U/C:N/I:L/A:L https://nvd.nist.gov/vuln-metrics/cvss/v3-calculator . Thanks Alexey Solovyev for reporting. \n\n"
+            }
+          ]
+        },
+        "problemtype": {
+          "problemtype_data": []
+        },
+        "references": {
+          "reference_data": [
+            {
+              "name": "https://documentation.concretecms.org/9-x/developers/introduction/version-history/928-release-notes?_gl=1*1bcxp5s*_ga*MTc1NDc0Njk2Mi4xNzA2ODI4MDU1*_ga_HFB3HPNNLS*MTcxMjE2NjYyNi4xMy4xLjE3MTIxNjY2ODEuMC4wLjA.",
+              "url": "https://documentation.concretecms.org/9-x/developers/introduction/version-history/928-release-notes?_gl=1*1bcxp5s*_ga*MTc1NDc0Njk2Mi4xNzA2ODI4MDU1*_ga_HFB3HPNNLS*MTcxMjE2NjYyNi4xMy4xLjE3MTIxNjY2ODEuMC4wLjA."
+            },
+            {
+              "name": "https://documentation.concretecms.org/developers/introduction/version-history/8516-release-notes?_gl=1*1oa3zn1*_ga*MTc1NDc0Njk2Mi4xNzA2ODI4MDU1*_ga_HFB3HPNNLS*MTcxMjE2NjYyNi4xMy4xLjE3MTIxNjY3MDcuMC4wLjA.",
+              "url": "https://documentation.concretecms.org/developers/introduction/version-history/8516-release-notes?_gl=1*1oa3zn1*_ga*MTc1NDc0Njk2Mi4xNzA2ODI4MDU1*_ga_HFB3HPNNLS*MTcxMjE2NjYyNi4xMy4xLjE3MTIxNjY3MDcuMC4wLjA."
+            }
+          ]
+        }
+      },
+      "configurations": {
+        "CVE_data_version": "4.0",
+        "nodes": [
+          {
+            "cpe_match": [
+              {
+                "cpe23Uri": "cpe:2.3:a:concretecms:concrete_cms:*:*:*:*:*:*:*:*",
+                "versionEndExcluding": "8.5.16",
+                "versionStartIncluding": "5.0.0",
+                "vulnerable": true
+              },
+              {
+                "cpe23Uri": "cpe:2.3:a:concretecms:concrete_cms:*:*:*:*:*:*:*:*",
+                "versionEndExcluding": "9.2.8",
+                "versionStartIncluding": "9.0.0",
+                "vulnerable": true
+              }
+            ],
+            "operator": "OR"
+          }
+        ]
+      },
+      "impact": {},
+      "lastModifiedDate": "2024-04-04T12:48Z",
+      "publishedDate": "2024-04-03T19:15Z"
+    }
+  ]
+}

--- a/server/vulnerabilities/nvd/sync/testdata/cve/vulncheck_test_data/nvdcve-1.1-2024.json
+++ b/server/vulnerabilities/nvd/sync/testdata/cve/vulncheck_test_data/nvdcve-1.1-2024.json
@@ -1,6 +1,6 @@
 {
   "CVE_data_format": "MITRE",
-  "CVE_data_numberOfCVEs": "3",
+  "CVE_data_numberOfCVEs": "4",
   "CVE_data_timestamp": "2024-04-08T12:01:42Z",
   "CVE_data_type": "CVE",
   "CVE_data_version": "4.0",
@@ -9,7 +9,7 @@
       "cve": {
         "affects": null,
         "CVE_data_meta": {
-          "ASSIGNER": "psirt@paloaltonetworks.com",
+          "ASSIGNER": "foo@example.com",
           "ID": "CVE-2024-0001"
         },
         "data_format": "MITRE",
@@ -29,8 +29,8 @@
         "references": {
           "reference_data": [
             {
-              "name": "https://security.paloaltonetworks.com/CVE-2024-0007",
-              "url": "https://security.paloaltonetworks.com/CVE-2024-0007"
+              "name": "https://foo.com/CVE-2024-0001",
+              "url": "https://foo.com/CVE-2024-0001"
             }
           ]
         }
@@ -41,7 +41,7 @@
           {
             "cpe_match": [
               {
-                "cpe23Uri": "cpe:2.3:a:dell:unity_operating_environment:*:*:*:*:*:*:*:*",
+                "cpe23Uri": "cpe:2.3:a:foo:bar:*:*:*:*:*:*:*:*",
                 "versionEndExcluding": "5.4.0.0.5.094",
                 "vulnerable": true
               }
@@ -78,97 +78,15 @@
         "references": {
           "reference_data": [
             {
-              "name": "https://security.paloaltonetworks.com/CVE-2024-0008",
-              "url": "https://security.paloaltonetworks.com/CVE-2024-0008"
+              "name": "https://foo.com/CVE-2024-0002",
+              "url": "https://foo.com/CVE-2024-0002"
             }
           ]
         }
-      },
-      "configurations": {
-        "CVE_data_version": "4.0",
-        "nodes": [
-          {
-            "cpe_match": [
-              {
-                "cpe23Uri": "cpe:2.3:a:concretecms:concrete_cms:*:*:*:*:*:*:*:*",
-                "versionEndExcluding": "8.5.16",
-                "versionStartIncluding": "5.0.0",
-                "vulnerable": true
-              },
-              {
-                "cpe23Uri": "cpe:2.3:a:concretecms:concrete_cms:*:*:*:*:*:*:*:*",
-                "versionEndExcluding": "9.2.8",
-                "versionStartIncluding": "9.0.0",
-                "vulnerable": true
-              }
-            ],
-            "operator": "OR"
-          }
-        ]
       },
       "impact": {},
       "lastModifiedDate": "2024-02-15T06:23Z",
       "publishedDate": "2024-02-14T18:15Z"
-    },
-    {
-      "cve": {
-        "affects": null,
-        "CVE_data_meta": {
-          "ASSIGNER": "ff5b8ace-8b95-4078-9743-eac1ca5451de",
-          "ID": "CVE-2024-0003"
-        },
-        "data_format": "MITRE",
-        "data_type": "CVE",
-        "data_version": "4.0",
-        "description": {
-          "description_data": [
-            {
-              "lang": "en",
-              "value": "Concrete CMS version 9 before 9.2.8 and previous versions before 8.5.16 are vulnerable to Stored XSS in the Custom Class page editing. Prior to the fix, a rogue administrator could insert malicious code in the custom class field due to insufficient validation of administrator provided data. The Concrete CMS security team gave this vulnerability a CVSS v3.1 score of 3.1 with a vector of  AV:N/AC:H/PR:H/UI:R/S:U/C:N/I:L/A:L https://nvd.nist.gov/vuln-metrics/cvss/v3-calculator . Thanks Alexey Solovyev for reporting. \n\n"
-            }
-          ]
-        },
-        "problemtype": {
-          "problemtype_data": []
-        },
-        "references": {
-          "reference_data": [
-            {
-              "name": "https://documentation.concretecms.org/9-x/developers/introduction/version-history/928-release-notes?_gl=1*1bcxp5s*_ga*MTc1NDc0Njk2Mi4xNzA2ODI4MDU1*_ga_HFB3HPNNLS*MTcxMjE2NjYyNi4xMy4xLjE3MTIxNjY2ODEuMC4wLjA.",
-              "url": "https://documentation.concretecms.org/9-x/developers/introduction/version-history/928-release-notes?_gl=1*1bcxp5s*_ga*MTc1NDc0Njk2Mi4xNzA2ODI4MDU1*_ga_HFB3HPNNLS*MTcxMjE2NjYyNi4xMy4xLjE3MTIxNjY2ODEuMC4wLjA."
-            },
-            {
-              "name": "https://documentation.concretecms.org/developers/introduction/version-history/8516-release-notes?_gl=1*1oa3zn1*_ga*MTc1NDc0Njk2Mi4xNzA2ODI4MDU1*_ga_HFB3HPNNLS*MTcxMjE2NjYyNi4xMy4xLjE3MTIxNjY3MDcuMC4wLjA.",
-              "url": "https://documentation.concretecms.org/developers/introduction/version-history/8516-release-notes?_gl=1*1oa3zn1*_ga*MTc1NDc0Njk2Mi4xNzA2ODI4MDU1*_ga_HFB3HPNNLS*MTcxMjE2NjYyNi4xMy4xLjE3MTIxNjY3MDcuMC4wLjA."
-            }
-          ]
-        }
-      },
-      "configurations": {
-        "CVE_data_version": "4.0",
-        "nodes": [
-          {
-            "cpe_match": [
-              {
-                "cpe23Uri": "cpe:2.3:a:concretecms:concrete_cms:*:*:*:*:*:*:*:*",
-                "versionEndExcluding": "8.5.16",
-                "versionStartIncluding": "5.0.0",
-                "vulnerable": true
-              },
-              {
-                "cpe23Uri": "cpe:2.3:a:concretecms:concrete_cms:*:*:*:*:*:*:*:*",
-                "versionEndExcluding": "9.2.8",
-                "versionStartIncluding": "9.0.0",
-                "vulnerable": true
-              }
-            ],
-            "operator": "OR"
-          }
-        ]
-      },
-      "impact": {},
-      "lastModifiedDate": "2024-04-04T12:48Z",
-      "publishedDate": "2024-04-03T19:15Z"
     }
   ]
 }

--- a/server/vulnerabilities/nvd/sync/testdata/cve/vulncheck_test_data/nvdcve-1.1-2024.json
+++ b/server/vulnerabilities/nvd/sync/testdata/cve/vulncheck_test_data/nvdcve-1.1-2024.json
@@ -1,0 +1,174 @@
+{
+  "CVE_data_format": "MITRE",
+  "CVE_data_numberOfCVEs": "3",
+  "CVE_data_timestamp": "2024-04-08T12:01:42Z",
+  "CVE_data_type": "CVE",
+  "CVE_data_version": "4.0",
+  "CVE_Items": [
+    {
+      "cve": {
+        "affects": null,
+        "CVE_data_meta": {
+          "ASSIGNER": "psirt@paloaltonetworks.com",
+          "ID": "CVE-2024-0001"
+        },
+        "data_format": "MITRE",
+        "data_type": "CVE",
+        "data_version": "4.0",
+        "description": {
+          "description_data": [
+            {
+              "lang": "en",
+              "value": "A CVE with Configuration Nodes"
+            }
+          ]
+        },
+        "problemtype": {
+          "problemtype_data": []
+        },
+        "references": {
+          "reference_data": [
+            {
+              "name": "https://security.paloaltonetworks.com/CVE-2024-0007",
+              "url": "https://security.paloaltonetworks.com/CVE-2024-0007"
+            }
+          ]
+        }
+      },
+      "configurations": {
+        "CVE_data_version": "4.0",
+        "nodes": [
+          {
+            "cpe_match": [
+              {
+                "cpe23Uri": "cpe:2.3:a:dell:unity_operating_environment:*:*:*:*:*:*:*:*",
+                "versionEndExcluding": "5.4.0.0.5.094",
+                "vulnerable": true
+              }
+            ],
+            "operator": "OR"
+          }
+        ]
+      },
+      "impact": {},
+      "lastModifiedDate": "2024-02-15T06:23Z",
+      "publishedDate": "2024-02-14T18:15Z"
+    },
+    {
+      "cve": {
+        "affects": null,
+        "CVE_data_meta": {
+          "ASSIGNER": "psirt@paloaltonetworks.com",
+          "ID": "CVE-2024-0002"
+        },
+        "data_format": "MITRE",
+        "data_type": "CVE",
+        "data_version": "4.0",
+        "description": {
+          "description_data": [
+            {
+              "lang": "en",
+              "value": "A CVE Without Congiguration Nodes"
+            }
+          ]
+        },
+        "problemtype": {
+          "problemtype_data": []
+        },
+        "references": {
+          "reference_data": [
+            {
+              "name": "https://security.paloaltonetworks.com/CVE-2024-0008",
+              "url": "https://security.paloaltonetworks.com/CVE-2024-0008"
+            }
+          ]
+        }
+      },
+      "configurations": {
+        "CVE_data_version": "4.0",
+        "nodes": [
+          {
+            "cpe_match": [
+              {
+                "cpe23Uri": "cpe:2.3:a:concretecms:concrete_cms:*:*:*:*:*:*:*:*",
+                "versionEndExcluding": "8.5.16",
+                "versionStartIncluding": "5.0.0",
+                "vulnerable": true
+              },
+              {
+                "cpe23Uri": "cpe:2.3:a:concretecms:concrete_cms:*:*:*:*:*:*:*:*",
+                "versionEndExcluding": "9.2.8",
+                "versionStartIncluding": "9.0.0",
+                "vulnerable": true
+              }
+            ],
+            "operator": "OR"
+          }
+        ]
+      },
+      "impact": {},
+      "lastModifiedDate": "2024-02-15T06:23Z",
+      "publishedDate": "2024-02-14T18:15Z"
+    },
+    {
+      "cve": {
+        "affects": null,
+        "CVE_data_meta": {
+          "ASSIGNER": "ff5b8ace-8b95-4078-9743-eac1ca5451de",
+          "ID": "CVE-2024-0003"
+        },
+        "data_format": "MITRE",
+        "data_type": "CVE",
+        "data_version": "4.0",
+        "description": {
+          "description_data": [
+            {
+              "lang": "en",
+              "value": "Concrete CMS version 9 before 9.2.8 and previous versions before 8.5.16 are vulnerable to Stored XSS in the Custom Class page editing. Prior to the fix, a rogue administrator could insert malicious code in the custom class field due to insufficient validation of administrator provided data. The Concrete CMS security team gave this vulnerability a CVSS v3.1 score of 3.1 with a vector of  AV:N/AC:H/PR:H/UI:R/S:U/C:N/I:L/A:L https://nvd.nist.gov/vuln-metrics/cvss/v3-calculator . Thanks Alexey Solovyev for reporting. \n\n"
+            }
+          ]
+        },
+        "problemtype": {
+          "problemtype_data": []
+        },
+        "references": {
+          "reference_data": [
+            {
+              "name": "https://documentation.concretecms.org/9-x/developers/introduction/version-history/928-release-notes?_gl=1*1bcxp5s*_ga*MTc1NDc0Njk2Mi4xNzA2ODI4MDU1*_ga_HFB3HPNNLS*MTcxMjE2NjYyNi4xMy4xLjE3MTIxNjY2ODEuMC4wLjA.",
+              "url": "https://documentation.concretecms.org/9-x/developers/introduction/version-history/928-release-notes?_gl=1*1bcxp5s*_ga*MTc1NDc0Njk2Mi4xNzA2ODI4MDU1*_ga_HFB3HPNNLS*MTcxMjE2NjYyNi4xMy4xLjE3MTIxNjY2ODEuMC4wLjA."
+            },
+            {
+              "name": "https://documentation.concretecms.org/developers/introduction/version-history/8516-release-notes?_gl=1*1oa3zn1*_ga*MTc1NDc0Njk2Mi4xNzA2ODI4MDU1*_ga_HFB3HPNNLS*MTcxMjE2NjYyNi4xMy4xLjE3MTIxNjY3MDcuMC4wLjA.",
+              "url": "https://documentation.concretecms.org/developers/introduction/version-history/8516-release-notes?_gl=1*1oa3zn1*_ga*MTc1NDc0Njk2Mi4xNzA2ODI4MDU1*_ga_HFB3HPNNLS*MTcxMjE2NjYyNi4xMy4xLjE3MTIxNjY3MDcuMC4wLjA."
+            }
+          ]
+        }
+      },
+      "configurations": {
+        "CVE_data_version": "4.0",
+        "nodes": [
+          {
+            "cpe_match": [
+              {
+                "cpe23Uri": "cpe:2.3:a:concretecms:concrete_cms:*:*:*:*:*:*:*:*",
+                "versionEndExcluding": "8.5.16",
+                "versionStartIncluding": "5.0.0",
+                "vulnerable": true
+              },
+              {
+                "cpe23Uri": "cpe:2.3:a:concretecms:concrete_cms:*:*:*:*:*:*:*:*",
+                "versionEndExcluding": "9.2.8",
+                "versionStartIncluding": "9.0.0",
+                "vulnerable": true
+              }
+            ],
+            "operator": "OR"
+          }
+        ]
+      },
+      "impact": {},
+      "lastModifiedDate": "2024-04-04T12:48Z",
+      "publishedDate": "2024-04-03T19:15Z"
+    }
+  ]
+}

--- a/server/vulnerabilities/nvd/sync/testdata/cve/vulncheck_test_data/nvdcve-2.0-122.json
+++ b/server/vulnerabilities/nvd/sync/testdata/cve/vulncheck_test_data/nvdcve-2.0-122.json
@@ -1,0 +1,302 @@
+{
+    "resultsPerPage": 147,
+    "startIndex": 244000,
+    "totalResults": 244147,
+    "format": "NVD_CVE",
+    "version": "2.0",
+    "timestamp": "2024-04-04T20:32:52.097",
+    "vulnerabilities": [
+        {
+            "cve": {
+                "id": "CVE-2024-0001",
+                "sourceIdentifier": "ff5b8ace-8b95-4078-9743-eac1ca5451de",
+                "vulnStatus": "Awaiting Analysis",
+                "published": "2024-04-03T19:15:44.387",
+                "lastModified": "2024-04-04T12:48:41.700",
+                "descriptions": [
+                    {
+                        "lang": "en",
+                        "value": "A duplicate CVE with Configuration Nodes in the NVD Feed"
+                    }
+                ],
+                "references": [
+                    {
+                        "url": "https://foo.com/CVE-2024-0001",
+                        "source": "ff5b8ace-8b95-4078-9743-eac1ca5451de"
+                    },
+                    {
+                        "url": "https://foo.com/CVE-2024-0001",
+                        "source": "ff5b8ace-8b95-4078-9743-eac1ca5451de"
+                    }
+                ],
+                "metrics": {
+                    "cvssMetricV31": [
+                        {
+                            "source": "ff5b8ace-8b95-4078-9743-eac1ca5451de",
+                            "type": "Secondary",
+                            "cvssData": {
+                                "version": "3.1",
+                                "vectorString": "CVSS:3.1/AV:N/AC:H/PR:H/UI:R/S:U/C:N/I:L/A:L",
+                                "attackVector": "NETWORK",
+                                "attackComplexity": "HIGH",
+                                "privilegesRequired": "HIGH",
+                                "userInteraction": "REQUIRED",
+                                "scope": "UNCHANGED",
+                                "confidentialityImpact": "NONE",
+                                "integrityImpact": "LOW",
+                                "availabilityImpact": "LOW",
+                                "baseScore": 3.1,
+                                "baseSeverity": "LOW"
+                            },
+                            "exploitabilityScore": 0.5,
+                            "impactScore": 2.5
+                        }
+                    ]
+                },
+                "weaknesses": [
+                    {
+                        "source": "ff5b8ace-8b95-4078-9743-eac1ca5451de",
+                        "type": "Secondary",
+                        "description": [
+                            {
+                                "lang": "en",
+                                "value": "CWE-20"
+                            }
+                        ]
+                    }
+                ],
+                "vcConfigurations": [
+                    {
+                        "nodes": [
+                            {
+                                "operator": "OR",
+                                "cpeMatch": [
+                                    {
+                                        "vulnerable": true,
+                                        "criteria": "cpe:2.3:a:concretecms:concrete_cms:*:*:*:*:*:*:*:*",
+                                        "versionStartIncluding": "5.0.0",
+                                        "versionEndExcluding": "8.5.16",
+                                        "matchCriteriaId": ""
+                                    },
+                                    {
+                                        "vulnerable": true,
+                                        "criteria": "cpe:2.3:a:concretecms:concrete_cms:*:*:*:*:*:*:*:*",
+                                        "versionStartIncluding": "9.0.0",
+                                        "versionEndExcluding": "9.2.8",
+                                        "matchCriteriaId": ""
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            }
+        },
+        {
+            "cve": {
+                "id": "CVE-2024-0002",
+                "sourceIdentifier": "zdi-disclosures@trendmicro.com",
+                "vulnStatus": "Awaiting Analysis",
+                "published": "2024-04-03T17:15:57.627",
+                "lastModified": "2024-04-03T17:24:18.150",
+                "descriptions": [
+                    {
+                        "lang": "en",
+                        "value": "An existing CVE with Configuration Nodes in the NVD Feed"
+                    }
+                ],
+                "references": [
+                    {
+                        "url": "https://www.foo.com/support/security-bulletins.html",
+                        "source": "zdi-disclosures@foo.com"
+                    }
+                ],
+                "metrics": {
+                    "cvssMetricV30": [
+                        {
+                            "source": "zdi-disclosures@foo.com",
+                            "type": "Secondary",
+                            "cvssData": {
+                                "version": "3.0",
+                                "vectorString": "CVSS:3.0/AV:L/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H",
+                                "attackVector": "LOCAL",
+                                "attackComplexity": "LOW",
+                                "privilegesRequired": "NONE",
+                                "userInteraction": "REQUIRED",
+                                "scope": "UNCHANGED",
+                                "confidentialityImpact": "HIGH",
+                                "integrityImpact": "HIGH",
+                                "availabilityImpact": "HIGH",
+                                "baseScore": 7.8,
+                                "baseSeverity": "HIGH"
+                            },
+                            "exploitabilityScore": 1.8,
+                            "impactScore": 5.9
+                        }
+                    ]
+                },
+                "weaknesses": [
+                    {
+                        "source": "zdi-disclosures@foo.com",
+                        "type": "Secondary",
+                        "description": [
+                            {
+                                "lang": "en",
+                                "value": "CWE-416"
+                            }
+                        ]
+                    }
+                ],
+                "vcConfigurations": [
+                    {
+                        "nodes": [
+                            {
+                                "cpeMatch": [
+                                    {
+                                        "vulnerable": true,
+                                        "criteria": "cpe:2.3:a:foo:bar:2023.2.0.21408:*:*:*:*:*:*:*",
+                                        "matchCriteriaId": ""
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "vcVulnerableCPEs": [
+                    "cpe:2.3:a:foo:bar:2023.2.0.21408:*:*:*:*:*:*:*"
+                ]
+            }
+        },
+        {
+            "cve": {
+                "id": "CVE-2024-0003",
+                "sourceIdentifier": "zdi-disclosures@trendmicro.com",
+                "vulnStatus": "Awaiting Analysis",
+                "published": "2024-04-03T17:15:57.803",
+                "lastModified": "2024-04-03T17:24:18.150",
+                "descriptions": [
+                    {
+                        "lang": "en",
+                        "value": "A CVE that doesn't exist in the NVD Feed"
+                    }
+                ],
+                "references": [
+                    {
+                        "url": "https://www.foo.com/support/security-bulletins.html",
+                        "source": "zdi-disclosures@foo.com"
+                    }
+                ],
+                "metrics": {
+                    "cvssMetricV30": [
+                        {
+                            "source": "zdi-disclosures@foo.com",
+                            "type": "Secondary",
+                            "cvssData": {
+                                "version": "3.0",
+                                "vectorString": "CVSS:3.0/AV:L/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H",
+                                "attackVector": "LOCAL",
+                                "attackComplexity": "LOW",
+                                "privilegesRequired": "NONE",
+                                "userInteraction": "REQUIRED",
+                                "scope": "UNCHANGED",
+                                "confidentialityImpact": "HIGH",
+                                "integrityImpact": "HIGH",
+                                "availabilityImpact": "HIGH",
+                                "baseScore": 7.8,
+                                "baseSeverity": "HIGH"
+                            },
+                            "exploitabilityScore": 1.8,
+                            "impactScore": 5.9
+                        }
+                    ]
+                },
+                "weaknesses": [
+                    {
+                        "source": "zdi-disclosures@foo.com",
+                        "type": "Secondary",
+                        "description": [
+                            {
+                                "lang": "en",
+                                "value": "CWE-416"
+                            }
+                        ]
+                    }
+                ],
+                "vcConfigurations": [
+                    {
+                        "nodes": [
+                            {
+                                "cpeMatch": [
+                                    {
+                                        "vulnerable": true,
+                                        "criteria": "cpe:2.3:a:foo:bar:2023.2.0.21408:*:*:*:*:*:*:*",
+                                        "matchCriteriaId": ""
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "vcVulnerableCPEs": [
+                    "cpe:2.3:a:foo:bar:2023.2.0.21408:*:*:*:*:*:*:*"
+                ]
+            }
+        }, {
+            "cve": {
+                "id": "CVE-2024-0004",
+                "sourceIdentifier": "zdi-disclosures@trendmicro.com",
+                "vulnStatus": "Awaiting Analysis",
+                "published": "2024-04-03T17:15:57.803",
+                "lastModified": "2024-04-03T17:24:18.150",
+                "descriptions": [
+                    {
+                        "lang": "en",
+                        "value": "A CVE without Configuration Nodes that doesn't exist in the NVD Feed"
+                    }
+                ],
+                "references": [
+                    {
+                        "url": "https://www.foo.com/support/security-bulletins.html",
+                        "source": "zdi-disclosures@foo.com"
+                    }
+                ],
+                "metrics": {
+                    "cvssMetricV30": [
+                        {
+                            "source": "zdi-disclosures@foo.com",
+                            "type": "Secondary",
+                            "cvssData": {
+                                "version": "3.0",
+                                "vectorString": "CVSS:3.0/AV:L/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H",
+                                "attackVector": "LOCAL",
+                                "attackComplexity": "LOW",
+                                "privilegesRequired": "NONE",
+                                "userInteraction": "REQUIRED",
+                                "scope": "UNCHANGED",
+                                "confidentialityImpact": "HIGH",
+                                "integrityImpact": "HIGH",
+                                "availabilityImpact": "HIGH",
+                                "baseScore": 7.8,
+                                "baseSeverity": "HIGH"
+                            },
+                            "exploitabilityScore": 1.8,
+                            "impactScore": 5.9
+                        }
+                    ]
+                },
+                "weaknesses": [
+                    {
+                        "source": "zdi-disclosures@foo.com",
+                        "type": "Secondary",
+                        "description": [
+                            {
+                                "lang": "en",
+                                "value": "CWE-416"
+                            }
+                        ]
+                    }
+                ]
+            }
+        }
+    ]
+}

--- a/server/vulnerabilities/nvd/sync/testdata/cve/vulncheck_test_data/nvdcve-2.0-122.json
+++ b/server/vulnerabilities/nvd/sync/testdata/cve/vulncheck_test_data/nvdcve-2.0-122.json
@@ -297,6 +297,86 @@
                     }
                 ]
             }
+        }, {
+            "cve": {
+                "id": "CVE-2024-0005",
+                "sourceIdentifier": "zdi-disclosures@trendmicro.com",
+                "vulnStatus": "Awaiting Analysis",
+                "published": "2024-04-03T17:15:57.803",
+                "lastModified": "2024-04-03T17:24:18.150",
+                "descriptions": [
+                    {
+                        "lang": "en",
+                        "value": "A CVE with an AND operator in Configuration Nodes that doesn't exist in the NVD Feed"
+                    }
+                ],
+                "references": [
+                    {
+                        "url": "https://www.foo.com/support/security-bulletins.html",
+                        "source": "zdi-disclosures@foo.com"
+                    }
+                ],
+                "metrics": {
+                    "cvssMetricV30": [
+                        {
+                            "source": "zdi-disclosures@foo.com",
+                            "type": "Secondary",
+                            "cvssData": {
+                                "version": "3.0",
+                                "vectorString": "CVSS:3.0/AV:L/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H",
+                                "attackVector": "LOCAL",
+                                "attackComplexity": "LOW",
+                                "privilegesRequired": "NONE",
+                                "userInteraction": "REQUIRED",
+                                "scope": "UNCHANGED",
+                                "confidentialityImpact": "HIGH",
+                                "integrityImpact": "HIGH",
+                                "availabilityImpact": "HIGH",
+                                "baseScore": 7.8,
+                                "baseSeverity": "HIGH"
+                            },
+                            "exploitabilityScore": 1.8,
+                            "impactScore": 5.9
+                        }
+                    ]
+                },
+                "weaknesses": [
+                    {
+                        "source": "zdi-disclosures@foo.com",
+                        "type": "Secondary",
+                        "description": [
+                            {
+                                "lang": "en",
+                                "value": "CWE-416"
+                            }
+                        ]
+                    }
+                ],
+                "vcConfigurations": [
+                    {
+                        "nodes": [
+                            {
+                                "operator": "AND",
+                                "cpeMatch": [
+                                    {
+                                        "vulnerable": true,
+                                        "criteria": "cpe:2.3:a:foo:bar:2023.2.0.21408:*:*:*:*:*:*:*",
+                                        "matchCriteriaId": ""
+                                    },
+                                    {
+                                        "vulnerable": true,
+                                        "criteria": "cpe:2.3:o:apple:macos:-:*:*:*:*:*:*:*",
+                                        "matchCriteriaId": ""
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "vcVulnerableCPEs": [
+                    "cpe:2.3:a:foo:bar:2023.2.0.21408:*:*:*:*:*:*:*"
+                ]
+            }
         }
     ]
 }

--- a/server/vulnerabilities/nvd/sync/utils.go
+++ b/server/vulnerabilities/nvd/sync/utils.go
@@ -1,0 +1,88 @@
+package nvdsync
+
+import (
+	"archive/zip"
+	"bufio"
+	"compress/gzip"
+	"io"
+	"os"
+)
+
+func CompressFile(fileName string, newFileName string) error {
+	// Read old file
+	file, err := os.Open(fileName)
+	if err != nil {
+		return err
+	}
+	read := bufio.NewReader(file)
+	data, err := io.ReadAll(read)
+	if err != nil {
+		return err
+	}
+	file.Close()
+
+	// Write new file
+	newFile, err := os.Create(newFileName)
+	if err != nil {
+		return err
+	}
+	writer := gzip.NewWriter(newFile)
+	if _, err = writer.Write(data); err != nil {
+		return err
+	}
+	writer.Close()
+	newFile.Close()
+
+	// Remove old file
+	if err = os.Remove(fileName); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func zipFile(source, target string) error {
+	// Create a new zip archive.
+	zipFile, err := os.Create(target)
+	if err != nil {
+		return err
+	}
+	defer zipFile.Close()
+
+	zipWriter := zip.NewWriter(zipFile)
+	defer zipWriter.Close()
+
+	// Add a file to the archive.
+	fileToZip, err := os.Open(source)
+	if err != nil {
+		return err
+	}
+	defer fileToZip.Close()
+
+	// Get the file information.
+	info, err := fileToZip.Stat()
+	if err != nil {
+		return err
+	}
+
+	header, err := zip.FileInfoHeader(info)
+	if err != nil {
+		return err
+	}
+
+	// Using FileInfoHeader() above only uses the basename of the file. If you want
+	// to preserve the folder structure (for example, if you're zipping files from
+	// a directory), you would need to set header.Name to the full path.
+	header.Name = source
+
+	// Change to deflate to reduce file size but keep it compatible with unzip.
+	header.Method = zip.Deflate
+
+	writer, err := zipWriter.CreateHeader(header)
+	if err != nil {
+		return err
+	}
+
+	_, err = io.Copy(writer, fileToZip)
+	return err
+}

--- a/server/vulnerabilities/nvd/sync/utils.go
+++ b/server/vulnerabilities/nvd/sync/utils.go
@@ -8,30 +8,34 @@ import (
 	"os"
 )
 
+// CompressFile compresses a file using gzip and writes it to a new file
+// with the given name and removes the old file.
 func CompressFile(fileName string, newFileName string) error {
 	// Read old file
 	file, err := os.Open(fileName)
 	if err != nil {
 		return err
 	}
+	defer file.Close()
+
 	read := bufio.NewReader(file)
 	data, err := io.ReadAll(read)
 	if err != nil {
 		return err
 	}
-	file.Close()
 
 	// Write new file
 	newFile, err := os.Create(newFileName)
 	if err != nil {
 		return err
 	}
+	defer newFile.Close()
+
 	writer := gzip.NewWriter(newFile)
+	defer writer.Close()
 	if _, err = writer.Write(data); err != nil {
 		return err
 	}
-	writer.Close()
-	newFile.Close()
 
 	// Remove old file
 	if err = os.Remove(fileName); err != nil {

--- a/server/vulnerabilities/nvd/sync/vulncheck_api.go
+++ b/server/vulnerabilities/nvd/sync/vulncheck_api.go
@@ -1,0 +1,19 @@
+package nvdsync
+
+import "github.com/pandatix/nvdapi/v2"
+
+type VulnCheckCVE struct {
+	nvdapi.CVE
+	VcConfigurations []nvdapi.Config `json:"vcConfigurations,omitempty"`
+}
+
+type VulnCheckResponse struct {
+	Meta            VulnCheckMeta  `json:"_meta"`
+	Vulnerabilities []VulnCheckCVE `json:"data"`
+}
+
+type VulnCheckMeta struct {
+	NextCursor *string `json:"next_cursor"`
+}
+
+

--- a/server/vulnerabilities/nvd/sync/vulncheck_api.go
+++ b/server/vulnerabilities/nvd/sync/vulncheck_api.go
@@ -2,18 +2,23 @@ package nvdsync
 
 import "github.com/pandatix/nvdapi/v2"
 
+type VulnCheckCVEItem struct {
+	Item VulnCheckCVE `json:"cve"`
+}
+
 type VulnCheckCVE struct {
 	nvdapi.CVE
 	VcConfigurations []nvdapi.Config `json:"vcConfigurations,omitempty"`
 }
 
-type VulnCheckResponse struct {
-	Meta            VulnCheckMeta  `json:"_meta"`
-	Vulnerabilities []VulnCheckCVE `json:"data"`
+type VulnCheckBackupResponse struct {
+	Data []VulnCheckBackupData `json:"data"`
 }
 
-type VulnCheckMeta struct {
-	NextCursor *string `json:"next_cursor"`
+type VulnCheckBackupData struct {
+	URL string `json:"url"`
 }
 
-
+type VulnCheckBackupDataFile struct {
+	Vulnerabilities []VulnCheckCVEItem `json:"vulnerabilities"`
+}


### PR DESCRIPTION
#17966 

This change supplements NVD feed files with CPE data from Vulncheck.  NVD JSON feeds are generated via `/cmd/cve/generate.go` and are intended to be run in a GitHub action, with artifacts released every 30 min (`generate.go`) This currently takes ~17m.

After NVD data is generated, the "backup" Vulncheck feed (a zipped archive of gzipped json files) is downloaded containing the entire NVD feed with supplemented data (`vcConfigurations`).  Vulncheck also provides a paginated `index` API, but was found to be less reliable, so the full dataset is downloaded and which is sorted by lastModDate.  The dataset is processed is reverse alphabetical order until < 2024-02-01 which is when NVD began falling behind processing CPEs in their feed.

CPEs (Configuration Nodes in the JSON Data) found in the Vulncheck feed replace existing entries only if the NVD CVE does not have them.  CVEs found in the Vulncheck data that do not exist in the NVD feed are appended to the NVD feed.

Fleet currently converts the NVD 2.0 format to the legacy NVD format for processing, so the same is done with the Vulncheck data (which is in NVD 2.0 format) in order to insert correctly.

It was also found that the Vulncheck feed was not using the default "OR" operator within Configuration Nodes, which was causing a lot of log warnings from the `nvdtools` processing.  To resolve this, an OR is appended if no operator exists in the Vulncheck feed.

- [ ] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [X] Added/updated tests
- [X] Manual QA for all new/changed functionality
