### PR TITLE
Update single-sign-on-sso.md

### DIFF
--- a/docs/Deploy/single-sign-on-sso.md
+++ b/docs/Deploy/single-sign-on-sso.md
@@ -1,10 +1,14 @@
 # Single sign-on (SSO)
 
-Fleet supports SSO and just-in-time (JIT) user provisioning using any identity provider (IdP) that supports SAML.
+Any user who can log in to Fleet with a password can log in using SSO.
 
-Fleet supports both service (SP) initiated login and IdP initiated login.
+Fleet supports [Okta](#okta), [Authentik](https://github.com/goauthentik/authentik), [Google Workspace](#google-workspace), and [Microsoft Active Directory (AD) / Entra ID](https://learn.microsoft.com/en-us/entra/architecture/auth-saml), as well as any other identity provider (IdP) that supports the SAML standard.  (Thankfully, this seems to be all of them.)
 
 To configure SSO, follow steps for your IdP and then complete [Fleet configuration](#fleet-configuration).
+
+> Notes:
+> - JIT? SAML implementation supports just-in-time (JIT) user provisioning, as well as both IdP-initiated login and service-initiated (SP) login.
+
 
 ## Okta
 

--- a/docs/Deploy/single-sign-on-sso.md
+++ b/docs/Deploy/single-sign-on-sso.md
@@ -1,13 +1,10 @@
 # Single sign-on (SSO)
 
-Any user who can log in to Fleet with a password can log in using SSO.
-
-Fleet supports [Okta](#okta), [Authentik](https://github.com/goauthentik/authentik), [Google Workspace](#google-workspace), and [Microsoft Active Directory (AD) / Entra ID](https://learn.microsoft.com/en-us/entra/architecture/auth-saml), as well as any other identity provider (IdP) that supports the SAML standard.  (Thankfully, this seems to be all of them.)
+Fleet supports [Okta](#okta), [Authentik](https://github.com/goauthentik/authentik), [Google Workspace](#google-workspace), and [Microsoft Active Directory (AD) / Entra ID](https://learn.microsoft.com/en-us/entra/architecture/auth-saml), as well as any other identity provider (IdP) that supports the SAML standard.
 
 To configure SSO, follow steps for your IdP and then complete [Fleet configuration](#fleet-configuration).
 
-> Notes:
-> - JIT? SAML implementation supports just-in-time (JIT) user provisioning, as well as both IdP-initiated login and service-initiated (SP) login.
+> JIT? SAML implementation supports just-in-time (JIT) user provisioning, as well as both IdP-initiated login and service-initiated (SP) login.
 
 
 ## Okta


### PR DESCRIPTION
This is a really bad PR.  I am sorry.  I  previewed it and I know it looks horrible.  Please consider it only little stickerboard of ideas.

I do, however, stand by these ideas (though not my execution of them):
- changing the first sentence to clarify whether or not this is SSO for the Fleet console GUI/CLI experience, or if we're talking about end user admin for employees using Fleet Desktop / getting "zero touched" (signing into their ABM'd or autopiloted devices)
- finding some way to name Okta, and ideally the other examples I provided, for SEO, to give people examples from a set, to get recognizable names of the integratiion above the fold, to give people a dash of personality by including authentik
- consolidating JIT and the other SAML implementation details into a sentence
- unhoisting it downards (though not in the weird way I did it) -

> References:
> - ["Why read documentation?"](https://fleetdm.com/handbook/company/why-this-way#why-read-documentation)