### PR TITLE
Delete Fleet Desktop auth token when we detect a migrated host

### DIFF
--- a/orbit/changes/23164-delete-migrated-identifier
+++ b/orbit/changes/23164-delete-migrated-identifier
@@ -1,0 +1,1 @@
+* Fixed stale Fleet Desktop token UUID after a macOS host completes Migration Assistant.

--- a/orbit/cmd/orbit/orbit.go
+++ b/orbit/cmd/orbit/orbit.go
@@ -719,9 +719,12 @@ func main() {
 					return fmt.Errorf("removing old osquery.db: %w", err)
 				}
 
-				// We can remove this because we want it to be regenerated during the re-enrollment.
+				// We can remove these because we want them to be regenerated during the re-enrollment.
 				if err := os.RemoveAll(filepath.Join(c.String("root-dir"), constant.OrbitNodeKeyFileName)); err != nil {
 					return fmt.Errorf("removing old orbit node key file: %w", err)
+				}
+				if err := os.RemoveAll(filepath.Join(c.String("root-dir"), constant.DesktopTokenFileName)); err != nil {
+					return fmt.Errorf("removing old Fleet Desktop identifier file: %w", err)
 				}
 
 				return errors.New("found a new hardware uuid, restarting")
@@ -1017,7 +1020,7 @@ func main() {
 		var trw *token.ReadWriter
 		var deviceClient *service.DeviceClient
 		if c.Bool("fleet-desktop") {
-			trw = token.NewReadWriter(filepath.Join(c.String("root-dir"), "identifier"))
+			trw = token.NewReadWriter(filepath.Join(c.String("root-dir"), constant.DesktopTokenFileName))
 			if err := trw.LoadOrGenerate(); err != nil {
 				return fmt.Errorf("initializing token read writer: %w", err)
 			}

--- a/orbit/pkg/constant/constant.go
+++ b/orbit/pkg/constant/constant.go
@@ -17,6 +17,8 @@ const (
 	// We use fleet-desktop as name to properly identify the process when listing
 	// running processes/tasks.
 	DesktopAppExecName = "fleet-desktop"
+	// DesktopTokenFileName is the filename on disk (in the orbit base dir) where we store the Fleet Desktop auth token
+	DesktopTokenFileName = "identifier"
 	// OrbitNodeKeyFileName is the filename on disk where we write the orbit node key to
 	OrbitNodeKeyFileName = "secret-orbit-node-key.txt"
 	// OrbitEnrollMaxRetries is the max number of retries when doing an enroll request.


### PR DESCRIPTION
#23164

This ensures that "My device" correctly shows the current host immediately after migration, rather than the old host (Orbit is already reporting on the current host correctly due to swapped node keys)

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/Committing-Changes.md#changes-files) for more information.
- [x] Manual QA for all new/changed functionality
- For Orbit and Fleet Desktop changes:
   - [x] Orbit runs on macOS, Linux and Windows. Check if the orbit feature/bugfix should only apply to one platform (`runtime.GOOS`).

QA'd on macOS as there's a runtime guard on this code.