### PR TITLE
Interpret windows exit codes as a signed integer

### DIFF
--- a/changes/18282-signed-windows-exit-code
+++ b/changes/18282-signed-windows-exit-code
@@ -1,0 +1,2 @@
+* Cast windows exit codes to signed integers to match windows interpreter
+* Fix bug where some scripts got stuck in "upcoming" activity permanently

--- a/orbit/changes/18282-signed-windows-exit-code
+++ b/orbit/changes/18282-signed-windows-exit-code
@@ -1,0 +1,1 @@
+* Cast windows exit codes to signed integers to match windows interpreter

--- a/server/datastore/mysql/scripts.go
+++ b/server/datastore/mysql/scripts.go
@@ -128,6 +128,11 @@ func (ds *Datastore) SetHostScriptExecutionResult(ctx context.Context, result *f
 		res, err := tx.ExecContext(ctx, updStmt,
 			output,
 			result.Runtime,
+			// Windows error codes are signed 32-bit integers, but are
+			// returned as unsigned integers by the windows API. The
+			// software that receives them is responsible for casting
+			// it to a 32-bit signed integer.
+			// See /orbit/pkg/scripts/exec_windows.go
 			int32(result.ExitCode),
 			result.HostID,
 			result.ExecutionID,

--- a/server/datastore/mysql/scripts.go
+++ b/server/datastore/mysql/scripts.go
@@ -128,7 +128,7 @@ func (ds *Datastore) SetHostScriptExecutionResult(ctx context.Context, result *f
 		res, err := tx.ExecContext(ctx, updStmt,
 			output,
 			result.Runtime,
-			result.ExitCode,
+			int32(result.ExitCode),
 			result.HostID,
 			result.ExecutionID,
 		)

--- a/server/datastore/mysql/scripts_test.go
+++ b/server/datastore/mysql/scripts_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	_ "embed"
 	"fmt"
+	"math"
 	"strings"
 	"testing"
 	"time"
@@ -220,6 +221,25 @@ func testHostScriptResult(t *testing.T, ds *Datastore) {
 	pending, err = ds.ListPendingHostScriptExecutions(ctx, 1)
 	require.NoError(t, err)
 	require.Empty(t, pending, 0)
+
+	// check that scripts with large unsigned error codes get
+	// converted to signed error codes
+	createdUnsignedScript, err := ds.NewHostScriptExecutionRequest(ctx, &fleet.HostScriptRequestPayload{
+		HostID:         1,
+		ScriptContents: "echo",
+		UserID:         &u.ID,
+		SyncRequest:    true,
+	})
+
+	unsignedScriptResult, err := ds.SetHostScriptExecutionResult(ctx, &fleet.HostScriptResultPayload{
+		HostID:      1,
+		ExecutionID: createdUnsignedScript.ExecutionID,
+		Output:      "foo",
+		Runtime:     1,
+		ExitCode:    math.MaxUint32,
+	})
+	require.NoError(t, err)
+	require.EqualValues(t, -1, *unsignedScriptResult.ExitCode)
 }
 
 func testScripts(t *testing.T, ds *Datastore) {

--- a/server/datastore/mysql/scripts_test.go
+++ b/server/datastore/mysql/scripts_test.go
@@ -230,6 +230,7 @@ func testHostScriptResult(t *testing.T, ds *Datastore) {
 		UserID:         &u.ID,
 		SyncRequest:    true,
 	})
+	require.NoError(t, err)
 
 	unsignedScriptResult, err := ds.SetHostScriptExecutionResult(ctx, &fleet.HostScriptResultPayload{
 		HostID:      1,


### PR DESCRIPTION
#17695

The windows exit code is a 32-bit unsigned integer, but the command interpreter treats it like a signed integer. When a process is killed, it returns 0xFFFFFFFF (interpreted as -1). We convert the integer to an signed 32-bit integer to flip it to a -1 to match our expectations, and fit in our db column.

https://en.wikipedia.org/wiki/Exit_status#Windows

FIxed on both the client and server side.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [x] Added/updated tests
- [x] Manual QA for all new/changed functionality
  - For Orbit and Fleet Desktop changes:
    - [x] Manual QA must be performed in the three main OSs, macOS, Windows and Linux.
    - [x] Auto-update manual QA, from released version of component to new version (see [tools/tuf/test](../tools/tuf/test/README.md)).
