### PR TITLE
Various setup exp UI fixes

### DIFF
--- a/frontend/pages/ManageControlsPage/SetupExperience/cards/BootstrapPackage/components/BootstrapPackagePreview/BootstrapPackagePreview.tsx
+++ b/frontend/pages/ManageControlsPage/SetupExperience/cards/BootstrapPackage/components/BootstrapPackagePreview/BootstrapPackagePreview.tsx
@@ -11,17 +11,18 @@ const BootstrapPackagePreview = () => {
       <p>
         The bootstrap package is automatically installed after the end user
         authenticates and agrees to the EULA during the <b>Remote Management</b>{" "}
-        pane in macOS Setup Assistant.
+        screen in macOS Setup Assistant.
       </p>
       <p>
-        The end user is allowed to continue to the next setup pane before the
+        The end user is allowed to continue to the next setup screen before the
         installation starts.
       </p>
       <p>The package isn&apos;t installed on hosts that already enrolled.</p>
       <img
         className={`${baseClass}__preview-img`}
         src={OsSetupPreview}
-        alt="OS setup preview"
+        alt="End user experience during the macOS setup assistant with the
+        bootstrap package installation"
       />
     </div>
   );

--- a/frontend/pages/ManageControlsPage/SetupExperience/cards/EndUserAuthentication/EndUserAuthentication.tsx
+++ b/frontend/pages/ManageControlsPage/SetupExperience/cards/EndUserAuthentication/EndUserAuthentication.tsx
@@ -13,8 +13,6 @@ import Spinner from "components/Spinner";
 
 import RequireEndUserAuth from "./components/RequireEndUserAuth/RequireEndUserAuth";
 import EndUserAuthForm from "./components/EndUserAuthForm/EndUserAuthForm";
-
-import OsSetupPreview from "../../../../../../assets/images/os-setup-preview.gif";
 import EndUserExperiencePreview from "./components/EndUserExperiencePreview";
 
 const baseClass = "end-user-authentication";
@@ -97,17 +95,7 @@ const EndUserAuthentication = ({
               defaultIsEndUserAuthEnabled={defaultIsEndUserAuthEnabled}
             />
           )}
-          <EndUserExperiencePreview previewImage={OsSetupPreview}>
-            <p>
-              When the end user reaches the <b>Remote Management</b> pane in the
-              macOS Setup Assistant, they are asked to authenticate and agree to
-              the end user license agreement (EULA).
-            </p>
-            <p>
-              After, Fleet enrolls the Mac, applies macOS settings, and installs
-              the bootstrap package.
-            </p>
-          </EndUserExperiencePreview>
+          <EndUserExperiencePreview />
         </div>
       )}
     </div>

--- a/frontend/pages/ManageControlsPage/SetupExperience/cards/EndUserAuthentication/components/EndUserExperiencePreview/EndUserExperiencePreview.tsx
+++ b/frontend/pages/ManageControlsPage/SetupExperience/cards/EndUserAuthentication/components/EndUserExperiencePreview/EndUserExperiencePreview.tsx
@@ -1,19 +1,15 @@
-import classnames from "classnames";
 import React from "react";
