### PR TITLE
Add backoff and retry to vuln downloads

### DIFF
--- a/pkg/download/download.go
+++ b/pkg/download/download.go
@@ -59,6 +59,14 @@ func download(client *http.Client, u *url.URL, path string, extract bool) error 
 	}()
 
 	operation := func() error {
+		if err := tmpFile.Truncate(0); err != nil {
+			return fmt.Errorf("truncate temporary file: %w", err)
+		}
+
+		if _, err := tmpFile.Seek(0, 0); err != nil {
+			return fmt.Errorf("seek temporary file: %w", err)
+		}
+
 		req, err := http.NewRequest(http.MethodGet, u.String(), nil)
 		if err != nil {
 			return err

--- a/pkg/download/download.go
+++ b/pkg/download/download.go
@@ -12,8 +12,11 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/cenkalti/backoff/v4"
 	"github.com/ulikunitz/xz"
 )
+
+const backoffMaxElapsedTime = 3 * 60 // 3 minutes
 
 // Download downloads a file from a URL and writes it to path.
 func Download(client *http.Client, u *url.URL, path string) error {
@@ -55,43 +58,53 @@ func download(client *http.Client, u *url.URL, path string, extract bool) error 
 		}
 	}()
 
-	req, err := http.NewRequest(http.MethodGet, u.String(), nil)
-	if err != nil {
-		return err
-	}
-
-	resp, err := client.Do(req)
-	if err != nil {
-		return err
-	}
-	defer resp.Body.Close()
-
-	r := io.Reader(resp.Body)
-
-	// extract (optional)
-	if extract {
-		switch {
-		case strings.HasSuffix(u.Path, "gz"):
-			gr, err := gzip.NewReader(resp.Body)
-			if err != nil {
-				return err
-			}
-			r = gr
-		case strings.HasSuffix(u.Path, "bz2"):
-			r = bzip2.NewReader(resp.Body)
-		case strings.HasSuffix(u.Path, "xz"):
-			xzr, err := xz.NewReader(resp.Body)
-			if err != nil {
-				return err
-			}
-			r = xzr
-		default:
-			return fmt.Errorf("unknown extension: %s", u.Path)
+	operation := func() error {
+		req, err := http.NewRequest(http.MethodGet, u.String(), nil)
+		if err != nil {
+			return err
 		}
+
+		resp, err := client.Do(req)
+		if err != nil {
+			return err
+		}
+		defer resp.Body.Close()
+
+		r := io.Reader(resp.Body)
+
+		// extract (optional)
+		if extract {
+			switch {
+			case strings.HasSuffix(u.Path, "gz"):
+				gr, err := gzip.NewReader(resp.Body)
+				if err != nil {
+					return err
+				}
+				r = gr
+			case strings.HasSuffix(u.Path, "bz2"):
+				r = bzip2.NewReader(resp.Body)
+			case strings.HasSuffix(u.Path, "xz"):
+				xzr, err := xz.NewReader(resp.Body)
+				if err != nil {
+					return err
+				}
+				r = xzr
+			default:
+				return fmt.Errorf("unknown extension: %s", u.Path)
+			}
+		}
+
+		if _, err := io.Copy(tmpFile, r); err != nil {
+			return err
+		}
+
+		return nil
 	}
 
-	if _, err := io.Copy(tmpFile, r); err != nil {
-		return err
+	expBackOff := backoff.NewExponentialBackOff()
+	expBackOff.MaxElapsedTime = backoffMaxElapsedTime
+	if err := backoff.Retry(operation, expBackOff); err != nil {
+		return fmt.Errorf("download and write file: %w", err)
 	}
 
 	// Writes are not synchronous. Handle errors from writes returned by Close.


### PR DESCRIPTION
This adds a 3min max retry interval when downloading vulnerability assets.  The need was discovered initially due to frequent test failures when downloading an unstable Ubuntu Kinetic OVAL feed.