### PR TITLE
Increase severity level for dependency review

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -25,3 +25,5 @@ jobs:
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
       - name: 'Dependency Review'
         uses: actions/dependency-review-action@0efb1d1d84fc9633afcdaad14c485cbbc90ef46c # v2.5.1
+        with:
+          fail-on-severity: moderate


### PR DESCRIPTION
Increase the severity level for dependency-review GH action

Reference https://github.com/actions/dependency-review-action?tab=readme-ov-file#configuration-options