### PR TITLE
Website: Add account to website page view CRM records

### DIFF
--- a/website/api/hooks/custom/index.js
+++ b/website/api/hooks/custom/index.js
@@ -325,6 +325,7 @@ will be disabled and/or hidden in the UI.
                       return await salesforceConnection.sobject('fleet_website_page_views__c')
                       .create({
                         Contact__c: recordIds.salesforceContactId,// eslint-disable-line camelcase
+                        Account__c: recordIds.salesforceAccountId,// eslint-disable-line camelcase
                         Page_URL__c: `https://fleetdm.com${req.url}`,// eslint-disable-line camelcase
                         Visited_on__c: nowOn,// eslint-disable-line camelcase
                         Website_visit_reason__c: websiteVisitReason// eslint-disable-line camelcase


### PR DESCRIPTION
https://github.com/fleetdm/fleet/issues/23958

Changes:
- Updated the custom hook to set an `account` value on new Fleet website page view records created.