### PR TITLE
UI - 19511 SW title details, host software, DUP self-service

### DIFF
--- a/frontend/interfaces/software.ts
+++ b/frontend/interfaces/software.ts
@@ -109,6 +109,7 @@ export interface ISoftwareTitleDetails {
   source: string; // "apps" | "ios_apps" | "ipados_apps" | ?
   hosts_count: number;
   versions: ISoftwareTitleVersion[] | null;
+  versions_updated_at?: string;
   bundle_identifier?: string;
   browser?: string;
   versions_count?: number;

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwarePackageCard/SoftwarePackageCard.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwarePackageCard/SoftwarePackageCard.tsx
@@ -142,6 +142,7 @@ const PackageStatusCount = ({
   })}`;
   return (
     <DataSet
+      className={`${baseClass}__status`}
       title={
         <TooltipWrapper
           position="top"
@@ -161,7 +162,6 @@ const PackageStatusCount = ({
           {count} hosts
         </a>
       }
-      className={`${baseClass}__status`}
     />
   );
 };

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwarePackageCard/SoftwarePackageCard.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwarePackageCard/SoftwarePackageCard.tsx
@@ -4,8 +4,6 @@ import React, {
   useLayoutEffect,
   useState,
 } from "react";
-import FileSaver from "file-saver";
-import { parse } from "content-disposition";
 
 import PATHS from "router/paths";
 import { AppContext } from "context/app";
@@ -139,7 +137,7 @@ const PackageStatusCount = ({
         >
           <div className={`${baseClass}__status-title`}>
             <Icon name={displayData.iconName} />
-            <span>{displayData.displayName}</span>
+            <div>{displayData.displayName}</div>
           </div>
         </TooltipWrapper>
       }
@@ -148,6 +146,7 @@ const PackageStatusCount = ({
           {count} hosts
         </a>
       }
+      className={`${baseClass}__status`}
     />
   );
 };
@@ -305,7 +304,7 @@ const SoftwarePackageCard = ({
 
   return (
     <Card borderRadiusSize="xxlarge" includeShadow className={baseClass}>
-      <div className={`${baseClass}__main-content`}>
+      <div className={`${baseClass}__row-1`}>
         {/* TODO: main-info could be a seperate component as its reused on a couple
         pages already. Come back and pull this into a component */}
         <div className={`${baseClass}__main-info`}>
@@ -315,46 +314,46 @@ const SoftwarePackageCard = ({
             <span className={`${baseClass}__details`}>{renderDetails()}</span>
           </div>
         </div>
-        <div className={`${baseClass}__package-statuses`}>
-          <PackageStatusCount
-            softwareId={softwareId}
-            status="installed"
-            count={status.installed}
-            teamId={teamId}
-          />
-          <PackageStatusCount
-            softwareId={softwareId}
-            status="pending"
-            count={status.pending}
-            teamId={teamId}
-          />
-          <PackageStatusCount
-            softwareId={softwareId}
-            status="failed"
-            count={status.failed}
-            teamId={teamId}
-          />
+        <div className={`${baseClass}__actions-wrapper`}>
+          {isSelfService && (
+            <div className={`${baseClass}__self-service-badge`}>
+              <Icon
+                name="install-self-service"
+                size="small"
+                color="ui-fleet-black-75"
+              />
+              Self-service
+            </div>
+          )}
+          {showActions && (
+            <ActionsDropdown
+              isSoftwarePackage={!!softwarePackage}
+              onDownloadClick={onDownloadClick}
+              onDeleteClick={onDeleteClick}
+              onAdvancedOptionsClick={onAdvancedOptionsClick}
+            />
+          )}
         </div>
       </div>
-      <div className={`${baseClass}__actions-wrapper`}>
-        {isSelfService && (
-          <div className={`${baseClass}__self-service-badge`}>
-            <Icon
-              name="install-self-service"
-              size="small"
-              color="ui-fleet-black-75"
-            />
-            Self-service
-          </div>
-        )}
-        {showActions && (
-          <ActionsDropdown
-            isSoftwarePackage={!!softwarePackage}
-            onDownloadClick={onDownloadClick}
-            onDeleteClick={onDeleteClick}
-            onAdvancedOptionsClick={onAdvancedOptionsClick}
-          />
-        )}
+      <div className={`${baseClass}__package-statuses`}>
+        <PackageStatusCount
+          softwareId={softwareId}
+          status="installed"
+          count={status.installed}
+          teamId={teamId}
+        />
+        <PackageStatusCount
+          softwareId={softwareId}
+          status="pending"
+          count={status.pending}
+          teamId={teamId}
+        />
+        <PackageStatusCount
+          softwareId={softwareId}
+          status="failed"
+          count={status.failed}
+          teamId={teamId}
+        />
       </div>
       {showAdvancedOptionsModal && (
         <AdvancedOptionsModal

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwarePackageCard/SoftwarePackageCard.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwarePackageCard/SoftwarePackageCard.tsx
@@ -43,10 +43,15 @@ function useTruncatedElement<T extends HTMLElement>(ref: React.RefObject<T>) {
 
   useLayoutEffect(() => {
     const element = ref.current;
-    if (element) {
-      const { scrollWidth, clientWidth } = element;
-      setIsTruncated(scrollWidth > clientWidth);
+    function updateIsTruncated() {
+      if (element) {
+        const { scrollWidth, clientWidth } = element;
+        setIsTruncated(scrollWidth > clientWidth);
+      }
     }
+    window.addEventListener("resize", updateIsTruncated);
+    updateIsTruncated();
+    return () => window.removeEventListener("resize", updateIsTruncated);
   }, [ref]);
 
   return isTruncated;

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwarePackageCard/SoftwarePackageCard.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwarePackageCard/SoftwarePackageCard.tsx
@@ -90,20 +90,29 @@ const STATUS_DISPLAY_OPTIONS: Record<
     iconName: "success",
     tooltip: (
       <>
-        Fleet installed software on these hosts. Currently, if the software is
-        uninstalled, the &quot;Installed&quot; status won&apos;t be updated.
+        Software is installed on these hosts (install script finished
+        <br />
+        with exit code 0). Currently, if the software is uninstalled, the
+        <br />
+        &quot;installed&quot; status won&apos;t be updated.
       </>
     ),
   },
   pending: {
     displayName: "Pending",
     iconName: "pending-outline",
-    tooltip: "Fleet will install software when these hosts come online.",
+    tooltip: "Fleet is installing or will install when the host comes online.",
   },
   failed: {
     displayName: "Failed",
     iconName: "error",
-    tooltip: "Fleet failed to install software on these hosts.",
+    tooltip: (
+      <>
+        These hosts failed to install software. Click on a host to view
+        <br />
+        error(s).
+      </>
+    ),
   },
 };
 
@@ -134,6 +143,7 @@ const PackageStatusCount = ({
           tipContent={displayData.tooltip}
           underline={false}
           showArrow
+          tipOffset={10}
         >
           <div className={`${baseClass}__status-title`}>
             <Icon name={displayData.iconName} />

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwarePackageCard/_styles.scss
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwarePackageCard/_styles.scss
@@ -9,6 +9,7 @@
     display: flex;
     justify-content: space-between;
     width: 100%;
+    gap: $pad-medium;
   }
 
   &__main-info {
@@ -27,7 +28,7 @@
     font-size: $x-small;
     font-weight: $bold;
     @include ellipse-text;
-    max-width: 290px;
+    max-width: 48vw;
   }
 
   &__details {
@@ -91,6 +92,7 @@
     color: $ui-fleet-black-75;
     font-size: $xx-small;
     font-weight: $bold;
+    white-space: nowrap;
   }
 
   &__actions {

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwarePackageCard/_styles.scss
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwarePackageCard/_styles.scss
@@ -1,13 +1,14 @@
 .software-package-card {
   display: flex;
+  flex-direction: column;
   justify-content: space-between;
   align-items: center;
   gap: $pad-medium;
 
-  &__main-content {
+  &__row-1 {
     display: flex;
-    align-items: flex-start;
-    gap: $pad-xxlarge;
+    justify-content: space-between;
+    width: 100%;
   }
 
   &__main-info {
@@ -19,6 +20,7 @@
     display: flex;
     flex-direction: column;
     gap: $pad-xsmall;
+    justify-content: center;
   }
 
   &__title {
@@ -34,13 +36,32 @@
 
   &__package-statuses {
     display: flex;
-    gap: $pad-xxlarge;
+    align-items: flex-start;
+    align-self: stretch;
+    border-radius: 6px;
+    border: 1px solid $ui-fleet-black-10;
+    font-size: $x-small;
   }
 
-  &__status-title {
+  &__status {
     display: flex;
+    flex-direction: column;
+    padding: 16px 24px;
+    justify-content: center;
     align-items: center;
-    gap: $pad-xsmall;
+    flex: 1 0 0;
+    border-right: 1px solid var(--UI-Fleet-Black-10, #e2e4ea);
+
+    &:last-child {
+      border-right: none;
+    }
+  }
+
+  &__status-title{
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: $pad-small;
   }
 
   &__status-count {

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwarePackageCard/_styles.scss
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwarePackageCard/_styles.scss
@@ -55,6 +55,10 @@
     &:last-child {
       border-right: none;
     }
+
+    .react-tooltip {
+      text-align: center;
+    }
   }
 
   &__status-title{

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwareTitleDetailsPage.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwareTitleDetailsPage.tsx
@@ -208,6 +208,7 @@ const SoftwareTitleDetailsPage = ({
                 softwareTitle.source
               )}
               isAvailableForInstall={isAvailableForInstall}
+              countsUpdatedAt={softwareTitle.versions_updated_at}
             />
           </Card>
         </>

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwareTitleDetailsTable/SoftwareTitleDetailsTable.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwareTitleDetailsTable/SoftwareTitleDetailsTable.tsx
@@ -13,6 +13,7 @@ import TableContainer from "components/TableContainer";
 import TableCount from "components/TableContainer/TableCount";
 import EmptyTable from "components/EmptyTable";
 import CustomLink from "components/CustomLink";
+import LastUpdatedText from "components/LastUpdatedText";
 
 import generateSoftwareTitleDetailsTableConfig from "./SoftwareTitleDetailsTableConfig";
 
@@ -20,6 +21,21 @@ const DEFAULT_SORT_HEADER = "hosts_count";
 const DEFAULT_SORT_DIRECTION = "desc";
 
 const baseClass = "software-title-details-table";
+
+const SoftwareLastUpdatedInfo = (lastUpdatedAt: string) => {
+  return (
+    <LastUpdatedText
+      lastUpdatedAt={lastUpdatedAt}
+      customTooltipText={
+        <>
+          The last time software data was <br />
+          updated, including vulnerabilities <br />
+          and host counts.
+        </>
+      }
+    />
+  );
+};
 
 const NoVersionsDetected = (isAvailableForInstall = false): JSX.Element => {
   return (
@@ -54,6 +70,7 @@ interface ISoftwareTitleDetailsTableProps {
   teamIdForApi?: number;
   isIPadOSOrIOSApp: boolean;
   isAvailableForInstall?: boolean;
+  countsUpdatedAt?: string;
 }
 
 interface IRowProps extends Row {
@@ -69,6 +86,7 @@ const SoftwareTitleDetailsTable = ({
   teamIdForApi,
   isIPadOSOrIOSApp,
   isAvailableForInstall,
+  countsUpdatedAt,
 }: ISoftwareTitleDetailsTableProps) => {
   const handleRowSelect = (row: IRowProps) => {
     const hostsBySoftwareParams = {
@@ -95,7 +113,10 @@ const SoftwareTitleDetailsTable = ({
   );
 
   const renderVersionsCount = () => (
-    <TableCount name="versions" count={data?.length} />
+    <>
+      <TableCount name="versions" count={data?.length} />
+      {countsUpdatedAt && SoftwareLastUpdatedInfo(countsUpdatedAt)}
+    </>
   );
 
   return (

--- a/frontend/pages/hosts/details/cards/Software/InstallStatusCell/InstallStatusCell.tsx
+++ b/frontend/pages/hosts/details/cards/Software/InstallStatusCell/InstallStatusCell.tsx
@@ -4,7 +4,6 @@ import ReactTooltip from "react-tooltip";
 import { uniqueId } from "lodash";
 
 import { IHostSoftware, SoftwareInstallStatus } from "interfaces/software";
-import { dateAgo } from "utilities/date_format";
 
 import Icon from "components/Icon";
 import TextCell from "components/TableContainer/DataTable/TextCell";
@@ -14,7 +13,6 @@ const baseClass = "install-status-cell";
 type IStatusValue = SoftwareInstallStatus | "avaiableForInstall";
 interface TootipArgs {
   softwareName?: string | null;
-  lastInstalledAt?: string;
   isAppStoreApp?: boolean;
 }
 
@@ -36,26 +34,23 @@ export const INSTALL_STATUS_DISPLAY_OPTIONS: Record<
   installed: {
     iconName: "success",
     displayText: "Installed",
-    tooltip: ({ lastInstalledAt: lastInstall }) => (
-      <>
-        Fleet installed software on this host ({dateAgo(lastInstall as string)}
-        ). Currently, if the software is uninstalled, the &quot;Installed&quot;
-        status won&apos;t be updated.
-      </>
-    ),
+    tooltip: () =>
+      "Software is installed (install script finished with exit code 0).",
   },
   pending: {
     iconName: "pending-outline",
     displayText: "Pending",
-    tooltip: () => "Fleet will install software when the host comes online.",
+    tooltip: () =>
+      "Fleet is installing or will install when the host comes online.",
   },
   failed: {
     iconName: "error",
     displayText: "Failed",
-    tooltip: ({ lastInstalledAt: lastInstall }) => (
+    tooltip: () => (
       <>
-        Fleet failed to install software ({dateAgo(lastInstall as string)} ago).
-        Select <b>Actions &gt; Software details</b> to see more.
+        The host failed to install software. To view errors, select
+        <br />
+        <b>Actions &gt; Show details</b>.
       </>
     ),
   },
@@ -96,10 +91,6 @@ const InstallStatusCell = ({
   app_store_app,
 }: IInstallStatusCellProps) => {
   // FIXME: Improve the way we handle polymophism of software_package and app_store_app
-  const lastInstalledAt =
-    software_package?.last_install?.installed_at ||
-    app_store_app?.last_install?.installed_at ||
-    "";
   const hasPackage = !!software_package;
   const hasAppStoreApp = !!app_store_app;
 
@@ -140,7 +131,6 @@ const InstallStatusCell = ({
         <span className={`${baseClass}__status-tooltip-text`}>
           {displayConfig.tooltip({
             softwareName,
-            lastInstalledAt,
             isAppStoreApp: hasAppStoreApp,
           })}
         </span>

--- a/frontend/pages/hosts/details/cards/Software/InstallStatusCell/InstallStatusCell.tsx
+++ b/frontend/pages/hosts/details/cards/Software/InstallStatusCell/InstallStatusCell.tsx
@@ -13,6 +13,8 @@ const baseClass = "install-status-cell";
 type IStatusValue = SoftwareInstallStatus | "avaiableForInstall";
 interface TootipArgs {
   softwareName?: string | null;
+  // this field is used in My device > Self-service
+  lastInstalledAt?: string;
   isAppStoreApp?: boolean;
 }
 

--- a/frontend/pages/hosts/details/cards/Software/SelfService/SelfService.tests.tsx
+++ b/frontend/pages/hosts/details/cards/Software/SelfService/SelfService.tests.tsx
@@ -166,7 +166,7 @@ describe("SelfService", () => {
     ).toHaveTextContent("Install");
   });
 
-  it("renders no action button with 'Install in progress...' status", async () => {
+  it("renders no action button with 'Pending' status", async () => {
     mockServer.use(
       customDeviceSoftwareHandler({
         software: [
@@ -186,7 +186,7 @@ describe("SelfService", () => {
 
     expect(
       screen.getByTestId("self-service-item__status--test")
-    ).toHaveTextContent("Install in progress...");
+    ).toHaveTextContent("Pending");
 
     expect(
       screen.queryByTestId("self-service-item__item-action-button--test")

--- a/frontend/pages/hosts/details/cards/Software/SelfService/SelfServiceItem/SelfServiceItem.tsx
+++ b/frontend/pages/hosts/details/cards/Software/SelfService/SelfServiceItem/SelfServiceItem.tsx
@@ -139,7 +139,6 @@ const getInstallButtonText = (status: SoftwareInstallStatus | null) => {
     case "installed":
       return "Reinstall";
     default:
-      // we don't show a button for pending installs
       return "";
   }
 };
@@ -160,10 +159,7 @@ const InstallerStatusAction = ({
     SoftwareInstallStatus | undefined
   >(undefined);
 
-  // displayStatus allows us to display the localStatus (if any) or the status from the list
-  // software reponse
-  const displayStatus = localStatus || status;
-  const installButtonText = getInstallButtonText(displayStatus);
+  const installButtonText = getInstallButtonText(status);
 
   // if the localStatus is "failed", we don't want our tooltip to include the old installed_at date so we
   // set this to null, which tells the tooltip to omit the parenthetical date
@@ -195,21 +191,16 @@ const InstallerStatusAction = ({
   return (
     <div className={`${baseClass}__item-status-action`}>
       <div className={`${baseClass}__item-status`}>
-        <InstallerStatus
-          id={id}
-          status={displayStatus}
-          last_install={lastInstall}
-        />
+        <InstallerStatus id={id} status={status} last_install={lastInstall} />
       </div>
       <div className={`${baseClass}__item-action`}>
         {!!installButtonText && (
           <Button
             variant="text-icon"
             type="button"
-            className={`${baseClass}__item-action-button${
-              localStatus === "pending" ? "--installing" : ""
-            }`}
+            className={`${baseClass}__item-action-button`}
             onClick={onClick}
+            disabled={localStatus === "pending"}
           >
             <span data-testid={`${baseClass}__item-action-button--test`}>
               {installButtonText}

--- a/frontend/pages/hosts/details/cards/Software/SelfService/SelfServiceItem/SelfServiceItem.tsx
+++ b/frontend/pages/hosts/details/cards/Software/SelfService/SelfServiceItem/SelfServiceItem.tsx
@@ -25,25 +25,20 @@ const STATUS_CONFIG: Record<SoftwareInstallStatus, IStatusDisplayConfig> = {
   installed: {
     iconName: "success",
     displayText: "Installed",
-    tooltip: ({ lastInstalledAt }) => (
-      <>
-        Software installed successfully ({dateAgo(lastInstalledAt as string)}).
-        Currently, if the software is uninstalled, the &quot;Installed&quot;
-        status won&apos;t be updated.
-      </>
-    ),
+    tooltip: ({ lastInstalledAt }) =>
+      `Software is installed (${dateAgo(lastInstalledAt as string)}).`,
   },
   pending: {
     iconName: "pending-outline",
-    displayText: "Install in progress...",
-    tooltip: () => "Software installation in progress...",
+    displayText: "Pending",
+    tooltip: () => "Fleet is installing software.",
   },
   failed: {
     iconName: "error",
     displayText: "Failed",
     tooltip: ({ lastInstalledAt = "" }) => (
       <>
-        Software failed to install
+        Software failed to install{" "}
         {lastInstalledAt ? ` (${dateAgo(lastInstalledAt)})` : ""}. Select{" "}
         <b>Retry</b> to install again, or contact your IT department.
       </>

--- a/frontend/pages/hosts/details/cards/Software/SelfService/SelfServiceItem/_styles.scss
+++ b/frontend/pages/hosts/details/cards/Software/SelfService/SelfServiceItem/_styles.scss
@@ -87,9 +87,5 @@
 
   &__item-action-button {
     height: auto;
-
-    &--installing {
-      display: none;
-    }
   }
 }


### PR DESCRIPTION
## #21444  
- See issue for full enumeration of work done / to check for QA

- Software title details:
![title-details-new](https://github.com/user-attachments/assets/c4b87fe2-0bed-4651-8952-a517c745fd53)
![Screenshot 2024-09-03 at 12 43 04 PM](https://github.com/user-attachments/assets/0324db82-6571-433e-b3ac-d16b3fd9ae1c)
_See [conversation re "updated at" text](https://fleetdm.slack.com/archives/C01EZVBHFHU/p1725018679363979?thread_ts=1723150212.158479&cid=C01EZVBHFHU) - tl;dr, it will be there once the field is added to the API_

- Host software:
![host-sw](https://github.com/user-attachments/assets/1ea5f488-fb69-4f00-9c38-9c46989ef9ab)

- DUP self-service - new behavior:
![ezgif-6-458a04e431](https://github.com/user-attachments/assets/45ed6232-fc5a-49bd-8e92-5fb0b1beb855)



- [x] Added/updated tests
- [x] Manual QA for all new/changed functionality