### PR TITLE
Fleet UI: Fix errors font size

### DIFF
--- a/frontend/pages/policies/PolicyPage/components/PolicyResults/_styles.scss
+++ b/frontend/pages/policies/PolicyPage/components/PolicyResults/_styles.scss
@@ -33,9 +33,6 @@
     justify-content: space-between;
     align-items: center;
     margin-top: $pad-xlarge;
-  }
-
-  &__results-meta > * {
     font-size: $x-small;
   }
 


### PR DESCRIPTION
## Issue
Cerra #20053 

## Description
- Fix font size from rendering default 1.25 REM

## Screenshot of fix
<img width="990" alt="Screenshot 2024-06-27 at 3 21 35 PM" src="https://github.com/fleetdm/fleet/assets/71795832/460e982e-698e-43a9-a86f-e192a7433476">


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->


- [x] Manual QA for all new/changed functionality