### PR TITLE
Included Windows and Linux script usage info for lock and unlock

### DIFF
--- a/articles/lock-wipe-hosts.md
+++ b/articles/lock-wipe-hosts.md
@@ -14,7 +14,7 @@ where a host might have been lost or stolen, or to remotely prepare a device to 
 1. Navigate to the **Hosts** page by clicking the "Hosts" tab in the main navigation header. Find the device you want to lock. You can search by name, hostname, UUID, serial number, or private IP address in the search box in the upper right corner.
 2. Click the host to open the **Host Overview** page.
 3. Click the **Actions** dropdown, then click  **Lock**.
-4. A confirmation dialog will appear. Confirm that you want to lock the device. The host will now be marked with a "Lock pending" badge. Once the lock command is acknowledged by the host, the badge will update to "Locked".
+4. A confirmation dialog will appear. Confirm that you want to lock the device. The host will now be marked with a "Lock pending" badge. Once the lock command is acknowledged by the host, the badge will update to "Locked".*
 
 ## Wipe a host
 
@@ -33,7 +33,7 @@ To unlock a locked host:
 2. Click the host to open the **Host Overview** page.
 3. Click the **Actions** menu, then click **Unlock**.
     - **macOS**: A dialog with the PIN will appear. Type the PIN into the device to unlock it.
-    - **Windows and Linux**: The command to unlock the host will be queued and the host will unlock once it receives the command (no PIN needed).
+    - **Windows and Linux**: The command to unlock the host will be queued and the host will unlock once it receives the command (no PIN needed).*
 5. When you click **Unlock**, Windows and Linux hosts will be marked with an "Unlock pending" badge. Once the host is unlocked and checks back in with Fleet, the "Unlock pending" badge will be removed. macOS hosts do not have an "Unlock pending" badge as they cannot be remotely unlocked (the PIN has to be typed into the device).
 
 
@@ -57,7 +57,9 @@ fleetctl mdm wipe --host $HOST_IDENTIFIER
 
 Add the `--help` flag to any command to learn more about how to use it.
 
-**Note**: for macOS hosts, the `mdm unlock` command will return the security PIN, which must be typed into the device in order to finish unlocking it.
+**Note**: for macOS hosts, the `mdm unlock` command will return the security PIN, which must be typed into the device in order to finish unlocking it. 
+
+*For Windows and Linux hosts, a script will run as part of the lock and unlock actions. Details for each script can be found in GitHub for [Windows](https://github.com/fleetdm/fleet/blob/337d4955a060854fddcb1dcf35ff0aad679c04eb/scripts/mdm/windows/windows-unlock.ps1) and [Linux](https://github.com/fleetdm/fleet/blob/337d4955a060854fddcb1dcf35ff0aad679c04eb/scripts/mdm/linux/linux-lock.sh) hosts.
 
 <meta name="articleTitle" value="Lock and wipe hosts">
 <meta name="authorFullName" value="JD Strong">


### PR DESCRIPTION
Added additional information about functionality when locking/unlocking Windows and Linux hosts, with links to the scripts that are run as part of the process.
