### PR TITLE
Use team id instead of profile uuids to bulk set pending for gitops and refactor to skip unnecessary deletes

### DIFF
--- a/server/datastore/mysql/apple_mdm.go
+++ b/server/datastore/mysql/apple_mdm.go
@@ -2325,6 +2325,7 @@ func (ds *Datastore) bulkSetPendingMDMAppleHostProfilesDB(
 		// host (since the installation failed). Skipping it here will lead to it being removed from
 		// the host in Fleet during profile reconciliation, which is what we want.
 		if p.DidNotInstallOnHost() {
+			// TODO: maybe we want to delete the row here instead of waiting for the reconciliation?
 			continue
 		}
 		profilesToInsert[fmt.Sprintf("%s\n%s", p.HostUUID, p.ProfileUUID)] = &fleet.MDMAppleProfilePayload{

--- a/server/datastore/mysql/apple_mdm.go
+++ b/server/datastore/mysql/apple_mdm.go
@@ -2135,18 +2135,18 @@ func (ds *Datastore) bulkSetPendingMDMAppleHostProfilesDB(
 		return false, nil
 	}
 
-	// delete all host profiles to start from a clean slate, new entries will be added next
-	// TODO(roberto): is this really necessary? this was pre-existing
-	// behavior but I think it can be refactored. For now leaving it as-is.
-	//
-	// TODO part II(roberto): we found this call to be a major bottleneck during load testing
-	// https://github.com/fleetdm/fleet/issues/21338
-	if len(wantedProfiles) > 0 {
-		if err := ds.bulkDeleteMDMAppleHostsConfigProfilesDB(ctx, tx, wantedProfiles); err != nil {
-			return false, ctxerr.Wrap(ctx, err, "bulk delete all profiles")
-		}
-		updatedDB = true
-	}
+	// // delete all host profiles to start from a clean slate, new entries will be added next
+	// // TODO(roberto): is this really necessary? this was pre-existing
+	// // behavior but I think it can be refactored. For now leaving it as-is.
+	// //
+	// // TODO part II(roberto): we found this call to be a major bottleneck during load testing
+	// // https://github.com/fleetdm/fleet/issues/21338
+	// if len(wantedProfiles) > 0 {
+	// 	if err := ds.bulkDeleteMDMAppleHostsConfigProfilesDB(ctx, tx, wantedProfiles); err != nil {
+	// 		return false, ctxerr.Wrap(ctx, err, "bulk delete all profiles")
+	// 	}
+	// 	updatedDB = true
+	// }
 
 	// profileIntersection tracks profilesToAdd ∩ profilesToRemove, this is used to avoid:
 	//

--- a/server/datastore/mysql/mdm_test.go
+++ b/server/datastore/mysql/mdm_test.go
@@ -946,6 +946,10 @@ func assertHostProfiles(t *testing.T, ds *Datastore, want map[*fleet.Host][]anyP
 	ctx := context.Background()
 	for h, wantProfs := range want {
 		var gotProfs []anyProfile
+		wantMsg := ""
+		for _, wp := range wantProfs {
+			wantMsg += fmt.Sprintf("identifier: %s, status: %v, operation: %s, prof uuid: %s\n", wp.IdentifierOrName, *wp.Status, wp.OperationType, wp.ProfileUUID)
+		}
 
 		switch h.Platform {
 		case "windows":
@@ -963,8 +967,9 @@ func assertHostProfiles(t *testing.T, ds *Datastore, want map[*fleet.Host][]anyP
 		default:
 			profs, err := ds.GetHostMDMAppleProfiles(ctx, h.UUID)
 			require.NoError(t, err)
-			require.Equal(t, len(wantProfs), len(profs), "host uuid: %s", h.UUID)
+			gotMsg := ""
 			for _, p := range profs {
+				gotMsg += fmt.Sprintf("identifier: %s, status: %v, operation: %s, prof uuid: %s\n", p.Identifier, *p.Status, p.OperationType, p.ProfileUUID)
 				gotProfs = append(gotProfs, anyProfile{
 					ProfileUUID:      p.ProfileUUID,
 					Status:           p.Status,
@@ -972,6 +977,7 @@ func assertHostProfiles(t *testing.T, ds *Datastore, want map[*fleet.Host][]anyP
 					IdentifierOrName: p.Identifier,
 				})
 			}
+			require.Equal(t, len(wantProfs), len(profs), "host uuid: \n%s\n want: \n%s\n got: \n%s\n", h.UUID, wantMsg, gotMsg)
 		}
 
 		sortProfs := func(profs []anyProfile) []anyProfile {


### PR DESCRIPTION
Issues #24322 and #21338

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [ ] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/Committing-Changes.md#changes-files) for more information.
- [ ] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [ ] Added support on fleet's osquery simulator `cmd/osquery-perf` for new osquery data ingestion features.
- [ ] Added/updated tests
- [ ] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes
- [ ] If database migrations are included, checked table schema to confirm autoupdate
- For database migrations:
  - [ ] Checked schema for all modified table for columns that will auto-update timestamps during migration.
  - [ ] Confirmed that updating the timestamps is acceptable, and will not cause unwanted side effects.
  - [ ] Ensured the correct collation is explicitly set for character columns (`COLLATE utf8mb4_unicode_ci`).
- [ ] Manual QA for all new/changed functionality
- For Orbit and Fleet Desktop changes:
   - [ ] Orbit runs on macOS, Linux and Windows. Check if the orbit feature/bugfix should only apply to one platform (`runtime.GOOS`).
   - [ ] Manual QA must be performed in the three main OSs, macOS, Windows and Linux.
   - [ ] Auto-update manual QA, from released version of component to new version (see [tools/tuf/test](../tools/tuf/test/README.md)).
