### PR TITLE
separate queries for software matching to use indexes

### DIFF
--- a/server/datastore/mysql/software.go
+++ b/server/datastore/mysql/software.go
@@ -1652,24 +1652,37 @@ ON DUPLICATE KEY UPDATE
 		level.Debug(ds.logger).Log("msg", "upsert software titles", "rows_affected", n)
 
 		// update title ids for software table entries
-		updateSoftwareStmt := `
+		updateSoftwareWithoutIdentifierStmt := `
 UPDATE software s
 JOIN software_titles st
-ON (
-    s.bundle_identifier = st.bundle_identifier
-    OR (COALESCE(s.bundle_identifier, '') = '' AND (s.name, s.source, s.browser) = (st.name, st.source, st.browser))
-)
+ON COALESCE(s.bundle_identifier, '') = '' AND s.name = st.name AND s.source = st.source AND s.browser = st.browser
+SET s.title_id = st.id
+WHERE (s.title_id IS NULL OR s.title_id != st.id)
+AND COALESCE(s.bundle_identifier, '') = '';
+`
+
+		res, err = tx.ExecContext(ctx, updateSoftwareWithoutIdentifierStmt)
+		if err != nil {
+			return ctxerr.Wrap(ctx, err, "update software title_id without bundle identifier")
+		}
+		n, _ = res.RowsAffected()
+		level.Debug(ds.logger).Log("msg", "update software title_id without bundle identifier", "rows_affected", n)
+
+		updateSoftwareWithIdentifierStmt := `
+UPDATE software s
+JOIN software_titles st
+ON s.bundle_identifier = st.bundle_identifier
 SET s.title_id = st.id
 WHERE s.title_id IS NULL
 OR s.title_id != st.id;
 `
 
-		res, err = tx.ExecContext(ctx, updateSoftwareStmt)
+		res, err = tx.ExecContext(ctx, updateSoftwareWithIdentifierStmt)
 		if err != nil {
-			return ctxerr.Wrap(ctx, err, "update software title_id")
+			return ctxerr.Wrap(ctx, err, "update software title_id with bundle identifier")
 		}
 		n, _ = res.RowsAffected()
-		level.Debug(ds.logger).Log("msg", "update software title_id", "rows_affected", n)
+		level.Debug(ds.logger).Log("msg", "update software title_id with bundle identifier", "rows_affected", n)
 
 		// clean up orphaned software titles
 		cleanupStmt := `


### PR DESCRIPTION
during load testing we found this query to be a bottleneck, locally splitting in to two different statements makes a difference since we can effectively use the indexes.

```
mysql> explain UPDATE software s
    -> JOIN software_titles st
    -> ON COALESCE(s.bundle_identifier, '') = '' AND s.name = st.name AND s.source = st.source AND s.browser = st.browser
    -> SET s.title_id = st.id
    -> WHERE (s.title_id IS NULL OR s.title_id != st.id)
    -> AND COALESCE(s.bundle_identifier, '') = '';
+----+-------------+-------+------------+-------+-------------------------------------------------------------------------------------+----------------------------+---------+------------------------------------------------+------+----------+-------------+
| id | select_type | table | partitions | type  | possible_keys                                                                       | key                        | key_len | ref                                            | rows | filtered | Extra       |
+----+-------------+-------+------------+-------+-------------------------------------------------------------------------------------+----------------------------+---------+------------------------------------------------+------+----------+-------------+
|  1 | SIMPLE      | st    | NULL       | index | idx_sw_titles                                                                       | idx_sw_titles              | 2302    | NULL                                           |  765 |   100.00 | Using index |
|  1 | UPDATE      | s     | NULL       | ref   | software_listing_idx,software_source_vendor_idx,title_id,idx_sw_name_source_browser | idx_sw_name_source_browser | 2302    | fleet.st.name,fleet.st.source,fleet.st.browser |    1 |    91.00 | Using where |
+----+-------------+-------+------------+-------+-------------------------------------------------------------------------------------+----------------------------+---------+------------------------------------------------+------+----------+-------------+
2 rows in set (0.00 sec)

mysql> explain UPDATE software s
    -> JOIN software_titles st
    -> ON s.bundle_identifier = st.bundle_identifier
    -> SET s.title_id = st.id
    -> WHERE s.title_id IS NULL
    -> OR s.title_id != st.id;
+----+-------------+-------+------------+------+-----------------------------------------------------+---------------------------------------+---------+---------------------------+------+----------+--------------------------+
| id | select_type | table | partitions | type | possible_keys                                       | key                                   | key_len | ref                       | rows | filtered | Extra                    |
+----+-------------+-------+------------+------+-----------------------------------------------------+---------------------------------------+---------+---------------------------+------+----------+--------------------------+
|  1 | UPDATE      | s     | NULL       | ALL  | title_id,idx_software_bundle_id                     | NULL                                  | NULL    | NULL                      |  788 |   100.00 | Using where              |
|  1 | SIMPLE      | st    | NULL       | ref  | idx_software_titles_bundle_identifier,idx_composite | idx_software_titles_bundle_identifier | 1023    | fleet.s.bundle_identifier |    1 |   100.00 | Using where; Using index |
+----+-------------+-------+------------+------+-----------------------------------------------------+---------------------------------------+---------+---------------------------+------+----------+--------------------------+
2 rows in set (0.00 sec)
```

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Manual QA for all new/changed functionality
