### PR TITLE
When updating a policy's 'platform' field, the aggregated policy stats are now cleared.

### DIFF
--- a/changes/18157-update-platform-policy-stats
+++ b/changes/18157-update-platform-policy-stats
@@ -1,0 +1,1 @@
+When updating a policy's 'platform' field, the aggregated policy stats are now cleared.

--- a/server/datastore/mysql/policies_test.go
+++ b/server/datastore/mysql/policies_test.go
@@ -40,6 +40,7 @@ func TestPolicies(t *testing.T) {
 		{"PoliciesByID", testPoliciesByID},
 		{"TeamPolicyTransfer", testTeamPolicyTransfer},
 		{"ApplyPolicySpec", testApplyPolicySpec},
+		{"ApplyPolicySpecWithQueryPlatformChanges", testApplyPolicySpecWithQueryPlatformChanges},
 		{"Save", testPoliciesSave},
 		{"DelUser", testPoliciesDelUser},
 		{"FlippingPoliciesForHost", testFlippingPoliciesForHost},
@@ -1398,6 +1399,298 @@ func testApplyPolicySpec(t *testing.T, ds *Datastore) {
 					Platform:    "",
 				},
 			}))
+}
+
+func testApplyPolicySpecWithQueryPlatformChanges(t *testing.T, ds *Datastore) {
+	ctx := context.Background()
+	unicode, _ := strconv.Unquote(`"\uAC00"`)         // 가
+	unicodeEq, _ := strconv.Unquote(`"\u1100\u1161"`) // ᄀ + ᅡ
+
+	user1 := test.NewUser(t, ds, "User1", "user1@example.com", true)
+	team1, err := ds.NewTeam(ctx, &fleet.Team{Name: "team1" + unicode})
+	require.NoError(t, err)
+
+	globalNames := []string{"global query1" + unicode, "global query2" + unicode, "global query3" + unicode}
+	teamNames := []string{"team query1", "team query2", "team query3"}
+	require.NoError(
+		t, ds.ApplyPolicySpecs(
+			ctx, user1.ID, []*fleet.PolicySpec{
+				{
+					Name:     globalNames[0],
+					Query:    "select 1;",
+					Team:     "",
+					Platform: "",
+				},
+				{
+					Name:     globalNames[1],
+					Query:    "select 2;",
+					Team:     "",
+					Platform: "darwin",
+				},
+				{
+					Name:     globalNames[2],
+					Query:    "select 3;",
+					Team:     "",
+					Platform: "darwin,linux",
+				},
+				{
+					Name:     teamNames[0],
+					Query:    "select 1;",
+					Team:     "team1" + unicode,
+					Platform: "",
+				},
+				{
+					Name:     teamNames[1],
+					Query:    "select 2;",
+					Team:     "team1" + unicode,
+					Platform: "darwin",
+				},
+				{
+					Name:     teamNames[2],
+					Query:    "select 3;",
+					Team:     "team1" + unicodeEq,
+					Platform: "darwin,linux",
+				},
+			},
+		),
+	)
+
+	// create hosts with different platforms, for that team
+	const hostWin, hostMac, hostDeb, hostLin = 0, 1, 2, 3
+	platforms := []string{"windows", "darwin", "debian", "linux"}
+	teamHosts := make([]*fleet.Host, len(platforms))
+	for i, pl := range platforms {
+		id := fmt.Sprintf("%s-%d", strings.ReplaceAll(t.Name(), "/", "_"), i)
+		h, err := ds.NewHost(
+			ctx, &fleet.Host{
+				OsqueryHostID:   &id,
+				DetailUpdatedAt: time.Now(),
+				LabelUpdatedAt:  time.Now(),
+				PolicyUpdatedAt: time.Now(),
+				SeenTime:        time.Now(),
+				NodeKey:         &id,
+				UUID:            id,
+				Hostname:        id,
+				Platform:        pl,
+				TeamID:          ptr.Uint(team1.ID),
+			},
+		)
+		require.NoError(t, err)
+		teamHosts[i] = h
+	}
+
+	// create hosts with different platforms, without team
+	globalHosts := make([]*fleet.Host, len(platforms))
+	for i, pl := range platforms {
+		id := fmt.Sprintf("g%s-%d", strings.ReplaceAll(t.Name(), "/", "_"), i)
+		h, err := ds.NewHost(
+			ctx, &fleet.Host{
+				OsqueryHostID:   &id,
+				DetailUpdatedAt: time.Now(),
+				LabelUpdatedAt:  time.Now(),
+				PolicyUpdatedAt: time.Now(),
+				SeenTime:        time.Now(),
+				NodeKey:         &id,
+				UUID:            id,
+				Hostname:        id,
+				Platform:        pl,
+			},
+		)
+		require.NoError(t, err)
+		globalHosts[i] = h
+	}
+
+	// load the global policies
+	gPolicies, err := ds.ListGlobalPolicies(ctx, fleet.ListOptions{})
+	require.NoError(t, err)
+	require.Len(t, gPolicies, 3)
+	// load the team policies
+	tPolicies, _, err := ds.ListTeamPolicies(ctx, team1.ID, fleet.ListOptions{}, fleet.ListOptions{})
+	require.NoError(t, err)
+	require.Len(t, tPolicies, 3)
+
+	// index the policies by name for easier access in the rest of the test
+	polsByName := make(map[string]*fleet.Policy, len(gPolicies)+len(tPolicies))
+	globalPolsByName := make(map[string]*fleet.Policy, len(gPolicies))
+	for _, pol := range tPolicies {
+		polsByName[pol.Name] = pol
+	}
+	for _, pol := range gPolicies {
+		globalPolsByName[pol.Name] = pol
+		polsByName[pol.Name] = pol
+	}
+
+	// record some results for each policy
+	// Note: we are adding results to hosts that shouldn't have results, based on their platform.
+	for _, h := range teamHosts {
+		res := make(map[uint]*bool, len(polsByName))
+		for _, pol := range polsByName {
+			res[pol.ID] = ptr.Bool(false)
+		}
+		err = ds.RecordPolicyQueryExecutions(ctx, h, res, time.Now(), false)
+		require.NoError(t, err)
+	}
+	for _, h := range globalHosts {
+		res := make(map[uint]*bool, len(globalPolsByName))
+		for _, pol := range globalPolsByName {
+			res[pol.ID] = ptr.Bool(false)
+		}
+		err = ds.RecordPolicyQueryExecutions(ctx, h, res, time.Now(), false)
+		require.NoError(t, err)
+	}
+	err = ds.UpdateHostPolicyCounts(ctx)
+	require.NoError(t, err)
+
+	// Update host failure counts and ensure they are correct
+	teamHosts, err = ds.UpdatePolicyFailureCountsForHosts(ctx, teamHosts)
+	require.NoError(t, err)
+	assert.Equal(t, 6, teamHosts[hostWin].FailingPoliciesCount)
+	assert.Equal(t, 6, teamHosts[hostMac].FailingPoliciesCount)
+	assert.Equal(t, 6, teamHosts[hostDeb].FailingPoliciesCount)
+	assert.Equal(t, 6, teamHosts[hostLin].FailingPoliciesCount)
+	globalHosts, err = ds.UpdatePolicyFailureCountsForHosts(ctx, globalHosts)
+	require.NoError(t, err)
+	assert.Equal(t, 3, globalHosts[hostWin].FailingPoliciesCount)
+	assert.Equal(t, 3, globalHosts[hostMac].FailingPoliciesCount)
+	assert.Equal(t, 3, globalHosts[hostDeb].FailingPoliciesCount)
+	assert.Equal(t, 3, globalHosts[hostLin].FailingPoliciesCount)
+
+	// Ensure policy passing and failing counts are correct
+	gPolicies, err = ds.ListGlobalPolicies(ctx, fleet.ListOptions{})
+	require.NoError(t, err)
+	require.Len(t, gPolicies, 3)
+	tPolicies, _, err = ds.ListTeamPolicies(ctx, team1.ID, fleet.ListOptions{}, fleet.ListOptions{})
+	require.NoError(t, err)
+	require.Len(t, tPolicies, 3)
+
+	for _, pol := range gPolicies {
+		polsByName[pol.Name] = pol
+	}
+	for _, pol := range tPolicies {
+		polsByName[pol.Name] = pol
+	}
+	assert.Equal(t, uint(8), polsByName[globalNames[0]].FailingHostCount)
+	assert.Equal(t, uint(8), polsByName[globalNames[1]].FailingHostCount)
+	assert.Equal(t, uint(8), polsByName[globalNames[2]].FailingHostCount)
+	assert.Equal(t, uint(4), polsByName[teamNames[0]].FailingHostCount)
+	assert.Equal(t, uint(4), polsByName[teamNames[1]].FailingHostCount)
+	assert.Equal(t, uint(4), polsByName[teamNames[2]].FailingHostCount)
+
+	// Update policies
+	require.NoError(
+		t, ds.ApplyPolicySpecs(
+			ctx, user1.ID, []*fleet.PolicySpec{
+				{
+					Name:        globalNames[0],
+					Query:       "select 1;",
+					Team:        "",
+					Platform:    "",
+					Description: "updated", // update description
+				},
+				{
+					Name:     globalNames[1],
+					Query:    "select 2 updated;", // update query
+					Team:     "",
+					Platform: "darwin",
+				},
+				{
+					Name:     globalNames[2],
+					Query:    "select 3;",
+					Team:     "",
+					Platform: "darwin", // update platform
+				},
+				{
+					Name:     "new global query",
+					Query:    "select 4;",
+					Team:     "",
+					Platform: "",
+				},
+				{
+					Name:     teamNames[0],
+					Query:    "select 1;",
+					Team:     "team1" + unicode,
+					Platform: "linux", // update platform
+				},
+				{
+					Name:                  teamNames[1],
+					Query:                 "select 2;",
+					Team:                  "team1" + unicode,
+					Platform:              "darwin",
+					CalendarEventsEnabled: true, // update calendar events
+				},
+				{
+					Name:     teamNames[2],
+					Query:    "select 3 updated;", // update query
+					Team:     "team1" + unicodeEq,
+					Platform: "darwin,linux",
+				},
+				{
+					Name:     "new team query",
+					Query:    "select 4;",
+					Team:     "team1" + unicode,
+					Platform: "",
+				},
+			},
+		),
+	)
+
+	// Update host failure counts and ensure they are correct
+	teamHosts, err = ds.UpdatePolicyFailureCountsForHosts(ctx, teamHosts)
+	require.NoError(t, err)
+	assert.Equal(t, 1, teamHosts[hostWin].FailingPoliciesCount) // kept result from globalNames[0]
+	assert.Equal(t, 3, teamHosts[hostMac].FailingPoliciesCount)
+	assert.Equal(t, 2, teamHosts[hostDeb].FailingPoliciesCount)
+	assert.Equal(t, 2, teamHosts[hostLin].FailingPoliciesCount)
+	globalHosts, err = ds.UpdatePolicyFailureCountsForHosts(ctx, globalHosts)
+	require.NoError(t, err)
+	assert.Equal(t, 1, globalHosts[hostWin].FailingPoliciesCount)
+	assert.Equal(t, 2, globalHosts[hostMac].FailingPoliciesCount)
+	assert.Equal(t, 1, globalHosts[hostDeb].FailingPoliciesCount)
+	assert.Equal(t, 1, globalHosts[hostLin].FailingPoliciesCount)
+
+	// Ensure policy passing and failing counts are correct
+	gPolicies, err = ds.ListGlobalPolicies(ctx, fleet.ListOptions{})
+	require.NoError(t, err)
+	require.Len(t, gPolicies, 4)
+	tPolicies, _, err = ds.ListTeamPolicies(ctx, team1.ID, fleet.ListOptions{}, fleet.ListOptions{})
+	require.NoError(t, err)
+	require.Len(t, tPolicies, 4)
+
+	for _, pol := range gPolicies {
+		polsByName[pol.Name] = pol
+	}
+	for _, pol := range tPolicies {
+		polsByName[pol.Name] = pol
+	}
+	assert.Equal(t, uint(8), polsByName[globalNames[0]].FailingHostCount)
+	assert.Equal(t, uint(0), polsByName[globalNames[1]].FailingHostCount) // updated query
+	assert.Equal(t, uint(0), polsByName[globalNames[2]].FailingHostCount) // updated platform
+	assert.Equal(t, uint(0), polsByName[teamNames[0]].FailingHostCount)   // updated platform
+	assert.Equal(t, uint(4), polsByName[teamNames[1]].FailingHostCount)
+	assert.Equal(t, uint(0), polsByName[teamNames[2]].FailingHostCount) // updated query
+
+	err = ds.UpdateHostPolicyCounts(ctx)
+	require.NoError(t, err)
+	gPolicies, err = ds.ListGlobalPolicies(ctx, fleet.ListOptions{})
+	require.NoError(t, err)
+	require.Len(t, gPolicies, 4)
+	tPolicies, _, err = ds.ListTeamPolicies(ctx, team1.ID, fleet.ListOptions{}, fleet.ListOptions{})
+	require.NoError(t, err)
+	require.Len(t, tPolicies, 4)
+
+	for _, pol := range gPolicies {
+		polsByName[pol.Name] = pol
+	}
+	for _, pol := range tPolicies {
+		polsByName[pol.Name] = pol
+	}
+	assert.Equal(t, uint(8), polsByName[globalNames[0]].FailingHostCount) // platform is "" -- no change
+	assert.Equal(t, uint(0), polsByName[globalNames[1]].FailingHostCount) // updated query
+	assert.Equal(t, uint(2), polsByName[globalNames[2]].FailingHostCount) // updated platform
+	assert.Equal(t, uint(2), polsByName[teamNames[0]].FailingHostCount)   // updated platform
+	assert.Equal(t, uint(1), polsByName[teamNames[1]].FailingHostCount)   // platform is "darwin" -- no change
+	assert.Equal(t, uint(0), polsByName[teamNames[2]].FailingHostCount)   // updated query
+
 }
 
 func testPoliciesSave(t *testing.T, ds *Datastore) {

--- a/server/fleet/datastore.go
+++ b/server/fleet/datastore.go
@@ -602,7 +602,7 @@ type Datastore interface {
 	// SavePolicy updates some fields of the given policy on the datastore.
 	//
 	// It is also used to update team policies.
-	SavePolicy(ctx context.Context, p *Policy, shouldRemoveAllPolicyMemberships bool) error
+	SavePolicy(ctx context.Context, p *Policy, shouldRemoveAllPolicyMemberships bool, removePolicyStats bool) error
 
 	ListGlobalPolicies(ctx context.Context, opts ListOptions) ([]*Policy, error)
 	PoliciesByID(ctx context.Context, ids []uint) (map[uint]*Policy, error)

--- a/server/mock/datastore_mock.go
+++ b/server/mock/datastore_mock.go
@@ -435,7 +435,7 @@ type NewGlobalPolicyFunc func(ctx context.Context, authorID *uint, args fleet.Po
 
 type PolicyFunc func(ctx context.Context, id uint) (*fleet.Policy, error)
 
-type SavePolicyFunc func(ctx context.Context, p *fleet.Policy, shouldRemoveAllPolicyMemberships bool) error
+type SavePolicyFunc func(ctx context.Context, p *fleet.Policy, shouldRemoveAllPolicyMemberships bool, removePolicyStats bool) error
 
 type ListGlobalPoliciesFunc func(ctx context.Context, opts fleet.ListOptions) ([]*fleet.Policy, error)
 
@@ -3724,11 +3724,11 @@ func (s *DataStore) Policy(ctx context.Context, id uint) (*fleet.Policy, error) 
 	return s.PolicyFunc(ctx, id)
 }
 
-func (s *DataStore) SavePolicy(ctx context.Context, p *fleet.Policy, shouldRemoveAllPolicyMemberships bool) error {
+func (s *DataStore) SavePolicy(ctx context.Context, p *fleet.Policy, shouldRemoveAllPolicyMemberships bool, removePolicyStats bool) error {
 	s.mu.Lock()
 	s.SavePolicyFuncInvoked = true
 	s.mu.Unlock()
-	return s.SavePolicyFunc(ctx, p, shouldRemoveAllPolicyMemberships)
+	return s.SavePolicyFunc(ctx, p, shouldRemoveAllPolicyMemberships, removePolicyStats)
 }
 
 func (s *DataStore) ListGlobalPolicies(ctx context.Context, opts fleet.ListOptions) ([]*fleet.Policy, error) {

--- a/server/service/global_policies_test.go
+++ b/server/service/global_policies_test.go
@@ -68,7 +68,7 @@ func TestGlobalPoliciesAuth(t *testing.T) {
 	ds.NewActivityFunc = func(ctx context.Context, user *fleet.User, activity fleet.ActivityDetails) error {
 		return nil
 	}
-	ds.SavePolicyFunc = func(ctx context.Context, p *fleet.Policy, shouldDeleteAll bool) error {
+	ds.SavePolicyFunc = func(ctx context.Context, p *fleet.Policy, shouldDeleteAll bool, removePolicyStats bool) error {
 		return nil
 	}
 	ds.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {

--- a/server/service/team_policies.go
+++ b/server/service/team_policies.go
@@ -368,7 +368,7 @@ func (svc *Service) modifyPolicy(ctx context.Context, teamID *uint, id uint, p f
 		})
 	}
 
-	var shouldRemoveAll bool
+	var removeAllMemberships bool
 	var removeStats bool
 	if p.Name != nil {
 		policy.Name = *p.Name
@@ -378,7 +378,7 @@ func (svc *Service) modifyPolicy(ctx context.Context, teamID *uint, id uint, p f
 	}
 	if p.Query != nil {
 		if policy.Query != *p.Query {
-			shouldRemoveAll = true
+			removeAllMemberships = true
 			removeStats = true
 		}
 		policy.Query = *p.Query
@@ -404,7 +404,7 @@ func (svc *Service) modifyPolicy(ctx context.Context, teamID *uint, id uint, p f
 	}
 	logging.WithExtras(ctx, "name", policy.Name, "sql", policy.Query)
 
-	err = svc.ds.SavePolicy(ctx, policy, shouldRemoveAll, removeStats)
+	err = svc.ds.SavePolicy(ctx, policy, removeAllMemberships, removeStats)
 	if err != nil {
 		return nil, ctxerr.Wrap(ctx, err, "saving policy")
 	}

--- a/server/service/team_policies.go
+++ b/server/service/team_policies.go
@@ -369,6 +369,7 @@ func (svc *Service) modifyPolicy(ctx context.Context, teamID *uint, id uint, p f
 	}
 
 	var shouldRemoveAll bool
+	var removeStats bool
 	if p.Name != nil {
 		policy.Name = *p.Name
 	}
@@ -378,8 +379,7 @@ func (svc *Service) modifyPolicy(ctx context.Context, teamID *uint, id uint, p f
 	if p.Query != nil {
 		if policy.Query != *p.Query {
 			shouldRemoveAll = true
-			policy.FailingHostCount = 0
-			policy.PassingHostCount = 0
+			removeStats = true
 		}
 		policy.Query = *p.Query
 	}
@@ -387,6 +387,9 @@ func (svc *Service) modifyPolicy(ctx context.Context, teamID *uint, id uint, p f
 		policy.Resolution = p.Resolution
 	}
 	if p.Platform != nil {
+		if policy.Platform != *p.Platform {
+			removeStats = true
+		}
 		policy.Platform = *p.Platform
 	}
 	if p.Critical != nil {
@@ -395,9 +398,13 @@ func (svc *Service) modifyPolicy(ctx context.Context, teamID *uint, id uint, p f
 	if p.CalendarEventsEnabled != nil {
 		policy.CalendarEventsEnabled = *p.CalendarEventsEnabled
 	}
+	if removeStats {
+		policy.FailingHostCount = 0
+		policy.PassingHostCount = 0
+	}
 	logging.WithExtras(ctx, "name", policy.Name, "sql", policy.Query)
 
-	err = svc.ds.SavePolicy(ctx, policy, shouldRemoveAll)
+	err = svc.ds.SavePolicy(ctx, policy, shouldRemoveAll, removeStats)
 	if err != nil {
 		return nil, ctxerr.Wrap(ctx, err, "saving policy")
 	}

--- a/server/service/team_policies_test.go
+++ b/server/service/team_policies_test.go
@@ -44,7 +44,7 @@ func TestTeamPoliciesAuth(t *testing.T) {
 		}
 		return nil, nil
 	}
-	ds.SavePolicyFunc = func(ctx context.Context, p *fleet.Policy, shouldDeleteAll bool) error {
+	ds.SavePolicyFunc = func(ctx context.Context, p *fleet.Policy, shouldDeleteAll bool, removePolicyStats bool) error {
 		return nil
 	}
 	ds.DeleteTeamPoliciesFunc = func(ctx context.Context, teamID uint, ids []uint) ([]uint, error) {


### PR DESCRIPTION
#18157
When updating a policy's 'platform' field, the aggregated policy stats are now cleared.

# Checklist for submitter
- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [x] Added/updated tests
- [x] Manual QA for all new/changed functionality
