### PR TITLE
UI - add help text to activity feed automations modal

### DIFF
--- a/frontend/pages/DashboardPage/components/ActivityFeedAutomationsModal/ActivityFeedAutomationsModal.tsx
+++ b/frontend/pages/DashboardPage/components/ActivityFeedAutomationsModal/ActivityFeedAutomationsModal.tsx
@@ -11,6 +11,7 @@ import Button from "components/buttons/Button";
 import RevealButton from "components/buttons/RevealButton";
 
 import { syntaxHighlight } from "utilities/helpers";
+import CustomLink from "components/CustomLink";
 
 const baseClass = "activity-feed-automations-modal";
 
@@ -114,6 +115,17 @@ const ActivityFeedAutomationsModal = ({
             }),
           }}
         />
+        <div className="form-field__help-text">
+          To see the data included in each activity, check out the documentation
+          for{" "}
+          {
+            <CustomLink
+              url="https://fleetdm.com/learn-more-about/audit-logs"
+              text="audit logs"
+              newTab
+            />
+          }
+        </div>
       </>
     );
   };


### PR DESCRIPTION
## Follow up for #19052 
<img width="941" alt="Screenshot 2024-05-31 at 10 49 38 AM" src="https://github.com/fleetdm/fleet/assets/61553566/8ace21c0-fc7f-4bea-bff3-80f0afafdf5c">

- [x] Manual QA for all new/changed functionality