### PR TITLE
Adding clarification on how to override availability zones

### DIFF
--- a/terraform/example/main.tf
+++ b/terraform/example/main.tf
@@ -55,7 +55,7 @@ module "fleet" {
 
   vpc = {
     # By default, Availabililty zones for us-east-2 are configured. If an alternative region is desired,
-    # configure the azs variable below to the desired region. If you have an exported AWS-REGION or a
+    # configure the azs (3 required) variable below to the desired region.  If you have an exported AWS-REGION or a
     # region declared in ~/.aws/config, this value must match the region declared below.
     name = local.vpc_name
     # azs = ["ca-central-1a", "ca-central-1b", "ca-central-1d"]

--- a/terraform/example/main.tf
+++ b/terraform/example/main.tf
@@ -54,7 +54,11 @@ module "fleet" {
   certificate_arn = module.acm.acm_certificate_arn
 
   vpc = {
+    # By default, Availabililty zones for us-east-2 are configured. If an alternative region is desired,
+    # configure the azs variable below to the desired region. If you have an exported AWS-REGION or a
+    # region declared in ~/.aws/config, this value must match the region declared below.
     name = local.vpc_name
+    # azs = ["ca-central-1a", "ca-central-1b", "ca-central-1d"]
   }
 
   fleet_config = {


### PR DESCRIPTION
If an end user wishes to host in some region other than us-east-2, the availability zones need to be updated in this example main.tf