### PR TITLE
Fleet UI: Fix host actions dropdown from cutting off last 2 options

### DIFF
--- a/frontend/components/ActionsDropdown/ActionsDropdown.tsx
+++ b/frontend/components/ActionsDropdown/ActionsDropdown.tsx
@@ -124,10 +124,6 @@ const ActionsDropdown = ({
   };
 
   const customStyles: StylesConfig<IDropdownOption, false> = {
-    container: (provided) => ({
-      ...provided,
-      width: "80px",
-    }),
     control: (provided, state) => ({
       ...provided,
       display: "flex",
@@ -182,11 +178,10 @@ const ActionsDropdown = ({
       boxShadow: "0 2px 6px rgba(0, 0, 0, 0.1)",
       borderRadius: "4px",
       zIndex: 6,
-      overflow: "hidden",
       border: 0,
       marginTop: 0,
-      minWidth: "158px",
-      maxHeight: "220px",
+      width: "auto",
+      minWidth: "100%",
       position: "absolute",
       left: getLeftMenuAlign(menuAlign),
       right: getRightMenuAlign(menuAlign),
@@ -195,6 +190,7 @@ const ActionsDropdown = ({
     menuList: (provided) => ({
       ...provided,
       padding: PADDING["pad-small"],
+      maxHeight: "initial", // Override react-select default height of 300px to avoid scrollbar on hostactionsdropdown
     }),
     valueContainer: (provided) => ({
       ...provided,
@@ -205,6 +201,7 @@ const ActionsDropdown = ({
       padding: "10px 8px",
       fontSize: "14px",
       backgroundColor: getOptionBackgroundColor(state),
+      whiteSpace: "nowrap",
       "&:hover": {
         backgroundColor: state.isDisabled
           ? "transparent"


### PR DESCRIPTION
## Issue
Cerra #23307 

## Description
- Cause of bug: maxHeight was cutting off the last two options
- Also fixed menu options width so long text options do not wrap to a second line

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->
- [x] Manual QA for all new/changed functionality

