### PR TITLE
As of Go 1.21, toolchain versions must use the 1.N.P syntax

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/fleetdm/fleet/v4
 
-go 1.21
+go 1.21.0
 
 require (
 	cloud.google.com/go/pubsub v1.33.0


### PR DESCRIPTION
This resolves a code scanning warning due to not using 1.N.P syntax, which is [required](https://go.dev/doc/toolchain#version) as of Go 1.21.0.