### PR TITLE
Add cpe translation for macos vbox

### DIFF
--- a/server/vulnerabilities/nvd/cpe_test.go
+++ b/server/vulnerabilities/nvd/cpe_test.go
@@ -1654,6 +1654,15 @@ func TestCPEFromSoftwareIntegration(t *testing.T) {
 			},
 			cpe: "cpe:2.3:o:linux:linux_kernel:5.4.0-105.118:*:*:*:*:*:*:*",
 		},
+		{
+			software: fleet.Software{
+				Name:             "VirtualBox.app",
+				Source:           "apps",
+				Version:          "7.0.12",
+				BundleIdentifier: "org.virtualbox.app.VirtualBox",
+			},
+			cpe: "cpe:2.3:a:oracle:virtualbox:7.0.12:*:*:*:*:macos:*:*",
+		},
 	}
 
 	// NVD_TEST_CPEDB_PATH can be used to speed up development (sync cpe.sqlite only once).

--- a/server/vulnerabilities/nvd/cpe_translations.json
+++ b/server/vulnerabilities/nvd/cpe_translations.json
@@ -417,5 +417,14 @@
       "product": ["git"],
       "vendor": ["git"]
     }
+  },
+  {
+    "software": {
+      "bundle_identifier": ["org.virtualbox.app.VirtualBox"]
+    },
+    "filter": {
+      "product": ["virtualbox"],
+      "vendor": ["oracle"]
+    }
   }
 ]

--- a/tools/nvd/nvdvuln/nvdvuln.go
+++ b/tools/nvd/nvdvuln/nvdvuln.go
@@ -69,6 +69,12 @@ func main() {
 		}
 	}
 
+	// All macOS apps are expected to have a bundle identifier, which influences CPE generation.
+	if softwareSource != nil && *softwareSource == "apps" && softwareBundleIdentifier != nil && *softwareBundleIdentifier == "" {
+		printf("Must set --software_bundle_identifier for macOS apps when specifying -software_source apps\n")
+		return
+	}
+
 	if err := os.MkdirAll(*dbDir, os.ModePerm); err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
#20846 

Fixing #21646 as it wasn't tested with the bundleIdentifier.  Needing a cpe translation here because the vendor string (oracle) does not exist in the bundleIdentifier (org.virtualbox.app.VirtualBox)

- [ ] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/Committing-Changes.md#changes-files) for more information.
- [X] Added/updated tests
- [X] Manual QA for all new/changed functionality
