### PR TITLE
Fleet UI: Update profile activities to not include host platform

### DIFF
--- a/frontend/pages/DashboardPage/cards/ActivityFeed/ActivityItem/ActivityItem.tsx
+++ b/frontend/pages/DashboardPage/cards/ActivityFeed/ActivityItem/ActivityItem.tsx
@@ -36,19 +36,16 @@ const PREMIUM_ACTIVITIES = new Set([
 
 const getProfileMessageSuffix = (
   isPremiumTier: boolean,
-  platform: "apple" | "windows",
   teamName?: string | null
 ) => {
-  const platformDisplayName =
-    platform === "apple" ? "macOS, iOS, and iPadOS" : "Windows";
-  let messageSuffix = <>all {platformDisplayName} hosts</>;
+  let messageSuffix = <>hosts</>;
   if (isPremiumTier) {
     messageSuffix = teamName ? (
       <>
-        {platformDisplayName} hosts assigned to the <b>{teamName}</b> team
+        the <b>{teamName}</b> team
       </>
     ) : (
-      <>{platformDisplayName} hosts with no team</>
+      <>hosts with no team</>
     );
   }
   return messageSuffix;
@@ -359,12 +356,7 @@ const TAGGED_TEMPLATES = {
         ) : (
           <>a configuration profile</>
         )}{" "}
-        to{" "}
-        {getProfileMessageSuffix(
-          isPremiumTier,
-          "apple",
-          activity.details?.team_name
-        )}
+        to {getProfileMessageSuffix(isPremiumTier, activity.details?.team_name)}
         .
       </>
     );
@@ -383,12 +375,7 @@ const TAGGED_TEMPLATES = {
           <>a configuration profile</>
         )}{" "}
         from{" "}
-        {getProfileMessageSuffix(
-          isPremiumTier,
-          "apple",
-          activity.details?.team_name
-        )}
-        .
+        {getProfileMessageSuffix(isPremiumTier, activity.details?.team_name)}.
       </>
     );
   },
@@ -399,7 +386,6 @@ const TAGGED_TEMPLATES = {
         edited configuration profiles for{" "}
         {getProfileMessageSuffix(
           isPremiumTier,
-          "apple",
           activity.details?.team_name
         )}{" "}
         via fleetctl.
@@ -419,12 +405,7 @@ const TAGGED_TEMPLATES = {
         ) : (
           <>a configuration profile</>
         )}{" "}
-        to{" "}
-        {getProfileMessageSuffix(
-          isPremiumTier,
-          "windows",
-          activity.details?.team_name
-        )}
+        to {getProfileMessageSuffix(isPremiumTier, activity.details?.team_name)}
         .
       </>
     );
@@ -443,12 +424,7 @@ const TAGGED_TEMPLATES = {
           <>a configuration profile</>
         )}{" "}
         from{" "}
-        {getProfileMessageSuffix(
-          isPremiumTier,
-          "windows",
-          activity.details?.team_name
-        )}
-        .
+        {getProfileMessageSuffix(isPremiumTier, activity.details?.team_name)}.
       </>
     );
   },
@@ -459,7 +435,6 @@ const TAGGED_TEMPLATES = {
         edited configuration profiles for{" "}
         {getProfileMessageSuffix(
           isPremiumTier,
-          "windows",
           activity.details?.team_name
         )}{" "}
         via fleetctl.
@@ -779,12 +754,7 @@ const TAGGED_TEMPLATES = {
         added declaration (DDM) profile <b>
           {activity.details?.profile_name}
         </b>{" "}
-        to{" "}
-        {getProfileMessageSuffix(
-          isPremiumTier,
-          "apple",
-          activity.details?.team_name
-        )}
+        to {getProfileMessageSuffix(isPremiumTier, activity.details?.team_name)}
         .
       </>
     );
@@ -795,12 +765,7 @@ const TAGGED_TEMPLATES = {
         {" "}
         removed declaration (DDM) profile{" "}
         <b>{activity.details?.profile_name}</b> from{" "}
-        {getProfileMessageSuffix(
-          isPremiumTier,
-          "apple",
-          activity.details?.team_name
-        )}
-        .
+        {getProfileMessageSuffix(isPremiumTier, activity.details?.team_name)}.
       </>
     );
   },
@@ -810,11 +775,7 @@ const TAGGED_TEMPLATES = {
         {" "}
         edited declaration (DDM) profiles{" "}
         <b>{activity.details?.profile_name}</b> for{" "}
-        {getProfileMessageSuffix(
-          isPremiumTier,
-          "apple",
-          activity.details?.team_name
-        )}{" "}
+        {getProfileMessageSuffix(isPremiumTier, activity.details?.team_name)}{" "}
         via fleetctl.
       </>
     );


### PR DESCRIPTION
## Issue
Cerra #20575 

## Description
- Product decision to remove platform names from activities that are for add/edit/deleting a configuration profile

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Manual QA for all new/changed functionality
