### PR TITLE
Fleet UI: Close modals with no CTA, and query sidebar, using enter key

### DIFF
--- a/frontend/components/side_panels/QuerySidePanel/QuerySidePanel.tsx
+++ b/frontend/components/side_panels/QuerySidePanel/QuerySidePanel.tsx
@@ -18,7 +18,7 @@ import EventedTableTag from "./EventedTableTag";
 interface IQuerySidePanel {
   selectedOsqueryTable: IOsQueryTable;
   onOsqueryTableSelect: (tableName: string) => void;
-  onClose?: () => void;
+  onClose: () => void;
 }
 
 const baseClass = "query-side-panel";
@@ -67,6 +67,11 @@ const QuerySidePanel = ({
         className={`${baseClass}__close-button`}
         tabIndex={0}
         onClick={onClose}
+        onKeyDown={(e) => {
+          if (e.key === "Enter" || e.key === " ") {
+            onClose();
+          }
+        }}
       >
         <Icon name="close" color="ui-fleet-black-50" size="small" />
       </div>

--- a/frontend/components/side_panels/QuerySidePanel/_styles.scss
+++ b/frontend/components/side_panels/QuerySidePanel/_styles.scss
@@ -18,13 +18,20 @@
     z-index: 2;
 
     &:focus {
+      border: 1px solid $core-vibrant-blue;
       outline: none;
+
+      svg {
+        path {
+          stroke: $core-vibrant-blue;
+        }
+      }
     }
 
     &:hover {
       svg {
         path {
-          stroke: $core-vibrant-blue;
+          stroke: $core-vibrant-blue-over;
         }
       }
     }

--- a/frontend/pages/DashboardPage/components/MdmSolutionModal/MdmSolutionModal.tsx
+++ b/frontend/pages/DashboardPage/components/MdmSolutionModal/MdmSolutionModal.tsx
@@ -45,6 +45,7 @@ const MdmSolutionModal = ({
       title={mdmSolutions[0].name || DEFAULT_TITLE}
       width="large"
       onExit={onCancel}
+      onEnter={onCancel}
     >
       <>
         <div className={`${baseClass}__modal-content`}>

--- a/frontend/pages/admin/components/HostStatusWebhookPreviewModal/HostStatusWebhookPreviewModal.tsx
+++ b/frontend/pages/admin/components/HostStatusWebhookPreviewModal/HostStatusWebhookPreviewModal.tsx
@@ -39,6 +39,7 @@ const HostStatusWebhookPreviewModal = ({
     <Modal
       title="Host status webhook"
       onExit={toggleModal}
+      onEnter={toggleModal}
       className={baseClass}
     >
       <>

--- a/frontend/pages/hosts/details/DeviceUserPage/AutoEnrollMdmModal/AutoEnrollMdmModal.tsx
+++ b/frontend/pages/hosts/details/DeviceUserPage/AutoEnrollMdmModal/AutoEnrollMdmModal.tsx
@@ -78,6 +78,7 @@ const AutoEnrollMdmModal = ({
     <Modal
       title="Turn on MDM"
       onExit={onCancel}
+      onEnter={onCancel}
       className={baseClass}
       width="xlarge"
     >

--- a/frontend/pages/hosts/details/DeviceUserPage/ManualEnrollMdmModal/ManualEnrollMdmModal.tsx
+++ b/frontend/pages/hosts/details/DeviceUserPage/ManualEnrollMdmModal/ManualEnrollMdmModal.tsx
@@ -72,6 +72,7 @@ const ManualEnrollMdmModal = ({
     <Modal
       title="Turn on MDM"
       onExit={onCancel}
+      onEnter={onCancel}
       className={baseClass}
       width="xlarge"
     >

--- a/frontend/pages/hosts/details/HostDetailsPage/modals/DiskEncryptionKeyModal/DiskEncryptionKeyModal.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/modals/DiskEncryptionKeyModal/DiskEncryptionKeyModal.tsx
@@ -59,7 +59,12 @@ const DiskEncryptionKeyModal = ({
     : "Use this key to unlock the encrypted drive.";
 
   return (
-    <Modal title="Disk encryption key" onExit={onCancel} className={baseClass}>
+    <Modal
+      title="Disk encryption key"
+      onExit={onCancel}
+      onEnter={onCancel}
+      className={baseClass}
+    >
       {encryptionKeyError ? (
         <DataError />
       ) : (

--- a/frontend/pages/hosts/details/HostDetailsPage/modals/SelectQueryModal/SelectQueryModal.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/modals/SelectQueryModal/SelectQueryModal.tsx
@@ -183,6 +183,7 @@ const SelectQueryModal = ({
     <Modal
       title="Select a query"
       onExit={onCancel}
+      onEnter={onCancel}
       className={baseClass}
       width="large"
     >

--- a/frontend/pages/hosts/details/cards/Policies/HostPoliciesTable/PolicyDetailsModal/PolicyDetailsModal.tsx
+++ b/frontend/pages/hosts/details/cards/Policies/HostPoliciesTable/PolicyDetailsModal/PolicyDetailsModal.tsx
@@ -20,6 +20,7 @@ const PolicyDetailsModal = ({
     <Modal
       title={`${policy?.name || "Policy name"}`}
       onExit={onCancel}
+      onEnter={onCancel}
       className={baseClass}
     >
       <div className={`${baseClass}__body`}>


### PR DESCRIPTION
## Issue
Part 2 of #22606 

## Description
- 7 modals without a CTA (CTA is usually an API call of some sort) can be closed using the enter key consistent with the rest of the modals without a CTA behavior
- Query side panel can be closed using keyboard only

## Screen recording of examples
https://www.loom.com/share/5eae561e4ea246d2b24fadcb36074c07?sid=33beb0a3-dc44-4121-9d39-7da6312e4247

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Manual QA for all new/changed functionality

