### PR TITLE
UI - Only include custom sourced emails that are present

### DIFF
--- a/changes/24321-exclude-custom-source-without-email
+++ b/changes/24321-exclude-custom-source-without-email
@@ -1,0 +1,2 @@
+- Exclude any custom sourced "users" from the host details "used by" display if Fleet doesn't have
+  an email for them.

--- a/frontend/interfaces/host.ts
+++ b/frontend/interfaces/host.ts
@@ -119,7 +119,10 @@ export const mapDeviceUsersForDisplay = (
         idpUser = d;
         break;
       case "custom":
-        customUser = d;
+        // exclude custom user without email
+        if (d.email) {
+          customUser = d;
+        }
         break;
       default:
         newDeviceMapping.push(getDeviceUserForDisplay(d));

--- a/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
@@ -39,7 +39,6 @@ import {
   IQueryKeyQueriesLoadAll,
   ISchedulableQuery,
 } from "interfaces/schedulable_query";
-import { IHostScript } from "interfaces/script";
 
 import {
   normalizeEmptyValues,


### PR DESCRIPTION
## Addresses #24321 

Note that the "Used by" section includes the Google chrome user and the custom user that has an associated email, but ignores the custom user with no email:

<img width="1349" alt="Screenshot 2024-12-04 at 9 37 10 PM" src="https://github.com/user-attachments/assets/b03b519b-c904-4327-bf76-494a3c80a27b">

- [x] Changes file added for user-visible changes in `changes/`, 
- [x] Manual QA for all new/changed functionality