### PR TITLE
Website: Add redirect for users with a Fleet Premium subscription.

### DIFF
--- a/website/api/controllers/view-start.js
+++ b/website/api/controllers/view-start.js
@@ -11,12 +11,20 @@ module.exports = {
 
     success: {
       viewTemplatePath: 'pages/start'
+    },
+    redirect: {
+      description: 'The requesting user already has a Fleet Premium subscription.',
+      responseType: 'redirect',
     }
-
   },
 
 
   fn: async function () {
+    // If the user has a license key, we'll redirect them to the customer dashboard.
+    let userHasExistingSubscription = await Subscription.findOne({user: this.req.me.id});
+    if (userHasExistingSubscription) {
+      throw {redirect: '/customers/dashboard'};
+    }
     if(this.req.me.lastSubmittedGetStartedQuestionnaireStep && !_.isEmpty(this.req.me.getStartedQuestionnaireAnswers)){
       let currentStep = this.req.me.lastSubmittedGetStartedQuestionnaireStep;
       let previouslyAnsweredQuestions = this.req.me.getStartedQuestionnaireAnswers;


### PR DESCRIPTION
Closes: #18373

Changes:
- Updated `view-start` to redirect users who have already purchased a license to their customer dashboard