### PR TITLE
Update authdb.yml

### DIFF
--- a/schema/tables/authdb.yml
+++ b/schema/tables/authdb.yml
@@ -1,19 +1,19 @@
 name: authdb
 platforms:
   - darwin
-description: The macOS authorizationdb is used by Mac admins to give their users or themselves granular permissions on the Macs they manage. The `authdb` osquery table returns JSON output for the `authorizationdb read <right_name|-` command.
+description: The macOS authorizationdb is used by Mac admins to give their users or themselves granular permissions on the Macs they manage. The `authdb` osquery table returns JSON output for the `authorizationdb read <right_name>` command.
 evented: false
 columns:
   - name: right_name
     type: text
     required: true
     description: |-
-      The right_name to query in the `authorizationdb read <right_name|-` command.
+      The right_name to query in the `authorizationdb read <right_name>` command.
   - name: json_result
     type: text
     required: false
     description: |-
-      The JSON output parsed from the plist output of the `authorizationdb read <right_name|-` command. 
+      The JSON output parsed from `authorizationdb` plist. 
 example: |-
 
   ```


### PR DESCRIPTION
Fixed copy+paste or find+replace booboo when scalar was changed from >- to |- 

Copy operation caught up the angle brackets used around "right_name" in this doc.

Thanks.