### PR TITLE
Added JSON result and gotestsum

### DIFF
--- a/.github/workflows/test-go.yaml
+++ b/.github/workflows/test-go.yaml
@@ -180,6 +180,14 @@ jobs:
         path: /tmp/gotest.log
         if-no-files-found: error
 
+    - name: Upload JSON result
+      if: always()
+      uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v2
+      with:
+        name: result.json
+        path: ./${{ matrix.suite }}-${{ env.MATRIX_MYSQL_ID }}-result.json
+        if-no-files-found: error
+
     - name: Upload summary test log
       if: always()
       uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v2

--- a/.github/workflows/test-go.yaml
+++ b/.github/workflows/test-go.yaml
@@ -184,8 +184,8 @@ jobs:
       if: always()
       uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v2
       with:
-        name: result.json
-        path: ./${{ matrix.suite }}-${{ env.MATRIX_MYSQL_ID }}-result.json
+        name: ${{ matrix.suite }}-${{ env.MATRIX_MYSQL_ID }}-result.json
+        path: ./result.json
         if-no-files-found: error
 
     - name: Upload summary test log

--- a/Makefile
+++ b/Makefile
@@ -138,7 +138,8 @@ dump-test-schema:
 	go run ./tools/dbutils ./server/datastore/mysql/schema.sql
 
 test-go: dump-test-schema generate-mock
-	go test -tags full,fts5,netgo ${GO_TEST_EXTRA_FLAGS_VAR} -parallel 8 -coverprofile=coverage.txt -covermode=atomic -coverpkg=github.com/fleetdm/fleet/v4/... ./cmd/... ./ee/... ./orbit/pkg/... ./orbit/cmd/orbit ./pkg/... ./server/... ./tools/...
+	go run gotest.tools/gotestsum@latest --jsonfile result.json -- -tags full,fts5,netgo ${GO_TEST_EXTRA_FLAGS_VAR} -parallel 8 -coverprofile=coverage.txt -covermode=atomic -coverpkg=github.com/fleetdm/fleet/v4/... ./cmd/... ./ee/... ./orbit/pkg/... ./orbit/cmd/orbit ./pkg/... ./server/... ./tools/...
+	go run gotest.tools/gotestsum@latest tool slowest --jsonfile result.json
 
 analyze-go:
 	go test -tags full,fts5,netgo -race -cover ./...

--- a/cmd/fleetctl/generate.go
+++ b/cmd/fleetctl/generate.go
@@ -49,24 +49,24 @@ func generateMDMAppleCommand() *cli.Command {
 			// before printing the CSR output message.
 			client, err := clientFromCLI(c)
 			if err != nil {
-				fmt.Fprintf(c.App.ErrWriter, "client from CLI: %s", err)
+				fmt.Fprintf(c.App.ErrWriter, "client from CLI: %s\n", err)
 				return ErrGeneric
 			}
 
 			csr, err := client.RequestAppleCSR()
 			if err != nil {
-				fmt.Fprintf(c.App.ErrWriter, "requesting APNs CSR: %s", err)
+				fmt.Fprintf(c.App.ErrWriter, "requesting APNs CSR: %s\n", err)
 				return ErrGeneric
 			}
 
 			if err := os.WriteFile(csrPath, csr, defaultFileMode); err != nil {
-				fmt.Fprintf(c.App.ErrWriter, "write CSR: %s", err)
+				fmt.Fprintf(c.App.ErrWriter, "write CSR: %s\n", err)
 				return ErrGeneric
 			}
 
 			appCfg, err := client.GetAppConfig()
 			if err != nil {
-				fmt.Fprintf(c.App.ErrWriter, "fetching app config: %s", err)
+				fmt.Fprintf(c.App.ErrWriter, "fetching app config: %s\n", err)
 				return ErrGeneric
 			}
 

--- a/server/datastore/mysql/mysql_test.go
+++ b/server/datastore/mysql/mysql_test.go
@@ -595,7 +595,7 @@ func TestWhereFilterHostsByTeams(t *testing.T) {
 	for _, tt := range testCases {
 		tt := tt
 		t.Run("", func(t *testing.T) {
-			t.Parallel()
+			// t.Parallel() already set for parent test
 			ds := &Datastore{logger: log.NewNopLogger()}
 			sql := ds.whereFilterHostsByTeams(tt.filter, "hosts")
 			assert.Equal(t, tt.expected, sql)
@@ -631,7 +631,7 @@ func TestWhereOmitIDs(t *testing.T) {
 	for _, tt := range testCases {
 		tt := tt
 		t.Run("", func(t *testing.T) {
-			t.Parallel()
+			// t.Parallel() already set for parent test
 			ds := &Datastore{logger: log.NewNopLogger()}
 			sql := ds.whereOmitIDs("id", tt.omits)
 			assert.Equal(t, tt.expected, sql)
@@ -856,7 +856,7 @@ func TestWhereFilterTeams(t *testing.T) {
 	for _, tt := range testCases {
 		tt := tt
 		t.Run("", func(t *testing.T) {
-			t.Parallel()
+			// t.Parallel() already set for parent test
 			ds := &Datastore{logger: log.NewNopLogger()}
 			sql := ds.whereFilterTeams(tt.filter, "t")
 			assert.Equal(t, tt.expected, sql)


### PR DESCRIPTION
# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [ ] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/Committing-Changes.md#changes-files) for more information.
- [ ] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [ ] Added support on fleet's osquery simulator `cmd/osquery-perf` for new osquery data ingestion features.
- [ ] Added/updated tests
- [ ] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes
- [ ] If database migrations are included, checked table schema to confirm autoupdate
- For database migrations:
  - [ ] Checked schema for all modified table for columns that will auto-update timestamps during migration.
  - [ ] Confirmed that updating the timestamps is acceptable, and will not cause unwanted side effects.
  - [ ] Ensured the correct collation is explicitly set for character columns (`COLLATE utf8mb4_unicode_ci`).
- [ ] Manual QA for all new/changed functionality
- For Orbit and Fleet Desktop changes:
   - [ ] Orbit runs on macOS, Linux and Windows. Check if the orbit feature/bugfix should only apply to one platform (`runtime.GOOS`).
   - [ ] Manual QA must be performed in the three main OSs, macOS, Windows and Linux.
   - [ ] Auto-update manual QA, from released version of component to new version (see [tools/tuf/test](../tools/tuf/test/README.md)).
