### PR TITLE
[released bug] Fleet UI: Final piece to keep form state when toggling new policy modal

### DIFF
--- a/frontend/pages/policies/PolicyPage/components/PolicyForm/PolicyForm.tsx
+++ b/frontend/pages/policies/PolicyPage/components/PolicyForm/PolicyForm.tsx
@@ -246,10 +246,9 @@ const PolicyForm = ({
       });
     }
 
-    let selectedPlatforms: OsqueryPlatform[] = [];
-    if (isEditMode || defaultPolicy) {
-      selectedPlatforms = getSelectedPlatforms();
-    } else {
+    let selectedPlatforms = getSelectedPlatforms();
+    if (selectedPlatforms.length === 0 && !isEditMode && !defaultPolicy) {
+      // If no platforms are selected, default to all compatible platforms
       selectedPlatforms = getCompatiblePlatforms();
       setSelectedPlatforms(selectedPlatforms);
     }


### PR DESCRIPTION
## Issue
Final piece of #18681 (most of it fixed in #18646)

## Description
- Persist state of policy platform when toggling save new policy modal

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
- [x] Manual QA for all new/changed functionality

Co-authored-by: Sarah Gillespie <73313222+gillespi314@users.noreply.github.com>
