### PR TITLE
Guide: "Enforce disk encryption when macOS hosts automatically enroll" and "Rotate FileVault (disk encryption) key w/o prompt"

### DIFF
--- a/docs/Using Fleet/MDM-disk-encryption.md
+++ b/docs/Using Fleet/MDM-disk-encryption.md
@@ -8,7 +8,9 @@ In Fleet, you can enforce disk encryption for your macOS and Windows hosts.
 
 When disk encryption is enforced, hosts’ disk encryption keys will be stored in Fleet.
 
-For Windows hosts, disk encryption is enforced on the C: volume (default system/OS drive).
+For macOS hosts that automatically enroll, disk encryption is enforced during Setup Assistant.
+
+For Windows, disk encryption is enforced on the C: volume (default system/OS drive).
 
 ## Enforce disk encryption
 

--- a/docs/Using Fleet/MDM-disk-encryption.md
+++ b/docs/Using Fleet/MDM-disk-encryption.md
@@ -56,7 +56,7 @@ How to view the disk encryption key:
 
 ## Migrate macOS hosts
 
-When migrating macOS hosts another MDM solution, in order to complete the process of encrypting the hard drive and escrowing the key in Fleet, your end users must log out or restart their device.
+When migrating macOS hosts from another MDM solution, in order to complete the process of encrypting the hard drive and escrowing the key in Fleet, your end users must log out or restart their device.
 
 Share [these guided instructions](./MDM-migration-guide.md#how-to-turn-on-disk-encryption) with your end users.
 

--- a/docs/Using Fleet/MDM-disk-encryption.md
+++ b/docs/Using Fleet/MDM-disk-encryption.md
@@ -54,6 +54,12 @@ How to view the disk encryption key:
 
 2. On the **Host details** page, select **Actions > Show disk encryption key**.
 
+## Migrate macOS hosts
+
+When migrating macOS hosts another MDM solution, in order to complete the process of encrypting the hard drive and escrowing the key in Fleet, your end users must log out or restart their device.
+
+Share [these guided instructions](./MDM-migration-guide.md#how-to-turn-on-disk-encryption) with your end users.
+
 <meta name="pageOrderInSection" value="1504">
 <meta name="title" value="Disk encryption">
 <meta name="description" value="Learn how to enforce disk encryption on macOS and Windows hosts and manage encryption keys with Fleet Premium.">

--- a/docs/Using Fleet/MDM-disk-encryption.md
+++ b/docs/Using Fleet/MDM-disk-encryption.md
@@ -54,16 +54,6 @@ How to view the disk encryption key:
 
 2. On the **Host details** page, select **Actions > Show disk encryption key**.
 
-## Migrate macOS hosts
-
-When migrating macOS hosts another MDM solution, in order to complete the process of encrypting the hard drive and escrowing the key in Fleet, your end users must take action. 
-
-If the host already had disk encryption turned on, the user will need to input their password. 
-
-If the host did not already have disk encryption turned on, the user will need to log out or restart their computer.
-
-Share [these guided instructions](./MDM-migration-guide.md#how-to-turn-on-disk-encryption) with your end users.
-
 <meta name="pageOrderInSection" value="1504">
 <meta name="title" value="Disk encryption">
 <meta name="description" value="Learn how to enforce disk encryption on macOS and Windows hosts and manage encryption keys with Fleet Premium.">

--- a/docs/Using Fleet/MDM-migration-guide.md
+++ b/docs/Using Fleet/MDM-migration-guide.md
@@ -176,13 +176,11 @@ Then, scroll down to the **Mobile device management (MDM)** section.
 
 _Available in Fleet Premium_
 
-When migrating from a previous MDM, end users need to take action to escrow FileVault keys to Fleet. The **My device** page in Fleet Desktop will present users with instructions to reset their key. 
+When migrating from a previous MDM, end users need to restart or logout of their device to escrow FileVault keys to Fleet. The **My device** page in Fleet Desktop will present users with instructions to reset their key. 
 
 To start, enforce FileVault (disk encryption) and escrow in Fleet. Learn how [here](./MDM-disk-encryption.md). 
 
 After turning on disk encryption in Fleet, share [these guided instructions](#how-to-turn-on-disk-encryption) with your end users.
-
-The end user will need to restart or log out of the host.
 
 ## Activation Lock
 

--- a/docs/Using Fleet/MDM-migration-guide.md
+++ b/docs/Using Fleet/MDM-migration-guide.md
@@ -182,9 +182,7 @@ To start, enforce FileVault (disk encryption) and escrow in Fleet. Learn how [he
 
 After turning on disk encryption in Fleet, share [these guided instructions](#how-to-turn-on-disk-encryption) with your end users.
 
-If your old MDM solution did not enforce disk encryption, the end user will need to restart or log out of the host.
-
-If your old MDM solution did enforce disk encryption, the end user will need to reset their disk encryption key by following the prompt on the My device page and inputting their password. 
+The end user will need to restart or log out of the host.
 
 ## Activation Lock
 


### PR DESCRIPTION
Guide update for the "Enforce disk encryption when macOS hosts automatically enroll" (#16866) and "Rotate FileVault (disk encryption) key w/o prompt" (#13157) stories.

Technically these pages doesn't live under fleetdm.com/articles yet (which is what we call a guide) but they will soon.
