### PR TITLE
Ensure scripts set in no-team.yml can be used in run-script actions for No Team

### DIFF
--- a/cmd/fleetctl/apply.go
+++ b/cmd/fleetctl/apply.go
@@ -90,7 +90,11 @@ func applyCommand() *cli.Command {
 				opts.TeamForPolicies = policiesTeamName
 			}
 			baseDir := filepath.Dir(flFilename)
-			_, _, _, err = fleetClient.ApplyGroup(c.Context, specs, baseDir, logf, nil, opts)
+
+			teamsSoftwareInstallers := make(map[string][]fleet.SoftwarePackageResponse)
+			teamsScripts := make(map[string][]fleet.ScriptResponse)
+
+			_, _, _, err = fleetClient.ApplyGroup(c.Context, specs, baseDir, logf, nil, opts, teamsSoftwareInstallers, teamsScripts)
 			if err != nil {
 				return err
 			}

--- a/cmd/fleetctl/gitops.go
+++ b/cmd/fleetctl/gitops.go
@@ -109,6 +109,11 @@ func gitopsCommand() *cli.Command {
 			if totalFilenames > 1 {
 				firstFileMustBeGlobal = ptr.Bool(true)
 			}
+
+			// we keep track of team software installers and scripts for correct policy application
+			teamsSoftwareInstallers := make(map[string][]fleet.SoftwarePackageResponse)
+			teamsScripts := make(map[string][]fleet.ScriptResponse)
+
 			// We keep track of the secrets to check if duplicates exist during dry run
 			secrets := make(map[string]struct{})
 			for _, flFilename := range flFilenames.Value() {
@@ -207,7 +212,7 @@ func gitopsCommand() *cli.Command {
 					}
 				}
 
-				assumptions, err := fleetClient.DoGitOps(c.Context, config, flFilename, logf, flDryRun, teamDryRunAssumptions, appConfig)
+				assumptions, err := fleetClient.DoGitOps(c.Context, config, flFilename, logf, flDryRun, teamDryRunAssumptions, appConfig, teamsSoftwareInstallers, teamsScripts)
 				if err != nil {
 					return err
 				}

--- a/cmd/fleetctl/preview.go
+++ b/cmd/fleetctl/preview.go
@@ -387,7 +387,9 @@ Use the stop and reset subcommands to manage the server and dependencies once st
 			}
 			// this only applies standard queries, the base directory is not used,
 			// so pass in the current working directory.
-			_, _, _, err = client.ApplyGroup(c.Context, specs, ".", logf, nil, fleet.ApplyClientSpecOptions{})
+			teamsSoftwareInstallers := make(map[string][]fleet.SoftwarePackageResponse)
+			teamsScripts := make(map[string][]fleet.ScriptResponse)
+			_, _, _, err = client.ApplyGroup(c.Context, specs, ".", logf, nil, fleet.ApplyClientSpecOptions{}, teamsSoftwareInstallers, teamsScripts)
 			if err != nil {
 				return err
 			}

--- a/pkg/spec/gitops.go
+++ b/pkg/spec/gitops.go
@@ -596,7 +596,10 @@ func parsePolicyRunScript(baseDir string, teamName *string, policy *Policy, scri
 		}
 	}
 	if !scriptOnTeamFound {
-		return fmt.Errorf("policy script not found on team: %v vs. %v", foundScriptPaths, scriptPath)
+		if *teamName == noTeam {
+			return fmt.Errorf("policy script %s was not defined in controls in no-team.yml", scriptPath)
+		}
+		return fmt.Errorf("policy script %s was not defined in controls for %s", scriptPath, *teamName)
 	}
 
 	scriptName := filepath.Base(policy.RunScript.Path)

--- a/pkg/spec/gitops_test.go
+++ b/pkg/spec/gitops_test.go
@@ -1016,7 +1016,7 @@ controls:
 	}
 	_, err = GitOpsFromFile(path, basePath, &appConfig, nopLogf)
 	assert.ErrorContains(t, err,
-		"policy script not found on team",
+		"was not defined in controls for TeamName",
 	)
 }
 


### PR DESCRIPTION
For #22787

Also revises the spec check to explain that scripts have to be defined "controls" when used in policies for the same team, with an explicit call-out for no-team.yml since this fix doesn't support pulling scripts from the global file. This is because parsing and script-matching happens early enough that we can't throw an error in the part of the code where we bail when controls are defined in both no-team and default files.

To minimize diff size, we're both passing-by-ref and returning the maps-by-team of scripts and installers, though pass-by-ref would be sufficient on its own. If we're okay with a bigger diff the extra pieces of the return tuple can be dropped in a subsequent revision.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- N/A Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/Committing-Changes.md#changes-files) for more information.
- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [x] Added/updated tests (sorta)
- [x] Manual QA for all new/changed functionality