### PR TITLE
Remove docs for #21795 (Update "Resend host's configuration profile" API URL)

### DIFF
--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -4213,7 +4213,7 @@ A `team_id` of `0` returns the statistics for hosts that are not part of any tea
 
 Resends a configuration profile for the specified host.
 
-`POST /api/v1/fleet/hosts/:id/configuration_profiles/:profile_uuid/resend`
+`POST /api/v1/fleet/hosts/:id/configuration_profiles/resend/:profile_uuid`
 
 #### Parameters
 
@@ -4224,7 +4224,7 @@ Resends a configuration profile for the specified host.
 
 #### Example
 
-`POST /api/v1/fleet/hosts/233/configuration_profiles/fc14a20-84a2-42d8-9257-a425f62bb54d/resend`
+`POST /api/v1/fleet/hosts/233/configuration_profiles/resend/fc14a20-84a2-42d8-9257-a425f62bb54d`
 
 ##### Default response
 


### PR DESCRIPTION
#21795 did not make it into the 4.59.0 release (dropped during sprint planning).