### PR TITLE
Add callout that software-related features are experimental

### DIFF
--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -7166,6 +7166,8 @@ Team policies work the same as policies, but at the team level.
 
 ### Add team policy
 
+> **Experimental feature**. Software related features ( like install software policy automation) are undergoing rapid improvement, which may result in breaking changes to the API or configuration surface. It is not recommended for use in automated workflows.
+
 The semantics for creating a team policy are the same as for global policies, see [Add policy](#add-policy).
 
 `POST /api/v1/fleet/teams/:id/policies`
@@ -7273,6 +7275,8 @@ Either `query` or `query_id` must be provided.
 ```
 
 ### Edit team policy
+
+> **Experimental feature**. Software related features ( like install software policy automation) are undergoing rapid improvement, which may result in breaking changes to the API or configuration surface. It is not recommended for use in automated workflows.
 
 `PATCH /api/v1/fleet/teams/:team_id/policies/:policy_id`
 

--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -7166,7 +7166,7 @@ Team policies work the same as policies, but at the team level.
 
 ### Add team policy
 
-> **Experimental feature**. Software related features ( like install software policy automation) are undergoing rapid improvement, which may result in breaking changes to the API or configuration surface. It is not recommended for use in automated workflows.
+> **Experimental feature**. Software related features (like install software policy automation) are undergoing rapid improvement, which may result in breaking changes to the API or configuration surface. It is not recommended for use in automated workflows.
 
 The semantics for creating a team policy are the same as for global policies, see [Add policy](#add-policy).
 

--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -7276,7 +7276,7 @@ Either `query` or `query_id` must be provided.
 
 ### Edit team policy
 
-> **Experimental feature**. Software related features ( like install software policy automation) are undergoing rapid improvement, which may result in breaking changes to the API or configuration surface. It is not recommended for use in automated workflows.
+> **Experimental feature**. Software related features (like install software policy automation) are undergoing rapid improvement, which may result in breaking changes to the API or configuration surface. It is not recommended for use in automated workflows.
 
 `PATCH /api/v1/fleet/teams/:team_id/policies/:policy_id`
 


### PR DESCRIPTION
Some parts of policy feature are related to software (install software policy automation) and it's experimental.