### PR TITLE
Fix `PATCH /api/latest/fleet/config` to not clear VPP token/team associations when not set

### DIFF
--- a/changes/23174-fix-patch-config-vpp-associations
+++ b/changes/23174-fix-patch-config-vpp-associations
@@ -1,0 +1,1 @@
+* Fixed bug where `PATCH /api/latest/fleet/config` was incorrectly clearing VPP token<->team associations.

--- a/cmd/fleet/serve_test.go
+++ b/cmd/fleet/serve_test.go
@@ -307,6 +307,8 @@ func TestAutomationsSchedule(t *testing.T) {
 }
 
 func TestCronVulnerabilitiesCreatesDatabasesPath(t *testing.T) {
+	t.Skip("Failing due to missing datastore method, commenting to verify if other tests are passing...")
+
 	t.Parallel()
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
@@ -621,6 +623,8 @@ func TestScanVulnerabilitiesMkdirFailsIfVulnPathIsFile(t *testing.T) {
 }
 
 func TestCronVulnerabilitiesSkipMkdirIfDisabled(t *testing.T) {
+	t.Skip("Failing due to missing datastore method, commenting to verify if other tests are passing...")
+
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
 

--- a/cmd/fleet/serve_test.go
+++ b/cmd/fleet/serve_test.go
@@ -307,8 +307,6 @@ func TestAutomationsSchedule(t *testing.T) {
 }
 
 func TestCronVulnerabilitiesCreatesDatabasesPath(t *testing.T) {
-	t.Skip("Failing due to missing datastore method, commenting to verify if other tests are passing...")
-
 	t.Parallel()
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
@@ -623,8 +621,6 @@ func TestScanVulnerabilitiesMkdirFailsIfVulnPathIsFile(t *testing.T) {
 }
 
 func TestCronVulnerabilitiesSkipMkdirIfDisabled(t *testing.T) {
-	t.Skip("Failing due to missing datastore method, commenting to verify if other tests are passing...")
-
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
 

--- a/cmd/fleetctl/gitops_test.go
+++ b/cmd/fleetctl/gitops_test.go
@@ -1014,6 +1014,50 @@ software:
 	assert.Equal(t, filepath.Base(tmpFile.Name()), *savedTeam.Filename)
 }
 
+func createFakeITunesAndVPPServices(t *testing.T) {
+	config := &appleVPPConfigSrvConf{
+		Assets: []vpp.Asset{
+			{
+				AdamID:         "1",
+				PricingParam:   "STDQ",
+				AvailableCount: 12,
+			},
+			{
+				AdamID:         "2",
+				PricingParam:   "STDQ",
+				AvailableCount: 3,
+			},
+		},
+		SerialNumbers: []string{"123", "456"},
+	}
+	startVPPApplyServer(t, config)
+
+	appleITunesSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// a map of apps we can respond with
+		db := map[string]string{
+			// macos app
+			"1": `{"bundleId": "a-1", "artworkUrl512": "https://example.com/images/1", "version": "1.0.0", "trackName": "App 1", "TrackID": 1}`,
+			// macos, ios, ipados app
+			"2": `{"bundleId": "b-2", "artworkUrl512": "https://example.com/images/2", "version": "2.0.0", "trackName": "App 2", "TrackID": 2,
+				"supportedDevices": ["MacDesktop-MacDesktop", "iPhone5s-iPhone5s", "iPadAir-iPadAir"] }`,
+			// ipados app
+			"3": `{"bundleId": "c-3", "artworkUrl512": "https://example.com/images/3", "version": "3.0.0", "trackName": "App 3", "TrackID": 3,
+				"supportedDevices": ["iPadAir-iPadAir"] }`,
+		}
+
+		adamIDString := r.URL.Query().Get("id")
+		adamIDs := strings.Split(adamIDString, ",")
+
+		var objs []string
+		for _, a := range adamIDs {
+			objs = append(objs, db[a])
+		}
+
+		_, _ = w.Write([]byte(fmt.Sprintf(`{"results": [%s]}`, strings.Join(objs, ","))))
+	}))
+	t.Setenv("FLEET_DEV_ITUNES_URL", appleITunesSrv.URL)
+}
+
 func TestGitOpsBasicGlobalAndTeam(t *testing.T) {
 	// Cannot run t.Parallel() because it sets environment variables
 	license := &fleet.LicenseInfo{Tier: fleet.TierPremium, Expiration: time.Now().Add(24 * time.Hour)}
@@ -1027,7 +1071,8 @@ func TestGitOpsBasicGlobalAndTeam(t *testing.T) {
 	// Mock appConfig
 	savedAppConfig := &fleet.AppConfig{}
 	ds.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {
-		return &fleet.AppConfig{}, nil
+		appConfig := savedAppConfig.Copy()
+		return appConfig, nil
 	}
 	ds.SaveAppConfigFunc = func(ctx context.Context, config *fleet.AppConfig) error {
 		savedAppConfig = config
@@ -1098,6 +1143,9 @@ func TestGitOpsBasicGlobalAndTeam(t *testing.T) {
 		return nil, nil, nil
 	}
 	ds.ListTeamsFunc = func(ctx context.Context, filter fleet.TeamFilter, opt fleet.ListOptions) ([]*fleet.Team, error) {
+		if savedTeam != nil {
+			return []*fleet.Team{savedTeam}, nil
+		}
 		return nil, nil
 	}
 	ds.ListQueriesFunc = func(ctx context.Context, opts fleet.ListQueryOptions) ([]*fleet.Query, error) { return nil, nil }
@@ -1152,19 +1200,50 @@ func TestGitOpsBasicGlobalAndTeam(t *testing.T) {
 		return nil
 	}
 
+	vppToken := &fleet.VPPTokenDB{
+		Location:  "Foobar",
+		RenewDate: time.Now().Add(24 * 365 * time.Hour),
+	}
 	ds.ListVPPTokensFunc = func(ctx context.Context) ([]*fleet.VPPTokenDB, error) {
-		return []*fleet.VPPTokenDB{}, nil
+		return []*fleet.VPPTokenDB{vppToken}, nil
 	}
 
 	ds.ListABMTokensFunc = func(ctx context.Context) ([]*fleet.ABMToken, error) {
 		return []*fleet.ABMToken{}, nil
 	}
 
+	ds.TeamsSummaryFunc = func(ctx context.Context) ([]*fleet.TeamSummary, error) {
+		var teamsSummary []*fleet.TeamSummary
+		if savedTeam != nil {
+			teamsSummary = append(teamsSummary, &fleet.TeamSummary{
+				ID:          savedTeam.ID,
+				Name:        savedTeam.Name,
+				Description: savedTeam.Description,
+			})
+		}
+		return teamsSummary, nil
+	}
+
+	ds.GetVPPTokenByTeamIDFunc = func(ctx context.Context, teamID *uint) (*fleet.VPPTokenDB, error) {
+		if teamID != nil && *teamID == savedTeam.ID {
+			return vppToken, nil
+		}
+		return nil, &notFoundError{}
+	}
+
+	ds.UpdateVPPTokenTeamsFunc = func(ctx context.Context, id uint, teams []uint) (*fleet.VPPTokenDB, error) {
+		return vppToken, nil
+	}
+
+	createFakeITunesAndVPPServices(t)
+
 	globalFile, err := os.CreateTemp(t.TempDir(), "*.yml")
 	require.NoError(t, err)
 
 	t.Setenv("FLEET_SERVER_URL", fleetServerURL)
 	t.Setenv("ORG_NAME", orgName)
+	t.Setenv("TEST_TEAM_NAME", teamName)
+	t.Setenv("TEST_SECRET", secret)
 
 	_, err = globalFile.WriteString(
 		`
@@ -1180,6 +1259,11 @@ org_settings:
     org_logo_url: ""
     org_logo_url_light_background: ""
     org_name: ${ORG_NAME}
+  mdm:
+    volume_purchasing_program:
+    - location: Foobar
+      teams:
+      - "${TEST_TEAM_NAME}"
   secrets: [{"secret":"globalSecret"}]
 software:
 `,
@@ -1188,9 +1272,6 @@ software:
 
 	teamFile, err := os.CreateTemp(t.TempDir(), "*.yml")
 	require.NoError(t, err)
-
-	t.Setenv("TEST_TEAM_NAME", teamName)
-	t.Setenv("TEST_SECRET", secret)
 
 	_, err = teamFile.WriteString(
 		`
@@ -1202,6 +1283,8 @@ name: ${TEST_TEAM_NAME}
 team_settings:
   secrets: [{"secret":"${TEST_SECRET}"}]
 software:
+  app_store_apps:
+    - app_store_id: '1'
 `,
 	)
 	require.NoError(t, err)
@@ -1237,12 +1320,18 @@ software:
 	require.Error(t, err)
 	assert.ErrorContains(t, err, "duplicate enroll secret found")
 
+	ds.GetVPPTokenByTeamIDFuncInvoked = false
+
 	// Dry run
 	_ = runAppForTest(t, []string{"gitops", "-f", globalFile.Name(), "-f", teamFile.Name(), "--dry-run"})
 	assert.Equal(t, fleet.AppConfig{}, *savedAppConfig, "AppConfig should be empty")
 
+	// Dry run should not attempt to get the VPP token when applying VPP apps (it may not exist).
+	require.False(t, ds.GetVPPTokenByTeamIDFuncInvoked)
+	ds.ListTeamsFuncInvoked = false
+
 	// Dry run, deleting other teams
-	assert.False(t, ds.ListTeamsFuncInvoked)
+	savedAppConfig = &fleet.AppConfig{}
 	_ = runAppForTest(t, []string{"gitops", "-f", globalFile.Name(), "-f", teamFile.Name(), "--dry-run", "--delete-other-teams"})
 	assert.Equal(t, fleet.AppConfig{}, *savedAppConfig, "AppConfig should be empty")
 	assert.True(t, ds.ListTeamsFuncInvoked)
@@ -1256,6 +1345,12 @@ software:
 	assert.Equal(t, teamName, savedTeam.Name)
 	require.Len(t, enrolledTeamSecrets, 1)
 	assert.Equal(t, secret, enrolledTeamSecrets[0].Secret)
+
+	// Dry run again (after team was created by real run)
+	ds.GetVPPTokenByTeamIDFuncInvoked = false
+	_ = runAppForTest(t, []string{"gitops", "-f", globalFile.Name(), "-f", teamFile.Name(), "--dry-run"})
+	// Dry run should not attempt to get the VPP token when applying VPP apps (it may not exist).
+	require.False(t, ds.GetVPPTokenByTeamIDFuncInvoked)
 
 	// Now, set  up a team to delete
 	teamToDeleteID := uint(999)

--- a/server/service/appconfig.go
+++ b/server/service/appconfig.go
@@ -1215,6 +1215,11 @@ func (svc *Service) validateVPPAssignments(
 	invalid *fleet.InvalidArgumentError,
 	license *fleet.LicenseInfo,
 ) (map[uint][]uint, error) {
+	// Allow clearing VPP assignments in free and premium.
+	if len(volumePurchasingProgramInfo) == 0 {
+		return nil, nil
+	}
+
 	if !license.IsPremium() {
 		invalid.Append("mdm.volume_purchasing_program", ErrMissingLicense.Error())
 		return nil, nil

--- a/server/service/appconfig.go
+++ b/server/service/appconfig.go
@@ -493,9 +493,13 @@ func (svc *Service) ModifyAppConfig(ctx context.Context, p []byte, applyOpts fle
 		return nil, ctxerr.Wrap(ctx, err, "validating ABM token assignments")
 	}
 
-	vppAssignments, err := svc.validateVPPAssignments(ctx, &newAppConfig.MDM, invalid, license)
-	if err != nil {
-		return nil, ctxerr.Wrap(ctx, err, "validating VPP token assignments")
+	var vppAssignments map[uint][]uint
+	vppAssignmentsDefined := newAppConfig.MDM.VolumePurchasingProgram.Set && newAppConfig.MDM.VolumePurchasingProgram.Valid
+	if vppAssignmentsDefined {
+		vppAssignments, err = svc.validateVPPAssignments(ctx, newAppConfig.MDM.VolumePurchasingProgram.Value, invalid, license)
+		if err != nil {
+			return nil, ctxerr.Wrap(ctx, err, "validating VPP token assignments")
+		}
 	}
 
 	if invalid.HasErrors() {
@@ -669,27 +673,25 @@ func (svc *Service) ModifyAppConfig(ctx context.Context, p []byte, applyOpts fle
 		}
 	}
 
-	// Reset teams for VPP tokens that exist in Fleet but aren't present in the config being passed
-	clear(tokensInCfg)
-
-	for _, t := range newAppConfig.MDM.VolumePurchasingProgram.Value {
-		tokensInCfg[t.Location] = struct{}{}
-	}
-
-	vppToks, err := svc.ds.ListVPPTokens(ctx)
-	if err != nil {
-		return nil, ctxerr.Wrap(ctx, err, "listing VPP tokens")
-	}
-	for _, tok := range vppToks {
-		if _, ok := tokensInCfg[tok.Location]; !ok {
-			tok.Teams = nil
-			if _, err := svc.ds.UpdateVPPTokenTeams(ctx, tok.ID, nil); err != nil {
-				return nil, ctxerr.Wrap(ctx, err, "saving VPP token teams")
+	if vppAssignmentsDefined {
+		// 1. Reset teams for VPP tokens that exist in Fleet but aren't present in the config being passed
+		clear(tokensInCfg)
+		for _, t := range newAppConfig.MDM.VolumePurchasingProgram.Value {
+			tokensInCfg[t.Location] = struct{}{}
+		}
+		vppToks, err := svc.ds.ListVPPTokens(ctx)
+		if err != nil {
+			return nil, ctxerr.Wrap(ctx, err, "listing VPP tokens")
+		}
+		for _, tok := range vppToks {
+			if _, ok := tokensInCfg[tok.Location]; !ok {
+				tok.Teams = nil
+				if _, err := svc.ds.UpdateVPPTokenTeams(ctx, tok.ID, nil); err != nil {
+					return nil, ctxerr.Wrap(ctx, err, "saving VPP token teams")
+				}
 			}
 		}
-	}
-
-	if appConfig.MDM.VolumePurchasingProgram.Set && appConfig.MDM.VolumePurchasingProgram.Valid {
+		// 2. Set VPP assignments that are defined in the config.
 		for tokenID, tokenTeams := range vppAssignments {
 			if _, err := svc.ds.UpdateVPPTokenTeams(ctx, tokenID, tokenTeams); err != nil {
 				var errTokConstraint fleet.ErrVPPTokenTeamConstraint
@@ -1209,76 +1211,72 @@ func (svc *Service) validateABMAssignments(
 
 func (svc *Service) validateVPPAssignments(
 	ctx context.Context,
-	mdm *fleet.MDM,
+	volumePurchasingProgramInfo []fleet.MDMAppleVolumePurchasingProgramInfo,
 	invalid *fleet.InvalidArgumentError,
 	license *fleet.LicenseInfo,
 ) (map[uint][]uint, error) {
-	if mdm.VolumePurchasingProgram.Set && mdm.VolumePurchasingProgram.Valid {
-		if !license.IsPremium() {
-			invalid.Append("mdm.volume_purchasing_program", ErrMissingLicense.Error())
+	if !license.IsPremium() {
+		invalid.Append("mdm.volume_purchasing_program", ErrMissingLicense.Error())
+		return nil, nil
+	}
+
+	teams, err := svc.ds.TeamsSummary(ctx)
+	if err != nil {
+		return nil, err
+	}
+	teamsByName := map[string]uint{fleet.TeamNameNoTeam: 0}
+	for _, tm := range teams {
+		teamsByName[tm.Name] = tm.ID
+	}
+	tokens, err := svc.ds.ListVPPTokens(ctx)
+	if err != nil {
+		return nil, err
+	}
+	tokensByLocation := map[string]*fleet.VPPTokenDB{}
+	for _, token := range tokens {
+		// The default assignments for all tokens is "no team"
+		// (ie: team_id IS NULL), here we reset the assignments
+		// for all tokens, those will be re-added below.
+		//
+		// This ensures any unassignments are properly handled.
+		tokensByLocation[token.Location] = token
+		token.Teams = nil
+	}
+
+	tokensToSave := make(map[uint][]uint, len(volumePurchasingProgramInfo))
+	for _, vpp := range volumePurchasingProgramInfo {
+		for _, tmName := range vpp.Teams {
+			if _, ok := teamsByName[norm.NFC.String(tmName)]; !ok && tmName != fleet.TeamNameAllTeams {
+				invalid.Appendf("mdm.volume_purchasing_program", "team %s doesn't exist", tmName)
+				return nil, nil
+			}
+		}
+
+		loc := norm.NFC.String(vpp.Location)
+		if _, ok := tokensByLocation[loc]; !ok {
+			invalid.Appendf("mdm.volume_purchasing_program", "token with location %s doesn't exist", vpp.Location)
 			return nil, nil
 		}
 
-		teams, err := svc.ds.TeamsSummary(ctx)
-		if err != nil {
-			return nil, err
-		}
-		teamsByName := map[string]uint{fleet.TeamNameNoTeam: 0}
-		for _, tm := range teams {
-			teamsByName[tm.Name] = tm.ID
-		}
-		tokens, err := svc.ds.ListVPPTokens(ctx)
-		if err != nil {
-			return nil, err
-		}
-		tokensByLocation := map[string]*fleet.VPPTokenDB{}
-		for _, token := range tokens {
-			// The default assignments for all tokens is "no team"
-			// (ie: team_id IS NULL), here we reset the assignments
-			// for all tokens, those will be re-added below.
-			//
-			// This ensures any unassignments are properly handled.
-			tokensByLocation[token.Location] = token
-			token.Teams = nil
-		}
-
-		tokensToSave := make(map[uint][]uint, len(mdm.VolumePurchasingProgram.Value))
-		for _, vpp := range mdm.VolumePurchasingProgram.Value {
-			for _, tmName := range vpp.Teams {
-				if _, ok := teamsByName[norm.NFC.String(tmName)]; !ok && tmName != fleet.TeamNameAllTeams {
-					invalid.Appendf("mdm.volume_purchasing_program", "team %s doesn't exist", tmName)
+		var tokenTeams []uint
+		for _, teamName := range vpp.Teams {
+			if teamName == fleet.TeamNameAllTeams {
+				if len(vpp.Teams) > 1 {
+					invalid.Appendf("mdm.volume_purchasing_program", "token cannot belong to %s and other teams", fleet.TeamNameAllTeams)
 					return nil, nil
 				}
+				tokenTeams = []uint{}
+				break
 			}
-
-			loc := norm.NFC.String(vpp.Location)
-			if _, ok := tokensByLocation[loc]; !ok {
-				invalid.Appendf("mdm.volume_purchasing_program", "token with location %s doesn't exist", vpp.Location)
-				return nil, nil
-			}
-
-			var tokenTeams []uint
-			for _, teamName := range vpp.Teams {
-				if teamName == fleet.TeamNameAllTeams {
-					if len(vpp.Teams) > 1 {
-						invalid.Appendf("mdm.volume_purchasing_program", "token cannot belong to %s and other teams", fleet.TeamNameAllTeams)
-						return nil, nil
-					}
-					tokenTeams = []uint{}
-					break
-				}
-				teamID := teamsByName[teamName]
-				tokenTeams = append(tokenTeams, teamID)
-			}
-
-			tok := tokensByLocation[loc]
-			tokensToSave[tok.ID] = tokenTeams
+			teamID := teamsByName[teamName]
+			tokenTeams = append(tokenTeams, teamID)
 		}
 
-		return tokensToSave, nil
+		tok := tokensByLocation[loc]
+		tokensToSave[tok.ID] = tokenTeams
 	}
 
-	return nil, nil
+	return tokensToSave, nil
 }
 
 func validateSSOProviderSettings(incoming, existing fleet.SSOProviderSettings, invalid *fleet.InvalidArgumentError) {

--- a/server/service/client.go
+++ b/server/service/client.go
@@ -400,7 +400,6 @@ func (c *Client) ApplyGroup(
 	teamsSoftwareInstallers map[string][]fleet.SoftwarePackageResponse,
 	teamsScripts map[string][]fleet.ScriptResponse,
 ) (map[string]uint, map[string][]fleet.SoftwarePackageResponse, map[string][]fleet.ScriptResponse, error) {
-
 	logfn := func(format string, args ...interface{}) {
 		if logf != nil {
 			logf(format, args...)
@@ -1287,6 +1286,11 @@ func (c *Client) DoGitOps(
 		mdmAppConfig, ok = mdmConfig.(map[string]interface{})
 		if !ok {
 			return nil, errors.New("org_settings.mdm config is not a map")
+		}
+
+		// Put in default value for volume_purchasing_program to clear the configuration if it's not set.
+		if v, ok := mdmAppConfig["volume_purchasing_program"]; !ok || v == nil {
+			mdmAppConfig["volume_purchasing_program"] = []interface{}{}
 		}
 
 		// Put in default values for macos_migration

--- a/server/service/integration_mdm_test.go
+++ b/server/service/integration_mdm_test.go
@@ -10562,13 +10562,44 @@ func (s *integrationMDMTestSuite) TestVPPApps() {
 	s.DoJSON("POST", "/api/latest/fleet/teams", &createTeamRequest{TeamPayload: fleet.TeamPayload{Name: ptr.String("Team 1")}}, http.StatusOK, &newTeamResp)
 	team := newTeamResp.Team
 
+	// Associate team to the VPP token.
 	var resPatchVPP patchVPPTokensTeamsResponse
-	s.DoJSON("PATCH", fmt.Sprintf("/api/latest/fleet/vpp_tokens/%d/teams", resp.Tokens[0].ID), patchVPPTokensTeamsRequest{TeamIDs: []uint{}}, http.StatusOK, &resPatchVPP)
+	s.DoJSON("PATCH", fmt.Sprintf("/api/latest/fleet/vpp_tokens/%d/teams", resp.Tokens[0].ID), patchVPPTokensTeamsRequest{TeamIDs: []uint{team.ID}}, http.StatusOK, &resPatchVPP)
 
-	// Reset the token's teams by omitting the token from app config
+	// A PATCH endpoint omitting mdm.volume_purchasing_program should not remove the VPP token association.
 	acResp := appConfigResponse{}
 	s.DoJSON("PATCH", "/api/latest/fleet/config", json.RawMessage(`{
-		"mdm": { "volume_purchasing_program": null }
+		"agent_options": {
+			"config": {
+				"options": {
+					"pack_delimiter": "/",
+					"logger_tls_period": 10,
+					"distributed_plugin": "tls",
+					"disable_distributed": false,
+					"logger_tls_endpoint": "/api/osquery/log",
+					"distributed_interval": 10,
+					"distributed_tls_max_attempts": 3
+				}
+			}
+		}
+  }`), http.StatusOK, &acResp)
+
+	// Check that the VPP token is still associated to the team.
+	resp = getVPPTokensResponse{}
+	s.DoJSON("GET", "/api/latest/fleet/vpp_tokens", &getVPPTokensRequest{}, http.StatusOK, &resp)
+	require.NoError(t, resp.Err)
+	require.Len(t, resp.Tokens, 1)
+	require.Equal(t, orgName, resp.Tokens[0].OrgName)
+	require.Equal(t, location, resp.Tokens[0].Location)
+	require.Equal(t, expTime, resp.Tokens[0].RenewDate)
+	require.Len(t, resp.Tokens[0].Teams, 1)
+	require.Equal(t, team.ID, resp.Tokens[0].Teams[0].ID)
+	require.Equal(t, team.Name, resp.Tokens[0].Teams[0].Name)
+
+	// Reset the token's teams by omitting the token from app config
+	acResp = appConfigResponse{}
+	s.DoJSON("PATCH", "/api/latest/fleet/config", json.RawMessage(`{
+		"mdm": { "volume_purchasing_program": [] }
   }`), http.StatusOK, &acResp)
 
 	resp = getVPPTokensResponse{}
@@ -10580,9 +10611,23 @@ func (s *integrationMDMTestSuite) TestVPPApps() {
 	require.Equal(t, expTime, resp.Tokens[0].RenewDate)
 	require.Empty(t, resp.Tokens[0].Teams)
 
-	// Add the team back
-	resPatchVPP = patchVPPTokensTeamsResponse{}
-	s.DoJSON("PATCH", fmt.Sprintf("/api/latest/fleet/vpp_tokens/%d/teams", resp.Tokens[0].ID), patchVPPTokensTeamsRequest{TeamIDs: []uint{}}, http.StatusOK, &resPatchVPP)
+	// Add the team back using the PATCH /api/latest/fleet/config endpoint now (what GitOps uses).
+	acResp = appConfigResponse{}
+	s.DoJSON("PATCH", "/api/latest/fleet/config", json.RawMessage(fmt.Sprintf(`{
+		"mdm": { "volume_purchasing_program": [ {"location": "%s", "teams": [ "%s" ]} ] }
+  }`, location, team.Name)), http.StatusOK, &acResp)
+
+	// Check again that the VPP token is associated to the team.
+	resp = getVPPTokensResponse{}
+	s.DoJSON("GET", "/api/latest/fleet/vpp_tokens", &getVPPTokensRequest{}, http.StatusOK, &resp)
+	require.NoError(t, resp.Err)
+	require.Len(t, resp.Tokens, 1)
+	require.Equal(t, orgName, resp.Tokens[0].OrgName)
+	require.Equal(t, location, resp.Tokens[0].Location)
+	require.Equal(t, expTime, resp.Tokens[0].RenewDate)
+	require.Len(t, resp.Tokens[0].Teams, 1)
+	require.Equal(t, team.ID, resp.Tokens[0].Teams[0].ID)
+	require.Equal(t, team.Name, resp.Tokens[0].Teams[0].Name)
 
 	// Get list of VPP apps from "Apple"
 	// We're passing team 1 here, but we haven't added any app store apps to that team, so we get
@@ -11678,7 +11723,6 @@ func (s *integrationMDMTestSuite) TestSCEPProxy() {
 	pkiMessage, err = scep.ParsePKIMessage(body, scep.WithCACerts(certs))
 	require.NoError(t, err)
 	assert.Equal(t, scep.CertRep, pkiMessage.MessageType)
-
 }
 
 type noopCertDepot struct{ depot.Depot }


### PR DESCRIPTION
#23174

PS: Make sure to render the diff without whitespace changes.
![Screenshot 2024-10-24 at 10 58 47 AM](https://github.com/user-attachments/assets/fb36c995-206c-4a15-8bf2-6b375c5cc565)


- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/Committing-Changes.md#changes-files) for more information.
- [x] Added/updated tests
- [x] Manual QA for all new/changed functionality