### PR TITLE
My Device status is now refreshed when user clicks on My Device or Self-Service

### DIFF
--- a/orbit/changes/20181-desktop-bubble
+++ b/orbit/changes/20181-desktop-bubble
@@ -1,0 +1,1 @@
+In Fleet Desktop, My Device status is now refreshed when user clicks on My Device or Self-Service dropdown option.


### PR DESCRIPTION
#20181 
In Fleet Desktop, My Device status is now refreshed when user clicks on My Device or Self-Service dropdown option.

Demo: https://www.loom.com/share/7c5968b8ed1a481a8ffd46e8fdac1ea4

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/Committing-Changes.md#changes-files) for more information.
- [ ] Added/updated tests
- [x] Manual QA for all new/changed functionality
- For Orbit and Fleet Desktop changes:
   - [x] Manual QA must be performed in the three main OSs, macOS, Windows and Linux.
