### PR TITLE
Bugfix: 18843 fix policy host counts

### DIFF
--- a/server/datastore/mysql/policies.go
+++ b/server/datastore/mysql/policies.go
@@ -641,11 +641,11 @@ func (ds *Datastore) ListMergedTeamPolicies(ctx context.Context, teamID uint, op
 		FROM policies p
 		LEFT JOIN users u ON p.author_id = u.id
 		LEFT JOIN policy_stats ps ON p.id = ps.policy_id
-		AND ps.inherited_team_id = COALESCE(p.team_id, 0)
+		AND ps.inherited_team_id = IF(p.team_id IS NULL, ?, 0)
 		WHERE (p.team_id = ? OR p.team_id IS NULL)
     `
 
-	args = append(args, teamID)
+	args = append(args, teamID, teamID)
 
 	// We must normalize the name for full Unicode support (Unicode equivalence).
 	match := norm.NFC.String(opts.MatchQuery)

--- a/server/datastore/mysql/policies_test.go
+++ b/server/datastore/mysql/policies_test.go
@@ -35,7 +35,7 @@ func TestPolicies(t *testing.T) {
 		{"MembershipViewNotDeferred", func(t *testing.T, ds *Datastore) { testPoliciesMembershipView(false, t, ds) }},
 		{"TeamPolicyLegacy", testTeamPolicyLegacy},
 		{"TeamPolicyProprietary", testTeamPolicyProprietary},
-		// {"ListMergedTeamPolicies", testListMergedTeamPolicies},
+		{"ListMergedTeamPolicies", testListMergedTeamPolicies},
 		{"PolicyQueriesForHost", testPolicyQueriesForHost},
 		{"PolicyQueriesForHostPlatforms", testPolicyQueriesForHostPlatforms},
 		{"PoliciesByID", testPoliciesByID},
@@ -710,8 +710,7 @@ func testTeamPolicyProprietary(t *testing.T, ds *Datastore) {
 	require.Equal(t, user1.ID, *team2Policies[0].AuthorID)
 }
 
-func TestListMergedTeamPolicies(t *testing.T) {
-	ds := CreateMySQLDS(t)
+func testListMergedTeamPolicies(t *testing.T, ds *Datastore) {
 	ctx := context.Background()
 	gpol, err := ds.NewGlobalPolicy(ctx, nil, fleet.PolicyPayload{
 		Name:        "query1 global",

--- a/server/datastore/mysql/policies_test.go
+++ b/server/datastore/mysql/policies_test.go
@@ -35,7 +35,7 @@ func TestPolicies(t *testing.T) {
 		{"MembershipViewNotDeferred", func(t *testing.T, ds *Datastore) { testPoliciesMembershipView(false, t, ds) }},
 		{"TeamPolicyLegacy", testTeamPolicyLegacy},
 		{"TeamPolicyProprietary", testTeamPolicyProprietary},
-		{"ListMergedTeamPolicies", testListMergedTeamPolicies},
+		// {"ListMergedTeamPolicies", testListMergedTeamPolicies},
 		{"PolicyQueriesForHost", testPolicyQueriesForHost},
 		{"PolicyQueriesForHostPlatforms", testPolicyQueriesForHostPlatforms},
 		{"PoliciesByID", testPoliciesByID},
@@ -710,7 +710,8 @@ func testTeamPolicyProprietary(t *testing.T, ds *Datastore) {
 	require.Equal(t, user1.ID, *team2Policies[0].AuthorID)
 }
 
-func testListMergedTeamPolicies(t *testing.T, ds *Datastore) {
+func TestListMergedTeamPolicies(t *testing.T) {
+	ds := CreateMySQLDS(t)
 	ctx := context.Background()
 	gpol, err := ds.NewGlobalPolicy(ctx, nil, fleet.PolicyPayload{
 		Name:        "query1 global",
@@ -723,7 +724,7 @@ func testListMergedTeamPolicies(t *testing.T, ds *Datastore) {
 	team1, err := ds.NewTeam(ctx, &fleet.Team{Name: "team1"})
 	require.NoError(t, err)
 
-	p, err := ds.NewTeamPolicy(ctx, team1.ID, nil, fleet.PolicyPayload{
+	team1policy, err := ds.NewTeamPolicy(ctx, team1.ID, nil, fleet.PolicyPayload{
 		Name:        "query2 team1",
 		Query:       "select 1;",
 		Description: "query1 desc",
@@ -734,7 +735,7 @@ func testListMergedTeamPolicies(t *testing.T, ds *Datastore) {
 	team2, err := ds.NewTeam(ctx, &fleet.Team{Name: "team2"})
 	require.NoError(t, err)
 
-	_, err = ds.NewTeamPolicy(ctx, team2.ID, nil, fleet.PolicyPayload{
+	team2policy, err := ds.NewTeamPolicy(ctx, team2.ID, nil, fleet.PolicyPayload{
 		Name:        "query3 team2",
 		Query:       "select 2;",
 		Description: "query2 desc",
@@ -748,10 +749,6 @@ func testListMergedTeamPolicies(t *testing.T, ds *Datastore) {
 	})
 	require.NoError(t, err)
 
-	require.Len(t, merged, 2)
-	assert.Equal(t, gpol.ID, merged[0].ID)
-	assert.Equal(t, p.ID, merged[1].ID)
-
 	// Test list options affect both global and team policies
 	merged, err = ds.ListMergedTeamPolicies(ctx, team1.ID, fleet.ListOptions{
 		OrderKey:       "name",
@@ -760,7 +757,7 @@ func testListMergedTeamPolicies(t *testing.T, ds *Datastore) {
 	require.NoError(t, err)
 
 	require.Len(t, merged, 2)
-	assert.Equal(t, p.ID, merged[0].ID)
+	assert.Equal(t, team1policy.ID, merged[0].ID)
 	assert.Equal(t, gpol.ID, merged[1].ID)
 
 	// Test filter
@@ -776,7 +773,68 @@ func testListMergedTeamPolicies(t *testing.T, ds *Datastore) {
 	})
 	require.NoError(t, err)
 	require.Len(t, merged, 1)
-	assert.Equal(t, p.ID, merged[0].ID)
+	assert.Equal(t, team1policy.ID, merged[0].ID)
+
+	// Test HostPolicyCounts
+
+	// Global Host
+	host, err := ds.NewHost(context.Background(), &fleet.Host{OsqueryHostID: ptr.String(fmt.Sprint("host1")), NodeKey: ptr.String(fmt.Sprint("host1", 1)), TeamID: nil})
+	require.NoError(t, err)
+
+	err = ds.RecordPolicyQueryExecutions(ctx, host, map[uint]*bool{gpol.ID: ptr.Bool(true)}, time.Now(), false)
+	require.NoError(t, err)
+
+	err = ds.UpdateHostPolicyCounts(context.Background())
+	require.NoError(t, err)
+
+	// team 1 shows no host counts
+	merged, err = ds.ListMergedTeamPolicies(ctx, team1.ID, fleet.ListOptions{
+		OrderKey: "name",
+	})
+	require.NoError(t, err)
+	require.Len(t, merged, 2)
+	assert.Equal(t, gpol.ID, merged[0].ID)
+	assert.Equal(t, uint(0), merged[0].PassingHostCount)
+	assert.Equal(t, uint(0), merged[0].FailingHostCount)
+	assert.Equal(t, team1policy.ID, merged[1].ID)
+	assert.Equal(t, uint(0), merged[1].PassingHostCount)
+	assert.Equal(t, uint(0), merged[1].FailingHostCount)
+
+	// move host to team1
+	err = ds.AddHostsToTeam(ctx, &team1.ID, []uint{host.ID})
+	require.NoError(t, err)
+
+	err = ds.RecordPolicyQueryExecutions(ctx, host, map[uint]*bool{team1policy.ID: ptr.Bool(true)}, time.Now(), false)
+	require.NoError(t, err)
+
+	err = ds.UpdateHostPolicyCounts(context.Background())
+	require.NoError(t, err)
+
+	// team 1 shows host counts
+	merged, err = ds.ListMergedTeamPolicies(ctx, team1.ID, fleet.ListOptions{
+		OrderKey: "name",
+	})
+	require.NoError(t, err)
+	require.Len(t, merged, 2)
+	assert.Equal(t, gpol.ID, merged[0].ID)
+	assert.Equal(t, uint(1), merged[0].PassingHostCount)
+	assert.Equal(t, uint(0), merged[0].FailingHostCount)
+	assert.Equal(t, team1policy.ID, merged[1].ID)
+	assert.Equal(t, uint(1), merged[1].PassingHostCount)
+	assert.Equal(t, uint(0), merged[1].FailingHostCount)
+
+	// team2 shows no host counts
+	merged, err = ds.ListMergedTeamPolicies(ctx, team2.ID, fleet.ListOptions{
+		OrderKey: "name",
+	})
+	require.NoError(t, err)
+	require.Len(t, merged, 2)
+	assert.Equal(t, gpol.ID, merged[0].ID)
+	assert.Equal(t, uint(0), merged[0].PassingHostCount)
+	assert.Equal(t, uint(0), merged[0].FailingHostCount)
+	assert.Equal(t, team2policy.ID, merged[1].ID)
+	assert.Equal(t, uint(0), merged[1].PassingHostCount)
+	assert.Equal(t, uint(0), merged[1].FailingHostCount)
 }
 
 func newTestHostWithPlatform(t *testing.T, ds *Datastore, hostname, platform string, teamID *uint) *fleet.Host {
@@ -1760,7 +1818,6 @@ func testApplyPolicySpecWithQueryPlatformChanges(t *testing.T, ds *Datastore) {
 	assert.Equal(t, uint(2), polsByName[teamNames[0]].FailingHostCount)   // updated platform
 	assert.Equal(t, uint(1), polsByName[teamNames[1]].FailingHostCount)   // platform is "darwin" -- no change
 	assert.Equal(t, uint(0), polsByName[teamNames[2]].FailingHostCount)   // updated query
-
 }
 
 func testPoliciesSave(t *testing.T, ds *Datastore) {
@@ -3180,7 +3237,6 @@ func testUpdatePolicyHostCounts(t *testing.T, ds *Datastore) {
 	assert.True(
 		t, policy2.HostCountUpdatedAt.Compare(later) < 0, fmt.Sprintf("later:%v HostCountUpdatedAt:%v", later, *policy2.HostCountUpdatedAt),
 	)
-
 }
 
 func testPoliciesNameUnicode(t *testing.T, ds *Datastore) {

--- a/server/datastore/mysql/policies_test.go
+++ b/server/datastore/mysql/policies_test.go
@@ -743,14 +743,8 @@ func TestListMergedTeamPolicies(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	merged, err := ds.ListMergedTeamPolicies(ctx, team1.ID, fleet.ListOptions{
-		OrderKey:       "name",
-		OrderDirection: fleet.OrderAscending,
-	})
-	require.NoError(t, err)
-
 	// Test list options affect both global and team policies
-	merged, err = ds.ListMergedTeamPolicies(ctx, team1.ID, fleet.ListOptions{
+	merged, err := ds.ListMergedTeamPolicies(ctx, team1.ID, fleet.ListOptions{
 		OrderKey:       "name",
 		OrderDirection: fleet.OrderDescending,
 	})


### PR DESCRIPTION
#18843 

Corrected join on `policy_stats` table

- [X] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [X] Added/updated tests
- [X] Manual QA for all new/changed functionality
 