### PR TITLE
Docs: fix broken link

### DIFF
--- a/docs/Using Fleet/MDM-macOS-setup-experience.md
+++ b/docs/Using Fleet/MDM-macOS-setup-experience.md
@@ -182,7 +182,7 @@ To customize the macOS Setup Assistant, we will do the following steps:
 
 ### Step 1: create an automatic enrollment profile
 
-1. Download Fleet's example automatic enrollment profile by navigating to the example [here](fleetdm.com/example-dep-profile) and clicking the download icon.
+1. Download Fleet's example automatic enrollment profile by navigating to the example [here](https://fleetdm.com/example-dep-profile) and clicking the download icon.
 
 2. Open the automatic enrollment profile and replace the `profile_name` key with your organization's name.
 


### PR DESCRIPTION
Changes:
- Fixed a broken link on the "macOS setup experience" docs page.