### PR TITLE
backport: Detect software from deb_packages which is 'on hold' (#20751)

### DIFF
--- a/changes/20751-detect-held-linux-packages-as-installed
+++ b/changes/20751-detect-held-linux-packages-as-installed
@@ -1,0 +1,1 @@
+Linux .deb packages 'on hold' are now included in the installed software list.

--- a/docs/Using Fleet/Understanding-host-vitals.md
+++ b/docs/Using Fleet/Understanding-host-vitals.md
@@ -504,7 +504,7 @@ SELECT
   '' AS arch,
   '' AS installed_path
 FROM deb_packages
-WHERE status = 'install ok installed'
+WHERE status LIKE '% ok installed'
 UNION
 SELECT
   package AS name,

--- a/server/service/osquery_utils/queries.go
+++ b/server/service/osquery_utils/queries.go
@@ -944,7 +944,7 @@ SELECT
   '' AS arch,
   '' AS installed_path
 FROM deb_packages
-WHERE status = 'install ok installed'
+WHERE status LIKE '% ok installed'
 UNION
 SELECT
   package AS name,


### PR DESCRIPTION
> [!NOTE]
> This PR already merged in `main`, see https://github.com/fleetdm/fleet/pull/20751. This is against the release branch so it can be included in 4.55.0


# Checklist for submitter

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
See [Changes
files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [X] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
