### PR TITLE
18053 custom kernel scan

### DIFF
--- a/docs/Using Fleet/Vulnerability-Processing.md
+++ b/docs/Using Fleet/Vulnerability-Processing.md
@@ -25,8 +25,6 @@ Fleet detects vulnerabilities for these software types:
 
 Only app names with all ASCII characters are supported. Apps with names featuring non-ASCII characters, such as Cyrillic, will not generate matches.
 
-For kernel packages, only Ubtuntu is supported. On Ubtuntu, any unknown kernel variants are mapped to CVEs for the `-generic` variant.
-
 ## Configuration
 
 When upgrading to Fleet 4.7.0 or later, vulnerability processing is automatically enabled if

--- a/docs/Using Fleet/Vulnerability-Processing.md
+++ b/docs/Using Fleet/Vulnerability-Processing.md
@@ -20,10 +20,12 @@ Fleet detects vulnerabilities for these software types:
 | ------------------- | ------------------------------------------ | ------------------------------------------------ | ---------------- |
 | Apps                | ✅                                         | ✅                                               | ❌               |
 | Browser plugins     | Chrome extensions, Firefox extensions      | Chrome extensions, Firefox extensions            | ❌               |
-| Packages            | Python, Homebrew  | Python, Atom, Chocolatey | Adhere to whatever is defined in the [OVAL definitions](https://github.com/fleetdm/nvd/blob/master/oval_sources.json), except for kernel vulnerabilities and vulnerabilities involving configuration files. Supported distributions: <ul><li>Ubuntu</li><li>RHEL based distros (Red Hat, CentOS, Fedora, and Amazon Linux)</li></ul> |
+| Packages            | Python, Homebrew  | Python, Atom, Chocolatey | Adhere to whatever is defined in the [OVAL definitions](https://github.com/fleetdm/nvd/blob/master/oval_sources.json), except for vulnerabilities involving configuration files. Supported distributions: <ul><li>Ubuntu</li><li>RHEL based distros (Red Hat, CentOS, Fedora, and Amazon Linux)</li></ul> |
 | IDE extensions      | VS Code extensions | VS Code extensions | VS Code extensions |
 
-As of right now, only app names with all ASCII characters are supported. Apps with names featuring non-ASCII characters, such as Cyrillic, will not generate matches.
+Only app names with all ASCII characters are supported. Apps with names featuring non-ASCII characters, such as Cyrillic, will not generate matches.
+
+For kernel packages, only Ubtuntu is supported. On Ubtuntu, any unknown kernel variants are mapped to CVEs for the `-generic` variant.
 
 ## Configuration
 

--- a/server/vulnerabilities/oval/parsed/object_state_string.go
+++ b/server/vulnerabilities/oval/parsed/object_state_string.go
@@ -58,7 +58,7 @@ func (sta ObjectStateString) ParseKernelVariants() []string {
 
 	re := regexp.MustCompile(pattern)
 
-	match := re.FindStringSubmatch(string(v))
+	match := re.FindStringSubmatch(v)
 	if len(match) < 2 {
 		return []string{}
 	}

--- a/server/vulnerabilities/oval/parsed/object_state_string.go
+++ b/server/vulnerabilities/oval/parsed/object_state_string.go
@@ -42,31 +42,3 @@ func (sta ObjectStateString) Eval(other string) (bool, error) {
 
 	return false, fmt.Errorf("can not compute op %q", op)
 }
-
-func (sta ObjectStateString) EvalUname(other string) (bool, error) {
-	op, val := sta.unpack()
-
-	// strip EVR epoch
-	parts := strings.Split(val, ":")
-	if len(parts) > 1 {
-		val = parts[1]
-	}
-
-	switch op {
-	case Equals:
-		return val == other, nil
-	case NotEqual:
-		return val != other, nil
-	case CaseInsensitiveEquals:
-		return strings.ToLower(val) == strings.ToLower(other), nil
-	case CaseInsensitiveNotEqual:
-		return strings.ToLower(val) != strings.ToLower(other), nil
-	case LessThan:
-		return val < other, nil
-	case PatternMatch:
-		// Skipping pattern matching to support custom kernel versions
-		return false, nil
-	}
-
-	return false, fmt.Errorf("can not compute op %q", op)
-}

--- a/server/vulnerabilities/oval/parsed/object_state_string.go
+++ b/server/vulnerabilities/oval/parsed/object_state_string.go
@@ -42,3 +42,31 @@ func (sta ObjectStateString) Eval(other string) (bool, error) {
 
 	return false, fmt.Errorf("can not compute op %q", op)
 }
+
+func (sta ObjectStateString) EvalUname(other string) (bool, error) {
+	op, val := sta.unpack()
+
+	// strip EVR epoch
+	parts := strings.Split(val, ":")
+	if len(parts) > 1 {
+		val = parts[1]
+	}
+
+	switch op {
+	case Equals:
+		return val == other, nil
+	case NotEqual:
+		return val != other, nil
+	case CaseInsensitiveEquals:
+		return strings.ToLower(val) == strings.ToLower(other), nil
+	case CaseInsensitiveNotEqual:
+		return strings.ToLower(val) != strings.ToLower(other), nil
+	case LessThan:
+		return val < other, nil
+	case PatternMatch:
+		// Skipping pattern matching to support custom kernel versions
+		return false, nil
+	}
+
+	return false, fmt.Errorf("can not compute op %q", op)
+}

--- a/server/vulnerabilities/oval/parsed/object_state_string_test.go
+++ b/server/vulnerabilities/oval/parsed/object_state_string_test.go
@@ -75,3 +75,41 @@ func TestObjectStateString(t *testing.T) {
 		})
 	})
 }
