### PR TITLE
Fleet UI: Submitting empty name results in inline error validation, not hitting API

### DIFF
--- a/frontend/pages/admin/UserManagementPage/components/UserForm/UserForm.tsx
+++ b/frontend/pages/admin/UserManagementPage/components/UserForm/UserForm.tsx
@@ -210,6 +210,15 @@ const UserForm = ({
   };
 
   const validate = (): boolean => {
+    if (!validatePresence(formData.name)) {
+      setErrors({
+        ...errors,
+        name: "Name field must be completed",
+      });
+
+      return false;
+    }
+
     if (!validatePresence(formData.email)) {
       setErrors({
         ...errors,


### PR DESCRIPTION
## Issue 
Cerra #18376 

## Description
- Client side validate name presence, not calling the API
- Returns inline error instead of API error flash message aligned with pattern of the rest of the form

## Screenshot
<img width="1463" alt="Screenshot 2024-04-18 at 3 28 08 PM" src="https://github.com/fleetdm/fleet/assets/71795832/7b919402-9915-4fd6-a550-c550488edfb5">

## More information
- Such a small bug fix = no changelog

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Manual QA for all new/changed functionality

