### PR TITLE
fleetd-chrome 1.3.0 release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -325,7 +325,9 @@ changelog-orbit:
 	sh -c "git rm orbit/changes/*"
 
 changelog-chrome:
-	sh -c "find ee/fleetd-chrome/changes -type file | grep -v .keep | xargs -I {} sh -c 'grep \"\S\" {}; echo' > new-CHANGELOG.md"
+	$(eval TODAY_DATE := $(shell date "+%b %d, %Y"))
+	@echo -e "## fleetd-chrome $(version) ($(TODAY_DATE))\n" > new-CHANGELOG.md
+	sh -c "find ee/fleetd-chrome/changes -type file | grep -v .keep | xargs -I {} sh -c 'grep \"\S\" {}; echo' >> new-CHANGELOG.md"
 	sh -c "cat new-CHANGELOG.md ee/fleetd-chrome/CHANGELOG.md > tmp-CHANGELOG.md && rm new-CHANGELOG.md && mv tmp-CHANGELOG.md ee/fleetd-chrome/CHANGELOG.md"
 	sh -c "git rm ee/fleetd-chrome/changes/*"
 

--- a/ee/fleetd-chrome/CHANGELOG.md
+++ b/ee/fleetd-chrome/CHANGELOG.md
@@ -1,6 +1,6 @@
-## fleetd-chrome 1.3.0 (Apr 25, 2024)
+## fleetd-chrome 1.3.0 (Apr 29, 2024)
 
-* Reinitialize DB and recover after a rare RuntimeError coming from sqlite web assembly code.
+* Created a fix to recover after a rare RuntimeError coming from sqlite web assembly code by reinitializing the DB.
 
-* Fix a bug where values not derived from "actual" fleetd-chrome tables were not being displayed
+* Fixed a bug where values not derived from "actual" fleetd-chrome tables were not being displayed
   correctly (e.g., `SELECT 1` gets its value from the query itself, not a table)

--- a/ee/fleetd-chrome/CHANGELOG.md
+++ b/ee/fleetd-chrome/CHANGELOG.md
@@ -1,0 +1,6 @@
+## fleetd-chrome 1.3.0 (Apr 25, 2024)
+
+* Reinitialize DB and recover after a rare RuntimeError coming from sqlite web assembly code.
+
+* Fix a bug where values not derived from "actual" fleetd-chrome tables were not being displayed
+  correctly (e.g., `SELECT 1` gets its value from the query itself, not a table)

--- a/ee/fleetd-chrome/README.md
+++ b/ee/fleetd-chrome/README.md
@@ -67,6 +67,14 @@ npm run test
 
 ## Release
 
+1. Update CHANGELOG.md by running `version="X.X.X" make changelog-chrome`
+2. Review CHANGELOG.md
+3. Run `npm version X.X.X` to update the version in `package.json` and `package-lock.json`
+4. Update [updates.xml](./updates.xml) and [updates-beta.xml](./updates-beta.xml) versions.
+5. Commit the changes and tag the commit with `fleetd-chrome-vX.X.X-beta`. This will trigger the beta release workflow.
+6. Once the beta release is tested and PR merged, tag the commit with `fleetd-chrome-vX.X.X`. This will trigger the release workflow.
+7. Announce the release in the #help-engineering channel in Slack.
+
 Release a new version via GitHub automation. Update the [package.json](./package.json) and [updates.xml](./updates.xml) versions, then tag a commit with `fleetd-chrome-vX.X.X` to kick off the build and deploy. The build is automatically uploaded to R2 and properly configured clients should be able to update immediately when the job completes. Note that automatic updates seem to only happen about once a day in Chrome -- Hit the "Update" button in `chrome://extensions` to trigger the update manually.
 
 ### Beta releases

--- a/ee/fleetd-chrome/changes/18337-runtime-error
+++ b/ee/fleetd-chrome/changes/18337-runtime-error
@@ -1,1 +1,0 @@
-Reinitialize DB and recover after a rare RuntimeError coming from sqlite web assembly code.

--- a/ee/fleetd-chrome/package-lock.json
+++ b/ee/fleetd-chrome/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fleetd-for-chrome",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fleetd-for-chrome",
-      "version": "1.2.1",
+      "version": "1.3.0",
       "dependencies": {
         "dotenv": "^16.0.3",
         "wa-sqlite": "github:rhashimoto/wa-sqlite#v0.9.11"

--- a/ee/fleetd-chrome/package.json
+++ b/ee/fleetd-chrome/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fleetd-for-chrome",
   "description": "Extension for Fleetd on ChromeOS",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "dependencies": {
     "dotenv": "^16.0.3",
     "wa-sqlite": "github:rhashimoto/wa-sqlite#v0.9.11"

--- a/ee/fleetd-chrome/updates-beta.xml
+++ b/ee/fleetd-chrome/updates-beta.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <gupdate xmlns='http://www.google.com/update2/response' protocol='2.0'>
   <app appid='bfleegjcoffelppfmadimianphbcdjkb'>
-    <updatecheck codebase='https://chrome-beta.fleetdm.com/fleetd.crx' version='1.2.1' />
+    <updatecheck codebase='https://chrome-beta.fleetdm.com/fleetd.crx' version='1.3.0' />
   </app>
 </gupdate>

--- a/ee/fleetd-chrome/updates.xml
+++ b/ee/fleetd-chrome/updates.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <gupdate xmlns='http://www.google.com/update2/response' protocol='2.0'>
   <app appid='fleeedmmihkfkeemmipgmhhjemlljidg'>
-    <updatecheck codebase='https://chrome.fleetdm.com/fleetd.crx' version='1.2.0' />
+    <updatecheck codebase='https://chrome.fleetdm.com/fleetd.crx' version='1.3.0' />
   </app>
 </gupdate>


### PR DESCRIPTION
#18466 

The beta release is already available at: https://chrome-beta.fleetdm.com/updates.xml