### PR TITLE
Keep all fleetd-base and fleetd-chrome artifacts.

### DIFF
--- a/.github/actions/r2-upload/action.yml
+++ b/.github/actions/r2-upload/action.yml
@@ -9,6 +9,10 @@ description: Upload a file to R2
 # - R2_BUCKET: The bucket to upload to
 
 inputs:
+  working-directory:
+    description: 'The working directory, relative to which the files will be uploaded.'
+    default: './'
+    required: false
   filenames:
     description: 'Comma-delimited names of the file(s) to upload. For example: file1,manifest.json,file with spaces.txt'
     required: true
@@ -18,6 +22,7 @@ runs:
   steps:
     - name: Upload file to R2
       shell: bash
+      working-directory: ${{ inputs.working-directory }}
       run: |
         sudo ./.github/scripts/rclone-install.sh
         mkdir -p ~/.config/rclone

--- a/.github/actions/r2-upload/action.yml
+++ b/.github/actions/r2-upload/action.yml
@@ -32,6 +32,6 @@ runs:
         " > ~/.config/rclone/rclone.conf
         : # Loop over each filename in the array of filenames and upload each one.
         IFS=$'\n'
-        for row in $(echo "${{ inputs.filenames }}" | tr "," "\n"); do
-          rclone copy --verbose "$row" r2:${{ env.R2_BUCKET }}/
+        for filename in $(echo "${{ inputs.filenames }}" | tr "," "\n"); do
+          rclone copy --verbose "$filename" r2:${{ env.R2_BUCKET }}/$(dirname "$filename")
         done

--- a/.github/actions/r2-upload/action.yml
+++ b/.github/actions/r2-upload/action.yml
@@ -1,5 +1,5 @@
 name: R2 upload
-description: Upload a file to R2
+description: Upload files to R2, keeping the directory structure intact
 # Schema: https://json.schemastore.org/github-action.json
 
 # This action expects the following env vars to be set:

--- a/.github/actions/r2-upload/action.yml
+++ b/.github/actions/r2-upload/action.yml
@@ -38,5 +38,10 @@ runs:
         : # Loop over each filename in the array of filenames and upload each one.
         IFS=$'\n'
         for filename in $(echo "${{ inputs.filenames }}" | tr "," "\n"); do
-          rclone copy --verbose "$filename" r2:${{ env.R2_BUCKET }}/$(dirname "$filename")
+          upload_dir=${{ env.R2_BUCKET }}
+          dirname=$(dirname "$filename")
+          if [ "$dirname" != "" ] && [ "$dirname" != "." ]; then
+            upload_dir="$upload_dir"/"$dirname"
+          fi
+          rclone copy --verbose "$filename" r2:"$upload_dir"
         done

--- a/.github/actions/r2-upload/action.yml
+++ b/.github/actions/r2-upload/action.yml
@@ -24,7 +24,7 @@ runs:
       shell: bash
       working-directory: ${{ inputs.working-directory }}
       run: |
-        sudo ./.github/scripts/rclone-install.sh
+        sudo ${{ github.workspace }}/.github/scripts/rclone-install.sh
         mkdir -p ~/.config/rclone
         echo "[r2]
         type = s3

--- a/.github/workflows/release-fleetd-base.yml
+++ b/.github/workflows/release-fleetd-base.yml
@@ -1,4 +1,4 @@
-name: Upload fleetd base to https://download.fleetdm.com
+name: Release and upload fleetd base to https://download.fleetdm.com
 
 on:
   workflow_dispatch: # Manual
@@ -149,6 +149,7 @@ jobs:
       - name: Set up files and directories for upload
         run: |
           mkdir -p stable
+          mkdir -p ${{ env.FULL_DATE_DIR }}
           cp fleetd-base.pkg stable/
           cp fleetd-base-manifest.plist stable/
           cp fleetd-base.pkg ${{ env.FULL_DATE_DIR }}/
@@ -194,6 +195,7 @@ jobs:
       - name: Set up files and directories for upload
         run: |
           mkdir -p stable
+          mkdir -p ${{ env.FULL_DATE_DIR }}
           cp fleetd-base.msi stable/
           cp fleetd-base.msi ${{ env.FULL_DATE_DIR }}/
 

--- a/.github/workflows/release-fleetd-base.yml
+++ b/.github/workflows/release-fleetd-base.yml
@@ -204,7 +204,7 @@ jobs:
         with:
           filenames: stable/fleetd-base.msi,${{ env.FULL_DATE_DIR }}/fleetd-base.msi
 
-  update-meta-json:
+  update-meta-files:
     needs: [check-for-fleetd-component-updates, update-fleetd-base-pkg, update-fleetd-base-msi]
     runs-on: ubuntu-latest
     env:
@@ -230,6 +230,8 @@ jobs:
 
       - name: Set up files and directories for upload
         run: |
+          mkdir -p stable
+          mkdir -p ${{ env.FULL_DATE_DIR }}
           echo '{
             "fleetd_base_pkg_url": "${{ env.BASE_URL }}/${{ env.FULL_DATE_DIR }}/fleetd-base.pkg",
             "fleetd_base_pkg_sha256\": "${{ needs.update-fleetd-base-pkg.outputs.fleetd_base_pkg_sha256 }}",

--- a/.github/workflows/release-fleetd-base.yml
+++ b/.github/workflows/release-fleetd-base.yml
@@ -210,7 +210,7 @@ jobs:
       DIGICERT_KEYLOCKER_CERTIFICATE_FINGERPRINT: ${{ secrets.DIGICERT_KEYLOCKER_CERTIFICATE_FINGERPRINT }}
 
   update-fleetd-base-msi:
-    needs: [code-sign-windows]
+    needs: [code-sign-windows, check-for-fleetd-component-updates]
     runs-on: ubuntu-latest
     outputs:
       fleetd_base_msi_sha256: ${{ steps.prepare-files.outputs.fleetd_base_msi_sha256 }}
@@ -297,3 +297,9 @@ jobs:
         uses: ./.github/actions/r2-upload
         with:
           filenames: stable/meta.json,stable/tuf-meta.json,${{ env.FULL_DATE_DIR }}/meta.json,${{ env.FULL_DATE_DIR }}/tuf-meta.json
+
+  verify-fleetd-base:
+    needs: update-meta-files
+    uses: ./.github/workflows/verify-fleetd-base.yml
+    with:
+      base-url: ${{ env.BASE_URL }}

--- a/.github/workflows/release-fleetd-base.yml
+++ b/.github/workflows/release-fleetd-base.yml
@@ -143,7 +143,7 @@ jobs:
                         <string>${{ steps.build-sign-notarize.outputs.fleetd_base_pkg_sha256 }}</string>
                       </array>
                       <key>url</key>
-                      <string>${{ env.BASE_URL }}/fleetd-base.pkg</string>
+                      <string>${{ env.FULL_DATE_DIR }}/fleetd-base.pkg</string>
                     </dict>
                   </array>
                 </dict>
@@ -239,10 +239,11 @@ jobs:
           mkdir -p stable
           mkdir -p ${{ env.FULL_DATE_DIR }}
           echo '{
-            "fleetd_base_pkg_url": "${{ env.BASE_URL }}/${{ env.FULL_DATE_DIR }}/fleetd-base.pkg",
-            "fleetd_base_pkg_sha256": "${{ needs.update-fleetd-base-pkg.outputs.fleetd_base_pkg_sha256 }}",
             "fleetd_base_msi_url": "${{ env.BASE_URL }}/${{ env.FULL_DATE_DIR }}/fleetd-base.msi",
             "fleetd_base_msi_sha256": "${{ needs.update-fleetd-base-msi.outputs.fleetd_base_msi_sha256 }}",
