### PR TITLE
Fleet UI: Updated styles to license expiration banner

### DIFF
--- a/changes/17860-improve-license-expiration-banner
+++ b/changes/17860-improve-license-expiration-banner
@@ -1,0 +1,1 @@
+- UI: Updated look to license expiration banner

--- a/frontend/components/CustomLink/CustomLink.tsx
+++ b/frontend/components/CustomLink/CustomLink.tsx
@@ -12,6 +12,7 @@ interface ICustomLinkProps {
   /** Icon wraps on new line with last word */
   multiline?: boolean;
   iconColor?: Colors;
+  color?: "core-fleet-blue" | "core-fleet-black";
 }
 
 const baseClass = "custom-link";
@@ -23,8 +24,11 @@ const CustomLink = ({
   newTab = false,
   multiline = false,
   iconColor = "core-fleet-blue",
+  color = "core-fleet-blue",
 }: ICustomLinkProps): JSX.Element => {
-  const customLinkClass = classnames(baseClass, className);
+  const customLinkClass = classnames(baseClass, className, {
+    [`${baseClass}--black`]: color === "core-fleet-black",
+  });
 
   const target = newTab ? "_blank" : "";
 

--- a/frontend/components/CustomLink/_styles.scss
+++ b/frontend/components/CustomLink/_styles.scss
@@ -9,4 +9,8 @@
       padding-left: 6px;
     }
   }
+
+  &--black {
+    color: $core-fleet-black;
+  }
 }

--- a/frontend/components/LicenseExpirationBanner/LicenseExpirationBanner.tsx
+++ b/frontend/components/LicenseExpirationBanner/LicenseExpirationBanner.tsx
@@ -1,0 +1,28 @@
+import React from "react";
+
+import InfoBanner from "components/InfoBanner";
+import CustomLink from "components/CustomLink";
+
+const baseClass = "license-expiry-banner";
+
+const LicenseExpirationBanner = (): JSX.Element => {
+  return (
+    <InfoBanner
+      className={baseClass}
+      color="yellow"
+      cta={
+        <CustomLink
+          url="https://fleetdm.com/learn-more-about/downgrading"
+          text="Downgrade or renew"
+          newTab
+          iconColor="core-fleet-black"
+          color="core-fleet-black"
+        />
+      }
+    >
+      Your Fleet Premium license is about to expire.
+    </InfoBanner>
+  );
+};
+
+export default LicenseExpirationBanner;

