### PR TITLE
adjust logic to get default scripts

### DIFF
--- a/ee/server/service/software_installers.go
+++ b/ee/server/service/software_installers.go
@@ -3,7 +3,6 @@ package service
 import (
 	"context"
 	"encoding/hex"
-	"path/filepath"
 	"strings"
 
 	"github.com/fleetdm/fleet/v4/pkg/file"
@@ -55,9 +54,7 @@ func (svc *Service) UploadSoftwareInstaller(ctx context.Context, payload *fleet.
 	}
 
 	if payload.InstallScript == "" {
-		installerType := file.InstallerType(strings.TrimPrefix(filepath.Ext(payload.Filename), "."))
-		installerPath := "some path" // TODO: where does this come from?
-		payload.InstallScript = file.GetInstallScript(installerType, installerPath)
+		payload.InstallScript = file.GetInstallScript(payload.Filename)
 	}
 
 	// TODO: basic validation of install and post-install script (e.g., supported interpreters)?

--- a/frontend/interfaces/software.ts
+++ b/frontend/interfaces/software.ts
@@ -133,7 +133,3 @@ export const formatSoftwareType = ({
   }
   return type;
 };
-
-// ISoftwareInstallerType defines the supported installer types for
-// software uploaded by the IT admin.
-export type ISoftwareInstallerType = "pkg" | "msi" | "deb" | "exe";

--- a/frontend/utilities/software_install_scripts.ts
+++ b/frontend/utilities/software_install_scripts.ts
@@ -1,5 +1,3 @@
-import { ISoftwareInstallerType } from "interfaces/software";
-
 // @ts-ignore
 import installPkg from "../../pkg/file/scripts/install_pkg.sh";
 // @ts-ignore
@@ -12,10 +10,6 @@ import installDeb from "../../pkg/file/scripts/install_deb.sh";
 /*
  * getInstallScript returns a string with a script to install the
  * provided software.
- *
- * Note that we don't do any sanitization of the arguments here,
- * delegating that to the caller which should have the right context
- * about what should be escaped.
  * */
 const getInstallScript = (fileName: string): string => {
   const extension = fileName.split(".").pop();
@@ -29,8 +23,7 @@ const getInstallScript = (fileName: string): string => {
     case "exe":
       return installExe;
     default:
-      // this should never happen as this function is type-guarded
-      throw new Error(`unsupported file type: ${filetype}`);
+      throw new Error(`unsupported file extension: ${extension}`);
   }
 };
 

--- a/frontend/utilities/software_install_scripts.ts
+++ b/frontend/utilities/software_install_scripts.ts
@@ -9,10 +9,6 @@ import installExe from "../../pkg/file/scripts/install_exe.ps1";
 // @ts-ignore
 import installDeb from "../../pkg/file/scripts/install_deb.sh";
 
-const replaceVariables = (rawScript: string, installerPath: string): string => {
-  return rawScript.replace("$INSTALLER_PATH", installerPath);
-};
-
 /*
  * getInstallScript returns a string with a script to install the
  * provided software.
@@ -21,30 +17,21 @@ const replaceVariables = (rawScript: string, installerPath: string): string => {
  * delegating that to the caller which should have the right context
  * about what should be escaped.
  * */
-const getInstallScript = (
-  filetype: ISoftwareInstallerType,
-  path: string
-): string => {
-  let rawScript: string;
-  switch (filetype) {
+const getInstallScript = (fileName: string): string => {
+  const extension = fileName.split(".").pop();
+  switch (extension) {
     case "pkg":
-      rawScript = installPkg;
-      break;
+      return installPkg;
     case "msi":
-      rawScript = installMsi;
-      break;
+      return installMsi;
     case "deb":
-      rawScript = installDeb;
-      break;
+      return installDeb;
     case "exe":
-      rawScript = installExe;
-      break;
+      return installExe;
     default:
       // this should never happen as this function is type-guarded
       throw new Error(`unsupported file type: ${filetype}`);
   }
-
-  return replaceVariables(rawScript, path);
 };
 
 export default getInstallScript;

--- a/pkg/file/management.go
+++ b/pkg/file/management.go
@@ -2,16 +2,7 @@ package file
 
 import (
 	_ "embed"
-	"strings"
-)
-
-type InstallerType string
-
-const (
-	InstallerTypeMsi InstallerType = "msi"
-	InstallerTypeDeb InstallerType = "deb"
-	InstallerTypePkg InstallerType = "pkg"
-	InstallerTypeExe InstallerType = "exe"
+	"path/filepath"
 )
 
 //go:embed scripts/install_pkg.sh
@@ -26,25 +17,20 @@ var installExeScript string
 //go:embed scripts/install_deb.sh
 var installDebScript string
 
-// GetInstallScript returns a script that can be used to install the given
-// installer based on the provided type
-func GetInstallScript(installerType InstallerType, installerPath string) string {
-	var rawScript string
-
-	switch installerType {
-	case InstallerTypeMsi:
-		rawScript = installMsiScript
-	case InstallerTypeDeb:
-		rawScript = installDebScript
-	case InstallerTypePkg:
-		rawScript = installPkgScript
-	case InstallerTypeExe:
-		rawScript = installExeScript
+// GetInstallScript returns a script that can be used to install the given file
+func GetInstallScript(filename string) string {
+	switch ext := filepath.Ext(filename); ext {
+	case ".msi":
+		return installMsiScript
+	case ".deb":
+		return installDebScript
+	case ".pkg":
+		return installPkgScript
+	case ".exe":
+		return installExeScript
 	default:
 		return ""
 	}
-
-	return replaceVars(rawScript, installerPath)
 }
 
 //go:embed scripts/remove_exe.ps1
@@ -59,27 +45,18 @@ var removeMsiScript string
 //go:embed scripts/remove_deb.sh
 var removeDebScript string
 
-// GetRemoveScript returns a script that can be used to remove the given
-// installer based on the provided type
-func GetRemoveScript(installerType InstallerType, installerPath string) string {
-	var rawScript string
-
-	switch installerType {
-	case InstallerTypeMsi:
-		rawScript = removeMsiScript
-	case InstallerTypeDeb:
-		rawScript = removeDebScript
-	case InstallerTypePkg:
-		rawScript = removePkgScript
-	case InstallerTypeExe:
-		rawScript = removeExeScript
+// GetRemoveScript returns a script that can be used to remove the given file
+func GetRemoveScript(filename string) string {
+	switch ext := filepath.Ext(filename); ext {
+	case ".msi":
+		return removeMsiScript
+	case ".deb":
+		return removeDebScript
+	case ".pkg":
+		return removePkgScript
+	case ".exe":
+		return removeExeScript
 	default:
 		return ""
 	}
-
-	return replaceVars(rawScript, installerPath)
-}
-
-func replaceVars(rawScript string, installerPath string) string {
-	return strings.Replace(rawScript, "$INSTALLER_PATH", installerPath, -1)
 }

--- a/pkg/file/management_test.go
+++ b/pkg/file/management_test.go
@@ -23,32 +23,32 @@ func TestMain(m *testing.M) {
 //
 // go test ./pkg/file/... -update
 func TestGetInstallAndRemoveScript(t *testing.T) {
-	scriptsByType := map[InstallerType][2]string{
-		InstallerTypeMsi: {
+	scriptsByType := map[string][2]string{
+		"msi": {
 			"./scripts/install_msi.ps1",
 			"./scripts/remove_msi.ps1",
 		},
-		InstallerTypePkg: {
+		"pkg": {
 			"./scripts/install_pkg.sh",
 			"./scripts/remove_pkg.sh",
 		},
-		InstallerTypeDeb: {
+		"deb": {
 			"./scripts/install_deb.sh",
 			"./scripts/remove_deb.sh",
 		},
-		InstallerTypeExe: {
+		"exe": {
 			"./scripts/install_exe.ps1",
 			"./scripts/remove_exe.ps1",
 		},
 	}
 
 	for itype, scripts := range scriptsByType {
-		installerPath := "./foo/bar baz.f"
+		installerPath := "./foo/bar baz." + itype
 
-		gotScript := GetInstallScript(itype, installerPath)
+		gotScript := GetInstallScript(installerPath)
 		assertGoldenMatches(t, scripts[0], gotScript, *update)
 
-		gotScript = GetRemoveScript(itype, installerPath)
+		gotScript = GetRemoveScript(installerPath)
 		assertGoldenMatches(t, scripts[1], gotScript, *update)
 	}
 }

--- a/pkg/file/scripts/README.md
+++ b/pkg/file/scripts/README.md
@@ -9,7 +9,9 @@ Scripts are stored on their own files for two reasons:
 
 #### Variables
 
-Because the scripts are shared between Go and JS, the convention is to declare variables using `$VAR_NAME` and document its intended usage here.
+The scrips in this folder accept variables like `$VAR_NAME` that will be replaced/populated by `fleetd` when they run.
+
+Supported variables are:
 
 - `$INSTALLER_PATH` path to the installer file.
 

--- a/pkg/file/scripts/README.md
+++ b/pkg/file/scripts/README.md
@@ -9,7 +9,7 @@ Scripts are stored on their own files for two reasons:
 
 #### Variables
 
-The scrips in this folder accept variables like `$VAR_NAME` that will be replaced/populated by `fleetd` when they run.
+The scripts in this folder accept variables like `$VAR_NAME` that will be replaced/populated by `fleetd` when they run.
 
 Supported variables are:
 

--- a/pkg/file/testdata/scripts/install_deb.sh.golden
+++ b/pkg/file/testdata/scripts/install_deb.sh.golden
@@ -1,1 +1,1 @@
-apt-get install -f "./foo/bar baz.f"
+apt-get install -f "$INSTALLER_PATH"

--- a/pkg/file/testdata/scripts/install_exe.ps1.golden
+++ b/pkg/file/testdata/scripts/install_exe.ps1.golden
@@ -1,4 +1,4 @@
-$exeFilePath = "./foo/bar baz.f"
+$exeFilePath = "$INSTALLER_PATH"
 
 # extract the name of the executable to use as the sub-directory name
 $exeName = [System.IO.Path]::GetFileName($exeFilePath)

--- a/pkg/file/testdata/scripts/install_msi.ps1.golden
+++ b/pkg/file/testdata/scripts/install_msi.ps1.golden
@@ -1,7 +1,7 @@
 $logFile = "${env:TEMP}/fleet-install-software.log"
 
 $installProcess = Start-Process msiexec.exe `
-  -ArgumentList "/quiet /norestart /lv ${logFile} /i `"./foo/bar baz.f`"" `
+  -ArgumentList "/quiet /norestart /lv ${logFile} /i `"$INSTALLER_PATH`"" `
   -PassThru -Verb RunAs -Wait
 
 Get-Content $logFile -Tail 500

--- a/pkg/file/testdata/scripts/install_pkg.sh.golden
+++ b/pkg/file/testdata/scripts/install_pkg.sh.golden
@@ -1,1 +1,1 @@
-installer -pkg "./foo/bar baz.f" -target /
+installer -pkg "$INSTALLER_PATH" -target /

--- a/pkg/file/testdata/scripts/remove_deb.sh.golden
+++ b/pkg/file/testdata/scripts/remove_deb.sh.golden
@@ -1,1 +1,1 @@
-apt-get remove -y $(dpkg -f "./foo/bar baz.f" Package)
+apt-get remove -y $(dpkg -f "$INSTALLER_PATH" Package)

--- a/pkg/file/testdata/scripts/remove_exe.ps1.golden
+++ b/pkg/file/testdata/scripts/remove_exe.ps1.golden
@@ -1,4 +1,4 @@
-$exeFilePath = "./foo/bar baz.f"
+$exeFilePath = "$INSTALLER_PATH"
 
 # extract the name of the executable to use as the sub-directory name
 $exeName = [System.IO.Path]::GetFileName($exeFilePath)

--- a/pkg/file/testdata/scripts/remove_msi.ps1.golden
+++ b/pkg/file/testdata/scripts/remove_msi.ps1.golden
@@ -1,7 +1,7 @@
 $logFile = "${env:TEMP}/fleet-remove-software.log"
 
 $removeProcess = Start-Process msiexec.exe `
-  -ArgumentList "/quiet /norestart /lv ${logFile} /x `"./foo/bar baz.f`"" `
+  -ArgumentList "/quiet /norestart /lv ${logFile} /x `"$INSTALLER_PATH`"" `
   -PassThru -Verb RunAs -Wait
 
 Get-Content $logFile -Tail 500

--- a/pkg/file/testdata/scripts/remove_pkg.sh.golden
+++ b/pkg/file/testdata/scripts/remove_pkg.sh.golden
@@ -1,5 +1,5 @@
 # grab the identifier from the first PackageInfo we find. Those are placed in different locations depending on the installer
-pkg_id=$(tar xOvf "./foo/bar baz.f" --include='*PackageInfo*' 2>/dev/null | sed -n 's/.*identifier="\([^"]*\)".*/\1/p')
+pkg_id=$(tar xOvf "$INSTALLER_PATH" --include='*PackageInfo*' 2>/dev/null | sed -n 's/.*identifier="\([^"]*\)".*/\1/p')
 
 # remove all the files and empty directories that were installed
 pkgutil --files $pkg_id | tr '\n' '\0' | xargs -n 1 -0 rm -d


### PR DESCRIPTION
This tweaks the logic to get default install/remove scripts to delegate the variable replacement to `fleetd`