### PR TITLE
Release QA issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/release-qa.md
+++ b/.github/ISSUE_TEMPLATE/release-qa.md
@@ -99,6 +99,12 @@ Smoke tests are limited to core functionality and serve as a pre-release final r
 3. Verify able to run MDM commands on both macOS and Windows hosts from the CLI.
 </td><td>pass/fail</td></tr>
 
+<tr><td>MDM migration flow</td><td>Verify MDM enrollments, run MDM commands</td><td>
+  
+1. Turn off MDM on an ADE-eligible macOS host and verify that the native, "Device Enrollment" macOS notification appears.
+2. Follow the "Turn on MDM" instructions and verify that MDM is turned on.
+</td><td>pass/fail</td></tr>
+
 <tr><td>Scripts</td><td>Verify script library and execution</td><td>
 
 1. Verify able to run a script on all host types from CLI.

--- a/.github/ISSUE_TEMPLATE/release-qa.md
+++ b/.github/ISSUE_TEMPLATE/release-qa.md
@@ -99,7 +99,7 @@ Smoke tests are limited to core functionality and serve as a pre-release final r
 3. Verify able to run MDM commands on both macOS and Windows hosts from the CLI.
 </td><td>pass/fail</td></tr>
 
-<tr><td>MDM migration flow</td><td>Verify MDM default MDM migration for ADE and non-ADE hosts</td><td>
+<tr><td>MDM migration flow</td><td>Verify MDM migration for ADE and non-ADE hosts</td><td>
   
 1. Turn off MDM on an ADE-eligible macOS host and verify that the native, "Device Enrollment" macOS notification appears.
 2. On the My device page, follow the "Turn on MDM" instructions and verify that MDM is turned on.

--- a/.github/ISSUE_TEMPLATE/release-qa.md
+++ b/.github/ISSUE_TEMPLATE/release-qa.md
@@ -99,10 +99,12 @@ Smoke tests are limited to core functionality and serve as a pre-release final r
 3. Verify able to run MDM commands on both macOS and Windows hosts from the CLI.
 </td><td>pass/fail</td></tr>
 
-<tr><td>MDM migration flow</td><td>Verify MDM enrollments, run MDM commands</td><td>
+<tr><td>MDM migration flow</td><td>Verify MDM default MDM migration for ADE and non-ADE hosts</td><td>
   
 1. Turn off MDM on an ADE-eligible macOS host and verify that the native, "Device Enrollment" macOS notification appears.
-2. Follow the "Turn on MDM" instructions and verify that MDM is turned on.
+2. On the My device page, follow the "Turn on MDM" instructions and verify that MDM is turned on.
+3. Turn off MDM on a non ADE-eligible macOS host.
+4. On the My device page, follow the "Turn on MDM" instructions and verify that MDM is turned on.
 </td><td>pass/fail</td></tr>
 
 <tr><td>Scripts</td><td>Verify script library and execution</td><td>


### PR DESCRIPTION
Proposed update after discussion w/ @georgekarrv that we may have caught the following bug if we were testing the migration workflow each release: #19512

We also thought it was a good idea to make this part of release QA in case the flow breaks w/ a never version of macOS.

- Add section for testing the [default migration workflow](https://fleetdm.com/docs/using-fleet/mdm-migration-guide#default-workflow) for macOS hosts.
