### PR TITLE
Improved software ingestion performance by deduplicating incoming software.

### DIFF
--- a/changes/11942-duplicated-software
+++ b/changes/11942-duplicated-software
@@ -1,0 +1,1 @@
+Improved software ingestion performance by deduplicating incoming software.

--- a/server/datastore/mysql/software_test.go
+++ b/server/datastore/mysql/software_test.go
@@ -423,15 +423,33 @@ func testSoftwareNothingChanged(t *testing.T, ds *Datastore) {
 			[]fleet.Software{{Name: "A", Version: "1.0", Source: "ASD", LastOpenedAt: ptr.Time(time.Now())}},
 			true,
 		},
+		{
+			"identical with duplicates incoming",
+			[]fleet.Software{{Name: "A", Version: "1.0", Source: "ASD"}},
+			[]fleet.Software{{Name: "A", Version: "1.0", Source: "ASD"}, {Name: "A", Version: "1.0", Source: "ASD"}},
+			true,
+		},
+		{
+			"identical with duplicates incoming and insignificantly changed last open",
+			[]fleet.Software{{Name: "A", Version: "1.0", Source: "ASD", LastOpenedAt: ptr.Time(time.Now().Add(-time.Second))}},
+			[]fleet.Software{
+				{Name: "A", Version: "1.0", Source: "ASD"},
+				{Name: "A", Version: "1.0", Source: "ASD", LastOpenedAt: ptr.Time(time.Now().Add(-time.Hour))},
+				{Name: "A", Version: "1.0", Source: "ASD", LastOpenedAt: ptr.Time(time.Now())},
+			},
+			true,
+		},
 	}
 	for _, c := range cases {
 		t.Run(c.desc, func(t *testing.T) {
-			got := nothingChanged(c.current, c.incoming, defaultMinLastOpenedAtDiff)
+			current, incoming, got := nothingChanged(c.current, c.incoming, defaultMinLastOpenedAtDiff)
 			if c.want {
-				require.True(t, got)
+				assert.True(t, got)
+				assert.Equal(t, len(current), len(incoming))
 			} else {
-				require.False(t, got)
+				assert.False(t, got)
 			}
+			assert.Equal(t, len(c.current), len(current))
 		})
 	}
 }


### PR DESCRIPTION
#11942 

To check if you have duplicate software, install multiple python versions, like:
```shell
brew install python@3.11
brew install python@3.12
```

Then query: `SELECT * FROM python_packages` to see the packages with the same versions but different paths.

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [x] Added/updated tests
- [x] Manual QA for all new/changed functionality
