### PR TITLE
Added release-fleetd-base workflow.

### DIFF
--- a/.github/actions/r2-upload/action.yml
+++ b/.github/actions/r2-upload/action.yml
@@ -4,6 +4,7 @@ description: Upload a file to R2
 
 inputs:
   filename:
+    # Future improvement: accept array of filenames as JSON string, and loop over it like in https://www.starkandwayne.com/blog/bash-for-loop-over-json-array-using-jq/index.html
     description: 'Name of the file to upload'
     required: true
   r2_endpoint:

--- a/.github/actions/r2-upload/action.yml
+++ b/.github/actions/r2-upload/action.yml
@@ -36,8 +36,8 @@ runs:
         provider = Cloudflare
         region = auto
         no_check_bucket = true
-        access_key_id = $R2_CHROME_ACCESS_KEY_ID
-        secret_access_key = $R2_CHROME_ACCESS_KEY_SECRET
+        access_key_id = $R2_ACCESS_KEY_ID
+        secret_access_key = $R2_ACCESS_KEY_SECRET
         endpoint = $R2_ENDPOINT
         " > ~/.config/rclone/rclone.conf
-        rclone copy --verbose ${{ inputs.filename}} r2:${{ inputs.r2_bucket }}/
+        rclone copy --verbose ${{ inputs.filename }} r2:${{ inputs.r2_bucket }}/

--- a/.github/actions/r2-upload/action.yml
+++ b/.github/actions/r2-upload/action.yml
@@ -25,7 +25,7 @@ runs:
     - name: Upload file to R2
       shell: bash
       run: |
-        ./.github/scripts/rclone-install.sh
+        sudo ./.github/scripts/rclone-install.sh
         mkdir -p ~/.config/rclone
         echo "[r2]
         type = s3

--- a/.github/actions/r2-upload/action.yml
+++ b/.github/actions/r2-upload/action.yml
@@ -40,4 +40,4 @@ runs:
         secret_access_key = $R2_CHROME_ACCESS_KEY_SECRET
         endpoint = $R2_ENDPOINT
         " > ~/.config/rclone/rclone.conf
-        rclone copy -v ${{ inputs.filename}} r2:${{ inputs.r2_bucket }}/
+        rclone copy --verbose ${{ inputs.filename}} r2:${{ inputs.r2_bucket }}/

--- a/.github/actions/r2-upload/action.yml
+++ b/.github/actions/r2-upload/action.yml
@@ -24,6 +24,10 @@ runs:
   steps:
     - name: Upload file to R2
       shell: bash
+      env:
+        R2_ENDPOINT: ${{ inputs.r2_endpoint }}
+        R2_ACCESS_KEY_ID: ${{ inputs.r2_access_key_id }}
+        R2_ACCESS_KEY_SECRET: ${{ inputs.r2_access_key_secret }}
       run: |
         sudo ./.github/scripts/rclone-install.sh
         mkdir -p ~/.config/rclone
@@ -32,8 +36,8 @@ runs:
         provider = Cloudflare
         region = auto
         no_check_bucket = true
-        access_key_id = ${{ inputs.r2_access_key_id }}
-        secret_access_key = ${{ inputs.r2_access_key_secret }}
-        endpoint = ${{ inputs.r2_endpoint }}
+        access_key_id = $R2_CHROME_ACCESS_KEY_ID
+        secret_access_key = $R2_CHROME_ACCESS_KEY_SECRET
+        endpoint = $R2_ENDPOINT
         " > ~/.config/rclone/rclone.conf
-        rclone copy ${{ inputs.filename}} r2:${{ inputs.r2_bucket }}/
+        rclone copy -v ${{ inputs.filename}} r2:${{ inputs.r2_bucket }}/

--- a/.github/actions/r2-upload/action.yml
+++ b/.github/actions/r2-upload/action.yml
@@ -2,22 +2,16 @@ name: R2 upload
 description: Upload a file to R2
 # Schema: https://json.schemastore.org/github-action.json
 
+# This action expects the following env vars to be set:
+# - R2_ENDPOINT: The endpoint of the R2 instance to upload to
+# - R2_ACCESS_KEY_ID: The access key ID to use for R2
+# - R2_ACCESS_KEY_SECRET: The access key secret to use for R2
+# - R2_BUCKET: The bucket to upload to
+
 inputs:
   filename:
     # Future improvement: accept array of filenames as JSON string, and loop over it like in https://www.starkandwayne.com/blog/bash-for-loop-over-json-array-using-jq/index.html
     description: 'Name of the file to upload'
-    required: true
-  r2_endpoint:
-    description: 'R2 endpoint'
-    required: true
-  r2_access_key_id:
-    description: 'R2 access key ID'
-    required: true
-  r2_access_key_secret:
-    description: 'R2 access key secret'
-    required: true
-  r2_bucket:
-    description: 'R2 bucket'
     required: true
 
 runs:
@@ -25,10 +19,6 @@ runs:
   steps:
     - name: Upload file to R2
       shell: bash
-      env:
-        R2_ENDPOINT: ${{ inputs.r2_endpoint }}
-        R2_ACCESS_KEY_ID: ${{ inputs.r2_access_key_id }}
-        R2_ACCESS_KEY_SECRET: ${{ inputs.r2_access_key_secret }}
       run: |
         sudo ./.github/scripts/rclone-install.sh
         mkdir -p ~/.config/rclone
@@ -41,4 +31,4 @@ runs:
         secret_access_key = $R2_ACCESS_KEY_SECRET
         endpoint = $R2_ENDPOINT
         " > ~/.config/rclone/rclone.conf
-        rclone copy --verbose ${{ inputs.filename }} r2:${{ inputs.r2_bucket }}/
+        rclone copy --verbose ${{ inputs.filename }} r2:${R2_BUCKET}/

--- a/.github/actions/r2-upload/action.yml
+++ b/.github/actions/r2-upload/action.yml
@@ -1,0 +1,39 @@
+name: R2 upload
+description: Upload a file to R2
+# Schema: https://json.schemastore.org/github-action.json
+
+inputs:
+  filename:
+    description: 'Name of the file to upload'
+    required: true
+  r2_endpoint:
+    description: 'R2 endpoint'
+    required: true
+  r2_access_key_id:
+    description: 'R2 access key ID'
+    required: true
+  r2_access_key_secret:
+    description: 'R2 access key secret'
+    required: true
+  r2_bucket:
+    description: 'R2 bucket'
+    required: true
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Upload file to R2
+      shell: bash
+      run: |
+        ./.github/scripts/rclone-install.sh
+        mkdir -p ~/.config/rclone
+        echo "[r2]
+        type = s3
+        provider = Cloudflare
+        region = auto
+        no_check_bucket = true
+        access_key_id = ${{ inputs.r2_access_key_id }}
+        secret_access_key = ${{ inputs.r2_access_key_secret }}
+        endpoint = ${{ inputs.r2_endpoint }}
+        " > ~/.config/rclone/rclone.conf
+        rclone copy ${{ inputs.filename}} r2:${{ inputs.r2_bucket }}/

