### PR TITLE
Website: update CRM record creation in custom hook

### DIFF
--- a/website/api/hooks/custom/index.js
+++ b/website/api/hooks/custom/index.js
@@ -287,44 +287,52 @@ will be disabled and/or hidden in the UI.
 
               res.locals.me = sanitizedUser;
 
-              // Track a website page view in the CRM for logged-in users:
-              sails.helpers.flow.build(async ()=>{
-                if(sails.config.environment !== 'production') {
-                  sails.log.verbose('Skipping Salesforce integration...');
-                  return;
+              // start tracking a website page view in the CRM for logged-in users:
+              res.once('finish', function onceFinish() {
+                // Only track a page view if the requested URL is not a redirect.
+                if(res.statusCode === 200){
+                  sails.helpers.flow.build(async ()=>{
+                    if(sails.config.environment !== 'production') {
+                      sails.log.verbose('Skipping Salesforce integration...');
+                      return;
+                    }
+                    let recordIds = await sails.helpers.salesforce.updateOrCreateContactAndAccount.with({
+                      emailAddress: sanitizedUser.emailAddress,
+                      firstName: sanitizedUser.firstName,
+                      lastName: sanitizedUser.lastName,
+                      organization: sanitizedUser.organization,
+                    });
+                    let jsforce = require('jsforce');
+                    // login to Salesforce
+                    let salesforceConnection = new jsforce.Connection({
+                      loginUrl : 'https://fleetdm.my.salesforce.com'
+                    });
+                    await salesforceConnection.login(sails.config.custom.salesforceIntegrationUsername, sails.config.custom.salesforceIntegrationPasskey);
+                    let today = new Date();
+                    let nowOn = today.toISOString().replace('Z', '+0000');
+                    // Create the new Fleet website page view record.
+                    return await sails.helpers.flow.build(async ()=>{
+                      return await salesforceConnection.sobject('fleet_website_page_views__c')
+                      .create({
+                        Contact__c: recordIds.salesforceContactId,// eslint-disable-line camelcase
+                        Page_URL__c: `https://fleetdm.com${req.url}`,// eslint-disable-line camelcase
+                        Visited_on__c: nowOn,// eslint-disable-line camelcase
+                      });
+                    }).intercept((err)=>{
+                      return new Error(`Could not create new Fleet website page view record. Error: ${err}`);
+                    });
+                  })
+                  .exec((err)=>{
+                    if(err && typeof err.errorCode !== 'undefined' && err.errorCode === 'DUPLICATES_DETECTED') {
+                      // Swallow errors related to duplicate records.
+                      sails.log.verbose(`Background task failed: When a logged-in user (email: ${sanitizedUser.emailAddress} visited a page, a Contact/Account/website activity record could not be created/updated in the CRM.`, err);
+                    } else if(err){
+                      sails.log.warn(`Background task failed: When a logged-in user (email: ${sanitizedUser.emailAddress} visited a page, a Contact/Account/website activity record could not be created/updated in the CRM.`, err);
+                    }
+                    return;
+                  });//_∏_
                 }
-                let recordIds = await sails.helpers.salesforce.updateOrCreateContactAndAccount.with({
-                  emailAddress: sanitizedUser.emailAddress,
-                  firstName: sanitizedUser.firstName,
-                  lastName: sanitizedUser.lastName,
-                  organization: sanitizedUser.organization,
-                });
-                let jsforce = require('jsforce');
-                // login to Salesforce
-                let salesforceConnection = new jsforce.Connection({
-                  loginUrl : 'https://fleetdm.my.salesforce.com'
-                });
-                await salesforceConnection.login(sails.config.custom.salesforceIntegrationUsername, sails.config.custom.salesforceIntegrationPasskey);
-                let today = new Date();
-                let nowOn = today.toISOString().replace('Z', '+0000');
-                // Create the new Fleet website page view record.
-                return await sails.helpers.flow.build(async ()=>{
-                  return await salesforceConnection.sobject('fleet_website_page_views__c')
-                  .create({
-                    Contact__c: recordIds.salesforceContactId,// eslint-disable-line camelcase
-                    Page_URL__c: `https://fleetdm.com${req.url}`,// eslint-disable-line camelcase
-                    Visited_on__c: nowOn,// eslint-disable-line camelcase
-                  });
-                }).intercept((err)=>{
-                  return new Error(`Could not create new Fleet website page view record. Error: ${err}`);
-                });
-              })
-              .exec((err)=>{
-                if(err){
-                  sails.log.warn(`Background task failed: When a logged-in user (email: ${sanitizedUser.emailAddress} visited a page, a Contact/Account/website activity record could not be created/updated in the CRM.`, err);
-                }
-                return;
-              });//_∏_
+              });
 
               // Include information on the locals as to whether billing features
               // are enabled for this app, and whether email verification is required.


### PR DESCRIPTION
Closes: #22881

Changes:
- updated the website's custom hook to only create Fleet website page view records if the requested URL will not redirect the user and to not log warnings caused by duplicate records.