### PR TITLE
Fleet UI: Reinstate sort policies by passing count

### DIFF
--- a/changes/20056-sort-policy-bug
+++ b/changes/20056-sort-policy-bug
@@ -1,0 +1,1 @@
+* UI: Reinstate ability to sort policies by passing count

--- a/frontend/pages/policies/ManagePoliciesPage/components/PassingColumnHeader/PassingColumnHeader.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/components/PassingColumnHeader/PassingColumnHeader.tsx
@@ -22,7 +22,14 @@ const PassingColumnHeader = ({
   return (
     <div className={baseClass}>
       <Icon name={iconName} />
-      <TooltipWrapper tipContent={<>{updateText} Counts are updated hourly.</>}>
+      <TooltipWrapper
+        tipContent={
+          <>
+            {updateText}
+            <br /> Counts are updated hourly.
+          </>
+        }
+      >
         <span className="status-header-text">{columnText}</span>
       </TooltipWrapper>
     </div>

--- a/frontend/pages/policies/ManagePoliciesPage/components/PoliciesTable/PoliciesTableConfig.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/components/PoliciesTable/PoliciesTableConfig.tsx
@@ -167,13 +167,17 @@ const generateTableHeaders = (
     },
     {
       title: "Yes",
-      Header: () => (
-        <PassingColumnHeader
-          isPassing
-          timeSinceHostCountUpdate={timeSinceHostCountUpdate}
+      Header: (cellProps) => (
+        <HeaderCell
+          value={
+            <PassingColumnHeader
+              isPassing
+              timeSinceHostCountUpdate={timeSinceHostCountUpdate}
+            />
+          }
+          isSortedDesc={cellProps.column.isSortedDesc}
         />
       ),
-      disableSortBy: true,
       accessor: "passing_host_count",
       Cell: (cellProps: ICellProps): JSX.Element => {
         if (cellProps.row.original.has_run) {


### PR DESCRIPTION
## Issue
Cerra #20056 

## Description
- Allows Policy table to be sorted by yes count
- Styling nit: Update tooltip to break lines prettier.

## Screenshot 
BEFORE
<img width="535" alt="Screenshot 2024-06-27 at 2 45 01 PM" src="https://github.com/fleetdm/fleet/assets/71795832/6899caf9-dc6c-469b-8235-4548dbf895a6">
AFTER
<img width="358" alt="Screenshot 2024-06-27 at 2 40 37 PM" src="https://github.com/fleetdm/fleet/assets/71795832/1e5eb262-7d9a-4adf-91cb-3f7bf939066d">


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [ ] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [ ] Added support on fleet's osquery simulator `cmd/osquery-perf` for new osquery data ingestion features.
- [ ] Added/updated tests
- [ ] If database migrations are included, checked table schema to confirm autoupdate
- For database migrations:
  - [ ] Checked schema for all modified table for columns that will auto-update timestamps during migration.
  - [ ] Confirmed that updating the timestamps is acceptable, and will not cause unwanted side effects.
  - [ ] Ensured the correct collation is explicitly set for character columns (`COLLATE utf8mb4_unicode_ci`).
- [x] Manual QA for all new/changed functionality
  - For Orbit and Fleet Desktop changes:
    - [ ] Manual QA must be performed in the three main OSs, macOS, Windows and Linux.
    - [ ] Auto-update manual QA, from released version of component to new version (see [tools/tuf/test](../tools/tuf/test/README.md)).
