### PR TITLE
Fix manual MDM profile download

### DIFF
--- a/frontend/services/entities/mdm.ts
+++ b/frontend/services/entities/mdm.ts
@@ -334,7 +334,12 @@ const mdmService = {
 
   downloadManualEnrollmentProfile: (token: string) => {
     const { DEVICE_USER_MDM_ENROLLMENT_PROFILE } = endpoints;
-    return sendRequest("GET", DEVICE_USER_MDM_ENROLLMENT_PROFILE(token), undefined, 'blob');
+    return sendRequest(
+      "GET",
+      DEVICE_USER_MDM_ENROLLMENT_PROFILE(token),
+      undefined,
+      "blob"
+    );
   },
 };
 

--- a/frontend/services/entities/mdm.ts
+++ b/frontend/services/entities/mdm.ts
@@ -334,7 +334,7 @@ const mdmService = {
 
   downloadManualEnrollmentProfile: (token: string) => {
     const { DEVICE_USER_MDM_ENROLLMENT_PROFILE } = endpoints;
-    return sendRequest("GET", DEVICE_USER_MDM_ENROLLMENT_PROFILE(token));
+    return sendRequest("GET", DEVICE_USER_MDM_ENROLLMENT_PROFILE(token), undefined, 'blob');
   },
 };
 


### PR DESCRIPTION
#23162

By default, Axios treats responses as if they're JSON, and the content type delivered for mobileconfig files doesn't make Axios switch back to providing the download as a blob. Explicitly telling Axios to give us a blob back fixes the issue where profiles were 50% larger than they should have been...and unparseable.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Manual QA for all new/changed functionality