### PR TITLE
Fix link for fleetctl install 

### DIFF
--- a/docs/Using Fleet/enroll-hosts.md
+++ b/docs/Using Fleet/enroll-hosts.md
@@ -12,7 +12,7 @@ Fleet supports the [latest version of osquery](https://github.com/osquery/osquer
 
 ## CLI
 
-> You must have `fleetctl` installed. [Learn how to install `fleetctl`](https://fleetdm.com/fleetctl-preview).
+> You must have `fleetctl` installed. [Learn how to install `fleetctl`](https://fleetdm.com/docs/using-fleet/fleetctl-cli#installing-fleetctl).
 
 The `fleetctl package` command is used to generate Fleet's agent (fleetd).
 


### PR DESCRIPTION
Link is from when the /fleetctl -preview page on the website was not behind a login.