### PR TITLE
close progress with stdin

### DIFF
--- a/.github/workflows/fleet-and-orbit.yml
+++ b/.github/workflows/fleet-and-orbit.yml
@@ -213,12 +213,7 @@ jobs:
   # Here we generate the Fleet Desktop and osqueryd targets for
   # macOS which can only be generated from a macOS host.
   build-macos-targets:
-    # Set macOS version to '12' (current equivalent to macos-latest) for
-    # building the binary. This ensures compatibility with macOS version 13 and
-    # later, avoiding runtime errors on systems using macOS 13 or newer.
-    #
-    # Note: Update this version to '13' once GitHub marks macOS 13 as stable
-    # or if we revise our minimum supported macOS version.
+    # Set macOS version to '13' for building the binary as Fleet's minimum supported macOS version.
     runs-on: macos-13
     steps:
       - name: Harden Runner

--- a/.github/workflows/fleet-and-orbit.yml
+++ b/.github/workflows/fleet-and-orbit.yml
@@ -219,7 +219,7 @@ jobs:
     #
     # Note: Update this version to '13' once GitHub marks macOS 13 as stable
     # or if we revise our minimum supported macOS version.
-    runs-on: macos-12
+    runs-on: macos-13
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@63c24ba6bd7ba022e95695ff85de572c04a18142 # v2.7.0

--- a/orbit/changes/24212-fix-zenity-progress
+++ b/orbit/changes/24212-fix-zenity-progress
@@ -1,0 +1,1 @@
+* fixed issue where the linux encryption progress window in zenity was not displaying properly

--- a/orbit/pkg/dialog/dialog.go
+++ b/orbit/pkg/dialog/dialog.go
@@ -26,7 +26,7 @@ type Dialog interface {
 	ShowInfo(ctx context.Context, opts InfoOptions) error
 	// Progress displays a dialog that shows progress. It waits until the
 	// context is cancelled.
-	ShowProgress(ctx context.Context, opts ProgressOptions) error
+	ShowProgress(opts ProgressOptions) (cancelFunc func() error, err error)
 }
 
 // EntryOptions represents options for a dialog that accepts end user input.

--- a/orbit/pkg/execuser/execuser.go
+++ b/orbit/pkg/execuser/execuser.go
@@ -2,6 +2,8 @@
 // SYSTEM service on Windows) as the current login user.
 package execuser
 
+import "io"
+
 type eopts struct {
 	env        [][2]string
 	args       [][2]string
@@ -48,4 +50,12 @@ func RunWithOutput(path string, opts ...Option) (output []byte, exitCode int, er
 		fn(&o)
 	}
 	return runWithOutput(path, o)
+}
+
+func RunWithStdin(path string, opts ...Option) (io.WriteCloser, error) {
+	var o eopts
+	for _, fn := range opts {
+		fn(&o)
+	}
+	return runWithStdin(path, o)
 }

