### PR TITLE
Fleet Desktop: Remove hover state on logo

### DIFF
--- a/frontend/components/top_nav/SiteTopNav/_styles.scss
+++ b/frontend/components/top_nav/SiteTopNav/_styles.scss
@@ -23,7 +23,7 @@
   align-items: center;
   justify-content: center;
 
-  &:hover {
+  &:not(.dup-org-logo):hover {
     background-color: $site-nav-on-hover;
   }
 


### PR DESCRIPTION
## Issue
Cerra #22659 

## Description
- Remove hover state on my device page's logo
- Confirmed fixed on Chrome, Safari, and FF

## Screenrecording of fix

https://github.com/user-attachments/assets/d5cc760d-cdac-496b-a625-52dcab7f896b


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Manual QA for all new/changed functionality

