### PR TITLE
Fleet UI: Switching vuln search types does not cause page re-render

### DIFF
--- a/changes/21923-switch-exact-search-focus-bug
+++ b/changes/21923-switch-exact-search-focus-bug
@@ -1,0 +1,1 @@
+- UI fix: Switching vulnerability search types does not cause page re-render

--- a/frontend/pages/SoftwarePage/SoftwareVulnerabilities/SoftwareVulnerabilities.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareVulnerabilities/SoftwareVulnerabilities.tsx
@@ -56,6 +56,15 @@ const SoftwareVulnerabilities = ({
     setEmptyStateReason,
   ] = useState<IVulnerabilitiesEmptyStateReason>();
 
+  // isInitialLoad is used to show the Spinner only on the first render.
+  // This prevents the Spinner from flashing on every data refresh,
+  // noticeable when going between search and exact match search deselects search box.
+  const [isInitialLoad, setIsInitialLoad] = useState(true);
+
+  useEffect(() => {
+    setIsInitialLoad(false);
+  }, []);
+
   const queryParams = {
     page: currentPage,
     per_page: perPage,
@@ -238,7 +247,7 @@ const SoftwareVulnerabilities = ({
     }
   }, [queryParams.exploit, isExactMatchQuery]);
 
-  if (isLoading || isLoadingExactMatch) {
+  if (isInitialLoad && (isLoading || isLoadingExactMatch)) {
     return <Spinner />;
   }
 

--- a/frontend/pages/SoftwarePage/SoftwareVulnerabilities/SoftwareVulnerabilities.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareVulnerabilities/SoftwareVulnerabilities.tsx
@@ -56,15 +56,6 @@ const SoftwareVulnerabilities = ({
     setEmptyStateReason,
   ] = useState<IVulnerabilitiesEmptyStateReason>();
 
-  // isInitialLoad is used to show the Spinner only on the first render.
-  // This prevents the Spinner from flashing on every data refresh,
-  // noticeable when going between search and exact match search deselects search box.
-  const [isInitialLoad, setIsInitialLoad] = useState(true);
-
-  useEffect(() => {
-    setIsInitialLoad(false);
-  }, []);
-
   const queryParams = {
     page: currentPage,
     per_page: perPage,
@@ -247,7 +238,10 @@ const SoftwareVulnerabilities = ({
     }
   }, [queryParams.exploit, isExactMatchQuery]);
 
-  if (isInitialLoad && (isLoading || isLoadingExactMatch)) {
+  // !tableData is used to show the Spinner only on the first render.
+  // This prevents the Spinner from flashing on every data refresh, noticable
+  // when going between search and exact match search deselects search box.
+  if (!tableData && (isLoading || isLoadingExactMatch)) {
     return <Spinner />;
   }
 


### PR DESCRIPTION
## Issue 
Cerra #21923 

## Description
- Problem: Page level loading spinner was showing when calling different APIs because (`isLoading` and `isLoadingExactMatch` turn true on calling a different API
- Solution: Only show page level loading spinner on first load

## Screenrecording of fix
https://www.loom.com/share/12315498c89d4e8caf8527a9f1e1d498?sid=98023e8c-be25-4625-b014-08934bb9641c

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
- [x] Manual QA for all new/changed functionality

