### PR TITLE
Website: Add unsubscribe link to marketing emails

### DIFF
--- a/website/api/controllers/admin/view-email-template-preview.js
+++ b/website/api/controllers/admin/view-email-template-preview.js
@@ -117,19 +117,22 @@ module.exports = {
       case 'email-nurture-stage-three':
         layout = 'layout-nurture-email';
         fakeData = {
-          firstName: 'Sage'
+          firstName: 'Sage',
+          emailAddress: 'sage@example.com',
         };
         break;
       case 'email-nurture-stage-four':
         layout = 'layout-nurture-email';
         fakeData = {
-          firstName: 'Sage'
+          firstName: 'Sage',
+          emailAddress: 'sage@example.com',
         };
         break;
       case 'email-nurture-stage-five':
         layout = 'layout-nurture-email';
         fakeData = {
-          firstName: 'Sage'
+          firstName: 'Sage',
+          emailAddress: 'sage@example.com',
         };
         break;
       case 'email-deal-registration':

--- a/website/api/controllers/unsubscribe-from-marketing-emails.js
+++ b/website/api/controllers/unsubscribe-from-marketing-emails.js
@@ -1,0 +1,80 @@
+module.exports = {
+
+
+  friendlyName: 'Unsubscribe from marketing emails',
+
+
+  description: 'Unsubscribes a specified email address from the nurture email automation.',
+
+
+  inputs: {
+    emailAddress: {
+      type: 'string',
+      description: 'The email address of the user who wants to unsubscribe from marketing emails.',
+      required: true,
+    }
+  },
+
+
+  exits: {
+    userNotFound: {
+      description: 'The provided email address could not be matched to a Fleet user account',
+      responseType: 'badRequest',
+    },
+    userAlreadyUnsubscribed: {
+      description: 'The provided email address is already unsubscribed to marketing emails',
+      responseType: 'success',
+    },
+    success: {
+      description: 'The user has opted out of markering emails',
+    }
+  },
+
+
+  fn: async function ({emailAddress}) {
+
+    let userRecord = await User.findOne({emailAddress: emailAddress});
+
+    if(!userRecord){
+      throw 'userNotFound';
+    }
+
+    if(!userRecord.subscribedToNurtureEmails){
+      throw 'userAlreadyUnsubscribed';
+    }
+
+    await User.updateOne({emailAddress: emailAddress}).set({subscribedToNurtureEmails: false});
+
+    if(sails.config.environment === 'production'){
+      require('assert')(sails.config.custom.salesforceIntegrationUsername);
+      require('assert')(sails.config.custom.salesforceIntegrationPasskey);
+
+      // Log in to Salesforce.
+      let jsforce = require('jsforce');
+      let salesforceConnection = new jsforce.Connection({
+        loginUrl : 'https://fleetdm.my.salesforce.com'
+      });
+      await salesforceConnection.login(sails.config.custom.salesforceIntegrationUsername, sails.config.custom.salesforceIntegrationPasskey);
+
+      let existingContactRecord = await salesforceConnection.sobject('Contact')
+      .findOne({
+        Email:  emailAddress,
+      });
+
+      if(existingContactRecord) {
+        //If we found an existing contact record in salesforce, update its status to be "Do not contact"
+        let salesforceContactId = existingContactRecord.Id;
+        await salesforceConnection.sobject('Contact')
+        .update({
+          Id: salesforceContactId,
+          Stage__c: 'Do not contact',// eslint-disable-line camelcase
+        });
+      }
+    }
+    // All done.
+    return;
+
+  }
+
+
+};

--- a/website/api/controllers/unsubscribe-from-marketing-emails.js
+++ b/website/api/controllers/unsubscribe-from-marketing-emails.js
@@ -66,7 +66,7 @@ module.exports = {
         await salesforceConnection.sobject('Contact')
         .update({
           Id: salesforceContactId,
-          HasOptedOutOfEmail: true,
+          Unsubscribed_from_email_contact__c: true,// eslint-disable-line camelcase
         });
       }
     }

--- a/website/api/controllers/unsubscribe-from-marketing-emails.js
+++ b/website/api/controllers/unsubscribe-from-marketing-emails.js
@@ -43,34 +43,34 @@ module.exports = {
       stageFiveNurtureEmailSentAt: 1,
     });
 