+            "fleetd_base_pkg_url": "${{ env.BASE_URL }}/${{ env.FULL_DATE_DIR }}/fleetd-base.pkg",
+            "fleetd_base_pkg_sha256": "${{ needs.update-fleetd-base-pkg.outputs.fleetd_base_pkg_sha256 }}",
+            "fleetd_base_manifest_plist_url": "${{ env.BASE_URL }}/${{ env.FULL_DATE_DIR }}/fleetd-base-manifest.plist",
             "version": "${{ needs.check-for-fleetd-component-updates.outputs.date_dir }}"
           }' > meta.json
           : # Check that meta.json is valid

--- a/.github/workflows/release-fleetd-base.yml
+++ b/.github/workflows/release-fleetd-base.yml
@@ -181,8 +181,6 @@ jobs:
     needs: [check-for-fleetd-component-updates]
     if: needs.check-for-fleetd-component-updates.outputs.update_needed == 'true'
     runs-on: ubuntu-latest
-    outputs:
-      fleetd_base_msi_sha256: ${{ steps.build.outputs.fleetd_base_msi_sha256 }}
     env:
       FULL_DATE_DIR: archive/stable/${{ needs.check-for-fleetd-component-updates.outputs.date_dir }}
     steps:
@@ -199,8 +197,6 @@ jobs:
         run: |
           fleetctl package --type msi --fleet-desktop --fleet-url dummy --enroll-secret dummy
           mv fleet-osquery*.msi fleetd-base.msi
-          : # Calculate the SHA256 checksum of the package
-          echo "fleetd_base_msi_sha256=$(shasum -a 256 fleetd-base.msi | cut -d ' ' -f 1)" >> $GITHUB_OUTPUT
 
       - name: Upload fleetd-base.msi for code signing
         uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # 4.3.3

--- a/.github/workflows/release-fleetd-base.yml
+++ b/.github/workflows/release-fleetd-base.yml
@@ -143,7 +143,7 @@ jobs:
                         <string>${{ steps.build-sign-notarize.outputs.fleetd_base_pkg_sha256 }}</string>
                       </array>
                       <key>url</key>
-                      <string>${{ env.FULL_DATE_DIR }}/fleetd-base.pkg</string>
+                      <string>${{ env.BASE_URL }}/${{ env.FULL_DATE_DIR }}/fleetd-base.pkg</string>
                     </dict>
                   </array>
                 </dict>

--- a/.github/workflows/release-fleetd-base.yml
+++ b/.github/workflows/release-fleetd-base.yml
@@ -151,7 +151,7 @@ jobs:
             </dict>
           </plist>' > fleetd-base-manifest.plist
 
-      - name: Set up files and directories for upload
+      - name: Set up files and directories for R2 upload
         run: |
           mkdir -p stable
           mkdir -p ${{ env.FULL_DATE_DIR }}
@@ -165,12 +165,55 @@ jobs:
         with:
           filenames: stable/fleetd-base.pkg,stable/fleetd-base-manifest.plist,${{ env.FULL_DATE_DIR }}/fleetd-base.pkg,${{ env.FULL_DATE_DIR }}/fleetd-base-manifest.plist
 
-  update-fleetd-base-msi:
+  build-fleetd-base-msi:
     needs: [check-for-fleetd-component-updates]
     if: needs.check-for-fleetd-component-updates.outputs.update_needed == 'true'
     runs-on: ubuntu-latest
     outputs:
       fleetd_base_msi_sha256: ${{ steps.build.outputs.fleetd_base_msi_sha256 }}
+    env:
+      FULL_DATE_DIR: archive/stable/${{ needs.check-for-fleetd-component-updates.outputs.date_dir }}
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@63c24ba6bd7ba022e95695ff85de572c04a18142 # v2.7.0
+        with:
+          egress-policy: audit
+
+      - name: Install fleetctl
+        run: npm install -g fleetctl
+
+      - name: Build MSI
+        id: build
+        run: |
+          fleetctl package --type msi --fleet-desktop --fleet-url dummy --enroll-secret dummy
+          mv fleet-osquery*.msi fleetd-base.msi
+          : # Calculate the SHA256 checksum of the package
+          echo "fleetd_base_msi_sha256=$(shasum -a 256 fleetd-base.msi | cut -d ' ' -f 1)" >> $GITHUB_OUTPUT
+
+      - name: Upload fleetd-base.msi for code signing
+        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # 4.3.3
+        with:
+          name: unsigned-windows
+          path: fleetd-base.msi
+
+  code-sign-windows:
+    needs: build-fleetd-base-msi
+    uses: ./.github/workflows/code-sign-windows.yml
+    with:
+      filename: fleetd-base.msi
+      upload_name: fleetd-base-msi
+    secrets:
+      DIGICERT_KEYLOCKER_CERTIFICATE: ${{ secrets.DIGICERT_KEYLOCKER_CERTIFICATE }}
+      DIGICERT_KEYLOCKER_PASSWORD: ${{ secrets.DIGICERT_KEYLOCKER_PASSWORD }}
+      DIGICERT_KEYLOCKER_HOST_URL: ${{ secrets.DIGICERT_KEYLOCKER_HOST_URL }}
+      DIGICERT_API_KEY: ${{ secrets.DIGICERT_API_KEY }}
+      DIGICERT_KEYLOCKER_CERTIFICATE_FINGERPRINT: ${{ secrets.DIGICERT_KEYLOCKER_CERTIFICATE_FINGERPRINT }}
+
+  update-fleetd-base-msi:
+    needs: [code-sign-windows]
+    runs-on: ubuntu-latest
+    outputs:
+      fleetd_base_msi_sha256: ${{ steps.prepare.outputs.fleetd_base_msi_sha256 }}
     env:
       FULL_DATE_DIR: archive/stable/${{ needs.check-for-fleetd-component-updates.outputs.date_dir }}
     steps:
@@ -187,23 +230,20 @@ jobs:
             .github/scripts/rclone-install.sh
           sparse-checkout-cone-mode: false
 
-      - name: Install fleetctl
-        run: npm install -g fleetctl
+      - name: Download signed artifact
+        uses: actions/download-artifact@9c19ed7fe5d278cd354c7dfd5d3b88589c7e2395 # v4.1.6
+        with:
+          name: fleetd-base-msi
 
-      - name: Build MSI
-        id: build
-        run: |
-          fleetctl package --type msi --fleet-desktop --fleet-url dummy --enroll-secret dummy
-          mv fleet-osquery*.msi fleetd-base.msi
-          : # Calculate the SHA256 checksum of the package
-          echo "fleetd_base_msi_sha256=$(shasum -a 256 fleetd-base.msi | cut -d ' ' -f 1)" >> $GITHUB_OUTPUT
-
-      - name: Set up files and directories for upload
+      - name: Set up files and directories for R2 upload
+        id: prepare
         run: |
           mkdir -p stable
           mkdir -p ${{ env.FULL_DATE_DIR }}
           cp fleetd-base.msi stable/
           cp fleetd-base.msi ${{ env.FULL_DATE_DIR }}/
+          : # Calculate the SHA256 checksum of the package
+          echo "fleetd_base_msi_sha256=$(shasum -a 256 fleetd-base.msi | cut -d ' ' -f 1)" >> $GITHUB_OUTPUT
 
       - name: Upload package
         uses: ./.github/actions/r2-upload
@@ -234,7 +274,7 @@ jobs:
         with:
           name: latest-tuf-meta.json
 
-      - name: Set up files and directories for upload
+      - name: Set up files and directories for R2 upload
         run: |
           mkdir -p stable
           mkdir -p ${{ env.FULL_DATE_DIR }}

