### PR TITLE
fix: add open paren

### DIFF
--- a/frontend/pages/hosts/details/cards/Software/InstallStatusCell/InstallStatusCell.tsx
+++ b/frontend/pages/hosts/details/cards/Software/InstallStatusCell/InstallStatusCell.tsx
@@ -38,8 +38,8 @@ export const INSTALL_STATUS_DISPLAY_OPTIONS: Record<
     displayText: "Installed",
     tooltip: ({ lastInstalledAt: lastInstall }) => (
       <>
-        Fleet installed software on this host {dateAgo(lastInstall as string)}).
-        Currently, if the software is uninstalled, the &quot;Installed&quot;
+        Fleet installed software on this host ({dateAgo(lastInstall as string)}
+        ). Currently, if the software is uninstalled, the &quot;Installed&quot;
         status won&apos;t be updated.
       </>
     ),


### PR DESCRIPTION
> No issue, just a tiny bug I noticed while testing in dogfood

Saw a missing open paren in this tooltip:

![Screenshot 2024-08-07 at 9 22 38 AM](https://github.com/user-attachments/assets/018d9387-70d9-4877-bfe5-5654c7acb5d2)


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Manual QA for all new/changed functionality
