### PR TITLE
Website: Update /queries page

### DIFF
--- a/docs/01-Using-Fleet/standard-query-library/standard-query-library.yml
+++ b/docs/01-Using-Fleet/standard-query-library/standard-query-library.yml
@@ -1099,7 +1099,7 @@ spec:
   contributors: defensivedepth
 ---
 apiVersion: v1
-kind: policy
+kind: query
 spec:
   name: Identify Apple development secrets (macOS)
   query: SELECT * FROM keychain_items WHERE label LIKE '%ABCDEFG%';

--- a/docs/01-Using-Fleet/standard-query-library/standard-query-library.yml
+++ b/docs/01-Using-Fleet/standard-query-library/standard-query-library.yml
@@ -5,16 +5,16 @@ spec:
   name: Ensure a password is required to wake the computer from sleep or screen saver is enabled
   platforms: macOS
   platform: darwin
-  description: Checks that Password is Required to Wake the Computer From Sleep or Screen Saver Is Enabled.
+  description: Checks that password is required to wake the computer from sleep or screen saver is enabled.
   resolution: |
     Automated method:
-    Ask your system administrator to deploy an MDM profile that Ensure a Password is Required to Wake the Computer From Sleep or Screen Saver Is Enabled.
+    Ask your system administrator to deploy an MDM profile that ensures a password is required to wake the computer from sleep or screen saver is enabled.
     Graphical method:
-      Perform the following steps to ensure a Password is Required to Wake the Computer From Sleep or Screen Saver Is Enabled:
+      Perform the following steps to ensure a password is required to wake the computer from sleep or screen saver is enabled:
         1. Open System Settings
         2. Select Lock Screen
-        3. Verify that Require password after screensaver begins or display is turned
-        off is set with After 0 seconds or After 5 seconds
+        3. Verify that "Require password after screensaver begins or display is turned
+        off" is set with "After 0 seconds" or "After 5 seconds"
   query: |-
     SELECT 1 WHERE 
       EXISTS (

--- a/docs/01-Using-Fleet/standard-query-library/standard-query-library.yml
+++ b/docs/01-Using-Fleet/standard-query-library/standard-query-library.yml
@@ -1,5 +1,98 @@
 ---
 apiVersion: v1
+kind: policy
+spec:
+  name: Ensure a password is required to wake the computer from sleep or screen saver is enabled
+  platforms: macOS
+  platform: darwin
+  description: Checks that Password is Required to Wake the Computer From Sleep or Screen Saver Is Enabled.
+  resolution: |
+    Automated method:
+    Ask your system administrator to deploy an MDM profile that Ensure a Password is Required to Wake the Computer From Sleep or Screen Saver Is Enabled.
+    Graphical method:
+      Perform the following steps to ensure a Password is Required to Wake the Computer From Sleep or Screen Saver Is Enabled:
+        1. Open System Settings
+        2. Select Lock Screen
+        3. Verify that Require password after screensaver begins or display is turned
+        off is set with After 0 seconds or After 5 seconds
+  query: |-
+    SELECT 1 WHERE 
+      EXISTS (
+        SELECT 1 FROM managed_policies WHERE 
+            domain='com.apple.screensaver' AND 
+            name='askForPassword' AND 
+            (value = 1 OR value = 'true') AND 
+            username = ''
+        )
+      AND EXISTS (
+        SELECT 1 FROM managed_policies WHERE 
+            domain='com.apple.screensaver' AND 
+            name='askForPasswordDelay' AND 
+            value <= 5 AND 
+            username = ''
+        )
+      AND NOT EXISTS (
+        SELECT 1 FROM managed_policies WHERE 
+            domain='com.apple.screensaver' AND 
+            name='askForPassword' AND 
+            (value != 1 AND value != 'true')
+        )
+      AND NOT EXISTS (
+        SELECT 1 FROM managed_policies WHERE 
+            domain='com.apple.screensaver' AND 
+            name='askForPasswordDelay' AND 
+            value > 5
+        );  
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1, premium,
+  contributors: sharon-fdm
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: Ensure auto-update is enabled
+  platforms: macOS
+  platform: darwin
+  description: Checks that the system is configured via MDM to automatically install updates.
+  resolution: "Ask your system administrator to deploy an MDM profile that enables automatic updates."
+  query: |
+    SELECT 1 WHERE 
+      EXISTS (
+        SELECT 1 FROM managed_policies WHERE 
+            domain='com.apple.SoftwareUpdate' AND 
+            name='AutomaticCheckEnabled' AND 
+            (value = 1 OR value = 'true') AND 
+            username = ''
+        )
+      AND NOT EXISTS (
+        SELECT 1 FROM managed_policies WHERE 
+            domain='com.apple.SoftwareUpdate' AND 
+            name='AutomaticCheckEnabled' AND 
+            (value != 1 AND value != 'true')
+        );  
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1, premium
+  contributors: sharon-fdm
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: Ensure 'Minimum password length' is set to '14 or more characters'
+  platforms: win10
+  platform: windows
+  description: |
+    This policy setting determines the least number of characters that make up a password for a user account.
+  resolution: |
+    Automatic method:
+    Ask your system administrator to establish the recommended configuration via GP, set the following UI path to 14 or more characters
+    'Computer Configuration\Policies\Windows Settings\Security Settings\Account Policies\Password Policy\Minimum password length'
+  query: |
+    SELECT 1 FROM security_profile_info WHERE minimum_password_length >= 14;
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1, premium
+  contributors: marcosd4h
+---
+apiVersion: v1
 kind: query
 spec:
   name: Get OpenSSL versions

--- a/docs/01-Using-Fleet/standard-query-library/standard-query-library.yml
+++ b/docs/01-Using-Fleet/standard-query-library/standard-query-library.yml
@@ -1104,7 +1104,6 @@ spec:
   name: Identify Apple development secrets (macOS)
   query: SELECT * FROM keychain_items WHERE label LIKE '%ABCDEFG%';
   description: "Identifies certificates associated with Apple development signing and notarization. Replace ABCDEFG with your company's identifier."
-  resolution: "Ensure your official Apple builds, signing and notarization happen on a centralized system, and remove these certificates from workstations."
   tags: compliance, inventory, built-in
   platform: darwin
   contributors: GuillaumeRoss

--- a/website/api/controllers/view-query-library.js
+++ b/website/api/controllers/view-query-library.js
@@ -21,17 +21,14 @@ module.exports = {
     let policies = _.where(sails.config.builtStaticContent.queries, {kind: 'policy'});
     let macOsPolicies = _.filter(policies, (policy)=>{
       let platformsForThisPolicy = policy.platform.split(',');
-      console.log(platformsForThisPolicy, _.includes(platformsForThisPolicy, 'darwin'));
       return _.includes(platformsForThisPolicy, 'darwin');
     });
     let windowsPolicies = _.filter(policies, (policy)=>{
       let platformsForThisPolicy = policy.platform.split(',');
-      console.log(platformsForThisPolicy, _.includes(platformsForThisPolicy, 'darwin'));
       return _.includes(platformsForThisPolicy, 'windows');
     });
     let linuxPolicies = _.filter(policies, (policy)=>{
       let platformsForThisPolicy = policy.platform.split(',');
-      console.log(platformsForThisPolicy, _.includes(platformsForThisPolicy, 'darwin'));
       return _.includes(platformsForThisPolicy, 'linux');
     });
     // console.log(macOsQueries);
@@ -39,7 +36,8 @@ module.exports = {
     return {
       macOsPolicies,
       windowsPolicies,
-      linuxPolicies
+      linuxPolicies,
+      policies,
     };
 
   }

--- a/website/api/controllers/view-query-library.js
+++ b/website/api/controllers/view-query-library.js
@@ -36,7 +36,7 @@ module.exports = {
       macOsPolicies,
       windowsPolicies,
       linuxPolicies,
-      policies,
+      policies,// FUTURE: remove this once Algolia search is on this page
     };
 
   }

--- a/website/api/controllers/view-query-library.js
+++ b/website/api/controllers/view-query-library.js
@@ -18,10 +18,28 @@ module.exports = {
     if (!_.isObject(sails.config.builtStaticContent) || !_.isArray(sails.config.builtStaticContent.queries)) {
       throw {badConfig: 'builtStaticContent.queries'};
     }
-
+    let policies = _.where(sails.config.builtStaticContent.queries, {kind: 'policy'});
+    let macOsPolicies = _.filter(policies, (policy)=>{
+      let platformsForThisPolicy = policy.platform.split(',');
+      console.log(platformsForThisPolicy, _.includes(platformsForThisPolicy, 'darwin'));
+      return _.includes(platformsForThisPolicy, 'darwin');
+    });
+    let windowsPolicies = _.filter(policies, (policy)=>{
+      let platformsForThisPolicy = policy.platform.split(',');
+      console.log(platformsForThisPolicy, _.includes(platformsForThisPolicy, 'darwin'));
+      return _.includes(platformsForThisPolicy, 'windows');
+    });
+    let linuxPolicies = _.filter(policies, (policy)=>{
+      let platformsForThisPolicy = policy.platform.split(',');
+      console.log(platformsForThisPolicy, _.includes(platformsForThisPolicy, 'darwin'));
+      return _.includes(platformsForThisPolicy, 'linux');
+    });
+    // console.log(macOsQueries);
     // Respond with view.
     return {
-      queries: sails.config.builtStaticContent.queries
+      macOsPolicies,
+      windowsPolicies,
+      linuxPolicies
     };
 
   }

--- a/website/api/controllers/view-query-library.js
+++ b/website/api/controllers/view-query-library.js
@@ -31,7 +31,6 @@ module.exports = {
       let platformsForThisPolicy = policy.platform.split(',');
       return _.includes(platformsForThisPolicy, 'linux');
     });