--- a/.github/workflows/release-fleetd-base.yml
+++ b/.github/workflows/release-fleetd-base.yml
@@ -51,6 +51,9 @@ jobs:
         id: check-for-fleetd-component-updates
         run: |
           go run tools/tuf/status/tuf-status.go channel-version -channel stable --components orbit,desktop,osqueryd --format json > latest-tuf-meta.json
+          : # Check that latest-tuf-meta.json is valid
+          jq -e . >/dev/null 2>&1 <<< $(cat latest-tuf-meta.json)
+          : # Download the current TUF meta file in order to compare it with the latest
           curl -O $BASE_URL/stable/tuf-meta.json
           if diff latest-tuf-meta.json tuf-meta.json >/dev/null 2>&1
           then
@@ -59,6 +62,8 @@ jobs:
             echo "update_needed=true" >> $GITHUB_OUTPUT
           fi
           echo "date_dir=$(date -u +%Y-%m-%d_%H-%M-%S)" >> $GITHUB_OUTPUT
+          : # BOZO remove this
+          echo "update_needed=true" >> $GITHUB_OUTPUT
 
       - name: Upload latest TUF meta artifact
         uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
@@ -165,7 +170,7 @@ jobs:
     if: needs.check-for-fleetd-component-updates.outputs.update_needed == 'true'
     runs-on: ubuntu-latest
     outputs:
-      fleetd_base_msi_sha256: ${{ steps.build-sign-notarize.outputs.fleetd_base_msi_sha256 }}
+      fleetd_base_msi_sha256: ${{ steps.build.outputs.fleetd_base_msi_sha256 }}
     env:
       FULL_DATE_DIR: archive/stable/${{ needs.check-for-fleetd-component-updates.outputs.date_dir }}
     steps:
@@ -186,6 +191,7 @@ jobs:
         run: npm install -g fleetctl
 
       - name: Build MSI
+        id: build
         run: |
           fleetctl package --type msi --fleet-desktop --fleet-url dummy --enroll-secret dummy
           mv fleet-osquery*.msi fleetd-base.msi
@@ -234,11 +240,13 @@ jobs:
           mkdir -p ${{ env.FULL_DATE_DIR }}
           echo '{
             "fleetd_base_pkg_url": "${{ env.BASE_URL }}/${{ env.FULL_DATE_DIR }}/fleetd-base.pkg",
-            "fleetd_base_pkg_sha256\": "${{ needs.update-fleetd-base-pkg.outputs.fleetd_base_pkg_sha256 }}",
+            "fleetd_base_pkg_sha256": "${{ needs.update-fleetd-base-pkg.outputs.fleetd_base_pkg_sha256 }}",
             "fleetd_base_msi_url": "${{ env.BASE_URL }}/${{ env.FULL_DATE_DIR }}/fleetd-base.msi",
             "fleetd_base_msi_sha256": "${{ needs.update-fleetd-base-msi.outputs.fleetd_base_msi_sha256 }}",
             "version": "${{ needs.check-for-fleetd-component-updates.outputs.date_dir }}"
           }' > meta.json
+          : # Check that meta.json is valid
+          jq -e . >/dev/null 2>&1 <<< $(cat meta.json)
           cp latest-tuf-meta.json stable/tuf-meta.json
           cp latest-tuf-meta.json ${{ env.FULL_DATE_DIR }}/tuf-meta.json
           cp meta.json stable/meta.json

--- a/.github/workflows/release-fleetd-base.yml
+++ b/.github/workflows/release-fleetd-base.yml
@@ -29,6 +29,7 @@ jobs:
   check-for-fleetd-component-updates:
     runs-on: ubuntu-latest
     outputs:
+      date_dir: ${{ steps.check-for-fleetd-component-updates.outputs.date_dir }}
       update_needed: ${{ steps.check-for-fleetd-component-updates.outputs.update_needed }}
     steps:
       - name: Harden Runner
@@ -49,25 +50,30 @@ jobs:
       - name: Check for fleetd component updates
         id: check-for-fleetd-component-updates
         run: |
-          go run tools/tuf/status/tuf-status.go channel-version -channel stable --components orbit,desktop,osqueryd --format json > latest-meta.json
-          curl -O $BASE_URL/meta.json
-          if diff latest-meta.json meta.json >/dev/null 2>&1
+          go run tools/tuf/status/tuf-status.go channel-version -channel stable --components orbit,desktop,osqueryd --format json > latest-tuf-meta.json
+          curl -O $BASE_URL/stable/tuf-meta.json
+          if diff latest-tuf-meta.json tuf-meta.json >/dev/null 2>&1
           then
             echo "update_needed=false" >> $GITHUB_OUTPUT
           else
             echo "update_needed=true" >> $GITHUB_OUTPUT
           fi
+          echo "date_dir=$(date -u +%Y-%m-%d_%H-%M-%S)" >> $GITHUB_OUTPUT
 
-      - name: Upload latest meta.json artifact
+      - name: Upload latest TUF meta artifact
         uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
         with:
-          name: latest-meta.json
-          path: latest-meta.json
+          name: latest-tuf-meta.json
+          path: latest-tuf-meta.json
 
   update-fleetd-base-pkg:
     needs: [check-for-fleetd-component-updates]
     if: needs.check-for-fleetd-component-updates.outputs.update_needed == 'true'
     runs-on: macos-latest
+    outputs:
+      fleetd_base_pkg_sha256: ${{ steps.build-sign-notarize.outputs.fleetd_base_pkg_sha256 }}
+    env:
+      FULL_DATE_DIR: archive/stable/${{ needs.check-for-fleetd-component-updates.outputs.date_dir }}
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@63c24ba6bd7ba022e95695ff85de572c04a18142 # v2.7.0
@@ -101,6 +107,7 @@ jobs:
           rm certificate.p12
 
       - name: Build PKG, sign, and notarize
+        id: build-sign-notarize
         env:
           AC_USERNAME: ${{ secrets.APPLE_USERNAME }}
           AC_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
@@ -109,8 +116,8 @@ jobs:
         run: |
           fleetctl package --type pkg --fleet-desktop --use-system-configuration --sign-identity $PACKAGE_SIGNING_IDENTITY_SHA1 --notarize
           mv fleet-osquery*.pkg fleetd-base.pkg
-          : # Calculate the SHA256 checksum of the package for the next step
-          echo "FLEETD_BASE_PKG_CHECKSUM=$(shasum -a 256 fleetd-base.pkg | cut -d ' ' -f 1)" >> $GITHUB_ENV
+          : # Calculate the SHA256 checksum of the package
+          echo "fleetd_base_pkg_sha256=$(shasum -a 256 fleetd-base.pkg | cut -d ' ' -f 1)" >> $GITHUB_OUTPUT
 
       - name: Create plist
         run: |
@@ -128,7 +135,7 @@ jobs:
                       <integer>32</integer>
                       <key>sha256s</key>
                       <array>
-                        <string>${{ env.FLEETD_BASE_PKG_CHECKSUM }}</string>
+                        <string>${{ steps.build-sign-notarize.outputs.fleetd_base_pkg_sha256 }}</string>
                       </array>
                       <key>url</key>
                       <string>${{ env.BASE_URL }}/fleetd-base.pkg</string>
@@ -139,15 +146,27 @@ jobs:
             </dict>
           </plist>' > fleetd-base-manifest.plist
 
