### PR TITLE
Update to Go convention and use same version defined in GitHub enviro…

### DIFF
--- a/terraform/addons/monitoring/lambda/go.mod
+++ b/terraform/addons/monitoring/lambda/go.mod
@@ -1,6 +1,6 @@
 module github.com/fleetdm/fleet/terraform/addons/monitoring/lambda
 
-go 1.21.1
+go 1.21.7
 
 require (
 	github.com/aws/aws-lambda-go v1.41.0

--- a/tools/mdm/windows/bitlocker/go.mod
+++ b/tools/mdm/windows/bitlocker/go.mod
@@ -1,6 +1,6 @@
 module bitlocker
 
-go 1.21
+go 1.21.7
 
 require github.com/go-ole/go-ole v1.3.0
 


### PR DESCRIPTION
This is to address some code scanning warnings. 