### PR TITLE
Fleet UI: Surface duplicate label name error to users

### DIFF
--- a/changes/21875-duplicate-label-name
+++ b/changes/21875-duplicate-label-name
@@ -1,0 +1,1 @@
+- Fleet UI: Surface duplicate label name error to user

--- a/frontend/pages/labels/NewLabelPage/ManualLabel/ManualLabel.tsx
+++ b/frontend/pages/labels/NewLabelPage/ManualLabel/ManualLabel.tsx
@@ -1,29 +1,40 @@
-import React, { useContext } from "react";
+import React, { useCallback, useContext } from "react";
 import { RouteComponentProps } from "react-router";
 
 import PATHS from "router/paths";
 import labelsAPI from "services/entities/labels";
 import { NotificationContext } from "context/notification";
+import { IApiError } from "interfaces/errors";
 
 import ManualLabelForm from "pages/labels/components/ManualLabelForm";
 import { IManualLabelFormData } from "pages/labels/components/ManualLabelForm/ManualLabelForm";
 
 const baseClass = "manual-label";
 
+export const DUPLICATE_ENTRY_ERROR =
+  "Couldn't add. A label with this name already exists.";
+
 type IManualLabelProps = RouteComponentProps<never, never>;
 
 const ManualLabel = ({ router }: IManualLabelProps) => {
   const { renderFlash } = useContext(NotificationContext);
 
-  const onSaveNewLabel = async (formData: IManualLabelFormData) => {
-    try {
-      const res = await labelsAPI.create(formData);
-      router.push(PATHS.MANAGE_HOSTS_LABEL(res.label.id));
-      renderFlash("success", "Label added successfully.");
-    } catch {
-      renderFlash("error", "Couldn't add label. Please try again.");
-    }
-  };
+  const onSaveNewLabel = useCallback(
+    (formData: IManualLabelFormData) => {
+      labelsAPI
+        .create(formData)
+        .then((res) => {
+          router.push(PATHS.MANAGE_HOSTS_LABEL(res.label.id));
+          renderFlash("success", "Label added successfully.");
+        })
+        .catch((error: { data: IApiError }) => {
+          if (error.data.errors[0].reason.includes("Duplicate entry")) {
+            renderFlash("error", DUPLICATE_ENTRY_ERROR);
+          } else renderFlash("error", "Couldn't add label. Please try again.");
+        });
+    },
+    [renderFlash, router]
+  );
 
   const onCancelLabel = () => {
     router.goBack();


### PR DESCRIPTION
## Issue
Cerra #21875 

## Description
- Surface duplicate label name error to users on dynamic and manual label pages

## Screenshot of fix
<img width="840" alt="Screenshot 2024-09-25 at 8 58 13 AM" src="https://github.com/user-attachments/assets/1c58d15b-b3df-4ad7-afad-0ab0f26c94ca">



# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
- [x] Manual QA for all new/changed functionality
