### PR TITLE
Fleet UI: Add more description to delete host modal

### DIFF
--- a/changes/22819-delete-modal
+++ b/changes/22819-delete-modal
@@ -1,0 +1,1 @@
+- Fleet UI: Better information on what deleting a host does

--- a/frontend/pages/hosts/components/DeleteHostModal/DeleteHostModal.tsx
+++ b/frontend/pages/hosts/components/DeleteHostModal/DeleteHostModal.tsx
@@ -4,6 +4,8 @@ import strUtils from "utilities/strings";
 
 import Modal from "components/Modal";
 import Button from "components/buttons/Button";
+import CustomLink from "components/CustomLink";
+import { LEARN_MORE_ABOUT_BASE_LINK } from "utilities/constants";
 
 const baseClass = "delete-host-modal";
 
@@ -63,6 +65,19 @@ const DeleteHostModal = ({
         <p>
           This will remove the record of <b>{hostText()}</b>.{largeVolumeText()}
         </p>
+        <ul>
+          <li>
+            macOS, Windows, or Linux hosts will re-appear unless Fleet&apos;s
+            agent is uninstalled.{" "}
+            <CustomLink
+              text="Uninstall Fleet's agent"
+              url={`${LEARN_MORE_ABOUT_BASE_LINK}/uninstall-fleetd`}
+              newTab
+            />
+          </li>
+          <li>iOS and iPadOS hosts will re-appear unless MDM is turned off.</li>
+          <li>If the host is locked, this will also delete any unlock PINs.</li>
+        </ul>
         <div className="modal-cta-wrap">
           <Button
             type="button"

--- a/frontend/pages/hosts/components/DeleteHostModal/DeleteHostModal.tsx
+++ b/frontend/pages/hosts/components/DeleteHostModal/DeleteHostModal.tsx
@@ -63,7 +63,8 @@ const DeleteHostModal = ({
     <Modal title="Delete host" onExit={onCancel} className={baseClass}>
       <>
         <p>
-          This will remove the record of <b>{hostText()}</b>.{largeVolumeText()}
+          This will remove the record of <b>{hostText()}</b> and associated data
+          (e.g. unlock PINs).{largeVolumeText()}
         </p>
         <ul>
           <li>
@@ -76,7 +77,6 @@ const DeleteHostModal = ({
             />
           </li>
           <li>iOS and iPadOS hosts will re-appear unless MDM is turned off.</li>
-          <li>If the host is locked, this will also delete any unlock PINs.</li>
         </ul>
         <div className="modal-cta-wrap">
           <Button

--- a/frontend/pages/hosts/components/DeleteHostModal/_styles.scss
+++ b/frontend/pages/hosts/components/DeleteHostModal/_styles.scss
@@ -5,6 +5,6 @@
     align-items: flex-start;
     gap: $pad-medium;
     align-self: stretch;
-    padding-inline-start: $padding-large;
+    padding-inline-start: $pad-large;
   }
 }

--- a/frontend/pages/hosts/components/DeleteHostModal/_styles.scss
+++ b/frontend/pages/hosts/components/DeleteHostModal/_styles.scss
@@ -1,0 +1,10 @@
+.delete-host-modal {
+  ul {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: $pad-medium;
+    align-self: stretch;
+    padding-inline-start: $padding-large;
+  }
+}


### PR DESCRIPTION
## Issue
Cerra #23244 

## Description
- Add description to delete host modal

## Screenshot

<img width="805" alt="Screenshot 2024-11-22 at 2 58 49 PM" src="https://github.com/user-attachments/assets/82f41bfb-dc7c-4496-82bb-6cd6f4f6e123">


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/Committing-Changes.md#changes-files) for more information.
- [x] Manual QA for all new/changed functionality
