### PR TITLE
Website integrations page update

### DIFF
--- a/website/views/pages/integrations.ejs
+++ b/website/views/pages/integrations.ejs
@@ -15,7 +15,7 @@
         </div>
         <div purpose="integration-card-body" class="card-body">
           <p>
-            Know who opened your computer before you let them log into anything.
+            Enable single sign-on (SSO) by configuring Fleet as an Okta SAML application.
           </p>
           <div purpose="integration-card-buttons" class="d-flex flex-row justify-content-between">
             <a purpose="learn-more-link" target="_blank" href="https://www.okta.com/">Learn more</a>
@@ -29,7 +29,7 @@
         </div>
         <div purpose="integration-card-body" class="card-body">
           <p>
-            Ingest osquery data and monitor for important changes or events.
+            Import Fleet data to Chronicle.
           </p>
           <div purpose="integration-card-buttons" class="d-flex flex-row justify-content-between">
             <a purpose="learn-more-link" target="_blank"  href="https://www.snowflake.com/">Learn more</a>
@@ -73,11 +73,10 @@
         </div>
         <div purpose="integration-card-body" class="card-body">
           <p>
-            Know who opened your computer before you let them log into anything.
+            Integrate with a legacy on-prem identity server.
           </p>
           <div purpose="integration-card-buttons" class="d-flex flex-row justify-content-between">
             <a purpose="learn-more-link" target="_blank" href="https://learn.microsoft.com/en-us/azure/active-directory/fundamentals/whatis">Learn more</a>
-            <animated-arrow-button class="py-0" href="/docs/deploy/single-sign-on-sso#other-idps">Docs</animated-arrow-button>
           </div>
         </div>
       </div>
@@ -88,11 +87,11 @@
         </div>
         <div purpose="integration-card-body" class="card-body">
           <p>
-            Deploy Fleet in Ansible.
+            Deploy Fleet with Ansible.
           </p>
           <div purpose="integration-card-buttons" class="d-flex flex-row justify-content-between">
-            <a purpose="learn-more-link" target="_blank" href="https://ansible.com">Learn more</a>
-            <animated-arrow-button class="py-0" target="_blank"  href="https://github.com/CptOfEvilMinions/FleetDM-Automation">Docs</animated-arrow-button>
+            <a purpose="learn-more-link" target="_blank" href="">Learn more</a>
+            <animated-arrow-button class="py-0" href="https://github.com/CptOfEvilMinions/FleetDM-Automation">Guide</animated-arrow-button>
           </div>
         </div>
       </div>
@@ -103,11 +102,11 @@
         </div>
         <div purpose="integration-card-body" class="card-body">
           <p>
-            Deploy your own self-managed Fleet in any AWS environment in minutes.
+            Deploy your own self-managed Fleet server on AWS.
           </p>
           <div purpose="integration-card-buttons" class="d-flex flex-row justify-content-between">
             <a purpose="learn-more-link" target="_blank" href="https://aws.amazon.com/">Learn more</a>
-            <animated-arrow-button class="py-0" href="/docs/deploy/deploy-on-aws-with-terraform">Get started</animated-arrow-button>
+            <animated-arrow-button class="py-0" href="/docs/deploy/deploy-fleet#aws">Get started</animated-arrow-button>
           </div>
         </div>
       </div>
@@ -117,11 +116,11 @@
         </div>
         <div purpose="integration-card-body" class="card-body">
           <p>
-            Deploy your own self-managed Fleet in the Microsoft Cloud.
+            Deploy your own self-managed Fleet server on Azure.
           </p>
           <div purpose="integration-card-buttons" class="d-flex flex-row justify-content-between">
             <a purpose="learn-more-link" target="_blank" href="https://azure.microsoft.com/en-us">Learn more</a>
-            <animated-arrow-button class="py-0" href="/docs/deploy/reference-architectures#azure">Docs</animated-arrow-button>
+            <animated-arrow-button class="py-0" href="https://chat.osquery.io/c/fleet">Community support</animated-arrow-button>
           </div>
         </div>
       </div>
@@ -132,11 +131,10 @@
         </div>
         <div purpose="integration-card-body" class="card-body">
           <p>
-            Easily issue MDM commands and standardize data across operating systems.
+            Chef is an automation tool that can be used with Fleet.
           </p>
           <div purpose="integration-card-buttons" class="d-flex flex-row justify-content-between">
             <a purpose="learn-more-link" target="_blank" href="https://www.chef.io/products/chef-infra">Learn more</a>
-            <animated-arrow-button class="py-0" target="_blank"  href="https://docs.chef.io/chef_overview/">Docs</animated-arrow-button>
           </div>
         </div>
       </div>
@@ -147,7 +145,7 @@
         </div>
         <div purpose="integration-card-body" class="card-body">
           <p>
-            Ingest osquery data and monitor for important changes or events.
+            Import Fleet data to Snowflake.
           </p>
           <div purpose="integration-card-buttons" class="d-flex flex-row justify-content-between">
             <a purpose="learn-more-link" target="_blank" href="https://www.elastic.co/">Learn more</a>
@@ -189,7 +187,7 @@
         </div>
         <div purpose="integration-card-body" class="card-body">
           <p>
-            Ingest osquery data and monitor for important changes or events.
+            Import Fleet data to Elastic.
           </p>
           <div purpose="integration-card-buttons" class="d-flex flex-row justify-content-between">
             <a purpose="learn-more-link" target="_blank" href="https://chronicle.security/">Learn more</a>
