### PR TITLE
Website: add new usage statistics

### DIFF
--- a/website/api/controllers/webhooks/receive-usage-analytics.js
+++ b/website/api/controllers/webhooks/receive-usage-analytics.js
@@ -33,6 +33,12 @@ module.exports = {
     mdmWindowsEnabled: {type: 'boolean', defaultsTo: false},
     liveQueryDisabled: {type: 'boolean', defaultsTo: false},
     hostExpiryEnabled: {type: 'boolean', defaultsTo: false},
+    numSoftwareVersions: {type: 'number', defaultsTo: 0},
+    numHostSoftwares: {type: 'number', defaultsTo: 0},
+    numSoftwareTitles: {type: 'number', defaultsTo: 0},
+    numHostSoftwareInstalledPaths: {type: 'number', defaultsTo: 0},
+    numSoftwareCPEs: {type: 'number', defaultsTo: 0},
+    numSoftwareCVEs: {type: 'number', defaultsTo: 0},
   },
 
 

--- a/website/api/models/HistoricalUsageSnapshot.js
+++ b/website/api/models/HistoricalUsageSnapshot.js
@@ -37,6 +37,12 @@ module.exports = {
     mdmWindowsEnabled: {required: true, type: 'boolean'},
     liveQueryDisabled: {required: true, type: 'boolean'},
     hostExpiryEnabled: {required: true, type: 'boolean'},
+    numSoftwareVersions: {required: true, type: 'number'},
+    numHostSoftwares: {required: true, type: 'number'},
+    numSoftwareTitles: {required: true, type: 'number'},
+    numHostSoftwareInstalledPaths: {required: true, type: 'number'},
+    numSoftwareCPEs: {required: true, type: 'number'},
+    numSoftwareCVEs: {required: true, type: 'number'},
 
     //  ╔═╗╔╦╗╔╗ ╔═╗╔╦╗╔═╗
     //  ║╣ ║║║╠╩╗║╣  ║║╚═╗


### PR DESCRIPTION
Closes: https://github.com/fleetdm/fleet/issues/19308

Changes:
- Added six new attributes to the `HistoricalUsageSnapshot` model ( `numSoftwareVersions`, `numHostSoftwares`, `numSoftwareTitles`, `numHostSoftwareInstalledPaths`, `numSoftwareCPEs` and `numSoftwareCVEs`)
- Added inputs to the receive-usage-analytics webhook for the new usage statistics.


When this PR is merged, we will need to migrate the Fleet website's database to add the new columns, to do this:
- [x] Make an announcement in Slack to let people know the website will be offline for ~8 minutes
- [ ] Merge this PR
- [ ] As the deploy action runs, put the website into maintenance mode
- [ ] Add the new columns for the added attributes
- [ ] Set the default value for the new attributes on existing database records
- [ ] After the deploy workflow is complete, take the website out of maintenance mode.