### PR TITLE
escape % in query

### DIFF
--- a/server/service/osquery_utils/queries.go
+++ b/server/service/osquery_utils/queries.go
@@ -944,7 +944,7 @@ SELECT
   '' AS arch,
   '' AS installed_path
 FROM deb_packages
-WHERE status LIKE '% ok installed'
+WHERE status LIKE '%% ok installed'
 UNION
 SELECT
   package AS name,


### PR DESCRIPTION
for https://github.com/fleetdm/fleet/issues/20940. Ran `make generate-doc` as well but docs don't change with this.
