### PR TITLE
Fleet UI: Update to consistent button styling

### DIFF
--- a/frontend/pages/SoftwarePage/SoftwarePage.tsx
+++ b/frontend/pages/SoftwarePage/SoftwarePage.tsx
@@ -330,9 +330,9 @@ const SoftwarePage = ({ children, router, location }: ISoftwarePageProps) => {
           <Button
             onClick={toggleManageAutomationsModal}
             className={`${baseClass}__manage-automations`}
-            variant="text-link"
+            variant="inverse"
           >
-            <span>Manage automations</span>
+            Manage automations
           </Button>
         )}
         {canAddSoftware && (

--- a/frontend/pages/SoftwarePage/_styles.scss
+++ b/frontend/pages/SoftwarePage/_styles.scss
@@ -28,7 +28,7 @@
   &__action-buttons {
     display: flex;
     align-items: center;
-    gap: $pad-medium;
+    gap: $pad-small;
   }
 
   &__text {

--- a/frontend/pages/admin/OrgSettingsPage/_styles.scss
+++ b/frontend/pages/admin/OrgSettingsPage/_styles.scss
@@ -71,10 +71,6 @@
             }
           }
         }
-        .button--inverse {
-          // compensate for button's padding
-          margin-left: -$pad-small;
-        }
       }
 
       &__section-description {

--- a/frontend/pages/admin/OrgSettingsPage/cards/GlobalHostStatusWebhook/GlobalHostStatusWebhook.tsx
+++ b/frontend/pages/admin/OrgSettingsPage/cards/GlobalHostStatusWebhook/GlobalHostStatusWebhook.tsx
@@ -153,20 +153,18 @@ const GlobalHostStatusWebhook = ({
           >
             Enable host status webhook
           </Checkbox>
-          <div>
-            <p className={`${baseClass}__section-description`}>
-              A request will be sent to your configured <b>Destination URL</b>{" "}
-              if the configured <b>Percentage of hosts</b> have not checked into
-              Fleet for the configured <b>Number of days</b>.
-            </p>
-            <Button
-              type="button"
-              variant="inverse"
-              onClick={toggleHostStatusWebhookPreviewModal}
-            >
-              Preview request
-            </Button>
-          </div>
+          <p className={`${baseClass}__section-description`}>
+            A request will be sent to your configured <b>Destination URL</b> if
+            the configured <b>Percentage of hosts</b> have not checked into
+            Fleet for the configured <b>Number of days</b>.
+          </p>
+          <Button
+            type="button"
+            variant="text-link"
+            onClick={toggleHostStatusWebhookPreviewModal}
+          >
+            Preview request
+          </Button>
           {enableHostStatusWebhook && (
             <>
               <InputField

--- a/frontend/pages/admin/TeamManagementPage/TeamDetailsWrapper/TeamSettings/TeamSettings.tsx
+++ b/frontend/pages/admin/TeamManagementPage/TeamDetailsWrapper/TeamSettings/TeamSettings.tsx
@@ -301,7 +301,7 @@ const TeamSettings = ({ location, router }: ITeamSubnavProps) => {
         </Checkbox>
         <Button
           type="button"
-          variant="inverse"
+          variant="text-link"
           onClick={toggleHostStatusWebhookPreviewModal}
         >
           Preview request

--- a/frontend/pages/admin/TeamManagementPage/TeamDetailsWrapper/TeamSettings/_styles.scss
+++ b/frontend/pages/admin/TeamManagementPage/TeamDetailsWrapper/TeamSettings/_styles.scss
@@ -6,8 +6,4 @@
       margin-top: $pad-medium;
     }
   }
-  .button--inverse {
-    // compensate for button's padding
-    margin: -$pad-small;
-  }
 }

--- a/frontend/pages/queries/ManageQueriesPage/components/ManageQueryAutomationsModal/ManageQueryAutomationsModal.tsx
+++ b/frontend/pages/queries/ManageQueriesPage/components/ManageQueryAutomationsModal/ManageQueryAutomationsModal.tsx
@@ -179,7 +179,7 @@ const ManageQueryAutomationsModal = ({
         </InfoBanner>
         <Button
           type="button"
-          variant="inverse"
+          variant="text-link"
           onClick={togglePreviewDataModal}
           className={`${baseClass}__preview-data`}
         >


### PR DESCRIPTION
## Issue
Cerra #20240 

## Description
- Find all inline preview like buttons and give them the same styling (`variant="text-link"`)
- Fix header button on software automations to match other header inverse buttons such as Manage enroll secrets or Manage query automations (`variant="inverse"`)
- Fix global host status webhook preview button's missing padding between it and the paragraph above it


## Screenshots of alignment and hover state fixes
<img width="860" alt="Screenshot 2024-07-08 at 9 59 32 AM" src="https://github.com/fleetdm/fleet/assets/71795832/259e6798-38f3-473f-9124-87c10a0e9c42">
<img width="843" alt="Screenshot 2024-07-08 at 9 56 44 AM" src="https://github.com/fleetdm/fleet/assets/71795832/a9bf7548-9d3a-4763-a167-e4d4f75078ba">
<img width="823" alt="Screenshot 2024-07-08 at 9 54 50 AM" src="https://github.com/fleetdm/fleet/assets/71795832/abb3ff72-5ea5-43fd-9919-06cffebd7ffe">
<img width="1072" alt="Screenshot 2024-07-08 at 10 14 35 AM" src="https://github.com/fleetdm/fleet/assets/71795832/ebdbbd67-2f01-404c-b1d9-5125d806303a">



# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Manual QA for all new/changed functionality
