### PR TITLE
Website: Fix responsibilities list showing up on non departmental handbook page.

### DIFF
--- a/website/assets/js/pages/handbook/basic-handbook.page.js
+++ b/website/assets/js/pages/handbook/basic-handbook.page.js
@@ -124,11 +124,11 @@ parasails.registerPage('basic-handbook', {
       ol.style.counterReset = 'custom-counter ' + startValue;
     });
     // Add links to the responsibilities under the responsibilities heading.
-    if($('#responsibilities')){
+    if($('h2#responsibilities')){
       let responsibilitiesLinksHtml = '<ul>\n';
       $('h3').each((unused, el)=>{ responsibilitiesLinksHtml += '<li><a href="#'+_.escape($(el).attr('id'))+'">'+_.escape($(el).text())+'</a></li>\n';  });
       responsibilitiesLinksHtml+= '</ul>';
-      $('#responsibilities + p').after(responsibilitiesLinksHtml);
+      $('h2#responsibilities + p').after(responsibilitiesLinksHtml);
     }
   },
 


### PR DESCRIPTION
Closes: #23504

Changes:
- Updated the handbook page script to make sure lists of responsibilities only appear on departmental handbook pages.