### PR TITLE
VPP: Add PK to `vpp_apps_teams` to avoid migration issues

### DIFF
--- a/server/datastore/mysql/migrations/tables/20240701113709_VPPDBUpdates.go
+++ b/server/datastore/mysql/migrations/tables/20240701113709_VPPDBUpdates.go
@@ -48,6 +48,7 @@ CREATE TABLE vpp_apps (
 
 	_, err = tx.Exec(`
 CREATE TABLE vpp_apps_teams (
+	id int(10) unsigned NOT NULL AUTO_INCREMENT PRIMARY KEY,
 	adam_id VARCHAR(16) NOT NULL,
 	-- team_id NULL is for no team (cannot use 0 with foreign key)
 	team_id INT(10) UNSIGNED NULL,

--- a/server/datastore/mysql/schema.sql
+++ b/server/datastore/mysql/schema.sql
@@ -1685,9 +1685,11 @@ CREATE TABLE `vpp_apps` (
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `vpp_apps_teams` (
+  `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
   `adam_id` varchar(16) COLLATE utf8mb4_unicode_ci NOT NULL,
   `team_id` int(10) unsigned DEFAULT NULL,
   `global_or_team_id` int(10) NOT NULL DEFAULT '0',
+  PRIMARY KEY (`id`),
   UNIQUE KEY `idx_global_or_team_id_adam_id` (`global_or_team_id`,`adam_id`),
   KEY `adam_id` (`adam_id`),
   KEY `team_id` (`team_id`),


### PR DESCRIPTION
We've had issues in the past with DB migrations when a table doesn't have a primary key, some mysql variants or configs require that all non-temp tables have a PK at all times.

**NOTE: this updates the existing DB migration, since it hasn't landed in `main` yet. This means that local DB envs will need to be reset.**

# Checklist for submitter

- [x] If database migrations are included, checked table schema to confirm autoupdate
