### PR TITLE
Website: Update save-questionnaire-progress

### DIFF
--- a/website/api/controllers/save-questionnaire-progress.js
+++ b/website/api/controllers/save-questionnaire-progress.js
@@ -174,16 +174,17 @@ module.exports = {
 
     }//ﬁ
 
-
-
-    await sails.helpers.salesforce.updateOrCreateContactAndAccount.with({
-      emailAddress: this.req.me.emailAddress,
-      firstName: this.req.me.firstName,
-      lastName: this.req.me.lastName,
-      primaryBuyingSituation: primaryBuyingSituation === 'eo-security' ? 'Endpoint operations - Security' : primaryBuyingSituation === 'eo-it' ? 'Endpoint operations - IT' : primaryBuyingSituation === 'mdm' ? 'Device management (MDM)' : primaryBuyingSituation === 'vm' ? 'Vulnerability management' : undefined,
-      organization: this.req.me.organization,
-      psychologicalStage,
-    });
+    // Only update CRM records if the user's psychological stage changes.
+    if(currentStep !== userRecord.currentStep){
+      await sails.helpers.salesforce.updateOrCreateContactAndAccount.with({
+        emailAddress: this.req.me.emailAddress,
+        firstName: this.req.me.firstName,
+        lastName: this.req.me.lastName,
+        primaryBuyingSituation: primaryBuyingSituation === 'eo-security' ? 'Endpoint operations - Security' : primaryBuyingSituation === 'eo-it' ? 'Endpoint operations - IT' : primaryBuyingSituation === 'mdm' ? 'Device management (MDM)' : primaryBuyingSituation === 'vm' ? 'Vulnerability management' : undefined,
+        organization: this.req.me.organization,
+        psychologicalStage,
+      });
+    }
     // TODO: send all other answers to Salesforce (when there are fields for them)
 
     // await sails.helpers.http.post.with({


### PR DESCRIPTION
Related to https://github.com/fleetdm/confidential/issues/6357

Changes:
- Updated `save-questionnaire-progress` to only call `sails.helpers.salesforce.updateOrCreateContactAndAccount` is called when a user's `psychologicalStage` changes.