### PR TITLE
Linux Wipe Async

### DIFF
--- a/changes/18173-linux-async-wipe
+++ b/changes/18173-linux-async-wipe
@@ -1,0 +1,1 @@
+* Fixed bug where Linux host wipe would repeat if the host got re-enrolled

--- a/ee/server/service/embedded_scripts/linux_wipe.sh
+++ b/ee/server/service/embedded_scripts/linux_wipe.sh
@@ -38,9 +38,19 @@ wipe_system_files() {
     done
 }
 
-# Start the wiping process
-logout_users
-wipe_non_essential_data
-wipe_system_files
+wipe_all_files() {
+    sleep 10 # Give fleetd enough time to register the script as completed
+    wipe_non_essential_data
+    wipe_system_files
+}
 
-echo "Wiping process completed."
+if [ $1 == "wipe" ]; then
+    # We are in the detatched child process
+    wipe_all_files
+else
+    # We are in the parent shell, logout users and begin the detached
+    # wipe child process
+    logout_users
+    echo "Wiping, system will be unreachable"
+    nohup sh $0 wipe >/dev/null 2>/dev/null </dev/null &
+fi

--- a/ee/server/service/embedded_scripts/linux_wipe.sh
+++ b/ee/server/service/embedded_scripts/linux_wipe.sh
@@ -44,7 +44,7 @@ wipe_all_files() {
     wipe_system_files
 }
 
-if [ $1 == "wipe" ]; then
+if [ "$1" = "wipe" ]; then
     # We are in the detatched child process
     wipe_all_files
 else
@@ -52,5 +52,5 @@ else
     # wipe child process
     logout_users
     echo "Wiping, system will be unreachable"
-    nohup sh $0 wipe >/dev/null 2>/dev/null </dev/null &
+    (/usr/bin/nohup sh $0 wipe >/dev/null 2>/dev/null </dev/null) &
 fi

--- a/ee/server/service/embedded_scripts/linux_wipe.sh
+++ b/ee/server/service/embedded_scripts/linux_wipe.sh
@@ -38,10 +38,25 @@ wipe_system_files() {
     done
 }
 
+prepare_system_reset() {
+    cp /usr/bin/sync /sync_bin
+    # https://docs.kernel.org/admin-guide/sysrq.html
+    echo "1" > /proc/sys/kernel/sysrq
+}
+
+system_reset() {
+    # Give the system time to sync
+    /sync_bin
+    # Halt the system immediately
+    echo "o" > /proc/sysrq-trigger
+}
+
 wipe_all_files() {
     sleep 10 # Give fleetd enough time to register the script as completed
+    prepare_system_reset
     wipe_non_essential_data
     wipe_system_files
+    system_reset
 }
 
 if [ "$1" = "wipe" ]; then

--- a/scripts/mdm/linux/linux-wipe.sh
+++ b/scripts/mdm/linux/linux-wipe.sh
@@ -38,9 +38,19 @@ wipe_system_files() {
     done
 }
 
-# Start the wiping process
-logout_users
-wipe_non_essential_data
-wipe_system_files
+wipe_all_files() {
+    sleep 10 # Give fleetd enough time to register the script as completed
+    wipe_non_essential_data
+    wipe_system_files
+}
 
-echo "Wiping process completed."
+if [ $1 == "wipe" ]; then
+    # We are in the detatched child process
+    wipe_all_files
+else
+    # We are in the parent shell, logout users and begin the detached
+    # wipe child process
+    logout_users
+    echo "Wiping, system will be unreachable"
+    nohup sh $0 wipe >/dev/null 2>/dev/null </dev/null &
+fi


### PR DESCRIPTION
#18173

Creates a detached child shell process to wipe the host. This lets the main shell script return and tells the server the command has completed, clearing it from the run queue.

Now shuts the host down after being wiped instead of leaving it running without files like a zombie

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [x] Manual QA for all new/changed functionality
