### PR TITLE
update changelog prepare 4.60.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Fleet 4.60.1 (Dec 03, 2024)
+
+### Bug fixes
+
+- Fixed a bug that caused breaking with gitops user role running `fleetctl gitops` command when MDM was enabled.
+
 ## Fleet 4.60.0 (Nov 27, 2024)
 
 ### Endpoint operations

--- a/changes/24024-bypass-setup-experience-if-empty
+++ b/changes/24024-bypass-setup-experience-if-empty
@@ -1,2 +1,0 @@
-* Bypass the setup experience UI if there is no setup experience item to process (no software to install, no script to execute), so that releasing the device is done without going through that window.
-* Fixed releasing a DEP-enrolled macOS device if mTLS is configured for `fleetd`.

--- a/changes/24288-mdm-gitops-role
+++ b/changes/24288-mdm-gitops-role
@@ -1,1 +1,0 @@
-Fixed breaking with gitops user role running `fleetctl gitops` command when MDM is enabled.

--- a/charts/fleet/Chart.yaml
+++ b/charts/fleet/Chart.yaml
@@ -8,7 +8,7 @@ version: v6.2.3
 home: https://github.com/fleetdm/fleet
 sources:
   - https://github.com/fleetdm/fleet.git
-appVersion: v4.60.0
+appVersion: v4.60.1
 dependencies:
   - name: mysql
     condition: mysql.enabled

--- a/charts/fleet/Chart.yaml
+++ b/charts/fleet/Chart.yaml
@@ -4,7 +4,7 @@ name: fleet
 keywords:
   - fleet
   - osquery
-version: v6.2.3
+version: v6.2.4
 home: https://github.com/fleetdm/fleet
 sources:
   - https://github.com/fleetdm/fleet.git

--- a/charts/fleet/values.yaml
+++ b/charts/fleet/values.yaml
@@ -3,7 +3,7 @@
 hostName: fleet.localhost
 replicas: 3 # The number of Fleet instances to deploy
 imageRepository: fleetdm/fleet
-imageTag: v4.60.0 # Version of Fleet to deploy
+imageTag: v4.60.1 # Version of Fleet to deploy
 podAnnotations: {} # Additional annotations to add to the Fleet pod
 serviceAccountAnnotations: {} # Additional annotations to add to the Fleet service account
 resources:

