### PR TITLE
Fleet UI: Equal padding above and below empty states on host details page

### DIFF
--- a/changes/16562-sql-deadlock copy
+++ b/changes/16562-sql-deadlock copy
@@ -1,0 +1,1 @@
+Reduced the number of 'Deadlock found' errors seen by the server when multiple hosts share the same UUID

--- a/changes/18084-hdp-empty-state-padding
+++ b/changes/18084-hdp-empty-state-padding
@@ -1,0 +1,1 @@
+- UI fix: padding around empty states of host details page

--- a/frontend/pages/hosts/details/_styles.scss
+++ b/frontend/pages/hosts/details/_styles.scss
@@ -186,7 +186,7 @@
 
   .empty-table {
     &__container {
-      margin: 0 0 $pad-xxlarge 0;
+      margin: $pad-xxlarge 0; // Equal padding above and below empty states
       min-height: initial;
     }
   }


### PR DESCRIPTION
## Issue
Cerra #18084 

## Description
- Found all empty states were padded with 0 padding/margin above the empty state, but 40px below it
- Fixed all host details page pages to include 40px margin above and below the empty state

## Screenshot of fixes (several but not all examples)
<img width="1164" alt="Screenshot 2024-04-17 at 1 13 19 PM" src="https://github.com/fleetdm/fleet/assets/71795832/73daf31a-9547-4ca2-bf66-a16354b34705">
<img width="1160" alt="Screenshot 2024-04-17 at 1 12 27 PM" src="https://github.com/fleetdm/fleet/assets/71795832/2d13d8f4-58ca-48c4-b78f-d7eb8d046236">
<img width="1172" alt="Screenshot 2024-04-17 at 1 11 05 PM" src="https://github.com/fleetdm/fleet/assets/71795832/fd5bca02-2f44-4cd5-85c8-ebc45182e8fe">



# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
- [x] Manual QA for all new/changed functionality
