### PR TITLE
Add createdAt to Vulnerability responses

### DIFF
--- a/cmd/fleetctl/get_test.go
+++ b/cmd/fleetctl/get_test.go
@@ -785,8 +785,8 @@ func TestGetSoftwareVersions(t *testing.T) {
 	foo001 := fleet.Software{
 		Name: "foo", Version: "0.0.1", Source: "chrome_extensions", GenerateCPE: "somecpe",
 		Vulnerabilities: fleet.Vulnerabilities{
-			{CVE: "cve-321-432-543", DetailsLink: "https://nvd.nist.gov/vuln/detail/cve-321-432-543"},
-			{CVE: "cve-333-444-555", DetailsLink: "https://nvd.nist.gov/vuln/detail/cve-333-444-555"},
+			{CVE: "cve-321-432-543", DetailsLink: "https://nvd.nist.gov/vuln/detail/cve-321-432-543", CreatedAt: time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC)},
+			{CVE: "cve-333-444-555", DetailsLink: "https://nvd.nist.gov/vuln/detail/cve-333-444-555", CreatedAt: time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC)},
 		},
 	}
 	foo002 := fleet.Software{Name: "foo", Version: "0.0.2", Source: "chrome_extensions", ExtensionID: "xyz", Browser: "edge"}
@@ -830,8 +830,10 @@ spec:
   vulnerabilities:
   - cve: cve-321-432-543
     details_link: https://nvd.nist.gov/vuln/detail/cve-321-432-543
+    created_at: "2021-01-01T00:00:00Z"
   - cve: cve-333-444-555
     details_link: https://nvd.nist.gov/vuln/detail/cve-333-444-555
+    created_at: "2021-01-01T00:00:00Z"
 - generated_cpe: ""
   id: 0
   name: foo
@@ -872,11 +874,13 @@ spec:
       "vulnerabilities": [
         {
           "cve": "cve-321-432-543",
-          "details_link": "https://nvd.nist.gov/vuln/detail/cve-321-432-543"
+          "details_link": "https://nvd.nist.gov/vuln/detail/cve-321-432-543",
+		  "created_at": "2021-01-01T00:00:00Z"
         },
         {
           "cve": "cve-333-444-555",
-          "details_link": "https://nvd.nist.gov/vuln/detail/cve-333-444-555"
+          "details_link": "https://nvd.nist.gov/vuln/detail/cve-333-444-555",
+		  "created_at": "2021-01-01T00:00:00Z"
         }
       ]
     },

--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -3708,6 +3708,7 @@ Retrieves information about the specified OS version.
       {
         "cve": "CVE-2022-30190",
         "details_link": "https://nvd.nist.gov/vuln/detail/CVE-2022-30190",
+        "created_at": "2024-07-01T00:15:00Z",
         "cvss_score": 7.8,// Available in Fleet Premium
         "epss_probability": 0.9729,// Available in Fleet Premium
         "cisa_known_exploit": false,// Available in Fleet Premium
@@ -8500,20 +8501,22 @@ Returns information about the specified software version.
       {
         "cve": "CVE-2023-4863",
         "details_link": "https://nvd.nist.gov/vuln/detail/CVE-2023-4863",
-        "cvss_score": 8.8,
-        "epss_probability": 0.4101,
-        "cisa_known_exploit": true,
-        "cve_published": "2023-09-12T15:15:00Z",
-        "resolved_in_version": ""
+        "created_at": "2024-07-01T00:15:00Z",
+        "cvss_score": 8.8, // Available in Fleet Premium
+        "epss_probability": 0.4101, // Available in Fleet Premium
+        "cisa_known_exploit": true, // Available in Fleet Premium
+        "cve_published": "2023-09-12T15:15:00Z", // Available in Fleet Premium
+        "resolved_in_version": "" // Available in Fleet Premium
       },
       {
         "cve": "CVE-2023-5169",
         "details_link": "https://nvd.nist.gov/vuln/detail/CVE-2023-5169",
-        "cvss_score": 6.5,
-        "epss_probability": 0.00073,
-        "cisa_known_exploit": false,
-        "cve_published": "2023-09-27T15:19:00Z",
-        "resolved_in_version": "118"
+        "created_at": "2024-07-01T00:15:00Z",
+        "cvss_score": 6.5, // Available in Fleet Premium
+        "epss_probability": 0.00073, // Available in Fleet Premium
+        "cisa_known_exploit": false, // Available in Fleet Premium
+        "cve_published": "2023-09-27T15:19:00Z", // Available in Fleet Premium
+        "resolved_in_version": "118" // Available in Fleet Premium
       }
     ]
   }

