### PR TITLE
Set `source = 'apps'` when creating software titles for vpp apps

### DIFF
--- a/server/datastore/mysql/vpp.go
+++ b/server/datastore/mysql/vpp.go
@@ -235,11 +235,10 @@ VALUES
 }
 
 func (ds *Datastore) getOrInsertSoftwareTitleForVPPApp(ctx context.Context, tx sqlx.ExtContext, app *fleet.VPPApp) (uint, error) {
-	// NOTE: it was decided to leave the source empty for VPP apps for now, TBD
+	// NOTE: it was decided to populate "apps" as the source for VPP apps for now, TBD
 	// if this needs to change to better map to how software titles are reported
-	// back by osquery. Since I think this will likely not stay empty, I'm using
-	// a variable for the source.
-	const source = ""
+	// back by osquery. Since it may change, we're using a variable for the source.
+	const source = "apps"
 
 	selectStmt := `SELECT id FROM software_titles WHERE name = ? AND source = ? AND browser = ''`
 	selectArgs := []any{app.Name, source}


### PR DESCRIPTION
Issue #20229 