### PR TITLE
Remove docs for #23241 (Include host data in lock/wipe responses)

### DIFF
--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -4585,14 +4585,8 @@ To lock a macOS host, the host must have MDM turned on. To lock a Windows or Lin
 
 ##### Default response
 
-`Status: 200`
+`Status: 204`
 
-```json
-{
-  "device_status": "unlocked",
-  "pending_action": "lock"
-}
-```
 
 #### Example
 
@@ -4604,14 +4598,9 @@ To lock a macOS host, the host must have MDM turned on. To lock a Windows or Lin
 
 ```json
 {
-  "unlock_pin": "123456",
-  "device_status": "unlocked",
-  "pending_action": "lock",
+  "unlock_pin": "123456"
 }
 ```
-
-
-> To verify the host successfully locked, you can use the [Get host](https://fleetdm.com/docs/rest-api/rest-api#get-host) endpoint to retrieve the host's `mdm.device_status`.
 
 ### Unlock host
 
@@ -4635,14 +4624,8 @@ To unlock a Windows or Linux host, the host must have [scripts enabled](https://
 
 ##### Default response (Windows or Linux hosts)
 
-`Status: 200`
+`Status: 204`
 
-```json
-{
-  "device_status": "locked",
-  "pending_action": "unlock"
-}
-```
 
 ##### Default response (macOS hosts)
 
@@ -4650,14 +4633,9 @@ To unlock a Windows or Linux host, the host must have [scripts enabled](https://
 
 ```json
 {
-  "host_id": 8,
-  "unlock_pin": "123456",
-  "device_status": "locked",
-  "pending_action": ""
+  "host_id": 8
 }
 ```
-
-> To verify the host successfully unlocked, you can use the [Get host](https://fleetdm.com/docs/rest-api/rest-api#get-host) endpoint to retrieve the host's `mdm.device_status`.
 
 ### Wipe host
 
@@ -4679,16 +4657,7 @@ To wipe a macOS, iOS, iPadOS, or Windows host, the host must have MDM turned on.
 
 ##### Default response
 
-`Status: 200`
-
-```json
-{
-  "device_status": "unlocked",
-  "pending_action": "wipe"
-}
-```
-
-> To verify the host was successfully wiped, you can use the [Get host](https://fleetdm.com/docs/rest-api/rest-api#get-host) endpoint to retrieve the host's `mdm.device_status`.
+`Status: 204`
 
 
 ### Get host's past activity


### PR DESCRIPTION
#23241 is no longer planned for the v4.61.0 release (didn't make it into the sprint)