### PR TITLE
CPE fixes

### DIFF
--- a/changes/20463-cpe-fixes
+++ b/changes/20463-cpe-fixes
@@ -1,0 +1,2 @@
+- During vulnerability scanning, use 'macos' SW target for CPEs of homebrew packages
+- During vulnerability scanning, don't ignore software with non-ASCII en dash and em dash characters

--- a/server/vulnerabilities/nvd/cpe.go
+++ b/server/vulnerabilities/nvd/cpe.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"slices"
 	"strings"
 	"time"
 	"unicode"
@@ -567,9 +568,14 @@ func translateSoftwareToCPEWithIterator(
 	return nil
 }
 
+var allowedNonASCII = []int32{
+	'–', // en dash
+	'—', // em dash
+}
+
 func containsNonASCII(s string) bool {
 	for _, char := range s {
-		if char > unicode.MaxASCII {
+		if char > unicode.MaxASCII && !slices.Contains(allowedNonASCII, char) {
 			return true
 		}
 	}

--- a/server/vulnerabilities/nvd/cpe_test.go
+++ b/server/vulnerabilities/nvd/cpe_test.go
@@ -676,7 +676,7 @@ func TestCPEFromSoftwareIntegration(t *testing.T) {
 		},
 		{
 			software: fleet.Software{
-				Name:             "1Password - Password Manager",
+				Name:             "1Password – Password Manager",
 				Source:           "chrome_extensions",
 				Version:          "2.3.8",
 				Vendor:           "",
@@ -762,7 +762,7 @@ func TestCPEFromSoftwareIntegration(t *testing.T) {
 				Version:          "18.9.0",
 				Vendor:           "",
 				BundleIdentifier: "",
-			}, cpe: "cpe:2.3:a:nodejs:node.js:18.9.0:*:*:*:*:*:*:*",
+			}, cpe: "cpe:2.3:a:nodejs:node.js:18.9.0:*:*:*:*:macos:*:*",
 		},
 		{
 			software: fleet.Software{
@@ -1342,7 +1342,7 @@ func TestCPEFromSoftwareIntegration(t *testing.T) {
 				Vendor:           "",
 				BundleIdentifier: "",
 			},
-			cpe: "cpe:2.3:a:jetbrains:intellij_idea:2023.3.2.233.13135.103:*:*:*:*:*:*:*",
+			cpe: "cpe:2.3:a:jetbrains:intellij_idea:2023.3.2.233.13135.103:*:*:*:*:macos:*:*",
 		},
 		{
 			software: fleet.Software{
@@ -1643,7 +1643,7 @@ func TestCPEFromSoftwareIntegration(t *testing.T) {
 				Version: "3.9.18_2",
 				Vendor:  "",
 			},
-			cpe: `cpe:2.3:a:python:python:3.9.18_2:*:*:*:*:*:*:*`,
+			cpe: `cpe:2.3:a:python:python:3.9.18_2:*:*:*:*:macos:*:*`,
 		},
 		{
 			software: fleet.Software{
@@ -1693,7 +1693,7 @@ func TestContainsNonASCII(t *testing.T) {
 	}{
 		{"hello", false},
 		{"hello world", false},
-		{"hello world!", false},
+		{"hello – world!", false},
 		{"😊👍", true},
 		{"hello world! 😊👍", true},
 		{"Девушка Фонарём", true},

--- a/server/vulnerabilities/nvd/sanitize.go
+++ b/server/vulnerabilities/nvd/sanitize.go
@@ -222,6 +222,8 @@ func targetSW(s *fleet.Software) string {
 	switch s.Source {
 	case "apps":
 		return "macos"
+	case "homebrew_packages":
+		return "macos" // osquery homebrew_packages table is currently only for macOS (2024/08/12)
 	case "python_packages":
 		return "python"
 	case "chrome_extensions":


### PR DESCRIPTION
#20463 and #21173
- During vulnerability scanning, use 'macos' SW target for CPEs of homebrew packages
- During vulnerability scanning, don't ignore software with non-ASCII en dash and em dash characters

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/Committing-Changes.md#changes-files) for more information.
- [x] Added/updated tests
- [x] Manual QA for all new/changed functionality
