### PR TITLE
Update label name in configuration profile

### DIFF
--- a/changes/21163-config-profile-label
+++ b/changes/21163-config-profile-label
@@ -1,0 +1,1 @@
+- Fixed bug where configuration profile was still showing the old label name after the name was updated.

--- a/server/datastore/mysql/labels.go
+++ b/server/datastore/mysql/labels.go
@@ -58,18 +58,25 @@ func (ds *Datastore) ApplyLabelSpecs(ctx context.Context, specs []*fleet.LabelSp
 				return ctxerr.Wrap(ctx, err, "exec ApplyLabelSpecs insert")
 			}
 
-			if s.LabelType == fleet.LabelTypeBuiltIn ||
-				s.LabelMembershipType != fleet.LabelMembershipTypeManual {
-				// No need to update membership
-				continue
-			}
-
 			var labelID uint
 			sql = `
 SELECT id from labels WHERE name = ?
 `
 			if err := sqlx.GetContext(ctx, tx, &labelID, sql, s.Name); err != nil {
 				return ctxerr.Wrap(ctx, err, "get label ID")
+			}
+
+			// Update the label name in mdm_configuration_profile_labels
+			sql = `UPDATE mdm_configuration_profile_labels SET label_name = ? WHERE label_id = ?`
+			_, err = tx.ExecContext(ctx, sql, s.Name, labelID)
+			if err != nil {
+				return ctxerr.Wrap(ctx, err, "update label name in mdm_configuration_profile_labels")
+			}
+
+			if s.LabelType == fleet.LabelTypeBuiltIn ||
+				s.LabelMembershipType != fleet.LabelMembershipTypeManual {
+				// No need to update membership
+				continue
 			}
 
 			sql = `
@@ -227,6 +234,14 @@ func (ds *Datastore) SaveLabel(ctx context.Context, label *fleet.Label, teamFilt
 	if err != nil {
 		return nil, nil, ctxerr.Wrap(ctx, err, "saving label")
 	}
+
+	// Update the label name in mdm_configuration_profile_labels
+	query = `UPDATE mdm_configuration_profile_labels SET label_name = ? WHERE label_id = ?`
+	_, err = ds.writer(ctx).ExecContext(ctx, query, label.Name, label.ID)
+	if err != nil {
+		return nil, nil, ctxerr.Wrap(ctx, err, "updating mdm configuration profile label")
+	}
+
 	return ds.labelDB(ctx, label.ID, teamFilter, ds.writer(ctx))
 }
 

--- a/server/service/integration_core_test.go
+++ b/server/service/integration_core_test.go
@@ -4048,21 +4048,28 @@ func (s *integrationTestSuite) TestLabels() {
 
 	// modify manual label 1 without modifying its hosts
 	modResp = modifyLabelResponse{}
-	s.DoJSON("PATCH", fmt.Sprintf("/api/latest/fleet/labels/%d", manualLbl1.ID), &fleet.ModifyLabelPayload{Name: ptr.String("modified_manual_label1")}, http.StatusOK, &modResp)
+	newName := "modified_manual_label1"
+	s.DoJSON("PATCH", fmt.Sprintf("/api/latest/fleet/labels/%d", manualLbl1.ID), &fleet.ModifyLabelPayload{Name: &newName}, http.StatusOK,
+		&modResp)
 	assert.Equal(t, manualLbl1.ID, modResp.Label.ID)
 	assert.Equal(t, fleet.LabelTypeRegular, modResp.Label.LabelType)
 	assert.Equal(t, fleet.LabelMembershipTypeManual, modResp.Label.LabelMembershipType)
 	assert.ElementsMatch(t, []uint{manualHosts[0].ID, manualHosts[1].ID, manualHosts[2].ID}, modResp.Label.HostIDs)
 	assert.EqualValues(t, 3, modResp.Label.HostCount)
+	assert.Equal(t, newName, modResp.Label.Name)
 
 	// modify manual label 2 adding some hosts
 	modResp = modifyLabelResponse{}
-	s.DoJSON("PATCH", fmt.Sprintf("/api/latest/fleet/labels/%d", manualLbl2.ID), &fleet.ModifyLabelPayload{Hosts: []string{manualHosts[0].UUID}}, http.StatusOK, &modResp)
+	newName = "modified_manual_label2"
+	s.DoJSON("PATCH", fmt.Sprintf("/api/latest/fleet/labels/%d", manualLbl2.ID),
+		&fleet.ModifyLabelPayload{Name: &newName, Hosts: []string{manualHosts[0].UUID}}, http.StatusOK, &modResp)
 	assert.Equal(t, manualLbl2.ID, modResp.Label.ID)
 	assert.Equal(t, fleet.LabelTypeRegular, modResp.Label.LabelType)
 	assert.Equal(t, fleet.LabelMembershipTypeManual, modResp.Label.LabelMembershipType)
 	assert.ElementsMatch(t, []uint{manualHosts[0].ID}, modResp.Label.HostIDs)
 	assert.EqualValues(t, 1, modResp.Label.HostCount)
+	assert.Equal(t, newName, modResp.Label.Name)
+	manualLbl2.Name = newName
 
 	// modify manual label 2 clearing its hosts
 	modResp = modifyLabelResponse{}


### PR DESCRIPTION
#21163 
Fixed bug where configuration profile was still showing the old label name after the name was updated.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/Committing-Changes.md#changes-files) for more information.
- [x] Added/updated tests
- [x] Manual QA for all new/changed functionality
