### PR TITLE
Website: update number of hosts options in start questionnaire form responses

### DIFF
--- a/website/views/pages/start.ejs
+++ b/website/views/pages/start.ejs
@@ -140,10 +140,15 @@
                 <span purpose="custom-radio"><span purpose="custom-radio-selected"></span></span>
                 100 to 300
               </label>
-              <label purpose="form-option" class="form-control" :class="[formData['how-many-hosts'].numberOfHosts === '300-10000' ? 'selected' : '']">
-                <input type="radio" v-model.trim="formData['how-many-hosts'].numberOfHosts" value="300-10000" @input="clickClearOneFormError('numberOfHosts')">
+              <label purpose="form-option" class="form-control" :class="[formData['how-many-hosts'].numberOfHosts === '300-700' ? 'selected' : '']">
+                <input type="radio" v-model.trim="formData['how-many-hosts'].numberOfHosts" value="300-700" @input="clickClearOneFormError('numberOfHosts')">
                 <span purpose="custom-radio"><span purpose="custom-radio-selected"></span></span>
-                300 to 10,000
+                300 to 700
+              </label>
+              <label purpose="form-option" class="form-control" :class="[formData['how-many-hosts'].numberOfHosts === '700-10000' ? 'selected' : '']">
+                <input type="radio" v-model.trim="formData['how-many-hosts'].numberOfHosts" value="700-10000" @input="clickClearOneFormError('numberOfHosts')">
+                <span purpose="custom-radio"><span purpose="custom-radio-selected"></span></span>
+                700 to 10,000
               </label>
 <!--               <label purpose="form-option" class="form-control" :class="[formData['how-many-hosts'].numberOfHosts === '100-700' ? 'selected' : '']">
                 <input type="radio" v-model.trim="formData['how-many-hosts'].numberOfHosts" value="100-700" @input="clickClearOneFormError('numberOfHosts')">


### PR DESCRIPTION
Changes:
- Updated the options in the "How many hosts?" question of the /start questionnaire. (300-10000 » 300-700 & 700-10000)