### PR TITLE
Update sprint kickoff review ritual

### DIFF
--- a/handbook/product-design/product-design.rituals.yml
+++ b/handbook/product-design/product-design.rituals.yml
@@ -23,7 +23,7 @@
   task: "Sprint kickoff review" # 2024-03-06 TODO: Link to responsibility or corresponding "how to" info e.g. https://fleetdm.com/handbook/company/product-groups#making-changes
   startedOn: "2024-03-07" 
   frequency: "Triweekly" 
-  description: "Review stories that made it into this sprint and recommend highlights for next release notes. Then, review stories that did not make it into this sprint." 
+  description: "Review stories that made it into this sprint and recommend highlights for next release notes. Then, review stories that did not make it into this sprint. Ensure stories/bugs have been effectively prioritized across teams." 
   moreInfoUrl: 
   dri: "noahtalerman"
 -

--- a/handbook/product-design/product-design.rituals.yml
+++ b/handbook/product-design/product-design.rituals.yml
@@ -23,7 +23,7 @@
   task: "Sprint kickoff review" # 2024-03-06 TODO: Link to responsibility or corresponding "how to" info e.g. https://fleetdm.com/handbook/company/product-groups#making-changes
   startedOn: "2024-03-07" 
   frequency: "Triweekly" 
-  description: "Identify stories that did not make it into this sprint and remove them from the board. Notify relevant requesters/stakeholders. Ensure bugs have been effectively prioritized across teams. Recommend highlights for next release notes. Record the number of drops for KPI reporting. Consider product group staffing. Are we scheduling what we prioritized?  Did we finish what we scheduled in the sprint?  (Look at org chart.)" 
+  description: "Review stories that made it into this sprint and recommend highlights for next release notes. Then, review stories that did not make it into this sprint." 
   moreInfoUrl: 
   dri: "noahtalerman"
 -


### PR DESCRIPTION
Update ritual to reflect what actually happens today

- @noahtalerman: I'm responsible for updating the stories pushed KPI. I do this async using the `~pushed` label
- @noahtalerman: I'm responsible for notifying stakeholders. I do this async
- @noahtalerman: We haven't been chatting about product group staffing on this call. I think this is happening separately during 1:1s and other calls. I chat w/ Luke about this semi-regularly during our 1:1
