### PR TITLE
Update cloudflare warp uninstall script again

### DIFF
--- a/server/mdm/maintainedapps/apps.json
+++ b/server/mdm/maintainedapps/apps.json
@@ -30,7 +30,8 @@
 	{
 		"identifier": "cloudflare-warp",
 		"bundle_identifier": "com.cloudflare.1dot1dot1dot1.macos",
-		"installer_format": "pkg"
+		"installer_format": "pkg",
+		"post_uninstall_scripts": ["/Applications/Cloudflare\\ WARP.app/Contents/Resources/uninstall.sh"]
 	},
 	{
 		"identifier": "docker",

--- a/server/mdm/maintainedapps/testdata/scripts/cloudflare-warp_uninstall.golden.sh
+++ b/server/mdm/maintainedapps/testdata/scripts/cloudflare-warp_uninstall.golden.sh
@@ -113,6 +113,7 @@ remove_launchctl_service 'com.cloudflare.1dot1dot1dot1.macos.loginlauncherapp'
 remove_launchctl_service 'com.cloudflare.1dot1dot1dot1.macos.warp.daemon'
 quit_application 'com.cloudflare.1dot1dot1dot1.macos'
 sudo pkgutil --forget 'com.cloudflare.1dot1dot1dot1.macos'
+/Applications/Cloudflare\ WARP.app/Contents/Resources/uninstall.sh
 trash $LOGGED_IN_USER '~/Library/Application Scripts/com.cloudflare.1dot1dot1dot1.macos.loginlauncherapp'
 trash $LOGGED_IN_USER '~/Library/Application Support/com.cloudflare.1dot1dot1dot1.macos'
 trash $LOGGED_IN_USER '~/Library/Caches/com.cloudflare.1dot1dot1dot1.macos'


### PR DESCRIPTION
#22773

Missed calling this shell script mentioned on the cloudflare website https://developers.cloudflare.com/cloudflare-one/connections/connect-devices/warp/remove-warp/

- [x] Manual QA for all new/changed functionality
