### PR TITLE
Update drafting process for API changes

### DIFF
--- a/handbook/product-design/README.md
+++ b/handbook/product-design/README.md
@@ -48,8 +48,9 @@ When starting a new draft:
     -  **Cover.** This page has a component with issue number, issue name, and status fields. There are 3 statuses: Work in progress, Approved, and Released (the main source of truth is still the drafting board).
     -  **Ready.** Use this page to communicate designs reviews and development.
     -  **Scratchpad.** Use this page for work in progress and design that might be useful in the future.
-- If the story requires API changes, open a draft PR with the proposed API design.
-
+- If the story requires API changes, open a draft PR with the proposed API design and request the API DRI for review.
+    - These draft PRs are not actually merged, since they're often created several weeks ahead of implementation, which can artificially affect our PR open time KPI. Instead, once the documentation changes are ready for final review, the PR author will close the draft PR and open a new PR from the same branch.
+      
 ### Schedule a design review
 - Prepare your draft in the user story issue.
 - Prepare the agenda for your design review meeting, which should be an empty document other than the proposed changes you will present.

--- a/handbook/product-design/README.md
+++ b/handbook/product-design/README.md
@@ -48,8 +48,8 @@ When starting a new draft:
     -  **Cover.** This page has a component with issue number, issue name, and status fields. There are 3 statuses: Work in progress, Approved, and Released (the main source of truth is still the drafting board).
     -  **Ready.** Use this page to communicate designs reviews and development.
     -  **Scratchpad.** Use this page for work in progress and design that might be useful in the future.
-- If the story requires API changes, open a draft PR with the proposed API design and request the API DRI for review.
-    - These draft PRs are not actually merged, since they're often created several weeks ahead of implementation, which can artificially affect our PR open time KPI. Instead, once the documentation changes are ready for final review, the PR author will close the draft PR and open a new PR from the same branch.
+- If the story requires API changes, open a draft PR with the proposed API design.
+    - These draft PRs are not actually merged, since they're often created weeks ahead of implenentation and can artificially affect our PR open time KPI. Instead, once the documentation changes are ready for final review, the designer closes the draft PR and opens a fresh PR from the same branch.
       
 ### Schedule a design review
 - Prepare your draft in the user story issue.

--- a/handbook/product-design/README.md
+++ b/handbook/product-design/README.md
@@ -49,7 +49,7 @@ When starting a new draft:
     -  **Ready.** Use this page to communicate designs reviews and development.
     -  **Scratchpad.** Use this page for work in progress and design that might be useful in the future.
 - If the story requires API changes, open a draft PR with the proposed API design.
-    - These draft PRs are not actually merged, since they're often created weeks ahead of implenentation and can artificially affect our PR open time KPI. Instead, once the documentation changes are ready for final review, the designer closes the draft PR and opens a fresh PR from the same branch.
+    - These draft PRs are not actually merged, since they're often created weeks ahead of implementation and can artificially affect our PR open time KPI. Instead, once the documentation changes are ready for final review, the designer closes the draft PR and opens a fresh PR from the same branch.
       
 ### Schedule a design review
 - Prepare your draft in the user story issue.


### PR DESCRIPTION
Proposes a solution to avoid messing with the PR open time KPI when creating API design draft PRs. (These PRs are created fairly often as part of the normal product design process, and usually sit in draft for weeks before they're ready to merge.) See conversation [here](https://github.com/fleetdm/fleet/pull/16129#issuecomment-2080181953) for context.