### PR TITLE
Website: link to personalized view of endpoint ops page without changing primaryBuyingSituation

### DIFF
--- a/website/api/controllers/view-endpoint-ops.js
+++ b/website/api/controllers/view-endpoint-ops.js
@@ -22,13 +22,23 @@ module.exports = {
     }
     // Get testimonials for the <scrolalble-tweets> component.
     let testimonialsForScrollableTweets = _.clone(sails.config.builtStaticContent.testimonials);
+    // Default the pagePersonalization to the user's primaryBuyingSituation.
+    let pagePersonalization = this.req.session.primaryBuyingSituation;
+    // If a pageMode query parameter is set, update the pagePersonalization value.
+    // Note: This is the only page we're using this method instead of using the primaryBuyingSiutation value set in the users session.
+    // This lets us link to the security and IT versions of the endpoint ops page from the unpersonalized homepage without changing the users primaryBuyingSituation.
+    if(this.req.param('pageMode') === 'it'){
+      pagePersonalization = 'eo-it';
+    } else if(this.req.param('pageMode') === 'security'){
+      pagePersonalization = 'eo-security';
+    }
 
 
     // Specify an order for the testimonials on this page using the last names of quote authors
     let testimonialOrderForThisPage = ['Charles Zaffery','Dan Grzelak','Nico Waisman','Tom Larkin','Austin Anderson','Erik Gomez','Nick Fohs','Brendan Shaklovitz','Mike Arpaia','Andre Shields','Dhruv Majumdar','Ahmed Elshaer','Abubakar Yousafzai','Harrison Ravazzolo','Wes Whetstone','Kenny Botelho', 'Chandra Majumdar','Eric Tan', 'Alvaro Gutierrez', 'Joe Pistone'];
