### PR TITLE
Troubleshoot CI issues with TestVulnerabilityDataStream

### DIFF
--- a/cmd/fleetctl/vulnerability_data_stream.go
+++ b/cmd/fleetctl/vulnerability_data_stream.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
 
 	"github.com/fleetdm/fleet/v4/server/vulnerabilities/macoffice"
@@ -47,42 +48,42 @@ Downloads (if needed) the data streams that can be used by the Fleet server to p
 			log(c, "[-] Downloading CPE database...")
 			err = nvd.DownloadCPEDBFromGithub(dir, "")
 			if err != nil {
-				return err
+				return fmt.Errorf("download CPE DB from Github: %w", err)
 			}
 			log(c, " Done\n")
 
 			log(c, "[-] Downloading CPE translations...")
 			err = nvd.DownloadCPETranslationsFromGithub(dir, "")
 			if err != nil {
-				return err
+				return fmt.Errorf("download CPE translations from Github: %w", err)
 			}
 			log(c, " Done\n")
 
 			log(c, "[-] Downloading NVD CVE feed...")
 			err = nvd.DownloadCVEFeed(dir, "", false, klog.NewNopLogger())
 			if err != nil {
-				return err
+				return fmt.Errorf("download CVE feed from Github: %w", err)
 			}
 			log(c, " Done\n")
 
 			log(c, "[-] Downloading EPSS feed...")
 			err = nvd.DownloadEPSSFeed(dir)
 			if err != nil {
-				return err
+				return fmt.Errorf("download EPSS feed from Cyentia: %w", err)
 			}
 			log(c, " Done\n")
 
 			log(c, "[-] Downloading CISA known exploits feed...")
 			err = nvd.DownloadCISAKnownExploitsFeed(dir)
 			if err != nil {
-				return err
+				return fmt.Errorf("download CISA known exploits feed from cisa.gov: %w", err)
 			}
 			log(c, " Done\n")
 
 			log(c, "[-] Downloading Oval definitions...")
 			err = oval.Sync(dir, nil)
 			if err != nil {
-				return err
+				return fmt.Errorf("download OVAL definitions: %w", err)
 			}
 			log(c, " Done\n")
 
@@ -90,14 +91,14 @@ Downloads (if needed) the data streams that can be used by the Fleet server to p
 			ctx := context.Background()
 			err = msrc.SyncFromGithub(ctx, dir, nil)
 			if err != nil {
-				return err
+				return fmt.Errorf("download MSRC artifacts from Github: %w", err)
 			}
 			log(c, " Done\n")
 
 			log(c, "[-] Downloading MacOffice release notes...")
 			err = macoffice.SyncFromGithub(ctx, dir)
 			if err != nil {
-				return err
+				return fmt.Errorf("download Mac Office release notes from Github: %w", err)
 			}
 			log(c, " Done\n")
 

--- a/cmd/fleetctl/vulnerability_data_stream_test.go
+++ b/cmd/fleetctl/vulnerability_data_stream_test.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"os"
 	"path"
 	"testing"
 
@@ -27,10 +26,6 @@ func TestVulnerabilityDataStream(t *testing.T) {
 [-] Downloading MacOffice release notes... Done
 [+] Data streams successfully downloaded!
 `
-
-	// Set start and end indexes otherwise a full sync using the NVD API 2.0 takes a long time (>15m).
-	os.Setenv("NETWORK_TEST_NVD_CVE_START_IDX", "220000")
-	os.Setenv("NETWORK_TEST_NVD_CVE_END_IDX", "226000")
 
 	var actualOutput string
 	err := nettest.RunWithNetRetry(t, func() error {

--- a/pkg/download/download.go
+++ b/pkg/download/download.go
@@ -66,6 +66,10 @@ func download(client *http.Client, u *url.URL, path string, extract bool) error 
 	}
 	defer resp.Body.Close()
 
+	if resp.StatusCode != http.StatusOK {
+		return err
+	}
+
 	r := io.Reader(resp.Body)
 
 	// extract (optional)

--- a/server/vulnerabilities/nvd/sync/cve_syncer.go
+++ b/server/vulnerabilities/nvd/sync/cve_syncer.go
@@ -404,16 +404,6 @@ func (s *CVE) sync(ctx context.Context, lastModStartDate *string) (newLastModSta
 		startIndex += cveResponse.ResultsPerPage
 		newLastModStartDate = cveResponse.Timestamp
 
-		// Environment variable NETWORK_TEST_NVD_CVE_END_IDX is set only in tests
-		// (to reduce test duration time).
-		if v := os.Getenv("NETWORK_TEST_NVD_CVE_END_IDX"); v != "" {
-			endIdx, err := strconv.ParseInt(v, 10, 32)
-			if err != nil {
-				return "", err
-			}
-			totalResults = int(endIdx)
-		}
-
 		for _, vuln := range cveResponse.Vulnerabilities {
 			year, err := strconv.Atoi((*vuln.CVE.ID)[4:8])
 			if err != nil {


### PR DESCRIPTION
`TestVulnerabilityDataStream` is currently too flaky.

```
=== RUN   TestVulnerabilityDataStream
    nettest.go:33: network test start: TestVulnerabilityDataStream
    vulnerability_data_stream_test.go:41: 
        	Error Trace:	/home/runner/work/fleet/fleet/cmd/fleetctl/vulnerability_data_stream_test.go:41
        	Error:      	Received unexpected error:
        	            	bzip2 data invalid: bad magic value
        	Test:       	TestVulnerabilityDataStream
    nettest.go:36: network test done: TestVulnerabilityDataStream
--- FAIL: TestVulnerabilityDataStream (64.23s)
```