### PR TITLE
Enable macOS Setup Experience for Workstations team

### DIFF
--- a/it-and-security/lib/automatic-enrollment.dep.json
+++ b/it-and-security/lib/automatic-enrollment.dep.json
@@ -6,11 +6,8 @@
 	"language": "en",
 	"region": "US",
 	"skip_setup_items": [
-		"Accessibility",
-		"Appearance",
 		"AppleID",
 		"AppStore",
-		"Biometric",
 		"Diagnostics",
 		"FileVault",
 		"iCloudDiagnostics",

--- a/it-and-security/lib/software/mac-google-chrome.yml
+++ b/it-and-security/lib/software/mac-google-chrome.yml
@@ -1,0 +1,2 @@
+url: https://dl.google.com/chrome/mac/stable/accept_tos%3Dhttps%253A%252F%252Fwww.google.com%252Fintl%252Fen_ph%252Fchrome%252Fterms%252F%26_and_accept_tos%3Dhttps%253A%252F%252Fpolicies.google.com%252Fterms/googlechrome.pkg
+self_service: true

--- a/it-and-security/lib/software/mac-zoom-arm.yml
+++ b/it-and-security/lib/software/mac-zoom-arm.yml
@@ -1,0 +1,4 @@
+url: https://zoom.us/client/latest/Zoom.pkg?archType=arm64
+pre_install_query:
+  path: ../lib/macos-check-if-apple-silicon.queries.yml
+self_service: true

--- a/it-and-security/teams/workstations.yml
+++ b/it-and-security/teams/workstations.yml
@@ -59,7 +59,7 @@ controls:
   macos_setup:
     bootstrap_package: ""
     enable_end_user_authentication: true
-    macos_setup_assistant: null
+    macos_setup_assistant: ../lib/automatic-enrollment.dep.json
     software:
       - package_path: ../lib/software/mac-google-chrome.yml # Google Chrome for macOS
       - package_path: ../lib/software/mac-zoom-arm.yml # Zoom for macOS

--- a/it-and-security/teams/workstations.yml
+++ b/it-and-security/teams/workstations.yml
@@ -60,6 +60,11 @@ controls:
     bootstrap_package: ""
     enable_end_user_authentication: true
     macos_setup_assistant: null
+    software:
+      - package_path: ../lib/software/mac-google-chrome.yml # Google Chrome for macOS
+      - package_path: ../lib/software/mac-zoom-arm.yml # Zoom for macOS
+      - app_store_id: '803453959' # Slack Desktop
+      - app_store_id: '1333542190' # 1Password 7 Desktop
   macos_updates:
     deadline: "2024-12-02"
     minimum_version: "15.1.1"
@@ -101,12 +106,8 @@ queries:
     observer_can_run: true
 software:
   packages:
-    - url: https://zoom.us/client/latest/Zoom.pkg?archType=arm64
-      pre_install_query:
-        path: ../lib/macos-check-if-apple-silicon.queries.yml
-      self_service: true
-    - url: https://dl.google.com/chrome/mac/stable/accept_tos%3Dhttps%253A%252F%252Fwww.google.com%252Fintl%252Fen_ph%252Fchrome%252Fterms%252F%26_and_accept_tos%3Dhttps%253A%252F%252Fpolicies.google.com%252Fterms/googlechrome.pkg
-      self_service: true
+    - path: ../lib/software/mac-zoom-arm.yml # Zoom for macOS
+    - path: ../lib/software/mac-google-chrome.yml # Google Chrome for macOS
   app_store_apps:
     - app_store_id: '803453959' # Slack Desktop
     - app_store_id: '1333542190' # 1Password 7 Desktop


### PR DESCRIPTION
In support of: https://github.com/fleetdm/confidential/issues/8790

I made the following changes to support the macOS Setup Experience in `dogfood` for the Workstations team
- moved Software titles to their own dedicated folder and `yml` files so they could be called via path
- edited the `macos_setup` configuration in the Workstations team yml file.
- edited the `macos_setup_assistant` json file to skip certain items during initial setup
- completed a `dry-run` successfully before submitting this pull request 

# Expected behavior
When an ADE Mac boots for the first time, macOS Setup Experience will automatically install Google Chrome, Zoom, Slack, and 1Password. 

- Google Chrome will be downloaded via URL
- Zoom will be downloaded via URL
- Slack will be downloaded via VPP
- 1Password will be downloaded via VPP

No scripts have been included at this time and will be tracked in a separate issue. 
