### PR TITLE
[DRAFT] Fleet UI: Show updated osquery versions in UI

### DIFF
--- a/frontend/utilities/constants.tsx
+++ b/frontend/utilities/constants.tsx
@@ -90,9 +90,10 @@ export const MIN_OSQUERY_VERSION_OPTIONS = [
   { label: "5.8.1 +", value: "5.8.1" },
   { label: "5.7.0 +", value: "5.7.0" },
   { label: "5.6.0 +", value: "5.6.0" },
+  { label: "5.5.1 +", value: "5.5.1" },
   { label: "5.4.0 +", value: "5.4.0" },
   { label: "5.3.0 +", value: "5.3.0" },
-  { label: "5.2.3 +", value: "5.2.4" },
+  { label: "5.2.3 +", value: "5.2.3" },
   { label: "5.2.2 +", value: "5.2.2" },
   { label: "5.2.1 +", value: "5.2.1" },
   { label: "5.2.0 +", value: "5.2.0" },
@@ -126,6 +127,33 @@ export const MIN_OSQUERY_VERSION_OPTIONS = [
   { label: "1.8.2 +", value: "1.8.2" },
   { label: "1.8.1 +", value: "1.8.1" },
 ];
+
+export const getUpdatedMinOsqueryVersionOptions = (
+  recentOsqueryVersionsReleased: string[]
+) => {
+  // Create a set of existing version values for quick lookup
+  const existingVersionOptions = new Set(
+    MIN_OSQUERY_VERSION_OPTIONS.map((option) => option.value)
+  );
+
+  // Find missing versions
+  const missingVersions = recentOsqueryVersionsReleased.filter(
+    (version) => !existingVersionOptions.has(version)
+  );
+
+  // Create new options for missing versions
+  const newVersionOptions = missingVersions.map((version) => ({
+    label: `${version} +`,
+    value: version,
+  }));
+
+  // Combine the new options with the existing ones, inserting after the first item
+  return [
+    MIN_OSQUERY_VERSION_OPTIONS[0],
+    ...newVersionOptions,
+    ...MIN_OSQUERY_VERSION_OPTIONS.slice(1),
+  ];
+};
 
 export const LIVE_POLICY_STEPS = {
   1: "EDITOR",


### PR DESCRIPTION
## Issue
#21431 

DRAFT, started but not finished

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [ ] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/Committing-Changes.md#changes-files) for more information.
- [ ] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [ ] Added support on fleet's osquery simulator `cmd/osquery-perf` for new osquery data ingestion features.
- [ ] Added/updated tests
- [ ] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes
- [ ] If database migrations are included, checked table schema to confirm autoupdate
- For database migrations:
  - [ ] Checked schema for all modified table for columns that will auto-update timestamps during migration.
  - [ ] Confirmed that updating the timestamps is acceptable, and will not cause unwanted side effects.
  - [ ] Ensured the correct collation is explicitly set for character columns (`COLLATE utf8mb4_unicode_ci`).
- [ ] Manual QA for all new/changed functionality
- For Orbit and Fleet Desktop changes:
   - [ ] Orbit runs on macOS, Linux and Windows. Check if the orbit feature/bugfix should only apply to one platform (`runtime.GOOS`).
   - [ ] Manual QA must be performed in the three main OSs, macOS, Windows and Linux.
   - [ ] Auto-update manual QA, from released version of component to new version (see [tools/tuf/test](../tools/tuf/test/README.md)).
