### PR TITLE
For R.C. - Fleet UI: Fix host actions dropdown from cutting off last 2 options

### DIFF
--- a/frontend/components/ActionsDropdown/ActionsDropdown.tsx
+++ b/frontend/components/ActionsDropdown/ActionsDropdown.tsx
@@ -124,10 +124,6 @@ const ActionsDropdown = ({
   };
 
   const customStyles: StylesConfig<IDropdownOption, false> = {
-    container: (provided) => ({
-      ...provided,
-      width: "80px",
-    }),
     control: (provided, state) => ({
       ...provided,
       display: "flex",
@@ -182,11 +178,10 @@ const ActionsDropdown = ({
       boxShadow: "0 2px 6px rgba(0, 0, 0, 0.1)",
       borderRadius: "4px",
       zIndex: 6,
-      overflow: "hidden",
       border: 0,
       marginTop: 0,
-      minWidth: "158px",
-      maxHeight: "220px",
+      width: "auto",
+      minWidth: "100%",
       position: "absolute",
       left: getLeftMenuAlign(menuAlign),
       right: getRightMenuAlign(menuAlign),
@@ -195,6 +190,7 @@ const ActionsDropdown = ({
     menuList: (provided) => ({
       ...provided,
       padding: PADDING["pad-small"],
+      maxHeight: "initial", // Override react-select default height of 300px to avoid scrollbar on hostactionsdropdown
     }),
     valueContainer: (provided) => ({
       ...provided,
@@ -205,6 +201,7 @@ const ActionsDropdown = ({
       padding: "10px 8px",
       fontSize: "14px",
       backgroundColor: getOptionBackgroundColor(state),
+      whiteSpace: "nowrap",
       "&:hover": {
         backgroundColor: state.isDisabled
           ? "transparent"


### PR DESCRIPTION
 > [!NOTE]
> This PR is already merged in `main`, see https://github.com/fleetdm/fleet/pull/23335  This is against the release branch so it can be included in 4.59.0 

```

 1184  git checkout fleetdm/rc-minor-fleet-v4.59.0
 1185  git checkout -b 23307-host-actions-dropdown-bug-rc
 1186  git log main
 1187  git cherry-pick eaac61534e0a79ac4c5724c40a811194364d11bd
 1188  git push -u fleetdm 23307-host-actions-dropdown-bug-rc
```