### PR TITLE
Add calendar integration settings into workstation canary team

### DIFF
--- a/it-and-security/teams/workstations-canary.yml
+++ b/it-and-security/teams/workstations-canary.yml
@@ -8,6 +8,10 @@ team_settings:
     host_expiry_window: 0
   secrets:
     - secret: $DOGFOOD_WORKSTATIONS_CANARY_ENROLL_SECRET
+  integrations:
+    google_calendar:
+      enable_calendar_events: true
+      webhook_url: $DOGFOOD_WORKSTATIONS_CANARY_CALENDAR_WEBHOOK_URL
 agent_options:
   config:
     decorators:


### PR DESCRIPTION
Adding integration settings and linking to the webhook_url secret set for calendar webhook