### PR TITLE
Restore intended flash messages

### DIFF
--- a/frontend/pages/admin/TeamManagementPage/TeamDetailsWrapper/TeamDetailsWrapper.tsx
+++ b/frontend/pages/admin/TeamManagementPage/TeamDetailsWrapper/TeamDetailsWrapper.tsx
@@ -295,12 +295,11 @@ const TeamDetailsWrapper = ({
 
     try {
       await teamsAPI.destroy(teamIdForApi);
-      return router.push(PATHS.ADMIN_TEAMS);
+      router.push(PATHS.ADMIN_TEAMS);
       renderFlash("success", "Team removed");
     } catch (response) {
       renderFlash("error", "Something went wrong removing the team");
       console.error(response);
-      return false;
     } finally {
       toggleDeleteTeamModal();
       setIsUpdatingTeams(false);

--- a/frontend/pages/admin/TeamManagementPage/components/DeleteTeamModal/DeleteTeamModal.tsx
+++ b/frontend/pages/admin/TeamManagementPage/components/DeleteTeamModal/DeleteTeamModal.tsx
@@ -20,7 +20,7 @@ const DeleteTeamModal = ({
 }: IDeleteTeamModalProps): JSX.Element => {
   return (
     <Modal
-      title={"Delete team"}
+      title="Delete team"
       onExit={onCancel}
       onEnter={onSubmit}
       className={baseClass}

--- a/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
@@ -547,11 +547,11 @@ const HostDetailsPage = ({
       setIsUpdatingHost(true);
       try {
         await hostAPI.destroy(host);
+        router.push(PATHS.MANAGE_HOSTS);
         renderFlash(
           "success",
           `Host "${host.display_name}" was successfully deleted.`
         );
-        router.push(PATHS.MANAGE_HOSTS);
       } catch (error) {
         console.log(error);
         renderFlash(


### PR DESCRIPTION
Addresses #23139 and #23141

- Remove a premature `return` that prevented subsequent `renderFlash` from firing
- Fix order of `push` and subsequent `renderFlash` for correct behavior
- Check codebase for additional instances of problematic `push` calls _after_ associated `renderFlash` calls via regex `\renderFlash\([\s\S\n]{0,400}router\.push/`
- Misc cleanup

![ezgif-6-c49d5d0432](https://github.com/user-attachments/assets/40a96439-7647-45ec-8847-5b0c85b448aa)


- [x] Manual QA for all new/changed functionality
