### PR TITLE
Clear policy results and stats when setting or changing an installer

### DIFF
--- a/server/service/team_policies.go
+++ b/server/service/team_policies.go
@@ -493,6 +493,13 @@ func (svc *Service) modifyPolicy(ctx context.Context, teamID *uint, id uint, p f
 		if err != nil {
 			return nil, err
 		}
+		// If the associated installer is changed (or it's set and the policy didn't have an associated installer)
+		// then we clear the results of the policy so that automation can be triggered upon failure
+		// (automation is currently triggered on the first failure or when it goes from passing to failure).
+		if softwareInstallerID != nil && (policy.SoftwareInstallerID == nil || *policy.SoftwareInstallerID != *softwareInstallerID) {
+			removeAllMemberships = true
+			removeStats = true
+		}
 		policy.SoftwareInstallerID = softwareInstallerID
 	}
 


### PR DESCRIPTION
Follow up PR for #21428.

After some discussions with Noah we want to clear policy results when a user sets for the first time or changes an installer on a policy.