### PR TITLE
Fix TestIntegrations/TestUsers flaky test

### DIFF
--- a/server/service/testing_utils.go
+++ b/server/service/testing_utils.go
@@ -41,7 +41,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/throttled/throttled/v2"
 	"github.com/throttled/throttled/v2/store/memstore"
-	"golang.org/x/exp/maps"
 )
 
 func newTestService(t *testing.T, ds fleet.Datastore, rs fleet.QueryResultStore, lq fleet.LiveQueryStore, opts ...*TestServerOpts) (fleet.Service, context.Context) {
@@ -205,8 +204,11 @@ func newTestServiceWithClock(t *testing.T, ds fleet.Datastore, rs fleet.QueryRes
 func createTestUsers(t *testing.T, ds fleet.Datastore) map[string]fleet.User {
 	users := make(map[string]fleet.User)
 	// Map iteration is random so we sort and iterate using the testUsers keys.
-	keys := maps.Keys(testUsers)
-	sort.StringSlice(keys).Sort()
+	var keys []string
+	for key := range testUsers {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
 	for _, key := range keys {
 		u := testUsers[key]
 		role := fleet.RoleObserver

--- a/server/service/testing_utils.go
+++ b/server/service/testing_utils.go
@@ -209,6 +209,7 @@ func createTestUsers(t *testing.T, ds fleet.Datastore) map[string]fleet.User {
 		keys = append(keys, key)
 	}
 	sort.Strings(keys)
+	userID := uint(1)
 	for _, key := range keys {
 		u := testUsers[key]
 		role := fleet.RoleObserver
@@ -216,6 +217,7 @@ func createTestUsers(t *testing.T, ds fleet.Datastore) map[string]fleet.User {
 			role = fleet.RoleAdmin
 		}
 		user := &fleet.User{
+			ID:         userID, // We need to set this in case ds is a mocked Datastore.
 			Name:       "Test Name " + u.Email,
 			Email:      u.Email,
 			GlobalRole: &role,
@@ -225,6 +227,7 @@ func createTestUsers(t *testing.T, ds fleet.Datastore) map[string]fleet.User {
 		user, err = ds.NewUser(context.Background(), user)
 		require.Nil(t, err)
 		users[user.Email] = *user
+		userID++
 	}
 	return users
 }


### PR DESCRIPTION
```
--- FAIL: TestIntegrations (47.44s)
    --- FAIL: TestIntegrations/TestUsers (1.42s)
        integration_core_test.go:4198:
            	Error Trace:	/Users/tim/workspace/fleet/server/service/integration_core_test.go:4198
            	Error:      	Not equal:
            	            	expected: 0x2
            	            	actual  : 0x1
            	Test:       	TestIntegrations/TestUsers
```