### PR TITLE
Website: redirect admins to the license key generator

### DIFF
--- a/website/api/controllers/view-start.js
+++ b/website/api/controllers/view-start.js
@@ -25,6 +25,9 @@ module.exports = {
     if (userHasExistingSubscription) {
       throw {redirect: '/customers/dashboard'};
     }
+    if(this.req.me.isSuperAdmin){
+      throw {redirect: '/admin/generate-license'};
+    }
     if(this.req.me.lastSubmittedGetStartedQuestionnaireStep && !_.isEmpty(this.req.me.getStartedQuestionnaireAnswers)){
       let currentStep = this.req.me.lastSubmittedGetStartedQuestionnaireStep;
       let previouslyAnsweredQuestions = this.req.me.getStartedQuestionnaireAnswers;


### PR DESCRIPTION
Closes: https://github.com/fleetdm/confidential/issues/6151

Changes:
- Updated `view-start.js` to redirect website admins to the admin license key generator page.