### PR TITLE
Ignore teams files for non-premium gitops users.

### DIFF
--- a/cmd/fleetctl/gitops.go
+++ b/cmd/fleetctl/gitops.go
@@ -86,8 +86,13 @@ func gitopsCommand() *cli.Command {
 				noTeamControls spec.Controls
 				noTeamPresent  bool
 			)
+			isPremium := appConfig.License.IsPremium()
 			for _, flFilename := range flFilenames.Value() {
 				if filepath.Base(flFilename) == "no-team.yml" {
+					if !isPremium {
+						// Message is printed in the next flFilenames loop to avoid printing it multiple times
+						break
+					}
 					baseDir := filepath.Dir(flFilename)
 					config, err := spec.GitOpsFromFile(flFilename, baseDir, appConfig, func(format string, a ...interface{}) {})
 					if err != nil {
@@ -148,13 +153,16 @@ func gitopsCommand() *cli.Command {
 					if !config.Controls.Set() {
 						config.Controls = noTeamControls
 					}
+				} else if !isPremium {
+					logf("[!] skipping team config %s since teams are only supported for premium Fleet users\n", flFilename)
+					continue
 				}
 
 				// Special handling for tokens is required because they link to teams (by
 				// name.) Because teams can be created/deleted during the same gitops run, we
 				// grab some information to help us determine allowed/restricted actions and
 				// when to perform the associations.
-				if isGlobalConfig && totalFilenames > 1 && !(totalFilenames == 2 && noTeamPresent) {
+				if isGlobalConfig && totalFilenames > 1 && !(totalFilenames == 2 && noTeamPresent) && isPremium {
 					abmTeams, hasMissingABMTeam, usesLegacyABMConfig, err = checkABMTeamAssignments(config, fleetClient)
 					if err != nil {
 						return err


### PR DESCRIPTION
#21715

This fix is needed for https://github.com/fleetdm/fleet-gitops CI to run successfully against a non-premium Fleet server.
That CI test will cover this change.

# Checklist for submitter
- [x] Manual QA for all new/changed functionality
