### PR TITLE
Fleet UI: Host details page for iOS and iPadOS

### DIFF
--- a/frontend/__mocks__/hostMock.ts
+++ b/frontend/__mocks__/hostMock.ts
@@ -112,6 +112,23 @@ const createMockHost = (overrides?: Partial<IHost>): IHost => {
 
 export const createMockHostResponse = { host: createMockHost() };
 
+export const createMockIosHostResponse = {
+  host: createMockHost({
+    hostname: "Test device (iPhone)",
+    display_name: "Test device (iPhone)",
+    team_id: 2,
+    team_name: "Mobile",
+    platform: "ios",
+    os_version: "iOS 14.7.1",
+    hardware_serial: "C8QH6T96DPNA",
+    created_at: "2024-01-01T12:00:00Z",
+    updated_at: "2024-05-02T12:00:00Z",
+    detail_updated_at: "2024-05-02T12:00:00Z",
+    last_restarted_at: "2024-04-02T12:00:00Z",
+    last_enrolled_at: "2024-01-02T12:00:00Z",
+  }),
+};
+
 export const createMockHostSummary = (overrides?: Partial<IHost>) => {
   return normalizeEmptyValues(
     pick(createMockHost(overrides), HOST_SUMMARY_DATA)

--- a/frontend/pages/SoftwarePage/components/ManageSoftwareAutomationsModal/ManageSoftwareAutomationsModal.tsx
+++ b/frontend/pages/SoftwarePage/components/ManageSoftwareAutomationsModal/ManageSoftwareAutomationsModal.tsx
@@ -16,6 +16,7 @@ import {
   CONFIG_DEFAULT_RECENT_VULNERABILITY_MAX_AGE_IN_DAYS,
 } from "interfaces/config";
 import configAPI from "services/entities/config";
+import { SUPPORT_LINK } from "utilities/constants";
 
 import ReactTooltip from "react-tooltip";
 // @ts-ignore
@@ -477,11 +478,7 @@ const ManageAutomationsModal = ({
           <p>
             Vulnerability automations currently run for software
             vulnerabilities. Interested in automations for OS vulnerabilities?{" "}
-            <CustomLink
-              url="https://www.fleetdm.com/support"
-              text="Let us know"
-              newTab
-            />
+            <CustomLink url={SUPPORT_LINK} text="Let us know" newTab />
           </p>
         </div>
         <div className="modal-cta-wrap">

--- a/frontend/pages/errors/Fleet404/Fleet404.tsx
+++ b/frontend/pages/errors/Fleet404/Fleet404.tsx
@@ -3,6 +3,7 @@ import { Link } from "react-router";
 
 import PATHS from "router/paths";
 
+import { SUPPORT_LINK } from "utilities/constants";
 import Button from "components/buttons/Button";
 
 // @ts-ignore
@@ -38,11 +39,7 @@ const Fleet404 = () => (
         The page you are looking for has either moved, or doesn&apos;t exist.
       </p>
       <div className={`${baseClass}__button-wrapper`}>
-        <a
-          href="https://fleetdm.com/support"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
+        <a href={SUPPORT_LINK} target="_blank" rel="noopener noreferrer">
           <Button
             type="button"
             variant="unstyled"

--- a/frontend/pages/errors/Fleet500/Fleet500.tsx
+++ b/frontend/pages/errors/Fleet500/Fleet500.tsx
@@ -3,6 +3,7 @@ import { Link } from "react-router";
 
 import PATHS from "router/paths";
 
+import { SUPPORT_LINK } from "utilities/constants";
 import Button from "components/buttons/Button";
 // @ts-ignore
 import fleetLogoText from "../../../../assets/images/fleet-logo-text-white.svg";
@@ -35,11 +36,7 @@ const Fleet500 = () => (
       </h1>
       <p>Please file an issue if you believe this is a bug.</p>
       <div className={`${baseClass}__button-wrapper`}>
-        <a
-          href="https://fleetdm.com/support"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
+        <a href={SUPPORT_LINK} target="_blank" rel="noopener noreferrer">
           <Button
             type="button"
             variant="unstyled"

--- a/frontend/pages/hosts/ManageHostsPage/HostTableConfig.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/HostTableConfig.tsx
@@ -57,13 +57,13 @@ const condenseDeviceUsers = (users: IDeviceUser[]): string[] => {
   const condensed =
     users.length === 4
       ? users
-        .slice(-4)
-        .map((u) => u.email)
-        .reverse()
+          .slice(-4)
+          .map((u) => u.email)
+          .reverse()
       : users
-        .slice(-3)
-        .map((u) => u.email)
-        .reverse() || [];
+          .slice(-3)
+          .map((u) => u.email)
+          .reverse() || [];
   return users.length > 4
     ? condensed.concat(`+${users.length - 3} more`) // TODO: confirm limit
     : condensed;
@@ -328,8 +328,9 @@ const allHostTableHeaders: IHostTableColumnConfig[] = [
         return (
           <>
             <span
-              className={`text-cell ${users.length > 1 ? "text-muted tooltip" : ""
-                }`}
+              className={`text-cell ${
+                users.length > 1 ? "text-muted tooltip" : ""
+              }`}
               data-tip
               data-for={`device_mapping__${cellProps.row.original.id}`}
               data-tip-disable={users.length <= 1}

--- a/frontend/pages/hosts/details/DeviceUserPage/DeviceUserPage.tsx
+++ b/frontend/pages/hosts/details/DeviceUserPage/DeviceUserPage.tsx
@@ -375,7 +375,7 @@ const DeviceUserPage = ({
               mdmName={deviceMacAdminsData?.mobile_device_management?.name}
               showRefetchSpinner={showRefetchSpinner}
               onRefetchHost={onRefetchHost}
-              renderActionButtons={renderActionButtons}
+              renderActionDropdown={renderActionButtons}
               osSettings={host?.mdm.os_settings}
               deviceUser
             />
@@ -413,7 +413,7 @@ const DeviceUserPage = ({
                     pathname={location.pathname}
                     queryParams={parseHostSoftwareQueryParams(location.query)}
                     isMyDevicePage
-                    teamId={host.team_id || 0}
+                    hostTeamId={host.team_id || 0}
                   />
                 </TabPanel>
                 {isPremiumTier && (

--- a/frontend/pages/hosts/details/DeviceUserPage/DeviceUserPage.tsx
+++ b/frontend/pages/hosts/details/DeviceUserPage/DeviceUserPage.tsx
@@ -44,7 +44,7 @@ import ManualEnrollMdmModal from "./ManualEnrollMdmModal";
 import OSSettingsModal from "../OSSettingsModal";
 import ResetKeyModal from "./ResetKeyModal";
 import BootstrapPackageModal from "../HostDetailsPage/modals/BootstrapPackageModal";
-import { parseHostSoftwareQueryParams } from "../cards/Software/Software";
+import { parseHostSoftwareQueryParams } from "../cards/Software/HostSoftware";
 
 const baseClass = "device-user";
 

--- a/frontend/pages/hosts/details/DeviceUserPage/DeviceUserPage.tsx
+++ b/frontend/pages/hosts/details/DeviceUserPage/DeviceUserPage.tsx
@@ -414,6 +414,7 @@ const DeviceUserPage = ({
                     queryParams={parseHostSoftwareQueryParams(location.query)}
                     isMyDevicePage
                     hostTeamId={host.team_id || 0}
+                    hostPlatform={host?.platform || ""}
                   />
                 </TabPanel>
                 {isPremiumTier && (
@@ -423,6 +424,7 @@ const DeviceUserPage = ({
                       isLoading={isLoadingHost}
                       deviceUser
                       togglePolicyDetailsModal={togglePolicyDetailsModal}
+                      hostPlatform={host?.platform || ""}
                     />
                   </TabPanel>
                 )}

--- a/frontend/pages/hosts/details/HostDetailsPage/HostActionsDropdown/HostActionsDropdown.tests.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/HostActionsDropdown/HostActionsDropdown.tests.tsx
@@ -1138,4 +1138,56 @@ describe("Host Actions Dropdown", () => {
       expect(screen.queryByText("Run script")).not.toBeInTheDocument();
     });
   });
+
+  describe("Does not render dropdown for certain platforms", () => {
+    it("does not render dropdown for iOS", async () => {
+      const render = createCustomRenderer({
+        context: {
+          app: {
+            isGlobalAdmin: true,
+            currentUser: createMockUser(),
+          },
+        },
+      });
+
+      render(
+        <HostActionsDropdown
+          hostTeamId={null}
+          onSelect={noop}
+          hostStatus="online"
+          hostPlatform="ios"
+          hostMdmEnrollmentStatus={null}
+          hostMdmDeviceStatus={"unlocked"}
+          hostScriptsEnabled={false}
+        />
+      );
+
+      expect(screen.queryByText("Actions")).not.toBeInTheDocument();
+    });
+
+    it("does not render dropdown for iPadOS", async () => {
+      const render = createCustomRenderer({
+        context: {
+          app: {
+            isGlobalAdmin: true,
+            currentUser: createMockUser(),
+          },
+        },
+      });
+
+      render(
+        <HostActionsDropdown
+          hostTeamId={null}
+          onSelect={noop}
+          hostStatus="online"
+          hostPlatform="ipados"
+          hostMdmEnrollmentStatus={null}
+          hostMdmDeviceStatus={"unlocked"}
+          hostScriptsEnabled={false}
+        />
+      );
+
+      expect(screen.queryByText("Actions")).not.toBeInTheDocument();
+    });
+  });
 });

--- a/frontend/pages/hosts/details/HostDetailsPage/HostActionsDropdown/HostActionsDropdown.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/HostActionsDropdown/HostActionsDropdown.tsx
@@ -79,6 +79,10 @@ const HostActionsDropdown = ({
   // No options to render. Exit early
   if (options.length === 0) return null;
 
+  if (hostPlatform === "ios" || hostPlatform === "ipados") {
+    return null;
+  }
+
   return (
     <div className={baseClass}>
       <Dropdown

--- a/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
@@ -92,7 +92,7 @@ import {
 } from "../helpers";
 import WipeModal from "./modals/WipeModal";
 import SoftwareDetailsModal from "../cards/Software/SoftwareDetailsModal";
-import { parseHostSoftwareQueryParams } from "../cards/Software/Software";
+import { parseHostSoftwareQueryParams } from "../cards/Software/HostSoftware";
 
 const baseClass = "host-details";
 

--- a/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
@@ -1,4 +1,5 @@
 import React, { useContext, useState, useCallback, useEffect } from "react";
+import classNames from "classnames";
 import { Params, InjectedRouter } from "react-router/lib/Router";
 import { useQuery } from "react-query";
 import { useErrorHandler } from "react-error-boundary";
@@ -760,6 +761,13 @@ const HostDetailsPage = ({
     name: host?.mdm.macos_setup?.bootstrap_package_name,
   };
 
+  const isIosOrIpadosHost =
+    host.platform === "ios" || host.platform === "ipados";
+
+  const detailsPanelClass = classNames(`${baseClass}__details-panel`, {
+    [`${baseClass}__details-panel--ios-grid`]: isIosOrIpadosHost,
+  });
+
   return (
     <MainContent className={baseClass}>
       <>
@@ -802,52 +810,58 @@ const HostDetailsPage = ({
                 return <Tab key={navItem.title}>{navItem.name}</Tab>;
               })}
             </TabList>
-            <TabPanel className={`${baseClass}__details-panel`}>
+            <TabPanel className={detailsPanelClass}>
               <AboutCard
                 aboutData={aboutData}
                 deviceMapping={deviceMapping}
                 munki={macadmins?.munki}
                 mdm={mdm}
               />
-              <ActivityCard
-                activeTab={activeActivityTab}
-                activities={
-                  activeActivityTab === "past"
-                    ? pastActivities
-                    : upcomingActivities
-                }
-                isLoading={
-                  activeActivityTab === "past"
-                    ? pastActivitiesIsFetching
-                    : upcomingActivitiesIsFetching
-                }
-                isError={
-                  activeActivityTab === "past"
-                    ? pastActivitiesIsError
-                    : upcomingActivitiesIsError
-                }
-                upcomingCount={upcomingActivities?.count || 0}
-                onChangeTab={onChangeActivityTab}
-                onNextPage={() => setActivityPage(activityPage + 1)}
-                onPreviousPage={() => setActivityPage(activityPage - 1)}
-                onShowDetails={onShowActivityDetails}
-              />
-              <AgentOptionsCard
-                osqueryData={osqueryData}
-                wrapFleetHelper={wrapFleetHelper}
-                isChromeOS={host?.platform === "chrome"}
-              />
+              {!isIosOrIpadosHost && (
+                <ActivityCard
+                  activeTab={activeActivityTab}
+                  activities={
+                    activeActivityTab === "past"
+                      ? pastActivities
+                      : upcomingActivities
+                  }
+                  isLoading={
+                    activeActivityTab === "past"
+                      ? pastActivitiesIsFetching
+                      : upcomingActivitiesIsFetching
+                  }
+                  isError={
+                    activeActivityTab === "past"
+                      ? pastActivitiesIsError
+                      : upcomingActivitiesIsError
+                  }
+                  upcomingCount={upcomingActivities?.count || 0}
+                  onChangeTab={onChangeActivityTab}
+                  onNextPage={() => setActivityPage(activityPage + 1)}
+                  onPreviousPage={() => setActivityPage(activityPage - 1)}
+                  onShowDetails={onShowActivityDetails}
+                />
+              )}
+              {!isIosOrIpadosHost && (
+                <AgentOptionsCard
+                  osqueryData={osqueryData}
+                  wrapFleetHelper={wrapFleetHelper}
+                  isChromeOS={host?.platform === "chrome"}
+                />
+              )}
               <LabelsCard
                 labels={host?.labels || []}
                 onLabelClick={onLabelClick}
               />
-              <UsersCard
-                users={host?.users || []}
-                usersState={usersState}
-                isLoading={isLoadingHost}
-                onUsersTableSearchChange={onUsersTableSearchChange}
-                hostUsersEnabled={featuresConfig?.enable_host_users}
-              />
+              {!isIosOrIpadosHost && (
+                <UsersCard
+                  users={host?.users || []}
+                  usersState={usersState}
+                  isLoading={isLoadingHost}
+                  onUsersTableSearchChange={onUsersTableSearchChange}
+                  hostUsersEnabled={featuresConfig?.enable_host_users}
+                />
+              )}
             </TabPanel>
             <TabPanel>
               <SoftwareCard

--- a/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
@@ -30,7 +30,7 @@ import {
 import { ILabel } from "interfaces/label";
 import { IHostPolicy } from "interfaces/policy";
 import { IQueryStats } from "interfaces/query_stats";
-import Software, { IHostSoftware, ISoftware } from "interfaces/software";
+import { IHostSoftware } from "interfaces/software";
 import { DEFAULT_TARGETS_BY_TYPE } from "interfaces/target";
 import { ITeam } from "interfaces/team";
 import {
@@ -665,7 +665,7 @@ const HostDetailsPage = ({
   //   host.mdm.pending_action
   // );
 
-  const renderActionButtons = () => {
+  const renderActionDropdown = () => {
     if (!host) {
       return null;
     }
@@ -786,7 +786,7 @@ const HostDetailsPage = ({
           mdmName={mdm?.name}
           showRefetchSpinner={showRefetchSpinner}
           onRefetchHost={onRefetchHost}
-          renderActionButtons={renderActionButtons}
+          renderActionDropdown={renderActionDropdown}
           osSettings={host?.mdm.os_settings}
           hostMdmDeviceStatus={hostMdmDeviceStatus}
         />
@@ -858,7 +858,8 @@ const HostDetailsPage = ({
                 queryParams={parseHostSoftwareQueryParams(location.query)}
                 pathname={location.pathname}
                 onShowSoftwareDetails={setSelectedSoftwareDetails}
-                teamId={host.team_id || 0}
+                hostTeamId={host.team_id || 0}
+                hostPlatform={host.platform}
               />
               {host?.platform === "darwin" && macadmins?.munki?.version && (
                 <MunkiIssuesCard
@@ -872,7 +873,7 @@ const HostDetailsPage = ({
               <QueriesCard
                 hostId={host.id}
                 router={router}
-                isChromeOSHost={host.platform === "chrome"}
+                hostPlatform={host.platform}
                 schedule={schedule}
                 queryReportsDisabled={
                   config?.server_settings?.query_reports_disabled
@@ -887,6 +888,7 @@ const HostDetailsPage = ({
                 policies={host?.policies || []}
                 isLoading={isLoadingHost}
                 togglePolicyDetailsModal={togglePolicyDetailsModal}
+                hostPlatform={host.platform}
               />
             </TabPanel>
           </Tabs>

--- a/frontend/pages/hosts/details/HostDetailsPage/_styles.scss
+++ b/frontend/pages/hosts/details/HostDetailsPage/_styles.scss
@@ -21,6 +21,18 @@
         "activity agent-options"
         "activity labels"
         "users users";
+      grid-auto-flow: column;
+    }
+
+    // Note: CSS for labels card spans the whole grid for iOS and iPadOS
+    // because activity card is missing
+    &__details-panel--ios-grid.react-tabs__tab-panel--selected {
+      // Must be selected to show grid
+      grid-template-columns: 1fr;
+      grid-template-areas:
+        "about"
+        "labels";
+      grid-auto-flow: column;
     }
 
     .about-card {

--- a/frontend/pages/hosts/details/cards/About/About.tsx
+++ b/frontend/pages/hosts/details/cards/About/About.tsx
@@ -49,7 +49,7 @@ const About = ({
   const isIosOrIpadosHost =
     aboutData.platform === "ios" || aboutData.platform === "ipados";
 
-  const renderSerialAndIPs = () => {
+  const renderHardwareSerialAndIPs = () => {
     if (isIosOrIpadosHost) {
       return (
         <DataSet title="Serial number" value={aboutData.hardware_serial} />
@@ -58,6 +58,7 @@ const About = ({
 
     return (
       <>
+        <DataSet title="Hardware model" value={aboutData.hardware_model} />
         <DataSet title="Serial number" value={aboutData.hardware_serial} />
         <DataSet title="Private IP address" value={aboutData.primary_ip} />
         <DataSet
@@ -206,8 +207,7 @@ const About = ({
             />
           }
         />
-        <DataSet title="Hardware model" value={aboutData.hardware_model} />
-        {renderSerialAndIPs()}
+        {renderHardwareSerialAndIPs()}
         {renderMunkiData()}
         {renderMdmData()}
         {renderDeviceUser()}

--- a/frontend/pages/hosts/details/cards/About/About.tsx
+++ b/frontend/pages/hosts/details/cards/About/About.tsx
@@ -46,7 +46,16 @@ const About = ({
   munki,
   mdm,
 }: IAboutProps): JSX.Element => {
+  const isiOSoriPadOSHost =
+    aboutData.platform === "ios" || aboutData.platform === "ipados";
+
   const renderSerialAndIPs = () => {
+    if (isiOSoriPadOSHost) {
+      return (
+        <DataSet title="Serial number" value={aboutData.hardware_serial} />
+      );
+    }
+
     return (
       <>
         <DataSet title="Serial number" value={aboutData.hardware_serial} />

--- a/frontend/pages/hosts/details/cards/About/About.tsx
+++ b/frontend/pages/hosts/details/cards/About/About.tsx
@@ -46,11 +46,11 @@ const About = ({
   munki,
   mdm,
 }: IAboutProps): JSX.Element => {
-  const isiOSoriPadOSHost =
+  const isIosOrIpadosHost =
     aboutData.platform === "ios" || aboutData.platform === "ipados";
 
   const renderSerialAndIPs = () => {
-    if (isiOSoriPadOSHost) {
+    if (isIosOrIpadosHost) {
       return (
         <DataSet title="Serial number" value={aboutData.hardware_serial} />
       );

--- a/frontend/pages/hosts/details/cards/HostSummary/HostSummary.tests.tsx
+++ b/frontend/pages/hosts/details/cards/HostSummary/HostSummary.tests.tsx
@@ -8,7 +8,7 @@ import { createMockHostSummary } from "__mocks__/hostMock";
 
 import HostSummary from "./HostSummary";
 
-describe("Host Actions Dropdown", () => {
+describe("Host Summary section", () => {
   describe("Agent data", () => {
     it("with all info present, render Agent header with orbit_version and tooltip with all 3 data points", async () => {
       const render = createCustomRenderer({
@@ -113,7 +113,9 @@ describe("Host Actions Dropdown", () => {
       await user.hover(screen.getByText(new RegExp(fleetdChromeVersion, "i")));
       expect(screen.queryByText("Osquery")).not.toBeInTheDocument();
     });
-    it("for non-Chromebooks with no orbit_version, render Osquery header with osquery_version and no tooltip", async () => {
+  });
+  describe("iOS and iPadOS data", () => {
+    it("for iOS, renders Team, Disk space, and Operating system data only and hides the refetch button", async () => {
       const render = createCustomRenderer({
         context: {
           app: {
@@ -123,25 +125,93 @@ describe("Host Actions Dropdown", () => {
           },
         },
       });
+
       const summaryData = createMockHostSummary({
-        orbit_version: null,
+        team_id: 2,
+        team_name: "Mobile",
+        platform: "ios",
+        os_version: "iOS 14.7.1",
       });
 
-      const osqueryVersion = summaryData.osquery_version as string;
+      const teamName = summaryData.team_name as string;
+      const diskSpaceAvailable = summaryData.gigs_disk_space_available as string;
+      const osVersion = summaryData.os_version as string;
 
-      const { user } = render(
+      render(
         <HostSummary
           summaryData={summaryData}
           showRefetchSpinner={false}
           onRefetchHost={noop}
           renderActionDropdown={() => null}
+          isPremiumTier
         />
       );
 
-      expect(screen.getByText("Osquery")).toBeInTheDocument();
-      await user.hover(screen.getByText(new RegExp(osqueryVersion, "i")));
-      expect(screen.queryByText(/Orbit/i)).not.toBeInTheDocument();
-      expect(screen.queryByText(/Fleet desktop/i)).not.toBeInTheDocument();
+      expect(screen.getByText("Team").nextElementSibling).toHaveTextContent(
+        teamName
+      );
+      expect(
+        screen.getByText("Disk space").nextElementSibling
+      ).toHaveTextContent(`${diskSpaceAvailable} GB available`);
+      expect(
+        screen.getByText("Operating system").nextElementSibling
+      ).toHaveTextContent(osVersion);
+
+      expect(screen.queryByText("Refetch")).not.toBeInTheDocument();
+      expect(screen.queryByText("Status")).not.toBeInTheDocument();
+      expect(screen.queryByText("Memory")).not.toBeInTheDocument();
+      expect(screen.queryByText("Processor type")).not.toBeInTheDocument();
+      expect(screen.queryByText("Agent")).not.toBeInTheDocument();
+      expect(screen.queryByText("Osquery")).not.toBeInTheDocument();
+    });
+    it("for iPadOS, renders Team, Disk space, and Operating system data only and hides the refetch button", async () => {
+      const render = createCustomRenderer({
+        context: {
+          app: {
+            isPremiumTier: true,
+            isGlobalAdmin: true,
+            currentUser: createMockUser(),
+          },
+        },
+      });
+
+      const summaryData = createMockHostSummary({
+        team_id: 2,
+        team_name: "Mobile",
+        platform: "ipados",
+        os_version: "iPadOS 16.7.8",
+      });
+
+      const teamName = summaryData.team_name as string;
+      const diskSpaceAvailable = summaryData.gigs_disk_space_available as string;
+      const osVersion = summaryData.os_version as string;
+
+      render(
+        <HostSummary
+          summaryData={summaryData}
+          showRefetchSpinner={false}
+          onRefetchHost={noop}
+          renderActionDropdown={() => null}
+          isPremiumTier
+        />
+      );
+
+      expect(screen.getByText("Team").nextElementSibling).toHaveTextContent(
+        teamName
+      );
+      expect(
+        screen.getByText("Disk space").nextElementSibling
+      ).toHaveTextContent(`${diskSpaceAvailable} GB available`);
+      expect(
+        screen.getByText("Operating system").nextElementSibling
+      ).toHaveTextContent(osVersion);
+
+      expect(screen.queryByText("Refetch")).not.toBeInTheDocument();
+      expect(screen.queryByText("Status")).not.toBeInTheDocument();
+      expect(screen.queryByText("Memory")).not.toBeInTheDocument();
+      expect(screen.queryByText("Processor type")).not.toBeInTheDocument();
+      expect(screen.queryByText("Agent")).not.toBeInTheDocument();
+      expect(screen.queryByText("Osquery")).not.toBeInTheDocument();
     });
   });
 });

--- a/frontend/pages/hosts/details/cards/HostSummary/HostSummary.tests.tsx
+++ b/frontend/pages/hosts/details/cards/HostSummary/HostSummary.tests.tsx
@@ -30,7 +30,7 @@ describe("Host Actions Dropdown", () => {
           summaryData={summaryData}
           showRefetchSpinner={false}
           onRefetchHost={noop}
-          renderActionButtons={() => null}
+          renderActionDropdown={() => null}
         />
       );
 
@@ -70,7 +70,7 @@ describe("Host Actions Dropdown", () => {
           summaryData={summaryData}
           showRefetchSpinner={false}
           onRefetchHost={noop}
-          renderActionButtons={() => null}
+          renderActionDropdown={() => null}
         />
       );
 
@@ -105,7 +105,7 @@ describe("Host Actions Dropdown", () => {
           summaryData={summaryData}
           showRefetchSpinner={false}
           onRefetchHost={noop}
-          renderActionButtons={() => null}
+          renderActionDropdown={() => null}
         />
       );
 
@@ -134,7 +134,7 @@ describe("Host Actions Dropdown", () => {
           summaryData={summaryData}
           showRefetchSpinner={false}
           onRefetchHost={noop}
-          renderActionButtons={() => null}
+          renderActionDropdown={() => null}
         />
       );
 

--- a/frontend/pages/hosts/details/cards/HostSummary/HostSummary.tsx
+++ b/frontend/pages/hosts/details/cards/HostSummary/HostSummary.tsx
@@ -183,7 +183,6 @@ const HostSummary = ({
     status,
     platform,
     disk_encryption_enabled: diskEncryptionEnabled,
-    team_name: teamName,
   } = summaryData;
 
   const isChromeHost = platform === "chrome";
@@ -260,8 +259,8 @@ const HostSummary = ({
     <DataSet
       title="Team"
       value={
-        teamName !== "---" ? (
-          `${teamName}`
+        summaryData.team_name !== "---" ? (
+          `${summaryData.team_name}`
         ) : (
           <span className="no-team">No team</span>
         )

--- a/frontend/pages/hosts/details/cards/HostSummary/HostSummary.tsx
+++ b/frontend/pages/hosts/details/cards/HostSummary/HostSummary.tsx
@@ -411,7 +411,6 @@ const HostSummary = ({
           !isIosOrIpadosHost &&
           renderIssues()}
         {isPremiumTier && renderHostTeam()}
-        abc
         {/* Rendering of OS Settings data */}
         {(platform === "darwin" || platform === "windows") &&
           isPremiumTier &&

--- a/frontend/pages/hosts/details/cards/HostSummary/HostSummary.tsx
+++ b/frontend/pages/hosts/details/cards/HostSummary/HostSummary.tsx
@@ -115,7 +115,7 @@ interface IHostSummaryProps {
   onRefetchHost: (
     evt: React.MouseEvent<HTMLButtonElement, React.MouseEvent>
   ) => void;
-  renderActionButtons: () => JSX.Element | null;
+  renderActionDropdown: () => JSX.Element | null;
   deviceUser?: boolean;
   osSettings?: IOSSettings;
   hostMdmDeviceStatus?: HostMdmDeviceStatusUIState;
@@ -174,7 +174,7 @@ const HostSummary = ({
   mdmName,
   showRefetchSpinner,
   onRefetchHost,
-  renderActionButtons,
+  renderActionDropdown,
   deviceUser,
   osSettings,
   hostMdmDeviceStatus,
@@ -206,6 +206,10 @@ const HostSummary = ({
       tooltip = !isOnline
         ? REFETCH_TOOLTIP_MESSAGES.offline
         : REFETCH_TOOLTIP_MESSAGES[hostMdmDeviceStatus];
+    }
+
+    if (platform === "ios" || platform === "ipados") {
+      return null;
     }
 
     return (
@@ -498,7 +502,7 @@ const HostSummary = ({
             {renderRefetch()}
           </div>
         </div>
-        {renderActionButtons()}
+        {renderActionDropdown()}
       </div>
       {renderSummary()}
     </div>

--- a/frontend/pages/hosts/details/cards/HostSummary/HostSummary.tsx
+++ b/frontend/pages/hosts/details/cards/HostSummary/HostSummary.tsx
@@ -183,7 +183,11 @@ const HostSummary = ({
     status,
     platform,
     disk_encryption_enabled: diskEncryptionEnabled,
+    team_name: teamName,
   } = summaryData;
+
+  const isChromeHost = platform === "chrome";
+  const isiOSoriPadOSHost = platform === "ios" || platform === "ipados";
 
   const renderRefetch = () => {
     const isOnline = summaryData.status === "online";
@@ -208,7 +212,7 @@ const HostSummary = ({
         : REFETCH_TOOLTIP_MESSAGES[hostMdmDeviceStatus];
     }
 
-    if (platform === "ios" || platform === "ipados") {
+    if (isiOSoriPadOSHost) {
       return null;
     }
 
@@ -256,8 +260,8 @@ const HostSummary = ({
     <DataSet
       title="Team"
       value={
-        summaryData.team_name !== "---" ? (
-          `${summaryData.team_name}`
+        teamName !== "---" ? (
+          `${teamName}`
         ) : (
           <span className="no-team">No team</span>
         )
@@ -294,7 +298,7 @@ const HostSummary = ({
 
     let statusText;
     switch (true) {
-      case platform === "chrome":
+      case isChromeHost:
         statusText = "Always on";
         break;
       case diskEncryptionEnabled === true:
@@ -307,6 +311,10 @@ const HostSummary = ({
         // something unexpected happened on the way to this component, display whatever we got or
         // "Unknown" to draw attention to the issue.
         statusText = diskEncryptionEnabled || "Unknown";
+    }
+
+    if (isiOSoriPadOSHost) {
+      return null;
     }
 
     return (
@@ -322,9 +330,14 @@ const HostSummary = ({
   };
 
   const renderAgentSummary = () => {
-    if (platform === "chrome") {
+    if (isChromeHost) {
       return <DataSet title="Agent" value={summaryData.osquery_version} />;
     }
+
+    if (isiOSoriPadOSHost) {
+      return null;
+    }
+
     if (summaryData.orbit_version !== DEFAULT_EMPTY_CELL_VALUE) {
       return (
         <DataSet
@@ -380,24 +393,26 @@ const HostSummary = ({
         largePadding
         className={`${baseClass}-card`}
       >
-        <DataSet
-          title="Status"
-          value={
-            <StatusIndicator
-              value={status || ""} // temporary work around of integration test bug
-              tooltip={{
-                tooltipText: getHostStatusTooltipText(status),
-                position: "bottom",
-              }}
-            />
-          }
-        />
+        {!isiOSoriPadOSHost && (
+          <DataSet
+            title="Status"
+            value={
+              <StatusIndicator
+                value={status || ""} // temporary work around of integration test bug
+                tooltip={{
+                  tooltipText: getHostStatusTooltipText(status),
+                  position: "bottom",
+                }}
+              />
+            }
+          />
+        )}
         {(summaryData.issues?.total_issues_count > 0 || isSandboxMode) &&
           isPremiumTier &&
+          !isiOSoriPadOSHost &&
           renderIssues()}
-
         {isPremiumTier && renderHostTeam()}
-
+        abc
         {/* Rendering of OS Settings data */}
         {(platform === "darwin" || platform === "windows") &&
           isPremiumTier &&
@@ -416,8 +431,7 @@ const HostSummary = ({
               }
             />
           )}
-
-        {bootstrapPackageData?.status && (
+        {bootstrapPackageData?.status && !isiOSoriPadOSHost && (
           <DataSet
             title="Bootstrap package"
             value={
@@ -428,19 +442,19 @@ const HostSummary = ({
             }
           />
         )}
-
-        {platform !== "chrome" && renderDiskSpaceSummary()}
-
+        {!isChromeHost && renderDiskSpaceSummary()}
         {renderDiskEncryptionSummary()}
-
-        <DataSet
-          title="Memory"
-          value={wrapFleetHelper(humanHostMemory, summaryData.memory)}
-        />
-        <DataSet title="Processor type" value={summaryData.cpu_type} />
+        {!isiOSoriPadOSHost && (
+          <DataSet
+            title="Memory"
+            value={wrapFleetHelper(humanHostMemory, summaryData.memory)}
+          />
+        )}
+        {!isiOSoriPadOSHost && (
+          <DataSet title="Processor type" value={summaryData.cpu_type} />
+        )}
         <DataSet title="Operating system" value={summaryData.os_version} />
-
-        {renderAgentSummary()}
+        {!isiOSoriPadOSHost && renderAgentSummary()}
       </Card>
     );
   };

--- a/frontend/pages/hosts/details/cards/HostSummary/HostSummary.tsx
+++ b/frontend/pages/hosts/details/cards/HostSummary/HostSummary.tsx
@@ -186,7 +186,7 @@ const HostSummary = ({
   } = summaryData;
 
   const isChromeHost = platform === "chrome";
-  const isiOSoriPadOSHost = platform === "ios" || platform === "ipados";
+  const isIosOrIpadosHost = platform === "ios" || platform === "ipados";
 
   const renderRefetch = () => {
     const isOnline = summaryData.status === "online";
@@ -211,7 +211,7 @@ const HostSummary = ({
         : REFETCH_TOOLTIP_MESSAGES[hostMdmDeviceStatus];
     }
 
-    if (isiOSoriPadOSHost) {
+    if (isIosOrIpadosHost) {
       return null;
     }
 
@@ -312,7 +312,7 @@ const HostSummary = ({
         statusText = diskEncryptionEnabled || "Unknown";
     }
 
-    if (isiOSoriPadOSHost) {
+    if (isIosOrIpadosHost) {
       return null;
     }
 
@@ -333,7 +333,7 @@ const HostSummary = ({
       return <DataSet title="Agent" value={summaryData.osquery_version} />;
     }
 
-    if (isiOSoriPadOSHost) {
+    if (isIosOrIpadosHost) {
       return null;
     }
 
@@ -392,7 +392,7 @@ const HostSummary = ({
         largePadding
         className={`${baseClass}-card`}
       >
-        {!isiOSoriPadOSHost && (
+        {!isIosOrIpadosHost && (
           <DataSet
             title="Status"
             value={
@@ -408,7 +408,7 @@ const HostSummary = ({
         )}
         {(summaryData.issues?.total_issues_count > 0 || isSandboxMode) &&
           isPremiumTier &&
-          !isiOSoriPadOSHost &&
+          !isIosOrIpadosHost &&
           renderIssues()}
         {isPremiumTier && renderHostTeam()}
         abc
@@ -430,7 +430,7 @@ const HostSummary = ({
               }
             />
           )}
-        {bootstrapPackageData?.status && !isiOSoriPadOSHost && (
+        {bootstrapPackageData?.status && !isIosOrIpadosHost && (
           <DataSet
             title="Bootstrap package"
             value={
@@ -443,17 +443,17 @@ const HostSummary = ({
         )}
         {!isChromeHost && renderDiskSpaceSummary()}
         {renderDiskEncryptionSummary()}
-        {!isiOSoriPadOSHost && (
+        {!isIosOrIpadosHost && (
           <DataSet
             title="Memory"
             value={wrapFleetHelper(humanHostMemory, summaryData.memory)}
           />
         )}
-        {!isiOSoriPadOSHost && (
+        {!isIosOrIpadosHost && (
           <DataSet title="Processor type" value={summaryData.cpu_type} />
         )}
         <DataSet title="Operating system" value={summaryData.os_version} />
-        {!isiOSoriPadOSHost && renderAgentSummary()}
+        {!isIosOrIpadosHost && renderAgentSummary()}
       </Card>
     );
   };

--- a/frontend/pages/hosts/details/cards/Policies/HostPolicies.tsx
+++ b/frontend/pages/hosts/details/cards/Policies/HostPolicies.tsx
@@ -1,9 +1,11 @@
 import React from "react";
 
 import { IHostPolicy } from "interfaces/policy";
+import { SUPPORT_LINK } from "utilities/constants";
 import TableContainer from "components/TableContainer";
 import EmptyTable from "components/EmptyTable";
 import Card from "components/Card";
+import CustomLink from "components/CustomLink";
 
 import {
   generatePolicyTableHeaders,
@@ -18,6 +20,7 @@ interface IPoliciesProps {
   isLoading: boolean;
   deviceUser?: boolean;
   togglePolicyDetailsModal: (policy: IHostPolicy) => void;
+  hostPlatform: string;
 }
 
 const Policies = ({
@@ -25,6 +28,7 @@ const Policies = ({
   isLoading,
   deviceUser,
   togglePolicyDetailsModal,
+  hostPlatform,
 }: IPoliciesProps): JSX.Element => {
   if (policies.length === 0) {
     return (
@@ -35,21 +39,34 @@ const Policies = ({
         className={baseClass}
       >
         <p className="card__header">Policies</p>
-        <EmptyTable
-          header={
-            <>
-              No policies are checked{" "}
-              {deviceUser ? `on your device` : `for this host`}
-            </>
-          }
-          info={
-            <>
-              Expecting to see policies? Try selecting “Refetch” to ask{" "}
-              {deviceUser ? `your device ` : `this host `}
-              to report new vitals.
-            </>
-          }
-        />
+        {hostPlatform === "ios" || hostPlatform === "ipados" ? (
+          <EmptyTable
+            header={<>Policies are not supported for this host</>}
+            info={
+              <>
+                Interested in detecting device health issues on{" "}
+                {hostPlatform === "ios" ? "iPhones" : "iPads"}?{" "}
+                <CustomLink url={SUPPORT_LINK} text="Let us know" newTab />
+              </>
+            }
+          />
+        ) : (
+          <EmptyTable
+            header={
+              <>
+                No policies are checked{" "}
+                {deviceUser ? `on your device` : `for this host`}
+              </>
+            }
+            info={
+              <>
+                Expecting to see policies? Try selecting “Refetch” to ask{" "}
+                {deviceUser ? `your device ` : `this host `}
+                to report new vitals.
+              </>
+            }
+          />
+        )}
       </Card>
     );
   }

--- a/frontend/pages/hosts/details/cards/Queries/HostQueries.tsx
+++ b/frontend/pages/hosts/details/cards/Queries/HostQueries.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useMemo } from "react";
 
 import { IQueryStats } from "interfaces/query_stats";
+import { SUPPORT_LINK } from "utilities/constants";
 import TableContainer from "components/TableContainer";
 import EmptyTable from "components/EmptyTable";
 import CustomLink from "components/CustomLink";
@@ -19,7 +20,7 @@ const baseClass = "host-queries-card";
 interface IHostQueriesProps {
   hostId: number;
   schedule?: IQueryStats[];
-  isChromeOSHost: boolean;
+  hostPlatform: string;
   queryReportsDisabled?: boolean;
   router: InjectedRouter;
 }
@@ -30,15 +31,16 @@ interface IHostQueriesRowProps extends Row {
     should_link_to_hqr?: boolean;
   };
 }
+
 const HostQueries = ({
   hostId,
   schedule,
-  isChromeOSHost,
+  hostPlatform,
   queryReportsDisabled,
   router,
 }: IHostQueriesProps): JSX.Element => {
   const renderEmptyQueriesTab = () => {
-    if (isChromeOSHost) {
+    if (hostPlatform === "chrome") {
       return (
         <EmptyTable
           header="Scheduled queries are not supported for this host"
@@ -55,6 +57,22 @@ const HostQueries = ({
         />
       );
     }
+
+    if (hostPlatform === "ios" || hostPlatform === "ipados") {
+      return (
+        <EmptyTable
+          header="Queries are not supported for this host"
+          info={
+            <>
+              Interested in querying{" "}
+              {hostPlatform === "ios" ? "iPhones" : "iPads"}?{" "}
+              <CustomLink url={SUPPORT_LINK} text="Let us know" newTab />
+            </>
+          }
+        />
+      );
+    }
+
     return (
       <EmptyTable
         header="No queries are scheduled to run on this host"
@@ -95,7 +113,11 @@ const HostQueries = ({
       className={baseClass}
     >
       <p className="card__header">Queries</p>
-      {!schedule || !schedule.length || isChromeOSHost ? (
+      {!schedule ||
+      !schedule.length ||
+      hostPlatform === "chrome" ||
+      hostPlatform === "ios" ||
+      hostPlatform === "ipados" ? (
         renderEmptyQueriesTab()
       ) : (
         <div>

--- a/frontend/pages/hosts/details/cards/Software/HostSoftware.tsx
+++ b/frontend/pages/hosts/details/cards/Software/HostSoftware.tsx
@@ -14,13 +14,15 @@ import deviceAPI, {
 } from "services/entities/device_user";
 import { getErrorReason } from "interfaces/errors";
 import { IHostSoftware, ISoftware } from "interfaces/software";
-import { DEFAULT_USE_QUERY_OPTIONS } from "utilities/constants";
+import { DEFAULT_USE_QUERY_OPTIONS, SUPPORT_LINK } from "utilities/constants";
 import { NotificationContext } from "context/notification";
 import { AppContext } from "context/app";
 
 import Card from "components/Card/Card";
 import DataError from "components/DataError";
 import Spinner from "components/Spinner";
+import EmptyTable from "components/EmptyTable";
+import CustomLink from "components/CustomLink";
 
 import { generateSoftwareTableHeaders as generateHostSoftwareTableConfig } from "./HostSoftwareTableConfig";
 import { generateSoftwareTableHeaders as generateDeviceSoftwareTableConfig } from "./DeviceSoftwareTableConfig";
@@ -32,15 +34,15 @@ export interface ITableSoftware extends Omit<ISoftware, "vulnerabilities"> {
   vulnerabilities: string[]; // for client-side search purposes, we only want an array of cve strings
 }
 
-interface ISoftwareCardProps {
+interface IHostSoftwareProps {
   /** This is the host id or the device token */
   id: number | string;
   isFleetdHost: boolean;
   router: InjectedRouter;
   queryParams: ReturnType<typeof parseHostSoftwareQueryParams>;
   pathname: string;
-  /** Team id for the host */
-  teamId: number;
+  hostTeamId: number;
+  hostPlatform: string;
   onShowSoftwareDetails?: (software: IHostSoftware) => void;
   isSoftwareEnabled?: boolean;
   isMyDevicePage?: boolean;
@@ -75,17 +77,18 @@ export const parseHostSoftwareQueryParams = (queryParams: {
   };
 };
 
-const SoftwareCard = ({
+const HostSoftware = ({
   id,
   isFleetdHost,
   router,
   queryParams,
   pathname,
-  teamId = 0,
+  hostTeamId = 0,
+  hostPlatform,
   onShowSoftwareDetails,
   isSoftwareEnabled = false,
   isMyDevicePage = false,
-}: ISoftwareCardProps) => {
+}: IHostSoftwareProps) => {
   const { renderFlash } = useContext(NotificationContext);
   const {
     isGlobalAdmin,
@@ -217,7 +220,7 @@ const SoftwareCard = ({
           installingSoftwareId,
           canInstall: canInstallSoftware,
           onSelectAction,
-          teamId,
+          teamId: hostTeamId,
           isFleetdHost,
         });
   }, [
@@ -226,7 +229,7 @@ const SoftwareCard = ({
     installingSoftwareId,
     canInstallSoftware,
     onSelectAction,
-    teamId,
+    hostTeamId,
     isFleetdHost,
   ]);
 
@@ -238,6 +241,28 @@ const SoftwareCard = ({
 
   const data = isMyDevicePage ? deviceSoftwareRes : hostSoftwareRes;
 
+  if (hostPlatform === "ios" || hostPlatform === "ipados") {
+    return (
+      <Card
+        borderRadiusSize="large"
+        includeShadow
+        largePadding
+        className={baseClass}
+      >
+        <p className="card__header">Software</p>
+        <EmptyTable
+          header="Software is not supported for this host"
+          info={
+            <>
+              Interested in viewing software for{" "}
+              {hostPlatform === "ios" ? "iPhones" : "iPads"}?{" "}
+              <CustomLink url={SUPPORT_LINK} text="Let us know" newTab />
+            </>
+          }
+        />
+      </Card>
+    );
+  }
   return (
     <Card
       borderRadiusSize="large"
@@ -272,4 +297,4 @@ const SoftwareCard = ({
   );
 };
 
-export default React.memo(SoftwareCard);
+export default React.memo(HostSoftware);

--- a/frontend/pages/hosts/details/cards/Software/index.ts
+++ b/frontend/pages/hosts/details/cards/Software/index.ts
@@ -1,1 +1,1 @@
-export { default } from "./Software";
+export { default } from "./HostSoftware";

--- a/frontend/pages/queries/details/QueryDetailsPage/QueryDetailsPage.tsx
+++ b/frontend/pages/queries/details/QueryDetailsPage/QueryDetailsPage.tsx
@@ -21,7 +21,7 @@ import {
   isGlobalObserver,
   isTeamObserver,
 } from "utilities/permissions/permissions";
-import { DOCUMENT_TITLE_SUFFIX } from "utilities/constants";
+import { DOCUMENT_TITLE_SUFFIX, SUPPORT_LINK } from "utilities/constants";
 import { buildQueryStringFromParams } from "utilities/url";
 import useTeamIdParam from "hooks/useTeamIdParam";
 
@@ -332,13 +332,7 @@ const QueryDetailsPage = ({
   const renderClippedBanner = () => (
     <InfoBanner
       color="yellow"
-      cta={
-        <CustomLink
-          url="https://www.fleetdm.com/support"
-          text="Get help"
-          newTab
-        />
-      }
+      cta={<CustomLink url={SUPPORT_LINK} text="Get help" newTab />}
     >
       <div>
         <b>Report clipped.</b> A sample of this query&apos;s results is included

--- a/frontend/pages/queries/edit/components/QueryResults/QueryResults.tsx
+++ b/frontend/pages/queries/edit/components/QueryResults/QueryResults.tsx
@@ -11,6 +11,7 @@ import {
   generateCSVQueryResults,
 } from "utilities/generate_csv";
 import { getTableColumnsFromSql } from "utilities/helpers";
+import { SUPPORT_LINK } from "utilities/constants";
 import { ICampaign, ICampaignError } from "interfaces/campaign";
 import { ITarget } from "interfaces/target";
 
@@ -263,13 +264,7 @@ const QueryResults = ({
       {isQueryClipped && (
         <InfoBanner
           color="yellow"
-          cta={
-            <CustomLink
-              url="https://www.fleetdm.com/support"
-              text="Get help"
-              newTab
-            />
-          }
+          cta={<CustomLink url={SUPPORT_LINK} text="Get help" newTab />}
         >
           <div>
             <b>Results clipped.</b> A sample of this query&apos;s results and

--- a/frontend/services/mock_service/mocks/config.ts
+++ b/frontend/services/mock_service/mocks/config.ts
@@ -23,6 +23,7 @@ const REQUEST_RESPONSE_MAPPINGS: IResponses = {
     // expensive data operations
     "targets?query={*}": RESPONSES.hosts,
     // "SchedulableQueries" to be used in developing frontend for #7765
+    "hosts/12345": RESPONSES.hostDetailsiOS,
     queries: RESPONSES.globalQueries,
     "queries/1": RESPONSES.globalQuery1,
     "queries/2": RESPONSES.globalQuery2,

--- a/frontend/services/mock_service/mocks/responses.ts
+++ b/frontend/services/mock_service/mocks/responses.ts
@@ -4,6 +4,7 @@
  * Also please check the README for how to use the mock service :)
  */
 
+import { createMockIosHostResponse } from "__mocks__/hostMock";
 import { createMockPoliciesResponse } from "__mocks__/policyMock";
 
 const count = {
@@ -10593,7 +10594,7 @@ const globalQuery6 = { query: globalQueries.queries[6] };
 const teamQuery1 = { query: teamQueries.queries[0] };
 const teamQuery2 = { query: teamQueries.queries[1] };
 const teamPolicy1 = createMockPoliciesResponse();
-
+const hostDetailsiOS = createMockIosHostResponse;
 const aiAutofillPolicy = {
   description:
     "The firewall is not enabled, exposing the laptop to potential security threats such as unauthorized access, data breaches, and malware attacks.",
@@ -10618,4 +10619,5 @@ export default {
   teamQuery2,
   aiAutofillPolicy,
   teamPolicy1,
+  hostDetailsiOS,
 };

--- a/frontend/utilities/constants.tsx
+++ b/frontend/utilities/constants.tsx
@@ -387,6 +387,7 @@ export const HOST_ABOUT_DATA = [
   "batteries",
   "detail_updated_at",
   "last_restarted_at",
+  "platform",
 ];
 
 export const HOST_OSQUERY_DATA = [


### PR DESCRIPTION
## Issue
Frontend part of #18119 

## Description
Host details page for iOS and iPadOS

  - Hides refetch button
  - Hides host action dropdown
  - Only show team, disk space, and operating system in host summary
  - Renders specific empty state for host software, host queries, and host policies tab

## Dev
- Add tests for host action dropdown being hidden
- Add test to refetch button and various host summary empty values being hidden
- Clean up all links to "https://fleetdm.com/support" appwide to use `SUPPORT_LINK` variable
- For host details section, rename `cards/Software/Software.tsx` to `cards/Software/HostSoftware.tsx` to match `cards/Queries/HostQueries.tsx` and `cards/Policies/HostPolicies.tsx`
- Remove 2 unused imports
- TODO: Automated tests for hidden cards and hidden about data (only wrote tests for dropdown and summary sections)

## Screenshots

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Added/updated tests
- [x] Manual QA for all new/changed functionality
