### PR TITLE
Minor Fix Fleet Server Configuration Docs Markdown Docs

### DIFF
--- a/docs/Configuration/fleet-server-configuration.md
+++ b/docs/Configuration/fleet-server-configuration.md
@@ -1444,7 +1444,6 @@ AWS secret access key to use for Firehose authentication.
   firehose:
     secret_access_key: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
   ```
-Optional unique identifier that can be used by the principal assuming the role to assert its identity.
 
 ##### firehose_sts_assume_role_arn
 

--- a/docs/Configuration/fleet-server-configuration.md
+++ b/docs/Configuration/fleet-server-configuration.md
@@ -1445,6 +1445,7 @@ AWS secret access key to use for Firehose authentication.
     secret_access_key: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
   ```
 Optional unique identifier that can be used by the principal assuming the role to assert its identity.
+
 ##### firehose_sts_assume_role_arn
 
 This flag only has effect if one of the following is true:


### PR DESCRIPTION
- Removes _"Optional unique identifier that can be used by the principal assuming the role to assert its identity."_ text as it:
  1. Is (possibly?) duplicative of _"AWS STS External ID to use for Firehose authentication. This is typically used in conjunction with an STS role ARN to ensure that only the intended AWS account can assume the role."_
  2. Seems ill-placed (even if it should persist, if should probably be nested under the [`firehose​_sts​_external​_id` heading](https://fleetdm.com/docs/configuration/fleet-server-configuration#firehose-sts-external-id))
- Fixes markdown formatting on `firehose_sts_assume_role_arn` by adding another newline char so the resulting HTML gets properly rendered (as an `<h5>`)  _outside the `<ul>` tag:_
![image](https://github.com/user-attachments/assets/ace319f7-a2ac-4a6b-93d7-ef19414e2c46)

Currently looks like this on [Fleet Server Configuration page](https://fleetdm.com/docs/configuration/fleet-server-configuration):
![image](https://github.com/user-attachments/assets/95114996-41af-4ea8-9cc5-677b49fdcf84)

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

(None of the checklist items applied to this change.