### PR TITLE
Update automatic-software-install-in-fleet.md

### DIFF
--- a/articles/automatic-software-install-in-fleet.md
+++ b/articles/automatic-software-install-in-fleet.md
@@ -76,5 +76,4 @@ By automating software deployment, you can gain greater control over what's inst
 <meta name="authorGitHubUsername" value="sharon-fdm">
 <meta name="category" value="guides">
 <meta name="publishedOn" value="2024-09-23">
-<meta name="articleImageUrl" value="../website/assets/images/articles/deploy-security-agents-1600x900@2x.png">
 <meta name="description" value="A guide to workflows using automatic software installation in Fleet.">

--- a/articles/automatic-software-install-in-fleet.md
+++ b/articles/automatic-software-install-in-fleet.md
@@ -76,5 +76,5 @@ By automating software deployment, you can gain greater control over what's inst
 <meta name="authorGitHubUsername" value="sharon-fdm">
 <meta name="category" value="guides">
 <meta name="publishedOn" value="2024-09-23">
-<meta name="articleImageUrl" value=""../website/assets/images/articles/deploy-security-agents-1600x900@2x.png">
+<meta name="articleImageUrl" value="../website/assets/images/articles/deploy-security-agents-1600x900@2x.png">
 <meta name="description" value="A guide to workflows using automatic software installation in Fleet.">

--- a/articles/automatic-software-install-in-fleet.md
+++ b/articles/automatic-software-install-in-fleet.md
@@ -76,5 +76,5 @@ By automating software deployment, you can gain greater control over what's inst
 <meta name="authorGitHubUsername" value="sharon-fdm">
 <meta name="category" value="guides">
 <meta name="publishedOn" value="2024-09-23">
-<meta name="articleImageUrl" value="../website/assets/images/articles/automatic-software-install-in-fleet-731x738@2x.png">
+<meta name="articleImageUrl" value=""../website/assets/images/articles/deploy-security-agents-1600x900@2x.png">
 <meta name="description" value="A guide to workflows using automatic software installation in Fleet.">


### PR DESCRIPTION
Current article image wasn't rendering on the site as it wasn't present in the repo. Removing meta tag for the article image so that it can resort to the Fleet logo.

![](https://github.com/user-attachments/assets/23c97aa5-d8e2-46bf-8cee-bb27b7a1685e)

This is only visible when visiting [fleetdm.com/articles](fleetdm.com/articles)

https://fleetdm.com/guides renders the articles without the article images. Just something to be aware of 😄