### PR TITLE
Fleet UI: Do not truncate label/platform dropdown text

### DIFF
--- a/frontend/pages/hosts/ManageHostsPage/components/LabelFilterSelect/_styles.scss
+++ b/frontend/pages/hosts/ManageHostsPage/components/LabelFilterSelect/_styles.scss
@@ -68,7 +68,7 @@
   }
 
   .label-filter-select__placeholder {
-    width: 75px; // Truncates text for smaller filter width
+    width: 215px; // Any larger runs into indicator
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;


### PR DESCRIPTION
## Issue
Cerra #23337 

## Description
- Do not truncate "Filter by platform or label" placeholder text when it fits in the dropdown

## Screenrecording of fix on Chrome/Safari/FF
https://www.loom.com/share/796b1895f76d40b39d4a26be51b94fc9?sid=4012ab65-217e-4aba-9da5-77ea26e7d4c7

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Manual QA for all new/changed functionality

