### PR TITLE
Website: Fix typo in maintainer GitHub username.

### DIFF
--- a/website/config/custom.js
+++ b/website/config/custom.js
@@ -267,7 +267,7 @@ module.exports.custom = {
     'handbook/README.md': 'mikermcneil', // See https://github.com/fleetdm/fleet/pull/13195
     'handbook/company': 'mikermcneil',
     'handbook/company/product-groups.md': ['lukeheath', 'sampfluger88','mikermcneil'],
-    // 'handbook/company/open-positions.yml': ['@sampfluger88','mikermcneil'],
+    'handbook/company/open-positions.yml': ['sampfluger88','mikermcneil'],
     'handbook/digital-experience': ['sampfluger88','mikermcneil'],
     'handbook/finance': ['sampfluger88','mikermcneil'],
     'handbook/engineering': ['sampfluger88','mikermcneil', 'lukeheath'],


### PR DESCRIPTION
Changes:
- Removed an @ symbol from a maintainer's GitHub username in the website's custom configuration