### PR TITLE
17744 policies backend

### DIFF
--- a/changes/15605-merge-inherited-and-team-queries-policies
+++ b/changes/15605-merge-inherited-and-team-queries-policies
@@ -1,0 +1,2 @@
+- UI Change: Team queries page renders team level and inherited queries in a single table set by a new merge_inherited API parameter
+- UI Change: Team policies page renders team level and inherited policies in a single table set by a new merge_inherited API parameter

--- a/server/datastore/mysql/policies.go
+++ b/server/datastore/mysql/policies.go
@@ -562,6 +562,14 @@ func (ds *Datastore) ListTeamPolicies(ctx context.Context, teamID uint, opts fle
 	return teamPolicies, inheritedPolicies, err
 }
 
+func (ds *Datastore) ListMergedTeamPolicies(ctx context.Context, teamID uint, opts fleet.ListOptions) ([]*fleet.Policy, error) {
+	teamPolicies, inheritedPolicies, err := ds.ListTeamPolicies(ctx, teamID, opts, fleet.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+	return append(teamPolicies, inheritedPolicies...), nil
+}
+
 func (ds *Datastore) DeleteTeamPolicies(ctx context.Context, teamID uint, ids []uint) ([]uint, error) {
 	return deletePolicyDB(ctx, ds.writer(ctx), ids, &teamID)
 }

--- a/server/datastore/mysql/policies.go
+++ b/server/datastore/mysql/policies.go
@@ -563,11 +563,37 @@ func (ds *Datastore) ListTeamPolicies(ctx context.Context, teamID uint, opts fle
 }
 
 func (ds *Datastore) ListMergedTeamPolicies(ctx context.Context, teamID uint, opts fleet.ListOptions) ([]*fleet.Policy, error) {
-	teamPolicies, inheritedPolicies, err := ds.ListTeamPolicies(ctx, teamID, opts, fleet.ListOptions{})
+	var args []interface{}
+
+	query := `
+		SELECT 
+			` + policyCols + `,
+			COALESCE(u.name, '<deleted>') AS author_name,
+			COALESCE(u.email, '') AS author_email,
+			ps.updated_at as host_count_updated_at,
+			COALESCE(ps.passing_host_count, 0) as passing_host_count,
+			COALESCE(ps.failing_host_count, 0) as failing_host_count
+		FROM policies p
+		LEFT JOIN users u ON p.author_id = u.id
+		LEFT JOIN policy_stats ps ON p.id = ps.policy_id
+		AND ps.inherited_team_id = COALESCE(p.team_id, 0)
+		WHERE p.team_id = ? OR p.team_id IS NULL
+    `
+
+	args = append(args, teamID)
+
+	// We must normalize the name for full Unicode support (Unicode equivalence).
+	match := norm.NFC.String(opts.MatchQuery)
+	query, args = searchLike(query, args, match, policySearchColumns...)
+	query, _ = appendListOptionsToSQL(query, &opts)
+
+	var policies []*fleet.Policy
+	err := sqlx.SelectContext(ctx, ds.reader(ctx), &policies, query, args...)
 	if err != nil {
-		return nil, err
+		return nil, ctxerr.Wrap(ctx, err, "listing merged team policies")
 	}
-	return append(teamPolicies, inheritedPolicies...), nil
+
+	return policies, nil
 }
 
 func (ds *Datastore) DeleteTeamPolicies(ctx context.Context, teamID uint, ids []uint) ([]uint, error) {

--- a/server/datastore/mysql/policies_test.go
+++ b/server/datastore/mysql/policies_test.go
@@ -742,7 +742,7 @@ func testListMergedTeamPolicies(t *testing.T, ds *Datastore) {
 	require.NoError(t, err)
 
 	merged, err := ds.ListMergedTeamPolicies(ctx, team1.ID, fleet.ListOptions{
-		OrderKey: "name",
+		OrderKey:       "name",
 		OrderDirection: fleet.OrderAscending,
 	})
 	require.NoError(t, err)

--- a/server/datastore/mysql/policies_test.go
+++ b/server/datastore/mysql/policies_test.go
@@ -712,7 +712,7 @@ func testTeamPolicyProprietary(t *testing.T, ds *Datastore) {
 func testListMergedTeamPolicies(t *testing.T, ds *Datastore) {
 	ctx := context.Background()
 	gpol, err := ds.NewGlobalPolicy(ctx, nil, fleet.PolicyPayload{
-		Name:        "existing-query-global-1",
+		Name:        "query1 global",
 		Query:       "select 1;",
 		Description: "query1 desc",
 		Resolution:  "query1 resolution",
@@ -723,7 +723,7 @@ func testListMergedTeamPolicies(t *testing.T, ds *Datastore) {
 	require.NoError(t, err)
 
 	p, err := ds.NewTeamPolicy(ctx, team1.ID, nil, fleet.PolicyPayload{
-		Name:        "query1",
+		Name:        "query2 team1",
 		Query:       "select 1;",
 		Description: "query1 desc",
 		Resolution:  "query1 resolution",
@@ -734,7 +734,7 @@ func testListMergedTeamPolicies(t *testing.T, ds *Datastore) {
 	require.NoError(t, err)
 
 	_, err = ds.NewTeamPolicy(ctx, team2.ID, nil, fleet.PolicyPayload{
-		Name:        "query2",
+		Name:        "query3 team2",
 		Query:       "select 2;",
 		Description: "query2 desc",
 		Resolution:  "query2 resolution",
@@ -744,6 +744,17 @@ func testListMergedTeamPolicies(t *testing.T, ds *Datastore) {
 	merged, err := ds.ListMergedTeamPolicies(ctx, team1.ID, fleet.ListOptions{
 		OrderKey:       "name",
 		OrderDirection: fleet.OrderAscending,
+	})
+	require.NoError(t, err)
+
+	require.Len(t, merged, 2)
+	assert.Equal(t, gpol.ID, merged[0].ID)
+	assert.Equal(t, p.ID, merged[1].ID)
+
+	// Test list options affect both global and team policies
+	merged, err = ds.ListMergedTeamPolicies(ctx, team1.ID, fleet.ListOptions{
+		OrderKey:       "name",
+		OrderDirection: fleet.OrderDescending,
 	})
 	require.NoError(t, err)
 

--- a/server/datastore/mysql/policies_test.go
+++ b/server/datastore/mysql/policies_test.go
@@ -35,6 +35,7 @@ func TestPolicies(t *testing.T) {
 		{"MembershipViewNotDeferred", func(t *testing.T, ds *Datastore) { testPoliciesMembershipView(false, t, ds) }},
 		{"TeamPolicyLegacy", testTeamPolicyLegacy},
 		{"TeamPolicyProprietary", testTeamPolicyProprietary},
+		{"ListMergedTeamPolicies", testListMergedTeamPolicies},
 		{"PolicyQueriesForHost", testPolicyQueriesForHost},
 		{"PolicyQueriesForHostPlatforms", testPolicyQueriesForHostPlatforms},
 		{"PoliciesByID", testPoliciesByID},
@@ -706,6 +707,49 @@ func testTeamPolicyProprietary(t *testing.T, ds *Datastore) {
 	assert.Equal(t, "query2 other resolution", *teamPolicies[0].Resolution)
 	require.NotNil(t, team2Policies[0].AuthorID)
 	require.Equal(t, user1.ID, *team2Policies[0].AuthorID)
+}
+
+func testListMergedTeamPolicies(t *testing.T, ds *Datastore) {
+	ctx := context.Background()
+	gpol, err := ds.NewGlobalPolicy(ctx, nil, fleet.PolicyPayload{
+		Name:        "existing-query-global-1",
+		Query:       "select 1;",
+		Description: "query1 desc",
+		Resolution:  "query1 resolution",
+	})
+	require.NoError(t, err)
+
+	team1, err := ds.NewTeam(ctx, &fleet.Team{Name: "team1"})
+	require.NoError(t, err)
+
+	p, err := ds.NewTeamPolicy(ctx, team1.ID, nil, fleet.PolicyPayload{
+		Name:        "query1",
+		Query:       "select 1;",
+		Description: "query1 desc",
+		Resolution:  "query1 resolution",
+	})
+	require.NoError(t, err)
+
+	team2, err := ds.NewTeam(ctx, &fleet.Team{Name: "team2"})
+	require.NoError(t, err)
+
+	_, err = ds.NewTeamPolicy(ctx, team2.ID, nil, fleet.PolicyPayload{
+		Name:        "query2",
+		Query:       "select 2;",
+		Description: "query2 desc",
+		Resolution:  "query2 resolution",
+	})
+	require.NoError(t, err)
+
+	merged, err := ds.ListMergedTeamPolicies(ctx, team1.ID, fleet.ListOptions{
+		OrderKey: "name",
+		OrderDirection: fleet.OrderAscending,
+	})
+	require.NoError(t, err)
+
+	require.Len(t, merged, 2)
+	assert.Equal(t, p.ID, merged[0].ID)
+	assert.Equal(t, gpol.ID, merged[1].ID)
 }
 
 func newTestHostWithPlatform(t *testing.T, ds *Datastore, hostname, platform string, teamID *uint) *fleet.Host {

--- a/server/fleet/datastore.go
+++ b/server/fleet/datastore.go
@@ -657,6 +657,8 @@ type Datastore interface {
 
 	NewTeamPolicy(ctx context.Context, teamID uint, authorID *uint, args PolicyPayload) (*Policy, error)
 	ListTeamPolicies(ctx context.Context, teamID uint, opts ListOptions, iopts ListOptions) (teamPolicies, inheritedPolicies []*Policy, err error)
+	ListMergedTeamPolicies(ctx context.Context, teamID uint, opts ListOptions) ([]*Policy, error)
+
 	DeleteTeamPolicies(ctx context.Context, teamID uint, ids []uint) ([]uint, error)
 	TeamPolicy(ctx context.Context, teamID uint, policyID uint) (*Policy, error)
 

--- a/server/fleet/service.go
+++ b/server/fleet/service.go
@@ -639,7 +639,7 @@ type Service interface {
 	// Team Policies
 
 	NewTeamPolicy(ctx context.Context, teamID uint, p PolicyPayload) (*Policy, error)
-	ListTeamPolicies(ctx context.Context, teamID uint, opts ListOptions, iopts ListOptions) (teamPolicies, inheritedPolicies []*Policy, err error)
+	ListTeamPolicies(ctx context.Context, teamID uint, opts ListOptions, iopts ListOptions, mergeInherited bool) (teamPolicies, inheritedPolicies []*Policy, err error)
 	DeleteTeamPolicies(ctx context.Context, teamID uint, ids []uint) ([]uint, error)
 	ModifyTeamPolicy(ctx context.Context, teamID uint, id uint, p ModifyPolicyPayload) (*Policy, error)
 	GetTeamPolicyByIDQueries(ctx context.Context, teamID uint, policyID uint) (*Policy, error)

--- a/server/mock/datastore_mock.go
+++ b/server/mock/datastore_mock.go
@@ -493,6 +493,8 @@ type NewTeamPolicyFunc func(ctx context.Context, teamID uint, authorID *uint, ar
 
 type ListTeamPoliciesFunc func(ctx context.Context, teamID uint, opts fleet.ListOptions, iopts fleet.ListOptions) (teamPolicies []*fleet.Policy, inheritedPolicies []*fleet.Policy, err error)
 
+type ListMergedTeamPoliciesFunc func(ctx context.Context, teamID uint, opts fleet.ListOptions) ([]*fleet.Policy, error)
+
 type DeleteTeamPoliciesFunc func(ctx context.Context, teamID uint, ids []uint) ([]uint, error)
 
 type TeamPolicyFunc func(ctx context.Context, teamID uint, policyID uint) (*fleet.Policy, error)
@@ -1628,6 +1630,9 @@ type DataStore struct {
 
 	ListTeamPoliciesFunc        ListTeamPoliciesFunc
 	ListTeamPoliciesFuncInvoked bool
+
+	ListMergedTeamPoliciesFunc        ListMergedTeamPoliciesFunc
+	ListMergedTeamPoliciesFuncInvoked bool
 
 	DeleteTeamPoliciesFunc        DeleteTeamPoliciesFunc
 	DeleteTeamPoliciesFuncInvoked bool
@@ -3925,6 +3930,13 @@ func (s *DataStore) ListTeamPolicies(ctx context.Context, teamID uint, opts flee
 	s.ListTeamPoliciesFuncInvoked = true
 	s.mu.Unlock()
 	return s.ListTeamPoliciesFunc(ctx, teamID, opts, iopts)
+}
+
+func (s *DataStore) ListMergedTeamPolicies(ctx context.Context, teamID uint, opts fleet.ListOptions) ([]*fleet.Policy, error) {
+	s.mu.Lock()
+	s.ListMergedTeamPoliciesFuncInvoked = true
+	s.mu.Unlock()
+	return s.ListMergedTeamPoliciesFunc(ctx, teamID, opts)
 }
 
 func (s *DataStore) DeleteTeamPolicies(ctx context.Context, teamID uint, ids []uint) ([]uint, error) {

--- a/server/service/integration_enterprise_test.go
+++ b/server/service/integration_enterprise_test.go
@@ -809,7 +809,7 @@ func (s *integrationEnterpriseTestSuite) TestTeamPolicies() {
 	require.Len(t, ts.InheritedPolicies, 0)
 
 	// create a global policy
-	gpol, err := s.ds.NewGlobalPolicy(context.Background(), nil, fleet.PolicyPayload{Name: "TestGlobalPolicy", Query: "SELECT 1"})
+	gpol, err := s.ds.NewGlobalPolicy(context.Background(), nil, fleet.PolicyPayload{Name: "Policy1 Global", Query: "SELECT 1"})
 	require.NoError(t, err)
 	defer func() {
 		_, err := s.ds.DeleteGlobalPolicies(context.Background(), []uint{gpol.ID})
@@ -817,7 +817,7 @@ func (s *integrationEnterpriseTestSuite) TestTeamPolicies() {
 	}()
 
 	qr, err := s.ds.NewQuery(context.Background(), &fleet.Query{
-		Name:           "TestQuery2",
+		Name:           "Policy2 TestQuery2",
 		Description:    "Some description",
 		Query:          "select * from osquery;",
 		ObserverCanRun: true,
@@ -835,7 +835,7 @@ func (s *integrationEnterpriseTestSuite) TestTeamPolicies() {
 	ts = listTeamPoliciesResponse{}
 	s.DoJSON("GET", fmt.Sprintf("/api/latest/fleet/teams/%d/policies", team1.ID), nil, http.StatusOK, &ts)
 	require.Len(t, ts.Policies, 1)
-	assert.Equal(t, "TestQuery2", ts.Policies[0].Name)
+	assert.Equal(t, "Policy2 TestQuery2", ts.Policies[0].Name)
 	assert.Equal(t, "select * from osquery;", ts.Policies[0].Query)
 	assert.Equal(t, "Some description", ts.Policies[0].Description)
 	require.NotNil(t, ts.Policies[0].Resolution)
@@ -848,7 +848,7 @@ func (s *integrationEnterpriseTestSuite) TestTeamPolicies() {
 	ltParams := listTeamPoliciesRequest{
 		MergeInherited: true,
 		Opts: fleet.ListOptions{
-			OrderKey:       "team_id",
+			OrderKey:       "name",
 			OrderDirection: fleet.OrderDescending,
 		},
 	}
@@ -856,7 +856,7 @@ func (s *integrationEnterpriseTestSuite) TestTeamPolicies() {
 	s.DoJSON("GET", fmt.Sprintf("/api/latest/fleet/teams/%d/policies", team1.ID), ltParams, http.StatusOK, &ts)
 	require.Len(t, ts.Policies, 2)
 	require.Nil(t, ts.InheritedPolicies)
-	assert.Equal(t, "TestQuery2", ts.Policies[0].Name)
+	assert.Equal(t, "Policy2 TestQuery2", ts.Policies[0].Name)
 	assert.Equal(t, "select * from osquery;", ts.Policies[0].Query)
 	assert.Equal(t, "Some description", ts.Policies[0].Description)
 	require.NotNil(t, ts.Policies[0].Resolution)

--- a/server/service/integration_enterprise_test.go
+++ b/server/service/integration_enterprise_test.go
@@ -845,15 +845,8 @@ func (s *integrationEnterpriseTestSuite) TestTeamPolicies() {
 	assert.Equal(t, gpol.ID, ts.InheritedPolicies[0].ID)
 
 	// Test merge inherited
-	ltParams := listTeamPoliciesRequest{
-		MergeInherited: true,
-		Opts: fleet.ListOptions{
-			OrderKey:       "team_id",
-			OrderDirection: fleet.OrderDescending,
-		},
-	}
 	ts = listTeamPoliciesResponse{}
-	s.DoJSON("GET", fmt.Sprintf("/api/latest/fleet/teams/%d/policies", team1.ID), ltParams, http.StatusOK, &ts)
+	s.DoJSON("GET", fmt.Sprintf("/api/latest/fleet/teams/%d/policies", team1.ID), nil, http.StatusOK, &ts, "merge_inherited", "true", "order_key", "team_id", "order_direction", "desc")
 	require.Len(t, ts.Policies, 2)
 	require.Nil(t, ts.InheritedPolicies)
 	assert.Equal(t, "TestQuery2", ts.Policies[0].Name)

--- a/server/service/integration_enterprise_test.go
+++ b/server/service/integration_enterprise_test.go
@@ -809,7 +809,7 @@ func (s *integrationEnterpriseTestSuite) TestTeamPolicies() {
 	require.Len(t, ts.InheritedPolicies, 0)
 
 	// create a global policy
-	gpol, err := s.ds.NewGlobalPolicy(context.Background(), nil, fleet.PolicyPayload{Name: "Policy1 Global", Query: "SELECT 1"})
+	gpol, err := s.ds.NewGlobalPolicy(context.Background(), nil, fleet.PolicyPayload{Name: "TestGlobalPolicy", Query: "SELECT 1"})
 	require.NoError(t, err)
 	defer func() {
 		_, err := s.ds.DeleteGlobalPolicies(context.Background(), []uint{gpol.ID})
@@ -817,7 +817,7 @@ func (s *integrationEnterpriseTestSuite) TestTeamPolicies() {
 	}()
 
 	qr, err := s.ds.NewQuery(context.Background(), &fleet.Query{
-		Name:           "Policy2 TestQuery2",
+		Name:           "TestQuery2",
 		Description:    "Some description",
 		Query:          "select * from osquery;",
 		ObserverCanRun: true,
@@ -835,7 +835,7 @@ func (s *integrationEnterpriseTestSuite) TestTeamPolicies() {
 	ts = listTeamPoliciesResponse{}
 	s.DoJSON("GET", fmt.Sprintf("/api/latest/fleet/teams/%d/policies", team1.ID), nil, http.StatusOK, &ts)
 	require.Len(t, ts.Policies, 1)
-	assert.Equal(t, "Policy2 TestQuery2", ts.Policies[0].Name)
+	assert.Equal(t, "TestQuery2", ts.Policies[0].Name)
 	assert.Equal(t, "select * from osquery;", ts.Policies[0].Query)
 	assert.Equal(t, "Some description", ts.Policies[0].Description)
 	require.NotNil(t, ts.Policies[0].Resolution)
@@ -848,7 +848,7 @@ func (s *integrationEnterpriseTestSuite) TestTeamPolicies() {
 	ltParams := listTeamPoliciesRequest{
 		MergeInherited: true,
 		Opts: fleet.ListOptions{
-			OrderKey:       "name",
+			OrderKey:       "team_id",
 			OrderDirection: fleet.OrderDescending,
 		},
 	}
@@ -856,7 +856,7 @@ func (s *integrationEnterpriseTestSuite) TestTeamPolicies() {
 	s.DoJSON("GET", fmt.Sprintf("/api/latest/fleet/teams/%d/policies", team1.ID), ltParams, http.StatusOK, &ts)
 	require.Len(t, ts.Policies, 2)
 	require.Nil(t, ts.InheritedPolicies)
-	assert.Equal(t, "Policy2 TestQuery2", ts.Policies[0].Name)
+	assert.Equal(t, "TestQuery2", ts.Policies[0].Name)
 	assert.Equal(t, "select * from osquery;", ts.Policies[0].Query)
 	assert.Equal(t, "Some description", ts.Policies[0].Description)
 	require.NotNil(t, ts.Policies[0].Resolution)

--- a/server/service/team_policies_test.go
+++ b/server/service/team_policies_test.go
@@ -149,7 +149,7 @@ func TestTeamPoliciesAuth(t *testing.T) {
 			})
 			checkAuthErr(t, tt.shouldFailWrite, err)
 
-			_, _, err = svc.ListTeamPolicies(ctx, 1, fleet.ListOptions{}, fleet.ListOptions{})
+			_, _, err = svc.ListTeamPolicies(ctx, 1, fleet.ListOptions{}, fleet.ListOptions{}, false)
 			checkAuthErr(t, tt.shouldFailRead, err)
 
 			_, err = svc.GetTeamPolicyByIDQueries(ctx, 1, 1)


### PR DESCRIPTION
#17744 

This change implements a new query parameter on `/teams/%d/policies` to merge inherited policies into the policies array instead of listing them separately.  The frontend will key off the existing `team_id` field to mark policies as "inherited" in theUI.

I opted for an additive approach in adding a datastore method rather than modifying the existing ListTeamPolicies to avoid a large test refactor.

- [ ] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [X] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [X] Added/updated tests
- [X] Manual QA for all new/changed functionality
