### PR TITLE
Bulk operations dashboard: update edit-script

### DIFF
--- a/ee/bulk-operations-dashboard/api/controllers/scripts/edit-script.js
+++ b/ee/bulk-operations-dashboard/api/controllers/scripts/edit-script.js
@@ -69,7 +69,7 @@ module.exports = {
     } else if (!newScript && !script.teams){// Undeployed profiles are stored in the app's database.
       // console.log('editing an undeployed profile!');
       scriptContents = script.scriptContents;
-      filename = script.name + script.scriptType;
+      filename = script.name;
       extension = script.scriptType;
     }
 


### PR DESCRIPTION
Changes:
- Fixed a bug where an undeployed script would have a duplicate file extension when it is deployed to a team on a Fleet instance