### PR TITLE
fix: truncate private key and add docs

### DIFF
--- a/changes/jve-pk-docs
+++ b/changes/jve-pk-docs
@@ -1,0 +1,2 @@
+- Updates the private key requirements to allow keys longer than 32 bytes
+- Adds documentation around the new `FLEET_SERVER_PRIVATE_KEY` var

--- a/cmd/fleet/serve.go
+++ b/cmd/fleet/serve.go
@@ -508,9 +508,13 @@ the way that the Fleet server works.
 				cancel()
 			}
 
-			if len(config.Server.PrivateKey) > 0 && len([]byte(config.Server.PrivateKey)) != 32 {
-				initFatal(errors.New("private key must be 32 bytes long"), "validate private key")
+			if len([]byte(config.Server.PrivateKey)) < 32 {
+				initFatal(errors.New("private key must be at least 32 bytes long"), "validate private key")
 			}
+
+			// We truncate to 32 bytes because AES-256 requires a 32 byte (256 bit) PK, but some
+			// infra setups generate keys that are longer than 32 bytes.
+			config.Server.PrivateKey = config.Server.PrivateKey[:32]
 
 			appCfg, err := ds.AppConfig(context.Background())
 			if err != nil {

--- a/cmd/fleet/serve.go
+++ b/cmd/fleet/serve.go
@@ -163,6 +163,14 @@ the way that the Fleet server works.
 				}
 			}
 
+			if len([]byte(config.Server.PrivateKey)) < 32 {
+				initFatal(errors.New("private key must be at least 32 bytes long"), "validate private key")
+			}
+
+			// We truncate to 32 bytes because AES-256 requires a 32 byte (256 bit) PK, but some
+			// infra setups generate keys that are longer than 32 bytes.
+			config.Server.PrivateKey = config.Server.PrivateKey[:32]
+
 			var ds fleet.Datastore
 			var carveStore fleet.CarveStore
 			var installerStore fleet.InstallerStore
@@ -507,14 +515,6 @@ the way that the Fleet server works.
 				}
 				cancel()
 			}
-
-			if len([]byte(config.Server.PrivateKey)) < 32 {
-				initFatal(errors.New("private key must be at least 32 bytes long"), "validate private key")
-			}
-
-			// We truncate to 32 bytes because AES-256 requires a 32 byte (256 bit) PK, but some
-			// infra setups generate keys that are longer than 32 bytes.
-			config.Server.PrivateKey = config.Server.PrivateKey[:32]
 
 			appCfg, err := ds.AppConfig(context.Background())
 			if err != nil {

--- a/docs/Configuration/fleet-server-configuration.md
+++ b/docs/Configuration/fleet-server-configuration.md
@@ -678,6 +678,21 @@ Setting to true will disable the origin check.
     websockets_allow_unsafe_origin: true
   ```
 
+##### server_private_key
+
+The private key used to encrypt sensitive data in Fleet, for example, MDM certificates and keys.
+The key must be at least 32 bytes long. If the key is longer than 32 bytes, only the first 32 bytes
+will be used (the data is encrypted using AES-256, which requires a 32 byte key). This key is
+required for enabling MDM features in Fleet.
+
+- Default value: ""
+- Environment variable: FLEET_SERVER_PRIVATE_KEY
+- Config file format:
+  ```yaml
+  server:
+    private_key: 72414F4A688151F75D032F5CDA095FC4
+  ```
+
 ##### Example YAML
 
 ```yaml

--- a/docs/Configuration/fleet-server-configuration.md
+++ b/docs/Configuration/fleet-server-configuration.md
@@ -683,7 +683,9 @@ Setting to true will disable the origin check.
 The private key used to encrypt sensitive data in Fleet, for example, MDM certificates and keys.
 The key must be at least 32 bytes long. If the key is longer than 32 bytes, only the first 32 bytes
 will be used (the data is encrypted using AES-256, which requires a 32 byte key). This key is
-required for enabling MDM features in Fleet.
+required for enabling MDM features in Fleet. If you are using the `FLEET_APPLE_APNS_*` and
+`FLEET_APPLE_SCEP_*` variables, Fleet will automatically encrypt the values of those variables using
+`FLEET_SERVER_PRIVATE_KEY` and save them in the database when you restart after updating.
 
 - Default value: ""
 - Environment variable: FLEET_SERVER_PRIVATE_KEY


### PR DESCRIPTION
Addressing some docs changes, as well as a change in the code that's needed to handle private keys that are longer than 32 bytes (such as those generated by Render).

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [x] Manual QA for all new/changed functionality
