### PR TITLE
Fleet UI: Add tooltips to battery condition

### DIFF
--- a/changes/19619-win-battery
+++ b/changes/19619-win-battery
@@ -1,1 +1,2 @@
 - Windows host details now include battery status
+- UI includes information on how battery health is defined

--- a/frontend/pages/hosts/details/cards/About/About.tsx
+++ b/frontend/pages/hosts/details/cards/About/About.tsx
@@ -13,6 +13,7 @@ import {
 import {
   DEFAULT_EMPTY_CELL_VALUE,
   MDM_STATUS_TOOLTIP,
+  BATTERY_TOOLTIP,
 } from "utilities/constants";
 import DataSet from "components/DataSet";
 
@@ -180,7 +181,13 @@ const About = ({
     return (
       <DataSet
         title="Battery condition"
-        value={aboutData.batteries?.[0]?.health}
+        value={
+          <TooltipWrapper
+            tipContent={BATTERY_TOOLTIP[aboutData.batteries?.[0]?.health]}
+          >
+            {aboutData.batteries?.[0]?.health}
+          </TooltipWrapper>
+        }
       />
     );
   };

--- a/frontend/pages/hosts/details/cards/About/About.tsx
+++ b/frontend/pages/hosts/details/cards/About/About.tsx
@@ -174,7 +174,8 @@ const About = ({
   const renderBattery = () => {
     if (
       aboutData.batteries === null ||
-      typeof aboutData.batteries !== "object"
+      typeof aboutData.batteries !== "object" ||
+      aboutData.batteries?.[0]?.health === "Unknown"
     ) {
       return null;
     }

--- a/frontend/utilities/constants.tsx
+++ b/frontend/utilities/constants.tsx
@@ -336,6 +336,29 @@ export const MDM_STATUS_TOOLTIP: Record<string, string | React.ReactNode> = {
   ),
 };
 
+export const BATTERY_TOOLTIP: Record<string, string | React.ReactNode> = {
+  Normal: (
+    <span>
+      Current maximum capacity is at least
+      <br />
+      80% of its designed capacity and the
+      <br />
+      cycle count is below 1000.
+    </span>
+  ),
+  "Service recommended": (
+    <span>
+      Current maximum capacity has fallen below
+      <br />
+      80% of its designed capacity or the cycle count
+      <br />
+      has reached 1000. Consider having the battery
+      <br />
+      checked or replaced.
+    </span>
+  ),
+};
+
 export const DEFAULT_CREATE_USER_ERRORS = {
   email: "",
   name: "",

--- a/frontend/utilities/constants.tsx
+++ b/frontend/utilities/constants.tsx
@@ -348,13 +348,11 @@ export const BATTERY_TOOLTIP: Record<string, string | React.ReactNode> = {
   ),
   "Service recommended": (
     <span>
-      Current maximum capacity has fallen below
+      Current maximum capacity has fallen
       <br />
-      80% of its designed capacity or the cycle count
+      below 80% of its designed capacity
       <br />
-      has reached 1000. Consider having the battery
-      <br />
-      checked or replaced.
+      or the cycle count has reached 1000.
     </span>
   ),
 };


### PR DESCRIPTION
## Issue
Cerra #21816 
Story #19619

## Description
- Add tooltip for battery health in Fleet UI
- Final specs approved 10/2 ([Figma](https://www.figma.com/design/P5lBL6cRfDt7DgE4y0ciiZ/%2319619-Show-windows-battery-health?node-id=85-33&node-type=instance&t=u4P5hSddSR334hYt-0))

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
- [x] Manual QA for all new/changed functionality
