### PR TITLE
disable FileVault rotation if the server talks to an old fleetd

### DIFF
--- a/server/fleet/capabilities.go
+++ b/server/fleet/capabilities.go
@@ -99,5 +99,11 @@ func GetServerDeviceCapabilities() CapabilityMap {
 	return capabilities
 }
 
+func GetOrbitClientCapabilities() CapabilityMap {
+	return CapabilityMap{
+		CapabilityEscrowBuddy: {},
+	}
+}
+
 // CapabilitiesHeader is the header name used to communicate the capabilities.
 const CapabilitiesHeader = "X-Fleet-Capabilities"

--- a/server/service/orbit_client.go
+++ b/server/service/orbit_client.go
@@ -146,7 +146,7 @@ func NewOrbitClient(
 	orbitHostInfo fleet.OrbitHostInfo,
 	onGetConfigErrFns *OnGetConfigErrFuncs,
 ) (*OrbitClient, error) {
-	orbitCapabilities := fleet.CapabilityMap{}
+	orbitCapabilities := fleet.GetOrbitClientCapabilities()
 	bc, err := newBaseClient(addr, insecureSkipVerify, rootCA, "", fleetClientCert, orbitCapabilities)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
for https://github.com/fleetdm/confidential/issues/7522 and part of #13157, support map is defined as:

|                | fleetd < v1.30                           | fleetd >= v1.30                          |
| -------------- | ---------------------------------------- | ---------------------------------------- |
| Server < 4.55  | OK/FileVault rotation uses system prompt | OK/FileVault rotation uses system prompt |
| Server >= 4.55 | FileVault rotation disabled              | Escrow Buddy                             |

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Added/updated tests
- [x] Manual QA for all new/changed functionality
- For Orbit and Fleet Desktop changes:
   - [ ] Orbit runs on macOS, Linux and Windows. Check if the orbit feature/bugfix should only apply to one platform (`runtime.GOOS`).
   - [ ] Manual QA must be performed in the three main OSs, macOS, Windows and Linux.
   - [ ] Auto-update manual QA, from released version of component to new version (see [tools/tuf/test](../tools/tuf/test/README.md)).
