### PR TITLE
Website: Add uninstall command to app details page.

### DIFF
--- a/website/assets/styles/pages/app-details.less
+++ b/website/assets/styles/pages/app-details.less
@@ -197,11 +197,6 @@
       }
 
     }
-    [purpose='app-uninstall'] {
-      pre {
-        height: 141px;
-      }
-    }
     [purpose='app-install'] {
       ol {
         counter-reset: custom-counter;
@@ -315,7 +310,7 @@
       [purpose='copy-button'] {
         position: absolute;
         top: 11px;
-        right: 10px;
+        right: 1px;
         border-radius: 8px;
         height: 32px;
         width: 32px;
@@ -346,7 +341,7 @@
       border-radius: 4px;
       margin-top: 32px;
       margin-bottom: 24px;
-      white-space: pre-wrap;
+      white-space: nowrap;
       word-wrap: break-word;
       overflow: auto;
       code {

--- a/website/views/pages/app-details.ejs
+++ b/website/views/pages/app-details.ejs
@@ -48,14 +48,14 @@
             </ol>
             <p>Don’t see <%- thisApp.name %> or the Fleet Desktop icon? Send a <a :href="'/app-library/'+thisApp.identifier">link to this page</a> to your IT team.</p>
           </div>
-          <!-- <div purpose="app-uninstall">
+          <div purpose="app-uninstall">
             <h3>Uninstall <%- thisApp.name %></h3>
-            <p>Run the following script in your terminal to uninstall <%- thisApp.name %>:</p>
+            <p>Run the following command in your terminal to uninstall <%- thisApp.name %>:</p>
             <div purpose="codeblock">
               <div purpose="copy-button"></div>
               <pre><code class="hljs bash"><%= thisApp.uninstallScript %></code></pre>
             </div>
-          </div> -->
+          </div>
           <div purpose="app-check">
             <h3>Is <%- thisApp.name %> up to date?</h3>
             <p>Run this query in Fleet to find old versions of 1Password across all your computers:</p>


### PR DESCRIPTION
Closes: #24231

Changes:
- Updated build-static-content to ingest the uninstall scripts from the `/server/mdm/maintainedapps/testdata/scripts` and condense them into a single line command that can be pasted into a terminal.
- uncommented the uninstall section of the app-details page