### PR TITLE
Website: fix typo in send-aggregated-metrics-to-datadog script

### DIFF
--- a/website/scripts/send-aggregated-metrics-to-datadog.js
+++ b/website/scripts/send-aggregated-metrics-to-datadog.js
@@ -450,7 +450,7 @@ module.exports = {
     });
     // maintenanceWindowsConfigured
     let numberOfInstancesWithMaintenanceWindowsConfigured = _.where(latestStatisticsReportedByReleasedFleetVersions, {maintenanceWindowsEnabled: true}).length;
-    let numberOfInstancesWithoutMaintenanceWindowsConfigured = numberOfInstancesToReport - numberOfInstancesWithMaintenanceWindowsEnabled;
+    let numberOfInstancesWithoutMaintenanceWindowsConfigured = numberOfInstancesToReport - numberOfInstancesWithMaintenanceWindowsConfigured;
     metricsToReport.push({
       metric: 'usage_statistics.maintenance_windows_configured',
       type: 3,


### PR DESCRIPTION
Changes:
- Fixed a typo in the `send-aggregated-metrics-to-datadog` script