### PR TITLE
Fix code linting issue where a slice was created non-empty and appended-to

### DIFF
--- a/changes/19290-fix-make-slice-with-capacity
+++ b/changes/19290-fix-make-slice-with-capacity
@@ -1,0 +1,1 @@
+* Fixed a code linter issue where a slice was created non-empty and appended-to, instead of empty with the required capacity.

--- a/server/datastore/mysql/microsoft_mdm.go
+++ b/server/datastore/mysql/microsoft_mdm.go
@@ -416,7 +416,7 @@ func updateMDMWindowsHostProfileStatusFromResponseDB(
 		WHERE host_uuid = ? AND command_uuid IN (?)`
 
 	// grab command UUIDs to find matching entries using `getMatchingHostProfilesStmt`
-	commandUUIDs := make([]string, len(payloads))
+	commandUUIDs := make([]string, 0, len(payloads))
 	// also grab the payloads keyed by the command uuid, so we can easily
 	// grab the corresponding `Detail` and `Status` from the matching
 	// command later on.


### PR DESCRIPTION
#19290 

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
