### PR TITLE
add windows configuration profiles to workstations canary

### DIFF
--- a/it-and-security/lib/configuration-profiles/windows-firewall.xml
+++ b/it-and-security/lib/configuration-profiles/windows-firewall.xml
@@ -1,0 +1,25 @@
+<Replace>
+  <!-- Enable firewall -->
+  <Item>
+    <Meta>
+      <Format xmlns="syncml:metinf">bool</Format>
+    </Meta>
+    <Target>
+      <LocURI>./Vendor/MSFT/Firewall/MdmStore/DomainProfile/EnableFirewall</LocURI>
+    </Target>
+    <Data>true</Data>
+  </Item>
+</Replace>
+<Replace>
+  <!-- Enable stealth mode -->
+  <Item>
+    <Meta>
+      <Format xmlns="syncml:metinf">bool</Format>
+    </Meta>
+    <Target>
+      <LocURI>./Vendor/MSFT/Firewall/MdmStore/DomainProfile/DisableStealthMode
+</LocURI>
+    </Target>
+    <Data>true</Data>
+  </Item>
+</Replace>

--- a/it-and-security/lib/configuration-profiles/windows-password.xml
+++ b/it-and-security/lib/configuration-profiles/windows-password.xml
@@ -1,0 +1,24 @@
+<Replace>
+  <!-- Enforce PIN or password length (10 characters) -->
+  <Item>
+    <Meta>
+      <Format xmlns="syncml:metinf">int</Format>
+    </Meta>
+    <Target>
+      <LocURI>./Device/Vendor/MSFT/Policy/Config/DeviceLock/MinDevicePasswordLength</LocURI>
+    </Target>
+    <Data>10</Data>
+  </Item>
+</Replace>
+<Replace>
+  <!-- Enforce PIN or password has at least one lowercase letter and at least one number -->
+  <Item>
+    <Meta>
+      <Format xmlns="syncml:metinf">int</Format>
+    </Meta>
+    <Target>
+      <LocURI>./Device/Vendor/MSFT/Policy/Config/DeviceLock/MinDevicePasswordComplexCharacters</LocURI>
+    </Target>
+    <Data>2</Data>
+  </Item>
+</Replace>

--- a/it-and-security/lib/configuration-profiles/windows-screen-lock.xml
+++ b/it-and-security/lib/configuration-profiles/windows-screen-lock.xml
@@ -1,0 +1,24 @@
+<Replace>
+  <!-- Enforce screenlock -->
+  <Item>
+    <Meta>
+      <Format xmlns="syncml:metinf">int</Format>
+    </Meta>
+    <Target>
+      <LocURI>./Device/Vendor/MSFT/Policy/Config/DeviceLock/DevicePasswordEnabled</LocURI>
+    </Target>
+    <Data>0</Data>
+  </Item>
+</Replace>
+<Replace>
+  <!-- Enforce screenlock after 15 minutes -->
+  <Item>
+    <Meta>
+      <Format xmlns="syncml:metinf">int</Format>
+    </Meta>
+    <Target>
+      <LocURI>./Device/Vendor/MSFT/Policy/Config/DeviceLock/MaxInactivityTimeDeviceLock</LocURI>
+    </Target>
+    <Data>15</Data>
+  </Item>
+</Replace>

--- a/it-and-security/teams/workstations-canary.yml
+++ b/it-and-security/teams/workstations-canary.yml
@@ -96,7 +96,10 @@ controls:
     deadline: "2024-08-23"
     minimum_version: "14.6.1"
   windows_settings:
-    custom_settings: null
+    custom_settings:
+      - path: ../lib/configuration-profiles/windows-firewall.xml
+      - path: ../lib/configuration-profiles/windows-password.xml
+      - path: ../lib/configuration-profiles/windows-screen-lock.xml
   windows_updates:
     deadline_days: 7
     grace_period_days: 2


### PR DESCRIPTION
Adding a few Windows configuration profiles so we can dogfood them. Most of the profiles are adaptations from the macOS profiles.

I'm not an expert, adding them to the canary team for now to avoid breaking anyone's machine.