### PR TITLE
Website: Reduce number of requests to the Algolia crawler

### DIFF
--- a/website/api/hooks/custom/index.js
+++ b/website/api/hooks/custom/index.js
@@ -88,8 +88,8 @@ will be disabled and/or hidden in the UI.
           from: sails.config.custom.fromEmailAddress,
           fromName: sails.config.custom.fromName,
         });
-
-        if(sails.config.environment === 'production'){
+        // Send a request to our Algolia crawler to reindex the website.
+        if(sails.config.environment === 'production' && process.env.DYNO === 'web.1'){
           sails.helpers.http.post.with({
             url: `https://crawler.algolia.com/api/1/crawlers/${sails.config.custom.algoliaCrawlerId}/reindex`,
             headers: { 'Authorization': sails.config.custom.algoliaCrawlerApiToken}


### PR DESCRIPTION
Related to: #18242

Changes:
 - Updated the request that is sent to the Algolia crawler to only be sent from the `web.1` dyno in Heroku. 

