### PR TITLE
Website: Track psystage and buying situation changed changes caused by start flow in Segment.

### DIFF
--- a/website/api/controllers/save-questionnaire-progress.js
+++ b/website/api/controllers/save-questionnaire-progress.js
@@ -221,7 +221,7 @@ module.exports = {
       psychologicalStageLastChangedAt,
     });
     // Return the JSON dictionary of form data submitted by this user.
-    return {getStartedProgress, psychologicalStage};
+    return {getStartedProgress, psychologicalStage, primaryBuyingSituation};
   }
 
 

--- a/website/assets/js/pages/start.page.js
+++ b/website/assets/js/pages/start.page.js
@@ -76,6 +76,7 @@ parasails.registerPage('start', {
 
     // Success state when form has been submitted
     cloudSuccess: false,
+    primaryBuyingSituation: undefined,
   },
 
   //  ╦  ╦╔═╗╔═╗╔═╗╦ ╦╔═╗╦  ╔═╗
@@ -139,6 +140,17 @@ parasails.registerPage('start', {
 
       this.previouslyAnsweredQuestions[this.currentStep] = questionanireProgress.getStartedProgress[this.currentStep];
       this.psychologicalStage = questionanireProgress.psychologicalStage;
+      this.primaryBuyingSituation = questionanireProgress.primaryBuyingSituation;
+      if(typeof analytics !== 'undefined') {
+        analytics.identify(this.me.id, {
+          email: this.me.emailAddress,
+          firstName: this.me.firstName,
+          lastName: this.me.lastName,
+          company: this.me.organization,
+          primaryBuyingSituation: this.primaryBuyingSituation,
+          psychologicalStage: this.psychologicalStage,
+        });
+      }
       if(_.startsWith(nextStep, '/')){
         this.goto(nextStep);
       } else {

--- a/website/assets/styles/pages/start.less
+++ b/website/assets/styles/pages/start.less
@@ -68,7 +68,6 @@
     background-size: cover;
     background-position: center;
     background-repeat: no-repeat;
-    border: 1px solid @core-vibrant-blue-15;
     border-radius: 16px;
     &.stage-one {
       background-image: url('/images/psystage-1-unaware-558x680@2x.png');


### PR DESCRIPTION
Related to: https://github.com/fleetdm/confidential/issues/7339

Changes:
- Updated `save-questionnaire-progress` to return the user's selected `primaryBuyingSituation`
- Updated the /start flow to update data in Segment
- Removed the border on the /start flow images that I mistakenly added.