### PR TITLE
[Unreleased bug] Fleet UI: onChange called twice due to repeat 

### DIFF
--- a/frontend/components/ActionsDropdown/ActionsDropdown.tsx
+++ b/frontend/components/ActionsDropdown/ActionsDropdown.tsx
@@ -76,13 +76,12 @@ const CustomDropdownIndicator = (
 };
 
 const CustomOption: React.FC<OptionProps<IDropdownOption, false>> = (props) => {
-  const { innerProps, innerRef, data, isDisabled } = props;
+  const { innerRef, data, isDisabled } = props;
 
   const optionContent = (
     <div
       className={`${baseClass}__option`}
       ref={innerRef}
-      {...innerProps}
       tabIndex={isDisabled ? -1 : 0} // Tabbing skipped when disabled
       aria-disabled={isDisabled}
     >


### PR DESCRIPTION
## Issue
Cerra #23355 

## Description
- All action clicks were being called twice
- react-select's default behavior: react-select uses innerProps to pass down necessary event handlers and props to custom components. These typically include click handlers and other interactive elements.
- Custom implementation: CustomOption component is wrapped inside components.Option, which already applies the necessary event handlers from react-select.
- Double application of handlers: By spreading {...innerProps} essentially applies the event handlers twice - once through the components.Option wrapper, and again in the custom component.
- Solution: removing {...innerProps} from custom component leaving only the handlers applied by the components.Option wrapper, which suffices

## Screenrecording of fix
https://www.loom.com/share/c4ffaf74d9204c28a1e05d42f18dc7c0?sid=2de2364c-2396-49f4-80d3-fc072dccb570

> Note: Also tested a disabled option and option with tooltip hover to be sure

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Manual QA for all new/changed functionality
