### PR TITLE
Fleet UI: Keyboard accessibility for clickable rows, view report

### DIFF
--- a/frontend/components/LiveQuery/TargetsInput/TargetsInput.tsx
+++ b/frontend/components/LiveQuery/TargetsInput/TargetsInput.tsx
@@ -122,6 +122,7 @@ const TargetsInput = ({
               disablePagination
               disableMultiRowSelect
               onClickRow={handleRowSelect}
+              keyboardSelectableRow
             />
           </div>
         )}

--- a/frontend/components/LiveQuery/TargetsInput/TargetsInputHostsTableConfig.tsx
+++ b/frontend/components/LiveQuery/TargetsInput/TargetsInputHostsTableConfig.tsx
@@ -9,6 +9,7 @@ import { IHost } from "interfaces/host";
 import TextCell from "components/TableContainer/DataTable/TextCell";
 import LiveQueryIssueCell from "components/TableContainer/DataTable/LiveQueryIssueCell/LiveQueryIssueCell";
 import StatusIndicator from "components/StatusIndicator";
+import Button from "components/buttons/Button";
 import Icon from "components/Icon/Icon";
 
 export type ITargestInputHostTableConfig = Column<IHost>;
@@ -25,9 +26,12 @@ export const generateTableHeaders = (
           id: "delete",
           Header: "",
           Cell: (cellProps: ITableStringCellProps) => (
-            <div onClick={() => handleRowRemove(cellProps.row)}>
+            <Button
+              onClick={() => handleRowRemove(cellProps.row)}
+              variant="icon"
+            >
               <Icon name="close-filled" />
-            </div>
+            </Button>
           ),
           disableHidden: true,
         },

--- a/frontend/components/TableContainer/DataTable/DataTable.tsx
+++ b/frontend/components/TableContainer/DataTable/DataTable.tsx
@@ -574,6 +574,7 @@ const DataTable = ({
                       }
                     },
                   })}
