### PR TITLE
In fleetctl debug db-locks and fleetctl debug db-innodb-status, fixed 500 errors

### DIFF
--- a/changes/17733-innodb-lock-waits
+++ b/changes/17733-innodb-lock-waits
@@ -1,0 +1,1 @@
+In fleetctl debug db-locks (GET debug/db/locks) and fleetctl debug db-innodb-status (GET debug/db/innodb-status), fixed 500 error in MySQL 8 and when DB user has insufficient privileges.

--- a/server/datastore/mysql/locks.go
+++ b/server/datastore/mysql/locks.go
@@ -9,6 +9,8 @@ import (
 	"github.com/fleetdm/fleet/v4/server/fleet"
 )
 
+var innodbLockWaitsTableExists *bool
+
 func (ds *Datastore) Lock(ctx context.Context, name string, owner string, expiration time.Duration) (bool, error) {
 	lockObtainers := []func(context.Context, string, string, time.Duration) (sql.Result, error){
 		ds.extendLockIfAlreadyAcquired,
@@ -60,24 +62,69 @@ func (ds *Datastore) Unlock(ctx context.Context, name string, owner string) erro
 }
 
 func (ds *Datastore) DBLocks(ctx context.Context) ([]*fleet.DBLock, error) {
-	stmt := `
-    SELECT
-      r.trx_id              waiting_trx_id,
-      r.trx_mysql_thread_id waiting_thread,
-      r.trx_query           waiting_query,
-      b.trx_id              blocking_trx_id,
-      b.trx_mysql_thread_id blocking_thread,
-      b.trx_query           blocking_query
-    FROM       information_schema.innodb_lock_waits w
-    INNER JOIN information_schema.innodb_trx b
-      ON b.trx_id = w.blocking_trx_id
-    INNER JOIN information_schema.innodb_trx r
-      ON r.trx_id = w.requesting_trx_id`
+	// information_schema.innodb_lock_waits has been deprecated in MySQL 8, so we need to check if it exists.
+	// We only need to check once.
+	if innodbLockWaitsTableExists == nil {
+		existsStmt := `
+		SELECT EXISTS (SELECT *
+			FROM information_schema.tables
+			WHERE table_schema = 'information_schema'
+  			AND table_name = 'innodb_lock_waits')`
+		if err := ds.writer(ctx).GetContext(ctx, &innodbLockWaitsTableExists, existsStmt); err != nil {
+			return nil, ctxerr.Wrap(ctx, err, "check for existence of innodb_lock_waits table")
+		}
+	}
+	var stmt string
+	if *innodbLockWaitsTableExists {
+		stmt = `
+		SELECT
+		  r.trx_id              waiting_trx_id,
+		  r.trx_mysql_thread_id waiting_thread,
+		  r.trx_query           waiting_query,
+		  b.trx_id              blocking_trx_id,
+		  b.trx_mysql_thread_id blocking_thread,
+		  b.trx_query           blocking_query
+		FROM       information_schema.innodb_lock_waits w
+		INNER JOIN information_schema.innodb_trx b
+		  ON b.trx_id = w.blocking_trx_id
+		INNER JOIN information_schema.innodb_trx r
+		  ON r.trx_id = w.requesting_trx_id`
+	} else {
+		// Mapping from information_schema.innodb_lock_waits to performance_schema.data_lock_waits columns:
+		//
+		// INNODB_LOCK_WAITS data_lock_waits
+		// ----------------- ----------------
+		// REQUESTING_TRX_ID REQUESTING_ENGINE_TRANSACTION_ID
+		// REQUESTED_LOCK_ID REQUESTING_ENGINE_LOCK_ID
+		// BLOCKING_TRX_ID   BLOCKING_ENGINE_TRANSACTION_ID
+		// BLOCKING_LOCK_ID  BLOCKING_ENGINE_LOCK_ID
+		stmt = `
+		SELECT
+		  r.trx_id              waiting_trx_id,
+		  r.trx_mysql_thread_id waiting_thread,
+		  r.trx_query           waiting_query,
+		  b.trx_id              blocking_trx_id,
+		  b.trx_mysql_thread_id blocking_thread,
+		  b.trx_query           blocking_query
+		FROM       performance_schema.data_lock_waits w
+		INNER JOIN information_schema.innodb_trx b
+		  ON b.trx_id = w.blocking_engine_transaction_id
+		INNER JOIN information_schema.innodb_trx r
+		  ON r.trx_id = w.requesting_engine_transaction_id`
+	}
 
 	var locks []*fleet.DBLock
 	// Even though this is a Read, use the writer as we want the db locks from
 	// the primary database (the read replica should have little to no trx locks).
 	if err := ds.writer(ctx).SelectContext(ctx, &locks, stmt); err != nil {
+		// To read innodb tables, DB user must have PROCESS privilege
+		// This can be set by DB admin like: GRANT PROCESS,SELECT ON *.* TO 'fleet'@'%';
+		if isMySQLAccessDenied(err) {
+			return nil, &accessDeniedError{
+				Message:     "select locking information: DB user must have global PROCESS and SELECT privilege",
+				InternalErr: err,
+			}
+		}
 		return nil, ctxerr.Wrap(ctx, err, "select locking information")
 	}
 	return locks, nil

--- a/server/datastore/mysql/mysql.go
+++ b/server/datastore/mysql/mysql.go
@@ -1177,7 +1177,15 @@ func (ds *Datastore) InnoDBStatus(ctx context.Context) (string, error) {
 	// using the writer even when doing a read to get the data from the main db node
 	err := ds.writer(ctx).GetContext(ctx, &status, "show engine innodb status")
 	if err != nil {
-		return "", ctxerr.Wrap(ctx, err, "Getting innodb status")
+		// To read innodb tables, DB user must have PROCESS privilege
+		// This can be set by DB admin like: GRANT PROCESS,SELECT ON *.* TO 'fleet'@'%';
+		if isMySQLAccessDenied(err) {
+			return "", &accessDeniedError{
+				Message:     "getting innodb status: DB user must have global PROCESS and SELECT privilege",
+				InternalErr: err,
+			}
+		}
+		return "", ctxerr.Wrap(ctx, err, "getting innodb status")
 	}
 	return status.Status, nil
 }

--- a/server/service/client_debug.go
+++ b/server/service/client_debug.go
@@ -16,6 +16,10 @@ func (c *Client) getRawBody(endpoint string) ([]byte, error) {
 	defer response.Body.Close()
 
 	if response.StatusCode != http.StatusOK {
+		body, err := io.ReadAll(response.Body)
+		if err == nil && len(body) > 0 {
+			return nil, fmt.Errorf("get %s received status %d: %s", endpoint, response.StatusCode, body)
+		}
 		return nil, fmt.Errorf("get %s received status %d", endpoint, response.StatusCode)
 	}
 

--- a/server/service/debug_handler.go
+++ b/server/service/debug_handler.go
@@ -3,16 +3,19 @@ package service
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/pprof"
 
 	"github.com/fleetdm/fleet/v4/server/config"
+	"github.com/fleetdm/fleet/v4/server/contexts/logging"
 	"github.com/fleetdm/fleet/v4/server/contexts/token"
 	"github.com/fleetdm/fleet/v4/server/errorstore"
 	"github.com/fleetdm/fleet/v4/server/fleet"
 
 	kitlog "github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
+	kithttp "github.com/go-kit/kit/transport/http"
 	"github.com/gorilla/mux"
 )
 
@@ -49,9 +52,19 @@ func jsonHandler(
 	jsonGenerator func(ctx context.Context) (interface{}, error),
 ) func(rw http.ResponseWriter, r *http.Request) {
 	return func(rw http.ResponseWriter, r *http.Request) {
-		jsonData, err := jsonGenerator(r.Context())
+		lc := &logging.LoggingContext{SkipUser: true} // The debug handler does not save the logged-in user.
+		ctx := logging.NewContext(kithttp.PopulateRequestContext(r.Context(), r), lc)
+		ctx = logging.WithStartTime(ctx)
+		jsonData, err := jsonGenerator(ctx)
 		if err != nil {
-			level.Error(logger).Log("err", err)
+			lc.SetErrs(err)
+			lc.Log(ctx, logger)
+			var sce kithttp.StatusCoder
+			if errors.As(err, &sce) {
+				rw.WriteHeader(sce.StatusCode())
+				_, _ = rw.Write([]byte(err.Error()))
+				return
+			}
 			rw.WriteHeader(http.StatusInternalServerError)
 			return
 		}

--- a/server/service/integration_core_test.go
+++ b/server/service/integration_core_test.go
@@ -11310,3 +11310,14 @@ func (s *integrationTestSuite) TestAddingRemovingManualLabels() {
 	teamHost2Labels = getHostLabels(teamHost2)
 	require.Empty(t, teamHost2Labels)
 }
+
+func (s *integrationTestSuite) TestDebugDB() {
+	t := s.T()
+	var response map[string]string
+	s.DoJSON("GET", "/debug/db/locks", nil, http.StatusOK, &response)
+	assert.Empty(t, response)
+
+	var responseString string
+	s.DoJSON("GET", "/debug/db/innodb-status", nil, http.StatusOK, &responseString)
+	assert.Contains(t, responseString, "INNODB MONITOR OUTPUT")
+}

--- a/server/service/testing_utils.go
+++ b/server/service/testing_utils.go
@@ -350,6 +350,8 @@ func RunServerForTestsWithDS(t *testing.T, ds fleet.Datastore, opts ...*TestServ
 
 	apiHandler := MakeHandler(svc, cfg, logger, limitStore, WithLoginRateLimit(throttled.PerMin(1000)))
 	rootMux.Handle("/api/", apiHandler)
+	debugHandler := MakeDebugHandler(svc, cfg, logger, nil, ds)
+	rootMux.Handle("/debug/", debugHandler)
 
 	server := httptest.NewUnstartedServer(rootMux)
 	server.Config = cfg.Server.DefaultHTTPServer(ctx, rootMux)


### PR DESCRIPTION
#17733
In fleetctl debug db-locks (GET debug/db/locks) and fleetctl debug db-innodb-status (GET debug/db/innodb-status), fixed 500 error in MySQL 8 and when DB user has insufficient privileges.

# Checklist for submitter
- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [x] Added/updated tests
- [x] Manual QA for all new/changed functionality
