### PR TITLE
set fix widths on os settings table so we can consistantly show data

### DIFF
--- a/changes/7476-fix-ui-overflow-os-settings-table
+++ b/changes/7476-fix-ui-overflow-os-settings-table
@@ -1,0 +1,1 @@
+- fixes UI overflow issues with OS settings table data

--- a/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
@@ -53,7 +53,7 @@ import {
   HOST_OSQUERY_DATA,
 } from "utilities/constants";
 
-import { isIPadOrIPhone, Platform } from "interfaces/platform";
+import { isIPadOrIPhone } from "interfaces/platform";
 
 import Spinner from "components/Spinner";
 import TabsWrapper from "components/TabsWrapper";
@@ -103,6 +103,7 @@ import {
 import WipeModal from "./modals/WipeModal";
 import SoftwareDetailsModal from "../cards/Software/SoftwareDetailsModal";
 import { parseHostSoftwareQueryParams } from "../cards/Software/HostSoftware";
+import { createMockHostMdmProfile } from "__mocks__/hostMock";
 
 const baseClass = "host-details";
 
@@ -479,7 +480,7 @@ const HostDetailsPage = ({
       case "ios":
         return mdmConfig?.ios_updates;
       default:
-        null;
+        return undefined;
     }
   };
 

--- a/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
@@ -103,7 +103,6 @@ import {
 import WipeModal from "./modals/WipeModal";
 import SoftwareDetailsModal from "../cards/Software/SoftwareDetailsModal";
 import { parseHostSoftwareQueryParams } from "../cards/Software/HostSoftware";
-import { createMockHostMdmProfile } from "__mocks__/hostMock";
 
 const baseClass = "host-details";
 

--- a/frontend/pages/hosts/details/OSSettingsModal/OSSettingsModal.tsx
+++ b/frontend/pages/hosts/details/OSSettingsModal/OSSettingsModal.tsx
@@ -43,7 +43,7 @@ const OSSettingsModal = ({
       title="OS settings"
       onExit={onClose}
       className={baseClass}
-      width="large"
+      width="xlarge"
     >
       <>
         <OSSettingsTable

--- a/frontend/pages/hosts/details/OSSettingsModal/OSSettingsTable/OSSettingsErrorCell/_styles.scss
+++ b/frontend/pages/hosts/details/OSSettingsModal/OSSettingsTable/OSSettingsErrorCell/_styles.scss
@@ -15,6 +15,7 @@
   }
 
   &__resend-button {
+    width: 106px;
     display: flex;
 
     .children-wrapper {

--- a/frontend/pages/hosts/details/OSSettingsModal/OSSettingsTable/_styles.scss
+++ b/frontend/pages/hosts/details/OSSettingsModal/OSSettingsTable/_styles.scss
@@ -4,8 +4,15 @@
   // for these cells in the table. Total width of the table cell will be
   // 240px including the padding.
   .data-table-block .data-table tbody td {
-    .os-settings-name-cell, .os-settings-status-cell, .os-settings-error-cell {
-      max-width: 192px;
+    .os-settings-name-cell {
+      width: 135px;
+      max-width: none;
+    }
+    .os-settings-status-cell {
+      width: 200px;
+    }
+    .os-settings-error-cell {
+      width: 237px;
     }
   }
 

--- a/frontend/pages/hosts/details/cards/HostSummary/HostSummary.tsx
+++ b/frontend/pages/hosts/details/cards/HostSummary/HostSummary.tsx
@@ -441,6 +441,7 @@ const HostSummary = ({
   };
 
   const renderSummary = () => {
+    console.log(hostMdmProfiles);
     // for windows hosts we have to manually add a profile for disk encryption
     // as this is not currently included in the `profiles` value from the API
     // response for windows hosts.


### PR DESCRIPTION
relates to #7476, #21632

we add fix widths to the columns of the OS Settings modal table so that we can correctly show the information without UI overflow issues.

**before**

![image](https://github.com/user-attachments/assets/fb4f60c1-a70f-4c4f-a194-2143f98e6ec1)


**after**

![image](https://github.com/user-attachments/assets/2b88619f-f1b6-4c84-ab6e-bace5b584c36)


- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
- [x] Manual QA for all new/changed functionality
