### PR TITLE
"Compare all features" >>> "View all features" on the device management land page

### DIFF
--- a/website/views/pages/device-management.ejs
+++ b/website/views/pages/device-management.ejs
@@ -412,7 +412,7 @@
           </div>
         </div>
 
-        <animated-arrow-button class="mx-auto" href="/pricing">Compare all features</animated-arrow-button>
+        <animated-arrow-button class="mx-auto" href="/pricing">View all features</animated-arrow-button>
       </div>
       <%/* Shorten the feedback loop section */%>
       <div purpose="page-section">


### PR DESCRIPTION
Closes https://github.com/fleetdm/confidential/issues/7685

I changed "Compare all features" to "View all features." The current "Compare all features" language suggests that the user can continue to a large list of feature comparisons between Fleet, Omnissa, and Jamf Pro which is not the case.