+      - name: Set up files and directories for upload
+        run: |
+          mkdir -p stable
+          cp fleetd-base.pkg stable/
+          cp fleetd-base-manifest.plist stable/
+          cp fleetd-base.pkg ${{ env.FULL_DATE_DIR }}/
+          cp fleetd-base-manifest.plist ${{ env.FULL_DATE_DIR }}/
+
       - name: Upload package
         uses: ./.github/actions/r2-upload
         with:
-          filenames: fleetd-base.pkg,fleetd-base-manifest.plist
+          filenames: stable/fleetd-base.pkg,stable/fleetd-base-manifest.plist,${{ env.FULL_DATE_DIR }}/fleetd-base.pkg,${{ env.FULL_DATE_DIR }}/fleetd-base-manifest.plist
 
   update-fleetd-base-msi:
     needs: [check-for-fleetd-component-updates]
     if: needs.check-for-fleetd-component-updates.outputs.update_needed == 'true'
     runs-on: ubuntu-latest
+    outputs:
+      fleetd_base_msi_sha256: ${{ steps.build-sign-notarize.outputs.fleetd_base_msi_sha256 }}
+    env:
+      FULL_DATE_DIR: archive/stable/${{ needs.check-for-fleetd-component-updates.outputs.date_dir }}
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@63c24ba6bd7ba022e95695ff85de572c04a18142 # v2.7.0
@@ -169,15 +188,25 @@ jobs:
         run: |
           fleetctl package --type msi --fleet-desktop --fleet-url dummy --enroll-secret dummy
           mv fleet-osquery*.msi fleetd-base.msi
+          : # Calculate the SHA256 checksum of the package
+          echo "fleetd_base_msi_sha256=$(shasum -a 256 fleetd-base.msi | cut -d ' ' -f 1)" >> $GITHUB_OUTPUT
+
+      - name: Set up files and directories for upload
+        run: |
+          mkdir -p stable
+          cp fleetd-base.msi stable/
+          cp fleetd-base.msi ${{ env.FULL_DATE_DIR }}/
 
       - name: Upload package
         uses: ./.github/actions/r2-upload
         with:
-          filenames: fleetd-base.msi
+          filenames: stable/fleetd-base.msi,${{ env.FULL_DATE_DIR }}/fleetd-base.msi
 
   update-meta-json:
-    needs: [update-fleetd-base-pkg, update-fleetd-base-msi]
+    needs: [check-for-fleetd-component-updates, update-fleetd-base-pkg, update-fleetd-base-msi]
     runs-on: ubuntu-latest
+    env:
+      FULL_DATE_DIR: archive/stable/${{ needs.check-for-fleetd-component-updates.outputs.date_dir }}
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@63c24ba6bd7ba022e95695ff85de572c04a18142 # v2.7.0
@@ -192,15 +221,26 @@ jobs:
             .github/scripts/rclone-install.sh
           sparse-checkout-cone-mode: false
 
-      - name: Download latest-meta.json artifact
+      - name: Download latest-tuf-meta.json artifact
         uses: actions/download-artifact@c850b930e6ba138125429b7e5c93fc707a7f8427 # v4.1.4
         with:
-          name: latest-meta.json
+          name: latest-tuf-meta.json
 
-      - name: Rename latest-meta.json to meta.json
-        run: mv latest-meta.json meta.json
+      - name: Set up files and directories for upload
+        run: |
+          echo "{
+            \"fleetd_base_pkg_url\": \"${{ env.BASE_URL }}/${{ env.FULL_DATE_DIR }}/fleetd-base.pkg\",
+            \"fleetd_base_pkg_sha256\": \"${{ needs.update-fleetd-base-pkg.outputs.fleetd_base_pkg_sha256 }}\",
+            \"fleetd_base_msi_url\": \"${{ env.BASE_URL }}/${{ env.FULL_DATE_DIR }}/fleetd-base.msi\",
+            \"fleetd_base_msi_sha256\": \"${{ needs.update-fleetd-base-msi.outputs.fleetd_base_msi_sha256 }}\",
+            \"timestamp\": \"$(date -u +%Y-%m-%d_%H-%M-%S)\",
+          }" > meta.json
+          cp latest-tuf-meta.json stable/tuf-meta.json
+          cp latest-tuf-meta.json ${{ env.FULL_DATE_DIR }}/tuf-meta.json
+          cp meta.json stable/meta.json
+          cp meta.json ${{ env.FULL_DATE_DIR }}/meta.json
 
-      - name: Upload meta.json
+      - name: Upload meta files
         uses: ./.github/actions/r2-upload
         with:
-          filenames: meta.json
+          filenames: stable/meta.json,stable/tuf-meta.json,${{ env.FULL_DATE_DIR }}/meta.json,${{ env.FULL_DATE_DIR }}/tuf-meta.json

--- a/.github/workflows/release-fleetd-base.yml
+++ b/.github/workflows/release-fleetd-base.yml
@@ -1,5 +1,19 @@
 name: Release and upload fleetd base to https://download.fleetdm.com
 
+# This workflow checks TUF if there are updates to orbit, desktop, and osqueryd components of fleetd.
+# If there are updates, it builds and uploads the following files:
+# - stable/meta.json
+# - stable/tuf-meta.json
+# - stable/fleetd-base.pkg
+# - stable/fleetd-base-manifest.plist
+# - stable/fleetd-base.msi
+# - archive/stable/YYYY-MM-DD_HH-MM-SS/meta.json
+# - archive/stable/YYYY-MM-DD_HH-MM-SS/tuf-meta.json
+# - archive/stable/YYYY-MM-DD_HH-MM-SS/fleetd-base.pkg
+# - archive/stable/YYYY-MM-DD_HH-MM-SS/fleetd-base-manifest.plist
+# - archive/stable/YYYY-MM-DD_HH-MM-SS/fleetd-base.msi
+# Finally, it verifies the uploaded installers and their checksums.
+
 on:
   workflow_dispatch: # Manual
   schedule:
@@ -62,8 +76,6 @@ jobs:
             echo "update_needed=true" >> $GITHUB_OUTPUT
           fi
           echo "date_dir=$(date -u +%Y-%m-%d_%H-%M-%S)" >> $GITHUB_OUTPUT
-          : # BOZO remove this
-          echo "update_needed=true" >> $GITHUB_OUTPUT
 
       - name: Upload latest TUF meta artifact
         uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1

--- a/.github/workflows/release-fleetd-base.yml
+++ b/.github/workflows/release-fleetd-base.yml
@@ -302,4 +302,4 @@ jobs:
     needs: update-meta-files
     uses: ./.github/workflows/verify-fleetd-base.yml
     with:
-      base-url: ${{ env.BASE_URL }}
+      base-url: "https://download-testing.fleetdm.com" # Production: "https://download.fleetdm.com" | Testing: "https://download-testing.fleetdm.com"

--- a/.github/workflows/release-fleetd-base.yml
+++ b/.github/workflows/release-fleetd-base.yml
@@ -213,7 +213,7 @@ jobs:
     needs: [code-sign-windows]
     runs-on: ubuntu-latest
     outputs:
-      fleetd_base_msi_sha256: ${{ steps.prepare.outputs.fleetd_base_msi_sha256 }}
+      fleetd_base_msi_sha256: ${{ steps.prepare-files.outputs.fleetd_base_msi_sha256 }}
     env:
       FULL_DATE_DIR: archive/stable/${{ needs.check-for-fleetd-component-updates.outputs.date_dir }}
     steps:
@@ -235,8 +235,8 @@ jobs:
         with:
           name: fleetd-base-msi
 
-      - name: Set up files and directories for R2 upload
-        id: prepare
+      - name: Prepare files for R2 upload
+        id: prepare-files
         run: |
           mkdir -p stable
           mkdir -p ${{ env.FULL_DATE_DIR }}

