### PR TITLE
Website: Update request to Zapier in save-questionnaire-progress.js

### DIFF
--- a/website/api/controllers/save-questionnaire-progress.js
+++ b/website/api/controllers/save-questionnaire-progress.js
@@ -157,6 +157,7 @@ module.exports = {
         primaryBuyingSituation: primaryBuyingSituation,
         organization: this.req.me.organization,
         psychologicalStage,
+        currentStep,
         webhookSecret: sails.config.custom.zapierSandboxWebhookSecret,
       }
     })


### PR DESCRIPTION
Related to https://github.com/fleetdm/confidential/issues/6216

Changes:
- Updated the request to Zapier in save-questionnaire-progress to send the name of the step the user submitted.