### PR TITLE
Set self-service on initial data pull when premium license is set

### DIFF
--- a/orbit/changes/21948-self-service-checked
+++ b/orbit/changes/21948-self-service-checked
@@ -1,0 +1,1 @@
+* Fixed cases where self-service menu item temporarily disappeared from Fleet Desktop menu when it should have stayed visible.

--- a/orbit/cmd/desktop/desktop.go
+++ b/orbit/cmd/desktop/desktop.go
@@ -248,16 +248,23 @@ func main() {
 
 				for {
 					refetchToken()
-					_, err := client.DesktopSummary(tokenReader.GetCached())
+					summary, err := client.DesktopSummary(tokenReader.GetCached())
 
 					if err == nil || errors.Is(err, service.ErrMissingLicense) {
 						log.Debug().Msg("enabling tray items")
 						myDeviceItem.SetTitle("My device")
 						myDeviceItem.Enable()
 						transparencyItem.Enable()
+
 						// Hide Self-Service for Free tier
-						selfServiceItem.Disable()
-						selfServiceItem.Hide()
+						if errors.Is(err, service.ErrMissingLicense) || (summary.SelfService != nil && !*summary.SelfService) {
+							selfServiceItem.Disable()
+							selfServiceItem.Hide()
+						} else {
+							selfServiceItem.Enable()
+							selfServiceItem.Show()
+						}
+
 						return
 					}
 


### PR DESCRIPTION
#21948

This should avoid temporary periods where self-service is missing when it shouldn't be.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/Committing-Changes.md#changes-files) for more information.
- [x] Manual QA for all new/changed functionality
- For Orbit and Fleet Desktop changes:
   - [ ] Orbit runs on macOS, Linux and Windows. Check if the orbit feature/bugfix should only apply to one platform (`runtime.GOOS`).
   - [ ] Manual QA must be performed in the three main OSs, macOS, Windows and Linux.
   - [ ] Auto-update manual QA, from released version of component to new version (see [tools/tuf/test](../tools/tuf/test/README.md)).

Will validate updates and cross-OS compat once code is reviewed and I hear back on logs to make sure this is the correct fix.