### PR TITLE
[Small released styling bugs] Fleet UI: Fix last activity's styling

### DIFF
--- a/changes/18060-host-activity-styling-bugs
+++ b/changes/18060-host-activity-styling-bugs
@@ -1,0 +1,1 @@
+- Styling bug fixes of host details page activities (Remove trailing dash line from last activity, Re-instate padding below last activity)

--- a/frontend/pages/DashboardPage/cards/ActivityFeed/ActivityItem/_styles.scss
+++ b/frontend/pages/DashboardPage/cards/ActivityFeed/ActivityItem/_styles.scss
@@ -57,7 +57,7 @@
     .activity-item__dash {
       border-right: none;
     }
-    .activity-item__details {
+    .activity-details {
       padding-bottom: $pad-xxlarge;
     }
   }

--- a/frontend/pages/hosts/details/cards/Activity/HostActivityItem/_styles.scss
+++ b/frontend/pages/hosts/details/cards/Activity/HostActivityItem/_styles.scss
@@ -54,13 +54,12 @@
   }
 
   &:last-child {
-    .past-activity__dash {
+    .host-activity-item__dash {
       border-right: none;
     }
 
-    .past-activity__details {
+    .host-activity-item__details {
       padding-bottom: $pad-xxlarge;
     }
   }
-
 }

--- a/frontend/pages/hosts/details/cards/Activity/HostActivityItem/_styles.scss
+++ b/frontend/pages/hosts/details/cards/Activity/HostActivityItem/_styles.scss
@@ -58,7 +58,7 @@
       border-right: none;
     }
 
-    .host-activity-item__details {
+    .host-activity-item__details-wrapper {
       padding-bottom: $pad-xxlarge;
     }
   }

--- a/frontend/pages/hosts/details/cards/Activity/UpcomingActivityFeed/UpcomingActivityFeed.tsx
+++ b/frontend/pages/hosts/details/cards/Activity/UpcomingActivityFeed/UpcomingActivityFeed.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-import { IActivity, IActivityDetails } from "interfaces/activity";
+import { IActivity } from "interfaces/activity";
 import { IActivitiesResponse } from "services/entities/activities";
 
 // @ts-ignore


### PR DESCRIPTION
## Issue
Cerra #18060 

## Description
- Removes trailing dashes from last activity
- Adds padding below last activity

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
- [x] Manual QA for all new/changed functionality

