### PR TITLE
Fix line break Markdown in commas-and-numbers list heading

### DIFF
--- a/handbook/company/communications.md
+++ b/handbook/company/communications.md
@@ -1217,6 +1217,7 @@ Sometimes numerals seem out of place. If an expression typically spells out the 
 - First impression
 - Third-party integration
 - All-in-one platform
+
 Numbers over 3 digits get commas:
 - 999
 - 1,000


### PR DESCRIPTION
Checked in GitHub preview. Previously "Numbers over three digits" got appended to "All-in-one platform" because Markdown