### PR TITLE
Vuln cron fail fix

### DIFF
--- a/server/vulnerabilities/nvd/sync/cve_syncer.go
+++ b/server/vulnerabilities/nvd/sync/cve_syncer.go
@@ -788,8 +788,6 @@ func convertAPI20CVEToLegacy(cve nvdapi.CVE, logger log.Logger) *schema.NVDCVEFe
 		case description.Lang == "en-US":
 			// This occurred starting with Microsoft CVE-2024-38200
 			lang = "en"
-		case strings.HasPrefix(description.Lang, "en-"):
-			lang = description.Lang
 		default:
 			// Non-english descriptions are ignored.
 			continue


### PR DESCRIPTION
#21239 

This PR fixes the generated vuln JSON files, which would get the current customers up and running.

QA Done:

- New vuln JSON files generated at: https://github.com/getvictor/vulnerabilities/releases
- Ran local server with new vuln JSON files by setting `export TEST_VULN_GITHUB_OWNER=getvictor`
- Diff of JSON files from https://github.com/fleetdm/vulnerabilities and https://github.com/getvictor/vulnerabilities

Steps for diff:
```
mkdir new
cd new
gh release download cve-202408111650 -D . -R getvictor/vulnerabilities
gunzip *.gz
cd ../
mkdir old
cd old
gh release download cve-202408111637 -D . -R fleetdm/vulnerabilities
gunzip *.gz
cd ..
diff old new
```

Diff results also remove a few Rejected CVEs from JSON files. The 2024 results also have a few minor diffs that don't seem significant.