### PR TITLE
Website: Fix testimonials.yml maintainers & DRI in custom config

### DIFF
--- a/website/config/custom.js
+++ b/website/config/custom.js
@@ -148,7 +148,7 @@ module.exports.custom = {
     // 'website/views/pages/pricing.ejs': '',                // « Covered in CODEOWNERS (2023-07-22)
     // 'handbook/company/pricing-features-table.yml': '',    // « Covered in CODEOWNERS (2023-07-22)
 
-    '/handbook/company/testimonials.yml': 'mike-j-thomas',
+    'handbook/company/testimonials.yml': 'mike-j-thomas',
 
     // 🫧 Other brandfronts
     'README.md': 'mikermcneil',// « GitHub brandfront
@@ -251,7 +251,7 @@ module.exports.custom = {
     'handbook/sales': ['sampfluger88','mikermcneil'],
     'handbook/demand': ['sampfluger88','mikermcneil'],
     'handbook/customer-success': ['sampfluger88','mikermcneil'],
-    '/handbook/company/testimonials.yml': ['eashaw', 'mike-j-thomas', 'sampfluger88', 'mikermcneil'],
+    'handbook/company/testimonials.yml': ['eashaw', 'mike-j-thomas', 'sampfluger88', 'mikermcneil'],
 
     // GitHub issue templates
     '.github/ISSUE_TEMPLATE': ['mikermcneil', 'lukeheath', 'sampfluger88'],


### PR DESCRIPTION
Changes:
- removed a leading slash from the path to `handbook/company/testimonials.yml` in the website's custom config