### PR TITLE
Fleet UI: Host details > about info uses less columns at small widths

### DIFF
--- a/changes/20683-less-columns-smaller-width
+++ b/changes/20683-less-columns-smaller-width
@@ -1,1 +1,1 @@
-- UI cleanup: Host details about section condenses information into to less columns at smaller widths
+- UI cleanup: Host details about section condenses information into fewer columns at smaller widths

--- a/changes/20683-less-columns-smaller-width
+++ b/changes/20683-less-columns-smaller-width
@@ -1,0 +1,1 @@
+- UI cleanup: Host details about section condenses information into to less columns at smaller widths

--- a/frontend/pages/hosts/details/HostDetailsPage/_styles.scss
+++ b/frontend/pages/hosts/details/HostDetailsPage/_styles.scss
@@ -63,11 +63,6 @@
           flex-direction: row;
         }
       }
-      &__block {
-        display: flex;
-        flex-direction: column;
-        margin-right: $pad-xxlarge;
-      }
       &__data {
         margin-bottom: $pad-medium;
 

--- a/frontend/pages/hosts/details/_styles.scss
+++ b/frontend/pages/hosts/details/_styles.scss
@@ -21,41 +21,6 @@
       margin: 0 0 $pad-medium 0;
     }
 
-    .info-grid {
-      display: grid;
-      grid-auto-flow: column;
-      grid-template-columns: repeat(
-        3,
-        max-content
-      ); // Prevents overflow off screen
-      grid-template-rows: repeat(4, 1fr);
-      column-gap: $pad-xxlarge;
-      row-gap: $pad-medium;
-
-      @media (min-width: $break-md) {
-        grid-template-columns: repeat(4, max-content);
-        grid-template-rows: repeat(3, 1fr);
-      }
-
-      &__block {
-        font-size: $x-small;
-        display: flex;
-        flex-direction: column;
-        white-space: nowrap;
-      }
-
-      &__data {
-        .device-mapping {
-          &__source {
-            color: $ui-fleet-black-75;
-          }
-          &__more {
-            color: $ui-fleet-black-50;
-          }
-        }
-      }
-    }
-
     .list {
       list-style: none;
       padding: 0;

--- a/frontend/pages/hosts/details/cards/About/About.tsx
+++ b/frontend/pages/hosts/details/cards/About/About.tsx
@@ -189,11 +189,11 @@ const About = ({
     <Card
       borderRadiusSize="xxlarge"
       includeShadow
-      largePadding
+      paddingSize="large"
       className={baseClass}
     >
       <p className="card__header">About</p>
-      <div className="info-grid">
+      <div className="info-flex">
         <DataSet
           title="Added to Fleet"
           value={

--- a/frontend/pages/hosts/details/cards/About/_styles.scss
+++ b/frontend/pages/hosts/details/cards/About/_styles.scss
@@ -1,4 +1,54 @@
 .about-card {
+  // Adjusts for edge cases of extra long MDM server URL and used by email
+  .info-flex {
+    display: flex;
+    flex-direction: column;
+    flex-wrap: wrap;
+    gap: $pad-medium $pad-xxlarge;
+    max-height: 350px;
+    align-content: flex-start;
+
+    .data-set {
+      min-width: none;
+    }
+
+    dd,
+    .component__tooltip-wrapper__element {
+      max-width: 350px;
+      white-space: initial;
+      word-break: break-word;
+    }
+
+    &__data {
+      .device-mapping {
+        &__source {
+          color: $ui-fleet-black-75;
+        }
+        &__more {
+          color: $ui-fleet-black-50;
+        }
+      }
+    }
+
+    @media (min-width: $break-md) {
+      max-height: 250px;
+
+      dd,
+      .component__tooltip-wrapper__element {
+        max-width: 340px;
+      }
+    }
+
+    @media (min-width: $break-lg) {
+      max-height: 200px;
+
+      dd,
+      .component__tooltip-wrapper__element {
+        max-width: 500px;
+      }
+    }
+  }
+
   .text-muted {
     color: $ui-fleet-black-50;
   }


### PR DESCRIPTION
## Issue
Cerra #20683 

## Description
- Bug: Condense down to 3 columns doesn't happen until after data overflows container
- Fix: Condense down to 3 columns when smaller than breakpoint large, condense down to 2 columns when smaller than breakpoint medium
- Fix: Convert to flexboxes from display grid. Why? Grid creates a fixed height per box so if extremely long URL or emails are wrapped onto a 3rd line, it will make all grid boxes 3 lines in height, which looks bad

## Screenrecording of fix
https://www.loom.com/share/151d47ce93314bd782ef9df8eafc3aac?sid=a6359ca9-5492-4448-8fe4-4d567b06d9e8

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
- [x] Manual QA for all new/changed functionality

