### PR TITLE
fix for the enrollment page to not send back a 404 page

### DIFF
--- a/changes/fix-issue-with-enroll-handler
+++ b/changes/fix-issue-with-enroll-handler
@@ -1,0 +1,1 @@
+- fix an issue with the byod enrollment page where it sometimes would show a 404 page.

--- a/cmd/fleet/serve.go
+++ b/cmd/fleet/serve.go
@@ -1035,12 +1035,11 @@ the way that the Fleet server works.
 				if setupRequired {
 					apiHandler = service.WithSetup(svc, logger, apiHandler)
 					frontendHandler = service.RedirectLoginToSetup(svc, logger, frontendHandler, config.Server.URLPrefix)
-					endUserEnrollOTAHandler = service.RedirectLoginToSetup(svc, logger, frontendHandler, config.Server.URLPrefix)
 				} else {
 					frontendHandler = service.RedirectSetupToLogin(svc, logger, frontendHandler, config.Server.URLPrefix)
-					endUserEnrollOTAHandler = service.ServeEndUserEnrollOTA(config.Server.URLPrefix, logger)
 				}
 
+				endUserEnrollOTAHandler = service.ServeEndUserEnrollOTA(svc, config.Server.URLPrefix, logger)
 			}
 
 			healthCheckers := make(map[string]health.Checker)
@@ -1182,6 +1181,7 @@ the way that the Fleet server works.
 				}
 				apiHandler.ServeHTTP(rw, req)
 			})
+
 			rootMux.Handle("/enroll", endUserEnrollOTAHandler)
 			rootMux.Handle("/", frontendHandler)
 

--- a/server/service/frontend.go
+++ b/server/service/frontend.go
@@ -9,6 +9,7 @@ import (
 
 	assetfs "github.com/elazarl/go-bindata-assetfs"
 	"github.com/fleetdm/fleet/v4/server/bindata"
+	"github.com/fleetdm/fleet/v4/server/fleet"
 	"github.com/go-kit/log"
 )
 
@@ -70,7 +71,7 @@ func ServeFrontend(urlPrefix string, sandbox bool, logger log.Logger) http.Handl
 	})
 }
 
-func ServeEndUserEnrollOTA(urlPrefix string, logger log.Logger) http.Handler {
+func ServeEndUserEnrollOTA(svc fleet.Service, urlPrefix string, logger log.Logger) http.Handler {
 	herr := func(w http.ResponseWriter, err string) {
 		logger.Log("err", err)
 		http.Error(w, err, http.StatusInternalServerError)
@@ -78,6 +79,16 @@ func ServeEndUserEnrollOTA(urlPrefix string, logger log.Logger) http.Handler {
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		writeBrowserSecurityHeaders(w)
+		setupRequired, err := svc.SetupRequired(r.Context())
+		if err != nil {
+			herr(w, "setup required err: "+err.Error())
+			return
+		}
+
+		if setupRequired {
+			herr(w, "fleet instance not setup: "+err.Error())
+			return
+		}
 
 		fs := newBinaryFileSystem("/frontend")
 		file, err := fs.Open("templates/enroll-ota.html")

--- a/server/service/frontend.go
+++ b/server/service/frontend.go
@@ -86,7 +86,7 @@ func ServeEndUserEnrollOTA(svc fleet.Service, urlPrefix string, logger log.Logge
 		}
 
 		if setupRequired {
-			herr(w, "fleet instance not setup: "+err.Error())
+			herr(w, "fleet instance not setup")
 			return
 		}
 

--- a/server/service/frontend_test.go
+++ b/server/service/frontend_test.go
@@ -2,12 +2,15 @@ package service
 
 import (
 	"bytes"
+	"context"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"testing"
 
+	"github.com/fleetdm/fleet/v4/server/fleet"
+	"github.com/fleetdm/fleet/v4/server/mock"
 	"github.com/go-kit/log"
 	"github.com/stretchr/testify/require"
 )
@@ -47,7 +50,11 @@ func TestServeEndUserEnrollOTA(t *testing.T) {
 		t.Skip("This test requires running with -tags full")
 	}
 
-	svc, _ := newTestService(t, nil, nil, nil)
+	ds := new(mock.DataStore)
+	ds.ListUsersFunc = func(ctx context.Context, opt fleet.UserListOptions) ([]*fleet.User, error) {
+		return []*fleet.User{{}}, nil
+	}
+	svc, _ := newTestService(t, ds, nil, nil)
 
 	logger := log.NewLogfmtLogger(os.Stdout)
 	h := ServeEndUserEnrollOTA(svc, "", logger)

--- a/server/service/frontend_test.go
+++ b/server/service/frontend_test.go
@@ -46,8 +46,11 @@ func TestServeEndUserEnrollOTA(t *testing.T) {
 	if !hasBuildTag("full") {
 		t.Skip("This test requires running with -tags full")
 	}
+
+	svc, _ := newTestService(t, nil, nil, nil)
+
 	logger := log.NewLogfmtLogger(os.Stdout)
-	h := ServeEndUserEnrollOTA("", logger)
+	h := ServeEndUserEnrollOTA(svc, "", logger)
 	ts := httptest.NewServer(h)
 	t.Cleanup(func() {
 		ts.Close()


### PR DESCRIPTION
makes a fix to the enroll byod handler. The hander use to be set once when the server started but this lead to a user receiving a 404 page after the fleet instance setup was complete but was not restarted.

now the `/enroll` handler will check for the setup requirement itself. There is some error handling when the setup is  required. if the fleet instance has been setup, they will get the enroll byod page.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/Committing-Changes.md#changes-files) for more information.
