### PR TITLE
Website: Update contact form validation and slack message

### DIFF
--- a/website/api/controllers/deliver-contact-form-message.js
+++ b/website/api/controllers/deliver-contact-form-message.js
@@ -41,10 +41,6 @@ module.exports = {
 
   exits: {
 
-    invalidEmailDomain: {
-      description: 'This email address is on a denylist of domains and was not delivered.',
-      responseType: 'badRequest'
-    },
     success: {
       description: 'The message was sent successfully.'
     }
@@ -61,13 +57,8 @@ module.exports = {
       );
     }
 
-    let emailDomain = emailAddress.split('@')[1];
-    if(_.includes(sails.config.custom.bannedEmailDomainsForWebsiteSubmissions, emailDomain.toLowerCase())){
-      throw 'invalidEmailDomain';
-    }
-
     await sails.helpers.http.post(sails.config.custom.slackWebhookUrlForContactForm, {
-      text: `New contact form message: (Remember: we have to email back; can't just reply to this thread.)`+
+      text: `New contact form message: (cc: <@U05CS07KASK>) (Remember: we have to email back; can't just reply to this thread.)`+
       `Name: ${firstName + ' ' + lastName}, Email: ${emailAddress}, Message: ${message ? message : 'No message.'}`
     });
 


### PR DESCRIPTION
Closes: #22522

Changes:
- Updated the contact form to not have a personal email address filter.
- Updated the message posted in Slack when users submit contact form messages.