### PR TITLE
vulnerabilities.current_instance_checks=no is now an alias for vulnerabilities.disable_schedule=true

### DIFF
--- a/changes/16661-current-instance-checks
+++ b/changes/16661-current-instance-checks
@@ -1,0 +1,1 @@
+vulnerabilities.current_instance_checks=no is now an alias for vulnerabilities.disable_schedule=true

--- a/cmd/fleet/cron.go
+++ b/cmd/fleet/cron.go
@@ -77,10 +77,6 @@ func cronVulnerabilities(
 	if config == nil {
 		return errors.New("nil configuration")
 	}
-	if config.CurrentInstanceChecks == "no" || config.CurrentInstanceChecks == "0" {
-		level.Info(logger).Log("msg", "host not configured to check for vulnerabilities")
-		return nil
-	}
 
 	level.Info(logger).Log("periodicity", config.Periodicity)
 

--- a/cmd/fleet/serve.go
+++ b/cmd/fleet/serve.go
@@ -713,15 +713,22 @@ the way that the Fleet server works.
 				initFatal(err, "failed to register stats schedule")
 			}
 
-			if !config.Vulnerabilities.DisableSchedule {
+			vulnerabilityScheduleDisabled := false
+			if config.Vulnerabilities.DisableSchedule {
+				vulnerabilityScheduleDisabled = true
+				level.Info(logger).Log("msg", "vulnerabilities schedule disabled via vulnerabilities.disable_schedule")
+			}
+			if config.Vulnerabilities.CurrentInstanceChecks == "no" || config.Vulnerabilities.CurrentInstanceChecks == "0" {
+				level.Info(logger).Log("msg", "vulnerabilities schedule disabled via vulnerabilities.current_instance_checks")
+				vulnerabilityScheduleDisabled = true
+			}
+			if !vulnerabilityScheduleDisabled {
 				// vuln processing by default is run by internal cron mechanism
 				if err := cronSchedules.StartCronSchedule(func() (fleet.CronSchedule, error) {
 					return newVulnerabilitiesSchedule(ctx, instanceID, ds, logger, &config.Vulnerabilities)
 				}); err != nil {
 					initFatal(err, "failed to register vulnerabilities schedule")
 				}
-			} else {
-				level.Info(logger).Log("msg", "vulnerabilities schedule disabled")
 			}
 
 			if err := cronSchedules.StartCronSchedule(func() (fleet.CronSchedule, error) {


### PR DESCRIPTION
#16661 
vulnerabilities.current_instance_checks=no is now an alias for vulnerabilities.disable_schedule=true

PR for doc changes: https://github.com/fleetdm/fleet/pull/18186

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [ ] Added/updated tests
- [x] Manual QA for all new/changed functionality
