### PR TITLE
Remove default `WriteTimeout` on server

### DIFF
--- a/changes/22069-remove-write-timeout
+++ b/changes/22069-remove-write-timeout
@@ -1,0 +1,1 @@
+* Remove 100s write timeout on the server (to allow for long running `POST /api/latest/fleet/software/batch` requests).

--- a/cmd/fleet/serve.go
+++ b/cmd/fleet/serve.go
@@ -1208,32 +1208,11 @@ the way that the Fleet server works.
 				rootMux = prefixMux
 			}
 
-			liveQueryRestPeriod := 90 * time.Second // default (see #1798)
-			if v := os.Getenv("FLEET_LIVE_QUERY_REST_PERIOD"); v != "" {
-				duration, err := time.ParseDuration(v)
-				if err != nil {
-					level.Error(logger).Log("live_query_rest_period_err", err)
-				} else {
-					liveQueryRestPeriod = duration
-				}
-			}
-
-			// The "GET /api/latest/fleet/queries/run" API requires
-			// WriteTimeout to be higher than the live query rest period
-			// (otherwise the response is not sent back to the client).
-			//
-			// We add 10s to the live query rest period to allow the writing
-			// of the response.
-			liveQueryRestPeriod += 10 * time.Second
-
 			// Create the handler based on whether tracing should be there
 			var handler http.Handler
 			handler = launcher.Handler(rootMux)
 
 			srv := config.Server.DefaultHTTPServer(ctx, handler)
-			if liveQueryRestPeriod > srv.WriteTimeout {
-				srv.WriteTimeout = liveQueryRestPeriod
-			}
 			srv.SetKeepAlivesEnabled(config.Server.Keepalive)
 			errs := make(chan error, 2)
 			go func() {

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -102,7 +102,6 @@ func (s *ServerConfig) DefaultHTTPServer(ctx context.Context, handler http.Handl
 		Addr:              s.Address,
 		Handler:           handler,
 		ReadTimeout:       25 * time.Second,
-		WriteTimeout:      40 * time.Second,
 		ReadHeaderTimeout: 5 * time.Second,
 		IdleTimeout:       5 * time.Minute,
 		MaxHeaderBytes:    1 << 18, // 0.25 MB (262144 bytes)


### PR DESCRIPTION
#22069

When performing GitOps with many pieces of software packages Fleet was terminating the connection after `100s` thus not being able to use GitOps for software package management. The timeout depends on the number of software pieces + their size + how fast the server behind the URL serve the content + download speed of host running Fleet.

The 100 second timeout was only there for the synchronous live query APIs, but they are setting the timeout on the request:
https://github.com/fleetdm/fleet/blob/adc7713e049401cd4b1cbc1e6abf856c24afaa04/server/service/live_queries.go#L206-L211

I will create a separate issue to address this the correct way, as the current one request approach is not optimal and some customers may find issues with it.

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/Committing-Changes.md#changes-files) for more information.
- [X] Manual QA for all new/changed functionality