### PR TITLE
Fleet UI: Host filter styling/click bug fixes

### DIFF
--- a/frontend/components/forms/fields/Dropdown/Dropdown.jsx
+++ b/frontend/components/forms/fields/Dropdown/Dropdown.jsx
@@ -51,6 +51,8 @@ class Dropdown extends Component {
     autoFocus: PropTypes.bool,
     /** Includes styled filter icon */
     tableFilterDropdown: PropTypes.bool,
+    /** Includes styled filter icon */
+    hostsFilterBlock: PropTypes.bool,
     helpText: PropTypes.oneOfType([
       PropTypes.string,
       PropTypes.arrayOf(PropTypes.string),
@@ -72,6 +74,7 @@ class Dropdown extends Component {
     tooltip: "",
     autoFocus: false,
     tableFilterDropdown: false,
+    hostsFilterBlock: false,
   };
 
   onMenuOpen = () => {
@@ -156,7 +159,7 @@ class Dropdown extends Component {
   };
 
   // Adds styled filter icon to dropdown
-  renderCustomTableFilter = () => {
+  renderCustomTableFilter = (hostsFilterBlock) => {
     const { options, value } = this.props;
     const customLabel = options
       .filter((option) => option.value === value)
@@ -164,7 +167,10 @@ class Dropdown extends Component {
 
     return (
       <div className={`${baseClass}__custom-value`}>
-        <Icon name="filter" className={`${baseClass}__icon`} />
+        <Icon
+          name={hostsFilterBlock ? "filter-alt" : "filter"}
+          className={`${baseClass}__icon`}
+        />
         <div className={`${baseClass}__custom-value-label`}>{customLabel}</div>
       </div>
     );
@@ -193,6 +199,7 @@ class Dropdown extends Component {
       searchable,
       autoFocus,
       tableFilterDropdown,
+      hostsFilterBlock,
     } = this.props;
 
     const formFieldProps = pick(this.props, [
@@ -230,9 +237,11 @@ class Dropdown extends Component {
           onClose={onMenuClose}
           autoFocus={autoFocus}
           arrowRenderer={renderCustomDropdownArrow}
-          valueComponent={
-            tableFilterDropdown ? renderCustomTableFilter : undefined
-          }
+          valueComponent={() => {
+            return tableFilterDropdown || hostsFilterBlock
+              ? renderCustomTableFilter(hostsFilterBlock)
+              : undefined;
+          }}
         />
       </FormField>
     );

--- a/frontend/components/forms/fields/Dropdown/Dropdown.jsx
+++ b/frontend/components/forms/fields/Dropdown/Dropdown.jsx
@@ -49,10 +49,8 @@ class Dropdown extends Component {
     parseTarget: PropTypes.bool,
     tooltip: PropTypes.string,
     autoFocus: PropTypes.bool,
-    /** Includes styled filter icon */
-    tableFilterDropdown: PropTypes.bool,
-    /** Includes styled filter icon */
-    hostsFilterBlock: PropTypes.bool,
+    /** Includes styled icon */
+    iconName: PropTypes.string,
     helpText: PropTypes.oneOfType([
       PropTypes.string,
       PropTypes.arrayOf(PropTypes.string),
@@ -73,8 +71,7 @@ class Dropdown extends Component {
     parseTarget: false,
     tooltip: "",
     autoFocus: false,
-    tableFilterDropdown: false,
-    hostsFilterBlock: false,
+    iconName: "",
   };
 
   onMenuOpen = () => {
@@ -158,19 +155,16 @@ class Dropdown extends Component {
     );
   };
 
-  // Adds styled filter icon to dropdown
-  renderCustomTableFilter = (hostsFilterBlock) => {
-    const { options, value } = this.props;
+  // Adds styled icon to dropdown
+  renderWithIcon = () => {
+    const { options, value, iconName } = this.props;
     const customLabel = options
       .filter((option) => option.value === value)
       .map((option) => option.label);
 
     return (
       <div className={`${baseClass}__custom-value`}>
-        <Icon
-          name={hostsFilterBlock ? "filter-alt" : "filter"}
-          className={`${baseClass}__icon`}
-        />
+        <Icon name={iconName} className={`${baseClass}__icon`} />
         <div className={`${baseClass}__custom-value-label`}>{customLabel}</div>
       </div>
     );
@@ -183,7 +177,7 @@ class Dropdown extends Component {
       onMenuOpen,
       onMenuClose,
       renderCustomDropdownArrow,
-      renderCustomTableFilter,
+      renderWithIcon,
     } = this;
     const {
       error,
@@ -198,8 +192,7 @@ class Dropdown extends Component {
       wrapperClassName,
       searchable,
       autoFocus,
-      tableFilterDropdown,
-      hostsFilterBlock,
+      iconName,
     } = this.props;
 
     const formFieldProps = pick(this.props, [
@@ -237,11 +230,7 @@ class Dropdown extends Component {
           onClose={onMenuClose}
           autoFocus={autoFocus}
           arrowRenderer={renderCustomDropdownArrow}
-          valueComponent={() => {
-            return tableFilterDropdown || hostsFilterBlock
-              ? renderCustomTableFilter(hostsFilterBlock)
-              : undefined;
-          }}
+          valueComponent={iconName ? () => renderWithIcon() : undefined}
         />
       </FormField>
     );

--- a/frontend/components/forms/fields/Dropdown/Dropdown.jsx
+++ b/frontend/components/forms/fields/Dropdown/Dropdown.jsx
@@ -230,7 +230,7 @@ class Dropdown extends Component {
           onClose={onMenuClose}
           autoFocus={autoFocus}
           arrowRenderer={renderCustomDropdownArrow}
-          valueComponent={iconName ? () => renderWithIcon() : undefined}
+          valueComponent={iconName ? renderWithIcon : undefined}
         />
       </FormField>
     );

--- a/frontend/components/forms/fields/Dropdown/_styles.scss
+++ b/frontend/components/forms/fields/Dropdown/_styles.scss
@@ -6,7 +6,6 @@
     }
 
     &-label {
-      width: 105px;
       line-height: 38px;
       font-size: $small;
     }

--- a/frontend/components/forms/fields/Dropdown/_styles.scss
+++ b/frontend/components/forms/fields/Dropdown/_styles.scss
@@ -1,6 +1,8 @@
 .dropdown {
   &__custom-value {
     display: inline-flex;
+    font-size: $small;
+
     svg {
       padding: 0 $pad-small;
     }
@@ -8,7 +10,6 @@
     &-label {
       width: 105px;
       line-height: 38px;
-      font-size: $small;
     }
   }
 

--- a/frontend/components/forms/fields/Dropdown/_styles.scss
+++ b/frontend/components/forms/fields/Dropdown/_styles.scss
@@ -1,7 +1,6 @@
 .dropdown {
   &__custom-value {
     display: inline-flex;
-    font-size: $small;
 
     svg {
       padding: 0 $pad-small;
@@ -10,6 +9,7 @@
     &-label {
       width: 105px;
       line-height: 38px;
+      font-size: $small;
     }
   }
 

--- a/frontend/components/forms/fields/Dropdown/_styles.scss
+++ b/frontend/components/forms/fields/Dropdown/_styles.scss
@@ -1,7 +1,6 @@
 .dropdown {
   &__custom-value {
     display: inline-flex;
-
     svg {
       padding: 0 $pad-small;
     }

--- a/frontend/pages/SoftwarePage/SoftwareTitles/SoftwareTable/SoftwareTable.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitles/SoftwareTable/SoftwareTable.tsx
@@ -300,7 +300,7 @@ const SoftwareTable = ({
             options={SOFTWARE_TITLES_DROPDOWN_OPTIONS}
             searchable={false}
             onChange={handleCustomFilterDropdownChange}
-            tableFilterDropdown
+            iconName="filter"
           />
         )}
         <Slider

--- a/frontend/pages/SoftwarePage/SoftwareVulnerabilities/SoftwareVulnerabilitiesTable/SoftwareVulnerabilitiesTable.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareVulnerabilities/SoftwareVulnerabilitiesTable/SoftwareVulnerabilitiesTable.tsx
@@ -242,7 +242,7 @@ const SoftwareVulnerabilitiesTable = ({
         options={getExploitedVulnerabilitiesDropdownOptions(isPremiumTier)}
         searchable={false}
         onChange={handleExploitedVulnFilterDropdownChange}
-        tableFilterDropdown
+        iconName="filter"
       />
     );
   };

--- a/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
@@ -1441,7 +1441,7 @@ const ManageHostsPage = ({
           options={getHostSelectStatuses(isSandboxMode)}
           searchable={false}
           onChange={handleStatusDropdownChange}
-          tableFilterDropdown
+          iconName="filter"
         />
         <LabelFilterSelect
           className={`${baseClass}__label-filter-dropdown`}

--- a/frontend/pages/hosts/ManageHostsPage/components/HostsFilterBlock/HostsFilterBlock.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/components/HostsFilterBlock/HostsFilterBlock.tsx
@@ -251,6 +251,8 @@ const HostsFilterBlock = ({
           className={`${baseClass}__macsettings-dropdown`}
           options={OS_SETTINGS_FILTER_OPTIONS}
           onChange={onChangeMacSettingsFilter}
+          searchable={false}
+          hostsFilterBlock
         />
         <FilterPill
           label={label}
@@ -414,6 +416,8 @@ const HostsFilterBlock = ({
           className={`${baseClass}__os_settings-dropdown`}
           options={OS_SETTINGS_FILTER_OPTIONS}
           onChange={onChangeOsSettingsFilter}
+          searchable={false}
+          hostsFilterBlock
         />
         <FilterPill
           label={label}
@@ -472,7 +476,9 @@ const HostsFilterBlock = ({
           value={softwareStatus}
           className={`${baseClass}__sw-install-status-dropdown`}
           options={OPTIONS}
+          searchable={false}
           onChange={onChangeSoftwareInstallStatusFilter}
+          hostsFilterBlock
         />
         {renderSoftwareFilterBlock([HOSTS_QUERY_PARAMS.SOFTWARE_STATUS])}
       </>

--- a/frontend/pages/hosts/ManageHostsPage/components/HostsFilterBlock/HostsFilterBlock.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/components/HostsFilterBlock/HostsFilterBlock.tsx
@@ -252,7 +252,7 @@ const HostsFilterBlock = ({
           options={OS_SETTINGS_FILTER_OPTIONS}
           onChange={onChangeMacSettingsFilter}
           searchable={false}
-          hostsFilterBlock
+          iconName="filter-alt"
         />
         <FilterPill
           label={label}
@@ -417,7 +417,7 @@ const HostsFilterBlock = ({
           options={OS_SETTINGS_FILTER_OPTIONS}
           onChange={onChangeOsSettingsFilter}
           searchable={false}
-          hostsFilterBlock
+          iconName="filter-alt"
         />
         <FilterPill
           label={label}
@@ -478,7 +478,7 @@ const HostsFilterBlock = ({
           options={OPTIONS}
           searchable={false}
           onChange={onChangeSoftwareInstallStatusFilter}
-          hostsFilterBlock
+          iconName="filter-alt"
         />
         {renderSoftwareFilterBlock([HOSTS_QUERY_PARAMS.SOFTWARE_STATUS])}
       </>

--- a/frontend/pages/hosts/ManageHostsPage/components/HostsFilterBlock/_styles.scss
+++ b/frontend/pages/hosts/ManageHostsPage/components/HostsFilterBlock/_styles.scss
@@ -21,11 +21,6 @@
   &__os_settings-dropdown,
   &__macsettings-dropdown,
   &__sw-install-status-dropdown {
-    .Select-value {
-      padding-left: $pad-medium;
-      padding-right: $pad-medium;
-    }
-
     .dropdown__select {
       border: 1px solid #e2e4ea;
     }

--- a/frontend/pages/hosts/ManageHostsPage/components/HostsFilterBlock/_styles.scss
+++ b/frontend/pages/hosts/ManageHostsPage/components/HostsFilterBlock/_styles.scss
@@ -29,5 +29,9 @@
     .dropdown__select {
       border: 1px solid #e2e4ea;
     }
+
+    .Select-multi-value-wrapper {
+      width: 150px; // Fits all dropdown options without resizing
+    }
   }
 }

--- a/frontend/pages/hosts/ManageHostsPage/components/HostsFilterBlock/_styles.scss
+++ b/frontend/pages/hosts/ManageHostsPage/components/HostsFilterBlock/_styles.scss
@@ -10,36 +10,20 @@
       // and other "form-fields" in the filter block
       width: initial;
     }
+
+    // Vertically centers icon and text
+    .Select-multi-value-wrapper {
+      display: flex;
+      align-items: center;
+    }
   }
 
-  // NOTE: Look more into this styling
   &__os_settings-dropdown,
   &__macsettings-dropdown,
   &__sw-install-status-dropdown {
     .Select-value {
-      display: flex;
-      align-items: center;
-      position: initial !important;
-      line-height: initial !important;
-
-      &::before {
-        position: relative;
-        content: url(../assets/images/icon-filter-v2-black-16x16@2x.png);
-        transform: scale(0.5);
-        top: 1px;
-      }
-    }
-
-    .Select-input {
-      display: none !important;
-    }
-
-    .Select {
-      box-sizing: initial;
-    }
-
-    .Select-control {
-      height: 36px;
+      padding-left: $pad-medium;
+      padding-right: $pad-medium;
     }
 
     .dropdown__select {

--- a/frontend/pages/hosts/ManageHostsPage/components/PoliciesFilter/PoliciesFilter.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/components/PoliciesFilter/PoliciesFilter.tsx
@@ -32,13 +32,14 @@ const PoliciesFilter = ({
   const value = policyResponse;
 
   return (
-    <div className={`${baseClass}__policies-block`}>
+    <div className={baseClass}>
       <Dropdown
         value={value}
         className={`${baseClass}__status_dropdown`}
         options={POLICY_RESPONSE_OPTIONS}
         searchable={false}
         onChange={onChange}
+        iconName="filter-alt"
       />
     </div>
   );

--- a/frontend/pages/hosts/ManageHostsPage/components/PoliciesFilter/_styles.scss
+++ b/frontend/pages/hosts/ManageHostsPage/components/PoliciesFilter/_styles.scss
@@ -1,41 +1,5 @@
 .policies-filter {
-  display: flex;
-  justify-content: flex-start;
-  align-items: center;
-
-  &__status_dropdown {
-    width: 114px;
-
-    .Select-menu-outer {
-      width: 114px;
-      max-height: 310px;
-
-      .Select-menu {
-        max-height: none;
-
-        .dropdown__option {
-          font-size: $small !important;
-        }
-      }
-    }
-    .Select-value {
-      padding-left: $pad-medium;
-      padding-right: $pad-medium;
-
-      &::before {
-        display: inline-block;
-        position: absolute;
-        padding: 5px 0 0 0; // centers spin
-        content: url(../assets/images/icon-filter-v2-black-16x16@2x.png);
-        transform: scale(0.5);
-        width: 16px;
-        height: 26px;
-        left: 2px;
-      }
-    }
-    .Select-value-label {
-      padding-left: $pad-large;
-      font-size: $small !important;
-    }
+  .Select-multi-value-wrapper {
+    width: 91px; // Fits all dropdown options without resizing
   }
 }

--- a/frontend/pages/hosts/details/cards/Software/HostSoftwareTable/HostSoftwareTable.tsx
+++ b/frontend/pages/hosts/details/cards/Software/HostSoftwareTable/HostSoftwareTable.tsx
@@ -114,7 +114,7 @@ const HostSoftwareTable = ({
         options={DROPDOWN_OPTIONS}
         searchable={false}
         onChange={handleFilterDropdownChange}
-        tableFilterDropdown
+        iconName="filter"
       />
     );
   }, [handleFilterDropdownChange, hostSoftwareFilter]);

--- a/frontend/pages/policies/ManagePoliciesPage/components/AddPolicyModal/AddPolicyModal.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/components/AddPolicyModal/AddPolicyModal.tsx
@@ -183,7 +183,7 @@ const AddPolicyModal = ({
           options={PLATFORM_FILTER_OPTIONS}
           searchable={false}
           onChange={onPlatformFilterChange}
-          tableFilterDropdown
+          iconName="filter"
         />
         <div className={`${baseClass}__policy-selection`}>
           {filteredPoliciesCount > 0 ? filteredPoliciesList : renderNoResults()}

--- a/frontend/pages/queries/ManageQueriesPage/components/QueriesTable/QueriesTable.tsx
+++ b/frontend/pages/queries/ManageQueriesPage/components/QueriesTable/QueriesTable.tsx
@@ -272,7 +272,7 @@ const QueriesTable = ({
         options={PLATFORM_FILTER_OPTIONS}
         searchable={false}
         onChange={handlePlatformFilterDropdownChange}
-        tableFilterDropdown
+        iconName="filter"
       />
     );
   }, [platform, queryParams, router]);


### PR DESCRIPTION
## Issue
Cerra #22139 

## Description
Fix host filter dropdown styling
- Host filter dropdowns are all clickable (not just the arrow)
- The icon changes color on hover
- Uses built in styling in `<Dropdown/>` and removes unnecessary one-off styling, some of which wasn't even being rendered

## Screen recording
https://www.loom.com/share/6e6920f7bee747ad94dd561724faffcf?sid=cc13045e-3d69-48dc-96d9-1ca6a12fa344

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Manual QA for all new/changed functionality

