### PR TITLE
List paths used by Fleet desktop

### DIFF
--- a/docs/Contributing/FAQ.md
+++ b/docs/Contributing/FAQ.md
@@ -102,4 +102,6 @@ Hosts running Fleet Desktop will need access to these API endpoints:
 * `/api/latest/fleet/device/.+/desktop`
 * `/api/latest/fleet/device/.+/ping`
 
+> Full list [here](https://github.com/fleetdm/fleet/blob/c080a3b0e1eed2184b4b7bb77a6abd8c2c39b9f4/server/service/handler.go#L791-L839)
+
 <meta name="description" value="Find commonly asked questions and answers about contributing to Fleet as part of our community.">

--- a/docs/Contributing/FAQ.md
+++ b/docs/Contributing/FAQ.md
@@ -97,7 +97,7 @@ If you also have Fleetd running on hosts, it will need access to these API endpo
 * `/api/fleet/orbit/device_mapping`
 * `/api/osquery/log`
 
-If you also have Fleet Desktop running on hosts, it will need access to these API endpoints:
+Hosts running Fleet Desktop will need access to these API endpoints:
 
 * `/api/latest/fleet/device/.+/desktop`
 * `/api/latest/fleet/device/.+/ping`

--- a/docs/Contributing/FAQ.md
+++ b/docs/Contributing/FAQ.md
@@ -97,4 +97,9 @@ If you also have Fleetd running on hosts, it will need access to these API endpo
 * `/api/fleet/orbit/device_mapping`
 * `/api/osquery/log`
 
+If you also have Fleet Desktop running on hosts, it will need access to these API endpoints:
+
+* `/api/latest/fleet/device/.+/desktop`
+* `/api/latest/fleet/device/.+/ping`
+
 <meta name="description" value="Find commonly asked questions and answers about contributing to Fleet as part of our community.">


### PR DESCRIPTION
We don't expose fleet publicly and we had to open these paths to make Fleet Desktop work.

# Checklist for submitter

- [ ] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/Committing-Changes.md#changes-files) for more information.
- [ ] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [ ] Added support on fleet's osquery simulator `cmd/osquery-perf` for new osquery data ingestion features.
- [ ] Added/updated tests
- [ ] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes
- [ ] If database migrations are included, checked table schema to confirm autoupdate
- For database migrations:
  - [ ] Checked schema for all modified table for columns that will auto-update timestamps during migration.
  - [ ] Confirmed that updating the timestamps is acceptable, and will not cause unwanted side effects.
  - [ ] Ensured the correct collation is explicitly set for character columns (`COLLATE utf8mb4_unicode_ci`).
- [ ] Manual QA for all new/changed functionality
- For Orbit and Fleet Desktop changes:
   - [ ] Orbit runs on macOS, Linux and Windows. Check if the orbit feature/bugfix should only apply to one platform (`runtime.GOOS`).
   - [ ] Manual QA must be performed in the three main OSs, macOS, Windows and Linux.
   - [ ] Auto-update manual QA, from released version of component to new version (see [tools/tuf/test](../tools/tuf/test/README.md)).
