### PR TITLE
Add host IDs to get/create/modify label endpoints

### DIFF
--- a/server/datastore/mysql/labels_test.go
+++ b/server/datastore/mysql/labels_test.go
@@ -1480,6 +1480,7 @@ func testAddDeleteLabelsToFromHost(t *testing.T, ds *Datastore) {
 	err = ds.AddLabelsToHost(ctx, host1.ID, []uint{label1.ID})
 	require.NoError(t, err)
 	lbl, hids, err := ds.Label(ctx, label1.ID)
+	require.NoError(t, err)
 	require.Equal(t, label1.ID, lbl.ID)
 	require.ElementsMatch(t, []uint{host1.ID}, hids)
 	getLabelUpdatedAt := func(updatedAt *time.Time) func(q sqlx.ExtContext) error {
@@ -1526,6 +1527,7 @@ func testAddDeleteLabelsToFromHost(t *testing.T, ds *Datastore) {
 	require.Len(t, labels, 1)
 
 	lbl, hids, err = ds.Label(ctx, label1.ID)
+	require.NoError(t, err)
 	require.Equal(t, label1.ID, lbl.ID)
 	require.ElementsMatch(t, []uint{host1.ID, host2.ID}, hids)
 

--- a/server/datastore/mysql/labels_test.go
+++ b/server/datastore/mysql/labels_test.go
@@ -216,9 +216,9 @@ func testLabelsSearch(t *testing.T, db *Datastore) {
 	err := db.ApplyLabelSpecs(context.Background(), specs)
 	require.Nil(t, err)
 
-	all, err := db.Label(context.Background(), specs[len(specs)-1].ID)
+	all, _, err := db.Label(context.Background(), specs[len(specs)-1].ID)
 	require.Nil(t, err)
-	l3, err := db.Label(context.Background(), specs[2].ID)
+	l3, _, err := db.Label(context.Background(), specs[2].ID)
 	require.Nil(t, err)
 
 	user := &fleet.User{GlobalRole: ptr.String(fleet.RoleAdmin)}
@@ -664,7 +664,7 @@ func testLabelsChangeDetails(t *testing.T, db *Datastore) {
 	err = db.ApplyLabelSpecs(context.Background(), []*fleet.LabelSpec{&label})
 	require.Nil(t, err)
 
-	saved, err := db.Label(context.Background(), label.ID)
+	saved, _, err := db.Label(context.Background(), label.ID)
 	require.Nil(t, err)
 	assert.Equal(t, label.Name, saved.Name)
 }
@@ -781,9 +781,9 @@ func testLabelsSave(t *testing.T, db *Datastore) {
 
 	require.NoError(t, db.RecordLabelQueryExecutions(context.Background(), h1, map[uint]*bool{label.ID: ptr.Bool(true)}, time.Now(), false))
 
-	_, err = db.SaveLabel(context.Background(), label)
+	_, _, err = db.SaveLabel(context.Background(), label)
 	require.NoError(t, err)
-	saved, err := db.Label(context.Background(), label.ID)
+	saved, _, err := db.Label(context.Background(), label.ID)
 	require.NoError(t, err)
 	assert.Equal(t, label.Name, saved.Name)
 	assert.Equal(t, label.Description, saved.Description)
@@ -1479,6 +1479,9 @@ func testAddDeleteLabelsToFromHost(t *testing.T, ds *Datastore) {
 	// Adding and removing labels.
 	err = ds.AddLabelsToHost(ctx, host1.ID, []uint{label1.ID})
 	require.NoError(t, err)
+	lbl, hids, err := ds.Label(ctx, label1.ID)
+	require.Equal(t, label1.ID, lbl.ID)
+	require.ElementsMatch(t, []uint{host1.ID}, hids)
 	getLabelUpdatedAt := func(updatedAt *time.Time) func(q sqlx.ExtContext) error {
 		return func(q sqlx.ExtContext) error {
 			return sqlx.GetContext(ctx, q, updatedAt, `SELECT updated_at FROM label_membership WHERE host_id = ? AND label_id = ?`, host1.ID, label1.ID)
@@ -1515,6 +1518,17 @@ func testAddDeleteLabelsToFromHost(t *testing.T, ds *Datastore) {
 	labels, err = ds.ListLabelsForHost(ctx, host1.ID)
 	require.NoError(t, err)
 	require.Len(t, labels, 2)
+
+	err = ds.AddLabelsToHost(ctx, host2.ID, []uint{label1.ID})
+	require.NoError(t, err)
+	labels, err = ds.ListLabelsForHost(ctx, host2.ID)
+	require.NoError(t, err)
+	require.Len(t, labels, 1)
+
+	lbl, hids, err = ds.Label(ctx, label1.ID)
+	require.Equal(t, label1.ID, lbl.ID)
+	require.ElementsMatch(t, []uint{host1.ID, host2.ID}, hids)
+
 	err = ds.RemoveLabelsFromHost(ctx, host1.ID, []uint{label1.ID, label2.ID})
 	require.NoError(t, err)
 	labels, err = ds.ListLabelsForHost(ctx, host1.ID)

--- a/server/datastore/mysql/targets_test.go
+++ b/server/datastore/mysql/targets_test.go
@@ -381,19 +381,19 @@ func testTargetsHostIDsInTargets(t *testing.T, ds *Datastore) {
 	h6 := initHost(nil, "darwin")
 
 	// Load and record results for builtin labels.
-	allHosts, err := ds.Label(context.Background(), 6)
+	allHosts, _, err := ds.Label(context.Background(), 6)
 	require.NoError(t, err)
-	macOS, err := ds.Label(context.Background(), 7)
+	macOS, _, err := ds.Label(context.Background(), 7)
 	require.NoError(t, err)
-	ubuntuLinux, err := ds.Label(context.Background(), 8)
+	ubuntuLinux, _, err := ds.Label(context.Background(), 8)
 	require.NoError(t, err)
-	centOSLinux, err := ds.Label(context.Background(), 9)
+	centOSLinux, _, err := ds.Label(context.Background(), 9)
 	require.NoError(t, err)
-	msWindows, err := ds.Label(context.Background(), 10)
+	msWindows, _, err := ds.Label(context.Background(), 10)
 	require.NoError(t, err)
-	redHatLinux, err := ds.Label(context.Background(), 11)
+	redHatLinux, _, err := ds.Label(context.Background(), 11)
 	require.NoError(t, err)
-	allLinux, err := ds.Label(context.Background(), 12)
+	allLinux, _, err := ds.Label(context.Background(), 12)
 	require.NoError(t, err)
 
 	allBuiltIn := []*fleet.Label{

--- a/server/datastore/mysql/unicode_test.go
+++ b/server/datastore/mysql/unicode_test.go
@@ -25,7 +25,7 @@ func TestUnicode(t *testing.T) {
 	err := ds.ApplyLabelSpecs(context.Background(), []*fleet.LabelSpec{&l1})
 	require.Nil(t, err)
 
-	label, err := ds.Label(context.Background(), l1.ID)
+	label, _, err := ds.Label(context.Background(), l1.ID)
 	require.Nil(t, err)
 	assert.Equal(t, "測試", label.Name)
 

--- a/server/fleet/datastore.go
+++ b/server/fleet/datastore.go
@@ -184,9 +184,12 @@ type Datastore interface {
 	RemoveLabelsFromHost(ctx context.Context, hostID uint, labelIDs []uint) error
 
 	NewLabel(ctx context.Context, Label *Label, opts ...OptionalArg) (*Label, error)
-	SaveLabel(ctx context.Context, label *Label) (*Label, error)
+	// SaveLabel updates the label and returns the label and an array of host IDs
+	// members of this label, or an error.
+	SaveLabel(ctx context.Context, label *Label) (*Label, []uint, error)
 	DeleteLabel(ctx context.Context, name string) error
-	Label(ctx context.Context, lid uint) (*Label, error)
+	// Label returns the label and an array of host IDs members of this label, or an error.
+	Label(ctx context.Context, lid uint) (*Label, []uint, error)
 	ListLabels(ctx context.Context, filter TeamFilter, opt ListOptions) ([]*Label, error)
 	LabelsSummary(ctx context.Context) ([]*LabelSummary, error)
 

--- a/server/fleet/service.go
+++ b/server/fleet/service.go
@@ -241,11 +241,11 @@ type Service interface {
 	// GetLabelSpec gets the spec for the label with the given name.
 	GetLabelSpec(ctx context.Context, name string) (*LabelSpec, error)
 
-	NewLabel(ctx context.Context, p LabelPayload) (label *Label, err error)
-	ModifyLabel(ctx context.Context, id uint, payload ModifyLabelPayload) (*Label, error)
+	NewLabel(ctx context.Context, p LabelPayload) (label *Label, hostIDs []uint, err error)
+	ModifyLabel(ctx context.Context, id uint, payload ModifyLabelPayload) (*Label, []uint, error)
 	ListLabels(ctx context.Context, opt ListOptions) (labels []*Label, err error)
 	LabelsSummary(ctx context.Context) (labels []*LabelSummary, err error)
-	GetLabel(ctx context.Context, id uint) (label *Label, err error)
+	GetLabel(ctx context.Context, id uint) (label *Label, hostIDs []uint, err error)
 
 	DeleteLabel(ctx context.Context, name string) (err error)
 	// DeleteLabelByID is for backwards compatibility with the UI

--- a/server/mock/datastore_mock.go
+++ b/server/mock/datastore_mock.go
@@ -135,11 +135,11 @@ type RemoveLabelsFromHostFunc func(ctx context.Context, hostID uint, labelIDs []
 
 type NewLabelFunc func(ctx context.Context, Label *fleet.Label, opts ...fleet.OptionalArg) (*fleet.Label, error)
 
-type SaveLabelFunc func(ctx context.Context, label *fleet.Label) (*fleet.Label, error)
+type SaveLabelFunc func(ctx context.Context, label *fleet.Label) (*fleet.Label, []uint, error)
 
 type DeleteLabelFunc func(ctx context.Context, name string) error
 
-type LabelFunc func(ctx context.Context, lid uint) (*fleet.Label, error)
+type LabelFunc func(ctx context.Context, lid uint) (*fleet.Label, []uint, error)
 
 type ListLabelsFunc func(ctx context.Context, filter fleet.TeamFilter, opt fleet.ListOptions) ([]*fleet.Label, error)
 
@@ -2659,7 +2659,7 @@ func (s *DataStore) NewLabel(ctx context.Context, Label *fleet.Label, opts ...fl
 	return s.NewLabelFunc(ctx, Label, opts...)
 }
 
-func (s *DataStore) SaveLabel(ctx context.Context, label *fleet.Label) (*fleet.Label, error) {
+func (s *DataStore) SaveLabel(ctx context.Context, label *fleet.Label) (*fleet.Label, []uint, error) {
 	s.mu.Lock()
 	s.SaveLabelFuncInvoked = true
 	s.mu.Unlock()
@@ -2673,7 +2673,7 @@ func (s *DataStore) DeleteLabel(ctx context.Context, name string) error {
 	return s.DeleteLabelFunc(ctx, name)
 }
 
-func (s *DataStore) Label(ctx context.Context, lid uint) (*fleet.Label, error) {
+func (s *DataStore) Label(ctx context.Context, lid uint) (*fleet.Label, []uint, error) {
 	s.mu.Lock()
 	s.LabelFuncInvoked = true
 	s.mu.Unlock()

--- a/server/service/hosts.go
+++ b/server/service/hosts.go
@@ -2403,7 +2403,7 @@ func (svc *Service) validateLabelNames(ctx context.Context, action string, label
 
 	var dynamicLabels []string
 	for labelName, labelID := range labels {
-		label, err := svc.ds.Label(ctx, labelID)
+		label, _, err := svc.ds.Label(ctx, labelID)
 		if err != nil {
 			return nil, ctxerr.Wrap(ctx, err, "load label from id")
 		}

--- a/server/service/labels.go
+++ b/server/service/labels.go
@@ -28,12 +28,12 @@ func (r createLabelResponse) error() error { return r.Err }
 func createLabelEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (errorer, error) {
 	req := request.(*createLabelRequest)
 
-	label, err := svc.NewLabel(ctx, req.LabelPayload)
+	label, hostIDs, err := svc.NewLabel(ctx, req.LabelPayload)
 	if err != nil {
 		return createLabelResponse{Err: err}, nil
 	}
 
-	labelResp, err := labelResponseForLabel(ctx, svc, label)
+	labelResp, err := labelResponseForLabel(ctx, svc, label, hostIDs)
 	if err != nil {
 		return createLabelResponse{Err: err}, nil
 	}
@@ -41,9 +41,9 @@ func createLabelEndpoint(ctx context.Context, request interface{}, svc fleet.Ser
 	return createLabelResponse{Label: *labelResp}, nil
 }
 
-func (svc *Service) NewLabel(ctx context.Context, p fleet.LabelPayload) (*fleet.Label, error) {
+func (svc *Service) NewLabel(ctx context.Context, p fleet.LabelPayload) (*fleet.Label, []uint, error) {
 	if err := svc.authz.Authorize(ctx, &fleet.Label{}, fleet.ActionWrite); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	label := &fleet.Label{
@@ -52,12 +52,12 @@ func (svc *Service) NewLabel(ctx context.Context, p fleet.LabelPayload) (*fleet.
 	}
 
 	if p.Name == "" {
-		return nil, fleet.NewInvalidArgumentError("name", "missing required argument")
+		return nil, nil, fleet.NewInvalidArgumentError("name", "missing required argument")
 	}
 	label.Name = p.Name
 
 	if p.Query != "" && len(p.Hosts) > 0 {
-		return nil, fleet.NewInvalidArgumentError("query", `Only one of either "query" or "hosts" can be included in the request.`)
+		return nil, nil, fleet.NewInvalidArgumentError("query", `Only one of either "query" or "hosts" can be included in the request.`)
 	}
 	label.Query = p.Query
 	if p.Query == "" {
@@ -69,7 +69,7 @@ func (svc *Service) NewLabel(ctx context.Context, p fleet.LabelPayload) (*fleet.
 
 	for name := range fleet.ReservedLabelNames() {
 		if label.Name == name {
-			return nil, fleet.NewInvalidArgumentError("name", fmt.Sprintf("cannot add label '%s' because it conflicts with the name of a built-in label", name))
+			return nil, nil, fleet.NewInvalidArgumentError("name", fmt.Sprintf("cannot add label '%s' because it conflicts with the name of a built-in label", name))
 		}
 	}
 
@@ -77,6 +77,7 @@ func (svc *Service) NewLabel(ctx context.Context, p fleet.LabelPayload) (*fleet.
 	// not create label memberships), otherwise NewLabel works for dynamic
 	// membership. Must resolve the host identifiers to hostname so that
 	// ApplySpecs can be used.
+	var hostIDs []uint
 	if label.LabelMembershipType == fleet.LabelMembershipTypeManual {
 		spec := fleet.LabelSpec{
 			Name:                label.Name,
@@ -88,28 +89,30 @@ func (svc *Service) NewLabel(ctx context.Context, p fleet.LabelPayload) (*fleet.
 		}
 		hostnames, err := svc.ds.HostnamesByIdentifiers(ctx, p.Hosts)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 		spec.Hosts = hostnames
 		if err := svc.ds.ApplyLabelSpecs(ctx, []*fleet.LabelSpec{&spec}); err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 
-		// must reload it to get the id
+		// must reload it to get the id, and the host IDs
 		lblIDsByName, err := svc.ds.LabelIDsByName(ctx, []string{label.Name})
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
-		label.ID = lblIDsByName[label.Name]
-		label.HostCount = len(hostnames)
+		label, hostIDs, err = svc.ds.Label(ctx, lblIDsByName[label.Name])
+		if err != nil {
+			return nil, nil, err
+		}
 	} else {
 		newLbl, err := svc.ds.NewLabel(ctx, label)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 		label = newLbl
 	}
-	return label, nil
+	return label, hostIDs, nil
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -130,12 +133,12 @@ func (r modifyLabelResponse) error() error { return r.Err }
 
 func modifyLabelEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (errorer, error) {
 	req := request.(*modifyLabelRequest)
-	label, err := svc.ModifyLabel(ctx, req.ID, req.ModifyLabelPayload)
+	label, hostIDs, err := svc.ModifyLabel(ctx, req.ID, req.ModifyLabelPayload)
 	if err != nil {
 		return modifyLabelResponse{Err: err}, nil
 	}
 
-	labelResp, err := labelResponseForLabel(ctx, svc, label)
+	labelResp, err := labelResponseForLabel(ctx, svc, label, hostIDs)
 	if err != nil {
 		return modifyLabelResponse{Err: err}, nil
 	}
@@ -143,23 +146,23 @@ func modifyLabelEndpoint(ctx context.Context, request interface{}, svc fleet.Ser
 	return modifyLabelResponse{Label: *labelResp}, err
 }
 
-func (svc *Service) ModifyLabel(ctx context.Context, id uint, payload fleet.ModifyLabelPayload) (*fleet.Label, error) {
+func (svc *Service) ModifyLabel(ctx context.Context, id uint, payload fleet.ModifyLabelPayload) (*fleet.Label, []uint, error) {
 	if err := svc.authz.Authorize(ctx, &fleet.Label{}, fleet.ActionWrite); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
-	label, err := svc.ds.Label(ctx, id)
+	label, _, err := svc.ds.Label(ctx, id)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	if label.LabelType == fleet.LabelTypeBuiltIn {
-		return nil, fleet.NewInvalidArgumentError("label_type", fmt.Sprintf("cannot modify built-in label '%s'", label.Name))
+		return nil, nil, fleet.NewInvalidArgumentError("label_type", fmt.Sprintf("cannot modify built-in label '%s'", label.Name))
 	}
 	if payload.Name != nil {
 		// Check if the new name is a reserved label name
 		for name := range fleet.ReservedLabelNames() {
 			if *payload.Name == name {
-				return nil, fleet.NewInvalidArgumentError("name", fmt.Sprintf("cannot rename label to '%s' because it conflicts with the name of a built-in label", name))
+				return nil, nil, fleet.NewInvalidArgumentError("name", fmt.Sprintf("cannot rename label to '%s' because it conflicts with the name of a built-in label", name))
 			}
 		}
 		label.Name = *payload.Name
@@ -168,7 +171,7 @@ func (svc *Service) ModifyLabel(ctx context.Context, id uint, payload fleet.Modi
 		label.Description = *payload.Description
 	}
 	if len(payload.Hosts) > 0 && label.LabelMembershipType != fleet.LabelMembershipTypeManual {
-		return nil, fleet.NewInvalidArgumentError("hosts", "cannot provide a list of hosts for a dynamic label")
+		return nil, nil, fleet.NewInvalidArgumentError("hosts", "cannot provide a list of hosts for a dynamic label")
 	}
 
 	// if membership type is manual and the Hosts membership is provided, must
@@ -187,11 +190,11 @@ func (svc *Service) ModifyLabel(ctx context.Context, id uint, payload fleet.Modi
 		}
 		hostnames, err := svc.ds.HostnamesByIdentifiers(ctx, payload.Hosts)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 		spec.Hosts = hostnames
 		if err := svc.ds.ApplyLabelSpecs(ctx, []*fleet.LabelSpec{&spec}); err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 
 		// must reload it to get the host counts information
@@ -224,20 +227,20 @@ func (r getLabelResponse) error() error { return r.Err }
 
 func getLabelEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (errorer, error) {
 	req := request.(*getLabelRequest)
-	label, err := svc.GetLabel(ctx, req.ID)
+	label, hostIDs, err := svc.GetLabel(ctx, req.ID)
 	if err != nil {
 		return getLabelResponse{Err: err}, nil
 	}
-	resp, err := labelResponseForLabel(ctx, svc, label)
+	resp, err := labelResponseForLabel(ctx, svc, label, hostIDs)
 	if err != nil {
 		return getLabelResponse{Err: err}, nil
 	}
 	return getLabelResponse{Label: *resp}, nil
 }
 
-func (svc *Service) GetLabel(ctx context.Context, id uint) (*fleet.Label, error) {
+func (svc *Service) GetLabel(ctx context.Context, id uint) (*fleet.Label, []uint, error) {
 	if err := svc.authz.Authorize(ctx, &fleet.Label{}, fleet.ActionRead); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	return svc.ds.Label(ctx, id)
@@ -268,7 +271,7 @@ func listLabelsEndpoint(ctx context.Context, request interface{}, svc fleet.Serv
 
 	resp := listLabelsResponse{}
 	for _, label := range labels {
-		labelResp, err := labelResponseForLabel(ctx, svc, label)
+		labelResp, err := labelResponseForLabel(ctx, svc, label, nil)
 		if err != nil {
 			return listLabelsResponse{Err: err}, nil
 		}
@@ -287,14 +290,20 @@ func (svc *Service) ListLabels(ctx context.Context, opt fleet.ListOptions) ([]*f
 	}
 	filter := fleet.TeamFilter{User: vc.User, IncludeObserver: true}
 
+	// TODO(mna): ListLabels doesn't currently return the hostIDs members of the
+	// label, that would be an N+1 queries endpoint (unless we gather the host
+	// IDs in the same query with e.g. a JSON array column, but this probably
+	// only works if the number of hosts is low). Leaving like that for now
+	// because we're in a hurry before merge freeze.
 	return svc.ds.ListLabels(ctx, filter, opt)
 }
 
-func labelResponseForLabel(ctx context.Context, svc fleet.Service, label *fleet.Label) (*labelResponse, error) {
+func labelResponseForLabel(ctx context.Context, svc fleet.Service, label *fleet.Label, hostIDs []uint) (*labelResponse, error) {
 	return &labelResponse{
 		Label:       *label,
 		DisplayText: label.Name,
 		Count:       label.HostCount,
+		HostIDs:     hostIDs,
 	}, nil
 }
 
@@ -437,7 +446,7 @@ func (svc *Service) DeleteLabelByID(ctx context.Context, id uint) error {
 		return err
 	}
 
-	label, err := svc.ds.Label(ctx, id)
+	label, _, err := svc.ds.Label(ctx, id)
 	if err != nil {
 		return err
 	}

--- a/server/service/labels.go
+++ b/server/service/labels.go
@@ -291,10 +291,11 @@ func (svc *Service) ListLabels(ctx context.Context, opt fleet.ListOptions) ([]*f
 	filter := fleet.TeamFilter{User: vc.User, IncludeObserver: true}
 
 	// TODO(mna): ListLabels doesn't currently return the hostIDs members of the
-	// label, that would be an N+1 queries endpoint (unless we gather the host
-	// IDs in the same query with e.g. a JSON array column, but this probably
-	// only works if the number of hosts is low). Leaving like that for now
-	// because we're in a hurry before merge freeze.
+	// label, the quick approach would be an N+1 queries endpoint. Leaving like
+	// that for now because we're in a hurry before merge freeze but the solution
+	// would probably be to do it in 2 queries : grab all label IDs from the
+	// list, then select hostID+labelID tuples in one query (where labelID IN
+	// <list of ids>)and fill the hostIDs per label.
 	return svc.ds.ListLabels(ctx, filter, opt)
 }
 

--- a/server/service/labels_test.go
+++ b/server/service/labels_test.go
@@ -90,16 +90,16 @@ func TestLabelsAuth(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := viewer.NewContext(ctx, viewer.Viewer{User: tt.user})
 
-			_, err := svc.NewLabel(ctx, fleet.LabelPayload{Name: t.Name(), Query: `SELECT 1`})
+			_, _, err := svc.NewLabel(ctx, fleet.LabelPayload{Name: t.Name(), Query: `SELECT 1`})
 			checkAuthErr(t, tt.shouldFailWrite, err)
 
-			_, err = svc.ModifyLabel(ctx, 1, fleet.ModifyLabelPayload{})
+			_, _, err = svc.ModifyLabel(ctx, 1, fleet.ModifyLabelPayload{})
 			checkAuthErr(t, tt.shouldFailWrite, err)
 
 			err = svc.ApplyLabelSpecs(ctx, []*fleet.LabelSpec{})
 			checkAuthErr(t, tt.shouldFailWrite, err)
 
-			_, err = svc.GetLabel(ctx, 1)
+			_, _, err = svc.GetLabel(ctx, 1)
 			checkAuthErr(t, tt.shouldFailRead, err)
 
 			_, err = svc.GetLabelSpecs(ctx)
@@ -155,7 +155,7 @@ func testLabelsGetLabel(t *testing.T, ds *mysql.Datastore) {
 	assert.Nil(t, err)
 	assert.NotZero(t, label.ID)
 
-	labelVerify, err := svc.GetLabel(test.UserContext(ctx, test.UserAdmin), label.ID)
+	labelVerify, _, err := svc.GetLabel(test.UserContext(ctx, test.UserAdmin), label.ID)
 	assert.Nil(t, err)
 	assert.Equal(t, label.ID, labelVerify.ID)
 }

--- a/server/service/labels_test.go
+++ b/server/service/labels_test.go
@@ -21,8 +21,8 @@ func TestLabelsAuth(t *testing.T) {
 	ds.NewLabelFunc = func(ctx context.Context, lbl *fleet.Label, opts ...fleet.OptionalArg) (*fleet.Label, error) {
 		return lbl, nil
 	}
-	ds.SaveLabelFunc = func(ctx context.Context, lbl *fleet.Label) (*fleet.Label, error) {
-		return lbl, nil
+	ds.SaveLabelFunc = func(ctx context.Context, lbl *fleet.Label) (*fleet.Label, []uint, error) {
+		return lbl, nil, nil
 	}
 	ds.DeleteLabelFunc = func(ctx context.Context, nm string) error {
 		return nil
@@ -30,8 +30,8 @@ func TestLabelsAuth(t *testing.T) {
 	ds.ApplyLabelSpecsFunc = func(ctx context.Context, specs []*fleet.LabelSpec) error {
 		return nil
 	}
-	ds.LabelFunc = func(ctx context.Context, id uint) (*fleet.Label, error) {
-		return &fleet.Label{}, nil
+	ds.LabelFunc = func(ctx context.Context, id uint) (*fleet.Label, []uint, error) {
+		return &fleet.Label{}, nil, nil
 	}
 	ds.ListLabelsFunc = func(ctx context.Context, filter fleet.TeamFilter, opts fleet.ListOptions) ([]*fleet.Label, error) {
 		return nil, nil

--- a/server/service/metrics_labels.go
+++ b/server/service/metrics_labels.go
@@ -8,17 +8,17 @@ import (
 	"github.com/fleetdm/fleet/v4/server/fleet"
 )
 
-func (mw metricsMiddleware) ModifyLabel(ctx context.Context, id uint, p fleet.ModifyLabelPayload) (*fleet.Label, error) {
+func (mw metricsMiddleware) ModifyLabel(ctx context.Context, id uint, p fleet.ModifyLabelPayload) (*fleet.Label, []uint, error) {
 	var (
-		lic *fleet.Label
-		err error
+		lic  *fleet.Label
+		hids []uint
+		err  error
 	)
 	defer func(begin time.Time) {
 		lvs := []string{"method", "ModifyLabel", "error", fmt.Sprint(err != nil)}
 		mw.requestCount.With(lvs...).Add(1)
 		mw.requestLatency.With(lvs...).Observe(time.Since(begin).Seconds())
 	}(time.Now())
-	lic, err = mw.Service.ModifyLabel(ctx, id, p)
-	return lic, err
-
+	lic, hids, err = mw.Service.ModifyLabel(ctx, id, p)
+	return lic, hids, err
 }


### PR DESCRIPTION
#17899 

Note that those endpoints already existed and already documented that `host_ids` were returned, but they never were (even though manual labels could be created before, via `fleetctl apply`). So in a way this addresses an old released bug.

# Checklist for submitter

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [x] Added/updated tests
