### PR TITLE
fix typo fleet maintained empty state

### DIFF
--- a/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareFleetMaintained/FleetMaintainedAppsTable/FleetMaintainedAppsTable.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareFleetMaintained/FleetMaintainedAppsTable/FleetMaintainedAppsTable.tsx
@@ -24,7 +24,7 @@ const EmptyFleetAppsTable = () => (
     header={"No items match the current search criteria"}
     info={
       <>
-        Can&apos; find app?{" "}
+        Can&apos;t find app?{" "}
         <CustomLink
           newTab
           url="https://github.com/fleetdm/fleet/issues/new/choose"


### PR DESCRIPTION
relates to #22731

> NOTE: cherry pick PR

quick typo fix on the fleet maintained apps table empty state

