### PR TITLE
doc: firefox_preferences works on linux and windows

### DIFF
--- a/changes/23967-doc-firefox_preferences-linux-windows
+++ b/changes/23967-doc-firefox_preferences-linux-windows
@@ -1,0 +1,1 @@
+* doc: document firefox_preferences table for Linux and Windows platforms

--- a/schema/osquery_fleet_schema.json
+++ b/schema/osquery_fleet_schema.json
@@ -10946,14 +10946,17 @@
     "name": "firefox_preferences",
     "description": "Get the filepath where the host's Firefox preferences live.",
     "evented": false,
+    "examples": "Check if a preference is enabled:\n\n```\nSELECT * FROM firefox_preferences WHERE path IN (SELECT path FROM file WHERE path LIKE '/home/%/.mozilla/firefox/%/prefs.js') AND fullkey = 'network.dns.disablePrefetch' and value = 'true';\n```",
     "notes": "This table is not a core osquery table. It is included as part of fleetd, the osquery manager from Fleet. Code based on work by [Kolide](https://github.com/kolide/launcher).",
     "platforms": [
-      "darwin"
+      "darwin",
+      "linux",
+      "windows"
     ],
     "columns": [
       {
         "name": "path",
-        "description": "The path to the host's Firefox preferences.",
+        "description": "The absolute path to the host's Firefox preferences.",
         "type": "text",
         "required": true
       },

--- a/schema/tables/firefox_preferences.yml
+++ b/schema/tables/firefox_preferences.yml
@@ -1,12 +1,20 @@
 name: firefox_preferences
-description: Get the filepath where the host's Firefox preferences live. 
+description: Get the filepath where the host's Firefox preferences live.
 evented: false
+examples: |-
+  Check if a preference is enabled:
+
+  ```
+  SELECT * FROM firefox_preferences WHERE path IN (SELECT path FROM file WHERE path LIKE '/home/%/.mozilla/firefox/%/prefs.js') AND fullkey = 'network.dns.disablePrefetch' and value = 'true';
+  ```
 notes: This table is not a core osquery table. It is included as part of fleetd, the osquery manager from Fleet. Code based on work by [Kolide](https://github.com/kolide/launcher).
 platforms:
   - darwin
+  - linux
+  - windows
 columns:
   - name: path
-    description: The path to the host's Firefox preferences.
+    description: The absolute path to the host's Firefox preferences.
     type: text
     required: true
   - name: key
@@ -29,4 +37,4 @@ columns:
     description: The query is printed in this column. For example the SQL `SELECT * FROM firefox_preferences WHERE path = 'testdata/prefs.js'` will print "*" in the query column.
     type: text
     required: false
-  
+


### PR DESCRIPTION
Solves #23955

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/Committing-Changes.md#changes-files) for more information.
- [ ] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [ ] Added support on fleet's osquery simulator `cmd/osquery-perf` for new osquery data ingestion features.
- [ ] Added/updated tests
- [ ] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes
- [ ] If database migrations are included, checked table schema to confirm autoupdate
- For database migrations:
  - [ ] Checked schema for all modified table for columns that will auto-update timestamps during migration.
  - [ ] Confirmed that updating the timestamps is acceptable, and will not cause unwanted side effects.
  - [ ] Ensured the correct collation is explicitly set for character columns (`COLLATE utf8mb4_unicode_ci`).
- [ ] Manual QA for all new/changed functionality
- For Orbit and Fleet Desktop changes:
   - [ ] Orbit runs on macOS, Linux and Windows. Check if the orbit feature/bugfix should only apply to one platform (`runtime.GOOS`).
   - [ ] Manual QA must be performed in the three main OSs, macOS, Windows and Linux.
   - [ ] Auto-update manual QA, from released version of component to new version (see [tools/tuf/test](../tools/tuf/test/README.md)).
