### PR TITLE
docs-tutorials-and-guides-update

### DIFF
--- a/articles/how-to-install-osquery-and-enroll-linux-devices-into-fleet.md
+++ b/articles/how-to-install-osquery-and-enroll-linux-devices-into-fleet.md
@@ -1,5 +1,7 @@
 # How to install osquery and enroll Linux devices into Fleet
 
+> **Archived** While still usable, this guide has not been updated recently. See the [Enroll hosts](http://fleetdm.com/guides/enroll-hosts) guide.
+
 Here, we will cover enrolling Linux devices to an existing Fleet server. If you don’t have a Fleet
 server configured already, check out [Deploying Fleet on Render](https://fleetdm.com/deploy/deploying-fleet-on-render). If you’re still getting to know Fleet and would like to skip the server setup process and try Fleet, you can [run Fleet in a preview environment](https://fleetdm.com/try-fleet/register).
 

--- a/articles/how-to-install-osquery-and-enroll-macos-devices-into-fleet.md
+++ b/articles/how-to-install-osquery-and-enroll-macos-devices-into-fleet.md
@@ -1,5 +1,7 @@
 # How to install osquery and enroll macOS devices into Fleet
 
+> **Archived** While still usable, this guide has not been updated recently. See the [Enroll hosts](http://fleetdm.com/guides/enroll-hosts) guide.
+
 Here, we will cover enrolling macOS devices to an existing Fleet server. If you don’t have a Fleet
 server configured already, check out [Deploying Fleet on Render](https://fleetdm.com/deploy/deploying-fleet-on-render). If you’re still getting to know Fleet and would like to skip the server setup process and try Fleet, you can [run Fleet in a preview environment](https://fleetdm.com/try-fleet/register).
 

--- a/articles/how-to-install-osquery-and-enroll-windows-devices-into-fleet.md
+++ b/articles/how-to-install-osquery-and-enroll-windows-devices-into-fleet.md
@@ -1,5 +1,7 @@
 # How to install osquery and enroll Windows devices into Fleet
 
+> **Archived** While still usable, this guide has not been updated recently. See the [Enroll hosts](http://fleetdm.com/guides/enroll-hosts) guide.
+
 Here, we will cover enrolling Windows devices to an existing Fleet server. If you don’t have a Fleet
 server configured already, check out [Deploying Fleet on Render](https://fleetdm.com/deploy/deploying-fleet-on-render). If you’re still getting to know Fleet and would like to skip the server setup process and try Fleet, you can [run Fleet in a preview environment](https://fleetdm.com/try-fleet/register).
 

--- a/articles/managing-labels-in-fleet.md
+++ b/articles/managing-labels-in-fleet.md
@@ -1,4 +1,4 @@
-# Managing labels in Fleet
+# Labels
 
 ![Managing labels in Fleet](../website/assets/images/articles/managing-labels-in-fleet-1600x900@2x.png)
 

--- a/articles/queries.md
+++ b/articles/queries.md
@@ -69,6 +69,11 @@ By default, queries that run on a schedule will only target platforms compatible
 
 > Note: When viewing a specific [team](https://fleetdm.com/docs/using-fleet/segment-hosts) in Fleet Premium, only queries that belong to the selected team will be listed. When configuring query automations for all hosts, only global queries will be listed.
 
+### Further reading
+
+- [Import and export queries in Fleet](https://fleetdm.com/guides/import-and-export-queries-in-fleet)
+- [Osquery: Consider joining against the users table](https://fleetdm.com/guides/osquery-consider-joining-against-the-users-table) 
+
 
 <meta name="category" value="guides">
 <meta name="authorGitHubUsername" value="noahtalerman">

--- a/articles/what-are-fleet-policies.md
+++ b/articles/what-are-fleet-policies.md
@@ -1,4 +1,4 @@
-# What are Fleet policies?
+# Policies
 
 Fleet policies are a great way to quickly monitor your devices by asking yes or no questions about them. Policies are also an easy way to make sure you maintain data integrity, confidentiality, and security. Whether you’re checking in on a small set of devices, or a fleet of thousands, policies give quick insight into their status and IT compliance. For example, suppose one of your defined controls makes sure that all of your macOS devices have Gatekeeper enabled. In that case, the Security team can create a policy to quickly and easily return a yes or no response from all of your enrolled devices.
 
@@ -54,6 +54,11 @@ These principles helped us create policies for our own devices to track:
 - Is system Integrity Protection enabled (macOS)
 
 Policies and automation help your security and IT teams feel confident that devices are passing your organization’s standards. Fleet is building an open, transparent, and simple future for device management and is the [most widely deployed osquery fleet manager.](https://fleetdm.com/) 
+
+## Further reading
+
+- [Understanding the intricacies of Fleet policies](https://fleetdm.com/guides/understanding-the-intricacies-of-fleet-policies)
+
 
 <meta name="category" value="security">
 <meta name="authorGitHubUsername" value="Drew-P-drawers">

--- a/docs/Get started/tutorials-and-guides.md
+++ b/docs/Get started/tutorials-and-guides.md
@@ -2,26 +2,34 @@
 
 A collection of guides to help you with Fleet.
 
-- [How to install osquery and enroll macOS devices into Fleet](https://fleetdm.com/guides/how-to-install-osquery-and-enroll-macos-devices-into-fleet)  
-- [How to install osquery and enroll Linux devices into Fleet](https://fleetdm.com/guides/how-to-install-osquery-and-enroll-linux-devices-into-fleet)  
-- [How to install osquery and enroll Windows devices into Fleet](https://fleetdm.com/guides/how-to-install-osquery-and-enroll-windows-devices-into-fleet)  
-- [Sysadmin diaries: restoring fleetd](https://fleetdm.com/guides/sysadmin-diaries-restoring-fleetd)  
-- [How to uninstall Fleet's agent (fleetd)](https://fleetdm.com/guides/how-to-uninstall-fleetd)  
-- [Sysadmin diaries: device enrollment](https://fleetdm.com/guides/sysadmin-diaries-device-enrollment)  
-- [Sysadmin diaries: passcode profiles](https://fleetdm.com/guides/sysadmin-diaries-passcode-profiles)  
-- [Sysadmin diaries: lost device](https://fleetdm.com/guides/sysadmin-diaries-lost-device)  
-- [Windows MDM setup](https://fleetdm.com/guides/windows-mdm-setup)  
-- [Using GitHub Actions to apply configuration profiles with Fleet](https://fleetdm.com/guides/using-github-actions-to-apply-configuration-profiles-with-fleet)  
-- [Managing labels in Fleet](https://fleetdm.com/guides/managing-labels-in-fleet)  
-- [What are Fleet policies?](https://fleetdm.com/securing/what-are-fleet-policies)  
-- [Understanding the intricacies of Fleet policies](https://fleetdm.com/guides/understanding-the-intricacies-of-fleet-policies)  
-- [Sysadmin diaries: exporting policies](https://fleetdm.com/guides/sysadmin-diaries-exporting-policies)  
-- [Locate device assets in the event of an emergency](https://fleetdm.com/guides/locate-assets-with-osquery)  
-- [Osquery: Consider joining against the users table](https://fleetdm.com/guides/osquery-consider-joining-against-the-users-table)  
-- [Using Fleet and Okta Workflows to generate a daily OS report](https://fleetdm.com/guides/using-fleet-and-okta-workflows-to-generate-a-daily-os-report)  
-- [How to configure logging destinations](https://fleetdm.com/guides/how-to-configure-logging-destinations)  
-- [Import and export queries in Fleet](https://fleetdm.com/guides/import-and-export-queries-in-fleet)  
+<!--Deploying Fleet-->
+- [Deploy Fleet](https://fleetdm.com/docs/deploy)
+- [MDM migration](https://fleetdm.com/guides/mdm-migration)
+- [macOS MDM setup](https://fleetdm.com/guides/macos-mdm-setup)
+- [Windows MDM setup](https://fleetdm.com/guides/windows-mdm-setup)
+<!--Highest level organizational unit-->
+- [Teams](https://fleetdm.com/guides/teams)
+- [Enroll hosts](https://fleetdm.com/guides/enroll-hosts)
+- [Enroll BYOD iOS/iPadOS hosts](https://fleetdm.com/guides/enroll-byod-ios-ipados-hosts)
+- [Queries](https://fleetdm.com/guides/queries)
+- [Labels](https://fleetdm.com/guides/managing-labels-in-fleet)
+- [Policies](https://fleetdm.com/securing/what-are-fleet-policies)
+<!--Controls-->
+- [Enforce OS updates](https://fleetdm.com/guides/enforce-os-updates)
+- [Enforce disk encryption](https://fleetdm.com/guides/enforce-disk-encryption)
 - [Certificates in fleetd](https://fleetdm.com/guides/certificates-in-fleetd)
+- [Automatically run scripts](https://fleetdm.com/guides/policy-automation-run-script)
+<!--Installing software-->
+- [Fleet-maintained apps](https://fleetdm.com/guides/install-fleet-maintained-apps-on-macos-hosts)
+- [Deploy software packages](https://fleetdm.com/guides/deploy-software-packages)
+- [Automatic installation of software](https://fleetdm.com/guides/automatic-software-install-in-fleet)
+- [Install App Store (VPP) apps](https://fleetdm.com/guides/install-vpp-apps-on-macos-using-fleet)
+<!--Admin-->
+- [Fleetctl](https://fleetdm.com/guides/fleetctl)
+- [Fleetd updates](https://fleetdm.com/guides/fleetd-updates)
+- [How to uninstall Fleet's agent (fleetd)](https://fleetdm.com/guides/how-to-uninstall-fleetd)
+- [How to configure logging destinations](https://fleetdm.com/guides/how-to-configure-logging-destinations)  
+
 
 <a style="text-decoration: none;" href="https://fleetdm.com/guides"><animated-arrow-button>See all guides</animated-arrow-button></a>
 


### PR DESCRIPTION
Closes https://github.com/fleetdm/fleet/issues/22951

- Updated the guides listed on https://fleetdm.com/docs/get-started/tutorials-and-guides to only include the most essential onboarding guides. Guides are listed in the following order:
    - Deploying Fleet
    - Organizational units
    - Controls
    - Installing software
    - Admin
- Added archive notices to the three "How to install osquery..." articles
- Added "Further reading" links to the bottom of the Queries guide and Policies guide to point to related advanced topics
- Renamed "Managing labels in Fleet" to "Labels" for parallelism with our other guides (left the URL as is, no redirect necessary)
- Renamed "What are Fleet policies" to "Policies" for parallelism with our other guides (left the URL as is, no redirect necessary)