### PR TITLE
Fleet UI: Update host details > software > status "Installed" tooltip

### DIFF
--- a/frontend/pages/SoftwarePage/SoftwarePage.tsx
+++ b/frontend/pages/SoftwarePage/SoftwarePage.tsx
@@ -348,7 +348,7 @@ const SoftwarePage = ({ children, router, location }: ISoftwarePageProps) => {
   const renderHeaderDescription = () => {
     return (
       <p>
-        Manage software and search for installed software, OS and
+        Manage software and search for installed software, OS, and
         vulnerabilities {isAllTeamsSelected ? "for all hosts" : "on this team"}.
       </p>
     );

--- a/frontend/pages/hosts/details/cards/Software/InstallStatusCell/InstallStatusCell.tsx
+++ b/frontend/pages/hosts/details/cards/Software/InstallStatusCell/InstallStatusCell.tsx
@@ -38,8 +38,9 @@ export const INSTALL_STATUS_DISPLAY_OPTIONS: Record<
     displayText: "Installed",
     tooltip: ({ lastInstalledAt: lastInstall }) => (
       <>
-        Fleet installed software on these hosts. (
-        {dateAgo(lastInstall as string)})
+        Fleet installed software on this host
+        {dateAgo(lastInstall as string)}). Currently, if the software is
+        deleted, the “Installed” status won’t be updated.
       </>
     ),
   },


### PR DESCRIPTION
## Issue
Short term fix for #21024 

## Description
- This is the 4.55 temporary fix designed for software that is installed but deleted still showing installed
- Temporary fix is to mention it in a tooltip
