### PR TITLE
Fleet UI: Fix observer persisting host_id when querying host from host details page

### DIFF
--- a/changes/20959-query-host-flow-fix-observer
+++ b/changes/20959-query-host-flow-fix-observer
@@ -1,0 +1,1 @@
+- Fix UI flow for observers to easily query hosts from the host details page

--- a/frontend/pages/queries/details/QueryDetailsPage/QueryDetailsPage.tsx
+++ b/frontend/pages/queries/details/QueryDetailsPage/QueryDetailsPage.tsx
@@ -49,7 +49,12 @@ interface IQueryDetailsPageProps {
   params: Params;
   location: {
     pathname: string;
-    query: { team_id?: string; order_key?: string; order_direction?: string };
+    query: {
+      team_id?: string;
+      order_key?: string;
+      order_direction?: string;
+      host_id?: string;
+    };
     search: string;
   };
 }
@@ -66,6 +71,12 @@ const QueryDetailsPage = ({
     router.push(PATHS.MANAGE_QUERIES);
   }
   const queryParams = location.query;
+
+  // Present when observer is redirected from host details > query
+  // since observer does not have access to edit page
+  const hostId = queryParams?.host_id
+    ? parseInt(queryParams.host_id, 10)
+    : undefined;
 
   const { currentTeamId } = useTeamIdParam({
     location,
@@ -295,7 +306,7 @@ const QueryDetailsPage = ({
                         onClick={() => {
                           queryId &&
                             router.push(
-                              PATHS.LIVE_QUERY(queryId, currentTeamId)
+                              PATHS.LIVE_QUERY(queryId, currentTeamId, hostId)
                             );
                         }}
                         disabled={isLiveQueryDisabled}

--- a/frontend/pages/queries/edit/EditQueryPage.tsx
+++ b/frontend/pages/queries/edit/EditQueryPage.tsx
@@ -208,7 +208,14 @@ const EditQueryPage = ({
       queryId > 0 &&
       !canEditExistingQuery
     ) {
-      router.push(PATHS.QUERY_DETAILS(queryId));
+      // Reroute to query report page still maintains query params for live query purposes
+      const baseUrl = PATHS.QUERY_DETAILS(queryId);
+      const queryParams = buildQueryStringFromParams({
+        host_id: location.query.host_id,
+        team_id: location.query.team_id,
+      });
+
+      router.push(queryParams ? `${baseUrl}?${queryParams}` : baseUrl);
     }
   }, [queryId, isTeamMaintainerOrTeamAdmin, isStoredQueryLoading]);
 

--- a/frontend/router/paths.ts
+++ b/frontend/router/paths.ts
@@ -1,3 +1,5 @@
+import { buildQueryStringFromParams } from "utilities/url";
+
 import { IPolicy } from "../interfaces/policy";
 import URL_PREFIX from "./url_prefix";
 
@@ -95,10 +97,17 @@ export default {
       teamId ? `?team_id=${teamId}` : ""
     }`;
   },
-  LIVE_QUERY: (queryId: number | null, teamId?: number): string => {
-    return `${URL_PREFIX}/queries/${queryId || "new"}/live${
-      teamId ? `?team_id=${teamId}` : ""
-    }`;
+  LIVE_QUERY: (
+    queryId: number | null,
+    teamId?: number,
+    hostId?: number
+  ): string => {
+    const baseUrl = `${URL_PREFIX}/queries/${queryId || "new"}/live`;
+    const queryParams = buildQueryStringFromParams({
+      team_id: teamId,
+      host_id: hostId,
+    });
+    return queryParams ? `${baseUrl}?${queryParams}` : baseUrl;
   },
   QUERY_DETAILS: (queryId: number, teamId?: number): string => {
     return `${URL_PREFIX}/queries/${queryId}${


### PR DESCRIPTION
## Issue
Cerra #20959 

## Description
- Bug: Design decision to not allow observers to access edit query page and redirect to query details page caused regression with allowing observers to flow `host_id` into query flow that starts on edit query page from host details page > query option
- Fix: Since observers are pushed to the query details page when they don't have access to edit query page, persist `host_id` param on query details page as well, so when user goes to live query flow, the `host_id` param persists

## Screen recording of fix
https://www.loom.com/share/6fdf3682bf46424b8d26eae33e78f326?sid=c167192e-0edc-476e-8023-f41f630764b5

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
- [x] Manual QA for all new/changed functionality

