### PR TITLE
website-change-macOS-to-Apple

### DIFF
--- a/website/views/pages/endpoint-ops.ejs
+++ b/website/views/pages/endpoint-ops.ejs
@@ -175,7 +175,7 @@
           <p>Track progress towards deadlines for security posture remediation projects, and enforce due dates through automations.</p>
         </div>
       </div>
-      <p purpose="feature-footnote">*Currently limited to: macOS, Linux, Windows, Chromebooks, OT, data centers, Amazon Web Services (AWS), Google Cloud (GCP), and the Microsoft Cloud (Azure).</p>
+      <p purpose="feature-footnote">*Currently limited to: Apple, Linux, Windows, Chromebooks, OT, data centers, Amazon Web Services (AWS), Google Cloud (GCP), and the Microsoft Cloud (Azure).</p>
     </div>
 
     <div purpose="feature" class="d-flex flex-md-row flex-column-reverse justify-content-between mx-auto align-items-center">

--- a/website/views/pages/homepage.ejs
+++ b/website/views/pages/homepage.ejs
@@ -62,7 +62,7 @@
           <strong>Debunk the cross-platform myth</strong>
           <p>Fleet exposes familiar concepts from traditional MDMs like custom attributes and dynamic grouping, but in a way that lets you work directly with data and events from each native operating system.</p>
           <strong>Less friction</strong>
-          <p>Automatically manage updates and apps on macOS, Windows, and Linux computers.</p>
+          <p>Automatically manage updates and apps on Apple, Windows, and Linux computers.</p>
           <div>
             <a purpose="category-button" class="text-nowrap btn btn-primary" href="/device-management">Start with device management</a>
           </div>


### PR DESCRIPTION
Closes https://github.com/fleetdm/confidential/issues/8485

- Changed "macOS" to "Apple" on the homepage and endpoint ops landing page.