### PR TITLE
Add Linux encryption states to APIs

### DIFF
--- a/ee/server/service/mdm.go
+++ b/ee/server/service/mdm.go
@@ -1013,10 +1013,16 @@ func (svc *Service) GetMDMDiskEncryptionSummary(ctx context.Context, teamID *uin
 		windows = *w
 	}
 
+	linux, err := svc.ds.GetLinuxDiskEncryptionSummary(ctx, teamID)
+	if err != nil {
+		return nil, ctxerr.Wrap(ctx, err, "getting linux disk encryption summary")
+	}
+
 	return &fleet.MDMDiskEncryptionSummary{
 		Verified: fleet.MDMPlatformsCounts{
 			MacOS:   macOS.Verified,
 			Windows: windows.Verified,
+			Linux:   linux.Verified,
 		},
 		Verifying: fleet.MDMPlatformsCounts{
 			MacOS:   macOS.Verifying,
@@ -1025,6 +1031,7 @@ func (svc *Service) GetMDMDiskEncryptionSummary(ctx context.Context, teamID *uin
 		ActionRequired: fleet.MDMPlatformsCounts{
 			MacOS:   macOS.ActionRequired,
 			Windows: windows.ActionRequired,
+			Linux:   linux.ActionRequired,
 		},
 		Enforcing: fleet.MDMPlatformsCounts{
 			MacOS:   macOS.Enforcing,
@@ -1033,6 +1040,7 @@ func (svc *Service) GetMDMDiskEncryptionSummary(ctx context.Context, teamID *uin
 		Failed: fleet.MDMPlatformsCounts{
 			MacOS:   macOS.Failed,
 			Windows: windows.Failed,
+			Linux:   linux.Failed,
 		},
 		RemovingEnforcement: fleet.MDMPlatformsCounts{
 			MacOS:   macOS.RemovingEnforcement,

--- a/server/datastore/mysql/apple_mdm.go
+++ b/server/datastore/mysql/apple_mdm.go
@@ -3413,27 +3413,6 @@ func (ds *Datastore) CleanupUnusedBootstrapPackages(ctx context.Context, pkgStor
 	return ctxerr.Wrap(ctx, err, "cleanup unused bootstrap packages")
 }
 
-func (ds *Datastore) CleanupDiskEncryptionKeysOnTeamChange(ctx context.Context, hostIDs []uint, newTeamID *uint) error {
-	return ds.withTx(ctx, func(tx sqlx.ExtContext) error {
-		return cleanupDiskEncryptionKeysOnTeamChangeDB(ctx, tx, hostIDs, newTeamID)
-	})
-}
-
-func cleanupDiskEncryptionKeysOnTeamChangeDB(ctx context.Context, tx sqlx.ExtContext, hostIDs []uint, newTeamID *uint) error {
-	_, err := getMDMAppleConfigProfileByTeamAndIdentifierDB(ctx, tx, newTeamID, mobileconfig.FleetFileVaultPayloadIdentifier)
-	if err != nil {
-		if fleet.IsNotFound(err) {
-			// the new team does not have a filevault profile so we need to delete the existing ones
-			if err := bulkDeleteMacosHostDiskEncryptionKeysDB(ctx, tx, hostIDs); err != nil {
-				return ctxerr.Wrap(ctx, err, "reconcile filevault profiles on team change bulk delete host disk encryption keys")
-			}
-		} else {
-			return ctxerr.Wrap(ctx, err, "reconcile filevault profiles on team change get profile")
-		}
-	}
-	return nil
-}
-
 func getMDMAppleConfigProfileByTeamAndIdentifierDB(ctx context.Context, tx sqlx.QueryerContext, teamID *uint, profileIdentifier string) (*fleet.MDMAppleConfigProfile, error) {
 	if teamID == nil {
 		teamID = ptr.Uint(0)
@@ -3839,7 +3818,8 @@ func (ds *Datastore) updateHostDEPAssignProfileResponses(ctx context.Context, pa
 }
 
 func updateHostDEPAssignProfileResponses(ctx context.Context, tx sqlx.ExtContext, logger log.Logger, profileUUID string, serials []string,
-	status string, abmTokenID *uint) error {
+	status string, abmTokenID *uint,
+) error {
 	if len(serials) == 0 {
 		return nil
 	}

--- a/server/datastore/mysql/apple_mdm.go
+++ b/server/datastore/mysql/apple_mdm.go
@@ -3413,6 +3413,27 @@ func (ds *Datastore) CleanupUnusedBootstrapPackages(ctx context.Context, pkgStor
 	return ctxerr.Wrap(ctx, err, "cleanup unused bootstrap packages")
 }
 
+func (ds *Datastore) CleanupDiskEncryptionKeysOnTeamChange(ctx context.Context, hostIDs []uint, newTeamID *uint) error {
+	return ds.withTx(ctx, func(tx sqlx.ExtContext) error {
+		return cleanupDiskEncryptionKeysOnTeamChangeDB(ctx, tx, hostIDs, newTeamID)
+	})
+}
+
+func cleanupDiskEncryptionKeysOnTeamChangeDB(ctx context.Context, tx sqlx.ExtContext, hostIDs []uint, newTeamID *uint) error {
+	_, err := getMDMAppleConfigProfileByTeamAndIdentifierDB(ctx, tx, newTeamID, mobileconfig.FleetFileVaultPayloadIdentifier)
+	if err != nil {
+		if fleet.IsNotFound(err) {
+			// the new team does not have a filevault profile so we need to delete the existing ones
+			if err := bulkDeleteMacosHostDiskEncryptionKeysDB(ctx, tx, hostIDs); err != nil {
+				return ctxerr.Wrap(ctx, err, "reconcile filevault profiles on team change bulk delete host disk encryption keys")
+			}
+		} else {
+			return ctxerr.Wrap(ctx, err, "reconcile filevault profiles on team change get profile")
+		}
+	}
+	return nil
+}
+
 func getMDMAppleConfigProfileByTeamAndIdentifierDB(ctx context.Context, tx sqlx.QueryerContext, teamID *uint, profileIdentifier string) (*fleet.MDMAppleConfigProfile, error) {
 	if teamID == nil {
 		teamID = ptr.Uint(0)
@@ -3818,8 +3839,7 @@ func (ds *Datastore) updateHostDEPAssignProfileResponses(ctx context.Context, pa
 }
 
 func updateHostDEPAssignProfileResponses(ctx context.Context, tx sqlx.ExtContext, logger log.Logger, profileUUID string, serials []string,
-	status string, abmTokenID *uint,
-) error {
+	status string, abmTokenID *uint) error {
 	if len(serials) == 0 {
 		return nil
 	}

--- a/server/datastore/mysql/apple_mdm.go
+++ b/server/datastore/mysql/apple_mdm.go
@@ -3424,7 +3424,7 @@ func cleanupDiskEncryptionKeysOnTeamChangeDB(ctx context.Context, tx sqlx.ExtCon
 	if err != nil {
 		if fleet.IsNotFound(err) {
 			// the new team does not have a filevault profile so we need to delete the existing ones
-			if err := bulkDeleteMacosHostDiskEncryptionKeysDB(ctx, tx, hostIDs); err != nil {
+			if err := bulkDeleteHostDiskEncryptionKeysDB(ctx, tx, hostIDs); err != nil {
 				return ctxerr.Wrap(ctx, err, "reconcile filevault profiles on team change bulk delete host disk encryption keys")
 			}
 		} else {
@@ -3465,17 +3465,15 @@ WHERE
 	return &profile, nil
 }
 
-func bulkDeleteMacosHostDiskEncryptionKeysDB(ctx context.Context, tx sqlx.ExtContext, hostIDs []uint) error {
+func bulkDeleteHostDiskEncryptionKeysDB(ctx context.Context, tx sqlx.ExtContext, hostIDs []uint) error {
 	if len(hostIDs) == 0 {
 		return nil
 	}
 
-	query, args, err := sqlx.In(`
-		DELETE hdek 
-		FROM host_disk_encryption_keys hdek
-		INNER JOIN hosts h ON hdek.host_id = h.id 
-		WHERE h.platform = 'darwin' AND hdek.host_id IN (?)`,
-		hostIDs)
+	query, args, err := sqlx.In(
+		"DELETE FROM host_disk_encryption_keys WHERE host_id IN (?)",
+		hostIDs,
+	)
 	if err != nil {
 		return ctxerr.Wrap(ctx, err, "building query")
 	}
@@ -3839,7 +3837,8 @@ func (ds *Datastore) updateHostDEPAssignProfileResponses(ctx context.Context, pa
 }
 
 func updateHostDEPAssignProfileResponses(ctx context.Context, tx sqlx.ExtContext, logger log.Logger, profileUUID string, serials []string,
-	status string, abmTokenID *uint) error {
+	status string, abmTokenID *uint,
+) error {
 	if len(serials) == 0 {
 		return nil
 	}

--- a/server/datastore/mysql/hosts.go
+++ b/server/datastore/mysql/hosts.go
@@ -3849,7 +3849,7 @@ func (ds *Datastore) GetHostDiskEncryptionKey(ctx context.Context, hostID uint) 
 	var key fleet.HostDiskEncryptionKey
 	err := sqlx.GetContext(ctx, ds.reader(ctx), &key, `
           SELECT
-            host_id, base64_encrypted, decryptable, updated_at
+            host_id, base64_encrypted, decryptable, updated_at, client_error
           FROM
             host_disk_encryption_keys
           WHERE host_id = ?`, hostID)

--- a/server/datastore/mysql/hosts.go
+++ b/server/datastore/mysql/hosts.go
@@ -2850,6 +2850,10 @@ func (ds *Datastore) AddHostsToTeam(ctx context.Context, teamID *uint, hostIDs [
 					return ctxerr.Wrap(ctx, err, "exec AddHostsToTeam")
 				}
 
+				if err := cleanupDiskEncryptionKeysOnTeamChangeDB(ctx, tx, hostIDsBatch, teamID); err != nil {
+					return ctxerr.Wrap(ctx, err, "AddHostsToTeam cleanup disk encryption keys")
+				}
+
 				return nil
 			},
 		)

--- a/server/datastore/mysql/hosts.go
+++ b/server/datastore/mysql/hosts.go
@@ -2850,10 +2850,6 @@ func (ds *Datastore) AddHostsToTeam(ctx context.Context, teamID *uint, hostIDs [
 					return ctxerr.Wrap(ctx, err, "exec AddHostsToTeam")
 				}
 
-				if err := cleanupDiskEncryptionKeysOnTeamChangeDB(ctx, tx, hostIDsBatch, teamID); err != nil {
-					return ctxerr.Wrap(ctx, err, "AddHostsToTeam cleanup disk encryption keys")
-				}
-
 				return nil
 			},
 		)

--- a/server/datastore/mysql/linux_mdm.go
+++ b/server/datastore/mysql/linux_mdm.go
@@ -1,0 +1,69 @@
+package mysql
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/fleetdm/fleet/v4/server/fleet"
+	"github.com/jmoiron/sqlx"
+)
+
+func (ds *Datastore) GetLinuxDiskEncryptionSummary(ctx context.Context, teamID *uint) (fleet.LinuxDiskEncryptionSummary, error) {
+	var args []interface{}
+	var teamFilter string
+	if teamID != nil {
+		teamFilter = "AND h.team_id = ?"
+		args = append(args, *teamID)
+	} else {
+		teamFilter = "AND h.team_id IS NULL"
+	}
+
+	stmt := fmt.Sprintf(`SELECT
+			CASE WHEN hdek.base64_encrypted IS NOT NULL
+					AND hdek.base64_encrypted != ''
+					AND hdek.client_error = '' THEN
+					'verified'
+				WHEN hdek.client_error IS NOT NULL
+					AND hdek.client_error != '' THEN
+					'failed'
+				WHEN hdek.base64_encrypted IS NULL
+					OR (hdek.base64_encrypted = ''
+					AND hdek.client_error = '') THEN
+					'action_required'
+				END AS status,
+				COUNT(h.id) AS host_count
+			FROM
+				hosts h
+				LEFT JOIN host_disk_encryption_keys hdek ON h.id = hdek.host_id
+			WHERE
+				(h.os_version LIKE '%%fedora%%'
+				OR h.platform LIKE 'ubuntu')
+				%s
+			GROUP BY
+				status`, teamFilter)
+
+	type countRow struct {
+		Status    string `db:"status"`
+		HostCount uint   `db:"host_count"`
+	}
+
+	var counts []countRow
+	summary := fleet.LinuxDiskEncryptionSummary{}
+
+	if err := sqlx.SelectContext(ctx, ds.reader(ctx), &counts, stmt, args...); err != nil {
+		return summary, err
+	}
+
+	for _, count := range counts {
+		switch count.Status {
+		case "verified":
+			summary.Verified = count.HostCount
+		case "action_required":
+			summary.ActionRequired = count.HostCount
+		case "failed":
+			summary.Failed = count.HostCount
+		}
+	}
+
+	return summary, nil
+}

--- a/server/datastore/mysql/linux_mdm.go
+++ b/server/datastore/mysql/linux_mdm.go
@@ -8,7 +8,7 @@ import (
 	"github.com/jmoiron/sqlx"
 )
 
-func (ds *Datastore) GetLinuxDiskEncryptionSummary(ctx context.Context, teamID *uint) (fleet.LinuxDiskEncryptionSummary, error) {
+func (ds *Datastore) GetLinuxDiskEncryptionSummary(ctx context.Context, teamID *uint) (fleet.MDMLinuxDiskEncryptionSummary, error) {
 	var args []interface{}
 	var teamFilter string
 	if teamID != nil {
@@ -48,7 +48,7 @@ func (ds *Datastore) GetLinuxDiskEncryptionSummary(ctx context.Context, teamID *
 	}
 
 	var counts []countRow
-	summary := fleet.LinuxDiskEncryptionSummary{}
+	summary := fleet.MDMLinuxDiskEncryptionSummary{}
 
 	if err := sqlx.SelectContext(ctx, ds.reader(ctx), &counts, stmt, args...); err != nil {
 		return summary, err

--- a/server/datastore/mysql/linux_mdm_test.go
+++ b/server/datastore/mysql/linux_mdm_test.go
@@ -89,7 +89,7 @@ func TestLinuxDiskEncryptionSummary(t *testing.T) {
 	require.Equal(t, uint(7), summary.ActionRequired)
 	require.Equal(t, uint(2), summary.Failed)
 
-	// move verified fedora host to team
+	// move verified fedora host to team will remove existing key
 	team, err := ds.NewTeam(ctx, &fleet.Team{Name: "team1"})
 	require.NoError(t, err)
 
@@ -100,8 +100,8 @@ func TestLinuxDiskEncryptionSummary(t *testing.T) {
 	summary, err = ds.GetLinuxDiskEncryptionSummary(ctx, &team.ID)
 	require.NoError(t, err)
 
-	require.Equal(t, uint(1), summary.Verified)
-	require.Equal(t, uint(0), summary.ActionRequired)
+	require.Equal(t, uint(0), summary.Verified)
+	require.Equal(t, uint(1), summary.ActionRequired)
 	require.Equal(t, uint(0), summary.Failed)
 
 	// no team summary
@@ -132,9 +132,9 @@ func TestLinuxDiskEncryptionSummary(t *testing.T) {
 	summary, err = ds.GetLinuxDiskEncryptionSummary(ctx, &team.ID)
 	require.NoError(t, err)
 
-	require.Equal(t, uint(1), summary.Verified)
-	require.Equal(t, uint(7), summary.ActionRequired)
-	require.Equal(t, uint(2), summary.Failed)
+	require.Equal(t, uint(0), summary.Verified)
+	require.Equal(t, uint(10), summary.ActionRequired)
+	require.Equal(t, uint(0), summary.Failed)
 
 	// no team summary
 	summary, err = ds.GetLinuxDiskEncryptionSummary(ctx, nil)

--- a/server/datastore/mysql/linux_mdm_test.go
+++ b/server/datastore/mysql/linux_mdm_test.go
@@ -1,0 +1,146 @@
+package mysql
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/fleetdm/fleet/v4/server/fleet"
+	"github.com/fleetdm/fleet/v4/server/test"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLinuxDiskEncryptionSummary(t *testing.T) {
+	ds := CreateMySQLDS(t)
+	ctx := context.Background()
+
+	// 5 new ubuntu hosts
+	var ubuntuHosts []*fleet.Host
+	for i := 0; i < 5; i++ {
+		h := test.NewHost(t, ds, fmt.Sprintf("foo.local.%d", i), "1.1.1.1",
+			fmt.Sprintf("%d", i), fmt.Sprintf("%d", i), time.Now(), test.WithPlatform("ubuntu"))
+		ubuntuHosts = append(ubuntuHosts, h)
+	}
+
+	// 5 new fedora hosts
+	var fedoraHosts []*fleet.Host
+	for i := 5; i < 10; i++ {
+		h := test.NewHost(t, ds, fmt.Sprintf("foo.local.%d", i), "1.1.1.1",
+			fmt.Sprintf("%d", i), fmt.Sprintf("%d", i), time.Now(),
+			test.WithOSVersion("Fedora Linux 38.0.0"), test.WithPlatform("rhel"))
+		fedoraHosts = append(fedoraHosts, h)
+	}
+
+	// 5 macos hosts
+	var macosHosts []*fleet.Host
+	for i := 10; i < 15; i++ {
+		h := test.NewHost(t, ds, fmt.Sprintf("foo.local.%d", i), "1.1.1.1",
+			fmt.Sprintf("%d", i), fmt.Sprintf("%d", i), time.Now(), test.WithPlatform("darwin"))
+		macosHosts = append(macosHosts, h)
+	}
+
+	// no teams tests =====
+	summary, err := ds.GetLinuxDiskEncryptionSummary(ctx, nil)
+	require.NoError(t, err)
+
+	require.Equal(t, uint(0), summary.Verified)
+	require.Equal(t, uint(10), summary.ActionRequired)
+	require.Equal(t, uint(0), summary.Failed)
+
+	// Add disk encryption keys
+
+	// ubuntu
+	err = ds.SetOrUpdateHostDiskEncryptionKey(ctx, ubuntuHosts[0].ID, "base64_encrypted", "", nil)
+	require.NoError(t, err)
+	// fedora
+	err = ds.SetOrUpdateHostDiskEncryptionKey(ctx, fedoraHosts[0].ID, "base64_encrypted", "", nil)
+	require.NoError(t, err)
+	// macos
+	err = ds.SetOrUpdateHostDiskEncryptionKey(ctx, macosHosts[0].ID, "base64_encrypted", "", nil)
+	require.NoError(t, err)
+
+	summary, err = ds.GetLinuxDiskEncryptionSummary(ctx, nil)
+	require.NoError(t, err)
+
+	require.Equal(t, uint(2), summary.Verified)
+	require.Equal(t, uint(8), summary.ActionRequired)
+	require.Equal(t, uint(0), summary.Failed)
+
+	// update ubuntu with key and client error
+	err = ds.SetOrUpdateHostDiskEncryptionKey(ctx, ubuntuHosts[0].ID, "base64_encrypted", "client error", nil)
+	require.NoError(t, err)
+
+	summary, err = ds.GetLinuxDiskEncryptionSummary(ctx, nil)
+	require.NoError(t, err)
+
+	require.Equal(t, uint(1), summary.Verified)
+	require.Equal(t, uint(8), summary.ActionRequired)
+	require.Equal(t, uint(1), summary.Failed)
+
+	// add ubuntu with no key and client error
+	err = ds.SetOrUpdateHostDiskEncryptionKey(ctx, ubuntuHosts[1].ID, "", "client error", nil)
+	require.NoError(t, err)
+
+	summary, err = ds.GetLinuxDiskEncryptionSummary(ctx, nil)
+	require.NoError(t, err)
+
+	require.Equal(t, uint(1), summary.Verified)
+	require.Equal(t, uint(7), summary.ActionRequired)
+	require.Equal(t, uint(2), summary.Failed)
+
+	// move verified fedora host to team
+	team, err := ds.NewTeam(ctx, &fleet.Team{Name: "team1"})
+	require.NoError(t, err)
+
+	err = ds.AddHostsToTeam(ctx, &team.ID, []uint{fedoraHosts[0].ID})
+	require.NoError(t, err)
+
+	// team summary
+	summary, err = ds.GetLinuxDiskEncryptionSummary(ctx, &team.ID)
+	require.NoError(t, err)
+
+	require.Equal(t, uint(1), summary.Verified)
+	require.Equal(t, uint(0), summary.ActionRequired)
+	require.Equal(t, uint(0), summary.Failed)
+
+	// no team summary
+	summary, err = ds.GetLinuxDiskEncryptionSummary(ctx, nil)
+	require.NoError(t, err)
+
+	require.Equal(t, uint(0), summary.Verified)
+	require.Equal(t, uint(7), summary.ActionRequired)
+	require.Equal(t, uint(2), summary.Failed)
+
+	// move all hosts to team
+	for _, h := range ubuntuHosts {
+		err = ds.AddHostsToTeam(ctx, &team.ID, []uint{h.ID})
+		require.NoError(t, err)
+	}
+
+	for _, h := range fedoraHosts {
+		err = ds.AddHostsToTeam(ctx, &team.ID, []uint{h.ID})
+		require.NoError(t, err)
+	}
+
+	for _, h := range macosHosts {
+		err = ds.AddHostsToTeam(ctx, &team.ID, []uint{h.ID})
+		require.NoError(t, err)
+	}
+
+	// team summary
+	summary, err = ds.GetLinuxDiskEncryptionSummary(ctx, &team.ID)
+	require.NoError(t, err)
+
+	require.Equal(t, uint(1), summary.Verified)
+	require.Equal(t, uint(7), summary.ActionRequired)
+	require.Equal(t, uint(2), summary.Failed)
+
+	// no team summary
+	summary, err = ds.GetLinuxDiskEncryptionSummary(ctx, nil)
+	require.NoError(t, err)
+
+	require.Equal(t, uint(0), summary.Verified)
+	require.Equal(t, uint(0), summary.ActionRequired)
+	require.Equal(t, uint(0), summary.Failed)
+}

--- a/server/datastore/mysql/mdm.go
+++ b/server/datastore/mysql/mdm.go
@@ -124,8 +124,7 @@ func (ds *Datastore) getMDMCommand(ctx context.Context, q sqlx.QueryerContext, c
 
 func (ds *Datastore) BatchSetMDMProfiles(ctx context.Context, tmID *uint, macProfiles []*fleet.MDMAppleConfigProfile,
 	winProfiles []*fleet.MDMWindowsConfigProfile, macDeclarations []*fleet.MDMAppleDeclaration) (updates fleet.MDMProfilesUpdates,
-	err error,
-) {
+	err error) {
 	err = ds.withRetryTxx(ctx, func(tx sqlx.ExtContext) error {
 		var err error
 		if updates.WindowsConfigProfile, err = ds.batchSetMDMWindowsProfilesDB(ctx, tx, tmID, winProfiles); err != nil {
@@ -1450,25 +1449,4 @@ func (ds *Datastore) IsHostConnectedToFleetMDM(ctx context.Context, host *fleet.
 		return false, ctxerr.Wrap(ctx, err, "finding if host is connected to Fleet MDM")
 	}
 	return mp[host.UUID], nil
-}
-
-func (ds *Datastore) CleanupDiskEncryptionKeysOnTeamChange(ctx context.Context, hostIDs []uint, newTeamID *uint) error {
-	return ds.withTx(ctx, func(tx sqlx.ExtContext) error {
-		return cleanupDiskEncryptionKeysOnTeamChangeDB(ctx, tx, hostIDs, newTeamID)
-	})
-}
-
-func cleanupDiskEncryptionKeysOnTeamChangeDB(ctx context.Context, tx sqlx.ExtContext, hostIDs []uint, newTeamID *uint) error {
-	_, err := getMDMAppleConfigProfileByTeamAndIdentifierDB(ctx, tx, newTeamID, mobileconfig.FleetFileVaultPayloadIdentifier)
-	if err != nil {
-		if fleet.IsNotFound(err) {
-			// the new team does not have a filevault profile so we need to delete the existing ones
-			if err := bulkDeleteMacosHostDiskEncryptionKeysDB(ctx, tx, hostIDs); err != nil {
-				return ctxerr.Wrap(ctx, err, "reconcile filevault profiles on team change bulk delete host disk encryption keys")
-			}
-		} else {
-			return ctxerr.Wrap(ctx, err, "reconcile filevault profiles on team change get profile")
-		}
-	}
-	return nil
 }

--- a/server/fleet/datastore.go
+++ b/server/fleet/datastore.go
@@ -1502,7 +1502,7 @@ type Datastore interface {
 	// GetLinuxDiskEncryptionSummary summarizes the current state of Linux disk encryption on
 	// each Linux host in the specified team (or, if no team is specified, each host that is not assigned
 	// to any team).
-	GetLinuxDiskEncryptionSummary(ctx context.Context, teamID *uint) (LinuxDiskEncryptionSummary, error)
+	GetLinuxDiskEncryptionSummary(ctx context.Context, teamID *uint) (MDMLinuxDiskEncryptionSummary, error)
 
 	///////////////////////////////////////////////////////////////////////////////
 	// MDM Commands

--- a/server/fleet/datastore.go
+++ b/server/fleet/datastore.go
@@ -1069,7 +1069,6 @@ type Datastore interface {
 	// GetHostMDMAppleProfiles returns the MDM profile information for the specified host UUID.
 	GetHostMDMAppleProfiles(ctx context.Context, hostUUID string) ([]HostMDMAppleProfile, error)
 
-	// CleanupDiskEncryptionKeysOnTeamChange removes all disk encryption keys for the given hosts on the provided team.
 	CleanupDiskEncryptionKeysOnTeamChange(ctx context.Context, hostIDs []uint, newTeamID *uint) error
 
 	// NewMDMAppleEnrollmentProfile creates and returns new enrollment profile.

--- a/server/fleet/datastore.go
+++ b/server/fleet/datastore.go
@@ -1069,6 +1069,7 @@ type Datastore interface {
 	// GetHostMDMAppleProfiles returns the MDM profile information for the specified host UUID.
 	GetHostMDMAppleProfiles(ctx context.Context, hostUUID string) ([]HostMDMAppleProfile, error)
 
+	// CleanupDiskEncryptionKeysOnTeamChange removes all disk encryption keys for the given hosts on the provided team.
 	CleanupDiskEncryptionKeysOnTeamChange(ctx context.Context, hostIDs []uint, newTeamID *uint) error
 
 	// NewMDMAppleEnrollmentProfile creates and returns new enrollment profile.

--- a/server/fleet/datastore.go
+++ b/server/fleet/datastore.go
@@ -1497,6 +1497,14 @@ type Datastore interface {
 	GetHostMDMProfileInstallStatus(ctx context.Context, hostUUID string, profileUUID string) (MDMDeliveryStatus, error)
 
 	///////////////////////////////////////////////////////////////////////////////
+	// Linux MDM
+
+	// GetLinuxDiskEncryptionSummary summarizes the current state of Linux disk encryption on
+	// each Linux host in the specified team (or, if no team is specified, each host that is not assigned
+	// to any team).
+	GetLinuxDiskEncryptionSummary(ctx context.Context, teamID *uint) (LinuxDiskEncryptionSummary, error)
+
+	///////////////////////////////////////////////////////////////////////////////
 	// MDM Commands
 
 	// GetMDMCommandPlatform returns the platform (i.e. "darwin" or "windows") for the given command.

--- a/server/fleet/hosts.go
+++ b/server/fleet/hosts.go
@@ -678,6 +678,12 @@ func (h *Host) IsDEPAssignedToFleet() bool {
 	return h.DEPAssignedToFleet != nil && *h.DEPAssignedToFleet
 }
 
+// IsLUKSSupported returns true if the host's platform is Linux and running
+// one of the supported OS versions.
+func (h *Host) IsLUKSSupported() bool {
+	return h.Platform == "ubuntu" || strings.Contains(h.OSVersion, "Fedora") // fedora h.Platform reports as "rhel"
+}
+
 // IsEligibleForWindowsMDMUnenrollment returns true if the host must be
 // unenrolled from Fleet's Windows MDM (if it MDM was disabled).
 func (h *Host) IsEligibleForWindowsMDMUnenrollment(isConnectedToFleetMDM bool) bool {
@@ -1169,6 +1175,7 @@ type HostDiskEncryptionKey struct {
 	Decryptable     *bool     `json:"-" db:"decryptable"`
 	UpdatedAt       time.Time `json:"updated_at" db:"updated_at"`
 	DecryptedValue  string    `json:"key" db:"-"`
+	ClientError     string    `json:"-" db:"client_error"`
 }
 
 // HostSoftwareInstalledPath represents where in the file system a software on a host was installed

--- a/server/fleet/linux_mdm.go
+++ b/server/fleet/linux_mdm.go
@@ -1,6 +1,6 @@
 package fleet
 
-type LinuxDiskEncryptionSummary struct {
+type MDMLinuxDiskEncryptionSummary struct {
 	Verified       uint `json:"verified"`
 	ActionRequired uint `json:"action_required"`
 	Failed         uint `json:"failed"`

--- a/server/fleet/linux_mdm.go
+++ b/server/fleet/linux_mdm.go
@@ -1,0 +1,7 @@
+package fleet
+
+type LinuxDiskEncryptionSummary struct {
+	Verified       uint `json:"verified"`
+	ActionRequired uint `json:"action_required"`
+	Failed         uint `json:"failed"`
+}

--- a/server/fleet/mdm.go
+++ b/server/fleet/mdm.go
@@ -298,6 +298,7 @@ type MDMCommandFilters struct {
 type MDMPlatformsCounts struct {
 	MacOS   uint `db:"macos" json:"macos"`
 	Windows uint `db:"windows" json:"windows"`
+	Linux   uint `db:"linux" json:"linux"`
 }
 
 type MDMDiskEncryptionSummary struct {
@@ -741,9 +742,11 @@ func FilterMacOSOnlyProfilesFromIOSIPadOS(profiles []*MDMAppleProfilePayload) []
 }
 
 // RefetchBaseCommandUUIDPrefix and below command prefixes are the prefixes used for MDM commands used to refetch information from iOS/iPadOS devices.
-const RefetchBaseCommandUUIDPrefix = "REFETCH-"
-const RefetchDeviceCommandUUIDPrefix = RefetchBaseCommandUUIDPrefix + "DEVICE-"
-const RefetchAppsCommandUUIDPrefix = RefetchBaseCommandUUIDPrefix + "APPS-"
+const (
+	RefetchBaseCommandUUIDPrefix   = "REFETCH-"
+	RefetchDeviceCommandUUIDPrefix = RefetchBaseCommandUUIDPrefix + "DEVICE-"
+	RefetchAppsCommandUUIDPrefix   = RefetchBaseCommandUUIDPrefix + "APPS-"
+)
 
 // VPPTokenInfo is the representation of the VPP token that we send out via API.
 type VPPTokenInfo struct {

--- a/server/fleet/service.go
+++ b/server/fleet/service.go
@@ -1052,7 +1052,7 @@ type Service interface {
 	///////////////////////////////////////////////////////////////////////////////
 	// Linux MDM
 
-	// LinuxHostDiskEncryptionStatus returns the current disk encryption status of the specified Linx host
+	// LinuxHostDiskEncryptionStatus returns the current disk encryption status of the specified Linux host
 	// Returns empty status if the host is not a supported Linux host
 	LinuxHostDiskEncryptionStatus(ctx context.Context, host Host) (HostMDMDiskEncryption, error)
 

--- a/server/fleet/service.go
+++ b/server/fleet/service.go
@@ -1050,6 +1050,13 @@ type Service interface {
 	) error
 
 	///////////////////////////////////////////////////////////////////////////////
+	// Linux MDM
+
+	// LinuxHostDiskEncryptionStatus returns the current disk encryption status of the specified Linx host
+	// Returns empty status if the host is not a supported Linux host
+	LinuxHostDiskEncryptionStatus(ctx context.Context, host Host) (HostMDMDiskEncryption, error)
+
+	///////////////////////////////////////////////////////////////////////////////
 	// Common MDM
 
 	// GetMDMDiskEncryptionSummary returns the current disk encryption status of all macOS and

--- a/server/mock/datastore_mock.go
+++ b/server/mock/datastore_mock.go
@@ -973,6 +973,8 @@ type ResendHostMDMProfileFunc func(ctx context.Context, hostUUID string, profile
 
 type GetHostMDMProfileInstallStatusFunc func(ctx context.Context, hostUUID string, profileUUID string) (fleet.MDMDeliveryStatus, error)
 
+type GetLinuxDiskEncryptionSummaryFunc func(ctx context.Context, teamID *uint) (fleet.LinuxDiskEncryptionSummary, error)
+
 type GetMDMCommandPlatformFunc func(ctx context.Context, commandUUID string) (string, error)
 
 type ListMDMCommandsFunc func(ctx context.Context, tmFilter fleet.TeamFilter, listOpts *fleet.MDMCommandListOptions) ([]*fleet.MDMCommand, error)
@@ -2575,6 +2577,9 @@ type DataStore struct {
 
 	GetHostMDMProfileInstallStatusFunc        GetHostMDMProfileInstallStatusFunc
 	GetHostMDMProfileInstallStatusFuncInvoked bool
+
+	GetLinuxDiskEncryptionSummaryFunc        GetLinuxDiskEncryptionSummaryFunc
+	GetLinuxDiskEncryptionSummaryFuncInvoked bool
 
 	GetMDMCommandPlatformFunc        GetMDMCommandPlatformFunc
 	GetMDMCommandPlatformFuncInvoked bool
@@ -6170,6 +6175,13 @@ func (s *DataStore) GetHostMDMProfileInstallStatus(ctx context.Context, hostUUID
 	s.GetHostMDMProfileInstallStatusFuncInvoked = true
 	s.mu.Unlock()
 	return s.GetHostMDMProfileInstallStatusFunc(ctx, hostUUID, profileUUID)
+}
+
+func (s *DataStore) GetLinuxDiskEncryptionSummary(ctx context.Context, teamID *uint) (fleet.LinuxDiskEncryptionSummary, error) {
+	s.mu.Lock()
+	s.GetLinuxDiskEncryptionSummaryFuncInvoked = true
+	s.mu.Unlock()
+	return s.GetLinuxDiskEncryptionSummaryFunc(ctx, teamID)
 }
 
 func (s *DataStore) GetMDMCommandPlatform(ctx context.Context, commandUUID string) (string, error) {

--- a/server/mock/datastore_mock.go
+++ b/server/mock/datastore_mock.go
@@ -973,7 +973,7 @@ type ResendHostMDMProfileFunc func(ctx context.Context, hostUUID string, profile
 
 type GetHostMDMProfileInstallStatusFunc func(ctx context.Context, hostUUID string, profileUUID string) (fleet.MDMDeliveryStatus, error)
 
-type GetLinuxDiskEncryptionSummaryFunc func(ctx context.Context, teamID *uint) (fleet.LinuxDiskEncryptionSummary, error)
+type GetLinuxDiskEncryptionSummaryFunc func(ctx context.Context, teamID *uint) (fleet.MDMLinuxDiskEncryptionSummary, error)
 
 type GetMDMCommandPlatformFunc func(ctx context.Context, commandUUID string) (string, error)
 
@@ -6177,7 +6177,7 @@ func (s *DataStore) GetHostMDMProfileInstallStatus(ctx context.Context, hostUUID
 	return s.GetHostMDMProfileInstallStatusFunc(ctx, hostUUID, profileUUID)
 }
 
-func (s *DataStore) GetLinuxDiskEncryptionSummary(ctx context.Context, teamID *uint) (fleet.LinuxDiskEncryptionSummary, error) {
+func (s *DataStore) GetLinuxDiskEncryptionSummary(ctx context.Context, teamID *uint) (fleet.MDMLinuxDiskEncryptionSummary, error) {
 	s.mu.Lock()
 	s.GetLinuxDiskEncryptionSummaryFuncInvoked = true
 	s.mu.Unlock()

--- a/server/service/hosts.go
+++ b/server/service/hosts.go
@@ -1173,9 +1173,10 @@ func (svc *Service) getHostDetails(ctx context.Context, host *fleet.Host, opts f
 		return nil, ctxerr.Wrap(ctx, err, "get app config for host mdm details")
 	}
 
+	host.MDM.OSSettings = &fleet.HostMDMOSSettings{}
+
 	var profiles []fleet.HostMDMProfile
 	if ac.MDM.EnabledAndConfigured || ac.MDM.WindowsEnabledAndConfigured {
-		host.MDM.OSSettings = &fleet.HostMDMOSSettings{}
 		switch host.Platform {
 		case "windows":
 			if !ac.MDM.WindowsEnabledAndConfigured {

--- a/server/service/hosts.go
+++ b/server/service/hosts.go
@@ -1240,6 +1240,14 @@ func (svc *Service) getHostDetails(ctx context.Context, host *fleet.Host, opts f
 	}
 	host.MDM.Profiles = &profiles
 
+	if host.IsLUKSSupported() {
+		status, err := svc.LinuxHostDiskEncryptionStatus(ctx, *host)
+		if err != nil {
+			return nil, ctxerr.Wrap(ctx, err, "get host disk encryption status")
+		}
+		host.MDM.OSSettings.DiskEncryption = status
+	}
+
 	var macOSSetup *fleet.HostMDMMacOSSetup
 	if ac.MDM.EnabledAndConfigured && license.IsPremium(ctx) {
 		macOSSetup, err = svc.ds.GetHostMDMMacOSSetup(ctx, host.ID)

--- a/server/service/hosts.go
+++ b/server/service/hosts.go
@@ -1246,6 +1246,10 @@ func (svc *Service) getHostDetails(ctx context.Context, host *fleet.Host, opts f
 			return nil, ctxerr.Wrap(ctx, err, "get host disk encryption status")
 		}
 		host.MDM.OSSettings.DiskEncryption = status
+
+		if status.Status != nil && *status.Status == fleet.DiskEncryptionVerified {
+			host.MDM.EncryptionKeyAvailable = true
+		}
 	}
 
 	var macOSSetup *fleet.HostMDMMacOSSetup

--- a/server/service/hosts.go
+++ b/server/service/hosts.go
@@ -825,11 +825,6 @@ func (svc *Service) AddHostsToTeam(ctx context.Context, teamID *uint, hostIDs []
 	if err := svc.ds.AddHostsToTeam(ctx, teamID, hostIDs); err != nil {
 		return err
 	}
-
-	if err := svc.cleanupDiskEncryptionKeys(ctx, teamID, hostIDs); err != nil {
-		return ctxerr.Wrap(ctx, err, "cleanup disk encryption keys")
-	}
-
 	if !skipBulkPending {
 		if _, err := svc.ds.BulkSetPendingMDMHostProfiles(ctx, hostIDs, nil, nil, nil); err != nil {
 			return ctxerr.Wrap(ctx, err, "bulk set pending host profiles")
@@ -852,34 +847,6 @@ func (svc *Service) AddHostsToTeam(ctx context.Context, teamID *uint, hostIDs []
 	}
 
 	return svc.createTransferredHostsActivity(ctx, teamID, hostIDs, nil)
-}
-
-// removes any existing disk encryption keys for hosts that are being transferred
-// to a different team if disk encryption is NOT enabled on the new team
-func (svc *Service) cleanupDiskEncryptionKeys(ctx context.Context, teamID *uint, hostIDs []uint) error {
-	var encryptionEnabled bool
-	if teamID == nil {
-		appConfig, err := svc.ds.AppConfig(ctx)
-		if err != nil {
-			return ctxerr.Wrap(ctx, err, "get app config")
-		}
-		encryptionEnabled = appConfig.MDM.EnableDiskEncryption.Value
-	} else {
-		team, err := svc.ds.Team(ctx, *teamID)
-		if err != nil {
-			return ctxerr.Wrap(ctx, err, "get team")
-		}
-		encryptionEnabled = team.Config.MDM.EnableDiskEncryption
-	}
-
-	if !encryptionEnabled {
-		err := svc.ds.CleanupDiskEncryptionKeysOnTeamChange(ctx, hostIDs, teamID)
-		if err != nil {
-			return ctxerr.Wrap(ctx, err, "cleanup disk encryption keys on team change")
-		}
-	}
-
-	return nil
 }
 
 // creates the transferred hosts activity if hosts were transferred, taking
@@ -994,9 +961,6 @@ func (svc *Service) AddHostsToTeamByFilter(ctx context.Context, teamID *uint, fi
 	// Apply the team to the selected hosts.
 	if err := svc.ds.AddHostsToTeam(ctx, teamID, hostIDs); err != nil {
 		return err
-	}
-	if err := svc.cleanupDiskEncryptionKeys(ctx, teamID, hostIDs); err != nil {
-		return ctxerr.Wrap(ctx, err, "cleanup disk encryption keys")
 	}
 	if _, err := svc.ds.BulkSetPendingMDMHostProfiles(ctx, hostIDs, nil, nil, nil); err != nil {
 		return ctxerr.Wrap(ctx, err, "bulk set pending host profiles")

--- a/server/service/hosts.go
+++ b/server/service/hosts.go
@@ -1245,8 +1245,9 @@ func (svc *Service) getHostDetails(ctx context.Context, host *fleet.Host, opts f
 		if err != nil {
 			return nil, ctxerr.Wrap(ctx, err, "get host disk encryption status")
 		}
-		host.MDM.OSSettings = &fleet.HostMDMOSSettings{}
-		host.MDM.OSSettings.DiskEncryption = status
+		host.MDM.OSSettings = &fleet.HostMDMOSSettings{
+			DiskEncryption: status,
+		}
 
 		if status.Status != nil && *status.Status == fleet.DiskEncryptionVerified {
 			host.MDM.EncryptionKeyAvailable = true

--- a/server/service/hosts.go
+++ b/server/service/hosts.go
@@ -1245,6 +1245,7 @@ func (svc *Service) getHostDetails(ctx context.Context, host *fleet.Host, opts f
 		if err != nil {
 			return nil, ctxerr.Wrap(ctx, err, "get host disk encryption status")
 		}
+		host.MDM.OSSettings = &fleet.HostMDMOSSettings{}
 		host.MDM.OSSettings.DiskEncryption = status
 
 		if status.Status != nil && *status.Status == fleet.DiskEncryptionVerified {

--- a/server/service/hosts.go
+++ b/server/service/hosts.go
@@ -1173,10 +1173,9 @@ func (svc *Service) getHostDetails(ctx context.Context, host *fleet.Host, opts f
 		return nil, ctxerr.Wrap(ctx, err, "get app config for host mdm details")
 	}
 
-	host.MDM.OSSettings = &fleet.HostMDMOSSettings{}
-
 	var profiles []fleet.HostMDMProfile
 	if ac.MDM.EnabledAndConfigured || ac.MDM.WindowsEnabledAndConfigured {
+		host.MDM.OSSettings = &fleet.HostMDMOSSettings{}
 		switch host.Platform {
 		case "windows":
 			if !ac.MDM.WindowsEnabledAndConfigured {

--- a/server/service/hosts_test.go
+++ b/server/service/hosts_test.go
@@ -399,6 +399,10 @@ func TestHostDetailsOSSettings(t *testing.T) {
 		return &fleet.HostLockWipeStatus{}, nil
 	}
 
+	ds.GetHostDiskEncryptionKeyFunc = func(ctx context.Context, hostID uint) (*fleet.HostDiskEncryptionKey, error) {
+		return &fleet.HostDiskEncryptionKey{}, nil
+	}
+
 	type testCase struct {
 		name        string
 		host        *fleet.Host
@@ -1286,7 +1290,8 @@ func TestHostEncryptionKey(t *testing.T) {
 			}
 
 			ds.GetAllMDMConfigAssetsByNameFunc = func(ctx context.Context, assetNames []fleet.MDMAssetName,
-				_ sqlx.QueryerContext) (map[fleet.MDMAssetName]fleet.MDMConfigAsset, error) {
+				_ sqlx.QueryerContext,
+			) (map[fleet.MDMAssetName]fleet.MDMConfigAsset, error) {
 				return map[fleet.MDMAssetName]fleet.MDMConfigAsset{
 					fleet.MDMAssetCACert: {Name: fleet.MDMAssetCACert, Value: testCertPEM},
 					fleet.MDMAssetCAKey:  {Name: fleet.MDMAssetCAKey, Value: testKeyPEM},
@@ -1339,7 +1344,8 @@ func TestHostEncryptionKey(t *testing.T) {
 			return nil, keyErr
 		}
 		ds.GetAllMDMConfigAssetsByNameFunc = func(ctx context.Context, assetNames []fleet.MDMAssetName,
-			_ sqlx.QueryerContext) (map[fleet.MDMAssetName]fleet.MDMConfigAsset, error) {
+			_ sqlx.QueryerContext,
+		) (map[fleet.MDMAssetName]fleet.MDMConfigAsset, error) {
 			return map[fleet.MDMAssetName]fleet.MDMConfigAsset{
 				fleet.MDMAssetCACert: {Name: fleet.MDMAssetCACert, Value: testCertPEM},
 				fleet.MDMAssetCAKey:  {Name: fleet.MDMAssetCAKey, Value: testKeyPEM},
@@ -1400,7 +1406,8 @@ func TestHostEncryptionKey(t *testing.T) {
 					return nil
 				}
 				ds.GetAllMDMConfigAssetsByNameFunc = func(ctx context.Context, assetNames []fleet.MDMAssetName,
-					_ sqlx.QueryerContext) (map[fleet.MDMAssetName]fleet.MDMConfigAsset, error) {
+					_ sqlx.QueryerContext,
+				) (map[fleet.MDMAssetName]fleet.MDMConfigAsset, error) {
 					return map[fleet.MDMAssetName]fleet.MDMConfigAsset{
 						fleet.MDMAssetCACert: {Name: fleet.MDMAssetCACert, Value: testCertPEM},
 						fleet.MDMAssetCAKey:  {Name: fleet.MDMAssetCAKey, Value: testKeyPEM},

--- a/server/service/linux_mdm.go
+++ b/server/service/linux_mdm.go
@@ -1,0 +1,44 @@
+package service
+
+import (
+	"context"
+
+	"github.com/fleetdm/fleet/v4/server/fleet"
+)
+
+func (svc *Service) LinuxHostDiskEncryptionStatus(ctx context.Context, host fleet.Host) (fleet.HostMDMDiskEncryption, error) {
+	if !host.IsLUKSSupported() {
+		return fleet.HostMDMDiskEncryption{}, nil
+	}
+
+	actionRequired := fleet.DiskEncryptionActionRequired
+	verified := fleet.DiskEncryptionVerified
+	failed := fleet.DiskEncryptionFailed
+
+	key, err := svc.ds.GetHostDiskEncryptionKey(ctx, host.ID)
+	if err != nil {
+		if fleet.IsNotFound(err) {
+			return fleet.HostMDMDiskEncryption{
+				Status: &actionRequired,
+			}, nil
+		}
+		return fleet.HostMDMDiskEncryption{}, err
+	}
+
+	if key.ClientError != "" {
+		return fleet.HostMDMDiskEncryption{
+			Status: &failed,
+			Detail: key.ClientError,
+		}, nil
+	}
+
+	if key.Base64Encrypted == "" {
+		return fleet.HostMDMDiskEncryption{
+			Status: &actionRequired,
+		}, nil
+	}
+
+	return fleet.HostMDMDiskEncryption{
+		Status: &verified,
+	}, nil
+}

--- a/server/service/linux_mdm_test.go
+++ b/server/service/linux_mdm_test.go
@@ -1,0 +1,103 @@
+package service
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/fleetdm/fleet/v4/server/fleet"
+	"github.com/fleetdm/fleet/v4/server/mock"
+	"github.com/fleetdm/fleet/v4/server/ptr"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLinuxHostDiskEncryptionStatus(t *testing.T) {
+	ds := new(mock.Store)
+	svc, ctx := newTestService(t, ds, nil, nil)
+
+	actionRequired := fleet.DiskEncryptionActionRequired
+	verified := fleet.DiskEncryptionVerified
+	failed := fleet.DiskEncryptionFailed
+
+	testcases := []struct {
+		name              string
+		host              fleet.Host
+		keyExists         bool
+		clientErrorExists bool
+		status            fleet.HostMDMDiskEncryption
+		notFound          bool
+	}{
+		{
+			name:              "no key",
+			host:              fleet.Host{ID: 1, Platform: "ubuntu"},
+			keyExists:         false,
+			clientErrorExists: false,
+			status: fleet.HostMDMDiskEncryption{
+				Status: &actionRequired,
+			},
+		},
+		{
+			name:              "key exists",
+			host:              fleet.Host{ID: 1, Platform: "ubuntu"},
+			keyExists:         true,
+			clientErrorExists: false,
+			status: fleet.HostMDMDiskEncryption{
+				Status: &verified,
+			},
+		},
+		{
+			name:              "key exists && client error",
+			host:              fleet.Host{ID: 1, Platform: "ubuntu"},
+			keyExists:         true,
+			clientErrorExists: true,
+			status: fleet.HostMDMDiskEncryption{
+				Status: &failed,
+				Detail: "client error",
+			},
+		},
+		{
+			name:              "key not found",
+			host:              fleet.Host{ID: 1, Platform: "ubuntu"},
+			keyExists:         false,
+			clientErrorExists: false,
+			status: fleet.HostMDMDiskEncryption{
+				Status: &actionRequired,
+			},
+			notFound: true,
+		},
+	}
+
+	for _, tt := range testcases {
+		t.Run(tt.name, func(t *testing.T) {
+			ds.GetHostDiskEncryptionKeyFunc = func(ctx context.Context, hostID uint) (*fleet.HostDiskEncryptionKey, error) {
+				var encrypted string
+				if tt.keyExists {
+					encrypted = "encrypted"
+				}
+
+				var clientError string
+				if tt.clientErrorExists {
+					clientError = "client error"
+				}
+
+				var nfe notFoundError
+				if tt.notFound {
+					return nil, &nfe
+				}
+
+				return &fleet.HostDiskEncryptionKey{
+					HostID:          hostID,
+					Base64Encrypted: encrypted,
+					Decryptable:     ptr.Bool(true),
+					UpdatedAt:       time.Now(),
+					ClientError:     clientError,
+				}, nil
+			}
+
+			status, err := svc.LinuxHostDiskEncryptionStatus(ctx, tt.host)
+			assert.Nil(t, err)
+
+			assert.Equal(t, tt.status, status)
+		})
+	}
+}

--- a/server/service/linux_mdm_test.go
+++ b/server/service/linux_mdm_test.go
@@ -56,6 +56,16 @@ func TestLinuxHostDiskEncryptionStatus(t *testing.T) {
 			},
 		},
 		{
+			name:              "no key && client error",
+			host:              fleet.Host{ID: 1, Platform: "ubuntu"},
+			keyExists:         false,
+			clientErrorExists: true,
+			status: fleet.HostMDMDiskEncryption{
+				Status: &failed,
+				Detail: "client error",
+			},
+		},
+		{
 			name:              "key not found",
 			host:              fleet.Host{ID: 1, Platform: "ubuntu"},
 			keyExists:         false,
@@ -64,6 +74,11 @@ func TestLinuxHostDiskEncryptionStatus(t *testing.T) {
 				Status: &actionRequired,
 			},
 			notFound: true,
+		},
+		{
+			name:   "unsupported platform",
+			host:   fleet.Host{ID: 1, Platform: "amzn"},
+			status: fleet.HostMDMDiskEncryption{},
 		},
 	}
 

--- a/server/service/mdm_test.go
+++ b/server/service/mdm_test.go
@@ -873,6 +873,11 @@ func TestGetMDMDiskEncryptionSummary(t *testing.T) {
 		return res, nil
 	}
 
+	ds.GetLinuxDiskEncryptionSummaryFunc = func(ctx context.Context, teamID *uint) (fleet.MDMLinuxDiskEncryptionSummary, error) {
+		require.Nil(t, teamID)
+		return fleet.MDMLinuxDiskEncryptionSummary{Verified: 1, ActionRequired: 2, Failed: 3}, nil
+	}
+
 	// Test that the summary properly combines the results of the two methods
 	des, err := svc.GetMDMDiskEncryptionSummary(ctx, nil)
 	require.NoError(t, err)
@@ -881,6 +886,7 @@ func TestGetMDMDiskEncryptionSummary(t *testing.T) {
 		Verified: fleet.MDMPlatformsCounts{
 			MacOS:   1,
 			Windows: 7,
+			Linux:   1,
 		},
 		Verifying: fleet.MDMPlatformsCounts{
 			MacOS:   2,
@@ -889,10 +895,12 @@ func TestGetMDMDiskEncryptionSummary(t *testing.T) {
 		ActionRequired: fleet.MDMPlatformsCounts{
 			MacOS:   3,
 			Windows: 0,
+			Linux:   2,
 		},
 		Failed: fleet.MDMPlatformsCounts{
 			MacOS:   4,
 			Windows: 8,
+			Linux:   3,
 		},
 		Enforcing: fleet.MDMPlatformsCounts{
 			MacOS:   5,

--- a/server/service/mdm_test.go
+++ b/server/service/mdm_test.go
@@ -605,6 +605,11 @@ func TestMDMCommonAuthorization(t *testing.T) {
 	ds.GetMDMWindowsProfilesSummaryFunc = func(ctx context.Context, teamID *uint) (*fleet.MDMProfilesSummary, error) {
 		return &fleet.MDMProfilesSummary{}, nil
 	}
+
+	ds.GetLinuxDiskEncryptionSummaryFunc = func(ctx context.Context, teamID *uint) (fleet.MDMLinuxDiskEncryptionSummary, error) {
+		return fleet.MDMLinuxDiskEncryptionSummary{}, nil
+	}
+
 	ds.AreHostsConnectedToFleetMDMFunc = func(ctx context.Context, hosts []*fleet.Host) (map[string]bool, error) {
 		res := make(map[string]bool, len(hosts))
 		for _, h := range hosts {

--- a/server/test/new_objects.go
+++ b/server/test/new_objects.go
@@ -217,6 +217,12 @@ func WithPlatform(s string) NewHostOption {
 	}
 }
 
+func WithOSVersion(s string) NewHostOption {
+	return func(h *fleet.Host) {
+		h.OSVersion = s
+	}
+}
+
 func WithTeamID(teamID uint) NewHostOption {
 	return func(h *fleet.Host) {
 		h.TeamID = &teamID


### PR DESCRIPTION
#23582 

This change covers the disk encryption summary API.  Reporting Host Detail linux encryption state will be a separate PR.

- [ ] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/Committing-Changes.md#changes-files) for more information.
- [X] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [X] Added/updated tests
- [X] Manual QA for all new/changed functionality