### PR TITLE
toRC: UI – adjust disk encryption table style (#20981)

### DIFF
--- a/changes/20395-DE-table-style-fix
+++ b/changes/20395-DE-table-style-fix
@@ -1,0 +1,1 @@
+* Fix a styling issue in the Controls > OS Settings > disk encryption table

--- a/frontend/pages/ManageControlsPage/OSSettings/_styles.scss
+++ b/frontend/pages/ManageControlsPage/OSSettings/_styles.scss
@@ -12,6 +12,7 @@
   &__side-nav {
     .side-nav__nav-list {
       top: 0;
+      padding-right: 40px;
     }
   }
 

--- a/frontend/pages/ManageControlsPage/OSSettings/cards/DiskEncryption/components/DiskEncryptionTable/_styles.scss
+++ b/frontend/pages/ManageControlsPage/OSSettings/cards/DiskEncryption/components/DiskEncryptionTable/_styles.scss
@@ -9,11 +9,29 @@
     border-right: none;
   }
 
-  @media (max-width: 1120px) {
-    .view-hosts-link {
-      span {
-        display: none;
+  .linkToFilteredHosts__header {
+    width: auto;
+    max-width: 120px;
+  }
+
+}
+
+@media (max-width: 1120px) {
+  .view-hosts-link {
+    span {
+      display: none;
+    }
+  }
+  .linkToFilteredHosts {
+    &__header {
+      width: 0;
+      .column-header {
+        width: 0;
       }
     }
+    &__cell {
+      width: min-content;
+    }
+
   }
 }


### PR DESCRIPTION
#### This PR already merged to `main`, see https://github.com/fleetdm/fleet/pull/20981. This is against the release branch so it can be included in 4.55.0
