### PR TITLE
Bugfix: remove filter validation

### DIFF
--- a/server/datastore/mysql/software_titles.go
+++ b/server/datastore/mysql/software_titles.go
@@ -96,10 +96,6 @@ func (ds *Datastore) ListSoftwareTitles(
 		opt.ListOptions.OrderDirection = fleet.OrderDescending
 	}
 
-	if opt.AvailableForInstall && opt.VulnerableOnly {
-		return nil, 0, nil, fleet.NewInvalidArgumentError("query", "available_for_install and vulnerable can't be provided together")
-	}
-
 	if (opt.MinimumCVSS > 0 || opt.MaximumCVSS > 0 || opt.KnownExploit) && !opt.VulnerableOnly {
 		return nil, 0, nil, fleet.NewInvalidArgumentError("query", "min_cvss_score, max_cvss_score, and exploit can only be provided with vulnerable=true")
 	}


### PR DESCRIPTION
#21376

Unreleased bugfix:  removing validation for (now valid) filter of available to install AND vulnerable software.