### PR TITLE
Don't reuse GitHub HTTP client to pull MSRC feeds

### DIFF
--- a/changes/22492-msrc-fix
+++ b/changes/22492-msrc-fix
@@ -1,0 +1,1 @@
+* Fix MSRC feed pulls (for NVD release builds) in environments where GitHub access is authenticated

--- a/cmd/msrc/generate.go
+++ b/cmd/msrc/generate.go
@@ -35,13 +35,16 @@ func main() {
 	panicif(err)
 
 	now := time.Now()
-	httpC := fleethttp.NewGithubClient()
 
 	ctx := context.Background()
-	ghAPI := io.NewGitHubClient(httpC, github.NewClient(httpC).Repositories, wd)
-	msrcAPI := msrc.NewMSRCClient(httpC, inPath, msrc.MSRCBaseURL)
 
-	fmt.Println("Downloading existing bulletins...")
+	githubHttp := fleethttp.NewGithubClient()
+	ghAPI := io.NewGitHubClient(githubHttp, github.NewClient(githubHttp).Repositories, wd)
+
+	msrcHttp := fleethttp.NewClient() // don't reuse the GitHub client as it has an OAuth token baked in
+	msrcAPI := msrc.NewMSRCClient(msrcHttp, inPath, msrc.MSRCBaseURL)
+
+	fmt.Println("Downloading existing MSRC bulletins...")
 	eBulletins, err := ghAPI.MSRCBulletins(ctx)
 	panicif(err)
 
@@ -62,7 +65,7 @@ func main() {
 		panicif(err)
 	}
 
-	fmt.Println("Done.")
+	fmt.Println("Done processing MSRC feed.")
 }
 
 // windowsBulletinGracePeriod returns whether we are within the grace period for a MSRC monthly feed to exist.

--- a/server/vulnerabilities/msrc/msrc_api.go
+++ b/server/vulnerabilities/msrc/msrc_api.go
@@ -49,7 +49,7 @@ func feedName(date time.Time) string {
 }
 
 func (msrc MSRCClient) getURL(date time.Time) (*url.URL, error) {
-	return url.Parse(msrc.baseURL + "/cvrf/v2.0/document/" + feedName(date))
+	return url.Parse(msrc.baseURL + "/cvrf/v3.0/document/" + feedName(date))
 }
 
 // GetFeed downloads the MSRC security feed for 'month' and 'year' into 'workDir', returning the


### PR DESCRIPTION
See #22492

As of today, MSRC's API will 401 if you pass it a JWT it doesn't expect, and by reusing the GitHub API HTTP client for MSRC pulls we were passing the API an unexpected JWT. Wasn't able to reproduce this locally because I didn't need a GitHub token locally to pull release details, while the token is populated in Actions. Was able to repro both the issue and this fix inside Actions on my fork.

This also updates to call v3.0 of the API directly, which v2.0 has been redirecting to for awhile.

Finally, adds slightly better logging so we know which part of the feed generation process we're in when we're running this in Actions.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/Committing-Changes.md#changes-files) for more information.
- [x] Manual QA for all new/changed functionality