### PR TITLE
Enable gitops to create teams with no enroll secrets, or clear enroll secrets for an existing team

### DIFF
--- a/changes/ 19332-clear-secrets-with-gitops
+++ b/changes/ 19332-clear-secrets-with-gitops
@@ -1,0 +1,1 @@
+Enable gitops to create teams with no enroll secrets, or clear enroll secrets for an existing team by setting team_settings.secret to nothing or to an empty array.

--- a/cmd/fleetctl/testdata/expectedGetTeamsYaml.yml
+++ b/cmd/fleetctl/testdata/expectedGetTeamsYaml.yml
@@ -29,6 +29,7 @@ spec:
         enable_release_device_manually: false
         macos_setup_assistant:
     scripts: null
+    secrets: null
     software: null
     webhook_settings:
       host_status_webhook: null

--- a/cmd/fleetctl/testdata/macosSetupExpectedTeam1And2Empty.yml
+++ b/cmd/fleetctl/testdata/macosSetupExpectedTeam1And2Empty.yml
@@ -29,6 +29,7 @@ spec:
         deadline_days: null
         grace_period_days: null
     scripts: null
+    secrets: null
     software: null
     webhook_settings:
       host_status_webhook: null
@@ -63,6 +64,7 @@ spec:
         deadline_days: null
         grace_period_days: null
     scripts: null
+    secrets: null
     software: null
     webhook_settings:
       host_status_webhook: null

--- a/cmd/fleetctl/testdata/macosSetupExpectedTeam1And2Set.yml
+++ b/cmd/fleetctl/testdata/macosSetupExpectedTeam1And2Set.yml
@@ -29,6 +29,7 @@ spec:
         deadline_days: null
         grace_period_days: null
     scripts: null
+    secrets: null
     software: null
     webhook_settings:
       host_status_webhook: null
@@ -63,6 +64,7 @@ spec:
         deadline_days: null
         grace_period_days: null
     scripts: null
+    secrets: null
     software: null
     webhook_settings:
       host_status_webhook: null

--- a/cmd/fleetctl/testdata/macosSetupExpectedTeam1Empty.yml
+++ b/cmd/fleetctl/testdata/macosSetupExpectedTeam1Empty.yml
@@ -29,6 +29,7 @@ spec:
       windows_settings:
         custom_settings: null
     scripts: null
+    secrets: null
     software: null
     webhook_settings:
       host_status_webhook: null

--- a/cmd/fleetctl/testdata/macosSetupExpectedTeam1Set.yml
+++ b/cmd/fleetctl/testdata/macosSetupExpectedTeam1Set.yml
@@ -28,6 +28,7 @@ spec:
         deadline_days: null
         grace_period_days: null
     scripts: null
+    secrets: null
     software: null
     webhook_settings:
       host_status_webhook: null

