### PR TITLE
vscode false positivies

### DIFF
--- a/changes/18733-vscode-false-pos
+++ b/changes/18733-vscode-false-pos
@@ -1,0 +1,1 @@
+removed vscode false positive vulnerabilities

--- a/server/vulnerabilities/nvd/cpe_matching_rule.go
+++ b/server/vulnerabilities/nvd/cpe_matching_rule.go
@@ -42,6 +42,7 @@ type CPEMatchingRule struct {
 	// IgnoreAll will cause all CPEs to not match hence ignoring a CVE.
 	IgnoreAll bool
 	// IgnoreIf is a function that can determine if a CPE matching rule should be ignored or not.
+	// If IgnoreIf is set, CPESpecs will not be evaluated.
 	IgnoreIf func(cpeMeta *wfn.Attributes) bool
 }
 
@@ -55,8 +56,11 @@ func (rule CPEMatchingRule) CPEMatches(cpeMeta *wfn.Attributes) bool {
 		return false
 	}
 
-	if rule.IgnoreIf != nil && rule.IgnoreIf(cpeMeta) {
-		return false
+	if rule.IgnoreIf != nil {
+		if rule.IgnoreIf(cpeMeta) {
+			return false
+		}
+		return true
 	}
 
 	ver, err := semver.NewVersion(wfn.StripSlashes(cpeMeta.Version))

--- a/server/vulnerabilities/nvd/cpe_matching_rules.go
+++ b/server/vulnerabilities/nvd/cpe_matching_rules.go
@@ -197,6 +197,18 @@ func GetKnownNVDBugRules() (CPEMatchingRules, error) {
 				return cpeMeta.TargetSW == "visual_studio_code"
 			},
 		},
+		// Issue #18733 incorrect CPEs that should be matching
+		// visual studio code extensions
+		CPEMatchingRule{
+			CVEs: map[string]struct{}{
+				"CVE-2021-28967": {},
+				"CVE-2020-1192":  {},
+				"CVE-2020-1171":  {},
+			},
+			IgnoreIf: func(cpeMeta *wfn.Attributes) bool {
+				return cpeMeta.Product == "visual_studio_code" && cpeMeta.TargetSW == wfn.Any
+			},
+		},
 	}
 
 	for i, rule := range rules {

--- a/tools/nvd/nvdvuln/nvdvuln.go
+++ b/tools/nvd/nvdvuln/nvdvuln.go
@@ -191,7 +191,7 @@ func main() {
 	ds.DeleteOutOfDateOSVulnerabilitiesFunc = func(ctx context.Context, source fleet.VulnerabilitySource, duration time.Duration) error {
 		return nil
 	}
-	
+
 	printf("Translating software to CPE...\n")
 	err := nvd.TranslateSoftwareToCPE(ctx, ds, *dbDir, logger)
 	if err != nil {

--- a/tools/nvd/nvdvuln/nvdvuln.go
+++ b/tools/nvd/nvdvuln/nvdvuln.go
@@ -184,6 +184,14 @@ func main() {
 		return nil
 	}
 
+	ds.ListOperatingSystemsForPlatformFunc = func(ctx context.Context, platform string) ([]fleet.OperatingSystem, error) {
+		return nil, nil
+	}
+
+	ds.DeleteOutOfDateOSVulnerabilitiesFunc = func(ctx context.Context, source fleet.VulnerabilitySource, duration time.Duration) error {
+		return nil
+	}
+	
 	printf("Translating software to CPE...\n")
 	err := nvd.TranslateSoftwareToCPE(ctx, ds, *dbDir, logger)
 	if err != nil {


### PR DESCRIPTION
#18733 

Added a rule for the affected CVEs and made a change to the `IfIgnore` func.  Manually tested CVE removals with `/tools/nvd/nvdvuln`.  Existing test coverage ensures the rule doesn't cause false negatives on vscode extensions.

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.  
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [] Added/updated tests
- [X] Manual QA for all new/changed functionality