### PR TITLE
Fleet UI: Hide no teams option from team level users

### DIFF
--- a/changes/19501-team-level-no-teams-bug
+++ b/changes/19501-team-level-no-teams-bug
@@ -1,0 +1,1 @@
+* bug fix: Hide no teams option from team level users

--- a/frontend/components/LiveQuery/SelectTargets.tsx
+++ b/frontend/components/LiveQuery/SelectTargets.tsx
@@ -151,7 +151,7 @@ const SelectTargets = ({
   setTargetedTeams,
   setTargetsTotalCount,
 }: ISelectTargetsProps): JSX.Element => {
-  const { isPremiumTier } = useContext(AppContext);
+  const { isPremiumTier, isOnGlobalTeam } = useContext(AppContext);
 
   const [labels, setLabels] = useState<ILabelsByType | null>(null);
   const [inputTabIndex, setInputTabIndex] = useState<number | null>(null);
@@ -457,10 +457,12 @@ const SelectTargets = ({
         {!!labels?.platforms?.length &&
           renderTargetEntityList("Platforms", labels.platforms)}
         {!!teams?.length &&
-          renderTargetEntityList("Teams", [
-            { id: 0, name: "No team" },
-            ...teams,
-          ])}
+          (isOnGlobalTeam
+            ? renderTargetEntityList("Teams", [
+                { id: 0, name: "No team" },
+                ...teams,
+              ])
+            : renderTargetEntityList("Teams", teams))}
         {!!labels?.other?.length &&
           renderTargetEntityList("Labels", labels.other)}
       </div>


### PR DESCRIPTION
## Issue
Cerra #19501 

## Description
- When query/policy > select targets, hide No teams option from team level users

## Screenshot


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
- [x] Manual QA for all new/changed functionality

Adding tests in a separate PR since the tests ended up being more complicated than anticipated.

