### PR TITLE
Fixed a bug when a cached prepared statement gets deleted in the MySQL server

### DIFF
--- a/changes/20781-cached-statements
+++ b/changes/20781-cached-statements
@@ -1,0 +1,1 @@
+* Fixed a bug when a cached prepared statement gets deleted in the MySQL server itself without Fleet knowing. 

--- a/server/datastore/mysql/errors.go
+++ b/server/datastore/mysql/errors.go
@@ -191,6 +191,12 @@ func isMySQLAccessDenied(err error) bool {
 	return false
 }
 
+func isMySQLUnknownStatement(err error) bool {
+	err = ctxerr.Cause(err)
+	var mySQLErr *mysql.MySQLError
+	return errors.As(err, &mySQLErr) && (mySQLErr.Number == mysqlerr.ER_UNKNOWN_STMT_HANDLER)
+}
+
 // ErrPartialResult indicates that a batch operation was completed,
 // but some of the results are missing or incomplete.
 var ErrPartialResult = errors.New("batch operation completed with partial results")

--- a/server/datastore/mysql/mysql.go
+++ b/server/datastore/mysql/mysql.go
@@ -160,6 +160,22 @@ func (ds *Datastore) loadOrPrepareStmt(ctx context.Context, query string) *sqlx.
 	return stmt
 }
 
+func (ds *Datastore) deleteCachedStmt(query string) {
+	ds.stmtCacheMu.Lock()
+	defer ds.stmtCacheMu.Unlock()
+	stmt, ok := ds.stmtCache[query]
+	if ok {
+		if err := stmt.Close(); err != nil {
+			level.Error(ds.logger).Log(
+				"msg", "failed to close prepared statement before deleting it",
+				"query", query,
+				"err", err,
+			)
+		}
+	}
+	delete(ds.stmtCache, query)
+}
+
 // NewMDMAppleSCEPDepot returns a scep_depot.Depot that uses the Datastore
 // underlying MySQL writer *sql.DB.
 func (ds *Datastore) NewSCEPDepot() (scep_depot.Depot, error) {

--- a/server/datastore/mysql/mysql.go
+++ b/server/datastore/mysql/mysql.go
@@ -172,8 +172,8 @@ func (ds *Datastore) deleteCachedStmt(query string) {
 				"err", err,
 			)
 		}
+		delete(ds.stmtCache, query)
 	}
-	delete(ds.stmtCache, query)
 }
 
 // NewMDMAppleSCEPDepot returns a scep_depot.Depot that uses the Datastore

--- a/server/datastore/mysql/mysql_test.go
+++ b/server/datastore/mysql/mysql_test.go
@@ -1301,3 +1301,85 @@ func TestBatchProcessDB(t *testing.T) {
 		require.Equal(t, 2, callCount)
 	})
 }
+
+func TestGetContextTryStmt(t *testing.T) {
+	ctx := context.Background()
+
+	dbMock, ds := mockDatastore(t)
+	ds.stmtCache = map[string]*sqlx.Stmt{}
+
+	t.Run("get with unknown statement error", func(t *testing.T) {
+		count := 0
+		query := "SELECT 1"
+
+		// first call to cache the statement
+		dbMock.ExpectPrepare(query)
+		mockResult := sqlmock.NewRows([]string{query})
+		mockResult.AddRow("1")
+		dbMock.ExpectQuery(query).WillReturnRows(mockResult)
+		err := ds.getContextTryStmt(ctx, &count, query)
+		require.NoError(t, err)
+		require.NoError(t, dbMock.ExpectationsWereMet())
+
+		// verify that the statement was cached
+		stmt := ds.loadOrPrepareStmt(ctx, query)
+		require.NotNil(t, stmt)
+
+		// call again to trigger the unknown statement error and ensure it retries
+		// first query, make it fail
+		queryMock := dbMock.ExpectQuery(query)
+		mySQLErr := &mysql.MySQLError{
+			Number: mysqlerr.ER_UNKNOWN_STMT_HANDLER,
+		}
+		queryMock.WillReturnError(mySQLErr)
+
+		// after the failure, a second call is made, this time without
+		// the prepared statement
+		mockResult = sqlmock.NewRows([]string{query})
+		mockResult.AddRow("1")
+		dbMock.ExpectQuery(query).WillReturnRows(mockResult)
+
+		// make the call and verify we removed the prepared statement
+		err = ds.getContextTryStmt(ctx, &count, query)
+		require.NoError(t, err)
+		require.NoError(t, dbMock.ExpectationsWereMet())
+		stmt = ds.loadOrPrepareStmt(ctx, query)
+		require.Nil(t, stmt)
+	})
+
+	t.Run("get with other error", func(t *testing.T) {
+		dbMock, ds := mockDatastore(t)
+		ds.stmtCache = map[string]*sqlx.Stmt{}
+		count := 0
+		query := "SELECT 1"
+
+		// first call to cache the statement
+		dbMock.ExpectPrepare(query)
+		mockResult := sqlmock.NewRows([]string{query})
+		mockResult.AddRow("1")
+		dbMock.ExpectQuery(query).WillReturnRows(mockResult)
+		err := ds.getContextTryStmt(ctx, &count, query)
+		require.NoError(t, err)
+		require.Equal(t, 1, count)
+		require.NoError(t, dbMock.ExpectationsWereMet())
+
+		// verify that the statement was cached
+		stmt := ds.loadOrPrepareStmt(ctx, query)
+		require.NotNil(t, stmt)
+
+		// return a duplicate error
+		queryMock := dbMock.ExpectQuery(query)
+		mySQLErr := &mysql.MySQLError{
+			Number: mysqlerr.ER_DUP_ENTRY,
+		}
+		queryMock.WillReturnError(mySQLErr)
+
+		count = 0
+		err = ds.getContextTryStmt(ctx, &count, query)
+		require.ErrorIs(t, mySQLErr, err)
+		require.NoError(t, dbMock.ExpectationsWereMet())
+		stmt = ds.loadOrPrepareStmt(ctx, query)
+		require.NotNil(t, stmt)
+	})
+
+}


### PR DESCRIPTION
for #20781, I found this hard to reproduce, but apparently can happen in AWS Aurora when the server is upgraded under the hood.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/Committing-Changes.md#changes-files) for more information.
- [x] Added/updated tests
- [x] Manual QA for all new/changed functionality
