### PR TITLE
Hide `Run script` option from Observer/+s

### DIFF
--- a/changes/19055-hide-run-script
+++ b/changes/19055-hide-run-script
@@ -1,0 +1,1 @@
+* Hide the host detail page's "Run script" action from Global and Team Observer/+s.

--- a/frontend/pages/hosts/details/HostDetailsPage/HostActionsDropdown/HostActionsDropdown.tests.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/HostActionsDropdown/HostActionsDropdown.tests.tsx
@@ -1137,6 +1137,60 @@ describe("Host Actions Dropdown", () => {
 
       expect(screen.queryByText("Run script")).not.toBeInTheDocument();
     });
+    it("does not render the Run script action for global observers/+", async () => {
+      // Global observer
+      const render = createCustomRenderer({
+        context: {
+          app: {
+            isGlobalObserver: true,
+            currentUser: createMockUser(),
+          },
+        },
+      });
+      const { user } = render(
+        <HostActionsDropdown
+          hostTeamId={null}
+          onSelect={noop}
+          hostStatus="offline"
+          isConnectedToFleetMdm
+          hostPlatform="windows"
+          hostMdmEnrollmentStatus={null}
+          hostMdmDeviceStatus="unlocked"
+          hostScriptsEnabled
+        />
+      );
+
+      await user.click(screen.getByText("Actions"));
+
+      expect(screen.queryByText("Run script")).not.toBeInTheDocument();
+    });
+    it("does not render the Run script action for team observers/+", async () => {
+      // team observer
+      const render = createCustomRenderer({
+        context: {
+          app: {
+            isTeamObserver: true,
+            currentUser: createMockUser(),
+          },
+        },
+      });
+      const { user } = render(
+        <HostActionsDropdown
+          hostTeamId={1}
+          onSelect={noop}
+          hostStatus="offline"
+          isConnectedToFleetMdm
+          hostPlatform="windows"
+          hostMdmEnrollmentStatus={null}
+          hostMdmDeviceStatus="unlocked"
+          hostScriptsEnabled
+        />
+      );
+
+      await user.click(screen.getByText("Actions"));
+
+      expect(screen.queryByText("Run script")).not.toBeInTheDocument();
+    });
   });
 
   describe("Render options only available for iOS and iPadOS", () => {

--- a/frontend/pages/hosts/details/HostDetailsPage/HostActionsDropdown/helpers.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/HostActionsDropdown/helpers.tsx
@@ -226,18 +226,11 @@ const canRunScript = ({
   hostPlatform,
   isGlobalAdmin,
   isGlobalMaintainer,
-  isGlobalObserver,
   isTeamAdmin,
   isTeamMaintainer,
-  isTeamObserver,
 }: IHostActionConfigOptions) => {
   return (
-    (isGlobalAdmin ||
-      isGlobalMaintainer ||
-      isGlobalObserver ||
-      isTeamAdmin ||
-      isTeamMaintainer ||
-      isTeamObserver) &&
+    (isGlobalAdmin || isGlobalMaintainer || isTeamAdmin || isTeamMaintainer) &&
     isScriptSupportedPlatform(hostPlatform)
   );
 };


### PR DESCRIPTION
## Addresses #19055 

<img width="508" alt="Screenshot 2024-06-27 at 11 42 12 AM" src="https://github.com/fleetdm/fleet/assets/61553566/e85fe3f4-bef5-4694-9371-dfe441772789">
<img width="508" alt="Screenshot 2024-06-27 at 11 42 40 AM" src="https://github.com/fleetdm/fleet/assets/61553566/6124f0cf-bcff-4b76-96c1-cf2ad49175d2">
<img width="508" alt="Screenshot 2024-06-27 at 11 39 36 AM" src="https://github.com/fleetdm/fleet/assets/61553566/c5863278-def1-4739-bba8-9f88acd1ddce">
<img width="508" alt="Screenshot 2024-06-27 at 11 40 16 AM" src="https://github.com/fleetdm/fleet/assets/61553566/ad3b9806-8435-49a7-9bea-89f8ab5aa81e">
<img width="508" alt="Screenshot 2024-06-27 at 11 40 42 AM" src="https://github.com/fleetdm/fleet/assets/61553566/855b7802-545f-4d3c-aabb-a4002912ee8f">

- [x] Changes file added for user-visible changes in `changes/`
- [x] Added/updated tests
- [x] Manual QA for all new/changed functionality