### PR TITLE
23832 loadtest (for CI)

### DIFF
--- a/infrastructure/loadtesting/terraform/docker/loadtest.Dockerfile
+++ b/infrastructure/loadtesting/terraform/docker/loadtest.Dockerfile
@@ -1,18 +1,1 @@
-FROM golang:1.23.1-alpine3.20@sha256:436e2d978524b15498b98faa367553ba6c3655671226f500c72ceb7afb2ef0b1
-ARG TAG
-RUN apk add git
-RUN git clone -b $TAG --depth=1 --no-tags --progress --no-recurse-submodules https://github.com/fleetdm/fleet.git && cd /go/fleet/cmd/osquery-perf/ && go build .
-
-FROM alpine:3.20@sha256:77726ef6b57ddf65bb551896826ec38bc3e53f75cdde31354fbffb4f25238ebd
-LABEL maintainer="Fleet Developers"
-
-# Create FleetDM group and user
-RUN addgroup -S osquery-perf && adduser -S osquery-perf -G osquery-perf
-
-COPY --from=0 /go/fleet/cmd/osquery-perf/osquery-perf /go/osquery-perf
-COPY --from=0 /go/fleet/server/vulnerabilities/testdata/ /go/fleet/server/vulnerabilities/testdata/
-RUN set -eux; \
-        apk update; \
-        apk upgrade
-
-USER osquery-perf
+FROM getvictor/fleet-loadtest:latest

--- a/infrastructure/loadtesting/terraform/loadtesting.tf
+++ b/infrastructure/loadtesting/terraform/loadtesting.tf
@@ -55,7 +55,11 @@ resource "aws_ecs_task_definition" "loadtest" {
           "-server_url", "http://${aws_lb.internal.dns_name}",
           "--policy_pass_prob", "0.5",
           "--start_period", "5m",
-          "--orbit_prob", "0.0"
+          "--orbit_prob", "1",
+          "--mdm_prob", "1",
+          "--mdm_scep_challenge", "foo",
+          "--os_templates", "macos_14.1.2:500",
+          "--mdm_check_in_interval", "1m"
         ]
       }
   ])

--- a/pkg/mdm/mdmtest/apple.go
+++ b/pkg/mdm/mdmtest/apple.go
@@ -685,6 +685,23 @@ func (c *TestAppleMDMClient) Acknowledge(cmdUUID string) (*mdm.Command, error) {
 	return c.sendAndDecodeCommandResponse(payload)
 }
 
