### PR TITLE
Allow uploading PKG without Distribution.xml

### DIFF
--- a/changes/23213-okta-verify
+++ b/changes/23213-okta-verify
@@ -1,0 +1,1 @@
+Fixed issue with uploading macOS software packages that do not have a top level Distribution.xml, but do have a top level PackageInfo.xml. For example, Okta Verify.app

--- a/pkg/file/testdata/packageInfo/packageInfo-empty.xml
+++ b/pkg/file/testdata/packageInfo/packageInfo-empty.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="utf-8"?>
+<pkg-info/>

--- a/pkg/file/testdata/packageInfo/packageInfo-iriunWebcam.xml
+++ b/pkg/file/testdata/packageInfo/packageInfo-iriunWebcam.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<pkg-info overwrite-permissions="true" relocatable="false" identifier="com.iriun.pkg.webcam.tmp" postinstall-action="none" version="0" format-version="2" generator-version="InstallCmds-834 (23G93)" auth="root">
+    <payload numberOfFiles="54" installKBytes="20220"/>
+    <bundle path="./Applications/IriunWebcam.app/Contents/Library/SystemExtensions/com.iriun.macwebcam.extension4.systemextension" id="com.iriun.macwebcam.extension4" CFBundleShortVersionString="1.2" CFBundleVersion="3"/>
+    <bundle path="./Applications/IriunWebcam.app/Contents/Library/SystemExtensions/com.iriun.macwebcam.extension.systemextension" id="com.iriun.macwebcam.extension" CFBundleShortVersionString="1.2" CFBundleVersion="3"/>
+    <bundle id="com.iriun.macwebcam" CFBundleShortVersionString="2.8.10" path="./Applications/IriunWebcam.app"/>
+    <bundle path="./Library/Audio/Plug-Ins/HAL/IriunMic.driver" id="com.iriun.mic" CFBundleShortVersionString="1.5" CFBundleVersion="6"/>
+    <bundle-version>
+        <bundle id="com.iriun.macwebcam"/>
+        <bundle id="com.iriun.mic"/>
+    </bundle-version>
+    <upgrade-bundle>
+        <bundle id="com.iriun.macwebcam"/>
+        <bundle id="com.iriun.mic"/>
+    </upgrade-bundle>
+    <update-bundle/>
+    <atomic-update-bundle/>
+    <strict-identifier>
+        <bundle id="com.iriun.macwebcam"/>
+    </strict-identifier>
+    <relocate>
+        <bundle id="com.iriun.macwebcam"/>
+    </relocate>
+    <scripts>
+        <preinstall file="./preinstall"/>
+        <postinstall file="./postinstall"/>
+    </scripts>
+</pkg-info>

--- a/pkg/file/testdata/packageInfo/packageInfo-oktaVerify.xml
+++ b/pkg/file/testdata/packageInfo/packageInfo-oktaVerify.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<pkg-info overwrite-permissions="true" relocatable="false" identifier="com.okta.mobile" postinstall-action="none" version="9.27.0" format-version="2" generator-version="InstallCmds-834 (23B74)" install-location="/Applications" auth="root" minimumSystemVersion="12.0">
+    <payload numberOfFiles="270" installKBytes="134424"/>
+    <bundle path="./Okta Verify.app" id="com.okta.mobile" CFBundleShortVersionString="9.27.0" CFBundleVersion="2024.1004.1653"/>
+    <bundle-version>
+        <bundle id="com.okta.mobile"/>
+    </bundle-version>
+    <upgrade-bundle>
+        <bundle id="com.okta.mobile"/>
+    </upgrade-bundle>
+    <update-bundle/>
+    <atomic-update-bundle/>
+    <strict-identifier>
+        <bundle id="com.okta.mobile"/>
+    </strict-identifier>
+    <relocate>
+        <bundle id="com.okta.mobile"/>
+    </relocate>
+    <scripts>
+        <postinstall file="./postinstall"/>
+    </scripts>
+</pkg-info>

--- a/pkg/file/testdata/packageInfo/packageInfo-scriptOnly.xml
+++ b/pkg/file/testdata/packageInfo/packageInfo-scriptOnly.xml
@@ -1,0 +1,6 @@
+<pkg-info format-version="2" identifier="com.mygreatcompany.pkg.HelloWorld" version="1.2.3" relocatable="false" overwrite-permissions="false" followSymLinks="false" install-location="/" auth="root">
+    <payload installKBytes="0" numberOfFiles="1"/>
+    <scripts>
+        <preinstall file="./preinstall"/>
+    </scripts>
+</pkg-info>

