### PR TITLE
Add GitOps docs for "No team"

### DIFF
--- a/docs/Configuration/yaml-files.md
+++ b/docs/Configuration/yaml-files.md
@@ -92,7 +92,7 @@ policies:
     package_path: "../lib/software/firefox.deb.package.yml"
 ```
 
-`default.yml` or `teams/team-name.yml`
+`default.yml`, `teams/team-name.yml`, or `teams/no-team.yml`
 
 ```yaml
 policies:

--- a/docs/Configuration/yaml-files.md
+++ b/docs/Configuration/yaml-files.md
@@ -375,6 +375,15 @@ $installProcess = Start-Process $exeFilePath `
     -PassThru -Verb RunAs -Wait
 ```
 
+`default.yml or teams/team-name.yml`
+
+```yaml
+software:
+  packages:
+    - path: ..lib/software-name.package.yml
+# path is relative to default.yml or teams/team-name.yml
+```
+
 ### org_settings and team_settings
 
 #### features

--- a/docs/Configuration/yaml-files.md
+++ b/docs/Configuration/yaml-files.md
@@ -8,7 +8,7 @@ To learn how to set up a GitOps workflow see the [Fleet GitOps repo](https://git
 
 - `default.yml` - File where you define the queries, policies and agent options for all hosts. If you're using Fleet Premium, this file updates queries and policies that run on all hosts ("All teams"). 
 - `teams/no-team.yml` - File where you define the policies, controls, and software for hosts on "No team". Available in Fleet Premium. 
-- `teams/` - Folder where you define your teams in Fleet. These `teams/team-name.yml` files define the controls, queries, policies, software, and agent options for hosts assigned to the specified team. Teams are available in Fleet Premium.
+- `teams/` - Folder where you define your teams in Fleet. These `teams/team-name.yml` files define the controls, queries, policies, software, and agent options for hosts assigned to the specified team. Available in Fleet Premium.
 - `lib/` - Folder where you define policies, queries, configuration profiles, scripts, and agent options. These files can be referenced in top level keys in the `default.yml` file and the files in the `teams/` folder.
 - `.github/workflows/workflow.yml` - The GitHub workflow file where you can add [environment variables](https://docs.github.com/en/actions/learn-github-actions/variables#defining-environment-variables-for-a-single-workflow).
 

--- a/docs/Configuration/yaml-files.md
+++ b/docs/Configuration/yaml-files.md
@@ -6,8 +6,9 @@ To learn how to set up a GitOps workflow see the [Fleet GitOps repo](https://git
 
 ## File structure
 
-- `default.yml`- File where you define the queries, policies, controls, and agent options for all hosts. If you're using Fleet Premium, this file updates queries and policies that run on all hosts ("All teams"). Controls and agent options are defined for hosts on "No team."
-- `teams/` - Folder where you define your teams in Fleet. These `teams/team-name.yml` files define the controls, queries, policies, and agent options for hosts assigned to the specified team. Teams are available in Fleet Premium.
+- `default.yml` - File where you define the queries, policies and agent options for all hosts. If you're using Fleet Premium, this file updates queries and policies that run on all hosts ("All teams"). 
+- `teams/no-team.yml` - File where you define the policies, controls, and software for hosts on "No team". This file must have the `name: No team`.
+- `teams/` - Folder where you define your teams in Fleet. These `teams/team-name.yml` files define the controls, queries, policies, software, and agent options for hosts assigned to the specified team. Teams are available in Fleet Premium.
 - `lib/` - Folder where you define policies, queries, configuration profiles, scripts, and agent options. These files can be referenced in top level keys in the `default.yml` file and the files in the `teams/` folder.
 - `.github/workflows/workflow.yml` - The GitHub workflow file where you can add [environment variables](https://docs.github.com/en/actions/learn-github-actions/variables#defining-environment-variables-for-a-single-workflow).
 
@@ -24,8 +25,7 @@ name: # Only teams/team-name.yml. To edit a team's name, change `name` but don't
 policies:
 queries:
 agent_options:
-controls:
-software:
+controls: # Can be defined in teams/no-team.yml too.
 org_settings: # Only default.yml
 team_settings: # Only teams/team-name.yml
 ```
@@ -40,6 +40,8 @@ team_settings: # Only teams/team-name.yml
 ### policies
 
 Polcies can be specified inline in your `default.yml` file or `teams/team-name.yml` files. They can also be specified in separate files in your `lib/` folder.
+Policies defined in `default.yml` run on **all** hosts.
+Policies defined in `teams/no-team.yml` run on hosts that belong to "No team".
 
 #### Options
 
@@ -81,6 +83,13 @@ policies:
   platform: darwin
   critical: false
   calendar_event_enabled: false
+- name: Firefox on Linux installed and up to date
+  platform: linux
+  description: "This policy checks that Firefox is installed and up to date."
+  resolution: "Install Firefox version 129.0.2 or higher."
+  query: "SELECT 1 FROM deb_packages WHERE name = 'firefox' AND version_compare(version, '129.0.2') >= 0;"
+  install_software:
+    package_path: "../lib/software/firefox.deb.software.yml"
 ```
 
 `default.yml` or `teams/team-name.yml`
@@ -210,6 +219,8 @@ queries:
 
 The `controls` section allows you to configure scripts and device management (MDM) features in Fleet.
 
+Controls for hosts that are in "No team" can be defined in `default.yml` or in `teams/no-team.yml` (but not in both files).
+
 - `scripts` is a list of paths to macOS, Windows, or Linux scripts.
 - `windows_enabled_and_configured` specifies whether or not to turn on Windows MDM features (default: `false`). Can only be configured for all teams (`default.yml`).
 - `enable_disk_encryption` specifies whether or not to enforce disk encryption on macOS and Windows hosts (default: `false`).
@@ -304,11 +315,15 @@ Can only be configure for all teams (`default.yml`).
 > **Experimental feature**. This feature is undergoing rapid improvement, which may result in breaking changes to the API or configuration surface. It is not recommended for use in automated workflows.
 
 The `software` section allows you to configure packages and Apple App Store apps that you want to install on your hosts.
+Software for hosts that belong to "No team" have to be defined in `teams/no-team.yml`.
+Software can also be specified in separate files in your `lib/` folder.
 
 - `packages` is a list of software packages (.pkg, .msi, .exe, or .deb) and software specific options.
 - `app_store_apps` is a list of Apple App Store apps.
 
-##### Example
+#### Example
+
+##### Inline
 
 ```yaml
 software:
@@ -326,7 +341,7 @@ software:
    - app_store_id: '1091189122'
 ```
 
-#### packages
+##### packages
 
 - `url` specifies the URL at which the software is located. Fleet will download the software and upload it to S3 (default: `""`).
 - `install_script.path` specifies the command Fleet will run on hosts to install software. The [default script](https://github.com/fleetdm/fleet/tree/main/pkg/file/scripts) is dependent on the software type (i.e. .pkg).
@@ -334,11 +349,31 @@ software:
 - `post_install_script.path` is the script Fleet will run on hosts after intalling software (default: `""`).
 - `self_service` specifies whether or not end users can install from **Fleet Desktop > Self-service**.
 
-#### app_store_apps
+##### app_store_apps
 
 - `app_store_id` is the ID of the Apple App Store app. You can find this at the end of the app's App Store URL. For example, "Bear - Markdown Notes" URL is "https://apps.apple.com/us/app/bear-markdown-notes/id1016366447" and the `app_store_id` is `1016366447`.
 
 > Make sure to include only the ID itself, and not the `id` prefix shown in the URL. The ID must be wrapped in quotes as shown in the example so that it is processed as a string. 
+
+##### Separate file
+
+`lib/software/tailscale.exe.software.yml`:
+
+```yaml
+url: https://dl.tailscale.com/stable/tailscale-setup-1.72.0.exe
+install_script:
+  path: ../lib/software/tailscale-install-script.ps1
+self_sergice: true
+```
+
+`lib/software/tailscale-install-script.ps1`
+
+```yaml
+$exeFilePath = "${env:INSTALLER_PATH}"
+$installProcess = Start-Process $exeFilePath `
+  -ArgumentList "/quiet /norestart" `
+    -PassThru -Verb RunAs -Wait
+```
 
 ### org_settings and team_settings
 

--- a/docs/Configuration/yaml-files.md
+++ b/docs/Configuration/yaml-files.md
@@ -363,7 +363,7 @@ software:
 url: https://dl.tailscale.com/stable/tailscale-setup-1.72.0.exe
 install_script:
   path: ../lib/software/tailscale-install-script.ps1
-self_sergice: true
+self_service: true
 ```
 
 `lib/software/tailscale-install-script.ps1`

--- a/docs/Configuration/yaml-files.md
+++ b/docs/Configuration/yaml-files.md
@@ -89,7 +89,7 @@ policies:
   resolution: "Install Firefox version 129.0.2 or higher."
   query: "SELECT 1 FROM deb_packages WHERE name = 'firefox' AND version_compare(version, '129.0.2') >= 0;"
   install_software:
-    package_path: "../lib/software/firefox.deb.software.yml"
+    package_path: "../lib/software/firefox.deb.package.yml"
 ```
 
 `default.yml` or `teams/team-name.yml`
@@ -380,7 +380,7 @@ $installProcess = Start-Process $exeFilePath `
 ```yaml
 software:
   packages:
-    - path: ..lib/software-name.package.yml
+    - path: ../lib/software-name.package.yml
 # path is relative to default.yml or teams/team-name.yml
 ```
 

--- a/docs/Configuration/yaml-files.md
+++ b/docs/Configuration/yaml-files.md
@@ -375,7 +375,7 @@ $installProcess = Start-Process $exeFilePath `
     -PassThru -Verb RunAs -Wait
 ```
 
-`default.yml or teams/team-name.yml`
+`default.yml`, `teams/team-name.yml`, or `teams/no-team.yml`
 
 ```yaml
 software:

--- a/docs/Configuration/yaml-files.md
+++ b/docs/Configuration/yaml-files.md
@@ -7,7 +7,7 @@ To learn how to set up a GitOps workflow see the [Fleet GitOps repo](https://git
 ## File structure
 
 - `default.yml` - File where you define the queries, policies and agent options for all hosts. If you're using Fleet Premium, this file updates queries and policies that run on all hosts ("All teams"). 
-- `teams/no-team.yml` - File where you define the policies, controls, and software for hosts on "No team". This file must have the `name: No team`.
+- `teams/no-team.yml` - File where you define the policies, controls, and (for Fleet Premium) software for hosts on "No team". This file must have the `name: No team` attribute.
 - `teams/` - Folder where you define your teams in Fleet. These `teams/team-name.yml` files define the controls, queries, policies, software, and agent options for hosts assigned to the specified team. Teams are available in Fleet Premium.
 - `lib/` - Folder where you define policies, queries, configuration profiles, scripts, and agent options. These files can be referenced in top level keys in the `default.yml` file and the files in the `teams/` folder.
 - `.github/workflows/workflow.yml` - The GitHub workflow file where you can add [environment variables](https://docs.github.com/en/actions/learn-github-actions/variables#defining-environment-variables-for-a-single-workflow).

--- a/docs/Configuration/yaml-files.md
+++ b/docs/Configuration/yaml-files.md
@@ -357,7 +357,7 @@ software:
 
 ##### Separate file
 
-`lib/software/tailscale.exe.software.yml`:
+`lib/software-name.package.yml`:
 
 ```yaml
 url: https://dl.tailscale.com/stable/tailscale-setup-1.72.0.exe

--- a/docs/Configuration/yaml-files.md
+++ b/docs/Configuration/yaml-files.md
@@ -89,7 +89,7 @@ policies:
   resolution: "Install Firefox version 129.0.2 or higher."
   query: "SELECT 1 FROM deb_packages WHERE name = 'firefox' AND version_compare(version, '129.0.2') >= 0;"
   install_software:
-    package_path: "../lib/software/firefox.deb.package.yml"
+    package_path: "../lib/linux-firefox.deb.package.yml"
 ```
 
 `default.yml`, `teams/team-name.yml`, or `teams/no-team.yml`

--- a/docs/Configuration/yaml-files.md
+++ b/docs/Configuration/yaml-files.md
@@ -7,7 +7,7 @@ To learn how to set up a GitOps workflow see the [Fleet GitOps repo](https://git
 ## File structure
 
 - `default.yml` - File where you define the queries, policies and agent options for all hosts. If you're using Fleet Premium, this file updates queries and policies that run on all hosts ("All teams"). 
-- `teams/no-team.yml` - File where you define the policies, controls, and (for Fleet Premium) software for hosts on "No team". This file must have the `name: No team` attribute.
+- `teams/no-team.yml` - File where you define the policies, controls, and software for hosts on "No team". Available in Fleet Premium. 
 - `teams/` - Folder where you define your teams in Fleet. These `teams/team-name.yml` files define the controls, queries, policies, software, and agent options for hosts assigned to the specified team. Teams are available in Fleet Premium.
 - `lib/` - Folder where you define policies, queries, configuration profiles, scripts, and agent options. These files can be referenced in top level keys in the `default.yml` file and the files in the `teams/` folder.
 - `.github/workflows/workflow.yml` - The GitHub workflow file where you can add [environment variables](https://docs.github.com/en/actions/learn-github-actions/variables#defining-environment-variables-for-a-single-workflow).


### PR DESCRIPTION
- @noahtalerman: I closed this PR and opened a new one [here](https://github.com/fleetdm/fleet/pull/22307) (w/ same changes) against the docs-v4.57.0 branch.

As of 4.57.0, each minor release has it's own reference docs branch as part of a new process to make sure that every change to how Fleet is used is reflected live on the website in reference documentation at release day: https://github.com/fleetdm/fleet/pull/22284/files#diff-d426c2ae6cac2a2baffd54adae00ad7bb936dbb17a873f93a327d5763f7fb574R141

---
Docs for #21790.