### PR TITLE
Product design rituals

### DIFF
--- a/handbook/product-design/product-design.rituals.yml
+++ b/handbook/product-design/product-design.rituals.yml
@@ -65,5 +65,7 @@
   task: "Pre-sprint prioritization" # 2024-03-06 TODO: Link to responsibility or corresponding "how to" info e.g. https://fleetdm.com/handbook/company/product-groups#making-changes
   startedOn: "2024-02-27" 
   frequency: "Triweekly"
+  description: "Align on priorities for upcoming sprint."
+  dri: "noahtalerman"
   description: "Discuss what stories weren't completed in the previous sprint. Record the number of stories in KPIs. Align on priorities for upcoming sprint."
   dri: "noahtalerman"

--- a/handbook/product-design/product-design.rituals.yml
+++ b/handbook/product-design/product-design.rituals.yml
@@ -67,5 +67,3 @@
   frequency: "Triweekly"
   description: "Align on priorities for upcoming sprint."
   dri: "noahtalerman"
-  description: "Discuss what stories weren't completed in the previous sprint. Record the number of stories in KPIs. Align on priorities for upcoming sprint."
-  dri: "noahtalerman"


### PR DESCRIPTION
- Update description for pre-sprint prioritization. Stories not completed count is done async using the `~pushed` label.
