### PR TITLE
Fleet UI: Update software updated time tooltip

### DIFF
--- a/changes/19760-software-update-tooltip
+++ b/changes/19760-software-update-tooltip
@@ -1,0 +1,1 @@
+* Update software updated timestamp tooltip

--- a/frontend/components/LastUpdatedText/LastUpdatedText.tsx
+++ b/frontend/components/LastUpdatedText/LastUpdatedText.tsx
@@ -6,14 +6,27 @@ import TooltipWrapper from "components/TooltipWrapper";
 
 const baseClass = "component__last-updated-text";
 
-interface ILastUpdatedTextProps {
+interface ILastUpdatedTextBase {
   lastUpdatedAt?: string;
+}
+
+interface ILastUpdatedTextWithCustomTooltip extends ILastUpdatedTextBase {
+  customTooltipText: React.ReactNode;
+  whatToRetrieve?: never;
+}
+
+interface ILastUpdatedTextWithWhatToRetrieve extends ILastUpdatedTextBase {
+  customTooltipText?: never;
   whatToRetrieve: string;
 }
+
 const LastUpdatedText = ({
   lastUpdatedAt,
   whatToRetrieve,
-}: ILastUpdatedTextProps): JSX.Element => {
+  customTooltipText,
+}:
+  | ILastUpdatedTextWithCustomTooltip
+  | ILastUpdatedTextWithWhatToRetrieve): JSX.Element => {
   if (!lastUpdatedAt || lastUpdatedAt === "0001-01-01T00:00:00Z") {
     lastUpdatedAt = "never";
   } else {
@@ -24,16 +37,16 @@ const LastUpdatedText = ({
     );
   }
 
+  const tooltipContent = customTooltipText || (
+    <>
+      Fleet periodically queries all hosts <br />
+      to retrieve {whatToRetrieve}.
+    </>
+  );
+
   return (
     <span className={baseClass}>
-      <TooltipWrapper
-        tipContent={
-          <>
-            Fleet periodically queries all hosts <br />
-            to retrieve {whatToRetrieve}.
-          </>
-        }
-      >
+      <TooltipWrapper tipContent={tooltipContent}>
         {`Updated ${lastUpdatedAt}`}
       </TooltipWrapper>
     </span>

--- a/frontend/pages/SoftwarePage/SoftwareOS/SoftwareOSTable/SoftwareOSTable.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareOS/SoftwareOSTable/SoftwareOSTable.tsx
@@ -1,6 +1,6 @@
 /** software/os OS tab > Table */
 
-import React, { useCallback, useContext, useMemo } from "react";
+import React, { useCallback, useMemo } from "react";
 import { InjectedRouter } from "react-router";
 import { Row } from "react-table";
 
@@ -137,7 +137,13 @@ const SoftwareOSTable = ({
         {data?.os_versions && data?.counts_updated_at && (
           <LastUpdatedText
             lastUpdatedAt={data.counts_updated_at}
-            whatToRetrieve="vulnerabilities"
+            customTooltipText={
+              <>
+                The last time software data was <br />
+                updated, including vulnerabilities <br />
+                and host counts.
+              </>
+            }
           />
         )}
       </>

--- a/frontend/pages/SoftwarePage/SoftwareTitles/SoftwareTable/SoftwareTable.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitles/SoftwareTable/SoftwareTable.tsx
@@ -270,7 +270,13 @@ const SoftwareTable = ({
         {tableData && data?.counts_updated_at && (
           <LastUpdatedText
             lastUpdatedAt={data.counts_updated_at}
-            whatToRetrieve="software"
+            customTooltipText={
+              <>
+                The last time software data was <br />
+                updated, including vulnerabilities <br />
+                and host counts.
+              </>
+            }
           />
         )}
       </>

--- a/frontend/pages/SoftwarePage/SoftwareVulnerabilities/SoftwareVulnerabilitiesTable/SoftwareVulnerabilitiesTable.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareVulnerabilities/SoftwareVulnerabilitiesTable/SoftwareVulnerabilitiesTable.tsx
@@ -189,7 +189,13 @@ const SoftwareVulnerabilitiesTable = ({
         {data?.vulnerabilities && data?.counts_updated_at && (
           <LastUpdatedText
             lastUpdatedAt={data.counts_updated_at}
-            whatToRetrieve="vulnerabilities"
+            customTooltipText={
+              <>
+                The last time software data was <br />
+                updated, including vulnerabilities <br />
+                and host counts.
+              </>
+            }
           />
         )}
       </>


### PR DESCRIPTION
## Issue
Cerra #19760 

## Description
- Updates tooltip in 3 places
- Now allowing custom tooltips for updated timestamp component

## Screenshot (1 of 3 locations of changes)
<img width="672" alt="Screenshot 2024-06-26 at 3 15 09 PM" src="https://github.com/fleetdm/fleet/assets/71795832/f52d325d-1978-486e-a3c0-700f13721577">


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
- [x] Manual QA for all new/changed functionality
