### PR TITLE
Pull xz'd goval-dictionary sqlite files to evaluate vulnerabilities on Amazon Linux hosts

### DIFF
--- a/changes/20934-amazon-linux
+++ b/changes/20934-amazon-linux
@@ -1,0 +1,1 @@
+Use ALAS bulletins as vulnerability source for Amazon Linux (instead of OVAL for Amazon Linux 2, and adds support for Amazon Linux 1, 2022, and 2023)

--- a/cmd/fleet/cron.go
+++ b/cmd/fleet/cron.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	goval_dictionary "github.com/fleetdm/fleet/v4/server/vulnerabilities/goval-dictionary"
 	"net/url"
 	"os"
 	"strconv"
@@ -158,6 +159,7 @@ func scanVulnerabilities(
 
 	nvdVulns := checkNVDVulnerabilities(ctx, ds, logger, vulnPath, config, vulnAutomationEnabled != "")
 	ovalVulns := checkOvalVulnerabilities(ctx, ds, logger, vulnPath, config, vulnAutomationEnabled != "")
+	govalDictVulns := checkGovalDictionaryVulnerabilities(ctx, ds, logger, vulnPath, config, vulnAutomationEnabled != "")
 	macOfficeVulns := checkMacOfficeVulnerabilities(ctx, ds, logger, vulnPath, config, vulnAutomationEnabled != "")
 	customVulns := checkCustomVulnerabilities(ctx, ds, logger, config, vulnAutomationEnabled != "")
 
@@ -172,6 +174,7 @@ func scanVulnerabilities(
 	vulns = append(vulns, nvdVulns...)
 	vulns = append(vulns, ovalVulns...)
 	vulns = append(vulns, macOfficeVulns...)
+	vulns = append(vulns, govalDictVulns...)
 	vulns = append(vulns, customVulns...)
 
 	meta, err := ds.ListCVEs(ctx, config.RecentVulnerabilityMaxAge)
@@ -353,6 +356,53 @@ func checkOvalVulnerabilities(
 		results = append(results, r...)
 		if err != nil {
 			errHandler(ctx, logger, "analyzing oval definitions", err)
+		}
+	}
+
+	return results
+}
+
+func checkGovalDictionaryVulnerabilities(
+	ctx context.Context,
+	ds fleet.Datastore,
+	logger kitlog.Logger,
+	vulnPath string,
+	config *config.VulnerabilitiesConfig,
+	collectVulns bool,
+) []fleet.SoftwareVulnerability {
+	var results []fleet.SoftwareVulnerability
+
+	// Get Platforms
+	versions, err := ds.OSVersions(ctx, nil, nil, nil, nil)
+	if err != nil {
+		errHandler(ctx, logger, "listing platforms for goval-dictionary pulls", err)
+		return nil
+	}
+
+	if !config.DisableDataSync {
+		// Sync on disk goval-dictionary sqlite with current OS Versions.
+		downloaded, err := goval_dictionary.Refresh(ctx, versions, vulnPath)
+		if err != nil {
+			errHandler(ctx, logger, "updating goval-dictionary databases", err)
+		}
+		for _, d := range downloaded {
+			level.Debug(logger).Log("goval-dictionary-sync-downloaded", d)
+		}
+	}
+
+	// Analyze all supported os versions using the synced goval-dictionary definitions.
+	for _, version := range versions.OSVersions {
+		start := time.Now()
+		r, err := goval_dictionary.Analyze(ctx, ds, version, vulnPath, collectVulns)
+		elapsed := time.Since(start)
+		level.Debug(logger).Log(
+			"msg", "goval-dictionary-analysis-done",
+			"platform", version.Name,
+			"elapsed", elapsed,
+			"found new", len(r))
+		results = append(results, r...)
+		if err != nil {
+			errHandler(ctx, logger, "analyzing goval-dictionary definitions", err)
 		}
 	}
 

--- a/server/fleet/vulnerabilities.go
+++ b/server/fleet/vulnerabilities.go
@@ -127,6 +127,7 @@ const (
 	MSRCSource
 	MacOfficeReleaseNotesSource
 	CustomSource
+	GovalDictionarySource
 )
 
 type VulnerabilityWithMetadata struct {

--- a/server/vulnerabilities/goval-dictionary/analyzer.go
+++ b/server/vulnerabilities/goval-dictionary/analyzer.go
@@ -1,0 +1,134 @@
+package goval_dictionary
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"github.com/fleetdm/fleet/v4/server/fleet"
+	"github.com/fleetdm/fleet/v4/server/vulnerabilities/oval"
+	"github.com/fleetdm/fleet/v4/server/vulnerabilities/utils"
+)
+
+const (
+	hostsBatchSize = 500
+	vulnBatchSize  = 500
+)
+
+func Analyze(
+	ctx context.Context,
+	ds fleet.Datastore,
+	ver fleet.OSVersion,
+	vulnPath string,
+	collectVulns bool,
+) ([]fleet.SoftwareVulnerability, error) {
+	platform := oval.NewPlatform(ver.Platform, ver.Name)
+	source := fleet.GovalDictionarySource
+	if !platform.IsGovalDictionarySupported() {
+		return nil, nil
+	}
+	db, err := loadDb(platform, vulnPath)
+	if err != nil {
+		return nil, err
+	}
+
+	// Since hosts and software have a M:N relationship, the following sets are used to
+	// avoid doing duplicated inserts/delete operations (a vulnerable software might be
+	// present in many hosts).
+	toInsertSet := make(map[string]fleet.SoftwareVulnerability)
+	toDeleteSet := make(map[string]fleet.SoftwareVulnerability)
+
+	var offset int
+	for {
+		hostIDs, err := ds.HostIDsByOSVersion(ctx, ver, offset, hostsBatchSize)
+		if err != nil {
+			return nil, err
+		}
+
+		if len(hostIDs) == 0 {
+			break
+		}
+		offset += hostsBatchSize
+
+		foundInBatch := make(map[uint][]fleet.SoftwareVulnerability)
+		for _, hostID := range hostIDs {
+			hostID := hostID
+			software, err := ds.ListSoftwareForVulnDetection(ctx, fleet.VulnSoftwareFilter{HostID: &hostID})
+			if err != nil {
+				return nil, err
+			}
+
+			vulnerabilities, err := db.Eval(ver, software)
+			if err != nil {
+				return nil, err
+			}
+			foundInBatch[hostID] = vulnerabilities
+		}
+
+		existingInBatch, err := ds.ListSoftwareVulnerabilitiesByHostIDsSource(ctx, hostIDs, source)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, hostID := range hostIDs {
+			inserts, deletes := utils.VulnsDelta(foundInBatch[hostID], existingInBatch[hostID])
+			for _, i := range inserts {
+				toInsertSet[i.Key()] = i
+			}
+			for _, d := range deletes {
+				toDeleteSet[d.Key()] = d
+			}
+		}
+	}
+
+	err = utils.BatchProcess(toDeleteSet, func(v []fleet.SoftwareVulnerability) error {
+		return ds.DeleteSoftwareVulnerabilities(ctx, v)
+	}, vulnBatchSize)
+	if err != nil {
+		return nil, err
+	}
+
+	var inserted []fleet.SoftwareVulnerability
+	if collectVulns {
+		inserted = make([]fleet.SoftwareVulnerability, 0, len(toInsertSet))
+	}
+
+	err = utils.BatchProcess(toInsertSet, func(vulns []fleet.SoftwareVulnerability) error {
+		for _, v := range vulns {
+			ok, err := ds.InsertSoftwareVulnerability(ctx, v, source)
+			if err != nil {
+				return err
+			}
+
+			if collectVulns && ok {
+				inserted = append(inserted, v)
+			}
+		}
+		return nil
+	}, vulnBatchSize)
+	if err != nil {
+		return nil, err
+	}
+
+	return inserted, nil
+}
+
+// loadDb returns the latest goval-dictionary database for the given platform.
+func loadDb(platform oval.Platform, vulnPath string) (VulnDataSource, error) {
+	if !platform.IsGovalDictionarySupported() {
+		return nil, fmt.Errorf("platform %q not supported", platform)
+	}
+
+	fileName := platform.ToGovalDictionaryFilename()
+	latest, err := utils.LatestFile(fileName, vulnPath)
+	if err != nil {
+		return nil, err
+	}
+
+	sqlite, err := sql.Open("sqlite3", latest)
+	if err != nil {
+		return nil, err
+	}
+
+	db := NewDB(sqlite)
+	return db, nil
+}

--- a/server/vulnerabilities/goval-dictionary/database.go
+++ b/server/vulnerabilities/goval-dictionary/database.go
@@ -1,0 +1,69 @@
+package goval_dictionary
+
+import (
+	"database/sql"
+	"errors"
+	"fmt"
+	"github.com/fleetdm/fleet/v4/server/fleet"
+	"github.com/fleetdm/fleet/v4/server/vulnerabilities/utils"
+	"strings"
+)
+
+type VulnDataSource interface {
+	// Eval evaluates the current OVAL definition against an OS version and a list of installed software, returns all software
+	// vulnerabilities found.
+	Eval(fleet.OSVersion, []fleet.Software) ([]fleet.SoftwareVulnerability, error)
+}
+
+func NewDB(db *sql.DB) *Database {
+	return &Database{sqlite: db}
+}
+
+type Database struct {
+	sqlite *sql.DB
+}
+
+// Eval evaluates the current goval-dictionary database against an OS version and a list of installed software,
+// returns all software vulnerabilities found.
+func (db Database) Eval(version fleet.OSVersion, software []fleet.Software) ([]fleet.SoftwareVulnerability, error) {
+	searchStmt := `SELECT packages.version, cves.cve_id 
+		FROM packages join definitions on definitions.id = packages.definition_id
+		JOIN advisories ON advisories.definition_id = definitions.id JOIN cves ON cves.advisory_id = advisories.id
+		WHERE packages.name = ? AND packages.arch = ?`
+	vulnerabilities := make([]fleet.SoftwareVulnerability, 0)
+
+	for _, swItem := range software {
+		affectedSoftwareRows, err := db.sqlite.Query(searchStmt, swItem.Name, swItem.Arch)
+		if errors.Is(err, sql.ErrNoRows) {
+			continue // No vulns for this package-OS combo
+		}
+		if err != nil {
+			return nil, fmt.Errorf("could not query goval-dictionary database for package %s", swItem.Name)
+		}
+		defer affectedSoftwareRows.Close()
+		for affectedSoftwareRows.Next() {
+			var fixedVersionWithEpochPrefix, cve string
+			if err := affectedSoftwareRows.Scan(&fixedVersionWithEpochPrefix, &cve); err != nil {
+				return nil, fmt.Errorf("could not read package vulnerability result %s", swItem.Name)
+			}
+
+			var currentVersion string
+			if swItem.Release != "" {
+				currentVersion = fmt.Sprintf("%s-%s", swItem.Version, swItem.Release)
+			} else {
+				currentVersion = swItem.Version
+			}
+			fixedVersion := strings.Split(fixedVersionWithEpochPrefix, ":")[1]
+
+			if utils.Rpmvercmp(currentVersion, fixedVersion) < 0 {
+				vulnerabilities = append(vulnerabilities, fleet.SoftwareVulnerability{
+					SoftwareID:        swItem.ID,
+					CVE:               cve,
+					ResolvedInVersion: &fixedVersion,
+				})
+			}
+		}
+	}
+
+	return vulnerabilities, nil
+}

--- a/server/vulnerabilities/goval-dictionary/sync.go
+++ b/server/vulnerabilities/goval-dictionary/sync.go
@@ -1,0 +1,90 @@
+package goval_dictionary
+
+import (
+	"context"
+	"fmt"
+	"github.com/fleetdm/fleet/v4/pkg/download"
+	"github.com/fleetdm/fleet/v4/pkg/fleethttp"
+	"github.com/fleetdm/fleet/v4/server/fleet"
+	"github.com/fleetdm/fleet/v4/server/vulnerabilities/nvd"
+	"github.com/fleetdm/fleet/v4/server/vulnerabilities/oval"
+	"net/http"
+	"net/url"
+	"path/filepath"
+)
+
+func Refresh(
+	ctx context.Context,
+	versions *fleet.OSVersions,
+	vulnPath string,
+) ([]oval.Platform, error) {
+	toDownload := whatToDownload(versions)
+	if len(toDownload) > 0 {
+		err := Sync(vulnPath, toDownload)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return toDownload, nil
+}
+
+func Sync(dstDir string, platforms []oval.Platform) error {
+	client := fleethttp.NewClient()
+	dwn := downloadDecompressed(client)
+	basePath, err := nvd.GetGitHubCVEAssetPath()
+	if err != nil {
+		return err
+	}
+
+	for _, platform := range platforms {
+		err := downloadDatabase(platform, dwn, basePath, dstDir)
+		if err != nil {
+			return fmt.Errorf("downloadDefinitions: %w", err)
+		}
+	}
+	return nil
+}
+
+func downloadDatabase(
+	platform oval.Platform,
+	downloader func(string, string) error,
+	basePath string,
+	vulnDir string,
+) error {
+	dstPath := filepath.Join(vulnDir, platform.ToGovalDictionaryFilename())
+	err := downloader(basePath+string(platform)+".sqlite3.xz", dstPath)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func downloadDecompressed(client *http.Client) func(string, string) error {
+	return func(u, dstPath string) error {
+		parsedUrl, err := url.Parse(u)
+		if err != nil {
+			return fmt.Errorf("url parse: %w", err)
+		}
+
+		err = download.DownloadAndExtract(client, parsedUrl, dstPath)
+		if err != nil {
+			return fmt.Errorf("download and extract url %s: %w", parsedUrl, err)
+		}
+
+		return nil
+	}
+}
+
+func whatToDownload(osVers *fleet.OSVersions) []oval.Platform {
+	var r []oval.Platform
+	for _, os := range osVers.OSVersions {
+		platform := oval.NewPlatform(os.Platform, os.Name)
+		if platform.IsGovalDictionarySupported() {
+			r = append(r, platform)
+		}
+	}
+
+	return r
+}

--- a/server/vulnerabilities/oval/oval_platform.go
+++ b/server/vulnerabilities/oval/oval_platform.go
@@ -13,6 +13,7 @@ type Platform string
 
 // OvalFilePrefix is the file prefix used when saving an OVAL artifact.
 const OvalFilePrefix = "fleet_oval"
+const GovalDictionaryFilePrefix = "fleet_goval_dictionary"
 
 // SupportedSoftwareSources are the software sources for which we are using OVAL for vulnerability detection.
 var SupportedSoftwareSources = []string{"deb_packages", "rpm_packages"}
@@ -69,6 +70,10 @@ func (op Platform) ToFilename(date time.Time, extension string) string {
 	return fmt.Sprintf("%s_%s-%d_%02d_%02d.%s", OvalFilePrefix, op, date.Year(), date.Month(), date.Day(), extension)
 }
 
+func (op Platform) ToGovalDictionaryFilename() string {
+	return fmt.Sprintf("%s_%s.sqlite3", GovalDictionaryFilePrefix, op)
+}
+
 // IsSupported returns whether the given platform is currently supported.
 func (op Platform) IsSupported() bool {
 	supported := []string{
@@ -89,8 +94,23 @@ func (op Platform) IsSupported() bool {
 		"rhel_07",
 		"rhel_08",
 		"rhel_09",
-		"amzn_02",
 	}
+	for _, p := range supported {
+		if strings.HasPrefix(string(op), p) {
+			return true
+		}
+	}
+	return false
+}
+
+func (op Platform) IsGovalDictionarySupported() bool {
+	supported := []string{
+		"amzn_01",
+		"amzn_02",
+		"amzn_2022",
+		"amzn_2023",
+	}
+
 	for _, p := range supported {
 		if strings.HasPrefix(string(op), p) {
 			return true


### PR DESCRIPTION
#20934

I fully expect some back-and-forth on this as I expect code is rather naive/non-idiomatic (particularly adding methods to `oval_platform` and another place or two, to try to avoid even more code duplication), but the underlying logic works so...progress!

This is tied to https://github.com/fleetdm/vulnerabilities/pull/14; for supported OS versions (currently Amazon Linux 1/2/2022/2023) we'll pull XZ'd sqlite files from the vulnerabilities repo and query them to determine what's vulnerable. See the associated issue for how I self-QA'd this.

This replaced OVAL parsing for Amazon Linux 2, as we were using the wrong data source there (Amazon has backported a bunch of fixes to their own-named releases, so any RHEL fixes don't match).

Some checklist items are missing here; getting this set up in draft to get code feedback now, and I'll push updates with e.g. docs changes, as well ass an addition to the changes file.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/Committing-Changes.md#changes-files) for more information.
- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [ ] Added/updated tests
- [x] Manual QA for all new/changed functionality
- [ ] Update vulnerability management docs