### PR TITLE
Fleet UI: Edit team name closes modal

### DIFF
--- a/changes/22207-close-team-modal
+++ b/changes/22207-close-team-modal
@@ -1,0 +1,1 @@
+- Fix UI bug: Edit team name closes modal

--- a/frontend/pages/admin/TeamManagementPage/TeamDetailsWrapper/TeamDetailsWrapper.tsx
+++ b/frontend/pages/admin/TeamManagementPage/TeamDetailsWrapper/TeamDetailsWrapper.tsx
@@ -330,6 +330,7 @@ const TeamDetailsWrapper = ({
         setBackendValidators({});
         refetchTeams();
         refetchMe();
+        toggleRenameTeamModal();
       } catch (response) {
         console.error(response);
         const errorObject = formatErrorResponse(response);


### PR DESCRIPTION
## Issue
Cerra #22207 

## Description
- Close Rename team modal on success of renaming team

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
- [x] Manual QA for all new/changed functionality
