### PR TITLE
Fleet UI: Team admin/maintainer access to edit in new policy flow

### DIFF
--- a/frontend/pages/policies/PolicyPage/components/PolicyForm/PolicyForm.tsx
+++ b/frontend/pages/policies/PolicyPage/components/PolicyForm/PolicyForm.tsx
@@ -690,10 +690,12 @@ const PolicyForm = ({
     return <Spinner />;
   }
 
+  const isInheritedPolicy = !!policyIdForEdit && storedPolicy?.team_id === null;
+
   const noEditPermissions =
     isTeamObserver ||
     isGlobalObserver ||
-    (!isOnGlobalTeam && policyTeamId === null); // Team user viewing inherited policy
+    (!isOnGlobalTeam && isInheritedPolicy); // Team user viewing inherited policy
 
   // Render non-editable form only
   if (noEditPermissions) {

--- a/frontend/pages/policies/PolicyPage/components/PolicyForm/PolicyForm.tsx
+++ b/frontend/pages/policies/PolicyPage/components/PolicyForm/PolicyForm.tsx
@@ -693,7 +693,7 @@ const PolicyForm = ({
   const noEditPermissions =
     isTeamObserver ||
     isGlobalObserver ||
-    (!isOnGlobalTeam && policyTeamId !== storedPolicy?.team_id); // Team user viewing inherited policy
+    (!isOnGlobalTeam && policyTeamId === null); // Team user viewing inherited policy
 
   // Render non-editable form only
   if (noEditPermissions) {


### PR DESCRIPTION
## Issue
Continuation of #19996 

## Description
- Logic was restricting team admin/maintainer from editing new policies instead of just restricting inherited policies

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

-  Test in QA Wolf
- [x] Manual QA for all new/changed functionality

