### PR TITLE
Update docs: Best practice infra for deploy security agents

### DIFF
--- a/docs/Deploy/Reference-Architectures.md
+++ b/docs/Deploy/Reference-Architectures.md
@@ -170,7 +170,7 @@ assume On-Demand pricing (savings are available through Reserved Instances). Cal
 | Dependencies | Version                 | Instance type |
 | ------------ | ----------------------- | ------------- |
 | Redis        | 6                       | t4g.small     |
-| MySQL        | 8.0.mysql_aurora.3.02.0 | db.t3.small   |
+| MySQL        | 8.0.mysql_aurora.3.02.0 | db.t4g.medium |
 
 ###### [Up to 25000 hosts](https://calculator.aws/#/estimate?id=4a3e3168275967d1e79a3d1fcfedc5b17d67a271)
 

--- a/docs/Deploy/Reference-Architectures.md
+++ b/docs/Deploy/Reference-Architectures.md
@@ -280,7 +280,7 @@ GCP reference architecture can be found in [the Fleet repository](https://github
 - Cloud SQL MySQL 5.7 (Fleet database)
 - Memorystore Redis (Fleet cache & live query orchestrator)
 
-GCP support for deploying security agents and file carves is coming soon. Get [commmunity support](https://chat.osquery.io/c/fleet).
+GCP support for add/install software and file carve features is coming soon. Get [commmunity support](https://chat.osquery.io/c/fleet).
 
 ##### Example configuration breakpoints
 ###### [Up to 1000 hosts](https://cloud.google.com/products/calculator/#id=59670518-9af4-4044-af4a-cc100a9bed2f)

--- a/docs/Deploy/Reference-Architectures.md
+++ b/docs/Deploy/Reference-Architectures.md
@@ -170,7 +170,7 @@ assume On-Demand pricing (savings are available through Reserved Instances). Cal
 | Dependencies | Version                 | Instance type |
 | ------------ | ----------------------- | ------------- |
 | Redis        | 6                       | t4g.small     |
-| MySQL        | 8.0.mysql_aurora.3.02.0 | db.t4g.medium |
+| MySQL        | 8.0.mysql_aurora.3.04.2 | db.t4g.medium |
 
 ###### [Up to 25000 hosts](https://calculator.aws/#/estimate?id=4a3e3168275967d1e79a3d1fcfedc5b17d67a271)
 
@@ -181,7 +181,7 @@ assume On-Demand pricing (savings are available through Reserved Instances). Cal
 | Dependencies | Version                 | Instance type |
 | ------------ | ----------------------- | ------------- |
 | Redis        | 6                       | m6g.large     |
-| MySQL        | 8.0.mysql_aurora.3.02.0 | db.r6g.large  |
+| MySQL        | 8.0.mysql_aurora.3.04.2 | db.r6g.large  |
 
 
 ###### [Up to 150000 hosts](https://calculator.aws/#/estimate?id=1d8fdd63f01e71027e9d898ed05f4a07299a7000)
@@ -193,7 +193,7 @@ assume On-Demand pricing (savings are available through Reserved Instances). Cal
 | Dependencies | Version                 | Instance type  | Nodes |
 | ------------ | ----------------------- | -------------- | ----- |
 | Redis        | 6                       | m6g.large      | 3     |
-| MySQL        | 8.0.mysql_aurora.3.02.0 | db.r6g.4xlarge | 1     |
+| MySQL        | 8.0.mysql_aurora.3.04.2 | db.r6g.4xlarge | 1     |
 
 ###### [Up to 300000 hosts](https://calculator.aws/#/estimate?id=f3da0597a172c6a0a3683023e2700a6df6d42c0b)
 
@@ -204,7 +204,7 @@ assume On-Demand pricing (savings are available through Reserved Instances). Cal
 | Dependencies | Version                 | Instance type   | Nodes |
 | ------------ | ----------------------- | --------------- | ----- |
 | Redis        | 6                       | m6g.large       | 3     |
-| MySQL        | 8.0.mysql_aurora.3.02.0 | db.r6g.16xlarge | 2     |
+| MySQL        | 8.0.mysql_aurora.3.04.2 | db.r6g.16xlarge | 2     |
 
 AWS reference architecture can be found [here](https://github.com/fleetdm/fleet/tree/main/terraform/example). This configuration includes:
 

--- a/docs/Deploy/Reference-Architectures.md
+++ b/docs/Deploy/Reference-Architectures.md
@@ -171,7 +171,6 @@ assume On-Demand pricing (savings are available through Reserved Instances). Cal
 | ------------ | ----------------------- | ------------- |
 | Redis        | 6                       | t4g.small     |
 | MySQL        | 8.0.mysql_aurora.3.02.0 | db.t3.small   |
-| S3           | TODO                    | TODO          |
 
 ###### [Up to 25000 hosts](https://calculator.aws/#/estimate?id=4a3e3168275967d1e79a3d1fcfedc5b17d67a271)
 
@@ -183,7 +182,6 @@ assume On-Demand pricing (savings are available through Reserved Instances). Cal
 | ------------ | ----------------------- | ------------- |
 | Redis        | 6                       | m6g.large     |
 | MySQL        | 8.0.mysql_aurora.3.02.0 | db.r6g.large  |
-| S3           | TODO                    | TODO          |
 
 
 ###### [Up to 150000 hosts](https://calculator.aws/#/estimate?id=1d8fdd63f01e71027e9d898ed05f4a07299a7000)
@@ -196,7 +194,6 @@ assume On-Demand pricing (savings are available through Reserved Instances). Cal
 | ------------ | ----------------------- | -------------- | ----- |
 | Redis        | 6                       | m6g.large      | 3     |
 | MySQL        | 8.0.mysql_aurora.3.02.0 | db.r6g.4xlarge | 1     |
-| S3           | TODO                    | TODO           | TODO  |
 
 ###### [Up to 300000 hosts](https://calculator.aws/#/estimate?id=f3da0597a172c6a0a3683023e2700a6df6d42c0b)
 
@@ -208,9 +205,8 @@ assume On-Demand pricing (savings are available through Reserved Instances). Cal
 | ------------ | ----------------------- | --------------- | ----- |
 | Redis        | 6                       | m6g.large       | 3     |
 | MySQL        | 8.0.mysql_aurora.3.02.0 | db.r6g.16xlarge | 2     |
-| S3           | TODO                    | TODO            | TODO  |
 
-AWS reference architecture can be found [here](https://github.com/fleetdm/fleet/tree/main/infrastructure/dogfood/terraform/aws). This configuration includes:
+AWS reference architecture can be found [here](https://github.com/fleetdm/fleet/tree/main/terraform/example). This configuration includes:
 
 - VPC
   - Subnets
@@ -224,7 +220,10 @@ AWS reference architecture can be found [here](https://github.com/fleetdm/fleet/
 - Elasticache Redis Engine
 - Firehose osquery log destination
   - S3 bucket sync to allow further ingestion/processing
-- [Monitoring via Cloudwatch alarms](https://github.com/fleetdm/fleet/tree/main/infrastructure/dogfood/terraform/aws/monitoring)
+- Carves/software stored in an S3 bucket
+
+Additional addons are available such as:
+- [Monitoring via Cloudwatch alarms](https://github.com/fleetdm/fleet/tree/main/terraform/addons/monitoring)
 
 Some AWS services used in the provider reference architecture are billed as pay-per-use such as Firehose. This means that osquery scheduled query frequency can have
 a direct correlation to how much these services cost, something to keep in mind when configuring Fleet in AWS.

--- a/docs/Deploy/Reference-Architectures.md
+++ b/docs/Deploy/Reference-Architectures.md
@@ -280,6 +280,8 @@ GCP reference architecture can be found in [the Fleet repository](https://github
 - Cloud SQL MySQL 5.7 (Fleet database)
 - Memorystore Redis (Fleet cache & live query orchestrator)
 
+GCP support for deploying security agents and file carves is coming soon. Get [commmunity support](https://chat.osquery.io/c/fleet).
+
 ##### Example configuration breakpoints
 ###### [Up to 1000 hosts](https://cloud.google.com/products/calculator/#id=59670518-9af4-4044-af4a-cc100a9bed2f)
 

--- a/docs/Deploy/Reference-Architectures.md
+++ b/docs/Deploy/Reference-Architectures.md
@@ -171,6 +171,7 @@ assume On-Demand pricing (savings are available through Reserved Instances). Cal
 | ------------ | ----------------------- | ------------- |
 | Redis        | 6                       | t4g.small     |
 | MySQL        | 8.0.mysql_aurora.3.02.0 | db.t3.small   |
+| S3           | TODO                    | TODO          |
 
 ###### [Up to 25000 hosts](https://calculator.aws/#/estimate?id=4a3e3168275967d1e79a3d1fcfedc5b17d67a271)
 
@@ -182,6 +183,7 @@ assume On-Demand pricing (savings are available through Reserved Instances). Cal
 | ------------ | ----------------------- | ------------- |
 | Redis        | 6                       | m6g.large     |
 | MySQL        | 8.0.mysql_aurora.3.02.0 | db.r6g.large  |
+| S3           | TODO                    | TODO          |
 
 
 ###### [Up to 150000 hosts](https://calculator.aws/#/estimate?id=1d8fdd63f01e71027e9d898ed05f4a07299a7000)
@@ -194,6 +196,7 @@ assume On-Demand pricing (savings are available through Reserved Instances). Cal
 | ------------ | ----------------------- | -------------- | ----- |
 | Redis        | 6                       | m6g.large      | 3     |
 | MySQL        | 8.0.mysql_aurora.3.02.0 | db.r6g.4xlarge | 1     |
+| S3           | TODO                    | TODO           | TODO  |
 
 ###### [Up to 300000 hosts](https://calculator.aws/#/estimate?id=f3da0597a172c6a0a3683023e2700a6df6d42c0b)
 
@@ -205,6 +208,7 @@ assume On-Demand pricing (savings are available through Reserved Instances). Cal
 | ------------ | ----------------------- | --------------- | ----- |
 | Redis        | 6                       | m6g.large       | 3     |
 | MySQL        | 8.0.mysql_aurora.3.02.0 | db.r6g.16xlarge | 2     |
+| S3           | TODO                    | TODO            | TODO  |
 
 AWS reference architecture can be found [here](https://github.com/fleetdm/fleet/tree/main/infrastructure/dogfood/terraform/aws). This configuration includes:
 

--- a/docs/Deploy/deploy-fleet.md
+++ b/docs/Deploy/deploy-fleet.md
@@ -28,7 +28,6 @@ Render is a cloud hosting service that makes it easy to get up and running fast,
    <iframe src="https://www.youtube.com/embed/hly0tAOqveA?rel=0" frameborder="0" allowfullscreen></iframe>
 </div>
 
-
 ### Prerequisites
 
 - A Render account with payment information.
@@ -56,6 +55,7 @@ Render is a cloud hosting service that makes it easy to get up and running fast,
 
 6. Click on the URL to open your Fleet instance, then follow the on-screen instructions to set up your Fleet account.
 
+The deployment must stay on a single container (default).
 
 <h2 class="d-none markdown-heading">AWS</h2>
 <h2 id="aws">Deploy at scale with AWS and Terraform</h2>

--- a/docs/Deploy/deploy-fleet.md
+++ b/docs/Deploy/deploy-fleet.md
@@ -55,7 +55,7 @@ Render is a cloud hosting service that makes it easy to get up and running fast,
 
 6. Click on the URL to open your Fleet instance, then follow the on-screen instructions to set up your Fleet account.
 
-The deployment must stay on a single container (default).
+Support for add/install software features is coming soon. Get [commmunity support](https://chat.osquery.io/c/fleet).
 
 <h2 class="d-none markdown-heading">AWS</h2>
 <h2 id="aws">Deploy at scale with AWS and Terraform</h2>

--- a/terraform/addons/monitoring/.header.md
+++ b/terraform/addons/monitoring/.header.md
@@ -25,25 +25,36 @@ This assumes your fleet module is `main` and is configured with it's default doc
  https://github.com/fleetdm/fleet/blob/main/terraform/example/main.tf for details.
 
 
+Note if you haven't specified a `local.customer`, the default is "fleet".
+
 ```
 module "monitoring" {
-  source                      = "github.com/fleetdm/fleet//terraform/addons/monitoring?ref=tf-mod-addon-monitoring-v1.1.0"
-  customer_prefix             = local.customer
-  fleet_ecs_service_name      = module.main.byo-vpc.byo-db.byo-ecs.service.name
-  albs                        = [
+  source                 = "github.com/fleetdm/fleet//terraform/addons/monitoring?ref=tf-mod-addon-monitoring-v1.4.0"
+  customer_prefix        = local.customer
+  fleet_ecs_service_name = module.main.byo-vpc.byo-db.byo-ecs.service.name
+  albs = [
     {
-      name = module.main.byo-vpc.byo-db.alb.lb_dns_name,
-      target_group_name = module.main.byo-vpc.byo-db.alb.target_group_names[0]
+      name                    = module.main.byo-vpc.byo-db.alb.lb_dns_name,
+      target_group_name       = module.main.byo-vpc.byo-db.alb.target_group_names[0]
       target_group_arn_suffix = module.main.byo-vpc.byo-db.alb.target_group_arn_suffixes[0]
-      arn_suffix = module.main.byo-vpc.byo-db.alb.lb_arn_suffix
-      ecs_service_name = module.main.byo-vpc.byo-db.byo-ecs.service.name
-      min_containers = module.main.byo-vpc.byo-db.byo-ecs.appautoscaling_target.min_capacity
+      arn_suffix              = module.main.byo-vpc.byo-db.alb.lb_arn_suffix
+      ecs_service_name        = module.main.byo-vpc.byo-db.byo-ecs.service.name
+      min_containers          = module.main.byo-vpc.byo-db.byo-ecs.appautoscaling_target.min_capacity
+      alert_thresholds = {
+        HTTPCode_ELB_5XX_Count = {
+          period    = 3600
+          threshold = 2
+        },
+        HTTPCode_Target_5XX_Count = {
+          period    = 120
+          threshold = 0
+        }
+      }
     },
   ]
-  # Only publish alerts for items in this map
   sns_topic_arns_map = {
-    alb_httpcode_5xx = [var.sns_topic_arn]
-    cron_monitoring  = [var.sns_topic_arn]
+    alb_httpcode_5xx = [var.slack_topic_arn]
+    cron_monitoring  = [var.shared.outputs.slack_topic_arn]
   }
   mysql_cluster_members = module.main.byo-vpc.rds.cluster_members
   # The cloudposse module seems to have a nested list here.
@@ -58,9 +69,10 @@ module "monitoring" {
     subnet_ids                 = module.main.vpc.private_subnets
     vpc_id                     = module.main.vpc.vpc_id
     # Format of https://pkg.go.dev/time#ParseDuration
-    delay_tolerance            = "2h"
+    delay_tolerance = "4h"
     # Interval format for: https://docs.aws.amazon.com/scheduler/latest/UserGuide/schedule-types.html#rate-based
-    run_interval               = "1 hour"
+    run_interval          = "1 hour"
+    log_retention_in_days = 365
   }
 }
 ```

--- a/terraform/addons/monitoring/.header.md
+++ b/terraform/addons/monitoring/.header.md
@@ -25,7 +25,7 @@ This assumes your fleet module is `main` and is configured with it's default doc
  https://github.com/fleetdm/fleet/blob/main/terraform/example/main.tf for details.
 
 
-Note if you haven't specified a `local.customer`, the default is "fleet".
+Note if you haven't specified defined `local.customer` or customized service names, the default is "fleet" for anywhere that `local.customer` is specified below.
 
 ```
 module "monitoring" {
@@ -54,7 +54,7 @@ module "monitoring" {
   ]
   sns_topic_arns_map = {
     alb_httpcode_5xx = [var.slack_topic_arn]
-    cron_monitoring  = [var.shared.outputs.slack_topic_arn]
+    cron_monitoring  = [var.slack_topic_arn]
   }
   mysql_cluster_members = module.main.byo-vpc.rds.cluster_members
   # The cloudposse module seems to have a nested list here.

--- a/terraform/addons/monitoring/.header.md
+++ b/terraform/addons/monitoring/.header.md
@@ -53,8 +53,8 @@ module "monitoring" {
     },
   ]
   sns_topic_arns_map = {
-    alb_httpcode_5xx = [var.slack_topic_arn]
-    cron_monitoring  = [var.slack_topic_arn]
+    alb_httpcode_5xx = [var.sns_topic_arn]
+    cron_monitoring  = [var.sns_topic_arn]
   }
   mysql_cluster_members = module.main.byo-vpc.rds.cluster_members
   # The cloudposse module seems to have a nested list here.

--- a/terraform/addons/monitoring/README.md
+++ b/terraform/addons/monitoring/README.md
@@ -24,25 +24,36 @@ This assumes your fleet module is `main` and is configured with it's default doc
 
  https://github.com/fleetdm/fleet/blob/main/terraform/example/main.tf for details.
 
+Note if you haven't specified a `local.customer`, the default is "fleet".
+
 ```
 module "monitoring" {
-  source                      = "github.com/fleetdm/fleet//terraform/addons/monitoring?ref=tf-mod-addon-monitoring-v1.1.0"
-  customer_prefix             = local.customer
-  fleet_ecs_service_name      = module.main.byo-vpc.byo-db.byo-ecs.service.name
-  albs                        = [
+  source                 = "github.com/fleetdm/fleet//terraform/addons/monitoring?ref=tf-mod-addon-monitoring-v1.4.0"
+  customer_prefix        = local.customer
+  fleet_ecs_service_name = module.main.byo-vpc.byo-db.byo-ecs.service.name
+  albs = [
     {
-      name = module.main.byo-vpc.byo-db.alb.lb_dns_name,
-      target_group_name = module.main.byo-vpc.byo-db.alb.target_group_names[0]
+      name                    = module.main.byo-vpc.byo-db.alb.lb_dns_name,
+      target_group_name       = module.main.byo-vpc.byo-db.alb.target_group_names[0]
       target_group_arn_suffix = module.main.byo-vpc.byo-db.alb.target_group_arn_suffixes[0]
-      arn_suffix = module.main.byo-vpc.byo-db.alb.lb_arn_suffix
-      ecs_service_name = module.main.byo-vpc.byo-db.byo-ecs.service.name
-      min_containers = module.main.byo-vpc.byo-db.byo-ecs.appautoscaling_target.min_capacity
+      arn_suffix              = module.main.byo-vpc.byo-db.alb.lb_arn_suffix
+      ecs_service_name        = module.main.byo-vpc.byo-db.byo-ecs.service.name
+      min_containers          = module.main.byo-vpc.byo-db.byo-ecs.appautoscaling_target.min_capacity
+      alert_thresholds = {
+        HTTPCode_ELB_5XX_Count = {
+          period    = 3600
+          threshold = 2
+        },
+        HTTPCode_Target_5XX_Count = {
+          period    = 120
+          threshold = 0
+        }
+      }
     },
   ]
-  # Only publish alerts for items in this map
   sns_topic_arns_map = {
-    alb_httpcode_5xx = [var.sns_topic_arn]
-    cron_monitoring  = [var.sns_topic_arn]
+    alb_httpcode_5xx = [var.slack_topic_arn]
+    cron_monitoring  = [var.shared.outputs.slack_topic_arn]
   }
   mysql_cluster_members = module.main.byo-vpc.rds.cluster_members
   # The cloudposse module seems to have a nested list here.
@@ -57,9 +68,10 @@ module "monitoring" {
     subnet_ids                 = module.main.vpc.private_subnets
     vpc_id                     = module.main.vpc.vpc_id
     # Format of https://pkg.go.dev/time#ParseDuration
-    delay_tolerance            = "2h"
+    delay_tolerance = "4h"
     # Interval format for: https://docs.aws.amazon.com/scheduler/latest/UserGuide/schedule-types.html#rate-based
-    run_interval               = "1 hour"
+    run_interval          = "1 hour"
+    log_retention_in_days = 365
   }
 }
 ```

--- a/terraform/addons/monitoring/README.md
+++ b/terraform/addons/monitoring/README.md
@@ -24,7 +24,7 @@ This assumes your fleet module is `main` and is configured with it's default doc
 
  https://github.com/fleetdm/fleet/blob/main/terraform/example/main.tf for details.
 
-Note if you haven't specified a `local.customer`, the default is "fleet".
+Note if you haven't specified defined `local.customer` or customized service names, the default is "fleet" for anywhere that `local.customer` is specified below.
 
 ```
 module "monitoring" {
@@ -53,7 +53,7 @@ module "monitoring" {
   ]
   sns_topic_arns_map = {
     alb_httpcode_5xx = [var.slack_topic_arn]
-    cron_monitoring  = [var.shared.outputs.slack_topic_arn]
+    cron_monitoring  = [var.slack_topic_arn]
   }
   mysql_cluster_members = module.main.byo-vpc.rds.cluster_members
   # The cloudposse module seems to have a nested list here.

--- a/terraform/example/main.tf
+++ b/terraform/example/main.tf
@@ -128,6 +128,7 @@ module "migrations" {
 }
 
 module "osquery-carve" {
+  # The carve bucket also stores software.
   source = "github.com/fleetdm/fleet//terraform/addons/osquery-carve?ref=tf-mod-addon-osquery-carve-v1.0.1"
   osquery_carve_s3_bucket = {
     name = local.osquery_carve_bucket_name


### PR DESCRIPTION
In Fleet 4.50, Fleet added the ability to deploy security agents:
- #14921 

In production environments, this feature requires an S3 bucket.

Changes:
- Add S3 to AWS reference architecture docs
- Add note that GCP support for add/install software (deploy security agents) and file carves is coming soon. 
  - Using "Add/install" software language in the docs instead of "deploy security agents" so that we don't have to remember to change it later. Let's use "deploy security agents" when talking to customers/prospects. Why? So we don't overpromise. We're focused on security agents. Iterating on installing all software.
  - Request is here: https://github.com/fleetdm/fleet/issues/19259
- Add note that Render support for add/install software (deploy security agents) is coming soon. 
  - Request is here: https://github.com/fleetdm/fleet/issues/19260
- Update links to best practice Terraform example
