### PR TITLE
Remove macOS 13 packaging test build

### DIFF
--- a/.github/workflows/test-packaging.yml
+++ b/.github/workflows/test-packaging.yml
@@ -47,7 +47,7 @@ jobs:
         # packages, this worker needs to run on an x86_64 architecture.
         # `macos-latest` uses arm64 by default now, so please be careful when
         # updating this version.
-        os: [ubuntu-latest, macos-13]
+        os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -55,24 +55,6 @@ jobs:
         uses: step-security/harden-runner@63c24ba6bd7ba022e95695ff85de572c04a18142 # v2.7.0
         with:
           egress-policy: audit
-
-      - name: Run Colima
-        if: startsWith(matrix.os, 'macos')
-        timeout-minutes: 15
-        # notes:
-        # - docker to install the docker CLI and interact with the Colima
-        #   container runtime
-        # - colima is pre-installed in macos-12 runners, but not in macos-13 or
-        #   macos-14 runners
-        run: |
-          brew install docker
-          # The runners come with an old version of python@3.12 that fails to upgrade
-          # when python gets pulled in as a dep through the chain
-          # colima -> lima -> qemu -> glibc -> python@3.12
-          # Force upgrade it for now, remove once the problem is fixed
-          brew install --overwrite python@3.12
-          brew install colima
-          colima start --mount $TMPDIR:w
 
       - name: Pull fleetdm/wix
         # Run in background while other steps complete to speed up the workflow
@@ -89,16 +71,6 @@ jobs:
         uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
         with:
           go-version-file: "go.mod"
-
-      - name: Install wine and wix
-        if: startsWith(matrix.os, 'macos')
-        run: |
-          ./scripts/macos-install-wine.sh -n
-          wget https://github.com/wixtoolset/wix3/releases/download/wix3112rtm/wix311-binaries.zip -nv -O wix.zip
-          mkdir wix
-          unzip wix.zip -d wix
-          rm -f wix.zip
-          echo wix installed at $(pwd)/wix
 
         # It seems faster not to cache Go dependencies
       - name: Install Go Dependencies
@@ -130,7 +102,3 @@ jobs:
 
       - name: Build PKG with Fleet Desktop
         run: ./build/fleetctl package --type pkg --enroll-secret=foo --fleet-url=https://localhost:8080 --fleet-desktop
-
-      - name: Build MSI (using local Wix)
-        if: startsWith(matrix.os, 'macos')
-        run: ./build/fleetctl package --type msi --enroll-secret=foo --fleet-url=https://localhost:8080 --fleet-desktop --local-wix-dir ./wix


### PR DESCRIPTION
This test almost always fails and frequently hold up CI. Until we have a better test we should remove it. The fact that it's failure is a coin toss means it provides no useful information.