### PR TITLE
Catch `FAIL` and `panic: runtime error` in CI

### DIFF
--- a/.github/workflows/test-go.yaml
+++ b/.github/workflows/test-go.yaml
@@ -128,6 +128,8 @@ jobs:
         c1grep -oP 'FAIL: .*$' /tmp/gotest.log > /tmp/summary.txt
         c1grep 'test timed out after' /tmp/gotest.log >> /tmp/summary.txt
         c1grep 'fatal error:' /tmp/gotest.log >> /tmp/summary.txt
+        c1grep 'panic: runtime error: ' /tmp/gotest.log >> /tmp/summary.txt
+        c1grep ' FAIL\t' /tmp/gotest.log >> /tmp/summary.txt
         GO_FAIL_SUMMARY=$(head -n 5 /tmp/summary.txt | sed ':a;N;$!ba;s/\n/\\n/g')
         echo "GO_FAIL_SUMMARY=$GO_FAIL_SUMMARY"
         if [[ -z "$GO_FAIL_SUMMARY" ]]; then


### PR DESCRIPTION
This is just a CI change to catch these other type of errors and display them on the Slack message:

Instead of showing just `unknown, please check build URL`:
![Screenshot 2024-05-15 at 8 34 19 AM](https://github.com/fleetdm/fleet/assets/2073526/bd66def6-50de-4ee5-8ccd-17a7cf0741ae)
