### PR TITLE
UI – Update host activity feed empty states and tooltip

### DIFF
--- a/changes/20955-host-activity-feed-copy-updates
+++ b/changes/20955-host-activity-feed-copy-updates
@@ -1,0 +1,2 @@
+* Update Host details activities tooltip and empty state copy to reflect recently added
+capabilities.

--- a/frontend/pages/hosts/details/cards/Activity/Activity.tsx
+++ b/frontend/pages/hosts/details/cards/Activity/Activity.tsx
@@ -26,16 +26,18 @@ export type ShowActivityDetailsHandler = (
   data: IShowActivityDetailsData
 ) => void;
 
+
 const UpcomingTooltip = () => {
   return (
     <TooltipWrapper
       tipContent={
         <>
-          Upcoming activities will run as listed. Failure of one activity
-          won&apos;t cancel other activities.
+          Currently, only scripts run before other scripts and
+          <br />
+          software is installed before other software.
           <br />
           <br />
-          Currently, only scripts are guaranteed to run in order.
+          Failure of one activity won&apos;t cancel other activities.
         </>
       }
       className={`${baseClass}__upcoming-tooltip`}

--- a/frontend/pages/hosts/details/cards/Activity/Activity.tsx
+++ b/frontend/pages/hosts/details/cards/Activity/Activity.tsx
@@ -26,7 +26,6 @@ export type ShowActivityDetailsHandler = (
   data: IShowActivityDetailsData
 ) => void;
 
-
 const UpcomingTooltip = () => {
   return (
     <TooltipWrapper

--- a/frontend/pages/hosts/details/cards/Activity/PastActivityFeed/PastActivityFeed.tsx
+++ b/frontend/pages/hosts/details/cards/Activity/PastActivityFeed/PastActivityFeed.tsx
@@ -44,7 +44,7 @@ const PastActivityFeed = ({
     return (
       <EmptyFeed
         title="No activity"
-        message="When a script runs on a host, it shows up here."
+        message="Completed actions will appear here (scripts, software, lock, and wipe)."
         className={`${baseClass}__empty-feed`}
       />
     );

--- a/frontend/pages/hosts/details/cards/Activity/UpcomingActivityFeed/UpcomingActivityFeed.tsx
+++ b/frontend/pages/hosts/details/cards/Activity/UpcomingActivityFeed/UpcomingActivityFeed.tsx
@@ -43,7 +43,7 @@ const UpcomingActivityFeed = ({
     return (
       <EmptyFeed
         title="No pending activity "
-        message="When you run a script on an offline host, it will appear here."
+        message="Pending actions will appear here (scripts, software, lock, and wipe)."
         className={`${baseClass}__empty-feed`}
       />
     );


### PR DESCRIPTION
## Addresses #20955 

<img width="988" alt="Screenshot 2024-08-23 at 8 58 02 AM" src="https://github.com/user-attachments/assets/29d03464-1795-4b2a-b15f-2c974db184ca">
<img width="733" alt="Screenshot 2024-08-23 at 8 58 09 AM" src="https://github.com/user-attachments/assets/780fa0ee-747a-4f73-982b-891042124633">

- [x] Changes file added for user-visible changes in `changes/`, 
- [x] Manual QA for all new/changed functionality