### PR TITLE
Fix unreleased bug in dashboard page UI that caused re-render loop

### DIFF
--- a/frontend/pages/DashboardPage/DashboardPage.tsx
+++ b/frontend/pages/DashboardPage/DashboardPage.tsx
@@ -4,6 +4,7 @@ import React, {
   useEffect,
   useRef,
   useCallback,
+  useMemo,
 } from "react";
 import { InjectedRouter } from "react-router";
 import { useQuery } from "react-query";
@@ -652,14 +653,19 @@ const DashboardPage = ({ router, location }: IDashboardProps): JSX.Element => {
     ),
   });
 
-  const MunkiCard = useInfoCard({
-    title: "Munki",
-    titleDetail: (
+  const munkiTitleDetail = useMemo(
+    () => (
       <LastUpdatedText
         lastUpdatedAt={munkiCountsUpdatedAt}
         whatToRetrieve="Munki"
       />
     ),
+    [munkiCountsUpdatedAt]
+  );
+
+  const MunkiCard = useInfoCard({
+    title: "Munki",
+    titleDetail: munkiTitleDetail,
     showTitle: !isMacAdminsFetching,
     description: (
       <p>


### PR DESCRIPTION
This fixes an unreleased bug introduced [here](https://github.com/fleetdm/fleet/pull/21481/files#diff-644b85543c104735112abf832ddc1905bc916a19947800c053e8aca5fa6c493eR657). The issue was discovered by @roperzh while working on an unrelated part of the dashboard page (the issue becomes apparent when adding a console log in the page component or one of its child components).

The immediate fix is to memoize value passed as `titleDetail` prop. In the longer term, we should take a closer look at the `useInfoCard` pattern as it seems to be a potential trouble spot.