### PR TITLE
Fix JSON parsing for fleetdm.com EST certificate issuance

### DIFF
--- a/website/api/controllers/get-est-device-certificate.js
+++ b/website/api/controllers/get-est-device-certificate.js
@@ -83,11 +83,11 @@ module.exports = {
       throw 'invalidToken';
     }
 
-    if (!introspectResponse.body.active) {
+    const introspectBody = JSON.parse(introspectResponse.body);
+    if (!introspectBody.active) {
       throw 'invalidToken';
     }
-
-    const introspectUsername = introspectResponse.body.username;
+    const introspectUsername = introspectBody.username;
 
     // Extract the email and username from the CSR. Ensure they match.
     let jsrsasign = require('jsrsasign');


### PR DESCRIPTION
Missed a JSON.parse after refactoring the HTTP request code. This was missed because we had to comment out some of the code for testing in order to skip authentication.