### PR TITLE
Fleet UI: Ability to Esc out of SQL/YML editors

### DIFF
--- a/frontend/components/Editor/Editor.tsx
+++ b/frontend/components/Editor/Editor.tsx
@@ -2,6 +2,7 @@ import classnames from "classnames";
 import TooltipWrapper from "components/TooltipWrapper";
 import React, { ReactNode } from "react";
 import AceEditor from "react-ace";
+import { IAceEditor } from "react-ace/lib/types";
 
 const baseClass = "editor";
 
@@ -66,6 +67,19 @@ const Editor = ({
     [`${baseClass}__error`]: !!error,
   });
 
+  const onLoadHandler = (editor: IAceEditor) => {
+    // Lose focus using the Escape key so you can Tab forward (or Shift+Tab backwards) through app
+    editor.commands.addCommand({
+      name: "escapeToBlur",
+      bindKey: { win: "Esc", mac: "Esc" },
+      exec: (aceEditor) => {
+        aceEditor.blur(); // Lose focus from the editor
+        return true;
+      },
+      readOnly: true,
+    });
+  };
+
   const renderLabel = () => {
     const labelText = error || label;
     const labelClassName = classnames(`${baseClass}__label`, {
@@ -117,6 +131,7 @@ const Editor = ({
         tabSize={2}
         focus={focus}
         onChange={onChange}
+        onLoad={onLoadHandler}
       />
       {renderHelpText()}
     </div>

--- a/frontend/components/FleetAce/FleetAce.tsx
+++ b/frontend/components/FleetAce/FleetAce.tsx
@@ -202,6 +202,18 @@ const FleetAce = ({
 
   const onLoadHandler = (editor: IAceEditor) => {
     fixHotkeys(editor);
+
+    // Lose focus using the Escape key so you can Tab forward (or Shift+Tab backwards) through app
+    editor.commands.addCommand({
+      name: "escapeToBlur",
+      bindKey: { win: "Esc", mac: "Esc" },
+      exec: (aceEditor) => {
+        aceEditor.blur(); // Lose focus from the editor
+        return true;
+      },
+      readOnly: true,
+    });
+
     onLoad && onLoad(editor);
   };
 

--- a/frontend/components/YamlAce/YamlAce.jsx
+++ b/frontend/components/YamlAce/YamlAce.jsx
@@ -17,6 +17,19 @@ class YamlAce extends Component {
     wrapperClassName: PropTypes.string,
   };
 
+  onLoadHandler = (editor) => {
+    // Lose focus using the Escape key so you can Tab forward (or Shift+Tab backwards) through app
+    editor.commands.addCommand({
+      name: "escapeToBlur",
+      bindKey: { win: "Esc", mac: "Esc" },
+      exec: (aceEditor) => {
+        aceEditor.blur(); // Lose focus from the editor
+        return true;
+      },
+      readOnly: true,
+    });
+  };
+
   renderLabel = () => {
     const { name, error, label } = this.props;
 
@@ -45,7 +58,7 @@ class YamlAce extends Component {
       wrapperClassName,
     } = this.props;
 
-    const { renderLabel } = this;
+    const { renderLabel, onLoadHandler } = this;
 
     const wrapperClass = classnames(wrapperClassName, "form-field", {
       [`${baseClass}__wrapper--error`]: error,
@@ -67,6 +80,7 @@ class YamlAce extends Component {
           onChange={onChange}
           name={name}
           label={label}
+          onLoad={onLoadHandler}
         />
       </div>
     );


### PR DESCRIPTION
## Issue
More #22606 

## Description
- On Chrome: Users can `Esc` out of SQL and YML editors and use Tab (or Shift+Tab) to continue Tabbing through the app

Note: I timeboxed trying to make this work on Firefox and Safari to no avail

## Screenrecording
https://www.loom.com/share/4de107d2d6a448118349dd2d5c0944a5?sid=a2d1a8ed-1409-4a08-a801-8d78d74177e1

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Manual QA for all new/changed functionality

