### PR TITLE
App Store apps ID string instead of integer

### DIFF
--- a/docs/Using Fleet/GitOps.md
+++ b/docs/Using Fleet/GitOps.md
@@ -309,7 +309,7 @@ software:
       self_service: true
     - url: https://github.com/organinzation/repository/package-2.msi
   app_store_apps:
-   - app_store_id: 1091189122
+   - app_store_id: '1091189122'
 ```
 
 #### packages

--- a/docs/Using Fleet/GitOps.md
+++ b/docs/Using Fleet/GitOps.md
@@ -322,7 +322,7 @@ software:
 
 #### app_store_apps
 
-- `app_store_id` is the ID of the Apple App Store app. You can find this at the end of the app's App Store URL. For example, "Bear - Markdown Notes" URL is "https://apps.apple.com/us/app/bear-markdown-notes/id1016366447" and the `app_store_id` is `1016366447` (default: `0`).
+- `app_store_id` is the ID of the Apple App Store app. You can find this at the end of the app's App Store URL. For example, "Bear - Markdown Notes" URL is "https://apps.apple.com/us/app/bear-markdown-notes/id1016366447" and the `app_store_id` is `1016366447`.
 
 ### org_settings and team_settings
 


### PR DESCRIPTION
Related to: #20851

We decided to change `app_store_id` to a string instead of an integer since in the Apple APIs it's returned as a string.