### PR TITLE
Website: update default personalization on endpoint ops page.

### DIFF
--- a/website/api/controllers/view-endpoint-ops.js
+++ b/website/api/controllers/view-endpoint-ops.js
@@ -27,10 +27,11 @@ module.exports = {
     // If a purpose query parameter is set, update the pagePersonalization value.
     // Note: This is the only page we're using this method instead of using the primaryBuyingSiutation value set in the users session.
     // This lets us link to the security and IT versions of the endpoint ops page from the unpersonalized homepage without changing the users primaryBuyingSituation.
-    if(this.req.param('purpose') === 'it'){
-      pagePersonalization = 'eo-it';
-    } else if(this.req.param('purpose') === 'security'){
+    if(this.req.param('purpose') === 'security'){
       pagePersonalization = 'eo-security';
+    } else {
+      // Default to IT personalization if no primaryBuyingSituation or purpose query parameter is set.
+      pagePersonalization = 'eo-it';
     }
 
 


### PR DESCRIPTION
Closes: #23987

Changes:
 - Updated the endpoint ops page to default to the IT personalization if no primaryBuyingSituation or `purpose` query string is provided/set