### PR TITLE
For R.C. - Use previous package filename for activity if installer edit doesn't change the package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,6 +74,7 @@ define HELP_TEXT
 	make generate-go  - Generate and bundle required go code
 	make generate-js  - Generate and bundle required js code
 	make generate-dev - Generate and bundle required code in a watch loop
+	make generate-doc - Generate updated API documentation for activities, osquery flags
 
     make clean        - Clean all build artifacts
 	make clean-assets - Clean assets only

--- a/docs/Contributing/Audit-logs.md
+++ b/docs/Contributing/Audit-logs.md
@@ -1222,7 +1222,7 @@ Generated when a software installer is updated in Fleet.
 
 This activity contains the following fields:
 - "software_title": Name of the software.
-- "software_package": Filename of the installer. `null` if the installer package was not modified.
+- "software_package": Filename of the installer as of this update (including if unchanged).
 - "team_name": Name of the team on which this software was updated. `null` if it was updated on no team.
 - "team_id": The ID of the team on which this software was updated. `null` if it was updated on no team.
 - "self_service": Whether the software is available for installation by the end user.

--- a/ee/server/service/software_installers.go
+++ b/ee/server/service/software_installers.go
@@ -175,10 +175,11 @@ func (svc *Service) UpdateSoftwareInstaller(ctx context.Context, payload *fleet.
 	}
 
 	activity := fleet.ActivityTypeEditedSoftware{
-		SoftwareTitle: existingInstaller.SoftwareTitle,
-		TeamName:      teamName,
-		TeamID:        payload.TeamID,
-		SelfService:   existingInstaller.SelfService,
+		SoftwareTitle:   existingInstaller.SoftwareTitle,
+		TeamName:        teamName,
+		TeamID:          payload.TeamID,
+		SelfService:     existingInstaller.SelfService,
+		SoftwarePackage: &existingInstaller.Name,
 	}
 
 	var payloadForNewInstallerFile *fleet.UploadSoftwareInstallerPayload

--- a/server/fleet/activities.go
+++ b/server/fleet/activities.go
@@ -1597,7 +1597,7 @@ func (a ActivityTypeEditedSoftware) ActivityName() string {
 func (a ActivityTypeEditedSoftware) Documentation() (string, string, string) {
 	return `Generated when a software installer is updated in Fleet.`, `This activity contains the following fields:
 - "software_title": Name of the software.
-- "software_package": Filename of the installer.` + " `null` " + `if the installer package was not modified.
+- "software_package": Filename of the installer as of this update (including if unchanged).
 - "team_name": Name of the team on which this software was updated.` + " `null` " + `if it was updated on no team.
 - "team_id": The ID of the team on which this software was updated.` + " `null` " + `if it was updated on no team.
 - "self_service": Whether the software is available for installation by the end user.`, `{


### PR DESCRIPTION
 > [!NOTE]
> This PR is already merged in `main`, see https://github.com/fleetdm/fleet/pull/22177  This is against the release branch so it can be included in 4.57.0 

```
1140  git fetch fleetdm 
 1141  git checkout fleetdm/minor-fleet-v4.57.0
 1142  git log main
 1143  git cherry-pick 518a4a1f98db33ad62fccf35231b5191e11e8d0a
 1144  git checkout -b 20404-be-fix-rc
 1145  git push -u fleetdm 20404-be-fix-rc
```