### PR TITLE
Disable test packaging of MSI on macOS Github runners

### DIFF
--- a/.github/workflows/test-packaging.yml
+++ b/.github/workflows/test-packaging.yml
@@ -19,6 +19,7 @@ on:
       - 'cmd/fleetctl/**.go'
       - 'pkg/**.go'
       - 'server/context/**.go'
+      - 'orbit/**.go'
       - 'ee/fleetctl/**.go'
       - 'tools/fleetctl-docker/**'
       - 'tools/wix-docker/**'

--- a/.github/workflows/test-packaging.yml
+++ b/.github/workflows/test-packaging.yml
@@ -3,6 +3,9 @@
 #
 # It fetches the targets: orbit, osquery and fleet-desktop from the default
 # (Fleet's) TUF server, https://tuf.fleetctl.com.
+#
+# Docker and colima are extremely unreliable on macOS Github runners
+# thus this workflow is not testing MSI package generation on macOS.
 name: Test packaging
 
 on:
@@ -15,9 +18,7 @@ on:
     paths:
       - 'cmd/fleetctl/**.go'
       - 'pkg/**.go'
-      - 'server/service/**.go'
       - 'server/context/**.go'
-      - 'orbit/**.go'
       - 'ee/fleetctl/**.go'
       - 'tools/fleetctl-docker/**'
       - 'tools/wix-docker/**'
@@ -43,11 +44,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # note: in order to test both the wix and the docker flow for msi
-        # packages, this worker needs to run on an x86_64 architecture.
-        # `macos-latest` uses arm64 by default now, so please be careful when
-        # updating this version.
-        os: [ubuntu-latest, macos-13]
+        os: [ubuntu-latest, macos-15]
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -56,31 +53,17 @@ jobs:
         with:
           egress-policy: audit
 
-      - name: Run Colima
-        if: startsWith(matrix.os, 'macos')
-        timeout-minutes: 15
-        # notes:
-        # - docker to install the docker CLI and interact with the Colima
-        #   container runtime
-        # - colima is pre-installed in macos-12 runners, but not in macos-13 or
-        #   macos-14 runners
-        run: |
-          brew install docker
-          # The runners come with an old version of python@3.12 that fails to upgrade
-          # when python gets pulled in as a dep through the chain
-          # colima -> lima -> qemu -> glibc -> python@3.12
-          # Force upgrade it for now, remove once the problem is fixed
-          brew install --overwrite python@3.12
-          brew install colima
-          colima start --mount $TMPDIR:w
-
       - name: Pull fleetdm/wix
+        if: ${{ !startsWith(matrix.os, 'macos') }}
         # Run in background while other steps complete to speed up the workflow
-        run: docker pull fleetdm/wix:latest
+        run: |
+          docker pull fleetdm/wix:latest &
 
       - name: Pull fleetdm/bomutils
+        if: ${{ !startsWith(matrix.os, 'macos') }}
         # Run in background while other steps complete to speed up the workflow
-        run: docker pull fleetdm/bomutils:latest
+        run: |
+          docker pull fleetdm/bomutils:latest &
 
       - name: Checkout Code
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
@@ -120,9 +103,11 @@ jobs:
         run: ./build/fleetctl package --type rpm --enroll-secret=foo --fleet-url=https://localhost:8080 --fleet-desktop
 
       - name: Build MSI
+        if: ${{ !startsWith(matrix.os, 'macos') }}
         run: ./build/fleetctl package --type msi --enroll-secret=foo --fleet-url=https://localhost:8080
 
       - name: Build MSI with Fleet Desktop
+        if: ${{ !startsWith(matrix.os, 'macos') }}
         run: ./build/fleetctl package --type msi --enroll-secret=foo --fleet-url=https://localhost:8080 --fleet-desktop
 
       - name: Build PKG
@@ -131,6 +116,6 @@ jobs:
       - name: Build PKG with Fleet Desktop
         run: ./build/fleetctl package --type pkg --enroll-secret=foo --fleet-url=https://localhost:8080 --fleet-desktop
 
-      - name: Build MSI (using local Wix)
+      - name: Build MSI on macOS (using local Wix)
         if: startsWith(matrix.os, 'macos')
         run: ./build/fleetctl package --type msi --enroll-secret=foo --fleet-url=https://localhost:8080 --fleet-desktop --local-wix-dir ./wix


### PR DESCRIPTION
#22206

This was discussed in the backend weekly.

Currently the test-packaging.yml is extremely unreliable (it has more failures than successes), because of issues with Docker and colima on Github macOS runners (we tried docker then colima but both have issues, timeouts, etc.).

This only removes testing of MSI package generation from macOS. IMO this is low risk as almost all Fleet devs generate MSI packages from their macOS workstations.