### PR TITLE
Minio vulnerability false positives

### DIFF
--- a/changes/21404-minio-false-positive
+++ b/changes/21404-minio-false-positive
@@ -1,0 +1,1 @@
+- resolved issue where minio was reporting false positive vulnerabilities due to a mismatch in version strings 

--- a/server/service/osquery_utils/queries.go
+++ b/server/service/osquery_utils/queries.go
@@ -1599,6 +1599,31 @@ func sanitizeSoftware(h *fleet.Host, s *fleet.Software, logger log.Logger) {
 				s.Version = strings.Join(newParts, ".")
 			},
 		},
+		{
+			// Trim the "RELEASE." prefix from Minio versions.
+			checkSoftware: func(h *fleet.Host, s *fleet.Software) bool {
+				return s.Name == "minio" && strings.Contains(s.Version, "RELEASE.")
+			},
+			mutateSoftware: func(s *fleet.Software) {
+				s.Version = strings.TrimPrefix(s.Version, "RELEASE.")
+			},
+		},
+		{
+			// Convert the timestamp to NVD's format for Minio versions.
+			checkSoftware: func(h *fleet.Host, s *fleet.Software) bool {
+				regex := regexp.MustCompile(`^\d{14}$`)
+
+				return s.Name == "minio" && regex.MatchString(s.Version)
+			},
+			mutateSoftware: func(s *fleet.Software) {
+				timestamp, err := time.Parse("20060102150405", s.Version)
+				if err != nil {
+					level.Debug(logger).Log("msg", "failed to parse software version", "name", s.Name, "version", s.Version, "err", err)
+					return
+				}
+				s.Version = timestamp.Format("2006-01-02T15-04-05Z")
+			},
+		},
 	}
 
 	for _, softwareSanitizer := range softwareSanitizers {

--- a/server/service/osquery_utils/queries_test.go
+++ b/server/service/osquery_utils/queries_test.go
@@ -1830,6 +1830,30 @@ func TestSanitizeSoftware(t *testing.T) {
 				Version: "1.6.00.34263",
 			},
 		},
+		{
+			name: "minio",
+			h:    &fleet.Host{},
+			s: &fleet.Software{
+				Name:    "minio",
+				Version: "RELEASE.2022-03-10T00-00-00Z",
+			},
+			sanitized: &fleet.Software{
+				Name:    "minio",
+				Version: "2022-03-10T00-00-00Z",
+			},
+		},
+		{
+			name: "minio",
+			h:    &fleet.Host{},
+			s: &fleet.Software{
+				Name:    "minio",
+				Version: "20200310000000",
+			},
+			sanitized: &fleet.Software{
+				Name:    "minio",
+				Version: "2020-03-10T00-00-00Z",
+			},
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			sanitizeSoftware(tc.h, tc.s, log.NewNopLogger())


### PR DESCRIPTION
#21404 

Sanitizing the minio version string to match the timestamp in NVD.

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/Committing-Changes.md#changes-files) for more information.
- [X] Added/updated tests
- [X] Manual QA for all new/changed functionality