--- a/.github/workflows/release-fleetd-base.yml
+++ b/.github/workflows/release-fleetd-base.yml
@@ -230,13 +230,13 @@ jobs:
 
       - name: Set up files and directories for upload
         run: |
-          echo "{
-            \"fleetd_base_pkg_url\": \"${{ env.BASE_URL }}/${{ env.FULL_DATE_DIR }}/fleetd-base.pkg\",
-            \"fleetd_base_pkg_sha256\": \"${{ needs.update-fleetd-base-pkg.outputs.fleetd_base_pkg_sha256 }}\",
-            \"fleetd_base_msi_url\": \"${{ env.BASE_URL }}/${{ env.FULL_DATE_DIR }}/fleetd-base.msi\",
-            \"fleetd_base_msi_sha256\": \"${{ needs.update-fleetd-base-msi.outputs.fleetd_base_msi_sha256 }}\",
-            \"timestamp\": \"$(date -u +%Y-%m-%d_%H-%M-%S)\",
-          }" > meta.json
+          echo '{
+            "fleetd_base_pkg_url": "${{ env.BASE_URL }}/${{ env.FULL_DATE_DIR }}/fleetd-base.pkg",
+            "fleetd_base_pkg_sha256\": "${{ needs.update-fleetd-base-pkg.outputs.fleetd_base_pkg_sha256 }}",
+            "fleetd_base_msi_url": "${{ env.BASE_URL }}/${{ env.FULL_DATE_DIR }}/fleetd-base.msi",
+            "fleetd_base_msi_sha256": "${{ needs.update-fleetd-base-msi.outputs.fleetd_base_msi_sha256 }}",
+            "version": "${{ needs.check-for-fleetd-component-updates.outputs.date_dir }}"
+          }' > meta.json
           cp latest-tuf-meta.json stable/tuf-meta.json
           cp latest-tuf-meta.json ${{ env.FULL_DATE_DIR }}/tuf-meta.json
           cp meta.json stable/meta.json

--- a/.github/workflows/release-fleetd-chrome-beta.yml
+++ b/.github/workflows/release-fleetd-chrome-beta.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Run test
         working-directory: ./ee/fleetd-chrome
         run: |
-          npm install && npm run test
+          npm install --no-save && npm run test
 
       - name: Set the version
         working-directory: ./ee/fleetd-chrome

--- a/.github/workflows/release-fleetd-chrome-beta.yml
+++ b/.github/workflows/release-fleetd-chrome-beta.yml
@@ -24,6 +24,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    env:
+      BASE_URL: https://chrome-beta.fleetdm.com
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@63c24ba6bd7ba022e95695ff85de572c04a18142 # v2.7.0

--- a/.github/workflows/release-fleetd-chrome-beta.yml
+++ b/.github/workflows/release-fleetd-chrome-beta.yml
@@ -1,6 +1,7 @@
 name: Release fleetd-chrome beta
 
 on:
+  pull_request:
   push:
    tags:
      - 'fleetd-chrome-**-beta'
@@ -54,10 +55,24 @@ jobs:
           /usr/bin/google-chrome --pack-extension=./dist --pack-extension-key=chrome.pem
 
       - name: Prepare files for upload
+        id: prepare-files
         working-directory: ./ee/fleetd-chrome
         run: |
           mv dist.crx fleetd.crx
           mv updates-beta.xml updates.xml
+          datedir=$(date -u +%Y-%m-%d_%H-%M-%S)
+          mkdir -p archive/$datedir
+          cp fleetd.crx archive/$datedir
+          cp updates.xml archive/$datedir
+          echo "{
+            \"fleetd_crx_url\": "${{ env.BASE_URL }}/archive/$datedir/fleetd.crx\",
+            \"updates_xml\": \"${{ env.BASE_URL }}/archive/$datedir/updates.xml\",
+            \"version\": \"$datedir\"
+          }" > meta.json
+          : # Check that meta.json is valid
+          jq -e . >/dev/null 2>&1 <<< $(cat meta.json)
+          cp meta.json archive/$datedir
+          echo "datedir=$datedir" >> $GITHUB_OUTPUT
 
       - name: Upload extension
         uses: ./.github/actions/r2-upload
@@ -67,4 +82,5 @@ jobs:
           R2_ACCESS_KEY_SECRET: ${{ secrets.R2_CHROME_BETA_ACCESS_KEY_SECRET }}
           R2_BUCKET: chrome-beta
         with:
-          filenames: ./ee/fleetd-chrome/fleetd.crx,./ee/fleetd-chrome/updates.xml
+          working-directory: ./ee/fleetd-chrome
+          filenames: fleetd.crx,updates.xml,meta.json,archive/${{ steps.prepare-files.outputs.datedir }}/fleetd.crx,archive/${{ steps.prepare-files.outputs.datedir }}/updates.xml,archive/${{ steps.prepare-files.outputs.datedir }}/meta.json

--- a/.github/workflows/release-fleetd-chrome-beta.yml
+++ b/.github/workflows/release-fleetd-chrome-beta.yml
@@ -65,7 +65,7 @@ jobs:
           cp fleetd.crx archive/$datedir
           cp updates.xml archive/$datedir
           echo "{
-            \"fleetd_crx_url\": "${{ env.BASE_URL }}/archive/$datedir/fleetd.crx\",
+            \"fleetd_crx_url\": \"${{ env.BASE_URL }}/archive/$datedir/fleetd.crx\",
             \"updates_xml\": \"${{ env.BASE_URL }}/archive/$datedir/updates.xml\",
             \"version\": \"$datedir\"
           }" > meta.json

--- a/.github/workflows/release-fleetd-chrome-beta.yml
+++ b/.github/workflows/release-fleetd-chrome-beta.yml
@@ -1,5 +1,13 @@
 name: Release fleetd-chrome beta
 
+# Build and upload the following files:
+# - fleetd.crx
+# - updates.xml
+# - meta.json
+# - archive/YYYY-MM-DD_HH-MM-SS/fleetd.crx
+# - archive/YYYY-MM-DD_HH-MM-SS/updates.xml
+# - archive/YYYY-MM-DD_HH-MM-SS/meta.json
+
 on:
   pull_request:
   push:

--- a/.github/workflows/release-fleetd-chrome-beta.yml
+++ b/.github/workflows/release-fleetd-chrome-beta.yml
@@ -9,7 +9,6 @@ name: Release fleetd-chrome beta
 # - archive/YYYY-MM-DD_HH-MM-SS/meta.json
 
 on:
-  pull_request:
   push:
    tags:
      - 'fleetd-chrome-**-beta'

--- a/.github/workflows/release-fleetd-chrome.yml
+++ b/.github/workflows/release-fleetd-chrome.yml
@@ -24,6 +24,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    env:
+      BASE_URL: https://chrome-beta.fleetdm.com
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@63c24ba6bd7ba022e95695ff85de572c04a18142 # v2.7.0
@@ -36,7 +38,7 @@ jobs:
       - name: Run test
         working-directory: ./ee/fleetd-chrome
         run: |
-          npm install && npm run test
+          npm install --no-save && npm run test
 
       - name: Set the version
         working-directory: ./ee/fleetd-chrome

--- a/.github/workflows/release-fleetd-chrome.yml
+++ b/.github/workflows/release-fleetd-chrome.yml
@@ -1,5 +1,13 @@
 name: Release fleetd-chrome
 
+# Build and upload the following files:
+# - fleetd.crx
+# - updates.xml
+# - meta.json
+# - archive/YYYY-MM-DD_HH-MM-SS/fleetd.crx
+# - archive/YYYY-MM-DD_HH-MM-SS/updates.xml
+# - archive/YYYY-MM-DD_HH-MM-SS/meta.json
+
 on:
   push:
    tags:

