### PR TITLE
fix for downloading manual enrolment profile when device token is expired

### DIFF
--- a/changes/22322-fix-issue-man-enrollment-device
+++ b/changes/22322-fix-issue-man-enrollment-device
@@ -1,0 +1,2 @@
+- fix issue when trying to download the manual enrollment profile when device token is expired. We
+  now show an error for this case.

--- a/frontend/pages/hosts/details/DeviceUserPage/DeviceUserPage.tsx
+++ b/frontend/pages/hosts/details/DeviceUserPage/DeviceUserPage.tsx
@@ -23,6 +23,8 @@ import Spinner from "components/Spinner";
 import Button from "components/buttons/Button";
 import TabsWrapper from "components/TabsWrapper";
 import Icon from "components/Icon/Icon";
+import FlashMessage from "components/FlashMessage";
+
 import { normalizeEmptyValues } from "utilities/helpers";
 import PATHS from "router/paths";
 import {
@@ -87,7 +89,9 @@ const DeviceUserPage = ({
 }: IDeviceUserPageProps): JSX.Element => {
   const deviceAuthToken = device_auth_token;
 
-  const { renderFlash } = useContext(NotificationContext);
+  const { renderFlash, notification, hideFlash } = useContext(
+    NotificationContext
+  );
 
   const [isPremiumTier, setIsPremiumTier] = useState(false);
   const [showInfoModal, setShowInfoModal] = useState(false);
@@ -477,6 +481,11 @@ const DeviceUserPage = ({
   return (
     <div className="app-wrap">
       <UnsupportedScreenSize />
+      <FlashMessage
+        fullWidth
+        notification={notification}
+        onRemoveFlash={hideFlash}
+      />
       <nav className="site-nav-container">
         <div className="site-nav-content">
           <ul className="site-nav-list">

--- a/frontend/pages/hosts/details/DeviceUserPage/ManualEnrollMdmModal/_styles.scss
+++ b/frontend/pages/hosts/details/DeviceUserPage/ManualEnrollMdmModal/_styles.scss
@@ -1,21 +1,7 @@
 .manual-enroll-mdm-modal {
   @include enroll-mdm-modal;
 
-  // TODO: make a link component that appears as a button.
-  &__download-link {
-    display: inline-block;
-    border-radius: 6px;
+  &__download-button {
     margin-top: 12px;
-    background-color: $core-vibrant-blue;
-    color: $core-white;
-    padding: $pad-small $pad-medium;
-
-    &:hover {
-      background-color: $core-vibrant-blue-over;
-    }
-
-    &:active {
-      background-color: $core-vibrant-blue-down;
-    }
   }
 }

--- a/frontend/services/entities/mdm.ts
+++ b/frontend/services/entities/mdm.ts
@@ -331,6 +331,11 @@ const mdmService = {
     const url = `${MDM_COMMANDS_RESULTS}?command_uuid=${command_uuid}`;
     return sendRequest("GET", url);
   },
+
+  downloadManualEnrollmentProfile: (token: string) => {
+    const { DEVICE_USER_MDM_ENROLLMENT_PROFILE } = endpoints;
+    return sendRequest("GET", DEVICE_USER_MDM_ENROLLMENT_PROFILE(token));
+  },
 };
 
 export default mdmService;


### PR DESCRIPTION
relates to #22322

Makes a fix in the UI so that we show an error message when the device token is expired and the user tried to download the mdm enrollment profile.

**Showing error when device token is expired and tried to download mdm enrollment profile**
https://www.loom.com/share/6306dcf851c24d5f8916ecb2498288cb


- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
- [x] Manual QA for all new/changed functionality
