### PR TITLE
For R.C. - Fleet UI: No team header text and button fix

### DIFF
--- a/frontend/hooks/useTeamIdParam.ts
+++ b/frontend/hooks/useTeamIdParam.ts
@@ -395,6 +395,8 @@ export const useTeamIdParam = ({
     currentTeamName: currentTeam?.name,
     currentTeamSummary: currentTeam,
     isAnyTeamSelected: isAnyTeamSelected(currentTeam?.id),
+    isAllTeamsSelected:
+      !isAnyTeamSelected(currentTeam?.id) && currentTeam?.id !== 0,
     isRouteOk,
     isTeamAdmin:
       !!currentTeam?.id && permissions.isTeamAdmin(currentUser, currentTeam.id),

--- a/frontend/pages/SoftwarePage/SoftwarePage.tsx
+++ b/frontend/pages/SoftwarePage/SoftwarePage.tsx
@@ -157,7 +157,7 @@ const SoftwarePage = ({ children, router, location }: ISoftwarePageProps) => {
 
   const {
     currentTeamId,
-    isAnyTeamSelected,
+    isAllTeamsSelected,
     isRouteOk,
     teamIdForApi,
     userTeams,
@@ -318,7 +318,7 @@ const SoftwarePage = ({ children, router, location }: ISoftwarePageProps) => {
 
   const renderPageActions = () => {
     const canManageAutomations =
-      isGlobalAdmin && (!isPremiumTier || !isAnyTeamSelected);
+      isGlobalAdmin && (!isPremiumTier || isAllTeamsSelected);
 
     const canAddSoftware =
       isGlobalAdmin || isGlobalMaintainer || isTeamAdmin || isTeamMaintainer;
@@ -349,7 +349,7 @@ const SoftwarePage = ({ children, router, location }: ISoftwarePageProps) => {
     return (
       <p>
         Manage software and search for installed software, OS and
-        vulnerabilities {isAnyTeamSelected ? "on this team" : "for all hosts"}.
+        vulnerabilities {isAllTeamsSelected ? "for all hosts" : "on this team"}.
       </p>
     );
   };


### PR DESCRIPTION
> [!NOTE]
> This PR already merged in `main`, see https://github.com/fleetdm/fleet/pull/21008 This is against the release branch so it can be included in 4.55.0


```
 1274  git checkout fleetdm/minor-fleet-v4.55.0
 1275  git cherry-pick c83458e26f1bd05c50ca87d78e14093f98aa8b0b
 1276  git status
 1277  git checkout -b no-teams-header-btn-and-text-rc
 1278  git push -u fleetdm no-teams-header-btn-and-text-rc
```
