### PR TITLE
Website: Prevent scrolling when mobile nav menu is open

### DIFF
--- a/website/assets/styles/layout.less
+++ b/website/assets/styles/layout.less
@@ -17,6 +17,27 @@ html, body {
   padding-bottom: @footer-height;
   background: linear-gradient(180deg, #E8F1F6 0%, #FFFFFF 200px);
   background-position: center 40px;
+  opacity: 1;
+  // Note: This element has the "show" class toggled by the mobile header nav menu button.
+  // We are overriding bootstrap classes here to allow us to prevent the page being scrolled while the mobile menu is open.
+  &.collapse {
+    display: block;
+    [purpose='mobile-nav'] {
+      display: none;
+    }
+  }
+  &.collapsing {
+    opacity: 0;
+    transition: 0s;
+  }
+  &.collapse.show {
+    max-height: 100vh;
+    overflow: hidden;
+    [purpose='mobile-nav'] {
+      display: block;
+      opacity: 1;
+    }
+  }
 }
 
 [purpose='header-background'] {
@@ -40,7 +61,7 @@ html, body {
 }
 
 [purpose='continue-banner'] {
-  z-index: 199;
+  z-index: 198;
   position: fixed;
   bottom: 24px;
   left: 24px;
@@ -279,14 +300,14 @@ html, body {
     left: 0;
     right: 0;
     bottom: 0;
-    pointer-events: none;
+    z-index: 200;
     background-color: #ffffff;
     hr {
       margin-top: 4px;
       margin-bottom: 8px;
     }
     [purpose='mobile-nav-header'] {
-      padding: 19px 40px;
+      padding: 19px 32px;
       height: 80px;
     }
     [purpose='mobile-nav-container'] {
@@ -783,6 +804,7 @@ body.detected-mobile {
 
 @media (max-width: 375px) {
   [purpose='page-header'] {
+    padding: 19px 16px;
     [purpose='mobile-nav'] {
       [purpose='mobile-nav-header'] {
         padding: 19px 16px;

--- a/website/views/layouts/layout.ejs
+++ b/website/views/layouts/layout.ejs
@@ -130,7 +130,7 @@
     <!--STYLES END-->
   </head>
   <body>
-    <div purpose="page-wrap" class="<%= hideFooterLinks ? 'reduced-footer-links' : '' %>">
+    <div purpose="page-wrap" class="<%= hideFooterLinks ? 'reduced-footer-links' : '' %> collapse"  id="navbarToggleExternalContent">
       <%// Page header%>
       <div class="header" purpose="header-container" hide-when-scrolled data-nosnippet>
         <div purpose="header-background">
@@ -146,7 +146,7 @@
                   <img class="align-self-center" alt="An icon indicating that interacting with this button will open the navigation menu." src="/images/icon-hamburger-blue-16x14@2x.png"/>
                 </a>
               </div>
-              <div purpose="mobile-nav" always-visible-when-shown class="collapse" id="navbarToggleExternalContent">
+              <div purpose="mobile-nav" always-visible-when-shown>
                 <div purpose="mobile-nav-header" class="d-flex justify-content-between align-items-center">
                   <a purpose="mobile-header-logo" href="/">
                     <img purpose="mobile-nav-logo" alt="Fleet logo" src="/images/logo-blue-118x41@2x.png" />
@@ -505,7 +505,6 @@
     <script src="/js/pages/try-fleet/sandbox-teleporter.page.js"></script>
     <script src="/js/pages/try-fleet/waitlist.page.js"></script>
     <script src="/js/pages/vanta-authorization.page.js"></script>
-    <script src="/js/pages/vulnerability-management.page.js"></script>
     <!--SCRIPTS END-->
 
     <% /* Display an overlay if the current browser is not supported.


### PR DESCRIPTION
Closes: #23705

Changes:
- Updated the styles and layout of the website to prevent scrolling when the mobile navigation menu is open.
- Updated padding on the mobile navigation menu to keep the Fleet logo in the same place when the menu is opened.