### PR TITLE
Additional UI integration and fix unreleased bugs in software installers UI: Part 2

### DIFF
--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/DeleteSoftwareModal/DeleteSoftwareModal.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/DeleteSoftwareModal/DeleteSoftwareModal.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from "react";
+import React, { useCallback, useContext } from "react";
 
 import softwareAPI from "services/entities/software";
 import { NotificationContext } from "context/notification";
@@ -12,24 +12,27 @@ interface IDeleteSoftwareModalProps {
   softwareId: number;
   teamId: number;
   onExit: () => void;
+  onSuccess: () => void;
 }
 
 const DeleteSoftwareModal = ({
   softwareId,
   teamId,
   onExit,
+  onSuccess,
 }: IDeleteSoftwareModalProps) => {
   const { renderFlash } = useContext(NotificationContext);
 
-  const onDeleteSoftware = async () => {
+  const onDeleteSoftware = useCallback(async () => {
     try {
       await softwareAPI.deleteSoftwarePackage(softwareId, teamId);
       renderFlash("success", "Software deleted successfully!");
+      onSuccess();
     } catch {
       renderFlash("error", "Couldn't delete. Please try again.");
     }
     onExit();
-  };
+  }, [softwareId, teamId, renderFlash, onSuccess, onExit]);
 
   return (
     <Modal className={baseClass} title="Delete software" onExit={onExit}>

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwarePackageCard/SoftwarePackageCard.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwarePackageCard/SoftwarePackageCard.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useState } from "react";
+import React, { useCallback, useContext, useState } from "react";
 
 import endpoints from "utilities/endpoints";
 import { SoftwareInstallStatus, ISoftwarePackage } from "interfaces/software";
@@ -93,12 +93,14 @@ interface ISoftwarePackageCardProps {
   softwarePackage: ISoftwarePackage;
   softwareId: number;
   teamId: number;
+  onDelete: () => void;
 }
 
 const SoftwarePackageCard = ({
   softwarePackage,
   softwareId,
   teamId,
+  onDelete,
 }: ISoftwarePackageCardProps) => {
   const {
     isGlobalAdmin,
@@ -119,6 +121,11 @@ const SoftwarePackageCard = ({
   const onDeleteClick = () => {
     setShowDeleteModal(true);
   };
+
+  const onSuccess = useCallback(() => {
+    setShowDeleteModal(false);
+    onDelete();
+  }, [onDelete]);
 
   const showActions =
     isGlobalAdmin || isGlobalMaintainer || isTeamAdmin || isTeamMaintainer;
@@ -203,6 +210,7 @@ const SoftwarePackageCard = ({
           softwareId={softwareId}
           teamId={teamId}
           onExit={() => setShowDeleteModal(false)}
+          onSuccess={onSuccess}
         />
       )}
     </Card>

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwareTitleDetailsPage.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwareTitleDetailsPage.tsx
@@ -6,6 +6,8 @@ import { useErrorHandler } from "react-error-boundary";
 import { RouteComponentProps } from "react-router";
 import { AxiosError } from "axios";
 
+import paths from "router/paths";
+
 import useTeamIdParam from "hooks/useTeamIdParam";
 
 import { AppContext } from "context/app";
@@ -74,6 +76,7 @@ const SoftwareTitleDetailsPage = ({
     data: softwareTitle,
     isLoading: isSoftwareTitleLoading,
     isError: isSoftwareTitleError,
+    refetch: refetchSoftwareTitle,
   } = useQuery<
     ISoftwareTitleResponse,
     AxiosError,
@@ -93,6 +96,19 @@ const SoftwareTitleDetailsPage = ({
       },
     }
   );
+
+  const onDeleteInstaller = useCallback(() => {
+    if (softwareTitle?.versions?.length) {
+      refetchSoftwareTitle();
+      return;
+    }
+    // redirect to software titles page if no versions are available
+    if (teamIdForApi && teamIdForApi > 0) {
+      router.push(paths.SOFTWARE_TITLES.concat(`?team_id=${teamIdForApi}`));
+    } else {
+      router.push(paths.SOFTWARE_TITLES);
+    }
+  }, [refetchSoftwareTitle, router, softwareTitle, teamIdForApi]);
 
   const onTeamChange = useCallback(
     (teamId: number) => {
@@ -156,6 +172,7 @@ const SoftwareTitleDetailsPage = ({
                   softwarePackage={softwareTitle.software_package}
                   softwareId={softwareId}
                   teamId={currentTeamId}
+                  onDelete={onDeleteInstaller}
                 />
               )}
             <Card

--- a/frontend/pages/hosts/details/DeviceUserPage/DeviceUserPage.tsx
+++ b/frontend/pages/hosts/details/DeviceUserPage/DeviceUserPage.tsx
@@ -407,10 +407,12 @@ const DeviceUserPage = ({
                 <TabPanel>
                   <SoftwareCard
                     id={deviceAuthToken}
+                    isFleetdHost={!!host.orbit_version}
                     router={router}
                     pathname={location.pathname}
                     queryParams={queryParams}
                     isMyDevicePage
+                    teamId={host.team_id || 0}
                   />
                 </TabPanel>
                 {isPremiumTier && (

--- a/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
@@ -849,11 +849,13 @@ const HostDetailsPage = ({
             <TabPanel>
               <SoftwareCard
                 id={host.id}
+                isFleetdHost={!!host.orbit_version}
                 isSoftwareEnabled={featuresConfig?.enable_software_inventory}
                 router={router}
                 queryParams={queryParams}
                 pathname={location.pathname}
                 onShowSoftwareDetails={setSelectedSoftwareDetails}
+                teamId={host.team_id || 0}
               />
               {host?.platform === "darwin" && macadmins?.munki?.version && (
                 <MunkiIssuesCard

--- a/frontend/pages/hosts/details/cards/Software/HostSoftwareTable/HostSoftwareTable.tsx
+++ b/frontend/pages/hosts/details/cards/Software/HostSoftwareTable/HostSoftwareTable.tsx
@@ -116,6 +116,7 @@ const HostSoftwareTable = ({
         showMarkAllPages={false}
         isAllPagesSelected={false}
         searchable
+        manualSortBy
       />
     </div>
   );

--- a/frontend/pages/hosts/details/cards/Software/HostSoftwareTableConfig.tsx
+++ b/frontend/pages/hosts/details/cards/Software/HostSoftwareTableConfig.tsx
@@ -79,6 +79,7 @@ interface ISoftwareTableHeadersProps {
   onSelectAction: (software: IHostSoftware, action: string) => void;
   canInstall: boolean;
   router: InjectedRouter;
+  teamId: number;
 }
 
 // NOTE: cellProps come from react-table
@@ -88,6 +89,7 @@ export const generateSoftwareTableHeaders = ({
   installingSoftwareId,
   onSelectAction,
   canInstall,
+  teamId,
 }: ISoftwareTableHeadersProps): ISoftwareTableConfig[] => {
   const tableHeaders: ISoftwareTableConfig[] = [
     {
@@ -100,7 +102,7 @@ export const generateSoftwareTableHeaders = ({
         const { id, name, source } = cellProps.row.original;
 
         const softwareTitleDetailsPath = PATHS.SOFTWARE_TITLE_DETAILS(
-          id.toString()
+          id.toString().concat(`?team_id=${teamId}`)
         );
 
         return (

--- a/frontend/pages/hosts/details/cards/Software/InstallStatusCell/InstallStatusCell.tsx
+++ b/frontend/pages/hosts/details/cards/Software/InstallStatusCell/InstallStatusCell.tsx
@@ -68,10 +68,10 @@ const InstallStatusCell = ({
 }: IInstallStatusCellProps) => {
   let displayStatus: IStatusValue;
 
-  if (packageToInstall) {
-    displayStatus = "avaiableForInstall";
-  } else if (status !== null) {
+  if (status !== null) {
     displayStatus = status;
+  } else if (packageToInstall) {
+    displayStatus = "avaiableForInstall";
   } else {
     return <TextCell value="---" greyed />;
   }

--- a/frontend/pages/hosts/details/cards/Software/Software.tsx
+++ b/frontend/pages/hosts/details/cards/Software/Software.tsx
@@ -11,6 +11,7 @@ import deviceAPI, {
   IDeviceSoftwareQueryParams,
   IGetDeviceSoftwareResponse,
 } from "services/entities/device_user";
+import { getErrorReason } from "interfaces/errors";
 import { IHostSoftware, ISoftware } from "interfaces/software";
 import { DEFAULT_USE_QUERY_OPTIONS } from "utilities/constants";
 import { NotificationContext } from "context/notification";
@@ -33,6 +34,7 @@ export interface ITableSoftware extends Omit<ISoftware, "vulnerabilities"> {
 interface ISoftwareCardProps {
   /** This is the host id or the device token */
   id: number | string;
+  isFleetdHost: boolean;
   router: InjectedRouter;
   queryParams?: {
     page?: string;
@@ -41,22 +43,26 @@ interface ISoftwareCardProps {
     order_direction?: "asc" | "desc";
   };
   pathname: string;
+  /** Team id for the host */
+  teamId: number;
   onShowSoftwareDetails?: (software: IHostSoftware) => void;
   isSoftwareEnabled?: boolean;
   isMyDevicePage?: boolean;
 }
 
 const DEFAULT_SEARCH_QUERY = "";
-const DEFAULT_SORT_DIRECTION = "desc";
+const DEFAULT_SORT_DIRECTION = "asc";
 const DEFAULT_SORT_HEADER = "name";
 const DEFAULT_PAGE = 0;
 const DEFAULT_PAGE_SIZE = 20;
 
 const SoftwareCard = ({
   id,
+  isFleetdHost,
   router,
   queryParams,
   pathname,
+  teamId = 0,
   onShowSoftwareDetails,
   isSoftwareEnabled = false,
   isMyDevicePage = false,
@@ -86,6 +92,7 @@ const SoftwareCard = ({
     isLoading: hostSoftwareLoading,
     isError: hostSoftwareError,
     isFetching: hostSoftwareFetching,
+    refetch: refetchHostSoftware,
   } = useQuery<
     IGetHostSoftwareResponse,
     AxiosError,
@@ -116,6 +123,7 @@ const SoftwareCard = ({
     isLoading: deviceSoftwareLoading,
     isError: deviceSoftwareError,
     isFetching: deviceSoftwareFetching,
+    refetch: refetchDeviceSoftware,
   } = useQuery<
     IGetDeviceSoftwareResponse,
     AxiosError,
@@ -139,9 +147,16 @@ const SoftwareCard = ({
     }
   );
 
-  const canInstallSoftware = Boolean(
-    isGlobalAdmin || isGlobalMaintainer || isTeamAdmin || isTeamMaintainer
+  const refetchSoftware = useMemo(
+    () => (isMyDevicePage ? refetchDeviceSoftware : refetchHostSoftware),
+    [isMyDevicePage, refetchDeviceSoftware, refetchHostSoftware]
   );
+
+  const canInstallSoftware =
+    isFleetdHost &&
+    Boolean(
+      isGlobalAdmin || isGlobalMaintainer || isTeamAdmin || isTeamMaintainer
+    );
 
   const installHostSoftwarePackage = useCallback(
     async (softwareId: number) => {
@@ -152,12 +167,18 @@ const SoftwareCard = ({
           "success",
           "Software is installing or will install when the host comes online."
         );
-      } catch {
-        renderFlash("error", "Couldn't install. Please try again.");
+      } catch (e) {
+        const reason = getErrorReason(e);
+        if (reason.includes("fleetd installed")) {
+          renderFlash("error", reason);
+        } else {
+          renderFlash("error", "Couldn't install. Please try again.");
+        }
       }
       setInstallingSoftwareId(null);
+      refetchSoftware();
     },
-    [id, renderFlash]
+    [id, renderFlash, refetchSoftware]
   );
 
   const onSelectAction = useCallback(
@@ -184,6 +205,7 @@ const SoftwareCard = ({
           installingSoftwareId,
           canInstall: canInstallSoftware,
           onSelectAction,
+          teamId,
         });
   }, [
     isMyDevicePage,
@@ -191,6 +213,7 @@ const SoftwareCard = ({
     installingSoftwareId,
     canInstallSoftware,
     onSelectAction,
+    teamId,
   ]);
 
   const renderSoftwareTable = () => {


### PR DESCRIPTION
Issue #18677 

- Refetch table data on install action
- On installer delete, refetch title or redirect to manage software titles if no installed versions found
- Fix default sort order of host software table
- Hide software installers for UI plain osquery hosts 
- Fix show all hosts link to include team id
- Fix status column so it shows status (if any) then availability (previously was always displaying availability and never status)
