### PR TITLE
Add redirect for calendar events article

### DIFF
--- a/website/config/routes.js
+++ b/website/config/routes.js
@@ -494,6 +494,7 @@ module.exports.routes = {
   'GET /learn-more-about/downgrading': '/docs/using-fleet/downgrading-fleet',
   'GET /learn-more-about/fleetd': '/docs/get-started/anatomy#fleetd',
   'GET /learn-more-about/rotating-enroll-secrets': '/docs/configuration/configuration-files#rotating-enroll-secrets',
+  'GET /learn-more-about/calendar-events': '/announcements/fleet-in-your-calendar-introducing-maintenance-windows',
 
   // Sitemap
   // =============================================================================================================


### PR DESCRIPTION
The UI currently links out to fleetdm.com/learn-more-about/calendar-events which was meant to link to the article but was never set up.