### PR TITLE
Detect software from deb_packages which is 'on hold'

### DIFF
--- a/changes/20751-detect-held-linux-packages-as-installed
+++ b/changes/20751-detect-held-linux-packages-as-installed
@@ -1,0 +1,1 @@
+Linux .deb packages 'on hold' are now included in the installed software list.

--- a/docs/Using Fleet/Understanding-host-vitals.md
+++ b/docs/Using Fleet/Understanding-host-vitals.md
@@ -504,7 +504,7 @@ SELECT
   '' AS arch,
   '' AS installed_path
 FROM deb_packages
-WHERE status = 'install ok installed'
+WHERE status LIKE '% ok installed'
 UNION
 SELECT
   package AS name,

--- a/server/service/osquery_utils/queries.go
+++ b/server/service/osquery_utils/queries.go
@@ -944,7 +944,7 @@ SELECT
   '' AS arch,
   '' AS installed_path
 FROM deb_packages
-WHERE status = 'install ok installed'
+WHERE status LIKE '% ok installed'
 UNION
 SELECT
   package AS name,


### PR DESCRIPTION
The list of installed software was missing packages put ['on hold'](https://askubuntu.com/questions/18654/how-to-prevent-updating-of-a-specific-package)

The reason for this is that the old query looks for the status

    install ok installed

but there are other valid status which are also installed, like `hold ok installed`. The syntax is `<desired> <error> <status>` so we only need to look at the last or two last parts and ignore the first one.

See https://man7.org/linux/man-pages/man1/dpkg-query.1.html for a list of status.

# Checklist for submitter

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [X] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)