### PR TITLE
Added archive notes to deployment guides and linked to recommended docs

### DIFF
--- a/articles/deploy-fleet-on-aws-ecs.md
+++ b/articles/deploy-fleet-on-aws-ecs.md
@@ -1,6 +1,6 @@
 # Deploy Fleet on AWS ECS
 
-> **This article was archived on May 15, 2024** and may be out of date. Check out [Deploy Fleet](https://fleetdm.com/docs/deploy/deploy-fleet) for our recommended deployment method.
+> **This article was archived on May 16, 2024,** and may be outdated. Check out [Deploy Fleet](https://fleetdm.com/docs/deploy/deploy-fleet) for our recommended deployment method.
 
 ![Deploy Fleet on AWS ECS](../website/assets/images/articles/deploy-fleet-on-aws-ecs-800x450@2x.png)
 
@@ -30,7 +30,7 @@ Alternatively you can bake the prepare command into the same task definition see
 <meta name="articleTitle" value="Deploy Fleet on AWS ECS">
 <meta name="authorGitHubUsername" value="edwardsb">
 <meta name="authorFullName" value="Ben Edwards">
-<meta name="publishedOn" value="2022-02-14">
+<meta name="publishedOn" value="2021-10-06">
 <meta name="category" value="guides">
 <meta name="articleImageUrl" value="../website/assets/images/articles/deploy-fleet-on-aws-ecs-800x450@2x.png">
 <meta name="description" value="Information for deploying Fleet on AWS ECS.">

--- a/articles/deploy-fleet-on-aws-with-terraform.md
+++ b/articles/deploy-fleet-on-aws-with-terraform.md
@@ -1,12 +1,12 @@
 # Deploy Fleet on AWS with Terraform
 
+> **This article was archived on May 16, 2024,** and may be outdated. Check out [Deploy Fleet](https://fleetdm.com/docs/deploy/deploy-fleet) for our recommended deployment method.
+
 ![Deploy Fleet on AWS ECS](../website/assets/images/articles/deploy-fleet-on-aws-with-terraform-800x450@2x.png)
 
 Learn how to deploy Fleet on AWS with Terraform IaC (infrastructure as code).
 
 Deploying on AWS with Fleet’s reference architecture is an easy way to get a fully functional Fleet instance that can scale to your needs.
-
-> Updated May 2023 to reflect Fleet's current Terraform Module setup. 
 
 ## Prerequisites:
 
@@ -23,8 +23,7 @@ Remote state can be simple (local state) or complicated (S3, state locking, etc.
 
 ### Modules
 
-[Fleet terraform](https://github.com/fleetdm/fleet/tree/main/terraform) is made up of multiple modules. These modules can be used independently, or as group to stand up an opinionated
-set of infrastructure that we have found success with.
+[Fleet terraform](https://github.com/fleetdm/fleet/tree/main/terraform) is made up of multiple modules. These modules can be used independently, or as group to stand up an opinionated set of infrastructure that we have found success with.
 
 Each module defines the required resource and consumes the next nested module. The root module creates the VPC and then pulls in the `byo-vpc` module configuring it as necessary. The `byo-vpc` module creates the database and cache instances that get passed into the `byo-db` module. And finally the `byo-db` module creates the ECS cluster and load balancer to be consumed by the `byo-ecs` module.
 

--- a/articles/deploy-fleet-on-centos.md
+++ b/articles/deploy-fleet-on-centos.md
@@ -1,6 +1,10 @@
 # Deploy Fleet on CentOS
 
+> **This article was archived on May 16, 2024,** and may be outdated. Check out [Deploy Fleet](https://fleetdm.com/docs/deploy/deploy-fleet) for our recommended deployment method.
+
 ![Deploy Fleet on CentOS](../website/assets/images/articles/deploy-fleet-on-centos-800x450@2x.png)
+
+> Updated on December 2, 2020, by [Noah Talerman](https://github.com/noahtalerman).
 
 In this guide, we're going to install Fleet and all of its application dependencies on a CentOS 7.1 server. Once we have Fleet up and running, we're going to install osquery on that same CentOS 7.1 host and enroll it in Fleet. This should give you a good understanding of both how to install Fleet as well as how to install and configure osquery such that it can communicate with Fleet.
 
@@ -219,7 +223,7 @@ If you go back to [https://localhost:8080/hosts/manage](https://localhost:8080/h
 <meta name="articleTitle" value="Deploy Fleet on CentOS">
 <meta name="authorGitHubUsername" value="marpaia">
 <meta name="authorFullName" value="Mike Arpaia">
-<meta name="publishedOn" value="2022-06-27">
+<meta name="publishedOn" value="2017-09-22">
 <meta name="category" value="guides">
 <meta name="articleImageUrl" value="../website/assets/images/articles/deploy-fleet-on-centos-800x450@2x.png">
 <meta name="description" value="A guide to deploy Fleet on CentOS.">

--- a/articles/deploy-fleet-on-cloudgov.md
+++ b/articles/deploy-fleet-on-cloudgov.md
@@ -1,5 +1,7 @@
 # Deploy Fleet on Cloud.gov (Cloud Foundry)
 
+> **This article was archived on May 16, 2024,** and may be outdated. Check out [Deploy Fleet](https://fleetdm.com/docs/deploy/deploy-fleet) for our recommended deployment method.
+
 ![Deploy Fleet on Cloud.gov](../website/assets/images/articles/deploy-fleet-on-cloudgov-800x450@2x.png)
 
 Cloud.gov is a [FEDRAMP moderate Platform-as-a-Service
@@ -115,7 +117,7 @@ variables](https://fleetdm.com/docs/deploying/configuration#using-only-environme
 <meta name="articleTitle" value="Deploy Fleet on Cloud.gov">
 <meta name="authorGitHubUsername" value="JJediny">
 <meta name="authorFullName" value="John Jediny">
-<meta name="publishedOn" value="2022-04-24">
+<meta name="publishedOn" value="2022-09-08">
 <meta name="category" value="guides">
 <meta name="articleImageUrl" value="../website/assets/images/articles/deploy-fleet-on-cloudgov-800x450@2x.png">
 <meta name="description" value="Information for deploying Fleet on Cloud.gov.">

--- a/articles/deploy-fleet-on-hetzner-cloud.md
+++ b/articles/deploy-fleet-on-hetzner-cloud.md
@@ -1,5 +1,7 @@
 # Deploy Fleet on Hetzner Cloud
 
+> **This article was archived on May 16, 2024,** and may be outdated. Check out [Deploy Fleet](https://fleetdm.com/docs/deploy/deploy-fleet) for our recommended deployment method.
+
 ![Deploy Fleet on Hetzner Cloud](../website/assets/images/articles/deploy-fleet-on-hetzner-cloud-800x450@2x.png)
 
 Learn how to deploy Fleet on Hetzner Cloud using cloud-init and Docker. [Hetzner](https://hetzner.com) is a great price-performance provider for “root” (dedicated) and Virtual Private Servers (VPS), offering high performance and generous bandwidth.

--- a/articles/deploy-fleet-on-kubernetes.md
+++ b/articles/deploy-fleet-on-kubernetes.md
@@ -1,6 +1,10 @@
 # Deploy Fleet on Kubernetes
 
+> **This article was archived on May 16, 2024,** and may be outdated. Check out [Deploy Fleet](https://fleetdm.com/docs/deploy/deploy-fleet) for our recommended deployment method.
+
 ![Deploy Fleet on Kubernetes](../website/assets/images/articles/deploy-fleet-on-kubernetes-800x450@2x.png)
+
+> Updated on May 10, 2022, by [Kelvin Oghenerhoro Omereshone](https://github.com/DominusKelvin).
 
 In this guide, we will focus on deploying Fleet only on a Kubernetes cluster. Kubernetes is a container orchestration tool that was open sourced by Google in 2014.
 
@@ -194,7 +198,7 @@ Once you have the public IP address for the load balancer, create an A record in
 <meta name="articleTitle" value="Deploy Fleet on Kubernetes">
 <meta name="authorGitHubUsername" value="marpaia">
 <meta name="authorFullName" value="Mike Arpaia">
-<meta name="publishedOn" value="2022-05-10">
+<meta name="publishedOn" value="2017-11-18">
 <meta name="category" value="guides">
 <meta name="articleImageUrl" value="../website/assets/images/articles/deploy-fleet-on-kubernetes-800x450@2x.png">
 <meta name="description" value="Learn how to deploy Fleet on Kubernetes.">

--- a/articles/deploy-fleet-on-render.md
+++ b/articles/deploy-fleet-on-render.md
@@ -1,12 +1,12 @@
 # Deploy Fleet on Render
 
-![Deploy Fleet on Render](../website/assets/images/articles/deploy-fleet-on-render-800x450@2x.png)
+> **This article was archived on May 16, 2024,** and may be outdated. Check out [Deploy Fleet](https://fleetdm.com/docs/deploy/deploy-fleet) for our recommended deployment method.
 
-> Updated May 2024 to reflect Fleet's recommended Render deployment.
+![Deploy Fleet on Render](../website/assets/images/articles/deploy-fleet-on-render-800x450@2x.png)
 
 [Render](https://render.com/) is a cloud hosting service that makes it easy to get up and running fast, without the typical configuration headaches of larger enterprise hosting providers. Our Render blueprint offers a one-click deploy of Fleet in under five minutes, and provides a scalable cloud environment with a lower barrier to entry, making it a great place to get some experience with [Fleet](https://fleetdm.com/) and [osquery](https://osquery.io/).
 
-With one click, our Render blueprint will provision a Fleet web service, a MySQL database, and a Redis in-memory data store. Each service requires Render's `standard` plan at a cost of $7/mo each, totaling $21/mo to host your Fleet instance. If you prefer to follow a video, you can [watch us demonstrating the Render deployment process](https://www.loom.com/share/9373fb6bab2c43aa91949490ceb2678c?sid=081d70de-d736-4681-8107-2d80ec525235).
+With one click, our Render blueprint will provision a Fleet web service, a MySQL database, and a Redis in-memory data store. Each service requires Render's `standard` plan at a cost of $7/mo each, totaling $21/mo to host your Fleet instance. If you prefer to follow a video, you can [watch us demonstrating the Render deployment process](https://youtu.be/hly0tAOqveA).
 
 ## Deployment steps
 


### PR DESCRIPTION
To reduce the surface area of deployment guides to maintain (other than our recommended method in the docs), I have:

- Added archive notes to deployment guides in our blog and linked to our recommended deployment methods in the docs.
- Tracked down (approximately) the original publication dates of the guides for posterity.