### PR TITLE
Website: clear UTM parameters

### DIFF
--- a/website/views/layouts/layout.ejs
+++ b/website/views/layouts/layout.ejs
@@ -634,6 +634,12 @@
     $(function() {
       $('[data-hide-until-rendered]').removeClass('invisible'); // Note: invisible is a bootstrap 4 class
     });
+    $(function() {
+      if (window.location.search && window.location.search.includes('utm_content')) {
+        let url = window.location.protocol + '//' + window.location.host + window.location.pathname;
+        window.history.replaceState({ path: url }, '', url);
+      }
+    });
     <%/* Adding hover events to header dropdown menus*/%>
     $(function(){
       $('[purpose=dropdown-button]').hover(

--- a/website/views/layouts/layout.ejs
+++ b/website/views/layouts/layout.ejs
@@ -635,9 +635,10 @@
       $('[data-hide-until-rendered]').removeClass('invisible'); // Note: invisible is a bootstrap 4 class
     });
     $(function() {
+      // Clean up URLs that contain UTM parameters
       if (window.location.search && window.location.search.includes('utm_content')) {
-        let url = window.location.protocol + '//' + window.location.host + window.location.pathname;
-        window.history.replaceState({ path: url }, '', url);
+        let queryParameterLessUrl = window.location.protocol + '//' + window.location.host + window.location.pathname + window.location.hash;
+        window.history.replaceState({}, '', queryParameterLessUrl);
       }
     });
     <%/* Adding hover events to header dropdown menus*/%>

--- a/website/views/layouts/layout.ejs
+++ b/website/views/layouts/layout.ejs
@@ -638,7 +638,7 @@
       // Clean up URLs that contain UTM parameters
       if (window.location.search && window.location.search.includes('utm_content')) {
         let queryParameterLessUrl = window.location.protocol + '//' + window.location.host + window.location.pathname + window.location.hash;
-        window.history.replaceState({}, '', queryParameterLessUrl);
+        window.history.replaceState({}, '', queryParameterLessUrl);// https://caniuse.com/mdn-api_history_replacestate
       }
     });
     <%/* Adding hover events to header dropdown menus*/%>


### PR DESCRIPTION
Closes: #19428

Changes:
- Updated the website to strip query parameters from URLs that contain a `utm_content` query parameter.