### PR TITLE
Website: Update questionnaire pre-filling.

### DIFF
--- a/website/assets/js/pages/start.page.js
+++ b/website/assets/js/pages/start.page.js
@@ -85,7 +85,9 @@ parasails.registerPage('start', {
     }
     // If this user has not completed the 'what are you using fleet for' step, and has a primaryBuyingSituation set by an ad. prefill the formData for this step.
     if(this.primaryBuyingSituation && _.isEmpty(this.formData['what-are-you-using-fleet-for'])){
-      this.formData['what-are-you-using-fleet-for'] = {primaryBuyingSituation: this.primaryBuyingSituation};
+      if(this.primaryBuyingSituation !== 'vm') {
+        this.formData['what-are-you-using-fleet-for'] = {primaryBuyingSituation: this.primaryBuyingSituation};
+      }
     }
     if(window.location.hash) {
       if(typeof analytics !== 'undefined') {


### PR DESCRIPTION
Changes:
- Updated the /start questionnaire to not prefill the "What will you use Fleet for?" question if the user has a primaryBuyingSituation set to `vm`