### PR TITLE
Website: Remove duplicate "Fleet" from page titles

### DIFF
--- a/website/api/controllers/articles/view-articles.js
+++ b/website/api/controllers/articles/view-articles.js
@@ -50,7 +50,7 @@ module.exports = {
       });
     }
 
-    let pageTitleForMeta = 'Fleet blog | Fleet';
+    let pageTitleForMeta = 'Fleet blog';
     let pageDescriptionForMeta = 'Read the latest articles written by Fleet.';
     // Create a currentSection variable, this will be used to highlight the header dropdown that this article category lives under.
     // There are three possible values for this (documentation, community, and platform), so we'll default to the one with the most article categories (community) and set the value to another section if needed.
@@ -60,39 +60,39 @@ module.exports = {
     // Set a pageTitleForMeta, pageDescriptionForMeta, and currentSection variable based on the article category.
     switch(category) {
       case 'success-stories':
-        pageTitleForMeta = 'Success stories | Fleet';
+        pageTitleForMeta = 'Success stories';
         pageDescriptionForMeta = 'Read about how others are using Fleet and osquery.';
         currentSection = 'platform';
         break;
       case 'deploy':
-        pageTitleForMeta = 'Deployment guides | Fleet';
+        pageTitleForMeta = 'Deployment guides';
         pageDescriptionForMeta = 'Learn how to deploy Fleet on a variety of production environments.';
         currentSection = 'documentation';
         break;
       case 'releases':
-        pageTitleForMeta = 'Releases | Fleet';
+        pageTitleForMeta = 'Releases';
         pageDescriptionForMeta = 'Fleet releases new and updated features every three weeks. Read about the latest product improvements here.';
         currentSection = 'documentation';
         break;
       case 'guides':
-        pageTitleForMeta = 'Guides | Fleet';
+        pageTitleForMeta = 'Guides';
         pageDescriptionForMeta = 'A collection of how-to guides for Fleet and osquery.';
         currentSection = 'documentation';
         break;
       case 'securing':
-        pageTitleForMeta = 'Security articles | Fleet';
+        pageTitleForMeta = 'Security articles';
         pageDescriptionForMeta = 'Learn more about how we secure Fleet.';
         break;
       case 'engineering':
-        pageTitleForMeta = 'Engineering articles | Fleet';
+        pageTitleForMeta = 'Engineering articles';
         pageDescriptionForMeta = 'Read about engineering at Fleet and beyond.';
         break;
       case 'announcements':
-        pageTitleForMeta = 'Announcements | Fleet';
+        pageTitleForMeta = 'Announcements';
         pageDescriptionForMeta = 'Read the latest news from Fleet.';
         break;
       case 'podcasts':
-        pageTitleForMeta = 'Podcasts | Fleet';
+        pageTitleForMeta = 'Podcasts';
         pageDescriptionForMeta = 'Listen to the Future of Device Management podcast.';
         break;
     }

--- a/website/api/controllers/articles/view-basic-article.js
+++ b/website/api/controllers/articles/view-basic-article.js
@@ -52,7 +52,7 @@ module.exports = {
     // Note: Leaving title and description as `undefined` in our view means we'll default to the generic title and description set in layout.ejs.
     let pageTitleForMeta;
     if(thisPage.meta.articleTitle) {
-      pageTitleForMeta = thisPage.meta.articleTitle + ' | Fleet';
+      pageTitleForMeta = thisPage.meta.articleTitle;
     }//ﬁ
     let pageDescriptionForMeta;
     if(thisPage.meta.description){

--- a/website/api/controllers/docs/view-basic-documentation.js
+++ b/website/api/controllers/docs/view-basic-documentation.js
@@ -69,7 +69,7 @@ module.exports = {
       compiledPagePartialsAppPath: sails.config.builtStaticContent.compiledPagePartialsAppPath,
       pageTitleForMeta: (
         thisPage.title !== 'Readme.md' ? thisPage.title + ' | Fleet documentation'// « custom meta title for this page, if provided in markdown
-        : 'Documentation | Fleet' // « otherwise we're on the landing page for this section of the site, so we'll follow the title format of other top-level pages
+        : 'Documentation' // « otherwise we're on the landing page for this section of the site, so we'll follow the title format of other top-level pages
       ),
       pageDescriptionForMeta: (
         thisPage.meta.description ? thisPage.meta.description // « custom meta description for this page, if provided in markdown

--- a/website/api/controllers/handbook/view-basic-handbook.js
+++ b/website/api/controllers/handbook/view-basic-handbook.js
@@ -64,7 +64,7 @@ module.exports = {
       compiledPagePartialsAppPath: sails.config.builtStaticContent.compiledPagePartialsAppPath,
       pageTitleForMeta: (
         thisPage.title !== 'Readme.md' ? thisPage.title + ' | Fleet handbook'// « custom meta title for this page, if provided in markdown
-        : 'Handbook | Fleet' // « otherwise we're on the landing page for this section of the site, so we'll follow the title format of other top-level pages
+        : 'Handbook' // « otherwise we're on the landing page for this section of the site, so we'll follow the title format of other top-level pages
       ),
       pageDescriptionForMeta: (
         thisPage.meta.description ? thisPage.meta.description // « custom meta description for this page, if provided in markdown

--- a/website/api/controllers/view-query-detail.js
+++ b/website/api/controllers/view-query-detail.js
@@ -35,7 +35,7 @@ module.exports = {
     }
 
     // Setting the meta title and description of this page using the query object, and falling back to a generic title or description if query.name or query.description are missing.
-    let pageTitleForMeta = query.name ? query.name + ' | Query details' : 'Query details | Fleet';
+    let pageTitleForMeta = query.name ? query.name + ' | Query details' : 'Query details';
     let pageDescriptionForMeta = query.description ? query.description : 'View more information about a query in Fleet\'s standard query library';
     // Respond with view.
     return {

--- a/website/config/routes.js
+++ b/website/config/routes.js
@@ -23,7 +23,7 @@ module.exports.routes = {
   'GET /contact': {
     action: 'view-contact',
     locals: {
-      pageTitleForMeta: 'Contact us | Fleet',
+      pageTitleForMeta: 'Contact us',
       pageDescriptionForMeta: 'Get in touch with our team.',
       hideFooterLinks: true,
     }
@@ -34,7 +34,7 @@ module.exports.routes = {
     locals: {
       hideHeaderLinks: true,
       hideFooterLinks: true,
-      pageTitleForMeta: 'fleetctl preview | Fleet',
+      pageTitleForMeta: 'fleetctl preview',
       pageDescriptionForMeta: 'Learn about getting started with Fleet using fleetctl.'
     }
   },
@@ -43,7 +43,7 @@ module.exports.routes = {
     action: 'view-pricing',
     locals: {
       currentSection: 'pricing',
-      pageTitleForMeta: 'Pricing | Fleet',
+      pageTitleForMeta: 'Pricing',
       pageDescriptionForMeta: 'Use Fleet for free or get started with Fleet Premium (self-hosted or managed cloud). Have a large deployment? We\'ve got you covered.'
     }
   },
@@ -51,7 +51,7 @@ module.exports.routes = {
   'GET /logos': {
     action: 'view-press-kit',
     locals: {
-      pageTitleForMeta: 'Logos | Fleet',
+      pageTitleForMeta: 'Logos',
       pageDescriptionForMeta: 'Download Fleet logos, wallpapers, and screenshots.'
     }
   },
@@ -60,7 +60,7 @@ module.exports.routes = {
     action: 'view-query-library',
     locals: {
       currentSection: 'documentation',
-      pageTitleForMeta: 'Queries | Fleet',
+      pageTitleForMeta: 'Queries',
       pageDescriptionForMeta: 'A growing collection of useful queries for organizations deploying Fleet and osquery.'
     }
   },
@@ -106,7 +106,7 @@ module.exports.routes = {
       hideHeaderLinks: true,
       hideFooterLinks: true,
       hideStartCTA: true,
-      pageTitleForMeta: 'Get Fleet Premium | Fleet',
+      pageTitleForMeta: 'Get Fleet Premium',
       pageDescriptionForMeta: 'Generate your quote and start using Fleet Premium today.',
     }
   },
@@ -114,7 +114,7 @@ module.exports.routes = {
     action: 'entrance/view-signup',
     locals: {
       hideFooterLinks: true,
-      pageTitleForMeta: 'Sign up | Fleet',
+      pageTitleForMeta: 'Sign up',
       pageDescriptionForMeta: 'Sign up for a Fleet account.',
     }
   },
@@ -122,7 +122,7 @@ module.exports.routes = {
     action: 'entrance/view-login',
     locals: {
       hideFooterLinks: true,
-      pageTitleForMeta: 'Log in | Fleet',
+      pageTitleForMeta: 'Log in',
       pageDescriptionForMeta: 'Log in to Fleet.',
     }
   },
@@ -132,7 +132,7 @@ module.exports.routes = {
       hideHeaderLinks: true,
       hideFooterLinks: true,
       hideStartCTA: true,
-      pageTitleForMeta: 'Customer dashboard | Fleet',
+      pageTitleForMeta: 'Customer dashboard',
       pageDescriptionForMeta: 'View and edit information about your Fleet Premium license.',
     }
   },
@@ -142,7 +142,7 @@ module.exports.routes = {
       hideHeaderLinks: true,
       hideFooterLinks: true,
       hideStartCTA: true,
-      pageTitleForMeta: 'Forgot password | Fleet',
+      pageTitleForMeta: 'Forgot password',
       pageDescriptionForMeta: 'Recover the password for your Fleet customer account.',
     }
   },
@@ -152,7 +152,7 @@ module.exports.routes = {
       hideHeaderLinks: true,
       hideFooterLinks: true,
       hideStartCTA: true,
-      pageTitleForMeta: 'New password | Fleet',
+      pageTitleForMeta: 'New password',
       pageDescriptionForMeta: 'Change the password for your Fleet customer account.',
     }
   },
@@ -160,7 +160,7 @@ module.exports.routes = {
   'GET /reports/state-of-device-management': {
     action: 'reports/view-state-of-device-management',
     locals: {
-      pageTitleForMeta: 'State of device management | Fleet',
+      pageTitleForMeta: 'State of device management',
       pageDescriptionForMeta: 'We surveyed 200+ security practitioners to discover the state of device management in 2022. Click here to learn about their struggles and best practices.',
     }
   },
@@ -221,7 +221,7 @@ module.exports.routes = {
   'GET /device-management': {
     action: 'view-device-management',
     locals: {
-      pageTitleForMeta: 'Device management (MDM) | Fleet',
+      pageTitleForMeta: 'Device management (MDM)',
       pageDescriptionForMeta: 'Manage your devices in any browser or use git to make changes as code.',
       currentSection: 'platform',
     }
@@ -230,7 +230,7 @@ module.exports.routes = {
   'GET /endpoint-ops': {
     action: 'view-endpoint-ops',
     locals: {
-      pageTitleForMeta: 'Endpoint ops | Fleet',
+      pageTitleForMeta: 'Endpoint ops',
       pageDescriptionForMeta: 'Pulse check anything, build reports, and ship data to any platform with Fleet.',
       currentSection: 'platform',
     }
@@ -239,7 +239,7 @@ module.exports.routes = {
   'GET /vulnerability-management': {
     action: 'view-vulnerability-management',
     locals: {
-      pageTitleForMeta: 'Vulnerability management | Fleet',
+      pageTitleForMeta: 'Vulnerability management',
       pageDescriptionForMeta: 'Report CVEs, software inventory, security posture, and other risks down to the chipset of any endpoint with Fleet.',
       currentSection: 'platform',
     }
@@ -248,7 +248,7 @@ module.exports.routes = {
   'GET /support': {
     action: 'view-support',
     locals: {
-      pageTitleForMeta: 'Support | Fleet',
+      pageTitleForMeta: 'Support',
       pageDescriptionForMeta: 'Ask a question, chat with engineers, or get in touch with the Fleet team.',
       currentSection: 'documentation',
     }
@@ -257,7 +257,7 @@ module.exports.routes = {
   'GET /integrations': {
     action: 'view-integrations',
     locals: {
-      pageTitleForMeta: 'Integrations | Fleet',
+      pageTitleForMeta: 'Integrations',
       pageDescriptionForMeta: 'Integrate IT ticketing systems, SIEM and SOAR platforms, custom IT workflows, and more.',
       currentSection: 'platform'
     }
@@ -269,7 +269,7 @@ module.exports.routes = {
       hideFooterLinks: true,
       hideGetStartedButton: true,
       hideStartCTA: true,
-      pageTitleForMeta: 'Start | Fleet',
+      pageTitleForMeta: 'Start',
       pageDescriptionForMeta: 'Get Started with Fleet. Spin up a local demo or get your Premium license key.',
     }
   },
@@ -278,7 +278,7 @@ module.exports.routes = {
     action: 'view-transparency',
     locals: {
       pageDescriptionForMeta: 'Discover how Fleet simplifies IT and security, prioritizing privacy, transparency, and trust for end users.',
-      pageTitleForMeta: 'Better with Fleet | Fleet'
+      pageTitleForMeta: 'Better with Fleet'
     }
   },
 


### PR DESCRIPTION
Changes:
- Removed the duplicate "Fleet" from page titles. 