### PR TITLE
Website: Update logic deciding when to create issue for monthly rituals.

### DIFF
--- a/website/scripts/create-issues-for-todays-rituals.js
+++ b/website/scripts/create-issues-for-todays-rituals.js
@@ -34,7 +34,7 @@ module.exports = {
           continue;
         }
         let isItTimeToCreateANewIssue = false;// Default this value to false.
-
+        let nextIssueShouldBeCreatedAt;
         let ritualsFrequencyInMs = 0;
 
         if(_.startsWith(ritual.frequency, 'Daily')){// Using _.startsWith() to handle frequencies with emoji ("Daily ⏰") and with out ("Daily")
@@ -46,35 +46,52 @@ module.exports = {
         } else if(ritual.frequency === 'Triweekly'){
           ritualsFrequencyInMs = 1000 * 60 * 60 * 24 * 7 * 3;
         } else if (ritual.frequency === 'Monthly') {
-          // For monthly rituals, we will get the number of days in the previous month, and create a timestamp of the next time this ritual should be run.
+          // For monthly rituals, we will create issues on the day of the month that the ritual was started on, or the last day of the month if the ritual was started on a day that doesn't exist in the current month
+          // (e.g, the next issue for a monthly ritual started on 2024-01-31 would be created for on 2024-02-29)
           let todaysDate = new Date();
-          let numberOfDaysInLastMonth = new Date(todaysDate.getFullYear(), todaysDate.getMonth(), 0).getDate();
-          ritualsFrequencyInMs = 1000 * 60 * 60 * 24 * numberOfDaysInLastMonth;
+          let ritualStartedOn = new Date(ritual.startedOn);
+          // Get the day in the month that we'll create the issue for this ritual on.
+          let dayToCreateIssueOn = ritualStartedOn.getUTCDate();
+          // Get the number of days in the current month.
+          let numberOfDaysInThisMonth = new Date(todaysDate.getFullYear(), todaysDate.getMonth() + 1, 0).getUTCDate();
+          if(dayToCreateIssueOn === todaysDate.getUTCDate()){
+            // If this is the day of the month this ritual was started on, create an issue.
+            isItTimeToCreateANewIssue = true;
+          } else if(numberOfDaysInThisMonth < dayToCreateIssueOn && numberOfDaysInThisMonth === todaysDate.getUTCDate()){
+            // If this ritual was started on a date that does not exist in the current month, and this is the last day of the month, create an issue.
+            isItTimeToCreateANewIssue = true;
+          }
+          nextIssueShouldBeCreatedAt = new Date(todaysDate.getFullYear(), todaysDate.getMonth() + 1, dayToCreateIssueOn);
+          ritualsFrequencyInMs = 1000 * 60 * 60 * 24 * numberOfDaysInThisMonth;
         }
-        // Get a JS timestamp representing 12 PM UTC of the day this script is running.
-        let twelveHoursInMs = 1000 * 60 * 60 * 12;
-        let today = new Date();
-        let lastUTCNoonAt = new Date(Date.UTC(today.getUTCFullYear(), today.getUTCMonth(), today.getUTCDate(), 12, 0, 0, 0)).getTime();
+        // Determine if we should create an issue for non-monthly rituals.
+        if(ritual.frequency !== 'Monthly') {
+          // Get a JS timestamp representing 12 PM UTC of the day this script is running.
+          let twelveHoursInMs = 1000 * 60 * 60 * 12;
+          let today = new Date();
+          let lastUTCNoonAt = new Date(Date.UTC(today.getUTCFullYear(), today.getUTCMonth(), today.getUTCDate(), 12, 0, 0, 0)).getTime();
 
-        // Get a JS timestamp representing 12:00 PM UTC of the day this ritual started.
-        let ritualStartedAt = new Date(ritual.startedOn).getTime() + twelveHoursInMs;
-        // Find out how many times this ritual has occurred.
-        let howManyRitualsCycles = (lastUTCNoonAt - ritualStartedAt ) / ritualsFrequencyInMs;
-        // Find out when the next issue will be created at
-        let nextIssueShouldBeCreatedAt = ritualStartedAt + ((Math.floor(howManyRitualsCycles) + 1) * ritualsFrequencyInMs);
-        // Get the amount of this ritual's cycle remaining.
-        let amountOfCycleRemainingTillNextRitual = (Math.floor(howManyRitualsCycles) - howManyRitualsCycles) + 1;
-        // Get the number of milliseconds until the next issue for this ritual will be created.
-        let timeToNextRitualInMs = amountOfCycleRemainingTillNextRitual * ritualsFrequencyInMs;
-        if(_.startsWith(ritual.frequency, 'Daily')) {// Using _.startsWith() to handle frequencies with emoji ("Daily ⏰") and with out ("Daily")
-          // Since this script runs once a day, we'll always create issues for daily rituals.
-          isItTimeToCreateANewIssue = true;
-        } else if(timeToNextRitualInMs === ritualsFrequencyInMs) {
-          // For any other frequency, we'll check to see if the calculated timeToNextRitualInMs is the same as the rituals frequency.
-          isItTimeToCreateANewIssue = true;
+          // Get a JS timestamp representing 12:00 PM UTC of the day this ritual started.
+          let ritualStartedAt = new Date(ritual.startedOn).getTime() + twelveHoursInMs;
+          // Find out how many times this ritual has occurred.
+          let howManyRitualsCycles = (lastUTCNoonAt - ritualStartedAt ) / ritualsFrequencyInMs;
+          // Find out when the next issue will be created at
+          nextIssueShouldBeCreatedAt = ritualStartedAt + ((Math.floor(howManyRitualsCycles) + 1) * ritualsFrequencyInMs);
+          // Get the amount of this ritual's cycle remaining.
+          let amountOfCycleRemainingTillNextRitual = (Math.floor(howManyRitualsCycles) - howManyRitualsCycles) + 1;
+          // Get the number of milliseconds until the next issue for this ritual will be created.
+          let timeToNextRitualInMs = amountOfCycleRemainingTillNextRitual * ritualsFrequencyInMs;
+
+          if(_.startsWith(ritual.frequency, 'Daily')) {// Using _.startsWith() to handle frequencies with emoji ("Daily ⏰") and with out ("Daily")
+            // Since this script runs once a day, we'll always create issues for daily rituals.
+            isItTimeToCreateANewIssue = true;
+          } else if(timeToNextRitualInMs === ritualsFrequencyInMs) {
+            // For weekly, biweekly, and triweekly frequencies, we'll check to see if the calculated timeToNextRitualInMs is the same as the rituals frequency.
+            isItTimeToCreateANewIssue = true;
+          }
         }
         // Skip to the next ritual if it isn't time yet.
-        if (!isItTimeToCreateANewIssue) {
+        if(!isItTimeToCreateANewIssue) {
           sails.log.verbose(`Next issue for ${ritual.task} (${ritual.autoIssue.labels.join(',')}) will be created on ${new Date(nextIssueShouldBeCreatedAt)} (Started on: ${ritual.startedOn}, frequency: ${ritual.frequency})`);
           continue;
         }

--- a/website/scripts/create-issues-for-todays-rituals.js
+++ b/website/scripts/create-issues-for-todays-rituals.js
@@ -36,6 +36,7 @@ module.exports = {
         let isItTimeToCreateANewIssue = false;// Default this value to false.
         let nextIssueShouldBeCreatedAt;
         let ritualsFrequencyInMs = 0;
+        let now = new Date();
 
         if(_.startsWith(ritual.frequency, 'Daily')){// Using _.startsWith() to handle frequencies with emoji ("Daily ⏰") and with out ("Daily")
           ritualsFrequencyInMs = 1000 * 60 * 60 * 24;
@@ -48,20 +49,19 @@ module.exports = {
         } else if (ritual.frequency === 'Monthly') {
           // For monthly rituals, we will create issues on the day of the month that the ritual was started on, or the last day of the month if the ritual was started on a day that doesn't exist in the current month
           // (e.g, the next issue for a monthly ritual started on 2024-01-31 would be created for on 2024-02-29)
-          let todaysDate = new Date();
           let ritualStartedOn = new Date(ritual.startedOn);
           // Get the day in the month that we'll create the issue for this ritual on.
           let dayToCreateIssueOn = ritualStartedOn.getUTCDate();
           // Get the number of days in the current month.
-          let numberOfDaysInThisMonth = new Date(todaysDate.getFullYear(), todaysDate.getMonth() + 1, 0).getUTCDate();
-          if(dayToCreateIssueOn === todaysDate.getUTCDate()){
+          let numberOfDaysInThisMonth = new Date(now.getFullYear(), now.getMonth() + 1, 0).getUTCDate();
+          if(dayToCreateIssueOn === now.getUTCDate()){
             // If this is the day of the month this ritual was started on, create an issue.
             isItTimeToCreateANewIssue = true;
-          } else if(numberOfDaysInThisMonth < dayToCreateIssueOn && numberOfDaysInThisMonth === todaysDate.getUTCDate()){
+          } else if(numberOfDaysInThisMonth < dayToCreateIssueOn && numberOfDaysInThisMonth === now.getUTCDate()){
             // If this ritual was started on a date that does not exist in the current month, and this is the last day of the month, create an issue.
             isItTimeToCreateANewIssue = true;
           }
-          nextIssueShouldBeCreatedAt = new Date(todaysDate.getFullYear(), todaysDate.getMonth() + 1, dayToCreateIssueOn);
+          nextIssueShouldBeCreatedAt = new Date(now.getFullYear(), now.getMonth() + 1, dayToCreateIssueOn);
           ritualsFrequencyInMs = 1000 * 60 * 60 * 24 * numberOfDaysInThisMonth;
         }//ﬁ
 
@@ -69,8 +69,7 @@ module.exports = {
         if(ritual.frequency !== 'Monthly') {
           // Get a JS timestamp representing 12 PM UTC of the day this script is running.
           let twelveHoursInMs = 1000 * 60 * 60 * 12;
-          let today = new Date();
-          let lastUTCNoonAt = new Date(Date.UTC(today.getUTCFullYear(), today.getUTCMonth(), today.getUTCDate(), 12, 0, 0, 0)).getTime();
+          let lastUTCNoonAt = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate(), 12, 0, 0, 0)).getTime();
 
           // Get a JS timestamp representing 12:00 PM UTC of the day this ritual started.
           let ritualStartedAt = new Date(ritual.startedOn).getTime() + twelveHoursInMs;

--- a/website/scripts/create-issues-for-todays-rituals.js
+++ b/website/scripts/create-issues-for-todays-rituals.js
@@ -63,7 +63,8 @@ module.exports = {
           }
           nextIssueShouldBeCreatedAt = new Date(todaysDate.getFullYear(), todaysDate.getMonth() + 1, dayToCreateIssueOn);
           ritualsFrequencyInMs = 1000 * 60 * 60 * 24 * numberOfDaysInThisMonth;
-        }
+        }//ﬁ
+
         // Determine if we should create an issue for non-monthly rituals.
         if(ritual.frequency !== 'Monthly') {
           // Get a JS timestamp representing 12 PM UTC of the day this script is running.
@@ -89,7 +90,8 @@ module.exports = {
             // For weekly, biweekly, and triweekly frequencies, we'll check to see if the calculated timeToNextRitualInMs is the same as the rituals frequency.
             isItTimeToCreateANewIssue = true;
           }
-        }
+        }//ﬁ
+
         // Skip to the next ritual if it isn't time yet.
         if(!isItTimeToCreateANewIssue) {
           sails.log.verbose(`Next issue for ${ritual.task} (${ritual.autoIssue.labels.join(',')}) will be created on ${new Date(nextIssueShouldBeCreatedAt)} (Started on: ${ritual.startedOn}, frequency: ${ritual.frequency})`);


### PR DESCRIPTION
Closes: https://github.com/fleetdm/confidential/issues/7106

Changes:
- Updated the auto-issue logic for monthly rituals to create issues for rituals on the day of the month the ritual was started and to create issues on the last day of the month if the ritual was started on a day that does not exist in the current month.