### PR TITLE
Fleet UI: Do not wrap host details dropdown options

### DIFF
--- a/frontend/pages/hosts/details/HostDetailsPage/HostActionsDropdown/_styles.scss
+++ b/frontend/pages/hosts/details/HostDetailsPage/HostActionsDropdown/_styles.scss
@@ -5,7 +5,7 @@
     width: 55px;
   }
   .Select > .Select-menu-outer {
-    left: -120px;
+    right: 0;
     min-width: max-content;
   }
 }

--- a/frontend/pages/hosts/details/HostDetailsPage/HostActionsDropdown/_styles.scss
+++ b/frontend/pages/hosts/details/HostDetailsPage/HostActionsDropdown/_styles.scss
@@ -6,5 +6,6 @@
   }
   .Select > .Select-menu-outer {
     left: -120px;
+    min-width: max-content;
   }
 }


### PR DESCRIPTION
## Issue
Cerra #22142 

## Description
- Do not wrap host details dropdown options
- Tested fix on FF, Chrome, and Safari

## Screenshots of fix

<img width="344" alt="Screenshot 2024-10-03 at 3 54 24 PM" src="https://github.com/user-attachments/assets/5dbfb5a1-e003-4359-896d-fbdfcf9d77d2">


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->


- [x] Manual QA for all new/changed functionality

