### PR TITLE
Fleet docs: Update config > features documentation

### DIFF
--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -873,6 +873,8 @@ None.
     "activity_expiry_window": 0
   },
   "features": {
+    "enable_host_users": true,
+    "enable_software_inventory": true,
     "additional_queries": null
   },
   "mdm": {
@@ -1142,7 +1144,9 @@ Modifies the Fleet's configuration with the supplied information.
 | custom_settings                   | list    | body  | _mdm.windows_settings settings_. Windows hosts that belong to no team, and are members of specified labels will have custom profiles applied. |
 | scripts                           | list    | body  | A list of script files to add so they can be executed at a later time.                                                                                                                                                 |
 | enable_end_user_authentication            | boolean | body  | _mdm.macos_setup settings_. If set to true, end user authentication will be required during automatic MDM enrollment of new macOS devices. Settings for your IdP provider must also be [configured](https://fleetdm.com/docs/using-fleet/mdm-macos-setup-experience#end-user-authentication-and-eula). **Requires Fleet Premium license** |
-| additional_queries                | boolean | body  | Whether or not additional queries are enabled on hosts.                                                                                                                                |
+| enable_host_users                 | boolean | body  | _Features_ Determines enabling the users feature in Fleet. Default: true                                                                               |
+| enable_software_inventory         | boolean | body  | _Features_ Determines enabling the software inventory feature in Fleet. Default: true                                                                               |
+| additional_queries                | boolean | body  | _Features_ Determines whether additional queries are enabled on hosts. Default: null                                                                               |
 | force                             | bool    | query | Force apply the agent options even if there are validation errors.                                                                                                 |
 | dry_run                           | bool    | query | Validate the configuration and return any validation errors, but do not apply the changes.                                                                         |
 
@@ -1220,6 +1224,8 @@ Note that when making changes to the `integrations` object, all integrations mus
     "activity_expiry_window": 0
   },
   "features": {
+    "enable_host_users": true,
+    "enable_software_inventory": true,
     "additional_queries": null
   },
   "license": {


### PR DESCRIPTION
## Issue
Part of #18176 

## Description
The enable_software_inventory and enable_host_users parameters can be modified using PATCH /config but are not on the docs.

 Adds `enable_software_inventory` and `enable_host_users` keys to:
  - GET config doc > Example response: 
  - PATCH config doc > Parameters table: Add `enable_software_inventory` and `enable_host_users` keys
  - PATCH config doc > Example response: Add `enable_software_inventory` and `enable_host_users` keys

## TODO
- I was able to modify `additional_queries` boolean, however, the documentation for setting the additional queries to run is unclear and needs followup. I plan on asking @mna next week.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->