### PR TITLE
Deploy software: update pricing page and guides

### DIFF
--- a/articles/deploy-software-packages.md
+++ b/articles/deploy-software-packages.md
@@ -1,8 +1,14 @@
-# Deploy software packages
+# Deploy software
 
 ![Deploy software](../website/assets/images/articles/deploy-security-agents-1600x900@2x.png)
 
-Fleet [v4.50.0](https://github.com/fleetdm/fleet/releases/tag/fleet-v4.50.0) introduced the ability to upload and deploy software to your hosts. Fleet [v4.57.0](https://github.com/fleetdm/fleet/releases/tag/fleet-v4.57.0) added the ability to include an uninstall script and edit software details. Beyond a [bootstrap package](https://fleetdm.com/docs/using-fleet/mdm-macos-setup-experience#bootstrap-package) at enrollment, deploying software allows you to specify and verify device configuration using a pre-install query and customization of the install, post-install, and uninstall scripts, allowing for key and license deployment and configuration.  Admins can modify these options and settings after the initial upload. This guide will walk you through the steps to upload, configure, install, and uninstall a software package to hosts in your fleet.
+_Available in Fleet Premium_
+
+In Fleet you can deploy [Fleet-maintained apps](https://fleetdm.com/guides/install-fleet-maintained-apps-on-macos-hosts), [App Store (VPP) apps](https://fleetdm.com/guides/install-vpp-apps-on-macos-using-fleet), and custom packages to your hosts.
+
+This guide will walk you through steps to manually install custom packages on your hosts.
+
+Learn more about automatically installing software in a separate guide [here](https://fleetdm.com/guides/automatic-software-install-in-fleet).
 
 ## Prerequisites
 
@@ -10,9 +16,7 @@ Fleet [v4.50.0](https://github.com/fleetdm/fleet/releases/tag/fleet-v4.50.0) int
 
 * If you're self-hosting Fleet, you need an S3 bucket [configured](https://fleetdm.com/docs/configuration/fleet-server-configuration#s-3-software-installers-bucket) to store the packages. Increase any load balancer timeouts to at least 5 minutes for the [Add package](https://fleetdm.com/docs/rest-api/rest-api#add-package) and [Modify package](https://fleetdm.com/docs/rest-api/rest-api#modify-package) API endpoints.
 
-## Step-by-step instructions
-
-### Add a software package to a team
+## Add a custom package
 
 * **Navigate to the Software page**: Click on the "Software" tab in the main navigation menu.
 
@@ -32,25 +36,25 @@ Fleet [v4.50.0](https://github.com/fleetdm/fleet/releases/tag/fleet-v4.50.0) int
 
 > After the initial package upload, all options can be modified, including the self-service setting, pre-install query, scripts, and even the software package file. When replacing an installer package, the replacement package must be the same type and for the same software as the original package.
 
-#### Pre-install query
+### Pre-install query
 
 A pre-install query is a valid osquery SQL statement that will be evaluated on the host before installing the software. If provided, the installation will proceed only if the query returns any value.
 
-#### Install script
+### Install script
 
 After selecting a file, a default install script will be pre-filled. If the software package requires a custom installation process (for example, if [an EXE-based Windows installer requires custom handling](https://fleetdm.com/learn-more-about/exe-install-scripts)), this script can be edited. When the script is run, the `$INSTALLER_PATH` environment variable will be set by `fleetd` to where the installer is being run.
 
-#### Post-install script
+### Post-install script
 
 A post-install script will run after the installation, allowing you to, for example, configure the security agent right after installation. If this script returns a non-zero exit code, the installation will fail, and `fleetd` will attempt to uninstall the software.
 
-#### Uninstall script
+### Uninstall script
 
 An uninstall script will run when an admin chooses to uninstall the software from the host on the host details page, or if an install fails for hosts running `fleetd` 1.33.0 or later. Like the install script, a default uninstall script will be pre-filled after selecting a file. This script can be edited if the software package requires a custom uninstallation process.
 
 In addition to the `$INSTALLER_PATH` environment variable supported by install scripts, you can use `$PACKAGE_ID` in uninstall scripts as a placeholder for the package IDs (for .pkg files), package name (for Linux installers), product code (for MSIs), or software name (for EXE installers). The Fleet server will substitute `$PACKAGE_ID` on upload.
 
-### Install a software package on a host
+## Install the package
 
 After a software package is added to a team, it can be installed on hosts via the UI.
 
@@ -70,7 +74,7 @@ After a software package is added to a team, it can be installed on hosts via th
 
     * Navigate to the “Details” tab on the host details page and check the activity log.
 
-### Edit a software package
+## Edit the package
 
 * **Navigate to the Software page**: Click on the "Software" tab in the main navigation menu.
 
@@ -88,7 +92,7 @@ After a software package is added to a team, it can be installed on hosts via th
 
 > Editing the advanced options cancels all pending installations and uninstallations for that package. Installs and uninstalls currently running on a host will complete, but results won't appear in Fleet. The software's host counts will be reset.
 
-### Uninstall a software package on a host
+## Uninstall the package
 
 After a software package is installed on a host, it can be uninstalled on the host via the UI.
 
@@ -108,7 +112,7 @@ After a software package is installed on a host, it can be uninstalled on the ho
 
     * Navigate to the “Details” tab on the host details page and check the activity log.
 
-### Remove a software package from a team
+## Remove the package
 
 * **Navigate to the Software page**: Click on the "Software" tab in the main navigation menu.
 
@@ -126,29 +130,11 @@ After a software package is installed on a host, it can be uninstalled on the ho
 
 > Removing a software package from a team will cancel pending installs for hosts that are not in the middle of installing the software but will not uninstall the software from hosts where it is already installed.
 
-### Access software packages
-
-To access and manage software in Fleet:
-
-* **Navigate to the Software page**: Click on the "Software" tab in the main navigation menu.
-
-* **Select a team**: Click on the dropdown at the top left of the page.
-
-> Software packages are tied to a specific team. This allows you to, for example, test a newer release of an application within your IT team before rolling it out to the rest of your organization, or deploy the appropriate architecture-specific installer to both Intel and Apple Silicon Macs.
-
-* **Find your software**: using the filters on the top of the table, you can choose between:
-
-    * “Available for install” filters software that can be installed on your hosts.
-
-    * “Self-service” filters software that end users can install from Fleet Desktop.
-
-* **Select software package**: Click on a software package to view details and access additional actions for the software.
-
-### Manage software with the REST API
+## Manage packages with Fleet's REST API
 
 Fleet also provides a REST API for managing software programmatically. The API allows you to add, update, retrieve, list, and delete software. Detailed documentation on Fleet's [REST API is available]([https://fleetdm.com/docs/rest-api/rest-api#software](https://fleetdm.com/docs/rest-api/rest-api#software)), including endpoints for installing and uninstalling packages.
 
-### Manage software with GitOps
+## Manage packages with GitOps
 
 Software packages can be managed via `fleetctl` using [GitOps](https://fleetdm.com/docs/using-fleet/gitops).
 
@@ -156,13 +142,7 @@ Please refer to the documentation for [managing software with GitOps](https://fl
 
 > When managing software installers via GitOps, the Fleet server receiving GitOps requests (**not** the machine running fleetctl as part of the GitOps workflow) will download installers from the specified URLs directly.
 
-## Conclusion
-
-Managing software with Fleet is straightforward and ensures your hosts are equipped with the latest tools. This guide has outlined how to access, add, edit, and remove software packages from a team, install and uninstall from specific hosts, and use the REST API and `fleetctl` to manage software packages. By following these steps, you can effectively maintain software packages across your fleet.
-
-For more information on advanced setups and features, explore Fleet’s [documentation](https://fleetdm.com/docs/using-fleet) and additional [guides](https://fleetdm.com/guides).
-
-<meta name="articleTitle" value="Deploy software packages">
+<meta name="articleTitle" value="Deploy software">
 <meta name="authorFullName" value="Roberto Dip">
 <meta name="authorGitHubUsername" value="roperzh">
 <meta name="category" value="guides">

--- a/articles/install-fleet-maintained-apps-on-macos-hosts.md
+++ b/articles/install-fleet-maintained-apps-on-macos-hosts.md
@@ -1,32 +1,17 @@
-# Installing Fleet-maintained apps on macOS hosts
+# Fleet-maintained apps
 
-Fleet’s new premium feature lets you quickly install **Fleet-maintained apps** on macOS hosts—no need for manual uploads or extra configuration. This simplifies the process and adds another source of applications for your fleet.
+_Available in Fleet Premium_
+
+In Fleet, you can install Fleet-maintained apps on macOS hosts without the need for manual uploads or extra configuration. This simplifies the process and adds another source of applications for your fleet.
 
 Fleet starts with some of the most common and popular apps, enabling you to pull directly from this curated list and install them on your hosts without any additional configuration.
 
-## Prerequisites
+## Add a Fleet-maintained app
 
-* Fleet Premium is required for Fleet-maintained apps.
-
-> Software packages can be added to a specific team or the "No team" category. The "No team" category is the default assignment for hosts not part of any specific team.
-
-## Fleet-maintained app installation flow
-
-Let’s take a look at the Fleet-maintained app installation flow.
-
-### Navigating the add software pages
-
-Click **Add software** to access three different options for adding software:
-
-1. **Fleet-maintained**: A list of apps curated and maintained by Fleet.
-2. **App store (VPP)**: If you have a [VPP (Volume Purchase Program)](https://fleetdm.com/guides/install-vpp-apps-on-macos-using-fleet) configured, you can install apps from this connection.
-3. **Custom package**: You can upload your custom installers.
-
-### Adding a Fleet-maintained app
-
-1. From the **Add software** page, navigate to the **Fleet-maintained** tab.
-2. You’ll see a list of popular apps, such as Chrome, Visual Studio Code, and Notion. Click on a row in the table to select the desired app.
-3. You will be taken to the app details page after selecting the app. Here, you can set the app as a self-service app, allowing hosts to install it on demand. You can also expand the **Advanced options**, which will enable you to edit the following:
+1. Head to the **Software** page and click **Add software**.
+2. From the **Add software** page, navigate to the **Fleet-maintained** tab.
+3. You’ll see a list of popular apps, such as Chrome, Visual Studio Code, and Notion. Click on a row in the table to select the desired app.
+4. You will be taken to the app details page after selecting the app. Here, you can set the app as a self-service app, allowing hosts to install it on demand. You can also expand the **Advanced options**, which will enable you to edit the following:
    - Pre-install query
    - Installation script
    - Post-install script
@@ -34,7 +19,7 @@ Click **Add software** to access three different options for adding software:
 
    These scripts are auto-generated based on the app's Homebrew Cask formula, but you can modify them. Modifying these scripts allows you to tailor the app installation process to your organization's needs, such as automating additional setup tasks or custom configurations post-installation.
 
-### Installing the app
+## Install the app
 
 Once configured, click **Add Software**. This will download the installer specified in the Homebrew Cask and apply the installation scripts. The process may take a moment as it pulls the package.
 
@@ -44,7 +29,7 @@ The app can now be installed on a host in the **Host Details** page under the **
 
 You can track the installation process in the **Activities** section on the **Details** tab of this **Host Details** page.
 
-### Uninstalling the app
+## Uninstall the app
 
 To remove the app, select **Uninstall** from the same actions dropdown. Fleet will run the uninstall script you configured on the host, ensuring a clean app removal.
 
@@ -58,4 +43,4 @@ Fleet checks [Homebrew Casks](https://github.com/Homebrew/homebrew-cask) every h
 <meta name="authorFullName" value="Gabriel Hernandez">
 <meta name="authorGitHubUsername" value="ghernandez345">
 <meta name="publishedOn" value="2024-10-16">
-<meta name="articleTitle" value="Installing Fleet-maintained apps on macOS hosts.">
+<meta name="articleTitle" value="Fleet-maintained apps">

--- a/articles/install-vpp-apps-on-macos-using-fleet.md
+++ b/articles/install-vpp-apps-on-macos-using-fleet.md
@@ -1,26 +1,17 @@
-# Install App Store apps (VPP) on macOS, iOS, and iPadOS using Fleet
+# Install App Store apps (VPP)
 
 ![Install VPP apps on macOS using Fleet](../website/assets/images/articles/install-vpp-apps-on-macos-using-fleet-1600x900@2x.png)
 
+_Available in Fleet Premium_
 
-Fleet Premium supports the ability to add Apple App Store applications to your software library using the Volume Purchasing Program (VPP) and then install those apps on macOS, iOS, or iPadOS hosts. This guide will walk you through using this feature to add apps from your Apple Business Manager account to Fleet and install those apps on your hosts.
-
-The Volume Purchasing Program is an Apple initiative that allows organizations to purchase and distribute apps and books in bulk. This program is particularly beneficial for organizations that need to deploy multiple apps to many devices. Key benefits of VPP include:
-* **Bulk purchasing**: Purchase multiple licenses for an app in one transaction, often with volume discounts.
-* **Centralized management**: Manage and distribute purchased apps from a central location.
-* **Licensing flexibility**: Reassign app licenses as needed, ensuring efficient use of resources.
-* **Streamlined deployment**: Use Fleet to automate the installation and configuration of purchased apps on enrolled devices.
-* **Self-Service (macOS only)**: Allow users to assign licenses to their own devices as needed.
-
-By integrating VPP with Fleet, organizations can seamlessly add apps to their software library and deploy them across macOS, iOS, and iPadOS hosts, ensuring that all devices have the necessary applications installed efficiently and effectively.
+In Fleet, you can install Apple App Store apps using the [Volume Purchasing Program (VPP)](https://support.apple.com/guide/app-store/volume-purchasing-app-store-mac-firc1767ec54/mac) on your macOS, iOS, and iPadOS hosts. This guide will walk you through using this feature to add apps from your Apple Business Manager account to Fleet and install those apps on your hosts.
 
 ## Prerequisites
 * **MDM features**: to use the VPP integration, you must first enable MDM features in Fleet. See the [MDM setup guide](https://fleetdm.com/docs/using-fleet/mdm-setup) for instructions on enabling MDM features.
-* **Teams**: Apps can only be added to a specific Team. You can manage teams by selecting your avatar in the top navigation and then **Settings > Teams**. (Note: Apps can also be added to the 'No Team' team, which contains hosts not assigned to any other team.) You can control which team uses which VPP token by assigning teams to the VPP token. Each token may have multiple teams assigned to it, but each team may be assigned to only 1 token.
 
 > As of Fleet 4.55.0, there is a [known issue](https://github.com/fleetdm/fleet/issues/20686) that uninstalled or deleted VPP apps will continue to show a status of `installed`.
 
-## Accessing the VPP configuration
+## Add your VPP token
 
 1. **Navigate to the MDM integration settings page**: Click your avatar on the far right of the main navigation menu, and then **Settings > Integrations > "Mobile device management (MDM)"**
 
@@ -28,7 +19,7 @@ By integrating VPP with Fleet, organizations can seamlessly add apps to their so
 
 3. **Edit the team assignment for the new token**: Find the token in the table of VPP tokens. Click the "Actions" dropdown, and then click "Edit teams". Use the picker to select which team(s) this VPP token should be assigned to.
 
-## Purchasing apps
+## Purchase apps
 
 To add apps to Fleet, you must first purchase them through Apple Business Manager, even if they are free. This ensures that all apps are appropriately licensed and available for distribution via the Volume Purchasing Program (VPP). For detailed instructions on selecting and buying content, please refer to Apple’s documentation on [purchasing apps through Apple Business Manager](https://support.apple.com/guide/apple-business-manager/select-and-buy-content-axmc21817890/web).
 
@@ -54,7 +45,7 @@ To add apps to Fleet, you must first purchase them through Apple Business Manage
 
 4. **Remove the app**: Click on the "Actions" dropdown on the right side of the page. Click "Delete," then click "Delete" on the confirmation modal. Deleting an app will not uninstall the app from the hosts on which it was previously installed.
 
-## Installing apps on macOS, iOS, and iPadOS hosts
+## Install an app on your hosts
 
 1. **Add the host to the relevant team.**
 
@@ -68,7 +59,7 @@ To add apps to Fleet, you must first purchase them through Apple Business Manage
    the **Details** -> **Activity** -> **Upcoming** tab of this page. After the app is installed and
    the host details are refetched, the app will show up as **Installed** in the **Software** tab.
 
-## Installing apps on macOS using self-service
+## Install an app via self-service
 
 1. **Open Fleet from the host**: On the host that will be installing an application through self-service, click on the Fleet Desktop tray icon, then click **My Device**. This will open the browser to the device's page on Fleet.
 
@@ -76,7 +67,7 @@ To add apps to Fleet, you must first purchase them through Apple Business Manage
 
 3. **Locate the app and click install**: Scroll through the list of software to find the app you would like to install, then click the **Install** button underneath it.
 
-## Renewing an expired or expiring VPP token
+## Renew VPP token
 
 When one of your uploaded VPP tokens has expired or is within 30 days of expiring, you will see a warning
 banner at the top of page reminding you to renew your token. You can do this with the following steps:
@@ -85,7 +76,7 @@ banner at the top of page reminding you to renew your token. You can do this wit
 
 2. **Renew the token**: Find the VPP token that you want to renew in the table. Token status is indicated in the "Renew date" column: tokens less than 30 days from expiring will have a yellow indicator, and expired tokens will have a red indicator. Click the "Actions" dropdown for the token and then click "Renew". Follow the instructions in the modal to download a new token from Apple Business Manager and then upload the new token to Fleet.
 
-## Deleting a VPP token
+## Delete a VPP token
 
 To remove VPP tokens from Fleet:
 
@@ -93,19 +84,15 @@ To remove VPP tokens from Fleet:
 
 2. **Delete the token**: Find the VPP token that you want to delete in the table. Click the "Actions" dropdown for that token, and then click "Delete". Click "Delete" in the confirmation modal to finish deleting the token.
 
-## Managing apps with GitOps
+## Manage apps with GitOps
 
 To manage App Store apps using Fleet's best practice GitOps, check out the `software` key in the GitOps reference documentation [here](https://fleetdm.com/docs/using-fleet/gitops#software).
 
-## REST API
+## Manage apps with Fleet's REST API
 
 Fleet also provides a REST API for managing apps programmatically. You can add, install, and delete apps via this API and manage your organization’s VPP tokens. Learn more about Fleet's [REST API](https://fleetdm.com/docs/rest-api/rest-api).
 
-## Conclusion
-
-This feature extends Fleet's capabilities for managing macOS, iOS, and iPadOS hosts. Whether you manage your hosts' software via uploaded installers or via the App Store VPP integration, Fleet provides you with the tools you need to manage your hosts effectively.
-
-<meta name="articleTitle" value="Install VPP apps on macOS, iOS, and iPadOS using Fleet">
+<meta name="articleTitle" value="Install App Store (VPP) apps">
 <meta name="authorFullName" value="Jahziel Villasana-Espinoza">
 <meta name="authorGitHubUsername" value="jahzielv">
 <meta name="category" value="guides">

--- a/articles/install-vpp-apps-on-macos-using-fleet.md
+++ b/articles/install-vpp-apps-on-macos-using-fleet.md
@@ -19,11 +19,11 @@ In Fleet, you can install Apple App Store apps using the [Volume Purchasing Prog
 
 3. **Edit the team assignment for the new token**: Find the token in the table of VPP tokens. Click the "Actions" dropdown, and then click "Edit teams". Use the picker to select which team(s) this VPP token should be assigned to.
 
-## Purchase apps
+## Purchase an app
 
 To add apps to Fleet, you must first purchase them through Apple Business Manager, even if they are free. This ensures that all apps are appropriately licensed and available for distribution via the Volume Purchasing Program (VPP). For detailed instructions on selecting and buying content, please refer to Apple’s documentation on [purchasing apps through Apple Business Manager](https://support.apple.com/guide/apple-business-manager/select-and-buy-content-axmc21817890/web).
 
-## Add an app to Fleet
+## Add the app to Fleet
 
 1. **Navigate to the Software page**: Click on the "Software" tab in the main navigation menu.
 
@@ -35,7 +35,7 @@ To add apps to Fleet, you must first purchase them through Apple Business Manage
 
 5. **Add an app**: Select an app from the list. You may optionally check the "Self-Service" box at the bottom left of the modal if you wish for the software to be available for user-initiated installs. Finally, click the "Add software" button in the bottom right of the modal. The app should appear in the software list for the selected team.
 
-## Remove an app from Fleet
+## Remove the app from Fleet
 
 1. **Navigate to the Software page**: Click "Software" in the main navigation menu.
 
@@ -45,7 +45,7 @@ To add apps to Fleet, you must first purchase them through Apple Business Manage
 
 4. **Remove the app**: Click on the "Actions" dropdown on the right side of the page. Click "Delete," then click "Delete" on the confirmation modal. Deleting an app will not uninstall the app from the hosts on which it was previously installed.
 
-## Install an app on your hosts
+## Install the app
 
 1. **Add the host to the relevant team.**
 
@@ -67,7 +67,7 @@ To add apps to Fleet, you must first purchase them through Apple Business Manage
 
 3. **Locate the app and click install**: Scroll through the list of software to find the app you would like to install, then click the **Install** button underneath it.
 
-## Renew VPP token
+## Renew your VPP token
 
 When one of your uploaded VPP tokens has expired or is within 30 days of expiring, you will see a warning
 banner at the top of page reminding you to renew your token. You can do this with the following steps:
@@ -76,7 +76,7 @@ banner at the top of page reminding you to renew your token. You can do this wit
 
 2. **Renew the token**: Find the VPP token that you want to renew in the table. Token status is indicated in the "Renew date" column: tokens less than 30 days from expiring will have a yellow indicator, and expired tokens will have a red indicator. Click the "Actions" dropdown for the token and then click "Renew". Follow the instructions in the modal to download a new token from Apple Business Manager and then upload the new token to Fleet.
 
-## Delete a VPP token
+## Delete your VPP token
 
 To remove VPP tokens from Fleet:
 
@@ -84,13 +84,13 @@ To remove VPP tokens from Fleet:
 
 2. **Delete the token**: Find the VPP token that you want to delete in the table. Click the "Actions" dropdown for that token, and then click "Delete". Click "Delete" in the confirmation modal to finish deleting the token.
 
-## Manage apps with GitOps
-
-To manage App Store apps using Fleet's best practice GitOps, check out the `software` key in the GitOps reference documentation [here](https://fleetdm.com/docs/using-fleet/gitops#software).
-
 ## Manage apps with Fleet's REST API
 
 Fleet also provides a REST API for managing apps programmatically. You can add, install, and delete apps via this API and manage your organization’s VPP tokens. Learn more about Fleet's [REST API](https://fleetdm.com/docs/rest-api/rest-api).
+
+## Manage apps with GitOps
+
+To manage App Store apps using Fleet's best practice GitOps, check out the `software` key in the GitOps reference documentation [here](https://fleetdm.com/docs/using-fleet/gitops#software).
 
 <meta name="articleTitle" value="Install App Store (VPP) apps">
 <meta name="authorFullName" value="Jahziel Villasana-Espinoza">

--- a/handbook/company/pricing-features-table.yml
+++ b/handbook/company/pricing-features-table.yml
@@ -517,7 +517,8 @@
 #  ╠═╣╠═╝╠═╝║  ║║  ╠═╣ ║ ║║ ║║║║   ║║║╣ ╠═╝║  ║ ║╚╦╝║║║║╣ ║║║ ║ 
 #  ╩ ╩╩  ╩  ╩═╝╩╚═╝╩ ╩ ╩ ╩╚═╝╝╚╝  ═╩╝╚═╝╩  ╩═╝╚═╝ ╩ ╩ ╩╚═╝╝╚╝ ╩ 
 - industryName: Application deployment
-  description: Deploy applications and security agents on macOS, iOS/iPadOS, Linux, Windows, and Android (coming soon) devices. Additionally, install macOS and iOS/iPadOS apps from the App Store (coming soon).
+  description: Deploy applications on macOS, iOS/iPadOS, Linux, Windows, and Android (coming soon). Additionally, install macOS and iOS/iPadOS apps from the App Store.
+  documentationUrl: https://fleetdm.com/guides/deploy-software-packages
   tier: Premium
   jamfProHasFeature: appleOnly
   jamfProtectHasFeature: no


### PR DESCRIPTION
- Add learn more link to pricing page to point to deploy software guide [here](https://fleetdm.com/guides/deploy-software-packages)
- Update deploy software guide to link to the guides for other software types (Fleet-maintained and App Store apps) and automatic install guide
  - This way, when a user lands on deploy software, they can quickly find guides for all other guides
