### PR TITLE
Remove docs for #21855 (🪲 Queries page takes a long time to load with a few hundred queries)

### DIFF
--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -7670,9 +7670,6 @@ Returns a list of global queries or team queries.
 | team_id         | integer | query | _Available in Fleet Premium_. The ID of the parent team for the queries to be listed. When omitted, returns global queries.                  |
 | query           | string  | query | Search query keywords. Searchable fields include `name`.                                                                      |
 | merge_inherited | boolean | query | _Available in Fleet Premium_. If `true`, will include global queries in addition to team queries when filtering by `team_id`. (If no `team_id` is provided, this parameter is ignored.) |
-| page                    | integer | query | Page number of the results to fetch. |
-| per_page                | integer | query | Results per page. |
-| compatible_platform     | string | query | Return queries that only reference tables compatible with this platform (not a strict compatibility check). One of: `"macos"`, `"windows"`, `"linux"`, `"chrome"` (case-insensitive). |
 
 #### Example
 
@@ -7761,12 +7758,7 @@ Returns a list of global queries or team queries.
         "total_executions": null
       }
     }
-  ],
-  "meta": {
-    "has_next_results": true,
-    "has_previous_results": false
-  },
-  "count": 200
+  ]
 }
 ```
 


### PR DESCRIPTION
#21855 is in progress for the 4.60.0 release instead of 4.59.0.

(This content will be moved to the 4.60.0 docs)

This PR does not revert the formatting fix in the API response.