### PR TITLE
Handbook: fix `<ticket-number>` template on engineering handbook page.

### DIFF
--- a/handbook/engineering/README.md
+++ b/handbook/engineering/README.md
@@ -66,7 +66,7 @@ If there are no product changes, and the DRI decides to prioritize the story, th
 
 ### Fix a bug
 
-All bug fix pull requests should have a mention back to the issue they resolve with #<ticket_number> in the description or even in a comment. Please do not use any [automated words](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) since we don't want the tickets auto-closing when PR's are merged. 
+All bug fix pull requests should have a mention back to the issue they resolve with `#<ticket_number>` in the description or even in a comment. Please do not use any [automated words](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) since we don't want the tickets auto-closing when PR's are merged. 
 If the bug is labeled `~unreleased bug`, branch off and put your PR into `main`. These issues can be closed as soon as they complete QA.
 
 If the bug is labeled `~released bug`, branch off and put your PR into `main`. After merging checkout the latest tag, for example `git checkout fleet-v4.48.2`, then `git fetch; git cherry-pick <commit>`. If the cherry-pick fails with a conflict call out in the ticket how to resolve or if it is sufficiently complicated call out this fix is not suited for the patch release process and should only be included in the end of sprint release. This approach makes sure the bug fix is not built on top of unreleased feature code, which can cause merge conflicts during patch releases. 


### PR DESCRIPTION
Changes:
- Wrapped the `<ticket-number>` template in the "Fix a bug" section of the engineering handbook in a code block to prevent it from being interpreted as a custom HTML element by the website.
