### PR TITLE
use "-LiteralPath" during registry loop to allow for special characters in registry

### DIFF
--- a/changes/update-installutils-to-allow-for-special-characters-in-registry
+++ b/changes/update-installutils-to-allow-for-special-characters-in-registry
@@ -1,0 +1,1 @@
+- Fixes an issue where special characters in HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall breaks the "installer_utils.ps1 -uninstallOrbit" step in the Windows MSI installer

--- a/orbit/pkg/packaging/windows_templates.go
+++ b/orbit/pkg/packaging/windows_templates.go
@@ -571,7 +571,7 @@ function Force-Remove-Orbit {
     Get-ChildItem "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall" -Recurse  -ErrorAction "SilentlyContinue" |  Where-Object {($_.ValueCount -gt 0)} | ForEach-Object {
 
       # Filter for osquery entries
-      $properties = Get-ItemProperty $_.PSPath  -ErrorAction "SilentlyContinue" |  Where-Object {($_.DisplayName -eq "Fleet osquery")}
+      $properties = Get-ItemProperty -LiteralPath $_.PSPath  -ErrorAction "SilentlyContinue" |  Where-Object {($_.DisplayName -eq "Fleet osquery")}
       if ($properties) {
 
         #Remove Registry Entries
@@ -613,7 +613,7 @@ function Force-Remove-Osquery {
     Get-ChildItem "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall" -Recurse -ErrorAction "SilentlyContinue" |  Where-Object {($_.ValueCount -gt 0)} | ForEach-Object {
 
       # Filter for osquery entries
-      $properties = Get-ItemProperty $_.PSPath -ErrorAction "SilentlyContinue" |  Where-Object {($_.DisplayName -eq "osquery")}
+      $properties = Get-ItemProperty -LiteralPath $_.PSPath -ErrorAction "SilentlyContinue" |  Where-Object {($_.DisplayName -eq "osquery")}
       if ($properties) {
 
         #Remove files from osquery location


### PR DESCRIPTION
See [Slack thread](https://osquery.slack.com/archives/C01DXJL16D8/p1719011873116019?thread_ts=1718999703.685059&cid=C01DXJL16D8) for more info.

For https://github.com/fleetdm/fleet/issues/19950

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
