### PR TITLE
Fix old change added outside `changes/`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -756,6 +756,7 @@ enrolled into teams (or no team) with disk encryption turned on. Thank you [home
 * Fixed an issue where software from a Parallels VM on a MacOS host would show up in Fleet as if it were the host's software.
 * Removed unnecessary nested database transactions in batch-setting of MDM profiles.
 * Added count of upcoming activities to host vitals UI.
+* Fixed a bug where the manage query automations modal would lose its state when the user clicks "Preview data".
 
 ## Fleet 4.44.0 (Jan 31, 2024)
 

--- a/changes/16538-preserve-manage-query-automations-modal-state
+++ b/changes/16538-preserve-manage-query-automations-modal-state
@@ -1,2 +1,0 @@
-- Fix a bug where the manage query automations modal would lose its state when the user clicks
-  "Preview data"


### PR DESCRIPTION
This lingering changes was first detected by https://github.com/fleetdm/fleet/pull/21369 (the user moved it to the correct place and this PR is removing it).
I traced the PR that added the change to the wrong location to an issue with the milestone 4.44.1.