### PR TITLE
Updating user now updates activity feed.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -487,10 +487,11 @@ db-replica-setup:
 	$(eval MYSQL_REPLICATION_USER := replicator)
 	$(eval MYSQL_REPLICATION_PASSWORD := rotacilper)
 	MYSQL_PWD=toor mysql --host 127.0.0.1 --port 3309 -uroot -AN -e "stop slave; reset slave all;"
-	MYSQL_PWD=toor mysql --host 127.0.0.1 --port 3308 -uroot -AN -e "drop user if exists '$(MYSQL_REPLICATION_USER)'; create user '$(MYSQL_REPLICATION_USER)'@'%'; grant replication slave on *.* to '$(MYSQL_REPLICATION_USER)'@'%' identified by '$(MYSQL_REPLICATION_PASSWORD)'; flush privileges;"
+	MYSQL_PWD=toor mysql --host 127.0.0.1 --port 3308 -uroot -AN -e "drop user if exists '$(MYSQL_REPLICATION_USER)'; create user '$(MYSQL_REPLICATION_USER)'@'%' identified by '$(MYSQL_REPLICATION_PASSWORD)'; grant replication slave on *.* to '$(MYSQL_REPLICATION_USER)'@'%'; flush privileges;"
 	$(eval MAIN_POSITION := $(shell MYSQL_PWD=toor mysql --host 127.0.0.1 --port 3308 -uroot -e 'show master status \G' | grep Position | grep -o '[0-9]*'))
 	$(eval MAIN_FILE := $(shell MYSQL_PWD=toor mysql --host 127.0.0.1 --port 3308 -uroot -e 'show master status \G' | grep File | sed -n -e 's/^.*: //p'))
-	MYSQL_PWD=toor mysql --host 127.0.0.1 --port 3309 -uroot -AN -e "change master to master_host='mysql_main',master_user='$(MYSQL_REPLICATION_USER)',master_password='$(MYSQL_REPLICATION_PASSWORD)',master_log_file='$(MAIN_FILE)',master_log_pos=$(MAIN_POSITION);"
+	MYSQL_PWD=toor mysql --host 127.0.0.1 --port 3309 -uroot -AN -e "change master to master_port=3306,master_host='mysql_main',master_user='$(MYSQL_REPLICATION_USER)',master_password='$(MYSQL_REPLICATION_PASSWORD)',master_log_file='$(MAIN_FILE)',master_log_pos=$(MAIN_POSITION);"
+	if [ "${FLEET_MYSQL_IMAGE}" == "mysql:8.0" ]; then MYSQL_PWD=toor mysql --host 127.0.0.1 --port 3309 -uroot -AN -e "change master to get_master_public_key=1;"; fi
 	MYSQL_PWD=toor mysql --host 127.0.0.1 --port 3309 -uroot -AN -e "change master to master_delay=1;"
 	MYSQL_PWD=toor mysql --host 127.0.0.1 --port 3309 -uroot -AN -e "start slave;"
 

--- a/changes/18766-updating-user
+++ b/changes/18766-updating-user
@@ -1,0 +1,1 @@
+Fixed bug where updating user via `/api/v1/fleet/users/:id` endpoint sometimes did not update the activity feed and returned the un-updated user object.

--- a/tools/backup_db/backup.sh
+++ b/tools/backup_db/backup.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-docker run --rm --network fleet_default mysql:5.7 bash -c 'mysqldump -hmysql -uroot -ptoor --default-character-set=utf8mb4 fleet | gzip -' > backup.sql.gz
+docker run --rm --network fleet_default ${FLEET_MYSQL_IMAGE:-mysql:5.7} bash -c 'mysqldump -hmysql -uroot -ptoor --default-character-set=utf8mb4 fleet | gzip -' > backup.sql.gz

--- a/tools/backup_db/restore.sh
+++ b/tools/backup_db/restore.sh
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-docker run --rm -i --network fleet_default ${FLEET_MYSQL_IMAGE:-mysql:5.7} bash -c 'gzip -dc - | mysql -hmysql -uroot -ptoor --port 3308 fleet' < backup.sql.gz
-
+docker run --rm -i --network fleet_default ${FLEET_MYSQL_IMAGE:-mysql:5.7} bash -c 'gzip -dc - | mysql -hmysql -uroot -ptoor fleet' < backup.sql.gz

--- a/tools/backup_db/restore.sh
+++ b/tools/backup_db/restore.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-docker run --rm -i --network fleet_default mysql:5.7 bash -c 'gzip -dc - | mysql -hmysql -uroot -ptoor fleet' < backup.sql.gz
+docker run --rm -i --network fleet_default ${FLEET_MYSQL_IMAGE:-mysql:5.7} bash -c 'gzip -dc - | mysql -hmysql -uroot -ptoor --port 3308 fleet' < backup.sql.gz
 

--- a/tools/mysql-replica-testing/docker-compose.yml
+++ b/tools/mysql-replica-testing/docker-compose.yml
@@ -3,7 +3,7 @@ version: "2"
 services:
   mysql_main:
     image: ${FLEET_MYSQL_IMAGE:-mysql:5.7}
-    platform: linux/x86_64
+    platform: ${FLEET_MYSQL_PLATFORM:-linux/x86_64}
     volumes:
       - mysql-persistent-volume-replica-main:/tmp
     command:
@@ -13,7 +13,9 @@ services:
         # These 3 keys run MySQL with GTID consistency enforced to avoid issues with production deployments that use it.
         "--enforce-gtid-consistency=ON",
         "--log-bin=bin.log",
-        "--server-id=1"
+        "--server-id=1",
+        # Required for storage of Apple MDM installers.
+        "--max_allowed_packet=536870912"
       ]
     environment:
       &mysql-default-environment
@@ -26,7 +28,7 @@ services:
 
   mysql_read_replica:
     image: ${FLEET_MYSQL_IMAGE:-mysql:5.7}
-    platform: linux/x86_64
+    platform: ${FLEET_MYSQL_PLATFORM:-linux/x86_64}
     volumes:
       - mysql-persistent-volume-replica-read:/tmp
     # innodb-file-per-table=OFF gives ~20% speedup for test runs.
@@ -41,7 +43,9 @@ services:
         # These 3 keys run MySQL with GTID consistency enforced to avoid issues with production deployments that use it.
         "--enforce-gtid-consistency=ON",
         "--log-bin=bin.log",
-        "--server-id=2"
+        "--server-id=2",
+        # Required for storage of Apple MDM installers.
+        "--max_allowed_packet=536870912"
       ]
     environment: *mysql-default-environment
     ports:


### PR DESCRIPTION
#18766
Fixed a bug where updating user via `/api/v1/fleet/users/:id` endpoint sometimes did not update the activity feed and returned the un-updated user object.

You must use a DB configuration with a replica to reproduce the issue.

# Checklist for submitter

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [ ] Added/updated tests
- [x] Manual QA for all new/changed functionality
