### PR TITLE
Download ABM Certificate with correct extension

### DIFF
--- a/changes/23021-abm-cert-pem
+++ b/changes/23021-abm-cert-pem
@@ -1,0 +1,1 @@
+- Download ABM public key as PEM format instead of CRT

--- a/frontend/pages/admin/components/DownloadFileButtons/DownloadABMKey.tsx
+++ b/frontend/pages/admin/components/DownloadFileButtons/DownloadABMKey.tsx
@@ -21,7 +21,7 @@ interface IDownloadABMKeyProps {
 }
 
 const downloadKeyFile = (data: { public_key: string }) => {
-  downloadBase64ToFile(data.public_key, "fleet-mdm-apple-bm-public-key.crt");
+  downloadBase64ToFile(data.public_key, "fleet-mdm-apple-bm-public-key.pem");
 };
 
 // TODO: why can't we use Content-Dispostion for these? We're only getting one file back now.


### PR DESCRIPTION
#23021

Excellent news, it's already in PEM format and we just had to change the extension

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/Committing-Changes.md#changes-files) for more information.
- [x] Manual QA for all new/changed functionality