### PR TITLE
allow to customize the signed CSR return type

### DIFF
--- a/website/api/controllers/deliver-apple-csr.js
+++ b/website/api/controllers/deliver-apple-csr.js
@@ -130,6 +130,7 @@ module.exports = {
         respBody = JSON.stringify({
           csr: Buffer.from(generateCertificateResult.request).toString('base64'),
         });
+        break;
       default:
         // Send an email to the user, with the result from the mdm-gen-cert command attached as a plain text file.
         await sails.helpers.sendTemplateEmail.with({

--- a/website/api/controllers/deliver-apple-csr.js
+++ b/website/api/controllers/deliver-apple-csr.js
@@ -153,6 +153,7 @@ module.exports = {
         }).intercept((err)=>{
           return new Error(`When trying to send a signed CSR to a user (${generateCertificateResult.email}), an error occured. Full error: ${err}`);
         });
+        break;
       default:
         throw 'badRequest';
     }

--- a/website/api/controllers/deliver-apple-csr.js
+++ b/website/api/controllers/deliver-apple-csr.js
@@ -16,7 +16,6 @@ module.exports = {
       description: 'Base64 encoded CSR submitted from the Fleet server or `fleetctl` on behalf of the user.'
     },
     alt: {
-      required: false,
       type: 'string',
       description: 'Allows to customize the response type. If specified and set to "json" it returns the signed CSR contents in the response.'
     }

--- a/website/api/controllers/deliver-apple-csr.js
+++ b/website/api/controllers/deliver-apple-csr.js
@@ -26,7 +26,7 @@ module.exports = {
 
     success: {
       description: 'Signed the provided CSR.',
-      outputType: ['string'],
+      outputType: {csr:'string'},
       outputFriendlyName: 'Signed CSR',
     },
 


### PR DESCRIPTION
for #19027, this modifies the website to accept an `alt` parameter to respond with the signed CSR instead of delivering an email.

I used `alt` because:

- That's what we use in the Fleet server API in similar scenarios
- It was simpler than adding an additional endpoint

However, I'm not familiar with sails.js idioms so I'm happy to adjust with whatever it makes sense.

The current approach also maintains backwards compatibility:

**Response without `alt` (unchanged except for custom headers)**

```
$ curl --insecure -v -H 'content-type: application/json' http://localhost:2024/api/v1/deliver-apple-csr -d '{"unsignedCsrData": "foo"}'
*   Trying [::1]:2024...
* Connected to localhost (::1) port 2024
> POST /api/v1/deliver-apple-csr HTTP/1.1
> Host: localhost:2024
> User-Agent: curl/8.4.0
> Accept: */*
> content-type: application/json
> Content-Length: 26
>
< HTTP/1.1 200 OK
< X-Powered-By: Sails <sailsjs.com>
< Cache-Control: no-cache, no-store
< X-Exit: success
< X-Exit-Description: Delivered email to specified email address with certificate signing request attached.
< Content-Type: text/plain; charset=utf-8
< Content-Length: 2
< ETag: W/"2-nOO9QiTIwXgNtWtBJezz8kv3SLc"
< Set-Cookie: sails.sid=s%3AqOZoNKY2CCZ6PFb9fIKaAjtiTKjB7Gum.9jodWIUG6DCNnXu%2Bn%2BF8cJmI%2Fn19Tk%2FdIkDPBl%2BILbI; Path=/; HttpOnly
< Date: Wed, 22 May 2024 18:23:16 GMT
< Connection: keep-alive
< Keep-Alive: timeout=5
<
* Connection #0 to host localhost left intact
OK
```

**Response with `alt=json`**

```
$ curl --insecure -v -H 'content-type: application/json' http://localhost:2024/api/v1/deliver-apple-csr?alt=json -d '{"unsignedCsrData": "foo"}'
*   Trying [::1]:2024...
* Connected to localhost (::1) port 2024
> POST /api/v1/deliver-apple-csr?alt=json HTTP/1.1
> Host: localhost:2024
> User-Agent: curl/8.4.0
> Accept: */*
> content-type: application/json
> Content-Length: 26
>
< HTTP/1.1 200 OK
< X-Powered-By: Sails <sailsjs.com>
< Cache-Control: no-cache, no-store
< Content-Type: application/json; charset=utf-8
< X-Exit: success
< X-Exit-Description: Delivered email to specified email address with certificate signing request attached.
< X-Exit-Output-Friendly-Name: RSS feed XML
< Content-Length: 26
< ETag: W/"1a-NnuclRv86ZEKA9WB967iUGlz84s"
< Set-Cookie: sails.sid=s%3AbpaKOTbNe4E911qH4z1-12ABGd_z2d2I.mAimDARoZgnq8zpJHcF95y8qFJXX0iky4Suj0HUKjpI; Path=/; HttpOnly
< Date: Wed, 22 May 2024 18:22:07 GMT
< Connection: keep-alive
< Keep-Alive: timeout=5
<
* Connection #0 to host localhost left intact
{"csr":"UEQ5NGJXdy4uLg=="}
```

# Checklist for submitter

- [x] Manual QA for all new/changed functionality
