### PR TITLE
Update ABM hosts tooltip to clarify when host vitals will be available

### DIFF
--- a/changes/21065-update-host-tooltip-copy
+++ b/changes/21065-update-host-tooltip-copy
@@ -1,0 +1,2 @@
+- update ABM (Apple business manageer) host tooltip copy on the manage host page to clarify when
+  host vitals will be available to view.

--- a/frontend/pages/hosts/ManageHostsPage/HostTableConfig.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/HostTableConfig.tsx
@@ -148,9 +148,8 @@ const allHostTableHeaders: IHostTableColumnConfig[] = [
               <span className={`tooltip__tooltip-text`}>
                 This host was ordered using <br />
                 Apple Business Manager <br />
-                (ABM). You can&apos;t see host <br />
-                vitals until it&apos;s unboxed and <br />
-                automatically enrolls to Fleet.
+                (ABM). You will see host <br />
+                vitals when it is enrolled in Fleet <br />
               </span>
             </ReactTooltip>
           </>


### PR DESCRIPTION
relates to #21065

This updates the tooltip on ABM hosts on the manage host page to clarify that the host vitals will be available on enrollment, not on unboxing.


- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
- [x] Manual QA for all new/changed functionality
