### PR TITLE
Fleet UI: Fix disk space tooltip cut off, add tests

### DIFF
--- a/frontend/components/DiskSpaceGraph/DiskSpaceGraph.tests.tsx
+++ b/frontend/components/DiskSpaceGraph/DiskSpaceGraph.tests.tsx
@@ -1,0 +1,79 @@
+import React from "react";
+
+import { screen, render, fireEvent } from "@testing-library/react";
+
+import DiskSpaceGraph from "./DiskSpaceGraph";
+
+describe("Disk space graph", () => {
+  it("renders warning tooltip for <32gB when hovering over the yellow disk space graph for darwin or windows", async () => {
+    render(
+      <DiskSpaceGraph
+        baseClass="data-set"
+        gigsDiskSpaceAvailable={17}
+        percentDiskSpaceAvailable={10}
+        id="disk-space-graph"
+        platform="darwin"
+        tooltipPosition="bottom"
+      />
+    );
+
+    expect(screen.getByTitle("disk space indicator")).toHaveStyle("width: 10%");
+    expect(screen.getByTitle("disk space indicator")).toHaveClass(
+      "data-set__disk-space--yellow"
+    );
+
+    await fireEvent.mouseOver(screen.getByTitle("disk space indicator"));
+    const tooltip = screen.getByText(
+      "Not enough disk space available to install most large operating systems updates."
+    );
+    expect(tooltip).toBeInTheDocument();
+  });
+
+  it("renders severe warning tooltip for <16 gBwhen hovering over the red disk space graph for darwin or windows", async () => {
+    render(
+      <DiskSpaceGraph
+        baseClass="data-set"
+        gigsDiskSpaceAvailable={5}
+        percentDiskSpaceAvailable={2}
+        id="disk-space-graph"
+        platform="windows"
+        tooltipPosition="bottom"
+      />
+    );
+
+    expect(screen.getByTitle("disk space indicator")).toHaveStyle("width: 2%");
+    expect(screen.getByTitle("disk space indicator")).toHaveClass(
+      "data-set__disk-space--red"
+    );
+
+    await fireEvent.mouseOver(screen.getByTitle("disk space indicator"));
+    const tooltip = screen.getByText(
+      "Not enough disk space available to install most small operating systems updates."
+    );
+    expect(tooltip).toBeInTheDocument();
+  });
+
+  it("renders tooltip when hovering over the green disk space graph for darwin or windows", async () => {
+    render(
+      <DiskSpaceGraph
+        baseClass="data-set"
+        gigsDiskSpaceAvailable={33}
+        percentDiskSpaceAvailable={15}
+        id="disk-space-graph"
+        platform="windows"
+        tooltipPosition="bottom"
+      />
+    );
+
+    expect(screen.getByTitle("disk space indicator")).toHaveStyle("width: 15%");
+    expect(screen.getByTitle("disk space indicator")).toHaveClass(
+      "data-set__disk-space--green"
+    );
+
+    await fireEvent.mouseOver(screen.getByTitle("disk space indicator"));
+    const tooltip = screen.getByText(
+      "Enough disk space available to install most operating systems updates."
+    );
+    expect(tooltip).toBeInTheDocument();
+  });
+});

--- a/frontend/components/DiskSpaceGraph/DiskSpaceGraph.tsx
+++ b/frontend/components/DiskSpaceGraph/DiskSpaceGraph.tsx
@@ -5,7 +5,7 @@ import { COLORS } from "styles/var/colors";
 
 interface IDiskSpaceGraphProps {
   baseClass: string;
-  gigsDiskSpaceAvailable: number | string;
+  gigsDiskSpaceAvailable: number | "---";
   percentDiskSpaceAvailable: number;
   id: string;
   platform: string;
@@ -20,6 +20,10 @@ const DiskSpaceGraph = ({
   platform,
   tooltipPosition = "top",
 }: IDiskSpaceGraphProps): JSX.Element => {
+  if (gigsDiskSpaceAvailable === 0 || gigsDiskSpaceAvailable === "---") {
+    return <span className={`${baseClass}__data`}>No data available</span>;
+  }
+
   const getDiskSpaceIndicatorColor = (): string => {
     // return space-dependent graph colors for mac and windows hosts, green for linux
     if (platform === "darwin" || platform === "windows") {
@@ -43,10 +47,6 @@ const DiskSpaceGraph = ({
     }
     return undefined;
   })();
-
-  if (gigsDiskSpaceAvailable === 0 || gigsDiskSpaceAvailable === "---") {
-    return <span className={`${baseClass}__data`}>No data available</span>;
-  }
 
   return (
     <span className={`${baseClass}__data`}>

--- a/frontend/components/DiskSpaceGraph/_styles.scss
+++ b/frontend/components/DiskSpaceGraph/_styles.scss
@@ -32,9 +32,11 @@
     }
   }
 
-  .disk-space-tooltip {
-    display: block;
-    white-space: normal;
-    max-width: 160px;
+  &__data {
+    .disk-space-tooltip {
+      display: block;
+      white-space: normal;
+      max-width: 160px;
+    }
   }
 }

--- a/frontend/pages/hosts/details/cards/HostSummary/HostSummary.tests.tsx
+++ b/frontend/pages/hosts/details/cards/HostSummary/HostSummary.tests.tsx
@@ -39,14 +39,14 @@ describe("Host Actions Dropdown", () => {
         waitFor(() => {
           user.hover(screen.getByText(new RegExp(orbitVersion, "i")));
         });
-      });
 
-      expect(
-        screen.getByText(new RegExp(osqueryVersion, "i"))
-      ).toBeInTheDocument();
-      expect(
-        screen.getByText(new RegExp(fleetdVersion, "i"))
-      ).toBeInTheDocument();
+        expect(
+          screen.getByText(new RegExp(osqueryVersion, "i"))
+        ).toBeInTheDocument();
+        expect(
+          screen.getByText(new RegExp(fleetdVersion, "i"))
+        ).toBeInTheDocument();
+      });
     });
 
     it("omit fleet desktop from tooltip if no fleet desktop version", async () => {

--- a/frontend/pages/hosts/details/cards/HostSummary/HostSummary.tests.tsx
+++ b/frontend/pages/hosts/details/cards/HostSummary/HostSummary.tests.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { noop } from "lodash";
-import { screen } from "@testing-library/react";
+import { screen, waitFor } from "@testing-library/react";
 import { createCustomRenderer } from "test/test-utils";
 
 import createMockUser from "__mocks__/userMock";
@@ -35,7 +35,11 @@ describe("Host Actions Dropdown", () => {
       );
 
       expect(screen.getByText("Agent")).toBeInTheDocument();
-      await user.hover(screen.getByText(new RegExp(orbitVersion, "i")));
+      await waitFor(() => {
+        waitFor(() => {
+          user.hover(screen.getByText(new RegExp(orbitVersion, "i")));
+        });
+      });
 
       expect(
         screen.getByText(new RegExp(osqueryVersion, "i"))


### PR DESCRIPTION
## Issue
Cerra #18338
Building tests closes #8782 

## Description
- Fix CSS that was cutting off the tooltip text
- Root cause: Updates to parent set to `<DataSet/>` caused CSS not to render
- Add unit test for colors/percentages/tooltip text

## Screenshot of fix
<img width="673" alt="Screenshot 2024-04-17 at 9 24 33 AM" src="https://github.com/fleetdm/fleet/assets/71795832/2b6e84f2-c3b4-44de-917f-8bb99a3a78d0">


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
- [x] Manual QA for all new/changed functionality
