### PR TITLE
Orbit SOFA user agent

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -246,9 +246,9 @@ binary-bundle: xp-fleet xp-fleetctl
 
 # Build orbit/fleetd fleetd_tables extension
 fleetd-tables-windows:
-	GOOS=windows GOARCH=amd64 go build -o fleetd_tables_windows.exe -ldflags ${LDFLAGS_VERSION} ./orbit/cmd/fleetd_tables
+	GOOS=windows GOARCH=amd64 go build -o fleetd_tables_windows.exe ./orbit/cmd/fleetd_tables
 fleetd-tables-linux:
-	GOOS=linux GOARCH=amd64 go build -o fleetd_tables_linux.ext -ldflags ${LDFLAGS_VERSION} ./orbit/cmd/fleetd_tables
+	GOOS=linux GOARCH=amd64 go build -o fleetd_tables_linux.ext ./orbit/cmd/fleetd_tables
 fleetd-tables-darwin:
 	GOOS=darwin GOARCH=amd64 go build -o fleetd_tables_darwin.ext -ldflags ${LDFLAGS_VERSION} ./orbit/cmd/fleetd_tables
 fleetd-tables-darwin_arm:

--- a/Makefile
+++ b/Makefile
@@ -250,9 +250,9 @@ fleetd-tables-windows:
 fleetd-tables-linux:
 	GOOS=linux GOARCH=amd64 go build -o fleetd_tables_linux.ext ./orbit/cmd/fleetd_tables
 fleetd-tables-darwin:
-	GOOS=darwin GOARCH=amd64 go build -o fleetd_tables_darwin.ext -ldflags ${LDFLAGS_VERSION} ./orbit/cmd/fleetd_tables
+	GOOS=darwin GOARCH=amd64 go build -o fleetd_tables_darwin.ext ./orbit/cmd/fleetd_tables
 fleetd-tables-darwin_arm:
-	GOOS=darwin GOARCH=arm64 CGO_ENABLED=1 go build -o fleetd_tables_darwin_arm.ext -ldflags ${LDFLAGS_VERSION} ./orbit/cmd/fleetd_tables
+	GOOS=darwin GOARCH=arm64 CGO_ENABLED=1 go build -o fleetd_tables_darwin_arm.ext -ldflags ./orbit/cmd/fleetd_tables
 fleetd-tables-darwin-universal: fleetd-tables-darwin fleetd-tables-darwin_arm
 	lipo -create fleetd_tables_darwin.ext fleetd_tables_darwin_arm.ext -output fleetd_tables_darwin_universal.ext
 fleetd-tables-all: fleetd-tables-windows fleetd-tables-linux fleetd-tables-darwin-universal

--- a/Makefile
+++ b/Makefile
@@ -252,7 +252,7 @@ fleetd-tables-linux:
 fleetd-tables-darwin:
 	GOOS=darwin GOARCH=amd64 go build -o fleetd_tables_darwin.ext ./orbit/cmd/fleetd_tables
 fleetd-tables-darwin_arm:
-	GOOS=darwin GOARCH=arm64 CGO_ENABLED=1 go build -o fleetd_tables_darwin_arm.ext -ldflags ./orbit/cmd/fleetd_tables
+	GOOS=darwin GOARCH=arm64 CGO_ENABLED=1 go build -o fleetd_tables_darwin_arm.ext ./orbit/cmd/fleetd_tables
 fleetd-tables-darwin-universal: fleetd-tables-darwin fleetd-tables-darwin_arm
 	lipo -create fleetd_tables_darwin.ext fleetd_tables_darwin_arm.ext -output fleetd_tables_darwin_universal.ext
 fleetd-tables-all: fleetd-tables-windows fleetd-tables-linux fleetd-tables-darwin-universal

--- a/Makefile
+++ b/Makefile
@@ -246,13 +246,13 @@ binary-bundle: xp-fleet xp-fleetctl
 
 # Build orbit/fleetd fleetd_tables extension
 fleetd-tables-windows:
-	GOOS=windows GOARCH=amd64 go build -o fleetd_tables_windows.exe ./orbit/cmd/fleetd_tables
+	GOOS=windows GOARCH=amd64 go build -o fleetd_tables_windows.exe -ldflags ${LDFLAGS_VERSION} ./orbit/cmd/fleetd_tables
 fleetd-tables-linux:
-	GOOS=linux GOARCH=amd64 go build -o fleetd_tables_linux.ext ./orbit/cmd/fleetd_tables
+	GOOS=linux GOARCH=amd64 go build -o fleetd_tables_linux.ext -ldflags ${LDFLAGS_VERSION} ./orbit/cmd/fleetd_tables
 fleetd-tables-darwin:
