### PR TITLE
Host issues query optimization

### DIFF
--- a/changes/22366-host-issues
+++ b/changes/22366-host-issues
@@ -1,0 +1,1 @@
+- fixed issue where the vulnerabilities cron failed to complete due to a large temporary table creation when calculating host issue counts

--- a/server/datastore/mysql/hosts.go
+++ b/server/datastore/mysql/hosts.go
@@ -5392,21 +5392,27 @@ func (ds *Datastore) UpdateHostIssuesVulnerabilities(ctx context.Context) error 
 		}
 		criticalVulnerabilitiesCountStmt := `
 		SELECT combined.host_id, COUNT(*) as count
-		FROM (SELECT host_id, cve
+		FROM (
+			SELECT host_id, sc.cve
 			FROM host_software hs
 			INNER JOIN software_cve sc ON sc.software_id = hs.software_id
+			INNER JOIN cve_meta cm ON cm.cve = sc.cve
 			WHERE host_id IN (?)
+			AND cm.cvss_score > ?
+
 			UNION
-			SELECT host_id, cve
+
+			SELECT host_id, osv.cve
 			FROM host_operating_system hos
 			INNER JOIN operating_system_vulnerabilities osv ON osv.operating_system_id = hos.os_id
+			INNER JOIN cve_meta cm ON cm.cve = osv.cve
 			WHERE host_id IN (?)
+			AND cm.cvss_score > ?
 		) combined
 		INNER JOIN cve_meta cm ON cm.cve = combined.cve
-		WHERE cm.cvss_score > ?
 		GROUP BY combined.host_id
 		ORDER BY combined.host_id`
-		stmt, args, err := sqlx.In(criticalVulnerabilitiesCountStmt, allHostIDs[start:end], allHostIDs[start:end], criticalCVSSScoreCutoff)
+		stmt, args, err := sqlx.In(criticalVulnerabilitiesCountStmt, allHostIDs[start:end], criticalCVSSScoreCutoff, allHostIDs[start:end], criticalCVSSScoreCutoff)
 		if err != nil {
 			return ctxerr.Wrap(ctx, err, "building IN statement for getting critical vulnerabilities count")
 		}

--- a/server/datastore/mysql/hosts.go
+++ b/server/datastore/mysql/hosts.go
@@ -5383,7 +5383,8 @@ func (ds *Datastore) UpdateHostIssuesVulnerabilities(ctx context.Context) error 
 	}
 	var criticalCounts []issuesCount
 	// We must batch the query extracting the critical vulnerabilities count because the query is too complex for MySQL to handle in one go.
-	// We saw MySQL error 1114 (HY000), where the temporary table reached its max capacity.
+	// We saw MySQL error 1114 (HY000), where the temporary table reached its max capacity.  Temporary table size is reduced further by
+	// filtering cvss_score in the subqueries.
 	for i := 0; i < len(allHostIDs); i += hostIssuesInsertBatchSize {
 		start := i
 		end := i + hostIssuesInsertBatchSize


### PR DESCRIPTION
#22366 

Moving the cvss score filter into the subqueries to reduce the size of the temporary table created by UNION.

Using the loadtest db dump this reduced row count in the temp table from 4.7M to 1.5M and reduced execution time from 8.9s to 800ms.

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/Committing-Changes.md#changes-files) for more information.
- [X] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [ ] Added/updated tests
- [X] Manual QA for all new/changed functionality
