### PR TITLE
Ensure empty gitops AdamIDs return an error to the user

### DIFF
--- a/cmd/fleetctl/gitops_test.go
+++ b/cmd/fleetctl/gitops_test.go
@@ -1310,6 +1310,7 @@ func TestTeamVPPAppsGitOps(t *testing.T) {
 		{"testdata/gitops/team_vpp_valid_empty.yml", "", time.Now().Add(-24 * time.Hour)},
 		{"testdata/gitops/team_vpp_valid_app.yml", "VPP token expired", time.Now().Add(-24 * time.Hour)},
 		{"testdata/gitops/team_vpp_invalid_app.yml", "app not available on vpp account", time.Now().Add(24 * time.Hour)},
+		{"testdata/gitops/team_vpp_empty_adamid.yml", "software app store id required", time.Now().Add(24 * time.Hour)},
 	}
 
 	for _, c := range cases {

--- a/cmd/fleetctl/testdata/gitops/team_vpp_empty_adamid.yml
+++ b/cmd/fleetctl/testdata/gitops/team_vpp_empty_adamid.yml
@@ -1,0 +1,17 @@
+name: "${TEST_TEAM_NAME}"
+team_settings:
+  secrets:
+    - secret: "ABC"
+  features:
+    enable_host_users: true
+    enable_software_inventory: true
+  host_expiry_settings:
+    host_expiry_enabled: true
+    host_expiry_window: 30
+agent_options:
+controls:
+policies:
+queries:
+software:
+  app_store_apps:
+    - app_store_id:


### PR DESCRIPTION
Covers a case brought up in a question in #20875

This covers a case that was already handled by code, but not tested

- [x] Added/updated tests