-    // FUTURE: update the users contact record in salesforce to indicate that they do not want to receive automated marketing emails. (If we update the stage, it might be changed by an action the user takes on the website)
-    // if(sails.config.environment === 'production'){
-    //   require('assert')(sails.config.custom.salesforceIntegrationUsername);
-    //   require('assert')(sails.config.custom.salesforceIntegrationPasskey);
+    // Update the contact record in salesforce for this email address to indicate that they have opted out of marketing emails.
+    if(sails.config.environment === 'production'){
+      require('assert')(sails.config.custom.salesforceIntegrationUsername);
+      require('assert')(sails.config.custom.salesforceIntegrationPasskey);
 
-    //   // Log in to Salesforce.
-    //   let jsforce = require('jsforce');
-    //   let salesforceConnection = new jsforce.Connection({
-    //     loginUrl : 'https://fleetdm.my.salesforce.com'
-    //   });
-    //   await salesforceConnection.login(sails.config.custom.salesforceIntegrationUsername, sails.config.custom.salesforceIntegrationPasskey);
+      // Log in to Salesforce.
+      let jsforce = require('jsforce');
+      let salesforceConnection = new jsforce.Connection({
+        loginUrl : 'https://fleetdm.my.salesforce.com'
+      });
+      await salesforceConnection.login(sails.config.custom.salesforceIntegrationUsername, sails.config.custom.salesforceIntegrationPasskey);
 
-    //   let existingContactRecord = await salesforceConnection.sobject('Contact')
-    //   .findOne({
-    //     Email:  emailAddress,
-    //   });
+      let existingContactRecord = await salesforceConnection.sobject('Contact')
+      .findOne({
+        Email:  emailAddress,
+      });
 
-    //   if(existingContactRecord) {
-    //     //If we found an existing contact record in salesforce, update its status to be "Do not contact"
-    //     let salesforceContactId = existingContactRecord.Id;
-    //     await salesforceConnection.sobject('Contact')
-    //     .update({
-    //       Id: salesforceContactId,
-    //       Stage__c: 'Do not contact',// eslint-disable-line camelcase
-    //     });
-    //   }
-    // }
-    // All done.
+      if(existingContactRecord) {
+        //If we found an existing contact record in salesforce, update its status to be "Do not contact"
+        let salesforceContactId = existingContactRecord.Id;
+        await salesforceConnection.sobject('Contact')
+        .update({
+          Id: salesforceContactId,
+          HasOptedOutOfEmail: true,
+        });
+      }
+    }
+    // Redirect the user to the homepage with a #unsubscribe hash link.
     return this.res.redirect('/#unsubscribed');
 
   }

--- a/website/api/controllers/unsubscribe-from-marketing-emails.js
+++ b/website/api/controllers/unsubscribe-from-marketing-emails.js
@@ -71,7 +71,7 @@ module.exports = {
     //   }
     // }
     // All done.
-    return this.res.redirect('/?showUnsubscribeMessage');
+    return this.res.redirect('/#unsubscribed');
 
   }
 

--- a/website/api/models/User.js
+++ b/website/api/models/User.js
@@ -248,17 +248,17 @@ without necessarily having a billing card.`
 
     stageThreeNurtureEmailSentAt: {
       type: 'number',
-      description: 'A JS timestamp of when the stage 3 nurture email was sent to the user.'
+      description: 'A JS timestamp of when the stage 3 nurture email was sent to the user, or 1 if the user is unsubscribed from automated emails.',
     },
 
     stageFourNurtureEmailSentAt: {
       type: 'number',
-      description: 'A JS timestamp of when the stage 4 nurture email was sent to the user.'
+      description: 'A JS timestamp of when the stage 4 nurture email was sent to the user, or 1 if the user is unsubscribed from automated emails.',
     },
 
     stageFiveNurtureEmailSentAt: {
       type: 'number',
-      description: 'A JS timestamp of when the stage 5 nurture email was sent to the user.'
+      description: 'A JS timestamp of when the stage 5 nurture email was sent to the user, or 1 if the user is unsubscribed from automated emails.',
     },
 
     //  ╔═╗╔╦╗╔╗ ╔═╗╔╦╗╔═╗

--- a/website/api/models/User.js
+++ b/website/api/models/User.js
@@ -261,12 +261,6 @@ without necessarily having a billing card.`
       description: 'A JS timestamp of when the stage 5 nurture email was sent to the user.'
     },
 
