### PR TITLE
Introducing Fleet Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Contributions are welcome, whether you answer questions on [Slack](https://fleet
 - Small, iterative, simple (boring) changes are the easiest to merge. -->
 
 ## What's next?
-To see what Fleet can do, head over to [fleetdm.com](https://fleetdm.com) and try it out for yourself, grab time with one of the maintainers to discuss, or visit the docs and roll it out to your organization.
+To see what Fleet can do, head over to [fleetdm.com](https://fleetdm.com) and try it out for yourself, grab time with one of the maintainers to discuss, or visit the docs and roll it out to your organization. You can also [Ask Fleet Guru](https://gurubase.io/g/fleet), it is a Fleet-focused AI to answer your questions.
 
 #### Production deployment
 Fleet is simple enough to [spin up for yourself](https://fleetdm.com/docs/get-started/tutorials-and-guides).  Or you can have us [host it for you](https://fleetdm.com/pricing).  Premium features are [available](https://fleetdm.com/pricing) either way.


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [Fleet Guru](https://gurubase.io/g/fleet) to Gurubase. Fleet Guru uses the data from this repo and data from the [docs](https://fleetdm.com/docs/get-started/why-fleet) to answer questions by leveraging the LLM.

In this PR, I showcased the "Fleet Guru", which highlights that Fleet now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable Fleet Guru in Gurubase, just let me know that's totally fine.