### PR TITLE
Exclude migration tests from migration timestamp/ordering check

### DIFF
--- a/.github/workflows/test-db-changes.yml
+++ b/.github/workflows/test-db-changes.yml
@@ -57,8 +57,8 @@ jobs:
           base_ref=$(git tag --list "fleet-v*" --sort=-creatordate | head -n 1)
         fi
 
-        all_migrations=($(ls server/datastore/mysql/migrations/tables/20*_*.go | sort -r))
-        new_migrations=($(git diff --find-renames --name-only --diff-filter=A $base_ref -- server/datastore/mysql/migrations/tables/20\*_\*.go | sort -r))
+        all_migrations=($(ls server/datastore/mysql/migrations/tables/20*_*.go | sort -r | grep -v '_test.go'))
+        new_migrations=($(git diff --find-renames --name-only --diff-filter=A $base_ref -- server/datastore/mysql/migrations/tables/20\*_\*.go ':(exclude,glob)server/datastore/mysql/migrations/tables/20*_*_test.go' | sort -r))
 
         index=0
         for migration in "${new_migrations[@]}"; do

--- a/.github/workflows/test-db-changes.yml
+++ b/.github/workflows/test-db-changes.yml
@@ -40,33 +40,6 @@ jobs:
       with:
         fetch-depth: 0
 
-    - name: Install Go
-      uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
-      with:
-        go-version-file: 'go.mod'
-
-    - name: Start Infra Dependencies
-      # Use & to background this
-      run: docker compose up -d mysql_test &
-
-    - name: Wait for mysql
-      run: |
-        echo "waiting for mysql..."
-        until docker compose exec -T mysql_test sh -c "mysql -uroot -p\"\${MYSQL_ROOT_PASSWORD}\" -e \"SELECT 1=1\" fleet" &> /dev/null; do
-            echo "."
-            sleep 1
-        done
-        echo "mysql is ready"
-
-    - name: Verify test schema changes
-      run: |
-        make dump-test-schema
-        if [[ $(git diff server/datastore/mysql/schema.sql) ]]; then
-          echo "❌ fail: uncommited changes in schema.sql"
-          echo "please run `make dump-test-schema` and commit the changes"
-          exit 1
-        fi
-
     # TODO: This doesn't cover all scenarios since other PRs might
     # be merged into `main` after this check has passed.
     #
@@ -109,4 +82,32 @@ jobs:
         	echo "❌ fail: hosts foreign keys are not allowed"
         	echo "Ref: https://github.com/fleetdm/fleet/blob/main/handbook/engineering/scaling-fleet.md#foreign-keys-and-locking"
         	exit 1
+        fi
+
+
+    - name: Install Go
+      uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
+      with:
+        go-version-file: 'go.mod'
+
+    - name: Start Infra Dependencies
+      # Use & to background this
+      run: docker compose up -d mysql_test &
+
+    - name: Wait for mysql
+      run: |
+        echo "waiting for mysql..."
+        until docker compose exec -T mysql_test sh -c "mysql -uroot -p\"\${MYSQL_ROOT_PASSWORD}\" -e \"SELECT 1=1\" fleet" &> /dev/null; do
+            echo "."
+            sleep 1
+        done
+        echo "mysql is ready"
+
+    - name: Verify test schema changes
+      run: |
+        make dump-test-schema
+        if [[ $(git diff server/datastore/mysql/schema.sql) ]]; then
+          echo "❌ fail: uncommited changes in schema.sql"
+          echo "please run `make dump-test-schema` and commit the changes"
+          exit 1
         fi


### PR DESCRIPTION
This fix applies to cases (e.g. 00ec402f18e0b8ed36ec7f51a20a5a38c774d9fb) where order of files being added is e.g.:

1. Migration A
2. Migration B
3. Test for migration A

This also reorders workflow steps so the ones that don't require setting up Go + compiling happen first, so if we have a migration issue it gets reported sooner.

# Checklist for submitter

- [x] Manual QA for all new/changed functionality