### PR TITLE
Docs: change name of "Deploy Fleet" page

### DIFF
--- a/docs/Deploy/deploy-fleet.md
+++ b/docs/Deploy/deploy-fleet.md
@@ -143,3 +143,4 @@ This workflow takes about 30 minutes to complete and supports between 10 and 350
 
 <meta name="pageOrderInSection" value="100">
 <meta name="description" value="Learn how to easily deploy Fleet on Render or AWS with Terraform.">
+<meta name="title" value="Hosting Fleet">


### PR DESCRIPTION
Closes: #23759

Changes:
- Added a title meta tag to the "Deploy Fleet" documentation page to change the name to "Hosting Fleet"

> Note: This only changes the title of the page in the UI on fleetdm.com, the URL will still be `/docs/deploy/deploy-fleet`