### PR TITLE
Website: Update MDM section on homepage, move zero trust section to endpoint ops page

### DIFF
--- a/website/views/pages/device-management.ejs
+++ b/website/views/pages/device-management.ejs
@@ -130,36 +130,6 @@
         </div>
 
       </div>
-      <%/* Implement “zero trust” faster section */%>
-      <div purpose="page-section">
-        <div purpose="feature-headline" style="max-width: 580px;">
-          <h2>“Zero” trust, fewer tickets</h2>
-          <p>You can use Fleet’s API to customize every aspect of conditional access – even the stuff your CISO hasn’t thought of yet.</p>
-        </div>
-
-        <div purpose="three-column-features" class="mx-auto">
-          <div purpose="feature-row" class="d-flex flex-md-row flex-column align-items-md-start align-items-center justify-content-center">
-
-            <div purpose="feature-column" class="ml-md-0">
-              <img alt="Get in front of the IdP" src="/images/device-management-icon-control-login-experience-48x48@2x.png" class="mx-auto mx-sm-0">
-              <h5>Get in front of the IdP</h5>
-              <p>Gate access with <a href="https://fleetdm.com/queries">common device trust policies</a> from industry peers, or roll out your own device health checks using system data and events.</p>
-            </div>
-
-            <div purpose="feature-column">
-              <img alt="Step-by-step instructions" src="/images/device-management-icon-step-by-step-48x48@2x.png">
-              <h5>Step-by-step instructions</h5>
-              <p>Show resolution steps or use <a href="https://medium.com/pinterest-engineering/enforcing-device-authn-compliance-at-pinterest-a74938cb089b" target="_blank">custom HTML</a> to show employees what they need to do to restore their access without waiting on a ticket. Then give it back automatically, as soon as the problems are fixed.</p>
-            </div>
-
-            <div purpose="feature-column" class="mr-md-0 mb-0">
-              <img alt="Manage device posture" src="/images/device-management-icon-manage-device-posture-48x48@2x.png">
-              <h5>Live retry</h5>
-              <p>Give people a way to get back to work quickly and minimize downtime. Fleet’s live query API instantly re-checks the OS version and other device state so users don’t get locked out.</p>
-            </div>
-          </div>
-        </div>
-      </div>
       <div purpose="page-section">
         <div purpose="feature" class="d-flex flex-md-row flex-column-reverse justify-content-between mx-auto align-items-center">
           <div purpose="feature-text" class="d-flex flex-column">

--- a/website/views/pages/endpoint-ops.ejs
+++ b/website/views/pages/endpoint-ops.ejs
@@ -171,9 +171,9 @@
         </div>
 
         <div purpose="feature-item">
-          <img alt="Get in front of the IdP" src="/images/icon-automatic-posture-assessment-48x48@2x.png" class="mx-auto mx-sm-0">
-          <h5>Get in front of the IdP</h5>
-          <p>Gate access with <a href="/queries">common device trust policies</a> from industry peers, or roll out your own device health checks using system data and events.</p>
+          <img alt="Verify updates and settings" src="/images/icon-edr-health-check-48x48@2x.png" class="mx-auto mx-sm-0">
+          <h5>EDR health checks</h5>
+          <p>Verify that your EDR tools are installed and working so you can identify and address configuration issues quickly.</p>
         </div>
 
         <div purpose="feature-item" class="mr-sm-0 mb-0">
@@ -181,15 +181,6 @@
           <h5>Verify updates and settings</h5>
           <p>Track progress towards deadlines for security posture remediation projects, and enforce due dates through automations.</p>
         </div>
-      </div>
-      <div purpose="feature-row" class="d-flex flex-sm-row flex-column align-items-sm-start align-items-center">
-        <div purpose="feature-item" class="ml-sm-0 mb-0">
-          <img alt="Verify updates and settings" src="/images/icon-edr-health-check-48x48@2x.png" class="mx-auto mx-sm-0">
-          <h5>EDR health checks</h5>
-          <p>Verify that your EDR tools are installed and working so you can identify and address configuration issues quickly.</p>
-        </div>
-        <div purpose="feature-item" class="ml-sm-0 mb-0"></div>
-        <div purpose="feature-item" class="ml-sm-0 mb-0"></div>
       </div>
       <p purpose="feature-footnote">*Currently limited to: macOS, Linux, Windows, Chromebooks, OT, data centers, Amazon Web Services (AWS), Google Cloud (GCP), and the Microsoft Cloud (Azure).</p>
     </div>
@@ -210,27 +201,27 @@
     <%/* Implement “zero trust” faster section */%>
     <div purpose="page-section">
       <div purpose="feature-headline" style="max-width: 580px;">
-        <h2>“Zero” trust, fewer tickets</h2>
+        <h3>“Zero” trust, fewer tickets</h3>
         <p>You can use Fleet’s API to customize every aspect of conditional access – even the stuff your CISO hasn’t thought of yet.</p>
       </div>
 
       <div purpose="three-column-features" class="mx-auto">
-        <div purpose="feature-row" class="d-flex flex-md-row flex-column align-items-md-start align-items-center justify-content-center">
+        <div purpose="feature-row" class="d-flex flex-sm-row flex-column align-items-sm-start align-items-center justify-content-center">
 
