### PR TITLE
Remove unused toxiproxy service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -167,12 +167,6 @@ services:
     volumes:
       - data-minio:/data
 
-  toxiproxy:
-    image: shopify/toxiproxy
-    ports:
-      - "22220:22220"
-      - "8474:8474"
-
 volumes:
   mysql-persistent-volume:
   data-minio:

--- a/docs/Contributing/Simulate-slow-network.md
+++ b/docs/Contributing/Simulate-slow-network.md
@@ -7,6 +7,17 @@ The guide assumes you'll build and run the Fleet server locally with the `make f
 
 (Has been tested on macOS only.)
 
+## 0. Edit docker-compose.yml
+
+Add the following service to the main `docker-compose.yml`:
+```yml
+  toxiproxy:
+    image: shopify/toxiproxy
+    ports:
+      - "22220:22220"
+      - "8474:8474"
+```
+
 ## 1. Start services
 
 ```sh


### PR DESCRIPTION
Everyone running this thing by default when doing `docker compose up` does not make sense. I added it and used once a few years ago.