### PR TITLE
Website: Deliver contact form messages to Slack

### DIFF
--- a/website/api/controllers/deliver-contact-form-message.js
+++ b/website/api/controllers/deliver-contact-form-message.js
@@ -66,26 +66,9 @@ module.exports = {
       throw 'invalidEmailDomain';
     }
 
-    // await sails.helpers.http.post(sails.config.custom.slackWebhookUrlForContactForm, {
-    //   text: `New contact form message: (Remember: we have to email back; can't just reply to this thread.) cc @sales `+
-    //   `Name: ${firstName + ' ' + lastName}, Email: ${emailAddress}, Message: ${message ? message : 'No message.'}`
-    // });
-
-    await sails.helpers.sendTemplateEmail.with({
-      to: sails.config.custom.fromEmailAddress,
-      replyTo: {
-        name: firstName + ' '+ lastName,
-        emailAddress: emailAddress,
-      },
-      subject: 'New contact form message',
-      layout: false,
-      template: 'email-contact-form',
-      templateData: {
-        emailAddress,
-        firstName,
-        lastName,
-        message,
-      },
+    await sails.helpers.http.post(sails.config.custom.slackWebhookUrlForContactForm, {
+      text: `New contact form message: (Remember: we have to email back; can't just reply to this thread.)`+
+      `Name: ${firstName + ' ' + lastName}, Email: ${emailAddress}, Message: ${message ? message : 'No message.'}`
     });
 
     sails.helpers.salesforce.updateOrCreateContactAndAccount.with({


### PR DESCRIPTION
Related to: https://github.com/fleetdm/confidential/issues/8098

Changes:
- Updated `deliver-contact-form-message` to send contact form submissions to a Slack webhook.