+
+func TestParseKernelVariantsinObject(t *testing.T) {
+	tests := []struct {
+		input    ObjectStateString
+		expected []string
+	}{
+		{
+			input:    ObjectStateString(`pattern match|5.15.0-\d+(-generic|-generic-64k|-generic-lpae|-lowlatency|-lowlatency-64k)`),
+			expected: []string{"generic", "generic-64k", "generic-lpae", "lowlatency", "lowlatency-64k"},
+		},
+		{
+			input:    ObjectStateString(`pattern match|5.15.0-\d+(-generic|-lowlatency)`),
+			expected: []string{"generic", "lowlatency"},
+		},
+		{
+			input:    ObjectStateString(`pattern match|5.15.0-\d+(-custom)`),
+			expected: []string{"custom"},
+		},
+		{
+			input:    ObjectStateString(`pattern match|5.15.0-\d+()`),
+			expected: []string{},
+		},
+		{
+			input:    ObjectStateString(`pattern match|invalid-string`),
+			expected: []string{},
+		},
+		{
+			input:    ObjectStateString(`less than|5.15.0-\d+(-generic)`),
+			expected: []string{},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(fmt.Sprintf("input: %s", tc.input), func(t *testing.T) {
+			require.Equal(t, tc.expected, tc.input.ParseKernelVariants())
+		})
+	}
+}

--- a/server/vulnerabilities/oval/parsed/ubuntu_result.go
+++ b/server/vulnerabilities/oval/parsed/ubuntu_result.go
@@ -12,6 +12,9 @@ type UbuntuResult struct {
 	Definitions  []Definition
 	PackageTests map[int]*DpkgInfoTest
 	UnameTests   map[int]*UnixUnameTest
+	// KernelVariants do not exist in the OVAL schema, but are extracted from UnameTests
+	// and used to store the kernel variants to determine if a kernel is unknown/custom.
+	KernelVariants []string
 }
 
 // NewUbuntuResult is the result of parsing an OVAL file that targets an Ubuntu distro.
@@ -35,6 +38,14 @@ func (r *UbuntuResult) AddPackageTest(id int, tst *DpkgInfoTest) {
 
 func (r *UbuntuResult) AddUnameTest(id int, tst *UnixUnameTest) {
 	r.UnameTests[id] = tst
+}
+
+func (r *UbuntuResult) AddKernelVariant(v string) {
+	r.KernelVariants = append(r.KernelVariants, v)
+}
+
+func parseKernelVariants(s string) []string {
+	return strings.Fields(s)
 }
 
 func (r UbuntuResult) Eval(ver fleet.OSVersion, software []fleet.Software) ([]fleet.SoftwareVulnerability, error) {
@@ -84,6 +95,8 @@ func (r UbuntuResult) EvalKernel(software []fleet.Software) ([]fleet.SoftwareVul
 				return nil, fmt.Errorf("linux kernel package %s does not match expected format:", s.Name)
 			}
 
+			v = r.ReplaceUnknownKernel(v)
+
 			for i, u := range r.UnameTests {
 				isMatch, err := u.Eval(v)
 				if err != nil {
@@ -111,4 +124,24 @@ func (r UbuntuResult) EvalKernel(software []fleet.Software) ([]fleet.SoftwareVul
 	}
 
 	return vuln, nil
+}
+
+var kernelVariantRegex = regexp.MustCompile(`^([\d|\.]+-\d+)([-|\w]+$)`)
+
+// ReplaceUnknownKernel replaces an unknown kernel variant with the default kernel variant.
+func (r UbuntuResult) ReplaceUnknownKernel(version string) string {
+	defaultKernel := "generic"
+
+	v := kernelVariantRegex.FindStringSubmatch(version)
+	if len(v) < 3 {
+		return version
+	}
+
+	for _, variant := range r.KernelVariants {
+		if variant == strings.TrimPrefix(v[2], "-") {
+			return version
+		}
+	}
+
+	return fmt.Sprintf("%s-%s", v[1], defaultKernel)
 }

--- a/server/vulnerabilities/oval/parsed/ubuntu_result.go
+++ b/server/vulnerabilities/oval/parsed/ubuntu_result.go
@@ -44,10 +44,6 @@ func (r *UbuntuResult) AddKernelVariant(v string) {
 	r.KernelVariants = append(r.KernelVariants, v)
 }
 
-func parseKernelVariants(s string) []string {
-	return strings.Fields(s)
-}
-
 func (r UbuntuResult) Eval(ver fleet.OSVersion, software []fleet.Software) ([]fleet.SoftwareVulnerability, error) {
 	// Test Id => Matching software
 	pkgTstResults := make(map[int][]fleet.Software)

--- a/server/vulnerabilities/oval/parsed/unix_unameTest_test.go
+++ b/server/vulnerabilities/oval/parsed/unix_unameTest_test.go
@@ -23,9 +23,11 @@ func TestEval(t *testing.T) {
 		{Name: "greater than", Input: "5.15.0-1005-generic", Expected: false},
 		{Name: "equal", Input: "5.15.0-1004-generic", Expected: false},
 		{Name: "alt pattern match", Input: "5.15.0-1003-lowlatency", Expected: true},
-		{Name: "suffix doesn't match", Input: "5.15.0-1004-foo", Expected: false},
 		{Name: "lower version fails pattern match", Input: "4.0.0-10-generic", Expected: false},
 		{Name: "higher version fails pattern match", Input: "6.0.0-10-generic", Expected: false},
+		{Name: "unknown kernel variant matches generic", Input: "5.15.0-1003-foo", Expected: true},
+		{Name: "uknown kernel variant is greater than", Input: "5.15.0-1005-foo", Expected: false},
+		{Name: "unknown kernel variant is wrong version", Input: "4.0.0-1003-foo", Expected: false},
 	}
 
 	for _, tc := range testCases {

--- a/server/vulnerabilities/oval/parser.go
+++ b/server/vulnerabilities/oval/parser.go
@@ -490,5 +490,20 @@ func mapToUbuntuResult(xmlResult *oval_input.UbuntuResultXML) (*oval_parsed.Ubun
 		}
 	}
 
+	// Extract kernel variants from uname tests
+	kernelVariants := make(map[string]struct{})
+	for _, v := range r.UnameTests {
+		for _, s := range v.States {
+			variants := s.ParseKernelVariants()
+			for _, v := range variants {
+				kernelVariants[v] = struct{}{}
+			}
+		}
+	}
+
+	for v := range kernelVariants {
+		r.AddKernelVariant(v)
+	}
+
 	return r, nil
 }

--- a/server/vulnerabilities/oval/parser.go
+++ b/server/vulnerabilities/oval/parser.go
@@ -427,5 +427,66 @@ func mapToUbuntuResult(xmlResult *oval_input.UbuntuResultXML) (*oval_parsed.Ubun
 			}
 		}
 	}
+
+	for _, t := range xmlResult.UnameTests {
+		id, tst, err := mapUnixUnameTest(t)
+		if err != nil {
+			return nil, fmt.Errorf("mapping uname test: %w", err)
+		}
+
+		for _, sta := range t.States {
+			ustaToTst[sta.Id] = append(ustaToTst[sta.Id], id)
+		}
+		r.AddUnameTest(id, tst)
+	}
+
+	for _, s := range xmlResult.UnameStates {
+		sta := mapUnameState(s)
+		for _, tId := range ustaToTst[s.Id] {
+			t, ok := r.UnameTests[tId]
+			if ok {
+				t.States = append(t.States, *sta)
+			} else {
+				return nil, fmt.Errorf("test not found: %d", tId)
+			}
+		}
+	}
+
+	for _, t := range xmlResult.VariableTests {
+		id, tst, err := mapVariableTest(t)
+		if err != nil {
+			return nil, fmt.Errorf("mapping variable test: %w", err)
+		}
+
+		// Skip tests that are not used in any uname test
+		// (there should be none)
+		if obj, ok := xmlResult.VariableObjects[id]; ok {
+			id, err := extractId(obj.RefID)
+			if err != nil {
+				return nil, fmt.Errorf("extracting variable object id: %w", err)
+			}
+			if _, ok := r.UnameTests[id]; !ok {
+				continue
+			}
+		}
+
+		for _, sta := range t.States {
+			vstaToTst[sta.Id] = append(vstaToTst[sta.Id], id)
+		}
+		r.AddUnameTest(id, tst)
+	}
+
+	for _, s := range xmlResult.VariableStates {
+		sta := mapVariableState(s)
+		for _, tId := range vstaToTst[s.Id] {
+			t, ok := r.UnameTests[tId]
+			if ok {
+				t.States = append(t.States, *sta)
+			} else {
+				return nil, fmt.Errorf("test not found: %d", tId)
+			}
+		}
+	}
+
 	return r, nil
 }

--- a/server/vulnerabilities/oval/parser.go
+++ b/server/vulnerabilities/oval/parser.go
@@ -373,6 +373,8 @@ func mapToUbuntuResult(xmlResult *oval_input.UbuntuResultXML) (*oval_parsed.Ubun
 
 	staToTst := make(map[string][]int)
 	objToTst := make(map[string][]int)
+	ustaToTst := make(map[string][]int)
+	vstaToTst := make(map[string][]int)
 
 	for _, d := range xmlResult.Definitions {
 		if len(d.Vulnerabilities) > 0 {


### PR DESCRIPTION
#18053 

Added scanning for custom kernel variants:
- added a known kernel array in the JSON data by parsing uname state rules
- if a kernel is not in the list, it matches vulnerabilities with "generic" variants (ie. `5.15.0-1002-foo` --> `5.15.0-1002-generic`)

- [X] Added/updated tests
- [X] Manual QA for all new/changed functionality