### PR TITLE
Clear pending (un)installs when installers are deleted

### DIFF
--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/DeleteSoftwareModal/DeleteSoftwareModal.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/DeleteSoftwareModal/DeleteSoftwareModal.tsx
@@ -18,6 +18,7 @@ const DELETE_SW_INSTALLED_DURING_SETUP_ERROR_MSG =
 interface IDeleteSoftwareModalProps {
   softwareId: number;
   teamId: number;
+  software: any; // TODO
   onExit: () => void;
   onSuccess: () => void;
 }
@@ -25,6 +26,7 @@ interface IDeleteSoftwareModalProps {
 const DeleteSoftwareModal = ({
   softwareId,
   teamId,
+  software,
   onExit,
   onSuccess,
 }: IDeleteSoftwareModalProps) => {
@@ -51,7 +53,16 @@ const DeleteSoftwareModal = ({
   return (
     <Modal className={baseClass} title="Delete software" onExit={onExit}>
       <>
-        <p>Software won&apos;t be uninstalled from existing hosts.</p>
+        <p>
+          Software won&apos;t be uninstalled from existing hosts, but any
+          pending pending installs and uninstalls for <b>{software.name}</b>{" "}
+          will be cancelled.
+        </p>
+        <p>
+          Installs or uninstalls currently running on a host will still
+          complete, but results won’t appear in Fleet.
+        </p>
+        <p>You cannot undo this action.</p>
         <div className="modal-cta-wrap">
           <Button variant="alert" onClick={onDeleteSoftware}>
             Delete

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/DeleteSoftwareModal/DeleteSoftwareModal.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/DeleteSoftwareModal/DeleteSoftwareModal.tsx
@@ -18,7 +18,7 @@ const DELETE_SW_INSTALLED_DURING_SETUP_ERROR_MSG =
 interface IDeleteSoftwareModalProps {
   softwareId: number;
   teamId: number;
-  software: any; // TODO
+  softwarePackageName?: string;
   onExit: () => void;
   onSuccess: () => void;
 }
@@ -26,7 +26,7 @@ interface IDeleteSoftwareModalProps {
 const DeleteSoftwareModal = ({
   softwareId,
   teamId,
-  software,
+  softwarePackageName,
   onExit,
   onSuccess,
 }: IDeleteSoftwareModalProps) => {
@@ -55,8 +55,15 @@ const DeleteSoftwareModal = ({
       <>
         <p>
           Software won&apos;t be uninstalled from existing hosts, but any
-          pending pending installs and uninstalls for <b>{software.name}</b>{" "}
-          will be cancelled.
+          pending pending installs and uninstalls{" "}
+          {softwarePackageName ? (
+            <>
+              for <b> {softwarePackageName}</b>{" "}
+            </>
+          ) : (
+            ""
+          )}
+          will be canceled.
         </p>
         <p>
           Installs or uninstalls currently running on a host will still

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwarePackageCard/SoftwarePackageCard.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwarePackageCard/SoftwarePackageCard.tsx
@@ -395,7 +395,7 @@ const SoftwarePackageCard = ({
       {showDeleteModal && (
         <DeleteSoftwareModal
           softwareId={softwareId}
-          software={softwarePackage}
+          softwarePackageName={softwarePackage?.name}
           teamId={teamId}
           onExit={() => setShowDeleteModal(false)}
           onSuccess={onDeleteSuccess}

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwarePackageCard/SoftwarePackageCard.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwarePackageCard/SoftwarePackageCard.tsx
@@ -395,6 +395,7 @@ const SoftwarePackageCard = ({
       {showDeleteModal && (
         <DeleteSoftwareModal
           softwareId={softwareId}
+          software={softwarePackage}
           teamId={teamId}
           onExit={() => setShowDeleteModal(false)}
           onSuccess={onDeleteSuccess}

--- a/server/datastore/mysql/activities.go
+++ b/server/datastore/mysql/activities.go
@@ -261,12 +261,12 @@ func (ds *Datastore) ListHostUpcomingActivities(ctx context.Context, hostID uint
 		`SELECT
 			COUNT(*) c
 			FROM host_software_installs hsi
-			WHERE hsi.host_id = :host_id AND
+			WHERE hsi.host_id = :host_id AND hsi.software_installer_id IS NOT NULL AND
 				hsi.status = :software_status_install_pending`,
 		`SELECT
 			COUNT(*) c
 			FROM host_software_installs hsi
-			WHERE hsi.host_id = :host_id AND
+			WHERE hsi.host_id = :host_id AND hsi.software_installer_id IS NOT NULL AND
 				hsi.status = :software_status_uninstall_pending`,
 		`
 		SELECT

--- a/server/datastore/mysql/activities_test.go
+++ b/server/datastore/mysql/activities_test.go
@@ -433,6 +433,7 @@ func testListHostUpcomingActivities(t *testing.T, ds *Datastore) {
 	sw2Meta, err := ds.GetSoftwareInstallerMetadataByID(ctx, sw2)
 	require.NoError(t, err)
 	sw3Meta, err := ds.GetSoftwareInstallerMetadataByID(ctx, sw3)
+	require.NoError(t, err)
 
 	// insert a VPP app
 	vppCommand1, vppCommand2 := "vpp-command-1", "vpp-command-2"

--- a/server/datastore/mysql/software_installers.go
+++ b/server/datastore/mysql/software_installers.go
@@ -865,14 +865,14 @@ WHERE
 	const deleteAllPendingSoftwareInstalls = `
 		DELETE FROM host_software_installs
 		   WHERE status IN('pending_install', 'pending_uninstall')
-				AND software_installer IN (
+				AND software_installer_id IN (
 					SELECT id FROM software_installers WHERE global_or_team_id = ?
 			   )
 `
 	const markAllSoftwareInstallsAsRemoved = `
 		UPDATE host_software_installs SET removed = TRUE
 			WHERE status IS NOT NULL AND host_deleted_at IS NULL
-				AND software_installer IN (
+				AND software_installer_id IN (
 					SELECT id FROM software_installers WHERE global_or_team_id = ?
 			   )
 `
@@ -895,14 +895,14 @@ WHERE
 	const deletePendingSoftwareInstallsNotInList = `
 		DELETE FROM host_software_installs
 		   WHERE status IN('pending_install', 'pending_uninstall')
-				AND software_installer IN (
+				AND software_installer_id IN (
 					SELECT id FROM software_installers WHERE global_or_team_id = ? AND title_id NOT IN (?)
 			   )
 `
 	const markSoftwareInstallsNotInListAsRemoved = `
 		UPDATE host_software_installs SET removed = TRUE
 			WHERE status IS NOT NULL AND host_deleted_at IS NULL
-				AND software_installer IN (
+				AND software_installer_id IN (
 					SELECT id FROM software_installers WHERE global_or_team_id = ? AND title_id NOT IN (?)
 			   )
 `

--- a/server/datastore/mysql/software_installers.go
+++ b/server/datastore/mysql/software_installers.go
@@ -1081,7 +1081,7 @@ ON DUPLICATE KEY UPDATE
 		if err != nil {
 			return ctxerr.Wrap(ctx, err, "build statement to delete pending uninstall script executions")
 		}
-		if _, err := tx.ExecContext(ctx, stmt, args); err != nil {
+		if _, err := tx.ExecContext(ctx, stmt, args...); err != nil {
 			return ctxerr.Wrap(ctx, err, "delete obsolete pending uninstall script executions")
 		}
 
@@ -1089,7 +1089,7 @@ ON DUPLICATE KEY UPDATE
 		if err != nil {
 			return ctxerr.Wrap(ctx, err, "build statement to delete pending software installs")
 		}
-		if _, err := tx.ExecContext(ctx, stmt, globalOrTeamID); err != nil {
+		if _, err := tx.ExecContext(ctx, stmt, args...); err != nil {
 			return ctxerr.Wrap(ctx, err, "delete obsolete pending host software install records")
 		}
 
@@ -1097,7 +1097,7 @@ ON DUPLICATE KEY UPDATE
 		if err != nil {
 			return ctxerr.Wrap(ctx, err, "build statement to mark obsolete host software installs as removed")
 		}
-		if _, err := tx.ExecContext(ctx, stmt, globalOrTeamID); err != nil {
+		if _, err := tx.ExecContext(ctx, stmt, args...); err != nil {
 			return ctxerr.Wrap(ctx, err, "mark obsolete host software installs as removed")
 		}
 

--- a/server/service/integration_enterprise_test.go
+++ b/server/service/integration_enterprise_test.go
@@ -11174,6 +11174,26 @@ func (s *integrationEnterpriseTestSuite) TestBatchSetSoftwareInstallersSideEffec
 	orbitKey := setOrbitEnrollment(t, h, s.ds)
 	h.OrbitNodeKey = &orbitKey
 
+	// create another host that doesn't have fleetd installed
+	h2, err := s.ds.NewHost(context.Background(), &fleet.Host{
+		DetailUpdatedAt: time.Now(),
+		LabelUpdatedAt:  time.Now(),
+		PolicyUpdatedAt: time.Now(),
+		SeenTime:        time.Now().Add(-1 * time.Minute),
+		OsqueryHostID:   ptr.String(t.Name() + uuid.New().String()),
+		NodeKey:         ptr.String(t.Name() + uuid.New().String()),
+		Hostname:        fmt.Sprintf("%sbar.local", t.Name()),
+		Platform:        "linux",
+	})
+	require.NoError(t, err)
+	err = s.ds.AddHostsToTeam(context.Background(), &tm.ID, []uint{h2.ID})
+	require.NoError(t, err)
+	h2.TeamID = &tm.ID
+
+	// host installs fleetd
+	orbitKey2 := setOrbitEnrollment(t, h2, s.ds)
+	h2.OrbitNodeKey = &orbitKey2
+
 	// install software
 	installResp := installSoftwareResponse{}
 	s.DoJSON("POST", fmt.Sprintf("/api/latest/fleet/hosts/%d/software/%d/install", h.ID, titlesResp.SoftwareTitles[0].ID), nil, http.StatusAccepted, &installResp)
@@ -11297,6 +11317,38 @@ func (s *integrationEnterpriseTestSuite) TestBatchSetSoftwareInstallersSideEffec
 	installDetailsResp := getSoftwareInstallResultsResponse{}
 	s.DoJSON("GET", fmt.Sprintf("/api/latest/fleet/software/install/%s/results", installUUID), nil, http.StatusOK, &installDetailsResp)
 	require.Equal(t, fleet.SoftwareInstalled, installDetailsResp.Results.Status)
+
+	// queue another install before we delete the installer via batch
+	pendingResp := installSoftwareResponse{}
+	s.DoJSON("POST", fmt.Sprintf("/api/latest/fleet/hosts/%d/software/%d/install", h.ID, titlesResp.SoftwareTitles[0].ID), nil, http.StatusAccepted, &pendingResp)
+
+	// install should show as pending
+	s.DoJSON("GET", fmt.Sprintf("/api/latest/fleet/hosts/%d/software", h.ID), nil, http.StatusOK, &afterPreinstallHostResp)
+	require.Equal(t, fleet.SoftwareInstallPending, *afterPreinstallHostResp.Software[0].Status)
+	installUUID = afterPreinstallHostResp.Software[0].SoftwarePackage.LastInstall.InstallUUID
+
+	// queue an uninstall on another host
+	uninstallResp := installSoftwareResponse{}
+	s.DoJSON("POST", fmt.Sprintf("/api/latest/fleet/hosts/%d/software/%d/uninstall", h2.ID, titlesResp.SoftwareTitles[0].ID), nil, http.StatusAccepted, &uninstallResp)
+
+	// uninstall should show as pending
+	s.DoJSON("GET", fmt.Sprintf("/api/latest/fleet/hosts/%d/software", h2.ID), nil, http.StatusOK, &afterPreinstallHostResp)
+	require.Equal(t, fleet.SoftwareUninstallPending, *afterPreinstallHostResp.Software[0].Status)
+
+	// delete all installers
+	s.DoJSON("POST", "/api/latest/fleet/software/batch", batchSetSoftwareInstallersRequest{Software: []fleet.SoftwareInstallerPayload{}}, http.StatusOK, &batchResponse, "team_name", tm.Name)
+	packages = waitBatchSetSoftwareInstallersCompleted(t, s, tm.Name, batchResponse.RequestUUID)
+	require.Len(t, packages, 0)
+
+	// software should no longer exist on either host
+	s.DoJSON("GET", fmt.Sprintf("/api/latest/fleet/hosts/%d/software", h.ID), nil, http.StatusOK, &afterPreinstallHostResp)
+	require.Len(t, afterPreinstallHostResp.Software, 0)
+	s.DoJSON("GET", fmt.Sprintf("/api/latest/fleet/hosts/%d/software", h2.ID), nil, http.StatusOK, &afterPreinstallHostResp)
+	require.Len(t, afterPreinstallHostResp.Software, 0)
+
+	// pending install record should not exist
+	installDetailsResp = getSoftwareInstallResultsResponse{}
+	s.DoJSON("GET", fmt.Sprintf("/api/latest/fleet/software/install/%s/results", installUUID), nil, http.StatusNotFound, &installDetailsResp)
 }
 
 func (s *integrationEnterpriseTestSuite) TestBatchSetSoftwareInstallersWithPoliciesAssociated() {


### PR DESCRIPTION
For unreleased bug #23350, introduced because we're no longer cascade-deleting _all_ related installs (related to #22996, #21654, #22087)

# Checklist for submitter

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [x] Added/updated tests
- [x] Manual QA for all new/changed functionality