--- a/.github/scripts/rclone-install.sh
+++ b/.github/scripts/rclone-install.sh
@@ -1,0 +1,212 @@
+#!/usr/bin/env bash
+
+# This script is a modified version of MIT licensed script from https://github.com/rclone/rclone/blob/v1.66.0/docs/content/install.sh
+# The script is used to install rclone on a GitHub Actions runner machine.
+# We use a specific version of rclone for stability/security reasons.
+download_version="v1.66.0"
+
+# error codes
+# 0 - exited without problems
+# 1 - parameters not supported were used or some unexpected error occurred
+# 2 - OS not supported by this script
+# 0 (was 3) - installed version of rclone is up to date
+# 4 - supported unzip tools are not available
+
+set -e
+
+#when adding a tool to the list make sure to also add its corresponding command further in the script
+unzip_tools_list=('unzip' '7z' 'busybox')
+
+usage() { echo "Usage: sudo -v ; curl https://rclone.org/install.sh | sudo bash [-s beta]" 1>&2; exit 1; }
+
+#check for beta flag
+if [ -n "$1" ] && [ "$1" != "beta" ]; then
+    usage
+fi
+
+if [ -n "$1" ]; then
+    install_beta="beta "
+fi
+
+
+#create tmp directory and move to it with macOS compatibility fallback
+tmp_dir=$(mktemp -d 2>/dev/null || mktemp -d -t 'rclone-install.XXXXXXXXXX')
+cd "$tmp_dir"
+
+
+#make sure unzip tool is available and choose one to work with
+set +e
+for tool in ${unzip_tools_list[*]}; do
+    trash=$(hash "$tool" 2>>errors)
+    if [ "$?" -eq 0 ]; then
+        unzip_tool="$tool"
+        break
+    fi
+done
+set -e
+
+# exit if no unzip tools available
+if [ -z "$unzip_tool" ]; then
+    printf "\nNone of the supported tools for extracting zip archives (${unzip_tools_list[*]}) were found. "
+    printf "Please install one of them and try again.\n\n"
+    exit 4
+fi
+
+# Make sure we don't create a root owned .config/rclone directory #2127
+export XDG_CONFIG_HOME=config
+
+#check installed version of rclone to determine if update is necessary
+version=$(rclone --version 2>>errors | head -n 1)
+if [ -z "$install_beta" ]; then
+    current_version=$(curl -fsS https://downloads.rclone.org/version.txt)
+else
+    current_version=download_version
+    # current_version=$(curl -fsS https://beta.rclone.org/version.txt)
+fi
+
+if [ "$version" = "$current_version" ]; then
+    printf "\nThe latest ${install_beta}version of rclone ${version} is already installed.\n\n"
+    exit 0 # originally 3
+fi
+
+
+#detect the platform
+OS="$(uname)"
+case $OS in
+  Linux)
+    OS='linux'
+    ;;
+  FreeBSD)
+    OS='freebsd'
+    ;;
+  NetBSD)
+    OS='netbsd'
+    ;;
+  OpenBSD)
+    OS='openbsd'
+    ;;
+  Darwin)
+    OS='osx'
+    binTgtDir=/usr/local/bin
+    man1TgtDir=/usr/local/share/man/man1
+    ;;
+  SunOS)
+    OS='solaris'
+    echo 'OS not supported'
+    exit 2
+    ;;
+  *)
+    echo 'OS not supported'
+    exit 2
+    ;;
+esac
+
+OS_type="$(uname -m)"
+case "$OS_type" in
+  x86_64|amd64)
+    OS_type='amd64'
+    ;;
+  i?86|x86)
+    OS_type='386'
+    ;;
+  aarch64|arm64)
+    OS_type='arm64'
+    ;;
+  armv7*)
+    OS_type='arm-v7'
+    ;;
+  armv6*)
+    OS_type='arm-v6'
+    ;;
+  arm*)
+    OS_type='arm'
+    ;;
+  *)
+    echo 'OS type not supported'
+    exit 2
+    ;;
+esac
+
+
+#download and unzip
+if [ -z "$install_beta" ]; then
+    download_link="https://downloads.rclone.org/${download_version}/rclone-${download_version}-${OS}-${OS_type}.zip"
+    rclone_zip="rclone-${download_version}-${OS}-${OS_type}.zip"
+    # download_link="https://downloads.rclone.org/rclone-current-${OS}-${OS_type}.zip"
+    # rclone_zip="rclone-current-${OS}-${OS_type}.zip"
+else
+    download_link="https://beta.rclone.org/rclone-beta-latest-${OS}-${OS_type}.zip"
+    rclone_zip="rclone-beta-latest-${OS}-${OS_type}.zip"
+fi
+
+curl -OfsS "$download_link"
+unzip_dir="tmp_unzip_dir_for_rclone"
+# there should be an entry in this switch for each element of unzip_tools_list
+case "$unzip_tool" in
+  'unzip')
+    unzip -a "$rclone_zip" -d "$unzip_dir"
+    ;;
+  '7z')
+    7z x "$rclone_zip" "-o$unzip_dir"
+    ;;
+  'busybox')
+    mkdir -p "$unzip_dir"
+    busybox unzip "$rclone_zip" -d "$unzip_dir"
+    ;;
+esac
+
+cd $unzip_dir/*
+
+#mounting rclone to environment
+
+case "$OS" in
+  'linux')
+    #binary
+    cp rclone /usr/bin/rclone.new
+    chmod 755 /usr/bin/rclone.new
+    chown root:root /usr/bin/rclone.new
+    mv /usr/bin/rclone.new /usr/bin/rclone
+    #manual
+    if ! [ -x "$(command -v mandb)" ]; then
+        echo 'mandb not found. The rclone man docs will not be installed.'
+    else
+        mkdir -p /usr/local/share/man/man1
+        cp rclone.1 /usr/local/share/man/man1/
+        mandb
+    fi
+    ;;
+  'freebsd'|'openbsd'|'netbsd')
+    #binary
+    cp rclone /usr/bin/rclone.new
+    chown root:wheel /usr/bin/rclone.new
+    mv /usr/bin/rclone.new /usr/bin/rclone
+    #manual
+    mkdir -p /usr/local/man/man1
+    cp rclone.1 /usr/local/man/man1/
+    makewhatis
+    ;;
+  'osx')
+    #binary
+    mkdir -m 0555 -p ${binTgtDir}
+    cp rclone ${binTgtDir}/rclone.new
+    mv ${binTgtDir}/rclone.new ${binTgtDir}/rclone
+    chmod a=x ${binTgtDir}/rclone
+    #manual
+    mkdir -m 0555 -p ${man1TgtDir}
+    cp rclone.1 ${man1TgtDir}
+    chmod a=r ${man1TgtDir}/rclone.1
+    ;;
+  *)
+    echo 'OS not supported'
+    exit 2
+esac
+
+#update version variable post install
+version=$(rclone --version 2>>errors | head -n 1)
+
+#cleanup
+rm -rf "$tmp_dir"
+
+printf "\n${version} has successfully installed."
+printf '\nNow run "rclone config" for setup. Check https://rclone.org/docs/ for more details.\n\n'
+exit 0

--- a/.github/scripts/rclone-install.sh
+++ b/.github/scripts/rclone-install.sh
@@ -167,13 +167,13 @@ case "$OS" in
     chown root:root /usr/bin/rclone.new
     mv /usr/bin/rclone.new /usr/bin/rclone
     #manual
-    if ! [ -x "$(command -v mandb)" ]; then
-        echo 'mandb not found. The rclone man docs will not be installed.'
-    else
-        mkdir -p /usr/local/share/man/man1
-        cp rclone.1 /usr/local/share/man/man1/
-        mandb
-    fi
+#    if ! [ -x "$(command -v mandb)" ]; then
+#        echo 'mandb not found. The rclone man docs will not be installed.'
+#    else
+#        mkdir -p /usr/local/share/man/man1
+#        cp rclone.1 /usr/local/share/man/man1/
+#        mandb
+#    fi
     ;;
   'freebsd'|'openbsd'|'netbsd')
     #binary
@@ -192,9 +192,9 @@ case "$OS" in
     mv ${binTgtDir}/rclone.new ${binTgtDir}/rclone
     chmod a=x ${binTgtDir}/rclone
     #manual
-    mkdir -m 0555 -p ${man1TgtDir}
-    cp rclone.1 ${man1TgtDir}
-    chmod a=r ${man1TgtDir}/rclone.1
+#    mkdir -m 0555 -p ${man1TgtDir}
+#    cp rclone.1 ${man1TgtDir}
+#    chmod a=r ${man1TgtDir}/rclone.1
     ;;
   *)
     echo 'OS not supported'

--- a/.github/workflows/release-fleetd-base.yml
+++ b/.github/workflows/release-fleetd-base.yml
@@ -76,10 +76,12 @@ jobs:
         with:
           egress-policy: audit
 
-      - name: Checkout Code to get install-rclone.sh script
+      - name: Checkout code needed for R2 upload
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
-          sparse-checkout: .github/scripts/rclone-install.sh
+          sparse-checkout: |
+            .github/actions/r2-upload/action.yml
+            .github/scripts/rclone-install.sh
           sparse-checkout-cone-mode: false
 
       - name: Install fleetctl
@@ -129,10 +131,12 @@ jobs:
         with:
           egress-policy: audit
 
-      - name: Checkout Code to get install-rclone.sh script
+      - name: Checkout code needed for R2 upload
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
-          sparse-checkout: .github/scripts/rclone-install.sh
+          sparse-checkout: |
+            .github/actions/r2-upload/action.yml
+            .github/scripts/rclone-install.sh
           sparse-checkout-cone-mode: false
 
       - name: Install fleetctl
@@ -161,10 +165,12 @@ jobs:
         with:
           egress-policy: audit
 
-      - name: Checkout Code to get install-rclone.sh script
+      - name: Checkout code needed for R2 upload
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
-          sparse-checkout: .github/scripts/rclone-install.sh
+          sparse-checkout: |
+            .github/actions/r2-upload/action.yml
+            .github/scripts/rclone-install.sh
           sparse-checkout-cone-mode: false
 
       - name: Download latest-meta.json artifact

--- a/.github/workflows/release-fleetd-base.yml
+++ b/.github/workflows/release-fleetd-base.yml
@@ -75,15 +75,15 @@ jobs:
 
       - name: Import package signing keys
         env:
-          APPLE_DEVELOPER_ID_CERTIFICATE: ${{ secrets.APPLE_DEVELOPER_ID_CERTIFICATE }}
-          APPLE_DEVELOPER_ID_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_DEVELOPER_ID_CERTIFICATE_PASSWORD }}
+          APPLE_INSTALLER_CERTIFICATE: ${{ secrets.APPLE_INSTALLER_CERTIFICATE }}
+          APPLE_INSTALLER_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_INSTALLER_CERTIFICATE_PASSWORD }}
           KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}
         run: |
-          echo "$APPLE_DEVELOPER_ID_CERTIFICATE" | base64 --decode > certificate.p12
+          echo "$APPLE_INSTALLER_CERTIFICATE" | base64 --decode > certificate.p12
           security create-keychain -p $KEYCHAIN_PASSWORD build.keychain
           security default-keychain -s build.keychain
           security unlock-keychain -p $KEYCHAIN_PASSWORD build.keychain
-          security import certificate.p12 -k build.keychain -P $APPLE_APPLICATION_CERTIFICATE_PASSWORD -T /usr/bin/productsign
+          security import certificate.p12 -k build.keychain -P $APPLE_INSTALLER_CERTIFICATE_PASSWORD -T /usr/bin/productsign
           security set-key-partition-list -S apple-tool:,apple:,productsign: -s -k $KEYCHAIN_PASSWORD build.keychain
           security find-identity -vv
           rm certificate.p12

--- a/.github/workflows/release-fleetd-base.yml
+++ b/.github/workflows/release-fleetd-base.yml
@@ -1,7 +1,6 @@
 name: Upload fleetd base to https://download.fleetdm.com
 
 on:
-  pull_request:
   workflow_dispatch: # Manual
   schedule:
     - cron: '0 3 * * *' # Nightly 3AM UTC
@@ -54,8 +53,7 @@ jobs:
           curl -O $BASE_URL/meta.json
           if diff latest-meta.json meta.json >/dev/null 2>&1
           then
-            echo "update_needed=false"
-            echo "update_needed=true" >> $GITHUB_OUTPUT
+            echo "update_needed=false" >> $GITHUB_OUTPUT
           else
             echo "update_needed=true" >> $GITHUB_OUTPUT
           fi

--- a/.github/workflows/release-fleetd-base.yml
+++ b/.github/workflows/release-fleetd-base.yml
@@ -20,7 +20,7 @@ permissions:
   contents: read
 
 env:
-  R2_ENDPOINT: $${{ secrets.R2_ENDPOINT }}
+  R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}
   R2_ACCESS_KEY_ID: ${{ secrets.R2_DOWNLOAD_TESTING_ACCESS_KEY_ID }} # Production: ${{ secrets.R2_DOWNLOAD_ACCESS_KEY_ID }} | Testing: ${{ secrets.R2_DOWNLOAD_TESTING_ACCESS_KEY_ID }}
   R2_ACCESS_KEY_SECRET: ${{ secrets.R2_DOWNLOAD_TESTING_ACCESS_KEY_SECRET }} # Production: ${{ secrets.R2_DOWNLOAD_ACCESS_KEY_SECRET }} | Testing: ${{ secrets.R2_DOWNLOAD_TESTING_ACCESS_KEY_SECRET }}
   R2_BUCKET: download-testing # Production: download | Testing: download-testing

--- a/.github/workflows/release-fleetd-base.yml
+++ b/.github/workflows/release-fleetd-base.yml
@@ -112,7 +112,7 @@ jobs:
           R2_ACCESS_KEY_SECRET: ${{ secrets.R2_DOWNLOAD_TESTING_ACCESS_KEY_SECRET }} # Production: ${{ secrets.R2_DOWNLOAD_ACCESS_KEY_SECRET }} | Testing: ${{ secrets.R2_DOWNLOAD_TESTING_ACCESS_KEY_SECRET }}
           R2_BUCKET: download-testing # Production: download | Testing: download-testing
         run: |
-          ./.github/scripts/install-rclone.sh
+          ./.github/scripts/rclone-install.sh
           mkdir -p ~/.config/rclone
           echo "[r2]
           type = s3
@@ -155,7 +155,7 @@ jobs:
           R2_ACCESS_KEY_SECRET: ${{ secrets.R2_DOWNLOAD_TESTING_ACCESS_KEY_SECRET }} # Production: ${{ secrets.R2_DOWNLOAD_ACCESS_KEY_SECRET }} | Testing: ${{ secrets.R2_DOWNLOAD_TESTING_ACCESS_KEY_SECRET }}
           R2_BUCKET: download-testing # Production: download | Testing: download-testing
         run: |
-          ./.github/scripts/install-rclone.sh
+          ./.github/scripts/rclone-install.sh
           mkdir -p ~/.config/rclone
           echo "[r2]
           type = s3
@@ -194,7 +194,7 @@ jobs:
           R2_ACCESS_KEY_SECRET: ${{ secrets.R2_DOWNLOAD_TESTING_ACCESS_KEY_SECRET }} # Production: ${{ secrets.R2_DOWNLOAD_ACCESS_KEY_SECRET }} | Testing: ${{ secrets.R2_DOWNLOAD_TESTING_ACCESS_KEY_SECRET }}
           R2_BUCKET: download-testing # Production: download | Testing: download-testing
         run: |
-          ./.github/scripts/install-rclone.sh
+          ./.github/scripts/rclone-install.sh
           mkdir -p ~/.config/rclone
           echo "[r2]
           type = s3

--- a/.github/workflows/release-fleetd-base.yml
+++ b/.github/workflows/release-fleetd-base.yml
@@ -54,8 +54,7 @@ jobs:
           curl -O $BASE_URL/meta.json
           if diff latest-meta.json meta.json >/dev/null 2>&1
           then
-            echo "overwriting update_needed=false"
-            echo "update_needed=true" >> $GITHUB_OUTPUT
+            echo "update_needed=false" >> $GITHUB_OUTPUT
           else
             echo "update_needed=true" >> $GITHUB_OUTPUT
           fi

--- a/.github/workflows/release-fleetd-base.yml
+++ b/.github/workflows/release-fleetd-base.yml
@@ -103,7 +103,8 @@ jobs:
       - name: Checkout Code to get install-rclone.sh script
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
-          fetch-depth: 0
+          sparse-checkout: .github/scripts/rclone-install.sh
+          sparse-checkout-cone-mode: false
 
       - name: Upload package
         env:
@@ -112,7 +113,7 @@ jobs:
           R2_ACCESS_KEY_SECRET: ${{ secrets.R2_DOWNLOAD_TESTING_ACCESS_KEY_SECRET }} # Production: ${{ secrets.R2_DOWNLOAD_ACCESS_KEY_SECRET }} | Testing: ${{ secrets.R2_DOWNLOAD_TESTING_ACCESS_KEY_SECRET }}
           R2_BUCKET: download-testing # Production: download | Testing: download-testing
         run: |
-          ./.github/scripts/rclone-install.sh
+          sudo ./.github/scripts/rclone-install.sh
           mkdir -p ~/.config/rclone
           echo "[r2]
           type = s3
@@ -146,7 +147,8 @@ jobs:
       - name: Checkout Code to get install-rclone.sh script
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
-          fetch-depth: 0
+          sparse-checkout: .github/scripts/rclone-install.sh
+          sparse-checkout-cone-mode: false
 
       - name: Upload package
         env:
@@ -155,7 +157,7 @@ jobs:
           R2_ACCESS_KEY_SECRET: ${{ secrets.R2_DOWNLOAD_TESTING_ACCESS_KEY_SECRET }} # Production: ${{ secrets.R2_DOWNLOAD_ACCESS_KEY_SECRET }} | Testing: ${{ secrets.R2_DOWNLOAD_TESTING_ACCESS_KEY_SECRET }}
           R2_BUCKET: download-testing # Production: download | Testing: download-testing
         run: |
-          ./.github/scripts/rclone-install.sh
+          sudo ./.github/scripts/rclone-install.sh
           mkdir -p ~/.config/rclone
           echo "[r2]
           type = s3
@@ -182,10 +184,14 @@ jobs:
         with:
           name: latest-meta.json
 
+      - name: Rename latest-meta.json to meta.json
+        run: mv latest-meta.json meta.json
+
       - name: Checkout Code to get install-rclone.sh script
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
-          fetch-depth: 0
+          sparse-checkout: .github/scripts/rclone-install.sh
+          sparse-checkout-cone-mode: false
 
       - name: Upload meta.json to R2
         env:
@@ -194,7 +200,7 @@ jobs:
           R2_ACCESS_KEY_SECRET: ${{ secrets.R2_DOWNLOAD_TESTING_ACCESS_KEY_SECRET }} # Production: ${{ secrets.R2_DOWNLOAD_ACCESS_KEY_SECRET }} | Testing: ${{ secrets.R2_DOWNLOAD_TESTING_ACCESS_KEY_SECRET }}
           R2_BUCKET: download-testing # Production: download | Testing: download-testing
         run: |
-          ./.github/scripts/rclone-install.sh
+          sudo ./.github/scripts/rclone-install.sh
           mkdir -p ~/.config/rclone
           echo "[r2]
           type = s3
@@ -205,5 +211,4 @@ jobs:
           secret_access_key = $R2_ACCESS_KEY_SECRET
           endpoint = $R2_ENDPOINT
           " > ~/.config/rclone/rclone.conf
-          mv latest-meta.json meta.json
           rclone copy meta.json r2:$R2_BUCKET/

--- a/.github/workflows/release-fleetd-base.yml
+++ b/.github/workflows/release-fleetd-base.yml
@@ -1,7 +1,6 @@
 name: Upload fleetd base to https://download.fleetdm.com
 
 on:
-  pull_request: # for testing
   workflow_dispatch: # Manual
   schedule:
     - cron: '0 3 * * *' # Nightly 3AM UTC
@@ -23,12 +22,11 @@ env:
   R2_ACCESS_KEY_ID: ${{ secrets.R2_DOWNLOAD_TESTING_ACCESS_KEY_ID }} # Production: ${{ secrets.R2_DOWNLOAD_ACCESS_KEY_ID }} | Testing: ${{ secrets.R2_DOWNLOAD_TESTING_ACCESS_KEY_ID }}
   R2_ACCESS_KEY_SECRET: ${{ secrets.R2_DOWNLOAD_TESTING_ACCESS_KEY_SECRET }} # Production: ${{ secrets.R2_DOWNLOAD_ACCESS_KEY_SECRET }} | Testing: ${{ secrets.R2_DOWNLOAD_TESTING_ACCESS_KEY_SECRET }}
   R2_BUCKET: download-testing # Production: download | Testing: download-testing
+  BASE_URL: https://download-testing.fleetdm.com # Production: https://download.fleetdm.com | Testing: https://download-testing.fleetdm.com
 
 jobs:
   check-for-fleetd-component-updates:
     runs-on: ubuntu-latest
-    env:
-      BASE_URL: https://download-testing.fleetdm.com # Production: https://download.fleetdm.com | Testing: https://download-testing.fleetdm.com
     outputs:
       update_needed: ${{ steps.check-for-fleetd-component-updates.outputs.update_needed }}
     steps:

--- a/.github/workflows/release-fleetd-base.yml
+++ b/.github/workflows/release-fleetd-base.yml
@@ -49,7 +49,8 @@ jobs:
           curl -O $BASE_URL/meta.json
           if diff latest-meta.json meta.json >/dev/null 2>&1
           then
-            echo "update_needed=false" >> $GITHUB_OUTPUT
+            echo "overwriting update_needed=false"
+            echo "update_needed=true" >> $GITHUB_OUTPUT
           else
             echo "update_needed=true" >> $GITHUB_OUTPUT
           fi
@@ -105,7 +106,7 @@ jobs:
           R2_ACCESS_KEY_SECRET: ${{ secrets.R2_DOWNLOAD_TESTING_ACCESS_KEY_SECRET }} # Production: ${{ secrets.R2_DOWNLOAD_ACCESS_KEY_SECRET }} | Testing: ${{ secrets.R2_DOWNLOAD_TESTING_ACCESS_KEY_SECRET }}
           R2_BUCKET: download-testing # Production: download | Testing: download-testing
         run: |
-          brew install rclone
+          ./.github/scripts/install-rclone.sh
           mkdir -p ~/.config/rclone
           echo "[r2]
           type = s3
@@ -143,7 +144,7 @@ jobs:
           R2_ACCESS_KEY_SECRET: ${{ secrets.R2_DOWNLOAD_TESTING_ACCESS_KEY_SECRET }} # Production: ${{ secrets.R2_DOWNLOAD_ACCESS_KEY_SECRET }} | Testing: ${{ secrets.R2_DOWNLOAD_TESTING_ACCESS_KEY_SECRET }}
           R2_BUCKET: download-testing # Production: download | Testing: download-testing
         run: |
-          sudo apt-get install rclone
+          ./.github/scripts/install-rclone.sh
           mkdir -p ~/.config/rclone
           echo "[r2]
           type = s3
@@ -175,7 +176,7 @@ jobs:
           R2_ACCESS_KEY_SECRET: ${{ secrets.R2_DOWNLOAD_TESTING_ACCESS_KEY_SECRET }} # Production: ${{ secrets.R2_DOWNLOAD_ACCESS_KEY_SECRET }} | Testing: ${{ secrets.R2_DOWNLOAD_TESTING_ACCESS_KEY_SECRET }}
           R2_BUCKET: download-testing # Production: download | Testing: download-testing
         run: |
-          sudo apt-get install rclone
+          ./.github/scripts/install-rclone.sh
           mkdir -p ~/.config/rclone
           echo "[r2]
           type = s3

--- a/.github/workflows/release-fleetd-base.yml
+++ b/.github/workflows/release-fleetd-base.yml
@@ -54,6 +54,7 @@ jobs:
           else
             echo "update_needed=true" >> $GITHUB_OUTPUT
           fi
+
       - name: Upload latest meta.json artifact
         uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
         with:
@@ -99,6 +100,11 @@ jobs:
           fleetctl package --type pkg --fleet-desktop --use-system-configuration --sign-identity $PACKAGE_SIGNING_IDENTITY_SHA1 --notarize
           mv fleet-osquery*.pkg fleetd-base.pkg
 
+      - name: Checkout Code to get install-rclone.sh script
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        with:
+          fetch-depth: 0
+
       - name: Upload package
         env:
           R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}
@@ -137,6 +143,11 @@ jobs:
           fleetctl package --type msi --fleet-desktop --fleet-url dummy --enroll-secret dummy
           mv fleet-osquery*.msi fleetd-base.msi
 
+      - name: Checkout Code to get install-rclone.sh script
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        with:
+          fetch-depth: 0
+
       - name: Upload package
         env:
           R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}
@@ -165,10 +176,17 @@ jobs:
         uses: step-security/harden-runner@63c24ba6bd7ba022e95695ff85de572c04a18142 # v2.7.0
         with:
           egress-policy: audit
+
       - name: Download latest-meta.json artifact
         uses: actions/download-artifact@c850b930e6ba138125429b7e5c93fc707a7f8427 # v4.1.4
         with:
           name: latest-meta.json
+
+      - name: Checkout Code to get install-rclone.sh script
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        with:
+          fetch-depth: 0
+
       - name: Upload meta.json to R2
         env:
           R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}

--- a/.github/workflows/release-fleetd-base.yml
+++ b/.github/workflows/release-fleetd-base.yml
@@ -117,9 +117,9 @@ jobs:
         with:
           filename: fleetd-base.pkg
           r2_endpoint: ${{ secrets.R2_ENDPOINT }}
-          r2_access_key_id: $R2_ACCESS_KEY_ID
-          r2_access_key_secret: $R2_ACCESS_KEY_SECRET
-          r2_bucket: $R2_BUCKET
+          r2_access_key_id: ${{ env.R2_ACCESS_KEY_ID }}
+          r2_access_key_secret: ${{ env.R2_ACCESS_KEY_SECRET }}
+          r2_bucket: ${{ env.R2_BUCKET }}
 
   update-fleetd-base-msi:
     needs: [check-for-fleetd-component-updates]
@@ -152,9 +152,9 @@ jobs:
         with:
           filename: fleetd-base.msi
           r2_endpoint: ${{ secrets.R2_ENDPOINT }}
-          r2_access_key_id: $R2_ACCESS_KEY_ID
-          r2_access_key_secret: $R2_ACCESS_KEY_SECRET
-          r2_bucket: $R2_BUCKET
+          r2_access_key_id: ${{ env.R2_ACCESS_KEY_ID }}
+          r2_access_key_secret: ${{ env.R2_ACCESS_KEY_SECRET }}
+          r2_bucket: ${{ env.R2_BUCKET }}
 
   update-meta-json:
     needs: [update-fleetd-base-pkg, update-fleetd-base-msi]
@@ -186,6 +186,6 @@ jobs:
         with:
           filename: meta.json
           r2_endpoint: ${{ secrets.R2_ENDPOINT }}
-          r2_access_key_id: $R2_ACCESS_KEY_ID
-          r2_access_key_secret: $R2_ACCESS_KEY_SECRET
-          r2_bucket: $R2_BUCKET
+          r2_access_key_id: ${{ env.R2_ACCESS_KEY_ID }}
+          r2_access_key_secret: ${{ env.R2_ACCESS_KEY_SECRET }}
+          r2_bucket: ${{ env.R2_BUCKET }}

--- a/.github/workflows/release-fleetd-base.yml
+++ b/.github/workflows/release-fleetd-base.yml
@@ -1,6 +1,7 @@
 name: Upload fleetd base to https://download.fleetdm.com
 
 on:
+  pull_request:
   workflow_dispatch: # Manual
   schedule:
     - cron: '0 3 * * *' # Nightly 3AM UTC
@@ -19,6 +20,7 @@ permissions:
   contents: read
 
 env:
+  R2_ENDPOINT: $${{ secrets.R2_ENDPOINT }}
   R2_ACCESS_KEY_ID: ${{ secrets.R2_DOWNLOAD_TESTING_ACCESS_KEY_ID }} # Production: ${{ secrets.R2_DOWNLOAD_ACCESS_KEY_ID }} | Testing: ${{ secrets.R2_DOWNLOAD_TESTING_ACCESS_KEY_ID }}
   R2_ACCESS_KEY_SECRET: ${{ secrets.R2_DOWNLOAD_TESTING_ACCESS_KEY_SECRET }} # Production: ${{ secrets.R2_DOWNLOAD_ACCESS_KEY_SECRET }} | Testing: ${{ secrets.R2_DOWNLOAD_TESTING_ACCESS_KEY_SECRET }}
   R2_BUCKET: download-testing # Production: download | Testing: download-testing
@@ -52,7 +54,8 @@ jobs:
           curl -O $BASE_URL/meta.json
           if diff latest-meta.json meta.json >/dev/null 2>&1
           then
-            echo "update_needed=false" >> $GITHUB_OUTPUT
+            echo "update_needed=false"
+            echo "update_needed=true" >> $GITHUB_OUTPUT
           else
             echo "update_needed=true" >> $GITHUB_OUTPUT
           fi
@@ -113,10 +116,6 @@ jobs:
         uses: ./.github/actions/r2-upload
         with:
           filename: fleetd-base.pkg
-          r2_endpoint: ${{ secrets.R2_ENDPOINT }}
-          r2_access_key_id: ${{ env.R2_ACCESS_KEY_ID }}
-          r2_access_key_secret: ${{ env.R2_ACCESS_KEY_SECRET }}
-          r2_bucket: ${{ env.R2_BUCKET }}
 
   update-fleetd-base-msi:
     needs: [check-for-fleetd-component-updates]
@@ -148,10 +147,6 @@ jobs:
         uses: ./.github/actions/r2-upload
         with:
           filename: fleetd-base.msi
-          r2_endpoint: ${{ secrets.R2_ENDPOINT }}
-          r2_access_key_id: ${{ env.R2_ACCESS_KEY_ID }}
-          r2_access_key_secret: ${{ env.R2_ACCESS_KEY_SECRET }}
-          r2_bucket: ${{ env.R2_BUCKET }}
 
   update-meta-json:
     needs: [update-fleetd-base-pkg, update-fleetd-base-msi]
@@ -182,7 +177,3 @@ jobs:
         uses: ./.github/actions/r2-upload
         with:
           filename: meta.json
-          r2_endpoint: ${{ secrets.R2_ENDPOINT }}
-          r2_access_key_id: ${{ env.R2_ACCESS_KEY_ID }}
-          r2_access_key_secret: ${{ env.R2_ACCESS_KEY_SECRET }}
-          r2_bucket: ${{ env.R2_BUCKET }}

--- a/.github/workflows/release-fleetd-base.yml
+++ b/.github/workflows/release-fleetd-base.yml
@@ -33,12 +33,12 @@ jobs:
           egress-policy: audit
 
       - name: Install Go
-        uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
+        uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
         with:
           go-version: ${{ vars.GO_VERSION }}
 
       - name: Checkout Code
-        uses: actions/checkout@629c2de402a417ea7690ca6ce3f33229e27606a5 # v2
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           fetch-depth: 0
 

--- a/.github/workflows/release-fleetd-base.yml
+++ b/.github/workflows/release-fleetd-base.yml
@@ -1,0 +1,170 @@
+name: Upload fleetd base to https://download.fleetdm.com
+
+on:
+  pull_request: # for testing
+  workflow_dispatch: # Manual
+  schedule:
+    - cron: '0 3 * * *' # Nightly 3AM UTC
+
+# This allows a subsequently queued workflow run to interrupt previous runs
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id}}
+  cancel-in-progress: true
+
+defaults:
+  run:
+    # fail-fast using bash -eo pipefail. See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#exit-codes-and-error-action-preference
+    shell: bash
+
+permissions:
+  contents: read
+
+jobs:
+  check-for-fleetd-component-updates:
+    runs-on: ubuntu-latest
+    env:
+      BASE_URL: https://download-testing.fleetdm.com # Production: https://download.fleetdm.com | Testing: https://download-testing.fleetdm.com
+    outputs:
+      update_needed: ${{ steps.check-for-fleetd-component-updates.outputs.update_needed }}
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@63c24ba6bd7ba022e95695ff85de572c04a18142 # v2.7.0
+        with:
+          egress-policy: audit
+
+      - name: Install Go
+        uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
+        with:
+          go-version: ${{ vars.GO_VERSION }}
+
+      - name: Checkout Code
+        uses: actions/checkout@629c2de402a417ea7690ca6ce3f33229e27606a5 # v2
+        with:
+          fetch-depth: 0
+
+      - name: Check for fleetd component updates
+        id: check-for-fleetd-component-updates
+        run: |
+          go run tools/tuf/status/tuf-status.go channel-version -channel stable --components orbit,desktop,osqueryd --format json > latest-meta.json
+          curl -O $BASE_URL/meta.json
+          if diff latest-meta.json meta.json >/dev/null 2>&1
+          then
+            echo "update_needed=false" >> $GITHUB_OUTPUT
+          else
+            echo "update_needed=true" >> $GITHUB_OUTPUT
+          fi
+      - name: Upload latest meta.json artifact
+        uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
+        with:
+          name: latest-meta.json
+          path: latest-meta.json
+          retention-days: 5
+
+  update-fleetd-base-pkg:
+    needs: [check-for-fleetd-component-updates]
+    if: needs.check-for-fleetd-component-updates.outputs.update_needed == 'true'
+    runs-on: macos-latest
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@63c24ba6bd7ba022e95695ff85de572c04a18142 # v2.7.0
+        with:
+          egress-policy: audit
+
+      - name: Install fleetctl
+        run: npm install -g fleetctl
+
+      - name: Build PKG
+        run: |
+          fleetctl package --type pkg --fleet-desktop --use-system-configuration
+          mv fleet-osquery*.pkg fleetd-base.pkg
+
+      - name: Upload package
+        env:
+          R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_DOWNLOAD_TESTING_ACCESS_KEY_ID }} # Production: ${{ secrets.R2_DOWNLOAD_ACCESS_KEY_ID }} | Testing: ${{ secrets.R2_DOWNLOAD_TESTING_ACCESS_KEY_ID }}
+          R2_ACCESS_KEY_SECRET: ${{ secrets.R2_DOWNLOAD_TESTING_ACCESS_KEY_SECRET }} # Production: ${{ secrets.R2_DOWNLOAD_ACCESS_KEY_SECRET }} | Testing: ${{ secrets.R2_DOWNLOAD_TESTING_ACCESS_KEY_SECRET }}
+          R2_BUCKET: download-testing # Production: download | Testing: download-testing
+        run: |
+          brew install rclone
+          mkdir -p ~/.config/rclone
+          echo "[r2]
+          type = s3
+          provider = Cloudflare
+          region = auto
+          no_check_bucket = true
+          access_key_id = $R2_ACCESS_KEY_ID
+          secret_access_key = $R2_ACCESS_KEY_SECRET
+          endpoint = $R2_ENDPOINT
+          " > ~/.config/rclone/rclone.conf
+          rclone copy fleetd-base.pkg r2:$R2_BUCKET/
+
+  update-fleetd-base-msi:
+    needs: [check-for-fleetd-component-updates]
+    if: needs.check-for-fleetd-component-updates.outputs.update_needed == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@63c24ba6bd7ba022e95695ff85de572c04a18142 # v2.7.0
+        with:
+          egress-policy: audit
+
+      - name: Install fleetctl
+        run: npm install -g fleetctl
+
+      - name: Build MSI
+        run: |
+          fleetctl package --type msi --fleet-desktop --fleet-url dummy --enroll-secret dummy
+          mv fleet-osquery*.msi fleetd-base.msi
+
+      - name: Upload package
+        env:
+          R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_DOWNLOAD_TESTING_ACCESS_KEY_ID }} # Production: ${{ secrets.R2_DOWNLOAD_ACCESS_KEY_ID }} | Testing: ${{ secrets.R2_DOWNLOAD_TESTING_ACCESS_KEY_ID }}
+          R2_ACCESS_KEY_SECRET: ${{ secrets.R2_DOWNLOAD_TESTING_ACCESS_KEY_SECRET }} # Production: ${{ secrets.R2_DOWNLOAD_ACCESS_KEY_SECRET }} | Testing: ${{ secrets.R2_DOWNLOAD_TESTING_ACCESS_KEY_SECRET }}
+          R2_BUCKET: download-testing # Production: download | Testing: download-testing
+        run: |
+          sudo apt-get install rclone
+          mkdir -p ~/.config/rclone
+          echo "[r2]
+          type = s3
+          provider = Cloudflare
+          region = auto
+          no_check_bucket = true
+          access_key_id = $R2_ACCESS_KEY_ID
+          secret_access_key = $R2_ACCESS_KEY_SECRET
+          endpoint = $R2_ENDPOINT
+          " > ~/.config/rclone/rclone.conf
+          rclone copy fleetd-base.msi r2:$R2_BUCKET/
+
+  update-meta-json:
+    needs: [update-fleetd-base-pkg, update-fleetd-base-msi]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@63c24ba6bd7ba022e95695ff85de572c04a18142 # v2.7.0
+        with:
+          egress-policy: audit
+      - name: Download latest-meta.json artifact
+        uses: actions/download-artifact@c850b930e6ba138125429b7e5c93fc707a7f8427 # v4.1.4
+        with:
+          name: latest-meta.json
+      - name: Upload meta.json to R2
+        env:
+          R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_DOWNLOAD_TESTING_ACCESS_KEY_ID }} # Production: ${{ secrets.R2_DOWNLOAD_ACCESS_KEY_ID }} | Testing: ${{ secrets.R2_DOWNLOAD_TESTING_ACCESS_KEY_ID }}
+          R2_ACCESS_KEY_SECRET: ${{ secrets.R2_DOWNLOAD_TESTING_ACCESS_KEY_SECRET }} # Production: ${{ secrets.R2_DOWNLOAD_ACCESS_KEY_SECRET }} | Testing: ${{ secrets.R2_DOWNLOAD_TESTING_ACCESS_KEY_SECRET }}
+          R2_BUCKET: download-testing # Production: download | Testing: download-testing
+        run: |
+          sudo apt-get install rclone
+          mkdir -p ~/.config/rclone
+          echo "[r2]
+          type = s3
+          provider = Cloudflare
+          region = auto
+          no_check_bucket = true
+          access_key_id = $R2_ACCESS_KEY_ID
+          secret_access_key = $R2_ACCESS_KEY_SECRET
+          endpoint = $R2_ENDPOINT
+          " > ~/.config/rclone/rclone.conf
+          mv latest-meta.json meta.json
+          rclone copy meta.json r2:$R2_BUCKET/

--- a/.github/workflows/release-fleetd-base.yml
+++ b/.github/workflows/release-fleetd-base.yml
@@ -73,9 +73,29 @@ jobs:
       - name: Install fleetctl
         run: npm install -g fleetctl
 
-      - name: Build PKG
+      - name: Import package signing keys
+        env:
+          APPLE_DEVELOPER_ID_CERTIFICATE: ${{ secrets.APPLE_DEVELOPER_ID_CERTIFICATE }}
+          APPLE_DEVELOPER_ID_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_DEVELOPER_ID_CERTIFICATE_PASSWORD }}
+          KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}
         run: |
-          fleetctl package --type pkg --fleet-desktop --use-system-configuration
+          echo "$APPLE_DEVELOPER_ID_CERTIFICATE" | base64 --decode > certificate.p12
+          security create-keychain -p $KEYCHAIN_PASSWORD build.keychain
+          security default-keychain -s build.keychain
+          security unlock-keychain -p $KEYCHAIN_PASSWORD build.keychain
+          security import certificate.p12 -k build.keychain -P $APPLE_APPLICATION_CERTIFICATE_PASSWORD -T /usr/bin/productsign
+          security set-key-partition-list -S apple-tool:,apple:,productsign: -s -k $KEYCHAIN_PASSWORD build.keychain
+          security find-identity -vv
+          rm certificate.p12
+
+      - name: Build PKG, sign, and notarize
+        env:
+          AC_USERNAME: ${{ secrets.APPLE_USERNAME }}
+          AC_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
+          AC_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          PACKAGE_SIGNING_IDENTITY_SHA1: D52080FD1F0941DE31346F06DA0F08AED6FACBBF
+        run: |
+          fleetctl package --type pkg --fleet-desktop --use-system-configuration --sign-identity $PACKAGE_SIGNING_IDENTITY_SHA1 --notarize
           mv fleet-osquery*.pkg fleetd-base.pkg
 
       - name: Upload package

--- a/.github/workflows/release-fleetd-base.yml
+++ b/.github/workflows/release-fleetd-base.yml
@@ -19,6 +19,11 @@ defaults:
 permissions:
   contents: read
 
+env:
+  R2_ACCESS_KEY_ID: ${{ secrets.R2_DOWNLOAD_TESTING_ACCESS_KEY_ID }} # Production: ${{ secrets.R2_DOWNLOAD_ACCESS_KEY_ID }} | Testing: ${{ secrets.R2_DOWNLOAD_TESTING_ACCESS_KEY_ID }}
+  R2_ACCESS_KEY_SECRET: ${{ secrets.R2_DOWNLOAD_TESTING_ACCESS_KEY_SECRET }} # Production: ${{ secrets.R2_DOWNLOAD_ACCESS_KEY_SECRET }} | Testing: ${{ secrets.R2_DOWNLOAD_TESTING_ACCESS_KEY_SECRET }}
+  R2_BUCKET: download-testing # Production: download | Testing: download-testing
+
 jobs:
   check-for-fleetd-component-updates:
     runs-on: ubuntu-latest
@@ -60,7 +65,6 @@ jobs:
         with:
           name: latest-meta.json
           path: latest-meta.json
-          retention-days: 5
 
   update-fleetd-base-pkg:
     needs: [check-for-fleetd-component-updates]
@@ -107,24 +111,13 @@ jobs:
           mv fleet-osquery*.pkg fleetd-base.pkg
 
       - name: Upload package
-        env:
-          R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}
-          R2_ACCESS_KEY_ID: ${{ secrets.R2_DOWNLOAD_TESTING_ACCESS_KEY_ID }} # Production: ${{ secrets.R2_DOWNLOAD_ACCESS_KEY_ID }} | Testing: ${{ secrets.R2_DOWNLOAD_TESTING_ACCESS_KEY_ID }}
-          R2_ACCESS_KEY_SECRET: ${{ secrets.R2_DOWNLOAD_TESTING_ACCESS_KEY_SECRET }} # Production: ${{ secrets.R2_DOWNLOAD_ACCESS_KEY_SECRET }} | Testing: ${{ secrets.R2_DOWNLOAD_TESTING_ACCESS_KEY_SECRET }}
-          R2_BUCKET: download-testing # Production: download | Testing: download-testing
-        run: |
-          sudo ./.github/scripts/rclone-install.sh
-          mkdir -p ~/.config/rclone
-          echo "[r2]
-          type = s3
-          provider = Cloudflare
-          region = auto
-          no_check_bucket = true
-          access_key_id = $R2_ACCESS_KEY_ID
-          secret_access_key = $R2_ACCESS_KEY_SECRET
-          endpoint = $R2_ENDPOINT
-          " > ~/.config/rclone/rclone.conf
-          rclone copy fleetd-base.pkg r2:$R2_BUCKET/
+        uses: ./.github/actions/r2-upload
+        with:
+          filename: fleetd-base.pkg
+          r2_endpoint: ${{ secrets.R2_ENDPOINT }}
+          r2_access_key_id: $R2_ACCESS_KEY_ID
+          r2_access_key_secret: $R2_ACCESS_KEY_SECRET
+          r2_bucket: $R2_BUCKET
 
   update-fleetd-base-msi:
     needs: [check-for-fleetd-component-updates]
@@ -151,24 +144,13 @@ jobs:
           mv fleet-osquery*.msi fleetd-base.msi
 
       - name: Upload package
-        env:
-          R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}
-          R2_ACCESS_KEY_ID: ${{ secrets.R2_DOWNLOAD_TESTING_ACCESS_KEY_ID }} # Production: ${{ secrets.R2_DOWNLOAD_ACCESS_KEY_ID }} | Testing: ${{ secrets.R2_DOWNLOAD_TESTING_ACCESS_KEY_ID }}
-          R2_ACCESS_KEY_SECRET: ${{ secrets.R2_DOWNLOAD_TESTING_ACCESS_KEY_SECRET }} # Production: ${{ secrets.R2_DOWNLOAD_ACCESS_KEY_SECRET }} | Testing: ${{ secrets.R2_DOWNLOAD_TESTING_ACCESS_KEY_SECRET }}
-          R2_BUCKET: download-testing # Production: download | Testing: download-testing
-        run: |
-          sudo ./.github/scripts/rclone-install.sh
-          mkdir -p ~/.config/rclone
-          echo "[r2]
-          type = s3
-          provider = Cloudflare
-          region = auto
-          no_check_bucket = true
-          access_key_id = $R2_ACCESS_KEY_ID
-          secret_access_key = $R2_ACCESS_KEY_SECRET
-          endpoint = $R2_ENDPOINT
-          " > ~/.config/rclone/rclone.conf
-          rclone copy fleetd-base.msi r2:$R2_BUCKET/
+        uses: ./.github/actions/r2-upload
+        with:
+          filename: fleetd-base.msi
+          r2_endpoint: ${{ secrets.R2_ENDPOINT }}
+          r2_access_key_id: $R2_ACCESS_KEY_ID
+          r2_access_key_secret: $R2_ACCESS_KEY_SECRET
+          r2_bucket: $R2_BUCKET
 
   update-meta-json:
     needs: [update-fleetd-base-pkg, update-fleetd-base-msi]
@@ -193,22 +175,11 @@ jobs:
       - name: Rename latest-meta.json to meta.json
         run: mv latest-meta.json meta.json
 
-      - name: Upload meta.json to R2
-        env:
-          R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}
-          R2_ACCESS_KEY_ID: ${{ secrets.R2_DOWNLOAD_TESTING_ACCESS_KEY_ID }} # Production: ${{ secrets.R2_DOWNLOAD_ACCESS_KEY_ID }} | Testing: ${{ secrets.R2_DOWNLOAD_TESTING_ACCESS_KEY_ID }}
-          R2_ACCESS_KEY_SECRET: ${{ secrets.R2_DOWNLOAD_TESTING_ACCESS_KEY_SECRET }} # Production: ${{ secrets.R2_DOWNLOAD_ACCESS_KEY_SECRET }} | Testing: ${{ secrets.R2_DOWNLOAD_TESTING_ACCESS_KEY_SECRET }}
-          R2_BUCKET: download-testing # Production: download | Testing: download-testing
-        run: |
-          sudo ./.github/scripts/rclone-install.sh
-          mkdir -p ~/.config/rclone
-          echo "[r2]
-          type = s3
-          provider = Cloudflare
-          region = auto
-          no_check_bucket = true
-          access_key_id = $R2_ACCESS_KEY_ID
-          secret_access_key = $R2_ACCESS_KEY_SECRET
-          endpoint = $R2_ENDPOINT
-          " > ~/.config/rclone/rclone.conf
-          rclone copy meta.json r2:$R2_BUCKET/
+      - name: Upload meta.json
+        uses: ./.github/actions/r2-upload
+        with:
+          filename: meta.json
+          r2_endpoint: ${{ secrets.R2_ENDPOINT }}
+          r2_access_key_id: $R2_ACCESS_KEY_ID
+          r2_access_key_secret: $R2_ACCESS_KEY_SECRET
+          r2_bucket: $R2_BUCKET

--- a/.github/workflows/release-fleetd-base.yml
+++ b/.github/workflows/release-fleetd-base.yml
@@ -72,6 +72,12 @@ jobs:
         with:
           egress-policy: audit
 
+      - name: Checkout Code to get install-rclone.sh script
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        with:
+          sparse-checkout: .github/scripts/rclone-install.sh
+          sparse-checkout-cone-mode: false
+
       - name: Install fleetctl
         run: npm install -g fleetctl
 
@@ -99,12 +105,6 @@ jobs:
         run: |
           fleetctl package --type pkg --fleet-desktop --use-system-configuration --sign-identity $PACKAGE_SIGNING_IDENTITY_SHA1 --notarize
           mv fleet-osquery*.pkg fleetd-base.pkg
-
-      - name: Checkout Code to get install-rclone.sh script
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-        with:
-          sparse-checkout: .github/scripts/rclone-install.sh
-          sparse-checkout-cone-mode: false
 
       - name: Upload package
         env:
@@ -136,6 +136,12 @@ jobs:
         with:
           egress-policy: audit
 
+      - name: Checkout Code to get install-rclone.sh script
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        with:
+          sparse-checkout: .github/scripts/rclone-install.sh
+          sparse-checkout-cone-mode: false
+
       - name: Install fleetctl
         run: npm install -g fleetctl
 
@@ -143,12 +149,6 @@ jobs:
         run: |
           fleetctl package --type msi --fleet-desktop --fleet-url dummy --enroll-secret dummy
           mv fleet-osquery*.msi fleetd-base.msi
-
-      - name: Checkout Code to get install-rclone.sh script
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-        with:
-          sparse-checkout: .github/scripts/rclone-install.sh
-          sparse-checkout-cone-mode: false
 
       - name: Upload package
         env:
@@ -179,6 +179,12 @@ jobs:
         with:
           egress-policy: audit
 
+      - name: Checkout Code to get install-rclone.sh script
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        with:
+          sparse-checkout: .github/scripts/rclone-install.sh
+          sparse-checkout-cone-mode: false
+
       - name: Download latest-meta.json artifact
         uses: actions/download-artifact@c850b930e6ba138125429b7e5c93fc707a7f8427 # v4.1.4
         with:
@@ -186,12 +192,6 @@ jobs:
 
       - name: Rename latest-meta.json to meta.json
         run: mv latest-meta.json meta.json
-
-      - name: Checkout Code to get install-rclone.sh script
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-        with:
-          sparse-checkout: .github/scripts/rclone-install.sh
-          sparse-checkout-cone-mode: false
 
       - name: Upload meta.json to R2
         env:


### PR DESCRIPTION
#16347

New GitHub workflow.
- Uses `tools/tuf/status/tuf-status.go` to check the latest osquery/orbit/fleet-desktop versions
- Uploads https://download-testing.fleetdm.com/meta.json to keep track of versions
- macOS: https://download-testing.fleetdm.com/fleetd-base.pkg
- Windows: https://download-testing.fleetdm.com/fleetd-base.msi

This version creates and uploads macOS and fleetd base packages to https://download-testing.fleetdm.com

QA instructions updated in the issue. After QA, we will update the workflow to upload to https://download.fleetdm.com
