### PR TITLE
Fix fleetctl preview bug caused by creating enroll secrets

### DIFF
--- a/changes/19129-fleetctl-preview-enroll-secrets
+++ b/changes/19129-fleetctl-preview-enroll-secrets
@@ -1,0 +1,1 @@
+* Fixed bug in `fleetctl preview` caused by creating enroll secrets.

--- a/cmd/fleetctl/preview.go
+++ b/cmd/fleetctl/preview.go
@@ -407,8 +407,8 @@ Use the stop and reset subcommands to manage the server and dependencies once st
 				return fmt.Errorf("Error retrieving enroll secret: %w", err)
 			}
 
-			if len(secrets.Secrets) != 1 {
-				return errors.New("Expected 1 active enroll secret")
+			if len(secrets.Secrets) == 0 {
+				return errors.New("Expected at least one enroll secret")
 			}
 
 			// disable analytics collection for preview


### PR DESCRIPTION
#19129

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [X] Manual QA for all new/changed functionality