### PR TITLE
Add activity item for disabled/edited webhook

### DIFF
--- a/changes/21368-add-activity-item-webhook
+++ b/changes/21368-add-activity-item-webhook
@@ -1,1 +1,1 @@
-- Generate activities when a user turns on/off the activities webhook.
+- Generate activities when a user turns off the activities webhook or modify the destination url.

--- a/changes/21368-add-activity-item-webhook
+++ b/changes/21368-add-activity-item-webhook
@@ -1,0 +1,1 @@
+- Generate activities when a user turns on/off the activities webhook.

--- a/docs/Contributing/Audit-logs.md
+++ b/docs/Contributing/Audit-logs.md
@@ -1301,6 +1301,18 @@ This activity contains the following fields:
 }
 ```
 
+## enabled_activities_webhook
+
+Generated when a user turns on the activities webhook.
+
+This activity does not contain any detail fields.
+
+## disabled_activities_webhook
+
+Generated when a user turns off the activities webhook.
+
+This activity does not contain any detail fields.
+
 
 <meta name="title" value="Audit logs">
 <meta name="pageOrderInSection" value="1400">

--- a/docs/Contributing/Audit-logs.md
+++ b/docs/Contributing/Audit-logs.md
@@ -1301,17 +1301,26 @@ This activity contains the following fields:
 }
 ```
 
-## enabled_activities_webhook
-
-Generated when a user turns on the activities webhook.
-
-This activity does not contain any detail fields.
-
 ## disabled_activities_webhook
 
 Generated when a user turns off the activities webhook.
 
 This activity does not contain any detail fields.
+
+## edited_activities_webhook
+
+Generated when a user modify the activities webhook.
+
+This activity contains the following fields:
+- destionation_url: the current destionation URL.
+
+#### Example
+
+```json
+{
+  "destionation_url": "https://notify.fleet.example.com"
+}
+```
 
 
 <meta name="title" value="Audit logs">

--- a/server/fleet/activities.go
+++ b/server/fleet/activities.go
@@ -107,8 +107,8 @@ var ActivityDetailsList = []ActivityDetails{
 	ActivityDeletedAppStoreApp{},
 	ActivityInstalledAppStoreApp{},
 
-	ActivityTypeEnabledActivitiesWebhook{},
 	ActivityTypeDisabledActivitiesWebhook{},
+	ActivityTypeEditedActivitiesWebhook{},
 }
 
 type ActivityDetails interface {
@@ -1771,18 +1771,6 @@ func (a ActivityInstalledAppStoreApp) Documentation() (string, string, string) {
 }`
 }
 
-type ActivityTypeEnabledActivitiesWebhook struct {
-}
-
-func (a ActivityTypeEnabledActivitiesWebhook) ActivityName() string {
-	return "enabled_activities_webhook"
-}
-
-func (a ActivityTypeEnabledActivitiesWebhook) Documentation() (activity, details, detailsExample string) {
-	return `Generated when a user turns on the activities webhook.`,
-		`This activity does not contain any detail fields.`, ""
-}
-
 type ActivityTypeDisabledActivitiesWebhook struct {
 }
 
@@ -1793,4 +1781,19 @@ func (a ActivityTypeDisabledActivitiesWebhook) ActivityName() string {
 func (a ActivityTypeDisabledActivitiesWebhook) Documentation() (activity, details, detailsExample string) {
 	return `Generated when a user turns off the activities webhook.`,
 		`This activity does not contain any detail fields.`, ""
+}
+
+type ActivityTypeEditedActivitiesWebhook struct {
+	DestionationURL string `json:"destination_url"`
+}
+
+func (a ActivityTypeEditedActivitiesWebhook) ActivityName() string {
+	return "edited_activities_webhook"
+}
+
+func (a ActivityTypeEditedActivitiesWebhook) Documentation() (activity, details, detailsExample string) {
+	return `Generated when a user modify the activities webhook.`, `This activity contains the following fields:
+- destionation_url: the current destionation URL.`, `{
+  "destionation_url": "https://notify.fleet.example.com"
+}`
 }

--- a/server/fleet/activities.go
+++ b/server/fleet/activities.go
@@ -106,6 +106,9 @@ var ActivityDetailsList = []ActivityDetails{
 	ActivityAddedAppStoreApp{},
 	ActivityDeletedAppStoreApp{},
 	ActivityInstalledAppStoreApp{},
+
+	ActivityTypeEnabledActivitiesWebhook{},
+	ActivityTypeDisabledActivitiesWebhook{},
 }
 
 type ActivityDetails interface {
@@ -1766,4 +1769,28 @@ func (a ActivityInstalledAppStoreApp) Documentation() (string, string, string) {
   "app_store_id": "1234567",
   "command_uuid": "98765432-1234-1234-1234-1234567890ab"
 }`
+}
+
+type ActivityTypeEnabledActivitiesWebhook struct {
+}
+
+func (a ActivityTypeEnabledActivitiesWebhook) ActivityName() string {
+	return "enabled_activities_webhook"
+}
+
+func (a ActivityTypeEnabledActivitiesWebhook) Documentation() (activity, details, detailsExample string) {
+	return `Generated when a user turns on the activities webhook.`,
+		`This activity does not contain any detail fields.`, ""
+}
+
+type ActivityTypeDisabledActivitiesWebhook struct {
+}
+
+func (a ActivityTypeDisabledActivitiesWebhook) ActivityName() string {
+	return "disabled_activities_webhook"
+}
+
+func (a ActivityTypeDisabledActivitiesWebhook) Documentation() (activity, details, detailsExample string) {
+	return `Generated when a user turns off the activities webhook.`,
+		`This activity does not contain any detail fields.`, ""
 }

