### PR TITLE
Feature/clarify package generation process

### DIFF
--- a/frontend/components/AddHostsModal/PlatformWrapper/PlatformWrapper.tsx
+++ b/frontend/components/AddHostsModal/PlatformWrapper/PlatformWrapper.tsx
@@ -220,11 +220,13 @@ const PlatformWrapper = ({
   const renderInstallerString = (packageType: string) => {
     return packageType === "advanced"
       ? `fleetctl package --type=YOUR_TYPE --fleet-url=${config?.server_settings.server_url} --enroll-secret=${enrollSecret} --fleet-certificate=PATH_TO_YOUR_CERTIFICATE/fleet.pem`
-      : `fleetctl package --type=${packageType} ${config && !config.server_settings.scripts_disabled
-        ? "--enable-scripts "
-        : ""
-      }${includeFleetDesktop ? "--fleet-desktop " : ""}--fleet-url=${config?.server_settings.server_url
-      } --enroll-secret=${enrollSecret}`;
+      : `fleetctl package --type=${packageType} ${
+          config && !config.server_settings.scripts_disabled
+            ? "--enable-scripts "
+            : ""
+        }${includeFleetDesktop ? "--fleet-desktop " : ""}--fleet-url=${
+          config?.server_settings.server_url
+        } --enroll-secret=${enrollSecret}`;
   };
 
   const renderLabel = (packageType: string, installerString: string) => {
@@ -335,6 +337,14 @@ const PlatformWrapper = ({
     "Value": "${enrollSecret}"
   }
 }`,
+    };
+    const getHelpTextForPackageType = (): string => {
+      if (packageType === "deb") {
+        return " For CentOS, Red Hat, and Fedora Linux, use --type=rpm.";
+      } else if (packageType === "msi") {
+        return " Windows can only generate an MSI package.";
+      }
+      return "";
     };
 
     if (packageType === "chromeos") {
@@ -543,10 +553,7 @@ const PlatformWrapper = ({
           label={renderLabel(packageType, renderInstallerString(packageType))}
           type="textarea"
           value={renderInstallerString(packageType)}
-          helpText={`Distribute your package to add hosts to Fleet.${packageType === "deb"
-              ? " For CentOS, Red Hat, and Fedora Linux, use --type=rpm."
-              : ""
-            }`}
+          helpText={`Distribute your package to add hosts to Fleet.${getHelpTextForPackageType()}`}
         />
       </>
     );

--- a/frontend/components/AddHostsModal/PlatformWrapper/PlatformWrapper.tsx
+++ b/frontend/components/AddHostsModal/PlatformWrapper/PlatformWrapper.tsx
@@ -344,7 +344,7 @@ const PlatformWrapper = ({
       } else if (packageType === "msi") {
         return "Install this package to add hosts to Fleet. For Windows, this generates an MSI package.";
       } else if (packageType === "pkg") {
-        return "Install this package to add hosts to Fleet";
+        return "Install this package to add hosts to Fleet.";
       }
       return "";
     };

--- a/frontend/components/AddHostsModal/PlatformWrapper/PlatformWrapper.tsx
+++ b/frontend/components/AddHostsModal/PlatformWrapper/PlatformWrapper.tsx
@@ -254,7 +254,7 @@ const PlatformWrapper = ({
       <>
         {packageType !== "plain-osquery" && (
           <span className={`${baseClass}__cta`}>
-            Run this command to generate an install package with the updated{" "}
+            Run this command with the{" "}
             <a
               className={`${baseClass}__command-line-tool`}
               href="https://fleetdm.com/learn-more-about/installing-fleetctl"
@@ -263,7 +263,7 @@ const PlatformWrapper = ({
             >
               Fleet command-line tool
             </a>{" "}
-            installed:
+            installed to generate an install package:
           </span>
         )}{" "}
         <span className="buttons">

--- a/frontend/components/AddHostsModal/PlatformWrapper/PlatformWrapper.tsx
+++ b/frontend/components/AddHostsModal/PlatformWrapper/PlatformWrapper.tsx
@@ -220,13 +220,11 @@ const PlatformWrapper = ({
   const renderInstallerString = (packageType: string) => {
     return packageType === "advanced"
       ? `fleetctl package --type=YOUR_TYPE --fleet-url=${config?.server_settings.server_url} --enroll-secret=${enrollSecret} --fleet-certificate=PATH_TO_YOUR_CERTIFICATE/fleet.pem`
-      : `fleetctl package --type=${packageType} ${
-          config && !config.server_settings.scripts_disabled
-            ? "--enable-scripts "
-            : ""
-        }${includeFleetDesktop ? "--fleet-desktop " : ""}--fleet-url=${
-          config?.server_settings.server_url
-        } --enroll-secret=${enrollSecret}`;
+      : `fleetctl package --type=${packageType} ${config && !config.server_settings.scripts_disabled
+        ? "--enable-scripts "
+        : ""
+      }${includeFleetDesktop ? "--fleet-desktop " : ""}--fleet-url=${config?.server_settings.server_url
+      } --enroll-secret=${enrollSecret}`;
   };
 
   const renderLabel = (packageType: string, installerString: string) => {
@@ -254,7 +252,7 @@ const PlatformWrapper = ({
       <>
         {packageType !== "plain-osquery" && (
           <span className={`${baseClass}__cta`}>
-            Run this command with the{" "}
+            Run this command to generate an install package with the updated{" "}
             <a
               className={`${baseClass}__command-line-tool`}
               href="https://fleetdm.com/learn-more-about/installing-fleetctl"
@@ -545,11 +543,10 @@ const PlatformWrapper = ({
           label={renderLabel(packageType, renderInstallerString(packageType))}
           type="textarea"
           value={renderInstallerString(packageType)}
-          helpText={`Distribute your package to add hosts to Fleet.${
-            packageType === "deb"
+          helpText={`Distribute your package to add hosts to Fleet.${packageType === "deb"
               ? " For CentOS, Red Hat, and Fedora Linux, use --type=rpm."
               : ""
-          }`}
+            }`}
         />
       </>
     );

--- a/frontend/components/AddHostsModal/PlatformWrapper/PlatformWrapper.tsx
+++ b/frontend/components/AddHostsModal/PlatformWrapper/PlatformWrapper.tsx
@@ -263,7 +263,7 @@ const PlatformWrapper = ({
             >
               Fleet command-line tool
             </a>{" "}
-            installed to generate an install package:
+            :
           </span>
         )}{" "}
         <span className="buttons">
@@ -342,7 +342,7 @@ const PlatformWrapper = ({
       if (packageType === "deb") {
         return "Install this package to add hosts to Fleet. For CentOS, Red Hat, and Fedora Linux, use --type=rpm.";
       } else if (packageType === "msi") {
-        return "Install this package to add hosts to Fleet.";
+        return "Install this package to add hosts to Fleet. For Windows, this generates an MSI package.";
       } else if (packageType === "pkg") {
         return "Install this package to add hosts to Fleet";
       }

--- a/frontend/components/AddHostsModal/PlatformWrapper/PlatformWrapper.tsx
+++ b/frontend/components/AddHostsModal/PlatformWrapper/PlatformWrapper.tsx
@@ -340,9 +340,11 @@ const PlatformWrapper = ({
     };
     const getHelpTextForPackageType = (): string => {
       if (packageType === "deb") {
-        return " For CentOS, Red Hat, and Fedora Linux, use --type=rpm.";
+        return "Install this package to add hosts to Fleet. For CentOS, Red Hat, and Fedora Linux, use --type=rpm.";
       } else if (packageType === "msi") {
-        return " Windows can only generate an MSI package.";
+        return "Install this package to add hosts to Fleet.";
+      } else if (packageType === "pkg") {
+        return "Install this package to add hosts to Fleet";
       }
       return "";
     };
@@ -553,7 +555,7 @@ const PlatformWrapper = ({
           label={renderLabel(packageType, renderInstallerString(packageType))}
           type="textarea"
           value={renderInstallerString(packageType)}
-          helpText={`Distribute your package to add hosts to Fleet.${getHelpTextForPackageType()}`}
+          helpText={`${getHelpTextForPackageType()}`}
         />
       </>
     );


### PR DESCRIPTION
# Checklist for submitter

Updated the help text to clarify that the command shown is for generating install packages, not enrolling devices. Added a note for Windows users to specify that only MSI packages can be generated.

See #25305 
