### PR TITLE
Fixed ingestion of private IPv6 address from agent.

### DIFF
--- a/changes/18039-private-IPv6-address
+++ b/changes/18039-private-IPv6-address
@@ -1,0 +1,1 @@
+Fixed ingestion of private IPv6 address from agent. Host details page can now display private IPv6 address if private IPv4 does not exist.

--- a/server/service/osquery_utils/queries.go
+++ b/server/service/osquery_utils/queries.go
@@ -85,8 +85,8 @@ FROM
 	-- whereas on Windows ia.interface is the IP of the interface.
     JOIN routes r ON %s
 WHERE
-	-- Destination 0.0.0.0/0 is the default route on route tables.
-    r.destination = '0.0.0.0' AND r.netmask = 0
+	-- Destination 0.0.0.0/0 or ::/0 (IPv6) is the default route on route tables.
+    (r.destination = '0.0.0.0' OR r.destination = '::') AND r.netmask = 0
 	-- Type of route is "gateway" for Unix, "remote" for Windows.
     AND r.type = '%s'
 	-- We are only interested on private IPs (some devices have their Public IP as Primary IP too).

--- a/server/service/osquery_utils/queries_test.go
+++ b/server/service/osquery_utils/queries_test.go
@@ -52,6 +52,21 @@ func TestDetailQueryNetworkInterfaces(t *testing.T) {
 	assert.NoError(t, ingest(context.Background(), log.NewNopLogger(), &host, rows))
 	assert.Equal(t, "10.0.1.2", host.PrimaryIP)
 	assert.Equal(t, "bc:d0:74:4b:10:6d", host.PrimaryMac)
+
+	rows = make([]map[string]string, 1)
+	require.NoError(
+		t, json.Unmarshal(
+			[]byte(`
+[
+  {"address":"fd7a:115c:a1e0::d401:6637","mac":"b2:a2:e4:62:0f:1e"}
+]`),
+			&rows,
+		),
+	)
+	assert.NoError(t, ingest(context.Background(), log.NewNopLogger(), &host, rows))
+	assert.Equal(t, "fd7a:115c:a1e0::d401:6637", host.PrimaryIP)
+	assert.Equal(t, "b2:a2:e4:62:0f:1e", host.PrimaryMac)
+
 }
 
 func TestDetailQueryScheduledQueryStats(t *testing.T) {


### PR DESCRIPTION
#18039 
Fixed ingestion of private IPv6 address from agent. Host details page can now display private IPv6 address if private IPv4 does not exist.

How to set up an IPv6-only host: https://www.loom.com/share/5e205549b6484df88702c27a5aa5a3ee

# Checklist for submitter
- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [x] Added/updated tests
- [x] Manual QA for all new/changed functionality
