### PR TITLE
to RC: UI – Read "unavailable" when iPad/iPhone refetch is unsuccessful

### DIFF
--- a/frontend/interfaces/platform.ts
+++ b/frontend/interfaces/platform.ts
@@ -108,3 +108,7 @@ export const isAppleDevice = (platform: string) => {
     platform as typeof HOST_APPLE_PLATFORMS[number]
   );
 };
+
+// TODO - improve all platform types to be Platform
+export const isIPadOrIPhone = (platform: string | Platform) =>
+  ["ios", "ipados"].includes(platform);

--- a/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
@@ -53,7 +53,7 @@ import {
   HOST_OSQUERY_DATA,
 } from "utilities/constants";
 
-import { Platform } from "interfaces/platform";
+import { isIPadOrIPhone, Platform } from "interfaces/platform";
 
 import Spinner from "components/Spinner";
 import TabsWrapper from "components/TabsWrapper";
@@ -335,7 +335,11 @@ const HostDetailsPage = ({
               } else {
                 renderFlash(
                   "error",
-                  `This host is offline. Please try refetching host vitals later.`
+                  `This host is ${
+                    isIPadOrIPhone(returnedHost.platform)
+                      ? "unavailable"
+                      : "offline"
+                  }. Please try refetching host vitals later.`
                 );
                 setShowRefetchSpinner(false);
               }

--- a/frontend/pages/hosts/details/cards/Software/HostSoftware.tsx
+++ b/frontend/pages/hosts/details/cards/Software/HostSoftware.tsx
@@ -12,7 +12,7 @@ import deviceAPI, {
   IGetDeviceSoftwareResponse,
 } from "services/entities/device_user";
 import { IHostSoftware, ISoftware } from "interfaces/software";
-import { Platform } from "interfaces/platform";
+import { isIPadOrIPhone, Platform } from "interfaces/platform";
 import { DEFAULT_USE_QUERY_OPTIONS } from "utilities/constants";
 import { NotificationContext } from "context/notification";
 import { AppContext } from "context/app";
@@ -98,7 +98,7 @@ const HostSoftware = ({
 }: IHostSoftwareProps) => {
   const { renderFlash } = useContext(NotificationContext);
   const vulnFilterAndNotSupported =
-    ["ios", "ipados"].includes(platform ?? "") && queryParams.vulnerable;
+    isIPadOrIPhone(platform ?? "") && queryParams.vulnerable;
   const {
     isGlobalAdmin,
     isGlobalMaintainer,

--- a/frontend/pages/hosts/details/cards/Software/HostSoftwareTable/HostSoftwareTable.tsx
+++ b/frontend/pages/hosts/details/cards/Software/HostSoftwareTable/HostSoftwareTable.tsx
@@ -11,6 +11,7 @@ import { ISoftwareDropdownFilterVal } from "pages/SoftwarePage/SoftwareTitles/So
 import {
   ApplePlatform,
   APPLE_PLATFORM_DISPLAY_NAMES,
+  isIPadOrIPhone,
   Platform,
 } from "interfaces/platform";
 
@@ -189,8 +190,7 @@ const HostSoftwareTable = ({
 
   const memoizedEmptyComponent = useCallback(() => {
     const vulnFilterAndNotSupported =
-      ["ios", "ipados"].includes(platform) &&
-      hostSoftwareFilter === "vulnerableSoftware";
+      isIPadOrIPhone(platform) && hostSoftwareFilter === "vulnerableSoftware";
     return vulnFilterAndNotSupported ? (
       <VulnsNotSupported
         platformText={APPLE_PLATFORM_DISPLAY_NAMES[platform as ApplePlatform]}


### PR DESCRIPTION
#### This PR already merged to `main`, see https://github.com/fleetdm/fleet/pull/21120. This is against the release branch so it can be included in 4.55.0