### PR TITLE
Remove vpp warning banner when it has been successfuly reuploaded

### DIFF
--- a/frontend/pages/admin/IntegrationsPage/cards/Vpp/VppSetupPage/VppSetupPage.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/Vpp/VppSetupPage/VppSetupPage.tsx
@@ -4,6 +4,7 @@ import { useQuery } from "react-query";
 import { AxiosError } from "axios";
 
 import PATHS from "router/paths";
+import { AppContext } from "context/app";
 import { NotificationContext } from "context/notification";
 import { getErrorReason } from "interfaces/errors";
 import mdmAppleAPI, { IGetVppInfoResponse } from "services/entities/mdm_apple";
@@ -121,6 +122,7 @@ interface IVppSetupPageProps {
 const VppSetupPage = ({ router }: IVppSetupPageProps) => {
   const [showDisableModal, setShowDisableModal] = useState(false);
   const [showRenewModal, setShowRenewModal] = useState(false);
+  const { setVppExpiry } = useContext(AppContext);
 
   const {
     data: vppData,
@@ -134,6 +136,9 @@ const VppSetupPage = ({ router }: IVppSetupPageProps) => {
     {
       ...DEFAULT_USE_QUERY_OPTIONS,
       retry: false,
+      onSuccess: (data) => {
+        setVppExpiry(data.renew_date);
+      },
     }
   );
 


### PR DESCRIPTION
quick fix to remove the vpp warning banner when the user has successfully uploaded a new one.