### PR TITLE
add UI for new windows mdm page and automatic migration

### DIFF
--- a/changes/22896-ui-windows-automatic-migration
+++ b/changes/22896-ui-windows-automatic-migration
@@ -1,0 +1,1 @@
+- add UI changes for windows mdm page and allow for automatic migration for windows hosts.

--- a/frontend/__mocks__/configMock.ts
+++ b/frontend/__mocks__/configMock.ts
@@ -39,6 +39,7 @@ const DEFAULT_CONFIG_MDM_MOCK: IMdmConfig = {
     deadline_days: null,
     grace_period_days: null,
   },
+  windows_migration_enabled: false,
   end_user_authentication: {
     entity_id: "",
     issuer_uri: "",

--- a/frontend/components/forms/fields/Checkbox/_styles.scss
+++ b/frontend/components/forms/fields/Checkbox/_styles.scss
@@ -68,6 +68,7 @@
         }
         .checkbox-unchecked-state {
           stroke: $ui-fleet-black-25;
+          fill: $ui-fleet-black-25;
         }
       }
     }

--- a/frontend/interfaces/config.ts
+++ b/frontend/interfaces/config.ts
@@ -57,6 +57,7 @@ export interface IMdmConfig {
   apple_bm_terms_expired: boolean;
   apple_bm_enabled_and_configured: boolean;
   windows_enabled_and_configured: boolean;
+  windows_migration_enabled: boolean;
   end_user_authentication: IEndUserAuthentication;
   macos_updates: IAppleDeviceUpdates;
   ios_updates: IAppleDeviceUpdates;

--- a/frontend/pages/DashboardPage/cards/MDM/MDM.tsx
+++ b/frontend/pages/DashboardPage/cards/MDM/MDM.tsx
@@ -2,11 +2,7 @@ import React, { useMemo, useState } from "react";
 import { Tab, Tabs, TabList, TabPanel } from "react-tabs";
 import { Row } from "react-table";
 
-import {
-  IMdmStatusCardData,
-  IMdmSolution,
-  IMdmSummaryMdmSolution,
-} from "interfaces/mdm";
+import { IMdmStatusCardData, IMdmSummaryMdmSolution } from "interfaces/mdm";
 
 import TabsWrapper from "components/TabsWrapper";
 import TableContainer from "components/TableContainer";

--- a/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/WindowsMdmPage/WindowsMdmPage.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/WindowsMdmPage/WindowsMdmPage.tsx
@@ -31,6 +31,7 @@ const useSetWindowsMdm = ({
   errorMessage,
   router,
 }: ISetWindowsMdmOptions) => {
+  console.log("hook hit");
   const { setConfig } = useContext(AppContext);
   const { renderFlash } = useContext(NotificationContext);
 
@@ -40,6 +41,7 @@ const useSetWindowsMdm = ({
       const updatedConfig = await configAPI.updateMDMConfig(
         {
           windows_enabled_and_configured: enableMdm,
+          windows_migration_enabled: enableAutoMigration,
         },
         true
       );
@@ -76,30 +78,30 @@ const WindowsMdmPage = ({ router }: IWindowsMdmPageProps) => {
   const [mdmOn, setMdmOn] = useState(
     config?.mdm?.windows_enabled_and_configured ?? false
   );
-  const [automaticMigration, setAutomaticMigration] = useState(false);
+  const [autoMigration, setAutoMigration] = useState(
+    config?.mdm?.windows_migration_enabled ?? false
+  );
 
-  const { turnOnWindowsMdm } = useSetWindowsMdm({
+  const updateWindowsMdm = useSetWindowsMdm({
     enableMdm: mdmOn,
-    enableAutoMigration: automaticMigration,
+    enableAutoMigration: autoMigration,
     successMessage: "Windows MDM settings successfully updated.",
     errorMessage: "Unable to update Windows MDM. Please try again.",
     router,
   });
 
-  // const isWindowsMdmEnabled =
-  //   config?.mdm?.windows_enabled_and_configured ?? false;
-  const migrationEnabled = config?.mdm?.windows_migration_enabled ?? false;
-
   const onChangeMdmOn = () => {
     setMdmOn(!mdmOn);
-    mdmOn && setAutomaticMigration(false);
+    mdmOn && setAutoMigration(false);
   };
 
   const onChangeAutoMigration = () => {
-    setAutomaticMigration(!automaticMigration);
+    setAutoMigration(!autoMigration);
   };
 
-  const onSaveMdm = async () => {};
+  const onSaveMdm = () => {
+    updateWindowsMdm();
+  };
 
   const descriptionText = mdmOn
     ? "Turns on MDM for Windows hosts that enroll to Fleet (excluding servers)."
@@ -124,7 +126,7 @@ const WindowsMdmPage = ({ router }: IWindowsMdmPageProps) => {
           <p>{descriptionText}</p>
           <Checkbox
             disabled={!mdmOn}
-            value={automaticMigration}
+            value={autoMigration}
             onChange={onChangeAutoMigration}
           >
             Automatically migrate hosts connected to another MDM solution

--- a/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/WindowsMdmPage/WindowsMdmPage.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/WindowsMdmPage/WindowsMdmPage.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from "react";
+import React, { useContext, useState } from "react";
 import { InjectedRouter } from "react-router";
 import { isAxiosError } from "axios";
 
@@ -11,18 +11,22 @@ import { AppContext } from "context/app";
 import MainContent from "components/MainContent/MainContent";
 import Button from "components/buttons/Button";
 import BackLink from "components/BackLink/BackLink";
+import Slider from "components/forms/fields/Slider";
+import Checkbox from "components/forms/fields/Checkbox";
 
 const baseClass = "windows-mdm-page";
 
 interface ISetWindowsMdmOptions {
-  enable: boolean;
+  enableMdm: boolean;
+  enableAutoMigration: boolean;
   successMessage: string;
   errorMessage: string;
   router: InjectedRouter;
 }
 
 const useSetWindowsMdm = ({
-  enable,
+  enableMdm,
+  enableAutoMigration,
   successMessage,
   errorMessage,
   router,
@@ -35,13 +39,13 @@ const useSetWindowsMdm = ({
     try {
       const updatedConfig = await configAPI.updateMDMConfig(
         {
-          windows_enabled_and_configured: enable,
+          windows_enabled_and_configured: enableMdm,
         },
         true
       );
       setConfig(updatedConfig);
     } catch (e) {
-      if (enable && isAxiosError(e) && e.response?.status === 422) {
+      if (enableMdm && isAxiosError(e) && e.response?.status === 422) {
         flashErrMsg =
           getErrorReason(e, {
             nameEquals: "mdm.windows_enabled_and_configured",
@@ -62,53 +66,6 @@ const useSetWindowsMdm = ({
   return turnOnWindowsMdm;
 };
 
-interface IWindowsMdmOnContentProps {
-  router: InjectedRouter;
-}
-
-const WindowsMdmOnContent = ({ router }: IWindowsMdmOnContentProps) => {
-  const turnOnWindowsMdm = useSetWindowsMdm({
-    enable: true,
-    successMessage: "Windows MDM turned on (servers excluded).",
-    errorMessage: "Unable to turn on Windows MDM. Please try again.",
-    router,
-  });
-
-  return (
-    <>
-      <h1>Turn on Windows MDM</h1>
-      <p>This will turn MDM on for Windows hosts with fleetd.</p>
-      <p>Hosts connected to another MDM solution won&apos;t be migrated.</p>
-      <p>MDM won&apos;t be turned on for Windows servers.</p>
-      <Button onClick={turnOnWindowsMdm}>Turn on</Button>
-    </>
-  );
-};
-
-interface IWindowsMdmOffContentProps {
-  router: InjectedRouter;
-}
-
-const WindowsMdmOffContent = ({ router }: IWindowsMdmOffContentProps) => {
-  const turnOffWindowsMdm = useSetWindowsMdm({
-    enable: false,
-    successMessage: "Windows MDM turned off.",
-    errorMessage: "Unable to turn off Windows MDM. Please try again.",
-    router,
-  });
-
-  return (
-    <>
-      <h1>Turn off Windows MDM</h1>
-      <p>
-        MDM will no longer be turned on for Windows hosts that enroll to Fleet.
-      </p>
-      <p>Hosts with MDM already turned on will not have MDM removed.</p>
-      <Button onClick={turnOffWindowsMdm}>Turn off MDM</Button>
-    </>
-  );
-};
-
 interface IWindowsMdmPageProps {
   router: InjectedRouter;
 }
@@ -116,8 +73,37 @@ interface IWindowsMdmPageProps {
 const WindowsMdmPage = ({ router }: IWindowsMdmPageProps) => {
   const { config } = useContext(AppContext);
 
-  const isWindowsMdmEnabled =
-    config?.mdm?.windows_enabled_and_configured ?? false;
+  const [mdmOn, setMdmOn] = useState(
+    config?.mdm?.windows_enabled_and_configured ?? false
+  );
+  const [automaticMigration, setAutomaticMigration] = useState(false);
+
+  const { turnOnWindowsMdm } = useSetWindowsMdm({
+    enableMdm: mdmOn,
+    enableAutoMigration: automaticMigration,
+    successMessage: "Windows MDM settings successfully updated.",
+    errorMessage: "Unable to update Windows MDM. Please try again.",
+    router,
+  });
+
+  // const isWindowsMdmEnabled =
+  //   config?.mdm?.windows_enabled_and_configured ?? false;
+  const migrationEnabled = config?.mdm?.windows_migration_enabled ?? false;
+
+  const onChangeMdmOn = () => {
+    setMdmOn(!mdmOn);
+    mdmOn && setAutomaticMigration(false);
+  };
+
+  const onChangeAutoMigration = () => {
+    setAutomaticMigration(!automaticMigration);
+  };
+
+  const onSaveMdm = async () => {};
+
+  const descriptionText = mdmOn
+    ? "Turns on MDM for Windows hosts that enroll to Fleet (excluding servers)."
+    : "Hosts with MDM already turned on will not have MDM removed.";
 
   return (
     <MainContent className={baseClass}>
@@ -127,11 +113,27 @@ const WindowsMdmPage = ({ router }: IWindowsMdmPageProps) => {
           path={PATHS.ADMIN_INTEGRATIONS_MDM}
           className={`${baseClass}__back-to-mdm`}
         />
-        {isWindowsMdmEnabled ? (
-          <WindowsMdmOffContent router={router} />
-        ) : (
-          <WindowsMdmOnContent router={router} />
-        )}
+        <h1>Manage Windows MDM</h1>
+        <form>
+          <Slider
+            value={mdmOn}
+            activeText="Windows MDM on"
+            inactiveText="Windows MDM off"
+            onChange={onChangeMdmOn}
+          />
+          <p>{descriptionText}</p>
+          <Checkbox
+            disabled={!mdmOn}
+            value={automaticMigration}
+            onChange={onChangeAutoMigration}
+          >
+            Automatically migrate hosts connected to another MDM solution
+          </Checkbox>
+
+          <Button variant="brand" onClick={onSaveMdm}>
+            Save
+          </Button>
+        </form>
       </>
     </MainContent>
   );

--- a/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/WindowsMdmPage/WindowsMdmPage.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/WindowsMdmPage/WindowsMdmPage.tsx
@@ -31,7 +31,6 @@ const useSetWindowsMdm = ({
   errorMessage,
   router,
 }: ISetWindowsMdmOptions) => {
-  console.log("hook hit");
   const { setConfig } = useContext(AppContext);
   const { renderFlash } = useContext(NotificationContext);
 

--- a/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/WindowsMdmPage/__styles.scss
+++ b/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/WindowsMdmPage/__styles.scss
@@ -5,12 +5,13 @@
   }
 
   h1 {
-    margin-bottom: $pad-xxlarge;
+    margin-bottom: $pad-large;
     font-size: $x-large;
   }
 
-  p {
-    font-size: $x-small;
-    margin: 0 0 $pad-large;
+  form {
+    display: flex;
+    flex-direction: column;
+    gap: $pad-large;
   }
 }

--- a/frontend/utilities/constants.tsx
+++ b/frontend/utilities/constants.tsx
@@ -340,7 +340,10 @@ export const MDM_STATUS_TOOLTIP: Record<string, string | React.ReactNode> = {
     </span>
   ),
   "On (manual)": (
-    <span>MDM was turned on manually. End users can turn MDM off.</span>
+    <span>
+      MDM was turned on manually (macOS), or hosts were automatically migrated
+      with fleetd (Windows). End users can turn MDM off.
+    </span>
   ),
   Off: undefined, // no tooltip specified
   Pending: (


### PR DESCRIPTION
relates to #22896

Implements the UI for the windows automatic migration.

**new windows mdm page layout with automatic migration checkbox**

![image](https://github.com/user-attachments/assets/2909d6d2-e802-4dec-9c78-0b8f6a4466c0)

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/Committing-Changes.md#changes-files) for more information.
- [ ] Added/updated tests
- [x] Manual QA for all new/changed functionality
