### PR TITLE
Fix UI bug where "Script is already running" tooltip incorrectly displayed when script is not running

### DIFF
--- a/changes/20293-script-pending-tooltip
+++ b/changes/20293-script-pending-tooltip
@@ -1,2 +1,1 @@
-- Fixed UI issue where "Script is already running" tooltip was incorrectly displayed when the script
-  was not runing.
+- Fixed UI issue where "Script is already running" tooltip incorrectly displayed when the script is not running.

--- a/changes/20293-script-pending-tooltip
+++ b/changes/20293-script-pending-tooltip
@@ -1,0 +1,2 @@
+- Fixed UI issue where "Script is already running" tooltip was incorrectly displayed when the script
+  was not runing.

--- a/frontend/pages/hosts/details/HostDetailsPage/modals/RunScriptModal/ScriptsTableConfig.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/modals/RunScriptModal/ScriptsTableConfig.tsx
@@ -1,8 +1,4 @@
 import React from "react";
-import ReactTooltip from "react-tooltip";
-import { noop } from "lodash";
-
-import { COLORS } from "styles/var/colors";
 
 import { IDropdownOption } from "interfaces/dropdownOption";
 import { IHostScript, ILastExecution } from "interfaces/script";
@@ -42,6 +38,7 @@ const generateActionDropdownOptions = (
   teamId: number | null,
   { last_execution }: IHostScript
 ): IDropdownOption[] => {
+  const isPending = last_execution?.status === "pending";
   const hasRunPermission =
     !!currentUser &&
     (isGlobalAdmin(currentUser) ||
@@ -58,14 +55,15 @@ const generateActionDropdownOptions = (
       disabled: last_execution === null,
       value: "showDetails",
     },
-    {
-      label: "Run",
-      disabled: last_execution?.status === "pending",
-      value: "run",
-      tooltipContent: "Script is already running.",
-    },
   ];
-  return hasRunPermission ? options : options.slice(0, 1);
+  hasRunPermission &&
+    options.push({
+      label: "Run",
+      disabled: isPending,
+      value: "run",
+      tooltipContent: isPending ? "Script is already running." : undefined,
+    });
+  return options;
 };
 
 // eslint-disable-next-line import/prefer-default-export


### PR DESCRIPTION
Issue #20293 

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [x] Manual QA for all new/changed functionality

