### PR TITLE
Fleet UI: Fix unreleased border showing up on hover of dropdown with no border

### DIFF
--- a/frontend/components/forms/fields/Dropdown/_styles.scss
+++ b/frontend/components/forms/fields/Dropdown/_styles.scss
@@ -70,9 +70,10 @@
 
     &:hover:not(.is-disabled) {
       box-shadow: none;
-      border: 1px solid $core-vibrant-blue;
+      border-color: $core-vibrant-blue;
     }
   }
+
   .Select-control {
     background-color: $ui-light-grey;
     border: 0;


### PR DESCRIPTION
Unreleased bug seen all over UI

Cause of bug:
- https://github.com/fleetdm/fleet/pull/21278/files#r1729113923
- Removing hover color of disabled dropdown accidentally added hover border to any non disabled dropdown

