### PR TITLE
Add fleet license as an optional helm value

### DIFF
--- a/charts/fleet/Chart.yaml
+++ b/charts/fleet/Chart.yaml
@@ -4,7 +4,7 @@ name: fleet
 keywords:
   - fleet
   - osquery
-version: v6.0.2
+version: v6.0.3
 home: https://github.com/fleetdm/fleet
 sources:
   - https://github.com/fleetdm/fleet.git

--- a/charts/fleet/templates/deployment.yaml
+++ b/charts/fleet/templates/deployment.yaml
@@ -96,6 +96,13 @@ spec:
             value: "{{ .Values.fleet.carving.s3.stsAssumeRoleARN }}"
           {{- end }}
           {{- end }}
+          {{- if .Values.fleet.license.secretName }}
+          - name: FLEET_LICENSE_KEY
+            valueFrom:
+              secretKeyRef:
+                key: {{ .Values.fleet.license.licenseKey }}
+                name: {{ .Values.fleet.license.secretName }}
+          {{- end }}
           ## END FLEET SECTION
           ## BEGIN MYSQL SECTION
           - name: FLEET_MYSQL_ADDRESS

--- a/charts/fleet/values.yaml
+++ b/charts/fleet/values.yaml
@@ -90,6 +90,9 @@ fleet:
       accessKeyID: ""
       secretKey: s3-bucket
       stsAssumeRoleARN: ""
+  license:
+    secretName: ""
+    licenseKey: license-key
   extraVolumes: []
   extraVolumeMounts: []
 


### PR DESCRIPTION
- [ ] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [ ] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [ ] Added support on fleet's osquery simulator `cmd/osquery-perf` for new osquery data ingestion features.
- [ ] Added/updated tests
- [ ] If database migrations are included, checked table schema to confirm autoupdate
- For database migrations:
  - [ ] Checked schema for all modified table for columns that will auto-update timestamps during migration.
  - [ ] Confirmed that updating the timestamps is acceptable, and will not cause unwanted side effects.
  - [ ] Ensured the correct collation is explicitly set for character columns (`COLLATE utf8mb4_unicode_ci`).
- [x] Manual QA for all new/changed functionality
  - For Orbit and Fleet Desktop changes:
    - [ ] Manual QA must be performed in the three main OSs, macOS, Windows and Linux.
    - [ ] Auto-update manual QA, from released version of component to new version (see [tools/tuf/test](../tools/tuf/test/README.md)).

This is a Helm only change to optionally permit licensing Fleet when deployed via the Helm chart.
If the value `fleet.license.secretName` contains a non-empty string in the  Helm values, then the deployment will try to retrieve a license key from that secret and add it as the appropriate container value.
```yaml
          {{- if .Values.fleet.license.secretName }}
          - name: FLEET_LICENSE_KEY
            valueFrom:
              secretKeyRef:
                key: {{ .Values.fleet.license.licenseKey }}
                name: {{ .Values.fleet.license.secretName }}
          {{- end }}
```