### PR TITLE
Improved label(s) validation when running queries

### DIFF
--- a/changes/23834-improve-label-flag-validation
+++ b/changes/23834-improve-label-flag-validation
@@ -1,1 +1,1 @@
-* Improved fleetctl query command flag validation. An explicit error message is returned if a label passed via the --label flag is not found.
+* Improved label validation when running queries. When passing label(s) that are not found, previously, the labels were ignored, now an error will be raised indicating which labels were not found. This change will affect the api and `fleetctl query` command.

--- a/changes/23834-improve-label-flag-validation
+++ b/changes/23834-improve-label-flag-validation
@@ -1,1 +1,1 @@
-* Improved label validation when running queries. When passing label(s) that are not found, previously, the labels were ignored, now an error will be raised indicating which labels were not found. This change will affect the api and `fleetctl query` command.
+* Improved label validation when running live queries. Previously, when passing label(s) that do not exist, the labels were ignored. Now, an error is returned indicating which labels were not found. This change affects both the API and `fleetctl query` command.

--- a/changes/23834-improve-label-flag-validation
+++ b/changes/23834-improve-label-flag-validation
@@ -1,0 +1,1 @@
+* Improved fleetctl query command flag validation. An explicit error message is returned if a label passed via the --label flag is not found.

--- a/cmd/fleetctl/query.go
+++ b/cmd/fleetctl/query.go
@@ -140,9 +140,10 @@ func queryCommand() *cli.Command {
 					return errors.New(fleet.NoHostsTargetedErrMsg)
 				}
 				if strings.Contains(err.Error(), fleet.InvalidLabelSpecifiedErrMsg) {
-					regex := regexp.MustCompile(`(\[.*?\])`)
+					pattern := fmt.Sprintf("(%s.*)$", regexp.QuoteMeta(fleet.InvalidLabelSpecifiedErrMsg))
+					regex := regexp.MustCompile(pattern)
 					match := regex.FindString(err.Error())
-					return errors.New(fmt.Sprintf("%s %s", match, fleet.InvalidLabelSpecifiedErrMsg))
+					return errors.New(match)
 				}
 				return err
 			}

--- a/cmd/fleetctl/query.go
+++ b/cmd/fleetctl/query.go
@@ -123,6 +123,47 @@ func queryCommand() *cli.Command {
 				return errors.New("Query must be specified with --query or --query-name")
 			}
 