--- a/.github/workflows/release-fleetd-chrome.yml
+++ b/.github/workflows/release-fleetd-chrome.yml
@@ -25,7 +25,7 @@ jobs:
     permissions:
       contents: read
     env:
-      BASE_URL: https://chrome-beta.fleetdm.com
+      BASE_URL: https://chrome.fleetdm.com
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@63c24ba6bd7ba022e95695ff85de572c04a18142 # v2.7.0

--- a/.github/workflows/release-fleetd-chrome.yml
+++ b/.github/workflows/release-fleetd-chrome.yml
@@ -57,9 +57,23 @@ jobs:
           /usr/bin/google-chrome --pack-extension=./dist --pack-extension-key=chrome.pem
 
       - name: Prepare files for upload
+        id: prepare-files
         working-directory: ./ee/fleetd-chrome
         run: |
           mv dist.crx fleetd.crx
+          datedir=$(date -u +%Y-%m-%d_%H-%M-%S)
+          mkdir -p archive/$datedir
+          cp fleetd.crx archive/$datedir
+          cp updates.xml archive/$datedir
+          echo "{
+            \"fleetd_crx_url\": \"${{ env.BASE_URL }}/archive/$datedir/fleetd.crx\",
+            \"updates_xml\": \"${{ env.BASE_URL }}/archive/$datedir/updates.xml\",
+            \"version\": \"$datedir\"
+          }" > meta.json
+          : # Check that meta.json is valid
+          jq -e . >/dev/null 2>&1 <<< $(cat meta.json)
+          cp meta.json archive/$datedir
+          echo "datedir=$datedir" >> $GITHUB_OUTPUT
 
       - name: Upload extension
         uses: ./.github/actions/r2-upload
@@ -69,4 +83,5 @@ jobs:
           R2_ACCESS_KEY_SECRET: ${{ secrets.R2_CHROME_ACCESS_KEY_SECRET }}
           R2_BUCKET: chrome
         with:
-          filenames: ./ee/fleetd-chrome/fleetd.crx,./ee/fleetd-chrome/updates.xml
+          working-directory: ./ee/fleetd-chrome
+          filenames: fleetd.crx,updates.xml,meta.json,archive/${{ steps.prepare-files.outputs.datedir }}/fleetd.crx,archive/${{ steps.prepare-files.outputs.datedir }}/updates.xml,archive/${{ steps.prepare-files.outputs.datedir }}/meta.json

--- a/.github/workflows/test-fleetd-chrome.yml
+++ b/.github/workflows/test-fleetd-chrome.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Install JS Dependencies
         if: steps.js-cache.outputs.cache-hit != 'true'
         working-directory: ./ee/fleetd-chrome
-        run: npm install
+        run: npm install --no-save
 
       - name: Build JS
         working-directory: ./ee/fleetd-chrome

--- a/.github/workflows/verify-fleetd-base.yml
+++ b/.github/workflows/verify-fleetd-base.yml
@@ -83,8 +83,11 @@ jobs:
       - name: Install fleetd-base.msi
         shell: powershell
         run: |
-          Start-Process msiexec "/i fleetd-base.msi /qn FLEET_URL='https://fleet.example.com' FLEET_SECRET='insecure'" -Wait
-          if (! $?) { exit 1 }
+          $log = "install.log"
+          $procMain = Start-Process msiexec "/i fleetd-base.msi /qn /l*! `"$log`" FLEET_URL='https://fleet.example.com' FLEET_SECRET='insecure'" -NoNewWindow -PassThru
+          $procLog = Start-Process "powershell" "Get-Content -Path `"$log`" -Wait" -NoNewWindow -PassThru
+          $procMain.WaitForExit()
+          $procLog.Kill()
           cd "C:\Windows\System32\config\systemprofile\AppData\Local\FleetDM\Orbit\Logs"
           Get-ChildItem
           if (!(Test-Path "C:\Windows\System32\config\systemprofile\AppData\Local\FleetDM\Orbit\Logs\orbit-osquery.log" -PathType Leaf)) { exit 1 }

--- a/.github/workflows/verify-fleetd-base.yml
+++ b/.github/workflows/verify-fleetd-base.yml
@@ -1,0 +1,90 @@
+name: Verify fleetd-base files at https://download.fleetdm.com
+
+on:
+  workflow_dispatch: # Manual
+  workflow_call:
+    inputs:
+      base-url:
+        description: 'The base URL to download the files from'
+        required: false
+        default: 'https://download-testing.fleetdm.com'
+        type: string
+  pull_request: # BOZO remove
+
+# This allows a subsequently queued workflow run to interrupt previous runs
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id}}
+  cancel-in-progress: true
+
+defaults:
+  run:
+    # fail-fast using bash -eo pipefail. See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#exit-codes-and-error-action-preference
+    shell: bash
+
+permissions:
+  contents: read
+
+jobs:
+  verify-checksums:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@63c24ba6bd7ba022e95695ff85de572c04a18142 # v2.7.0
+        with:
+          egress-policy: audit
+
+      - name: Verify checksums
+        run: |
+          curl -O ${{ env.BASE_URL }}/stable/meta.json
+          curl -O ${{ env.BASE_URL }}/stable/fleetd-base.msi
+          fleetd_base_msi_sha256=$(shasum -a 256 fleetd-base.msi | cut -d ' ' -f 1)
+          if [ "$(jq '.fleetd_base_msi_sha256' meta.json)" != "$fleetd_base_msi_sha256" ]; then
+            echo "Checksum mismatch for fleetd-base.msi"
+            exit 1
+          fi
+          curl -O ${{ env.BASE_URL }}/stable/fleetd-base.pkg
+          fleetd_base_pkg_sha256=$(shasum -a 256 fleetd-base.pkg | cut -d ' ' -f 1)
+          if [ "$(jq '.fleetd_base_pkg_sha256' meta.json)" != "$fleetd_base_pkg_sha256" ]; then
+              echo "Checksum mismatch for fleetd-base.pkg"
+              exit 1
+          fi
+          : # Check the files at the permalinks
+          curl -o fleetd-base-permalink.msi "$(jq '.fleetd_base_msi_url' meta.json)"
+          diff fleetd-base.msi fleetd-base-permalink.msi
+          curl -o fleetd-base-permalink.pkg "$(jq '.fleetd_base_pkg_url' meta.json)"
+          diff fleetd-base.pkg fleetd-base-permalink.pkg
+
+  verify-fleetd-base-msi:
+    runs-on: windows-latest
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@63c24ba6bd7ba022e95695ff85de572c04a18142 # v2.7.0
+        with:
+          egress-policy: audit
+
+      - name: Download fleetd-base.msi
+        shell: powershell
+        run: |
+          curl -O ${{ env.BASE_URL }}/stable/fleetd-base.msi
+
+      - name: Run fleetd-base.msi
+        shell: powershell
+        run: |
+          msiexec /i fleetd-base.msi FLEET_URL="https://fleet.example.com" FLEET_SECRET="insecure"
+          if ($LASTEXITCODE) { exit $LASTEXITCODE }
+
+  verify-fleetd-base-pkg:
+    runs-on: macos-latest
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@63c24ba6bd7ba022e95695ff85de572c04a18142 # v2.7.0
+        with:
+          egress-policy: audit
+
+      - name: Download fleetd-base.pkg
+        run: |
+          curl -O ${{ env.BASE_URL }}/stable/fleetd-base.pkg
+
+      - name: Run fleetd-base.pkg
+        run: |
+          sudo installer -pkg fleetd-base.pkg -target /

