### PR TITLE
[released bug] Fleet free UI: Hide Software > Vulnerabilities > Severity column and Exploited vulnerabilities dropdown option

### DIFF
--- a/changes/18937-hide-severity-column
+++ b/changes/18937-hide-severity-column
@@ -1,0 +1,1 @@
+- Fleet UI Bug fix: Fleet free doesn't return software severity so that column should be hidden

--- a/frontend/pages/SoftwarePage/SoftwareVulnerabilities/SoftwareVulnerabilitiesTable/SoftwareVulnerabilitiesTable.tests.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareVulnerabilities/SoftwareVulnerabilitiesTable/SoftwareVulnerabilitiesTable.tests.tsx
@@ -1,0 +1,207 @@
+import React from "react";
+import { screen, waitFor } from "@testing-library/react";
+import { noop } from "lodash";
+import { createCustomRenderer } from "test/test-utils";
+
+import { createMockVulnerabilitiesResponse } from "__mocks__/vulnerabilitiesMock";
+import createMockUser from "__mocks__/userMock";
+
+import SoftwareVulnerabilitiesTable from "./SoftwareVulnerabilitiesTable";
+
+// TODO: figure out how to mock the router properly.
+const mockRouter = {
+  push: jest.fn(),
+  replace: jest.fn(),
+  goBack: jest.fn(),
+  goForward: jest.fn(),
+  go: jest.fn(),
+  setRouteLeaveHook: jest.fn(),
+  isActive: jest.fn(),
+  createHref: jest.fn(),
+  createPath: jest.fn(),
+};
+
+describe("Software Vulnerabilities table", () => {
+  it("Renders the page-wide disabled state when software inventory is disabled", async () => {
+    const render = createCustomRenderer({
+      context: {
+        app: {
+          isGlobalAdmin: true,
+          currentUser: createMockUser(),
+        },
+      },
+    });
+
+    render(
+      <SoftwareVulnerabilitiesTable
+        router={mockRouter}
+        isSoftwareEnabled={false}
+        data={createMockVulnerabilitiesResponse({
+          count: 0,
+          vulnerabilities: null,
+          meta: {
+            has_next_results: false,
+            has_previous_results: false,
+          },
+        })}
+        query=""
+        perPage={20}
+        orderDirection="asc"
+        orderKey="hosts_count"
+        showExploitedVulnerabilitiesOnly={false}
+        currentPage={0}
+        isLoading={false}
+      />
+    );
+
+    expect(screen.getByText("Software inventory disabled")).toBeInTheDocument();
+    expect(screen.queryByText("Vulnerability")).toBeNull();
+  });
+
+  // TODO: Reinstate collecting software view
+  it("Renders the page-wide empty state when no software vulnerabilities are present", async () => {
+    const render = createCustomRenderer({
+      context: {
+        app: {
+          isGlobalAdmin: true,
+          currentUser: createMockUser(),
+        },
+      },
+    });
+
+    render(
+      <SoftwareVulnerabilitiesTable
+        router={mockRouter}
+        isSoftwareEnabled
+        data={createMockVulnerabilitiesResponse({
+          count: 0,
+          vulnerabilities: null,
+          meta: {
+            has_next_results: false,
+            has_previous_results: false,
+          },
+        })}
+        query=""
+        perPage={20}
+        orderDirection="asc"
+        orderKey="hosts_count"
+        showExploitedVulnerabilitiesOnly={false}
+        currentPage={0}
+        isLoading={false}
+      />
+    );
+
+    expect(
+      screen.getByText("No software match the current search criteria")
+    ).toBeInTheDocument();
+    expect(screen.queryByText("Vulnerability")).toBeNull();
+  });
+
+  it("Renders the empty search state when search query exists for server side search with no results", async () => {
+    const render = createCustomRenderer({
+      context: {
+        app: {
+          isGlobalAdmin: true,
+          currentUser: createMockUser(),
+        },
+      },
+    });
+
+    render(
+      <SoftwareVulnerabilitiesTable
+        router={mockRouter}
+        isSoftwareEnabled
+        data={createMockVulnerabilitiesResponse({
+          count: 0,
+          vulnerabilities: null,
+          meta: {
+            has_next_results: false,
+            has_previous_results: false,
+          },
+        })}
+        query="abcdefg"
+        perPage={20}
+        orderDirection="asc"
+        orderKey="hosts_count"
+        showExploitedVulnerabilitiesOnly={false}
+        currentPage={0}
+        isLoading={false}
+      />
+    );
+
+    expect(
+      screen.getByText("No software match the current search criteria")
+    ).toBeInTheDocument();
+    expect(screen.queryByText("Vulnerability")).toBeNull();
+  });
+
+  it("Renders premium columns", async () => {
+    const render = createCustomRenderer({
+      context: {
+        app: {
+          isPremiumTier: true,
+          isGlobalAdmin: true,
+          currentUser: createMockUser(),
+        },
+      },
+    });
+
+    render(
+      <SoftwareVulnerabilitiesTable
+        router={mockRouter}
+        isSoftwareEnabled
+        data={createMockVulnerabilitiesResponse()}
+        query=""
+        perPage={20}
+        orderDirection="asc"
+        orderKey="hosts_count"
+        showExploitedVulnerabilitiesOnly={false}
+        currentPage={0}
+        isLoading={false}
+      />
+    );
+
+    expect(screen.getByText("Vulnerability")).toBeInTheDocument();
+    expect(screen.getByText("Severity")).toBeInTheDocument();
+    expect(screen.getByText("Probability of exploit")).toBeInTheDocument();
+    expect(screen.getByText("Published")).toBeInTheDocument();
+    expect(screen.getByText("Detected")).toBeInTheDocument();
+    expect(screen.getByText("Hosts")).toBeInTheDocument();
+  });
+
+  it("Renders free columns", async () => {
+    const render = createCustomRenderer({
+      context: {
+        app: {
+          isPremiumTier: false,
+          isGlobalAdmin: true,
+          currentUser: createMockUser(),
+        },
+      },
+    });
+
+    render(
+      <SoftwareVulnerabilitiesTable
+        router={mockRouter}
+        isSoftwareEnabled
+        data={createMockVulnerabilitiesResponse()}
+        query=""
+        perPage={20}
+        orderDirection="asc"
+        orderKey="hosts_count"
+        showExploitedVulnerabilitiesOnly={false}
+        currentPage={0}
+        isLoading={false}
+      />
+    );
+
+    expect(screen.getByText("Vulnerability")).toBeInTheDocument();
+    expect(screen.queryByText("Severity")).not.toBeInTheDocument();
+    expect(
+      screen.queryByText("Probability of exploit")
+    ).not.toBeInTheDocument();
+    expect(screen.queryByText("Published")).not.toBeInTheDocument();
+    expect(screen.getByText("Detected")).toBeInTheDocument();
+    expect(screen.getByText("Hosts")).toBeInTheDocument();
+  });
+});

