### PR TITLE
Ignore Rejected CVEs

### DIFF
--- a/changes/18913-ignore-rejected-cves
+++ b/changes/18913-ignore-rejected-cves
@@ -1,0 +1,1 @@
+CVEs identified as 'Rejected' in NVD will no longer match against software

--- a/server/vulnerabilities/nvd/cve_test.go
+++ b/server/vulnerabilities/nvd/cve_test.go
@@ -320,7 +320,6 @@ func TestTranslateCPEToCVE(t *testing.T) {
 			},
 			excludedCVEs: []string{
 				"CVE-2023-28205", // This vulnerability is for Safari 16.4.0
-				"CVE-2024-23252", // Rejected CVE
 			},
 			continuesToUpdate: true,
 		},

--- a/server/vulnerabilities/nvd/cve_test.go
+++ b/server/vulnerabilities/nvd/cve_test.go
@@ -318,7 +318,10 @@ func TestTranslateCPEToCVE(t *testing.T) {
 				{ID: "CVE-2023-42950", resolvedInVersion: "17.2"},
 				{ID: "CVE-2024-23273", resolvedInVersion: "17.4"},
 			},
-			excludedCVEs:      []string{"CVE-2023-28205"},
+			excludedCVEs: []string{
+				"CVE-2023-28205", // This vulnerability is for Safari 16.4.0
+				"CVE-2024-23252", // Rejected CVE
+			},
 			continuesToUpdate: true,
 		},
 		"cpe:2.3:a:apple:safari:16.4.0:*:*:*:*:macos:*:*": {

--- a/server/vulnerabilities/nvd/sync/cve_syncer.go
+++ b/server/vulnerabilities/nvd/sync/cve_syncer.go
@@ -199,6 +199,9 @@ func (s *CVE) updateYearFile(year int, cves []nvdapi.CVEItem) error {
 	// Convert new API 2.0 format to legacy feed format and create map of new CVE information.
 	newLegacyCVEs := make(map[string]*schema.NVDCVEFeedJSON10DefCVEItem)
 	for _, cve := range cves {
+		if cve.CVE.VulnStatus != nil && *cve.CVE.VulnStatus == "Rejected" {
+			continue
+		}
 		legacyCVE := convertAPI20CVEToLegacy(cve.CVE, s.logger)
 		newLegacyCVEs[legacyCVE.CVE.CVEDataMeta.ID] = legacyCVE
 	}
@@ -249,6 +252,9 @@ func (s *CVE) updateVulnCheckYearFile(year int, cves []VulnCheckCVE, modCount, a
 	// Convert new API 2.0 format to legacy feed format and create map of new CVE information.
 	newLegacyCVEs := make(map[string]*schema.NVDCVEFeedJSON10DefCVEItem)
 	for _, cve := range cves {
+		if cve.CVE.VulnStatus != nil && *cve.CVE.VulnStatus == "Rejected" {
+			continue
+		}
 		legacyCVE := convertAPI20CVEToLegacy(cve.CVE, s.logger)
 		updateWithVulnCheckConfigurations(legacyCVE, cve.VcConfigurations)
 		newLegacyCVEs[legacyCVE.CVE.CVEDataMeta.ID] = legacyCVE


### PR DESCRIPTION
#18913

'Rejected' and other vuln statuses are only available in the 2.0 API, so this PR ignores 'Rejected' CVEs when it converts the feed from 2.0 to the legacy format.  This needs to be deployed to the vulnerabilities repo before the tests are merged, otherwise they will not pass.

Related PRs:
- Increase job timeout: https://github.com/fleetdm/vulnerabilities/pull/13
- Tests: incoming
 
- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [ ] Added/updated tests
- [X] Manual QA for all new/changed functionality
 