### PR TITLE
Redirect for learn-how-to-use-fleet guide

### DIFF
--- a/website/config/routes.js
+++ b/website/config/routes.js
@@ -451,6 +451,7 @@ module.exports.routes = {
     }
   },
   'GET /docs/using-fleet/fleet-ui': (req,res)=> { return res.redirect(301, '/guides/queries');},
+  'GET /docs/using-fleet/learn-how-to-use-fleet': (req,res)=> { return res.redirect(301, '/guides/queries');},
   'GET /docs/using-fleet/fleetctl-cli': (req,res)=> { return res.redirect(301, '/guides/fleetctl');},
   'GET /docs/using-fleet/fleet-desktop': (req,res)=> { return res.redirect(301, '/guides/fleet-desktop');},
   'GET /docs/using-fleet/enroll-hosts': (req,res)=> { return res.redirect(301, '/guides/enroll-hosts');},


### PR DESCRIPTION
Redirected the link for "Learn how to use Fleet" from local preview to go to [/guides/queries](https://fleetdm.com/guides/queries) since the information in "Learn how to use Fleet" is redundant.