### PR TITLE
[unreleased bug] Fleet UI: Automated queries policies

### DIFF
--- a/frontend/pages/policies/ManagePoliciesPage/ManagePoliciesPage.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/ManagePoliciesPage.tsx
@@ -339,11 +339,10 @@ const ManagePolicyPage = ({
     }
   );
 
-  const canAddOrDeletePolicy: boolean =
+  const canAddOrDeletePolicy =
     isGlobalAdmin || isGlobalMaintainer || isTeamMaintainer || isTeamAdmin;
-  const canManageAutomations: boolean = isGlobalAdmin || isTeamAdmin;
-  const hasPoliciesToAutomateOrDelete: boolean =
-    policiesAvailableToAutomate.length > 0;
+  const canManageAutomations = isGlobalAdmin || isTeamAdmin;
+  const hasPoliciesToAutomateOrDelete = policiesAvailableToAutomate.length > 0;
 
   const {
     data: config,
@@ -523,7 +522,7 @@ const ManagePolicyPage = ({
 
       // update changed policies calendar events enabled
       const changedPolicies = formData.policies.filter((formPolicy) => {
-        const prevPolicyState = policiesAvailableToAutomate?.find(
+        const prevPolicyState = policiesAvailableToAutomate.find(
           (policy) => policy.id === formPolicy.id
         );
         return (

--- a/frontend/pages/queries/ManageQueriesPage/ManageQueriesPage.tsx
+++ b/frontend/pages/queries/ManageQueriesPage/ManageQueriesPage.tsx
@@ -117,6 +117,9 @@ const ManageQueriesPage = ({
   const [showPreviewDataModal, setShowPreviewDataModal] = useState(false);
   const [isUpdatingQueries, setIsUpdatingQueries] = useState(false);
   const [isUpdatingAutomations, setIsUpdatingAutomations] = useState(false);
+  const [queriesAvailableToAutomate, setQueriesAvailableToAutomate] = useState<
+    IEnhancedQuery[] | []
+  >([]);
 
   const {
     data: enhancedQueries,
@@ -138,6 +141,20 @@ const ManageQueriesPage = ({
       refetchOnWindowFocus: false,
       enabled: isRouteOk,
       staleTime: 5000,
+      onSuccess: (data) => {
+        if (data) {
+          const enhancedAllQueries = data.map(enhanceQuery);
+
+          const allQueriesAvailableToAutomate =
+            teamIdForApi && enhancedAllQueries
+              ? enhancedAllQueries.filter(
+                  (query: IEnhancedQuery) => query.team_id === currentTeamId
+                )
+              : enhancedAllQueries;
+
+          setQueriesAvailableToAutomate(allQueriesAvailableToAutomate);
+        }
+      },
     }
   );
 
@@ -150,12 +167,12 @@ const ManageQueriesPage = ({
   }, [teamIdForApi, enhancedQueries]);
 
   const automatedQueryIds = useMemo(() => {
-    return enhancedQueries
-      ? enhancedQueries
+    return queriesAvailableToAutomate
+      ? queriesAvailableToAutomate
           .filter((query) => query.automations_enabled)
           .map((query) => query.id)
       : [];
-  }, [enhancedQueries]);
+  }, [queriesAvailableToAutomate]);
 
   useEffect(() => {
     const path = location.pathname + location.search;
@@ -330,7 +347,7 @@ const ManageQueriesPage = ({
             onCancel={toggleManageAutomationsModal}
             isShowingPreviewDataModal={showPreviewDataModal}
             togglePreviewDataModal={togglePreviewDataModal}
-            availableQueries={enhancedQueries}
+            availableQueries={queriesAvailableToAutomate}
             automatedQueryIds={automatedQueryIds}
             logDestination={config?.logging.result.plugin || ""}
           />

--- a/frontend/pages/queries/ManageQueriesPage/ManageQueriesPage.tsx
+++ b/frontend/pages/queries/ManageQueriesPage/ManageQueriesPage.tsx
@@ -145,12 +145,11 @@ const ManageQueriesPage = ({
         if (data) {
           const enhancedAllQueries = data.map(enhanceQuery);
 
-          const allQueriesAvailableToAutomate =
-            teamIdForApi && enhancedAllQueries
-              ? enhancedAllQueries.filter(
-                  (query: IEnhancedQuery) => query.team_id === currentTeamId
-                )
-              : enhancedAllQueries;
+          const allQueriesAvailableToAutomate = teamIdForApi
+            ? enhancedAllQueries.filter(
+                (query: IEnhancedQuery) => query.team_id === currentTeamId
+              )
+            : enhancedAllQueries;
 
           setQueriesAvailableToAutomate(allQueriesAvailableToAutomate);
         }
@@ -168,10 +167,8 @@ const ManageQueriesPage = ({
 
   const automatedQueryIds = useMemo(() => {
     return queriesAvailableToAutomate
-      ? queriesAvailableToAutomate
-          .filter((query) => query.automations_enabled)
-          .map((query) => query.id)
-      : [];
+      .filter((query) => query.automations_enabled)
+      .map((query) => query.id);
   }, [queriesAvailableToAutomate]);
 
   useEffect(() => {


### PR DESCRIPTION
## Issue
Unreleased bug for #15605 

## Description
Fixes bug: Team view of queries and policies shows inherited queries and inherited policies, but should not show inherited queries and inherited policies in the manage automations modal
- Queries page > Manage automations modal should only show policies available to that team to modify
  - The single API call for global or team policies uses `onSuccess` functionality to set `queriesAvailableToAutomate` 
- Policies page > Calendar events modal and Other workflows modal should only show policies available to that team to modify
  - The global policies API call or team policies API call uses `onSuccess` functionality to set `policiesAvailableToAutomate`


## Screenshot
Notice the modal only shows policies that have the team_id the same as the team view.
<img width="1556" alt="Screenshot 2024-05-06 at 2 27 09 PM" src="https://github.com/fleetdm/fleet/assets/71795832/23184d60-d965-45b5-8961-7631a39e5a1d">
<img width="1550" alt="Screenshot 2024-05-06 at 2 26 55 PM" src="https://github.com/fleetdm/fleet/assets/71795832/ccde1a76-b6e2-4974-823c-f2e4ec7063d1">



# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [ ] Added/updated tests
- [x] Manual QA for all new/changed functionality

