### PR TITLE
add UI to support self service VPP software (#21174)

### DIFF
--- a/changes/19883-add-support-for-ui-self-service-vpp
+++ b/changes/19883-add-support-for-ui-self-service-vpp
@@ -1,0 +1,1 @@
+- add support to UI for self service VPP software

--- a/docs/Contributing/API-for-contributors.md
+++ b/docs/Contributing/API-for-contributors.md
@@ -2615,13 +2615,21 @@ Lists the software installed on the current device.
       "source": "apps",
       "status": "failed",
       "installed_versions": [
-        { 
+        {
           "version": "121.0",
           "last_opened_at": "2024-04-01T23:03:07Z",
           "vulnerabilities": ["CVE-2023-1234","CVE-2023-4321","CVE-2023-7654"],
           "installed_paths": ["/Applications/Google Chrome.app"]
         }
-      ]
+      ],
+       "software_package": {
+        "name": "google-chrome-124-0-6367-207.pkg",
+        "version": "121.0",
+        "self_service": true,
+        "icon_url": null,
+        "last_install": null
+      },
+      "app_store_app": null
     },
     {
       "id": 143,
@@ -2631,13 +2639,21 @@ Lists the software installed on the current device.
       "source": "apps",
       "status": null,
       "installed_versions": [
-        { 
+        {
           "version": "125.6",
           "last_opened_at": "2024-04-01T23:03:07Z",
           "vulnerabilities": ["CVE-2023-1234","CVE-2023-4321","CVE-2023-7654"],
           "installed_paths": ["/Applications/Firefox.app"]
         }
-      ]
+      ],
+      "software_package": null,
+      "app_store_app": {
+        "app_store_id": "12345",
+        "version": "125.6",
+        "self_service": false,
+        "icon_url": "https://example.com/logo-light.jpg",
+        "last_install": null
+      },
     }
   ],
   "meta": {
@@ -2986,7 +3002,7 @@ If the Fleet instance is provided required parameters to complete setup.
 
 ## Scripts
 
-### Batch-apply scripts 
+### Batch-apply scripts
 
 _Available in Fleet Premium_
 
@@ -3015,7 +3031,7 @@ If both `team_id` and `team_name` parameters are included, this endpoint will re
 
 ## Software
 
-### Batch-apply software 
+### Batch-apply software
 
 _Available in Fleet Premium._
 

--- a/frontend/__mocks__/softwareMock.ts
+++ b/frontend/__mocks__/softwareMock.ts
@@ -104,6 +104,7 @@ const DEFAULT_APP_STORE_APP_MOCK: IAppStoreApp = {
   app_store_id: 1,
   icon_url: "https://via.placeholder.com/512",
   latest_version: "1.2.3",
+  self_service: true,
   status: {
     installed: 1,
     pending: 2,

--- a/frontend/interfaces/software.ts
+++ b/frontend/interfaces/software.ts
@@ -79,6 +79,7 @@ export interface IAppStoreApp {
   app_store_id: number;
   latest_version: string;
   icon_url: string;
+  self_service: boolean;
   status: {
     installed: number;
     pending: number;

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwarePackageCard/_styles.scss
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwarePackageCard/_styles.scss
@@ -51,6 +51,7 @@
     display: flex;
     justify-content: flex-end;
     gap: $pad-medium;
+    align-items: center;
   }
 
   &__self-service-badge {

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/helpers.ts
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/helpers.ts
@@ -25,8 +25,6 @@ export const getPackageCardInfo = (softwareTitle: ISoftwareTitleDetails) => {
         : packageData.latest_version) || DEFAULT_EMPTY_CELL_VALUE,
     uploadedAt: isSoftwarePackage(packageData) ? packageData.uploaded_at : "",
     status: packageData.status,
-    isSelfService: isSoftwarePackage(packageData)
-      ? packageData.self_service
-      : false,
+    isSelfService: packageData.self_service,
   };
 };

--- a/frontend/pages/SoftwarePage/SoftwareTitles/SoftwareTable/SoftwareTitlesTableConfig.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitles/SoftwareTable/SoftwareTitlesTableConfig.tsx
@@ -76,7 +76,7 @@ const getSoftwareNameCellData = (
     isSelfService = software_package.self_service;
   } else if (app_store_app) {
     hasPackage = true;
-    isSelfService = false;
+    isSelfService = app_store_app.self_service;
     iconUrl = app_store_app.icon_url;
   }
 

--- a/frontend/pages/SoftwarePage/components/AppStoreVpp/_styles.scss
+++ b/frontend/pages/SoftwarePage/components/AppStoreVpp/_styles.scss
@@ -4,10 +4,11 @@
   &__list-container {
     border: 1px solid $ui-fleet-black-10;
     border-radius: $border-radius-medium;
-    margin-bottom: $pad-medium;
   }
 
   &__list {
+    max-height: 315px;
+    overflow-y: auto;
     list-style: none;
     margin: 0;
     padding: 0;
@@ -56,6 +57,12 @@
 
   &__error {
     margin: $pad-xxlarge 0;
+  }
+
+  &__modal-body {
+    display: flex;
+    flex-direction: column;
+    gap: $pad-medium;
   }
 
   &__enable-vpp {

--- a/frontend/pages/SoftwarePage/components/AppStoreVpp/helpers.tsx
+++ b/frontend/pages/SoftwarePage/components/AppStoreVpp/helpers.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { getErrorReason } from "interfaces/errors";
 import { IVppApp } from "services/entities/mdm_apple";
+import { buildQueryStringFromParams } from "utilities/url";
 
 const ADD_SOFTWARE_ERROR_PREFIX = "Couldn’t add software.";
 const DEFAULT_ERROR_MESSAGE = `${ADD_SOFTWARE_ERROR_PREFIX} Please try again.`;
@@ -44,3 +45,21 @@ export const getErrorMessage = (e: unknown) => {
 
 export const getUniqueAppId = (app: IVppApp) =>
   `${app.app_store_id}_${app.platform}`;
+
+/**
+ * Generates the query params for the redirect to the software page. This
+ * will either generate query params to filter by available for install or
+ * self service.
+ */
+export const generateRedirectQueryParams = (
+  teamId: number,
+  isSelfService: boolean
+) => {
+  let queryParams = buildQueryStringFromParams({ team_id: teamId });
+  if (isSelfService) {
+    queryParams = `${queryParams}&self_service=true`;
+  } else {
+    queryParams = `${queryParams}&available_for_install=true`;
+  }
+  return queryParams;
+};

--- a/frontend/pages/hosts/details/cards/Software/SelfService/SelfService.tsx
+++ b/frontend/pages/hosts/details/cards/Software/SelfService/SelfService.tsx
@@ -122,9 +122,12 @@ const SoftwareSelfService = ({
                   </div>
                   <div className={`${baseClass}__items`}>
                     {data.software.map((s) => {
-                      // TODO: update this if/when we support self-service app store apps
-                      const uuid =
-                        s.software_package?.last_install?.install_uuid || "";
+                      let uuid =
+                        s.software_package?.last_install?.install_uuid ??
+                        s.app_store_app?.last_install?.command_uuid;
+                      if (!uuid) {
+                        uuid = "";
+                      }
                       // concatenating uuid so item updates with fresh data on refetch
                       const key = `${s.id}${uuid}`;
                       return (

--- a/frontend/pages/hosts/details/cards/Software/SelfService/SelfServiceItem/SelfServiceItem.tsx
+++ b/frontend/pages/hosts/details/cards/Software/SelfService/SelfServiceItem/SelfServiceItem.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useContext, useEffect, useRef } from "react";
 import ReactTooltip from "react-tooltip";
 
 import {
+  IAppLastInstall,
   IDeviceSoftware,
   IHostSoftware,
   ISoftwareLastInstall,
@@ -55,18 +56,28 @@ interface IInstallerInfoProps {
 }
 
 const InstallerInfo = ({ software }: IInstallerInfoProps) => {
-  const { name, source, software_package: installerPackage } = software;
+  const {
+    name,
+    source,
+    software_package: installerPackage,
+    app_store_app: vppApp,
+  } = software;
   return (
     <div className={`${baseClass}__item-topline`}>
       <div className={`${baseClass}__item-icon`}>
-        <SoftwareIcon name={name} source={source} size="large" />
+        <SoftwareIcon
+          url={vppApp?.icon_url}
+          name={name}
+          source={source}
+          size="large"
+        />
       </div>
       <div className={`${baseClass}__item-name-version`}>
         <div className={`${baseClass}__item-name`}>
           {name || installerPackage?.name}
         </div>
         <div className={`${baseClass}__item-version`}>
-          {installerPackage?.version || ""}
+          {installerPackage?.version || vppApp?.version || ""}
         </div>
       </div>
     </div>
@@ -75,7 +86,7 @@ const InstallerInfo = ({ software }: IInstallerInfoProps) => {
 
 // TODO: update if/when we support self-service app store apps
 type IInstallerStatusProps = Pick<IHostSoftware, "id" | "status"> & {
-  last_install: ISoftwareLastInstall | null;
+  last_install: ISoftwareLastInstall | IAppLastInstall | null;
 };
 
 const InstallerStatus = ({
@@ -140,13 +151,14 @@ const getInstallButtonText = (status: SoftwareInstallStatus | null) => {
 
 const InstallerStatusAction = ({
   deviceToken,
-  software: { id, status, software_package },
+  software: { id, status, software_package, app_store_app },
   onInstall,
 }: IInstallerStatusActionProps) => {
   const { renderFlash } = useContext(NotificationContext);
 
   // TODO: update this if/when we support self-service app store apps
-  const last_install = software_package?.last_install || null;
+  const last_install =
+    software_package?.last_install ?? app_store_app?.last_install ?? null;
 
   // localStatus is used to track the status of the any user-initiated install action
   const [localStatus, setLocalStatus] = React.useState<

--- a/frontend/services/entities/mdm_apple.ts
+++ b/frontend/services/entities/mdm_apple.ts
@@ -18,6 +18,13 @@ export interface IVppApp {
   platform: ApplePlatform;
 }
 
+interface IAddVppAppPostBody {
+  app_store_id: string;
+  team_id: number;
+  platform: ApplePlatform;
+  self_service?: boolean;
+}
+
 export interface IGetVppAppsResponse {
   app_store_apps: IVppApp[];
 }
@@ -69,12 +76,23 @@ export default {
     return sendRequest("GET", path);
   },
 
-  addVppApp: (teamId: number, appStoreId: string, platform: ApplePlatform) => {
+  addVppApp: (
+    teamId: number,
+    appStoreId: string,
+    platform: ApplePlatform,
+    isSelfService: boolean
+  ) => {
     const { MDM_APPLE_VPP_APPS } = endpoints;
-    return sendRequest("POST", MDM_APPLE_VPP_APPS, {
+    const postBody: IAddVppAppPostBody = {
       app_store_id: appStoreId,
       team_id: teamId,
       platform,
-    });
+    };
+
+    if (isSelfService) {
+      postBody.self_service = isSelfService;
+    }
+
+    return sendRequest("POST", MDM_APPLE_VPP_APPS, postBody);
   },
 };


### PR DESCRIPTION
relates to #19883

implements UI to support self service VPP apps. 

**Self service checkbox in add software modal**


![image](https://github.com/user-attachments/assets/bb6f3b3b-61aa-4a78-a223-e73ad2c2c5b9)

The rest of the changes are the same as the original self service feature.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
See [Changes
files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/Committing-Changes.md#changes-files) for more information.
- [x] Manual QA for all new/changed functionality