### PR TITLE
Fully deleting pending host.

### DIFF
--- a/server/datastore/mysql/apple_mdm.go
+++ b/server/datastore/mysql/apple_mdm.go
@@ -1554,7 +1554,7 @@ func (ds *Datastore) DeleteHostDEPAssignments(ctx context.Context, abmTokenID ui
 		for _, host := range hosts {
 			hostIDs = append(hostIDs, host.ID)
 			if host.EnrollmentStatus != nil && *host.EnrollmentStatus == "Pending" {
-				hostIDsPending = append(hostIDs, host.ID)
+				hostIDsPending = append(hostIDsPending, host.ID)
 			}
 		}
 

--- a/server/datastore/mysql/apple_mdm.go
+++ b/server/datastore/mysql/apple_mdm.go
@@ -1527,22 +1527,35 @@ func (ds *Datastore) DeleteHostDEPAssignments(ctx context.Context, abmTokenID ui
 	}
 
 	selectStmt, selectArgs, err := sqlx.In(`
-		SELECT h.id
+		SELECT h.id, hmdm.enrollment_status
 		FROM hosts h
 		JOIN host_dep_assignments hdep ON h.id = hdep.host_id
+		LEFT JOIN host_mdm hmdm ON h.id = hmdm.host_id
 		WHERE hdep.abm_token_id = ? AND h.hardware_serial IN (?)`, abmTokenID, serials)
 	if err != nil {
 		return ctxerr.Wrap(ctx, err, "building IN statement for selecting host IDs")
 	}
 
 	return ds.withTx(ctx, func(tx sqlx.ExtContext) error {
-		var hostIDs []uint
-		if err = sqlx.SelectContext(ctx, tx, &hostIDs, selectStmt, selectArgs...); err != nil {
+		type hostWithEnrollmentStatus struct {
+			ID               uint    `db:"id"`
+			EnrollmentStatus *string `db:"enrollment_status"`
+		}
+		var hosts []hostWithEnrollmentStatus
+		if err = sqlx.SelectContext(ctx, tx, &hosts, selectStmt, selectArgs...); err != nil {
 			return ctxerr.Wrap(ctx, err, "selecting host IDs")
 		}
-		if len(hostIDs) == 0 {
+		if len(hosts) == 0 {
 			// Nothing to delete. Hosts may have already been transferred to another ABM.
 			return nil
+		}
+		var hostIDs []uint
+		var hostIDsPending []uint
+		for _, host := range hosts {
+			hostIDs = append(hostIDs, host.ID)
+			if host.EnrollmentStatus != nil && *host.EnrollmentStatus == "Pending" {
+				hostIDsPending = append(hostIDs, host.ID)
+			}
 		}
 
 		stmt, args, err := sqlx.In(`
@@ -1558,17 +1571,11 @@ func (ds *Datastore) DeleteHostDEPAssignments(ctx context.Context, abmTokenID ui
 
 		// If pending host is no longer in ABM, we should delete it because it will never enroll in Fleet.
 		// If the host is later re-added to ABM, it will be re-created.
-		deletePendingStmt, args, err := sqlx.In(`
-		DELETE h, hmdm FROM hosts h
-		JOIN host_mdm hmdm ON h.id = hmdm.host_id
-		WHERE h.id IN (?) AND hmdm.enrollment_status = 'Pending'`, hostIDs)
-		if err != nil {
-			return ctxerr.Wrap(ctx, err, "building delete IN statement")
+		if len(hostIDsPending) == 0 {
+			return nil
 		}
-		if _, err := tx.ExecContext(ctx, deletePendingStmt, args...); err != nil {
-			return ctxerr.Wrap(ctx, err, "deleting pending hosts by host_id")
-		}
-		return nil
+
+		return deleteHosts(ctx, tx, hostIDsPending)
 	})
 }
 

--- a/server/service/integration_mdm_dep_test.go
+++ b/server/service/integration_mdm_dep_test.go
@@ -920,10 +920,13 @@ func (s *integrationMDMTestSuite) TestDEPProfileAssignment() {
 	s.DoJSON("POST", "/api/latest/fleet/teams", team, http.StatusOK, &createTeamResp)
 	require.NotZero(t, createTeamResp.Team.ID)
 	team = createTeamResp.Team
+	var device1ID uint
 	for _, h := range listHostsRes.Hosts {
 		if h.HardwareSerial == devices[1].SerialNumber {
 			err = s.ds.AddHostsToTeam(ctx, &team.ID, []uint{h.ID})
 			require.NoError(t, err)
+			device1ID = h.ID
+			break
 		}
 	}
 
@@ -1061,6 +1064,12 @@ func (s *integrationMDMTestSuite) TestDEPProfileAssignment() {
 		{SerialNumber: deletedSerial, Model: "MacBook Mini", OS: "osx", OpType: "deleted", OpDate: time.Now().Add(2 * time.Second)},
 	}
 	profileAssignmentReqs = []profileAssignmentReq{}
+	// Check that host display name is present for the device to be deleted; later we will check that it has been deleted
+	mysql.ExecAdhocSQL(t, s.ds, func(q sqlx.ExtContext) error {
+		var dest uint
+		return sqlx.GetContext(ctx, q, &dest,
+			"SELECT 1 FROM host_display_names WHERE host_id = ?", device1ID)
+	})
 	s.runDEPSchedule()
 	// all hosts should be returned from the hosts endpoint
 	listHostsRes = listHostsResponse{}
@@ -1080,6 +1089,12 @@ func (s *integrationMDMTestSuite) TestDEPProfileAssignment() {
 		gotSerials = append(gotSerials, req.Devices...)
 	}
 	assert.ElementsMatch(t, []string{addedModifiedDeletedSerial, deletedAddedSerial}, gotSerials)
+	// Check that host display name was deleted
+	mysql.ExecAdhocSQL(t, s.ds, func(q sqlx.ExtContext) error {
+		var dest uint
+		return sqlx.GetContext(ctx, q, &dest,
+			"SELECT 1 FROM host_display_names WHERE NOT EXISTS (SELECT 1 FROM host_display_names WHERE host_id = ?)", device1ID)
+	})
 
 	// delete all MDM info
 	mysql.ExecAdhocSQL(t, s.ds, func(q sqlx.ExtContext) error {


### PR DESCRIPTION
#23204 

When deleting Pending hosts, using the standard `ds.DeleteHosts` method. This seems cleaner and more scalable than trying to handle every host table in cleanups cron.

# Checklist for submitter

- [x] Added/updated tests
- [x] Manual QA for all new/changed functionality
