### PR TITLE
add linux platform tuxedo

### DIFF
--- a/changes/add-tuxedo-os
+++ b/changes/add-tuxedo-os
@@ -1,0 +1,1 @@
+* Added Tuxedo OS to the Linux distribution platform list.

--- a/docs/Using Fleet/Understanding-host-vitals.md
+++ b/docs/Using Fleet/Understanding-host-vitals.md
@@ -32,7 +32,7 @@ SELECT 1 FROM disk_encryption WHERE user_uuid IS NOT "" AND filevault_status = '
 
 ## disk_encryption_linux
 
-- Platforms: linux, ubuntu, debian, rhel, centos, sles, kali, gentoo, amzn, pop, arch, linuxmint, void, nixos, endeavouros, manjaro, opensuse-leap, opensuse-tumbleweed
+- Platforms: linux, ubuntu, debian, rhel, centos, sles, kali, gentoo, amzn, pop, arch, linuxmint, void, nixos, endeavouros, manjaro, opensuse-leap, opensuse-tumbleweed, tuxedo
 
 - Query:
 ```sql
@@ -50,7 +50,7 @@ SELECT 1 FROM bitlocker_info WHERE drive_letter = 'C:' AND protection_status = 1
 
 ## disk_space_unix
 
-- Platforms: linux, ubuntu, debian, rhel, centos, sles, kali, gentoo, amzn, pop, arch, linuxmint, void, nixos, endeavouros, manjaro, opensuse-leap, opensuse-tumbleweed, darwin
+- Platforms: linux, ubuntu, debian, rhel, centos, sles, kali, gentoo, amzn, pop, arch, linuxmint, void, nixos, endeavouros, manjaro, opensuse-leap, opensuse-tumbleweed, darwin, tuxedo
 
 - Query:
 ```sql
@@ -228,7 +228,7 @@ SELECT ipv4 AS address, mac FROM network_interfaces LIMIT 1
 
 ## network_interface_unix
 
-- Platforms: linux, ubuntu, debian, rhel, centos, sles, kali, gentoo, amzn, pop, arch, linuxmint, void, nixos, endeavouros, manjaro, opensuse-leap, opensuse-tumbleweed, darwin
+- Platforms: linux, ubuntu, debian, rhel, centos, sles, kali, gentoo, amzn, pop, arch, linuxmint, void, nixos, endeavouros, manjaro, opensuse-leap, opensuse-tumbleweed, darwin, tuxedo
 
 - Query:
 ```sql
@@ -338,7 +338,7 @@ SELECT
 
 ## os_unix_like
 
-- Platforms: linux, ubuntu, debian, rhel, centos, sles, kali, gentoo, amzn, pop, arch, linuxmint, void, nixos, endeavouros, manjaro, opensuse-leap, opensuse-tumbleweed, darwin
+- Platforms: linux, ubuntu, debian, rhel, centos, sles, kali, gentoo, amzn, pop, arch, linuxmint, void, nixos, endeavouros, manjaro, opensuse-leap, opensuse-tumbleweed, darwin, tuxedo
 
 - Query:
 ```sql
@@ -463,7 +463,7 @@ FROM chrome_extensions
 
 ## software_linux
 
-- Platforms: linux, ubuntu, debian, rhel, centos, sles, kali, gentoo, amzn, pop, arch, linuxmint, void, nixos, endeavouros, manjaro, opensuse-leap, opensuse-tumbleweed
+- Platforms: linux, ubuntu, debian, rhel, centos, sles, kali, gentoo, amzn, pop, arch, linuxmint, void, nixos, endeavouros, manjaro, opensuse-leap, opensuse-tumbleweed, tuxedo
 
 - Query:
 ```sql
@@ -655,7 +655,7 @@ FROM homebrew_packages;
 
 ## software_vscode_extensions
 
-- Platforms: linux, ubuntu, debian, rhel, centos, sles, kali, gentoo, amzn, pop, arch, linuxmint, void, nixos, endeavouros, manjaro, opensuse-leap, opensuse-tumbleweed, darwin, windows
+- Platforms: linux, ubuntu, debian, rhel, centos, sles, kali, gentoo, amzn, pop, arch, linuxmint, void, nixos, endeavouros, manjaro, opensuse-leap, opensuse-tumbleweed, darwin, windows, tuxedo
 
 - Discovery query:
 ```sql

--- a/frontend/interfaces/platform.ts
+++ b/frontend/interfaces/platform.ts
@@ -65,6 +65,7 @@ export const HOST_LINUX_PLATFORMS = [
   "manjaro",
   "opensuse-leap",
   "opensuse-tumbleweed",
+  "tuxedo",
 ] as const;
 
 /**

--- a/server/fleet/hosts.go
+++ b/server/fleet/hosts.go
@@ -838,7 +838,7 @@ func (h *Host) FleetPlatform() string {
 
 // HostLinuxOSs are the possible linux values for Host.Platform.
 var HostLinuxOSs = []string{
-	"linux", "ubuntu", "debian", "rhel", "centos", "sles", "kali", "gentoo", "amzn", "pop", "arch", "linuxmint", "void", "nixos", "endeavouros", "manjaro", "opensuse-leap", "opensuse-tumbleweed",
+	"linux", "ubuntu", "debian", "rhel", "centos", "sles", "kali", "gentoo", "amzn", "pop", "arch", "linuxmint", "void", "nixos", "endeavouros", "manjaro", "opensuse-leap", "opensuse-tumbleweed", "tuxedo",
 }
 
 func IsLinux(hostPlatform string) bool {

--- a/server/fleet/hosts_test.go
+++ b/server/fleet/hosts_test.go
@@ -130,6 +130,10 @@ func TestPlatformFromHost(t *testing.T) {
 			expPlatform: "linux",
 		},
 		{
+			host:        "tuxedo",
+			expPlatform: "linux",
+		},
+		{
 			host:        "darwin",
 			expPlatform: "darwin",
 		},


### PR DESCRIPTION
# Changes

I'm running orbit based osqueryd on a laptop with [Tuxedo OS](https://www.tuxedocomputers.com/en/TUXEDO-OS_1.tuxedo#).
This OS identifies its platform via osquery as `tuxedo` and is therefore not recognized by the Fleet server:

```json
{
    "err": "unrecognized platform",
    "hostID": 76,
    "level": "error",
    "platform": "tuxedo",
    "ts": "2024-05-15T13:17:34.513509387Z"
}
```

This causes policy and scheduled queries to not being run on my system.
With this PR Im adding `tuxedo` to all occurrences found when searching for `kali`.

Additionally pre-commit checks were failing for me locally as it could not find the hook-id `RuboCop`. This could be solved by using `rubocop` instead.
Afterwards all pre-commit checks succeeded locally.

# Checklist for submitter

- [x] Added/updated tests