### PR TITLE
Fixed fleetctl gitops dry-run validation issues when enabling calendar integration for the first time.

### DIFF
--- a/changes/18299-gitops-calendar-validation
+++ b/changes/18299-gitops-calendar-validation
@@ -1,0 +1,1 @@
+Fixed fleetctl gitops dry-run validation issues when enabling calendar integration for the first time.

--- a/ee/server/service/teams.go
+++ b/ee/server/service/teams.go
@@ -214,7 +214,7 @@ func (svc *Service) ModifyTeam(ctx context.Context, teamID uint, payload fleet.T
 		// Only update the calendar integration if it's not nil
 		if payload.Integrations.GoogleCalendar != nil {
 			invalid := &fleet.InvalidArgumentError{}
-			_ = svc.validateTeamCalendarIntegrations(payload.Integrations.GoogleCalendar, appCfg, invalid)
+			_ = svc.validateTeamCalendarIntegrations(payload.Integrations.GoogleCalendar, appCfg, false, invalid)
 			if invalid.HasErrors() {
 				return nil, ctxerr.Wrap(ctx, invalid)
 			}
@@ -1095,7 +1095,7 @@ func (svc *Service) editTeamFromSpec(
 	}
 
 	if spec.Integrations.GoogleCalendar != nil {
-		err = svc.validateTeamCalendarIntegrations(spec.Integrations.GoogleCalendar, appCfg, invalid)
+		err = svc.validateTeamCalendarIntegrations(spec.Integrations.GoogleCalendar, appCfg, dryRun, invalid)
 		if err != nil {
 			return ctxerr.Wrap(ctx, err, "validate team calendar integrations")
 		}
@@ -1170,13 +1170,13 @@ func (svc *Service) editTeamFromSpec(
 
 func (svc *Service) validateTeamCalendarIntegrations(
 	calendarIntegration *fleet.TeamGoogleCalendarIntegration,
-	appCfg *fleet.AppConfig, invalid *fleet.InvalidArgumentError,
+	appCfg *fleet.AppConfig, dryRun bool, invalid *fleet.InvalidArgumentError,
 ) error {
 	if !calendarIntegration.Enable {
 		return nil
 	}
-	// Check that global configs exist
-	if len(appCfg.Integrations.GoogleCalendar) == 0 {
+	// Check that global configs exist. During dry run, the global config may not be available yet.
+	if len(appCfg.Integrations.GoogleCalendar) == 0 && !dryRun {
 		invalid.Append("integrations.google_calendar.enable_calendar_events", "global Google Calendar integration is not configured")
 	}
 	// Validate URL


### PR DESCRIPTION
#18299
Fixed fleetctl gitops dry-run validation issues when enabling calendar integration for the first time.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [x] Added/updated tests
- [x] Manual QA for all new/changed functionality
