### PR TITLE
Fleet UI: Tabbing through hdp tabs and global view all host links fixed

### DIFF
--- a/frontend/components/ViewAllHostsLink/_styles.scss
+++ b/frontend/components/ViewAllHostsLink/_styles.scss
@@ -7,4 +7,9 @@
       }
     }
   }
+
+  // For tabbing through the app
+  &:focus-visible.row-hover-link {
+    opacity: 1;
+  }
 }

--- a/frontend/pages/hosts/details/_styles.scss
+++ b/frontend/pages/hosts/details/_styles.scss
@@ -84,11 +84,12 @@
       }
       .react-tabs__tab--selected {
         background-color: $ui-off-white;
-      }
-    }
 
-    .focus-visible {
-      background-color: $ui-vibrant-blue-10;
+        // When tabbing through the app
+        &:focus-visible {
+          background-color: $ui-vibrant-blue-10;
+        }
+      }
     }
   }
 


### PR DESCRIPTION
## Issue
More to #22606 

## Description
2 of the quickest fixes on the list
- Tabbing through the host details tabs show while tabbing
- Tabbing through tables that have a hidden View all host button, shows when view all host is focused through tabbing

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Manual QA for all new/changed functionality
