### PR TITLE
Cherry-Pick: Populate disk encryption status when pulling a host by device auth token

### DIFF
--- a/server/datastore/mysql/hosts.go
+++ b/server/datastore/mysql/hosts.go
@@ -2440,6 +2440,7 @@ func (ds *Datastore) LoadHostByDeviceAuthToken(ctx context.Context, authToken st
       COALESCE(hd.gigs_disk_space_available, 0) as gigs_disk_space_available,
       COALESCE(hd.percent_disk_space_available, 0) as percent_disk_space_available,
       COALESCE(hd.gigs_total_disk_space, 0) as gigs_total_disk_space,
+      hd.encrypted as disk_encryption_enabled,
       IF(hdep.host_id AND ISNULL(hdep.deleted_at), true, false) AS dep_assigned_to_fleet
     FROM
       host_device_auth hda

--- a/server/datastore/mysql/hosts_test.go
+++ b/server/datastore/mysql/hosts_test.go
@@ -6194,6 +6194,17 @@ func testHostsLoadHostByDeviceAuthToken(t *testing.T, ds *Datastore) {
 	require.Equal(t, hSimple.ID, loadSimple.ID)
 	require.True(t, loadSimple.IsOsqueryEnrolled())
 
+	// make sure disk encryption state is reflected
+	require.Nil(t, loadSimple.DiskEncryptionEnabled)
+	require.NoError(t, ds.SetOrUpdateHostDisksEncryption(ctx, hSimple.ID, false))
+	loadSimple, err = ds.LoadHostByDeviceAuthToken(ctx, "simple", time.Second*3)
+	require.NoError(t, err)
+	require.False(t, *loadSimple.DiskEncryptionEnabled)
+	require.NoError(t, ds.SetOrUpdateHostDisksEncryption(ctx, hSimple.ID, true))
+	loadSimple, err = ds.LoadHostByDeviceAuthToken(ctx, "simple", time.Second*3)
+	require.NoError(t, err)
+	require.True(t, *loadSimple.DiskEncryptionEnabled)
+
 	// create a host that will be pending enrollment in Fleet MDM
 	hFleet := createHostWithDeviceToken("fleet")
 	err = ds.SetOrUpdateMDMData(ctx, hFleet.ID, false, false, "https://fleetdm.com", true, fleet.WellKnownMDMFleet, "")


### PR DESCRIPTION
Cherry-pick of #24014, related to #23583