### PR TITLE
Pad copy button for BYOD link

### DIFF
--- a/changes/22485-BYOD-enroll-copy-button
+++ b/changes/22485-BYOD-enroll-copy-button
@@ -1,0 +1,1 @@
+* Fix a small UI bug where a button overlapped some copy.

--- a/frontend/components/AddHostsModal/PlatformWrapper/IosIpadosPanel/_styles.scss
+++ b/frontend/components/AddHostsModal/PlatformWrapper/IosIpadosPanel/_styles.scss
@@ -1,4 +1,7 @@
 .ios-ipados-panel {
+  .input-field {
+    padding: 7px 36px 7px 12px;
+  }
   &__spinner {
     margin: $pad-xxlarge auto;
   }


### PR DESCRIPTION
## #22485 

<img width="1464" alt="Screenshot 2024-10-03 at 4 54 04 PM" src="https://github.com/user-attachments/assets/1c64a78f-7642-4dd2-b7a5-14de6ab32018">


- [x] Changes file added for user-visible changes in `changes/`,
- [x] Manual QA for all new/changed functionality
