### PR TITLE
Exclude `host_ids` field from `label` responses when it is empty, which is the case for the list labels endpoint

### DIFF
--- a/changes/18515-remove-host-ids-from-list-labels
+++ b/changes/18515-remove-host-ids-from-list-labels
@@ -1,0 +1,1 @@
+- Prevent the `host_id`s field from being returned from the list labels endpoint.

--- a/server/service/labels.go
+++ b/server/service/labels.go
@@ -33,7 +33,7 @@ func createLabelEndpoint(ctx context.Context, request interface{}, svc fleet.Ser
 		return createLabelResponse{Err: err}, nil
 	}
 
-	labelResp, err := labelResponseForLabel(ctx, svc, label, hostIDs)
+	labelResp, err := labelResponseForLabel(label, hostIDs)
 	if err != nil {
 		return createLabelResponse{Err: err}, nil
 	}
@@ -139,7 +139,7 @@ func modifyLabelEndpoint(ctx context.Context, request interface{}, svc fleet.Ser
 		return modifyLabelResponse{Err: err}, nil
 	}
 
-	labelResp, err := labelResponseForLabel(ctx, svc, label, hostIDs)
+	labelResp, err := labelResponseForLabel(label, hostIDs)
 	if err != nil {
 		return modifyLabelResponse{Err: err}, nil
 	}
@@ -237,7 +237,7 @@ func getLabelEndpoint(ctx context.Context, request interface{}, svc fleet.Servic
 	if err != nil {
 		return getLabelResponse{Err: err}, nil
 	}
-	resp, err := labelResponseForLabel(ctx, svc, label, hostIDs)
+	resp, err := labelResponseForLabel(label, hostIDs)
 	if err != nil {
 		return getLabelResponse{Err: err}, nil
 	}
@@ -282,7 +282,7 @@ func listLabelsEndpoint(ctx context.Context, request interface{}, svc fleet.Serv
 
 	resp := listLabelsResponse{}
 	for _, label := range labels {
-		labelResp, err := labelResponseForLabel(ctx, svc, label, nil)
+		labelResp, err := labelResponseForLabel(label, nil)
 		if err != nil {
 			return listLabelsResponse{Err: err}, nil
 		}
@@ -310,7 +310,7 @@ func (svc *Service) ListLabels(ctx context.Context, opt fleet.ListOptions) ([]*f
 	return svc.ds.ListLabels(ctx, filter, opt)
 }
 
-func labelResponseForLabel(ctx context.Context, svc fleet.Service, label *fleet.Label, hostIDs []uint) (*labelResponse, error) {
+func labelResponseForLabel(label *fleet.Label, hostIDs []uint) (*labelResponse, error) {
 	return &labelResponse{
 		Label:       *label,
 		DisplayText: label.Name,

--- a/server/service/labels.go
+++ b/server/service/labels.go
@@ -221,7 +221,7 @@ type labelResponse struct {
 	fleet.Label
 	DisplayText string `json:"display_text"`
 	Count       int    `json:"count"`
-	HostIDs     []uint `json:"host_ids"`
+	HostIDs     []uint `json:"host_ids,omitempty"`
 }
 
 type getLabelResponse struct {


### PR DESCRIPTION
## Addresses #18515 
<img width="989" alt="Screenshot 2024-05-21 at 4 11 53 PM" src="https://github.com/fleetdm/fleet/assets/61553566/99f137a1-50cf-4cfb-a3e1-0ed13264c963">


- [x] Changes file added for user-visible changes in `changes/`, 
- [x] Manual QA for all new/changed functionality
