### PR TITLE
Website: remove client-side query string removal

### DIFF
--- a/website/assets/js/pages/contact.page.js
+++ b/website/assets/js/pages/contact.page.js
@@ -63,9 +63,6 @@ parasails.registerPage('contact', {
       }
       this.formData = _.clone(this.formDataToPrefillForLoggedInUsers);
     }
-    if(window.location.search){// auto-clear query string  (TODO: Document why we're doing this further.  I think this shouldn't exist in the frontend code, instead in the hook.  Because analytics corruption.)
-      window.history.replaceState({}, document.title, '/contact' );
-    }
   },
   mounted: async function() {
     //…

--- a/website/assets/js/pages/entrance/signup.page.js
+++ b/website/assets/js/pages/entrance/signup.page.js
@@ -30,11 +30,7 @@ parasails.registerPage('signup', {
   //  ║  ║╠╣ ║╣ ║  ╚╦╝║  ║  ║╣
   //  ╩═╝╩╚  ╚═╝╚═╝ ╩ ╚═╝╩═╝╚═╝
   beforeMount: function() {
-    // Removing the query string for users redirected to this page by the /try-fleet/explore-data pages.
-    // FUTURE: remove this when that view-query-report is updated.
-    if(window.location.search){
-      window.history.replaceState({}, document.title, '/register' );
-    }
+    //…
   },
   mounted: async function() {
     //…

--- a/website/assets/js/pages/fleetctl-preview.page.js
+++ b/website/assets/js/pages/fleetctl-preview.page.js
@@ -10,12 +10,7 @@ parasails.registerPage('fleetctl-preview', {
   //  ║  ║╠╣ ║╣ ║  ╚╦╝║  ║  ║╣
   //  ╩═╝╩╚  ╚═╝╚═╝ ╩ ╚═╝╩═╝╚═╝
   beforeMount: function() {
-
-    // If the user navigated to this page from the 'try it now' button, we'll strip the '?tryitnow' from the url.
-    if(window.location.search){
-      // https://caniuse.com/mdn-api_history_replacestate
-      window.history.replaceState({}, document.title, '/fleetctl-preview' );
-    }
+    //…
   },
   mounted: async function() {
     //…


### PR DESCRIPTION
Changes:
- Removed the client-side browser history adjustment that was used to clean up URLs with query strings on the /contact, /register, and /fleetctl-preview pages.