### PR TITLE
Fix path resolution for installer queries and scripts to always be relative to where the query file or script is referenced

### DIFF
--- a/changes/22187-gitops-software-relative-paths
+++ b/changes/22187-gitops-software-relative-paths
@@ -1,1 +1,1 @@
-* GitOps: Fixed path resolution for installer queries and scripts to always be relative to where the query file or script is referenced
+* GitOps: Fixed path resolution for installer queries and scripts to always be relative to where the query file or script is referenced. This change breaks existing YAML files that had to account for previous inconsistent behavior (e.g. installers in a subdirectory referencing scripts elsewhere).

--- a/changes/22187-gitops-software-relative-paths
+++ b/changes/22187-gitops-software-relative-paths
@@ -1,0 +1,1 @@
+* GitOps: Fixed path resolution for installer queries and scripts to always be relative to where the query file or script is referenced

--- a/cmd/fleetctl/gitops_test.go
+++ b/cmd/fleetctl/gitops_test.go
@@ -1875,6 +1875,8 @@ func TestGitOpsTeamSofwareInstallers(t *testing.T) {
 		// commenting out, results in the process getting killed on CI and on some machines
 		// {"testdata/gitops/team_software_installer_too_large.yml", "The maximum file size is 3 GB"},
 		{"testdata/gitops/team_software_installer_valid.yml", ""},
+		{"testdata/gitops/team_software_installer_subdir.yml", ""},
+		{"testdata/gitops/subdir/team_software_installer_valid.yml", ""},
 		{"testdata/gitops/team_software_installer_valid_apply.yml", ""},
 		{"testdata/gitops/team_software_installer_pre_condition_multiple_queries.yml", "should have only one query."},
 		{"testdata/gitops/team_software_installer_pre_condition_multiple_queries_apply.yml", "should have only one query."},
@@ -1957,6 +1959,8 @@ func TestGitOpsNoTeamSoftwareInstallers(t *testing.T) {
 		// commenting out, results in the process getting killed on CI and on some machines
 		// {"testdata/gitops/no_team_software_installer_too_large.yml", "The maximum file size is 3 GB"},
 		{"testdata/gitops/no_team_software_installer_valid.yml", ""},
+		{"testdata/gitops/no_team_software_installer_subdir.yml", ""},
+		{"testdata/gitops/subdir/no_team_software_installer_valid.yml", ""},
 		{"testdata/gitops/no_team_software_installer_pre_condition_multiple_queries.yml", "should have only one query."},
 		{"testdata/gitops/no_team_software_installer_pre_condition_not_found.yml", "no such file or directory"},
 		{"testdata/gitops/no_team_software_installer_install_not_found.yml", "no such file or directory"},

--- a/cmd/fleetctl/testdata/gitops/lib/software_ruby.yml
+++ b/cmd/fleetctl/testdata/gitops/lib/software_ruby.yml
@@ -1,9 +1,9 @@
 url: ${SOFTWARE_INSTALLER_URL}/ruby.deb
 install_script:
-  path: lib/install_ruby.sh
+  path: ./install_ruby.sh
 pre_install_query:
-  path: lib/query_ruby.yml
+  path: ./query_ruby.yml
 post_install_script:
-  path: lib/post_install_ruby.sh
+  path: ./post_install_ruby.sh
 uninstall_script:
-  path: lib/uninstall_ruby.sh
+  path: ./uninstall_ruby.sh

--- a/cmd/fleetctl/testdata/gitops/no_team_software_installer_subdir.yml
+++ b/cmd/fleetctl/testdata/gitops/no_team_software_installer_subdir.yml
@@ -1,0 +1,6 @@
+name: No team
+controls:
+policies:
+software:
+  packages:
+    - path: subdir/installer.yml

--- a/cmd/fleetctl/testdata/gitops/subdir/installer.yml
+++ b/cmd/fleetctl/testdata/gitops/subdir/installer.yml
@@ -1,0 +1,9 @@
+url: ${SOFTWARE_INSTALLER_URL}/ruby.deb
+install_script:
+  path: ../lib/install_ruby.sh
+pre_install_query:
+  path: ../lib/query_ruby.yml
+post_install_script:
+  path: ../lib/post_install_ruby.sh
+uninstall_script:
+  path: ../lib/uninstall_ruby.sh

--- a/cmd/fleetctl/testdata/gitops/subdir/no_team_software_installer_valid.yml
+++ b/cmd/fleetctl/testdata/gitops/subdir/no_team_software_installer_valid.yml
@@ -1,0 +1,16 @@
+name: No team
+controls:
+policies:
+software:
+  packages:
+    - url: ${SOFTWARE_INSTALLER_URL}/ruby.deb
+      install_script:
+        path: ../lib/install_ruby.sh
+      pre_install_query:
+        path: ../lib/query_ruby.yml
+      post_install_script:
+        path: ../lib/post_install_ruby.sh
+      uninstall_script:
+        path: ../lib/uninstall_ruby.sh
+    - url: ${SOFTWARE_INSTALLER_URL}/other.deb
+      self_service: true

--- a/cmd/fleetctl/testdata/gitops/subdir/team_software_installer_valid.yml
+++ b/cmd/fleetctl/testdata/gitops/subdir/team_software_installer_valid.yml
@@ -1,0 +1,27 @@
+name: "${TEST_TEAM_NAME}"
+team_settings:
+  secrets:
+    - secret: "ABC"
+  features:
+    enable_host_users: true
+    enable_software_inventory: true
+  host_expiry_settings:
+    host_expiry_enabled: true
+    host_expiry_window: 30
+agent_options:
+controls:
+policies:
+queries:
+software:
+  packages:
+    - url: ${SOFTWARE_INSTALLER_URL}/ruby.deb
+      install_script:
+        path: ../lib/install_ruby.sh
+      pre_install_query:
+        path: ../lib/query_ruby.yml
+      post_install_script:
+        path: ../lib/post_install_ruby.sh
+      uninstall_script:
+        path: ../lib/uninstall_ruby.sh
+    - url: ${SOFTWARE_INSTALLER_URL}/other.deb
+      self_service: true

--- a/cmd/fleetctl/testdata/gitops/team_software_installer_subdir.yml
+++ b/cmd/fleetctl/testdata/gitops/team_software_installer_subdir.yml
@@ -1,0 +1,17 @@
+name: "${TEST_TEAM_NAME}"
+team_settings:
+  secrets:
+    - secret: "ABC"
+  features:
+    enable_host_users: true
+    enable_software_inventory: true
+  host_expiry_settings:
+    host_expiry_enabled: true
+    host_expiry_window: 30
+agent_options:
+controls:
+policies:
+queries:
+software:
+  packages:
+    - path: ./subdir/installer.yml

--- a/pkg/spec/gitops.go
+++ b/pkg/spec/gitops.go
@@ -773,8 +773,10 @@ func parseSoftware(top map[string]json.RawMessage, result *GitOps, baseDir strin
 				multiError = multierror.Append(multiError, fmt.Errorf("failed to unmarshal software package file %s: %v", *item.Path, err))
 				continue
 			}
+
+			softwarePackageSpec = resolveSoftwarePackagePaths(filepath.Dir(softwarePackageSpec.ReferencedYamlPath), softwarePackageSpec)
 		} else {
-			softwarePackageSpec = item.SoftwarePackageSpec
+			softwarePackageSpec = resolveSoftwarePackagePaths(baseDir, item.SoftwarePackageSpec)
 		}
 		if softwarePackageSpec.URL == "" {
 			multiError = multierror.Append(multiError, errors.New("software URL is required"))
@@ -788,6 +790,23 @@ func parseSoftware(top map[string]json.RawMessage, result *GitOps, baseDir strin
 	}
 
 	return multiError
+}
+
+func resolveSoftwarePackagePaths(baseDir string, softwareSpec fleet.SoftwarePackageSpec) fleet.SoftwarePackageSpec {
+	if softwareSpec.PreInstallQuery.Path != "" {
+		softwareSpec.PreInstallQuery.Path = resolveApplyRelativePath(baseDir, softwareSpec.PreInstallQuery.Path)
+	}
+	if softwareSpec.InstallScript.Path != "" {
+		softwareSpec.InstallScript.Path = resolveApplyRelativePath(baseDir, softwareSpec.InstallScript.Path)
+	}
+	if softwareSpec.PostInstallScript.Path != "" {
+		softwareSpec.PostInstallScript.Path = resolveApplyRelativePath(baseDir, softwareSpec.PostInstallScript.Path)
+	}
+	if softwareSpec.UninstallScript.Path != "" {
+		softwareSpec.UninstallScript.Path = resolveApplyRelativePath(baseDir, softwareSpec.UninstallScript.Path)
+	}
+
+	return softwareSpec
 }
 
 func getDuplicateNames[T any](slice []T, getComparableString func(T) string) []string {

--- a/pkg/spec/testdata/microsoft-teams.pkg.software.yml
+++ b/pkg/spec/testdata/microsoft-teams.pkg.software.yml
@@ -1,4 +1,4 @@
 url: https://statics.teams.cdn.office.net/production-osx/enterprise/webview2/lkg/MicrosoftTeams.pkg
 self_service: false
 uninstall_script:
-  path: uninstall.sh
+  path: ../uninstall.sh

--- a/server/service/client.go
+++ b/server/service/client.go
@@ -639,7 +639,7 @@ func (c *Client) ApplyGroup(
 		tmSoftwarePackageByPath := make(map[string]map[string]fleet.SoftwarePackageSpec, len(tmSoftwarePackages))
 		for tmName, software := range tmSoftwarePackages {
 			installDuringSetupKeys := tmSoftwareMacOSSetup[tmName]
-			softwarePayloads, err := buildSoftwarePackagesPayload(baseDir, software, installDuringSetupKeys)
+			softwarePayloads, err := buildSoftwarePackagesPayload(software, installDuringSetupKeys)
 			if err != nil {
 				return nil, nil, nil, fmt.Errorf("applying software installers for team %q: %w", tmName, err)
 			}
@@ -885,13 +885,13 @@ func validateTeamOrNoTeamMacOSSetupSoftware(teamName string, macOSSetupSoftware 
 	return nil
 }
 
-func buildSoftwarePackagesPayload(baseDir string, specs []fleet.SoftwarePackageSpec, installDuringSetupKeys map[fleet.MacOSSetupSoftware]struct{}) ([]fleet.SoftwareInstallerPayload, error) {
+func buildSoftwarePackagesPayload(specs []fleet.SoftwarePackageSpec, installDuringSetupKeys map[fleet.MacOSSetupSoftware]struct{}) ([]fleet.SoftwareInstallerPayload, error) {
 	softwarePayloads := make([]fleet.SoftwareInstallerPayload, len(specs))
 	for i, si := range specs {
 		var qc string
 		var err error
 		if si.PreInstallQuery.Path != "" {
-			queryFile := resolveApplyRelativePath(baseDir, si.PreInstallQuery.Path)
+			queryFile := si.PreInstallQuery.Path
 			rawSpec, err := os.ReadFile(queryFile)
 			if err != nil {
 				return nil, fmt.Errorf("reading pre-install query: %w", err)
@@ -945,7 +945,7 @@ func buildSoftwarePackagesPayload(baseDir string, specs []fleet.SoftwarePackageS
 
 		var ic []byte
 		if si.InstallScript.Path != "" {
-			installScriptFile := resolveApplyRelativePath(baseDir, si.InstallScript.Path)
+			installScriptFile := si.InstallScript.Path
 			ic, err = os.ReadFile(installScriptFile)
 			if err != nil {
 				return nil, fmt.Errorf("Couldn't edit software (%s). Unable to read install script file %s: %w", si.URL, si.InstallScript.Path, err)
@@ -954,7 +954,7 @@ func buildSoftwarePackagesPayload(baseDir string, specs []fleet.SoftwarePackageS
 
 		var pc []byte
 		if si.PostInstallScript.Path != "" {
-			postInstallScriptFile := resolveApplyRelativePath(baseDir, si.PostInstallScript.Path)
+			postInstallScriptFile := si.PostInstallScript.Path
 			pc, err = os.ReadFile(postInstallScriptFile)
 			if err != nil {
 				return nil, fmt.Errorf("Couldn't edit software (%s). Unable to read post-install script file %s: %w", si.URL, si.PostInstallScript.Path, err)
@@ -963,7 +963,7 @@ func buildSoftwarePackagesPayload(baseDir string, specs []fleet.SoftwarePackageS
 
 		var us []byte
 		if si.UninstallScript.Path != "" {
-			uninstallScriptFile := resolveApplyRelativePath(baseDir, si.UninstallScript.Path)
+			uninstallScriptFile := si.UninstallScript.Path
 			us, err = os.ReadFile(uninstallScriptFile)
 			if err != nil {
 				return nil, fmt.Errorf("Couldn't edit software (%s). Unable to read uninstall script file %s: %w", si.URL,
@@ -1753,7 +1753,7 @@ func (c *Client) doGitOpsNoTeamSoftware(
 	if err := validateTeamOrNoTeamMacOSSetupSoftware(*config.TeamName, macOSSetup.Software.Value, packagesByPath, appsByAppID); err != nil {
 		return nil, err
 	}
-	swPkgPayload, err := buildSoftwarePackagesPayload(baseDir, packages, noTeamSoftwareMacOSSetup)
+	swPkgPayload, err := buildSoftwarePackagesPayload(packages, noTeamSoftwareMacOSSetup)
 	if err != nil {
 		return nil, fmt.Errorf("applying software installers: %w", err)
 	}


### PR DESCRIPTION
#22187

Similar fix to #22555: resolve paths at spec parsing time rather than when trying to grab files

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/Committing-Changes.md#changes-files) for more information.
- [x] Added/updated tests
- [x] Manual QA for all new/changed functionality