### PR TITLE
Bugfix: unblock ADE enrollments for hosts on an old fleetd version

### DIFF
--- a/changes/23366-fix-release-device-for-old-fleetd
+++ b/changes/23366-fix-release-device-for-old-fleetd
@@ -1,0 +1,1 @@
+* Fixed the ADE enrollment release device processing for hosts running an old fleetd version.

--- a/server/datastore/mysql/apple_mdm_test.go
+++ b/server/datastore/mysql/apple_mdm_test.go
@@ -4624,6 +4624,13 @@ func testMDMAppleResetEnrollment(t *testing.T, ds *Datastore) {
 		Token:  uuid.New().String(),
 	}, nil)
 	require.NoError(t, err)
+
+	// host has no boostrap package command yet
+	cmd, err := ds.GetHostBootstrapPackageCommand(ctx, host.UUID)
+	require.Error(t, err)
+	nfe := &notFoundError{}
+	require.ErrorAs(t, err, &nfe)
+
 	err = ds.RecordHostBootstrapPackage(ctx, "command-uuid", host.UUID)
 	require.NoError(t, err)
 	// add a record of the host DEP assignment
@@ -4633,6 +4640,9 @@ func testMDMAppleResetEnrollment(t *testing.T, ds *Datastore) {
 		ON DUPLICATE KEY UPDATE added_at = CURRENT_TIMESTAMP, deleted_at = NULL
 	`, host.ID)
 	require.NoError(t, err)
+	cmd, err = ds.GetHostBootstrapPackageCommand(ctx, host.UUID)
+	require.NoError(t, err)
+	require.Equal(t, "command-uuid", cmd)
 	err = ds.SetOrUpdateMDMData(context.Background(), host.ID, false, true, "foo.mdm.example.com", true, "", "")
 	require.NoError(t, err)
 

--- a/server/datastore/mysql/apple_mdm_test.go
+++ b/server/datastore/mysql/apple_mdm_test.go
@@ -4626,7 +4626,7 @@ func testMDMAppleResetEnrollment(t *testing.T, ds *Datastore) {
 	require.NoError(t, err)
 
 	// host has no boostrap package command yet
-	cmd, err := ds.GetHostBootstrapPackageCommand(ctx, host.UUID)
+	_, err = ds.GetHostBootstrapPackageCommand(ctx, host.UUID)
 	require.Error(t, err)
 	nfe := &notFoundError{}
 	require.ErrorAs(t, err, &nfe)
@@ -4640,7 +4640,7 @@ func testMDMAppleResetEnrollment(t *testing.T, ds *Datastore) {
 		ON DUPLICATE KEY UPDATE added_at = CURRENT_TIMESTAMP, deleted_at = NULL
 	`, host.ID)
 	require.NoError(t, err)
-	cmd, err = ds.GetHostBootstrapPackageCommand(ctx, host.UUID)
+	cmd, err := ds.GetHostBootstrapPackageCommand(ctx, host.UUID)
 	require.NoError(t, err)
 	require.Equal(t, "command-uuid", cmd)
 	err = ds.SetOrUpdateMDMData(context.Background(), host.ID, false, true, "foo.mdm.example.com", true, "", "")

