### PR TITLE
For R.C. - Fleet UI: Updates to installed software tooltips #21084

### DIFF
--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwarePackageCard/SoftwarePackageCard.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwarePackageCard/SoftwarePackageCard.tsx
@@ -76,7 +76,7 @@ const SoftwareName = ({ name }: ISoftwareNameProps) => {
 interface IStatusDisplayOption {
   displayName: string;
   iconName: "success" | "pending-outline" | "error";
-  tooltip: string;
+  tooltip: React.ReactNode;
 }
 
 const STATUS_DISPLAY_OPTIONS: Record<
@@ -86,7 +86,12 @@ const STATUS_DISPLAY_OPTIONS: Record<
   installed: {
     displayName: "Installed",
     iconName: "success",
-    tooltip: "Fleet installed software on these hosts.",
+    tooltip: (
+      <>
+        Fleet installed software on these hosts. Currently, if the software is
+        uninstalled, the &quot;Installed&quot; status won&apos;t be updated.
+      </>
+    ),
   },
   pending: {
     displayName: "Pending",

--- a/frontend/pages/hosts/details/cards/Software/InstallStatusCell/InstallStatusCell.tsx
+++ b/frontend/pages/hosts/details/cards/Software/InstallStatusCell/InstallStatusCell.tsx
@@ -38,8 +38,9 @@ export const INSTALL_STATUS_DISPLAY_OPTIONS: Record<
     displayText: "Installed",
     tooltip: ({ lastInstalledAt: lastInstall }) => (
       <>
-        Fleet installed software on these hosts. (
-        {dateAgo(lastInstall as string)})
+        Fleet installed software on this host {dateAgo(lastInstall as string)}).
+        Currently, if the software is uninstalled, the &quot;Installed&quot;
+        status won&apos;t be updated.
       </>
     ),
   },

--- a/frontend/pages/hosts/details/cards/Software/SelfService/SelfServiceItem/SelfServiceItem.tsx
+++ b/frontend/pages/hosts/details/cards/Software/SelfService/SelfServiceItem/SelfServiceItem.tsx
@@ -27,6 +27,8 @@ const STATUS_CONFIG: Record<SoftwareInstallStatus, IStatusDisplayConfig> = {
     tooltip: ({ lastInstalledAt }) => (
       <>
         Software installed successfully ({dateAgo(lastInstalledAt as string)}).
+        Currently, if the software is uninstalled, the &quot;Installed&quot;
+        status won&apos;t be updated.
       </>
     ),
   },


### PR DESCRIPTION
> [!NOTE]
> This PR already merged in `main`, see https://github.com/fleetdm/fleet/pull/21084 This is against the release branch so it can be included in 4.55.0


```
 1014  git checkout fleetdm/minor-fleet-v4.55.0
 1015  git log main
 1016  git cherry-pick d8af8c638b88a65fa6155f67bcd7da4b0d857226
 1017  git status
 1018  git cherry-pick --continue
 1019  git checkout -b installed-tooltip-update-rc
 1020  git push -u fleetdm installed-tooltip-update-rc
```