-	GOOS=darwin GOARCH=amd64 go build -o fleetd_tables_darwin.ext ./orbit/cmd/fleetd_tables
+	GOOS=darwin GOARCH=amd64 go build -o fleetd_tables_darwin.ext -ldflags ${LDFLAGS_VERSION} ./orbit/cmd/fleetd_tables
 fleetd-tables-darwin_arm:
-	GOOS=darwin GOARCH=arm64 CGO_ENABLED=1 go build -o fleetd_tables_darwin_arm.ext ./orbit/cmd/fleetd_tables
+	GOOS=darwin GOARCH=arm64 CGO_ENABLED=1 go build -o fleetd_tables_darwin_arm.ext -ldflags ${LDFLAGS_VERSION} ./orbit/cmd/fleetd_tables
 fleetd-tables-darwin-universal: fleetd-tables-darwin fleetd-tables-darwin_arm
 	lipo -create fleetd_tables_darwin.ext fleetd_tables_darwin_arm.ext -output fleetd_tables_darwin_universal.ext
 fleetd-tables-all: fleetd-tables-windows fleetd-tables-linux fleetd-tables-darwin-universal

--- a/go.mod
+++ b/go.mod
@@ -329,4 +329,4 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-replace github.com/macadmins/osquery-extension => github.com/mostlikelee/osquery-extension v0.0.0-20240530002426-7785d6274f31
+replace github.com/macadmins/osquery-extension => github.com/mostlikelee/osquery-extension v0.0.0-20240530152220-6fe33e03c016

