### PR TITLE
Fleet UI: Indicator for min os requirement not met includes warning icon

### DIFF
--- a/frontend/pages/hosts/details/cards/HostSummary/HostSummary.tsx
+++ b/frontend/pages/hosts/details/cards/HostSummary/HostSummary.tsx
@@ -320,44 +320,47 @@ const HostSummary = ({
   };
 
   const renderOperatingSystemSummary = () => {
-    const renderOSVersion = () => {
-      // No tooltip if minimum version is not set, including all Windows, Linux, ChromeOS operating systems
-      if (!osVersionRequirement?.minimum_version) {
-        return summaryData.os_version;
-      }
-
-      const osVersionWithoutPrefix = removeOSPrefix(summaryData.os_version);
-      const osVersionRequirementMet =
-        compareVersions(
-          osVersionWithoutPrefix,
-          osVersionRequirement.minimum_version
-        ) >= 0;
-
+    // No tooltip if minimum version is not set, including all Windows, Linux, ChromeOS operating systems
+    if (!osVersionRequirement?.minimum_version) {
       return (
-        <>
-          {!osVersionRequirementMet && (
-            <Icon name="error-outline" color="ui-fleet-black-75" />
-          )}
-          <TooltipWrapper
-            tipContent={
-              osVersionRequirementMet ? (
-                "Meets minimum version requirement."
-              ) : (
-                <>
-                  Does not meet minimum version requirement.
-                  <br />
-                  Deadline to update: {osVersionRequirement.deadline}
-                </>
-              )
-            }
-          >
-            {summaryData.os_version}
-          </TooltipWrapper>
-        </>
+        <DataSet title="Operating system" value={summaryData.os_version} />
       );
-    };
+    }
 
-    return <DataSet title="Operating system" value={renderOSVersion()} />;
+    const osVersionWithoutPrefix = removeOSPrefix(summaryData.os_version);
+    const osVersionRequirementMet =
+      compareVersions(
+        osVersionWithoutPrefix,
+        osVersionRequirement.minimum_version
+      ) >= 0;
+
+    return (
+      <DataSet
+        title="Operating system"
+        value={
+          <>
+            {!osVersionRequirementMet && (
+              <Icon name="error-outline" color="ui-fleet-black-75" />
+            )}
+            <TooltipWrapper
+              tipContent={
+                osVersionRequirementMet ? (
+                  "Meets minimum version requirement."
+                ) : (
+                  <>
+                    Does not meet minimum version requirement.
+                    <br />
+                    Deadline to update: {osVersionRequirement.deadline}
+                  </>
+                )
+              }
+            >
+              {summaryData.os_version}
+            </TooltipWrapper>
+          </>
+        }
+      />
+    );
   };
 
   const renderAgentSummary = () => {

--- a/frontend/pages/hosts/details/cards/HostSummary/HostSummary.tsx
+++ b/frontend/pages/hosts/details/cards/HostSummary/HostSummary.tsx
@@ -173,26 +173,6 @@ const getHostDiskEncryptionTooltipMessage = (
   ];
 };
 
-const getOSVersionRequirementTooltipMessage = (
-  osVersion: string,
-  osVersionRequirement: IAppleDeviceUpdates
-) => {
-  const requirementMetTooltip = "Meets minimum version requirement.";
-  const requirementNotMetTooltip = (
-    <>
-      Does not meet minimum version requirement.
-      <br />
-      Deadline to update: {osVersionRequirement.deadline}
-    </>
-  );
-
-  const result = compareVersions(
-    removeOSPrefix(osVersion),
-    osVersionRequirement.minimum_version
-  );
-  return result < 0 ? requirementNotMetTooltip : requirementMetTooltip;
-};
-
 const HostSummary = ({
   summaryData,
   bootstrapPackageData,
@@ -340,26 +320,44 @@ const HostSummary = ({
   };
 
   const renderOperatingSystemSummary = () => {
-    // No tooltip if minimum version is not set, including all Windows, Linux, ChromeOS operating systems
-    return (
-      <DataSet
-        title="Operating system"
-        value={
-          osVersionRequirement?.minimum_version ? (
-            <TooltipWrapper
-              tipContent={getOSVersionRequirementTooltipMessage(
-                summaryData.os_version,
-                osVersionRequirement
-              )}
-            >
-              {summaryData.os_version}
-            </TooltipWrapper>
-          ) : (
-            summaryData.os_version
-          )
-        }
-      />
-    );
+    const renderOSVersion = () => {
+      // No tooltip if minimum version is not set, including all Windows, Linux, ChromeOS operating systems
+      if (!osVersionRequirement?.minimum_version) {
+        return summaryData.os_version;
+      }
+
+      const osVersionWithoutPrefix = removeOSPrefix(summaryData.os_version);
+      const osVersionRequirementMet =
+        compareVersions(
+          osVersionWithoutPrefix,
+          osVersionRequirement.minimum_version
+        ) >= 0;
+
+      return (
+        <>
+          {!osVersionRequirementMet && (
+            <Icon name="error-outline" color="ui-fleet-black-75" />
+          )}
+          <TooltipWrapper
+            tipContent={
+              osVersionRequirementMet ? (
+                "Meets minimum version requirement."
+              ) : (
+                <>
+                  Does not meet minimum version requirement.
+                  <br />
+                  Deadline to update: {osVersionRequirement.deadline}
+                </>
+              )
+            }
+          >
+            {summaryData.os_version}
+          </TooltipWrapper>
+        </>
+      );
+    };
+
+    return <DataSet title="Operating system" value={renderOSVersion()} />;
   };
 
   const renderAgentSummary = () => {


### PR DESCRIPTION
## Issue
Cerra #20100 

## Description
- QA caught missing icon when requirement is not met
- Majority of code changes is to move logic around to add in icon when requirement is not met


## Screenrecording
https://www.loom.com/share/79f803ff287a4e069260368179b88a81?sid=2508868c-a878-45bf-b05f-bd8dc0a45301

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Manual QA for all new/changed functionality
