### PR TITLE
UI: handle possibly 'null' 'storedPolicy.team_id' on update policy call

### DIFF
--- a/frontend/pages/policies/PolicyPage/screens/QueryEditor.tsx
+++ b/frontend/pages/policies/PolicyPage/screens/QueryEditor.tsx
@@ -198,7 +198,7 @@ const QueryEditor = ({
 
     const updateAPIRequest = () => {
       // storedPolicy.team_id is used for existing policies because selectedTeamId is subject to change
-      const team_id = storedPolicy?.team_id;
+      const team_id = storedPolicy?.team_id ?? undefined;
 
       return team_id !== undefined
         ? teamPoliciesAPI.update(policyIdForEdit, {


### PR DESCRIPTION
## #22145 

![ezgif-2-c62195a3ba](https://github.com/user-attachments/assets/4db3fcf8-f706-40e5-a1e5-c422ff7ac6c6)

- [x] Changes file added for user-visible changes in `changes/`
- [x] Manual QA for all new/changed functionality
