### PR TITLE
Website: Update zapier webhook request in signup action.

### DIFF
--- a/website/api/controllers/entrance/signup.js
+++ b/website/api/controllers/entrance/signup.js
@@ -139,7 +139,7 @@ the account verification message.)`,
     .fetch();
 
 
-    await sails.helpers.salesforce.updateOrCreateContactAndAccount.with({
+    let recordIds = await sails.helpers.salesforce.updateOrCreateContactAndAccount.with({
       emailAddress: newEmailAddress,
       firstName: firstName,
       lastName: lastName,
@@ -155,6 +155,8 @@ the account verification message.)`,
         lastName,
         organization,
         signupReason,
+        salesforceContactId: recordIds.salesforceContactId,
+        salesforceAccountId: recordIds.salesforceAccountId,
         webhookSecret: sails.config.custom.zapierSandboxWebhookSecret,
       }
     })

--- a/website/api/helpers/salesforce/update-or-create-contact-and-account.js
+++ b/website/api/helpers/salesforce/update-or-create-contact-and-account.js
@@ -47,7 +47,10 @@ module.exports = {
   fn: async function ({emailAddress, linkedinUrl, firstName, lastName, organization, primaryBuyingSituation, psychologicalStage}) {
     if(sails.config.environment !== 'production') {
       sails.log.verbose('Skipping Salesforce integration...');
-      return;
+      return {
+        salesforceAccountId: undefined,
+        salesforceContactId: undefined
+      };
     }
 
     require('assert')(sails.config.custom.salesforceIntegrationUsername);


### PR DESCRIPTION
Closes: #18643

Changes:
- Updated the response from the `updateOrCreateAccountAndContact` helper when running the website in a development environment.
- Updated the Zapier webhook request in the signup action to send the contact and account IDs returned from the  `updateOrCreateAccountAndContact` helper.