### PR TITLE
Disable `mdm_bridge` table on Windows Server

### DIFF
--- a/orbit/cmd/fleetd_tables/fleetd_tables.go
+++ b/orbit/cmd/fleetd_tables/fleetd_tables.go
@@ -54,7 +54,11 @@ func main() {
 	opts := orbittable.PluginOpts{
 		Socket: *socket,
 	}
-	plugins = append(plugins, orbittable.PlatformTables(opts)...)
+	platformTables, err := orbittable.PlatformTables(opts)
+	if err != nil {
+		log.Fatalln(err)
+	}
+	plugins = append(plugins, platformTables...)
 	server.RegisterPlugin(plugins...)
 	if err := server.Run(); err != nil {
 		log.Fatalln(err)

--- a/orbit/pkg/table/extension.go
+++ b/orbit/pkg/table/extension.go
@@ -111,7 +111,12 @@ func (r *Runner) Execute() error {
 	plugins := OrbitDefaultTables()
 
 	opts := PluginOpts{Socket: r.socket}
-	plugins = append(plugins, PlatformTables(opts)...)
+	platformTables, err := PlatformTables(opts)
+	if err != nil {
+		return fmt.Errorf("populating platform tabeles: %w", err)
+	}
+
+	plugins = append(plugins, platformTables...)
 	for _, t := range r.tableExtensions {
 		plugins = append(plugins, table.NewPlugin(
 			t.Name(),

--- a/orbit/pkg/table/extension_darwin.go
+++ b/orbit/pkg/table/extension_darwin.go
@@ -38,7 +38,7 @@ import (
 	"github.com/osquery/osquery-go/plugin/table"
 )
 
-func PlatformTables(opts PluginOpts) []osquery.OsqueryPlugin {
+func PlatformTables(opts PluginOpts) ([]osquery.OsqueryPlugin, error) {
 	plugins := []osquery.OsqueryPlugin{
 		// Fleet tables
 		table.NewPlugin("icloud_private_relay", privaterelay.Columns(), privaterelay.Generate),
@@ -96,5 +96,5 @@ func PlatformTables(opts PluginOpts) []osquery.OsqueryPlugin {
 	// append platform specific tables
 	plugins = appendTables(plugins)
 
-	return plugins
+	return plugins, nil
 }

--- a/orbit/pkg/table/extension_linux.go
+++ b/orbit/pkg/table/extension_linux.go
@@ -10,10 +10,10 @@ import (
 	"github.com/osquery/osquery-go"
 )
 
-func PlatformTables(_ PluginOpts) []osquery.OsqueryPlugin {
+func PlatformTables(_ PluginOpts) ([]osquery.OsqueryPlugin, error) {
 	return []osquery.OsqueryPlugin{
 		cryptsetup.TablePlugin(osqueryLogger),            // table name is "cryptsetup_status"
 		falconctl.NewFalconctlOptionTable(osqueryLogger), // table name is "falconctl_option"
 		falcon_kernel_check.TablePlugin(osqueryLogger),   // table name is "falcon_kernel_check"
-	}
+	}, nil
 }

--- a/orbit/pkg/table/extension_windows.go
+++ b/orbit/pkg/table/extension_windows.go
@@ -6,17 +6,44 @@ import (
 	cisaudit "github.com/fleetdm/fleet/v4/orbit/pkg/table/cis_audit"
 	mdmbridge "github.com/fleetdm/fleet/v4/orbit/pkg/table/mdm"
 	"github.com/fleetdm/fleet/v4/orbit/pkg/table/windowsupdatetable"
+	"golang.org/x/sys/windows/registry"
 
 	"github.com/osquery/osquery-go"
 	"github.com/osquery/osquery-go/plugin/table"
 )
 
 func PlatformTables(_ PluginOpts) []osquery.OsqueryPlugin {
-	return []osquery.OsqueryPlugin{
+	plugins := []osquery.OsqueryPlugin{
 		// Fleet tables
-		table.NewPlugin("mdm_bridge", mdmbridge.Columns(), mdmbridge.Generate),
 		table.NewPlugin("cis_audit", cisaudit.Columns(), cisaudit.Generate),
 
 		windowsupdatetable.TablePlugin(windowsupdatetable.UpdatesTable, osqueryLogger), // table name is "windows_updates"
 	}
+
+	if !IsWindowsServer() {
+		plugins = append(plugins, table.NewPlugin("mdm_bridge", mdmbridge.Columns(), mdmbridge.Generate))
+	}
+
+	return plugins
+}
+
+func IsWindowsServer() bool {
+	// If the registry can't be read, it's safer to assume we're a
+	// server and not load the broken table
+	k, err := registry.OpenKey(registry.LOCAL_MACHINE, `SOFTWARE\Microsoft\Windows NT\CurrentVersion`, registry.QUERY_VALUE)
+	if err != nil {
+		return true
+	}
+	defer k.Close()
+
+	s, _, err := k.GetStringValue("InstallationType")
+	if err != nil {
+		return true
+	}
+
+	if s == "Server" {
+		return true
+	}
+
+	return false
 }

--- a/orbit/pkg/table/mdm/mdm_windows.go
+++ b/orbit/pkg/table/mdm/mdm_windows.go
@@ -137,8 +137,8 @@ func Generate(ctx context.Context, queryContext table.QueryContext) ([]map[strin
 		deviceEnrollmentStatus = "device_not_enrolled"
 	}
 
-	// Executing the input MDM command if it was present and we're MDM-enabled
-	if len(inputCmd) > 0 && isHostMDMenrolled != 0 {
+	// Executing the input MDM command
+	if len(inputCmd) > 0 {
 
 		// performs the actual MDM cmd execution against the OS MDM stack
 		outputCmd, err := executeMDMcommand(strings.TrimSpace(inputCmd))

--- a/orbit/pkg/table/mdm/mdm_windows.go
+++ b/orbit/pkg/table/mdm/mdm_windows.go
@@ -137,7 +137,7 @@ func Generate(ctx context.Context, queryContext table.QueryContext) ([]map[strin
 		deviceEnrollmentStatus = "device_not_enrolled"
 	}
 
-	// Executing the input MDM command
+	// Executing the input MDM command if it was present
 	if len(inputCmd) > 0 {
 
 		// performs the actual MDM cmd execution against the OS MDM stack

--- a/orbit/pkg/table/mdm/mdm_windows.go
+++ b/orbit/pkg/table/mdm/mdm_windows.go
@@ -137,8 +137,8 @@ func Generate(ctx context.Context, queryContext table.QueryContext) ([]map[strin
 		deviceEnrollmentStatus = "device_not_enrolled"
 	}
 
-	// Executing the input MDM command if it was present
-	if len(inputCmd) > 0 {
+	// Executing the input MDM command if it was present and we're MDM-enabled
+	if len(inputCmd) > 0 && isHostMDMenrolled != 0 {
 
 		// performs the actual MDM cmd execution against the OS MDM stack
 		outputCmd, err := executeMDMcommand(strings.TrimSpace(inputCmd))

--- a/server/service/osquery_utils/queries.go
+++ b/server/service/osquery_utils/queries.go
@@ -699,7 +699,7 @@ var mdmQueries = map[string]DetailQuery{
 		QueryFunc:        buildConfigProfilesWindowsQuery,
 		Platforms:        []string{"windows"},
 		DirectIngestFunc: directIngestWindowsProfiles,
-		Discovery:        discoveryTableAndServer("mdm_bridge"),
+		Discovery:        discoveryTable("mdm_bridge"),
 	},
 	// There are two mutually-exclusive queries used to read the FileVaultPRK depending on which
 	// extension tables are discovered on the agent. The preferred query uses the newer custom
@@ -752,21 +752,6 @@ var mdmQueries = map[string]DetailQuery{
 		DirectIngestFunc: directIngestMDMDeviceIDWindows,
 	},
 }
-
-func discoveryTableAndServer(tableName string) string {
-	discoveryTableServerQuery := `
-SELECT 1
-FROM osquery_registry o
-INNER JOIN
-   (SELECT 1 FROM registry WHERE path = 'HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows NT\CurrentVersion\InstallationType' AND data <> 'Server')
-WHERE o.active = true
-  AND o.registry = 'table'
-  AND o.name = 'mdm_bridge'`
-
-	return fmt.Sprintf(discoveryTableServerQuery, tableName)
-}
-
-const DiscoveryServer = `SELECT 1 FROM registry WHERE path = 'HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows NT\CurrentVersion\InstallationType' AND data <> 'Server' LIMIT 1`
 
 // discoveryTable returns a query to determine whether a table exists or not.
 func discoveryTable(tableName string) string {

--- a/server/service/osquery_utils/queries.go
+++ b/server/service/osquery_utils/queries.go
@@ -756,13 +756,13 @@ var mdmQueries = map[string]DetailQuery{
 func discoveryTableAndServer(tableName string) string {
 	discoveryTableServerQuery := `
 SELECT 1
-FROM osquery_registry
-WHERE active = true
-  AND registry = 'table'
-  AND name = '%s'
+FROM osquery_registry o
 INNER JOIN
    (SELECT 1 FROM registry WHERE path = 'HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows NT\CurrentVersion\InstallationType' AND data <> 'Server')
-`
+WHERE o.active = true
+  AND o.registry = 'table'
+  AND o.name = 'mdm_bridge'`
+
 	return fmt.Sprintf(discoveryTableServerQuery, tableName)
 }
 


### PR DESCRIPTION
#19239

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Manual QA for all new/changed functionality
  - For Orbit and Fleet Desktop changes:
    - [x] Manual QA must be performed in the three main OSs, macOS, Windows and Linux.
    - [x] Auto-update manual QA, from released version of component to new version (see [tools/tuf/test](../tools/tuf/test/README.md)).
