### PR TITLE
Update macos-mdm-setup.md

### DIFF
--- a/articles/macos-mdm-setup.md
+++ b/articles/macos-mdm-setup.md
@@ -50,7 +50,7 @@ Hosts that automatically enroll will be assigned to a default team. You can conf
 
 1. Creating teams, if you have not already, following [this guide](https://fleetdm.com/guides/teams#basic-article). Our [best practice](#best-practice) recommendation is to have a team for each device type.
 2. Navigating to the **Settings > Integrations > Mobile device management (MDM)** page and clicking "Edit" under "Automatic enrollment".
-3. Click on the "Actions" dropdown for the ABM token you want to update, and then click "Edit teams".
+3. Clicking on the "Actions" dropdown for the ABM token you want to update, and then clicking "Edit teams".
 4. Use the dropdowns in the modal to select the default team for each type of host, and click "Save" to save your selections.
 
 If no default team is set for a host platform (macOS, iOS, or iPadOS), then newly enrolled hosts of that platform will be placed in "No team". 

--- a/articles/macos-mdm-setup.md
+++ b/articles/macos-mdm-setup.md
@@ -51,7 +51,7 @@ Hosts that automatically enroll will be assigned to a default team. You can conf
 1. Creating teams, if you have not already, following [this guide](https://fleetdm.com/guides/teams#basic-article). Our [best practice](#best-practice) recommendation is to have a team for each device type.
 2. Navigating to the **Settings > Integrations > Mobile device management (MDM)** page and clicking "Edit" under "Automatic enrollment".
 3. Clicking on the "Actions" dropdown for the ABM token you want to update, and then clicking "Edit teams".
-4. Use the dropdowns in the modal to select the default team for each type of host, and click "Save" to save your selections.
+4. Using the dropdowns in the modal to select the default team for each type of host, and clicking "Save" to save your selections.
 
 If no default team is set for a host platform (macOS, iOS, or iPadOS), then newly enrolled hosts of that platform will be placed in "No team". 
 

--- a/articles/macos-mdm-setup.md
+++ b/articles/macos-mdm-setup.md
@@ -18,7 +18,7 @@ Then click **Turn on** under the Apple (macOS, iOS, iPadOS) MDM section.
 > - If your certificate expires, you will have to turn MDM off and back on for all macOS hosts.
 > - Be sure to use the same Apple ID from year-to-year. If you don't, you will have to turn MDM off and back on for all macOS hosts.
 
-## Automatic Enrollment
+## Automatic enrollment
 
 > Available in Fleet Premium
 

--- a/articles/macos-mdm-setup.md
+++ b/articles/macos-mdm-setup.md
@@ -18,14 +18,16 @@ Then click **Turn on** under the Apple (macOS, iOS, iPadOS) MDM section.
 > - If your certificate expires, you will have to turn MDM off and back on for all macOS hosts.
 > - Be sure to use the same Apple ID from year-to-year. If you don't, you will have to turn MDM off and back on for all macOS hosts.
 
-## Apple Business Manager (ABM)
+## Automatic Enrollment
 
 > Available in Fleet Premium
+
+Add your ABM to automatically enroll newly purchased Apple hosts when they're first unboxed and set up by your end users.
 
 To connect Fleet to ABM, you have to add an ABM token to Fleet. To add an ABM token: 
 
 1. Navigate to the **Settings > Integrations > Mobile device management (MDM)** page.
-2. Under "Automatic enrollment", click "Add ABM", and then click "Add ABM" again on the next page. Follow the instructions in the modal and upload an ABM token to Fleet.
+2. Under "Automatic enrollment", click "Add ABM", and then follow the instructions in the modal to upload an ABM token to Fleet.
 
 When one of your uploaded ABM tokens has expired or is within 30 days of expiring, you will see a warning banner at the top of page reminding you to renew your token.
 
@@ -46,9 +48,10 @@ macOS, iOS, and iPadOS hosts listed in ABM and associated to a Fleet instance wi
 
 Hosts that automatically enroll will be assigned to a default team. You can configure the default team for macOS, iOS, and iPadOS hosts by:
 
-1. Navigating to the **Settings > Integrations > Mobile device management (MDM)** page and clicking "Edit" under "Automatic enrollment".
-2. Click on the "Actions" dropdown for the ABM token you want to update, and then click "Edit teams".
-3. Use the dropdowns in the modal to select the default team for each type of host, and click "Save" to save your selections.
+1. If you have not already, create teams following [this guide](https://fleetdm.com/guides/teams#basic-article). Our [best practice](#best-practice) recommendation is to have a team for each device type.
+2. Navigating to the **Settings > Integrations > Mobile device management (MDM)** page and clicking "Edit" under "Automatic enrollment".
+3. Click on the "Actions" dropdown for the ABM token you want to update, and then click "Edit teams".
+4. Use the dropdowns in the modal to select the default team for each type of host, and click "Save" to save your selections.
 
 If no default team is set for a host platform (macOS, iOS, or iPadOS), then newly enrolled hosts of that platform will be placed in "No team". 
 

--- a/articles/macos-mdm-setup.md
+++ b/articles/macos-mdm-setup.md
@@ -48,7 +48,7 @@ macOS, iOS, and iPadOS hosts listed in ABM and associated to a Fleet instance wi
 
 Hosts that automatically enroll will be assigned to a default team. You can configure the default team for macOS, iOS, and iPadOS hosts by:
 
-1. If you have not already, create teams following [this guide](https://fleetdm.com/guides/teams#basic-article). Our [best practice](#best-practice) recommendation is to have a team for each device type.
+1. Creating teams, if you have not already, following [this guide](https://fleetdm.com/guides/teams#basic-article). Our [best practice](#best-practice) recommendation is to have a team for each device type.
 2. Navigating to the **Settings > Integrations > Mobile device management (MDM)** page and clicking "Edit" under "Automatic enrollment".
 3. Click on the "Actions" dropdown for the ABM token you want to update, and then click "Edit teams".
 4. Use the dropdowns in the modal to select the default team for each type of host, and click "Save" to save your selections.

--- a/articles/macos-mdm-setup.md
+++ b/articles/macos-mdm-setup.md
@@ -6,11 +6,13 @@ To use automatic enrollment (aka zero-touch) features on macOS, iOS, and iPadOS,
 
 To turn on Windows MDM features, head to this [Windows MDM setup article](https://fleetdm.com/guides/windows-mdm-setup).
 
-## Apple Push Notification service (APNs)
+## Turn on Apple MDM
 
 Apple uses APNs to authenticate and manage interactions between Fleet and hosts.
 
-To connect Fleet to APNs or renew APNs, head to the **Settings > Integrations > Mobile device management (MDM)** page.
+To connect Fleet to APNs or renew APNs, head to the **Settings > Integrations > Mobile device management (MDM)** page. 
+
+Then click **Turn on** under the Apple (macOS, iOS, iPadOS) MDM section.
 
 > Apple requires that APNs certificates are renewed annually. 
 > - If your certificate expires, you will have to turn MDM off and back on for all macOS hosts.


### PR DESCRIPTION
Added step on line 15 concerning pressing a "Turn on" button (two different "Turn on" buttons are on screen)

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [ ] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/Committing-Changes.md#changes-files) for more information.
- [ ] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [ ] Added support on fleet's osquery simulator `cmd/osquery-perf` for new osquery data ingestion features.
- [ ] Added/updated tests
- [ ] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes
- [ ] If database migrations are included, checked table schema to confirm autoupdate
- For database migrations:
  - [ ] Checked schema for all modified table for columns that will auto-update timestamps during migration.
  - [ ] Confirmed that updating the timestamps is acceptable, and will not cause unwanted side effects.
  - [ ] Ensured the correct collation is explicitly set for character columns (`COLLATE utf8mb4_unicode_ci`).
- [ ] Manual QA for all new/changed functionality
- For Orbit and Fleet Desktop changes:
   - [ ] Orbit runs on macOS, Linux and Windows. Check if the orbit feature/bugfix should only apply to one platform (`runtime.GOOS`).
   - [ ] Manual QA must be performed in the three main OSs, macOS, Windows and Linux.
   - [ ] Auto-update manual QA, from released version of component to new version (see [tools/tuf/test](../tools/tuf/test/README.md)).
