### PR TITLE
Fix broken link in GitOps docs

### DIFF
--- a/docs/Using Fleet/GitOps.md
+++ b/docs/Using Fleet/GitOps.md
@@ -5,7 +5,7 @@ Use Fleet's best practice GitOps workflow to manage your computers as code.
 
 To learn how to set up a GitOps workflow see the [Fleet GitOps repo](https://github.com/fleetdm/fleet-gitops).
 
-> For one-off imports and updates via fleetctl, see the [`fleetctl apply`]((https://github.com/fleetdm/fleet/blob/main/docs/Contributing/Configuration-files.md)) format.
+> For one-off imports and updates via fleetctl, see the [`fleetctl apply`](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/Configuration-files.md) format.
 
 ## File structure
 


### PR DESCRIPTION
Changes:
- Fixed a broken link on the GitOps documentation page