### PR TITLE
Website: fix broken link to enroll hosts page in teams guide.

### DIFF
--- a/articles/teams.md
+++ b/articles/teams.md
@@ -30,7 +30,7 @@ You can add hosts to a new team in Fleet by either enrolling the host with a tea
 
 ## Advanced
 
-You can automatically enroll hosts to a specific team in Fleet by installing a fleetd with a team enroll secret. Learn more [here](./enroll-hosts.md#enroll-host-to-a-specific-team).
+You can automatically enroll hosts to a specific team in Fleet by installing a fleetd with a team enroll secret. Learn more [here](https://fleetdm.com/guides/enroll-hosts#enroll-host-to-a-specific-team).
 
 Changing the host's enroll secret after enrollment will not cause the host to be transferred to a different team.
 


### PR DESCRIPTION
Closes: https://github.com/fleetdm/confidential/issues/7902

Changes:
- fixed a broken link going to the enroll hosts guide.