### PR TITLE
Fleet UI: Hide delete checkboxes from team observer 

### DIFF
--- a/changes/19828-hide-query-delete-checkboxes-from-observers
+++ b/changes/19828-hide-query-delete-checkboxes-from-observers
@@ -1,0 +1,1 @@
+- Hide query delete checkboxes from team observers

--- a/frontend/pages/queries/ManageQueriesPage/components/QueriesTable/QueriesTableConfig.tsx
+++ b/frontend/pages/queries/ManageQueriesPage/components/QueriesTable/QueriesTableConfig.tsx
@@ -115,7 +115,9 @@ const generateTableHeaders = ({
   currentTeamId,
   omitSelectionColumn = false,
 }: IGenerateTableHeaders): IDataColumn[] => {
-  const isOnlyObserver = permissionsUtils.isOnlyObserver(currentUser);
+  const isCurrentTeamObserverOrGlobalObserver = currentTeamId
+    ? permissionsUtils.isTeamObserver(currentUser, currentTeamId)
+    : permissionsUtils.isOnlyObserver(currentUser);
   const viewingTeamScope = currentTeamId !== API_ALL_TEAMS_ID;
 
   const tableHeaders: IDataColumn[] = [
@@ -135,32 +137,33 @@ const generateTableHeaders = ({
             value={
               <>
                 <div className="query-name-text">{cellProps.cell.value}</div>
-                {!isOnlyObserver && cellProps.row.original.observer_can_run && (
-                  <div className="observer-can-run-badge">
-                    <span
-                      className="observer-can-run-icon"
-                      data-tooltip-id={`observer-can-run-tooltip-${cellProps.row.original.id}`}
-                    >
-                      <Icon
-                        className="observer-can-run-query-icon"
-                        name="query"
-                        size="small"
-                        color="core-fleet-blue"
-                      />
-                    </span>
-                    <ReactTooltip5
-                      className="observer-can-run-tooltip"
-                      disableStyleInjection
-                      place="top"
-                      opacity={1}
-                      id={`observer-can-run-tooltip-${cellProps.row.original.id}`}
-                      offset={8}
-                      positionStrategy="fixed"
-                    >
-                      Observers can run this query.
-                    </ReactTooltip5>
-                  </div>
-                )}
+                {!isCurrentTeamObserverOrGlobalObserver &&
+                  cellProps.row.original.observer_can_run && (
+                    <div className="observer-can-run-badge">
+                      <span
+                        className="observer-can-run-icon"
+                        data-tooltip-id={`observer-can-run-tooltip-${cellProps.row.original.id}`}
+                      >
+                        <Icon
+                          className="observer-can-run-query-icon"
+                          name="query"
+                          size="small"
+                          color="core-fleet-blue"
+                        />
+                      </span>
+                      <ReactTooltip5
+                        className="observer-can-run-tooltip"
+                        disableStyleInjection
+                        place="top"
+                        opacity={1}
+                        id={`observer-can-run-tooltip-${cellProps.row.original.id}`}
+                        offset={8}
+                        positionStrategy="fixed"
+                      >
+                        Observers can run this query.
+                      </ReactTooltip5>
+                    </div>
+                  )}
                 {viewingTeamScope &&
                   // inherited
                   cellProps.row.original.team_id !== currentTeamId && (
@@ -260,7 +263,7 @@ const generateTableHeaders = ({
       ),
     },
   ];
-  if (!isOnlyObserver && !omitSelectionColumn) {
+  if (!isCurrentTeamObserverOrGlobalObserver && !omitSelectionColumn) {
     tableHeaders.unshift({
       id: "selection",
       // TODO - improve typing of IHeaderProps instead of using any


### PR DESCRIPTION
## Issue
Cerra #19828 

## Description
- Fix bug for users with multiple roles from showing delete flow for teams they are observers on

Note: This checkbox bug is only for team observers that are maintainers/admins of other teams

## Screenshots (notice the delete checkboxes are hidden now for these teams since the user is an observer/observer+ on these teams)
<img width="703" alt="Screenshot 2024-06-21 at 3 07 46 PM" src="https://github.com/fleetdm/fleet/assets/71795832/18b10684-c53d-4db2-8214-12a3df593de8">
<img width="929" alt="Screenshot 2024-06-21 at 3 07 40 PM" src="https://github.com/fleetdm/fleet/assets/71795832/519af303-d4ee-4e37-9aa1-0e7797d6140b">


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
- [x] Manual QA for all new/changed functionality

