### PR TITLE
Render installer store changes

### DIFF
--- a/infrastructure/render/README.md
+++ b/infrastructure/render/README.md
@@ -39,4 +39,5 @@ Click the deploy on render button or import the blueprint from the Render servic
 
 ### Post-Deployment
 
-Navigate to the generated URL and run through the initial setup.
+Navigate to the generated URL and run through the initial setup. If you have a license key you can add it post-deploy as
+an environment variable `FLEET_LICENSE_KEY=value` in the Fleet service configuration.

--- a/render.yaml
+++ b/render.yaml
@@ -7,7 +7,13 @@ services:
       url: 'fleetdm/fleet:latest'
     preDeployCommand: "fleet prepare --no-prompt=true db"
     healthCheckPath: /healthz
+    disk:
+      name: installers
+      mountPath: /opt/fleet/installers
+      sizeGB: 10
     envVars:
+      - key: FLEET_SOFTWARE_INSTALLER_STORE_DIR
+        value: '/opt/fleet/installers'
       - key: FLEET_SERVER_PRIVATE_KEY
         generateValue: true
       - key: FLEET_MYSQL_ADDRESS


### PR DESCRIPTION
updated render deployment to support software installers, simply using a filesystem store as its realistically a POC environment.

![image](https://github.com/fleetdm/fleet/assets/1945008/b944cec7-86c0-42af-bce2-8a9938ef1355)
