### PR TITLE
Fleet UI: Ability to clear webhook address and still disable policy automation

### DIFF
--- a/changes/24093-clear-policy-automation
+++ b/changes/24093-clear-policy-automation
@@ -1,0 +1,1 @@
+- Fleet UI: Fix ability to clear policy automation that empties webhook URL

--- a/frontend/pages/policies/ManagePoliciesPage/components/OtherWorkflowsModal/OtherWorkflowsModal.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/components/OtherWorkflowsModal/OtherWorkflowsModal.tsx
@@ -196,7 +196,7 @@ const OtherWorkflowsModal = ({
       delete newErrors.integration;
     }
 
-    if (isWebhookEnabled) {
+    if (isPolicyAutomationsEnabled && isWebhookEnabled) {
       if (!destinationUrl) {
         newErrors.url = "Please add a destination URL";
       } else if (!validUrl({ url: destinationUrl })) {

--- a/frontend/pages/policies/ManagePoliciesPage/components/OtherWorkflowsModal/OtherWorkflowsModal.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/components/OtherWorkflowsModal/OtherWorkflowsModal.tsx
@@ -185,24 +185,23 @@ const OtherWorkflowsModal = ({
 
     const newErrors = { ...errors };
 
-    if (
-      isPolicyAutomationsEnabled &&
-      newPolicyIds.length &&
-      !isWebhookEnabled &&
-      !selectedIntegration
-    ) {
-      newErrors.integration = "Please enable at least one integration:";
-    } else {
-      delete newErrors.integration;
-    }
-
-    if (isPolicyAutomationsEnabled && isWebhookEnabled) {
-      if (!destinationUrl) {
-        newErrors.url = "Please add a destination URL";
-      } else if (!validUrl({ url: destinationUrl })) {
-        newErrors.url = `${destinationUrl} is not a valid URL`;
+    if (isPolicyAutomationsEnabled) {
+      // Ticket workflow validation
+      if (newPolicyIds.length && !isWebhookEnabled && !selectedIntegration) {
+        newErrors.integration = "Please enable at least one integration:";
       } else {
-        delete newErrors.url;
+        delete newErrors.integration;
+      }
+
+      // Webhook workflow validation
+      if (isWebhookEnabled) {
+        if (!destinationUrl) {
+          newErrors.url = "Please add a destination URL";
+        } else if (!validUrl({ url: destinationUrl })) {
+          newErrors.url = `${destinationUrl} is not a valid URL`;
+        } else {
+          delete newErrors.url;
+        }
       }
     }
 


### PR DESCRIPTION
## Issue
Cerra #24093 

## Description
- Clearing a webhook address gave users a form error when trying to save, however, if the webhook is disabled, it should still allow saving the form
- Fix to allow disabling automations after a webhook address has been removed

## Screenshot of section fixed
<img width="1661" alt="Screenshot 2024-11-26 at 9 01 03 AM" src="https://github.com/user-attachments/assets/e9e88ccd-e308-4abf-bf5e-03b9e9f7f56a">


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
- [x] Manual QA for all new/changed functionality

