### PR TITLE
Removed duplicate `os_versions` results in /api/latest/fleet/vulnerabilities/:cve endpoint

### DIFF
--- a/changes/19819-duplicate-os-versions
+++ b/changes/19819-duplicate-os-versions
@@ -1,0 +1,1 @@
+- Removed duplicate `os_versions` results in /api/latest/fleet/vulnerabilities/:cve endpoint

--- a/server/datastore/mysql/vulnerabilities_test.go
+++ b/server/datastore/mysql/vulnerabilities_test.go
@@ -892,10 +892,14 @@ func seedVulnerabilities(t *testing.T, ds *Datastore) {
 
 	// update 15 hosts to windows
 	for i := 0; i < 10; i++ {
+		arch := "arm64"
+		if i%2 == 0 {
+			arch = "x86_64"
+		}
 		err := ds.UpdateHostOperatingSystem(context.Background(), hostids[i], fleet.OperatingSystem{
 			Name:     "Microsoft Windows 11 Enterprise 22H2",
 			Version:  "10.0.22621.2715",
-			Arch:     "x86_64",
+			Arch:     arch,
 			Platform: "windows",
 		})
 		require.NoError(t, err)
@@ -903,10 +907,14 @@ func seedVulnerabilities(t *testing.T, ds *Datastore) {
 
 	// update 5 hosts to macOS
 	for i := 10; i < 15; i++ {
+		arch := "arm64"
+		if i%2 == 0 {
+			arch = "x86_64"
+		}
 		err := ds.UpdateHostOperatingSystem(context.Background(), hostids[i], fleet.OperatingSystem{
 			Name:     "macOS",
 			Version:  "14.1.2",
-			Arch:     "arm64",
+			Arch:     arch,
 			Platform: "darwin",
 		})
 		require.NoError(t, err)
@@ -988,7 +996,7 @@ func seedVulnerabilities(t *testing.T, ds *Datastore) {
 
 	osVulns := []fleet.OSVulnerability{
 		{
-			OSID:              1,
+			OSID:              1, // windows x86_64
 			CVE:               "CVE-2020-1238",
 			ResolvedInVersion: ptr.String("1.0.0"),
 		},
@@ -998,11 +1006,29 @@ func seedVulnerabilities(t *testing.T, ds *Datastore) {
 			ResolvedInVersion: ptr.String("1.0.1"),
 		},
 		{
-			OSID: 2,
+			OSID:              2, // windows arm64
+			CVE:               "CVE-2020-1238",
+			ResolvedInVersion: ptr.String("1.0.0"),
+		},
+		{
+			OSID:              2,
+			CVE:               "CVE-2020-1239",
+			ResolvedInVersion: ptr.String("1.0.1"),
+		},
+		{
+			OSID: 2, // macos x86_64
 			CVE:  "CVE-2020-1240",
 		},
 		{
 			OSID: 2,
+			CVE:  "CVE-2020-1241",
+		},
+		{
+			OSID: 3, // macos arm64
+			CVE:  "CVE-2020-1240",
+		},
+		{
+			OSID: 3,
 			CVE:  "CVE-2020-1241",
 		},
 	}


### PR DESCRIPTION
#19819
Removed duplicate `os_versions` results in /api/latest/fleet/vulnerabilities/:cve endpoint

Could not manually test since I do not have an Intel mac. We will need to QA on dogfood.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [x] Added/updated tests
- [ ] Manual QA for all new/changed functionality
