### PR TITLE
Added character validation to /api/fleet/orbit/device_token endpoint

### DIFF
--- a/changes/6978-device-token-validation
+++ b/changes/6978-device-token-validation
@@ -1,0 +1,1 @@
+Added character validation to /api/fleet/orbit/device_token endpoint

--- a/server/service/integration_core_test.go
+++ b/server/service/integration_core_test.go
@@ -11187,6 +11187,13 @@ func (s *integrationTestSuite) TestHostDeviceToken() {
 	}
 	s.DoJSON("POST", "/api/fleet/orbit/device_token", body, http.StatusBadRequest, &response{})
 
+	// Use illegal characters
+	body = setOrUpdateDeviceTokenRequest{
+		OrbitNodeKey:    *orbitHost.OrbitNodeKey,
+		DeviceAuthToken: "../.",
+	}
+	s.DoJSON("POST", "/api/fleet/orbit/device_token", body, http.StatusBadRequest, &response{})
+
 	// Write bad node key
 	body = setOrUpdateDeviceTokenRequest{
 		OrbitNodeKey:    "",

--- a/server/service/orbit.go
+++ b/server/service/orbit.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"net/url"
 
 	"github.com/fleetdm/fleet/v4/server"
 	"github.com/fleetdm/fleet/v4/server/contexts/ctxerr"
@@ -488,6 +489,10 @@ func (svc *Service) SetOrUpdateDeviceAuthToken(ctx context.Context, deviceAuthTo
 
 	if len(deviceAuthToken) == 0 {
 		return badRequest("device auth token cannot be empty")
+	}
+
+	if url.QueryEscape(deviceAuthToken) != deviceAuthToken {
+		return badRequest("device auth token contains invalid characters")
 	}
 
 	host, ok := hostctx.FromContext(ctx)


### PR DESCRIPTION
https://github.com/fleetdm/confidential/issues/6978
Added character validation to /api/fleet/orbit/device_token endpoint

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [x] Added/updated tests
- [x] Manual QA for all new/changed functionality
