### PR TITLE
Fleetctl: Add YAML validation error for apply command

### DIFF
--- a/changes/20075-fleetctl-apply-validation
+++ b/changes/20075-fleetctl-apply-validation
@@ -1,0 +1,1 @@
+- Add .yml and .yaml file type validation and error message to fleetctl apply

--- a/cmd/fleetctl/apply.go
+++ b/cmd/fleetctl/apply.go
@@ -66,7 +66,7 @@ func applyCommand() *cli.Command {
 			// Check if the file has a .yml or .yaml extension
 			ext := strings.ToLower(filepath.Ext(flFilename))
 			if ext == "" {
-				return fmt.Errorf("Missing file extension: only .yml or .yaml files can be applied")
+				return errors.New("Missing file extension: only .yml or .yaml files can be applied")
 			}
 			if ext != ".yml" && ext != ".yaml" {
 				return fmt.Errorf("Invalid file extension %s: only .yml or .yaml files can be applied", ext)

--- a/cmd/fleetctl/apply.go
+++ b/cmd/fleetctl/apply.go
@@ -65,8 +65,11 @@ func applyCommand() *cli.Command {
 
 			// Check if the file has a .yml or .yaml extension
 			ext := strings.ToLower(filepath.Ext(flFilename))
+			if ext == "" {
+				return fmt.Errorf("Missing file extension: only .yml or .yaml files can be applied")
+			}
 			if ext != ".yml" && ext != ".yaml" {
-				return fmt.Errorf("Invalid file extension %s: only .yml or .yaml files can be applied\n", ext)
+				return fmt.Errorf("Invalid file extension %s: only .yml or .yaml files can be applied", ext)
 			}
 
 			specs, err := spec.GroupFromBytes(b)

--- a/cmd/fleetctl/apply.go
+++ b/cmd/fleetctl/apply.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/fleetdm/fleet/v4/pkg/spec"
 	"github.com/fleetdm/fleet/v4/server/fleet"
@@ -61,6 +62,13 @@ func applyCommand() *cli.Command {
 			if err != nil {
 				return err
 			}
+
+			// Check if the file has a .yml or .yaml extension
+			ext := strings.ToLower(filepath.Ext(flFilename))
+			if ext != ".yml" && ext != ".yaml" {
+				return fmt.Errorf("Invalid file extension %s: only .yml or .yaml files can be applied\n", ext)
+			}
+
 			specs, err := spec.GroupFromBytes(b)
 			if err != nil {
 				return err


### PR DESCRIPTION
## Issue
Cerra #20075

## Description
- Fix: When trying to apply a non-YAML file, the user will see an error without it's contents spilled out

## Screenrecording


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
- [x] Added/updated tests
- [x] Manual QA for all new/changed functionality

