### PR TITLE
[unreleased bugs] Fleet UI: Observer+ live query button, Team admin/maintainer save button

### DIFF
--- a/frontend/pages/policies/PolicyPage/components/PolicyForm/PolicyForm.tsx
+++ b/frontend/pages/policies/PolicyPage/components/PolicyForm/PolicyForm.tsx
@@ -188,7 +188,8 @@ const PolicyForm = ({
   const hasSavePermissions =
     !isEditMode || // save a new policy
     isGlobalAdmin ||
-    isGlobalMaintainer;
+    isGlobalMaintainer ||
+    isTeamMaintainerOrTeamAdmin;
 
   const onLoad = (editor: IAceEditor) => {
     editor.setOptions({

--- a/frontend/pages/queries/ManageQueriesPage/ManageQueriesPage.tsx
+++ b/frontend/pages/queries/ManageQueriesPage/ManageQueriesPage.tsx
@@ -77,6 +77,7 @@ const ManageQueriesPage = ({
   const queryParams = location.query;
   const {
     isGlobalAdmin,
+    isGlobalMaintainer,
     isTeamAdmin,
     isTeamMaintainer,
     isOnlyObserver,
@@ -361,9 +362,12 @@ const ManageQueriesPage = ({
   };
 
   // CTA button shows for all roles but global observers and current team's observers
-  const canCustomQuery = isOnGlobalTeam
-    ? !isOnlyObserver
-    : isTeamAdmin || isTeamMaintainer || isObserverPlus; // isObserverPlus checks specific team as well
+  const canCustomQuery =
+    isGlobalAdmin ||
+    isGlobalMaintainer ||
+    isTeamAdmin ||
+    isTeamMaintainer ||
+    isObserverPlus; // isObserverPlus checks global and selected team
 
   return (
     <MainContent className={baseClass}>


### PR DESCRIPTION
## Issues
Cerra #19996
Cerra #19997

## Description
Unreleased bugs related to updates to permissions of edit query introduced with #19523 
- Observer+ can see Live query button
- Team admin/team maintainer can see Save button

## Causes
For transparency, a screenshot of how these 2 bugs got introduced:
<img width="934" alt="Screenshot 2024-06-26 at 11 57 05 AM" src="https://github.com/fleetdm/fleet/assets/71795832/dae2471a-c468-4c69-8601-1f1b635ffa81">

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- Test exist on QA wolf
- [x] Manual QA for all new/changed functionality

