### PR TITLE
fix icon misalignments on dashboard cards

### DIFF
--- a/changes/issue-19555-dashboard-icon-fixes
+++ b/changes/issue-19555-dashboard-icon-fixes
@@ -1,0 +1,1 @@
+- fix various icon misalignments on the dashboard page

--- a/frontend/components/TableContainer/DataTable/InternalLinkCell/_styles.scss
+++ b/frontend/components/TableContainer/DataTable/InternalLinkCell/_styles.scss
@@ -5,6 +5,7 @@
     color: $core-vibrant-blue;
     font-weight: $bold;
     display: inline-flex;
+    gap: $pad-small;
 
     &:hover {
       cursor: pointer;

--- a/frontend/pages/DashboardPage/components/InfoCard/_styles.scss
+++ b/frontend/pages/DashboardPage/components/InfoCard/_styles.scss
@@ -57,6 +57,7 @@
     color: $core-vibrant-blue;
     font-weight: $bold;
     text-decoration: none !important;
+    gap: $pad-small;
 
     &:focus-visible {
       outline: 1px solid $core-vibrant-blue;
@@ -64,10 +65,5 @@
   }
   &__action-button-text {
     text-align: right;
-  }
-
-  .icon {
-    margin-left: $pad-small;
-    vertical-align: sub;
   }
 }


### PR DESCRIPTION
relates to #19555

This fixes various icon misalignments on the dashboard page.

**before:**

![image](https://github.com/fleetdm/fleet/assets/1153709/0738c8a3-88c7-481b-8675-fdeb5713de78)

**after:**

![image](https://github.com/fleetdm/fleet/assets/1153709/25bc995a-644e-4310-b32d-09d39f28960c)

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [x] Manual QA for all new/changed functionality
