### PR TITLE
Linux disk encryption guides: add disclaimers

### DIFF
--- a/articles/enforce-disk-encryption.md
+++ b/articles/enforce-disk-encryption.md
@@ -48,7 +48,7 @@ You can click each status to view the list of hosts for that status.
 
 ## Enforce disk encryption on Linux
 
-To enforce disk encryption on Ubuntu Linux and Fedora Linux devices, Fleet supports Linux Unified Key Setup (LUKS) for encrypting volumes.
+To enforce disk encryption on Ubuntu Linux and Fedora Linux devices, Fleet supports Linux Unified Key Setup (LUKS) for encrypting volumes. Support for Ubuntu 20.04 is coming soon.
 
 1. Share [this step-by-step guide](https://fleetdm.com/learn-more-about/encrypt-linux-device) with end users setting up a work computer running Ubuntu Linux or Fedora Linux.
 

--- a/articles/linux-disk-encryption-end-user.md
+++ b/articles/linux-disk-encryption-end-user.md
@@ -41,8 +41,8 @@ Follow the steps below to get set up.
 ## 3. Escrow your key with Fleet
 
   - Open Fleet Desktop. If your device is encrypted, you'll see a banner prompting you to escrow the key.
-  - Click **Create key**. Enter your existing encryption passphrase when prompted.
-  - Fleet will generate and securely store a new passphrase for recovery.
+  - Click **Create key**. Enter your existing encryption passphrase when prompted. 
+  - Fleet will generate and securely store a new passphrase for recovery. This may take several minutes. A popup will appear when Fleet is done.
 
 Now, your encryption status will update to "verified" in Fleet Desktop, meaning that your recovery key has been successfully stored.
 


### PR DESCRIPTION
- Key escrow may take several minutes to complete after the process begins.
- We currently do not support Ubuntu 20.04 but will be adding support in a patch next week.
