### PR TITLE
UI - fix a small issue in the device user page banner logic, add test

### DIFF
--- a/frontend/pages/hosts/details/DeviceUserPage/components/DeviceUserBanners/DeviceUserBanners.tests.tsx
+++ b/frontend/pages/hosts/details/DeviceUserPage/components/DeviceUserBanners/DeviceUserBanners.tests.tsx
@@ -86,7 +86,31 @@ describe("Device User Banners", () => {
     ).toBeInTheDocument();
   });
 
-  it("renders no banner correctly", () => {
+  it("renders no banner correctly for a mac that is verifying its disk encryption", () => {
+    // setup so mdm is not enabled and configured.
+    render(
+      <DeviceUserBanners
+        hostPlatform="darwin"
+        mdmEnrollmentStatus="On (manual)"
+        mdmEnabledAndConfigured
+        connectedToFleetMdm
+        macDiskEncryptionStatus="verifying"
+        diskEncryptionActionRequired={null}
+        onTurnOnMdm={noop}
+        onTriggerEscrowLinuxKey={noop}
+        diskEncryptionOSSetting={{ status: "verifying", detail: "" }}
+      />
+    );
+
+    expect(screen.queryByText(turnOnMdmExpcetedText)).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(resetNonLinuxDiskEncryptKeyExpectedText)
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(resetNonLinuxDiskEncryptKeyExpectedText)
+    ).not.toBeInTheDocument();
+  });
+  it("renders no banner correctly for a mac without MDM set up", () => {
     // setup so mdm is not enabled and configured.
     render(
       <DeviceUserBanners

--- a/frontend/pages/hosts/details/DeviceUserPage/components/DeviceUserBanners/DeviceUserBanners.tsx
+++ b/frontend/pages/hosts/details/DeviceUserPage/components/DeviceUserBanners/DeviceUserBanners.tsx
@@ -5,7 +5,10 @@ import Button from "components/buttons/Button";
 import { MacDiskEncryptionActionRequired } from "interfaces/host";
 import { IHostBannersBaseProps } from "pages/hosts/details/HostDetailsPage/components/HostDetailsBanners/HostDetailsBanners";
 import CustomLink from "components/CustomLink";
-import { platformSupportsDiskEncryption } from "interfaces/platform";
+import {
+  isDiskEncryptionSupportedLinuxPlatform,
+  platformSupportsDiskEncryption,
+} from "interfaces/platform";
 
 const baseClass = "device-user-banners";
 
@@ -74,8 +77,10 @@ const DeviceUserBanners = ({
     // setting applies to a supported Linux host
     if (
       hostPlatform &&
-      hostPlatform !== "windows" &&
-      platformSupportsDiskEncryption(hostPlatform, hostOsVersion) &&
+      isDiskEncryptionSupportedLinuxPlatform(
+        hostPlatform,
+        hostOsVersion ?? ""
+      ) &&
       diskEncryptionOSSetting?.status
     ) {
       // host not in compliance with setting


### PR DESCRIPTION
**Bug:**
<img width="1399" alt="Screenshot 2024-11-20 at 4 43 19 PM" src="https://github.com/user-attachments/assets/31a3fd0e-3eda-461b-9c56-d4e821f8592f">


**Fixed:**
<img width="1391" alt="Screenshot 2024-11-20 at 4 44 48 PM" src="https://github.com/user-attachments/assets/257b080a-d83e-4317-b3da-91922ed423a0">


- [x] Added/updated tests
- [x] Manual QA for all new/changed functionality
