### PR TITLE
add boilerplate to host installation result outputs

### DIFF
--- a/ee/server/service/software_installers.go
+++ b/ee/server/service/software_installers.go
@@ -316,5 +316,6 @@ func (svc *Service) GetSoftwareInstallResults(ctx context.Context, resultUUID st
 		return nil, err
 	}
 
+	res.EnhanceOutputDetails()
 	return res, nil
 }

--- a/server/datastore/mysql/software_installers.go
+++ b/server/datastore/mysql/software_installers.go
@@ -327,7 +327,9 @@ SELECT
 	COALESCE(%s, '') AS status,
 	si.filename AS software_package,
 	h.team_id AS host_team_id,
-	hsi.user_id AS user_id
+	hsi.user_id AS user_id,
+	hsi.post_install_script_exit_code,
+	hsi.install_script_exit_code
 FROM
 	host_software_installs hsi
 	JOIN hosts h ON h.id = hsi.host_id

--- a/server/fleet/software_test.go
+++ b/server/fleet/software_test.go
@@ -3,6 +3,7 @@ package fleet
 import (
 	"testing"
 
+	"github.com/fleetdm/fleet/v4/server/ptr"
 	"github.com/stretchr/testify/require"
 )
 
@@ -74,4 +75,84 @@ func TestParseSoftwareLastOpenedAtRowValue(t *testing.T) {
 	lastOpenedAt, err = ParseSoftwareLastOpenedAtRowValue("1694026958")
 	require.NoError(t, err)
 	require.NotZero(t, lastOpenedAt)
+}
+
+func TestEnhanceOutputDetails(t *testing.T) {
+	tests := []struct {
+		name                            string
+		hsr                             HostSoftwareInstallerResult
+		expectedPreInstallQueryOutput   string
+		expectedOutput                  string
+		expectedPostInstallScriptOutput string
+	}{
+		{
+			name: "pending status",
+			hsr: HostSoftwareInstallerResult{
+				Status: SoftwareInstallerPending,
+			},
+			expectedPreInstallQueryOutput:   "",
+			expectedOutput:                  "",
+			expectedPostInstallScriptOutput: "",
+		},
+		{
+			name: "non-pending status with empty PreInstallQueryOutput and successful install",
+			hsr: HostSoftwareInstallerResult{
+				Status:                SoftwareInstallerInstalled,
+				InstallScriptExitCode: ptr.Int(0),
+				PreInstallQueryOutput: "1",
+			},
+			expectedPreInstallQueryOutput:   "Query returned result\nProceeding to install...",
+			expectedOutput:                  "Installing software...\nSuccess\n",
+			expectedPostInstallScriptOutput: "",
+		},
+		{
+			name: "non-pending status with empty PreInstallQueryOutput and failed install",
+			hsr: HostSoftwareInstallerResult{
+				Status:                SoftwareInstallerFailed,
+				InstallScriptExitCode: ptr.Int(1),
+				PreInstallQueryOutput: "1",
+			},
+			expectedPreInstallQueryOutput:   "Query returned result\nProceeding to install...",
+			expectedOutput:                  "Installing software...\nFailed\n",
+			expectedPostInstallScriptOutput: "",
+		},
+		{
+			name: "non-pending status with non-empty PreInstallQueryOutput and disabled scripts",
+			hsr: HostSoftwareInstallerResult{
+				Status:                SoftwareInstallerFailed,
+				InstallScriptExitCode: ptr.Int(-2),
+				PreInstallQueryOutput: "1",
+			},
+			expectedPreInstallQueryOutput:   "Query returned result\nProceeding to install...",
+			expectedOutput:                  "Installing software...\nError: Scripts are disabled for this host. To run scripts, deploy the fleetd agent with --scripts-enabled.",
+			expectedPostInstallScriptOutput: "",
+		},
+		{
+			name: "non-pending status with non-empty PreInstallQueryOutput and failed post install script",
+			hsr: HostSoftwareInstallerResult{
+				Status:                    SoftwareInstallerInstalled,
+				InstallScriptExitCode:     ptr.Int(0),
+				PostInstallScriptExitCode: ptr.Int(1),
+				PreInstallQueryOutput:     "1",
+				PostInstallScriptOutput:   "output!",
+			},
+			expectedPreInstallQueryOutput: "Query returned result\nProceeding to install...",
+			expectedOutput:                "Installing software...\nSuccess\n",
+			expectedPostInstallScriptOutput: `Running script...
+Exit code: 1 (Failed)
+output!
+Rolling back software install...
+Rolled back successfully
+`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.hsr.EnhanceOutputDetails()
+			require.Equal(t, tt.expectedPreInstallQueryOutput, tt.hsr.PreInstallQueryOutput)
+			require.Equal(t, tt.expectedOutput, tt.hsr.Output)
+			require.Equal(t, tt.expectedPostInstallScriptOutput, tt.hsr.PostInstallScriptOutput)
+		})
+	}
 }

