### PR TITLE
Pull xz'd goval-dictionary sqlite files to evaluate vulnerabilities on Amazon Linux hosts

### DIFF
--- a/changes/20934-amazon-linux
+++ b/changes/20934-amazon-linux
@@ -1,0 +1,1 @@
+Use ALAS bulletins as vulnerability source for Amazon Linux (instead of OVAL for Amazon Linux 2, and adds support for Amazon Linux 1, 2022, and 2023)

--- a/cmd/fleet/cron.go
+++ b/cmd/fleet/cron.go
@@ -386,7 +386,7 @@ func checkGovalDictionaryVulnerabilities(
 
 	if !config.DisableDataSync {
 		// Sync on disk goval_dictionary sqlite with current OS Versions.
-		downloaded, err := goval_dictionary.Refresh(ctx, versions, vulnPath)
+		downloaded, err := goval_dictionary.Refresh(versions, vulnPath, logger)
 		if err != nil {
 			errHandler(ctx, logger, "updating goval_dictionary databases", err)
 		}
@@ -398,7 +398,7 @@ func checkGovalDictionaryVulnerabilities(
 	// Analyze all supported os versions using the synced goval_dictionary definitions.
 	for _, version := range versions.OSVersions {
 		start := time.Now()
-		r, err := goval_dictionary.Analyze(ctx, ds, version, vulnPath, collectVulns)
+		r, err := goval_dictionary.Analyze(ctx, ds, version, vulnPath, collectVulns, logger)
 		if err != nil && errors.Is(err, goval_dictionary.ErrUnsupportedPlatform) {
 			level.Debug(logger).Log("msg", "goval_dictionary-analysis-unsupported", "platform", version.Name)
 			continue

--- a/cmd/fleet/cron.go
+++ b/cmd/fleet/cron.go
@@ -347,7 +347,8 @@ func checkOvalVulnerabilities(
 	for _, version := range versions.OSVersions {
 		start := time.Now()
 		r, err := oval.Analyze(ctx, ds, version, vulnPath, collectVulns)
-		if r == nil && err == nil { // skip metrics/logging when unsupported version
+		if err != nil && errors.Is(err, oval.ErrUnsupportedPlatform) {
+			level.Debug(logger).Log("msg", "oval-analysis-unsupported", "platform", version.Name)
 			continue
 		}
 
@@ -398,7 +399,8 @@ func checkGovalDictionaryVulnerabilities(
 	for _, version := range versions.OSVersions {
 		start := time.Now()
 		r, err := goval_dictionary.Analyze(ctx, ds, version, vulnPath, collectVulns)
-		if r == nil && err == nil { // skip metrics/logging when unsupported version
+		if err != nil && errors.Is(err, goval_dictionary.ErrUnsupportedPlatform) {
+			level.Debug(logger).Log("msg", "goval_dictionary-analysis-unsupported", "platform", version.Name)
 			continue
 		}
 		elapsed := time.Since(start)

--- a/cmd/fleet/cron.go
+++ b/cmd/fleet/cron.go
@@ -347,6 +347,10 @@ func checkOvalVulnerabilities(
 	for _, version := range versions.OSVersions {
 		start := time.Now()
 		r, err := oval.Analyze(ctx, ds, version, vulnPath, collectVulns)
+		if r == nil && err == nil { // skip metrics/logging when unsupported version
+			continue
+		}
+
 		elapsed := time.Since(start)
 		level.Debug(logger).Log(
 			"msg", "oval-analysis-done",
@@ -394,6 +398,9 @@ func checkGovalDictionaryVulnerabilities(
 	for _, version := range versions.OSVersions {
 		start := time.Now()
 		r, err := goval_dictionary.Analyze(ctx, ds, version, vulnPath, collectVulns)
+		if r == nil && err == nil { // skip metrics/logging when unsupported version
+			continue
+		}
 		elapsed := time.Since(start)
 		level.Debug(logger).Log(
 			"msg", "goval_dictionary-analysis-done",

--- a/pkg/download/download.go
+++ b/pkg/download/download.go
@@ -4,7 +4,6 @@ package download
 import (
 	"compress/bzip2"
 	"compress/gzip"
-	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -80,9 +79,7 @@ func download(client *http.Client, u *url.URL, path string, extract bool) error 
 		}
 		defer resp.Body.Close()
 
-		if resp.StatusCode == http.StatusNotFound {
-			return backoff.Permanent(errors.New("url returned not found"))
-		} else if resp.StatusCode != http.StatusOK {
+		if resp.StatusCode != http.StatusOK {
 			return fmt.Errorf("unexpected status code %d", resp.StatusCode)
 		}
 

--- a/pkg/download/download.go
+++ b/pkg/download/download.go
@@ -79,6 +79,12 @@ func download(client *http.Client, u *url.URL, path string, extract bool) error 
 		}
 		defer resp.Body.Close()
 
+		if resp.StatusCode == http.StatusNotFound {
+			return backoff.Permanent(fmt.Errorf("url returned not found"))
+		} else if resp.StatusCode != http.StatusOK {
+			return fmt.Errorf("unexpected status code %d", resp.StatusCode)
+		}
+
 		r := io.Reader(resp.Body)
 
 		// extract (optional)

--- a/pkg/download/download.go
+++ b/pkg/download/download.go
@@ -4,6 +4,7 @@ package download
 import (
 	"compress/bzip2"
 	"compress/gzip"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -80,7 +81,7 @@ func download(client *http.Client, u *url.URL, path string, extract bool) error 
 		defer resp.Body.Close()
 
 		if resp.StatusCode == http.StatusNotFound {
-			return backoff.Permanent(fmt.Errorf("url returned not found"))
+			return backoff.Permanent(errors.New("url returned not found"))
 		} else if resp.StatusCode != http.StatusOK {
 			return fmt.Errorf("unexpected status code %d", resp.StatusCode)
 		}

--- a/server/fleet/vulnerabilities.go
+++ b/server/fleet/vulnerabilities.go
@@ -127,6 +127,7 @@ const (
 	MSRCSource
 	MacOfficeReleaseNotesSource
 	CustomSource
+	GovalDictionarySource
 )
 
 type VulnerabilityWithMetadata struct {

--- a/server/vulnerabilities/goval_dictionary/analyzer.go
+++ b/server/vulnerabilities/goval_dictionary/analyzer.go
@@ -1,0 +1,134 @@
+package goval_dictionary
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"github.com/fleetdm/fleet/v4/server/fleet"
+	"github.com/fleetdm/fleet/v4/server/vulnerabilities/oval"
+	"github.com/fleetdm/fleet/v4/server/vulnerabilities/utils"
+)
+
+const (
+	hostsBatchSize = 500
+	vulnBatchSize  = 500
+)
+
+func Analyze(
+	ctx context.Context,
+	ds fleet.Datastore,
+	ver fleet.OSVersion,
+	vulnPath string,
+	collectVulns bool,
+) ([]fleet.SoftwareVulnerability, error) {
+	platform := oval.NewPlatform(ver.Platform, ver.Name)
+	source := fleet.GovalDictionarySource
+	if !platform.IsGovalDictionarySupported() {
+		return nil, nil
+	}
+	db, err := loadDb(platform, vulnPath)
+	if err != nil {
+		return nil, err
+	}
+
+	// Since hosts and software have a M:N relationship, the following sets are used to
+	// avoid doing duplicated inserts/delete operations (a vulnerable software might be
+	// present in many hosts).
+	toInsertSet := make(map[string]fleet.SoftwareVulnerability)
+	toDeleteSet := make(map[string]fleet.SoftwareVulnerability)
+
+	var offset int
+	for {
+		hostIDs, err := ds.HostIDsByOSVersion(ctx, ver, offset, hostsBatchSize)
+		if err != nil {
+			return nil, err
+		}
+
+		if len(hostIDs) == 0 {
+			break
+		}
+		offset += hostsBatchSize
+
+		foundInBatch := make(map[uint][]fleet.SoftwareVulnerability)
+		for _, hostID := range hostIDs {
+			hostID := hostID
+			software, err := ds.ListSoftwareForVulnDetection(ctx, fleet.VulnSoftwareFilter{HostID: &hostID})
+			if err != nil {
+				return nil, err
+			}
+
+			vulnerabilities, err := db.Eval(ver, software)
+			if err != nil {
+				return nil, err
+			}
+			foundInBatch[hostID] = vulnerabilities
+		}
+
+		existingInBatch, err := ds.ListSoftwareVulnerabilitiesByHostIDsSource(ctx, hostIDs, source)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, hostID := range hostIDs {
+			inserts, deletes := utils.VulnsDelta(foundInBatch[hostID], existingInBatch[hostID])
+			for _, i := range inserts {
+				toInsertSet[i.Key()] = i
+			}
+			for _, d := range deletes {
+				toDeleteSet[d.Key()] = d
+			}
+		}
+	}
+
+	err = utils.BatchProcess(toDeleteSet, func(v []fleet.SoftwareVulnerability) error {
+		return ds.DeleteSoftwareVulnerabilities(ctx, v)
+	}, vulnBatchSize)
+	if err != nil {
+		return nil, err
+	}
+
+	var inserted []fleet.SoftwareVulnerability
+	if collectVulns {
+		inserted = make([]fleet.SoftwareVulnerability, 0, len(toInsertSet))
+	}
+
+	err = utils.BatchProcess(toInsertSet, func(vulns []fleet.SoftwareVulnerability) error {
+		for _, v := range vulns {
+			ok, err := ds.InsertSoftwareVulnerability(ctx, v, source)
+			if err != nil {
+				return err
+			}
+
+			if collectVulns && ok {
+				inserted = append(inserted, v)
+			}
+		}
+		return nil
+	}, vulnBatchSize)
+	if err != nil {
+		return nil, err
+	}
+
+	return inserted, nil
+}
+
+// loadDb returns the latest goval_dictionary database for the given platform.
+func loadDb(platform oval.Platform, vulnPath string) (VulnDataSource, error) {
+	if !platform.IsGovalDictionarySupported() {
+		return nil, fmt.Errorf("platform %q not supported", platform)
+	}
+
+	fileName := platform.ToGovalDictionaryFilename()
+	latest, err := utils.LatestFile(fileName, vulnPath)
+	if err != nil {
+		return nil, err
+	}
+
+	sqlite, err := sql.Open("sqlite3", latest)
+	if err != nil {
+		return nil, err
+	}
+
+	db := NewDB(sqlite)
+	return db, nil
+}

--- a/server/vulnerabilities/goval_dictionary/analyzer.go
+++ b/server/vulnerabilities/goval_dictionary/analyzer.go
@@ -8,6 +8,7 @@ import (
 	"github.com/fleetdm/fleet/v4/server/fleet"
 	"github.com/fleetdm/fleet/v4/server/vulnerabilities/oval"
 	"github.com/fleetdm/fleet/v4/server/vulnerabilities/utils"
+	kitlog "github.com/go-kit/log"
 )
 
 const (
@@ -26,6 +27,7 @@ func Analyze(
 	ver fleet.OSVersion,
 	vulnPath string,
 	collectVulns bool,
+	logger kitlog.Logger,
 ) ([]fleet.SoftwareVulnerability, error) {
 	platform := oval.NewPlatform(ver.Platform, ver.Name)
 	source := fleet.GovalDictionarySource
@@ -63,10 +65,7 @@ func Analyze(
 				return nil, err
 			}
 
-			vulnerabilities, err := db.Eval(software)
-			if err != nil {
-				return nil, err
-			}
+			vulnerabilities := db.Eval(software, logger)
 			foundInBatch[hostID] = vulnerabilities
 		}
 

--- a/server/vulnerabilities/goval_dictionary/analyzer.go
+++ b/server/vulnerabilities/goval_dictionary/analyzer.go
@@ -14,6 +14,9 @@ const (
 	vulnBatchSize  = 500
 )
 
+// Analyze scans all hosts for vulnerabilities based on the sqlite output of goval-dictionary
+// for their platform,  inserting any new vulnerabilities and deleting anything patched.
+// Returns nil, nil when the platform isn't supported.
 func Analyze(
 	ctx context.Context,
 	ds fleet.Datastore,

--- a/server/vulnerabilities/goval_dictionary/database.go
+++ b/server/vulnerabilities/goval_dictionary/database.go
@@ -1,0 +1,71 @@
+package goval_dictionary
+
+import (
+	"database/sql"
+	"errors"
+	"fmt"
+	"github.com/fleetdm/fleet/v4/server/fleet"
+	"github.com/fleetdm/fleet/v4/server/vulnerabilities/utils"
+	"strings"
+)
+
+type VulnDataSource interface {
+	// Eval evaluates the current OVAL definition against an OS version and a list of installed software, returns all software
+	// vulnerabilities found.
+	Eval(fleet.OSVersion, []fleet.Software) ([]fleet.SoftwareVulnerability, error)
+}
+
+func NewDB(db *sql.DB) *Database {
+	return &Database{sqlite: db}
+}
+
+type Database struct {
+	sqlite *sql.DB
+}
+
+// Eval evaluates the current goval_dictionary database against an OS version and a list of installed software,
+// returns all software vulnerabilities found.
+func (db Database) Eval(version fleet.OSVersion, software []fleet.Software) ([]fleet.SoftwareVulnerability, error) {
+	searchStmt := `SELECT packages.version, cves.cve_id 
+		FROM packages join definitions on definitions.id = packages.definition_id
+		JOIN advisories ON advisories.definition_id = definitions.id JOIN cves ON cves.advisory_id = advisories.id
+		WHERE packages.name = ? AND packages.arch = ?`
+	vulnerabilities := make([]fleet.SoftwareVulnerability, 0)
+
+	for _, swItem := range software {
+		affectedSoftwareRows, err := db.sqlite.Query(searchStmt, swItem.Name, swItem.Arch)
+		if errors.Is(err, sql.ErrNoRows) {
+			continue // No vulns for this package-OS combo
+		}
+		if err != nil {
+			return nil, fmt.Errorf("could not query goval_dictionary database for package %s", swItem.Name)
+		}
+		defer affectedSoftwareRows.Close()
+		for affectedSoftwareRows.Next() {
+			var fixedVersionWithEpochPrefix, cve string
+			if err := affectedSoftwareRows.Scan(&fixedVersionWithEpochPrefix, &cve); err != nil {
+				return nil, fmt.Errorf("could not read package vulnerability result %s", swItem.Name)
+			} else if affectedSoftwareRows.Err() != nil {
+				return nil, affectedSoftwareRows.Err()
+			}
+
+			var currentVersion string
+			if swItem.Release != "" {
+				currentVersion = fmt.Sprintf("%s-%s", swItem.Version, swItem.Release)
+			} else {
+				currentVersion = swItem.Version
+			}
+			fixedVersion := strings.Split(fixedVersionWithEpochPrefix, ":")[1]
+
+			if utils.Rpmvercmp(currentVersion, fixedVersion) < 0 {
+				vulnerabilities = append(vulnerabilities, fleet.SoftwareVulnerability{
+					SoftwareID:        swItem.ID,
+					CVE:               cve,
+					ResolvedInVersion: &fixedVersion,
+				})
+			}
+		}
+	}
+
+	return vulnerabilities, nil
+}

--- a/server/vulnerabilities/goval_dictionary/database.go
+++ b/server/vulnerabilities/goval_dictionary/database.go
@@ -33,7 +33,7 @@ func (db Database) Eval(software []fleet.Software, logger kitlog.Logger) []fleet
 		err := func() error {
 			affectedSoftwareRows, err := db.sqlite.Query(searchStmt, swItem.Name, swItem.Arch)
 			if err != nil {
-				return fmt.Errorf("could not query database for package %s: %w", swItem.Name, err)
+				return fmt.Errorf("could not query database: %w", err)
 			}
 			defer affectedSoftwareRows.Close()
 			for affectedSoftwareRows.Next() {

--- a/server/vulnerabilities/goval_dictionary/database.go
+++ b/server/vulnerabilities/goval_dictionary/database.go
@@ -5,27 +5,23 @@ import (
 	"errors"
 	"fmt"
 	"github.com/fleetdm/fleet/v4/server/fleet"
+	"github.com/fleetdm/fleet/v4/server/vulnerabilities/oval"
 	"github.com/fleetdm/fleet/v4/server/vulnerabilities/utils"
 	"strings"
 )
 
-type VulnDataSource interface {
-	// Eval evaluates the current OVAL definition against an OS version and a list of installed software, returns all software
-	// vulnerabilities found.
-	Eval(fleet.OSVersion, []fleet.Software) ([]fleet.SoftwareVulnerability, error)
-}
-
-func NewDB(db *sql.DB) *Database {
-	return &Database{sqlite: db}
+func NewDB(db *sql.DB, platform oval.Platform) *Database {
+	return &Database{sqlite: db, platform: platform}
 }
 
 type Database struct {
-	sqlite *sql.DB
+	sqlite   *sql.DB
+	platform oval.Platform
 }
 
 // Eval evaluates the current goval_dictionary database against an OS version and a list of installed software,
 // returns all software vulnerabilities found.
-func (db Database) Eval(version fleet.OSVersion, software []fleet.Software) ([]fleet.SoftwareVulnerability, error) {
+func (db Database) Eval(software []fleet.Software) ([]fleet.SoftwareVulnerability, error) {
 	searchStmt := `SELECT packages.version, cves.cve_id 
 		FROM packages join definitions on definitions.id = packages.definition_id
 		JOIN advisories ON advisories.definition_id = definitions.id JOIN cves ON cves.advisory_id = advisories.id

--- a/server/vulnerabilities/goval_dictionary/database.go
+++ b/server/vulnerabilities/goval_dictionary/database.go
@@ -26,7 +26,7 @@ func (db Database) Eval(software []fleet.Software, logger kitlog.Logger) []fleet
 	searchStmt := `SELECT packages.version, cves.cve_id 
 		FROM packages join definitions on definitions.id = packages.definition_id
 		JOIN advisories ON advisories.definition_id = definitions.id JOIN cves ON cves.advisory_id = advisories.id
-		WHERE packages.name = ? AND packages.arch = ?`
+		WHERE packages.name = ? AND packages.arch = ? ORDER BY cve_id, version`
 	vulnerabilities := make([]fleet.SoftwareVulnerability, 0)
 
 	for _, swItem := range software {

--- a/server/vulnerabilities/goval_dictionary/database.go
+++ b/server/vulnerabilities/goval_dictionary/database.go
@@ -42,6 +42,7 @@ func (db Database) Eval(software []fleet.Software, logger kitlog.Logger) []fleet
 					level.Error(logger).Log(
 						"msg", "could not read package vulnerability result",
 						"package", swItem.Name,
+						"arch", swItem.Arch,
 						"platform", db.platform,
 						"err", err,
 					)
@@ -75,6 +76,7 @@ func (db Database) Eval(software []fleet.Software, logger kitlog.Logger) []fleet
 			level.Error(logger).Log(
 				"msg", "could not read package vulnerabilities",
 				"package", swItem.Name,
+				"arch", swItem.Arch,
 				"platform", db.platform,
 				"err", err,
 			)

--- a/server/vulnerabilities/goval_dictionary/database_test.go
+++ b/server/vulnerabilities/goval_dictionary/database_test.go
@@ -1,0 +1,48 @@
+package goval_dictionary
+
+import (
+	"database/sql"
+	"testing"
+)
+
+func TestDatabase(t *testing.T) {
+	// build minimal slice of goval-dictionary sqlite schema
+	db, err := sql.Open("sqlite3", ":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	db.Exec("CREATE TABLE packages (name TEXT NOT NULL, arch TEXT NOT NULL, version TEXT NOT NULL, definition_id INTEGER NOT NULL)")
+	db.Exec("CREATE TABLE cves (cve_id TEXT NOT NULL, advisory_id INTEGER NOT NULL)")
+	db.Exec("CREATE TABLE definitions (id INTEGER NOT NULL PRIMARY KEY)")
+	db.Exec("CREATE TABLE advisories (id INTEGER NOT NULL PRIMARY KEY, definition_id INTEGER NOT NULL)")
+
+	// TODO populate goval-dictionary sqlite schema with a few vulnerabilities
+
+	t.Run("Non-matching architecture", func(t *testing.T) {
+		// TODO
+	})
+
+	t.Run("Non-matching package name", func(t *testing.T) {
+		// TODO
+	})
+
+	t.Run("Fixed version", func(t *testing.T) {
+		// TODO
+	})
+
+	t.Run("Newer than fixed version", func(t *testing.T) {
+		// TODO
+	})
+
+	t.Run("Older than fixed version", func(t *testing.T) {
+		// TODO
+	})
+
+	t.Run("Multiple packages, fixed version", func(t *testing.T) {
+		// TODO
+	})
+
+	t.Run("Multiple packages, multiple vulnerabilities", func(t *testing.T) {
+		// TODO
+	})
+}

--- a/server/vulnerabilities/goval_dictionary/database_test.go
+++ b/server/vulnerabilities/goval_dictionary/database_test.go
@@ -2,47 +2,92 @@ package goval_dictionary
 
 import (
 	"database/sql"
+	"github.com/fleetdm/fleet/v4/server/fleet"
+	"github.com/fleetdm/fleet/v4/server/vulnerabilities/oval"
+	kitlog "github.com/go-kit/log"
+	"github.com/stretchr/testify/require"
 	"testing"
 )
 
 func TestDatabase(t *testing.T) {
 	// build minimal slice of goval-dictionary sqlite schema
-	db, err := sql.Open("sqlite3", ":memory:")
+	sqlite, err := sql.Open("sqlite3", ":memory:")
 	if err != nil {
 		t.Fatal(err)
 	}
-	db.Exec("CREATE TABLE packages (name TEXT NOT NULL, arch TEXT NOT NULL, version TEXT NOT NULL, definition_id INTEGER NOT NULL)")
-	db.Exec("CREATE TABLE cves (cve_id TEXT NOT NULL, advisory_id INTEGER NOT NULL)")
-	db.Exec("CREATE TABLE definitions (id INTEGER NOT NULL PRIMARY KEY)")
-	db.Exec("CREATE TABLE advisories (id INTEGER NOT NULL PRIMARY KEY, definition_id INTEGER NOT NULL)")
-
-	// TODO populate goval-dictionary sqlite schema with a few vulnerabilities
+	dbSetupQueries := []string{
+		// create schema
+		"CREATE TABLE packages (name TEXT NOT NULL, arch TEXT NOT NULL, version TEXT NOT NULL, definition_id INTEGER NOT NULL)",
+		"CREATE TABLE definitions (id INTEGER NOT NULL PRIMARY KEY)",
+		"CREATE TABLE advisories (id INTEGER NOT NULL PRIMARY KEY, definition_id INTEGER NOT NULL)",
+		"CREATE TABLE cves (cve_id TEXT NOT NULL, advisory_id INTEGER NOT NULL)",
+		// insert records
+		`INSERT INTO packages (name, arch, version, definition_id) VALUES
+		  ('expat', 'aarch64', '0:2.1.0-15.amzn2.0.3', 1), ('krb5-server', 'aarch64', '0:1.15.1-55.amzn2.2.8', 2)`,
+		"INSERT INTO definitions (id) VALUES (1), (2)",
+		"INSERT INTO advisories (id, definition_id) VALUES (1, 1), (2, 2)",
+		`INSERT INTO cves (cve_id, advisory_id) VALUES
+		   ('CVE-2022-23990', 1), ('CVE-2022-25313', 1), ('CVE-2024-37370', 2), ('CVE-2024-37371', 2)`,
+	}
+	for _, query := range dbSetupQueries {
+		if _, err := sqlite.Exec(query); err != nil {
+			t.Fatal(err)
+		}
+	}
+	db := NewDB(sqlite, oval.NewPlatform("amzn", "Amazon Linux 2.0.0"))
+	logger := kitlog.NewNopLogger()
 
 	t.Run("Non-matching architecture", func(t *testing.T) {
-		// TODO
+		require.Len(t, db.Eval([]fleet.Software{{Name: "expat", Version: "2.1.0", Release: "", Arch: "x86_64"}}, logger), 0)
 	})
 
 	t.Run("Non-matching package name", func(t *testing.T) {
-		// TODO
+		require.Len(t, db.Eval([]fleet.Software{{Name: "expath", Version: "2.1.0", Release: "", Arch: "aarch64"}}, logger), 0)
 	})
 
 	t.Run("Fixed version", func(t *testing.T) {
-		// TODO
+		require.Len(t, db.Eval([]fleet.Software{{Name: "expath", Version: "2.1.0", Release: "15.amzn2.0.3", Arch: "aarch64"}}, logger), 0)
 	})
 
 	t.Run("Newer than fixed version", func(t *testing.T) {
-		// TODO
+		require.Len(t, db.Eval([]fleet.Software{{Name: "expath", Version: "2.1.0", Release: "15.amzn2.0.5", Arch: "aarch64"}}, logger), 0)
 	})
 
 	t.Run("Older than fixed version", func(t *testing.T) {
-		// TODO
+		vulns := db.Eval([]fleet.Software{{Name: "expat", Version: "2.1.0", Release: "", Arch: "aarch64", ID: 123}}, logger)
+		require.Len(t, vulns, 2)
+		require.Equal(t, "2.1.0-15.amzn2.0.3", *vulns[0].ResolvedInVersion)
+		require.Equal(t, "2.1.0-15.amzn2.0.3", *vulns[1].ResolvedInVersion)
+		require.Equal(t, "CVE-2022-23990", vulns[0].CVE)
+		require.Equal(t, "CVE-2022-25313", vulns[1].CVE)
+		require.Equal(t, uint(123), vulns[0].SoftwareID)
+		require.Equal(t, uint(123), vulns[1].SoftwareID)
 	})
 
 	t.Run("Multiple packages, fixed version", func(t *testing.T) {
-		// TODO
+		require.Len(t, db.Eval([]fleet.Software{
+			{Name: "expat", Version: "2.1.0", Release: "15.amzn2.1.0", Arch: "aarch64"},
+			{Name: "krb5-server", Version: "1.15.1", Release: "55.amzn2.2.8", Arch: "aarch64"},
+		}, logger), 0)
 	})
 
 	t.Run("Multiple packages, multiple vulnerabilities", func(t *testing.T) {
-		// TODO
+		vulns := db.Eval([]fleet.Software{
+			{Name: "expat", Version: "2.1.0", Release: "15.amzn2.0.2", Arch: "aarch64", ID: 234},
+			{Name: "krb5-server", Version: "1.15.1", Release: "55.amzn2.2.7", Arch: "aarch64", ID: 235},
+		}, logger)
+		require.Len(t, vulns, 4)
+
+		require.Equal(t, "2.1.0-15.amzn2.0.3", *vulns[0].ResolvedInVersion)
+		require.Equal(t, "2.1.0-15.amzn2.0.3", *vulns[1].ResolvedInVersion)
+		require.Equal(t, "1.15.1-55.amzn2.2.8", *vulns[2].ResolvedInVersion)
+		require.Equal(t, "CVE-2022-23990", vulns[0].CVE)
+		require.Equal(t, "CVE-2022-25313", vulns[1].CVE)
+		require.Equal(t, "CVE-2024-37370", vulns[2].CVE)
+		require.Equal(t, "CVE-2024-37371", vulns[3].CVE)
+		require.Equal(t, uint(234), vulns[0].SoftwareID)
+		require.Equal(t, uint(234), vulns[1].SoftwareID)
+		require.Equal(t, uint(235), vulns[2].SoftwareID)
+		require.Equal(t, uint(235), vulns[3].SoftwareID)
 	})
 }

--- a/server/vulnerabilities/goval_dictionary/sync.go
+++ b/server/vulnerabilities/goval_dictionary/sync.go
@@ -1,25 +1,27 @@
 package goval_dictionary
 
 import (
-	"context"
 	"fmt"
 	"github.com/fleetdm/fleet/v4/pkg/download"
 	"github.com/fleetdm/fleet/v4/pkg/fleethttp"
 	"github.com/fleetdm/fleet/v4/server/fleet"
 	"github.com/fleetdm/fleet/v4/server/vulnerabilities/nvd"
 	"github.com/fleetdm/fleet/v4/server/vulnerabilities/oval"
+	kitlog "github.com/go-kit/log"
+	"github.com/go-kit/log/level"
 	"net/http"
 	"net/url"
 	"path/filepath"
 )
 
 func Refresh(
-	ctx context.Context,
 	versions *fleet.OSVersions,
 	vulnPath string,
+	logger kitlog.Logger,
 ) ([]oval.Platform, error) {
 	toDownload := whatToDownload(versions)
 	if len(toDownload) > 0 {
+		level.Debug(logger).Log("msg", "goval_dictionary-sync-downloading")
 		err := Sync(vulnPath, toDownload)
 		if err != nil {
 			return nil, err

--- a/server/vulnerabilities/goval_dictionary/sync.go
+++ b/server/vulnerabilities/goval_dictionary/sync.go
@@ -1,0 +1,90 @@
+package goval_dictionary
+
+import (
+	"context"
+	"fmt"
+	"github.com/fleetdm/fleet/v4/pkg/download"
+	"github.com/fleetdm/fleet/v4/pkg/fleethttp"
+	"github.com/fleetdm/fleet/v4/server/fleet"
+	"github.com/fleetdm/fleet/v4/server/vulnerabilities/nvd"
+	"github.com/fleetdm/fleet/v4/server/vulnerabilities/oval"
+	"net/http"
+	"net/url"
+	"path/filepath"
+)
+
+func Refresh(
+	ctx context.Context,
+	versions *fleet.OSVersions,
+	vulnPath string,
+) ([]oval.Platform, error) {
+	toDownload := whatToDownload(versions)
+	if len(toDownload) > 0 {
+		err := Sync(vulnPath, toDownload)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return toDownload, nil
+}
+
+func Sync(dstDir string, platforms []oval.Platform) error {
+	client := fleethttp.NewClient()
+	dwn := downloadDecompressed(client)
+	basePath, err := nvd.GetGitHubCVEAssetPath()
+	if err != nil {
+		return err
+	}
+
+	for _, platform := range platforms {
+		err := downloadDatabase(platform, dwn, basePath, dstDir)
+		if err != nil {
+			return fmt.Errorf("downloadDefinitions: %w", err)
+		}
+	}
+	return nil
+}
+
+func downloadDatabase(
+	platform oval.Platform,
+	downloader func(string, string) error,
+	basePath string,
+	vulnDir string,
+) error {
+	dstPath := filepath.Join(vulnDir, platform.ToGovalDictionaryFilename())
+	err := downloader(basePath+string(platform)+".sqlite3.xz", dstPath)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func downloadDecompressed(client *http.Client) func(string, string) error {
+	return func(u, dstPath string) error {
+		parsedUrl, err := url.Parse(u)
+		if err != nil {
+			return fmt.Errorf("url parse: %w", err)
+		}
+
+		err = download.DownloadAndExtract(client, parsedUrl, dstPath)
+		if err != nil {
+			return fmt.Errorf("download and extract url %s: %w", parsedUrl, err)
+		}
+
+		return nil
+	}
+}
+
+func whatToDownload(osVers *fleet.OSVersions) []oval.Platform {
+	var r []oval.Platform
+	for _, os := range osVers.OSVersions {
+		platform := oval.NewPlatform(os.Platform, os.Name)
+		if platform.IsGovalDictionarySupported() {
+			r = append(r, platform)
+		}
+	}
+
+	return r
+}

--- a/server/vulnerabilities/goval_dictionary/sync.go
+++ b/server/vulnerabilities/goval_dictionary/sync.go
@@ -38,9 +38,8 @@ func Sync(dstDir string, platforms []oval.Platform) error {
 	}
 
 	for _, platform := range platforms {
-		err := downloadDatabase(platform, dwn, basePath, dstDir)
-		if err != nil {
-			return fmt.Errorf("downloadDefinitions: %w", err)
+		if err := downloadDatabase(platform, dwn, basePath, dstDir); err != nil {
+			return err
 		}
 	}
 	return nil
@@ -53,8 +52,7 @@ func downloadDatabase(
 	vulnDir string,
 ) error {
 	dstPath := filepath.Join(vulnDir, platform.ToGovalDictionaryFilename())
-	err := downloader(basePath+string(platform)+".sqlite3.xz", dstPath)
-	if err != nil {
+	if err := downloader(basePath+string(platform)+".sqlite3.xz", dstPath); err != nil {
 		return err
 	}
 
@@ -68,8 +66,7 @@ func downloadDecompressed(client *http.Client) func(string, string) error {
 			return fmt.Errorf("url parse: %w", err)
 		}
 
-		err = download.DownloadAndExtract(client, parsedUrl, dstPath)
-		if err != nil {
+		if err = download.DownloadAndExtract(client, parsedUrl, dstPath); err != nil {
 			return fmt.Errorf("download and extract url %s: %w", parsedUrl, err)
 		}
 

--- a/server/vulnerabilities/goval_dictionary/sync_test.go
+++ b/server/vulnerabilities/goval_dictionary/sync_test.go
@@ -1,0 +1,34 @@
+package goval_dictionary
+
+import (
+	"github.com/fleetdm/fleet/v4/server/fleet"
+	"github.com/fleetdm/fleet/v4/server/vulnerabilities/oval"
+	"github.com/stretchr/testify/require"
+	"testing"
+	"time"
+)
+
+func TestSync(t *testing.T) {
+	t.Run("#whatToDownload", func(t *testing.T) {
+		osVersions := fleet.OSVersions{
+			CountsUpdatedAt: time.Now(),
+			OSVersions: []fleet.OSVersion{
+				{
+					HostsCount: 1,
+					Platform:   "ubuntu",
+					Name:       "Ubuntu 20.4.0",
+				},
+				{
+					HostsCount: 1,
+					Platform:   "amzn",
+					Name:       "Amazon Linux 2.0.0",
+				},
+			},
+		}
+
+		result := whatToDownload(&osVersions)
+		require.Len(t, result, 1)
+		require.Contains(t, result, oval.NewPlatform("amzn", "Amazon Linux 2.0.0"))
+		require.NotContains(t, result, oval.NewPlatform("ubuntu", "Ubuntu 20.4.0"))
+	})
+}

--- a/server/vulnerabilities/nvd/cpe.go
+++ b/server/vulnerabilities/nvd/cpe.go
@@ -440,7 +440,7 @@ func TranslateSoftwareToCPE(
 	vulnPath string,
 	logger kitlog.Logger,
 ) error {
-	// Skip software from sources for which we will be using OVAL for vulnerability detection.
+	// Skip software from sources for which we will be using OVAL or goval-dictionary for vulnerability detection.
 	nonOvalIterator, err := ds.AllSoftwareIterator(
 		ctx,
 		fleet.SoftwareIterQueryOptions{

--- a/server/vulnerabilities/oval/analyzer.go
+++ b/server/vulnerabilities/oval/analyzer.go
@@ -18,7 +18,8 @@ const (
 )
 
 // Analyze scans all hosts for vulnerabilities based on the OVAL definitions for their platform,
-// inserting any new vulnerabilities and deleting anything patched.
+// inserting any new vulnerabilities and deleting anything patched. Returns nil, nil when
+// the platform isn't supported.
 func Analyze(
 	ctx context.Context,
 	ds fleet.Datastore,

--- a/server/vulnerabilities/oval/analyzer.go
+++ b/server/vulnerabilities/oval/analyzer.go
@@ -3,6 +3,7 @@ package oval
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"time"
@@ -16,6 +17,8 @@ const (
 	hostsBatchSize = 500
 	vulnBatchSize  = 500
 )
+
+var ErrUnsupportedPlatform = errors.New("unsupported platform")
 
 // Analyze scans all hosts for vulnerabilities based on the OVAL definitions for their platform,
 // inserting any new vulnerabilities and deleting anything patched. Returns nil, nil when
@@ -35,7 +38,7 @@ func Analyze(
 	}
 
 	if !platform.IsSupported() {
-		return nil, nil
+		return nil, ErrUnsupportedPlatform
 	}
 
 	defs, err := loadDef(platform, vulnPath)

--- a/server/vulnerabilities/oval/analyzer_test.go
+++ b/server/vulnerabilities/oval/analyzer_test.go
@@ -121,7 +121,7 @@ func extractFixtures(
 	extract(srcCvesPath, dstCvesPath, t)
 }
 
-func withTestFixutre(
+func withTestFixture(
 	version fleet.OSVersion,
 	ovalFixtureDir string,
 	softwareFixtureDir string,
@@ -218,7 +218,7 @@ func BenchmarkTestOvalAnalyzer(b *testing.B) {
 
 		for _, v := range systems {
 			b.Run(fmt.Sprintf("for %s %s", v.Platform, v.Name), func(b *testing.B) {
-				withTestFixutre(v, ovalFixtureDir, softwareFixtureDir, vulnPath, ds, func(h *fleet.Host) {
+				withTestFixture(v, ovalFixtureDir, softwareFixtureDir, vulnPath, ds, func(h *fleet.Host) {
 					b.ResetTimer()
 					for i := 0; i < b.N; i++ {
 						_, err := Analyze(context.Background(), ds, v, vulnPath, true)
@@ -269,7 +269,7 @@ func BenchmarkTestOvalAnalyzer(b *testing.B) {
 
 		for _, v := range systems {
 			b.Run(fmt.Sprintf("for %s %s", v.version.Platform, v.version.Name), func(b *testing.B) {
-				withTestFixutre(v.version, v.ovalFixtureDir, v.softwareFixtureDir, vulnPath, ds, func(h *fleet.Host) {
+				withTestFixture(v.version, v.ovalFixtureDir, v.softwareFixtureDir, vulnPath, ds, func(h *fleet.Host) {
 					b.ResetTimer()
 					for i := 0; i < b.N; i++ {
 						_, err := Analyze(context.Background(), ds, v.version, vulnPath, true)
@@ -323,7 +323,7 @@ func TestOvalAnalyzer(t *testing.T) {
 		}
 
 		for _, s := range systems {
-			withTestFixutre(s.version, s.ovalFixtureDir, s.softwareFixtureDir, vulnPath, ds, func(h *fleet.Host) {
+			withTestFixture(s.version, s.ovalFixtureDir, s.softwareFixtureDir, vulnPath, ds, func(h *fleet.Host) {
 				_, err := Analyze(ctx, ds, s.version, vulnPath, true)
 				require.NoError(t, err)
 				p := NewPlatform(s.version.Platform, s.version.Name)
@@ -355,7 +355,7 @@ func TestOvalAnalyzer(t *testing.T) {
 		ovalFixtureDir := "ubuntu"
 		softwareFixtureDir := filepath.Join("ubuntu", "software")
 		for _, v := range systems {
-			withTestFixutre(v, ovalFixtureDir, softwareFixtureDir, vulnPath, ds, func(h *fleet.Host) {
+			withTestFixture(v, ovalFixtureDir, softwareFixtureDir, vulnPath, ds, func(h *fleet.Host) {
 				_, err := Analyze(ctx, ds, v, vulnPath, true)
 				require.NoError(t, err)
 

--- a/server/vulnerabilities/oval/oval_platform.go
+++ b/server/vulnerabilities/oval/oval_platform.go
@@ -13,8 +13,9 @@ type Platform string
 
 // OvalFilePrefix is the file prefix used when saving an OVAL artifact.
 const OvalFilePrefix = "fleet_oval"
+const GovalDictionaryFilePrefix = "fleet_goval_dictionary"
 
-// SupportedSoftwareSources are the software sources for which we are using OVAL for vulnerability detection.
+// SupportedSoftwareSources are the software sources for which we are using OVAL or goval-dictionary for vulnerability detection.
 var SupportedSoftwareSources = []string{"deb_packages", "rpm_packages"}
 
 // getMajorMinorVer returns the major and minor version of an 'os_version'.
@@ -69,6 +70,10 @@ func (op Platform) ToFilename(date time.Time, extension string) string {
 	return fmt.Sprintf("%s_%s-%d_%02d_%02d.%s", OvalFilePrefix, op, date.Year(), date.Month(), date.Day(), extension)
 }
 
+func (op Platform) ToGovalDictionaryFilename() string {
+	return fmt.Sprintf("%s_%s.sqlite3", GovalDictionaryFilePrefix, op)
+}
+
 // IsSupported returns whether the given platform is currently supported.
 func (op Platform) IsSupported() bool {
 	supported := []string{
@@ -89,8 +94,23 @@ func (op Platform) IsSupported() bool {
 		"rhel_07",
 		"rhel_08",
 		"rhel_09",
-		"amzn_02",
 	}
+	for _, p := range supported {
+		if strings.HasPrefix(string(op), p) {
+			return true
+		}
+	}
+	return false
+}
+
+func (op Platform) IsGovalDictionarySupported() bool {
+	supported := []string{
+		"amzn_01",
+		"amzn_02",
+		"amzn_2022",
+		"amzn_2023",
+	}
+
 	for _, p := range supported {
 		if strings.HasPrefix(string(op), p) {
 			return true

--- a/server/vulnerabilities/oval/oval_platform_test.go
+++ b/server/vulnerabilities/oval/oval_platform_test.go
@@ -27,6 +27,7 @@ func TestOvalPlatform(t *testing.T) {
 			{"ubuntu", "Ubuntu 18.4.0 LTS asdfasd", "ubuntu_1804"},
 			{"rhel", "CentOS Linux 7.9.2009", "rhel_07"},
 			{"amzn", "Amazon Linux 2.0.0", "amzn_02"},
+			{"amzn", "Amazon Linux 2023.0.0", "amzn_2023"},
 			{"rhel", "Fedora Linux 12.0.0", "rhel_06"},
 			{"rhel", "Fedora Linux 13.0.0", "rhel_06"},
 			{"rhel", "Fedora Linux 14.0.0", "rhel_06"},
@@ -71,6 +72,20 @@ func TestOvalPlatform(t *testing.T) {
 		for _, c := range cases {
 			plat := NewPlatform("ubuntu", "Ubuntu 20.4.0")
 			require.Equal(t, c.expected, plat.ToFilename(c.date, "json"))
+		}
+	})
+
+	t.Run("ToGovalDictionaryFilename", func(t *testing.T) {
+		cases := []struct {
+			version  string
+			expected string
+		}{
+			{"Amazon Linux 2.0.0", "fleet_goval_dictionary_amzn_02.sqlite3"},
+			{"Amazon Linux 2023.0.0", "fleet_goval_dictionary_amzn_2023.sqlite3"},
+		}
+		for _, c := range cases {
+			plat := NewPlatform("amzn", c.version)
+			require.Equal(t, c.expected, plat.ToGovalDictionaryFilename())
 		}
 	})
 }


### PR DESCRIPTION
#20934

I fully expect some back-and-forth on this as I expect code is rather naive/non-idiomatic (particularly adding methods to `oval_platform` and another place or two, to try to avoid even more code duplication), but the underlying logic works so...progress!

This is tied to https://github.com/fleetdm/vulnerabilities/pull/14; for supported OS versions (currently Amazon Linux 1/2/2022/2023) we'll pull XZ'd sqlite files from the vulnerabilities repo and query them to determine what's vulnerable. See the associated issue for how I self-QA'd this.

This replaced OVAL parsing for Amazon Linux 2, as we were using the wrong data source there (Amazon has backported a bunch of fixes to their own-named releases, so any RHEL fixes don't match).

Some checklist items are missing here; getting this set up in draft to get code feedback now, and I'll push updates with e.g. docs changes, as well ass an addition to the changes file.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/Committing-Changes.md#changes-files) for more information.
- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [x] Added/updated tests
    - [x] Add tests to oval_platform
    ~~- [ ] Add analyzer_test~~
    - [x] Add sync_test
    - [x] Add database_test
- [x] Manual QA for all new/changed functionality
- [x] Update vulnerability management docs