### PR TITLE
fix to return software titles url for all teams context

### DIFF
--- a/server/datastore/mysql/vpp.go
+++ b/server/datastore/mysql/vpp.go
@@ -14,7 +14,7 @@ import (
 )
 
 func (ds *Datastore) GetVPPAppMetadataByTeamAndTitleID(ctx context.Context, teamID *uint, titleID uint) (*fleet.VPPAppStoreApp, error) {
-	query := `
+	const query = `
 SELECT
 	vap.adam_id,
 	vap.platform,
@@ -29,15 +29,14 @@ WHERE
 
 	// when team id is not nil, we need to filter by the global or team id given.
 	args := []any{titleID}
+	teamFilter := ""
 	if teamID != nil {
-		query = fmt.Sprintf(query, "AND vat.global_or_team_id = ?")
 		args = append(args, *teamID)
-	} else {
-		query = fmt.Sprintf(query, "")
+		teamFilter = "AND vat.global_or_team_id = ?"
 	}
 
 	var app fleet.VPPAppStoreApp
-	err := sqlx.GetContext(ctx, ds.reader(ctx), &app, query, args...)
+	err := sqlx.GetContext(ctx, ds.reader(ctx), &app, fmt.Sprintf(query, teamFilter), args...)
 	if err != nil {
 		if err == sql.ErrNoRows {
 			return nil, ctxerr.Wrap(ctx, notFound("VPPApp"), "get VPP app metadata")

--- a/server/datastore/mysql/vpp_test.go
+++ b/server/datastore/mysql/vpp_test.go
@@ -83,6 +83,11 @@ func testVPPAppMetadata(t *testing.T, ds *Datastore) {
 	require.NoError(t, err)
 	require.Equal(t, &fleet.VPPAppStoreApp{Name: "vpp2", VPPAppID: vpp2}, meta)
 
+	// get it for all teams
+	meta, err = ds.GetVPPAppMetadataByTeamAndTitleID(ctx, nil, titleID2)
+	require.NoError(t, err)
+	require.Equal(t, &fleet.VPPAppStoreApp{Name: "vpp2", VPPAppID: vpp2}, meta)
+
 	// try to add the same app again, fails
 	_, err = ds.InsertVPPAppWithTeam(ctx, &fleet.VPPApp{Name: "vpp2", BundleIdentifier: "com.app.vpp2",
 		VPPAppID: fleet.VPPAppID{AdamID: "adam_vpp_app_2", Platform: fleet.MacOSPlatform}}, &team1.ID)


### PR DESCRIPTION
relates to #21058

Makes a change to `GET /software/titles/:id` response so that we return the data needed to display the VPP app icon for the **All Teams** context.

![image](https://github.com/user-attachments/assets/6cf48c04-5713-4b9e-b310-cee91367c37f)

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/Committing-Changes.md#changes-files) for more information.
- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [x] Added/updated tests
- [x] Manual QA for all new/changed functionality
