### PR TITLE
fix docker compose detection in fleetctl preview (#21006)

### DIFF
--- a/changes/21006-fleetctl-preview
+++ b/changes/21006-fleetctl-preview
@@ -1,0 +1,1 @@
+* Fixed a bug in `fleetctl preview` that was causing it to fail if Docker was installed without support for the deprecated `docker-compose` CLI

--- a/cmd/fleetctl/preview.go
+++ b/cmd/fleetctl/preview.go
@@ -74,7 +74,7 @@ func (d dockerCompose) Command(arg ...string) *exec.Cmd {
 
 func newDockerCompose() (dockerCompose, error) {
 	// first, check if `docker compose` is available
-	if err := exec.Command("docker compose").Run(); err == nil {
+	if err := exec.Command("docker", "compose").Run(); err == nil {
 		return dockerCompose{dockerComposeV2}, nil
 	}
 


### PR DESCRIPTION
> [!NOTE]
> This the commits in this PR already merged in `main`. This is against the release branch so it can be included in 4.55.0
