### PR TITLE
Delete team policies: 404 for nonexistent team

### DIFF
--- a/changes/18993-404-when-no-team-on-delete-team-policies
+++ b/changes/18993-404-when-no-team-on-delete-team-policies
@@ -1,0 +1,1 @@
+* Error with 404 when the user attempts to delete team policies for a non-existent team

--- a/server/service/integration_core_test.go
+++ b/server/service/integration_core_test.go
@@ -6211,6 +6211,9 @@ func (s *integrationTestSuite) TestTeamPoliciesTeamNotExists() {
 	teamPoliciesResponse := listTeamPoliciesResponse{}
 	s.DoJSON("GET", fmt.Sprintf("/api/latest/fleet/teams/%d/policies", 9999999), nil, http.StatusNotFound, &teamPoliciesResponse)
 	require.Len(t, teamPoliciesResponse.Policies, 0)
+
+	deleteTeamPoliciesResponse := deleteTeamPoliciesResponse{}
+	s.DoJSON("POST", fmt.Sprintf("/api/latest/fleet/teams/%d/policies/delete", 9999999), deleteTeamPoliciesRequest{IDs: []uint{1, 1000}}, http.StatusNotFound, &deleteTeamPoliciesResponse)
 }
 
 func (s *integrationTestSuite) TestSessionInfo() {

--- a/server/service/team_policies.go
+++ b/server/service/team_policies.go
@@ -289,13 +289,6 @@ func (svc Service) DeleteTeamPolicies(ctx context.Context, teamID uint, ids []ui
 		return nil, ctxerr.Wrap(ctx, err, "getting policies by ID")
 	}
 
-	if err := svc.authz.Authorize(ctx, &fleet.Policy{
-		PolicyData: fleet.PolicyData{
-			TeamID: ptr.Uint(teamID),
-		},
-	}, fleet.ActionWrite); err != nil {
-		return nil, err
-	}
 	for _, policy := range policiesByID {
 		if t := policy.PolicyData.TeamID; t == nil || *t != teamID {
 			return nil, authz.ForbiddenWithInternal(

--- a/server/service/team_policies.go
+++ b/server/service/team_policies.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
 	"reflect"
 	"strconv"
 
@@ -269,6 +270,15 @@ func deleteTeamPoliciesEndpoint(ctx context.Context, request interface{}, svc fl
 }
 
 func (svc Service) DeleteTeamPolicies(ctx context.Context, teamID uint, ids []uint) ([]uint, error) {
+	if err := svc.authz.Authorize(ctx, &fleet.Policy{}, fleet.ActionWrite); err != nil {
+		return nil, err
+	}
+
+	_, err := svc.ds.Team(ctx, teamID)
+	if err != nil {
+		return nil, fleet.NewInvalidArgumentError("team_id", "The team does not exist").WithStatus(http.StatusBadRequest)
+	}
+
 	if len(ids) == 0 {
 		return nil, nil
 	}


### PR DESCRIPTION
## Addresses #18993 

- Return `404` when a user tries to delete team policies from a non-existent team – see [this precedent in the codebase](https://github.com/fleetdm/fleet/blob/6b3310aa51bbc54282a0f2cd7d527997448c961f/server/service/integration_core_test.go#L6212) for a 404 in this situation
- Add missing authorization check for this action


<img width="1494" alt="Screenshot 2024-06-04 at 6 22 02 PM" src="https://github.com/fleetdm/fleet/assets/61553566/15b98c7e-5d4b-450c-8403-a062d7d1bd5b">



- [x] Changes file added for user-visible changes in `changes/`,
- [x] Added/updated tests
- [x] Manual QA for all new/changed functionality
