### PR TITLE
docs: Add `team_identifier` to host software API endpoint

### DIFF
--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -8892,18 +8892,6 @@ Get a list of all software versions.
         "generated_cpe": "cpe:2.3:a:1password:1password:2.19.0:*:*:*:*:chrome:*:*",
         "hosts_count": 345,
         "vulnerabilities": null
-      },
-      {
-        "id": 3,
-        "name": "1Password.app",
-        "version": "8.10.50",
-        "bundle_identifier": "com.1password.1password",
-        "source": "apps",
-        "browser": "",
-        "generated_cpe": "",
-        "vulnerabilities": null,
-        "hosts_count": 1,
-        "team_identifier": "2BUA8C4S2C"
       }
     ],
     "meta": {
@@ -9156,8 +9144,7 @@ Returns information about the specified software version.
         "cve_published": "2023-09-27T15:19:00Z", // Available in Fleet Premium
         "resolved_in_version": "118" // Available in Fleet Premium
       }
-    ],
-    "team_identifier": "43AQ936H96"
+    ]
   }
 }
 ```

--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -4175,6 +4175,7 @@ Resends a configuration profile for the specified host.
       "installed_versions": [
         {
           "version": "121.0",
+          "bundle_identifier": "com.google.Chrome",
           "last_opened_at": "2024-04-01T23:03:07Z",
           "vulnerabilities": ["CVE-2023-1234","CVE-2023-4321","CVE-2023-7654"],
           "installed_paths": ["/Applications/Google Chrome.app"],
@@ -4223,6 +4224,7 @@ Resends a configuration profile for the specified host.
       "installed_versions": [
         {
           "version": "118.0",
+          "bundle_identifier": "com.apple.logic10",
           "last_opened_at": "2024-04-01T23:03:07Z",
           "vulnerabilities": ["CVE-2023-1234"],
           "installed_paths": ["/Applications/Logic Pro.app"],

--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -3054,7 +3054,7 @@ Returns the information of the specified host.
 
 > Note: `installed_paths` may be blank depending on installer package. For example, on Linux, RPM-installed packages do not provide installed path information.
 
-> Note: `signature_information` is only set for macOS (.app) Applications.
+> Note: `signature_information` is only set for macOS (.app) applications.
 
 > Note:
 > - `orbit_version: null` means this agent is not a fleetd agent

--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -3054,6 +3054,8 @@ Returns the information of the specified host.
 
 > Note: `installed_paths` may be blank depending on installer package. For example, on Linux, RPM-installed packages do not provide installed path information.
 
+> Note: `signature_information` is only set for macOS (.app) Applications.
+
 > Note:
 > - `orbit_version: null` means this agent is not a fleetd agent
 > - `fleet_desktop_version: null` means this agent is not a fleetd agent, or this agent is version <=1.23.0 which is not collecting the desktop version
@@ -4175,7 +4177,13 @@ Resends a configuration profile for the specified host.
           "version": "121.0",
           "last_opened_at": "2024-04-01T23:03:07Z",
           "vulnerabilities": ["CVE-2023-1234","CVE-2023-4321","CVE-2023-7654"],
-          "installed_paths": ["/Applications/Google Chrome.app"]
+          "installed_paths": ["/Applications/Google Chrome.app"],
+          "signature_information": [
+            {
+              "installed_path": "/Applications/Google Chrome.app",
+              "team_identifier": "EQHXZ8M8AV"
+            }
+          ]
         }
       ]
     },
@@ -4217,7 +4225,13 @@ Resends a configuration profile for the specified host.
           "version": "118.0",
           "last_opened_at": "2024-04-01T23:03:07Z",
           "vulnerabilities": ["CVE-2023-1234"],
-          "installed_paths": ["/Applications/Logic Pro.app"]
+          "installed_paths": ["/Applications/Logic Pro.app"],
+          "signature_information": [
+            {
+              "installed_path": "/Applications/Logic Pro.app",
+              "team_identifier": ""
+            }
+          ]
         }
       ]
     },

--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -8892,6 +8892,18 @@ Get a list of all software versions.
         "generated_cpe": "cpe:2.3:a:1password:1password:2.19.0:*:*:*:*:chrome:*:*",
         "hosts_count": 345,
         "vulnerabilities": null
+      },
+      {
+        "id": 3,
+        "name": "1Password.app",
+        "version": "8.10.50",
+        "bundle_identifier": "com.1password.1password",
+        "source": "apps",
+        "browser": "",
+        "generated_cpe": "",
+        "vulnerabilities": null,
+        "hosts_count": 1,
+        "team_identifier": "2BUA8C4S2C"
       }
     ],
     "meta": {

--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -9156,7 +9156,8 @@ Returns information about the specified software version.
         "cve_published": "2023-09-27T15:19:00Z", // Available in Fleet Premium
         "resolved_in_version": "118" // Available in Fleet Premium
       }
-    ]
+    ],
+    "team_identifier": "43AQ936H96"
   }
 }
 ```


### PR DESCRIPTION
Adding `team_identifier` (aka Team ID, Signing ID, Developer ID) to host software API endpoint.