-    subscribedToNurtureEmails: {
-      type: 'boolean',
-      description: 'Wheter or not this user will be sent marketing/nurture emails.',
-      defaultsTo: true,
-    },
-
     //  ╔═╗╔╦╗╔╗ ╔═╗╔╦╗╔═╗
     //  ║╣ ║║║╠╩╗║╣  ║║╚═╗
     //  ╚═╝╩ ╩╚═╝╚═╝═╩╝╚═╝

--- a/website/api/models/User.js
+++ b/website/api/models/User.js
@@ -261,6 +261,11 @@ without necessarily having a billing card.`
       description: 'A JS timestamp of when the stage 5 nurture email was sent to the user.'
     },
 
+    subscribedToNurtureEmails: {
+      type: 'boolean',
+      description: 'Wheter or not this user will be sent marketing/nurture emails.',
+      defaultsTo: true,
+    },
 
     //  ╔═╗╔╦╗╔╗ ╔═╗╔╦╗╔═╗
     //  ║╣ ║║║╠╩╗║╣  ║║╚═╗

--- a/website/assets/js/pages/homepage.page.js
+++ b/website/assets/js/pages/homepage.page.js
@@ -12,6 +12,10 @@ parasails.registerPage('homepage', {
   //  ╩═╝╩╚  ╚═╝╚═╝ ╩ ╚═╝╩═╝╚═╝
   beforeMount: function() {
     //…
+    if(window.location.hash === '#unsubscribed'){
+      this.modal = 'unsubscribed';
+      window.location.hash = '';
+    }
   },
   mounted: async function() {
     //…

--- a/website/config/routes.js
+++ b/website/config/routes.js
@@ -480,7 +480,7 @@ module.exports.routes = {
   'GET /get-started':            '/try-fleet',
   'GET /g':                       (req,res)=> { let originalQueryStringWithAmp = req.url.match(/\?(.+)$/) ? '&'+req.url.match(/\?(.+)$/)[1] : ''; return res.redirect(301, sails.config.custom.baseUrl+'/?meet-fleet'+originalQueryStringWithAmp); },
   'GET /test-fleet-sandbox':     '/register',
-  'GET /unsubscribe':             (req,res)=> { let originalQueryString = req.url.match(/\?(.+)$/) ? req.url.match(/\?(.+)$/)[1] : ''; return res.redirect(301, sails.config.custom.baseUrl+'/api/v1/unsubscribe-from-all-newsletters?'+originalQueryString);},
+  'GET /unsubscribe':             (req,res)=> { let originalQueryString = req.url.match(/\?(.+)$/) ? req.url.match(/\?(.+)$/)[1] : ''; return res.redirect(301, sails.config.custom.baseUrl+'/api/v1/unsubscribe-from-marketing-emails?'+originalQueryString);},
   'GET /tables':                 '/tables/account_policy_data',
   'GET /imagine/launch-party':  'https://www.eventbrite.com/e/601763519887',
   'GET /blackhat2023':   'https://github.com/fleetdm/fleet/tree/main/tools/blackhat-mdm', // Assets from @marcosd4h & @zwass Black Hat 2023 talk
@@ -605,4 +605,5 @@ module.exports.routes = {
   'POST /api/v1/save-questionnaire-progress': { action: 'save-questionnaire-progress' },
   'POST /api/v1/account/update-start-cta-visibility': { action: 'account/update-start-cta-visibility' },
   'POST /api/v1/deliver-deal-registration-submission': { action: 'deliver-deal-registration-submission' },
+  '/api/v1/unsubscribe-from-marketing-emails': { action: 'unsubscribe-from-marketing-emails' },
 };

--- a/website/scripts/deliver-nurture-emails.js
+++ b/website/scripts/deliver-nurture-emails.js
@@ -19,7 +19,6 @@ module.exports = {
     // Find user records that are over an hour old that were created after July 22nd.
     let usersWithMdmBuyingSituation = await User.find({
       primaryBuyingSituation: 'mdm',
-      subscribedToNurtureEmails: true,
       createdAt: {
         '>=': nurtureCampaignStartedAt,
         '<=': oneHourAgoAt,

--- a/website/scripts/deliver-nurture-emails.js
+++ b/website/scripts/deliver-nurture-emails.js
@@ -52,7 +52,8 @@ module.exports = {
           template: 'email-nurture-stage-three',
           layout: 'layout-nurture-email',
           templateData: {
-            firstName: user.firstName
+            firstName: user.firstName,
+            emailAddress: user.emailAddress
           },
           to: user.emailAddress,
           toName: `${user.firstName} ${user.lastName}`,
@@ -80,7 +81,8 @@ module.exports = {
           template: 'email-nurture-stage-four',
           layout: 'layout-nurture-email',
           templateData: {
-            firstName: user.firstName
+            firstName: user.firstName,
+            emailAddress: user.emailAddress
           },
           to: user.emailAddress,
           toName: `${user.firstName} ${user.lastName}`,
@@ -109,7 +111,8 @@ module.exports = {
           template: 'email-nurture-stage-five',
           layout: 'layout-nurture-email',
           templateData: {
-            firstName: user.firstName
+            firstName: user.firstName,
+            emailAddress: user.emailAddress
           },
           to: user.emailAddress,
           toName: `${user.firstName} ${user.lastName}`,

--- a/website/scripts/deliver-nurture-emails.js
+++ b/website/scripts/deliver-nurture-emails.js
@@ -19,6 +19,7 @@ module.exports = {
     // Find user records that are over an hour old that were created after July 22nd.
     let usersWithMdmBuyingSituation = await User.find({
       primaryBuyingSituation: 'mdm',
+      subscribedToNurtureEmails: true,
       createdAt: {
         '>=': nurtureCampaignStartedAt,
         '<=': oneHourAgoAt,

--- a/website/views/layouts/layout-nurture-email.ejs
+++ b/website/views/layouts/layout-nurture-email.ejs
@@ -18,6 +18,6 @@
         <p>© <%= (new Date()).getFullYear() %> Fleet Inc.<br> All trademarks are the property of their respective owners.</p>
       </div>
     </div>
-    <a href="<%= url.resolve(sails.config.custom.baseUrl, '/unsubscribe?emailAddress='+encodeURIComponent(emailAddress)) %>">Unsubscribe</a></p>
+    <a style="font-size: 12px; color: #3E4771;" href="<%= url.resolve(sails.config.custom.baseUrl, '/unsubscribe?emailAddress='+encodeURIComponent(emailAddress)) %>">Unsubscribe</a></p>
   </div>
 </div>

--- a/website/views/layouts/layout-nurture-email.ejs
+++ b/website/views/layouts/layout-nurture-email.ejs
@@ -18,5 +18,6 @@
         <p>© <%= (new Date()).getFullYear() %> Fleet Inc.<br> All trademarks are the property of their respective owners.</p>
       </div>
     </div>
+    <a href="<%= url.resolve(sails.config.custom.baseUrl, '/unsubscribe?emailAddress='+encodeURIComponent(emailAddress)) %>">Unsubscribe</a></p>
   </div>
 </div>

--- a/website/views/layouts/layout-nurture-email.ejs
+++ b/website/views/layouts/layout-nurture-email.ejs
@@ -18,6 +18,6 @@
         <p>© <%= (new Date()).getFullYear() %> Fleet Inc.<br> All trademarks are the property of their respective owners.</p>
       </div>
     </div>
-    <a style="font-size: 12px; color: #3E4771;" href="<%= url.resolve(sails.config.custom.baseUrl, '/unsubscribe?emailAddress='+encodeURIComponent(emailAddress)) %>">Unsubscribe</a></p>
+    <a style="font-size: 12px; color: #3E4771;" href="<%= url.resolve(sails.config.custom.baseUrl, '/unsubscribe?emailAddress='+encodeURIComponent(emailAddress)) %>">Unsubscribe</a>
   </div>
 </div>

--- a/website/views/pages/homepage.ejs
+++ b/website/views/pages/homepage.ejs
@@ -384,6 +384,9 @@
   </div>
   <%/* Cloud city banner */%>
   <parallax-city></parallax-city>
+  <modal v-if="modal === 'unsubscribed'" @close="closeModal()">
+    <p class="mb-0">Your email preferences have been updated.</p>
+  </modal>
   <modal purpose="video-modal" v-if="modal === 'austin-anderson'" @close="closeModal()">
     <iframe width="560" height="315" src="https://www.youtube.com/embed/G5Ry_vQPaYc?si=vv0AfRe30yssWWRM&amp;rel=0" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
   </modal>


### PR DESCRIPTION
Closes: https://github.com/fleetdm/confidential/issues/7528

Changes:
- Added a new action: unsubscribe-from-marketing-emails, which updates a user record that uses a specified email address to exclude it from the deliver-nurture-emails script.
- Updated the email template to include a link that users can click to unsubscribe.
- Added a modal to the homepage that is shown to users who unsubscribe from marketing emails
- Updated the email template data in deliver-nurture-emails and view-email-template-preview