### PR TITLE
18525 Vulncheck Index API

### DIFF
--- a/changes/18525-vulncheck-index-api
+++ b/changes/18525-vulncheck-index-api
@@ -1,0 +1,1 @@
+- vulnerability processing now uses the Vulncheck Index API feed to gather CPEs more frequently

--- a/cmd/cve/generate.go
+++ b/cmd/cve/generate.go
@@ -129,6 +129,11 @@ func downloadLatestRelease(dbDir string, debug bool, logger log.Logger) error {
 		return fmt.Errorf("downloading last_mod_start_date asset: %w", err)
 	}
 
+	err = downloadLatestGitHubAsset(dbDir, "vc_last_mod_start_date.txt")
+	if err != nil {
+		return fmt.Errorf("downloading vc_last_mod_start_date asset: %w", err)
+	}
+
 	return nil
 }
 

--- a/server/vulnerabilities/nvd/sync/cve_syncer.go
+++ b/server/vulnerabilities/nvd/sync/cve_syncer.go
@@ -483,7 +483,7 @@ func (s *CVE) sync(ctx context.Context, lastModStartDate *string) (newLastModSta
 	return newLastModStartDate, nil
 }
 
-func (s *CVE) lastVCModStartDate(ctx context.Context) (*time.Time, error) {
+func (s *CVE) lastVCModStartDate() (*time.Time, error) {
 	f, err := os.ReadFile(s.lastVCModStartDateFilePath())
 	if err != nil {
 		return nil, err
@@ -515,13 +515,13 @@ func (s *CVE) updateVulnCheck(ctx context.Context, lastModStartDate *time.Time) 
 	return nil
 }
 
-func (s *CVE) syncVulncheckIndexCVEs(ctx context.Context, lastModStartDate *time.Time) (error) {
+func (s *CVE) syncVulncheckIndexCVEs(ctx context.Context, lastModStartDate *time.Time) error {
 	var (
-		baseURL         = "https://api.vulncheck.com/v3/index/nist-nvd2/cursor"
-		cursor          *string
-		cvesByYear      = make(map[int][]VulnCheckCVE)
-		modCount        = 0
-		addCount        = 0
+		baseURL    = "https://api.vulncheck.com/v3/index/nist-nvd2/cursor"
+		cursor     *string
+		cvesByYear = make(map[int][]VulnCheckCVE)
+		modCount   = 0
+		addCount   = 0
 	)
 
 	// If lastModStartDate is nil, it's assumed that the most recent VulnCheck

--- a/server/vulnerabilities/nvd/sync/cve_syncer.go
+++ b/server/vulnerabilities/nvd/sync/cve_syncer.go
@@ -483,20 +483,6 @@ func (s *CVE) sync(ctx context.Context, lastModStartDate *string) (newLastModSta
 	return newLastModStartDate, nil
 }
 
-func (s *CVE) lastVCModStartDate() (*time.Time, error) {
-	f, err := os.ReadFile(s.lastVCModStartDateFilePath())
-	if err != nil {
-		return nil, err
-	}
-
-	t, err := time.Parse("2006-01-02", string(f))
-	if err != nil {
-		return nil, err
-	}
-
-	return &t, nil
-}
-
 func (s *CVE) updateVulnCheck(ctx context.Context, lastModStartDate *time.Time) error {
 	if lastModStartDate != nil {
 		// Use the last mod start date to fetch the last 24 hours of data.

--- a/server/vulnerabilities/nvd/sync/cve_syncer.go
+++ b/server/vulnerabilities/nvd/sync/cve_syncer.go
@@ -483,6 +483,8 @@ func (s *CVE) sync(ctx context.Context, lastModStartDate *string) (newLastModSta
 	return newLastModStartDate, nil
 }
 
+// updateVulnCheck updates the NVD feeds with the latest VulnCheck data from the Index feed
+// based on the lastModStartDate and updates the lastModStartDate for the next synchronization.
 func (s *CVE) updateVulnCheck(ctx context.Context, lastModStartDate *time.Time) error {
 	if lastModStartDate != nil {
 		// Use the last mod start date to fetch the last 24 hours of data.
@@ -501,6 +503,8 @@ func (s *CVE) updateVulnCheck(ctx context.Context, lastModStartDate *time.Time) 
 	return nil
 }
 
+// syncVulncheckIndexCVEs iterates through the VulnCheck index cursor feed
+// and updates the NVD feeds with the latest VulnCheck data.
 func (s *CVE) syncVulncheckIndexCVEs(ctx context.Context, lastModStartDate *time.Time) error {
 	var (
 		baseURL    = "https://api.vulncheck.com/v3/index/nist-nvd2/cursor"
@@ -511,7 +515,7 @@ func (s *CVE) syncVulncheckIndexCVEs(ctx context.Context, lastModStartDate *time
 	)
 
 	// If lastModStartDate is nil, it's assumed that the most recent VulnCheck
-	// archive has been processed so only the last 24 hours of data needs to be
+	// archive has been processed so only the last day of data needs to be
 	// fetched.
 	if lastModStartDate == nil {
 		lastModStartDate = ptr.Time(time.Now().AddDate(0, 0, -1))
@@ -551,6 +555,7 @@ func (s *CVE) syncVulncheckIndexCVEs(ctx context.Context, lastModStartDate *time
 	return nil
 }
 
+// DoVulnCheckCheck runs the synchronization from the VulnCheck service to the local DB directory.
 func (s *CVE) DoVulnCheck(ctx context.Context) error {
 	ok, err := fileExists(s.lastVCModStartDateFilePath())
 	if err != nil {
@@ -583,6 +588,9 @@ func (s *CVE) DoVulnCheck(ctx context.Context) error {
 	return s.updateVulnCheck(ctx, &lastModStartDate)
 }
 
+// vulncheckArchiveSync downloads the latest VulnCheck archive from the VulnCheck API.
+// This is faster than fetching bulk data from the index feed and only runs
+// with VULNERABILITIES_CLEAN=true.
 func (s *CVE) vulncheckArchiveSync(ctx context.Context) error {
 	vulnCheckArchive := "vulncheck.zip"
 	baseURL := "https://api.vulncheck.com/v3/backup/nist-nvd2"

--- a/server/vulnerabilities/nvd/sync/cve_syncer.go
+++ b/server/vulnerabilities/nvd/sync/cve_syncer.go
@@ -534,7 +534,7 @@ func (s *CVE) syncVulncheckIndexCVEs(ctx context.Context, lastModStartDate *time
 	level.Debug(s.logger).Log("msg", "using last mod start date", "date", lastModStartDate)
 
 	for {
-		vcr, err := s.getVulnCheckIndexCVEs(ctx, s.client, &baseURL, cursor, *lastModStartDate)
+		vcr, err := s.getVulnCheckIndexCVEs(ctx, &baseURL, cursor, *lastModStartDate)
 		if err != nil {
 			return fmt.Errorf("error getting VulnCheck index CVEs: %w", err)
 		}

--- a/server/vulnerabilities/nvd/sync/vulncheck_api.go
+++ b/server/vulnerabilities/nvd/sync/vulncheck_api.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/fleetdm/fleet/v4/server/contexts/ctxerr"
 	"github.com/go-kit/log/level"
 	"github.com/pandatix/nvdapi/v2"
 )
@@ -45,7 +46,7 @@ type VulnCheckResponseMeta struct {
 func (s *CVE) getVulnCheckIndexCVEs(ctx context.Context, url, cursor *string, lastModStartDate time.Time) (VulnCheckResponse, error) {
 	apiKey := os.Getenv("VULNCHECK_API_KEY")
 	if apiKey == "" {
-		return VulnCheckResponse{}, fmt.Errorf("VULNCHECK_API_KEY is not set")
+		return VulnCheckResponse{}, ctxerr.New(ctx, "VULNCHECK_API_KEY not set")
 	}
 	var vcr VulnCheckResponse
 
@@ -96,5 +97,5 @@ func (s *CVE) getVulnCheckIndexCVEs(ctx context.Context, url, cursor *string, la
 		return vcr, nil
 	}
 
-	return vcr, fmt.Errorf("reached max retry attempts")
+	return vcr, ctxerr.New(ctx, "reach max retry attempts")
 }

--- a/server/vulnerabilities/nvd/sync/vulncheck_api.go
+++ b/server/vulnerabilities/nvd/sync/vulncheck_api.go
@@ -42,7 +42,7 @@ type VulnCheckResponseMeta struct {
 	NextCursor string `json:"next_cursor"`
 }
 
-func (s *CVE) getVulnCheckIndexCVEs(ctx context.Context, c *http.Client, url, cursor *string, lastModStartDate time.Time) (VulnCheckResponse, error) {
+func (s *CVE) getVulnCheckIndexCVEs(ctx context.Context, url, cursor *string, lastModStartDate time.Time) (VulnCheckResponse, error) {
 	apiKey := os.Getenv("VULNCHECK_API_KEY")
 	if apiKey == "" {
 		return VulnCheckResponse{}, fmt.Errorf("VULNCHECK_API_KEY is not set")
@@ -66,7 +66,7 @@ func (s *CVE) getVulnCheckIndexCVEs(ctx context.Context, c *http.Client, url, cu
 
 	for attempt := 0; attempt < s.MaxTryAttempts; attempt++ {
 		start := time.Now()
-		resp, err := c.Do(req)
+		resp, err := s.client.Do(req)
 		if err != nil {
 			if attempt < s.MaxTryAttempts-1 {
 				level.Debug(s.logger).Log("msg", "Failed to do request", "attempt", attempt, "error", err)

--- a/server/vulnerabilities/nvd/sync/vulncheck_api.go
+++ b/server/vulnerabilities/nvd/sync/vulncheck_api.go
@@ -65,7 +65,6 @@ func (s *CVE) getVulnCheckIndexCVEs(ctx context.Context, url, cursor *string, la
 	if cursor != nil {
 		q.Add("cursor", *cursor)
 	}
-	q.Add("limit", "50")
 	q.Add("lastModStartDate", lastModStartDate.Format("2006-01-02"))
 	req.URL.RawQuery = q.Encode()
 

--- a/server/vulnerabilities/nvd/sync/vulncheck_api.go
+++ b/server/vulnerabilities/nvd/sync/vulncheck_api.go
@@ -1,6 +1,13 @@
 package nvdsync
 
-import "github.com/pandatix/nvdapi/v2"
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/pandatix/nvdapi/v2"
+)
 
 type VulnCheckCVEItem struct {
 	Item VulnCheckCVE `json:"cve"`
@@ -21,4 +28,46 @@ type VulnCheckBackupData struct {
 
 type VulnCheckBackupDataFile struct {
 	Vulnerabilities []VulnCheckCVEItem `json:"vulnerabilities"`
+}
+
+type VulnCheckResponse struct {
+	Meta VulnCheckResponseMeta `json:"_meta"`
+	Data []VulnCheckCVE        `json:"data"`
+}
+
+type VulnCheckResponseMeta struct {
+	NextCursor string `json:"next_cursor"`
+}
+
+func getVulnCheckIndexCVEs(c *http.Client, url, cursor *string, lastModStartDate time.Time) (VulnCheckResponse, error) {
+	var vcr VulnCheckResponse
+
+	req, err := http.NewRequest(http.MethodGet, *url, nil)
+	if err != nil {
+		return vcr, err
+	}
+
+	q := req.URL.Query()
+	if cursor != nil {
+		q.Add("cursor", *cursor)
+	}
+	q.Add("lastModStartDate", lastModStartDate.Format("2006-01-02"))
+
+	resp, err := c.Do(req)
+	if err != nil {
+		return vcr, fmt.Errorf("do request: %w", err)
+	}
+
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return vcr, err
+	}
+
+	err = json.NewDecoder(resp.Body).Decode(&vcr)
+	if err != nil {
+		return vcr, fmt.Errorf("decode response: %w", err)
+	}
+
+	return vcr, nil
 }

--- a/server/vulnerabilities/nvd/sync/vulncheck_api_test.go
+++ b/server/vulnerabilities/nvd/sync/vulncheck_api_test.go
@@ -1,0 +1,151 @@
+package nvdsync
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/fleetdm/fleet/v4/server/ptr"
+	"github.com/stretchr/testify/require"
+)
+
+func TestVulncheckIndexAPI(t *testing.T) {
+	vResp := `
+{
+    "_benchmark": 0.043638,
+    "_meta": {
+        "timestamp": "2024-04-29T18:54:33.9958854Z",
+        "index": "nist-nvd2",
+        "limit": 1,
+        "total_documents": 1,
+        "sort": "_id",
+        "parameters": [
+            {
+                "name": "cve",
+                "format": "CVE-YYYY-N{4-7}"
+            },
+            {
+                "name": "alias"
+            },
+            {
+                "name": "iava",
+                "format": "[0-9]{4}[A-Z-0-9]+"
+            },
+            {
+                "name": "threat_actor"
+            },
+            {
+                "name": "mitre_id"
+            },
+            {
+                "name": "misp_id"
+            },
+            {
+                "name": "ransomware"
+            },
+            {
+                "name": "botnet"
+            },
+            {
+                "name": "published"
+            },
+            {
+                "name": "lastModStartDate",
+                "format": "2024-04-29"
+            },
+            {
+                "name": "lastModEndDate",
+                "format": "YYYY-MM-DD"
+            }
+        ],
+        "order": "desc",
+        "next_cursor": "Q1ZFLTIwMjItNDg2NDc="
+    },
+    "data": [
+        {
+            "id": "CVE-2024-23205",
+            "sourceIdentifier": "product-security@apple.com",
+            "vulnStatus": "Awaiting Analysis",
+            "published": "2024-03-08T02:15:47.393",
+            "lastModified": "2024-03-13T21:15:55.680",
+            "descriptions": [
+                {
+                    "lang": "en",
+                    "value": "A privacy issue was addressed with improved private data redaction for log entries. This issue is fixed in macOS Sonoma 14.4, iOS 17.4 and iPadOS 17.4. An app may be able to access sensitive user data."
+                },
+                {
+                    "lang": "es",
+                    "value": "Se solucionó un problema de privacidad mejorando la redacción de datos privados para las entradas de registro. Este problema se solucionó en macOS Sonoma 14.4, iOS 17.4 y iPadOS 17.4. Es posible que una aplicación pueda acceder a datos confidenciales del usuario."
+                }
+            ],
+            "references": [
+                {
+                    "url": "http://seclists.org/fulldisclosure/2024/Mar/21",
+                    "source": "product-security@apple.com"
+                },
+                {
+                    "url": "https://support.apple.com/en-us/HT214081",
+                    "source": "product-security@apple.com"
+                },
+                {
+                    "url": "https://support.apple.com/en-us/HT214084",
+                    "source": "product-security@apple.com"
+                }
+            ],
+            "metrics": {},
+            "vcConfigurations": [
+                {
+                    "nodes": [
+                        {
+                            "cpeMatch": [
+                                {
+                                    "vulnerable": true,
+                                    "criteria": "cpe:2.3:o:apple:macos:*:*:*:*:*:*:*:*",
+                                    "versionEndExcluding": "14.4",
+                                    "matchCriteriaId": ""
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "nodes": [
+                        {
+                            "cpeMatch": [
+                                {
+                                    "vulnerable": true,
+                                    "criteria": "cpe:2.3:o:apple:iphone_os:*:*:*:*:*:*:*:*",
+                                    "versionEndExcluding": "17.4",
+                                    "matchCriteriaId": ""
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ],
+            "vcVulnerableCPEs": [
+                "cpe:2.3:o:apple:macos:1.0:*:*:*:*:*:*:*"
+            ],
+            "_timestamp": "2024-04-22T01:15:22.872714Z"
+        }
+    ]
+}
+`
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(vResp))
+	}))
+	defer server.Close()
+
+	client := server.Client()
+
+	resp, err := getVulnCheckIndexCVEs(client, &server.URL, nil, time.Now())
+	require.NoError(t, err)
+
+	require.Equal(t, "Q1ZFLTIwMjItNDg2NDc=", resp.Meta.NextCursor)
+	require.Len(t, resp.Data, 1)
+	require.Equal(t, ptr.String("CVE-2024-23205"), resp.Data[0].ID)
+	require.Len(t, resp.Data[0].VcConfigurations, 2)
+}

--- a/server/vulnerabilities/nvd/sync/vulncheck_api_test.go
+++ b/server/vulnerabilities/nvd/sync/vulncheck_api_test.go
@@ -138,7 +138,7 @@ func TestVulncheckIndexAPI(t *testing.T) {
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte(vResp))
+		_, _ = w.Write([]byte(vResp))
 	}))
 	defer server.Close()
 

--- a/server/vulnerabilities/nvd/sync/vulncheck_api_test.go
+++ b/server/vulnerabilities/nvd/sync/vulncheck_api_test.go
@@ -1,12 +1,15 @@
 package nvdsync
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 	"time"
 
+	"github.com/fleetdm/fleet/v4/pkg/fleethttp"
 	"github.com/fleetdm/fleet/v4/server/ptr"
+	"github.com/go-kit/kit/log"
 	"github.com/stretchr/testify/require"
 )
 
@@ -139,9 +142,15 @@ func TestVulncheckIndexAPI(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := server.Client()
+	s := CVE{
+		client:           fleethttp.NewClient(),
+		dbDir:            "/tmp",
+		logger:           log.NewNopLogger(),
+		MaxTryAttempts:   3,
+		WaitTimeForRetry: 1 * time.Second,
+	}
 
-	resp, err := getVulnCheckIndexCVEs(client, &server.URL, nil, time.Now())
+	resp, err := s.getVulnCheckIndexCVEs(context.Background(), &server.URL, nil, time.Now())
 	require.NoError(t, err)
 
 	require.Equal(t, "Q1ZFLTIwMjItNDg2NDc=", resp.Meta.NextCursor)


### PR DESCRIPTION
#18525 

Currently we fetch Vulncheck data from the archive feed (bulk download of JSON files), but it was discovered that the archive feed is not as recent as the Vulncheck Index feed.  This change uses the Index API to fetch recent data as it supports `lastModStartDate` in YYYY-MM-DD format, which (like we do with the NVD feed) we store the date in a text file in the release.  We still use the archive feed for "clean" runs, and then fetch the last day of data from the Index feed, but most runs will fetch the last release and append with the last day `time.Now() -1` of data. 

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [X] Added/updated tests
- [X] Manual QA for all new/changed functionality
 