### PR TITLE
HotFix err on script timeouts for legacy orbit versions

### DIFF
--- a/orbit/changes/16645-script-timeouts
+++ b/orbit/changes/16645-script-timeouts
@@ -1,0 +1,2 @@
+adding support for new agent option `script_execution_timeout` to configure seconds until a script
+is killed due to timeout.

--- a/server/fleet/scripts.go
+++ b/server/fleet/scripts.go
@@ -287,7 +287,7 @@ func (hsr HostScriptResult) UserMessage(hostTimeout bool, hostTimeoutValue *int)
 
 func HostScriptTimeoutMessage(seconds *int) string {
 	var timeout int
-	if seconds == nil {
+	if seconds == nil || *seconds == 0 {
 		timeout = int(scripts.MaxHostExecutionTime.Seconds())
 	} else {
 		timeout = *seconds


### PR DESCRIPTION
#20415 

Unreleased bug related to script timeout error messages.

- [ ] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [X] Added/updated tests
- [X] Manual QA for all new/changed functionality