### PR TITLE
Fleet UI: Clarify Fleet uses 3.x CVSS score

### DIFF
--- a/changes/19775-clarify-cvss-score
+++ b/changes/19775-clarify-cvss-score
@@ -1,0 +1,1 @@
+* Clarify Fleet uses CVSS base score version 3.x

--- a/frontend/pages/SoftwarePage/SoftwareVulnerabilityDetailsPage/SoftwareVulnSummary/SoftwareVulnSummary.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareVulnerabilityDetailsPage/SoftwareVulnSummary/SoftwareVulnSummary.tsx
@@ -59,7 +59,7 @@ const SoftwareVulnSummary = ({
               <DataSet
                 title={
                   <TooltipWrapper
-                    tipContent="The worst case impact across different environments (CVSS base score). This data is reported by the National Vulnerability Database (NVD)."
+                    tipContent="The worst case impact across different environments (CVSS version 3.x base score). This data is reported by the National Vulnerability Database (NVD)."
                     // to match neighboring tooltip wrapper
                   >
                     Severity

--- a/frontend/pages/SoftwarePage/components/SoftwareVulnerabilitiesTable/SoftwareVulnerabilitiesTableConfig.tsx
+++ b/frontend/pages/SoftwarePage/components/SoftwareVulnerabilitiesTable/SoftwareVulnerabilitiesTableConfig.tsx
@@ -92,8 +92,8 @@ const generateTableConfig = (
           <TooltipWrapper
             tipContent={
               <>
-                The worst case impact across different environments (CVSS base
-                score).
+                The worst case impact across different environments (CVSS
+                version 3.x base score).
               </>
             }
           >


### PR DESCRIPTION
## Issue
Cerra #19775 

## Description
- Clarify in the UI that we use CVSS score version 3.x

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
- [x] Manual QA for all new/changed functionality
