### PR TITLE
UI – Make spacing between `DataSet` label and value on Firefox consistent with other browsers

### DIFF
--- a/changes/20363-fix-dataset-spacing-on-firefox
+++ b/changes/20363-fix-dataset-spacing-on-firefox
@@ -1,0 +1,2 @@
+* Fixed a discrepancy in the spacing between DataSet labels and values on Firefox relative to other
+browsers.

--- a/frontend/components/DataSet/_styles.scss
+++ b/frontend/components/DataSet/_styles.scss
@@ -2,6 +2,13 @@
   font-size: $x-small;
   min-width: max-content;
 
+  // ff only
+  @-moz-document url-prefix() {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+  }
+
   dt {
     font-weight: $bold;
     display: flex;


### PR DESCRIPTION
## Addresses #20363 

<img width="1170" alt="Screenshot 2024-07-10 at 3 05 36 PM" src="https://github.com/fleetdm/fleet/assets/61553566/14a16330-e0fb-4a27-889d-dfe8dccb5d7b">

- [x] Changes file added for user-visible changes in `changes/`, 
- [x] Manual QA for all new/changed functionality