### PR TITLE
Update link in "Add host" modal

### DIFF
--- a/frontend/components/AddHostsModal/PlatformWrapper/PlatformWrapper.tsx
+++ b/frontend/components/AddHostsModal/PlatformWrapper/PlatformWrapper.tsx
@@ -257,7 +257,7 @@ const PlatformWrapper = ({
             Run this command with the{" "}
             <a
               className={`${baseClass}__command-line-tool`}
-              href="https://fleetdm.com/docs/using-fleet/fleetctl-cli"
+              href="https://fleetdm.com/learn-more-about/fleetctl"
               target="_blank"
               rel="noopener noreferrer"
             >


### PR DESCRIPTION
While working on some designs for this modal, I noticed it doesn't use a `fleetdm.com/learn-more-about/` redirect yet. Updated the link.