### PR TITLE
Updated docs to point to https://download.fleetdm.com/stable

### DIFF
--- a/articles/config-less-fleetd-agent-deployment.md
+++ b/articles/config-less-fleetd-agent-deployment.md
@@ -64,7 +64,7 @@ fleetctl package --type=pkg --use-system-configuration --fleet-desktop
 
 ## For Windows:
 
-1. Download the Base MSI installer from [https://download.fleetdm.com/fleetd-base.msi](https://download.fleetdm.com/fleetd-base.msi) (once installed, `fleetd` and `fleet-desktop` will be upgraded to the latest)
+1. Download the Base MSI installer from [https://download.fleetdm.com/stable/fleetd-base.msi](https://download.fleetdm.com/stable/fleetd-base.msi) (once installed, `fleetd` and `fleet-desktop` will be upgraded to the latest)
 
 2. Install fleet on Windows boxes by passing the `FLEET_URL` and `FLEET_SECRET` properties to the MSI installer:
 


### PR DESCRIPTION
#19182 
Updated docs to point to https://download.fleetdm.com/stable

The files at the root (https://download.fleetdm.com/fleetd-base.pkg and https://download.fleetdm.com/fleetd-base.msi) will no longer be updated.

