### PR TITLE
Remove docs for #22445 (Host details page: software vulnerability severity filters)

### DIFF
--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -4298,12 +4298,8 @@ Resends a configuration profile for the specified host.
 | Name | Type    | In   | Description                  |
 | ---- | ------- | ---- | ---------------------------- |
 | id   | integer | path | **Required**. The host's ID. |
-| query   | string | query | Search query keywords. Searchable fields include `name` and `vulnerabilities`. |
+| query   | string | query | Search query keywords. Searchable fields include `name`. |
 | available_for_install | boolean | query | If `true` or `1`, only list software that is available for install (added by the user). Default is `false`. |
-| vulnerable              | boolean | query | If true or 1, only list software that has detected vulnerabilities. Default is `false`.                                                                                    |
-| min_cvss_score | integer | query | _Available in Fleet Premium_. Filters to include only software with vulnerabilities that have a CVSS version 3.x base score higher than the specified value.   |
-| max_cvss_score | integer | query | _Available in Fleet Premium_. Filters to only include software with vulnerabilities that have a CVSS version 3.x base score lower than what's specified.   |
-| exploit | boolean | query | _Available in Fleet Premium_. If `true`, filters to only include software with vulnerabilities that have been actively exploited in the wild (`cisa_known_exploit: true`). Default is `false`.  |
 | page | integer | query | Page number of the results to fetch.|
 | per_page | integer | query | Results per page.|
 
@@ -4334,7 +4330,6 @@ Resends a configuration profile for the specified host.
       "app_store_app": null
       "source": "apps",
       "status": "failed",
-      "vulnerabilities": ["CVE-2023-9876", "CVE-2023-2367"],
       "installed_versions": [
         {
           "version": "121.0",


### PR DESCRIPTION
#22445 did not make it into the 4.59.0 release (dropped during sprint planning).