### PR TITLE
Updated host_operating_system INSERT.

### DIFF
--- a/changes/16562-deadlock
+++ b/changes/16562-deadlock
@@ -1,1 +1,1 @@
-Updated MySQL host_operating_system insert statement to reduce table lock time.
+Updated MySQL host_operating_system insert statement to reduce table lock time and optimize performance for the common case.

--- a/changes/16562-deadlock
+++ b/changes/16562-deadlock
@@ -1,0 +1,1 @@
+Updated MySQL host_operating_system insert statement to reduce table lock time.

--- a/server/datastore/mysql/operating_systems.go
+++ b/server/datastore/mysql/operating_systems.go
@@ -139,23 +139,12 @@ func getOperatingSystemDB(ctx context.Context, tx sqlx.ExtContext, hostOS fleet.
 // upsertHostOperatingSystemDB upserts the host operating system table
 // with the operating system id for the given host ID
 func upsertHostOperatingSystemDB(ctx context.Context, tx sqlx.ExtContext, hostID uint, osID uint) error {
-	res, err := tx.ExecContext(ctx, "UPDATE host_operating_system SET os_id = ? WHERE host_id = ?", osID, hostID)
-	if err != nil {
-		return err
-	}
-
-	if n, _ := res.RowsAffected(); n > 0 {
-		// update success
-		return nil
-	}
-
-	// no row to update so insert new row
-	_, err = tx.ExecContext(ctx, "INSERT INTO host_operating_system (host_id, os_id) VALUES (?, ?)", hostID, osID)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	_, err := tx.ExecContext(
+		ctx,
+		`INSERT INTO host_operating_system (host_id, os_id) VALUES (?, ?)
+				ON DUPLICATE KEY UPDATE os_id = VALUES(os_id)`, hostID, osID,
+	)
+	return err
 }
 
 // getIDHostOperatingSystemDB queries the `host_operating_system` table and returns the


### PR DESCRIPTION
#16562 

Updated MySQL host_operating_system insert statement to reduce table lock time.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [ ] Added/updated tests
  - Existing tests provide full coverage of the changes.
- [x] Manual QA for all new/changed functionality
