### PR TITLE
Fleet UI: Host status dropdown styling fixes

### DIFF
--- a/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
@@ -1430,16 +1430,11 @@ const ManageHostsPage = ({
         ? selectedLabel
         : undefined;
 
-    const statusDropdownClassnames = classNames(
-      `${baseClass}__status_dropdown`,
-      { [`${baseClass}__status-dropdown-sandbox`]: isSandboxMode }
-    );
-
     return (
       <div className={`${baseClass}__filter-dropdowns`}>
         <Dropdown
           value={status || ""}
-          className={statusDropdownClassnames}
+          className={`${baseClass}__status_dropdown`}
           options={getHostSelectStatuses(isSandboxMode)}
           searchable={false}
           onChange={handleStatusDropdownChange}

--- a/frontend/pages/hosts/ManageHostsPage/_styles.scss
+++ b/frontend/pages/hosts/ManageHostsPage/_styles.scss
@@ -233,6 +233,7 @@
 
     .Select-menu-outer {
       width: 364px;
+      max-height: min-content;
 
       .Select-menu {
         max-height: none;

--- a/frontend/pages/hosts/ManageHostsPage/_styles.scss
+++ b/frontend/pages/hosts/ManageHostsPage/_styles.scss
@@ -121,13 +121,6 @@
               line-height: 38px;
             }
           }
-
-          .manage-hosts__status-dropdown-sandbox {
-            width: auto;
-            .Select-control {
-              width: 182px;
-            }
-          }
         }
       }
     }
@@ -182,12 +175,6 @@
 
             .manage-hosts__status_dropdown {
               width: auto;
-            }
-
-            .manage-hosts__status-dropdown-sandbox {
-              .Select-control {
-                width: 100%;
-              }
             }
           }
         }
@@ -246,7 +233,6 @@
 
     .Select-menu-outer {
       width: 364px;
-      max-height: 325px;
 
       .Select-menu {
         max-height: none;

--- a/frontend/pages/hosts/details/cards/Software/_styles.scss
+++ b/frontend/pages/hosts/details/cards/Software/_styles.scss
@@ -9,7 +9,7 @@
       .Select {
         .Select-menu-outer {
           width: 364px;
-          max-height: 310px;
+          max-height: min-content;
 
           .Select-menu {
             max-height: none;

--- a/frontend/pages/queries/ManageQueriesPage/_styles.scss
+++ b/frontend/pages/queries/ManageQueriesPage/_styles.scss
@@ -63,7 +63,7 @@
     &__platform-dropdown {
       .Select-menu-outer {
         width: 364px;
-        max-height: 380px;
+        max-height: min-content;
 
         .Select-menu {
           max-height: none;


### PR DESCRIPTION
## Issue
Cerra #21129 

## Description
- Remove `max-height` causing the dropdown options to be cut off
- Looks like the centering bug was already fixed (likely global fix happened with work on software dropdown options)

Note: Also removed some related sandbox code (context: sandbox is a deprecated feature we had for users to trial premium and it's been a long run of trying to remove all related code)

## Screenshot of 1 of the fixes
<img width="797" alt="Screenshot 2024-09-23 at 12 51 48 PM" src="https://github.com/user-attachments/assets/2b146276-8b8f-483d-b444-95af1c55fc0e">


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Manual QA for all new/changed functionality
