### PR TITLE
MABM bugfix: fix the expected format of the migrated VPP token

### DIFF
--- a/cmd/fleet/serve.go
+++ b/cmd/fleet/serve.go
@@ -633,6 +633,12 @@ the way that the Fleet server works.
 					appCfg.MDM.AppleBMEnabledAndConfigured = count > 0
 				}
 			}
+			if appCfg.MDM.EnabledAndConfigured {
+				level.Info(logger).Log("msg", "Apple MDM enabled")
+			}
+			if appCfg.MDM.AppleBMEnabledAndConfigured {
+				level.Info(logger).Log("msg", "Apple Business Manager enabled")
+			}
 
 			// register the Microsoft MDM services
 			var (

--- a/server/test/mdm.go
+++ b/server/test/mdm.go
@@ -36,6 +36,14 @@ func CreateVPPTokenEncoded(expiration time.Time, orgName, location string) ([]by
 	if err != nil {
 		return nil, err
 	}
+	return []byte(dataToken.Token), nil
+}
+
+func CreateVPPTokenEncodedAfterMigration(expiration time.Time, orgName, location string) ([]byte, error) {
+	dataToken, err := CreateVPPTokenData(expiration, orgName, location)
+	if err != nil {
+		return nil, err
+	}
 
 	dataTokenJson, err := json.Marshal(dataToken)
 	if err != nil {

--- a/server/worker/db_migrations_test.go
+++ b/server/worker/db_migrations_test.go
@@ -12,12 +12,11 @@ import (
 	"github.com/fleetdm/fleet/v4/server/test"
 	kitlog "github.com/go-kit/log"
 	"github.com/jmoiron/sqlx"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestDBMigrationsVPPToken(t *testing.T) {
-	// FIXME
-	t.Skip()
 	ctx := context.Background()
 
 	ds := mysql.CreateMySQLDS(t)
@@ -38,7 +37,7 @@ func TestDBMigrationsVPPToken(t *testing.T) {
 
 	// create the migrated token and enqueue the job
 	expDate := time.Date(2024, 8, 27, 0, 0, 0, 0, time.UTC)
-	tok, err := test.CreateVPPTokenEncoded(expDate, "test-org", "test-loc")
+	tok, err := test.CreateVPPTokenEncodedAfterMigration(expDate, "test-org", "test-loc")
 	require.NoError(t, err)
 	encTok, err := mysql.EncryptWithPrivateKey(t, ds, tok)
 	require.NoError(t, err)
@@ -49,12 +48,10 @@ INSERT INTO vpp_tokens
 		organization_name,
 		location,
 		renew_at,
-		token,
-		team_id,
-		null_team_type
+		token
 	)
 VALUES
-	('', '', DATE('2000-01-01'), ?, NULL, 'allteams')
+	('', '', DATE('2000-01-01'), ?)
 `
 
 	const insJob = `
@@ -93,7 +90,9 @@ VALUES (?, ?, ?, '', ?, ?, ?)
 	// nothing more to run
 	jobs, err := ds.GetQueuedJobs(ctx, 1, time.Now().UTC().Add(time.Minute)) // look in the future to catch any delayed job
 	require.NoError(t, err)
-	require.Empty(t, jobs)
+	if !assert.Empty(t, jobs) {
+		t.Logf(">>> %#+v", jobs[0])
+	}
 
 	// token should've been updated
 	vppTok, err := ds.GetVPPTokenByLocation(ctx, "test-loc")
@@ -101,7 +100,8 @@ VALUES (?, ?, ?, '', ?, ?, ?)
 	require.Equal(t, "test-org", vppTok.OrgName)
 	require.Equal(t, "test-loc", vppTok.Location)
 	require.Equal(t, expDate, vppTok.RenewDate)
-	require.Equal(t, string(tok), vppTok.Token)
+	t.Log(string(tok))
+	require.Contains(t, string(tok), `"token":"`+vppTok.Token+`"`) // the DB-stored token is the "token" JSON field in the raw tok
 	require.NotNil(t, vppTok.Teams)
 	require.Len(t, vppTok.Teams, 0)
 

--- a/server/worker/db_migrations_test.go
+++ b/server/worker/db_migrations_test.go
@@ -100,7 +100,6 @@ VALUES (?, ?, ?, '', ?, ?, ?)
 	require.Equal(t, "test-org", vppTok.OrgName)
 	require.Equal(t, "test-loc", vppTok.Location)
 	require.Equal(t, expDate, vppTok.RenewDate)
-	t.Log(string(tok))
 	require.Contains(t, string(tok), `"token":"`+vppTok.Token+`"`) // the DB-stored token is the "token" JSON field in the raw tok
 	require.NotNil(t, vppTok.Teams)
 	require.Len(t, vppTok.Teams, 0)


### PR DESCRIPTION
#21757 

# Checklist for submitter

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [x] Added/updated tests
- [x] Manual QA for all new/changed functionality

Manually tested migrating from 4.55.1, and fixing migration from an earlier 4.56.0 release candidate can be done by running this SQL statement after the new RC is running:

```
INSERT INTO jobs ( name, args, state, error) VALUES ('db_migration', '{"task": "migrate_vpp_token"}', 'queued', '');
```