### PR TITLE
"Activity changes" checkbox in user story template

### DIFF
--- a/.github/ISSUE_TEMPLATE/story.md
+++ b/.github/ISSUE_TEMPLATE/story.md
@@ -33,12 +33,13 @@ What else should contributors [keep in mind](https://fleetdm.com/handbook/compan
 
 ### Product
 - [ ] Reference documentation changes: TODO <!-- Specify references documentation changes at fleetdm.com/docs -->
-- [ ] UI changes: TODO <!-- Insert the link to the relevant Figma cover page. Remove this checkbox if there are no changes to the user interface. -->
-- [ ] CLI (fleetctl) usage changes: TODO <!-- Insert the link to the relevant Figma cover page. Remove this checkbox if there are no changes to the CLI. -->
-- [ ] YAML changes: TODO <!-- Specify changes as a draft PR to the YAML files doc page and request the API DRI for review (codeowner reviews are not automatically requested for drafts). Remove this checkbox if there are no changes necessary. -->
-- [ ] REST API changes: TODO <!-- Specify changes as a draft PR to the REST API doc page and request the API DRI for review (codeowner reviews are not automatically requested for drafts). Remove this checkbox if there are no changes necessary. Move this item to the engineering list below if engineering will design the API changes. -->
-- [ ] Fleet's agent (fleetd) changes: TODO <!-- Specify changes to fleetd. If the change requires a new Fleet (server) version, consider specifying to only enable this change in new Fleet versions. Remove this checkbox if there are no changes necessary. -->
-- [ ] Permissions changes: TODO <!-- Specify changes as a draft PR to the Manage access doc page. If doc changes aren't necessary, explicitly mention no changes to the doc page. Remove this checkbox if there are no permissions changes. -->
+- [ ] UI changes: TODO <!-- Insert the link to the relevant Figma cover page. Put "No changes" if there are no changes to the user interface. -->
+- [ ] CLI (fleetctl) usage changes: TODO <!-- Insert the link to the relevant Figma cover page. Put "No changes" if there are no changes to the CLI. -->
+- [ ] YAML changes: TODO <!-- Specify changes as a draft PR to the YAML files doc page and request the API DRI for review (codeowner reviews are not automatically requested for drafts). Put "No changes" if there are no changes necessary. -->
+- [ ] REST API changes: TODO <!-- Specify changes as a draft PR to the REST API doc page and request the API DRI for review (codeowner reviews are not automatically requested for drafts). Put "No changes" if there are no changes necessary. Move this item to the engineering list below if engineering will design the API changes. -->
+- [ ] Fleet's agent (fleetd) changes: TODO <!-- Specify changes to fleetd. If the change requires a new Fleet (server) version, consider specifying to only enable this change in new Fleet versions. Put "No changes" if there are no changes necessary. -->
+- [ ] Activity changes: TODO <!-- Specify changes to Fleet's activity feed as a draft PR to the Audit log page in the contributor docs: https://github.com/fleetdm/fleet/blob/main/docs/Contributing/Audit-logs.md This PR will be closed before release because the Audit log page is automatically generated: https://fleetdm.com/handbook/company/communications#audit-logs Put "No changes" if there are no changes necessary. -->
+- [ ] Permissions changes: TODO <!-- Specify changes as a draft PR to the Manage access doc page. If doc changes aren't necessary, explicitly mention no changes to the doc page. Put "No changes" if there are no permissions changes. -->
 - [ ] Changes to paid features or tiers: TODO  <!-- Specify "Fleet Free" or "Fleet Premium".  If only certain parts of the user story involve paid features, specify which parts.  Implementation of paid features should live in the `ee/` directory. -->
 
 ### Engineering


### PR DESCRIPTION
- Add reminder to think about new activity items during the drafting process
- For all checkboxes, we want to be intentional when we decided to make "No changes" (instead of removing checkbox)
