### PR TITLE
Fleet UI: Add reminder banners for ABM and APNs expirations

### DIFF
--- a/frontend/components/App/App.tsx
+++ b/frontend/components/App/App.tsx
@@ -82,12 +82,10 @@ const App = ({ children, location }: IAppProps): JSX.Element => {
         setNoSandboxHosts(noSandboxHosts);
       }
 
-      // TODO: Confirm with MDM what to check on config to not hit 404 for /abm API
       if (configResponse.mdm.apple_bm_enabled_and_configured) {
         const abmInfo = await mdmAppleBMAPI.getAppleBMInfo();
         setABMExpiry(abmInfo.renew_date);
       }
-      // TODO: Confirm with MDM what to check on config to not hit 404 for /apns API
       if (configResponse.mdm.apple_bm_enabled_and_configured) {
         const apnsInfo = await mdmAppleAPI.getAppleAPNInfo();
         setAPNsExpiry(apnsInfo.renew_date);

--- a/frontend/components/App/App.tsx
+++ b/frontend/components/App/App.tsx
@@ -18,6 +18,8 @@ import useDeepEffect from "hooks/useDeepEffect";
 import usersAPI from "services/entities/users";
 import configAPI from "services/entities/config";
 import hostCountAPI from "services/entities/host_count";
+import mdmAppleBMAPI from "services/entities/mdm_apple_bm";
+import mdmAppleAPI from "services/entities/mdm_apple";
 
 import { ErrorBoundary } from "react-error-boundary";
 // @ts-ignore
@@ -61,6 +63,8 @@ const App = ({ children, location }: IAppProps): JSX.Element => {
     setCurrentUser,
     setConfig,
     setEnrollSecret,
+    setABMExpiry,
+    setAPNsExpiry,
     setSandboxExpiry,
     setNoSandboxHosts,
   } = useContext(AppContext);
@@ -76,6 +80,17 @@ const App = ({ children, location }: IAppProps): JSX.Element => {
         const hostCount = await hostCountAPI.load({});
         const noSandboxHosts = hostCount.count === 0;
         setNoSandboxHosts(noSandboxHosts);
+      }
+
+      // TODO: Confirm with MDM what to check on config to not hit 404 for /abm API
+      if (configResponse.mdm.apple_bm_enabled_and_configured) {
+        const abmInfo = await mdmAppleBMAPI.getAppleBMInfo();
+        setABMExpiry(abmInfo.renew_date);
+      }
+      // TODO: Confirm with MDM what to check on config to not hit 404 for /apns API
+      if (configResponse.mdm.apple_bm_enabled_and_configured) {
+        const apnsInfo = await mdmAppleAPI.getAppleAPNInfo();
+        setAPNsExpiry(apnsInfo.renew_date);
       }
       setConfig(configResponse);
     } catch (error) {

--- a/frontend/components/MDM/AppleBMRenewalMessage/AppleBMRenewalMessage.tsx
+++ b/frontend/components/MDM/AppleBMRenewalMessage/AppleBMRenewalMessage.tsx
@@ -1,0 +1,44 @@
+import React from "react";
+
+import InfoBanner from "components/InfoBanner";
+import CustomLink from "components/CustomLink";
+
+const baseClass = "apple-bm-renewal-message";
+
+type IAppleBMRenewalMessageProps = {
+  expired: boolean;
+};
+
+const AppleBMRenewalMessage = ({ expired }: IAppleBMRenewalMessageProps) => {
+  return (
+    <InfoBanner
+      className={baseClass}
+      color="yellow"
+      cta={
+        <CustomLink
+          url="https://fleetdm.com/learn-more-about/renew-abm"
+          text="Renew ABM"
+          className={`${baseClass}__new-tab`}
+          newTab
+          color="core-fleet-black"
+          iconColor="core-fleet-black"
+        />
+      }
+    >
+      {expired ? (
+        <>
+          Your Apple Business Manager (ABM) server token has expired. New macOS
+          hosts will not automatically enroll to Fleet.
+        </>
+      ) : (
+        <>
+          Your Apple Business Manager (ABM) server token is less than 30 days
+          from expiration. If it expires, new macOS hosts will not automatically
+          enroll to Fleet.
+        </>
+      )}
+    </InfoBanner>
+  );
+};
+
+export default AppleBMRenewalMessage;

--- a/frontend/components/MDM/AppleBMRenewalMessage/_styles.scss
+++ b/frontend/components/MDM/AppleBMRenewalMessage/_styles.scss
@@ -1,0 +1,5 @@
+.apple-bm-renewal-message {
+  margin-bottom: $pad-large;
+  position: sticky; // Needed for settings page scroll
+  z-index: 4; // Needed for settings page scroll
+}

--- a/frontend/components/MDM/AppleBMRenewalMessage/index.ts
+++ b/frontend/components/MDM/AppleBMRenewalMessage/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./AppleBMRenewalMessage";

--- a/frontend/components/MDM/ApplePNCertRenewalMessage/ApplePNCertRenewalMessage.tsx
+++ b/frontend/components/MDM/ApplePNCertRenewalMessage/ApplePNCertRenewalMessage.tsx
@@ -1,0 +1,45 @@
+import React from "react";
+
+import InfoBanner from "components/InfoBanner";
+import CustomLink from "components/CustomLink";
+
+const baseClass = "apple-pn-cert-renewal-message";
+
+type IApplePNCertRenewalMessage = {
+  expired: boolean;
+};
+
+const ApplePNCertRenewalMessage = ({ expired }: IApplePNCertRenewalMessage) => {
+  return (
+    <InfoBanner
+      className={baseClass}
+      color="yellow"
+      cta={
+        <CustomLink
+          url="https://fleetdm.com/learn-more-about/renew-apns"
+          text="Renew APNs"
+          className={`${baseClass}__new-tab`}
+          newTab
+          color="core-fleet-black"
+          iconColor="core-fleet-black"
+        />
+      }
+    >
+      {expired ? (
+        <>
+          Your Apple Push Notification service (APNs) certificate has expired.
+          After you renew the certificate, all end users have to turn MDM off
+          and back on.
+        </>
+      ) : (
+        <>
+          Your Apple Push Notification service (APNs) certificate is less than
+          30 days from expiration. If it expires all end users will have to turn
+          MDM off and back on.
+        </>
+      )}
+    </InfoBanner>
+  );
+};
+
+export default ApplePNCertRenewalMessage;

--- a/frontend/components/MDM/ApplePNCertRenewalMessage/_styles.scss
+++ b/frontend/components/MDM/ApplePNCertRenewalMessage/_styles.scss
@@ -1,0 +1,5 @@
+.apple-pn-cert-renewal-message {
+  margin-bottom: $pad-large;
+  position: sticky; // Needed for settings page scroll
+  z-index: 4; // Needed for settings page scroll
+}

--- a/frontend/components/MDM/ApplePNCertRenewalMessage/index.ts
+++ b/frontend/components/MDM/ApplePNCertRenewalMessage/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./ApplePNCertRenewalMessage";

--- a/frontend/components/MainContent/MainContent.tsx
+++ b/frontend/components/MainContent/MainContent.tsx
@@ -1,16 +1,16 @@
 import React, { ReactNode, useContext } from "react";
 import classnames from "classnames";
 import { formatDistanceToNow } from "date-fns";
-import { hasLicenseExpired } from "utilities/helpers";
+import { hasLicenseExpired, willExpireWithinXDays } from "utilities/helpers";
 
 import SandboxExpiryMessage from "components/Sandbox/SandboxExpiryMessage";
 import AppleBMTermsMessage from "components/MDM/AppleBMTermsMessage";
 
-import InfoBanner from "components/InfoBanner";
-import CustomLink from "components/CustomLink";
 import SandboxGate from "components/Sandbox/SandboxGate";
 import { AppContext } from "context/app";
 import LicenseExpirationBanner from "components/LicenseExpirationBanner";
+import ApplePNCertRenewalMessage from "components/MDM/ApplePNCertRenewalMessage";
+import AppleBMRenewalMessage from "components/MDM/AppleBMRenewalMessage";
 
 interface IMainContentProps {
   children: ReactNode;
@@ -34,31 +34,57 @@ const MainContent = ({
   const {
     sandboxExpiry,
     config,
-    isSandboxMode,
     isPremiumTier,
     noSandboxHosts,
+    apnsExpiry,
+    abmExpiry,
   } = useContext(AppContext);
-
-  const isAppleBmTermsExpired = config?.mdm?.apple_bm_terms_expired;
-  const isLicenseExpired = hasLicenseExpired(config?.license.expiration || "");
 
   const sandboxExpiryTime =
     sandboxExpiry === undefined
       ? "..."
       : formatDistanceToNow(new Date(sandboxExpiry));
 
-  const showAppleABMBanner =
-    isAppleBmTermsExpired && isPremiumTier && !isSandboxMode;
+  const renderWarningBanner = () => {
+    const isAppleBmTermsExpired = config?.mdm?.apple_bm_terms_expired;
+    const isApplePnsExpired = hasLicenseExpired(apnsExpiry || "");
+    const willApplePnsExpireIn30Days = willExpireWithinXDays(
+      apnsExpiry || "",
+      30
+    );
+    const isAppleBmExpired = hasLicenseExpired(abmExpiry || "");
+    const willAppleBmExpireIn30Days = willExpireWithinXDays(
+      abmExpiry || "",
+      30
+    );
+    const isFleetLicenseExpired = hasLicenseExpired(
+      config?.license.expiration || ""
+    );
 
-  // ABM banner takes precedence
-  const showLicenseExpirationBanner =
-    isLicenseExpired && isPremiumTier && !isAppleBmTermsExpired;
+    if (isPremiumTier) {
+      if (isApplePnsExpired || willApplePnsExpireIn30Days) {
+        return <ApplePNCertRenewalMessage expired={isApplePnsExpired} />;
+      }
 
+      if (isAppleBmExpired || willAppleBmExpireIn30Days) {
+        return <AppleBMRenewalMessage expired={isAppleBmExpired} />;
+      }
+
+      if (isAppleBmTermsExpired) {
+        return <AppleBMTermsMessage />;
+      }
+
+      if (isFleetLicenseExpired) {
+        return <LicenseExpirationBanner />;
+      }
+    }
+
+    return <></>;
+  };
   return (
     <div className={classes}>
       <div className={`${baseClass}--animation-disabled`}>
-        {showAppleABMBanner && <AppleBMTermsMessage />}
-        {showLicenseExpirationBanner && <LicenseExpirationBanner />}
+        {renderWarningBanner()}
         <SandboxGate
           fallbackComponent={() => (
             <SandboxExpiryMessage

--- a/frontend/components/MainContent/MainContent.tsx
+++ b/frontend/components/MainContent/MainContent.tsx
@@ -45,7 +45,7 @@ const MainContent = ({
       ? "..."
       : formatDistanceToNow(new Date(sandboxExpiry));
 
-  const renderWarningBanner = () => {
+  const renderAppWideBanner = () => {
     const isAppleBmTermsExpired = config?.mdm?.apple_bm_terms_expired;
     const isApplePnsExpired = hasLicenseExpired(apnsExpiry || "");
     const willApplePnsExpireIn30Days = willExpireWithinXDays(
@@ -84,7 +84,7 @@ const MainContent = ({
   return (
     <div className={classes}>
       <div className={`${baseClass}--animation-disabled`}>
-        {renderWarningBanner()}
+        {renderAppWideBanner()}
         <SandboxGate
           fallbackComponent={() => (
             <SandboxExpiryMessage

--- a/frontend/context/app.tsx
+++ b/frontend/context/app.tsx
@@ -18,6 +18,8 @@ enum ACTIONS {
   SET_CURRENT_TEAM = "SET_CURRENT_TEAM",
   SET_CONFIG = "SET_CONFIG",
   SET_ENROLL_SECRET = "SET_ENROLL_SECRET",
+  SET_ABM_EXPIRY = "SET_ABM_EXPIRY",
+  SET_APNS_EXPIRY = "SET_APNS_EXPIRY",
   SET_SANDBOX_EXPIRY = "SET_SANDBOX_EXPIRY",
   SET_NO_SANDBOX_HOSTS = "SET_NO_SANDBOX_HOSTS",
   SET_FILTERED_HOSTS_PATH = "SET_FILTERED_HOSTS_PATH",
@@ -48,6 +50,16 @@ interface ISetCurrentUserAction {
 interface ISetEnrollSecretAction {
   type: ACTIONS.SET_ENROLL_SECRET;
   enrollSecret: IEnrollSecret[];
+}
+
+interface ISetABMExpiryAction {
+  type: ACTIONS.SET_ABM_EXPIRY;
+  abmExpiry: string;
+}
+
+interface ISetAPNsExpiryAction {
+  type: ACTIONS.SET_APNS_EXPIRY;
+  apnsExpiry: string;
 }
 
 interface ISetSandboxExpiryAction {
@@ -85,6 +97,8 @@ type IAction =
   | ISetCurrentTeamAction
   | ISetCurrentUserAction
   | ISetEnrollSecretAction
+  | ISetABMExpiryAction
+  | ISetAPNsExpiryAction
   | ISetSandboxExpiryAction
   | ISetNoSandboxHostsAction
   | ISetFilteredHostsPathAction
@@ -123,6 +137,8 @@ type InitialStateType = {
   isOnlyObserver?: boolean;
   isObserverPlus?: boolean;
   isNoAccess?: boolean;
+  abmExpiry?: string;
+  apnsExpiry?: string;
   sandboxExpiry?: string;
   noSandboxHosts?: boolean;
   filteredHostsPath?: string;
@@ -137,6 +153,8 @@ type InitialStateType = {
   setCurrentTeam: (team?: ITeamSummary) => void;
   setConfig: (config: IConfig) => void;
   setEnrollSecret: (enrollSecret: IEnrollSecret[]) => void;
+  setAPNsExpiry: (apnsExpiry: string) => void;
+  setABMExpiry: (abmExpiry: string) => void;
   setSandboxExpiry: (sandboxExpiry: string) => void;
   setNoSandboxHosts: (noSandboxHosts: boolean) => void;
   setFilteredHostsPath: (filteredHostsPath: string) => void;
@@ -183,6 +201,8 @@ export const initialState = {
   setCurrentTeam: () => null,
   setConfig: () => null,
   setEnrollSecret: () => null,
+  setAPNsExpiry: () => null,
+  setABMExpiry: () => null,
   setSandboxExpiry: () => null,
   setNoSandboxHosts: () => null,
   setFilteredHostsPath: () => null,
@@ -363,6 +383,8 @@ const AppProvider = ({ children }: Props): JSX.Element => {
     currentTeam: state.currentTeam,
     enrollSecret: state.enrollSecret,
     sandboxExpiry: state.sandboxExpiry,
+    abmExpiry: state.abmExpiry,
+    apnsExpiry: state.apnsExpiry,
     noSandboxHosts: state.noSandboxHosts,
     filteredHostsPath: state.filteredHostsPath,
     filteredSoftwarePath: state.filteredSoftwarePath,
@@ -407,6 +429,12 @@ const AppProvider = ({ children }: Props): JSX.Element => {
     },
     setEnrollSecret: (enrollSecret: IEnrollSecret[]) => {
       dispatch({ type: ACTIONS.SET_ENROLL_SECRET, enrollSecret });
+    },
+    setABMExpiry: (abmExpiry: string) => {
+      dispatch({ type: ACTIONS.SET_ABM_EXPIRY, abmExpiry });
+    },
+    setAPNsExpiry: (apnsExpiry: string) => {
+      dispatch({ type: ACTIONS.SET_APNS_EXPIRY, apnsExpiry });
     },
     setSandboxExpiry: (sandboxExpiry: string) => {
       dispatch({ type: ACTIONS.SET_SANDBOX_EXPIRY, sandboxExpiry });

--- a/frontend/pages/hosts/details/HostDetailsPage/components/HostDetailsBanners/HostDetailsBanners.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/components/HostDetailsBanners/HostDetailsBanners.tsx
@@ -1,7 +1,9 @@
-import InfoBanner from "components/InfoBanner";
-import { AppContext } from "context/app";
-import { DiskEncryptionStatus, MdmEnrollmentStatus } from "interfaces/mdm";
 import React, { useContext } from "react";
+import { AppContext } from "context/app";
+
+import { DiskEncryptionStatus, MdmEnrollmentStatus } from "interfaces/mdm";
+import { hasLicenseExpired, willExpireWithinXDays } from "utilities/helpers";
+import InfoBanner from "components/InfoBanner";
 
 const baseClass = "host-details-banners";
 
@@ -21,26 +23,45 @@ const HostDetailsBanners = ({
   mdmName,
   diskEncryptionStatus,
 }: IHostDetailsBannersProps) => {
-  const { config, isSandboxMode, isPremiumTier } = useContext(AppContext);
+  const { config, isPremiumTier, apnsExpiry, abmExpiry } = useContext(
+    AppContext
+  );
 
-  // checks to see if the ABM message is being shown in a parent component.
-  // We want this to be the only banner shown to the user so we need to know
-  // if it's already being shown so we can suppress other banners.
+  // Checks to see if an app-wide banner is being shown (the ABM terms, ABM expiry,
+  // or APNs expiry banner) in a parent component. App-wide banners found in parent
+  // component take priority over host details page-level banners.
   const isAppleBmTermsExpired = config?.mdm?.apple_bm_terms_expired;
-  const showingAppleABMBanner =
-    (isAppleBmTermsExpired && isPremiumTier && !isSandboxMode) ?? false;
+  const isApplePnsExpired = hasLicenseExpired(apnsExpiry || "");
+  const willApplePnsExpireIn30Days = willExpireWithinXDays(
+    apnsExpiry || "",
+    30
+  );
+  const isAppleBmExpired = hasLicenseExpired(abmExpiry || "");
+  const willAppleBmExpireIn30Days = willExpireWithinXDays(abmExpiry || "", 30);
+  const isFleetLicenseExpired = hasLicenseExpired(
+    config?.license.expiration || ""
+  );
+
+  const showingAppWideBanner =
+    isPremiumTier &&
+    (isAppleBmTermsExpired ||
+      isApplePnsExpired ||
+      willApplePnsExpireIn30Days ||
+      isAppleBmExpired ||
+      willAppleBmExpireIn30Days ||
+      isFleetLicenseExpired);
 
   const isMdmUnenrolled =
     hostMdmEnrollmentStatus === "Off" || !hostMdmEnrollmentStatus;
 
   const showTurnOnMdmInfoBanner =
-    !showingAppleABMBanner &&
+    !showingAppWideBanner &&
     hostPlatform === "darwin" &&
     isMdmUnenrolled &&
     config?.mdm.enabled_and_configured;
 
   const showDiskEncryptionUserActionRequired =
-    !showingAppleABMBanner &&
+    !showingAppWideBanner &&
     config?.mdm.enabled_and_configured &&
     mdmName === "Fleet" &&
     diskEncryptionStatus === "action_required";

--- a/frontend/services/entities/mdm_apple.ts
+++ b/frontend/services/entities/mdm_apple.ts
@@ -4,8 +4,8 @@ import endpoints from "utilities/endpoints";
 
 export default {
   getAppleAPNInfo: () => {
-    const { MDM_APPLE } = endpoints;
-    const path = MDM_APPLE;
+    const { MDM_APPLE_PNS } = endpoints;
+    const path = MDM_APPLE_PNS;
     return sendRequest("GET", path);
   },
 };

--- a/frontend/utilities/endpoints.ts
+++ b/frontend/utilities/endpoints.ts
@@ -75,8 +75,8 @@ export default {
   MACADMINS: `/${API_VERSION}/fleet/macadmins`,
 
   // MDM endpoints
-  MDM_APPLE: `/${API_VERSION}/fleet/mdm/apple`,
-  MDM_APPLE_BM: `/${API_VERSION}/fleet/mdm/apple_bm`,
+  MDM_APPLE_PNS: `/${API_VERSION}/fleet/apns`,
+  MDM_APPLE_BM: `/${API_VERSION}/fleet/abm`,
   MDM_APPLE_BM_KEYS: `/${API_VERSION}/fleet/mdm/apple/dep/key_pair`,
   MDM_SUMMARY: `/${API_VERSION}/fleet/hosts/summary/mdm`,
   MDM_REQUEST_CSR: `/${API_VERSION}/fleet/mdm/apple/request_csr`,

--- a/frontend/utilities/helpers.tsx
+++ b/frontend/utilities/helpers.tsx
@@ -20,6 +20,7 @@ import {
   intervalToDuration,
   isAfter,
   isBefore,
+  addDays,
 } from "date-fns";
 import yaml from "js-yaml";
 
@@ -677,6 +678,15 @@ export const hasLicenseExpired = (expiration: string): boolean => {
   return isAfter(new Date(), new Date(expiration));
 };
 
+export const willExpireWithinXDays = (
+  expiration: string,
+  x: number
+): boolean => {
+  const xDaysFromNow = addDays(new Date(), x);
+
+  return isAfter(xDaysFromNow, new Date(expiration));
+};
+
 export const readableDate = (date: string) => {
   const dateString = new Date(date);
 
@@ -983,6 +993,7 @@ export default {
   humanQueryLastRun,
   inMilliseconds,
   hasLicenseExpired,
+  willExpireWithinXDays,
   readableDate,
   secondsToHms,
   secondsToDhms,


### PR DESCRIPTION
## Issue
Cerra #11544 

## Description
- Surfaces Apple Push Notification service (APNs) certificate and Apple Business Manager (ABM) expiration to show:
  - [x] a warning (starting 30 days before) banner or
  - [x] an expired banner if the date has passed
- [x] Update Fleetctl warning and error messages
- [x] Logic on details host detail page to hide page-level banners if app-wide banner exists 

Note: This PR builds on the license-expiration PR which should be reviewed and merged first as it will likely cause merge conflicts.

## Screen recording
https://www.loom.com/share/79108625899a4418af7343536ec26d56?sid=18709263-d797-4c46-afa9-c79cf18f13da

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
- [x] TODO: Manual QA for all new/changed functionality
