### PR TITLE
Update tutorials-and-guides.md

### DIFF
--- a/docs/Get started/tutorials-and-guides.md
+++ b/docs/Get started/tutorials-and-guides.md
@@ -1,71 +1,27 @@
 # Tutorials and guides
 
-A collection of guides to help you get up and running with Fleet.
+A collection of guides to help you with Fleet.
 
-## Deployment guides
-
-- [Deploy Fleet on Render](http://fleetdm.com/deploy/deploying-fleet-on-render)
-
-- [Deploy Fleet on AWS](http://fleetdm.com/deploy/deploying-fleet-on-aws-with-terraform)
-
-- [Deploy Fleet on Hetzner Cloud](http://fleetdm.com/deploy/deploy-fleet-on-hetzner-cloud)
-
-- [Deploy Fleet on AWS ECS](https://fleetdm.com/docs/deploy/deploy-fleet-on-aws-ecs)
-
-- [Deploy Fleet on CentOS](https://fleetdm.com/docs/deploy/deploy-fleet-on-centos)
-
-- [Deploy Fleet on Cloud.gov](https://fleetdm.com/docs/deploy/cloudgov)
-
-- [Deploy Fleet on Kubernetes](https://fleetdm.com/docs/deploy/deploy-fleet-on-kubernetes)
-
-## How-to guides
-
-- [Querying process_file_events on CentOS 7](https://fleetdm.com/guides/querying-process-file-events-table-on-centos-7)
-
-- [Using GitHub Actions to apply configuration profiles with Fleet](https://fleetdm.com/guides/using-github-actions-to-apply-configuration-profiles-with-fleet)
-
-- [Building an effective dashboard with Fleet's REST API, Flask, and Plotly: A step-by-step guide](https://fleetdm.com/guides/building-an-effective-dashboard-with-fleet-rest-api-flask-and-plotly)
-
-- [Discovering Geacon using Fleet](https://fleetdm.com/guides/discovering-geacon-using-fleet)
-
-- [Using Fleet and Okta Workflows to generate a daily OS report](https://fleetdm.com/guides/using-fleet-and-okta-workflows-to-generate-a-daily-os-report)
-
-- [Using Fleet and Tines together](https://fleetdm.com/guides/using-fleet-and-tines-together)
-
-- [How to use Fleet for zero trust attestation](https://fleetdm.com/guides/zero-trust-attestation-with-fleet)
-
-- [How to use osquery evented tables](https://fleetdm.com/guides/osquery-evented-tables-overview)
-
-- [Enrolling a DigitalOcean Droplet on a Fleet instance](https://fleetdm.com/guides/enrolling-a-digital-ocean-droplet-on-a-fleet-instance)
-
-- [Osquery: a tool to easily ask questions about operating systems](https://fleetdm.com/guides/osquery-a-tool-to-easily-ask-questions-about-operating-systems)
-
-- [How to install osquery and enroll Linux devices into Fleet](https://fleetdm.com/guides/how-to-install-osquery-and-enroll-linux-devices-into-fleet)
-
-- [How to install osquery and enroll Windows devices into Fleet](https://fleetdm.com/guides/how-to-install-osquery-and-enroll-windows-devices-into-fleet)
-
-- [Delivering data to Snowflake from Fleet and osquery.](https://fleetdm.com/guides/delivering-data-to-snowflake-from-fleet-and-osquery)
-
-- [How to install osquery and enroll macOS devices into Fleet](https://fleetdm.com/guides/how-to-install-osquery-and-enroll-macos-devices-into-fleet)
-
-- [How to uninstall osquery](https://fleetdm.com/guides/how-to-uninstall-osquery)
-
-- [Converting unix timestamps with osquery](https://fleetdm.com/guides/converting-unix-timestamps-with-osquery)
-
-- [Correlate network connections with community ID in osquery.](https://fleetdm.com/guides/correlate-network-connections-with-community-id-in-osquery)
-
-- [Using Elasticsearch and Kibana to visualize osquery performance](https://fleetdm.com/guides/using-elasticsearch-and-kibana-to-visualize-osquery-performance)
-
-- [Fleet quick tips — identify systems where the ProcDump EULA has been accepted](https://fleetdm.com/guides/fleet-quick-tips-querying-procdump-eula-has-been-accepted)
-
-- [Locate device assets in the event of an emergency.](https://fleetdm.com/guides/locate-assets-with-osquery)
-
-- [Osquery: Consider joining against the users table](https://fleetdm.com/guides/osquery-consider-joining-against-the-users-table)
-
-- [Import and export queries in Fleet](https://fleetdm.com/guides/import-and-export-queries-in-fleet)
-
-- [Generate process trees with osquery](https://fleetdm.com/guides/generate-process-trees-with-osquery)
-
+- [How to install osquery and enroll macOS devices into Fleet](https://fleetdm.com/guides/how-to-install-osquery-and-enroll-macos-devices-into-fleet)  
+- [How to install osquery and enroll Linux devices into Fleet](https://fleetdm.com/guides/how-to-install-osquery-and-enroll-linux-devices-into-fleet)  
+- [How to install osquery and enroll Windows devices into Fleet](https://fleetdm.com/guides/how-to-install-osquery-and-enroll-windows-devices-into-fleet)  
+- [Sysadmin diaries: restoring fleetd](https://fleetdm.com/guides/sysadmin-diaries-restoring-fleetd)  
+- [How to uninstall osquery](https://fleetdm.com/guides/how-to-uninstall-osquery)  
+- [Sysadmin diaries: device enrollment](https://fleetdm.com/guides/sysadmin-diaries-device-enrollment)  
+- [Sysadmin diaries: passcode profiles](https://fleetdm.com/guides/sysadmin-diaries-passcode-profiles)  
+- [Sysadmin diaries: lost device](https://fleetdm.com/guides/sysadmin-diaries-lost-device)  
+- [Windows MDM setup](https://fleetdm.com/guides/windows-mdm-setup)  
+- [Using GitHub Actions to apply configuration profiles with Fleet](https://fleetdm.com/guides/using-github-actions-to-apply-configuration-profiles-with-fleet)  
+- [Managing labels in Fleet](https://fleetdm.com/guides/managing-labels-in-fleet)  
+- [What are Fleet policies?](https://fleetdm.com/securing/what-are-fleet-policies)  
+- [Understanding the intricacies of Fleet policies](https://fleetdm.com/guides/understanding-the-intricacies-of-fleet-policies)  
+- [Sysadmin diaries: exporting policies](https://fleetdm.com/guides/sysadmin-diaries-exporting-policies)  
+- [Locate device assets in the event of an emergency](https://fleetdm.com/guides/locate-assets-with-osquery)  
+- [Osquery: Consider joining against the users table](https://fleetdm.com/guides/osquery-consider-joining-against-the-users-table)  
+- [Using Fleet and Okta Workflows to generate a daily OS report](https://fleetdm.com/guides/using-fleet-and-okta-workflows-to-generate-a-daily-os-report)  
+- [How to configure logging destinations](https://fleetdm.com/guides/how-to-configure-logging-destinations)  
+- [Import and export queries in Fleet](https://fleetdm.com/guides/import-and-export-queries-in-fleet)  
+- [Certificates in fleetd](https://fleetdm.com/guides/certificates-in-fleetd)
 
 <a style="text-decoration: none;" href="https://fleetdm.com/guides"><animated-arrow-button>See all guides</animated-arrow-button></a>
 


### PR DESCRIPTION
I have updated the list of tutorials and guides in the docs.

Although the brief stated the cut down the list to only the top 10, @nonpunctual and I whittled the list down to curate the top 20 guides that we believe are relevant to users who are deploying and setting up Fleet. We listed them in order of operation as much as possible.

Closes https://github.com/fleetdm/confidential/issues/7343