### PR TITLE
Fleet UI: Update profile verification copies to be more generic

### DIFF
--- a/frontend/pages/hosts/details/OSSettingsModal/OSSettingsTable/OSSettingStatusCell/helpers.ts
+++ b/frontend/pages/hosts/details/OSSettingsModal/OSSettingsTable/OSSettingStatusCell/helpers.ts
@@ -29,15 +29,15 @@ type OperationTypeOption = Record<
 
 type ProfileDisplayConfig = Record<ProfileOperationType, OperationTypeOption>;
 
-const MAC_PROFILE_VERIFIED_DISPLAY_CONFIG: ProfileDisplayOption = {
+// Profiles for iOS and iPadOS skip the verifying step
+const APPLE_PROFILE_VERIFIED_DISPLAY_CONFIG: ProfileDisplayOption = {
   statusText: "Verified",
   iconName: "success",
   tooltip: (innerProps) =>
     innerProps.isDiskEncryptionProfile
       ? "The host turned disk encryption on and sent the key to Fleet. " +
-        "Fleet verified with osquery."
-      : "The host applied the setting. Fleet verified with osquery. " +
-        "Declaration profiles are verified with DDM.",
+        "Fleet verified."
+      : "The host applied the setting. Fleet verified.",
 } as const;
 
 const MAC_PROFILE_VERIFYING_DISPLAY_CONFIG: ProfileDisplayOption = {
@@ -54,8 +54,8 @@ const MAC_PROFILE_VERIFYING_DISPLAY_CONFIG: ProfileDisplayOption = {
 
 export const PROFILE_DISPLAY_CONFIG: ProfileDisplayConfig = {
   install: {
-    verified: MAC_PROFILE_VERIFIED_DISPLAY_CONFIG,
-    success: MAC_PROFILE_VERIFIED_DISPLAY_CONFIG,
+    verified: APPLE_PROFILE_VERIFIED_DISPLAY_CONFIG,
+    success: APPLE_PROFILE_VERIFIED_DISPLAY_CONFIG,
     verifying: MAC_PROFILE_VERIFYING_DISPLAY_CONFIG,
     acknowledged: MAC_PROFILE_VERIFYING_DISPLAY_CONFIG,
     pending: {
@@ -114,7 +114,7 @@ export const WINDOWS_DISK_ENCRYPTION_DISPLAY_CONFIG: WindowsDiskEncryptionDispla
     statusText: "Verified",
     iconName: "success",
     tooltip: () =>
-      "The host turned disk encryption on and sent the key to Fleet. Fleet verified with osquery.",
+      "The host turned disk encryption on and sent the key to Fleet. Fleet verified.",
   },
   verifying: {
     statusText: "Verifying",


### PR DESCRIPTION
## Issue
Cerra #20481 

## Description
- Profiles do not mention being verified with osquery (which iOS and iPadOS doesn't use to verify)

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [ ] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/Committing-Changes.md#changes-files) for more information.
- [ ] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [ ] Added support on fleet's osquery simulator `cmd/osquery-perf` for new osquery data ingestion features.
- [ ] Added/updated tests
- [ ] If database migrations are included, checked table schema to confirm autoupdate
- For database migrations:
  - [ ] Checked schema for all modified table for columns that will auto-update timestamps during migration.
  - [ ] Confirmed that updating the timestamps is acceptable, and will not cause unwanted side effects.
  - [ ] Ensured the correct collation is explicitly set for character columns (`COLLATE utf8mb4_unicode_ci`).
- [ ] Manual QA for all new/changed functionality
- For Orbit and Fleet Desktop changes:
   - [ ] Orbit runs on macOS, Linux and Windows. Check if the orbit feature/bugfix should only apply to one platform (`runtime.GOOS`).
   - [ ] Manual QA must be performed in the three main OSs, macOS, Windows and Linux.
   - [ ] Auto-update manual QA, from released version of component to new version (see [tools/tuf/test](../tools/tuf/test/README.md)).
