### PR TITLE
Update calendar preview example in UI

### DIFF
--- a/frontend/pages/policies/ManagePoliciesPage/components/CalendarEventPreviewModal/CalendarEventPreviewModal.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/components/CalendarEventPreviewModal/CalendarEventPreviewModal.tsx
@@ -51,7 +51,7 @@ const CalendarEventPreviewModal = ({
                 💻 🚫 Scheduled maintenance
               </div>
               <div className={`${baseClass}__preview-header__time`}>
-                <span>Friday, April 5</span>
+                <span>Tuesday, June 18</span>
                 <span>⋅</span>
                 <span>5-5:30pm</span>
               </div>


### PR DESCRIPTION
Update date in preview calendar example to match article and be realistic since it will happen every Tuesday by default.

Related to:  #19031