### PR TITLE
use reader for stats

### DIFF
--- a/changes/part-of-19072-use-reader-db-for-stats
+++ b/changes/part-of-19072-use-reader-db-for-stats
@@ -1,0 +1,1 @@
+- Improved db usage when sending statistics

--- a/server/datastore/mysql/statistics.go
+++ b/server/datastore/mysql/statistics.go
@@ -24,47 +24,47 @@ func (ds *Datastore) ShouldSendStatistics(ctx context.Context, frequency time.Du
 	lic, _ := license.FromContext(ctx)
 
 	computeStats := func(stats *fleet.StatisticsPayload, since time.Time) error {
-		enrolledHostsByOS, amountEnrolledHosts, err := amountEnrolledHostsByOSDB(ctx, ds.writer(ctx))
+		enrolledHostsByOS, amountEnrolledHosts, err := amountEnrolledHostsByOSDB(ctx, ds.reader(ctx))
 		if err != nil {
 			return ctxerr.Wrap(ctx, err, "amount enrolled hosts by os")
 		}
-		amountUsers, err := tableRowsCount(ctx, ds.writer(ctx), "users")
+		amountUsers, err := tableRowsCount(ctx, ds.reader(ctx), "users")
 		if err != nil {
 			return ctxerr.Wrap(ctx, err, "amount users")
 		}
-		amountSoftwaresVersions, err := tableRowsCount(ctx, ds.writer(ctx), "software")
+		amountSoftwaresVersions, err := tableRowsCount(ctx, ds.reader(ctx), "software")
 		if err != nil {
 			return ctxerr.Wrap(ctx, err, "amount software")
 		}
-		amountHostSoftwares, err := tableRowsCount(ctx, ds.writer(ctx), "host_software")
+		amountHostSoftwares, err := tableRowsCount(ctx, ds.reader(ctx), "host_software")
 		if err != nil {
 			return ctxerr.Wrap(ctx, err, "amount host_software")
 		}
-		amountSoftwareTitles, err := tableRowsCount(ctx, ds.writer(ctx), "software_titles")
+		amountSoftwareTitles, err := tableRowsCount(ctx, ds.reader(ctx), "software_titles")
 		if err != nil {
 			return ctxerr.Wrap(ctx, err, "amount software_titles")
 		}
-		amountHostSoftwareInstalledPaths, err := tableRowsCount(ctx, ds.writer(ctx), "host_software_installed_paths")
+		amountHostSoftwareInstalledPaths, err := tableRowsCount(ctx, ds.reader(ctx), "host_software_installed_paths")
 		if err != nil {
 			return ctxerr.Wrap(ctx, err, "amount host_software_installed_paths")
 		}
-		amountSoftwareCpes, err := tableRowsCount(ctx, ds.writer(ctx), "software_cpe")
+		amountSoftwareCpes, err := tableRowsCount(ctx, ds.reader(ctx), "software_cpe")
 		if err != nil {
 			return ctxerr.Wrap(ctx, err, "amount software_cpe")
 		}
-		amountSoftwareCves, err := tableRowsCount(ctx, ds.writer(ctx), "software_cve")
+		amountSoftwareCves, err := tableRowsCount(ctx, ds.reader(ctx), "software_cve")
 		if err != nil {
 			return ctxerr.Wrap(ctx, err, "amount software_cve")
 		}
-		amountTeams, err := amountTeamsDB(ctx, ds.writer(ctx))
+		amountTeams, err := amountTeamsDB(ctx, ds.reader(ctx))
 		if err != nil {
 			return ctxerr.Wrap(ctx, err, "amount teams")
 		}
-		amountPolicies, err := amountPoliciesDB(ctx, ds.writer(ctx))
+		amountPolicies, err := amountPoliciesDB(ctx, ds.reader(ctx))
 		if err != nil {
 			return ctxerr.Wrap(ctx, err, "amount policies")
 		}
-		amountLabels, err := amountLabelsDB(ctx, ds.writer(ctx))
+		amountLabels, err := amountLabelsDB(ctx, ds.reader(ctx))
 		if err != nil {
 			return ctxerr.Wrap(ctx, err, "amount labels")
 		}
@@ -72,11 +72,11 @@ func (ds *Datastore) ShouldSendStatistics(ctx context.Context, frequency time.Du
 		if err != nil {
 			return ctxerr.Wrap(ctx, err, "statistics app config")
 		}
-		amountWeeklyUsers, err := amountActiveUsersSinceDB(ctx, ds.writer(ctx), since)
+		amountWeeklyUsers, err := amountActiveUsersSinceDB(ctx, ds.reader(ctx), since)
 		if err != nil {
 			return ctxerr.Wrap(ctx, err, "amount active users")
 		}
-		amountPolicyViolationDaysActual, amountPolicyViolationDaysPossible, err := amountPolicyViolationDaysDB(ctx, ds.writer(ctx))
+		amountPolicyViolationDaysActual, amountPolicyViolationDaysPossible, err := amountPolicyViolationDaysDB(ctx, ds.reader(ctx))
 		if err == sql.ErrNoRows {
 			level.Debug(ds.logger).Log("msg", "amount policy violation days", "err", err) //nolint:errcheck
 		} else if err != nil {
@@ -86,15 +86,15 @@ func (ds *Datastore) ShouldSendStatistics(ctx context.Context, frequency time.Du
 		if err != nil {
 			return ctxerr.Wrap(ctx, err, "statistics error store")
 		}
-		amountHostsNotResponding, err := countHostsNotRespondingDB(ctx, ds.writer(ctx), ds.logger, config)
+		amountHostsNotResponding, err := countHostsNotRespondingDB(ctx, ds.reader(ctx), ds.logger, config)
 		if err != nil {
 			return ctxerr.Wrap(ctx, err, "amount hosts not responding")
 		}
-		amountHostsByOrbitVersion, err := amountHostsByOrbitVersionDB(ctx, ds.writer(ctx))
+		amountHostsByOrbitVersion, err := amountHostsByOrbitVersionDB(ctx, ds.reader(ctx))
 		if err != nil {
 			return ctxerr.Wrap(ctx, err, "amount hosts by orbit version")
 		}
-		amountHostsByOsqueryVersion, err := amountHostsByOsqueryVersionDB(ctx, ds.writer(ctx))
+		amountHostsByOsqueryVersion, err := amountHostsByOsqueryVersionDB(ctx, ds.reader(ctx))
 		if err != nil {
 			return ctxerr.Wrap(ctx, err, "amount hosts by osquery version")
 		}
@@ -134,7 +134,7 @@ func (ds *Datastore) ShouldSendStatistics(ctx context.Context, frequency time.Du
 	}
 
 	dest := statistics{}
-	err := sqlx.GetContext(ctx, ds.writer(ctx), &dest, `SELECT created_at, updated_at, anonymous_identifier FROM statistics LIMIT 1`)
+	err := sqlx.GetContext(ctx, ds.reader(ctx), &dest, `SELECT created_at, updated_at, anonymous_identifier FROM statistics LIMIT 1`)
 	if err != nil {
 		if err == sql.ErrNoRows {
 			anonIdentifier, err := server.GenerateRandomText(64)


### PR DESCRIPTION
# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.



@xpkoala the main things to QA:

- Statistics should be sent by the server to our Heroku service.
- The should be a theoretical small improvement to DB load (using the reader instance instead of the writer). Not sure it will be measureable.