### PR TITLE
Prevent broken build system when Ctrl+C a orbit/desktop windows compilation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 *.exe
 
 # output directories
-build
+/build
 vendor
 node_modules
 dist
@@ -87,9 +87,9 @@ macoffice_rel_notes/
 
 # residual files when running the build-windows tool
 orbit/cmd/desktop/manifest.xml
-orbit/cmd/desktop/resource.syso
+orbit/cmd/desktop/resource_windows.syso
 orbit/cmd/orbit/manifest.xml
-orbit/cmd/orbit/resource.syso
+orbit/cmd/orbit/resource_windows.syso
 
 # Residual files from osqueryd loadtests.
 osquery_worker_*.jpg

--- a/orbit/pkg/packaging/windows.go
+++ b/orbit/pkg/packaging/windows.go
@@ -297,7 +297,7 @@ func writePowershellInstallerUtilsFile(opt Options, rootPath string) error {
 	return nil
 }
 
-// writeManifestXML creates the manifest.xml file used when generating the 'resource.syso' metadata
+// writeManifestXML creates the manifest.xml file used when generating the 'resource_windows.syso' metadata
 // (see writeResourceSyso). Returns the path of the newly created file.
 func writeManifestXML(vParts []string, orbitPath string) (string, error) {
 	filePath := filepath.Join(orbitPath, "manifest.xml")
@@ -320,7 +320,7 @@ func writeManifestXML(vParts []string, orbitPath string) (string, error) {
 	return filePath, nil
 }
 
-// createVersionInfo returns a VersionInfo struct pointer to be used to generate the 'resource.syso'
+// createVersionInfo returns a VersionInfo struct pointer to be used to generate the 'resource_windows.syso'
 // metadata file (see writeResourceSyso).
 func createVersionInfo(vParts []string, manifestPath string) (*goversioninfo.VersionInfo, error) {
 	vIntParts := make([]int, 0, len(vParts))
@@ -417,7 +417,7 @@ func SanitizeVersion(version string) ([]string, error) {
 	return vParts[:4], nil
 }
 
-// writeResourceSyso creates the 'resource.syso' metadata file which contains the required Microsoft
+// writeResourceSyso creates the 'resource_windows.syso' metadata file which contains the required Microsoft
 // Windows Version Information
 func writeResourceSyso(opt Options, orbitPath string) error {
 	if err := secure.MkdirAll(orbitPath, constant.DefaultDirMode); err != nil {
@@ -443,7 +443,7 @@ func writeResourceSyso(opt Options, orbitPath string) error {
 	vi.Build()
 	vi.Walk()
 
-	outPath := filepath.Join(orbitPath, "resource.syso")
+	outPath := filepath.Join(orbitPath, "resource_windows.syso")
 	if err := vi.WriteSyso(outPath, "amd64"); err != nil {
 		return fmt.Errorf("creating syso file: %w", err)
 	}

--- a/orbit/tools/build/build-windows.go
+++ b/orbit/tools/build/build-windows.go
@@ -24,7 +24,7 @@ import (
 func main() {
 	// Input flags
 	flagVersion := flag.String("version", "0.0.1", "Version string")
-	flagCreateResource := flag.Bool("resource", false, "This is a bool flag to just create the resource.syso file and not build the binary")
+	flagCreateResource := flag.Bool("resource", false, "This is a bool flag to just create the resource_windows.syso file and not build the binary")
 	flagIcon := flag.String("icon", "windows_app.ico", "Path to the icon file to embed on the binary")
 	flagOutputBinary := flag.String("output", "output.exe", "Path to the output binary")
 	flagCmdDir := flag.String("input", "", "Path to the directory containing the utility to build")
@@ -42,7 +42,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	// now we need to create the 'resource.syso' metadata file which contains versioninfo data
+	// now we need to create the 'resource_windows.syso' metadata file which contains versioninfo data
 
 	// lets start with sanitizing the version data
 	vParts, err := packaging.SanitizeVersion(*flagVersion)
@@ -69,12 +69,12 @@ func main() {
 		os.Exit(1) //nolint:gocritic // ignore exitAfterDefer
 	}
 
-	// and finally we can write the 'resource.syso' file
+	// and finally we can write the 'resource_windows.syso' file
 	vi.Build()
 	vi.Walk()
 
-	// resource.syso is the resource file that is going to be picked up by golang compiler
-	outPath := filepath.Join(*flagCmdDir, "resource.syso")
+	// resource_windows.syso is the resource file that is going to be picked up by golang compiler
+	outPath := filepath.Join(*flagCmdDir, "resource_windows.syso")
 	if err := vi.WriteSyso(outPath, "amd64"); err != nil {
 		zlog.Fatal().Err(err).Msg("creating syso file")
 		os.Exit(1)
@@ -96,7 +96,7 @@ func main() {
 	}
 }
 
-// createVersionInfo returns a VersionInfo struct pointer to be used to generate the 'resource.syso'
+// createVersionInfo returns a VersionInfo struct pointer to be used to generate the 'resource_windows.syso'
 // metadata file (see writeResourceSyso).
 func createVersionInfo(vParts []string, iconPath string, manifestPath string) (*goversioninfo.VersionInfo, error) {
 	vIntParts := make([]int, 0, len(vParts))
@@ -168,7 +168,7 @@ func createVersionInfo(vParts []string, iconPath string, manifestPath string) (*
 	return &result, nil
 }
 
-// writeManifestXML creates the manifest.xml file used when generating the 'resource.syso' metadata
+// writeManifestXML creates the manifest.xml file used when generating the 'resource_windows.syso' metadata
 // (see writeResourceSyso). Returns the path of the newly created file.
 func writeManifestXML(vParts []string, orbitPath string) (string, error) {
 	filePath := filepath.Join(orbitPath, "manifest.xml")


### PR DESCRIPTION
#23606

A Ctrl+C during a fleetd Windows build could leave a windows syso named `resource.syso` in Fleet Desktop folder which was preventing macOS/Linux builds from happening.

Related: https://github.com/josephspurrier/goversioninfo/issues/14

PS: If you already have a lingering `resource.syso` in `orbit/cmd/orbit` or `orbit/cmd/desktop` then removing it will solve the issue.