### PR TITLE
[fleetctl] fix deb package build

### DIFF
--- a/orbit/pkg/packaging/linux_shared.go
+++ b/orbit/pkg/packaging/linux_shared.go
@@ -250,6 +250,12 @@ func buildNFPM(opt Options, pkger nfpm.Packager) (string, error) {
 		return "", fmt.Errorf("removing existing file: %w", err)
 	}
 
+	if _, err := os.Stat("build"); errors.Is(err, os.ErrNotExist) {
+		if err := secure.MkdirAll("build", 0700); err != nil {
+			return "", fmt.Errorf("cannot create build dir: %w", err)
+		}
+	}
+
 	out, err := secure.OpenFile(filename, os.O_CREATE|os.O_RDWR, constant.DefaultFileMode)
 	if err != nil {
 		return "", fmt.Errorf("open output file: %w", err)


### PR DESCRIPTION
I'm trying to setup a GitLab CI job to build the deb packages, but it fails with:

```
Error: open output file: open build/fleet-osquery_1.35.0_amd64.deb: no such file or directory
```

It happens because I can't mount the `build` volume as I would do on my local pc. To reproduce:

```
docker run -it fleetdm/fleetctl package --type=deb --fleet-url=my.url --enroll-secret=mysecret
```

`pkg` and `msi` works fine. I can workaround it by creating the `build` dir first, but I think that's also fleetctl job to create it.

# Checklist for submitter

- [ ] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/Committing-Changes.md#changes-files) for more information.
- [ ] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [ ] Added support on fleet's osquery simulator `cmd/osquery-perf` for new osquery data ingestion features.
- [ ] Added/updated tests
- [ ] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes
- [ ] If database migrations are included, checked table schema to confirm autoupdate
- For database migrations:
  - [ ] Checked schema for all modified table for columns that will auto-update timestamps during migration.
  - [ ] Confirmed that updating the timestamps is acceptable, and will not cause unwanted side effects.
  - [ ] Ensured the correct collation is explicitly set for character columns (`COLLATE utf8mb4_unicode_ci`).
- [ ] Manual QA for all new/changed functionality
- For Orbit and Fleet Desktop changes:
   - [ ] Orbit runs on macOS, Linux and Windows. Check if the orbit feature/bugfix should only apply to one platform (`runtime.GOOS`).
   - [ ] Manual QA must be performed in the three main OSs, macOS, Windows and Linux.
   - [ ] Auto-update manual QA, from released version of component to new version (see [tools/tuf/test](../tools/tuf/test/README.md)).
