### PR TITLE
[unreleased bug] UI: Hide add policies button on initial empty state

### DIFF
--- a/frontend/services/entities/team_policies.ts
+++ b/frontend/services/entities/team_policies.ts
@@ -159,7 +159,7 @@ export default {
   getCount: async ({
     query,
     teamId,
-    mergeInherited = false,
+    mergeInherited = true,
   }: Pick<
     IPoliciesCountApiParams,
     "query" | "teamId" | "mergeInherited"


### PR DESCRIPTION
## Issue
FE Part of unreleased bugs #18879 

## Description
- Hides the "Add policy" button when initially viewing a completely empty state (no query filter)

## Other
- Clean code for readability
  - Remove unused merge_inherited: false teampolicycount API call
  - Reorder some constants
  - Add one more constant
  - Change a default value that's not actually the default

## Screenshot of fix
<img width="1393" alt="Screenshot 2024-05-09 at 2 30 34 PM" src="https://github.com/fleetdm/fleet/assets/71795832/08b8eb6f-b396-4bf3-9f28-8632ae618358">
<img width="1389" alt="Screenshot 2024-05-09 at 2 30 28 PM" src="https://github.com/fleetdm/fleet/assets/71795832/a00fc0ab-2584-41de-b9c9-fbe7cb7652d2">


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Manual QA for all new/changed functionality

