### PR TITLE
Uninstall script runs after failed post-install script

### DIFF
--- a/orbit/pkg/installer/installer.go
+++ b/orbit/pkg/installer/installer.go
@@ -242,13 +242,28 @@ func (r *Runner) installSoftware(ctx context.Context, installID string) (*fleet.
 			log.Info().Msgf("installation of %s failed, attempting rollback. Exit code: %d, error: %s", installerPath, postExitCode, postErr)
 			ext := filepath.Ext(installerPath)
 			ext = strings.TrimPrefix(ext, ".")
-			uninstallScript := file.GetRemoveScript(ext)
-			uninstallOutput, uninstallExitCode, uninstallErr := r.runInstallerScript(ctx, uninstallScript, installerPath, "rollback-script")
+			uninstallScript := installer.UninstallScript
+			var builder strings.Builder
+			builder.WriteString(*payload.PostInstallScriptOutput)
+			builder.WriteString("\nAttempting rollback by running uninstall script...\n")
+			if uninstallScript == "" {
+				// The Fleet server is < v4.57.0, so we need to use the old method.
+				// If all customers have updated to v4.57.0 or later, we can remove this method.
+				uninstallScript = file.GetRemoveScript(ext)
+			}
+			uninstallScriptName := "rollback_script"
+			if ext == "exe" || ext == "msi" {
+				uninstallScriptName = "rollback-script.ps1"
+			}
+			uninstallOutput, uninstallExitCode, uninstallErr := r.runInstallerScript(ctx, uninstallScript, installerPath,
+				uninstallScriptName)
 			log.Info().Msgf(
 				"rollback staus: exit code: %d, error: %s, output: %s",
 				uninstallExitCode, uninstallErr, uninstallOutput,
 			)
-
+			builder.WriteString(fmt.Sprintf("Uninstall script exit code: %d\n", uninstallExitCode))
+			builder.WriteString(uninstallOutput)
+			payload.PostInstallScriptOutput = ptr.String(builder.String())
 			return payload, uninstallErr
 		}
 	}

--- a/orbit/pkg/installer/installer.go
+++ b/orbit/pkg/installer/installer.go
@@ -251,12 +251,8 @@ func (r *Runner) installSoftware(ctx context.Context, installID string) (*fleet.
 				// If all customers have updated to v4.57.0 or later, we can remove this method.
 				uninstallScript = file.GetRemoveScript(ext)
 			}
