### PR TITLE
Fleet UI: Hide host software filters when no software + no filters applied

### DIFF
--- a/frontend/pages/hosts/details/cards/Software/HostSoftwareTable/HostSoftwareTable.tsx
+++ b/frontend/pages/hosts/details/cards/Software/HostSoftwareTable/HostSoftwareTable.tsx
@@ -207,6 +207,13 @@ const HostSoftwareTable = ({
     );
   }, [hostSoftwareFilter, platform, searchQuery]);
 
+  // Determines if a user should be able to filter or search in the table
+  const hasData = data && data.software.length > 0;
+  const hasQuery = searchQuery !== "";
+  const hasSoftwareFilter = hostSoftwareFilter !== "allSoftware";
+
+  const showFilterHeaders = hasData || hasQuery || hasSoftwareFilter;
+
   return (
     <div className={baseClass}>
       <TableContainer
@@ -223,10 +230,10 @@ const HostSoftwareTable = ({
         inputPlaceHolder="Search by name"
         onQueryChange={onQueryChange}
         emptyComponent={memoizedEmptyComponent}
-        customControl={memoizedFilterDropdown}
+        customControl={showFilterHeaders ? memoizedFilterDropdown : undefined}
         showMarkAllPages={false}
         isAllPagesSelected={false}
-        searchable
+        searchable={showFilterHeaders}
         manualSortBy
       />
     </div>


### PR DESCRIPTION
## Issue
Cerra #22991

## Description
- Add check similar to SoftwareTable.tsx for HostSoftwareTable.tsx that does not show the filters (dropdown, search bar) only if data is returned or a filter is applied (meaning they might've filtered and thats why the user sees zero results)

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Manual QA for all new/changed functionality

