### PR TITLE
[unreleased bug] Fleet UI banners: set expiries into global state

### DIFF
--- a/frontend/components/App/App.tsx
+++ b/frontend/components/App/App.tsx
@@ -95,7 +95,7 @@ const App = ({ children, location }: IAppProps): JSX.Element => {
         } catch (error) {
           console.error(error);
           const abmError = error as AxiosResponse;
-          if (abmError.status === 403) {
+          if (abmError.status === 400) {
             const pastDate = "2024-06-03T17:28:44Z";
             setABMExpiry(pastDate);
           }

--- a/frontend/components/App/App.tsx
+++ b/frontend/components/App/App.tsx
@@ -91,7 +91,7 @@ const App = ({ children, location }: IAppProps): JSX.Element => {
         // should be fixed upstream.
         try {
           const abmInfo = await mdmAppleBMAPI.getAppleBMInfo();
-          setABMExpiry(abmInfo.renew_date || "");
+          setABMExpiry(abmInfo.renew_date);
         } catch (error) {
           console.error(error);
           const abmError = error as AxiosResponse;

--- a/frontend/components/App/App.tsx
+++ b/frontend/components/App/App.tsx
@@ -83,8 +83,23 @@ const App = ({ children, location }: IAppProps): JSX.Element => {
       }
 
       if (configResponse.mdm.apple_bm_enabled_and_configured) {
-        const abmInfo = await mdmAppleBMAPI.getAppleBMInfo();
-        setABMExpiry(abmInfo.renew_date);
+        // FIXME: we need to catch and check for a 400 status code because the
+        // API behaves this way when the token is already expired or invalid.
+        //
+        // This is a quick fix to not completely break the UI, but it doesn't
+        // allow us to show ABM information when the token is expired so it
+        // should be fixed upstream.
+        try {
+          const abmInfo = await mdmAppleBMAPI.getAppleBMInfo();
+          setABMExpiry(abmInfo.renew_date || "");
+        } catch (error) {
+          console.error(error);
+          const abmError = error as AxiosResponse;
+          if (abmError.status === 403) {
+            const pastDate = "2024-06-03T17:28:44Z";
+            setABMExpiry(pastDate);
+          }
+        }
       }
       if (configResponse.mdm.enabled_and_configured) {
         const apnsInfo = await mdmAppleAPI.getAppleAPNInfo();

--- a/frontend/context/app.tsx
+++ b/frontend/context/app.tsx
@@ -323,6 +323,20 @@ const reducer = (state: InitialStateType, action: IAction) => {
         enrollSecret,
       };
     }
+    case ACTIONS.SET_ABM_EXPIRY: {
+      const { abmExpiry } = action;
+      return {
+        ...state,
+        abmExpiry,
+      };
+    }
+    case ACTIONS.SET_APNS_EXPIRY: {
+      const { apnsExpiry } = action;
+      return {
+        ...state,
+        apnsExpiry,
+      };
+    }
     case ACTIONS.SET_SANDBOX_EXPIRY: {
       const { sandboxExpiry } = action;
       return {


### PR DESCRIPTION
## Issue
Cerra #11544 

## Description
- Missing piece to set expiries into global state for the FE to use
- Catches expired ABM causing a 400 and erroring out the entire app

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->


- [x] Manual QA for all new/changed functionality

