### PR TITLE
Website: update receive-usage-analytics webhook

### DIFF
--- a/website/api/controllers/webhooks/receive-usage-analytics.js
+++ b/website/api/controllers/webhooks/receive-usage-analytics.js
@@ -42,7 +42,10 @@ module.exports = {
 
 
   fn: async function (inputs) {
-
+    // If organization was reported as an empty string, set it to the default value.
+    if(inputs.organization === '') {
+      inputs.organization = 'unknown';
+    }
     // Create a database record for these usage statistics.
     await HistoricalUsageSnapshot.create(Object.assign({}, inputs));
 


### PR DESCRIPTION
Related to: https://github.com/fleetdm/fleet/issues/18863

Changes:
- Updated the receive-usage-analytics webhook to set a default value for organization if a Fleet instance reports an empty string as its organization.