### PR TITLE
fix issue with disk encryption banner

### DIFF
--- a/orbit/changes/21381-fv
+++ b/orbit/changes/21381-fv
@@ -1,0 +1,1 @@
+* Fixed an issue that would display a disk encryption modal with MDM configured and FileVault enabled if the user hadn't escrowed the key in the past.

--- a/orbit/cmd/orbit/orbit.go
+++ b/orbit/cmd/orbit/orbit.go
@@ -1223,7 +1223,12 @@ func main() {
 			if orbitClient.GetServerCapabilities().Has(fleet.CapabilityEscrowBuddy) {
 				orbitClient.RegisterConfigReceiver(update.NewEscrowBuddyRunner(updateRunner, 5*time.Minute))
 			} else {
-				orbitClient.RegisterConfigReceiver(update.ApplyDiskEncryptionRunnerMiddleware())
+				orbitClient.RegisterConfigReceiver(
+					update.ApplyDiskEncryptionRunnerMiddleware(
+						orbitClient.GetServerCapabilities,
+						orbitClient.TriggerOrbitRestart,
+					),
+				)
 			}
 		}
 

--- a/orbit/pkg/update/disk_encryption.go
+++ b/orbit/pkg/update/disk_encryption.go
@@ -40,6 +40,7 @@ func (d *DiskEncryptionRunner) Run(cfg *fleet.OrbitConfig) error {
 
 	if d.capabilitiesFetcher().Has(fleet.CapabilityEscrowBuddy) {
 		d.triggerOrbitRestart("server has Escrow Buddy capability but old disk encryption fetcher was running")
+		return nil
 	}
 
 	if cfg.Notifications.RotateDiskEncryptionKey && !d.isRunning.Swap(true) {

--- a/orbit/pkg/update/disk_encryption.go
+++ b/orbit/pkg/update/disk_encryption.go
@@ -1,6 +1,7 @@
 package update
 
 import (
+	"errors"
 	"sync/atomic"
 
 	"github.com/fleetdm/fleet/v4/orbit/pkg/useraction"
@@ -11,15 +12,35 @@ import (
 const maxRetries = 2
 
 type DiskEncryptionRunner struct {
-	isRunning atomic.Bool
+	isRunning           atomic.Bool
+	capabilitiesFetcher func() fleet.CapabilityMap
+	triggerOrbitRestart func(reason string)
 }
 
-func ApplyDiskEncryptionRunnerMiddleware() fleet.OrbitConfigReceiver {
-	return &DiskEncryptionRunner{}
+func ApplyDiskEncryptionRunnerMiddleware(
+	capabilitiesFetcher func() fleet.CapabilityMap,
+	triggerOrbitRestart func(reason string),
+) fleet.OrbitConfigReceiver {
+	return &DiskEncryptionRunner{
+		capabilitiesFetcher: capabilitiesFetcher,
+		triggerOrbitRestart: triggerOrbitRestart,
+	}
 }
 
 func (d *DiskEncryptionRunner) Run(cfg *fleet.OrbitConfig) error {
 	log.Debug().Msgf("running disk encryption fetcher middleware, notification: %v, isIdle: %v", cfg.Notifications.RotateDiskEncryptionKey, d.isRunning.Load())
+
+	if d.capabilitiesFetcher == nil {
+		return errors.New("disk encryption runner needs a capabilitites fetcher configured")
+	}
+
+	if d.triggerOrbitRestart == nil {
+		return errors.New("disk encryption runner needs a function to trigger orbit restarts configured")
+	}
+
+	if d.capabilitiesFetcher().Has(fleet.CapabilityEscrowBuddy) {
+		d.triggerOrbitRestart("server has Escrow Buddy capability but old disk encryption fetcher was running")
+	}
 
 	if cfg.Notifications.RotateDiskEncryptionKey && !d.isRunning.Swap(true) {
 		go func() {


### PR DESCRIPTION
for #21381

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/Committing-Changes.md#changes-files) for more information.
- [x] Manual QA for all new/changed functionality
- For Orbit and Fleet Desktop changes:
   - [x] Orbit runs on macOS, Linux and Windows. Check if the orbit feature/bugfix should only apply to one platform (`runtime.GOOS`).
   - [ ] Manual QA must be performed in the three main OSs, macOS, Windows and Linux.
   - [x] Auto-update manual QA, from released version of component to new version (see [tools/tuf/test](../tools/tuf/test/README.md)).
