### PR TITLE
Fleet UI: 4.60 unreleased bug fix for scrollable content

### DIFF
--- a/frontend/components/Modal/_styles.scss
+++ b/frontend/components/Modal/_styles.scss
@@ -25,7 +25,7 @@
   &__content-wrapper {
     margin-top: $pad-large;
     font-size: $x-small;
-    max-height: 800px;
+    // New pattern of max height modals pushed to 4.61 with PR #24019
     overflow: visible;
 
     .input-field {


### PR DESCRIPTION
## Issue
Cerra #24137 

## Description
- Setting a `max-height` without `overflow-y: hidden` caused bug
- Since we removed `overflow-y: hidden` in because of another bug #23889, we need to remove `max-height` until a proper fix that fixes both is in

### Note
Stickiness which was a spec of #22446 ([see figma](https://www.figma.com/design/ntZEvtVGj5eKEE4CGx5KU5/%2322446-Host-details-and-Scripts-page%3A-view-script%C2%A0?node-id=5331-3186&node-type=instance&t=2BBSWLGzeoGeqIvC-0)) will now be pushed to 4.61 and merged with #22078 which also has new sticky pattern

## Screenshot of fix
### Fix
<img width="714" alt="Screenshot 2024-11-25 at 3 31 57 PM" src="https://github.com/user-attachments/assets/95639125-afa1-4a43-b8b2-3b3782cf2bc8">

### Other modals to check look good

https://github.com/user-attachments/assets/0229013c-20cb-49fe-9a16-b1b476be93c7



# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Manual QA for all new/changed functionality

