### PR TITLE
Fixed MySQL sort buffer overflow when fetching activities.

### DIFF
--- a/changes/12619-fixed-activities-sort-buffer-overflow
+++ b/changes/12619-fixed-activities-sort-buffer-overflow
@@ -1,0 +1,1 @@
+Fixed MySQL sort buffer overflow when fetching activities. This issue happened when activities contained very large details, such as large SQL queries.

--- a/server/datastore/mysql/activities.go
+++ b/server/datastore/mysql/activities.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"strings"
 
@@ -101,44 +100,42 @@ func (ds *Datastore) ListActivities(ctx context.Context, opt fleet.ListActivitie
 	activitiesQ, args = appendListOptionsWithCursorToSQL(activitiesQ, args, &opt.ListOptions)
 
 	err := sqlx.SelectContext(ctx, ds.reader(ctx), &activities, activitiesQ, args...)
-	if err == sql.ErrNoRows {
-		return nil, nil, ctxerr.Wrap(ctx, notFound("Activity"))
-	} else if err != nil {
+	if err != nil {
 		return nil, nil, ctxerr.Wrap(ctx, err, "select activities")
 	}
 
-	// Fetch details as a separate query due to sort buffer issue triggered by large JSON details entries. Issue last reproduced on MySQL 8.0.36
-	// https://stackoverflow.com/questions/29575835/error-1038-out-of-sort-memory-consider-increasing-sort-buffer-size/67266529
-	IDs := make([]uint, 0, len(activities))
-	for _, a := range activities {
-		IDs = append(IDs, a.ID)
-	}
-	detailsStmt, detailsArgs, err := sqlx.In("SELECT id, details FROM activities WHERE id IN (?)", IDs)
-	if err != nil {
-		return nil, nil, ctxerr.Wrap(ctx, err, "Error binding activity IDs")
-	}
-	type activityDetails struct {
-		ID      uint             `db:"id"`
-		Details *json.RawMessage `db:"details"`
-	}
-	var details []activityDetails
-	err = sqlx.SelectContext(ctx, ds.reader(ctx), &details, detailsStmt, detailsArgs...)
-	if errors.Is(err, sql.ErrNoRows) {
-		return nil, nil, ctxerr.Wrap(ctx, notFound("Activity"))
-	} else if err != nil {
-		return nil, nil, ctxerr.Wrap(ctx, err, "select activities details")
-	}
-	detailsLookup := make(map[uint]*json.RawMessage, len(details))
-	for _, d := range details {
-		detailsLookup[d.ID] = d.Details
-	}
-	for _, a := range activities {
-		det, ok := detailsLookup[a.ID]
-		if !ok {
-			level.Warn(ds.logger).Log("msg", "Activity details not found", "activity_id", a.ID)
-			continue
+	if len(activities) > 0 {
+		// Fetch details as a separate query due to sort buffer issue triggered by large JSON details entries. Issue last reproduced on MySQL 8.0.36
+		// https://stackoverflow.com/questions/29575835/error-1038-out-of-sort-memory-consider-increasing-sort-buffer-size/67266529
+		IDs := make([]uint, 0, len(activities))
+		for _, a := range activities {
+			IDs = append(IDs, a.ID)
 		}
-		a.Details = det
+		detailsStmt, detailsArgs, err := sqlx.In("SELECT id, details FROM activities WHERE id IN (?)", IDs)
+		if err != nil {
+			return nil, nil, ctxerr.Wrap(ctx, err, "Error binding activity IDs")
+		}
+		type activityDetails struct {
+			ID      uint             `db:"id"`
+			Details *json.RawMessage `db:"details"`
+		}
+		var details []activityDetails
+		err = sqlx.SelectContext(ctx, ds.reader(ctx), &details, detailsStmt, detailsArgs...)
+		if err != nil {
+			return nil, nil, ctxerr.Wrap(ctx, err, "select activities details")
+		}
+		detailsLookup := make(map[uint]*json.RawMessage, len(details))
+		for _, d := range details {
+			detailsLookup[d.ID] = d.Details
+		}
+		for _, a := range activities {
+			det, ok := detailsLookup[a.ID]
+			if !ok {
+				level.Warn(ds.logger).Log("msg", "Activity details not found", "activity_id", a.ID)
+				continue
+			}
+			a.Details = det
+		}
 	}
 
 	// Fetch users as a stand-alone query (because of performance reasons)


### PR DESCRIPTION
#12619

Fixed MySQL sort buffer overflow when fetching activities. This issue happened when activities contained very large details, such as large SQL queries.

# Checklist for submitter
<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [ ] Added/updated tests
  - Existing tests provide sufficient coverage
- [x] Manual QA for all new/changed functionality
