### PR TITLE
Update Sales handbook

### DIFF
--- a/handbook/sales/README.md
+++ b/handbook/sales/README.md
@@ -232,17 +232,15 @@ Temp Transfer to: Temp technical DRI
 3. If the customer "redlines" (i.e. wants to change) the NDA, follow the [contract review process](https://fleetdm.com/handbook/company/communications#getting-a-contract-reviewed) so that Digital Experience can look over any proposed changes and provide guidance on how to proceed.
 
 
-### Create a customer agreement
+### Create a subscription agreement
 
-- **Contract terms:** Fleet's subscription agreement is available at [fleetdm.com/terms](https://fleetdm.com/terms). 
-  - **Effective date:** The start date for the subscription service.
-  - **Close date:** The date the last party to the contract signed the agreement.
-  - **Invoice date:** The date that Fleet sent the invoice to the customer.
-- Fleeties can find a summary of contract terms in the relevant [customer's Salesforce opportunity.](https://fleetdm.lightning.force.com/lightning/o/Opportunity/list?filterName=Recent)
+1. Create a copy of the [subscription agreement template](https://docs.google.com/document/d/1ri9sS2rlBbBLEFi7RrfKZ9bZj8e48orsFKZDfF0PgAg/copy?tab=t.0).
+2. Add/remove table rows as needed for multi-year deals.
+3. Where possible, include a graphic of the customer's logo. Use good judgement and omit if a high quality graphic is unavailable. If in doubt, ask Digital Experience for help.
 
-- **Standard terms:** For all subscription agreements, NDAs, and similar contracts, Fleet maintains a [standard set of terms and maximum allowable adjustments for those terms](https://docs.google.com/spreadsheets/d/1gAenC948YWG2NwcaVHleUvX0LzS8suyMFpjaBqxHQNg/edit#gid=1136345578). Exceptions to these maximum allowable adjustments always require CEO approval, whether in the form of redlines to Fleet's agreements or in terms on a prospective customer's own contract.
-
-> All non-standard (from another party) subscription agreements, NDAs, and similar contracts require legal review from the Contracts and Compliance department before being signed. [Create an issue to request legal review](https://github.com/fleetdm/confidential/blob/main/.github/ISSUE_TEMPLATE/contract-review.md).
+> **Important**
+> - All changes to the [subscription agreement template](https://docs.google.com/document/d/1ri9sS2rlBbBLEFi7RrfKZ9bZj8e48orsFKZDfF0PgAg/copy?tab=t.0), or [standard terms](http://fleetdm.com/terms) must be brought to ["🦢🗣 Design review (#g-digital-experience)"](https://app.zenhub.com/workspaces/-g-digital-experience-6451748b4eb15200131d4bab/board?sprints=none) for approval.
+> - All non-standard (from another party) subscription agreements, NDAs, and similar contracts require legal review from Digital Experience before being signed. [Create an issue to request legal review](https://github.com/fleetdm/confidential/blob/main/.github/ISSUE_TEMPLATE/contract-review.md).
 
 
 ### Close a new customer deal


### PR DESCRIPTION
- Added instructions for how to create a subscription agreement
- Added important information about the review process
- Standardized naming of the document to be "Subscription agreement"
- Removed out-of-date and redundant information

Closes: https://github.com/fleetdm/confidential/issues/7922

cc @alexmitchelliii. We have removed all out-of-date subscription agreement (FKA order form) templates from Drive and DocuSign. Please use the template linked in this handbook update for all new agreements.