### PR TITLE
Add link from product groups

### DIFF
--- a/handbook/engineering/README.md
+++ b/handbook/engineering/README.md
@@ -34,7 +34,7 @@ We write [guides](https://fleetdm.com/guides) for all new features. Feature guid
 
 1. Review and follow the [Fleet writing style guide](https://fleetdm.com/handbook/company/communications#writing).
 2. Make a copy of the ["Article: Guide Template"](https://docs.google.com/document/d/1OPcDouyfyFPg3ScrN4bo6ol8vMfMa3P9-BIfbnEdcg4/copy) and rename "Article: [Guide] {feature name}".
-3. Open the template and insert your content into the provided template format. 
+3. Open the template and insert your [drafted content](https://fleetdm.com/handbook/company/product-groups#defining-done) into the provided template format. 
 4. Create a [new GitHub issue](https://github.com/fleetdm/fleet/issues/new?assignees=spokanemac&labels=:help-it&title=New%20guide:) with the guide title, and add the `:help-it` label. It will be processed and added to the website by our [Community Advocate](https://fleetdm.com/handbook/engineering#team).
 
 


### PR DESCRIPTION
@lukeheath We're looking to add this call out to from the "Defining done" section on the product groups page. I the interest of not duplication content I linked to that section but wanted your thoughts on if we need to specifically call this part out?

"Articles and guides: If an article needs to be updated, make sure to also change the "publishedOn" meta tag to the date of the edit to show visitors that the information is fresh and authoritative."

Closes https://github.com/fleetdm/confidential/issues/7345