### PR TITLE
Fleet UI: Revert small checkboxes to normal size

### DIFF
--- a/frontend/components/forms/fields/Checkbox/Checkbox.tsx
+++ b/frontend/components/forms/fields/Checkbox/Checkbox.tsx
@@ -22,7 +22,6 @@ export interface ICheckboxProps {
   tooltipContent?: React.ReactNode;
   isLeftLabel?: boolean;
   helpText?: React.ReactNode;
-  smallTick?: boolean;
 }
 
 const Checkbox = (props: ICheckboxProps) => {
@@ -40,7 +39,6 @@ const Checkbox = (props: ICheckboxProps) => {
     tooltipContent,
     isLeftLabel,
     helpText,
-    smallTick = false,
   } = props;
 
   const handleChange = () => {
@@ -61,7 +59,6 @@ const Checkbox = (props: ICheckboxProps) => {
   const checkBoxTickClass = classnames(`${baseClass}__tick`, {
     [`${baseClass}__tick--disabled`]: disabled,
     [`${baseClass}__tick--indeterminate`]: indeterminate,
-    [`${baseClass}__tick--small`]: smallTick,
   });
 
   const checkBoxLabelClass = classnames(checkBoxClass, {

--- a/frontend/components/forms/fields/Checkbox/_styles.scss
+++ b/frontend/components/forms/fields/Checkbox/_styles.scss
@@ -88,14 +88,6 @@
       cursor: default;
     }
 
-    &--small {
-      @include size(16px);
-
-      &::after {
-        @include size(16px);
-      }
-    }
-
     &--indeterminate {
       &::after {
         background-color: $core-vibrant-blue;

--- a/frontend/pages/policies/ManagePoliciesPage/components/CalendarEventsModal/CalendarEventsModal.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/components/CalendarEventsModal/CalendarEventsModal.tsx
@@ -197,7 +197,6 @@ const CalendarEventsModal = ({
                   onChange={() => {
                     onPolicyEnabledChange({ name, value: !isChecked });
                   }}
-                  smallTick
                 >
                   {name}
                 </Checkbox>

--- a/frontend/pages/policies/ManagePoliciesPage/components/OtherWorkflowsModal/OtherWorkflowsModal.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/components/OtherWorkflowsModal/OtherWorkflowsModal.tsx
@@ -426,7 +426,6 @@ const OtherWorkflowsModal = ({
                               !isChecked &&
                                 setErrors((errs) => omit(errs, "policyItems"));
                             }}
-                            smallTick
                           >
                             {name}
                           </Checkbox>


### PR DESCRIPTION
## Issue
Cerra #19230 

## Description
- Revert figma design having unintentionally smaller checkboxes for new policy list styling

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Manual QA for all new/changed functionality

