### PR TITLE
Fix Apple profile upload error message when identifier is a duplicate.

### DIFF
--- a/changes/18081-upload-apple-profile-error-message
+++ b/changes/18081-upload-apple-profile-error-message
@@ -1,0 +1,1 @@
+* Fixed the error message so that it indicates if a conflict error on uploading an Apple profile was caused by the profile's name or its identifier.

--- a/server/datastore/mysql/errors.go
+++ b/server/datastore/mysql/errors.go
@@ -106,6 +106,10 @@ func (e *existsError) IsExists() bool {
 	return true
 }
 
+func (e *existsError) Resource() string {
+	return e.ResourceType
+}
+
 func isDuplicate(err error) bool {
 	err = ctxerr.Cause(err)
 	if driverErr, ok := err.(*mysql.MySQLError); ok {

--- a/server/service/apple_mdm.go
+++ b/server/service/apple_mdm.go
@@ -359,7 +359,13 @@ func (svc *Service) NewMDMAppleConfigProfile(ctx context.Context, teamID uint, r
 	if err != nil {
 		var existsErr existsErrorInterface
 		if errors.As(err, &existsErr) {
-			err = fleet.NewInvalidArgumentError("profile", "Couldn't upload. A configuration profile with this name already exists.").
+			msg := "Couldn't upload. A configuration profile with this name already exists."
+			if re, ok := existsErr.(interface{ Resource() string }); ok {
+				if re.Resource() == "MDMAppleConfigProfile.PayloadIdentifier" {
+					msg = "Couldn't upload. A configuration profile with this identifier (PayloadIdentifier) already exists."
+				}
+			}
+			err = fleet.NewInvalidArgumentError("profile", msg).
 				WithStatus(http.StatusConflict)
 		}
 		return nil, ctxerr.Wrap(ctx, err)


### PR DESCRIPTION
#18081 

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [x] Manual QA for all new/changed functionality
