### PR TITLE
[unreleased bug] Fleet UI: Update autofill help text

### DIFF
--- a/frontend/pages/policies/PolicyPage/components/SaveNewPolicyModal/SaveNewPolicyModal.tsx
+++ b/frontend/pages/policies/PolicyPage/components/SaveNewPolicyModal/SaveNewPolicyModal.tsx
@@ -209,7 +209,6 @@ const SaveNewPolicyModal = ({
             error={errors.name}
             inputClassName={`${baseClass}__policy-save-modal-name`}
             label="Name"
-            helpText="What yes or no question does your policy ask about your hosts?"
             autofocus
             ignore1password
             disabled={disableForm}
@@ -220,6 +219,7 @@ const SaveNewPolicyModal = ({
             value={lastEditedQueryDescription}
             inputClassName={`${baseClass}__policy-save-modal-description`}
             label={renderAutofillLabel("Description")}
+            helpText="How does this policy's failure put the organization at risk?"
             type="textarea"
             disabled={disableForm}
           />
@@ -230,7 +230,7 @@ const SaveNewPolicyModal = ({
             inputClassName={`${baseClass}__policy-save-modal-resolution`}
             label={renderAutofillLabel("Resolution")}
             type="textarea"
-            helpText="What steps should an end user take to resolve a host that fails this policy? (optional)"
+            helpText="If this policy fails, what should the end user expect?"
             disabled={disableForm}
           />
           {platformSelector.render()}

--- a/frontend/pages/policies/PolicyPage/components/SaveNewPolicyModal/SaveNewPolicyModal.tsx
+++ b/frontend/pages/policies/PolicyPage/components/SaveNewPolicyModal/SaveNewPolicyModal.tsx
@@ -230,7 +230,7 @@ const SaveNewPolicyModal = ({
             inputClassName={`${baseClass}__policy-save-modal-resolution`}
             label={renderAutofillLabel("Resolution")}
             type="textarea"
-            helpText="If this policy fails, what should the end user expect?"
+            helpText="If this policy fails, what action should the device owner expect to be taken?"
             disabled={disableForm}
           />
           {platformSelector.render()}

--- a/frontend/pages/policies/PolicyPage/components/SaveNewPolicyModal/SaveNewPolicyModal.tsx
+++ b/frontend/pages/policies/PolicyPage/components/SaveNewPolicyModal/SaveNewPolicyModal.tsx
@@ -230,7 +230,7 @@ const SaveNewPolicyModal = ({
             inputClassName={`${baseClass}__policy-save-modal-resolution`}
             label={renderAutofillLabel("Resolution")}
             type="textarea"
-            helpText="If this policy fails, what action should the device owner expect to be taken?"
+            helpText="If this policy fails, what should the end user expect?"
             disabled={disableForm}
           />
           {platformSelector.render()}


### PR DESCRIPTION
## Issue
Per slack thread: https://fleetdm.slack.com/archives/C01EZVBHFHU/p1714771277711839

## Description
- Update help text for saving a new policy

## Screenshot of updates
<img width="844" alt="Screenshot 2024-05-06 at 10 14 01 AM" src="https://github.com/fleetdm/fleet/assets/71795832/233e9bf5-736b-4497-a1c0-b941de1f4804">


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Manual QA for all new/changed functionality
 