### PR TITLE
show errors for restricted team names, "all teams" and "no team"

### DIFF
--- a/frontend/pages/admin/TeamManagementPage/TeamManagementPage.tsx
+++ b/frontend/pages/admin/TeamManagementPage/TeamManagementPage.tsx
@@ -116,11 +116,11 @@ const TeamManagementPage = (): JSX.Element => {
             setBackendValidators({
               name: "A team with this name already exists",
             });
-          } else if (createError.data.errors[0].reason.includes("all teams")) {
+          } else if (createError.data.errors[0].reason.includes("All teams")) {
             setBackendValidators({
               name: `"All teams" is a reserved team name. Please try another name.`,
             });
-          } else if (createError.data.errors[0].reason.includes("no team")) {
+          } else if (createError.data.errors[0].reason.includes("No team")) {
             setBackendValidators({
               name: `"No team" is a reserved team name. Please try another name.`,
             });


### PR DESCRIPTION
relates to #21971

Show error messages when trying to create a team called "All teams" and "no team"

**all teams error:**

![image](https://github.com/user-attachments/assets/de00754c-176c-4362-9243-ce97719dff74)

**no team error:**

![image](https://github.com/user-attachments/assets/7b41e760-1779-4b53-8ba9-8ca12d84493a)


- [x] Manual QA for all new/changed functionality
