### PR TITLE
Website: Fix overflowing step of /start questionnaire

### DIFF
--- a/website/assets/styles/pages/start.less
+++ b/website/assets/styles/pages/start.less
@@ -357,7 +357,7 @@
       margin-bottom: 20px;
     }
     [purpose='form-container'] {
-      width: unset;
+      width: 100%;
       margin-left: 0;
       margin-right: 0;
     }


### PR DESCRIPTION
Related to: #21081
Closes: #21690

Changes:
- Updated the styles for the /start questionnaire to prevent the content from overflowing outside of the page's container on smaller screen sizes.