--- a/server/fleet/capabilities.go
+++ b/server/fleet/capabilities.go
@@ -76,7 +76,7 @@ const (
 	CapabilityTokenRotation  Capability = "token_rotation"
 	CapabilityErrorReporting Capability = "error_reporting"
 	// CapabilityEndUserEmail denotes the ability of the server to support
-	// receiving the end-user email from orbit.23366
+	// receiving the end-user email from orbit.
 	CapabilityEndUserEmail Capability = "end_user_email"
 	// CapabilityEscrowBuddy allows to use Escrow Buddy to rotate FileVault keys
 	CapabilityEscrowBuddy Capability = "escrow_buddy"

--- a/server/fleet/capabilities.go
+++ b/server/fleet/capabilities.go
@@ -76,18 +76,24 @@ const (
 	CapabilityTokenRotation  Capability = "token_rotation"
 	CapabilityErrorReporting Capability = "error_reporting"
 	// CapabilityEndUserEmail denotes the ability of the server to support
-	// receiving the end-user email from orbit.
+	// receiving the end-user email from orbit.23366
 	CapabilityEndUserEmail Capability = "end_user_email"
 	// CapabilityEscrowBuddy allows to use Escrow Buddy to rotate FileVault keys
 	CapabilityEscrowBuddy Capability = "escrow_buddy"
+	// CapabilitySetupExperience denotes the ability of the server to support
+	// installing software and running a script during macOS ADE enrollment, and
+	// the ability of the client to show the corresponding UI to support that
+	// flow.
+	CapabilitySetupExperience Capability = "setup_experience"
 )
 
 func GetServerOrbitCapabilities() CapabilityMap {
 	return CapabilityMap{
-		CapabilityOrbitEndpoints: {},
-		CapabilityTokenRotation:  {},
-		CapabilityEndUserEmail:   {},
-		CapabilityEscrowBuddy:    {},
+		CapabilityOrbitEndpoints:  {},
+		CapabilityTokenRotation:   {},
+		CapabilityEndUserEmail:    {},
+		CapabilityEscrowBuddy:     {},
+		CapabilitySetupExperience: {},
 	}
 }
 
@@ -101,7 +107,8 @@ func GetServerDeviceCapabilities() CapabilityMap {
 
 func GetOrbitClientCapabilities() CapabilityMap {
 	return CapabilityMap{
-		CapabilityEscrowBuddy: {},
+		CapabilityEscrowBuddy:     {},
+		CapabilitySetupExperience: {},
 	}
 }
 

--- a/server/fleet/datastore.go
+++ b/server/fleet/datastore.go
@@ -1232,6 +1232,9 @@ type Datastore interface {
 	// RecordHostBootstrapPackage records a command used to install a
 	// bootstrap package in a host.
 	RecordHostBootstrapPackage(ctx context.Context, commandUUID string, hostUUID string) error
+	// GetHostBootstrapPackageCommand returns the MDM command uuid used to
+	// install a bootstrap package in a host.
+	GetHostBootstrapPackageCommand(ctx context.Context, hostUUID string) (string, error)
 
 	// CleanupUnusedBootstrapPackages will remove bootstrap packages that have no
 	// references to them from the mdm_apple_bootstrap_packages table.

--- a/server/mock/datastore_mock.go
+++ b/server/mock/datastore_mock.go
@@ -823,6 +823,8 @@ type GetMDMAppleBootstrapPackageSummaryFunc func(ctx context.Context, teamID uin
 
 type RecordHostBootstrapPackageFunc func(ctx context.Context, commandUUID string, hostUUID string) error
 
+type GetHostBootstrapPackageCommandFunc func(ctx context.Context, hostUUID string) (string, error)
+
 type CleanupUnusedBootstrapPackagesFunc func(ctx context.Context, pkgStore fleet.MDMBootstrapPackageStore, removeCreatedBefore time.Time) error
 
 type GetHostMDMMacOSSetupFunc func(ctx context.Context, hostID uint) (*fleet.HostMDMMacOSSetup, error)
@@ -2342,6 +2344,9 @@ type DataStore struct {
 
 	RecordHostBootstrapPackageFunc        RecordHostBootstrapPackageFunc
 	RecordHostBootstrapPackageFuncInvoked bool
+
+	GetHostBootstrapPackageCommandFunc        GetHostBootstrapPackageCommandFunc
+	GetHostBootstrapPackageCommandFuncInvoked bool
 
 	CleanupUnusedBootstrapPackagesFunc        CleanupUnusedBootstrapPackagesFunc
 	CleanupUnusedBootstrapPackagesFuncInvoked bool
@@ -5625,6 +5630,13 @@ func (s *DataStore) RecordHostBootstrapPackage(ctx context.Context, commandUUID 
 	s.RecordHostBootstrapPackageFuncInvoked = true
 	s.mu.Unlock()
 	return s.RecordHostBootstrapPackageFunc(ctx, commandUUID, hostUUID)
+}
+
+func (s *DataStore) GetHostBootstrapPackageCommand(ctx context.Context, hostUUID string) (string, error) {
+	s.mu.Lock()
+	s.GetHostBootstrapPackageCommandFuncInvoked = true
+	s.mu.Unlock()
+	return s.GetHostBootstrapPackageCommandFunc(ctx, hostUUID)
 }
 
 func (s *DataStore) CleanupUnusedBootstrapPackages(ctx context.Context, pkgStore fleet.MDMBootstrapPackageStore, removeCreatedBefore time.Time) error {

--- a/server/service/integration_mdm_dep_test.go
+++ b/server/service/integration_mdm_dep_test.go
@@ -425,8 +425,8 @@ func (s *integrationMDMTestSuite) runDEPEnrollReleaseDeviceTest(t *testing.T, de
 
 		// make the pending job ready to run immediately and run the job
 		mysql.ExecAdhocSQL(t, s.ds, func(q sqlx.ExtContext) error {
-			q.ExecContext(ctx, `UPDATE jobs SET not_before = ? WHERE id = ?`, time.Now().Add(-1*time.Minute).UTC(), pending[0].ID)
-			return nil
+			_, err := q.ExecContext(ctx, `UPDATE jobs SET not_before = ? WHERE id = ?`, time.Now().Add(-1*time.Minute).UTC(), pending[0].ID)
+			return err
 		})
 
 		s.runWorker()

--- a/server/service/integration_mdm_dep_test.go
+++ b/server/service/integration_mdm_dep_test.go
@@ -110,9 +110,17 @@ func (s *integrationMDMTestSuite) TestDEPEnrollReleaseDeviceGlobal() {
 	s.Do("PATCH", "/api/latest/fleet/config", json.RawMessage([]byte(`{"mdm":{"macos_settings":{"enable_disk_encryption":true}}}`)), http.StatusOK)
 
 	s.enableABM("fleet_ade_test")
+
+	// test manual and automatic release with the new setup experience flow
 	for _, enableReleaseManually := range []bool{false, true} {
 		t.Run(fmt.Sprintf("enableReleaseManually=%t", enableReleaseManually), func(t *testing.T) {
-			s.runDEPEnrollReleaseDeviceTest(t, globalDevice, enableReleaseManually, nil, "I1")
+			s.runDEPEnrollReleaseDeviceTest(t, globalDevice, enableReleaseManually, nil, "I1", false)
+		})
+	}
+	// test manual and automatic release with the old worker flow
+	for _, enableReleaseManually := range []bool{false, true} {
+		t.Run(fmt.Sprintf("enableReleaseManually=%t", enableReleaseManually), func(t *testing.T) {
+			s.runDEPEnrollReleaseDeviceTest(t, globalDevice, enableReleaseManually, nil, "I1", true)
 		})
 	}
 }
@@ -199,14 +207,21 @@ func (s *integrationMDMTestSuite) TestDEPEnrollReleaseDeviceTeam() {
 	// enable FileVault
 	s.Do("PATCH", "/api/latest/fleet/mdm/apple/settings", json.RawMessage([]byte(fmt.Sprintf(`{"enable_disk_encryption":true,"team_id":%d}`, tm.ID))), http.StatusNoContent)
 
+	// test manual and automatic release with the new setup experience flow
 	for _, enableReleaseManually := range []bool{false, true} {
 		t.Run(fmt.Sprintf("enableReleaseManually=%t", enableReleaseManually), func(t *testing.T) {
-			s.runDEPEnrollReleaseDeviceTest(t, teamDevice, enableReleaseManually, &tm.ID, "I2")
+			s.runDEPEnrollReleaseDeviceTest(t, teamDevice, enableReleaseManually, &tm.ID, "I2", false)
+		})
+	}
+	// test manual and automatic release with the old worker flow
+	for _, enableReleaseManually := range []bool{false, true} {
+		t.Run(fmt.Sprintf("enableReleaseManually=%t", enableReleaseManually), func(t *testing.T) {
+			s.runDEPEnrollReleaseDeviceTest(t, teamDevice, enableReleaseManually, &tm.ID, "I2", true)
 		})
 	}
 }
 
-func (s *integrationMDMTestSuite) runDEPEnrollReleaseDeviceTest(t *testing.T, device godep.Device, enableReleaseManually bool, teamID *uint, customProfileIdent string) {
+func (s *integrationMDMTestSuite) runDEPEnrollReleaseDeviceTest(t *testing.T, device godep.Device, enableReleaseManually bool, teamID *uint, customProfileIdent string, useOldFleetdFlow bool) {
 	ctx := context.Background()
 
 	// set the enable release device manually option
@@ -288,7 +303,7 @@ func (s *integrationMDMTestSuite) runDEPEnrollReleaseDeviceTest(t *testing.T, de
 
 	// run the worker to process the DEP enroll request
 	s.runWorker()
-	// run the worker to assign configuration profiles
+	// run the cron to assign configuration profiles
 	s.awaitTriggerProfileSchedule(t)
 
 	var cmds []*micromdm.CommandPayload
@@ -361,7 +376,14 @@ func (s *integrationMDMTestSuite) runDEPEnrollReleaseDeviceTest(t *testing.T, de
 
 	// call the /config endpoint as fleetd would
 	var orbitConfigResp orbitGetConfigResponse
-	caps := fleet.GetOrbitClientCapabilities()
+	var caps fleet.CapabilityMap
+	if useOldFleetdFlow {
+		// important thing is that it doesn't have the CapabilitySetupExperience
+		caps.PopulateFromString(string(fleet.CapabilityEscrowBuddy))
+	} else {
+		caps = fleet.GetOrbitClientCapabilities()
+	}
+
 	res := s.DoRawWithHeaders("POST", "/api/fleet/orbit/config", json.RawMessage(fmt.Sprintf(`{"orbit_node_key": %q}`, *enrolledHost.OrbitNodeKey)),
 		http.StatusOK, map[string]string{fleet.CapabilitiesHeader: caps.String()})
 	b, err := io.ReadAll(res.Body)
@@ -376,7 +398,41 @@ func (s *integrationMDMTestSuite) runDEPEnrollReleaseDeviceTest(t *testing.T, de
 		pending, err := s.ds.GetQueuedJobs(ctx, 1, time.Now().UTC().Add(time.Minute))
 		require.NoError(t, err)
 		require.Empty(t, pending)
+		return
+	}
+
+	if useOldFleetdFlow {
+		// there should be a Release Device pending job
+		pending, err := s.ds.GetQueuedJobs(ctx, 2, time.Now().UTC().Add(time.Minute))
+		require.NoError(t, err)
+		require.Len(t, pending, 1)
+		require.Equal(t, "apple_mdm", pending[0].Name)
+		require.Contains(t, string(*pending[0].Args), worker.AppleMDMPostDEPReleaseDeviceTask)
+
+		// calling the orbit config endpoint again does NOT enqueue a new job, and doesn't
+		// return the RunSetupExperience notification anymore
+		orbitConfigResp = orbitGetConfigResponse{}
+		res := s.DoRawWithHeaders("POST", "/api/fleet/orbit/config", json.RawMessage(fmt.Sprintf(`{"orbit_node_key": %q}`, *enrolledHost.OrbitNodeKey)),
+			http.StatusOK, map[string]string{fleet.CapabilitiesHeader: caps.String()})
+		b, err := io.ReadAll(res.Body)
+		require.NoError(t, err)
+		require.NoError(t, json.Unmarshal(b, &orbitConfigResp))
+		require.False(t, orbitConfigResp.Notifications.RunSetupExperience)
+
+		pending, err = s.ds.GetQueuedJobs(ctx, 2, time.Now().UTC().Add(time.Minute))
+		require.NoError(t, err)
+		require.Len(t, pending, 1)
+
+		// make the pending job ready to run immediately and run the job
+		mysql.ExecAdhocSQL(t, s.ds, func(q sqlx.ExtContext) error {
+			q.ExecContext(ctx, `UPDATE jobs SET not_before = ? WHERE id = ?`, time.Now().Add(-1*time.Minute).UTC(), pending[0].ID)
+			return nil
+		})
+
+		s.runWorker()
+
 	} else {
+
 		// there shouldn't be a Release Device pending job anymore
 		pending, err := s.ds.GetQueuedJobs(ctx, 1, time.Now().UTC().Add(time.Minute))
 		require.NoError(t, err)
@@ -385,33 +441,33 @@ func (s *integrationMDMTestSuite) runDEPEnrollReleaseDeviceTest(t *testing.T, de
 		// call the /status endpoint to automatically release the host
 		var statusResp getOrbitSetupExperienceStatusResponse
 		s.DoJSON("POST", "/api/fleet/orbit/setup_experience/status", json.RawMessage(fmt.Sprintf(`{"orbit_node_key": %q}`, *enrolledHost.OrbitNodeKey)), http.StatusOK, &statusResp)
-
-		// make the device process the commands, it should receive the
-		// DeviceConfigured one.
-		cmds = cmds[:0]
-		cmd, err = mdmDevice.Idle()
-		require.NoError(t, err)
-		for cmd != nil {
-			var fullCmd micromdm.CommandPayload
-			require.NoError(t, plist.Unmarshal(cmd.Raw, &fullCmd))
-			cmds = append(cmds, &fullCmd)
-			cmd, err = mdmDevice.Acknowledge(cmd.CommandUUID)
-			require.NoError(t, err)
-		}
-
-		require.Len(t, cmds, 1)
-		var deviceConfiguredCount int
-		for _, cmd := range cmds {
-			switch cmd.Command.RequestType {
-			case "DeviceConfigured":
-				deviceConfiguredCount++
-			default:
-				otherCount++
-			}
-		}
-		require.Equal(t, 1, deviceConfiguredCount)
-		require.Equal(t, 0, otherCount)
 	}
+
+	// make the device process the commands, it should receive the
+	// DeviceConfigured one.
+	cmds = cmds[:0]
+	cmd, err = mdmDevice.Idle()
+	require.NoError(t, err)
+	for cmd != nil {
+		var fullCmd micromdm.CommandPayload
+		require.NoError(t, plist.Unmarshal(cmd.Raw, &fullCmd))
+		cmds = append(cmds, &fullCmd)
+		cmd, err = mdmDevice.Acknowledge(cmd.CommandUUID)
+		require.NoError(t, err)
+	}
+
+	require.Len(t, cmds, 1)
+	var deviceConfiguredCount int
+	for _, cmd := range cmds {
+		switch cmd.Command.RequestType {
+		case "DeviceConfigured":
+			deviceConfiguredCount++
+		default:
+			otherCount++
+		}
+	}
+	require.Equal(t, 1, deviceConfiguredCount)
+	require.Equal(t, 0, otherCount)
 }
 
 func (s *integrationMDMTestSuite) TestDEPProfileAssignment() {

--- a/server/service/orbit.go
+++ b/server/service/orbit.go
@@ -227,6 +227,7 @@ func (svc *Service) GetOrbitConfig(ctx context.Context) (fleet.OrbitConfig, erro
 				// setup experience flow.
 				mp, ok := capabilities.FromContext(ctx)
 				if !ok || !mp.Has(fleet.CapabilitySetupExperience) {
+					fmt.Println(">>>>> does NOT have setup experience capability")
 					level.Debug(svc.logger).Log("msg", "host doesn't support Setup experience, falling back to worker-based device release", "host_uuid", host.UUID)
 					if err := svc.processReleaseDeviceForOldFleetd(ctx, host); err != nil {
 						return fleet.OrbitConfig{}, err

--- a/server/service/orbit.go
+++ b/server/service/orbit.go
@@ -490,7 +490,6 @@ func (svc *Service) processReleaseDeviceForOldFleetd(ctx context.Context, host *
 	if err := svc.ds.SetHostAwaitingConfiguration(ctx, host.UUID, false); err != nil {
 		return ctxerr.Wrap(ctx, err, "unset host awaiting configuration")
 	}
-	// TODO: should we also clear the setup_experience_status_results table for that host?
 
 	return nil
 }

--- a/server/service/orbit.go
+++ b/server/service/orbit.go
@@ -18,6 +18,7 @@ import (
 	"github.com/fleetdm/fleet/v4/server/fleet"
 	microsoft_mdm "github.com/fleetdm/fleet/v4/server/mdm/microsoft"
 	"github.com/fleetdm/fleet/v4/server/ptr"
+	"github.com/fleetdm/fleet/v4/server/worker"
 	"github.com/go-kit/log/level"
 )
 
@@ -221,9 +222,18 @@ func (svc *Service) GetOrbitConfig(ctx context.Context) (fleet.OrbitConfig, erro
 
 			if inSetupAssistant {
 				notifs.RunSetupExperience = true
+
+				// check if the client is running an old fleetd version that doesn't support the new
+				// setup experience flow.
+				mp, ok := capabilities.FromContext(ctx)
+				if !ok || !mp.Has(fleet.CapabilitySetupExperience) {
+					level.Debug(svc.logger).Log("msg", "host doesn't support Setup experience, falling back to worker-based device release", "host_uuid", host.UUID)
+					if err := svc.processReleaseDeviceForOldFleetd(ctx, host); err != nil {
+						return fleet.OrbitConfig{}, err
+					}
+				}
 			}
 		}
-
 	}
 
 	// set the host's orbit notifications for Windows MDM
@@ -417,6 +427,55 @@ func (svc *Service) GetOrbitConfig(ctx context.Context) (fleet.OrbitConfig, erro
 		NudgeConfig:      nudgeConfig,
 		UpdateChannels:   updateChannels,
 	}, nil
+}
+
+func (svc *Service) processReleaseDeviceForOldFleetd(ctx context.Context, host *fleet.Host) error {
+	// For the commands to await, since we're in an orbit endpoint we know that
+	// fleetd has already been installed, so we only need to check for the
+	// bootstrap package install and the SSO account configuration (both are
+	// optional).
+	bootstrapCmdUUID, err := svc.ds.GetHostBootstrapPackageCommand(ctx, host.UUID)
+	if err != nil && !fleet.IsNotFound(err) {
+		return ctxerr.Wrap(ctx, err, "get bootstrap package command")
+	}
+
+	// AccountConfiguration covers the (optional) command to setup SSO.
+	adminTeamFilter := fleet.TeamFilter{
+		User: &fleet.User{GlobalRole: ptr.String(fleet.RoleAdmin)},
+	}
+	acctCmds, err := svc.ds.ListMDMCommands(ctx, adminTeamFilter, &fleet.MDMCommandListOptions{
+		Filters: fleet.MDMCommandFilters{
+			HostIdentifier: host.UUID,
+			RequestType:    "AccountConfiguration",
+		},
+	})
+	if err != nil {
+		return ctxerr.Wrap(ctx, err, "list AccountConfiguration commands")
+	}
+	var acctConfigCmdUUID string
+	if len(acctCmds) > 0 {
+		// there may be more than one if e.g. the worker job that sends them had to
+		// retry, but they would all be processed anyway so we can only care about
+		// the first one.
+		acctConfigCmdUUID = acctCmds[0].CommandUUID
+	}
+
+	// Enroll reference arg is not used in the release device task, passing empty string.
+	if err := worker.QueueAppleMDMJob(ctx, svc.ds, svc.logger, worker.AppleMDMPostDEPReleaseDeviceTask,
+		host.UUID, host.Platform, host.TeamID, "", bootstrapCmdUUID, acctConfigCmdUUID); err != nil {
+		return ctxerr.Wrap(ctx, err, "queue Apple Post-DEP release device job")
+	}
+
+	// at this point we know for sure that it will get released, but we need to
+	// ensure we won't continually enqueue new worker jobs for that host until it
+	// is released. To do so, we clear up the setup experience data (since anyway
+	// this host will not go through that new flow).
+	if err := svc.ds.SetHostAwaitingConfiguration(ctx, host.UUID, false); err != nil {
+		return ctxerr.Wrap(ctx, err, "unset host awaiting configuration")
+	}
+	// TODO: should we also clear the setup_experience_status_results table for that host?
+
+	return nil
 }
 
 func (svc *Service) setDiskEncryptionNotifications(


### PR DESCRIPTION
#23366 

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/Committing-Changes.md#changes-files) for more information.
- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [x] Added/updated tests
