### PR TITLE
Capitalize 'Fleeties'

### DIFF
--- a/handbook/company/communications.md
+++ b/handbook/company/communications.md
@@ -1154,7 +1154,7 @@ As we use sentence case, only the first word is capitalized. But, if a word woul
 
 - **Fleet:** When talking about Fleet the company, we stylize our name as either "Fleet" or "Fleet Device Management".
 - **Fleet the product:** We always say “Fleet” or “Fleet for osquery".  We _NEVER_ say "fleetDM" or "FleetDM" or "fleetdm".
-- **Team members:** [Core team members](https://fleetdm.com/handbook/company/leadership#who-isnt-a-consultant) are “fleeties".
+- **Team members:** [Core team members](https://fleetdm.com/handbook/company/leadership#who-isnt-a-consultant) are “Fleeties".
 - **Group of devices or virtual servers:** Use "fleet" or "fleets" (lowercase).
 - **Osquery:** Osquery should always be written in lowercase unless used to start a sentence or heading.
 - **Fleetd:** Fleetd should always be written in lowercase unless used to start a sentence or heading.


### PR DESCRIPTION
In the [capitalization section](https://fleetdm.com/handbook/company/communications#capitalization-and-proper-nouns) the word 'Fleeties" is not capitalized in the line "Core team members are 'fleeties'." However, it is capitalized everywhere else on the page. Updating the capitalization here to match the rest of the page.

Main page link for reference: https://fleetdm.com/handbook/company/communications