--- a/server/service/integration_enterprise_test.go
+++ b/server/service/integration_enterprise_test.go
@@ -9352,8 +9352,8 @@ func (s *integrationEnterpriseTestSuite) TestHostSoftwareInstallResult() {
 		InstallUUID:             installUUIDs[2],
 		Status:                  fleet.SoftwareInstallerInstalled,
 		PreInstallQueryOutput:   fleet.SoftwareInstallerQuerySuccessCopy,
-		Output:                  fmt.Sprintf(fleet.SoftwareInstallSucceedCopy, "success"),
-		PostInstallScriptOutput: fmt.Sprintf(fleet.SoftwarePostInstallSucceedCopy, "ok"),
+		Output:                  fmt.Sprintf(fleet.SoftwareInstallerInstallSuccessCopy, "success"),
+		PostInstallScriptOutput: fmt.Sprintf(fleet.SoftwareInstallerPostInstallSuccessCopy, "ok"),
 	})
 	wantAct.InstallUUID = installUUIDs[2]
 	wantAct.Status = string(fleet.SoftwareInstallerInstalled)

--- a/server/service/integration_enterprise_test.go
+++ b/server/service/integration_enterprise_test.go
@@ -9276,9 +9276,12 @@ func (s *integrationEnterpriseTestSuite) TestHostSoftwareInstallResult() {
 	}
 
 	type result struct {
-		HostID      uint
-		InstallUUID string
-		Status      fleet.SoftwareInstallerStatus
+		HostID                  uint
+		InstallUUID             string
+		Status                  fleet.SoftwareInstallerStatus
+		Output                  string
+		PostInstallScriptOutput string
+		PreInstallQueryOutput   string
 	}
 	checkResults := func(want result) {
 		var resp getSoftwareInstallResultsResponse
@@ -9287,6 +9290,9 @@ func (s *integrationEnterpriseTestSuite) TestHostSoftwareInstallResult() {
 		assert.Equal(t, want.HostID, resp.Results.HostID)
 		assert.Equal(t, want.InstallUUID, resp.Results.InstallUUID)
 		assert.Equal(t, want.Status, resp.Results.Status)
+		assert.Equal(t, want.PreInstallQueryOutput, resp.Results.PreInstallQueryOutput)
+		assert.Equal(t, want.Output, resp.Results.Output)
+		assert.Equal(t, want.PostInstallScriptOutput, resp.Results.PostInstallScriptOutput)
 	}
 
 	s.Do("POST", "/api/fleet/orbit/software_install/result",
@@ -9299,9 +9305,11 @@ func (s *integrationEnterpriseTestSuite) TestHostSoftwareInstallResult() {
 		}`, *host.OrbitNodeKey, installUUIDs[0])),
 		http.StatusNoContent)
 	checkResults(result{
-		HostID:      host.ID,
-		InstallUUID: installUUIDs[0],
-		Status:      fleet.SoftwareInstallerFailed,
+		HostID:                host.ID,
+		InstallUUID:           installUUIDs[0],
+		Status:                fleet.SoftwareInstallerFailed,
+		PreInstallQueryOutput: fleet.SoftwareInstallerQuerySuccessCopy,
+		Output:                fmt.Sprintf(fleet.SoftwareInstallerInstallFailCopy, "failed"),
 	})
 	wantAct := fleet.ActivityTypeInstalledSoftware{
 		HostID:          host.ID,
@@ -9320,9 +9328,10 @@ func (s *integrationEnterpriseTestSuite) TestHostSoftwareInstallResult() {
 		}`, *host.OrbitNodeKey, installUUIDs[1])),
 		http.StatusNoContent)
 	checkResults(result{
-		HostID:      host.ID,
-		InstallUUID: installUUIDs[1],
-		Status:      fleet.SoftwareInstallerFailed,
+		HostID:                host.ID,
+		InstallUUID:           installUUIDs[1],
+		Status:                fleet.SoftwareInstallerFailed,
+		PreInstallQueryOutput: fleet.SoftwareInstallerQueryFailCopy,
 	})
 	wantAct.InstallUUID = installUUIDs[1]
 	s.lastActivityOfTypeMatches(wantAct.ActivityName(), string(jsonMustMarshal(t, wantAct)), 0)
@@ -9339,9 +9348,12 @@ func (s *integrationEnterpriseTestSuite) TestHostSoftwareInstallResult() {
 		}`, *host.OrbitNodeKey, installUUIDs[2])),
 		http.StatusNoContent)
 	checkResults(result{
-		HostID:      host.ID,
-		InstallUUID: installUUIDs[2],
-		Status:      fleet.SoftwareInstallerInstalled,
+		HostID:                  host.ID,
+		InstallUUID:             installUUIDs[2],
+		Status:                  fleet.SoftwareInstallerInstalled,
+		PreInstallQueryOutput:   fleet.SoftwareInstallerQuerySuccessCopy,
+		Output:                  fmt.Sprintf(fleet.SoftwareInstallSucceedCopy, "success"),
+		PostInstallScriptOutput: fmt.Sprintf(fleet.SoftwarePostInstallSucceedCopy, "ok"),
 	})
 	wantAct.InstallUUID = installUUIDs[2]
 	wantAct.Status = string(fleet.SoftwareInstallerInstalled)


### PR DESCRIPTION
Specified by Marko, this should be returned by the API:

<img width="642" alt="image" src="https://github.com/fleetdm/fleet/assets/4419992/945e899e-9527-43cb-ac42-88b02d4bc844">


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Added/updated tests
- [x] Manual QA for all new/changed functionality
