### PR TITLE
For calendar integration, calendar event no longer created when policy has an invalid SQL query.

### DIFF
--- a/changes/18350-calendar-event-for-invalid-sql
+++ b/changes/18350-calendar-event-for-invalid-sql
@@ -1,0 +1,1 @@
+For calendar integration, calendar event no longer created when policy has an invalid SQL query.

--- a/server/datastore/mysql/policies.go
+++ b/server/datastore/mysql/policies.go
@@ -1186,9 +1186,9 @@ func (ds *Datastore) GetTeamHostsPolicyMemberships(
 		h.hardware_serial AS host_hardware_serial
 	FROM hosts h
 	LEFT JOIN (
-		SELECT host_id, BIT_AND(COALESCE(passes, 0)) AS passing
+		SELECT host_id, BIT_AND(passes) AS passing
 		FROM policy_membership
-		WHERE policy_id IN (?)
+		WHERE policy_id IN (?) AND passes IS NOT NULL
 		GROUP BY host_id
 	) pm ON h.id = pm.host_id
 	LEFT JOIN (

--- a/server/datastore/mysql/policies_test.go
+++ b/server/datastore/mysql/policies_test.go
@@ -3192,6 +3192,37 @@ func testGetTeamHostsPolicyMemberships(t *testing.T, ds *Datastore) {
 	require.Equal(t, "display_name3", hostsTeam2[1].HostDisplayName)
 
 	//
+	// Make host2 policy results invalid (NULL).
+	//
+
+	err = ds.RecordPolicyQueryExecutions(
+		ctx, host2, map[uint]*bool{
+			team2Policy1.ID: nil,
+			team2Policy2.ID: nil,
+		}, time.Now(), false,
+	)
+	require.NoError(t, err)
+
+	hostsTeam2, err = ds.GetTeamHostsPolicyMemberships(ctx, "example.com", team2.ID, []uint{team2Policies[0].ID, team2Policies[1].ID})
+	require.NoError(t, err)
+	require.Len(t, hostsTeam2, 2)
+	sort.Slice(
+		hostsTeam2, func(i, j int) bool {
+			return hostsTeam2[i].HostID < hostsTeam1[j].HostID
+		},
+	)
+	require.Equal(t, host2.ID, hostsTeam2[0].HostID)
+	require.Equal(t, "foo@example.com", hostsTeam2[0].Email)
+	require.True(t, hostsTeam2[0].Passing)
+	require.Equal(t, "serial2", hostsTeam2[0].HostHardwareSerial)
+	require.Equal(t, "display_name2", hostsTeam2[0].HostDisplayName)
+	require.Equal(t, host3.ID, hostsTeam2[1].HostID)
+	require.Equal(t, "zoo@example.com", hostsTeam2[1].Email)
+	require.True(t, hostsTeam2[1].Passing)
+	require.Equal(t, "serial3", hostsTeam2[1].HostHardwareSerial)
+	require.Equal(t, "display_name3", hostsTeam2[1].HostDisplayName)
+
+	//
 	// Make host2 pass all policies.
 	//
 


### PR DESCRIPTION
For calendar integration, calendar event no longer created when policy has an invalid SQL query.
#18350 

# Checklist for submitter
- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [x] Added/updated tests
- [x] Manual QA for all new/changed functionality
