### PR TITLE
Vuln dash: Reduce noise in and increase timeout for vulnerable wares processing in update-reports script.

### DIFF
--- a/ee/vulnerability-dashboard/scripts/update-reports.js
+++ b/ee/vulnerability-dashboard/scripts/update-reports.js
@@ -204,7 +204,7 @@ module.exports = {
         // So we'll look for an Operating system that matches that format, and log a warning and skip this host if one is not found.
         hostsOperatingSystem = _.find(allOsRecords, {'fullName': 'Microsoft '+host.os_version});
         if(!hostsOperatingSystem){
-          sails.log(`When building host records from the Fleet API, a host's (FleetApid: ${host.id}) os_version (os_version: ${host.os_version}) could not be matched to an operating system returned in the API response from the /os_versions endpoint. Host with missing operating system:`, host);
+          sails.log.verbose(`When building host records from the Fleet API, a host's (FleetApid: ${host.id}) os_version (os_version: ${host.os_version}) could not be matched to an operating system returned in the API response from the /os_versions endpoint. Host with missing operating system:`, host);
           continue;
         }
       }
@@ -241,6 +241,21 @@ module.exports = {
         }
       }
     }//∫
+
+
+    if (dry) {
+      sails.log.warn(`Dry run: ${newRecordsForUnrecognizedHosts.length} hosts were seemingly enrolled. (Fleet returned them in the API.)`);
+      sails.log.warn(`Dry run: ${hostRecordsToUpdate.length} hosts will be updated with new information. (Fleet returned them in the API.)`);
+    } else {
+      sails.log(`Creating ${newRecordsForUnrecognizedHosts.length} host records… `);
+      let batchedNewRecordsForUnrecognizedHosts = _.chunk(newRecordsForUnrecognizedHosts, 500);
+      for(let batch of batchedNewRecordsForUnrecognizedHosts){
+        await Host.createEach(batch);
+      }
+      for(let hostUpdate of hostRecordsToUpdate){
+        await Host.updateOne({id: hostUpdate.id}).set(_.omit(hostUpdate, 'id'));
+      }
+    }
 
     //  ██╗   ██╗██╗   ██╗██╗     ███╗   ██╗███████╗██████╗  █████╗ ██████╗ ██╗     ███████╗
     //  ██║   ██║██║   ██║██║     ████╗  ██║██╔════╝██╔══██╗██╔══██╗██╔══██╗██║     ██╔════╝
@@ -520,7 +535,7 @@ module.exports = {
       }//∞
       numVulnerableWaresProcessed += vulnerableWares.length;
       page++;
-    }, 45 * 60 * 1000)// (timeout after 45 mintutes)
+    }, 90 * 60 * 1000)// (timeout after 90 mintutes)
     .intercept((err) =>
       require('flaverr')({message: 'Could not get software from the Fleet API.  Error details: '+err.message}, err)
     );


### PR DESCRIPTION
Related to https://github.com/fleetdm/confidential/issues/7180

Changes:
- Increased the vulnerable wares processing timeout in the `update-reports` script (45 minutes » 90 minutes)
- Updated the log level of the log message about hosts that could not be matched to an operating system