### PR TITLE
Fleet UI: Fix tabbing software view all hosts link, software status

### DIFF
--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwarePackageCard/_styles.scss
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwarePackageCard/_styles.scss
@@ -62,7 +62,7 @@
     }
   }
 
-  &__status-title{
+  &__status-title {
     display: flex;
     flex-direction: column;
     align-items: center;
@@ -71,6 +71,13 @@
 
   &__status-count {
     font-weight: normal;
+
+    // When tabbing
+    &:focus-visible {
+      overflow: initial;
+      outline: 2px solid $ui-vibrant-blue-25;
+      box-shadow: inset 0 0 0 1px $ui-vibrant-blue-10;
+    }
   }
 
   &__actions-wrapper {

--- a/frontend/pages/SoftwarePage/SoftwareTitles/SoftwareTable/_styles.scss
+++ b/frontend/pages/SoftwarePage/SoftwareTitles/SoftwareTable/_styles.scss
@@ -78,20 +78,6 @@
     &__data-table-block {
       .data-table-block {
         .data-table__table {
-          // for showing and hiding "view all hosts" link on hover
-          tr {
-            .software-link {
-              opacity: 0;
-              transition: opacity 250ms;
-            }
-
-            &:hover {
-              .software-link {
-                opacity: 1;
-              }
-            }
-          }
-
           thead {
             .name__header {
               width: $col-md;


### PR DESCRIPTION
## Issue
More #22606 

## Description
- Software package status can see outline when tabbing
- Software view all host link can see when tabbing (fixed on another PR for most places but local styling overrid global fix here)

## Screenshots
<img width="1560" alt="Screenshot 2024-10-23 at 4 34 57 PM" src="https://github.com/user-attachments/assets/fd63166f-010e-444d-9ba8-14ccd127dee4">
<img width="1564" alt="Screenshot 2024-10-23 at 4 34 48 PM" src="https://github.com/user-attachments/assets/30c6fb0c-f049-4ec3-8e20-58e350996500">


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Manual QA for all new/changed functionality

