### PR TITLE
Requestor to provide Gong snippet when available

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -11,6 +11,8 @@ assignees: ''
 Thanks for filing an issue!  Please use the prompts below to provide as much context as you can about your use case and motivations.
 -->
 
+Gong snippet: TODO <!-- Insert the link to the relevant, private Gong snippet. Remove this checkbox if you don't have access to Fleet's Gong or there is no Gong recording available -->
+
 ## Problem
 
 <!-- Describe the problem you're trying to solve. What are you trying to accomplish? 
@@ -18,8 +20,6 @@ Thanks for filing an issue!  Please use the prompts below to provide as much con
 Example: I want to order a pair of shoes from my food delivery app, which does not show options for stores that don't carry food. 
 
 Note: @ Fleet requestor to provide a Gong snippet using the 'share internally' link for any recorded calls where a feature request is discussed -->
-
-Gong snippet: 
 
 ## What have you tried?
 

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -11,15 +11,13 @@ assignees: ''
 Thanks for filing an issue!  Please use the prompts below to provide as much context as you can about your use case and motivations.
 -->
 
-Gong snippet: TODO <!-- Insert the link to the relevant, private Gong snippet. Remove this checkbox if you don't have access to Fleet's Gong or there is no Gong recording available -->
+Gong snippet: TODO <!-- Insert the link to the relevant, private Gong snippet ("Share internally" button). Remove this checkbox if you don't have access to Fleet's Gong or there is no Gong recording available -->
 
 ## Problem
 
 <!-- Describe the problem you're trying to solve. What are you trying to accomplish? 
 
-Example: I want to order a pair of shoes from my food delivery app, which does not show options for stores that don't carry food. 
-
-Note: @ Fleet requestor to provide a Gong snippet using the 'share internally' link for any recorded calls where a feature request is discussed -->
+Example: I want to order a pair of shoes from my food delivery app, which does not show options for stores that don't carry food. -->
 
 ## What have you tried?
 

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -15,7 +15,11 @@ Thanks for filing an issue!  Please use the prompts below to provide as much con
 
 <!-- Describe the problem you're trying to solve. What are you trying to accomplish? 
 
-Example: I want to order a pair of shoes from my food delivery app, which does not show options for stores that don't carry food. -->
+Example: I want to order a pair of shoes from my food delivery app, which does not show options for stores that don't carry food. 
+
+Note: @ Fleet requestor to provide a Gong snippet using the 'share internally' link for any recorded calls where a feature request is discussed -->
+
+Gong snippet: 
 
 ## What have you tried?
 

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -11,7 +11,7 @@ assignees: ''
 Thanks for filing an issue!  Please use the prompts below to provide as much context as you can about your use case and motivations.
 -->
 
-Gong snippet: TODO <!-- Insert the link to the relevant, private Gong snippet ("Share internally" button). Remove this checkbox if you don't have access to Fleet's Gong or there is no Gong recording available -->
+Gong snippet: TODO <!-- Insert the link to the relevant, private Gong snippet ("Share internally" button). Remove this item if you don't have access to Fleet's Gong or there is no Gong recording available -->
 
 ## Problem
 


### PR DESCRIPTION
Updating the feature request template to note that the Fleet requestor should provide a Gong snippet where a customer or prospect discussed a feature when available