### PR TITLE
improvements to new connected_to_fleet logic + migration fixes

### DIFF
--- a/cmd/fleet/cron.go
+++ b/cmd/fleet/cron.go
@@ -860,6 +860,9 @@ func newCleanupsAndAggregationSchedule(
 		schedule.WithJob("cleanup_unused_software_installers", func(ctx context.Context) error {
 			return ds.CleanupUnusedSoftwareInstallers(ctx, softwareInstallStore)
 		}),
+		schedule.WithJob("reconcile_host_mdm_status", func(ctx context.Context) error {
+			return service.ReconcileHostMDMStatus(ctx, ds, logger)
+		}),
 	)
 
 	return s, nil

--- a/server/datastore/mysql/mdm_test.go
+++ b/server/datastore/mysql/mdm_test.go
@@ -6880,8 +6880,6 @@ func testIsHostConnectedToFleetMDM(t *testing.T, ds *Datastore) {
 	require.True(t, connected)
 }
 
-// func (ds *Datastore) GetHostsWithMDMOffStillConnected(ctx context.Context) ([]*fleet.Host, error) {
-
 func testGetHostsWithMDMOffStillConnected(t *testing.T, ds *Datastore) {
 	ctx := context.Background()
 

--- a/server/fleet/datastore.go
+++ b/server/fleet/datastore.go
@@ -858,6 +858,17 @@ type Datastore interface {
 	// SetOrUpdateHostDiskEncryptionKey sets the base64, encrypted key for
 	// a host
 	SetOrUpdateHostDiskEncryptionKey(ctx context.Context, hostID uint, encryptedBase64Key, clientError string, decryptable *bool) error
+
+	// GetHostsWithMDMOffStillConnected finds hosts that have been reported
+	// to have mdm off by osquery but Fleet thinks they still have an
+	// active MDM enrollment.
+	//
+	// This can happen when the host unenrolls but we don't receive a
+	// `Checkout` message, for example: if the host is reset to factory
+	// settings, or the enrollment profile is removed without an internet
+	// connection.
+	GetHostsWithMDMOffStillConnected(ctx context.Context) ([]*Host, error)
+
 	// GetUnverifiedDiskEncryptionKeys returns all the encryption keys that
 	// are collected but their decryptable status is not known yet (ie:
 	// we're able to decrypt the key using a private key in the server)

--- a/server/fleet/hosts.go
+++ b/server/fleet/hosts.go
@@ -708,14 +708,6 @@ func (h *Host) IsEligibleForDEPMigration(isConnectedToFleetMDM bool) bool {
 func (h *Host) NeedsDEPEnrollment(isConnectedToFleetMDM bool) bool {
 	return h.MDMInfo != nil &&
 		!h.MDMInfo.Enrolled &&
-		// as a special case for migration with user interaction, we
-		// also check the information stored in host_mdm, and assume
-		// the host needs migration if it's not Fleet
-		//
-		// this is because we can't always rely on nano setting
-		// `nano_enrollment.active = 1` since sometimes Fleet won't get
-		// the checkout message from the host.
-		(!isConnectedToFleetMDM || h.MDMInfo.Name != WellKnownMDMFleet) &&
 		h.IsDEPAssignedToFleet()
 }
 

--- a/server/mock/datastore_mock.go
+++ b/server/mock/datastore_mock.go
@@ -599,6 +599,8 @@ type SetOrUpdateHostDisksEncryptionFunc func(ctx context.Context, hostID uint, e
 
 type SetOrUpdateHostDiskEncryptionKeyFunc func(ctx context.Context, hostID uint, encryptedBase64Key string, clientError string, decryptable *bool) error
 
+type GetHostsWithMDMOffStillConnectedFunc func(ctx context.Context) ([]*fleet.Host, error)
+
 type GetUnverifiedDiskEncryptionKeysFunc func(ctx context.Context) ([]fleet.HostDiskEncryptionKey, error)
 
 type SetHostsDiskEncryptionKeyStatusFunc func(ctx context.Context, hostIDs []uint, encryptable bool, threshold time.Time) error
@@ -1845,6 +1847,9 @@ type DataStore struct {
 
 	SetOrUpdateHostDiskEncryptionKeyFunc        SetOrUpdateHostDiskEncryptionKeyFunc
 	SetOrUpdateHostDiskEncryptionKeyFuncInvoked bool
+
+	GetHostsWithMDMOffStillConnectedFunc        GetHostsWithMDMOffStillConnectedFunc
+	GetHostsWithMDMOffStillConnectedFuncInvoked bool
 
 	GetUnverifiedDiskEncryptionKeysFunc        GetUnverifiedDiskEncryptionKeysFunc
 	GetUnverifiedDiskEncryptionKeysFuncInvoked bool
@@ -4441,6 +4446,13 @@ func (s *DataStore) SetOrUpdateHostDiskEncryptionKey(ctx context.Context, hostID
 	s.SetOrUpdateHostDiskEncryptionKeyFuncInvoked = true
 	s.mu.Unlock()
 	return s.SetOrUpdateHostDiskEncryptionKeyFunc(ctx, hostID, encryptedBase64Key, clientError, decryptable)
+}
+
+func (s *DataStore) GetHostsWithMDMOffStillConnected(ctx context.Context) ([]*fleet.Host, error) {
+	s.mu.Lock()
+	s.GetHostsWithMDMOffStillConnectedFuncInvoked = true
+	s.mu.Unlock()
+	return s.GetHostsWithMDMOffStillConnectedFunc(ctx)
 }
 
 func (s *DataStore) GetUnverifiedDiskEncryptionKeys(ctx context.Context) ([]fleet.HostDiskEncryptionKey, error) {


### PR DESCRIPTION
- Accounts for hosts that disabled MDM without sending a Checkout message and still have `fleetd` installed
- Brings back old logic for `NeedsDEPEnrollment` where we would check if the host is unmanaged using `host_mdm`, regardless of enrollment server.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Added/updated tests
- [x] Manual QA for all new/changed functionality
