### PR TITLE
Fix typo in calendar events modal

### DIFF
--- a/frontend/pages/policies/ManagePoliciesPage/components/CalendarEventsModal/CalendarEventsModal.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/components/CalendarEventsModal/CalendarEventsModal.tsx
@@ -254,7 +254,7 @@ const CalendarEventsModal = ({
           error={formErrors.url}
           tooltip="Provide a URL to deliver a webhook request to."
           labelTooltipPosition="top-start"
-          helpText="A request will be sent to this URL during the calendar event. Use it to trigger auto-remidiation."
+          helpText="A request will be sent to this URL during the calendar event. Use it to trigger auto-remediation."
         />
         <RevealButton
           isShowing={showExamplePayload}


### PR DESCRIPTION
"remidiation" → "remediation"