### PR TITLE
Fleet UI: Update delete secret copy

### DIFF
--- a/changes/18239-delete-secret-copy
+++ b/changes/18239-delete-secret-copy
@@ -1,0 +1,1 @@
+* Update UI's delete secret link

--- a/frontend/components/EnrollSecrets/DeleteSecretModal/DeleteSecretModal.tsx
+++ b/frontend/components/EnrollSecrets/DeleteSecretModal/DeleteSecretModal.tsx
@@ -41,28 +41,14 @@ const DeleteSecretModal = ({
     >
       <div className={baseClass}>
         <div className={`${baseClass}__description`}>
+          <p>Hosts can no longer enroll using this secret.</p>
           <p>
-            This action will delete the secret used to enroll hosts to{" "}
-            <b>{renderTeam()?.name}</b>.
-          </p>
-          <p>
-            Any hosts that attempt to enroll to Fleet using this secret will be
-            unable to enroll.
-          </p>
-          <p>
-            Hosts that enrolled with this secret will not get updates to agent
-            options.
-          </p>
-          <p>
-            Follow this guide to{" "}
             <CustomLink
-              url="https://fleetdm.com/docs/using-fleet/configuration-files#rotate-enroll-secrets"
-              text="rotate enroll secrets"
+              url="https://fleetdm.com/learn-more-about/rotating-enroll-secrets"
+              text="Learn about rotating enroll secrets"
               newTab
             />
-            .
           </p>
-          <p>You cannot undo this action.</p>
         </div>
         <div className="modal-cta-wrap">
           <Button


### PR DESCRIPTION
## Issue
Cerra #18239 

## Description
- Update copy and link for delete secret modal

## Screenshot
<img width="1099" alt="Screenshot 2024-06-27 at 10 15 00 AM" src="https://github.com/fleetdm/fleet/assets/71795832/06c82073-2be0-4d57-a75f-ac4fd71013d9">


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [x] Manual QA for all new/changed functionality

