### PR TITLE
add error message for host having mdm off to host details

### DIFF
--- a/frontend/pages/hosts/details/DeviceUserPage/helpers.ts
+++ b/frontend/pages/hosts/details/DeviceUserPage/helpers.ts
@@ -1,16 +1,6 @@
-import { getErrorReason } from "interfaces/errors";
-
 const DEFAULT_ERROR_MESSAGE = "refetch error.";
 
 // eslint-disable-next-line import/prefer-default-export
 export const getErrorMessage = (e: unknown, hostName: string) => {
-  let errorMessage = getErrorReason(e, {
-    reasonIncludes: "Host does not have MDM turned on",
-  });
-
-  if (!errorMessage) {
-    errorMessage = DEFAULT_ERROR_MESSAGE;
-  }
-
-  return `Host "${hostName}" ${errorMessage}`;
+  return `Host "${hostName}" ${DEFAULT_ERROR_MESSAGE}`;
 };

--- a/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
@@ -104,6 +104,7 @@ import {
 import WipeModal from "./modals/WipeModal";
 import SoftwareDetailsModal from "../cards/Software/SoftwareDetailsModal";
 import { parseHostSoftwareQueryParams } from "../cards/Software/HostSoftware";
+import { getErrorMessage } from "./helpers";
 
 const baseClass = "host-details";
 
@@ -579,8 +580,7 @@ const HostDetailsPage = ({
           }, 1000);
         });
       } catch (error) {
-        console.log(error);
-        renderFlash("error", `Host "${host.display_name}" refetch error`);
+        renderFlash("error", getErrorMessage(error, host.display_name));
         setShowRefetchSpinner(false);
       }
     }

--- a/frontend/pages/hosts/details/HostDetailsPage/helpers.ts
+++ b/frontend/pages/hosts/details/HostDetailsPage/helpers.ts
@@ -1,0 +1,16 @@
+import { getErrorReason } from "interfaces/errors";
+
+const DEFAULT_ERROR_MESSAGE = "refetch error.";
+
+// eslint-disable-next-line import/prefer-default-export
+export const getErrorMessage = (e: unknown, hostName: string) => {
+  let errorMessage = getErrorReason(e, {
+    reasonIncludes: "Host does not have MDM turned on",
+  });
+
+  if (!errorMessage) {
+    errorMessage = DEFAULT_ERROR_MESSAGE;
+  }
+
+  return `Host "${hostName}" ${errorMessage}`;
+};


### PR DESCRIPTION
relates to #22041

This adds an error message when refetching a host when mdm is not turned on for it. This was accidentally added to the My Device page, so we are moving it to the Host details page.

