### PR TITLE
Process all vulncheck data

### DIFF
--- a/changes/24286-vulncheck
+++ b/changes/24286-vulncheck
@@ -1,0 +1,1 @@
+* added missing vulncheck data from nvd feeds

--- a/server/vulnerabilities/nvd/sync/cve_syncer.go
+++ b/server/vulnerabilities/nvd/sync/cve_syncer.go
@@ -628,7 +628,6 @@ func (s *CVE) processVulnCheckFile(fileName string) error {
 	var modCount int
 	for _, file := range zipReader.File {
 		cvesByYear := make(map[int][]VulnCheckCVE)
-		var stopProcessing bool
 
 		gzFile, err := file.Open()
 		if err != nil {
@@ -655,9 +654,8 @@ func (s *CVE) processVulnCheckFile(fileName string) error {
 			}
 
 			// Stop processing files if the last modified date is older than the vulncheck start
-			// date in order to avoid processing unnecessary files.
+			// date in order to avoid processing unnecessary CVEs.
 			if lastMod.Before(vulnCheckStartDate) {
-				stopProcessing = true
 				continue
 			}
 
@@ -675,10 +673,6 @@ func (s *CVE) processVulnCheckFile(fileName string) error {
 			if err := s.updateVulnCheckYearFile(year, cvesInYear, &modCount, &addCount); err != nil {
 				return err
 			}
-		}
-
-		if stopProcessing {
-			break
 		}
 
 		gReader.Close()


### PR DESCRIPTION
#24286 

When appending Vulncheck data to the NVD feeds, the `generate` job was aborting when it found a CVE with old modification dates in order to avoid processing the full Vulncheck dataset.  New data was found where the vulncheck data is not in order by last modification date.  This change is processing the entire dataset, adding about 10m to the job time.

Previous failing tests will be re-added after merge.

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/Committing-Changes.md#changes-files) for more information.
- [ ] Added/updated tests
- [ ] Manual QA for all new/changed functionality