--- a/.github/workflows/verify-fleetd-base.yml
+++ b/.github/workflows/verify-fleetd-base.yml
@@ -17,10 +17,7 @@ on:
         type: string
   pull_request: # BOZO remove
 
-# This allows a subsequently queued workflow run to interrupt previous runs
-concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id}}
-  cancel-in-progress: true
+# This workflow is intended to be called by release-fleetd-base workflow, so it does not have a concurrency group.
 
 defaults:
   run:

--- a/.github/workflows/verify-fleetd-base.yml
+++ b/.github/workflows/verify-fleetd-base.yml
@@ -46,15 +46,13 @@ jobs:
           curl -O ${{ env.BASE_URL }}/stable/meta.json
           curl -O ${{ env.BASE_URL }}/stable/fleetd-base.msi
           fleetd_base_msi_sha256=$(shasum -a 256 fleetd-base.msi | cut -d ' ' -f 1)
-          echo "$(jq '.fleetd_base_msi_sha256' meta.json)"
-          echo "$fleetd_base_msi_sha256"
-          if [ "$(jq '.fleetd_base_msi_sha256' meta.json)" != "$fleetd_base_msi_sha256" ]; then
+          if [ "$(jq --raw-output '.fleetd_base_msi_sha256' meta.json)" != "$fleetd_base_msi_sha256" ]; then
             echo "Checksum mismatch for fleetd-base.msi"
             exit 1
           fi
           curl -O ${{ env.BASE_URL }}/stable/fleetd-base.pkg
           fleetd_base_pkg_sha256=$(shasum -a 256 fleetd-base.pkg | cut -d ' ' -f 1)
-          if [ "$(jq '.fleetd_base_pkg_sha256' meta.json)" != "$fleetd_base_pkg_sha256" ]; then
+          if [ "$(jq --raw-output '.fleetd_base_pkg_sha256' meta.json)" != "$fleetd_base_pkg_sha256" ]; then
               echo "Checksum mismatch for fleetd-base.pkg"
               exit 1
           fi
@@ -79,11 +77,12 @@ jobs:
         run: |
           Invoke-WebRequest ${{ env.BASE_URL }}/stable/fleetd-base.msi -OutFile fleetd-base.msi
 
-      - name: Run fleetd-base.msi
+      - name: Install fleetd-base.msi
         shell: powershell
         run: |
-          msiexec /i fleetd-base.msi FLEET_URL="https://fleet.example.com" FLEET_SECRET="insecure"
+          msiexec /i fleetd-base.msi FLEET_URL="https://fleet.example.com" FLEET_SECRET="insecure" /L*V fleetd-base-install.log
           if ($LASTEXITCODE) { exit $LASTEXITCODE }
+          get-content fleetd-base-install.log
 
   verify-fleetd-base-pkg:
     runs-on: macos-latest

--- a/.github/workflows/verify-fleetd-base.yml
+++ b/.github/workflows/verify-fleetd-base.yml
@@ -83,11 +83,8 @@ jobs:
       - name: Install fleetd-base.msi
         shell: powershell
         run: |
-          $log = "install.log"
-          $procMain = Start-Process msiexec "/i fleetd-base.msi /qn /l*! `"$log`" FLEET_URL='https://fleet.example.com' FLEET_SECRET='insecure'" -NoNewWindow -PassThru
-          $procLog = Start-Process "powershell" "Get-Content -Path `"$log`" -Wait" -NoNewWindow -PassThru
-          $procMain.WaitForExit()
-          $procLog.Kill()
+          Start-Process msiexec "/i fleetd-base.msi /qn FLEET_URL='https://fleet.example.com' FLEET_SECRET='insecure'" -Wait
+          if (! $?) { exit 1 }
           cd "C:\Windows\System32\config\systemprofile\AppData\Local\FleetDM\Orbit\Logs"
           Get-ChildItem
           if (!(Test-Path "C:\Windows\System32\config\systemprofile\AppData\Local\FleetDM\Orbit\Logs\orbit-osquery.log" -PathType Leaf)) { exit 1 }

--- a/.github/workflows/verify-fleetd-base.yml
+++ b/.github/workflows/verify-fleetd-base.yml
@@ -77,16 +77,17 @@ jobs:
         shell: powershell
         run: |
           Invoke-WebRequest "${{ env.BASE_URL }}/stable/fleetd-base.msi" -OutFile "fleetd-base.msi"
-          if ($LASTEXITCODE) { exit $LASTEXITCODE }
+          if (! $?) { exit 1 }
           Get-ChildItem
 
       - name: Install fleetd-base.msi
         shell: powershell
         run: |
-          msiexec /i "${{ github.workspace}}/fleetd-base.msi" FLEET_URL="https://fleet.example.com" FLEET_SECRET="insecure" /L*V "${{ github.workspace}}/fleetd-base-install.log"
-          if ($LASTEXITCODE) { exit $LASTEXITCODE }
+          Start-Process msiexec "/i fleetd-base.msi /qn FLEET_URL='https://fleet.example.com' FLEET_SECRET='insecure'" -Wait
+          if (! $?) { exit 1 }
+          cd "C:\Windows\System32\config\systemprofile\AppData\Local\FleetDM\Orbit\Logs"
           Get-ChildItem
-          Get-Content "${{ github.workspace}}/fleetd-base-install.log"
+          if (! Test-Path "C:\Windows\System32\config\systemprofile\AppData\Local\FleetDM\Orbit\Logs\orbit-osquery.log" -PathType Leaf) { exit 1 }
 
   verify-fleetd-base-pkg:
     runs-on: macos-latest

--- a/.github/workflows/verify-fleetd-base.yml
+++ b/.github/workflows/verify-fleetd-base.yml
@@ -85,6 +85,7 @@ jobs:
         run: |
           Start-Process msiexec "/i fleetd-base.msi /qn FLEET_URL='https://fleet.example.com' FLEET_SECRET='insecure'" -Wait
           if (! $?) { exit 1 }
+          Start-Sleep -Seconds 5
           cd "C:\Windows\System32\config\systemprofile\AppData\Local\FleetDM\Orbit\Logs"
           Get-ChildItem
           if (!(Test-Path "C:\Windows\System32\config\systemprofile\AppData\Local\FleetDM\Orbit\Logs\orbit-osquery.log" -PathType Leaf)) { exit 1 }

--- a/.github/workflows/verify-fleetd-base.yml
+++ b/.github/workflows/verify-fleetd-base.yml
@@ -76,14 +76,17 @@ jobs:
       - name: Download fleetd-base.msi
         shell: powershell
         run: |
-          Invoke-WebRequest ${{ env.BASE_URL }}/stable/fleetd-base.msi -OutFile fleetd-base.msi
+          Invoke-WebRequest "${{ env.BASE_URL }}/stable/fleetd-base.msi" -OutFile "fleetd-base.msi"
+          if ($LASTEXITCODE) { exit $LASTEXITCODE }
+          Get-ChildItem
 
       - name: Install fleetd-base.msi
         shell: powershell
         run: |
           msiexec /i "${{ github.workspace}}/fleetd-base.msi" FLEET_URL="https://fleet.example.com" FLEET_SECRET="insecure" /L*V "${{ github.workspace}}/fleetd-base-install.log"
           if ($LASTEXITCODE) { exit $LASTEXITCODE }
-          get-content "${{ github.workspace}}/fleetd-base-install.log"
+          Get-ChildItem
+          Get-Content "${{ github.workspace}}/fleetd-base-install.log"
 
   verify-fleetd-base-pkg:
     runs-on: macos-latest

