### PR TITLE
Website: upgrade `sails` dependency to `1.5.11`

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -11,7 +11,7 @@
     "jsforce": "1.11.1",
     "jsonwebtoken": "9.0.2",
     "moment": "2.29.4",
-    "sails": "^1.5.10",
+    "sails": "^1.5.11",
     "sails-hook-apianalytics": "^2.0.6",
     "sails-hook-organics": "^2.2.2",
     "sails-hook-orm": "^4.0.3",


### PR DESCRIPTION
Closes: #19104
Closes: #18904

Changes:
- Updated version of `sails` used by the Fleet website to `1.5.11`