-			uninstallScriptName := "rollback_script"
-			if ext == "exe" || ext == "msi" {
-				uninstallScriptName = "rollback-script.ps1"
-			}
 			uninstallOutput, uninstallExitCode, uninstallErr := r.runInstallerScript(ctx, uninstallScript, installerPath,
-				uninstallScriptName)
+				"rollback-script"+scriptExtension)
 			log.Info().Msgf(
 				"rollback staus: exit code: %d, error: %s, output: %s",
 				uninstallExitCode, uninstallErr, uninstallOutput,

--- a/server/datastore/mysql/software_installers.go
+++ b/server/datastore/mysql/software_installers.go
@@ -44,6 +44,7 @@ func (ds *Datastore) GetSoftwareInstallDetails(ctx context.Context, executionId 
     hsi.self_service AS self_service,
     COALESCE(si.pre_install_query, '') AS pre_install_condition,
     inst.contents AS install_script,
+    uninst.contents AS uninstall_script,
     COALESCE(pisnt.contents, '') AS post_install_script
   FROM
     host_software_installs hsi
@@ -53,6 +54,9 @@ func (ds *Datastore) GetSoftwareInstallDetails(ctx context.Context, executionId 
   LEFT OUTER JOIN
     script_contents inst
     ON inst.id = si.install_script_content_id
+  LEFT OUTER JOIN
+    script_contents uninst
+    ON uninst.id = si.uninstall_script_content_id
   LEFT OUTER JOIN
     script_contents pisnt
     ON pisnt.id = si.post_install_script_content_id

--- a/server/datastore/mysql/software_installers_test.go
+++ b/server/datastore/mysql/software_installers_test.go
@@ -55,6 +55,7 @@ func testListPendingSoftwareInstalls(t *testing.T, ds *Datastore) {
 		InstallScript:     "hello",
 		PreInstallQuery:   "SELECT 1",
 		PostInstallScript: "world",
+		UninstallScript:   "goodbye",
 		InstallerFile:     bytes.NewReader([]byte("hello")),
 		StorageID:         "storage1",
 		Filename:          "file1",
@@ -146,6 +147,7 @@ func testListPendingSoftwareInstalls(t *testing.T, ds *Datastore) {
 	require.Equal(t, installerID1, exec1.InstallerID)
 	require.Equal(t, "SELECT 1", exec1.PreInstallCondition)
 	require.False(t, exec1.SelfService)
+	assert.Equal(t, "goodbye", exec1.UninstallScript)
 
 	hostInstall6, err := ds.InsertSoftwareInstallRequest(ctx, host1.ID, installerID3, true)
 	require.NoError(t, err)

--- a/server/fleet/software_installer.go
+++ b/server/fleet/software_installer.go
@@ -231,12 +231,9 @@ const (
 	SoftwareInstallerInstallFailCopy        = "Installing software...\nFailed\n%s"
 	SoftwareInstallerInstallSuccessCopy     = "Installing software...\nSuccess\n%s"
 	SoftwareInstallerPostInstallSuccessCopy = "Running script...\nExit code: 0 (Success)\n%s"
-	// TODO(roberto): this is not true, how do we know that the rollback script was successful?
-	SoftwareInstallerPostInstallFailCopy = `Running script...
+	SoftwareInstallerPostInstallFailCopy    = `Running script...
 Exit code: %d (Failed)
 %s
-Rolling back software install...
-Rolled back successfully
 `
 )
 

--- a/server/fleet/software_installer.go
+++ b/server/fleet/software_installer.go
@@ -47,7 +47,7 @@ func (FailingSoftwareInstallerStore) Cleanup(ctx context.Context, usedInstallerI
 	return 0, nil
 }
 
-// SoftwareInstallDetailsResult contains all of the information
+// SoftwareInstallDetails contains all of the information
 // required for a client to pull in and install software from the fleet server
 type SoftwareInstallDetails struct {
 	// HostID is used for authentication on the backend and should not
@@ -61,6 +61,8 @@ type SoftwareInstallDetails struct {
 	PreInstallCondition string `json:"pre_install_condition" db:"pre_install_condition"`
 	// InstallScript is the script to run to install the software package.
 	InstallScript string `json:"install_script" db:"install_script"`
+	// UninstallScript is the script to run to uninstall the software package.
+	UninstallScript string `json:"uninstall_script" db:"uninstall_script"`
 	// PostInstallScript is the script to run after installing the software package.
 	PostInstallScript string `json:"post_install_script" db:"post_install_script"`
 	// SelfService indicates the install was initiated by the device user


### PR DESCRIPTION
Unreleased bug #22081

# Demo

<div>
    <a href="https://www.loom.com/share/95e53e7681494ee6937664aa4d03a6fa">
      <p>[Demo] Uninstall script runs after failed post-install script - Watch Video</p>
    </a>
    <a href="https://www.loom.com/share/95e53e7681494ee6937664aa4d03a6fa">
      <img style="max-width:300px;" src="https://cdn.loom.com/sessions/thumbnails/95e53e7681494ee6937664aa4d03a6fa-f9ef3ca336e10a24-full-play.gif">
    </a>
  </div>

## Firefox EXE installer
Get the full installer like: https://download.mozilla.org/?product=firefox-latest&os=win&lang=en-US 
DO NOT get product=firefox-stub
In uninstall script, use -ms as $uninstallArgs


# Checklist for submitter

- [x] Added/updated tests
- [x] Manual QA for all new/changed functionality
- For Orbit and Fleet Desktop changes:
   - [x] Orbit runs on macOS, Linux and Windows. Check if the orbit feature/bugfix should only apply to one platform (`runtime.GOOS`).
   - [x] Manual QA must be performed in the three main OSs, macOS, Windows and Linux.
   - [x] Auto-update manual QA, from released version of component to new version (see [tools/tuf/test](../tools/tuf/test/README.md)).
