### PR TITLE
Fleet UI: Fix language and CTA button for controls page for non global admins

### DIFF
--- a/changes/18912-controls-language-and-cta-button-fix
+++ b/changes/18912-controls-language-and-cta-button-fix
@@ -1,0 +1,1 @@
+- UI: Updates to controls page language and hide CTA button for users without access to turn on MDM

--- a/frontend/pages/ManageControlsPage/components/TurnOnMdmMessage/TurnOnMdmMessage.tsx
+++ b/frontend/pages/ManageControlsPage/components/TurnOnMdmMessage/TurnOnMdmMessage.tsx
@@ -1,6 +1,7 @@
-import React from "react";
+import React, { useContext } from "react";
 import PATHS from "router/paths";
 
+import { AppContext } from "context/app";
 import EmptyTable from "components/EmptyTable";
 import Button from "components/buttons/Button";
 import { InjectedRouter } from "react-router";
@@ -12,12 +13,14 @@ interface ITurnOnMdmMessageProps {
 }
 
 const TurnOnMdmMessage = ({ router }: ITurnOnMdmMessageProps) => {
+  const { isGlobalAdmin } = useContext(AppContext);
+
   const onConnectClick = () => {
     router.push(PATHS.ADMIN_INTEGRATIONS_MDM);
   };
 
   const renderConnectButton = () => {
-    return (
+    return isGlobalAdmin ? (
       <Button
         variant="brand"
         onClick={onConnectClick}
@@ -25,13 +28,15 @@ const TurnOnMdmMessage = ({ router }: ITurnOnMdmMessageProps) => {
       >
         Turn on
       </Button>
+    ) : (
+      <></>
     );
   };
 
   return (
     <EmptyTable
       header="Manage your hosts"
-      info="Turn on MDM to change settings on your hosts."
+      info="MDM must be turned on to change settings on your hosts."
       primaryButton={renderConnectButton()}
     />
   );


### PR DESCRIPTION
## Issue
Cerra #18912 

## Description
- Free maintainers do not see CTA button
- Premium team admin and team maintainers do not see CTA button
- Change text copy to be more generic for both global admins with CTA button and users without CTA button

## Screen recording of fix for free maintainers
https://www.loom.com/share/e3468a1f677e4677ba1ad9f9eb879969?sid=25f24d20-af5a-48e2-9cc7-82d4b6fd8871

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
- [x] Manual QA for all new/changed functionality

