### PR TITLE
Fix Orbit version check in LUKS escrow trigger endpoint

### DIFF
--- a/ee/server/service/devices.go
+++ b/ee/server/service/devices.go
@@ -208,7 +208,13 @@ func (svc *Service) validateReadyForLinuxEscrow(ctx context.Context, host *fleet
 		return &fleet.BadRequestError{Message: "Host's disk is not encrypted. Please enable disk encryption for this host."}
 	}
 
-	if host.OrbitVersion == nil || !fleet.IsAtLeastVersion(*host.OrbitVersion, fleet.MinOrbitLUKSVersion) {
+	// We have to pull Orbit info because the auth context doesn't fill in host.OrbitVersion
+	orbitInfo, err := svc.ds.GetHostOrbitInfo(ctx, host.ID)
+	if err != nil {
+		return err
+	}
+
+	if orbitInfo == nil || !fleet.IsAtLeastVersion(orbitInfo.Version, fleet.MinOrbitLUKSVersion) {
 		return &fleet.BadRequestError{Message: "Host's Orbit version does not support this feature. Please upgrade Orbit to the latest version."}
 	}
 


### PR DESCRIPTION
The host context never includes Orbit version (only the hosts/{id} endpoint does) so we need to grab that data when we need it.

# Checklist for submitter

- [x] Added/updated tests
~~- [ ] Manual QA for all new/changed functionality~~ will be part of E2E QA