### PR TITLE
Fleet UI: Update login tab order

### DIFF
--- a/frontend/components/forms/LoginForm/LoginForm.tsx
+++ b/frontend/components/forms/LoginForm/LoginForm.tsx
@@ -141,18 +141,23 @@ const LoginForm = ({
         value={formData.password}
         onChange={onInputChange("password")}
       />
-      <div className={`${baseClass}__forgot-wrap`}>
-        <Link
-          className={`${baseClass}__forgot-link`}
-          to={paths.FORGOT_PASSWORD}
-        >
-          Forgot password?
-        </Link>
+      {/* Actions displayed using CSS column-reverse to preserve tab order */}
+      <div className={`${baseClass}__actions`}>
+        <div className={`${baseClass}__login-actions`}>
+          <Button className={`login-btn button button--brand`} type="submit">
+            Login
+          </Button>
+          {!ssoEnabled && renderSingleSignOnButton()}
+        </div>
+        <div className={`${baseClass}__forgot-wrap`}>
+          <Link
+            className={`${baseClass}__forgot-link`}
+            to={paths.FORGOT_PASSWORD}
+          >
+            Forgot password?
+          </Link>
+        </div>
       </div>
-      <Button className={`login-btn button button--brand`} type="submit">
-        Login
-      </Button>
-      {ssoEnabled && renderSingleSignOnButton()}
     </form>
   );
 };

--- a/frontend/components/forms/LoginForm/LoginForm.tsx
+++ b/frontend/components/forms/LoginForm/LoginForm.tsx
@@ -147,7 +147,7 @@ const LoginForm = ({
           <Button className={`login-btn button button--brand`} type="submit">
             Login
           </Button>
-          {!ssoEnabled && renderSingleSignOnButton()}
+          {ssoEnabled && renderSingleSignOnButton()}
         </div>
         <div className={`${baseClass}__forgot-wrap`}>
           <Link

--- a/frontend/components/forms/LoginForm/_styles.scss
+++ b/frontend/components/forms/LoginForm/_styles.scss
@@ -39,4 +39,17 @@
   &__sso-legend {
     vertical-align: middle;
   }
+
+  &__actions {
+    display: flex;
+    flex-direction: column-reverse;
+    gap: $pad-large;
+  }
+
+  &__login-actions {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: $pad-large;
+  }
 }


### PR DESCRIPTION
## Issue
Part of #22606 

## Description
- Tabbing through login page will go to login and sso button before forgot password button

## Note
- Lint error just assigning tabIndex to each element, so went with a CSS approach
- Dug into why and basically:
  - Screen readers and other assistive technologies rely on the natural DOM order. Changing this with tabIndex can create confusion.
  - Web accessibility guidelines (WCAG) recommend maintaining a logical tab order that matches the visual layout. Using positive tabIndex values is often discouraged in accessibility audits.
  - tabIndex doesn't allow for easy responsive design changes without JavaScript intervention.
- Suggested: Use CSS for visual positioning if needed. These can help you visually reorder elements while maintaining the logical HTML structure.

## Screenrecording
https://www.loom.com/share/a748451b0270460a89daa0f106b4f027?sid=011d2531-1349-4afd-8fa7-9a56297d372b

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Manual QA for all new/changed functionality

