### PR TITLE
to RC: UI – Update empty Software versions table when installable software present

### DIFF
--- a/frontend/pages/SoftwarePage/SoftwareTitles/SoftwareTable/SoftwareTable.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitles/SoftwareTable/SoftwareTable.tsx
@@ -60,6 +60,7 @@ interface ISoftwareTableProps {
   router: InjectedRouter;
   data?: ISoftwareTitlesResponse | ISoftwareVersionsResponse;
   showVersions: boolean;
+  installableSoftwareExists: boolean;
   isSoftwareEnabled: boolean;
   query: string;
   perPage: number;
@@ -78,6 +79,7 @@ const SoftwareTable = ({
   router,
   data,
   showVersions,
+  installableSoftwareExists,
   isSoftwareEnabled,
   query,
   perPage,
@@ -335,6 +337,8 @@ const SoftwareTable = ({
             softwareFilter={softwareFilter}
             isSoftwareDisabled={!isSoftwareEnabled}
             noSearchQuery={query === ""}
+            isCollectingSoftware={data?.counts_updated_at === null}
+            installableSoftwareExists={installableSoftwareExists}
           />
         )}
         defaultSortHeader={orderKey}

--- a/frontend/pages/SoftwarePage/components/EmptySoftwareTable/EmptySoftwareTable.tsx
+++ b/frontend/pages/SoftwarePage/components/EmptySoftwareTable/EmptySoftwareTable.tsx
@@ -17,6 +17,8 @@ export interface IEmptySoftwareTableProps {
   noSearchQuery?: boolean;
   /** isCollectingSoftware is only used on the Dashboard page with a TODO to revisit */
   isCollectingSoftware?: boolean;
+  /** true if the team has any software installers or VPP apps available to install on hosts */
+  installableSoftwareExists?: boolean;
 }
 
 const generateTypeText = (
@@ -38,6 +40,7 @@ const EmptySoftwareTable = ({
   isSoftwareDisabled,
   noSearchQuery,
   isCollectingSoftware,
+  installableSoftwareExists,
 }: IEmptySoftwareTableProps): JSX.Element => {
   const softwareTypeText = generateTypeText(tableName, softwareFilter);
 
@@ -50,10 +53,14 @@ const EmptySoftwareTable = ({
     emptySoftware.header = "No software detected";
   }
 
+  if (softwareFilter === "allSoftware" && installableSoftwareExists) {
+    emptySoftware.header = "No software detected";
+    emptySoftware.info = "Install software on your hosts to see versions.";
+  }
+
   if (isCollectingSoftware) {
     emptySoftware.header = "No software detected";
-    emptySoftware.info =
-      "This report is updated every hour to protect the performance of your devices.";
+    emptySoftware.info = `Expecting to see ${softwareTypeText}? Check back later.`;
   }
 
   if (isSoftwareDisabled) {

--- a/frontend/pages/hosts/details/cards/Software/HostSoftwareTableConfig.tsx
+++ b/frontend/pages/hosts/details/cards/Software/HostSoftwareTableConfig.tsx
@@ -47,7 +47,6 @@ type IInstalledVersionsCellProps = CellProps<
   IHostSoftware["installed_versions"]
 >;
 type IVulnerabilitiesCellProps = IInstalledVersionsCellProps;
-// type IActionsCellProps = CellProps<IHostSoftware, IHostSoftware["id"]>;
 
 const generateActions = ({
   userHasSWInstallPermission,

--- a/frontend/services/entities/software.ts
+++ b/frontend/services/entities/software.ts
@@ -63,7 +63,7 @@ export interface ISoftwareVersionsQueryKey extends ISoftwareApiParams {
 
 export interface ISoftwareTitlesQueryKey extends ISoftwareApiParams {
   // used to trigger software refetches from sibling pages
-  addedSoftwareToken: string | null;
+  addedSoftwareToken?: string | null;
   scope: "software-titles";
 }
 


### PR DESCRIPTION
#### This PR already merged to `main`, see https://github.com/fleetdm/fleet/pull/21118. This is against the release branch so it can be included in 4.55.0
