### PR TITLE
Populate created_at and updated_at for newly created (non-invited) users

### DIFF
--- a/changes/22387-user-timestamp
+++ b/changes/22387-user-timestamp
@@ -1,0 +1,1 @@
+* Set created_at/updated_at timestamps on user create endpoint

--- a/server/datastore/mysql/users.go
+++ b/server/datastore/mysql/users.go
@@ -46,6 +46,11 @@ func (ds *Datastore) NewUser(ctx context.Context, user *fleet.User) (*fleet.User
 			user.SSOEnabled,
 			user.APIOnly,
 			user.GlobalRole)
+
+		// set timestamp as close as possible to insert query to be as accurate as possible without needing to SELECT
+		user.CreatedAt = time.Now().UTC().Truncate(time.Second) // truncating because DB is at second resolution
+		user.UpdatedAt = user.CreatedAt
+
 		if err != nil {
 			return ctxerr.Wrap(ctx, err, "create new user")
 		}


### PR DESCRIPTION
#22387 

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/Committing-Changes.md#changes-files) for more information.
- [x] Added/updated tests
- [x] Manual QA for all new/changed functionality