### PR TITLE
Cherry-pick: update osquery version list

### DIFF
--- a/frontend/utilities/constants.tsx
+++ b/frontend/utilities/constants.tsx
@@ -84,6 +84,10 @@ export const MAX_OSQUERY_SCHEDULED_QUERY_INTERVAL = 604800;
 
 export const MIN_OSQUERY_VERSION_OPTIONS = [
   { label: "All", value: "" },
+  { label: "5.13.1 +", value: "5.13.1" },
+  { label: "5.12.2 +", value: "5.12.2" },
+  { label: "5.12.1 +", value: "5.12.1" },
+  { label: "5.11.0 +", value: "5.11.0" },
   { label: "5.10.2 +", value: "5.10.2" },
   { label: "5.9.1 +", value: "5.9.1" },
   { label: "5.8.2 +", value: "5.8.2" },


### PR DESCRIPTION
Cherry-pick of automated PR into `main` so 4.59.0's osquery list is closer to current