### PR TITLE
Website: send start flow responses to CRM

### DIFF
--- a/website/api/helpers/salesforce/update-or-create-contact-and-account.js
+++ b/website/api/helpers/salesforce/update-or-create-contact-and-account.js
@@ -37,6 +37,10 @@ module.exports = {
         'Website - Sign up',
       ],
     },
+    getStartedResponses: {
+      type: 'string',
+    }
+
   },
 
 
@@ -52,7 +56,7 @@ module.exports = {
   },
 
 
-  fn: async function ({emailAddress, linkedinUrl, firstName, lastName, organization, primaryBuyingSituation, psychologicalStage, contactSource, description}) {
+  fn: async function ({emailAddress, linkedinUrl, firstName, lastName, organization, primaryBuyingSituation, psychologicalStage, contactSource, description, getStartedResponses}) {
     // Return undefined if we're not running in a production environment.
     if(sails.config.environment !== 'production') {
       sails.log.verbose('Skipping Salesforce integration...');
@@ -95,6 +99,9 @@ module.exports = {
     }
     if(psychologicalStage) {
       valuesToSet.Stage__c = psychologicalStage;// eslint-disable-line camelcase
+    }
+    if(getStartedResponses) {
+      valuesToSet.Website_questionnaire_answers__c = getStartedResponses;// eslint-disable-line camelcase
     }
     if(description) {
       valuesToSet.Description = description;


### PR DESCRIPTION
Changes:
- Updated save-questionnaire-progress to send a formatted string of a user's start questionnaire responses to the update-or-create-contact-and-account helper
- Updated the update-or-create-contact-and-account helper to set getStartedResponses on contact records.