### PR TITLE
Fleet UI: Fix flaky race condition bug, clean code

### DIFF
--- a/frontend/pages/policies/ManagePoliciesPage/ManagePoliciesPage.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/ManagePoliciesPage.tsx
@@ -508,6 +508,9 @@ const ManagePolicyPage = ({
       );
 
       await Promise.all(responses);
+      await refetchTeamPolicies();
+      await refetchTeamConfig();
+
       renderFlash("success", "Successfully updated policy automations.");
     } catch {
       renderFlash(
@@ -517,8 +520,6 @@ const ManagePolicyPage = ({
     } finally {
       toggleCalendarEventsModal();
       setIsUpdatingCalendarEvents(false);
-      refetchTeamPolicies();
-      refetchTeamConfig();
     }
   };
 

--- a/frontend/pages/policies/ManagePoliciesPage/ManagePoliciesPage.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/ManagePoliciesPage.tsx
@@ -4,7 +4,7 @@ import { InjectedRouter } from "react-router/lib/Router";
 import PATHS from "router/paths";
 import { isEqual } from "lodash";
 
-import { getNextLocationPath } from "utilities/helpers";
+import { getNextLocationPath, wait } from "utilities/helpers";
 
 import { AppContext } from "context/app";
 import { PolicyContext } from "context/policy";
@@ -508,6 +508,7 @@ const ManagePolicyPage = ({
       );
 
       await Promise.all(responses);
+      await wait(100); // Wait 100ms to avoid race conditions with refetch
       await refetchTeamPolicies();
       await refetchTeamConfig();
 

--- a/frontend/pages/policies/ManagePoliciesPage/ManagePoliciesPage.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/ManagePoliciesPage.tsx
@@ -123,17 +123,18 @@ const ManagePolicyPage = ({
     },
   });
 
-  const [isUpdatingAutomations, setIsUpdatingAutomations] = useState(false);
   const [isUpdatingPolicies, setIsUpdatingPolicies] = useState(false);
-  const [
-    updatingPolicyEnabledCalendarEvents,
-    setUpdatingPolicyEnabledCalendarEvents,
-  ] = useState(false);
+  const [isUpdatingCalendarEvents, setIsUpdatingCalendarEvents] = useState(
+    false
+  );
+  const [isUpdatingOtherWorkflows, setIsUpdatingOtherWorkflows] = useState(
+    false
+  );
   const [selectedPolicyIds, setSelectedPolicyIds] = useState<number[]>([]);
-  const [showOtherWorkflowsModal, setShowOtherWorkflowsModal] = useState(false);
   const [showAddPolicyModal, setShowAddPolicyModal] = useState(false);
   const [showDeletePolicyModal, setShowDeletePolicyModal] = useState(false);
   const [showCalendarEventsModal, setShowCalendarEventsModal] = useState(false);
+  const [showOtherWorkflowsModal, setShowOtherWorkflowsModal] = useState(false);
   const [
     policiesAvailableToAutomate,
     setPoliciesAvailableToAutomate,
@@ -435,11 +436,11 @@ const ManagePolicyPage = ({
     }
   };
 
-  const handleUpdateOtherWorkflows = async (requestBody: {
+  const onUpdateOtherWorkflows = async (requestBody: {
     webhook_settings: Pick<IWebhookSettings, "failing_policies_webhook">;
     integrations: IZendeskJiraIntegrations;
   }) => {
-    setIsUpdatingAutomations(true);
+    setIsUpdatingOtherWorkflows(true);
     try {
       await (isAnyTeamSelected
         ? teamsAPI.update(requestBody, teamIdForApi)
@@ -452,16 +453,13 @@ const ManagePolicyPage = ({
       );
     } finally {
       toggleOtherWorkflowsModal();
-      setIsUpdatingAutomations(false);
-      refetchConfig();
-      isAnyTeamSelected && refetchTeamConfig();
+      setIsUpdatingOtherWorkflows(false);
+      isAnyTeamSelected ? refetchTeamConfig() : refetchConfig();
     }
   };
 
-  const updatePolicyEnabledCalendarEvents = async (
-    formData: ICalendarEventsFormData
-  ) => {
-    setUpdatingPolicyEnabledCalendarEvents(true);
+  const onUpdateCalendarEvents = async (formData: ICalendarEventsFormData) => {
+    setIsUpdatingCalendarEvents(true);
 
     try {
       // update team config if either field has been changed
@@ -518,7 +516,7 @@ const ManagePolicyPage = ({
       );
     } finally {
       toggleCalendarEventsModal();
-      setUpdatingPolicyEnabledCalendarEvents(false);
+      setIsUpdatingCalendarEvents(false);
       refetchTeamPolicies();
       refetchTeamConfig();
     }
@@ -781,9 +779,9 @@ const ManagePolicyPage = ({
             automationsConfig={automationsConfig}
             availableIntegrations={config.integrations}
             availablePolicies={policiesAvailableToAutomate}
-            isUpdatingAutomations={isUpdatingAutomations}
+            isUpdating={isUpdatingOtherWorkflows}
             onExit={toggleOtherWorkflowsModal}
-            handleSubmit={handleUpdateOtherWorkflows}
+            onSubmit={onUpdateOtherWorkflows}
           />
         )}
         {showAddPolicyModal && (
@@ -804,9 +802,7 @@ const ManagePolicyPage = ({
         {showCalendarEventsModal && (
           <CalendarEventsModal
             onExit={toggleCalendarEventsModal}
-            updatePolicyEnabledCalendarEvents={
-              updatePolicyEnabledCalendarEvents
-            }
+            onSubmit={onUpdateCalendarEvents}
             configured={isCalEventsConfigured}
             enabled={
               teamConfig?.integrations.google_calendar
@@ -814,7 +810,7 @@ const ManagePolicyPage = ({
             }
             url={teamConfig?.integrations.google_calendar?.webhook_url || ""}
             policies={policiesAvailableToAutomate}
-            isUpdating={updatingPolicyEnabledCalendarEvents}
+            isUpdating={isUpdatingCalendarEvents}
           />
         )}
       </div>

--- a/frontend/pages/policies/ManagePoliciesPage/components/CalendarEventsModal/CalendarEventsModal.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/components/CalendarEventsModal/CalendarEventsModal.tsx
@@ -341,7 +341,7 @@ const CalendarEventsModal = ({
       onEnter={
         configured
           ? () => {
-              onSubmit(formData);
+              onUpdateCalendarEvents();
             }
           : onExit
       }

--- a/frontend/pages/policies/ManagePoliciesPage/components/CalendarEventsModal/CalendarEventsModal.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/components/CalendarEventsModal/CalendarEventsModal.tsx
@@ -1,6 +1,6 @@
-import React, { useCallback, useState } from "react";
+import React, { useCallback, useState, useEffect } from "react";
 
-import { IPolicy } from "interfaces/policy";
+import { IPolicyStats } from "interfaces/policy";
 
 import validURL from "components/forms/validators/valid_url";
 
@@ -32,14 +32,12 @@ export interface ICalendarEventsFormData {
 
 interface ICalendarEventsModal {
   onExit: () => void;
-  updatePolicyEnabledCalendarEvents: (
-    formData: ICalendarEventsFormData
-  ) => void;
+  onSubmit: (formData: ICalendarEventsFormData) => void;
   isUpdating: boolean;
   configured: boolean;
   enabled: boolean;
   url: string;
-  policies: IPolicy[];
+  policies: IPolicyStats[];
 }
 
 // allows any policy name to be the name of a form field, one of the checkboxes
@@ -47,7 +45,7 @@ type FormNames = string;
 
 const CalendarEventsModal = ({
   onExit,
-  updatePolicyEnabledCalendarEvents,
+  onSubmit,
   isUpdating,
   configured,
   enabled,
@@ -71,8 +69,20 @@ const CalendarEventsModal = ({
   );
   const [showExamplePayload, setShowExamplePayload] = useState(false);
   const [selectedPolicyToPreview, setSelectedPolicyToPreview] = useState<
-    IPolicy | undefined
+    IPolicyStats | undefined
   >();
+
+  // Eliminate race condition after updating policies
+  useEffect(() => {
+    setFormData({
+      ...formData,
+      policies: policies.map((policy) => ({
+        name: policy.name,
+        id: policy.id,
+        isChecked: policy.calendar_events_enabled || false,
+      })),
+    });
+  }, [policies]);
 
   // Used on URL change only when URL error exists and always on attempting to save
   const validateForm = (newFormData: ICalendarEventsFormData) => {
@@ -133,13 +143,13 @@ const CalendarEventsModal = ({
     [formData]
   );
 
-  const onUpdatePolicyEnabledCalendarEvents = () => {
+  const onUpdateCalendarEvents = () => {
     const errors = validateForm(formData);
 
     if (Object.keys(errors).length > 0) {
       setFormErrors(errors);
     } else {
-      updatePolicyEnabledCalendarEvents(formData);
+      onSubmit(formData);
     }
   };
 
@@ -301,7 +311,7 @@ const CalendarEventsModal = ({
         <Button
           type="submit"
           variant="brand"
-          onClick={onUpdatePolicyEnabledCalendarEvents}
+          onClick={onUpdateCalendarEvents}
           className="save-loading"
           isLoading={isUpdating}
           disabled={Object.keys(formErrors).length > 0}
@@ -331,7 +341,7 @@ const CalendarEventsModal = ({
       onEnter={
         configured
           ? () => {
-              updatePolicyEnabledCalendarEvents(formData);
+              onSubmit(formData);
             }
           : onExit
       }

--- a/frontend/pages/policies/ManagePoliciesPage/components/OtherWorkflowsModal/OtherWorkflowsModal.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/components/OtherWorkflowsModal/OtherWorkflowsModal.tsx
@@ -98,7 +98,7 @@ const OtherWorkflowsModal = ({
   availablePolicies,
   isUpdating,
   onExit,
-  onSubmit: handleSubmit,
+  onSubmit,
 }: IOtherWorkflowsModalProps): JSX.Element => {
   const {
     webhook_settings: { failing_policies_webhook: webhook },
@@ -174,7 +174,9 @@ const OtherWorkflowsModal = ({
     );
   };
 
-  const onSubmit = (evt: React.MouseEvent<HTMLFormElement> | KeyboardEvent) => {
+  const onUpdateOtherWorkflows = (
+    evt: React.MouseEvent<HTMLFormElement> | KeyboardEvent
+  ) => {
     evt.preventDefault();
 
     const newPolicyIds: number[] = [];
@@ -259,7 +261,7 @@ const OtherWorkflowsModal = ({
       },
     };
 
-    handleSubmit({
+    onSubmit({
       webhook_settings: newWebhook,
       integrations: {
         jira: newJira,
@@ -275,7 +277,7 @@ const OtherWorkflowsModal = ({
     const listener = (event: KeyboardEvent) => {
       if (event.code === "Enter" || event.code === "NumpadEnter") {
         event.preventDefault();
-        onSubmit(event);
+        onUpdateOtherWorkflows(event);
       }
     };
     document.addEventListener("keydown", listener);
@@ -453,7 +455,7 @@ const OtherWorkflowsModal = ({
           <Button
             type="submit"
             variant="brand"
-            onClick={onSubmit}
+            onClick={onUpdateOtherWorkflows}
             className="save-loading"
             isLoading={isUpdating}
           >

--- a/frontend/pages/policies/ManagePoliciesPage/components/OtherWorkflowsModal/OtherWorkflowsModal.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/components/OtherWorkflowsModal/OtherWorkflowsModal.tsx
@@ -33,9 +33,9 @@ interface IOtherWorkflowsModalProps {
   automationsConfig: IAutomationsConfig | ITeamAutomationsConfig;
   availableIntegrations: IGlobalIntegrations | ITeamIntegrations;
   availablePolicies: IPolicy[];
-  isUpdatingAutomations: boolean;
+  isUpdating: boolean;
   onExit: () => void;
-  handleSubmit: (formData: {
+  onSubmit: (formData: {
     webhook_settings: Pick<IWebhookSettings, "failing_policies_webhook">;
     integrations: IGlobalIntegrations | ITeamIntegrations;
   }) => void;
@@ -96,9 +96,9 @@ const OtherWorkflowsModal = ({
   automationsConfig,
   availableIntegrations,
   availablePolicies,
-  isUpdatingAutomations,
+  isUpdating,
   onExit,
-  handleSubmit,
+  onSubmit: handleSubmit,
 }: IOtherWorkflowsModalProps): JSX.Element => {
   const {
     webhook_settings: { failing_policies_webhook: webhook },
@@ -455,7 +455,7 @@ const OtherWorkflowsModal = ({
             variant="brand"
             onClick={onSubmit}
             className="save-loading"
-            isLoading={isUpdatingAutomations}
+            isLoading={isUpdating}
           >
             Save
           </Button>

--- a/frontend/pages/queries/ManageQueriesPage/ManageQueriesPage.tsx
+++ b/frontend/pages/queries/ManageQueriesPage/ManageQueriesPage.tsx
@@ -340,7 +340,7 @@ const ManageQueriesPage = ({
         {showManageAutomationsModal && (
           <ManageQueryAutomationsModal
             isUpdatingAutomations={isUpdatingAutomations}
-            handleSubmit={onSaveQueryAutomations}
+            onSubmit={onSaveQueryAutomations}
             onCancel={toggleManageAutomationsModal}
             isShowingPreviewDataModal={showPreviewDataModal}
             togglePreviewDataModal={togglePreviewDataModal}

--- a/frontend/pages/queries/ManageQueriesPage/components/ManageQueryAutomationsModal/ManageQueryAutomationsModal.tsx
+++ b/frontend/pages/queries/ManageQueriesPage/components/ManageQueryAutomationsModal/ManageQueryAutomationsModal.tsx
@@ -12,7 +12,7 @@ import { ISchedulableQuery } from "interfaces/schedulable_query";
 
 interface IManageQueryAutomationsModalProps {
   isUpdatingAutomations: boolean;
-  handleSubmit: (formData: any) => void; // TODO
+  onSubmit: (formData: any) => void; // TODO
   onCancel: () => void;
   isShowingPreviewDataModal: boolean;
   togglePreviewDataModal: () => void;
@@ -57,7 +57,7 @@ const baseClass = "manage-query-automations-modal";
 const ManageQueryAutomationsModal = ({
   isUpdatingAutomations,
   automatedQueryIds,
-  handleSubmit,
+  onSubmit,
   onCancel,
   isShowingPreviewDataModal,
   togglePreviewDataModal,
@@ -78,13 +78,15 @@ const ManageQueryAutomationsModal = ({
     automatedQueryIds || []
   );
 
-  const onSubmit = (evt: React.MouseEvent<HTMLFormElement> | KeyboardEvent) => {
+  const onSubmitQueryAutomations = (
+    evt: React.MouseEvent<HTMLFormElement> | KeyboardEvent
+  ) => {
     evt.preventDefault();
 
     const newQueryIds: number[] = [];
     queryItems?.forEach((p) => p.isChecked && newQueryIds.push(p.id));
 
-    handleSubmit(newQueryIds);
+    onSubmit(newQueryIds);
   };
 
   useEffect(() => {
@@ -187,7 +189,7 @@ const ManageQueryAutomationsModal = ({
           <Button
             type="submit"
             variant="brand"
-            onClick={onSubmit}
+            onClick={onSubmitQueryAutomations}
             className="save-loading"
             isLoading={isUpdatingAutomations}
           >

--- a/frontend/utilities/helpers.tsx
+++ b/frontend/utilities/helpers.tsx
@@ -803,6 +803,9 @@ export const normalizeEmptyValues = (
   );
 };
 
+export const wait = (milliseconds: number) =>
+  new Promise((resolve) => setTimeout(resolve, milliseconds));
+
 export const wrapFleetHelper = (
   helperFn: (value: any) => string, // TODO: replace any with unknown and improve type narrowing by callers
   value: string
@@ -989,6 +992,7 @@ export default {
   setupData,
   syntaxHighlight,
   normalizeEmptyValues,
+  wait,
   wrapFleetHelper,
   TAGGED_TEMPLATES,
 };


### PR DESCRIPTION
## Issue
Addresses #18740 

## Description
- Use `useEffect` to update `formData` to avoid race condition
- Clean code and other consistency nits, examples include:
  - Rename `onSubmit`, instead of `handleSubmit`
  - Rename `isUpdatingXYZ`, instead of `updatingXYZ`
  - Re-order `useState``s for readability
  - Rename variables to clearly match 2 similar but different modals

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Manual QA for all new/changed functionality

