### PR TITLE
Bump Loadtest Aurora Version

### DIFF
--- a/infrastructure/loadtesting/terraform/rds.tf
+++ b/infrastructure/loadtesting/terraform/rds.tf
@@ -28,7 +28,7 @@ module "aurora_mysql" { #tfsec:ignore:aws-rds-enable-performance-insights-encryp
 
   name                  = "${local.name}-mysql"
   engine                = "aurora-mysql"
-  engine_version        = "8.0.mysql_aurora.3.03.3"
+  engine_version        = "8.0.mysql_aurora.3.05.2"
   instance_class         = var.db_instance_type
 
   instances = {


### PR DESCRIPTION
Aurora auto-upgraded past the specified terraform version in loadtest causing errors in `apply`