### PR TITLE
[unreleased bug] FE: Fix empty types to match empty type returned from Policies APIs

### DIFF
--- a/frontend/interfaces/policy.ts
+++ b/frontend/interfaces/policy.ts
@@ -74,13 +74,16 @@ export interface IHostPolicy extends IPolicy {
   response: PolicyStatusResponse;
 }
 
+// Policies API can return {}
 export interface ILoadAllPoliciesResponse {
-  policies: IPolicyStats[];
+  policies?: IPolicyStats[];
 }
 
+// Team policies API can return {}
 export interface ILoadTeamPoliciesResponse {
-  policies: IPolicyStats[];
+  policies?: IPolicyStats[];
 }
+
 export interface IPolicyFormData {
   description?: string | number | boolean | undefined;
   resolution?: string | number | boolean | undefined;

--- a/frontend/pages/policies/ManagePoliciesPage/ManagePoliciesPage.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/ManagePoliciesPage.tsx
@@ -215,10 +215,10 @@ const ManagePolicyPage = ({
     },
     {
       enabled: isRouteOk && !isAnyTeamSelected,
-      select: (data) => data.policies,
+      select: (data) => data.policies || [],
       staleTime: 5000,
       onSuccess: (data) => {
-        setPoliciesAvailableToAutomate(data);
+        setPoliciesAvailableToAutomate(data || []);
       },
     }
   );
@@ -273,12 +273,12 @@ const ManagePolicyPage = ({
     },
     {
       enabled: isRouteOk && isPremiumTier && !!teamIdForApi,
-      select: (data: ILoadTeamPoliciesResponse) => data.policies,
+      select: (data: ILoadTeamPoliciesResponse) => data.policies || [],
       onSuccess: (data) => {
         const allPoliciesAvailableToAutomate = data.filter(
           (policy: IPolicy) => policy.team_id === currentTeamId
         );
-        setPoliciesAvailableToAutomate(allPoliciesAvailableToAutomate);
+        setPoliciesAvailableToAutomate(allPoliciesAvailableToAutomate || []);
       },
     }
   );


### PR DESCRIPTION
## Issue
Unreleased bug for #15605 

## Description
- Empty state (e.g. searching "abcdefg") was not rendering properly
- API can return empty object `{ }` for policies API  (as opposed to queries API that returns `{ queries: [] }` for its empty state). Fix frontend types to account for this and add comments. (https://fleetdm.slack.com/archives/C01EZVBHFHU/p1715032840166069?thread_ts=1715012041.228919&cid=C01EZVBHFHU)

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Manual QA for all new/changed functionality

