### PR TITLE
[released bugs] UI fix: 4 software/policy tables reset to page 0 when switching teams

### DIFF
--- a/changes/18732-switch-teams-reset-page
+++ b/changes/18732-switch-teams-reset-page
@@ -1,0 +1,1 @@
+- UI fix: Switching team resets to page 0 for all software and policy tables

--- a/frontend/components/TableContainer/TableContainer.tsx
+++ b/frontend/components/TableContainer/TableContainer.tsx
@@ -101,6 +101,8 @@ interface ITableContainerProps<T = any> {
   renderCount?: () => JSX.Element | null;
   renderFooter?: () => JSX.Element | null;
   setExportRows?: (rows: Row[]) => void;
+  /** Use for serverside filtering: Set to true when filters change in URL
+   * bar and API call so TableContainer will reset its page state to 0  */
   resetPageIndex?: boolean;
   disableTableHeader?: boolean;
   show0Count?: boolean;

--- a/frontend/hooks/useTeamIdParam.ts
+++ b/frontend/hooks/useTeamIdParam.ts
@@ -58,14 +58,8 @@ const rebuildQueryStringWithTeamId = (
 
   // Reset page to 0
   const pageIndex = parts.findIndex((p) => p.startsWith("page="));
-  const inheritedPageIndex = parts.findIndex((p) =>
-    p.startsWith("inherited_page=")
-  );
   if (pageIndex !== -1) {
     parts.splice(pageIndex, 1, "page=0");
-  }
-  if (inheritedPageIndex !== -1) {
-    parts.splice(inheritedPageIndex, 1, "inherited_page=0");
   }
 
   const teamIndex = parts.findIndex((p) => p.startsWith("team_id="));

--- a/frontend/pages/SoftwarePage/SoftwareOS/SoftwareOS.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareOS/SoftwareOS.tsx
@@ -24,6 +24,7 @@ interface ISoftwareOSProps {
   orderKey: string;
   currentPage: number;
   teamId?: number;
+  resetPageIndex: boolean;
 }
 
 const SoftwareOS = ({
@@ -34,6 +35,7 @@ const SoftwareOS = ({
   orderKey,
   currentPage,
   teamId,
+  resetPageIndex,
 }: ISoftwareOSProps) => {
   const queryParams = {
     page: currentPage,
@@ -82,6 +84,7 @@ const SoftwareOS = ({
         currentPage={currentPage}
         teamId={teamId}
         isLoading={isFetching}
+        resetPageIndex={resetPageIndex}
       />
     </div>
   );

--- a/frontend/pages/SoftwarePage/SoftwareOS/SoftwareOSTable/SoftwareOSTable.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareOS/SoftwareOSTable/SoftwareOSTable.tsx
@@ -39,6 +39,7 @@ interface ISoftwareOSTableProps {
   currentPage: number;
   teamId?: number;
   isLoading: boolean;
+  resetPageIndex: boolean;
 }
 
 const SoftwareOSTable = ({
@@ -51,6 +52,7 @@ const SoftwareOSTable = ({
   currentPage,
   teamId,
   isLoading,
+  resetPageIndex,
 }: ISoftwareOSTableProps) => {
   const { isSandboxMode, noSandboxHosts } = useContext(AppContext);
 
@@ -197,6 +199,7 @@ const SoftwareOSTable = ({
         renderFooter={renderTableFooter}
         disableMultiRowSelect
         onSelectSingleRow={handleRowSelect}
+        resetPageIndex={resetPageIndex}
       />
     </div>
   );

--- a/frontend/pages/SoftwarePage/SoftwarePage.tsx
+++ b/frontend/pages/SoftwarePage/SoftwarePage.tsx
@@ -141,10 +141,10 @@ const SoftwarePage = ({ children, router, location }: ISoftwarePageProps) => {
     queryParams?.order_direction === undefined
       ? DEFAULT_SORT_DIRECTION
       : queryParams.order_direction;
-  const initialPage = (() =>
+  const page =
     queryParams && queryParams.page
       ? parseInt(queryParams.page, 10)
-      : DEFAULT_PAGE)();
+      : DEFAULT_PAGE;
   // TODO: move these down into the Software Titles component.
   const query = queryParams && queryParams.query ? queryParams.query : "";
   const showExploitedVulnerabilitiesOnly =
@@ -160,7 +160,6 @@ const SoftwarePage = ({ children, router, location }: ISoftwarePageProps) => {
   const [showPreviewPayloadModal, setShowPreviewPayloadModal] = useState(false);
   const [showPreviewTicketModal, setShowPreviewTicketModal] = useState(false);
   const [showAddSoftwareModal, setShowAddSoftwareModal] = useState(false);
-  const [page, setPage] = useState(initialPage);
   const [resetPageIndex, setResetPageIndex] = useState<boolean>(false);
 
   const {
@@ -281,29 +280,20 @@ const SoftwarePage = ({ children, router, location }: ISoftwarePageProps) => {
   // NOTE: Solution reused from ManageHostPage.tsx
   useEffect(() => {
     setResetPageIndex(false);
-
-    // Ensures setting page to same page as seen in URL
-    if (initialPage !== page) {
-      setPage(initialPage);
-    }
   }, [queryParams, page]);
-
-  // NOTE: used to reset page number to 0 when modifying filters
-  const handleResetPageIndex = () => {
-    setResetPageIndex(true);
-  };
 
   const onTeamChange = useCallback(
     (teamId: number) => {
       handleTeamChange(teamId);
-      handleResetPageIndex();
+      // NOTE: used to reset page number to 0 when modifying filters
+      setResetPageIndex(true);
     },
     [handleTeamChange]
   );
 
   const navigateToNav = useCallback(
     (i: number): void => {
-      handleResetPageIndex(); // Fixes flakey page reset in table state when switching between tabs
+      setResetPageIndex(true); // Fixes flakey page reset in table state when switching between tabs
 
       // Only query param to persist between tabs is team id
       const teamIdParam = buildQueryStringFromParams({

--- a/frontend/pages/SoftwarePage/SoftwarePage.tsx
+++ b/frontend/pages/SoftwarePage/SoftwarePage.tsx
@@ -281,8 +281,6 @@ const SoftwarePage = ({ children, router, location }: ISoftwarePageProps) => {
   // NOTE: Solution reused from ManageHostPage.tsx
   useEffect(() => {
     setResetPageIndex(false);
-    console.log("queryParams.page", queryParams.page);
-    console.log("page.toString()", page.toString());
 
     // Ensures setting page to same page as seen in URL
     if (initialPage !== page) {

--- a/frontend/pages/SoftwarePage/SoftwareTitles/SoftwareTable/SoftwareTable.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitles/SoftwareTable/SoftwareTable.tsx
@@ -63,6 +63,7 @@ interface ISoftwareTableProps {
   currentPage: number;
   teamId?: number;
   isLoading: boolean;
+  resetPageIndex: boolean;
 }
 
 const baseClass = "software-table";
@@ -80,6 +81,7 @@ const SoftwareTable = ({
   currentPage,
   teamId,
   isLoading,
+  resetPageIndex,
 }: ISoftwareTableProps) => {
   const currentPath = showVersions
     ? PATHS.SOFTWARE_VERSIONS
@@ -359,6 +361,7 @@ const SoftwareTable = ({
         renderFooter={renderTableFooter}
         disableMultiRowSelect
         onSelectSingleRow={handleRowSelect}
+        resetPageIndex={resetPageIndex}
       />
     </div>
   );

--- a/frontend/pages/SoftwarePage/SoftwareTitles/SoftwareTitles.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitles/SoftwareTitles.tsx
@@ -45,6 +45,7 @@ interface ISoftwareTitlesProps {
   softwareFilter: ISoftwareDropdownFilterVal;
   currentPage: number;
   teamId?: number;
+  resetPageIndex: boolean;
 }
 
 const SoftwareTitles = ({
@@ -57,6 +58,7 @@ const SoftwareTitles = ({
   softwareFilter,
   currentPage,
   teamId,
+  resetPageIndex,
 }: ISoftwareTitlesProps) => {
   const showVersions = location.pathname === PATHS.SOFTWARE_VERSIONS;
 
@@ -153,6 +155,7 @@ const SoftwareTitles = ({
         currentPage={currentPage}
         teamId={teamId}
         isLoading={isTitlesFetching || isVersionsFetching}
+        resetPageIndex={resetPageIndex}
       />
     </div>
   );

--- a/frontend/pages/SoftwarePage/SoftwareVulnerabilities/SoftwareVulnerabilities.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareVulnerabilities/SoftwareVulnerabilities.tsx
@@ -25,6 +25,7 @@ interface ISoftwareVulnerabilitiesProps {
   currentPage: number;
   teamId?: number;
   showExploitedVulnerabilitiesOnly: boolean;
+  resetPageIndex: boolean;
 }
 
 const SoftwareVulnerabilities = ({
@@ -37,6 +38,7 @@ const SoftwareVulnerabilities = ({
   currentPage,
   teamId,
   showExploitedVulnerabilitiesOnly,
+  resetPageIndex,
 }: ISoftwareVulnerabilitiesProps) => {
   const queryParams = {
     page: currentPage,
@@ -85,6 +87,7 @@ const SoftwareVulnerabilities = ({
         currentPage={currentPage}
         teamId={teamId}
         isLoading={isFetching}
+        resetPageIndex={resetPageIndex}
       />
     </div>
   );

--- a/frontend/pages/SoftwarePage/SoftwareVulnerabilities/SoftwareVulnerabilitiesTable/SoftwareVulnerabilitiesTable.tests.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareVulnerabilities/SoftwareVulnerabilitiesTable/SoftwareVulnerabilitiesTable.tests.tsx
@@ -51,6 +51,7 @@ describe("Software Vulnerabilities table", () => {
         showExploitedVulnerabilitiesOnly={false}
         currentPage={0}
         isLoading={false}
+        resetPageIndex={false}
       />
     );
 
@@ -88,6 +89,7 @@ describe("Software Vulnerabilities table", () => {
         showExploitedVulnerabilitiesOnly={false}
         currentPage={0}
         isLoading={false}
+        resetPageIndex={false}
       />
     );
 
@@ -126,6 +128,7 @@ describe("Software Vulnerabilities table", () => {
         showExploitedVulnerabilitiesOnly={false}
         currentPage={0}
         isLoading={false}
+        resetPageIndex={false}
       />
     );
 
@@ -158,6 +161,7 @@ describe("Software Vulnerabilities table", () => {
         showExploitedVulnerabilitiesOnly={false}
         currentPage={0}
         isLoading={false}
+        resetPageIndex={false}
       />
     );
 
@@ -192,6 +196,7 @@ describe("Software Vulnerabilities table", () => {
         showExploitedVulnerabilitiesOnly={false}
         currentPage={0}
         isLoading={false}
+        resetPageIndex={false}
       />
     );
 

--- a/frontend/pages/SoftwarePage/SoftwareVulnerabilities/SoftwareVulnerabilitiesTable/SoftwareVulnerabilitiesTable.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareVulnerabilities/SoftwareVulnerabilitiesTable/SoftwareVulnerabilitiesTable.tsx
@@ -43,6 +43,7 @@ interface ISoftwareVulnerabilitiesTableProps {
   currentPage: number;
   teamId?: number;
   isLoading: boolean;
+  resetPageIndex: boolean;
 }
 
 const SoftwareVulnerabilitiesTable = ({
@@ -57,6 +58,7 @@ const SoftwareVulnerabilitiesTable = ({
   currentPage,
   teamId,
   isLoading,
+  resetPageIndex,
 }: ISoftwareVulnerabilitiesTableProps) => {
   const { isPremiumTier, isSandboxMode, noSandboxHosts } = useContext(
     AppContext
@@ -288,6 +290,7 @@ const SoftwareVulnerabilitiesTable = ({
         renderFooter={renderTableFooter}
         disableMultiRowSelect
         onSelectSingleRow={handleRowSelect}
+        resetPageIndex={resetPageIndex}
       />
     </div>
   );

--- a/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
@@ -585,6 +585,7 @@ const ManageHostsPage = ({
   useEffect(() => {
     // TODO: cleanup this effect
     setResetPageIndex(false);
+
     if (queryParams.page === page) {
       setPage(queryParams.page);
     }

--- a/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
@@ -580,6 +580,16 @@ const ManageHostsPage = ({
     return true;
   };
 
+  // NOTE: Solution also used on ManagePoliciesPage.tsx
+  // NOTE: used to reset page number to 0 when modifying filters
+  useEffect(() => {
+    // TODO: cleanup this effect
+    setResetPageIndex(false);
+    if (queryParams.page === page) {
+      setPage(queryParams.page);
+    }
+  }, [queryParams, page]);
+
   // NOTE: used to reset page number to 0 when modifying filters
   const handleResetPageIndex = () => {
     setTableQueryData(
@@ -762,18 +772,6 @@ const ManageHostsPage = ({
     setHiddenColumns(newHiddenColumns);
     setShowEditColumnsModal(false);
   };
-
-  // NOTE: used to reset page number to 0 when modifying filters
-  useEffect(() => {
-    // TODO: cleanup this effect
-    setResetPageIndex(false);
-    if (queryParams.add_hosts === "true") {
-      setShowAddHostsModal(true);
-    }
-    if (queryParams.page === page) {
-      setPage(queryParams.page);
-    }
-  }, [queryParams, page]);
 
   // NOTE: this is called once on initial render and every time the query changes
   const onTableQueryChange = useCallback(

--- a/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
@@ -583,12 +583,7 @@ const ManageHostsPage = ({
   // NOTE: Solution also used on ManagePoliciesPage.tsx
   // NOTE: used to reset page number to 0 when modifying filters
   useEffect(() => {
-    // TODO: cleanup this effect
     setResetPageIndex(false);
-
-    if (queryParams.page === page) {
-      setPage(queryParams.page);
-    }
   }, [queryParams, page]);
 
   // NOTE: used to reset page number to 0 when modifying filters

--- a/frontend/pages/policies/ManagePoliciesPage/ManagePoliciesPage.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/ManagePoliciesPage.tsx
@@ -148,12 +148,11 @@ const ManagePolicyPage = ({
   const initialSortDirection = (() =>
     (queryParams?.order_direction as "asc" | "desc") ??
     DEFAULT_SORT_DIRECTION)();
-  const initialPage = (() =>
-    queryParams && queryParams.page ? parseInt(queryParams?.page, 10) : 0)();
+  const page =
+    queryParams && queryParams.page ? parseInt(queryParams?.page, 10) : 0;
 
   // Needs update on location change or table state might not match URL
   const [searchQuery, setSearchQuery] = useState(initialSearchQuery);
-  const [page, setPage] = useState(initialPage);
   const [tableQueryData, setTableQueryData] = useState<ITableQueryData>();
   const [sortHeader, setSortHeader] = useState(initialSortHeader);
   const [sortDirection, setSortDirection] = useState<
@@ -168,7 +167,6 @@ const ManagePolicyPage = ({
     if (!isRouteOk) {
       return;
     }
-    setPage(initialPage);
     setSearchQuery(initialSearchQuery);
     setSortHeader(initialSortHeader);
     setSortDirection(initialSortDirection);
@@ -361,10 +359,7 @@ const ManagePolicyPage = ({
   // NOTE: Solution reused from ManageHostPage.tsx
   useEffect(() => {
     setResetPageIndex(false);
-    if (queryParams.page === page.toString()) {
-      setPage(page);
-    }
-  }, [queryParams, page]);
+  }, [page]);
 
   // NOTE: used to reset page number to 0 when modifying filters
   const handleResetPageIndex = () => {

--- a/frontend/pages/policies/ManagePoliciesPage/ManagePoliciesPage.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/ManagePoliciesPage.tsx
@@ -138,6 +138,7 @@ const ManagePolicyPage = ({
     policiesAvailableToAutomate,
     setPoliciesAvailableToAutomate,
   ] = useState<IPolicyStats[]>([]);
+  const [resetPageIndex, setResetPageIndex] = useState<boolean>(false);
 
   // Functions to avoid race conditions
   const initialSearchQuery = (() => queryParams.query ?? "")();
@@ -356,10 +357,32 @@ const ManagePolicyPage = ({
     }
   };
 
+  // NOTE: used to reset page number to 0 when modifying filters
+  // NOTE: Solution reused from ManageHostPage.tsx
+  useEffect(() => {
+    setResetPageIndex(false);
+    if (queryParams.page === page.toString()) {
+      setPage(page);
+    }
+  }, [queryParams, page]);
+
+  // NOTE: used to reset page number to 0 when modifying filters
+  const handleResetPageIndex = () => {
+    setTableQueryData(
+      (prevState) =>
+        ({
+          ...prevState,
+          pageIndex: 0,
+        } as ITableQueryData)
+    );
+    setResetPageIndex(true);
+  };
+
   const onTeamChange = useCallback(
     (teamId: number) => {
       setSelectedPolicyIds([]);
       handleTeamChange(teamId);
+      handleResetPageIndex();
     },
     [handleTeamChange]
   );
@@ -408,7 +431,7 @@ const ManagePolicyPage = ({
 
       router?.replace(locationPath);
     },
-    [isRouteOk, teamIdForApi, searchQuery, sortDirection] // Other dependencies can cause infinite re-renders as URL is source of truth
+    [isRouteOk, teamIdForApi, searchQuery, sortDirection, page, sortHeader] // Other dependencies can cause infinite re-renders as URL is source of truth
   );
 
   const toggleOtherWorkflowsModal = () =>
@@ -650,6 +673,7 @@ const ManagePolicyPage = ({
             sortDirection={sortDirection}
             page={page}
             onQueryChange={onQueryChange}
+            resetPageIndex={resetPageIndex}
           />
         )}
         {!isAnyTeamSelected && globalPoliciesError && <TableDataError />}
@@ -674,6 +698,7 @@ const ManagePolicyPage = ({
             sortDirection={sortDirection}
             page={page}
             onQueryChange={onQueryChange}
+            resetPageIndex={resetPageIndex}
           />
         )}
       </div>

--- a/frontend/pages/policies/ManagePoliciesPage/components/PoliciesTable/PoliciesTable.tests.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/components/PoliciesTable/PoliciesTable.tests.tsx
@@ -30,6 +30,7 @@ describe("Policies table", () => {
         page={0}
         onQueryChange={noop}
         renderPoliciesCount={() => null}
+        resetPageIndex={false}
       />
     );
 
@@ -59,6 +60,7 @@ describe("Policies table", () => {
         page={0}
         onQueryChange={noop}
         renderPoliciesCount={() => null}
+        resetPageIndex={false}
       />
     );
 
@@ -90,6 +92,7 @@ describe("Policies table", () => {
         page={0}
         onQueryChange={noop}
         renderPoliciesCount={() => null}
+        resetPageIndex={false}
       />
     );
 
@@ -128,6 +131,7 @@ describe("Policies table", () => {
         page={0}
         onQueryChange={noop}
         renderPoliciesCount={() => null}
+        resetPageIndex={false}
       />
     );
 
@@ -166,6 +170,7 @@ describe("Policies table", () => {
         page={0}
         onQueryChange={noop}
         renderPoliciesCount={() => null}
+        resetPageIndex={false}
       />
     );
 
@@ -207,6 +212,7 @@ describe("Policies table", () => {
         renderPoliciesCount={() => null}
         canAddOrDeletePolicy
         hasPoliciesToDelete
+        resetPageIndex={false}
       />
     );
 

--- a/frontend/pages/policies/ManagePoliciesPage/components/PoliciesTable/PoliciesTable.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/components/PoliciesTable/PoliciesTable.tsx
@@ -32,6 +32,7 @@ interface IPoliciesTableProps {
   sortHeader?: "name" | "failing_host_count";
   sortDirection?: "asc" | "desc";
   page: number;
+  resetPageIndex: boolean;
 }
 
 const PoliciesTable = ({
@@ -50,6 +51,7 @@ const PoliciesTable = ({
   sortHeader,
   sortDirection,
   page,
+  resetPageIndex,
 }: IPoliciesTableProps): JSX.Element => {
   const { config } = useContext(AppContext);
 
@@ -136,6 +138,7 @@ const PoliciesTable = ({
         onQueryChange={onTableQueryChange}
         inputPlaceHolder="Search by name"
         searchable={searchable}
+        resetPageIndex={resetPageIndex}
       />
     </div>
   );


### PR DESCRIPTION
## Issue
Cerra #18732 

## Description
- When switching teams, the page number wasn't resetting, so if you were on page 3 of one team, and you click to switch teams, you shouldn't page 3 of the new team (which might not even exist!), it should be reset to page 0
- Fix resets to page 0 on the policies page and software pages
- Note: As I was fixing the software page bug, other issues like pages not resetting between tabs occurred and had to be fixed. So below is everything that should be tested tested 

## Tables to QA starting from a page other than page 0 and either switching teams or switching tabs to ensure the page number is reset to page 0
- Policies table switching teams from not the first page:
 - [x] from team to global
 - [x] from global to team
 - [x] from team to team
- Software table switching teams  from not the first page:
 - [x] from team to global
 - [x] from global to team
 - [x] from team to team
- Software versions table switching teams from not the first page:
 - [x] from team to global
 - [x] from global to team
 - [x] from team to team
- Operating systems table switching teams between from not the first page:
 - [ ] from team to global  I don't have enough OSs in my dev environment to test
 - [ ] from global to team  I don't have enough OSs in my dev environment to test
 - [ ] from team to team  I don't have enough OSs  in my dev environment to test
- Software vulnerabilities table switching teams from not the first page:
 - [x] from team to global
 - [x] from global to team
 - [x] from team to team
 - Switching software tabs from not the first page:
 

FROM tab TO tab | Software table | Software versions toggle on | Os table | Vuln table
-- | -- | -- | -- | --
Software table | reclick ✓ | ✓ | I don't have enough OSs to test | ✓
Software versions toggle on | ✓| reclick ✓|  I don't have enough OSs to test | ✓
Os table | ✓ | ✓ |  I don't have enough OSs to test reclick | ✓
Vuln table | ✓ | ✓ |  I don't have enough OSs to test | reclick ✓



  

## Screenrecording
https://www.loom.com/share/4b544936bcca48258b056b3592150b00?sid=feec5558-7605-4c26-b5ab-4f700c0bf6f5

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
- [x] Manual QA for all new/changed functionality