--- a/ee/server/service/teams.go
+++ b/ee/server/service/teams.go
@@ -773,10 +773,17 @@ func (svc *Service) ApplyTeamSpecs(ctx context.Context, specs []*fleet.TeamSpec,
 
 	for _, spec := range specs {
 		var secrets []*fleet.EnrollSecret
-		for _, secret := range spec.Secrets {
-			secrets = append(secrets, &fleet.EnrollSecret{
-				Secret: secret.Secret,
-			})
+		// When secrets slice is empty, all secrets are removed.
+		// When secrets slice is nil, existing secrets are kept.
+		if spec.Secrets != nil {
+			secrets = make([]*fleet.EnrollSecret, 0, len(*spec.Secrets))
+			for _, secret := range *spec.Secrets {
+				secrets = append(
+					secrets, &fleet.EnrollSecret{
+						Secret: secret.Secret,
+					},
+				)
+			}
 		}
 
 		var create bool
@@ -804,7 +811,7 @@ func (svc *Service) ApplyTeamSpecs(ctx context.Context, specs []*fleet.TeamSpec,
 				}
 			}
 		}
-		if len(spec.Secrets) > fleet.MaxEnrollSecretsCount {
+		if len(secrets) > fleet.MaxEnrollSecretsCount {
 			return nil, ctxerr.Wrap(ctx, fleet.NewInvalidArgumentError("secrets", "too many secrets"), "validate secrets")
 		}
 		if err := spec.MDM.MacOSUpdates.Validate(); err != nil {
@@ -816,8 +823,9 @@ func (svc *Service) ApplyTeamSpecs(ctx context.Context, specs []*fleet.TeamSpec,
 
 		if create {
 
-			// create a new team enroll secret if none is provided for a new team.
-			if len(secrets) == 0 {
+			// create a new team enroll secret if none is provided for a new team,
+			// unless the user explicitly passed in an empty array
+			if secrets == nil {
 				secret, err := server.GenerateRandomText(fleet.EnrollSecretDefaultLength)
 				if err != nil {
 					return nil, ctxerr.Wrap(ctx, err, "generate enroll secret string")
@@ -1125,7 +1133,7 @@ func (svc *Service) editTeamFromSpec(
 		team.Config.Software = spec.Software
 	}
 
-	if len(secrets) > 0 {
+	if secrets != nil {
 		team.Secrets = secrets
 	}
 
@@ -1179,8 +1187,8 @@ func (svc *Service) editTeamFromSpec(
 		return err
 	}
 
-	// only replace enroll secrets if at least one is provided (#6774)
-	if len(secrets) > 0 {
+	// If no secrets are provided and user did not explicitly specify an empty list, do not replace secrets. (#6774)
+	if secrets != nil {
 		if err := svc.ds.ApplyEnrollSecrets(ctx, ptr.Uint(team.ID), secrets); err != nil {
 			return err
 		}

--- a/pkg/spec/gitops.go
+++ b/pkg/spec/gitops.go
@@ -244,7 +244,8 @@ func parseSecrets(result *GitOps, multiError *multierror.Error) *multierror.Erro
 			return multierror.Append(multiError, errors.New("'team_settings.secrets' is required"))
 		}
 	}
-	var enrollSecrets []*fleet.EnrollSecret
+	// When secrets slice is empty, all secrets are removed.
+	enrollSecrets := make([]*fleet.EnrollSecret, 0)
 	if rawSecrets != nil {
 		secrets, ok := rawSecrets.([]interface{})
 		if !ok {

--- a/server/fleet/teams.go
+++ b/server/fleet/teams.go
@@ -419,7 +419,7 @@ type TeamSpec struct {
 	// set to the agent options JSON object.
 	AgentOptions       json.RawMessage                 `json:"agent_options,omitempty"` // marshals as "null" if omitempty is not set
 	HostExpirySettings *HostExpirySettings             `json:"host_expiry_settings,omitempty"`
-	Secrets            []EnrollSecret                  `json:"secrets,omitempty"`
+	Secrets            *[]EnrollSecret                 `json:"secrets,omitempty"`
 	Features           *json.RawMessage                `json:"features"`
 	MDM                TeamSpecMDM                     `json:"mdm"`
 	Scripts            optjson.Slice[string]           `json:"scripts"`
@@ -486,7 +486,7 @@ func TeamSpecFromTeam(t *Team) (*TeamSpec, error) {
 		Name:               t.Name,
 		AgentOptions:       agentOptions,
 		Features:           &featuresJSON,
-		Secrets:            secrets,
+		Secrets:            &secrets,
 		MDM:                mdmSpec,
 		HostExpirySettings: &t.Config.HostExpirySettings,
 		WebhookSettings:    webhookSettings,

--- a/server/service/integration_core_test.go
+++ b/server/service/integration_core_test.go
@@ -6012,7 +6012,7 @@ func (s *integrationTestSuite) TestPremiumEndpointsWithoutLicense() {
 
 	// apply team specs
 	var specResp applyTeamSpecsResponse
-	teamSpecs := applyTeamSpecsRequest{Specs: []*fleet.TeamSpec{{Name: "newteam", Secrets: []fleet.EnrollSecret{{Secret: "ABC"}}}}}
+	teamSpecs := applyTeamSpecsRequest{Specs: []*fleet.TeamSpec{{Name: "newteam", Secrets: &[]fleet.EnrollSecret{{Secret: "ABC"}}}}}
 	s.DoJSON("POST", "/api/latest/fleet/spec/teams", teamSpecs, http.StatusPaymentRequired, &specResp)
 
 	// modify team agent options

--- a/server/service/integration_mdm_test.go
+++ b/server/service/integration_mdm_test.go
@@ -71,7 +71,7 @@ import (
 
 func TestIntegrationsMDM(t *testing.T) {
 	testingSuite := new(integrationMDMTestSuite)
-	testingSuite.s = &testingSuite.Suite
+	testingSuite.withServer.s = &testingSuite.Suite
 	suite.Run(t, testingSuite)
 }
 
@@ -2316,7 +2316,7 @@ func (s *integrationMDMTestSuite) TestFleetdConfiguration() {
 	// create an enroll secret for the team
 	teamSpecs := applyTeamSpecsRequest{Specs: []*fleet.TeamSpec{{
 		Name:    tm.Name,
-		Secrets: []fleet.EnrollSecret{{Secret: t.Name() + "team-secret"}},
+		Secrets: &[]fleet.EnrollSecret{{Secret: t.Name() + "team-secret"}},
 	}}}
 	s.Do("POST", "/api/latest/fleet/spec/teams", teamSpecs, http.StatusOK)
 

--- a/server/service/teams_test.go
+++ b/server/service/teams_test.go
@@ -431,7 +431,7 @@ func TestApplyTeamSpecEnrollSecretForNewTeams(t *testing.T) {
 			return false, nil
 		}
 		_, err := svc.ApplyTeamSpecs(
-			ctx, []*fleet.TeamSpec{{Name: "Foo", Secrets: []fleet.EnrollSecret{enrollSecret}}},
+			ctx, []*fleet.TeamSpec{{Name: "Foo", Secrets: &[]fleet.EnrollSecret{enrollSecret}}},
 			fleet.ApplyTeamSpecOptions{ApplySpecOptions: fleet.ApplySpecOptions{DryRun: true}},
 		)
 		assert.ErrorContains(t, err, "is already being used")
@@ -441,14 +441,14 @@ func TestApplyTeamSpecEnrollSecretForNewTeams(t *testing.T) {
 			return true, nil
 		}
 		_, err = svc.ApplyTeamSpecs(
-			ctx, []*fleet.TeamSpec{{Name: "Foo", Secrets: []fleet.EnrollSecret{enrollSecret}}},
+			ctx, []*fleet.TeamSpec{{Name: "Foo", Secrets: &[]fleet.EnrollSecret{enrollSecret}}},
 			fleet.ApplyTeamSpecOptions{ApplySpecOptions: fleet.ApplySpecOptions{DryRun: true}},
 		)
 		assert.NoError(t, err)
 		assert.False(t, ds.NewTeamFuncInvoked)
 
 		_, err = svc.ApplyTeamSpecs(
-			ctx, []*fleet.TeamSpec{{Name: "Foo", Secrets: []fleet.EnrollSecret{enrollSecret}}}, fleet.ApplyTeamSpecOptions{},
+			ctx, []*fleet.TeamSpec{{Name: "Foo", Secrets: &[]fleet.EnrollSecret{enrollSecret}}}, fleet.ApplyTeamSpecOptions{},
 		)
 		require.NoError(t, err)
 		require.True(t, ds.TeamByNameFuncInvoked)


### PR DESCRIPTION
Enable gitops to create teams with no enroll secrets, or clear enroll secrets for an existing team
#19332 

`fleetctl apply` also gains this extra functionality. In `fleetctl apply` secrets will not be change if one of the following:
- secrets is missing from yml
- They are blank in yml, like: `secrets:`
- They are null in yml, like: `secrets: null`

They will only be cleared with `fleetctl apply` if the user explicitly sets them to an empty array, like:
- `secrets: []`

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [x] Added/updated tests
- [x] Manual QA for all new/changed functionality
