### PR TITLE
to RC: UI –  Make download CSR "missing private key" error link clickable (#…

### DIFF
--- a/changes/20531-download-CSR-clickable-error
+++ b/changes/20531-download-CSR-clickable-error
@@ -1,0 +1,3 @@
+* When a CSR can't be downloaded due to missing private key, make the link clickable in the error
+  message that is flashed.
+  

--- a/frontend/components/ClickableUrls/ClickableUrls.tsx
+++ b/frontend/components/ClickableUrls/ClickableUrls.tsx
@@ -20,21 +20,19 @@ const ClickableUrls = ({ text, className }: IClickableUrls): JSX.Element => {
   const clickableUrlClasses = classnames(baseClass, className);
 
   // Regex to find case insensitive URLs and replace with link
-  const replacedLinks = text.replaceAll(
+  const textWithLinks = text.replaceAll(
     /(((https?)?(:\/\/))|((https?)?(:\/\/)?(www\.)))[-a-zA-Z0-9@:%._+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_+.~#?&//=]*)/g,
     urlReplacer
   );
-  const sanitizedResolutionContent = DOMPurify.sanitize(replacedLinks, {
+  const sanitizedTextWithLinks = DOMPurify.sanitize(textWithLinks, {
     ADD_ATTR: ["target"], // Allows opening in a new tab
   });
 
-  const textWithLinks = (
+  return (
     <div
       className={clickableUrlClasses}
-      dangerouslySetInnerHTML={{ __html: sanitizedResolutionContent }}
+      dangerouslySetInnerHTML={{ __html: sanitizedTextWithLinks }}
     />
   );
-
-  return textWithLinks;
 };
 export default ClickableUrls;

--- a/frontend/components/FlashMessage/_styles.scss
+++ b/frontend/components/FlashMessage/_styles.scss
@@ -70,6 +70,10 @@
       width: 16px;
       height: 16px;
     }
+
+    a {
+      color: inherit;
+    }
   }
 
   &__undo {

--- a/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/AppleMdmPage/components/content/ApplePushCertSetup.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/AppleMdmPage/components/content/ApplePushCertSetup.tsx
@@ -6,6 +6,7 @@ import mdmAppleApi from "services/entities/mdm_apple";
 
 import CustomLink from "components/CustomLink";
 import FileUploader from "components/FileUploader";
+import ClickableUrls from "components/ClickableUrls";
 import DownloadCSR from "../../../../../../components/DownloadFileButtons/DownloadCSR";
 
 interface IApplePushCertSetupProps {
@@ -49,13 +50,13 @@ const ApplePushCertSetup = ({
   const onDownloadError = useCallback(
     (e: unknown) => {
       const msg = getErrorReason(e);
-      if (
-        msg.toLowerCase().includes("email address") ||
-        msg.toLowerCase().includes("required private key")
-      ) {
+      if (msg.toLowerCase().includes("email address")) {
         renderFlash("error", msg);
+      } else if (msg.toLowerCase().includes("required private key")) {
+        // replace link with actually clickable link
+        renderFlash("error", ClickableUrls({ text: msg }));
       } else {
-        renderFlash("error", "Something’s gone wrong. Please try again.");
+        renderFlash("error", "Something's gone wrong. Please try again.");
       }
     },
     [renderFlash]

--- a/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/AppleMdmPage/components/modals/RenewCertModal/RenewCertModal.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/AppleMdmPage/components/modals/RenewCertModal/RenewCertModal.tsx
@@ -65,7 +65,7 @@ const RenewCertModal = ({
   const onDownloadError = useCallback(
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     (e: unknown) => {
-      renderFlash("error", "Something’s gone wrong. Please try again.");
+      renderFlash("error", "Something's gone wrong. Please try again.");
     },
     [renderFlash]
   );


### PR DESCRIPTION
#### This PR already merged to `main`, see https://github.com/fleetdm/fleet/pull/21515. This is against the release branch so it can be included in 4.56.0 (issue #20531 )