### PR TITLE
Rename Explore data (fleetdm.com) team

### DIFF
--- a/it-and-security/teams/explore-data.yml
+++ b/it-and-security/teams/explore-data.yml
@@ -1,4 +1,4 @@
-name: "Explore data (fleetdm.com) [DO NOT DELETE]"
+name: "Explore data (fleetdm.com)"
 team_settings:
   features:
     enable_host_users: true


### PR DESCRIPTION
Renames team `Explore data (fleetdm.com)` to match team name in dogfood for successful gitops run.