### PR TITLE
fix file uplader being shown twice when clicking button

### DIFF
--- a/frontend/components/FileUploader/FileUploader.tsx
+++ b/frontend/components/FileUploader/FileUploader.tsx
@@ -129,7 +129,6 @@ export const FileUploader = ({
           disabled={disabled}
           customOnKeyDown={handleKeyDown}
           tabIndex={0}
-          onClick={triggerFileInput}
         >
           <label htmlFor="upload-file">
             {buttonType === "link" && <Icon name="upload" />}


### PR DESCRIPTION
relates to #23294

This is a fix for the file uploader button. It only needs to trigger the input selection when using the keyboard navigation. It does not need the `onClick` prop on the button because that is handled by the `label` element. Removing this from the Button component fixes the issue with selecting a file.