+                  // Can tab onto an entire row if a child element does not have the same onClick functionality as clicking the whole row
                   tabIndex={keyboardSelectableRow ? 0 : -1}
                 >
                   {row.cells.map((cell: any) => {

--- a/frontend/components/TableContainer/DataTable/DataTable.tsx
+++ b/frontend/components/TableContainer/DataTable/DataTable.tsx
@@ -46,6 +46,7 @@ interface IDataTableProps {
   sortDirection: any;
   onSort: any; // TODO: an event type
   disableMultiRowSelect: boolean;
+  keyboardSelectableRow?: boolean;
   showMarkAllPages: boolean;
   isAllPagesSelected: boolean; // TODO: make dependent on showMarkAllPages
   toggleAllPagesSelected?: any; // TODO: an event type and make it dependent on showMarkAllPages
@@ -94,6 +95,7 @@ const DataTable = ({
   sortDirection,
   onSort,
   disableMultiRowSelect,
+  keyboardSelectableRow,
   showMarkAllPages,
   isAllPagesSelected,
   toggleAllPagesSelected,
@@ -562,7 +564,17 @@ const DataTable = ({
                         onSelectRowClick(row)) ||
                         (onClickRow && onClickRow(row));
                     },
+                    // For accessibility when tabable
+                    onKeyDown: (e: KeyboardEvent) => {
+                      if (e.key === "Enter") {
+                        (onSelectRowClick &&
+                          disableMultiRowSelect &&
+                          onSelectRowClick(row)) ||
+                          (onClickRow && onClickRow(row));
+                      }
+                    },
                   })}
+                  tabIndex={keyboardSelectableRow ? 0 : -1}
                 >
                   {row.cells.map((cell: any) => {
                     return (

--- a/frontend/components/TableContainer/DataTable/_styles.scss
+++ b/frontend/components/TableContainer/DataTable/_styles.scss
@@ -203,6 +203,10 @@ $shadow-transition-width: 10px;
         &:hover {
           background-color: $ui-off-white-opaque; // opaque needed for horizontal scroll shadow
         }
+        &:focus-visible {
+          outline: 2px solid $ui-vibrant-blue-25;
+          background: $ui-off-white;
+        }
       }
 
       .single-row {

--- a/frontend/components/TableContainer/TableContainer.tsx
+++ b/frontend/components/TableContainer/TableContainer.tsx
@@ -93,6 +93,8 @@ interface ITableContainerProps<T = any> {
    * if we want to keep this
    */
   onClickRow?: (row: T) => void;
+  /** Used if users can click the row and another child element does not have the same onClick functionality */
+  keyboardSelectableRow?: boolean;
   /** Use for clientside filtering: Use key global for filtering on any column, or use column id as
    * key */
   filters?: Record<string, string | number | boolean>;
@@ -160,6 +162,7 @@ const TableContainer = <T,>({
   stackControls,
   onSelectSingleRow,
   onClickRow,
+  keyboardSelectableRow,
   renderCount,
   renderTableHelpText,
   setExportRows,
@@ -511,6 +514,7 @@ const TableContainer = <T,>({
                 secondarySelectActions={secondarySelectActions}
                 onSelectSingleRow={onSelectSingleRow}
                 onClickRow={onClickRow}
+                keyboardSelectableRow={keyboardSelectableRow}
                 onResultsCountChange={setClientFilterCount}
                 isClientSidePagination={isClientSidePagination}
                 onClientSidePaginationChange={onClientSidePaginationChange}

--- a/frontend/components/forms/fields/Slider/Slider.tsx
+++ b/frontend/components/forms/fields/Slider/Slider.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect, useRef } from "react";
 import classnames from "classnames";
 import { pick } from "lodash";
 
@@ -19,6 +19,14 @@ const baseClass = "fleet-slider";
 
 const Slider = (props: ISliderProps): JSX.Element => {
   const { onChange, value, inactiveText, activeText, autoFocus } = props;
+
+  const sliderRef = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    if (autoFocus && sliderRef.current) {
+      sliderRef.current.focus();
+    }
+  }, [autoFocus]);
 
   const sliderBtnClass = classnames(baseClass, {
     [`${baseClass}--active`]: value,
@@ -48,7 +56,7 @@ const Slider = (props: ISliderProps): JSX.Element => {
         <button
           className={`button button--unstyled ${sliderBtnClass}`}
           onClick={handleClick}
-          autoFocus={autoFocus}
+          ref={sliderRef}
         >
           <div className={sliderDotClass} />
         </button>

--- a/frontend/components/forms/fields/Slider/Slider.tsx
+++ b/frontend/components/forms/fields/Slider/Slider.tsx
@@ -12,12 +12,13 @@ interface ISliderProps {
   activeText: JSX.Element | string;
   className?: string;
   helpText?: JSX.Element | string;
+  autoFocus?: boolean;
 }
 
 const baseClass = "fleet-slider";
 
 const Slider = (props: ISliderProps): JSX.Element => {
-  const { onChange, value, inactiveText, activeText } = props;
+  const { onChange, value, inactiveText, activeText, autoFocus } = props;
 
   const sliderBtnClass = classnames(baseClass, {
     [`${baseClass}--active`]: value,
@@ -47,6 +48,7 @@ const Slider = (props: ISliderProps): JSX.Element => {
         <button
           className={`button button--unstyled ${sliderBtnClass}`}
           onClick={handleClick}
+          autoFocus={autoFocus}
         >
           <div className={sliderDotClass} />
         </button>

--- a/frontend/pages/hosts/details/cards/Queries/HostQueries.tsx
+++ b/frontend/pages/hosts/details/cards/Queries/HostQueries.tsx
@@ -29,6 +29,7 @@ interface IHostQueriesRowProps extends Row {
   original: {
     id?: number;
     should_link_to_hqr?: boolean;
+    hostId?: number;
   };
 }
 
@@ -101,8 +102,8 @@ const HostQueries = ({
   const tableData = useMemo(() => generateDataSet(schedule ?? []), [schedule]);
 
   const columnConfigs = useMemo(
-    () => generateColumnConfigs(queryReportsDisabled),
-    [queryReportsDisabled]
+    () => generateColumnConfigs(hostId, queryReportsDisabled),
+    [hostId, queryReportsDisabled]
   );
 
   const renderHostQueries = () => {

--- a/frontend/pages/hosts/details/cards/Queries/HostQueriesTableConfig.tsx
+++ b/frontend/pages/hosts/details/cards/Queries/HostQueriesTableConfig.tsx
@@ -12,6 +12,7 @@ import Icon from "components/Icon";
 interface IHostQueriesTableData extends Partial<IQueryStats> {
   performance: { indicator: string; id: number };
   should_link_to_hqr: boolean;
+  id: number;
 }
 interface IHeaderProps {
   column: {
@@ -56,6 +57,7 @@ interface IDataColumn {
 // NOTE: cellProps come from react-table
 // more info here https://react-table.tanstack.com/docs/api/useTable#cell-properties
 const generateColumnConfigs = (
+  hostId: number,
   queryReportsDisabled?: boolean
 ): IDataColumn[] => {
   const cols: IDataColumn[] = [
@@ -115,9 +117,16 @@ const generateColumnConfigs = (
       Header: "Report updated",
       disableSortBy: true,
       accessor: "last_fetched", // tbd - may change
-      Cell: (cellProps: ICellProps) => (
-        <ReportUpdatedCell {...cellProps.row.original} />
-      ),
+      Cell: (cellProps: ICellProps) => {
+        console.log("cellprops.row.original", cellProps.row.original);
+        return (
+          <ReportUpdatedCell
+            {...cellProps.row.original}
+            hostId={hostId}
+            queryId={cellProps.row.original.id}
+          />
+        );
+      },
     });
   }
   return cols;

--- a/frontend/pages/hosts/details/cards/Queries/HostQueriesTableConfig.tsx
+++ b/frontend/pages/hosts/details/cards/Queries/HostQueriesTableConfig.tsx
@@ -118,7 +118,6 @@ const generateColumnConfigs = (
       disableSortBy: true,
       accessor: "last_fetched", // tbd - may change
       Cell: (cellProps: ICellProps) => {
-        console.log("cellprops.row.original", cellProps.row.original);
         return (
           <ReportUpdatedCell
             {...cellProps.row.original}

--- a/frontend/pages/hosts/details/cards/Queries/ReportUpdatedCell/ReportUpdatedCell.tests.tsx
+++ b/frontend/pages/hosts/details/cards/Queries/ReportUpdatedCell/ReportUpdatedCell.tests.tsx
@@ -14,6 +14,8 @@ describe("ReportUpdatedCell component", () => {
         discard_data
         automations_enabled
         should_link_to_hqr={false}
+        queryId={3}
+        hostId={4}
       />
     );
 
@@ -29,6 +31,8 @@ describe("ReportUpdatedCell component", () => {
         discard_data={false}
         automations_enabled={false}
         should_link_to_hqr
+        queryId={3}
+        hostId={4}
       />
     );
 
@@ -49,6 +53,8 @@ describe("ReportUpdatedCell component", () => {
         automations_enabled={false}
         should_link_to_hqr
         last_fetched={tenDaysAgo.toISOString()}
+        queryId={3}
+        hostId={4}
       />
     );
 
@@ -66,6 +72,8 @@ describe("ReportUpdatedCell component", () => {
         automations_enabled={false}
         should_link_to_hqr
         last_fetched={tenDaysAgo.toISOString()}
+        queryId={3}
+        hostId={4}
       />
     );
 

--- a/frontend/pages/hosts/details/cards/Queries/ReportUpdatedCell/ReportUpdatedCell.tsx
+++ b/frontend/pages/hosts/details/cards/Queries/ReportUpdatedCell/ReportUpdatedCell.tsx
@@ -118,7 +118,7 @@ const ReportUpdatedCell = ({
     <span className={baseClass}>
       {renderCellValue()}
       {should_link_to_hqr && hostId && queryId && (
-        // link functionality for keyboard accessibility
+        // parent row has same onClick functionality but link here is required for keyboard accessibility
         <Link
           className={`${baseClass}__link`}
           title="link to host query report"

--- a/frontend/pages/hosts/details/cards/Queries/ReportUpdatedCell/ReportUpdatedCell.tsx
+++ b/frontend/pages/hosts/details/cards/Queries/ReportUpdatedCell/ReportUpdatedCell.tsx
@@ -6,7 +6,9 @@ import ReactTooltip from "react-tooltip";
 import { COLORS } from "styles/var/colors";
 import Icon from "components/Icon";
 import TextCell from "components/TableContainer/DataTable/TextCell";
+import { Link } from "react-router";
 import { DEFAULT_EMPTY_CELL_VALUE } from "utilities/constants";
+import PATHS from "router/paths";
 
 const baseClass = "report-updated-cell";
 
@@ -16,6 +18,8 @@ interface IReportUpdatedCell {
   discard_data?: boolean;
   automations_enabled?: boolean;
   should_link_to_hqr?: boolean;
+  hostId?: number;
+  queryId?: number;
 }
 
 const ReportUpdatedCell = ({
@@ -24,6 +28,8 @@ const ReportUpdatedCell = ({
   discard_data,
   automations_enabled,
   should_link_to_hqr,
+  hostId,
+  queryId,
 }: IReportUpdatedCell) => {
   const renderCellValue = () => {
     // if this query doesn't have an interval, it either has a stored report from previous runs
@@ -111,11 +117,12 @@ const ReportUpdatedCell = ({
   return (
     <span className={baseClass}>
       {renderCellValue()}
-      {should_link_to_hqr && (
-        // actual link functionality handled by clickable parent row
-        <span
+      {should_link_to_hqr && hostId && queryId && (
+        // link functionality for keyboard accessibility
+        <Link
           className={`${baseClass}__link`}
           title="link to host query report"
+          to={PATHS.HOST_QUERY_REPORT(hostId, queryId)}
         >
           <span className={`${baseClass}__link-text`}>View report</span>
           <Icon
@@ -123,7 +130,7 @@ const ReportUpdatedCell = ({
             className={`${baseClass}__link-icon`}
             color="core-fleet-blue"
           />
-        </span>
+        </Link>
       )}
     </span>
   );

--- a/frontend/pages/hosts/details/cards/Queries/ReportUpdatedCell/_styles.scss
+++ b/frontend/pages/hosts/details/cards/Queries/ReportUpdatedCell/_styles.scss
@@ -11,6 +11,13 @@
 
   &__link {
     @include table-link;
+
+    &:focus-visible {
+      .report-updated-cell__link-text {
+        opacity: 1; // Text visible when tabbing through app
+        transition: opacity 250ms;
+      }
+    }
   }
 
   &__link-text {

--- a/frontend/pages/policies/ManagePoliciesPage/_styles.scss
+++ b/frontend/pages/policies/ManagePoliciesPage/_styles.scss
@@ -18,6 +18,14 @@
     .Select-multi-value-wrapper {
       width: 146px;
     }
+
+    // When tabbing through the app
+    .manage-policies-page__manage-automations-dropdown {
+      &.is-focused {
+        outline: 2px solid $ui-vibrant-blue-25;
+      }
+    }
+
     .Select > .Select-menu-outer {
       left: -186px;
       width: 360px;

--- a/frontend/pages/policies/ManagePoliciesPage/components/OtherWorkflowsModal/OtherWorkflowsModal.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/components/OtherWorkflowsModal/OtherWorkflowsModal.tsx
@@ -379,6 +379,7 @@ const OtherWorkflowsModal = ({
           }}
           inactiveText="Disabled"
           activeText="Enabled"
+          autoFocus
         />
         <div
           className={`form ${baseClass}__policy-automations__${


### PR DESCRIPTION
## Issue
Part of #23266

## Description
Note this part of a big initiative to be more keyboard accessible, unfortunately these are more of the low hanging fruit of #23266 

- In running a live query via the keyboard, allows tabbing onto SelectTargets rows to select a specific host to query
- In running a live query via the keyboard, allows tabbing onto SelectTargets rows to remove a specific host to query
- In viewing a host's details report, allows tabbing from the host details page to see the query report
- In managing policy automations, allows tabbing onto the manage automations dropdown
- In managing policy automations, focuses on first element in Other workflows modal when opened

## Screen recording
https://www.loom.com/share/5196d4386fd84b4197d7eeabd767f8d2?sid=7e7504f6-393c-4164-9331-8f9131e6666a

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->


- [x] Manual QA for all new/changed functionality



## QA notes
- On Chrome, FF, Safari, you can use the keyboard for the following:
  - In running a live query via the keyboard, allows tabbing onto SelectTargets rows to select a specific host to query (press enter)
  - In running a live query via the keyboard, allows tabbing onto SelectTargets rows to remove a specific host to query (press space or enter)
  - In viewing a host's details report, allows tabbing from the host details page to see the query report
    - NOTE: This works for wide screen only, adding a fix for small screen that doesn't have the whole "view report"
  - In managing policy automations, allows tabbing onto the manage automations dropdown
  - In managing policy automations, focuses on first element in Other workflows modal when opened

- If you see/feel anything wonky outside of this scope of QA, please add it to #24951