--- a/orbit/pkg/execuser/execuser_darwin.go
+++ b/orbit/pkg/execuser/execuser_darwin.go
@@ -54,3 +54,7 @@ func run(path string, opts eopts) (lastLogs string, err error) {
 func runWithOutput(path string, opts eopts) (output []byte, exitCode int, err error) {
 	return nil, 0, errors.New("not implemented")
 }
+
+func runWithStdin(path string, opts eopts) (io.WriteCloser, error) {
+	return nil, errors.New("not implemented")
+}

--- a/orbit/pkg/execuser/execuser_linux.go
+++ b/orbit/pkg/execuser/execuser_linux.go
@@ -79,6 +79,35 @@ func runWithOutput(path string, opts eopts) (output []byte, exitCode int, err er
 	return output, exitCode, nil
 }
 
+func runWithStdin(path string, opts eopts) (io.WriteCloser, error) {
+	args, err := getUserAndDisplayArgs(path, opts)
+	if err != nil {
+		return nil, fmt.Errorf("get args: %w", err)
+	}
+
+	args = append(args, path)
+
+	if len(opts.args) > 0 {
+		for _, arg := range opts.args {
+			args = append(args, arg[0], arg[1])
+		}
+	}
+
+	cmd := exec.Command("sudo", args...)
+	log.Printf("cmd=%s", cmd.String())
+
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		return nil, fmt.Errorf("stdin pipe: %w", err)
+	}
+
+	if err := cmd.Start(); err != nil {
+		return nil, fmt.Errorf("open path %q: %w", path, err)
+	}
+
+	return stdin, nil
+}
+
 func getUserAndDisplayArgs(path string, opts eopts) ([]string, error) {
 	user, err := getLoginUID()
 	if err != nil {

--- a/orbit/pkg/execuser/execuser_windows.go
+++ b/orbit/pkg/execuser/execuser_windows.go
@@ -8,6 +8,7 @@ package execuser
 import (
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"unsafe"
 
@@ -119,6 +120,10 @@ func run(path string, opts eopts) (lastLogs string, err error) {
 
 func runWithOutput(path string, opts eopts) (output []byte, exitCode int, err error) {
 	return nil, 0, errors.New("not implemented")
+}
+
+func runWithStdin(path string, opts eopts) (io.WriteCloser, error) {
+	return nil, errors.New("not implemented")
 }
 
 // getCurrentUserSessionId will attempt to resolve

--- a/orbit/pkg/luks/luks_linux.go
+++ b/orbit/pkg/luks/luks_linux.go
@@ -127,7 +127,7 @@ func (lr *LuksRunner) getEscrowKey(ctx context.Context, devicePath string) ([]by
 	}
 	defer func() {
 		if err := cancelProgress(); err != nil {
-			log.Error().Err(err).Msg("failed to cancel progress dialog")
+			log.Debug().Err(err).Msg("failed to cancel progress dialog")
 		}
 	}()
 

--- a/orbit/pkg/luks/luks_linux.go
+++ b/orbit/pkg/luks/luks_linux.go
@@ -67,7 +67,7 @@ func (lr *LuksRunner) Run(oc *fleet.OrbitConfig) error {
 			if err := removeKeySlot(ctx, devicePath, *keyslot); err != nil {
 				log.Error().Err(err).Msgf("failed to remove key slot %d", *keyslot)
 			}
-			return fmt.Errorf("Failed to get salt for key slot: %w", err)
+			response.Err = fmt.Sprintf("Failed to get salt for key slot: %s", err)
 		}
 		response.Salt = salt
 	}
@@ -118,13 +118,14 @@ func (lr *LuksRunner) getEscrowKey(ctx context.Context, devicePath string) ([]by
 		return nil, nil, nil
 	}
 
-	err = lr.notifier.ShowProgress(ctx, dialog.ProgressOptions{
+	cancelProgress, err := lr.notifier.ShowProgress(dialog.ProgressOptions{
 		Title: infoTitle,
 		Text:  "Validating passphrase...",
 	})
 	if err != nil {
 		log.Error().Err(err).Msg("failed to show progress dialog")
 	}
+	defer cancelProgress()
 
 	// Validate the passphrase
 	for {
@@ -147,22 +148,17 @@ func (lr *LuksRunner) getEscrowKey(ctx context.Context, devicePath string) ([]by
 			return nil, nil, nil
 		}
 
-		err = lr.notifier.ShowProgress(ctx, dialog.ProgressOptions{
-			Title: infoTitle,
-			Text:  "Validating passphrase...",
-		})
-		if err != nil {
-			log.Error().Err(err).Msg("failed to show progress dialog after retry")
-		}
 	}
 
-	err = lr.notifier.ShowProgress(ctx, dialog.ProgressOptions{
+	cancelProgress()
+	cancelProgress, err = lr.notifier.ShowProgress(dialog.ProgressOptions{
 		Title: infoTitle,
-		Text:  "Key escrow in progress...",
+		Text:  "Escrowing key...",
 	})
 	if err != nil {
 		log.Error().Err(err).Msg("failed to show progress dialog")
 	}
+	defer cancelProgress()
 
 	escrowPassphrase, err := generateRandomPassphrase()
 	if err != nil {

--- a/orbit/pkg/luks/luks_linux.go
+++ b/orbit/pkg/luks/luks_linux.go
@@ -125,7 +125,11 @@ func (lr *LuksRunner) getEscrowKey(ctx context.Context, devicePath string) ([]by
 	if err != nil {
 		log.Error().Err(err).Msg("failed to show progress dialog")
 	}
-	defer cancelProgress()
+	defer func() {
+		if err := cancelProgress(); err != nil {
+			log.Error().Err(err).Msg("failed to cancel progress dialog")
+		}
+	}()
 
 	// Validate the passphrase
 	for {
@@ -150,7 +154,10 @@ func (lr *LuksRunner) getEscrowKey(ctx context.Context, devicePath string) ([]by
 
 	}
 
-	cancelProgress()
+	if err := cancelProgress(); err != nil {
+		log.Error().Err(err).Msg("failed to cancel progress dialog")
+	}
+
 	cancelProgress, err = lr.notifier.ShowProgress(dialog.ProgressOptions{
 		Title: infoTitle,
 		Text:  "Escrowing key...",
@@ -158,7 +165,12 @@ func (lr *LuksRunner) getEscrowKey(ctx context.Context, devicePath string) ([]by
 	if err != nil {
 		log.Error().Err(err).Msg("failed to show progress dialog")
 	}
-	defer cancelProgress()
+
+	defer func() {
+		if err := cancelProgress(); err != nil {
+			log.Error().Err(err).Msg("failed to cancel progress dialog")
+		}
+	}()
 
 	escrowPassphrase, err := generateRandomPassphrase()
 	if err != nil {

--- a/tools/dialog/main.go
+++ b/tools/dialog/main.go
@@ -27,21 +27,20 @@ func main() {
 		panic(err)
 	}
 
-	ctx, cancelProgress := context.WithCancel(context.Background())
-
-	go func() {
-		err := prompt.ShowProgress(ctx, dialog.ProgressOptions{
-			Title: "Zenity Test Progress Title",
-			Text:  "Zenity Test Progress Text",
-		})
-		if err != nil {
-			fmt.Println("Err ShowProgress")
-			panic(err)
-		}
-	}()
+	cancelProgress, err := prompt.ShowProgress(dialog.ProgressOptions{
+		Title: "Zenity Test Progress Title",
+		Text:  "Zenity Test Progress Text",
+	})
+	if err != nil {
+		fmt.Println("Err ShowProgress")
+		panic(err)
+	}
 
 	time.Sleep(2 * time.Second)
-	cancelProgress()
+	if err := cancelProgress(); err != nil {
+		fmt.Println("Err cancelProgress")
+		panic(err)
+	}
 
 	err = prompt.ShowInfo(ctx, dialog.InfoOptions{
 		Title:   "Zenity Test Info Title",


### PR DESCRIPTION
#24212 

The zenity progress window expects stdin to update and close the window, this caused a few issues where 

1) zenity was not recognizing some flags
2) the zenity process was forced to be killed as it did not respect a context cancellation

creating a `StdinPipe()` and closing it fixes both issues 

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/Committing-Changes.md#changes-files) for more information.
- [X] Added/updated tests
- [X] Manual QA for all new/changed functionality
- For Orbit and Fleet Desktop changes:
   - [X] Orbit runs on macOS, Linux and Windows. Check if the orbit feature/bugfix should only apply to one platform (`runtime.GOOS`).
   - [ ] Manual QA must be performed in the three main OSs, macOS, Windows and Linux.
   - [ ] Auto-update manual QA, from released version of component to new version (see [tools/tuf/test](../tools/tuf/test/README.md)).
