### PR TITLE
API design: Policy automations: install software

### DIFF
--- a/docs/Contributing/API-for-contributors.md
+++ b/docs/Contributing/API-for-contributors.md
@@ -3042,7 +3042,24 @@ If both `team_id` and `team_name` parameters are included, this endpoint will re
 
 ##### Default response
 
-`Status: 204`
+`Status: 200`
+
+```json
+{
+  "packages": [
+    {
+      "team_id": 3,
+      "software_title_id": 6690,
+      "url": "https://dl.tailscale.com/stable/tailscale-setup-1.72.0.exe"
+    },
+    {
+      "team_id": 3,
+      "software_title_id": 10412,
+      "url": "https://ftp.mozilla.org/pub/firefox/releases/129.0.2/win64/en-US/Firefox%20Setup%20129.0.2.msi"
+    }
+  ]
+}
+```
 
  ### Run live script
 

--- a/docs/Contributing/API-for-contributors.md
+++ b/docs/Contributing/API-for-contributors.md
@@ -1189,12 +1189,14 @@ NOTE: when updating a policy, team and platform will be ignored.
       "name": "new policy",
       "description": "This will be a new policy because a policy with the name 'new policy' doesn't exist in Fleet.",
       "query": "SELECT * FROM osquery_info",
+      "team": "No team",
       "resolution": "some resolution steps here",
       "critical": false
     },
     {
       "name": "Is FileVault enabled on macOS devices?",
       "query": "SELECT 1 FROM disk_encryption WHERE user_uuid IS NOT “” AND filevault_status = ‘on’ LIMIT 1;",
+      "team": "Workstations",
       "description": "Checks to make sure that the FileVault feature is enabled on macOS devices.",
       "resolution": "Choose Apple menu > System Preferences, then click Security & Privacy. Click the FileVault tab. Click the Lock icon, then enter an administrator name and password. Click Turn On FileVault.",
       "platform": "darwin",

--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -6736,7 +6736,7 @@ Team policies work the same as policies, but at the team level.
       "passing_host_count": 2000,
       "failing_host_count": 300,
       "host_count_updated_at": "2023-12-20T15:23:57Z",
-      "calendar_events_enabled": true
+      "calendar_events_enabled": true,
     },
     {
       "id": 2,
@@ -6756,6 +6756,29 @@ Team policies work the same as policies, but at the team level.
       "failing_host_count": 0,
       "host_count_updated_at": "2023-12-20T15:23:57Z",
       "calendar_events_enabled": false
+    },
+    {
+      "id": 3,
+      "name": "macOS - install/update Adobe Acrobat",
+      "query": "SELECT 1 FROM apps WHERE name = "Adobe Acrobat.app" AND bundle_short_version != "24.002.21005",
+      "description": "Checks if the hard disk is encrypted on Windows devices",
+      "critical": false,
+      "author_id": 43,
+      "author_name": "Alice",
+      "author_email": "alice@example.com",
+      "team_id": 1,
+      "resolution": "Resolution steps",
+      "platform": "windows",
+      "created_at": "2021-12-16T14:37:37Z",
+      "updated_at": "2021-12-16T16:39:00Z",
+      "passing_host_count": 2300,
+      "failing_host_count": 0,
+      "host_count_updated_at": "2023-12-20T15:23:57Z",
+      "calendar_events_enabled": false,
+      "install_software" {
+        "name": "Adobe Acrobat.app",
+        "software_title_id": 1234
+      }
     }
   ],
   "inherited_policies": [

--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -6736,7 +6736,7 @@ Team policies work the same as policies, but at the team level.
       "passing_host_count": 2000,
       "failing_host_count": 300,
       "host_count_updated_at": "2023-12-20T15:23:57Z",
-      "calendar_events_enabled": true,
+      "calendar_events_enabled": true
     },
     {
       "id": 2,

--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -6775,7 +6775,7 @@ Team policies work the same as policies, but at the team level.
       "failing_host_count": 3,
       "host_count_updated_at": "2023-12-20T15:23:57Z",
       "calendar_events_enabled": false,
-      "install_software" {
+      "install_software": {
         "name": "Adobe Acrobat.app",
         "software_title_id": 1234
       }

--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -6760,7 +6760,7 @@ Team policies work the same as policies, but at the team level.
     {
       "id": 3,
       "name": "macOS - install/update Adobe Acrobat",
-      "query": "SELECT 1 FROM apps WHERE name = "Adobe Acrobat.app" AND bundle_short_version != "24.002.21005",
+      "query": "SELECT 1 FROM apps WHERE name = \"Adobe Acrobat.app\" AND bundle_short_version != \"24.002.21005\";",
       "description": "Checks if the hard disk is encrypted on Windows devices",
       "critical": false,
       "author_id": 43,

--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -7006,7 +7006,7 @@ Either `query` or `query_id` must be provided.
     "host_count_updated_at": null,
     "calendar_events_enabled": false,
     "install_software": {
-     "name": "Adobe Acrobat.app",
+      "name": "Adobe Acrobat.app",
       "software_title_id": 1234
     }
   }

--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -6960,6 +6960,7 @@ The semantics for creating a team policy are the same as for global policies, se
 | resolution  | string  | body | The resolution steps for the policy. |
 | platform    | string  | body | Comma-separated target platforms, currently supported values are "windows", "linux", "darwin". The default, an empty string means target all platforms. |
 | critical    | boolean | body | _Available in Fleet Premium_. Mark policy as critical/high impact. |
+| software_title_id  | integer | body | _Available in Fleet Premium_. ID of software title to install if the policy fails. |
 
 Either `query` or `query_id` must be provided.
 
@@ -7003,7 +7004,11 @@ Either `query` or `query_id` must be provided.
     "passing_host_count": 0,
     "failing_host_count": 0,
     "host_count_updated_at": null,
-    "calendar_events_enabled": false
+    "calendar_events_enabled": false,
+    "install_software": {
+     "name": "Adobe Acrobat.app",
+      "software_title_id": 1234
+    }
   }
 }
 ```
@@ -7058,6 +7063,7 @@ Either `query` or `query_id` must be provided.
 | platform    | string  | body | Comma-separated target platforms, currently supported values are "windows", "linux", "darwin". The default, an empty string means target all platforms. |
 | critical    | boolean | body | _Available in Fleet Premium_. Mark policy as critical/high impact. |
 | calendar_events_enabled    | boolean | body | _Available in Fleet Premium_. Whether to trigger calendar events when policy is failing. |
+| software_title_id  | integer | body | _Available in Fleet Premium_. ID of software title to install if the policy fails. |
 
 #### Example
 
@@ -7099,7 +7105,11 @@ Either `query` or `query_id` must be provided.
     "passing_host_count": 0,
     "failing_host_count": 0,
     "host_count_updated_at": null,
-    "calendar_events_enabled": true
+    "calendar_events_enabled": true,
+    "install_software": {
+      "name": "Adobe Acrobat.app",
+      "software_title_id": 1234
+    }
   }
 }
 ```

