### PR TITLE
Website: Update SF helper to ensure numberOfEmployees is always a number.

### DIFF
--- a/website/api/helpers/iq/get-enriched.js
+++ b/website/api/helpers/iq/get-enriched.js
@@ -279,7 +279,7 @@ module.exports = {
 
           if (openAiResponse) {
             try {
-              employer.numberOfEmployees = JSON.parse(openAiResponse.choices[0].message.content);
+              employer.numberOfEmployees = JSON.parse(openAiResponse.choices[0].message.content).employees;
             } catch (unusedErr) {
               employer.numberOfEmployees = 1;
             }

--- a/website/api/helpers/salesforce/update-or-create-contact-and-account.js
+++ b/website/api/helpers/salesforce/update-or-create-contact-and-account.js
@@ -204,7 +204,7 @@ module.exports = {
             Name: enrichmentData.employer.organization,// IFWMIH: We know organization exists
             Website: enrichmentData.employer.emailDomain,
             LinkedIn_company_URL__c: enrichmentData.employer.linkedinCompanyPageUrl,// eslint-disable-line camelcase
-            NumberOfEmployees: enrichmentData.employer.numberOfEmployees,
+            NumberOfEmployees: Number(enrichmentData.employer.numberOfEmployees),
             OwnerId: salesforceAccountOwnerId
           });
           salesforceAccountId = newAccountRecord.id;


### PR DESCRIPTION
Closes: https://github.com/fleetdm/confidential/issues/7844

Changes:
- Updated the get-enriched helper to fix the return value for numberOfEmployees.
- Updated the update-or-create-contact-and-account to make sure the number of employees set on new account records is always a number.