### PR TITLE
Custom URL for MDM routes: Document impact of changing

### DIFF
--- a/docs/Configuration/yaml-files.md
+++ b/docs/Configuration/yaml-files.md
@@ -486,7 +486,7 @@ org_settings:
 - `query_reports_disabled` disables query reports and deletes existing repors (default: `false`).
 - `query_report_cap` sets the maximum number of results to store per query report before the report is clipped. If increasing this cap, we recommend enabling reports for one query at time and monitoring your infrastructure. (Default: `1000`)
 - `scripts_disabled` blocks access to run scripts. Scripts may still be added in the UI and CLI (defaul: `false`).
-- `server_url` is the base URL of the Fleet instance (default: provided during Fleet setup)
+- `server_url` is the base URL of the Fleet instance. If this URL changes and Apple (macOS, iOS, iPadOS) hosts already have MDM turned on, the end users will have to turn MDM off and back on to use MDM features. (default: provided during Fleet setup)
 
 Can only be configured for all teams (`org_settings`).
 
@@ -710,16 +710,18 @@ Once the IdP settings are configured, you can use the [`controls.macos_setup.ena
 
 Can only be configured for all teams (`org_settings`).
 
-##### apple_server_url
+##### apple_client_url
 
-Update this URL if you're self-hosting Fleet and you want your hosts to talk to a different URL for MDM features. (If not configured, hosts will use the base URL of the Fleet instance.)
+Update this URL if you're self-hosting Fleet and you want your hosts to talk to this URL for MDM features. (If not configured, hosts will use the base URL of the Fleet instance.)
+
+If this URL changes and hosts already have MDM turned on, the end users will have to turn MDM off and back on to use MDM features.
 
 ##### Example
 
 ```yaml
 org_settings:
   mdm:
-    apple_server_url: https://instance.fleet.com
+    apple_client_url: https://instance.fleet.com
 ```
 
 Can only be configured for all teams (`org_settings`).

--- a/docs/Configuration/yaml-files.md
+++ b/docs/Configuration/yaml-files.md
@@ -710,7 +710,7 @@ Once the IdP settings are configured, you can use the [`controls.macos_setup.ena
 
 Can only be configured for all teams (`org_settings`).
 
-##### apple_client_url
+##### apple_server_url
 
 Update this URL if you're self-hosting Fleet and you want your hosts to talk to this URL for MDM features. (If not configured, hosts will use the base URL of the Fleet instance.)
 
@@ -721,7 +721,7 @@ If this URL changes and hosts already have MDM turned on, the end users will hav
 ```yaml
 org_settings:
   mdm:
-    apple_client_url: https://instance.fleet.com
+    apple_server_url: https://instance.fleet.com
 ```
 
 Can only be configured for all teams (`org_settings`).

--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -1242,7 +1242,7 @@ Modifies the Fleet's configuration with the supplied information.
       "enable_end_user_authentication": false,
       "macos_setup_assistant": "path/to/config.json"
     },
-    "apple_server_url": "https://instance.fleet.com"
+    "apple_client_url": "https://instance.fleet.com"
   },
   "agent_options": {
     "config": {
@@ -1719,7 +1719,7 @@ _Available in Fleet Premium._
 | macos_setup         | object  | See [`mdm.macos_setup`](#mdm-macos-setup). |
 | macos_settings         | object  | See [`mdm.macos_settings`](#mdm-macos-settings). |
 | windows_settings         | object  | See [`mdm.windows_settings`](#mdm-windows-settings). |
-| apple_server_url         | string  | Update this URL if you're self-hosting Fleet and you want your hosts to talk to a different URL for MDM features. (If not configured, hosts will use the base URL of the Fleet instance.) |
+| apple_client_url         | string  | Update this URL if you're self-hosting Fleet and you want your hosts to talk to this URL for MDM features. If this URL changes and Apple (macOS, iOS, iPadOS) hosts already have MDM turned on, the end users will have to turn MDM off and back on to use MDM features. (If not configured, hosts will use the base URL of the Fleet instance.)  |
 
 <br/>
 

--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -1719,7 +1719,9 @@ _Available in Fleet Premium._
 | macos_setup         | object  | See [`mdm.macos_setup`](#mdm-macos-setup). |
 | macos_settings         | object  | See [`mdm.macos_settings`](#mdm-macos-settings). |
 | windows_settings         | object  | See [`mdm.windows_settings`](#mdm-windows-settings). |
-| apple_server_url         | string  | Update this URL if you're self-hosting Fleet and you want your hosts to talk to this URL for MDM features. If this URL changes and Apple (macOS, iOS, iPadOS) hosts already have MDM turned on, the end users will have to turn MDM off and back on to use MDM features. (If not configured, hosts will use the base URL of the Fleet instance.)  |
+| apple_server_url         | string  | Update this URL if you're self-hosting Fleet and you want your hosts to talk to this URL for MDM features. (If not configured, hosts will use the base URL of the Fleet instance.)  |
+
+> Note: If `apple_server_url` changes and Apple (macOS, iOS, iPadOS) hosts already have MDM turned on, the end users will have to turn MDM off and back on to use MDM features.
 
 <br/>
 

--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -1242,7 +1242,7 @@ Modifies the Fleet's configuration with the supplied information.
       "enable_end_user_authentication": false,
       "macos_setup_assistant": "path/to/config.json"
     },
-    "apple_client_url": "https://instance.fleet.com"
+    "apple_server_url": "https://instance.fleet.com"
   },
   "agent_options": {
     "config": {
@@ -1719,7 +1719,7 @@ _Available in Fleet Premium._
 | macos_setup         | object  | See [`mdm.macos_setup`](#mdm-macos-setup). |
 | macos_settings         | object  | See [`mdm.macos_settings`](#mdm-macos-settings). |
 | windows_settings         | object  | See [`mdm.windows_settings`](#mdm-windows-settings). |
-| apple_client_url         | string  | Update this URL if you're self-hosting Fleet and you want your hosts to talk to this URL for MDM features. If this URL changes and Apple (macOS, iOS, iPadOS) hosts already have MDM turned on, the end users will have to turn MDM off and back on to use MDM features. (If not configured, hosts will use the base URL of the Fleet instance.)  |
+| apple_server_url         | string  | Update this URL if you're self-hosting Fleet and you want your hosts to talk to this URL for MDM features. If this URL changes and Apple (macOS, iOS, iPadOS) hosts already have MDM turned on, the end users will have to turn MDM off and back on to use MDM features. (If not configured, hosts will use the base URL of the Fleet instance.)  |
 
 <br/>
 


### PR DESCRIPTION
If you change the Fleet server URL or Apple MDM server URL, any macOS, iOS, or iPadOS host that already has MDM turned on won’t be able to renew SCEP certificates. 

To the IT admin, this means that the end user will have to turn MDM off and back on.
