### PR TITLE
Minor fixes from analyzing test results

### DIFF
--- a/cmd/fleetctl/generate.go
+++ b/cmd/fleetctl/generate.go
@@ -49,24 +49,24 @@ func generateMDMAppleCommand() *cli.Command {
 			// before printing the CSR output message.
 			client, err := clientFromCLI(c)
 			if err != nil {
-				fmt.Fprintf(c.App.ErrWriter, "client from CLI: %s", err)
+				fmt.Fprintf(c.App.ErrWriter, "client from CLI: %s\n", err)
 				return ErrGeneric
 			}
 
 			csr, err := client.RequestAppleCSR()
 			if err != nil {
-				fmt.Fprintf(c.App.ErrWriter, "requesting APNs CSR: %s", err)
+				fmt.Fprintf(c.App.ErrWriter, "requesting APNs CSR: %s\n", err)
 				return ErrGeneric
 			}
 
 			if err := os.WriteFile(csrPath, csr, defaultFileMode); err != nil {
-				fmt.Fprintf(c.App.ErrWriter, "write CSR: %s", err)
+				fmt.Fprintf(c.App.ErrWriter, "write CSR: %s\n", err)
 				return ErrGeneric
 			}
 
 			appCfg, err := client.GetAppConfig()
 			if err != nil {
-				fmt.Fprintf(c.App.ErrWriter, "fetching app config: %s", err)
+				fmt.Fprintf(c.App.ErrWriter, "fetching app config: %s\n", err)
 				return ErrGeneric
 			}
 

--- a/server/datastore/mysql/mysql_test.go
+++ b/server/datastore/mysql/mysql_test.go
@@ -595,7 +595,6 @@ func TestWhereFilterHostsByTeams(t *testing.T) {
 	for _, tt := range testCases {
 		tt := tt
 		t.Run("", func(t *testing.T) {
-			t.Parallel()
 			ds := &Datastore{logger: log.NewNopLogger()}
 			sql := ds.whereFilterHostsByTeams(tt.filter, "hosts")
 			assert.Equal(t, tt.expected, sql)
@@ -631,7 +630,6 @@ func TestWhereOmitIDs(t *testing.T) {
 	for _, tt := range testCases {
 		tt := tt
 		t.Run("", func(t *testing.T) {
-			t.Parallel()
 			ds := &Datastore{logger: log.NewNopLogger()}
 			sql := ds.whereOmitIDs("id", tt.omits)
 			assert.Equal(t, tt.expected, sql)
@@ -856,7 +854,6 @@ func TestWhereFilterTeams(t *testing.T) {
 	for _, tt := range testCases {
 		tt := tt
 		t.Run("", func(t *testing.T) {
-			t.Parallel()
 			ds := &Datastore{logger: log.NewNopLogger()}
 			sql := ds.whereFilterTeams(tt.filter, "t")
 			assert.Equal(t, tt.expected, sql)


### PR DESCRIPTION
Newlines improve test result parsing.

Extra `t.Parallel()` calls removed in subtest since parent test and package are already parallelized.