### PR TITLE
Add VSCode launch configuration for debugging vuln_processing command

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -62,6 +62,21 @@
             ]
         },
         {
+            "name": "Fleet vuln_processing (licensed)",
+            "type": "go",
+            "request": "launch",
+            "mode": "auto",
+            "buildFlags": "-tags='full,fts5'",
+            "cwd": "${workspaceFolder}",
+            "program": "${workspaceFolder}/cmd/fleet",
+            "args": [
+                "vuln_processing",
+                "--dev",
+                "--logging_debug",
+                "--dev_license",
+            ]
+        },
+        {
             "name": "Attach to a running Fleet server",
             "type": "go",
             "request": "attach",


### PR DESCRIPTION
This is an easy way to debug the various vulnerabilities ETLs that we'd normally execute as an in-app cron. I used this over the weekend to test #21242.

# Checklist for submitter

- [x] Manual QA for all new/changed functionality
