### PR TITLE
Fleet UI: Label display names fix

### DIFF
--- a/changes/22330-label-display-names
+++ b/changes/22330-label-display-names
@@ -1,0 +1,1 @@
+- Fix bug with label display names always sentence casing

--- a/frontend/components/LiveQuery/SelectTargets.tsx
+++ b/frontend/components/LiveQuery/SelectTargets.tsx
@@ -24,6 +24,10 @@ import targetsAPI, {
 import teamsAPI, { ILoadTeamsResponse } from "services/entities/teams";
 import { formatSelectedTargetsForApi } from "utilities/helpers";
 import permissions from "utilities/permissions";
+import {
+  LABEL_DISPLAY_MAP,
+  PlatformLabelNameFromAPI,
+} from "utilities/constants";
 
 import PageError from "components/DataError";
 import TargetsInput from "components/LiveQuery/TargetsInput";
@@ -108,23 +112,15 @@ const TargetPillSelector = ({
   isSelected,
   onClick,
 }: ITargetPillSelectorProps): JSX.Element => {
-  const displayText = () => {
+  const displayText = (): string => {
     if (isBuiltInLabel(entity)) {
-      switch (entity.name) {
-        case "All Hosts":
-          return "All hosts";
-        case "All Linux":
-          return "Linux";
-        case "chrome":
-          return "ChromeOS";
-        case "MS Windows":
-          return "Windows";
-        default:
-          return entity.name || "Missing display name"; // TODO
+      const labelName = entity.name as PlatformLabelNameFromAPI;
+      if (labelName in LABEL_DISPLAY_MAP) {
+        return LABEL_DISPLAY_MAP[labelName] || labelName;
       }
     }
 
-    return entity.name || "Missing display name"; // TODO
+    return entity.name || "Missing display name";
   };
 
   return (

--- a/frontend/pages/hosts/details/cards/Labels/Labels.tsx
+++ b/frontend/pages/hosts/details/cards/Labels/Labels.tsx
@@ -25,9 +25,7 @@ const Labels = ({ onLabelClick, labels }: ILabelsProps): JSX.Element => {
           variant="label"
           className="list__button"
         >
-          {label.label_type === "builtin" &&
-          label.name in LABEL_DISPLAY_MAP &&
-          (label.name as keyof typeof LABEL_DISPLAY_MAP)
+          {label.label_type === "builtin" && label.name in LABEL_DISPLAY_MAP
             ? LABEL_DISPLAY_MAP[label.name as keyof typeof LABEL_DISPLAY_MAP]
             : label.name}
         </Button>

--- a/frontend/pages/hosts/details/cards/Labels/Labels.tsx
+++ b/frontend/pages/hosts/details/cards/Labels/Labels.tsx
@@ -2,10 +2,10 @@ import React from "react";
 
 import Button from "components/buttons/Button";
 import { ILabel } from "interfaces/label";
-import { enforceFleetSentenceCasing } from "utilities/strings/stringUtils";
 import classnames from "classnames";
 
 import Card from "components/Card";
+import { LABEL_DISPLAY_MAP } from "utilities/constants";
 
 const baseClass = "labels-card";
 
@@ -25,7 +25,11 @@ const Labels = ({ onLabelClick, labels }: ILabelsProps): JSX.Element => {
           variant="label"
           className="list__button"
         >
-          {enforceFleetSentenceCasing(label.name)}
+          {label.label_type === "builtin" &&
+          label.name in LABEL_DISPLAY_MAP &&
+          (label.name as keyof typeof LABEL_DISPLAY_MAP)
+            ? LABEL_DISPLAY_MAP[label.name as keyof typeof LABEL_DISPLAY_MAP]
+            : label.name}
         </Button>
       </li>
     );

--- a/frontend/utilities/constants.tsx
+++ b/frontend/utilities/constants.tsx
@@ -264,7 +264,7 @@ export const PLATFORM_LABEL_DISPLAY_TYPES: Record<
   iPadOS: "platform",
 } as const;
 
-// For labels we display different than what is returned from the API
+// For some builtin labels, display different strings than what API returns
 export const LABEL_DISPLAY_MAP: Partial<
   Record<PlatformLabelNameFromAPI, string>
 > = {

--- a/frontend/utilities/constants.tsx
+++ b/frontend/utilities/constants.tsx
@@ -210,7 +210,7 @@ const PLATFORM_LABEL_NAMES_FROM_API = [
   "iPadOS",
 ] as const;
 
-type PlatformLabelNameFromAPI = typeof PLATFORM_LABEL_NAMES_FROM_API[number];
+export type PlatformLabelNameFromAPI = typeof PLATFORM_LABEL_NAMES_FROM_API[number];
 
 export const isPlatformLabelNameFromAPI = (
   s: string
@@ -263,6 +263,16 @@ export const PLATFORM_LABEL_DISPLAY_TYPES: Record<
   iOS: "platform",
   iPadOS: "platform",
 } as const;
+
+// For labels we display different than what is returned from the API
+export const LABEL_DISPLAY_MAP: Partial<
+  Record<PlatformLabelNameFromAPI, string>
+> = {
+  "All Hosts": "All hosts",
+  "All Linux": "Linux",
+  chrome: "ChromeOS",
+  "MS Windows": "Windows",
+};
 
 export const PLATFORM_TYPE_ICONS: Record<
   Extract<


### PR DESCRIPTION
## Issue 
Cerra 
#22330 

## Description
- Clean up label display names to display text according to `LABEL_DISPLAY_MAP` for built in labels only
- Reuse  `LABEL_DISPLAY_MAP` for built in labels only

## Screenshot of updated UI
<img width="601" alt="Screenshot 2024-10-03 at 3 39 33 PM" src="https://github.com/user-attachments/assets/a1aa83ca-20a1-4e0a-a36b-657952298bb0">
<img width="486" alt="Screenshot 2024-10-03 at 3 39 56 PM" src="https://github.com/user-attachments/assets/c3438406-0d44-439f-9824-9190543b20e9">


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
- [x] Manual QA for all new/changed functionality
