### PR TITLE
Update macos-device-health.policies.yml to add check macOS version

### DIFF
--- a/it-and-security/lib/macos-device-health.policies.yml
+++ b/it-and-security/lib/macos-device-health.policies.yml
@@ -59,7 +59,7 @@
   description: Looks for PDF files with file names typically used by 1Password for emergency recovery kits. To protect the performance of your devices, the search is one level deep and limited to the Desktop, Documents, Downloads, and Shared folders.
   resolution: Delete 1Password emergency kits from your computer, and empty the trash. 1Password emergency kits should only be printed and stored in a physically secure location.
   platform: darwin
-- name: macOS - check if latest version
+- name: macOS - Check if latest version
   query: SELECT 1 where exists(SELECT major, concat_ws(".", major, minor, patch) AS "macOS Version"
 FROM os_version
 --Sonoma

--- a/it-and-security/lib/macos-device-health.policies.yml
+++ b/it-and-security/lib/macos-device-health.policies.yml
@@ -56,6 +56,16 @@
 - name: macOS - No 1Password emergency kit stored in desktop, documents, or downloads folders
   query: SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM file WHERE filename LIKE '%Emergency Kit%.pdf' AND (path LIKE '/Users/%/Desktop/%' OR path LIKE '/Users/%/Documents/%' OR path LIKE '/Users/%/Downloads/%' OR path LIKE '/Users/Shared/%'));
   critical: false
-  description: "Looks for PDF files with file names typically used by 1Password for emergency recovery kits. To protect the performance of your devices, the search is one level deep and limited to the Desktop, Documents, Downloads, and Shared folders."
-  resolution: "Delete 1Password emergency kits from your computer, and empty the trash. 1Password emergency kits should only be printed and stored in a physically secure location."
+  description: Looks for PDF files with file names typically used by 1Password for emergency recovery kits. To protect the performance of your devices, the search is one level deep and limited to the Desktop, Documents, Downloads, and Shared folders.
+  resolution: Delete 1Password emergency kits from your computer, and empty the trash. 1Password emergency kits should only be printed and stored in a physically secure location.
   platform: darwin
+- name: macOS - check if latest version
+  query: SELECT 1 where exists(SELECT major, concat_ws(".", major, minor, patch) AS "macOS Version"
+FROM os_version
+--Sonoma
+WHERE (major = "14" AND "macOS Version" < "14.4.1"));
+  critical: false
+  description: This policy check if macOS version is most recent version available.
+  resolution: From the Apple menu, select System Settings. Navigate to General > Software Update.
+  platform: darwin
+  calendar_events_enabled: true

--- a/it-and-security/lib/macos-device-health.policies.yml
+++ b/it-and-security/lib/macos-device-health.policies.yml
@@ -44,7 +44,7 @@
         username = ''
     ) 
     AND NOT EXISTS (
-        SELECT 1 FROM managed_policies WHERE 
+      SELECT 1 FROM managed_policies WHERE 
         domain='com.apple.screensaver' AND 
         name='idleTime' AND 
         CAST(value AS INT) > 1200
@@ -54,16 +54,22 @@
   resolution: An an IT admin, deploy a macOS, screen saver profile with the maxInactivity option set to 20 minutes.
   platform: darwin
 - name: macOS - No 1Password emergency kit stored in desktop, documents, or downloads folders
-  query: SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM file WHERE filename LIKE '%Emergency Kit%.pdf' AND (path LIKE '/Users/%/Desktop/%' OR path LIKE '/Users/%/Documents/%' OR path LIKE '/Users/%/Downloads/%' OR path LIKE '/Users/Shared/%'));
+  query: SELECT 1 WHERE 
+    NOT EXISTS (
+      SELECT 1 FROM file WHERE 
+        filename LIKE '%Emergency Kit%.pdf' AND 
+        (path LIKE '/Users/%/Desktop/%' OR path LIKE '/Users/%/Documents/%' OR path LIKE '/Users/%/Downloads/%' OR path LIKE '/Users/Shared/%')
+    );
   critical: false
   description: Looks for PDF files with file names typically used by 1Password for emergency recovery kits. To protect the performance of your devices, the search is one level deep and limited to the Desktop, Documents, Downloads, and Shared folders.
   resolution: Delete 1Password emergency kits from your computer, and empty the trash. 1Password emergency kits should only be printed and stored in a physically secure location.
   platform: darwin
 - name: macOS - Check if latest version
-  query: SELECT 1 where exists(SELECT major, concat_ws(".", major, minor, patch) AS "macOS Version"
-FROM os_version
---Sonoma
-WHERE (major = "14" AND "macOS Version" < "14.4.1"));
+  query: SELECT 1 WHERE 
+    EXISTS ( 
+      SELECT major, concat_ws(".", major, minor, patch) AS "macOS Version" FROM os_version --Sonoma WHERE 
+        (major = "14" AND "macOS Version" < "14.4.1")
+    );
   critical: false
   description: This policy check if macOS version is most recent version available.
   resolution: From the Apple menu, select System Settings. Navigate to General > Software Update.


### PR DESCRIPTION
Adding new policy to the macos-device-health.policies.yml that checks if the device meets minimum macOS (currently set to 14.4.1) and enables it for calendar events.
Reference https://github.com/fleetdm/confidential/issues/6015