### PR TITLE
/api/latest/fleet/hosts/:id/lock returns `unlock_pin` for Apple hosts

### DIFF
--- a/changes/19545-unlock-pin
+++ b/changes/19545-unlock-pin
@@ -1,1 +1,2 @@
 * /api/latest/fleet/hosts/:id/lock returns `unlock_pin` for Apple hosts
+* UI no longer uses unlock pending state for Apple hosts

--- a/changes/19545-unlock-pin
+++ b/changes/19545-unlock-pin
@@ -1,0 +1,1 @@
+* /api/latest/fleet/hosts/:id/lock returns `unlock_pin` for Apple hosts

--- a/cmd/fleetctl/mdm_test.go
+++ b/cmd/fleetctl/mdm_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"slices"
@@ -361,13 +362,6 @@ func TestMDMLockCommand(t *testing.T) {
 		MDMInfo:  &fleet.HostMDM{Enrolled: true, Name: fleet.WellKnownMDMFleet},
 		MDM:      fleet.MDMHostData{Name: fleet.WellKnownMDMFleet, EnrollmentStatus: ptr.String("On (manual)")},
 	}
-	macEnrolledUP := &fleet.Host{
-		ID:       9,
-		UUID:     "mac-enrolled-up",
-		Platform: "darwin",
-		MDMInfo:  &fleet.HostMDM{Enrolled: true, Name: fleet.WellKnownMDMFleet},
-		MDM:      fleet.MDMHostData{Name: fleet.WellKnownMDMFleet, EnrollmentStatus: ptr.String("On (manual)")},
-	}
 
 	winEnrolledLP := &fleet.Host{
 		ID:       10,
@@ -409,7 +403,6 @@ func TestMDMLockCommand(t *testing.T) {
 		macPending,
 		winPending,
 		winEnrolledUP,
-		macEnrolledUP,
 		winEnrolledLP,
 		macEnrolledLP,
 		winEnrolledWP,
@@ -421,7 +414,6 @@ func TestMDMLockCommand(t *testing.T) {
 
 	unlockPending := map[uint]*fleet.Host{
 		winEnrolledUP.ID: winEnrolledUP,
-		macEnrolledUP.ID: macEnrolledUP,
 	}
 
 	lockPending := map[uint]*fleet.Host{
@@ -446,9 +438,7 @@ func TestMDMLockCommand(t *testing.T) {
 
 		if _, ok := unlockPending[host.ID]; ok {
 			if fleetPlatform == "darwin" {
-				status.UnlockPIN = "1234"
-				status.UnlockRequestedAt = time.Now()
-				return &status, nil
+				return nil, errors.New("apple devices do not have an unlock pending state")
 			}
 
 			status.UnlockScript = &fleet.HostScriptResult{}
@@ -542,7 +532,6 @@ fleetctl mdm unlock --host=%s
 		{appCfgWinMDM, "valid windows but pending ", []string{"--host", winPending.UUID}, `Can't lock the host because it doesn't have MDM turned on.`},
 		{appCfgMacMDM, "valid macos but pending", []string{"--host", macPending.UUID}, `Can't lock the host because it doesn't have MDM turned on.`},
 		{appCfgAllMDM, "valid windows but pending unlock", []string{"--host", winEnrolledUP.UUID}, "Host has pending unlock request."},
-		{appCfgAllMDM, "valid macos but pending unlock", []string{"--host", macEnrolledUP.UUID}, "Host has pending unlock request."},
 		{appCfgAllMDM, "valid windows but pending lock", []string{"--host", winEnrolledLP.UUID}, "Host has pending lock request."},
 		{appCfgAllMDM, "valid macos but pending lock", []string{"--host", macEnrolledLP.UUID}, "Host has pending lock request."},
 		{appCfgAllMDM, "valid windows but pending wipe", []string{"--host", winEnrolledWP.UUID}, "Host has pending wipe request."},
@@ -603,13 +592,6 @@ func TestMDMUnlockCommand(t *testing.T) {
 		MDMInfo:  &fleet.HostMDM{Enrolled: true, Name: fleet.WellKnownMDMFleet},
 		MDM:      fleet.MDMHostData{Name: fleet.WellKnownMDMFleet, EnrollmentStatus: ptr.String("On (manual)")},
 	}
-	macEnrolledUP := &fleet.Host{
-		ID:       9,
-		UUID:     "mac-enrolled-up",
-		Platform: "darwin",
-		MDMInfo:  &fleet.HostMDM{Enrolled: true, Name: fleet.WellKnownMDMFleet},
-		MDM:      fleet.MDMHostData{Name: fleet.WellKnownMDMFleet, EnrollmentStatus: ptr.String("On (manual)")},
-	}
 	winEnrolledLP := &fleet.Host{
 		ID:       10,
 		UUID:     "win-enrolled-lp",
@@ -650,7 +632,6 @@ func TestMDMUnlockCommand(t *testing.T) {
 		macPending,
 		winPending,
 		winEnrolledUP,
-		macEnrolledUP,
 		winEnrolledLP,
 		macEnrolledLP,
 		winEnrolledWP,
@@ -667,7 +648,6 @@ func TestMDMUnlockCommand(t *testing.T) {
 
 	unlockPending := map[uint]*fleet.Host{
 		winEnrolledUP.ID: winEnrolledUP,
-		macEnrolledUP.ID: macEnrolledUP,
 	}
 
 	lockPending := map[uint]*fleet.Host{
@@ -701,9 +681,7 @@ func TestMDMUnlockCommand(t *testing.T) {
 
 		if _, ok := unlockPending[host.ID]; ok {
 			if fleetPlatform == "darwin" {
-				status.UnlockPIN = "1234"
-				status.UnlockRequestedAt = time.Now()
-				return &status, nil
+				return nil, errors.New("apple devices do not have an unlock pending state")
 			}
 
 			status.UnlockScript = &fleet.HostScriptResult{}
@@ -800,7 +778,6 @@ fleetctl get host %s
 		{appCfgWinMDM, "valid windows but pending mdm enroll", []string{"--host", winPending.UUID}, `Can't unlock the host because it doesn't have MDM turned on.`},
 		{appCfgMacMDM, "valid macos but pending mdm enroll", []string{"--host", macPending.UUID}, `Can't unlock the host because it doesn't have MDM turned on.`},
 		{appCfgAllMDM, "valid windows but pending unlock", []string{"--host", winEnrolledUP.UUID}, "Host has pending unlock request."},
-		{appCfgAllMDM, "valid macos but pending unlock", []string{"--host", macEnrolledUP.UUID}, ""},
 		{appCfgAllMDM, "valid windows but pending lock", []string{"--host", winEnrolledLP.UUID}, "Host has pending lock request."},
 		{appCfgAllMDM, "valid macos but pending lock", []string{"--host", macEnrolledLP.UUID}, "Host has pending lock request."},
 		{appCfgAllMDM, "valid windows but pending wipe", []string{"--host", winEnrolledWP.UUID}, "Host has pending wipe request."},
@@ -853,13 +830,6 @@ func TestMDMWipeCommand(t *testing.T) {
 		ID:       8,
 		UUID:     "win-enrolled-up",
 		Platform: "windows",
-		MDMInfo:  &fleet.HostMDM{Enrolled: true, Name: fleet.WellKnownMDMFleet},
-		MDM:      fleet.MDMHostData{Name: fleet.WellKnownMDMFleet, EnrollmentStatus: ptr.String("On (manual)")},
-	}
-	macEnrolledUP := &fleet.Host{
-		ID:       9,
-		UUID:     "mac-enrolled-up",
-		Platform: "darwin",
 		MDMInfo:  &fleet.HostMDM{Enrolled: true, Name: fleet.WellKnownMDMFleet},
 		MDM:      fleet.MDMHostData{Name: fleet.WellKnownMDMFleet, EnrollmentStatus: ptr.String("On (manual)")},
 	}
@@ -950,7 +920,6 @@ func TestMDMWipeCommand(t *testing.T) {
 		macPending,
 		winPending,
 		winEnrolledUP,
-		macEnrolledUP,
 		winEnrolledLP,
 		macEnrolledLP,
 		winEnrolledWP,
@@ -971,7 +940,6 @@ func TestMDMWipeCommand(t *testing.T) {
 
 	unlockPending := map[uint]*fleet.Host{
 		winEnrolledUP.ID: winEnrolledUP,
-		macEnrolledUP.ID: macEnrolledUP,
 	}
 
 	lockPending := map[uint]*fleet.Host{
@@ -1010,9 +978,7 @@ func TestMDMWipeCommand(t *testing.T) {
 
 		if _, ok := unlockPending[host.ID]; ok {
 			if fleetPlatform == "darwin" {
-				status.UnlockPIN = "1234"
-				status.UnlockRequestedAt = time.Now()
-				return &status, nil
+				return nil, errors.New("apple devices do not have an unlock pending state")
 			}
 
 			status.UnlockScript = &fleet.HostScriptResult{}
@@ -1129,7 +1095,6 @@ func TestMDMWipeCommand(t *testing.T) {
 		{appCfgWinMDM, "valid windows but pending mdm enroll", []string{"--host", winPending.UUID}, `Can't wipe the host because it doesn't have MDM turned on.`},
 		{appCfgMacMDM, "valid macos but pending mdm enroll", []string{"--host", macPending.UUID}, `Can't wipe the host because it doesn't have MDM turned on.`},
 		{appCfgAllMDM, "valid windows but pending unlock", []string{"--host", winEnrolledUP.UUID}, "Host has pending unlock request."},
-		{appCfgAllMDM, "valid macos but pending unlock", []string{"--host", macEnrolledUP.UUID}, "Host has pending unlock request."},
 		{appCfgAllMDM, "valid windows but pending lock", []string{"--host", winEnrolledLP.UUID}, "Host has pending lock request."},
 		{appCfgAllMDM, "valid macos but pending lock", []string{"--host", macEnrolledLP.UUID}, "Host has pending lock request."},
 		{appCfgAllMDM, "valid windows but pending wipe", []string{"--host", winEnrolledWP.UUID}, "Host has pending wipe request."},

--- a/ee/server/service/hosts.go
+++ b/ee/server/service/hosts.go
@@ -38,22 +38,22 @@ func (svc *Service) OSVersion(ctx context.Context, osID uint, teamID *uint, incl
 	return svc.Service.OSVersion(ctx, osID, teamID, true)
 }
 
-func (svc *Service) LockHost(ctx context.Context, hostID uint) error {
+func (svc *Service) LockHost(ctx context.Context, hostID uint) (unlockPIN string, err error) {
 	// First ensure the user has access to list hosts, then check the specific
 	// host once team_id is loaded.
 	if err := svc.authz.Authorize(ctx, &fleet.Host{}, fleet.ActionList); err != nil {
-		return err
+		return "", err
 	}
 	host, err := svc.ds.HostLite(ctx, hostID)
 	if err != nil {
-		return ctxerr.Wrap(ctx, err, "get host lite")
+		return "", ctxerr.Wrap(ctx, err, "get host lite")
 	}
 
 	// Authorize again with team loaded now that we have the host's team_id.
 	// Authorize as "execute mdm_command", which is the correct access
 	// requirement and is what happens for macOS platforms.
 	if err := svc.authz.Authorize(ctx, fleet.MDMCommandAuthz{TeamID: host.TeamID}, fleet.ActionWrite); err != nil {
-		return err
+		return "", err
 	}
 
 	// locking validations are based on the platform of the host
@@ -63,19 +63,23 @@ func (svc *Service) LockHost(ctx context.Context, hostID uint) error {
 			if errors.Is(err, fleet.ErrMDMNotConfigured) {
 				err = fleet.NewInvalidArgumentError("host_id", fleet.AppleMDMNotConfiguredMessage).WithStatus(http.StatusBadRequest)
 			}
-			return ctxerr.Wrap(ctx, err, "check macOS MDM enabled")
+			return "", ctxerr.Wrap(ctx, err, "check macOS MDM enabled")
 		}
 
 		// on macOS, the lock command requires the host to be MDM-enrolled in Fleet
 		hostMDM, err := svc.ds.GetHostMDM(ctx, host.ID)
 		if err != nil {
 			if fleet.IsNotFound(err) {
-				return ctxerr.Wrap(ctx, fleet.NewInvalidArgumentError("host_id", "Can't lock the host because it doesn't have MDM turned on."))
+				return "", ctxerr.Wrap(
+					ctx, fleet.NewInvalidArgumentError("host_id", "Can't lock the host because it doesn't have MDM turned on."),
+				)
 			}
-			return ctxerr.Wrap(ctx, err, "get host MDM information")
+			return "", ctxerr.Wrap(ctx, err, "get host MDM information")
 		}
 		if !hostMDM.IsFleetEnrolled() {
-			return ctxerr.Wrap(ctx, fleet.NewInvalidArgumentError("host_id", "Can't lock the host because it doesn't have MDM turned on."))
+			return "", ctxerr.Wrap(
+				ctx, fleet.NewInvalidArgumentError("host_id", "Can't lock the host because it doesn't have MDM turned on."),
+			)
 		}
 
 	case "windows", "linux":
@@ -84,27 +88,30 @@ func (svc *Service) LockHost(ctx context.Context, hostID uint) error {
 				if errors.Is(err, fleet.ErrMDMNotConfigured) {
 					err = fleet.NewInvalidArgumentError("host_id", fleet.WindowsMDMNotConfiguredMessage).WithStatus(http.StatusBadRequest)
 				}
-				return ctxerr.Wrap(ctx, err, "check windows MDM enabled")
+				return "", ctxerr.Wrap(ctx, err, "check windows MDM enabled")
 			}
 		}
 		// on windows and linux, a script is used to lock the host so scripts must
 		// be enabled
 		appCfg, err := svc.ds.AppConfig(ctx)
 		if err != nil {
-			return ctxerr.Wrap(ctx, err, "get app config")
+			return "", ctxerr.Wrap(ctx, err, "get app config")
 		}
 		if appCfg.ServerSettings.ScriptsDisabled {
-			return ctxerr.Wrap(ctx, fleet.NewInvalidArgumentError("host_id", "Can't lock host because running scripts is disabled in organization settings."))
+			return "", ctxerr.Wrap(
+				ctx,
+				fleet.NewInvalidArgumentError("host_id", "Can't lock host because running scripts is disabled in organization settings."),
+			)
 		}
 		hostOrbitInfo, err := svc.ds.GetHostOrbitInfo(ctx, host.ID)
 		switch {
 		case err != nil:
 			// If not found, then do nothing. We do not know if this host has scripts enabled or not
 			if !fleet.IsNotFound(err) {
-				return ctxerr.Wrap(ctx, err, "get host orbit info")
+				return "", ctxerr.Wrap(ctx, err, "get host orbit info")
 			}
 		case hostOrbitInfo.ScriptsEnabled != nil && !*hostOrbitInfo.ScriptsEnabled:
-			return ctxerr.Wrap(
+			return "", ctxerr.Wrap(
 				ctx, fleet.NewInvalidArgumentError(
 					"host_id", "Couldn't lock host. To lock, deploy the fleetd agent with --enable-scripts and refetch host vitals.",
 				),
@@ -112,26 +119,37 @@ func (svc *Service) LockHost(ctx context.Context, hostID uint) error {
 		}
 
 	default:
-		return ctxerr.Wrap(ctx, fleet.NewInvalidArgumentError("host_id", fmt.Sprintf("Unsupported host platform: %s", host.Platform)))
+		return "", ctxerr.Wrap(ctx, fleet.NewInvalidArgumentError("host_id", fmt.Sprintf("Unsupported host platform: %s", host.Platform)))
 	}
 
 	// if there's a lock, unlock or wipe action pending, do not accept the lock
 	// request.
 	lockWipe, err := svc.ds.GetHostLockWipeStatus(ctx, host)
 	if err != nil {
-		return ctxerr.Wrap(ctx, err, "get host lock/wipe status")
+		return "", ctxerr.Wrap(ctx, err, "get host lock/wipe status")
 	}
 	switch {
 	case lockWipe.IsPendingLock():
-		return ctxerr.Wrap(ctx, fleet.NewInvalidArgumentError("host_id", "Host has pending lock request. The host will lock when it comes online."))
+		return "", ctxerr.Wrap(
+			ctx, fleet.NewInvalidArgumentError("host_id", "Host has pending lock request. The host will lock when it comes online."),
+		)
 	case lockWipe.IsPendingUnlock():
-		return ctxerr.Wrap(ctx, fleet.NewInvalidArgumentError("host_id", "Host has pending unlock request. Host cannot be locked again until unlock is complete."))
+		return "", ctxerr.Wrap(
+			ctx, fleet.NewInvalidArgumentError(
+				"host_id", "Host has pending unlock request. Host cannot be locked again until unlock is complete.",
+			),
+		)
 	case lockWipe.IsPendingWipe():
-		return ctxerr.Wrap(ctx, fleet.NewInvalidArgumentError("host_id", "Host has pending wipe request. Cannot process lock requests once host is wiped."))
+		return "", ctxerr.Wrap(
+			ctx,
+			fleet.NewInvalidArgumentError("host_id", "Host has pending wipe request. Cannot process lock requests once host is wiped."),
+		)
 	case lockWipe.IsWiped():
-		return ctxerr.Wrap(ctx, fleet.NewInvalidArgumentError("host_id", "Host is wiped. Cannot process lock requests once host is wiped."))
+		return "", ctxerr.Wrap(
+			ctx, fleet.NewInvalidArgumentError("host_id", "Host is wiped. Cannot process lock requests once host is wiped."),
+		)
 	case lockWipe.IsLocked():
-		return ctxerr.Wrap(ctx, fleet.NewInvalidArgumentError("host_id", "Host is already locked.").WithStatus(http.StatusConflict))
+		return "", ctxerr.Wrap(ctx, fleet.NewInvalidArgumentError("host_id", "Host is already locked.").WithStatus(http.StatusConflict))
 	}
 
 	// all good, go ahead with queuing the lock request.
@@ -331,19 +349,21 @@ func (svc *Service) WipeHost(ctx context.Context, hostID uint) error {
 	return svc.enqueueWipeHostRequest(ctx, host, lockWipe)
 }
 
-func (svc *Service) enqueueLockHostRequest(ctx context.Context, host *fleet.Host, lockStatus *fleet.HostLockWipeStatus) error {
+func (svc *Service) enqueueLockHostRequest(ctx context.Context, host *fleet.Host, lockStatus *fleet.HostLockWipeStatus) (
+	unlockPIN string, err error,
+) {
 	vc, ok := viewer.FromContext(ctx)
 	if !ok {
-		return fleet.ErrNoContext
+		return "", fleet.ErrNoContext
 	}
 
 	if lockStatus.HostFleetPlatform == "darwin" {
 		lockCommandUUID := uuid.NewString()
-		if err := svc.mdmAppleCommander.DeviceLock(ctx, host, lockCommandUUID); err != nil {
-			return ctxerr.Wrap(ctx, err, "enqueuing lock request for darwin")
+		if unlockPIN, err = svc.mdmAppleCommander.DeviceLock(ctx, host, lockCommandUUID); err != nil {
+			return "", ctxerr.Wrap(ctx, err, "enqueuing lock request for darwin")
 		}
 
-		if err := svc.NewActivity(
+		if err = svc.NewActivity(
 			ctx,
 			vc.User,
 			fleet.ActivityTypeLockedHost{
@@ -351,10 +371,10 @@ func (svc *Service) enqueueLockHostRequest(ctx context.Context, host *fleet.Host
 				HostDisplayName: host.DisplayName(),
 			},
 		); err != nil {
-			return ctxerr.Wrap(ctx, err, "create activity for darwin lock host request")
+			return "", ctxerr.Wrap(ctx, err, "create activity for darwin lock host request")
 		}
 
-		return nil
+		return unlockPIN, nil
 	}
 
 	script := windowsLockScript
@@ -374,7 +394,7 @@ func (svc *Service) enqueueLockHostRequest(ctx context.Context, host *fleet.Host
 		UserID:         &vc.User.ID,
 		SyncRequest:    false,
 	}, host.FleetPlatform()); err != nil {
-		return err
+		return "", err
 	}
 
 	if err := svc.NewActivity(
@@ -385,10 +405,10 @@ func (svc *Service) enqueueLockHostRequest(ctx context.Context, host *fleet.Host
 			HostDisplayName: host.DisplayName(),
 		},
 	); err != nil {
-		return ctxerr.Wrap(ctx, err, "create activity for lock host request")
+		return "", ctxerr.Wrap(ctx, err, "create activity for lock host request")
 	}
 
-	return nil
+	return "", nil
 }
 
 func (svc *Service) enqueueUnlockHostRequest(ctx context.Context, host *fleet.Host, lockStatus *fleet.HostLockWipeStatus) (string, error) {

--- a/ee/server/service/hosts.go
+++ b/ee/server/service/hosts.go
@@ -419,7 +419,9 @@ func (svc *Service) enqueueUnlockHostRequest(ctx context.Context, host *fleet.Ho
 
 	var unlockPIN string
 	if lockStatus.HostFleetPlatform == "darwin" {
-		// record the unlock request if it was not already recorded
+		// Record the unlock request time if it was not already recorded.
+		// It should be always recorded, since the UnlockRequestedAt time is created after the lock command is acknowledged.
+		// This code is left here to catch potential issues.
 		if lockStatus.UnlockRequestedAt.IsZero() {
 			if err := svc.ds.UnlockHostManually(ctx, host.ID, host.FleetPlatform(), time.Now().UTC()); err != nil {
 				return "", err

--- a/ee/server/service/mdm.go
+++ b/ee/server/service/mdm.go
@@ -135,7 +135,7 @@ func (svc *Service) MDMAppleDeviceLock(ctx context.Context, hostID uint) error {
 		return err
 	}
 
-	err = svc.mdmAppleCommander.DeviceLock(ctx, host, uuid.New().String())
+	_, err = svc.mdmAppleCommander.DeviceLock(ctx, host, uuid.New().String())
 	if err != nil {
 		return err
 	}

--- a/server/datastore/mysql/apple_mdm_test.go
+++ b/server/datastore/mysql/apple_mdm_test.go
@@ -4603,14 +4603,14 @@ func testLockUnlockWipeMacOS(t *testing.T, ds *Datastore) {
 	require.NoError(t, err)
 	checkLockWipeState(t, status, false, true, false, false, false, false)
 
-	// request an unlock, to make it pending unlock
+	// request an unlock. This is a NOOP for Apple MDM.
 	err = ds.UnlockHostManually(ctx, host.ID, host.FleetPlatform(), time.Now().UTC())
 	require.NoError(t, err)
 
-	// it is now locked pending unlock
+	// it is still locked
 	status, err = ds.GetHostLockWipeStatus(ctx, host)
 	require.NoError(t, err)
-	checkLockWipeState(t, status, false, true, false, true, false, false)
+	checkLockWipeState(t, status, false, true, false, false, false, false)
 
 	// execute CleanMacOSMDMLock to simulate successful unlock
 	err = ds.CleanMacOSMDMLock(ctx, host.UUID)

--- a/server/datastore/mysql/microsoft_mdm.go
+++ b/server/datastore/mysql/microsoft_mdm.go
@@ -359,7 +359,8 @@ ON DUPLICATE KEY UPDATE
 		// if we received a Wipe command result, update the host's status
 		if wipeCmdUUID != "" {
 			if err := updateHostLockWipeStatusFromResultAndHostUUID(ctx, tx, enrollment.HostUUID,
-				"wipe_ref", wipeCmdUUID, strings.HasPrefix(wipeCmdStatus, "2")); err != nil {
+				"wipe_ref", wipeCmdUUID, strings.HasPrefix(wipeCmdStatus, "2"), false,
+			); err != nil {
 				return ctxerr.Wrap(ctx, err, "updating wipe command result in host_mdm_actions")
 			}
 		}

--- a/server/datastore/mysql/scripts.go
+++ b/server/datastore/mysql/scripts.go
@@ -1023,7 +1023,7 @@ func (ds *Datastore) UnlockHostManually(ctx context.Context, hostID uint, hostFl
 	return ctxerr.Wrap(ctx, err, "record manual unlock host request")
 }
 
-func buildHostLockWipeStatusUpdateStmt(refCol string, succeeded bool, joinPart string) string {
+func buildHostLockWipeStatusUpdateStmt(refCol string, succeeded bool, joinPart string, setUnlockRef bool) string {
 	var alias string
 
 	stmt := `UPDATE host_mdm_actions `
@@ -1036,13 +1036,17 @@ func buildHostLockWipeStatusUpdateStmt(refCol string, succeeded bool, joinPart s
 	if succeeded {
 		switch refCol {
 		case "lock_ref":
-			// Currently only used for Apple MDM devices.
 			// Note that this must not clear the unlock_pin, because recording the
 			// lock request does generate the PIN and store it there to be used by an
 			// eventual unlock.
-			// We set the unlock_ref to current time since the device can be unlocked any time after the lock.
-			// Apple MDM does not have a concept of unlock pending.
-			stmt += fmt.Sprintf("%sunlock_ref = '%s', %[1]swipe_ref = NULL", alias, time.Now().Format(time.DateTime))
+			if !setUnlockRef {
+				// Currently only used for Apple MDM devices.
+				// We set the unlock_ref to current time since the device can be unlocked any time after the lock.
+				// Apple MDM does not have a concept of unlock pending.
+				stmt += fmt.Sprintf("%sunlock_ref = NULL, %[1]swipe_ref = NULL", alias)
+			} else {
+				stmt += fmt.Sprintf("%sunlock_ref = '%s', %[1]swipe_ref = NULL", alias, time.Now().Format(time.DateTime))
+			}
 		case "unlock_ref":
 			// a successful unlock clears itself as well as the lock ref, because
 			// unlock is the default state so we don't need to keep its unlock_ref
@@ -1064,26 +1068,30 @@ func (ds *Datastore) UpdateHostLockWipeStatusFromAppleMDMResult(ctx context.Cont
 	// a bit of MDM protocol leaking in the mysql layer, but it's either that or
 	// the other way around (MDM protocol would translate to database column)
 	var refCol string
+	var setUnlockRef bool
 	switch requestType {
 	case "EraseDevice":
 		refCol = "wipe_ref"
 	case "DeviceLock":
 		refCol = "lock_ref"
+		setUnlockRef = true
 	default:
 		return nil
 	}
-	return updateHostLockWipeStatusFromResultAndHostUUID(ctx, ds.writer(ctx), hostUUID, refCol, cmdUUID, succeeded)
+	return updateHostLockWipeStatusFromResultAndHostUUID(ctx, ds.writer(ctx), hostUUID, refCol, cmdUUID, succeeded, setUnlockRef)
 }
 
-func updateHostLockWipeStatusFromResultAndHostUUID(ctx context.Context, tx sqlx.ExtContext, hostUUID, refCol, cmdUUID string, succeeded bool) error {
-	stmt := buildHostLockWipeStatusUpdateStmt(refCol, succeeded, `JOIN hosts h ON hma.host_id = h.id`)
+func updateHostLockWipeStatusFromResultAndHostUUID(
+	ctx context.Context, tx sqlx.ExtContext, hostUUID, refCol, cmdUUID string, succeeded bool, setUnlockRef bool,
+) error {
+	stmt := buildHostLockWipeStatusUpdateStmt(refCol, succeeded, `JOIN hosts h ON hma.host_id = h.id`, setUnlockRef)
 	stmt += ` WHERE h.uuid = ? AND hma.` + refCol + ` = ?`
 	_, err := tx.ExecContext(ctx, stmt, hostUUID, cmdUUID)
 	return ctxerr.Wrap(ctx, err, "update host lock/wipe status from result via host uuid")
 }
 
 func updateHostLockWipeStatusFromResult(ctx context.Context, tx sqlx.ExtContext, hostID uint, refCol string, succeeded bool) error {
-	stmt := buildHostLockWipeStatusUpdateStmt(refCol, succeeded, "")
+	stmt := buildHostLockWipeStatusUpdateStmt(refCol, succeeded, "", false)
 	stmt += ` WHERE host_id = ?`
 	_, err := tx.ExecContext(ctx, stmt, hostID)
 	return ctxerr.Wrap(ctx, err, "update host lock/wipe status from result")

--- a/server/datastore/mysql/scripts.go
+++ b/server/datastore/mysql/scripts.go
@@ -1036,10 +1036,13 @@ func buildHostLockWipeStatusUpdateStmt(refCol string, succeeded bool, joinPart s
 	if succeeded {
 		switch refCol {
 		case "lock_ref":
+			// Currently only used for Apple MDM devices.
 			// Note that this must not clear the unlock_pin, because recording the
 			// lock request does generate the PIN and store it there to be used by an
 			// eventual unlock.
-			stmt += fmt.Sprintf("%sunlock_ref = NULL, %[1]swipe_ref = NULL", alias)
+			// We set the unlock_ref to current time since the device can be unlocked any time after the lock.
+			// Apple MDM does not have a concept of unlock pending.
+			stmt += fmt.Sprintf("%sunlock_ref = '%s', %[1]swipe_ref = NULL", alias, time.Now().Format(time.DateTime))
 		case "unlock_ref":
 			// a successful unlock clears itself as well as the lock ref, because
 			// unlock is the default state so we don't need to keep its unlock_ref

--- a/server/datastore/mysql/scripts_test.go
+++ b/server/datastore/mysql/scripts_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/fleetdm/fleet/v4/server/test"
 	"github.com/google/uuid"
 	"github.com/jmoiron/sqlx"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -764,6 +765,7 @@ func testLockHostViaScript(t *testing.T, ds *Datastore) {
 	require.NoError(t, err)
 	require.Equal(t, "windows", status.HostFleetPlatform)
 	require.NotNil(t, status.LockScript)
+	assert.Nil(t, status.UnlockScript)
 
 	s := status.LockScript
 	require.Equal(t, script, s.ScriptContents)

--- a/server/fleet/apple_mdm.go
+++ b/server/fleet/apple_mdm.go
@@ -18,7 +18,7 @@ import (
 type MDMAppleCommandIssuer interface {
 	InstallProfile(ctx context.Context, hostUUIDs []string, profile mobileconfig.Mobileconfig, uuid string) error
 	RemoveProfile(ctx context.Context, hostUUIDs []string, identifier string, uuid string) error
-	DeviceLock(ctx context.Context, host *Host, uuid string) error
+	DeviceLock(ctx context.Context, host *Host, uuid string) (unlockPIN string, err error)
 	EraseDevice(ctx context.Context, host *Host, uuid string) error
 	InstallEnterpriseApplication(ctx context.Context, hostUUIDs []string, uuid string, manifestURL string) error
 }

--- a/server/fleet/scripts.go
+++ b/server/fleet/scripts.go
@@ -412,8 +412,8 @@ func (s *HostLockWipeStatus) IsPendingLock() bool {
 
 func (s HostLockWipeStatus) IsPendingUnlock() bool {
 	if s.HostFleetPlatform == "darwin" {
-		// pending unlock if an unlock was requested
-		return !s.UnlockRequestedAt.IsZero()
+		// Apple MDM does not have a concept of pending unlock.
+		return false
 	}
 	// pending unlock if script execution request is queued but no result yet
 	return s.UnlockScript != nil && s.UnlockScript.ExitCode == nil

--- a/server/fleet/service.go
+++ b/server/fleet/service.go
@@ -1040,7 +1040,7 @@ type Service interface {
 	BatchSetScripts(ctx context.Context, maybeTmID *uint, maybeTmName *string, payloads []ScriptPayload, dryRun bool) error
 
 	// Script-based methods (at least for some platforms, MDM-based for others)
-	LockHost(ctx context.Context, hostID uint) error
+	LockHost(ctx context.Context, hostID uint) (unlockPIN string, err error)
 	UnlockHost(ctx context.Context, hostID uint) (unlockPIN string, err error)
 	WipeHost(ctx context.Context, hostID uint) error
 

--- a/server/mdm/apple/commander_test.go
+++ b/server/mdm/apple/commander_test.go
@@ -132,8 +132,9 @@ func TestMDMAppleCommander(t *testing.T) {
 		require.Len(t, pin, 6)
 		return nil
 	}
-	err = cmdr.DeviceLock(ctx, host, cmdUUID)
+	pin, err := cmdr.DeviceLock(ctx, host, cmdUUID)
 	require.NoError(t, err)
+	require.Len(t, pin, 6)
 	require.True(t, mdmStorage.EnqueueDeviceLockCommandFuncInvoked)
 	mdmStorage.EnqueueDeviceLockCommandFuncInvoked = false
 	require.True(t, mdmStorage.RetrievePushInfoFuncInvoked)

--- a/server/service/hosts_test.go
+++ b/server/service/hosts_test.go
@@ -1648,9 +1648,9 @@ func TestLockUnlockWipeHostAuth(t *testing.T) {
 			}
 			ctx := viewer.NewContext(ctx, viewer.Viewer{User: tt.user})
 
-			err := svc.LockHost(ctx, globalHostID)
+			_, err := svc.LockHost(ctx, globalHostID)
 			checkAuthErr(t, tt.shouldFailGlobalWrite, err)
-			err = svc.LockHost(ctx, teamHostID)
+			_, err = svc.LockHost(ctx, teamHostID)
 			checkAuthErr(t, tt.shouldFailTeamWrite, err)
 
 			// Pretend we locked the host

--- a/server/service/integration_mdm_lifecycle_test.go
+++ b/server/service/integration_mdm_lifecycle_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"encoding/xml"
 	"fmt"
+	"github.com/stretchr/testify/assert"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -73,12 +74,15 @@ func (s *integrationMDMTestSuite) TestTurnOnLifecycleEventsApple() {
 		{
 			"locked host turns on MDM",
 			func(t *testing.T, host *fleet.Host, device *mdmtest.TestAppleMDMClient) {
-				s.Do(
+				var resp lockHostResponse
+				s.DoJSON(
 					"POST",
 					fmt.Sprintf("/api/latest/fleet/hosts/%d/lock", host.ID),
 					nil,
-					http.StatusNoContent,
+					http.StatusOK,
+					&resp,
 				)
+				assert.Len(t, resp.UnlockPIN, 6)
 
 				cmd, err := device.Idle()
 				require.NoError(t, err)

--- a/server/service/integration_mdm_test.go
+++ b/server/service/integration_mdm_test.go
@@ -8086,12 +8086,12 @@ func (s *integrationMDMTestSuite) TestLockUnlockWipeMacOS() {
 	unlockActID := s.lastActivityOfTypeMatches(fleet.ActivityTypeUnlockedHost{}.ActivityName(),
 		fmt.Sprintf(`{"host_id": %d, "host_display_name": %q, "host_platform": %q}`, host.ID, host.DisplayName(), host.FleetPlatform()), 0)
 
-	// refresh the host's status, it is locked pending unlock
+	// refresh the host's status, it is still locked
 	s.DoJSON("GET", fmt.Sprintf("/api/latest/fleet/hosts/%d", host.ID), nil, http.StatusOK, &getHostResp)
 	require.NotNil(t, getHostResp.Host.MDM.DeviceStatus)
 	require.Equal(t, "locked", *getHostResp.Host.MDM.DeviceStatus)
 	require.NotNil(t, getHostResp.Host.MDM.PendingAction)
-	require.Equal(t, "unlock", *getHostResp.Host.MDM.PendingAction)
+	assert.Empty(t, *getHostResp.Host.MDM.PendingAction)
 
 	// try unlocking the host again simply returns the PIN again
 	unlockResp = unlockHostResponse{}

--- a/server/service/integration_mdm_test.go
+++ b/server/service/integration_mdm_test.go
@@ -8038,7 +8038,9 @@ func (s *integrationMDMTestSuite) TestLockUnlockWipeMacOS() {
 	s.DoJSON("POST", fmt.Sprintf("/api/latest/fleet/hosts/%d/unlock", host.ID), nil, http.StatusConflict, &unlockResp)
 
 	// lock the host
-	s.Do("POST", fmt.Sprintf("/api/latest/fleet/hosts/%d/lock", host.ID), nil, http.StatusNoContent)
+	var lockResp lockHostResponse
+	s.DoJSON("POST", fmt.Sprintf("/api/latest/fleet/hosts/%d/lock", host.ID), nil, http.StatusOK, &lockResp)
+	assert.Len(t, lockResp.UnlockPIN, 6)
 
 	// refresh the host's status, it is now pending lock
 	s.DoJSON("GET", fmt.Sprintf("/api/latest/fleet/hosts/%d", host.ID), nil, http.StatusOK, &getHostResp)


### PR DESCRIPTION
/api/latest/fleet/hosts/:id/lock returns `unlock_pin` for Apple hosts
#19545 
# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [x] Added/updated tests
- [x] Manual QA for all new/changed functionality
