### PR TITLE
UI – For iPad/iPhones: update refetch behavior, add `Not supported` to Host software vulnerabilites column 

### DIFF
--- a/frontend/interfaces/software.ts
+++ b/frontend/interfaces/software.ts
@@ -323,3 +323,6 @@ export const hasHostSoftwareAppLastInstall = (
 } => {
   return !!software.app_store_app?.last_install;
 };
+
+export const isIpadOrIphoneSoftwareSource = (source: string) =>
+  ["ios_apps", "ipados_apps"].includes(source);

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwareTitleDetailsPage.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwareTitleDetailsPage.tsx
@@ -12,7 +12,11 @@ import useTeamIdParam from "hooks/useTeamIdParam";
 
 import { AppContext } from "context/app";
 
-import { ISoftwareTitleDetails, formatSoftwareType } from "interfaces/software";
+import {
+  ISoftwareTitleDetails,
+  formatSoftwareType,
+  isIpadOrIphoneSoftwareSource,
+} from "interfaces/software";
 import { ignoreAxiosError } from "interfaces/errors";
 import softwareAPI, {
   ISoftwareTitleResponse,
@@ -200,7 +204,7 @@ const SoftwareTitleDetailsPage = ({
               data={softwareTitle.versions ?? []}
               isLoading={isSoftwareTitleLoading}
               teamIdForApi={teamIdForApi}
-              isIPadOSOrIOSApp={["ios_apps", "ipados_apps"].includes(
+              isIPadOSOrIOSApp={isIpadOrIphoneSoftwareSource(
                 softwareTitle.source
               )}
               isAvailableForInstall={isAvailableForInstall}

--- a/frontend/pages/SoftwarePage/SoftwareTitles/SoftwareTable/SoftwareTitlesTableConfig.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitles/SoftwareTable/SoftwareTitlesTableConfig.tsx
@@ -2,7 +2,11 @@ import React from "react";
 import { CellProps, Column } from "react-table";
 import { InjectedRouter } from "react-router";
 
-import { ISoftwareTitle, formatSoftwareType } from "interfaces/software";
+import {
+  ISoftwareTitle,
+  formatSoftwareType,
+  isIpadOrIphoneSoftwareSource,
+} from "interfaces/software";
 import PATHS from "router/paths";
 
 import { buildQueryStringFromParams } from "utilities/url";
@@ -145,9 +149,7 @@ const generateTableHeaders = (
       Header: "Vulnerabilities",
       disableSortBy: true,
       Cell: (cellProps: IVulnerabilitiesCellProps) => {
-        if (
-          ["ios_apps", "ipados_apps"].includes(cellProps.row.original.source)
-        ) {
+        if (isIpadOrIphoneSoftwareSource(cellProps.row.original.source)) {
           return <TextCell value="Not supported" grey />;
         }
         const vulnerabilities = getVulnerabilities(

--- a/frontend/pages/SoftwarePage/SoftwareTitles/SoftwareTitles.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitles/SoftwareTitles.tsx
@@ -143,7 +143,7 @@ const SoftwareTitles = ({
     [
       {
         scope: "software-titles",
-        page: 1,
+        page: 0,
         perPage,
         query: "",
         orderDirection,

--- a/frontend/pages/SoftwarePage/SoftwareVersionDetailsPage/SoftwareVersionDetailsPage.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareVersionDetailsPage/SoftwareVersionDetailsPage.tsx
@@ -18,7 +18,11 @@ import hostsCountAPI, {
   IHostsCountQueryKey,
   IHostsCountResponse,
 } from "services/entities/host_count";
-import { ISoftwareVersion, formatSoftwareType } from "interfaces/software";
+import {
+  ISoftwareVersion,
+  formatSoftwareType,
+  isIpadOrIphoneSoftwareSource,
+} from "interfaces/software";
 import { ignoreAxiosError } from "interfaces/errors";
 
 import { DEFAULT_USE_QUERY_OPTIONS } from "utilities/constants";
@@ -114,7 +118,7 @@ const SoftwareVersionDetailsPage = ({
   );
 
   const renderVulnTable = (swVersion: ISoftwareVersion) => {
-    if (["ios_apps", "ipados_apps"].includes(swVersion.source)) {
+    if (isIpadOrIphoneSoftwareSource(swVersion.source)) {
       const platformText = swVersion.source === "ios_apps" ? "iOS" : "iPadOS";
       return <VulnsNotSupported platformText={platformText} />;
     }

--- a/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
@@ -315,7 +315,10 @@ const HostDetailsPage = ({
             // If our 60 second timer wasn't already started (e.g., if a refetch was pending when
             // the first page loads), we start it now if the host is online. If the host is offline,
             // we skip the refetch on page load.
-            if (returnedHost.status === "online") {
+            if (
+              returnedHost.status === "online" ||
+              isIPadOrIPhone(returnedHost.platform)
+            ) {
               setRefetchStartTime(Date.now());
               setTimeout(() => {
                 refetchHostDetails();
@@ -325,9 +328,13 @@ const HostDetailsPage = ({
               setShowRefetchSpinner(false);
             }
           } else {
+            // !!refetchStartTime
             const totalElapsedTime = Date.now() - refetchStartTime;
             if (totalElapsedTime < 60000) {
-              if (returnedHost.status === "online") {
+              if (
+                returnedHost.status === "online" ||
+                isIPadOrIPhone(returnedHost.platform)
+              ) {
                 setTimeout(() => {
                   refetchHostDetails();
                   refetchExtensions();
@@ -335,15 +342,12 @@ const HostDetailsPage = ({
               } else {
                 renderFlash(
                   "error",
-                  `This host is ${
-                    isIPadOrIPhone(returnedHost.platform)
-                      ? "unavailable"
-                      : "offline"
-                  }. Please try refetching host vitals later.`
+                  `This host is offline. Please try refetching host vitals later.`
                 );
                 setShowRefetchSpinner(false);
               }
             } else {
+              // totalElapsedTime > 60000
               renderFlash(
                 "error",
                 `We're having trouble fetching fresh vitals for this host. Please try again later.`

--- a/frontend/pages/hosts/details/cards/Software/HostSoftwareTableConfig.tsx
+++ b/frontend/pages/hosts/details/cards/Software/HostSoftwareTableConfig.tsx
@@ -9,6 +9,7 @@ import {
   IHostSoftwarePackage,
   SoftwareInstallStatus,
   formatSoftwareType,
+  isIpadOrIphoneSoftwareSource,
 } from "interfaces/software";
 import {
   IHeaderProps,
@@ -183,6 +184,9 @@ export const generateSoftwareTableHeaders = ({
       accessor: (originalRow) => originalRow.installed_versions,
       disableSortBy: true,
       Cell: (cellProps: IVulnerabilitiesCellProps) => {
+        if (isIpadOrIphoneSoftwareSource(cellProps.row.original.source)) {
+          return <TextCell value="Not supported" grey />;
+        }
         const vulnerabilities = getVulnerabilities(cellProps.cell.value ?? []);
         return <VulnerabilitiesCell vulnerabilities={vulnerabilities} />;
       },


### PR DESCRIPTION
## Addresses #21149 and #21148 

1.  21149: Updated refetch behavior – instead of looking for a not "online" host status and short-circuiting the refetch cycle with an error, keep trying until the 60s timeout limit:
  - Couldn't refetch after 60s: ![Screenshot 2024-08-07 at 2 47 15 PM](https://github.com/user-attachments/assets/19467c43-1e19-43c3-8f89-a6b7e893ed75)
  - Successful refetch: ![Screenshot 2024-08-07 at 2 47 35 PM](https://github.com/user-attachments/assets/1ab9b00f-8496-453c-b491-52c0e9aeb51c)

2. 21148: Vulnerabilities `Not supported` on iPad/iPhone host details:
![Screenshot 2024-08-07 at 2 55 44 PM](https://github.com/user-attachments/assets/5527bcdb-fb77-40d4-bbca-62264b7ea561)


- [x] Manual QA for all new/changed functionality