### PR TITLE
to RC: UI – Update host activity feed empty states and tooltip (#21530)

### DIFF
--- a/changes/20955-host-activity-feed-copy-updates
+++ b/changes/20955-host-activity-feed-copy-updates
@@ -1,0 +1,2 @@
+* Update Host details activities tooltip and empty state copy to reflect recently added
+capabilities.

--- a/frontend/pages/hosts/details/cards/Activity/Activity.tsx
+++ b/frontend/pages/hosts/details/cards/Activity/Activity.tsx
@@ -31,11 +31,12 @@ const UpcomingTooltip = () => {
     <TooltipWrapper
       tipContent={
         <>
-          Upcoming activities will run as listed. Failure of one activity
-          won&apos;t cancel other activities.
+          Currently, only scripts run before other scripts and
+          <br />
+          software is installed before other software.
           <br />
           <br />
-          Currently, only scripts are guaranteed to run in order.
+          Failure of one activity won&apos;t cancel other activities.
         </>
       }
       className={`${baseClass}__upcoming-tooltip`}

--- a/frontend/pages/hosts/details/cards/Activity/PastActivityFeed/PastActivityFeed.tsx
+++ b/frontend/pages/hosts/details/cards/Activity/PastActivityFeed/PastActivityFeed.tsx
@@ -44,7 +44,7 @@ const PastActivityFeed = ({
     return (
       <EmptyFeed
         title="No activity"
-        message="When a script runs on a host, it shows up here."
+        message="Completed actions will appear here (scripts, software, lock, and wipe)."
         className={`${baseClass}__empty-feed`}
       />
     );

--- a/frontend/pages/hosts/details/cards/Activity/UpcomingActivityFeed/UpcomingActivityFeed.tsx
+++ b/frontend/pages/hosts/details/cards/Activity/UpcomingActivityFeed/UpcomingActivityFeed.tsx
@@ -43,7 +43,7 @@ const UpcomingActivityFeed = ({
     return (
       <EmptyFeed
         title="No pending activity "
-        message="When you run a script on an offline host, it will appear here."
+        message="Pending actions will appear here (scripts, software, lock, and wipe)."
         className={`${baseClass}__empty-feed`}
       />
     );


### PR DESCRIPTION
#### This PR already merged to `main`, see https://github.com/fleetdm/fleet/pull/21530. This is against the release branch so it can be included in 4.56.0 (issue #20955 )