### PR TITLE
Vulnerability dashboard: Update `update-reports` script to continue when the Fleet API returns a 404 error

### DIFF
--- a/ee/vulnerability-dashboard/scripts/update-reports.js
+++ b/ee/vulnerability-dashboard/scripts/update-reports.js
@@ -549,6 +549,7 @@ module.exports = {
     let totalNumberOfHostRecordsCreated = 0;
     let totalNumberOfHostRecordsUpdated = 0;
     let potentialCriticalInstalls = [];
+    let criticalWaresWithNoHostInformation = [];
     await sails.helpers.flow.forEach(QUERIES_TO_GET_CRITICAL_SOFTWARE, async (softwareQuery)=>{
       // Send a request to the software endpoint for each query to get a list of software isntalled for each query.
       let criticalWares;
@@ -606,8 +607,11 @@ module.exports = {
             })
             .timeout(120000)
             .retry(['requestFailed', {name: 'TimeoutError'}])
-            .intercept({raw:{statusCode: 404}} , (error)=>{
-              return new Error(`When sending a request to the '/api/v1/fleet/hosts' API endpoint to get a filtered array of hosts with ${ware.name} ${ware.version} installed (software ID: ${ware.id}), the Fleet instance returned a 404 response when we expected it to return an array of ${ware.hosts_count} host(s).\n Response from Fleet instance: ${error.raw.body}`);
+            .tolerate({raw:{statusCode: 404}} , (error)=>{
+              // If the hosts API returns a 404 response for a software item that was returned from in the list of critical software, we'll log a warning and remove this software from the list of software.
+              sails.log.warn(`When sending a request to the '/api/v1/fleet/hosts' API endpoint to get a filtered array of hosts with ${ware.name} ${ware.version} installed (software ID: ${ware.id}), the Fleet instance returned a 404 response when we expected it to return an array of ${ware.hosts_count} host(s).\n Response from Fleet instance: ${error.raw.body}`);
+              criticalWaresWithNoHostInformation.push(ware);// Add this software to the criticalWaresWithNoHostInformation array, these will be removed before we create and update database records.
+              return {};// Return an empty object. This will let the script continue without information about this software.
             });
             // sails.log.warn(`got a response for page ${hostsPage} for ${ware.name}.`);
             if (!responseData.hosts) {// When pages of results are exhausted, bail.  (`responseData.software` is absent in that case)
@@ -653,6 +657,9 @@ module.exports = {
           return err;
         }
       });//∞  </each software version>
+
+      // Remove any software items that was not returned in the hosts API.
+      criticalWares = _.difference(criticalWares, criticalWaresWithNoHostInformation);
 
       let hostRecordsToUpdate = [];
       // Unrecognized hosts? Save 'em to the database.


### PR DESCRIPTION
Related to: https://github.com/fleetdm/confidential/issues/6523

Changes:
- (Vulnerability dashboard) Updated the `update-reports` script to log a warning and continue running if the Fleet API returns a 404 response when we expect to receive an array of hosts.

