### PR TITLE
When trying to delete an installer associated with a policy automation, return 409 instead of 500

### DIFF
--- a/changes/22565-policy-automation-sw-delete-400
+++ b/changes/22565-policy-automation-sw-delete-400
@@ -1,0 +1,1 @@
+* Return 400 instead of 500 when trying to delete an installer associated with a policy automation.

--- a/changes/22565-policy-automation-sw-delete-400
+++ b/changes/22565-policy-automation-sw-delete-400
@@ -1,1 +1,1 @@
-* Return 400 instead of 500 when trying to delete an installer associated with a policy automation.
+* Return 409 instead of 500 when trying to delete an installer associated with a policy automation.

--- a/server/datastore/mysql/software_installers.go
+++ b/server/datastore/mysql/software_installers.go
@@ -405,7 +405,7 @@ WHERE
 	return &dest, nil
 }
 
-var errDeleteInstallerWithAssociatedPolicy = &fleet.BadRequestError{Message: "Couldn't delete. Policy automation uses this software. Please disable policy automation for this software and try again."}
+var errDeleteInstallerWithAssociatedPolicy = &fleet.ConflictError{Message: "Couldn't delete. Policy automation uses this software. Please disable policy automation for this software and try again."}
 
 func (ds *Datastore) DeleteSoftwareInstaller(ctx context.Context, id uint) error {
 	res, err := ds.writer(ctx).ExecContext(ctx, `DELETE FROM software_installers WHERE id = ?`, id)

--- a/server/datastore/mysql/software_installers.go
+++ b/server/datastore/mysql/software_installers.go
@@ -405,7 +405,7 @@ WHERE
 	return &dest, nil
 }
 
-var errDeleteInstallerWithAssociatedPolicy = errors.New("Couldn't delete. Policy automation uses this software. Please disable policy automation for this software and try again.")
+var errDeleteInstallerWithAssociatedPolicy = &fleet.BadRequestError{Message: "Couldn't delete. Policy automation uses this software. Please disable policy automation for this software and try again."}
 
 func (ds *Datastore) DeleteSoftwareInstaller(ctx context.Context, id uint) error {
 	res, err := ds.writer(ctx).ExecContext(ctx, `DELETE FROM software_installers WHERE id = ?`, id)
@@ -417,7 +417,7 @@ func (ds *Datastore) DeleteSoftwareInstaller(ctx context.Context, id uint) error
 				return ctxerr.Wrapf(ctx, err, "getting reference from policies")
 			}
 			if count > 0 {
-				return ctxerr.Wrap(ctx, errDeleteInstallerWithAssociatedPolicy, "delete software installer")
+				return errDeleteInstallerWithAssociatedPolicy
 			}
 		}
 		return ctxerr.Wrap(ctx, err, "delete software installer")


### PR DESCRIPTION
## #22565 

- Update returned error type
- Confirm test of DS method still passes

<img width="1464" alt="Screenshot 2024-10-03 at 6 12 11 PM" src="https://github.com/user-attachments/assets/c1513714-2016-4fa4-a9cb-0bf1fff35f0f">


- [x] Changes file added for user-visible changes in `changes/`,
- [x] Manual QA for all new/changed functionality