### PR TITLE
cover edge case for alternative zoom installer (#20286)

### DIFF
--- a/pkg/file/testdata/distribution/distribution-zoom-full.xml
+++ b/pkg/file/testdata/distribution/distribution-zoom-full.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<installer-gui-script minSpecVersion="1">
+  <pkg-ref id="us.zoom.pkg.videomeeting"/>
+  <title>Zoom Workplace</title>
+  <options hostArchitectures="x86_64,arm64"/>
+  <options customize="never"/>
+  <domains enable_currentUserHome="true" enable_localSystem="true"/>
+  <options customLocation="Applications" customLocationAllowAlternateVolumes="true"/>
+  <options allow-external-scripts="false"/>
+  <welcome file="Welcome.rtf"/>
+  <!--    
+    <readme file="ReadMe.rtf"/>
+-->
+  <background file="background.png" scaling="proportional" alignment="bottomleft"/>
+  <allowed-os-versions>
+    <os-version min="10.13"/>
+  </allowed-os-versions>
+  <pkg-ref id="us.zoom.pkg.videomeeting">
+    <must-close>
+      <app id="us.zoom.xos"/>
+    </must-close>
+    <bundle-version/>
+  </pkg-ref>
+  <choices-outline>
+    <line choice="default">
+      <line choice="us.zoom.pkg.videomeeting"/>
+    </line>
+  </choices-outline>
+  <choice id="default"/>
+  <choice id="us.zoom.pkg.videomeeting" visible="false">
+    <pkg-ref id="us.zoom.pkg.videomeeting"/>
+  </choice>
+  <pkg-ref id="us.zoom.pkg.videomeeting" version="6.1.1.36333" onConclusion="none" installKBytes="308054">#zoomus.pkg</pkg-ref>
+  <product version="6.1.1.36333"/>
+</installer-gui-script>

--- a/pkg/file/xar.go
+++ b/pkg/file/xar.go
@@ -262,7 +262,11 @@ out:
 				identifier = pkg.MustClose.Apps[0].ID
 				break
 			}
+		}
+	}
 
+	if identifier == "" {
+		for _, pkg := range d.PkgRefs {
 			if pkg.PackageIdentifier != "" {
 				identifier = pkg.PackageIdentifier
 				break

--- a/pkg/file/xar_test.go
+++ b/pkg/file/xar_test.go
@@ -154,6 +154,12 @@ func TestParseRealDistributionFiles(t *testing.T) {
 			expectedVersion:  "24.1.32.9774",
 			expectedBundleID: "com.ringcentral.glip",
 		},
+		{
+			file:             "distribution-zoom-full.xml",
+			expectedName:     "Zoom Workplace",
+			expectedVersion:  "6.1.1.36333",
+			expectedBundleID: "us.zoom.xos",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
> [!NOTE]
> This PR already merged in `main`, see https://github.com/fleetdm/fleet/pull/20286. This is against the release branch so it can be included in 4.54.0

Zoom offers two installers:

- Zoom for IT admins (already covered previously)
- "Regular" Zoom (covered here)

This tweaks the logic made as part of #19144 to ensure we cover both

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Added/updated tests
- [x] Manual QA for all new/changed functionality

