### PR TITLE
improve iPad detection on OTA enroll page

### DIFF
--- a/frontend/templates/enroll-ota.html
+++ b/frontend/templates/enroll-ota.html
@@ -167,7 +167,9 @@
       document.addEventListener("DOMContentLoaded", function () {
         const userAgent = navigator.userAgent;
         const isIPhone = /iPhone/.test(userAgent);
-        const isIPad = /iPad/.test(userAgent);
+        const isIPad =
+          /iPad/.test(userAgent) ||
+          (navigator.platform === "MacIntel" && navigator.maxTouchPoints > 1);
 
         // update text content for device type
         let deviceType = "iPhone or iPad";

--- a/frontend/templates/enroll-ota.html
+++ b/frontend/templates/enroll-ota.html
@@ -169,7 +169,9 @@
         const isIPhone = /iPhone/.test(userAgent);
         const isIPad =
           /iPad/.test(userAgent) ||
-          (navigator.platform === "MacIntel" && navigator.maxTouchPoints > 1);
+          (/Macintosh/i.test(navigator.userAgent) &&
+            navigator.maxTouchPoints &&
+            navigator.maxTouchPoints > 1);
 
         // update text content for device type
         let deviceType = "iPhone or iPad";


### PR DESCRIPTION
some iPads default to requesting the desktop version of websites, and thus they send a different user agent. This improves the detection with a well-known method.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Manual QA for all new/changed functionality
