### PR TITLE
Fleet UI: Fix unreleased bug of team dropdown width being static 80px

### DIFF
--- a/frontend/components/TeamsDropdown/TeamsDropdown.tsx
+++ b/frontend/components/TeamsDropdown/TeamsDropdown.tsx
@@ -113,10 +113,6 @@ const TeamsDropdown = ({
   };
 
   const customStyles: StylesConfig<INumberDropdownOption, false> = {
-    container: (provided) => ({
-      ...provided,
-      width: "80px",
-    }),
     control: (provided, state) => ({
       ...provided,
       display: "flex",


### PR DESCRIPTION
## Issue
Cerra #23922 

## Description
- Fix unreleased bug of fix width of 80px for all team dropdowns, even if there is a host count next to it which makes the team name overlap the host count  (unreleased-bug)
- Filed a release bug for long team names #23924 (released bug) and can attach a fix here or wait until next sprint based on product decision

## Screenshot of fix
<img width="616" alt="Screenshot 2024-11-18 at 4 21 06 PM" src="https://github.com/user-attachments/assets/650a76cb-fcee-4a5e-b102-4cde829f7b2e">


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->


- [x] Manual QA for all new/changed functionality

