### PR TITLE
Disable final `Next` when no more results; cleanup

### DIFF
--- a/frontend/components/Pagination/Pagination.jsx
+++ b/frontend/components/Pagination/Pagination.jsx
@@ -25,6 +25,10 @@ class Pagination extends PureComponent {
   };
 
   disableNext = () => {
+    // NOTE: Disable next page is passed through from api metadata
+    if (this.props.disableNextPage !== undefined) {
+      return this.props.disableNextPage;
+    }
     // NOTE: not sure why resultsOnCurrentPage is getting assigned undefined.
     // but this seems to work when there is no data in the table.
     return (

--- a/frontend/components/TableContainer/TableContainer.tsx
+++ b/frontend/components/TableContainer/TableContainer.tsx
@@ -45,7 +45,6 @@ interface ITableContainerProps<T = any> {
   disableMultiRowSelect?: boolean;
   /** resultsTitle used in DataTable for matching results text */
   resultsTitle?: string;
-  resultsHtml?: JSX.Element;
   additionalQueries?: string;
   emptyComponent: React.ElementType;
   className?: string;
@@ -119,7 +118,6 @@ const TableContainer = <T,>({
   inputPlaceHolder = "Search",
   additionalQueries,
   resultsTitle,
-  resultsHtml,
   emptyComponent,
   className,
   disableActionButton,

--- a/frontend/pages/ManageControlsPage/OSUpdates/components/CurrentVersionSection/CurrentVersionSection.tsx
+++ b/frontend/pages/ManageControlsPage/OSUpdates/components/CurrentVersionSection/CurrentVersionSection.tsx
@@ -126,6 +126,7 @@ const CurrentVersionSection = ({
         currentTeamId={currentTeamId}
         isLoading={isLoadingOsVersions}
         queryParams={queryParams}
+        hasNextPage={data.meta.has_next_results}
       />
     );
   };

--- a/frontend/pages/ManageControlsPage/OSUpdates/components/OSVersionTable/OSVersionTable.tsx
+++ b/frontend/pages/ManageControlsPage/OSUpdates/components/OSVersionTable/OSVersionTable.tsx
@@ -20,6 +20,7 @@ interface IOSVersionTableProps {
   currentTeamId: number;
   isLoading: boolean;
   queryParams: ReturnType<typeof parseOSUpdatesCurrentVersionsQueryParams>;
+  hasNextPage: boolean;
 }
 
 const OSVersionTable = ({
@@ -28,6 +29,7 @@ const OSVersionTable = ({
   currentTeamId,
   isLoading,
   queryParams,
+  hasNextPage,
 }: IOSVersionTableProps) => {
   const columns = generateTableHeaders(currentTeamId);
 
@@ -104,6 +106,7 @@ const OSVersionTable = ({
         disableCount
         pageSize={queryParams.per_page}
         onQueryChange={onQueryChange}
+        disableNextPage={!hasNextPage}
       />
     </div>
   );


### PR DESCRIPTION
Follow-up to #20408 
- Explicitly prevent pagination from being disabled when API says there are more results

- [x] Manual QA for all new/changed functionality
