### PR TITLE
Fleet UI: Fix dot problem so UI renders responses for columns with dot notation

### DIFF
--- a/changes/19528-dot-notation-bug-on-queries
+++ b/changes/19528-dot-notation-bug-on-queries
@@ -1,0 +1,1 @@
+* Fix queries with dot notation in the column name to show results

--- a/frontend/pages/hosts/details/HostQueryReport/HQRTable/HQRTableConfig.tsx
+++ b/frontend/pages/hosts/details/HostQueryReport/HQRTable/HQRTableConfig.tsx
@@ -31,7 +31,7 @@ const generateColumnConfigs = (rows: IWebSocketData[]): IHQRTTableColumn[] =>
           isSortedDesc={headerProps.column.isSortedDesc}
         />
       ),
-      accessor: colName,
+      accessor: (data) => data[colName],
       Cell: (cellProps: ITableStringCellProps) => {
         if (typeof cellProps?.cell?.value !== "string") return null;
 

--- a/frontend/pages/queries/details/components/QueryReport/QueryReportTableConfig.tsx
+++ b/frontend/pages/queries/details/components/QueryReport/QueryReportTableConfig.tsx
@@ -65,7 +65,7 @@ const generateReportColumnConfigsFromResults = (
             isSortedDesc={headerProps.column.isSortedDesc}
           />
         ),
-        accessor: key,
+        accessor: (data) => data[key],
         Cell: (cellProps: ITableCellProps) => {
           if (typeof cellProps.cell.value !== "string") return null;
 

--- a/frontend/pages/queries/edit/components/QueryResults/QueryResultsTableConfig.tsx
+++ b/frontend/pages/queries/edit/components/QueryResults/QueryResultsTableConfig.tsx
@@ -50,7 +50,7 @@ const generateColumnConfigsFromRows = <T extends Record<keyof T, unknown>>(
           isSortedDesc={headerProps.column.isSortedDesc}
         />
       ),
-      accessor: colName,
+      accessor: (data) => data[colName],
       Cell: (cellProps: CellProps<T>) => {
         const val = cellProps?.cell?.value;
         return !!val?.length && val.length > 300


### PR DESCRIPTION
## Issue
Cerra #15446 

## Description
- Fix dot problem so UI renders responses for query results that have columns with dot notation

## Solution
https://github.com/TanStack/table/issues/1671#issuecomment-574721330

## Screenshot of fix
<img width="1453" alt="Screenshot 2024-06-05 at 11 46 40 AM" src="https://github.com/fleetdm/fleet/assets/71795832/a004c571-9ccf-40b9-bb2d-323b72a07a08">


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
- [x] Manual QA for all new/changed functionality

