### PR TITLE
increase timeout for the installation of Colima

### DIFF
--- a/.github/workflows/test-packaging.yml
+++ b/.github/workflows/test-packaging.yml
@@ -63,7 +63,7 @@ jobs:
 
     - name: Run Colima
       if: startsWith(matrix.os, 'macos')
-      timeout-minutes: 5
+      timeout-minutes: 10
       # notes:
       # - docker to install the docker CLI and interact with the Colima
       #   container runtime


### PR DESCRIPTION
saw many jobs timeout and fail. Optionally, should we use `macos-12` that comes with Colima pre-installed? can make that change as well, just lmk