-    if(['eo-it', 'mdm'].includes(this.req.session.primaryBuyingSituation)){
+    if(['eo-it', 'mdm'].includes(pagePersonalization)){
       testimonialOrderForThisPage = [ 'Harrison Ravazzolo', 'Eric Tan','Erik Gomez', 'Tom Larkin', 'Nick Fohs', 'Wes Whetstone', 'Mike Arpaia', 'Kenny Botelho', 'Alvaro Gutierrez'];
-    } else if(['eo-security', 'vm'].includes(this.req.session.primaryBuyingSituation)){
+    } else if(['eo-security', 'vm'].includes(pagePersonalization)){
       testimonialOrderForThisPage = ['Nico Waisman','Charles Zaffery','Abubakar Yousafzai','Eric Tan','Mike Arpaia','Chandra Majumdar','Ahmed Elshaer','Brendan Shaklovitz','Austin Anderson','Dan Grzelak','Dhruv Majumdar','Alvaro Gutierrez', 'Joe Pistone'];
     }
     // Filter the testimonials by product category and the filtered list we built above.
@@ -48,6 +58,7 @@ module.exports = {
     // Respond with view.
     return {
       testimonialsForScrollableTweets,
+      pagePersonalization,
     };
 
   }

--- a/website/views/pages/endpoint-ops.ejs
+++ b/website/views/pages/endpoint-ops.ejs
@@ -3,22 +3,22 @@
     <div purpose="page-content" class="mx-auto">
     <div purpose="hero">
       <div purpose="page-headline">
-        <h4>Endpoint operations <%= ['eo-security', 'vm'].includes(primaryBuyingSituation) ? 'for security' : ['eo-it', 'mdm'].includes(primaryBuyingSituation) ? 'for IT' : '' %></h4>
-        <h1><%= primaryBuyingSituation==='eo-security'? 'Instrument your endpoints' : 'Understand your computers'%></h1>
+        <h4>Endpoint operations <%= ['eo-security', 'vm'].includes(pagePersonalization) ? 'for security' : ['eo-it', 'mdm'].includes(pagePersonalization) ? 'for IT' : '' %></h4>
+        <h1><%= pagePersonalization==='eo-security'? 'Instrument your endpoints' : 'Understand your computers'%></h1>
       </div>
       <div purpose="hero-content" class="d-flex flex-md-row flex-column align-items-center justify-content-between">
         <div purpose="hero-image">
           <img alt="A device verifying compliance for every endpoint" src="/images/endpoint-operations-hero-image-380x380@2x.png">
         </div>
         <div purpose="hero-text">
-          <% if(['eo-it', 'mdm'].includes(primaryBuyingSituation)) { %>
+          <% if(['eo-it', 'mdm'].includes(pagePersonalization)) { %>
             <strong>Automate anything</strong>
             <p>Remotely run scripts and prompts to complete tasks on every kind of computer, including Linux.</p>
             <strong>Pulse check anything</strong>
             <p>Use a live connection to every endpoint to simplify audit, compliance, and reporting from workstations to data centers.</p>
             <strong>Ship data to any platform</strong>
             <p>Ship logs to any platform like Splunk, Snowflake, or <a href="/docs/using-fleet/log-destinations">any streaming infrastructure</a> like AWS Kinesis and Apache Kafka.</p>
-          <% } else if(['eo-security', 'vm'].includes(primaryBuyingSituation)) { %>
+          <% } else if(['eo-security', 'vm'].includes(pagePersonalization)) { %>
             <strong>Osquery on easy mode</strong>
             <p>Build the agent in "read-only" mode or enable remote scripting to automatically mitigate misconfigurations and vulnerabilities.</p>
             <strong>Pulse check anything</strong>
@@ -41,7 +41,7 @@
       </div>
     </div>
     <div purpose="testimonials" class="d-flex flex-md-row flex-column align-items-center justify-content-between">
-      <% if (['eo-security'].includes(primaryBuyingSituation)) { %>
+      <% if (['eo-security'].includes(pagePersonalization)) { %>
         <div purpose="testimonial-quote">
           <div purpose="quote">
             <img alt="an opening quotation mark" style="width:20px; margin-bottom: 16px;" src="/images/icon-quote-21x17@2x.png">
@@ -57,7 +57,7 @@
           </div>
             </a>
         </div>
-      <% } else if (['vm'].includes(primaryBuyingSituation)) { %>
+      <% } else if (['vm'].includes(pagePersonalization)) { %>
         <div purpose="testimonial-quote">
           <div purpose="quote">
             <img alt="an opening quotation mark" style="width:20px; margin-bottom: 16px;" src="/images/icon-quote-21x17@2x.png">
@@ -91,15 +91,15 @@
         </div>
       <% } %>
       <div purpose="testimonial-videos" class="d-flex">
-        <%if(['eo-security'].includes(primaryBuyingSituation)) {%>
+        <%if(['eo-security'].includes(pagePersonalization)) {%>
         <div purpose="testimonial-video" class="charles-zaffery mx-auto" @click="clickOpenVideoModal('charles-zaffery')">
           <span><img src="/images/icon-play-video-8x9@2x.png" alt="Play">Play video</span>
         </div>
-        <%} else if(['vm'].includes(primaryBuyingSituation)){%>
+        <%} else if(['vm'].includes(pagePersonalization)){%>
         <div purpose="testimonial-video" class="austin-anderson mx-auto" @click="clickOpenVideoModal('austin-anderson')">
           <span><img src="/images/icon-play-video-8x9@2x.png" alt="Play">Play video</span>
         </div>
-        <%} else if(['eo-it', 'mdm'].includes(primaryBuyingSituation)) {%>
+        <%} else if(['eo-it', 'mdm'].includes(pagePersonalization)) {%>
         <div purpose="testimonial-video" class="nick-fohs mx-auto" @click="clickOpenVideoModal('nick-fohs')">
           <span><img src="/images/icon-play-video-8x9@2x.png" alt="Play">Play video</span>
         </div>
@@ -116,7 +116,7 @@
     <logo-carousel></logo-carousel>
 
 
-    <% if(!primaryBuyingSituation || ['mdm', 'eo-it'].includes(primaryBuyingSituation)){%>
+    <% if(!pagePersonalization || ['mdm', 'eo-it'].includes(pagePersonalization)){%>
     <div purpose="feature" class="d-flex flex-md-row flex-column-reverse justify-content-between mx-auto align-items-center">
       <div purpose="feature-text" class="d-flex flex-column">
         <h3>Automate anything</h3>
@@ -232,7 +232,7 @@
       </div>
       <div purpose="feature-text" class="d-flex flex-column">
         <h3>Osquery on easy mode</h3>
-        <p>Accelerate deployment and get more out of osquery. You don’t need to be an osquery expert to get the answers you need from your <%= ['vm', 'eo-security'].includes(primaryBuyingSituation) ? 'endpoints' : 'devices' %>.</p>
+        <p>Accelerate deployment and get more out of osquery. You don’t need to be an osquery expert to get the answers you need from your <%= ['vm', 'eo-security'].includes(pagePersonalization) ? 'endpoints' : 'devices' %>.</p>
         <div purpose="checklist" class="flex-column d-flex">
           <p>Remotely disable/enable agent features, choose plugins, and keep osquery up to date.</p>
           <p>Import community queries from other security teams at top brands like Palantir and Fastly.</p>
@@ -242,7 +242,7 @@
       </div>
     </div>
 
-    <% if(!primaryBuyingSituation || ['vm', 'eo-security'].includes(primaryBuyingSituation)) {%>
+    <% if(!pagePersonalization || ['vm', 'eo-security'].includes(pagePersonalization)) {%>
     <div purpose="feature-headline" class="mr-auto">
       <h3>Open security tooling</h3>
       <p>Consolidate your security tooling on top of open data standards like YAML, SQL, and JSON.</p>
@@ -298,7 +298,7 @@
     <div purpose="tweets-container" class="container-fluid px-md-0 pb-0 d-flex flex-column justify-content-center">
       <div purpose="section-heading" class="mx-auto text-center">
         <h4>Who else uses Fleet?</h4>
-        <h3>Empowering <%= ['mdm'].includes(primaryBuyingSituation) ? 'IT and corporate engineering' : ['eo-it'].includes(primaryBuyingSituation) ? 'IT and client platform' : ['eo-security'].includes(primaryBuyingSituation) ? 'security and platform' : ['vm'].includes(primaryBuyingSituation) ? 'security and IT' : 'IT and security' %> teams, globally</h3>
+        <h3>Empowering <%= ['mdm'].includes(pagePersonalization) ? 'IT and corporate engineering' : ['eo-it'].includes(pagePersonalization) ? 'IT and client platform' : ['eo-security'].includes(pagePersonalization) ? 'security and platform' : ['vm'].includes(pagePersonalization) ? 'security and IT' : 'IT and security' %> teams, globally</h3>
       </div>
     </div>
 
@@ -307,7 +307,7 @@
 
       <div purpose="section-heading" class="text-center">
         <h4>Endpoint operations</h4>
-        <h3><%= primaryBuyingSituation==='eo-security'? 'Instrument your endpoints' : 'Understand your computers'%></h3>
+        <h3><%= pagePersonalization==='eo-security'? 'Instrument your endpoints' : 'Understand your computers'%></h3>
         <div purpose="button-row" style="margin-top: 32px;" class="d-flex flex-md-row flex-column justify-content-center align-items-center mx-auto">
           <a purpose="cta-button" href="/register">Start now</a>
           <animated-arrow-button href="/contact">Talk to us</animated-arrow-button>

--- a/website/views/pages/homepage.ejs
+++ b/website/views/pages/homepage.ejs
@@ -62,7 +62,7 @@
           <strong>Osquery on easy mode</strong>
           <p>Use "read-only" mode or enable remote scripting to automate anything on every operating system, including Linux.</p>
           <div>
-            <a purpose="category-button" class="text-nowrap btn btn-primary" href="/endpoint-ops?utm_content=eo-it">Start with IT engineering</a>
+            <a purpose="category-button" class="text-nowrap btn btn-primary" href="/endpoint-ops?pageMode=it">Start with IT engineering</a>
           </div>
         </div>
       </div>
@@ -80,7 +80,7 @@
           <strong>Ship data to any platform</strong>
           <p>Ship logs to any platform like Splunk, Snowflake, or <a href="/docs/using-fleet/log-destinations">any streaming infrastructure</a> like AWS Kinesis and Apache Kafka.</p>
           <div>
-            <a purpose="category-button" class="text-nowrap btn btn-primary" href="/endpoint-ops?utm_content=eo-security">Start with security engineering</a>
+            <a purpose="category-button" class="text-nowrap btn btn-primary" href="/endpoint-ops?pageMode=security">Start with security engineering</a>
           </div>
         </div>
       </div>
@@ -108,7 +108,7 @@
              <h2><%= primaryBuyingSituation==='eo-security'? 'Instrument your endpoints' : 'Understand your computers'%></h2>
              <p>A <%= primaryBuyingSituation==='eo-security'? 'lightweight' : 'quick-fast' %> way to gather <%= primaryBuyingSituation==='vm'? 'patch level and custom reports across all your computing devices, even in OT and production environments' : primaryBuyingSituation==='eo-security'? 'deep context and custom telemetry across all your endpoints, even servers' : primaryBuyingSituation==='mdm'||primaryBuyingSituation==='eo-it'? 'compliance and inventory data across all your devices' : 'device data across all your computers' %>. Pulse check or automate anything on any platform.</p>
              <div>
-               <animated-arrow-button href="/endpoint-ops<%= primaryBuyingSituation==='eo-security' ? '?utm_content=eo-security' : '?utm_content=eo-it'%>">Start with <%= primaryBuyingSituation==='eo-security' ? 'security engineering' : 'IT engineering'%></animated-arrow-button>
+               <animated-arrow-button href="/endpoint-ops">Start with <%= primaryBuyingSituation==='eo-security' ? 'security engineering' : 'IT engineering'%></animated-arrow-button>
              </div>
            </div>
            <div purpose="endpoint-ops-image" class="right">
@@ -175,7 +175,7 @@
              <h2><%= primaryBuyingSituation==='vm'? 'Instrument your endpoints' : 'Understand your computers'%></h2>
              <p>A <%= primaryBuyingSituation==='vm'? 'lightweight' : 'quick-fast' %> way to gather <%= primaryBuyingSituation==='vm'? 'patch level and custom reports across all your computing devices, even in OT and production environments' : primaryBuyingSituation==='vm'? 'deep context and custom telemetry across all your endpoints, even servers' : primaryBuyingSituation==='mdm'||primaryBuyingSituation==='eo-it'? 'compliance and inventory data across all your devices' : 'device data across all your computers' %>. Pulse check or automate anything on any platform.</p>
              <div>
-               <animated-arrow-button href="/endpoint-ops<%= primaryBuyingSituation==='mdm' ? '?utm_content=eo-it' : '?utm_content=eo-security'%>">Start with <%= primaryBuyingSituation==='mdm' ? 'IT engineering' : 'security engineering'%></animated-arrow-button>
+               <animated-arrow-button href="/endpoint-ops">Start with <%= primaryBuyingSituation==='mdm' ? 'IT engineering' : 'security engineering'%></animated-arrow-button>
              </div>
            </div>
          </div>


### PR DESCRIPTION
Closes: #21237

Changes:
- Updated view-endpoint-ops to set a `pagePersonalization` value using the users primaryBuyingSituation (if it is set) or a `pageMode` query parameter.
- Updated the endpoint ops page to be personalized based off the pagePersonalization value set in the view action
- Updated the links to the endpoint ops page on the unpersonalized homepage to use a pageMode query parameter (e.g., pageMode=it) instead of a utm_content query parameter.
- Updated the links to the endpoint ops page on the personalized homepage to not include a utm_content query parameter.