### PR TITLE
[unreleased bug 19090] Fleet UI: Fix where platform causes incorrect count

### DIFF
--- a/frontend/pages/queries/ManageQueriesPage/ManageQueriesPage.tsx
+++ b/frontend/pages/queries/ManageQueriesPage/ManageQueriesPage.tsx
@@ -14,7 +14,7 @@ import { QueryContext } from "context/query";
 import { TableContext } from "context/table";
 import { NotificationContext } from "context/notification";
 import { getPerformanceImpactDescription } from "utilities/helpers";
-import { SupportedPlatform } from "interfaces/platform";
+import { SupportedPlatform, SelectedPlatform } from "interfaces/platform";
 import {
   IEnhancedQuery,
   IQueryKeyQueriesLoadAll,
@@ -43,7 +43,7 @@ interface IManageQueriesPageProps {
   location: {
     pathname: string;
     query: {
-      platform?: SupportedPlatform;
+      platform?: SelectedPlatform;
       page?: string;
       query?: string;
       order_key?: string;

--- a/frontend/pages/queries/ManageQueriesPage/components/QueriesTable/QueriesTable.tsx
+++ b/frontend/pages/queries/ManageQueriesPage/components/QueriesTable/QueriesTable.tsx
@@ -131,7 +131,7 @@ const QueriesTable = ({
       );
     }
     setIsQueriesStateLoading(false);
-  }, [queriesList, queryParams?.query]);
+  }, [queriesList, queryParams]);
 
   // Functions to avoid race conditions
   const initialSearchQuery = (() => queryParams?.query ?? "")();

--- a/frontend/pages/queries/ManageQueriesPage/components/QueriesTable/QueriesTable.tsx
+++ b/frontend/pages/queries/ManageQueriesPage/components/QueriesTable/QueriesTable.tsx
@@ -10,7 +10,7 @@ import { InjectedRouter } from "react-router";
 
 import { AppContext } from "context/app";
 import { IEmptyTableProps } from "interfaces/empty_table";
-import { SupportedPlatform } from "interfaces/platform";
+import { SelectedPlatform } from "interfaces/platform";
 import { IEnhancedQuery } from "interfaces/schedulable_query";
 import { ITableQueryData } from "components/TableContainer/TableContainer";
 import { IActionButtonProps } from "components/TableContainer/DataTable/ActionButton/ActionButton";
@@ -38,7 +38,7 @@ export interface IQueriesTableProps {
   isAnyTeamObserverPlus: boolean;
   router?: InjectedRouter;
   queryParams?: {
-    platform?: SupportedPlatform;
+    platform?: SelectedPlatform;
     page?: string;
     query?: string;
     order_key?: string;
@@ -118,13 +118,13 @@ const QueriesTable = ({
                 .toLowerCase()
                 .includes(queryParams?.query.toLowerCase())
             : true;
-
           const compatiblePlatforms =
             checkPlatformCompatibility(query.query).platforms || [];
 
-          const filterCompatiblePlatform = queryParams?.platform
-            ? compatiblePlatforms.includes(queryParams?.platform)
-            : true;
+          const filterCompatiblePlatform =
+            queryParams?.platform && queryParams?.platform !== "all"
+              ? compatiblePlatforms.includes(queryParams?.platform)
+              : true;
 
           return filterSearchQuery && filterCompatiblePlatform;
         }) || []


### PR DESCRIPTION
## Issue
Unreleased bug from #19090 

## Description
Fix 1: Refreshing page causes platform to be set to "all" which is not included in `SupportedPlatform`
- Account for queryParams.platform === "all" in client side filtering code
  - Update code to use `SelectedPlatform` type which includes "all" option
  - Update code that filters the platform type to not search for queries that have "all" as a platform

Fix 2: Changing platform was not updating the count
- Update useEffect code to watch for changes in all queryParams not just the search query

## Screenrecording of fix
https://www.loom.com/share/b1c22f159c344df8b6efdb5fdfee1b90?sid=ca8d2e18-6dae-44eb-b695-61c47792f6be

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Manual QA for all new/changed functionality
.
