### PR TITLE
Update s3 carves bucket expiry for dogfood

### DIFF
--- a/infrastructure/dogfood/terraform/aws-tf-module/main.tf
+++ b/infrastructure/dogfood/terraform/aws-tf-module/main.tf
@@ -290,7 +290,8 @@ module "firehose-logging" {
 module "osquery-carve" {
   source = "github.com/fleetdm/fleet//terraform/addons/osquery-carve?ref=tf-mod-addon-osquery-carve-v1.0.0"
   osquery_carve_s3_bucket = {
-    name = "${local.customer}-osquery-carve"
+    name         = "fleet-${local.customer}-osquery-carve"
+    expires_days = 3650
   }
 }
 


### PR DESCRIPTION
Need to update to extended expiry for carves s3 as not to remove for software_installs

@rfairburn will apply with no downtime to Dogfood
