### PR TITLE
Website: Update build-static-content to only send GitHub requests if an access token is provided, add command to start website to website/package.json

### DIFF
--- a/handbook/digital-experience/README.md
+++ b/handbook/digital-experience/README.md
@@ -66,7 +66,7 @@ Once you have the above follow these steps:
 
     > When this script runs, the website's configuration file ([`website/.sailsrc`](https://github.com/fleetdm/fleet/blob/main/website/.sailsrc)) will automatically be updated with information the website uses to display content built from Markdown and YAML. Changes to this file should never be committed to the GitHub repo. If you want to exclude changes to this file in any PRs you make, you can run this terminal command in your local copy of the Fleet repo: `git update-index --assume-unchanged ./website/.sailsrc`.
     
-    > Note: You can run `npm run start-website` in the `website/` folder to run the `build-static-content` script and start the website server with a single command.
+    > Note: You can run `npm run start-dev` in the `website/` folder to run the `build-static-content` script and start the website server with a single command.
 
 3. Once the script is complete, start the website server:
   - **With Node.js:** start the server by running `node ./node_modules/sails/bin/sails lift`

--- a/handbook/digital-experience/README.md
+++ b/handbook/digital-experience/README.md
@@ -63,14 +63,12 @@ Once you have the above follow these steps:
 2. Run the `build-static-content` script to generate HTML pages from our Markdown and YAML content.
   - **With Node**, you will need to use `node ./node_modules/sails/bin/sails run build-static-content` to execute the script.
   - **With Sails.js installed globally** you can use `sails run build-static-content` to execute the script.
-    
-    > You can use the `--skipGithubRequests` flag to skip requests made to GitHub if you get rate-limited by GitHub’s API while running this script. 
-    > 
-    > e.g., `node ./node_modules/sails/bin/sails run build-static-content --skipGithubRequests`
 
     > When this script runs, the website's configuration file ([`website/.sailsrc`](https://github.com/fleetdm/fleet/blob/main/website/.sailsrc)) will automatically be updated with information the website uses to display content built from Markdown and YAML. Changes to this file should never be committed to the GitHub repo. If you want to exclude changes to this file in any PRs you make, you can run this terminal command in your local copy of the Fleet repo: `git update-index --assume-unchanged ./website/.sailsrc`.
+    
+    > Note: You can run `npm run start-website` in the `website/` folder to run the `build-static-content` script and start the website server with a single command.
 
-3. Once the script is complete, start the website server. From the `website/` folder:
+3. Once the script is complete, start the website server:
   - **With Node.js:** start the server by running `node ./node_modules/sails/bin/sails lift`
   - **With Sails.js installed globally:** start the server by running `sails lift`.
 

