### PR TITLE
Update docs: Vulnerability Processing page

### DIFF
--- a/docs/Using Fleet/Vulnerability-Processing.md
+++ b/docs/Using Fleet/Vulnerability-Processing.md
@@ -20,50 +20,10 @@ Fleet detects vulnerabilities for these software types:
 | ------------------- | ------------------------------------------ | ------------------------------------------------ | ---------------- |
 | Apps                | ✅                                         | ✅                                               | ❌               |
 | Browser plugins     | Chrome extensions, Firefox extensions      | Chrome extensions, Firefox extensions            | ❌               |
-| Packages            | Python, Homebrew  | Python, Atom, Chocolatey | Adhere to whatever is defined in the [OVAL definitions](https://github.com/fleetdm/nvd/blob/master/oval_sources.json), except for kernel vulnerabilities and vulnerabilities involving configuration files. Supported distributions: <ul><li>Ubuntu</li><li>RHEL based distros (Red Hat, CentOS, Fedora, and Amazon Linux)</li></ul> |
+| Packages            | Python, Homebrew  | Python, Atom, Chocolatey | Packages defined in the [OVAL definitions](https://github.com/fleetdm/nvd/blob/master/oval_sources.json), except for vulnerabilities involving configuration files. Supported distributions: <ul><li>Ubuntu</li><li>RHEL based distros (Red Hat, CentOS, Fedora, and Amazon Linux)</li></ul> |
 | IDE extensions      | VS Code extensions | VS Code extensions | VS Code extensions |
 
 As of right now, only app names with all ASCII characters are supported. Apps with names featuring non-ASCII characters, such as Cyrillic, will not generate matches.
-
-## Configuration
-
-When upgrading to Fleet 4.7.0 or later, vulnerability processing is automatically enabled if
-vulnerability processing and software inventory are not explicitly disabled.
-
-If you explicitly disabled vulnerability processing, and now would like to enable this feature, first enable the software inventory feature by setting the following app config:
-
-```yaml
----
-apiVersion: v1
-kind: config
-spec:
-  features:
-    enable_software_inventory: true
-```
-
-Then, enable vulnerability processing by specifying a path where Fleet will download the different
-data feeds. This can be done by setting the following app config:
-
-```yaml
----
-apiVersion: v1
-kind: config
-spec:
-  vulnerabilities:
-    databases_path: /some/path
-```
-
-Or through environment variables:
-
-```text
-FLEET_VULNERABILITIES_DATABASES_PATH=/some/path
-```
-
-The path specified needs to exist and Fleet needs to be able to read and write to and from it. This is the only mandatory
-configuration needed for vulnerability processing to work. Additional options, like vulnerability check frequency, can be
-found in the [configuration documentation](https://fleetdm.com/docs/deploying/configuration#vulnerabilities).
-
-You'll need to restart the Fleet instances after changing these settings.
 
 ### Advanced configuration
 


### PR DESCRIPTION
- Fleet detects vulns (CVEs) for Linux kernels: #18053
- Remove outdated section about enabling vulnerability processing. It's enabled by default