--- a/frontend/components/LicenseExpirationBanner/_styles.scss
+++ b/frontend/components/LicenseExpirationBanner/_styles.scss
@@ -1,4 +1,4 @@
-.apple-bm-terms-message {
+.license-expiry-banner {
   margin-bottom: $pad-large;
   position: sticky; // Needed for settings page scroll
   z-index: 4; // Needed for settings page scroll

--- a/frontend/components/LicenseExpirationBanner/index.ts
+++ b/frontend/components/LicenseExpirationBanner/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./LicenseExpirationBanner";

--- a/frontend/components/MDM/AppleBMTermsMessage/AppleBMTermsMessage.tsx
+++ b/frontend/components/MDM/AppleBMTermsMessage/AppleBMTermsMessage.tsx
@@ -1,26 +1,31 @@
 import React from "react";
 
+import InfoBanner from "components/InfoBanner";
 import CustomLink from "components/CustomLink";
 
 const baseClass = "apple-bm-terms-message";
 
 const AppleBMTermsMessage = () => {
   return (
-    <div className={baseClass}>
-      <p>
-        Your organization can&apos;t automatically enroll macOS hosts until you
-        accept the new terms and conditions for Apple Business Manager (ABM). An
-        ABM administrator can accept these terms. Done? It might take some time
-        for ABM to report back to Fleet.
-      </p>
-      <CustomLink
-        url="https://business.apple.com/"
-        text="Go to ABM"
-        className={`${baseClass}__new-tab`}
-        newTab
-        iconColor="core-fleet-black"
-      />
-    </div>
+    <InfoBanner
+      className={baseClass}
+      color="yellow"
+      cta={
+        <CustomLink
+          url="https://business.apple.com/"
+          text="Go to ABM"
+          className={`${baseClass}__new-tab`}
+          newTab
+          color="core-fleet-black"
+          iconColor="core-fleet-black"
+        />
+      }
+    >
+      Your organization can&apos;t automatically enroll macOS hosts until you
+      accept the new terms and conditions for Apple Business Manager (ABM). An
+      ABM administrator can accept these terms. Done? It might take some time
+      for ABM to report back to Fleet.
+    </InfoBanner>
   );
 };
 

--- a/frontend/components/MainContent/MainContent.tsx
+++ b/frontend/components/MainContent/MainContent.tsx
@@ -10,6 +10,7 @@ import InfoBanner from "components/InfoBanner";
 import CustomLink from "components/CustomLink";
 import SandboxGate from "components/Sandbox/SandboxGate";
 import { AppContext } from "context/app";
+import LicenseExpirationBanner from "components/LicenseExpirationBanner";
 
 interface IMainContentProps {
   children: ReactNode;
@@ -49,37 +50,24 @@ const MainContent = ({
   const showAppleABMBanner =
     isAppleBmTermsExpired && isPremiumTier && !isSandboxMode;
 
+  // ABM banner takes precedence
   const showLicenseExpirationBanner =
-    !isLicenseExpired && isPremiumTier && !isAppleBmTermsExpired;
+    isLicenseExpired && isPremiumTier && !isAppleBmTermsExpired;
 
   return (
     <div className={classes}>
-      {showAppleABMBanner && <AppleBMTermsMessage />}
-      {showLicenseExpirationBanner && (
-        <InfoBanner
-          className="license-expiry-banner"
-          color="yellow"
-          cta={
-            <CustomLink
-              url="https://fleetdm.com/learn-more-about/downgrading"
-              text="Downgrade or renew"
-              newTab
-              iconColor="core-fleet-black"
-              color="core-fleet-black"
+      <div className={`${baseClass}--animation-disabled`}>
+        {showAppleABMBanner && <AppleBMTermsMessage />}
+        {showLicenseExpirationBanner && <LicenseExpirationBanner />}
+        <SandboxGate
+          fallbackComponent={() => (
+            <SandboxExpiryMessage
+              expiry={sandboxExpiryTime}
+              noSandboxHosts={noSandboxHosts}
             />
-          }
-        >
-          Your Fleet Premium license is about to expire.
-        </InfoBanner>
-      )}
-      <SandboxGate
-        fallbackComponent={() => (
-          <SandboxExpiryMessage
-            expiry={sandboxExpiryTime}
-            noSandboxHosts={noSandboxHosts}
-          />
-        )}
-      />
+          )}
+        />
+      </div>
       {children}
     </div>
   );

--- a/frontend/components/MainContent/MainContent.tsx
+++ b/frontend/components/MainContent/MainContent.tsx
@@ -1,10 +1,13 @@
 import React, { ReactNode, useContext } from "react";
 import classnames from "classnames";
 import { formatDistanceToNow } from "date-fns";
+import { hasLicenseExpired } from "utilities/helpers";
 
 import SandboxExpiryMessage from "components/Sandbox/SandboxExpiryMessage";
 import AppleBMTermsMessage from "components/MDM/AppleBMTermsMessage";
 
+import InfoBanner from "components/InfoBanner";
+import CustomLink from "components/CustomLink";
 import SandboxGate from "components/Sandbox/SandboxGate";
 import { AppContext } from "context/app";
 
@@ -36,6 +39,7 @@ const MainContent = ({
   } = useContext(AppContext);
 
   const isAppleBmTermsExpired = config?.mdm?.apple_bm_terms_expired;
+  const isLicenseExpired = hasLicenseExpired(config?.license.expiration || "");
 
   const sandboxExpiryTime =
     sandboxExpiry === undefined
@@ -45,9 +49,29 @@ const MainContent = ({
   const showAppleABMBanner =
     isAppleBmTermsExpired && isPremiumTier && !isSandboxMode;
 
+  const showLicenseExpirationBanner =
+    !isLicenseExpired && isPremiumTier && !isAppleBmTermsExpired;
+
   return (
     <div className={classes}>
       {showAppleABMBanner && <AppleBMTermsMessage />}
+      {showLicenseExpirationBanner && (
+        <InfoBanner
+          className="license-expiry-banner"
+          color="yellow"
+          cta={
+            <CustomLink
+              url="https://fleetdm.com/learn-more-about/downgrading"
+              text="Downgrade or renew"
+              newTab
+              iconColor="core-fleet-black"
+              color="core-fleet-black"
+            />
+          }
+        >
+          Your Fleet Premium license is about to expire.
+        </InfoBanner>
+      )}
       <SandboxGate
         fallbackComponent={() => (
           <SandboxExpiryMessage

--- a/frontend/components/MainContent/_styles.scss
+++ b/frontend/components/MainContent/_styles.scss
@@ -6,5 +6,8 @@
   // of the main-content when there is a banner. (e.g. sandbox mode)
   // Without it the main content pushes the banner off the page.
   overflow: auto;
-  animation: fade-in 250ms ease-out;
+
+  > :not(.main-content--animation-disabled) {
+    animation: fade-in 250ms ease-out;
+  }
 }

--- a/frontend/layouts/CoreLayout/CoreLayout.tsx
+++ b/frontend/layouts/CoreLayout/CoreLayout.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useContext } from "react";
+import React, { useContext } from "react";
 import { InjectedRouter } from "react-router";
 import { Params } from "react-router/lib/Router";
 
@@ -10,9 +10,6 @@ import paths from "router/paths";
 import useDeepEffect from "hooks/useDeepEffect";
 import FlashMessage from "components/FlashMessage";
 import SiteTopNav from "components/top_nav/SiteTopNav";
-import CustomLink from "components/CustomLink";
-import { INotification } from "interfaces/notification";
-import { licenseExpirationWarning } from "utilities/helpers";
 import { QueryParams } from "utilities/url";
 
 import smallScreenImage from "../../../assets/images/small-screen-160x80@2x.png";
@@ -30,31 +27,15 @@ interface ICoreLayoutProps {
   params: Params;
 }
 
-const expirationMessage = (
-  <>
-    Your license for Fleet Premium is about to expire. If you’d like to renew or
-    have questions about downgrading,{" "}
-    <CustomLink
-      url="https://fleetdm.com/docs/using-fleet/faq#how-do-i-downgrade-from-fleet-premium-to-fleet-free"
-      text="please head to the Fleet documentation"
-      newTab
-      multiline
-    />
-  </>
-);
-
 const CoreLayout = ({
   children,
   router,
   location,
   params: routeParams,
 }: ICoreLayoutProps) => {
-  const { config, currentUser, isPremiumTier } = useContext(AppContext);
+  const { config, currentUser } = useContext(AppContext);
   const { notification, hideFlash } = useContext(NotificationContext);
   const { setResetSelectedRows } = useContext(TableContext);
-  const [showExpirationFlashMessage, setShowExpirationFlashMessage] = useState(
-    false
-  );
 
   // on success of an action, the table will reset its checkboxes.
   // setTimeout is to help with race conditions as table reloads
@@ -68,10 +49,6 @@ const CoreLayout = ({
         }, 300);
       }, 0);
     }
-
-    setShowExpirationFlashMessage(
-      licenseExpirationWarning(config?.license.expiration || "")
-    );
   }, [notification]);
 
   const onLogoutUser = async () => {
@@ -106,11 +83,6 @@ const CoreLayout = ({
   };
 
   const fullWidthFlash = !currentUser;
-  const expirationNotification: INotification = {
-    alertType: "warning-filled",
-    isVisible: true,
-    message: expirationMessage,
-  };
 
   if (!currentUser || !config) {
     return null;
@@ -135,21 +107,13 @@ const CoreLayout = ({
         />
       </nav>
       <div className="core-wrapper">
-        {isPremiumTier && showExpirationFlashMessage && (
-          <FlashMessage
-            fullWidth={fullWidthFlash}
-            notification={expirationNotification}
-            onRemoveFlash={() =>
-              setShowExpirationFlashMessage(!showExpirationFlashMessage)
-            }
-          />
-        )}
         <FlashMessage
           fullWidth={fullWidthFlash}
           notification={notification}
           onRemoveFlash={hideFlash}
           onUndoActionClick={onUndoActionClick}
         />
+
         {children}
       </div>
     </div>

--- a/frontend/utilities/helpers.tsx
+++ b/frontend/utilities/helpers.tsx
@@ -19,6 +19,7 @@ import {
   intlFormat,
   intervalToDuration,
   isAfter,
+  isBefore,
 } from "date-fns";
 import yaml from "js-yaml";
 
@@ -671,7 +672,7 @@ export const humanQueryLastRun = (lastRun: string): string => {
   }
 };
 
-export const licenseExpirationWarning = (expiration: string): boolean => {
+export const hasLicenseExpired = (expiration: string): boolean => {
   return isAfter(new Date(), new Date(expiration));
 };
 
@@ -980,7 +981,7 @@ export default {
   hostTeamName,
   humanQueryLastRun,
   inMilliseconds,
-  licenseExpirationWarning,
+  hasLicenseExpired,
   readableDate,
   secondsToHms,
   secondsToDhms,


### PR DESCRIPTION
## Issue
Cerra #17860

## Description
- Banner now inline of main content pages and not a flash notification
- This matches the newer style of banners such as the ABM banner

## Other
- Clean up styling of ABM message banner to use `<InfoBanner/>` component and its styling
- Remove main-content animation that is making the banner flash on every page change

## Screenshots
<img width="1537" alt="Screenshot 2024-05-08 at 2 54 11 PM" src="https://github.com/fleetdm/fleet/assets/71795832/4d3cafcc-47fd-487d-8ec0-c34a11b96eda">
<img width="1538" alt="Screenshot 2024-05-08 at 2 53 58 PM" src="https://github.com/fleetdm/fleet/assets/71795832/36c33884-5796-4bd3-bcc5-7fe08f3a36bc">
<img width="1541" alt="Screenshot 2024-05-08 at 2 53 50 PM" src="https://github.com/fleetdm/fleet/assets/71795832/c65c4104-ded9-4ebb-b129-ba59ec4ebb0f">
<img width="1543" alt="Screenshot 2024-05-08 at 2 53 37 PM" src="https://github.com/fleetdm/fleet/assets/71795832/befa7470-718e-48ea-9eb9-3fcfacca6f0f">
<img width="1542" alt="Screenshot 2024-05-08 at 2 53 28 PM" src="https://github.com/fleetdm/fleet/assets/71795832/8f228316-7e67-4385-9626-045a17071856">


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
- [x] Manual QA for all new/changed functionality
