### PR TITLE
Website: Update /tables styles

### DIFF
--- a/website/assets/styles/pages/osquery-table-details.less
+++ b/website/assets/styles/pages/osquery-table-details.less
@@ -245,7 +245,6 @@
       padding-right: 7px;
     }
     a:not(.markdown-link):not([purpose='evented-table-label']) {
-      white-space: nowrap;
       &:after {
         background-image: url('/images/icon-arrow-upper-right-7x7@2x.png');
         background-size: 7px 7px;
@@ -291,12 +290,12 @@
         }
         .hljs-string { // For words wrapped in quotation marks
           color: #3DB67B;
-          white-space: pre;
         }
         background-color: @ui-off-white;
         border: none;
         word-break: break-word;
-        white-space: normal;
+        white-space-collapse: collapse;
+        text-wrap: wrap;
         padding: 0;
         font-size: 13px;
         line-height: 24px;


### PR DESCRIPTION
Closes: https://github.com/fleetdm/fleet/issues/19809

Changes:
- Updated styles for examples and links on `/tables` pages to prevent content from overflowing outside of the page's container.
