### PR TITLE
Zay reviews articles

### DIFF
--- a/website/config/custom.js
+++ b/website/config/custom.js
@@ -132,7 +132,7 @@ module.exports.custom = {
     'ee/cis': 'sharon-fdm',//« Fleet Premium only: built-in queries  (built-in policies for CIS benchmarks)  -- FYI: On 2023-07-15, we changed this so that Sharon, Lucas, and Rachel are all maintainers, but where there is a single DRI who is automatically requested approval from.
 
     // 🫧 Articles and release notes
-    'articles': 'rachaelshaw',
+    'articles': 'zayhanlon',
     'CHANGELOG.md': 'lukeheath',
 
     // 🫧 Website (fleetdm.com)


### PR DESCRIPTION
- Auto-request Zay as reviewer on all articles. Zay will make sure that language is consistent, concise, and matches Fleet's brand
- Why? Guides are written for and consumed by users/customers. I think customer success gets the most questions about guides.

@noahtalerman: Opted for changing this instead of CODEOWNERS so that quick tweaks to articles can be approved and merged by other folks
