### PR TITLE
update the help text of macOS min version input

### DIFF
--- a/frontend/pages/ManageControlsPage/OSUpdates/components/AppleOSTargetForm/AppleOSTargetForm.tsx
+++ b/frontend/pages/ManageControlsPage/OSUpdates/components/AppleOSTargetForm/AppleOSTargetForm.tsx
@@ -5,12 +5,13 @@ import { APP_CONTEXT_NO_TEAM_ID } from "interfaces/team";
 import { NotificationContext } from "context/notification";
 import configAPI from "services/entities/config";
 import teamsAPI from "services/entities/teams";
+import { ApplePlatform } from "interfaces/platform";
 
 // @ts-ignore
 import InputField from "components/forms/fields/InputField";
 import Button from "components/buttons/Button";
 import validatePresence from "components/forms/validators/validate_presence";
-import { ApplePlatform } from "interfaces/platform";
+import CustomLink from "components/CustomLink";
 
 const baseClass = "apple-os-target-form";
 
@@ -197,7 +198,16 @@ const AppleOSTargetForm = ({
       <InputField
         label="Minimum version"
         tooltip={getMinimumVersionTooltip()}
-        helpText="Version number only (e.g., “13.0.1” not “Ventura 13” or “13.0.1 (22A400)”)"
+        helpText={
+          <>
+            Use only versions available from Apple.{" "}
+            <CustomLink
+              text="Learn more"
+              newTab
+              url="https://fleetdm.com/learn-more-about/available-os-update-versions"
+            />
+          </>
+        }
         value={minOsVersion}
         error={minOsVersionError}
         onChange={handleMinVersionChange}


### PR DESCRIPTION
relates to #21976

This updates the help text for the macOS min version input.

![image](https://github.com/user-attachments/assets/ef20ad99-7592-41bc-959e-a90129c47f66)
