### PR TITLE
prevent errors on tests that use real replicas

### DIFF
--- a/server/datastore/mysql/testing_utils.go
+++ b/server/datastore/mysql/testing_utils.go
@@ -20,6 +20,7 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
+	"sync"
 	"testing"
 	"text/tabwriter"
 	"time"
@@ -215,6 +216,16 @@ func setupDummyReplica(t testing.TB, testName string, ds *Datastore, opts *Datas
 	}
 }
 
+// we need to keep track of the databases that need replication in order to
+// configure the replica to only track those, otherwise the replica worker
+// might fail/stop trying to execute statements on databases that don't exist.
+//
+// this happens because we create a database and import our test dump on the
+// leader each time `connectMySQL` is called, but we only do the same on the
+// replica when it's enabled via options.
+var mu sync.Mutex
+var databasesToReplicate string
+
 func setupRealReplica(t testing.TB, testName string, ds *Datastore, options *dbOptions) {
 	t.Helper()
 	const replicaUser = "replicator"
@@ -263,6 +274,10 @@ func setupRealReplica(t testing.TB, testName string, ds *Datastore, options *dbO
 		extraMasterOptions = "GET_MASTER_PUBLIC_KEY=1," // needed for MySQL 8.0 caching_sha2_password authentication
 	}
 
+	mu.Lock()
+	databasesToReplicate = strings.TrimSuffix(databasesToReplicate+fmt.Sprintf("`%s`,", testName), ",")
+	mu.Unlock()
+
 	// Configure slave and start replication
 	if out, err := exec.Command(
 		"docker-compose", "exec", "-T", "mysql_replica_test",
@@ -274,6 +289,7 @@ func setupRealReplica(t testing.TB, testName string, ds *Datastore, options *dbO
 			`
 			STOP SLAVE;
 			RESET SLAVE ALL;
+			CHANGE REPLICATION FILTER REPLICATE_DO_DB = ( %s );
 			CHANGE MASTER TO
 				%s
 				MASTER_HOST='mysql_test',
@@ -282,7 +298,7 @@ func setupRealReplica(t testing.TB, testName string, ds *Datastore, options *dbO
 				MASTER_LOG_FILE='%s',
 				MASTER_LOG_POS=%d;
 			START SLAVE;
-			`, extraMasterOptions, replicaUser, replicaPassword, ms.File, ms.Position,
+			`, databasesToReplicate, extraMasterOptions, replicaUser, replicaPassword, ms.File, ms.Position,
 		),
 	).CombinedOutput(); err != nil {
 		t.Error(err)

--- a/server/datastore/mysql/testing_utils.go
+++ b/server/datastore/mysql/testing_utils.go
@@ -275,7 +275,7 @@ func setupRealReplica(t testing.TB, testName string, ds *Datastore, options *dbO
 	}
 
 	mu.Lock()
-	databasesToReplicate = strings.TrimSuffix(databasesToReplicate+fmt.Sprintf("`%s`,", testName), ",")
+	databasesToReplicate = strings.TrimPrefix(databasesToReplicate+fmt.Sprintf(", `%s`", testName), ",")
 	mu.Unlock()
 
 	// Configure slave and start replication


### PR DESCRIPTION
For #20046, I found this while trying to get #20085 merged, as MySQL 8 tests were consistenly failing (5 times in a row) with this when integration tests are run in parallel.

I used the `lhotari/action-upterm@v1` action to hook an SSH session into the worker, and I noticed different errors in different runs, but all on the same lines of this sample:

```
mysql> SELECT * FROM replication_applier_status_by_worker LIMIT 1 OFFSET 0\G
*************************** 1. row ***************************
                                           CHANNEL_NAME:
                                              WORKER_ID: 1
                                              THREAD_ID: NULL
                                          SERVICE_STATE: OFF
                                      LAST_ERROR_NUMBER: 1146
                                     LAST_ERROR_MESSAGE: Worker 1 failed executing transaction 'ANONYMOUS' at master log bin.000003, end_log_pos 25540153; Error 'Table 'server_datastore_mysql_TestTeams.host_mdm_apple_bootstrap_packages' doesn't exist' on query. Default database: 'server_datastore_mysql_TestTeams'. Query: 'TRUNCATE TABLE host_mdm_apple_bootstrap_packages'
                                   LAST_ERROR_TIMEST
```

This uses
[REPLICATE_DO_DB](https://dev.mysql.com/doc/refman/5.7/en/change-replication-filter.html) to configure the replica at runtime to replicate only the databases that are configured with replicas and prevent any unexpected behavior.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Added/updated tests
- [x] Manual QA for all new/changed functionality
