### PR TITLE
Update reference doc page: Fleet server configuration

### DIFF
--- a/docs/Configuration/fleet-server-configuration.md
+++ b/docs/Configuration/fleet-server-configuration.md
@@ -4,8 +4,6 @@ Fleet server configuration options update the internals of the Fleet server (MyS
 
 Only self-managed users and customers can modify this configuration. If you're a managed-cloud customer, please reach out to Fleet about modifying the configuration.
 
-## Configuration options
-
 You can specify configuration options in the following formats:
 
 1. YAML file
@@ -15,13 +13,13 @@ You can specify configuration options in the following formats:
 - All duration-based settings accept valid time units of `s`, `m`, `h`.
 - Command-line flags can also be piped in via stdin.
 
-#### MySQL
+## MySQL
 
 This section describes the configuration options for the primary. Suppose you also want to set up a read replica. In that case the options are the same, except that the YAML section is `mysql_read_replica`, and the flags have the `mysql_read_replica_` prefix instead of `mysql_` (the corresponding environment variables follow the same transformation). Note that there is no default value for `mysql_read_replica_address`, it must be set explicitly for Fleet to use a read replica, and it is recommended in that case to set a non-zero value for `mysql_read_replica_conn_max_lifetime` as in some environments, the replica's address may dynamically change to point
 from the primary to an actual distinct replica based on auto-scaling options, so existing idle connections need to be recycled
 periodically.
 
-##### mysql_address
+### mysql_address
 
 For the address of the MySQL server that Fleet should connect to, include the hostname and port.
 
@@ -33,7 +31,7 @@ For the address of the MySQL server that Fleet should connect to, include the ho
     address: localhost:3306
   ```
 
-##### mysql_database
+### mysql_database
 
 This is the name of the MySQL database which Fleet will use.
 
@@ -45,7 +43,7 @@ This is the name of the MySQL database which Fleet will use.
     database: fleet
   ```
 
-##### mysql_username
+### mysql_username
 
 The username to use when connecting to the MySQL instance.
 
@@ -57,7 +55,7 @@ The username to use when connecting to the MySQL instance.
     username: fleet
   ```
 
-##### mysql_password
+### mysql_password
 
 The password to use when connecting to the MySQL instance.
 
@@ -69,7 +67,7 @@ The password to use when connecting to the MySQL instance.
     password: fleet
   ```
 
-##### mysql_password_path
+### mysql_password_path
 
 File path to a file that contains the password to use when connecting to the MySQL instance.
 
@@ -81,7 +79,7 @@ File path to a file that contains the password to use when connecting to the MyS
     password_path: '/run/secrets/fleetdm-mysql-password'
   ```
 
-##### mysql_tls_ca
+### mysql_tls_ca
 
 The path to a PEM encoded certificate of MYSQL's CA for client certificate authentication.
 
@@ -93,7 +91,7 @@ The path to a PEM encoded certificate of MYSQL's CA for client certificate authe
     tls_ca: /path/to/server-ca.pem
   ```
 
-##### mysql_tls_cert
+### mysql_tls_cert
 
 The path to a PEM encoded certificate is used for TLS authentication.
 
@@ -105,7 +103,7 @@ The path to a PEM encoded certificate is used for TLS authentication.
     tls_cert: /path/to/certificate.pem
   ```
 
-##### mysql_tls_key
+### mysql_tls_key
 
 The path to a PEM encoded private key used for TLS authentication.
 
@@ -117,7 +115,7 @@ The path to a PEM encoded private key used for TLS authentication.
     tls_key: /path/to/key.pem
   ```
 
-##### mysql_tls_config
+### mysql_tls_config
 
 The TLS value in an MYSQL DSN. Can be `true`,`false`,`skip-verify`, or the CN value of the certificate.
 
@@ -129,7 +127,7 @@ The TLS value in an MYSQL DSN. Can be `true`,`false`,`skip-verify`, or the CN va
     tls_config: true
   ```
 
-##### mysql_tls_server_name
+### mysql_tls_server_name
 
 This is the server name or IP address used by the client certificate.
 
@@ -141,7 +139,7 @@ This is the server name or IP address used by the client certificate.
     server_name: 127.0.0.1
   ```
 
-##### mysql_max_open_conns
+### mysql_max_open_conns
 
 The maximum open connections to the database.
 
@@ -161,7 +159,7 @@ FLEET_MYSQL_MAX_OPEN_CONNS * (max number of fleet servers) * 4
 
 > Fleet uses 3 prepared statements for authentication (used by Fleet API) + each database connection can be using 1 additional prepared statement.
 
-##### mysql_max_idle_conns
+### mysql_max_idle_conns
 
 The maximum idle connections to the database. This value should be equal to or less than `mysql_max_open_conns`.
 
@@ -173,7 +171,7 @@ The maximum idle connections to the database. This value should be equal to or l
     max_idle_conns: 50
   ```
 
-##### mysql_conn_max_lifetime
+### mysql_conn_max_lifetime
 
 The maximum amount of time, in seconds, a connection may be reused.
 
@@ -185,7 +183,7 @@ The maximum amount of time, in seconds, a connection may be reused.
     conn_max_lifetime: 50
   ```
 
-##### mysql_sql_mode
+### mysql_sql_mode
 
 Sets the connection `sql_mode`. See [MySQL Reference](https://dev.mysql.com/doc/refman/8.0/en/sql-mode.html) for more details.
 This setting should not usually be used.
@@ -198,19 +196,7 @@ This setting should not usually be used.
     sql_mode: ANSI
   ```
 
-##### Example YAML
-
-```yaml
-mysql:
-  address: localhost:3306
-  database: fleet
-  password: fleet
-  max_open_conns: 50
-  max_idle_conns: 50
-  conn_max_lifetime: 50
-```
-
-#### Redis
+## Redis
 
 Note that to test a TLS connection to a Redis instance, run the
 `tlsconnect` Go program in `tools/redis-tests`, e.g., from the root of the repository:
@@ -223,7 +209,7 @@ $ go run ./tools/redis-tests/tlsconnect.go -addr <redis_address> -cacert <redis_
 By default, this will set up a Redis pool for that configuration and execute a
 `PING` command with a TLS connection, printing any error it encounters.
 
-##### redis_address
+### redis_address
 
 For the address of the Redis server that Fleet should connect to, include the hostname and port.
 
@@ -235,7 +221,7 @@ For the address of the Redis server that Fleet should connect to, include the ho
     address: 127.0.0.1:7369
   ```
 
-##### redis_username
+### redis_username
 
 The username to use when connecting to the Redis instance.
 
@@ -247,7 +233,7 @@ The username to use when connecting to the Redis instance.
     username: foobar
   ```
 
-##### redis_password
+### redis_password
 
 The password to use when connecting to the Redis instance.
 
@@ -259,7 +245,7 @@ The password to use when connecting to the Redis instance.
     password: foobar
   ```
 
-##### redis_database
+### redis_database
 
 The database to use when connecting to the Redis instance.
 
@@ -271,7 +257,7 @@ The database to use when connecting to the Redis instance.
     database: 14
   ```
 
-##### redis_use_tls
+### redis_use_tls
 
 Use a TLS connection to the Redis server.
 
@@ -283,7 +269,7 @@ Use a TLS connection to the Redis server.
     use_tls: true
   ```
 
-##### redis_duplicate_results
+### redis_duplicate_results
 
 Whether or not to duplicate Live Query results to another Redis channel named `LQDuplicate`. This is useful in a scenario involving shipping the Live Query results outside of Fleet, near real-time.
 
@@ -295,7 +281,7 @@ Whether or not to duplicate Live Query results to another Redis channel named `L
     duplicate_results: true
   ```
 
-##### redis_connect_timeout
+### redis_connect_timeout
 
 Timeout for redis connection.
 
@@ -307,7 +293,7 @@ Timeout for redis connection.
     connect_timeout: 10s
   ```
 
-##### redis_keep_alive
+### redis_keep_alive
 
 The interval between keep-alive probes.
 
@@ -319,7 +305,7 @@ The interval between keep-alive probes.
     keep_alive: 30s
   ```
 
-##### redis_connect_retry_attempts
+### redis_connect_retry_attempts
 
 The maximum number of attempts to retry a failed connection to a Redis node. Only
 certain types of errors are retried, such as connection timeouts.
@@ -332,7 +318,7 @@ certain types of errors are retried, such as connection timeouts.
     connect_retry_attempts: 2
   ```
 
-##### redis_cluster_follow_redirections
+### redis_cluster_follow_redirections
 
 Whether or not to automatically follow redirection errors received from the
 Redis server. Applies only to Redis Cluster setups, ignored in standalone
@@ -349,7 +335,7 @@ handled transparently instead of ending in an error.
     cluster_follow_redirections: true
   ```
 
-##### redis_cluster_read_from_replica
+### redis_cluster_read_from_replica
 
 Whether or not to prefer reading from a replica when possible. Applies only
 to Redis Cluster setups, ignored in standalone Redis.
@@ -362,7 +348,7 @@ to Redis Cluster setups, ignored in standalone Redis.
     cluster_read_from_replica: true
   ```
 
-##### redis_tls_cert
+### redis_tls_cert
 
 This is the path to a PEM-encoded certificate used for TLS authentication.
 
@@ -374,7 +360,7 @@ This is the path to a PEM-encoded certificate used for TLS authentication.
     tls_cert: /path/to/certificate.pem
   ```
 
-##### redis_tls_key
+### redis_tls_key
 
 This is the path to a PEM-encoded private key used for TLS authentication.
 
@@ -386,7 +372,7 @@ This is the path to a PEM-encoded private key used for TLS authentication.
     tls_key: /path/to/key.pem
   ```
 
-##### redis_tls_ca
+### redis_tls_ca
 
 This is the path to a PEM-encoded certificate of Redis' CA for client certificate authentication.
 
@@ -398,7 +384,7 @@ This is the path to a PEM-encoded certificate of Redis' CA for client certificat
     tls_ca: /path/to/server-ca.pem
   ```
 
-##### redis_tls_server_name
+### redis_tls_server_name
 
 The server name or IP address used by the client certificate.
 
@@ -410,7 +396,7 @@ The server name or IP address used by the client certificate.
     tls_server_name: 127.0.0.1
   ```
 
-##### redis_tls_handshake_timeout
+### redis_tls_handshake_timeout
 
 The timeout for the Redis TLS handshake part of the connection. A value of 0 means no timeout.
 
@@ -422,7 +408,7 @@ The timeout for the Redis TLS handshake part of the connection. A value of 0 mea
     tls_handshake_timeout: 10s
   ```
 
-##### redis_max_idle_conns
+### redis_max_idle_conns
 
 The maximum idle connections to Redis. This value should be equal to or less than `redis_max_open_conns`.
 
@@ -434,7 +420,7 @@ The maximum idle connections to Redis. This value should be equal to or less tha
     max_idle_conns: 50
   ```
 
-##### redis_max_open_conns
+### redis_max_open_conns
 
 The maximum open connections to Redis. A value of 0 means no limit.
 
@@ -446,7 +432,7 @@ The maximum open connections to Redis. A value of 0 means no limit.
     max_open_conns: 100
   ```
 
-##### redis_conn_max_lifetime
+### redis_conn_max_lifetime
 
 The maximum time a Redis connection may be reused. A value of 0 means no limit.
 
@@ -458,7 +444,7 @@ The maximum time a Redis connection may be reused. A value of 0 means no limit.
     conn_max_lifetime: 30m
   ```
 
-##### redis_idle_timeout
+### redis_idle_timeout
 
 The maximum time a Redis connection may stay idle. A value of 0 means no limit.
 
@@ -470,7 +456,7 @@ The maximum time a Redis connection may stay idle. A value of 0 means no limit.
     idle_timeout: 5m
   ```
 
-##### redis_conn_wait_timeout
+### redis_conn_wait_timeout
 
 The maximum time to wait for a Redis connection if the max_open_conns
 limit is reached. A value of 0 means no wait.
@@ -483,7 +469,7 @@ limit is reached. A value of 0 means no wait.
     conn_wait_timeout: 1s
   ```
 
-##### redis_read_timeout
+### redis_read_timeout
 
 The maximum time to wait to receive a response from a Redis server.
 A value of 0 means no timeout.
@@ -496,7 +482,7 @@ A value of 0 means no timeout.
     read_timeout: 5s
   ```
 
-##### redis_write_timeout
+### redis_write_timeout
 
 The maximum time to wait to send a command to a Redis server.
 A value of 0 means no timeout.
@@ -509,20 +495,9 @@ A value of 0 means no timeout.
     write_timeout: 5s
   ```
 
-##### Example YAML
+## Server
 
-```yaml
-redis:
-  address: localhost:7369
-  password: foobar
-  database: 14
-  connect_timeout: 10s
-  connect_retry_attempts: 2
-```
-
-### Server
-
-##### server_address
+### server_address
 
 The address to serve the Fleet webserver.
 
@@ -534,7 +509,7 @@ The address to serve the Fleet webserver.
     address: 0.0.0.0:443
   ```
 
-##### server_cert
+### server_cert
 
 The TLS cert to use when terminating TLS.
 
@@ -548,7 +523,7 @@ See [TLS certificate considerations](https://fleetdm.com/docs/deploying/introduc
     cert: /tmp/fleet.crt
   ```
 
-##### server_key
+### server_key
 
 The TLS key to use when terminating TLS.
 
@@ -560,7 +535,7 @@ The TLS key to use when terminating TLS.
     key: /tmp/fleet.key
   ```
 
-##### server_tls
+### server_tls
 
 Whether or not the server should be served over TLS.
 
@@ -572,7 +547,7 @@ Whether or not the server should be served over TLS.
     tls: false
   ```
 
-##### server_tls_compatibility
+### server_tls_compatibility
 
 Configures the TLS settings for compatibility with various user agents. Options are `modern` and `intermediate`. These correspond to the compatibility levels [defined by the Mozilla OpSec team](https://wiki.mozilla.org/index.php?title=Security/Server_Side_TLS&oldid=1229478) (updated July 24, 2020).
 
@@ -584,7 +559,7 @@ Configures the TLS settings for compatibility with various user agents. Options 
     tls_compatibility: intermediate
   ```
 
-##### server_url_prefix
+### server_url_prefix
 
 Sets a URL prefix to use when serving the Fleet API and frontend. Prefixes should be in the form `/apps/fleet` (no trailing slash).
 
@@ -598,7 +573,7 @@ Note that some other configurations may need to be changed when modifying the UR
     url_prefix: /apps/fleet
   ```
 
-##### server_keepalive
+### server_keepalive
 
 Controls the server side http keep alive property.
 
@@ -612,7 +587,7 @@ Turning off keepalives has helped reduce outstanding TCP connections in some dep
     keepalive: true
   ```
 
-##### server_websockets_allow_unsafe_origin
+### server_websockets_allow_unsafe_origin
 
 Controls the servers websocket origin check. If your Fleet server is behind a reverse proxy,
 the Origin header may not reflect the client's true origin. In this case, you might need to
@@ -629,7 +604,7 @@ Setting to true will disable the origin check.
     websockets_allow_unsafe_origin: true
   ```
 
-##### server_private_key
+### server_private_key
 
 This key is required for enabling macOS MDM features in Fleet. If you are using the `FLEET_APPLE_APNS_*` and `FLEET_APPLE_SCEP_*` variables, Fleet will automatically encrypt the values of those variables using `FLEET_SERVER_PRIVATE_KEY` and save them in the database when you restart after updating.
 
@@ -643,20 +618,9 @@ The key must be at least 32 bytes long. Run `openssl rand -base64 32` in the Ter
     private_key: 72414F4A688151F75D032F5CDA095FC4
   ```
 
-##### Example YAML
+## Auth
 
-```yaml
-server:
-  address: 0.0.0.0:443
-  password: foobar
-  cert: /tmp/fleet.crt
-  key: /tmp/fleet.key
-  invite_token_validity_period: 1d
-```
-
-#### Auth
-
-##### auth_bcrypt_cost
+### auth_bcrypt_cost
 
 The bcrypt cost to use when hashing user passwords.
 
@@ -668,7 +632,7 @@ The bcrypt cost to use when hashing user passwords.
     bcrypt_cost: 14
   ```
 
-##### auth_salt_key_size
+### auth_salt_key_size
 
 The key size of the salt which is generated when hashing user passwords.
 
@@ -686,17 +650,9 @@ The key size of the salt which is generated when hashing user passwords.
     salt_key_size: 36
   ```
 
-##### Example YAML
+## App
 
-```yaml
-auth:
-  bcrypt_cost: 14
-  salt_key_size: 36
-```
-
-#### App
-
-##### app_token_key_size
+### app_token_key_size
 
 Size of generated app tokens.
 
@@ -708,7 +664,7 @@ Size of generated app tokens.
     token_key_size: 36
   ```
 
-##### app_invite_token_validity_period
+### app_invite_token_validity_period
 
 How long invite tokens should be valid for.
 
@@ -720,7 +676,7 @@ How long invite tokens should be valid for.
     invite_token_validity_period: 1d
   ```
 
-##### app_enable_scheduled_query_stats
+### app_enable_scheduled_query_stats
 
 Determines whether Fleet collects performance impact statistics for scheduled queries.
 
@@ -734,18 +690,9 @@ If set to `false`, stats are still collected for live queries.
     enable_scheduled_query_stats: true
   ```
 
-##### Example YAML
+## License
 
-```yaml
-app:
-  token_key_size: 36
-  salt_key_size: 36
-  invite_token_validity_period: 1d
-```
-
-#### License
-
-##### license_key
+### license_key
 
 The license key provided to Fleet customers which provides access to Fleet Premium features.
 
@@ -757,9 +704,9 @@ The license key provided to Fleet customers which provides access to Fleet Premi
     key: foobar
   ```
 
-#### Session
+## Session
 
-##### session_key_size
+### session_key_size
 
 The size of the session key.
 
@@ -771,7 +718,7 @@ The size of the session key.
     key_size: 48
   ```
 
-##### session_duration
+### session_duration
 
 This is the amount of time that a session should last. Whenever a user logs in, the time is reset to the specified, or default, duration.
 
@@ -785,16 +732,9 @@ Valid time units are `s`, `m`, `h`.
     duration: 4h
   ```
 
-##### Example YAML
+## Osquery
 
-```yaml
-session:
-  duration: 4h
-```
-
-#### Osquery
-
-##### osquery_node_key_size
+### osquery_node_key_size
 
 The size of the node key which is negotiated with `osqueryd` clients.
 
@@ -806,7 +746,7 @@ The size of the node key which is negotiated with `osqueryd` clients.
     node_key_size: 36
   ```
 
-##### osquery_host_identifier
+### osquery_host_identifier
 
 The identifier to use when determining uniqueness of hosts.
 
@@ -826,7 +766,7 @@ Users that have duplicate UUIDs in their environment can benefit from setting th
     host_identifier: uuid
   ```
 
-##### osquery_enroll_cooldown
+### osquery_enroll_cooldown
 
 The cooldown period for host enrollment. If a host (uniquely identified by the `osquery_host_identifier` option) tries to enroll within this duration from the last enrollment, enroll will fail.
 
@@ -840,7 +780,7 @@ This flag can be used to control load on the database in scenarios in which many
     enroll_cooldown: 1m
   ```
 
-##### osquery_label_update_interval
+### osquery_label_update_interval
 
 The interval at which Fleet will ask Fleet's agent (fleetd) to update results for label queries.
 
@@ -858,7 +798,7 @@ Valid time units are `s`, `m`, `h`.
     label_update_interval: 90m
   ```
 
-##### osquery_policy_update_interval
+### osquery_policy_update_interval
 
 The interval at which Fleet will ask Fleet's agent (fleetd) to update results for policy queries.
 
@@ -876,7 +816,7 @@ Valid time units are `s`, `m`, `h`.
     policy_update_interval: 90m
   ```
 
-##### osquery_detail_update_interval
+### osquery_detail_update_interval
 
 The interval at which Fleet will ask Fleet's agent (fleetd) to update host details (such as uptime, hostname, network interfaces, etc.)
 
@@ -894,7 +834,7 @@ Valid time units are `s`, `m`, `h`.
     detail_update_interval: 90m
   ```
 
-##### osquery_status_log_plugin
+### osquery_status_log_plugin
 
 This is the log output plugin that should be used for osquery status logs received from clients. Check out the [reference documentation for log destinations](https://fleetdm.com/docs/using-fleet/log-destinations).
 
@@ -909,7 +849,7 @@ Options are `filesystem`, `firehose`, `kinesis`, `lambda`, `pubsub`, `kafkarest`
     status_log_plugin: firehose
   ```
 
-##### osquery_result_log_plugin
+### osquery_result_log_plugin
 
 This is the log output plugin that should be used for osquery result logs received from clients. Check out the [reference documentation for log destinations](https://fleetdm.com/docs/using-fleet/log-destinations).
 
@@ -923,7 +863,7 @@ Options are `filesystem`, `firehose`, `kinesis`, `lambda`, `pubsub`, `kafkarest`
     result_log_plugin: firehose
   ```
 
-##### osquery_max_jitter_percent
+### osquery_max_jitter_percent
 
 Given an update interval (label, or details), this will add up to the defined percentage in randomness to the interval.
 
@@ -940,7 +880,7 @@ to the amount of time it takes for Fleet to give the host the label queries.
     max_jitter_percent: 10
   ```
 
-##### osquery_enable_async_host_processing
+### osquery_enable_async_host_processing
 
 **Experimental feature**. Enable asynchronous processing of hosts' query results. Currently, asyncronous processing is only supported for label query execution, policy membership results, hosts' last seen timestamp, and hosts' scheduled query statistics. This may improve the performance and CPU usage of the Fleet instances and MySQL database servers for setups with a large number of hosts while requiring more resources from Redis server(s).
 
@@ -963,7 +903,7 @@ It can be set to a single boolean value ("true" or "false"), which controls all 
 
 > Fleet tested this option for `policy_membership=true` in [this issue](https://github.com/fleetdm/fleet/issues/12697) and found that it does not impact the performance or behavior of the app.
 
-##### osquery_async_host_collect_interval
+### osquery_async_host_collect_interval
 
 Applies only when `osquery_enable_async_host_processing` is enabled. Sets the interval at which the host data will be collected into the database. Each Fleet instance will attempt to do the collection at this interval (with some optional jitter added, see `osquery_async_host_collect_max_jitter_percent`), with only one succeeding to get the exclusive lock.
 
@@ -977,7 +917,7 @@ It can be set to a single duration value (e.g., "30s"), which defines the interv
     async_host_collect_interval: 1m
   ```
 
-##### osquery_async_host_collect_max_jitter_percent
+### osquery_async_host_collect_max_jitter_percent
 
 Applies only when `osquery_enable_async_host_processing` is enabled. A number interpreted as a percentage of `osquery_async_host_collect_interval` to add to (or remove from) the interval so that not all hosts try to do the collection at the same time.
 
@@ -989,7 +929,7 @@ Applies only when `osquery_enable_async_host_processing` is enabled. A number in
     async_host_collect_max_jitter_percent: 5
   ```
 
-##### osquery_async_host_collect_lock_timeout
+### osquery_async_host_collect_lock_timeout
 
 Applies only when `osquery_enable_async_host_processing` is enabled. Timeout of the lock acquired by a Fleet instance to collect host data into the database. If the collection runs for too long or the instance crashes unexpectedly, the lock will be automatically released after this duration and another Fleet instance can proceed with the next collection.
 
@@ -1003,7 +943,7 @@ It can be set to a single duration value (e.g., "1m"), which defines the lock ti
     async_host_collect_lock_timeout: 5m
   ```
 
-##### osquery_async_host_collect_log_stats_interval
+### osquery_async_host_collect_log_stats_interval
 
 Applies only when `osquery_enable_async_host_processing` is enabled. Interval at which the host collection statistics are logged, 0 to disable logging of statistics. Note that logging is done at the "debug" level.
 
@@ -1015,7 +955,7 @@ Applies only when `osquery_enable_async_host_processing` is enabled. Interval at
     async_host_collect_log_stats_interval: 5m
   ```
 
-##### osquery_async_host_insert_batch
+### osquery_async_host_insert_batch
 
 Applies only when `osquery_enable_async_host_processing` is enabled. Size of the INSERT batch when collecting host data into the database.
 
@@ -1027,7 +967,7 @@ Applies only when `osquery_enable_async_host_processing` is enabled. Size of the
     async_host_insert_batch: 1000
   ```
 
-##### osquery_async_host_delete_batch
+### osquery_async_host_delete_batch
 
 Applies only when `osquery_enable_async_host_processing` is enabled. Size of the DELETE batch when collecting host data into the database.
 
@@ -1039,7 +979,7 @@ Applies only when `osquery_enable_async_host_processing` is enabled. Size of the
     async_host_delete_batch: 1000
   ```
 
-##### osquery_async_host_update_batch
+### osquery_async_host_update_batch
 
 Applies only when `osquery_enable_async_host_processing` is enabled. Size of the UPDATE batch when collecting host data into the database.
 
@@ -1051,7 +991,7 @@ Applies only when `osquery_enable_async_host_processing` is enabled. Size of the
     async_host_update_batch: 500
   ```
 
-##### osquery_async_host_redis_pop_count
+### osquery_async_host_redis_pop_count
 
 Applies only when `osquery_enable_async_host_processing` is enabled. Maximum number of items to pop from a redis key at a time when collecting host data into the database.
 
@@ -1063,7 +1003,7 @@ Applies only when `osquery_enable_async_host_processing` is enabled. Maximum num
     async_host_redis_pop_count: 500
   ```
 
-##### osquery_async_host_redis_scan_keys_count
+### osquery_async_host_redis_scan_keys_count
 
 Applies only when `osquery_enable_async_host_processing` is enabled. Order of magnitude (e.g., 10, 100, 1000, etc.) of set members to scan in a single ZSCAN/SSCAN request for items to process when collecting host data into the database.
 
@@ -1075,7 +1015,7 @@ Applies only when `osquery_enable_async_host_processing` is enabled. Order of ma
     async_host_redis_scan_keys_count: 100
   ```
 
-##### osquery_min_software_last_opened_at_diff
+### osquery_min_software_last_opened_at_diff
 
 The minimum time difference between the software's "last opened at" timestamp reported by osquery and the last timestamp saved for that software on that host helps minimize the number of updates required when a host reports its installed software information, resulting in less load on the database. If there is no existing timestamp for the software on that host (or if the software was not installed on that host previously), the new timestamp is automatically saved.
 
@@ -1087,23 +1027,13 @@ The minimum time difference between the software's "last opened at" timestamp re
     min_software_last_opened_at_diff: 4h
   ```
 
-##### Example YAML
-
-```yaml
-osquery:
-  host_identifier: uuid
-  policy_update_interval: 30m
-  duration: 4h
-  status_log_plugin: firehose
-  result_log_plugin: firehose
-```
-#### External activity audit logging
+## External activity audit logging
 
 > Applies only to Fleet Premium. Activity information is available for all Fleet instances using the [Activities API](https://fleetdm.com/docs/using-fleet/rest-api#activities).
 
 Stream Fleet user activities to logs using Fleet's logging plugins. The audit events are logged in an asynchronous fashion. It can take up to 5 minutes for an event to be logged.
 
-##### activity_enable_audit_log
+### activity_enable_audit_log
 
 This enables/disables the log output for audit events.
 See the `activity_audit_log_plugin` option below that specifies the logging destination.
@@ -1116,7 +1046,7 @@ See the `activity_audit_log_plugin` option below that specifies the logging dest
     enable_audit_log: true
   ```
 
-##### activity_audit_log_plugin
+### activity_audit_log_plugin
 
 This is the log output plugin that should be used for audit logs.
 This flag only has effect if `activity_enable_audit_log` is set to `true`.
@@ -1133,9 +1063,9 @@ Options are [`filesystem`](#filesystem), [`firehose`](#firehose), [`kinesis`](#k
     audit_log_plugin: firehose
   ```
 
-#### Logging (Fleet server logging)
+## Logging (Fleet server logging)
 
-##### logging_debug
+### logging_debug
 
 Whether or not to enable debug logging.
 
@@ -1147,7 +1077,7 @@ Whether or not to enable debug logging.
     debug: true
   ```
 
-##### logging_json
+### logging_json
 
 Whether or not to log in JSON.
 
@@ -1159,7 +1089,7 @@ Whether or not to log in JSON.
     json: true
   ```
 
-##### logging_disable_banner
+### logging_disable_banner
 
 Whether or not to log the welcome banner.
 
@@ -1171,7 +1101,7 @@ Whether or not to log the welcome banner.
     disable_banner: true
   ```
 
-##### logging_error_retention_period
+### logging_error_retention_period
 
 The amount of time to keep an error. Unique instances of errors are stored temporarily to help
 with troubleshooting, this setting controls that duration. Set to 0 to keep them without expiration,
@@ -1185,17 +1115,9 @@ and a negative value to disable storage of errors in Redis.
     error_retention_period: 1h
   ```
 
-##### Example YAML
+## Filesystem
 
-```yaml
-logging:
-  disable_banner: true
-  policy_update_interval: 30m
-  error_retention_period: 1h
-```
-#### Filesystem
-
-##### filesystem_status_log_file
+### filesystem_status_log_file
 
 This flag only has effect if `osquery_status_log_plugin` is set to `filesystem` (the default value).
 
@@ -1209,7 +1131,7 @@ The path which osquery status logs will be logged to.
     status_log_file: /var/log/osquery/status.log
   ```
 
-##### filesystem_result_log_file
+### filesystem_result_log_file
 
 This flag only has effect if `osquery_result_log_plugin` is set to `filesystem` (the default value).
 
@@ -1223,7 +1145,7 @@ The path which osquery result logs will be logged to.
     result_log_file: /var/log/osquery/result.log
   ```
 
-##### filesystem_audit_log_file
+### filesystem_audit_log_file
 
 This flag only has effect if `activity_audit_log_plugin` is set to `filesystem` (the default value) and if `activity_enable_audit_log` is set to `true`.
 
@@ -1237,7 +1159,7 @@ The path which audit logs will be logged to.
     audit_log_file: /var/log/fleet/audit.log
   ```
 
-##### filesystem_enable_log_rotation
+### filesystem_enable_log_rotation
 
 This flag only has effect if one of the following is true:
 - `osquery_result_log_plugin` or `osquery_status_log_plugin` are set to `filesystem` (the default value).
@@ -1254,7 +1176,7 @@ rotated when files reach a size of 500 MB or an age of 28 days.
      enable_log_rotation: true
   ```
 
-##### filesystem_enable_log_compression
+### filesystem_enable_log_compression
 
 This flag only has effect if `filesystem_enable_log_rotation` is set to `true`.
 
@@ -1268,7 +1190,7 @@ This flag will cause the rotated logs to be compressed with gzip.
      enable_log_compression: true
   ```
 
-##### filesystem_max_size
+### filesystem_max_size
 
 This flag only has effect if `filesystem_enable_log_rotation` is set to `true`.
 
@@ -1282,7 +1204,7 @@ Sets the maximum size in megabytes of log files before it gets rotated.
      max_size: 100
   ```
 
-##### filesystem_max_age
+### filesystem_max_age
 
 This flag only has effect if `filesystem_enable_log_rotation` is set to `true`.
 
@@ -1297,7 +1219,7 @@ to zero will retain all logs.
      max_age: 0
   ```
 
-##### filesystem_max_backups
+### filesystem_max_backups
 
 This flag only has effect if `filesystem_enable_log_rotation` is set to `true`.
 
@@ -1312,21 +1234,9 @@ to zero will retain all logs. _Note_ max_age may still cause them to be deleted.
      max_backups: 0
   ```
 
-##### Example YAML
+## Firehose
 
-```yaml
-osquery:
-  osquery_status_log_plugin: filesystem
-  osquery_result_log_plugin: filesystem
-filesystem:
-  status_log_file: /var/log/osquery/status.log
-  result_log_file: /var/log/osquery/result.log
-  enable_log_rotation: true
-```
-
-#### Firehose
-
-##### firehose_region
+### firehose_region
 
 This flag only has effect if one of the following is true:
 - `osquery_result_log_plugin` or `osquery_status_log_plugin` are set to `firehose`.
@@ -1342,7 +1252,7 @@ AWS region to use for Firehose connection.
     region: ca-central-1
   ```
 
-##### firehose_access_key_id
+### firehose_access_key_id
 
 This flag only has effect if one of the following is true:
 - `osquery_result_log_plugin` or `osquery_status_log_plugin` are set to `firehose`.
@@ -1360,7 +1270,7 @@ AWS access key ID to use for Firehose authentication.
     access_key_id: AKIAIOSFODNN7EXAMPLE
   ```
 
-##### firehose_secret_access_key
+### firehose_secret_access_key
 
 This flag only has effect if one of the following is true:
 - `osquery_result_log_plugin` or `osquery_status_log_plugin` are set to `firehose`.
@@ -1376,7 +1286,7 @@ AWS secret access key to use for Firehose authentication.
     secret_access_key: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
   ```
 
-##### firehose_sts_assume_role_arn
+### firehose_sts_assume_role_arn
 
 This flag only has effect if one of the following is true:
 - `osquery_result_log_plugin` or `osquery_status_log_plugin` are set to `firehose`.
@@ -1392,7 +1302,7 @@ AWS STS role ARN to use for Firehose authentication.
     sts_assume_role_arn: arn:aws:iam::1234567890:role/firehose-role
   ```
 
-##### firehose_sts_external_id
+### firehose_sts_external_id
 
 This flag only has effect if one of the following is true:
 - `osquery_result_log_plugin` or `osquery_status_log_plugin` are set to `firehose`.
@@ -1409,7 +1319,7 @@ conjunction with an STS role ARN to ensure that only the intended AWS account ca
     sts_external_id: your_unique_id
   ```
 
-##### firehose_status_stream
+### firehose_status_stream
 
 This flag only has effect if `osquery_status_log_plugin` is set to `firehose`.
 
@@ -1429,7 +1339,7 @@ the stream listed:
 - `firehose:DescribeDeliveryStream`
 - `firehose:PutRecordBatch`
 
-##### firehose_result_stream
+### firehose_result_stream
 
 This flag only has effect if `osquery_result_log_plugin` is set to `firehose`.
 
@@ -1449,7 +1359,7 @@ the stream listed:
 - `firehose:DescribeDeliveryStream`
 - `firehose:PutRecordBatch`
 
-##### firehose_audit_stream
+### firehose_audit_stream
 
 This flag only has effect if `activity_audit_log_plugin` is set to `firehose`.
 
@@ -1469,26 +1379,9 @@ the stream listed:
 - `firehose:DescribeDeliveryStream`
 - `firehose:PutRecordBatch`
 
+## Kinesis
 
-##### Example YAML
-
-```yaml
-osquery:
-  osquery_status_log_plugin: firehose
-  osquery_result_log_plugin: firehose
-firehose:
-  region: ca-central-1
-  access_key_id: AKIAIOSFODNN7EXAMPLE
-  secret_access_key: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
-  sts_assume_role_arn: arn:aws:iam::1234567890:role/firehose-role
-  sts_external_id: your_unique_id
-  status_stream: osquery_status
-  result_stream: osquery_result
-```
-
-#### Kinesis
-
-##### kinesis_region
+### kinesis_region
 
 This flag only has effect if one of the following is true:
 - `osquery_result_log_plugin` or `osquery_status_log_plugin` are set to `kinesis`.
@@ -1504,7 +1397,7 @@ AWS region to use for Kinesis connection
     region: ca-central-1
   ```
 
-##### kinesis_access_key_id
+### kinesis_access_key_id
 
 This flag only has effect if one of the following is true:
 - `osquery_result_log_plugin` or `osquery_status_log_plugin` are set to `kinesis`.
@@ -1525,7 +1418,7 @@ AWS access key ID to use for Kinesis authentication.
     access_key_id: AKIAIOSFODNN7EXAMPLE
   ```
 
-##### kinesis_secret_access_key
+### kinesis_secret_access_key
 
 This flag only has effect if one of the following is true:
 - `osquery_result_log_plugin` or `osquery_status_log_plugin` are set to `kinesis`.
@@ -1541,7 +1434,7 @@ AWS secret access key to use for Kinesis authentication.
     secret_access_key: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
   ```
 
-##### kinesis_sts_assume_role_arn
+### kinesis_sts_assume_role_arn
 
 This flag only has effect if one of the following is true:
 - `osquery_result_log_plugin` or `osquery_status_log_plugin` are set to `kinesis`.
@@ -1557,7 +1450,7 @@ AWS STS role ARN to use for Kinesis authentication.
     sts_assume_role_arn: arn:aws:iam::1234567890:role/kinesis-role
   ```
 
-##### kinesis_sts_external_id
+### kinesis_sts_external_id
 
 This flag only has effect if one of the following is true:
 - `osquery_result_log_plugin` or `osquery_status_log_plugin` are set to `kinesis`.
@@ -1574,7 +1467,7 @@ conjunction with an STS role ARN to ensure that only the intended AWS account ca
     sts_external_id: your_unique_id
   ```
 
-##### kinesis_status_stream
+### kinesis_status_stream
 
 This flag only has effect if `osquery_status_log_plugin` is set to `kinesis`.
 
@@ -1594,7 +1487,7 @@ the stream listed:
 - `kinesis:DescribeStream`
 - `kinesis:PutRecords`
 
-##### kinesis_result_stream
+### kinesis_result_stream
 
 This flag only has effect if `osquery_result_log_plugin` is set to `kinesis`.
 
@@ -1614,7 +1507,7 @@ the stream listed:
 - `kinesis:DescribeStream`
 - `kinesis:PutRecords`
 
-##### kinesis_audit_stream
+### kinesis_audit_stream
 
 This flag only has effect if `activity_audit_log_plugin` is set to `kinesis`.
 
@@ -1634,25 +1527,9 @@ the stream listed:
 - `kinesis:DescribeStream`
 - `kinesis:PutRecords`
 
-##### Example YAML
+## Lambda
 
-```yaml
-osquery:
-  osquery_status_log_plugin: kinesis
-  osquery_result_log_plugin: kinesis
-kinesis:
-  region: ca-central-1
-  access_key_id: AKIAIOSFODNN7EXAMPLE
-  secret_access_key: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
-  sts_assume_role_arn: arn:aws:iam::1234567890:role/firehose-role
-  sts_external_id: your_unique_id
-  status_stream: osquery_status
-  result_stream: osquery_result
-```
-
-#### Lambda
-
-##### lambda_region
+### lambda_region
 
 This flag only has effect if one of the following is true:
 - `osquery_result_log_plugin` or `osquery_status_log_plugin` are set to `lambda`.
@@ -1668,7 +1545,7 @@ AWS region to use for Lambda connection.
     region: ca-central-1
   ```
 
-##### lambda_access_key_id
+### lambda_access_key_id
 
 This flag only has effect if one of the following is true:
 - `osquery_result_log_plugin` or `osquery_status_log_plugin` are set to `lambda`.
@@ -1689,7 +1566,7 @@ AWS access key ID to use for Lambda authentication.
     access_key_id: AKIAIOSFODNN7EXAMPLE
   ```
 
-##### lambda_secret_access_key
+### lambda_secret_access_key
 
 This flag only has effect if one of the following is true:
 - `osquery_result_log_plugin` or `osquery_status_log_plugin` are set to `lambda`.
@@ -1705,7 +1582,7 @@ AWS secret access key to use for Lambda authentication.
     secret_access_key: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
   ```
 
-##### lambda_sts_assume_role_arn
+### lambda_sts_assume_role_arn
 
 This flag only has effect if one of the following is true:
 - `osquery_result_log_plugin` or `osquery_status_log_plugin` are set to `lambda`.
@@ -1721,7 +1598,7 @@ AWS STS role ARN to use for Lambda authentication.
     sts_assume_role_arn: arn:aws:iam::1234567890:role/lambda-role
   ```
 
-##### lambda_sts_external_id
+### lambda_sts_external_id
 
 This flag only has effect if one of the following is true:
 - `osquery_result_log_plugin` or `osquery_status_log_plugin` are set to `lambda`.
@@ -1738,7 +1615,7 @@ conjunction with an STS role ARN to ensure that only the intended AWS account ca
     sts_external_id: your_unique_id
   ```
 
-##### lambda_status_function
+### lambda_status_function
 
 This flag only has effect if `osquery_status_log_plugin` is set to `lambda`.
 
@@ -1757,7 +1634,7 @@ the function listed:
 
 - `lambda:InvokeFunction`
 
-##### lambda_result_function
+### lambda_result_function
 
 This flag only has effect if `osquery_result_log_plugin` is set to `lambda`.
 
@@ -1776,7 +1653,7 @@ the function listed:
 
 - `lambda:InvokeFunction`
 
-##### lambda_audit_function
+### lambda_audit_function
 
 This flag only has effect if `activity_audit_log_plugin` is set to `lambda`.
 
@@ -1795,24 +1672,9 @@ the function listed:
 
 - `lambda:InvokeFunction`
 
-##### Example YAML
+## PubSub
 
-```yaml
-osquery:
-  osquery_status_log_plugin: lambda
-  osquery_result_log_plugin: lambda
-lambda:
-  region: ca-central-1
-  access_key_id: AKIAIOSFODNN7EXAMPLE
-  secret_access_key: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
-  sts_assume_role_arn: arn:aws:iam::1234567890:role/firehose-role
-  status_function: statusFunction
-  result_function: resultFunction
-```
-
-#### PubSub
-
-##### pubsub_project
+### pubsub_project
 
 This flag only has effect if one of the following is true:
 - `osquery_result_log_plugin` or `osquery_status_log_plugin` are set to `pubsub`.
@@ -1832,7 +1694,7 @@ for authentication with the service.
     project: my-gcp-project
   ```
 
-##### pubsub_result_topic
+### pubsub_result_topic
 
 This flag only has effect if `osquery_result_log_plugin` is set to `pubsub`.
 
@@ -1846,7 +1708,7 @@ The identifier of the pubsub topic that client results will be published to.
     result_topic: osquery_result
   ```
 
-##### pubsub_status_topic
+### pubsub_status_topic
 
 This flag only has effect if `osquery_status_log_plugin` is set to `pubsub`.
 
@@ -1860,7 +1722,7 @@ The identifier of the pubsub topic that osquery status logs will be published to
     status_topic: osquery_status
   ```
 
-##### pubsub_audit_topic
+### pubsub_audit_topic
 
 This flag only has effect if `osquery_audit_log_plugin` is set to `pubsub`.
 
@@ -1874,7 +1736,7 @@ The identifier of the pubsub topic that client results will be published to.
     audit_topic: fleet_audit
   ```
 
-##### pubsub_add_attributes
+### pubsub_add_attributes
 
 This flag only has effect if `osquery_status_log_plugin` is set to `pubsub`.
 
@@ -1895,22 +1757,9 @@ This feature is useful when combined with [subscription filters](https://cloud.g
     add_attributes: true
   ```
 
-##### Example YAML
+## Kafka REST Proxy logging
 
-```yaml
-osquery:
-  osquery_status_log_plugin: pubsub
-  osquery_result_log_plugin: pubsub
-pubsub:
-  project: my-gcp-project
-  result_topic: osquery_result
-  status_topic: osquery_status
-  add_attributes: true
-```
-
-#### Kafka REST Proxy logging
-
-##### kafkarest_proxyhost
+### kafkarest_proxyhost
 
 This flag only has effect if one of the following is true:
 - `osquery_result_log_plugin` or `osquery_status_log_plugin` are set to `kafkarest`.
@@ -1926,7 +1775,7 @@ The URL of the host which to check for the topic existence and post messages to 
     proxyhost: "https://localhost:8443"
   ```
 
-##### kafkarest_status_topic
+### kafkarest_status_topic
 
 This flag only has effect if `osquery_status_log_plugin` is set to `kafkarest`.
 
@@ -1940,7 +1789,7 @@ The identifier of the kafka topic that osquery status logs will be published to.
     status_topic: osquery_status
   ```
 
-##### kafkarest_result_topic
+### kafkarest_result_topic
 
 This flag only has effect if `osquery_result_log_plugin` is set to `kafkarest`.
 
@@ -1954,7 +1803,7 @@ The identifier of the kafka topic that osquery result logs will be published to.
     result_topic: osquery_result
   ```
 
-##### kafkarest_audit_topic
+### kafkarest_audit_topic
 
 This flag only has effect if `osquery_audit_log_plugin` is set to `kafkarest`.
 
@@ -1968,7 +1817,7 @@ The identifier of the kafka topic that audit logs will be published to.
     audit_topic: fleet_audit
   ```
 
-##### kafkarest_timeout
+### kafkarest_timeout
 
 This flag only has effect if one of the following is true:
 - `osquery_result_log_plugin` or `osquery_status_log_plugin` are set to `kafkarest`.
@@ -1984,7 +1833,7 @@ The timeout value for the http post attempt. Value is in units of seconds.
     timeout: 5
   ```
 
-##### kafkarest_content_type_value
+### kafkarest_content_type_value
 
 This flag only has effect if one of the following is true:
 - `osquery_result_log_plugin` or `osquery_status_log_plugin` are set to `kafkarest`.
@@ -2001,25 +1850,13 @@ can be found [here](https://docs.confluent.io/platform/current/kafka-rest/api.ht
     content_type_value: application/vnd.kafka.json.v2+json
   ```
 
-##### Example YAML
-
-```yaml
-osquery:
-  osquery_status_log_plugin: kafkarest
-  osquery_result_log_plugin: kafkarest
-kafkarest:
-  proxyhost: "https://localhost:8443"
-  result_topic: osquery_result
-  status_topic: osquery_status
-```
-
-#### Email backend
+## Email backend
 
 By default, the SMTP backend is enabled and no additional configuration is required on the server settings. You can configure
 SMTP through the [Fleet console UI](https://fleetdm.com/docs/using-fleet/configuration-files#smtp-settings). However, you can also
 configure Fleet to use AWS SES natively rather than through SMTP.
 
-##### backend
+### backend
 
 Enable SES support for Fleet. You must also configure the ses configurations such as `ses.source_arn`
 
@@ -2028,11 +1865,11 @@ email:
   backend: ses
 ````
 
-#### SES
+## SES
 
 The following configurations only have an effect if SES email backend is enabled `FLEET_EMAIL_BACKEND=ses`.
 
-##### ses_region
+### ses_region
 
 This flag only has effect if `email.backend` or `FLEET_EMAIL_BACKEND` is set to `ses`.
 
@@ -2046,7 +1883,7 @@ AWS region to use for SES connection.
     region: us-east-2
   ```
 
-##### ses_access_key_id
+### ses_access_key_id
 
 This flag only has effect if `email.backend` or `FLEET_EMAIL_BACKEND` is set to `ses`.
 
@@ -2065,7 +1902,7 @@ AWS access key ID to use for Lambda authentication.
     access_key_id: AKIAIOSFODNN7EXAMPLE
   ```
 
-##### ses_secret_access_key
+### ses_secret_access_key
 
 This flag only has effect if `email.backend` or `FLEET_EMAIL_BACKEND` is set to `ses`.
 
@@ -2084,7 +1921,7 @@ AWS secret access key to use for SES authentication.
     secret_access_key: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
   ```
 
-##### ses_sts_assume_role_arn
+### ses_sts_assume_role_arn
 
 This flag only has effect if `email.backend` or `FLEET_EMAIL_BACKEND` is set to `ses`.
 
@@ -2098,7 +1935,7 @@ AWS STS role ARN to use for SES authentication.
     sts_assume_role_arn: arn:aws:iam::1234567890:role/ses-role
   ```
 
-##### ses_sts_external_id
+### ses_sts_external_id
 
 This flag only has effect if `email.backend` or `FLEET_EMAIL_BACKEND` is set to `ses`.
 
@@ -2114,7 +1951,7 @@ conjunction with an STS role ARN to ensure that only the intended AWS account ca
     sts_external_id: your_unique_id
   ```
 
-##### ses_source_arn
+### ses_source_arn
 
 This flag only has effect if `email.backend` or `FLEET_EMAIL_BACKEND` is set to `ses`. This configuration **is
 required** when using the SES email backend.
@@ -2130,9 +1967,9 @@ for the email address specified in the Source parameter of SendRawEmail.
     sts_assume_role_arn: arn:aws:iam::1234567890:role/ses-role
   ```
 
-#### S3
+## S3
 
-##### s3_software_installers_bucket
+### s3_software_installers_bucket
 
 Name of the S3 bucket for storing software and bootstrap package.
 
@@ -2144,7 +1981,7 @@ Name of the S3 bucket for storing software and bootstrap package.
     software_intallers_bucket: some-bucket
   ```
 
-##### s3_software_installers_prefix
+### s3_software_installers_prefix
 
 Prefix to prepend to software.
 
@@ -2156,7 +1993,7 @@ Prefix to prepend to software.
     software_intallers_prefix: prefix-here/
   ```
 
-##### s3_software_installers_access_key_id
+### s3_software_installers_access_key_id
 
 AWS access key ID to use for S3 authentication.
 
@@ -2173,7 +2010,7 @@ The IAM identity used in this context must be allowed to perform the following a
     software_intallers_access_key_id: AKIAIOSFODNN7EXAMPLE
   ```
 
-##### s3_software_installers_secret_access_key
+### s3_software_installers_secret_access_key
 
 AWS secret access key to use for S3 authentication.
 
@@ -2185,7 +2022,7 @@ AWS secret access key to use for S3 authentication.
     software_intallers_secret_access_key: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
   ```
 
-##### s3_software_installers_sts_assume_role_arn
+### s3_software_installers_sts_assume_role_arn
 
 AWS STS role ARN to use for S3 authentication.
 
@@ -2197,7 +2034,7 @@ AWS STS role ARN to use for S3 authentication.
     software_intallers_sts_assume_role_arn: arn:aws:iam::1234567890:role/some-s3-role
   ```
 
-##### s3_software_installers_sts_external_id
+### s3_software_installers_sts_external_id
 
 AWS STS External ID to use for S3 authentication. This is typically used in
 conjunction with an STS role ARN to ensure that only the intended AWS account can assume the role.
@@ -2210,7 +2047,7 @@ conjunction with an STS role ARN to ensure that only the intended AWS account ca
    software_intallers_sts_external_id: your_unique_id
   ```
 
-##### s3_software_installers_endpoint_url
+### s3_software_installers_endpoint_url
 
 AWS S3 Endpoint URL. Override when using a different S3 compatible object storage backend (such as Minio),
 or running s3 locally with localstack. Leave this blank to use the default S3 service endpoint.
@@ -2223,7 +2060,7 @@ or running s3 locally with localstack. Leave this blank to use the default S3 se
     software_intallers_endpoint_url: http://localhost:9000
   ```
 
-##### s3_software_installers_force_s3_path_style
+### s3_software_installers_force_s3_path_style
 
 AWS S3 Force S3 Path Style. Set this to `true` to force the request to use path-style addressing,
 i.e., `http://s3.amazonaws.com/BUCKET/KEY`. By default, the S3 client
@@ -2240,7 +2077,7 @@ See [here](http://docs.aws.amazon.com/AmazonS3/latest/dev/VirtualHosting.html) f
     software_intallers_force_s3_path_style: false
   ```
 
-##### s3_software_installers_region
+### s3_software_installers_region
 
 AWS S3 Region. Leave blank to enable region discovery.
 
@@ -2254,7 +2091,7 @@ Minio users must set this to any nonempty value (eg. `minio`), as Minio does not
     software_intallers_region: us-east-1
   ```
 
-##### s3_carves_bucket
+### s3_carves_bucket
 
 Name of the S3 bucket for file carves.
 
@@ -2266,7 +2103,7 @@ Name of the S3 bucket for file carves.
      carves_bucket: some-bucket
   ```
 
-##### s3_carves_prefix
+### s3_carves_prefix
 
 All carve objects will also be prefixed by date and hour (UTC), making the resulting keys look like: `<prefix><year>/<month>/<day>/<hour>/<carve-name>`.
 
@@ -2278,7 +2115,7 @@ All carve objects will also be prefixed by date and hour (UTC), making the resul
      carves_prefix: prefix-here/
   ```
 
-##### s3_carves_access_key_id
+### s3_carves_access_key_id
 
 - Default value: none
 - Environment variable: `FLEET_S3_CARVES_ACCESS_KEY_ID`
@@ -2288,7 +2125,7 @@ All carve objects will also be prefixed by date and hour (UTC), making the resul
     carves_access_key_id: AKIAIOSFODNN7EXAMPLE
   ```
 
-##### s3_carves_secret_access_key
+### s3_carves_secret_access_key
 
 - Default value: none
 - Environment variable: `FLEET_S3_CARVES_SECRET_ACCESS_KEY`
@@ -2298,7 +2135,7 @@ All carve objects will also be prefixed by date and hour (UTC), making the resul
      carves_secret_access_key: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
   ```
 
-##### s3_carves_sts_assume_role_arn
+### s3_carves_sts_assume_role_arn
 
 - Default value: none
 - Environment variable: `FLEET_S3_CARVES_STS_ASSUME_ROLE_ARN`
@@ -2308,7 +2145,7 @@ All carve objects will also be prefixed by date and hour (UTC), making the resul
      carves_sts_assume_role_arn: arn:aws:iam::1234567890:role/some-s3-role
   ```
 
-##### s3_carves_sts_external_id
+### s3_carves_sts_external_id
 
 - Default value: none
 - Environment variable: `FLEET_S3_CARVES_STS_EXTERNAL_ID`
@@ -2318,7 +2155,7 @@ All carve objects will also be prefixed by date and hour (UTC), making the resul
      carves_sts_external_id: your_unique_id
   ```
 
-##### s3_carves_endpoint_url
+### s3_carves_endpoint_url
 
 - Default value: none
 - Environment variable: `FLEET_S3_CARVES_ENDPOINT_URL`
@@ -2328,7 +2165,7 @@ All carve objects will also be prefixed by date and hour (UTC), making the resul
      carves_endpoint_url: http://localhost:9000
   ```
 
-##### s3_carves_force_s3_path_style
+### s3_carves_force_s3_path_style
 
 - Default value: false
 - Environment variable: `FLEET_S3_CARVES_FORCE_S3_PATH_STYLE`
@@ -2338,7 +2175,7 @@ All carve objects will also be prefixed by date and hour (UTC), making the resul
      carves_force_s3_path_style: false
   ```
 
-##### s3_carves_region
+### s3_carves_region
 
 - Default value:
 - Environment variable: `FLEET_S3_CARVES_REGION`
@@ -2348,27 +2185,9 @@ All carve objects will also be prefixed by date and hour (UTC), making the resul
     carves_region: us-east-1
   ```
 
-##### Example YAML
+## Upgrades
 
-```yaml
-s3:
-  software_installers_bucket: software-installers-bucket
-  software_installers_prefix: prefix-here/
-  software_installers_access_key_id: AKIAIOSFODNN7EXAMPLE
-  software_installers_secret_access_key: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
-  software_installers_sts_assume_role_arn: arn:aws:iam::1234567890:role/some-s3-role
-  software_installers_region: us-east-1
-  carves_bucket: carves-bucket
-  carves_prefix: prefix-here/
-  carves_access_key_id: AKIAIOSFODNN7EXAMPLE
-  carves_secret_access_key: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
-  carves_sts_assume_role_arn: arn:aws:iam::1234567890:role/some-s3-role
-  carves_region: us-east-1
-```
-
-#### Upgrades
-
-##### allow_missing_migrations
+### allow_missing_migrations
 
 If set then `fleet serve` will run even if there are database migrations missing.
 
@@ -2380,9 +2199,9 @@ If set then `fleet serve` will run even if there are database migrations missing
     allow_missing_migrations: true
   ```
 
-#### Vulnerabilities
+## Vulnerabilities
 
-##### databases_path
+### databases_path
 
 The path specified needs to exist and Fleet needs to be able to read and write to and from it. This is the only mandatory configuration needed for vulnerability processing to work.
 
@@ -2396,7 +2215,7 @@ When `disable_schedule` is set to `false` (the default), Fleet instances will tr
     databases_path: /some/path
   ```
 
-##### periodicity
+### periodicity
 
 How often vulnerabilities are checked. This is also the interval at which the counts of hosts per software is calculated.
 
@@ -2408,7 +2227,7 @@ How often vulnerabilities are checked. This is also the interval at which the co
     periodicity: 1h
   ```
 
-##### cpe_database_url
+### cpe_database_url
 
 You can fetch the CPE dictionary database from this URL. Some users want to control where Fleet gets its database.
 When Fleet sees this value defined, it downloads the file directly.
@@ -2423,7 +2242,7 @@ If this value is not defined, Fleet checks for the latest release in Github and 
     cpe_database_url: ""
   ```
 
-##### cpe_translations_url
+### cpe_translations_url
 
 You can fetch the CPE translations from this URL.
 Translations are used when matching software to CPE entries in the CPE database that would otherwise be missed for various reasons.
@@ -2439,7 +2258,7 @@ If this value is not defined, Fleet checks for the latest release in Github and 
     cpe_translations_url: ""
   ```
 
-##### cve_feed_prefix_url
+### cve_feed_prefix_url
 
 Like the CPE dictionary, we allow users to define where to get the legacy CVE feeds from.
 In this case, the URL should be a host that serves the files in the legacy feed format.
@@ -2456,7 +2275,7 @@ When not defined, Fleet downloads CVE information from the nvd.nist.gov host usi
     cve_feed_prefix_url: ""
   ```
 
-##### disable_schedule
+### disable_schedule
 
 When running multiple instances of the Fleet server, by default, one of them dynamically takes the lead in vulnerability processing. This lead can change over time. Some Fleet users want to be able to define which deployment is doing this checking. If you wish to do this, you'll need to deploy your Fleet instances with this set explicitly to `true` and one of them set to `false`.
 
@@ -2471,7 +2290,7 @@ tools like crontab.
     disable_schedule: false
   ```
 
-##### disable_data_sync
+### disable_data_sync
 
 Fleet by default automatically downloads and keeps the different data streams needed to properly do vulnerability processing. In some setups, this behavior is not wanted, as access to outside resources might be blocked, or the data stream files might need review/audit before use.
 
@@ -2487,7 +2306,7 @@ To download the data streams, you can use `fleetctl vulnerability-data-stream --
     disable_data_sync: true
   ```
 
-##### recent_vulnerability_max_age
+### recent_vulnerability_max_age
 
 Maximum age of a vulnerability (a CVE) to be considered "recent". The age is calculated based on the published date of the CVE in the [National Vulnerability Database](https://nvd.nist.gov/) (NVD). Recent vulnerabilities play a special role in Fleet's [automations](https://fleetdm.com/docs/using-fleet/automations), as they are reported when discovered on a host if the vulnerabilities webhook or a vulnerability integration is enabled.
 
@@ -2499,7 +2318,7 @@ Maximum age of a vulnerability (a CVE) to be considered "recent". The age is cal
        recent_vulnerability_max_age: 48h
   ```
 
-##### disable_win_os_vulnerabilities
+### disable_win_os_vulnerabilities
 
 If using osquery 5.4 or later, Fleet by default will fetch and store all applied Windows updates and use that for detecting Windows
 vulnerabilities — which might be a writing-intensive process (depending on the number of Windows hosts
@@ -2513,18 +2332,9 @@ in your Fleet). Setting this to true will cause Fleet to skip both processes.
     disable_win_os_vulnerabilities: true
   ```
 
-##### Example YAML
+## GeoIP
 
-```yaml
-vulnerabilities:
-  databases_path: /some/path
-  current_instance_checks: yes
-  disable_data_sync: true
-```
-
-#### GeoIP
-
-##### database_path
+### database_path
 
 The path to a valid Maxmind GeoIP database (mmdb). Support exists for the country & city versions of the database. If city database is supplied
 then Fleet will attempt to resolve the location via the city lookup, otherwise it defaults to the country lookup. The IP address used
@@ -2566,9 +2376,9 @@ work devices on them for e.g. oncall responsibilities.
     database_path: /some/path/to/geolite2.mmdb
   ```
 
-#### Sentry
+## Sentry
 
-##### DSN
+### DSN
 
 If set, then `Fleet serve` will capture errors and panics and push them to Sentry.
 
@@ -2580,10 +2390,9 @@ If set, then `Fleet serve` will capture errors and panics and push them to Sentr
     dsn: "https://somedsnprovidedby.sentry.com/"
   ```
 
+## Prometheus
 
-#### Prometheus
-
-##### basic_auth.username
+### basic_auth.username
 
 This is the username to use for HTTP Basic Auth on the `/metrics` endpoint.
 
@@ -2600,7 +2409,7 @@ If `basic_auth.username` is not set, then:
       username: "foo"
   ```
 
-##### basic_auth.password
+### basic_auth.password
 
 This is the password to use for HTTP Basic Auth on the `/metrics` endpoint.
 
@@ -2617,7 +2426,7 @@ If `basic_auth.password` is not set, then:
       password: "bar"
   ```
 
-##### basic_auth.disable
+### basic_auth.disable
 
 This allows running the Prometheus endpoint `/metrics` without HTTP Basic Auth.
 
@@ -2809,26 +2618,13 @@ Minio users must set this to any non-empty value (e.g., `minio`), as Minio does 
       region: us-east-1
   ``` -->
 
-##### Example YAML
-
-```yaml
-packaging:
-  s3:
-    bucket: some-bucket
-    prefix: installers-go-here/
-    access_key_id: AKIAIOSFODNN7EXAMPLE
-    secret_access_key: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
-    sts_assume_role_arn: arn:aws:iam::1234567890:role/some-s3-role
-    region: us-east-1
-```
-
-#### Mobile device management (MDM)
+## Mobile device management (MDM)
 
 > The [`server_private_key` configuration option](#server_private_key) is required for macOS MDM features.
 
 > The Apple Push Notification service (APNs), Simple Certificate Enrollment Protocol (SCEP), and Apple Business Manager (ABM) [certificate and key configuration](https://github.com/fleetdm/fleet/blob/fleet-v4.51.0/docs/Contributing/Configuration-for-contributors.md#mobile-device-management-mdm) are deprecated as of Fleet 4.51. They are maintained for backwards compatibility. Please upload your APNs certificate and ABM token. Learn how [here](https://fleetdm.com/docs/using-fleet/mdm-setup).
 
-##### mdm.apple_scep_signer_validity_days
+### mdm.apple_scep_signer_validity_days
 
 The number of days the signed SCEP client certificates will be valid.
 
@@ -2840,7 +2636,7 @@ The number of days the signed SCEP client certificates will be valid.
     apple_scep_signer_validity_days: 100
   ```
 
-##### mdm.apple_scep_signer_allow_renewal_days
+### mdm.apple_scep_signer_allow_renewal_days
 
 The number of days allowed to renew SCEP certificates.
 
@@ -2852,7 +2648,7 @@ The number of days allowed to renew SCEP certificates.
     apple_scep_signer_allow_renewal_days: 30
   ```
 
-##### mdm.apple_dep_sync_periodicity
+### mdm.apple_dep_sync_periodicity
 
 The duration between DEP device syncing (fetching and setting of DEP profiles). Only relevant if Apple Business Manager (ABM) is configured.
 
@@ -2863,7 +2659,8 @@ The duration between DEP device syncing (fetching and setting of DEP profiles). 
   mdm:
     apple_dep_sync_periodicity: 10m
   ```
-##### mdm.windows_wstep_identity_cert_bytes
+
+### mdm.windows_wstep_identity_cert_bytes
 
 The content of the Windows WSTEP identity certificate. An X.509 certificate, PEM-encoded.
 - Default value: ""
@@ -2879,7 +2676,7 @@ The content of the Windows WSTEP identity certificate. An X.509 certificate, PEM
 
 If your WSTEP certificate/key pair was compromised and you change the pair, the disk encryption keys will no longer be viewable on all macOS hosts' **Host details** page until you turn disk encryption off and back on.
 
-##### mdm.windows_wstep_identity_key_bytes
+### mdm.windows_wstep_identity_key_bytes
 
 The content of the Windows WSTEP identity key. An RSA private key, PEM-encoded.
 - Default value: ""


### PR DESCRIPTION
- Update section headers so that config options show up in the right side bar. Today, there's only one header that shows up in the sidebar:
![Screenshot 2024-11-05 at 3 29 29 PM](https://github.com/user-attachments/assets/a208f6fa-d48d-482d-b689-36ba36fb8764)
- Remove "Example YAML" sections b/c they're redundant. More to maintain
