### PR TITLE
Explicitly set "Add profile" message line heights

### DIFF
--- a/changes/23215-message-spacing
+++ b/changes/23215-message-spacing
@@ -1,0 +1,1 @@
+* Explicitly set line heights on "add profile" messages so they are consistent cross-browser

--- a/frontend/pages/ManageControlsPage/OSSettings/cards/CustomSettings/_styles.scss
+++ b/frontend/pages/ManageControlsPage/OSSettings/cards/CustomSettings/_styles.scss
@@ -102,6 +102,7 @@
 
       &--message {
         text-align: center;
+        line-height: 20px;
       }
     }
 

--- a/frontend/pages/ManageControlsPage/OSSettings/cards/CustomSettings/components/ProfileUploader/components/AddProfileModal/_styles.scss
+++ b/frontend/pages/ManageControlsPage/OSSettings/cards/CustomSettings/components/ProfileUploader/components/AddProfileModal/_styles.scss
@@ -60,6 +60,7 @@
 
     &--message {
       text-align: center;
+      line-height: 20px;
     }
   }
 


### PR DESCRIPTION
## #23215 

- Explicitly set "Add profile" message line heights so they are consistent cross-browser

<img width="1624" alt="Screenshot 2024-10-24 at 3 34 45 PM" src="https://github.com/user-attachments/assets/ac793e32-729f-423a-b672-ed60412eb92d">
<img width="1624" alt="Screenshot 2024-10-24 at 3 34 53 PM" src="https://github.com/user-attachments/assets/5d8c8947-34ad-49c0-87d6-ea10b0ebd980">


- [x] Changes file added for user-visible changes in `changes/`,
- [x] Manual QA for all new/changed functionality