### PR TITLE
Website: Update error handling in `create-vanta-authorization-request`

### DIFF
--- a/website/api/controllers/create-vanta-authorization-request.js
+++ b/website/api/controllers/create-vanta-authorization-request.js
@@ -43,6 +43,10 @@ module.exports = {
       description: 'The Fleet instance provided is using a Free license.',
       statusCode: 400,
     },
+    invalidResponseFromFleetInstance: {
+      description: 'The response body from the Fleet API was invalid.',
+      statusCode: 400,
+    },
     nonApiOnlyUser: {
       description: 'The provided API token for this Fleet instance is not associated with an api-only user.',
       statusCode: 400,
@@ -90,6 +94,11 @@ module.exports = {
       return new Error(`When sending a request to a Fleet instance's /me endpoint to verify that a token meets the requirements for a Vanta connection, an error occurred: ${error}`);
     });
 
+    // Throw an error if the response from the Fleet instance's /me API endpoint does not contain a user.
+    if(!responseFromFleetInstance.user){
+      throw 'invalidResponseFromFleetInstance';
+    }
+
     // Throw an error if the provided API token is not an API-only user.
     if(!responseFromFleetInstance.user.api_only) {
       throw 'nonApiOnlyUser';
@@ -108,6 +117,12 @@ module.exports = {
     .intercept((error)=>{
       return new Error(`When sending a request to a Fleet instance's /config API endpoint for a Vanta connection, an error occurred: ${error}`);
     });
+
+
+    // Throw an error if the response from the Fleet instance's /config API endpoint does not contain a license.
+    if(!configResponse.license){
+      throw 'invalidResponseFromFleetInstance';
+    }
 
     // If the user's Fleet instance has a free license, we'll throw the 'invalidLicense' exit and let the user know that this is only available for Fleet Premium subscribers.
     if(configResponse.license.tier === 'free') {

--- a/website/views/pages/connect-vanta.ejs
+++ b/website/views/pages/connect-vanta.ejs
@@ -49,6 +49,9 @@
       <cloud-error purpose="cloud-error" v-else-if="cloudError === 'invalidLicense'">
         This integration is only available for Fleet Premium customers.
       </cloud-error>
+      <cloud-error purpose="cloud-error" v-else-if="cloudError === 'invalidResponseFromFleetInstance'">
+        An error occured when verifying the configuration of the Fleet instance. Please check to make sure that the provided URL is correct and try resubmitting.
+      </cloud-error>
       <cloud-error purpose="cloud-error" v-else-if="cloudError"></cloud-error>
       <ajax-button style="height: 44px;" purpose="submit-button" spinner="true" type="submit" :syncing="syncing" class="btn btn-block btn-lg btn-info" v-if="!cloudError">Connect</ajax-button>
       <ajax-button style="height: 44px;" purpose="submit-button" type="button" :syncing="syncing" class="btn btn-block btn-lg btn-info" v-if="cloudError" @click="clickClearErrors()">Try again</ajax-button>


### PR DESCRIPTION
Closes: https://github.com/fleetdm/fleet/issues/18448

Changes:
- Updated `create-vanta-authorization-request` to return an `invalidResponseFromFleetInstance ` response when a response from a Fleet instance does not contain the expected values (A `user` object for a request to the `/me` endpoint and a `license` object for the request to the `/config` endpoint.)
- Updated the /connect-vanta page to show an error message to users asking them to verify the URL of their Fleet instance if the API response is invalid.