--- a/pkg/file/testdata/packageInfo/packageInfo-versionOnly.xml
+++ b/pkg/file/testdata/packageInfo/packageInfo-versionOnly.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="utf-8"?>
+<pkg-info version="test-version"/>

--- a/pkg/file/xar.go
+++ b/pkg/file/xar.go
@@ -115,6 +115,7 @@ type distributionXML struct {
 type packageInfoXML struct {
 	Version         string               `xml:"version,attr"`
 	InstallLocation string               `xml:"install-location,attr"`
+	Identifier      string               `xml:"identifier,attr"`
 	Bundles         []distributionBundle `xml:"bundle"`
 }
 
@@ -432,6 +433,24 @@ func getPackageInfo(p *packageInfoXML) (name string, identifier string, version 
 	// Note: this version may be wrong since it is the version of the package and not the app
 	if version == "" {
 		version = fleet.Preprocess(p.Version)
+	}
+
+	// if we didn't find a bundle identifier, grab the identifier from pkg-info element
+	if identifier == "" {
+		identifier = fleet.Preprocess(p.Identifier)
+	}
+
+	// if we didn't find a name, grab the name from the identifier
+	if name == "" {
+		idParts := strings.Split(identifier, ".")
+		if len(idParts) > 0 {
+			name = idParts[len(idParts)-1]
+		}
+	}
+
+	// if we didn't find package IDs, use the identifier as the package ID
+	if len(packageIDs) == 0 && identifier != "" {
+		packageIDs = append(packageIDs, identifier)
 	}
 
 	return name, identifier, version, packageIDs

--- a/pkg/file/xar.go
+++ b/pkg/file/xar.go
@@ -31,6 +31,8 @@ import (
 	"io"
 	"path/filepath"
 	"strings"
+
+	"github.com/fleetdm/fleet/v4/server/fleet"
 )
 
 const (
@@ -110,6 +112,12 @@ type distributionXML struct {
 	PkgRefs []distributionPkgRef `xml:"pkg-ref"`
 }
 
+type packageInfoXML struct {
+	Version         string               `xml:"version,attr"`
+	InstallLocation string               `xml:"install-location,attr"`
+	Bundles         []distributionBundle `xml:"bundle"`
+}
+
 // distributionProduct represents the product element
 type distributionProduct struct {
 	ID      string `xml:"id,attr"`
@@ -181,29 +189,9 @@ func ExtractXARMetadata(r io.Reader) (*InstallerMetadata, error) {
 	heapOffset := xarHeaderSize + hdr.CompressedSize
 	for _, f := range root.TOC.Files {
 		if f.Name == "Distribution" {
-			var fileReader io.Reader
-			heapReader := io.NewSectionReader(rr, heapOffset, int64(len(b))-heapOffset)
-			fileReader = io.NewSectionReader(heapReader, f.Data.Offset, f.Data.Length)
-
-			// the distribution file can be compressed differently than the TOC, the
-			// actual compression is specified in the Encoding.Style field.
-			if strings.Contains(f.Data.Encoding.Style, "x-gzip") {
-				// despite the name, x-gzip fails to decode with the gzip package
-				// (invalid header), but it works with zlib.
-				zr, err := zlib.NewReader(fileReader)
-				if err != nil {
-					return nil, fmt.Errorf("create zlib reader: %w", err)
-				}
-				defer zr.Close()
-				fileReader = zr
-			} else if strings.Contains(f.Data.Encoding.Style, "x-bzip2") {
-				fileReader = bzip2.NewReader(fileReader)
-			}
-			// TODO: what other compression methods are supported?
-
-			contents, err := io.ReadAll(fileReader)
+			contents, err := readCompressedFile(rr, heapOffset, int64(len(b)), f)
 			if err != nil {
-				return nil, fmt.Errorf("reading Distribution file: %w", err)
+				return nil, err
 			}
 
 			meta, err := parseDistributionFile(contents)
@@ -211,11 +199,57 @@ func ExtractXARMetadata(r io.Reader) (*InstallerMetadata, error) {
 				return nil, fmt.Errorf("parsing Distribution file: %w", err)
 			}
 			meta.SHASum = h.Sum(nil)
-			return meta, err
+			return meta, nil
+		}
+	}
+
+	// If Distribution archive was not found, we look for a top-level PackageInfo archive
+	// Unofficial specs: http://s.sudre.free.fr/Stuff/Ivanhoe/FLAT.html
+	for _, f := range root.TOC.Files {
+		if f.Name == "PackageInfo" {
+			contents, err := readCompressedFile(rr, heapOffset, int64(len(b)), f)
+			if err != nil {
+				return nil, err
+			}
+
+			meta, err := parsePackageInfoFile(contents)
+			if err != nil {
+				return nil, fmt.Errorf("parsing PackageInfo file: %w", err)
+			}
+			meta.SHASum = h.Sum(nil)
+			return meta, nil
 		}
 	}
 
 	return &InstallerMetadata{SHASum: h.Sum(nil)}, nil
+}
+
+func readCompressedFile(rr *bytes.Reader, heapOffset int64, sectionLength int64, f *xmlFile) ([]byte, error) {
+	var fileReader io.Reader
+	heapReader := io.NewSectionReader(rr, heapOffset, sectionLength-heapOffset)
+	fileReader = io.NewSectionReader(heapReader, f.Data.Offset, f.Data.Length)
+
+	// the distribution file can be compressed differently than the TOC, the
+	// actual compression is specified in the Encoding.Style field.
+	if strings.Contains(f.Data.Encoding.Style, "x-gzip") {
+		// despite the name, x-gzip fails to decode with the gzip package
+		// (invalid header), but it works with zlib.
+		zr, err := zlib.NewReader(fileReader)
+		if err != nil {
+			return nil, fmt.Errorf("create zlib reader: %w", err)
+		}
+		defer zr.Close()
+		fileReader = zr
+	} else if strings.Contains(f.Data.Encoding.Style, "x-bzip2") {
+		fileReader = bzip2.NewReader(fileReader)
+	}
+	// TODO: what other compression methods are supported?
+
+	contents, err := io.ReadAll(fileReader)
+	if err != nil {
+		return nil, fmt.Errorf("reading %s file: %w", f.Name, err)
+	}
+	return contents, nil
 }
 
 func parseDistributionFile(rawXML []byte) (*InstallerMetadata, error) {
@@ -348,6 +382,56 @@ out:
 				version = pkgRef.Version
 			}
 		}
+	}
+
+	return name, identifier, version, packageIDs
+}
+
+func parsePackageInfoFile(rawXML []byte) (*InstallerMetadata, error) {
+	var packageInfo packageInfoXML
+	if err := xml.Unmarshal(rawXML, &packageInfo); err != nil {
+		return nil, fmt.Errorf("unmarshal PackageInfo XML: %w", err)
+	}
+
+	name, identifier, version, packageIDs := getPackageInfo(&packageInfo)
+	return &InstallerMetadata{
+		Name:             name,
+		Version:          version,
+		BundleIdentifier: identifier,
+		PackageIDs:       packageIDs,
+	}, nil
+
+}
+
+// getPackageInfo gets the name, bundle identifier and version of a PKG top level PackageInfo file
+func getPackageInfo(p *packageInfoXML) (name string, identifier string, version string, packageIDs []string) {
+	var packageIDSet = make(map[string]struct{}, 1)
+	for _, bundle := range p.Bundles {
+		installPath := bundle.Path
+		if p.InstallLocation != "" {
+			installPath = filepath.Join(p.InstallLocation, installPath)
+		}
+		installPath = strings.TrimPrefix(installPath, "/")
+		installPath = strings.TrimPrefix(installPath, "./")
+		if base, isValid := isValidAppFilePath(installPath); isValid {
+			identifier = fleet.Preprocess(bundle.ID)
+			name = base
+			version = fleet.Preprocess(bundle.CFBundleShortVersionString)
+		}
+		bundleID := fleet.Preprocess(bundle.ID)
+		if bundleID != "" {
+			packageIDSet[bundleID] = struct{}{}
+		}
+	}
+
+	for id := range packageIDSet {
+		packageIDs = append(packageIDs, id)
+	}
+
+	// if we didn't find a version, grab the version from pkg-info element
+	// Note: this version may be wrong since it is the version of the package and not the app
+	if version == "" {
+		version = fleet.Preprocess(p.Version)
 	}
 
 	return name, identifier, version, packageIDs

--- a/pkg/file/xar_test.go
+++ b/pkg/file/xar_test.go
@@ -211,7 +211,7 @@ func TestParseRealDistributionFiles(t *testing.T) {
 	}
 }
 
-func TestParseRealPackageInfoFiles(t *testing.T) {
+func TestParsePackageInfoFiles(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
 		file               string
@@ -234,6 +234,20 @@ func TestParseRealPackageInfoFiles(t *testing.T) {
 			expectedBundleID: "com.iriun.macwebcam",
 			expectedPackageIDs: []string{"com.iriun.macwebcam", "com.iriun.macwebcam.extension4", "com.iriun.macwebcam.extension",
 				"com.iriun.mic"},
+		},
+		{
+			file:               "packageInfo-empty.xml",
+			expectedName:       "",
+			expectedVersion:    "",
+			expectedBundleID:   "",
+			expectedPackageIDs: []string{},
+		},
+		{
+			file:               "packageInfo-versionOnly.xml",
+			expectedName:       "",
+			expectedVersion:    "test-version",
+			expectedBundleID:   "",
+			expectedPackageIDs: []string{},
 		},
 	}
 

--- a/pkg/file/xar_test.go
+++ b/pkg/file/xar_test.go
@@ -236,6 +236,13 @@ func TestParsePackageInfoFiles(t *testing.T) {
 				"com.iriun.mic"},
 		},
 		{
+			file:               "packageInfo-scriptOnly.xml",
+			expectedName:       "HelloWorld",
+			expectedVersion:    "1.2.3",
+			expectedBundleID:   "com.mygreatcompany.pkg.HelloWorld",
+			expectedPackageIDs: []string{"com.mygreatcompany.pkg.HelloWorld"},
+		},
+		{
 			file:               "packageInfo-empty.xml",
 			expectedName:       "",
 			expectedVersion:    "",

--- a/pkg/file/xar_test.go
+++ b/pkg/file/xar_test.go
@@ -211,6 +211,46 @@ func TestParseRealDistributionFiles(t *testing.T) {
 	}
 }
 
+func TestParseRealPackageInfoFiles(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		file               string
+		expectedName       string
+		expectedVersion    string
+		expectedBundleID   string
+		expectedPackageIDs []string
+	}{
+		{
+			file:               "packageInfo-oktaVerify.xml",
+			expectedName:       "Okta Verify.app",
+			expectedVersion:    "9.27.0",
+			expectedBundleID:   "com.okta.mobile",
+			expectedPackageIDs: []string{"com.okta.mobile"},
+		},
+		{
+			file:             "packageInfo-iriunWebcam.xml",
+			expectedName:     "IriunWebcam.app",
+			expectedVersion:  "2.8.10",
+			expectedBundleID: "com.iriun.macwebcam",
+			expectedPackageIDs: []string{"com.iriun.macwebcam", "com.iriun.macwebcam.extension4", "com.iriun.macwebcam.extension",
+				"com.iriun.mic"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.file, func(t *testing.T) {
+			rawXML, err := os.ReadFile(filepath.Join("testdata", "packageInfo", tt.file))
+			require.NoError(t, err)
+			metadata, err := parsePackageInfoFile(rawXML)
+			require.NoError(t, err)
+			assert.ElementsMatch(t, tt.expectedPackageIDs, metadata.PackageIDs)
+			assert.Equal(t, tt.expectedName, metadata.Name)
+			assert.Equal(t, tt.expectedVersion, metadata.Version)
+			assert.Equal(t, tt.expectedBundleID, metadata.BundleIdentifier)
+		})
+	}
+}
+
 func TestIsValidAppFilePath(t *testing.T) {
 	tests := []struct {
 		input    string


### PR DESCRIPTION
#23213
Use PackageInfo.xml if Distribution.xml does not exist in uploaded macOS PKG.

This means we now support script-only packages:
<div>
    <a href="https://www.loom.com/share/fb2f9fe93cb64f3aa1221f974ca0eb3a">
      <p>[Demo] Install script-only macOS package on Fleet (#23213) - Watch Video</p>
    </a>
    <a href="https://www.loom.com/share/fb2f9fe93cb64f3aa1221f974ca0eb3a">
      <img style="max-width:300px;" src="https://cdn.loom.com/sessions/thumbnails/fb2f9fe93cb64f3aa1221f974ca0eb3a-4b035241497a6c22-full-play.gif">
    </a>
  </div>

# Checklist for submitter
- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/Committing-Changes.md#changes-files) for more information.
- [x] Added/updated tests
- [x] Manual QA for all new/changed functionality
