### PR TITLE
Add attribution for Mac Admins tables

### DIFF
--- a/schema/tables/authdb.yml
+++ b/schema/tables/authdb.yml
@@ -21,7 +21,7 @@ example: |-
   ```
 
 notes: |-
-  This table is not a core osquery table. It is included as part of Fleet's agent ([fleetd](https://fleetdm.com/docs/get-started/anatomy#fleetd)).
+  This table is from the [Mac Admins osquery extension](https://github.com/macadmins/osquery-extension).
 
   The authorizationdb is a SQLite database that can be dumped out with the following Terminal command:
 

--- a/schema/tables/file_lines.yml
+++ b/schema/tables/file_lines.yml
@@ -1,5 +1,5 @@
 name: file_lines
-notes: This table is not a core osquery table. It is included as part of Fleet's agent ([fleetd](https://fleetdm.com/docs/get-started/anatomy#fleetd)).
+notes: This table is from the [Mac Admins osquery extension](https://github.com/macadmins/osquery-extension).
 description: Allows reading an arbitrary file.
 platforms: 
   - darwin

--- a/schema/tables/filevault_users.yml
+++ b/schema/tables/filevault_users.yml
@@ -1,5 +1,5 @@
 name: filevault_users
-notes: This table is not a core osquery table. It is included as part of Fleet's agent ([fleetd](https://fleetdm.com/docs/get-started/anatomy#fleetd)).
+notes: This table is from the [Mac Admins osquery extension](https://github.com/macadmins/osquery-extension).
 description: Information on the users able to unlock the current boot volume if protected with FileVault.
 platforms: 
   - darwin

--- a/schema/tables/google_chrome_profiles.yml
+++ b/schema/tables/google_chrome_profiles.yml
@@ -1,5 +1,5 @@
 name: google_chrome_profiles
-notes: This table is not a core osquery table. It is included as part of Fleet's agent ([fleetd](https://fleetdm.com/docs/get-started/anatomy#fleetd)).
+notes: This table is from the [Mac Admins osquery extension](https://github.com/macadmins/osquery-extension).
 description: Profiles configured in Google Chrome.
 platforms: 
   - darwin

--- a/schema/tables/macadmins_unified_log.yml
+++ b/schema/tables/macadmins_unified_log.yml
@@ -1,5 +1,5 @@
 name: macadmins_unified_log
-notes: This table is not a core osquery table. It is included as part of Fleet's agent ([fleetd](https://fleetdm.com/docs/get-started/anatomy#fleetd)).
+notes: notes: This table is from the [Mac Admins osquery extension](https://github.com/macadmins/osquery-extension).
 description: Allows querying macOS [unified logs](https://developer.apple.com/documentation/os/logging).
 platforms: 
   - darwin

--- a/schema/tables/macadmins_unified_log.yml
+++ b/schema/tables/macadmins_unified_log.yml
@@ -1,5 +1,5 @@
 name: macadmins_unified_log
-notes: notes: This table is from the [Mac Admins osquery extension](https://github.com/macadmins/osquery-extension).
+notes: This table is from the [Mac Admins osquery extension](https://github.com/macadmins/osquery-extension).
 description: Allows querying macOS [unified logs](https://developer.apple.com/documentation/os/logging).
 platforms: 
   - darwin

--- a/schema/tables/macos_profiles.yml
+++ b/schema/tables/macos_profiles.yml
@@ -1,5 +1,5 @@
 name: macos_profiles
-notes: This table is not a core osquery table. It is included as part of Fleet's agent ([fleetd](https://fleetdm.com/docs/get-started/anatomy#fleetd)).
+notes: This table is from the [Mac Admins osquery extension](https://github.com/macadmins/osquery-extension).
 description: High level information on installed profiles enrollment.
 platforms: 
   - darwin

--- a/schema/tables/macos_rsr.yml
+++ b/schema/tables/macos_rsr.yml
@@ -1,5 +1,5 @@
 name: macos_rsr
-notes: This table is not a core osquery table. It is included as part of Fleet's agent ([fleetd](https://fleetdm.com/docs/get-started/anatomy#fleetd)).
+notes: This table is from the [Mac Admins osquery extension](https://github.com/macadmins/osquery-extension).
 description: Returns information about installed Rapid Security Responses (RSRs).
 platforms: 
   - darwin

--- a/schema/tables/mdm.yml
+++ b/schema/tables/mdm.yml
@@ -1,8 +1,6 @@
 name: mdm
 notes: |-
-  - This table is not a core osquery table. It is included as part of Fleet's agent ([fleetd](https://fleetdm.com/docs/get-started/anatomy#fleetd)).
-
-  - Code based on work by [Kolide](https://github.com/kolide/launcher).
+  This table is from the [Mac Admins osquery extension](https://github.com/macadmins/osquery-extension).
   
   - Due to changes in macOS 12.3, the output of `profiles show -type enrollment` can only be generated once a day. If you are running this command with another tool, you should set the `PROFILES_SHOW_ENROLLMENT_CACHE_PATH` environment variable to the path you are caching this. The cache file should be `json` with the keys `dep_capable` and `rate_limited present`, both booleans representing whether the device is capable of DEP enrollment and whether the response from `profiles show -type enrollment` is being rate limited or not.
 description: Information on the device's MDM enrollment.

--- a/schema/tables/munki_info.yml
+++ b/schema/tables/munki_info.yml
@@ -1,8 +1,5 @@
 name: munki_info
-notes: |-
-  - This table is not a core osquery table. It is included as part of Fleet's agent ([fleetd](https://fleetdm.com/docs/get-started/anatomy#fleetd)).
-  
-  - Code based on work by [macadmins/osquery-extension](https://github.com/macadmins/osquery-extension) and [Kolide](https://github.com/kolide/launcher).
+notes: This table is from the [Mac Admins osquery extension](https://github.com/macadmins/osquery-extension).
 description: Information from the last [Munki](https://github.com/munki/munki) run.
 platforms: 
   - darwin

--- a/schema/tables/munki_installs.yml
+++ b/schema/tables/munki_installs.yml
@@ -1,8 +1,5 @@
 name: munki_installs
-notes: |-
-  - This table is not a core osquery table. It is included as part of Fleet's agent ([fleetd](https://fleetdm.com/docs/get-started/anatomy#fleetd)).
-  
-  - Code based on work by [macadmins/osquery-extension](https://github.com/macadmins/osquery-extension) and [Kolide](https://github.com/kolide/launcher).
+notes: This table is from the [Mac Admins osquery extension](https://github.com/macadmins/osquery-extension).
 description: Software packages and other items [Munki](https://github.com/munki/munki) is managing.
 platforms: 
   - darwin

--- a/schema/tables/puppet_info.yml
+++ b/schema/tables/puppet_info.yml
@@ -1,5 +1,5 @@
 name: puppet_info
-notes: This table is not a core osquery table. It is included as part of Fleet's agent ([fleetd](https://fleetdm.com/docs/get-started/anatomy#fleetd)).
+notes: This table is from the [Mac Admins osquery extension](https://github.com/macadmins/osquery-extension).
 description: Information on the last [Puppet](https://puppet.com/) run. This table uses data from the `last_run_report` that Puppet creates.
 platforms: 
   - darwin

--- a/schema/tables/puppet_logs.yml
+++ b/schema/tables/puppet_logs.yml
@@ -1,5 +1,5 @@
 name: puppet_logs
-notes: This table is not a core osquery table. It is included as part of Fleet's agent ([fleetd](https://fleetdm.com/docs/get-started/anatomy#fleetd)).
+notes: This table is from the [Mac Admins osquery extension](https://github.com/macadmins/osquery-extension).
 description: Outputs [Puppet](https://puppet.com/) logs from the last run. 
 platforms: 
   - darwin

--- a/schema/tables/puppet_state.yml
+++ b/schema/tables/puppet_state.yml
@@ -1,5 +1,5 @@
 name: puppet_state
-notes: This table is not a core osquery table. It is included as part of Fleet's agent ([fleetd](https://fleetdm.com/docs/get-started/anatomy#fleetd)).
+notes: This table is from the [Mac Admins osquery extension](https://github.com/macadmins/osquery-extension).
 description: State of every resource [Puppet](https://puppet.com/) is managing. This table uses data from the `last_run_report` that Puppet creates.
 platforms: 
   - darwin

--- a/schema/tables/sofa_security_release_info.yml
+++ b/schema/tables/sofa_security_release_info.yml
@@ -1,6 +1,6 @@
 name: sofa_security_release_info
 notes: |-
-  This table is not a core osquery table. It is included as part of Fleet's agent ([fleetd](https://fleetdm.com/docs/get-started/anatomy#fleetd)).
+  This table is from the [Mac Admins osquery extension](https://github.com/macadmins/osquery-extension).
   
   - By default this table will return vulnerability data for the running operating system.
 

--- a/schema/tables/sofa_unpatched_cves.yml
+++ b/schema/tables/sofa_unpatched_cves.yml
@@ -1,6 +1,6 @@
 name: sofa_unpatched_cves
 notes: |-
-  This table is not a core osquery table. It is included as part of Fleet's agent ([fleetd](https://fleetdm.com/docs/get-started/anatomy#fleetd)).
+  This table is from the [Mac Admins osquery extension](https://github.com/macadmins/osquery-extension).
 
   - By default this table will return all unpatched vulnerability data for the running operating system.
 


### PR DESCRIPTION
- Add note for all tables from the [Mac Admins osquery extensions](https://github.com/macadmins/osquery-extension/tree/main/tables). This note will show up on fleetdm.com/tables and in the core product
