### PR TITLE
Website: Update endpoint-ops landing page view action

### DIFF
--- a/website/api/controllers/view-endpoint-ops.js
+++ b/website/api/controllers/view-endpoint-ops.js
@@ -27,11 +27,10 @@ module.exports = {
     // If a purpose query parameter is set, update the pagePersonalization value.
     // Note: This is the only page we're using this method instead of using the primaryBuyingSiutation value set in the users session.
     // This lets us link to the security and IT versions of the endpoint ops page from the unpersonalized homepage without changing the users primaryBuyingSituation.
-    if(this.req.param('purpose') === 'security'){
-      pagePersonalization = 'eo-security';
-    } else {
-      // Default to IT personalization if no primaryBuyingSituation or purpose query parameter is set.
+    if(this.req.param('purpose') === 'it'){
       pagePersonalization = 'eo-it';
+    } else if(this.req.param('purpose') === 'security'){
+      pagePersonalization = 'eo-security';
     }
 
 

--- a/website/api/controllers/view-endpoint-ops.js
+++ b/website/api/controllers/view-endpoint-ops.js
@@ -22,8 +22,8 @@ module.exports = {
     }
     // Get testimonials for the <scrolalble-tweets> component.
     let testimonialsForScrollableTweets = _.clone(sails.config.builtStaticContent.testimonials);
-    // Default the pagePersonalization to the user's primaryBuyingSituation.
-    let pagePersonalization = this.req.session.primaryBuyingSituation;
+    // Default the pagePersonalization to the user's primaryBuyingSituation if it is set, otherwise, default to the eo-it view..
+    let pagePersonalization = this.req.session.primaryBuyingSituation ? this.req.session.primaryBuyingSituation : 'eo-it';
     // If a purpose query parameter is set, update the pagePersonalization value.
     // Note: This is the only page we're using this method instead of using the primaryBuyingSiutation value set in the users session.
     // This lets us link to the security and IT versions of the endpoint ops page from the unpersonalized homepage without changing the users primaryBuyingSituation.


### PR DESCRIPTION
Changes:
- Updated the endpoint ops view action to use the user's primaryBuyingSituation for personalization if it is set, and to default to the IT view if not (Note: this behavior is overridden with a purpose query string. e.g., ?purpose=security.