### PR TITLE
fix not showing install software when there was software titles

### DIFF
--- a/frontend/pages/ManageControlsPage/SetupExperience/cards/InstallSoftware/InstallSoftware.tsx
+++ b/frontend/pages/ManageControlsPage/SetupExperience/cards/InstallSoftware/InstallSoftware.tsx
@@ -65,7 +65,7 @@ const InstallSoftware = ({ currentTeamId }: IInstallSoftwareProps) => {
       return <DataError />;
     }
 
-    if (softwareTitles === null) {
+    if (softwareTitles || softwareTitles === null) {
       return (
         <div className={`${baseClass}__content`}>
           <AddInstallSoftware


### PR DESCRIPTION
relates to #23321

fix that shows the add install software UI when there is software to install.