### PR TITLE
improve the migration flow to make it safe to run multiple times

### DIFF
--- a/tools/mdm/migration/micromdm/touchless/README.md
+++ b/tools/mdm/migration/micromdm/touchless/README.md
@@ -1,0 +1,23 @@
+# MicroMDM touchless migration
+
+This Go script reads information from a MicroMDM database and outputs:
+
+- SCEP, APNs and ADE certificates.
+- A file with MySQL statements to import the records into a Fleet database.
+
+### Usage
+
+The only requirement is to have a compatible version of Go installed, and a MicroMDM database.
+
+Here's an example of how a successful run looks like:
+
+```sh
+$ go run tools/mdm/migration/micromdm/touchless/main.go --db ~/projects/micromdm/micromdm.db
+
+2024/09/11 10:05:53 Open DB for devices
+2024/09/11 10:05:53 Found 1 devices
+2024/09/11 10:05:53 Wrote device/enrollment records to dump.sql
+2024/09/11 10:05:53 Open DB for SCEP cert and key
+2024/09/11 10:05:53 Wrote SCEP cert/key to scep.cert/scep.key
+```
+


### PR DESCRIPTION
The intention of this change is to make the SQL output of the script "safe" to run multiple times, even if it's being generated from different MicroMDM database versions.

For context, the migration has two steps that might happen concurrently:

1. Database dumps are generated, and the records are imported into Fleet.
2. There's a proxy that gradually "redirects" hosts based on their UUID to use Fleet as the MDM server.

The behavior we seek is:

1. If a record was previously imported, but the host is still "talking" to MicroMDM, some of the values might have been updated in the MicroMDM database, so we need to update them.
2. If a record is already talking to Fleet, the data in the MicroMDM database might be stale and we don't want to update them.