### PR TITLE
Fleet UI fix: Input is treated as strings but send number to API

### DIFF
--- a/changes/18605-host-expiry-window-setting
+++ b/changes/18605-host-expiry-window-setting
@@ -1,0 +1,1 @@
+- UI: Fix host expiry window setting to be able to save

--- a/frontend/pages/admin/OrgSettingsPage/cards/Advanced/Advanced.tsx
+++ b/frontend/pages/admin/OrgSettingsPage/cards/Advanced/Advanced.tsx
@@ -20,7 +20,7 @@ interface IAdvancedConfigFormData {
   verifySSLCerts: boolean;
   enableStartTLS?: boolean;
   enableHostExpiry: boolean;
-  hostExpiryWindow: number;
+  hostExpiryWindow: string;
   deleteActivities: boolean;
   activityExpiryWindow: number;
   disableLiveQuery: boolean;
@@ -43,7 +43,10 @@ const Advanced = ({
     enableStartTLS: appConfig.smtp_settings?.enable_start_tls,
     enableHostExpiry:
       appConfig.host_expiry_settings.host_expiry_enabled || false,
-    hostExpiryWindow: appConfig.host_expiry_settings.host_expiry_window || 0,
+    hostExpiryWindow:
+      (appConfig.host_expiry_settings.host_expiry_window &&
+        appConfig.host_expiry_settings.host_expiry_window.toString()) ||
+      "0",
     deleteActivities:
       appConfig.activity_expiry_settings?.activity_expiry_enabled || false,
     activityExpiryWindow:
@@ -90,7 +93,10 @@ const Advanced = ({
     // validate desired form fields
     const errors: IAdvancedConfigFormErrors = {};
 
-    if (enableHostExpiry && (!hostExpiryWindow || hostExpiryWindow <= 0)) {
+    if (
+      enableHostExpiry &&
+      (!hostExpiryWindow || parseInt(hostExpiryWindow, 10) <= 0)
+    ) {
       errors.host_expiry_window =
         "Host expiry window must be a positive number";
     }
@@ -116,7 +122,7 @@ const Advanced = ({
       },
       host_expiry_settings: {
         host_expiry_enabled: enableHostExpiry,
-        host_expiry_window: hostExpiryWindow || undefined,
+        host_expiry_window: parseInt(hostExpiryWindow, 10) || undefined,
       },
       activity_expiry_settings: {
         activity_expiry_enabled: deleteActivities,


### PR DESCRIPTION
## Issue
Cerra bug #18605 

## Description
- Root cause: HTML input form fields treats input field fields as strings even though the API expects a number
- Solution: Type the key as a string while working with the input fields, and convert to a number when sent to the API

## Screen recording 
https://www.loom.com/share/4f3a048c03754b82ac3644543c78b6a9?sid=ae6bab9d-b0a9-46b2-a3d1-29bdfef6a058

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
- [x[ Manual QA for all new/changed functionality
- No test added because caught by E2E test already

