### PR TITLE
Update API docs for MFA support

### DIFF
--- a/docs/Contributing/API-for-contributors.md
+++ b/docs/Contributing/API-for-contributors.md
@@ -21,7 +21,7 @@ If you are interested in gathering information from Fleet in a production enviro
 
 ## Authentication
 
-### Create Session
+### Create session
 
 `POST /api/v1/fleet/sessions`
 

--- a/docs/Contributing/API-for-contributors.md
+++ b/docs/Contributing/API-for-contributors.md
@@ -1,5 +1,6 @@
 # API for contributors
 
+- [Authentication](#authentication)
 - [Packs](#packs)
 - [Mobile device management (MDM)](#mobile-device-management-mdm)
 - [Get or apply configuration files](#get-or-apply-configuration-files)
@@ -17,6 +18,22 @@
 This document includes the internal Fleet API routes that are helpful when developing or contributing to Fleet.
 
 If you are interested in gathering information from Fleet in a production environment, please see the [public Fleet REST API documentation](https://fleetdm.com/docs/using-fleet/rest-api).
+
+## Authentication
+
+### Create Session
+
+`POST /api/v1/fleet/sessions`
+
+#### Parameters
+
+| Name | Type | In | Description |
+| token | string | body | **Required**. The token retrieved from the magic link email. |
+
+#### Response
+
+See [the Log in endpoint](https://fleetdm.com/docs/rest-api/rest-api#log-in) for the current
+successful response format.
 
 ## Packs
 

--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -48,7 +48,7 @@ Then, use that API token to authenticate all subsequent API requests by sending 
 Authorization: Bearer <your token>
 ```
 
-> For SSO users, email/password login is disabled. The API token can instead be retrieved from the "My account" page in the UI (/profile). On this page, choose "Get API token".
+> For SSO and MFA users, email/password login is disabled. The API token can instead be retrieved from the "My account" page in the UI (/profile). On this page, choose "Get API token".
 
 ### Log in
 
@@ -56,7 +56,13 @@ Authenticates the user with the specified credentials. Use the token returned fr
 
 `POST /api/v1/fleet/login`
 
-> This API endpoint is not available to SSO users, since email/password login is disabled for SSO users. To get an API token for an SSO user, you can use the Fleet UI.
+> This API endpoint is not available to SSO users, since email/password login is disabled for SSO
+> users. To get an API token for an SSO user, you can use the Fleet UI.
+
+> While this endpoint is used by the Fleet UI to log users in with MFA (via email verification)
+> enabled (by setting the `supports_email_verification` body paramter to `true`), clients other than
+> the Fleet UI won't be able to finish the MFA process. Users with MFA, similar to SSO users, should
+> log into the Fleet UI and retrieve an API token from there instead of using the login endpoint.
 
 #### Parameters
 

--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -100,6 +100,7 @@ Authenticates the user with the specified credentials. Use the token returned fr
     "force_password_reset": false,
     "gravatar_url": "",
     "sso_enabled": false,
+    "mfa_enabled": false,
     "global_role": "admin",
     "teams": []
   },
@@ -11287,8 +11288,6 @@ Creates a user account after an invited user provides registration information a
 | name                  | string | body | **Required**. The name of the user.                                                                                                                                                                                                                                                                                                                      |
 | password              | string | body | The password chosen by the user (if not SSO user).                                                                                                                                                                                                                                                                                                       |
 | password_confirmation | string | body | Confirmation of the password chosen by the user.                                                                                                                                                                                                                                                                                                         |
-| global_role           | string | body | The role assigned to the user. In Fleet 4.0.0, 3 user roles were introduced (`admin`, `maintainer`, and `observer`). In Fleet 4.30.0 and 4.31.0, the `observer_plus` and `gitops` roles were introduced respectively. If `global_role` is specified, `teams` cannot be specified. For more information, see [manage access](https://fleetdm.com/docs/using-fleet/manage-access).                                                                                                                                                                        |
-| teams                 | array  | body | _Available in Fleet Premium_. The teams and respective roles assigned to the user. Should contain an array of objects in which each object includes the team's `id` and the user's `role` on each team. In Fleet 4.0.0, 3 user roles were introduced (`admin`, `maintainer`, and `observer`). In Fleet 4.30.0 and 4.31.0, the `observer_plus` and `gitops` roles were introduced respectively. If `teams` is specified, `global_role` cannot be specified. For more information, see [manage access](https://fleetdm.com/docs/using-fleet/manage-access). |
 
 #### Example
 
@@ -11302,17 +11301,7 @@ Creates a user account after an invited user provides registration information a
   "invite_token": "SjdReDNuZW5jd3dCbTJtQTQ5WjJTc2txWWlEcGpiM3c=",
   "name": "janedoe",
   "password": "test-123",
-  "password_confirmation": "test-123",
-  "teams": [
-    {
-      "id": 2,
-      "role": "observer"
-    },
-    {
-      "id": 4,
-      "role": "observer"
-    }
-  ]
+  "password_confirmation": "test-123"
 }
 ```
 
@@ -11404,6 +11393,7 @@ By default, the user will be forced to reset its password upon first login.
 | name        | string  | body | **Required**. The user's full name or nickname.                                                                                                                                                                                                                                                                                                          |
 | password    | string  | body | The user's password (required for non-SSO users).                                                                                                                                                                                                                                                                                                        |
 | sso_enabled | boolean | body | Whether or not SSO is enabled for the user.                                                                                                                                                                                                                                                                                                              |
+| mfa_enabled | boolean | body | Whether or not the user must click a magic link emailed to them to log in, after they successfully enter their username and password. Incompatible with SSO and API-only users. |
 | api_only    | boolean | body | User is an "API-only" user (cannot use web UI) if true.                                                                                                                                                                                                                                                                                                  |
 | global_role | string | body | The role assigned to the user. In Fleet 4.0.0, 3 user roles were introduced (`admin`, `maintainer`, and `observer`). In Fleet 4.30.0 and 4.31.0, the `observer_plus` and `gitops` roles were introduced respectively. If `global_role` is specified, `teams` cannot be specified. For more information, see [manage access](https://fleetdm.com/docs/using-fleet/manage-access).                                                                                                                                                                        |
 | admin_forced_password_reset    | boolean | body | Sets whether the user will be forced to reset its password upon first login (default=true) |
@@ -11450,6 +11440,7 @@ By default, the user will be forced to reset its password upon first login.
     "force_password_reset": false,
     "gravatar_url": "",
     "sso_enabled": false,
+    "mfa_enabled": false,
     "api_only": true,
     "global_role": null,
     "teams": [
@@ -11501,14 +11492,6 @@ Returns all information about a specific user.
 
 `GET /api/v1/fleet/users/2`
 
-##### Request query parameters
-
-```json
-{
-  "id": 1
-}
-```
-
 ##### Default response
 
 `Status: 200`
@@ -11524,6 +11507,7 @@ Returns all information about a specific user.
     "force_password_reset": false,
     "gravatar_url": "",
     "sso_enabled": false,
+    "mfa_enabled": false,
     "global_role": "admin",
     "api_only": false,
     "teams": []
@@ -11560,6 +11544,7 @@ Returns all information about a specific user.
 | position    | string  | body | The user's position.                                                                                                                                                                                                                                                                                                                                     |
 | email       | string  | body | The user's email.                                                                                                                                                                                                                                                                                                                                        |
 | sso_enabled | boolean | body | Whether or not SSO is enabled for the user.                                                                                                                                                                                                                                                                                                              |
+| mfa_enabled | boolean | body | Whether or not the user must click a magic link emailed to them to log in, after they successfully enter their username and password. Incompatible with SSO and API-only users. |
 | api_only    | boolean | body | User is an "API-only" user (cannot use web UI) if true.                                                                                                                                                                                                                                                                                                  |
 | password    | string  | body | The user's current password, required to change the user's own email or password (not required for an admin to modify another user).                                                                                                                                                                                                                     |
 | new_password| string  | body | The user's new password. |
@@ -11595,6 +11580,7 @@ Returns all information about a specific user.
     "force_password_reset": false,
     "gravatar_url": "",
     "sso_enabled": false,
+    "mfa_enabled": false,
     "api_only": false,
     "teams": []
   }
@@ -11638,6 +11624,7 @@ Returns all information about a specific user.
     "force_password_reset": false,
     "gravatar_url": "",
     "sso_enabled": false,
+    "mfa_enabled": false,
     "global_role": "admin",
     "teams": [
       {
@@ -11713,6 +11700,7 @@ The selected user is logged out of Fleet and required to reset their password du
     "email": "janedoe@example.com",
     "force_password_reset": true,
     "gravatar_url": "",
+    "mfa_enabled": false,
     "sso_enabled": false,
     "global_role": "observer",
     "teams": []

--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -11239,6 +11239,7 @@ None.
       "force_password_reset": false,
       "gravatar_url": "",
       "sso_enabled": false,
+      "mfa_enabled": false,
       "global_role": null,
       "api_only": false,
       "teams": [
@@ -11331,6 +11332,7 @@ Creates a user account after an invited user provides registration information a
     "force_password_reset": false,
     "gravatar_url": "",
     "sso_enabled": false,
+    "mfa_enabled": false,
     "global_role": "admin",
     "teams": []
   }

--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -56,13 +56,7 @@ Authenticates the user with the specified credentials. Use the token returned fr
 
 `POST /api/v1/fleet/login`
 
-> This API endpoint is not available to SSO users, since email/password login is disabled for SSO
-> users. To get an API token for an SSO user, you can use the Fleet UI.
-
-> While this endpoint is used by the Fleet UI to log users in with MFA (via email verification)
-> enabled (by setting the `supports_email_verification` body parameter to `true`), clients other than
-> the Fleet UI won't be able to finish the MFA process. Users with MFA, similar to SSO users, should
-> log into the Fleet UI and retrieve an API token from there instead of using the login endpoint.
+> Logging in via the API is not supported for SSO and MFA users. The API token can instead be retrieved from the "My account" page in the UI (/profile). On this page, choose "Get API token".
 
 #### Parameters
 

--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -60,7 +60,7 @@ Authenticates the user with the specified credentials. Use the token returned fr
 > users. To get an API token for an SSO user, you can use the Fleet UI.
 
 > While this endpoint is used by the Fleet UI to log users in with MFA (via email verification)
-> enabled (by setting the `supports_email_verification` body paramter to `true`), clients other than
+> enabled (by setting the `supports_email_verification` body parameter to `true`), clients other than
 > the Fleet UI won't be able to finish the MFA process. Users with MFA, similar to SSO users, should
 > log into the Fleet UI and retrieve an API token from there instead of using the login endpoint.
 

--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -125,6 +125,16 @@ Authenticates the user with the specified credentials. Use the token returned fr
 }
 ```
 
+##### MFA Required
+
+`Status: 202 Accepted`
+
+```json
+{
+  "message": "We sent an email to you. Please click the magic link in the email to sign in.",
+}
+```
+
 ##### Too many requests / Rate limiting
 
 `Status: 429 Too Many Requests`
@@ -11393,7 +11403,7 @@ By default, the user will be forced to reset its password upon first login.
 | name        | string  | body | **Required**. The user's full name or nickname.                                                                                                                                                                                                                                                                                                          |
 | password    | string  | body | The user's password (required for non-SSO users).                                                                                                                                                                                                                                                                                                        |
 | sso_enabled | boolean | body | Whether or not SSO is enabled for the user.                                                                                                                                                                                                                                                                                                              |
-| mfa_enabled | boolean | body | Whether or not the user must click a magic link emailed to them to log in, after they successfully enter their username and password. Incompatible with SSO and API-only users. |
+| mfa_enabled | boolean | body | _Available in Fleet Premium._ Whether or not the user must click a magic link emailed to them to log in, after they successfully enter their username and password. Incompatible with SSO and API-only users. |
 | api_only    | boolean | body | User is an "API-only" user (cannot use web UI) if true.                                                                                                                                                                                                                                                                                                  |
 | global_role | string | body | The role assigned to the user. In Fleet 4.0.0, 3 user roles were introduced (`admin`, `maintainer`, and `observer`). In Fleet 4.30.0 and 4.31.0, the `observer_plus` and `gitops` roles were introduced respectively. If `global_role` is specified, `teams` cannot be specified. For more information, see [manage access](https://fleetdm.com/docs/using-fleet/manage-access).                                                                                                                                                                        |
 | admin_forced_password_reset    | boolean | body | Sets whether the user will be forced to reset its password upon first login (default=true) |
@@ -11544,7 +11554,7 @@ Returns all information about a specific user.
 | position    | string  | body | The user's position.                                                                                                                                                                                                                                                                                                                                     |
 | email       | string  | body | The user's email.                                                                                                                                                                                                                                                                                                                                        |
 | sso_enabled | boolean | body | Whether or not SSO is enabled for the user.                                                                                                                                                                                                                                                                                                              |
-| mfa_enabled | boolean | body | Whether or not the user must click a magic link emailed to them to log in, after they successfully enter their username and password. Incompatible with SSO and API-only users. |
+| mfa_enabled | boolean | body | _Available in Fleet Premium._ Whether or not the user must click a magic link emailed to them to log in, after they successfully enter their username and password. Incompatible with SSO and API-only users. |
 | api_only    | boolean | body | User is an "API-only" user (cannot use web UI) if true.                                                                                                                                                                                                                                                                                                  |
 | password    | string  | body | The user's current password, required to change the user's own email or password (not required for an admin to modify another user).                                                                                                                                                                                                                     |
 | new_password| string  | body | The user's new password. |


### PR DESCRIPTION
For #22078, since the original docs PR got reverted.

Also removes fields for the "create user from invite" endpoint that aren't actually used (if they worked, which they don't, that'd be a significant security vulnerability).