### PR TITLE
Enable launch daemon before trying to bootstrap it

### DIFF
--- a/orbit/pkg/packaging/macos_templates.go
+++ b/orbit/pkg/packaging/macos_templates.go
@@ -62,6 +62,9 @@ pkill fleet-desktop || true
 # Remove any pre-existing version of the config
 launchctl bootout "system/${DAEMON_LABEL}"
 
+# Make sure the launch daemon is enabled before we try to bootstrap it
+launchctl enable "system/${DAEMON_LABEL}"
+
 # Add the daemon to the launchd system.
 #
 # We add retries because we've seen "launchctl bootstrap" fail
@@ -81,8 +84,6 @@ while ! launchctl bootstrap system "${DAEMON_PLIST}"; do
 done
 echo "Successfully bootstrap system ${DAEMON_PLIST}"
 
-# Enable the daemon
-launchctl enable "system/${DAEMON_LABEL}"
 # Force the daemon to start
 launchctl kickstart "system/${DAEMON_LABEL}"
 {{- end }}


### PR DESCRIPTION
## Description
Moves the enabling of the launch daemon to before trying to launch it, so it doesn't fail if the launch daemon is disabled

## Testing Done
launch daemon is enabled
```
 launchctl print system | grep fleetdm
		   78074      - 	com.fleetdm.orbit
		"com.fleetdm.orbit" => enabled
```
uninstalling FleetDM via https://github.com/fleetdm/fleet/blob/main/orbit/tools/cleanup/cleanup_macos.sh
```
sudo ~/Desktop/removefleet.sh 
Removing fleet, system will be unenrolled in 15 seconds...
Executing detached child process
```
launch daemon is still enabled:
```
launchctl print system | grep fleetdm   
		   78074      - 	com.fleetdm.orbit
		"com.fleetdm.orbit" => enabled
```
If I manually disable the launch daemon...
```
sudo launchctl disable system/com.fleetdm.orbit
```
```
launchctl print system | grep fleetdm          
		       0     78 	com.fleetdm.orbit
		"com.fleetdm.orbit" => disabled
```
... then the install will fail:
```
sudo installer -pkg ~/Desktop/fleet-osquery-1.18.3.pkg -target /
installer: Package name is Fleet osquery
installer: Installing at base path /
installer: The install failed. (The Installer encountered an error that caused the installation to fail. Contact the software manufacturer for assistance. An error occurred while running scripts from the package “fleet-osquery-1.18.3.pkg”.)
```
Excerpt from `/var/log/install.log`:
```
2024-10-08 15:00:57-07 HOSTNAME package_script_service[80350]: ./postinstall: Retrying launchctl bootstrap...
2024-10-08 15:00:57-07 HOSTNAME package_script_service[80350]: ./postinstall: Bootstrap failed: 5: Input/output error
2024-10-08 15:00:58-07 HOSTNAME package_script_service[80350]: ./postinstall: Retrying launchctl bootstrap...
2024-10-08 15:00:58-07 HOSTNAME package_script_service[80350]: ./postinstall: Bootstrap failed: 5: Input/output error
2024-10-08 15:00:59-07 HOSTNAME package_script_service[80350]: ./postinstall: Retrying launchctl bootstrap...
2024-10-08 15:00:59-07 HOSTNAME package_script_service[80350]: ./postinstall: Bootstrap failed: 5: Input/output error
2024-10-08 15:01:00-07 HOSTNAME package_script_service[80350]: ./postinstall: Retrying launchctl bootstrap...
2024-10-08 15:01:00-07 HOSTNAME package_script_service[80350]: ./postinstall: Bootstrap failed: 5: Input/output error
2024-10-08 15:01:01-07 HOSTNAME package_script_service[80350]: ./postinstall: Retrying launchctl bootstrap...
2024-10-08 15:01:01-07 HOSTNAME package_script_service[80350]: ./postinstall: Bootstrap failed: 5: Input/output error
2024-10-08 15:01:02-07 HOSTNAME package_script_service[80350]: ./postinstall: Retrying launchctl bootstrap...
2024-10-08 15:01:02-07 HOSTNAME package_script_service[80350]: ./postinstall: Bootstrap failed: 5: Input/output error
2024-10-08 15:01:03-07 HOSTNAME package_script_service[80350]: ./postinstall: Retrying launchctl bootstrap...
2024-10-08 15:01:03-07 HOSTNAME package_script_service[80350]: ./postinstall: Bootstrap failed: 5: Input/output error
2024-10-08 15:01:04-07 HOSTNAME package_script_service[80350]: ./postinstall: Failed to bootstrap system /Library/LaunchDaemons/com.fleetdm.orbit.plist
```
If I then enable the launch daemon...
```
sudo launchctl enable system/com.fleetdm.orbit  
```
```
launchctl print system | grep fleetdm                           
		"com.fleetdm.orbit" => enabled
```
... then the postinstall in the pkg works fine:
```
sudo installer -pkg ~/Desktop/fleet-osquery-1.18.3.pkg -target /
installer: Package name is Fleet osquery
installer: Installing at base path /
installer: The install was successful.
```
So, yeah, the enabling has to be before the launching of the launch daemon.