### PR TITLE
YAML: add missing ios_updates and ipados_updates

### DIFF
--- a/docs/Configuration/yaml-files.md
+++ b/docs/Configuration/yaml-files.md
@@ -262,6 +262,16 @@ controls:
 - `deadline_days` (default: null)
 - `grace_period_days` (default: null)
 
+#### ios_updates
+
+- `deadline` specifies the deadline in the form of `YYYY-MM-DD`. The exact deadline time is at 04:00:00 (UTC-8) (default: `""`).
+- `minimum_version` specifies the minimum required iOS version (default: `""`).
+
+#### ipados_updates
+
+- `deadline` specifies the deadline in the form of `YYYY-MM-DD`. The exact deadline time is at 04:00:00 (UTC-8) (default: `""`).
+- `minimum_version` specifies the minimum required iPadOS version (default: `""`).
+
 #### macos_settings and windows_settings
 
 - `macos_settings.custom_settings` is a list of paths to macOS configuration profiles (.mobileconfig) or declaration profiles (.json).


### PR DESCRIPTION
We missed to document `ios_updates` and `ipados_updates` that's built as part of the #19852