### PR TITLE
[unreleased bug] Fleet UI: Only global admins see ABM and APNs banners

### DIFF
--- a/frontend/components/App/App.tsx
+++ b/frontend/components/App/App.tsx
@@ -105,8 +105,12 @@ const App = ({ children, location }: IAppProps): JSX.Element => {
           }
         }
         if (configResponse.mdm.enabled_and_configured) {
-          const apnsInfo = await mdmAppleAPI.getAppleAPNInfo();
-          setAPNsExpiry(apnsInfo.renew_date);
+          try {
+            const apnsInfo = await mdmAppleAPI.getAppleAPNInfo();
+            setAPNsExpiry(apnsInfo.renew_date);
+          } catch (error) {
+            console.error(error);
+          }
         }
       }
 

--- a/frontend/components/App/App.tsx
+++ b/frontend/components/App/App.tsx
@@ -56,6 +56,7 @@ const App = ({ children, location }: IAppProps): JSX.Element => {
   const {
     config,
     currentUser,
+    isGlobalAdmin,
     isGlobalObserver,
     isOnlyObserver,
     isAnyTeamMaintainerOrTeamAdmin,
@@ -82,29 +83,33 @@ const App = ({ children, location }: IAppProps): JSX.Element => {
         setNoSandboxHosts(noSandboxHosts);
       }
 
-      if (configResponse.mdm.apple_bm_enabled_and_configured) {
-        // FIXME: we need to catch and check for a 400 status code because the
-        // API behaves this way when the token is already expired or invalid.
-        //
-        // This is a quick fix to not completely break the UI, but it doesn't
-        // allow us to show ABM information when the token is expired so it
-        // should be fixed upstream.
-        try {
-          const abmInfo = await mdmAppleBMAPI.getAppleBMInfo();
-          setABMExpiry(abmInfo.renew_date);
-        } catch (error) {
-          console.error(error);
-          const abmError = error as AxiosResponse;
-          if (abmError.status === 400) {
-            const pastDate = "2024-06-03T17:28:44Z";
-            setABMExpiry(pastDate);
+      // These endpoints 403 for non-global admins
+      if (isGlobalAdmin) {
+        if (configResponse.mdm.apple_bm_enabled_and_configured) {
+          // FIXME: we need to catch and check for a 400 status code because the
+          // API behaves this way when the token is already expired or invalid.
+          //
+          // This is a quick fix to not completely break the UI, but it doesn't
+          // allow us to show ABM information when the token is expired so it
+          // should be fixed upstream.
+          try {
+            const abmInfo = await mdmAppleBMAPI.getAppleBMInfo();
+            setABMExpiry(abmInfo.renew_date);
+          } catch (error) {
+            console.error(error);
+            const abmError = error as AxiosResponse;
+            if (abmError.status === 400) {
+              const pastDate = "2024-06-03T17:28:44Z";
+              setABMExpiry(pastDate);
+            }
           }
         }
+        if (configResponse.mdm.enabled_and_configured) {
+          const apnsInfo = await mdmAppleAPI.getAppleAPNInfo();
+          setAPNsExpiry(apnsInfo.renew_date);
+        }
       }
-      if (configResponse.mdm.enabled_and_configured) {
-        const apnsInfo = await mdmAppleAPI.getAppleAPNInfo();
-        setAPNsExpiry(apnsInfo.renew_date);
-      }
+
       setConfig(configResponse);
     } catch (error) {
       console.error(error);


### PR DESCRIPTION
## Issue
Cerra #11544 

## Description
- Unreleased bug: 403 if not global admin when checking for expiration of ABM and APNs
- Found unreleased bug here: https://github.com/fleetdm/fleet/issues/19361#issuecomment-2140529103
- Solution created by Rachael Shaw, comment left in #19361 


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [ ] Manual QA for all new/changed functionality
  