### PR TITLE
Add count and apps_updated_at data to `GET /fleet_maintained_apps`

### DIFF
--- a/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareFleetMaintained/FleetMaintainedAppsTable/FleetMaintainedAppsTable.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareFleetMaintained/FleetMaintainedAppsTable/FleetMaintainedAppsTable.tsx
@@ -135,9 +135,9 @@ const FleetMaintainedAppsTable = ({
     return (
       <>
         <TableCount name="items" count={data?.count} />
-        {data?.counts_updated_at && (
+        {data?.apps_updated_at && (
           <LastUpdatedText
-            lastUpdatedAt={data.counts_updated_at}
+            lastUpdatedAt={data.apps_updated_at}
             customTooltipText={
               <>
                 The last time Fleet-maintained <br />

--- a/frontend/services/entities/software.ts
+++ b/frontend/services/entities/software.ts
@@ -119,7 +119,7 @@ export interface ISoftwareFleetMaintainedAppsQueryParams {
 export interface ISoftwareFleetMaintainedAppsResponse {
   fleet_maintained_apps: IFleetMaintainedApp[];
   count: number;
-  counts_updated_at: string | null;
+  apps_updated_at: string | null;
   meta: {
     has_next_results: boolean;
     has_previous_results: boolean;

--- a/server/datastore/mysql/maintained_apps.go
+++ b/server/datastore/mysql/maintained_apps.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"fmt"
 
 	"github.com/fleetdm/fleet/v4/server/contexts/ctxerr"
 	"github.com/fleetdm/fleet/v4/server/fleet"
@@ -102,7 +103,8 @@ SELECT
 	fla.id,
 	fla.name,
 	fla.version,
-	fla.platform
+	fla.platform,
+	fla.updated_at
 FROM
 	fleet_library_apps fla
 WHERE NOT EXISTS (
@@ -128,6 +130,11 @@ WHERE NOT EXISTS (
 	)
 )`
 
+	// build the count statement before adding the pagination constraints to the
+	// default stmt.
+	dbReader := ds.reader(ctx)
+	getAppsCountStmt := fmt.Sprintf(`SELECT COUNT(DISTINCT s.id) FROM (%s) AS s`, stmt)
+
 	args := []any{teamID, teamID}
 
 	if match := opt.MatchQuery; match != "" {
@@ -143,7 +150,13 @@ WHERE NOT EXISTS (
 		return nil, nil, ctxerr.Wrap(ctx, err, "selecting available fleet managed apps")
 	}
 
-	meta := &fleet.PaginationMetadata{HasPreviousResults: opt.Page > 0}
+	// perform a second query to grab the counts
+	var counts int
+	if err := sqlx.GetContext(ctx, dbReader, &counts, getAppsCountStmt, args...); err != nil {
+		return nil, nil, ctxerr.Wrap(ctx, err, "get fleet maintained apps count")
+	}
+
+	meta := &fleet.PaginationMetadata{HasPreviousResults: opt.Page > 0, TotalResults: uint(counts)}
 	if len(avail) > int(opt.PerPage) {
 		meta.HasNextResults = true
 		avail = avail[:len(avail)-1]

--- a/server/fleet/maintained_apps.go
+++ b/server/fleet/maintained_apps.go
@@ -1,5 +1,7 @@
 package fleet
 
+import "time"
+
 // MaintainedApp represets an app in the Fleet library of maintained apps,
 // as stored in the fleet_library_apps table.
 type MaintainedApp struct {
@@ -17,4 +19,6 @@ type MaintainedApp struct {
 	// fields are used to provide the content of those scripts.
 	InstallScript   string `json:"install_script" db:"install_script"`
 	UninstallScript string `json:"uninstall_script" db:"uninstall_script"`
+	// UpdatedAt is the timestamp when the fleet maintained app data was last updated.
+	UpdatedAt *time.Time `json:"-" db:"updated_at"`
 }

--- a/server/service/handler.go
+++ b/server/service/handler.go
@@ -392,7 +392,7 @@ func attachFleetAPIRoutes(r *mux.Router, svc fleet.Service, config config.FleetC
 
 	// Fleet-maintained apps
 	ue.POST("/api/_version_/fleet/software/fleet_maintained_apps", addFleetMaintainedAppEndpoint, addFleetMaintainedAppRequest{})
-	ue.GET("/api/_version_/fleet/software/fleet_maintained_apps", listFleetMaintainedApps, listFleetMaintainedAppsRequest{})
+	ue.GET("/api/_version_/fleet/software/fleet_maintained_apps", listFleetMaintainedAppsEndpoint, listFleetMaintainedAppsRequest{})
 	ue.GET("/api/_version_/fleet/software/fleet_maintained_apps/{app_id}", getFleetMaintainedApp, getFleetMaintainedAppRequest{})
 
 	// Vulnerabilities


### PR DESCRIPTION
relates to #22732

Cherry pick commit for release branch.

This adds the `counts` and `apps_updated_at` response data on the `GET /fleet_maintained_apps` endpoint. We then add that to the UI to show the counts and last time fleet maintained app data has been updated:
