### PR TITLE
Add links to CVEs in software pages

### DIFF
--- a/frontend/pages/DashboardPage/cards/OperatingSystems/OperatingSystemsTableConfig.tsx
+++ b/frontend/pages/DashboardPage/cards/OperatingSystems/OperatingSystemsTableConfig.tsx
@@ -110,7 +110,13 @@ const generateDefaultTableHeaders = (
       if (platform !== "darwin" && platform !== "windows") {
         return <TextCell value="Not supported" greyed />;
       }
-      return <VulnerabilitiesCell vulnerabilities={cellProps.cell.value} />;
+      return (
+        <VulnerabilitiesCell
+          vulnerabilities={cellProps.cell.value}
+          teamId={teamId}
+          router={router}
+        />
+      );
     },
   },
   {

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwareTitleDetailsTable/SoftwareTitleDetailsTableConfig.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwareTitleDetailsTable/SoftwareTitleDetailsTableConfig.tsx
@@ -91,7 +91,11 @@ const generateSoftwareTitleDetailsTableConfig = ({
       // total number of vulnerabilities for the software title
       accessor: "vulnerabilities",
       Cell: (cellProps: IVulnCellProps): JSX.Element => (
-        <VulnerabilitiesCell vulnerabilities={cellProps.cell.value} />
+        <VulnerabilitiesCell
+          vulnerabilities={cellProps.cell.value}
+          teamId={teamId}
+          router={router}
+        />
         // TODO: tooltip
       ),
     },

--- a/frontend/pages/SoftwarePage/SoftwareTitles/SoftwareTable/SoftwareTitlesTableConfig.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitles/SoftwareTable/SoftwareTitlesTableConfig.tsx
@@ -122,7 +122,13 @@ const generateTableHeaders = (
         const vulnerabilities = getVulnerabilities(
           cellProps.row.original.versions ?? []
         );
-        return <VulnerabilitiesCell vulnerabilities={vulnerabilities} />;
+        return (
+          <VulnerabilitiesCell
+            vulnerabilities={vulnerabilities}
+            teamId={teamId}
+            router={router}
+          />
+        );
       },
     },
     {

--- a/frontend/pages/SoftwarePage/SoftwareTitles/SoftwareTable/SoftwareVersionsTableConfig.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitles/SoftwareTable/SoftwareVersionsTableConfig.tsx
@@ -95,7 +95,11 @@ const generateTableHeaders = (
       disableSortBy: true,
       accessor: "vulnerabilities",
       Cell: (cellProps: IVulnerabilitiesCellProps) => (
-        <VulnerabilitiesCell vulnerabilities={cellProps.cell.value} />
+        <VulnerabilitiesCell
+          vulnerabilities={cellProps.cell.value}
+          teamId={teamId}
+          router={router}
+        />
       ),
     },
     {

--- a/frontend/pages/SoftwarePage/components/VulnerabilitiesCell/VulnerabilitiesCell.tsx
+++ b/frontend/pages/SoftwarePage/components/VulnerabilitiesCell/VulnerabilitiesCell.tsx
@@ -1,16 +1,22 @@
 import React from "react";
 import { uniqueId } from "lodash";
 import ReactTooltip from "react-tooltip";
+import { InjectedRouter } from "react-router";
 
+import LinkCell from "components/TableContainer/DataTable/LinkCell";
 import TextCell from "components/TableContainer/DataTable/TextCell";
 import { ISoftwareVulnerability } from "interfaces/software";
+import { buildQueryStringFromParams } from "utilities/url";
+import PATHS from "router/paths";
 
 const NUM_VULNERABILITIES_IN_TOOLTIP = 3;
 
 const baseClass = "vulnerabilities-cell";
 
 const generateCell = (
-  vulnerabilities: ISoftwareVulnerability[] | string[] | null
+  vulnerabilities: ISoftwareVulnerability[] | string[] | null,
+  teamId?: number,
+  router?: InjectedRouter
 ) => {
   if (vulnerabilities === null) {
     return <TextCell value="---" greyed />;
@@ -26,6 +32,23 @@ const generateCell = (
       typeof vulnerabilities[0] === "string"
         ? vulnerabilities[0]
         : vulnerabilities[0].cve;
+    const teamQueryParam = buildQueryStringFromParams({ team_id: teamId });
+    const softwareVulnerabilitiesDetailsPath = `${PATHS.SOFTWARE_VULNERABILITY_DETAILS(
+      text
+    )}?${teamQueryParam}`;
+    const onClickCVE = (e: React.MouseEvent) => {
+      // Allows for button to be clickable in a clickable row
+      e.stopPropagation();
+
+      router?.push(softwareVulnerabilitiesDetailsPath);
+    };
+    return (
+      <LinkCell
+        path={softwareVulnerabilitiesDetailsPath}
+        value={text}
+        customOnClick={onClickCVE}
+      />
+    );
   } else {
     text = `${vulnerabilities.length} vulnerabilities`;
   }
@@ -82,15 +105,19 @@ const generateTooltip = (
 };
 interface IVulnerabilitiesCellProps {
   vulnerabilities: ISoftwareVulnerability[] | string[] | null;
+  teamId?: number;
+  router?: InjectedRouter;
 }
 
 const VulnerabilitiesCell = ({
   vulnerabilities,
+  teamId,
+  router,
 }: IVulnerabilitiesCellProps) => {
   const tooltipId = uniqueId();
 
   // only one vulnerability, no need for tooltip
-  const cell = generateCell(vulnerabilities);
+  const cell = generateCell(vulnerabilities, teamId, router);
   if (vulnerabilities === null || vulnerabilities.length <= 1) {
     return <>{cell}</>;
   }


### PR DESCRIPTION
#18428

I was trying to demo vulnerabilities in VSCode extensions and came across this UX thing:

https://www.loom.com/share/cf4e9fada67740528be56149762ef360

This is obviously not required for v4.49.0