### PR TITLE
macOS VirtualBox false negative

### DIFF
--- a/changes/20846-vuln-virtual-box
+++ b/changes/20846-vuln-virtual-box
@@ -1,0 +1,1 @@
+- resolved an issue where virtual box for macOS wasn't matching against the vm_virtualbox NVD product name

--- a/server/vulnerabilities/nvd/cve.go
+++ b/server/vulnerabilities/nvd/cve.go
@@ -588,6 +588,14 @@ func expandCPEAliases(cpeItem *wfn.Attributes) []*wfn.Attributes {
 		}
 	}
 
+	for _, cpeItem := range cpeItems {
+		if cpeItem.Vendor == "oracle" && cpeItem.Product == "virtualbox" {
+			cpeItem2 := *cpeItem
+			cpeItem2.Product = "vm_virtualbox"
+			cpeItems = append(cpeItems, &cpeItem2)
+		}
+	}
+
 	return cpeItems
 }
 

--- a/server/vulnerabilities/nvd/cve_test.go
+++ b/server/vulnerabilities/nvd/cve_test.go
@@ -347,6 +347,14 @@ func TestTranslateCPEToCVE(t *testing.T) {
 			},
 			continuesToUpdate: true,
 		},
+		// Tests the expandCPEAliases rule for virtualbox on macOS
+		"cpe:2.3:a:oracle:virtualbox:7.0.6:*:*:*:*:macos:*:*": {
+			includedCVEs: []cve{
+				{ID: "CVE-2023-21989", resolvedInVersion: "7.0.8"},
+				{ID: "CVE-2024-21141", resolvedInVersion: "7.0.20"},
+			},
+			continuesToUpdate: true,
+		},
 	}
 
 	cveOSTests := []struct {


### PR DESCRIPTION
#20846 

Adding a `vm_virtualbox` product alias to `cpe:2.3:a:oracle:virtualbox:7.0.6:*:*:*:*:macos:*:*`

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
- [X] Added/updated tests
- [X] Manual QA for all new/changed functionality