### PR TITLE
For RC 4.54.0 (UI – Make spacing between `DataSet` label and value on Firefox consistent with other browsers)

### DIFF
--- a/changes/20363-fix-dataset-spacing-on-firefox
+++ b/changes/20363-fix-dataset-spacing-on-firefox
@@ -1,0 +1,2 @@
+* Fixed a discrepancy in the spacing between DataSet labels and values on Firefox relative to other
+browsers.

--- a/frontend/components/DataSet/_styles.scss
+++ b/frontend/components/DataSet/_styles.scss
@@ -2,6 +2,13 @@
   font-size: $x-small;
   min-width: max-content;
 
+  // ff only
+  @-moz-document url-prefix() {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+  }
+
   dt {
     font-weight: $bold;
     display: flex;


### PR DESCRIPTION
> [!NOTE]
> This PR already merged in `main`, see https://github.com/fleetdm/fleet/pull/20366. This is against the release branch so it can be included in 4.54.0
