### PR TITLE
Website: update save-questionnaire-progress

### DIFF
--- a/website/api/controllers/save-questionnaire-progress.js
+++ b/website/api/controllers/save-questionnaire-progress.js
@@ -21,7 +21,7 @@ module.exports = {
         'what-does-your-team-manage-eo-it',
         'what-does-your-team-manage-vm',
         'what-do-you-manage-mdm',
-        'cross-platform-mdm',
+        'message-about-cross-platform-mdm',
         'is-it-any-good',
         'what-did-you-think',
         'deploy-fleet-in-your-environment',
@@ -57,7 +57,6 @@ module.exports = {
     } else {// other wise clone it from the user record.
       questionnaireProgress = _.clone(userRecord.getStartedQuestionnaireAnswers);
     }
-
     // Tease out what liur buying situation will now be (or is and was, if it's not changing)
     let primaryBuyingSituation = formData.primaryBuyingSituation === undefined ? this.req.me.primaryBuyingSituation : formData.primaryBuyingSituation;
 
@@ -212,7 +211,8 @@ module.exports = {
       questionnaireProgressAsAFormattedString = JSON.stringify(getStartedProgress)
       .replace(/[\{|\}|"]/g, '')// Remove the curly braces and quotation marks wrapping JSON objects
       .replace(/,/g, '\n')// Replace commas with newlines.
-      .replace(/:\w+:/g, ':\t');// Replace the key from the formData with a color and tab, (e.g., what-are-you-using-fleet-for:primaryBuyingSituation:eo-security, » what-are-you-using-fleet-for:   eo-security)
+      .replace(/:\w+:/g, ':\t')// Replace the key from the formData with a colon and tab, (e.g., what-are-you-using-fleet-for:primaryBuyingSituation:eo-security, » what-are-you-using-fleet-for:   eo-security)
+      .replace(/(true)/g, 'step completed');// Replace any "true" answers with "step completed".
     } catch(err){
       sails.log.warn(`When converting a user's (email: ${this.req.me.emailAddress}) getStartedQuestionnaireAnswers to a formatted string to send to the CRM, and error occurred`, err);
     }

--- a/website/assets/js/pages/start.page.js
+++ b/website/assets/js/pages/start.page.js
@@ -18,7 +18,7 @@ parasails.registerPage('start', {
       'what-does-your-team-manage-eo-it': {},
       'what-does-your-team-manage-vm': {},
       'what-do-you-manage-mdm': {},
-      'cross-platform-mdm': {stepCompleted: true},
+      'message-about-cross-platform-mdm': {stepCompleted: true},
       'is-it-any-good': {stepCompleted: true},
       'what-did-you-think': {},
       'deploy-fleet-in-your-environment': {stepCompleted: true},
@@ -198,10 +198,10 @@ parasails.registerPage('start', {
           } else if(primaryBuyingSituation === 'vm') {
             this.currentStep = 'what-does-your-team-manage-vm';
           } else if(primaryBuyingSituation === 'mdm') {
-            this.currentStep = 'cross-platform-mdm';
+            this.currentStep = 'message-about-cross-platform-mdm';
           }
           break;
-        case 'cross-platform-mdm':
+        case 'message-about-cross-platform-mdm':
           this.currentStep = 'what-do-you-manage-mdm';
           break;
         case 'lets-talk-to-your-team':
@@ -300,9 +300,9 @@ parasails.registerPage('start', {
           nextStepInForm = 'is-it-any-good';
           break;
         case 'what-do-you-manage-mdm':
-          nextStepInForm = 'cross-platform-mdm';
+          nextStepInForm = 'message-about-cross-platform-mdm';
           break;
-        case 'cross-platform-mdm':
+        case 'message-about-cross-platform-mdm':
           nextStepInForm = 'is-it-any-good';
           break;
         case 'is-it-any-good':

--- a/website/views/pages/start.ejs
+++ b/website/views/pages/start.ejs
@@ -399,8 +399,8 @@
       <%//  ╔═╗╦═╗╔═╗╔═╗╔═╗  ╔═╗╦  ╔═╗╔╦╗╔═╗╔═╗╦═╗╔╦╗  ╔╦╗╔╦╗╔╦╗
         //  ║  ╠╦╝║ ║╚═╗╚═╗  ╠═╝║  ╠═╣ ║ ╠╣ ║ ║╠╦╝║║║  ║║║ ║║║║║
         //  ╚═╝╩╚═╚═╝╚═╝╚═╝  ╩  ╩═╝╩ ╩ ╩ ╚  ╚═╝╩╚═╩ ╩  ╩ ╩═╩╝╩ ╩%>
-      <div v-if="currentStep === 'cross-platform-mdm'">
-        <ajax-form :handle-submitting="handleSubmittingForm" :form-errors.sync="formErrors" :form-data="formData['cross-platform-mdm']" :form-rules="formRules" :syncing.sync="syncing" :cloud-error.sync="cloudError">
+      <div v-if="currentStep === 'message-about-cross-platform-mdm'">
+        <ajax-form :handle-submitting="handleSubmittingForm" :form-errors.sync="formErrors" :form-data="formData['message-about-cross-platform-mdm']" :form-rules="formRules" :syncing.sync="syncing" :cloud-error.sync="cloudError">
           <div purpose="progress-bar-container">
             <div purpose="form-progress-bar"><div purpose="current-progress" style="width: 45%"></div></div>
             <img purpose="success-icon" alt="🚀" src="/images/icon-form-success-16x16@2x.png">


### PR DESCRIPTION
Closes: https://github.com/fleetdm/confidential/issues/8237
Closes: https://github.com/fleetdm/confidential/issues/8236

Changes:
- Updated `save-questionnaire-progress` to update CRM records whenever a user submits a step of the get started questionnaire. (This previously only happened when a user's psychological stage changed)
- Changed the name of the 'cross-platform-mdm' step to 'message-about-cross-platform-mdm'