### PR TITLE
Remove "available in Fleet Premium" note from scripts permissions docs

### DIFF
--- a/docs/Using Fleet/manage-access.md
+++ b/docs/Using Fleet/manage-access.md
@@ -88,10 +88,10 @@ GitOps is an API-only and write-only role that can be used on CI/CD pipelines.
 | View all [MDM settings](https://fleetdm.com/docs/using-fleet/mdm-macos-settings)                                                           |          |            |            | ✅    | ✅      |
 | Edit setup experience (end user authentication, bootstrap package, Setup Assistant)\*                                                                                         |          |            | ✅             | ✅    | ✅          |
 | Edit end user license agreement (EULA)\*                                                                                         |          |            |              | ✅    |         |
-| Run arbitrary scripts on hosts\*                                                                                                           |          |            | ✅         | ✅    |         |
-| View saved scripts\*                                                                                                                       | ✅       | ✅         | ✅         | ✅    |         |
-| Edit/upload saved scripts\*                                                                                                                |          |            | ✅         | ✅    | ✅      |
-| Run saved scripts on hosts\*                                                                                                               | ✅       | ✅         | ✅         | ✅    |         |
+| Run arbitrary scripts on hosts                                                                                                             |          |            | ✅         | ✅    |         |
+| View saved scripts                                                                                                                         | ✅       | ✅         | ✅         | ✅    |         |
+| Edit/upload saved scripts                                                                                                                  |          |            | ✅         | ✅    | ✅      |
+| Run saved scripts on hosts                                                                                                                 | ✅       | ✅         | ✅         | ✅    |         |
 | Lock, unlock, and wipe hosts\*                                                                                                             |          |            | ✅         | ✅    |         |
 
 \* Applies only to Fleet Premium


### PR DESCRIPTION
Scripts are available to free users.