### PR TITLE
Bugfix: cron startup scheduling is delayed too long if no prior run exists

### DIFF
--- a/changes/21757-fix-scheduling-cron-jobs-at-startup
+++ b/changes/21757-fix-scheduling-cron-jobs-at-startup
@@ -1,0 +1,1 @@
+* Fixed an issue with the scheduling of cron jobs at startup if the job has never run, which caused it to be delayed.

--- a/server/service/schedule/schedule.go
+++ b/server/service/schedule/schedule.go
@@ -167,7 +167,13 @@ func (s *Schedule) Start() {
 		level.Error(s.logger).Log("err", "start schedule", "details", err)
 		ctxerr.Handle(s.ctx, err)
 	}
-	s.setIntervalStartedAt(prevScheduledRun.CreatedAt)
+
+	// if there is no previous run, set the start time to the current time.
+	startedAt := prevScheduledRun.CreatedAt
+	if startedAt.IsZero() {
+		startedAt = time.Now()
+	}
+	s.setIntervalStartedAt(startedAt)
 
 	initialWait := 10 * time.Second
 	if schedInterval := s.getSchedInterval(); schedInterval < initialWait {


### PR DESCRIPTION
Found when debugging and fixing #21757 , cron jobs took up to 5m to be scheduled again, while with this fix, tested from migrating VPP and ABM tokens from v.4.55.1, it took about 1m.

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/Committing-Changes.md#changes-files) for more information.
- [x] Manual QA for all new/changed functionality
