### PR TITLE
UI - Fix DUP banners for Fedora disk encryption

### DIFF
--- a/frontend/pages/hosts/details/DeviceUserPage/DeviceUserPage.tsx
+++ b/frontend/pages/hosts/details/DeviceUserPage/DeviceUserPage.tsx
@@ -371,6 +371,7 @@ const DeviceUserPage = ({
           <div className={`${baseClass} main-content`}>
             <DeviceUserBanners
               hostPlatform={host.platform}
+              hostOsVersion={host.os_version}
               mdmEnrollmentStatus={host.mdm.enrollment_status}
               mdmEnabledAndConfigured={
                 !!globalConfig?.mdm.enabled_and_configured

--- a/frontend/pages/hosts/details/DeviceUserPage/components/DeviceUserBanners/DeviceUserBanners.tsx
+++ b/frontend/pages/hosts/details/DeviceUserPage/components/DeviceUserBanners/DeviceUserBanners.tsx
@@ -5,10 +5,7 @@ import Button from "components/buttons/Button";
 import { MacDiskEncryptionActionRequired } from "interfaces/host";
 import { IHostBannersBaseProps } from "pages/hosts/details/HostDetailsPage/components/HostDetailsBanners/HostDetailsBanners";
 import CustomLink from "components/CustomLink";
-import {
-  isDiskEncryptionSupportedLinuxPlatform,
-  platformSupportsDiskEncryption,
-} from "interfaces/platform";
+import { isDiskEncryptionSupportedLinuxPlatform } from "interfaces/platform";
 
 const baseClass = "device-user-banners";
 


### PR DESCRIPTION
## Addresses unreleased bug where banners were not functioning for Fedora host

<img width="1464" alt="Screenshot 2024-11-25 at 4 39 05 PM" src="https://github.com/user-attachments/assets/78c3adee-ff45-4236-b1b1-299d79575cb6">


- [x] Manual QA for all new/changed functionality