### PR TITLE
Fleet UI: Fix policy automation truncation when auto-install software

### DIFF
--- a/changes/22197-policy-auto-software-truncation
+++ b/changes/22197-policy-auto-software-truncation
@@ -1,0 +1,1 @@
+- Fleet UI: Fix policy automation truncation when selecting software to auto-install

--- a/frontend/pages/policies/ManagePoliciesPage/components/InstallSoftwareModal/InstallSoftwareModal.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/components/InstallSoftwareModal/InstallSoftwareModal.tsx
@@ -174,7 +174,7 @@ const InstallSoftwareModal = ({
       <li
         className={`${baseClass}__policy-row policy-row`}
         id={`policy-row--${policyId}`}
-        key={policyId}
+        key={`${policyId}-${enabled}`} // Re-renders when modifying enabled for truncation check
       >
         <Checkbox
           value={enabled}


### PR DESCRIPTION
## Issue
Cerra #22197 

## Description
- Fix truncation so when clicking checkbox for auto install software policy automation, the policy name is truncated and doesn't run into the dropdown
- TIL Solution: If the unique key changes, the component re-renders, thus checks for truncation based on new widths

## Screenrecording of fix
https://www.loom.com/share/e3084ef48bc94918affbc7dbbf06a367?sid=01fc8d3b-53b6-4b19-acd1-fc28e18f2913

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
- [x] Manual QA for all new/changed functionality

