### PR TITLE
Fix TestIntegrations/TestGetHostSoftwareUpdatedAt

### DIFF
--- a/server/service/integration_core_test.go
+++ b/server/service/integration_core_test.go
@@ -7963,7 +7963,7 @@ func (s *integrationTestSuite) TestGetHostSoftwareUpdatedAt() {
 		LabelUpdatedAt:  time.Now(),
 		PolicyUpdatedAt: time.Now(),
 		SeenTime:        time.Now(),
-		NodeKey:         ptr.String(t.Name() + "1"),
+		NodeKey:         ptr.String(strings.ReplaceAll(t.Name(), "/", "_") + "1"),
 		UUID:            t.Name() + "1",
 		Hostname:        t.Name() + "foo.local",
 		PrimaryIP:       "192.168.1.1",


### PR DESCRIPTION
Fix failing test `TestIntegrations/TestGetHostSoftwareUpdatedAt`