### PR TITLE
Website: Create protocol and subdomain regex custom config & normalize LinkedIn urls

### DIFF
--- a/website/api/helpers/iq/get-enriched.js
+++ b/website/api/helpers/iq/get-enriched.js
@@ -54,7 +54,7 @@ module.exports = {
   fn: async function ({emailAddress,linkedinUrl,firstName,lastName,organization}) {
 
     require('assert')(sails.config.custom.iqSecret);// FUTURE: Rename this config
-    require('assert')(sails.config.RX_PROTOCOL_AND_COMMON_SUBDOMAINS);
+    require('assert')(sails.config.custom.RX_PROTOCOL_AND_COMMON_SUBDOMAINS);
 
     sails.log.verbose('Enriching from…', emailAddress,linkedinUrl,firstName,lastName,organization);
 

--- a/website/api/helpers/iq/get-enriched.js
+++ b/website/api/helpers/iq/get-enriched.js
@@ -55,8 +55,6 @@ module.exports = {
 
     require('assert')(sails.config.custom.iqSecret);// FUTURE: Rename this config
 
-    let RX_PROTOCOL_AND_COMMON_SUBDOMAINS = /^(https?\:\/\/)?(www\.|about\.|ch\.|uk\.|pl\.|ca\.|jp\.|im\.|fr\.|pt\.|vn\.)*/;
-
     sails.log.verbose('Enriching from…', emailAddress,linkedinUrl,firstName,lastName,organization);
 
     // Gather initial information that is obtainable just from parsing provided inputs.
@@ -161,7 +159,7 @@ module.exports = {
         }
 
         person = {
-          linkedinUrl: matchingPersonInfo.canonical_url.replace(RX_PROTOCOL_AND_COMMON_SUBDOMAINS,''),
+          linkedinUrl: matchingPersonInfo.canonical_url.replace(sails.config.custom.RX_PROTOCOL_AND_COMMON_SUBDOMAINS,''),
           firstName: matchingPersonInfo.first_name,
           lastName: matchingPersonInfo.last_name,
           organization: matchedOrganizationName || '',
@@ -240,12 +238,12 @@ module.exports = {
       if (matchingCompanyPageInfo) {
         let parsedCompanyEmailDomain = require('url').parse(matchingCompanyPageInfo.website);
         // If a company's website does not include the protocol (https://), url.parse will return null as the hostname, if this happens, we'll use the href value returned instead.
-        let emailDomain = parsedCompanyEmailDomain.hostname ? parsedCompanyEmailDomain.hostname.replace(RX_PROTOCOL_AND_COMMON_SUBDOMAINS,'') : parsedCompanyEmailDomain.href.replace(RX_PROTOCOL_AND_COMMON_SUBDOMAINS,'');
+        let emailDomain = parsedCompanyEmailDomain.hostname ? parsedCompanyEmailDomain.hostname.replace(sails.config.custom.RX_PROTOCOL_AND_COMMON_SUBDOMAINS,'') : parsedCompanyEmailDomain.href.replace(sails.config.custom.RX_PROTOCOL_AND_COMMON_SUBDOMAINS,'');
         employer = {
           organization: matchingCompanyPageInfo.name,
           numberOfEmployees: matchingCompanyPageInfo.employees_count,
           emailDomain: emailDomain,
-          linkedinCompanyPageUrl: matchingCompanyPageInfo.canonical_url.replace(RX_PROTOCOL_AND_COMMON_SUBDOMAINS,''),
+          linkedinCompanyPageUrl: matchingCompanyPageInfo.canonical_url.replace(sails.config.custom.RX_PROTOCOL_AND_COMMON_SUBDOMAINS,''),
         };
         if (organization && employer.organization && employer.organization !== organization) {
           sails.log.info(`Unexpected result when enriching: Matched organization name (${employer.organization}) does not equal the provided "organization" (${organization})`);

--- a/website/api/helpers/iq/get-enriched.js
+++ b/website/api/helpers/iq/get-enriched.js
@@ -55,7 +55,7 @@ module.exports = {
 
     require('assert')(sails.config.custom.iqSecret);// FUTURE: Rename this config
 
-    let RX_PROTOCOL_AND_COMMON_SUBDOMAINS = /^(https?\:\/\/)?(www\.|about\.)*/;
+    let RX_PROTOCOL_AND_COMMON_SUBDOMAINS = /^(https?\:\/\/)?(www\.|about\.|ch\.|uk\.|pl\.|ca\.|jp\.|im\.|fr\.|pt\.|vn\.)*/;
 
     sails.log.verbose('Enriching from…', emailAddress,linkedinUrl,firstName,lastName,organization);
 

--- a/website/api/helpers/iq/get-enriched.js
+++ b/website/api/helpers/iq/get-enriched.js
@@ -54,6 +54,7 @@ module.exports = {
   fn: async function ({emailAddress,linkedinUrl,firstName,lastName,organization}) {
 
     require('assert')(sails.config.custom.iqSecret);// FUTURE: Rename this config
+    require('assert')(sails.config.RX_PROTOCOL_AND_COMMON_SUBDOMAINS);
 
     sails.log.verbose('Enriching from…', emailAddress,linkedinUrl,firstName,lastName,organization);
 

--- a/website/api/helpers/salesforce/update-or-create-contact-and-account.js
+++ b/website/api/helpers/salesforce/update-or-create-contact-and-account.js
@@ -56,7 +56,7 @@ module.exports = {
     require('assert')(sails.config.custom.salesforceIntegrationUsername);
     require('assert')(sails.config.custom.salesforceIntegrationPasskey);
     require('assert')(sails.config.custom.iqSecret);
-    require('assert')(sails.config.RX_PROTOCOL_AND_COMMON_SUBDOMAINS);
+    require('assert')(sails.config.custom.RX_PROTOCOL_AND_COMMON_SUBDOMAINS);
 
 
     if(!emailAddress && !linkedinUrl){

--- a/website/api/helpers/salesforce/update-or-create-contact-and-account.js
+++ b/website/api/helpers/salesforce/update-or-create-contact-and-account.js
@@ -56,6 +56,7 @@ module.exports = {
     require('assert')(sails.config.custom.salesforceIntegrationUsername);
     require('assert')(sails.config.custom.salesforceIntegrationPasskey);
     require('assert')(sails.config.custom.iqSecret);
+    require('assert')(sails.config.RX_PROTOCOL_AND_COMMON_SUBDOMAINS);
 
 
     if(!emailAddress && !linkedinUrl){
@@ -63,7 +64,7 @@ module.exports = {
     }
 
     if(linkedinUrl){
-      // If linkedinUrl was prvided, strip the protocol and subdomain from the URL.
+      // If linkedinUrl was provided, strip the protocol and subdomain from the URL.
       linkedinUrl = linkedinUrl.replace(sails.config.custom.RX_PROTOCOL_AND_COMMON_SUBDOMAINS, '');
     }
     // Send the information we have to the enrichment helper.

--- a/website/api/helpers/salesforce/update-or-create-contact-and-account.js
+++ b/website/api/helpers/salesforce/update-or-create-contact-and-account.js
@@ -61,6 +61,11 @@ module.exports = {
     if(!emailAddress && !linkedinUrl){
       throw new Error('UsageError: when updating or creating a contact and account in salesforce, either an email or linkedInUrl is required.');
     }
+
+    if(linkedinUrl){
+      // If linkedinUrl was prvided, strip the protocol and subdomain from the URL.
+      linkedinUrl = linkedinUrl.replace(sails.config.custom.RX_PROTOCOL_AND_COMMON_SUBDOMAINS, '');
+    }
     // Send the information we have to the enrichment helper.
     let enrichmentData = await sails.helpers.iq.getEnriched(emailAddress, linkedinUrl, firstName, lastName, organization);
     // console.log(enrichmentData);

--- a/website/config/custom.js
+++ b/website/config/custom.js
@@ -91,6 +91,7 @@ module.exports.custom = {
   // iqSecret: undefined, // You gotta use the base64-encoded API secret.  (Get it in your account settings in LeadIQ.)
   // salesforceIntegrationUsername: undefined,
   // salesforceIntegrationPasskey: undefined,
+  RX_PROTOCOL_AND_COMMON_SUBDOMAINS: /^(https?\:\/\/)?(www\.|about\.|ch\.|uk\.|pl\.|ca\.|jp\.|im\.|fr\.|pt\.|vn\.)*/,// For cleaning up LinkedIn URLs before creating CRM records.
 
   //  ██████╗ ██████╗ ██╗███████╗
   //  ██╔══██╗██╔══██╗██║██╔════╝


### PR DESCRIPTION
Changes:
 - Updated the regex used to match HTTP protocol and common subdomains in the `get-enriched` helper to include more subdomains and changed it to a custom config variable (`sails.config.custom.RX_PROTOCOL_AND_COMMON_SUBDOMAINS`)
 - Updated the update-or-create-contact-and-account helper to remove HTTP protocol and subdomains from provided linkedIn URLs.