### PR TITLE
MABM: migration of the existing ABM token part 2

### DIFF
--- a/cmd/fleet/cron.go
+++ b/cmd/fleet/cron.go
@@ -1074,6 +1074,20 @@ func newAppleMDMDEPProfileAssigner(
 				return nil
 			}
 
+			// As part of the DB migration of the single ABM token to the multi-ABM
+			// token world (where the token was migrated from mdm_config_assets to
+			// abm_tokens), we need to complete migration of the existing token as
+			// during the DB migration we didn't have the organization name, apple id
+			// and renewal date.
+			//incompleteToken, err := ds.GetABMTokenByName(ctx, "")
+			//if err != nil && !fleet.IsNotFound(err) {
+			//	return ctxerr.Wrap(ctx, err, "retrieving migrated ABM token")
+			//}
+			//if incompleteToken != nil {
+			//	// TODO(mna): make the API call, decrypt the token to get renewal date, update token
+			//	depClient := apple_mdm.NewDEPClient(depStorage, ds, logger)
+			//}
+
 			if fleetSyncer == nil {
 				fleetSyncer = apple_mdm.NewDEPService(ds, depStorage, logger)
 			}

--- a/cmd/fleet/cron.go
+++ b/cmd/fleet/cron.go
@@ -1084,7 +1084,12 @@ func newAppleMDMDEPProfileAssigner(
 				return ctxerr.Wrap(ctx, err, "retrieving migrated ABM token")
 			}
 			if incompleteToken != nil {
-				// TODO(mna): make the API call, decrypt the token to get renewal date, update token
+				if err := apple_mdm.SetABMTokenMetadata(ctx, incompleteToken, depStorage, ds, logger); err != nil {
+					return ctxerr.Wrap(ctx, err, "updating migrated ABM token metadata")
+				}
+				if err := ds.SaveABMToken(ctx, incompleteToken); err != nil {
+					return ctxerr.Wrap(ctx, err, "saving updated migrated ABM token")
+				}
 			}
 
 			if fleetSyncer == nil {

--- a/cmd/fleet/cron.go
+++ b/cmd/fleet/cron.go
@@ -1079,14 +1079,13 @@ func newAppleMDMDEPProfileAssigner(
 			// abm_tokens), we need to complete migration of the existing token as
 			// during the DB migration we didn't have the organization name, apple id
 			// and renewal date.
-			//incompleteToken, err := ds.GetABMTokenByName(ctx, "")
-			//if err != nil && !fleet.IsNotFound(err) {
-			//	return ctxerr.Wrap(ctx, err, "retrieving migrated ABM token")
-			//}
-			//if incompleteToken != nil {
-			//	// TODO(mna): make the API call, decrypt the token to get renewal date, update token
-			//	depClient := apple_mdm.NewDEPClient(depStorage, ds, logger)
-			//}
+			incompleteToken, err := ds.GetABMTokenByOrgName(ctx, "")
+			if err != nil && !fleet.IsNotFound(err) {
+				return ctxerr.Wrap(ctx, err, "retrieving migrated ABM token")
+			}
+			if incompleteToken != nil {
+				// TODO(mna): make the API call, decrypt the token to get renewal date, update token
+			}
 
 			if fleetSyncer == nil {
 				fleetSyncer = apple_mdm.NewDEPService(ds, depStorage, logger)

--- a/ee/server/service/mdm.go
+++ b/ee/server/service/mdm.go
@@ -9,7 +9,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"net/http"
 	"net/url"
 	"sort"
 	"strings"
@@ -26,11 +25,8 @@ import (
 	apple_mdm "github.com/fleetdm/fleet/v4/server/mdm/apple"
 	"github.com/fleetdm/fleet/v4/server/mdm/apple/mobileconfig"
 	"github.com/fleetdm/fleet/v4/server/mdm/assets"
-	depclient "github.com/fleetdm/fleet/v4/server/mdm/nanodep/client"
-	"github.com/fleetdm/fleet/v4/server/mdm/nanodep/storage"
 	"github.com/fleetdm/fleet/v4/server/sso"
 	"github.com/fleetdm/fleet/v4/server/worker"
-	kitlog "github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	"github.com/google/uuid"
 )
@@ -74,55 +70,24 @@ func (svc *Service) GetAppleBM(ctx context.Context) (*fleet.AppleBM, error) {
 		return nil, err
 	}
 
-	appleBM, err := getAppleBMAccountDetail(ctx, svc.depStorage, svc.ds, svc.logger)
-	if err != nil {
+	// this is temporary just to fit the refactored call, this whole endpoint
+	// will have to be adapted to the new ABM storage.
+	abmToken := &fleet.ABMToken{
+		OrganizationName: apple_mdm.DEPName,
+	}
+	if err := apple_mdm.SetABMTokenMetadata(ctx, abmToken, svc.depStorage, svc.ds, svc.logger); err != nil {
 		return nil, err
 	}
 
-	token, err := assets.ABMToken(ctx, svc.ds, appleBM.OrgName)
-	if err != nil {
-		return nil, err
-	}
-
-	// fill the rest of the AppleBM fields
-	appleBM.RenewDate = token.AccessTokenExpiry
+	var appleBM fleet.AppleBM
+	// transfer the abmToken metadata info to the appleBM struct
+	appleBM.AppleID = abmToken.AppleID
+	appleBM.OrgName = abmToken.OrganizationName
+	appleBM.RenewDate = abmToken.RenewAt
 	appleBM.DefaultTeam = appCfg.MDM.AppleBMDefaultTeam
 	appleBM.MDMServerURL = mdmServerURL
 
-	return appleBM, nil
-}
-
-func getAppleBMAccountDetail(ctx context.Context, depStorage storage.AllDEPStorage, ds fleet.Datastore, logger kitlog.Logger) (*fleet.AppleBM, error) {
-	depClient := apple_mdm.NewDEPClient(depStorage, ds, logger)
-	res, err := depClient.AccountDetail(ctx, apple_mdm.DEPName)
-	if err != nil {
-		var authErr *depclient.AuthError
-		if errors.As(err, &authErr) {
-			// authentication failure with 401 unauthorized means that the configured
-			// Apple BM certificate and/or token are invalid. Fail with a 400 Bad
-			// Request.
-			msg := err.Error()
-			if authErr.StatusCode == http.StatusUnauthorized {
-				msg = "The Apple Business Manager certificate or server token is invalid. Restart Fleet with a valid certificate and token. See https://fleetdm.com/learn-more-about/setup-abm for help."
-			}
-			return nil, ctxerr.Wrap(ctx, &fleet.BadRequestError{
-				Message:     msg,
-				InternalErr: err,
-			}, "apple GET /account request failed with authentication error")
-		}
-		return nil, ctxerr.Wrap(ctx, err, "apple GET /account request failed")
-	}
-
-	if res.AdminID == "" {
-		// fallback to facilitator ID, as this is the same information but for
-		// older versions of the Apple API.
-		// https://github.com/fleetdm/fleet/issues/7515#issuecomment-1346579398
-		res.AdminID = res.FacilitatorID
-	}
-	return &fleet.AppleBM{
-		AppleID: res.AdminID,
-		OrgName: res.OrgName,
-	}, nil
+	return &appleBM, nil
 }
 
 func (svc *Service) MDMAppleDeviceLock(ctx context.Context, hostID uint) error {

--- a/ee/server/service/mdm.go
+++ b/ee/server/service/mdm.go
@@ -49,6 +49,11 @@ func (svc *Service) GetAppleBM(ctx context.Context) (*fleet.AppleBM, error) {
 		return nil, err
 	}
 
+	// TODO: to be addressed in the ABM API implementation, this endpoint is now only
+	// supported if a single ABM token exists:
+	// https://github.com/fleetdm/fleet/pull/21043/files#r1706095564
+	// It has NOT been updated to the new abm tokens storage yet.
+
 	abmAssets, err := svc.ds.GetAllMDMConfigAssetsHashes(ctx, []fleet.MDMAssetName{
 		fleet.MDMAssetABMKey,
 		fleet.MDMAssetABMCert,
@@ -74,7 +79,7 @@ func (svc *Service) GetAppleBM(ctx context.Context) (*fleet.AppleBM, error) {
 		return nil, err
 	}
 
-	token, err := assets.ABMToken(ctx, svc.ds)
+	token, err := assets.ABMToken(ctx, svc.ds, appleBM.OrgName)
 	if err != nil {
 		return nil, err
 	}

--- a/server/datastore/mysql/migrations/tables/20240813103800_SupportMultipleABMTokens_test.go
+++ b/server/datastore/mysql/migrations/tables/20240813103800_SupportMultipleABMTokens_test.go
@@ -54,10 +54,10 @@ func TestUp_20240813103800(t *testing.T) {
 	}
 	var storedToken abmToken
 	err = db.Get(&storedToken, `
-SELECT 
-	id, organization_name, apple_id, terms_expired, renew_at, token, macos_default_team_id, ios_default_team_id, ipados_default_team_id 
-FROM 
-	abm_tokens 
+SELECT
+	id, organization_name, apple_id, terms_expired, renew_at, token, macos_default_team_id, ios_default_team_id, ipados_default_team_id
+FROM
+	abm_tokens
 LIMIT 1`)
 	require.NoError(t, err)
 
@@ -72,10 +72,8 @@ LIMIT 1`)
 	// all platform default teams are set to the configured team
 	require.NotNil(t, storedToken.MacOSDefaultTeamID)
 	require.EqualValues(t, tmID, *storedToken.MacOSDefaultTeamID)
-	require.NotNil(t, storedToken.IOSDefaultTeamID)
-	require.EqualValues(t, tmID, *storedToken.IOSDefaultTeamID)
-	require.NotNil(t, storedToken.IPadOSDefaultTeamID)
-	require.EqualValues(t, tmID, *storedToken.IPadOSDefaultTeamID)
+	require.Nil(t, storedToken.IOSDefaultTeamID)
+	require.Nil(t, storedToken.IPadOSDefaultTeamID)
 
 	// the existing host DEP assignment is linked to the token
 	var hostTokenID *uint

--- a/server/datastore/mysql/nanomdm_storage.go
+++ b/server/datastore/mysql/nanomdm_storage.go
@@ -158,6 +158,7 @@ type NanoDEPStorage struct {
 
 // RetrieveAuthTokens partially implements nanodep.AuthTokensRetriever.
 func (s *NanoDEPStorage) RetrieveAuthTokens(ctx context.Context, name string) (*nanodep_client.OAuth1Tokens, error) {
+	// TODO(mna): pass the name to ABMToken
 	token, err := assets.ABMToken(ctx, s.ds)
 	if err != nil {
 		return nil, fmt.Errorf("retrieving token in nano dep storage: %w", err)

--- a/server/datastore/mysql/nanomdm_storage.go
+++ b/server/datastore/mysql/nanomdm_storage.go
@@ -135,6 +135,10 @@ func (s *NanoMDMStorage) GetAllMDMConfigAssetsByName(ctx context.Context, assetN
 	return s.ds.GetAllMDMConfigAssetsByName(ctx, assetNames)
 }
 
+func (s *NanoMDMStorage) GetABMTokenByOrgName(ctx context.Context, orgName string) (*fleet.ABMToken, error) {
+	return s.ds.GetABMTokenByOrgName(ctx, orgName)
+}
+
 // NewMDMAppleDEPStorage returns a MySQL nanodep storage that uses the Datastore
 // underlying MySQL writer *sql.DB.
 func (ds *Datastore) NewMDMAppleDEPStorage() (*NanoDEPStorage, error) {
@@ -158,8 +162,7 @@ type NanoDEPStorage struct {
 
 // RetrieveAuthTokens partially implements nanodep.AuthTokensRetriever.
 func (s *NanoDEPStorage) RetrieveAuthTokens(ctx context.Context, name string) (*nanodep_client.OAuth1Tokens, error) {
-	// TODO(mna): pass the name to ABMToken
-	token, err := assets.ABMToken(ctx, s.ds)
+	token, err := assets.ABMToken(ctx, s.ds, name)
 	if err != nil {
 		return nil, fmt.Errorf("retrieving token in nano dep storage: %w", err)
 	}

--- a/server/fleet/datastore.go
+++ b/server/fleet/datastore.go
@@ -1318,6 +1318,13 @@ type Datastore interface {
 	// generated ones.
 	ReplaceMDMConfigAssets(ctx context.Context, assets []MDMConfigAsset) error
 
+	// GetABMTokenByOrgName retrieves the Apple Business Manager token identified by
+	// its unique name (the organization name).
+	GetABMTokenByOrgName(ctx context.Context, orgName string) (*ABMToken, error)
+
+	// SaveABMToken updates the ABM token using the provided struct.
+	SaveABMToken(ctx context.Context, tok *ABMToken) error
+
 	///////////////////////////////////////////////////////////////////////////////
 	// Microsoft MDM
 
@@ -1615,6 +1622,7 @@ type MDMAppleStore interface {
 
 type MDMAssetRetriever interface {
 	GetAllMDMConfigAssetsByName(ctx context.Context, assetNames []MDMAssetName) (map[MDMAssetName]MDMConfigAsset, error)
+	// TODO(mna): add GetABMTokenByName here
 }
 
 // Cloner represents any type that can clone itself. Used for the cached_mysql

--- a/server/fleet/datastore.go
+++ b/server/fleet/datastore.go
@@ -1622,7 +1622,7 @@ type MDMAppleStore interface {
 
 type MDMAssetRetriever interface {
 	GetAllMDMConfigAssetsByName(ctx context.Context, assetNames []MDMAssetName) (map[MDMAssetName]MDMConfigAsset, error)
-	// TODO(mna): add GetABMTokenByName here
+	GetABMTokenByOrgName(ctx context.Context, orgName string) (*ABMToken, error)
 }
 
 // Cloner represents any type that can clone itself. Used for the cached_mysql

--- a/server/fleet/mdm.go
+++ b/server/fleet/mdm.go
@@ -43,6 +43,32 @@ func (a AppleBM) AuthzType() string {
 	return "mdm_apple"
 }
 
+// TODO: during API implementation, remove AppleBM above or reconciliate those
+// two types. We'll likely need a new authz type for the ABM token.
+type ABMToken struct {
+	ID                  uint      `db:"id" json:"id"`
+	AppleID             string    `db:"apple_id" json:"apple_id"`
+	OrganizationName    string    `db:"organization_name" json:"org_name"`
+	RenewAt             time.Time `db:"renew_at" json:"renew_date"`
+	TermsExpired        bool      `db:"terms_expired" json:"terms_expired"`
+	MacOSDefaultTeamID  *uint     `db:"macos_default_team_id" json:"-"`
+	IOSDefaultTeamID    *uint     `db:"ios_default_team_id" json:"-"`
+	IPadOSDefaultTeamID *uint     `db:"ipados_default_team_id" json:"-"`
+	EncryptedToken      []byte    `db:"token" json:"-"`
+
+	// MDMServerURL is not a database field, it is computed from the AppConfig's
+	// Server URL and the static path to the MDM endpoint (using
+	// apple_mdm.ResolveAppleMDMURL).
+	MDMServerURL string `db:"-" json:"mdm_server_url"`
+
+	// the following fields are not in the abm_tokens table, they must be queried
+	// by a LEFT JOIN on the corresponding team, coalesced to an empty string if
+	// null (no team).
+	MacOSTeam  string `db:"macos_team" json:"macos_team"`
+	IOSTeam    string `db:"ios_team" json:"ios_team"`
+	IPadOSTeam string `db:"ipados_team" json:"ipados_team"`
+}
+
 type AppleCSR struct {
 	// NOTE: []byte automatically JSON-encodes as a base64-encoded string
 	APNsKey  []byte `json:"apns_key"`

--- a/server/mdm/apple/apple_bm.go
+++ b/server/mdm/apple/apple_bm.go
@@ -1,0 +1,63 @@
+package apple_mdm
+
+import (
+	"context"
+	"errors"
+	"net/http"
+
+	"github.com/fleetdm/fleet/v4/server/contexts/ctxerr"
+	"github.com/fleetdm/fleet/v4/server/fleet"
+	"github.com/fleetdm/fleet/v4/server/mdm/assets"
+	depclient "github.com/fleetdm/fleet/v4/server/mdm/nanodep/client"
+	"github.com/fleetdm/fleet/v4/server/mdm/nanodep/storage"
+	kitlog "github.com/go-kit/log"
+)
+
+// SetABMTokenMetadata uses the provided ABM token to fetch the associated
+// metadata and use it to update the rest of the abmToken fields (org name,
+// apple ID, renew date). It only sets the data on the struct, it does not
+// save it in the DB.
+func SetABMTokenMetadata(
+	ctx context.Context,
+	abmToken *fleet.ABMToken,
+	depStorage storage.AllDEPStorage,
+	ds fleet.Datastore,
+	logger kitlog.Logger) error {
+
+	decryptedToken, err := assets.ABMToken(ctx, ds, abmToken.OrganizationName)
+	if err != nil {
+		return err
+	}
+
+	depClient := NewDEPClient(depStorage, ds, logger)
+	res, err := depClient.AccountDetail(ctx, abmToken.OrganizationName)
+	if err != nil {
+		var authErr *depclient.AuthError
+		if errors.As(err, &authErr) {
+			// authentication failure with 401 unauthorized means that the configured
+			// Apple BM certificate and/or token are invalid. Fail with a 400 Bad
+			// Request.
+			msg := err.Error()
+			if authErr.StatusCode == http.StatusUnauthorized {
+				msg = "The Apple Business Manager certificate or server token is invalid. Restart Fleet with a valid certificate and token. See https://fleetdm.com/learn-more-about/setup-abm for help."
+			}
+			return ctxerr.Wrap(ctx, &fleet.BadRequestError{
+				Message:     msg,
+				InternalErr: err,
+			}, "apple GET /account request failed with authentication error")
+		}
+		return ctxerr.Wrap(ctx, err, "apple GET /account request failed")
+	}
+
+	if res.AdminID == "" {
+		// fallback to facilitator ID, as this is the same information but for
+		// older versions of the Apple API.
+		// https://github.com/fleetdm/fleet/issues/7515#issuecomment-1346579398
+		res.AdminID = res.FacilitatorID
+	}
+
+	abmToken.OrganizationName = res.OrgName
+	abmToken.AppleID = res.AdminID
+	abmToken.RenewAt = decryptedToken.AccessTokenExpiry
+	return nil
+}

--- a/server/mdm/assets/assets.go
+++ b/server/mdm/assets/assets.go
@@ -73,6 +73,7 @@ func APNSTopic(ctx context.Context, ds fleet.MDMAssetRetriever) (string, error) 
 }
 
 func ABMToken(ctx context.Context, ds fleet.MDMAssetRetriever) (*nanodep_client.OAuth1Tokens, error) {
+	// TODO(mna): add name argument, passed by RetrieveToken
 	assets, err := ds.GetAllMDMConfigAssetsByName(ctx, []fleet.MDMAssetName{
 		fleet.MDMAssetABMKey,
 		fleet.MDMAssetABMCert,

--- a/server/mdm/assets/assets.go
+++ b/server/mdm/assets/assets.go
@@ -72,8 +72,7 @@ func APNSTopic(ctx context.Context, ds fleet.MDMAssetRetriever) (string, error) 
 	return mdmPushCertTopic, nil
 }
 
-func ABMToken(ctx context.Context, ds fleet.MDMAssetRetriever) (*nanodep_client.OAuth1Tokens, error) {
-	// TODO(mna): add name argument, passed by RetrieveToken
+func ABMToken(ctx context.Context, ds fleet.MDMAssetRetriever, abmOrgName string) (*nanodep_client.OAuth1Tokens, error) {
 	assets, err := ds.GetAllMDMConfigAssetsByName(ctx, []fleet.MDMAssetName{
 		fleet.MDMAssetABMKey,
 		fleet.MDMAssetABMCert,
@@ -82,6 +81,15 @@ func ABMToken(ctx context.Context, ds fleet.MDMAssetRetriever) (*nanodep_client.
 	if err != nil {
 		return nil, fmt.Errorf("loading ABM assets from the database: %w", err)
 	}
+
+	// TODO(mna): this is what it should now use, but if I change it immediately,
+	// everything else breaks. This should be changed only after the ABM API work
+	// (and then fleet.MDMAssetABMTokenDeprecated will have to be removed from
+	// the call to GetAllMDMConfigAssetsByName above).
+	//abmTok, err := ds.GetABMTokenByOrgName(ctx, abmOrgName)
+	//if err != nil {
+	//	return nil, fmt.Errorf("get ABM token by name: %w", err)
+	//}
 
 	cert, err := tls.X509KeyPair(assets[fleet.MDMAssetABMCert].Value, assets[fleet.MDMAssetABMKey].Value)
 	if err != nil {
@@ -94,7 +102,7 @@ func ABMToken(ctx context.Context, ds fleet.MDMAssetRetriever) (*nanodep_client.
 	}
 
 	return DecryptRawABMToken(
-		assets[fleet.MDMAssetABMTokenDeprecated].Value,
+		assets[fleet.MDMAssetABMTokenDeprecated].Value, //abmTok.EncryptedToken,
 		leaf,
 		assets[fleet.MDMAssetABMKey].Value,
 	)

--- a/server/mdm/assets/assets_test.go
+++ b/server/mdm/assets/assets_test.go
@@ -185,30 +185,33 @@ func TestABMToken(t *testing.T) {
 			"\r\n%s", base64.StdEncoding.EncodeToString(encryptedToken))
 
 	assets := map[fleet.MDMAssetName]fleet.MDMConfigAsset{
-		fleet.MDMAssetABMCert: {Value: certPEM},
-		fleet.MDMAssetABMKey:  {Value: keyPEM},
+		fleet.MDMAssetABMCert:            {Value: certPEM},
+		fleet.MDMAssetABMKey:             {Value: keyPEM},
+		fleet.MDMAssetABMTokenDeprecated: {Value: []byte(tokenBytes)},
 	}
 	ds.GetAllMDMConfigAssetsByNameFunc = func(ctx context.Context, assetNames []fleet.MDMAssetName) (map[fleet.MDMAssetName]fleet.MDMConfigAsset, error) {
 		require.ElementsMatch(t, []fleet.MDMAssetName{
 			fleet.MDMAssetABMCert,
 			fleet.MDMAssetABMKey,
+			fleet.MDMAssetABMTokenDeprecated,
 		}, assetNames)
 		return assets, nil
 	}
 	const testOrgName = "test-org"
-	ds.GetABMTokenByOrgNameFunc = func(ctx context.Context, orgName string) (*fleet.ABMToken, error) {
-		require.Equal(t, testOrgName, orgName)
-		return &fleet.ABMToken{
-			ID:               1,
-			OrganizationName: testOrgName,
-			EncryptedToken:   []byte(tokenBytes),
-		}, nil
-	}
+	// TODO: use this once we read from abm_tokens (and remove MDMAssetABMTokenDeprecated from the other call)
+	//ds.GetABMTokenByOrgNameFunc = func(ctx context.Context, orgName string) (*fleet.ABMToken, error) {
+	//	require.Equal(t, testOrgName, orgName)
+	//	return &fleet.ABMToken{
+	//		ID:               1,
+	//		OrganizationName: testOrgName,
+	//		EncryptedToken:   []byte(tokenBytes),
+	//	}, nil
+	//}
 
 	tokens, err := ABMToken(ctx, ds, testOrgName)
 	require.NoError(t, err)
 	require.NotNil(t, tokens)
 	require.Equal(t, "test_access_secret", tokens.AccessSecret)
 	require.True(t, ds.GetAllMDMConfigAssetsByNameFuncInvoked)
-	require.True(t, ds.GetABMTokenByOrgNameFuncInvoked)
+	//require.True(t, ds.GetABMTokenByOrgNameFuncInvoked)
 }

--- a/server/mdm/assets/assets_test.go
+++ b/server/mdm/assets/assets_test.go
@@ -185,22 +185,30 @@ func TestABMToken(t *testing.T) {
 			"\r\n%s", base64.StdEncoding.EncodeToString(encryptedToken))
 
 	assets := map[fleet.MDMAssetName]fleet.MDMConfigAsset{
-		fleet.MDMAssetABMCert:            {Value: certPEM},
-		fleet.MDMAssetABMKey:             {Value: keyPEM},
-		fleet.MDMAssetABMTokenDeprecated: {Value: []byte(tokenBytes)},
+		fleet.MDMAssetABMCert: {Value: certPEM},
+		fleet.MDMAssetABMKey:  {Value: keyPEM},
 	}
 	ds.GetAllMDMConfigAssetsByNameFunc = func(ctx context.Context, assetNames []fleet.MDMAssetName) (map[fleet.MDMAssetName]fleet.MDMConfigAsset, error) {
 		require.ElementsMatch(t, []fleet.MDMAssetName{
 			fleet.MDMAssetABMCert,
 			fleet.MDMAssetABMKey,
-			fleet.MDMAssetABMTokenDeprecated,
 		}, assetNames)
 		return assets, nil
 	}
+	const testOrgName = "test-org"
+	ds.GetABMTokenByOrgNameFunc = func(ctx context.Context, orgName string) (*fleet.ABMToken, error) {
+		require.Equal(t, testOrgName, orgName)
+		return &fleet.ABMToken{
+			ID:               1,
+			OrganizationName: testOrgName,
+			EncryptedToken:   []byte(tokenBytes),
+		}, nil
+	}
 
-	tokens, err := ABMToken(ctx, ds)
+	tokens, err := ABMToken(ctx, ds, testOrgName)
 	require.NoError(t, err)
 	require.NotNil(t, tokens)
 	require.Equal(t, "test_access_secret", tokens.AccessSecret)
 	require.True(t, ds.GetAllMDMConfigAssetsByNameFuncInvoked)
+	require.True(t, ds.GetABMTokenByOrgNameFuncInvoked)
 }

--- a/server/mock/datastore_mock.go
+++ b/server/mock/datastore_mock.go
@@ -860,6 +860,10 @@ type DeleteMDMConfigAssetsByNameFunc func(ctx context.Context, assetNames []flee
 
 type ReplaceMDMConfigAssetsFunc func(ctx context.Context, assets []fleet.MDMConfigAsset) error
 
+type GetABMTokenByOrgNameFunc func(ctx context.Context, orgName string) (*fleet.ABMToken, error)
+
+type SaveABMTokenFunc func(ctx context.Context, tok *fleet.ABMToken) error
+
 type WSTEPStoreCertificateFunc func(ctx context.Context, name string, crt *x509.Certificate) error
 
 type WSTEPNewSerialFunc func(ctx context.Context) (*big.Int, error)
@@ -2274,6 +2278,12 @@ type DataStore struct {
 
 	ReplaceMDMConfigAssetsFunc        ReplaceMDMConfigAssetsFunc
 	ReplaceMDMConfigAssetsFuncInvoked bool
+
+	GetABMTokenByOrgNameFunc        GetABMTokenByOrgNameFunc
+	GetABMTokenByOrgNameFuncInvoked bool
+
+	SaveABMTokenFunc        SaveABMTokenFunc
+	SaveABMTokenFuncInvoked bool
 
 	WSTEPStoreCertificateFunc        WSTEPStoreCertificateFunc
 	WSTEPStoreCertificateFuncInvoked bool
@@ -5447,6 +5457,20 @@ func (s *DataStore) ReplaceMDMConfigAssets(ctx context.Context, assets []fleet.M
 	s.ReplaceMDMConfigAssetsFuncInvoked = true
 	s.mu.Unlock()
 	return s.ReplaceMDMConfigAssetsFunc(ctx, assets)
+}
+
+func (s *DataStore) GetABMTokenByOrgName(ctx context.Context, orgName string) (*fleet.ABMToken, error) {
+	s.mu.Lock()
+	s.GetABMTokenByOrgNameFuncInvoked = true
+	s.mu.Unlock()
+	return s.GetABMTokenByOrgNameFunc(ctx, orgName)
+}
+
+func (s *DataStore) SaveABMToken(ctx context.Context, tok *fleet.ABMToken) error {
+	s.mu.Lock()
+	s.SaveABMTokenFuncInvoked = true
+	s.mu.Unlock()
+	return s.SaveABMTokenFunc(ctx, tok)
 }
 
 func (s *DataStore) WSTEPStoreCertificate(ctx context.Context, name string, crt *x509.Certificate) error {

--- a/server/mock/mdm/datastore_mdm_mock.go
+++ b/server/mock/mdm/datastore_mdm_mock.go
@@ -56,6 +56,8 @@ type RetrieveTokenUpdateTallyFunc func(ctx context.Context, id string) (int, err
 
 type GetAllMDMConfigAssetsByNameFunc func(ctx context.Context, assetNames []fleet.MDMAssetName) (map[fleet.MDMAssetName]fleet.MDMConfigAsset, error)
 
+type GetABMTokenByOrgNameFunc func(ctx context.Context, orgName string) (*fleet.ABMToken, error)
+
 type EnqueueDeviceLockCommandFunc func(ctx context.Context, host *fleet.Host, cmd *mdm.Command, pin string) error
 
 type EnqueueDeviceWipeCommandFunc func(ctx context.Context, host *fleet.Host, cmd *mdm.Command) error
@@ -123,6 +125,9 @@ type MDMAppleStore struct {
 
 	GetAllMDMConfigAssetsByNameFunc        GetAllMDMConfigAssetsByNameFunc
 	GetAllMDMConfigAssetsByNameFuncInvoked bool
+
+	GetABMTokenByOrgNameFunc        GetABMTokenByOrgNameFunc
+	GetABMTokenByOrgNameFuncInvoked bool
 
 	EnqueueDeviceLockCommandFunc        EnqueueDeviceLockCommandFunc
 	EnqueueDeviceLockCommandFuncInvoked bool
@@ -278,6 +283,13 @@ func (fs *MDMAppleStore) GetAllMDMConfigAssetsByName(ctx context.Context, assetN
 	fs.GetAllMDMConfigAssetsByNameFuncInvoked = true
 	fs.mu.Unlock()
 	return fs.GetAllMDMConfigAssetsByNameFunc(ctx, assetNames)
+}
+
+func (fs *MDMAppleStore) GetABMTokenByOrgName(ctx context.Context, orgName string) (*fleet.ABMToken, error) {
+	fs.mu.Lock()
+	fs.GetABMTokenByOrgNameFuncInvoked = true
+	fs.mu.Unlock()
+	return fs.GetABMTokenByOrgNameFunc(ctx, orgName)
 }
 
 func (fs *MDMAppleStore) EnqueueDeviceLockCommand(ctx context.Context, host *fleet.Host, cmd *mdm.Command, pin string) error {


### PR DESCRIPTION
#21176 

This partially implements what was discussed here: https://github.com/fleetdm/fleet/pull/21287#discussion_r1715891448

I say it only "partially" implements it because to finalize the implementation, many other changes related to reading the token from `abm_tokens` would be required and would bust the scope of the DB changes ticket. What I'll do instead is create a cleanup/finalization ticket to remember to come back to it.

# Checklist for submitter

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