--- a/server/service/appconfig.go
+++ b/server/service/appconfig.go
@@ -417,6 +417,20 @@ func (svc *Service) ModifyAppConfig(ctx context.Context, p []byte, applyOpts fle
 		return nil, ctxerr.Wrap(ctx, invalid)
 	}
 
+	if appConfig.WebhookSettings.ActivitiesWebhook.Enable != oldAppConfig.WebhookSettings.ActivitiesWebhook.Enable {
+		if appConfig.WebhookSettings.ActivitiesWebhook.Enable {
+			act := fleet.ActivityTypeEnabledActivitiesWebhook{}
+			if err := svc.NewActivity(ctx, authz.UserFromContext(ctx), act); err != nil {
+				return nil, ctxerr.Wrap(ctx, err, "create activity for enabled webhook activities")
+			}
+		} else {
+			act := fleet.ActivityTypeDisabledActivitiesWebhook{}
+			if err := svc.NewActivity(ctx, authz.UserFromContext(ctx), act); err != nil {
+				return nil, ctxerr.Wrap(ctx, err, "create activity for disabled webhook activities")
+			}
+		}
+	}
+
 	// ignore MDM.EnabledAndConfigured MDM.AppleBMTermsExpired, and MDM.AppleBMEnabledAndConfigured
 	// if provided in the modify payload we don't return an error in this case because it would
 	// prevent using the output of fleetctl get config as input to fleetctl apply or this endpoint.

--- a/server/service/appconfig.go
+++ b/server/service/appconfig.go
@@ -417,17 +417,19 @@ func (svc *Service) ModifyAppConfig(ctx context.Context, p []byte, applyOpts fle
 		return nil, ctxerr.Wrap(ctx, invalid)
 	}
 
