### PR TITLE
send an APNs push to hosts with pending commands every minute (#19941)

### DIFF
--- a/cmd/fleet/serve.go
+++ b/cmd/fleet/serve.go
@@ -849,6 +849,18 @@ the way that the Fleet server works.
 				initFatal(err, "failed to register mdm_apple_profile_manager schedule")
 			}
 
+			if err := cronSchedules.StartCronSchedule(func() (fleet.CronSchedule, error) {
+				return newMDMAPNsPusher(
+					ctx,
+					instanceID,
+					ds,
+					apple_mdm.NewMDMAppleCommander(mdmStorage, mdmPushService),
+					logger,
+				)
+			}); err != nil {
+				initFatal(err, "failed to register APNs pusher schedule")
+			}
+
 			if license.IsPremium() {
 				if err := cronSchedules.StartCronSchedule(func() (fleet.CronSchedule, error) {
 					commander := apple_mdm.NewMDMAppleCommander(mdmStorage, mdmPushService)

--- a/server/fleet/cron_schedules.go
+++ b/server/fleet/cron_schedules.go
@@ -22,6 +22,7 @@ const (
 	CronActivitiesStreaming         CronScheduleName = "activities_streaming"
 	CronMDMAppleProfileManager      CronScheduleName = "mdm_apple_profile_manager"
 	CronAppleMDMIPhoneIPadRefetcher CronScheduleName = "apple_mdm_iphone_ipad_refetcher"
+	CronAppleMDMAPNsPusher          CronScheduleName = "apple_mdm_apns_pusher"
 	CronCalendar                    CronScheduleName = "calendar"
 )
 

--- a/server/fleet/datastore.go
+++ b/server/fleet/datastore.go
@@ -195,6 +195,8 @@ type Datastore interface {
 	ListLabels(ctx context.Context, filter TeamFilter, opt ListOptions) ([]*Label, error)
 	LabelsSummary(ctx context.Context) ([]*LabelSummary, error)
 
+	GetHostUUIDsWithPendingMDMAppleCommands(ctx context.Context) ([]string, error)
+
 	// LabelQueriesForHost returns the label queries that should be executed for the given host.
 	// Results are returned in a map of label id -> query
 	LabelQueriesForHost(ctx context.Context, host *Host) (map[string]string, error)

--- a/server/mdm/apple/commander.go
+++ b/server/mdm/apple/commander.go
@@ -118,7 +118,7 @@ func (svc *MDMAppleCommander) DeviceLock(ctx context.Context, host *fleet.Host, 
 		return "", ctxerr.Wrap(ctx, err, "enqueuing for DeviceLock")
 	}
 
-	if err := svc.sendNotifications(ctx, []string{host.UUID}); err != nil {
+	if err := svc.SendNotifications(ctx, []string{host.UUID}); err != nil {
 		return "", ctxerr.Wrap(ctx, err, "sending notifications for DeviceLock")
 	}
 
@@ -154,7 +154,7 @@ func (svc *MDMAppleCommander) EraseDevice(ctx context.Context, host *fleet.Host,
 		return ctxerr.Wrap(ctx, err, "enqueuing for DeviceWipe")
 	}
 
-	if err := svc.sendNotifications(ctx, []string{host.UUID}); err != nil {
+	if err := svc.SendNotifications(ctx, []string{host.UUID}); err != nil {
 		return ctxerr.Wrap(ctx, err, "sending notifications for DeviceWipe")
 	}
 
@@ -289,14 +289,14 @@ func (svc *MDMAppleCommander) EnqueueCommand(ctx context.Context, hostUUIDs []st
 		return ctxerr.Wrap(ctx, err, "enqueuing command")
 	}
 
-	if err := svc.sendNotifications(ctx, hostUUIDs); err != nil {
+	if err := svc.SendNotifications(ctx, hostUUIDs); err != nil {
 		return ctxerr.Wrap(ctx, err, "sending notifications")
 	}
 
 	return nil
 }
 
-func (svc *MDMAppleCommander) sendNotifications(ctx context.Context, hostUUIDs []string) error {
+func (svc *MDMAppleCommander) SendNotifications(ctx context.Context, hostUUIDs []string) error {
 	apnsResponses, err := svc.pusher.Push(ctx, hostUUIDs)
 	if err != nil {
 		return ctxerr.Wrap(ctx, err, "commander push")

--- a/server/mock/datastore_mock.go
+++ b/server/mock/datastore_mock.go
@@ -145,6 +145,8 @@ type ListLabelsFunc func(ctx context.Context, filter fleet.TeamFilter, opt fleet
 
 type LabelsSummaryFunc func(ctx context.Context) ([]*fleet.LabelSummary, error)
 
+type GetHostUUIDsWithPendingMDMAppleCommandsFunc func(ctx context.Context) ([]string, error)
+
 type LabelQueriesForHostFunc func(ctx context.Context, host *fleet.Host) (map[string]string, error)
 
 type ListLabelsForHostFunc func(ctx context.Context, hid uint) ([]*fleet.Label, error)
@@ -1184,6 +1186,9 @@ type DataStore struct {
 
 	LabelsSummaryFunc        LabelsSummaryFunc
 	LabelsSummaryFuncInvoked bool
+
+	GetHostUUIDsWithPendingMDMAppleCommandsFunc        GetHostUUIDsWithPendingMDMAppleCommandsFunc
+	GetHostUUIDsWithPendingMDMAppleCommandsFuncInvoked bool
 
 	LabelQueriesForHostFunc        LabelQueriesForHostFunc
 	LabelQueriesForHostFuncInvoked bool
@@ -2902,6 +2907,13 @@ func (s *DataStore) LabelsSummary(ctx context.Context) ([]*fleet.LabelSummary, e
 	s.LabelsSummaryFuncInvoked = true
 	s.mu.Unlock()
 	return s.LabelsSummaryFunc(ctx)
+}
+
+func (s *DataStore) GetHostUUIDsWithPendingMDMAppleCommands(ctx context.Context) ([]string, error) {
+	s.mu.Lock()
+	s.GetHostUUIDsWithPendingMDMAppleCommandsFuncInvoked = true
+	s.mu.Unlock()
+	return s.GetHostUUIDsWithPendingMDMAppleCommandsFunc(ctx)
 }
 
 func (s *DataStore) LabelQueriesForHost(ctx context.Context, host *fleet.Host) (map[string]string, error) {


### PR DESCRIPTION
> [!NOTE]
> This PR already merged in `main`, see https://github.com/fleetdm/fleet/pull/19941. This is against the release branch so it can be included in 4.54.0

Initial naive implementation that sends push notifications to hosts with pending enqueued commands every 1 minute.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [ ] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
See [Changes
files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [x] Added/updated tests
- [x] Manual QA for all new/changed functionality

