### PR TITLE
github cli false negative vulnerability

### DIFF
--- a/changes/24009-gh-translation
+++ b/changes/24009-gh-translation
@@ -1,0 +1,1 @@
+* Fixed an issue where the github cli software name was not matching against the cpe vulnerability name

--- a/server/vulnerabilities/nvd/cpe_test.go
+++ b/server/vulnerabilities/nvd/cpe_test.go
@@ -1663,6 +1663,24 @@ func TestCPEFromSoftwareIntegration(t *testing.T) {
 			},
 			cpe: "cpe:2.3:a:oracle:virtualbox:7.0.12:*:*:*:*:macos:*:*",
 		},
+		{
+			software: fleet.Software{
+				Name:             "gh",
+				Source:           "deb_packages",
+				Version:          "2.61.0",
+				Vendor:           "",
+				BundleIdentifier: "",
+			}, cpe: "cpe:2.3:a:github:cli:2.61.0:*:*:*:*:*:*:*",
+		},
+		{
+			software: fleet.Software{
+				Name:             "gh",
+				Source:           "homebrew_packages",
+				Version:          "2.61.0",
+				Vendor:           "",
+				BundleIdentifier: "",
+			}, cpe: "cpe:2.3:a:github:cli:2.61.0:*:*:*:*:macos:*:*",
+		},
 	}
 
 	// NVD_TEST_CPEDB_PATH can be used to speed up development (sync cpe.sqlite only once).

--- a/server/vulnerabilities/nvd/cpe_translations.json
+++ b/server/vulnerabilities/nvd/cpe_translations.json
@@ -426,5 +426,14 @@
       "product": ["virtualbox"],
       "vendor": ["oracle"]
     }
+  },
+  {
+    "software": {
+      "name": ["gh"]
+    },
+    "filter": {
+      "product": ["cli"],
+      "vendor": ["github"]
+    }
   }
 ]


### PR DESCRIPTION
Added a cpe translation for the `gh` command. The software is identified as `gh`, however, the cpe (`cpe:2.3:a:github:cli:2.62.0:*:*:*:*:*:*:*`) name is labeled as `cli`, thus the mismatch.

https://github.com/fleetdm/fleet/issues/24009

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/Committing-Changes.md#changes-files) for more information.
- [x] Added/updated tests
- [x] Manual QA for all new/changed functionality