### PR TITLE
Fix rate limiting issue in Trivy workflow scan

### DIFF
--- a/.github/workflows/trivy-scan.yml
+++ b/.github/workflows/trivy-scan.yml
@@ -32,7 +32,7 @@ permissions:
 jobs:
   trivy:
     permissions:
-      id-token: write
+      id-token: write # for aws-actions/configure-aws-credentials
       contents: read # for actions/checkout to fetch code
       security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
     name: Trivy sarif report

--- a/.github/workflows/trivy-scan.yml
+++ b/.github/workflows/trivy-scan.yml
@@ -45,9 +45,9 @@ jobs:
           egress-policy: audit
 
       - name: Checkout code
-        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      - uses: aws-actions/configure-aws-credentials@67fbcbb121271f7775d2e7715933280b06314838 # v1.7.0
+      - uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4.0.2
         with:
           role-to-assume: ${{env.AWS_IAM_ROLE}}
           aws-region: ${{ env.AWS_REGION }}

--- a/.github/workflows/trivy-scan.yml
+++ b/.github/workflows/trivy-scan.yml
@@ -27,12 +27,12 @@ env:
   AWS_IAM_ROLE: arn:aws:iam::160035666661:role/github-actions-role
 
 permissions:
-  id-token: write
   contents: read
 
 jobs:
   trivy:
     permissions:
+      id-token: write
       contents: read # for actions/checkout to fetch code
       security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
     name: Trivy sarif report

--- a/.github/workflows/trivy-scan.yml
+++ b/.github/workflows/trivy-scan.yml
@@ -22,7 +22,12 @@ defaults:
     # fail-fast using bash -eo pipefail. See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#exit-codes-and-error-action-preference
     shell: bash
 
+env:
+  AWS_REGION: us-east-2
+  AWS_IAM_ROLE: arn:aws:iam::160035666661:role/github-actions-role
+
 permissions:
+  id-token: write
   contents: read
 
 jobs:
@@ -42,8 +47,16 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
 
+      - uses: aws-actions/configure-aws-credentials@67fbcbb121271f7775d2e7715933280b06314838 # v1.7.0
+        with:
+          role-to-assume: ${{env.AWS_IAM_ROLE}}
+          aws-region: ${{ env.AWS_REGION }}
+
       - name: Run Trivy vulnerability scanner in repo mode
         uses: aquasecurity/trivy-action@062f2592684a31eb3aa050cc61e7ca1451cecd3d # 0.18.0
+        env:
+          TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db
+          TRIVY_JAVA_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-java-db
         with:
           scan-type: "fs"
           ignore-unfixed: false


### PR DESCRIPTION
This PR updates the way that the Trivy scan workflow downloads the vulnerability database.  Previously, it would download the database from the Github container registry (ghcr.io) by default.  This caused issues where the request for the file would get a ["too many requests" error response](https://github.com/fleetdm/fleet/actions/runs/11696989880/job/32574994558#step:6:35), seemingly due to ever user of Trivy being lumped together for the purpose of rate limiting.  Now, we're instructing Trivy to download the dbs from [their own public ECR](https://github.com/aquasecurity/trivy-db/pull/440).  We're also authenticating with AWS first, so that we [get our own quota](https://docs.aws.amazon.com/AmazonECR/latest/public/public-service-quotas.html).  

This PR also updates the version of the Github checkout action to avoid a warning about it not being designed for Node 20:
```
The following actions use a deprecated Node.js version and will be forced to run on node20: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c, aws-actions/configure-aws-credentials@67fbcbb121271f7775d2e7715933280b06314838. For more info: https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/
```

I tested this by pushing the branch up and [triggering the workflow manually](https://github.com/fleetdm/fleet/actions/runs/11730565177).  Only time will tell if it really solves the rate limit issue, since we run this pretty infrequently.