### PR TITLE
Correct placement of disable_tables

### DIFF
--- a/docs/Configuration/agent-configuration.md
+++ b/docs/Configuration/agent-configuration.md
@@ -73,7 +73,6 @@ spec:
             distributed_tls_max_attempts: 10
             logger_tls_endpoint: /api/osquery/log
             logger_tls_period: 300
-            disable_tables: chrome_extensions
             docker_socket: /var/run/docker.sock
           file_paths:
             users:
@@ -132,6 +131,7 @@ agent_options:
   command_line_flags: # requires Fleet's agent (fleetd)
     verbose: true
     disable_watchdog: false
+    disable_tables: chrome_extensions
     logger_path: /path/to/logger
 ```
 
@@ -404,7 +404,6 @@ agent_options:
           distributed_tls_max_attempts: 10
           logger_tls_endpoint: /api/osquery/log
           logger_tls_period: 300
-          disable_tables: chrome_extensions
           docker_socket: /var/run/docker.sock
         file_paths:
           users:


### PR DESCRIPTION
Remove any reference to CLI only flag`disable_tables` in `agent_options.config.options` and added a reference to `agent_options.command_line_flags`

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

-Documentation only change, thanks to @rebeccaui for calling it out!
