### PR TITLE
Switch to one planned patch per sprint

### DIFF
--- a/docs/Contributing/Releasing-Fleet.md
+++ b/docs/Contributing/Releasing-Fleet.md
@@ -1,5 +1,5 @@
 # Releasing Fleet
 
-This section outlines the release process at Fleet. The current release cadence is one minor and two patch releases every three weeks.
+This section outlines the release process at Fleet. The current release cadence is one minor and one patch release every three weeks.
 
 All Fleet releases are completed using the [Fleet releaser script](https://github.com/fleetdm/fleet/blob/main/tools/release/README.md).


### PR DESCRIPTION
@georgekarrv will be the DRI for scheduled patch releases with @sharon-fdm as backup. DRI for unscheduled patch release is @georgekarrv or @sharon-fdm depending on which product group is driving the patch.

Why? 

- Part of effort to improve quality and publish releases on time.
- Every release has to go through smoke testing, which takes 2-4 hours. That's time that could go into QA'ing the next minor release instead.
- If the first planned patch is late, we often don't issue a second patch. When we do, it's typically light with no high priority bug fixes.
- If there is urgent need, we can still issue a second patch as needed, we just won't plan on it.