--- a/infrastructure/dogfood/terraform/aws/variables.tf
+++ b/infrastructure/dogfood/terraform/aws/variables.tf
@@ -56,7 +56,7 @@ variable "database_name" {
 
 variable "fleet_image" {
   description = "the name of the container image to run"
-  default     = "fleetdm/fleet:v4.60.0"
+  default     = "fleetdm/fleet:v4.60.1"
 }
 
 variable "software_inventory" {

--- a/infrastructure/dogfood/terraform/gcp/variables.tf
+++ b/infrastructure/dogfood/terraform/gcp/variables.tf
@@ -68,7 +68,7 @@ variable "redis_mem" {
 }
 
 variable "image" {
-  default = "fleetdm/fleet:v4.60.0"
+  default = "fleetdm/fleet:v4.60.1"
 }
 
 variable "software_installers_bucket_name" {

--- a/infrastructure/guardduty/.terraform.lock.hcl
+++ b/infrastructure/guardduty/.terraform.lock.hcl
@@ -2,8 +2,8 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/hashicorp/aws" {
-  version     = "4.60.0"
-  constraints = ">= 3.0.0, >= 4.8.0, >= 4.9.0, ~> 4.60.0"
+  version     = "4.60.1"
+  constraints = ">= 3.0.0, >= 4.8.0, >= 4.9.0, ~> 4.60.1"
   hashes = [
     "h1:fuIdjl9f2JEH0TLoq5kc9NIPbJAAV7YBbZ8fvNp5XSg=",
     "zh:0341a460210463a0bebd5c12ce13dc49bd8cae2399b215418c5efa607fed84e4",

--- a/infrastructure/guardduty/main.tf
+++ b/infrastructure/guardduty/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.60.0"
+      version = "~> 4.60.1"
     }
   }
   backend "s3" {

--- a/infrastructure/infrastructure/cloudtrail/main.tf
+++ b/infrastructure/infrastructure/cloudtrail/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.60.0"
+      version = "~> 4.60.1"
     }
   }
   backend "s3" {

--- a/infrastructure/infrastructure/elastic-agent/.terraform.lock.hcl
+++ b/infrastructure/infrastructure/elastic-agent/.terraform.lock.hcl
@@ -2,8 +2,8 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/hashicorp/aws" {
-  version     = "4.60.0"
-  constraints = ">= 3.63.0, ~> 4.60.0"
+  version     = "4.60.1"
+  constraints = ">= 3.63.0, ~> 4.60.1"
   hashes = [
     "h1:fuIdjl9f2JEH0TLoq5kc9NIPbJAAV7YBbZ8fvNp5XSg=",
     "zh:0341a460210463a0bebd5c12ce13dc49bd8cae2399b215418c5efa607fed84e4",

--- a/infrastructure/infrastructure/elastic-agent/main.tf
+++ b/infrastructure/infrastructure/elastic-agent/main.tf
@@ -20,7 +20,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.60.0"
+      version = "~> 4.60.1"
     }
   }
   backend "s3" {

--- a/infrastructure/infrastructure/guardduty-alerts/.terraform.lock.hcl
+++ b/infrastructure/infrastructure/guardduty-alerts/.terraform.lock.hcl
@@ -2,8 +2,8 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/hashicorp/aws" {
-  version     = "4.60.0"
-  constraints = ">= 3.0.0, >= 4.8.0, >= 4.9.0, ~> 4.60.0"
+  version     = "4.60.1"
+  constraints = ">= 3.0.0, >= 4.8.0, >= 4.9.0, ~> 4.60.1"
   hashes = [
     "h1:fuIdjl9f2JEH0TLoq5kc9NIPbJAAV7YBbZ8fvNp5XSg=",
     "zh:0341a460210463a0bebd5c12ce13dc49bd8cae2399b215418c5efa607fed84e4",

--- a/infrastructure/infrastructure/guardduty-alerts/main.tf
+++ b/infrastructure/infrastructure/guardduty-alerts/main.tf
@@ -15,7 +15,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.60.0"
+      version = "~> 4.60.1"
     }
   }
   backend "s3" {

--- a/infrastructure/infrastructure/spend_alerts/main.tf
+++ b/infrastructure/infrastructure/spend_alerts/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.60.0"
+      version = "~> 4.60.1"
     }
   }
   backend "s3" {

--- a/terraform/addons/ses/README.md
+++ b/terraform/addons/ses/README.md
@@ -9,7 +9,7 @@ No requirements.
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.60.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.60.1 |
 
 ## Modules
 

--- a/terraform/addons/vuln-processing/variables.tf
+++ b/terraform/addons/vuln-processing/variables.tf
@@ -24,7 +24,7 @@ variable "fleet_config" {
     vuln_processing_cpu                  = optional(number, 2048)
     vuln_data_stream_mem                 = optional(number, 1024)
     vuln_data_stream_cpu                 = optional(number, 512)
-    image                                = optional(string, "fleetdm/fleet:v4.60.0")
+    image                                = optional(string, "fleetdm/fleet:v4.60.1")
     family                               = optional(string, "fleet-vuln-processing")
     sidecars                             = optional(list(any), [])
     extra_environment_variables          = optional(map(string), {})
@@ -82,7 +82,7 @@ variable "fleet_config" {
     vuln_processing_cpu                  = 2048
     vuln_data_stream_mem                 = 1024
     vuln_data_stream_cpu                 = 512
-    image                                = "fleetdm/fleet:v4.60.0"
+    image                                = "fleetdm/fleet:v4.60.1"
     family                               = "fleet-vuln-processing"
     sidecars                             = []
     extra_environment_variables          = {}

--- a/terraform/byo-vpc/byo-db/README.md
+++ b/terraform/byo-vpc/byo-db/README.md
@@ -6,7 +6,7 @@ No requirements.
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.60.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.60.1 |
 
 ## Modules
 

--- a/terraform/byo-vpc/byo-db/byo-ecs/variables.tf
+++ b/terraform/byo-vpc/byo-db/byo-ecs/variables.tf
@@ -16,7 +16,7 @@ variable "fleet_config" {
     mem                          = optional(number, 4096)
     cpu                          = optional(number, 512)
     pid_mode                     = optional(string, null)
-    image                        = optional(string, "fleetdm/fleet:v4.60.0")
+    image                        = optional(string, "fleetdm/fleet:v4.60.1")
     family                       = optional(string, "fleet")
     sidecars                     = optional(list(any), [])
     depends_on                   = optional(list(any), [])
@@ -119,7 +119,7 @@ variable "fleet_config" {
     mem                          = 512
     cpu                          = 256
     pid_mode                     = null
-    image                        = "fleetdm/fleet:v4.60.0"
+    image                        = "fleetdm/fleet:v4.60.1"
     family                       = "fleet"
     sidecars                     = []
     depends_on                   = []

--- a/terraform/byo-vpc/byo-db/variables.tf
+++ b/terraform/byo-vpc/byo-db/variables.tf
@@ -77,7 +77,7 @@ variable "fleet_config" {
     mem                          = optional(number, 4096)
     cpu                          = optional(number, 512)
     pid_mode                     = optional(string, null)
-    image                        = optional(string, "fleetdm/fleet:v4.60.0")
+    image                        = optional(string, "fleetdm/fleet:v4.60.1")
     family                       = optional(string, "fleet")
     sidecars                     = optional(list(any), [])
     depends_on                   = optional(list(any), [])
@@ -205,7 +205,7 @@ variable "fleet_config" {
     mem                          = 512
     cpu                          = 256
     pid_mode                     = null
-    image                        = "fleetdm/fleet:v4.60.0"
+    image                        = "fleetdm/fleet:v4.60.1"
     family                       = "fleet"
     sidecars                     = []
     depends_on                   = []

--- a/terraform/byo-vpc/example/main.tf
+++ b/terraform/byo-vpc/example/main.tf
@@ -17,7 +17,7 @@ provider "aws" {
 }
 
 locals {
-  fleet_image = "fleetdm/fleet:v4.60.0"
+  fleet_image = "fleetdm/fleet:v4.60.1"
   domain_name = "example.com"
 }
 

--- a/terraform/byo-vpc/variables.tf
+++ b/terraform/byo-vpc/variables.tf
@@ -170,7 +170,7 @@ variable "fleet_config" {
     mem                          = optional(number, 4096)
     cpu                          = optional(number, 512)
     pid_mode                     = optional(string, null)
-    image                        = optional(string, "fleetdm/fleet:v4.60.0")
+    image                        = optional(string, "fleetdm/fleet:v4.60.1")
     family                       = optional(string, "fleet")
     sidecars                     = optional(list(any), [])
     depends_on                   = optional(list(any), [])
@@ -298,7 +298,7 @@ variable "fleet_config" {
     mem                          = 512
     cpu                          = 256
     pid_mode                     = null
-    image                        = "fleetdm/fleet:v4.60.0"
+    image                        = "fleetdm/fleet:v4.60.1"
     family                       = "fleet"
     sidecars                     = []
     depends_on                   = []

--- a/terraform/example/main.tf
+++ b/terraform/example/main.tf
@@ -63,8 +63,8 @@ module "fleet" {
 
   fleet_config = {
     # To avoid pull-rate limiting from dockerhub, consider using our quay.io mirror
-    # for the Fleet image. e.g. "quay.io/fleetdm/fleet:v4.60.0"
-    image = "fleetdm/fleet:v4.60.0" # override default to deploy the image you desire
+    # for the Fleet image. e.g. "quay.io/fleetdm/fleet:v4.60.1"
+    image = "fleetdm/fleet:v4.60.1" # override default to deploy the image you desire
     # See https://fleetdm.com/docs/deploy/reference-architectures#aws for appropriate scaling
     # memory and cpu.
     autoscaling = {

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -218,7 +218,7 @@ variable "fleet_config" {
     mem                          = optional(number, 4096)
     cpu                          = optional(number, 512)
     pid_mode                     = optional(string, null)
-    image                        = optional(string, "fleetdm/fleet:v4.60.0")
+    image                        = optional(string, "fleetdm/fleet:v4.60.1")
     family                       = optional(string, "fleet")
     sidecars                     = optional(list(any), [])
     depends_on                   = optional(list(any), [])
@@ -346,7 +346,7 @@ variable "fleet_config" {
     mem                          = 512
     cpu                          = 256
     pid_mode                     = null
-    image                        = "fleetdm/fleet:v4.60.0"
+    image                        = "fleetdm/fleet:v4.60.1"
     family                       = "fleet"
     sidecars                     = []
     depends_on                   = []

--- a/tools/fleetctl-npm/package.json
+++ b/tools/fleetctl-npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fleetctl",
-  "version": "v4.60.0",
+  "version": "v4.60.1",
   "description": "Installer for the fleetctl CLI tool",
   "bin": {
     "fleetctl": "./run.js"


### PR DESCRIPTION
## Fleet 4.60.1 (Dec 03, 2024)

### Bug fixes

- Fixed a bug that caused breaking with gitops user role running `fleetctl gitops` command when MDM was enabled.
