### PR TITLE
Website: update docsearch styles

### DIFF
--- a/website/assets/styles/docsearch.less
+++ b/website/assets/styles/docsearch.less
@@ -149,6 +149,10 @@
   justify-content: center;
 }
 
+.DocSearch-VisuallyHiddenForAccessibility {
+  display: none;
+}
+
 .DocSearch-Container--Stalled .DocSearch-MagnifierLabel {
   display: none;
 }


### PR DESCRIPTION
Closes: https://github.com/fleetdm/fleet/issues/22055

Changes:
- Updated docsearch.less to hide the duplicate placeholder text in the search modal.
