### PR TITLE
Add github action to check the auto-generated documentation is up-to-date

### DIFF
--- a/.github/workflows/check-automated-doc.yml
+++ b/.github/workflows/check-automated-doc.yml
@@ -29,7 +29,7 @@ permissions:
 
 jobs:
   check-doc-gen:
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@63c24ba6bd7ba022e95695ff85de572c04a18142 # v2.7.0

--- a/.github/workflows/check-automated-doc.yml
+++ b/.github/workflows/check-automated-doc.yml
@@ -9,7 +9,7 @@ on:
   pull_request:
     paths:
       - "**.go"
-      - ".github/workflows/check-doc-generation.yml"
+      - ".github/workflows/check-automated-doc.yml"
       - "schema/tables/**"
       - "schema/osquery_fleet_schema.json"
   workflow_dispatch: # Manual

--- a/.github/workflows/check-automated-doc.yml
+++ b/.github/workflows/check-automated-doc.yml
@@ -1,0 +1,66 @@
+name: Check automated documentation is up-to-date
+
+# This action is used to check that auto-generated documentation is up-to-date.
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    paths:
+      - "**.go"
+      - ".github/workflows/check-doc-generation.yml"
+      - "schema/tables/**"
+      - "schema/osquery_fleet_schema.json"
+  workflow_dispatch: # Manual
+
+# This allows a subsequently queued workflow run to interrupt previous runs
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id}}
+  cancel-in-progress: true
+
+defaults:
+  run:
+    # fail-fast using bash -eo pipefail. See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#exit-codes-and-error-action-preference
+    shell: bash
+
+permissions:
+  contents: read
+
+jobs:
+  check-doc-gen:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@63c24ba6bd7ba022e95695ff85de572c04a18142 # v2.7.0
+        with:
+          egress-policy: audit
+
+      - name: Install Go
+        uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
+        with:
+          go-version: ${{ vars.GO_VERSION }}
+      - name: Checkout Code
+        uses: actions/checkout@629c2de402a417ea7690ca6ce3f33229e27606a5 # v2
+        with:
+          fetch-depth: 0
+
+      - name: Verify golang generated documentation is up-to-date
+        run: |
+          make generate-doc
+          if [[ $(git diff) ]]; then
+            echo "❌ fail: uncommited changes"
+            echo "please run `make generate-doc` and commit the changes"
+            exit 1
+          fi
+
+      - name: Verify osquery table JSON schema is up-to-date
+        run: |
+          cd website
+          npm install
+          ./node_modules/sails/bin/sails.js run generate-merged-schema
+          if [[ $(git diff) ]]; then
+            echo "❌ fail: uncommited changes"
+            echo "please run `cd website && npm install && ./node_modules/sails/bin/sails.js run generate-merged-schema` and commit the changes"
+            exit 1
+          fi


### PR DESCRIPTION
Oncall project to keep auto-generated documentation up-to-date.
- Auto-generated documentation from Golang source code.
- Auto-generated table JSON schema from yaml files in `schema/tables/` (we currently remind the developer to run the sails.js commands in the PR or ask Eric to do it).

Sample of the failure if the developer forgot to run `make generate-doc` (similar to `make test-db-schema`):
![Screenshot 2024-06-26 at 2 41 23 PM](https://github.com/fleetdm/fleet/assets/2073526/9bbfee24-f5cc-4ce5-bc90-5eb94231c24c)
