### PR TITLE
Moving Go integration tests to integration test job

### DIFF
--- a/cmd/fleetctl/gitops_enterprise_integration_test.go
+++ b/cmd/fleetctl/gitops_enterprise_integration_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/stretchr/testify/suite"
 )
 
-func TestEnterpriseIntegrationsGitops(t *testing.T) {
+func TestIntegrationsEnterpriseGitops(t *testing.T) {
 	testingSuite := new(enterpriseIntegrationGitopsTestSuite)
 	testingSuite.suite = &testingSuite.Suite
 	suite.Run(t, testingSuite)

--- a/ee/fleetctl/updates_test.go
+++ b/ee/fleetctl/updates_test.go
@@ -210,7 +210,7 @@ func compressSingleFile(t *testing.T, filePath, outFilePath string) {
 	require.NoError(t, err)
 }
 
-func TestUpdatesIntegration(t *testing.T) {
+func TestIntegrationsUpdates(t *testing.T) {
 	// Not t.Parallel() due to modifications to environment.
 	tmpDir := t.TempDir()
 

--- a/ee/server/calendar/google_calendar_integration_test.go
+++ b/ee/server/calendar/google_calendar_integration_test.go
@@ -45,7 +45,7 @@ func (s *googleCalendarIntegrationTestSuite) TearDownSuite() {
 
 // TestGoogleCalendarIntegration tests should be able to be run in parallel, but this is not natively supported by suites: https://github.com/stretchr/testify/issues/187
 // There are workarounds that can be explored.
-func TestGoogleCalendarIntegration(t *testing.T) {
+func TestIntegrationsGoogleCalendar(t *testing.T) {
 	testingSuite := new(googleCalendarIntegrationTestSuite)
 	suite.Run(t, testingSuite)
 }

--- a/orbit/pkg/useraction/mdm_migration_darwin_test.go
+++ b/orbit/pkg/useraction/mdm_migration_darwin_test.go
@@ -17,6 +17,7 @@ func (d dummyHandler) NotifyRemote() error {
 func (d dummyHandler) ShowInstructions() error { return nil }
 
 func TestWaitForUnenrollment(t *testing.T) {
+	t.Parallel()
 	m := &swiftDialogMDMMigrator{
 		handler:                   dummyHandler{},
 		baseDialog:                newBaseDialog("foo/bar"),

--- a/server/service/integration_ds_only_test.go
+++ b/server/service/integration_ds_only_test.go
@@ -15,9 +15,9 @@ type integrationDSTestSuite struct {
 	suite.Suite
 }
 
-func TestIntegrationDSTestSuite(t *testing.T) {
+func TestIntegrationsDSTestSuite(t *testing.T) {
 	testingSuite := new(integrationDSTestSuite)
-	testingSuite.s = &testingSuite.Suite
+	testingSuite.withDS.s = &testingSuite.Suite
 	suite.Run(t, testingSuite)
 }
 

--- a/server/service/integration_live_queries_test.go
+++ b/server/service/integration_live_queries_test.go
@@ -31,7 +31,7 @@ import (
 	"github.com/stretchr/testify/suite"
 )
 
-func TestIntegrationLiveQueriesTestSuite(t *testing.T) {
+func TestIntegrationsLiveQueriesTestSuite(t *testing.T) {
 	testingSuite := new(liveQueriesTestSuite)
 	testingSuite.withServer.s = &testingSuite.Suite
 	suite.Run(t, testingSuite)

--- a/server/service/integration_logger_test.go
+++ b/server/service/integration_logger_test.go
@@ -22,9 +22,9 @@ import (
 	"github.com/stretchr/testify/suite"
 )
 
-func TestIntegrationLoggerTestSuite(t *testing.T) {
+func TestIntegrationsLoggerTestSuite(t *testing.T) {
 	testingSuite := new(integrationLoggerTestSuite)
-	testingSuite.s = &testingSuite.Suite
+	testingSuite.withDS.s = &testingSuite.Suite
 	suite.Run(t, testingSuite)
 }
 

--- a/server/vulnerabilities/io/github_test.go
+++ b/server/vulnerabilities/io/github_test.go
@@ -168,7 +168,8 @@ func (m mockGHReleaseLister) ListReleases(
 	return releases, res, nil
 }
 
-func TestGithubClient(t *testing.T) {
+func TestIntegrationsGithubClient(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 
 	t.Run("MacOfficeReleaseNotes", func(t *testing.T) {

--- a/server/vulnerabilities/macoffice/integration_analyzer_test.go
+++ b/server/vulnerabilities/macoffice/integration_analyzer_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestIntegrationAnalyzer(t *testing.T) {
+func TestIntegrationsAnalyzer(t *testing.T) {
 	ds := mysql.CreateMySQLDS(t)
 	vulnPath := t.TempDir()
 	releaseNotes := macoffice.ReleaseNotes{

--- a/server/vulnerabilities/macoffice/integration_parser_test.go
+++ b/server/vulnerabilities/macoffice/integration_parser_test.go
@@ -653,7 +653,7 @@ var expected = []macoffice.ReleaseNote{
 	},
 }
 
-func TestIntegrationParseReleaseHTML(t *testing.T) {
+func TestIntegrationsParseReleaseHTML(t *testing.T) {
 	nettest.Run(t)
 
 	res, err := http.Get(macoffice.RelNotesURL)

--- a/server/vulnerabilities/macoffice/integration_sync_test.go
+++ b/server/vulnerabilities/macoffice/integration_sync_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestIntegrationSync(t *testing.T) {
+func TestIntegrationsSync(t *testing.T) {
 	nettest.Run(t)
 
 	vulnPath := t.TempDir()


### PR DESCRIPTION
#20929
Moving Go integration tests to integration test job, which runs tests that start with `TestIntegrations`
Test changes only. No product changes

