### PR TITLE
Use ubuntu 22.04 for trivy ci scheduled check

### DIFF
--- a/.github/workflows/build-and-check-fleetctl-docker-and-deps.yml
+++ b/.github/workflows/build-and-check-fleetctl-docker-and-deps.yml
@@ -2,11 +2,6 @@ name: Build fleetctl docker dependencies and check vulnerabilities
 
 on:
   workflow_dispatch:
-    inputs:
-      image_tag:
-        description: "Docker image tag"
-        required: true
-        type: string
   schedule:
     - cron: "0 6 * * *"
 
@@ -25,7 +20,7 @@ permissions:
 
 jobs:
   build-and-check:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     environment: Docker Hub
     permissions:
       contents: write
@@ -47,7 +42,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
         with:
-          go-version-file: 'go.mod'
+          go-version-file: "go.mod"
 
       - name: Install Go Dependencies
         run: make deps-go


### PR DESCRIPTION
Fixing these failures: https://github.com/fleetdm/fleet/actions/runs/11454239765/job/31881900492

Following this advice https://github.com/orgs/community/discussions/139074#discussioncomment-10935090.
It seems it works.