### PR TITLE
Bugfix: add filter to counts

### DIFF
--- a/server/datastore/mysql/software_test.go
+++ b/server/datastore/mysql/software_test.go
@@ -4990,6 +4990,9 @@ func testListSoftwareVersionsVulnerabilityFilters(t *testing.T, ds *Datastore) {
 				require.Equal(t, tt.expected[i].Name, s.Name)
 				require.Equal(t, tt.expected[i].Version, s.Version)
 			}
+			count, err := ds.CountSoftware(ctx, tt.opts)
+			require.NoError(t, err)
+			require.Equal(t, len(tt.expected), count)
 		})
 	}
 }

--- a/server/service/software.go
+++ b/server/service/software.go
@@ -241,5 +241,10 @@ func (svc Service) CountSoftware(ctx context.Context, opt fleet.SoftwareListOpti
 		return 0, fleet.ErrMissingLicense
 	}
 
+	// required for vulnerability filters
+	if lic.IsPremium() {
+		opt.IncludeCVEScores = true
+	}
+
 	return svc.ds.CountSoftware(ctx, opt)
 }


### PR DESCRIPTION
#21377 

Unreleased bugfix.  Returned count was incorrect when applying new vulnerability filters on software titles endpoint.
