### PR TITLE
Fleet UI: Make delete host modal generic for ABM/fleetd hosts deletion

### DIFF
--- a/frontend/pages/hosts/components/DeleteHostModal/DeleteHostModal.tsx
+++ b/frontend/pages/hosts/components/DeleteHostModal/DeleteHostModal.tsx
@@ -69,17 +69,6 @@ const DeleteHostModal = ({
         <p>
           This will remove the record of <b>{hostText()}</b>.{largeVolumeText()}
         </p>
-        <p>
-          The {pluralizeHost()} will re-appear unless fleet&apos;s agent is
-          uninstalled.
-        </p>
-        <p>
-          <CustomLink
-            url={"https://fleetdm.com/learn-more-about/uninstall-fleetd"}
-            text="Uninstall Fleet's agent"
-            newTab
-          />
-        </p>
         <div className="modal-cta-wrap">
           <Button
             type="button"


### PR DESCRIPTION
## Issue
Cerra #21529 

## Description
- Product decision to make delete host modal generic and not give info on why a host will reappear after removal

## Screenshot of fix
<img width="1114" alt="Screenshot 2024-09-25 at 10 00 03 AM" src="https://github.com/user-attachments/assets/8b8113d6-e7a5-43ed-818e-ff654063c659">


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Manual QA for all new/changed functionality
