### PR TITLE
[unreleased] Fleet UI: Live query target spinner fix for various browsers

### DIFF
--- a/frontend/components/LiveQuery/TargetsInput/_styles.scss
+++ b/frontend/components/LiveQuery/TargetsInput/_styles.scss
@@ -14,6 +14,9 @@
       box-shadow: 0px 4px 10px rgba(52, 59, 96, 0.15);
       border-radius: 0px 0px 8px 8px;
       .data-table__wrapper {
+        position: relative;
+        width: 100%;
+        height: 100%;
         overflow: auto;
       }
 
@@ -27,10 +30,6 @@
           margin-left: $pad-xsmall;
           display: inline-flex;
         }
-      }
-
-      .data-table-block {
-        display: initial;
       }
     }
 
@@ -84,8 +83,7 @@
     margin-top: 8px;
 
     .data-table__wrapper {
-      width: 100%;
-      overflow: auto;
+      position: relative;
     }
 
     .delete__cell {
@@ -98,10 +96,15 @@
   }
 
   .loading-overlay {
-    height: 100%; // Match container height
-  }
-
-  .loading-spinner.centered {
-    margin: auto;
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background-color: rgba(255, 255, 255, 0.7);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    z-index: 1000;
   }
 }

--- a/frontend/components/LiveQuery/TargetsInput/_styles.scss
+++ b/frontend/components/LiveQuery/TargetsInput/_styles.scss
@@ -20,6 +20,10 @@
         overflow: auto;
       }
 
+      &__data-table-block > div {
+        display: flex;
+      }
+
       // Properly vertically aligns host issue icon
       .display_name__cell {
         display: inline-flex;
@@ -91,8 +95,15 @@
     }
   }
 
+  // Empty loading height matches height of empty and error state
+  .loading-overlay + .data-table__wrapper {
+    .data-table__table .data-table__no-rows {
+      min-height: 225px;
+    }
+  }
+
   .data-table-block .data-table__no-rows {
-    min-height: 225px; // Match empty and error state
+    min-height: 25px;
   }
 
   .loading-overlay {

--- a/frontend/components/LiveQuery/TargetsInput/_styles.scss
+++ b/frontend/components/LiveQuery/TargetsInput/_styles.scss
@@ -97,14 +97,15 @@
 
   // Empty loading height matches height of empty and error state
   .loading-overlay + .data-table__wrapper {
-    .data-table__table .data-table__no-rows {
+    .data-table__no-rows {
       min-height: 225px;
+
+      tbody {
+        min-height: 173px;
+      }
     }
   }
-
-  .data-table-block .data-table__no-rows {
-    min-height: 25px;
-  }
+  // End
 
   .loading-overlay {
     position: absolute;


### PR DESCRIPTION
## Issue
Cerra #21276 

## Description
- Original solution worked for Chrome but looked broken for Safari and FF
- Clean up for Safari and FF

### Details
- Because .loading-overlay in TableContainer is a sibling component to the table, this is the best we can do across browsers since FF and Safari has a hard time rendering .scss styling on loading-overlay that is conditionally rendered after first render.
- To make the views completely uniform between FF, Safari, and Chrome, we'd have to modify how we handle loading for ALL tables by moving .loading-overlay to be a parent component somehow and style accordingly). IMO, that scope is excessive scope creep for this issue.

## Screenrecording of 3 browsers
https://www.loom.com/share/6632c337805b42128ca4bc94d91658c4?sid=e7dfeb23-cd20-4a28-8720-6f8d5dcde12e

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Manual QA for all new/changed functionality

