### PR TITLE
Website - homepage text fix

### DIFF
--- a/website/views/pages/homepage.ejs
+++ b/website/views/pages/homepage.ejs
@@ -243,7 +243,7 @@
             </div>
             <div purpose="endpoint-image-box" class="d-md-none d-flex">
               <img alt="ChromeOS" src="/images/logo-chrome-36x37@2x.png">
-              <p>Chromebook</p>
+              <p>ChromeOS</p>
             </div>
             <div purpose="endpoint-image-box" class="d-md-none d-flex">
               <img alt="Containers" src="/images/logo-docker-40x40@2x.png">
@@ -256,7 +256,7 @@
             <div purpose="endpoint-empty-image-box" class="d-md-flex d-none"></div>
             <div purpose="endpoint-image-box" class="d-md-flex d-none">
               <img alt="ChromeOS" src="/images/logo-chrome-36x37@2x.png">
-              <p>Chromebook</p>
+              <p>ChromeOS</p>
             </div>
             <div purpose="endpoint-image-box" class="d-md-flex d-none">
               <img alt="Containers" src="/images/logo-docker-40x40@2x.png">


### PR DESCRIPTION
Changed "Chromebook" to "ChromeOS" to be consistent with macOS, Windows, and Linux, which refer to the operating system, not the device name.