@@ -203,11 +201,11 @@
         </div>
         <div purpose="integration-card-body" class="card-body">
           <p>
-            Deploy your own self-managed Fleet in any GCP environment.
+            Deploy your own self-managed Fleet server on Google Cloud Platform (GCP).
           </p>
           <div purpose="integration-card-buttons" class="d-flex flex-row justify-content-between">
             <a purpose="learn-more-link" target="_blank" href="https://console.cloud.google.com/getting-started">Learn more</a>
-            <animated-arrow-button class="py-0" href="/docs/deploy/reference-architectures#gcp">Get started</animated-arrow-button>
+            <animated-arrow-button class="py-0" href="https://chat.osquery.io/c/fleet">Community support</animated-arrow-button>
           </div>
         </div>
       </div>
@@ -231,7 +229,7 @@
         </div>
         <div purpose="integration-card-body" class="card-body">
           <p>
-            Easily issue MDM commands and standardize data across operating systems.
+            Deploy software with Fleet and Munki.
           </p>
           <div purpose="integration-card-buttons" class="d-flex flex-row justify-content-between">
             <a purpose="learn-more-link" target="_blank" href="https://github.com/munki/munki">Learn more</a>
@@ -245,7 +243,7 @@
         </div>
         <div purpose="integration-card-body" class="card-body">
           <p>
-            Easily issue MDM commands and standardize data across operating systems.
+            Deploy configuration profiles and issue MDM commands with Fleet and Puppet.
           </p>
           <div purpose="integration-card-buttons" class="d-flex flex-row justify-content-between">
             <a purpose="learn-more-link" target="_blank" href="https://puppet.com/">Learn more</a>
@@ -260,7 +258,7 @@
         </div>
         <div purpose="integration-card-body" class="card-body">
           <p>
-            Ingest osquery data and monitor for important changes or events.
+            Import Fleet data to Splunk.
           </p>
           <div purpose="integration-card-buttons" class="d-flex flex-row justify-content-between">
             <a purpose="learn-more-link" target="_blank" href="https://www.splunk.com/">Learn more</a>

--- a/website/views/pages/integrations.ejs
+++ b/website/views/pages/integrations.ejs
@@ -91,7 +91,7 @@
           </p>
           <div purpose="integration-card-buttons" class="d-flex flex-row justify-content-between">
             <a purpose="learn-more-link" target="_blank" href="">Learn more</a>
-            <animated-arrow-button class="py-0" href="https://github.com/CptOfEvilMinions/FleetDM-Automation">Guide</animated-arrow-button>
+            <animated-arrow-button class="py-0" target="_blank" href="https://github.com/CptOfEvilMinions/FleetDM-Automation">Guide</animated-arrow-button>
           </div>
         </div>
       </div>

--- a/website/views/pages/integrations.ejs
+++ b/website/views/pages/integrations.ejs
@@ -29,7 +29,7 @@
         </div>
         <div purpose="integration-card-body" class="card-body">
           <p>
-            Import Fleet data to Chronicle.
+            Import Fleet data to Snowflake.
           </p>
           <div purpose="integration-card-buttons" class="d-flex flex-row justify-content-between">
             <a purpose="learn-more-link" target="_blank"  href="https://www.snowflake.com/">Learn more</a>
@@ -145,7 +145,7 @@
         </div>
         <div purpose="integration-card-body" class="card-body">
           <p>
-            Import Fleet data to Snowflake.
+            Import Fleet data to Elastic.
           </p>
           <div purpose="integration-card-buttons" class="d-flex flex-row justify-content-between">
             <a purpose="learn-more-link" target="_blank" href="https://www.elastic.co/">Learn more</a>
@@ -187,7 +187,7 @@
         </div>
         <div purpose="integration-card-body" class="card-body">
           <p>
-            Import Fleet data to Elastic.
+            Import Fleet data to Chronicle.
           </p>
           <div purpose="integration-card-buttons" class="d-flex flex-row justify-content-between">
             <a purpose="learn-more-link" target="_blank" href="https://chronicle.security/">Learn more</a>


### PR DESCRIPTION
Updated incorrect/outdated descriptions and links. Closes https://github.com/fleetdm/fleet/issues/17022.

- Okta
  - Updated description: Enable single sign-on (SSO) by configuring Fleet as an Okta SAML application.
- Active Directory
  - Updated description: Integrate with a legacy on-prem identity server. 
  - Removed the docs links since there is currently no official Fleet integration for this.
- Azure
  - Updated description: Deploy your own self-managed Fleet server on Azure.
  - Updated the link to point to community support since we don’t have documentation.
- Ansible
  - Updated description: Deploy Fleet with Ansible.  
- Chef
  - Updated description: Chef is an automation tool that can be used with Fleet.
  - Removed the docs link since we don’t have an integration like the Puppet module for Chef. The existing link pointed to an irrelevant Chef reference.
- Google Cloud Platform
  - Updated description: Deploy your own self-managed Fleet server on Google Cloud Platform (GCP).
  - Updated the link to point to community support since we don’t have documentation.
- AWS
  - Updated the link Link to point to the deploy docs: [/docs/deploy/deploy-fleet#aws](/docs/deploy/deploy-fleet#aws)
- Munki
  - Updated description: Deploy software with Fleet and Munki.
- Puppet
  - Updated description: Deploy configuration profiles and issue MDM commands with Fleet and Puppet.
