### PR TITLE
UI - Install software modal: Include package platform in helptext

### DIFF
--- a/frontend/pages/policies/ManagePoliciesPage/components/InstallSoftwareModal/InstallSoftwareModal.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/components/InstallSoftwareModal/InstallSoftwareModal.tsx
@@ -133,11 +133,33 @@ const InstallSoftwareModal = ({
     [formData]
   );
 
-  const availableSoftwareOptions = titlesAFI?.map((title) => ({
-    label: title.name,
-    value: title.id,
-    helpText: title.software_package?.version,
-  }));
+  const getPlatformDisplayFromPackageSuffix = (packageName: string) => {
+    const split = packageName.split(".");
+    const suff = split[split.length - 1];
+    switch (suff) {
+      case "pkg":
+        return "macOS";
+      case "deb":
+        return "Linux";
+      case "exe":
+        return "Windows";
+      case "msi":
+        return "Windows";
+      default:
+        return null;
+    }
+  };
+  const availableSoftwareOptions = titlesAFI?.map((title) => {
+    const platformDisplay = getPlatformDisplayFromPackageSuffix(
+      title.software_package?.name ?? ""
+    );
+    const platformString = platformDisplay ? `${platformDisplay} • ` : "";
+    return {
+      label: title.name,
+      value: title.id,
+      helpText: `${platformString}${title.software_package?.version ?? ""}`,
+    };
+  });
 
   const renderPolicySwInstallOption = (policy: IFormPolicy) => {
     const {

--- a/frontend/pages/policies/ManagePoliciesPage/components/InstallSoftwareModal/InstallSoftwareModal.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/components/InstallSoftwareModal/InstallSoftwareModal.tsx
@@ -21,6 +21,23 @@ import CustomLink from "components/CustomLink";
 import Button from "components/buttons/Button";
 import { ISoftwareTitle } from "interfaces/software";
 
+const getPlatformDisplayFromPackageSuffix = (packageName: string) => {
+  const split = packageName.split(".");
+  const suff = split[split.length - 1];
+  switch (suff) {
+    case "pkg":
+      return "macOS";
+    case "deb":
+      return "Linux";
+    case "exe":
+      return "Windows";
+    case "msi":
+      return "Windows";
+    default:
+      return null;
+  }
+};
+
 const AFI_SOFTWARE_BATCH_SIZE = 1000;
 
 const baseClass = "install-software-modal";
@@ -133,22 +150,6 @@ const InstallSoftwareModal = ({
     [formData]
   );
 
-  const getPlatformDisplayFromPackageSuffix = (packageName: string) => {
-    const split = packageName.split(".");
-    const suff = split[split.length - 1];
-    switch (suff) {
-      case "pkg":
-        return "macOS";
-      case "deb":
-        return "Linux";
-      case "exe":
-        return "Windows";
-      case "msi":
-        return "Windows";
-      default:
-        return null;
-    }
-  };
   const availableSoftwareOptions = titlesAFI?.map((title) => {
     const platformDisplay = getPlatformDisplayFromPackageSuffix(
       title.software_package?.name ?? ""


### PR DESCRIPTION
## #21719 

- Include macOS, Windows, or Linux in the help text of each software available for install in Dropdowns of the Install software modal 

![Screenshot 2024-08-30 at 5 14 43 PM](https://github.com/user-attachments/assets/49dc3ea5-d1a7-41d9-96c7-6ffaff8e06c7)

- [x] Manual QA for all new/changed functionality