### PR TITLE
Website: update guaranteed locals in custom hook

### DIFF
--- a/website/api/hooks/custom/index.js
+++ b/website/api/hooks/custom/index.js
@@ -123,9 +123,9 @@ will be disabled and/or hidden in the UI.
 
             var url = require('url');
 
-            // First, if this is a GET request (and thus potentially a view),
+            // First, if this is a GET request (and thus potentially a view) or a HEAD request,
             // attach a couple of guaranteed locals.
-            if (req.method === 'GET') {
+            if (req.method === 'GET' || req.method === 'HEAD') {
 
               // The  `_environment` local lets us do a little workaround to make Vue.js
               // run in "production mode" without unnecessarily involving complexities

--- a/website/views/pages/homepage.ejs
+++ b/website/views/pages/homepage.ejs
@@ -64,7 +64,7 @@
               <h3>Tell employees why</h3>
               <p>Use AI to explain why your security policies matter, and install required updates en masse without locking people out of meetings.</p>
             <%}%>
-            <% if(me && me.primaryBuyingSituation) {%>
+            <% if(typeof me !== 'undefined' && me.primaryBuyingSituation) {%>
             <a purpose="animated-arrow-button-red" href="https://kqphpqst851.typeform.com/to/WwAtAUdm#primarybuyingsituation=<%= encodeURIComponent(me.primaryBuyingSituation) %>" target="_blank">Let me know</a>
             <% } else if(primaryBuyingSituation) {%>
             <a purpose="animated-arrow-button-red" href="https://kqphpqst851.typeform.com/to/WwAtAUdm#primarybuyingsituation=<%= encodeURIComponent(primaryBuyingSituation) %>" target="_blank">Let me know</a>

--- a/website/views/pages/homepage.ejs
+++ b/website/views/pages/homepage.ejs
@@ -64,7 +64,7 @@
               <h3>Tell employees why</h3>
               <p>Use AI to explain why your security policies matter, and install required updates en masse without locking people out of meetings.</p>
             <%}%>
-            <% if(typeof me !== 'undefined' && me.primaryBuyingSituation) {%>
+            <% if(me && me.primaryBuyingSituation) {%>
             <a purpose="animated-arrow-button-red" href="https://kqphpqst851.typeform.com/to/WwAtAUdm#primarybuyingsituation=<%= encodeURIComponent(me.primaryBuyingSituation) %>" target="_blank">Let me know</a>
             <% } else if(primaryBuyingSituation) {%>
             <a purpose="animated-arrow-button-red" href="https://kqphpqst851.typeform.com/to/WwAtAUdm#primarybuyingsituation=<%= encodeURIComponent(primaryBuyingSituation) %>" target="_blank">Let me know</a>


### PR DESCRIPTION
Closes: #18295

Changes:
- Updated the custom hook to set `res.locals` for HEAD requests to prevent 500 errors when a request is sent to a page that references `res.locals.me`