### PR TITLE
Fixed broken link in Deploy/README.md

### DIFF
--- a/docs/Deploy/README.md
+++ b/docs/Deploy/README.md
@@ -12,7 +12,7 @@ Includes a guide for how to update and run new versions of Fleet.
 ### [Reference architecture](./reference-architectures.md)
 An opinionated view of running Fleet in a production environment, and configuration strategies to enable high availability.
 
-### [Monitoring Fleet](./monitoring-fleet.md)
+### [Monitoring Fleet](./reference-architectures.md#monitoring-fleet)
 Learn about monitoring and scaling Fleet servers with health checks, metrics, and alerting
 
 ### [Deploying to Cloud.gov](./cloudgov.md)


### PR DESCRIPTION
A `monitoring-fleet.md` file does not seem to exist. Pointed the link to the `Reference-Architectures.md` Monitoring Fleet section.
