### PR TITLE
Website: increase ad attribution period (30m » 7 days)

### DIFF
--- a/website/api/controllers/save-questionnaire-progress.js
+++ b/website/api/controllers/save-questionnaire-progress.js
@@ -234,9 +234,9 @@ module.exports = {
     if(psychologicalStage !== userRecord.psychologicalStage) {
       let psychologicalStageChangeReason = 'Website - Organic start flow'; // Default psystageChangeReason to "Website - Organic start flow"
       if(this.req.session.adAttributionString && this.req.session.visitedSiteFromAdAt) {
-        let thirtyMinutesAgoAt = Date.now() - (1000 * 60 * 30);
+        let sevenDaysAgoAt = Date.now() - (1000 * 60 * 60 * 24 * 7);
         // If this user visited the website from an ad, set the psychologicalStageChangeReason to be the adCampaignId stored in their session.
-        if(this.req.session.visitedSiteFromAdAt > thirtyMinutesAgoAt) {
+        if(this.req.session.visitedSiteFromAdAt > sevenDaysAgoAt) {
           psychologicalStageChangeReason = this.req.session.adAttributionString;
         }
       }


### PR DESCRIPTION
Related to: https://github.com/fleetdm/confidential/issues/8234

Changes:
- Increased the period of time that psychological stage change reason is set by ads in save-questionnaire-progress. (30 minutes » 7 days)