-	if appConfig.WebhookSettings.ActivitiesWebhook.Enable != oldAppConfig.WebhookSettings.ActivitiesWebhook.Enable {
-		if appConfig.WebhookSettings.ActivitiesWebhook.Enable {
-			act := fleet.ActivityTypeEnabledActivitiesWebhook{}
-			if err := svc.NewActivity(ctx, authz.UserFromContext(ctx), act); err != nil {
-				return nil, ctxerr.Wrap(ctx, err, "create activity for enabled webhook activities")
-			}
-		} else {
-			act := fleet.ActivityTypeDisabledActivitiesWebhook{}
-			if err := svc.NewActivity(ctx, authz.UserFromContext(ctx), act); err != nil {
-				return nil, ctxerr.Wrap(ctx, err, "create activity for disabled webhook activities")
-			}
+	if !appConfig.WebhookSettings.ActivitiesWebhook.Enable && oldAppConfig.WebhookSettings.ActivitiesWebhook.Enable {
+		act := fleet.ActivityTypeDisabledActivitiesWebhook{}
+		if err := svc.NewActivity(ctx, authz.UserFromContext(ctx), act); err != nil {
+			return nil, ctxerr.Wrap(ctx, err, "create activity for disabled webhook activities")
+		}
+	}
+
+	if appConfig.WebhookSettings.ActivitiesWebhook.DestinationURL != oldAppConfig.WebhookSettings.ActivitiesWebhook.DestinationURL {
+		act := fleet.ActivityTypeEditedActivitiesWebhook{
+			DestionationURL: appConfig.WebhookSettings.ActivitiesWebhook.DestinationURL,
+		}
+		if err := svc.NewActivity(ctx, authz.UserFromContext(ctx), act); err != nil {
+			return nil, ctxerr.Wrap(ctx, err, "create activity for edited webhook activities")
 		}
 	}
 

--- a/server/service/integration_core_test.go
+++ b/server/service/integration_core_test.go
@@ -4731,10 +4731,6 @@ func (s *integrationTestSuite) TestActivitiesWebhookConfig() {
 		), http.StatusOK,
 	)
 
-	s.lastActivityOfTypeMatches(
-		fleet.ActivityTypeEnabledActivitiesWebhook{}.ActivityName(), "", 0,
-	)
-
 	appConfig := s.getConfig()
 	require.True(t, appConfig.WebhookSettings.ActivitiesWebhook.Enable)
 	require.Equal(t, "http://some/url", appConfig.WebhookSettings.ActivitiesWebhook.DestinationURL)
@@ -4774,6 +4770,12 @@ func (s *integrationTestSuite) TestHostStatusWebhookConfig() {
     		"interval": "1h"
   		}
 	}`), http.StatusUnprocessableEntity)
+
+	s.lastActivityOfTypeMatches(
+		fleet.ActivityTypeEditedActivitiesWebhook{}.ActivityName(),
+		`{"destination_url": ""}`,
+		0,
+	)
 
 	// update without a negative days count
 	s.DoRaw("PATCH", "/api/latest/fleet/config", []byte(`{

--- a/server/service/integration_core_test.go
+++ b/server/service/integration_core_test.go
@@ -4731,6 +4731,10 @@ func (s *integrationTestSuite) TestActivitiesWebhookConfig() {
 		), http.StatusOK,
 	)
 
+	s.lastActivityOfTypeMatches(
+		fleet.ActivityTypeEnabledActivitiesWebhook{}.ActivityName(), "", 0,
+	)
+
 	appConfig := s.getConfig()
 	require.True(t, appConfig.WebhookSettings.ActivitiesWebhook.Enable)
 	require.Equal(t, "http://some/url", appConfig.WebhookSettings.ActivitiesWebhook.DestinationURL)


### PR DESCRIPTION
This PR adds `enabled_activities_webhook`/`disabled_activities_webhook` activity types to trace activities webhook changes.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/Committing-Changes.md#changes-files) for more information.
- [ ] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [ ] Added support on fleet's osquery simulator `cmd/osquery-perf` for new osquery data ingestion features.
- [x] Added/updated tests
- [ ] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes
- [ ] If database migrations are included, checked table schema to confirm autoupdate
- For database migrations:
  - [ ] Checked schema for all modified table for columns that will auto-update timestamps during migration.
  - [ ] Confirmed that updating the timestamps is acceptable, and will not cause unwanted side effects.
  - [ ] Ensured the correct collation is explicitly set for character columns (`COLLATE utf8mb4_unicode_ci`).
- [ ] Manual QA for all new/changed functionality