### PR TITLE
Website: Send analytics events

### DIFF
--- a/website/assets/.eslintrc
+++ b/website/assets/.eslintrc
@@ -48,7 +48,7 @@
     "moment": true,
     "docsearch": true,
     "Chart": true,
-    // "google": true,
+    "gtag": true,
     // ...etc.
     // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 

--- a/website/assets/js/pages/contact.page.js
+++ b/website/assets/js/pages/contact.page.js
@@ -80,13 +80,18 @@ parasails.registerPage('contact', {
   methods: {
 
     submittedContactForm: async function() {
-
+      if(typeof gtag !== 'undefined'){
+        gtag('event','website_contact_forms');
+      }
       // Show the success message.
       this.cloudSuccess = true;
 
     },
     submittedTalkToUsForm: async function() {
       this.syncing = true;
+      if(typeof gtag !== 'undefined'){
+        gtag('event','website_contact_forms');
+      }
       if(this.formData.numberOfHosts > 700){
         this.goto(`https://calendly.com/fleetdm/talk-to-us?email=${encodeURIComponent(this.formData.emailAddress)}&name=${encodeURIComponent(this.formData.firstName+' '+this.formData.lastName)}`);
       } else {

--- a/website/assets/js/pages/docs/basic-documentation.page.js
+++ b/website/assets/js/pages/docs/basic-documentation.page.js
@@ -223,10 +223,10 @@ parasails.registerPage('basic-documentation', {
   methods: {
 
     clickSwagRequestCTA: function () {
-      if(typeof gtag !== 'undefined'){
+      if(typeof gtag !== 'undefined') {
         gtag('event','website_swag_request');
       }
-      this.goto('https://kqphpqst851.typeform.com/to/ZfA3sOu0')
+      this.goto('https://kqphpqst851.typeform.com/to/ZfA3sOu0');
     },
 
     clickCTA: function (slug) {

--- a/website/assets/js/pages/docs/basic-documentation.page.js
+++ b/website/assets/js/pages/docs/basic-documentation.page.js
@@ -222,6 +222,13 @@ parasails.registerPage('basic-documentation', {
   //  ╩╝╚╝ ╩ ╚═╝╩╚═╩ ╩╚═╝ ╩ ╩╚═╝╝╚╝╚═╝
   methods: {
 
+    clickSwagRequestCTA: function () {
+      if(typeof gtag !== 'undefined'){
+        gtag('event','website_swag_request');
+      }
+      this.goto('https://kqphpqst851.typeform.com/to/ZfA3sOu0')
+    },
+
     clickCTA: function (slug) {
       this.goto(slug);
     },

--- a/website/assets/js/pages/entrance/signup.page.js
+++ b/website/assets/js/pages/entrance/signup.page.js
@@ -67,6 +67,9 @@ parasails.registerPage('signup', {
       // redirect to the /start page.
       // > (Note that we re-enable the syncing state here.  This is on purpose--
       // > to make sure the spinner stays there until the page navigation finishes.)
+      if(typeof gtag !== 'undefined'){
+        gtag('event','website_sign_up');
+      }
       this.syncing = true;
       this.goto(this.pageToRedirectToAfterRegistration);// « / start if the user came here from the start now button, or customers/new-license if the user came here from the "Get your license" link.
     }

--- a/website/views/pages/docs/basic-documentation.ejs
+++ b/website/views/pages/docs/basic-documentation.ejs
@@ -157,7 +157,7 @@
           <a class="pb-3" target="_blank" href="https://github.com/fleetdm/fleet/releases">Releases</a>
           <a class="pb-3" target="_blank" href="/support">Support</a>
           <div class="d-none d-lg-block" purpose="swag-cta" v-if="showSwagForm">
-            <a class="d-flex align-items-center justify-content-center" href="https://kqphpqst851.typeform.com/to/ZfA3sOu0" target="_blank">
+            <a class="d-flex align-items-center justify-content-center" @click="clickSwagRequestCTA()">
               <div class="d-flex flex-column align-items-center">
               <img style="height: auto; width: 47px; margin-bottom: 8px;" alt="A very nice Fleet branded shirt" src="/images/fleet-shirt-60x55@2x.png">
                 <p class="mb-0">Request Fleet swag</p>


### PR DESCRIPTION
Related to: #19603 

Changes:
 - Updated the contact page to send an event (`website_contact_forms`) to Google Analytics when a user submits the form
 - Update the signup page to send an event (`website_sign_up`) to Google Analytics when a user signs up
 - Updated the swag request button in the docs to send an event (`website_swag_request`) to Google Analytics when a user visits the swag request typeform.
