### PR TITLE
Website: Move banned email domains to config variables

### DIFF
--- a/website/api/controllers/deliver-apple-csr.js
+++ b/website/api/controllers/deliver-apple-csr.js
@@ -57,23 +57,6 @@ module.exports = {
       throw new Error('Could not generate signed CSR: The vendor key passphrase (sails.config.custom.mdmVendorKeyPassphrase) is missing.');
     }
 
-    const bannedEmailDomainsForCSRSigning = [
-      'gmail.com','yahoo.com','hotmail.com','aol.com','hotmail.co.uk','hotmail.fr','hotmail.ca','msn.com',
-      'yahoo.fr','wanadoo.fr','orange.fr','comcast.net','yahoo.co.uk','yahoo.com.br','yahoo.co.in',
-      'live.com','rediffmail.com','free.fr','gmx.de','web.de','yandex.ru','ymail.com','libero.it',
-      'outlook.com','uol.com.br','bol.com.br','mail.ru','cox.net','hotmail.it','sbcglobal.net',
-      'sfr.fr','live.fr','verizon.net','live.co.uk','googlemail.com','yahoo.es','ig.com.br','live.nl',
-      'bigpond.com','terra.com.br','yahoo.it','neuf.fr','yahoo.de','alice.it','rocketmail.com',
-      'att.net','laposte.net','facebook.com','bellsouth.net','yahoo.in','hotmail.es','charter.net',
-      'yahoo.ca','yahoo.com.au','rambler.ru','hotmail.de','tiscali.it','shaw.ca','yahoo.co.jp',
-      'sky.com','earthlink.net','optonline.net','freenet.de','t-online.de','aliceadsl.fr','virgilio.it',
-      'home.nl','qq.com','telenet.be','me.com','yahoo.com.ar','tiscali.co.uk','yahoo.com.mx','voila.fr',
-      'gmx.net','mail.com','planet.nl','tin.it','live.it','ntlworld.com','arcor.de','yahoo.co.id',
-      'frontiernet.net','hetnet.nl','live.com.au','yahoo.com.sg','zonnet.nl','club-internet.fr',
-      'juno.com','optusnet.com.au','blueyonder.co.uk','bluewin.ch','skynet.be','sympatico.ca',
-      'windstream.net','mac.com','centurytel.net','chello.nl','live.ca','aim.com','bigpond.net.au',
-      'icloud.com','protonmail.com','zoho.com','proton.me','pm.me','protonmail.ch','tmmbt.net',
-    ];
 
     // Use sails.helpers.process.executeCommand to run the mdm-gen-cert binary.
     let generateCertificateCommand = await sails.helpers.process.executeCommand.with({
@@ -120,7 +103,7 @@ module.exports = {
     let emailDomain = generateCertificateResult.email.split('@')[1];
 
     // If the email domain is in the list of banned email domains list, we'll return the invalidEmailDomain response to the user.
-    if(_.includes(bannedEmailDomainsForCSRSigning, emailDomain.toLowerCase())){
+    if(_.includes(sails.config.custom.bannedEmailDomainsForCSRSigning, emailDomain.toLowerCase())){
       throw 'invalidEmailDomain';
     }
 

--- a/website/api/controllers/deliver-contact-form-message.js
+++ b/website/api/controllers/deliver-contact-form-message.js
@@ -60,13 +60,9 @@ module.exports = {
         `Name: ${firstName + ' ' + lastName}, Email: ${emailAddress}, Message: ${message ? message : 'No message.'}`
       );
     }
-    const bannedEmailDomainsForContactFormMessages = [
-      'gmail.com','yahoo.com', 'yahoo.co.uk','hotmail.com','hotmail.co.uk', 'hotmail.ca','outlook.com', 'icloud.com', 'proton.me','live.com','yandex.ru','ymail.com',
-    ];
 
     let emailDomain = emailAddress.split('@')[1];
-
-    if(_.includes(bannedEmailDomainsForContactFormMessages, emailDomain.toLowerCase())){
+    if(_.includes(sails.config.custom.bannedEmailDomainsForWebsiteSubmissions, emailDomain.toLowerCase())){
       throw 'invalidEmailDomain';
     }
 

--- a/website/api/controllers/deliver-talk-to-us-form-submission.js
+++ b/website/api/controllers/deliver-talk-to-us-form-submission.js
@@ -68,13 +68,9 @@ module.exports = {
 
   fn: async function ({emailAddress, firstName, lastName, organization, numberOfHosts, primaryBuyingSituation}) {
 
-    const bannedEmailDomainsForContactFormMessages = [
-      'gmail.com','yahoo.com', 'yahoo.co.uk','hotmail.com','hotmail.co.uk','hotmail.ca','outlook.com', 'icloud.com', 'proton.me','live.com','yandex.ru','ymail.com',
-    ];
 
     let emailDomain = emailAddress.split('@')[1];
-
-    if(_.includes(bannedEmailDomainsForContactFormMessages, emailDomain.toLowerCase())){
+    if(_.includes(sails.config.custom.bannedEmailDomainsForWebsiteSubmissions, emailDomain.toLowerCase())){
       throw 'invalidEmailDomain';
     }
     await sails.helpers.http.post.with({

--- a/website/api/controllers/entrance/signup.js
+++ b/website/api/controllers/entrance/signup.js
@@ -100,23 +100,9 @@ the account verification message.)`,
     if(await User.findOne({emailAddress: newEmailAddress})) {
       throw 'emailAlreadyInUse';
     }
-    // Check the user's email address and return an 'invalidEmailDomain' response if the domain is in the bannedEmailDomainsForSignup array.
+    // Check the user's email address and return an 'invalidEmailDomain' response if the domain is in the sails.config.custom.bannedEmailDomainsForWebsiteSubmissions array.
     let emailDomain = newEmailAddress.split('@')[1];
-    let bannedEmailDomainsForSignup = [
-      'gmail.com',
-      'yahoo.com',
-      'yahoo.co.uk',
-      'hotmail.com',
-      'hotmail.co.uk',
-      'hotmail.ca',
-      'outlook.com',
-      'icloud.com',
-      'proton.me',
-      'live.com',
-      'yandex.ru',
-      'ymail.com',
-    ];
-    if(_.includes(bannedEmailDomainsForSignup, emailDomain)){
+    if(_.includes(sails.config.custom.bannedEmailDomainsForWebsiteSubmissions, emailDomain)){
       throw 'invalidEmailDomain';
     }
 

--- a/website/config/custom.js
+++ b/website/config/custom.js
@@ -290,6 +290,52 @@ module.exports.custom = {
   // (both in Fleet's query console and on fleetdm.com)
   versionOfOsquerySchemaToUseWhenGeneratingDocumentation: '5.11.0',
 
+  // For the deliver-apple-csr webhook:
+  bannedEmailDomainsForCSRSigning:   [
+    'aim.com',         'alice.it',     'aliceadsl.fr',     'aol.com',
+    'arcor.de',        'att.net',      'bellsouth.net',    'bigpond.com',
+    'bigpond.net.au',  'bluewin.ch',   'blueyonder.co.uk', 'bol.com.br',
+    'centurytel.net',  'charter.net',  'chello.nl',        'club-internet.fr',
+    'comcast.net',     'cox.net',      'earthlink.net',    'facebook.com',
+    'free.fr',         'freenet.de',   'frontiernet.net',  'gmail.com',
+    'gmx.de',          'gmx.net',      'googlemail.com',   'hetnet.nl',
+    'home.nl',         'hotmail.ca',   'hotmail.co.uk',    'hotmail.com',
+    'hotmail.de',      'hotmail.es',   'hotmail.fr',       'hotmail.it',
+    'icloud.com',      'ig.com.br',    'juno.com',         'laposte.net',
+    'libero.it',       'live.ca',      'live.co.uk',       'live.com',
+    'live.com.au',     'live.fr',      'live.it',          'live.nl',
+    'mac.com',         'mail.com',     'mail.ru',          'me.com',
+    'msn.com',         'neuf.fr',      'ntlworld.com',     'optonline.net',
+    'optusnet.com.au', 'orange.fr',    'outlook.com',      'planet.nl',
+    'pm.me',           'proton.me',    'protonmail.ch',    'protonmail.com',
+    'qq.com',          'rambler.ru',   'rediffmail.com',   'rocketmail.com',
+    'sbcglobal.net',   'sfr.fr',       'shaw.ca',          'sky.com',
+    'skynet.be',       'sympatico.ca', 't-online.de',      'telenet.be',
+    'terra.com.br',    'tin.it',       'tiscali.co.uk',    'tiscali.it',
+    'tmmbt.net',       'uol.com.br',   'verizon.net',      'virgilio.it',
+    'voila.fr',        'wanadoo.fr',   'web.de',           'windstream.net',
+    'yahoo.ca',        'yahoo.co.id',  'yahoo.co.in',      'yahoo.co.jp',
+    'yahoo.co.uk',     'yahoo.com',    'yahoo.com.ar',     'yahoo.com.au',
+    'yahoo.com.br',    'yahoo.com.mx', 'yahoo.com.sg',     'yahoo.de',
+    'yahoo.es',        'yahoo.fr',     'yahoo.in',         'yahoo.it',
+    'yandex.ru',       'ymail.com',    'zoho.com',         'zonnet.nl'
+  ],
+
+  // For website signups & contact form submissions:
+  bannedEmailDomainsForWebsiteSubmissions: [
+    'gmail.com',
+    'yahoo.com',
+    'yahoo.co.uk',
+    'hotmail.com',
+    'hotmail.co.uk',
+    'hotmail.ca',
+    'outlook.com',
+    'icloud.com',
+    'proton.me',
+    'live.com',
+    'yandex.ru',
+    'ymail.com',
+  ],
 
   //  ███████╗██╗  ██╗██████╗ ██╗      ██████╗ ██████╗ ███████╗    ██████╗  █████╗ ████████╗ █████╗
   //  ██╔════╝╚██╗██╔╝██╔══██╗██║     ██╔═══██╗██╔══██╗██╔════╝    ██╔══██╗██╔══██╗╚══██╔══╝██╔══██╗

--- a/website/config/custom.js
+++ b/website/config/custom.js
@@ -290,6 +290,8 @@ module.exports.custom = {
   // (both in Fleet's query console and on fleetdm.com)
   versionOfOsquerySchemaToUseWhenGeneratingDocumentation: '5.11.0',
 
+
+  // FUTURE: Consolidate these two lists of email domains (And maybe find another word for banned)
   // For the deliver-apple-csr webhook:
   bannedEmailDomainsForCSRSigning:   [
     'aim.com',         'alice.it',     'aliceadsl.fr',     'aol.com',


### PR DESCRIPTION
Closes: https://github.com/fleetdm/confidential/issues/6158

Changes:
- Added two new config variables to website/config/custom:
   - `bannedEmailDomainsForCSRSigning` An array of email domains that are not allowed for CSR signing requests
   - `bannedEmailDomainsForWebsiteSubmissions` an array of email domains that are not allowed for website signups and contact form submissions.
- Updated the `deliver-apple-csr`, `deliver-talk-to-us-form-submission`, `deliver-contact-form-message`, and `signup` actions to use the new config variables. 