-          <div purpose="feature-column" class="ml-md-0">
+          <div purpose="feature-item" class="ml-sm-0">
             <img alt="Get in front of the IdP" src="/images/device-management-icon-control-login-experience-48x48@2x.png" class="mx-auto mx-sm-0">
             <h5>Get in front of the IdP</h5>
             <p>Gate access with <a href="https://fleetdm.com/queries">common device trust policies</a> from industry peers, or roll out your own device health checks using system data and events.</p>
           </div>
 
-          <div purpose="feature-column">
-            <img alt="Step-by-step instructions" src="/images/device-management-icon-step-by-step-48x48@2x.png">
+          <div purpose="feature-item">
+            <img alt="Step-by-step instructions" src="/images/device-management-icon-step-by-step-48x48@2x.png" class="mx-auto mx-sm-0">
             <h5>Step-by-step instructions</h5>
             <p>Show resolution steps or use <a href="https://medium.com/pinterest-engineering/enforcing-device-authn-compliance-at-pinterest-a74938cb089b" target="_blank">custom HTML</a> to show employees what they need to do to restore their access without waiting on a ticket. Then give it back automatically, as soon as the problems are fixed.</p>
           </div>
 
-          <div purpose="feature-column" class="mr-md-0 mb-0">
-            <img alt="Manage device posture" src="/images/device-management-icon-manage-device-posture-48x48@2x.png">
+          <div purpose="feature-item" class="mr-sm-0 mb-0">
+            <img alt="Manage device posture" src="/images/device-management-icon-manage-device-posture-48x48@2x.png" class="mx-auto mx-sm-0">
             <h5>Live retry</h5>
             <p>Give people a way to get back to work quickly and minimize downtime. Fleet’s live query API instantly re-checks the OS version and other device state so users don’t get locked out.</p>
           </div>

--- a/website/views/pages/endpoint-ops.ejs
+++ b/website/views/pages/endpoint-ops.ejs
@@ -207,6 +207,36 @@
         <img alt="Ship data to any platform" src="/images/endpoint-ops-feature-image-1-381x282@2x.png">
       </div>
     </div>
+    <%/* Implement “zero trust” faster section */%>
+    <div purpose="page-section">
+      <div purpose="feature-headline" style="max-width: 580px;">
+        <h2>“Zero” trust, fewer tickets</h2>
+        <p>You can use Fleet’s API to customize every aspect of conditional access – even the stuff your CISO hasn’t thought of yet.</p>
+      </div>
+
+      <div purpose="three-column-features" class="mx-auto">
+        <div purpose="feature-row" class="d-flex flex-md-row flex-column align-items-md-start align-items-center justify-content-center">
+
+          <div purpose="feature-column" class="ml-md-0">
+            <img alt="Get in front of the IdP" src="/images/device-management-icon-control-login-experience-48x48@2x.png" class="mx-auto mx-sm-0">
+            <h5>Get in front of the IdP</h5>
+            <p>Gate access with <a href="https://fleetdm.com/queries">common device trust policies</a> from industry peers, or roll out your own device health checks using system data and events.</p>
+          </div>
+
+          <div purpose="feature-column">
+            <img alt="Step-by-step instructions" src="/images/device-management-icon-step-by-step-48x48@2x.png">
+            <h5>Step-by-step instructions</h5>
+            <p>Show resolution steps or use <a href="https://medium.com/pinterest-engineering/enforcing-device-authn-compliance-at-pinterest-a74938cb089b" target="_blank">custom HTML</a> to show employees what they need to do to restore their access without waiting on a ticket. Then give it back automatically, as soon as the problems are fixed.</p>
+          </div>
+
+          <div purpose="feature-column" class="mr-md-0 mb-0">
+            <img alt="Manage device posture" src="/images/device-management-icon-manage-device-posture-48x48@2x.png">
+            <h5>Live retry</h5>
+            <p>Give people a way to get back to work quickly and minimize downtime. Fleet’s live query API instantly re-checks the OS version and other device state so users don’t get locked out.</p>
+          </div>
+        </div>
+      </div>
+    </div>
     <%-  partial('../partials/calendar-banner.partial.ejs') %>
     <div purpose="feature" class="d-flex flex-md-row flex-column justify-content-between mx-auto align-items-center">
       <div purpose="feature-image" class="right">

--- a/website/views/pages/homepage.ejs
+++ b/website/views/pages/homepage.ejs
@@ -47,8 +47,8 @@
           <p>Even if you've never done an MDM migration, you've probably heard it's hard.  Fleet makes it easy to get your data in and get it out.</p>
           <strong>Tidy up your tools</strong>
           <p>Deploy a modern Mac-first MDM purpose-built for IT engineers and cross-training. Use principles from DevOps to manage Apple, Windows, and Linux computers declaratively.</p>
-          <strong>“Zero” trust, fewer tickets</strong>
-          <p>You can use Fleet’s API to customize every aspect of conditional access – even the stuff your CISO hasn’t thought of yet.</p>
+          <strong>Less friction</strong>
+          <p>Fork the CIS benchmarks or easily build your own compliance framework. 100% source available.</p>
           <div>
             <a purpose="category-button" class="text-nowrap btn btn-primary" href="/device-management">Start with device management</a>
           </div>


### PR DESCRIPTION
Closes: #20083

Changes:
- Updated the buying situation-agnostic MDM section on the homepage.
- Moved the zero trust section from the device management page to the /endpoint-ops page.