### PR TITLE
Fleet server private key

### DIFF
--- a/infrastructure/dogfood/terraform/aws-tf-module/free.tf
+++ b/infrastructure/dogfood/terraform/aws-tf-module/free.tf
@@ -77,7 +77,7 @@ module "free" {
     }
     extra_iam_policies          = module.ses-free.fleet_extra_iam_policies
     extra_environment_variables = merge(module.ses-free.fleet_extra_environment_variables, local.extra_environment_variables_free, module.geolite2.extra_environment_variables)
-    private_key_secret_name = "${local.customer_free}-fleet-server-private-key"
+    private_key_secret_name     = "${local.customer_free}-fleet-server-private-key"
   }
   alb_config = {
     name            = local.customer_free

--- a/infrastructure/dogfood/terraform/aws-tf-module/free.tf
+++ b/infrastructure/dogfood/terraform/aws-tf-module/free.tf
@@ -15,7 +15,7 @@ locals {
 }
 
 module "free" {
-  source = "github.com/fleetdm/fleet//terraform/byo-vpc?ref=tf-mod-byo-vpc-v1.8.1"
+  source = "github.com/fleetdm/fleet//terraform/byo-vpc?ref=tf-mod-byo-vpc-v1.9.0"
   vpc_config = {
     name   = local.customer_free
     vpc_id = module.main.vpc.vpc_id

--- a/infrastructure/dogfood/terraform/aws-tf-module/free.tf
+++ b/infrastructure/dogfood/terraform/aws-tf-module/free.tf
@@ -77,6 +77,7 @@ module "free" {
     }
     extra_iam_policies          = module.ses-free.fleet_extra_iam_policies
     extra_environment_variables = merge(module.ses-free.fleet_extra_environment_variables, local.extra_environment_variables_free, module.geolite2.extra_environment_variables)
+    private_key_secret_name = "${local.customer_free}-fleet-server-private-key"
   }
   alb_config = {
     name            = local.customer_free

--- a/infrastructure/dogfood/terraform/aws-tf-module/main.tf
+++ b/infrastructure/dogfood/terraform/aws-tf-module/main.tf
@@ -126,6 +126,7 @@ module "main" {
       module.vuln-processing.extra_environment_variables
     )
     extra_secrets = merge(module.mdm.extra_secrets, local.sentry_secrets)
+    private_key_secret_name = "${local.customer}-fleet-server-private-key"
     # extra_load_balancers         = [{
     #   target_group_arn = module.saml_auth_proxy.lb_target_group_arn
     #   container_name   = "fleet"

--- a/infrastructure/dogfood/terraform/aws-tf-module/main.tf
+++ b/infrastructure/dogfood/terraform/aws-tf-module/main.tf
@@ -63,7 +63,7 @@ locals {
 }
 
 module "main" {
-  source          = "github.com/fleetdm/fleet//terraform?ref=tf-mod-root-v1.7.1"
+  source          = "github.com/fleetdm/fleet//terraform?ref=tf-mod-root-v1.8.0"
   certificate_arn = module.acm.acm_certificate_arn
   vpc = {
     name = local.customer
@@ -448,13 +448,14 @@ module "geolite2" {
 }
 
 module "vuln-processing" {
-  source                 = "github.com/fleetdm/fleet//terraform/addons/external-vuln-scans?ref=tf-mod-addon-external-vuln-scans-v2.0.2"
-  ecs_cluster            = module.main.byo-vpc.byo-db.byo-ecs.service.cluster
-  execution_iam_role_arn = module.main.byo-vpc.byo-db.byo-ecs.execution_iam_role_arn
-  subnets                = module.main.byo-vpc.byo-db.byo-ecs.service.network_configuration[0].subnets
-  security_groups        = module.main.byo-vpc.byo-db.byo-ecs.service.network_configuration[0].security_groups
-  fleet_config           = module.main.byo-vpc.byo-db.byo-ecs.fleet_config
-  task_role_arn          = module.main.byo-vpc.byo-db.byo-ecs.iam_role_arn
+  source                              = "github.com/fleetdm/fleet//terraform/addons/external-vuln-scans?ref=tf-mod-addon-external-vuln-scans-v2.1.0"
+  ecs_cluster                         = module.main.byo-vpc.byo-db.byo-ecs.service.cluster
+  execution_iam_role_arn              = module.main.byo-vpc.byo-db.byo-ecs.execution_iam_role_arn
+  subnets                             = module.main.byo-vpc.byo-db.byo-ecs.service.network_configuration[0].subnets
+  security_groups                     = module.main.byo-vpc.byo-db.byo-ecs.service.network_configuration[0].security_groups
+  fleet_config                        = module.main.byo-vpc.byo-db.byo-ecs.fleet_config
+  task_role_arn                       = module.main.byo-vpc.byo-db.byo-ecs.iam_role_arn
+  fleet_server_private_key_secret_arn = module.main.byo-vpc.byo-db.byo-ecs.fleet_server_private_key_secret_arn
   awslogs_config = {
     group  = module.main.byo-vpc.byo-db.byo-ecs.fleet_config.awslogs.name
     region = module.main.byo-vpc.byo-db.byo-ecs.fleet_config.awslogs.region

--- a/infrastructure/dogfood/terraform/aws-tf-module/main.tf
+++ b/infrastructure/dogfood/terraform/aws-tf-module/main.tf
@@ -125,7 +125,7 @@ module "main" {
       module.geolite2.extra_environment_variables,
       module.vuln-processing.extra_environment_variables
     )
-    extra_secrets = merge(module.mdm.extra_secrets, local.sentry_secrets)
+    extra_secrets           = merge(module.mdm.extra_secrets, local.sentry_secrets)
     private_key_secret_name = "${local.customer}-fleet-server-private-key"
     # extra_load_balancers         = [{
     #   target_group_arn = module.saml_auth_proxy.lb_target_group_arn

--- a/infrastructure/loadtesting/terraform/ecs-iam.tf
+++ b/infrastructure/loadtesting/terraform/ecs-iam.tf
@@ -8,7 +8,7 @@ data "aws_iam_policy_document" "fleet" {
   statement {
     effect    = "Allow"
     actions   = ["secretsmanager:GetSecretValue"]
-    resources = [aws_secretsmanager_secret.database_password_secret.arn, data.aws_secretsmanager_secret.license.arn]
+    resources = [aws_secretsmanager_secret.database_password_secret.arn, data.aws_secretsmanager_secret.license.arn, aws_secretsmanager_secret.fleet_server_private_key.arn]
   }
 
   // useful when there is a static number of mysql cluster members

--- a/infrastructure/loadtesting/terraform/ecs.tf
+++ b/infrastructure/loadtesting/terraform/ecs.tf
@@ -125,6 +125,10 @@ resource "aws_ecs_task_definition" "backend" {
           {
             name      = "FLEET_LICENSE_KEY"
             valueFrom = data.aws_secretsmanager_secret.license.arn
+          },
+          {
+            name      = "FLEET_SERVER_PRIVATE_KEY"
+            valueFrom = aws_secretsmanager_secret.fleet_server_private_key.arn
           }
         ]
         environment = concat([
@@ -321,3 +325,22 @@ resource "aws_appautoscaling_policy" "ecs_policy_cpu" {
     target_value = 90
   }
 }
+
+resource "random_password" "fleet_server_private_key" {
+  length  = 32
+  special = true
+} 
+    
+resource "aws_secretsmanager_secret" "fleet_server_private_key" { 
+  name = var.fleet_config.private_key_secret_name
+
+  recovery_window_in_days = "0"
+  lifecycle {
+    create_before_destroy = true
+  }
+} 
+  
+resource "aws_secretsmanager_secret_version" "fleet_server_private_key" {
+  secret_id     = aws_secretsmanager_secret.fleet_server_private_key.id
+  secret_string = random_password.fleet_server_private_key.result
+} 

--- a/infrastructure/loadtesting/terraform/ecs.tf
+++ b/infrastructure/loadtesting/terraform/ecs.tf
@@ -332,7 +332,7 @@ resource "random_password" "fleet_server_private_key" {
 } 
     
 resource "aws_secretsmanager_secret" "fleet_server_private_key" { 
-  name = var.fleet_config.private_key_secret_name
+  name = "${terraform.workspace}-fleet-server-private-key"
 
   recovery_window_in_days = "0"
   lifecycle {


### PR DESCRIPTION
This is needed to support the latest release in loadtesting and dogfood.

We should merge prior to release so that we can properly deploy pre-releases to these environments.