### PR TITLE
Set workstations to use DDM for macOS updates

### DIFF
--- a/it-and-security/teams/workstations.yml
+++ b/it-and-security/teams/workstations.yml
@@ -44,7 +44,7 @@ controls:
     enable_end_user_authentication: true
     macos_setup_assistant: null
   macos_updates:
-    deadline: ""
+    deadline: "2024-07-12"
     minimum_version: "14.5"
   windows_settings:
     custom_settings: null

--- a/it-and-security/teams/workstations.yml
+++ b/it-and-security/teams/workstations.yml
@@ -63,13 +63,6 @@ policies:
   - path: ../lib/linux-device-health.policies.yml
   - path: ../lib/macos-cis.policies.yml
   - path: ../lib/windows-cis.policies.yml
-  - name: macOS - Check if latest version
-    query: SELECT 1 FROM os_version WHERE major = '14' OR major = '15';
-    critical: false
-    description: Using an outdated macOS version risks exposure to security vulnerabilities and potential system instability.
-    resolution: We will update your macOS to the latest version.
-    platform: darwin
-    calendar_events_enabled: true  
 queries:
   - path: ../lib/collect-failed-login-attempts.queries.yml
   - path: ../lib/collect-usb-devices.queries.yml

--- a/it-and-security/teams/workstations.yml
+++ b/it-and-security/teams/workstations.yml
@@ -45,7 +45,7 @@ controls:
     macos_setup_assistant: null
   macos_updates:
     deadline: ""
-    minimum_version: ""
+    minimum_version: "14.5"
   windows_settings:
     custom_settings: null
   windows_updates:


### PR DESCRIPTION
On workstations, we dogfood the current recommended best practice: https://fleetdm.com/docs/using-fleet/mdm-os-updates

On workstations (canary), we dogfood using the calendar feature to run managed OS updates.