### PR TITLE
Fleet UI: Navigate between no teams tabs

### DIFF
--- a/frontend/components/top_nav/SiteTopNav/SiteTopNav.tsx
+++ b/frontend/components/top_nav/SiteTopNav/SiteTopNav.tsx
@@ -56,6 +56,7 @@ const REGEX_GLOBAL_PAGES = {
 
 const REGEX_EXCLUDE_NO_TEAM_PAGES = {
   MANAGE_POLICIES: /\/policies\/manage/i,
+  MANAGE_QUERIES: /\/queries\/manage/i,
 };
 
 const testDetailPage = (path: string, re: RegExp) => {
@@ -96,7 +97,6 @@ const SiteTopNav = ({
     isGlobalMaintainer,
     isAnyTeamMaintainer,
     isNoAccess,
-    isSandboxMode,
   } = useContext(AppContext);
 
   const isActiveDetailPage = isDetailPage(currentPath);
@@ -187,7 +187,7 @@ const SiteTopNav = ({
           <LinkWithContext
             className={`${navItemBaseClass}__link`}
             withParams={withParams}
-            currentQueryParams={currentQueryParams}
+            currentQueryParams={{ team_id: currentQueryParams.team_id }}
             to={navItem.location.pathname}
           >
             <span
@@ -220,8 +220,7 @@ const SiteTopNav = ({
     isAnyTeamAdmin,
     isAnyTeamMaintainer,
     isGlobalMaintainer,
-    isNoAccess,
-    isSandboxMode
+    isNoAccess
   );
 
   const renderNavItems = () => {
@@ -238,7 +237,6 @@ const SiteTopNav = ({
           currentUser={currentUser}
           isAnyTeamAdmin={isAnyTeamAdmin}
           isGlobalAdmin={isGlobalAdmin}
-          isSandboxMode={isSandboxMode}
         />
       </div>
     );

--- a/frontend/components/top_nav/SiteTopNav/navItems.ts
+++ b/frontend/components/top_nav/SiteTopNav/navItems.ts
@@ -27,8 +27,7 @@ export default (
   isAnyTeamAdmin = false,
   isAnyTeamMaintainer = false,
   isGlobalMaintainer = false,
-  isNoAccess = false,
-  isSandboxMode = false
+  isNoAccess = false
 ): INavItem[] => {
   if (!user) {
     return [];
@@ -67,7 +66,7 @@ export default (
         regex: new RegExp(`^${URL_PREFIX}/controls/`),
         pathname: PATHS.CONTROLS,
       },
-      exclude: isSandboxMode || !isMaintainerOrAdmin,
+      exclude: !isMaintainerOrAdmin,
       withParams: { type: "query", names: ["team_id"] },
     },
     {

--- a/frontend/components/top_nav/UserMenu/UserMenu.tsx
+++ b/frontend/components/top_nav/UserMenu/UserMenu.tsx
@@ -17,7 +17,6 @@ interface IUserMenuProps {
   isAnyTeamAdmin: boolean | undefined;
   isGlobalAdmin: boolean | undefined;
   currentUser: IUser;
-  isSandboxMode?: boolean;
 }
 
 const UserMenu = ({
@@ -26,7 +25,6 @@ const UserMenu = ({
   isAnyTeamAdmin,
   isGlobalAdmin,
   currentUser,
-  isSandboxMode = false,
 }: IUserMenuProps): JSX.Element => {
   const accountNavigate = onNavItemClick(PATHS.ACCOUNT);
   const dropdownItems = [
@@ -44,7 +42,7 @@ const UserMenu = ({
     },
   ];
 
-  if (isGlobalAdmin && !isSandboxMode) {
+  if (isGlobalAdmin) {
     const manageUsersNavigate = onNavItemClick(PATHS.ADMIN_USERS);
 
     const manageUserNavItem = {


### PR DESCRIPTION
## Issue
Cerra #20861 

## Description
- When switching between no team pages, the users stays on team no teams instead of getting kicked to all teams
- Other: Remove unused `sandbox` code


## Screen recording
https://www.loom.com/share/951d84e995c24b36aee1f47c73a43886?sid=65b016b2-9307-4bcd-91e5-89bfd6a922ad

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Manual QA for all new/changed functionality

