### PR TITLE
For R.C. - Fleet UI: Hides Never timestamp for empty OS page, clean styling

### DIFF
--- a/frontend/pages/SoftwarePage/SoftwareOS/SoftwareOSTable/SoftwareOSTable.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareOS/SoftwareOSTable/SoftwareOSTable.tsx
@@ -173,13 +173,19 @@ const SoftwareOSTable = ({
     router.push(path);
   };
 
+  // Determines if a user should be able to filter the table
+  const hasData = data?.os_versions && data?.os_versions.length > 0;
+  const hasPlatformFilter = platform !== "all";
+
+  const showFilterHeaders = isSoftwareEnabled && (hasData || hasPlatformFilter);
+
   const renderSoftwareCount = () => {
     if (!data) return null;
 
     return (
       <>
         <TableCount name="items" count={data?.count} />
-        {data?.os_versions && data?.counts_updated_at && (
+        {showFilterHeaders && data?.counts_updated_at && (
           <LastUpdatedText
             lastUpdatedAt={data.counts_updated_at}
             customTooltipText={
@@ -257,12 +263,10 @@ const SoftwareOSTable = ({
         pageSize={perPage}
         showMarkAllPages={false}
         isAllPagesSelected={false}
-        customControl={renderPlatformDropdown}
-        customFiltersButton={() => <></>}
+        customControl={showFilterHeaders ? renderPlatformDropdown : undefined}
         disableNextPage={!data?.meta.has_next_results}
         searchable={false}
         onQueryChange={onQueryChange}
-        stackControls
         renderCount={renderSoftwareCount}
         renderTableHelpText={renderTableHelpText}
         disableMultiRowSelect


### PR DESCRIPTION
> [!NOTE]
> This PR is already merged in `main`, see https://github.com/fleetdm/fleet/pull/23844  This is against the release branch so it can be included in 4.60.0 


```
 1029  git fetch fleetdm
 1030  git checkout fleetdm/rc-minor-fleet-v4.60.0
 1031  git log fleetdm
 1032  git cherry-pick 706a42032a346c737eb0af6bec001c8c4bf94675
 1033  git checkout -b 23023-software-timestamp
 1034  git checkout -b 23023-software-timestamp-rc
 1035  git push -u fleetdm 23023-software-timestamp-rc
```

Cherry picked fix for #23023 , #23776 - cannot connect on zenhub since once a PR has 2 issues, it won't let another PR connect to those issues