### PR TITLE
Remove note about using the certificates table sparingly

### DIFF
--- a/schema/osquery_fleet_schema.json
+++ b/schema/osquery_fleet_schema.json
@@ -3264,7 +3264,7 @@
     ],
     "evented": false,
     "cacheable": true,
-    "notes": "- This table should be used sparingly as it uses an Apple API which occasionally corrupts the underlying certificate. Learn more [here](https://github.com/fleetdm/fleet/issues/13065#issuecomment-1658849614).",
+    "notes": "",
     "examples": "Replace 1QAZ2WSX with your Apple Developer ID, if you have one. This query\nwill then let you identify Macs that have a copy of your code signing and\nnotarization certificates.\n\n```\nSELECT * FROM certificates WHERE common_\"name\" LIKE '%%1QAZ2SWX%%';\n```",
     "columns": [
       {

--- a/schema/tables/certificates.yml
+++ b/schema/tables/certificates.yml
@@ -34,5 +34,3 @@ columns:
     platforms:
       - linux
       - darwin
-notes: |-
-  - This table should be used sparingly as it uses an Apple API which occasionally corrupts the underlying certificate. Learn more [here](https://github.com/fleetdm/fleet/issues/13065#issuecomment-1658849614).


### PR DESCRIPTION
Looks like the bug was fixed: https://github.com/fleetdm/fleet/issues/13065