### PR TITLE
Use WaitDelay in non_windows script timeout

### DIFF
--- a/changes/20248-non-windows-script-timeout
+++ b/changes/20248-non-windows-script-timeout
@@ -1,0 +1,1 @@
+- fixed issue where macOS scripts failed to timeout on long running commands

--- a/changes/20248-non-windows-script-timeout
+++ b/changes/20248-non-windows-script-timeout
@@ -1,1 +1,1 @@
-- fixed issue where macOS scripts failed to timeout on long running commands
+- fixed issue where macOS and Linux scripts failed to timeout on long running commands

--- a/orbit/pkg/scripts/exec_nonwindows_test.go
+++ b/orbit/pkg/scripts/exec_nonwindows_test.go
@@ -4,12 +4,14 @@ package scripts
 
 import (
 	"context"
+	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/fleetdm/fleet/v4/server/fleet"
 	"github.com/stretchr/testify/require"
@@ -76,5 +78,78 @@ func TestExecCmdNonWindows(t *testing.T) {
 			require.Equal(t, tc.exitCode, exitCode)
 			require.ErrorIs(t, err, tc.error)
 		})
+	}
+}
+
+func writeTestScript(content string) (string, error) {
+	tmpfile, err := ioutil.TempFile("", "testscript*.sh")
+	if err != nil {
+		return "", err
+	}
+
+	if _, err := tmpfile.Write([]byte(content)); err != nil {
+		tmpfile.Close()
+		return "", err
+	}
+	if err := tmpfile.Close(); err != nil {
+		return "", err
+	}
+
+	err = os.Chmod(tmpfile.Name(), 0o700)
+	if err != nil {
+		return "", err
+	}
+
+	return tmpfile.Name(), nil
+}
+
+func TestExecCmdTimeout(t *testing.T) {
+	scriptContent := `#!/bin/sh
+	sleep 5
+	echo "Finished"`
+	scriptPath, err := writeTestScript(scriptContent)
+	if err != nil {
+		t.Fatalf("Failed to write test script: %v", err)
+	}
+	defer os.Remove(scriptPath)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+
+	start := time.Now()
+	output, exitCode, err := ExecCmd(ctx, scriptPath, nil)
+	require.NotNil(t, err)
+	require.Contains(t, err.Error(), "signal: killed")
+	if exitCode != -1 {
+		t.Fatalf("Expected exit code -1, got: %d", exitCode)
+	}
+	if len(output) != 0 {
+		t.Fatalf("Expected no output, got: %s", output)
+	}
+	require.True(t, time.Since(start) <= 5*time.Second)
+}
+
+func TestExecCmdSuccess(t *testing.T) {
+	scriptContent := `#!/bin/sh
+	echo "Hello, World!"`
+	scriptPath, err := writeTestScript(scriptContent)
+	if err != nil {
+		t.Fatalf("Failed to write test script: %v", err)
+	}
+	defer os.Remove(scriptPath)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	output, exitCode, err := ExecCmd(ctx, scriptPath, nil)
+	if err != nil {
+		t.Fatalf("Expected no error, got: %v", err)
+	}
+	if exitCode != 0 {
+		t.Fatalf("Expected exit code 0, got: %d", exitCode)
+	}
+	expectedOutput := "Hello, World!\n"
+	if string(output) != expectedOutput {
+		t.Fatalf("Expected output %q, got: %q", expectedOutput, output)
 	}
 }


### PR DESCRIPTION
#20248

Fixed issue where scripts on macOS were not respecting context.Cancel()

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/Committing-Changes.md#changes-files) for more information.
- [X] Added/updated tests
- [X] Manual QA for all new/changed functionality
- For Orbit and Fleet Desktop changes:
   - [X] Orbit runs on macOS, Linux and Windows. Check if the orbit feature/bugfix should only apply to one platform (`runtime.GOOS`).
   - [X] Manual QA must be performed in the three main OSs, macOS, Windows and Linux.
   - [ ] Auto-update manual QA, from released version of component to new version (see [tools/tuf/test](../tools/tuf/test/README.md)).
