### PR TITLE
Fleet UI: Update to react-ace, allow escaping sql input

### DIFF
--- a/frontend/components/SQLEditor/SQLEditor.tsx
+++ b/frontend/components/SQLEditor/SQLEditor.tsx
@@ -1,7 +1,8 @@
 import React, { ReactNode, useCallback, useRef } from "react";
-import AceEditor from "react-ace";
-import ReactAce from "react-ace/lib/ace";
-import { IAceEditor } from "react-ace/lib/types";
+// import AceEditor from "react-ace";
+import AceEditor from "react-ace-12";
+import ReactAce from "react-ace-12/lib/ace";
+import { IAceEditor } from "react-ace-12/lib/types";
 import classnames from "classnames";
 import "ace-builds/src-noconflict/mode-sql";
 import "ace-builds/src-noconflict/ext-linking";
@@ -40,7 +41,7 @@ export interface ISQLEditorProps {
   helpText?: ReactNode;
   labelActionComponent?: React.ReactNode;
   style?: React.CSSProperties;
-  onBlur?: (editor?: IAceEditor) => void;
+  onBlur?: (event: any, editor?: IAceEditor) => void;
   onLoad?: (editor: IAceEditor) => void;
   onChange?: (value: string) => void;
   handleSubmit?: () => void;
@@ -218,7 +219,7 @@ const SQLEditor = ({
   };
 
   const onBlurHandler = (event: any, editor?: IAceEditor): void => {
-    onBlur && onBlur(editor);
+    onBlur && onBlur(event, editor);
   };
 
   const handleDelete = (deleteCommand: string) => {

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "react": "18.3.1",
     "react-accessible-accordion": "3.3.5",
     "react-ace": "9.3.0",
+    "react-ace-12": "npm:react-ace@12.0.0",
     "react-dom": "18.2.0",
     "react-error-boundary": "3.1.4",
     "react-markdown": "8.0.3",


### PR DESCRIPTION
## Issue
Part of #22606 

## Description
- Hitting esc key when in a sql editor will unfocus it and allow the user to tab to other parts of the app

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or
- [x] Manual QA for all new/changed functionality

