### PR TITLE
Fix UI premium message for free tier adm vpp

### DIFF
--- a/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/AppleBusinessManagerPage/AppleBusinessManagerPage.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/AppleBusinessManagerPage/AppleBusinessManagerPage.tsx
@@ -18,6 +18,7 @@ import Button from "components/buttons/Button";
 import DataError from "components/DataError";
 import MainContent from "components/MainContent";
 import Spinner from "components/Spinner";
+import PremiumFeatureMessage from "components/PremiumFeatureMessage";
 
 import AppleBusinessManagerTable from "./components/AppleBusinessManagerTable";
 import AddAbmModal from "./components/AddAbmModal";
@@ -71,7 +72,7 @@ const AddAbmMessage = ({ onAddAbm }: IAddAbmMessageProps) => {
 };
 
 const AppleBusinessManagerPage = ({ router }: { router: InjectedRouter }) => {
-  const { config } = useContext(AppContext);
+  const { config, isPremiumTier } = useContext(AppContext);
 
   const [showRenewModal, setShowRenewModal] = useState(false);
   const [showDeleteModal, setShowDeleteModal] = useState(false);
@@ -94,6 +95,7 @@ const AppleBusinessManagerPage = ({ router }: { router: InjectedRouter }) => {
       retry: (tries, error) =>
         error.status !== 404 && error.status !== 400 && tries <= 3,
       select: (data) => data?.abm_tokens,
+      enabled: isPremiumTier,
     }
   );
 
@@ -161,6 +163,10 @@ const AppleBusinessManagerPage = ({ router }: { router: InjectedRouter }) => {
   const showDataError = errorAbmTokens && errorAbmTokens.status !== 404;
 
   const renderContent = () => {
+    if (!isPremiumTier) {
+      return <PremiumFeatureMessage />;
+    }
+
     if (!config?.mdm.enabled_and_configured) {
       return <TurnOnMdmMessage router={router} />;
     }
@@ -213,11 +219,13 @@ const AppleBusinessManagerPage = ({ router }: { router: InjectedRouter }) => {
         <div className={`${baseClass}__page-content`}>
           <div className={`${baseClass}__page-header-section`}>
             <h1>Apple Business Manager (ABM)</h1>
-            {abmTokens?.length !== 0 && !!config?.mdm.enabled_and_configured && (
-              <Button variant="brand" onClick={onAddAbm}>
-                Add ABM
-              </Button>
-            )}
+            {isPremiumTier &&
+              abmTokens?.length !== 0 &&
+              !!config?.mdm.enabled_and_configured && (
+                <Button variant="brand" onClick={onAddAbm}>
+                  Add ABM
+                </Button>
+              )}
           </div>
           <>{renderContent()}</>
         </div>

--- a/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/MdmSettings.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/MdmSettings.tsx
@@ -1,6 +1,6 @@
 import React, { useContext } from "react";
 import { useQuery } from "react-query";
-import { AxiosError, AxiosResponse } from "axios";
+import { AxiosError } from "axios";
 import { InjectedRouter } from "react-router";
 
 import { DEFAULT_USE_QUERY_OPTIONS } from "utilities/constants";
@@ -62,7 +62,7 @@ const MdmSettings = ({ router }: IMdmSettingsProps) => {
     {
       ...DEFAULT_USE_QUERY_OPTIONS,
       retry: false,
-      enabled: !!config?.mdm.enabled_and_configured,
+      enabled: isPremiumTier && !!config?.mdm.enabled_and_configured,
     }
   );
 
@@ -79,7 +79,7 @@ const MdmSettings = ({ router }: IMdmSettingsProps) => {
     {
       ...DEFAULT_USE_QUERY_OPTIONS,
       retry: false,
-      enabled: !!config?.mdm.enabled_and_configured,
+      enabled: isPremiumTier && !!config?.mdm.enabled_and_configured,
     }
   );
 

--- a/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/VppPage/VppPage.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/VppPage/VppPage.tsx
@@ -15,6 +15,7 @@ import MainContent from "components/MainContent";
 import Button from "components/buttons/Button";
 import DataError from "components/DataError";
 import Spinner from "components/Spinner";
+import PremiumFeatureMessage from "components/PremiumFeatureMessage";
 
 import AddVppModal from "./components/AddVppModal";
 import RenewVppModal from "./components/RenewVppModal";
@@ -71,7 +72,7 @@ interface IVppPageProps {
 }
 
 const VppPage = ({ router }: IVppPageProps) => {
-  const { config } = useContext(AppContext);
+  const { config, isPremiumTier } = useContext(AppContext);
 
   const [showRenewModal, setShowRenewModal] = useState(false);
   const [showDeleteModal, setShowDeleteModal] = useState(false);
@@ -93,6 +94,7 @@ const VppPage = ({ router }: IVppPageProps) => {
       retry: (tries, error) =>
         error.status !== 404 && error.status !== 400 && tries <= 3,
       select: (data) => data.vpp_tokens,
+      enabled: isPremiumTier,
     }
   );
 
@@ -156,6 +158,10 @@ const VppPage = ({ router }: IVppPageProps) => {
   const showDataError = errorVppTokens && errorVppTokens.status !== 404;
 
   const renderContent = () => {
+    if (!isPremiumTier) {
+      return <PremiumFeatureMessage />;
+    }
+
     if (!config?.mdm.enabled_and_configured) {
       return <TurnOnMdmMessage router={router} />;
     }
@@ -208,11 +214,13 @@ const VppPage = ({ router }: IVppPageProps) => {
         <div className={`${baseClass}__page-content`}>
           <div className={`${baseClass}__page-header-section`}>
             <h1>Volume Purchasing Program (VPP)</h1>
-            {vppTokens?.length !== 0 && !!config?.mdm.enabled_and_configured && (
-              <Button variant="brand" onClick={onAddVpp}>
-                Add VPP
-              </Button>
-            )}
+            {isPremiumTier &&
+              vppTokens?.length !== 0 &&
+              !!config?.mdm.enabled_and_configured && (
+                <Button variant="brand" onClick={onAddVpp}>
+                  Add VPP
+                </Button>
+              )}
           </div>
           <>{renderContent()}</>
         </div>


### PR DESCRIPTION
relates to #21309

fix UI to show premium messages on the mdm settings page, abm page, and vpp page when a user is on the free tier

**mdm page**

![image](https://github.com/user-attachments/assets/331d1041-185d-4ca8-85a1-35470fd1fb2b)

**abm page**

![image](https://github.com/user-attachments/assets/fd4d81f5-1f18-4d52-8105-043f9913b6ac)

**vpp page**

![image](https://github.com/user-attachments/assets/c240fff4-e6e9-494c-b71d-13ae3a45c212)


- [x] Manual QA for all new/changed functionality