### PR TITLE
Vulnerability processing docs: Add VS Code extensions

### DIFF
--- a/docs/Using Fleet/Vulnerability-Processing.md
+++ b/docs/Using Fleet/Vulnerability-Processing.md
@@ -21,6 +21,7 @@ Fleet detects vulnerabilities for these software types:
 | Apps                | ✅                                         | ✅                                               | ❌               |
 | Browser plugins     | Chrome extensions, Firefox extensions      | Chrome extensions, Firefox extensions            | ❌               |
 | Packages            | Python, Homebrew  | Python, Atom, Chocolatey | Adhere to whatever is defined in the [OVAL definitions](https://github.com/fleetdm/nvd/blob/master/oval_sources.json), except for kernel vulnerabilities and vulnerabilities involving configuration files. Supported distributions: <ul><li>Ubuntu</li><li>RHEL based distros (Red Hat, CentOS, Fedora, and Amazon Linux)</li></ul> |
+| IDE extensions      | VS Code extensions | VS Code extensions | VS Code extensions |
 
 As of right now, only app names with all ASCII characters are supported. Apps with names featuring non-ASCII characters, such as Cyrillic, will not generate matches.
 


### PR DESCRIPTION
- Document that Fleet now detects vulns on VS Code extensions: 
  - #15997
