### PR TITLE
Remove docs for #22156 (Custom OS settings: "include any label" option for custom target)

### DIFF
--- a/docs/Configuration/yaml-files.md
+++ b/docs/Configuration/yaml-files.md
@@ -280,7 +280,7 @@ controls:
 
 Fleet supports adding [GitHub environment variables](https://docs.github.com/en/actions/learn-github-actions/variables#defining-environment-variables-for-a-single-workflow) in your configuration profiles. Use `$ENV_VARIABLE` format.
 
-Use `labels_include_all` or `labels_include_any` to only apply (scope) profiles to hosts that have all those labels, `labels_exclude_any` to apply profiles to hosts that have any of those labels, or `labels_exclude_any` to apply profiles to hosts that don't have any of those labels.
+Use `labels_include_all` to only apply (scope) profiles to hosts that have all those labels, or `labels_exclude_any` to apply profiles to hosts that don't have any of those labels.
 
 ### macos_setup
 


### PR DESCRIPTION
#22156 did not make it into the 4.59.0 release (planned for 4.60.0).

(The API docs were already removed, this just cleans up the YAML file docs.)