### PR TITLE
Account for `umask` on `isMorePermissive`

### DIFF
--- a/changes/22877-fleetctl-package-to-account-for-umask
+++ b/changes/22877-fleetctl-package-to-account-for-umask
@@ -1,0 +1,1 @@
+* Fixed `fleetctl package` to account for `umask` when checking file/folder permissions during package generation.

--- a/pkg/secure/secure.go
+++ b/pkg/secure/secure.go
@@ -11,11 +11,20 @@ import (
 	"syscall"
 )
 
+func getUmask() os.FileMode {
+	current := syscall.Umask(0)
+	syscall.Umask(current)
+	return os.FileMode(current)
+}
+
 func isMorePermissive(currentMode, newMode os.FileMode) bool {
-	currentGroup := currentMode & 070
-	newGroup := newMode & 070
-	currentAll := currentMode & 07
-	newAll := newMode & 07
+	// Get process umask to account for it on the newMode bits.
+	umask := getUmask()
+
+	currentGroup := currentMode & 0o70
+	newGroup := newMode & ^umask & 0o70
+	currentAll := currentMode & 0o7
+	newAll := newMode & ^umask & 0o7
 
 	return newGroup > currentGroup || newAll > currentAll
 }

--- a/pkg/secure/secure.go
+++ b/pkg/secure/secure.go
@@ -14,7 +14,7 @@ import (
 func getUmask() os.FileMode {
 	current := syscall.Umask(0)
 	syscall.Umask(current)
-	return os.FileMode(current)
+	return os.FileMode(current) //nolint:gosec // dismiss G115 (max value is 0o777)
 }
 
 func isMorePermissive(currentMode, newMode os.FileMode) bool {


### PR DESCRIPTION
Tentative fix for #22877, to support different values of `umask`.

Still waiting for user feedback, thus opening as draft.

Alternative, just document `fleetctl package` is currently expected to work with `umask = 002` (my Ubuntu VMs) or `umask = 022` (macOS / most Linux distros).

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/Committing-Changes.md#changes-files) for more information.
- [ ] Added/updated tests
- [ ] Manual QA for all new/changed functionality
- For Orbit and Fleet Desktop changes:
   - [ ] Orbit runs on macOS, Linux and Windows. Check if the orbit feature/bugfix should only apply to one platform (`runtime.GOOS`).
   - [ ] Manual QA must be performed in the three main OSs, macOS, Windows and Linux.
   - [ ] Auto-update manual QA, from released version of component to new version (see [tools/tuf/test](../tools/tuf/test/README.md)).
