### PR TITLE
Website: Update "What will you use Fleet for?" options in /start questionnaire and talk to us form options

### DIFF
--- a/website/assets/js/pages/contact.page.js
+++ b/website/assets/js/pages/contact.page.js
@@ -62,8 +62,8 @@ parasails.registerPage('contact', {
       this.formDataToPrefillForLoggedInUsers.firstName = this.me.firstName;
       this.formDataToPrefillForLoggedInUsers.lastName = this.me.lastName;
       this.formDataToPrefillForLoggedInUsers.organization = this.me.organization;
-      // Only prefil this information if the user has this value set.
-      if(this.me.primaryBuyingSituation) {
+      // Only prefil this information if the user has this value set to a value that is not VM.
+      if(this.me.primaryBuyingSituation && this.me.primaryBuyingSituation !== 'vm') {
         this.formDataToPrefillForLoggedInUsers.primaryBuyingSituation = this.me.primaryBuyingSituation;
       }
       this.formData = _.clone(this.formDataToPrefillForLoggedInUsers);

--- a/website/views/pages/contact.ejs
+++ b/website/views/pages/contact.ejs
@@ -82,9 +82,9 @@
             <select class="form-control" id="primaryBuyingSituation" name="primaryBuyingSituation" :class="[formErrors.primaryBuyingSituation ? 'is-invalid' : '']" v-model="formData.primaryBuyingSituation">
               <option disabled hidden value="undefined">Choose an option</option>
               <option value="mdm">Device management (MDM)</option>
-              <option value="eo-security">Endpoint operations for security engineering</option>
-              <option value="eo-it">Endpoint ops for identity engineers and IT admins</option>
-              <option value="vm">Vulnerability management</option>
+              <option value="eo-it">IT engineering</option>
+              <option value="eo-security">Security engineering</option>
+              <!-- <option value="vm">Vulnerability management</option> -->
             </select>
             </div>
             <div class="d-block invalid-feedback" v-if="formErrors.topic">Please select an option.</div>

--- a/website/views/pages/start.ejs
+++ b/website/views/pages/start.ejs
@@ -35,18 +35,18 @@
           <label purpose="form-option" class="form-control" :class="[formData['what-are-you-using-fleet-for'].primaryBuyingSituation === 'eo-security' ? 'selected' : '']">
             <input type="radio" v-model.trim="formData['what-are-you-using-fleet-for'].primaryBuyingSituation" value="eo-security" @input="clickClearOneFormError('primaryBuyingSituation')">
             <span purpose="custom-radio"><span purpose="custom-radio-selected"></span></span>
-            Endpoint ops for security engineering
+            Security engineering
           </label>
           <label purpose="form-option" class="form-control" :class="[formData['what-are-you-using-fleet-for'].primaryBuyingSituation === 'eo-it' ? 'selected' : '']">
             <input type="radio" :class="[formErrors.primaryBuyingSituation ? 'is-invalid' : '']" v-model.trim="formData['what-are-you-using-fleet-for'].primaryBuyingSituation" value="eo-it" @input="clickClearOneFormError('primaryBuyingSituation')">
             <span purpose="custom-radio"><span purpose="custom-radio-selected"></span></span>
-            Endpoint ops for identity engineers and IT admins
+            IT engineering
           </label>
-          <label purpose="form-option" class="form-control" :class="[formData['what-are-you-using-fleet-for'].primaryBuyingSituation === 'vm' ? 'selected' : '']">
+<!--           <label purpose="form-option" class="form-control" :class="[formData['what-are-you-using-fleet-for'].primaryBuyingSituation === 'vm' ? 'selected' : '']">
             <input type="radio" :class="[formErrors.primaryBuyingSituation ? 'is-invalid' : '']" v-model.trim="formData['what-are-you-using-fleet-for'].primaryBuyingSituation" value="vm" @input="clickClearOneFormError('primaryBuyingSituation')">
             <span purpose="custom-radio"><span purpose="custom-radio-selected"></span></span>
             Vulnerability management
-          </label>
+          </label> -->
           <div class="invalid-feedback" v-if="formErrors.primaryBuyingSituation">Please select an option</div>
         </div>
         <cloud-error v-if="cloudError"></cloud-error>


### PR DESCRIPTION
Closes: #20557
Closes: #20735

Changes:
 - Updated the options for the "What will you use Fleet for?" question in the /start questionnaire and the talk to us form
    - “Endpoint ops for Identity engineers and IT admins” » “IT engineering”
    - “Endpoint ops for security engineering” » “Security engineering”
    - Removed the "Vulnerability management" option
   