### PR TITLE
For R.C. - [unreleased bug] Fleet UI: Hide exploit/severity vuln filters for fleet free / Fleet UI: Filter software by vulnerabilities follow-up

### DIFF
--- a/changes/19099-sw-vuln-filters
+++ b/changes/19099-sw-vuln-filters
@@ -1,1 +1,2 @@
 - adds the following filters to `/software/titles` and `/software/versions` API endpoints: `exploit: bool`, `min_cvss_score: float`, `max_cvss_score: float`
+- Software titles/versions tables allow for filtering by vulnerabilities including severity and known exploit

--- a/frontend/components/TableContainer/TableContainer.tsx
+++ b/frontend/components/TableContainer/TableContainer.tsx
@@ -81,8 +81,8 @@ interface ITableContainerProps<T = any> {
     | ((queryData: ITableQueryData) => void)
     | ((queryData: ITableQueryData) => number);
   customControl?: () => JSX.Element;
-  /** Filter button right of the search rendering alternative responsive design */
-  customFilters?: () => JSX.Element;
+  /** Filter button right of the search rendering alternative responsive design where search bar moves to new line but filter button remains inline with other table headers */
+  customFiltersButton?: () => JSX.Element;
   stackControls?: boolean;
   onSelectSingleRow?: (value: Row | IRowProps) => void;
   /** This is called when you click on a row. This was added as `onSelectSingleRow`
@@ -146,7 +146,7 @@ const TableContainer = <T,>({
   searchQueryColumn,
   onQueryChange,
   customControl,
-  customFilters,
+  customFiltersButton,
   stackControls,
   onSelectSingleRow,
   onClickRow,
@@ -269,11 +269,13 @@ const TableContainer = <T,>({
     onPaginationChange,
   ]);
 
-  const opacity = isLoading ? { opacity: 0.4 } : { opacity: 1 };
+  const renderFilters = useCallback(() => {
+    const opacity = isLoading ? { opacity: 0.4 } : { opacity: 1 };
 
-  return (
-    <div className={wrapperClasses}>
-      {customFilters ? (
+    // New preferred pattern uses grid container/box to allow for more dynamic responsiveness
+    // At low widths, search bar (3rd div of 4) moves above other 3 divs
+    if (customFiltersButton) {
+      return (
         <div className="container">
           <div className="box">
             {renderCount && !disableCount && (
@@ -331,94 +333,115 @@ const TableContainer = <T,>({
               </div>
             )}
           </div>
-          {customFilters && <div className="box"> {customFilters()} </div>}
+          <div className="box"> {customFiltersButton()} </div>
         </div>
-      ) : (
-        <>
-          {wideSearch && searchable && (
-            <div className={`${baseClass}__search-input wide-search`}>
-              <SearchField
-                placeholder={inputPlaceHolder}
-                defaultValue={searchQuery}
-                onChange={onSearchQueryChange}
-              />
-            </div>
-          )}
-          {!disableTableHeader && (
+      );
+    }
+    return (
+      <>
+        {wideSearch && searchable && (
+          <div className={`${baseClass}__search-input wide-search`}>
+            <SearchField
+              placeholder={inputPlaceHolder}
+              defaultValue={searchQuery}
+              onChange={onSearchQueryChange}
+            />
+          </div>
+        )}
+        {!disableTableHeader && (
+          <div
+            className={`${baseClass}__header ${
+              stackControls ? "stack-table-controls" : ""
+            }`}
+          >
             <div
-              className={`${baseClass}__header ${
+              className={`${baseClass}__header-left ${
                 stackControls ? "stack-table-controls" : ""
               }`}
             >
-              <div
-                className={`${baseClass}__header-left ${
-                  stackControls ? "stack-table-controls" : ""
-                }`}
-              >
-                {renderCount && !disableCount && (
-                  <div
-                    className={`${baseClass}__results-count ${
-                      stackControls ? "stack-table-controls" : ""
-                    }`}
-                    style={opacity}
-                  >
-                    {renderCount()}
-                  </div>
-                )}
-                <span className="controls">
-                  {actionButton && !actionButton.hideButton && (
-                    <Button
-                      disabled={disableActionButton}
-                      onClick={actionButton.onActionButtonClick}
-                      variant={actionButton.variant || "brand"}
-                      className={`${baseClass}__table-action-button`}
-                    >
-                      <>
-                        {actionButton.buttonText}
-                        {actionButton.iconSvg && (
-                          <Icon name={actionButton.iconSvg} />
-                        )}
-                      </>
-                    </Button>
-                  )}
-                  {customControl && customControl()}
-                </span>
-              </div>
-
-              {/* Render search bar only if not empty component */}
-              {searchable && !wideSearch && (
-                <div className={`${baseClass}__search`}>
-                  <div
-                    className={`${baseClass}__search-input ${
-                      stackControls ? "stack-table-controls" : ""
-                    }`}
-                    data-tip
-                    data-for="search-tooltip"
-                    data-tip-disable={!searchToolTipText}
-                  >
-                    <SearchField
-                      placeholder={inputPlaceHolder}
-                      defaultValue={searchQuery}
-                      onChange={onSearchQueryChange}
-                    />
-                  </div>
-                  <ReactTooltip
-                    effect="solid"
-                    backgroundColor={COLORS["tooltip-bg"]}
-                    id="search-tooltip"
-                    data-html
-                  >
-                    <span className={`tooltip ${baseClass}__tooltip-text`}>
-                      {searchToolTipText}
-                    </span>
-                  </ReactTooltip>
+              {renderCount && !disableCount && (
+                <div
+                  className={`${baseClass}__results-count ${
+                    stackControls ? "stack-table-controls" : ""
+                  }`}
+                  style={opacity}
+                >
+                  {renderCount()}
                 </div>
               )}
+              <span className="controls">
+                {actionButton && !actionButton.hideButton && (
+                  <Button
+                    disabled={disableActionButton}
+                    onClick={actionButton.onActionButtonClick}
+                    variant={actionButton.variant || "brand"}
+                    className={`${baseClass}__table-action-button`}
+                  >
+                    <>
+                      {actionButton.buttonText}
+                      {actionButton.iconSvg && (
+                        <Icon name={actionButton.iconSvg} />
+                      )}
+                    </>
+                  </Button>
+                )}
+                {customControl && customControl()}
+              </span>
             </div>
-          )}
-        </>
-      )}
 
