### PR TITLE
Msp dashboard: Update error handling in software-related actions

### DIFF
--- a/ee/bulk-operations-dashboard/api/controllers/software/upload-software.js
+++ b/ee/bulk-operations-dashboard/api/controllers/software/upload-software.js
@@ -51,8 +51,8 @@ module.exports = {
       };
       await UndeployedSoftware.create(newSoftwareInfo);
     } else {
+      uploadedSoftware = await sails.uploadOne(newSoftware, {bucket: sails.config.uploads.bucketWithPostfix});
       for(let teamApid of teams) {
-        uploadedSoftware = await sails.uploadOne(newSoftware, {bucket: sails.config.uploads.bucketWithPostfix});
         var WritableStream = require('stream').Writable;
         await sails.cp(uploadedSoftware.fd, {bucket: sails.config.uploads.bucketWithPostfix}, {
           adapter: ()=>{
@@ -88,7 +88,7 @@ module.exports = {
                     doneWithThisFile();
                   })
                   .catch((err)=>{
-                    doneWithThisFile(err);
+                    doneWithThisFile(require('util').inspect(err, {depth:null}));
                   });
                 };//ƒ
                 return receiver__;

--- a/ee/bulk-operations-dashboard/api/controllers/software/upload-software.js
+++ b/ee/bulk-operations-dashboard/api/controllers/software/upload-software.js
@@ -106,7 +106,7 @@ module.exports = {
         })
         .intercept({name: 'AxiosError'}, async (error)=>{
           await sails.rm(sails.config.uploads.prefixForFileDeletion+uploadedSoftware.fd);
-          sails.log.warn(`When attempting to upload a software installer, an unexpected error occurred communicating with the Fleet API, ${require('util').inspect(error, {depth: 0})}`)
+          sails.log.warn(`When attempting to upload a software installer, an unexpected error occurred communicating with the Fleet API, ${require('util').inspect(error, {depth: 0})}`);
           return {'softwareUploadFailed': error};
         });
       }

--- a/ee/bulk-operations-dashboard/assets/js/components/cloud-error.component.js
+++ b/ee/bulk-operations-dashboard/assets/js/components/cloud-error.component.js
@@ -43,7 +43,7 @@ parasails.registerComponent('cloud-error', {
   //  ╩ ╩ ╩ ╩ ╩╩═╝
   template: `
   <div>
-    <p :class="{ 'm-0': beWithoutMargins }" class="text-danger"><slot name="default">An error occured while processing your request. Please try again, or contact Fleet if the error persists.</slot></p>
+    <p :class="{ 'm-0': beWithoutMargins }" class="text-danger"><slot name="default">An unexpected error occurred communicating with the Fleet API</slot></p>
   </div>
   `,
 

--- a/ee/bulk-operations-dashboard/assets/js/components/cloud-error.component.js
+++ b/ee/bulk-operations-dashboard/assets/js/components/cloud-error.component.js
@@ -43,7 +43,7 @@ parasails.registerComponent('cloud-error', {
   //  ╩ ╩ ╩ ╩ ╩╩═╝
   template: `
   <div>
-    <p :class="{ 'm-0': beWithoutMargins }" class="text-danger"><slot name="default">An error occured while processing your request. Please check your information and try again, or <a href="/contact">contact support</a> if the error persists.</slot></p>
+    <p :class="{ 'm-0': beWithoutMargins }" class="text-danger"><slot name="default">An error occured while processing your request. Please try again, or contact Fleet if the error persists.</slot></p>
   </div>
   `,
 

--- a/ee/bulk-operations-dashboard/assets/js/pages/software/software.page.js
+++ b/ee/bulk-operations-dashboard/assets/js/pages/software/software.page.js
@@ -95,6 +95,7 @@ parasails.registerPage('software', {
       this.modal = '';
       this.formErrors = {};
       this.formData = {};
+      this.cloudError = '';
       this.showAdvancedOptions = false;
       await this.forceRender();
     },


### PR DESCRIPTION
For: https://github.com/fleetdm/confidential/issues/8473

Changes:
- Updated the cloud error components message
- Updated the upload-software action to log errors about failed requests to the Fleet API
- Updated the edit-software action to log errors about failed requests to the Fleet API, and to delete temporary files when requests fail.
- Updated the software page to clear cloud errors when modals are closed.