### PR TITLE
Fleet UI: Account for 0 as empty state instead of undefined

### DIFF
--- a/frontend/pages/hosts/components/IssuesIndicator/IssuesIndicator.tsx
+++ b/frontend/pages/hosts/components/IssuesIndicator/IssuesIndicator.tsx
@@ -39,10 +39,11 @@ const IssuesIndicator = ({
         data-html
       >
         <span className={`tooltip__tooltip-text`}>
-          {criticalVulnerabilitiesCount &&
+          {!!criticalVulnerabilitiesCount &&
             `Critical vulnerabilities (${criticalVulnerabilitiesCount})`}
-          {criticalVulnerabilitiesCount && failingPoliciesCount && <br />}
-          {failingPoliciesCount && `Failing policies (${failingPoliciesCount})`}
+          {!!criticalVulnerabilitiesCount && !!failingPoliciesCount && <br />}
+          {!!failingPoliciesCount &&
+            `Failing policies (${failingPoliciesCount})`}
         </span>
       </ReactTooltip>
     </>


### PR DESCRIPTION
## Issue
Unreleased fix for #18115 

## Description
- BE shows `0` count for empty state so FE needs to account for `0` instead of `undefined`

## Screenshot of fix
<img width="1219" alt="Screenshot 2024-06-18 at 5 00 04 PM" src="https://github.com/fleetdm/fleet/assets/71795832/cd6ec944-ce99-4f8e-a630-9bf037abd0b9">


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Manual QA for all new/changed functionality