### PR TITLE
Enable firefox_preferences on Linux and Windows as well

### DIFF
--- a/changes/22825-firefox_preferences-linux-windows
+++ b/changes/22825-firefox_preferences-linux-windows
@@ -1,0 +1,1 @@
+* Enable `firefox_preferences` table to Linux and Windows platforms

--- a/schema/osquery_fleet_schema.json
+++ b/schema/osquery_fleet_schema.json
@@ -10948,7 +10948,9 @@
     "evented": false,
     "notes": "This table is not a core osquery table. It is included as part of fleetd, the osquery manager from Fleet. Code based on work by [Kolide](https://github.com/kolide/launcher).",
     "platforms": [
-      "darwin"
+      "darwin",
+      "linux",
+      "windows"
     ],
     "columns": [
       {

--- a/schema/tables/firefox_preferences.yml
+++ b/schema/tables/firefox_preferences.yml
@@ -4,6 +4,8 @@ evented: false
 notes: This table is not a core osquery table. It is included as part of fleetd, the osquery manager from Fleet. Code based on work by [Kolide](https://github.com/kolide/launcher).
 platforms:
   - darwin
+  - linux
+  - windows
 columns:
   - name: path
     description: The path to the host's Firefox preferences.
@@ -29,4 +31,4 @@ columns:
     description: The query is printed in this column. For example the SQL `SELECT * FROM firefox_preferences WHERE path = 'testdata/prefs.js'` will print "*" in the query column.
     type: text
     required: false
-  
+


### PR DESCRIPTION
From my understanding, the `firefox_preferences` table is supposed to work on all platforms (see [kolide](https://github.com/kolide/launcher/blob/main/pkg/osquery/table/table.go#L57)), while fleet provides it to `darwin` only.

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/Committing-Changes.md#changes-files) for more information.
- [ ] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [ ] Added support on fleet's osquery simulator `cmd/osquery-perf` for new osquery data ingestion features.
- [ ] Added/updated tests
- [ ] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes
- [ ] If database migrations are included, checked table schema to confirm autoupdate
- For database migrations:
  - [ ] Checked schema for all modified table for columns that will auto-update timestamps during migration.
  - [ ] Confirmed that updating the timestamps is acceptable, and will not cause unwanted side effects.
  - [ ] Ensured the correct collation is explicitly set for character columns (`COLLATE utf8mb4_unicode_ci`).
- [ ] Manual QA for all new/changed functionality
- For Orbit and Fleet Desktop changes:
   - [ ] Orbit runs on macOS, Linux and Windows. Check if the orbit feature/bugfix should only apply to one platform (`runtime.GOOS`).
   - [ ] Manual QA must be performed in the three main OSs, macOS, Windows and Linux.
   - [ ] Auto-update manual QA, from released version of component to new version (see [tools/tuf/test](../tools/tuf/test/README.md)).