### PR TITLE
17379 cache live queries

### DIFF
--- a/changes/17379-live-query-caching
+++ b/changes/17379-live-query-caching
@@ -1,1 +1,1 @@
-- increased performance of live queries to accomodate for higher volumes when utilizing zero trust workflows
+- Increased performance of live queries to accommodate for higher volumes when utilizing zero-trust workflows

--- a/changes/17379-live-query-caching
+++ b/changes/17379-live-query-caching
@@ -1,0 +1,1 @@
+- increased performance of live queries to accomodate for higher volumes when utilizing zero trust workflows

--- a/cmd/fleet/serve.go
+++ b/cmd/fleet/serve.go
@@ -76,6 +76,7 @@ import (
 var allowedURLPrefixRegexp = regexp.MustCompile("^(?:/[a-zA-Z0-9_.~-]+)+$")
 
 const softwareInstallerUploadTimeout = 4 * time.Minute
+const liveQueryMemCacheDuration = 1 * time.Second
 
 type initializer interface {
 	// Initialize is used to populate a datastore with
@@ -346,7 +347,7 @@ the way that the Fleet server works.
 			resultStore := pubsub.NewRedisQueryResults(redisPool, config.Redis.DuplicateResults,
 				log.With(logger, "component", "query-results"),
 			)
-			liveQueryStore := live_query.NewRedisLiveQuery(redisPool, logger, config.Redis.LiveQueryCacheExpiration)
+			liveQueryStore := live_query.NewRedisLiveQuery(redisPool, logger, liveQueryMemCacheDuration)
 			ssoSessionStore := sso.NewSessionStore(redisPool)
 
 			// Set common configuration for all logging.

--- a/cmd/fleet/serve.go
+++ b/cmd/fleet/serve.go
@@ -346,7 +346,7 @@ the way that the Fleet server works.
 			resultStore := pubsub.NewRedisQueryResults(redisPool, config.Redis.DuplicateResults,
 				log.With(logger, "component", "query-results"),
 			)
-			liveQueryStore := live_query.NewRedisLiveQuery(redisPool)
+			liveQueryStore := live_query.NewRedisLiveQuery(redisPool, logger)
 			ssoSessionStore := sso.NewSessionStore(redisPool)
 
 			// Set common configuration for all logging.

--- a/cmd/fleet/serve.go
+++ b/cmd/fleet/serve.go
@@ -346,7 +346,7 @@ the way that the Fleet server works.
 			resultStore := pubsub.NewRedisQueryResults(redisPool, config.Redis.DuplicateResults,
 				log.With(logger, "component", "query-results"),
 			)
-			liveQueryStore := live_query.NewRedisLiveQuery(redisPool, logger)
+			liveQueryStore := live_query.NewRedisLiveQuery(redisPool, logger, config.Redis.LiveQueryCacheExpiration)
 			ssoSessionStore := sso.NewSessionStore(redisPool)
 
 			// Set common configuration for all logging.

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -74,8 +74,6 @@ type RedisConfig struct {
 	ConnWaitTimeout time.Duration `yaml:"conn_wait_timeout"`
 	WriteTimeout    time.Duration `yaml:"write_timeout"`
 	ReadTimeout     time.Duration `yaml:"read_timeout"`
-	// Fleet Server in memory cache duration for live queries
-	LiveQueryCacheExpiration time.Duration `yaml:"live_query_cache_expiration"`
 }
 
 const (
@@ -973,7 +971,6 @@ func (man Manager) addConfigs() {
 	man.addConfigDuration("redis.conn_wait_timeout", 0, "Redis maximum amount of time to wait for a connection if the maximum is reached (0 for no wait)")
 	man.addConfigDuration("redis.write_timeout", 10*time.Second, "Redis maximum amount of time to wait for a write (send) on a connection")
 	man.addConfigDuration("redis.read_timeout", 10*time.Second, "Redis maximum amount of time to wait for a read (receive) on a connection")
-	man.addConfigDuration("redis.live_query_cache_expiration", 1*time.Second, "Time to cache Redis live query keys in memory")
 
 	// Server
 	man.addConfigString("server.address", "0.0.0.0:8080",
@@ -1394,7 +1391,6 @@ func (man Manager) LoadConfig() FleetConfig {
 			ConnWaitTimeout:           man.getConfigDuration("redis.conn_wait_timeout"),
 			WriteTimeout:              man.getConfigDuration("redis.write_timeout"),
 			ReadTimeout:               man.getConfigDuration("redis.read_timeout"),
-			LiveQueryCacheExpiration:  man.getConfigDuration("redis.live_query_cache_expiration"),
 		},
 		Server: ServerConfig{
 			Address:                     man.getConfigString("server.address"),

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -74,6 +74,8 @@ type RedisConfig struct {
 	ConnWaitTimeout time.Duration `yaml:"conn_wait_timeout"`
 	WriteTimeout    time.Duration `yaml:"write_timeout"`
 	ReadTimeout     time.Duration `yaml:"read_timeout"`
+	// Fleet Server in memory cache duration for live queries
+	LiveQueryCacheExpiration time.Duration `yaml:"live_query_cache_expiration"`
 }
 
 const (
@@ -971,6 +973,7 @@ func (man Manager) addConfigs() {
 	man.addConfigDuration("redis.conn_wait_timeout", 0, "Redis maximum amount of time to wait for a connection if the maximum is reached (0 for no wait)")
 	man.addConfigDuration("redis.write_timeout", 10*time.Second, "Redis maximum amount of time to wait for a write (send) on a connection")
 	man.addConfigDuration("redis.read_timeout", 10*time.Second, "Redis maximum amount of time to wait for a read (receive) on a connection")
+	man.addConfigDuration("redis.live_query_cache_expiration", 1*time.Second, "Time to cache Redis live query keys in memory")
 
 	// Server
 	man.addConfigString("server.address", "0.0.0.0:8080",
@@ -1391,6 +1394,7 @@ func (man Manager) LoadConfig() FleetConfig {
 			ConnWaitTimeout:           man.getConfigDuration("redis.conn_wait_timeout"),
 			WriteTimeout:              man.getConfigDuration("redis.write_timeout"),
 			ReadTimeout:               man.getConfigDuration("redis.read_timeout"),
+			LiveQueryCacheExpiration:  man.getConfigDuration("redis.live_query_cache_expiration"),
 		},
 		Server: ServerConfig{
 			Address:                     man.getConfigString("server.address"),

--- a/server/live_query/live_query_test.go
+++ b/server/live_query/live_query_test.go
@@ -134,11 +134,11 @@ func testLiveQueryOnlyExpired(t *testing.T, store fleet.LiveQueryStore) {
 	require.NoError(t, err)
 	assert.Len(t, queries, 0)
 
-	time.Sleep(2 * time.Second)
-
-	activeNames, err := redigo.Strings(conn.Do("SMEMBERS", activeQueriesKey))
-	require.NoError(t, err)
-	require.Len(t, activeNames, 0)
+	assert.Eventually(t, func() bool {
+		activeNames, err := redigo.Strings(conn.Do("SMEMBERS", activeQueriesKey))
+		require.NoError(t, err)
+		return len(activeNames) == 0
+	}, 5*time.Second, 100*time.Millisecond)
 }
 
 func testLiveQueryCleanupInactive(t *testing.T, store fleet.LiveQueryStore) {

--- a/server/live_query/live_query_test.go
+++ b/server/live_query/live_query_test.go
@@ -131,6 +131,7 @@ func testLiveQueryOnlyExpired(t *testing.T, store fleet.LiveQueryStore) {
 
 	queries, err := store.QueriesForHost(1)
 	require.NoError(t, err)
+	t.Log("queries for host 1:", queries)
 	assert.Len(t, queries, 0)
 
 	activeNames, err := redigo.Strings(conn.Do("SMEMBERS", activeQueriesKey))

--- a/server/live_query/live_query_test.go
+++ b/server/live_query/live_query_test.go
@@ -131,7 +131,6 @@ func testLiveQueryOnlyExpired(t *testing.T, store fleet.LiveQueryStore) {
 
 	queries, err := store.QueriesForHost(1)
 	require.NoError(t, err)
-	t.Log("queries for host 1:", queries)
 	assert.Len(t, queries, 0)
 
 	activeNames, err := redigo.Strings(conn.Do("SMEMBERS", activeQueriesKey))

--- a/server/live_query/live_query_test.go
+++ b/server/live_query/live_query_test.go
@@ -3,6 +3,7 @@ package live_query
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/fleetdm/fleet/v4/server/datastore/redis"
 	"github.com/fleetdm/fleet/v4/server/fleet"
@@ -132,6 +133,8 @@ func testLiveQueryOnlyExpired(t *testing.T, store fleet.LiveQueryStore) {
 	queries, err := store.QueriesForHost(1)
 	require.NoError(t, err)
 	assert.Len(t, queries, 0)
+
+	time.Sleep(2 * time.Second)
 
 	activeNames, err := redigo.Strings(conn.Do("SMEMBERS", activeQueriesKey))
 	require.NoError(t, err)

--- a/server/live_query/redis_live_query.go
+++ b/server/live_query/redis_live_query.go
@@ -174,12 +174,13 @@ func (r *redisLiveQuery) QueriesForHost(hostID uint) (map[string]string, error) 
 	}
 
 	// convert the query name (campaign id) to the key name
-	for i, name := range names {
+	keyNames := make([]string, len(names))
+	for _, name := range names {
 		tkey, _ := generateKeys(name)
-		names[i] = tkey
+		keyNames = append(keyNames, tkey)
 	}
 
-	keysBySlot := redis.SplitKeysBySlot(r.pool, names...)
+	keysBySlot := redis.SplitKeysBySlot(r.pool, keyNames...)
 	queries := make(map[string]string)
 	for _, qkeys := range keysBySlot {
 		if err := r.collectBatchQueriesForHost(hostID, qkeys, queries); err != nil {

--- a/server/live_query/redis_live_query.go
+++ b/server/live_query/redis_live_query.go
@@ -339,7 +339,7 @@ func (r *redisLiveQuery) LoadActiveQueryNames() ([]string, error) {
 func (r *redisLiveQuery) loadCache() (memCache, error) {
 	expiredQueries := make(map[string]struct{})
 	sqlCache := make(map[string]string)
-	conn := redis.ConfigureDoer(r.pool, r.pool.Get())
+	conn := redis.ReadOnlyConn(r.pool, r.pool.Get())
 	defer conn.Close()
 
 	names, err := redigo.Strings(conn.Do("SMEMBERS", activeQueriesKey))

--- a/server/live_query/redis_live_query.go
+++ b/server/live_query/redis_live_query.go
@@ -394,8 +394,10 @@ func (r *redisLiveQuery) loadCache() (memCache, error) {
 			}
 
 			go func() {
+				fmt.Println("Cleaning up expired queries", names)
 				err = r.removeQueryNames(names...)
 				if err != nil {
+					fmt.Printf("Error removing expired queries: %v\n", err)
 					level.Warn(r.logger).Log("msg", "removing expired live queries", "err", err)
 				}
 			}()

--- a/server/live_query/redis_live_query.go
+++ b/server/live_query/redis_live_query.go
@@ -73,12 +73,16 @@ type redisLiveQuery struct {
 	// connection pool
 	pool fleet.RedisPool
 	// in memory cache
-	cache           memCache
+	cache memCache
+	// in memory cache expiration
 	cacheExpiration time.Duration
 
 	logger kitlog.Logger
 }
 
+// memCache is an in-memory cache for live queries. It stores the SQL of the
+// queries and the active queries set. It also stores the expiration time of the
+// cache.
 type memCache struct {
 	sqlCache           map[string]string
 	activeQueriesCache []string
@@ -86,12 +90,15 @@ type memCache struct {
 	mu                 sync.RWMutex
 }
 
+// cacheIsExpired is a thread-safe method to check if the cache is expired.
 func (r *redisLiveQuery) cacheIsExpired() bool {
 	r.cache.mu.RLock()
 	defer r.cache.mu.RUnlock()
 	return r.cache.cacheExp.Before(time.Now())
 }
 
+// getSQLByCampaignID is a thread-safe method to get the SQL of a live query by its
+// campaign ID.
 func (r *redisLiveQuery) getSQLByCampaignID(campaignID string) (string, bool) {
 	r.cache.mu.RLock()
 	defer r.cache.mu.RUnlock()

--- a/server/live_query/redis_live_query.go
+++ b/server/live_query/redis_live_query.go
@@ -339,13 +339,16 @@ func (r *redisLiveQuery) LoadActiveQueryNames() ([]string, error) {
 func (r *redisLiveQuery) loadCache() (memCache, error) {
 	expiredQueries := make(map[string]struct{})
 	sqlCache := make(map[string]string)
-	conn := redis.ReadOnlyConn(r.pool, r.pool.Get())
+	conn := redis.ConfigureDoer(r.pool, r.pool.Get())
 	defer conn.Close()
 
 	names, err := redigo.Strings(conn.Do("SMEMBERS", activeQueriesKey))
 	if err != nil {
 		return memCache{}, fmt.Errorf("get active queries: %w", err)
 	}
+
+	conn = redis.ReadOnlyConn(r.pool, r.pool.Get())
+	defer conn.Close()
 
 	for _, name := range names {
 		_, sqlKey := generateKeys(name)

--- a/server/live_query/redis_live_query.go
+++ b/server/live_query/redis_live_query.go
@@ -394,10 +394,8 @@ func (r *redisLiveQuery) loadCache() (memCache, error) {
 			}
 
 			go func() {
-				fmt.Println("Cleaning up expired queries", names)
 				err = r.removeQueryNames(names...)
 				if err != nil {
-					fmt.Printf("Error removing expired queries: %v\n", err)
 					level.Warn(r.logger).Log("msg", "removing expired live queries", "err", err)
 				}
 			}()

--- a/server/live_query/redis_live_query_test.go
+++ b/server/live_query/redis_live_query_test.go
@@ -27,7 +27,7 @@ func TestRedisLiveQuery(t *testing.T) {
 
 func setupRedisLiveQuery(t *testing.T, cluster bool) *redisLiveQuery {
 	pool := redistest.SetupRedis(t, "*livequery", cluster, true, true)
-	return NewRedisLiveQuery(pool, log.NewNopLogger())
+	return NewRedisLiveQuery(pool, log.NewNopLogger(), 0)
 }
 
 func TestMapBitfield(t *testing.T) {

--- a/server/live_query/redis_live_query_test.go
+++ b/server/live_query/redis_live_query_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/fleetdm/fleet/v4/server/datastore/redis/redistest"
 	"github.com/fleetdm/fleet/v4/server/test"
+	"github.com/go-kit/log"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -26,7 +27,7 @@ func TestRedisLiveQuery(t *testing.T) {
 
 func setupRedisLiveQuery(t *testing.T, cluster bool) *redisLiveQuery {
 	pool := redistest.SetupRedis(t, "*livequery", cluster, true, true)
-	return NewRedisLiveQuery(pool)
+	return NewRedisLiveQuery(pool, log.NewNopLogger())
 }
 
 func TestMapBitfield(t *testing.T) {


### PR DESCRIPTION
#17379 

This change caches live query keys (`livequery:active` and `sql:livequery:{id}`) in memory for 1s (configurable) to improve performance and to accommodate higher loads when using live queries with a zero trust workflow (large numbers of concurrent queries scoped to a single host)

- both key types are cached and expired on the same interval
- we are no longer pipelining calls to `sql:livequery:{id}` as it was causing errors in  clustered redis, but the performance benefits of caching seem to far exceed the pipeline optimization
- cleanup operation (i believe to accomodate for an edge case) is now performed async in the loadCache method to ensure low response times.

Manual QA performed in loadtest environment showing stable redis performance at high loads: https://fleetdm.slack.com/archives/C01EZVBHFHU/p1724080736283729

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/Committing-Changes.md#changes-files) for more information.
- [X] Added/updated tests
- [X] Manual QA for all new/changed functionality
