### PR TITLE
API design: Hide "Self-service" if there's no self-service software

### DIFF
--- a/docs/Contributing/API-for-contributors.md
+++ b/docs/Contributing/API-for-contributors.md
@@ -2381,7 +2381,7 @@ Gets all information required by Fleet Desktop, this includes things like the nu
 ```json
 {
   "failing_policies_count": 3,
-  "self_service: true,
+  "self_service": true,
   "notifications": {
     "needs_mdm_migration": true,
     "renew_enrollment_profile": false,

--- a/docs/Contributing/API-for-contributors.md
+++ b/docs/Contributing/API-for-contributors.md
@@ -2381,6 +2381,7 @@ Gets all information required by Fleet Desktop, this includes things like the nu
 ```json
 {
   "failing_policies_count": 3,
+  "self_service: true,
   "notifications": {
     "needs_mdm_migration": true,
     "renew_enrollment_profile": false,

--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -3002,6 +3002,7 @@ This is the API route used by the **My device** page in Fleet desktop to display
       ]
     }
   },
+  "self_service": true,
   "org_logo_url": "https://example.com/logo.jpg",
   "license": {
     "tier": "free",


### PR DESCRIPTION
UPDATE: Closed this PR and opened this new one to avoid messing w/ PR open time KPI: https://github.com/fleetdm/fleet/pull/20908

API changes for Hide "Self-service" if there's no self-service software (#19651)
