### PR TITLE
dogfood: Restore VPP token association to teams

### DIFF
--- a/it-and-security/default.yml
+++ b/it-and-security/default.yml
@@ -20,6 +20,13 @@ org_settings:
       entity_id: dogfood-eula.fleetdm.com
       idp_name: Google Workspace
       metadata_url: $DOGFOOD_MDM_SSO_METADATA_URL
+    volume_purchasing_program:
+    - location: Fleet Device Management Inc.
+      teams:
+      - "💻 Workstations"
+      - "💻🐣 Workstations (canary)"
+      - "📱🏢 Company-owned iPhones"
+      - "🔳🏢 Company-owned iPads"
   org_info:
     contact_url: https://fleetdm.com/company/contact
     org_logo_url: ""


### PR DESCRIPTION
To fix https://github.com/fleetdm/fleet/actions/runs/11468989615/job/31915263035#step:7:174

```
Error: applying app store apps for team: "🔳🏢 Company-owned iPads": POST /api/latest/fleet/software/app_store_apps/batch received status 422 Unprocessable Entity: could not retrieve vpp token: No available VPP Token
```

https://github.com/fleetdm/fleet/pull/22326 fixed so that GitOps removes associations if they are not set (GitOps mode of operation where stuff that's not set is removed), thus we now need to define it.