### PR TITLE
UI – Only render SW version tooltip for > 1 version

### DIFF
--- a/changes/18852-sw-versions-tooltips-bug
+++ b/changes/18852-sw-versions-tooltips-bug
@@ -1,0 +1,1 @@
+- Fix a bug where a singular software version in the Software table generated a tooltip unnecessarily.

--- a/frontend/components/forms/fields/SearchField/SearchField.tsx
+++ b/frontend/components/forms/fields/SearchField/SearchField.tsx
@@ -4,8 +4,6 @@ import { IconNames } from "components/icons";
 // @ts-ignore
 import InputFieldWithIcon from "../InputFieldWithIcon";
 
-const baseClass = "search-field";
-
 export interface ISearchFieldProps {
   placeholder: string;
   defaultValue?: string;
@@ -37,7 +35,6 @@ const SearchField = ({
       name={icon}
       placeholder={placeholder}
       value={searchQueryInput}
-      // inputWrapperClass={`${baseClass}__input-wrapper`}
       onChange={onInputChange}
       onClick={onClick}
       iconPosition="start"

--- a/frontend/pages/SoftwarePage/components/VersionCell/VersionCell.tsx
+++ b/frontend/pages/SoftwarePage/components/VersionCell/VersionCell.tsx
@@ -44,13 +44,13 @@ interface IVersionCellProps {
 }
 
 const VersionCell = ({ versions }: IVersionCellProps) => {
-  const tooltipId = uniqueId();
-
   // only one version, no need for tooltip
   const cellText = generateText(versions);
-  if (!versions) {
+  if (!versions || versions.length <= 1) {
     return <>{cellText}</>;
   }
+
+  const tooltipId = uniqueId();
 
   const versionTooltip = generateTooltip(versions, tooltipId);
   return (


### PR DESCRIPTION
## Addresses #18852 
![Screenshot-2024-05-14-at-41502PM](https://github.com/fleetdm/fleet/assets/61553566/04e2ae9c-613e-49ba-95df-e2915e1427df)

- [x] Changes file added for user-visible changes in `changes/`
- [x] Manual QA for all new/changed functionality