+// NotNow sends a NotNow message to the MDM server.
+// The cmdUUID is the UUID of the command to reference.
+//
+// The server can signal back with either a command to run
+// or an empty (nil, nil) response body to end the communication
+// (i.e. no commands to run).
+func (c *TestAppleMDMClient) NotNow(cmdUUID string) (*mdm.Command, error) {
+	payload := map[string]any{
+		"Status":       "NotNow",
+		"Topic":        "com.apple.mgmt.External." + c.UUID,
+		"UDID":         c.UUID,
+		"EnrollmentID": "testenrollmentid-" + c.UUID,
+		"CommandUUID":  cmdUUID,
+	}
+	return c.sendAndDecodeCommandResponse(payload)
+}
+
 func (c *TestAppleMDMClient) AcknowledgeDeviceInformation(udid, cmdUUID, deviceName, productName string) (*mdm.Command, error) {
 	payload := map[string]any{
 		"Status":      "Acknowledged",

--- a/server/datastore/mysql/apple_mdm.go
+++ b/server/datastore/mysql/apple_mdm.go
@@ -1883,7 +1883,9 @@ ON DUPLICATE KEY UPDATE
 }
 
 func (ds *Datastore) BulkDeleteMDMAppleHostsConfigProfiles(ctx context.Context, profs []*fleet.MDMAppleProfilePayload) error {
-	return ds.withTx(ctx, func(tx sqlx.ExtContext) error {
+	// We need to run with retry due to deadlocks.
+	// Two simultaneous transactions may happen when cron job runs and the user is updating via the UI at the same time.
+	return ds.withRetryTxx(ctx, func(tx sqlx.ExtContext) error {
 		return ds.bulkDeleteMDMAppleHostsConfigProfilesDB(ctx, tx, profs)
 	})
 }

--- a/server/datastore/mysql/locks_test.go
+++ b/server/datastore/mysql/locks_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/fleetdm/fleet/v4/server"
+	"github.com/fleetdm/fleet/v4/server/fleet"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -89,7 +90,7 @@ const (
 )
 
 //nolint:unused // used in skipped tests
-func getMySQLServer(t *testing.T, r dbReader) mysqlServer {
+func getMySQLServer(t *testing.T, r fleet.DBReader) mysqlServer {
 	row := r.QueryRowxContext(context.Background(), "SELECT VERSION()")
 	var version string
 	require.NoError(t, row.Scan(&version))

--- a/server/datastore/mysql/nanomdm_storage.go
+++ b/server/datastore/mysql/nanomdm_storage.go
@@ -54,6 +54,7 @@ func (ds *Datastore) NewMDMAppleMDMStorage() (*NanoMDMStorage, error) {
 	s, err := nanomdm_mysql.New(
 		nanomdm_mysql.WithDB(ds.primary.DB),
 		nanomdm_mysql.WithLogger(nanoMDMLogAdapter{logger: ds.logger}),
+		nanomdm_mysql.WithReaderFunc(ds.reader),
 	)
 	if err != nil {
 		return nil, err
@@ -73,6 +74,7 @@ func (ds *Datastore) NewTestMDMAppleMDMStorage(asyncCap int, asyncInterval time.
 	s, err := nanomdm_mysql.New(
 		nanomdm_mysql.WithDB(ds.primary.DB),
 		nanomdm_mysql.WithLogger(nanoMDMLogAdapter{logger: ds.logger}),
+		nanomdm_mysql.WithReaderFunc(ds.reader),
 		nanomdm_mysql.WithAsyncLastSeen(asyncCap, asyncInterval),
 	)
 	if err != nil {

--- a/server/fleet/db.go
+++ b/server/fleet/db.go
@@ -1,5 +1,7 @@
 package fleet
 
+import "github.com/jmoiron/sqlx"
+
 // DBLock represents a database transaction lock information as returned
 // by datastore.DBLocks.
 type DBLock struct {
@@ -9,4 +11,13 @@ type DBLock struct {
 	BlockingTrxID  string  `db:"blocking_trx_id" json:"blocking_trx_id"`
 	BlockingThread uint64  `db:"blocking_thread" json:"blocking_thread"`
 	BlockingQuery  *string `db:"blocking_query" json:"blocking_query,omitempty"`
+}
+
+// DBReader is an interface that defines the methods required for reads.
+type DBReader interface {
+	sqlx.QueryerContext
+	sqlx.PreparerContext
+
+	Close() error
+	Rebind(string) string
 }

--- a/server/mdm/nanomdm/service/nanomdm/service.go
+++ b/server/mdm/nanomdm/service/nanomdm/service.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/fleetdm/fleet/v4/server/contexts/ctxdb"
 	"github.com/fleetdm/fleet/v4/server/mdm/nanomdm/mdm"
 	"github.com/fleetdm/fleet/v4/server/mdm/nanomdm/service"
 	"github.com/fleetdm/fleet/v4/server/mdm/nanomdm/storage"
@@ -243,6 +244,10 @@ func (s *Service) CommandAndReportResults(r *mdm.Request, results *mdm.CommandRe
 			"status", results.Status,
 			"error_chain", results.ErrorChain,
 		)
+	}
+	if results.Status != "Idle" {
+		// If the host is not idle, we use primary DB since we just wrote results of previous command.
+		ctxdb.RequirePrimary(r.Context, true)
 	}
 	cmd, err := s.store.RetrieveNextCommand(r, results.Status == "NotNow")
 	if err != nil {

--- a/server/mdm/nanomdm/storage/mysql/mysql.go
+++ b/server/mdm/nanomdm/storage/mysql/mysql.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/fleetdm/fleet/v4/server/fleet"
 	"github.com/fleetdm/fleet/v4/server/mdm/nanomdm/cryptoutil"
 	"github.com/fleetdm/fleet/v4/server/mdm/nanomdm/mdm"
 	"github.com/jmoiron/sqlx"
@@ -29,6 +30,7 @@ type MySQLStorage struct {
 	db            *sql.DB
 	rm            bool
 	asyncLastSeen *asyncLastSeen
+	reader        func(ctx context.Context) fleet.DBReader
 }
 
 type config struct {

--- a/server/mdm/nanomdm/storage/mysql/mysql.go
+++ b/server/mdm/nanomdm/storage/mysql/mysql.go
@@ -111,8 +111,12 @@ func New(opts ...Option) (*MySQLStorage, error) {
 	}
 
 	mysqlStore := &MySQLStorage{db: cfg.db, logger: cfg.logger, rm: cfg.rm}
-	mysqlStore.reader = func(ctx context.Context) fleet.DBReader {
-		return sqlx.NewDb(mysqlStore.db, "mysql")
+	if cfg.reader == nil {
+		mysqlStore.reader = func(ctx context.Context) fleet.DBReader {
+			return sqlx.NewDb(mysqlStore.db, "mysql")
+		}
+	} else {
+		mysqlStore.reader = cfg.reader
 	}
 
 	if v := os.Getenv("FLEET_DISABLE_ASYNC_NANO_LAST_SEEN"); v != "1" {

--- a/server/mdm/nanomdm/storage/mysql/queue.go
+++ b/server/mdm/nanomdm/storage/mysql/queue.go
@@ -22,7 +22,7 @@ func enqueue(ctx context.Context, tx *sql.Tx, ids []string, cmd *mdm.Command) er
 	if err != nil {
 		return err
 	}
-	const mySQLPlaceholderLimit = 65536
+	const mySQLPlaceholderLimit = 65536 - 1
 	const placeholdersPerInsert = 2
 	const batchSize = mySQLPlaceholderLimit / placeholdersPerInsert
 	for i := 0; i < len(ids); i += batchSize {

--- a/server/mdm/nanomdm/storage/mysql/queue.go
+++ b/server/mdm/nanomdm/storage/mysql/queue.go
@@ -200,7 +200,7 @@ func (m *MySQLStorage) RetrieveNextCommand(r *mdm.Request, skipNotNow bool) (*md
 		ctxerr.Handle(r.Context, err)
 		args = append(args, r.ID)
 	}
-	err := m.db.QueryRowContext(
+	err := m.reader(r.Context).QueryRowxContext(
 		r.Context, fmt.Sprintf(`
 SELECT c.command_uuid, c.request_type, c.command
 FROM nano_enrollment_queue AS q

--- a/server/mdm/nanomdm/storage/mysql/queue.go
+++ b/server/mdm/nanomdm/storage/mysql/queue.go
@@ -22,15 +22,30 @@ func enqueue(ctx context.Context, tx *sql.Tx, ids []string, cmd *mdm.Command) er
 	if err != nil {
 		return err
 	}
-	query := `INSERT INTO nano_enrollment_queue (id, command_uuid) VALUES (?, ?)`
-	query += strings.Repeat(", (?, ?)", len(ids)-1)
-	args := make([]interface{}, len(ids)*2)
-	for i, id := range ids {
-		args[i*2] = id
-		args[i*2+1] = cmd.CommandUUID
+	const mySQLPlaceholderLimit = 65536
+	const placeholdersPerInsert = 2
+	const batchSize = mySQLPlaceholderLimit / placeholdersPerInsert
+	for i := 0; i < len(ids); i += batchSize {
+		end := i + batchSize
+		if end > len(ids) {
+			end = len(ids)
+		}
+		idsBatch := ids[i:end]
+
+		// Process batch
+		query := `INSERT INTO nano_enrollment_queue (id, command_uuid) VALUES (?, ?)`
+		query += strings.Repeat(", (?, ?)", len(idsBatch)-1)
+		args := make([]interface{}, len(idsBatch)*placeholdersPerInsert)
+		for i, id := range idsBatch {
+			args[i*2] = id
+			args[i*2+1] = cmd.CommandUUID
+		}
+		_, err = tx.ExecContext(ctx, query+";", args...)
+		if err != nil {
+			return err
+		}
 	}
-	_, err = tx.ExecContext(ctx, query+";", args...)
-	return err
+	return nil
 }
 
 func (m *MySQLStorage) EnqueueCommand(ctx context.Context, ids []string, cmd *mdm.Command) (map[string]error, error) {

--- a/server/service/integration_mdm_test.go
+++ b/server/service/integration_mdm_test.go
@@ -9963,6 +9963,95 @@ func (s *integrationMDMTestSuite) TestAPNsPushCron() {
 	require.Len(t, recordedPushes, 0)
 }
 
+func (s *integrationMDMTestSuite) TestAPNsPushWithNotNow() {
+	t := s.T()
+	ctx := context.Background()
+
+	// macOS host, MDM on
+	_, macDevice := createHostThenEnrollMDM(s.ds, s.server.URL, t)
+	// windows host, MDM on
+	createWindowsHostThenEnrollMDM(s.ds, s.server.URL, t)
+	// linux and darwin, MDM off
+	createOrbitEnrolledHost(t, "linux", "linux_host", s.ds)
+	createOrbitEnrolledHost(t, "darwin", "mac_not_enrolled", s.ds)
+
+	// we're going to modify this mock, make sure we restore its default
+	originalPushMock := s.pushProvider.PushFunc
+	defer func() { s.pushProvider.PushFunc = originalPushMock }()
+
+	var recordedPushes []*mdm.Push
+	var mu sync.Mutex
+	s.pushProvider.PushFunc = func(ctx context.Context, pushes []*mdm.Push) (map[string]*push.Response, error) {
+		mu.Lock()
+		defer mu.Unlock()
+		recordedPushes = pushes
+		return mockSuccessfulPush(ctx, pushes)
+	}
+
+	// trigger the reconciliation schedule
+	err := ReconcileAppleProfiles(ctx, s.ds, s.mdmCommander, s.logger)
+	require.NoError(t, err)
+	require.Len(t, recordedPushes, 1)
+	recordedPushes = nil
+
+	// Flush any existing profiles.
+	cmd, err := macDevice.Idle()
+	require.NoError(t, err)
+	for {
+		if cmd == nil {
+			break
+		}
+		t.Logf("Received: %s %s", cmd.CommandUUID, cmd.Command.RequestType)
+		cmd, err = macDevice.Acknowledge(cmd.CommandUUID)
+		require.NoError(t, err)
+	}
+
+	// Load new profiles
+	s.Do("POST", "/api/v1/fleet/mdm/profiles/batch", batchSetMDMProfilesRequest{Profiles: []fleet.MDMProfileBatchPayload{
+		{Name: "N1", Contents: mobileconfigForTest("N1", "I1")},
+		{Name: "N2", Contents: syncMLForTest("./Foo/Bar")},
+	}}, http.StatusNoContent)
+
+	// trigger the reconciliation schedule
+	err = ReconcileAppleProfiles(ctx, s.ds, s.mdmCommander, s.logger)
+	require.NoError(t, err)
+	require.Len(t, recordedPushes, 1)
+	recordedPushes = nil
+
+	// The cron to trigger pushes sends a new push request each time it runs.
+	err = SendPushesToPendingDevices(ctx, s.ds, s.mdmCommander, s.logger)
+	require.NoError(t, err)
+	require.Len(t, recordedPushes, 1)
+	recordedPushes = nil
+
+	// device sends 'NotNow'
+	cmd, err = macDevice.Idle()
+	require.NoError(t, err)
+	require.NotNil(t, cmd)
+	cmd, err = macDevice.NotNow(cmd.CommandUUID)
+	require.NoError(t, err)
+	assert.Nil(t, cmd)
+
+	// A 'NotNow' command will not trigger a new push. Device is expected to check in again when conditions change.
+	err = ReconcileAppleProfiles(ctx, s.ds, s.mdmCommander, s.logger)
+	require.NoError(t, err)
+	require.Len(t, recordedPushes, 0)
+	recordedPushes = nil
+
+	// device acknowledges the commands
+	cmd, err = macDevice.Idle()
+	require.NoError(t, err)
+	require.NotNil(t, cmd)
+	cmd, err = macDevice.Acknowledge(cmd.CommandUUID)
+	require.NoError(t, err)
+	assert.Nil(t, cmd)
+
+	// no more pushes are enqueued
+	err = SendPushesToPendingDevices(ctx, s.ds, s.mdmCommander, s.logger)
+	require.NoError(t, err)
+	assert.Zero(t, recordedPushes)
+}
+
 func (s *integrationMDMTestSuite) TestMDMRequestWithoutCerts() {
 	t := s.T()
 	res := s.DoRawNoAuth("PUT", "/mdm/apple/mdm", nil, http.StatusBadRequest)


### PR DESCRIPTION
# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [ ] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/Committing-Changes.md#changes-files) for more information.
- [ ] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [ ] Added support on fleet's osquery simulator `cmd/osquery-perf` for new osquery data ingestion features.
- [ ] Added/updated tests
- [ ] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes
- [ ] If database migrations are included, checked table schema to confirm autoupdate
- For database migrations:
  - [ ] Checked schema for all modified table for columns that will auto-update timestamps during migration.
  - [ ] Confirmed that updating the timestamps is acceptable, and will not cause unwanted side effects.
  - [ ] Ensured the correct collation is explicitly set for character columns (`COLLATE utf8mb4_unicode_ci`).
- [ ] Manual QA for all new/changed functionality
- For Orbit and Fleet Desktop changes:
   - [ ] Orbit runs on macOS, Linux and Windows. Check if the orbit feature/bugfix should only apply to one platform (`runtime.GOOS`).
   - [ ] Manual QA must be performed in the three main OSs, macOS, Windows and Linux.
   - [ ] Auto-update manual QA, from released version of component to new version (see [tools/tuf/test](../tools/tuf/test/README.md)).
