### PR TITLE
Bump retries/timeouts for NVD pulls

### DIFF
--- a/cmd/cpe/generate.go
+++ b/cmd/cpe/generate.go
@@ -22,10 +22,10 @@ import (
 )
 
 const (
-	httpClientTimeout       = 2 * time.Minute
+	httpClientTimeout       = 3 * time.Minute
 	waitTimeBetweenRequests = 6 * time.Second
-	waitTimeForRetry        = 30 * time.Second
-	maxRetryAttempts        = 10
+	waitTimeForRetry        = 10 * time.Second
+	maxRetryAttempts        = 20
 	apiKeyEnvVar            = "NVD_API_KEY" //nolint:gosec
 )
 


### PR DESCRIPTION
For #24132

Drops retry wait a bit as there doesn't seem to be a point in waiting that long (I pulled feeds with a 10s retry interval in curl earlier).

Total time to pull feeds and build the CPE DB was ~4 hours this evening (~6pm to ~10pm CST).

# Checklist for submitter

- [x] Manual QA for all new/changed functionality