--- a/website/README.md
+++ b/website/README.md
@@ -7,17 +7,8 @@ This is where the code for the public https://fleetdm.com website lives.
 To report a bug or make a suggestion for the website, [click here](https://github.com/fleetdm/fleet/issues).
 
 ## Testing locally
-Run the following commands to test the site locally:
 
-```sh
-npm install -g sails
-cd website/
-npm install
-npm run start-website
-```
-
-Your local copy of the website is now running at [http://localhost:2024](http://localhost:2024)!
-
+See https://fleetdm.com/handbook/digital-experience#test-fleetdm-com-locally
 
 ## Deploying the website
 To deploy changes to the website to production, merge changes to the `main` branch.  If the changes affect the website's code, or touch any files that the website relies on to build content, such as the query library, osquery schema, docs, handbook, articles, etc., then the website will be redeployed.

--- a/website/README.md
+++ b/website/README.md
@@ -13,8 +13,7 @@ Run the following commands to test the site locally:
 npm install -g sails
 cd website/
 npm install
-sails run scripts/build-static-content.js
-sails lift
+npm run start-website
 ```
 
 Your local copy of the website is now running at [http://localhost:2024](http://localhost:2024)!

--- a/website/package.json
+++ b/website/package.json
@@ -33,6 +33,7 @@
     "build": "echo '\"npm run build\" deliberately left unimplemented to prevent its use, since different platforms like Heroku and GitHub Actions all like to try and run it by default, which can lead to inadvertent duplication and unnecessary lock-in, since one has to find the config to turn that off.'",
     "lint": "./node_modules/eslint/bin/eslint.js . --max-warnings=0 --report-unused-disable-directives && echo '✔  Your .js files look so good.' && ./node_modules/htmlhint/bin/htmlhint -c ./.htmlhintrc views/*.ejs && ./node_modules/htmlhint/bin/htmlhint -c ./.htmlhintrc views/**/*.ejs && ./node_modules/htmlhint/bin/htmlhint -c ./.htmlhintrc views/**/**/*.ejs && ./node_modules/htmlhint/bin/htmlhint -c ./.htmlhintrc views/pages/**/**/*.ejs && ./node_modules/htmlhint/bin/htmlhint -c ./.htmlhintrc views/pages/**/**/**/*.ejs && ./node_modules/htmlhint/bin/htmlhint -c ./.htmlhintrc views/pages/**/**/**/**/*.ejs && ./node_modules/htmlhint/bin/htmlhint -c ./.htmlhintrc views/pages/**/**/**/**/**/*.ejs && echo '✔  So do your .ejs files.' && ./node_modules/lesshint/bin/lesshint assets/styles/ --max-warnings=0 && echo '✔  Your .less files look good, too.'",
     "start": "NODE_ENV=production node app.js",
+    "start-website": "./node_modules/sails/bin/sails.js run build-static-content && ./node_modules/sails/bin/sails.js console",
     "test": "npm run lint && npm run custom-tests && echo 'Done.'",
     "wipe": "sails_datastores__default__adapter=sails-postgresql sails_datastores__default__ssl='{ \"rejectUnauthorized\": false }' sails lift --drop"
   },

--- a/website/package.json
+++ b/website/package.json
@@ -33,7 +33,7 @@
     "build": "echo '\"npm run build\" deliberately left unimplemented to prevent its use, since different platforms like Heroku and GitHub Actions all like to try and run it by default, which can lead to inadvertent duplication and unnecessary lock-in, since one has to find the config to turn that off.'",
     "lint": "./node_modules/eslint/bin/eslint.js . --max-warnings=0 --report-unused-disable-directives && echo '✔  Your .js files look so good.' && ./node_modules/htmlhint/bin/htmlhint -c ./.htmlhintrc views/*.ejs && ./node_modules/htmlhint/bin/htmlhint -c ./.htmlhintrc views/**/*.ejs && ./node_modules/htmlhint/bin/htmlhint -c ./.htmlhintrc views/**/**/*.ejs && ./node_modules/htmlhint/bin/htmlhint -c ./.htmlhintrc views/pages/**/**/*.ejs && ./node_modules/htmlhint/bin/htmlhint -c ./.htmlhintrc views/pages/**/**/**/*.ejs && ./node_modules/htmlhint/bin/htmlhint -c ./.htmlhintrc views/pages/**/**/**/**/*.ejs && ./node_modules/htmlhint/bin/htmlhint -c ./.htmlhintrc views/pages/**/**/**/**/**/*.ejs && echo '✔  So do your .ejs files.' && ./node_modules/lesshint/bin/lesshint assets/styles/ --max-warnings=0 && echo '✔  Your .less files look good, too.'",
     "start": "NODE_ENV=production node app.js",
-    "start-website": "./node_modules/sails/bin/sails.js run build-static-content && ./node_modules/sails/bin/sails.js console",
+    "start-dev": "./node_modules/sails/bin/sails.js run build-static-content && ./node_modules/sails/bin/sails.js console",
     "test": "npm run lint && npm run custom-tests && echo 'Done.'",
     "wipe": "sails_datastores__default__adapter=sails-postgresql sails_datastores__default__ssl='{ \"rejectUnauthorized\": false }' sails lift --drop"
   },

--- a/website/scripts/build-static-content.js
+++ b/website/scripts/build-static-content.js
@@ -122,9 +122,8 @@ module.exports = {
             githubDataByUsername[username] = await sails.helpers.http.get.with({
               url: 'https://api.github.com/users/' + encodeURIComponent(username),
               headers: baseHeadersForGithubRequests,
-            }).catch((err)=>{
-              // Note: since this only
-              throw new Error(`When validating users in standard-query-library.yml, an error when a request was sent to GitHub get the information about a user (username: ${username}). Error: ${err}`);
+            }).intercept((err)=>{
+              return new Error(`When validating users in standard-query-library.yml, an error when a request was sent to GitHub get the information about a user (username: ${username}). Error: ${err}`);
             });
           });//∞
           // Now expand queries with relevant profile data for the contributors.

--- a/website/scripts/build-static-content.js
+++ b/website/scripts/build-static-content.js
@@ -9,7 +9,6 @@ module.exports = {
 
   inputs: {
     dry: { type: 'boolean', description: 'Whether to make this a dry run.  (.sailsrc file will not be overwritten.  HTML files will not be generated.)' },
-    skipGithubRequests: { type: 'boolean', description: 'Support for this flag has been disabled, it is only left as an input to not throw errors when contributors'},
     githubAccessToken: { type: 'string', description: 'If provided, A GitHub token will be used to authenticate requests to the GitHub API'},
   },
 

--- a/website/scripts/build-static-content.js
+++ b/website/scripts/build-static-content.js
@@ -123,7 +123,7 @@ module.exports = {
               url: 'https://api.github.com/users/' + encodeURIComponent(username),
               headers: baseHeadersForGithubRequests,
             }).intercept((err)=>{
-              return new Error(`When validating users in standard-query-library.yml, an error when a request was sent to GitHub get the information about a user (username: ${username}). Error: ${err}`);
+              return new Error(`When validating users in standard-query-library.yml, an error when a request was sent to GitHub get the information about a user (username: ${username}). Error: ${err.stack}`);
             });
           });//∞
           // Now expand queries with relevant profile data for the contributors.

--- a/website/scripts/build-static-content.js
+++ b/website/scripts/build-static-content.js
@@ -14,7 +14,6 @@ module.exports = {
 
 
   fn: async function ({ dry, githubAccessToken }) {
-
     let path = require('path');
     let YAML = require('yaml');
 
@@ -33,7 +32,7 @@ module.exports = {
         'Authorization': `token ${githubAccessToken}`,
       };
     } else {
-      sails.log('Skipping GitHub API requests for contributer profiles and ritual validation.\nNOTE: The contributors in the standard query library will be populated with fake data.\nTo see how the standard query library will look on fleetdm.com, pass a GitHub access token into this script with the `--githubAccessToken={YOUR_GITHUB_ACCESS_TOKEN}` flag.');
+      sails.log('Skipping GitHub API requests for contributer profiles and ritual validation.\nNOTE: The contributors in the standard query library will be populated with fake data.\nTo see how the standard query library will look on fleetdm.com, pass a GitHub access token into this script with the `--githubAccessToken={YOUR_GITHUB_ACCESS_TOKEN}` flag. \n Note: This script can take up to 30s to run.');
     }//ﬁ
 
     await sails.helpers.flow.simultaneously([

--- a/website/scripts/build-static-content.js
+++ b/website/scripts/build-static-content.js
@@ -9,12 +9,11 @@ module.exports = {
 
   inputs: {
     dry: { type: 'boolean', description: 'Whether to make this a dry run.  (.sailsrc file will not be overwritten.  HTML files will not be generated.)' },
-    skipGithubRequests: { type: 'boolean', description: 'Whether to minimize requests to the GitHub API which usually can be skipped during local development, such as requests used for fetching GitHub avatar URLs'},
     githubAccessToken: { type: 'string', description: 'If provided, A GitHub token will be used to authenticate requests to the GitHub API'},
   },
 
 
-  fn: async function ({ dry, skipGithubRequests, githubAccessToken }) {
+  fn: async function ({ dry, githubAccessToken }) {
 
     let path = require('path');
     let YAML = require('yaml');
@@ -27,17 +26,15 @@ module.exports = {
     let rootRelativeUrlPathsSeen = [];
     let baseHeadersForGithubRequests;
     let osqueryTables = [];
-    if(!skipGithubRequests){
+    if(githubAccessToken) {// If a github token was provided, set headers for requests to GitHub.
       baseHeadersForGithubRequests = {
         'User-Agent': 'Fleet-Standard-Query-Library',
         'Accept': 'application/vnd.github.v3+json',
+        'Authorization': `token ${githubAccessToken}`,
       };
-
-      if(githubAccessToken) {
-        // If a GitHub access token was provided, add it to the baseHeadersForGithubRequests object.
-        baseHeadersForGithubRequests['Authorization'] = `token ${githubAccessToken}`;
-      }
-    }
+    } else {
+      sails.log('Skipping GitHub API requests for contributer profiles and ritual validation.\nNOTE: The contributors in the standard query library will be populated with fake data.\nTo see how the standard query library will look on fleetdm.com, pass a GitHub access token into this script with the `--githubAccessToken={YOUR_GITHUB_ACCESS_TOKEN}` flag.');
+    }//ﬁ
 
     await sails.helpers.flow.simultaneously([
       async()=>{// Parse query library from YAML and prepare to bake them into the Sails app's configuration.
@@ -119,8 +116,7 @@ module.exports = {
 
         let githubDataByUsername = {};
 
-        if(skipGithubRequests) {// If the --skipGithubRequests flag was provided, we'll skip querying GitHubs API
-          sails.log('Skipping GitHub API requests for contributer profiles.\nNOTE: The contributors in the standard query library will be populated with fake data. To see how the standard query library will look on fleetdm.com, run this script without the `--skipGithubRequests` flag.');
+        if(!githubAccessToken) {// If no github token was provided, don't validate
           // Because we're not querying GitHub to get the real names for contributer profiles, we'll use their GitHub username as their name and their handle
           for (let query of queries) {
             let usernames = query.contributors.split(',');
@@ -135,18 +131,15 @@ module.exports = {
             }
             query.contributors = contributorProfiles;
           }
-        } else {// If the --skipGithubRequests flag was not provided, we'll query GitHub's API to get additional information about each contributor.
+        } else {// Otherwise, validate all users listed in the standard query library YAML.
 
           await sails.helpers.flow.simultaneouslyForEach(githubUsernames, async(username)=>{
             githubDataByUsername[username] = await sails.helpers.http.get.with({
               url: 'https://api.github.com/users/' + encodeURIComponent(username),
               headers: baseHeadersForGithubRequests,
-            }).catch((err)=>{// If the above GET requests return a non 200 response we'll look for signs that the user has hit their GitHub API rate limit.
-              if (err.raw.statusCode === 403 && err.raw.headers['x-ratelimit-remaining'] === '0') {// If the user has reached their GitHub API rate limit, we'll throw an error that suggest they run this script with the `--skipGithubRequests` flag.
-                throw new Error('GitHub API rate limit exceeded. If you\'re running this script in a development environment, use the `--skipGithubRequests` flag to skip querying the GitHub API. See full error for more details:\n'+err);
-              } else {// If the error was not because of the user's API rate limit, we'll display the full error
-                throw err;
-              }
+            }).catch((err)=>{
+              // Note: since this only
+              throw new Error(`When validating users in standard-query-library.yml, an error when a request was sent to GitHub get the information about a user (username: ${username}). Error: ${err}`);
             });
           });//∞
           // Now expand queries with relevant profile data for the contributors.
@@ -163,7 +156,7 @@ module.exports = {
             }
             query.contributors = contributorProfiles;
           }
-        }
+        }//ﬁ
 
         // Attach to what will become configuration for the Sails app.
         builtStaticContent.queries = queries;
@@ -1012,16 +1005,14 @@ module.exports = {
               if (!KNOWN_AUTOMATABLE_FREQUENCIES.includes(ritual.frequency)) {
                 throw new Error(`Could not build rituals from ${ritualsYamlFilePath}. Invalid ritual: "${ritual.task}" indicates frequency "${ritual.frequency}", but that isn't supported with automations turned on.  Supported frequencies: ${KNOWN_AUTOMATABLE_FREQUENCIES}`);
               }
-              if(!skipGithubRequests){ // If the ritual has an autoIssue value, we'll validate that the DRI value is a GitHub username.
+              if(githubAccessToken){ // If the ritual has an autoIssue value, we'll validate that the DRI value is a GitHub username.
                 await sails.helpers.http.get.with({
                   url: 'https://api.github.com/users/' + encodeURIComponent(ritual.dri),
                   headers: baseHeadersForGithubRequests
-                }).intercept((err)=>{// If the above GET requests return a non 200 response we'll look for signs that the user has hit their GitHub API rate limit.
-                  if (err.raw.statusCode === 403 && err.raw.headers['x-ratelimit-remaining'] === '0') {// If the user has reached their GitHub API rate limit, we'll throw an error that suggest they run this script with the `--skipGithubRequests` flag.
-                    return new Error('GitHub API rate limit exceeded. If you\'re running this script in a development environment, use the `--skipGithubRequests` flag to skip querying the GitHub API. See full error for more details:\n'+err);
-                  } else if(err.raw.statusCode === 404) {// If the GitHub API responds with a 404, we'll throw an error with a message about the invalid GitHub username.
+                }).intercept((err)=>{
+                  if(err.raw.statusCode === 404) {// If the GitHub API responds with a 404, we'll throw an error with a message about the invalid GitHub username.
                     return new Error(`Could not build rituals from ${ritualsYamlFilePath}. The DRI value of a ritual (${ritual.task}) contains an invalid GitHub username (${ritual.dri}). To resolve, make sure the DRI value for this ritual is a valid GitHub username.`);
-                  } else {// If the error was not a 404 and not because of the user's API rate limit, we'll display the full error
+                  } else {// If the error was not a 404, we'll display the full error
                     return err;
                   }
                 });
@@ -1058,8 +1049,8 @@ module.exports = {
           rituals[relativeRepoPathForThisRitualsFile] = ritualsFromRitualTableYaml;
 
         }//∞
-        // Validate all GitHub labels used in all ritual yaml files. Note: We check these here to minimize requests to the GitHub API. We'll send requests to get all existing labels in the Fleet repo, and will throw an error if a label in a rituals YAML file does not exist in the repo.
-        if(!skipGithubRequests){
+        if(githubAccessToken) {
+        // Validate all GitHub labels used in all ritual yaml files. Note: We check these here to minimize requests to the GitHub API.
           for(let repo in githubLabelsToCheck){
             let allExistingLabelsInSpecifiedRepo = [];
             let pageOfResultsReturned = 0;
@@ -1083,7 +1074,7 @@ module.exports = {
               }
             });//∞
           }
-        }
+        }//ﬁ
 
         // Add the rituals dictionary to builtStaticContent.rituals
         builtStaticContent.rituals = rituals;


### PR DESCRIPTION
Closes: #18787

Changes:
- Updated the `build-static-content` script to only send requests to GitHub if a GitHub token was provided via the `--GithubAccessToken` flag, and removed the skipGithubRequests input.
- Added a command to website/package.json to run the build static content script and start the website server (`npm run start-website`)
- Updated the "Test fleetdm.com locally" section of the Digital Experience handbook page.
- Updated the "Testing locally" section of the website's readme