### PR TITLE
Remove docker check during release publish

### DIFF
--- a/tools/release/publish_release.sh
+++ b/tools/release/publish_release.sh
@@ -626,15 +626,6 @@ fi
 
 start_ver_tag=fleet-$start_version
 
-# Check if there are updates to fleetctl dependencies (only when doing security updates to base images).
-if [[ $(git diff $start_ver_tag ./tools/wix-docker ./tools/bomutils-docker) ]]; then
-	echo "⚠️  Changes in fleetctl dependencies detected, please run the following before continuing the release:"
-	echo "1. git tag fleetctl-docker-deps-$next_ver && git push origin fleetctl-docker-deps-$next_ver"
-	echo "2. Wait for the triggered https://github.com/fleetdm/fleet/actions/workflows/release-fleetctl-docker-deps.yaml build to finish."
-	echo "3. Smoke test the pushed images by manually running the following action: https://github.com/fleetdm/fleet/actions/workflows/test-packaging.yml"
-	exit 1
-fi
-
 if [[ "$minor" == "true" ]]; then
     echo "Minor release from $start_version to $next_ver"
     # For scheduled minor releases, we want to branch off of main


### PR DESCRIPTION
@lucasmrod It sounded like we didn't need this check here anymore, is that correct? If we do still need a check, is there somewhere else we could put it that wouldn't block the release process? 