### PR TITLE
Update pmset_darwin.go

### DIFF
--- a/orbit/pkg/table/pmset/pmset_darwin.go
+++ b/orbit/pkg/table/pmset/pmset_darwin.go
@@ -41,7 +41,7 @@ func Generate(ctx context.Context, queryContext table.QueryContext) ([]map[strin
 		}
 	}
 
-	output, err := exec.CommandContext(ctx, "/usr/bin/pmset", "-g", getting).CombinedOutput()
+	output, err := exec.CommandContext(ctx, "/usr/bin/pmset", "-g", "custom", getting).CombinedOutput()
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
From the pmset man page:

-g custom displays custom settings for all power sources.

i.e., pmset -g is incomplete. 

What would be even better is pmset -g everything which outputs results from all -g options but the schema of this data is inconsistent (it's not all key/vals) so would probably require more work.