### PR TITLE
Allow clicking through handbook back-to-top button container

### DIFF
--- a/website/assets/styles/pages/handbook/basic-handbook.less
+++ b/website/assets/styles/pages/handbook/basic-handbook.less
@@ -580,6 +580,7 @@
       position: sticky;
       bottom: 107px;
       overflow-x: hidden;
+      pointer-events: none;
     }
     [purpose='back-to-top-button'] {
       display: inline-block;
@@ -593,6 +594,7 @@
       cursor: pointer;
       border: 1px solid #E2E4EA;
       border-radius: 16px 0px 0px 16px;
+      pointer-events: auto;
       p {
         color: #515774;
         font-size: 11px;


### PR DESCRIPTION
This fix was already applied to the button on the docs pages, but not the handbook.