### PR TITLE
notify #help-engineering when a dogfood deploy is in progress

### DIFF
--- a/.github/workflows/dogfood-deploy.yml
+++ b/.github/workflows/dogfood-deploy.yml
@@ -77,6 +77,26 @@ jobs:
         id: plan
         run: terraform plan -no-color
         continue-on-error: true
+      - name: Slack Notification
+        if: success()
+        uses: slackapi/slack-github-action@e28cf165c92ffef168d23c5c9000cffc8a25e117 # v1.24.0
+        with:
+          payload: |
+            {
+              "text": "${{ job.status }}\n${{ github.event.pull_request.html_url || github.event.head.html_url }}",
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "🚀 🛠️ Dogfood deploy in progress\nhttps://github.com/fleetdm/fleet/actions/runs/${{  github.run_id }}"
+                  }
+                }
+              ]
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_G_HELP_ENGINEERING_WEBHOOK_URL }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
         # first we'll scale everything down and create the new task definitions
       - name: Terraform Apply
         id: apply

--- a/.github/workflows/test-go.yaml
+++ b/.github/workflows/test-go.yaml
@@ -156,10 +156,6 @@ jobs:
         fi
         GO_FAIL_SUMMARY=$GO_FAIL_SUMMARY envsubst < .github/workflows/config/slack_payload_template.json > ./payload.json
 
-    # TODO: figure out a sane way to combine outputs from different matrix jobs
-    # into a single slack notification, instead of sending one per job. This
-    # problem already existed but now it's accentuated because we're running 4
-    # jobs.
     - name: Slack Notification
       if: github.event.schedule == '0 4 * * *' && failure()
       uses: slackapi/slack-github-action@e28cf165c92ffef168d23c5c9000cffc8a25e117 # v1.24.0


### PR DESCRIPTION
This ensures `#help-engineering` is notified when a dogfood deploy is in progress. It helps set people's expectations about what's going on while the server is temporarily down. 