--- a/go.mod
+++ b/go.mod
@@ -65,7 +65,7 @@ require (
 	github.com/kevinburke/go-bindata v3.24.0+incompatible
 	github.com/kolide/launcher v1.0.12
 	github.com/lib/pq v1.10.9
-	github.com/macadmins/osquery-extension v1.1.2
+	github.com/macadmins/osquery-extension v1.1.3-0.20240530154548-05bb97403086
 	github.com/mattermost/xml-roundtrip-validator v0.0.0-20201213122252-bcd7e1b9601e
 	github.com/mattn/go-sqlite3 v1.14.22
 	github.com/micromdm/micromdm v1.9.0
@@ -328,5 +328,3 @@ require (
 	gopkg.in/warnings.v0 v0.1.2 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
-
-replace github.com/macadmins/osquery-extension => github.com/macadmins/osquery-extension v1.1.3-0.20240530154548-05bb97403086

--- a/go.mod
+++ b/go.mod
@@ -65,7 +65,7 @@ require (
 	github.com/kevinburke/go-bindata v3.24.0+incompatible
 	github.com/kolide/launcher v1.0.12
 	github.com/lib/pq v1.10.9
-	github.com/macadmins/osquery-extension v1.0.1
+	github.com/macadmins/osquery-extension v1.1.2
 	github.com/mattermost/xml-roundtrip-validator v0.0.0-20201213122252-bcd7e1b9601e
 	github.com/mattn/go-sqlite3 v1.14.22
 	github.com/micromdm/micromdm v1.9.0
@@ -328,3 +328,5 @@ require (
 	gopkg.in/warnings.v0 v0.1.2 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
+
+replace github.com/macadmins/osquery-extension => github.com/mostlikelee/osquery-extension v0.0.0-20240530002426-7785d6274f31

--- a/go.mod
+++ b/go.mod
@@ -329,4 +329,4 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-replace github.com/macadmins/osquery-extension => github.com/mostlikelee/osquery-extension v0.0.0-20240530152220-6fe33e03c016
+replace github.com/macadmins/osquery-extension => github.com/macadmins/osquery-extension v1.1.3-0.20240530154548-05bb97403086

--- a/go.sum
+++ b/go.sum
@@ -836,6 +836,8 @@ github.com/lib/pq v1.10.9 h1:YXG7RB+JIjhP29X+OtkiDnYaXQwpS4JEWq7dtCCRUEw=
 github.com/lib/pq v1.10.9/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 h1:6E+4a0GO5zZEnZ81pIr0yLvtUWk2if982qA3F3QD6H4=
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0/go.mod h1:zJYVVT2jmtg6P3p1VtQj7WsuWi/y4VnjVBn7F8KPB3I=
+github.com/macadmins/osquery-extension v1.1.3-0.20240530154548-05bb97403086 h1:pom8HjoknG5GF+cqeTP+2sXIn8Tl8Y7cinlPNv0O+LY=
+github.com/macadmins/osquery-extension v1.1.3-0.20240530154548-05bb97403086/go.mod h1:q0BnBuYocHBRB+m3AQwdQNETH5a2KzVT3S8TKMHo9Lk=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/magiconair/properties v1.8.1/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/magiconair/properties v1.8.4/go.mod h1:y3VJvCyxH9uVvJTWEGAELF3aiYNyPKd5NZ3oSwXrF60=
@@ -913,8 +915,6 @@ github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lN
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/morikuni/aec v1.0.0 h1:nP9CBfwrvYnBRgY6qfDQkygYDmYwOilePFkwzv4dU8A=
 github.com/morikuni/aec v1.0.0/go.mod h1:BbKIizmSmc5MMPqRYbxO4ZU0S0+P200+tUnFx7PXmsc=
-github.com/mostlikelee/osquery-extension v0.0.0-20240530152220-6fe33e03c016 h1:GrCJR3EwPAUtWpUtru/l+QUv4TNprdFOUFVJtOdTFR0=
-github.com/mostlikelee/osquery-extension v0.0.0-20240530152220-6fe33e03c016/go.mod h1:q0BnBuYocHBRB+m3AQwdQNETH5a2KzVT3S8TKMHo9Lk=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646 h1:zYyBkD/k9seD2A7fsi6Oo2LfFZAehjjQMERAvZLEDnQ=
 github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646/go.mod h1:jpp1/29i3P1S/RLdc7JQKbRpFeM1dOBd8T9ki5s+AY8=

--- a/go.sum
+++ b/go.sum
@@ -836,8 +836,6 @@ github.com/lib/pq v1.10.9 h1:YXG7RB+JIjhP29X+OtkiDnYaXQwpS4JEWq7dtCCRUEw=
 github.com/lib/pq v1.10.9/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 h1:6E+4a0GO5zZEnZ81pIr0yLvtUWk2if982qA3F3QD6H4=
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0/go.mod h1:zJYVVT2jmtg6P3p1VtQj7WsuWi/y4VnjVBn7F8KPB3I=
-github.com/macadmins/osquery-extension v1.0.1 h1:SW6Vkr4t3scMsjl4vUHgNbL7Fo8CbxE+c5FR+m5fCzo=
-github.com/macadmins/osquery-extension v1.0.1/go.mod h1:q0BnBuYocHBRB+m3AQwdQNETH5a2KzVT3S8TKMHo9Lk=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/magiconair/properties v1.8.1/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/magiconair/properties v1.8.4/go.mod h1:y3VJvCyxH9uVvJTWEGAELF3aiYNyPKd5NZ3oSwXrF60=
@@ -915,6 +913,8 @@ github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lN
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/morikuni/aec v1.0.0 h1:nP9CBfwrvYnBRgY6qfDQkygYDmYwOilePFkwzv4dU8A=
 github.com/morikuni/aec v1.0.0/go.mod h1:BbKIizmSmc5MMPqRYbxO4ZU0S0+P200+tUnFx7PXmsc=
+github.com/mostlikelee/osquery-extension v0.0.0-20240530002426-7785d6274f31 h1:+uGnaOYKM7pJmEdDVx43Hb+8T33BkhAWyyavY7hhJWY=
+github.com/mostlikelee/osquery-extension v0.0.0-20240530002426-7785d6274f31/go.mod h1:q0BnBuYocHBRB+m3AQwdQNETH5a2KzVT3S8TKMHo9Lk=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646 h1:zYyBkD/k9seD2A7fsi6Oo2LfFZAehjjQMERAvZLEDnQ=
 github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646/go.mod h1:jpp1/29i3P1S/RLdc7JQKbRpFeM1dOBd8T9ki5s+AY8=

--- a/go.sum
+++ b/go.sum
@@ -913,8 +913,8 @@ github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lN
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/morikuni/aec v1.0.0 h1:nP9CBfwrvYnBRgY6qfDQkygYDmYwOilePFkwzv4dU8A=
 github.com/morikuni/aec v1.0.0/go.mod h1:BbKIizmSmc5MMPqRYbxO4ZU0S0+P200+tUnFx7PXmsc=
-github.com/mostlikelee/osquery-extension v0.0.0-20240530002426-7785d6274f31 h1:+uGnaOYKM7pJmEdDVx43Hb+8T33BkhAWyyavY7hhJWY=
-github.com/mostlikelee/osquery-extension v0.0.0-20240530002426-7785d6274f31/go.mod h1:q0BnBuYocHBRB+m3AQwdQNETH5a2KzVT3S8TKMHo9Lk=
+github.com/mostlikelee/osquery-extension v0.0.0-20240530152220-6fe33e03c016 h1:GrCJR3EwPAUtWpUtru/l+QUv4TNprdFOUFVJtOdTFR0=
+github.com/mostlikelee/osquery-extension v0.0.0-20240530152220-6fe33e03c016/go.mod h1:q0BnBuYocHBRB+m3AQwdQNETH5a2KzVT3S8TKMHo9Lk=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646 h1:zYyBkD/k9seD2A7fsi6Oo2LfFZAehjjQMERAvZLEDnQ=
 github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646/go.mod h1:jpp1/29i3P1S/RLdc7JQKbRpFeM1dOBd8T9ki5s+AY8=

--- a/orbit/changes/19276-sofa-user-agent
+++ b/orbit/changes/19276-sofa-user-agent
@@ -1,0 +1,1 @@
+HTTP calls from the SOFA macOS tables now identified by a 'fleetd' user agent

--- a/orbit/pkg/table/extension_darwin.go
+++ b/orbit/pkg/table/extension_darwin.go
@@ -5,7 +5,6 @@ package table
 import (
 	"context"
 
-	"github.com/fleetdm/fleet/v4/orbit/pkg/build"
 	"github.com/fleetdm/fleet/v4/orbit/pkg/table/authdb"
 	"github.com/fleetdm/fleet/v4/orbit/pkg/table/csrutil_info"
 	"github.com/fleetdm/fleet/v4/orbit/pkg/table/dataflattentable"
@@ -72,7 +71,7 @@ func PlatformTables(opts PluginOpts) []osquery.OsqueryPlugin {
 		table.NewPlugin(
 			"sofa_security_release_info", sofa.SofaSecurityReleaseInfoColumns(),
 			func(ctx context.Context, queryContext table.QueryContext) ([]map[string]string, error) {
-				return sofa.SofaSecurityReleaseInfoGenerate(ctx, queryContext, opts.Socket, sofa.WithUserAgent("Fleet/"+build.Version))
+				return sofa.SofaSecurityReleaseInfoGenerate(ctx, queryContext, opts.Socket, sofa.WithUserAgent("fleetd"))
 			},
 		),
 		table.NewPlugin(

--- a/orbit/pkg/table/extension_darwin.go
+++ b/orbit/pkg/table/extension_darwin.go
@@ -77,7 +77,7 @@ func PlatformTables(opts PluginOpts) []osquery.OsqueryPlugin {
 		table.NewPlugin(
 			"sofa_unpatched_cves", sofa.SofaUnpatchedCVEsColumns(),
 			func(ctx context.Context, queryContext table.QueryContext) ([]map[string]string, error) {
-				return sofa.SofaUnpatchedCVEsGenerate(ctx, queryContext, opts.Socket)
+				return sofa.SofaUnpatchedCVEsGenerate(ctx, queryContext, opts.Socket, sofa.WithUserAgent("fleetd"))
 			},
 		),
 

--- a/orbit/pkg/table/extension_darwin.go
+++ b/orbit/pkg/table/extension_darwin.go
@@ -4,6 +4,8 @@ package table
 
 import (
 	"context"
+
+	"github.com/fleetdm/fleet/v4/orbit/pkg/build"
 	"github.com/fleetdm/fleet/v4/orbit/pkg/table/authdb"
 	"github.com/fleetdm/fleet/v4/orbit/pkg/table/csrutil_info"
 	"github.com/fleetdm/fleet/v4/orbit/pkg/table/dataflattentable"
@@ -70,7 +72,7 @@ func PlatformTables(opts PluginOpts) []osquery.OsqueryPlugin {
 		table.NewPlugin(
 			"sofa_security_release_info", sofa.SofaSecurityReleaseInfoColumns(),
 			func(ctx context.Context, queryContext table.QueryContext) ([]map[string]string, error) {
-				return sofa.SofaSecurityReleaseInfoGenerate(ctx, queryContext, opts.Socket)
+				return sofa.SofaSecurityReleaseInfoGenerate(ctx, queryContext, opts.Socket, sofa.WithUserAgent("Fleet/"+build.Version))
 			},
 		),
 		table.NewPlugin(


### PR DESCRIPTION
#19276 

Currently awaiting changes on the macadmins repo to support this option.

This passes a "Fleet" user agent string into the SOFA table config so the SOFA maintainers can identify traffic coming from fleetd agents.

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
- [X] Manual QA for all new/changed functionality
