### PR TITLE
Guide and API reference: Show iOS & iPadOS as supported platforms in the UI

### DIFF
--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -2791,6 +2791,18 @@ Returns the count of all hosts organized by status. `online_count` includes all 
       "name": "All Linux",
       "description": "All Linux distributions",
       "label_type": "builtin"
+    },
+    {
+      "id": 13,
+      "name": "iOS",
+      "description": "All iOS hosts",
+      "label_type": "builtin"
+    },
+    {
+      "id": 14,
+      "name": "iPadOS",
+      "description": "All iPadOS hosts",
+      "label_type": "builtin"
     }
   ],
   "platforms": [
@@ -2800,6 +2812,14 @@ Returns the count of all hosts organized by status. `online_count` includes all 
     },
     {
       "platform": "darwin",
+      "hosts_count": 1234
+    },
+    {
+      "platform": "ios",
+      "hosts_count": 1234
+    },
+    {
+      "platform": "ipados",
       "hosts_count": 1234
     },
     {

--- a/docs/Using Fleet/MDM-custom-OS-settings.md
+++ b/docs/Using Fleet/MDM-custom-OS-settings.md
@@ -1,6 +1,6 @@
 # Custom OS settings
 
-In Fleet you can enforce OS settings on your macOS and Windows hosts using configuration profiles.
+In Fleet you can enforce OS settings on your your macOS, iOS, iPadOS, and Windows hosts using configuration profiles.
 
 ## Enforce OS settings
 


### PR DESCRIPTION
Guide and API reference changes for the following story:
- #19319
