### PR TITLE
Fix issues around selecting software to install

### DIFF
--- a/frontend/components/TableContainer/DataTable/DataTable.tsx
+++ b/frontend/components/TableContainer/DataTable/DataTable.tsx
@@ -363,10 +363,13 @@ const DataTable = ({
   };
 
   const renderSelectedCount = (): JSX.Element => {
+    const selectedCount = Object.entries(selectedRowIds).filter(
+      ([, value]) => value
+    ).length;
     return (
       <p>
         <span>
-          {selectedFlatRows.length}
+          {selectedCount}
           {isAllPagesSelected && "+"}
         </span>{" "}
         selected
@@ -473,6 +476,9 @@ const DataTable = ({
     "is-observer": isOnlyObserver,
   });
 
+  console.log("rows", rows);
+  console.log("selectedFlatRows", selectedFlatRows);
+  console.log("selectedRowIds", selectedRowIds);
   return (
     <div className={baseClass}>
       {isLoading && (

--- a/frontend/components/TableContainer/DataTable/DataTable.tsx
+++ b/frontend/components/TableContainer/DataTable/DataTable.tsx
@@ -476,9 +476,6 @@ const DataTable = ({
     "is-observer": isOnlyObserver,
   });
 
-  console.log("rows", rows);
-  console.log("selectedFlatRows", selectedFlatRows);
-  console.log("selectedRowIds", selectedRowIds);
   return (
     <div className={baseClass}>
       {isLoading && (

--- a/frontend/components/TableContainer/DataTable/DataTable.tsx
+++ b/frontend/components/TableContainer/DataTable/DataTable.tsx
@@ -258,7 +258,9 @@ const DataTable = ({
   }, [isClientSideFilter, onResultsCountChange, rows.length]);
 
   useEffect(() => {
+    console.log(searchQuery);
     if (isClientSideFilter && searchQueryColumn) {
+      console.log("resetting selected rows");
       toggleAllRowsSelected(false); // Resets row selection on query change (client-side)
       setDebouncedClientFilter(searchQueryColumn, searchQuery || "");
     }
@@ -294,7 +296,7 @@ const DataTable = ({
 
   useEffect(() => {
     if (isAllPagesSelected) {
-      toggleAllRowsSelected(true);
+      // toggleAllRowsSelected(true);
     }
   }, [isAllPagesSelected, toggleAllRowsSelected]);
 

--- a/frontend/components/TableContainer/DataTable/SoftwareNameCell/SoftwareNameCell.tsx
+++ b/frontend/components/TableContainer/DataTable/SoftwareNameCell/SoftwareNameCell.tsx
@@ -82,7 +82,7 @@ const SoftwareNameCell = ({
   if (!router || !path) {
     return (
       <div className={baseClass}>
-        <SoftwareIcon name={name} source={source} />
+        <SoftwareIcon name={name} source={source} url={iconUrl} />
         <span className="software-name">{name}</span>
       </div>
     );

--- a/frontend/components/TableContainer/TableContainer.tsx
+++ b/frontend/components/TableContainer/TableContainer.tsx
@@ -39,6 +39,7 @@ interface ITableContainerProps<T = any> {
   defaultSortDirection?: string;
   defaultSearchQuery?: string;
   defaultPageIndex?: number;
+  defaultSelectedRows?: Record<string, boolean>;
   /** Button visible above the table container next to search bar */
   actionButton?: IActionButtonProps;
   inputPlaceHolder?: string;
@@ -104,6 +105,8 @@ interface ITableContainerProps<T = any> {
    * bar and API call so TableContainer will reset its page state to 0  */
   resetPageIndex?: boolean;
   disableTableHeader?: boolean;
+  /** Set to true to persist the row selections across table data filters */
+  persistSelectedRows?: boolean;
   /** handler called when the  `clear selection` button is called */
   onClearSelection?: () => void;
 }
@@ -123,6 +126,7 @@ const TableContainer = <T,>({
   defaultPageIndex = DEFAULT_PAGE_INDEX,
   defaultSortHeader = "name",
   defaultSortDirection = "asc",
+  defaultSelectedRows,
   inputPlaceHolder = "Search",
   additionalQueries,
   resultsTitle,
@@ -161,6 +165,7 @@ const TableContainer = <T,>({
   setExportRows,
   resetPageIndex,
   disableTableHeader,
+  persistSelectedRows,
   onClearSelection = noop,
 }: ITableContainerProps<T>) => {
   const [searchQuery, setSearchQuery] = useState(defaultSearchQuery);
@@ -501,6 +506,7 @@ const TableContainer = <T,>({
                 resultsTitle={resultsTitle}
                 defaultPageSize={pageSize}
                 defaultPageIndex={defaultPageIndex}
+                defaultSelectedRows={defaultSelectedRows}
                 primarySelectAction={primarySelectAction}
                 secondarySelectActions={secondarySelectActions}
                 onSelectSingleRow={onSelectSingleRow}
@@ -519,6 +525,7 @@ const TableContainer = <T,>({
                 }
                 setExportRows={setExportRows}
                 onClearSelection={onClearSelection}
+                persistSelectedRows={persistSelectedRows}
               />
             </div>
           </>

--- a/frontend/components/TableContainer/TableContainer.tsx
+++ b/frontend/components/TableContainer/TableContainer.tsx
@@ -72,6 +72,7 @@ interface ITableContainerProps<T = any> {
   isClientSidePagination?: boolean;
   /** Used to set URL to correct path and include page query param */
   onClientSidePaginationChange?: (pageIndex: number) => void;
+  /** Sets the table to filter the data on the client */
   isClientSideFilter?: boolean;
   /** isMultiColumnFilter is used to preserve the table headers
   in lieu of displaying the empty component when client-side filtering yields zero results */

--- a/frontend/pages/ManageControlsPage/SetupExperience/cards/InstallSoftware/components/AddInstallSoftware/AddInstallSoftware.tsx
+++ b/frontend/pages/ManageControlsPage/SetupExperience/cards/InstallSoftware/components/AddInstallSoftware/AddInstallSoftware.tsx
@@ -22,7 +22,9 @@ const AddInstallSoftware = ({
 }: IAddInstallSoftwareProps) => {
   const hasNoSoftware = softwareTitles.length === 0;
   const installDuringSetupCount = softwareTitles.filter(
-    (software) => software.software_package?.install_during_setup
+    (software) =>
+      software.software_package?.install_during_setup ||
+      software.app_store_app?.install_during_setup
   ).length;
 
   let addedText = <></>;

--- a/frontend/pages/ManageControlsPage/SetupExperience/cards/InstallSoftware/components/SelectSoftwareModal/SelectSoftwareModal.tsx
+++ b/frontend/pages/ManageControlsPage/SetupExperience/cards/InstallSoftware/components/SelectSoftwareModal/SelectSoftwareModal.tsx
@@ -11,9 +11,7 @@ import SelectSoftwareTable from "../SelectSoftwareTable";
 
 const baseClass = "select-software-modal";
 
-export const initializeSelectedSoftwareIds = (
-  softwareTitles: ISoftwareTitle[]
-) => {
+const initializeSelectedSoftwareIds = (softwareTitles: ISoftwareTitle[]) => {
   return softwareTitles.reduce<number[]>((acc, software) => {
     if (
       software.software_package?.install_during_setup ||
@@ -84,7 +82,6 @@ const SelectSoftwareModal = ({
     <Modal className={baseClass} title="Select software" onExit={onExit}>
       <>
         <SelectSoftwareTable
-          initialSelectedSoftware={initalSelectedSoftware}
           softwareTitles={softwareTitles}
           onChangeSoftwareSelect={onChangeSoftwareSelect}
           onChangeSelectAll={onChangeSelectAll}

--- a/frontend/pages/ManageControlsPage/SetupExperience/cards/InstallSoftware/components/SelectSoftwareModal/SelectSoftwareModal.tsx
+++ b/frontend/pages/ManageControlsPage/SetupExperience/cards/InstallSoftware/components/SelectSoftwareModal/SelectSoftwareModal.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useState } from "react";
+import React, { useCallback, useContext, useMemo, useState } from "react";
 
 import { ISoftwareTitle } from "interfaces/software";
 import { NotificationContext } from "context/notification";
@@ -11,7 +11,9 @@ import SelectSoftwareTable from "../SelectSoftwareTable";
 
 const baseClass = "select-software-modal";
 
-const initializeSelectedSoftwareIds = (softwareTitles: ISoftwareTitle[]) => {
+export const initializeSelectedSoftwareIds = (
+  softwareTitles: ISoftwareTitle[]
+) => {
   return softwareTitles.reduce<number[]>((acc, software) => {
     if (
       software.software_package?.install_during_setup ||
@@ -38,9 +40,13 @@ const SelectSoftwareModal = ({
 }: ISelectSoftwareModalProps) => {
   const { renderFlash } = useContext(NotificationContext);
 
+  const initalSelectedSoftware = useMemo(
+    () => initializeSelectedSoftwareIds(softwareTitles),
+    [softwareTitles]
+  );
   const [isSaving, setIsSaving] = useState(false);
-  const [selectedSoftwareIds, setSelectedSoftwareIds] = useState<number[]>(() =>
-    initializeSelectedSoftwareIds(softwareTitles)
+  const [selectedSoftwareIds, setSelectedSoftwareIds] = useState<number[]>(
+    initalSelectedSoftware
   );
 
   const onSaveSelectedSoftware = async () => {
@@ -58,23 +64,27 @@ const SelectSoftwareModal = ({
     onSave();
   };
 
-  const onChangeSoftwareSelect = (select: boolean, id: number) => {
+  const onChangeSoftwareSelect = useCallback((select: boolean, id: number) => {
     setSelectedSoftwareIds((prevSelectedSoftwareIds) => {
       if (select) {
         return [...prevSelectedSoftwareIds, id];
       }
       return prevSelectedSoftwareIds.filter((selectedId) => selectedId !== id);
     });
-  };
+  }, []);
 
-  const onChangeSelectAll = (selectAll: boolean) => {
-    setSelectedSoftwareIds(selectAll ? softwareTitles.map((s) => s.id) : []);
-  };
+  const onChangeSelectAll = useCallback(
+    (selectAll: boolean) => {
+      setSelectedSoftwareIds(selectAll ? softwareTitles.map((s) => s.id) : []);
+    },
+    [softwareTitles]
+  );
 
   return (
     <Modal className={baseClass} title="Select software" onExit={onExit}>
       <>
         <SelectSoftwareTable
+          initialSelectedSoftware={initalSelectedSoftware}
           softwareTitles={softwareTitles}
           onChangeSoftwareSelect={onChangeSoftwareSelect}
           onChangeSelectAll={onChangeSelectAll}

--- a/frontend/pages/ManageControlsPage/SetupExperience/cards/InstallSoftware/components/SelectSoftwareTable/SelectSoftwareTable.tsx
+++ b/frontend/pages/ManageControlsPage/SetupExperience/cards/InstallSoftware/components/SelectSoftwareTable/SelectSoftwareTable.tsx
@@ -3,14 +3,25 @@ import React, { useMemo } from "react";
 import { ISoftwareTitle } from "interfaces/software";
 
 import TableContainer from "components/TableContainer";
+import EmptyTable from "components/EmptyTable";
 
 import generateTableConfig from "./SelectSoftwareTableConfig";
-import EmptyTable from "components/EmptyTable";
 
 const baseClass = "select-software-table";
 
+const generateSelectedRows = (softwareTitles: ISoftwareTitle[]) => {
+  return softwareTitles.reduce<Record<string, boolean>>((acc, software, i) => {
+    if (
+      software.software_package?.install_during_setup ||
+      software.app_store_app?.install_during_setup
+    ) {
+      acc[i] = true;
+    }
+    return acc;
+  }, {});
+};
+
 interface ISelectSoftwareTableProps {
-  initialSelectedSoftware: number[];
   softwareTitles: ISoftwareTitle[];
   onChangeSoftwareSelect: (select: boolean, id: number) => void;
   onChangeSelectAll: (selectAll: boolean) => void;
@@ -18,18 +29,16 @@ interface ISelectSoftwareTableProps {
 
 const SelectSoftwareTable = ({
   softwareTitles,
-  initialSelectedSoftware,
   onChangeSoftwareSelect,
   onChangeSelectAll,
 }: ISelectSoftwareTableProps) => {
   const tabelConfig = useMemo(() => {
-    console.log("initial selected software", initialSelectedSoftware);
-    return generateTableConfig(
-      initialSelectedSoftware,
-      onChangeSelectAll,
-      onChangeSoftwareSelect
-    );
-  }, [initialSelectedSoftware, onChangeSelectAll, onChangeSoftwareSelect]);
+    return generateTableConfig(onChangeSelectAll, onChangeSoftwareSelect);
+  }, [onChangeSelectAll, onChangeSoftwareSelect]);
+
+  const initialSelectedSoftwareRows = useMemo(() => {
+    return generateSelectedRows(softwareTitles);
+  }, [softwareTitles]);
 
   return (
     <TableContainer
@@ -44,8 +53,10 @@ const SelectSoftwareTable = ({
           className={baseClass}
         />
       )}
+      defaultSelectedRows={initialSelectedSoftwareRows}
       showMarkAllPages
       isAllPagesSelected={false}
+      persistSelectedRows
       disablePagination
       searchable
       searchQueryColumn="name"

--- a/frontend/pages/ManageControlsPage/SetupExperience/cards/InstallSoftware/components/SelectSoftwareTable/SelectSoftwareTable.tsx
+++ b/frontend/pages/ManageControlsPage/SetupExperience/cards/InstallSoftware/components/SelectSoftwareTable/SelectSoftwareTable.tsx
@@ -1,14 +1,16 @@
-import React from "react";
+import React, { useMemo } from "react";
 
 import { ISoftwareTitle } from "interfaces/software";
 
 import TableContainer from "components/TableContainer";
 
 import generateTableConfig from "./SelectSoftwareTableConfig";
+import EmptyTable from "components/EmptyTable";
 
 const baseClass = "select-software-table";
 
 interface ISelectSoftwareTableProps {
+  initialSelectedSoftware: number[];
   softwareTitles: ISoftwareTitle[];
   onChangeSoftwareSelect: (select: boolean, id: number) => void;
   onChangeSelectAll: (selectAll: boolean) => void;
@@ -16,13 +18,18 @@ interface ISelectSoftwareTableProps {
 
 const SelectSoftwareTable = ({
   softwareTitles,
+  initialSelectedSoftware,
   onChangeSoftwareSelect,
   onChangeSelectAll,
 }: ISelectSoftwareTableProps) => {
-  const tabelConfig = generateTableConfig(
-    onChangeSelectAll,
-    onChangeSoftwareSelect
-  );
+  const tabelConfig = useMemo(() => {
+    console.log("initial selected software", initialSelectedSoftware);
+    return generateTableConfig(
+      initialSelectedSoftware,
+      onChangeSelectAll,
+      onChangeSoftwareSelect
+    );
+  }, [initialSelectedSoftware, onChangeSelectAll, onChangeSoftwareSelect]);
 
   return (
     <TableContainer
@@ -30,7 +37,13 @@ const SelectSoftwareTable = ({
       data={softwareTitles}
       columnConfigs={tabelConfig}
       isLoading={false}
-      emptyComponent={() => null}
+      emptyComponent={() => (
+        <EmptyTable
+          header="No software available"
+          info=" There are no results to your query."
+          className={baseClass}
+        />
+      )}
       showMarkAllPages
       isAllPagesSelected={false}
       disablePagination

--- a/frontend/pages/ManageControlsPage/SetupExperience/cards/InstallSoftware/components/SelectSoftwareTable/SelectSoftwareTableConfig.tsx
+++ b/frontend/pages/ManageControlsPage/SetupExperience/cards/InstallSoftware/components/SelectSoftwareTable/SelectSoftwareTableConfig.tsx
@@ -3,10 +3,7 @@ import { CellProps, Column } from "react-table";
 
 import { IHeaderProps, IStringCellProps } from "interfaces/datatable_config";
 import { ISoftwareTitle } from "interfaces/software";
-import {
-  APPLE_PLATFORM_DISPLAY_NAMES,
-  ApplePlatform,
-} from "interfaces/platform";
+import { APPLE_PLATFORM_DISPLAY_NAMES } from "interfaces/platform";
 
 import TextCell from "components/TableContainer/DataTable/TextCell";
 import SoftwareNameCell from "components/TableContainer/DataTable/SoftwareNameCell";
@@ -72,9 +69,8 @@ const generateTableConfig = (
       disableSortBy: true,
       accessor: "source",
       Cell: (cellProps: ITableStringCellProps) => (
-        <TextCell
-          value={APPLE_PLATFORM_DISPLAY_NAMES[cellProps.value as ApplePlatform]}
-        />
+        // TODO: this will need to be updated when we add support for other platforms
+        <TextCell value={APPLE_PLATFORM_DISPLAY_NAMES.darwin} />
       ),
       sortType: "caseInsensitive",
     },

--- a/frontend/pages/ManageControlsPage/SetupExperience/cards/InstallSoftware/components/SelectSoftwareTable/SelectSoftwareTableConfig.tsx
+++ b/frontend/pages/ManageControlsPage/SetupExperience/cards/InstallSoftware/components/SelectSoftwareTable/SelectSoftwareTableConfig.tsx
@@ -19,12 +19,9 @@ type ITableStringCellProps = IStringCellProps<ISoftwareTitle>;
 type ISelectionCellProps = CellProps<ISoftwareTitle>;
 
 const generateTableConfig = (
-  initialSelectedSoftware: number[],
   onSelectAll: (selectAll: boolean) => void,
   onSelectSoftware: (select: boolean, id: number) => void
 ): ISelectSoftwareTableConfig[] => {
-  let initialRender = true;
-
   const headerConfigs: ISelectSoftwareTableConfig[] = [
     {
       id: "selection",
@@ -46,19 +43,7 @@ const generateTableConfig = (
         return <Checkbox {...checkboxProps} />;
       },
       Cell: (cellProps: ISelectionCellProps) => {
-        if (initialRender) {
-          const isSelected = initialSelectedSoftware.includes(
-            cellProps.row.original.id
-          );
-          console.log("row:", cellProps.row.original.id, isSelected);
-          cellProps.row.toggleRowSelected();
-        }
         const { checked } = cellProps.row.getToggleRowSelectedProps();
-        console.log(
-          "row:",
-          cellProps.row.original.id,
-          cellProps.row.getToggleRowSelectedProps()
-        );
         const checkboxProps = {
           value: checked,
           onChange: () => {
@@ -66,7 +51,6 @@ const generateTableConfig = (
             cellProps.row.toggleRowSelected();
           },
         };
-        initialRender = false;
         return <Checkbox {...checkboxProps} />;
       },
     },

--- a/frontend/pages/ManageControlsPage/SetupExperience/cards/InstallSoftware/components/SelectSoftwareTable/SelectSoftwareTableConfig.tsx
+++ b/frontend/pages/ManageControlsPage/SetupExperience/cards/InstallSoftware/components/SelectSoftwareTable/SelectSoftwareTableConfig.tsx
@@ -59,8 +59,11 @@ const generateTableConfig = (
       disableSortBy: true,
       accessor: "name",
       Cell: (cellProps: ITableStringCellProps) => {
-        const { name, source } = cellProps.row.original;
-        return <SoftwareNameCell name={name} source={source} />;
+        const { name, source, app_store_app } = cellProps.row.original;
+
+        const url = app_store_app?.icon_url;
+
+        return <SoftwareNameCell name={name} source={source} iconUrl={url} />;
       },
       sortType: "caseInsensitive",
     },

--- a/frontend/pages/ManageControlsPage/SetupExperience/cards/InstallSoftware/components/SelectSoftwareTable/SelectSoftwareTableConfig.tsx
+++ b/frontend/pages/ManageControlsPage/SetupExperience/cards/InstallSoftware/components/SelectSoftwareTable/SelectSoftwareTableConfig.tsx
@@ -19,9 +19,12 @@ type ITableStringCellProps = IStringCellProps<ISoftwareTitle>;
 type ISelectionCellProps = CellProps<ISoftwareTitle>;
 
 const generateTableConfig = (
+  initialSelectedSoftware: number[],
   onSelectAll: (selectAll: boolean) => void,
   onSelectSoftware: (select: boolean, id: number) => void
 ): ISelectSoftwareTableConfig[] => {
+  let initialRender = true;
+
   const headerConfigs: ISelectSoftwareTableConfig[] = [
     {
       id: "selection",
@@ -43,7 +46,19 @@ const generateTableConfig = (
         return <Checkbox {...checkboxProps} />;
       },
       Cell: (cellProps: ISelectionCellProps) => {
+        if (initialRender) {
+          const isSelected = initialSelectedSoftware.includes(
+            cellProps.row.original.id
+          );
+          console.log("row:", cellProps.row.original.id, isSelected);
+          cellProps.row.toggleRowSelected();
+        }
         const { checked } = cellProps.row.getToggleRowSelectedProps();
+        console.log(
+          "row:",
+          cellProps.row.original.id,
+          cellProps.row.getToggleRowSelectedProps()
+        );
         const checkboxProps = {
           value: checked,
           onChange: () => {
@@ -51,6 +66,7 @@ const generateTableConfig = (
             cellProps.row.toggleRowSelected();
           },
         };
+        initialRender = false;
         return <Checkbox {...checkboxProps} />;
       },
     },


### PR DESCRIPTION
relates to #23180

fixes up some issues with showing the correct number of selected software to install and also with the table row selection behaviour.

We've had to create a couple new props on the `TableContainer` component; one called `defaultSelectedRows` and the other `persistSelectedRows`.


`defaultSelectedRows` will allow you to specify the default rows that are selected in the table on the initial render. This is done with an object with the key being the index of the row and the value being a boolean.

```tsx
// the first and third rows will be selected in this case
<TableContainer
  defaultSelectedRows={{0: true, 2: true}}
  ...
/>
```

`persistSelectedRows` will allow the row selections to persist across search query changes. This defaults to false.
