### PR TITLE
fix back-end test for UI OTA template

### DIFF
--- a/server/service/frontend_test.go
+++ b/server/service/frontend_test.go
@@ -64,6 +64,5 @@ func TestServeEndUserEnrollOTA(t *testing.T) {
 	bodyBytes, err := io.ReadAll(response.Body)
 	require.NoError(t, err)
 	bodyString := string(bodyBytes)
-	require.Contains(t, bodyString, "Enroll your device to Fleet")
-	require.Contains(t, bodyString, "?enroll_secret=foo")
+	require.Contains(t, bodyString, "api/v1/fleet/enrollment_profiles/ota?enroll_secret=foo")
 }


### PR DESCRIPTION
See https://github.com/fleetdm/fleet/actions/runs/10804752744 for the failure. I changed a UI template in https://github.com/fleetdm/fleet/pull/21957 yesterday that didn't trigger the Go tests.

In this PR I'm just fixing the test failure, I will adjust the worker to trigger a test run when this file is modified in a separate PR to not block this on codeowners.

# Checklist for submitter

- [x] Added/updated tests
