### PR TITLE
Update prompt for API endpoint to get human interpretation of osquery SQL

### DIFF
--- a/website/api/controllers/get-human-interpretation-from-osquery-sql.js
+++ b/website/api/controllers/get-human-interpretation-from-osquery-sql.js
@@ -56,7 +56,7 @@ Please give me all of the above in JSON, with this data shape:
 
 Please do not add any text outside of the JSON report or wrap it in a code fence.`;
 // > Note that this returns `whatWillHappenDuringMaintenance` instead of `whatWillProbablyHappenDuringMaintenance`.
-// > This naming gets better (more decisive-sounding) results from Open AI. We'll rename it for our final response.
+// > This naming gets a better (more decisive-sounding) result from Open AI. We'll rename it for our final response.
 
     // Fallback message in case LLM API request fails.
     let failureMessage = 'Failed to generate human interpretation using generative AI.';

--- a/website/api/controllers/get-human-interpretation-from-osquery-sql.js
+++ b/website/api/controllers/get-human-interpretation-from-osquery-sql.js
@@ -55,8 +55,8 @@ Please give me all of the above in JSON, with this data shape:
 }
 
 Please do not add any text outside of the JSON report or wrap it in a code fence.`;
-// > Note that this returns `whatWillHappenDuringMaintenance` instead of `whatWillProbablyHappenDuringMaintenance`.
-// > This naming gets a better (more decisive-sounding) result from Open AI. We'll rename it for our final response.
+    // > Note that this returns `whatWillHappenDuringMaintenance` instead of `whatWillProbablyHappenDuringMaintenance`.
+    // > This naming gets a better (more decisive-sounding) result from Open AI. We'll rename it for our final response.
 
     // Fallback message in case LLM API request fails.
     let failureMessage = 'Failed to generate human interpretation using generative AI.';

--- a/website/api/controllers/get-human-interpretation-from-osquery-sql.js
+++ b/website/api/controllers/get-human-interpretation-from-osquery-sql.js
@@ -51,10 +51,13 @@ Please give me all of the above in JSON, with this data shape:
 
 {
   risks: 'TODO',
-  whatWillProbablyHappenDuringMaintenance: 'TODO'
+  whatWillHappenDuringMaintenance: 'TODO'
 }
 
 Please do not add any text outside of the JSON report or wrap it in a code fence.`;
+// > Note that this returns `whatWillHappenDuringMaintenance` instead of `whatWillProbablyHappenDuringMaintenance`.
+// > This naming gets better (more decisive-sounding) results from Open AI. We'll rename it for our final response.
+
     // Fallback message in case LLM API request fails.
     let failureMessage = 'Failed to generate human interpretation using generative AI.';
 
@@ -90,6 +93,9 @@ Please do not add any text outside of the JSON report or wrap it in a code fence
     let report;
     try {
       report = JSON.parse(openAiResponse.choices[0].message.content);
+      // Change `whatWillHappenDuringMaintenance` to `whatWillProbablyHappenDuringMaintenance`
+      report.whatWillProbablyHappenDuringMaintenance = report.whatWillHappenDuringMaintenance;
+      delete report.whatWillHappenDuringMaintenance;
     } catch (err) {
       sails.log.warn('When trying to parse a JSON report returned from the Open AI API, an error occurred. Error details from JSON.parse: '+err.stack+'\n Report returned from Open AI:'+openAiResponse.choices[0].message.content);
       report = {


### PR DESCRIPTION
When using this API many times in a row to try and populate real policy descriptions/resolutions, I discovered a problem: the inferred resolution (“What we’ll do”) almost never used decisive language, so you'd get a lot of “probably”, etc., when we really want it to sound more confident about what will happen during the maintenance window. (The calendar events say what WILL happen to your device, not what should probably happen.)

After several attempts to tweak the prompt, I ended up getting the best results by just removing "probably" from `whatWillProbablyHappenDuringMaintenance`. I made this change to the prompt without changing the data that this API returns.