### PR TITLE
Add zenity package

### DIFF
--- a/orbit/pkg/dialog/dialog.go
+++ b/orbit/pkg/dialog/dialog.go
@@ -24,9 +24,9 @@ type Dialog interface {
 	// ShowInfo displays a dialog that displays information. It returns an error if the dialog
 	// could not be displayed.
 	ShowInfo(ctx context.Context, opts InfoOptions) error
-	// Progress displays a dialog that shows progress. It returns a channel that can be used to
-	// end the dialog.
-	ShowProgress(ctx context.Context, opts ProgressOptions) chan struct{}
+	// Progress displays a dialog that shows progress. It waits until the
+	// context is cancelled.
+	ShowProgress(ctx context.Context, opts ProgressOptions) error
 }
 
 // EntryOptions represents options for a dialog that accepts end user input.
@@ -63,10 +63,4 @@ type ProgressOptions struct {
 
 	// Text sets the text of the dialog.
 	Text string
-
-	// Pulsate sets the progress bar to pulsate.
-	Pulsate bool
-
-	// NoCancel sets the dialog to grey out the cancel button.
-	NoCancel bool
 }

--- a/orbit/pkg/dialog/dialog.go
+++ b/orbit/pkg/dialog/dialog.go
@@ -1,0 +1,55 @@
+package dialog
+
+// Dialog represents a UI dialog that can be displayed to the end user
+// on a host
+
+import (
+	"context"
+	"errors"
+	"time"
+)
+
+var (
+	// ErrCanceled is returned when the dialog is canceled by the cancel button.
+	ErrCanceled = errors.New("dialog canceled")
+	// ErrTimeout is returned when the dialog is automatically closed due to a timeout.
+	ErrTimeout = errors.New("dialog timed out")
+	// ErrUnknown is returned when an unknown error occurs.
+	ErrUnknown = errors.New("unknown error")
+)
+
+type Dialog interface {
+	// ShowEntry displays a dialog that accepts end user input. It returns the entered
+	// text or errors ErrCanceled, ErrTimeout, or ErrUnknown.
+	ShowEntry(ctx context.Context, opts EntryOptions) ([]byte, error)
+	// ShowInfo displays a dialog that displays information. It returns an error if the dialog
+	// could not be displayed.
+	ShowInfo(ctx context.Context, opts InfoOptions) error
+}
+
+// EntryOptions represents options for a dialog that accepts end user input.
+type EntryOptions struct {
+	// Title sets the title of the dialog.
+	Title string
+
+	// Text sets the text of the dialog.
+	Text string
+
+	// HideText hides the text entered by the user.
+	HideText bool
+
+	// TimeOut sets the time in seconds before the dialog is automatically closed.
+	TimeOut time.Duration
+}
+
+// InfoOptions represents options for a dialog that displays information.
+type InfoOptions struct {
+	// Title sets the title of the dialog.
+	Title string
+
+	// Text sets the text of the dialog.
+	Text string
+
+	// Timeout sets the time in seconds before the dialog is automatically closed.
+	TimeOut time.Duration
+}

--- a/orbit/pkg/dialog/dialog.go
+++ b/orbit/pkg/dialog/dialog.go
@@ -1,8 +1,5 @@
 package dialog
 
