### PR TITLE
Fleet UI: Add a tooltip to truncated text only

### DIFF
--- a/changes/20236-tooltip-on-truncation
+++ b/changes/20236-tooltip-on-truncation
@@ -1,0 +1,1 @@
+- UI: Adds a tooltip to truncated text and not to untruncated values

--- a/frontend/components/TableContainer/DataTable/TooltipTruncatedTextCell/TooltipTruncatedTextCell.tsx
+++ b/frontend/components/TableContainer/DataTable/TooltipTruncatedTextCell/TooltipTruncatedTextCell.tsx
@@ -39,7 +39,6 @@ const TooltipTruncatedTextCell = ({
 
   useLayoutEffect(() => {
     if (ref?.current !== null) {
-      console.log("ref.current", ref.current);
       setOffsetWidth(ref.current.offsetWidth);
       setScrollWidth(ref.current.scrollWidth);
     }

--- a/frontend/components/TableContainer/DataTable/TooltipTruncatedTextCell/TooltipTruncatedTextCell.tsx
+++ b/frontend/components/TableContainer/DataTable/TooltipTruncatedTextCell/TooltipTruncatedTextCell.tsx
@@ -2,7 +2,7 @@ import React, { useState, useRef, useLayoutEffect } from "react";
 import { uniqueId } from "lodash";
 import classnames from "classnames";
 
-import { Tooltip as ReactTooltip, PlacesType } from "react-tooltip-5";
+import ReactTooltip from "react-tooltip";
 import { DEFAULT_EMPTY_CELL_VALUE } from "utilities/constants";
 import { COLORS } from "styles/var/colors";
 

--- a/frontend/components/TableContainer/DataTable/TooltipTruncatedTextCell/TooltipTruncatedTextCell.tsx
+++ b/frontend/components/TableContainer/DataTable/TooltipTruncatedTextCell/TooltipTruncatedTextCell.tsx
@@ -1,8 +1,8 @@
-import React, { useState, useLayoutEffect, useRef } from "react";
+import React, { useState, useRef, useLayoutEffect } from "react";
 import { uniqueId } from "lodash";
 import classnames from "classnames";
 
-import ReactTooltip from "react-tooltip";
+import { Tooltip as ReactTooltip, PlacesType } from "react-tooltip-5";
 import { DEFAULT_EMPTY_CELL_VALUE } from "utilities/constants";
 import { COLORS } from "styles/var/colors";
 
@@ -34,16 +34,15 @@ const TooltipTruncatedTextCell = ({
 
   // Tooltip visibility logic: Enable only when text is truncated
   const ref = useRef<HTMLInputElement>(null);
-  const [offsetWidth, setOffsetWidth] = useState(0);
-  const [scrollWidth, setScrollWidth] = useState(0);
+  const [tooltipDisabled, setTooltipDisabled] = useState(true);
 
   useLayoutEffect(() => {
     if (ref?.current !== null) {
-      setOffsetWidth(ref.current.offsetWidth);
-      setScrollWidth(ref.current.scrollWidth);
+      const scrollWidth = ref.current.scrollWidth;
+      const offsetWidth = ref.current.offsetWidth;
+      setTooltipDisabled(scrollWidth <= offsetWidth);
     }
   }, [ref]);
-  const tooltipDisabled = offsetWidth === scrollWidth;
   // End
 
   const tooltipId = uniqueId();

--- a/frontend/components/TableContainer/DataTable/TooltipTruncatedTextCell/_styles.scss
+++ b/frontend/components/TableContainer/DataTable/TooltipTruncatedTextCell/_styles.scss
@@ -10,9 +10,19 @@
       text-overflow: ellipsis;
       max-width: 101%;
     }
+
+    .truncated {
+      display: inline-block;
+      max-width: 100%;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
   }
 
   .truncated-tooltip {
+    text-wrap: wrap;
+    overflow-wrap: break-word;
+
     .safari-hack {
       height: 0px;
     }

--- a/frontend/components/TooltipTruncatedText/TooltipTruncatedText.tsx
+++ b/frontend/components/TooltipTruncatedText/TooltipTruncatedText.tsx
@@ -1,9 +1,8 @@
-import React, { useState, useLayoutEffect, useRef } from "react";
+import React, { useState, useRef, useLayoutEffect } from "react";
 import { uniqueId } from "lodash";
 import classnames from "classnames";
 
 import ReactTooltip from "react-tooltip";
-import { DEFAULT_EMPTY_CELL_VALUE } from "utilities/constants";
 import { COLORS } from "styles/var/colors";
 
 interface ITooltipTruncatedTextCellProps {
@@ -14,21 +13,18 @@ interface ITooltipTruncatedTextCellProps {
   /** If set to `true` the text inside the tooltip will break on words instead of any character.
    * By default the tooltip text breaks on any character. Default: false */
   tooltipBreakOnWord?: boolean;
-  /** @deprecated use the prop `className` in order to add custom classes to this component */
-  classes?: string;
   className?: string;
 }
 
-const baseClass = "tooltip-truncated-cell";
+const baseClass = "tooltip-truncated-text";
 
-const TooltipTruncatedTextCell = ({
+const TooltipTruncatedText = ({
   value,
   tooltip,
   tooltipBreakOnWord = false,
-  classes = "w250",
   className,
 }: ITooltipTruncatedTextCellProps): JSX.Element => {
-  const classNames = classnames(baseClass, classes, className, {
+  const classNames = classnames(baseClass, className, {
     "tooltip-break-on-word": tooltipBreakOnWord,
   });
 
@@ -48,23 +44,10 @@ const TooltipTruncatedTextCell = ({
   // End
 
   const tooltipId = uniqueId();
-  const isDefaultValue = value === DEFAULT_EMPTY_CELL_VALUE;
-
   return (
     <div ref={ref} className={classNames}>
-      <div
-        className="data-table__tooltip-truncated-text"
-        data-tip
-        data-for={tooltipId}
-        data-tip-disable={isDefaultValue || tooltipDisabled}
-      >
-        <span
-          className={`data-table__tooltip-truncated-text--cell ${
-            isDefaultValue ? "text-muted" : ""
-          } ${tooltipDisabled ? "" : "truncated"}`}
-        >
-          {value}
-        </span>
+      <div className={"tooltip-truncated"} data-tip data-for={tooltipId}>
+        <span className={tooltipDisabled ? "" : "truncated"}>{value}</span>
       </div>
       <ReactTooltip
         place="top"
@@ -75,6 +58,7 @@ const TooltipTruncatedTextCell = ({
         className="truncated-tooltip" // responsive widths
         clickable
         delayHide={200} // need delay set to hover using clickable
+        disable={tooltipDisabled}
       >
         <>
           {tooltip ?? value}
@@ -86,4 +70,4 @@ const TooltipTruncatedTextCell = ({
   );
 };
 
-export default TooltipTruncatedTextCell;
+export default TooltipTruncatedText;

--- a/frontend/components/TooltipTruncatedText/TooltipTruncatedText.tsx
+++ b/frontend/components/TooltipTruncatedText/TooltipTruncatedText.tsx
@@ -30,16 +30,15 @@ const TooltipTruncatedText = ({
 
   // Tooltip visibility logic: Enable only when text is truncated
   const ref = useRef<HTMLInputElement>(null);
-  const [offsetWidth, setOffsetWidth] = useState(0);
-  const [scrollWidth, setScrollWidth] = useState(0);
+  const [tooltipDisabled, setTooltipDisabled] = useState(true);
 
   useLayoutEffect(() => {
     if (ref?.current !== null) {
-      setOffsetWidth(ref.current.offsetWidth);
-      setScrollWidth(ref.current.scrollWidth);
+      const scrollWidth = ref.current.scrollWidth;
+      const offsetWidth = ref.current.offsetWidth;
+      setTooltipDisabled(scrollWidth <= offsetWidth);
     }
   }, [ref]);
-  const tooltipDisabled = offsetWidth === scrollWidth;
   // End
 
   const tooltipId = uniqueId();

--- a/frontend/components/TooltipTruncatedText/TooltipTruncatedText.tsx
+++ b/frontend/components/TooltipTruncatedText/TooltipTruncatedText.tsx
@@ -35,7 +35,6 @@ const TooltipTruncatedText = ({
 
   useLayoutEffect(() => {
     if (ref?.current !== null) {
-      console.log("ref.current", ref.current);
       setOffsetWidth(ref.current.offsetWidth);
       setScrollWidth(ref.current.scrollWidth);
     }

--- a/frontend/components/TooltipTruncatedText/_styles.scss
+++ b/frontend/components/TooltipTruncatedText/_styles.scss
@@ -1,0 +1,33 @@
+.tooltip-truncated-text {
+  .tooltip-truncated {
+    max-width: 100%;
+  }
+
+  .truncated {
+    display: inline-block;
+    max-width: 99%;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .inner-text {
+    text-overflow: ellipsis;
+    overflow: hidden;
+    white-space: nowrap;
+  }
+  .truncated-tooltip {
+    text-wrap: wrap;
+    overflow-wrap: break-word;
+
+    .safari-hack {
+      height: 0px;
+    }
+  }
+
+  // allows for the tooltip text to break on a word instead of a character
+  &.tooltip-break-on-word {
+    .truncated-tooltip {
+      word-break: normal;
+    }
+  }
+}

--- a/frontend/components/TooltipTruncatedText/index.ts
+++ b/frontend/components/TooltipTruncatedText/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./TooltipTruncatedText";

--- a/frontend/pages/hosts/details/cards/Software/SoftwareDetailsModal/SoftwareDetailsModal.tsx
+++ b/frontend/pages/hosts/details/cards/Software/SoftwareDetailsModal/SoftwareDetailsModal.tsx
@@ -14,6 +14,7 @@ import DataSet from "components/DataSet";
 import { dateAgo } from "utilities/date_format";
 
 import { SoftwareInstallDetails } from "pages/SoftwarePage/components/SoftwareInstallDetails";
+import TooltipTruncatedText from "components/TooltipTruncatedText";
 
 const baseClass = "software-details-modal";
 
@@ -42,8 +43,14 @@ const SoftwareDetailsInfo = ({
   source,
   bundleIdentifier,
 }: ISoftwareDetailsInfoProps) => {
-  const { vulnerabilities, installed_paths } = installedVersion;
+  const { vulnerabilities } = installedVersion;
 
+  const installed_paths = [
+    "/System/Library/PrivateFrameworks/AppleMediaServicesUI.framework/Versions/A/Resources/AMSEngagementViewService.app",
+    "Fake/System/Library/PrivateFrameworks/AppleMediaServicesUI.framework/Versions/A/Resources/AMSEngagementViewService.app",
+    "Fake2/System/Library/PrivateFrameworks/AppleMediaServicesUI.framework/Versions/A/Resources/AMSEngagementViewService.app",
+    "short/file/path",
+  ];
   return (
     <div className={`${baseClass}__details-info`}>
       <div className={`${baseClass}__row`}>
@@ -67,7 +74,7 @@ const SoftwareDetailsInfo = ({
             value={
               <div className={`${baseClass}__file-path-values`}>
                 {installed_paths.map((path) => (
-                  <span key={path}>{path}</span>
+                  <TooltipTruncatedText value={path} />
                 ))}
               </div>
             }

--- a/frontend/pages/hosts/details/cards/Software/SoftwareDetailsModal/SoftwareDetailsModal.tsx
+++ b/frontend/pages/hosts/details/cards/Software/SoftwareDetailsModal/SoftwareDetailsModal.tsx
@@ -43,14 +43,8 @@ const SoftwareDetailsInfo = ({
   source,
   bundleIdentifier,
 }: ISoftwareDetailsInfoProps) => {
-  const { vulnerabilities } = installedVersion;
+  const { vulnerabilities, installed_paths } = installedVersion;
 
-  const installed_paths = [
-    "/System/Library/PrivateFrameworks/AppleMediaServicesUI.framework/Versions/A/Resources/AMSEngagementViewService.app",
-    "Fake/System/Library/PrivateFrameworks/AppleMediaServicesUI.framework/Versions/A/Resources/AMSEngagementViewService.app",
-    "Fake2/System/Library/PrivateFrameworks/AppleMediaServicesUI.framework/Versions/A/Resources/AMSEngagementViewService.app",
-    "short/file/path",
-  ];
   return (
     <div className={`${baseClass}__details-info`}>
       <div className={`${baseClass}__row`}>


### PR DESCRIPTION
## Issue
Cerra #20236

## Description
- Fix truncated text cells to only show tooltip if the text is truncated
- Fix host details > software > details > paths to show tooltip if the text is truncated

Truncated text cell and truncated text are extremely similar, if time allows, iterate to combine the two while maintaining functionality.

Note: this method was orginally in our code base on https://github.com/fleetdm/fleet/pull/7613

## Screenrecording
https://www.loom.com/share/a4ac4ea5e56e481a8bfd27af0771b676?sid=ac4644bd-bb4c-4359-9f88-2d2a199a064b

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
- [x] Manual QA for all new/changed functionality

