### PR TITLE
Revert "Update pmset_darwin.go" (to reduce testing of 1.26.0)

### DIFF
--- a/orbit/pkg/table/pmset/pmset_darwin.go
+++ b/orbit/pkg/table/pmset/pmset_darwin.go
@@ -41,7 +41,7 @@ func Generate(ctx context.Context, queryContext table.QueryContext) ([]map[strin
 		}
 	}
 
-	output, err := exec.CommandContext(ctx, "/usr/bin/pmset", "-g", "custom", getting).CombinedOutput()
+	output, err := exec.CommandContext(ctx, "/usr/bin/pmset", "-g", getting).CombinedOutput()
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This reverts commit aa7a2689f1ce84049aa8510db795a8eeaf8f91cd.