### PR TITLE
[small unreleased bug] Fleet UI: Fix Show schema button location

### DIFF
--- a/changes/18276-fix-schema-button-location
+++ b/changes/18276-fix-schema-button-location
@@ -1,0 +1,1 @@
+* UI Fix to Show schema button location

--- a/frontend/components/FleetAce/_styles.scss
+++ b/frontend/components/FleetAce/_styles.scss
@@ -7,10 +7,12 @@
       color: $ui-error;
     }
     &--with-action {
+      display: flex;
       justify-content: space-between;
 
       button {
         height: 36px; // aligning space between label and textarea
+        animation: fade-in 250ms ease-out;
       }
     }
   }

--- a/frontend/components/FleetAce/_styles.scss
+++ b/frontend/components/FleetAce/_styles.scss
@@ -11,7 +11,7 @@
       justify-content: space-between;
 
       button {
-        height: 36px; // aligning space between label and textarea
+        height: initial; // aligning space between label and textarea
         animation: fade-in 250ms ease-out;
       }
     }

--- a/frontend/components/SidePanelContent/_styles.scss
+++ b/frontend/components/SidePanelContent/_styles.scss
@@ -7,6 +7,7 @@
   padding: $pad-xxlarge;
   // need relative positioning for a close icon that is on some sidebars have
   position: relative;
+  animation: fade-in 250ms ease-out;
 
   .component__tooltip-wrapper__tip-text {
     max-width: 280px;

--- a/frontend/pages/policies/PolicyPage/components/PolicyForm/PolicyForm.tsx
+++ b/frontend/pages/policies/PolicyPage/components/PolicyForm/PolicyForm.tsx
@@ -294,7 +294,7 @@ const PolicyForm = ({
     }
 
     return (
-      <Button variant="small-icon" onClick={onOpenSchemaSidebar}>
+      <Button variant="text-icon" onClick={onOpenSchemaSidebar}>
         <>
           <Icon name="info" size="small" />
           Show schema


### PR DESCRIPTION
## Issue
Cerra #18276 

## Description
- Fixes location of show schema button across label/query/policy edit pages

Must've been a byproduct of cleaning up form labels, hmw avoid similar regressions when we refactor old code?

## Screenshot of fix
<img width="1505" alt="Screenshot 2024-04-15 at 4 13 39 PM" src="https://github.com/fleetdm/fleet/assets/71795832/aaef2d1c-65a0-4a9f-9304-83052b095e79">


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
- [x] Manual QA for all new/changed functionality

