### PR TITLE
Store bootstrap packages in S3: use a reference timestamp in Cleanup to avoid deleting newly created ones

### DIFF
--- a/cmd/fleet/cron.go
+++ b/cmd/fleet/cron.go
@@ -883,10 +883,16 @@ func newCleanupsAndAggregationSchedule(
 			return ds.CleanupActivitiesAndAssociatedData(ctx, maxCount, appConfig.ActivityExpirySettings.ActivityExpiryWindow)
 		}),
 		schedule.WithJob("cleanup_unused_software_installers", func(ctx context.Context) error {
-			return ds.CleanupUnusedSoftwareInstallers(ctx, softwareInstallStore)
+			// remove only those unused created more than a minute ago to avoid a
+			// race where we delete those created after the mysql query to get those
+			// in use.
+			return ds.CleanupUnusedSoftwareInstallers(ctx, softwareInstallStore, time.Now().Add(-time.Minute))
 		}),
 		schedule.WithJob("cleanup_unused_bootstrap_packages", func(ctx context.Context) error {
-			return ds.CleanupUnusedBootstrapPackages(ctx, bootstrapPackageStore)
+			// remove only those unused created more than a minute ago to avoid a
+			// race where we delete those created after the mysql query to get those
+			// in use.
+			return ds.CleanupUnusedBootstrapPackages(ctx, bootstrapPackageStore, time.Now().Add(-time.Minute))
 		}),
 	)
 

--- a/server/datastore/mysql/apple_mdm.go
+++ b/server/datastore/mysql/apple_mdm.go
@@ -3235,7 +3235,7 @@ func (ds *Datastore) GetMDMAppleBootstrapPackageMeta(ctx context.Context, teamID
 	return &bp, nil
 }
 
