### PR TITLE
Add "Modify script" + capitalization & :id update for consistency

### DIFF
--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -8833,7 +8833,7 @@ Modifies an existing script.
 
 ##### Default response
 
-`Status: 204`
+`Status: 200`
 
 ```json
 {

--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -8816,7 +8816,7 @@ Modifies an existing script.
 
 ```json
 {
-  "script_content": "updated script content"
+  "script_content": "#!/bin/sh\\n\\n#!/usr/bin/env bash\\n\\nsudo systemsetup -settimezone Pacific/Ponape"
 }
 ```
 
@@ -8837,7 +8837,7 @@ Modifies an existing script.
 
 ```json
 {
-  "script_content": "updated content is returned here"
+  "script_content": "#!/bin/sh\\n\\n#!/usr/bin/env bash\\n\\nsudo systemsetup -settimezone Pacific/Ponape"
 }
 ```
 

--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -8825,6 +8825,7 @@ Modifies an existing script.
 | Name            | Type    | In   | Description                                           |
 | ----            | ------- | ---- | --------------------------------------------          |
 | id              | integer | path | **Required**. The ID of the script to modify. |
+| script_contents | string  | body | The contents of the script to run. Only one of either `script_id` or `script_contents` can be included in the request; omit this parameter if using `script_id`. |
 
 #### Example
 

--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -8812,13 +8812,6 @@ Modifies an existing script.
 
 `PATCH /api/v1/fleet/scripts/:id`
 
-##### Request body
-
-```json
-{
-  "script_content": "#!/bin/sh\\n\\n#!/usr/bin/env bash\\n\\nsudo systemsetup -settimezone Pacific/Ponape"
-}
-```
 
 #### Parameters
 
@@ -8830,6 +8823,15 @@ Modifies an existing script.
 #### Example
 
 `PATCH /api/v1/fleet/scripts/1`
+
+
+##### Request body
+
+```json
+{
+  "script_contents": "#!/bin/sh\\n\\n#!/usr/bin/env bash\\n\\nsudo systemsetup -settimezone Pacific/Ponape"
+}
+```
 
 ##### Default response
 

--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -8816,7 +8816,7 @@ Modifies an existing script.
 
 ```json
 {
-  script_content: "updated script content"
+  "script_content": "updated script content"
 }
 ```
 
@@ -8837,7 +8837,7 @@ Modifies an existing script.
 
 ```json
 {
-  script_content: "updated content is returned here"
+  "script_content": "updated content is returned here"
 }
 ```
 

--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -8825,7 +8825,7 @@ Modifies an existing script.
 | Name            | Type    | In   | Description                                           |
 | ----            | ------- | ---- | --------------------------------------------          |
 | id              | integer | path | **Required**. The ID of the script to modify. |
-| script_contents | string  | body | The contents of the script to run. Only one of either `script_id` or `script_contents` can be included in the request; omit this parameter if using `script_id`. |
+| script_contents | string  | body | **Required**. The contents of the script to be updated. |
 
 #### Example
 

--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -8676,6 +8676,7 @@ This allows you to easily configure scheduled queries that will impact a whole t
 - [Run script](#run-script)
 - [Get script result](#get-script-result)
 - [Add script](#add-script)
+- [Modify script](#modify-script)
 - [Delete script](#delete-script)
 - [List scripts](#list-scripts)
 - [Get or download script](#get-or-download-script)
@@ -8732,7 +8733,7 @@ Gets the result of a script that was executed.
 
 `GET /api/v1/fleet/scripts/results/:execution_id`
 
-##### Default Response
+##### Default response
 
 `Status: 200`
 
@@ -8804,6 +8805,41 @@ echo "hello"
   "script_id": 1227
 }
 ```
+
+### Modify script
+
+Modifies an existing script.
+
+`PATCH /api/v1/fleet/scripts/:id`
+
+##### Request body
+
+```json
+{
+  script_content: "updated script content"
+}
+```
+
+#### Parameters
+
+| Name            | Type    | In   | Description                                           |
+| ----            | ------- | ---- | --------------------------------------------          |
+| id              | integer | path | **Required**. The ID of the script to modify. |
+
+#### Example
+
+`PATCH /api/v1/fleet/scripts/1`
+
+##### Default response
+
+`Status: 204`
+
+```json
+{
+  script_content: "updated content is returned here"
+}
+```
+
 
 ### Delete script
 
@@ -9582,7 +9618,7 @@ _Available in Fleet Premium._
 
 Update a package to install on macOS, Windows, or Linux (Ubuntu) hosts.
 
-`PATCH /api/v1/fleet/software/titles/:title_id/package`
+`PATCH /api/v1/fleet/software/titles/:id/package`
 
 #### Parameters
 

--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -8837,7 +8837,13 @@ Modifies an existing script.
 
 ```json
 {
-  "script_content": "#!/bin/sh\\n\\n#!/usr/bin/env bash\\n\\nsudo systemsetup -settimezone Pacific/Ponape"
+{
+  "id": 1,
+  "team_id": null,
+  "name": "script_1.sh",
+  "created_at": "2023-07-30T13:41:07Z",
+  "updated_at": "2023-07-30T13:41:07Z"
+}
 }
 ```
 


### PR DESCRIPTION
- Added a "[Modify scripts](https://fleetdm.com/docs/rest-api/rest-api#modify-script)" section to the "Scripts" section.
- Normalized sentence casing for "Default response" under "[Get script result](https://fleetdm.com/docs/rest-api/rest-api#get-script-result)".
- Normalized "[Modify package](https://fleetdm.com/docs/rest-api/rest-api#modify-package)" docs to use :id instead of :titie_id to maintain consitency with the rest of the page.

