### PR TITLE
Use `edge` channels in "Compliance exclusions" team

### DIFF
--- a/it-and-security/teams/compliance-exclusions.yml
+++ b/it-and-security/teams/compliance-exclusions.yml
@@ -9,7 +9,24 @@ team_settings:
   secrets:
     - secret: $DOGFOOD_COMPLIANCE_EXCLUSIONS_ENROLL_SECRET
 agent_options:
-  path: ../lib/agent-options.yml
+  config:
+    decorators:
+      load:
+        - SELECT uuid AS host_uuid FROM system_info;
+        - SELECT hostname AS hostname FROM system_info;
+    options:
+      disable_distributed: false
+      distributed_interval: 10
+      distributed_plugin: tls
+      distributed_tls_max_attempts: 3
+      logger_tls_endpoint: /api/osquery/log
+      logger_tls_period: 10
+      pack_delimiter: /
+  update_channels:
+    # We want to use these hosts to smoke test edge releases.
+    osqueryd: edge
+    orbit: edge
+    desktop: edge
 controls:
 policies:
 queries:


### PR DESCRIPTION
The more hosts dogfood the `edge` channels the better.