### PR TITLE
Fleet UI: Add iOS, iPadOS to Apple Profile activity updates

### DIFF
--- a/changes/20575-fix-profile-activities-to-include-ios-ipados
+++ b/changes/20575-fix-profile-activities-to-include-ios-ipados
@@ -1,0 +1,1 @@
+- Update profile activities to include iOS and iPadOS

--- a/frontend/interfaces/activity.ts
+++ b/frontend/interfaces/activity.ts
@@ -36,9 +36,9 @@ export enum ActivityType {
   MdmUnenrolled = "mdm_unenrolled",
   EditedMacosMinVersion = "edited_macos_min_version",
   ReadHostDiskEncryptionKey = "read_host_disk_encryption_key",
-  CreatedMacOSProfile = "created_macos_profile",
-  DeletedMacOSProfile = "deleted_macos_profile",
-  EditedMacOSProfile = "edited_macos_profile",
+  CreatedMacOSProfile = "created_macos_profile", // TODO: rename on frontend only
+  DeletedMacOSProfile = "deleted_macos_profile", // same
+  EditedMacOSProfile = "edited_macos_profile", // same
   CreatedWindowsProfile = "created_windows_profile",
   DeletedWindowsProfile = "deleted_windows_profile",
   EditedWindowsProfile = "edited_windows_profile",

--- a/frontend/interfaces/activity.ts
+++ b/frontend/interfaces/activity.ts
@@ -36,9 +36,12 @@ export enum ActivityType {
   MdmUnenrolled = "mdm_unenrolled",
   EditedMacosMinVersion = "edited_macos_min_version",
   ReadHostDiskEncryptionKey = "read_host_disk_encryption_key",
-  CreatedMacOSProfile = "created_macos_profile", // TODO: rename on frontend only
-  DeletedMacOSProfile = "deleted_macos_profile", // same
-  EditedMacOSProfile = "edited_macos_profile", // same
+  /** Note: BE not renamed (yet) from macOS even though activity is also used for iOS and iPadOS */
+  CreatedAppleOSProfile = "created_macos_profile",
+  /** Note: BE not renamed (yet) from macOS even though activity is also used for iOS and iPadOS */
+  DeletedAppleOSProfile = "deleted_macos_profile",
+  /** Note: BE not renamed (yet) from macOS even though activity is also used for iOS and iPadOS */
+  EditedAppleOSProfile = "edited_macos_profile",
   CreatedWindowsProfile = "created_windows_profile",
   DeletedWindowsProfile = "deleted_windows_profile",
   EditedWindowsProfile = "edited_windows_profile",

--- a/frontend/pages/DashboardPage/cards/ActivityFeed/ActivityItem/ActivityItem.tsx
+++ b/frontend/pages/DashboardPage/cards/ActivityFeed/ActivityItem/ActivityItem.tsx
@@ -36,10 +36,11 @@ const PREMIUM_ACTIVITIES = new Set([
 
 const getProfileMessageSuffix = (
   isPremiumTier: boolean,
-  platform: "darwin" | "windows",
+  platform: "apple" | "windows",
   teamName?: string | null
 ) => {
-  const platformDisplayName = platform === "darwin" ? "macOS" : "Windows";
+  const platformDisplayName =
+    platform === "apple" ? "macOS, iOS, and iPadOS" : "Windows";
   let messageSuffix = <>all {platformDisplayName} hosts</>;
   if (isPremiumTier) {
     messageSuffix = teamName ? (
@@ -306,7 +307,10 @@ const TAGGED_TEMPLATES = {
       </>
     );
   },
-  editedMacosMinVersion: (activity: IActivity) => {
+  editedAppleosMinVersion: (
+    osType: AppleDisplayPlatform,
+    activity: IActivity
+  ) => {
     const editedActivity =
       activity.details?.minimum_version === "" ? "removed" : "updated";
 
@@ -345,6 +349,7 @@ const TAGGED_TEMPLATES = {
       </>
     );
   },
+  // TODO: This should be reword to create AppleOSProfile
   createMacOSProfile: (activity: IActivity, isPremiumTier: boolean) => {
     const profileName = activity.details?.profile_name;
     return (
@@ -361,7 +366,7 @@ const TAGGED_TEMPLATES = {
         to{" "}
         {getProfileMessageSuffix(
           isPremiumTier,
-          "darwin",
+          "apple",
           activity.details?.team_name
         )}
         .
@@ -781,7 +786,7 @@ const TAGGED_TEMPLATES = {
         to{" "}
         {getProfileMessageSuffix(
           isPremiumTier,
-          "darwin",
+          "apple",
           activity.details?.team_name
         )}
         .
@@ -796,7 +801,7 @@ const TAGGED_TEMPLATES = {
         <b>{activity.details?.profile_name}</b> from{" "}
         {getProfileMessageSuffix(
           isPremiumTier,
-          "darwin",
+          "apple",
           activity.details?.team_name
         )}
         .
@@ -811,7 +816,7 @@ const TAGGED_TEMPLATES = {
         <b>{activity.details?.profile_name}</b> for{" "}
         {getProfileMessageSuffix(
           isPremiumTier,
-          "darwin",
+          "apple",
           activity.details?.team_name
         )}{" "}
         via fleetctl.
@@ -962,11 +967,13 @@ const getDetail = (
       return TAGGED_TEMPLATES.mdmUnenrolled(activity);
     }
     case ActivityType.EditedMacosMinVersion: {
-      return TAGGED_TEMPLATES.editedMacosMinVersion(activity);
+      return TAGGED_TEMPLATES.editedmacOSMinVersion(activity);
     }
+
     case ActivityType.ReadHostDiskEncryptionKey: {
       return TAGGED_TEMPLATES.readHostDiskEncryptionKey(activity);
     }
+    // Change name
     case ActivityType.CreatedMacOSProfile: {
       return TAGGED_TEMPLATES.createMacOSProfile(activity, isPremiumTier);
     }

--- a/frontend/pages/DashboardPage/cards/ActivityFeed/ActivityItem/ActivityItem.tsx
+++ b/frontend/pages/DashboardPage/cards/ActivityFeed/ActivityItem/ActivityItem.tsx
@@ -307,10 +307,7 @@ const TAGGED_TEMPLATES = {
       </>
     );
   },
-  editedAppleosMinVersion: (
-    osType: AppleDisplayPlatform,
-    activity: IActivity
-  ) => {
+  editedMacOSMinVersion: (activity: IActivity) => {
     const editedActivity =
       activity.details?.minimum_version === "" ? "removed" : "updated";
 
@@ -349,8 +346,7 @@ const TAGGED_TEMPLATES = {
       </>
     );
   },
-  // TODO: This should be reword to create AppleOSProfile
-  createMacOSProfile: (activity: IActivity, isPremiumTier: boolean) => {
+  createdAppleOSProfile: (activity: IActivity, isPremiumTier: boolean) => {
     const profileName = activity.details?.profile_name;
     return (
       <>
@@ -373,7 +369,7 @@ const TAGGED_TEMPLATES = {
       </>
     );
   },
-  deleteMacOSProfile: (activity: IActivity, isPremiumTier: boolean) => {
+  deletedAppleOSProfile: (activity: IActivity, isPremiumTier: boolean) => {
     const profileName = activity.details?.profile_name;
     return (
       <>
@@ -389,28 +385,28 @@ const TAGGED_TEMPLATES = {
         from{" "}
         {getProfileMessageSuffix(
           isPremiumTier,
-          "darwin",
+          "apple",
           activity.details?.team_name
         )}
         .
       </>
     );
   },
-  editMacOSProfile: (activity: IActivity, isPremiumTier: boolean) => {
+  editedAppleOSProfile: (activity: IActivity, isPremiumTier: boolean) => {
     return (
       <>
         {" "}
         edited configuration profiles for{" "}
         {getProfileMessageSuffix(
           isPremiumTier,
-          "darwin",
+          "apple",
           activity.details?.team_name
         )}{" "}
         via fleetctl.
       </>
     );
   },
-  createWindowsProfile: (activity: IActivity, isPremiumTier: boolean) => {
+  createdWindowsProfile: (activity: IActivity, isPremiumTier: boolean) => {
     const profileName = activity.details?.profile_name;
     return (
       <>
@@ -433,7 +429,7 @@ const TAGGED_TEMPLATES = {
       </>
     );
   },
-  deleteWindowsProfile: (activity: IActivity, isPremiumTier: boolean) => {
+  deletedWindowsProfile: (activity: IActivity, isPremiumTier: boolean) => {
     const profileName = activity.details?.profile_name;
     return (
       <>
@@ -456,7 +452,7 @@ const TAGGED_TEMPLATES = {
       </>
     );
   },
-  editWindowsProfile: (activity: IActivity, isPremiumTier: boolean) => {
+  editedWindowsProfile: (activity: IActivity, isPremiumTier: boolean) => {
     return (
       <>
         {" "}
@@ -967,7 +963,7 @@ const getDetail = (
       return TAGGED_TEMPLATES.mdmUnenrolled(activity);
     }
     case ActivityType.EditedMacosMinVersion: {
-      return TAGGED_TEMPLATES.editedmacOSMinVersion(activity);
+      return TAGGED_TEMPLATES.editedMacOSMinVersion(activity);
     }
 
     case ActivityType.ReadHostDiskEncryptionKey: {
@@ -975,22 +971,22 @@ const getDetail = (
     }
     // Change name
     case ActivityType.CreatedMacOSProfile: {
-      return TAGGED_TEMPLATES.createMacOSProfile(activity, isPremiumTier);
+      return TAGGED_TEMPLATES.createdAppleOSProfile(activity, isPremiumTier);
     }
     case ActivityType.DeletedMacOSProfile: {
-      return TAGGED_TEMPLATES.deleteMacOSProfile(activity, isPremiumTier);
+      return TAGGED_TEMPLATES.deletedAppleOSProfile(activity, isPremiumTier);
     }
     case ActivityType.EditedMacOSProfile: {
-      return TAGGED_TEMPLATES.editMacOSProfile(activity, isPremiumTier);
+      return TAGGED_TEMPLATES.editedAppleOSProfile(activity, isPremiumTier);
     }
     case ActivityType.CreatedWindowsProfile: {
-      return TAGGED_TEMPLATES.createWindowsProfile(activity, isPremiumTier);
+      return TAGGED_TEMPLATES.createdWindowsProfile(activity, isPremiumTier);
     }
     case ActivityType.DeletedWindowsProfile: {
-      return TAGGED_TEMPLATES.deleteWindowsProfile(activity, isPremiumTier);
+      return TAGGED_TEMPLATES.deletedWindowsProfile(activity, isPremiumTier);
     }
     case ActivityType.EditedWindowsProfile: {
-      return TAGGED_TEMPLATES.editWindowsProfile(activity, isPremiumTier);
+      return TAGGED_TEMPLATES.editedWindowsProfile(activity, isPremiumTier);
     }
     // Note: Both "enabled_disk_encryption" and "enabled_macos_disk_encryption" display the same
     // message. The latter is deprecated in the API but it is retained here for backwards compatibility.

--- a/frontend/pages/DashboardPage/cards/ActivityFeed/ActivityItem/ActivityItem.tsx
+++ b/frontend/pages/DashboardPage/cards/ActivityFeed/ActivityItem/ActivityItem.tsx
@@ -307,7 +307,7 @@ const TAGGED_TEMPLATES = {
       </>
     );
   },
-  editedMacOSMinVersion: (activity: IActivity) => {
+  editedMacosMinVersion: (activity: IActivity) => {
     const editedActivity =
       activity.details?.minimum_version === "" ? "removed" : "updated";
 
@@ -963,7 +963,7 @@ const getDetail = (
       return TAGGED_TEMPLATES.mdmUnenrolled(activity);
     }
     case ActivityType.EditedMacosMinVersion: {
-      return TAGGED_TEMPLATES.editedMacOSMinVersion(activity);
+      return TAGGED_TEMPLATES.editedMacosMinVersion(activity);
     }
 
     case ActivityType.ReadHostDiskEncryptionKey: {

--- a/frontend/pages/DashboardPage/cards/ActivityFeed/ActivityItem/ActivityItem.tsx
+++ b/frontend/pages/DashboardPage/cards/ActivityFeed/ActivityItem/ActivityItem.tsx
@@ -969,14 +969,13 @@ const getDetail = (
     case ActivityType.ReadHostDiskEncryptionKey: {
       return TAGGED_TEMPLATES.readHostDiskEncryptionKey(activity);
     }
-    // Change name
-    case ActivityType.CreatedMacOSProfile: {
+    case ActivityType.CreatedAppleOSProfile: {
       return TAGGED_TEMPLATES.createdAppleOSProfile(activity, isPremiumTier);
     }
-    case ActivityType.DeletedMacOSProfile: {
+    case ActivityType.DeletedAppleOSProfile: {
       return TAGGED_TEMPLATES.deletedAppleOSProfile(activity, isPremiumTier);
     }
-    case ActivityType.EditedMacOSProfile: {
+    case ActivityType.EditedAppleOSProfile: {
       return TAGGED_TEMPLATES.editedAppleOSProfile(activity, isPremiumTier);
     }
     case ActivityType.CreatedWindowsProfile: {


### PR DESCRIPTION
## Issue
Cerra #20575 

## Description
- In 5.54.0 we shipped adding iOS and iPadOS profiles, but we forgot to update the activity type
- Since we're using the same activities as MacOS, we can't easily update the backend, but we can update the copy shown to the user and rename the FE code to encapsalate iOS and iPadOS

## Other fixes
- All activities use past tense code naming patterns so updated any create/edit/delete to created/edited/deleted respectively
## Screenshot of fix
<img width="760" alt="Screenshot 2024-07-18 at 1 56 18 PM" src="https://github.com/user-attachments/assets/83009dc3-6bfc-4cf9-9bb1-d54081997d90">



# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
- [ ] Added/updated tests
- [x] Manual QA for all new/changed functionality

