### PR TITLE
Updated /api/v1/fleet/vulnerabilities/{cve} endpoint

### DIFF
--- a/changes/19857-known_vulnerability
+++ b/changes/19857-known_vulnerability
@@ -1,2 +1,2 @@
-For GET /api/v1/fleet/vulnerabilities endpoint, added `known_vulnerability` field to the response. This field is present when query is a valid CVE format and returns no results. It indicates whether the vulnerability is in Fleet's DB.
+For GET /api/v1/fleet/vulnerabilities/{cve} endpoint, added validation of CVE format, and added a 204 response. The 204 response indicates that the vulnerability is known to Fleet but not present on any hosts.
 For the UI, add new empty states for searching vulnerabilities: invalid CVE format searched, a known CVE serached but not present on hosts, not a known CVE searched, exploited vulnerability empty state, operating systems empty state, new icons

--- a/ee/server/service/vulnerabilities.go
+++ b/ee/server/service/vulnerabilities.go
@@ -21,6 +21,7 @@ func (svc *Service) ListVulnerabilities(ctx context.Context, opt fleet.VulnListO
 	return svc.Service.ListVulnerabilities(ctx, opt)
 }
 
-func (svc *Service) Vulnerability(ctx context.Context, cve string, teamID *uint, useCVSScores bool) (*fleet.VulnerabilityWithMetadata, error) {
+func (svc *Service) Vulnerability(ctx context.Context, cve string, teamID *uint, useCVSScores bool) (vuln *fleet.VulnerabilityWithMetadata,
+	known bool, err error) {
 	return svc.Service.Vulnerability(ctx, cve, teamID, true)
 }

--- a/server/fleet/service.go
+++ b/server/fleet/service.go
@@ -661,15 +661,13 @@ type Service interface {
 	// ListVulnerabilities returns a list of vulnerabilities based on the provided options.
 	ListVulnerabilities(ctx context.Context, opt VulnListOptions) ([]VulnerabilityWithMetadata, *PaginationMetadata, error)
 	// ListVulnerability returns a vulnerability based on the provided CVE.
-	Vulnerability(ctx context.Context, cve string, teamID *uint, useCVSScores bool) (*VulnerabilityWithMetadata, error)
+	Vulnerability(ctx context.Context, cve string, teamID *uint, useCVSScores bool) (vuln *VulnerabilityWithMetadata, known bool, err error)
 	// CountVulnerabilities returns the number of vulnerabilities based on the provided options.
 	CountVulnerabilities(ctx context.Context, opt VulnListOptions) (uint, error)
 	// ListOSVersionsByCVE returns a list of OS versions affected by the provided CVE.
 	ListOSVersionsByCVE(ctx context.Context, cve string, teamID *uint) (result []*VulnerableOS, updatedAt time.Time, err error)
 	// ListSoftwareByCVE returns a list of software affected by the provided CVE.
 	ListSoftwareByCVE(ctx context.Context, cve string, teamID *uint) (result []*VulnerableSoftware, updatedAt time.Time, err error)
-	// IsCVEKnownToFleet returns whether the provided CVE is known to Fleet.
-	IsCVEKnownToFleet(ctx context.Context, cve string) (bool, error)
 
 	// /////////////////////////////////////////////////////////////////////////////
 	// Team Policies

--- a/server/service/vulnerabilities.go
+++ b/server/service/vulnerabilities.go
@@ -3,6 +3,7 @@ package service
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"regexp"
 	"time"
 
@@ -18,21 +19,32 @@ var freeValidVulnSortColumns = []string{
 	"created_at",
 }
 
+type cveNotFoundError struct{}
+
+var _ fleet.NotFoundError = (*cveNotFoundError)(nil)
+
+func (p cveNotFoundError) Error() string {
+	return "This is not known CVE. None of Fleet’s vulnerability sources are aware of this CVE."
+}
+
+func (p cveNotFoundError) IsNotFound() bool {
+	return true
+}
+
 type listVulnerabilitiesRequest struct {
 	fleet.VulnListOptions
 }
 
 type listVulnerabilitiesResponse struct {
-	Vulnerabilities    []fleet.VulnerabilityWithMetadata `json:"vulnerabilities"`
-	Count              uint                              `json:"count"`
-	CountsUpdatedAt    time.Time                         `json:"counts_updated_at"`
-	Meta               *fleet.PaginationMetadata         `json:"meta,omitempty"`
-	Err                error                             `json:"error,omitempty"`
-	KnownVulnerability *bool                             `json:"known_vulnerability,omitempty"`
+	Vulnerabilities []fleet.VulnerabilityWithMetadata `json:"vulnerabilities"`
+	Count           uint                              `json:"count"`
+	CountsUpdatedAt time.Time                         `json:"counts_updated_at"`
+	Meta            *fleet.PaginationMetadata         `json:"meta,omitempty"`
+	Err             error                             `json:"error,omitempty"`
 }
 
-// Allow formats like: CVE-2017-12345, cve-2017-12345 or 2017-12345
-var cveRegex = regexp.MustCompile(`(?i)^(CVE-)?\d{4}-\d{4}\d*$`)
+// Allow formats like: CVE-2017-12345, cve-2017-12345
+var cveRegex = regexp.MustCompile(`(?i)^CVE-\d{4}-\d{4}\d*$`)
 
 func (r listVulnerabilitiesResponse) error() error { return r.Err }
 
@@ -55,42 +67,11 @@ func listVulnerabilitiesEndpoint(ctx context.Context, req interface{}, svc fleet
 		}
 	}
 
-	// Check whether the query was for a vulnerability known to fleet
-	var knownVulnerability *bool
-	if len(request.ListOptions.MatchQuery) > 0 {
-		query := request.ListOptions.MatchQuery
-		matches := cveRegex.FindStringSubmatch(query)
-		if matches != nil {
-			const cvePrefix = "CVE-"
-			if len(matches) > 1 && matches[1] == "" {
-				// If CVE prefix was missing, we add it
-				query = cvePrefix + query
-			}
-			// As an optimization, we first check if the CVE was one of the ones returned
-			// by the query. If it was, we already know it's known to Fleet.
-			var known bool
-			for _, vuln := range vulns {
-				if vuln.CVE.CVE == query {
-					known = true
-					break
-				}
-			}
-			if !known {
-				known, err = svc.IsCVEKnownToFleet(ctx, query)
-				if err != nil {
-					return listVulnerabilitiesResponse{Err: err}, nil
-				}
-			}
-			knownVulnerability = &known
-		}
-	}
-
 	return listVulnerabilitiesResponse{
-		Vulnerabilities:    vulns,
-		Meta:               meta,
-		Count:              count,
-		CountsUpdatedAt:    updatedAt,
-		KnownVulnerability: knownVulnerability,
+		Vulnerabilities: vulns,
+		Meta:            meta,
+		Count:           count,
+		CountsUpdatedAt: updatedAt,
 	}, nil
 }
 
