### PR TITLE
Handbook: Update drafting steps

### DIFF
--- a/handbook/product-design/README.md
+++ b/handbook/product-design/README.md
@@ -36,9 +36,9 @@ At Fleet, like [GitLab](https://about.gitlab.com/handbook/product-development-fl
   -  **Ready.** Use this page to communicate designs reviews and development.
   -  **Scratchpad.** Use this page for work in progress and design that might be useful in the future.
 
-- If the story requires API or YAML file changes, open a draft PR with the proposed design.
+- If the story requires API, YAML file, or other reference documentation changes, open a pull request to the reference docs release branch (e.g. `docs-v4.58.0`) with the proposed design. Mark the PR ready for review as soon as it's ready for feedback from the [API design DRI](https://fleetdm.com/handbook/company/communications#directly-responsible-individuals-dris).
 
-- Add links to the Figma file's cover page and draft PRs in the user story.
+- Add links to the user story as specified in the current [issue template](https://github.com/fleetdm/fleet/issues/new?template=story.md).
 
 - Draft changes to the Fleet product that solve the problem specified in the story. Constantly place yourself in the shoes of a user while drafting changes. Place these drafts in the appropriate Figma file in Fleet product project.
 

--- a/handbook/product-design/README.md
+++ b/handbook/product-design/README.md
@@ -38,7 +38,7 @@ At Fleet, like [GitLab](https://about.gitlab.com/handbook/product-development-fl
 
 - If the story requires API, YAML file, or other reference documentation changes, open a pull request to the reference docs release branch (e.g. `docs-v4.58.0`) with the proposed design. Mark the PR ready for review as soon as it's ready for feedback from the [API design DRI](https://fleetdm.com/handbook/company/communications#directly-responsible-individuals-dris).
 
-- Add links to the user story as specified in the current [issue template](https://github.com/fleetdm/fleet/issues/new?template=story.md).
+- Add links to the user story as specified in the [issue template](https://github.com/fleetdm/fleet/issues/new?template=story.md).
 
 - Draft changes to the Fleet product that solve the problem specified in the story. Constantly place yourself in the shoes of a user while drafting changes. Place these drafts in the appropriate Figma file in Fleet product project.
 

--- a/handbook/product-design/README.md
+++ b/handbook/product-design/README.md
@@ -36,7 +36,7 @@ At Fleet, like [GitLab](https://about.gitlab.com/handbook/product-development-fl
   -  **Ready.** Use this page to communicate designs reviews and development.
   -  **Scratchpad.** Use this page for work in progress and design that might be useful in the future.
 
-- If the story requires API, YAML file, or other reference documentation changes, open a pull request to the reference docs release branch (e.g. `docs-v4.58.0`) with the proposed design. Mark the PR ready for review as soon as it's ready for feedback from the [API design DRI](https://fleetdm.com/handbook/company/communications#directly-responsible-individuals-dris).
+- If the story requires API or YAML file changes, open a pull request to the reference docs release branch (e.g. `docs-v4.58.0`) with the proposed design. Mark the PR ready for review as soon as it's ready for feedback from the [API design DRI](https://fleetdm.com/handbook/company/communications#directly-responsible-individuals-dris).
 
 - Add links to the user story as specified in the [issue template](https://github.com/fleetdm/fleet/issues/new?template=story.md).
 


### PR DESCRIPTION
- Update where to make reference doc PRs (use reference doc release branch)
- Point toward story issue template re: what to link to in issues (since it's always evolving)