+			labels := strings.Split(flLabels, ",")
+			if len(flLabels) > 0 {
+				labelSpecs, err := client.GetLabels()
+				if err != nil {
+					return fmt.Errorf("could not list labels: %w", err)
+				}
+
+				labelsFound := make(map[string]bool)
+				// create a map of labels to check
+				for _, label := range labels {
+					labelsFound[strings.TrimSpace(label)] = false
+				}
+				// iterate through labels available from the platform and mark the ones that are found
+				for _, label := range labelSpecs {
+					if _, ok := labelsFound[label.Name]; ok {
+						labelsFound[label.Name] = true
+					}
+				}
+				// generate list of labels that were not found
+				labelsNotFound := make([]string, 0, len(labels))
+				for label, found := range labelsFound {
+					if !found {
+						labelsNotFound = append(labelsNotFound, label)
+					}
+				}
+
+				if len(labelsNotFound) > 0 {
+					pluralizedLabel := "label"
+					if len(labelsNotFound) > 1 {
+						pluralizedLabel += string("s were")
+					} else {
+						pluralizedLabel += string(" was")
+					}
+
+					return fmt.Errorf("The %s not found: %s. Please remove from --labels to continue.",
+						pluralizedLabel,
+						strings.Join(labelsNotFound, ", "),
+					)
+				}
+			}
+
 			var output outputWriter
 			if flPretty {
 				output = newPrettyWriter()
@@ -131,7 +172,6 @@ func queryCommand() *cli.Command {
 			}
 
 			hostIdentifiers := strings.Split(flHosts, ",")
-			labels := strings.Split(flLabels, ",")
 
 			res, err := client.LiveQuery(flQuery, queryID, labels, hostIdentifiers)
 			if err != nil {

--- a/cmd/fleetctl/query_test.go
+++ b/cmd/fleetctl/query_test.go
@@ -310,5 +310,5 @@ func TestAdHocLiveQuery(t *testing.T) {
 
 	expected := `{"host":"somehostname","rows":[{"bing":"fds","host_display_name":"somehostname","host_hostname":"somehostname"}]}
 `
-	assert.Equal(t, expected, runAppForTest(t, []string{"query", "--labels", "", "--hosts", "1234", "--query", "select 42, * from time"}))
+	assert.Equal(t, expected, runAppForTest(t, []string{"query", "--hosts", "1234", "--query", "select 42, * from time"}))
 }

--- a/cmd/fleetctl/query_test.go
+++ b/cmd/fleetctl/query_test.go
@@ -302,13 +302,11 @@ func TestAdHocLiveQuery(t *testing.T) {
 
 	// test label not found
 	_, err = runAppNoChecks([]string{"query", "--hosts", "1234", "--labels", "iamnotalabel", "--query", "select 42, * from time"})
-	assert.Error(t, err)
-	assert.Equal(t, "[iamnotalabel] are not valid label names, remove to continue.", err.Error())
+	assert.ErrorContains(t, err, "Invalid label name(s): iamnotalabel.")
 
 	// test if some labels were not found
 	_, err = runAppNoChecks([]string{"query", "--labels", "label1, mac, windows", "--hosts", "1234", "--query", "select 42, * from time"})
-	assert.Error(t, err)
-	assert.Equal(t, "[mac, windows] are not valid label names, remove to continue.", err.Error())
+	assert.ErrorContains(t, err, "Invalid label name(s): mac, windows.")
 
 	expected := `{"host":"somehostname","rows":[{"bing":"fds","host_display_name":"somehostname","host_hostname":"somehostname"}]}
 `

--- a/server/fleet/errors.go
+++ b/server/fleet/errors.go
@@ -593,6 +593,8 @@ const (
 	// End user authentication
 	EndUserAuthDEPWebURLConfiguredErrMsg = `End user authentication can't be configured when the configured automatic enrollment (DEP) profile specifies a configuration_web_url.` // #nosec G101
 
+	// Labels
+	InvalidLabelSpecifiedErrMsg = "are not valid label names, remove to continue."
 )
 
 // ConflictError is used to indicate a conflict, such as a UUID conflict in the DB.

--- a/server/fleet/errors.go
+++ b/server/fleet/errors.go
@@ -594,7 +594,7 @@ const (
 	EndUserAuthDEPWebURLConfiguredErrMsg = `End user authentication can't be configured when the configured automatic enrollment (DEP) profile specifies a configuration_web_url.` // #nosec G101
 
 	// Labels
-	InvalidLabelSpecifiedErrMsg = "are not valid label names, remove to continue."
+	InvalidLabelSpecifiedErrMsg = "Invalid label name(s):"
 )
 
 // ConflictError is used to indicate a conflict, such as a UUID conflict in the DB.

--- a/server/fleet/labels.go
+++ b/server/fleet/labels.go
@@ -2,6 +2,7 @@ package fleet
 
 import (
 	"fmt"
+	"strings"
 	"time"
 )
 
@@ -178,4 +179,18 @@ func ReservedLabelNames() map[string]struct{} {
 		BuiltinLabelIPadOS:          {},
 		BuiltinLabelFedoraLinux:     {},
 	}
+}
+
+// DetectMissingLabels returns a list of labels in the labels slice that could not be found in the labelMap.
+func DetectMissingLabels(labelMap map[string]uint, labels []string) []string {
+	missingLabels := make([]string, 0, len(labels))
+
+	for _, rawLabel := range labels {
+		label := strings.TrimSpace(rawLabel)
+		if _, ok := labelMap[label]; len(label) > 0 && !ok {
+			missingLabels = append(missingLabels, label)
+		}
+	}
+
+	return missingLabels
 }

--- a/server/fleet/labels.go
+++ b/server/fleet/labels.go
@@ -181,13 +181,13 @@ func ReservedLabelNames() map[string]struct{} {
 	}
 }
 
-// DetectMissingLabels returns a list of labels in the labels slice that could not be found in the labelMap.
-func DetectMissingLabels(labelMap map[string]uint, labels []string) []string {
-	missingLabels := make([]string, 0, len(labels))
+// DetectMissingLabels returns a list of labels present in the unvalidatedLabels list that could not be found in the validLabelMap.
+func DetectMissingLabels(validLabelMap map[string]uint, unvalidatedLabels []string) []string {
+	missingLabels := make([]string, 0, len(unvalidatedLabels))
 
-	for _, rawLabel := range labels {
+	for _, rawLabel := range unvalidatedLabels {
 		label := strings.TrimSpace(rawLabel)
-		if _, ok := labelMap[label]; len(label) > 0 && !ok {
+		if _, ok := validLabelMap[label]; len(label) > 0 && !ok {
 			missingLabels = append(missingLabels, label)
 		}
 	}

--- a/server/fleet/labels_test.go
+++ b/server/fleet/labels_test.go
@@ -1,0 +1,52 @@
+package fleet
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestDetectMissingLabels(t *testing.T) {
+	labelMap := map[string]uint{"label1": 1, "label2": 2}
+
+	testCases := []struct {
+		name     string
+		labels   []string
+		expected []string
+	}{
+		{
+			name:     "no labels",
+			labels:   []string{},
+			expected: []string{},
+		},
+		{
+			name:     "empty label",
+			labels:   []string{""},
+			expected: []string{},
+		},
+		{
+			name:     "one missing label",
+			labels:   []string{"iamnotalabel"},
+			expected: []string{"iamnotalabel"},
+		},
+		{
+			name:     "missing multiple labels",
+			labels:   []string{"mac", "windows"},
+			expected: []string{"mac", "windows"},
+		},
+		{
+			name:     "some missing labels and some valid labels",
+			labels:   []string{"label1", "mac", "label2", "windows"},
+			expected: []string{"mac", "windows"},
+		},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			missing := DetectMissingLabels(labelMap, tt.labels)
+			if !reflect.DeepEqual(tt.expected, missing) {
+				t.Errorf("Expected [%s], but got [%s]", strings.Join(tt.expected, ", "), strings.Join(missing, ", "))
+			}
+		})
+	}
+}

--- a/server/fleet/labels_test.go
+++ b/server/fleet/labels_test.go
@@ -1,9 +1,10 @@
 package fleet
 
 import (
-	"reflect"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestDetectMissingLabels(t *testing.T) {
@@ -44,7 +45,7 @@ func TestDetectMissingLabels(t *testing.T) {
 	for _, tt := range testCases {
 		t.Run(tt.name, func(t *testing.T) {
 			missing := DetectMissingLabels(labelMap, tt.labels)
-			if !reflect.DeepEqual(tt.expected, missing) {
+			if !assert.Equal(t, tt.expected, missing) {
 				t.Errorf("Expected [%s], but got [%s]", strings.Join(tt.expected, ", "), strings.Join(missing, ", "))
 			}
 		})

--- a/server/service/campaigns.go
+++ b/server/service/campaigns.go
@@ -211,6 +211,16 @@ func (svc *Service) NewDistributedQueryCampaignByIdentifiers(ctx context.Context
 		return nil, ctxerr.Wrap(ctx, err, "finding label IDs")
 	}
 
+	// DetectMissingLabels will return the list of labels that are not found in the database
+	// These labels are considered invalid
+	invalidLabels := fleet.DetectMissingLabels(labelMap, labels)
+	if len(invalidLabels) > 0 {
+		setAuthCheckedOnPreAuthErr(ctx)
+		return nil, ctxerr.Wrap(ctx, &fleet.BadRequestError{
+			Message: fmt.Sprintf("[%s] %s", strings.Join(invalidLabels, ", "), fleet.InvalidLabelSpecifiedErrMsg),
+		}, "invalid labels")
+	}
+
 	var labelIDs []uint
 	for _, labelID := range labelMap {
 		labelIDs = append(labelIDs, labelID)

--- a/server/service/campaigns.go
+++ b/server/service/campaigns.go
@@ -217,7 +217,7 @@ func (svc *Service) NewDistributedQueryCampaignByIdentifiers(ctx context.Context
 	if len(invalidLabels) > 0 {
 		setAuthCheckedOnPreAuthErr(ctx)
 		return nil, ctxerr.Wrap(ctx, &fleet.BadRequestError{
-			Message: fmt.Sprintf("[%s] %s", strings.Join(invalidLabels, ", "), fleet.InvalidLabelSpecifiedErrMsg),
+			Message: fmt.Sprintf("%s %s.", fleet.InvalidLabelSpecifiedErrMsg, strings.Join(invalidLabels, ", ")),
 		}, "invalid labels")
 	}
 

--- a/server/service/campaigns.go
+++ b/server/service/campaigns.go
@@ -206,6 +206,9 @@ func (svc *Service) NewDistributedQueryCampaignByIdentifiers(ctx context.Context
 		return nil, ctxerr.Wrap(ctx, err, "finding host IDs")
 	}
 
+	if err := svc.authz.Authorize(ctx, &fleet.Label{}, fleet.ActionRead); err != nil {
+		return nil, err
+	}
 	labelMap, err := svc.ds.LabelIDsByName(ctx, labels)
 	if err != nil {
 		return nil, ctxerr.Wrap(ctx, err, "finding label IDs")
@@ -215,7 +218,6 @@ func (svc *Service) NewDistributedQueryCampaignByIdentifiers(ctx context.Context
 	// These labels are considered invalid
 	invalidLabels := fleet.DetectMissingLabels(labelMap, labels)
 	if len(invalidLabels) > 0 {
-		setAuthCheckedOnPreAuthErr(ctx)
 		return nil, ctxerr.Wrap(ctx, &fleet.BadRequestError{
 			Message: fmt.Sprintf("%s %s.", fleet.InvalidLabelSpecifiedErrMsg, strings.Join(invalidLabels, ", ")),
 		}, "invalid labels")

--- a/server/service/campaigns_test.go
+++ b/server/service/campaigns_test.go
@@ -294,7 +294,7 @@ func TestLiveQueryLabelValidation(t *testing.T) {
 		{
 			name:          "invalid label",
 			labels:        []string{"iamnotalabel"},
-			expectedError: "[iamnotalabel] are not valid label names, remove to continue.",
+			expectedError: "Invalid label name(s): iamnotalabel.",
 		},
 		{
 			name:          "valid label",

--- a/server/service/campaigns_test.go
+++ b/server/service/campaigns_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/fleetdm/fleet/v4/server/mock"
 	"github.com/fleetdm/fleet/v4/server/ptr"
 	"github.com/fleetdm/fleet/v4/server/pubsub"
+	"github.com/stretchr/testify/require"
 )
 
 type nopLiveQuery struct{}
@@ -233,6 +234,85 @@ func TestLiveQueryAuth(t *testing.T) {
 
 				_, err = svc.NewDistributedQueryCampaignByIdentifiers(ctx, query2ObsCannotRun.Query, ptr.Uint(query2ObsCannotRun.ID), nil, nil)
 				checkAuthErr(t, tt.shouldFailRunObsCannot, err)
+			}
+		})
+	}
+}
+
+func TestLiveQueryLabelValidation(t *testing.T) {
+	ds := new(mock.Store)
+	qr := pubsub.NewInmemQueryResults()
+	svc, ctx := newTestService(t, ds, qr, nopLiveQuery{})
+
+	user := &fleet.User{GlobalRole: ptr.String(fleet.RoleAdmin)}
+	query := &fleet.Query{
+		ID:             1,
+		Name:           "q1",
+		Query:          "SELECT 1",
+		ObserverCanRun: true,
+	}
+	ds.NewQueryFunc = func(ctx context.Context, query *fleet.Query, opts ...fleet.OptionalArg) (*fleet.Query, error) {
+		query.ID = 123
+		return query, nil
+	}
+	ds.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {
+		return &fleet.AppConfig{ServerSettings: fleet.ServerSettings{LiveQueryDisabled: false}}, nil
+	}
+	ds.NewDistributedQueryCampaignFunc = func(ctx context.Context, camp *fleet.DistributedQueryCampaign) (*fleet.DistributedQueryCampaign, error) {
+		return camp, nil
+	}
+	ds.NewDistributedQueryCampaignTargetFunc = func(ctx context.Context, target *fleet.DistributedQueryCampaignTarget) (*fleet.DistributedQueryCampaignTarget, error) {
+		return target, nil
+	}
+	ds.HostIDsInTargetsFunc = func(ctx context.Context, filters fleet.TeamFilter, targets fleet.HostTargets) ([]uint, error) {
+		return []uint{1}, nil
+	}
+	ds.HostIDsByIdentifierFunc = func(ctx context.Context, filter fleet.TeamFilter, identifiers []string) ([]uint, error) {
+		return nil, nil
+	}
+	ds.CountHostsInTargetsFunc = func(ctx context.Context, filters fleet.TeamFilter, targets fleet.HostTargets, now time.Time) (fleet.TargetMetrics, error) {
+		return fleet.TargetMetrics{}, nil
+	}
+	ds.QueryFunc = func(ctx context.Context, id uint) (*fleet.Query, error) {
+		return query, nil
+	}
+
+	ds.LabelIDsByNameFunc = func(ctx context.Context, names []string) (map[string]uint, error) {
+		return map[string]uint{"label1": uint(1)}, nil
+	}
+
+	testCases := []struct {
+		name          string
+		labels        []string
+		expectedError string
+	}{
+		{
+			name:          "no labels",
+			labels:        []string{},
+			expectedError: "",
+		},
+		{
+			name:          "invalid label",
+			labels:        []string{"iamnotalabel"},
+			expectedError: "[iamnotalabel] are not valid label names, remove to continue.",
+		},
+		{
+			name:          "valid label",
+			labels:        []string{"label1"},
+			expectedError: "",
+		},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := viewer.NewContext(ctx, viewer.Viewer{User: user})
+			_, err := svc.NewDistributedQueryCampaignByIdentifiers(ctx, query.Query, nil, nil, tt.labels)
+
+			if tt.expectedError == "" {
+				require.Nil(t, err)
+			} else {
+				require.NotNil(t, err)
+				require.Contains(t, err.Error(), tt.expectedError)
 			}
 		})
 	}

--- a/server/service/client_labels.go
+++ b/server/service/client_labels.go
@@ -23,7 +23,7 @@ func (c *Client) GetLabel(name string) (*fleet.LabelSpec, error) {
 	return responseBody.Spec, err
 }
 
-// GetLabels retrieves the list of all Labels.
+// GetLabels retrieves the list of all LabelSpecs.
 func (c *Client) GetLabels() ([]*fleet.LabelSpec, error) {
 	verb, path := "GET", "/api/latest/fleet/spec/labels"
 	var responseBody getLabelSpecsResponse

--- a/server/service/integration_live_queries_test.go
+++ b/server/service/integration_live_queries_test.go
@@ -1021,6 +1021,20 @@ func (s *liveQueriesTestSuite) TestCreateDistributedQueryCampaign() {
 		},
 	}
 	s.DoJSON("POST", "/api/latest/fleet/queries/run_by_identifiers", req2, http.StatusOK, &createResp)
+
+	// wait to prevent duplicate name for new query
+	time.Sleep(200 * time.Millisecond)
+
+	// create with invalid label
+	req3 := createDistributedQueryCampaignByIdentifierRequest{
+		QuerySQL: "SELECT 3",
+		Selected: distributedQueryCampaignTargetsByIdentifiers{
+			Hosts:  []string{h1.Hostname},
+			Labels: []string{"label1"},
+		},
+	}
+
+	s.DoJSON("POST", "/api/latest/fleet/queries/run_by_identifiers", req3, http.StatusBadRequest, &createResp)
 }
 
 func (s *liveQueriesTestSuite) TestOsqueryDistributedRead() {

--- a/server/service/integration_live_queries_test.go
+++ b/server/service/integration_live_queries_test.go
@@ -1022,12 +1022,9 @@ func (s *liveQueriesTestSuite) TestCreateDistributedQueryCampaign() {
 	}
 	s.DoJSON("POST", "/api/latest/fleet/queries/run_by_identifiers", req2, http.StatusOK, &createResp)
 
-	// wait to prevent duplicate name for new query
-	time.Sleep(200 * time.Millisecond)
-
 	// create with invalid label
 	req3 := createDistributedQueryCampaignByIdentifierRequest{
-		QuerySQL: "SELECT 3",
+		QuerySQL: "SELECT 4",
 		Selected: distributedQueryCampaignTargetsByIdentifiers{
 			Hosts:  []string{h1.Hostname},
 			Labels: []string{"label1"},


### PR DESCRIPTION
Previously when passing labels to the query run endpoints that do not exist, the labels would simply be ignored. Now the endpoints will return an error indicating which labels are invalid. This change also affects the `fleetctl query` command `--labels` flag. 

https://github.com/fleetdm/fleet/issues/23015

To test via api:
```
curl -X POST 'http://localhost:8080/api/latest/fleet/queries/run_by_names' \
  -H 'accept: application/json, text/plain, */*' \
  -H 'Authorization: Bearer <put token here>' \
  -H 'Content-Type: application/json' \
  -d '
{
  "query": "SELECT instance_id FROM system_info",
  "selected": {
    "labels": ["boop"]
  }
}'
```
To test via fleetctl:
```
fleetctl query --labels 'boop' --query 'SELECT * FROM uptime;' --exit
```

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/Committing-Changes.md#changes-files) for more information.
- [x] Added/updated tests
- [x] Manual QA for all new/changed functionality
