### PR TITLE
Fleet UI: Fleet free does not see empty severity column

### DIFF
--- a/changes/22159-hide-severity-fleet-free
+++ b/changes/22159-hide-severity-fleet-free
@@ -1,0 +1,1 @@
+- Hide CVSS severity column from Fleet Free software details > vulnerabilities sections

--- a/frontend/pages/SoftwarePage/components/SoftwareVulnerabilitiesTable/SoftwareVulnerabilitiesTableConfig.tsx
+++ b/frontend/pages/SoftwarePage/components/SoftwareVulnerabilitiesTable/SoftwareVulnerabilitiesTableConfig.tsx
@@ -247,7 +247,8 @@ const generateTableConfig = (
     return tableHeaders.filter(
       (header) =>
         header.accessor !== "epss_probability" &&
-        header.accessor !== "cve_published"
+        header.accessor !== "cve_published" &&
+        header.accessor !== "cvss_score"
     );
   }
 


### PR DESCRIPTION
## Issue
Cerra #22159 

## Description
- Hide Severity column from Fleet Free on software/versions/:id and software/os/:id details page

## Screenshot of fix
<img width="1625" alt="Screenshot 2024-09-25 at 1 54 30 PM" src="https://github.com/user-attachments/assets/d9ccc974-4168-4120-af8e-f5a3d8bb2e39">


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
- [x] Manual QA for all new/changed functionality