--- a/.github/workflows/verify-fleetd-base.yml
+++ b/.github/workflows/verify-fleetd-base.yml
@@ -2,12 +2,18 @@ name: Verify fleetd-base files at https://download.fleetdm.com
 
 on:
   workflow_dispatch: # Manual
+    inputs:
+      base-url:
+        description: 'The base URL to download the files from'
+        required: false
+        default: 'https://download.fleetdm.com'
+        type: string
   workflow_call:
     inputs:
       base-url:
         description: 'The base URL to download the files from'
         required: false
-        default: 'https://download-testing.fleetdm.com'
+        default: 'https://download.fleetdm.com'
         type: string
   pull_request: # BOZO remove
 
@@ -27,6 +33,8 @@ permissions:
 jobs:
   verify-checksums:
     runs-on: ubuntu-latest
+    env:
+      BASE_URL: ${{ github.event.inputs.base-url || 'https://download-testing.fleetdm.com' }}
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@63c24ba6bd7ba022e95695ff85de572c04a18142 # v2.7.0
@@ -56,6 +64,8 @@ jobs:
 
   verify-fleetd-base-msi:
     runs-on: windows-latest
+    env:
+      BASE_URL: ${{ github.event.inputs.base-url || 'https://download-testing.fleetdm.com' }}
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@63c24ba6bd7ba022e95695ff85de572c04a18142 # v2.7.0
@@ -75,6 +85,8 @@ jobs:
 
   verify-fleetd-base-pkg:
     runs-on: macos-latest
+    env:
+      BASE_URL: ${{ github.event.inputs.base-url || 'https://download-testing.fleetdm.com' }}
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@63c24ba6bd7ba022e95695ff85de572c04a18142 # v2.7.0

--- a/.github/workflows/verify-fleetd-base.yml
+++ b/.github/workflows/verify-fleetd-base.yml
@@ -49,17 +49,21 @@ jobs:
           if [ "$(jq --raw-output '.fleetd_base_msi_sha256' meta.json)" != "$fleetd_base_msi_sha256" ]; then
             echo "Checksum mismatch for fleetd-base.msi"
             exit 1
+          else
+            echo "Checksum matches for fleetd-base.msi"
           fi
           curl -O ${{ env.BASE_URL }}/stable/fleetd-base.pkg
           fleetd_base_pkg_sha256=$(shasum -a 256 fleetd-base.pkg | cut -d ' ' -f 1)
           if [ "$(jq --raw-output '.fleetd_base_pkg_sha256' meta.json)" != "$fleetd_base_pkg_sha256" ]; then
               echo "Checksum mismatch for fleetd-base.pkg"
               exit 1
+          else
+              echo "Checksum matches for fleetd-base.pkg"
           fi
           : # Check the files at the permalinks
-          curl -o fleetd-base-permalink.msi "$(jq '.fleetd_base_msi_url' meta.json)"
+          curl -o fleetd-base-permalink.msi "$(jq --raw-output '.fleetd_base_msi_url' meta.json)"
           diff fleetd-base.msi fleetd-base-permalink.msi
-          curl -o fleetd-base-permalink.pkg "$(jq '.fleetd_base_pkg_url' meta.json)"
+          curl -o fleetd-base-permalink.pkg "$(jq --raw-output '.fleetd_base_pkg_url' meta.json)"
           diff fleetd-base.pkg fleetd-base-permalink.pkg
 
   verify-fleetd-base-msi:
@@ -80,9 +84,9 @@ jobs:
       - name: Install fleetd-base.msi
         shell: powershell
         run: |
-          msiexec /i fleetd-base.msi FLEET_URL="https://fleet.example.com" FLEET_SECRET="insecure" /L*V fleetd-base-install.log
+          msiexec /i "${{ github.workspace}}/fleetd-base.msi" FLEET_URL="https://fleet.example.com" FLEET_SECRET="insecure" /L*V "${{ github.workspace}}/fleetd-base-install.log"
           if ($LASTEXITCODE) { exit $LASTEXITCODE }
-          get-content fleetd-base-install.log
+          get-content "${{ github.workspace}}/fleetd-base-install.log"
 
   verify-fleetd-base-pkg:
     runs-on: macos-latest

--- a/.github/workflows/verify-fleetd-base.yml
+++ b/.github/workflows/verify-fleetd-base.yml
@@ -87,7 +87,7 @@ jobs:
           if (! $?) { exit 1 }
           cd "C:\Windows\System32\config\systemprofile\AppData\Local\FleetDM\Orbit\Logs"
           Get-ChildItem
-          if (! Test-Path "C:\Windows\System32\config\systemprofile\AppData\Local\FleetDM\Orbit\Logs\orbit-osquery.log" -PathType Leaf) { exit 1 }
+          if (!(Test-Path "C:\Windows\System32\config\systemprofile\AppData\Local\FleetDM\Orbit\Logs\orbit-osquery.log" -PathType Leaf)) { exit 1 }
 
   verify-fleetd-base-pkg:
     runs-on: macos-latest

--- a/.github/workflows/verify-fleetd-base.yml
+++ b/.github/workflows/verify-fleetd-base.yml
@@ -15,7 +15,6 @@ on:
         required: false
         default: 'https://download.fleetdm.com'
         type: string
-  pull_request: # BOZO remove
 
 # This workflow is intended to be called by release-fleetd-base workflow, so it does not have a concurrency group.
 

--- a/.github/workflows/verify-fleetd-base.yml
+++ b/.github/workflows/verify-fleetd-base.yml
@@ -46,6 +46,8 @@ jobs:
           curl -O ${{ env.BASE_URL }}/stable/meta.json
           curl -O ${{ env.BASE_URL }}/stable/fleetd-base.msi
           fleetd_base_msi_sha256=$(shasum -a 256 fleetd-base.msi | cut -d ' ' -f 1)
+          echo "$(jq '.fleetd_base_msi_sha256' meta.json)"
+          echo "$fleetd_base_msi_sha256"
           if [ "$(jq '.fleetd_base_msi_sha256' meta.json)" != "$fleetd_base_msi_sha256" ]; then
             echo "Checksum mismatch for fleetd-base.msi"
             exit 1
@@ -75,7 +77,7 @@ jobs:
       - name: Download fleetd-base.msi
         shell: powershell
         run: |
-          curl -O ${{ env.BASE_URL }}/stable/fleetd-base.msi
+          Invoke-WebRequest ${{ env.BASE_URL }}/stable/fleetd-base.msi -OutFile fleetd-base.msi
 
       - name: Run fleetd-base.msi
         shell: powershell
@@ -97,6 +99,6 @@ jobs:
         run: |
           curl -O ${{ env.BASE_URL }}/stable/fleetd-base.pkg
 
-      - name: Run fleetd-base.pkg
+      - name: Install fleetd-base.pkg
         run: |
           sudo installer -pkg fleetd-base.pkg -target /


### PR DESCRIPTION
#19182 and #19111

- Upload and keep all fleetd-base and fleetd-chrome artifacts
- Code sign fleetd-base.msi
- Verify checksums and try installing fleetd-base packages

These changes will apply the fleet-base workflow to download-testing.fleetdm.com, and another PR will change to the production endpoint (download.fleetdm.com) after QA.

## fleetd-base
Successful fleetd-base workflow run: https://github.com/fleetdm/fleet/actions/runs/9522282299

New meta files will be in the `stable` directory:
- https://download-testing.fleetdm.com/stable/meta.json
- https://download-testing.fleetdm.com/stable/tuf-meta.json

The files in the root directory will no longer be updated for backward compatibility.

## fleetd-chrome
Successful fleetd-chrome beta run: https://github.com/fleetdm/fleet/actions/runs/9552391075/job/26328861033