### PR TITLE
Update contributor API docs to cover LUKS trigger/escrow endpoints (#23583, #23584)

### DIFF
--- a/docs/Contributing/API-for-contributors.md
+++ b/docs/Contributing/API-for-contributors.md
@@ -3248,7 +3248,7 @@ Notifies the server about an agent error, resulting in two outcomes:
 {
   "orbit_node_key":"FbvSsWfTRwXEecUlCBTLmBcjGFAdzqd/",
   "passphrase": "6e657665-7220676f-6e6e6120-67697665-20796f75-207570",
-  "slot_key": "",
+  "slot_key": "1",
   "client_error": ""
 }
 ```

--- a/docs/Contributing/API-for-contributors.md
+++ b/docs/Contributing/API-for-contributors.md
@@ -2790,7 +2790,7 @@ Device-authenticated routes are routes used by the Fleet Desktop application. Un
 - [Get device's transparency URL](#get-devices-transparency-url)
 - [Download device's MDM manual enrollment profile](#download-devices-mdm-manual-enrollment-profile)
 - [Migrate device to Fleet from another MDM solution](#migrate-device-to-fleet-from-another-mdm-solution)
-- [Trigger FileVault key escrow](#trigger-filevault-key-escrow)
+- [Trigger Linux disk encryption escrow](#trigger-linux-disk-encryption-escrow)
 - [Report an agent error](#report-an-agent-error)
 
 #### Refetch device's host
@@ -2876,7 +2876,6 @@ Gets all information required by Fleet Desktop, this includes things like the nu
   "notifications": {
     "needs_mdm_migration": true,
     "renew_enrollment_profile": false,
-    "enforce_bitlocker_encryption": false,
   },
   "config": {
     "org_info": {
@@ -2898,8 +2897,6 @@ In regards to the `notifications` key:
 
 - `needs_mdm_migration` means that the device fits all the requirements to allow the user to initiate an MDM migration to Fleet.
 - `renew_enrollment_profile` means that the device is currently unmanaged from MDM but should be DEP enrolled into Fleet.
-- `enforce_bitlocker_encryption` applies only to Windows devices and means that it should encrypt the disk and report the encryption key back to Fleet.
-
 
 #### Get device's software
 
@@ -3098,7 +3095,7 @@ This supports the dynamic discovery of API features supported by the server for 
 
 #### Get device's transparency URL
 
-Returns the URL to open when clicking the "Transparency" menu item in Fleet Desktop. Note that _Fleet Premium_ is required to configure a custom transparency URL.
+Returns the URL to open when clicking the "About Fleet" menu item in Fleet Desktop. Note that _Fleet Premium_ is required to configure a custom transparency URL.
 
 `GET /api/v1/fleet/device/{token}/transparency`
 
@@ -3170,6 +3167,30 @@ Signals the Fleet server to send a webbook request with the device UUID and seri
 
 ---
 
+### Trigger Linux disk encryption escrow
+
+_Available in Fleet Premium_
+
+Signals the fleet server to queue up the LUKS disk encryption escrow process (LUKS passphrase and slot key). If validation succeeds (disk encryption must be enforced for the team, the host's platform must be supported, the host's disk must already be encrypted, and the host's Orbit version must be new enough), this adds a notification flag for Orbit that, triggers escrow from the Orbit side.
+
+`POST /api/v1/fleet/device/{token}/mdm/linux/trigger_escrow`
+
+##### Parameters
+
+| Name  | Type   | In   | Description                        |
+| ----- | ------ | ---- | ---------------------------------- |
+| token | string | path | The device's authentication token. |
+
+##### Example
+
+`POST /api/v1/fleet/device/abcdef012456789/mdm/linux/trigger_escrow`
+
+##### Default response
+
+`Status: 204`
+
+---
+
 ### Report an agent error
 
 Notifies the server about an agent error, resulting in two outcomes:
@@ -3199,8 +3220,44 @@ Notifies the server about an agent error, resulting in two outcomes:
 
 ## Orbit-authenticated routes
 
+- [Escrow LUKS data](#escrow-luks-data)
 - [Get the status of a device in the setup experience](#get-the-status-of-a-device-in-the-setup-experience)
 
+---
+
+### Escrow LUKS data
+
+`POST /api/fleet/orbit/luks_data`
+
+##### Parameters
+
+| Name  | Type   | In   | Description                        |
+| ----- | ------ | ---- | ---------------------------------- |
+| orbit_node_key | string | body | The Orbit's node key for authentication. |
+| passphrase | string | body | The LUKS passphrase generated for Fleet (the end user's existing passphrase is not transmitted) |
+| slot_key | string | body | The LUKS slot key corresponding to the provided passphrase (optional) |
+| client_error | string | body | An error description if the LUKS key escrow process fails client-side. If provided, passphrase and slot key request parameters are ignored. |
+
+##### Example
+
+`POST /api/v1/fleet/orbit/luks_data`
+
+##### Request body
+
+```json
+{
+  "orbit_node_key":"FbvSsWfTRwXEecUlCBTLmBcjGFAdzqd/",
+  "passphrase": "6e657665-7220676f-6e6e6120-67697665-20796f75-207570",
+  "slot_key": "",
+  "client_error": ""
+}
+```
+
+##### Default response
+
+`Status: 204`
+
+---
 
 ### Get the status of a device in the setup experience
 

--- a/docs/Contributing/API-for-contributors.md
+++ b/docs/Contributing/API-for-contributors.md
@@ -3234,9 +3234,10 @@ Notifies the server about an agent error, resulting in two outcomes:
 | Name  | Type   | In   | Description                        |
 | ----- | ------ | ---- | ---------------------------------- |
 | orbit_node_key | string | body | The Orbit's node key for authentication. |
+| client_error | string | body | An error description if the LUKS key escrow process fails client-side. If provided, passphrase/salt/key slot request parameters are ignored and may be omitted. |
 | passphrase | string | body | The LUKS passphrase generated for Fleet (the end user's existing passphrase is not transmitted) |
-| slot_key | string | body | The LUKS slot key corresponding to the provided passphrase (optional) |
-| client_error | string | body | An error description if the LUKS key escrow process fails client-side. If provided, passphrase and slot key request parameters are ignored. |
+| key_slot | int | body | The LUKS key slot ID corresponding to the provided passphrase |
+| salt | string | body | The salt corresponding to the specified LUKS key slot. Provided to track cases where an end user rotates LUKS credentials (at which point we'll no longer be able to decrypt data with the escrowed passphrase). |
 
 ##### Example
 
@@ -3248,7 +3249,8 @@ Notifies the server about an agent error, resulting in two outcomes:
 {
   "orbit_node_key":"FbvSsWfTRwXEecUlCBTLmBcjGFAdzqd/",
   "passphrase": "6e657665-7220676f-6e6e6120-67697665-20796f75-207570",
-  "slot_key": "1",
+  "salt": "d34db33f",
+  "key_slot": 1,
   "client_error": ""
 }
 ```


### PR DESCRIPTION
Other cleanup:

* Remove orphaned FileVault rotation ToC link
* Revise transparency endpoint to reference new "About Fleet" terminology
* Remove enforce_bitlocker_encryption Fleet Desktop notification (that notification is on Orbit config, which we don't document in contributor docs, not on the Fleet Desktop endpoint)