### PR TITLE
Redirect: Show automatic enrollment (DEP) profile validation errors

### DIFF
--- a/website/config/routes.js
+++ b/website/config/routes.js
@@ -559,6 +559,7 @@ module.exports.routes = {
   'GET /learn-more-about/host-identifiers': '/docs/rest-api/rest-api#get-host-by-identifier',
   'GET /learn-more-about/uninstall-fleetd': '/docs/using-fleet/faq#how-can-i-uninstall-fleetd',
   'GET /learn-more-about/vulnerability-processing': '/docs/using-fleet/vulnerability-processing',
+  'GET /learn-more-about/dep-profile': 'https://developer.apple.com/documentation/devicemanagement/define_a_profile',
 
   // Sitemap
   // =============================================================================================================


### PR DESCRIPTION
- @noahtalerman: I closed this PR and opened a new one [here](https://github.com/fleetdm/fleet/pull/22309) (w/ same changes) against the docs-v4.57.0 branch.

As of 4.57.0, each minor release has it's own reference docs branch as part of a new process to make sure that every change to how Fleet is used is reflected live on the website in reference documentation at release day: https://github.com/fleetdm/fleet/pull/22284/files#diff-d426c2ae6cac2a2baffd54adae00ad7bb936dbb17a873f93a327d5763f7fb574R141

---

Related to: #17558
