### PR TITLE
Handbook: Update MDM capacity

### DIFF
--- a/handbook/company/product-groups.md
+++ b/handbook/company/product-groups.md
@@ -23,7 +23,7 @@ At Fleet, [anyone can contribute](https://fleetdm.com/handbook/company#openness)
 | Product group             | Goal _(value for customers and/or community)_                       | Capacity\* |
 |:--------------------------|:--------------------------------------------------------------------|:-----------------|
 | [Endpoint ops](#endpoint-ops-group)                     | Increase and exceed maturity in the "Endpoint operations" category.             | 130       |
-| [MDM](#mdm-group)                                       | Reach maturity in the "MDM" product category.           | 130       |
+| [MDM](#mdm-group)                                       | Reach maturity in the "MDM" product category.           | 156       |
 
 \* The number of estimated story points this group can take on per-sprint under ideal circumstances, used as a baseline number for planning and prioritizing user stories for drafting. In reality, capacity will vary as engineers are on-call, out-of-office, filling in for other product groups, etc.
 


### PR DESCRIPTION
- 6 contributors (engineers) on the MDM team. 26 points per engineer

Noah: Realized this changed when looking a George's capacity planning sheet: https://docs.google.com/spreadsheets/d/1_HtlUcZ4U64mYc6OTAURkqdvJhxzj9C9uinctr12YNM/edit?gid=0#gid=0
