### PR TITLE
linux key escrow progress windows

### DIFF
--- a/orbit/pkg/execuser/execuser.go
+++ b/orbit/pkg/execuser/execuser.go
@@ -2,8 +2,6 @@
 // SYSTEM service on Windows) as the current login user.
 package execuser
 
-import "context"
-
 type eopts struct {
 	env        [][2]string
 	args       [][2]string
@@ -50,15 +48,4 @@ func RunWithOutput(path string, opts ...Option) (output []byte, exitCode int, er
 		fn(&o)
 	}
 	return runWithOutput(path, o)
-}
-
-// RunWithWait runs an application as the current login user and waits for it to finish
-// or to be canceled by the context.  Canceling the context will not return an error.
-// It assumes the caller is running with high privileges (root on UNIX).
-func RunWithWait(ctx context.Context, path string, opts ...Option) error {
-	var o eopts
-	for _, fn := range opts {
-		fn(&o)
-	}
-	return runWithWait(ctx, path, o)
 }

--- a/orbit/pkg/execuser/execuser_darwin.go
+++ b/orbit/pkg/execuser/execuser_darwin.go
@@ -9,6 +9,8 @@ import (
 )
 
 // run uses macOS open command to start application as the current login user.
+// Note that the child process spawns a new process in user space and thus it is not
+// effective to add a context to this function to cancel the child process.
 func run(path string, opts eopts) (lastLogs string, err error) {
 	info, err := os.Stat(path)
 	if err != nil {

--- a/orbit/pkg/execuser/execuser_darwin.go
+++ b/orbit/pkg/execuser/execuser_darwin.go
@@ -1,7 +1,6 @@
 package execuser
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -52,8 +51,4 @@ func run(path string, opts eopts) (lastLogs string, err error) {
 
 func runWithOutput(path string, opts eopts) (output []byte, exitCode int, err error) {
 	return nil, 0, errors.New("not implemented")
-}
-
-func runWithWait(ctx context.Context, path string, opts eopts) error {
-	return errors.New("not implemented")
 }

--- a/orbit/pkg/execuser/execuser_windows.go
+++ b/orbit/pkg/execuser/execuser_windows.go
@@ -6,7 +6,6 @@ package execuser
 // To view what was modified/added, you can use the execuser_windows_diff.sh script.
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -120,10 +119,6 @@ func run(path string, opts eopts) (lastLogs string, err error) {
 
 func runWithOutput(path string, opts eopts) (output []byte, exitCode int, err error) {
 	return nil, 0, errors.New("not implemented")
-}
-
-func runWithWait(ctx context.Context, path string, opts eopts) error {
-	return errors.New("not implemented")
 }
 
 // getCurrentUserSessionId will attempt to resolve

--- a/orbit/pkg/luks/luks_linux.go
+++ b/orbit/pkg/luks/luks_linux.go
@@ -160,6 +160,9 @@ func (lr *LuksRunner) getEscrowKey(ctx context.Context, devicePath string) ([]by
 		Title: infoTitle,
 		Text:  "Key escrow in progress...",
 	})
+	if err != nil {
+		log.Error().Err(err).Msg("failed to show progress dialog")
+	}
 
 	escrowPassphrase, err := generateRandomPassphrase()
 	if err != nil {

--- a/orbit/pkg/luks/luks_linux.go
+++ b/orbit/pkg/luks/luks_linux.go
@@ -28,7 +28,7 @@ const (
 	infoTitle            = "Disk encryption"
 	infoFailedText       = "Failed to escrow key. Please try again later."
 	infoSuccessText      = "Success!  Now, return to your browser window and follow the instructions to verify disk encryption."
-	timeoutMessage       = "Please visit Fleet Desktop > My device and click Create Key"
+	timeoutMessage       = "Please visit Fleet Desktop > My device and click Create key"
 	maxKeySlots          = 8
 	userKeySlot          = 0 // Key slot 0 is assumed to be the location of the user's passphrase
 )

--- a/orbit/pkg/luks/luks_linux.go
+++ b/orbit/pkg/luks/luks_linux.go
@@ -108,6 +108,14 @@ func (lr *LuksRunner) getEscrowKey(ctx context.Context, devicePath string) ([]by
 		return nil, nil, fmt.Errorf("Failed to show passphrase entry prompt: %w", err)
 	}
 
+	err = lr.notifier.ShowProgress(ctx, dialog.ProgressOptions{
+		Title: infoSuccessText,
+		Text:  "Validating passphrase...",
+	})
+	if err != nil {
+		log.Error().Err(err).Msg("failed to show progress dialog")
+	}
+
 	// Validate the passphrase
 	for {
 		valid, err := lr.passphraseIsValid(ctx, device, devicePath, passphrase, userKeySlot)
@@ -123,12 +131,25 @@ func (lr *LuksRunner) getEscrowKey(ctx context.Context, devicePath string) ([]by
 		if err != nil {
 			return nil, nil, fmt.Errorf("Failed re-prompting for passphrase: %w", err)
 		}
+
+		err = lr.notifier.ShowProgress(ctx, dialog.ProgressOptions{
+			Title: infoSuccessText,
+			Text:  "Validating passphrase...",
+		})
+		if err != nil {
+			log.Error().Err(err).Msg("failed to show progress dialog after retry")
+		}
 	}
 
 	if len(passphrase) == 0 {
 		log.Debug().Msg("Passphrase is empty, no password supplied, dialog was canceled, or timed out")
 		return nil, nil, nil
 	}
+
+	err = lr.notifier.ShowProgress(ctx, dialog.ProgressOptions{
+		Title: infoSuccessText,
+		Text:  "Escrowing key...",
+	})
 
 	escrowPassphrase, err := generateRandomPassphrase()
 	if err != nil {

--- a/orbit/pkg/zenity/zenity.go
+++ b/orbit/pkg/zenity/zenity.go
@@ -55,9 +55,9 @@ func (z *Zenity) ShowEntry(ctx context.Context, opts dialog.EntryOptions) ([]byt
 	if err != nil {
 		switch statusCode {
 		case 1:
-			return nil, ctxerr.Wrap(ctx, dialog.ErrCanceled)
+			return nil, dialog.ErrCanceled
 		case 5:
-			return nil, ctxerr.Wrap(ctx, dialog.ErrTimeout)
+			return nil, dialog.ErrTimeout
 		default:
 			return nil, ctxerr.Wrap(ctx, dialog.ErrUnknown, err.Error())
 		}

--- a/orbit/pkg/zenity/zenity_test.go
+++ b/orbit/pkg/zenity/zenity_test.go
@@ -76,7 +76,8 @@ func TestShowEntryArgs(t *testing.T) {
 				output: []byte("some output"),
 			}
 			z := &Zenity{
-				cmdWithOutput: mock.runWithOutput,
+				cmdWithOutput:  mock.runWithOutput,
+				killZenityFunc: func() {},
 			}
 			output, err := z.ShowEntry(ctx, tt.opts)
 			assert.NoError(t, err)
@@ -117,7 +118,8 @@ func TestShowEntryError(t *testing.T) {
 				exitCode: tt.exitCode,
 			}
 			z := &Zenity{
-				cmdWithOutput: mock.runWithOutput,
+				cmdWithOutput:  mock.runWithOutput,
+				killZenityFunc: func() {},
 			}
 			output, err := z.ShowEntry(ctx, dialog.EntryOptions{})
 			require.ErrorIs(t, err, tt.expectedErr)
@@ -133,7 +135,8 @@ func TestShowEntrySuccess(t *testing.T) {
 		output: []byte("some output"),
 	}
 	z := &Zenity{
-		cmdWithOutput: mock.runWithOutput,
+		cmdWithOutput:  mock.runWithOutput,
+		killZenityFunc: func() {},
 	}
 	output, err := z.ShowEntry(ctx, dialog.EntryOptions{})
 	assert.NoError(t, err)
@@ -168,7 +171,8 @@ func TestShowInfoArgs(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			mock := &mockExecCmd{}
 			z := &Zenity{
-				cmdWithOutput: mock.runWithOutput,
+				cmdWithOutput:  mock.runWithOutput,
+				killZenityFunc: func() {},
 			}
 			err := z.ShowInfo(ctx, tt.opts)
 			assert.NoError(t, err)
@@ -203,7 +207,8 @@ func TestShowInfoError(t *testing.T) {
 				exitCode: tt.exitCode,
 			}
 			z := &Zenity{
-				cmdWithOutput: mock.runWithOutput,
+				cmdWithOutput:  mock.runWithOutput,
+				killZenityFunc: func() {},
 			}
 			err := z.ShowInfo(ctx, dialog.InfoOptions{})
 			require.ErrorIs(t, err, tt.expectedErr)
@@ -233,7 +238,8 @@ func TestProgressArgs(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			mock := &mockExecCmd{}
 			z := &Zenity{
-				cmdWithWait: mock.runWithWait,
+				cmdWithWait:    mock.runWithWait,
+				killZenityFunc: func() {},
 			}
 			err := z.ShowProgress(ctx, tt.opts)
 			assert.NoError(t, err)
@@ -249,7 +255,8 @@ func TestProgressKillOnCancel(t *testing.T) {
 		waitDuration: 5 * time.Second,
 	}
 	z := &Zenity{
-		cmdWithWait: mock.runWithWait,
+		cmdWithWait:    mock.runWithWait,
+		killZenityFunc: func() {},
 	}
 
 	done := make(chan struct{})


### PR DESCRIPTION
#24013 

Adding progress windows to key escrow process during passphrase validation and key escrow.   Because of how we launch user processes as root (`execuser.Run`), to kill a progress window (runs until killed) we cannot simply cancel the context or `cmd.Process.Kill()`.  This PR takes a brute force approach by killing all `zenity` processes.  Also attempted limiting the kill scope by only killing child processes of orbit, but the `zenity` user process does not show up as a child process after launched.  `ps aux` shows 2 zenity processes: 1 as sudo, the other as a zenity process in user space.

Also included are some bug and copy fixes to the user prompts.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [ ] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/Committing-Changes.md#changes-files) for more information.
- [ ] Added/updated tests
- [X] Manual QA for all new/changed functionality
- For Orbit and Fleet Desktop changes:
   - [X] Orbit runs on macOS, Linux and Windows. Check if the orbit feature/bugfix should only apply to one platform (`runtime.GOOS`).
   - [ ] Manual QA must be performed in the three main OSs, macOS, Windows and Linux.
   - [ ] Auto-update manual QA, from released version of component to new version (see [tools/tuf/test](../tools/tuf/test/README.md)).