@@ -149,16 +130,28 @@ type getVulnerabilityResponse struct {
 	OSVersions    []*fleet.VulnerableOS            `json:"os_versions"`
 	Software      []*fleet.VulnerableSoftware      `json:"software"`
 	Err           error                            `json:"error,omitempty"`
+	statusCode    int
 }
 
 func (r getVulnerabilityResponse) error() error { return r.Err }
 
+func (r getVulnerabilityResponse) Status() int {
+	if r.statusCode == 0 {
+		return http.StatusOK
+	}
+	return r.statusCode
+}
+
 func getVulnerabilityEndpoint(ctx context.Context, req interface{}, svc fleet.Service) (errorer, error) {
 	request := req.(*getVulnerabilityRequest)
 
-	vuln, err := svc.Vulnerability(ctx, request.CVE, request.TeamID, false)
+	vuln, known, err := svc.Vulnerability(ctx, request.CVE, request.TeamID, false)
 	if err != nil {
 		return getVulnerabilityResponse{Err: err}, nil
+	}
+	if vuln == nil && known {
+		// Return 204 status code if the vulnerability is known to Fleet but does not match any host software/OS
+		return getVulnerabilityResponse{statusCode: http.StatusNoContent}, nil
 	}
 
 	vuln.DetailsLink = fmt.Sprintf("https://nvd.nist.gov/vuln/detail/%s", vuln.CVE.CVE)
@@ -180,30 +173,47 @@ func getVulnerabilityEndpoint(ctx context.Context, req interface{}, svc fleet.Se
 	}, nil
 }
 
