### PR TITLE
Docs: Update broken link in REST API documentation

### DIFF
--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -60,7 +60,7 @@ Authenticates the user with the specified credentials. Use the token returned fr
 
 #### Parameters
 
-| Name     | Type   | In   | Description                                   |
+| Name     | Type   | In   | Deion                                   |
 | -------- | ------ | ---- | --------------------------------------------- |
 | email    | string | body | **Required**. The user's email.               |
 | password | string | body | **Required**. The user's plain text password. |
@@ -7721,7 +7721,7 @@ This allows you to easily configure scheduled queries that will impact a whole t
 - [Delete script](#delete-script)
 - [List scripts](#list-scripts)
 - [Get or download script](#get-or-download-script)
-- [Get script details by host](#get-script-details-by-host)
+- [Get script details by host](#get-hosts-scripts)
 
 ### Run script
 

--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -60,7 +60,7 @@ Authenticates the user with the specified credentials. Use the token returned fr
 
 #### Parameters
 
-| Name     | Type   | In   | Deion                                   |
+| Name     | Type   | In   | Description                                   |
 | -------- | ------ | ---- | --------------------------------------------- |
 | email    | string | body | **Required**. The user's email.               |
 | password | string | body | **Required**. The user's plain text password. |


### PR DESCRIPTION
Closes: https://github.com/fleetdm/fleet/issues/20041

Changes:
- Updated a link to a moved section in the scripts section of the REST API documentation
