### PR TITLE
Add reviewers to automated PRs

### DIFF
--- a/.github/workflows/fleetd-tuf.yml
+++ b/.github/workflows/fleetd-tuf.yml
@@ -51,6 +51,7 @@ jobs:
         branch: update-versions-of-fleetd-components-tuf
         delete-branch: true
         title: Update versions of fleetd components in Fleet's TUF [automated]
+        reviewers: lukeheath,georgekarrv,sharon-fdm
         commit-message: |
           Update versions of fleetd components in Fleet's TUF [automated]
 

--- a/.github/workflows/update-certs.yml
+++ b/.github/workflows/update-certs.yml
@@ -51,6 +51,7 @@ jobs:
         branch: update-ca-certs
         delete-branch: true
         title: Update Orbit CA certs [automated]
+        reviewers: lukeheath,georgekarrv,sharon-fdm
         commit-message: |
           Update Orbit CA certs [automated]
 


### PR DESCRIPTION
I was thinking on adding `team-reviewers: go`, but there's the following note on the github's action repository, so let's start simple:
![Screenshot 2024-04-18 at 9 30 51 AM](https://github.com/fleetdm/fleet/assets/2073526/9477038a-320d-4aa0-860b-d18faf962f03)

