### PR TITLE
Website: Update lastModifiedAt timestamps when running build-static-content script in website tests

### DIFF
--- a/docs/Get started/test-markdown-file.md
+++ b/docs/Get started/test-markdown-file.md
@@ -1,0 +1,1 @@
+Testing if adding a new file will make the test fail

--- a/docs/Get started/test-markdown-file.md
+++ b/docs/Get started/test-markdown-file.md
@@ -1,6 +1,0 @@
-Testing if adding a new file will make the test fail
-
-
-
-<meta name="description" value="test">
-<meta name="pageOrderInSection" value="390">

--- a/docs/Get started/test-markdown-file.md
+++ b/docs/Get started/test-markdown-file.md
@@ -1,1 +1,6 @@
 Testing if adding a new file will make the test fail
+
+
+
+<meta name="description" value="test">
+<meta name="pageOrderInSection" value="390">

--- a/website/scripts/build-static-content.js
+++ b/website/scripts/build-static-content.js
@@ -393,7 +393,7 @@ module.exports = {
               let lastModifiedAt;
               if(!githubAccessToken) {
                 lastModifiedAt = Date.now();
-              } else {
+              } else if(process.env.GITHUB_REF_NAME && process.env.GITHUB_REF_NAME === 'main') {// Only add lastModifiedAt timestamps if this test is running on the main branch
                 let responseData = await sails.helpers.http.get.with({// [?]: https://docs.github.com/en/rest/commits/commits?apiVersion=2022-11-28#list-commits
                   url: 'https://api.github.com/repos/fleetdm/fleet/commits',
                   data: {
@@ -406,12 +406,12 @@ module.exports = {
                   return new Error(`When getting the commit history for ${path.join(sectionRepoPath, pageRelSourcePath)} to get a lastModifiedAt timestamp, an error occured.`, err);
                 });
                 // The value we'll use for the lastModifiedAt timestamp will be date value of the `commiter` property of the `commit` we got in the API response from github.
-                let mostRecentCommitToOsquerySchema = responseData[0];
-                if(!mostRecentCommitToOsquerySchema.commit || !mostRecentCommitToOsquerySchema.commit.committer) {
+                let mostRecentCommitToThisFile = responseData[0];
+                if(!mostRecentCommitToThisFile.commit || !mostRecentCommitToThisFile.commit.committer) {
                   // Throw an error if the the response from GitHub is missing a commit or commiter.
                   throw new Error(`When getting the commit history for ${path.join(sectionRepoPath, pageRelSourcePath)} to get a lastModifiedAt timestamp, the response from the GitHub API did not include information about the most recent commit. Response from GitHub: ${util.inspect(responseData, {depth:null})}`);
                 }
-                lastModifiedAt = (new Date(mostRecentCommitToOsquerySchema.commit.committer.date)).getTime(); // Convert the UTC timestamp from GitHub to a JS timestamp.
+                lastModifiedAt = (new Date(mostRecentCommitToThisFile.commit.committer.date)).getTime(); // Convert the UTC timestamp from GitHub to a JS timestamp.
               }
 
               // Determine display title (human-readable title) to use for this page.
@@ -595,12 +595,12 @@ module.exports = {
             return new Error(`When getting the commit history for the open positions YAML to get a lastModifiedAt timestamp, an error occured.`, err);
           });
           // The value we'll use for the lastModifiedAt timestamp will be date value of the `commiter` property of the `commit` we got in the API response from github.
-          let mostRecentCommitToOsquerySchema = responseData[0];
-          if(!mostRecentCommitToOsquerySchema.commit || !mostRecentCommitToOsquerySchema.commit.committer) {
+          let mostRecentCommitToThisFile = responseData[0];
+          if(!mostRecentCommitToThisFile.commit || !mostRecentCommitToThisFile.commit.committer) {
             // Throw an error if the the response from GitHub is missing a commit or commiter.
             throw new Error(`When trying to get a lastModifiedAt timestamp for the open positions YAML, the response from the GitHub API did not include information about the most recent commit. Response from GitHub: ${util.inspect(responseData, {depth:null})}`);
           }
-          lastModifiedAt = (new Date(mostRecentCommitToOsquerySchema.commit.committer.date)).getTime(); // Convert the UTC timestamp from GitHub to a JS timestamp.
+          lastModifiedAt = (new Date(mostRecentCommitToThisFile.commit.committer.date)).getTime(); // Convert the UTC timestamp from GitHub to a JS timestamp.
         }
 
         let openPositionsYaml = await sails.helpers.fs.read(path.join(topLvlRepoPath, RELATIVE_PATH_TO_OPEN_POSITIONS_YML_IN_FLEET_REPO)).intercept('doesNotExist', (err)=>new Error(`Could not find open positions YAML file at "${RELATIVE_PATH_TO_OPEN_POSITIONS_YML_IN_FLEET_REPO}".  Was it accidentally moved?  Raw error: `+err.message));


### PR DESCRIPTION
Changes:
- Updated the build-static-content script to only get lastModifiedAt timestamps when the script is run on the `main` branch fo the Fleet repo and updated variable names.