### PR TITLE
Per Figma, using default policy description/resolution if either is missing.

### DIFF
--- a/server/cron/calendar_cron.go
+++ b/server/cron/calendar_cron.go
@@ -616,8 +616,7 @@ func getCalendarEventDescriptionAndResolution(
 
 	var description, resolution string
 	policyIDs := strings.Split(host.FailingPolicyIDs, ",")
-	switch {
-	case len(policyIDs) == 1 && policyIDs[0] != "":
+	if len(policyIDs) == 1 && policyIDs[0] != "" {
 		var policy *fleet.PolicyLite
 		policyAny, ok := policyIDtoPolicy.Load(policyIDs[0])
 		if !ok {
@@ -636,22 +635,14 @@ func getCalendarEventDescriptionAndResolution(
 			policy = policyAny.(*fleet.PolicyLite)
 		}
 		policyDescription := strings.TrimSpace(policy.Description)
-		if policyDescription == "" {
+		if policyDescription == "" || policy.Resolution == nil || strings.TrimSpace(*policy.Resolution) == "" {
 			description = getDefaultDescription()
-		} else {
-			description = policyDescription
-		}
-		if policy.Resolution == nil {
 			resolution = defaultResolution
 		} else {
-			policyResolution := strings.TrimSpace(*policy.Resolution)
-			if policyResolution == "" {
-				resolution = defaultResolution
-			} else {
-				resolution = policyResolution
-			}
+			description = policyDescription
+			resolution = strings.TrimSpace(*policy.Resolution)
 		}
-	default:
+	} else {
 		description = getDefaultDescription()
 		resolution = defaultResolution
 	}

--- a/server/cron/calendar_cron_test.go
+++ b/server/cron/calendar_cron_test.go
@@ -941,21 +941,13 @@ func TestEventDescription(t *testing.T) {
 		err = json.Unmarshal(calendarEvents[hostCalEvent.HostID].Data, &details)
 		require.NoError(t, err)
 		description := createdCalendarEvents[details["id"]].Description
+		defaultDescriptionWithOrg := fmt.Sprintf("%s %s", orgName, defaultDescription)
 		switch hostCalEvent.HostID {
 		case hostID1, hostID6:
 			assert.Contains(t, description, "Description for policy 1")
 			assert.Contains(t, description, "Resolution for policy 1")
-		case hostID2:
-			assert.Contains(t, description, "Description for policy 2")
-			assert.Contains(t, description, defaultResolution)
-		case hostID3:
-			assert.Contains(t, description, "Description for policy 3")
-			assert.Contains(t, description, defaultResolution)
-		case hostID4:
-			assert.Contains(t, description, fmt.Sprintf("%s %s", orgName, defaultDescription))
-			assert.Contains(t, description, "Resolution for policy 4")
-		case hostID5, hostID7:
-			assert.Contains(t, description, fmt.Sprintf("%s %s", orgName, defaultDescription))
+		default:
+			assert.Contains(t, description, defaultDescriptionWithOrg)
 			assert.Contains(t, description, defaultResolution)
 		}
 	}


### PR DESCRIPTION
#18187 
Per Figma, use the default policy description/resolution if either is missing.

