### PR TITLE
Website: update "Get your license" link & login/register pages.

### DIFF
--- a/website/api/controllers/customers/view-new-license.js
+++ b/website/api/controllers/customers/view-new-license.js
@@ -25,7 +25,7 @@ module.exports = {
 
     // if the user isn't logged in, we'll redirect them to the register page.
     if (!this.req.me) {
-      throw {redirect: '/customers/register'};
+      throw {redirect: '/register?purchaseLicense'};
     }
     // If the user is a super admin, we'll redirect them to the generate-license page.
     if(this.req.me.isSuperAdmin) {

--- a/website/api/controllers/entrance/view-login.js
+++ b/website/api/controllers/entrance/view-login.js
@@ -6,6 +6,14 @@ module.exports = {
 
   description: 'Display "Login" page.',
 
+  inputs: {
+    purchaseLicense: {
+      type: 'boolean',
+      description: 'If this query string is provided, this user will be taken directly to the /new-license page after they login.',
+      extendedDescription: 'This value is only present when a user navigates to this page from the /register page if they were redirected to that page from the /new-license page.',
+      defaultsTo: false,
+    }
+  },
 
   exits: {
 
@@ -21,7 +29,7 @@ module.exports = {
   },
 
 
-  fn: async function () {
+  fn: async function ({purchaseLicense}) {
 
     if (this.req.me) {
       if(this.req.me.isSuperAdmin){
@@ -31,7 +39,9 @@ module.exports = {
       }
     }
 
-    return {};
+    return {
+      redirectToLicenseDispenser: purchaseLicense,
+    };
 
   }
 

--- a/website/api/controllers/entrance/view-signup.js
+++ b/website/api/controllers/entrance/view-signup.js
@@ -6,6 +6,14 @@ module.exports = {
 
   description: 'Display "Signup" page.',
 
+  inputs: {
+    purchaseLicense: {
+      type: 'boolean',
+      description: 'If this query string is provided, this user will be taken directly to the /new-license page after they signup.',
+      extendedDescription: 'This value will only be present if the user is redirected to this page from the customers/view-new-license',
+      defaultsTo: false,
+    }
+  },
 
   exits: {
 
@@ -21,13 +29,15 @@ module.exports = {
   },
 
 
-  fn: async function () {
+  fn: async function ({purchaseLicense}) {
 
     if (this.req.me) {
       throw {redirect: '/start'};
     }
 
-    return {};
+    return {
+      redirectToLicenseDispenser: purchaseLicense,
+    };
 
   }
 

--- a/website/assets/js/pages/entrance/login.page.js
+++ b/website/assets/js/pages/entrance/login.page.js
@@ -25,6 +25,9 @@ parasails.registerPage('login', {
     // Server error state for the form
     cloudError: '',
     showCustomerLogin: true,
+    // For redirecting users coming from the "Get your license" link to the license dispenser.
+    registerSlug: '/register',
+    pageToRedirectToAfterLogin: '/start',
   },
 
   //  ╦  ╦╔═╗╔═╗╔═╗╦ ╦╔═╗╦  ╔═╗
@@ -33,6 +36,11 @@ parasails.registerPage('login', {
   beforeMount: function() {
     if(window.location.search === '?admin') {
       this.showCustomerLogin = false;
+    }
+    // If we're redirecting this user to the license dispenser after they log in, modify the link to the /register page and the pageToRedirectToAfterLogin.
+    if(this.redirectToLicenseDispenser){
+      this.loginSlug = '/register?purchaseLicense';
+      this.pageToRedirectToAfterLogin = '/new-license';
     }
   },
   mounted: async function() {
@@ -49,7 +57,7 @@ parasails.registerPage('login', {
       // > (Note that we re-enable the syncing state here.  This is on purpose--
       // > to make sure the spinner stays there until the page navigation finishes.)
       this.syncing = true;
-      window.location = '/start';
+      window.location = this.pageToRedirectToAfterLogin;
     },
 
   }

--- a/website/assets/js/pages/entrance/signup.page.js
+++ b/website/assets/js/pages/entrance/signup.page.js
@@ -24,13 +24,20 @@ parasails.registerPage('signup', {
     cloudError: '',
     // For displaying the full signup form.
     showFullForm: false,
+    // For redirecting users coming from the "Get your license" link to the license dispenser.
+    loginSlug: '/login',
+    pageToRedirectToAfterRegistration: '/start',
   },
 
   //  ╦  ╦╔═╗╔═╗╔═╗╦ ╦╔═╗╦  ╔═╗
   //  ║  ║╠╣ ║╣ ║  ╚╦╝║  ║  ║╣
   //  ╩═╝╩╚  ╚═╝╚═╝ ╩ ╚═╝╩═╝╚═╝
   beforeMount: function() {
-    //…
+    // If we're redirecting this user to the license dispenser after they sign up, modify the link to the login page and the pageToRedirectToAfterRegistration
+    if(this.redirectToLicenseDispenser){
+      this.loginSlug = '/login?purchaseLicense';
+      this.pageToRedirectToAfterRegistration = '/new-license';
+    }
   },
   mounted: async function() {
     //…
@@ -60,7 +67,7 @@ parasails.registerPage('signup', {
       // > (Note that we re-enable the syncing state here.  This is on purpose--
       // > to make sure the spinner stays there until the page navigation finishes.)
       this.syncing = true;
-      window.location = '/start';
+      window.location = this.pageToRedirectToAfterRegistration;// « / start if the user came here from the start now button, or customers/new-license if the user came here from the "Get your license" link.
     }
 
 

--- a/website/config/policies.js
+++ b/website/config/policies.js
@@ -53,4 +53,5 @@ module.exports.policies = {
   'try-fleet/view-explore-data': true,
   'try-fleet/view-query-report': true,
   'deliver-talk-to-us-form-submission': true,
+  'customers/view-new-license': true,
 };

--- a/website/views/layouts/layout.ejs
+++ b/website/views/layouts/layout.ejs
@@ -178,7 +178,7 @@
                       <a purpose="mobile-dropdown-link" href="/support">Chat</a>
                       <a purpose="mobile-dropdown-link" href="/docs/deploy/introduction">Hosting</a>
                       <a purpose="mobile-dropdown-link" href="/releases">Release notes</a>
-                      <a purpose="mobile-dropdown-link" href="/customers/register">Get your license</a>
+                      <a purpose="mobile-dropdown-link" href="/new-license">Get your license</a>
                       <a purpose="mobile-dropdown-link" href="/contribute">Contribute</a>
                     </div>
                   </div>
@@ -237,7 +237,7 @@
                     <a class="dropdown-item" href="/support">Chat</a>
                     <a class="dropdown-item" href="/docs/deploy/introduction">Hosting</a>
                     <a class="dropdown-item" href="/releases">Release notes</a>
-                    <a class="dropdown-item" href="/customers/register">Get your license</a>
+                    <a class="dropdown-item" href="/new-license">Get your license</a>
                     <a class="dropdown-item" href="/contribute">Contribute</a>
                   </div>
                 </div>
@@ -318,7 +318,7 @@
             <a href="/support">Support</a>
             <a href="/docs">Docs</a>
             <a href="/docs/rest-api">REST API</a>
-            <a href="/customers/register">Get your license</a>
+            <a href="/new-license">Get your license</a>
             <a href="/docs/contributing">Contribute</a>
           </div>
           <div purpose="footer-nav-column" class="d-flex flex-column col-lg-3 col-md-4 col-sm-6 col-12">

--- a/website/views/pages/entrance/login.ejs
+++ b/website/views/pages/entrance/login.ejs
@@ -10,7 +10,7 @@
     </div>
     <div purpose="customer-portal-form"  class="card card-body mb-5">
       <div purpose="register-link" v-if="showCustomerLogin">
-        <a href="/register">Create an account</a>
+        <a :href="registerSlug">Create an account</a>
       </div>
       <ajax-form class="customers-login" action="login" :syncing.sync="syncing" :cloud-error.sync="cloudError" :form-data="formData" :form-rules="formRules" :form-errors.sync="formErrors" @submitted="submittedForm()">
         <div class="form-group">

--- a/website/views/pages/entrance/signup.ejs
+++ b/website/views/pages/entrance/signup.ejs
@@ -6,7 +6,7 @@
     </div>
     <div purpose="customer-portal-form" class="card card-body">
       <div purpose="login-link">
-        <a href="/login">I have an account</a>
+        <a :href="loginSlug">I have an account</a>
       </div>
       <ajax-form action="signup" class="self-service-register" :syncing.sync="syncing" :cloud-error.sync="cloudError" :form-errors.sync="formErrors" :form-data="formData" :form-rules="formRules" @submitted="submittedSignUpForm()">
         <div class="form-group">


### PR DESCRIPTION
Closes: https://github.com/fleetdm/confidential/issues/6199

Changes:
- Updated view-new-license to redirect non-logged-in users to the /register page (it was previously doing this, but had a policy applied, so non-logged-in users were always redirected to the signup page.)
- Updated the /register page to support a new input: `purchaseLicense`. If this query string is provided, the register page will redirect users who sign up to the /new-license page.
- Updated the /login page to support a new input: `purchaseLicense`. If this query string is provided, the login page will redirect users who log in to the /new-license page.
- Updated policies to bypass the is-logged-in policy for the /new-license page.
- Updated the "get your license" link in the website nav menu to go to the /new-license page.