### PR TITLE
Fleet UI: Fix long flash message bleeding off viewport

### DIFF
--- a/changes/20948-fix-flash-bleeding-off-viewport
+++ b/changes/20948-fix-flash-bleeding-off-viewport
@@ -1,0 +1,1 @@
+- UI Fix: Flash message no longer bleeds off viewport

--- a/frontend/components/FlashMessage/FlashMessage.tsx
+++ b/frontend/components/FlashMessage/FlashMessage.tsx
@@ -65,38 +65,40 @@ const FlashMessage = ({
   }
 
   return (
-    <div className={baseClasses} id={baseClasses}>
-      <div className={`${baseClass}__content`}>
-        <Icon
-          name={alertType === "success" ? "success" : "error"}
-          color="core-fleet-white"
-        />
-        <span>{message}</span>
-        {onUndoActionClick && undoAction && (
-          <Button
-            className={`${baseClass}__undo`}
-            variant="unstyled"
-            onClick={onUndoActionClick(undoAction)}
-          >
-            Undo
-          </Button>
-        )}
-      </div>
-      <div className={`${baseClass}__action`}>
-        <div className={`${baseClass}__ex`}>
-          <button
-            className={`${baseClass}__remove ${baseClass}__remove--${alertType} button--unstyled`}
-            onClick={onRemoveFlash}
-          >
-            <Icon
-              name="close"
-              color={
-                alertType === "warning-filled"
-                  ? "core-fleet-black"
-                  : "core-fleet-white"
-              }
-            />
-          </button>
+    <div className={"flash-message-container"}>
+      <div className={baseClasses} id={baseClasses}>
+        <div className={`${baseClass}__content`}>
+          <Icon
+            name={alertType === "success" ? "success" : "error"}
+            color="core-fleet-white"
+          />
+          <span>{message}</span>
+          {onUndoActionClick && undoAction && (
+            <Button
+              className={`${baseClass}__undo`}
+              variant="unstyled"
+              onClick={onUndoActionClick(undoAction)}
+            >
+              Undo
+            </Button>
+          )}
+        </div>
+        <div className={`${baseClass}__action`}>
+          <div className={`${baseClass}__ex`}>
+            <button
+              className={`${baseClass}__remove ${baseClass}__remove--${alertType} button--unstyled`}
+              onClick={onRemoveFlash}
+            >
+              <Icon
+                name="close"
+                color={
+                  alertType === "warning-filled"
+                    ? "core-fleet-black"
+                    : "core-fleet-white"
+                }
+              />
+            </button>
+          </div>
         </div>
       </div>
     </div>

--- a/frontend/components/FlashMessage/_styles.scss
+++ b/frontend/components/FlashMessage/_styles.scss
@@ -8,11 +8,18 @@
   }
 }
 
-.flash-message {
+// Allows for centering flash message for short and long, wrapped messages
+.flash-message-container {
   @include position(fixed);
   top: 80px;
-  left: 50%;
-  transform: translate(-50%, 0);
+  left: 0;
+  right: 0;
+  display: flex;
+  justify-content: center;
+  z-index: 999;
+}
+
+.flash-message {
   display: flex;
   align-items: center;
   justify-content: center;
@@ -20,11 +27,11 @@
   padding: $pad-small $pad-medium;
   z-index: 999;
   background-color: $core-vibrant-blue;
-  margin: auto;
   border: 1px solid $ui-fleet-black-10;
   box-sizing: border-box;
   box-shadow: 0px 7px 3px -5px rgba(25, 33, 71, 0.1);
   border-radius: 8px;
+  max-width: calc(100% - 64px); // Same horizontal margin as .main-content
 
   &--success {
     background-color: $ui-success;
@@ -42,7 +49,6 @@
       margin-right: 15px;
       font-size: $x-small;
       color: $core-fleet-black;
-      white-space: nowrap;
     }
   }
 
@@ -54,7 +60,6 @@
       margin-left: 15px;
       margin-right: 15px;
       font-size: $x-small;
-      white-space: nowrap;
     }
 
     .fleeticon {


### PR DESCRIPTION
## Issue
Cerra #20948 

## Description
- Put a wrapper around flash message to allow for dynamic widths while maintaining centering of flash message

## Screenrecording
https://www.loom.com/share/1b269a4098684eafbed1a5be6c0a158c?sid=c91553d9-d154-41c9-9335-0edcbf009cce


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/`, 
- [x] Manual QA must be performed in the three main OSs, macOS, Windows and Linux.
