### PR TITLE
fix to PUT /setup_experience/software and GET /setup_experience/software endpoints

### DIFF
--- a/frontend/__mocks__/softwareMock.ts
+++ b/frontend/__mocks__/softwareMock.ts
@@ -229,7 +229,6 @@ const DEFAULT_SOFTWARE_TITLE_MOCK: ISoftwareTitle = {
   versions: [createMockSoftwareTitleVersion()],
   software_package: createMockSoftwarePackage(),
   app_store_app: null,
-  install_during_setup: false,
 };
 
 export const createMockSoftwareTitle = (

--- a/frontend/interfaces/software.ts
+++ b/frontend/interfaces/software.ts
@@ -71,6 +71,7 @@ export interface ISoftwarePackage {
     pending_uninstall: number;
     failed_uninstall: number;
   };
+  install_during_setup: boolean;
 }
 
 export const isSoftwarePackage = (
@@ -101,7 +102,6 @@ export interface ISoftwareTitle {
   software_package: ISoftwarePackage | null;
   app_store_app: IAppStoreApp | null;
   browser?: BrowserType;
-  install_during_setup: boolean;
 }
 
 export interface ISoftwareTitleDetails {

--- a/frontend/interfaces/software.ts
+++ b/frontend/interfaces/software.ts
@@ -71,7 +71,7 @@ export interface ISoftwarePackage {
     pending_uninstall: number;
     failed_uninstall: number;
   };
-  install_during_setup: boolean;
+  install_during_setup?: boolean;
 }
 
 export const isSoftwarePackage = (
@@ -90,6 +90,7 @@ export interface IAppStoreApp {
     pending: number;
     failed: number;
   };
+  install_during_setup?: boolean;
 }
 
 export interface ISoftwareTitle {

--- a/frontend/pages/ManageControlsPage/SetupExperience/cards/InstallSoftware/InstallSoftware.tsx
+++ b/frontend/pages/ManageControlsPage/SetupExperience/cards/InstallSoftware/InstallSoftware.tsx
@@ -2,11 +2,10 @@ import React, { useState } from "react";
 import { useQuery } from "react-query";
 import { AxiosError } from "axios";
 
+import mdmAPI, {
+  IGetSetupExperienceSoftwareResponse,
+} from "services/entities/mdm";
 import { ISoftwareTitle } from "interfaces/software";
-import softwareAPI, {
-  ISoftwareTitlesResponse,
-} from "services/entities/software";
-
 import { DEFAULT_USE_QUERY_OPTIONS } from "utilities/constants";
 
 import SectionHeader from "components/SectionHeader";
@@ -35,13 +34,16 @@ const InstallSoftware = ({ currentTeamId }: IInstallSoftwareProps) => {
     isLoading,
     isError,
     refetch: refetchSoftwareTitles,
-  } = useQuery<ISoftwareTitlesResponse, AxiosError, ISoftwareTitle[]>(
+  } = useQuery<
+    IGetSetupExperienceSoftwareResponse,
+    AxiosError,
+    ISoftwareTitle[]
+  >(
     ["install-software", currentTeamId],
     () =>
-      softwareAPI.getSoftwareTitles({
-        teamId: currentTeamId,
-        availableForInstall: true,
-        perPage: PER_PAGE_SIZE,
+      mdmAPI.getSetupExperienceSoftware({
+        team_id: currentTeamId,
+        per_page: PER_PAGE_SIZE,
       }),
     {
       ...DEFAULT_USE_QUERY_OPTIONS,

--- a/frontend/pages/ManageControlsPage/SetupExperience/cards/InstallSoftware/components/AddInstallSoftware/AddInstallSoftware.tests.tsx
+++ b/frontend/pages/ManageControlsPage/SetupExperience/cards/InstallSoftware/components/AddInstallSoftware/AddInstallSoftware.tests.tsx
@@ -2,7 +2,10 @@ import React from "react";
 import { render, screen } from "@testing-library/react";
 import { noop } from "lodash";
 
-import { createMockSoftwareTitle } from "__mocks__/softwareMock";
+import {
+  createMockSoftwarePackage,
+  createMockSoftwareTitle,
+} from "__mocks__/softwareMock";
 
 import AddInstallSoftware from "./AddInstallSoftware";
 
@@ -38,8 +41,18 @@ describe("AddInstallSoftware", () => {
       <AddInstallSoftware
         currentTeamId={1}
         softwareTitles={[
-          createMockSoftwareTitle({ install_during_setup: true }),
-          createMockSoftwareTitle({ install_during_setup: true }),
+          createMockSoftwareTitle({
+            software_package: createMockSoftwarePackage({
+              install_during_setup: true,
+            }),
+          }),
+          createMockSoftwareTitle(
+            createMockSoftwareTitle({
+              software_package: createMockSoftwarePackage({
+                install_during_setup: true,
+              }),
+            })
+          ),
           createMockSoftwareTitle(),
         ]}
         onAddSoftware={noop}

--- a/frontend/pages/ManageControlsPage/SetupExperience/cards/InstallSoftware/components/AddInstallSoftware/AddInstallSoftware.tsx
+++ b/frontend/pages/ManageControlsPage/SetupExperience/cards/InstallSoftware/components/AddInstallSoftware/AddInstallSoftware.tsx
@@ -22,7 +22,7 @@ const AddInstallSoftware = ({
 }: IAddInstallSoftwareProps) => {
   const hasNoSoftware = softwareTitles.length === 0;
   const installDuringSetupCount = softwareTitles.filter(
-    (software) => software.install_during_setup
+    (software) => software.software_package?.install_during_setup
   ).length;
 
   let addedText = <></>;

--- a/frontend/services/entities/mdm.ts
+++ b/frontend/services/entities/mdm.ts
@@ -9,6 +9,7 @@ import { API_NO_TEAM_ID } from "interfaces/team";
 import sendRequest from "services";
 import endpoints from "utilities/endpoints";
 import { buildQueryStringFromParams } from "utilities/url";
+import { ISoftwareTitlesResponse } from "./software";
 
 export interface IEulaMetadataResponse {
   name: string;
@@ -87,6 +88,13 @@ export interface IGetSetupExperienceScriptResponse {
   created_at: string;
   updated_at: string;
 }
+
+interface IGetSetupExperienceSoftwareParams {
+  team_id: number;
+  per_page: number;
+}
+
+export type IGetSetupExperienceSoftwareResponse = ISoftwareTitlesResponse;
 
 const mdmService = {
   unenrollHostFromMdm: (hostId: number, timeout?: number) => {
@@ -345,6 +353,20 @@ const mdmService = {
   downloadManualEnrollmentProfile: (token: string) => {
     const { DEVICE_USER_MDM_ENROLLMENT_PROFILE } = endpoints;
     return sendRequest("GET", DEVICE_USER_MDM_ENROLLMENT_PROFILE(token));
+  },
+
+  getSetupExperienceSoftware: (
+    params: IGetSetupExperienceSoftwareParams
+  ): Promise<IGetSetupExperienceSoftwareResponse> => {
+    const { MDM_SETUP_EXPERIENCE_SOFTWARE } = endpoints;
+
+    const path = `${MDM_SETUP_EXPERIENCE_SOFTWARE}?${buildQueryStringFromParams(
+      {
+        ...params,
+      }
+    )}`;
+
+    return sendRequest("GET", path);
   },
 
   updateSetupExperienceSoftware: (

--- a/server/datastore/mysql/setup_experience.go
+++ b/server/datastore/mysql/setup_experience.go
@@ -265,7 +265,7 @@ func (ds *Datastore) ListSetupExperienceSoftwareTitles(ctx context.Context, team
 		TeamID:              &teamID,
 		ListOptions:         opts,
 		Platform:            string(fleet.MacOSPlatform),
-		SetupExperienceOnly: true,
+		AvailableForInstall: true,
 	}, fleet.TeamFilter{
 		IncludeObserver: true,
 		TeamID:          &teamID,

--- a/server/datastore/mysql/setup_experience_test.go
+++ b/server/datastore/mysql/setup_experience_test.go
@@ -370,8 +370,8 @@ func testGetSetupExperienceTitles(t *testing.T, ds *Datastore) {
 
 	titles, count, meta, err := ds.ListSetupExperienceSoftwareTitles(ctx, team1.ID, fleet.ListOptions{})
 	require.NoError(t, err)
-	assert.Len(t, titles, 0)
-	assert.Equal(t, 0, count)
+	assert.Len(t, titles, 1)
+	assert.Equal(t, 1, count)
 	assert.NotNil(t, meta)
 
 	ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
@@ -518,8 +518,8 @@ func testSetSetupExperienceTitles(t *testing.T, ds *Datastore) {
 
 	titles, count, meta, err := ds.ListSetupExperienceSoftwareTitles(ctx, team1.ID, fleet.ListOptions{})
 	require.NoError(t, err)
-	assert.Len(t, titles, 0)
-	assert.Equal(t, 0, count)
+	assert.Len(t, titles, 2)
+	assert.Equal(t, 2, count)
 	assert.NotNil(t, meta)
 
 	app1 := &fleet.VPPApp{Name: "vpp_app_1", VPPAppTeam: fleet.VPPAppTeam{VPPAppID: fleet.VPPAppID{AdamID: "1", Platform: fleet.MacOSPlatform}}, BundleIdentifier: "b1"}
@@ -576,9 +576,11 @@ func testSetSetupExperienceTitles(t *testing.T, ds *Datastore) {
 
 	titles, count, meta, err = ds.ListSetupExperienceSoftwareTitles(ctx, team1.ID, fleet.ListOptions{})
 	require.NoError(t, err)
-	assert.Len(t, titles, 1)
-	assert.Equal(t, 1, count)
+	assert.Len(t, titles, 3)
+	assert.Equal(t, 3, count)
 	assert.Equal(t, "file1", titles[0].SoftwarePackage.Name)
+	assert.Equal(t, "file2", titles[1].SoftwarePackage.Name)
+	assert.Equal(t, "1", titles[2].AppStoreApp.AppStoreID)
 	assert.NotNil(t, meta)
 
 	err = ds.SetSetupExperienceSoftwareTitles(ctx, team1.ID, []uint{titleVPP["1"]})
@@ -586,26 +588,20 @@ func testSetSetupExperienceTitles(t *testing.T, ds *Datastore) {
 
 	titles, count, meta, err = ds.ListSetupExperienceSoftwareTitles(ctx, team1.ID, fleet.ListOptions{})
 	require.NoError(t, err)
-	require.Len(t, titles, 1)
-	require.Equal(t, 1, count)
-	assert.Equal(t, "1", titles[0].AppStoreApp.AppStoreID)
+	require.Len(t, titles, 3)
+	require.Equal(t, 3, count)
+	assert.Equal(t, "file1", titles[0].SoftwarePackage.Name)
+	assert.Equal(t, "file2", titles[1].SoftwarePackage.Name)
+	assert.Equal(t, "1", titles[2].AppStoreApp.AppStoreID)
 	assert.NotNil(t, meta)
 
 	titles, count, meta, err = ds.ListSetupExperienceSoftwareTitles(ctx, team2.ID, fleet.ListOptions{})
 	require.NoError(t, err)
-	require.Len(t, titles, 0)
-	require.Equal(t, 0, count)
+	require.Len(t, titles, 2)
+	require.Equal(t, 2, count)
+	assert.Equal(t, "file3", titles[0].SoftwarePackage.Name)
+	assert.Equal(t, "3", titles[1].AppStoreApp.AppStoreID)
 	require.NotNil(t, meta)
-
-	// Assign one vpp and one installer app
-	err = ds.SetSetupExperienceSoftwareTitles(ctx, team1.ID, []uint{titleVPP["1"], titleSoftware["file1"]})
-	require.NoError(t, err)
-
-	titles, count, meta, err = ds.ListSetupExperienceSoftwareTitles(ctx, team1.ID, fleet.ListOptions{})
-	require.NoError(t, err)
-	assert.Len(t, titles, 2)
-	assert.Equal(t, 2, count)
-	assert.NotNil(t, meta)
 
 	// iOS software
 	err = ds.SetSetupExperienceSoftwareTitles(ctx, team2.ID, []uint{titleSoftware["file4"]})
@@ -630,8 +626,8 @@ func testSetSetupExperienceTitles(t *testing.T, ds *Datastore) {
 	// Failures and other team assignments didn't affected the number of apps on team 1
 	titles, count, meta, err = ds.ListSetupExperienceSoftwareTitles(ctx, team1.ID, fleet.ListOptions{})
 	require.NoError(t, err)
-	assert.Len(t, titles, 2)
-	assert.Equal(t, 2, count)
+	assert.Len(t, titles, 3)
+	assert.Equal(t, 3, count)
 	assert.NotNil(t, meta)
 }
 

--- a/server/datastore/mysql/software_titles.go
+++ b/server/datastore/mysql/software_titles.go
@@ -281,7 +281,7 @@ LEFT JOIN software_titles_host_counts sthc ON sthc.software_title_id = st.id AND
 WHERE %s
 -- placeholder for filter based on software installed on hosts + software installers
 AND (%s)
-GROUP BY st.id, package_self_service, package_name, package_version, package_url, vpp_app_self_service, vpp_app_adam_id, vpp_app_version, vpp_app_icon_url`
+GROUP BY st.id, package_self_service, package_name, package_version, package_url, vpp_app_self_service, vpp_app_adam_id, vpp_app_version, vpp_app_icon_url, si.install_during_setup`
 
 	cveJoinType := "LEFT"
 	if opt.VulnerableOnly {
@@ -358,10 +358,6 @@ GROUP BY st.id, package_self_service, package_name, package_version, package_url
 		additionalWhere = " (st.name LIKE ? OR scve.cve LIKE ?)"
 		match = likePattern(match)
 		args = append(args, match, match)
-	}
-
-	if opt.SetupExperienceOnly {
-		additionalWhere += ` AND ( si.install_during_setup = 1 OR vat.install_during_setup = 1 )`
 	}
 
 	if opt.Platform != "" {

--- a/server/datastore/mysql/software_titles.go
+++ b/server/datastore/mysql/software_titles.go
@@ -166,10 +166,11 @@ func (ds *Datastore) ListSoftwareTitles(
 				version = *title.VPPAppVersion
 			}
 			title.AppStoreApp = &fleet.SoftwarePackageOrApp{
-				AppStoreID:  *title.VPPAppAdamID,
-				Version:     version,
-				SelfService: title.VPPAppSelfService,
-				IconURL:     title.VPPAppIconURL,
+				AppStoreID:         *title.VPPAppAdamID,
+				Version:            version,
+				SelfService:        title.VPPAppSelfService,
+				IconURL:            title.VPPAppIconURL,
+				InstallDuringSetup: title.PackageInstallDuringSetup,
 			}
 		}
 

--- a/server/datastore/mysql/software_titles.go
+++ b/server/datastore/mysql/software_titles.go
@@ -112,11 +112,12 @@ func (ds *Datastore) ListSoftwareTitles(
 		PackageName               *string `db:"package_name"`
 		PackageVersion            *string `db:"package_version"`
 		PackageURL                *string `db:"package_url"`
-		PackageInstallDuringSetup *bool   `db:"install_during_setup"`
+		PackageInstallDuringSetup *bool   `db:"package_install_during_setup"`
 		VPPAppSelfService         *bool   `db:"vpp_app_self_service"`
 		VPPAppAdamID              *string `db:"vpp_app_adam_id"`
 		VPPAppVersion             *string `db:"vpp_app_version"`
 		VPPAppIconURL             *string `db:"vpp_app_icon_url"`
+		VPPInstallDuringSetup     *bool   `db:"vpp_install_during_setup"`
 	}
 	var softwareList []*softwareTitle
 	getTitlesStmt, args = appendListOptionsWithCursorToSQL(getTitlesStmt, args, &opt.ListOptions)
@@ -170,7 +171,7 @@ func (ds *Datastore) ListSoftwareTitles(
 				Version:            version,
 				SelfService:        title.VPPAppSelfService,
 				IconURL:            title.VPPAppIconURL,
-				InstallDuringSetup: title.PackageInstallDuringSetup,
+				InstallDuringSetup: title.VPPInstallDuringSetup,
 			}
 		}
 
@@ -268,9 +269,10 @@ SELECT
 	si.filename as package_name,
 	si.version as package_version,
 	si.url AS package_url,
-	si.install_during_setup,
+	si.install_during_setup as package_install_during_setup,
 	vat.self_service as vpp_app_self_service,
 	vat.adam_id as vpp_app_adam_id,
+	vat.install_during_setup as vpp_install_during_setup,
 	vap.latest_version as vpp_app_version,
 	vap.icon_url as vpp_app_icon_url
 FROM software_titles st
@@ -284,7 +286,7 @@ LEFT JOIN software_titles_host_counts sthc ON sthc.software_title_id = st.id AND
 WHERE %s
 -- placeholder for filter based on software installed on hosts + software installers
 AND (%s)
-GROUP BY st.id, package_self_service, package_name, package_version, package_url, vpp_app_self_service, vpp_app_adam_id, vpp_app_version, vpp_app_icon_url, si.install_during_setup`
+GROUP BY st.id, package_self_service, package_name, package_version, package_url, package_install_during_setup, vpp_app_self_service, vpp_app_adam_id, vpp_app_version, vpp_app_icon_url, vpp_install_during_setup`
 
 	cveJoinType := "LEFT"
 	if opt.VulnerableOnly {

--- a/server/datastore/mysql/software_titles.go
+++ b/server/datastore/mysql/software_titles.go
@@ -265,6 +265,7 @@ SELECT
 	si.filename as package_name,
 	si.version as package_version,
 	si.url AS package_url,
+	si.install_during_setup,
 	vat.self_service as vpp_app_self_service,
 	vat.adam_id as vpp_app_adam_id,
 	vap.latest_version as vpp_app_version,

--- a/server/datastore/mysql/software_titles.go
+++ b/server/datastore/mysql/software_titles.go
@@ -108,14 +108,15 @@ func (ds *Datastore) ListSoftwareTitles(
 	// grab titles that match the list options
 	type softwareTitle struct {
 		fleet.SoftwareTitleListResult
-		PackageSelfService *bool   `db:"package_self_service"`
-		PackageName        *string `db:"package_name"`
-		PackageVersion     *string `db:"package_version"`
-		PackageURL         *string `db:"package_url"`
-		VPPAppSelfService  *bool   `db:"vpp_app_self_service"`
-		VPPAppAdamID       *string `db:"vpp_app_adam_id"`
-		VPPAppVersion      *string `db:"vpp_app_version"`
-		VPPAppIconURL      *string `db:"vpp_app_icon_url"`
+		PackageSelfService        *bool   `db:"package_self_service"`
+		PackageName               *string `db:"package_name"`
+		PackageVersion            *string `db:"package_version"`
+		PackageURL                *string `db:"package_url"`
+		PackageInstallDuringSetup *bool   `db:"install_during_setup"`
+		VPPAppSelfService         *bool   `db:"vpp_app_self_service"`
+		VPPAppAdamID              *string `db:"vpp_app_adam_id"`
+		VPPAppVersion             *string `db:"vpp_app_version"`
+		VPPAppIconURL             *string `db:"vpp_app_icon_url"`
 	}
 	var softwareList []*softwareTitle
 	getTitlesStmt, args = appendListOptionsWithCursorToSQL(getTitlesStmt, args, &opt.ListOptions)
@@ -150,10 +151,11 @@ func (ds *Datastore) ListSoftwareTitles(
 				version = *title.PackageVersion
 			}
 			title.SoftwarePackage = &fleet.SoftwarePackageOrApp{
-				Name:        *title.PackageName,
-				Version:     version,
-				SelfService: title.PackageSelfService,
-				PackageURL:  title.PackageURL,
+				Name:               *title.PackageName,
+				Version:            version,
+				SelfService:        title.PackageSelfService,
+				PackageURL:         title.PackageURL,
+				InstallDuringSetup: title.PackageInstallDuringSetup,
 			}
 		}
 

--- a/server/fleet/software.go
+++ b/server/fleet/software.go
@@ -232,7 +232,6 @@ type SoftwareTitleListOptions struct {
 	MaximumCVSS         float64 `query:"max_cvss_score,optional"`
 	PackagesOnly        bool    `query:"packages_only,optional"`
 	Platform            string  `query:"platform,optional"`
-	SetupExperienceOnly bool    `query:"setup_experience,optional"`
 }
 
 type HostSoftwareTitleListOptions struct {

--- a/server/fleet/software.go
+++ b/server/fleet/software.go
@@ -213,6 +213,10 @@ type SoftwareTitleListResult struct {
 	// the software installed. It's surfaced in software_titles to match
 	// with existing software entries.
 	BundleIdentifier *string `json:"bundle_identifier,omitempty" db:"bundle_identifier"`
+
+	// InstallDuringSetup is a boolean that indicates if the software title
+	// will be installed during the macos setup experience.
+	InstallDuringSetup bool `json:"install_during_setup" db:"install_during_setup"`
 }
 
 type SoftwareTitleListOptions struct {

--- a/server/fleet/software.go
+++ b/server/fleet/software.go
@@ -213,10 +213,6 @@ type SoftwareTitleListResult struct {
 	// the software installed. It's surfaced in software_titles to match
 	// with existing software entries.
 	BundleIdentifier *string `json:"bundle_identifier,omitempty" db:"bundle_identifier"`
-
-	// InstallDuringSetup is a boolean that indicates if the software title
-	// will be installed during the macos setup experience.
-	InstallDuringSetup bool `json:"install_during_setup" db:"install_during_setup"`
 }
 
 type SoftwareTitleListOptions struct {

--- a/server/fleet/software_installer.go
+++ b/server/fleet/software_installer.go
@@ -426,6 +426,9 @@ type SoftwarePackageOrApp struct {
 	LastInstall   *HostSoftwareInstall   `json:"last_install"`
 	LastUninstall *HostSoftwareUninstall `json:"last_uninstall"`
 	PackageURL    *string                `json:"package_url"`
+	// InstallDuringSetup is a boolean that indicates if the package
+	// will be installed during the macos setup experience.
+	InstallDuringSetup *bool `json:"install_during_setup,omitempty" db:"install_during_setup"`
 }
 
 type SoftwarePackageSpec struct {

--- a/server/service/integration_mdm_test.go
+++ b/server/service/integration_mdm_test.go
@@ -11678,7 +11678,6 @@ func (s *integrationMDMTestSuite) TestSCEPProxy() {
 	pkiMessage, err = scep.ParsePKIMessage(body, scep.WithCACerts(certs))
 	require.NoError(t, err)
 	assert.Equal(t, scep.CertRep, pkiMessage.MessageType)
-
 }
 
 type noopCertDepot struct{ depot.Depot }
@@ -11731,7 +11730,7 @@ func (s *integrationMDMTestSuite) TestSetupExperience() {
 
 	var respGetSetupExperience getSetupExperienceSoftwareResponse
 	s.DoJSON("GET", "/api/latest/fleet/setup_experience/software", getSetupExperienceSoftwareRequest{}, http.StatusOK, &respGetSetupExperience, "team_id", strconv.Itoa(int(team1.ID)))
-	require.Len(t, respGetSetupExperience.SoftwareTitles, 0)
+	require.Len(t, respGetSetupExperience.SoftwareTitles, 2)
 
 	var respPutSetupExperience putSetupExperienceSoftwareResponse
 	s.DoJSON("PUT", "/api/latest/fleet/setup_experience/software", putSetupExperienceSoftwareRequest{TeamID: team1.ID, TitleIDs: []uint{respListTitles.SoftwareTitles[0].ID, respListTitles.SoftwareTitles[1].ID}}, http.StatusOK, &respPutSetupExperience)

--- a/server/service/setup_experience.go
+++ b/server/service/setup_experience.go
@@ -17,7 +17,7 @@ import (
 
 type putSetupExperienceSoftwareRequest struct {
 	TeamID   uint   `json:"team_id"`
-	TitleIDs []uint `json:"title_ids"`
+	TitleIDs []uint `json:"software_title_ids"`
 }
 
 type putSetupExperienceSoftwareResponse struct {

--- a/server/service/software_titles.go
+++ b/server/service/software_titles.go
@@ -44,7 +44,11 @@ func listSoftwareTitlesEndpoint(ctx context.Context, request interface{}, svc fl
 		}
 		// we dont want to include the InstallDuringSetup field in the response
 		// for software titles list.
-		sw.SoftwarePackage.InstallDuringSetup = nil
+		if sw.SoftwarePackage != nil {
+			sw.SoftwarePackage.InstallDuringSetup = nil
+		} else if sw.AppStoreApp != nil {
+			sw.AppStoreApp.InstallDuringSetup = nil
+		}
 	}
 	if len(titles) == 0 {
 		titles = []fleet.SoftwareTitleListResult{}

--- a/server/service/software_titles.go
+++ b/server/service/software_titles.go
@@ -42,6 +42,9 @@ func listSoftwareTitlesEndpoint(ctx context.Context, request interface{}, svc fl
 		if sw.CountsUpdatedAt != nil && !sw.CountsUpdatedAt.IsZero() && sw.CountsUpdatedAt.After(latest) {
 			latest = *sw.CountsUpdatedAt
 		}
+		// we dont want to include the InstallDuringSetup field in the response
+		// for software titles list.
+		sw.SoftwarePackage.InstallDuringSetup = nil
 	}
 	if len(titles) == 0 {
 		titles = []fleet.SoftwareTitleListResult{}


### PR DESCRIPTION
relates to #23079, #23119

This PR fixes two issues:

1. `PUT /setup_experience/software` will now take the correct json body of `software_title_ids` to update the software to install during setup experience

2. include the `install_during_setup` attribute on the software titles software package results from `GET /setup_experience` endpoint

