### PR TITLE
Fleet UI: Fix platform compatibility styling

### DIFF
--- a/frontend/components/PlatformCompatibility/PlatformCompatibility.tsx
+++ b/frontend/components/PlatformCompatibility/PlatformCompatibility.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from "react";
+import React from "react";
 
 import { OsqueryPlatform } from "interfaces/platform";
 import { PLATFORM_DISPLAY_NAMES } from "utilities/constants";

--- a/frontend/components/PlatformCompatibility/PlatformCompatibility.tsx
+++ b/frontend/components/PlatformCompatibility/PlatformCompatibility.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useCallback } from "react";
 
 import { OsqueryPlatform } from "interfaces/platform";
 import { PLATFORM_DISPLAY_NAMES } from "utilities/constants";
@@ -51,30 +51,33 @@ const PlatformCompatibility = ({
   if (!compatiblePlatforms) {
     return null;
   }
-  if (error || !compatiblePlatforms?.length) {
-    return (
-      <span className={baseClass}>
-        <b>
-          <TooltipWrapper
-            tipContent={
-              <>
-                Estimated compatiblity based on <br />
-                the tables used in the query.
-              </>
-            }
-          >
-            Compatible with:
-          </TooltipWrapper>
-        </b>
 
-        {displayIncompatibilityText(error || ERROR_NO_COMPATIBLE_TABLES)}
-      </span>
-    );
-  }
+  const renderCompatiblePlatforms = () => {
+    if (error || !compatiblePlatforms?.length) {
+      return displayIncompatibilityText(error || ERROR_NO_COMPATIBLE_TABLES);
+    }
+
+    return DISPLAY_ORDER.map((platform) => {
+      const isCompatible = displayPlatforms.includes(platform);
+      return (
+        <span key={`platform-compatibility__${platform}`} className="platform">
+          <Icon
+            name={isCompatible ? "check" : "close"}
+            className={
+              isCompatible ? "compatible-platform" : "incompatible-platform"
+            }
+            color={isCompatible ? "status-success" : "status-error"}
+            size="small"
+          />
+          {platform}
+        </span>
+      );
+    });
+  };
 
   const displayPlatforms = formatPlatformsForDisplay(compatiblePlatforms);
   return (
-    <span className={baseClass}>
+    <div className={baseClass}>
       <b>
         <TooltipWrapper
           tipContent={
@@ -87,26 +90,8 @@ const PlatformCompatibility = ({
           Compatible with:
         </TooltipWrapper>
       </b>
-      {DISPLAY_ORDER.map((platform) => {
-        const isCompatible = displayPlatforms.includes(platform);
-        return (
-          <span
-            key={`platform-compatibility__${platform}`}
-            className="platform"
-          >
-            <Icon
-              name={isCompatible ? "check" : "close"}
-              className={
-                isCompatible ? "compatible-platform" : "incompatible-platform"
-              }
-              color={isCompatible ? "status-success" : "status-error"}
-              size="small"
-            />
-            {platform}
-          </span>
-        );
-      })}
-    </span>
+      {renderCompatiblePlatforms()}
+    </div>
   );
 };
 export default PlatformCompatibility;

--- a/frontend/components/PlatformCompatibility/PlatformCompatibility.tsx
+++ b/frontend/components/PlatformCompatibility/PlatformCompatibility.tsx
@@ -52,6 +52,8 @@ const PlatformCompatibility = ({
     return null;
   }
 
+  const displayPlatforms = formatPlatformsForDisplay(compatiblePlatforms);
+
   const renderCompatiblePlatforms = () => {
     if (error || !compatiblePlatforms?.length) {
       return displayIncompatibilityText(error || ERROR_NO_COMPATIBLE_TABLES);
@@ -75,7 +77,6 @@ const PlatformCompatibility = ({
     });
   };
 
-  const displayPlatforms = formatPlatformsForDisplay(compatiblePlatforms);
   return (
     <div className={baseClass}>
       <b>

--- a/frontend/components/PlatformCompatibility/_styles.scss
+++ b/frontend/components/PlatformCompatibility/_styles.scss
@@ -2,6 +2,9 @@
   display: flex;
   font-size: $x-small;
   align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+
   b,
   svg,
   span {
@@ -9,16 +12,8 @@
     align-items: center;
   }
 
-  span {
-    padding-left: 12px;
-  }
-
   .platform {
-    padding-left: 0px;
-
-    .icon {
-      padding-left: 12px;
-      padding-right: $pad-xsmall;
-    }
+    display: flex;
+    gap: $pad-xsmall;
   }
 }

--- a/frontend/pages/policies/PolicyPage/components/PolicyForm/PolicyForm.tsx
+++ b/frontend/pages/policies/PolicyPage/components/PolicyForm/PolicyForm.tsx
@@ -589,9 +589,7 @@ const PolicyForm = ({
             wrapEnabled
             focus={!isEditMode}
           />
-          <span className={`${baseClass}__platform-compatibility`}>
-            {renderPlatformCompatibility()}
-          </span>
+          {renderPlatformCompatibility()}
           {(isEditMode || defaultPolicy) && platformSelector.render()}
           {isEditMode && isPremiumTier && renderCriticalPolicy()}
           {renderLiveQueryWarning()}

--- a/frontend/pages/queries/edit/components/EditQueryForm/EditQueryForm.tsx
+++ b/frontend/pages/queries/edit/components/EditQueryForm/EditQueryForm.tsx
@@ -587,9 +587,7 @@ const EditQueryForm = ({
           data-testid="ace-editor"
         />
       )}
-      <span className={`${baseClass}__platform-compatibility`}>
-        {renderPlatformCompatibility()}
-      </span>
+      {renderPlatformCompatibility()}
       {renderLiveQueryWarning()}
       {(lastEditedQueryObserverCanRun ||
         isObserverPlus ||
@@ -711,9 +709,8 @@ const EditQueryForm = ({
             wrapEnabled
             focus={!savedQueryMode}
           />
-          <span className={`${baseClass}__platform-compatibility`}>
-            {renderPlatformCompatibility()}
-          </span>
+          {renderPlatformCompatibility()}
+
           {savedQueryMode && (
             <>
               <Dropdown


### PR DESCRIPTION
## Issue
Cerra #19710 

## Description
- Remove 12px padding to the left of platform compatibility
- Refactor to `flex-wrap` so on small widths, the chrome platform doesn't overflow past the section

## Code cleanup
- Remove redundant `<span/>`
- Refactor 12px gaps and 4px gaps to use flex `gap` instead of `padding`
- Refactor redundant code in `<PlatformCompatibility/>`



# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Manual QA for all new/changed functionality

