### PR TITLE
Update loadtest osquery-perf to cleanup vulns in built image

### DIFF
--- a/infrastructure/loadtesting/terraform/docker/loadtest.Dockerfile
+++ b/infrastructure/loadtesting/terraform/docker/loadtest.Dockerfile
@@ -1,7 +1,18 @@
-FROM golang:1.22.3@sha256:f43c6f049f04cbbaeb28f0aad3eea15274a7d0a7899a617d0037aec48d7ab010
+FROM golang:1.22.3-alpine3.20@sha256:1b455a3f7786e5765dbeb4f7ab32a36cdc0c3f4ddd35406606df612dc6e3269b
 ARG TAG
+RUN apk add git
 RUN git clone -b $TAG --depth=1 --no-tags --progress --no-recurse-submodules https://github.com/fleetdm/fleet.git && cd /go/fleet/cmd/osquery-perf/ && go build .
 
-FROM golang:1.22.3@sha256:f43c6f049f04cbbaeb28f0aad3eea15274a7d0a7899a617d0037aec48d7ab010
+FROM alpine:3.20@sha256:77726ef6b57ddf65bb551896826ec38bc3e53f75cdde31354fbffb4f25238ebd
+LABEL maintainer="Fleet Developers"
+
+# Create FleetDM group and user
+RUN addgroup -S osquery-perf && adduser -S osquery-perf -G osquery-perf
 
 COPY --from=0 /go/fleet/cmd/osquery-perf/osquery-perf /go/osquery-perf
+COPY --from=0 /go/fleet/server/vulnerabilities/testdata/ /go/fleet/server/vulnerabilities/testdata/
+RUN set -eux; \
+        apk update; \
+        apk upgrade
+
+USER osquery-perf


### PR DESCRIPTION
Note this is the same Dockerfile used in cloud for adding fake hosts to preview/tests environments.