### PR TITLE
Vuln dashboard: Update query to find `Vulnerability` records with no associated `VulnerabilityInstall` records.

### DIFF
--- a/ee/vulnerability-dashboard/scripts/update-reports.js
+++ b/ee/vulnerability-dashboard/scripts/update-reports.js
@@ -906,12 +906,10 @@ module.exports = {
 
     // Check for Vulnerabilities that have no associated Host or VulnerabilityInstall records.
     let nativeQueryToFindVulnsWithNoAssociatedRecords =
-    `SELECT id
-    FROM vulnerability
-    WHERE id NOT IN (
-        SELECT vulnerability
-        FROM vulnerabilityinstall
-    );`;
+    `SELECT v.id
+    FROM vulnerability v
+    LEFT JOIN vulnerabilityinstall vi ON v.id = vi.vulnerability
+    WHERE vi.vulnerability IS NULL;`;
     let rawResultFromDatabase = await sails.sendNativeQuery(nativeQueryToFindVulnsWithNoAssociatedRecords);
     let vulnerabilityRecordIdsWithNoAssociatedRecords = rawResultFromDatabase.rows;
 


### PR DESCRIPTION
Related to: https://github.com/fleetdm/confidential/issues/7180

Changes:
- Updated the `nativeQueryToFindVulnsWithNoAssociatedRecords` query to improve the performance of the update-reports script on large deployments