### PR TITLE
Fleet UI: Add loading spinner to current versions table

### DIFF
--- a/frontend/pages/ManageControlsPage/OSUpdates/components/CurrentVersionSection/CurrentVersionSection.tsx
+++ b/frontend/pages/ManageControlsPage/OSUpdates/components/CurrentVersionSection/CurrentVersionSection.tsx
@@ -11,6 +11,7 @@ import {
 import LastUpdatedText from "components/LastUpdatedText";
 import SectionHeader from "components/SectionHeader";
 import DataError from "components/DataError";
+import Spinner from "components/Spinner";
 
 import OSVersionTable from "../OSVersionTable";
 import { OSUpdatesSupportedPlatform } from "../../OSUpdates";
@@ -56,6 +57,10 @@ const CurrentVersionSection = ({
   };
 
   const renderTable = () => {
+    if (isLoadingOsVersions) {
+      return <Spinner />;
+    }
+
     if (isError) {
       return (
         <DataError


### PR DESCRIPTION
## Issue
Cerra #20076 

## Description
- Add loading spinner for API call for getting OS versions on the OS Updates page

## Screenshot of fix
<img width="1430" alt="Screenshot 2024-06-28 at 3 28 21 PM" src="https://github.com/fleetdm/fleet/assets/71795832/a48279a3-1bf0-426f-828c-b19b8f26298e">


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Manual QA for all new/changed functionality

