### PR TITLE
[19857 bug fix] Fleet UI: Update empty state of OS to show info line

### DIFF
--- a/frontend/pages/DashboardPage/DashboardPage.tsx
+++ b/frontend/pages/DashboardPage/DashboardPage.tsx
@@ -521,13 +521,6 @@ const DashboardPage = ({ router, location }: IDashboardProps): JSX.Element => {
       renderFlash,
     ]
   );
-  // TODO: Rework after backend is adjusted to differentiate empty search/filter results from
-  // collecting inventory
-  const isCollectingInventory =
-    !isAnyTeamSelected &&
-    !softwarePageIndex &&
-    !software?.software &&
-    software?.counts_updated_at === null;
 
   const HostsSummaryCard = useInfoCard({
     title: "Hosts",
@@ -640,7 +633,6 @@ const DashboardPage = ({ router, location }: IDashboardProps): JSX.Element => {
     children: (
       <Software
         errorSoftware={errorSoftware}
-        isCollectingInventory={isCollectingInventory}
         isSoftwareFetching={isSoftwareFetching}
         isSoftwareEnabled={isSoftwareEnabled}
         software={software}

--- a/frontend/pages/DashboardPage/cards/Software/DashboardSoftware.tests.tsx
+++ b/frontend/pages/DashboardPage/cards/Software/DashboardSoftware.tests.tsx
@@ -62,7 +62,6 @@ describe("Dashboard software card", () => {
     render(
       <Software
         errorSoftware={null}
-        isCollectingInventory={false}
         isSoftwareFetching={false}
         isSoftwareEnabled
         navTabIndex={0}
@@ -118,7 +117,6 @@ describe("Dashboard software card", () => {
     render(
       <Software
         errorSoftware={null}
-        isCollectingInventory={false}
         isSoftwareFetching={false}
         isSoftwareEnabled
         navTabIndex={1}

--- a/frontend/pages/DashboardPage/cards/Software/Software.tsx
+++ b/frontend/pages/DashboardPage/cards/Software/Software.tsx
@@ -18,7 +18,6 @@ import generateTableHeaders from "./SoftwareTableConfig";
 
 interface ISoftwareCardProps {
   errorSoftware: Error | null;
-  isCollectingInventory: boolean;
   isSoftwareFetching: boolean;
   isSoftwareEnabled?: boolean;
   software?: ISoftwareResponse;
@@ -45,7 +44,6 @@ const baseClass = "home-software";
 
 const Software = ({
   errorSoftware,
-  isCollectingInventory,
   isSoftwareFetching,
   isSoftwareEnabled,
   navTabIndex,
@@ -95,11 +93,7 @@ const Software = ({
                   defaultSortHeader={SOFTWARE_DEFAULT_SORT_DIRECTION}
                   defaultSortDirection={SOFTWARE_DEFAULT_SORT_DIRECTION}
                   resultsTitle="software"
-                  emptyComponent={() => (
-                    <EmptySoftwareTable
-                      isCollectingSoftware={isCollectingInventory}
-                    />
-                  )}
+                  emptyComponent={() => <EmptySoftwareTable />}
                   showMarkAllPages={false}
                   isAllPagesSelected={false}
                   disableCount
@@ -122,10 +116,7 @@ const Software = ({
                   defaultSortDirection={SOFTWARE_DEFAULT_SORT_DIRECTION}
                   resultsTitle="software"
                   emptyComponent={() => (
-                    <EmptySoftwareTable
-                      isCollectingSoftware={isCollectingInventory}
-                      vulnFilters={{ vulnerable: true }}
-                    />
+                    <EmptySoftwareTable vulnFilters={{ vulnerable: true }} />
                   )}
                   showMarkAllPages={false}
                   isAllPagesSelected={false}

--- a/frontend/pages/SoftwarePage/SoftwareTitles/SoftwareTable/SoftwareTable.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitles/SoftwareTable/SoftwareTable.tsx
@@ -356,7 +356,6 @@ const SoftwareTable = ({
             vulnFilters={vulnFilters}
             isSoftwareDisabled={!isSoftwareEnabled}
             noSearchQuery={query === ""}
-            isCollectingSoftware={data?.counts_updated_at === null}
             installableSoftwareExists={installableSoftwareExists}
           />
         )}

--- a/frontend/pages/SoftwarePage/components/EmptySoftwareTable/EmptySoftwareTable.tsx
+++ b/frontend/pages/SoftwarePage/components/EmptySoftwareTable/EmptySoftwareTable.tsx
@@ -14,7 +14,6 @@ export interface IEmptySoftwareTableProps {
   tableName?: string;
   isSoftwareDisabled?: boolean;
   noSearchQuery?: boolean;
-  isCollectingSoftware?: boolean;
   installableSoftwareExists?: boolean;
 }
 
@@ -38,7 +37,6 @@ const EmptySoftwareTable = ({
   tableName = "software",
   isSoftwareDisabled,
   noSearchQuery,
-  isCollectingSoftware,
   installableSoftwareExists,
 }: IEmptySoftwareTableProps): JSX.Element => {
   const softwareTypeText = generateTypeText(
@@ -80,13 +78,10 @@ const EmptySoftwareTable = ({
             info: "Install software on your hosts to see versions.",
           };
         }
-        if (isCollectingSoftware) {
-          return {
-            header: `No ${tableName} detected`,
-            info: `Expecting to see ${softwareTypeText}? Check back later.`,
-          };
-        }
-        return { header: `No ${tableName} detected`, info: "" };
+        return {
+          header: `No ${tableName} detected`,
+          info: `Expecting to see ${softwareTypeText}? Check back later.`,
+        };
       }
     }
 


### PR DESCRIPTION
## Issue
Cerra #21641 

## Description
- UI Second line of empty state was being omitted
  - Problem: as we didn't add a "collecting software" tag onto the rendering OS empty state. Since default return should be the same as collecting software return (I think a separate collecting software empty state UI was remove completely), just render the default empty state and no longer need to check for collecting software

## Screenshot of fix

<img width="1520" alt="Screenshot 2024-08-28 at 4 04 14 PM" src="https://github.com/user-attachments/assets/f3687690-d0c4-488a-915e-53bfe7fc4807">


- [x] Manual QA for all new/changed functionality
