### PR TITLE
Exclude ios_apps and ipados_apps from normal vuln processing. (#21143)

### DIFF
--- a/server/vulnerabilities/nvd/cpe.go
+++ b/server/vulnerabilities/nvd/cpe.go
@@ -443,7 +443,8 @@ func TranslateSoftwareToCPE(
 	nonOvalIterator, err := ds.AllSoftwareIterator(
 		ctx,
 		fleet.SoftwareIterQueryOptions{
-			ExcludedSources: oval.SupportedSoftwareSources,
+			// Also exclude iOS and iPadOS apps until we enable vulnerabilities support for them.
+			ExcludedSources: append(oval.SupportedSoftwareSources, "ios_apps", "ipados_apps"),
 		},
 	)
 	if err != nil {


### PR DESCRIPTION
Cherry pick of https://github.com/fleetdm/fleet/pull/21143

