### PR TITLE
Add docs for --dev default MinIO buckets

### DIFF
--- a/docs/Contributing/File-carving.md
+++ b/docs/Contributing/File-carving.md
@@ -77,7 +77,7 @@ The same is not true if S3 is used as the storage backend. In that scenario, it 
 
 ### Alternative carving backends
 
-#### Minio
+#### MinIO
 
 Configure the following:
 - `FLEET_S3_ENDPOINT_URL=minio_host:port`
@@ -86,6 +86,11 @@ Configure the following:
 - `FLEET_S3_ACCESS_KEY_ID=acces_key_id`
 - `FLEET_S3_FORCE_S3_PATH_STYLE=true`
 - `FLEET_S3_REGION=minio` or any non-empty string otherwise Fleet will attempt to derive the region.
+
+If you're testing file carving locally with the docker-compose environment, the `--dev` flag on Fleet server will
+automatically point carves to the local MinIO container and write to the `carves-dev` bucket without needing to set
+additional configuration. Note that this bucket is *not* created automatically when bringing MinIO up; you'll need to
+log in via `http://localhost:9001` with credentials `minio` / `minio123!` to create the bucket.
 
 ### Troubleshooting
 

--- a/docs/Contributing/Testing-and-local-development.md
+++ b/docs/Contributing/Testing-and-local-development.md
@@ -489,7 +489,9 @@ FLEET_SERVER_SANDBOX_ENABLED=1 FLEET_PACKAGING_GLOBAL_ENROLL_SECRET=xyz  ./build
 Be sure to replace the `FLEET_PACKAGING_GLOBAL_ENROLL_SECRET` value above with the global enroll
 secret from the `fleetctl package` command used to build the installers.
 
-MinIO also offers a web interface at http://localhost:9001. Credentials are `minio` / `minio123!`.
+MinIO also offers a web interface at http://localhost:9001. Credentials are `minio` / `minio123!`. When starting the
+Fleet server up with `--dev` the server will look for installers in the `software-installers-dev` MinIO bucket. You can
+create this bucket via the MinIO web UI (it is *not* created by default when setting up the docker-compose environment).
 
 ## Telemetry
 


### PR DESCRIPTION
I noticed this wasn't documented when i went hunting for what I figured were defaults baked into `--dev`; thanks @jahzielv for pointing me in the right direction!