### PR TITLE
Website: Update button hover state on /try-fleet page

### DIFF
--- a/website/assets/styles/pages/fleetctl-preview.less
+++ b/website/assets/styles/pages/fleetctl-preview.less
@@ -161,6 +161,11 @@
       }
 
     }
+    &:hover {
+      [purpose='install-copy-button'], [purpose='command-copy-button'] {
+        background-color: #F2F2F5;
+      }
+    }
   }
   [purpose='tip'] {
     margin: 16px 0 32px;

--- a/website/assets/styles/pages/fleetctl-preview.less
+++ b/website/assets/styles/pages/fleetctl-preview.less
@@ -137,7 +137,7 @@
     }
 
     [purpose='install-copy-button'], [purpose='command-copy-button'] {
-      display: none;
+      display: inline-block;
       background: url('/images/icon-copy-16x16@2x.png');
       font-size: 32px;
       position: absolute;
@@ -160,14 +160,6 @@
         background-position: center;
       }
 
-    }
-    &:hover {
-      [purpose='install-copy-button'], [purpose='command-copy-button'] {
-        display: inline-block;
-        &:hover {
-          background-color: #F2F2F5;
-        }
-      }
     }
   }
   [purpose='tip'] {


### PR DESCRIPTION
Related to: #22885

Changes:
- Updated the copy buttons on the /try-fleet page to always be visible.