### PR TITLE
Fleet UI: Not show error state when enabling calendar events automation

### DIFF
--- a/changes/18256-calendar-feature-url-validation
+++ b/changes/18256-calendar-feature-url-validation
@@ -1,0 +1,1 @@
+- Update calendar events automations to not show error validation on enabling the feature

--- a/frontend/pages/policies/ManagePoliciesPage/components/CalendarEventsModal/CalendarEventsModal.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/components/CalendarEventsModal/CalendarEventsModal.tsx
@@ -69,7 +69,7 @@ const CalendarEventsModal = ({
   );
   const [showExamplePayload, setShowExamplePayload] = useState(false);
 
-  // Used on URL change only when URL error exists, always onBlur, and always on attempting to save
+  // Used on URL change only when URL error exists and always on attempting to save
   const validateForm = (newFormData: ICalendarEventsFormData) => {
     const errors: Record<string, string> = {};
     const { url: newUrl } = newFormData;
@@ -278,9 +278,6 @@ const CalendarEventsModal = ({
           tooltip="Provide a URL to deliver a webhook request to."
           labelTooltipPosition="top-start"
           helpText="A request will be sent to this URL during the calendar event. Use it to trigger auto-remediation."
-          onBlur={() => {
-            validateForm(formData);
-          }}
         />
         <RevealButton
           isShowing={showExamplePayload}

--- a/frontend/pages/policies/ManagePoliciesPage/components/CalendarEventsModal/CalendarEventsModal.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/components/CalendarEventsModal/CalendarEventsModal.tsx
@@ -69,30 +69,45 @@ const CalendarEventsModal = ({
   );
   const [showExamplePayload, setShowExamplePayload] = useState(false);
 
-  const validateCalendarEventsFormData = (
-    curFormData: ICalendarEventsFormData
-  ) => {
+  // Used on URL change only when URL error exists, always onBlur, and always on attempting to save
+  const validateForm = (newFormData: ICalendarEventsFormData) => {
     const errors: Record<string, string> = {};
-    if (curFormData.enabled) {
-      const { url: curUrl } = curFormData;
-      if (!validURL({ url: curUrl })) {
-        const errorPrefix = curUrl ? `${curUrl} is not` : "Please enter";
-        errors.url = `${errorPrefix} a valid resolution webhook URL`;
-      }
+    const { url: newUrl } = newFormData;
+    if (
+      formData.enabled &&
+      !validURL({ url: newUrl || "", protocol: "http" })
+    ) {
+      const errorPrefix = newUrl ? `${newUrl} is not` : "Please enter";
+      errors.url = `${errorPrefix} a valid resolution webhook URL`;
     }
+
+    setFormErrors(errors);
+
     return errors;
   };
 
   // two onChange handlers to handle different levels of nesting in the form data
-  const onFeatureEnabledOrUrlChange = useCallback(
-    (newVal: { name: "enabled" | "url"; value: string | boolean }) => {
-      const { name, value } = newVal;
-      const newFormData = { ...formData, [name]: value };
-      setFormData(newFormData);
-      setFormErrors(validateCalendarEventsFormData(newFormData));
-    },
-    [formData]
-  );
+  const onFeatureEnabledOrUrlChange = (newVal: {
+    name: "enabled" | "url";
+    value: string | boolean;
+  }) => {
+    const { name, value } = newVal;
+    const newFormData = { ...formData, [name]: value };
+
+    // On disabling feature with erroneous URL, clear erroneous URL and URL error
+    if (name === "enabled" && value === false && formErrors.url) {
+      newFormData.url = "";
+      const { url: removedUrl, ...remainingFormErrors } = formErrors;
+      setFormErrors(remainingFormErrors);
+    }
+    setFormData(newFormData);
+
+    // On URL change with erroneous URL, validate form
+    if (name === "url" && formErrors.url) {
+      validateForm(newFormData);
+    }
+  };
+
   const onPolicyEnabledChange = useCallback(
     (newVal: { name: FormNames; value: boolean }) => {
       const { name, value } = newVal;
@@ -104,10 +119,18 @@ const CalendarEventsModal = ({
       });
       const newFormData = { ...formData, policies: newFormPolicies };
       setFormData(newFormData);
-      setFormErrors(validateCalendarEventsFormData(newFormData));
     },
     [formData]
   );
+
+  const onUpdatePolicyEnabledCalendarEvents = () => {
+    const errors = validateForm(formData);
+
+    // Submit only if there are no errors
+    if (Object.keys(errors).length === 0) {
+      updatePolicyEnabledCalendarEvents(formData);
+    }
+  };
 
   const togglePreviewCalendarEvent = () => {
     setShowPreviewCalendarEvent(!showPreviewCalendarEvent);
@@ -255,6 +278,9 @@ const CalendarEventsModal = ({
           tooltip="Provide a URL to deliver a webhook request to."
           labelTooltipPosition="top-start"
           helpText="A request will be sent to this URL during the calendar event. Use it to trigger auto-remediation."
+          onBlur={() => {
+            validateForm(formData);
+          }}
         />
         <RevealButton
           isShowing={showExamplePayload}
@@ -273,9 +299,7 @@ const CalendarEventsModal = ({
         <Button
           type="submit"
           variant="brand"
-          onClick={() => {
-            updatePolicyEnabledCalendarEvents(formData);
-          }}
+          onClick={onUpdatePolicyEnabledCalendarEvents}
           className="save-loading"
           isLoading={isUpdating}
           disabled={Object.keys(formErrors).length > 0}


### PR DESCRIPTION
## Issue
Cerra #18256 

## Description
  - Initially, feedback on submit only (e.g. as a first time user, editing saved automations)
  - Once there is an error from on submit, immediate feedback on input change until there is no error
  - When disabling, clears erroneous URLs but keeps valid URLs, so you can toggle between but not have issues saving

## Screenrecording of fix
https://www.loom.com/share/20848378c171423398db93697927157f?sid=5832d659-08c0-4859-a38a-2763adb5392f

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
- [x] Manual QA for all new/changed functionality
 
