### PR TITLE
Updated the "Operating system up to date (macOS)" policy criteria

### DIFF
--- a/frontend/pages/policies/constants.ts
+++ b/frontend/pages/policies/constants.ts
@@ -205,7 +205,7 @@ export const DEFAULT_POLICIES: IPolicyNew[] = [
   },
   {
     key: 16,
-    query: "SELECT 1 FROM os_version WHERE version >= '12.5.1';",
+    query: "SELECT 1 FROM os_version WHERE version >= '14.6.1' OR version >= '15.0';",
     name: "Operating system up to date (macOS)",
     description: "Using an outdated macOS version risks exposure to security vulnerabilities and potential system instability.",
     resolution:


### PR DESCRIPTION
I updated the os_version that is being evaluated in the "Operating system up to date (macOS)" policy to reflect the current and n-1 major OS versions. This is currently 2+ years out of date. 