### PR TITLE
For R.C. - Fleet UI: Fix unreleased border showing up on hover of dropdown with no border

### DIFF
--- a/frontend/components/forms/fields/Dropdown/_styles.scss
+++ b/frontend/components/forms/fields/Dropdown/_styles.scss
@@ -70,9 +70,10 @@
 
     &:hover:not(.is-disabled) {
       box-shadow: none;
-      border: 1px solid $core-vibrant-blue;
+      border-color: $core-vibrant-blue;
     }
   }
+
   .Select-control {
     background-color: $ui-light-grey;
     border: 0;


### PR DESCRIPTION
> [!NOTE]
> This PR already merged in `main`, see https://github.com/fleetdm/fleet/pull/21528 This is against the release branch so it can be included in 4.56.0 

```
1198  git checkout fleetdm/minor-fleet-v4.56.0
 1199  git log main
 1200  git cherry-pick b0025fbe981b3dc86903fc08cbeffbea7abe3fdf
 1201  git checkout -b dropdown-border-unreleased-rc
 1202  git log
 1203  git push -u fleetdm dropdown-border-unreleased-rc
```