-func (ds *Datastore) CleanupUnusedBootstrapPackages(ctx context.Context, pkgStore fleet.MDMBootstrapPackageStore) error {
+func (ds *Datastore) CleanupUnusedBootstrapPackages(ctx context.Context, pkgStore fleet.MDMBootstrapPackageStore, removeCreatedBefore time.Time) error {
 	if pkgStore == nil {
 		// no-op in this case, possible if not running with a Premium license or
 		// configured S3 storage
@@ -3252,7 +3252,7 @@ func (ds *Datastore) CleanupUnusedBootstrapPackages(ctx context.Context, pkgStor
 		pkgIDs = append(pkgIDs, hex.EncodeToString(sha))
 	}
 
-	_, err := pkgStore.Cleanup(ctx, pkgIDs)
+	_, err := pkgStore.Cleanup(ctx, pkgIDs, removeCreatedBefore)
 	return ctxerr.Wrap(ctx, err, "cleanup unused bootstrap packages")
 }
 

--- a/server/datastore/mysql/apple_mdm_test.go
+++ b/server/datastore/mysql/apple_mdm_test.go
@@ -6256,7 +6256,7 @@ func testMDMAppleBootstrapPackageWithS3(t *testing.T, ds *Datastore) {
 	require.NoError(t, err)
 
 	// run the cleanup job
-	err = ds.CleanupUnusedBootstrapPackages(ctx, pkgStore)
+	err = ds.CleanupUnusedBootstrapPackages(ctx, pkgStore, time.Now())
 	require.NoError(t, err)
 
 	// team 1 can still be retrieved (it shares the same contents)
@@ -6306,7 +6306,7 @@ func testMDMAppleBootstrapPackageWithS3(t *testing.T, ds *Datastore) {
 	require.Equal(t, bp3.Bytes, bpContent.Bytes)
 
 	// run the cleanup job
-	err = ds.CleanupUnusedBootstrapPackages(ctx, pkgStore)
+	err = ds.CleanupUnusedBootstrapPackages(ctx, pkgStore, time.Now())
 	require.NoError(t, err)
 
 	ok, err = pkgStore.Exists(ctx, hex.EncodeToString(bp1.Sha256))

--- a/server/datastore/mysql/software_installers.go
+++ b/server/datastore/mysql/software_installers.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/fleetdm/fleet/v4/server/authz"
 	"github.com/fleetdm/fleet/v4/server/contexts/ctxerr"
@@ -482,7 +483,7 @@ WHERE
 	})
 }
 
-func (ds *Datastore) CleanupUnusedSoftwareInstallers(ctx context.Context, softwareInstallStore fleet.SoftwareInstallerStore) error {
+func (ds *Datastore) CleanupUnusedSoftwareInstallers(ctx context.Context, softwareInstallStore fleet.SoftwareInstallerStore, removeCreatedBefore time.Time) error {
 	if softwareInstallStore == nil {
 		// no-op in this case, possible if not running with a Premium license
 		return nil
@@ -494,7 +495,7 @@ func (ds *Datastore) CleanupUnusedSoftwareInstallers(ctx context.Context, softwa
 		return ctxerr.Wrap(ctx, err, "get list of software installers in use")
 	}
 
-	_, err := softwareInstallStore.Cleanup(ctx, storageIDs)
+	_, err := softwareInstallStore.Cleanup(ctx, storageIDs, removeCreatedBefore)
 	return ctxerr.Wrap(ctx, err, "cleanup unused software installers")
 }
 

--- a/server/datastore/mysql/software_installers_test.go
+++ b/server/datastore/mysql/software_installers_test.go
@@ -355,7 +355,7 @@ func testCleanupUnusedSoftwareInstallers(t *testing.T, ds *Datastore) {
 	}
 
 	// cleanup an empty store
-	err = ds.CleanupUnusedSoftwareInstallers(ctx, store)
+	err = ds.CleanupUnusedSoftwareInstallers(ctx, store, time.Now())
 	require.NoError(t, err)
 	assertExisting(nil)
 
@@ -377,7 +377,7 @@ func testCleanupUnusedSoftwareInstallers(t *testing.T, ds *Datastore) {
 	require.NoError(t, err)
 
 	assertExisting([]string{ins0})
-	err = ds.CleanupUnusedSoftwareInstallers(ctx, store)
+	err = ds.CleanupUnusedSoftwareInstallers(ctx, store, time.Now())
 	require.NoError(t, err)
 	assertExisting([]string{ins0})
 
@@ -385,7 +385,7 @@ func testCleanupUnusedSoftwareInstallers(t *testing.T, ds *Datastore) {
 	err = ds.DeleteSoftwareInstaller(ctx, swi)
 	require.NoError(t, err)
 
-	err = ds.CleanupUnusedSoftwareInstallers(ctx, store)
+	err = ds.CleanupUnusedSoftwareInstallers(ctx, store, time.Now())
 	require.NoError(t, err)
 	assertExisting(nil)
 }

--- a/server/datastore/mysql/software_installers_test.go
+++ b/server/datastore/mysql/software_installers_test.go
@@ -385,7 +385,13 @@ func testCleanupUnusedSoftwareInstallers(t *testing.T, ds *Datastore) {
 	err = ds.DeleteSoftwareInstaller(ctx, swi)
 	require.NoError(t, err)
 
-	err = ds.CleanupUnusedSoftwareInstallers(ctx, store, time.Now())
+	// would clean up, but not created before 1m ago
+	err = ds.CleanupUnusedSoftwareInstallers(ctx, store, time.Now().Add(-time.Minute))
+	require.NoError(t, err)
+	assertExisting([]string{ins0})
+
+	// do actual cleanup
+	err = ds.CleanupUnusedSoftwareInstallers(ctx, store, time.Now().Add(time.Minute))
 	require.NoError(t, err)
 	assertExisting(nil)
 }

--- a/server/datastore/s3/bootstrap_package_test.go
+++ b/server/datastore/s3/bootstrap_package_test.go
@@ -135,9 +135,15 @@ func TestBootstrapPackageCleanup(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	n, err = store.Cleanup(ctx, []string{packages[0], packages[2]}, time.Now())
+	// cleanup with a time in the past, nothing gets removed
+	n, err = store.Cleanup(ctx, []string{}, time.Now().Add(-time.Minute))
+	require.NoError(t, err)
+	require.Equal(t, 0, n)
+	assertExisting([]string{packages[0], packages[1], packages[2], packages[3]})
+
+	// cleanup in the future, all unused get removed
+	n, err = store.Cleanup(ctx, []string{packages[0], packages[2]}, time.Now().Add(time.Minute))
 	require.NoError(t, err)
 	require.Equal(t, 2, n)
-
 	assertExisting([]string{packages[0], packages[2]})
 }

--- a/server/datastore/s3/bootstrap_package_test.go
+++ b/server/datastore/s3/bootstrap_package_test.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"path"
 	"testing"
+	"time"
 
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/fleetdm/fleet/v4/server/fleet"
@@ -104,7 +105,7 @@ func TestBootstrapPackageCleanup(t *testing.T) {
 	}
 
 	// cleanup an empty store
-	n, err := store.Cleanup(ctx, nil)
+	n, err := store.Cleanup(ctx, nil, time.Now())
 	require.NoError(t, err)
 	require.Equal(t, 0, n)
 
@@ -114,14 +115,14 @@ func TestBootstrapPackageCleanup(t *testing.T) {
 	require.NoError(t, err)
 
 	// cleanup but mark it as used
-	n, err = store.Cleanup(ctx, []string{ins0})
+	n, err = store.Cleanup(ctx, []string{ins0}, time.Now())
 	require.NoError(t, err)
 	require.Equal(t, 0, n)
 
 	assertExisting([]string{ins0})
 
 	// cleanup but mark it as unused
-	n, err = store.Cleanup(ctx, []string{})
+	n, err = store.Cleanup(ctx, []string{}, time.Now())
 	require.NoError(t, err)
 	require.Equal(t, 1, n)
 
@@ -134,7 +135,7 @@ func TestBootstrapPackageCleanup(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	n, err = store.Cleanup(ctx, []string{packages[0], packages[2]})
+	n, err = store.Cleanup(ctx, []string{packages[0], packages[2]}, time.Now())
 	require.NoError(t, err)
 	require.Equal(t, 2, n)
 

--- a/server/datastore/s3/software_installer_test.go
+++ b/server/datastore/s3/software_installer_test.go
@@ -135,9 +135,15 @@ func TestSoftwareInstallerCleanup(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	n, err = store.Cleanup(ctx, []string{installers[0], installers[2]}, time.Now())
+	// cleanup with a time in the past, nothing gets removed
+	n, err = store.Cleanup(ctx, []string{}, time.Now().Add(-time.Minute))
+	require.NoError(t, err)
+	require.Equal(t, 0, n)
+	assertExisting([]string{installers[0], installers[1], installers[2], installers[3]})
+
+	// cleanup in the future, all unused get removed
+	n, err = store.Cleanup(ctx, []string{installers[0], installers[2]}, time.Now().Add(time.Minute))
 	require.NoError(t, err)
 	require.Equal(t, 2, n)
-
 	assertExisting([]string{installers[0], installers[2]})
 }

--- a/server/datastore/s3/software_installer_test.go
+++ b/server/datastore/s3/software_installer_test.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"path"
 	"testing"
+	"time"
 
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/fleetdm/fleet/v4/server/fleet"
@@ -104,7 +105,7 @@ func TestSoftwareInstallerCleanup(t *testing.T) {
 	}
 
 	// cleanup an empty store
-	n, err := store.Cleanup(ctx, nil)
+	n, err := store.Cleanup(ctx, nil, time.Now())
 	require.NoError(t, err)
 	require.Equal(t, 0, n)
 
@@ -114,14 +115,14 @@ func TestSoftwareInstallerCleanup(t *testing.T) {
 	require.NoError(t, err)
 
 	// cleanup but mark it as used
-	n, err = store.Cleanup(ctx, []string{ins0})
+	n, err = store.Cleanup(ctx, []string{ins0}, time.Now())
 	require.NoError(t, err)
 	require.Equal(t, 0, n)
 
 	assertExisting([]string{ins0})
 
 	// cleanup but mark it as unused
-	n, err = store.Cleanup(ctx, []string{})
+	n, err = store.Cleanup(ctx, []string{}, time.Now())
 	require.NoError(t, err)
 	require.Equal(t, 1, n)
 
@@ -134,7 +135,7 @@ func TestSoftwareInstallerCleanup(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	n, err = store.Cleanup(ctx, []string{installers[0], installers[2]})
+	n, err = store.Cleanup(ctx, []string{installers[0], installers[2]}, time.Now())
 	require.NoError(t, err)
 	require.Equal(t, 2, n)
 

--- a/server/fleet/apple_mdm.go
+++ b/server/fleet/apple_mdm.go
@@ -849,5 +849,5 @@ type MDMBootstrapPackageStore interface {
 	Get(ctx context.Context, packageID string) (io.ReadCloser, int64, error)
 	Put(ctx context.Context, packageID string, content io.ReadSeeker) error
 	Exists(ctx context.Context, packageID string) (bool, error)
-	Cleanup(ctx context.Context, usedPackageIDs []string) (int, error)
+	Cleanup(ctx context.Context, usedPackageIDs []string, removeCreatedBefore time.Time) (int, error)
 }

--- a/server/fleet/datastore.go
+++ b/server/fleet/datastore.go
@@ -1209,7 +1209,7 @@ type Datastore interface {
 
 	// CleanupUnusedBootstrapPackages will remove bootstrap packages that have no
 	// references to them from the mdm_apple_bootstrap_packages table.
-	CleanupUnusedBootstrapPackages(ctx context.Context, pkgStore MDMBootstrapPackageStore) error
+	CleanupUnusedBootstrapPackages(ctx context.Context, pkgStore MDMBootstrapPackageStore, removeCreatedBefore time.Time) error
 
 	// GetHostMDMMacOSSetup returns the MDM macOS setup information for the specified host id.
 	GetHostMDMMacOSSetup(ctx context.Context, hostID uint) (*HostMDMMacOSSetup, error)
@@ -1587,7 +1587,7 @@ type Datastore interface {
 
 	// CleanupUnusedSoftwareInstallers will remove software installers that have
 	// no references to them from the software_installers table.
-	CleanupUnusedSoftwareInstallers(ctx context.Context, softwareInstallStore SoftwareInstallerStore) error
+	CleanupUnusedSoftwareInstallers(ctx context.Context, softwareInstallStore SoftwareInstallerStore, removeCreatedBefore time.Time) error
 
 	// BatchSetSoftwareInstallers sets the software installers for the given team or no team.
 	BatchSetSoftwareInstallers(ctx context.Context, tmID *uint, installers []*UploadSoftwareInstallerPayload) error

--- a/server/fleet/software_installer.go
+++ b/server/fleet/software_installer.go
@@ -20,7 +20,7 @@ type SoftwareInstallerStore interface {
 	Get(ctx context.Context, installerID string) (io.ReadCloser, int64, error)
 	Put(ctx context.Context, installerID string, content io.ReadSeeker) error
 	Exists(ctx context.Context, installerID string) (bool, error)
-	Cleanup(ctx context.Context, usedInstallerIDs []string) (int, error)
+	Cleanup(ctx context.Context, usedInstallerIDs []string, removeCreatedBefore time.Time) (int, error)
 }
 
 // FailingSoftwareInstallerStore is an implementation of SoftwareInstallerStore

--- a/server/fleet/software_installer.go
+++ b/server/fleet/software_installer.go
@@ -40,7 +40,7 @@ func (FailingSoftwareInstallerStore) Exists(ctx context.Context, installerID str
 	return false, errors.New("software installer store not properly configured")
 }
 
-func (FailingSoftwareInstallerStore) Cleanup(ctx context.Context, usedInstallerIDs []string) (int, error) {
+func (FailingSoftwareInstallerStore) Cleanup(ctx context.Context, usedInstallerIDs []string, removeCreatedBefore time.Time) (int, error) {
 	// do not fail for the failing store's cleanup, as unlike the other store
 	// methods, this will be called even if software installers are otherwise not
 	// used (by the cron job).

--- a/server/mock/datastore_mock.go
+++ b/server/mock/datastore_mock.go
@@ -800,7 +800,7 @@ type GetMDMAppleBootstrapPackageSummaryFunc func(ctx context.Context, teamID uin
 
 type RecordHostBootstrapPackageFunc func(ctx context.Context, commandUUID string, hostUUID string) error
 
-type CleanupUnusedBootstrapPackagesFunc func(ctx context.Context, pkgStore fleet.MDMBootstrapPackageStore) error
+type CleanupUnusedBootstrapPackagesFunc func(ctx context.Context, pkgStore fleet.MDMBootstrapPackageStore, removeCreatedBefore time.Time) error
 
 type GetHostMDMMacOSSetupFunc func(ctx context.Context, hostID uint) (*fleet.HostMDMMacOSSetup, error)
 
@@ -996,7 +996,7 @@ type GetSummaryHostVPPAppInstallsFunc func(ctx context.Context, teamID *uint, ap
 
 type GetSoftwareInstallResultsFunc func(ctx context.Context, resultsUUID string) (*fleet.HostSoftwareInstallerResult, error)
 
-type CleanupUnusedSoftwareInstallersFunc func(ctx context.Context, softwareInstallStore fleet.SoftwareInstallerStore) error
+type CleanupUnusedSoftwareInstallersFunc func(ctx context.Context, softwareInstallStore fleet.SoftwareInstallerStore, removeCreatedBefore time.Time) error
 
 type BatchSetSoftwareInstallersFunc func(ctx context.Context, tmID *uint, installers []*fleet.UploadSoftwareInstallerPayload) error
 
@@ -5239,11 +5239,11 @@ func (s *DataStore) RecordHostBootstrapPackage(ctx context.Context, commandUUID 
 	return s.RecordHostBootstrapPackageFunc(ctx, commandUUID, hostUUID)
 }
 
-func (s *DataStore) CleanupUnusedBootstrapPackages(ctx context.Context, pkgStore fleet.MDMBootstrapPackageStore) error {
+func (s *DataStore) CleanupUnusedBootstrapPackages(ctx context.Context, pkgStore fleet.MDMBootstrapPackageStore, removeCreatedBefore time.Time) error {
 	s.mu.Lock()
 	s.CleanupUnusedBootstrapPackagesFuncInvoked = true
 	s.mu.Unlock()
-	return s.CleanupUnusedBootstrapPackagesFunc(ctx, pkgStore)
+	return s.CleanupUnusedBootstrapPackagesFunc(ctx, pkgStore, removeCreatedBefore)
 }
 
 func (s *DataStore) GetHostMDMMacOSSetup(ctx context.Context, hostID uint) (*fleet.HostMDMMacOSSetup, error) {
@@ -5925,11 +5925,11 @@ func (s *DataStore) GetSoftwareInstallResults(ctx context.Context, resultsUUID s
 	return s.GetSoftwareInstallResultsFunc(ctx, resultsUUID)
 }
 
-func (s *DataStore) CleanupUnusedSoftwareInstallers(ctx context.Context, softwareInstallStore fleet.SoftwareInstallerStore) error {
+func (s *DataStore) CleanupUnusedSoftwareInstallers(ctx context.Context, softwareInstallStore fleet.SoftwareInstallerStore, removeCreatedBefore time.Time) error {
 	s.mu.Lock()
 	s.CleanupUnusedSoftwareInstallersFuncInvoked = true
 	s.mu.Unlock()
-	return s.CleanupUnusedSoftwareInstallersFunc(ctx, softwareInstallStore)
+	return s.CleanupUnusedSoftwareInstallersFunc(ctx, softwareInstallStore, removeCreatedBefore)
 }
 
 func (s *DataStore) BatchSetSoftwareInstallers(ctx context.Context, tmID *uint, installers []*fleet.UploadSoftwareInstallerPayload) error {


### PR DESCRIPTION
Implements what was discussed in the previous PR: https://github.com/fleetdm/fleet/pull/21156#discussion_r1707785452

# Checklist for submitter
- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [x] Added/updated tests
