### PR TITLE
[small released bug] UI: Linux OSs show linux icon in OS table

### DIFF
--- a/changes/18506-linux-icon-bug
+++ b/changes/18506-linux-icon-bug
@@ -1,0 +1,1 @@
+- UI: Fix icon on Software OS table to show a Linux icon for Linux operating systems

--- a/frontend/pages/SoftwarePage/components/icons/index.ts
+++ b/frontend/pages/SoftwarePage/components/icons/index.ts
@@ -1,3 +1,4 @@
+import { HOST_LINUX_PLATFORMS } from "interfaces/platform";
 import Linux from "components/icons/Linux";
 import AcrobatReader from "./AcrobatReader";
 import ChromeApp from "./ChromeApp";
@@ -18,6 +19,12 @@ import Zoom from "./Zoom";
 import ChromeOS from "./ChromeOS";
 import LinuxOS from "./LinuxOS";
 
+// Maps all known Linux platforms to the LinuxOS icon
+const LINUX_OS_NAME_TO_ICON_MAP = HOST_LINUX_PLATFORMS.reduce(
+  (a, platform) => ({ ...a, [platform]: LinuxOS }),
+  {}
+);
+
 // SOFTWARE_NAME_TO_ICON_MAP list "special" applications that have a defined
 // icon for them, keys refer to application names, and are intended to be fuzzy
 // matched in the application logic.
@@ -36,7 +43,7 @@ export const SOFTWARE_NAME_TO_ICON_MAP = {
   darwin: MacOS,
   windows: WindowsOS,
   chrome: ChromeOS,
-  linux: LinuxOS,
+  ...LINUX_OS_NAME_TO_ICON_MAP,
 } as const;
 
 // SOFTWARE_SOURCE_TO_ICON_MAP maps different software sources to a defined


### PR DESCRIPTION
## Issue
Cerra #18506 

## Description
- On Software > OS tab, Fix all Linux operating systems to show a Linux icon 

## Screenshot (Using dogfood response as mock data for development testing)

<img width="1377" alt="Screenshot 2024-05-13 at 12 20 59 PM" src="https://github.com/fleetdm/fleet/assets/71795832/0d711239-cc61-48b1-b519-a791af21ffc3">


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
- [x] Manual QA for all new/changed functionality

