### PR TITLE
Fleet UI: Hides Never timestamp for empty OS page, clean styling

### DIFF
--- a/frontend/pages/SoftwarePage/SoftwareOS/SoftwareOSTable/SoftwareOSTable.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareOS/SoftwareOSTable/SoftwareOSTable.tsx
@@ -173,13 +173,19 @@ const SoftwareOSTable = ({
     router.push(path);
   };
 
+  // Determines if a user should be able to filter or search in the table
+  const hasData = data?.os_versions && data?.os_versions.length > 0;
+  const hasPlatformFilter = platform !== "all";
+
+  const showFilterHeaders = isSoftwareEnabled && (hasData || hasPlatformFilter);
+
   const renderSoftwareCount = () => {
     if (!data) return null;
 
     return (
       <>
         <TableCount name="items" count={data?.count} />
-        {data?.os_versions && data?.counts_updated_at && (
+        {showFilterHeaders && data?.counts_updated_at && (
           <LastUpdatedText
             lastUpdatedAt={data.counts_updated_at}
             customTooltipText={
@@ -257,12 +263,10 @@ const SoftwareOSTable = ({
         pageSize={perPage}
         showMarkAllPages={false}
         isAllPagesSelected={false}
-        customControl={renderPlatformDropdown}
-        customFiltersButton={() => <></>}
+        customControl={showFilterHeaders ? renderPlatformDropdown : undefined}
         disableNextPage={!data?.meta.has_next_results}
         searchable={false}
         onQueryChange={onQueryChange}
-        stackControls
         renderCount={renderSoftwareCount}
         renderTableHelpText={renderTableHelpText}
         disableMultiRowSelect

--- a/frontend/pages/SoftwarePage/SoftwareOS/SoftwareOSTable/SoftwareOSTable.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareOS/SoftwareOSTable/SoftwareOSTable.tsx
@@ -173,7 +173,7 @@ const SoftwareOSTable = ({
     router.push(path);
   };
 
-  // Determines if a user should be able to filter or search in the table
+  // Determines if a user should be able to filter the table
   const hasData = data?.os_versions && data?.os_versions.length > 0;
   const hasPlatformFilter = platform !== "all";
 


### PR DESCRIPTION
## Issue
Cerra #23023 , #23776

## Description
- Consistency across software pages hides timestamp and platform filter dropdown for empty OS page
- Fix styling bug of table filter not being aligned right

## Screenshots of fixes
<img width="906" alt="Screenshot 2024-11-15 at 9 35 33 AM" src="https://github.com/user-attachments/assets/39ac2011-8ef1-4ebb-819e-1c3ac671799e">
<img width="907" alt="Screenshot 2024-11-15 at 9 35 16 AM" src="https://github.com/user-attachments/assets/23dd021f-d07d-4fbd-9b83-df73e80150ba">


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Manual QA for all new/changed functionality