+import classnames from "classnames";
+
+import OsSetupPreview from "../../../../../../../../assets/images/os-setup-preview.gif";
 
 const baseClass = "end-user-experience-preview";
 
 interface IEndUserExperiencePreviewProps {
-  previewImage: string;
-  altText?: string;
-  children?: React.ReactNode;
   className?: string;
 }
 
 const EndUserExperiencePreview = ({
-  previewImage,
-  altText = "end user experience preview",
-  children,
   className,
 }: IEndUserExperiencePreviewProps) => {
   const classes = classnames(baseClass, className);
@@ -21,11 +17,20 @@ const EndUserExperiencePreview = ({
   return (
     <div className={classes}>
       <h3>End user experience</h3>
-      <>{children}</>
+      <p>
+        When the end user reaches the <b>Remote Management</b> screen in the
+        macOS Setup Assistant, they are asked to authenticate and agree to the
+        end user license agreement (EULA).
+      </p>
+      <p>
+        After, Fleet enrolls the Mac, applies macOS settings, and installs the
+        bootstrap package.
+      </p>
       <img
         className={`${baseClass}__preview-img`}
-        src={previewImage}
-        alt={altText}
+        src={OsSetupPreview}
+        alt="End user experience during the macOS setup assistant with the user
+        logging in with their IdP provider"
       />
     </div>
   );

--- a/frontend/pages/ManageControlsPage/SetupExperience/cards/InstallSoftware/InstallSoftware.tsx
+++ b/frontend/pages/ManageControlsPage/SetupExperience/cards/InstallSoftware/InstallSoftware.tsx
@@ -5,7 +5,7 @@ import { AxiosError } from "axios";
 import mdmAPI, {
   IGetSetupExperienceSoftwareResponse,
 } from "services/entities/mdm";
-import software, { ISoftwareTitle } from "interfaces/software";
+import { ISoftwareTitle } from "interfaces/software";
 import { DEFAULT_USE_QUERY_OPTIONS } from "utilities/constants";
 
 import SectionHeader from "components/SectionHeader";

--- a/frontend/pages/ManageControlsPage/SetupExperience/cards/InstallSoftware/InstallSoftware.tsx
+++ b/frontend/pages/ManageControlsPage/SetupExperience/cards/InstallSoftware/InstallSoftware.tsx
@@ -37,7 +37,7 @@ const InstallSoftware = ({ currentTeamId }: IInstallSoftwareProps) => {
   } = useQuery<
     IGetSetupExperienceSoftwareResponse,
     AxiosError,
-    ISoftwareTitle[]
+    ISoftwareTitle[] | null
   >(
     ["install-software", currentTeamId],
     () =>
@@ -65,7 +65,7 @@ const InstallSoftware = ({ currentTeamId }: IInstallSoftwareProps) => {
       return <DataError />;
     }
 
-    if (softwareTitles) {
+    if (softwareTitles === null) {
       return (
         <div className={`${baseClass}__content`}>
           <AddInstallSoftware

--- a/frontend/pages/ManageControlsPage/SetupExperience/cards/InstallSoftware/_styles.scss
+++ b/frontend/pages/ManageControlsPage/SetupExperience/cards/InstallSoftware/_styles.scss
@@ -6,4 +6,10 @@
     grid-template-columns: repeat(2, minmax(0, 1fr));
     gap: $pad-xxlarge;
   }
+
+  @media (max-width: $break-md) {
+    &__content {
+      grid-template-columns: minmax(0, 1fr);
+    }
+  }
 }

--- a/frontend/pages/ManageControlsPage/SetupExperience/cards/InstallSoftware/components/AddInstallSoftware/AddInstallSoftware.tests.tsx
+++ b/frontend/pages/ManageControlsPage/SetupExperience/cards/InstallSoftware/components/AddInstallSoftware/AddInstallSoftware.tests.tsx
@@ -14,7 +14,7 @@ describe("AddInstallSoftware", () => {
     render(
       <AddInstallSoftware
         currentTeamId={1}
-        softwareTitles={[]}
+        softwareTitles={null}
         onAddSoftware={noop}
       />
     );

--- a/frontend/pages/ManageControlsPage/SetupExperience/cards/InstallSoftware/components/AddInstallSoftware/AddInstallSoftware.tsx
+++ b/frontend/pages/ManageControlsPage/SetupExperience/cards/InstallSoftware/components/AddInstallSoftware/AddInstallSoftware.tsx
@@ -11,7 +11,7 @@ const baseClass = "add-install-software";
 
 interface IAddInstallSoftwareProps {
   currentTeamId: number;
-  softwareTitles: ISoftwareTitle[];
+  softwareTitles: ISoftwareTitle[] | null;
   onAddSoftware: () => void;
 }
 
@@ -20,40 +20,54 @@ const AddInstallSoftware = ({
   softwareTitles,
   onAddSoftware,
 }: IAddInstallSoftwareProps) => {
-  const hasNoSoftware = softwareTitles.length === 0;
-  const installDuringSetupCount = softwareTitles.filter(
-    (software) =>
-      software.software_package?.install_during_setup ||
-      software.app_store_app?.install_during_setup
-  ).length;
+  const hasNoSoftware = !softwareTitles || softwareTitles.length === 0;
 
-  let addedText = <></>;
-  let buttonText = "";
+  const getAddedText = () => {
+    if (hasNoSoftware) {
+      return (
+        <>
+          No software available to add. Please{" "}
+          <LinkWithContext
+            to={PATHS.SOFTWARE_ADD_FLEET_MAINTAINED}
+            currentQueryParams={{ team_id: currentTeamId }}
+            withParams={{ type: "query", names: ["team_id"] }}
+          >
+            upload software
+          </LinkWithContext>{" "}
+          to be able to add during setup experience.
+        </>
+      );
+    }
 
-  if (hasNoSoftware) {
-    addedText = (
-      <>
-        No software available to add. Please{" "}
-        <LinkWithContext
-          to={PATHS.SOFTWARE_ADD_FLEET_MAINTAINED}
-          currentQueryParams={{ team_id: currentTeamId }}
-          withParams={{ type: "query", names: ["team_id"] }}
-        >
-          upload software
-        </LinkWithContext>{" "}
-        to be able to add during setup experience.{" "}
-      </>
-    );
-    buttonText = "Add software";
-  } else if (installDuringSetupCount === 0) {
-    addedText = <>No software added.</>;
-    buttonText = "Add software";
-  } else {
-    addedText = (
-      <>{installDuringSetupCount} software will be installed during setup.</>
-    );
-    buttonText = "Show selected software";
-  }
+    const installDuringSetupCount = softwareTitles.filter(
+      (software) =>
+        software.software_package?.install_during_setup ||
+        software.app_store_app?.install_during_setup
+    ).length;
+
+    return installDuringSetupCount === 0
+      ? "No software added."
+      : `${installDuringSetupCount} software will be installed during setup.`;
+  };
+
+  const getButtonText = () => {
+    if (hasNoSoftware) {
+      return "Add software";
+    }
+
+    const installDuringSetupCount = softwareTitles.filter(
+      (software) =>
+        software.software_package?.install_during_setup ||
+        software.app_store_app?.install_during_setup
+    ).length;
+
+    return installDuringSetupCount === 0
+      ? "Add software"
+      : "Show selected software";
+  };
+
+  const addedText = getAddedText();
+  const buttonText = getButtonText();
 
   return (
     <div className={baseClass}>

--- a/frontend/pages/ManageControlsPage/SetupExperience/cards/InstallSoftware/components/InstallSoftwarePreview/InstallSoftwarePreview.tsx
+++ b/frontend/pages/ManageControlsPage/SetupExperience/cards/InstallSoftware/components/InstallSoftwarePreview/InstallSoftwarePreview.tsx
@@ -22,7 +22,8 @@ const InstallSoftwarePreview = () => {
       <img
         className={`${baseClass}__preview-img`}
         src={InstallSoftwarePreviewImg}
-        alt="install software preview"
+        alt="End user experience during the macOS setup assistant with selected
+        software being installed"
       />
     </Card>
   );

--- a/frontend/pages/ManageControlsPage/SetupExperience/cards/SetupAssistant/components/SetupAssistantPreview/SetupAssistantPreview.tsx
+++ b/frontend/pages/ManageControlsPage/SetupExperience/cards/SetupAssistant/components/SetupAssistantPreview/SetupAssistantPreview.tsx
@@ -21,7 +21,8 @@ const SetupAssistantPreview = () => {
       <img
         className={`${baseClass}__preview-img`}
         src={OsPrefillPreview}
-        alt="OS setup preview"
+        alt="End user experience during the macOS setup assistant customised by
+        an automatic enrollment profile"
       />
     </Card>
   );

--- a/frontend/pages/ManageControlsPage/SetupExperience/cards/SetupExperienceScript/_styles.scss
+++ b/frontend/pages/ManageControlsPage/SetupExperience/cards/SetupExperienceScript/_styles.scss
@@ -19,4 +19,10 @@
     margin: 0 0 $pad-small;
     font-weight: $bold;
   }
+
+  @media (max-width: $break-md) {
+    &__content {
+      grid-template-columns: minmax(0, 1fr);
+    }
+  }
 }

--- a/frontend/pages/ManageControlsPage/SetupExperience/cards/SetupExperienceScript/components/SetupExperienceScriptPreview/SetupExperienceScriptPreview.tsx
+++ b/frontend/pages/ManageControlsPage/SetupExperience/cards/SetupExperienceScript/components/SetupExperienceScriptPreview/SetupExperienceScriptPreview.tsx
@@ -21,7 +21,8 @@ const SetupExperienceScriptPreview = () => {
       <img
         className={`${baseClass}__preview-img`}
         src={InstallSoftwarePreviewImg}
-        alt="install software preview"
+        alt="End user experience during the macOS setup assistant with the uploaded
+        script being run"
       />
     </Card>
   );

--- a/frontend/services/entities/mdm.ts
+++ b/frontend/services/entities/mdm.ts
@@ -6,9 +6,11 @@ import {
   MdmProfileStatus,
 } from "interfaces/mdm";
 import { API_NO_TEAM_ID } from "interfaces/team";
+import { ISoftwareTitle } from "interfaces/software";
 import sendRequest from "services";
 import endpoints from "utilities/endpoints";
 import { buildQueryStringFromParams } from "utilities/url";
+
 import { ISoftwareTitlesResponse } from "./software";
 
 export interface IEulaMetadataResponse {
@@ -94,7 +96,9 @@ interface IGetSetupExperienceSoftwareParams {
   per_page: number;
 }
 
-export type IGetSetupExperienceSoftwareResponse = ISoftwareTitlesResponse;
+export type IGetSetupExperienceSoftwareResponse = ISoftwareTitlesResponse & {
+  software_titles: ISoftwareTitle[] | null;
+};
 
 const mdmService = {
   unenrollHostFromMdm: (hostId: number, timeout?: number) => {


### PR DESCRIPTION
relates to #23321, #23322, #23323

This contains three UI fixes:

1. fix when we show the empty state for install software. We were expecting an empty array but the response from `GET /setup_experience/software` sends null when no software has been added

![image](https://github.com/user-attachments/assets/0300fffa-5586-4073-a6df-491e844516c9)

2. fix to add responsive style to install software and run script panels that matches the other setup experience panels.

![image](https://github.com/user-attachments/assets/5494146f-583d-4816-9c1b-6227bb520108)

![image](https://github.com/user-attachments/assets/a2e3c43d-64bf-4695-9870-029482080172)

3. Fix and clean up the copy of the first three setup experience panels to match the new ones. Also, update the alt text on the images to be more descriptive. 

- [x] Added/updated tests
- [x] Manual QA for all new/changed functionality