--- a/server/datastore/mysql/operating_system_vulnerabilities.go
+++ b/server/datastore/mysql/operating_system_vulnerabilities.go
@@ -45,7 +45,8 @@ func (ds *Datastore) ListVulnsByOsNameAndVersion(ctx context.Context, name, vers
 				cm.cisa_known_exploit,
 				cm.published as cve_published,
 				cm.description,
-				osv.resolved_in_version
+				osv.resolved_in_version,
+				osv.created_at
 			FROM operating_system_vulnerabilities osv
 			LEFT JOIN cve_meta cm ON cm.cve = osv.cve
 			WHERE osv.operating_system_id IN (
@@ -55,7 +56,8 @@ func (ds *Datastore) ListVulnsByOsNameAndVersion(ctx context.Context, name, vers
 	} else {
 		sqlstmt = `
 			SELECT DISTINCT
-				osv.cve
+				osv.cve,
+				osv.created_at
 			FROM operating_system_vulnerabilities osv
 			WHERE osv.operating_system_id IN (
 				SELECT id FROM operating_systems WHERE name = ? AND version = ?

--- a/server/datastore/mysql/operating_system_vulnerabilities_test.go
+++ b/server/datastore/mysql/operating_system_vulnerabilities_test.go
@@ -158,12 +158,12 @@ func testListVulnsByOsNameAndVersion(t *testing.T, ds *Datastore) {
 	cves, err = ds.ListVulnsByOsNameAndVersion(ctx, "Microsoft Windows 11 Pro 21H2", "10.0.22000.795", false)
 	require.NoError(t, err)
 
-	expected := fleet.Vulnerabilities{
-		{CVE: "CVE-2021-1234"},
-		{CVE: "CVE-2021-1235"},
-	}
+	expected := []string{"CVE-2021-1234", "CVE-2021-1235"}
 	require.Len(t, cves, 2)
-	require.ElementsMatch(t, expected, cves)
+	for _, cve := range cves {
+		require.Contains(t, expected, cve.CVE)
+		require.Greater(t, cve.CreatedAt, time.Now().Add(-time.Hour)) // assert non-zero time
+	}
 
 	// test with CVS meta
 	cves, err = ds.ListVulnsByOsNameAndVersion(ctx, "Microsoft Windows 11 Pro 21H2", "10.0.22000.795", true)

--- a/server/datastore/mysql/software.go
+++ b/server/datastore/mysql/software.go
@@ -801,6 +801,7 @@ func listSoftwareDB(
 			cve := fleet.CVE{
 				CVE:         cveID,
 				DetailsLink: fmt.Sprintf("https://nvd.nist.gov/vuln/detail/%s", cveID),
+				CreatedAt:   *result.CreatedAt,
 			}
 			if opts.IncludeCVEScores {
 				cve.CVSSScore = &result.CVSSScore
@@ -1000,6 +1001,7 @@ func selectSoftwareSQL(opts fleet.SoftwareListOptions) (string, []interface{}, e
 			"s.arch",
 			goqu.COALESCE(goqu.I("s.generated_cpe"), "").As("generated_cpe"),
 			"scv.cve",
+			"scv.created_at",
 		).
 		LeftJoin(
 			goqu.I("software_cve").As("scv"),

--- a/server/datastore/mysql/software.go
+++ b/server/datastore/mysql/software.go
@@ -845,6 +845,9 @@ type softwareCVE struct {
 	// ResolvedInVersion is the version of software where the CVE is no longer applicable.
 	// This is pulled from the versionEndExcluding field in the NVD json
 	ResolvedInVersion *string `db:"resolved_in_version"`
+
+	// CreatedAt is the time the software vulnerability was created
+	CreatedAt *time.Time `db:"created_at"`
 }
 
 func selectSoftwareSQL(opts fleet.SoftwareListOptions) (string, []interface{}, error) {
@@ -1316,6 +1319,7 @@ func (ds *Datastore) SoftwareByID(ctx context.Context, id uint, teamID *uint, in
 			"s.arch",
 			"s.extension_id",
 			"scv.cve",
+			"scv.created_at",
 			goqu.COALESCE(goqu.I("scp.cpe"), "").As("generated_cpe"),
 		).
 		LeftJoin(
@@ -1399,6 +1403,7 @@ func (ds *Datastore) SoftwareByID(ctx context.Context, id uint, teamID *uint, in
 			cve := fleet.CVE{
 				CVE:         cveID,
 				DetailsLink: fmt.Sprintf("https://nvd.nist.gov/vuln/detail/%s", cveID),
+				CreatedAt:   *result.CreatedAt,
 			}
 			if includeCVEScores {
 				cve.CVSSScore = &result.CVSSScore

--- a/server/datastore/mysql/software_test.go
+++ b/server/datastore/mysql/software_test.go
@@ -313,6 +313,8 @@ func testSoftwareLoadVulnerabilities(t *testing.T, ds *Datastore) {
 	require.NoError(t, err)
 	require.NotNil(t, softByID)
 	require.Len(t, softByID.Vulnerabilities, 2)
+	assert.Equal(t, "CVE-2022-0001", softByID.Vulnerabilities[0].CVE)
+	assert.GreaterOrEqual(t, softByID.Vulnerabilities[0].CreatedAt, time.Now().Add(-time.Minute))
 
 	assert.Equal(t, "somecpe", host.Software[0].GenerateCPE)
 	require.Len(t, host.Software[0].Vulnerabilities, 2)
@@ -322,7 +324,6 @@ func testSoftwareLoadVulnerabilities(t *testing.T, ds *Datastore) {
 	assert.Equal(t, "CVE-2022-0002", host.Software[0].Vulnerabilities[1].CVE)
 	assert.Equal(t,
 		"https://nvd.nist.gov/vuln/detail/CVE-2022-0002", host.Software[0].Vulnerabilities[1].DetailsLink)
-
 	assert.Equal(t, "someothercpewithoutvulns", host.Software[1].GenerateCPE)
 	require.Len(t, host.Software[1].Vulnerabilities, 0)
 }

--- a/server/datastore/mysql/software_test.go
+++ b/server/datastore/mysql/software_test.go
@@ -313,11 +313,15 @@ func testSoftwareLoadVulnerabilities(t *testing.T, ds *Datastore) {
 	require.NoError(t, err)
 	require.NotNil(t, softByID)
 	require.Len(t, softByID.Vulnerabilities, 2)
-	assert.Equal(t, "CVE-2022-0001", softByID.Vulnerabilities[0].CVE)
 	assert.GreaterOrEqual(t, softByID.Vulnerabilities[0].CreatedAt, time.Now().Add(-time.Minute))
 
 	assert.Equal(t, "somecpe", host.Software[0].GenerateCPE)
 	require.Len(t, host.Software[0].Vulnerabilities, 2)
+
+	sort.Slice(host.Software[0].Vulnerabilities, func(i, j int) bool {
+		return host.Software[0].Vulnerabilities[i].CVE < host.Software[0].Vulnerabilities[j].CVE
+	})
+
 	assert.Equal(t, "CVE-2022-0001", host.Software[0].Vulnerabilities[0].CVE)
 	assert.Equal(t,
 		"https://nvd.nist.gov/vuln/detail/CVE-2022-0001", host.Software[0].Vulnerabilities[0].DetailsLink)
@@ -950,10 +954,14 @@ func listSoftwareCheckCount(t *testing.T, ds *Datastore, expectedListCount int, 
 		require.Nil(t, meta)
 	}
 
-	for _, s := range software {
+	for i, s := range software {
 		sort.Slice(s.Vulnerabilities, func(i, j int) bool {
 			return s.Vulnerabilities[i].CVE < s.Vulnerabilities[j].CVE
 		})
+		for i2, v := range s.Vulnerabilities {
+			require.Greater(t, v.CreatedAt, time.Now().Add(-time.Hour)) // assert non-zero
+			software[i].Vulnerabilities[i2].CreatedAt = time.Time{}     // zero out for comparison
+		}
 	}
 
 	if returnSorted {

--- a/server/fleet/vulnerabilities.go
+++ b/server/fleet/vulnerabilities.go
@@ -6,8 +6,9 @@ import (
 )
 
 type CVE struct {
-	CVE         string `json:"cve" db:"cve"`
-	DetailsLink string `json:"details_link" db:"-"`
+	CVE         string    `json:"cve" db:"cve"`
+	DetailsLink string    `json:"details_link" db:"-"`
+	CreatedAt   time.Time `json:"created_at" db:"created_at"`
 	// These are double pointers so that we can omit them AND return nulls when needed.
 	// 1. omitted when using the free tier
 	// 2. null when using the premium tier, but there is no value available. This may be due to an issue with syncing cve scores.


### PR DESCRIPTION
#19123 

Added CreatedAt fields to API responses, which are expected in the frontend to populate the `Detected At` fields.

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [X] Added/updated tests
- [X] Manual QA for all new/changed functionality