### PR TITLE
Re-enable TestCronVulnerabilitiesCreatesDatabasesPath test with more precise SUT and internal panic recovery

### DIFF
--- a/cmd/fleet/serve_test.go
+++ b/cmd/fleet/serve_test.go
@@ -357,7 +357,11 @@ func TestCronVulnerabilitiesCreatesDatabasesPath(t *testing.T) {
 
 	go func() {
 		defer func() {
-			recover() // we expect this test to panic as we're ending it early, so we shouldn't fail our suite on this panic
+			// this test may panic as we're ending it early, so we shouldn't fail our suite on this panic
+			// but depending on where we are in the cron call it may not panic, hence not checking the recover
+			// value either way
+			// nolint:errcheck
+			recover()
 		}()
 		_ = cronVulnerabilities(ctx, ds, lg, &config)
 	}()


### PR DESCRIPTION
#23258 (see [comment](https://github.com/fleetdm/fleet/issues/23258#issuecomment-2443304838) for rationale)

Validated by removing the two places that would create the directory (early in scanVulnerabilities in cron.go, partway through download in download.go) and ensuring the test failed (timeout after 10s).

Both dir creations happen early in the vulns cron so I was able to drastically tighten the timing on the periodic check on this test, so this tests completes way quicker than before as an added benefit (automatic test parallelism notwithstanding).

The panic recovery here theoretically shouldn't be necessary, as on a passed test the context will get cancelled while syncing the CPE sqlite, but is included to ensure the test doesn't flake if the implementation of the vulnerabilities cron changes such that we _would_ get a panic by cancelling the context this early.

# Checklist for submitter
- [x] Added/updated tests