-    // console.log(macOsQueries);
     // Respond with view.
     return {
       macOsPolicies,

--- a/website/assets/js/pages/query-detail.page.js
+++ b/website/assets/js/pages/query-detail.page.js
@@ -16,6 +16,14 @@ parasails.registerPage('query-detail', {
     $('pre code').each((i, block) => {
       window.hljs.highlightElement(block);
     });
+    $('[purpose="copy-button"]').on('click', async function() {
+      let code = $(this).siblings('pre').find('code').text();
+      $(this).addClass('copied');
+      await setTimeout(()=>{
+        $(this).removeClass('copied');
+      }, 2000);
+      navigator.clipboard.writeText(code);
+    });
   },
 
   //  ╦╔╗╔╔╦╗╔═╗╦═╗╔═╗╔═╗╔╦╗╦╔═╗╔╗╔╔═╗

--- a/website/assets/js/pages/query-library.page.js
+++ b/website/assets/js/pages/query-library.page.js
@@ -7,7 +7,7 @@ parasails.registerPage('query-library', {
     inputTimers: {},
     searchString: '', // The user input string to be searched against the query library
     selectedKind: 'policy', // Initially set to 'policy', the user may select a different option to filter queries by purpose (e.g., "all queries", "informational", "policies")
-    selectedPlatform: 'all platforms', // Initially set to all, the user may select a different option to filter queries by platform (e.g., "all platforms", "macOS", "Windows", "Linux")
+    selectedPlatform: 'macos', // Initially set to all, the user may select a different option to filter queries by platform (e.g., "all platforms", "macOS", "Windows", "Linux")
     selectedTag: 'built-in', // Initially set to the 'built-in' tag, the user may select a different tag to filter queries by.
   },
 

--- a/website/assets/js/pages/query-library.page.js
+++ b/website/assets/js/pages/query-library.page.js
@@ -6,23 +6,12 @@ parasails.registerPage('query-library', {
     inputTextValue: '',
     inputTimers: {},
     searchString: '', // The user input string to be searched against the query library
-    selectedKind: 'policy', // Initially set to 'policy', the user may select a different option to filter queries by purpose (e.g., "all queries", "informational", "policies")
-    selectedPlatform: 'macos', // Initially set to all, the user may select a different option to filter queries by platform (e.g., "all platforms", "macOS", "Windows", "Linux")
-    selectedTag: 'built-in', // Initially set to the 'built-in' tag, the user may select a different tag to filter queries by.
+    selectedPlatform: 'macos', // Initially set to 'macos'
   },
 
   computed: {
-    filteredQueries: function () {
-      return this.queries.filter(
-        (query) =>
-          this._isIncluded(query.platform, this.selectedPlatform) &&
-          this._isIncluded(query.kind, this.selectedKind) &&
-          this._isIncluded(query.tags, this.selectedTag)
-      );
-    },
-
     searchResults: function () {
-      return this._search(this.filteredQueries, this.searchString);
+      return this._search(this.policies, this.searchString);
     },
 
     queriesList: function () {
@@ -44,49 +33,9 @@ parasails.registerPage('query-library', {
   //  ║║║║ ║ ║╣ ╠╦╝╠═╣║   ║ ║║ ║║║║╚═╗
   //  ╩╝╚╝ ╩ ╚═╝╩╚═╩ ╩╚═╝ ╩ ╩╚═╝╝╚╝╚═╝
   methods: {
-    clickSelectKind(kind) {
-      this.selectedKind = kind;
-    },
 
     clickSelectPlatform(platform) {
       this.selectedPlatform = platform;
-    },
-
-    clickSelectTag(tag) {
-      this.selectedTag = tag;
-    },
-
-    clickCard: function (querySlug) {
-      this.goto('/queries/' + querySlug); // we can trust the query slug is url-safe
-    },
-
-    clickAvatar: function (contributor) {
-      this.goto(contributor.htmlUrl);
-    },
-
-    getAvatarUrl: function (contributorData) {
-      return contributorData ? contributorData.avatarUrl : '';
-    },
-
-    getContributorsString: function (contributors) {
-      if (!contributors) {
-        return;
-      }
-      const displayName = (contributorData) => {
-        if (contributorData) {
-          return !contributorData.name
-            ? contributorData.handle
-            : contributorData.name;
-        }
-      };
-      let contributorString = displayName(contributors[0]);
-      if (contributors.length > 2) {
-        contributorString += ` and ${contributors.length - 1} others`;
-      }
-      if (contributors.length === 2) {
-        contributorString += ` and ${displayName(contributors[1])}`;
-      }
-      return contributorString;
     },
 
     delayInput: function (callback, ms, label) {
@@ -117,27 +66,9 @@ parasails.registerPage('query-library', {
             textToSearch += ', ' + normalize(contributor.name) + ', ' + normalize(contributor.handle);
           });
         }
-        if (query.tags) {
-          query.tags.forEach((tag) => {
-            textToSearch += ', ' + normalize(tag);
-          });
-        }
         return (searchTerms.some((term) => textToSearch.includes(term)));
       });
     },
-
-    _isIncluded: function (data, selectedOption) {
-      if (selectedOption.startsWith('all') || selectedOption === '') {
-        return true;
-      }
-      if (_.isArray(data)) {
-        data = data.join(', ');
-      }
-      return (
-        _.isString(data) && data.toLowerCase().includes(selectedOption.toLowerCase())
-      );
-    },
-
   },
 
 });

--- a/website/assets/styles/pages/query-detail.less
+++ b/website/assets/styles/pages/query-detail.less
@@ -279,39 +279,19 @@
     margin-bottom: 24px;
     code {
       color: #515774;
-      font-family: "Source Code Pro";
+      font-family: 'Source Code Pro';
       font-size: 14px;
       font-weight: 400;
       line-height: 150%;
       .hljs-keyword { // SQL keywords (SELECT, FROM, WHERE, IN, etc.)
         color: #AE6DDF;
-        white-space: pre;
-      }
-      .hljs-attr { // For table and column names
-        .hljs-keyword {
-          color: #FFF;
-        }
-        color: #FFF;
-        background-color: #AE6DDF;
-        border-radius: 4px;
-        padding: 4px 4px 4px 4px;
-        white-space: pre;
-        vertical-align: baseline;
-        line-height: 16px;
-        span {
-          padding: 0;
-        }
       }
       .hljs-string { // For words wrapped in quotation marks
         color: #3DB67B;
       }
       background-color: @ui-off-white;
       border: none;
-      word-break: break-word;
-      text-wrap: wrap;
       padding: 0;
-      font-size: 13px;
-      line-height: 24px;
     }
   }
 

--- a/website/assets/styles/pages/query-detail.less
+++ b/website/assets/styles/pages/query-detail.less
@@ -1,157 +1,372 @@
 #query-detail {
 
-  h5 {
-    font-weight: bold;
-    font-size: 16px;
-    line-height: 25px;
-  }
+  h3 {
+    padding-bottom: 24px;
+    padding-top: 32px;
+    color: #192147;
 
-  h6 {
-    font-size: 16px;
-    line-height: 25px;
-    word-wrap: break-word;
+    /* Title M (FKA h3) */
+    font-family: Inter;
+    font-size: 24px;
+    font-style: normal;
+    font-weight: 800;
+    line-height: 28.8px; /* 120% */
+    margin-bottom: 0px;
   }
 
   p {
-    line-height: 25px;
+    color: #515774;
+    font-size: 16px;
+    font-weight: 400;
+    line-height: 24px; /* 150% */
   }
 
-  a {
+
+
+  [purpose='page-container'] {
+    padding: 64px 64px 32px 64px;
+  }
+  [purpose='page-content'] {
+    margin-left: auto;
+    margin-right: auto;
+    max-width: 1072px;
+  }
+
+  [purpose='breadcrumbs-and-search'] {
+    // padding-top: 64px;
+    margin-bottom: 64px;
+    max-width: 1072px;
+    font-size: 14px;
+    [purpose='breadcrumbs'] {
+      margin-right: 24px;
+    }
+    [purpose='search'] {
+      // Note: We're using classes here to override the default Docsearch styles;
+      button {
+        width: 100%;
+        cursor: text;
+        margin: 0;
+      }
+      .DocSearch-Button {
+        border-top-left-radius: 6px;
+        border-bottom-left-radius: 6px;
+        border-top-right-radius: 6px;
+        border-bottom-right-radius: 6px;
+        border: 1px solid @core-fleet-black-25;
+        background-color: #FFF;
+        padding: 6px;
+        height: 36px;
+        margin: 0;
+        width: 256px;
+      }
+      .DocSearch-Button:hover {
+        box-shadow: none;
+        border: 1px solid @core-fleet-black-25;
+        color: @core-fleet-black-50;
+      }
+      .DocSearch-Search-Icon {
+        margin-left: 10px;
+        height: 16px;
+        width: 16px;
+        color: @core-fleet-black-50;
+        stroke-width: 3px;
+      }
+      .DocSearch-Button-Keys {
+        display: none;
+      }
+      .input-group:focus-within {
+        border: 1px solid @core-vibrant-blue;
+      }
+      .DocSearch-Button-Placeholder {
+        font-size: 16px;
+        font-weight: 400;
+        padding-left: 12px;
+      }
+      [purpose='disabled-search'] {
+        input {
+          padding-top: 6px;
+          padding-bottom: 6px;
+          border: none;
+          } &::placeholder {
+            font-size: 16px;
+            line-height: 24px;
+            color: #8B8FA2;
+          }
+        .input-group {
+          border-top-left-radius: 6px;
+          border-bottom-left-radius: 6px;
+          border-top-right-radius: 6px;
+          border-bottom-right-radius: 6px;
+          border: 1px solid @core-fleet-black-25;
+          background: #FFF;
+        }
+        .input-group:focus-within {
+          border: 1px solid @core-vibrant-blue;
+        }
+        .form-control {
+          border-radius: 6px;
+          padding: 6px;
+          height: 36px;
+          margin: 0;
+          width: 212px;
+        }
+        .docsearch-input:focus-visible {
+          outline: none;
+        }
+        .ds-input:focus {
+          outline: rgba(0, 0, 0, 0);
+        }
+        .input-group-text {
+          color: @core-fleet-black-50;
+        }
+        .form-control {
+          height: 36px;
+          padding: 0px;
+          font-size: 16px;
+        } &:focus {
+          border: none;
+        }
+      }
+    }
+
+    [purpose='breadcrumbs-category'] {
+      color: #8B8FA2;
+      margin-right: 8px;
+      font-family: Inter;
+      font-size: 14px;
+      font-style: normal;
+      font-weight: 400;
+      line-height: 21px; /* 150% */
+      &:hover {
+        color: #192147;
+        text-decoration: none;
+      }
+    }
+    [purpose='breadcrumbs-title'] {
+      margin-left: 8px;
+    }
+  }
+
+  [purpose='policy-name'] {
+    color: #192147;
+    font-family: Inter;
+    font-size: 32px;
+    font-style: normal;
+    font-weight: 800;
+    line-height: 48px; /* 150% */
+    margin-bottom: 0px;
+  }
+  [purpose='policy-description'] {
+    color: var(--text-text-primary, #515774);
+    /* Body MD (FKA p) */
+    font-family: Inter;
     font-size: 16px;
-    line-height: 25px;
-    color: @core-vibrant-blue;
+    font-style: normal;
+    font-weight: 400;
+    line-height: 24px; /* 150% */
+    margin-bottom: 0px;
+    padding: 16px 0px 32px 0px;
+  }
+  [purpose='policy-details'] {
+    padding-right: 64px;
+    max-width: 800px;
+  }
+  [purpose='policy-check'] {
+    padding-bottom: 24px;
+  }
+
+  [purpose='right-sidebar'] {
+    // position: sticky;
+    // margin-top: 64px;
+    // top: 144px;
+    width: 256px;
+    margin-left: 16px;
+    font-size: 14px;
+    transition-property: transform;
+    transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+    transition-duration: 500ms;
+    a:not([purpose='edit-button']) {
+      margin-bottom: 8px;
+      display: block;
+      color: #515774;
+      &:hover {
+        text-decoration: none;
+        color: @core-fleet-black;
+      }
+    }
+  }
+  [purpose='docs-links'] {
+    a {
+      display: block;
+    }
+  }
+  [purpose='social-share-buttons'] {
+    padding-bottom: 24px;
+    margin-bottom: 24px;
+    border-bottom: 1px solid #E2E4EA;
+    a {
+      margin-right: 16px;
+    }
+    img {
+      height: 20px;
+      width: 20px;
+    }
+  }
+  [purpose='policy-platform'] {
+    border-bottom: 1px solid #E2E4EA;
+    padding-bottom: 24px;
+    padding-top: 16px;
+    margin-bottom: 24px;
+    h4 {
+      color: var(--text-text-brand, #192147);
+
+      /* Body SM (bold) */
+      font-family: Inter;
+      font-size: 14px;
+      font-style: normal;
+      font-weight: 700;
+      line-height: 21px; /* 150% */
+      padding-bottom: 8px;
+      margin-bottom: 8px;
+    }
+    img {
+      height: 24px;
+    }
+  }
+  [purpose='edit-button'] {
+    margin-top: 16px;
+    img {
+      width: 16px;
+      height: 16px;
+      display: inline;
+      margin-right: 8px;
+    }
+    padding: 6px 8px;
+    display: block;
+    color: @core-fleet-black-75;
+    text-decoration: none;
+    font-size: 14px;
+    line-height: 21px;
+    border-radius: 6px;
+    width: 102px;
+    background: rgba(25, 33, 71, 0.05);
+    &:hover {
+      background-color: rgba(25, 33, 71, 0.1);
+    }
+    &:active {
+      background-color: rgba(25, 33, 71, 0.1);
+    }
+  }
+
+  [purpose='codeblock'] {
+    padding: 0;
+    position: relative;
+    [purpose='copy-button'] {
+      position: absolute;
+      top: 11px;
+      right: 10px;
+      padding: 9px;
+      border-radius: 8px;
+      height: 14px;
+      width: 14px;
+      background: url('/images/icon-copy-16x16@2x.png');
+      background-size: 14px 14px;
+      background-position: center;
+      background-repeat: no-repeat;
+      cursor: pointer;
+      &:hover {
+        background-color: #F2F2F5;
+      }
+      &.copied {
+        background: url('/images/icon-copy-clicked-checkmark-32x32@2x.png');
+        background-size: 32px 32px;
+        background-repeat: no-repeat;
+        background-position: center;
+      }
+    }
   }
 
   pre {
     width: 100%;
     max-width: 100%;
-    padding: 30px;
+    padding: 16px 24px;
+    border: 1px solid #E2E4EA;
     background: #F9FAFC;
-    border: 1px solid @core-vibrant-blue-15;
     border-radius: 4px;
     margin-bottom: 0px;
     code {
+      color: #515774;
       .hljs-keyword { // SQL keywords (SELECT, FROM, WHERE, IN, etc.)
         color: #AE6DDF;
         white-space: pre;
       }
+      .hljs-attr { // For table and column names
+        .hljs-keyword {
+          color: #FFF;
+        }
+        color: #FFF;
+        background-color: #AE6DDF;
+        border-radius: 4px;
+        padding: 4px 4px 4px 4px;
+        white-space: pre;
+        vertical-align: baseline;
+        line-height: 16px;
+        span {
+          padding: 0;
+        }
+      }
       .hljs-string { // For words wrapped in quotation marks
         color: #3DB67B;
-        white-space: pre;
       }
       background-color: @ui-off-white;
       border: none;
       word-break: break-word;
-      white-space: normal;
+      text-wrap: wrap;
       padding: 0;
       font-size: 13px;
       line-height: 24px;
     }
   }
 
-  .border-top {
-    border-color: #E2E4EA;
-  }
-
-  [purpose='query-tag'] {
-    font-size: 12px;
-    font-weight: 700;
-    padding: 4px 8px;
-    border-radius: 20px;
-    background-color: #E2E4EA;
-  }
-
-  [purpose='requires-mdm-badge'] {
-    text-transform: uppercase;
-    background: #6A67FE;
-    border-radius: 4px;
-    padding: 4px;
-    font-weight: 700;
-    font-size: 10px;
-    line-height: 10px;
-    display: inline-block;
-    color: #FFF;
-    text-decoration: none;
-    white-space: nowrap;
-  }
-  [purpose='critical-badge'] {
-    text-transform: uppercase;
-    background: #FF5C83;
-    border-radius: 4px;
-    padding: 4px;
-    font-weight: 700;
-    font-size: 10px;
-    line-height: 10px;
-    display: inline-block;
-    color: #FFF;
-    text-decoration: none;
-    white-space: nowrap;
-  }
-
-
-  [purpose='remediation'] {
-    overflow-wrap: break-word;
-    word-wrap: break-word;
-    word-break: break-word;
-    p {
-      font-size: 16px;
-      line-height: 24px;
+  @media (max-width: 991px) {
+    [purpose='page-container'] {
+      padding: 32px;
+    }
+    [purpose='policy-details'] {
+      padding-right: 0px;
+      max-width: 100%;
+    }
+    [purpose='right-sidebar'] {
+      width: 100%;
+      margin-left: 0px;
+    }
+    [purpose='breadcrumbs-and-search'] {
+      margin-bottom: 32px;
     }
   }
 
-  [purpose='avatar-frame'] {
-    width: 24px;
-    height: 24px;
-    position: relative;
-    overflow: hidden;
-    border-radius: 50%;
-    &:hover {
-      cursor: pointer;
-    }
-
-    img {
-      display: inline;
-      margin: 0 auto;
-      height: 100%;
-      width: auto;
-    }
-
-  }
-
-  [purpose='platforms'] {
-    img {
-      height: 18px;
-      width: 18px;
-    }
-  }
-
-  @media (min-width: 768px) {
-
-    h5, p, a {
-      font-size: 18px;
-    }
-
-    [purpose='avatar-frame'] {
-      width: 32px;
-      height: 32px;
-    }
-
-    [purpose='platforms'] {
-      img {
-        height: 24px;
-        width: 24px;
+  @media (max-width: 768px) {
+    [purpose='breadcrumbs-and-search'] {
+      max-width: 1072px;
+      font-size: 14px;
+      [purpose='breadcrumbs'] {
+        margin-bottom: 24px;
+      }
+      [purpose='search'] {
+        width: 100%;
+        .DocSearch-Button {
+          width: 100%;
+        }
       }
     }
-
   }
 
   @media (max-width: 575px) {
-
-    h2 {
-      font-size: 28px;
-      line-height: 36px;
+    [purpose='page-container'] {
+      padding: 32px 24px;
     }
 
   }
+
 
 }

--- a/website/assets/styles/pages/query-detail.less
+++ b/website/assets/styles/pages/query-detail.less
@@ -4,13 +4,9 @@
     padding-bottom: 24px;
     padding-top: 32px;
     color: #192147;
-
-    /* Title M (FKA h3) */
-    font-family: Inter;
     font-size: 24px;
-    font-style: normal;
     font-weight: 800;
-    line-height: 28.8px; /* 120% */
+    line-height: 120%;
     margin-bottom: 0px;
   }
 
@@ -18,9 +14,8 @@
     color: #515774;
     font-size: 16px;
     font-weight: 400;
-    line-height: 24px; /* 150% */
+    line-height: 150%;
   }
-
 
 
   [purpose='page-container'] {
@@ -33,7 +28,6 @@
   }
 
   [purpose='breadcrumbs-and-search'] {
-    // padding-top: 64px;
     margin-bottom: 64px;
     max-width: 1072px;
     font-size: 14px;
@@ -132,11 +126,9 @@
     [purpose='breadcrumbs-category'] {
       color: #8B8FA2;
       margin-right: 8px;
-      font-family: Inter;
       font-size: 14px;
-      font-style: normal;
       font-weight: 400;
-      line-height: 21px; /* 150% */
+      line-height: 150%; /*  */
       &:hover {
         color: #192147;
         text-decoration: none;
@@ -149,21 +141,18 @@
 
   [purpose='policy-name'] {
     color: #192147;
-    font-family: Inter;
     font-size: 32px;
     font-style: normal;
     font-weight: 800;
-    line-height: 48px; /* 150% */
+    line-height: 150%;
     margin-bottom: 0px;
   }
   [purpose='policy-description'] {
-    color: var(--text-text-primary, #515774);
-    /* Body MD (FKA p) */
-    font-family: Inter;
+    color: #515774;
     font-size: 16px;
     font-style: normal;
     font-weight: 400;
-    line-height: 24px; /* 150% */
+    line-height: 150%;
     margin-bottom: 0px;
     padding: 16px 0px 32px 0px;
   }
@@ -176,9 +165,6 @@
   }
 
   [purpose='right-sidebar'] {
-    // position: sticky;
-    // margin-top: 64px;
-    // top: 144px;
     width: 256px;
     margin-left: 16px;
     font-size: 14px;
@@ -218,14 +204,10 @@
     padding-top: 16px;
     margin-bottom: 24px;
     h4 {
-      color: var(--text-text-brand, #192147);
-
-      /* Body SM (bold) */
-      font-family: Inter;
+      color: #192147;
       font-size: 14px;
-      font-style: normal;
       font-weight: 700;
-      line-height: 21px; /* 150% */
+      line-height: 150%;
       padding-bottom: 8px;
       margin-bottom: 8px;
     }
@@ -234,7 +216,7 @@
     }
   }
   [purpose='edit-button'] {
-    margin-top: 16px;
+    margin-top: 24px;
     img {
       width: 16px;
       height: 16px;
@@ -265,10 +247,10 @@
       position: absolute;
       top: 11px;
       right: 10px;
-      padding: 9px;
+      // padding: 9px;
       border-radius: 8px;
-      height: 14px;
-      width: 14px;
+      height: 32px;
+      width: 32px;
       background: url('/images/icon-copy-16x16@2x.png');
       background-size: 14px 14px;
       background-position: center;
@@ -293,9 +275,14 @@
     border: 1px solid #E2E4EA;
     background: #F9FAFC;
     border-radius: 4px;
-    margin-bottom: 0px;
+    margin-top: 16px;
+    margin-bottom: 24px;
     code {
       color: #515774;
+      font-family: "Source Code Pro";
+      font-size: 14px;
+      font-weight: 400;
+      line-height: 150%;
       .hljs-keyword { // SQL keywords (SELECT, FROM, WHERE, IN, etc.)
         color: #AE6DDF;
         white-space: pre;

--- a/website/assets/styles/pages/query-library.less
+++ b/website/assets/styles/pages/query-library.less
@@ -1,24 +1,24 @@
 #query-library {
-  h2 {
-    padding: 0px 30px 0px 30px;
-  }
+  // h2 {
+  //   padding: 0px 30px 0px 30px;
+  // }
 
-  h5 {
-    font-size: 18px;
-    font-weight: bold;
-    line-height: 25px;
-  }
+  // h5 {
+  //   font-size: 18px;
+  //   font-weight: bold;
+  //   line-height: 25px;
+  // }
 
-  h6 {
-    font-size: 16px;
-    line-height: 22px;
-    padding: 0px 30px 0px 30px;
-  }
+  // h6 {
+  //   font-size: 16px;
+  //   line-height: 22px;
+  //   padding: 0px 30px 0px 30px;
+  // }
 
-  a {
-    font-size: 16px;
-    color: @core-vibrant-blue;
-  }
+  // a {
+  //   font-size: 16px;
+  //   color: @core-vibrant-blue;
+  // }
 
   img {
     &.logo {
@@ -30,10 +30,56 @@
     }
   }
 
-  input {
-    &::placeholder {
-      font-size: 16px;
+  // input {
+  //   &::placeholder {
+  //     font-size: 16px;
+  //   }
+  // }
+  [purpose='page-container'] {
+    padding: 64px;
+
+  }
+  [purpose='page-content'] {
+    margin-left: auto;
+    margin-right: auto;
+    max-width: 1072px;
+  }
+  [purpose='search-and-headline'] {
+    margin-bottom: 64px;
+  }
+  [purpose='page-headline'] {
+    max-width: 662px;
+  }
+  [purpose='platform-filters'] {
+    border-bottom: 1px solid var(--border-border-primary, #E2E4EA);
+    [purpose='platform-filter'] {
+      width: 33%;
+      display: flex;
+      padding: 16px 40px;
+      justify-content: center;
+      align-items: center;
+      img {
+        height: 20px;
+        margin-right: 10px;
+      }
+      p {
+        color: var(--Core-Fleet-Black, #192147);
+        text-align: center;
+        margin-bottom: 0px;
+        /* Body MD (bold) */
+        font-family: Inter;
+        font-size: 16px;
+        font-style: normal;
+        font-weight: 700;
+        line-height: 24px; /* 150% */
+      }
+      &.selected {
+        border-bottom: 2px solid var(--text-text-brand, #192147);
+      }
     }
+
+
+
   }
 
   [purpose='requires-mdm-badge'] {

--- a/website/assets/styles/pages/query-library.less
+++ b/website/assets/styles/pages/query-library.less
@@ -1,43 +1,32 @@
 #query-library {
-  // h2 {
-  //   padding: 0px 30px 0px 30px;
-  // }
 
-  // h5 {
-  //   font-size: 18px;
-  //   font-weight: bold;
-  //   line-height: 25px;
-  // }
-
-  // h6 {
-  //   font-size: 16px;
-  //   line-height: 22px;
-  //   padding: 0px 30px 0px 30px;
-  // }
-
-  // a {
-  //   font-size: 16px;
-  //   color: @core-vibrant-blue;
-  // }
-
-  img {
-    &.logo {
-      height: 16px;
-      width: 16px;
-    }
-    &.search {
-      transform: scale(0.5);
-    }
+  a {
+    color: #515774;
+    font-family: Inter;
+    font-size: 16px;
+    font-style: normal;
+    font-weight: 400;
+    line-height: 24px;
+    text-decoration-line: underline;
   }
 
-  // input {
-  //   &::placeholder {
-  //     font-size: 16px;
-  //   }
-  // }
+  [purpose='policy-search'] {
+    img {
+      height: 16px;
+      margin-right: 8px;
+    }
+    span {
+      padding-left: 15px;
+      padding-right: 0px;
+    }
+    background: #FFF;
+    &::placeholder {
+      font-size: 16px;
+      color: @core-fleet-black-50;
+    }
+  }
   [purpose='page-container'] {
     padding: 64px;
-
   }
   [purpose='page-content'] {
     margin-left: auto;
@@ -49,64 +38,137 @@
   }
   [purpose='page-headline'] {
     max-width: 662px;
+    margin-right: 16px;
   }
   [purpose='platform-filters'] {
-    border-bottom: 1px solid var(--border-border-primary, #E2E4EA);
+    border-bottom: 1px solid #E2E4EA;
+    margin-bottom: 48px;
     [purpose='platform-filter'] {
       width: 33%;
       display: flex;
       padding: 16px 40px;
       justify-content: center;
       align-items: center;
+      cursor: pointer;
       img {
         height: 20px;
         margin-right: 10px;
       }
       p {
-        color: var(--Core-Fleet-Black, #192147);
+        color: #192147;
         text-align: center;
         margin-bottom: 0px;
-        /* Body MD (bold) */
         font-family: Inter;
         font-size: 16px;
         font-style: normal;
-        font-weight: 700;
+        font-weight: 400;
         line-height: 24px; /* 150% */
+        white-space: nowrap;
       }
       &.selected {
         border-bottom: 2px solid var(--text-text-brand, #192147);
+        p {
+          font-weight: 700;
+        }
       }
     }
 
 
 
   }
+  [purpose='policy'] {
+    padding: 32px 0px;
+    border-bottom: 1px solid #E2E4EA;
+  }
+  [purpose='read-more-link'] {
+    // margin-bottom: 16px;
+    span {
+      font-size: 14px;
+      color: ;
+      font-weight: 600;
+    }
+  }
+  [purpose='policy-link'] {
+    color: unset;
+    text-decoration: none;
+
+    &:hover {
+      text-decoration: none;
+    }
+  }
+  [purpose='policy-name-and-description'] {
+    max-width: 663px;
+  }
+  [purpose='policy-name'] {
+    color: #192147;
+    font-size: 20px;
+    font-weight: 800;
+    line-height: 24px;
+    margin-bottom: 8px;
+  }
+  [purpose='policy-description'] {
+    margin-top: 16px;
+    p {
+      color: #515774;
+
+      /* Body SM (FKA Card text) */
+      font-family: Inter;
+      font-size: 14px;
+      font-style: normal;
+      font-weight: 400;
+      line-height: 21px; /* 150% */
+    }
+    // max-width: 663px;
+  }
+  [purpose='contributor-profile-picture'] {
+    width: 24px;
+    height: 24px;
+    margin-right: 6px;
+    border-radius: 50%;
+  }
+  [purpose='contributor-profile-name'] {
+    font-size: 12px;
+    line-height: 18px;
+  }
 
   [purpose='requires-mdm-badge'] {
-    text-transform: uppercase;
-    background: #6A67FE;
+    // text-transform: uppercase;
+    display: flex;
+    padding: 4px 6px;
+    justify-content: center;
+    align-items: center;
     border-radius: 4px;
-    padding: 4px;
+    border: 1px solid #E2E4EA;
+    background: #F9FAFC;
+    color: #192147;
+    font-family: Inter;
+    font-size: 11px;
+    font-style: normal;
+    font-weight: 400;
+    line-height: 11px;
+    height: min-content;
+    white-space: nowrap;
+    // margin-bottom: 16px;
+    width: fit-content;
+  }
+  [purpose='premium-badge'] {
+    // margin-bottom: 16px;
+    margin-right: 16px;
+    border-radius: 4px;
+    border: 1px solid #0587FF;
+    background: #0587FF;
+    display: flex;
+    padding: 4px 6px;
+    justify-content: center;
+    align-items: center;
+    text-transform: uppercase;
     font-weight: 700;
     font-size: 10px;
     line-height: 10px;
-    display: inline;
     color: #FFF;
     text-decoration: none;
+    width: fit-content;
   }
-  [purpose='critical-badge'] {
-    text-transform: uppercase;
-    background: #FF5C83;
-    border-radius: 4px;
-    padding: 4px;
-    font-weight: 700;
-    font-size: 10px;
-    line-height: 10px;
-    display: inline;
-    color: #FFF;
-    text-decoration: none;
-  }
-
   [purpose='query-tag'] {
     font-size: 12px;
     font-weight: 700;
@@ -116,16 +178,6 @@
     color: #515774;
   }
 
-  [purpose='selected-tag'] {
-    border-bottom: 1px solid #e1e4e9;
-    padding: 16px 0;
-    margin-left: 30px;
-    margin-right: 30px;
-    p {
-      margin-bottom: 0;
-      line-height: 18px;
-    }
-  }
   [purpose='query-list-empty-state'] {
     margin-top: 40px;
     margin-right: 30px;
@@ -162,246 +214,31 @@
     }
   }
 
-  .btn-secondary:not(:disabled):not(.disabled):active:focus, .btn-secondary:not(:disabled):not(.disabled).active:focus, .show > .btn-secondary.dropdown-toggle:focus {
-    box-shadow: none;
-  }
 
-  .btn-secondary {
-    color: @core-vibrant-blue;
-    background-color: transparent;
-    border: 0;
-    cursor: pointer;
-    &:focus {
-      border: 0;
-      box-shadow: none;
+  @media (max-width: 991px) {
+    [purpose='page-container'] {
+      padding: 64px 32px;
     }
-  }
-
-  .filters {
-    height: 54px;
-    p {
-      font-size: 16px;
-      line-height: 25px;
+    [purpose='policy-name-and-description'] {
+      max-width: unset;
     }
-  }
-
-  .dropdown-menu {
-    left: 0px;
-    width: 180px;
-    border-radius: 8px;
-    cursor: pointer;
-    z-index: 1;
-
-  }
-  .dropdown-item {
-    padding: 12px;
-    border-radius: 5px;
-    cursor: pointer;
-    &:hover {
-      background-color: lightness(@core-vibrant-blue, 10%);
-      margin-right: 15px;
-    }
-  }
-  .dropdown-toggle::after {
-    margin-left: 4px;
-    vertical-align: 3px;
-    border-top: 5px solid;
-    border-right: 5px solid transparent;
-    border-bottom: 0;
-    border-left: 5px solid transparent;
-  }
-
-  select {
-    color: @core-vibrant-blue;
-    border: 0px;
-    outline: 0;
-    &:focus {
-      border: 0px;
-    }
-    &.select-purpose {
-      width: 102px;
-    }
-    &.select-platform {
-      width: 118px;
-    }
-    &.mobile {
-      height: 50px;
-      width: 100%;
-      margin-right: 0;
-      margin-left: 0;
-      border-radius: 8px;
-      padding: 12px;
-      background: url('/images/chevron-down-9x6@2x.png') no-repeat 95% 50%;
-      background-size: 9px 6px;
-      -webkit-appearance: none;
-    }
-  }
-
-  .library {
-    max-width: 960px;
-    margin-top: 80px;
-    margin-bottom: 0;
-  }
-
-  .description {
-    padding: 0px 30px 0px 30px;
-    p {
-      color: #515774;
-      font-size: 16px;
-      line-height: 25px;
-    }
-    a {
-      outline-bottom: 1px solid #c5c7d1;
-      text-decoration: underline;
-    }
-  }
-
-  .select-mobile-border {
-    height: 52px;
-    width: 100%;
-    margin-right: 0;
-    margin-left: 0;
-    border: 1px solid #c5c7d1;
-    border-radius: 8px;
-  }
-
-  .select-mobile {
-    padding-left: 30px;
-    padding-right: 30px;
-    padding-bottom: 12px;
-  }
-
-  .search-mobile {
-    height: 52px;
-    padding-left: 30px;
-    padding-right: 30px;
-    padding-bottom: 12px;
-  }
-
-  .filter-and-search-bar {
-    padding-left: 45px;
-    padding-right: 45px;
-    margin-bottom: 0;
-    min-height: 40px;
-  }
-
-  .contributors, .platforms {
-    p {
-      font-size: 13px;
-      line-height: 20px;
-    }
-  }
-
-  .row {
-    min-height: 70px;
-    align-items: center;
-  }
-
-  .divider {
-    margin-left: 30px;
-    margin-right: 30px;
-    border-bottom: 1px solid;
-    border-color: #e2e4ea;
-  }
-  .query-card {
-    padding-top: 24px;
-    padding-bottom: 24px;
-  }
-  .card.results {
-    box-shadow: none;
-    border: none;
-    border-radius: 8px;
-    color: #515774;
-    &:hover {
-      .query-card {
-        background-color: #F8F7FF;
-        box-shadow: none;
-        border: none;
-        border-radius: 8px;
-        cursor: pointer;
-      }
-      text-decoration: none;
-    }
-  }
-
-  .card.call-to-action {
-    background-color: @ui-off-white;
-    border-radius: 16px;
-    border-color: @ui-off-white;
-    box-shadow: 0 4px 16px 0 rgba(0, 0, 0, 0.1);
-    margin-bottom: 90px;
-    width: 100%;
-    padding: 40px;
-    p {
-      margin-block-end: 0px;
-    }
-    a {
-      font-size: 16px;
-    }
-  }
-
-  .card-body {
-    padding: 30px;
-    padding-top: 0px;
-    padding-bottom: 0px;
-  }
-
-  .avatar-frame {
-    width: 21px;
-    height: 21px;
-    position: relative;
-    overflow: hidden;
-    border-radius: 50%;
-    &:hover {
-      cursor: pointer;
-    }
-
-    img {
-      display: inline;
-      margin: 0 auto;
-      height: 100%;
-      width: auto;
+    [purpose='read-more-link'] {
+      margin-bottom: 16px;
     }
   }
 
   @media (max-width: 768px) {
-    .library {
-      max-width: 720px;
-      margin-top: 60px;
+    [purpose='policy-search'] {
+      margin-top: 32px;
+      width: 100%;
+      .input-group {
+        width: 100%;
+      }
     }
-    .results {
-      margin-top: 16px;
-    }
+
   }
 
   @media (max-width: 575px) {
-    h2 {
-      font-size: 28px;
-      line-height: 36px;
-    }
 
-    .library {
-      max-width: none;
-      margin-bottom: 0px;
-    }
-
-    [purpose='selected-tag'] {
-      margin-left: 30px;
-      margin-right: 30px;
-      [purpose='query-tag'] {
-      margin-top: 8px;
-      }
-    }
-
-    .results {
-      margin-top: 16px;
-    }
-
-    .contributors, .platforms {
-      p {
-        font-size: 13px;
-        line-height: 20px;
-      }
-    }
   }
 }

--- a/website/config/routes.js
+++ b/website/config/routes.js
@@ -60,8 +60,8 @@ module.exports.routes = {
     action: 'view-query-library',
     locals: {
       currentSection: 'documentation',
-      pageTitleForMeta: 'Queries',
-      pageDescriptionForMeta: 'A growing collection of useful queries for organizations deploying Fleet and osquery.'
+      pageTitleForMeta: 'Controls and policies',
+      pageDescriptionForMeta: 'A growing collection of useful controls and policies for organizations deploying Fleet and osquery.'
     }
   },
 

--- a/website/scripts/build-static-content.js
+++ b/website/scripts/build-static-content.js
@@ -47,6 +47,8 @@ module.exports = {
           let query = yamlDocument.toJSON().spec;
           query.kind = yamlDocument.toJSON().kind;
           query.slug = _.kebabCase(query.name);// « unique slug to use for routing to this query's detail page
+          // Remove the platform name from query names. This allows us to keep queries at their existing URLs while hiding them in the UI.
+          query.name = query.name.replace(/\s\(macOS\)|\(Windows\)|\(Linux\)$/gmi, '');
           if ((query.resolution !== undefined && !_.isString(query.resolution)) || (query.kind !== 'policy' && _.isString(query.resolution))) {
             // console.log(typeof query.resolution);
             queriesWithProblematicResolutions.push(query);

--- a/website/scripts/build-static-content.js
+++ b/website/scripts/build-static-content.js
@@ -48,7 +48,7 @@ module.exports = {
           query.kind = yamlDocument.toJSON().kind;
           query.slug = _.kebabCase(query.name);// « unique slug to use for routing to this query's detail page
           // Remove the platform name from query names. This allows us to keep queries at their existing URLs while hiding them in the UI.
-          query.name = query.name.replace(/\s\(macOS\)|\(Windows\)|\(Linux\)$/gmi, '');
+          query.name = query.name.replace(/\s\(macOS\)|\(Windows\)|\(Linux\)$/i, '');
           if ((query.resolution !== undefined && !_.isString(query.resolution)) || (query.kind !== 'policy' && _.isString(query.resolution))) {
             // console.log(typeof query.resolution);
             queriesWithProblematicResolutions.push(query);

--- a/website/scripts/build-static-content.js
+++ b/website/scripts/build-static-content.js
@@ -48,7 +48,7 @@ module.exports = {
           query.kind = yamlDocument.toJSON().kind;
           query.slug = _.kebabCase(query.name);// « unique slug to use for routing to this query's detail page
           // Remove the platform name from query names. This allows us to keep queries at their existing URLs while hiding them in the UI.
-          query.name = query.name.replace(/\s\(macOS\)|\(Windows\)|\(Linux\)$/i, '');
+          query.name = query.name.replace(/\s\(macOS\)|\(Windows\)|\(Linux\)$/, '');
           if ((query.resolution !== undefined && !_.isString(query.resolution)) || (query.kind !== 'policy' && _.isString(query.resolution))) {
             // console.log(typeof query.resolution);
             queriesWithProblematicResolutions.push(query);

--- a/website/views/pages/query-detail.ejs
+++ b/website/views/pages/query-detail.ejs
@@ -1,83 +1,76 @@
 <div id="query-detail" v-cloak>
-
-  <div style="max-width: 1000px;" class="container-fluid justify-content-center p-0 px-4 pb-5 mb-lg-5 mx-auto">
-    <div class="d-flex flex-column p-0">
-      <a href="/queries" style="font-size: 14px; font-weight: 700; text-decoration: none;" class="pt-4 pt-lg-5">
-        <img style="display: inline-block; width: 6px; height: 9px; transform: rotate(180deg); margin-bottom: 2px;" alt="back arrow" src="/images/chevron-right-6x9@2x.png"/>
-        <span class="ml-1"> Back to queries</span>
-      </a>
-      <div purpose="title-mobile" class="d-flex d-md-none flex-column pb-4 mb-3">
-        <h2 class="pt-4 pb-3 m-0">{{query.name}}</h2>
-        <h6 class="pb-3 m-0">{{query.description ? query.description : '--'}}</h6>
-      </div>
-    </div>
-    <div class="d-flex flex-column flex-md-row justify-content-md-between">
-      <div class="container-fluid col-md-8 d-flex flex-column p-0 pr-md-3">
-        <div purpose="title-widescreen" class="d-none d-md-flex flex-column">
-          <h2 class="pt-4 pb-3 m-0">{{query.name}}</h2>
-          <h6 class="pb-3 m-0">{{query.description ? query.description : '--'}}</h6>
-        </div>
-        <div purpose="body" class="pt-4 pt-md-3 mt-3 mt-md-0">
-          <div purpose="query">
-            <h3 class="pb-4 mb-3 m-0">Query</h3>
-            <pre ><code class="sql hljs">{{query.query ? query.query : '--'}}</code></pre>
+  <div purpose="page-container">
+    <div purpose="page-content">
+      <div purpose="breadcrumbs-and-search" class="d-flex flex-md-row flex-column justify-content-between align-items-md-center align-items-start">
+        <div purpose="breadcrumbs" class="d-flex flex-row align-items-start">
+          <div>
+            <a purpose="breadcrumbs-category" class="text-nowrap" href="/queries">Controls and policies</a>/
           </div>
-          <div purpose="resolution" v-if="query.kind === 'policy' && query.resolution">
-            <h3 class="pt-5 pb-3">Resolve</h3>
-            <p>{{query.resolution}}</p>
+          <div purpose="breadcrumbs-title">
+            <span><%- query.name %></span>
           </div>
         </div>
-      </div>
-      <div purpose="summary-sidebar" class="col-md-4 order-first order-md-last p-0 pl-md-3 pt-md-4">
-        <div class="pb-2">
-          <div class="d-flex flex-md-column justify-content-between justify-content-md-start align-items-center align-items-md-start pb-1 pb-md-3">
-            <h5 class="pb-md-2 m-0">Platforms</h5>
-            <p class="pb-1" v-if="!query.platform || !query.platform.length">--</p>
-            <div purpose="platforms" class="d-flex align-items-center align-items-md-start pb-1" v-else>
-              <img class="d-inline-flex ml-3 ml-md-0 mr-md-3" src="/images/os-macos-dark-24x24@2x.png" alt="macOS" v-if="query.platform.includes('darwin')"/>
-              <img class="d-inline-flex ml-3 ml-md-0 mr-md-3" src="/images/os-windows-dark-24x24@2x.png" alt="Windows" v-if="query.platform.includes('windows')"/>
-              <img class="d-inline-flex ml-3 ml-md-0 mr-md-3" src="/images/os-linux-dark-24x24@2x.png" alt="Linux" v-if="query.platform.includes('linux')"/>
-              <img class="d-inline-flex ml-3 ml-md-0 mr-md-3" src="/images/os-chromeos-dark-24x24@2x.png" alt="ChromeOS" v-if="query.platform.includes('chrome')"/>
-            </div>
-          </div>
-        </div>
-        <div class="border-top py-2 pb-md-4">
-          <div class="d-flex flex-md-column justify-content-between justify-content-md-start align-items-center align-items-md-start pt-md-3">
-            <h5 class="pb-md-2 m-0">Tags</h5>
-            <div :class="[query.tags.length > 2 ? 'mt-1' : '']"  class="d-flex flex-wrap align-items-center justify-content-end justify-content-sm-start">
-              <div purpose="requires-mdm-badge" class="mr-md-1 ml-1 ml-md-0" :class="[query.tags.length > 2 ? 'mb-1' : '']" v-if="query.requiresMdm">requires mdm</div>
-              <div purpose="critical-badge" class="mr-md-1 ml-1 ml-md-0" :class="[query.tags.length > 2 ? 'mb-1' : '']" v-if="query.critical">critical</div>
-              <span class="mb-1" v-if="(!query.tags || !query.tags.length) && !query.critical && !query.requiresMdm">--</span>
-              <div purpose="query-tag" class="mr-md-1 ml-1 ml-md-0" :class="[query.tags.length > 2 ? 'mb-1' : '']" v-for="tag in query.tags">
-                {{tag}}
+<!--         <div purpose="search" id="docsearch-query" class="d-flex">
+          <div purpose="disabled-search" class="d-flex w-100">
+            <div class="input-group">
+              <div class="input-group-prepend">
+                <span class="input-group-text border-0 bg-transparent pl-3" >
+                  <img style="height: 16px; width: 16px;" class="search" alt="search" src="/images/icon-search-16x16@2x.png">
+                </span>
+              </div>
+              <div class="form-control border-0 ">
+              <input class="docsearch-input pr-1"
+                placeholder="Search" aria-label="Search the handbook"
+                />
               </div>
             </div>
           </div>
-        </div>
-        <div class="border-top py-2">
-          <div class="d-flex flex-md-column justify-content-between justify-content-md-start align-items-center align-items-md-start py-1 py-md-3">
-            <h5 class="pb-md-2 m-0">Purpose</h5>
-            <p class="m-0">{{query.kind === 'policy' ? 'Policy' : query.kind === 'query' ? 'Informational' : '--'}}</p>
+        </div> -->
+      </div>
+      <div purpose="policy-details-and-sidebar" class="d-flex flex-lg-row flex-column">
+        <div purpose="policy-details" class="d-flex flex-column">
+          <h2 purpose="policy-name"><%- query.name %></h2>
+          <p purpose="policy-description"><%- query.description %></p>
+          <div purpose="policy-control" v-if="query.control">
+            <h3>Control</h3>
+            <p>Create or edit a configuration profile with the following information:</p>
+            <div  purpose="codeblock">
+              <div purpose="copy-button"></div>
+              <pre><code><%= query.control %></code></pre>
+            </div>
           </div>
-        </div>
-        <div class="border-top py-2 pb-md-4">
-          <div class="d-flex flex-md-column justify-content-between justify-content-md-start align-items-center align-items-md-start py-1 pt-md-3">
-            <h5 class="pb-md-2 m-0">Contributors</h5>
-            <div class="d-flex align-items-center">
-              <span class="mb-1" v-if="!query.contributors || !query.contributors.length">--</span>
-              <div class="d-flex pl-2 pl-md-0 pr-md-2" v-for="contributor in query.contributors">
-                <div purpose="avatar-frame" class="d-flex avatar-frame" @click="clickAvatar(contributor)">
-                  <img alt="a GitHub user avatar" :alt="contributor.name ? contributor.name : contributor.handle" :src="contributor.avatarUrl"/>
-                </div>
-              </div>
+          <div purpose="policy-check">
+            <h3>Check</h3>
+            <p>Use the policy below to verify</p>
+            <div purpose="codeblock">
+              <div purpose="copy-button"></div>
+              <pre><code><%= query.query %></code></pre>
             </div>
           </div>
         </div>
-        <div class="d-md-none border-top"></div>
-        <div class="py-2 pt-md-0">
-          <div class="d-flex flex-md-column justify-content-between justify-content-md-start align-items-center align-items-md-start py-1">
-            <h5 class="d-flex pb-md-2 m-0 mr-3">Contribute to this page</h5>
-            <p class="d-flex m-0"><a class="d-flex text-right m-0" target="_blank" :href="'https://github.com/fleetdm/fleet/edit/main/'+queryLibraryYmlRepoPath">View source</a></p>
+        <div purpose="sidebar-container">
+          <div purpose="right-sidebar" class="d-flex flex-column">
+            <div purpose="policy-platform">
+              <h4>Platform</h4>
+              <img class="d-inline-flex" src="/images/os-macos-dark-24x24@2x.png" alt="macOS" v-if="query.platform.includes('darwin')"/>
+              <img class="d-inline-flex" src="/images/os-windows-dark-24x24@2x.png" alt="Windows" v-if="query.platform.includes('windows')"/>
+              <img class="d-inline-flex" src="/images/os-linux-dark-24x24@2x.png" alt="Linux" v-if="query.platform.includes('linux')"/>
+              <img class="d-inline-flex" src="/images/os-chromeos-dark-24x24@2x.png" alt="ChromeOS" v-if="query.platform.includes('chrome')"/>
+            </div>
+            <div purpose="social-share-buttons" class="d-flex flex-column order-lg-2 order-1">
+              <p><strong>Share</strong></p>
+              <div class="d-flex flex-row">
+                <a :href="`https://news.ycombinator.com/submitlink?u=https://fleetdm.com/queries/${encodeURIComponent(query.slug)}&t=${encodeURIComponent(query.name)}`"><img src="/images/social-share-icon-hacker-news-20x20@2x.png" alt="Share this article on Hacker News"></a>
+                <a :href="`https://www.linkedin.com/sharing/share-offsite/?url=${encodeURIComponent('https://fleetdm.com/queries/'+query.slug)}`"><img src="/images/social-share-icon-linkedin-20x20@2x.png" alt="Share this article on LinkedIn"></a>
+                <a :href="`https://twitter.com/intent/tweet?url=${encodeURIComponent('https://fleetdm.com/queries/'+query.slug)}`"><img src="/images/social-share-icon-twitter-20x20@2x.png" alt="Share this article on Twitter"></a>
+              </div>
+            </div>
+            <div purpose="docs-links" class="order-3">
+              <a href="/docs">Docs</a>
+              <a href="/docs/rest-api">REST API</a>
+              <a href="/guides">Guides</a>
+              <a purpose="edit-button" class="d-inline-block text-nowrap" target="_blank" :href="'https://github.com/fleetdm/fleet/edit/main/'+queryLibraryYmlRepoPath"><img alt="A pencil icon" src="/images/pencil-16x16@2x.png">Edit page</a>
+            </div>
           </div>
         </div>
       </div>

--- a/website/views/pages/query-detail.ejs
+++ b/website/views/pages/query-detail.ejs
@@ -31,20 +31,21 @@
         <div purpose="policy-details" class="d-flex flex-column">
           <h2 purpose="policy-name"><%- query.name %></h2>
           <p purpose="policy-description"><%- query.description %></p>
-          <div purpose="policy-control" v-if="query.control">
+<!--           <div purpose="policy-control" v-if="query.control">
             <h3>Control</h3>
-            <p>Create or edit a configuration profile with the following information:</p>
+            <p v-if="query.controlType === 'profile'">Create or edit a configuration profile with the following information:</p>
+            <p v-if="query.controlType === 'script'">Create or edit the following script and configure it to run when the check fails:</p>
             <div  purpose="codeblock">
               <div purpose="copy-button"></div>
               <pre><code><%= query.control %></code></pre>
             </div>
-          </div>
+          </div> -->
           <div purpose="policy-check">
             <h3>Check</h3>
             <p>Use the policy below to verify</p>
             <div purpose="codeblock">
               <div purpose="copy-button"></div>
-              <pre><code><%= query.query %></code></pre>
+              <pre><code><%- query.query %></code></pre>
             </div>
           </div>
         </div>
@@ -52,10 +53,10 @@
           <div purpose="right-sidebar" class="d-flex flex-column">
             <div purpose="policy-platform">
               <h4>Platform</h4>
-              <img class="d-inline-flex" src="/images/os-macos-dark-24x24@2x.png" alt="macOS" v-if="query.platform.includes('darwin')"/>
-              <img class="d-inline-flex" src="/images/os-windows-dark-24x24@2x.png" alt="Windows" v-if="query.platform.includes('windows')"/>
-              <img class="d-inline-flex" src="/images/os-linux-dark-24x24@2x.png" alt="Linux" v-if="query.platform.includes('linux')"/>
-              <img class="d-inline-flex" src="/images/os-chromeos-dark-24x24@2x.png" alt="ChromeOS" v-if="query.platform.includes('chrome')"/>
+              <img src="/images/os-macos-dark-24x24@2x.png" alt="macOS" v-if="query.platform.includes('darwin')"/>
+              <img src="/images/os-windows-dark-24x24@2x.png" alt="Windows" v-if="query.platform.includes('windows')"/>
+              <img src="/images/os-linux-dark-24x24@2x.png" alt="Linux" v-if="query.platform.includes('linux')"/>
+              <img src="/images/os-chromeos-dark-24x24@2x.png" alt="ChromeOS" v-if="query.platform.includes('chrome')"/>
             </div>
             <div purpose="social-share-buttons" class="d-flex flex-column order-lg-2 order-1">
               <p><strong>Share</strong></p>
@@ -69,7 +70,7 @@
               <a href="/docs">Docs</a>
               <a href="/docs/rest-api">REST API</a>
               <a href="/guides">Guides</a>
-              <a purpose="edit-button" class="d-inline-block text-nowrap" target="_blank" :href="'https://github.com/fleetdm/fleet/edit/main/'+queryLibraryYmlRepoPath"><img alt="A pencil icon" src="/images/pencil-16x16@2x.png">Edit page</a>
+              <a purpose="edit-button" class="d-flex align-items-center text-nowrap" target="_blank" :href="'https://github.com/fleetdm/fleet/edit/main/'+queryLibraryYmlRepoPath"><img alt="A pencil icon" src="/images/pencil-16x16@2x.png">Edit page</a>
             </div>
           </div>
         </div>

--- a/website/views/pages/query-library.ejs
+++ b/website/views/pages/query-library.ejs
@@ -1,6 +1,110 @@
 <div id="query-library" v-cloak>
 
-  <div class="d-flex justify-content-center">
+
+  <div purpose="page-container">
+    <div purpose="page-content">
+
+      <div purpose="search-and-headline" class="d-flex flex-sm-row flex-column justify-content-between">
+        <div purpose="page-headline" class="d-flex flex-column">
+          <h2>Controls and policies</h2>
+          <p>Fleet's controls and policies library includes a growing collection of policies, OS settings, and scripts for macOS, Windows, and Linux.</p>
+          <p>Contributions welcome <a target="_blank" href="https://github.com/fleetdm/fleet/blob/main/docs/01-Using-Fleet/standard-query-library/standard-query-library.yml">over on GitHub.</a></p>
+        </div>
+        <div class="d-flex flex-column">
+          <div class="input-group search">
+            <div class="input-group-prepend border-right-0 search">
+              <span class="input-group-text bg-transparent border-right-0 pl-2 pr-1"><img class="search"
+                  alt="search" src="/images/icon-search-16x16@2x.png"></span>
+            </div>
+            <input class="form-control border-left-0 px-0" placeholder="Search queries" aria-label="Search queries"
+              v-model="inputTextValue" @keydown.self="delayInput(setSearchString, 400, 'defaultTimer')()" />
+          </div>
+        </div>
+      </div>
+      <div purpose="platform-filters" class="d-flex flex-row justify-content-center">
+        <div purpose="platform-filter" :class="[selectedPlatform === 'macos' ? 'selected' : '']" class="d-flex flex-row justify-content-center align-items-center" @click="clickSelectPlatform('macos')">
+          <p>
+            <img src="/images/os-macos-dark-24x24@2x.png" alt="macOS" class="d-inline">
+            <span class="d-none d-sm-inline">Apple</span>
+          </p>
+        </div>
+        <div purpose="platform-filter":class="[selectedPlatform === 'linux' ? 'selected' : '']" class="d-flex flex-row justify-content-center align-items-center" @click="clickSelectPlatform('linux')">
+          <p>
+            <img src="/images/os-linux-dark-24x24@2x.png" alt="Linux" class="d-inline">
+            <span class="d-none d-sm-inline">Linux</span>
+          </p>
+        </div>
+        <div purpose="platform-filter" :class="[selectedPlatform === 'windows' ? 'selected' : '']" class="d-flex flex-row justify-content-center align-items-center" @click="clickSelectPlatform('windows')">
+          <p>
+            <img src="/images/os-windows-dark-24x24@2x.png" alt="Windows" class="d-inline">
+            <span class="d-none d-sm-inline">Windows</span>
+          </p>
+        </div>
+      </div>
+      <div purpose="selected-queries">
+        <div v-if="selectedPlatform === 'macos'">
+        <% for(let policy of macOsPolicies) {%>
+          <div purpose="policy" class="d-flex flex-row justify-content-between">
+            <div class="d-flex flex-column">
+              <div class="d-flex flex-row">
+                <p><%- policy.name %></p>
+                <% if(policy.tags.includes('premium')) {%><div>PREMIUM</div><% } %>
+                <% if(policy.requiresMdm) {%><div purpose="requires-mdm-badge">MDM required</div><% } %>
+              </div>
+              <p><%- policy.description %></p>
+            </div>
+          </div>
+        <% } %>
+        </div>
+        <div v-else-if="selectedPlatform === 'linux'">
+        <% for(let policy of linuxPolicies) {%>
+          <div purpose="policy" class="d-flex flex-row justify-content-between">
+            <div class="d-flex flex-column">
+              <div class="d-flex flex-row">
+                <p><%- policy.name %></p>
+                <% if(policy.tags.includes('premium')) {%><div>PREMIUM</div><% } %>
+                <% if(policy.requiresMdm) {%><div purpose="requires-mdm-badge">MDM required</div><% } %>
+              </div>
+              <p><%- policy.description %></p>
+            </div>
+          </div>
+        <% } %>
+        </div>
+        <div v-else-if="selectedPlatform === 'windows'">
+        <% for(let policy of windowsPolicies) {%>
+          <div purpose="policy" class="d-flex flex-row justify-content-between">
+            <div class="d-flex flex-column">
+              <div class="d-flex flex-row">
+                <p><%- policy.name %></p>
+                <% if(policy.tags.includes('premium')) {%><div>PREMIUM</div><% } %>
+                <% if(policy.requiresMdm) {%><div purpose="requires-mdm-badge">MDM required</div><% } %>
+              </div>
+              <p><%- policy.description %></p>
+            </div>
+          </div>
+        <% } %>
+        </div>
+
+
+      </div>
+
+
+
+
+
+    </div>
+  </div>
+</div>
+
+
+
+
+
+
+
+
+
+ <!--  <div class="d-flex justify-content-center">
     <div class="container justify-content-center library">
       <h2 class="mb-3">
         <%= ['eo-it', 'mdm'].includes(primaryBuyingSituation) ? 'Device health checks' : 'Built-in queries' %>
@@ -162,7 +266,6 @@
         </p>
       </div>
     </div>
-  </div>
+  </div> -->
 
-</div>
 <%- /* Expose server-rendered data as window.SAILS_LOCALS :: */ exposeLocalsToBrowser() %>

--- a/website/views/pages/query-library.ejs
+++ b/website/views/pages/query-library.ejs
@@ -1,271 +1,186 @@
 <div id="query-library" v-cloak>
 
-
   <div purpose="page-container">
     <div purpose="page-content">
-
-      <div purpose="search-and-headline" class="d-flex flex-sm-row flex-column justify-content-between">
+      <div purpose="search-and-headline" class="d-flex flex-md-row flex-column justify-content-between align-items-md-center align-items-start">
         <div purpose="page-headline" class="d-flex flex-column">
           <h2>Controls and policies</h2>
           <p>Fleet's controls and policies library includes a growing collection of policies, OS settings, and scripts for macOS, Windows, and Linux.</p>
           <p>Contributions welcome <a target="_blank" href="https://github.com/fleetdm/fleet/blob/main/docs/01-Using-Fleet/standard-query-library/standard-query-library.yml">over on GitHub.</a></p>
         </div>
-        <div class="d-flex flex-column">
+        <div purpose="policy-search" class="d-flex flex-column">
           <div class="input-group search">
             <div class="input-group-prepend border-right-0 search">
-              <span class="input-group-text bg-transparent border-right-0 pl-2 pr-1"><img class="search"
-                  alt="search" src="/images/icon-search-16x16@2x.png"></span>
+              <span class="input-group-text bg-transparent border-right-0">
+                <img class="search"
+                  alt="search" src="/images/icon-search-16x16@2x.png">
+                </span>
             </div>
-            <input class="form-control border-left-0 px-0" placeholder="Search queries" aria-label="Search queries"
+            <input class="form-control border-left-0 px-0" placeholder="Search" aria-label="Search queries"
               v-model="inputTextValue" @keydown.self="delayInput(setSearchString, 400, 'defaultTimer')()" />
           </div>
         </div>
       </div>
       <div purpose="platform-filters" class="d-flex flex-row justify-content-center">
         <div purpose="platform-filter" :class="[selectedPlatform === 'macos' ? 'selected' : '']" class="d-flex flex-row justify-content-center align-items-center" @click="clickSelectPlatform('macos')">
-          <p>
-            <img src="/images/os-macos-dark-24x24@2x.png" alt="macOS" class="d-inline">
-            <span class="d-none d-sm-inline">Apple</span>
+          <p class="d-flex align-items-center">
+          <img src="/images/os-macos-dark-24x24@2x.png" alt="macOS" class="d-inline">
+          <span class="d-none d-sm-inline">Apple</span>
           </p>
         </div>
-        <div purpose="platform-filter":class="[selectedPlatform === 'linux' ? 'selected' : '']" class="d-flex flex-row justify-content-center align-items-center" @click="clickSelectPlatform('linux')">
-          <p>
+        <div purpose="platform-filter" :class="[selectedPlatform === 'linux' ? 'selected' : '']" class="d-flex flex-row justify-content-center align-items-center" @click="clickSelectPlatform('linux')">
+          <p class="d-flex align-items-center">
             <img src="/images/os-linux-dark-24x24@2x.png" alt="Linux" class="d-inline">
             <span class="d-none d-sm-inline">Linux</span>
           </p>
         </div>
         <div purpose="platform-filter" :class="[selectedPlatform === 'windows' ? 'selected' : '']" class="d-flex flex-row justify-content-center align-items-center" @click="clickSelectPlatform('windows')">
-          <p>
+          <p class="d-flex align-items-center">
             <img src="/images/os-windows-dark-24x24@2x.png" alt="Windows" class="d-inline">
             <span class="d-none d-sm-inline">Windows</span>
           </p>
         </div>
       </div>
       <div purpose="selected-queries">
-        <div v-if="selectedPlatform === 'macos'">
-        <% for(let policy of macOsPolicies) {%>
-          <div purpose="policy" class="d-flex flex-row justify-content-between">
-            <div class="d-flex flex-column">
-              <div class="d-flex flex-row">
-                <p><%- policy.name %></p>
-                <% if(policy.tags.includes('premium')) {%><div>PREMIUM</div><% } %>
-                <% if(policy.requiresMdm) {%><div purpose="requires-mdm-badge">MDM required</div><% } %>
+        <div v-if="selectedPlatform === 'macos' && !searchString">
+          <% // Unfiltered macOS policies (server-side-rendered)
+            for(let policy of macOsPolicies) {
+          %>
+          <div purpose="policy" class="d-flex flex-lg-row flex-column justify-content-between">
+            <div purpose="policy-name-and-description" class="d-flex flex-column">
+              <div class="d-flex flex-column">
+                <p purpose="policy-name"><%- policy.name %></p>
+                <% if(policy.tags.includes('premium')) {%><div purpose="premium-badge">PREMIUM</div><% } %>
+                <% if(policy.requiresMdm) {%><div purpose="requires-mdm-badge">mdm-required</div><% } %>
               </div>
-              <p><%- policy.description %></p>
+              <div purpose="policy-description"><p><%- policy.description %></p></div>
+              <div purpose="read-more-link"><animated-arrow-button arrow-color="#192147" href="/queries/<%- policy.slug%>">Read more</animated-arrow-button></div>
+            </div>
+            <div class="d-flex flex-column justify-content-center">
+              <div class="d-flex flex-row">
+                <a purpose="policy-link" href="https://github.com/<%- policy.contributors[0].handle %>" class="d-flex align-items-center">
+                  <img alt="Contributor's GitHub profile picture" purpose="contributor-profile-picture" src="https://github.com/<%- policy.contributors[0].handle %>.png?size=200">
+                  <p purpose="contributor-profile-name" class="mb-0"><%= policy.contributors[0].name %></p></a>
+              </div>
             </div>
           </div>
-        <% } %>
+          <% } %>
+        </div>
+        <div v-else-if="selectedPlatform === 'macos'">
+          <% // Filtered macOS policies %>
+          <div purpose="policy" class="d-flex flex-lg-row flex-column justify-content-between" v-for="policy in queriesList" v-if="policy.platform === 'darwin'">
+            <div purpose="policy-name-and-description" class="d-flex flex-column">
+              <div class="d-flex flex-column">
+                <p purpose="policy-name">{{policy.name}}</p>
+                <div purpose="premium-badge" v-if="policy.tags.includes('premium')">PREMIUM</div>
+                <div purpose="requires-mdm-badge" v-if="policy.requiresMdm">mdm-required</div>
+              </div>
+              <div purpose="policy-description"><p>{{policy.description}}</p></div>
+              <div purpose="read-more-link"><animated-arrow-button arrow-color="#192147" :href="'/queries/'+policy.slug">Read more</animated-arrow-button></div>
+            </div>
+            <div class="d-flex flex-column justify-content-center">
+              <div class="d-flex flex-row">
+                <a purpose="policy-link" :href="'https://github.com/'+policy.contributors[0].handle" class="d-flex align-items-center">
+                <img alt="Contributor's GitHub profile picture" purpose="contributor-profile-picture" :src="'https://github.com/'+policy.contributors[0].handle+'.png?size=200'">
+                <p purpose="contributor-profile-name" class="mb-0">{{policy.contributors[0].name}}</p></a>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div v-else-if="selectedPlatform === 'linux' && !searchString">
+          <% // Unfiltered Linux policies (server-side-rendered)
+            for(let policy of linuxPolicies) {
+          %>
+          <div purpose="policy" class="d-flex flex-lg-row flex-column justify-content-between">
+            <div purpose="policy-name-and-description" class="d-flex flex-column">
+              <div class="d-flex flex-column">
+                <p purpose="policy-name"><%- policy.name %></p>
+                <% if(policy.tags.includes('premium')) {%><div purpose="premium-badge">PREMIUM</div><% } %>
+                <% if(policy.requiresMdm) {%><div purpose="requires-mdm-badge">mdm-required</div><% } %>
+              </div>
+              <div purpose="policy-description"><p><%- policy.description %></p></div>
+              <div purpose="read-more-link"><animated-arrow-button arrow-color="#192147" href="/queries/<%- policy.slug%>">Read more</animated-arrow-button></div>
+            </div>
+            <div class="d-flex flex-column justify-content-center">
+              <div class="d-flex flex-row">
+                <a purpose="policy-link" href="https://github.com/<%- policy.contributors[0].handle %>" class="d-flex align-items-center">
+                  <img alt="Contributor's GitHub profile picture" purpose="contributor-profile-picture" src="https://github.com/<%- policy.contributors[0].handle %>.png?size=200">
+                  <p purpose="contributor-profile-name" class="mb-0"><%= policy.contributors[0].name %></p></a>
+              </div>
+            </div>
+          </div>
+          <% } %>
         </div>
         <div v-else-if="selectedPlatform === 'linux'">
-        <% for(let policy of linuxPolicies) {%>
-          <div purpose="policy" class="d-flex flex-row justify-content-between">
-            <div class="d-flex flex-column">
-              <div class="d-flex flex-row">
-                <p><%- policy.name %></p>
-                <% if(policy.tags.includes('premium')) {%><div>PREMIUM</div><% } %>
-                <% if(policy.requiresMdm) {%><div purpose="requires-mdm-badge">MDM required</div><% } %>
+          <% // Filtered Linux policies %>
+          <div purpose="policy" class="d-flex flex-lg-row flex-column justify-content-between" v-for="policy in queriesList" v-if="policy.platform === 'linux'">
+            <div purpose="policy-name-and-description" class="d-flex flex-column">
+              <div class="d-flex flex-column">
+                <p purpose="policy-name">{{policy.name}}</p>
+                <div purpose="premium-badge" v-if="policy.tags.includes('premium')">PREMIUM</div>
+                <div purpose="requires-mdm-badge" v-if="policy.requiresMdm">mdm-required</div>
               </div>
-              <p><%- policy.description %></p>
+              <div purpose="policy-description"><p>{{policy.description}}</p></div>
+              <div purpose="read-more-link"><animated-arrow-button arrow-color="#192147" :href="'/queries/'+policy.slug">Read more</animated-arrow-button></div>
+            </div>
+            <div class="d-flex flex-column justify-content-center">
+              <div class="d-flex flex-row">
+                <a purpose="policy-link" :href="'https://github.com/'+policy.contributors[0].handle" class="d-flex align-items-center">
+                <img alt="Contributor's GitHub profile picture" purpose="contributor-profile-picture" :src="'https://github.com/'+policy.contributors[0].handle+'.png?size=200'">
+                <p purpose="contributor-profile-name" class="mb-0">{{policy.contributors[0].name}}</p></a>
+              </div>
             </div>
           </div>
-        <% } %>
+        </div>
+        <div v-else-if="selectedPlatform === 'windows' && !searchString">
+          <% // Unfiltered Windows policies (server-side-rendered)
+            for(let policy of windowsPolicies) {
+          %>
+          <div purpose="policy" class="d-flex flex-lg-row flex-column justify-content-between">
+            <div purpose="policy-name-and-description" class="d-flex flex-column">
+              <div class="d-flex flex-column">
+                <p purpose="policy-name"><%- policy.name %></p>
+                <% if(policy.tags.includes('premium')) {%><div purpose="premium-badge">PREMIUM</div><% } %>
+                <% if(policy.requiresMdm) {%><div purpose="requires-mdm-badge">mdm-required</div><% } %>
+              </div>
+              <div purpose="policy-description"><p><%- policy.description %></p></div>
+              <div purpose="read-more-link"><animated-arrow-button arrow-color="#192147" href="/queries/<%- policy.slug%>">Read more</animated-arrow-button></div>
+            </div>
+            <div class="d-flex flex-column justify-content-center">
+              <div class="d-flex flex-row">
+                <a purpose="policy-link" href="https://github.com/<%- policy.contributors[0].handle %>" class="d-flex align-items-center">
+                  <img alt="Contributor's GitHub profile picture" purpose="contributor-profile-picture" src="https://github.com/<%- policy.contributors[0].handle %>.png?size=200">
+                  <p purpose="contributor-profile-name" class="mb-0"><%= policy.contributors[0].name %></p></a>
+              </div>
+            </div>
+          </div>
+          <% } %>
         </div>
         <div v-else-if="selectedPlatform === 'windows'">
-        <% for(let policy of windowsPolicies) {%>
-          <div purpose="policy" class="d-flex flex-row justify-content-between">
-            <div class="d-flex flex-column">
-              <div class="d-flex flex-row">
-                <p><%- policy.name %></p>
-                <% if(policy.tags.includes('premium')) {%><div>PREMIUM</div><% } %>
-                <% if(policy.requiresMdm) {%><div purpose="requires-mdm-badge">MDM required</div><% } %>
+          <% // Filtered windows policies %>
+          <div purpose="policy" class="d-flex flex-lg-row flex-column justify-content-between" v-for="policy in queriesList" v-if="policy.platform === 'windows'">
+            <div purpose="policy-name-and-description" class="d-flex flex-column">
+              <div class="d-flex flex-column">
+                <p purpose="policy-name">{{policy.name}}</p>
+                <div purpose="premium-badge" v-if="policy.tags.includes('premium')">PREMIUM</div>
+                <div purpose="requires-mdm-badge" v-if="policy.requiresMdm">mdm-required</div>
               </div>
-              <p><%- policy.description %></p>
+              <div purpose="policy-description"><p>{{policy.description}}</p></div>
+              <div purpose="read-more-link"><animated-arrow-button arrow-color="#192147" :href="'/queries/'+policy.slug">Read more</animated-arrow-button></div>
+            </div>
+            <div class="d-flex flex-column justify-content-center">
+              <div class="d-flex flex-row">
+                <a purpose="policy-link" :href="'https://github.com/'+policy.contributors[0].handle" class="d-flex align-items-center">
+                <img alt="Contributor's GitHub profile picture" purpose="contributor-profile-picture" :src="'https://github.com/'+policy.contributors[0].handle+'.png?size=200'">
+                <p purpose="contributor-profile-name" class="mb-0">{{policy.contributors[0].name}}</p></a>
+              </div>
             </div>
           </div>
-        <% } %>
         </div>
-
-
       </div>
-
-
-
-
-
     </div>
   </div>
 </div>
 
-
-
-
-
-
-
-
-
- <!--  <div class="d-flex justify-content-center">
-    <div class="container justify-content-center library">
-      <h2 class="mb-3">
-        <%= ['eo-it', 'mdm'].includes(primaryBuyingSituation) ? 'Device health checks' : 'Built-in queries' %>
-
-      </h2>
-      <p class="pb-3 description">Fleet's standard query library includes a growing collection of useful queries for organizations deploying Fleet and osquery. Want to add your own query? Please contribute <a target="_blank" href="https://github.com/fleetdm/fleet/edit/main/docs/01-Using-Fleet/standard-query-library/standard-query-library.yml">over on GitHub</a>.</p>
-      <div class="p-0 m-0">
-        <div class="d-md-none">
-          <div class="d-flex">
-            <div class="input-group search-mobile">
-              <div class="input-group-prepend border-right-0">
-                <span class="input-group-text bg-transparent border-right-0 pl-2 pr-1"><img class="search" alt="search"
-                    src="/images/icon-search-16x16@2x.png"></span>
-              </div>
-              <input class="form-control border-left-0 px-0" placeholder="Search queries" aria-label="Search queries"
-                v-model="inputTextValue" @keydown.self="delayInput(setSearchString, 400, 'defaultTimer')()" />
-            </div>
-          </div>
-          <div class="d-flex select-mobile">
-            <div class="select-mobile-border">
-              <select class="select-purpose mobile font-weight-bold" v-model="selectedKind">
-                <option value="all queries" selected>All queries</option>
-                <option value="query">Informational queries</option>
-                <option value="policy">Policies</option>
-              </select>
-            </div>
-          </div>
-          <div class="d-flex select-mobile">
-            <div class="select-mobile-border">
-              <select class="select-purpose mobile font-weight-bold" v-model="selectedPlatform">
-                <option value="all platforms" selected>All platforms</option>
-                <option value="darwin">macOS</option>
-                <option value="windows">Windows</option>
-                <option value="linux">Linux</option>
-                <option value="chrome">ChromeOS</option>
-              </select>
-            </div>
-          </div>
-        </div>
-
-        <div class="filter-and-search-bar d-none d-md-flex row align-items-center justify-content-between mb-3">
-          <div class="d-flex px-0 align-items-center filters">
-            <div class="d-flex">
-              <div class="dropdown flex-wrap filter purpose">
-                <p class="d-inline-flex mb-0 pr-1">Show</p>
-                <button class="btn btn-secondary btn-sm dropdown-toggle p-0" type="button"
-                  id="dropdownMenuSelectPurpose" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                  {{ selectedKind === 'query' ? 'informational' : selectedKind === 'policy' ? 'policies' : 'all queries'}}
-                </button>
-                <div class="dropdown-menu p-2" aria-labelledby="dropdownMenuSelectPurpose">
-                  <button class="dropdown-item" type="button"
-                    @click="clickSelectKind('all queries')">all queries</button>
-                    <button class="dropdown-item" type="button"
-                    @click="clickSelectKind('query')">informational</button>
-                  <button class="dropdown-item" type="button"
-                    @click="clickSelectKind('policy')">policies</button>
-                </div>
-              </div>
-            </div>
-            <div class="d-flex">
-              <div class="dropdown d-flex flex-wrap filter platform">
-                <p class="d-inline-flex flex-wrap px-2 mb-0">compatible with</p>
-                <button class="btn btn-secondary btn-sm dropdown-toggle p-0" type="button"
-                  id="dropdownMenuSelectPlatform" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                  {{selectedPlatform === 'windows' ? 'Windows' : selectedPlatform === 'darwin' ? 'macOS' : selectedPlatform === 'linux' ? 'Linux' : selectedPlatform === 'chrome' ? 'ChromeOS' : selectedPlatform}}
-                </button>
-                <div class="dropdown-menu p-2" aria-labelledby="dropdownMenuSelectPlatform">
-                  <button class="dropdown-item" type="button" @click="clickSelectPlatform('all platforms')">all platforms</button>
-                  <button class="dropdown-item" type="button" @click="clickSelectPlatform('darwin')">macOS</button>
-                  <button class="dropdown-item" type="button"
-                    @click="clickSelectPlatform('windows')">Windows</button>
-                  <button class="dropdown-item" type="button" @click="clickSelectPlatform('linux')">Linux</button>
-                  <button class="dropdown-item" type="button" @click="clickSelectPlatform('chrome')">ChromeOS</button>
-                </div>
-              </div>
-            </div>
-          </div>
-          <div class="d-flex px-0">
-            <div class="d-flex justify-content-end">
-              <div class="input-group search">
-                <div class="input-group-prepend border-right-0 search">
-                  <span class="input-group-text bg-transparent border-right-0 pl-2 pr-1"><img class="search"
-                      alt="search" src="/images/icon-search-16x16@2x.png"></span>
-                </div>
-                <input class="form-control border-left-0 px-0" placeholder="Search queries" aria-label="Search queries"
-                  v-model="inputTextValue" @keydown.self="delayInput(setSearchString, 400, 'defaultTimer')()" />
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-      <div class="results">
-        <div purpose="selected-tag" v-if="selectedTag">
-          <p>Showing {{ selectedKind === 'query' ? 'informational queries' : selectedKind === 'policy' ? 'policies' : 'all queries'}} for <span purpose="query-tag" class="d-inline-block" style="cursor: pointer;" @click="clickSelectTag('')">{{selectedTag}}<span style="color: #8b8fa2;" class="fa fa-times-circle pl-2"></span></span></p>
-        </div>
-        <div class="category__informational">
-          <div v-for="query of queriesList">
-            <a class="card results" :href="'/queries/'+query.slug">
-              <div class="card-body">
-                <div class="row justify-content-between align-items-center query-card">
-                  <div class="col-12">
-                    <div class="d-flex flex-row align-items-center flex-wrap">
-                      <h5 class="card-title m-0 mb-1 mr-2">{{query.name}}</h5>
-                      <span purpose="critical-badge" class="mr-2" v-if="query.critical">Critical</span>
-                      <span purpose="requires-mdm-badge" class="mr-2" v-if="query.requiresMdm">Requires MDM</span>
-                      <span class="mr-2 my-sm-0 my-1 text-nowrap d-inline-flex" purpose="query-tag" v-for="tag in query.tags" @click.stop.prevent="clickSelectTag(tag)">{{tag}}</span>
-                    </div>
-                  </div>
-                  <div class="col-sm-9 col-md-9">
-                    <p class="font-italic mb-1 p-0 description">{{query.description}}</p>
-                    <div class="contributors" v-if="query.contributors && query.contributors.length">
-                      <div class="d-flex mb-2 mb-sm-1 align-items-center">
-                        <div v-for="contributor in query.contributors">
-                          <div class="d-flex m-1 avatar-frame" @click.stop="clickAvatar(contributor)">
-                            <img alt="a GitHub user avatar" :alt="contributor" :src="contributor.avatarUrl" />
-                          </div>
-                        </div>
-                        <p class="mb-0 ml-1">contributed by {{getContributorsString(query.contributors)}}</p>
-                      </div>
-                    </div>
-                  </div>
-                  <div class="col-sm-3 col-md-auto align-self-start">
-                    <div class="text-sm-right m-0">
-                      <img class="d-inline-flex mr-1 mr-sm-0 ml-sm-1 ml-md-2 logo"
-                        src="/images/os-macos-dark-24x24@2x.png" alt="macOS"
-                        v-if="query.platform.includes('darwin')" />
-                      <img class="d-inline-flex mr-1 mr-sm-0 ml-sm-1 ml-md-2 logo"
-                        src="/images/os-windows-dark-24x24@2x.png" alt="Windows"
-                        v-if="query.platform.includes('windows')" />
-                      <img class="d-inline-flex mr-1 mr-ms-0 ml-sm-1 ml-md-2 logo"
-                        src="/images/os-linux-dark-24x24@2x.png" alt="Linux"
-                        v-if="query.platform.includes('linux')" />
-                      <img class="d-inline-flex mr-1 mr-ms-0 ml-sm-1 ml-md-2 logo"
-                        src="/images/os-chromeos-dark-24x24@2x.png" alt="Linux"
-                        v-if="query.platform.includes('chrome')" />
-                    </div>
-                  </div>
-                </div>
-              </div>
-              <div class="divider"></div>
-
-            </a>
-          </div>
-          <div purpose="query-list-empty-state" v-if="queriesList.length === 0">
-            <p class="mb-0">There are no results that match your filters. <a target="_blank" href="https://github.com/fleetdm/fleet/edit/main/docs/01-Using-Fleet/standard-query-library/standard-query-library.yml">Everyone can contribute</a>.</p>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-  <div class="d-flex justify-content-center p-3">
-    <div class="card call-to-action col-6-grow my-5 library">
-      <div class="card-body px-0">
-        <h3 class="mb-3">Contributors</h3>
-        <p><strong>Want to add your own query?</strong> Please submit a pull request
-          <a target="_blank" href="https://github.com/fleetdm/fleet/edit/main/docs/01-Using-Fleet/standard-query-library/standard-query-library.yml">
-            over on GitHub
-          </a>.
-        </p>
-      </div>
-    </div>
-  </div> -->
 
 <%- /* Expose server-rendered data as window.SAILS_LOCALS :: */ exposeLocalsToBrowser() %>


### PR DESCRIPTION
Changes:
- Standard query library:
   - Added three policies to the Standard query library (tagged as premium)
   - Changed the `kind` of the "Identify Apple development secrets (macOS)" query to `policy` because it is an informational query (It returns rows of results rather than 1 or 0) and removed its `resolution` value
 - Updated the build-static-content script to remove platform names from the end of query names (e.g., (macOS)). This is done to keep the URLs for queries the same while hiding them in the UI
 - Updated the layout of the queries page to match the latest wireframes and updated the page to only show policies
 - Updated the styles and layout of the queries-details page.