### PR TITLE
Add "exclude software" parameter to get host by identifier

### DIFF
--- a/changes/api-get-host-by-identifier-exclude-software
+++ b/changes/api-get-host-by-identifier-exclude-software
@@ -1,0 +1,1 @@
+- add exclude_software query paramter to "Get host by identifier" API

--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -1188,7 +1188,7 @@ Note that when making changes to the `integrations` object, all integrations mus
   },
   "server_settings": {
     "server_url": "https://localhost:8080",
-    "enable_analytics": true, 
+    "enable_analytics": true,
     "live_query_disabled": false,
     "query_reports_disabled": false,
     "ai_features_disabled": false
@@ -1269,7 +1269,7 @@ Note that when making changes to the `integrations` object, all integrations mus
           "path": "path/to/profile3.xml",
           "labels": ["Label 1", "Label 2"]
         }
-      ]     
+      ]
     },
     "end_user_authentication": {
       "entity_id": "",
@@ -2623,6 +2623,7 @@ If `hostname` is specified when there is more than one host with the same hostna
 | Name       | Type              | In   | Description                                                                   |
 | ---------- | ----------------- | ---- | ----------------------------------------------------------------------------- |
 | identifier | integer or string | path | **Required**. The host's `hardware_serial`, `uuid`, `osquery_host_id`, `hostname`, or `node_key` |
+| exclude_software | boolean | query | If `true`, the response will not include a list of installed software for the host. |
 
 #### Example
 
@@ -3840,7 +3841,7 @@ OS vulnerability data is currently available for Windows and macOS. For other pl
         "installed_at": "2024-05-15T15:23:57Z"
       },
       "installed_versions": [
-        { 
+        {
           "version": "121.0",
           "last_opened_at": "2024-04-01T23:03:07Z",
           "vulnerabilities": ["CVE-2023-1234","CVE-2023-4321","CVE-2023-7654"],
@@ -3872,7 +3873,7 @@ OS vulnerability data is currently available for Windows and macOS. For other pl
           "vulnerabilities": ["CVE-2023-1234"],
           "installed_paths": ["/Applications/Firefox.app"]
         },
-        { 
+        {
           "version": "119.0",
           "last_opened_at": "2024-04-01T23:03:07Z",
           "vulnerabilities": ["CVE-2023-4321","CVE-2023-7654"],
@@ -4264,7 +4265,7 @@ To wipe a macOS or Windows host, the host must have MDM turned on. To lock a Lin
 
 ### Add labels to host
 
-Adds manual labels to a host. 
+Adds manual labels to a host.
 
 `POST /api/v1/fleet/hosts/:id/labels`
 
@@ -8276,14 +8277,14 @@ Get a list of all software.
       "source": "apps",
       "browser": "",
       "hosts_count": 48,
-      "versions": [ 
+      "versions": [
         {
           "id": 123,
           "version": "1.12",
           "vulnerabilities": ["CVE-2023-1234","CVE-2023-4321","CVE-2023-7654"]
-        }, 
+        },
         {
-          "id": 124, 
+          "id": 124,
           "version": "3.4",
           "vulnerabilities": ["CVE-2023-1234","CVE-2023-4321","CVE-2023-7654"]
         },
@@ -8292,7 +8293,7 @@ Get a list of all software.
           "version": "1.13",
           "vulnerabilities": ["CVE-2023-1234","CVE-2023-4321","CVE-2023-7654"]
         }
-      ]  
+      ]
     },
     {
       "id": 22,
@@ -8465,7 +8466,7 @@ Returns information about the specified software. By default, `versions` are sor
     "source": "apps",
     "browser": "",
     "hosts_count": 48,
-    "versions": [ 
+    "versions": [
       {
         "id": 123,
         "version": "117.0",
@@ -8484,7 +8485,7 @@ Returns information about the specified software. By default, `versions` are sor
         "vulnerabilities": ["CVE-2023-7654"],
         "hosts_count": 4
       }
-    ]  
+    ]
   }
 }
 ```

--- a/server/service/hosts.go
+++ b/server/service/hosts.go
@@ -681,8 +681,8 @@ func (svc *Service) GetHostSummary(ctx context.Context, teamID *uint, platform *
 ////////////////////////////////////////////////////////////////////////////////
 
 type hostByIdentifierRequest struct {
-	Identifier string `url:"identifier"`
-	ExcludeSoftware bool `query:"exclude_software,optional"`
+	Identifier      string `url:"identifier"`
+	ExcludeSoftware bool   `query:"exclude_software,optional"`
 }
 
 func hostByIdentifierEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (errorer, error) {

--- a/server/service/hosts.go
+++ b/server/service/hosts.go
@@ -682,6 +682,7 @@ func (svc *Service) GetHostSummary(ctx context.Context, teamID *uint, platform *
 
 type hostByIdentifierRequest struct {
 	Identifier string `url:"identifier"`
+	ExcludeSoftware bool `query:"exclude_software,optional"`
 }
 
 func hostByIdentifierEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (errorer, error) {
@@ -689,6 +690,7 @@ func hostByIdentifierEndpoint(ctx context.Context, request interface{}, svc flee
 	opts := fleet.HostDetailOptions{
 		IncludeCVEScores: false,
 		IncludePolicies:  true, // intentionally true to preserve existing behavior
+		ExcludeSoftware:  req.ExcludeSoftware,
 	}
 	host, err := svc.HostByIdentifier(ctx, req.Identifier, opts)
 	if err != nil {

--- a/server/service/integration_core_test.go
+++ b/server/service/integration_core_test.go
@@ -7967,6 +7967,18 @@ func (s *integrationTestSuite) TestGetHostSoftwareUpdatedAt() {
 	require.Equal(t, host.ID, getHostResp.Host.ID)
 	require.Empty(t, getHostResp.Host.Software)
 	require.Greater(t, getHostResp.Host.SoftwareUpdatedAt, getHostResp.Host.CreatedAt)
+
+	getHostResp = getHostResponse{}
+	s.DoJSON("GET", fmt.Sprintf("/api/latest/fleet/hosts/identifier/%s", *host.NodeKey), nil, http.StatusOK, &getHostResp)
+	require.Equal(t, host.ID, getHostResp.Host.ID)
+	require.Len(t, getHostResp.Host.Software, len(software))
+	require.Greater(t, getHostResp.Host.SoftwareUpdatedAt, getHostResp.Host.CreatedAt)
+
+	getHostResp = getHostResponse{}
+	s.DoJSON("GET", fmt.Sprintf("/api/latest/fleet/hosts/identifier/%s", *host.NodeKey), nil, http.StatusOK, &getHostResp, "exclude_software", "true")
+	require.Equal(t, host.ID, getHostResp.Host.ID)
+	require.Empty(t, getHostResp.Host.Software)
+	require.Greater(t, getHostResp.Host.SoftwareUpdatedAt, getHostResp.Host.CreatedAt)
 }
 
 func (s *integrationTestSuite) TestHostsReportDownload() {


### PR DESCRIPTION
For #19540

Just added the same "exclude_software" functionality that exists in "get hosts" to the "get host by identifier" function.

- [ ] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [ ] Manual QA for all new/changed functionality