### PR TITLE
Fleet UI: Merge queries/policies tests and polish

### DIFF
--- a/frontend/pages/policies/ManagePoliciesPage/components/PoliciesTable/PoliciesTable.tests.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/components/PoliciesTable/PoliciesTable.tests.tsx
@@ -6,8 +6,6 @@ import { createCustomRenderer } from "test/test-utils";
 import createMockUser from "__mocks__/userMock";
 import createMockPolicy from "__mocks__/policyMock";
 import PoliciesTable from "./PoliciesTable";
-import userEvent from "@testing-library/user-event";
-import createMockQuery from "__mocks__/queryMock";
 
 describe("Policies table", () => {
   it("Renders the page-wide empty state when no policies are present", async () => {


### PR DESCRIPTION
## Issue
FE of #15605 
## Bug fix
Cerra #18599 

## Description
- Add arrows on tooltips to match new styling on queries and policies pages
- Move has not run policy tooltip to top to match other table level tooltips
- Removes sandbox code and sandbox test code
- Create 6 integration tests for PoliciesTable.tsx
- Create 4 more integration tests for QueriesTable.tsx

## Screenshots of integration tests
<img width="850" alt="Screenshot 2024-05-03 at 4 06 16 PM" src="https://github.com/fleetdm/fleet/assets/71795832/c20a2533-4614-4ef1-b0cc-d9e77474ed2d">
<img width="845" alt="Screenshot 2024-05-03 at 4 05 52 PM" src="https://github.com/fleetdm/fleet/assets/71795832/0ed2eba1-5927-4b24-99d0-e40242e2b5b2">



# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Manual QA for all new/changed functionality

