### PR TITLE
change add software modal to seperate pages in Fleet UI

### DIFF
--- a/changes/218090-add-sofware-from-modal-to-pages
+++ b/changes/218090-add-sofware-from-modal-to-pages
@@ -1,0 +1,1 @@
+- change add software modal to be seperate pages in Fleet UI

--- a/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareAddPage.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareAddPage.tsx
@@ -44,7 +44,7 @@ const getTabIndex = (path: string): number => {
   });
 };
 
-interface IQueryParams {
+export interface ISoftwareAddPageQueryParams {
   team_id?: string;
   query?: string;
   page?: string;
@@ -53,8 +53,8 @@ interface IQueryParams {
 }
 
 interface ISoftwareAddPageProps {
-  children: React.ReactNode;
-  location: Location<IQueryParams>;
+  children: JSX.Element;
+  location: Location<ISoftwareAddPageQueryParams>;
   router: InjectedRouter;
 }
 
@@ -63,8 +63,6 @@ const SoftwareAddPage = ({
   location,
   router,
 }: ISoftwareAddPageProps) => {
-  console.log(location);
-
   const navigateToNav = useCallback(
     (i: number): void => {
       // Only query param to persist between tabs is team id
@@ -103,7 +101,10 @@ const SoftwareAddPage = ({
             </TabList>
           </Tabs>
         </TabsWrapper>
-        <>{children}</>
+        {React.cloneElement(children, {
+          router,
+          teamId: location.query.team_id,
+        })}
       </>
     </MainContent>
   );

--- a/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareAddPage.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareAddPage.tsx
@@ -1,17 +1,111 @@
-import React from "react";
+import React, { useCallback } from "react";
+import { Tab, TabList, Tabs } from "react-tabs";
+import { InjectedRouter } from "react-router";
+import { Location } from "history";
+
+import PATHS from "router/paths";
+import { buildQueryStringFromParams } from "utilities/url";
+
+import MainContent from "components/MainContent";
+import BackLink from "components/BackLink";
+import TabsWrapper from "components/TabsWrapper";
 
 const baseClass = "software-add-page";
 
-interface ISoftwareAddPageProps {
-  children: React.ReactNode;
+interface IAddSoftwareSubNavItem {
+  name: string;
+  pathname: string;
 }
 
-const SoftwareAddPage = ({ children }: ISoftwareAddPageProps) => {
+const addSoftwareSubNav: IAddSoftwareSubNavItem[] = [
+  {
+    name: "Fleet-maintained",
+    pathname: PATHS.SOFTWARE_ADD_FLEET_MAINTAINED,
+  },
+  {
+    name: "Package",
+    pathname: PATHS.SOFTWARE_ADD_PACKAGE,
+  },
+  {
+    name: "App store (VPP)",
+    pathname: PATHS.SOFTWARE_ADD_APP_STORE,
+  },
+];
+
+const getTabIndex = (path: string): number => {
+  return addSoftwareSubNav.findIndex((navItem) => {
+    // This check ensures that for software versions path we still
+    // highlight the software tab.
+    if (navItem.name === "Software" && PATHS.SOFTWARE_VERSIONS === path) {
+      return true;
+    }
+    // tab stays highlighted for paths that start with same pathname
+    return path.startsWith(navItem.pathname);
+  });
+};
+
+interface IQueryParams {
+  team_id?: string;
+  query?: string;
+  page?: string;
+  order_key?: string;
+  order_direction?: "asc" | "desc";
+}
+
+interface ISoftwareAddPageProps {
+  children: React.ReactNode;
+  location: Location<IQueryParams>;
+  router: InjectedRouter;
+}
+
+const SoftwareAddPage = ({
+  children,
+  location,
+  router,
+}: ISoftwareAddPageProps) => {
+  console.log(location);
+
+  const navigateToNav = useCallback(
+    (i: number): void => {
+      // Only query param to persist between tabs is team id
+      const teamIdParam = buildQueryStringFromParams({
+        team_id: location?.query.team_id,
+      });
+
+      const navPath = addSoftwareSubNav[i].pathname.concat(`?${teamIdParam}`);
+      router.replace(navPath);
+    },
+    [location, router]
+  );
+
   return (
-    <div className={baseClass}>
-      Software Add Page
-      {children}
-    </div>
+    <MainContent className={baseClass}>
+      <>
+        <BackLink
+          text="Back to software"
+          path={PATHS.SOFTWARE_TITLES}
+          className={`${baseClass}__back-to-software`}
+        />
+        <h1>Add Software</h1>
+        <TabsWrapper>
+          <Tabs
+            selectedIndex={getTabIndex(location?.pathname || "")}
+            onSelect={navigateToNav}
+          >
+            <TabList>
+              {addSoftwareSubNav.map((navItem) => {
+                return (
+                  <Tab key={navItem.name} data-text={navItem.name}>
+                    {navItem.name}
+                  </Tab>
+                );
+              })}
+            </TabList>
+          </Tabs>
+        </TabsWrapper>
+        <>{children}</>
+      </>
+    </MainContent>
   );
 };
 

--- a/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareAddPage.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareAddPage.tsx
@@ -34,11 +34,6 @@ const addSoftwareSubNav: IAddSoftwareSubNavItem[] = [
 
 const getTabIndex = (path: string): number => {
   return addSoftwareSubNav.findIndex((navItem) => {
-    // This check ensures that for software versions path we still
-    // highlight the software tab.
-    if (navItem.name === "Software" && PATHS.SOFTWARE_VERSIONS === path) {
-      return true;
-    }
     // tab stays highlighted for paths that start with same pathname
     return path.startsWith(navItem.pathname);
   });

--- a/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareAddPage.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareAddPage.tsx
@@ -1,0 +1,18 @@
+import React from "react";
+
+const baseClass = "software-add-page";
+
+interface ISoftwareAddPageProps {
+  children: React.ReactNode;
+}
+
+const SoftwareAddPage = ({ children }: ISoftwareAddPageProps) => {
+  return (
+    <div className={baseClass}>
+      Software Add Page
+      {children}
+    </div>
+  );
+};
+
+export default SoftwareAddPage;

--- a/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareAppStore/SoftwareAppStore.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareAppStore/SoftwareAppStore.tsx
@@ -1,0 +1,11 @@
+import React from "react";
+
+const baseClass = "software-app-store";
+
+interface ISoftwareAppStoreProps {}
+
+const SoftwareAppStore = ({}: ISoftwareAppStoreProps) => {
+  return <div className={baseClass}>Software App store page</div>;
+};
+
+export default SoftwareAppStore;

--- a/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareAppStore/SoftwareAppStore.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareAppStore/SoftwareAppStore.tsx
@@ -1,10 +1,22 @@
 import React from "react";
+import { InjectedRouter } from "react-router";
+import { Location } from "history";
+
+import { ISoftwareAddPageQueryParams } from "../SoftwareAddPage";
 
 const baseClass = "software-app-store";
 
-interface ISoftwareAppStoreProps {}
+interface ISoftwareAppStoreProps {
+  currentTeamId: number;
+  router: InjectedRouter;
+  location: Location<ISoftwareAddPageQueryParams>;
+}
 
-const SoftwareAppStore = ({}: ISoftwareAppStoreProps) => {
+const SoftwareAppStore = ({
+  currentTeamId,
+  router,
+  location,
+}: ISoftwareAppStoreProps) => {
   return <div className={baseClass}>Software App store page</div>;
 };
 

--- a/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareAppStore/_styles.scss
+++ b/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareAppStore/_styles.scss
@@ -1,0 +1,3 @@
+.software-app-store {
+
+}

--- a/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareAppStore/index.ts
+++ b/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareAppStore/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./SoftwareAppStore";

--- a/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareFleetMaintained/SoftwareFleetMaintained.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareFleetMaintained/SoftwareFleetMaintained.tsx
@@ -1,11 +1,39 @@
 import React from "react";
+import { InjectedRouter } from "react-router";
+import { Location } from "history";
+
+import { DEFAULT_QUERY } from "utilities/constants";
+
+import { ISoftwareAddPageQueryParams } from "../SoftwareAddPage";
 
 const baseClass = "software-fleet-maintained";
 
-interface ISoftwareFleetMaintainedProps {}
+interface ISoftwareFleetMaintainedProps {
+  currentTeamId: number;
+  router: InjectedRouter;
+  location: Location<ISoftwareAddPageQueryParams>;
+}
 
-const SoftwareFleetMaintained = ({}: ISoftwareFleetMaintainedProps) => {
-  return <div className={baseClass}>Maintianed Page</div>;
+// default values for query params used on this page if not provided
+const DEFAULT_SORT_DIRECTION = "desc";
+const DEFAULT_SORT_HEADER = "hosts_count";
+const DEFAULT_PAGE_SIZE = 20;
+const DEFAULT_PAGE = 0;
+
+const SoftwareFleetMaintained = ({
+  currentTeamId,
+  router,
+  location,
+}: ISoftwareFleetMaintainedProps) => {
+  const {
+    order_key = DEFAULT_SORT_HEADER,
+    order_direction = DEFAULT_SORT_DIRECTION,
+    query = DEFAULT_QUERY,
+    page,
+  } = location.query;
+  const currentPage = page ? parseInt(page, 10) : DEFAULT_PAGE;
+
+  return <div className={baseClass}>Maintained Page</div>;
 };
 
 export default SoftwareFleetMaintained;

--- a/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareFleetMaintained/SoftwareFleetMaintained.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareFleetMaintained/SoftwareFleetMaintained.tsx
@@ -1,0 +1,11 @@
+import React from "react";
+
+const baseClass = "software-fleet-maintained";
+
+interface ISoftwareFleetMaintainedProps {}
+
+const SoftwareFleetMaintained = ({}: ISoftwareFleetMaintainedProps) => {
+  return <div className={baseClass}>Maintianed Page</div>;
+};
+
+export default SoftwareFleetMaintained;

--- a/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareFleetMaintained/_styles.scss
+++ b/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareFleetMaintained/_styles.scss
@@ -1,0 +1,3 @@
+.software-fleet-maintained {
+
+}

--- a/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareFleetMaintained/index.ts
+++ b/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareFleetMaintained/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./SoftwareFleetMaintained";

--- a/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwarePackage/SoftwarePackage.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwarePackage/SoftwarePackage.tsx
@@ -1,0 +1,11 @@
+import React from "react";
+
+const baseClass = "software-package";
+
+interface ISoftwarePackageProps {}
+
+const SoftwarePackage = ({}: ISoftwarePackageProps) => {
+  return <div className={baseClass}>Sofware package page</div>;
+};
+
+export default SoftwarePackage;

--- a/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwarePackage/SoftwarePackage.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwarePackage/SoftwarePackage.tsx
@@ -1,10 +1,22 @@
 import React from "react";
+import { InjectedRouter } from "react-router";
+import { Location } from "history";
+
+import { ISoftwareAddPageQueryParams } from "../SoftwareAddPage";
 
 const baseClass = "software-package";
 
-interface ISoftwarePackageProps {}
+interface ISoftwarePackageProps {
+  currentTeamId: number;
+  router: InjectedRouter;
+  location: Location<ISoftwareAddPageQueryParams>;
+}
 
-const SoftwarePackage = ({}: ISoftwarePackageProps) => {
+const SoftwarePackage = ({
+  currentTeamId,
+  router,
+  location,
+}: ISoftwarePackageProps) => {
   return <div className={baseClass}>Sofware package page</div>;
 };
 

--- a/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwarePackage/_styles.scss
+++ b/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwarePackage/_styles.scss
@@ -1,0 +1,3 @@
+.software-package {
+
+}

--- a/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwarePackage/index.ts
+++ b/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwarePackage/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./SoftwarePackage";

--- a/frontend/pages/SoftwarePage/SoftwareAddPage/_styles.scss
+++ b/frontend/pages/SoftwarePage/SoftwareAddPage/_styles.scss
@@ -1,3 +1,10 @@
 .software-add-page {
 
+  &__back-to-software {
+    margin-bottom: $pad-medium;
+  }
+
+  h1 {
+    margin-bottom: $pad-large;
+  }
 }

--- a/frontend/pages/SoftwarePage/SoftwareAddPage/_styles.scss
+++ b/frontend/pages/SoftwarePage/SoftwareAddPage/_styles.scss
@@ -1,0 +1,3 @@
+.software-add-page {
+
+}

--- a/frontend/pages/SoftwarePage/SoftwareAddPage/index.ts
+++ b/frontend/pages/SoftwarePage/SoftwareAddPage/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./SoftwareAddPage";

--- a/frontend/pages/SoftwarePage/SoftwarePage.tsx
+++ b/frontend/pages/SoftwarePage/SoftwarePage.tsx
@@ -13,7 +13,7 @@ import {
   IZendeskIntegration,
   IZendeskJiraIntegrations,
 } from "interfaces/integration";
-import { ITeamConfig } from "interfaces/team";
+import { APP_CONTEXT_ALL_TEAMS_ID, ITeamConfig } from "interfaces/team";
 import { IWebhookSoftwareVulnerabilities } from "interfaces/webhook";
 import configAPI from "services/entities/config";
 import teamsAPI, { ILoadTeamResponse } from "services/entities/teams";
@@ -255,9 +255,15 @@ const SoftwarePage = ({ children, router, location }: ISoftwarePageProps) => {
     setShowManageAutomationsModal(!showManageAutomationsModal);
   }, [setShowManageAutomationsModal, showManageAutomationsModal]);
 
-  const toggleAddSoftwareModal = useCallback(() => {
-    setShowAddSoftwareModal(!showAddSoftwareModal);
-  }, [showAddSoftwareModal]);
+  const onAddSoftware = useCallback(() => {
+    if (currentTeamId === APP_CONTEXT_ALL_TEAMS_ID) {
+      setShowAddSoftwareModal(true);
+    } else {
+      router.push(
+        `${PATHS.SOFTWARE_ADD_FLEET_MAINTAINED}?team_id=${currentTeamId}`
+      );
+    }
+  }, [currentTeamId, router]);
 
   const togglePreviewPayloadModal = useCallback(() => {
     setShowPreviewPayloadModal(!showPreviewPayloadModal);
@@ -383,7 +389,7 @@ const SoftwarePage = ({ children, router, location }: ISoftwarePageProps) => {
           </Button>
         )}
         {canAddSoftware && (
-          <Button onClick={toggleAddSoftwareModal} variant="brand">
+          <Button onClick={onAddSoftware} variant="brand">
             <span>Add software</span>
           </Button>
         )}
@@ -475,7 +481,7 @@ const SoftwarePage = ({ children, router, location }: ISoftwarePageProps) => {
           <AddSoftwareModal
             teamId={currentTeamId ?? 0}
             router={router}
-            onExit={toggleAddSoftwareModal}
+            onExit={() => setShowAddSoftwareModal(false)}
             setAddedSoftwareToken={setAddedSoftwareToken}
             isFreeTier={isFreeTier}
           />

--- a/frontend/pages/SoftwarePage/SoftwarePage.tsx
+++ b/frontend/pages/SoftwarePage/SoftwarePage.tsx
@@ -255,16 +255,6 @@ const SoftwarePage = ({ children, router, location }: ISoftwarePageProps) => {
     setShowManageAutomationsModal(!showManageAutomationsModal);
   }, [setShowManageAutomationsModal, showManageAutomationsModal]);
 
-  const onAddSoftware = useCallback(() => {
-    if (currentTeamId === APP_CONTEXT_ALL_TEAMS_ID) {
-      setShowAddSoftwareModal(true);
-    } else {
-      router.push(
-        `${PATHS.SOFTWARE_ADD_FLEET_MAINTAINED}?team_id=${currentTeamId}`
-      );
-    }
-  }, [currentTeamId, router]);
-
   const togglePreviewPayloadModal = useCallback(() => {
     setShowPreviewPayloadModal(!showPreviewPayloadModal);
   }, [setShowPreviewPayloadModal, showPreviewPayloadModal]);
@@ -299,6 +289,16 @@ const SoftwarePage = ({ children, router, location }: ISoftwarePageProps) => {
       toggleManageAutomationsModal();
     }
   };
+
+  const onAddSoftware = useCallback(() => {
+    if (currentTeamId === APP_CONTEXT_ALL_TEAMS_ID) {
+      setShowAddSoftwareModal(true);
+    } else {
+      router.push(
+        `${PATHS.SOFTWARE_ADD_FLEET_MAINTAINED}?team_id=${currentTeamId}`
+      );
+    }
+  }, [currentTeamId, router]);
 
   // NOTE: used to reset page number to 0 when modifying filters
   // NOTE: Solution reused from ManageHostPage.tsx
@@ -479,10 +479,7 @@ const SoftwarePage = ({ children, router, location }: ISoftwarePageProps) => {
         )}
         {showAddSoftwareModal && (
           <AddSoftwareModal
-            teamId={currentTeamId ?? 0}
-            router={router}
             onExit={() => setShowAddSoftwareModal(false)}
-            setAddedSoftwareToken={setAddedSoftwareToken}
             isFreeTier={isFreeTier}
           />
         )}

--- a/frontend/pages/SoftwarePage/components/AddSoftwareModal/AddSoftwareModal.tsx
+++ b/frontend/pages/SoftwarePage/components/AddSoftwareModal/AddSoftwareModal.tsx
@@ -1,16 +1,8 @@
 import React from "react";
-import { InjectedRouter } from "react-router";
-import { Tab, TabList, TabPanel, Tabs } from "react-tabs";
-
-import { APP_CONTEXT_ALL_TEAMS_ID } from "interfaces/team";
 
 import Modal from "components/Modal";
 import Button from "components/buttons/Button";
-import TabsWrapper from "components/TabsWrapper";
 import PremiumFeatureMessage from "components/PremiumFeatureMessage";
-
-import AppStoreVpp from "../AppStoreVpp";
-import AddPackage from "../AddPackage";
 
 const baseClass = "add-software-modal";
 
@@ -35,20 +27,11 @@ const AllTeamsMessage = ({ onExit }: IAllTeamsMessageProps) => {
 };
 
 interface IAddSoftwareModalProps {
-  teamId: number;
-  router: InjectedRouter;
   onExit: () => void;
-  setAddedSoftwareToken: (token: string) => void;
   isFreeTier?: boolean;
 }
 
-const AddSoftwareModal = ({
-  teamId,
-  router,
-  onExit,
-  setAddedSoftwareToken,
-  isFreeTier,
-}: IAddSoftwareModalProps) => {
+const AddSoftwareModal = ({ onExit, isFreeTier }: IAddSoftwareModalProps) => {
   const renderModalContent = () => {
     if (isFreeTier) {
       return (
@@ -63,45 +46,11 @@ const AddSoftwareModal = ({
       );
     }
 
-    if (teamId === APP_CONTEXT_ALL_TEAMS_ID) {
-      return <AllTeamsMessage onExit={onExit} />;
-    }
-
-    return (
-      <TabsWrapper className={`${baseClass}__tabs`}>
-        <Tabs>
-          <TabList>
-            <Tab>Package</Tab>
-            <Tab>App Store (VPP)</Tab>
-          </TabList>
-          <TabPanel>
-            <AddPackage
-              teamId={teamId}
-              router={router}
-              onExit={onExit}
-              setAddedSoftwareToken={setAddedSoftwareToken}
-            />
-          </TabPanel>
-          <TabPanel>
-            <AppStoreVpp
-              teamId={teamId}
-              router={router}
-              onExit={onExit}
-              setAddedSoftwareToken={setAddedSoftwareToken}
-            />
-          </TabPanel>
-        </Tabs>
-      </TabsWrapper>
-    );
+    return <AllTeamsMessage onExit={onExit} />;
   };
 
   return (
-    <Modal
-      title="Add software"
-      onExit={onExit}
-      width="large"
-      className={baseClass}
-    >
+    <Modal title="Add software" onExit={onExit} className={baseClass}>
       {renderModalContent()}
     </Modal>
   );

--- a/frontend/router/index.tsx
+++ b/frontend/router/index.tsx
@@ -77,6 +77,10 @@ import SoftwareVersionDetailsPage from "pages/SoftwarePage/SoftwareVersionDetail
 import TeamSettings from "pages/admin/TeamManagementPage/TeamDetailsWrapper/TeamSettings";
 import SoftwareOSDetailsPage from "pages/SoftwarePage/SoftwareOSDetailsPage";
 import SoftwareVulnerabilityDetailsPage from "pages/SoftwarePage/SoftwareVulnerabilityDetailsPage";
+import SoftwareAddPage from "pages/SoftwarePage/SoftwareAddPage";
+import SoftwareFleetMaintained from "pages/SoftwarePage/SoftwareAddPage/SoftwareFleetMaintained";
+import SoftwarePackage from "pages/SoftwarePage/SoftwareAddPage/SoftwarePackage";
+import SoftwareAppStore from "pages/SoftwarePage/SoftwareAddPage/SoftwareAppStore";
 
 import PATHS from "router/paths";
 
@@ -271,6 +275,17 @@ const routes = (
           </Route>
           <Route path="software">
             <IndexRedirect to="titles" />
+            {/* we check the add route first otherwise a route like 'software/add' will be caught
+             * by the 'software/:id' redirect and be redirected to 'software/versions/add  */}
+            <Route path="add" component={SoftwareAddPage}>
+              <IndexRedirect to="fleet-maintained" />
+              <Route
+                path="fleet-maintained"
+                component={SoftwareFleetMaintained}
+              />
+              <Route path="package" component={SoftwarePackage} />
+              <Route path="app-store" component={SoftwareAppStore} />
+            </Route>
             <Route component={SoftwarePage}>
               <Route path="titles" component={SoftwareTitles} />
               <Route path="versions" component={SoftwareTitles} />

--- a/frontend/router/paths.ts
+++ b/frontend/router/paths.ts
@@ -75,6 +75,9 @@ export default {
   SOFTWARE_VULNERABILITY_DETAILS: (cve: string): string => {
     return `${URL_PREFIX}/software/vulnerabilities/${cve}`;
   },
+  SOFTWARE_ADD_FLEET_MAINTAINED: `${URL_PREFIX}/software/add-fleet-maintained`,
+  SOFTWARE_ADD_PACKAGE: `${URL_PREFIX}/software/add/package`,
+  SOFTWARE_ADD_APP_STORE: `${URL_PREFIX}/software/add/app-store`,
 
   // Label pages
   LABEL_NEW_DYNAMIC: `${URL_PREFIX}/labels/new/dynamic`,

--- a/frontend/router/paths.ts
+++ b/frontend/router/paths.ts
@@ -75,7 +75,7 @@ export default {
   SOFTWARE_VULNERABILITY_DETAILS: (cve: string): string => {
     return `${URL_PREFIX}/software/vulnerabilities/${cve}`;
   },
-  SOFTWARE_ADD_FLEET_MAINTAINED: `${URL_PREFIX}/software/add-fleet-maintained`,
+  SOFTWARE_ADD_FLEET_MAINTAINED: `${URL_PREFIX}/software/add/fleet-maintained`,
   SOFTWARE_ADD_PACKAGE: `${URL_PREFIX}/software/add/package`,
   SOFTWARE_ADD_APP_STORE: `${URL_PREFIX}/software/add/app-store`,
 


### PR DESCRIPTION
relates to #21809

Change the add software modal to be a separate page with tabs for each type of software upload. This includes the tabs for Fleet-maintained, Package, and App Store (Vpp). We still show the add host modal with the all teams warning if the user is in the All teams context.


**New page with tabbed UI**

![image](https://github.com/user-attachments/assets/11a92e50-a598-466d-a14f-106ae3906130)

> NOTE: there will still be a little work needed to display the Team context on these new pages but that is currently in design review. We will come back and add that in another PR.


- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
- [ ] Added/updated tests
- [x] Manual QA for all new/changed functionality
