### PR TITLE
Reduce `test-packaging.yml` runs on main

### DIFF
--- a/.github/workflows/test-packaging.yml
+++ b/.github/workflows/test-packaging.yml
@@ -14,6 +14,16 @@ on:
       - main
       - patch-*
       - prepare-*
+    paths:
+      - 'cmd/fleetctl/**.go'
+      - 'pkg/**.go'
+      - 'server/context/**.go'
+      - 'orbit/**.go'
+      - 'ee/fleetctl/**.go'
+      - 'tools/fleetctl-docker/**'
+      - 'tools/wix-docker/**'
+      - 'tools/bomutils-docker/**'
+      - '.github/workflows/test-packaging.yml'
   pull_request:
     paths:
       - 'cmd/fleetctl/**.go'


### PR DESCRIPTION
Last change for #22206.

No need to run this workflow on **every** push to `main`. Let's match the PR paths.