### PR TITLE
fix: properly catch and log APNs errors

### DIFF
--- a/changes/apns-errors
+++ b/changes/apns-errors
@@ -1,0 +1,1 @@
+* Fixed logic to properly catch and log APNs errors.

--- a/server/mdm/apple/commander.go
+++ b/server/mdm/apple/commander.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"net/http"
+	"sort"
 	"strings"
 
 	"github.com/fleetdm/fleet/v4/server/contexts/ctxerr"
@@ -405,9 +406,17 @@ type APNSDeliveryError struct {
 }
 
 func (e *APNSDeliveryError) Error() string {
+	var uuids []string
+	for uuid := range e.errorsByUUID {
+		uuids = append(uuids, uuid)
+	}
+
+	// sort UUIDs alphabetically for deterministic output
+	sort.Strings(uuids)
+
 	var errStrings []string
-	for uuid, err := range e.errorsByUUID {
-		errStrings = append(errStrings, fmt.Sprintf("UUID: %s, Error: %v", uuid, err))
+	for _, uuid := range uuids {
+		errStrings = append(errStrings, fmt.Sprintf("UUID: %s, Error: %v", uuid, e.errorsByUUID[uuid]))
 	}
 
 	return fmt.Sprintf(
@@ -421,6 +430,9 @@ func (e *APNSDeliveryError) FailedUUIDs() []string {
 	for uuid := range e.errorsByUUID {
 		uuids = append(uuids, uuid)
 	}
+
+	// sort UUIDs alphabetically for deterministic output
+	sort.Strings(uuids)
 	return uuids
 }
 

--- a/server/service/apple_mdm.go
+++ b/server/service/apple_mdm.go
@@ -3149,7 +3149,7 @@ func SendPushesToPendingDevices(
 	if err := commander.SendNotifications(ctx, uuids); err != nil {
 		var apnsErr *apple_mdm.APNSDeliveryError
 		if errors.As(err, &apnsErr) {
-			level.Info(logger).Log("msg", "failed to send APNs notification to some hosts", "errs", apnsErr.Error())
+			level.Info(logger).Log("msg", "failed to send APNs notification to some hosts", "error", apnsErr.Error())
 			return nil
 		}
 

--- a/server/service/apple_mdm.go
+++ b/server/service/apple_mdm.go
@@ -3149,7 +3149,7 @@ func SendPushesToPendingDevices(
 	if err := commander.SendNotifications(ctx, uuids); err != nil {
 		var apnsErr *apple_mdm.APNSDeliveryError
 		if errors.As(err, &apnsErr) {
-			level.Info(logger).Log("msg", "failed to send APNs notification to some hosts", "host_uuids", apnsErr.FailedUUIDs)
+			level.Info(logger).Log("msg", "failed to send APNs notification to some hosts", "errs", apnsErr.Error())
 			return nil
 		}
 

--- a/server/service/mdm.go
+++ b/server/service/mdm.go
@@ -567,13 +567,14 @@ func (svc *Service) enqueueAppleMDMCommand(ctx context.Context, rawXMLCmd []byte
 		var apnsErr *apple_mdm.APNSDeliveryError
 		var mysqlErr *mysql.MySQLError
 		if errors.As(err, &apnsErr) {
-			if len(apnsErr.FailedUUIDs) < len(deviceIDs) {
+			failedUUIDs := apnsErr.FailedUUIDs()
+			if len(failedUUIDs) < len(deviceIDs) {
 				// some hosts properly received the command, so return success, with the list
 				// of failed uuids.
 				return &fleet.CommandEnqueueResult{
 					CommandUUID: cmd.CommandUUID,
 					RequestType: cmd.Command.RequestType,
-					FailedUUIDs: apnsErr.FailedUUIDs,
+					FailedUUIDs: failedUUIDs,
 				}, nil
 			}
 			// push failed for all hosts


### PR DESCRIPTION
found reproducing other issues:

1. In the APNs cron, the logger wasn't good enough to print an slice and the log message was "unsupported type"
2. `APNSDeliveryError` _always_ had `Err` set to nil, while we were catching those errors, it was impossible to see the cause in the logs (always printed err=nil)

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/Committing-Changes.md#changes-files) for more information.
- [x] Manual QA for all new/changed functionality
