### PR TITLE
Windows Battery Status

### DIFF
--- a/changes/19619-win-battery
+++ b/changes/19619-win-battery
@@ -1,0 +1,1 @@
+- Windows host details now includes battery status

--- a/changes/19619-win-battery
+++ b/changes/19619-win-battery
@@ -1,1 +1,1 @@
-- Windows host details now includes battery status
+- Windows host details now include battery status

--- a/docs/Contributing/Understanding-host-vitals.md
+++ b/docs/Contributing/Understanding-host-vitals.md
@@ -3,13 +3,27 @@
 
 Following is a summary of the detail queries hardcoded in Fleet used to populate the device details:
 
-## battery
+## battery_macos
 
 - Platforms: darwin
 
 - Query:
 ```sql
 SELECT serial_number, cycle_count, health FROM battery;
+```
+
+## battery_windows
+
+- Platforms: windows
+
+- Discovery query:
+```sql
+SELECT 1 FROM osquery_registry WHERE active = true AND registry = 'table' AND name = 'battery'
+```
+
+- Query:
+```sql
+SELECT serial_number, cycle_count, designed_capacity, max_capacity FROM battery
 ```
 
 ## chromeos_profile_user_info

--- a/server/service/osquery_test.go
+++ b/server/service/osquery_test.go
@@ -1062,6 +1062,7 @@ func verifyDiscovery(t *testing.T, queries, discovery map[string]string) {
 		hostDetailQueryPrefix + "orbit_info":                 {},
 		hostDetailQueryPrefix + "software_vscode_extensions": {},
 		hostDetailQueryPrefix + "software_macos_firefox":     {},
+		hostDetailQueryPrefix + "battery_windows":            {},
 	}
 	for name := range queries {
 		require.NotEmpty(t, discovery[name])

--- a/server/service/osquery_utils/queries_test.go
+++ b/server/service/osquery_utils/queries_test.go
@@ -279,7 +279,8 @@ func TestGetDetailQueries(t *testing.T) {
 		"mdm_windows",
 		"munki_info",
 		"google_chrome_profiles",
-		"battery",
+		"battery_macos",
+		"battery_windows",
 		"os_windows",
 		"os_unix_like",
 		"os_chrome",
@@ -296,7 +297,7 @@ func TestGetDetailQueries(t *testing.T) {
 	sortedKeysCompare(t, queriesNoConfig, baseQueries)
 
 	queriesWithoutWinOSVuln := GetDetailQueries(context.Background(), config.FleetConfig{Vulnerabilities: config.VulnerabilitiesConfig{DisableWinOSVulnerabilities: true}}, nil, nil)
-	require.Len(t, queriesWithoutWinOSVuln, 25)
+	require.Len(t, queriesWithoutWinOSVuln, 26)
 
 	queriesWithUsers := GetDetailQueries(context.Background(), config.FleetConfig{App: config.AppConfig{EnableScheduledQueryStats: true}}, nil, &fleet.Features{EnableHostUsers: true})
 	qs := append(baseQueries, "users", "users_chrome", "scheduled_query_stats")

--- a/server/service/osquery_utils/queries_test.go
+++ b/server/service/osquery_utils/queries_test.go
@@ -1009,6 +1009,9 @@ func TestDirectIngestBattery(t *testing.T) {
 		return nil
 	}
 
+	// reset the ds flag
+	ds.ReplaceHostBatteriesFuncInvoked = false
+
 	host = fleet.Host{
 		ID:       2,
 		Platform: "windows",

--- a/server/service/osquery_utils/queries_test.go
+++ b/server/service/osquery_utils/queries_test.go
@@ -998,12 +998,12 @@ func TestDirectIngestBattery(t *testing.T) {
 
 	ds.ReplaceHostBatteriesFunc = func(ctx context.Context, id uint, mappings []*fleet.HostBattery) error {
 		require.Equal(t, mappings, []*fleet.HostBattery{
-			{HostID: uint(2), SerialNumber: "a", CycleCount: 2, Health: "Good"},
-			{HostID: uint(2), SerialNumber: "b", CycleCount: 3, Health: "Check Battery"},
-			{HostID: uint(2), SerialNumber: "c", CycleCount: 4, Health: "Unknown"},
-			{HostID: uint(2), SerialNumber: "d", CycleCount: 5, Health: "Unknown"},
-			{HostID: uint(2), SerialNumber: "e", CycleCount: 6, Health: "Unknown"},
-			{HostID: uint(2), SerialNumber: "f", CycleCount: 7, Health: "Unknown"},
+			{HostID: uint(2), SerialNumber: "a", CycleCount: 2, Health: batteryStatusGood},
+			{HostID: uint(2), SerialNumber: "b", CycleCount: 3, Health: batteryStatusDegraded},
+			{HostID: uint(2), SerialNumber: "c", CycleCount: 4, Health: batteryStatusUnknown},
+			{HostID: uint(2), SerialNumber: "d", CycleCount: 5, Health: batteryStatusUnknown},
+			{HostID: uint(2), SerialNumber: "e", CycleCount: 6, Health: batteryStatusUnknown},
+			{HostID: uint(2), SerialNumber: "f", CycleCount: 7, Health: batteryStatusUnknown},
 		})
 		return nil
 	}
@@ -1014,8 +1014,8 @@ func TestDirectIngestBattery(t *testing.T) {
 	}
 
 	err = directIngestBattery(context.Background(), log.NewNopLogger(), &host, ds, []map[string]string{
-		{"serial_number": "a", "cycle_count": "2", "designed_capacity": "3000", "max_capacity": "2000"}, // max_capacity > 50%
-		{"serial_number": "b", "cycle_count": "3", "designed_capacity": "3000", "max_capacity": "1499"}, // max_capacity < 50%
+		{"serial_number": "a", "cycle_count": "2", "designed_capacity": "3000", "max_capacity": "2400"}, // max_capacity >= 80%
+		{"serial_number": "b", "cycle_count": "3", "designed_capacity": "3000", "max_capacity": "2399"}, // max_capacity < 50%
 		{"serial_number": "c", "cycle_count": "4", "designed_capacity": "3000", "max_capacity": ""},     // missing max_capacity
 		{"serial_number": "d", "cycle_count": "5", "designed_capacity": "", "max_capacity": ""},         // missing designed_capacity and max_capacity
 		{"serial_number": "e", "cycle_count": "6", "designed_capacity": "", "max_capacity": "2000"},     // missing designed_capacity


### PR DESCRIPTION
#21817 

Added a new detail query for Windows battery due to the lack of a "health" field so we can determine health via capacity.

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/Committing-Changes.md#changes-files) for more information.
- [X] Added/updated tests
- [X] Manual QA for all new/changed functionality