### PR TITLE
GitOps remove teams

### DIFF
--- a/changes/18640-gitops-remove-teams
+++ b/changes/18640-gitops-remove-teams
@@ -1,0 +1,4 @@
+Improvements to `fleetctl gitops` command:
+- Added the ability to pass multiple files, like `fleetctl gitops -f file1 -f file2`, where the first file must be the global configuration
+- Added the ability to remove teams that were not specified in team configs using the switch `--delete-other-teams`
+- When passing a global config and team config during initial configuration, the `org_settings.mdm.apple_bm_default_team` value can be set to match the team that will be created by the provided team config.

--- a/cmd/fleetctl/gitops.go
+++ b/cmd/fleetctl/gitops.go
@@ -137,6 +137,9 @@ func gitopsCommand() *cli.Command {
 				}
 				for _, team := range teams {
 					if !slices.Contains(teamNames, team.Name) {
+						if appleBMDefaultTeam == team.Name {
+							return fmt.Errorf("apple_bm_default_team %s cannot be deleted", appleBMDefaultTeam)
+						}
 						if flDryRun {
 							_, _ = fmt.Fprintf(c.App.Writer, "[!] would delete team %s\n", team.Name)
 						} else {

--- a/cmd/fleetctl/gitops.go
+++ b/cmd/fleetctl/gitops.go
@@ -51,7 +51,7 @@ func gitopsCommand() *cli.Command {
 			}
 			for _, flFilename := range flFilenames.Value() {
 				if strings.TrimSpace(flFilename) == "" {
-					return errors.New("filename cannot be empty")
+					return errors.New("file name cannot be empty")
 				}
 			}
 

--- a/cmd/fleetctl/gitops_enterprise_integration_test.go
+++ b/cmd/fleetctl/gitops_enterprise_integration_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/fleetdm/fleet/v4/server/config"
@@ -17,6 +18,7 @@ import (
 	"github.com/fleetdm/fleet/v4/server/service"
 	"github.com/fleetdm/fleet/v4/server/test"
 	"github.com/go-git/go-git/v5"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
@@ -146,21 +148,75 @@ contexts:
 	teamsDir := path.Join(repoDir, "teams")
 	teamFiles, err := os.ReadDir(teamsDir)
 	require.NoError(t, err)
-
-	// Dry run
-	_ = runAppForTest(t, []string{"gitops", "--config", fleetctlConfig.Name(), "-f", globalFile, "--dry-run"})
+	teamFileNames := make([]string, 0, len(teamFiles))
 	for _, file := range teamFiles {
 		if filepath.Ext(file.Name()) == ".yml" {
-			_ = runAppForTest(t, []string{"gitops", "--config", fleetctlConfig.Name(), "-f", path.Join(teamsDir, file.Name()), "--dry-run"})
+			teamFileNames = append(teamFileNames, path.Join(teamsDir, file.Name()))
 		}
 	}
 
-	// Real run
+	// Create a team to be deleted.
+	deletedTeamFile, err := os.CreateTemp(t.TempDir(), "*.yml")
+	require.NoError(t, err)
+	const deletedTeamName = "team_to_be_deleted"
+
+	_, err = deletedTeamFile.WriteString(
+		fmt.Sprintf(
+			`
+controls:
+queries:
+policies:
+agent_options:
+name: %s
+team_settings:
+  secrets: [{"secret":"deleted_team_secret"}]
+`, deletedTeamName,
+		),
+	)
+	require.NoError(t, err)
+	// Apply the team to be deleted
+	_ = runAppForTest(t, []string{"gitops", "--config", fleetctlConfig.Name(), "-f", deletedTeamFile.Name()})
+
+	// Dry run
+	_ = runAppForTest(t, []string{"gitops", "--config", fleetctlConfig.Name(), "-f", globalFile, "--dry-run"})
+	for _, fileName := range teamFileNames {
+		_ = runAppForTest(t, []string{"gitops", "--config", fleetctlConfig.Name(), "-f", fileName, "--dry-run"})
+	}
+
+	// Dry run with all the files
+	args := []string{"gitops", "--config", fleetctlConfig.Name(), "--dry-run", "--delete-other-teams", "-f", globalFile}
+	for _, fileName := range teamFileNames {
+		args = append(args, "-f", fileName)
+	}
+	_ = runAppForTest(t, args)
+
+	// Real run with all the files, but don't delete other teams
+	args = []string{"gitops", "--config", fleetctlConfig.Name(), "-f", globalFile}
+	for _, fileName := range teamFileNames {
+		args = append(args, "-f", fileName)
+	}
+	_ = runAppForTest(t, args)
+
+	// Check that all the teams exist
+	teamsJSON := runAppForTest(t, []string{"get", "teams", "--config", fleetctlConfig.Name(), "--json"})
+	assert.Equal(t, 3, strings.Count(teamsJSON, "team_id"))
+
+	// Real run with all the files, and delete other teams
+	args = []string{"gitops", "--config", fleetctlConfig.Name(), "--delete-other-teams", "-f", globalFile}
+	for _, fileName := range teamFileNames {
+		args = append(args, "-f", fileName)
+	}
+	_ = runAppForTest(t, args)
+
+	// Check that only the right teams exist
+	teamsJSON = runAppForTest(t, []string{"get", "teams", "--config", fleetctlConfig.Name(), "--json"})
+	assert.Equal(t, 2, strings.Count(teamsJSON, "team_id"))
+	assert.NotContains(t, teamsJSON, deletedTeamName)
+
+	// Real run with one file at a time
 	_ = runAppForTest(t, []string{"gitops", "--config", fleetctlConfig.Name(), "-f", globalFile})
-	for _, file := range teamFiles {
-		if filepath.Ext(file.Name()) == ".yml" {
-			_ = runAppForTest(t, []string{"gitops", "--config", fleetctlConfig.Name(), "-f", path.Join(teamsDir, file.Name())})
-		}
+	for _, fileName := range teamFileNames {
+		_ = runAppForTest(t, []string{"gitops", "--config", fleetctlConfig.Name(), "-f", fileName})
 	}
 
 }

--- a/cmd/fleetctl/gitops_test.go
+++ b/cmd/fleetctl/gitops_test.go
@@ -89,7 +89,7 @@ org_settings:
 	var errWriter strings.Builder
 	_, err = runAppNoChecks([]string{"gitops", tmpFile.Name()})
 	assert.Error(t, err)
-	assert.Equal(t, err.Error(), "-f must be specified")
+	assert.Equal(t, `Required flag "f" not set`, err.Error())
 
 	// Bad file
 	errWriter.Reset()

--- a/cmd/fleetctl/gitops_test.go
+++ b/cmd/fleetctl/gitops_test.go
@@ -772,6 +772,11 @@ team_settings:
 	assert.Error(t, err)
 	assert.True(t, strings.Contains(err.Error(), "must be the global config"))
 
+	// Global file specified multiple times
+	_, err = runAppNoChecks([]string{"gitops", "-f", globalFile.Name(), "-f", teamFile.Name(), "-f", globalFile.Name(), "--dry-run"})
+	assert.Error(t, err)
+	assert.True(t, strings.Contains(err.Error(), "only the first file can be the global config"))
+
 	// Dry run
 	_ = runAppForTest(t, []string{"gitops", "-f", globalFile.Name(), "-f", teamFile.Name(), "--dry-run"})
 	assert.Equal(t, fleet.AppConfig{}, *savedAppConfig, "AppConfig should be empty")

--- a/cmd/fleetctl/testdata/gitops/global_config_no_paths.yml
+++ b/cmd/fleetctl/testdata/gitops/global_config_no_paths.yml
@@ -144,7 +144,7 @@ org_settings:
                         "private_key": "google_calendar_private_key",
       }
   mdm:
-    apple_bm_default_team: ""
+    apple_bm_default_team: $APPLE_BM_DEFAULT_TEAM
     end_user_authentication:
       entity_id: ""
       idp_name: ""

--- a/ee/server/service/mdm.go
+++ b/ee/server/service/mdm.go
@@ -949,7 +949,7 @@ func (svc *Service) getOrCreatePreassignTeam(ctx context.Context, groups []strin
 				},
 			},
 		}
-		if _, err := svc.ApplyTeamSpecs(ctx, []*fleet.TeamSpec{spec}, fleet.ApplySpecOptions{}); err != nil {
+		if _, err := svc.ApplyTeamSpecs(ctx, []*fleet.TeamSpec{spec}, fleet.ApplyTeamSpecOptions{}); err != nil {
 			return nil, err
 		}
 		if err := svc.ds.CopyDefaultMDMAppleBootstrapPackage(ctx, ac, team.ID); err != nil {

--- a/ee/server/service/mdm_external_test.go
+++ b/ee/server/service/mdm_external_test.go
@@ -423,7 +423,7 @@ func TestGetOrCreatePreassignTeam(t *testing.T) {
 		spec := &fleet.TeamSpec{
 			Name: team2.Name,
 		}
-		_, err := svc.ApplyTeamSpecs(ctx, []*fleet.TeamSpec{spec}, fleet.ApplySpecOptions{})
+		_, err := svc.ApplyTeamSpecs(ctx, []*fleet.TeamSpec{spec}, fleet.ApplyTeamSpecOptions{})
 		require.NoError(t, err)
 		require.True(t, ds.SaveTeamFuncInvoked)
 		require.True(t, ds.AppConfigFuncInvoked)
@@ -522,7 +522,7 @@ func TestGetOrCreatePreassignTeam(t *testing.T) {
 		}
 
 		// apply team spec creates new team without defaults
-		_, err := svc.ApplyTeamSpecs(ctx, []*fleet.TeamSpec{spec}, fleet.ApplySpecOptions{})
+		_, err := svc.ApplyTeamSpecs(ctx, []*fleet.TeamSpec{spec}, fleet.ApplyTeamSpecOptions{})
 		require.NoError(t, err)
 		require.True(t, ds.NewTeamFuncInvoked)
 		require.True(t, ds.AppConfigFuncInvoked)
@@ -535,7 +535,7 @@ func TestGetOrCreatePreassignTeam(t *testing.T) {
 
 		// apply team spec edits existing team without applying defaults
 		spec.MDM.MacOSUpdates.Deadline = optjson.SetString("2025-01-01")
-		_, err = svc.ApplyTeamSpecs(ctx, []*fleet.TeamSpec{spec}, fleet.ApplySpecOptions{})
+		_, err = svc.ApplyTeamSpecs(ctx, []*fleet.TeamSpec{spec}, fleet.ApplyTeamSpecOptions{})
 		require.NoError(t, err)
 		require.True(t, ds.SaveTeamFuncInvoked)
 		require.True(t, ds.AppConfigFuncInvoked)

--- a/pkg/spec/spec.go
+++ b/pkg/spec/spec.go
@@ -24,9 +24,10 @@ type Group struct {
 	Policies []*fleet.PolicySpec
 	// This needs to be interface{} to allow for the patch logic. Otherwise we send a request that looks to the
 	// server like the user explicitly set the zero values.
-	AppConfig    interface{}
-	EnrollSecret *fleet.EnrollSecretSpec
-	UsersRoles   *fleet.UsersRoleSpec
+	AppConfig              interface{}
+	EnrollSecret           *fleet.EnrollSecretSpec
+	UsersRoles             *fleet.UsersRoleSpec
+	TeamsDryRunAssumptions *fleet.TeamSpecsDryRunAssumptions
 }
 
 // Metadata holds the metadata for a single YAML section/item.

--- a/server/datastore/mysql/mysql.go
+++ b/server/datastore/mysql/mysql.go
@@ -971,7 +971,7 @@ func (ds *Datastore) whereFilterTeams(filter fleet.TeamFilter, teamKey string) s
 
 	if filter.User.GlobalRole != nil {
 		switch *filter.User.GlobalRole {
-		case fleet.RoleAdmin, fleet.RoleMaintainer, fleet.RoleObserverPlus:
+		case fleet.RoleAdmin, fleet.RoleMaintainer, fleet.RoleGitOps, fleet.RoleObserverPlus:
 			return "TRUE"
 		case fleet.RoleObserver:
 			if filter.IncludeObserver {
@@ -988,6 +988,7 @@ func (ds *Datastore) whereFilterTeams(filter fleet.TeamFilter, teamKey string) s
 	for _, team := range filter.User.Teams {
 		if team.Role == fleet.RoleAdmin ||
 			team.Role == fleet.RoleMaintainer ||
+			team.Role == fleet.RoleGitOps ||
 			team.Role == fleet.RoleObserverPlus ||
 			(team.Role == fleet.RoleObserver && filter.IncludeObserver) {
 			idStrs = append(idStrs, strconv.Itoa(int(team.ID)))

--- a/server/fleet/app.go
+++ b/server/fleet/app.go
@@ -1035,6 +1035,11 @@ type ApplySpecOptions struct {
 	TeamForPolicies string
 }
 
+type ApplyTeamSpecOptions struct {
+	ApplySpecOptions
+	DryRunAssumptions *TeamSpecsDryRunAssumptions
+}
+
 // RawQuery returns the ApplySpecOptions url-encoded for use in an URL's
 // query string parameters. It only sets the parameters that are not the
 // default values.

--- a/server/fleet/service.go
+++ b/server/fleet/service.go
@@ -542,7 +542,7 @@ type Service interface {
 	ModifyTeamEnrollSecrets(ctx context.Context, teamID uint, secrets []EnrollSecret) ([]*EnrollSecret, error)
 	// ApplyTeamSpecs applies the changes for each team as defined in the specs.
 	// On success, it returns the mapping of team names to team ids.
-	ApplyTeamSpecs(ctx context.Context, specs []*TeamSpec, applyOpts ApplySpecOptions) (map[string]uint, error)
+	ApplyTeamSpecs(ctx context.Context, specs []*TeamSpec, applyOpts ApplyTeamSpecOptions) (map[string]uint, error)
 
 	// /////////////////////////////////////////////////////////////////////////////
 	// ActivitiesService
@@ -931,7 +931,7 @@ type Service interface {
 	// team or for hosts with no team.
 	BatchSetMDMProfiles(
 		ctx context.Context, teamID *uint, teamName *string, profiles []MDMProfileBatchPayload, dryRun bool, skipBulkPending bool,
-		assumeEnabled bool,
+		assumeEnabled *bool,
 	) error
 
 	///////////////////////////////////////////////////////////////////////////////

--- a/server/fleet/teams.go
+++ b/server/fleet/teams.go
@@ -425,6 +425,11 @@ type TeamSpecIntegrations struct {
 	GoogleCalendar *TeamGoogleCalendarIntegration `json:"google_calendar"`
 }
 
+// TeamSpecsDryRunAssumptions holds the assumptions that are made when applying team specs in dry-run mode.
+type TeamSpecsDryRunAssumptions struct {
+	WindowsEnabledAndConfigured optjson.Bool `json:"windows_enabled_and_configured,omitempty"`
+}
+
 // TeamSpecFromTeam returns a TeamSpec constructed from the given Team.
 func TeamSpecFromTeam(t *Team) (*TeamSpec, error) {
 	features, err := json.Marshal(t.Config.Features)

--- a/server/service/client.go
+++ b/server/service/client.go
@@ -1043,10 +1043,10 @@ func (c *Client) DoGitOps(
 	if appConfig.License.IsPremium() {
 		windowsUpdates := mdmAppConfig["windows_updates"].(map[string]interface{})
 		if deadlineDays, ok := windowsUpdates["deadline_days"]; !ok || deadlineDays == nil {
-			windowsUpdates["deadline_days"] = 0
+			windowsUpdates["deadline_days"] = nil
 		}
 		if gracePeriodDays, ok := windowsUpdates["grace_period_days"]; !ok || gracePeriodDays == nil {
-			windowsUpdates["grace_period_days"] = 0
+			windowsUpdates["grace_period_days"] = nil
 		}
 	}
 	// Put in default value for enable_disk_encryption

--- a/server/service/client.go
+++ b/server/service/client.go
@@ -544,7 +544,11 @@ func (c *Client) ApplyGroup(
 		// Next, apply the teams specs before saving the profiles, so that any
 		// non-existing team gets created.
 		var err error
-		teamIDsByName, err = c.ApplyTeams(specs.Teams, opts)
+		teamOpts := fleet.ApplyTeamSpecOptions{
+			ApplySpecOptions:  opts,
+			DryRunAssumptions: specs.TeamsDryRunAssumptions,
+		}
+		teamIDsByName, err = c.ApplyTeams(specs.Teams, teamOpts)
 		if err != nil {
 			return nil, fmt.Errorf("applying teams: %w", err)
 		}
@@ -556,7 +560,7 @@ func (c *Client) ApplyGroup(
 					logfn("[+] would've applied MDM profiles for new team %s\n", tmName)
 				} else {
 					logfn("[+] applying MDM profiles for team %s\n", tmName)
-					if err := c.ApplyTeamProfiles(tmName, profs, opts); err != nil {
+					if err := c.ApplyTeamProfiles(tmName, profs, teamOpts); err != nil {
 						return nil, fmt.Errorf("applying custom settings for team %q: %w", tmName, err)
 					}
 				}
@@ -870,8 +874,10 @@ func (c *Client) DoGitOps(
 	baseDir string,
 	logf func(format string, args ...interface{}),
 	dryRun bool,
+	teamDryRunAssumptions *fleet.TeamSpecsDryRunAssumptions,
 	appConfig *fleet.EnrichedAppConfig,
-) error {
+) (*fleet.TeamSpecsDryRunAssumptions, error) {
+	var teamAssumptions *fleet.TeamSpecsDryRunAssumptions
 	var err error
 	logFn := func(format string, args ...interface{}) {
 		if logf != nil {
@@ -916,7 +922,7 @@ func (c *Client) DoGitOps(
 		}
 		mdmAppConfig, ok = mdmConfig.(map[string]interface{})
 		if !ok {
-			return errors.New("org_settings.mdm config is not a map")
+			return nil, errors.New("org_settings.mdm config is not a map")
 		}
 
 		// Put in default values for macos_migration
@@ -935,6 +941,11 @@ func (c *Client) DoGitOps(
 			mdmAppConfig["windows_enabled_and_configured"] = config.Controls.WindowsEnabledAndConfigured
 		} else {
 			mdmAppConfig["windows_enabled_and_configured"] = false
+		}
+		if windowsEnabledAndConfiguredAssumption, ok := mdmAppConfig["windows_enabled_and_configured"].(bool); ok {
+			teamAssumptions = &fleet.TeamSpecsDryRunAssumptions{
+				WindowsEnabledAndConfigured: optjson.SetBool(windowsEnabledAndConfiguredAssumption),
+			}
 		}
 		group.AppConfig.(map[string]interface{})["scripts"] = scripts
 	} else {
@@ -970,14 +981,14 @@ func (c *Client) DoGitOps(
 		team["integrations"] = integrations
 		_, ok = integrations.(map[string]interface{})
 		if !ok {
-			return errors.New("team_settings.integrations config is not a map")
+			return nil, errors.New("team_settings.integrations config is not a map")
 		}
 		if googleCal, ok := integrations.(map[string]interface{})["google_calendar"]; !ok || googleCal == nil {
 			integrations.(map[string]interface{})["google_calendar"] = map[string]interface{}{}
 		} else {
 			_, ok = googleCal.(map[string]interface{})
 			if !ok {
-				return errors.New("team_settings.integrations.google_calendar config is not a map")
+				return nil, errors.New("team_settings.integrations.google_calendar config is not a map")
 			}
 		}
 
@@ -1058,39 +1069,40 @@ func (c *Client) DoGitOps(
 	if config.TeamName != nil {
 		rawTeam, err := json.Marshal(team)
 		if err != nil {
-			return fmt.Errorf("error marshalling team spec: %w", err)
+			return nil, fmt.Errorf("error marshalling team spec: %w", err)
 		}
 		group.Teams = []json.RawMessage{rawTeam}
+		group.TeamsDryRunAssumptions = teamDryRunAssumptions
 	}
 
 	// Apply org settings, scripts, enroll secrets, and controls
 	teamIDsByName, err := c.ApplyGroup(ctx, &group, baseDir, logf, fleet.ApplySpecOptions{DryRun: dryRun})
 	if err != nil {
-		return err
+		return nil, err
 	}
 	if config.TeamName != nil {
 		teamID, ok := teamIDsByName[*config.TeamName]
 		if !ok || teamID == 0 {
 			if dryRun {
 				logFn("[+] would've added any policies/queries to new team %s\n", *config.TeamName)
-				return nil
+				return nil, nil
 			}
-			return fmt.Errorf("team %s not created", *config.TeamName)
+			return nil, fmt.Errorf("team %s not created", *config.TeamName)
 		}
 		config.TeamID = &teamID
 	}
 
 	err = c.doGitOpsPolicies(config, logFn, dryRun)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	err = c.doGitOpsQueries(config, logFn, dryRun)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	return nil
+	return teamAssumptions, nil
 }
 
 func (c *Client) doGitOpsPolicies(config *spec.GitOps, logFn func(format string, args ...interface{}), dryRun bool) error {

--- a/server/service/client_teams.go
+++ b/server/service/client_teams.go
@@ -52,10 +52,14 @@ func (c *Client) DeleteTeam(teamID uint) error {
 
 // ApplyTeams sends the list of Teams to be applied to the
 // Fleet instance.
-func (c *Client) ApplyTeams(specs []json.RawMessage, opts fleet.ApplySpecOptions) (map[string]uint, error) {
+func (c *Client) ApplyTeams(specs []json.RawMessage, opts fleet.ApplyTeamSpecOptions) (map[string]uint, error) {
 	verb, path := "POST", "/api/latest/fleet/spec/teams"
 	var responseBody applyTeamSpecsResponse
-	err := c.authenticatedRequestWithQuery(map[string]interface{}{"specs": specs}, verb, path, &responseBody, opts.RawQuery())
+	params := map[string]interface{}{"specs": specs}
+	if opts.DryRun && opts.DryRunAssumptions != nil {
+		params["dry_run_assumptions"] = opts.DryRunAssumptions
+	}
+	err := c.authenticatedRequestWithQuery(params, verb, path, &responseBody, opts.RawQuery())
 	if err != nil {
 		return nil, err
 	}
@@ -64,13 +68,16 @@ func (c *Client) ApplyTeams(specs []json.RawMessage, opts fleet.ApplySpecOptions
 
 // ApplyTeamProfiles sends the list of profiles to be applied for the specified
 // team.
-func (c *Client) ApplyTeamProfiles(tmName string, profiles []fleet.MDMProfileBatchPayload, opts fleet.ApplySpecOptions) error {
+func (c *Client) ApplyTeamProfiles(tmName string, profiles []fleet.MDMProfileBatchPayload, opts fleet.ApplyTeamSpecOptions) error {
 	verb, path := "POST", "/api/latest/fleet/mdm/profiles/batch"
 	query, err := url.ParseQuery(opts.RawQuery())
 	if err != nil {
 		return err
 	}
 	query.Add("team_name", tmName)
+	if opts.DryRunAssumptions != nil && opts.DryRunAssumptions.WindowsEnabledAndConfigured.Valid {
+		query.Add("assume_enabled", strconv.FormatBool(opts.DryRunAssumptions.WindowsEnabledAndConfigured.Value))
+	}
 	return c.authenticatedRequestWithQuery(map[string]interface{}{"profiles": profiles}, verb, path, nil, query.Encode())
 }
 

--- a/server/service/mdm_test.go
+++ b/server/service/mdm_test.go
@@ -1394,7 +1394,7 @@ func TestMDMBatchSetProfiles(t *testing.T) {
 			}
 			ctx = license.NewContext(ctx, &fleet.LicenseInfo{Tier: tier})
 
-			err := svc.BatchSetMDMProfiles(ctx, tt.teamID, tt.teamName, tt.profiles, false, false, false)
+			err := svc.BatchSetMDMProfiles(ctx, tt.teamID, tt.teamName, tt.profiles, false, false, nil)
 			if tt.wantErr == "" {
 				require.NoError(t, err)
 				require.True(t, ds.BatchSetMDMProfilesFuncInvoked)

--- a/server/service/teams_test.go
+++ b/server/service/teams_test.go
@@ -187,7 +187,7 @@ func TestTeamAuth(t *testing.T) {
 			_, err = svc.ModifyTeamEnrollSecrets(ctx, 1, []fleet.EnrollSecret{{Secret: "newteamsecret", CreatedAt: time.Now()}})
 			checkAuthErr(t, tt.shouldFailTeamSecretsWrite, err)
 
-			_, err = svc.ApplyTeamSpecs(ctx, []*fleet.TeamSpec{{Name: "team1"}}, fleet.ApplySpecOptions{})
+			_, err = svc.ApplyTeamSpecs(ctx, []*fleet.TeamSpec{{Name: "team1"}}, fleet.ApplyTeamSpecOptions{})
 			checkAuthErr(t, tt.shouldFailTeamWrite, err)
 		})
 	}
@@ -281,7 +281,7 @@ func TestApplyTeamSpecs(t *testing.T) {
 					return nil
 				}
 
-				_, err := svc.ApplyTeamSpecs(ctx, []*fleet.TeamSpec{{Name: "team1", Features: tt.spec}}, fleet.ApplySpecOptions{})
+				_, err := svc.ApplyTeamSpecs(ctx, []*fleet.TeamSpec{{Name: "team1", Features: tt.spec}}, fleet.ApplyTeamSpecOptions{})
 				require.NoError(t, err)
 			})
 		}
@@ -362,7 +362,9 @@ func TestApplyTeamSpecs(t *testing.T) {
 					return nil
 				}
 
-				idsByTeam, err := svc.ApplyTeamSpecs(ctx, []*fleet.TeamSpec{{Name: "team1", Features: tt.spec}}, fleet.ApplySpecOptions{})
+				idsByTeam, err := svc.ApplyTeamSpecs(
+					ctx, []*fleet.TeamSpec{{Name: "team1", Features: tt.spec}}, fleet.ApplyTeamSpecOptions{},
+				)
 				require.NoError(t, err)
 				require.Len(t, idsByTeam, 1)
 				require.Equal(t, uint(123), idsByTeam["team1"])
@@ -398,7 +400,7 @@ func TestApplyTeamSpecEnrollSecretForNewTeams(t *testing.T) {
 			return &fleet.Team{ID: 1}, nil
 		}
 
-		_, err := svc.ApplyTeamSpecs(ctx, []*fleet.TeamSpec{{Name: "Foo"}}, fleet.ApplySpecOptions{})
+		_, err := svc.ApplyTeamSpecs(ctx, []*fleet.TeamSpec{{Name: "Foo"}}, fleet.ApplyTeamSpecOptions{})
 		require.NoError(t, err)
 		require.True(t, ds.TeamByNameFuncInvoked)
 		require.True(t, ds.NewTeamFuncInvoked)
@@ -413,7 +415,9 @@ func TestApplyTeamSpecEnrollSecretForNewTeams(t *testing.T) {
 			return &fleet.Team{ID: 1}, nil
 		}
 
-		_, err := svc.ApplyTeamSpecs(ctx, []*fleet.TeamSpec{{Name: "Foo", Secrets: []fleet.EnrollSecret{enrollSecret}}}, fleet.ApplySpecOptions{})
+		_, err := svc.ApplyTeamSpecs(
+			ctx, []*fleet.TeamSpec{{Name: "Foo", Secrets: []fleet.EnrollSecret{enrollSecret}}}, fleet.ApplyTeamSpecOptions{},
+		)
 		require.NoError(t, err)
 		require.True(t, ds.TeamByNameFuncInvoked)
 		require.True(t, ds.NewTeamFuncInvoked)
@@ -436,7 +440,7 @@ func TestApplyTeamSpecsErrorInTeamByName(t *testing.T) {
 	}
 	authzctx := &authz_ctx.AuthorizationContext{}
 	ctx = authz_ctx.NewContext(ctx, authzctx)
-	_, err := svc.ApplyTeamSpecs(ctx, []*fleet.TeamSpec{{Name: "Foo"}}, fleet.ApplySpecOptions{})
+	_, err := svc.ApplyTeamSpecs(ctx, []*fleet.TeamSpec{{Name: "Foo"}}, fleet.ApplyTeamSpecOptions{})
 	require.Error(t, err)
 	az, ok := authz_ctx.FromContext(ctx)
 	require.True(t, ok)

--- a/tools/mdm/apple/loadtest/loadtest.go
+++ b/tools/mdm/apple/loadtest/loadtest.go
@@ -112,7 +112,7 @@ func main() {
 
 	for _, team := range teams {
 		printf("Applying profiles to team %s...\n", team.Name)
-		if err := apiClient.ApplyTeamProfiles(team.Name, profiles, fleet.ApplySpecOptions{}); err != nil {
+		if err := apiClient.ApplyTeamProfiles(team.Name, profiles, fleet.ApplyTeamSpecOptions{}); err != nil {
 			log.Fatalf("apply profiles to team %s: %s", team.Name, err)
 		}
 	}
@@ -217,7 +217,7 @@ func main() {
 		start = time.Now()
 
 		for _, team := range extraTeams {
-			if err := apiClient.ApplyTeamProfiles(team.Name, profiles, fleet.ApplySpecOptions{}); err != nil {
+			if err := apiClient.ApplyTeamProfiles(team.Name, profiles, fleet.ApplyTeamSpecOptions{}); err != nil {
 				log.Fatalf("apply profiles to extra team %s: %s", team.Name, err)
 			}
 		}


### PR DESCRIPTION
#16677 

Improvements to `fleetctl gitops` command:
- Added the ability to pass multiple files, like `fleetctl gitops -f file1 -f file2`, where the first file must be the global configuration
- Added the ability to remove teams that were not specified in team configs using the switch `--delete-other-teams`
- When passing a global config and team config during initial configuration, the `org_settings.mdm.apple_bm_default_team` value can be set to match the team that will be created by the provided team config.

After these changes are released to prod, we can update https://github.com/fleetdm/fleet-gitops to use the new switches: #18692

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [x] Added/updated tests
- [x] Manual QA for all new/changed functionality
