### PR TITLE
Fix policy description container width in Add policy modal

### DIFF
--- a/changes/22619-policy-scrollbar
+++ b/changes/22619-policy-scrollbar
@@ -1,0 +1,1 @@
+* Restrict width of policy description wrappers for better UI

--- a/frontend/pages/policies/ManagePoliciesPage/components/AddPolicyModal/_styles.scss
+++ b/frontend/pages/policies/ManagePoliciesPage/components/AddPolicyModal/_styles.scss
@@ -18,6 +18,9 @@
 
   &__policy-selection {
     overflow-y: auto;
+    .children-wrapper {
+      width: 680px;
+    }
   }
 
   .Select-multi-value-wrapper {


### PR DESCRIPTION
## #22619 
<img width="1464" alt="Screenshot 2024-10-03 at 3 54 24 PM" src="https://github.com/user-attachments/assets/0ee1ac44-3c64-4307-bb6b-d07c55e9e27a">

- [x] Changes file added for user-visible changes in `changes/`, 
- [x] Manual QA for all new/changed functionality