### PR TITLE
fix: show script name in activity for setup experience script

### DIFF
--- a/changes/23787-script-name
+++ b/changes/23787-script-name
@@ -1,0 +1,2 @@
+- Fixes a bug where the name of the setup experience script was not showing up in the activity for
+  that script execution.

--- a/ee/server/service/setup_experience.go
+++ b/ee/server/service/setup_experience.go
@@ -220,9 +220,10 @@ func (svc *Service) SetupExperienceNextStep(ctx context.Context, hostUUID string
 				return false, ctxerr.Errorf(ctx, "setup experience script missing content id: %d", *script.SetupExperienceScriptID)
 			}
 			req := &fleet.HostScriptRequestPayload{
-				HostID:          host.ID,
-				ScriptName:      script.Name,
-				ScriptContentID: *script.ScriptContentID,
+				HostID:                  host.ID,
+				ScriptName:              script.Name,
+				ScriptContentID:         *script.ScriptContentID,
+				SetupExperienceScriptID: script.SetupExperienceScriptID,
 			}
 			res, err := svc.ds.NewHostScriptExecutionRequest(ctx, req)
 			if err != nil {

--- a/server/datastore/mysql/activities.go
+++ b/server/datastore/mysql/activities.go
@@ -312,7 +312,7 @@ func (ds *Datastore) ListHostUpcomingActivities(ctx context.Context, hostID uint
 			JSON_OBJECT(
 				'host_id', hsr.host_id,
 				'host_display_name', COALESCE(hdn.display_name, ''),
-				'script_name', COALESCE(scr.name, ''),
+				'script_name', COALESCE(ses.name, COALESCE(scr.name, '')),
 				'script_execution_id', hsr.execution_id,
 				'async', NOT hsr.sync_request,
 			    'policy_id', hsr.policy_id,
@@ -330,6 +330,8 @@ func (ds *Datastore) ListHostUpcomingActivities(ctx context.Context, hostID uint
 			scripts scr ON scr.id = hsr.script_id
 		LEFT OUTER JOIN
 		    host_software_installs hsi ON hsi.execution_id = hsr.execution_id
+		LEFT OUTER JOIN
+			setup_experience_scripts ses ON ses.id = hsr.setup_experience_script_id
 		WHERE
 			hsr.host_id = :host_id AND
 			hsr.exit_code IS NULL AND

--- a/server/datastore/mysql/activities_test.go
+++ b/server/datastore/mysql/activities_test.go
@@ -543,6 +543,7 @@ func testListHostUpcomingActivities(t *testing.T, ds *Datastore) {
 
 	setupExpScript := &fleet.Script{Name: "setup_experience_script", ScriptContents: "setup_experience"}
 	err = ds.SetSetupExperienceScript(ctx, setupExpScript)
+	require.NoError(t, err)
 	ses, err := ds.GetSetupExperienceScript(ctx, h2.TeamID)
 	require.NoError(t, err)
 	hsr, err = ds.NewHostScriptExecutionRequest(ctx, &fleet.HostScriptRequestPayload{HostID: h2.ID, ScriptContents: "setup_experience", SetupExperienceScriptID: &ses.ID})

--- a/server/datastore/mysql/activities_test.go
+++ b/server/datastore/mysql/activities_test.go
@@ -541,6 +541,14 @@ func testListHostUpcomingActivities(t *testing.T, ds *Datastore) {
 	h2SelfService, err := ds.InsertSoftwareInstallRequest(noUserCtx, h2.ID, sw1Meta.InstallerID, true, nil)
 	require.NoError(t, err)
 
+	setupExpScript := &fleet.Script{Name: "setup_experience_script", ScriptContents: "setup_experience"}
+	err = ds.SetSetupExperienceScript(ctx, setupExpScript)
+	ses, err := ds.GetSetupExperienceScript(ctx, h2.TeamID)
+	require.NoError(t, err)
+	hsr, err = ds.NewHostScriptExecutionRequest(ctx, &fleet.HostScriptRequestPayload{HostID: h2.ID, ScriptContents: "setup_experience", SetupExperienceScriptID: &ses.ID})
+	require.NoError(t, err)
+	h2SetupExp := hsr.ExecutionID
+
 	// create pending install and uninstall requests for h3 that will be deleted
 	_, err = ds.InsertSoftwareInstallRequest(ctx, h3.ID, sw3Meta.InstallerID, false, nil)
 	require.NoError(t, err)
@@ -560,7 +568,8 @@ func testListHostUpcomingActivities(t *testing.T, ds *Datastore) {
 	endTime = SetOrderedCreatedAtTimestamps(t, ds, endTime, "host_software_installs", "execution_id", h2SelfService)
 	endTime = SetOrderedCreatedAtTimestamps(t, ds, endTime, "host_software_installs", "execution_id", h2Bar)
 	endTime = SetOrderedCreatedAtTimestamps(t, ds, endTime, "host_script_results", "execution_id", h2A, h2F)
-	SetOrderedCreatedAtTimestamps(t, ds, endTime, "host_vpp_software_installs", "command_uuid", vppCommand1, vppCommand2)
+	endTime = SetOrderedCreatedAtTimestamps(t, ds, endTime, "host_vpp_software_installs", "command_uuid", vppCommand1, vppCommand2)
+	SetOrderedCreatedAtTimestamps(t, ds, endTime, "host_script_results", "execution_id", h2SetupExp)
 
 	execIDsWithUser := map[string]bool{
 		h1A:           true,
@@ -576,11 +585,13 @@ func testListHostUpcomingActivities(t *testing.T, ds *Datastore) {
 		h2Bar:         true,
 		vppCommand1:   true,
 		vppCommand2:   false,
+		h2SetupExp:    false,
 	}
 	execIDsScriptName := map[string]string{
-		h1A: scr1.Name,
-		h1B: scr2.Name,
-		h2A: scr1.Name,
+		h1A:        scr1.Name,
+		h1B:        scr2.Name,
+		h2A:        scr1.Name,
+		h2SetupExp: setupExpScript.Name,
 	}
 	execIDsSoftwareTitle := map[string]string{
 		h1Fleet:       "foo",
@@ -641,10 +652,10 @@ func testListHostUpcomingActivities(t *testing.T, ds *Datastore) {
 			wantMeta:  &fleet.PaginationMetadata{HasNextResults: false, HasPreviousResults: true, TotalResults: 8},
 		},
 		{
-			opts:      fleet.ListOptions{PerPage: 4},
+			opts:      fleet.ListOptions{PerPage: 5},
 			hostID:    h2.ID,
-			wantExecs: []string{h2SelfService, h2Bar, h2A, vppCommand2},
-			wantMeta:  &fleet.PaginationMetadata{HasNextResults: false, HasPreviousResults: false, TotalResults: 4},
+			wantExecs: []string{h2SelfService, h2Bar, h2A, vppCommand2, h2SetupExp},
+			wantMeta:  &fleet.PaginationMetadata{HasNextResults: false, HasPreviousResults: false, TotalResults: 5},
 		},
 		{
 			opts:      fleet.ListOptions{},

--- a/server/datastore/mysql/scripts.go
+++ b/server/datastore/mysql/scripts.go
@@ -40,8 +40,6 @@ func (ds *Datastore) NewHostScriptExecutionRequest(ctx context.Context, request 
 func newHostScriptExecutionRequest(ctx context.Context, tx sqlx.ExtContext, request *fleet.HostScriptRequestPayload) (*fleet.HostScriptResult, error) {
 	const (
 		insStmt = `INSERT INTO host_script_results (host_id, execution_id, script_content_id, output, script_id, policy_id, user_id, sync_request, setup_experience_script_id) VALUES (?, ?, ?, '', ?, ?, ?, ?, ?)`
-		// TODO(JVE): replace this with the transactionable function we have below (and update that
-		// to be a function, not a ds private method)
 		getStmt = `SELECT hsr.id, hsr.host_id, hsr.execution_id, hsr.created_at, hsr.script_id, hsr.policy_id, hsr.user_id, hsr.sync_request, sc.contents as script_contents, hsr.setup_experience_script_id FROM host_script_results hsr JOIN script_contents sc WHERE sc.id = hsr.script_content_id AND hsr.id = ?`
 	)
 

--- a/server/datastore/mysql/scripts.go
+++ b/server/datastore/mysql/scripts.go
@@ -39,8 +39,10 @@ func (ds *Datastore) NewHostScriptExecutionRequest(ctx context.Context, request 
 
 func newHostScriptExecutionRequest(ctx context.Context, tx sqlx.ExtContext, request *fleet.HostScriptRequestPayload) (*fleet.HostScriptResult, error) {
 	const (
-		insStmt = `INSERT INTO host_script_results (host_id, execution_id, script_content_id, output, script_id, policy_id, user_id, sync_request) VALUES (?, ?, ?, '', ?, ?, ?, ?)`
-		getStmt = `SELECT hsr.id, hsr.host_id, hsr.execution_id, hsr.created_at, hsr.script_id, hsr.policy_id, hsr.user_id, hsr.sync_request, sc.contents as script_contents FROM host_script_results hsr JOIN script_contents sc WHERE sc.id = hsr.script_content_id AND hsr.id = ?`
+		insStmt = `INSERT INTO host_script_results (host_id, execution_id, script_content_id, output, script_id, policy_id, user_id, sync_request, setup_experience_script_id) VALUES (?, ?, ?, '', ?, ?, ?, ?, ?)`
+		// TODO(JVE): replace this with the transactionable function we have below (and update that
+		// to be a function, not a ds private method)
+		getStmt = `SELECT hsr.id, hsr.host_id, hsr.execution_id, hsr.created_at, hsr.script_id, hsr.policy_id, hsr.user_id, hsr.sync_request, sc.contents as script_contents, hsr.setup_experience_script_id FROM host_script_results hsr JOIN script_contents sc WHERE sc.id = hsr.script_content_id AND hsr.id = ?`
 	)
 
 	execID := uuid.New().String()
@@ -52,6 +54,7 @@ func newHostScriptExecutionRequest(ctx context.Context, tx sqlx.ExtContext, requ
 		request.PolicyID,
 		request.UserID,
 		request.SyncRequest,
+		request.SetupExperienceScriptID,
 	)
 	if err != nil {
 		return nil, ctxerr.Wrap(ctx, err, "new host script execution request")
@@ -269,7 +272,8 @@ func (ds *Datastore) getHostScriptExecutionResultDB(ctx context.Context, q sqlx.
     hsr.created_at,
     hsr.user_id,
     hsr.sync_request,
-    hsr.host_deleted_at
+    hsr.host_deleted_at,
+	hsr.setup_experience_script_id
   FROM
     host_script_results hsr
   JOIN

--- a/server/datastore/mysql/setup_experience.go
+++ b/server/datastore/mysql/setup_experience.go
@@ -404,6 +404,32 @@ WHERE
 	return &script, nil
 }
 
+func (ds *Datastore) GetSetupExperienceScriptByID(ctx context.Context, scriptID uint) (*fleet.Script, error) {
+	query := `
+SELECT
+  id,
+  team_id,
+  name,
+  script_content_id,
+  created_at,
+  updated_at
+FROM
+  setup_experience_scripts
+WHERE
+  id = ?
+`
+
+	var script fleet.Script
+	if err := sqlx.GetContext(ctx, ds.reader(ctx), &script, query, scriptID); err != nil {
+		if err == sql.ErrNoRows {
+			return nil, ctxerr.Wrap(ctx, notFound("SetupExperienceScript"), "get setup experience script by id")
+		}
+		return nil, ctxerr.Wrap(ctx, err, "get setup experience script by id")
+	}
+
+	return &script, nil
+}
+
 func (ds *Datastore) SetSetupExperienceScript(ctx context.Context, script *fleet.Script) error {
 	err := ds.withRetryTxx(ctx, func(tx sqlx.ExtContext) error {
 		var err error

--- a/server/fleet/datastore.go
+++ b/server/fleet/datastore.go
@@ -1782,6 +1782,8 @@ type Datastore interface {
 	UpdateSetupExperienceStatusResult(ctx context.Context, status *SetupExperienceStatusResult) error
 	EnqueueSetupExperienceItems(ctx context.Context, hostUUID string, teamID uint) (bool, error)
 	GetSetupExperienceScript(ctx context.Context, teamID *uint) (*Script, error)
+	// GetSetupExperienceScriptByID gets the setup experience script by its ID.
+	GetSetupExperienceScriptByID(ctx context.Context, scriptID uint) (*Script, error)
 	SetSetupExperienceScript(ctx context.Context, script *Script) error
 	DeleteSetupExperienceScript(ctx context.Context, teamID *uint) error
 	MaybeUpdateSetupExperienceScriptStatus(ctx context.Context, hostUUID string, executionID string, status SetupExperienceStatusResultStatus) (bool, error)

--- a/server/fleet/datastore.go
+++ b/server/fleet/datastore.go
@@ -1778,16 +1778,46 @@ type Datastore interface {
 	// Setup Experience
 	//
 
+	// ListSetupExperienceResultsByHostUUID lists the setup experience results for a host by its UUID.
 	ListSetupExperienceResultsByHostUUID(ctx context.Context, hostUUID string) ([]*SetupExperienceStatusResult, error)
+
+	// UpdateSetupExperienceStatusResult updates the given setup experience status result.
 	UpdateSetupExperienceStatusResult(ctx context.Context, status *SetupExperienceStatusResult) error
+
+	// EnqueueSetupExperienceItems enqueues the relevant setup experience items (software and
+	// script) for a given host. It first clears out any pre-existing setup experience items that
+	// were previously enqueued for the host (since the setup experience only happens once during
+	// the initial device setup). It then adds any software and script that have been configured for
+	// this team to the host's queue and sets their status to pending. If any items were enqueued,
+	// it returns true, otherwise it returns false.
 	EnqueueSetupExperienceItems(ctx context.Context, hostUUID string, teamID uint) (bool, error)
+
+	// GetSetupExperienceScript gets the setup experience script for a team. There can only be 1
+	// setup experience script per team.
 	GetSetupExperienceScript(ctx context.Context, teamID *uint) (*Script, error)
+
 	// GetSetupExperienceScriptByID gets the setup experience script by its ID.
 	GetSetupExperienceScriptByID(ctx context.Context, scriptID uint) (*Script, error)
+
+	// SetSetupExperienceScript sets the setup experience script to the given script.
 	SetSetupExperienceScript(ctx context.Context, script *Script) error
+
+	// DeleteSetupExperienceScript deletes the setup experience script for the given team.
 	DeleteSetupExperienceScript(ctx context.Context, teamID *uint) error
+
+	// MaybeUpdateSetupExperienceScriptStatus updates the status of the setup experience script for
+	// the given host if the script result row exists. If there was an update, it returns true.
+	// Otherwise, it returns false.
 	MaybeUpdateSetupExperienceScriptStatus(ctx context.Context, hostUUID string, executionID string, status SetupExperienceStatusResultStatus) (bool, error)
+
+	// MaybeUpdateSetupExperienceSoftwareInstallStatus updates the status of the setup experience
+	// software installer for the given host if the software installer result row exists. If there
+	// was an update, it returns true. Otherwise, it returns false.
 	MaybeUpdateSetupExperienceSoftwareInstallStatus(ctx context.Context, hostUUID string, executionID string, status SetupExperienceStatusResultStatus) (bool, error)
+
+	// MaybeUpdateSetupExperienceVPPStatus updates the status of the setup experience
+	// VPP app for the given host if the VPP app installer row exists. If there was an update, it
+	// returns true. Otherwise, it returns false.
 	MaybeUpdateSetupExperienceVPPStatus(ctx context.Context, hostUUID string, commandUUID string, status SetupExperienceStatusResultStatus) (bool, error)
 
 	// Fleet-maintained apps

--- a/server/fleet/scripts.go
+++ b/server/fleet/scripts.go
@@ -148,7 +148,9 @@ type HostScriptRequestPayload struct {
 	UserID *uint `json:"-"`
 	// SyncRequest is filled automatically based on the endpoint used to create
 	// the execution request (synchronous or asynchronous).
-	SyncRequest             bool  `json:"-"`
+	SyncRequest bool `json:"-"`
+	// SetupExperienceScriptID is the ID of the setup experience script related to this request
+	// payload, if such a script exists.
 	SetupExperienceScriptID *uint `json:"-"`
 }
 

--- a/server/fleet/scripts.go
+++ b/server/fleet/scripts.go
@@ -148,7 +148,8 @@ type HostScriptRequestPayload struct {
 	UserID *uint `json:"-"`
 	// SyncRequest is filled automatically based on the endpoint used to create
 	// the execution request (synchronous or asynchronous).
-	SyncRequest bool `json:"-"`
+	SyncRequest             bool  `json:"-"`
+	SetupExperienceScriptID *uint `json:"-"`
 }
 
 func (r HostScriptRequestPayload) ValidateParams(waitForResult time.Duration) error {
@@ -251,6 +252,10 @@ type HostScriptResult struct {
 	// results can still be returned to see activity details after the host got
 	// deleted.
 	HostDeletedAt *time.Time `json:"-" db:"host_deleted_at"`
+
+	// SetupExperienceScriptID is the ID of the setup experience script, if this script execution
+	// was part of setup experience.
+	SetupExperienceScriptID *uint `json:"-" db:"setup_experience_script_id"`
 }
 
 func (hsr HostScriptResult) AuthzType() string {

--- a/server/mock/datastore_mock.go
+++ b/server/mock/datastore_mock.go
@@ -1127,6 +1127,8 @@ type EnqueueSetupExperienceItemsFunc func(ctx context.Context, hostUUID string, 
 
 type GetSetupExperienceScriptFunc func(ctx context.Context, teamID *uint) (*fleet.Script, error)
 
+type GetSetupExperienceScriptByIDFunc func(ctx context.Context, scriptID uint) (*fleet.Script, error)
+
 type SetSetupExperienceScriptFunc func(ctx context.Context, script *fleet.Script) error
 
 type DeleteSetupExperienceScriptFunc func(ctx context.Context, teamID *uint) error
@@ -2808,6 +2810,9 @@ type DataStore struct {
 
 	GetSetupExperienceScriptFunc        GetSetupExperienceScriptFunc
 	GetSetupExperienceScriptFuncInvoked bool
+
+	GetSetupExperienceScriptByIDFunc        GetSetupExperienceScriptByIDFunc
+	GetSetupExperienceScriptByIDFuncInvoked bool
 
 	SetSetupExperienceScriptFunc        SetSetupExperienceScriptFunc
 	SetSetupExperienceScriptFuncInvoked bool
@@ -6714,6 +6719,13 @@ func (s *DataStore) GetSetupExperienceScript(ctx context.Context, teamID *uint) 
 	s.GetSetupExperienceScriptFuncInvoked = true
 	s.mu.Unlock()
 	return s.GetSetupExperienceScriptFunc(ctx, teamID)
+}
+
+func (s *DataStore) GetSetupExperienceScriptByID(ctx context.Context, scriptID uint) (*fleet.Script, error) {
+	s.mu.Lock()
+	s.GetSetupExperienceScriptByIDFuncInvoked = true
+	s.mu.Unlock()
+	return s.GetSetupExperienceScriptByIDFunc(ctx, scriptID)
 }
 
 func (s *DataStore) SetSetupExperienceScript(ctx context.Context, script *fleet.Script) error {

--- a/server/service/orbit.go
+++ b/server/service/orbit.go
@@ -804,11 +804,20 @@ func (svc *Service) SaveHostScriptResult(ctx context.Context, result *fleet.Host
 			}
 		}
 		var scriptName string
-		if hsr.ScriptID != nil {
+
+		switch {
+		case hsr.ScriptID != nil:
 			scr, err := svc.ds.Script(ctx, *hsr.ScriptID)
 			if err != nil {
 				return ctxerr.Wrap(ctx, err, "get saved script")
 			}
+			scriptName = scr.Name
+		case hsr.SetupExperienceScriptID != nil:
+			scr, err := svc.ds.GetSetupExperienceScriptByID(ctx, *hsr.SetupExperienceScriptID)
+			if err != nil {
+				return ctxerr.Wrap(ctx, err, "get setup experience script")
+			}
+
 			scriptName = scr.Name
 		}
 


### PR DESCRIPTION
> Related issue: #23787 

This adds the script name to both the upcoming and past activities.

Demo video: https://www.youtube.com/watch?v=kLSsUZhyMC4

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/Committing-Changes.md#changes-files) for more information.
- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [x] Added/updated tests
- [x] Manual QA for all new/changed functionality
