### PR TITLE
Website: Update endpoint ops heading on homepage

### DIFF
--- a/website/views/pages/homepage.ejs
+++ b/website/views/pages/homepage.ejs
@@ -83,7 +83,7 @@
       <div purpose="platform-block" class="d-flex flex-md-row flex-column-reverse justify-content-md-between mx-auto align-items-center">
         <div purpose="category-text-block" class="d-flex flex-column">
           <h4>Endpoint ops</h4>
-          <h3>A consistent interface</h3>
+          <h3>Understand your computers</h3>
           <p>Use a consistent interface to deploy, update, and manage thousands of workstations and servers with open standards and data.</p>
           <div>
             <a purpose="category-button" class="text-nowrap btn btn-primary" href="/endpoint-ops">Start with endpoint ops</a>


### PR DESCRIPTION
Changes:
- Updated the endpoint ops heading on the homepage ("A consistent interface" » "Understand your computers")