### PR TITLE
Add nftables table

### DIFF
--- a/orbit/changes/nftables-table
+++ b/orbit/changes/nftables-table
@@ -1,0 +1,1 @@
+- Add `nftables` table to show configuration for Linux `nftables` network filters.

--- a/orbit/pkg/table/extension_linux.go
+++ b/orbit/pkg/table/extension_linux.go
@@ -17,6 +17,6 @@ func PlatformTables(_ PluginOpts) ([]osquery.OsqueryPlugin, error) {
 		cryptsetup.TablePlugin(log.Logger),            // table name is "cryptsetup_status"
 		falconctl.NewFalconctlOptionTable(log.Logger), // table name is "falconctl_option"
 		falcon_kernel_check.TablePlugin(log.Logger),   // table name is "falcon_kernel_check"
-		dataflattentable.TablePluginExec(log.Logger, "nftables", dataflattentable.JsonType, []string{"/usr/bin/nft", "-jat", "list", "ruleset"}), // -j (json) -a (show object handles) -t (terse, omit set contents)
+		dataflattentable.TablePluginExec(log.Logger, "nftables", dataflattentable.JsonType, []string{"nft", "-jat", "list", "ruleset"}, dataflattentable.WithBinDirs("/usr/bin", "/usr/sbin")), // -j (json) -a (show object handles) -t (terse, omit set contents)
 	}, nil
 }

--- a/orbit/pkg/table/extension_linux.go
+++ b/orbit/pkg/table/extension_linux.go
@@ -6,6 +6,7 @@ import (
 	"github.com/fleetdm/fleet/v4/orbit/pkg/table/crowdstrike/falcon_kernel_check"
 	"github.com/fleetdm/fleet/v4/orbit/pkg/table/crowdstrike/falconctl"
 	"github.com/fleetdm/fleet/v4/orbit/pkg/table/cryptsetup"
+	"github.com/fleetdm/fleet/v4/orbit/pkg/table/dataflattentable"
 	"github.com/rs/zerolog/log"
 
 	"github.com/osquery/osquery-go"
@@ -16,5 +17,6 @@ func PlatformTables(_ PluginOpts) ([]osquery.OsqueryPlugin, error) {
 		cryptsetup.TablePlugin(log.Logger),            // table name is "cryptsetup_status"
 		falconctl.NewFalconctlOptionTable(log.Logger), // table name is "falconctl_option"
 		falcon_kernel_check.TablePlugin(log.Logger),   // table name is "falcon_kernel_check"
+		dataflattentable.TablePluginExec(log.Logger, "nftables", dataflattentable.JsonType, []string{"/usr/bin/nft", "-jat", "list", "ruleset"}), // -j (json) -a (show object handles) -t (terse, omit set contents)
 	}, nil
 }


### PR DESCRIPTION
Following the discussion in #15651, this adds the `nftables` table by parsing the binary output.

Tests are missing, before I write them I would like to know if this is the correct way to implement it or if I should use the `cryptsetup` table as reference to implement it.

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/Committing-Changes.md#changes-files) for more information.
- [ ] Added/updated tests
- [x] Manual QA for all new/changed functionality
- For Orbit and Fleet Desktop changes:
   - [x] Orbit runs on macOS, Linux and Windows. Check if the orbit feature/bugfix should only apply to one platform (`runtime.GOOS`).
