### PR TITLE
Python Vulnerability False Positive

### DIFF
--- a/changes/19562-python-vuln
+++ b/changes/19562-python-vuln
@@ -1,0 +1,1 @@
+- Fixed CVE-2024-4030 in Vulncheck feed incorrectly targeting non-Windows hosts

--- a/server/vulnerabilities/nvd/cpe_matching_rules.go
+++ b/server/vulnerabilities/nvd/cpe_matching_rules.go
@@ -240,6 +240,15 @@ func GetKnownNVDBugRules() (CPEMatchingRules, error) {
 			},
 			IgnoreAll: true,
 		},
+		// CVE-2024-4030 only targets windows operating systems
+		CPEMatchingRule{
+			CVEs: map[string]struct{}{
+				"CVE-2024-4030": {},
+			},
+			IgnoreIf: func(cpeMeta *wfn.Attributes) bool {
+				return cpeMeta.TargetSW != "windows"
+			},
+		},
 	}
 
 	for i, rule := range rules {

--- a/server/vulnerabilities/nvd/cve_test.go
+++ b/server/vulnerabilities/nvd/cve_test.go
@@ -337,6 +337,16 @@ func TestTranslateCPEToCVE(t *testing.T) {
 			excludedCVEs:      []string{"CVE-2011-5049"}, // OS vulnerability
 			continuesToUpdate: true,
 		},
+		"cpe:2.3:a:python:python:3.9.6:*:*:*:*:macos:*:*": {
+			excludedCVEs:      []string{"CVE-2024-4030"},
+			continuesToUpdate: true,
+		},
+		"cpe:2.3:a:python:python:3.9.6:*:*:*:*:windows:*:*": {
+			includedCVEs: []cve{
+				{ID: "CVE-2024-4030", resolvedInVersion: "3.12.4"},
+			},
+			continuesToUpdate: true,
+		},
 	}
 
 	cveOSTests := []struct {


### PR DESCRIPTION
#19562 

Python vuln false should only target windows hosts

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/Committing-Changes.md#changes-files) for more information.
- [X] Added/updated tests
- [X] Manual QA for all new/changed functionality
