### PR TITLE
Fleet server now accepts arguments via stdin

### DIFF
--- a/changes/21038-pass-fleet-args-via-stdin
+++ b/changes/21038-pass-fleet-args-via-stdin
@@ -1,0 +1,1 @@
+Fleet server now accepts arguments via stdin. This is useful for passing secrets that you don't want to expose as env vars, in the command line, or in the config file.

--- a/cmd/fleet/main.go
+++ b/cmd/fleet/main.go
@@ -2,11 +2,14 @@ package main
 
 import (
 	"fmt"
+	"io"
 	"math/rand"
 	"os"
 	"time"
 
+	"github.com/briandowns/spinner"
 	"github.com/fleetdm/fleet/v4/server/config"
+	"github.com/fleetdm/fleet/v4/server/shellquote"
 	kitlog "github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	_ "github.com/go-sql-driver/mysql"
@@ -28,6 +31,35 @@ func main() {
 	rootCmd.AddCommand(createServeCmd(configManager))
 	rootCmd.AddCommand(createConfigDumpCmd(configManager))
 	rootCmd.AddCommand(createVersionCmd(configManager))
+
+	// See if the program is being piped data on stdin.
+	fi, err := os.Stdin.Stat()
+	if err != nil {
+		initFatal(err, "getting stdin stats")
+	}
+	if fi.Mode()&os.ModeNamedPipe != 0 {
+		_, _ = fmt.Fprintln(os.Stderr, "Reading additional arguments from stdin...")
+		// See charsets at https://godoc.org/github.com/briandowns/spinner#pkg-variables
+		s := spinner.New(spinner.CharSets[24], 200*time.Millisecond)
+		s.Writer = os.Stderr
+		s.Start()
+
+		data, err := io.ReadAll(os.Stdin)
+		if err != nil {
+			initFatal(err, "reading from stdin")
+		}
+
+		// Split the string into arguments like a shell would.
+		extraArgs, err := shellquote.Split(string(data))
+		if err != nil {
+			initFatal(err, "splitting arguments from stdin")
+		}
+
+		// Add the new args to the existing args
+		os.Args = append(os.Args, extraArgs...)
+
+		s.Stop()
+	}
 
 	if err := rootCmd.Execute(); err != nil {
 		initFatal(err, "running root command")

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/beevik/etree v1.3.0
 	github.com/beevik/ntp v0.3.0
 	github.com/blakesmith/ar v0.0.0-20190502131153-809d4375e1fb
-	github.com/briandowns/spinner v1.13.0
+	github.com/briandowns/spinner v1.23.1
 	github.com/cenkalti/backoff v2.2.1+incompatible
 	github.com/cenkalti/backoff/v4 v4.3.0
 	github.com/clbanning/mxj v1.8.4

--- a/go.sum
+++ b/go.sum
@@ -299,6 +299,8 @@ github.com/blakesmith/ar v0.0.0-20190502131153-809d4375e1fb h1:m935MPodAbYS46DG4
 github.com/blakesmith/ar v0.0.0-20190502131153-809d4375e1fb/go.mod h1:PkYb9DJNAwrSvRx5DYA+gUcOIgTGVMNkfSCbZM8cWpI=
 github.com/briandowns/spinner v1.13.0 h1:q/Y9LtpwtvL0CRzXrAMj0keVXqNhBYUFg6tBOUiY8ek=
 github.com/briandowns/spinner v1.13.0/go.mod h1:QOuQk7x+EaDASo80FEXwlwiA+j/PPIcX3FScO+3/ZPQ=
+github.com/briandowns/spinner v1.23.1 h1:t5fDPmScwUjozhDj4FA46p5acZWIPXYE30qW2Ptu650=
+github.com/briandowns/spinner v1.23.1/go.mod h1:LaZeM4wm2Ywy6vO571mvhQNRcWfRUnXOs0RcKV0wYKM=
 github.com/bwesterb/go-ristretto v1.2.3/go.mod h1:fUIoIZaG73pV5biE2Blr2xEzDoMj7NFEuV9ekS419A0=
 github.com/bytecodealliance/wasmtime-go v0.36.0 h1:B6thr7RMM9xQmouBtUqm1RpkJjuLS37m6nxX+iwsQSc=
 github.com/bytecodealliance/wasmtime-go v0.36.0/go.mod h1:q320gUxqyI8yB+ZqRuaJOEnGkAnHh6WtJjMaT2CW4wI=

--- a/server/shellquote/shellquote.go
+++ b/server/shellquote/shellquote.go
@@ -1,0 +1,158 @@
+// Based on https://github.com/kballard/go-shellquote
+
+package shellquote
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"unicode/utf8"
+)
+
+var (
+	UnterminatedSingleQuoteError = errors.New("unterminated single-quoted string")
+	UnterminatedDoubleQuoteError = errors.New("unterminated double-quoted string")
+	UnterminatedEscapeError      = errors.New("unterminated backslash-escape")
+)
+
+var (
+	splitChars        = " \n\t"
+	singleChar        = '\''
+	doubleChar        = '"'
+	escapeChar        = '\\'
+	doubleEscapeChars = "$`\"\n\\"
+)
+
+// Split splits a string according to /bin/sh's word-splitting rules. It
+// supports backslash-escapes, single-quotes, and double-quotes. Notably it does
+// not support the $” style of quoting. It also doesn't attempt to perform any
+// other sort of expansion, including brace expansion, shell expansion, or
+// pathname expansion.
+//
+// If the given input has an unterminated quoted string or ends in a
+// backslash-escape, one of UnterminatedSingleQuoteError,
+// UnterminatedDoubleQuoteError, or UnterminatedEscapeError is returned.
+func Split(input string) (words []string, err error) {
+	var buf bytes.Buffer
+	words = make([]string, 0)
+
+	for len(input) > 0 {
+		// skip any splitChars at the start
+		c, l := utf8.DecodeRuneInString(input)
+		if strings.ContainsRune(splitChars, c) {
+			input = input[l:]
+			continue
+		} else if c == escapeChar {
+			// Look ahead for escaped newline, so we can skip over it
+			next := input[l:]
+			if len(next) == 0 {
+				err = UnterminatedEscapeError
+				return
+			}
+			c2, l2 := utf8.DecodeRuneInString(next)
+			if c2 == '\n' {
+				input = next[l2:]
+				continue
+			}
+		}
+
+		var word string
+		word, input, err = splitWord(input, &buf)
+		if err != nil {
+			return
+		}
+		words = append(words, word)
+	}
+	return
+}
+
+func splitWord(input string, buf *bytes.Buffer) (word string, remainder string, err error) {
+	buf.Reset()
+
+raw:
+	{
+		cur := input
+		for len(cur) > 0 {
+			c, l := utf8.DecodeRuneInString(cur)
+			cur = cur[l:]
+			if c == singleChar {
+				buf.WriteString(input[0 : len(input)-len(cur)-l])
+				input = cur
+				goto single
+			} else if c == doubleChar {
+				buf.WriteString(input[0 : len(input)-len(cur)-l])
+				input = cur
+				goto double
+			} else if c == escapeChar {
+				buf.WriteString(input[0 : len(input)-len(cur)-l])
+				input = cur
+				goto escape
+			} else if strings.ContainsRune(splitChars, c) {
+				buf.WriteString(input[0 : len(input)-len(cur)-l])
+				return buf.String(), cur, nil
+			}
+		}
+		if len(input) > 0 {
+			buf.WriteString(input)
+			input = ""
+		}
+		goto done
+	}
+
+escape:
+	{
+		if len(input) == 0 {
+			return "", "", UnterminatedEscapeError
+		}
+		c, l := utf8.DecodeRuneInString(input)
+		if c == '\n' {
+			// a backslash-escaped newline is elided from the output entirely
+		} else {
+			buf.WriteString(input[:l])
+		}
+		input = input[l:]
+	}
+	goto raw
+
+single:
+	{
+		i := strings.IndexRune(input, singleChar)
+		if i == -1 {
+			return "", "", UnterminatedSingleQuoteError
+		}
+		buf.WriteString(input[0:i])
+		input = input[i+1:]
+		goto raw
+	}
+
+double:
+	{
+		cur := input
+		for len(cur) > 0 {
+			c, l := utf8.DecodeRuneInString(cur)
+			cur = cur[l:]
+			if c == doubleChar {
+				buf.WriteString(input[0 : len(input)-len(cur)-l])
+				input = cur
+				goto raw
+			} else if c == escapeChar {
+				// bash only supports certain escapes in double-quoted strings
+				c2, l2 := utf8.DecodeRuneInString(cur)
+				cur = cur[l2:]
+				if strings.ContainsRune(doubleEscapeChars, c2) {
+					buf.WriteString(input[0 : len(input)-len(cur)-l-l2])
+					if c2 == '\n' {
+						// newline is special, skip the backslash entirely
+					} else {
+						buf.WriteRune(c2)
+					}
+					input = cur
+				}
+			}
+		}
+		return "", "", UnterminatedDoubleQuoteError
+	}
+
+done:
+	return buf.String(), input, nil
+}

--- a/server/shellquote/shellquote.go
+++ b/server/shellquote/shellquote.go
@@ -105,9 +105,8 @@ escape:
 			return "", "", UnterminatedEscapeError
 		}
 		c, l := utf8.DecodeRuneInString(input)
-		if c == '\n' {
-			// a backslash-escaped newline is elided from the output entirely
-		} else {
+		// a backslash-escaped newline is elided from the output entirely
+		if c != '\n' {
 			buf.WriteString(input[:l])
 		}
 		input = input[l:]
@@ -141,9 +140,8 @@ double:
 				cur = cur[l2:]
 				if strings.ContainsRune(doubleEscapeChars, c2) {
 					buf.WriteString(input[0 : len(input)-len(cur)-l-l2])
-					if c2 == '\n' {
-						// newline is special, skip the backslash entirely
-					} else {
+					// newline is special, skip the backslash entirely
+					if c2 != '\n' {
 						buf.WriteRune(c2)
 					}
 					input = cur

--- a/server/shellquote/shellquote_test.go
+++ b/server/shellquote/shellquote_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 func TestSimpleSplit(t *testing.T) {
+	t.Parallel()
 	for _, elem := range simpleSplitTest {
 		output, err := Split(elem.input)
 		if err != nil {
@@ -20,6 +21,7 @@ func TestSimpleSplit(t *testing.T) {
 }
 
 func TestErrorSplit(t *testing.T) {
+	t.Parallel()
 	for _, elem := range errorSplitTest {
 		_, err := Split(elem.input)
 		if !errors.Is(err, elem.error) {
@@ -44,6 +46,7 @@ var simpleSplitTest = []struct {
 	{"\"quoted\\d\\\\\\\" text with\\\na backslash-escaped newline\"", []string{"quoted\\d\\\" text witha backslash-escaped newline"}},
 	{"text with an escaped \\\n newline in the middle", []string{"text", "with", "an", "escaped", "newline", "in", "the", "middle"}},
 	{"foo\"bar\"baz", []string{"foobarbaz"}},
+	{"--foo 6mI74pVBAidu1bALjY0F+wN4mPQyu8DUap/9M/kHp8I=", []string{"--foo", "6mI74pVBAidu1bALjY0F+wN4mPQyu8DUap/9M/kHp8I="}},
 }
 
 var errorSplitTest = []struct {

--- a/server/shellquote/shellquote_test.go
+++ b/server/shellquote/shellquote_test.go
@@ -1,0 +1,58 @@
+// Based on https://github.com/kballard/go-shellquote
+
+package shellquote
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+)
+
+func TestSimpleSplit(t *testing.T) {
+	for _, elem := range simpleSplitTest {
+		output, err := Split(elem.input)
+		if err != nil {
+			t.Errorf("Input %q, got error %#v", elem.input, err)
+		} else if !reflect.DeepEqual(output, elem.output) {
+			t.Errorf("Input %q, got %q, expected %q", elem.input, output, elem.output)
+		}
+	}
+}
+
+func TestErrorSplit(t *testing.T) {
+	for _, elem := range errorSplitTest {
+		_, err := Split(elem.input)
+		if !errors.Is(err, elem.error) {
+			t.Errorf("Input %q, got error %#v, expected error %#v", elem.input, err, elem.error)
+		}
+	}
+}
+
+var simpleSplitTest = []struct {
+	input  string
+	output []string
+}{
+	{"hello", []string{"hello"}},
+	{"hello goodbye", []string{"hello", "goodbye"}},
+	{"hello   goodbye", []string{"hello", "goodbye"}},
+	{"glob* test?", []string{"glob*", "test?"}},
+	{"don\\'t you know the dewey decimal system\\?", []string{"don't", "you", "know", "the", "dewey", "decimal", "system?"}},
+	{"'don'\\''t you know the dewey decimal system?'", []string{"don't you know the dewey decimal system?"}},
+	{"one '' two", []string{"one", "", "two"}},
+	{"text with\\\na backslash-escaped newline", []string{"text", "witha", "backslash-escaped", "newline"}},
+	{"text \"with\na\" quoted newline", []string{"text", "with\na", "quoted", "newline"}},
+	{"\"quoted\\d\\\\\\\" text with\\\na backslash-escaped newline\"", []string{"quoted\\d\\\" text witha backslash-escaped newline"}},
+	{"text with an escaped \\\n newline in the middle", []string{"text", "with", "an", "escaped", "newline", "in", "the", "middle"}},
+	{"foo\"bar\"baz", []string{"foobarbaz"}},
+}
+
+var errorSplitTest = []struct {
+	input string
+	error error
+}{
+	{"don't worry", UnterminatedSingleQuoteError},
+	{"'test'\\''ing", UnterminatedSingleQuoteError},
+	{"\"foo'bar", UnterminatedDoubleQuoteError},
+	{"foo\\", UnterminatedEscapeError},
+	{"   \\", UnterminatedEscapeError},
+}


### PR DESCRIPTION
#21038 
Fleet server now accepts arguments via stdin. This is useful for passing secrets that you don't want to expose as env vars, in the command line, or in the config file.

Demo: https://www.loom.com/share/c8b4dc6ae6ef4182bc812d7f43423f4d

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/Committing-Changes.md#changes-files) for more information.
- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [x] Added/updated tests
- [x] Manual QA for all new/changed functionality
