### PR TITLE
Added "a" to "Why a handbook-first strategy"

### DIFF
--- a/handbook/company/why-this-way.md
+++ b/handbook/company/why-this-way.md
@@ -31,7 +31,7 @@ Here are some of the reasons we build in the open:
 - **More timeless.** You are not doomed to disappear forever when you change jobs.  Why should your code?  In most jobs, most of the work you do becomes inaccessible when you quit.  But [open source is forever](https://twitter.com/mikermcneil/status/1476799587423772674).
 
 
-## Why handbook-first strategy?
+## Why a handbook-first strategy?
 
 The Fleet handbook provides team members with up-to-date information about how to do things in the company. 
 


### PR DESCRIPTION
I wish I could come up with the grammatical reason for this, but It feels like the article is missing. Feel free to disregard if you disagree. Or if you know the grammatical rule please lmk!

Text added on line 34

Link for reference: https://fleetdm.com/handbook/company/why-this-way#why-handbook-first-strategy

