### PR TITLE
Update go.mod

### DIFF
--- a/tools/terraform/go.mod
+++ b/tools/terraform/go.mod
@@ -1,6 +1,6 @@
 module terraform-provider-fleetdm
 
-go 1.22
+go 1.22.4
 
 require (
 	github.com/hashicorp/terraform-plugin-framework v1.7.0


### PR DESCRIPTION
Fixes code scanning warning: 

As of Go 1.21, toolchain versions [must use the 1.N.P syntax](https://go.dev/doc/toolchain#version).

1.22 in tools/terraform/go.mod does not match this syntax and there is no additional toolchain directive, which may cause some go commands to fail.