### PR TITLE
Update "macOS - Check if latest version" policy

### DIFF
--- a/it-and-security/lib/macos-device-health.policies.yml
+++ b/it-and-security/lib/macos-device-health.policies.yml
@@ -1,3 +1,10 @@
+- name: macOS - Check if latest version
+  query: SELECT 1 FROM os_version WHERE major = '14' AND minor = '5';
+  critical: false
+  description: This policy check if macOS version is most recent version available.
+  resolution: From the Apple menu, select System Settings. Navigate to General > Software Update.
+  platform: darwin
+  calendar_events_enabled: true
 - name: macOS - Enable FileVault
   query: SELECT 1 FROM filevault_status WHERE status = 'FileVault is On.';
   critical: false

--- a/it-and-security/lib/macos-device-health.policies.yml
+++ b/it-and-security/lib/macos-device-health.policies.yml
@@ -1,10 +1,3 @@
-- name: macOS - Check if latest version
-  query: SELECT 1 FROM os_version WHERE major = '14' AND minor = '5';
-  critical: false
-  description: This policy check if macOS version is most recent version available.
-  resolution: From the Apple menu, select System Settings. Navigate to General > Software Update.
-  platform: darwin
-  calendar_events_enabled: true
 - name: macOS - Enable FileVault
   query: SELECT 1 FROM filevault_status WHERE status = 'FileVault is On.';
   critical: false

--- a/it-and-security/teams/workstations-canary.yml
+++ b/it-and-security/teams/workstations-canary.yml
@@ -109,15 +109,6 @@ policies:
   - path: ../lib/macos-device-health.policies.yml
   - path: ../lib/windows-device-health.policies.yml
   - path: ../lib/linux-device-health.policies.yml
-  - name: macOS - Check if latest version
-    query: |
-      SELECT 1 FROM os_version
-        WHERE (major > 14 OR (major = 14 AND minor > 5) OR (major = 14 AND minor = 5 AND patch >= 0)); --Sonoma
-    critical: false
-    description: Using an outdated macOS version risks exposure to security vulnerabilities and potential system instability.
-    resolution: We will update your macOS to version 14.4.1 to enhance security and stability.
-    platform: darwin
-    calendar_events_enabled: true
 queries:
   - path: ../lib/collect-failed-login-attempts.queries.yml
   - path: ../lib/collect-fleetd-information.yml

--- a/it-and-security/teams/workstations.yml
+++ b/it-and-security/teams/workstations.yml
@@ -44,8 +44,8 @@ controls:
     enable_end_user_authentication: true
     macos_setup_assistant: null
   macos_updates:
-    deadline: "2024-05-31"
-    minimum_version: "14.5"
+    deadline: ""
+    minimum_version: ""
   windows_settings:
     custom_settings: null
   windows_updates:
@@ -61,6 +61,13 @@ policies:
   - path: ../lib/macos-device-health.policies.yml
   - path: ../lib/windows-device-health.policies.yml
   - path: ../lib/linux-device-health.policies.yml
+  - name: macOS - Check if latest version
+    query: SELECT 1 FROM os_version WHERE major = '14' AND minor = '5';
+    critical: false
+    description: This policy check if macOS version is most recent version available.
+    resolution: From the Apple menu, select System Settings. Navigate to General > Software Update.
+    platform: darwin
+    calendar_events_enabled: true
 queries:
   - path: ../lib/collect-failed-login-attempts.queries.yml
   - path: ../lib/collect-usb-devices.queries.yml

--- a/it-and-security/teams/workstations.yml
+++ b/it-and-security/teams/workstations.yml
@@ -63,6 +63,7 @@ policies:
   - path: ../lib/linux-device-health.policies.yml
   - name: macOS - Check if latest version
     query: SELECT 1 FROM os_version WHERE major = '14' AND minor = '5';
+    # patch query: SELECT 1 FROM os_version WHERE major = "14" AND minor = "5" AND patch >= "1";
     critical: false
     description: This policy check if macOS version is most recent version available.
     resolution: From the Apple menu, select System Settings. Navigate to General > Software Update.

--- a/it-and-security/teams/workstations.yml
+++ b/it-and-security/teams/workstations.yml
@@ -61,15 +61,6 @@ policies:
   - path: ../lib/macos-device-health.policies.yml
   - path: ../lib/windows-device-health.policies.yml
   - path: ../lib/linux-device-health.policies.yml
-  - name: macOS - Check if latest version
-    query: |
-      SELECT 1 FROM os_version
-        WHERE (major > 14 OR (major = 14 AND minor > 5) OR (major = 14 AND minor = 5 AND patch >= 0)); --Sonoma
-    critical: false
-    description: This policy check if macOS version is most recent version available.
-    resolution: From the Apple menu, select System Settings. Navigate to General > Software Update.
-    platform: darwin
-    calendar_events_enabled: true
 queries:
   - path: ../lib/collect-failed-login-attempts.queries.yml
   - path: ../lib/collect-usb-devices.queries.yml


### PR DESCRIPTION
- Simplify policy
- Move policy out of team files. Why? They use the same policy
- Sometimes values that look like integers are treated as strings in osquery.
This might be happening here w/ the major, minor, patch
in the policy. Another example here: https://github.com/fleetdm/fleet/issues/15962#issuecomment-1881783764