### PR TITLE
Fix type error

### DIFF
--- a/it-and-security/lib/configuration-profiles/passcode-settings-ddm.json
+++ b/it-and-security/lib/configuration-profiles/passcode-settings-ddm.json
@@ -2,7 +2,7 @@
     "Type": "com.apple.configuration.passcode.settings",
     "Identifier": "956e0d14-6019-479b-a6f9-a69ef77668c5",
     "Payload": {
-        "MaximumFailedAttempts": "five",
+        "MaximumFailedAttempts": 5,
         "MaximumInactivityInMinutes ": 5,
         "MinimumLength ": 12,
         "MinimumComplexCharacters": 3


### PR DESCRIPTION
- [x] Manual QA for all new/changed functionality: This profile did not install prior to the change. It does so after the correction in my test instance.
