### PR TITLE
Custom OS settings guide: Modify OS settings on macOS, iOS, iPadOS, and Windows

### DIFF
--- a/articles/custom-os-settings.md
+++ b/articles/custom-os-settings.md
@@ -20,6 +20,8 @@ Fleet UI:
 
 4. To modify the OS setting, first remove the old configuration profile and then add the new one.
 
+> On macOS, iOS, and iPadOS, removing a configuration profile will remove enforcement of the OS setting.
+
 Fleet API: API documentation is [here](https://fleetdm.com/docs/rest-api/rest-api#add-custom-os-setting-configuration-profile)
 
 ### OS settings status

--- a/articles/custom-os-settings.md
+++ b/articles/custom-os-settings.md
@@ -18,7 +18,7 @@ Fleet UI:
 
 3. Select **Upload** and choose your configuration profile.
 
-4. To modify the OS setting, first add a new configuration profile and then remove the old one.
+4. To modify the OS setting, first remove the old configuration profile and then add the new one.
 
 Fleet API: API documentation is [here](https://fleetdm.com/docs/rest-api/rest-api#add-custom-os-setting-configuration-profile)
 

--- a/articles/custom-os-settings.md
+++ b/articles/custom-os-settings.md
@@ -6,7 +6,7 @@ In Fleet you can enforce OS settings like security restrictions, screen lock, Wi
 
 You can enforce OS settings using the Fleet UI, Fleet API, or [Fleet's GitOps workflow](https://github.com/fleetdm/fleet-gitops).
 
-For macOS hosts, Fleet recommends the [iMazing Profile Creator](https://imazing.com/profile-editor) tool for creating and exporting macOS configuration profiles.
+For macOS, iOS, and iPadOS hosts, Fleet recommends the [iMazing Profile Creator](https://imazing.com/profile-editor) tool for creating and exporting macOS configuration profiles.
 
 For Windows hosts, copy out this [Windows configuration profile template](https://fleetdm.com/example-windows-profile) and update the profile using any configuration service providers (CSPs) from [Microsoft's MDM protocol](https://learn.microsoft.com/en-us/windows/client-management/mdm/).
 
@@ -17,6 +17,8 @@ Fleet UI:
 2. Choose which team you want to add a configuration profile to by selecting the desired team in the teams dropdown in the upper left corner. Teams are available in Fleet Premium.
 
 3. Select **Upload** and choose your configuration profile.
+
+4. To modify the OS setting, first add a new configuration profile and then remove the old one.
 
 Fleet API: API documentation is [here](https://fleetdm.com/docs/rest-api/rest-api#add-custom-os-setting-configuration-profile)
 


### PR DESCRIPTION
Document interim best practice for modifying OS settings. Later Fleet might add an "Edit" button in the UI so the IT admin doesn't have to add a new profile and then remove the old.
