### PR TITLE
Set minimum height for the Add hosts > ChromeOS > Policy for extension field to avoid scrollbar

### DIFF
--- a/changes/23016-add-chrome-host-text-area-height
+++ b/changes/23016-add-chrome-host-text-area-height
@@ -1,0 +1,2 @@
+* Set a more elegant minimum height for the Add hosts > ChromeOS > Policy for extension field,
+avoiding a scrollbar.

--- a/frontend/components/AddHostsModal/PlatformWrapper/_styles.scss
+++ b/frontend/components/AddHostsModal/PlatformWrapper/_styles.scss
@@ -106,8 +106,13 @@
   &__chromeos-policy-for-extension {
     height: 230px;
 
-    .input-field--disabled {
-      height: 190px;
+    .input-field {
+      &__textarea {
+        height: 190px;
+      }
+      &--disabled {
+        height: 190px;
+      }
     }
   }
 


### PR DESCRIPTION
## #23016 

![Screenshot 2024-11-07 at 10 50 48 PM](https://github.com/user-attachments/assets/68b1ea91-416b-4cf8-b4fa-ede1f72cef66)


- [x] Changes file added for user-visible changes in `changes/`, `
- [x] Manual QA for all new/changed functionality