### PR TITLE
Website: Fix overflowing schema table documentation

### DIFF
--- a/website/assets/styles/pages/osquery-table-details.less
+++ b/website/assets/styles/pages/osquery-table-details.less
@@ -178,6 +178,7 @@
   }
   [purpose='table-container'] {
     height: min-content;
+    max-width: 860px;
   }
 
   [purpose='overflow-shadow'] {
@@ -407,7 +408,9 @@
   }
 
   @media (max-width: 991px) {
-
+    [purpose='table-container'] {
+      max-width: unset;
+    }
     [purpose='schema-table'] {
       padding-top: 40px;
       [purpose='platform-logos'] {


### PR DESCRIPTION
Closes: #21970

Changes:
- Set a max width on the schema table container to prevent it from overflowing outside the page's container on certain browser versions.
