### PR TITLE
Website: Set leadSource on new contact records

### DIFF
--- a/website/api/controllers/save-questionnaire-progress.js
+++ b/website/api/controllers/save-questionnaire-progress.js
@@ -218,6 +218,7 @@ module.exports = {
         primaryBuyingSituation: primaryBuyingSituation === 'eo-security' ? 'Endpoint operations - Security' : primaryBuyingSituation === 'eo-it' ? 'Endpoint operations - IT' : primaryBuyingSituation === 'mdm' ? 'Device management (MDM)' : primaryBuyingSituation === 'vm' ? 'Vulnerability management' : undefined,
         organization: this.req.me.organization,
         psychologicalStage,
+        leadSource: 'Website - Sign up',
       }).exec((err)=>{
         if(err){
           sails.log.warn(`Background task failed: When a user (email: ${this.req.me.emailAddress} submitted a step of the get started questionnaire, a Contact and Account record could not be created/updated in the CRM.`, err);

--- a/website/api/helpers/salesforce/update-or-create-contact-and-account-and-create-lead.js
+++ b/website/api/helpers/salesforce/update-or-create-contact-and-account-and-create-lead.js
@@ -72,6 +72,7 @@ module.exports = {
       linkedinUrl,
       primaryBuyingSituation,
       psychologicalStage,
+      leadSource,
     });
 
     await sails.helpers.salesforce.createLead.with({

--- a/website/api/helpers/salesforce/update-or-create-contact-and-account.js
+++ b/website/api/helpers/salesforce/update-or-create-contact-and-account.js
@@ -29,6 +29,13 @@ module.exports = {
         '6 - Has team buy-in'
       ]
     },
+    leadSource: {
+      type: 'string',
+      isIn: [
+        'Website - Contact forms',
+        'Website - Sign up',
+      ],
+    },
   },
 
 
@@ -44,7 +51,7 @@ module.exports = {
   },
 
 
-  fn: async function ({emailAddress, linkedinUrl, firstName, lastName, organization, primaryBuyingSituation, psychologicalStage}) {
+  fn: async function ({emailAddress, linkedinUrl, firstName, lastName, organization, primaryBuyingSituation, psychologicalStage, leadSource}) {
     // Return undefined if we're not running in a production environment.
     if(sails.config.environment !== 'production') {
       sails.log.verbose('Skipping Salesforce integration...');
@@ -88,7 +95,6 @@ module.exports = {
     if(psychologicalStage) {
       valuesToSet.Stage__c = psychologicalStage;// eslint-disable-line camelcase
     }
-
 
     let existingContactRecord;
     // Search for an existing Contact record using the provided email address or linkedIn profile URL.
@@ -184,6 +190,10 @@ module.exports = {
         // console.log('New account created!', salesforceAccountId);
       }//ﬁ
 
+      // Only add leadSource to valuesToSet if we're creating a new contact record.
+      if(leadSource) {
+        valuesToSet.LeadSource = leadSource;
+      }
       // console.log(`creating new Contact record.`)
       // Create a new Contact record for this person.
       let newContactRecord = await salesforceConnection.sobject('Contact')


### PR DESCRIPTION
Closes: #20284

Changes:
- Updated the `update-or-create-contact-and-account` helper to set a lead source on new contact records
- Updated `update-or-create-contact-and-account-and-create-lead` to to pass in a lead source to the `update-or-create-contact-and-account` helper
- Updated save-questionnaire-progress to set a lead source on newly created contact records