### PR TITLE
[bug fix] Fleet UI: Activity readable without public IP

### DIFF
--- a/changes/19184-activity-human-readable
+++ b/changes/19184-activity-human-readable
@@ -1,0 +1,1 @@
+- Fix activity without public IP to be human readable

--- a/frontend/pages/DashboardPage/cards/ActivityFeed/ActivityItem/ActivityItem.tests.tsx
+++ b/frontend/pages/DashboardPage/cards/ActivityFeed/ActivityItem/ActivityItem.tests.tsx
@@ -262,7 +262,7 @@ describe("Activity Feed", () => {
   it("renders a user_logged_in type activity without public IP", () => {
     const activity = createMockActivity({
       type: ActivityType.UserLoggedIn,
-      details: { public_ip: undefined },
+      details: {},
     });
     render(<ActivityItem activity={activity} isPremiumTier />);
 

--- a/frontend/pages/DashboardPage/cards/ActivityFeed/ActivityItem/ActivityItem.tests.tsx
+++ b/frontend/pages/DashboardPage/cards/ActivityFeed/ActivityItem/ActivityItem.tests.tsx
@@ -259,6 +259,15 @@ describe("Activity Feed", () => {
       screen.getByText("successfully logged in from public IP 192.168.0.1.")
     ).toBeInTheDocument();
   });
+  it("renders a user_logged_in type activity without public IP", () => {
+    const activity = createMockActivity({
+      type: ActivityType.UserLoggedIn,
+      details: { public_ip: undefined },
+    });
+    render(<ActivityItem activity={activity} isPremiumTier />);
+
+    expect(screen.getByText("successfully logged in.")).toBeInTheDocument();
+  });
 
   it("renders a user_failed_login type activity globally", () => {
     const activity = createMockActivity({

--- a/frontend/pages/DashboardPage/cards/ActivityFeed/ActivityItem/ActivityItem.tsx
+++ b/frontend/pages/DashboardPage/cards/ActivityFeed/ActivityItem/ActivityItem.tsx
@@ -182,7 +182,14 @@ const TAGGED_TEMPLATES = {
     return "was added to Fleet by SSO.";
   },
   userLoggedIn: (activity: IActivity) => {
-    return `successfully logged in from public IP ${activity.details?.public_ip}.`;
+    return (
+      <>
+        successfully logged in
+        {activity.details?.public_ip &&
+          ` from public IP ${activity.details?.public_ip}`}
+        .
+      </>
+    );
   },
   userFailedLogin: (activity: IActivity) => {
     return (


### PR DESCRIPTION
## Issue 
Cerra #19184 

## Description
- Fix: Log in activity reads well even when public IP address is missing
- Added test

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
- [x] Added/updated tests
- [x] Manual QA for all new/changed functionality

