### PR TITLE
Fleet UI: multiple unreleased and released bugs

### DIFF
--- a/frontend/components/Editor/Editor.tsx
+++ b/frontend/components/Editor/Editor.tsx
@@ -75,7 +75,7 @@ const Editor = ({
         <TooltipWrapper
           className={labelClassName}
           tipContent={labelTooltip}
-          position="top"
+          position="top-start"
         >
           {labelText}
         </TooltipWrapper>

--- a/frontend/pages/ManageControlsPage/OSSettings/cards/CustomSettings/_styles.scss
+++ b/frontend/pages/ManageControlsPage/OSSettings/cards/CustomSettings/_styles.scss
@@ -99,6 +99,10 @@
       flex-direction: column;
       align-items: center;
       gap: $pad-small;
+
+      &--message {
+        text-align: center;
+      }
     }
 
     &__button-wrap {

--- a/frontend/pages/ManageControlsPage/OSSettings/cards/CustomSettings/components/ProfileUploader/components/AddProfileModal/_styles.scss
+++ b/frontend/pages/ManageControlsPage/OSSettings/cards/CustomSettings/components/ProfileUploader/components/AddProfileModal/_styles.scss
@@ -57,10 +57,10 @@
     flex-direction: column;
     align-items: center;
     gap: $pad-small;
-  }
 
-  &__profile-graphic--message {
-    text-align: center;
+    &--message {
+      text-align: center;
+    }
   }
 
   &__button-wrap {

--- a/frontend/pages/SoftwarePage/SoftwareTitles/SoftwareTable/SoftwareTitlesTableConfig.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitles/SoftwareTable/SoftwareTitlesTableConfig.tsx
@@ -76,11 +76,13 @@ const getSoftwareNameCellData = (
     iconUrl = app_store_app.icon_url;
   }
 
+  const isAllTeams = teamId === undefined;
+
   return {
     name: softwareTitle.name,
     source: softwareTitle.source,
     path: softwareTitleDetailsPath,
-    hasPackage: hasPackage && !!teamId,
+    hasPackage: hasPackage && !isAllTeams,
     isSelfService,
     iconUrl,
   };


### PR DESCRIPTION
## Issue
1. Unreleased bug #20945 
2. Released bug #20677 
3. Released bug #20840 

## Description
1. Icon and tooltip was hiding on no teams view
2. Fix text alignment
3. Fix Editor's label tooltip alignment to be top start and not just top

## Screenshot of fixes
1.
<img width="1116" alt="Screenshot 2024-08-01 at 2 13 18 PM" src="https://github.com/user-attachments/assets/361bdeb5-e495-41d4-8672-dceeaaa7e0bb">
2.
<img width="1340" alt="Screenshot 2024-08-01 at 11 54 21 AM" src="https://github.com/user-attachments/assets/a080319d-d784-48a6-a90f-960ea4adf05f">
3.
<img width="1434" alt="Screenshot 2024-08-01 at 11 59 40 AM" src="https://github.com/user-attachments/assets/1a2a6b30-21e3-49b8-ae5d-7f8e68c5ced4">





# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [ ] Manual QA for all new/changed functionality