### PR TITLE
Actually set `self_service` field in the batch-set of software installers (for CLI/gitops)

### DIFF
--- a/server/datastore/mysql/software_installers.go
+++ b/server/datastore/mysql/software_installers.go
@@ -469,9 +469,10 @@ INSERT INTO software_installers (
 	pre_install_query,
 	post_install_script_content_id,
 	platform,
+	self_service,
 	title_id
 ) VALUES (
-  ?, ?, ?, ?, ?, ?, ?, ?, ?,
+  ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
   (SELECT id FROM software_titles WHERE name = ? AND source = ? AND browser = '')
 )
 ON DUPLICATE KEY UPDATE
@@ -481,7 +482,8 @@ ON DUPLICATE KEY UPDATE
   filename = VALUES(filename),
   version = VALUES(version),
   pre_install_query = VALUES(pre_install_query),
-  platform = VALUES(platform)
+  platform = VALUES(platform),
+  self_service = VALUES(self_service)
 `
 
 	// use a team id of 0 if no-team
@@ -552,6 +554,7 @@ ON DUPLICATE KEY UPDATE
 				installer.PreInstallQuery,
 				postInstallScriptID,
 				installer.Platform,
+				installer.SelfService,
 				installer.Title,
 				installer.Source,
 			}

--- a/server/service/integration_enterprise_test.go
+++ b/server/service/integration_enterprise_test.go
@@ -9555,7 +9555,7 @@ func (s *integrationEnterpriseTestSuite) TestApplyTeamsSoftwareConfig() {
 	require.Empty(t, teamResp.Team.Config.Software.Value)
 }
 
-func (s *integrationMDMTestSuite) TestBatchSetSoftwareInstallers() {
+func (s *integrationEnterpriseTestSuite) TestBatchSetSoftwareInstallers() {
 	t := s.T()
 
 	// a team name is required (we don't allow installers for "no team")
@@ -9618,6 +9618,14 @@ func (s *integrationMDMTestSuite) TestBatchSetSoftwareInstallers() {
 	s.Do("POST", "/api/latest/fleet/software/batch", batchSetSoftwareInstallersRequest{Software: softwareToInstall}, http.StatusNoContent, "team_name", tm.Name)
 	newTitlesResp := listSoftwareTitlesResponse{}
 	s.DoJSON("GET", "/api/v1/fleet/software/titles", nil, http.StatusOK, &newTitlesResp, "available_for_install", "true", "team_id", strconv.Itoa(int(tm.ID)))
+	require.Equal(t, titlesResp, newTitlesResp)
+
+	// setting self-service to true updates the software title metadata
+	softwareToInstall[0].SelfService = true
+	s.Do("POST", "/api/latest/fleet/software/batch", batchSetSoftwareInstallersRequest{Software: softwareToInstall}, http.StatusNoContent, "team_name", tm.Name)
+	newTitlesResp = listSoftwareTitlesResponse{}
+	s.DoJSON("GET", "/api/v1/fleet/software/titles", nil, http.StatusOK, &newTitlesResp, "available_for_install", "true", "team_id", strconv.Itoa(int(tm.ID)))
+	titlesResp.SoftwareTitles[0].SelfService = true
 	require.Equal(t, titlesResp, newTitlesResp)
 
 	// empty payload cleans the software items


### PR DESCRIPTION
#17587 

# Checklist for submitter

- [x] Added/updated tests
- [x] Manual QA for all new/changed functionality (did a run with `fleetctl gitops` to confirm)
