### PR TITLE
Update CODEOWNERS and DRIs

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -77,7 +77,7 @@ go.mod @fleetdm/go
 # (see website/config/custom.js for DRIs of other paths not listed here)
 ##############################################################################################
 /docs                                           @rachaelshaw @eashaw @noahtalerman
-/docs/Using-Fleet/REST-API.md                   @rachaelshaw @lukeheath # « REST API reference documentation
+/docs/REST\ API/rest-api.md                   @rachaelshaw @lukeheath # « REST API reference documentation
 /docs/Contributing/API-for-contributors.md      @rachaelshaw @lukeheath # « Advanced / contributors-only API reference documentation
 /schema                                         @eashaw # « Data tables (osquery/fleetd schema) documentation
 /docs/Deploy/_kubernetes/ @dherder # « Kubernetes best practice

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -76,7 +76,7 @@ go.mod @fleetdm/go
 #
 # (see website/config/custom.js for DRIs of other paths not listed here)
 ##############################################################################################
-/docs                                           @rachaelshaw @eashaw
+/docs                                           @rachaelshaw @eashaw @noahtalerman
 /docs/Using-Fleet/REST-API.md                   @rachaelshaw @lukeheath # « REST API reference documentation
 /docs/Contributing/API-for-contributors.md      @rachaelshaw @lukeheath # « Advanced / contributors-only API reference documentation
 /schema                                         @eashaw # « Data tables (osquery/fleetd schema) documentation

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -76,9 +76,9 @@ go.mod @fleetdm/go
 #
 # (see website/config/custom.js for DRIs of other paths not listed here)
 ##############################################################################################
-/docs                                           @rachaelshaw @eashaw @noahtalerman
-/docs/REST\ API/rest-api.md                   @rachaelshaw @lukeheath # « REST API reference documentation
-/docs/Contributing/API-for-contributors.md      @rachaelshaw @lukeheath # « Advanced / contributors-only API reference documentation
+/docs                                           @eashaw
+/docs/REST\ API/rest-api.md                     @lukeheath # « REST API reference documentation
+/docs/Contributing/API-for-contributors.md      @lukeheath # « Advanced / contributors-only API reference documentation
 /schema                                         @eashaw # « Data tables (osquery/fleetd schema) documentation
 /docs/Deploy/_kubernetes/ @dherder # « Kubernetes best practice
 ##############################################################################################

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -76,8 +76,8 @@ go.mod @fleetdm/go
 #
 # (see website/config/custom.js for DRIs of other paths not listed here)
 ##############################################################################################
-/docs                                           @rachaelshaw
-/docs/Using-Fleet/REST-API.md                   @rachaelshaw # « REST API reference documentation
+/docs                                           @rachaelshaw @eashaw
+/docs/Using-Fleet/REST-API.md                   @rachaelshaw @lukeheath # « REST API reference documentation
 /docs/Contributing/API-for-contributors.md      @rachaelshaw @lukeheath # « Advanced / contributors-only API reference documentation
 /schema                                         @eashaw # « Data tables (osquery/fleetd schema) documentation
 /docs/Deploy/_kubernetes/ @dherder # « Kubernetes best practice

--- a/handbook/company/communications.md
+++ b/handbook/company/communications.md
@@ -41,12 +41,12 @@ We track competitors' capabilities and adjacent (or commonly integrated) product
 | Feature prioritization               | <sup><sub>_See [🦢 Head of Product Design](https://fleetdm.com/handbook/product-design#team)_</sup></sub>
 | Intentionality of Fleet's interfaces | <sup><sub>_See [🦢 Head of Product Design](https://fleetdm.com/handbook/product-design#team)_</sup></sub>
 | Best practices for using Fleet       | <sup><sub>_See [🦢 Product Design team](https://fleetdm.com/handbook/product-design#team)_</sup></sub>
-| [API design](https://fleetdm.com/docs/rest-api/rest-api) | <sup><sub>_See [🦢 Rachael Shaw](https://fleetdm.com/handbook/product-design#team)_</sup></sub>
+| [API design](https://fleetdm.com/docs/rest-api/rest-api) | <sup><sub>_See [🚀 Chief Technology Officer](https://fleetdm.com/handbook/engineering#team)_</sup></sub>
 | Structure of the [docs](https://fleetdm.com/docs/get-started/why-fleet) | <sup><sub>_See [🌐 Head of Design](https://fleetdm.com/handbook/digital-experience#team)_</sup></sub>
 | Product introduction docs            | <sup><sub>_See [🛠️ CEO responsibilities](https://fleetdm.com/handbook/company/leadership#ceo-responsibilities)_</sup></sub>
 | Product deployment docs              | <sup><sub>_See [🚀 Chief Technology Officer](https://fleetdm.com/handbook/engineering#team)_</sup></sub>
 | Product usage docs                   | <sup><sub>_See [🦢 Head of Product Design](https://fleetdm.com/handbook/product-design#team)_</sup></sub>
-| Product reference docs               | <sup><sub>_See [🦢 Rachael Shaw](https://fleetdm.com/handbook/product-design#team)_</sup></sub>
+| Product reference docs               | <sup><sub>_See [🦢 Noah Talerman](https://fleetdm.com/handbook/product-design#team)_</sup></sub>
 | What goes in a release               | <sup><sub>_See [🚀 Chief Technology Officer](https://fleetdm.com/handbook/engineering#team)_ </sup></sub> 
 | Engineering output and architecture  | <sup><sub>_See [🚀 Chief Technology Officer](https://fleetdm.com/handbook/engineering#team)_ </sup></sub>
 | Product development                  | <sup><sub>_See [🛩️ Product groups](https://fleetdm.com/handbook/company/product-groups#current-product-groups)_ </sup></sub>

--- a/website/config/custom.js
+++ b/website/config/custom.js
@@ -203,8 +203,9 @@ module.exports.custom = {
     'tools/api': ['lukeheath', 'georgekarrv', 'sharon-fdm'],//« Scripts for interacting with the Fleet API
 
     // Reference, config surface, built-in queries, API, and other documentation
-    'docs': ['rachaelshaw'],// (default for docs)
-    'docs/01-Using-Fleet/standard-query-library/standard-query-library.yml': ['rachaelshaw'],// (standard query library)
+    'docs': ['rachaelshaw', 'noahtalerman', 'eashaw'],// (default for docs)
+    'docs/01-Using-Fleet/standard-query-library/standard-query-library.yml': ['rachaelshaw', 'noahtalerman', 'eashaw'],// (standard query library)
+    'docs/REST API/rest-api.md': ['rachaelshaw', 'lukeheath'],// (standard query library)
     'schema': ['eashaw'],// (Osquery table schema)
     'ee/cis': ['lukeheath', 'sharon-fdm', 'lucasmrod', 'rachelElysia', 'rachaelshaw'],
 


### PR DESCRIPTION
- @lukeheath is interim DRI of API design while @rachaelshaw is out
- @noahtalerman is interim DRI of product reference docs
- @eashaw is also CODEOWNER of `docs/` b/c of doc generation markdown, structure expertise, and to unblock if Noah is slow to review
