### PR TITLE
Website: Use GitHub API to get `lastmodifiedAt` timestamps

### DIFF
--- a/website/api/helpers/get-extended-osquery-schema.js
+++ b/website/api/helpers/get-extended-osquery-schema.js
@@ -11,6 +11,10 @@ module.exports = {
       type: 'boolean',
       defaultsTo: false,
       description: 'Whether or not to include a lastModifiedAt value for each table.',
+    },
+    githubAccessToken: {
+      type: 'string',
+      description: 'A github token used to authenticate requests to the GitHub API'
     }
   },
 
@@ -25,11 +29,10 @@ module.exports = {
   },
 
 
-  fn: async function ({includeLastModifiedAtValue}) {
+  fn: async function ({includeLastModifiedAtValue, githubAccessToken}) {
     let path = require('path');
     let YAML = require('yaml');
     let util = require('util');
-
     let topLvlRepoPath = path.resolve(sails.config.appPath, '../');
     require('assert')(sails.config.custom.versionOfOsquerySchemaToUseWhenGeneratingDocumentation, 'Please set sails.config.custom.sails.config.custom.versionOfOsquerySchemaToUseWhenGeneratingDocumentation to the version of osquery to use, for example \'5.8.1\'.');
     let VERSION_OF_OSQUERY_SCHEMA_TO_USE = sails.config.custom.versionOfOsquerySchemaToUseWhenGeneratingDocumentation;
@@ -40,6 +43,14 @@ module.exports = {
     let rawOsqueryTablesLastModifiedAt;
     if(includeLastModifiedAtValue) {
       // If we're including a lastModifiedAt value for schema tables, we'll send a request to the GitHub API to get a timestamp of when the last commit
+      let baseHeadersForGithubRequests = {
+        'User-Agent': 'fleet-schema-builder',
+        'Accept': 'application/vnd.github.v3+json',
+      };
+      // If a GitHub access token was provided, add it to the headers.
+      if(githubAccessToken){
+        baseHeadersForGithubRequests['Authorization'] = `token ${githubAccessToken}`;
+      }
       let responseData = await sails.helpers.http.get.with({// [?]: https://docs.github.com/en/rest/commits/commits?apiVersion=2022-11-28#list-commits
         url: 'https://api.github.com/repos/osquery/osquery-site/commits',
         data: {
@@ -47,10 +58,7 @@ module.exports = {
           page: 1,
           per_page: 1,//eslint-disable-line camelcase
         },
-        headers: {
-          'User-Agent': 'fleet-schema-builder',
-          'Accept': 'application/vnd.github.v3+json',
-        },
+        headers: baseHeadersForGithubRequests
       }).intercept((err)=>{
         return new Error(`When trying to send a request to GitHub get a timestamp of the last commit to the osqeury schema JSON, an error occurred. Full error: ${util.inspect(err)}`);
       });

--- a/website/scripts/build-static-content.js
+++ b/website/scripts/build-static-content.js
@@ -391,7 +391,9 @@ module.exports = {
 
               // Get last modified timestamp using git, and represent it as a JS timestamp.
               let lastModifiedAt;
-              if(githubAccessToken) {
+              if(!githubAccessToken) {
+                lastModifiedAt = Date.now();
+              } else {
                 let responseData = await sails.helpers.http.get.with({// [?]: https://docs.github.com/en/rest/commits/commits?apiVersion=2022-11-28#list-commits
                   url: 'https://api.github.com/repos/fleetdm/fleet/commits',
                   data: {
@@ -410,8 +412,6 @@ module.exports = {
                   throw new Error(`When getting the commit history for ${path.join(sectionRepoPath, pageRelSourcePath)} to get a lastModifiedAt timestamp, the response from the GitHub API did not include information about the most recent commit. Response from GitHub: ${util.inspect(responseData, {depth:null})}`);
                 }
                 lastModifiedAt = (new Date(mostRecentCommitToOsquerySchema.commit.committer.date)).getTime(); // Convert the UTC timestamp from GitHub to a JS timestamp.
-              } else {
-                lastModifiedAt = Date.now();
               }
 
               // Determine display title (human-readable title) to use for this page.
@@ -579,7 +579,9 @@ module.exports = {
 
         // Get last modified timestamp using git, and represent it as a JS timestamp.
         let lastModifiedAt;
-        if(githubAccessToken) {
+        if(!githubAccessToken) {
+          lastModifiedAt = Date.now();
+        } else {
           // If we're including a lastModifiedAt value for schema tables, we'll send a request to the GitHub API to get a timestamp of when the last commit
           let responseData = await sails.helpers.http.get.with({// [?]: https://docs.github.com/en/rest/commits/commits?apiVersion=2022-11-28#list-commits
             url: 'https://api.github.com/repos/fleetdm/fleet/commits',
@@ -599,8 +601,6 @@ module.exports = {
             throw new Error(`When trying to get a lastModifiedAt timestamp for the open positions YAML, the response from the GitHub API did not include information about the most recent commit. Response from GitHub: ${util.inspect(responseData, {depth:null})}`);
           }
           lastModifiedAt = (new Date(mostRecentCommitToOsquerySchema.commit.committer.date)).getTime(); // Convert the UTC timestamp from GitHub to a JS timestamp.
-        } else {
-          lastModifiedAt = Date.now();
         }
 
         let openPositionsYaml = await sails.helpers.fs.read(path.join(topLvlRepoPath, RELATIVE_PATH_TO_OPEN_POSITIONS_YML_IN_FLEET_REPO)).intercept('doesNotExist', (err)=>new Error(`Could not find open positions YAML file at "${RELATIVE_PATH_TO_OPEN_POSITIONS_YML_IN_FLEET_REPO}".  Was it accidentally moved?  Raw error: `+err.message));

--- a/website/scripts/build-static-content.js
+++ b/website/scripts/build-static-content.js
@@ -1083,9 +1083,6 @@ module.exports = {
             let allExistingLabelsInSpecifiedRepo = [];
             let pageOfResultsReturned = 0;
             // Get all the labels in the specified repo.
-            if(repo = 'classified'){
-              continue;
-            }
             await sails.helpers.flow.until(async ()=>{
               let pageOfLabels = await sails.helpers.http.get.with({
                 url: `https://api.github.com/repos/fleetdm/${repo}/labels?per_page=100&page=${pageOfResultsReturned}`,

--- a/website/scripts/build-static-content.js
+++ b/website/scripts/build-static-content.js
@@ -16,7 +16,7 @@ module.exports = {
   fn: async function ({ dry, githubAccessToken }) {
     let path = require('path');
     let YAML = require('yaml');
-
+    let util = require('util');
     // FUTURE: If we ever need to gather source files from other places or branches, etc, see git history of this file circa 2021-05-19 for an example of a different strategy we might use to do that.
     let topLvlRepoPath = path.resolve(sails.config.appPath, '../');
 
@@ -390,11 +390,29 @@ module.exports = {
               }//ﬁ
 
               // Get last modified timestamp using git, and represent it as a JS timestamp.
-              // > Inspired by https://github.com/uncletammy/doc-templater/blob/2969726b598b39aa78648c5379e4d9503b65685e/lib/compile-markdown-tree-from-remote-git-repo.js#L265-L273
-              let lastModifiedAt = (new Date((await sails.helpers.process.executeCommand.with({
-                command: `git log -1 --format="%ai" '${path.relative(topLvlRepoPath, pageSourcePath)}'`,
-                dir: topLvlRepoPath,
-              })).stdout)).getTime();
+              let lastModifiedAt;
+              if(githubAccessToken) {
+                let responseData = await sails.helpers.http.get.with({// [?]: https://docs.github.com/en/rest/commits/commits?apiVersion=2022-11-28#list-commits
+                  url: 'https://api.github.com/repos/fleetdm/fleet/commits',
+                  data: {
+                    path: path.join(sectionRepoPath, pageRelSourcePath),
+                    page: 1,
+                    per_page: 1,//eslint-disable-line camelcase
+                  },
+                  headers: baseHeadersForGithubRequests,
+                }).intercept((err)=>{
+                  return new Error(`When getting the commit history for ${path.join(sectionRepoPath, pageRelSourcePath)} to get a lastModifiedAt timestamp, an error occured.`, err);
+                });
+                // The value we'll use for the lastModifiedAt timestamp will be date value of the `commiter` property of the `commit` we got in the API response from github.
+                let mostRecentCommitToOsquerySchema = responseData[0];
+                if(!mostRecentCommitToOsquerySchema.commit || !mostRecentCommitToOsquerySchema.commit.committer) {
+                  // Throw an error if the the response from GitHub is missing a commit or commiter.
+                  throw new Error(`When getting the commit history for ${path.join(sectionRepoPath, pageRelSourcePath)} to get a lastModifiedAt timestamp, the response from the GitHub API did not include information about the most recent commit. Response from GitHub: ${util.inspect(responseData, {depth:null})}`);
+                }
+                lastModifiedAt = (new Date(mostRecentCommitToOsquerySchema.commit.committer.date)).getTime(); // Convert the UTC timestamp from GitHub to a JS timestamp.
+              } else {
+                lastModifiedAt = Date.now();
+              }
 
               // Determine display title (human-readable title) to use for this page.
               let pageTitle;
@@ -560,11 +578,30 @@ module.exports = {
         let RELATIVE_PATH_TO_OPEN_POSITIONS_YML_IN_FLEET_REPO = 'handbook/company/open-positions.yml';
 
         // Get last modified timestamp using git, and represent it as a JS timestamp.
-        // > Inspired by https://github.com/uncletammy/doc-templater/blob/2969726b598b39aa78648c5379e4d9503b65685e/lib/compile-markdown-tree-from-remote-git-repo.js#L265-L273
-        let lastModifiedAt = (new Date((await sails.helpers.process.executeCommand.with({
-          command: `git log -1 --format="%ai" '${path.join(topLvlRepoPath, RELATIVE_PATH_TO_OPEN_POSITIONS_YML_IN_FLEET_REPO)}'`,
-          dir: topLvlRepoPath,
-        })).stdout)).getTime();
+        let lastModifiedAt;
+        if(githubAccessToken) {
+          // If we're including a lastModifiedAt value for schema tables, we'll send a request to the GitHub API to get a timestamp of when the last commit
+          let responseData = await sails.helpers.http.get.with({// [?]: https://docs.github.com/en/rest/commits/commits?apiVersion=2022-11-28#list-commits
+            url: 'https://api.github.com/repos/fleetdm/fleet/commits',
+            data: {
+              path: RELATIVE_PATH_TO_OPEN_POSITIONS_YML_IN_FLEET_REPO,
+              page: 1,
+              per_page: 1,//eslint-disable-line camelcase
+            },
+            headers: baseHeadersForGithubRequests,
+          }).intercept((err)=>{
+            return new Error(`When getting the commit history for the open positions YAML to get a lastModifiedAt timestamp, an error occured.`, err);
+          });
+          // The value we'll use for the lastModifiedAt timestamp will be date value of the `commiter` property of the `commit` we got in the API response from github.
+          let mostRecentCommitToOsquerySchema = responseData[0];
+          if(!mostRecentCommitToOsquerySchema.commit || !mostRecentCommitToOsquerySchema.commit.committer) {
+            // Throw an error if the the response from GitHub is missing a commit or commiter.
+            throw new Error(`When trying to get a lastModifiedAt timestamp for the open positions YAML, the response from the GitHub API did not include information about the most recent commit. Response from GitHub: ${util.inspect(responseData, {depth:null})}`);
+          }
+          lastModifiedAt = (new Date(mostRecentCommitToOsquerySchema.commit.committer.date)).getTime(); // Convert the UTC timestamp from GitHub to a JS timestamp.
+        } else {
+          lastModifiedAt = Date.now();
+        }
 
         let openPositionsYaml = await sails.helpers.fs.read(path.join(topLvlRepoPath, RELATIVE_PATH_TO_OPEN_POSITIONS_YML_IN_FLEET_REPO)).intercept('doesNotExist', (err)=>new Error(`Could not find open positions YAML file at "${RELATIVE_PATH_TO_OPEN_POSITIONS_YML_IN_FLEET_REPO}".  Was it accidentally moved?  Raw error: `+err.message));
         let openPositionsToCreatePartialsFor = YAML.parse(openPositionsYaml, {prettyErrors: true});
@@ -673,7 +710,12 @@ module.exports = {
 
         }
         // After we build the Markdown pages, we'll merge the osquery schema with the Fleet schema overrides, then create EJS partials for each table in the merged schema.
-        let expandedTables = await sails.helpers.getExtendedOsquerySchema.with({includeLastModifiedAtValue: true});
+        let expandedTables;
+        if(githubAccessToken){
+          expandedTables = await sails.helpers.getExtendedOsquerySchema.with({includeLastModifiedAtValue: true, githubAccessToken,});
+        } else {
+          expandedTables = await sails.helpers.getExtendedOsquerySchema();
+        }
 
         // Once we have our merged schema, we'll create ejs partials for each table.
         for(let table of expandedTables) {
@@ -1041,6 +1083,9 @@ module.exports = {
             let allExistingLabelsInSpecifiedRepo = [];
             let pageOfResultsReturned = 0;
             // Get all the labels in the specified repo.
+            if(repo = 'classified'){
+              continue;
+            }
             await sails.helpers.flow.until(async ()=>{
               let pageOfLabels = await sails.helpers.http.get.with({
                 url: `https://api.github.com/repos/fleetdm/${repo}/labels?per_page=100&page=${pageOfResultsReturned}`,
@@ -1091,7 +1136,6 @@ module.exports = {
         }
       });
     }
-
   }
 
 


### PR DESCRIPTION
Closes: #20823

Changes:
- Updated the build-static-content script to use the GitHub API to get timestamps of when files were last changed.
- Updated the get-extended-osquery schema helper to use a GitHub token to authenticate GitHub requests (if it is provided)