### PR TITLE
ignore osquery error when valid host info data is returned

### DIFF
--- a/orbit/changes/19218-exit-status-78
+++ b/orbit/changes/19218-exit-status-78
@@ -1,0 +1,1 @@
+When orbit gets host info from osquery at startup, ignore and log osquery error when valid data is returned.

--- a/orbit/cmd/orbit/orbit.go
+++ b/orbit/cmd/orbit/orbit.go
@@ -1499,9 +1499,8 @@ func getHostInfo(osqueryPath string, osqueryDBPath string) (*osqueryHostInfo, er
 				"stderr", string(osquerydStderr.Bytes()),
 			).Msg("getHostInfo via osquery")
 			return nil, err
-		} else {
-			log.Warn().Str("status", err.Error()).Msg("getHostInfo via osquery returned data, but with a non-zero exit status")
 		}
+		log.Warn().Str("status", err.Error()).Msg("getHostInfo via osquery returned data, but with a non-zero exit status")
 	}
 	if len(info) == 0 {
 		if err := json.Unmarshal(osquerydStdout.Bytes(), &info); err != nil {

--- a/orbit/cmd/orbit/orbit.go
+++ b/orbit/cmd/orbit/orbit.go
@@ -1486,7 +1486,7 @@ func getHostInfo(osqueryPath string, osqueryDBPath string) (*osqueryHostInfo, er
 	cmd.Stdout = &osquerydStdout
 	cmd.Stderr = &osquerydStderr
 	var info []osqueryHostInfo
-	if err := cmd.Run(); err != nil { // BOZO: !=
+	if err := cmd.Run(); err != nil {
 		// osquery may return correct data with an exit status 78, in which case we only log the error
 		// Related issue: https://github.com/osquery/osquery/issues/6566
 		unmarshalErr := json.Unmarshal(osquerydStdout.Bytes(), &info)

--- a/orbit/cmd/orbit/orbit.go
+++ b/orbit/cmd/orbit/orbit.go
@@ -1485,17 +1485,28 @@ func getHostInfo(osqueryPath string, osqueryDBPath string) (*osqueryHostInfo, er
 	)
 	cmd.Stdout = &osquerydStdout
 	cmd.Stderr = &osquerydStderr
-	if err := cmd.Run(); err != nil {
-		log.Error().Str(
-			"output", string(osquerydStdout.Bytes()),
-		).Str(
-			"stderr", string(osquerydStderr.Bytes()),
-		).Msg("getHostInfo via osquery")
-		return nil, err
-	}
 	var info []osqueryHostInfo
-	if err := json.Unmarshal(osquerydStdout.Bytes(), &info); err != nil {
-		return nil, err
+	if err := cmd.Run(); err != nil { // BOZO: !=
+		// osquery may return correct data with an exit status 78, in which case we only log the error
+		// Related issue: https://github.com/osquery/osquery/issues/6566
+		unmarshalErr := json.Unmarshal(osquerydStdout.Bytes(), &info)
+		// Note: Unmarshal will fail on an empty buffer output.
+		if unmarshalErr != nil {
+			// Since the original command failed, we log the original error and the output for debugging purposes.
+			log.Error().Str(
+				"output", string(osquerydStdout.Bytes()),
+			).Str(
+				"stderr", string(osquerydStderr.Bytes()),
+			).Msg("getHostInfo via osquery")
+			return nil, err
+		} else {
+			log.Warn().Str("status", err.Error()).Msg("getHostInfo via osquery returned data, but with a non-zero exit status")
+		}
+	}
+	if len(info) == 0 {
+		if err := json.Unmarshal(osquerydStdout.Bytes(), &info); err != nil {
+			return nil, err
+		}
 	}
 	if len(info) != 1 {
 		return nil, fmt.Errorf("invalid number of rows from system info query: %d", len(info))


### PR DESCRIPTION
#19218
This fixes the "exit status 78" error seen at orbit startup.

Related osquery issue: https://github.com/osquery/osquery/issues/6566

Manually tested by forcing orbit to take the "error" path.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [ ] Added/updated tests
- [x] Manual QA for all new/changed functionality
  - For Orbit and Fleet Desktop changes:
    - [ ] Manual QA must be performed in the three main OSs, macOS, Windows and Linux.
    - [ ] Auto-update manual QA, from released version of component to new version (see [tools/tuf/test](../tools/tuf/test/README.md)).
