### PR TITLE
Windows Vuln False Positives

### DIFF
--- a/changes/20010-win-false-positives
+++ b/changes/20010-win-false-positives
@@ -1,0 +1,1 @@
+- fixed issue where some Windows applications were getting matched against Windows OS vulnerabilities

--- a/server/vulnerabilities/nvd/cpe_matching_rules.go
+++ b/server/vulnerabilities/nvd/cpe_matching_rules.go
@@ -218,6 +218,28 @@ func GetKnownNVDBugRules() (CPEMatchingRules, error) {
 			},
 			IgnoreAll: true,
 		},
+		// Windows OS vulnerabilities without version constraints that should be ignored
+		// TODO(tim): This rule is too specific and should be generalized to ignore all
+		// Windows OS vulnerabilities in NVD
+		CPEMatchingRule{
+			CVEs: map[string]struct{}{
+				"CVE-2010-3143":  {},
+				"CVE-2011-5049":  {},
+				"CVE-2012-2972":  {},
+				"CVE-2018-0598":  {},
+				"CVE-2010-3888":  {},
+				"CVE-2010-3139":  {},
+				"CVE-2021-36958": {},
+				"CVE-2008-6194":  {},
+				"CVE-2010-2157":  {},
+				"CVE-2011-3389":  {},
+				"CVE-2012-2971":  {},
+				"CVE-2018-0599":  {},
+				"CVE-2010-3889":  {},
+				"CVE-2011-0638":  {},
+			},
+			IgnoreAll: true,
+		},
 	}
 
 	for i, rule := range rules {

--- a/server/vulnerabilities/nvd/cve_test.go
+++ b/server/vulnerabilities/nvd/cve_test.go
@@ -327,6 +327,13 @@ func TestTranslateCPEToCVE(t *testing.T) {
 			},
 			continuesToUpdate: true,
 		},
+		"cpe:2.3:a:microsoft:365_apps:16.0.17628.20144:*:*:*:*:windows:*:*": {
+			includedCVEs: []cve{
+				{ID: "CVE-2024-21402"},
+			},
+			excludedCVEs:      []string{"CVE-2011-5049"}, // OS vulnerability
+			continuesToUpdate: true,
+		},
 	}
 
 	cveOSTests := []struct {


### PR DESCRIPTION
#20010 

This ignores ~13 CVEs incorrectly matched against some Windows apps.  This is treated as a hotfix.

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
- [X] Added/updated tests
- [X] Manual QA for all new/changed functionality