### PR TITLE
Fleet UI: Fix built in label names for select targets page

### DIFF
--- a/changes/19001-builtin-label-names-selecting-targets
+++ b/changes/19001-builtin-label-names-selecting-targets
@@ -1,0 +1,1 @@
+- UI: Fix builtin label names for selecting targets

--- a/frontend/components/LiveQuery/SelectTargets.tsx
+++ b/frontend/components/LiveQuery/SelectTargets.tsx
@@ -75,6 +75,11 @@ const DEBOUNCE_DELAY = 500;
 const STALE_TIME = 60000;
 
 const isLabel = (entity: ISelectTargetsEntity) => "label_type" in entity;
+const isBuiltInLabel = (
+  entity: ISelectTargetsEntity
+): entity is ISelectLabel & { label_type: "builtin" } => {
+  return "label_type" in entity && entity.label_type === "builtin";
+};
 const isAllHosts = (entity: ISelectTargetsEntity) =>
   "label_type" in entity &&
   entity.name === "All Hosts" &&
@@ -101,16 +106,22 @@ const TargetPillSelector = ({
   onClick,
 }: ITargetPillSelectorProps): JSX.Element => {
   const displayText = () => {
-    switch (entity.name) {
-      case "All Hosts":
-        return "All hosts";
-      case "All Linux":
-        return "Linux";
-      case "chrome":
-        return "ChromeOS";
-      default:
-        return entity.name || "Missing display name"; // TODO
+    if (isBuiltInLabel(entity)) {
+      switch (entity.name) {
+        case "All Hosts":
+          return "All hosts";
+        case "All Linux":
+          return "Linux";
+        case "chrome":
+          return "ChromeOS";
+        case "MS Windows":
+          return "Windows";
+        default:
+          return entity.name || "Missing display name"; // TODO
+      }
     }
+
+    return entity.name || "Missing display name"; // TODO
   };
 
   return (


### PR DESCRIPTION
## Issue
Cerra #19001

## Description
- Change built in MS Windows display name to just Windows
- Fix logic that allowed edge cases of teams named "All Hosts", "All Linux", or "chrome", "MS Windows" to accidentally be displayed as "All hosts", "Linux", "ChromeOS" or "Windows"

## Screenshot of fixes
<img width="1060" alt="Screenshot 2024-05-30 at 10 29 10 AM" src="https://github.com/fleetdm/fleet/assets/71795832/7aaf2741-9a24-4f70-aea1-ea75ecd5fa98">


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
- [x] Manual QA for all new/changed functionality

