### PR TITLE
Skip TestCronVulnerabilitiesCreatesDatabasesPath

### DIFF
--- a/cmd/fleet/serve_test.go
+++ b/cmd/fleet/serve_test.go
@@ -307,6 +307,7 @@ func TestAutomationsSchedule(t *testing.T) {
 }
 
 func TestCronVulnerabilitiesCreatesDatabasesPath(t *testing.T) {
+	t.Skip() // https://github.com/fleetdm/fleet/issues/23258
 	t.Parallel()
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()


### PR DESCRIPTION
Seeing very high failure rate for this test. Bug already filed: https://github.com/fleetdm/fleet/issues/23258
