### PR TITLE
Store/retrieve Fleet URL and enroll secret when MDM profile has been removed

### DIFF
--- a/orbit/changes/23438-fleetd-with-mdm-removed
+++ b/orbit/changes/23438-fleetd-with-mdm-removed
@@ -1,0 +1,1 @@
+Fixed issue with fleetd not able to connect to Fleet server after Fleet MDM profiles have been removed.

--- a/orbit/cmd/orbit/orbit.go
+++ b/orbit/cmd/orbit/orbit.go
@@ -436,8 +436,8 @@ func main() {
 					break
 				}
 
-				// if we didn't find the configuration values, try to read them from the files
-				// Get Fleet URL
+				// If we didn't find the configuration values, try to read them from the stored files.
+				// First, get Fleet URL
 				b, err := os.ReadFile(path.Join(c.String("root-dir"), constant.FleetURLFileName))
 				if err != nil {
 					if !errors.Is(err, os.ErrNotExist) {
@@ -449,10 +449,12 @@ func main() {
 						return fmt.Errorf("set fleet URL from file: %w", err)
 					}
 				}
-				// Get enroll secret
+				// Now, get enroll secret
 				if err := readEnrollSecretFromFile(path.Join(c.String("root-dir"), constant.OsqueryEnrollSecretFileName)); err != nil {
 					return err
 				}
+				// Since the normal enroll secret flow supports keychain, we can use it here as well.
+				// The story to remove the enroll secret from macOS MDM profile is: https://github.com/fleetdm/fleet/issues/16118
 				if err := tryReadEnrollSecretFromKeystore(); err != nil {
 					// Log the error but don't return it, as we want to keep trying to read the configuration
 					// from the system profile.

--- a/orbit/pkg/constant/constant.go
+++ b/orbit/pkg/constant/constant.go
@@ -71,4 +71,6 @@ const (
 	OsqueryTUFTargetName = "osqueryd"
 	// DesktopTUFTargetName is the target name of the Fleet Desktop component of fleetd in TUF.
 	DesktopTUFTargetName = "desktop"
+	// FleetURLFileName is the file where Fleet URL is stored after being read from Apple config profile.
+	FleetURLFileName = "fleet_url.txt"
 )


### PR DESCRIPTION
#23438

# Demo
<div>
    <a href="https://www.loom.com/share/d5c0340512df49acba1f5412789f145b">
      <p>[Demo] fleetd connecting to Fleet server when MDM profiles removed (#23438) - Watch Video</p>
    </a>
    <a href="https://www.loom.com/share/d5c0340512df49acba1f5412789f145b">
      <img style="max-width:300px;" src="https://cdn.loom.com/sessions/thumbnails/d5c0340512df49acba1f5412789f145b-6688b64fea2e09ca-full-play.gif">
    </a>
  </div>

# Checklist for submitter
- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/Committing-Changes.md#changes-files) for more information.
- [x] Manual QA for all new/changed functionality
- For Orbit and Fleet Desktop changes:
   - [x] Orbit runs on macOS, Linux and Windows. Check if the orbit feature/bugfix should only apply to one platform (`runtime.GOOS`).
   - [x] Manual QA must be performed in the three main OSs, macOS, Windows and Linux.
   - [x] Auto-update manual QA, from released version of component to new version (see [tools/tuf/test](../tools/tuf/test/README.md)).
