### PR TITLE
Fleet UI: Add ModalFooter component to help handle sticky footers

### DIFF
--- a/frontend/components/Modal/Modal.tsx
+++ b/frontend/components/Modal/Modal.tsx
@@ -37,7 +37,7 @@ export interface IModalProps {
    * */
   disableClosingModal?: boolean;
   className?: string;
-  actionsFooter?: JSX.Element;
+  stickyFooter?: boolean;
 }
 
 const Modal = ({
@@ -51,7 +51,7 @@ const Modal = ({
   isContentDisabled = false,
   disableClosingModal = false,
   className,
-  actionsFooter,
+  stickyFooter = false,
 }: IModalProps): JSX.Element => {
   useEffect(() => {
     const closeWithEscapeKey = (e: KeyboardEvent) => {
@@ -97,6 +97,7 @@ const Modal = ({
     `${baseClass}__modal_container__${width}`,
     {
       [`${className}__loading`]: isLoading,
+      [`${className}__content-with-footer`]: stickyFooter,
     }
   );
 
@@ -127,9 +128,6 @@ const Modal = ({
           )}
           <div className={contentClasses}>{children}</div>
         </div>
-        {actionsFooter && (
-          <div className={`${baseClass}__actions-footer`}>{actionsFooter}</div>
-        )}
       </div>
     </div>
   );

--- a/frontend/components/Modal/Modal.tsx
+++ b/frontend/components/Modal/Modal.tsx
@@ -37,7 +37,6 @@ export interface IModalProps {
    * */
   disableClosingModal?: boolean;
   className?: string;
-  stickyFooter?: boolean;
 }
 
 const Modal = ({
@@ -51,7 +50,6 @@ const Modal = ({
   isContentDisabled = false,
   disableClosingModal = false,
   className,
-  stickyFooter = false,
 }: IModalProps): JSX.Element => {
   useEffect(() => {
     const closeWithEscapeKey = (e: KeyboardEvent) => {
@@ -97,7 +95,6 @@ const Modal = ({
     `${baseClass}__modal_container__${width}`,
     {
       [`${className}__loading`]: isLoading,
-      [`${className}__content-with-footer`]: stickyFooter,
     }
   );
 

--- a/frontend/components/Modal/_styles.scss
+++ b/frontend/components/Modal/_styles.scss
@@ -139,15 +139,6 @@
   max-height: 705px;
 }
 
-.modal-cta-footer {
-  border-top: 1px solid $ui-fleet-black-50;
-  align-self: flex-end;
-  display: flex;
-  flex-direction: row-reverse;
-  padding-top: $pad-xlarge;
-  gap: $pad-medium;
-}
-
 .modal-cta-wrap {
   align-self: flex-end;
   display: flex;

--- a/frontend/components/Modal/_styles.scss
+++ b/frontend/components/Modal/_styles.scss
@@ -25,17 +25,9 @@
   &__content-wrapper {
     margin-top: $pad-large;
     font-size: $x-small;
-    // New pattern of max height modals pushed to 4.61 with PR #24019
-    overflow: visible;
 
     .input-field {
       width: 100%;
-
-      &::placeholder {
-        font-size: $x-small;
-        font-style: italic;
-        line-height: 24px;
-      }
     }
 
     form .modal-cta-wrap,
@@ -140,6 +132,24 @@
       padding: 11px;
     }
   }
+}
+
+.modal-scrollable-content {
+  display: flex;
+  flex-direction: column;
+  gap: $pad-medium;
+  overflow-y: auto;
+  max-height: 705px;
+  position: relative;
+}
+
+.modal-cta-footer {
+  border-top: 1px solid $ui-fleet-black-50;
+  align-self: flex-end;
+  display: flex;
+  flex-direction: row-reverse;
+  padding-top: $pad-xlarge;
+  gap: $pad-medium;
 }
 
 .modal-cta-wrap {

--- a/frontend/components/Modal/_styles.scss
+++ b/frontend/components/Modal/_styles.scss
@@ -135,12 +135,8 @@
 }
 
 .modal-scrollable-content {
-  display: flex;
-  flex-direction: column;
-  gap: $pad-medium;
   overflow-y: auto;
   max-height: 705px;
-  position: relative;
 }
 
 .modal-cta-footer {

--- a/frontend/components/ModalFooter/ModalFooter.stories.tsx
+++ b/frontend/components/ModalFooter/ModalFooter.stories.tsx
@@ -1,0 +1,20 @@
+// import React from "react";
+// import { Meta, Story } from "@storybook/react";
+
+// import ModalFooter from ".";
+// import { IModalFooterProps } from "./ModalFooter";
+
+// import "../../index.scss";
+
+// export default {
+//   component: ModalFooter,
+//   title: "Components/ModalFooter",
+//   args: {
+//   },
+// } as Meta;
+
+// const Template: Story<IModalFooterProps> = (props) => (
+//   <ModalFooter {...props} />
+// );
+
+// export const Default = Template.bind({});

--- a/frontend/components/ModalFooter/ModalFooter.stories.tsx
+++ b/frontend/components/ModalFooter/ModalFooter.stories.tsx
@@ -1,20 +1,69 @@
-// import React from "react";
-// import { Meta, Story } from "@storybook/react";
+/* eslint-disable no-alert */
+import React from "react";
+import { Meta, Story } from "@storybook/react";
 
-// import ModalFooter from ".";
-// import { IModalFooterProps } from "./ModalFooter";
+import Button from "components/buttons/Button";
+import Icon from "components/Icon";
+import ActionsDropdown from "components/ActionsDropdown";
+import ModalFooter from "./ModalFooter";
 
-// import "../../index.scss";
+export default {
+  title: "Components/ModalFooter",
+  component: ModalFooter,
+} as Meta;
 
-// export default {
-//   component: ModalFooter,
-//   title: "Components/ModalFooter",
-//   args: {
-//   },
-// } as Meta;
+const Template: Story = (args) => (
+  <ModalFooter primaryButtons={<></>} {...args} />
+);
 
-// const Template: Story<IModalFooterProps> = (props) => (
-//   <ModalFooter {...props} />
-// );
+export const Default = Template.bind({});
+Default.args = {
+  primaryButtons: (
+    <>
+      <Button onClick={() => alert("Done clicked")} variant="brand">
+        Done
+      </Button>
+    </>
+  ),
+  secondaryButtons: (
+    <>
+      <Button variant="icon" onClick={() => alert("Download clicked")}>
+        <Icon name="download" />
+      </Button>
+      <Button variant="icon" onClick={() => alert("Delete clicked")}>
+        <Icon name="trash" color="ui-fleet-black-75" />
+      </Button>
+    </>
+  ),
+  isTopScrolling: false,
+};
 
-// export const Default = Template.bind({});
+export const WithTopScrolling = Template.bind({});
+WithTopScrolling.args = {
+  ...Default.args,
+  isTopScrolling: true,
+};
+
+export const WithActionsDropdown = Template.bind({});
+WithActionsDropdown.args = {
+  primaryButtons: (
+    <>
+      <ActionsDropdown
+        className="modal-footer__manage-automations-dropdown"
+        onChange={(value) => alert(`Selected action: ${value}`)}
+        placeholder="More actions"
+        isSearchable={false}
+        options={[
+          { value: "action1", label: "Action 1" },
+          { value: "action2", label: "Action 2" },
+        ]}
+        menuPlacement="top"
+      />
+      <Button onClick={() => alert("Done clicked")} variant="brand">
+        Done
+      </Button>
+    </>
+  ),
+  secondaryButtons: Default.args.secondaryButtons,
+  isTopScrolling: false,
+};

--- a/frontend/components/ModalFooter/ModalFooter.stories.tsx
+++ b/frontend/components/ModalFooter/ModalFooter.stories.tsx
@@ -20,6 +20,17 @@ export const Default = Template.bind({});
 Default.args = {
   primaryButtons: (
     <>
+      <ActionsDropdown
+        className="modal-footer__manage-automations-dropdown"
+        onChange={(value) => alert(`Selected action: ${value}`)}
+        placeholder="More actions"
+        isSearchable={false}
+        options={[
+          { value: "action1", label: "Action 1" },
+          { value: "action2", label: "Action 2" },
+        ]}
+        menuPlacement="top"
+      />
       <Button onClick={() => alert("Done clicked")} variant="brand">
         Done
       </Button>
@@ -44,26 +55,9 @@ WithTopScrolling.args = {
   isTopScrolling: true,
 };
 
-export const WithActionsDropdown = Template.bind({});
-WithActionsDropdown.args = {
-  primaryButtons: (
-    <>
-      <ActionsDropdown
-        className="modal-footer__manage-automations-dropdown"
-        onChange={(value) => alert(`Selected action: ${value}`)}
-        placeholder="More actions"
-        isSearchable={false}
-        options={[
-          { value: "action1", label: "Action 1" },
-          { value: "action2", label: "Action 2" },
-        ]}
-        menuPlacement="top"
-      />
-      <Button onClick={() => alert("Done clicked")} variant="brand">
-        Done
-      </Button>
-    </>
-  ),
-  secondaryButtons: Default.args.secondaryButtons,
+export const WithoutSecondaryButtons = Template.bind({});
+WithoutSecondaryButtons.args = {
+  primaryButtons: Default.args.primaryButtons,
+  secondaryButtons: undefined,
   isTopScrolling: false,
 };

--- a/frontend/components/ModalFooter/ModalFooter.tsx
+++ b/frontend/components/ModalFooter/ModalFooter.tsx
@@ -8,6 +8,7 @@ interface IModalFooterProps {
   primaryButtons: JSX.Element;
   secondaryButtons?: JSX.Element;
   className?: string;
+  /** Renders a line above action buttons to indicate scrollability */
   isTopScrolling?: boolean;
 }
 

--- a/frontend/components/ModalFooter/ModalFooter.tsx
+++ b/frontend/components/ModalFooter/ModalFooter.tsx
@@ -1,0 +1,43 @@
+import React from "react";
+import classnames from "classnames";
+import { COLORS } from "styles/var/colors";
+
+const baseClass = "modal-footer";
+
+interface IModalFooterProps {
+  primaryButtons: JSX.Element;
+  secondaryButtons?: JSX.Element;
+  className?: string;
+  isTopScrolling?: boolean;
+}
+
+const ModalFooter = ({
+  primaryButtons,
+  secondaryButtons,
+  className,
+  isTopScrolling = false,
+}: IModalFooterProps): JSX.Element => {
+  const classes = classnames(className, `${baseClass}__content-wrapper`);
+
+  return (
+    <div
+      className={classes}
+      style={{
+        borderTop: isTopScrolling
+          ? `1px solid ${COLORS["ui-fleet-black-50"]}`
+          : "none",
+      }}
+    >
+      <div className={`${baseClass}__primary-buttons-wrapper`}>
+        {primaryButtons}
+      </div>
+      {secondaryButtons && (
+        <div className={`${baseClass}__secondary-buttons-wrapper`}>
+          {secondaryButtons}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default ModalFooter;

--- a/frontend/components/ModalFooter/_styles.scss
+++ b/frontend/components/ModalFooter/_styles.scss
@@ -1,0 +1,27 @@
+.modal-footer {
+  &__content-wrapper {
+    align-self: flex-end;
+    display: flex;
+    flex-direction: row-reverse;
+    padding-top: $pad-medium;
+    justify-content: space-between;
+  }
+
+  // Styles both primary-actions and secondary-actions
+  &__primary-buttons-wrapper,
+  &__secondary-buttons_wrapper {
+    display: flex;
+    justify-content: space-between;
+    gap: $pad-medium;
+    align-items: center;
+  }
+
+  // Align primary actions right if no secondary actions
+  > :last-child {
+    margin-left: auto;
+  }
+
+  .button__text-icon {
+    padding: 11px;
+  }
+}

--- a/frontend/components/ModalFooter/index.ts
+++ b/frontend/components/ModalFooter/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./ModalFooter";

--- a/frontend/pages/DashboardPage/cards/ActivityFeed/components/RunScriptDetailsModal/RunScriptDetailsModal.tsx
+++ b/frontend/pages/DashboardPage/cards/ActivityFeed/components/RunScriptDetailsModal/RunScriptDetailsModal.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState, useEffect, useRef } from "react";
 import { useQuery } from "react-query";
 
 import scriptsAPI, { IScriptResultResponse } from "services/entities/scripts";
@@ -10,6 +10,7 @@ import Icon from "components/Icon";
 import Textarea from "components/Textarea";
 import DataError from "components/DataError/DataError";
 import Spinner from "components/Spinner/Spinner";
+import ModalFooter from "components/ModalFooter";
 
 const baseClass = "run-script-details-modal";
 
@@ -166,6 +167,17 @@ const RunScriptDetailsModal = ({
   onCancel,
   isHidden = false,
 }: IRunScriptDetailsModalProps) => {
+  // For scrollable modal
+  const [isTopScrolling, setIsTopScrolling] = useState(false);
+  const topDivRef = useRef<HTMLDivElement>(null);
+  const checkScroll = () => {
+    if (topDivRef.current) {
+      const isScrolling =
+        topDivRef.current.scrollHeight > topDivRef.current.clientHeight;
+      setIsTopScrolling(isScrolling);
+    }
+  };
+
   const { data, isLoading, isError } = useQuery<IScriptResultResponse>(
     ["runScriptDetailsModal", scriptExecutionId],
     () => {
@@ -173,6 +185,13 @@ const RunScriptDetailsModal = ({
     },
     { refetchOnWindowFocus: false, enabled: !!scriptExecutionId }
   );
+
+  // For scrollable modal
+  useEffect(() => {
+    checkScroll();
+    window.addEventListener("resize", checkScroll);
+    return () => window.removeEventListener("resize", checkScroll);
+  }, [data]); // Re-run when data changes
 
   const renderContent = () => {
     let content = <></>;
@@ -206,18 +225,21 @@ const RunScriptDetailsModal = ({
     }
 
     return (
-      <>
-        <div className={`${baseClass}__modal-content`}>{content}</div>
-      </>
+      <div className={`${baseClass}__modal-content`} ref={topDivRef}>
+        {content}
+      </div>
     );
   };
 
   const renderFooter = () => (
-    <div className={`primary-actions ${baseClass}__host-script-actions`}>
-      <Button onClick={onCancel} variant="brand">
-        Done
-      </Button>
-    </div>
+    <ModalFooter
+      isTopScrolling={isTopScrolling}
+      primaryButtons={
+        <Button onClick={onCancel} variant="brand">
+          Done
+        </Button>
+      }
+    />
   );
   return (
     <Modal
@@ -226,9 +248,11 @@ const RunScriptDetailsModal = ({
       onEnter={onCancel}
       className={baseClass}
       isHidden={isHidden}
-      actionsFooter={renderFooter()}
     >
-      {renderContent()}
+      <>
+        {renderContent()}
+        {renderFooter()}
+      </>
     </Modal>
   );
 };

--- a/frontend/pages/DashboardPage/cards/ActivityFeed/components/RunScriptDetailsModal/RunScriptDetailsModal.tsx
+++ b/frontend/pages/DashboardPage/cards/ActivityFeed/components/RunScriptDetailsModal/RunScriptDetailsModal.tsx
@@ -225,7 +225,10 @@ const RunScriptDetailsModal = ({
     }
 
     return (
-      <div className={`${baseClass}__modal-content`} ref={topDivRef}>
+      <div
+        className={`${baseClass}__modal-content modal-scrollable-content`}
+        ref={topDivRef}
+      >
         {content}
       </div>
     );

--- a/frontend/pages/DashboardPage/cards/ActivityFeed/components/RunScriptDetailsModal/_styles.scss
+++ b/frontend/pages/DashboardPage/cards/ActivityFeed/components/RunScriptDetailsModal/_styles.scss
@@ -6,6 +6,9 @@
     display: flex;
     flex-direction: column;
     gap: $pad-medium;
+    // For scrollable modal
+    max-height: 705px; /* Adjust as needed */
+    overflow-y: auto;
   }
 
   &__script-content {

--- a/frontend/pages/DashboardPage/cards/ActivityFeed/components/RunScriptDetailsModal/_styles.scss
+++ b/frontend/pages/DashboardPage/cards/ActivityFeed/components/RunScriptDetailsModal/_styles.scss
@@ -6,9 +6,6 @@
     display: flex;
     flex-direction: column;
     gap: $pad-medium;
-    // For scrollable modal
-    max-height: 705px; /* Adjust as needed */
-    overflow-y: auto;
   }
 
   &__script-content {

--- a/frontend/pages/ManageControlsPage/Scripts/components/ScriptDetailsModal/ScriptDetailsModal.tsx
+++ b/frontend/pages/ManageControlsPage/Scripts/components/ScriptDetailsModal/ScriptDetailsModal.tsx
@@ -111,7 +111,7 @@ const ScriptDetailsModal = ({
     checkScroll();
     window.addEventListener("resize", checkScroll);
     return () => window.removeEventListener("resize", checkScroll);
-  }, [useEffect]); // Re-run when data changes
+  }, [scriptContent]); // Re-run when data changes
 
   const getScriptContent = async () => {
     try {

--- a/frontend/pages/ManageControlsPage/Scripts/components/ScriptDetailsModal/ScriptDetailsModal.tsx
+++ b/frontend/pages/ManageControlsPage/Scripts/components/ScriptDetailsModal/ScriptDetailsModal.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useContext, ReactNode } from "react";
+import React, { useCallback, useContext } from "react";
 import { format } from "date-fns";
 import {
   useQuery,
@@ -15,6 +15,7 @@ import { IHostScript } from "interfaces/script";
 import { IApiError, getErrorReason } from "interfaces/errors";
 
 import Modal from "components/Modal";
+import ModalFooter from "components/ModalFooter";
 import Button from "components/buttons/Button";
 import Spinner from "components/Spinner";
 import Icon from "components/Icon";
@@ -87,6 +88,7 @@ const ScriptDetailsModal = ({
       enabled: !selectedScriptContent && !!selectedScriptDetails?.script_id,
     }
   );
+
   const getScriptContent = async () => {
     try {
       const content = selectedScriptContent || scriptContent;
@@ -157,60 +159,63 @@ const ScriptDetailsModal = ({
     ]
   );
 
-  const shouldShowFooter = () => {
-    return !isLoadingScriptContent && selectedScriptDetails !== undefined;
-  };
+  const shouldShowFooter =
+    !isLoadingScriptContent && selectedScriptDetails !== undefined;
 
   const renderFooter = () => {
     if (!shouldShowFooter) {
-      return <></>;
+      return null;
     }
 
     return (
-      <>
-        <div className={`secondary-actions ${baseClass}__script-actions`}>
-          <Button
-            className={`${baseClass}__action-button`}
-            variant="icon"
-            onClick={() => onClickDownload()}
-          >
-            <Icon name="download" />
-          </Button>
-          <Button
-            className={`${baseClass}__action-button`}
-            variant="icon"
-            onClick={onDelete}
-          >
-            <Icon name="trash" color="ui-fleet-black-75" />
-          </Button>
-        </div>
-        <div className={`primary-actions ${baseClass}__host-script-actions`}>
-          {showHostScriptActions && selectedScriptDetails && (
-            <div className={`${baseClass}__manage-automations-wrapper`}>
-              <ActionsDropdown
-                className={`${baseClass}__manage-automations-dropdown`}
-                onChange={(value) =>
-                  onSelectMoreActions(
-                    value,
+      <ModalFooter
+        secondaryButtons={
+          <>
+            <Button
+              className={`${baseClass}__action-button`}
+              variant="icon"
+              onClick={() => onClickDownload()}
+            >
+              <Icon name="download" />
+            </Button>
+            <Button
+              className={`${baseClass}__action-button`}
+              variant="icon"
+              onClick={onDelete}
+            >
+              <Icon name="trash" color="ui-fleet-black-75" />
+            </Button>
+          </>
+        }
+        primaryButtons={
+          <>
+            {showHostScriptActions && selectedScriptDetails && (
+              <div className={`${baseClass}__manage-automations-wrapper`}>
+                <ActionsDropdown
+                  className={`${baseClass}__manage-automations-dropdown`}
+                  onChange={(value) =>
+                    onSelectMoreActions(
+                      value,
+                      selectedScriptDetails as IHostScript
+                    )
+                  }
+                  placeholder="More actions"
+                  isSearchable={false}
+                  options={generateActionDropdownOptions(
+                    currentUser,
+                    hostTeamId || null,
                     selectedScriptDetails as IHostScript
-                  )
-                }
-                placeholder="More actions"
-                isSearchable={false}
-                options={generateActionDropdownOptions(
-                  currentUser,
-                  hostTeamId || null,
-                  selectedScriptDetails as IHostScript
-                )}
-                menuPlacement="top"
-              />
-            </div>
-          )}
-          <Button onClick={onCancel} variant="brand">
-            Done
-          </Button>
-        </div>
-      </>
+                  )}
+                  menuPlacement="top"
+                />
+              </div>
+            )}
+            <Button onClick={onCancel} variant="brand">
+              Done
+            </Button>
+          </>
+        }
+      />
     );
   };
 
@@ -249,10 +254,13 @@ const ScriptDetailsModal = ({
       title={selectedScriptDetails?.name || "Script details"}
       width="large"
       onExit={onCancel}
-      actionsFooter={shouldShowFooter() ? renderFooter() : undefined}
+      stickyFooter={shouldShowFooter}
       isHidden={isHidden}
     >
-      {renderContent()}
+      <>
+        {renderContent()}
+        {shouldShowFooter ? renderFooter() : undefined}
+      </>
     </Modal>
   );
 };

--- a/frontend/pages/ManageControlsPage/Scripts/components/ScriptDetailsModal/ScriptDetailsModal.tsx
+++ b/frontend/pages/ManageControlsPage/Scripts/components/ScriptDetailsModal/ScriptDetailsModal.tsx
@@ -1,4 +1,10 @@
-import React, { useCallback, useContext } from "react";
+import React, {
+  useCallback,
+  useContext,
+  useRef,
+  useState,
+  useEffect,
+} from "react";
 import { format } from "date-fns";
 import {
   useQuery,
@@ -69,6 +75,17 @@ const ScriptDetailsModal = ({
   isHidden = false,
   onClickRunDetails,
 }: IScriptDetailsModalProps) => {
+  // For scrollable modal
+  const [isTopScrolling, setIsTopScrolling] = useState(false);
+  const topDivRef = useRef<HTMLDivElement>(null);
+  const checkScroll = () => {
+    if (topDivRef.current) {
+      const isScrolling =
+        topDivRef.current.scrollHeight > topDivRef.current.clientHeight;
+      setIsTopScrolling(isScrolling);
+    }
+  };
+
   const { currentUser } = useContext(AppContext);
   const { renderFlash } = useContext(NotificationContext);
 
@@ -88,6 +105,13 @@ const ScriptDetailsModal = ({
       enabled: !selectedScriptContent && !!selectedScriptDetails?.script_id,
     }
   );
+
+  // For scrollable modal
+  useEffect(() => {
+    checkScroll();
+    window.addEventListener("resize", checkScroll);
+    return () => window.removeEventListener("resize", checkScroll);
+  }, [useEffect]); // Re-run when data changes
 
   const getScriptContent = async () => {
     try {
@@ -169,6 +193,7 @@ const ScriptDetailsModal = ({
 
     return (
       <ModalFooter
+        isTopScrolling={isTopScrolling}
         secondaryButtons={
           <>
             <Button
@@ -229,7 +254,10 @@ const ScriptDetailsModal = ({
     }
 
     return (
-      <div className={`${baseClass}__script-content`}>
+      <div
+        className={`${baseClass}__script-content  modal-scrollable-content`}
+        ref={topDivRef}
+      >
         <span>Script content:</span>
         <Textarea className={`${baseClass}__script-content-textarea`}>
           {scriptContent}
@@ -254,7 +282,6 @@ const ScriptDetailsModal = ({
       title={selectedScriptDetails?.name || "Script details"}
       width="large"
       onExit={onCancel}
-      stickyFooter={shouldShowFooter}
       isHidden={isHidden}
     >
       <>

--- a/frontend/pages/ManageControlsPage/Scripts/components/ScriptDetailsModal/_styles.scss
+++ b/frontend/pages/ManageControlsPage/Scripts/components/ScriptDetailsModal/_styles.scss
@@ -7,7 +7,8 @@
 
   &__script-content-textarea {
     font-family: "SourceCodePro";
+    min-height: 150px;
     max-height: 572px;
-    overflow: auto;
+    overflow: scroll;
   }
 }


### PR DESCRIPTION
## Issue
Pre-quel to #22789 

## Description
- Create `ModalFooter` component which handles styling of sticky footers
- Update code to check if the modal (2 implementations) is scrollable with a sticky footer
- Add ModalFooter to storybook
- Note: the line only renders if `isTopScrolling` which has to be set via a `useRef` to check if modal scrolls or not and the div that scrolls needs a classname `modal-scrollable-content` because it has a max-height while other modals in the app do not have a max-height
- Note: this is not app wide behavior

## Screenshots of ModalFooter

### In storybook
<img width="562" alt="Screenshot 2024-11-26 at 12 17 40 PM" src="https://github.com/user-attachments/assets/963fb4ea-bb00-4e44-b78f-cb23a1ee6537">


### In UI

https://github.com/user-attachments/assets/bc5b004f-e4d7-41f7-be3f-43b66c8181d8

https://github.com/user-attachments/assets/3f95a31d-e673-4c92-8497-bab1e8ad9bce


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->


- [x] Manual QA for all new/changed functionality



# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [ ] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
- [ ] Added/updated tests
- [x] Manual QA for all new/changed functionality
