### PR TITLE
Website: Update leads created from "Talk to us" form submissions.

### DIFF
--- a/website/api/controllers/deliver-talk-to-us-form-submission.js
+++ b/website/api/controllers/deliver-talk-to-us-form-submission.js
@@ -36,9 +36,9 @@ module.exports = {
     },
 
     numberOfHosts: {
-      type: 'string',
+      type: 'number',
       required: true,
-      description: 'The organization of the user who submitted the "talk to us" form'
+      description: 'The number of hosts the user who submitted the "talk to us" form has.'
     },
 
     primaryBuyingSituation: {
@@ -84,7 +84,7 @@ module.exports = {
         numberOfHosts: numberOfHosts,
         primaryBuyingSituation: primaryBuyingSituation === 'eo-security' ? 'Endpoint operations - Security' : primaryBuyingSituation === 'eo-it' ? 'Endpoint operations - IT' : primaryBuyingSituation === 'mdm' ? 'Device management (MDM)' : primaryBuyingSituation === 'vm' ? 'Vulnerability management' : undefined,
         leadSource: 'Website - Contact forms',
-        leadDescription: `Submitted the "Talk to us" form.`,
+        leadDescription: `Submitted the "Talk to us" form and was taken to the Calendly page for the "${numberOfHosts > 700 ? 'Talk to us' : 'Let\'s get you set up!'}" event.`,
       }).tolerate((err)=>{
         sails.log.warn(`Background task failed: When a user submitted the "Talk to us" form, a lead/contact could not be updated in the CRM for this email address: ${emailAddress}.`, err);
       });


### PR DESCRIPTION
Related to: #20107


Changes:
- Updated the description of leads created from "Talk to us" form submissions to include the name of the Calendly event.