### PR TITLE
Disable Firefox ESR query

### DIFF
--- a/server/service/osquery_test.go
+++ b/server/service/osquery_test.go
@@ -1061,7 +1061,6 @@ func verifyDiscovery(t *testing.T, queries, discovery map[string]string) {
 		hostDetailQueryPrefix + "kubequery_info":             {},
 		hostDetailQueryPrefix + "orbit_info":                 {},
 		hostDetailQueryPrefix + "software_vscode_extensions": {},
-		hostDetailQueryPrefix + "software_macos_firefox":     {},
 	}
 	for name := range queries {
 		require.NotEmpty(t, discovery[name])

--- a/server/service/osquery_utils/queries.go
+++ b/server/service/osquery_utils/queries.go
@@ -2015,9 +2015,13 @@ func GetDetailQueries(
 		generatedMap["software_chrome"] = softwareChrome
 		generatedMap["software_vscode_extensions"] = softwareVSCodeExtensions
 
-		for key, query := range SoftwareOverrideQueries {
-			generatedMap["software_"+key] = query
-		}
+		//
+		// Commenting out until we find root cause of discovery query hanging osquery:
+		// https://github.com/fleetdm/fleet/issues/19401
+		//
+		// for key, query := range SoftwareOverrideQueries {
+		//     generatedMap["software_"+key] = query
+		// }
 	}
 
 	if features != nil && features.EnableHostUsers {

--- a/server/service/osquery_utils/queries_test.go
+++ b/server/service/osquery_utils/queries_test.go
@@ -304,7 +304,7 @@ func TestGetDetailQueries(t *testing.T) {
 	sortedKeysCompare(t, queriesWithUsers, qs)
 
 	queriesWithUsersAndSoftware := GetDetailQueries(context.Background(), config.FleetConfig{App: config.AppConfig{EnableScheduledQueryStats: true}}, nil, &fleet.Features{EnableHostUsers: true, EnableSoftwareInventory: true})
-	qs = append(baseQueries, "users", "users_chrome", "software_macos", "software_linux", "software_windows", "software_vscode_extensions", "software_chrome", "scheduled_query_stats", "software_macos_firefox")
+	qs = append(baseQueries, "users", "users_chrome", "software_macos", "software_linux", "software_windows", "software_vscode_extensions", "software_chrome", "scheduled_query_stats")
 	require.Len(t, queriesWithUsersAndSoftware, len(qs))
 	sortedKeysCompare(t, queriesWithUsersAndSoftware, qs)
 


### PR DESCRIPTION
Quick fix for #19401 to unblock the release of v4.51.0. We should troubleshoot next sprint.