### PR TITLE
fix: make icon not as big

### DIFF
--- a/orbit/pkg/setup_experience/setup_experience.go
+++ b/orbit/pkg/setup_experience/setup_experience.go
@@ -237,7 +237,6 @@ func (s *SetupExperiencer) startSwiftDialog(binaryPath, orgLogo string) error {
 			Title:            "none",
 			Message:          "### Setting up your Mac...\n\nYour Mac is being configured by your organization using Fleet. This process may take some time to complete. Please don't attempt to restart or shut down the computer unless prompted to do so.",
 			Icon:             orgLogo,
-			IconSize:         30,
 			MessageAlignment: swiftdialog.AlignmentCenter,
 			CentreIcon:       true,
 			Height:           "625",
@@ -253,6 +252,10 @@ func (s *SetupExperiencer) startSwiftDialog(binaryPath, orgLogo string) error {
 
 		if err = s.sd.ShowProgress(); err != nil {
 			log.Error().Err(err).Msg("setting initial setup experience progress")
+		}
+
+		if err := s.sd.SetIconSize(80); err != nil {
+			log.Error().Err(err).Msg("setting initial setup experience icon size")
 		}
 
 		log.Debug().Msg("swiftDialog process started")


### PR DESCRIPTION
> No issue, just a bug found during testing

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Manual QA for all new/changed functionality
- For Orbit and Fleet Desktop changes:
   - [ ] Orbit runs on macOS, Linux and Windows. Check if the orbit feature/bugfix should only apply to one platform (`runtime.GOOS`).
   - [ ] Manual QA must be performed in the three main OSs, macOS, Windows and Linux.
   - [ ] Auto-update manual QA, from released version of component to new version (see [tools/tuf/test](../tools/tuf/test/README.md)).

Updated icon size:
![LWScreenShot 2024-10-24 at 7 15 13 AM](https://github.com/user-attachments/assets/cd1b0640-f602-414a-937d-c481b1ec7a44)
