### PR TITLE
Ignoring Valve Corporation's Steam client's vulnerabilities on Windows and macOS

### DIFF
--- a/changes/18126-steam-vulns
+++ b/changes/18126-steam-vulns
@@ -1,0 +1,3 @@
+Ignoring Valve Corporation's Steam client's vulnerabilities on Windows and macOS
+  - On Windows and macOS, the true version of the Steam client (like 2021-04-10) cannot be retrieved by standard methods used on other software. We would need to create custom logic to retrieve the version of the Steam client.
+  - Steam client automatically updates itself, so security risk is somewhat mitigated.

--- a/server/vulnerabilities/nvd/cpe_translations.json
+++ b/server/vulnerabilities/nvd/cpe_translations.json
@@ -359,5 +359,23 @@
       "product": ["edge_chromium"],
       "vendor": ["microsoft"]
     }
+  },
+  {
+    "software": {
+      "name": ["Steam"],
+      "source": ["programs"]
+    },
+    "filter": {
+      "skip": true
+    }
+  },
+  {
+    "software": {
+      "name": ["Steam.app"],
+      "source": ["apps"]
+    },
+    "filter": {
+      "skip": true
+    }
   }
 ]

--- a/server/vulnerabilities/nvd/cve_test.go
+++ b/server/vulnerabilities/nvd/cve_test.go
@@ -131,6 +131,7 @@ func (d *threadSafeDSMock) InsertSoftwareVulnerability(ctx context.Context, vuln
 }
 
 func TestTranslateCPEToCVE(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 
 	// NVD_TEST_VULNDB_DIR can be used to speed up development (sync vulnerability data only once).


### PR DESCRIPTION
#18126
Ignoring Valve Corporation's Steam client's vulnerabilities on Windows and macOS
  - On Windows and macOS, the true version of the Steam client (like 2021-04-10) cannot be retrieved by standard methods used on other software. We would need to create custom logic to retrieve the version of the Steam client.
  - Steam client automatically updates itself, so security risk is somewhat mitigated.

QA note: Items from software_cve table are cleared after 2 hours.

# Checklist for submitter

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [ ] Added/updated tests
- [x] Manual QA for all new/changed functionality
