### PR TITLE
In policy webhook, made sure the failing_host_count is never 0

### DIFF
--- a/changes/20599-policy-webhook
+++ b/changes/20599-policy-webhook
@@ -1,0 +1,1 @@
+- In policy webhook, made sure the failing_host_count is never 0. This count is normally updated once an hour during cleanups_then_aggregation cron job.

--- a/server/webhooks/failing_policies.go
+++ b/server/webhooks/failing_policies.go
@@ -36,6 +36,12 @@ func SendFailingPoliciesBatchedPOSTs(
 		level.Debug(logger).Log("msg", "no hosts", "policyID", policy.ID)
 		return nil
 	}
+	// The count may be out of date since it is only updated during the hourly cleanups_then_aggregation cron.
+	// Take care of the case where the count is less than the actual number of hosts we are returning.
+	hostsCount := uint(len(hosts))
+	if hostsCount > policy.FailingHostCount {
+		policy.FailingHostCount = hostsCount
+	}
 	sort.Slice(hosts, func(i, j int) bool {
 		return hosts[i].ID < hosts[j].ID
 	})

--- a/server/webhooks/failing_policies_test.go
+++ b/server/webhooks/failing_policies_test.go
@@ -122,7 +122,7 @@ func TestTriggerFailingPoliciesWebhookBasic(t *testing.T) {
         "created_at": "0001-01-01T00:00:00Z",
         "updated_at": "0001-01-01T00:00:00Z",
         "passing_host_count": 0,
-        "failing_host_count": 0,
+        "failing_host_count": 2,
         "host_count_updated_at": null,
 		"critical": true,
 		"calendar_events_enabled": false
@@ -309,7 +309,7 @@ func TestTriggerFailingPoliciesWebhookTeam(t *testing.T) {
         "created_at": "0001-01-01T00:00:00Z",
         "updated_at": "0001-01-01T00:00:00Z",
         "passing_host_count": 0,
-        "failing_host_count": 0,
+        "failing_host_count": 1,
         "host_count_updated_at": null,
 		"critical": false,
 		"calendar_events_enabled": true


### PR DESCRIPTION
#20599 

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/Committing-Changes.md#changes-files) for more information.
- [x] Manual QA for all new/changed functionality
