### PR TITLE
Allow Render connectionString as redis.address

### DIFF
--- a/changes/23057-redis-address
+++ b/changes/23057-redis-address
@@ -1,0 +1,1 @@
+Allow FLEET_REDIS_ADDRESS to include a `redis://` prefix

--- a/changes/23057-redis-address
+++ b/changes/23057-redis-address
@@ -1,1 +1,1 @@
-Allow FLEET_REDIS_ADDRESS to include a `redis://` prefix
+Allow FLEET_REDIS_ADDRESS to include a `redis://` prefix. Allowed formats are: `redis://host:port` or `host:port`

--- a/cmd/fleet/serve.go
+++ b/cmd/fleet/serve.go
@@ -312,8 +312,12 @@ the way that the Fleet server works.
 				}
 			}
 
+			// Strip the Redis URI scheme if it's present. Scheme docs are at: https://www.iana.org/assignments/uri-schemes/uri-schemes.xhtml
+			// This allows us to use Render's Redis service in render.yaml, including the free tier.
+			// In the future, we could support the full Redis URI if needed (including username, password, database, etc.)
+			redisAddress := strings.TrimPrefix(config.Redis.Address, "redis://")
 			redisPool, err := redis.NewPool(redis.PoolConfig{
-				Server:                    config.Redis.Address,
+				Server:                    redisAddress,
 				Username:                  config.Redis.Username,
 				Password:                  config.Redis.Password,
 				Database:                  config.Redis.Database,


### PR DESCRIPTION
#23057 

Render provides [connectionString](https://docs.render.com/blueprint-spec#connectionstring) for their Redis service, which Fleet cannot take because it includes `redis://` prefix.

Once this change is released, we can [update our render.yaml](https://github.com/fleetdm/fleet/pull/23056/files#diff-a64cf250b418ab8feee6c682a3d8cbd3b72cf24d4a241adeaf35c98b84045f93)

# Checklist for submitter
- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/Committing-Changes.md#changes-files) for more information.
- [x] Manual QA for all new/changed functionality
