### PR TITLE
Add sequence diagram for NVD vulnerability processing

### DIFF
--- a/docs/Contributing/Vulnerability-processing.md
+++ b/docs/Contributing/Vulnerability-processing.md
@@ -40,11 +40,11 @@ be able write a query to retrieve all CVEs).
 
 ```mermaid
 sequenceDiagram
-  participant fleet_server as "Fleet server"
-  participant vulndb_repo as "fleetdm/vulndb"
-  participant nvd_repo as "fleetdm/nvd"
-  participant nvd_site as "National Vulnerability Database"
-  participant vulncheck as "VulnCheck"
+  participant fleet_server as Fleet server
+  participant vulnerabilities_repo as github.com/fleetdm/vulnerabilities
+  participant nvd_repo as github.com/fleetdm/nvd
+  participant nvd_site as National Vulnerability Database
+  participant vulncheck as VulnCheck
 
   alt Github action every 24h
   nvd_repo->>nvd_site: Download CPE dictionary
@@ -53,18 +53,18 @@ sequenceDiagram
   end
 
   alt Github action every 30m
-  vulndb_repo->>nvd_site: Download CVE feed<br>using API 2.0
-  nvd_site-->>vulndb_repo: ;
-  vulndb_repo->>vulncheck: Download CVE gzip<br>(with vcConfigurations)
-  vulncheck-->>vulndb_repo: ;
-  note over vulndb_repo: 1. Combine NVD and VulnCheck feed data<br>2. Generate and release NVD feed legacy gzip format;
+  vulnerabilities_repo->>nvd_site: Download CVE feed<br>using API 2.0
+  nvd_site-->>vulnerabilities_repo: ;
+  vulnerabilities_repo->>vulncheck: Download CVE gzip<br>(with vcConfigurations)
+  vulncheck-->>vulnerabilities_repo: ;
+  note over vulnerabilities_repo: 1. Combine NVD and VulnCheck feed data<br>2. Generate and release NVD feed legacy gzip format;
   end
 
   alt cron every 1h
-  fleet_server->>nvd_repo: Download cpe.sqlite<br>(only updated once a day)
+  fleet_server->>nvd_repo: Download cpe.sqlite<br>(it's only downloaded once every day)
   nvd_repo-->>fleet_server: ;
-  fleet_server->>vulndb_repo: Download NVD feed using NVD legacy feed format;
-  vulndb_repo-->>fleet_server: ;
+  fleet_server->>vulnerabilities_repo: Download CVE updates using NVD legacy feed format;
+  vulnerabilities_repo-->>fleet_server: ;
   note over fleet_server: Run vulnerability processing
   end
 ```

--- a/docs/Contributing/Vulnerability-processing.md
+++ b/docs/Contributing/Vulnerability-processing.md
@@ -29,6 +29,46 @@ Vulnerability processing happens on the Fleet instance and not on the host machi
 detected vulnerabilities cannot be used in the same way you would use an osquery query (e.g. you wouldn't
 be able write a query to retrieve all CVEs).
 
+#### CPE and CVE data generation workflow
+
+- Fleet uses the [National Vulnerability Database CPE Dictionary](https://nvd.nist.gov/products/cpe) to get CPE information (this information maps software names/titles to CPEs)
+- Fleet combines two sources to get accurate and up-to-date CVE information:
+  - [National Vulnerability Database](https://nvd.nist.gov/developers/vulnerabilities)'s CVE feeds.
+  - [VulnCheck](https://vulncheck.com/)
+- To reduce the load and complexity of processing these datasets, Fleet uses two Github repositories (https://github.com/fleetdm/nvd and https://github.com/fleetdm/vulndb) that fetch, pre-process and expose the resulting dataset as Github releases.
+- The Fleet servers then download these Github releases and run vulnerability processing using the downloaded datasets and the software information fetched from hosts.
+
+```mermaid
+sequenceDiagram
+  participant fleet_server as "Fleet server"
+  participant vulndb_repo as "fleetdm/vulndb"
+  participant nvd_repo as "fleetdm/nvd"
+  participant nvd_site as "National Vulnerability Database"
+  participant vulncheck as "VulnCheck"
+
+  alt Github action every 24h
+  nvd_repo->>nvd_site: Download CPE dictionary
+  nvd_site-->>nvd_repo: ;
+  note over nvd_repo: Generate and<br>release cpe.sqlite
+  end
+
+  alt Github action every 30m
+  vulndb_repo->>nvd_site: Download CVE feed<br>using API 2.0
+  nvd_site-->>vulndb_repo: ;
+  vulndb_repo->>vulncheck: Download CVE gzip<br>(with vcConfigurations)
+  vulncheck-->>vulndb_repo: ;
+  note over vulndb_repo: 1. Combine NVD and VulnCheck feed data<br>2. Generate and release NVD feed legacy gzip format;
+  end
+
+  alt cron every 1h
+  fleet_server->>nvd_repo: Download cpe.sqlite<br>(only updated once a day)
+  nvd_repo-->>fleet_server: ;
+  fleet_server->>vulndb_repo: Download NVD feed using NVD legacy feed format;
+  vulndb_repo-->>fleet_server: ;
+  note over fleet_server: Run vulnerability processing
+  end
+```
+
 ### Mac Office release notes
 
 We periodically parse the Mac Office release notes posted at


### PR DESCRIPTION
#17966

Better view here: https://github.com/fleetdm/fleet/blob/17966-add-sequence-diagram-oncall/docs/Contributing/Vulnerability-processing.md#cpe-and-cve-data-generation-workflow

Added these docs during my oncall time (and also during the VulnCheck PR review).

@mostlikelee Let me know if I got this right.