### PR TITLE
Cherry-pick: Retime Nudge to 20:00 UTC

### DIFF
--- a/changes/21998-nudge-retime
+++ b/changes/21998-nudge-retime
@@ -1,0 +1,1 @@
+* Switched Nudge deadline time for OS upgrades on macOS pre-14 hosts from 04:00 UTC to 20:00 UTC

--- a/server/fleet/nudge.go
+++ b/server/fleet/nudge.go
@@ -50,15 +50,14 @@ func NewNudgeConfig(macOSUpdates AppleOSUpdateSettings) (*NudgeConfig, error) {
 		return nil, err
 	}
 
-	// Per the spec, the exact deadline time is arbitrarily chosen to be
-	// 04:00:00 (UTC-8) until we allow users to customize it.
-	//
-	// See https://github.com/fleetdm/fleet/issues/9013 for more details.
-	localizedDeadline := time.Date(deadline.Year(), deadline.Month(), deadline.Day(), 4, 0, 0, 0, time.UTC)
+	// For macOS 14+ we use DDM, which sets deadlines relative to local time. Nudge doesn't allow local-time deadlines
+	// when providing JSON config, so for compatibility with existing fleetd versions we're using a somewhat sane
+	// UTC value here (noon Pacific Standard Time, no revision for DST). See https://github.com/fleetdm/fleet/pull/23320
+	deadlineWithTime := time.Date(deadline.Year(), deadline.Month(), deadline.Day(), 20, 0, 0, 0, time.UTC)
 
 	return &NudgeConfig{
 		OSVersionRequirements: []nudgeOSVersionRequirements{{
-			RequiredInstallationDate: localizedDeadline,
+			RequiredInstallationDate: deadlineWithTime,
 			RequiredMinimumOSVersion: macOSUpdates.MinimumVersion.Value,
 			AboutUpdateURLs: []nudgeAboutUpdateURLs{{
 				Language:       "en",

--- a/server/service/integration_mdm_test.go
+++ b/server/service/integration_mdm_test.go
@@ -6093,7 +6093,7 @@ func (s *integrationMDMTestSuite) TestOrbitConfigNudgeSettings() {
 	wantCfg, err := fleet.NewNudgeConfig(fleet.AppleOSUpdateSettings{Deadline: optjson.SetString("2022-01-04"), MinimumVersion: optjson.SetString("12.1.3")})
 	require.NoError(t, err)
 	require.Equal(t, wantCfg, resp.NudgeConfig)
-	require.Equal(t, wantCfg.OSVersionRequirements[0].RequiredInstallationDate.String(), "2022-01-04 04:00:00 +0000 UTC")
+	require.Equal(t, wantCfg.OSVersionRequirements[0].RequiredInstallationDate.String(), "2022-01-04 20:00:00 +0000 UTC")
 
 	// create a team with an empty macos_updates config
 	team, err := s.ds.NewTeam(context.Background(), &fleet.Team{
@@ -6112,7 +6112,7 @@ func (s *integrationMDMTestSuite) TestOrbitConfigNudgeSettings() {
 	resp = orbitGetConfigResponse{}
 	s.DoJSON("POST", "/api/fleet/orbit/config", json.RawMessage(fmt.Sprintf(`{"orbit_node_key": %q}`, *h.OrbitNodeKey)), http.StatusOK, &resp)
 	require.Empty(t, resp.NudgeConfig)
-	require.Equal(t, wantCfg.OSVersionRequirements[0].RequiredInstallationDate.String(), "2022-01-04 04:00:00 +0000 UTC")
+	require.Equal(t, wantCfg.OSVersionRequirements[0].RequiredInstallationDate.String(), "2022-01-04 20:00:00 +0000 UTC")
 
 	// modify the team config, add macos_updates config
 	var tmResp teamResponse
@@ -6131,7 +6131,7 @@ func (s *integrationMDMTestSuite) TestOrbitConfigNudgeSettings() {
 	wantCfg, err = fleet.NewNudgeConfig(fleet.AppleOSUpdateSettings{Deadline: optjson.SetString("1992-01-01"), MinimumVersion: optjson.SetString("13.1.1")})
 	require.NoError(t, err)
 	require.Equal(t, wantCfg, resp.NudgeConfig)
-	require.Equal(t, wantCfg.OSVersionRequirements[0].RequiredInstallationDate.String(), "1992-01-01 04:00:00 +0000 UTC")
+	require.Equal(t, wantCfg.OSVersionRequirements[0].RequiredInstallationDate.String(), "1992-01-01 20:00:00 +0000 UTC")
 
 	// create a new host, still receives the global config
 	h2 := createOrbitEnrolledHost(t, "darwin", "h2", s.ds)
@@ -6153,7 +6153,7 @@ func (s *integrationMDMTestSuite) TestOrbitConfigNudgeSettings() {
 	wantCfg, err = fleet.NewNudgeConfig(fleet.AppleOSUpdateSettings{Deadline: optjson.SetString("2022-01-04"), MinimumVersion: optjson.SetString("12.1.3")})
 	require.NoError(t, err)
 	require.Equal(t, wantCfg, resp.NudgeConfig)
-	require.Equal(t, wantCfg.OSVersionRequirements[0].RequiredInstallationDate.String(), "2022-01-04 04:00:00 +0000 UTC")
+	require.Equal(t, wantCfg.OSVersionRequirements[0].RequiredInstallationDate.String(), "2022-01-04 20:00:00 +0000 UTC")
 
 	// host on macos > 14, shouldn't be receiving nudge configs
 	h3 := createOrbitEnrolledHost(t, "darwin", "h3", s.ds)


### PR DESCRIPTION
- @noahtalerman: 12p (noon) PST for Nudge and 12p local time for DDM

See #23320 and #21998

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
See [Changes
files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/Committing-Changes.md#changes-files) for more information.
- [x] Added/updated tests
- [ ] Manual QA for all new/changed functionality (@PezHub to QA)

Test plan:

1. Set OS update deadline for tomorrow
2. Enroll a macOS 13 host
3. Tonight at 9:15pm Pacific there shouldn't be a nudge (there would be with the old behavior)
4. Tomorrow at 9:15am Pacific there shouldn't be a nudge (there would be with the old behavior)
5. Tomorrow at 12:15pm Pacific there _should_ be a nudge (well, 15 minutes earlier-ish)