### PR TITLE
ensure strict configuration outputs for terraform logging destination modules

### DIFF
--- a/terraform/addons/byo-firehose-logging-destination/firehose/outputs.tf
+++ b/terraform/addons/byo-firehose-logging-destination/firehose/outputs.tf
@@ -6,10 +6,10 @@ output "fleet_extra_environment_variables" {
     FLEET_FIREHOSE_STS_ASSUME_ROLE_ARN = var.iam_role_arn
     FLEET_FIREHOSE_STS_EXTERNAL_ID     = var.sts_external_id
     FLEET_FIREHOSE_REGION              = var.region
-    FLEET_OSQUERY_STATUS_LOG_PLUGIN    = "firehose"
-    FLEET_OSQUERY_RESULT_LOG_PLUGIN    = "firehose"
+    FLEET_OSQUERY_STATUS_LOG_PLUGIN    = length(var.firehose_status_name) > 0 ? "firehose" : ""
+    FLEET_OSQUERY_RESULT_LOG_PLUGIN    = length(var.firehose_results_name) > 0 ? "firehose" : ""
+    FLEET_ACTIVITY_AUDIT_LOG_PLUGIN    = length(var.firehose_audit_name) > 0 ? "firehose" : ""
     FLEET_ACTIVITY_ENABLE_AUDIT_LOG    = length(var.firehose_audit_name) > 0 ? "true" : "false"
-    FLEET_ACTIVITY_AUDIT_LOG_PLUGIN    = "firehose" # only has an effect if ^ is true
   }
 }
 

--- a/terraform/addons/byo-kinesis-logging-destination/kinesis/outputs.tf
+++ b/terraform/addons/byo-kinesis-logging-destination/kinesis/outputs.tf
@@ -6,10 +6,10 @@ output "fleet_extra_environment_variables" {
     FLEET_KINESIS_STS_ASSUME_ROLE_ARN = var.iam_role_arn
     FLEET_KINESIS_STS_EXTERNAL_ID     = var.sts_external_id
     FLEET_KINESIS_REGION              = var.region
-    FLEET_OSQUERY_STATUS_LOG_PLUGIN    = "kinesis"
-    FLEET_OSQUERY_RESULT_LOG_PLUGIN    = "kinesis"
-    FLEET_ACTIVITY_ENABLE_AUDIT_LOG    = length(var.kinesis_audit_name) > 0 ? "true" : "false"
-    FLEET_ACTIVITY_AUDIT_LOG_PLUGIN    = "kinesis" # only has an effect if ^ is true
+    FLEET_OSQUERY_STATUS_LOG_PLUGIN   = length(var.kinesis_status_name) > 0 ? "kinesis" : ""
+    FLEET_OSQUERY_RESULT_LOG_PLUGIN   = length(var.kinesis_results_name) > 0 ? "kinesis" : ""
+    FLEET_ACTIVITY_AUDIT_LOG_PLUGIN   = length(var.kinesis_audit_name) > 0 ? "kinesis" : ""
+    FLEET_ACTIVITY_ENABLE_AUDIT_LOG   = length(var.kinesis_audit_name) > 0 ? "true" : "false"
   }
 }
 


### PR DESCRIPTION
```
June 17, 2024 at 15:41 (UTC-4:00)
Failed to start: initializing osqueryd status logging: create firehose status logger: create Firehose writer: describe stream : InvalidParameter: 1 validation error(s) found.
fleet
June 17, 2024 at 15:41 (UTC-4:00)
- minimum field size of 1, DescribeDeliveryStreamInput.DeliveryStreamName.
```

I was wrongly under the assumption that if the stream name was empty string it would not be attempted even if its set as the "configured" logging destination.

This change makes the terraform (env var) outputs much more strict. Note that `""` is the `filesystem` output: https://github.com/fleetdm/fleet/blob/1cc13a09fba9cd298b607785bda7a6400afe6787/server/logging/logging.go#L82-L88