### PR TITLE
Use sync.Map for stubbed key-value store to avoid data races in GitOps test

### DIFF
--- a/cmd/fleetctl/gitops_test.go
+++ b/cmd/fleetctl/gitops_test.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"slices"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -2919,24 +2920,23 @@ software:
 }
 
 type memKeyValueStore struct {
-	m map[string]string
+	m sync.Map
 }
 
 func newMemKeyValueStore() *memKeyValueStore {
-	return &memKeyValueStore{
-		m: make(map[string]string),
-	}
+	return &memKeyValueStore{}
 }
 
 func (m *memKeyValueStore) Set(ctx context.Context, key string, value string, expireTime time.Duration) error {
-	m.m[key] = value
+	m.m.Store(key, value)
 	return nil
 }
 
 func (m *memKeyValueStore) Get(ctx context.Context, key string) (*string, error) {
-	v, ok := m.m[key]
+	v, ok := m.m.Load(key)
 	if !ok {
 		return nil, nil
 	}
-	return &v, nil
+	vAsString := v.(string)
+	return &vAsString, nil
 }


### PR DESCRIPTION
This override only happens in testing, so this isn't release-blocking, but this is the quickest way to clean up a test that will otherwise be flaky due to data races, at the cost of performance (vs. setting up a more complex solution with mutexes).

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Added/updated tests
- [x] Manual QA for all new/changed functionality (via manually running test using the KV store)