### PR TITLE
Hide "Self-service" in Fleet Desktop and My device page

### DIFF
--- a/changes/19651-hide-self-service
+++ b/changes/19651-hide-self-service
@@ -1,0 +1,1 @@
+- Hide "Self-service" in Fleet Desktop and My device page if there is no self-service software available

--- a/ee/server/service/devices.go
+++ b/ee/server/service/devices.go
@@ -109,7 +109,7 @@ func (svc *Service) GetFleetDesktopSummary(ctx context.Context) (fleet.DesktopSu
 		return sum, err
 	}
 
-	hasSelfService, err := svc.ds.HasSelfServiceSoftwareInstallers(ctx, host.TeamID)
+	hasSelfService, err := svc.ds.HasSelfServiceSoftwareInstallers(ctx, host.Platform, host.TeamID)
 	if err != nil {
 		return sum, ctxerr.Wrap(ctx, err, "retrieving self service software installers")
 	}

--- a/ee/server/service/devices.go
+++ b/ee/server/service/devices.go
@@ -109,6 +109,12 @@ func (svc *Service) GetFleetDesktopSummary(ctx context.Context) (fleet.DesktopSu
 		return sum, err
 	}
 
+	hasSelfService, err := svc.ds.HasSelfServiceSoftwareInstallers(ctx, host.TeamID)
+	if err != nil {
+		return sum, ctxerr.Wrap(ctx, err, "retrieving self service software installers")
+	}
+	sum.SelfService = &hasSelfService
+
 	r, err := svc.ds.FailingPoliciesCount(ctx, host)
 	if err != nil {
 		return sum, ctxerr.Wrap(ctx, err, "retrieving failing policies")

--- a/frontend/interfaces/host.ts
+++ b/frontend/interfaces/host.ts
@@ -240,6 +240,7 @@ export interface IDeviceUserResponse {
   disk_encryption_enabled?: boolean;
   platform?: string;
   global_config: IDeviceGlobalConfig;
+  self_service: boolean;
 }
 
 export interface IHostEncrpytionKeyResponse {

--- a/frontend/pages/hosts/details/DeviceUserPage/DeviceUserPage.tsx
+++ b/frontend/pages/hosts/details/DeviceUserPage/DeviceUserPage.tsx
@@ -106,6 +106,7 @@ const DeviceUserPage = ({
   const [globalConfig, setGlobalConfig] = useState<IDeviceGlobalConfig | null>(
     null
   );
+  const [hasSelfService, setSelfService] = useState(false);
 
   const { data: deviceMapping, refetch: refetchDeviceMapping } = useQuery(
     ["deviceMapping", deviceAuthToken],
@@ -179,12 +180,14 @@ const DeviceUserPage = ({
         org_contact_url,
         global_config,
         host: responseHost,
+        self_service,
       }) => {
         setShowRefetchSpinner(isRefetching(responseHost));
         setIsPremiumTier(license.tier === "premium");
         setOrgLogoURL(org_logo_url);
         setOrgContactURL(org_contact_url);
         setGlobalConfig(global_config);
+        setSelfService(self_service);
         if (isRefetching(responseHost)) {
           // If the API reports that a Fleet refetch request is pending, we want to check back for fresh
           // host details. Here we set a one second timeout and poll the API again using
@@ -380,7 +383,7 @@ const DeviceUserPage = ({
               >
                 <TabList>
                   <Tab>Details</Tab>
-                  {isPremiumTier && isSoftwareEnabled && (
+                  {isPremiumTier && isSoftwareEnabled && hasSelfService && (
                     <Tab>Self-service</Tab>
                   )}
                   {isSoftwareEnabled && <Tab>Software</Tab>}
@@ -402,7 +405,7 @@ const DeviceUserPage = ({
                     munki={deviceMacAdminsData?.munki}
                   />
                 </TabPanel>
-                {isPremiumTier && isSoftwareEnabled && (
+                {isPremiumTier && isSoftwareEnabled && hasSelfService && (
                   <TabPanel>
                     <SelfService
                       contactUrl={orgContactURL}

--- a/orbit/cmd/desktop/desktop.go
+++ b/orbit/cmd/desktop/desktop.go
@@ -205,6 +205,7 @@ func main() {
 						myDeviceItem.SetTitle("My device")
 						myDeviceItem.Enable()
 						transparencyItem.Enable()
+						// Hide Self-Service for Free tier
 						selfServiceItem.Disable()
 						selfServiceItem.Hide()
 						return

--- a/orbit/cmd/desktop/desktop.go
+++ b/orbit/cmd/desktop/desktop.go
@@ -302,6 +302,15 @@ func main() {
 					continue
 				}
 
+				// Check for null for backward compatibility with an old Fleet server
+				if sum.SelfService != nil {
+					if *sum.SelfService {
+						selfServiceItem.Enable()
+					} else {
+						selfServiceItem.Disable()
+					}
+				}
+
 				failingPolicies := 0
 				if sum.FailingPolicies != nil {
 					failingPolicies = int(*sum.FailingPolicies)

--- a/orbit/cmd/desktop/desktop.go
+++ b/orbit/cmd/desktop/desktop.go
@@ -134,6 +134,7 @@ func main() {
 
 		selfServiceItem := systray.AddMenuItem("Self-service", "")
 		selfServiceItem.Disable()
+		selfServiceItem.Hide()
 
 		tokenReader := token.Reader{Path: identifierPath}
 		if _, err := tokenReader.Read(); err != nil {
@@ -180,6 +181,7 @@ func main() {
 			myDeviceItem.Disable()
 			transparencyItem.Disable()
 			selfServiceItem.Disable()
+			selfServiceItem.Hide()
 			migrateMDMItem.Disable()
 			migrateMDMItem.Hide()
 		}
@@ -203,7 +205,8 @@ func main() {
 						myDeviceItem.SetTitle("My device")
 						myDeviceItem.Enable()
 						transparencyItem.Enable()
-						selfServiceItem.Enable()
+						selfServiceItem.Disable()
+						selfServiceItem.Hide()
 						return
 					}
 
@@ -303,12 +306,12 @@ func main() {
 				}
 
 				// Check for null for backward compatibility with an old Fleet server
-				if sum.SelfService != nil {
-					if *sum.SelfService {
-						selfServiceItem.Enable()
-					} else {
-						selfServiceItem.Disable()
-					}
+				if sum.SelfService != nil && !*sum.SelfService {
+					selfServiceItem.Disable()
+					selfServiceItem.Hide()
+				} else {
+					selfServiceItem.Enable()
+					selfServiceItem.Show()
 				}
 
 				failingPolicies := 0

--- a/server/datastore/mysql/software_installers.go
+++ b/server/datastore/mysql/software_installers.go
@@ -568,9 +568,12 @@ ON DUPLICATE KEY UPDATE
 	})
 }
 
-func (ds *Datastore) HasSelfServiceSoftwareInstallers(ctx context.Context, teamID *uint) (bool, error) {
-	stmt := `SELECT 1 FROM software_installers WHERE self_service = 1 AND (global_or_team_id = 0`
-	var args []interface{}
+func (ds *Datastore) HasSelfServiceSoftwareInstallers(ctx context.Context, platform string, teamID *uint) (bool, error) {
+	if fleet.IsLinux(platform) {
+		platform = "linux"
+	}
+	stmt := `SELECT 1 FROM software_installers WHERE self_service = 1 AND platform = ? AND (global_or_team_id = 0`
+	args := []interface{}{platform}
 	if teamID != nil {
 		stmt += ` OR team_id = ?`
 		args = append(args, *teamID)

--- a/server/datastore/mysql/software_installers.go
+++ b/server/datastore/mysql/software_installers.go
@@ -572,13 +572,12 @@ func (ds *Datastore) HasSelfServiceSoftwareInstallers(ctx context.Context, platf
 	if fleet.IsLinux(platform) {
 		platform = "linux"
 	}
-	stmt := `SELECT 1 FROM software_installers WHERE self_service = 1 AND platform = ? AND (global_or_team_id = 0`
-	args := []interface{}{platform}
+	stmt := `SELECT 1 FROM software_installers WHERE self_service = 1 AND platform = ? AND global_or_team_id = ?`
+	var globalOrTeamID uint
 	if teamID != nil {
-		stmt += ` OR team_id = ?`
-		args = append(args, *teamID)
+		globalOrTeamID = *teamID
 	}
-	stmt += `)`
+	args := []interface{}{platform, globalOrTeamID}
 	var hasInstallers bool
 	err := sqlx.GetContext(ctx, ds.reader(ctx), &hasInstallers, stmt, args...)
 	if err != nil && !errors.Is(err, sql.ErrNoRows) {

--- a/server/datastore/mysql/software_installers_test.go
+++ b/server/datastore/mysql/software_installers_test.go
@@ -551,11 +551,12 @@ func testHasSelfServiceSoftwareInstallers(t *testing.T, ds *Datastore) {
 	team, err := ds.NewTeam(ctx, &fleet.Team{Name: "team 2"})
 	require.NoError(t, err)
 
+	const platform = "linux"
 	// No installers
-	hasSelfService, err := ds.HasSelfServiceSoftwareInstallers(ctx, nil)
+	hasSelfService, err := ds.HasSelfServiceSoftwareInstallers(ctx, platform, nil)
 	require.NoError(t, err)
 	assert.False(t, hasSelfService)
-	hasSelfService, err = ds.HasSelfServiceSoftwareInstallers(ctx, &team.ID)
+	hasSelfService, err = ds.HasSelfServiceSoftwareInstallers(ctx, platform, &team.ID)
 	require.NoError(t, err)
 	assert.False(t, hasSelfService)
 
@@ -566,13 +567,14 @@ func testHasSelfServiceSoftwareInstallers(t *testing.T, ds *Datastore) {
 		InstallScript: "echo install",
 		TeamID:        &team.ID,
 		Filename:      "foo.pkg",
+		Platform:      platform,
 		SelfService:   false,
 	})
 	require.NoError(t, err)
-	hasSelfService, err = ds.HasSelfServiceSoftwareInstallers(ctx, nil)
+	hasSelfService, err = ds.HasSelfServiceSoftwareInstallers(ctx, platform, nil)
 	require.NoError(t, err)
 	assert.False(t, hasSelfService)
-	hasSelfService, err = ds.HasSelfServiceSoftwareInstallers(ctx, &team.ID)
+	hasSelfService, err = ds.HasSelfServiceSoftwareInstallers(ctx, platform, &team.ID)
 	require.NoError(t, err)
 	assert.False(t, hasSelfService)
 
@@ -583,13 +585,14 @@ func testHasSelfServiceSoftwareInstallers(t *testing.T, ds *Datastore) {
 		InstallScript: "echo install",
 		TeamID:        &team.ID,
 		Filename:      "foo2.pkg",
+		Platform:      platform,
 		SelfService:   true,
 	})
 	require.NoError(t, err)
-	hasSelfService, err = ds.HasSelfServiceSoftwareInstallers(ctx, nil)
+	hasSelfService, err = ds.HasSelfServiceSoftwareInstallers(ctx, platform, nil)
 	require.NoError(t, err)
 	assert.False(t, hasSelfService)
-	hasSelfService, err = ds.HasSelfServiceSoftwareInstallers(ctx, &team.ID)
+	hasSelfService, err = ds.HasSelfServiceSoftwareInstallers(ctx, platform, &team.ID)
 	require.NoError(t, err)
 	assert.True(t, hasSelfService)
 
@@ -600,13 +603,22 @@ func testHasSelfServiceSoftwareInstallers(t *testing.T, ds *Datastore) {
 		InstallScript: "echo install",
 		TeamID:        nil,
 		Filename:      "foo global.pkg",
+		Platform:      platform,
 		SelfService:   true,
 	})
 	require.NoError(t, err)
-	hasSelfService, err = ds.HasSelfServiceSoftwareInstallers(ctx, nil)
+	hasSelfService, err = ds.HasSelfServiceSoftwareInstallers(ctx, "ubuntu", nil)
 	require.NoError(t, err)
 	assert.True(t, hasSelfService)
-	hasSelfService, err = ds.HasSelfServiceSoftwareInstallers(ctx, &team.ID)
+	hasSelfService, err = ds.HasSelfServiceSoftwareInstallers(ctx, "ubuntu", &team.ID)
 	require.NoError(t, err)
 	assert.True(t, hasSelfService)
+
+	// Check another platform
+	hasSelfService, err = ds.HasSelfServiceSoftwareInstallers(ctx, "darwin", nil)
+	require.NoError(t, err)
+	assert.False(t, hasSelfService)
+	hasSelfService, err = ds.HasSelfServiceSoftwareInstallers(ctx, "darwin", &team.ID)
+	require.NoError(t, err)
+	assert.False(t, hasSelfService)
 }

--- a/server/datastore/mysql/software_installers_test.go
+++ b/server/datastore/mysql/software_installers_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/fleetdm/fleet/v4/server/ptr"
 	"github.com/fleetdm/fleet/v4/server/test"
 	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -29,6 +30,7 @@ func TestSoftwareInstallers(t *testing.T) {
 		{"CleanupUnusedSoftwareInstallers", testCleanupUnusedSoftwareInstallers},
 		{"BatchSetSoftwareInstallers", testBatchSetSoftwareInstallers},
 		{"GetSoftwareInstallerMetadataByTeamAndTitleID", testGetSoftwareInstallerMetadataByTeamAndTitleID},
+		{"HasSelfServiceSoftwareInstallers", testHasSelfServiceSoftwareInstallers},
 	}
 
 	for _, c := range cases {
@@ -541,4 +543,70 @@ func testGetSoftwareInstallerMetadataByTeamAndTitleID(t *testing.T, ds *Datastor
 	require.Equal(t, "", metaByTeamAndTitle.PostInstallScript)
 	require.EqualValues(t, installerID, metaByTeamAndTitle.InstallerID)
 	require.Equal(t, "", metaByTeamAndTitle.PreInstallQuery)
+}
+
+func testHasSelfServiceSoftwareInstallers(t *testing.T, ds *Datastore) {
+	ctx := context.Background()
+
+	team, err := ds.NewTeam(ctx, &fleet.Team{Name: "team 2"})
+	require.NoError(t, err)
+
+	// No installers
+	hasSelfService, err := ds.HasSelfServiceSoftwareInstallers(ctx, nil)
+	require.NoError(t, err)
+	assert.False(t, hasSelfService)
+	hasSelfService, err = ds.HasSelfServiceSoftwareInstallers(ctx, &team.ID)
+	require.NoError(t, err)
+	assert.False(t, hasSelfService)
+
+	// Create a non-self service installer
+	_, err = ds.MatchOrCreateSoftwareInstaller(ctx, &fleet.UploadSoftwareInstallerPayload{
+		Title:         "foo",
+		Source:        "bar",
+		InstallScript: "echo install",
+		TeamID:        &team.ID,
+		Filename:      "foo.pkg",
+		SelfService:   false,
+	})
+	require.NoError(t, err)
+	hasSelfService, err = ds.HasSelfServiceSoftwareInstallers(ctx, nil)
+	require.NoError(t, err)
+	assert.False(t, hasSelfService)
+	hasSelfService, err = ds.HasSelfServiceSoftwareInstallers(ctx, &team.ID)
+	require.NoError(t, err)
+	assert.False(t, hasSelfService)
+
+	// Create a self-service installer for team
+	_, err = ds.MatchOrCreateSoftwareInstaller(ctx, &fleet.UploadSoftwareInstallerPayload{
+		Title:         "foo2",
+		Source:        "bar2",
+		InstallScript: "echo install",
+		TeamID:        &team.ID,
+		Filename:      "foo2.pkg",
+		SelfService:   true,
+	})
+	require.NoError(t, err)
+	hasSelfService, err = ds.HasSelfServiceSoftwareInstallers(ctx, nil)
+	require.NoError(t, err)
+	assert.False(t, hasSelfService)
+	hasSelfService, err = ds.HasSelfServiceSoftwareInstallers(ctx, &team.ID)
+	require.NoError(t, err)
+	assert.True(t, hasSelfService)
+
+	// Create a global self-service installer
+	_, err = ds.MatchOrCreateSoftwareInstaller(ctx, &fleet.UploadSoftwareInstallerPayload{
+		Title:         "foo global",
+		Source:        "bar",
+		InstallScript: "echo install",
+		TeamID:        nil,
+		Filename:      "foo global.pkg",
+		SelfService:   true,
+	})
+	require.NoError(t, err)
+	hasSelfService, err = ds.HasSelfServiceSoftwareInstallers(ctx, nil)
+	require.NoError(t, err)
+	assert.True(t, hasSelfService)
+	hasSelfService, err = ds.HasSelfServiceSoftwareInstallers(ctx, &team.ID)
+	require.NoError(t, err)
+	assert.True(t, hasSelfService)
 }

--- a/server/fleet/datastore.go
+++ b/server/fleet/datastore.go
@@ -1553,6 +1553,9 @@ type Datastore interface {
 
 	// BatchSetSoftwareInstallers sets the software installers for the given team or no team.
 	BatchSetSoftwareInstallers(ctx context.Context, tmID *uint, installers []*UploadSoftwareInstallerPayload) error
+
+	// HasSelfServiceSoftwareInstallers returns true if self-service software installers are available for the team or globally.
+	HasSelfServiceSoftwareInstallers(ctx context.Context, teamID *uint) (bool, error)
 }
 
 // MDMAppleStore wraps nanomdm's storage and adds methods to deal with

--- a/server/fleet/datastore.go
+++ b/server/fleet/datastore.go
@@ -1555,7 +1555,7 @@ type Datastore interface {
 	BatchSetSoftwareInstallers(ctx context.Context, tmID *uint, installers []*UploadSoftwareInstallerPayload) error
 
 	// HasSelfServiceSoftwareInstallers returns true if self-service software installers are available for the team or globally.
-	HasSelfServiceSoftwareInstallers(ctx context.Context, teamID *uint) (bool, error)
+	HasSelfServiceSoftwareInstallers(ctx context.Context, platform string, teamID *uint) (bool, error)
 }
 
 // MDMAppleStore wraps nanomdm's storage and adds methods to deal with

--- a/server/fleet/device.go
+++ b/server/fleet/device.go
@@ -6,6 +6,7 @@ import "time"
 // Desktop to operate (show/hide menu items, etc)
 type DesktopSummary struct {
 	FailingPolicies *uint                `json:"failing_policies_count,omitempty"`
+	SelfService     *bool                `json:"self_service"`
 	Notifications   DesktopNotifications `json:"notifications,omitempty"`
 	Config          DesktopConfig        `json:"config"`
 }

--- a/server/fleet/service.go
+++ b/server/fleet/service.go
@@ -648,6 +648,9 @@ type Service interface {
 	// initiated by the user
 	SelfServiceInstallSoftwareTitle(ctx context.Context, host *Host, softwareTitleID uint) error
 
+	// HasSelfServiceSoftwareInstallers returns whether the host has self-service software installers
+	HasSelfServiceSoftwareInstallers(ctx context.Context, host *Host) (bool, error)
+
 	// /////////////////////////////////////////////////////////////////////////////
 	// Vulnerabilities
 

--- a/server/mock/datastore_mock.go
+++ b/server/mock/datastore_mock.go
@@ -977,7 +977,7 @@ type CleanupUnusedSoftwareInstallersFunc func(ctx context.Context, softwareInsta
 
 type BatchSetSoftwareInstallersFunc func(ctx context.Context, tmID *uint, installers []*fleet.UploadSoftwareInstallerPayload) error
 
-type HasSelfServiceSoftwareInstallersFunc func(ctx context.Context, teamID *uint) (bool, error)
+type HasSelfServiceSoftwareInstallersFunc func(ctx context.Context, platform string, teamID *uint) (bool, error)
 
 type DataStore struct {
 	HealthCheckFunc        HealthCheckFunc
@@ -5776,9 +5776,9 @@ func (s *DataStore) BatchSetSoftwareInstallers(ctx context.Context, tmID *uint, 
 	return s.BatchSetSoftwareInstallersFunc(ctx, tmID, installers)
 }
 
-func (s *DataStore) HasSelfServiceSoftwareInstallers(ctx context.Context, teamID *uint) (bool, error) {
+func (s *DataStore) HasSelfServiceSoftwareInstallers(ctx context.Context, platform string, teamID *uint) (bool, error) {
 	s.mu.Lock()
 	s.HasSelfServiceSoftwareInstallersFuncInvoked = true
 	s.mu.Unlock()
-	return s.HasSelfServiceSoftwareInstallersFunc(ctx, teamID)
+	return s.HasSelfServiceSoftwareInstallersFunc(ctx, platform, teamID)
 }

--- a/server/mock/datastore_mock.go
+++ b/server/mock/datastore_mock.go
@@ -977,6 +977,8 @@ type CleanupUnusedSoftwareInstallersFunc func(ctx context.Context, softwareInsta
 
 type BatchSetSoftwareInstallersFunc func(ctx context.Context, tmID *uint, installers []*fleet.UploadSoftwareInstallerPayload) error
 
+type HasSelfServiceSoftwareInstallersFunc func(ctx context.Context, teamID *uint) (bool, error)
+
 type DataStore struct {
 	HealthCheckFunc        HealthCheckFunc
 	HealthCheckFuncInvoked bool
@@ -2414,6 +2416,9 @@ type DataStore struct {
 
 	BatchSetSoftwareInstallersFunc        BatchSetSoftwareInstallersFunc
 	BatchSetSoftwareInstallersFuncInvoked bool
+
+	HasSelfServiceSoftwareInstallersFunc        HasSelfServiceSoftwareInstallersFunc
+	HasSelfServiceSoftwareInstallersFuncInvoked bool
 
 	mu sync.Mutex
 }
@@ -5769,4 +5774,11 @@ func (s *DataStore) BatchSetSoftwareInstallers(ctx context.Context, tmID *uint, 
 	s.BatchSetSoftwareInstallersFuncInvoked = true
 	s.mu.Unlock()
 	return s.BatchSetSoftwareInstallersFunc(ctx, tmID, installers)
+}
+
+func (s *DataStore) HasSelfServiceSoftwareInstallers(ctx context.Context, teamID *uint) (bool, error) {
+	s.mu.Lock()
+	s.HasSelfServiceSoftwareInstallersFuncInvoked = true
+	s.mu.Unlock()
+	return s.HasSelfServiceSoftwareInstallersFunc(ctx, teamID)
 }

--- a/server/service/devices.go
+++ b/server/service/devices.go
@@ -110,6 +110,7 @@ func (r *getDeviceHostRequest) deviceAuthToken() string {
 
 type getDeviceHostResponse struct {
 	Host                      *HostDetailResponse      `json:"host"`
+	SelfService               bool                     `json:"self_service"`
 	OrgLogoURL                string                   `json:"org_logo_url"`
 	OrgLogoURLLightBackground string                   `json:"org_logo_url_light_background"`
 	OrgContactURL             string                   `json:"org_contact_url"`
@@ -178,6 +179,14 @@ func getDeviceHostEndpoint(ctx context.Context, request interface{}, svc fleet.S
 		}
 	}
 
+	hasSelfService := false
+	if softwareInventoryEnabled {
+		hasSelfService, err = svc.HasSelfServiceSoftwareInstallers(ctx, host)
+		if err != nil {
+			return getDeviceHostResponse{Err: err}, nil
+		}
+	}
+
 	deviceGlobalConfig := fleet.DeviceGlobalConfig{
 		MDM: fleet.DeviceGlobalMDMConfig{
 			// TODO(mna): It currently only returns the Apple enabled and configured,
@@ -196,6 +205,7 @@ func getDeviceHostEndpoint(ctx context.Context, request interface{}, svc fleet.S
 		OrgContactURL: ac.OrgInfo.ContactURL,
 		License:       *license,
 		GlobalConfig:  deviceGlobalConfig,
+		SelfService:   hasSelfService,
 	}, nil
 }
 

--- a/server/service/devices_test.go
+++ b/server/service/devices_test.go
@@ -270,9 +270,6 @@ func TestGetFleetDesktopSummary(t *testing.T) {
 			return &appCfg, nil
 		}
 
-		ds.IsHostConnectedToFleetMDMFunc = func(ctx context.Context, host *fleet.Host) (bool, error) {
-			return host.MDMInfo != nil && host.MDMInfo.Enrolled == true && host.MDMInfo.Name == fleet.WellKnownMDMFleet, nil
-		}
 		ds.HasSelfServiceSoftwareInstallersFunc = func(ctx context.Context, platform string, teamID *uint) (bool, error) {
 			return false, nil
 		}

--- a/server/service/devices_test.go
+++ b/server/service/devices_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/fleetdm/fleet/v4/server/mock"
 	"github.com/fleetdm/fleet/v4/server/ptr"
 	"github.com/fleetdm/fleet/v4/server/test"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -29,6 +30,11 @@ func TestGetFleetDesktopSummary(t *testing.T) {
 		svc, ctx := newTestService(t, ds, nil, nil, &TestServerOpts{License: license, SkipCreateTestUsers: true})
 		ds.FailingPoliciesCountFunc = func(ctx context.Context, host *fleet.Host) (uint, error) {
 			return uint(1), nil
+		}
+		const expectedPlatform = "darwin"
+		ds.HasSelfServiceSoftwareInstallersFunc = func(ctx context.Context, platform string, teamID *uint) (bool, error) {
+			assert.Equal(t, expectedPlatform, platform)
+			return true, nil
 		}
 
 		cases := []struct {
@@ -127,11 +133,13 @@ func TestGetFleetDesktopSummary(t *testing.T) {
 			ctx := test.HostContext(ctx, &fleet.Host{
 				OsqueryHostID:      ptr.String("test"),
 				DEPAssignedToFleet: &c.depAssigned,
+				Platform:           expectedPlatform,
 			})
 			sum, err := svc.GetFleetDesktopSummary(ctx)
 			require.NoError(t, err)
 			require.Equal(t, c.out, sum.Notifications, fmt.Sprintf("enabled_and_configured: %t | macos_migration.enable: %t", c.mdm.EnabledAndConfigured, c.mdm.MacOSMigration.Enable))
 			require.EqualValues(t, 1, *sum.FailingPolicies)
+			assert.Equal(t, ptr.Bool(true), sum.SelfService)
 		}
 
 	})
@@ -143,7 +151,9 @@ func TestGetFleetDesktopSummary(t *testing.T) {
 		ds.FailingPoliciesCountFunc = func(ctx context.Context, host *fleet.Host) (uint, error) {
 			return uint(1), nil
 		}
-
+		ds.HasSelfServiceSoftwareInstallersFunc = func(ctx context.Context, platform string, teamID *uint) (bool, error) {
+			return true, nil
+		}
 		cases := []struct {
 			mdm         fleet.MDM
 			depAssigned bool
@@ -258,6 +268,13 @@ func TestGetFleetDesktopSummary(t *testing.T) {
 			appCfg.MDM.EnabledAndConfigured = true
 			appCfg.MDM.MacOSMigration.Enable = true
 			return &appCfg, nil
+		}
+
+		ds.IsHostConnectedToFleetMDMFunc = func(ctx context.Context, host *fleet.Host) (bool, error) {
+			return host.MDMInfo != nil && host.MDMInfo.Enrolled == true && host.MDMInfo.Name == fleet.WellKnownMDMFleet, nil
+		}
+		ds.HasSelfServiceSoftwareInstallersFunc = func(ctx context.Context, platform string, teamID *uint) (bool, error) {
+			return false, nil
 		}
 
 		cases := []struct {


### PR DESCRIPTION
#19651 
Hide "Self-service" in Fleet Desktop and My device page if there is no self-service software available

# Checklist for submitter

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [x] Added/updated tests
- [x] Manual QA for all new/changed functionality
  - For Orbit and Fleet Desktop changes:
    - [x] Manual QA must be performed in the three main OSs, macOS, Windows and Linux.
    - [x] Auto-update manual QA, from released version of component to new version (see [tools/tuf/test](../tools/tuf/test/README.md)).
