### PR TITLE
Fix showing app-wide warning banners correctly on the first page load.

### DIFF
--- a/changes/issue-20784-fix-app-wide-banner-showing
+++ b/changes/issue-20784-fix-app-wide-banner-showing
@@ -1,0 +1,1 @@
+- fix an issue where the app-wide warning banners were not showing on the initial page load

--- a/frontend/services/entities/mdm_apple_bm.ts
+++ b/frontend/services/entities/mdm_apple_bm.ts
@@ -6,8 +6,16 @@ export interface IAppleBusinessManagerTokenFormData {
   token: File | null;
 }
 
+export interface IGetAppleBMInfoResponse {
+  apple_id: string;
+  default_team: string;
+  mdm_server_url: string;
+  org_name: string;
+  renew_date: string;
+}
+
 export default {
-  getAppleBMInfo: () => {
+  getAppleBMInfo: (): Promise<IGetAppleBMInfoResponse> => {
     const { MDM_APPLE_BM } = endpoints;
     const path = MDM_APPLE_BM;
     return sendRequest("GET", path);


### PR DESCRIPTION
relates to #20784

this fixes an issue where the app-wide warning banners were not loading on the first-page load.

> NOTE: I changed the fetch method for the data needed for the app-wide banners (e.g. abm, apns, vpp token data) to use react-query `useQuery` method as it follows our usual pattern for `GET` requests in components. To enable this, I moved up the react-query query client wrapper in the `AppWrapper component in `/frontend/router/index.tsx` file. This also gives us better control of when/how often this request is initiated.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/Committing-Changes.md#changes-files) for more information.
- [ ] Added/updated tests
- [x] Manual QA for all new/changed functionality
