### PR TITLE
Fleet UI: Host details page > policies improvements

### DIFF
--- a/changes/conf-6385-host-policy-table-fixes
+++ b/changes/conf-6385-host-policy-table-fixes
@@ -1,0 +1,1 @@
+- Host policy table can be sortable by response and View all host link preserves the team

--- a/frontend/pages/hosts/details/DeviceUserPage/DeviceUserPage.tsx
+++ b/frontend/pages/hosts/details/DeviceUserPage/DeviceUserPage.tsx
@@ -436,6 +436,7 @@ const DeviceUserPage = ({
                       deviceUser
                       togglePolicyDetailsModal={togglePolicyDetailsModal}
                       hostPlatform={host?.platform || ""}
+                      router={router}
                     />
                   </TabPanel>
                 )}

--- a/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
@@ -903,6 +903,8 @@ const HostDetailsPage = ({
                 isLoading={isLoadingHost}
                 togglePolicyDetailsModal={togglePolicyDetailsModal}
                 hostPlatform={host.platform}
+                router={router}
+                currentTeamId={currentTeam?.id}
               />
             </TabPanel>
           </Tabs>

--- a/frontend/pages/hosts/details/cards/Policies/HostPolicies.tsx
+++ b/frontend/pages/hosts/details/cards/Policies/HostPolicies.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback } from "react";
 import { InjectedRouter } from "react-router";
 import { Row } from "react-table";
+import { noop } from "lodash";
 
 import { IHostPolicy } from "interfaces/policy";
 import { PolicyResponse, SUPPORT_LINK } from "utilities/constants";
@@ -124,9 +125,9 @@ const Policies = ({
           showMarkAllPages={false}
           isAllPagesSelected={false}
           disableCount
-          disableMultiRowSelect
+          disableMultiRowSelect={!deviceUser} // Removes hover/click state if deviceUser
           isClientSidePagination
-          onClickRow={onClickRow}
+          onClickRow={deviceUser ? noop : onClickRow}
         />
       </>
     );

--- a/frontend/pages/hosts/details/cards/Policies/HostPoliciesTable/HostPoliciesTableConfig.tsx
+++ b/frontend/pages/hosts/details/cards/Policies/HostPoliciesTable/HostPoliciesTableConfig.tsx
@@ -1,8 +1,11 @@
 import React from "react";
-import StatusIndicatorWithIcon from "components/StatusIndicatorWithIcon";
-import Button from "components/buttons/Button";
+
 import { IHostPolicy } from "interfaces/policy";
 import { PolicyResponse, DEFAULT_EMPTY_CELL_VALUE } from "utilities/constants";
+
+import StatusIndicatorWithIcon from "components/StatusIndicatorWithIcon";
+import Button from "components/buttons/Button";
+import HeaderCell from "components/TableContainer/DataTable/HeaderCell";
 import ViewAllHostsLink from "components/ViewAllHostsLink";
 import { IndicatorStatus } from "components/StatusIndicatorWithIcon/StatusIndicatorWithIcon";
 
@@ -42,7 +45,8 @@ interface IDataColumn {
 // NOTE: cellProps come from react-table
 // more info here https://react-table.tanstack.com/docs/api/useTable#cell-properties
 const generatePolicyTableHeaders = (
-  togglePolicyDetails: (policy: IHostPolicy, teamId?: number) => void
+  togglePolicyDetails: (policy: IHostPolicy, teamId?: number) => void,
+  currentTeamId?: number
 ): IDataColumn[] => {
   const STATUS_CELL_VALUES: Record<PolicyStatus, IStatusCellValue> = {
     pass: {
@@ -80,9 +84,15 @@ const generatePolicyTableHeaders = (
     },
     {
       title: "Status",
-      Header: "Status",
+      Header: (cellProps) => (
+        <HeaderCell
+          value={cellProps.column.title}
+          isSortedDesc={cellProps.column.isSortedDesc}
+        />
+      ),
+      disableSortBy: false,
+      sortType: "caseInsensitive",
       accessor: "response",
-      disableSortBy: true,
       Cell: (cellProps) => {
         if (cellProps.row.original.response === "") {
           return <>{DEFAULT_EMPTY_CELL_VALUE}</>;
@@ -114,6 +124,7 @@ const generatePolicyTableHeaders = (
                     cellProps.row.original.response === "pass"
                       ? PolicyResponse.PASSING
                       : PolicyResponse.FAILING,
+                  team_id: currentTeamId,
                 }}
                 className="policy-link"
               />

--- a/frontend/pages/hosts/details/cards/Policies/HostPoliciesTable/HostPoliciesTableConfig.tsx
+++ b/frontend/pages/hosts/details/cards/Policies/HostPoliciesTable/HostPoliciesTableConfig.tsx
@@ -69,12 +69,17 @@ const generatePolicyTableHeaders = (
       disableSortBy: true,
       Cell: (cellProps) => {
         const { name } = cellProps.row.original;
+
+        const onClickPolicyName = (e: React.MouseEvent) => {
+          // Allows for button to be clickable in a clickable row
+          e.stopPropagation();
+          togglePolicyDetails(cellProps.row.original);
+        };
+
         return (
           <Button
             className="policy-info"
-            onClick={() => {
-              togglePolicyDetails(cellProps.row.original);
-            }}
+            onClick={onClickPolicyName}
             variant="text-icon"
           >
             <span className={`policy-info-text`}>{name}</span>

--- a/frontend/pages/policies/ManagePoliciesPage/components/PoliciesTable/PoliciesTableConfig.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/components/PoliciesTable/PoliciesTableConfig.tsx
@@ -17,7 +17,7 @@ import { IPolicyStats } from "interfaces/policy";
 import PATHS from "router/paths";
 import sortUtils from "utilities/sort";
 import { PolicyResponse } from "utilities/constants";
-import { buildQueryStringFromParams } from "utilities/url";
+import { createHostsByPolicyPath } from "utilities/helpers";
 import InheritedBadge from "components/InheritedBadge";
 import { getConditionalSelectHeaderCheckboxProps } from "components/TableContainer/utilities/config_utils";
 import PassingColumnHeader from "../PassingColumnHeader";
@@ -59,18 +59,6 @@ interface IDataColumn {
   disableSortBy?: boolean;
   sortType?: string;
 }
-
-const createHostsByPolicyPath = (
-  policyId: number,
-  policyResponse: PolicyResponse,
-  teamId?: number | null
-) => {
-  return `${PATHS.MANAGE_HOSTS}?${buildQueryStringFromParams({
-    policy_id: policyId,
-    policy_response: policyResponse,
-    team_id: teamId,
-  })}`;
-};
 
 const getPolicyRefreshTime = (ms: number): string => {
   const seconds = ms / 1000;

--- a/frontend/utilities/helpers.tsx
+++ b/frontend/utilities/helpers.tsx
@@ -19,7 +19,6 @@ import {
   intlFormat,
   intervalToDuration,
   isAfter,
-  isBefore,
   addDays,
 } from "date-fns";
 import yaml from "js-yaml";
@@ -41,6 +40,7 @@ import {
 import { ITeam } from "interfaces/team";
 import { UserRole } from "interfaces/user";
 
+import PATHS from "router/paths";
 import stringUtils from "utilities/strings";
 import sortUtils from "utilities/sort";
 import { checkTable } from "utilities/sql_tools";
@@ -54,6 +54,7 @@ import {
   INITIAL_FLEET_DATE,
   PLATFORM_LABEL_DISPLAY_TYPES,
   isPlatformLabelNameFromAPI,
+  PolicyResponse,
 } from "utilities/constants";
 import { ISchedulableQueryStats } from "interfaces/schedulable_query";
 import { IDropdownOption } from "interfaces/dropdownOption";
@@ -89,6 +90,18 @@ export const addGravatarUrlToResource = (resource: any): any => {
     gravatar_url,
     gravatar_url_dark,
   };
+};
+
+export const createHostsByPolicyPath = (
+  policyId: number,
+  policyResponse: PolicyResponse,
+  teamId?: number | null
+) => {
+  return `${PATHS.MANAGE_HOSTS}?${buildQueryStringFromParams({
+    policy_id: policyId,
+    policy_response: policyResponse,
+    team_id: teamId,
+  })}`;
 };
 
 const labelSlug = (label: ILabel): string => {
@@ -965,6 +978,7 @@ export function getCustomDropdownOptions(
 
 export default {
   addGravatarUrlToResource,
+  createHostsByPolicyPath,
   formatConfigDataForServer,
   formatLabelResponse,
   formatFloatAsPercentage,


### PR DESCRIPTION
## Issue
Cerra confidential 6395

## Description
- Bug fix: Response column is sortable
- Bug fix: Add clientside pagination to policies over length 20 to match other host details tables instead of a really big table
- Bug fix: View all host link preserves correct team
- Bug fix: Rows look clickable are now clickable and go to the view all host link, while still preserving clicking on a policy name to see the resolution
- Bug fix: Device user row is not clickable so remove styling so it doesn't look clickable

## Screenrecording of updates
https://www.loom.com/share/ed3eec6e7d0c4b54bd27a2ad2a5706f7?sid=85ea5e5a-2d17-4bfb-b7e8-72e85ca31503

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
- [x] Manual QA for all new/changed functionality
