### PR TITLE
Fix my device page banners

### DIFF
--- a/changes/issue-19951-render-banners-on-my-device-page-in-priority-order
+++ b/changes/issue-19951-render-banners-on-my-device-page-in-priority-order
@@ -1,0 +1,1 @@
+- render only one banner on the my device page based on priority order.

--- a/frontend/interfaces/host.ts
+++ b/frontend/interfaces/host.ts
@@ -139,7 +139,7 @@ export interface IMunkiData {
   version: string;
 }
 
-type MacDiskEncryptionActionRequired = "log_out" | "rotate_key" | null;
+export type MacDiskEncryptionActionRequired = "log_out" | "rotate_key";
 
 export interface IOSSettings {
   disk_encryption: {

--- a/frontend/pages/hosts/details/DeviceUserPage/DeviceUserPage.tsx
+++ b/frontend/pages/hosts/details/DeviceUserPage/DeviceUserPage.tsx
@@ -22,7 +22,6 @@ import OrgLogoIcon from "components/icons/OrgLogoIcon";
 import Spinner from "components/Spinner";
 import Button from "components/buttons/Button";
 import TabsWrapper from "components/TabsWrapper";
-import InfoBanner from "components/InfoBanner";
 import Icon from "components/Icon/Icon";
 import { normalizeEmptyValues } from "utilities/helpers";
 import PATHS from "router/paths";
@@ -47,6 +46,7 @@ import ResetKeyModal from "./ResetKeyModal";
 import BootstrapPackageModal from "../HostDetailsPage/modals/BootstrapPackageModal";
 import { parseHostSoftwareQueryParams } from "../cards/Software/HostSoftware";
 import SelfService from "../cards/Software/SelfService";
+import DeviceUserBanners from "./components/DeviceUserBanners";
 
 const baseClass = "device-user";
 
@@ -307,12 +307,6 @@ const DeviceUserPage = ({
     );
   };
 
-  const turnOnMdmButton = (
-    <Button variant="unstyled" onClick={toggleEnrollMdmModal}>
-      <b>Turn on MDM</b>
-    </Button>
-  );
-
   const renderEnrollMdmModal = () => {
     return host?.dep_assigned_to_fleet ? (
       <AutoEnrollMdmModal host={host} onCancel={toggleEnrollMdmModal} />
@@ -324,28 +318,8 @@ const DeviceUserPage = ({
     );
   };
 
-  const resetKeyButton = (
-    <Button variant="unstyled" onClick={toggleResetKeyModal}>
-      <b>Reset key</b>
-    </Button>
-  );
-
   const renderDeviceUserPage = () => {
     const failingPoliciesCount = host?.issues?.failing_policies_count || 0;
-    const isMdmUnenrolled =
-      host?.mdm.enrollment_status === "Off" || !host?.mdm.enrollment_status;
-
-    const diskEncryptionBannersEnabled =
-      globalConfig?.mdm.enabled_and_configured && host?.mdm.connected_to_fleet;
-
-    const showDiskEncryptionLogoutRestart =
-      diskEncryptionBannersEnabled &&
-      host?.mdm.macos_settings?.disk_encryption === "action_required" &&
-      host?.mdm.macos_settings?.action_required === "log_out";
-    const showDiskEncryptionKeyResetRequired =
-      diskEncryptionBannersEnabled &&
-      host?.mdm.macos_settings?.disk_encryption === "action_required" &&
-      host?.mdm.macos_settings?.action_required === "rotate_key";
 
     // TODO: We should probably have a standard way to handle this on all pages. Do we want to show
     // a premium-only message in the case that a user tries direct navigation to a premium-only page
@@ -370,33 +344,22 @@ const DeviceUserPage = ({
           <Spinner />
         ) : (
           <div className={`${baseClass} main-content`}>
-            {host?.platform === "darwin" &&
-              isMdmUnenrolled &&
-              globalConfig?.mdm.enabled_and_configured && (
-                // Turn on MDM banner
-                <InfoBanner color="yellow" cta={turnOnMdmButton}>
-                  Mobile device management (MDM) is off. MDM allows your
-                  organization to change settings and install software. This
-                  lets your organization keep your device up to date so you
-                  don’t have to.
-                </InfoBanner>
-              )}
-            {showDiskEncryptionLogoutRestart && (
-              // MDM - Disk Encryption: Logout or restart banner
-              <InfoBanner color="yellow">
-                Disk encryption: Log out of your device or restart to turn on
-                disk encryption. Then, select <strong>Refetch</strong>. This
-                prevents unauthorized access to the information on your device.
-              </InfoBanner>
-            )}
-            {showDiskEncryptionKeyResetRequired && (
-              // MDM - Disk Encryption: Reset key required banner
-              <InfoBanner color="yellow" cta={resetKeyButton}>
-                Disk encryption: Reset your disk encryption key. This lets your
-                organization help you unlock your device if you forget your
-                password.
-              </InfoBanner>
-            )}
+            <DeviceUserBanners
+              hostPlatform={host.platform}
+              mdmEnrollmentStatus={host.mdm.enrollment_status}
+              mdmEnabledAndConfigured={
+                !!globalConfig?.mdm.enabled_and_configured
+              }
+              mdmConnectedToFleet={!!host.mdm.connected_to_fleet}
+              diskEncryptionStatus={
+                host.mdm.macos_settings?.disk_encryption ?? null
+              }
+              diskEncryptionActionRequired={
+                host.mdm.macos_settings?.action_required ?? null
+              }
+              onTurnOnMdm={toggleEnrollMdmModal}
+              onResetKey={toggleResetKeyModal}
+            />
             <HostSummaryCard
               summaryData={summaryData}
               bootstrapPackageData={bootstrapPackageData}

--- a/frontend/pages/hosts/details/DeviceUserPage/components/DeviceUserBanners/DeviceUserBanners.tests.tsx
+++ b/frontend/pages/hosts/details/DeviceUserPage/components/DeviceUserBanners/DeviceUserBanners.tests.tsx
@@ -1,7 +1,107 @@
 import React from "react";
+import { noop } from "lodash";
+import { render, screen } from "@testing-library/react";
+
+import DeviceUserBanners from "./DeviceUserBanners";
 
 describe("Device User Banners", () => {
-  it("should render", () => {
-    expect(true).toBe(true);
+  const turnOnMdmExpcetedText = /Mobile device management \(MDM\) is off\./;
+  const logoutDiskEncryptExpectedText = /Disk encryption: Log out of your device or restart to turn on disk encryption\./;
+  const resetKeyDiskEncryptExpcetedText = /Disk encryption: Reset your disk encryption key\./;
+
+  it("renders the turn on mdm banner correctly", () => {
+    render(
+      <DeviceUserBanners
+        hostPlatform="darwin"
+        mdmEnrollmentStatus="Off"
+        mdmEnabledAndConfigured
+        mdmConnectedToFleet
+        diskEncryptionStatus={null}
+        diskEncryptionActionRequired={null}
+        onTurnOnMdm={noop}
+        onResetKey={noop}
+      />
+    );
+    expect(screen.getByText(turnOnMdmExpcetedText)).toBeInTheDocument();
+  });
+
+  it("renders the logout for disk encrpytion banner correctly", () => {
+    render(
+      <DeviceUserBanners
+        hostPlatform="darwin"
+        mdmEnrollmentStatus="On (automatic)"
+        mdmEnabledAndConfigured
+        mdmConnectedToFleet
+        diskEncryptionStatus="action_required"
+        diskEncryptionActionRequired="log_out"
+        onTurnOnMdm={noop}
+        onResetKey={noop}
+      />
+    );
+    expect(screen.getByText(logoutDiskEncryptExpectedText)).toBeInTheDocument();
+  });
+
+  it("renders the reset key for disk encryption banner correctly", () => {
+    render(
+      <DeviceUserBanners
+        hostPlatform="darwin"
+        mdmEnrollmentStatus="On (automatic)"
+        mdmEnabledAndConfigured
+        mdmConnectedToFleet
+        diskEncryptionStatus="action_required"
+        diskEncryptionActionRequired="rotate_key"
+        onTurnOnMdm={noop}
+        onResetKey={noop}
+      />
+    );
+    expect(
+      screen.getByText(resetKeyDiskEncryptExpcetedText)
+    ).toBeInTheDocument();
+  });
+
+  it("renders only one banner in a priority order", () => {
+    // set up to render logout disk encryption banner, which is 2nd in priority
+    render(
+      <DeviceUserBanners
+        hostPlatform="darwin"
+        mdmEnrollmentStatus="On (automatic)"
+        mdmEnabledAndConfigured
+        mdmConnectedToFleet
+        diskEncryptionStatus="action_required"
+        diskEncryptionActionRequired="log_out"
+        onTurnOnMdm={noop}
+        onResetKey={noop}
+      />
+    );
+
+    expect(screen.queryByText(turnOnMdmExpcetedText)).not.toBeInTheDocument();
+    expect(screen.getByText(logoutDiskEncryptExpectedText)).toBeInTheDocument();
+    expect(
+      screen.queryByText(resetKeyDiskEncryptExpcetedText)
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders no banner correctly", () => {
+    // setup so mdm is not enabled and configured.
+    render(
+      <DeviceUserBanners
+        hostPlatform="darwin"
+        mdmEnrollmentStatus={null}
+        mdmEnabledAndConfigured={false}
+        mdmConnectedToFleet={false}
+        diskEncryptionStatus={null}
+        diskEncryptionActionRequired={null}
+        onTurnOnMdm={noop}
+        onResetKey={noop}
+      />
+    );
+
+    expect(screen.queryByText(turnOnMdmExpcetedText)).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(logoutDiskEncryptExpectedText)
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(resetKeyDiskEncryptExpcetedText)
+    ).not.toBeInTheDocument();
   });
 });

--- a/frontend/pages/hosts/details/DeviceUserPage/components/DeviceUserBanners/DeviceUserBanners.tests.tsx
+++ b/frontend/pages/hosts/details/DeviceUserPage/components/DeviceUserBanners/DeviceUserBanners.tests.tsx
@@ -1,0 +1,7 @@
+import React from "react";
+
+describe("Device User Banners", () => {
+  it("should render", () => {
+    expect(true).toBe(true);
+  });
+});

--- a/frontend/pages/hosts/details/DeviceUserPage/components/DeviceUserBanners/DeviceUserBanners.tsx
+++ b/frontend/pages/hosts/details/DeviceUserPage/components/DeviceUserBanners/DeviceUserBanners.tsx
@@ -1,0 +1,94 @@
+import React from "react";
+
+import InfoBanner from "components/InfoBanner";
+import Button from "components/buttons/Button";
+import { DiskEncryptionStatus, MdmEnrollmentStatus } from "interfaces/mdm";
+import { MacDiskEncryptionActionRequired } from "interfaces/host";
+
+const baseClass = "device-user-banners";
+
+interface IDeviceUserBannersProps {
+  hostPlatform: string;
+  mdmEnrollmentStatus: MdmEnrollmentStatus | null;
+  mdmEnabledAndConfigured: boolean;
+  mdmConnectedToFleet: boolean;
+  diskEncryptionStatus: DiskEncryptionStatus | null;
+  diskEncryptionActionRequired: MacDiskEncryptionActionRequired | null;
+  onTurnOnMdm: () => void;
+  onResetKey: () => void;
+}
+
+const DeviceUserBanners = ({
+  hostPlatform,
+  mdmEnrollmentStatus,
+  mdmEnabledAndConfigured,
+  mdmConnectedToFleet,
+  diskEncryptionStatus,
+  diskEncryptionActionRequired,
+  onTurnOnMdm,
+  onResetKey,
+}: IDeviceUserBannersProps) => {
+  const isMdmUnenrolled =
+    mdmEnrollmentStatus === "Off" || mdmEnrollmentStatus === null;
+
+  const diskEncryptionBannersEnabled =
+    mdmEnabledAndConfigured && mdmConnectedToFleet;
+
+  const showTurnOnMdmBanner =
+    hostPlatform === "darwin" && isMdmUnenrolled && mdmEnabledAndConfigured;
+
+  const showDiskEncryptionLogoutRestart =
+    diskEncryptionBannersEnabled &&
+    diskEncryptionStatus === "action_required" &&
+    diskEncryptionActionRequired === "log_out";
+
+  const showDiskEncryptionKeyResetRequired =
+    diskEncryptionBannersEnabled &&
+    diskEncryptionStatus === "action_required" &&
+    diskEncryptionActionRequired === "rotate_key";
+
+  const turnOnMdmButton = (
+    <Button variant="unstyled" onClick={onTurnOnMdm}>
+      <b>Turn on MDM</b>
+    </Button>
+  );
+
+  const resetKeyButton = (
+    <Button variant="unstyled" onClick={onResetKey}>
+      <b>Reset key</b>
+    </Button>
+  );
+
+  const renderBanner = () => {
+    if (showTurnOnMdmBanner) {
+      return (
+        <InfoBanner color="yellow" cta={turnOnMdmButton}>
+          Mobile device management (MDM) is off. MDM allows your organization to
+          change settings and install software. This lets your organization keep
+          your device up to date so you don&apos;t have to.
+        </InfoBanner>
+      );
+    } else if (showDiskEncryptionLogoutRestart) {
+      return (
+        <InfoBanner color="yellow">
+          Disk encryption: Log out of your device or restart to turn on disk
+          encryption. Then, select <strong>Refetch</strong>. This prevents
+          unauthorized access to the information on your device.
+        </InfoBanner>
+      );
+    } else if (showDiskEncryptionKeyResetRequired) {
+      return (
+        <InfoBanner color="yellow" cta={resetKeyButton}>
+          Disk encryption: Reset your disk encryption key. This lets your
+          organization help you unlock your device if you forget your password.
+        </InfoBanner>
+      );
+    }
+
+    return null;
+  };
+
+  return <div className={baseClass}>{renderBanner()}</div>;
+};
+
+export default DeviceUserBanners;

--- a/frontend/pages/hosts/details/DeviceUserPage/components/DeviceUserBanners/_styles.scss
+++ b/frontend/pages/hosts/details/DeviceUserPage/components/DeviceUserBanners/_styles.scss
@@ -1,0 +1,3 @@
+.device-user-banners {
+
+}

--- a/frontend/pages/hosts/details/DeviceUserPage/components/DeviceUserBanners/_styles.scss
+++ b/frontend/pages/hosts/details/DeviceUserPage/components/DeviceUserBanners/_styles.scss
@@ -1,3 +1,0 @@
-.device-user-banners {
-
-}

--- a/frontend/pages/hosts/details/DeviceUserPage/components/DeviceUserBanners/index.ts
+++ b/frontend/pages/hosts/details/DeviceUserPage/components/DeviceUserBanners/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./DeviceUserBanners";


### PR DESCRIPTION
relates to #19951

renders only one banner at a time on the my device page based on a priority order. This priority is:

1. turn on mdm banner
2. logout for disk encryption banner
3. reset key for disk encryption banner

![image](https://github.com/fleetdm/fleet/assets/1153709/7a8725f1-d834-42ec-b6d3-8145f9f0a16c)

![image](https://github.com/fleetdm/fleet/assets/1153709/df32de66-6e85-4252-b88c-8c95b28626e6)

![image](https://github.com/fleetdm/fleet/assets/1153709/a6a065bb-cf6f-41ba-8f81-0b1a276d1ce3)


- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
- [x] Added/updated tests
- [x] Manual QA for all new/changed functionality