--- a/frontend/pages/SoftwarePage/SoftwareVulnerabilities/SoftwareVulnerabilitiesTable/SoftwareVulnerabilitiesTable.tests.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareVulnerabilities/SoftwareVulnerabilitiesTable/SoftwareVulnerabilitiesTable.tests.tsx
@@ -169,7 +169,7 @@ describe("Software Vulnerabilities table", () => {
     expect(screen.getByText("Hosts")).toBeInTheDocument();
   });
 
-  it("Renders free columns", async () => {
+  it("Does not render premium only columns and disables exploited vulnerabilities dropdown", async () => {
     const render = createCustomRenderer({
       context: {
         app: {
@@ -180,7 +180,7 @@ describe("Software Vulnerabilities table", () => {
       },
     });
 
-    render(
+    const { user } = render(
       <SoftwareVulnerabilitiesTable
         router={mockRouter}
         isSoftwareEnabled
@@ -203,5 +203,22 @@ describe("Software Vulnerabilities table", () => {
     expect(screen.queryByText("Published")).not.toBeInTheDocument();
     expect(screen.getByText("Detected")).toBeInTheDocument();
     expect(screen.getByText("Hosts")).toBeInTheDocument();
+
+    await user.click(screen.getByText("All vulnerabilities"));
+
+    expect(
+      screen.getByText("Exploited vulnerabilities").parentElement?.parentElement
+        ?.parentElement
+    ).toHaveClass("is-disabled");
+
+    await waitFor(() => {
+      waitFor(() => {
+        user.hover(screen.getByText("Exploited vulnerabilities"));
+      });
+
+      expect(
+        screen.getByText(/Available in Fleet Premium./i)
+      ).toBeInTheDocument();
+    });
   });
 });

--- a/frontend/pages/SoftwarePage/SoftwareVulnerabilities/SoftwareVulnerabilitiesTable/SoftwareVulnerabilitiesTable.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareVulnerabilities/SoftwareVulnerabilitiesTable/SoftwareVulnerabilitiesTable.tsx
@@ -7,10 +7,7 @@ import { Row } from "react-table";
 import PATHS from "router/paths";
 
 import { AppContext } from "context/app";
-import {
-  GITHUB_NEW_ISSUE_LINK,
-  EXPLOITED_VULNERABILITIES_DROPDOWN_OPTIONS,
-} from "utilities/constants";
+import { GITHUB_NEW_ISSUE_LINK } from "utilities/constants";
 
 // @ts-ignore
 import Dropdown from "components/forms/fields/Dropdown";
@@ -227,12 +224,34 @@ const SoftwareVulnerabilitiesTable = ({
     );
   };
 
+  const getExploitedVulnerabiltiesDropdownOptions = () => {
+    const disabledTooltipContent = "Available in Fleet Premium.";
+
+    return [
+      {
+        disabled: false,
+        label: "All vulnerabilities",
+        value: false,
+        helpText: "All vulnerabilities detected on your hosts.",
+      },
+      {
+        disabled: !isPremiumTier,
+        label: "Exploited vulnerabilities",
+        value: true,
+        helpText:
+          "Vulnerabilities that have been actively exploited in the wild.",
+        tooltipContent: !isPremiumTier && disabledTooltipContent,
+      },
+    ];
+  };
+
+  // Exploited vulnerabilities is a premium feature
   const renderExploitedVulnerabilitiesDropdown = () => {
     return (
       <Dropdown
         value={showExploitedVulnerabilitiesOnly}
         className={`${baseClass}__exploited-vulnerabilities-dropdown`}
-        options={EXPLOITED_VULNERABILITIES_DROPDOWN_OPTIONS}
+        options={getExploitedVulnerabiltiesDropdownOptions()}
         searchable={false}
         onChange={handleExploitedVulnFilterDropdownChange}
         tableFilterDropdown

--- a/frontend/pages/SoftwarePage/SoftwareVulnerabilities/SoftwareVulnerabilitiesTable/VulnerabilitiesTableConfig.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareVulnerabilities/SoftwareVulnerabilitiesTable/VulnerabilitiesTableConfig.tsx
@@ -284,7 +284,8 @@ const generateTableHeaders = (
     return tableHeaders.filter(
       (header) =>
         header.accessor !== "epss_probability" &&
-        header.accessor !== "cve_published"
+        header.accessor !== "cve_published" &&
+        header.accessor !== "cvss_score"
     );
   }
 

--- a/frontend/services/entities/vulnerabilities.ts
+++ b/frontend/services/entities/vulnerabilities.ts
@@ -33,7 +33,7 @@ export interface IGetVulnerabilityQueryKey extends IGetVulnerabilityOptions {
 export interface IVulnerabilitiesResponse {
   count: number;
   counts_updated_at: string;
-  vulnerabilities: IVulnerability[];
+  vulnerabilities: IVulnerability[] | null; // API can return null
   meta: {
     has_next_results: boolean;
     has_previous_results: boolean;

--- a/frontend/utilities/constants.tsx
+++ b/frontend/utilities/constants.tsx
@@ -333,21 +333,6 @@ export const VULNERABLE_DROPDOWN_OPTIONS = [
   },
 ];
 
-export const EXPLOITED_VULNERABILITIES_DROPDOWN_OPTIONS = [
-  {
-    disabled: false,
-    label: "All vulnerabilities",
-    value: false,
-    helpText: "All vulnerabilities detected on your hosts.",
-  },
-  {
-    disabled: false,
-    label: "Exploited vulnerabilities",
-    value: true,
-    helpText: "Vulnerabilities that have been actively exploited in the wild.",
-  },
-];
-
 // Keys from API
 export const MDM_STATUS_TOOLTIP: Record<string, string | React.ReactNode> = {
   "On (automatic)": (


### PR DESCRIPTION
## Issue
Cerra #18937 

## Description
- Severity column is not returned by Fleet Free API and is now hidden in Free UI
- Pending approval from product/design (thumbs up emoji confirmation only): Added fix for exploited vulnerabilities dropdown erroring out page for fleet free 
- Added basic tests to this table including what columns are being shown on free/premium

## Screenshot of fix
### Fleet free hides the severity column
<img width="1609" alt="Screenshot 2024-05-13 at 12 42 56 PM" src="https://github.com/fleetdm/fleet/assets/71795832/f698f998-fad5-4905-90bd-778baf282293">

### Added 5 tests to the Software Vulnerabilities table
<img width="735" alt="Screenshot 2024-05-14 at 9 45 43 AM" src="https://github.com/fleetdm/fleet/assets/71795832/05ebd9b6-9695-4d5e-bf63-2fbc8187f057">

### Fleet free disables the dropdown option that was erroring out on click because exploited vulnerabilities its a premium feature
<img width="1422" alt="Screenshot 2024-05-13 at 4 06 19 PM" src="https://github.com/fleetdm/fleet/assets/71795832/593315a8-6b08-40f8-bc80-059887f92571">

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
- [x] Manual QA for all new/changed functionality

