### PR TITLE
Website: Add /guides link to documentation dropdown

### DIFF
--- a/website/views/layouts/layout.ejs
+++ b/website/views/layouts/layout.ejs
@@ -192,6 +192,7 @@
                       <a purpose="mobile-dropdown-link" href="/support">Chat</a>
                       <a purpose="mobile-dropdown-link" href="/docs/deploy/introduction">Hosting</a>
                       <a purpose="mobile-dropdown-link" href="/releases">Release notes</a>
+                      <a purpose="mobile-dropdown-link" href="/guides">Guides</a>
                       <a purpose="mobile-dropdown-link" href="/new-license">Get your license</a>
                       <a purpose="mobile-dropdown-link" href="/contribute">Contribute</a>
                     </div>
@@ -251,6 +252,7 @@
                     <a class="dropdown-item" href="/support">Chat</a>
                     <a class="dropdown-item" href="/docs/deploy/introduction">Hosting</a>
                     <a class="dropdown-item" href="/releases">Release notes</a>
+                    <a class="dropdown-item" href="/guides">Guides</a>
                     <a class="dropdown-item" href="/new-license">Get your license</a>
                     <a class="dropdown-item" href="/contribute">Contribute</a>
                   </div>

--- a/website/views/layouts/layout.ejs
+++ b/website/views/layouts/layout.ejs
@@ -185,6 +185,7 @@
                   <div id="mobileNavbarToggleDocumentation" purpose="mobile-dropdown" class="collapse" data-parent="#mobileDropdowns">
                     <a purpose="mobile-dropdown-link" href="/docs">Docs</a>
                     <a purpose="mobile-dropdown-link" href="/docs/rest-api">REST API</a>
+                      <a purpose="mobile-dropdown-link" href="/guides">Guides</a>
                     <a purpose="mobile-dropdown-link" href="/queries"><%= ['eo-it', 'mdm'].includes(primaryBuyingSituation) ? 'Device health checks' : 'Built-in queries' %></a>
                     <a purpose="mobile-dropdown-link" href="/tables">Data tables</a>
                     <span>SUPPORT</span>
@@ -192,7 +193,6 @@
                       <a purpose="mobile-dropdown-link" href="/support">Chat</a>
                       <a purpose="mobile-dropdown-link" href="/docs/deploy/introduction">Hosting</a>
                       <a purpose="mobile-dropdown-link" href="/releases">Release notes</a>
-                      <a purpose="mobile-dropdown-link" href="/guides">Guides</a>
                       <a purpose="mobile-dropdown-link" href="/new-license">Get your license</a>
                       <a purpose="mobile-dropdown-link" href="/contribute">Contribute</a>
                     </div>
@@ -246,13 +246,13 @@
                   <div purpose="header-dropdown" class="dropdown-menu">
                     <a class="dropdown-item" href="/docs">Docs</a>
                     <a class="dropdown-item" href="/docs/rest-api">REST API</a>
+                    <a class="dropdown-item" href="/guides">Guides</a>
                     <a class="dropdown-item" href="/queries"><%= ['eo-it', 'mdm'].includes(primaryBuyingSituation) ? 'Built-in checks' : 'Built-in queries' %></a>
                     <a class="dropdown-item" href="/tables">Data tables</a>
                     <span class="muted dropdown-header">SUPPORT</span>
                     <a class="dropdown-item" href="/support">Chat</a>
                     <a class="dropdown-item" href="/docs/deploy/introduction">Hosting</a>
                     <a class="dropdown-item" href="/releases">Release notes</a>
-                    <a class="dropdown-item" href="/guides">Guides</a>
                     <a class="dropdown-item" href="/new-license">Get your license</a>
                     <a class="dropdown-item" href="/contribute">Contribute</a>
                   </div>


### PR DESCRIPTION
Closes: #20554

Changes:
- Updated the website's header nav to include a link to the `/guides` article category page.