### PR TITLE
UI – adjust disk encryption table style

### DIFF
--- a/changes/20395-DE-table-style-fix
+++ b/changes/20395-DE-table-style-fix
@@ -1,0 +1,1 @@
+* Fix a styling issue in the Controls > OS Settings > disk encryption table

--- a/frontend/pages/ManageControlsPage/OSSettings/_styles.scss
+++ b/frontend/pages/ManageControlsPage/OSSettings/_styles.scss
@@ -12,6 +12,7 @@
   &__side-nav {
     .side-nav__nav-list {
       top: 0;
+      padding-right: 40px;
     }
   }
 

--- a/frontend/pages/ManageControlsPage/OSSettings/cards/DiskEncryption/components/DiskEncryptionTable/_styles.scss
+++ b/frontend/pages/ManageControlsPage/OSSettings/cards/DiskEncryption/components/DiskEncryptionTable/_styles.scss
@@ -9,6 +9,11 @@
     border-right: none;
   }
 
+  .linkToFilteredHosts__header {
+    width: auto;
+    max-width: 120px;
+  }
+
   @media (max-width: 1120px) {
     .view-hosts-link {
       span {

--- a/frontend/pages/ManageControlsPage/OSSettings/cards/DiskEncryption/components/DiskEncryptionTable/_styles.scss
+++ b/frontend/pages/ManageControlsPage/OSSettings/cards/DiskEncryption/components/DiskEncryptionTable/_styles.scss
@@ -14,11 +14,24 @@
     max-width: 120px;
   }
 
-  @media (max-width: 1120px) {
-    .view-hosts-link {
-      span {
-        display: none;
+}
+
+@media (max-width: 1120px) {
+  .view-hosts-link {
+    span {
+      display: none;
+    }
+  }
+  .linkToFilteredHosts {
+    &__header {
+      width: 0;
+      .column-header {
+        width: 0;
       }
     }
+    &__cell {
+      width: min-content;
+    }
+
   }
 }


### PR DESCRIPTION
## #20395 

<img width="778" alt="Screenshot 2024-08-01 at 7 15 00 PM" src="https://github.com/user-attachments/assets/26fc82c0-d3e9-4e0d-b27d-82be63711fa9">

- [x] Changes file added for user-visible changes in `changes/`
- [x] Manual QA for all new/changed functionality
