### PR TITLE
Update installer extensions based on file contents as part of uninstall script migration cron

### DIFF
--- a/ee/server/service/software_installers.go
+++ b/ee/server/service/software_installers.go
@@ -1223,7 +1223,7 @@ func UninstallSoftwareMigration(
 		// Update $PACKAGE_ID in uninstall script
 		preProcessUninstallScript(&payload)
 
-		// Update the package_id in the software installer and the uninstall script
+		// Update the package_id and extension in the software installer and the uninstall script
 		if err := ds.UpdateSoftwareInstallerWithoutPackageIDs(ctx, id, payload); err != nil {
 			return ctxerr.Wrap(ctx, err, "updating package_id in software installer")
 		}

--- a/server/datastore/mysql/software_installers.go
+++ b/server/datastore/mysql/software_installers.go
@@ -959,10 +959,10 @@ func (ds *Datastore) UpdateSoftwareInstallerWithoutPackageIDs(ctx context.Contex
 	}
 	query := `
 		UPDATE software_installers
-		SET package_ids = ?, uninstall_script_content_id = ?
+		SET package_ids = ?, uninstall_script_content_id = ?, extension = ?
 		WHERE id = ?
 	`
-	_, err = ds.writer(ctx).ExecContext(ctx, query, strings.Join(payload.PackageIDs, ","), uninstallScriptID, id)
+	_, err = ds.writer(ctx).ExecContext(ctx, query, strings.Join(payload.PackageIDs, ","), uninstallScriptID, payload.Extension, id)
 	if err != nil {
 		return ctxerr.Wrap(ctx, err, "update software installer without package ID")
 	}


### PR DESCRIPTION
# Checklist for submitter

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [x] Added/updated tests

Automated integration tests fully exercise this change (and have been revised to assert that this works correctly).

This is PR'd against the existing migration cron branch for clarity, as it builds on top of both that and #22017. Once 22017 has been merged and the migration cron PR has been merged or updated with 22017, I'll rebase that out of this branch. The most recent commit is the important one here, as 22017 has already been reviewed.