### PR TITLE
Update go version to match GitHub environment variable

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/fleetdm/fleet/v4
 
-go 1.21.0
+go 1.21.7
 
 require (
 	cloud.google.com/go/pubsub v1.33.0


### PR DESCRIPTION
I realized the env var is 1.21.7 and our go.mod was 1.21.0.