### PR TITLE
[Unreleased bug and Unit tests] Test all disabled dropdown options on host actions dropdown

### DIFF
--- a/frontend/pages/hosts/details/HostDetailsPage/HostActionsDropdown/HostActionsDropdown.tests.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/HostActionsDropdown/HostActionsDropdown.tests.tsx
@@ -8,8 +8,6 @@ import createMockTeam from "__mocks__/teamMock";
 
 import HostActionsDropdown from "./HostActionsDropdown";
 
-const SCRIPTS_DISABLED_TOOLTIP_TEXT = /fleetd agent with --enable-scripts/i;
-
 describe("Host Actions Dropdown", () => {
   describe("Transfer action", () => {
     it("renders the Transfer action when on premium tier and the user is a global admin", async () => {
@@ -117,12 +115,14 @@ describe("Host Actions Dropdown", () => {
       await user.click(screen.getByText("Actions"));
 
       expect(
-        screen.getByText("Query").parentNode?.parentNode?.parentNode
+        screen.getByText("Query").parentElement?.parentElement?.parentElement
       ).toHaveClass("is-disabled");
 
-      await user.hover(screen.getByText("Query"));
-
       await waitFor(() => {
+        waitFor(() => {
+          user.hover(screen.getByText("Query"));
+        });
+
         expect(
           screen.getByText(/You can't query an offline host./i)
         ).toBeInTheDocument();
@@ -152,7 +152,7 @@ describe("Host Actions Dropdown", () => {
 
       await user.click(screen.getByText("Actions"));
       expect(
-        screen.getByText("Query").parentNode?.parentNode?.parentNode
+        screen.getByText("Query").parentElement?.parentElement?.parentElement
       ).toHaveClass("is-disabled");
     });
 
@@ -179,7 +179,9 @@ describe("Host Actions Dropdown", () => {
 
       await user.click(screen.getByText("Actions"));
 
-      expect(screen.getByText("Query").parentNode).toHaveClass("is-disabled");
+      expect(screen.getByText("Query").parentElement).toHaveClass(
+        "is-disabled"
+      );
     });
   });
 
@@ -385,7 +387,7 @@ describe("Host Actions Dropdown", () => {
 
       debug();
 
-      expect(screen.getByText("Turn off MDM").parentNode).toHaveClass(
+      expect(screen.getByText("Turn off MDM").parentElement).toHaveClass(
         "is-disabled"
       );
     });
@@ -587,14 +589,16 @@ describe("Host Actions Dropdown", () => {
       await user.click(screen.getByText("Actions"));
 
       expect(
-        screen.getByText("Lock").parentNode?.parentNode?.parentNode
+        screen.getByText("Lock").parentElement?.parentElement?.parentElement
       ).toHaveClass("is-disabled");
 
-      await user.hover(screen.getByText("Lock"));
-
       await waitFor(() => {
+        waitFor(() => {
+          user.hover(screen.getByText("Lock"));
+        });
+
         expect(
-          screen.getByText(SCRIPTS_DISABLED_TOOLTIP_TEXT)
+          screen.getByText(/fleetd agent with --enable-scripts/i)
         ).toBeInTheDocument();
       });
     });
@@ -840,14 +844,16 @@ describe("Host Actions Dropdown", () => {
       await user.click(screen.getByText("Actions"));
 
       expect(
-        screen.getByText("Unlock").parentNode?.parentNode?.parentNode
+        screen.getByText("Unlock").parentElement?.parentElement?.parentElement
       ).toHaveClass("is-disabled");
 
-      await user.hover(screen.getByText("Unlock"));
-
       await waitFor(() => {
+        waitFor(() => {
+          user.hover(screen.getByText("Unlock"));
+        });
+
         expect(
-          screen.getByText(SCRIPTS_DISABLED_TOOLTIP_TEXT)
+          screen.getByText(/fleetd agent with --enable-scripts/i)
         ).toBeInTheDocument();
       });
     });
@@ -972,15 +978,18 @@ describe("Host Actions Dropdown", () => {
       );
 
       await user.click(screen.getByText("Actions"));
-      await user.hover(screen.getByText(/Lock/i));
 
       expect(
-        screen.getByText(/Wipe/i).parentNode?.parentNode?.parentNode
+        screen.getByText("Wipe").parentElement?.parentElement?.parentElement
       ).toHaveClass("is-disabled");
 
       await waitFor(() => {
+        waitFor(() => {
+          user.hover(screen.getByText("Wipe"));
+        });
+
         expect(
-          screen.getByText(SCRIPTS_DISABLED_TOOLTIP_TEXT)
+          screen.getByText(/fleetd agent with --enable-scripts/i)
         ).toBeInTheDocument();
       });
     });
@@ -1041,14 +1050,17 @@ describe("Host Actions Dropdown", () => {
       await user.click(screen.getByText("Actions"));
 
       expect(
-        screen.getByText("Run script").parentNode?.parentNode?.parentNode
+        screen.getByText("Run script").parentElement?.parentElement
+          ?.parentElement
       ).toHaveClass("is-disabled");
 
-      await user.hover(screen.getByText(/Run script/i));
-
       await waitFor(() => {
+        waitFor(() => {
+          user.hover(screen.getByText("Run script"));
+        });
+
         expect(
-          screen.getByText(SCRIPTS_DISABLED_TOOLTIP_TEXT)
+          screen.getByText(/fleetd agent with --enable-scripts/i)
         ).toBeInTheDocument();
       });
     });

--- a/frontend/pages/hosts/details/HostDetailsPage/HostActionsDropdown/HostActionsDropdown.tests.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/HostActionsDropdown/HostActionsDropdown.tests.tsx
@@ -113,15 +113,18 @@ describe("Host Actions Dropdown", () => {
       );
 
       await user.click(screen.getByText("Actions"));
-      await user.hover(screen.getByText("Query"));
 
       expect(
         screen.getByText("Query").parentNode?.parentNode?.parentNode
       ).toHaveClass("is-disabled");
 
-      expect(
-        screen.getByText("You can't query an offline host.")
-      ).toBeInTheDocument();
+      await user.hover(screen.getByText(/Query/i));
+
+      const tooltipText = await screen.findByText(
+        /You can't query an offline host./i
+      );
+
+      expect(tooltipText).toBeInTheDocument();
     });
 
     it("renders the Query action as disabled when a host is locked", async () => {
@@ -146,13 +149,12 @@ describe("Host Actions Dropdown", () => {
       );
 
       await user.click(screen.getByText("Actions"));
-      await user.hover(screen.getByText("Query"));
-
       expect(
         screen.getByText("Query").parentNode?.parentNode?.parentNode
       ).toHaveClass("is-disabled");
     });
-    it("renders the Query action as disabled when a host is wiped", async () => {
+
+    it("renders the Query action as disabled when a host is updating", async () => {
       const render = createCustomRenderer({
         context: {
           app: {
@@ -166,19 +168,16 @@ describe("Host Actions Dropdown", () => {
         <HostActionsDropdown
           hostTeamId={null}
           onSelect={noop}
-          hostStatus="offline"
+          hostStatus="online"
           hostMdmEnrollmentStatus={null}
-          hostMdmDeviceStatus="wiped"
+          hostMdmDeviceStatus="locking"
           hostScriptsEnabled
         />
       );
 
       await user.click(screen.getByText("Actions"));
-      await user.hover(screen.getByText("Query"));
 
-      expect(
-        screen.getByText("Query").parentNode?.parentNode?.parentNode
-      ).toHaveClass("is-disabled");
+      expect(screen.getByText("Query").parentNode).toHaveClass("is-disabled");
     });
   });
 
@@ -584,15 +583,18 @@ describe("Host Actions Dropdown", () => {
       );
 
       await user.click(screen.getByText("Actions"));
-      await user.hover(screen.getByText("Lock"));
 
       expect(
         screen.getByText("Lock").parentNode?.parentNode?.parentNode
       ).toHaveClass("is-disabled");
 
-      expect(
-        screen.getByText(/fleetd agent with --enable-scripts/i)
-      ).toBeInTheDocument();
+      await user.hover(screen.getByText("Lock"));
+
+      const tooltipText = await screen.findByText(
+        /fleetd agent with --enable-scripts/i
+      );
+
+      expect(tooltipText).toBeInTheDocument();
     });
 
     it("does not render when the host is not enrolled in mdm", async () => {
@@ -834,15 +836,18 @@ describe("Host Actions Dropdown", () => {
       );
 
       await user.click(screen.getByText("Actions"));
-      await user.hover(screen.getByText("Unlock"));
 
       expect(
         screen.getByText("Unlock").parentNode?.parentNode?.parentNode
       ).toHaveClass("is-disabled");
 
-      expect(
-        screen.getByText(/fleetd agent with --enable-scripts/i)
-      ).toBeInTheDocument();
+      await user.hover(screen.getByText(/Unlock/i));
+
+      const tooltipText = await screen.findByText(
+        /fleetd agent with --enable-scripts/i
+      );
+
+      expect(tooltipText).toBeInTheDocument();
     });
   });
 
@@ -965,15 +970,17 @@ describe("Host Actions Dropdown", () => {
       );
 
       await user.click(screen.getByText("Actions"));
-      await user.hover(screen.getByText("Lock"));
+      await user.hover(screen.getByText(/Lock/i));
 
       expect(
-        screen.getByText("Wipe").parentNode?.parentNode?.parentNode
+        screen.getByText(/Wipe/i).parentNode?.parentNode?.parentNode
       ).toHaveClass("is-disabled");
 
-      expect(
-        screen.getByText(/fleetd agent with --enable-scripts/i)
-      ).toBeInTheDocument();
+      const tooltipText = await screen.findByText(
+        /fleetd agent with --enable-scripts/i
+      );
+
+      expect(tooltipText).toBeInTheDocument();
     });
   });
 
@@ -1030,15 +1037,17 @@ describe("Host Actions Dropdown", () => {
       );
 
       await user.click(screen.getByText("Actions"));
-      await user.hover(screen.getByText("Run script"));
+      await user.hover(screen.getByText(/Run script/i));
 
       expect(
         screen.getByText("Run script").parentNode?.parentNode?.parentNode
       ).toHaveClass("is-disabled");
 
-      expect(
-        screen.getByText(/fleetd agent with --enable-scripts/i)
-      ).toBeInTheDocument();
+      const tooltipText = await screen.findByText(
+        /fleetd agent with --enable-scripts/i
+      );
+
+      expect(tooltipText).toBeInTheDocument();
     });
 
     it("does not render the Run script action for ChromeOS", async () => {

--- a/frontend/pages/hosts/details/HostDetailsPage/HostActionsDropdown/HostActionsDropdown.tests.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/HostActionsDropdown/HostActionsDropdown.tests.tsx
@@ -64,6 +64,123 @@ describe("Host Actions Dropdown", () => {
       expect(screen.getByText("Transfer")).toBeInTheDocument();
     });
   });
+  describe("Query action", () => {
+    it("renders the Query action when the user is a global admin and the host is online", async () => {
+      const render = createCustomRenderer({
+        context: {
+          app: {
+            isGlobalAdmin: true,
+            currentUser: createMockUser(),
+          },
+        },
+      });
+
+      const { user } = render(
+        <HostActionsDropdown
+          hostTeamId={null}
+          onSelect={noop}
+          hostStatus="online"
+          hostMdmEnrollmentStatus={null}
+          hostMdmDeviceStatus="unlocked"
+          hostScriptsEnabled
+        />
+      );
+
+      await user.click(screen.getByText("Actions"));
+
+      expect(screen.getByText("Query")).toBeInTheDocument();
+    });
+
+    it("renders the Query action as disabled with a tooltip when a host is offline", async () => {
+      const render = createCustomRenderer({
+        context: {
+          app: {
+            isGlobalAdmin: true,
+            currentUser: createMockUser(),
+          },
+        },
+      });
+
+      const { user } = render(
+        <HostActionsDropdown
+          hostTeamId={null}
+          onSelect={noop}
+          hostStatus="offline"
+          hostMdmEnrollmentStatus={null}
+          hostMdmDeviceStatus="unlocked"
+          hostScriptsEnabled
+        />
+      );
+
+      await user.click(screen.getByText("Actions"));
+      await user.hover(screen.getByText("Query"));
+
+      expect(
+        screen.getByText("Query").parentNode?.parentNode?.parentNode
+      ).toHaveClass("is-disabled");
+
+      expect(
+        screen.getByText("You can't query an offline host.")
+      ).toBeInTheDocument();
+    });
+
+    it("renders the Query action as disabled when a host is locked", async () => {
+      const render = createCustomRenderer({
+        context: {
+          app: {
+            isGlobalAdmin: true,
+            currentUser: createMockUser(),
+          },
+        },
+      });
+
+      const { user } = render(
+        <HostActionsDropdown
+          hostTeamId={null}
+          onSelect={noop}
+          hostStatus="offline"
+          hostMdmEnrollmentStatus={null}
+          hostMdmDeviceStatus="locked"
+          hostScriptsEnabled
+        />
+      );
+
+      await user.click(screen.getByText("Actions"));
+      await user.hover(screen.getByText("Query"));
+
+      expect(
+        screen.getByText("Query").parentNode?.parentNode?.parentNode
+      ).toHaveClass("is-disabled");
+    });
+    it("renders the Query action as disabled when a host is wiped", async () => {
+      const render = createCustomRenderer({
+        context: {
+          app: {
+            isGlobalAdmin: true,
+            currentUser: createMockUser(),
+          },
+        },
+      });
+
+      const { user } = render(
+        <HostActionsDropdown
+          hostTeamId={null}
+          onSelect={noop}
+          hostStatus="offline"
+          hostMdmEnrollmentStatus={null}
+          hostMdmDeviceStatus="wiped"
+          hostScriptsEnabled
+        />
+      );
+
+      await user.click(screen.getByText("Actions"));
+      await user.hover(screen.getByText("Query"));
+
+      expect(
+        screen.getByText("Query").parentNode?.parentNode?.parentNode
+      ).toHaveClass("is-disabled");
+    });
+  });
 
   it("renders the Show Disk Encryption Key action when on premium tier and we store the disk encryption key", async () => {
     const render = createCustomRenderer({
@@ -746,6 +863,98 @@ describe("Host Actions Dropdown", () => {
       await user.click(screen.getByText("Actions"));
 
       expect(screen.queryByText("Wipe")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("Run script action", () => {
+    it("renders the Run script action when scripts_enabled is set to true", async () => {
+      const render = createCustomRenderer({
+        context: {
+          app: {
+            isGlobalAdmin: true,
+            currentUser: createMockUser(),
+          },
+        },
+      });
+
+      const { user } = render(
+        <HostActionsDropdown
+          hostTeamId={null}
+          onSelect={noop}
+          hostStatus="offline"
+          mdmName="Fleet"
+          hostPlatform="windows"
+          hostMdmEnrollmentStatus={null}
+          hostMdmDeviceStatus="unlocked"
+          hostScriptsEnabled
+        />
+      );
+
+      await user.click(screen.getByText("Actions"));
+
+      expect(screen.getByText("Run script")).toBeInTheDocument();
+    });
+
+    it("renders the Run script action as disabled with a tooltip when scripts_enabled is set to false", async () => {
+      const render = createCustomRenderer({
+        context: {
+          app: {
+            isGlobalAdmin: true,
+            currentUser: createMockUser(),
+          },
+        },
+      });
+
+      const { user } = render(
+        <HostActionsDropdown
+          hostTeamId={null}
+          onSelect={noop}
+          hostStatus="online"
+          mdmName="Fleet"
+          hostPlatform="darwin"
+          hostMdmEnrollmentStatus={null}
+          hostMdmDeviceStatus="unlocked"
+          hostScriptsEnabled={false}
+        />
+      );
+
+      await user.click(screen.getByText("Actions"));
+      await user.hover(screen.getByText("Run script"));
+
+      expect(
+        screen.getByText("Run script").parentNode?.parentNode?.parentNode
+      ).toHaveClass("is-disabled");
+
+      expect(
+        screen.getByText(/fleetd agent with --enable-scripts/i)
+      ).toBeInTheDocument();
+    });
+
+    it("does not render the Run script action for ChromeOS", async () => {
+      const render = createCustomRenderer({
+        context: {
+          app: {
+            isGlobalAdmin: true,
+            currentUser: createMockUser(),
+          },
+        },
+      });
+
+      const { user } = render(
+        <HostActionsDropdown
+          hostTeamId={null}
+          onSelect={noop}
+          hostStatus="online"
+          hostPlatform="chrome"
+          hostMdmEnrollmentStatus={null}
+          hostMdmDeviceStatus={"unlocked"}
+          hostScriptsEnabled={false}
+        />
+      );
+
+      await user.click(screen.getByText("Actions"));
+
+      expect(screen.queryByText("Run script")).not.toBeInTheDocument();
     });
   });
 });

--- a/frontend/pages/hosts/details/HostDetailsPage/HostActionsDropdown/HostActionsDropdown.tests.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/HostActionsDropdown/HostActionsDropdown.tests.tsx
@@ -558,6 +558,43 @@ describe("Host Actions Dropdown", () => {
       expect(screen.getByText("Lock")).toBeInTheDocument();
     });
 
+    it("renders as disabled with a tooltip when scripts_enabled is set to false for windows/linux", async () => {
+      const render = createCustomRenderer({
+        context: {
+          app: {
+            isPremiumTier: true,
+            isMacMdmEnabledAndConfigured: true,
+            isGlobalAdmin: true,
+            currentUser: createMockUser(),
+          },
+        },
+      });
+
+      const { user } = render(
+        <HostActionsDropdown
+          hostTeamId={null}
+          onSelect={noop}
+          hostStatus="online"
+          hostMdmEnrollmentStatus="On (automatic)"
+          mdmName="Fleet"
+          hostPlatform="debian"
+          hostMdmDeviceStatus="unlocked"
+          hostScriptsEnabled={false}
+        />
+      );
+
+      await user.click(screen.getByText("Actions"));
+      await user.hover(screen.getByText("Lock"));
+
+      expect(
+        screen.getByText("Lock").parentNode?.parentNode?.parentNode
+      ).toHaveClass("is-disabled");
+
+      expect(
+        screen.getByText(/fleetd agent with --enable-scripts/i)
+      ).toBeInTheDocument();
+    });
+
     it("does not render when the host is not enrolled in mdm", async () => {
       const render = createCustomRenderer({
         context: {
@@ -770,6 +807,43 @@ describe("Host Actions Dropdown", () => {
 
       expect(screen.queryByText("Unlock")).not.toBeInTheDocument();
     });
+
+    it("renders as disabled with a tooltip when scripts_enabled is set to false for windows/linux", async () => {
+      const render = createCustomRenderer({
+        context: {
+          app: {
+            isPremiumTier: true,
+            isMacMdmEnabledAndConfigured: true,
+            isGlobalAdmin: true,
+            currentUser: createMockUser(),
+          },
+        },
+      });
+
+      const { user } = render(
+        <HostActionsDropdown
+          hostTeamId={null}
+          onSelect={noop}
+          hostStatus="offline"
+          hostMdmEnrollmentStatus="On (automatic)"
+          mdmName="Fleet"
+          hostPlatform="windows"
+          hostMdmDeviceStatus="locked"
+          hostScriptsEnabled={false}
+        />
+      );
+
+      await user.click(screen.getByText("Actions"));
+      await user.hover(screen.getByText("Unlock"));
+
+      expect(
+        screen.getByText("Unlock").parentNode?.parentNode?.parentNode
+      ).toHaveClass("is-disabled");
+
+      expect(
+        screen.getByText(/fleetd agent with --enable-scripts/i)
+      ).toBeInTheDocument();
+    });
   });
 
   describe("Wipe action", () => {
@@ -863,6 +937,43 @@ describe("Host Actions Dropdown", () => {
       await user.click(screen.getByText("Actions"));
 
       expect(screen.queryByText("Wipe")).not.toBeInTheDocument();
+    });
+
+    it("renders as disabled with a tooltip when scripts_enabled is set to false for linux", async () => {
+      const render = createCustomRenderer({
+        context: {
+          app: {
+            isPremiumTier: true,
+            isMacMdmEnabledAndConfigured: true,
+            isGlobalAdmin: true,
+            currentUser: createMockUser(),
+          },
+        },
+      });
+
+      const { user } = render(
+        <HostActionsDropdown
+          hostTeamId={null}
+          onSelect={noop}
+          hostStatus="online"
+          hostMdmEnrollmentStatus="On (automatic)"
+          mdmName="Fleet"
+          hostPlatform="debian"
+          hostMdmDeviceStatus="unlocked"
+          hostScriptsEnabled={false}
+        />
+      );
+
+      await user.click(screen.getByText("Actions"));
+      await user.hover(screen.getByText("Lock"));
+
+      expect(
+        screen.getByText("Wipe").parentNode?.parentNode?.parentNode
+      ).toHaveClass("is-disabled");
+
+      expect(
+        screen.getByText(/fleetd agent with --enable-scripts/i)
+      ).toBeInTheDocument();
     });
   });
 

--- a/frontend/pages/hosts/details/HostDetailsPage/HostActionsDropdown/HostActionsDropdown.tests.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/HostActionsDropdown/HostActionsDropdown.tests.tsx
@@ -1,12 +1,14 @@
 import React from "react";
 import { noop } from "lodash";
-import { screen } from "@testing-library/react";
+import { screen, waitFor } from "@testing-library/react";
 import { createCustomRenderer } from "test/test-utils";
 
 import createMockUser from "__mocks__/userMock";
 import createMockTeam from "__mocks__/teamMock";
 
 import HostActionsDropdown from "./HostActionsDropdown";
+
+const SCRIPTS_DISABLED_TOOLTIP_TEXT = /fleetd agent with --enable-scripts/i;
 
 describe("Host Actions Dropdown", () => {
   describe("Transfer action", () => {
@@ -118,13 +120,13 @@ describe("Host Actions Dropdown", () => {
         screen.getByText("Query").parentNode?.parentNode?.parentNode
       ).toHaveClass("is-disabled");
 
-      await user.hover(screen.getByText(/Query/i));
+      await user.hover(screen.getByText("Query"));
 
-      const tooltipText = await screen.findByText(
-        /You can't query an offline host./i
-      );
-
-      expect(tooltipText).toBeInTheDocument();
+      await waitFor(() => {
+        expect(
+          screen.getByText(/You can't query an offline host./i)
+        ).toBeInTheDocument();
+      });
     });
 
     it("renders the Query action as disabled when a host is locked", async () => {
@@ -590,11 +592,11 @@ describe("Host Actions Dropdown", () => {
 
       await user.hover(screen.getByText("Lock"));
 
-      const tooltipText = await screen.findByText(
-        /fleetd agent with --enable-scripts/i
-      );
-
-      expect(tooltipText).toBeInTheDocument();
+      await waitFor(() => {
+        expect(
+          screen.getByText(SCRIPTS_DISABLED_TOOLTIP_TEXT)
+        ).toBeInTheDocument();
+      });
     });
 
     it("does not render when the host is not enrolled in mdm", async () => {
@@ -841,13 +843,13 @@ describe("Host Actions Dropdown", () => {
         screen.getByText("Unlock").parentNode?.parentNode?.parentNode
       ).toHaveClass("is-disabled");
 
-      await user.hover(screen.getByText(/Unlock/i));
+      await user.hover(screen.getByText("Unlock"));
 
-      const tooltipText = await screen.findByText(
-        /fleetd agent with --enable-scripts/i
-      );
-
-      expect(tooltipText).toBeInTheDocument();
+      await waitFor(() => {
+        expect(
+          screen.getByText(SCRIPTS_DISABLED_TOOLTIP_TEXT)
+        ).toBeInTheDocument();
+      });
     });
   });
 
@@ -976,11 +978,11 @@ describe("Host Actions Dropdown", () => {
         screen.getByText(/Wipe/i).parentNode?.parentNode?.parentNode
       ).toHaveClass("is-disabled");
 
-      const tooltipText = await screen.findByText(
-        /fleetd agent with --enable-scripts/i
-      );
-
-      expect(tooltipText).toBeInTheDocument();
+      await waitFor(() => {
+        expect(
+          screen.getByText(SCRIPTS_DISABLED_TOOLTIP_TEXT)
+        ).toBeInTheDocument();
+      });
     });
   });
 
@@ -1037,17 +1039,18 @@ describe("Host Actions Dropdown", () => {
       );
 
       await user.click(screen.getByText("Actions"));
-      await user.hover(screen.getByText(/Run script/i));
 
       expect(
         screen.getByText("Run script").parentNode?.parentNode?.parentNode
       ).toHaveClass("is-disabled");
 
-      const tooltipText = await screen.findByText(
-        /fleetd agent with --enable-scripts/i
-      );
+      await user.hover(screen.getByText(/Run script/i));
 
-      expect(tooltipText).toBeInTheDocument();
+      await waitFor(() => {
+        expect(
+          screen.getByText(SCRIPTS_DISABLED_TOOLTIP_TEXT)
+        ).toBeInTheDocument();
+      });
     });
 
     it("does not render the Run script action for ChromeOS", async () => {

--- a/frontend/pages/hosts/details/HostDetailsPage/HostActionsDropdown/helpers.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/HostActionsDropdown/helpers.tsx
@@ -290,6 +290,7 @@ const setOptionsAsDisabled = (
     isSandboxMode,
     hostMdmDeviceStatus,
     hostScriptsEnabled,
+    hostPlatform,
   }: IHostActionConfigOptions
 ) => {
   // Available tooltips for disabled options
@@ -339,6 +340,23 @@ const setOptionsAsDisabled = (
     optionsToDisable = optionsToDisable.concat(
       options.filter((option) => option.value === "runScript")
     );
+    if (isLinuxLike(hostPlatform)) {
+      optionsToDisable = optionsToDisable.concat(
+        options.filter(
+          (option) =>
+            option.value === "lock" ||
+            option.value === "unlock" ||
+            option.value === "wipe"
+        )
+      );
+    }
+    if (hostPlatform === "windows") {
+      optionsToDisable = optionsToDisable.concat(
+        options.filter(
+          (option) => option.value === "lock" || option.value === "unlock"
+        )
+      );
+    }
   }
   if (isSandboxMode) {
     optionsToDisable = optionsToDisable.concat(

--- a/frontend/pages/policies/PolicyPage/components/PolicyForm/PolicyForm.tests.tsx
+++ b/frontend/pages/policies/PolicyPage/components/PolicyForm/PolicyForm.tests.tsx
@@ -100,7 +100,7 @@ describe("PolicyForm - component", () => {
       },
     });
 
-    const { user } = render(
+    const { container, user } = render(
       <PolicyForm
         policyIdForEdit={mockPolicy.id}
         showOpenSchemaActionText={false}
@@ -123,12 +123,14 @@ describe("PolicyForm - component", () => {
     expect(screen.getByRole("button", { name: "Save" })).toBeDisabled();
     expect(screen.getByRole("button", { name: "Run" })).toBeDisabled();
 
-    await user.hover(screen.getByRole("button", { name: "Save" }));
-
     await waitFor(() => {
-      expect(
-        screen.getAllByText(/to save or run the policy/i)
-      ).toBeInTheDocument();
+      waitFor(() => {
+        user.hover(screen.getByRole("button", { name: "Save" }));
+      });
+
+      expect(container.querySelector("#save-policy-button")).toHaveTextContent(
+        /to save or run the policy/i
+      );
     });
   });
 
@@ -192,11 +194,15 @@ describe("PolicyForm - component", () => {
 
     expect(screen.getByRole("button", { name: "Run" })).toBeDisabled();
 
-    await user.hover(screen.getByRole("button", { name: "Run" }));
+    await waitFor(() => {
+      waitFor(() => {
+        user.hover(screen.getByRole("button", { name: "Run" }));
+      });
 
-    expect(container.querySelector("#run-policy-button")).toHaveTextContent(
-      /live queries are disabled/i
-    );
+      expect(
+        screen.getByText(/live queries are disabled/i)
+      ).toBeInTheDocument();
+    });
   });
 
   // TODO: Consider testing save button is disabled for a sql error

--- a/frontend/pages/policies/PolicyPage/components/PolicyForm/PolicyForm.tests.tsx
+++ b/frontend/pages/policies/PolicyPage/components/PolicyForm/PolicyForm.tests.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { screen } from "@testing-library/react";
+import { screen, waitFor } from "@testing-library/react";
 import { createCustomRenderer } from "test/test-utils";
 
 import createMockPolicy from "__mocks__/policyMock";
@@ -100,7 +100,7 @@ describe("PolicyForm - component", () => {
       },
     });
 
-    const { container, user } = render(
+    const { user } = render(
       <PolicyForm
         policyIdForEdit={mockPolicy.id}
         showOpenSchemaActionText={false}
@@ -125,9 +125,11 @@ describe("PolicyForm - component", () => {
 
     await user.hover(screen.getByRole("button", { name: "Save" }));
 
-    expect(container.querySelector("#save-policy-button")).toHaveTextContent(
-      /to save or run the policy/i
-    );
+    await waitFor(() => {
+      expect(
+        screen.getAllByText(/to save or run the policy/i)
+      ).toBeInTheDocument();
+    });
   });
 
   it("disables run button with tooltip when live queries are globally disabled", async () => {


### PR DESCRIPTION
## Issue
FE Tests for #17148

## Description
- Fix "Lock" and "Unlock" to be disabled with a tooltip for Linux/Windows if scripts are not enabled on the host
- Fix "Wipe" to be disabled with a tooltip for Linux if scripts are not enabled on the host
- Adds unit tests to "Run script", "Lock", "Unlock", "Wipe", and "Query" dropdown options (e.g. testing disabled tooltip)

## Screenrecording
https://www.loom.com/share/b58f5885143147839a8101f46b644cfe?sid=f1d16dda-fb23-4c20-b2e4-82f0df03f705

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->


- [x] Added/updated tests