### PR TITLE
Docs: Add fleetdm.com/guides link to tutorials-and-guides docs page.

### DIFF
--- a/docs/Get started/tutorials-and-guides.md
+++ b/docs/Get started/tutorials-and-guides.md
@@ -67,5 +67,7 @@ A collection of guides to help you get up and running with Fleet.
 - [Generate process trees with osquery](https://fleetdm.com/guides/generate-process-trees-with-osquery)
 
 
+<animated-arrow-button href="https://fleetdm.com/guides">See all guides</animated-arrow-button>
+
 <meta name="description" value="Links to deployment tutorials and guides for using Fleet.">
 <meta name="pageOrderInSection" value="300">

--- a/docs/Get started/tutorials-and-guides.md
+++ b/docs/Get started/tutorials-and-guides.md
@@ -67,7 +67,7 @@ A collection of guides to help you get up and running with Fleet.
 - [Generate process trees with osquery](https://fleetdm.com/guides/generate-process-trees-with-osquery)
 
 
-<a href="https://fleetdm.com/guides"><animated-arrow-button>See all guides</animated-arrow-button></a>
+<a style="text-decoration: none;" href="https://fleetdm.com/guides"><animated-arrow-button>See all guides</animated-arrow-button></a>
 
 <meta name="description" value="Links to deployment tutorials and guides for using Fleet.">
 <meta name="pageOrderInSection" value="300">

--- a/docs/Get started/tutorials-and-guides.md
+++ b/docs/Get started/tutorials-and-guides.md
@@ -67,7 +67,7 @@ A collection of guides to help you get up and running with Fleet.
 - [Generate process trees with osquery](https://fleetdm.com/guides/generate-process-trees-with-osquery)
 
 
-<animated-arrow-button href="https://fleetdm.com/guides">See all guides</animated-arrow-button>
+<a href="https://fleetdm.com/guides"><animated-arrow-button>See all guides</animated-arrow-button></a>
 
 <meta name="description" value="Links to deployment tutorials and guides for using Fleet.">
 <meta name="pageOrderInSection" value="300">


### PR DESCRIPTION
Related to: https://github.com/fleetdm/confidential/issues/7343

Changes:
- Added a fleetdm.com/guides link to the tutorials and guides docs page.