-func (svc *Service) Vulnerability(ctx context.Context, cve string, teamID *uint, useCVSScores bool) (*fleet.VulnerabilityWithMetadata, error) {
+func (svc *Service) Vulnerability(ctx context.Context, cve string, teamID *uint, useCVSScores bool) (vuln *fleet.VulnerabilityWithMetadata,
+	known bool, err error) {
 	if err := svc.authz.Authorize(ctx, &fleet.AuthzSoftwareInventory{TeamID: teamID}, fleet.ActionRead); err != nil {
-		return nil, err
+		return nil, false, err
 	}
 
 	if err := svc.authz.Authorize(ctx, &fleet.Host{TeamID: teamID}, fleet.ActionRead); err != nil {
-		return nil, err
+		return nil, false, err
+	}
+
+	if !cveRegex.Match([]byte(cve)) {
+		return nil, false, badRequest("That vulnerability (CVE) is not valid. Try updating your search to use CVE format: \"CVE-YYYY-<4 or more digits>\"")
 	}
 
 	if teamID != nil && *teamID != 0 {
 		exists, err := svc.ds.TeamExists(ctx, *teamID)
 		if err != nil {
-			return nil, ctxerr.Wrap(ctx, err, "checking if team exists")
+			return nil, false, ctxerr.Wrap(ctx, err, "checking if team exists")
 		} else if !exists {
-			return nil, authz.ForbiddenWithInternal("team does not exist", nil, nil, nil)
+			return nil, false, authz.ForbiddenWithInternal("team does not exist", nil, nil, nil)
 		}
 	}
 
-	vuln, err := svc.ds.Vulnerability(ctx, cve, teamID, useCVSScores)
-	if err != nil {
-		return nil, err
+	vuln, err = svc.ds.Vulnerability(ctx, cve, teamID, useCVSScores)
+	switch {
+	case fleet.IsNotFound(err):
+		var errKnown error
+		known, errKnown = svc.ds.IsCVEKnownToFleet(ctx, cve)
+		if errKnown != nil {
+			return nil, false, errKnown
+		}
+		if !known {
+			return nil, false, cveNotFoundError{}
+		}
+	case err != nil:
+		return nil, false, err
+	default:
+		known = true
 	}
 
-	return vuln, nil
+	return vuln, known, nil
 }
 
 func (svc *Service) ListOSVersionsByCVE(ctx context.Context, cve string, teamID *uint) (result []*fleet.VulnerableOS, updatedAt time.Time, err error) {

--- a/server/service/vulnerabilities_test.go
+++ b/server/service/vulnerabilities_test.go
@@ -173,10 +173,10 @@ func TestVulnerabilitesAuth(t *testing.T) {
 			})
 			checkAuthErr(t, tc.shouldFailTeamRead, err)
 
-			_, err = svc.Vulnerability(ctx, "CVE-2019-1234", nil, false)
+			_, _, err = svc.Vulnerability(ctx, "CVE-2019-1234", nil, false)
 			checkAuthErr(t, tc.shouldFailGlobalRead, err)
 
-			_, err = svc.Vulnerability(ctx, "CVE-2019-1234", ptr.Uint(1), false)
+			_, _, err = svc.Vulnerability(ctx, "CVE-2019-1234", ptr.Uint(1), false)
 			checkAuthErr(t, tc.shouldFailTeamRead, err)
 		})
 	}


### PR DESCRIPTION
main task: #19857
subtask: #21392

- For GET /api/v1/fleet/vulnerabilities/{cve} endpoint, added validation of CVE format, and added a 204 response. The 204 response indicates that the vulnerability is known to Fleet but not present on any hosts.
- Removed the previous known_vulnerability field implementation

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/Committing-Changes.md#changes-files) for more information.
- [x] Added/updated tests
- [x] Manual QA for all new/changed functionality
