### PR TITLE
Handle UTC timezone in `fleetd_logs` address #20263

### DIFF
--- a/orbit/changes/20263-fleetd_logs_utc
+++ b/orbit/changes/20263-fleetd_logs_utc
@@ -1,0 +1,1 @@
+- Fix bug where UTC timezone could cause error in `fleetd_logs` table time parsing

--- a/orbit/pkg/table/fleetd_logs/fleetd_logs.go
+++ b/orbit/pkg/table/fleetd_logs/fleetd_logs.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"strings"
 	"sync"
 	"time"
 
@@ -135,12 +134,7 @@ func processLogEntry(event []byte) ([]Event, error) {
 		var sqliteTime string
 		evtTime, ok := evt["time"].(string)
 		if ok {
-			// UTC times sometimes end in Z instead of time offset.
-			// Replace it with a regular offset so we can parse it
-			if strings.HasSuffix(evtTime, "Z") {
-				evtTime = evtTime[:len(evtTime)-1] + "+00:00"
-			}
-			goTime, err := time.Parse("2006-01-02T15:04:05-07:00", evtTime)
+			goTime, err := time.Parse(time.RFC3339, evtTime)
 			if err != nil {
 				return nil, fmt.Errorf("processLogEntry parsing time: %w", err)
 			}

--- a/orbit/pkg/table/fleetd_logs/fleetd_logs.go
+++ b/orbit/pkg/table/fleetd_logs/fleetd_logs.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"strings"
 	"sync"
 	"time"
 
@@ -134,6 +135,11 @@ func processLogEntry(event []byte) ([]Event, error) {
 		var sqliteTime string
 		evtTime, ok := evt["time"].(string)
 		if ok {
+			// UTC times sometimes end in Z instead of time offset.
+			// Replace it with a regular offset so we can parse it
+			if strings.HasSuffix(evtTime, "Z") {
+				evtTime = evtTime[:len(evtTime)-1] + "+00:00"
+			}
 			goTime, err := time.Parse("2006-01-02T15:04:05-07:00", evtTime)
 			if err != nil {
 				return nil, fmt.Errorf("processLogEntry parsing time: %w", err)


### PR DESCRIPTION
# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.