### PR TITLE
update os settings table table cell layout

### DIFF
--- a/changes/issue-18082-os-settings-stylings
+++ b/changes/issue-18082-os-settings-stylings
@@ -1,0 +1,2 @@
+- update styling of os settings modal table to have all cells have the same width and have content
+truncated when needed.

--- a/frontend/pages/hosts/details/OSSettingsModal/OSSettingsTable/OSSettingStatusCell/OSSettingStatusCell.tsx
+++ b/frontend/pages/hosts/details/OSSettingsModal/OSSettingsTable/OSSettingStatusCell/OSSettingStatusCell.tsx
@@ -19,7 +19,7 @@ import {
   WINDOWS_DISK_ENCRYPTION_DISPLAY_CONFIG,
 } from "./helpers";
 
-const baseClass = "os-setting-status-cell";
+const baseClass = "os-settings-status-cell";
 
 interface IOSSettingStatusCellProps {
   status: OsSettingsTableStatusValue;
@@ -57,7 +57,7 @@ const OSSettingStatusCell = ({
         {tooltip ? (
           <>
             <span
-              className="tooltip tooltip__tooltip-icon"
+              className={`${baseClass}__status-text`}
               data-tip
               data-for={tooltipId}
               data-tip-disable={false}

--- a/frontend/pages/hosts/details/OSSettingsModal/OSSettingsTable/OSSettingStatusCell/_styles.scss
+++ b/frontend/pages/hosts/details/OSSettingsModal/OSSettingsTable/OSSettingStatusCell/_styles.scss
@@ -1,4 +1,4 @@
-.os-setting-status-cell {
+.os-settings-status-cell {
   display: flex;
   gap: 4px;
 
@@ -14,5 +14,9 @@
 
   .__react_component_tooltip {
     white-space: normal;
+  }
+
+  &__status-text {
+    @include ellipse-text;
   }
 }

--- a/frontend/pages/hosts/details/OSSettingsModal/OSSettingsTable/OSSettingsErrorCell/OSSettingsErrorCell.tsx
+++ b/frontend/pages/hosts/details/OSSettingsModal/OSSettingsTable/OSSettingsErrorCell/OSSettingsErrorCell.tsx
@@ -135,7 +135,11 @@ const OSSettingsErrorCell = ({
         tooltipBreakOnWord
         tooltip={tooltip}
         value={value}
-        classes={showRefetchButton ? `${baseClass}__failed-message` : undefined}
+        // we dont want the default "w250" class so we pass in empty string
+        classes={""}
+        className={
+          showRefetchButton ? `${baseClass}__failed-message` : undefined
+        }
       />
       {showRefetchButton && (
         <RefetchButton isFetching={isLoading} onClick={onResendProfile} />

--- a/frontend/pages/hosts/details/OSSettingsModal/OSSettingsTable/OSSettingsErrorCell/_styles.scss
+++ b/frontend/pages/hosts/details/OSSettingsModal/OSSettingsTable/OSSettingsErrorCell/_styles.scss
@@ -5,7 +5,6 @@
   gap: $pad-small;
 
   &__failed-message {
-    max-width: calc(250px - 48px);
     min-width: 100px;
 
     .data-table__tooltip-truncated-text--cell {

--- a/frontend/pages/hosts/details/OSSettingsModal/OSSettingsTable/OSSettingsTableConfig.tsx
+++ b/frontend/pages/hosts/details/OSSettingsModal/OSSettingsTable/OSSettingsTableConfig.tsx
@@ -52,7 +52,12 @@ const generateTableConfig = (
       disableSortBy: true,
       accessor: "name",
       Cell: (cellProps: ITableStringCellProps) => {
-        return <TextCell value={cellProps.cell.value} />;
+        return (
+          <TextCell
+            value={cellProps.cell.value}
+            classes="os-settings-name-cell"
+          />
+        );
       },
     },
     {

--- a/frontend/pages/hosts/details/OSSettingsModal/OSSettingsTable/_styles.scss
+++ b/frontend/pages/hosts/details/OSSettingsModal/OSSettingsTable/_styles.scss
@@ -1,4 +1,14 @@
 .os-settings-table {
+
+  // stylings for the table cells. This was the explicit width we want
+  // for these cells in the table. Total width of the table cell will be
+  // 240px including the padding.
+  .data-table-block .data-table tbody td {
+    .os-settings-name-cell, .os-settings-status-cell, .os-settings-error-cell {
+      max-width: 192px;
+    }
+  }
+
   .statusText {
     &__cell {
       white-space: nowrap;

--- a/frontend/styles/var/mixins.scss
+++ b/frontend/styles/var/mixins.scss
@@ -182,6 +182,12 @@ $max-width: 2560px;
   }
 }
 
+@mixin ellipse-text {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 @mixin copy-message {
   font-weight: $regular;
   vertical-align: top;


### PR DESCRIPTION
relates to #18082

fixes the os settings modal table styling. We make all cells the same width and truncate when necessary.

![image](https://github.com/fleetdm/fleet/assets/1153709/48714f3c-567a-4631-809b-c4348e9faa6e)

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [x] Manual QA for all new/changed functionality
