### PR TITLE
Dont send 500 for every call to /debug/errors endpoint

### DIFF
--- a/changes/issue-15197-dont-send-500-debug-error
+++ b/changes/issue-15197-dont-send-500-debug-error
@@ -1,0 +1,1 @@
+- dont always send a 500 from the /debug/errors endpoint

--- a/server/fleet/service.go
+++ b/server/fleet/service.go
@@ -84,8 +84,8 @@ type Service interface {
 	// to fleetd (formerly orbit).
 	GetOrbitConfig(ctx context.Context) (OrbitConfig, error)
 
-	// ReceiveFleetdError handles an erorr report from a `fleetd` component
-	ReceiveFleetdError(ctx context.Context, errData FleetdError) error
+	// LogFleetdError logs an error report from a `fleetd` component
+	LogFleetdError(ctx context.Context, errData FleetdError) error
 
 	// SetOrUpdateDeviceAuthToken creates or updates a device auth token for the given host.
 	SetOrUpdateDeviceAuthToken(ctx context.Context, authToken string) error

--- a/server/service/device_client.go
+++ b/server/service/device_client.go
@@ -225,15 +225,7 @@ func (dc *DeviceClient) ReportError(token string, fleetdErr fleet.FleetdError) e
 	return retry.Do(
 		func() error {
 			err := dc.request(verb, path, token, "", req, nil)
-			scerr, ok := err.(*statusCodeErr)
-
-			// as backwards as this seems, this endpoint returns a
-			// `500` status code when we post an error (it might
-			// return `4xx` errors if the request is malformed or
-			// unauthenticated)
-			//
-			// see https://github.com/fleetdm/fleet/issues/13238#issuecomment-1671769460 for more details
-			if !ok || scerr.code != http.StatusInternalServerError {
+			if err != nil {
 				return err
 			}
 

--- a/server/service/integration_desktop_test.go
+++ b/server/service/integration_desktop_test.go
@@ -304,7 +304,7 @@ func (s *integrationTestSuite) TestErrorReporting() {
 	res = s.DoRawNoAuth("POST", "/api/latest/fleet/device/"+token+"/debug/errors", jsonData, http.StatusBadRequest)
 	res.Body.Close()
 
-	res = s.DoRawNoAuth("POST", "/api/latest/fleet/device/"+token+"/debug/errors", []byte("{}"), http.StatusInternalServerError)
+	res = s.DoRawNoAuth("POST", "/api/latest/fleet/device/"+token+"/debug/errors", []byte("{}"), http.StatusOK)
 	res.Body.Close()
 
 	testTime, err := time.Parse(time.RFC3339, "1969-06-19T21:44:05Z")
@@ -318,6 +318,6 @@ func (s *integrationTestSuite) TestErrorReporting() {
 	}
 	errBytes, err := json.Marshal(ferr)
 	require.NoError(t, err)
-	res = s.DoRawNoAuth("POST", "/api/latest/fleet/device/"+token+"/debug/errors", errBytes, http.StatusInternalServerError)
+	res = s.DoRawNoAuth("POST", "/api/latest/fleet/device/"+token+"/debug/errors", errBytes, http.StatusOK)
 	res.Body.Close()
 }


### PR DESCRIPTION
relates to #15197

This updates the handler for `/debug/errors` so that we no longer always send a 500 response.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [ ] Added/updated tests
