### PR TITLE
Fleet UI: Fix bug hiding manage automations dropdown from maintainers

### DIFF
--- a/changes/23448-maintainer-policy-automations
+++ b/changes/23448-maintainer-policy-automations
@@ -1,0 +1,1 @@
+- Fleet UI bug fix: Allow maintainers to manage install software or run scripts on policy automations

--- a/frontend/interfaces/dropdownOption.ts
+++ b/frontend/interfaces/dropdownOption.ts
@@ -7,11 +7,13 @@ export default PropTypes.shape({
   value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 });
 
+export type TooltipContent = string | JSX.Element | undefined;
+
 export interface IDropdownOption {
   disabled?: boolean;
   label: string | JSX.Element;
   value: string | number;
   helpText?: ReactNode;
   premiumOnly?: boolean;
-  tooltipContent?: string | JSX.Element;
+  tooltipContent?: TooltipContent;
 }

--- a/frontend/pages/policies/ManagePoliciesPage/ManagePoliciesPage.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/ManagePoliciesPage.tsx
@@ -336,7 +336,8 @@ const ManagePolicyPage = ({
 
   const canAddOrDeletePolicy =
     isGlobalAdmin || isGlobalMaintainer || isTeamMaintainer || isTeamAdmin;
-  const canManageAutomations = isGlobalAdmin || isTeamAdmin;
+  const canManageAutomations =
+    isGlobalAdmin || isGlobalMaintainer || isTeamAdmin || isTeamMaintainer;
 
   const {
     data: config,
@@ -899,7 +900,9 @@ const ManagePolicyPage = ({
       tooltipContent: disabledRunScriptTooltipContent,
     };
 
-    if (!configPresent) {
+    // Maintainers do not have access to automate calendar events or other workflows
+    // Config must be present to update calendar events or other workflows
+    if (!configPresent || isGlobalMaintainer || isTeamMaintainer) {
       return [installSWOption, runScriptOption];
     }
 

--- a/frontend/pages/policies/ManagePoliciesPage/components/CalendarEventsModal/CalendarEventsModal.tests.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/components/CalendarEventsModal/CalendarEventsModal.tests.tsx
@@ -1,0 +1,91 @@
+import React from "react";
+
+import { noop } from "lodash";
+import { fireEvent, screen } from "@testing-library/react";
+import { createCustomRenderer } from "test/test-utils";
+import createMockPolicy from "__mocks__/policyMock";
+
+import CalendarEventsModal from "./CalendarEventsModal";
+
+const testGlobalPolicy = [
+  createMockPolicy({ team_id: null, name: "Inherited policy 1" }),
+  createMockPolicy({ id: 2, team_id: null, name: "Inherited policy 2" }),
+  createMockPolicy({ id: 3, team_id: null, name: "Inherited policy 3" }),
+];
+
+const testTeamPolicies = [
+  createMockPolicy({ id: 4, team_id: 2, name: "Team policy 1" }),
+  createMockPolicy({ id: 5, team_id: 2, name: "Team policy 2" }),
+];
+
+describe("CalendarEventsModal - component", () => {
+  it("renders components for admin", async () => {
+    const render = createCustomRenderer({
+      context: {
+        app: {
+          isGlobalAdmin: true,
+          isTeamAdmin: false,
+        },
+      },
+    });
+
+    const { user } = render(
+      <CalendarEventsModal
+        onExit={noop}
+        onSubmit={noop}
+        isUpdating={false}
+        configured
+        enabled
+        url="https://server.com/example"
+        policies={testGlobalPolicy}
+      />
+    );
+
+    expect(screen.queryByText(/Resolution webhook URL/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Save/i })).toBeInTheDocument();
+    await user.click(
+      screen.getByRole("button", { name: /Preview calendar event/i })
+    );
+    expect(
+      screen.getByText(
+        /reserved this time to make some changes to your work computer/i
+      )
+    ).toBeInTheDocument();
+  });
+
+  it("renders limited components for team maintainer", async () => {
+    const render = createCustomRenderer({
+      context: {
+        app: {
+          isTeamMaintainer: true,
+        },
+      },
+    });
+
+    const { user } = render(
+      <CalendarEventsModal
+        onExit={noop}
+        onSubmit={noop}
+        isUpdating={false}
+        configured
+        enabled
+        url="https://server.com/example"
+        policies={testGlobalPolicy}
+      />
+    );
+
+    expect(screen.queryByText(/enabled/i)).not.toBeInTheDocument(); // Admin only
+    expect(
+      screen.queryByText(/Resolution webhook URL/i)
+    ).not.toBeInTheDocument(); // Admin only
+    expect(screen.queryByRole("button", { name: /Save/i })).toBeInTheDocument();
+    await user.click(
+      screen.getByRole("button", { name: /Preview calendar event/i })
+    );
+    expect(
+      screen.getByText(
+        /reserved this time to make some changes to your work computer/i
+      )
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/pages/policies/ManagePoliciesPage/components/CalendarEventsModal/CalendarEventsModal.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/components/CalendarEventsModal/CalendarEventsModal.tsx
@@ -1,7 +1,8 @@
-import React, { useCallback, useState, useEffect } from "react";
+import React, { useCallback, useState, useEffect, useContext } from "react";
 
 import { IPolicyStats } from "interfaces/policy";
 
+import { AppContext } from "context/app";
 import { syntaxHighlight } from "utilities/helpers";
 import validURL from "components/forms/validators/valid_url";
 import Button from "components/buttons/Button";
@@ -52,6 +53,10 @@ const CalendarEventsModal = ({
   url,
   policies,
 }: ICalendarEventsModal) => {
+  const { isGlobalAdmin, isTeamAdmin } = useContext(AppContext);
+
+  const isAdmin = isGlobalAdmin || isTeamAdmin;
+
   const [formData, setFormData] = useState<ICalendarEventsFormData>({
     enabled,
     url,
@@ -259,14 +264,45 @@ const CalendarEventsModal = ({
     );
   };
 
-  const renderConfiguredModal = () => (
-    <div className={`${baseClass} form`}>
+  const renderAdminHeader = () => (
+    <div className="form-header">
+      <Slider
+        value={formData.enabled}
+        onChange={onFeatureEnabledChange}
+        inactiveText="Disabled"
+        activeText="Enabled"
+      />
+      <Button
+        type="button"
+        variant="text-link"
+        onClick={() => {
+          setSelectedPolicyToPreview(undefined);
+          togglePreviewCalendarEvent();
+        }}
+      >
+        Preview calendar event
+      </Button>
+    </div>
+  );
+
+  /** Maintainer does not have access to update calendar event
+  / configuration only to set the automated policies
+  / Modal not available for maintainers if calendar is disabled but
+  / disabled inputs here as fail safe and to match admin view.
+  */
+  const renderMaintainerHeader = () => (
+    <>
       <div className="form-header">
-        <Slider
-          value={formData.enabled}
-          onChange={onFeatureEnabledChange}
-          inactiveText="Disabled"
-          activeText="Enabled"
+        <RevealButton
+          isShowing={showExamplePayload}
+          className={`${baseClass}__show-example-payload-toggle`}
+          hideText="Hide example payload"
+          showText="Show example payload"
+          caretPosition="after"
+          onClick={() => {
+            setShowExamplePayload(!showExamplePayload);
+          }}
+          // disabled={!formData.enabled}
         />
         <Button
           type="button"
@@ -279,32 +315,43 @@ const CalendarEventsModal = ({
           Preview calendar event
         </Button>
       </div>
+      {showExamplePayload && renderExamplePayload()}
+    </>
+  );
+
+  const renderConfiguredModal = () => (
+    <div className={`${baseClass} form`}>
+      {isAdmin ? renderAdminHeader() : renderMaintainerHeader()}
       <div
         className={`form ${formData.enabled ? "" : "form-fields--disabled"}`}
       >
-        <InputField
-          placeholder="https://server.com/example"
-          label="Resolution webhook URL"
-          onChange={onUrlChange}
-          name="url"
-          value={formData.url}
-          error={formErrors.url}
-          tooltip="Provide a URL to deliver a webhook request to."
-          helpText="A request will be sent to this URL during the calendar event. Use it to trigger auto-remediation."
-          disabled={!formData.enabled}
-        />
-        <RevealButton
-          isShowing={showExamplePayload}
-          className={`${baseClass}__show-example-payload-toggle`}
-          hideText="Hide example payload"
-          showText="Show example payload"
-          caretPosition="after"
-          onClick={() => {
-            setShowExamplePayload(!showExamplePayload);
-          }}
-          disabled={!formData.enabled}
-        />
-        {showExamplePayload && renderExamplePayload()}
+        {isAdmin && (
+          <>
+            <InputField
+              placeholder="https://server.com/example"
+              label="Resolution webhook URL"
+              onChange={onUrlChange}
+              name="url"
+              value={formData.url}
+              error={formErrors.url}
+              tooltip="Provide a URL to deliver a webhook request to."
+              helpText="A request will be sent to this URL during the calendar event. Use it to trigger auto-remediation."
+              disabled={!formData.enabled}
+            />
+            <RevealButton
+              isShowing={showExamplePayload}
+              className={`${baseClass}__show-example-payload-toggle`}
+              hideText="Hide example payload"
+              showText="Show example payload"
+              caretPosition="after"
+              onClick={() => {
+                setShowExamplePayload(!showExamplePayload);
+              }}
+              disabled={!formData.enabled}
+            />
+            {showExamplePayload && renderExamplePayload()}
+          </>
+        )}
         {renderPolicies()}
       </div>
       <div className="modal-cta-wrap">


### PR DESCRIPTION
## Issue
Cerra #23448 

## Description
- Show manage automations dropdown to maintainers including options available for them only (run script, install software)

## Screenshot
Global maintainer looking at all teams:
<img width="1356" alt="Screenshot 2024-12-09 at 1 09 41 PM" src="https://github.com/user-attachments/assets/d6fd2254-1ea3-4935-bb43-15ea6c685942">
Global/team maintainer looking at team with disabled calendar events
<img width="579" alt="Screenshot 2024-12-09 at 12 55 13 PM" src="https://github.com/user-attachments/assets/53394607-fb1d-41ae-964e-3ca421ba08c3">
Global/team maintainer viewing calendar events modal
<img width="1236" alt="Screenshot 2024-12-09 at 12 47 18 PM" src="https://github.com/user-attachments/assets/37cc31b4-8992-4b2b-909f-513d5f160751">


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
- [x] Added/updated tests
- [x] Manual QA for all new/changed functionality

