### PR TITLE
Fleet UI: Pass teamId through all query flows

### DIFF
--- a/frontend/pages/queries/details/QueryDetailsPage/QueryDetailsPage.tsx
+++ b/frontend/pages/queries/details/QueryDetailsPage/QueryDetailsPage.tsx
@@ -270,7 +270,10 @@ const QueryDetailsPage = ({
                         className={`${baseClass}__run`}
                         variant="blue-green"
                         onClick={() => {
-                          queryId && router.push(PATHS.LIVE_QUERY(queryId));
+                          queryId &&
+                            router.push(
+                              PATHS.LIVE_QUERY(queryId, currentTeamId)
+                            );
                         }}
                         disabled={disabledLiveQuery}
                       >

--- a/frontend/pages/queries/live/LiveQueryPage/LiveQueryPage.tsx
+++ b/frontend/pages/queries/live/LiveQueryPage/LiveQueryPage.tsx
@@ -3,6 +3,7 @@ import { useQuery } from "react-query";
 import { useErrorHandler } from "react-error-boundary";
 import { InjectedRouter, Params } from "react-router/lib/Router";
 import PATHS from "router/paths";
+import useTeamIdParam from "hooks/useTeamIdParam";
 
 import { AppContext } from "context/app";
 import { QueryContext } from "context/query";
@@ -40,6 +41,13 @@ const RunQueryPage = ({
   location,
 }: IRunQueryPageProps): JSX.Element => {
   const queryId = paramsQueryId ? parseInt(paramsQueryId, 10) : null;
+
+  const { currentTeamId } = useTeamIdParam({
+    location,
+    router,
+    includeAllTeams: true,
+    includeNoTeam: false,
+  });
 
   const handlePageError = useErrorHandler();
   const { config } = useContext(AppContext);
@@ -79,7 +87,7 @@ const RunQueryPage = ({
   if (disabledLiveQuery) {
     queryId
       ? router.push(PATHS.QUERY_DETAILS(queryId))
-      : router.push(PATHS.NEW_QUERY());
+      : router.push(PATHS.NEW_QUERY(currentTeamId));
   }
 
   // disabled on page load so we can control the number of renders
@@ -150,8 +158,8 @@ const RunQueryPage = ({
   const goToQueryEditor = useCallback(
     () =>
       queryId
-        ? router.push(PATHS.EDIT_QUERY(queryId))
-        : router.push(PATHS.NEW_QUERY()),
+        ? router.push(PATHS.EDIT_QUERY(queryId, currentTeamId))
+        : router.push(PATHS.NEW_QUERY(currentTeamId)),
     []
   );
 

--- a/frontend/pages/queries/live/LiveQueryPage/LiveQueryPage.tsx
+++ b/frontend/pages/queries/live/LiveQueryPage/LiveQueryPage.tsx
@@ -86,7 +86,7 @@ const RunQueryPage = ({
   // Reroute users out of live flow when live queries are globally disabled
   if (disabledLiveQuery) {
     queryId
-      ? router.push(PATHS.QUERY_DETAILS(queryId))
+      ? router.push(PATHS.QUERY_DETAILS(queryId, currentTeamId))
       : router.push(PATHS.NEW_QUERY(currentTeamId));
   }
 


### PR DESCRIPTION
## Issue
#17194 

## Description
- Team ID is not lost when going between live query flows 

## Screenrecording
https://www.loom.com/share/5ed8de89924c4fbfa08c7a50357802ce?sid=a911c650-14ae-4206-ade4-3e3e7f590f4b

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [ ] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
- [ ] Manual QA for all new/changed functionality

