### PR TITLE
change TextCell so that we are rendering '0' value as a number and re…

### DIFF
--- a/changes/issue-19433-render-0-value-as-number
+++ b/changes/issue-19433-render-0-value-as-number
@@ -1,0 +1,1 @@
+- Makes the rendering of empty text cell values consistent. Also render the '0' value as a number instead of the default value `---`.

--- a/frontend/components/TableContainer/DataTable/TextCell/TextCell.tests.tsx
+++ b/frontend/components/TableContainer/DataTable/TextCell/TextCell.tests.tsx
@@ -9,18 +9,33 @@ describe("TextCell", () => {
     expect(screen.getByText("false")).toBeInTheDocument();
   });
 
-  it("renders a default value when `value` is empty", () => {
-    render(<TextCell value="" />);
+  it("renders a default value when `value` is null, undefined, or an empty string", () => {
+    const { rerender } = render(<TextCell value={null} />);
+    expect(screen.getByText(DEFAULT_EMPTY_CELL_VALUE)).toBeInTheDocument();
+    rerender(<TextCell value={undefined} />);
+    expect(screen.getByText(DEFAULT_EMPTY_CELL_VALUE)).toBeInTheDocument();
+    rerender(<TextCell value="" />);
     expect(screen.getByText(DEFAULT_EMPTY_CELL_VALUE)).toBeInTheDocument();
   });
 
-  it("renders a default value when `value` is empty after formatting", () => {
-    render(<TextCell value="foo" formatter={() => ""} />);
+  it("renders a default value when `value` is null, undefined, or an empty string after formatting", () => {
+    const { rerender } = render(
+      <TextCell value="foo" formatter={() => null} />
+    );
+    expect(screen.getByText(DEFAULT_EMPTY_CELL_VALUE)).toBeInTheDocument();
+    rerender(<TextCell value="foo" formatter={() => undefined} />);
+    expect(screen.getByText(DEFAULT_EMPTY_CELL_VALUE)).toBeInTheDocument();
+    rerender(<TextCell value="foo" formatter={() => ""} />);
     expect(screen.getByText(DEFAULT_EMPTY_CELL_VALUE)).toBeInTheDocument();
   });
 
   it("uses the provided formatter function", () => {
     render(<TextCell value="foo" formatter={() => "bar"} />);
     expect(screen.getByText("bar")).toBeInTheDocument();
+  });
+
+  it("renders the value '0' as a number", () => {
+    render(<TextCell value={0} />);
+    expect(screen.getByText("0")).toBeInTheDocument();
   });
 });

--- a/frontend/components/TableContainer/DataTable/TextCell/TextCell.tsx
+++ b/frontend/components/TableContainer/DataTable/TextCell/TextCell.tsx
@@ -7,6 +7,10 @@ import { DEFAULT_EMPTY_CELL_VALUE } from "utilities/constants";
 interface ITextCellProps {
   value?: string | number | boolean | { timeString: string } | null;
   formatter?: (val: any) => React.ReactNode; // string, number, or null
+  /** adds a greyed styling to the cell. This will italicise and add a grey
+   * color to the cell text.
+   * @default false
+   */
   greyed?: boolean;
   classes?: string;
   emptyCellTooltipText?: React.ReactNode;
@@ -15,16 +19,30 @@ interface ITextCellProps {
 const TextCell = ({
   value,
   formatter = (val) => val, // identity function if no formatter is provided
-  greyed,
+  greyed = false,
   classes = "w250",
   emptyCellTooltipText,
-}: ITextCellProps): JSX.Element => {
+}: ITextCellProps) => {
   let val = value;
 
+  // we want to render booleans as strings.
   if (typeof value === "boolean") {
     val = value.toString();
   }
-  if (!val) {
+
+  const formattedValue = formatter(val);
+
+  // Check if the give value is empty or if the formatted value is empty.
+  // 'empty' is defined as null, undefined, or an empty string.
+  const isEmptyValue =
+    value === null ||
+    value === undefined ||
+    value === "" ||
+    formattedValue === null ||
+    formattedValue === undefined ||
+    formattedValue === "";
+
+  if (isEmptyValue) {
     greyed = true;
   }
 
@@ -50,9 +68,11 @@ const TextCell = ({
     return DEFAULT_EMPTY_CELL_VALUE;
   };
 
+  const cellText = isEmptyValue ? renderEmptyCell() : formattedValue;
+
   return (
     <span className={`text-cell ${classes} ${greyed ? "grey-cell" : ""}`}>
-      {formatter(val) || renderEmptyCell()}
+      {cellText}
     </span>
   );
 };

--- a/frontend/components/TableContainer/DataTable/TextCell/TextCell.tsx
+++ b/frontend/components/TableContainer/DataTable/TextCell/TextCell.tsx
@@ -32,7 +32,7 @@ const TextCell = ({
 
   const formattedValue = formatter(val);
 
-  // Check if the give value is empty or if the formatted value is empty.
+  // Check if the given value is empty or if the formatted value is empty.
   // 'empty' is defined as null, undefined, or an empty string.
   const isEmptyValue =
     value === null ||

--- a/frontend/pages/ManageControlsPage/OSSettings/cards/DiskEncryption/components/DiskEncryptionTable/DiskEncryptionTableConfig.tsx
+++ b/frontend/pages/ManageControlsPage/OSSettings/cards/DiskEncryption/components/DiskEncryptionTable/DiskEncryptionTableConfig.tsx
@@ -89,7 +89,7 @@ const defaultTableHeaders: IDataColumn[] = [
     Cell: ({ cell: { value: aggregateCount } }: ICellProps) => {
       return (
         <div className="disk-encryption-table__aggregate-table-data">
-          <TextCell value={aggregateCount} formatter={(val) => <>{val}</>} />
+          <TextCell value={aggregateCount} />
         </div>
       );
     },
@@ -106,9 +106,7 @@ const defaultTableHeaders: IDataColumn[] = [
     disableSortBy: true,
     accessor: "windowsHosts",
     Cell: ({ cell: { value: aggregateCount } }: ICellProps) => {
-      return (
-        <TextCell value={aggregateCount} formatter={(val) => <>{val}</>} />
-      );
+      return <TextCell value={aggregateCount} />;
     },
   },
   {


### PR DESCRIPTION
relates to #19433

Makes the rendering of empty text cell values consistent. We also want to render the '0' value as a number instead of the default value `---` with greyed styles.

**Before:**

![image](https://github.com/fleetdm/fleet/assets/1153709/7c0ecb99-409d-4698-bb6f-083245fb3919)

**After:**

![image](https://github.com/fleetdm/fleet/assets/1153709/d7da74a7-3492-4672-98ea-f810dc0038d7)

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
- [x] Added/updated tests
- [x] Manual QA for all new/changed functionality