+            {/* Render search bar only if not empty component */}
+            {searchable && !wideSearch && (
+              <div className={`${baseClass}__search`}>
+                <div
+                  className={`${baseClass}__search-input ${
+                    stackControls ? "stack-table-controls" : ""
+                  }`}
+                  data-tip
+                  data-for="search-tooltip"
+                  data-tip-disable={!searchToolTipText}
+                >
+                  <SearchField
+                    placeholder={inputPlaceHolder}
+                    defaultValue={searchQuery}
+                    onChange={onSearchQueryChange}
+                  />
+                </div>
+                <ReactTooltip
+                  effect="solid"
+                  backgroundColor={COLORS["tooltip-bg"]}
+                  id="search-tooltip"
+                  data-html
+                >
+                  <span className={`tooltip ${baseClass}__tooltip-text`}>
+                    {searchToolTipText}
+                  </span>
+                </ReactTooltip>
+              </div>
+            )}
+          </div>
+        )}
+      </>
+    );
+  }, [
+    actionButton,
+    customControl,
+    customFiltersButton,
+    disableActionButton,
+    disableCount,
+    disableTableHeader,
+    inputPlaceHolder,
+    isLoading,
+    renderCount,
+    searchQuery,
+    searchToolTipText,
+    searchable,
+    stackControls,
+    wideSearch,
+  ]);
+
+  return (
+    <div className={wrapperClasses}>
+      {renderFilters()}
       <div className={`${baseClass}__data-table-block`}>
         {/* No entities for this result. */}
         {(!isLoading && data.length === 0 && !isMultiColumnFilter) ||

--- a/frontend/components/TableContainer/_styles.scss
+++ b/frontend/components/TableContainer/_styles.scss
@@ -136,7 +136,6 @@
 
       @media (min-width: $break-md) {
         justify-content: space-between;
-        align-items: center;
       }
     }
 

--- a/frontend/pages/SoftwarePage/SoftwarePage.tsx
+++ b/frontend/pages/SoftwarePage/SoftwarePage.tsx
@@ -35,9 +35,9 @@ import TabsWrapper from "components/TabsWrapper";
 import ManageAutomationsModal from "./components/ManageSoftwareAutomationsModal";
 import AddSoftwareModal from "./components/AddSoftwareModal";
 import {
-  getSoftwareFilterForQueryKey,
+  buildSoftwareFilterQueryParams,
   getSoftwareFilterFromQueryParams,
-  getSoftwareVulnFiltersForQueryKey,
+  buildSoftwareVulnFiltersQueryParams,
   getSoftwareVulnFiltersFromQueryParams,
   ISoftwareVulnFilters,
 } from "./SoftwareTitles/SoftwareTable/helpers";
@@ -158,13 +158,19 @@ const SoftwarePage = ({ children, router, location }: ISoftwarePageProps) => {
   // defined redirect behavior if the params are invalid
   const softwareFilter = getSoftwareFilterFromQueryParams(queryParams);
 
+  const softwareVulnFilters = getSoftwareVulnFiltersFromQueryParams(
+    queryParams
+  );
+
   const [showManageAutomationsModal, setShowManageAutomationsModal] = useState(
     false
   );
   const [showPreviewPayloadModal, setShowPreviewPayloadModal] = useState(false);
   const [showPreviewTicketModal, setShowPreviewTicketModal] = useState(false);
   const [showAddSoftwareModal, setShowAddSoftwareModal] = useState(false);
-  const [showAddFilterModal, setShowAddFilterModal] = useState(false);
+  const [showSoftwareFiltersModal, setShowSoftwareFiltersModal] = useState(
+    false
+  );
   const [resetPageIndex, setResetPageIndex] = useState<boolean>(false);
   const [addedSoftwareToken, setAddedSoftwareToken] = useState<string | null>(
     null
@@ -261,9 +267,9 @@ const SoftwarePage = ({ children, router, location }: ISoftwarePageProps) => {
     setShowPreviewTicketModal(!showPreviewTicketModal);
   }, [setShowPreviewTicketModal, showPreviewTicketModal]);
 
-  const toggleAddFilterModal = useCallback(() => {
-    setShowAddFilterModal(!showAddFilterModal);
-  }, [setShowAddFilterModal, showAddFilterModal]);
+  const toggleSoftwareFiltersModal = useCallback(() => {
+    setShowSoftwareFiltersModal(!showSoftwareFiltersModal);
+  }, [setShowSoftwareFiltersModal, showSoftwareFiltersModal]);
 
   // TODO: move into manage automations modal
   const onCreateWebhookSubmit = async (
@@ -310,8 +316,8 @@ const SoftwarePage = ({ children, router, location }: ISoftwarePageProps) => {
       orderDirection: sortDirection,
       orderKey: sortHeader,
       page: 0, // resets page index
-      ...getSoftwareFilterForQueryKey(softwareFilter),
-      ...getSoftwareVulnFiltersForQueryKey(vulnFilters),
+      ...buildSoftwareFilterQueryParams(softwareFilter),
+      ...vulnFilters,
     };
 
     router.replace(
@@ -321,7 +327,7 @@ const SoftwarePage = ({ children, router, location }: ISoftwarePageProps) => {
         queryParams: convertParamsToSnakeCase(newQueryParams),
       })
     );
-    toggleAddFilterModal();
+    toggleSoftwareFiltersModal();
   };
 
   const navigateToNav = useCallback(
@@ -427,10 +433,10 @@ const SoftwarePage = ({ children, router, location }: ISoftwarePageProps) => {
           query,
           showExploitedVulnerabilitiesOnly,
           softwareFilter,
-          vulnFilters: getSoftwareVulnFiltersFromQueryParams(queryParams),
+          vulnFilters: softwareVulnFilters,
           resetPageIndex,
           addedSoftwareToken,
-          onAddFilterClick: toggleAddFilterModal,
+          onAddFiltersClick: toggleSoftwareFiltersModal,
         })}
       </div>
     );
