### PR TITLE
Vulnerability dashboard: Update update-reports script.

### DIFF
--- a/ee/vulnerability-dashboard/scripts/update-reports.js
+++ b/ee/vulnerability-dashboard/scripts/update-reports.js
@@ -280,6 +280,7 @@ module.exports = {
       // For each software version, look up affected hosts.
       // (i.e. they have this version of software installed)
       let hostApidsBySoftwareVersionApid = {};// « Save a mapping for use below.
+      let vulnerableWaresWithNoHostInformation = [];
       await sails.helpers.flow.simultaneouslyForEach(vulnerableWares, async(ware)=>{
         // Get hosts with this version of software installed.
         // [?] https://fleetdm.com/docs/using-fleet/rest-api#list-hosts
@@ -296,8 +297,11 @@ module.exports = {
             })
             .timeout(120000)
             .retry(['requestFailed', {name: 'TimeoutError'}])
-            .intercept({raw:{statusCode: 404}} , (error)=>{
-              return new Error(`When sending a request to the '/api/v1/fleet/hosts' API endpoint to get a filtered array of hosts with ${ware.name} ${ware.version} installed (software ID: ${ware.id}), the Fleet instance returned a 404 response when we expected it to return an array of ${ware.hosts_count} host(s).\n Response from Fleet instance: ${error.raw.body}`);
+            .tolerate({raw:{statusCode: 404}} , (error)=>{
+              // If the hosts API returns a 404 response for a software item that was returned from in the list of vulnerable software, we'll log a warning and remove this software from the list of software.
+              sails.log.warn(`When sending a request to the '/api/v1/fleet/hosts' API endpoint to get a filtered array of hosts with ${ware.name} ${ware.version} installed (software ID: ${ware.id}), the Fleet instance returned a 404 response when we expected it to return an array of ${ware.hosts_count} host(s).\n Response from Fleet instance: ${error.raw.body}`);
+              vulnerableWaresWithNoHostInformation.push(ware);// Add this software to the vulnerableWaresWithNoHostInformation array, these will be removed before we create and update database records.
+              return {};// Return an empty object. This will let the script continue without information about this software.
             });
             if (!responseData.hosts) {// When pages of results are exhausted, bail.  (`responseData.software` is absent in that case)
               return true;
@@ -344,6 +348,9 @@ module.exports = {
           return err;
         }
       });//∞  </each software version>
+
+      // Remove any software items that was not returned in the hosts API.
+      vulnerableWares = _.difference(vulnerableWares, vulnerableWaresWithNoHostInformation);
 
       let hostRecordsToUpdate = [];
       // Unrecognized hosts? Save 'em to the database.


### PR DESCRIPTION
Related to: https://github.com/fleetdm/confidential/issues/6523

Changes:
- Updated the vulnerability dashboard's update-reports script to continue if a Fleet instance returns a 404 response when a request is sent to get a filtered array of hosts with a vulnerable software item installed.