### PR TITLE
Website: add fixed width to Github stars button in website navigation

### DIFF
--- a/website/assets/styles/layout.less
+++ b/website/assets/styles/layout.less
@@ -444,8 +444,9 @@ html, body {
       }
     }
     [purpose='gh-button'] {
-      margin-left: 20px;
-      margin-right: 20px;
+      padding: 0px 20px;
+      min-width: 140px;
+      width: 140px;
     }
     [purpose='header-dropdown'] {
       box-shadow: 0px 4px 40px rgba(0, 0, 0, 0.4);


### PR DESCRIPTION
Closes: #21469

Changes:
- Updated the styles for the GitHub stars button in the websites desktop header navigation to prevent layout shifts when navigating between pages.
