### PR TITLE
update CODEOWNERS to allow fleetdm/go to review orbit code

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -41,7 +41,7 @@ go.mod @fleetdm/go
 /cmd/ @fleetdm/go
 /server/ @fleetdm/go
 /ee/server/ @fleetdm/go
-/orbit/ @lucasmrod @roperzh @lukeheath @georgekarrv @sharon-fdm
+/orbit/ @fleetdm/go
 
 ##############################################################################################
 # 🚀 React files and other files related to the core product frontend.


### PR DESCRIPTION
hey @lukeheath I was going to ask you in Slack but I figured this might be easier if you decide to change it.

should `fleetdm/go` own orbit changes as well? if not feel free to close this PR (or shout and I can close it)