### PR TITLE
Fleet UI: Hide redundant built in label filtering

### DIFF
--- a/changes/21343-hide-redundant-built-in-label-pills
+++ b/changes/21343-hide-redundant-built-in-label-pills
@@ -1,0 +1,1 @@
+- UI: Remove redundant built in label filter pills

--- a/frontend/pages/hosts/ManageHostsPage/components/HostsFilterBlock/HostsFilterBlock.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/components/HostsFilterBlock/HostsFilterBlock.tsx
@@ -24,6 +24,7 @@ import {
 
 import {
   PLATFORM_LABEL_DISPLAY_NAMES,
+  PLATFORM_TYPE_ICONS,
   isPlatformLabelNameFromAPI,
   PolicyResponse,
 } from "utilities/constants";
@@ -40,6 +41,8 @@ import DiskEncryptionStatusFilter from "../DiskEncryptionStatusFilter";
 import BootstrapPackageStatusFilter from "../BootstrapPackageStatusFilter/BootstrapPackageStatusFilter";
 
 const baseClass = "hosts-filter-block";
+
+type PlatformLabelNameFromAPI = keyof typeof PLATFORM_TYPE_ICONS;
 
 interface IHostsFilterBlockProps {
   /**
@@ -144,6 +147,16 @@ const HostsFilterBlock = ({
         (isPlatformLabelNameFromAPI(display_text) &&
           PLATFORM_LABEL_DISPLAY_NAMES[display_text]) ||
         display_text;
+
+      // Hide built-in labels supported in label dropdown
+      if (
+        label_type === "builtin" &&
+        Object.keys(PLATFORM_TYPE_ICONS).includes(
+          display_text as PlatformLabelNameFromAPI
+        )
+      ) {
+        return <></>;
+      }
 
       return (
         <>

--- a/frontend/pages/hosts/ManageHostsPage/components/LabelFilterSelect/_styles.scss
+++ b/frontend/pages/hosts/ManageHostsPage/components/LabelFilterSelect/_styles.scss
@@ -158,7 +158,7 @@
     min-width: 220px;
 
     &__single-value {
-      max-width: 135px !important; // Must override default styling of .css-qc6sy-singleValue
+      max-width: 210px !important; // Must override default styling of .css-qc6sy-singleValue
     }
   }
 }


### PR DESCRIPTION
## Issue
Cerra #21343 

## Description
- Hides redundant built in label filtering if the built in label is a part of the dropdown
- Clean up long label names awkwardly truncating much less wider than the dropdown space provided for the name

NOTE: We can't remove it for all labels as there's no other UI to get to edit/delete a custom label nor unclick a built in label that is not supported by the dropdown

## Screenrecording
https://www.loom.com/share/5ec6b869f81140f1baed4186871e1bc6?sid=e79788df-9cdb-4e39-85ef-8734ae3f8e3f

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
- [x] Manual QA for all new/changed functionality
