### PR TITLE
Enforce macOS 15.1.1

### DIFF
--- a/it-and-security/teams/workstations-canary.yml
+++ b/it-and-security/teams/workstations-canary.yml
@@ -92,7 +92,7 @@ controls:
     enable_end_user_authentication: true
     macos_setup_assistant: null
   macos_updates:
-    deadline: "2024-12-2"
+    deadline: "2024-12-02"
     minimum_version: "15.1.1"
   windows_settings:
     custom_settings:

--- a/it-and-security/teams/workstations-canary.yml
+++ b/it-and-security/teams/workstations-canary.yml
@@ -92,8 +92,8 @@ controls:
     enable_end_user_authentication: true
     macos_setup_assistant: null
   macos_updates:
-    deadline: "2024-08-23"
-    minimum_version: "14.6.1"
+    deadline: "2024-12-2"
+    minimum_version: "15.1.1"
   windows_settings:
     custom_settings:
       - path: ../lib/configuration-profiles/windows-firewall.xml

--- a/it-and-security/teams/workstations.yml
+++ b/it-and-security/teams/workstations.yml
@@ -62,7 +62,7 @@ controls:
     macos_setup_assistant: null
   macos_updates:
     deadline: "2024-08-23"
-    minimum_version: "14.6.1"
+    minimum_version: "15.1.1"
   windows_settings:
     custom_settings: null
   windows_updates:

--- a/it-and-security/teams/workstations.yml
+++ b/it-and-security/teams/workstations.yml
@@ -61,7 +61,7 @@ controls:
     enable_end_user_authentication: true
     macos_setup_assistant: null
   macos_updates:
-    deadline: "2024-08-23"
+    deadline: "2024-12-02"
     minimum_version: "15.1.1"
   windows_settings:
     custom_settings: null


### PR DESCRIPTION
Deadline is Monday after 🦃 Thanksgiving (US holiday)

For the "Dogfood OS updates (DDM feature)" issue: fleetdm/confidential#8369
