### PR TITLE
Documentation for query_report_cap config

### DIFF
--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -1340,7 +1340,7 @@ Modifies the Fleet's configuration with the supplied information.
 | live_query_disabled               | boolean | Whether the live query capabilities are disabled.                                                                                                                   |
 | query_reports_disabled            | boolean | Whether query report capabilities are disabled.                                                                                                                   |
 | ai_features_disabled              | boolean | Whether AI features are disabled. |
-| query_report_cap                  | integer | The maximum number of results to store per query report before the report is clipped. (Default: `1000`) |
+| query_report_cap                  | integer | The maximum number of results to store per query report before the report is clipped. If increasing this cap, we recommend enabling reports for one query at time and monitoring your infrastructure. (Default: `1000`) |
 
 <br/>
 

--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -7327,6 +7327,7 @@ Returns the query report specified by ID.
 ```json
 {
   "query_id": 31,
+  "report_clipped": false,
   "results": [
     {
       "host_id": 1,

--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -1340,6 +1340,7 @@ Modifies the Fleet's configuration with the supplied information.
 | live_query_disabled               | boolean | Whether the live query capabilities are disabled.                                                                                                                   |
 | query_reports_disabled            | boolean | Whether query report capabilities are disabled.                                                                                                                   |
 | ai_features_disabled              | boolean | Whether AI features are disabled. |
+| query_report_cap                  | integer | The maximum number of results to store per query report before the report is clipped. (Default: `1000`) |
 
 <br/>
 

--- a/docs/Using Fleet/GitOps.md
+++ b/docs/Using Fleet/GitOps.md
@@ -366,6 +366,7 @@ org_settings:
 - `enable_analytics` specifies whether or not to enable Fleet's [usage statistics](https://fleetdm.com/docs/using-fleet/usage-statistics) (default: `true`).
 - `live_query_disabled` disables the ability to run live queries (ad hoc queries executed via the UI or fleetctl) (default: `false`).
 - `query_reports_disabled` disables query reports and deletes existing repors (default: `false`).
+- `query_report_cap` sets the maximum number of results to store per query report before the report is clipped. If increasing this cap, we recommend enabling reports for one query at time and monitoring your infrastructure. (Default: `1000`)
 - `scripts_disabled` blocks access to run scripts. Scripts may still be added in the UI and CLI (defaul: `false`).
 - `server_url` is the base URL of the Fleet instance (default: provided during Fleet setup)
 


### PR DESCRIPTION
Add documentation for the `query_report_cap` config option. For #19600