### PR TITLE
Website: add `psychologicalStage` to User model

### DIFF
--- a/website/api/controllers/save-questionnaire-progress.js
+++ b/website/api/controllers/save-questionnaire-progress.js
@@ -83,7 +83,7 @@ module.exports = {
     //  └─┐├┤  │   ├─┘└─┐└┬┘│  ├─┤│ ││  │ ││ ┬││  ├─┤│    └─┐ │ ├─┤│ ┬├┤
     //  └─┘└─┘ ┴   ┴  └─┘ ┴ └─┘┴ ┴└─┘┴─┘└─┘└─┘┴└─┘┴ ┴┴─┘  └─┘ ┴ ┴ ┴└─┘└─┘
     // This is how the questionnaire steps/options change a user's psychologicalStage value.
-    // 'start': Stage 1 » Stage 2
+    // 'start': No change
     // 'what-are-you-using-fleet-for': No change
     // 'have-you-ever-used-fleet':
     //  - yes-deployed: » Stage 6
@@ -108,9 +108,7 @@ module.exports = {
     let psychologicalStage = userRecord.psychologicalStage;
     // Get the value of the submitted formData, we do this so we only need to check one variable, instead of (formData.attribute === 'foo');
     let valueFromFormData = _.values(formData)[0];
-    if(currentStep === 'start'){
-      psychologicalStage = '2 - Aware';
-    } else if(currentStep === 'have-you-ever-used-fleet') {
+    if(currentStep === 'have-you-ever-used-fleet') {
       if(['yes-deployed', 'yes-recently-deployed'].includes(valueFromFormData)) {
         // If the user has Fleet deployed, set their stage to 6.
         psychologicalStage = '6 - Has team buy-in';
@@ -133,7 +131,7 @@ module.exports = {
         psychologicalStage = '5 - Personally confident';
       }
       // If the user selects let me think about it, their stage will not change.
-    }
+    }//ﬁ
 
     // Set the user's answer to the current step.
     questionnaireProgress[currentStep] = formData;

--- a/website/api/controllers/save-questionnaire-progress.js
+++ b/website/api/controllers/save-questionnaire-progress.js
@@ -88,14 +88,20 @@ module.exports = {
     // 'have-you-ever-used-fleet':
     //  - yes-deployed: » Stage 6
     //  - yes-recently-deployed: » Stage 6
-    //  - yes-deployed-local: » Stage 3
+    //  - yes-deployed-local: » Stage 3 (Tried Fleet but don't have a use case)
     //  - yes-deployed-long-time: No change
     //  - no: No change
     // 'how-many-hosts': No change
     // 'will-you-be-self-hosting': No change
-    // 'what-are-you-working-on-eo-security' » Stage 4
-    // 'what-does-your-team-manage-eo-it' » Stage 4
-    // 'what-does-your-team-manage-vm' » Stage 4
+    // 'what-are-you-working-on-eo-security'
+    //  - no-use-case-yet: » No change
+    //  - All other options » Stage 4
+    // 'what-does-your-team-manage-eo-it'
+    //  - no-use-case-yet: » No change
+    //  - All other options » Stage 4
+    // 'what-does-your-team-manage-vm'
+    //  - no-use-case-yet: » No change
+    //  - All other options » Stage 4
     // 'what-do-you-manage-mdm'
     //  - no-use-case-yet: » No change
     //  - All other options » Stage 4
@@ -116,17 +122,15 @@ module.exports = {
         // If they've tried Fleet locally, set their stage to 3.
         psychologicalStage = '3 - Intrigued';
       }
-    } else if(['what-are-you-working-on-eo-security','what-does-your-team-manage-eo-it','what-does-your-team-manage-vm'].includes(currentStep)){
-      psychologicalStage = '4 - Has use case';
-    } else if(currentStep === 'what-do-you-manage-mdm') {
-      if(valueFromFormData === 'no-use-case-yet'){
-        // If this user doe not have a use case for Fleet MDM yet, set their psyStage to 3
+    } else if(['what-are-you-working-on-eo-security','what-does-your-team-manage-eo-it','what-does-your-team-manage-vm','what-do-you-manage-mdm'].includes(currentStep)){
+      if(valueFromFormData === 'no-use-case-yet') {
+        // If this user doe not have a use case for Fleet yet, set their psyStage to 3
         psychologicalStage = '3 - Intrigued';
       } else {// Otherwise, they have a use case and will be set to stage 4.
         psychologicalStage = '4 - Has use case';
       }
     } else if(currentStep === 'what-did-you-think') {
-      // If the user is read yto deploy Fleet, set their psyStage to 5.
+      // If the user is ready to deploy Fleet in their work environemnt, then they're ready to get buy-in from their team, so set their psyStage to 5.
       if(valueFromFormData === 'deploy-fleet-in-environment') {
         psychologicalStage = '5 - Personally confident';
       }

--- a/website/api/models/User.js
+++ b/website/api/models/User.js
@@ -228,7 +228,7 @@ without necessarily having a billing card.`
 
     psychologicalStage: {
       type: 'string',
-      description: 'This user\'s psychological buying stage based on the answers to the get started qeustionnaire.',
+      description: 'This user\'s psychological stage based on the answers to the get started questionnaire.',
       isIn: [
         '1 - Unaware',
         '2 - Aware',

--- a/website/api/models/User.js
+++ b/website/api/models/User.js
@@ -237,7 +237,7 @@ without necessarily having a billing card.`
         '5 - Personally confident',
         '6 - Has team buy-in'
       ],
-      defaultsTo: '1 - Unaware'
+      defaultsTo: '2 - Aware'
     },
 
     //  ╔═╗╔╦╗╔╗ ╔═╗╔╦╗╔═╗

--- a/website/api/models/User.js
+++ b/website/api/models/User.js
@@ -224,7 +224,21 @@ without necessarily having a billing card.`
       type: 'json',
       description: 'This answers the user provided when they filled out the get started form.',
       defaultsTo: {},
-    }
+    },
+
+    psychologicalStage: {
+      type: 'string',
+      description: 'This user\'s psychological buying stage based on the answers to the get started qeustionnaire.',
+      isIn: [
+        '1 - Unaware',
+        '2 - Aware',
+        '3 - Intrigued',
+        '4 - Has use case',
+        '5 - Personally confident',
+        '6 - Has team buy-in'
+      ],
+      defaultsTo: '1 - Unaware'
+    },
 
     //  ╔═╗╔╦╗╔╗ ╔═╗╔╦╗╔═╗
     //  ║╣ ║║║╠╩╗║╣  ║║╚═╗

--- a/website/assets/js/pages/contact.page.js
+++ b/website/assets/js/pages/contact.page.js
@@ -39,8 +39,8 @@ parasails.registerPage('contact', {
     // Success state when form has been submitted
     cloudSuccess: false,
 
-    // For personalizing the message at the top of the contact form.
-    buyingStage: undefined,
+    // For personalizing the message at the top of the contact form for logged-in users.
+    psychologicalStage: undefined,
   },
 
   //  ╦  ╦╔═╗╔═╗╔═╗╦ ╦╔═╗╦  ╔═╗
@@ -64,23 +64,7 @@ parasails.registerPage('contact', {
         this.formDataToPrefillForLoggedInUsers.primaryBuyingSituation = this.me.primaryBuyingSituation;
       }
       this.formData = _.clone(this.formDataToPrefillForLoggedInUsers);
-      // If this user has submitted the /start questionnaire, determine their buying stage based on the answers they provided
-      if(!_.isEmpty(this.me.getStartedQuestionnaireAnswers)) {
-        let getStartedQuestionnaireAnswers = _.clone(this.me.getStartedQuestionnaireAnswers);
-        if(getStartedQuestionnaireAnswers['have-you-ever-used-fleet']) {
-          // If the user has Fleet deployed, then we'll assume they're stage five.
-          if(getStartedQuestionnaireAnswers['have-you-ever-used-fleet'].fleetUseStatus === 'yes-deployed' ||
-            getStartedQuestionnaireAnswers['have-you-ever-used-fleet'].fleetUseStatus === 'yes-recently-deployed') {
-            this.buyingStage = 'five';
-          }
-        }
-        if(getStartedQuestionnaireAnswers['what-did-you-think']){
-          // If this user has completed the "What did you think" step and wants to self-host Fleet, we'll assume theyre stage four.
-          if(getStartedQuestionnaireAnswers['what-did-you-think'].whatDidYouThink === 'deploy-fleet-in-environment'){
-            this.buyingStage = 'four';
-          }
-        }
-      }
+      this.psychologicalStage = this.me.psychologicalStage;
     }
   },
   mounted: async function() {

--- a/website/views/pages/contact.ejs
+++ b/website/views/pages/contact.ejs
@@ -3,9 +3,9 @@
     <div class="d-flex flex-lg-row flex-column justify-content-center">
     <div purpose="form-container" v-if="!cloudSuccess">
       <h2>Get in touch</h2>
-      <p v-if="!buyingStage">Schedule a personalized demo, or ask us anything. We’d love to chat.</p>
-      <p v-else-if="buyingStage === 'four'">Let us help you deploy and evaluate Fleet quickly for yourself. We’d love to save you some time.</p>
-      <p v-else-if="buyingStage === 'five'">Schedule a personalized demo for your team and get support or training.</p>
+      <p v-if="!psychologicalStage">Schedule a personalized demo, or ask us anything. We’d love to chat.</p>
+      <p v-else-if="psychologicalStage === '4 - Has use case'">Let us help you deploy and evaluate Fleet quickly for yourself. We’d love to save you some time.</p>
+      <p v-else-if="psychologicalStage === '5 - Personally confident'">Schedule a personalized demo for your team and get support or training.</p>
       <div purpose="contact-form-switch" class="d-flex flex-sm-row flex-column justify-content-center mx-auto">
         <div purpose="switch-option" :class="[formToDisplay === 'talk-to-us' ? 'selected' : '']" @click="clickSwitchForms('talk-to-us')">Talk to us</div>
         <div purpose="switch-option" :class="[formToDisplay === 'contact' ? 'selected' : '']" @click="clickSwitchForms('contact')">Send a message</div>

--- a/website/views/pages/contact.ejs
+++ b/website/views/pages/contact.ejs
@@ -3,9 +3,9 @@
     <div class="d-flex flex-lg-row flex-column justify-content-center">
     <div purpose="form-container" v-if="!cloudSuccess">
       <h2>Get in touch</h2>
-      <p v-if="!psychologicalStage">Schedule a personalized demo, or ask us anything. We’d love to chat.</p>
-      <p v-else-if="psychologicalStage === '4 - Has use case'">Let us help you deploy and evaluate Fleet quickly for yourself. We’d love to save you some time.</p>
+      <p v-if="psychologicalStage === '4 - Has use case'">Let us help you deploy and evaluate Fleet quickly for yourself. We’d love to save you some time.</p>
       <p v-else-if="psychologicalStage === '5 - Personally confident'">Schedule a personalized demo for your team and get support or training.</p>
+      <p v-else>Schedule a personalized demo, or ask us anything. We’d love to chat.</p>
       <div purpose="contact-form-switch" class="d-flex flex-sm-row flex-column justify-content-center mx-auto">
         <div purpose="switch-option" :class="[formToDisplay === 'talk-to-us' ? 'selected' : '']" @click="clickSwitchForms('talk-to-us')">Talk to us</div>
         <div purpose="switch-option" :class="[formToDisplay === 'contact' ? 'selected' : '']" @click="clickSwitchForms('contact')">Send a message</div>

--- a/website/views/pages/start.ejs
+++ b/website/views/pages/start.ejs
@@ -420,7 +420,7 @@
       <ajax-form :handle-submitting="handleSubmittingForm" class="contact" :form-errors.sync="formErrors" :form-data="formData['what-did-you-think']" :form-rules="endpointOpsSecurityWhatDidYouThinkFormRules" :syncing.sync="syncing" :cloud-error.sync="cloudError">
         <div class="form-group" :class="[formErrors.whatDidYouThink ? 'is-invalid' : '']">
           <div purpose="form-option" class="form-control" @click.stop.prevent="clickGoToContactPage()">
-            <input type="radio" v-model.trim="formData['what-did-you-think'].whatDidYouThink" value="Id like you to host Fleet for me">
+            <input type="radio" v-model.trim="formData['what-did-you-think'].whatDidYouThink" value="host-fleet-for-me">
             <span purpose="custom-radio"><span purpose="custom-radio-selected"></span></span>
             I’d like you to host Fleet for me
           </div>


### PR DESCRIPTION
Related to: https://github.com/fleetdm/confidential/issues/6155

Changes:
- Added a new attribute to the `User` model: `psychologicalStage`
- Updated `save-questionnaire-progress` to update a user's `psychologicalStage` based on their current answers/progress on the /start questionnaire
- Updated the personalization on the /contact page to use the `psychologicalStage` from the user model
- Updated the value of a unselectable form option on the /start page