### PR TITLE
Allow custom docker images everwhere

### DIFF
--- a/charts/fleet/Chart.yaml
+++ b/charts/fleet/Chart.yaml
@@ -4,7 +4,7 @@ name: fleet
 keywords:
   - fleet
   - osquery
-version: v6.1.0
+version: v6.2.0
 home: https://github.com/fleetdm/fleet
 sources:
   - https://github.com/fleetdm/fleet.git

--- a/charts/fleet/templates/deployment.yaml
+++ b/charts/fleet/templates/deployment.yaml
@@ -33,7 +33,7 @@ spec:
       - name: fleet
         command: [/usr/bin/fleet]
         args: ["serve"]
-        image: fleetdm/fleet:{{ .Values.imageTag }}
+        image: "{{ .Values.image }}:{{ .Values.imageTag }}"
         ports:
         - name: fleet
           containerPort: {{ .Values.fleet.listenPort }}
@@ -335,7 +335,7 @@ spec:
         {{- end }}
       {{- if .Values.gke.cloudSQL.enableProxy }}
       - name: cloudsql-proxy
-        image: "gcr.io/cloudsql-docker/gce-proxy:{{ .Values.gke.cloudSQL.imageTag }}"
+        image: "{{ .Values.gke.cloudSQL.image }}:{{ .Values.gke.cloudSQL.imageTag }}"
         command:
         - "/cloud_sql_proxy"
         - "-verbose={{ .Values.gke.cloudSQL.verbose}}"

--- a/charts/fleet/templates/deployment.yaml
+++ b/charts/fleet/templates/deployment.yaml
@@ -33,7 +33,7 @@ spec:
       - name: fleet
         command: [/usr/bin/fleet]
         args: ["serve"]
-        image: "{{ .Values.image }}:{{ .Values.imageTag }}"
+        image: "{{ .Values.imageRepository }}:{{ .Values.imageTag }}"
         ports:
         - name: fleet
           containerPort: {{ .Values.fleet.listenPort }}
@@ -335,7 +335,7 @@ spec:
         {{- end }}
       {{- if .Values.gke.cloudSQL.enableProxy }}
       - name: cloudsql-proxy
-        image: "{{ .Values.gke.cloudSQL.image }}:{{ .Values.gke.cloudSQL.imageTag }}"
+        image: "{{ .Values.gke.cloudSQL.imageRepository }}:{{ .Values.gke.cloudSQL.imageTag }}"
         command:
         - "/cloud_sql_proxy"
         - "-verbose={{ .Values.gke.cloudSQL.verbose}}"

--- a/charts/fleet/templates/job-migration.yaml
+++ b/charts/fleet/templates/job-migration.yaml
@@ -35,7 +35,7 @@ spec:
       - name: fleet-migration
         command: [/usr/bin/fleet]
         args: ["prepare","db","--no-prompt"]
-        image: fleetdm/fleet:{{ .Values.imageTag }}
+        image: "{{ .Values.image }}:{{ .Values.imageTag }}"
         resources:
           limits:
             cpu: {{ .Values.resources.limits.cpu }}

--- a/charts/fleet/templates/job-migration.yaml
+++ b/charts/fleet/templates/job-migration.yaml
@@ -35,7 +35,7 @@ spec:
       - name: fleet-migration
         command: [/usr/bin/fleet]
         args: ["prepare","db","--no-prompt"]
-        image: "{{ .Values.image }}:{{ .Values.imageTag }}"
+        image: "{{ .Values.imageRepository }}:{{ .Values.imageTag }}"
         resources:
           limits:
             cpu: {{ .Values.resources.limits.cpu }}

--- a/charts/fleet/values.yaml
+++ b/charts/fleet/values.yaml
@@ -2,6 +2,7 @@
 # All settings related to how Fleet is deployed in Kubernetes
 hostName: fleet.localhost
 replicas: 3 # The number of Fleet instances to deploy
+image: fleetdm/fleet
 imageTag: v4.53.1 # Version of Fleet to deploy
 podAnnotations: {} # Additional annotations to add to the Fleet pod
 serviceAccountAnnotations: {} # Additional annotations to add to the Fleet service account
@@ -191,6 +192,7 @@ gke:
   # The CloudSQL Proxy runs as a container in the Fleet Pod that proxies connections to a Cloud SQL instance
   cloudSQL:
     enableProxy: false
+    image: gcr.io/cloudsql-docker/gce-proxy
     imageTag: 1.17-alpine
     verbose: true
     instanceName: ""

--- a/charts/fleet/values.yaml
+++ b/charts/fleet/values.yaml
@@ -2,7 +2,7 @@
 # All settings related to how Fleet is deployed in Kubernetes
 hostName: fleet.localhost
 replicas: 3 # The number of Fleet instances to deploy
-image: fleetdm/fleet
+imageRepository: fleetdm/fleet
 imageTag: v4.53.1 # Version of Fleet to deploy
 podAnnotations: {} # Additional annotations to add to the Fleet pod
 serviceAccountAnnotations: {} # Additional annotations to add to the Fleet service account
@@ -192,7 +192,7 @@ gke:
   # The CloudSQL Proxy runs as a container in the Fleet Pod that proxies connections to a Cloud SQL instance
   cloudSQL:
     enableProxy: false
-    image: gcr.io/cloudsql-docker/gce-proxy
+    imageRepository: gcr.io/cloudsql-docker/gce-proxy
     imageTag: 1.17-alpine
     verbose: true
     instanceName: ""


### PR DESCRIPTION
This is a Helm only change that allows a user to select custom docker images (or a cache URL) for all the current containers that exist in the Helm chart, namely:
- fleet
- cloudSQL

Because this adds functionality, but does not break existing deployments, I am also proposing that the Chart's minor version be incremented.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [ ] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [ ] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [ ] Added support on fleet's osquery simulator `cmd/osquery-perf` for new osquery data ingestion features.
- [ ] Added/updated tests
- [ ] If database migrations are included, checked table schema to confirm autoupdate
- For database migrations:
  - [ ] Checked schema for all modified table for columns that will auto-update timestamps during migration.
  - [ ] Confirmed that updating the timestamps is acceptable, and will not cause unwanted side effects.
  - [ ] Ensured the correct collation is explicitly set for character columns (`COLLATE utf8mb4_unicode_ci`).
- [x] Manual QA for all new/changed functionality
  - For Orbit and Fleet Desktop changes:
    - [ ] Manual QA must be performed in the three main OSs, macOS, Windows and Linux.
    - [ ] Auto-update manual QA, from released version of component to new version (see [tools/tuf/test](../tools/tuf/test/README.md)).
