### PR TITLE
to RC: UI: handle possibly 'null' 'storedPolicy.team_id' on update policy ca…

### DIFF
--- a/frontend/pages/policies/PolicyPage/screens/QueryEditor.tsx
+++ b/frontend/pages/policies/PolicyPage/screens/QueryEditor.tsx
@@ -198,7 +198,7 @@ const QueryEditor = ({
 
     const updateAPIRequest = () => {
       // storedPolicy.team_id is used for existing policies because selectedTeamId is subject to change
-      const team_id = storedPolicy?.team_id;
+      const team_id = storedPolicy?.team_id ?? undefined;
 
       return team_id !== undefined
         ? teamPoliciesAPI.update(policyIdForEdit, {


### PR DESCRIPTION
#### This PR already merged to `main`, see https://github.com/fleetdm/fleet/pull/22215. This is against the release branch so it can be included in 4.57.0 (issue #22145 )