### PR TITLE
backport: bypass not found mdm commands (#20369)

### DIFF
--- a/changes/20367-command-uuid
+++ b/changes/20367-command-uuid
@@ -1,0 +1,1 @@
+* Avoid returning a 500 status code if a host sends a command response with an invalid command uuid.

--- a/server/mdm/nanomdm/storage/mysql/queue.go
+++ b/server/mdm/nanomdm/storage/mysql/queue.go
@@ -119,6 +119,23 @@ func (m *MySQLStorage) StoreCommandReport(r *mdm.Request, result *mdm.CommandRes
 	if result.Status == "Idle" {
 		return nil
 	}
+
+	// ensure there's a matching command
+	matchingRow := m.db.QueryRowContext(
+		r.Context,
+		`SELECT 1 FROM nano_commands WHERE command_uuid = ?`,
+		result.CommandUUID,
+	)
+	var matchingCount int
+	if err := matchingRow.Scan(&matchingCount); err != nil {
+		return err
+	}
+	// this should be already handed by the error value in Scan above, but
+	// just to be safe
+	if matchingCount == 0 {
+		return sql.ErrNoRows
+	}
+
 	if m.rm && result.Status != "NotNow" {
 		return m.deleteCommandTx(r, result)
 	}


### PR DESCRIPTION
> [!NOTE]
> This PR already merged in `main`, see https://github.com/fleetdm/fleet/pull/20369. This is against the release branch so it can be included in 4.54.0

for #20367

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
See [Changes
files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [x] Added/updated tests
- [x] Manual QA for all new/changed functionality
