### PR TITLE
Live queries work with replication lag.

### DIFF
--- a/changes/19272-live-query-lag
+++ b/changes/19272-live-query-lag
@@ -1,0 +1,1 @@
+Live queries now work via UI with large (~1 second) replication lag (for master-replica DB setup).

--- a/server/service/live_queries.go
+++ b/server/service/live_queries.go
@@ -251,8 +251,6 @@ func (svc *Service) RunLiveQueryDeadline(
 	counterMutex := sync.Mutex{}
 	respondedHostIDs := make(map[uint]struct{})
 
-	fmt.Printf("VICTOR RunLiveQueryDeadline\n")
-
 	for _, queryID := range queryIDs {
 		queryID := queryID
 		wg.Add(1)
@@ -279,8 +277,6 @@ func (svc *Service) RunLiveQueryDeadline(
 			}
 			queryID = campaign.QueryID
 
-			fmt.Printf("VICTOR created compaign\n")
-
 			// We do not want to use the outer `ctx` directly because we want to cleanup the campaign
 			// even if the outer `ctx` is canceled (e.g. a client terminating the connection).
 			// Also, we make sure stats and activity DB operations don't get killed after we return results.
@@ -299,7 +295,6 @@ func (svc *Service) RunLiveQueryDeadline(
 				}
 			}()
 
-			fmt.Printf("VICTOR campaign is %#v\n", campaign)
 			readChan, cancelFunc, err := svc.GetCampaignReader(ctx, campaign)
 			if err != nil {
 				level.Error(svc.logger).Log(
@@ -309,7 +304,6 @@ func (svc *Service) RunLiveQueryDeadline(
 				return
 			}
 			defer cancelFunc()
-			fmt.Printf("VICTOR got campaign reader\n")
 
 			var results []fleet.QueryResult
 			timeout := time.After(deadline)

--- a/server/service/live_queries.go
+++ b/server/service/live_queries.go
@@ -251,6 +251,8 @@ func (svc *Service) RunLiveQueryDeadline(
 	counterMutex := sync.Mutex{}
 	respondedHostIDs := make(map[uint]struct{})
 
+	fmt.Printf("VICTOR RunLiveQueryDeadline\n")
+
 	for _, queryID := range queryIDs {
 		queryID := queryID
 		wg.Add(1)
@@ -277,6 +279,8 @@ func (svc *Service) RunLiveQueryDeadline(
 			}
 			queryID = campaign.QueryID
 
+			fmt.Printf("VICTOR created compaign\n")
+
 			// We do not want to use the outer `ctx` directly because we want to cleanup the campaign
 			// even if the outer `ctx` is canceled (e.g. a client terminating the connection).
 			// Also, we make sure stats and activity DB operations don't get killed after we return results.
@@ -295,6 +299,7 @@ func (svc *Service) RunLiveQueryDeadline(
 				}
 			}()
 
+			fmt.Printf("VICTOR campaign is %#v\n", campaign)
 			readChan, cancelFunc, err := svc.GetCampaignReader(ctx, campaign)
 			if err != nil {
 				level.Error(svc.logger).Log(
@@ -304,6 +309,7 @@ func (svc *Service) RunLiveQueryDeadline(
 				return
 			}
 			defer cancelFunc()
+			fmt.Printf("VICTOR got campaign reader\n")
 
 			var results []fleet.QueryResult
 			timeout := time.After(deadline)

--- a/server/service/service_campaigns.go
+++ b/server/service/service_campaigns.go
@@ -2,6 +2,8 @@ package service
 
 import (
 	"context"
+	"database/sql"
+	"errors"
 	"fmt"
 	"time"
 
@@ -67,10 +69,41 @@ func (svc Service) StreamCampaignResults(ctx context.Context, conn *websocket.Co
 		return
 	}
 
-	// Find the campaign and ensure it is active
-	campaign, err := svc.ds.DistributedQueryCampaign(ctx, campaignID)
-	if err != nil {
-		conn.WriteJSONError(fmt.Sprintf("cannot find campaign for ID %d", campaignID)) //nolint:errcheck
+	// Find the campaign and ensure it is active.
+	// Since we are reading from the replica DB, the campaign may not be found until it is replicated from the master.
+	done := make(chan error, 1)
+	stop := make(chan struct{}, 1)
+	var campaign *fleet.DistributedQueryCampaign
+	go func() {
+		var err error
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				campaign, err = svc.ds.DistributedQueryCampaign(ctx, campaignID)
+				if err != nil {
+					if errors.Is(err, sql.ErrNoRows) {
+						time.Sleep(30 * time.Millisecond) // We see the replication time less than 30 ms in production.
+						continue
+					}
+					done <- err
+					return
+				}
+				done <- nil
+				return
+			}
+		}
+	}()
+	select {
+	case err := <-done:
+		if err != nil {
+			_ = conn.WriteJSONError(fmt.Sprintf("cannot find campaign for ID %d", campaignID)) //nolint:errcheck
+			return
+		}
+	case <-time.After(5 * time.Second):
+		stop <- struct{}{}
+		_ = conn.WriteJSONError(fmt.Sprintf("timeout: cannot find campaign for ID %d", campaignID)) //nolint:errcheck
 		return
 	}
 


### PR DESCRIPTION
#19272
Live queries now work via UI with large (~1 second) replication lag (for master-replica DB setup).

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [ ] Added/updated tests
- [x] Manual QA for all new/changed functionality
