### PR TITLE
Drop Orbit version check on LUKS trigger endpoint

### DIFF
--- a/ee/server/service/devices.go
+++ b/ee/server/service/devices.go
@@ -208,15 +208,5 @@ func (svc *Service) validateReadyForLinuxEscrow(ctx context.Context, host *fleet
 		return &fleet.BadRequestError{Message: "Host's disk is not encrypted. Please enable disk encryption for this host."}
 	}
 
-	// We have to pull Orbit info because the auth context doesn't fill in host.OrbitVersion
-	orbitInfo, err := svc.ds.GetHostOrbitInfo(ctx, host.ID)
-	if err != nil {
-		return err
-	}
-
-	if orbitInfo == nil || !fleet.IsAtLeastVersion(orbitInfo.Version, fleet.MinOrbitLUKSVersion) {
-		return &fleet.BadRequestError{Message: "Host's Orbit version does not support this feature. Please upgrade Orbit to the latest version."}
-	}
-
 	return svc.ds.AssertHasNoEncryptionKeyStored(ctx, host.ID)
 }

--- a/server/fleet/service.go
+++ b/server/fleet/service.go
@@ -1179,6 +1179,4 @@ const (
 	BatchSetSoftwareInstallersStatusCompleted = "completed"
 	// BatchSetSoftwareInstallerStatusFailed is the value returned for a failed BatchSetSoftwareInstallers operation.
 	BatchSetSoftwareInstallersStatusFailed = "failed"
-	// MinOrbitLUKSVersion is the earliest version of Orbit that can escrow LUKS passphrases
-	MinOrbitLUKSVersion = "1.36.0"
 )


### PR DESCRIPTION
This avoids a significant waiting period between upgrading to the newest Orbit and being able to request a key escrow. The tradeoff is that an escrow request would be sent to a client that doesn't support it, then no-op, then need to be sent again.

# Checklist for submitter
- [x] Added/updated tests
~~- [ ] Manual QA for all new/changed functionality~~ Will test E2E