### PR TITLE
Fleet UI: Fix self-service icon from cutting off

### DIFF
--- a/frontend/pages/hosts/details/cards/Software/SelfService/SelfServiceItem/_styles.scss
+++ b/frontend/pages/hosts/details/cards/Software/SelfService/SelfServiceItem/_styles.scss
@@ -13,7 +13,7 @@
   &__item-topline {
     display: flex;
     flex-direction: row;
-    height: 64px;
+    height: 66px;
     align-items: center;
     gap: 16px;
     overflow: hidden;


### PR DESCRIPTION
## Issue
Cerra #21674 

## Description
- Height didn't take into account 2px of border

## Screenshot of fix
<img width="936" alt="Screenshot 2024-09-23 at 12 37 58 PM" src="https://github.com/user-attachments/assets/eb8a1ba6-c916-422a-8347-2d564822bf6b">


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

   - [x] Manual QA must be performed in the three main OSs, macOS, Windows and Linux.

