### PR TITLE
App OS Vulnerability Matching

### DIFF
--- a/changes/148940-app-os-vuln-matching
+++ b/changes/148940-app-os-vuln-matching
@@ -1,0 +1,1 @@
+- Fleet now matches vulnerabilies for applications that include an OS scope [example](https://nvd.nist.gov/vuln/detail/CVE-2023-0400)

--- a/server/vulnerabilities/nvd/cve_test.go
+++ b/server/vulnerabilities/nvd/cve_test.go
@@ -306,6 +306,12 @@ func TestTranslateCPEToCVE(t *testing.T) {
 			},
 			continuesToUpdate: false,
 		},
+		"cpe:2.3:a:adobe:animate:*:*:*:*:*:macos:*:*": {
+			includedCVEs: []cve{
+				{ID: "CVE-2023-44325"},
+			},
+			continuesToUpdate: true,
+		},
 	}
 
 	cveOSTests := []struct {

--- a/server/vulnerabilities/nvd/tools/cvefeed/matching_json_test.go
+++ b/server/vulnerabilities/nvd/tools/cvefeed/matching_json_test.go
@@ -112,6 +112,36 @@ func TestMatchJSON(t *testing.T) {
 	}
 }
 
+func TestTargetSWMatching(t *testing.T) {
+	inventoryAcrobat := []*wfn.Attributes{
+		{Part: "a", Vendor: "adobe", Product: "acrobat", Version: "20\\.001\\.3005", TargetSW: "macos"},
+	}
+
+	items, err := ParseJSON(bytes.NewBufferString(targetSWMatchingJSON))
+	if err != nil {
+		t.Fatalf("failed to parse the dictionary: %v", err)
+	}
+	// matches OS on targetSW
+	if mm := items[0].Match(inventoryAcrobat, true); len(mm) == 0 {
+		t.Fatal("expected Match to match, it did not")
+	}
+
+	// does not match OS on targetSW
+	if mm := items[1].Match(inventoryAcrobat, true); len(mm) != 0 {
+		t.Fatal("expected Match to not match, it did")
+	}
+
+	// matches when OS is not present
+	if mm := items[2].Match(inventoryAcrobat, true); len(mm) == 0 {
+		t.Fatal("expected Match to match, it did not")
+	}
+
+	//does not match OS on targetSW with multiple nodes
+	if mm := items[3].Match(inventoryAcrobat, true); len(mm) != 0 {
+		t.Fatal("expected Match to not match, it did")
+	}
+}
+
 func TestMatchJSONrequireVersion(t *testing.T) {
 	inventory := []*wfn.Attributes{
 		{Part: "a", Vendor: "microsoft", Product: "ie", Version: "6\\.0"},
@@ -281,6 +311,200 @@ var testJSONdict = `{
     }
   }
 ] }`
+
+var targetSWMatchingJSON = `{
+	"CVE_data_type" : "CVE",
+	"CVE_data_format" : "MITRE",
+	"CVE_data_version" : "4.0",
+	"CVE_data_numberOfCVEs" : "7083",
+	"CVE_data_timestamp" : "2018-07-31T07:00Z",
+	"CVE_Items" : [ {
+		"cve" : {
+			"data_type" : "CVE",
+			"data_format" : "MITRE",
+			"data_version" : "4.0",
+			"CVE_data_meta" : {
+				"ID" : "CVE-2023-26369",
+				"ASSIGNER" : "psirt@adobe.com"
+			}
+			},
+			"configurations" : {
+			"CVE_data_version" : "4.0",
+			"nodes" : [ {
+				"operator" : "AND",
+				"children" : [ {
+				"operator" : "OR",
+				"children" : [ ],
+				"cpe_match" : [ {
+					"vulnerable" : true,
+					"cpe23Uri" : "cpe:2.3:a:adobe:acrobat:*:*:*:*:classic:*:*:*",
+					"versionStartIncluding" : "20.001.3005",
+					"versionEndExcluding" : "20.005.30524",
+					"cpe_name" : [ ]
+				}, {
+					"vulnerable" : true,
+					"cpe23Uri" : "cpe:2.3:a:adobe:acrobat_dc:*:*:*:*:continuous:*:*:*",
+					"versionStartIncluding" : "15.007.20033",
+					"versionEndExcluding" : "23.006.20320",
+					"cpe_name" : [ ]
+				}, {
+					"vulnerable" : true,
+					"cpe23Uri" : "cpe:2.3:a:adobe:acrobat_reader:*:*:*:*:classic:*:*:*",
+					"versionStartIncluding" : "20.001.3005",
+					"versionEndExcluding" : "20.005.30524",
+					"cpe_name" : [ ]
+				}, {
+					"vulnerable" : true,
+					"cpe23Uri" : "cpe:2.3:a:adobe:acrobat_reader_dc:*:*:*:*:continuous:*:*:*",
+					"versionStartIncluding" : "15.007.20033",
+					"versionEndExcluding" : "23.006.20320",
+					"cpe_name" : [ ]
+				} ]
+				}, {
+				"operator" : "OR",
+				"children" : [ ],
+				"cpe_match" : [ {
+					"vulnerable" : false,
+					"cpe23Uri" : "cpe:2.3:o:apple:macos:-:*:*:*:*:*:*:*",
+					"cpe_name" : [ ]
+				}, {
+					"vulnerable" : false,
+					"cpe23Uri" : "cpe:2.3:o:microsoft:windows:-:*:*:*:*:*:*:*",
+					"cpe_name" : [ ]
+				} ]
+				} ],
+				"cpe_match" : [ ]
+			} ]
+			}
+		}, {
+			"cve" : {
+			"data_type" : "CVE",
+			"data_format" : "MITRE",
+			"data_version" : "4.0",
+			"CVE_data_meta" : {
+				"ID" : "CVE-2023-27928",
+				"ASSIGNER" : "product-security@apple.com"
+			}
+			},
+			"configurations" : {
+			"CVE_data_version" : "4.0",
+			"nodes" : [ {
+				"operator" : "OR",
+				"children" : [ ],
+				"cpe_match" : [ {
+				"vulnerable" : true,
+				"cpe23Uri" : "cpe:2.3:o:apple:macos:*:*:*:*:*:*:*:*",
+				"versionStartIncluding" : "13.0",
+				"versionEndExcluding" : "13.3",
+				"cpe_name" : [ ]
+				}, {
+				"vulnerable" : true,
+				"cpe23Uri" : "cpe:2.3:o:apple:tvos:*:*:*:*:*:*:*:*",
+				"versionEndExcluding" : "16.4",
+				"cpe_name" : [ ]
+				}, {
+				"vulnerable" : true,
+				"cpe23Uri" : "cpe:2.3:o:apple:watchos:*:*:*:*:*:*:*:*",
+				"versionEndExcluding" : "9.4",
+				"cpe_name" : [ ]
+				}, {
+				"vulnerable" : true,
+				"cpe23Uri" : "cpe:2.3:o:apple:macos:*:*:*:*:*:*:*:*",
+				"versionEndExcluding" : "11.7.5",
+				"cpe_name" : [ ]
+				} ]
+			} ]
+			}
+		}, {
+			"cve" : {
+			"data_type" : "CVE",
+			"data_format" : "MITRE",
+			"data_version" : "4.0",
+			"CVE_data_meta" : {
+				"ID" : "CVE-2023-27928",
+				"ASSIGNER" : "product-security@apple.com"
+			}
+			},
+			"configurations" : {
+			"CVE_data_version" : "4.0",
+			"nodes" : [ {
+				"operator" : "OR",
+				"children" : [ ],
+				"cpe_match" : [ {
+				"vulnerable" : true,
+				"cpe23Uri" : "cpe:2.3:a:adobe:acrobat:*:*:*:*:classic:*:*:*",
+				"versionStartIncluding" : "20.001.3005",
+				"versionEndExcluding" : "20.005.30524",
+				"cpe_name" : [ ]
+				}, {
+				"vulnerable" : true,
+				"cpe23Uri" : "cpe:2.3:a:adobe:acrobat_dc:*:*:*:*:continuous:*:*:*",
+				"versionStartIncluding" : "15.007.20033",
+				"versionEndExcluding" : "23.006.20320",
+				"cpe_name" : [ ]
+				}, {
+				"vulnerable" : true,
+				"cpe23Uri" : "cpe:2.3:a:adobe:acrobat_reader:*:*:*:*:classic:*:*:*",
+				"versionStartIncluding" : "20.001.3005",
+				"versionEndExcluding" : "20.005.30524",
+				"cpe_name" : [ ]
+				}, {
+				"vulnerable" : true,
+				"cpe23Uri" : "cpe:2.3:a:adobe:acrobat_reader_dc:*:*:*:*:continuous:*:*:*",
+				"versionStartIncluding" : "15.007.20033",
+				"versionEndExcluding" : "23.006.20320",
+				"cpe_name" : [ ]
+				} ]
+			} ]
+			}
+		}, {
+			"cve" : {
+				"data_type" : "CVE",
+				"data_format" : "MITRE",
+				"data_version" : "4.0",
+				"CVE_data_meta" : {
+				"ID" : "CVE-2023-28321",
+				"ASSIGNER" : "support@hackerone.com"
+				}
+			},
+			"configurations" : {
+				"CVE_data_version" : "4.0",
+				"nodes" : [ {
+				"operator" : "OR",
+				"children" : [ ],
+				"cpe_match" : [ {
+					"vulnerable" : true,
+					"cpe23Uri" : "cpe:2.3:a:haxx:curl:*:*:*:*:*:*:*:*",
+					"versionEndExcluding" : "8.1.0",
+					"cpe_name" : [ ]
+				} ]
+				}, {
+				"operator" : "OR",
+				"children" : [ ],
+				"cpe_match" : [ {
+					"vulnerable" : true,
+					"cpe23Uri" : "cpe:2.3:o:apple:macos:*:*:*:*:*:*:*:*",
+					"versionStartIncluding" : "13.0",
+					"versionEndExcluding" : "13.5",
+					"cpe_name" : [ ]
+				}, {
+					"vulnerable" : true,
+					"cpe23Uri" : "cpe:2.3:o:apple:macos:*:*:*:*:*:*:*:*",
+					"versionStartIncluding" : "12.0",
+					"versionEndExcluding" : "12.6.8",
+					"cpe_name" : [ ]
+				}, {
+					"vulnerable" : true,
+					"cpe23Uri" : "cpe:2.3:o:apple:macos:*:*:*:*:*:*:*:*",
+					"versionStartIncluding" : "11.0",
+					"versionEndExcluding" : "11.7.9",
+					"cpe_name" : [ ]
+				} ]
+				} ]
+			}
+		  }
+] }
+`
 
 func matchesAll(src, tgt []*wfn.Attributes) bool {
 	if len(src) != len(tgt) {

--- a/server/vulnerabilities/nvd/tools/cvefeed/matching_json_test.go
+++ b/server/vulnerabilities/nvd/tools/cvefeed/matching_json_test.go
@@ -43,6 +43,11 @@ func TestMatchJSON(t *testing.T) {
 			Inventory: []*wfn.Attributes{},
 		},
 		{
+			Rule:      0,
+			Inventory: []*wfn.Attributes{{}},
+			Matches:   []*wfn.Attributes{{}},
+		},
+		{
 			Inventory: []*wfn.Attributes{
 				{Part: "o", Vendor: "linux", Product: "linux_kernel", Version: "2\\.6\\.1"},
 				{Part: "a", Vendor: "djvulibre_project", Product: "djvulibre", Version: "3\\.5\\.11"},
@@ -106,9 +111,6 @@ func TestMatchJSON(t *testing.T) {
 	for i, c := range cases {
 		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
 			mm := items[c.Rule].Match(c.Inventory, false)
-			if len(mm) > 0 {
-				t.Logf("matches: %v", mm)
-			}
 			if len(mm) != len(c.Matches) {
 				t.Fatalf("expected %d matches, got %d matches", len(c.Matches), len(mm))
 			}

--- a/server/vulnerabilities/nvd/tools/cvefeed/nvd/match_cpe.go
+++ b/server/vulnerabilities/nvd/tools/cvefeed/nvd/match_cpe.go
@@ -69,6 +69,9 @@ func (cm *cpeMatch) Match(attrs []*wfn.Attributes, requireVersion bool) (matches
 		if cm.match(attr, requireVersion) {
 			matches = append(matches, attr)
 		}
+		if osMatch := cm.MatchTargetSW(attr); osMatch != nil {
+			matches = append(matches, osMatch)
+		}
 	}
 	return matches
 }

--- a/server/vulnerabilities/nvd/tools/wfn/matcher.go
+++ b/server/vulnerabilities/nvd/tools/wfn/matcher.go
@@ -49,14 +49,37 @@ func (a *Attributes) MatchWithoutVersion(attr *Attributes) bool {
 		matchAttr(a.Other, attr.Other)
 }
 
+func (a *Attributes) MatchTargetSW(attr *Attributes) *Attributes {
+	if a == nil || attr == nil {
+		return nil
+	}
+
+	var osMatch bool
+	var osAttr *Attributes
+	if attr.Part == "a" && attr.TargetSW != "" {
+		osAttr = &Attributes{
+			Part:    "o",
+			Product: attr.TargetSW,
+		}
+
+		osMatch = matchAttr(a.Part, osAttr.Part) && matchAttr(a.Product, osAttr.Product)
+	}
+
+	if !osMatch {
+		return nil
+	}
+
+	return osAttr
+}
+
 // MatchAll returns a Matcher which matches only if all matchers match
 func MatchAll(ms ...Matcher) Matcher {
-	return &multiMatcher{ms, true}
+	return &multiMatcher{matchers: ms, allMatch: true}
 }
 
 // MatchAll returns a Matcher which matches if any of the matchers match
 func MatchAny(ms ...Matcher) Matcher {
-	return &multiMatcher{ms, false}
+	return &multiMatcher{matchers: ms, allMatch: false}
 }
 
 // DontMatch returns a Matcher which matches if the given matchers doesn't
@@ -68,12 +91,23 @@ type multiMatcher struct {
 	matchers []Matcher
 	// if true, match will only return something if all matchers matched at least something
 	allMatch bool
+	depth    int
 }
 
 // Match is part of the Matcher interface
 func (mm *multiMatcher) Match(attrs []*Attributes, requireVersion bool) []*Attributes {
+	defer func() {
+		if mm.depth > 0 {
+			mm.depth--
+		}
+	}()
+
 	matched := make(map[*Attributes]bool)
 	for _, matcher := range mm.matchers {
+		// type check matcher against multiMatcher
+		if _, ok := matcher.(*multiMatcher); !ok {
+			mm.depth++
+		}
 		matches := matcher.Match(attrs, requireVersion)
 		if mm.allMatch && len(matches) == 0 {
 			// all matchers need to match at least one attr
@@ -88,6 +122,11 @@ func (mm *multiMatcher) Match(attrs []*Attributes, requireVersion bool) []*Attri
 	for m := range matched {
 		matches = append(matches, m)
 	}
+
+	if mm.depth == 0 && !attributesIncludeApp(matches) {
+		return nil
+	}
+
 	return matches
 }
 
@@ -117,4 +156,13 @@ func (nm notMatcher) Match(attrs []*Attributes, requireVersion bool) (matches []
 		}
 	}
 	return matches
+}
+
+func attributesIncludeApp(attrs []*Attributes) bool {
+	for _, a := range attrs {
+		if a.Part == "a" {
+			return true
+		}
+	}
+	return false
 }

--- a/server/vulnerabilities/nvd/tools/wfn/matcher.go
+++ b/server/vulnerabilities/nvd/tools/wfn/matcher.go
@@ -123,7 +123,7 @@ func (mm *multiMatcher) Match(attrs []*Attributes, requireVersion bool) []*Attri
 		matches = append(matches, m)
 	}
 
-	if mm.depth == 0 && !attributesIncludeApp(matches) {
+	if mm.depth == 0 && len(matches) > 1 && !attributesIncludeApp(matches) {
 		return nil
 	}
 


### PR DESCRIPTION
#14894 

Fleet is currently not matching against CVEs with separate application and operating system scopes ([sample](https://nvd.nist.gov/vuln/detail/CVE-2023-0400)]

Vuln processing already injects a targetSW attribute into CPEs, so we use this value to create an OS CPE to match against.

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [X] Added/updated tests
- [X] Manual QA for all new/changed functionality