### PR TITLE
FE: Clean up redundant code and lint warnings

### DIFF
--- a/frontend/pages/hosts/details/cards/HostSummary/HostSummary.tsx
+++ b/frontend/pages/hosts/details/cards/HostSummary/HostSummary.tsx
@@ -60,7 +60,8 @@ const RefetchButton = ({
     : "Refetch";
 
   // add additonal props when we need to display a tooltip for the button
-  const conditionalProps: any = {};
+  const conditionalProps: { "data-tip"?: boolean; "data-for"?: string } = {};
+
   if (tooltip) {
     conditionalProps["data-tip"] = true;
     conditionalProps["data-for"] = "refetch-tooltip";
@@ -189,6 +190,10 @@ const HostSummary = ({
   const isIosOrIpadosHost = platform === "ios" || platform === "ipados";
 
   const renderRefetch = () => {
+    if (isIosOrIpadosHost) {
+      return null;
+    }
+
     const isOnline = summaryData.status === "online";
     let isDisabled = false;
     let tooltip: React.ReactNode = <></>;
@@ -209,10 +214,6 @@ const HostSummary = ({
       tooltip = !isOnline
         ? REFETCH_TOOLTIP_MESSAGES.offline
         : REFETCH_TOOLTIP_MESSAGES[hostMdmDeviceStatus];
-    }
-
-    if (isIosOrIpadosHost) {
-      return null;
     }
 
     return (
@@ -287,7 +288,7 @@ const HostSummary = ({
   };
   const renderDiskEncryptionSummary = () => {
     // TODO: improve this typing, platforms!
-    if (!["darwin", "windows", "chrome"].includes(platform)) {
+    if (!["darwin", "windows", "chrome", "ios", "ipados"].includes(platform)) {
       return <></>;
     }
     const tooltipMessage = getHostDiskEncryptionTooltipMessage(
@@ -310,10 +311,6 @@ const HostSummary = ({
         // something unexpected happened on the way to this component, display whatever we got or
         // "Unknown" to draw attention to the issue.
         statusText = diskEncryptionEnabled || "Unknown";
-    }
-
-    if (isIosOrIpadosHost) {
-      return null;
     }
 
     return (

--- a/frontend/pages/hosts/details/cards/HostSummary/helpers.tsx
+++ b/frontend/pages/hosts/details/cards/HostSummary/helpers.tsx
@@ -30,13 +30,13 @@ export const DEVICE_STATUS_TAGS: DeviceStatusTagConfig = {
   unlocking: {
     title: "UNLOCK PENDING",
     tagType: "warning",
-    generateTooltip: (platform) =>
+    generateTooltip: () =>
       "Host will unlock when it comes online.  If the host is online, it will unlock the next time it checks in to Fleet.",
   },
   locking: {
     title: "LOCK PENDING",
     tagType: "warning",
-    generateTooltip: (platform) =>
+    generateTooltip: () =>
       "Host will lock when it comes online.  If the host is online, it will lock the next time it checks in to Fleet.",
   },
   wiped: {

--- a/frontend/pages/hosts/details/cards/Policies/HostPolicies.tsx
+++ b/frontend/pages/hosts/details/cards/Policies/HostPolicies.tsx
@@ -30,47 +30,6 @@ const Policies = ({
   togglePolicyDetailsModal,
   hostPlatform,
 }: IPoliciesProps): JSX.Element => {
-  if (policies.length === 0) {
-    return (
-      <Card
-        borderRadiusSize="large"
-        includeShadow
-        largePadding
-        className={baseClass}
-      >
-        <p className="card__header">Policies</p>
-        {hostPlatform === "ios" || hostPlatform === "ipados" ? (
-          <EmptyTable
-            header={<>Policies are not supported for this host</>}
-            info={
-              <>
-                Interested in detecting device health issues on{" "}
-                {hostPlatform === "ios" ? "iPhones" : "iPads"}?{" "}
-                <CustomLink url={SUPPORT_LINK} text="Let us know" newTab />
-              </>
-            }
-          />
-        ) : (
-          <EmptyTable
-            header={
-              <>
-                No policies are checked{" "}
-                {deviceUser ? `on your device` : `for this host`}
-              </>
-            }
-            info={
-              <>
-                Expecting to see policies? Try selecting “Refetch” to ask{" "}
-                {deviceUser ? `your device ` : `this host `}
-                to report new vitals.
-              </>
-            }
-          />
-        )}
-      </Card>
-    );
-  }
-
   const tableHeaders = generatePolicyTableHeaders(togglePolicyDetailsModal);
   if (deviceUser) {
     // Remove view all hosts link
@@ -78,6 +37,64 @@ const Policies = ({
   }
   const failingResponses: IHostPolicy[] =
     policies.filter((policy: IHostPolicy) => policy.response === "fail") || [];
+
+  const renderHostPolicies = () => {
+    if (hostPlatform === "ios" || hostPlatform === "ipados") {
+      return (
+        <EmptyTable
+          header={<>Policies are not supported for this host</>}
+          info={
+            <>
+              Interested in detecting device health issues on{" "}
+              {hostPlatform === "ios" ? "iPhones" : "iPads"}?{" "}
+              <CustomLink url={SUPPORT_LINK} text="Let us know" newTab />
+            </>
+          }
+        />
+      );
+    }
+
+    if (policies.length === 0) {
+      return (
+        <EmptyTable
+          header={
+            <>
+              No policies are checked{" "}
+              {deviceUser ? `on your device` : `for this host`}
+            </>
+          }
+          info={
+            <>
+              Expecting to see policies? Try selecting “Refetch” to ask{" "}
+              {deviceUser ? `your device ` : `this host `}
+              to report new vitals.
+            </>
+          }
+        />
+      );
+    }
+
+    return (
+      <>
+        {failingResponses?.length > 0 && (
+          <PolicyFailingCount policyList={policies} deviceUser={deviceUser} />
+        )}
+        <TableContainer
+          columnConfigs={tableHeaders}
+          data={generatePolicyDataSet(policies)}
+          isLoading={isLoading}
+          manualSortBy
+          resultsTitle="policy items"
+          emptyComponent={() => <></>}
+          showMarkAllPages={false}
+          isAllPagesSelected={false}
+          disablePagination
+          disableCount
+          disableMultiRowSelect
+        />
+      </>
+    );
+  };
 
   return (
     <Card
@@ -87,27 +104,7 @@ const Policies = ({
       className={baseClass}
     >
       <p className="card__header">Policies</p>
-
-      {policies.length > 0 && (
-        <>
-          {failingResponses?.length > 0 && (
-            <PolicyFailingCount policyList={policies} deviceUser={deviceUser} />
-          )}
-          <TableContainer
-            columnConfigs={tableHeaders}
-            data={generatePolicyDataSet(policies)}
-            isLoading={isLoading}
-            manualSortBy
-            resultsTitle="policy items"
-            emptyComponent={() => <></>}
-            showMarkAllPages={false}
-            isAllPagesSelected={false}
-            disablePagination
-            disableCount
-            disableMultiRowSelect
-          />
-        </>
-      )}
+      {renderHostPolicies()}
     </Card>
   );
 };

--- a/frontend/pages/hosts/details/cards/Queries/HostQueries.tsx
+++ b/frontend/pages/hosts/details/cards/Queries/HostQueries.tsx
@@ -105,6 +105,39 @@ const HostQueries = ({
     [queryReportsDisabled]
   );
 
+  const renderHostQueries = () => {
+    if (
+      !schedule ||
+      !schedule.length ||
+      hostPlatform === "chrome" ||
+      hostPlatform === "ios" ||
+      hostPlatform === "ipados"
+    ) {
+      return renderEmptyQueriesTab();
+    }
+
+    return (
+      <div>
+        <TableContainer
+          columnConfigs={columnConfigs}
+          data={tableData}
+          onQueryChange={() => null}
+          resultsTitle="queries"
+          defaultSortHeader="query_name"
+          defaultSortDirection="asc"
+          showMarkAllPages={false}
+          isAllPagesSelected={false}
+          emptyComponent={() => <></>}
+          disablePagination
+          disableCount
+          disableMultiRowSelect
+          isLoading={false} // loading state handled at parent level
+          onSelectSingleRow={onSelectSingleRow}
+        />
+      </div>
+    );
+  };
+
   return (
     <Card
       borderRadiusSize="large"
@@ -113,32 +146,7 @@ const HostQueries = ({
       className={baseClass}
     >
       <p className="card__header">Queries</p>
-      {!schedule ||
-      !schedule.length ||
-      hostPlatform === "chrome" ||
-      hostPlatform === "ios" ||
-      hostPlatform === "ipados" ? (
-        renderEmptyQueriesTab()
-      ) : (
-        <div>
-          <TableContainer
-            columnConfigs={columnConfigs}
-            data={tableData}
-            onQueryChange={() => null}
-            resultsTitle="queries"
-            defaultSortHeader="query_name"
-            defaultSortDirection="asc"
-            showMarkAllPages={false}
-            isAllPagesSelected={false}
-            emptyComponent={() => <></>}
-            disablePagination
-            disableCount
-            disableMultiRowSelect
-            isLoading={false} // loading state handled at parent level
-            onSelectSingleRow={onSelectSingleRow}
-          />
-        </div>
-      )}
+      {renderHostQueries()}
     </Card>
   );
 };

--- a/frontend/pages/hosts/details/cards/Software/HostSoftware.tsx
+++ b/frontend/pages/hosts/details/cards/Software/HostSoftware.tsx
@@ -241,15 +241,13 @@ const HostSoftware = ({
 
   const data = isMyDevicePage ? deviceSoftwareRes : hostSoftwareRes;
 
-  if (hostPlatform === "ios" || hostPlatform === "ipados") {
-    return (
-      <Card
-        borderRadiusSize="large"
-        includeShadow
-        largePadding
-        className={baseClass}
-      >
-        <p className="card__header">Software</p>
+  const renderHostSoftware = () => {
+    if (isLoading) {
+      return <Spinner />;
+    }
+
+    if (hostPlatform === "ios" || hostPlatform === "ipados") {
+      return (
         <EmptyTable
           header="Software is not supported for this host"
           info={
@@ -260,9 +258,31 @@ const HostSoftware = ({
             </>
           }
         />
-      </Card>
+      );
+    }
+
+    return (
+      <>
+        {(isError || !data) && <DataError />}
+        {!isError && data && (
+          <HostSoftwareTable
+            isLoading={
+              isMyDevicePage ? deviceSoftwareFetching : hostSoftwareFetching
+            }
+            data={data}
+            router={router}
+            tableConfig={tableConfig}
+            sortHeader={queryParams.order_key}
+            sortDirection={queryParams.order_direction}
+            searchQuery={queryParams.query}
+            page={queryParams.page}
+            pagePath={pathname}
+          />
+        )}
+      </>
     );
-  }
+  };
+
   return (
     <Card
       borderRadiusSize="large"
@@ -271,28 +291,7 @@ const HostSoftware = ({
       className={baseClass}
     >
       <p className="card__header">Software</p>
-      {isLoading ? (
-        <Spinner />
-      ) : (
-        <>
-          {(isError || !data) && <DataError />}
-          {!isError && data && (
-            <HostSoftwareTable
-              isLoading={
-                isMyDevicePage ? deviceSoftwareFetching : hostSoftwareFetching
-              }
-              data={data}
-              router={router}
-              tableConfig={tableConfig}
-              sortHeader={queryParams.order_key}
-              sortDirection={queryParams.order_direction}
-              searchQuery={queryParams.query}
-              page={queryParams.page}
-              pagePath={pathname}
-            />
-          )}
-        </>
-      )}
+      {renderHostSoftware()}
     </Card>
   );
 };


### PR DESCRIPTION
## Issue
Related cleanups from comments of #19139
Part of #18119 

## Description 
Code nits
 - Render `<Card/>` wrapper once for each card
 - Move empty/null states to top of renders
 - Clean up "easy-win" typing

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->


- [x] Manual QA for all new/changed functionality

