### PR TITLE
Add requirement for multiple product group PR reviews on some code paths

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -38,8 +38,20 @@
 *.go @fleetdm/go
 go.sum @fleetdm/go
 go.mod @fleetdm/go
-/server/ @fleetdm/go
 /cmd/ @fleetdm/go
+/orbit/ @lucasmrod @getvictor @roperzh @gillespi314
+/server/ @fleetdm/go
+/server/service/handler.go @lucasmrod @getvictor @roperzh @gillespi314
+/server/mdm/ @roperzh @gillespi314
+/server/worker/ @lucasmrod @getvictor @roperzh @gillespi314
+/server/vulnerabilities/ @lucasmrod @mostlikelee
+/server/cron/ @getvictor @lucasmrod
+/ee/fleetd-chrome @lucasmrod @getvictor
+/ee/vulnerability-dashboard @eashaw
+/ee/cis @sharon-fdm @lucasmrod
+/ee/server/calender @lucasmrod @getvictor
+/ee/server/service @roperzh @gillespi314 @lucasmrod @getvictor
+/scripts/mdm @roperzh @gillespi314
 
 ##############################################################################################
 # 🚀 React files and other files related to the core product frontend.

--- a/handbook/engineering/README.md
+++ b/handbook/engineering/README.md
@@ -281,6 +281,13 @@ Check the "📃 Planned articles" column in [#g-demand board](https://app.zenhub
     - [Sharpie Fine Point Markers](https://www.everythingbranded.com/product/sharpie-fine-point-332908)
     - [Custom sticky note pads](https://www.everythingbranded.com/product/custom-sticky-notes-585601) (design is in the StickerMule [brand kit](https://www.stickermule.com/studio/brand-kits))
 
+### Review another product group's pull request
+Some code paths require pull request review from multiple product groups to confirm there are no
+unintended side effects of the change for another product group. All code paths defined in
+[CODEOWNERS](https://github.com/fleetdm/fleet/blob/main/CODEOWNERS) that are assigned to individual
+engineers across multiple product groups must be approved by one engineer from each product group
+before merging.
+
 ### Review a community pull request
 If you're assigned a community pull request for review, it is important to keep things moving for the contributor. The goal is to not go more than one business day without following up with the contributor.
 


### PR DESCRIPTION
For https://github.com/fleetdm/fleet/issues/19183

I'm adding everyone as reviewers that is being added to codeowners for visibility. 

Trying to keep it light and just cover the primary folders or files we would want PR reviews across product groups. This is my best guess, so please feel free to suggest changes. 