--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -8839,6 +8839,7 @@ Returns information about the specified software. By default, `versions` are sor
     "source": "apps",
     "browser": "",
     "hosts_count": 48,
+    "versions_updated_at": "2024-04-01T14:22:58Z",
     "versions": [
       {
         "id": 123,
@@ -8892,6 +8893,7 @@ Returns information about the specified software. By default, `versions` are sor
     "source": "apps",
     "browser": "",
     "hosts_count": 48,
+    "versions_updated_at": "2024-04-01T14:22:58Z",
     "versions": [
       {
         "id": 123,

--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -6768,11 +6768,11 @@ Team policies work the same as policies, but at the team level.
       "author_email": "alice@example.com",
       "team_id": 1,
       "resolution": "Resolution steps",
-      "platform": "windows",
+      "platform": "darwin",
       "created_at": "2021-12-16T14:37:37Z",
       "updated_at": "2021-12-16T16:39:00Z",
       "passing_host_count": 2300,
-      "failing_host_count": 0,
+      "failing_host_count": 3,
       "host_count_updated_at": "2023-12-20T15:23:57Z",
       "calendar_events_enabled": false,
       "install_software" {


### PR DESCRIPTION
UPDATE: I closed this PR and opened a new one [here](https://github.com/fleetdm/fleet/pull/22315) (w/ same changes) against the docs-v4.57.0 branch.

As of 4.57.0, each minor release has it's own reference docs branch as part of a new process to make sure that every change to how Fleet is used is reflected live on the website in reference documentation at release day: https://github.com/fleetdm/fleet/pull/22284/files#diff-d426c2ae6cac2a2baffd54adae00ad7bb936dbb17a873f93a327d5763f7fb574R141

---

API design for: #19551