@@ -474,14 +480,11 @@ const SoftwarePage = ({ children, router, location }: ISoftwarePageProps) => {
             isFreeTier={isFreeTier}
           />
         )}
-
-        {showAddFilterModal && (
+        {showSoftwareFiltersModal && (
           <SoftwareFiltersModal
-            onExit={toggleAddFilterModal}
+            onExit={toggleSoftwareFiltersModal}
             onSubmit={onApplyVulnFilters}
-            vulnFiltersQueryParams={getSoftwareVulnFiltersFromQueryParams(
-              queryParams
-            )}
+            vulnFilters={softwareVulnFilters}
           />
         )}
       </div>

--- a/frontend/pages/SoftwarePage/SoftwarePage.tsx
+++ b/frontend/pages/SoftwarePage/SoftwarePage.tsx
@@ -37,7 +37,6 @@ import AddSoftwareModal from "./components/AddSoftwareModal";
 import {
   buildSoftwareFilterQueryParams,
   getSoftwareFilterFromQueryParams,
-  buildSoftwareVulnFiltersQueryParams,
   getSoftwareVulnFiltersFromQueryParams,
   ISoftwareVulnFilters,
 } from "./SoftwareTitles/SoftwareTable/helpers";
@@ -485,6 +484,7 @@ const SoftwarePage = ({ children, router, location }: ISoftwarePageProps) => {
             onExit={toggleSoftwareFiltersModal}
             onSubmit={onApplyVulnFilters}
             vulnFilters={softwareVulnFilters}
+            isPremiumTier={isPremiumTier || false}
           />
         )}
       </div>

--- a/frontend/pages/SoftwarePage/SoftwareTitles/SoftwareTable/SoftwareTable.tests.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitles/SoftwareTable/SoftwareTable.tests.tsx
@@ -60,7 +60,7 @@ describe("Software table", () => {
         teamId={1}
         isLoading={false}
         resetPageIndex={false}
-        onAddFilterClick={noop}
+        onAddFiltersClick={noop}
       />
     );
 
@@ -103,7 +103,7 @@ describe("Software table", () => {
         teamId={1}
         isLoading={false}
         resetPageIndex={false}
-        onAddFilterClick={noop}
+        onAddFiltersClick={noop}
       />
     );
 
@@ -150,7 +150,7 @@ describe("Software table", () => {
         teamId={1}
         isLoading={false}
         resetPageIndex={false}
-        onAddFilterClick={noop}
+        onAddFiltersClick={noop}
       />
     );
 
@@ -195,7 +195,7 @@ describe("Software table", () => {
         teamId={1}
         isLoading={false}
         resetPageIndex={false}
-        onAddFilterClick={noop}
+        onAddFiltersClick={noop}
       />
     );
 
@@ -244,7 +244,7 @@ describe("Software table", () => {
         teamId={1}
         isLoading={false}
         resetPageIndex={false}
-        onAddFilterClick={noop}
+        onAddFiltersClick={noop}
       />
     );
 

--- a/frontend/pages/SoftwarePage/SoftwareTitles/SoftwareTable/SoftwareTable.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitles/SoftwareTable/SoftwareTable.tsx
@@ -41,10 +41,9 @@ import {
   ISoftwareDropdownFilterVal,
   ISoftwareVulnFiltersParams,
   SOFTWARE_TITLES_DROPDOWN_OPTIONS,
-  SOFTWARE_VERSIONS_DROPDOWN_OPTIONS,
-  getSoftwareFilterForQueryKey,
-  getSoftwareVulnFiltersForQueryKey,
-  getVulnFilterDetails,
+  buildSoftwareFilterQueryParams,
+  buildSoftwareVulnFiltersQueryParams,
+  getVulnFilterRenderDetails,
 } from "./helpers";
 
 interface IRowProps extends Row {
@@ -78,7 +77,7 @@ interface ISoftwareTableProps {
   teamId?: number;
   isLoading: boolean;
   resetPageIndex: boolean;
-  onAddFilterClick: () => void;
+  onAddFiltersClick: () => void;
 }
 
 const baseClass = "software-table";
@@ -99,7 +98,7 @@ const SoftwareTable = ({
   teamId,
   isLoading,
   resetPageIndex,
-  onAddFilterClick,
+  onAddFiltersClick,
 }: ISoftwareTableProps) => {
   const currentPath = showVersions
     ? PATHS.SOFTWARE_VERSIONS
@@ -134,6 +133,7 @@ const SoftwareTable = ({
         order_direction: newTableQuery.sortDirection,
         order_key: newTableQuery.sortHeader,
         page: changedParam === "pageIndex" ? newTableQuery.pageIndex : 0,
+        ...buildSoftwareVulnFiltersQueryParams(vulnFilters),
       };
       if (softwareFilter === "installableSoftware") {
         newQueryParam.available_for_install = true.toString();
@@ -142,7 +142,7 @@ const SoftwareTable = ({
         newQueryParam.self_service = true.toString();
       }
 
-      return { ...newQueryParam, ...vulnFilters };
+      return newQueryParam;
     },
     [softwareFilter, teamId, vulnFilters]
   );
@@ -195,7 +195,8 @@ const SoftwareTable = ({
   const hasQuery = query !== "";
   const hasSoftwareFilter = softwareFilter !== "allSoftware";
   const hasVersionFilter = showVersions;
-  const hasVulnFilters = getVulnFilterDetails(vulnFilters).filterCount > 0;
+  const vulnFilterDetails = getVulnFilterRenderDetails(vulnFilters);
+  const hasVulnFilters = vulnFilterDetails.filterCount > 0;
 
   const showFilterHeaders =
     isSoftwareEnabled &&
@@ -212,8 +213,8 @@ const SoftwareTable = ({
       order_direction: orderDirection,
       order_key: orderKey,
       page: 0, // resets page index
-      ...getSoftwareFilterForQueryKey("allSoftware"), // Reset to all software
-      ...getSoftwareVulnFiltersForQueryKey(vulnFilters),
+      ...buildSoftwareFilterQueryParams("allSoftware"), // Reset to all software
+      ...buildSoftwareVulnFiltersQueryParams(vulnFilters),
     };
 
     router.replace(
@@ -236,8 +237,8 @@ const SoftwareTable = ({
       orderDirection,
       orderKey,
       page: 0, // resets page index
-      ...getSoftwareVulnFiltersForQueryKey(vulnFilters),
-      ...getSoftwareFilterForQueryKey(value),
+      ...buildSoftwareVulnFiltersQueryParams(vulnFilters),
+      ...buildSoftwareFilterQueryParams(value),
     };
 
     router.replace(
@@ -290,17 +291,13 @@ const SoftwareTable = ({
   };
 
   const renderCustomControls = () => {
-    const options = showVersions
-      ? SOFTWARE_VERSIONS_DROPDOWN_OPTIONS
-      : SOFTWARE_TITLES_DROPDOWN_OPTIONS;
-
     return (
       <div className={`${baseClass}__filter-controls`}>
         {!showVersions && ( // Hidden when viewing versions table
           <Dropdown
             value={softwareFilter}
             className={`${baseClass}__vuln_dropdown`}
-            options={options}
+            options={SOFTWARE_TITLES_DROPDOWN_OPTIONS}
             searchable={false}
             onChange={handleCustomFilterDropdownChange}
             tableFilterDropdown
@@ -316,9 +313,7 @@ const SoftwareTable = ({
     );
   };
 
-  const renderCustomFilters = () => {
-    const vulnFilterDetails = getVulnFilterDetails(vulnFilters);
-
+  const renderCustomFiltersButton = () => {
     return (
       <TooltipWrapper
         className={`${baseClass}__filters`}
@@ -327,9 +322,9 @@ const SoftwareTable = ({
         showArrow
         tipOffset={12}
         tipContent={vulnFilterDetails.tooltipText}
-        disableTooltip={vulnFilterDetails.filterCount === 0}
+        disableTooltip={!hasVulnFilters}
       >
-        <Button variant="text-link" onClick={onAddFilterClick}>
+        <Button variant="text-link" onClick={onAddFiltersClick}>
           <Icon name="filter" color="core-fleet-blue" />
           <span>{vulnFilterDetails.buttonText}</span>
         </Button>
@@ -384,7 +379,9 @@ const SoftwareTable = ({
         // the TableContainer.
         // additionalQueries={softwareFilter}
         customControl={showFilterHeaders ? renderCustomControls : undefined}
-        customFilters={showFilterHeaders ? renderCustomFilters : undefined}
+        customFiltersButton={
+          showFilterHeaders ? renderCustomFiltersButton : undefined
+        }
         stackControls
         renderCount={renderSoftwareCount}
         renderFooter={renderTableFooter}

--- a/frontend/pages/SoftwarePage/SoftwareTitles/SoftwareTable/_styles.scss
+++ b/frontend/pages/SoftwarePage/SoftwareTitles/SoftwareTable/_styles.scss
@@ -53,7 +53,7 @@
           margin: 0;
         }
         .form-field {
-          width: initial; // Fix styling bugs of slider having form-field class on it
+          width: initial; // Negate form-field styling on slider
         }
       }
     }

--- a/frontend/pages/SoftwarePage/SoftwareTitles/SoftwareTable/helpers.ts
+++ b/frontend/pages/SoftwarePage/SoftwareTitles/SoftwareTable/helpers.ts
@@ -11,33 +11,25 @@ export type IHostSoftwareDropdownFilterVal =
   | ISoftwareDropdownFilterVal
   | "vulnerableSoftware";
 
-const ALL_SOFTWARE_OPTION = {
-  disabled: false,
-  label: "All software",
-  value: "allSoftware",
-  helpText: "All software installed on your hosts.",
-};
-
-const INSTALLABLE_SOFTWARE_OPTION = {
-  disabled: false,
-  label: "Available for install",
-  value: "installableSoftware",
-  helpText: "Software that can be installed on your hosts.",
-};
-
-const SELF_SERVICE_SOFTWARE_OPTION = {
-  disabled: false,
-  label: "Self-service",
-  value: "selfServiceSoftware",
-  helpText: "Software that end users can install from Fleet Desktop.",
-};
-
-export const SOFTWARE_VERSIONS_DROPDOWN_OPTIONS = [ALL_SOFTWARE_OPTION];
-
 export const SOFTWARE_TITLES_DROPDOWN_OPTIONS = [
-  ALL_SOFTWARE_OPTION,
-  INSTALLABLE_SOFTWARE_OPTION,
-  SELF_SERVICE_SOFTWARE_OPTION,
+  {
+    disabled: false,
+    label: "All software",
+    value: "allSoftware",
+    helpText: "All software installed on your hosts.",
+  },
+  {
+    disabled: false,
+    label: "Available for install",
+    value: "installableSoftware",
+    helpText: "Software that can be installed on your hosts.",
+  },
+  {
+    disabled: false,
+    label: "Self-service",
+    value: "selfServiceSoftware",
+    helpText: "Software that end users can install from Fleet Desktop.",
+  },
 ];
 
 export const SEVERITY_DROPDOWN_OPTIONS = [
@@ -83,7 +75,7 @@ export const SEVERITY_DROPDOWN_OPTIONS = [
   },
 ];
 
-export const getSoftwareFilterForQueryKey = (
+export const buildSoftwareFilterQueryParams = (
   val: ISoftwareDropdownFilterVal
 ) => {
   switch (val) {
@@ -114,8 +106,8 @@ export const getSoftwareVulnFiltersFromQueryParams = (
   const { vulnerable, exploit, min_cvss_score, max_cvss_score } = queryParams;
 
   return {
-    vulnerable: Boolean(vulnerable),
-    exploit: Boolean(exploit),
+    vulnerable: stringUtils.strToBool(vulnerable as string),
+    exploit: stringUtils.strToBool(exploit as string),
     minCvssScore: parseQueryValueToNumberOrUndefined(min_cvss_score, 0, 10),
     maxCvssScore: parseQueryValueToNumberOrUndefined(max_cvss_score, 0, 10),
   };
@@ -135,23 +127,39 @@ export type ISoftwareVulnFiltersParams = {
   maxCvssScore?: number;
 };
 
-export const getSoftwareVulnFiltersForQueryKey = (
-  vulnFilters: ISoftwareVulnFilters
+const isValidNumber = (
+  value: any,
+  min?: number,
+  max?: number
+): value is number => {
+  // Check if the value is a number and not NaN
+  const isNumber = typeof value === "number" && !isNaN(value);
+
+  // If min or max is provided, check if the number is within the range
+  const withinRange =
+    (min === undefined || value >= min) && (max === undefined || value <= max);
+
+  return isNumber && withinRange;
+};
+
+export const buildSoftwareVulnFiltersQueryParams = (
+  vulnFilters: ISoftwareVulnFiltersParams
 ) => {
-  const { vulnerable, exploit, min_cvss_score, max_cvss_score } = vulnFilters;
+  const { vulnerable, exploit, minCvssScore, maxCvssScore } = vulnFilters;
 
   if (!vulnerable) {
     return {};
   }
 
-  const isValidNumber = (value: any): value is number =>
-    value !== null && value !== undefined && !isNaN(value);
-
   return {
     vulnerable: true,
     ...(exploit && { exploit: true }),
-    ...(isValidNumber(min_cvss_score) && { min_cvss_score }),
-    ...(isValidNumber(max_cvss_score) && { max_cvss_score }),
+    ...(isValidNumber(minCvssScore, 0, maxCvssScore || 10) && {
+      min_cvss_score: minCvssScore.toString(),
+    }),
+    ...(isValidNumber(maxCvssScore, minCvssScore || 0, 10) && {
+      max_cvss_score: maxCvssScore.toString(),
+    }),
   };
 };
 
@@ -175,7 +183,7 @@ export const findOptionBySeverityRange = (
   return severityOption;
 };
 
-export const getVulnFilterDetails = (
+export const getVulnFilterRenderDetails = (
   vulnFilters?: ISoftwareVulnFiltersParams
 ) => {
   let filterCount = 0;

--- a/frontend/pages/SoftwarePage/SoftwareTitles/SoftwareTitles.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitles/SoftwareTitles.tsx
@@ -22,7 +22,7 @@ import SoftwareTable from "./SoftwareTable";
 import {
   ISoftwareDropdownFilterVal,
   ISoftwareVulnFilters,
-  getSoftwareFilterForQueryKey,
+  buildSoftwareFilterQueryParams,
 } from "./SoftwareTable/helpers";
 
 const baseClass = "software-titles";
@@ -46,7 +46,7 @@ interface ISoftwareTitlesProps {
   teamId?: number;
   resetPageIndex: boolean;
   addedSoftwareToken: string | null;
-  onAddFilterClick: () => void;
+  onAddFiltersClick: () => void;
 }
 
 const SoftwareTitles = ({
@@ -62,7 +62,7 @@ const SoftwareTitles = ({
   teamId,
   resetPageIndex,
   addedSoftwareToken,
-  onAddFilterClick,
+  onAddFiltersClick,
 }: ISoftwareTitlesProps) => {
   const showVersions = location.pathname === PATHS.SOFTWARE_VERSIONS;
 
@@ -89,7 +89,7 @@ const SoftwareTitles = ({
         teamId,
         addedSoftwareToken,
         ...vulnFilters,
-        ...getSoftwareFilterForQueryKey(softwareFilter),
+        ...buildSoftwareFilterQueryParams(softwareFilter),
       },
     ],
     ({ queryKey: [queryKey] }) =>
@@ -197,7 +197,7 @@ const SoftwareTitles = ({
           isTitlesFetching || isVersionsFetching || isTitlesAFIFetching
         }
         resetPageIndex={resetPageIndex}
-        onAddFilterClick={onAddFilterClick}
+        onAddFiltersClick={onAddFiltersClick}
         vulnFilters={vulnFilters}
       />
     </div>

--- a/frontend/pages/SoftwarePage/components/EmptySoftwareTable/EmptySoftwareTable.tsx
+++ b/frontend/pages/SoftwarePage/components/EmptySoftwareTable/EmptySoftwareTable.tsx
@@ -3,7 +3,7 @@ import CustomLink from "components/CustomLink";
 import EmptyTable from "components/EmptyTable";
 import { IEmptyTableProps } from "interfaces/empty_table";
 import {
-  getVulnFilterDetails,
+  getVulnFilterRenderDetails,
   ISoftwareDropdownFilterVal,
   ISoftwareVulnFiltersParams,
 } from "pages/SoftwarePage/SoftwareTitles/SoftwareTable/helpers";
@@ -22,7 +22,7 @@ const generateTypeText = (
   tableName: string,
   softwareFilter?: ISoftwareDropdownFilterVal,
   vulnFilters?: ISoftwareVulnFiltersParams
-): string => {
+) => {
   if (softwareFilter === "installableSoftware") {
     return "installable software";
   }
@@ -47,7 +47,9 @@ const EmptySoftwareTable = ({
     vulnFilters
   );
 
-  const { filterCount: vulnFiltersCount } = getVulnFilterDetails(vulnFilters);
+  const { filterCount: vulnFiltersCount } = getVulnFilterRenderDetails(
+    vulnFilters
+  );
 
   const isFiltered =
     vulnFiltersCount > 0 || !noSearchQuery || softwareFilter !== "allSoftware";

--- a/frontend/pages/SoftwarePage/components/SoftwareFiltersModal/SoftwareFiltersModal.tsx
+++ b/frontend/pages/SoftwarePage/components/SoftwareFiltersModal/SoftwareFiltersModal.tsx
@@ -20,12 +20,14 @@ interface ISoftwareFiltersModalProps {
   onExit: () => void;
   onSubmit: (vulnFilters: ISoftwareVulnFilters) => void;
   vulnFilters: ISoftwareVulnFiltersParams;
+  isPremiumTier: boolean;
 }
 
 const SoftwareFiltersModal = ({
   onExit,
   onSubmit,
   vulnFilters,
+  isPremiumTier,
 }: ISoftwareFiltersModalProps) => {
   const [vulnSoftwareFilterEnabled, setVulnSoftwareFilterEnabled] = useState(
     vulnFilters.vulnerable || false
@@ -50,7 +52,7 @@ const SoftwareFiltersModal = ({
   const onApplyFilters = () => {
     onSubmit({
       vulnerable: vulnSoftwareFilterEnabled,
-      exploit: hasKnownExploit,
+      exploit: hasKnownExploit || undefined,
       min_cvss_score: severity?.minSeverity || undefined,
       max_cvss_score: severity?.maxSeverity || undefined,
     });
@@ -78,27 +80,31 @@ const SoftwareFiltersModal = ({
           inactiveText="Vulnerable software"
           activeText="Vulnerable software"
         />
-        <Dropdown
-          label={renderSeverityLabel()}
-          options={SEVERITY_DROPDOWN_OPTIONS}
-          value={severity}
-          onChange={onChangeSeverity}
-          placeholder="Any severity"
-          className={`${baseClass}__select-severity`}
-          disabled={!vulnSoftwareFilterEnabled}
-        />
-        <Checkbox
-          onChange={({ value }: { value: boolean }) =>
-            setHasKnownExploit(value)
-          }
-          name="hasKnownExploit"
-          value={hasKnownExploit}
-          parseTarget
-          helpText="Software has vulnerabilities that have been actively exploited in the wild."
-          disabled={!vulnSoftwareFilterEnabled}
-        >
-          Has known exploit
-        </Checkbox>
+        {isPremiumTier && (
+          <Dropdown
+            label={renderSeverityLabel()}
+            options={SEVERITY_DROPDOWN_OPTIONS}
+            value={severity}
+            onChange={onChangeSeverity}
+            placeholder="Any severity"
+            className={`${baseClass}__select-severity`}
+            disabled={!vulnSoftwareFilterEnabled}
+          />
+        )}
+        {isPremiumTier && (
+          <Checkbox
+            onChange={({ value }: { value: boolean }) =>
+              setHasKnownExploit(value)
+            }
+            name="hasKnownExploit"
+            value={hasKnownExploit}
+            parseTarget
+            helpText="Software has vulnerabilities that have been actively exploited in the wild."
+            disabled={!vulnSoftwareFilterEnabled}
+          >
+            Has known exploit
+          </Checkbox>
+        )}
         <div className="modal-cta-wrap">
           <Button variant="brand" onClick={onApplyFilters}>
             Apply

--- a/frontend/pages/SoftwarePage/components/SoftwareFiltersModal/SoftwareFiltersModal.tsx
+++ b/frontend/pages/SoftwarePage/components/SoftwareFiltersModal/SoftwareFiltersModal.tsx
@@ -19,26 +19,24 @@ const baseClass = "software-filters-modal";
 interface ISoftwareFiltersModalProps {
   onExit: () => void;
   onSubmit: (vulnFilters: ISoftwareVulnFilters) => void;
-  vulnFiltersQueryParams: ISoftwareVulnFiltersParams;
+  vulnFilters: ISoftwareVulnFiltersParams;
 }
 
 const SoftwareFiltersModal = ({
   onExit,
   onSubmit,
-  vulnFiltersQueryParams,
+  vulnFilters,
 }: ISoftwareFiltersModalProps) => {
   const [vulnSoftwareFilterEnabled, setVulnSoftwareFilterEnabled] = useState(
-    vulnFiltersQueryParams.vulnerable || false
+    vulnFilters.vulnerable || false
   );
   const [severity, setSeverity] = useState(
     findOptionBySeverityRange(
-      vulnFiltersQueryParams.minCvssScore,
-      vulnFiltersQueryParams.maxCvssScore
+      vulnFilters.minCvssScore,
+      vulnFilters.maxCvssScore
     )
   );
-  const [hasKnownExploit, setHasKnownExploit] = useState(
-    vulnFiltersQueryParams.exploit
-  );
+  const [hasKnownExploit, setHasKnownExploit] = useState(vulnFilters.exploit);
 
   const onChangeSeverity = (value: string) => {
     const selectedOption = SEVERITY_DROPDOWN_OPTIONS.find(

--- a/frontend/pages/SoftwarePage/components/SoftwareFiltersModal/_styles.scss
+++ b/frontend/pages/SoftwarePage/components/SoftwareFiltersModal/_styles.scss
@@ -8,4 +8,8 @@
     flex-direction: column;
     gap: $pad-medium;
   }
+
+  .Select-menu {
+    padding-bottom: $pad-medium;
+  }
 }

--- a/frontend/utilities/helpers.tsx
+++ b/frontend/utilities/helpers.tsx
@@ -11,6 +11,7 @@ import {
   trim,
   trimEnd,
   union,
+  uniqueId,
 } from "lodash";
 import md5 from "js-md5";
 import {
@@ -824,7 +825,7 @@ export const syntaxHighlight = (json: any): string => {
 export const tooltipTextWithLineBreaks = (lines: string[]) => {
   return lines.map((line) => {
     return (
-      <span key={Math.random().toString().slice(2)}>
+      <span key={uniqueId()}>
         {line}
         <br />
       </span>

--- a/frontend/utilities/strings/stringUtils.ts
+++ b/frontend/utilities/strings/stringUtils.ts
@@ -75,8 +75,13 @@ export const pluralize = (
   return `${root}${count !== 1 ? pluralSuffix : singularSuffix}`;
 };
 
+export const strToBool = (str?: string | null) => {
+  return str ? JSON.parse(str) : false;
+};
+
 export default {
   capitalize,
   capitalizeRole,
   pluralize,
+  strToBool,
 };


### PR DESCRIPTION
> [!NOTE]
> These PRs are already merged in `main`, see https://github.com/fleetdm/fleet/pull/21511 and  https://github.com/fleetdm/fleet/pull/21420 This is against the release branch so it can be included in 4.56.0 

```

 1224  git log
 1225  git log main
 1226  git cherry-pick 544fd4131dc1d03e24253ad88fc8f1c67c479f82
 1227  git log
 1228  git log main
 1229  git cherry-pick cfafb92c2d1eed1da3744cf1e3d505c71fed1b48
 1230  git push -uf fleetdm free-hide-advance-vuln-filters-rc
```