### PR TITLE
Split up apple and windows profile management cron jobs

### DIFF
--- a/cmd/fleet/cron.go
+++ b/cmd/fleet/cron.go
@@ -1182,7 +1182,7 @@ func appleMDMDEPSyncerJob(
 	}
 }
 
-func newAppleMDMProfileManager(
+func newAppleMDMProfileManagerSchedule(
 	ctx context.Context,
 	instanceID string,
 	ds fleet.Datastore,
@@ -1212,7 +1212,7 @@ func newAppleMDMProfileManager(
 	return s, nil
 }
 
-func newWindowsMDMProfileManager(
+func newWindowsMDMProfileManagerSchedule(
 	ctx context.Context,
 	instanceID string,
 	ds fleet.Datastore,

--- a/cmd/fleet/cron.go
+++ b/cmd/fleet/cron.go
@@ -1182,7 +1182,7 @@ func appleMDMDEPSyncerJob(
 	}
 }
 
-func newMDMProfileManager(
+func newAppleMDMProfileManager(
 	ctx context.Context,
 	instanceID string,
 	ds fleet.Datastore,
@@ -1207,6 +1207,29 @@ func newMDMProfileManager(
 		schedule.WithJob("manage_apple_declarations", func(ctx context.Context) error {
 			return service.ReconcileAppleDeclarations(ctx, ds, commander, logger)
 		}),
+	)
+
+	return s, nil
+}
+
+func newWindowsMDMProfileManager(
+	ctx context.Context,
+	instanceID string,
+	ds fleet.Datastore,
+	logger kitlog.Logger,
+) (*schedule.Schedule, error) {
+	const (
+		name = string(fleet.CronMDMWindowsProfileManager)
+		// Note: per a request from #g-product we are running this cron
+		// every 30 seconds, we should re-evaluate how we handle the
+		// cron interval as we scale to more hosts.
+		defaultInterval = 30 * time.Second
+	)
+
+	logger = kitlog.With(logger, "cron", name)
+	s := schedule.New(
+		ctx, name, instanceID, defaultInterval, ds, ds,
+		schedule.WithLogger(logger),
 		schedule.WithJob("manage_windows_profiles", func(ctx context.Context) error {
 			return service.ReconcileWindowsProfiles(ctx, ds, logger)
 		}),

--- a/cmd/fleet/cron_test.go
+++ b/cmd/fleet/cron_test.go
@@ -30,7 +30,7 @@ func TestNewAppleMDMProfileManagerWithoutConfig(t *testing.T) {
 	cmdr := apple_mdm.NewMDMAppleCommander(mdmStorage, nil)
 	logger := kitlog.NewNopLogger()
 
-	sch, err := newAppleMDMProfileManager(ctx, "foo", ds, cmdr, logger)
+	sch, err := newAppleMDMProfileManagerSchedule(ctx, "foo", ds, cmdr, logger)
 	require.NotNil(t, sch)
 	require.NoError(t, err)
 }
@@ -40,7 +40,7 @@ func TestNewWindowsMDMProfileManagerWithoutConfig(t *testing.T) {
 	ds := new(mock.Store)
 	logger := kitlog.NewNopLogger()
 
-	sch, err := newWindowsMDMProfileManager(ctx, "foo", ds, logger)
+	sch, err := newWindowsMDMProfileManagerSchedule(ctx, "foo", ds, logger)
 	require.NotNil(t, sch)
 	require.NoError(t, err)
 }

--- a/cmd/fleet/cron_test.go
+++ b/cmd/fleet/cron_test.go
@@ -23,14 +23,24 @@ import (
 	kitlog "github.com/go-kit/log"
 )
 
-func TestNewMDMProfileManagerWithoutConfig(t *testing.T) {
+func TestNewAppleMDMProfileManagerWithoutConfig(t *testing.T) {
 	ctx := context.Background()
 	mdmStorage := &mdmmock.MDMAppleStore{}
 	ds := new(mock.Store)
 	cmdr := apple_mdm.NewMDMAppleCommander(mdmStorage, nil)
 	logger := kitlog.NewNopLogger()
 
-	sch, err := newMDMProfileManager(ctx, "foo", ds, cmdr, logger)
+	sch, err := newAppleMDMProfileManager(ctx, "foo", ds, cmdr, logger)
+	require.NotNil(t, sch)
+	require.NoError(t, err)
+}
+
+func TestNewWindowsMDMProfileManagerWithoutConfig(t *testing.T) {
+	ctx := context.Background()
+	ds := new(mock.Store)
+	logger := kitlog.NewNopLogger()
+
+	sch, err := newWindowsMDMProfileManager(ctx, "foo", ds, logger)
 	require.NotNil(t, sch)
 	require.NoError(t, err)
 }

--- a/cmd/fleet/serve.go
+++ b/cmd/fleet/serve.go
@@ -919,7 +919,7 @@ the way that the Fleet server works.
 			}
 
 			if err := cronSchedules.StartCronSchedule(func() (fleet.CronSchedule, error) {
-				return newMDMProfileManager(
+				return newAppleMDMProfileManager(
 					ctx,
 					instanceID,
 					ds,
@@ -928,6 +928,17 @@ the way that the Fleet server works.
 				)
 			}); err != nil {
 				initFatal(err, "failed to register mdm_apple_profile_manager schedule")
+			}
+
+			if err := cronSchedules.StartCronSchedule(func() (fleet.CronSchedule, error) {
+				return newWindowsMDMProfileManager(
+					ctx,
+					instanceID,
+					ds,
+					logger,
+				)
+			}); err != nil {
+				initFatal(err, "failed to register mdm_windows_profile_manager schedule")
 			}
 
 			if err := cronSchedules.StartCronSchedule(func() (fleet.CronSchedule, error) {

--- a/cmd/fleet/serve.go
+++ b/cmd/fleet/serve.go
@@ -919,7 +919,7 @@ the way that the Fleet server works.
 			}
 
 			if err := cronSchedules.StartCronSchedule(func() (fleet.CronSchedule, error) {
-				return newAppleMDMProfileManager(
+				return newAppleMDMProfileManagerSchedule(
 					ctx,
 					instanceID,
 					ds,
@@ -931,7 +931,7 @@ the way that the Fleet server works.
 			}
 
 			if err := cronSchedules.StartCronSchedule(func() (fleet.CronSchedule, error) {
-				return newWindowsMDMProfileManager(
+				return newWindowsMDMProfileManagerSchedule(
 					ctx,
 					instanceID,
 					ds,

--- a/server/fleet/cron_schedules.go
+++ b/server/fleet/cron_schedules.go
@@ -21,6 +21,7 @@ const (
 	CronWorkerIntegrations          CronScheduleName = "integrations"
 	CronActivitiesStreaming         CronScheduleName = "activities_streaming"
 	CronMDMAppleProfileManager      CronScheduleName = "mdm_apple_profile_manager"
+	CronMDMWindowsProfileManager    CronScheduleName = "mdm_windows_profile_manager"
 	CronAppleMDMIPhoneIPadRefetcher CronScheduleName = "apple_mdm_iphone_ipad_refetcher"
 	CronAppleMDMAPNsPusher          CronScheduleName = "apple_mdm_apns_pusher"
 	CronCalendar                    CronScheduleName = "calendar"


### PR DESCRIPTION
for #22824 

This PR splits up the `newMDMProfileManager` function into two functions `newAppleMDMProfileManager` and `newWindowsMDMProfileManager`, the latter containing the code to start the windows-specific profile management job.  This allows scheduling and scaling the Apple and Windows profile management jobs separately.

Tested locally by checking that the jobs were scheduled at startup, and then triggering the `mdm_apple_profile_manager` and `mdm_windows_profile_manager` schedules via the `/trigger` API; nothing blew up.  