### PR TITLE
Website: Update update-or-create-contact-and-account helper

### DIFF
--- a/website/api/helpers/salesforce/update-or-create-contact-and-account.js
+++ b/website/api/helpers/salesforce/update-or-create-contact-and-account.js
@@ -73,7 +73,7 @@ module.exports = {
     await salesforceConnection.login(sails.config.custom.salesforceIntegrationUsername, sails.config.custom.salesforceIntegrationPasskey);
 
     let salesforceAccountId;
-    if(!organization && !enrichmentData.employer){
+    if (!organization || !enrichmentData.employer || !enrichmentData.employer.emailDomain) {
       // Special sacraficial meat cave where the contacts with no organization go.
       // https://fleetdm.lightning.force.com/lightning/r/Account/0014x000025JC8DAAW/view
       salesforceAccountId = '0014x000025JC8DAAW';

--- a/website/api/helpers/salesforce/update-or-create-contact-and-account.js
+++ b/website/api/helpers/salesforce/update-or-create-contact-and-account.js
@@ -73,7 +73,7 @@ module.exports = {
     await salesforceConnection.login(sails.config.custom.salesforceIntegrationUsername, sails.config.custom.salesforceIntegrationPasskey);
 
     let salesforceAccountId;
-    if(!organization || !enrichmentData.employer || !enrichmentData.employer.emailDomain) {
+    if(!enrichmentData.employer || !enrichmentData.employer.emailDomain) {
       // Special sacraficial meat cave where the contacts with no organization go.
       // https://fleetdm.lightning.force.com/lightning/r/Account/0014x000025JC8DAAW/view
       salesforceAccountId = '0014x000025JC8DAAW';

--- a/website/api/helpers/salesforce/update-or-create-contact-and-account.js
+++ b/website/api/helpers/salesforce/update-or-create-contact-and-account.js
@@ -73,7 +73,7 @@ module.exports = {
     await salesforceConnection.login(sails.config.custom.salesforceIntegrationUsername, sails.config.custom.salesforceIntegrationPasskey);
 
     let salesforceAccountId;
-    if (!organization || !enrichmentData.employer || !enrichmentData.employer.emailDomain) {
+    if(!organization || !enrichmentData.employer || !enrichmentData.employer.emailDomain) {
       // Special sacraficial meat cave where the contacts with no organization go.
       // https://fleetdm.lightning.force.com/lightning/r/Account/0014x000025JC8DAAW/view
       salesforceAccountId = '0014x000025JC8DAAW';


### PR DESCRIPTION
Changes:
- Updated the `salesforce/update-or-create-contact-and-account` helper to not to try to use  `enrichementData.employer.emailDomain` if an `organization` was provided.