### PR TITLE
Detach child process before removing fleet on MacOS

### DIFF
--- a/changes/19645-cleanup_macos
+++ b/changes/19645-cleanup_macos
@@ -1,1 +1,1 @@
-* Fleetd cleanup script for macOS will return completed if run from fleeet
+* Fleetd cleanup script for macOS will return completed if run from fleet

--- a/changes/19645-cleanup_macos
+++ b/changes/19645-cleanup_macos
@@ -1,0 +1,1 @@
+* Fleetd cleanup script for macOS will return completed if run from fleeet

--- a/changes/19645-uninstall-script-fleetd
+++ b/changes/19645-uninstall-script-fleetd
@@ -1,0 +1,1 @@
+* Provided fleetd uninstall script will return when run through fleet

--- a/orbit/tools/cleanup/cleanup_macos.sh
+++ b/orbit/tools/cleanup/cleanup_macos.sh
@@ -1,9 +1,29 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
-sudo launchctl stop com.fleetdm.orbit
-sudo launchctl unload /Library/LaunchDaemons/com.fleetdm.orbit.plist
+if [ $(id -u) -ne 0 ]; then
+    echo "Please run as root"
+    exit 1
+fi
 
-sudo pkill fleet-desktop || true
-sudo rm -rf /Library/LaunchDaemons/com.fleetdm.orbit.plist /var/lib/orbit /usr/local/bin/orbit /var/log/orbit /opt/orbit/
 
-sudo pkgutil --forget com.fleetdm.orbit.base.pkg || true
+function remove_fleet {
+    launchctl stop com.fleetdm.orbit
+    launchctl unload /Library/LaunchDaemons/com.fleetdm.orbit.plist
+
+    pkill fleet-desktop || true
+    rm -rf /Library/LaunchDaemons/com.fleetdm.orbit.plist /var/lib/orbit /usr/local/bin/orbit /var/log/orbit /opt/orbit/
+
+    pkgutil --forget com.fleetdm.orbit.base.pkg || true
+}
+
+if [ $1 == "remove" ]; then
+    # We are in the detached child process
+    # Give the parent process time to report the success before removing
+    sleep 15
+    remove_fleet
+else
+    # We are in the parent shell, start the detached child and return success
+    echo "Removing fleet, system will be unenrolled"
+    echo "Executing detached child process"
+    nohup sh $0 remove >/dev/null 2>/dev/null </dev/null &
+fi

--- a/orbit/tools/cleanup/cleanup_macos.sh
+++ b/orbit/tools/cleanup/cleanup_macos.sh
@@ -8,13 +8,14 @@ fi
 function remove_fleet {
     set -x
 
+    rm -rf /Library/LaunchDaemons/com.fleetdm.orbit.plist /var/lib/orbit /usr/local/bin/orbit /var/log/orbit /opt/orbit/
+
+    pkgutil --forget com.fleetdm.orbit.base.pkg || true
+
     launchctl stop com.fleetdm.orbit
     launchctl unload /Library/LaunchDaemons/com.fleetdm.orbit.plist
 
     pkill fleet-desktop || true
-    rm -rf /Library/LaunchDaemons/com.fleetdm.orbit.plist /var/lib/orbit /usr/local/bin/orbit /var/log/orbit /opt/orbit/
-
-    pkgutil --forget com.fleetdm.orbit.base.pkg || true
 }
 
 if [ "$1" = "remove" ]; then

--- a/orbit/tools/cleanup/cleanup_macos.sh
+++ b/orbit/tools/cleanup/cleanup_macos.sh
@@ -5,8 +5,9 @@ if [ $(id -u) -ne 0 ]; then
     exit 1
 fi
 
-
 function remove_fleet {
+    set -x
+
     launchctl stop com.fleetdm.orbit
     launchctl unload /Library/LaunchDaemons/com.fleetdm.orbit.plist
 
@@ -19,11 +20,12 @@ function remove_fleet {
 if [ "$1" = "remove" ]; then
     # We are in the detached child process
     # Give the parent process time to report the success before removing
+    echo "inside remove process" >>/tmp/fleet_remove_log.txt
     sleep 15
-    remove_fleet
+    remove_fleet >>/tmp/fleet_remove_log.txt 2>&1
 else
     # We are in the parent shell, start the detached child and return success
     echo "Removing fleet, system will be unenrolled in 15 seconds..."
     echo "Executing detached child process"
-    nohup sh $0 remove >/dev/null 2>/dev/null </dev/null &
+    bash -c "bash $0 remove >/dev/null 2>/dev/null </dev/null &"
 fi

--- a/orbit/tools/cleanup/cleanup_macos.sh
+++ b/orbit/tools/cleanup/cleanup_macos.sh
@@ -16,7 +16,7 @@ function remove_fleet {
     pkgutil --forget com.fleetdm.orbit.base.pkg || true
 }
 
-if [ $1 == "remove" ]; then
+if [ "$1" = "remove" ]; then
     # We are in the detached child process
     # Give the parent process time to report the success before removing
     sleep 15

--- a/orbit/tools/cleanup/cleanup_macos.sh
+++ b/orbit/tools/cleanup/cleanup_macos.sh
@@ -23,7 +23,7 @@ if [ $1 == "remove" ]; then
     remove_fleet
 else
     # We are in the parent shell, start the detached child and return success
-    echo "Removing fleet, system will be unenrolled"
+    echo "Removing fleet, system will be unenrolled in 15 seconds..."
     echo "Executing detached child process"
     nohup sh $0 remove >/dev/null 2>/dev/null </dev/null &
 fi


### PR DESCRIPTION
#19645

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [x] Manual QA for all new/changed functionality