-// Dialog represents a UI dialog that can be displayed to the end user
-// on a host
-
 import (
 	"context"
 	"errors"
@@ -18,6 +15,8 @@ var (
 	ErrUnknown = errors.New("unknown error")
 )
 
+// Dialog represents a UI dialog that can be displayed to the end user
+// on a host
 type Dialog interface {
 	// ShowEntry displays a dialog that accepts end user input. It returns the entered
 	// text or errors ErrCanceled, ErrTimeout, or ErrUnknown.
@@ -25,6 +24,9 @@ type Dialog interface {
 	// ShowInfo displays a dialog that displays information. It returns an error if the dialog
 	// could not be displayed.
 	ShowInfo(ctx context.Context, opts InfoOptions) error
+	// Progress displays a dialog that shows progress. It returns a channel that can be used to
+	// end the dialog.
+	ShowProgress(ctx context.Context, opts ProgressOptions) chan struct{}
 }
 
 // EntryOptions represents options for a dialog that accepts end user input.
@@ -52,4 +54,19 @@ type InfoOptions struct {
 
 	// Timeout sets the time in seconds before the dialog is automatically closed.
 	TimeOut time.Duration
+}
+
+// ProgressOptions represents options for a dialog that shows progress.
+type ProgressOptions struct {
+	// Title sets the title of the dialog.
+	Title string
+
+	// Text sets the text of the dialog.
+	Text string
+
+	// Pulsate sets the progress bar to pulsate.
+	Pulsate bool
+
+	// NoCancel sets the dialog to grey out the cancel button.
+	NoCancel bool
 }

--- a/orbit/pkg/execuser/execuser.go
+++ b/orbit/pkg/execuser/execuser.go
@@ -2,6 +2,8 @@
 // SYSTEM service on Windows) as the current login user.
 package execuser
 
+import "context"
+
 type eopts struct {
 	env        [][2]string
 	args       [][2]string
@@ -47,4 +49,15 @@ func RunWithOutput(path string, opts ...Option) (output []byte, exitCode int, er
 		fn(&o)
 	}
 	return runWithOutput(path, o)
+}
+
+// RunWithWait runs an application as the current login user and waits for it to finish
+// or to be canceled by the context.
+// It assumes the caller is running with high privileges (root on UNIX).
+func RunWithWait(ctx context.Context, path string, opts ...Option) error {
+	var o eopts
+	for _, fn := range opts {
+		fn(&o)
+	}
+	return runWithWait(ctx, path, o)
 }

--- a/orbit/pkg/execuser/execuser.go
+++ b/orbit/pkg/execuser/execuser.go
@@ -52,7 +52,7 @@ func RunWithOutput(path string, opts ...Option) (output []byte, exitCode int, er
 }
 
 // RunWithWait runs an application as the current login user and waits for it to finish
-// or to be canceled by the context.
+// or to be canceled by the context.  Canceling the context will not return an error.
 // It assumes the caller is running with high privileges (root on UNIX).
 func RunWithWait(ctx context.Context, path string, opts ...Option) error {
 	var o eopts

--- a/orbit/pkg/execuser/execuser.go
+++ b/orbit/pkg/execuser/execuser.go
@@ -43,6 +43,7 @@ func Run(path string, opts ...Option) (lastLogs string, err error) {
 // It assumes the caller is running with high privileges (root on UNIX).
 //
 // It blocks until the child process exits.
+// Non ExitError errors return with a -1 exitCode.
 func RunWithOutput(path string, opts ...Option) (output []byte, exitCode int, err error) {
 	var o eopts
 	for _, fn := range opts {

--- a/orbit/pkg/execuser/execuser.go
+++ b/orbit/pkg/execuser/execuser.go
@@ -19,10 +19,6 @@ func WithEnv(name, value string) Option {
 }
 
 // WithArg sets command line arguments for the application.
-//
-// TODO: for now CLI arguments are only used by the darwin
-// implementation, just because it's the only platform that needs
-// them.
 func WithArg(name, value string) Option {
 	return func(a *eopts) {
 		a.args = append(a.args, [2]string{name, value})
@@ -39,4 +35,16 @@ func Run(path string, opts ...Option) (lastLogs string, err error) {
 		fn(&o)
 	}
 	return run(path, o)
+}
+
+// RunWithOutput runs an application as the current login user and returns its output.
+// It assumes the caller is running with high privileges (root on UNIX).
+//
+// It blocks until the child process exits.
+func RunWithOutput(path string, opts ...Option) (output []byte, exitCode int, err error) {
+	var o eopts
+	for _, fn := range opts {
+		fn(&o)
+	}
+	return runWithOutput(path, o)
 }

--- a/orbit/pkg/execuser/execuser_darwin.go
+++ b/orbit/pkg/execuser/execuser_darwin.go
@@ -1,6 +1,7 @@
 package execuser
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -51,4 +52,8 @@ func run(path string, opts eopts) (lastLogs string, err error) {
 
 func runWithOutput(path string, opts eopts) (output []byte, exitCode int, err error) {
 	return nil, 0, errors.New("not implemented")
+}
+
+func runWithWait(ctx context.Context, path string, opts eopts) error {
+	return errors.New("not implemented")
 }

--- a/orbit/pkg/execuser/execuser_darwin.go
+++ b/orbit/pkg/execuser/execuser_darwin.go
@@ -1,6 +1,7 @@
 package execuser
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -46,4 +47,8 @@ func run(path string, opts eopts) (lastLogs string, err error) {
 		return tw.String(), fmt.Errorf("open path %q: %w", path, err)
 	}
 	return tw.String(), nil
+}
+
+func runWithOutput(path string, opts eopts) (output []byte, exitCode int, err error) {
+	return nil, 0, errors.New("not implemented")
 }

--- a/orbit/pkg/execuser/execuser_linux.go
+++ b/orbit/pkg/execuser/execuser_linux.go
@@ -66,6 +66,7 @@ func runWithOutput(path string, opts eopts) (output []byte, exitCode int, err er
 	if err != nil {
 		if exitErr, ok := err.(*exec.ExitError); ok {
 			exitCode = exitErr.ExitCode()
+			return output, exitCode, fmt.Errorf("%q exited with code %d: %w", path, exitCode, err)
 		}
 		return output, -1, fmt.Errorf("%q error: %w", path, err)
 	}

--- a/orbit/pkg/execuser/execuser_linux.go
+++ b/orbit/pkg/execuser/execuser_linux.go
@@ -3,6 +3,7 @@ package execuser
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -18,56 +19,12 @@ import (
 
 // run uses sudo to run the given path as login user.
 func run(path string, opts eopts) (lastLogs string, err error) {
-	user, err := getLoginUID()
+	args, err := getUserAndDisplayArgs(path, opts)
 	if err != nil {
-		return "", fmt.Errorf("get user: %w", err)
+		return "", fmt.Errorf("get args: %w", err)
 	}
-
-	// TODO(lucas): Default to display :0 if user DISPLAY environment variable
-	// could not be found, revisit when working on multi-user/multi-session support.
-	// This assumes there's only one desktop session and belongs to the
-	// user returned in `getLoginUID'.
-	defaultDisplay := ":0"
-
-	log.Info().
-		Str("user", user.name).
-		Int64("id", user.id).
-		Msg("attempting to get user's DISPLAY")
-
-	display, err := getUserDisplay(user.name, opts)
-	if err != nil {
-		log.Error().
-			Str("user", user.name).
-			Int64("id", user.id).
-			Err(err).
-			Msgf("failed to get user's DISPLAY, using default %s", defaultDisplay)
-		display = defaultDisplay
-	} else if display == "" {
-		log.Warn().
-			Str("user", user.name).
-			Int64("id", user.id).
-			Msgf("user's DISPLAY not found, using default %s", defaultDisplay)
-		display = defaultDisplay
-	}
-
-	log.Info().
-		Str("path", path).
-		Str("user", user.name).
-		Int64("id", user.id).
-		Str("display", display).
-		Msg("running sudo")
-
-	args := argsForSudo(user, opts)
 
 	args = append(args,
-		"DISPLAY="+display,
-		// DBUS_SESSION_BUS_ADDRESS sets the location of the user login session bus.
-		// Required by the libayatana-appindicator3 library to display a tray icon
-		// on the desktop session.
-		//
-		// This is required for Ubuntu 18, and not required for Ubuntu 21/22
-		// (because it's already part of the user).
-		fmt.Sprintf("DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/%d/bus", user.id),
 		// Append the packaged libayatana-appindicator3 libraries path to LD_LIBRARY_PATH.
 		//
 		// Fleet Desktop doesn't use libayatana-appindicator3 since 1.18.3, but we need to
@@ -89,9 +46,59 @@ func run(path string, opts eopts) (lastLogs string, err error) {
 
 // run uses sudo to run the given path as login user and waits for the process to finish.
 func runWithOutput(path string, opts eopts) (output []byte, exitCode int, err error) {
+	args, err := getUserAndDisplayArgs(path, opts)
+	if err != nil {
+		return nil, 0, fmt.Errorf("get args: %w", err)
+	}
+
+	if len(opts.args) > 0 {
+		for _, arg := range opts.args {
+			args = append(args, arg[0], arg[1])
+		}
+	}
+
+	args = append(args, path)
+
+	cmd := exec.Command("sudo", args...)
+	log.Printf("cmd=%s", cmd.String())
+
+	output, err = cmd.Output()
+	if err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			exitCode = exitErr.ExitCode()
+		}
+		return output, exitCode, fmt.Errorf("%q error: %w", path, err)
+	}
+
+	return output, exitCode, nil
+}
+
+func runWithWait(ctx context.Context, path string, opts eopts) error {
+	args, err := getUserAndDisplayArgs(path, opts)
+	if err != nil {
+		return fmt.Errorf("get args: %w", err)
+	}
+
+	args = append(args, path)
+
+	cmd := exec.CommandContext(ctx, "sudo", args...)
+	log.Printf("cmd=%s", cmd.String())
+
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("cmd %q: %w", path, err)
+	}
+
+	if err := cmd.Wait(); err != nil {
+		return fmt.Errorf("cmd %q: %w", path, err)
+	}
+
+	return nil
+}
+
+func getUserAndDisplayArgs(path string, opts eopts) ([]string, error) {
 	user, err := getLoginUID()
 	if err != nil {
-		return output, exitCode, fmt.Errorf("get user: %w", err)
+		return nil, fmt.Errorf("get user: %w", err)
 	}
 
 	// TODO(lucas): Default to display :0 if user DISPLAY environment variable
@@ -139,32 +146,9 @@ func runWithOutput(path string, opts eopts) (output []byte, exitCode int, err er
 		// This is required for Ubuntu 18, and not required for Ubuntu 21/22
 		// (because it's already part of the user).
 		fmt.Sprintf("DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/%d/bus", user.id),
-		// Append the packaged libayatana-appindicator3 libraries path to LD_LIBRARY_PATH.
-		//
-		// Fleet Desktop doesn't use libayatana-appindicator3 since 1.18.3, but we need to
-		// keep this to support older versions of Fleet Desktop.
-		fmt.Sprintf("LD_LIBRARY_PATH=%s:%s", filepath.Dir(path), os.ExpandEnv("$LD_LIBRARY_PATH")),
-		path,
 	)
 
-	if len(opts.args) > 0 {
-		for _, arg := range opts.args {
-			args = append(args, arg[0], arg[1])
-		}
-	}
-
-	cmd := exec.Command("sudo", args...)
-	log.Printf("cmd=%s", cmd.String())
-
-	output, err = cmd.Output()
-	if err != nil {
-		if exitErr, ok := err.(*exec.ExitError); ok {
-			exitCode = exitErr.ExitCode()
-		}
-		return output, exitCode, fmt.Errorf("%q error: %w", path, err)
-	}
-
-	return output, exitCode, nil
+	return args, nil
 }
 
 type user struct {

--- a/orbit/pkg/execuser/execuser_linux.go
+++ b/orbit/pkg/execuser/execuser_linux.go
@@ -87,6 +87,86 @@ func run(path string, opts eopts) (lastLogs string, err error) {
 	return "", nil
 }
 
+// run uses sudo to run the given path as login user and waits for the process to finish.
+func runWithOutput(path string, opts eopts) (output []byte, exitCode int, err error) {
+	user, err := getLoginUID()
+	if err != nil {
+		return output, exitCode, fmt.Errorf("get user: %w", err)
+	}
+
+	// TODO(lucas): Default to display :0 if user DISPLAY environment variable
+	// could not be found, revisit when working on multi-user/multi-session support.
+	// This assumes there's only one desktop session and belongs to the
+	// user returned in `getLoginUID'.
+	defaultDisplay := ":0"
+
+	log.Info().
+		Str("user", user.name).
+		Int64("id", user.id).
+		Msg("attempting to get user's DISPLAY")
+
+	display, err := getUserDisplay(user.name, opts)
+	if err != nil {
+		log.Error().
+			Str("user", user.name).
+			Int64("id", user.id).
+			Err(err).
+			Msgf("failed to get user's DISPLAY, using default %s", defaultDisplay)
+		display = defaultDisplay
+	} else if display == "" {
+		log.Warn().
+			Str("user", user.name).
+			Int64("id", user.id).
+			Msgf("user's DISPLAY not found, using default %s", defaultDisplay)
+		display = defaultDisplay
+	}
+
+	log.Info().
+		Str("path", path).
+		Str("user", user.name).
+		Int64("id", user.id).
+		Str("display", display).
+		Msg("running sudo")
+
+	args := argsForSudo(user, opts)
+
+	args = append(args,
+		"DISPLAY="+display,
+		// DBUS_SESSION_BUS_ADDRESS sets the location of the user login session bus.
+		// Required by the libayatana-appindicator3 library to display a tray icon
+		// on the desktop session.
+		//
+		// This is required for Ubuntu 18, and not required for Ubuntu 21/22
+		// (because it's already part of the user).
+		fmt.Sprintf("DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/%d/bus", user.id),
+		// Append the packaged libayatana-appindicator3 libraries path to LD_LIBRARY_PATH.
+		//
+		// Fleet Desktop doesn't use libayatana-appindicator3 since 1.18.3, but we need to
+		// keep this to support older versions of Fleet Desktop.
+		fmt.Sprintf("LD_LIBRARY_PATH=%s:%s", filepath.Dir(path), os.ExpandEnv("$LD_LIBRARY_PATH")),
+		path,
+	)
+
+	if len(opts.args) > 0 {
+		for _, arg := range opts.args {
+			args = append(args, arg[0], arg[1])
+		}
+	}
+
+	cmd := exec.Command("sudo", args...)
+	log.Printf("cmd=%s", cmd.String())
+
+	output, err = cmd.Output()
+	if err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			exitCode = exitErr.ExitCode()
+		}
+		return output, exitCode, fmt.Errorf("%q error: %w", path, err)
+	}
+
+	return output, exitCode, nil
+}
+
 type user struct {
 	name string
 	id   int64

--- a/orbit/pkg/execuser/execuser_linux.go
+++ b/orbit/pkg/execuser/execuser_linux.go
@@ -48,7 +48,7 @@ func run(path string, opts eopts) (lastLogs string, err error) {
 func runWithOutput(path string, opts eopts) (output []byte, exitCode int, err error) {
 	args, err := getUserAndDisplayArgs(path, opts)
 	if err != nil {
-		return nil, 0, fmt.Errorf("get args: %w", err)
+		return nil, -1, fmt.Errorf("get args: %w", err)
 	}
 
 	args = append(args, path)
@@ -67,7 +67,7 @@ func runWithOutput(path string, opts eopts) (output []byte, exitCode int, err er
 		if exitErr, ok := err.(*exec.ExitError); ok {
 			exitCode = exitErr.ExitCode()
 		}
-		return output, exitCode, fmt.Errorf("%q error: %w", path, err)
+		return output, -1, fmt.Errorf("%q error: %w", path, err)
 	}
 
 	return output, exitCode, nil

--- a/orbit/pkg/execuser/execuser_windows.go
+++ b/orbit/pkg/execuser/execuser_windows.go
@@ -117,6 +117,10 @@ func run(path string, opts eopts) (lastLogs string, err error) {
 	return "", startProcessAsCurrentUser(path, "", "")
 }
 
+func runWithOutput(path string, opts eopts) (output []byte, exitCode int, err error) {
+	return nil, 0, errors.New("not implemented")
+}
+
 // getCurrentUserSessionId will attempt to resolve
 // the session ID of the user currently active on
 // the system.

--- a/orbit/pkg/execuser/execuser_windows.go
+++ b/orbit/pkg/execuser/execuser_windows.go
@@ -6,6 +6,7 @@ package execuser
 // To view what was modified/added, you can use the execuser_windows_diff.sh script.
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -119,6 +120,10 @@ func run(path string, opts eopts) (lastLogs string, err error) {
 
 func runWithOutput(path string, opts eopts) (output []byte, exitCode int, err error) {
 	return nil, 0, errors.New("not implemented")
+}
+
+func runWithWait(ctx context.Context, path string, opts eopts) error {
+	return errors.New("not implemented")
 }
 
 // getCurrentUserSessionId will attempt to resolve

--- a/orbit/pkg/zenity/zenity.go
+++ b/orbit/pkg/zenity/zenity.go
@@ -1,5 +1,3 @@
-//go:build linux
-
 package zenity
 
 import (
@@ -51,7 +49,7 @@ type InfoOptions struct {
 }
 
 // NewZenity creates a new Zenity dialog instance for zenity v4 on Linux.
-func NewZenity() *Zenity {
+func New() *Zenity {
 	return &Zenity{
 		execCmdFn: execCmd,
 	}
@@ -119,7 +117,11 @@ func execCmd(ctx context.Context, args ...string) ([]byte, int, error) {
 	cmd := exec.CommandContext(ctx, "zenity", args...)
 	err := cmd.Run()
 	if err != nil {
-		return nil, cmd.ProcessState.ExitCode(), err
+		var exitCode int // exit 0 ok here if zenity returns an error
+		if cmd.ProcessState != nil {
+			exitCode = cmd.ProcessState.ExitCode()
+		}
+		return nil, exitCode, err
 	}
 
 	return nil, cmd.ProcessState.ExitCode(), nil

--- a/orbit/pkg/zenity/zenity.go
+++ b/orbit/pkg/zenity/zenity.go
@@ -60,16 +60,16 @@ func New() *Zenity {
 func (z *Zenity) ShowEntry(ctx context.Context, opts EntryOptions) ([]byte, error) {
 	args := []string{"--entry"}
 	if opts.Title != "" {
-		args = append(args, fmt.Sprintf(`--title="%s"`, opts.Title))
+		args = append(args, "--title=", opts.Title)
 	}
 	if opts.Text != "" {
-		args = append(args, fmt.Sprintf(`--text="%s"`, opts.Text))
+		args = append(args, "--text=", opts.Text)
 	}
 	if opts.HideText {
 		args = append(args, "--hide-text")
 	}
 	if opts.TimeOut > 0 {
-		args = append(args, fmt.Sprintf("--timeout=%d", int(opts.TimeOut.Seconds())))
+		args = append(args, "--timeout=", fmt.Sprintf("%d", int(opts.TimeOut.Seconds())))
 	}
 
 	output, statusCode, err := z.execCmdFn(ctx, args...)
@@ -91,13 +91,13 @@ func (z *Zenity) ShowEntry(ctx context.Context, opts EntryOptions) ([]byte, erro
 func (z *Zenity) ShowInfo(ctx context.Context, opts InfoOptions) error {
 	args := []string{"--info"}
 	if opts.Title != "" {
-		args = append(args, fmt.Sprintf(`--title="%s"`, opts.Title))
+		args = append(args, "--title=", opts.Title)
 	}
 	if opts.Text != "" {
-		args = append(args, fmt.Sprintf(`--text="%s"`, opts.Text))
+		args = append(args, "--text=", opts.Text)
 	}
 	if opts.TimeOut > 0 {
-		args = append(args, fmt.Sprintf("--timeout=%d", int(opts.TimeOut.Seconds())))
+		args = append(args, "--timeout=", fmt.Sprintf("%d", int(opts.TimeOut.Seconds())))
 	}
 
 	_, statusCode, err := z.execCmdFn(ctx, args...)

--- a/orbit/pkg/zenity/zenity.go
+++ b/orbit/pkg/zenity/zenity.go
@@ -1,0 +1,60 @@
+package zenity
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"time"
+)
+
+type Zenity struct {
+	// CommandContext defined here for testing purposes.
+	CommandContext func(ctx context.Context, name string, arg ...string) *exec.Cmd
+}
+
+type ExitStatus int
+
+const (
+	Success ExitStatus = iota
+	Canceled
+	Timeout
+)
+
+// EntryOptions represents options for the Entry dialog.
+type EntryOptions struct {
+	// Title sets the title of the dialog.
+	Title string
+
+	// Text sets the text of the dialog.
+	Text string
+
+	// HideText hides the text entered by the user.
+	HideText bool
+
+	// TimeOut sets the time in seconds before the dialog is automatically closed.
+	TimeOut time.Duration
+}
+
+func NewZenity() *Zenity {
+	return &Zenity{
+		CommandContext: exec.CommandContext,
+	}
+}
+
+// ShowEntry displays an entry dialog.
+func (z *Zenity) ShowEntry(ctx context.Context, opts EntryOptions) {
+	args := []string{"--entry"}
+	if opts.Title != "" {
+		args = append(args, fmt.Sprintf(`--title="%s"`, opts.Title))
+	}
+	if opts.Text != "" {
+		args = append(args, fmt.Sprintf(`--text="%s"`, opts.Text))
+	}
+	if opts.HideText {
+		args = append(args, "--hide-text")
+	}
+	if opts.TimeOut > 0 {
+		args = append(args, fmt.Sprintf("--timeout=%d", int(opts.TimeOut.Seconds())))
+	}
+	z.CommandContext(ctx, "zenity", args...)
+}

--- a/orbit/pkg/zenity/zenity.go
+++ b/orbit/pkg/zenity/zenity.go
@@ -1,6 +1,7 @@
 package zenity
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 
@@ -86,5 +87,10 @@ func execCmd(ctx context.Context, args ...string) ([]byte, int, error) {
 		opts = append(opts, execuser.WithArg(arg, "")) // Using empty value for positional args
 	}
 
-	return execuser.RunWithOutput("zenity", opts...)
+	output, exitCode, err := execuser.RunWithOutput("zenity", opts...)
+
+	// Trim the newline from zenity output
+	output = bytes.TrimSuffix(output, []byte("\n"))
+
+	return output, exitCode, err
 }

--- a/orbit/pkg/zenity/zenity.go
+++ b/orbit/pkg/zenity/zenity.go
@@ -115,6 +115,7 @@ func (z *Zenity) ShowInfo(ctx context.Context, opts InfoOptions) error {
 
 func execCmd(ctx context.Context, args ...string) ([]byte, int, error) {
 	cmd := exec.CommandContext(ctx, "zenity", args...)
+	fmt.Println(cmd.String())
 	err := cmd.Run()
 	if err != nil {
 		var exitCode int // exit 0 ok here if zenity returns an error

--- a/orbit/pkg/zenity/zenity.go
+++ b/orbit/pkg/zenity/zenity.go
@@ -17,7 +17,7 @@ type Zenity struct {
 	cmdWithWait func(ctx context.Context, args ...string) error
 }
 
-// NewZenity creates a new Zenity dialog instance for zenity v4 on Linux.
+// New creates a new Zenity dialog instance for zenity v4 on Linux.
 // Zenity implements the Dialog interface.
 func New() *Zenity {
 	return &Zenity{

--- a/orbit/pkg/zenity/zenity.go
+++ b/orbit/pkg/zenity/zenity.go
@@ -115,8 +115,7 @@ func (z *Zenity) ShowInfo(ctx context.Context, opts InfoOptions) error {
 
 func execCmd(ctx context.Context, args ...string) ([]byte, int, error) {
 	cmd := exec.CommandContext(ctx, "zenity", args...)
-	fmt.Println(cmd.String())
-	err := cmd.Run()
+	output, err := cmd.CombinedOutput()
 	if err != nil {
 		var exitCode int // exit 0 ok here if zenity returns an error
 		if cmd.ProcessState != nil {
@@ -125,5 +124,5 @@ func execCmd(ctx context.Context, args ...string) ([]byte, int, error) {
 		return nil, exitCode, err
 	}
 
-	return nil, cmd.ProcessState.ExitCode(), nil
+	return output, cmd.ProcessState.ExitCode(), nil
 }

--- a/orbit/pkg/zenity/zenity.go
+++ b/orbit/pkg/zenity/zenity.go
@@ -1,3 +1,5 @@
+//go:build linux
+
 package zenity
 
 import (
@@ -48,7 +50,7 @@ type InfoOptions struct {
 	TimeOut time.Duration
 }
 
-// NewZenity creates a new Zenity dialog instance for zenity v4
+// NewZenity creates a new Zenity dialog instance for zenity v4 on Linux.
 func NewZenity() *Zenity {
 	return &Zenity{
 		execCmdFn: execCmd,

--- a/orbit/pkg/zenity/zenity.go
+++ b/orbit/pkg/zenity/zenity.go
@@ -84,8 +84,15 @@ func (z *Zenity) ShowInfo(ctx context.Context, opts dialog.InfoOptions) error {
 	return nil
 }
 
-// ShowProgress displays a progress dialog. It returns a channel that can be used to
-// end the dialog.
+// ShowProgress starts a Zenity progress dialog with the given options.
+// This function is designed to block until the provided context is canceled.
+// It is intended to be used within a separate goroutine to avoid blocking
+// the main execution flow.
+//
+// If the context is already canceled, the function will return immediately.
+//
+// Use this function for cases where a progress dialog is needed to run
+// alongside other operations, with explicit cancellation or termination.
 func (z *Zenity) ShowProgress(ctx context.Context, opts dialog.ProgressOptions) error {
 	args := []string{"--progress"}
 	if opts.Title != "" {
@@ -94,12 +101,12 @@ func (z *Zenity) ShowProgress(ctx context.Context, opts dialog.ProgressOptions) 
 	if opts.Text != "" {
 		args = append(args, fmt.Sprintf("--text=%s", opts.Text))
 	}
-	if opts.Pulsate {
-		args = append(args, "--pulsate")
-	}
-	if opts.NoCancel {
-		args = append(args, "--no-cancel")
-	}
+
+	// --pulsate shows a pulsating progress bar
+	args = append(args, "--pulsate")
+
+	// --no-cancel disables the cancel button
+	args = append(args, "--no-cancel")
 
 	err := z.cmdWithWait(ctx, args...)
 	if err != nil {

--- a/orbit/pkg/zenity/zenity.go
+++ b/orbit/pkg/zenity/zenity.go
@@ -60,16 +60,16 @@ func New() *Zenity {
 func (z *Zenity) ShowEntry(ctx context.Context, opts EntryOptions) ([]byte, error) {
 	args := []string{"--entry"}
 	if opts.Title != "" {
-		args = append(args, "--title=", opts.Title)
+		args = append(args, fmt.Sprintf("--title=%q", opts.Title))
 	}
 	if opts.Text != "" {
-		args = append(args, "--text=", opts.Text)
+		args = append(args, fmt.Sprintf("--text=%q", opts.Text))
 	}
 	if opts.HideText {
 		args = append(args, "--hide-text")
 	}
 	if opts.TimeOut > 0 {
-		args = append(args, "--timeout=", fmt.Sprintf("%d", int(opts.TimeOut.Seconds())))
+		args = append(args, fmt.Sprintf("--timeout=%d", int(opts.TimeOut.Seconds())))
 	}
 
 	output, statusCode, err := z.execCmdFn(ctx, args...)
@@ -91,13 +91,13 @@ func (z *Zenity) ShowEntry(ctx context.Context, opts EntryOptions) ([]byte, erro
 func (z *Zenity) ShowInfo(ctx context.Context, opts InfoOptions) error {
 	args := []string{"--info"}
 	if opts.Title != "" {
-		args = append(args, "--title=", opts.Title)
+		args = append(args, fmt.Sprintf("--title=%q", opts.Title))
 	}
 	if opts.Text != "" {
-		args = append(args, "--text=", opts.Text)
+		args = append(args, fmt.Sprintf("--text=%q", opts.Text))
 	}
 	if opts.TimeOut > 0 {
-		args = append(args, "--timeout=", fmt.Sprintf("%d", int(opts.TimeOut.Seconds())))
+		args = append(args, fmt.Sprintf("--timeout=%d", int(opts.TimeOut.Seconds())))
 	}
 
 	_, statusCode, err := z.execCmdFn(ctx, args...)

--- a/orbit/pkg/zenity/zenity.go
+++ b/orbit/pkg/zenity/zenity.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os/exec"
 	"time"
 
+	"github.com/fleetdm/fleet/v4/orbit/pkg/execuser"
 	"github.com/fleetdm/fleet/v4/server/contexts/ctxerr"
 )
 
@@ -114,15 +114,10 @@ func (z *Zenity) ShowInfo(ctx context.Context, opts InfoOptions) error {
 }
 
 func execCmd(ctx context.Context, args ...string) ([]byte, int, error) {
-	cmd := exec.CommandContext(ctx, "zenity", args...)
-	output, err := cmd.CombinedOutput()
-	if err != nil {
-		var exitCode int // exit 0 ok here if zenity returns an error
-		if cmd.ProcessState != nil {
-			exitCode = cmd.ProcessState.ExitCode()
-		}
-		return nil, exitCode, err
+	var opts []execuser.Option
+	for _, arg := range args {
+		opts = append(opts, execuser.WithArg(arg, "")) // Using empty value for positional args
 	}
 
-	return output, cmd.ProcessState.ExitCode(), nil
+	return execuser.RunWithOutput("zenity", opts...)
 }

--- a/orbit/pkg/zenity/zenity.go
+++ b/orbit/pkg/zenity/zenity.go
@@ -60,10 +60,10 @@ func New() *Zenity {
 func (z *Zenity) ShowEntry(ctx context.Context, opts EntryOptions) ([]byte, error) {
 	args := []string{"--entry"}
 	if opts.Title != "" {
-		args = append(args, fmt.Sprintf("--title=%q", opts.Title))
+		args = append(args, fmt.Sprintf("--title=%s", opts.Title))
 	}
 	if opts.Text != "" {
-		args = append(args, fmt.Sprintf("--text=%q", opts.Text))
+		args = append(args, fmt.Sprintf("--text=%s", opts.Text))
 	}
 	if opts.HideText {
 		args = append(args, "--hide-text")
@@ -91,10 +91,10 @@ func (z *Zenity) ShowEntry(ctx context.Context, opts EntryOptions) ([]byte, erro
 func (z *Zenity) ShowInfo(ctx context.Context, opts InfoOptions) error {
 	args := []string{"--info"}
 	if opts.Title != "" {
-		args = append(args, fmt.Sprintf("--title=%q", opts.Title))
+		args = append(args, fmt.Sprintf("--title=%s", opts.Title))
 	}
 	if opts.Text != "" {
-		args = append(args, fmt.Sprintf("--text=%q", opts.Text))
+		args = append(args, fmt.Sprintf("--text=%s", opts.Text))
 	}
 	if opts.TimeOut > 0 {
 		args = append(args, fmt.Sprintf("--timeout=%d", int(opts.TimeOut.Seconds())))

--- a/orbit/pkg/zenity/zenity_test.go
+++ b/orbit/pkg/zenity/zenity_test.go
@@ -1,0 +1,69 @@
+package zenity
+
+import (
+	"context"
+	"os/exec"
+	"slices"
+	"testing"
+	"time"
+)
+
+// Variables to capture the command and args for verification
+var capturedArgs []string
+
+// MockCommandContext simulates exec.CommandContext and captures arguments
+func MockCommandContext(ctx context.Context, name string, args ...string) *exec.Cmd {
+	capturedArgs = append([]string{name}, args...)
+	return exec.CommandContext(ctx, name, args...) // Return a dummy Cmd
+}
+
+// MockProcessState simulates the ProcessState with a specific exit code.
+type MockProcessState struct {
+	exitCode int
+}
+
+func (m *MockProcessState) ExitCode() int {
+	return m.exitCode
+}
+
+func TestShowEntryArgs(t *testing.T) {
+	ctx := context.Background()
+	z := &Zenity{
+		CommandContext: MockCommandContext,
+	}
+
+	testCases := []struct {
+		name         string
+		opts         EntryOptions
+		expectedArgs []string
+	}{
+		{
+			name: "Basic Entry",
+			opts: EntryOptions{
+				Title: "A Title",
+				Text:  "Some text",
+			},
+			expectedArgs: []string{"zenity", "--entry", `--title="A Title"`, `--text="Some text"`},
+		},
+		{
+			name: "All Options",
+			opts: EntryOptions{
+				Title:    "Another Title",
+				Text:     "Some more text",
+				HideText: true,
+				TimeOut:  1 * time.Minute,
+			},
+			expectedArgs: []string{"zenity", "--entry", `--title="Another Title"`, `--text="Some more text"`, "--hide-text", "--timeout=60"},
+		},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			capturedArgs = nil // Reset capturedArgs before each test
+			z.ShowEntry(ctx, tt.opts)
+			if !slices.Equal(capturedArgs, tt.expectedArgs) {
+				t.Errorf("expected args %v, got %v", tt.expectedArgs, capturedArgs)
+			}
+		})
+	}
+}

--- a/orbit/pkg/zenity/zenity_test.go
+++ b/orbit/pkg/zenity/zenity_test.go
@@ -1,3 +1,5 @@
+//go:build linux
+
 package zenity
 
 import (

--- a/orbit/pkg/zenity/zenity_test.go
+++ b/orbit/pkg/zenity/zenity_test.go
@@ -225,17 +225,7 @@ func TestProgressArgs(t *testing.T) {
 				Title: "A Title",
 				Text:  "Some text",
 			},
-			expectedArgs: []string{"--progress", "--title=A Title", "--text=Some text"},
-		},
-		{
-			name: "All Options",
-			opts: dialog.ProgressOptions{
-				Title:    "Another Title",
-				Text:     "Some more text",
-				Pulsate:  true,
-				NoCancel: true,
-			},
-			expectedArgs: []string{"--progress", "--title=Another Title", "--text=Some more text", "--pulsate", "--no-cancel"},
+			expectedArgs: []string{"--progress", "--title=A Title", "--text=Some text", "--pulsate", "--no-cancel"},
 		},
 	}
 

--- a/orbit/pkg/zenity/zenity_test.go
+++ b/orbit/pkg/zenity/zenity_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/fleetdm/fleet/v4/orbit/pkg/dialog"
 	"github.com/stretchr/testify/require"
 	"github.com/tj/assert"
 )
@@ -32,12 +33,12 @@ func TestShowEntryArgs(t *testing.T) {
 
 	testCases := []struct {
 		name         string
-		opts         EntryOptions
+		opts         dialog.EntryOptions
 		expectedArgs []string
 	}{
 		{
 			name: "Basic Entry",
-			opts: EntryOptions{
+			opts: dialog.EntryOptions{
 				Title: "A Title",
 				Text:  "Some text",
 			},
@@ -45,7 +46,7 @@ func TestShowEntryArgs(t *testing.T) {
 		},
 		{
 			name: "All Options",
-			opts: EntryOptions{
+			opts: dialog.EntryOptions{
 				Title:    "Another Title",
 				Text:     "Some more text",
 				HideText: true,
@@ -82,17 +83,17 @@ func TestShowEntryError(t *testing.T) {
 		{
 			name:        "Dialog Cancelled",
 			exitCode:    1,
-			expectedErr: ErrCanceled,
+			expectedErr: dialog.ErrCanceled,
 		},
 		{
 			name:        "Dialog Timed Out",
 			exitCode:    5,
-			expectedErr: ErrTimeout,
+			expectedErr: dialog.ErrTimeout,
 		},
 		{
 			name:        "Unknown Error",
 			exitCode:    99,
-			expectedErr: ErrUnknown,
+			expectedErr: dialog.ErrUnknown,
 		},
 	}
 
@@ -104,7 +105,7 @@ func TestShowEntryError(t *testing.T) {
 			z := &Zenity{
 				execCmdFn: mock.run,
 			}
-			output, err := z.ShowEntry(ctx, EntryOptions{})
+			output, err := z.ShowEntry(ctx, dialog.EntryOptions{})
 			require.ErrorIs(t, err, tt.expectedErr)
 			assert.Nil(t, output)
 		})
@@ -120,7 +121,7 @@ func TestShowEntrySuccess(t *testing.T) {
 	z := &Zenity{
 		execCmdFn: mock.run,
 	}
-	output, err := z.ShowEntry(ctx, EntryOptions{})
+	output, err := z.ShowEntry(ctx, dialog.EntryOptions{})
 	assert.NoError(t, err)
 	assert.Equal(t, []byte("some output"), output)
 }
@@ -130,17 +131,17 @@ func TestShowInfoArgs(t *testing.T) {
 
 	testCases := []struct {
 		name         string
-		opts         InfoOptions
+		opts         dialog.InfoOptions
 		expectedArgs []string
 	}{
 		{
 			name:         "Basic Entry",
-			opts:         InfoOptions{},
+			opts:         dialog.InfoOptions{},
 			expectedArgs: []string{"--info"},
 		},
 		{
 			name: "All Options",
-			opts: InfoOptions{
+			opts: dialog.InfoOptions{
 				Title:   "Another Title",
 				Text:    "Some more text",
 				TimeOut: 1 * time.Minute,
@@ -173,12 +174,12 @@ func TestShowInfoError(t *testing.T) {
 		{
 			name:        "Dialog Timed Out",
 			exitCode:    5,
-			expectedErr: ErrTimeout,
+			expectedErr: dialog.ErrTimeout,
 		},
 		{
 			name:        "Unknown Error",
 			exitCode:    99,
-			expectedErr: ErrUnknown,
+			expectedErr: dialog.ErrUnknown,
 		},
 	}
 
@@ -190,7 +191,7 @@ func TestShowInfoError(t *testing.T) {
 			z := &Zenity{
 				execCmdFn: mock.run,
 			}
-			err := z.ShowInfo(ctx, InfoOptions{})
+			err := z.ShowInfo(ctx, dialog.InfoOptions{})
 			require.ErrorIs(t, err, tt.expectedErr)
 		})
 	}

--- a/orbit/pkg/zenity/zenity_test.go
+++ b/orbit/pkg/zenity/zenity_test.go
@@ -41,7 +41,7 @@ func TestShowEntryArgs(t *testing.T) {
 				Title: "A Title",
 				Text:  "Some text",
 			},
-			expectedArgs: []string{"--entry", "--title=", "A Title", "--text=", "Some text"},
+			expectedArgs: []string{"--entry", "--title=A Title", "--text=Some text"},
 		},
 		{
 			name: "All Options",
@@ -51,7 +51,7 @@ func TestShowEntryArgs(t *testing.T) {
 				HideText: true,
 				TimeOut:  1 * time.Minute,
 			},
-			expectedArgs: []string{"--entry", "--title=", "Another Title", "--text=", "Some more text", "--hide-text", "--timeout=", "60"},
+			expectedArgs: []string{"--entry", "--title=Another Title", "--text=Some more text", "--hide-text", "--timeout=60"},
 		},
 	}
 
@@ -145,7 +145,7 @@ func TestShowInfoArgs(t *testing.T) {
 				Text:    "Some more text",
 				TimeOut: 1 * time.Minute,
 			},
-			expectedArgs: []string{"--info", "--title=", "Another Title", "--text=", "Some more text", "--timeout=", "60"},
+			expectedArgs: []string{"--info", "--title=Another Title", "--text=Some more text", "--timeout=60"},
 		},
 	}
 

--- a/orbit/pkg/zenity/zenity_test.go
+++ b/orbit/pkg/zenity/zenity_test.go
@@ -1,5 +1,3 @@
-//go:build linux
-
 package zenity
 
 import (
@@ -43,7 +41,7 @@ func TestShowEntryArgs(t *testing.T) {
 				Title: "A Title",
 				Text:  "Some text",
 			},
-			expectedArgs: []string{"--entry", `--title="A Title"`, `--text="Some text"`},
+			expectedArgs: []string{"--entry", "--title=", "A Title", "--text=", "Some text"},
 		},
 		{
 			name: "All Options",
@@ -53,7 +51,7 @@ func TestShowEntryArgs(t *testing.T) {
 				HideText: true,
 				TimeOut:  1 * time.Minute,
 			},
-			expectedArgs: []string{"--entry", `--title="Another Title"`, `--text="Some more text"`, "--hide-text", "--timeout=60"},
+			expectedArgs: []string{"--entry", "--title=", "Another Title", "--text=", "Some more text", "--hide-text", "--timeout=", "60"},
 		},
 	}
 
@@ -147,7 +145,7 @@ func TestShowInfoArgs(t *testing.T) {
 				Text:    "Some more text",
 				TimeOut: 1 * time.Minute,
 			},
-			expectedArgs: []string{"--info", `--title="Another Title"`, `--text="Some more text"`, "--timeout=60"},
+			expectedArgs: []string{"--info", "--title=", "Another Title", "--text=", "Some more text", "--timeout=", "60"},
 		},
 	}
 

--- a/tools/dialog/main.go
+++ b/tools/dialog/main.go
@@ -27,14 +27,12 @@ func main() {
 		panic(err)
 	}
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancelProgress := context.WithCancel(context.Background())
 
 	go func() {
 		err := prompt.ShowProgress(ctx, dialog.ProgressOptions{
-			Title:    "Zenity Test Progress Title",
-			Text:     "Zenity Test Progress Text",
-			Pulsate:  true,
-			NoCancel: true,
+			Title: "Zenity Test Progress Title",
+			Text:  "Zenity Test Progress Text",
 		})
 		if err != nil {
 			fmt.Println("Err ShowProgress")
@@ -43,7 +41,7 @@ func main() {
 	}()
 
 	time.Sleep(2 * time.Second)
-	cancel()
+	cancelProgress()
 
 	err = prompt.ShowInfo(ctx, dialog.InfoOptions{
 		Title:   "Zenity Test Info Title",

--- a/tools/dialog/main.go
+++ b/tools/dialog/main.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/fleetdm/fleet/v4/orbit/pkg/dialog"
 	"github.com/fleetdm/fleet/v4/orbit/pkg/zenity"
 )
 
@@ -12,7 +13,7 @@ func main() {
 	prompt := zenity.New()
 	ctx := context.Background()
 
-	output, err := prompt.ShowEntry(ctx, zenity.EntryOptions{
+	output, err := prompt.ShowEntry(ctx, dialog.EntryOptions{
 		Title:    "Zenity Test Entry Title",
 		Text:     "Zenity Test Entry Text",
 		HideText: true,
@@ -23,7 +24,7 @@ func main() {
 		panic(err)
 	}
 
-	err = prompt.ShowInfo(ctx, zenity.InfoOptions{
+	err = prompt.ShowInfo(ctx, dialog.InfoOptions{
 		Title:   "Zenity Test Info Title",
 		Text:    "Result: " + string(output),
 		TimeOut: 10 * time.Second,

--- a/tools/dialog/main.go
+++ b/tools/dialog/main.go
@@ -1,5 +1,8 @@
 package main
 
+// This is a tool to test the zenity package on Linux
+// It will show an entry dialog, a progress dialog, and an info dialog
+
 import (
 	"context"
 	"fmt"
@@ -23,6 +26,24 @@ func main() {
 		fmt.Println("Err ShowEntry")
 		panic(err)
 	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	go func() {
+		err := prompt.ShowProgress(ctx, dialog.ProgressOptions{
+			Title:    "Zenity Test Progress Title",
+			Text:     "Zenity Test Progress Text",
+			Pulsate:  true,
+			NoCancel: true,
+		})
+		if err != nil {
+			fmt.Println("Err ShowProgress")
+			panic(err)
+		}
+	}()
+
+	time.Sleep(2 * time.Second)
+	cancel()
 
 	err = prompt.ShowInfo(ctx, dialog.InfoOptions{
 		Title:   "Zenity Test Info Title",

--- a/tools/zenity/main.go
+++ b/tools/zenity/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"time"
 
 	"github.com/fleetdm/fleet/v4/orbit/pkg/zenity"
 )
@@ -14,7 +15,7 @@ func main() {
 		Title:    "Zenity Test Entry Title",
 		Text:     "Zenity Test Entry Text",
 		HideText: true,
-		TimeOut:  5,
+		TimeOut:  5 * time.Second,
 	})
 	if err != nil {
 		panic(err)
@@ -23,7 +24,7 @@ func main() {
 	err = prompt.ShowInfo(ctx, zenity.InfoOptions{
 		Title:   "Zenity Test Info Title",
 		Text:    "Result: " + string(output),
-		TimeOut: 5,
+		TimeOut: 5 * time.Second,
 	})
 	if err != nil {
 		panic(err)

--- a/tools/zenity/main.go
+++ b/tools/zenity/main.go
@@ -16,7 +16,7 @@ func main() {
 		Title:    "Zenity Test Entry Title",
 		Text:     "Zenity Test Entry Text",
 		HideText: true,
-		TimeOut:  5 * time.Second,
+		TimeOut:  10 * time.Second,
 	})
 	if err != nil {
 		fmt.Println("Err ShowEntry")
@@ -26,7 +26,7 @@ func main() {
 	err = prompt.ShowInfo(ctx, zenity.InfoOptions{
 		Title:   "Zenity Test Info Title",
 		Text:    "Result: " + string(output),
-		TimeOut: 5 * time.Second,
+		TimeOut: 10 * time.Second,
 	})
 	if err != nil {
 		fmt.Println("Err ShowInfo")

--- a/tools/zenity/main.go
+++ b/tools/zenity/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/fleetdm/fleet/v4/orbit/pkg/zenity"
@@ -18,6 +19,7 @@ func main() {
 		TimeOut:  5 * time.Second,
 	})
 	if err != nil {
+		fmt.Println("Err ShowEntry")
 		panic(err)
 	}
 
@@ -27,6 +29,7 @@ func main() {
 		TimeOut: 5 * time.Second,
 	})
 	if err != nil {
+		fmt.Println("Err ShowInfo")
 		panic(err)
 	}
 }

--- a/tools/zenity/main.go
+++ b/tools/zenity/main.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"context"
+
+	"github.com/fleetdm/fleet/v4/orbit/pkg/zenity"
+)
+
+func main() {
+	prompt := zenity.New()
+	ctx := context.Background()
+
+	output, err := prompt.ShowEntry(ctx, zenity.EntryOptions{
+		Title:    "Zenity Test Entry Title",
+		Text:     "Zenity Test Entry Text",
+		HideText: true,
+		TimeOut:  5,
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	err = prompt.ShowInfo(ctx, zenity.InfoOptions{
+		Title:   "Zenity Test Info Title",
+		Text:    "Result: " + string(output),
+		TimeOut: 5,
+	})
+	if err != nil {
+		panic(err)
+	}
+}


### PR DESCRIPTION
#23585 

Adding package for `zenity` command on Linux to be used in #23586 and will be manually tested in that task.

- [ ] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/Committing-Changes.md#changes-files) for more information.
- [X] Added/updated tests
- [ ] Manual QA for all new/changed functionality
- For Orbit and Fleet Desktop changes:
   - [X] Orbit runs on macOS, Linux and Windows. Check if the orbit feature/bugfix should only apply to one platform (`runtime.GOOS`).
   - [ ] Manual QA must be performed in the three main OSs, macOS, Windows and Linux.
   - [ ] Auto-update manual QA, from released version of component to new version (see [tools/tuf/test](../tools/tuf/test/README.md)).
