### PR TITLE
Document new without_vulnerability_details option for software versions endpoint

### DIFF
--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -9141,6 +9141,9 @@ Get a list of all software versions.
 | min_cvss_score | integer | query | _Available in Fleet Premium_. Filters to include only software with vulnerabilities that have a CVSS version 3.x base score higher than the specified value.   |
 | max_cvss_score | integer | query | _Available in Fleet Premium_. Filters to only include software with vulnerabilities that have a CVSS version 3.x base score lower than what's specified.   |
 | exploit | boolean | query | _Available in Fleet Premium_. If `true`, filters to only include software with vulnerabilities that have been actively exploited in the wild (`cisa_known_exploit: true`). Default is `false`.  |
+| without_vulnerability_details | boolean | query | _Available in Fleet Premium_. If `true` only vulnerability name is included in response. `false` or omitted (only available in Fleet Premium), adds vulnerability description, CVSS score, and other details verbose details. Setting this to `false` using the free tier will not return verbose details. See notes below on performance. |
+
+> `without_vulnerability_details` should be set to `true` whenever possible. If set to `false` a large amount of data will be included in the response and this can cause performance issues. If you need vulnerability details consider using the [Get vulnerability](#get-vulnerability) endpoint.
 
 #### Example
 

--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -9143,7 +9143,7 @@ Get a list of all software versions.
 | exploit | boolean | query | _Available in Fleet Premium_. If `true`, filters to only include software with vulnerabilities that have been actively exploited in the wild (`cisa_known_exploit: true`). Default is `false`.  |
 | without_vulnerability_details | boolean | query | _Available in Fleet Premium_. If `true` only vulnerability name is included in response. If `false` (or omitted), adds vulnerability description, CVSS score, and other details available in Fleet Premium. See notes below on performance. |
 
-> `without_vulnerability_details` should be set to `true` whenever possible. If set to `false` a large amount of data will be included in the response and this can cause performance issues. If you need vulnerability details consider using the [Get vulnerability](#get-vulnerability) endpoint.
+> For optimal performance, we recommend Fleet Premium users set `without_vulnerability_details` to `true` whenever possible. If set to `false` a large amount of data will be included in the response. If you need vulnerability details, consider using the [Get vulnerability](#get-vulnerability) endpoint.
 
 #### Example
 

--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -9141,7 +9141,7 @@ Get a list of all software versions.
 | min_cvss_score | integer | query | _Available in Fleet Premium_. Filters to include only software with vulnerabilities that have a CVSS version 3.x base score higher than the specified value.   |
 | max_cvss_score | integer | query | _Available in Fleet Premium_. Filters to only include software with vulnerabilities that have a CVSS version 3.x base score lower than what's specified.   |
 | exploit | boolean | query | _Available in Fleet Premium_. If `true`, filters to only include software with vulnerabilities that have been actively exploited in the wild (`cisa_known_exploit: true`). Default is `false`.  |
-| without_vulnerability_details | boolean | query | _Available in Fleet Premium_. If `true` only vulnerability name is included in response. `false` or omitted (only available in Fleet Premium), adds vulnerability description, CVSS score, and other details verbose details. Setting this to `false` using the free tier will not return verbose details. See notes below on performance. |
+| without_vulnerability_details | boolean | query | _Available in Fleet Premium_. If `true` only vulnerability name is included in response. If `false` (or omitted), adds vulnerability description, CVSS score, and other details available in Fleet Premium. See notes below on performance. |
 
 > `without_vulnerability_details` should be set to `true` whenever possible. If set to `false` a large amount of data will be included in the response and this can cause performance issues. If you need vulnerability details consider using the [Get vulnerability](#get-vulnerability) endpoint.
 


### PR DESCRIPTION
#23679

In order to improve performance on the software version endpoint the option `without_vulnerability_details` has been added. It can be set to true to decrease the size of the response.

On the free tier setting this option to `false` will have no effect. On Fleet Premium setting it to `false` or omitting will include verbose vulnerability details.