### PR TITLE
add bundle_identifier to software titles responses (#20298)

### DIFF
--- a/server/datastore/mysql/software_titles.go
+++ b/server/datastore/mysql/software_titles.go
@@ -31,6 +31,7 @@ SELECT
 	st.name,
 	st.source,
 	st.browser,
+	st.bundle_identifier,
 	COALESCE(SUM(sthc.hosts_count), 0) as hosts_count,
 	MAX(sthc.updated_at)  as counts_updated_at
 FROM software_titles st
@@ -200,6 +201,7 @@ SELECT
 	st.name,
 	st.source,
 	st.browser,
+	st.bundle_identifier,
 	MAX(COALESCE(sthc.hosts_count, 0)) as hosts_count,
 	MAX(COALESCE(sthc.updated_at, date('0001-01-01 00:00:00'))) as counts_updated_at,
 	si.filename as software_package,

--- a/server/fleet/software.go
+++ b/server/fleet/software.go
@@ -169,7 +169,7 @@ type SoftwareTitle struct {
 	// BundleIdentifier is used by Apple installers to uniquely identify
 	// the software installed. It's surfaced in software_titles to match
 	// with existing software entries.
-	BundleIdentifier *string `json:"-" db:"bundle_identifier"`
+	BundleIdentifier *string `json:"bundle_identifier,omitempty" db:"bundle_identifier"`
 }
 
 // This type is essentially the same as the above SoftwareTitle type. The only difference is that
@@ -196,6 +196,10 @@ type SoftwareTitleListResult struct {
 	SoftwarePackage *string `json:"software_package" db:"software_package"`
 	// SelfService indicates if the end user can initiate the installation
 	SelfService bool `json:"self_service" db:"self_service"`
+	// BundleIdentifier is used by Apple installers to uniquely identify
+	// the software installed. It's surfaced in software_titles to match
+	// with existing software entries.
+	BundleIdentifier *string `json:"bundle_identifier,omitempty" db:"bundle_identifier"`
 }
 
 type SoftwareTitleListOptions struct {


### PR DESCRIPTION
> [!NOTE]
> This PR already merged in `main`, see https://github.com/fleetdm/fleet/pull/20298. This is against the release branch so it can be included in 4.54.0

final bit for #19144, doc changes will be made separately

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Added/updated tests
- [x] Manual QA for all new/changed functionality
