### PR TITLE
updated hyperlink capitalization

### DIFF
--- a/handbook/customer-success/README.md
+++ b/handbook/customer-success/README.md
@@ -29,7 +29,7 @@ The customer success department is directly responsible for ensuring that custom
 
 Occasionally, we will need to track public issues for customers and prospects who wish to remain anonymous on our public issue tracker. To do this: 
 
-1. The team member creating the issue will choose an appropriate minor planet name from this [Minor planets page](https://minorplanetcenter.net//iau/lists/MPNames.html) (alphabetical).
+1. The team member creating the issue will choose an appropriate minor planet name from this [minor planets page](https://minorplanetcenter.net//iau/lists/MPNames.html) (alphabetical).
 2. Create a label in the fleetdm/fleet and fleetdm/confidential repos which can be attached to current and future issues for the customer or prospect. As part of the label description in the fleetdm/confidential repo, add the customer or prospect name. This way, we maintain a confidential mapping of codename to customer or prospect.
 
 


### PR DESCRIPTION
Changed the word "minor" in the "minor planets page" hyperlink to lowercase, because there is no need for it to be capitalized.