### PR TITLE
[unreleased bug] Fleet UI: Hide exploit/severity vuln filters for fleet free

### DIFF
--- a/frontend/pages/SoftwarePage/SoftwarePage.tsx
+++ b/frontend/pages/SoftwarePage/SoftwarePage.tsx
@@ -37,7 +37,6 @@ import AddSoftwareModal from "./components/AddSoftwareModal";
 import {
   buildSoftwareFilterQueryParams,
   getSoftwareFilterFromQueryParams,
-  buildSoftwareVulnFiltersQueryParams,
   getSoftwareVulnFiltersFromQueryParams,
   ISoftwareVulnFilters,
 } from "./SoftwareTitles/SoftwareTable/helpers";
@@ -485,6 +484,7 @@ const SoftwarePage = ({ children, router, location }: ISoftwarePageProps) => {
             onExit={toggleSoftwareFiltersModal}
             onSubmit={onApplyVulnFilters}
             vulnFilters={softwareVulnFilters}
+            isPremiumTier={isPremiumTier || false}
           />
         )}
       </div>

--- a/frontend/pages/SoftwarePage/components/SoftwareFiltersModal/SoftwareFiltersModal.tsx
+++ b/frontend/pages/SoftwarePage/components/SoftwareFiltersModal/SoftwareFiltersModal.tsx
@@ -20,12 +20,14 @@ interface ISoftwareFiltersModalProps {
   onExit: () => void;
   onSubmit: (vulnFilters: ISoftwareVulnFilters) => void;
   vulnFilters: ISoftwareVulnFiltersParams;
+  isPremiumTier: boolean;
 }
 
 const SoftwareFiltersModal = ({
   onExit,
   onSubmit,
   vulnFilters,
+  isPremiumTier,
 }: ISoftwareFiltersModalProps) => {
   const [vulnSoftwareFilterEnabled, setVulnSoftwareFilterEnabled] = useState(
     vulnFilters.vulnerable || false
@@ -50,7 +52,7 @@ const SoftwareFiltersModal = ({
   const onApplyFilters = () => {
     onSubmit({
       vulnerable: vulnSoftwareFilterEnabled,
-      exploit: hasKnownExploit,
+      exploit: hasKnownExploit || undefined,
       min_cvss_score: severity?.minSeverity || undefined,
       max_cvss_score: severity?.maxSeverity || undefined,
     });
@@ -78,27 +80,31 @@ const SoftwareFiltersModal = ({
           inactiveText="Vulnerable software"
           activeText="Vulnerable software"
         />
-        <Dropdown
-          label={renderSeverityLabel()}
-          options={SEVERITY_DROPDOWN_OPTIONS}
-          value={severity}
-          onChange={onChangeSeverity}
-          placeholder="Any severity"
-          className={`${baseClass}__select-severity`}
-          disabled={!vulnSoftwareFilterEnabled}
-        />
-        <Checkbox
-          onChange={({ value }: { value: boolean }) =>
-            setHasKnownExploit(value)
-          }
-          name="hasKnownExploit"
-          value={hasKnownExploit}
-          parseTarget
-          helpText="Software has vulnerabilities that have been actively exploited in the wild."
-          disabled={!vulnSoftwareFilterEnabled}
-        >
-          Has known exploit
-        </Checkbox>
+        {isPremiumTier && (
+          <Dropdown
+            label={renderSeverityLabel()}
+            options={SEVERITY_DROPDOWN_OPTIONS}
+            value={severity}
+            onChange={onChangeSeverity}
+            placeholder="Any severity"
+            className={`${baseClass}__select-severity`}
+            disabled={!vulnSoftwareFilterEnabled}
+          />
+        )}
+        {isPremiumTier && (
+          <Checkbox
+            onChange={({ value }: { value: boolean }) =>
+              setHasKnownExploit(value)
+            }
+            name="hasKnownExploit"
+            value={hasKnownExploit}
+            parseTarget
+            helpText="Software has vulnerabilities that have been actively exploited in the wild."
+            disabled={!vulnSoftwareFilterEnabled}
+          >
+            Has known exploit
+          </Checkbox>
+        )}
         <div className="modal-cta-wrap">
           <Button variant="brand" onClick={onApplyFilters}>
             Apply


### PR DESCRIPTION
## Issue
Cerra #21509

## Description
- Hide options as shown in figma specs for fleet free
- Hide exploit=false in URL bar if exploit is not set or set to false