### PR TITLE
[unreleased bug] Fleet UI: Fix live query/error filter count displaying

### DIFF
--- a/frontend/pages/queries/edit/components/QueryResults/QueryResults.tsx
+++ b/frontend/pages/queries/edit/components/QueryResults/QueryResults.tsx
@@ -18,6 +18,7 @@ import { ITarget } from "interfaces/target";
 import Button from "components/buttons/Button";
 import Icon from "components/Icon/Icon";
 import TableContainer from "components/TableContainer";
+import TableCount from "components/TableContainer/TableCount";
 import TabsWrapper from "components/TabsWrapper";
 import ShowQueryModal from "components/modals/ShowQueryModal";
 import QueryResultsHeading from "components/queries/queryResults/QueryResultsHeading";
@@ -168,6 +169,18 @@ const QueryResults = ({
     );
   };
 
+  const renderCount = useCallback(
+    (tableType: "errors" | "results") => {
+      const count =
+        tableType === "results"
+          ? filteredResults.length
+          : filteredErrors.length;
+
+      return <TableCount name={tableType} count={count} />;
+    },
+    [filteredResults.length, filteredErrors.length]
+  );
+
   const renderTableButtons = (tableType: "results" | "errors") => {
     return (
       <div className={`${baseClass}__results-cta`}>
@@ -220,8 +233,9 @@ const QueryResults = ({
           resultsTitle={tableType}
           customControl={() => renderTableButtons(tableType)}
           setExportRows={
-            tableType === "errors" ? setFilteredErrors : setFilteredResults
+            tableType === "results" ? setFilteredResults : setFilteredErrors
           }
+          renderCount={() => renderCount(tableType)}
         />
       </div>
     );


### PR DESCRIPTION
## Issue
Cerra unreleased bug #19793 


## Description
- Fix multicolumn filter count rendering
- Turns out this was a quicker bug than expected because filter results existed for exporting CSV already so rendering correct count was just a few lines of code away

## Screenrecording 
https://www.loom.com/share/0fbd8a72820940e7ae49b040f50c1049?sid=a0f7930e-e12c-4fee-a615-8d4fed60f124

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Manual QA for all new/changed functionality

