### PR TITLE
Custom Ubuntu Kernel Vuln Scanning

### DIFF
--- a/changes/19347-custom-kernel-vuln-detection
+++ b/changes/19347-custom-kernel-vuln-detection
@@ -1,0 +1,1 @@
+- added vulnerability detection in NVD for custom ubuntu kernels

--- a/cmd/fleetctl/vulnerability_data_stream_test.go
+++ b/cmd/fleetctl/vulnerability_data_stream_test.go
@@ -12,7 +12,6 @@ import (
 )
 
 func TestVulnerabilityDataStream(t *testing.T) {
-	t.Skip("REMOVEME: when API keys are restored")
 	nettest.Run(t)
 
 	runAppCheckErr(t, []string{"vulnerability-data-stream"}, "No directory provided")

--- a/server/datastore/mysql/software.go
+++ b/server/datastore/mysql/software.go
@@ -1047,6 +1047,11 @@ func (ds *Datastore) AllSoftwareIterator(
 		arg["included_sources"] = query.IncludedSources
 	}
 
+	if query.NameFilter != "" {
+		conditionals = append(conditionals, "s.name LIKE :name_filter")
+		arg["name_filter"] = likePattern(query.NameFilter)
+	}
+
 	if len(conditionals) != 0 {
 		cond := strings.Join(conditionals, " AND ")
 		stmt, args, err = sqlx.Named(stmt+" WHERE "+cond, arg)

--- a/server/datastore/mysql/software.go
+++ b/server/datastore/mysql/software.go
@@ -15,7 +15,7 @@ import (
 	"github.com/fleetdm/fleet/v4/server/contexts/ctxerr"
 	"github.com/fleetdm/fleet/v4/server/fleet"
 	"github.com/fleetdm/fleet/v4/server/ptr"
-	"github.com/go-kit/kit/log/level"
+	"github.com/go-kit/log/level"
 	"github.com/google/uuid"
 	"github.com/jmoiron/sqlx"
 )
@@ -1035,38 +1035,39 @@ func (ds *Datastore) AllSoftwareIterator(
 	LEFT JOIN software_cpe sc ON (s.id=sc.software_id)`
 
 	var conditionals []string
-	arg := map[string]interface{}{}
 
 	if len(query.ExcludedSources) != 0 {
-		conditionals = append(conditionals, "s.source NOT IN (:excluded_sources)")
-		arg["excluded_sources"] = query.ExcludedSources
+		conditionals = append(conditionals, "s.source NOT IN (?)")
+		args = append(args, query.ExcludedSources)
 	}
 
 	if len(query.IncludedSources) != 0 {
-		conditionals = append(conditionals, "s.source IN (:included_sources)")
-		arg["included_sources"] = query.IncludedSources
+		conditionals = append(conditionals, "s.source IN (?)")
+		args = append(args, query.IncludedSources)
 	}
 
-	if query.NameFilter != "" {
-		conditionals = append(conditionals, "s.name LIKE :name_filter")
-		arg["name_filter"] = likePattern(query.NameFilter)
+	if query.NameMatch != "" {
+		conditionals = append(conditionals, "s.name REGEXP ?")
+		args = append(args, query.NameMatch)
+	}
+
+	if query.NameExclude != "" {
+		conditionals = append(conditionals, "s.name NOT REGEXP ?")
+		args = append(args, query.NameExclude)
 	}
 
 	if len(conditionals) != 0 {
-		cond := strings.Join(conditionals, " AND ")
-		stmt, args, err = sqlx.Named(stmt+" WHERE "+cond, arg)
-		if err != nil {
-			return nil, ctxerr.Wrap(ctx, err, "error binding named arguments on software iterator")
-		}
-		stmt, args, err = sqlx.In(stmt, args...)
-		if err != nil {
-			return nil, ctxerr.Wrap(ctx, err, "error building 'In' query part on software iterator")
-		}
+		stmt += " WHERE " + strings.Join(conditionals, " AND ")
+	}
+
+	stmt, args, err = sqlx.In(stmt, args...)
+	if err != nil {
+		return nil, fmt.Errorf("error building 'In' query part on software iterator: %w", err)
 	}
 
 	rows, err := ds.reader(ctx).QueryxContext(ctx, stmt, args...) //nolint:sqlclosecheck
 	if err != nil {
-		return nil, ctxerr.Wrap(ctx, err, "load host software")
+		return nil, fmt.Errorf("executing all software iterator %w", err)
 	}
 	return &softwareIterator{rows: rows}, nil
 }

--- a/server/datastore/mysql/software_test.go
+++ b/server/datastore/mysql/software_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/fleetdm/fleet/v4/server/fleet"
 	"github.com/fleetdm/fleet/v4/server/ptr"
 	"github.com/fleetdm/fleet/v4/server/test"
+	"github.com/fleetdm/fleet/v4/server/vulnerabilities/nvd"
 	"github.com/fleetdm/fleet/v4/server/vulnerabilities/oval"
 	"github.com/google/uuid"
 	"github.com/jmoiron/sqlx"
@@ -51,6 +52,7 @@ func TestSoftware(t *testing.T) {
 		{"ListCVEs", testListCVEs},
 		{"ListSoftwareForVulnDetection", testListSoftwareForVulnDetection},
 		{"AllSoftwareIterator", testAllSoftwareIterator},
+		{"AllSoftwareIteratorForCustomLinuxImages", testSoftwareIteratorForLinuxKernelCustomImages},
 		{"UpsertSoftwareCPEs", testUpsertSoftwareCPEs},
 		{"DeleteOutOfDateVulnerabilities", testDeleteOutOfDateVulnerabilities},
 		{"DeleteSoftwareCPEs", testDeleteSoftwareCPEs},
@@ -2272,10 +2274,12 @@ func testAllSoftwareIterator(t *testing.T, ds *Datastore) {
 	software := []fleet.Software{
 		{Name: "foo", Version: "0.0.1", Source: "chrome_extensions"},
 		{Name: "foo", Version: "0.0.3", Source: "chrome_extensions"},
+		{Name: "foobar", Version: "0.0.1", Source: "chrome_extensions"},
 		{Name: "bar", Version: "0.0.3", Source: "chrome_extensions"},
 		{Name: "foo", Version: "v0.0.2", Source: "apps"},
 		{Name: "foo", Version: "0.0.3", Source: "apps"},
 		{Name: "bar", Version: "0.0.3", Source: "deb_packages"},
+		{Name: "baz", Version: "0.0.3", Source: "deb_packages"},
 	}
 	_, err := ds.UpdateHostSoftware(context.Background(), host.ID, software)
 	require.NoError(t, err)
@@ -2318,7 +2322,9 @@ func testAllSoftwareIterator(t *testing.T, ds *Datastore) {
 				{Name: "foo", Version: "0.0.1", Source: "chrome_extensions", GenerateCPE: "cpe:foo_ce_v1"},
 				{Name: "foo", Version: "0.0.3", Source: "chrome_extensions"},
 				{Name: "bar", Version: "0.0.3", Source: "chrome_extensions"},
+				{Name: "foobar", Version: "0.0.1", Source: "chrome_extensions"},
 				{Name: "bar", Version: "0.0.3", Source: "deb_packages", GenerateCPE: "cpe:bar_v3"},
+				{Name: "baz", Version: "0.0.3", Source: "deb_packages"},
 			},
 			q: fleet.SoftwareIterQueryOptions{ExcludedSources: []string{"apps"}},
 		},
@@ -2330,6 +2336,8 @@ func testAllSoftwareIterator(t *testing.T, ds *Datastore) {
 				{Name: "foo", Version: "0.0.3", Source: "apps"},
 				{Name: "foo", Version: "0.0.3", Source: "chrome_extensions"},
 				{Name: "bar", Version: "0.0.3", Source: "chrome_extensions"},
+				{Name: "foobar", Version: "0.0.1", Source: "chrome_extensions"},
+				{Name: "baz", Version: "0.0.3", Source: "deb_packages"},
 				{Name: "bar", Version: "0.0.3", Source: "deb_packages", GenerateCPE: "cpe:bar_v3"},
 			},
 			q: fleet.SoftwareIterQueryOptions{},
@@ -2339,15 +2347,24 @@ func testAllSoftwareIterator(t *testing.T, ds *Datastore) {
 			expected: []fleet.Software{
 				{Name: "bar", Version: "0.0.3", Source: "deb_packages", GenerateCPE: "cpe:bar_v3"},
 			},
-			q: fleet.SoftwareIterQueryOptions{NameFilter: "ba", IncludedSources: []string{"deb_packages"}},
+			q: fleet.SoftwareIterQueryOptions{NameMatch: `ba[r|f]`, IncludedSources: []string{"deb_packages"}},
 		},
 		{
 			name: "name filter includes chrome_extensions",
 			expected: []fleet.Software{
 				{Name: "foo", Version: "0.0.1", Source: "chrome_extensions", GenerateCPE: "cpe:foo_ce_v1"},
 				{Name: "foo", Version: "0.0.3", Source: "chrome_extensions"},
+				{Name: "foobar", Version: "0.0.1", Source: "chrome_extensions"},
 			},
-			q: fleet.SoftwareIterQueryOptions{NameFilter: "foo", IncludedSources: []string{"chrome_extensions"}},
+			q: fleet.SoftwareIterQueryOptions{NameMatch: "foo\\.*", IncludedSources: []string{"chrome_extensions"}},
+		},
+		{
+			name: "name filter and not name filter",
+			expected: []fleet.Software{
+				{Name: "foo", Version: "0.0.1", Source: "chrome_extensions", GenerateCPE: "cpe:foo_ce_v1"},
+				{Name: "foo", Version: "0.0.3", Source: "chrome_extensions"},
+			},
+			q: fleet.SoftwareIterQueryOptions{NameMatch: "foo\\.*", NameExclude: "bar$", IncludedSources: []string{"chrome_extensions"}},
 		},
 	}
 
@@ -2366,6 +2383,47 @@ func testAllSoftwareIterator(t *testing.T, ds *Datastore) {
 			test.ElementsMatchSkipID(t, tC.expected, actual)
 		})
 	}
+}
+
+func testSoftwareIteratorForLinuxKernelCustomImages(t *testing.T, ds *Datastore) {
+	host := test.NewHost(t, ds, "host1", "", "host1key", "host1uuid", time.Now())
+
+	software := []fleet.Software{
+		{Name: "linux-image-5.4.0-42-generic", Version: "5.4.0-42.46", Source: "deb_packages"},
+		{Name: "linux-image-6.5.0-42-generic", Version: "6.5.0-100.27", Source: "deb_packages"},
+		{Name: "linux-image-5.4.0-42-custom", Version: "5.4.0-42.46", Source: "deb_packages"},
+		{Name: "linux-image-6.5.0-42-1234-foo", Version: "6.5.0-100.27", Source: "deb_packages"},
+		{Name: "linux-image-generic", Version: "1.0.0", Source: "deb_packages"},
+		{Name: "foo", Version: "0.0.1", Source: "chrome_extensions"},
+		{Name: "bar", Version: "0.0.3", Source: "deb_packages"},
+	}
+
+	_, err := ds.UpdateHostSoftware(context.Background(), host.ID, software)
+	require.NoError(t, err)
+	require.NoError(t, ds.LoadHostSoftware(context.Background(), host, false))
+
+	expected := []fleet.Software{
+		{Name: "linux-image-5.4.0-42-custom", Version: "5.4.0-42.46", Source: "deb_packages"},
+		{Name: "linux-image-6.5.0-42-1234-foo", Version: "6.5.0-100.27", Source: "deb_packages"},
+	}
+
+	opts := fleet.SoftwareIterQueryOptions{
+		NameMatch: nvd.LinuxImageRegex,
+		NameExclude: nvd.LinuxImageExclusions,
+		IncludedSources: []string{"deb_packages"},
+	}
+
+	iterator, err := ds.AllSoftwareIterator(context.Background(), opts)
+	require.NoError(t, err)
+
+	var actual []fleet.Software
+	for iterator.Next() {
+		software, err := iterator.Value()
+		require.NoError(t, err)
+		actual = append(actual, *software)
+	}
+	iterator.Close()
+	test.ElementsMatchSkipID(t, expected, actual)
 }
 
 func testUpsertSoftwareCPEs(t *testing.T, ds *Datastore) {

--- a/server/datastore/mysql/software_test.go
+++ b/server/datastore/mysql/software_test.go
@@ -2408,8 +2408,8 @@ func testSoftwareIteratorForLinuxKernelCustomImages(t *testing.T, ds *Datastore)
 	}
 
 	opts := fleet.SoftwareIterQueryOptions{
-		NameMatch: nvd.LinuxImageRegex,
-		NameExclude: nvd.LinuxImageExclusions,
+		NameMatch:       nvd.LinuxImageRegex,
+		NameExclude:     nvd.LinuxImageExclusions,
 		IncludedSources: []string{"deb_packages"},
 	}
 

--- a/server/datastore/mysql/software_test.go
+++ b/server/datastore/mysql/software_test.go
@@ -2409,7 +2409,7 @@ func testSoftwareIteratorForLinuxKernelCustomImages(t *testing.T, ds *Datastore)
 
 	opts := fleet.SoftwareIterQueryOptions{
 		NameMatch:       nvd.LinuxImageRegex,
-		NameExclude:     nvd.LinuxImageExclusions,
+		NameExclude:     nvd.BuildLinuxExclusionRegex(),
 		IncludedSources: []string{"deb_packages"},
 	}
 

--- a/server/fleet/software.go
+++ b/server/fleet/software.go
@@ -267,6 +267,7 @@ type SoftwareListOptions struct {
 type SoftwareIterQueryOptions struct {
 	ExcludedSources []string // what sources to exclude
 	IncludedSources []string // what sources to include
+	NameFilter      string   // filter software by name
 }
 
 // IsValid checks that either ExcludedSources or IncludedSources is specified but not both

--- a/server/fleet/software.go
+++ b/server/fleet/software.go
@@ -267,7 +267,8 @@ type SoftwareListOptions struct {
 type SoftwareIterQueryOptions struct {
 	ExcludedSources []string // what sources to exclude
 	IncludedSources []string // what sources to include
-	NameFilter      string   // filter software by name
+	NameMatch       string   // mysql regex to filter software by name
+	NameExclude     string   // mysql regex to filter software by name
 }
 
 // IsValid checks that either ExcludedSources or IncludedSources is specified but not both

--- a/server/vulnerabilities/macoffice/integration_sync_test.go
+++ b/server/vulnerabilities/macoffice/integration_sync_test.go
@@ -12,7 +12,6 @@ import (
 )
 
 func TestIntegrationSync(t *testing.T) {
-	t.Skip("REMOVEME: when API keys are restored")
 	nettest.Run(t)
 
 	vulnPath := t.TempDir()

--- a/server/vulnerabilities/nvd/README.md
+++ b/server/vulnerabilities/nvd/README.md
@@ -7,23 +7,24 @@ To improve accuracy when [mapping software to CVEs](../../../docs/Using%20Fleet/
 
 ## How CPE translations work
 
-CPE Translations are defined in `cpe_translations.json` and released in
+CPE Translations are defined in `cpe_translations.json` and currently released in
 [GitHub](https://github.com/fleetdm/nvd) once a day.  The rules are specified in JSON format and
-and each rule consists of a `software` and `filter` object.
+and each rule consists of a `software` and a `filter` object.
 
 `software` defines matching logic on what Fleet Software this rule should apply to.  You can use one
-or more of the following attributes to match on.  Each attribute is an array of string or regex
-matches.  A match on the attribute is found if at least 1 item in the array matches.  If multiple
+or more of the below attributes to match on.  Each attribute is an array of string or regex
+matches (a regex string is identified by a leading and trailing `/`).  
+A match on the attribute is found if at least 1 item in the array matches.  If multiple
 attributes are defined, then a match is needed for each attribute.  (ie. `name == Zoom.app` &&
 `source == apps`)
 
-`software`:
+`software` attributes:
 
 - `name`: A software name attribute 
-- `bundle_identifier`: A software bundle_identifier attribute (macOS)
-- `source`: A software source attribute (TODO: add link)
+- `bundle_identifier`: A software bundle_identifier attribute (macOS only)
+- `source`: A software source attribute (ie. `apps`, `chrome_extensions`, etc...)
 
-example:
+**example**: Search Fleet software for items that match: (bundle_identifier == us.zoom.xos) AND (source = apps)
 
 ```json
 "software": {
@@ -32,21 +33,22 @@ example:
     }
 ```
 
-This searches Fleet software for items that match:
-(bundle_identifier == us.zoom.xos) AND (source = apps)
+If the software rule matches, then Fleet will search known NVD CPEs (stored in a local sqlite database) using the
+specified filters or skip the software item based on the `filter` specified.  
 
-If the software rule matches, then Fleet will search the CPE database (TODO add link) using the
-specified filters or skip the software item based on the `filter` specified.  `filter` can contain:
+`filter` attributes:
 
 - `product`: array of strings to search by product field
 - `vendor`: array of strings to search by vendor field
 - `target_sw`: array of strings to search by target_sw field
+- `part`: string to override the default "a" Part value
 - `skip`: boolean; software is skipped if `true`.  This overrides any other filters set.
 
 Like the software matching logic, filter items are matched by OR within the array, and AND between
 filter items
 
-example:
+**example**: Query the CPE database for a CPE that matches:
+(product == zoom OR product == meetings) AND (vendor == zoom) AND (target == macos OR target == mac_os)
 
 ```json
 "filter": {
@@ -56,11 +58,9 @@ example:
     }
 ```
 
-The above will query the CPE database for a CPE that matches:
 
-(product == zoom OR product == meetings) AND (vendor == zoom) AND (target == macos OR target == mac_os)
 
-## Testing CPE Translations
+## Testing CPE Translations (end-to-end)
 
 1. make the [appropriate](../../../docs/Using%20Fleet/Vulnerability-Processing.md#Improving-accuracy) changes to cpe_translations
 

--- a/server/vulnerabilities/nvd/README.md
+++ b/server/vulnerabilities/nvd/README.md
@@ -1,9 +1,66 @@
-# Testing CPE Translations
+# CPE Translations
 
-To improve accuracy when [mapping software to CVEs](../../../docs/Using%20Fleet/Vulnerability-Processing.md), we can add data to [cpe_translations.json](./cpe_translations.json) which
-will get picked up by the NVD repo.
+CPE Translations are rules to address bugs when translating Fleet software to Common Platform Enumerations
+(CPEs) which are used to identify software in the National Vulnerability Database (NVD)
 
-To test these changes locally, you can:
+To improve accuracy when [mapping software to CVEs](../../../docs/Using%20Fleet/Vulnerability-Processing.md), we can add data to [cpe_translations.json](./cpe_translations.json)
+
+## How CPE translations work
+
+CPE Translations are defined in `cpe_translations.json` and released in
+[GitHub](https://github.com/fleetdm/nvd) once a day.  The rules are specified in JSON format and
+and each rule consists of a `software` and `filter` object.
+
+`software` defines matching logic on what Fleet Software this rule should apply to.  You can use one
+or more of the following attributes to match on.  Each attribute is an array of string or regex
+matches.  A match on the attribute is found if at least 1 item in the array matches.  If multiple
+attributes are defined, then a match is needed for each attribute.  (ie. `name == Zoom.app` &&
+`source == apps`)
+
+`software`:
+
+- `name`: A software name attribute 
+- `bundle_identifier`: A software bundle_identifier attribute (macOS)
+- `source`: A software source attribute (TODO: add link)
+
+example:
+
+```json
+"software": {
+      "bundle_identifier": ["us.zoom.xos"],
+      "source": ["apps"]
+    }
+```
+
+This searches Fleet software for items that match:
+(bundle_identifier == us.zoom.xos) AND (source = apps)
+
+If the software rule matches, then Fleet will search the CPE database (TODO add link) using the
+specified filters or skip the software item based on the `filter` specified.  `filter` can contain:
+
+- `product`: array of strings to search by product field
+- `vendor`: array of strings to search by vendor field
+- `target_sw`: array of strings to search by target_sw field
+- `skip`: boolean; software is skipped if `true`.  This overrides any other filters set.
+
+Like the software matching logic, filter items are matched by OR within the array, and AND between
+filter items
+
+example:
+
+```json
+"filter": {
+      "product": ["zoom", "meetings"],
+      "vendor": ["zoom"],
+      "target_sw": ["macos", "mac_os"]
+    }
+```
+
+The above will query the CPE database for a CPE that matches:
+
+(product == zoom OR product == meetings) AND (vendor == zoom) AND (target == macos OR target == mac_os)
+
+## Testing CPE Translations
 
 1. make the [appropriate](../../../docs/Using%20Fleet/Vulnerability-Processing.md#Improving-accuracy) changes to cpe_translations
 
@@ -16,17 +73,20 @@ To test these changes locally, you can:
 3. (re)launch your local fleet server with one of the following
 
     Config method
+
     ```yaml
     vulnerabilities:
     cpe_translations_url: "http://localhost:8082/cpe_translations.json"
     ```
-    
+
     Environment method
+
     ```bash
     FLEET_VULNERABILITIES_CPE_TRANSLATIONS_URL="http://localhost:8082/cpe_translations.json" ./build/fleet serve --dev --dev_license --logging_debug
     ```
 
 4. trigger a vulnerabilities scan
+
     ```bash
     fleetctl trigger --name vulnerabilities
     ```

--- a/server/vulnerabilities/nvd/cpe.go
+++ b/server/vulnerabilities/nvd/cpe.go
@@ -385,7 +385,7 @@ const LinuxImageRegex = `^linux-image-\d+\.\d+\.\d+-\d+-\w+`
 // knownUbuntuKernelVariants is a list of known kernel variants that are used in the Ubuntu kernel
 // OVAL feeds.  These are used to determine if a kernel package is a custom variant and should be
 // matched against the NVD feed rather than the OVAL feed.
-var knownUbuntuKernelVariants []string = []string{
+var knownUbuntuKernelVariants = []string{
 	"allwinner",
 	"aws",
 	"aws-hwe",

--- a/server/vulnerabilities/nvd/cpe.go
+++ b/server/vulnerabilities/nvd/cpe.go
@@ -380,7 +380,8 @@ func consumeCPEBuffer(
 	return nil
 }
 
-const LinuxImageRegex = `^linux-image-\d+\.\d+\.\d+-\d+-\w+`
+// mysql 5.7 compatible regexp for ubuntu kernel package names
+const LinuxImageRegex = `^linux-image-[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+-[[:digit:]]+-[[:alnum:]]+`
 
 // knownUbuntuKernelVariants is a list of known kernel variants that are used in the Ubuntu kernel
 // OVAL feeds.  These are used to determine if a kernel package is a custom variant and should be

--- a/server/vulnerabilities/nvd/cpe.go
+++ b/server/vulnerabilities/nvd/cpe.go
@@ -382,6 +382,9 @@ func consumeCPEBuffer(
 
 const LinuxImageRegex = `^linux-image-\d+\.\d+\.\d+-\d+-\w+`
 
+// knownUbuntuKernelVariants is a list of known kernel variants that are used in the Ubuntu kernel
+// OVAL feeds.  These are used to determine if a kernel package is a custom variant and should be
+// matched against the NVD feed rather than the OVAL feed.
 var knownUbuntuKernelVariants []string = []string{
 	"allwinner",
 	"aws",

--- a/server/vulnerabilities/nvd/cpe.go
+++ b/server/vulnerabilities/nvd/cpe.go
@@ -449,6 +449,7 @@ func TranslateSoftwareToCPE(
 	if err != nil {
 		return ctxerr.Wrap(ctx, err, "non-oval software iterator")
 	}
+	defer nonOvalIterator.Close()
 
 	err = translateSoftwareToCPEWithIterator(ctx, ds, vulnPath, logger, nonOvalIterator)
 	if err != nil {
@@ -470,6 +471,7 @@ func TranslateSoftwareToCPE(
 	if err != nil {
 		return ctxerr.Wrap(ctx, err, "ubuntu kernel iterator")
 	}
+	defer ubuntuKernelIterator.Close()
 
 	err = translateSoftwareToCPEWithIterator(ctx, ds, vulnPath, logger, ubuntuKernelIterator)
 	if err != nil {

--- a/server/vulnerabilities/nvd/cpe.go
+++ b/server/vulnerabilities/nvd/cpe.go
@@ -380,10 +380,54 @@ func consumeCPEBuffer(
 	return nil
 }
 
-const (
-	LinuxImageRegex      = `^linux-image-\d+\.\d+\.\d+-\d+-\w+`
-	LinuxImageExclusions = `-(azure|raspi2|powerpc64-emb|powerpc-e500mc|powerpc64-smp|kvm|gkeop|xilinx-zynqmp|intel|euclid|nvidia|lowlatency-64k|aws|raspi-nolpae|aws-hwe|oem-osp1|azure-fde|intel-iotg|iot|raspi|bluefield|oracle-64k|starfive|generic-lpae|dell300x|laptop|powerpc-e500|nvidia-lowlatency|powerpc-smp|generic|ibm|allwinner|gcp|snapdragon|gke|oem|lowlatency|generic-64k|oracle|nvidia-64k)$`
-)
+const LinuxImageRegex = `^linux-image-\d+\.\d+\.\d+-\d+-\w+`
+
+var knownUbuntuKernelVariants []string = []string{
+	"allwinner",
+	"aws",
+	"aws-hwe",
+	"azure",
+	"azure-fde",
+	"bluefield",
+	"dell300x",
+	"euclid",
+	"gcp",
+	"generic",
+	"generic-64k",
+	"generic-lpae",
+	"gke",
+	"gkeop",
+	"intel",
+	"intel-iotg",
+	"ibm",
+	"iot",
+	"kvm",
+	"laptop",
+	"lowlatency",
+	"lowlatency-64k",
+	"nvidia",
+	"nvidia-64k",
+	"nvidia-lowlatency",
+	"oem",
+	"oem-osp1",
+	"oracle",
+	"oracle-64k",
+	"powerpc-e500",
+	"powerpc-e500mc",
+	"powerpc-smp",
+	"powerpc64-emb",
+	"powerpc64-smp",
+	"raspi",
+	"raspi-nolpae",
+	"raspi2",
+	"snapdragon",
+	"starfive",
+	"xilinx-zynqmp",
+}
+
+func BuildLinuxExclusionRegex() string {
+	return fmt.Sprintf("-(%s)$", strings.Join(knownUbuntuKernelVariants, "|"))
+}
 
 func TranslateSoftwareToCPE(
 	ctx context.Context,
@@ -413,7 +457,7 @@ func TranslateSoftwareToCPE(
 		fleet.SoftwareIterQueryOptions{
 			IncludedSources: []string{"deb_packages"},
 			NameMatch:       LinuxImageRegex,
-			NameExclude:     LinuxImageExclusions,
+			NameExclude:     BuildLinuxExclusionRegex(),
 		},
 	)
 	if err != nil {

--- a/server/vulnerabilities/nvd/cpe.go
+++ b/server/vulnerabilities/nvd/cpe.go
@@ -447,13 +447,16 @@ func TranslateSoftwareToCPE(
 		},
 	)
 	if err != nil {
-		return ctxerr.Wrap(ctx, err, "software iterator")
+		return ctxerr.Wrap(ctx, err, "non-oval software iterator")
 	}
-	defer nonOvalIterator.Close()
 
 	err = translateSoftwareToCPEWithIterator(ctx, ds, vulnPath, logger, nonOvalIterator)
 	if err != nil {
-		return fmt.Errorf("translate software to CPE: %w", err)
+		return ctxerr.Wrap(ctx, err, "translate non-oval software to CPE")
+	}
+
+	if err := nonOvalIterator.Close(); err != nil {
+		return ctxerr.Wrap(ctx, err, "closing non-oval software iterator")
 	}
 
 	ubuntuKernelIterator, err := ds.AllSoftwareIterator(
@@ -467,11 +470,14 @@ func TranslateSoftwareToCPE(
 	if err != nil {
 		return ctxerr.Wrap(ctx, err, "ubuntu kernel iterator")
 	}
-	defer ubuntuKernelIterator.Close()
 
 	err = translateSoftwareToCPEWithIterator(ctx, ds, vulnPath, logger, ubuntuKernelIterator)
 	if err != nil {
-		return fmt.Errorf("translate ubuntu kernel to CPE: %w", err)
+		return ctxerr.Wrap(ctx, err, "translate ubuntu kernel to CPE")
+	}
+
+	if err := ubuntuKernelIterator.Close(); err != nil {
+		return ctxerr.Wrap(ctx, err, "closing ubuntu kernel iterator")
 	}
 
 	return nil

--- a/server/vulnerabilities/nvd/cpe_test.go
+++ b/server/vulnerabilities/nvd/cpe_test.go
@@ -135,6 +135,28 @@ func TestCPETranslations(t *testing.T) {
 			},
 			Expected: "cpe:2.3:a:vendor:product-1:1.2.3:*:*:*:*:macos:*:*",
 		},
+		{
+			Name: "translate part",
+			Translations: CPETranslations{
+				{
+					Software: CPETranslationSoftware{
+						Name:   []string{"X"},
+						Source: []string{"apps"},
+					},
+					Filter: CPETranslation{
+						Product: []string{"product-1"},
+						Vendor:  []string{"vendor"},
+						Part:    "o",
+					},
+				},
+			},
+			Software: &fleet.Software{
+				Name:    "X",
+				Version: "1.2.3",
+				Source:  "apps",
+			},
+			Expected: "cpe:2.3:o:vendor:product-1:1.2.3:*:*:*:*:macos:*:*",
+		},
 	}
 
 	reCache := newRegexpCache()
@@ -149,7 +171,6 @@ func TestCPETranslations(t *testing.T) {
 }
 
 func TestSyncCPEDatabase(t *testing.T) {
-	t.Skip("REMOVEME: when API keys are restored")
 	nettest.Run(t)
 
 	tempDir := t.TempDir()
@@ -467,7 +488,6 @@ func TestLegacyCPEDB(t *testing.T) {
 }
 
 func TestCPEFromSoftwareIntegration(t *testing.T) {
-	t.Skip("REMOVEME: when API keys are restored")
 	testCases := []struct {
 		software fleet.Software
 		cpe      string
@@ -1614,6 +1634,15 @@ func TestCPEFromSoftwareIntegration(t *testing.T) {
 				Vendor:  "",
 			},
 			cpe: `cpe:2.3:a:python:python:3.9.18_2:*:*:*:*:*:*:*`,
+		},
+		{
+			software: fleet.Software{
+				Name:    "linux-image-5.4.0-105-custom",
+				Source:  "deb_packages",
+				Version: "5.4.0-105.118",
+				Vendor:  "",
+			},
+			cpe: "cpe:2.3:o:linux:linux_kernel:5.4.0-105.118:*:*:*:*:*:*:*",
 		},
 	}
 

--- a/server/vulnerabilities/nvd/cpe_translations.go
+++ b/server/vulnerabilities/nvd/cpe_translations.go
@@ -215,6 +215,7 @@ type CPETranslation struct {
 	Product  []string `json:"product"`
 	Vendor   []string `json:"vendor"`
 	TargetSW []string `json:"target_sw"`
+	Part     string   `json:"part"`
 	// If Skip is set, no NVD vulnerabilities will be reported for the matching software.
 	Skip bool `json:"skip"`
 }

--- a/server/vulnerabilities/nvd/cpe_translations.json
+++ b/server/vulnerabilities/nvd/cpe_translations.json
@@ -377,5 +377,15 @@
     "filter": {
       "skip": true
     }
+  },
+  {
+    "software": {
+      "name": ["/^linux-image\\.*/"]
+    },
+    "filter": {
+      "product": ["linux_kernel"],
+      "vendor": ["linux"],
+      "part": "o"
+    }
   }
 ]

--- a/server/vulnerabilities/nvd/cve_test.go
+++ b/server/vulnerabilities/nvd/cve_test.go
@@ -131,7 +131,6 @@ func (d *threadSafeDSMock) InsertSoftwareVulnerability(ctx context.Context, vuln
 }
 
 func TestTranslateCPEToCVE(t *testing.T) {
-	t.Skip("REMOVEME: when API keys are restored")
 	t.Parallel()
 	ctx := context.Background()
 

--- a/server/vulnerabilities/nvd/indexed_cpe_item.go
+++ b/server/vulnerabilities/nvd/indexed_cpe_item.go
@@ -6,7 +6,8 @@ import (
 )
 
 type IndexedCPEItem struct {
-	ID         int    `json:"id" db:"rowid"`
+	ID         int `json:"id" db:"rowid"`
+	Part       string
 	Product    string `json:"product" db:"product"`
 	Vendor     string `json:"vendor" db:"vendor"`
 	Deprecated bool   `json:"deprecated" db:"deprecated"`
@@ -20,6 +21,10 @@ func (i *IndexedCPEItem) FmtStr(s *fleet.Software) string {
 	cpe.Product = i.Product
 	cpe.Version = sanitizeVersion(s.Version)
 	cpe.TargetSW = targetSW(s)
+
+	if i.Part != "" {
+		cpe.Part = i.Part
+	}
 
 	// Make sure we don't return a 'match all' CPE
 	if cpe.Vendor == wfn.Any || cpe.Product == wfn.Any {

--- a/server/vulnerabilities/nvd/sync_test.go
+++ b/server/vulnerabilities/nvd/sync_test.go
@@ -82,7 +82,6 @@ func TestLoadCVEMeta(t *testing.T) {
 }
 
 func TestDownloadCPETranslations(t *testing.T) {
-	t.Skip("REMOVEME: when API keys are restored")
 	nettest.Run(t)
 
 	tempDir := t.TempDir()


### PR DESCRIPTION
#19347

Scan for custom Ubuntu kernels in NVD

During NVD scan, Fleet currently iterates only through non-Linux software.   The iterator object is expanded to include mysql regex matches so we can initiate a 2nd iterator to only find custom linux kernel images.  "custom" is defined as a kernel with a suffix not in the pre-defined `knownUbuntuKernelVariants` slice.

Now that these kernel images can be iterated through, a CPE translation is added to transform product and vendor to `linux:linux_kernel`.   CPE Translations also had to be expanded to include a `Part` override (part is the 3rd object in a CPE string, defining operatingSystem ("o") or application("a").  Currently all CPE translations generate an "a" part.

NOTE: I changed course from the original method of parsing OVAL feeds on every scan to look for kernel variants.  I don't expect new kernel variants to be added very often, so we shouldn't have to maintain that parsing code.  New kernels can be added to the slice on demand.



- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [X] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [X] Added/updated tests
- [X] Manual QA for all new/changed functionality