### PR TITLE
Update "macOS - Check if latest version" policy description/resolution

### DIFF
--- a/it-and-security/teams/workstations-canary.yml
+++ b/it-and-security/teams/workstations-canary.yml
@@ -114,8 +114,8 @@ policies:
       SELECT 1 FROM os_version
         WHERE (major > 14 OR (major = 14 AND minor > 5) OR (major = 14 AND minor = 5 AND patch >= 0)); --Sonoma
     critical: false
-    description: This policy check if macOS version is most recent version available.
-    resolution: From the Apple menu, select System Settings. Navigate to General > Software Update.
+    description: Using an outdated macOS version risks exposure to security vulnerabilities and potential system instability.
+    resolution: We will update your macOS to version 14.4.1 to enhance security and stability.
     platform: darwin
     calendar_events_enabled: true
 queries:


### PR DESCRIPTION
This will make our own calendar events look like the one in the calendar wireframes/marketing images

Currently reads a little odd:
![Screenshot 2024-05-17 at 11 58 34 AM](https://github.com/fleetdm/fleet/assets/3065949/78b495df-fe8a-436e-a374-55a1179e99ed)
