### PR TITLE
[unreleased. bug] Fleet UI: Grey empty cell --- for host issues

### DIFF
--- a/frontend/pages/hosts/ManageHostsPage/_styles.scss
+++ b/frontend/pages/hosts/ManageHostsPage/_styles.scss
@@ -214,7 +214,8 @@
               .device_mapping__cell,
               .mdm_enrollment_status__cell,
               .mdm_server_url__cell,
-              .public_ip__cell {
+              .public_ip__cell,
+              .issues__cell {
                 .text-cell {
                   display: inline;
                 }


### PR DESCRIPTION
## Issue
Cerra #18115 

## Description
- Grey out `---` empty text in Manage Host issues column when there are no issues

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Manual QA for all new/changed functionality
