### PR TITLE
Fleet UI: Fix host software filter dropdown to persist other changes

### DIFF
--- a/changes/21594-host-software-filter-bug
+++ b/changes/21594-host-software-filter-bug
@@ -1,0 +1,1 @@
+- Fleet UI: Fix host software filter bug that resets dropdown filter on table changes (pagination, order by column, etc)

--- a/frontend/pages/hosts/details/cards/Software/HostSoftwareTable/HostSoftwareTable.tsx
+++ b/frontend/pages/hosts/details/cards/Software/HostSoftwareTable/HostSoftwareTable.tsx
@@ -118,6 +118,7 @@ const HostSoftwareTable = ({
       />
     );
   }, [handleFilterDropdownChange, hostSoftwareFilter]);
+
   const determineQueryParamChange = useCallback(
     (newTableQuery: ITableQueryData) => {
       const changedEntry = Object.entries(newTableQuery).find(([key, val]) => {
@@ -148,9 +149,15 @@ const HostSoftwareTable = ({
         page: changedParam === "pageIndex" ? newTableQuery.pageIndex : 0,
       };
 
+      if (hostSoftwareFilter === "vulnerableSoftware") {
+        newQueryParam.vulnerable = "true";
+      } else if (hostSoftwareFilter === "installableSoftware") {
+        newQueryParam.available_for_install = "true";
+      }
+
       return newQueryParam;
     },
-    []
+    [hostSoftwareFilter]
   );
 
   // TODO: Look into useDebounceCallback with dependencies


### PR DESCRIPTION
## Issue
Cerra #21594 

## Description
- Fixes host software dropdown filter to persist other table changes

## Screenrecording of fix
https://www.loom.com/share/0188c292092644ce96ae276c6388793a?sid=dad2b60a-e05e-4c69-aba2-d3ac84d16d47

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
- [x] Manual QA for all new/changed functionality

