### PR TITLE
UI – Software pages, treat dropdown filters as search criteria for empty states

### DIFF
--- a/frontend/pages/SoftwarePage/components/EmptySoftwareTable/EmptySoftwareTable.tsx
+++ b/frontend/pages/SoftwarePage/components/EmptySoftwareTable/EmptySoftwareTable.tsx
@@ -46,7 +46,7 @@ const EmptySoftwareTable = ({
     info: `Expecting to see ${softwareTypeText}? Check back later.`,
   };
 
-  if (isNotDetectingSoftware) {
+  if (isNotDetectingSoftware && softwareFilter === "allSoftware") {
     emptySoftware.header = "No software detected";
   }
 

--- a/frontend/pages/SoftwarePage/components/EmptySoftwareTable/EmptySoftwareTable.tsx
+++ b/frontend/pages/SoftwarePage/components/EmptySoftwareTable/EmptySoftwareTable.tsx
@@ -33,7 +33,7 @@ const generateTypeText = (
 };
 
 const EmptySoftwareTable = ({
-  softwareFilter,
+  softwareFilter = "allSoftware",
   tableName = "software",
   isSoftwareDisabled,
   isNotDetectingSoftware,


### PR DESCRIPTION
## Follow-up to #19181  

<img width="1480" alt="Screenshot 2024-06-19 at 2 56 04 PM" src="https://github.com/fleetdm/fleet/assets/61553566/303703e8-8be4-4ef5-866f-48edadc16d9f">
<img width="1480" alt="Screenshot 2024-06-19 at 2 51 28 PM" src="https://github.com/fleetdm/fleet/assets/61553566/56cde02b-2fee-4313-b7af-c328da1a2934">


- [x] Manual QA for all new/changed functionality
