### PR TITLE
Change Ubuntu version in Heroku deploy workflows

### DIFF
--- a/.github/workflows/deploy-fleet-website.yml
+++ b/.github/workflows/deploy-fleet-website.yml
@@ -27,7 +27,7 @@ jobs:
   build:
     if: ${{ github.repository == 'fleetdm/fleet' }}
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     strategy:
       matrix:

--- a/.github/workflows/deploy-vulnerability-dashboard.yml
+++ b/.github/workflows/deploy-vulnerability-dashboard.yml
@@ -15,7 +15,7 @@ jobs:
       contents: write  # for Git to git push
     if: ${{ github.repository == 'fleetdm/fleet' }}
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     strategy:
       matrix:


### PR DESCRIPTION
Closes: #22931

Changes:
- Updated the deploy workflows for the Fleet website and the vulnerability dashboard to run on Ubuntu 22.04 to prevent issues we've been seeing with the Heroku deploy action and the latest version of Ubuntu.