### PR TITLE
Fleet UI: Fix learn more about JIT provisioning link

### DIFF
--- a/changes/23749-fix-learn-more-link
+++ b/changes/23749-fix-learn-more-link
@@ -1,0 +1,1 @@
+- Fleet UI: Fix learn more about JIT provisioning link

--- a/frontend/pages/admin/OrgSettingsPage/cards/Sso/Sso.tsx
+++ b/frontend/pages/admin/OrgSettingsPage/cards/Sso/Sso.tsx
@@ -209,15 +209,18 @@ const Sso = ({
               name="enableJitProvisioning"
               value={enableJitProvisioning}
               parseTarget
+              helpText={
+                <>
+                  <CustomLink
+                    url="https://fleetdm.com/learn-more-about/just-in-time-provisioning"
+                    text="Learn more"
+                    newTab
+                  />{" "}
+                  about just-in-time (JIT) user provisioning.
+                </>
+              }
             >
-              <>
-                Create user and sync permissions on login{" "}
-                <CustomLink
-                  url="https://fleetdm.com/learn-more-about/just-in-time-provisioning"
-                  text="Learn more"
-                  newTab
-                />
-              </>
+              Create user and sync permissions on login
             </Checkbox>
           )}
           <Button

--- a/frontend/pages/admin/OrgSettingsPage/cards/Sso/Sso.tsx
+++ b/frontend/pages/admin/OrgSettingsPage/cards/Sso/Sso.tsx
@@ -8,6 +8,7 @@ import InputField from "components/forms/fields/InputField";
 import validUrl from "components/forms/validators/valid_url";
 import SectionHeader from "components/SectionHeader";
 
+import { LEARN_MORE_ABOUT_BASE_LINK } from "utilities/constants";
 import { IAppConfigFormProps, IFormField } from "../constants";
 
 const baseClass = "app-config-form";
@@ -212,7 +213,7 @@ const Sso = ({
               helpText={
                 <>
                   <CustomLink
-                    url="https://fleetdm.com/learn-more-about/just-in-time-provisioning"
+                    url={`${LEARN_MORE_ABOUT_BASE_LINK}/just-in-time-provisioning`}
                     text="Learn more"
                     newTab
                   />{" "}


### PR DESCRIPTION
## Issue
Cerra #23749 

## Description
- Move link outside of checkbox label which is clickable to check the checkbox
- Now link is in help text, making it clickable

## Screenshot
<img width="903" alt="Screenshot 2024-11-22 at 1 23 59 PM" src="https://github.com/user-attachments/assets/f24ec7da-c125-41c2-b1a6-52eed8cdd3a0">

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/Committing-Changes.md#changes-files) for more information.
- [x] Manual QA for all new/changed functionality