### PR TITLE
Update job-migration.yaml

### DIFF
--- a/charts/fleet/templates/job-migration.yaml
+++ b/charts/fleet/templates/job-migration.yaml
@@ -18,6 +18,7 @@ metadata:
     "helm.sh/hook-delete-policy": hook-succeeded
     {{- end }}
 spec:
+  ttlSecondsAfterFinished: 100
   template:
     metadata:
 {{- with .Values.podAnnotations }}


### PR DESCRIPTION
Adding ttl so the job will clean itself up after success so a helm upgrade doesn't require `kubectl delete job fleet-migration` before continuing.