### PR TITLE
Allow to disable Apple MDM SCEP renewal/verification

### DIFF
--- a/server/service/apple_mdm.go
+++ b/server/service/apple_mdm.go
@@ -3846,6 +3846,12 @@ func RenewSCEPCertificates(
 	config *config.FleetConfig,
 	commander *apple_mdm.MDMAppleCommander,
 ) error {
+	renewalDisable, exists := os.LookupEnv("FLEET_MDM_APPLE_SCEP_RENEWAL_DISABLE")
+	if exists && (strings.EqualFold(renewalDisable, "true") || renewalDisable == "1") {
+		level.Info(logger).Log("msg", "skipping renewal of macOS SCEP certificates as FLEET_MDM_APPLE_SCEP_RENEWAL_DISABLE is set to true")
+		return nil
+	}
+
 	appConfig, err := ds.AppConfig(ctx)
 	if err != nil {
 		return fmt.Errorf("reading app config: %w", err)


### PR DESCRIPTION
https://github.com/fleetdm/confidential/issues/8528

Manual merge from special branch https://github.com/fleetdm/fleet/compare/rc-patch-fleet-v4.57.3...rh-patch-4.57.3, gated by env vars.

No changes entry since this is a temporary feature for a customer, which we may not want to maintain.
