### PR TITLE
fix: remove references to adminstrator users in script

### DIFF
--- a/changes/jve-fix-lock-script-typo
+++ b/changes/jve-fix-lock-script-typo
@@ -1,0 +1,1 @@
+- Removes references to Administrator accounts in the comments of the Windows lock script.

--- a/ee/server/service/embedded_scripts/windows_lock.ps1
+++ b/ee/server/service/embedded_scripts/windows_lock.ps1
@@ -1,4 +1,4 @@
-# PowerShell script to log off all non-administrative users and disable their accounts
+# PowerShell script to log off all users and disable their accounts
 
 # Log off all users
 $loggedOffUsers = @{}
@@ -32,4 +32,4 @@ Get-LocalUser | Where-Object { $_.Enabled -eq $true } | ForEach-Object {
     Write-Host "Disabled account for $username"
 }
 
-Write-Host "All non-administrative users have been logged out and their accounts disabled."
+Write-Host "All users have been logged out and their accounts disabled."


### PR DESCRIPTION
> Related issue: #18461

Non-functional change; there were some comments in the embedded script that referenced Administrator accounts. These references needed to be removed, as the script can lock out all accounts now.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [x] Manual QA for all new/changed functionality
