### PR TITLE
Website: Update Markdown headings

### DIFF
--- a/website/api/helpers/strings/to-html.js
+++ b/website/api/helpers/strings/to-html.js
@@ -94,7 +94,11 @@ module.exports = {
       };
     } else  {
       customRenderer.heading = function (text, level) {
-        return '<h'+level+'>'+text+'</h'+level+'>';
+        var textWithLineBreaks;
+        if(text.match(/\S(\w+\_\S)+(\w\S)+/g) && !text.match(/\s/g)){
+          textWithLineBreaks = text.replace(/(\_)/g, '&#8203;_');
+        }
+        return '<h'+level+'>'+(textWithLineBreaks ? textWithLineBreaks : text)+'</h'+level+'>';
       };
     }
 


### PR DESCRIPTION
Closes: #19606

Changes:
- Updated the `to-html` helper to add optional linebreaks to all Markdown headings that contain an underscore.