### PR TITLE
Use node version defined in package.json

### DIFF
--- a/.github/workflows/build-binaries.yaml
+++ b/.github/workflows/build-binaries.yaml
@@ -37,11 +37,10 @@ jobs:
         with:
           go-version-file: 'go.mod'
 
-      # Set the Node.js version
-      - name: Set up Node.js ${{ vars.NODE_VERSION }}
+      - name: Set up Node.js
         uses: actions/setup-node@5e21ff4d9bc1a8cf6de233a3057d20ec6b3fb69d # v3.8.1
         with:
-          node-version: ${{ vars.NODE_VERSION }}
+          node-version-file: package.json
 
       - name: JS Dependency Cache
         id: js-cache
@@ -51,7 +50,7 @@ jobs:
             **/node_modules
           # Use a separate cache for this from other JS jobs since we run the
           # webpack steps and will have more to cache.
-          key: ${{ runner.os }}-node_modules-${{ hashFiles('**/yarn.lock') }}-node_version-${{ vars.NODE_VERSION }}
+          key: ${{ runner.os }}-node_modules-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-node_modules-
 

--- a/.github/workflows/fleet-and-orbit.yml
+++ b/.github/workflows/fleet-and-orbit.yml
@@ -79,11 +79,10 @@ jobs:
         with:
           go-version-file: 'go.mod'
 
-      # Set the Node.js version
-      - name: Set up Node.js ${{ vars.NODE_VERSION }}
+      - name: Set up Node.js
         uses: actions/setup-node@5e21ff4d9bc1a8cf6de233a3057d20ec6b3fb69d # v3.8.1
         with:
-          node-version: ${{ vars.NODE_VERSION }}
+          node-version-file: package.json
 
       - name: Start tunnel
         env:

--- a/.github/workflows/goreleaser-fleet.yaml
+++ b/.github/workflows/goreleaser-fleet.yaml
@@ -46,11 +46,10 @@ jobs:
         with:
           go-version-file: 'go.mod'
 
-      # Set the Node.js version
-      - name: Set up Node.js ${{ vars.NODE_VERSION }}
+      - name: Set up Node.js
         uses: actions/setup-node@5e21ff4d9bc1a8cf6de233a3057d20ec6b3fb69d # v3.8.1
         with:
-          node-version: ${{ vars.NODE_VERSION }}
+          node-version-file: package.json
 
       - name: Install JS Dependencies
         run: make deps-js

--- a/.github/workflows/goreleaser-snapshot-fleet.yaml
+++ b/.github/workflows/goreleaser-snapshot-fleet.yaml
@@ -60,10 +60,10 @@ jobs:
           go-version-file: 'go.mod'
 
       # Set the Node.js version
-      - name: Set up Node.js ${{ vars.NODE_VERSION }}
+      - name: Set up Node.js
         uses: actions/setup-node@5e21ff4d9bc1a8cf6de233a3057d20ec6b3fb69d # v3.8.1
         with:
-          node-version: ${{ vars.NODE_VERSION }}
+          node-version-file: package.json
 
       - name: Install Dependencies
         run: make deps

--- a/.github/workflows/test-js.yml
+++ b/.github/workflows/test-js.yml
@@ -42,13 +42,13 @@ jobs:
         with:
           egress-policy: audit
 
-      - name: Set up Node.js ${{ vars.NODE_VERSION }}
-        uses: actions/setup-node@5e21ff4d9bc1a8cf6de233a3057d20ec6b3fb69d # v3.8.1
-        with:
-          node-version: ${{ vars.NODE_VERSION }}
-
       - name: Checkout Code
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+
+      - name: Set up Node.js
+        uses: actions/setup-node@5e21ff4d9bc1a8cf6de233a3057d20ec6b3fb69d # v3.8.1
+        with:
+          node-version-file: package.json
 
       - name: JS Dependency Cache
         id: js-cache
@@ -87,10 +87,10 @@ jobs:
         with:
           egress-policy: audit
 
-      - name: Set up Node.js ${{ vars.NODE_VERSION }}
+      - name: Set up Node.js
         uses: actions/setup-node@5e21ff4d9bc1a8cf6de233a3057d20ec6b3fb69d # v3.8.1
         with:
-          node-version: ${{ vars.NODE_VERSION }}
+          node-version-file: package.json
 
       - name: Checkout Code
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3


### PR DESCRIPTION
We did the same thing for Go. (This allows us to not require admin permissions to update the used Node version in CI.)