### PR TITLE
Fix migration for 8.0.18

### DIFF
--- a/server/datastore/mysql/migrations/tables/20240826160025_AddRemovedToInstalls.go
+++ b/server/datastore/mysql/migrations/tables/20240826160025_AddRemovedToInstalls.go
@@ -39,8 +39,8 @@ func Up_20240826160025(tx *sql.Tx) error {
 	WHERE NOT EXISTS (
 		-- software is not installed on this specific host
 		SELECT 1 FROM host_software hs
-		INNER JOIN software s2 ON hs.software_id = s2.id AND s2.title_id = st.id
-		WHERE hs.host_id = hsi.host_id
+		INNER JOIN software s2 ON hs.software_id = s2.id
+		WHERE hs.host_id = hsi.host_id AND s2.title_id = st.id
 	) AND (
 		-- software status is: Installed
 		(hsi.post_install_script_exit_code IS NOT NULL AND hsi.post_install_script_exit_code = 0) OR
@@ -74,8 +74,8 @@ func Up_20240826160025(tx *sql.Tx) error {
 	WHERE NOT EXISTS (
 		-- software is not installed on this specific host
 		SELECT 1 FROM host_software hs
-		INNER JOIN software s2 ON hs.software_id = s2.id AND s2.title_id = st.id
-		WHERE hs.host_id = hvsi.host_id
+		INNER JOIN software s2 ON hs.software_id = s2.id
+		WHERE hs.host_id = hvsi.host_id AND s2.title_id = st.id
 	) AND
 		-- software was refetched after it was installed
 		hvsi.updated_at < h.detail_updated_at


### PR DESCRIPTION
Fix one migration issue for 8.0.18, but then we may hit another issue:

```
FAIL 20240829170023_CreateVPPTokenTeamsJoinTable.go (migrating vpp_tokens associations to join table: Error 1064 (42000): You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'CONSTRAINT idx_vpp_tokens_team_id;
ALTER TABLE vpp_tokens DROP COLUMN team_id;
A' at line 1), quitting migration.
exit status 1
```
