### PR TITLE
show correct chrome software icon for chrome packages

### DIFF
--- a/changes/20865-fix-chrome-icon
+++ b/changes/20865-fix-chrome-icon
@@ -1,0 +1,1 @@
+- show proper software icon for chrome packages

--- a/frontend/pages/SoftwarePage/components/icons/index.ts
+++ b/frontend/pages/SoftwarePage/components/icons/index.ts
@@ -45,6 +45,7 @@ const SOFTWARE_NAME_TO_ICON_MAP = {
   "microsoft teams": Teams,
   "visual studio code": VisualStudioCode,
   "microsoft word": Word,
+  "google chrome": ChromeApp,
   darwin: MacOS,
   windows: WindowsOS,
   chrome: ChromeOS,
@@ -113,8 +114,6 @@ const matchStrictNameSourceToIcon = ({
       return Zoom;
     case name === "zoom":
       return Zoom;
-    case name === "google chrome":
-      return ChromeApp;
     default:
       return null;
   }


### PR DESCRIPTION
relates to #20865

Show the correct software icon for uploaded chrome packages

![image](https://github.com/user-attachments/assets/85215a31-0b63-438b-a4dc-661cea026c3b)

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
- [x] Manual QA for all new/changed functionality
