### PR TITLE
For R.C. - Unreleased bug: Clear all pre-selected vuln filters when vulnerable filter is toggled off #21821

### DIFF
--- a/frontend/pages/SoftwarePage/SoftwarePage.tsx
+++ b/frontend/pages/SoftwarePage/SoftwarePage.tsx
@@ -36,9 +36,10 @@ import ManageAutomationsModal from "./components/ManageSoftwareAutomationsModal"
 import AddSoftwareModal from "./components/AddSoftwareModal";
 import {
   buildSoftwareFilterQueryParams,
+  buildSoftwareVulnFiltersQueryParams,
   getSoftwareFilterFromQueryParams,
   getSoftwareVulnFiltersFromQueryParams,
-  ISoftwareVulnFilters,
+  ISoftwareVulnFiltersParams,
 } from "./SoftwareTitles/SoftwareTable/helpers";
 import SoftwareFiltersModal from "./components/SoftwareFiltersModal";
 
@@ -308,7 +309,7 @@ const SoftwarePage = ({ children, router, location }: ISoftwarePageProps) => {
     [handleTeamChange]
   );
 
-  const onApplyVulnFilters = (vulnFilters: ISoftwareVulnFilters) => {
+  const onApplyVulnFilters = (vulnFilters: ISoftwareVulnFiltersParams) => {
     const newQueryParams: ISoftwareApiParams = {
       query,
       teamId: currentTeamId,
@@ -316,7 +317,7 @@ const SoftwarePage = ({ children, router, location }: ISoftwarePageProps) => {
       orderKey: sortHeader,
       page: 0, // resets page index
       ...buildSoftwareFilterQueryParams(softwareFilter),
-      ...vulnFilters,
+      ...buildSoftwareVulnFiltersQueryParams(vulnFilters),
     };
 
     router.replace(

--- a/frontend/pages/SoftwarePage/SoftwareTitles/SoftwareTable/helpers.tests.ts
+++ b/frontend/pages/SoftwarePage/SoftwareTitles/SoftwareTable/helpers.tests.ts
@@ -1,0 +1,49 @@
+import { isValidNumber } from "./helpers";
+
+describe("isValidNumber", () => {
+  // Test valid numbers
+  it("returns true for valid numbers", () => {
+    expect(isValidNumber(0)).toBe(true);
+    expect(isValidNumber(42)).toBe(true);
+    expect(isValidNumber(-10)).toBe(true);
+    expect(isValidNumber(3.14)).toBe(true);
+  });
+
+  // Test invalid inputs
+  it("returns false for non-number inputs", () => {
+    expect(isValidNumber("42")).toBe(false);
+    expect(isValidNumber(null)).toBe(false);
+    expect(isValidNumber(undefined)).toBe(false);
+    expect(isValidNumber({})).toBe(false);
+    expect(isValidNumber([])).toBe(false);
+    expect(isValidNumber(true)).toBe(false);
+  });
+
+  // Test NaN
+  it("returns false for NaN", () => {
+    expect(isValidNumber(NaN)).toBe(false);
+  });
+
+  // Test with min value
+  it("respects min value when provided", () => {
+    expect(isValidNumber(5, 0)).toBe(true);
+    expect(isValidNumber(5, 5)).toBe(true);
+    expect(isValidNumber(5, 6)).toBe(false);
+  });
+
+  // Test with max value
+  it("respects max value when provided", () => {
+    expect(isValidNumber(5, undefined, 10)).toBe(true);
+    expect(isValidNumber(5, undefined, 5)).toBe(true);
+    expect(isValidNumber(5, undefined, 4)).toBe(false);
+  });
+
+  // Test with both min and max values
+  it("respects both min and max values when provided", () => {
+    expect(isValidNumber(5, 0, 10)).toBe(true);
+    expect(isValidNumber(0, 0, 10)).toBe(true);
+    expect(isValidNumber(10, 0, 10)).toBe(true);
+    expect(isValidNumber(-1, 0, 10)).toBe(false);
+    expect(isValidNumber(11, 0, 10)).toBe(false);
+  });
+});

--- a/frontend/pages/SoftwarePage/SoftwareTitles/SoftwareTable/helpers.ts
+++ b/frontend/pages/SoftwarePage/SoftwareTitles/SoftwareTable/helpers.ts
@@ -127,7 +127,7 @@ export type ISoftwareVulnFiltersParams = {
   maxCvssScore?: number;
 };
 
-const isValidNumber = (
+export const isValidNumber = (
   value: any,
   min?: number,
   max?: number

--- a/frontend/pages/SoftwarePage/components/SoftwareFiltersModal/SoftwareFiltersModal.tsx
+++ b/frontend/pages/SoftwarePage/components/SoftwareFiltersModal/SoftwareFiltersModal.tsx
@@ -18,7 +18,7 @@ const baseClass = "software-filters-modal";
 
 interface ISoftwareFiltersModalProps {
   onExit: () => void;
-  onSubmit: (vulnFilters: ISoftwareVulnFilters) => void;
+  onSubmit: (vulnFilters: ISoftwareVulnFiltersParams) => void;
   vulnFilters: ISoftwareVulnFiltersParams;
   isPremiumTier: boolean;
 }
@@ -53,8 +53,8 @@ const SoftwareFiltersModal = ({
     onSubmit({
       vulnerable: vulnSoftwareFilterEnabled,
       exploit: hasKnownExploit || undefined,
-      min_cvss_score: severity?.minSeverity || undefined,
-      max_cvss_score: severity?.maxSeverity || undefined,
+      minCvssScore: severity?.minSeverity || undefined,
+      maxCvssScore: severity?.maxSeverity || undefined,
     });
   };
 


### PR DESCRIPTION
Last minute unreleased bug fix for R.C.

> [!NOTE]
> This PR is already merged in `main`, see https://github.com/fleetdm/fleet/pull/21821  This is against the release branch so it can be included in 4.56.0 

```
 1260  git checkout fleetdm/minor-fleet-v4.56.0
 1261  git log main
 1262  git cherry-pick a4fb3f45a181a3169fbca44d683a76191a40c74d
 1263  git checkout -b clear-vuln-filters-rc
 1264  git push -u fleetdm clear-vuln-filters-rc
```