### PR TITLE
Skip EAP Jetbrains editions in Vuln processing

### DIFF
--- a/changes/22723-intellij-EAP
+++ b/changes/22723-intellij-EAP
@@ -1,0 +1,1 @@
+- added translation rule to skip EAP versions of Jetbrains products in vulnerability processing

--- a/server/vulnerabilities/nvd/cpe_test.go
+++ b/server/vulnerabilities/nvd/cpe_test.go
@@ -1345,6 +1345,17 @@ func TestCPEFromSoftwareIntegration(t *testing.T) {
 			cpe: "cpe:2.3:a:jetbrains:intellij_idea:2023.3.2.233.13135.103:*:*:*:*:macos:*:*",
 		},
 		{
+			// Skip EAP JebBrains products
+			software: fleet.Software{
+				Name:             "IntelliJ IDEA 2024.3 EAP.app",
+				Source:           "apps",
+				Version:          "EAP IU-242.16677.21",
+				Vendor:           "",
+				BundleIdentifier: "com.jetbrains.intellij-EAP",
+			},
+			cpe: "",
+		},
+		{
 			software: fleet.Software{
 				Name:             "User PyCharm Custom Name.app", // 2023/10/31: The actual product name must be part of the app name per our code in CPEFromSoftware
 				Source:           "apps",

--- a/server/vulnerabilities/nvd/cpe_translations.json
+++ b/server/vulnerabilities/nvd/cpe_translations.json
@@ -122,6 +122,14 @@
   },
   {
     "software": {
+      "bundle_identifier": ["/^com.jetbrains.*EAP/"]
+    },
+    "filter": {
+      "skip": true
+    }
+  },
+  {
+    "software": {
       "bundle_identifier": ["/^com\\.jetbrains\\.intellij/"],
       "source": ["apps"]
     },

--- a/tools/nvd/nvdvuln/nvdvuln.go
+++ b/tools/nvd/nvdvuln/nvdvuln.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"sort"
@@ -305,6 +306,35 @@ func vulnDBSync(vulnDBDir string, debug bool, logger log.Logger) error {
 	if err != nil {
 		return err
 	}
+
+	// copy dev CPE Translations file
+	src := "./server/vulnerabilities/nvd/cpe_translations.json"
+	dst := filepath.Join(vulnDBDir, "cpe_translations.json")
+	if err := copyFile(src, dst); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func copyFile(src, dst string) error {
+	srcFile, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer srcFile.Close()
+
+	dstFile, err := os.Create(dst)
+	if err != nil {
+		return err
+	}
+	defer dstFile.Close()
+
+	_, err = io.Copy(dstFile, srcFile)
+	if err != nil {
+		return err
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
#22723 

- added CPE translation (needs to be above existing jetbrains translation rules)
- added using of of local translations file in nvdtools 

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/Committing-Changes.md#changes-files) for more information.
- [X] Added/updated tests
- [X] Manual QA for all new/changed functionality