### PR TITLE
Fall back to name/source for matching software titles on insert if bundle ID is provided, add missing special case for edit software upload timeout

### DIFF
--- a/changes/21370-bundle-id-quickfix
+++ b/changes/21370-bundle-id-quickfix
@@ -1,0 +1,1 @@
+- Fix "no rows" error when adding a software installer that matches an existing title's name and source but not its bundle ID

--- a/changes/software-edit-request-deadline
+++ b/changes/software-edit-request-deadline
@@ -1,0 +1,1 @@
+* Ensure request timeouts for software installer edits are just as high as for initial software installer uploads

--- a/cmd/fleet/serve.go
+++ b/cmd/fleet/serve.go
@@ -1145,7 +1145,8 @@ the way that the Fleet server works.
 					}
 				}
 
-				if req.Method == http.MethodPost && strings.HasSuffix(req.URL.Path, "/fleet/software/package") {
+				if (req.Method == http.MethodPost && strings.HasSuffix(req.URL.Path, "/fleet/software/package")) ||
+					(req.Method == http.MethodPatch && strings.HasSuffix(req.URL.Path, "/package") && strings.Contains(req.URL.Path, "/fleet/software/titles/")) {
 					// when uploading a software installer, the file might be large so
 					// the read timeout (to read the full request body) must be extended.
 					rc := http.NewResponseController(rw)

--- a/server/datastore/mysql/software_installers.go
+++ b/server/datastore/mysql/software_installers.go
@@ -174,8 +174,9 @@ func (ds *Datastore) getOrGenerateSoftwareInstallerTitleID(ctx context.Context, 
 	insertArgs := []any{payload.Title, payload.Source}
 
 	if payload.BundleIdentifier != "" {
-		selectStmt = `SELECT id FROM software_titles WHERE bundle_identifier = ?`
-		selectArgs = []any{payload.BundleIdentifier}
+		// match by bundle identifier first, or standard matching if we don't have a bundle identifier match
+		selectStmt = `SELECT id FROM software_titles WHERE bundle_identifier = ? OR (name = ? AND source = ? AND browser = '') ORDER BY bundle_identifier = ? DESC LIMIT 1`
+		selectArgs = []any{payload.BundleIdentifier, payload.Title, payload.Source, payload.BundleIdentifier}
 		insertStmt = `INSERT INTO software_titles (name, source, bundle_identifier, browser) VALUES (?, ?, ?, '')`
 		insertArgs = append(insertArgs, payload.BundleIdentifier)
 	}

--- a/server/datastore/mysql/software_installers_test.go
+++ b/server/datastore/mysql/software_installers_test.go
@@ -34,6 +34,7 @@ func TestSoftwareInstallers(t *testing.T) {
 		{"HasSelfServiceSoftwareInstallers", testHasSelfServiceSoftwareInstallers},
 		{"DeleteSoftwareInstallersAssignedToPolicy", testDeleteSoftwareInstallersAssignedToPolicy},
 		{"GetHostLastInstallData", testGetHostLastInstallData},
+		{"GetOrGenerateSoftwareInstallerTitleID", testGetOrGenerateSoftwareInstallerTitleID},
 	}
 
 	for _, c := range cases {
@@ -1097,4 +1098,79 @@ func testGetHostLastInstallData(t *testing.T, ds *Datastore) {
 	host2LastInstall, err = ds.GetHostLastInstallData(ctx, host2.ID, softwareInstallerID2)
 	require.NoError(t, err)
 	require.Nil(t, host2LastInstall)
+}
+
+func testGetOrGenerateSoftwareInstallerTitleID(t *testing.T, ds *Datastore) {
+	ctx := context.Background()
+
+	host1 := test.NewHost(t, ds, "host1", "", "host1key", "host1uuid", time.Now())
+	host2 := test.NewHost(t, ds, "host2", "", "host2key", "host2uuid", time.Now())
+
+	software1 := []fleet.Software{
+		{Name: "Existing Title", Version: "0.0.1", Source: "apps", BundleIdentifier: "existing.title"},
+	}
+	software2 := []fleet.Software{
+		{Name: "Existing Title", Version: "v0.0.2", Source: "apps", BundleIdentifier: "existing.title"},
+		{Name: "Existing Title", Version: "0.0.3", Source: "apps", BundleIdentifier: "existing.title"},
+		{Name: "Existing Title Without Bundle", Version: "0.0.3", Source: "apps"},
+	}
+
+	_, err := ds.UpdateHostSoftware(ctx, host1.ID, software1)
+	require.NoError(t, err)
+	_, err = ds.UpdateHostSoftware(ctx, host2.ID, software2)
+	require.NoError(t, err)
+	require.NoError(t, ds.SyncHostsSoftware(ctx, time.Now()))
+	require.NoError(t, ds.ReconcileSoftwareTitles(ctx))
+	require.NoError(t, ds.SyncHostsSoftwareTitles(ctx, time.Now()))
+
+	tests := []struct {
+		name    string
+		payload *fleet.UploadSoftwareInstallerPayload
+	}{
+		{
+			name: "title that already exists, no bundle identifier in payload",
+			payload: &fleet.UploadSoftwareInstallerPayload{
+				Title:  "Existing Title",
+				Source: "apps",
+			},
+		},
+		{
+			name: "title that already exists, bundle identifier in payload",
+			payload: &fleet.UploadSoftwareInstallerPayload{
+				Title:            "Existing Title",
+				Source:           "apps",
+				BundleIdentifier: "com.existing.bundle",
+			},
+		},
+		{
+			name: "title that already exists but doesn't have a bundle identifier",
+			payload: &fleet.UploadSoftwareInstallerPayload{
+				Title:  "Existing Title Without Bundle",
+				Source: "apps",
+			},
+		},
+		{
+			name: "title that doesn't exist, no bundle identifier in payload",
+			payload: &fleet.UploadSoftwareInstallerPayload{
+				Title:  "New Title",
+				Source: "some_source",
+			},
+		},
+		{
+			name: "title that doesn't exist, with bundle identifier in payload",
+			payload: &fleet.UploadSoftwareInstallerPayload{
+				Title:            "New Title With Bundle",
+				Source:           "some_source",
+				BundleIdentifier: "com.new.bundle",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			id, err := ds.getOrGenerateSoftwareInstallerTitleID(ctx, tt.payload)
+			require.NoError(t, err)
+			require.NotEmpty(t, id)
+		})
+	}
 }

--- a/server/datastore/mysql/software_installers_test.go
+++ b/server/datastore/mysql/software_installers_test.go
@@ -1135,7 +1135,7 @@ func testGetOrGenerateSoftwareInstallerTitleID(t *testing.T, ds *Datastore) {
 			},
 		},
 		{
-			name: "title that already exists, bundle identifier in payload",
+			name: "title that already exists, mismatched bundle identifier in payload",
 			payload: &fleet.UploadSoftwareInstallerPayload{
 				Title:            "Existing Title",
 				Source:           "apps",
@@ -1147,6 +1147,14 @@ func testGetOrGenerateSoftwareInstallerTitleID(t *testing.T, ds *Datastore) {
 			payload: &fleet.UploadSoftwareInstallerPayload{
 				Title:  "Existing Title Without Bundle",
 				Source: "apps",
+			},
+		},
+		{
+			name: "title that already exists, no bundle identifier in DB, bundle identifier in payload",
+			payload: &fleet.UploadSoftwareInstallerPayload{
+				Title:            "Existing Title Without Bundle",
+				Source:           "apps",
+				BundleIdentifier: "com.new.bundleid",
 			},
 		},
 		{

--- a/server/datastore/mysql/vpp_test.go
+++ b/server/datastore/mysql/vpp_test.go
@@ -2,6 +2,7 @@ package mysql
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -30,6 +31,7 @@ func TestVPP(t *testing.T) {
 		{"GetVPPAppByTeamAndTitleID", testGetVPPAppByTeamAndTitleID},
 		{"VPPTokensCRUD", testVPPTokensCRUD},
 		{"VPPTokenAppTeamAssociations", testVPPTokenAppTeamAssociations},
+		{"GetOrInsertSoftwareTitleForVPPApp", testGetOrInsertSoftwareTitleForVPPApp},
 	}
 
 	for _, c := range cases {
@@ -1200,4 +1202,90 @@ func testVPPTokenAppTeamAssociations(t *testing.T, ds *Datastore) {
 
 	_, err = ds.InsertVPPAppWithTeam(ctx, app1, &team2.ID)
 	assert.Error(t, err)
+}
+
+func testGetOrInsertSoftwareTitleForVPPApp(t *testing.T, ds *Datastore) {
+	ctx := context.Background()
+
+	host1 := test.NewHost(t, ds, "host1", "", "host1key", "host1uuid", time.Now())
+	host2 := test.NewHost(t, ds, "host2", "", "host2key", "host2uuid", time.Now())
+
+	software1 := []fleet.Software{
+		{Name: "Existing Title", Version: "0.0.1", Source: "apps", BundleIdentifier: "existing.title"},
+	}
+	software2 := []fleet.Software{
+		{Name: "Existing Title", Version: "v0.0.2", Source: "apps", BundleIdentifier: "existing.title"},
+		{Name: "Existing Title", Version: "0.0.3", Source: "apps", BundleIdentifier: "existing.title"},
+		{Name: "Existing Title Without Bundle", Version: "0.0.3", Source: "apps"},
+	}
+
+	_, err := ds.UpdateHostSoftware(ctx, host1.ID, software1)
+	require.NoError(t, err)
+	_, err = ds.UpdateHostSoftware(ctx, host2.ID, software2)
+	require.NoError(t, err)
+	require.NoError(t, ds.SyncHostsSoftware(ctx, time.Now()))
+	require.NoError(t, ds.ReconcileSoftwareTitles(ctx))
+	require.NoError(t, ds.SyncHostsSoftwareTitles(ctx, time.Now()))
+
+	tests := []struct {
+		name string
+		app  *fleet.VPPApp
+	}{
+		{
+			name: "title that already exists, no bundle identifier in payload",
+			app: &fleet.VPPApp{
+				Name:             "Existing Title",
+				LatestVersion:    "0.0.1",
+				BundleIdentifier: "",
+			},
+		},
+		{
+			name: "title that already exists, bundle identifier in payload",
+			app: &fleet.VPPApp{
+				Name:             "Existing Title",
+				LatestVersion:    "0.0.2",
+				BundleIdentifier: "existing.title",
+			},
+		},
+		{
+			name: "title that already exists but doesn't have a bundle identifier",
+			app: &fleet.VPPApp{
+				Name:             "Existing Title Without Bundle",
+				LatestVersion:    "0.0.3",
+				BundleIdentifier: "",
+			},
+		},
+		{
+			name: "title that doesn't exist, no bundle identifier in payload",
+			app: &fleet.VPPApp{
+				Name:             "New Title",
+				LatestVersion:    "0.1.0",
+				BundleIdentifier: "",
+			},
+		},
+		{
+			name: "title that doesn't exist, with bundle identifier in payload",
+			app: &fleet.VPPApp{
+				Name:             "New Title",
+				LatestVersion:    "0.1.0",
+				BundleIdentifier: "new.title.bundle",
+			},
+		},
+	}
+
+	for _, platform := range fleet.VPPAppsPlatforms {
+		for _, tt := range tests {
+			t.Run(fmt.Sprintf("%s_%v", tt.name, platform), func(t *testing.T) {
+				tt.app.Platform = platform
+				var id uint
+				err := ds.withTx(ctx, func(tx sqlx.ExtContext) error {
+					var err error
+					id, err = ds.getOrInsertSoftwareTitleForVPPApp(ctx, tx, tt.app)
+					return err
+				})
+				require.NoError(t, err)
+				require.NotEmpty(t, id)
+			})
+		}
+	}
 }

--- a/server/datastore/mysql/vpp_test.go
+++ b/server/datastore/mysql/vpp_test.go
@@ -1256,6 +1256,14 @@ func testGetOrInsertSoftwareTitleForVPPApp(t *testing.T, ds *Datastore) {
 			},
 		},
 		{
+			name: "title that already exists, no bundle identifier in DB, bundle identifier in payload",
+			app: &fleet.VPPApp{
+				Name:             "Existing Title Without Bundle",
+				LatestVersion:    "0.0.3",
+				BundleIdentifier: "new.bundle.id",
+			},
+		},
+		{
 			name: "title that doesn't exist, no bundle identifier in payload",
 			app: &fleet.VPPApp{
 				Name:             "New Title",


### PR DESCRIPTION
See #21370

For the first fix:

This avoids "no rows in set" errors when adding software whose name/source matches an existing software title but whose bundle ID doesn't, likely because the bundle ID is null due to e.g. a GitOps upload.

There's likely more work to do (e.g. on VPP) for this fallback, and on the write side we should probably be saving bundle identifiers in more places than we're doing (e.g. in the batch endpoint where GitOps is used) but this is the smallest fix that will un-break software uploads.

---

For the second fix: this matches the timeout for PATCH to the timeout for POST on installers, so if e.g. you're on a 20 Mbps up connection uploading a 150MB installer the upload actually completes rather than timing out after 20s.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/Committing-Changes.md#changes-files) for more information.
- [ ] Added/updated tests
- [x] Manual QA for all new/changed functionality

@roperzh lmk if this looks right. Pending assignment on this, I can add tests if this is the right approach.