### PR TITLE
Fix the `windows-remove-fleetd.ps1` script so that the agent can be reinstalled

### DIFF
--- a/changes/19197-fix-windows-remove-fleetd-script
+++ b/changes/19197-fix-windows-remove-fleetd-script
@@ -1,0 +1,1 @@
+* Fixed an issue with the Windows-specific `windows-remove-fleetd.ps1` script provided in the Fleet repository where running the script did remove `fleetd` but made it impossible to reinstall the agent.


### PR DESCRIPTION
#19197 

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [x] Manual QA for all new/changed functionality
