### PR TITLE
24215 keyslot

### DIFF
--- a/.github/workflows/fleet-and-orbit.yml
+++ b/.github/workflows/fleet-and-orbit.yml
@@ -213,12 +213,7 @@ jobs:
   # Here we generate the Fleet Desktop and osqueryd targets for
   # macOS which can only be generated from a macOS host.
   build-macos-targets:
-    # Set macOS version to '12' (current equivalent to macos-latest) for
-    # building the binary. This ensures compatibility with macOS version 13 and
-    # later, avoiding runtime errors on systems using macOS 13 or newer.
-    #
-    # Note: Update this version to '13' once GitHub marks macOS 13 as stable
-    # or if we revise our minimum supported macOS version.
+    # Set macOS version to '13' for building the binary as Fleet's minimum supported macOS version.
     runs-on: macos-13
     steps:
       - name: Harden Runner

--- a/.github/workflows/fleet-and-orbit.yml
+++ b/.github/workflows/fleet-and-orbit.yml
@@ -219,7 +219,7 @@ jobs:
     #
     # Note: Update this version to '13' once GitHub marks macOS 13 as stable
     # or if we revise our minimum supported macOS version.
-    runs-on: macos-12
+    runs-on: macos-13
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@63c24ba6bd7ba022e95695ff85de572c04a18142 # v2.7.0

--- a/orbit/changes/23697-kubuntu-luks
+++ b/orbit/changes/23697-kubuntu-luks
@@ -1,0 +1,1 @@
+* added support for kdialog linux key escrow prompts for compatibility with kubuntu systems

--- a/orbit/changes/24212-fix-zenity-progress
+++ b/orbit/changes/24212-fix-zenity-progress
@@ -1,0 +1,1 @@
+* fixed issue where the linux encryption progress window in zenity was not displaying properly

--- a/orbit/cmd/orbit/orbit.go
+++ b/orbit/cmd/orbit/orbit.go
@@ -39,7 +39,6 @@ import (
 	"github.com/fleetdm/fleet/v4/orbit/pkg/update"
 	"github.com/fleetdm/fleet/v4/orbit/pkg/update/filestore"
 	"github.com/fleetdm/fleet/v4/orbit/pkg/user"
-	"github.com/fleetdm/fleet/v4/orbit/pkg/zenity"
 	"github.com/fleetdm/fleet/v4/pkg/certificate"
 	"github.com/fleetdm/fleet/v4/pkg/file"
 	retrypkg "github.com/fleetdm/fleet/v4/pkg/retry"
@@ -938,7 +937,7 @@ func main() {
 			orbitClient.RegisterConfigReceiver(update.ApplyWindowsMDMEnrollmentFetcherMiddleware(windowsMDMEnrollmentCommandFrequency, orbitHostInfo.HardwareUUID, orbitClient))
 			orbitClient.RegisterConfigReceiver(update.ApplyWindowsMDMBitlockerFetcherMiddleware(windowsMDMBitlockerCommandFrequency, orbitClient))
 		case "linux":
-			orbitClient.RegisterConfigReceiver(luks.New(orbitClient, zenity.New()))
+			orbitClient.RegisterConfigReceiver(luks.New(orbitClient))
 		}
 
 		flagUpdateReceiver := update.NewFlagReceiver(orbitClient.TriggerOrbitRestart, update.FlagUpdateOptions{

--- a/orbit/pkg/dialog/dialog.go
+++ b/orbit/pkg/dialog/dialog.go
@@ -26,7 +26,7 @@ type Dialog interface {
 	ShowInfo(ctx context.Context, opts InfoOptions) error
 	// Progress displays a dialog that shows progress. It waits until the
 	// context is cancelled.
-	ShowProgress(ctx context.Context, opts ProgressOptions) error
+	ShowProgress(opts ProgressOptions) (cancelFunc func() error, err error)
 }
 
 // EntryOptions represents options for a dialog that accepts end user input.

--- a/orbit/pkg/dialog/dialog.go
+++ b/orbit/pkg/dialog/dialog.go
@@ -1,7 +1,6 @@
 package dialog
 
 import (
-	"context"
 	"errors"
 	"time"
 )
@@ -20,10 +19,10 @@ var (
 type Dialog interface {
 	// ShowEntry displays a dialog that accepts end user input. It returns the entered
 	// text or errors ErrCanceled, ErrTimeout, or ErrUnknown.
-	ShowEntry(ctx context.Context, opts EntryOptions) ([]byte, error)
+	ShowEntry(opts EntryOptions) ([]byte, error)
 	// ShowInfo displays a dialog that displays information. It returns an error if the dialog
 	// could not be displayed.
-	ShowInfo(ctx context.Context, opts InfoOptions) error
+	ShowInfo(opts InfoOptions) error
 	// Progress displays a dialog that shows progress. It waits until the
 	// context is cancelled.
 	ShowProgress(opts ProgressOptions) (cancelFunc func() error, err error)
@@ -63,4 +62,7 @@ type ProgressOptions struct {
 
 	// Text sets the text of the dialog.
 	Text string
+
+	// Value sets the percentage of the progress bar (0-100).
+	Value int
 }

--- a/orbit/pkg/dialog/dialog.go
+++ b/orbit/pkg/dialog/dialog.go
@@ -62,7 +62,4 @@ type ProgressOptions struct {
 
 	// Text sets the text of the dialog.
 	Text string
-
-	// Value sets the percentage of the progress bar (0-100).
-	Value int
 }

--- a/orbit/pkg/execuser/execuser.go
+++ b/orbit/pkg/execuser/execuser.go
@@ -5,12 +5,14 @@ package execuser
 import (
 	"context"
 	"io"
+	"time"
 )
 
 type eopts struct {
 	env        [][2]string
 	args       [][2]string
 	stderrPath string //nolint:structcheck,unused
+	timeout    time.Duration
 }
 
 // Option allows configuring the application.
@@ -27,6 +29,12 @@ func WithEnv(name, value string) Option {
 func WithArg(name, value string) Option {
 	return func(a *eopts) {
 		a.args = append(a.args, [2]string{name, value})
+	}
+}
+
+func WithTimeout(duration time.Duration) Option {
+	return func(a *eopts) {
+		a.timeout = duration
 	}
 }
 

--- a/orbit/pkg/execuser/execuser.go
+++ b/orbit/pkg/execuser/execuser.go
@@ -3,7 +3,6 @@
 package execuser
 
 import (
-	"context"
 	"io"
 	"time"
 )
@@ -32,6 +31,7 @@ func WithArg(name, value string) Option {
 	}
 }
 
+// WithTimeout sets the timeout for the application. Currently only supported on Linux.
 func WithTimeout(duration time.Duration) Option {
 	return func(a *eopts) {
 		a.timeout = duration
@@ -69,12 +69,4 @@ func RunWithStdin(path string, opts ...Option) (io.WriteCloser, error) {
 		fn(&o)
 	}
 	return runWithStdin(path, o)
-}
-
-func RunWithContext(ctx context.Context, path string, opts ...Option) error {
-	var o eopts
-	for _, fn := range opts {
-		fn(&o)
-	}
-	return runWithContext(ctx, path, o)
 }

--- a/orbit/pkg/execuser/execuser.go
+++ b/orbit/pkg/execuser/execuser.go
@@ -47,12 +47,12 @@ func Run(path string, opts ...Option) (lastLogs string, err error) {
 //
 // It blocks until the child process exits.
 // Non ExitError errors return with a -1 exitCode.
-func RunWithOutput(path string, opts ...Option) (output []byte, exitCode int, err error) {
+func RunWithOutput(ctx context.Context, path string, opts ...Option) (output []byte, exitCode int, err error) {
 	var o eopts
 	for _, fn := range opts {
 		fn(&o)
 	}
-	return runWithOutput(path, o)
+	return runWithOutput(ctx, path, o)
 }
 
 func RunWithStdin(path string, opts ...Option) (io.WriteCloser, error) {

--- a/orbit/pkg/execuser/execuser.go
+++ b/orbit/pkg/execuser/execuser.go
@@ -2,6 +2,8 @@
 // SYSTEM service on Windows) as the current login user.
 package execuser
 
+import "io"
+
 type eopts struct {
 	env        [][2]string
 	args       [][2]string
@@ -48,4 +50,12 @@ func RunWithOutput(path string, opts ...Option) (output []byte, exitCode int, er
 		fn(&o)
 	}
 	return runWithOutput(path, o)
+}
+
+func RunWithStdin(path string, opts ...Option) (io.WriteCloser, error) {
+	var o eopts
+	for _, fn := range opts {
+		fn(&o)
+	}
+	return runWithStdin(path, o)
 }

--- a/orbit/pkg/execuser/execuser.go
+++ b/orbit/pkg/execuser/execuser.go
@@ -47,12 +47,12 @@ func Run(path string, opts ...Option) (lastLogs string, err error) {
 //
 // It blocks until the child process exits.
 // Non ExitError errors return with a -1 exitCode.
-func RunWithOutput(ctx context.Context, path string, opts ...Option) (output []byte, exitCode int, err error) {
+func RunWithOutput(path string, opts ...Option) (output []byte, exitCode int, err error) {
 	var o eopts
 	for _, fn := range opts {
 		fn(&o)
 	}
-	return runWithOutput(ctx, path, o)
+	return runWithOutput(path, o)
 }
 
 func RunWithStdin(path string, opts ...Option) (io.WriteCloser, error) {

--- a/orbit/pkg/execuser/execuser.go
+++ b/orbit/pkg/execuser/execuser.go
@@ -2,7 +2,10 @@
 // SYSTEM service on Windows) as the current login user.
 package execuser
 
-import "io"
+import (
+	"context"
+	"io"
+)
 
 type eopts struct {
 	env        [][2]string
@@ -58,4 +61,12 @@ func RunWithStdin(path string, opts ...Option) (io.WriteCloser, error) {
 		fn(&o)
 	}
 	return runWithStdin(path, o)
+}
+
+func RunWithContext(ctx context.Context, path string, opts ...Option) error {
+	var o eopts
+	for _, fn := range opts {
+		fn(&o)
+	}
+	return runWithContext(ctx, path, o)
 }

--- a/orbit/pkg/execuser/execuser_darwin.go
+++ b/orbit/pkg/execuser/execuser_darwin.go
@@ -52,7 +52,7 @@ func run(path string, opts eopts) (lastLogs string, err error) {
 	return tw.String(), nil
 }
 
-func runWithOutput(ctx context.Context, path string, opts eopts) (output []byte, exitCode int, err error) {
+func runWithOutput(path string, opts eopts) (output []byte, exitCode int, err error) {
 	return nil, 0, errors.New("not implemented")
 }
 

--- a/orbit/pkg/execuser/execuser_darwin.go
+++ b/orbit/pkg/execuser/execuser_darwin.go
@@ -54,3 +54,7 @@ func run(path string, opts eopts) (lastLogs string, err error) {
 func runWithOutput(path string, opts eopts) (output []byte, exitCode int, err error) {
 	return nil, 0, errors.New("not implemented")
 }
+
+func runWithStdin(path string, opts eopts) (io.WriteCloser, error) {
+	return nil, errors.New("not implemented")
+}

--- a/orbit/pkg/execuser/execuser_darwin.go
+++ b/orbit/pkg/execuser/execuser_darwin.go
@@ -52,7 +52,7 @@ func run(path string, opts eopts) (lastLogs string, err error) {
 	return tw.String(), nil
 }
 
-func runWithOutput(path string, opts eopts) (output []byte, exitCode int, err error) {
+func runWithOutput(ctx context.Context, path string, opts eopts) (output []byte, exitCode int, err error) {
 	return nil, 0, errors.New("not implemented")
 }
 

--- a/orbit/pkg/execuser/execuser_darwin.go
+++ b/orbit/pkg/execuser/execuser_darwin.go
@@ -1,7 +1,6 @@
 package execuser
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -58,8 +57,4 @@ func runWithOutput(path string, opts eopts) (output []byte, exitCode int, err er
 
 func runWithStdin(path string, opts eopts) (io.WriteCloser, error) {
 	return nil, errors.New("not implemented")
-}
-
-func runWithContext(ctx context.Context, path string, opts eopts) error {
-	return errors.New("not implemented")
 }

--- a/orbit/pkg/execuser/execuser_darwin.go
+++ b/orbit/pkg/execuser/execuser_darwin.go
@@ -1,6 +1,7 @@
 package execuser
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -57,4 +58,8 @@ func runWithOutput(path string, opts eopts) (output []byte, exitCode int, err er
 
 func runWithStdin(path string, opts eopts) (io.WriteCloser, error) {
 	return nil, errors.New("not implemented")
+}
+
+func runWithContext(ctx context.Context, path string, opts eopts) error {
+	return errors.New("not implemented")
 }

--- a/orbit/pkg/execuser/execuser_linux.go
+++ b/orbit/pkg/execuser/execuser_linux.go
@@ -79,6 +79,35 @@ func runWithOutput(path string, opts eopts) (output []byte, exitCode int, err er
 	return output, exitCode, nil
 }
 
+func runWithStdin(path string, opts eopts) (io.WriteCloser, error) {
+	args, err := getUserAndDisplayArgs(path, opts)
+	if err != nil {
+		return nil, fmt.Errorf("get args: %w", err)
+	}
+
+	args = append(args, path)
+
+	if len(opts.args) > 0 {
+		for _, arg := range opts.args {
+			args = append(args, arg[0], arg[1])
+		}
+	}
+
+	cmd := exec.Command("sudo", args...)
+	log.Printf("cmd=%s", cmd.String())
+
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		return nil, fmt.Errorf("stdin pipe: %w", err)
+	}
+
+	if err := cmd.Start(); err != nil {
+		return nil, fmt.Errorf("open path %q: %w", path, err)
+	}
+
+	return stdin, nil
+}
+
 func getUserAndDisplayArgs(path string, opts eopts) ([]string, error) {
 	user, err := getLoginUID()
 	if err != nil {

--- a/orbit/pkg/execuser/execuser_linux.go
+++ b/orbit/pkg/execuser/execuser_linux.go
@@ -3,7 +3,6 @@ package execuser
 import (
 	"bufio"
 	"bytes"
-	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -48,41 +47,6 @@ func run(path string, opts eopts) (lastLogs string, err error) {
 		return "", fmt.Errorf("open path %q: %w", path, err)
 	}
 	return "", nil
-}
-
-// run uses sudo to run the given path as login user.
-func runWithContext(ctx context.Context, path string, opts eopts) error {
-	args, err := getUserAndDisplayArgs(path, opts)
-	if err != nil {
-		return fmt.Errorf("get args: %w", err)
-	}
-
-	args = append(args, path)
-
-	if len(opts.args) > 0 {
-		for _, arg := range opts.args {
-			args = append(args, arg[0], arg[1])
-		}
-	}
-
-	cmd := exec.CommandContext(ctx, "sudo", args...)
-	cmd.Stderr = os.Stderr
-	cmd.Stdout = os.Stdout
-	log.Printf("cmd=%s", cmd.String())
-
-	if err := cmd.Start(); err != nil {
-		return fmt.Errorf("open path %q: %w", path, err)
-	}
-
-	// Wait for the process to finish.
-	if err := cmd.Wait(); err != nil {
-		if exitErr, ok := err.(*exec.ExitError); ok {
-			return fmt.Errorf("%q exited with code %d: %w", path, exitErr.ExitCode(), err)
-		}
-		return fmt.Errorf("%q error: %w", path, err)
-	}
-
-	return nil
 }
 
 // run uses sudo to run the given path as login user and waits for the process to finish.

--- a/orbit/pkg/execuser/execuser_linux.go
+++ b/orbit/pkg/execuser/execuser_linux.go
@@ -75,18 +75,18 @@ func runWithContext(ctx context.Context, path string, opts eopts) error {
 	}
 
 	// Wait for the process to finish.
-	if err := cmd.Wait(); err != nil {
-		if exitErr, ok := err.(*exec.ExitError); ok {
-			return fmt.Errorf("%q exited with code %d: %w", path, exitErr.ExitCode(), err)
-		}
-		return fmt.Errorf("%q error: %w", path, err)
-	}
-	
+	// if err := cmd.Wait(); err != nil {
+	// 	if exitErr, ok := err.(*exec.ExitError); ok {
+	// 		return fmt.Errorf("%q exited with code %d: %w", path, exitErr.ExitCode(), err)
+	// 	}
+	// 	return fmt.Errorf("%q error: %w", path, err)
+	// }
+
 	return nil
 }
 
 // run uses sudo to run the given path as login user and waits for the process to finish.
-func runWithOutput(path string, opts eopts) (output []byte, exitCode int, err error) {
+func runWithOutput(ctx context.Context, path string, opts eopts) (output []byte, exitCode int, err error) {
 	args, err := getUserAndDisplayArgs(path, opts)
 	if err != nil {
 		return nil, -1, fmt.Errorf("get args: %w", err)
@@ -100,7 +100,7 @@ func runWithOutput(path string, opts eopts) (output []byte, exitCode int, err er
 		}
 	}
 
-	cmd := exec.Command("sudo", args...)
+	cmd := exec.CommandContext(ctx, "sudo", args...)
 	log.Printf("cmd=%s", cmd.String())
 
 	output, err = cmd.Output()

--- a/orbit/pkg/execuser/execuser_linux.go
+++ b/orbit/pkg/execuser/execuser_linux.go
@@ -72,7 +72,7 @@ func runWithOutput(path string, opts eopts) (output []byte, exitCode int, err er
 	cmdArgs = append(cmdArgs, "sudo")
 	cmdArgs = append(cmdArgs, args...)
 
-	cmd := exec.Command(cmdArgs[0], cmdArgs[1:]...) //nosec G204
+	cmd := exec.Command(cmdArgs[0], cmdArgs[1:]...) // #nosec G204
 
 	log.Printf("cmd=%s", cmd.String())
 

--- a/orbit/pkg/execuser/execuser_linux.go
+++ b/orbit/pkg/execuser/execuser_linux.go
@@ -81,7 +81,7 @@ func runWithContext(ctx context.Context, path string, opts eopts) error {
 		}
 		return fmt.Errorf("%q error: %w", path, err)
 	}
-	
+
 	return nil
 }
 
@@ -100,7 +100,16 @@ func runWithOutput(path string, opts eopts) (output []byte, exitCode int, err er
 		}
 	}
 
-	cmd := exec.Command("sudo", args...)
+	// Prefix with "timeout" and "sudo" if applicable
+	var cmdArgs []string
+	if opts.timeout > 0 {
+		cmdArgs = append(cmdArgs, "timeout", fmt.Sprintf("%ds", int(opts.timeout.Seconds())))
+	}
+	cmdArgs = append(cmdArgs, "sudo")
+	cmdArgs = append(cmdArgs, args...)
+
+	cmd := exec.Command(cmdArgs[0], cmdArgs[1:]...)
+
 	log.Printf("cmd=%s", cmd.String())
 
 	output, err = cmd.Output()

--- a/orbit/pkg/execuser/execuser_linux.go
+++ b/orbit/pkg/execuser/execuser_linux.go
@@ -72,7 +72,7 @@ func runWithOutput(path string, opts eopts) (output []byte, exitCode int, err er
 	cmdArgs = append(cmdArgs, "sudo")
 	cmdArgs = append(cmdArgs, args...)
 
-	cmd := exec.Command(cmdArgs[0], cmdArgs[1:]...)
+	cmd := exec.Command(cmdArgs[0], cmdArgs[1:]...) //nosec G204
 
 	log.Printf("cmd=%s", cmd.String())
 

--- a/orbit/pkg/execuser/execuser_linux.go
+++ b/orbit/pkg/execuser/execuser_linux.go
@@ -75,18 +75,18 @@ func runWithContext(ctx context.Context, path string, opts eopts) error {
 	}
 
 	// Wait for the process to finish.
-	// if err := cmd.Wait(); err != nil {
-	// 	if exitErr, ok := err.(*exec.ExitError); ok {
-	// 		return fmt.Errorf("%q exited with code %d: %w", path, exitErr.ExitCode(), err)
-	// 	}
-	// 	return fmt.Errorf("%q error: %w", path, err)
-	// }
-
+	if err := cmd.Wait(); err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			return fmt.Errorf("%q exited with code %d: %w", path, exitErr.ExitCode(), err)
+		}
+		return fmt.Errorf("%q error: %w", path, err)
+	}
+	
 	return nil
 }
 
 // run uses sudo to run the given path as login user and waits for the process to finish.
-func runWithOutput(ctx context.Context, path string, opts eopts) (output []byte, exitCode int, err error) {
+func runWithOutput(path string, opts eopts) (output []byte, exitCode int, err error) {
 	args, err := getUserAndDisplayArgs(path, opts)
 	if err != nil {
 		return nil, -1, fmt.Errorf("get args: %w", err)
@@ -100,7 +100,7 @@ func runWithOutput(ctx context.Context, path string, opts eopts) (output []byte,
 		}
 	}
 
-	cmd := exec.CommandContext(ctx, "sudo", args...)
+	cmd := exec.Command("sudo", args...)
 	log.Printf("cmd=%s", cmd.String())
 
 	output, err = cmd.Output()

--- a/orbit/pkg/execuser/execuser_windows.go
+++ b/orbit/pkg/execuser/execuser_windows.go
@@ -6,7 +6,6 @@ package execuser
 // To view what was modified/added, you can use the execuser_windows_diff.sh script.
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -125,10 +124,6 @@ func runWithOutput(path string, opts eopts) (output []byte, exitCode int, err er
 
 func runWithStdin(path string, opts eopts) (io.WriteCloser, error) {
 	return nil, errors.New("not implemented")
-}
-
-func runWithContext(ctx context.Context, path string, opts eopts) error {
-	return errors.New("not implemented")
 }
 
 // getCurrentUserSessionId will attempt to resolve

--- a/orbit/pkg/execuser/execuser_windows.go
+++ b/orbit/pkg/execuser/execuser_windows.go
@@ -8,6 +8,7 @@ package execuser
 import (
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"unsafe"
 
@@ -119,6 +120,10 @@ func run(path string, opts eopts) (lastLogs string, err error) {
 
 func runWithOutput(path string, opts eopts) (output []byte, exitCode int, err error) {
 	return nil, 0, errors.New("not implemented")
+}
+
+func runWithStdin(path string, opts eopts) (io.WriteCloser, error) {
+	return nil, errors.New("not implemented")
 }
 
 // getCurrentUserSessionId will attempt to resolve

--- a/orbit/pkg/execuser/execuser_windows.go
+++ b/orbit/pkg/execuser/execuser_windows.go
@@ -119,7 +119,7 @@ func run(path string, opts eopts) (lastLogs string, err error) {
 	return "", startProcessAsCurrentUser(path, "", "")
 }
 
-func runWithOutput(path string, opts eopts) (output []byte, exitCode int, err error) {
+func runWithOutput(ctx context.Context, path string, opts eopts) (output []byte, exitCode int, err error) {
 	return nil, 0, errors.New("not implemented")
 }
 

--- a/orbit/pkg/execuser/execuser_windows.go
+++ b/orbit/pkg/execuser/execuser_windows.go
@@ -119,7 +119,7 @@ func run(path string, opts eopts) (lastLogs string, err error) {
 	return "", startProcessAsCurrentUser(path, "", "")
 }
 
-func runWithOutput(ctx context.Context, path string, opts eopts) (output []byte, exitCode int, err error) {
+func runWithOutput(path string, opts eopts) (output []byte, exitCode int, err error) {
 	return nil, 0, errors.New("not implemented")
 }
 

--- a/orbit/pkg/execuser/execuser_windows.go
+++ b/orbit/pkg/execuser/execuser_windows.go
@@ -6,6 +6,7 @@ package execuser
 // To view what was modified/added, you can use the execuser_windows_diff.sh script.
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -124,6 +125,10 @@ func runWithOutput(path string, opts eopts) (output []byte, exitCode int, err er
 
 func runWithStdin(path string, opts eopts) (io.WriteCloser, error) {
 	return nil, errors.New("not implemented")
+}
+
+func runWithContext(ctx context.Context, path string, opts eopts) error {
+	return errors.New("not implemented")
 }
 
 // getCurrentUserSessionId will attempt to resolve

--- a/orbit/pkg/kdialog/kdialog.go
+++ b/orbit/pkg/kdialog/kdialog.go
@@ -1,0 +1,160 @@
+package kdialog
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/fleetdm/fleet/v4/orbit/pkg/dialog"
+	"github.com/fleetdm/fleet/v4/orbit/pkg/execuser"
+
+	"github.com/godbus/dbus/v5"
+)
+
+const kdialogProcessName = "kdialog"
+
+type KDialog struct {
+	cmdWithOutput  func(args ...string) ([]byte, int, error)
+	cmdWithContext func(ctx context.Context, args ...string) error
+}
+
+func New() *KDialog {
+	return &KDialog{
+		cmdWithOutput:  cmdWithOutput,
+		cmdWithContext: cmdWithContext,
+	}
+}
+
+func (k *KDialog) ShowEntry(opts dialog.EntryOptions) ([]byte, error) {
+	args := []string{"--password"}
+	if opts.Text != "" {
+		args = append(args, opts.Text)
+	}
+	if opts.Title != "" {
+		args = append(args, "--title", opts.Title)
+	}
+
+	output, _, err := k.cmdWithOutput(args...)
+	if err != nil {
+		return nil, errors.Join(dialog.ErrUnknown, err)
+	}
+
+	return output, nil
+}
+
+type ProgressBar struct {
+	serviceName string
+	objectPath  dbus.ObjectPath
+	conn        *dbus.Conn
+}
+
+// Update sets the progress value of the progress bar.
+func (p *ProgressBar) Update(value int) error {
+	obj := p.conn.Object(p.serviceName, p.objectPath)
+	call := obj.Call("org.freedesktop.DBus.Properties.Set", 0,
+		"org.kde.kdialog.ProgressDialog", "value", dbus.MakeVariant(value))
+	if call.Err != nil {
+		return fmt.Errorf("error updating progress: %w", call.Err)
+	}
+	return nil
+}
+
+// Close closes the progress bar.
+func (p *ProgressBar) Close() error {
+	obj := p.conn.Object(p.serviceName, p.objectPath)
+	call := obj.Call("org.kde.kdialog.ProgressDialog.close", 0)
+	if call.Err != nil {
+		return fmt.Errorf("error closing progress bar: %w", call.Err)
+	}
+	return p.conn.Close()
+}
+
+func (k *KDialog) ShowProgress(opts dialog.ProgressOptions) (func() error, error) {
+	args := []string{"--progressbar"}
+	if opts.Text != "" {
+		args = append(args, opts.Text)
+	}
+	if opts.Title != "" {
+		args = append(args, "--title", opts.Title)
+	}
+
+	output, _, err := k.cmdWithOutput(args...)
+	if err != nil {
+		return nil, errors.Join(dialog.ErrUnknown, err)
+	}
+
+	outputParts := strings.Split(string(output), " ")
+	if len(outputParts) != 2 {
+		return nil, errors.New("invalid output from kdialog")
+	}
+	serviceName := outputParts[0]
+	objectPath := outputParts[1]
+
+	conn, err := dbus.SessionBus()
+	if err != nil {
+		return nil, errors.Join(dialog.ErrUnknown, err)
+	}
+
+	progressBar := &ProgressBar{
+		serviceName: serviceName,
+		objectPath:  dbus.ObjectPath(objectPath),
+		conn:        conn,
+	}
+
+	// set the progress value
+	if opts.Value > 0 {
+		if err := progressBar.Update(opts.Value); err != nil {
+			return nil, err
+		}
+	}
+
+	return progressBar.Close, nil
+}
+
+func (k *KDialog) ShowInfo(opts dialog.InfoOptions) error {
+	args := []string{"--msgbox"}
+	if opts.Text != "" {
+		args = append(args, opts.Text)
+	}
+	if opts.Title != "" {
+		args = append(args, "--title", opts.Title)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), opts.TimeOut)
+	defer cancel()
+	err := k.cmdWithContext(ctx, args...)
+	if err != nil {
+		switch {
+		case ctx.Err() != nil:
+			return dialog.ErrTimeout
+		default:
+			return errors.Join(dialog.ErrUnknown, err)
+		}
+	}
+
+	return nil
+}
+
+func cmdWithOutput(args ...string) ([]byte, int, error) {
+	var opts []execuser.Option
+	for _, arg := range args {
+		opts = append(opts, execuser.WithArg(arg, "")) // using empty value for positional args
+	}
+
+	output, exitCode, err := execuser.RunWithOutput(kdialogProcessName, opts...)
+	if err != nil {
+		return nil, exitCode, err
+	}
+
+	return output, exitCode, nil
+}
+
+func cmdWithContext(ctx context.Context, args ...string) error {
+	var opts []execuser.Option
+	for _, arg := range args {
+		opts = append(opts, execuser.WithArg(arg, "")) // using empty value for positional args
+	}
+
+	return execuser.RunWithContext(ctx, kdialogProcessName, opts...)
+}

--- a/orbit/pkg/kdialog/kdialog.go
+++ b/orbit/pkg/kdialog/kdialog.go
@@ -2,14 +2,12 @@ package kdialog
 
 import (
 	"errors"
-	"fmt"
+	"strings"
 	"time"
 
 	"github.com/fleetdm/fleet/v4/orbit/pkg/dialog"
 	"github.com/fleetdm/fleet/v4/orbit/pkg/execuser"
 	"github.com/fleetdm/fleet/v4/orbit/pkg/platform"
-
-	"github.com/godbus/dbus/v5"
 )
 
 const kdialogProcessName = "kdialog"
@@ -47,34 +45,9 @@ func (k *KDialog) ShowEntry(opts dialog.EntryOptions) ([]byte, error) {
 		}
 	}
 
+	output = []byte(strings.TrimSuffix(string(output), "\n"))
+
 	return output, nil
-}
-
-type ProgressBar struct {
-	serviceName string
-	objectPath  dbus.ObjectPath
-	conn        *dbus.Conn
-}
-
-// Update sets the progress value of the progress bar.
-func (p *ProgressBar) Update(value int) error {
-	obj := p.conn.Object(p.serviceName, p.objectPath)
-	call := obj.Call("org.freedesktop.DBus.Properties.Set", 0,
-		"org.kde.kdialog.ProgressDialog", "value", dbus.MakeVariant(value))
-	if call.Err != nil {
-		return fmt.Errorf("error updating progress: %w", call.Err)
-	}
-	return nil
-}
-
-// Close closes the progress bar.
-func (p *ProgressBar) Close() error {
-	obj := p.conn.Object(p.serviceName, p.objectPath)
-	call := obj.Call("org.kde.kdialog.ProgressDialog.close", 0)
-	if call.Err != nil {
-		return fmt.Errorf("error closing progress bar: %w", call.Err)
-	}
-	return p.conn.Close()
 }
 
 func (k *KDialog) ShowProgress(opts dialog.ProgressOptions) (func() error, error) {

--- a/orbit/pkg/kdialog/kdialog_test.go
+++ b/orbit/pkg/kdialog/kdialog_test.go
@@ -16,7 +16,7 @@ type mockExecCmd struct {
 	err          error
 }
 
-func (m *mockExecCmd) runWithOutput(ctx context.Context, args ...string) ([]byte, int, error) {
+func (m *mockExecCmd) runWithOutput(args ...string) ([]byte, int, error) {
 	m.capturedArgs = append(m.capturedArgs, args...)
 
 	if m.exitCode != 0 {

--- a/orbit/pkg/kdialog/kdialog_test.go
+++ b/orbit/pkg/kdialog/kdialog_test.go
@@ -133,6 +133,38 @@ func TestShowInfoArgs(t *testing.T) {
 	}
 }
 
+func TestShowInfoError(t *testing.T) {
+	testcases := []struct {
+		name        string
+		exitCode    int
+		expectedErr error
+	}{
+		{
+			name:        "Dialog Timed Out",
+			exitCode:    124,
+			expectedErr: dialog.ErrTimeout,
+		},
+		{
+			name:        "Unknown Error",
+			exitCode:    99,
+			expectedErr: dialog.ErrUnknown,
+		},
+	}
+
+	for _, tt := range testcases {
+		t.Run(tt.name, func(t *testing.T) {
+			mock := &mockExecCmd{
+				exitCode: tt.exitCode,
+			}
+			k := &KDialog{
+				cmdWithOutput: mock.runWithOutput,
+			}
+			err := k.ShowInfo(dialog.InfoOptions{})
+			assert.ErrorIs(t, err, tt.expectedErr)
+		})
+	}
+}
+
 func TestShowProgressArgs(t *testing.T) {
 	testCases := []struct {
 		name         string

--- a/orbit/pkg/kdialog/kdialog_test.go
+++ b/orbit/pkg/kdialog/kdialog_test.go
@@ -16,7 +16,7 @@ type mockExecCmd struct {
 	err          error
 }
 
-func (m *mockExecCmd) runWithOutput(args ...string) ([]byte, int, error) {
+func (m *mockExecCmd) runWithOutput(ctx context.Context, args ...string) ([]byte, int, error) {
 	m.capturedArgs = append(m.capturedArgs, args...)
 
 	if m.exitCode != 0 {

--- a/orbit/pkg/kdialog/kdialog_test.go
+++ b/orbit/pkg/kdialog/kdialog_test.go
@@ -1,0 +1,141 @@
+package kdialog
+
+import (
+	"context"
+	"os/exec"
+	"testing"
+
+	"github.com/fleetdm/fleet/v4/orbit/pkg/dialog"
+	"github.com/stretchr/testify/assert"
+)
+
+type mockExecCmd struct {
+	output       []byte
+	exitCode     int
+	capturedArgs []string
+	err          error
+}
+
+func (m *mockExecCmd) runWithOutput(args ...string) ([]byte, int, error) {
+	m.capturedArgs = append(m.capturedArgs, args...)
+
+	if m.exitCode != 0 {
+		return nil, m.exitCode, &exec.ExitError{}
+	}
+
+	return m.output, m.exitCode, nil
+}
+
+func (m *mockExecCmd) runWithContext(ctx context.Context, args ...string) error {
+	m.capturedArgs = append(m.capturedArgs, args...)
+
+	if m.err != nil {
+		return m.err
+	}
+
+	return nil
+}
+
+func TestShowEntryArgs(t *testing.T) {
+	testCases := []struct {
+		name         string
+		opts         dialog.EntryOptions
+		expectedArgs []string
+	}{
+		{
+			name: "Basic Entry",
+			opts: dialog.EntryOptions{
+				Title: "A Title",
+				Text:  "Some text",
+			},
+			expectedArgs: []string{"--password", "Some text", "--title", "A Title"},
+		},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			mock := &mockExecCmd{
+				output: []byte("some output"),
+			}
+			k := &KDialog{
+				cmdWithOutput: mock.runWithOutput,
+			}
+			output, err := k.ShowEntry(tt.opts)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expectedArgs, mock.capturedArgs)
+			assert.Equal(t, []byte("some output"), output)
+		})
+	}
+}
+
+func TestShowEntryError(t *testing.T) {
+	mock := &mockExecCmd{
+		exitCode: 1,
+	}
+	k := &KDialog{
+		cmdWithOutput: mock.runWithOutput,
+	}
+	_, err := k.ShowEntry(dialog.EntryOptions{})
+	assert.Error(t, err)
+	assert.ErrorIs(t, err, dialog.ErrUnknown)
+}
+
+func TestShowInfoArgs(t *testing.T) {
+	testCases := []struct {
+		name         string
+		opts         dialog.InfoOptions
+		expectedArgs []string
+	}{
+		{
+			name: "Basic Info",
+			opts: dialog.InfoOptions{
+				Title: "A Title",
+				Text:  "Some text",
+			},
+			expectedArgs: []string{"--msgbox", "Some text", "--title", "A Title"},
+		},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			mock := &mockExecCmd{}
+			k := &KDialog{
+				cmdWithContext: mock.runWithContext,
+			}
+			err := k.ShowInfo(tt.opts)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expectedArgs, mock.capturedArgs)
+		})
+	}
+}
+
+// func TestShowProgressArgs(t *testing.T) {
+// 	testCases := []struct {
+// 		name         string
+// 		opts         dialog.ProgressOptions
+// 		expectedArgs []string
+// 	}{
+// 		{
+// 			name: "Basic Progress",
+// 			opts: dialog.ProgressOptions{
+// 				Title: "A Title",
+// 				Text:  "Some text",
+// 			},
+// 			expectedArgs: []string{"--progressbar", "Some text", "--title", "A Title"},
+// 		},
+// 	}
+
+// 	for _, tt := range testCases {
+// 		t.Run(tt.name, func(t *testing.T) {
+// 			mock := &mockExecCmd{
+// 				output: []byte("org.kde.kdialog.ProgressDialog /Progress_1"),
+// 			}
+// 			k := &KDialog{
+// 				cmdWithOutput: mock.runWithOutput,
+// 			}
+// 			_, err := k.ShowProgress(tt.opts)
+// 			assert.NoError(t, err)
+// 			assert.Equal(t, tt.expectedArgs, mock.capturedArgs)
+// 		})
+// 	}
+// }

--- a/orbit/pkg/luks/luks.go
+++ b/orbit/pkg/luks/luks.go
@@ -1,6 +1,9 @@
 package luks
 
 import (
+	"errors"
+	"regexp"
+
 	"github.com/fleetdm/fleet/v4/orbit/pkg/dialog"
 )
 
@@ -33,4 +36,14 @@ func New(escrower KeyEscrower) *LuksRunner {
 	return &LuksRunner{
 		escrower: escrower,
 	}
+}
+
+func extractJSON(input []byte) ([]byte, error) {
+	// Regular expression to extract JSON
+	re := regexp.MustCompile(`(?s)\{.*\}`)
+	match := re.FindString(string(input))
+	if match == "" {
+		return nil, errors.New("no JSON found")
+	}
+	return []byte(match), nil
 }

--- a/orbit/pkg/luks/luks.go
+++ b/orbit/pkg/luks/luks.go
@@ -10,7 +10,7 @@ type KeyEscrower interface {
 
 type LuksRunner struct {
 	escrower KeyEscrower
-	notifier dialog.Dialog
+	notifier dialog.Dialog //nolint:structcheck,unused
 }
 
 type LuksResponse struct {
@@ -29,9 +29,8 @@ type LuksResponse struct {
 	Err string
 }
 
-func New(escrower KeyEscrower, notifier dialog.Dialog) *LuksRunner {
+func New(escrower KeyEscrower) *LuksRunner {
 	return &LuksRunner{
 		escrower: escrower,
-		notifier: notifier,
 	}
 }

--- a/orbit/pkg/luks/luks_linux.go
+++ b/orbit/pkg/luks/luks_linux.go
@@ -127,7 +127,7 @@ func (lr *LuksRunner) getEscrowKey(ctx context.Context, devicePath string) ([]by
 	}
 	defer func() {
 		if err := cancelProgress(); err != nil {
-			log.Error().Err(err).Msg("failed to cancel progress dialog")
+			log.Debug().Err(err).Msg("failed to cancel progress dialog")
 		}
 	}()
 

--- a/orbit/pkg/luks/luks_linux.go
+++ b/orbit/pkg/luks/luks_linux.go
@@ -67,7 +67,7 @@ func (lr *LuksRunner) Run(oc *fleet.OrbitConfig) error {
 			if err := removeKeySlot(ctx, devicePath, *keyslot); err != nil {
 				log.Error().Err(err).Msgf("failed to remove key slot %d", *keyslot)
 			}
-			return fmt.Errorf("Failed to get salt for key slot: %w", err)
+			response.Err = fmt.Sprintf("Failed to get salt for key slot: %s", err)
 		}
 		response.Salt = salt
 	}
@@ -118,13 +118,14 @@ func (lr *LuksRunner) getEscrowKey(ctx context.Context, devicePath string) ([]by
 		return nil, nil, nil
 	}
 
-	err = lr.notifier.ShowProgress(ctx, dialog.ProgressOptions{
+	cancelProgress, err := lr.notifier.ShowProgress(dialog.ProgressOptions{
 		Title: infoTitle,
 		Text:  "Validating passphrase...",
 	})
 	if err != nil {
 		log.Error().Err(err).Msg("failed to show progress dialog")
 	}
+	defer cancelProgress()
 
 	// Validate the passphrase
 	for {
@@ -147,22 +148,17 @@ func (lr *LuksRunner) getEscrowKey(ctx context.Context, devicePath string) ([]by
 			return nil, nil, nil
 		}
 
-		err = lr.notifier.ShowProgress(ctx, dialog.ProgressOptions{
-			Title: infoTitle,
-			Text:  "Validating passphrase...",
-		})
-		if err != nil {
-			log.Error().Err(err).Msg("failed to show progress dialog after retry")
-		}
 	}
 
-	err = lr.notifier.ShowProgress(ctx, dialog.ProgressOptions{
+	cancelProgress()
+	cancelProgress, err = lr.notifier.ShowProgress(dialog.ProgressOptions{
 		Title: infoTitle,
-		Text:  "Key escrow in progress...",
+		Text:  "Escrowing key...",
 	})
 	if err != nil {
 		log.Error().Err(err).Msg("failed to show progress dialog")
 	}
+	defer cancelProgress()
 
 	escrowPassphrase, err := generateRandomPassphrase()
 	if err != nil {

--- a/orbit/pkg/luks/luks_linux.go
+++ b/orbit/pkg/luks/luks_linux.go
@@ -81,7 +81,7 @@ func (lr *LuksRunner) Run(oc *fleet.OrbitConfig) error {
 		}
 
 		// Show error in dialog
-		if err := lr.infoPrompt(ctx, infoTitle, infoFailedText); err != nil {
+		if err := lr.infoPrompt(infoTitle, infoFailedText); err != nil {
 			log.Info().Err(err).Msg("failed to show failed escrow key dialog")
 		}
 
@@ -89,14 +89,14 @@ func (lr *LuksRunner) Run(oc *fleet.OrbitConfig) error {
 	}
 
 	if response.Err != "" {
-		if err := lr.infoPrompt(ctx, infoTitle, response.Err); err != nil {
+		if err := lr.infoPrompt(infoTitle, response.Err); err != nil {
 			log.Info().Err(err).Msg("failed to show response error dialog")
 		}
 		return fmt.Errorf("error getting linux escrow key: %s", response.Err)
 	}
 
 	// Show success dialog
-	if err := lr.infoPrompt(ctx, infoTitle, infoSuccessText); err != nil {
+	if err := lr.infoPrompt(infoTitle, infoSuccessText); err != nil {
 		log.Info().Err(err).Msg("failed to show success escrow key dialog")
 	}
 
@@ -251,7 +251,7 @@ func generateRandomPassphrase() ([]byte, error) {
 }
 
 func (lr *LuksRunner) entryPrompt(ctx context.Context, title, text string) ([]byte, error) {
-	passphrase, err := lr.notifier.ShowEntry(ctx, dialog.EntryOptions{
+	passphrase, err := lr.notifier.ShowEntry(dialog.EntryOptions{
 		Title:    title,
 		Text:     text,
 		HideText: true,
@@ -264,7 +264,7 @@ func (lr *LuksRunner) entryPrompt(ctx context.Context, title, text string) ([]by
 			return nil, nil
 		case errors.Is(err, dialog.ErrTimeout):
 			log.Debug().Msg("key escrow dialog timed out")
-			err := lr.infoPrompt(ctx, infoTitle, timeoutMessage)
+			err := lr.infoPrompt(infoTitle, timeoutMessage)
 			if err != nil {
 				log.Info().Err(err).Msg("failed to show timeout dialog")
 			}
@@ -279,8 +279,8 @@ func (lr *LuksRunner) entryPrompt(ctx context.Context, title, text string) ([]by
 	return passphrase, nil
 }
 
-func (lr *LuksRunner) infoPrompt(ctx context.Context, title, text string) error {
-	err := lr.notifier.ShowInfo(ctx, dialog.InfoOptions{
+func (lr *LuksRunner) infoPrompt(title, text string) error {
+	err := lr.notifier.ShowInfo(dialog.InfoOptions{
 		Title:   title,
 		Text:    text,
 		TimeOut: 1 * time.Minute,

--- a/orbit/pkg/luks/luks_linux.go
+++ b/orbit/pkg/luks/luks_linux.go
@@ -125,7 +125,11 @@ func (lr *LuksRunner) getEscrowKey(ctx context.Context, devicePath string) ([]by
 	if err != nil {
 		log.Error().Err(err).Msg("failed to show progress dialog")
 	}
-	defer cancelProgress()
+	defer func() {
+		if err := cancelProgress(); err != nil {
+			log.Error().Err(err).Msg("failed to cancel progress dialog")
+		}
+	}()
 
 	// Validate the passphrase
 	for {
@@ -150,7 +154,10 @@ func (lr *LuksRunner) getEscrowKey(ctx context.Context, devicePath string) ([]by
 
 	}
 
-	cancelProgress()
+	if err := cancelProgress(); err != nil {
+		log.Error().Err(err).Msg("failed to cancel progress dialog")
+	}
+
 	cancelProgress, err = lr.notifier.ShowProgress(dialog.ProgressOptions{
 		Title: infoTitle,
 		Text:  "Escrowing key...",
@@ -158,7 +165,12 @@ func (lr *LuksRunner) getEscrowKey(ctx context.Context, devicePath string) ([]by
 	if err != nil {
 		log.Error().Err(err).Msg("failed to show progress dialog")
 	}
-	defer cancelProgress()
+
+	defer func() {
+		if err := cancelProgress(); err != nil {
+			log.Error().Err(err).Msg("failed to cancel progress dialog")
+		}
+	}()
 
 	escrowPassphrase, err := generateRandomPassphrase()
 	if err != nil {

--- a/orbit/pkg/luks/luks_test.go
+++ b/orbit/pkg/luks/luks_test.go
@@ -1,0 +1,215 @@
+package luks
+
+import (
+	"testing"
+
+	"github.com/tj/assert"
+)
+
+// output from cryptsetup luksDump /dev/sda3 --debug-json command
+// on cryptsetup 2.2.2
+var output = `# cryptsetup 2.2.2 processing "cryptsetup luksDump /dev/sda3 --debug-json"
+# Running command luksDump.
+# Locking memory.
+# Installing SIGINT/SIGTERM handler.
+# Unblocking interruption on signal.
+# Allocating context for crypt device /dev/sda3.
+# Trying to open and read device /dev/sda3 with direct-io.
+# Initialising device-mapper backend library.
+# Trying to load any crypt type from device /dev/sda3.
+# Crypto backend (OpenSSL 1.1.1f  31 Mar 2020) initialized in cryptsetup library version 2.2.2.
+# Detected kernel Linux 5.4.0-200-generic aarch64.
+# Loading LUKS2 header (repair disabled).
+# Acquiring read lock for device /dev/sda3.
+# Opening lock resource file /run/cryptsetup/L_8:3
+# Verifying lock handle for /dev/sda3.
+# Device /dev/sda3 READ lock taken.
+# Trying to read primary LUKS2 header at offset 0x0.
+# Opening locked device /dev/sda3
+# Veryfing locked device handle (bdev)
+# LUKS2 header version 2 of size 16384 bytes, checksum sha256.
+# Checksum:f16cfd36bbc588eb178d9f40e7da030edc6ed04cfb012ee14be14e3af459439b (on-disk)
+# Checksum:f16cfd36bbc588eb178d9f40e7da030edc6ed04cfb012ee14be14e3af459439b (in-memory)
+# Trying to read secondary LUKS2 header at offset 0x4000.
+# Reusing open ro fd on device /dev/sda3
+# LUKS2 header version 2 of size 16384 bytes, checksum sha256.
+# Checksum:0ce47e7c0460addb7a5ee2546e8404521ca0caf2e02830b1d4ef7172bf617d84 (on-disk)
+# Checksum:0ce47e7c0460addb7a5ee2546e8404521ca0caf2e02830b1d4ef7172bf617d84 (in-memory)
+# Device size 65442676736, offset 16777216.
+# Device /dev/sda3 READ lock released.
+# Only 2 active CPUs detected, PBKDF threads decreased from 4 to 2.
+# Not enough physical memory detected, PBKDF max memory decreased from 1048576kB to 1010800kB.
+# PBKDF argon2i, time_ms 2000 (iterations 0), max_memory_kb 1010800, parallel_threads 2.
+# {
+  "keyslots":{
+    "0":{
+      "type":"luks2",
+      "key_size":64,
+      "af":{
+        "type":"luks1",
+        "stripes":4000,
+        "hash":"sha256"
+      },
+      "area":{
+        "type":"raw",
+        "offset":"32768",
+        "size":"258048",
+        "encryption":"aes-xts-plain64",
+        "key_size":64
+      },
+      "kdf":{
+        "type":"argon2i",
+        "time":5,
+        "memory":1011024,
+        "cpus":2,
+        "salt":"b8+t4hTY/IFecqsKR20UZSUPFDZqyAtJ9lxYg5ye2Hg="
+      }
+    }
+  },
+  "tokens":{
+  },
+  "segments":{
+    "0":{
+      "type":"crypt",
+      "offset":"16777216",
+      "size":"dynamic",
+      "iv_tweak":"0",
+      "encryption":"aes-xts-plain64",
+      "sector_size":512
+    }
+  },
+  "digests":{
+    "0":{
+      "type":"pbkdf2",
+      "keyslots":[
+        "0"
+      ],
+      "segments":[
+        "0"
+      ],
+      "hash":"sha256",
+      "iterations":457493,
+      "salt":"BbZbHfAY5e90aoKjTYSJoj8ZLiRueUofVJWWG/4trWw=",
+      "digest":"f2sSMaJlh5qbdVUYT+RhabOmEit96KBIq0ltzAnfARc="
+    }
+  },
+  "config":{
+    "json_size":"12288",
+    "keyslots_size":"16744448"
+  }
+}LUKS header information
+Version:       	2
+Epoch:         	5
+Metadata area: 	16384 [bytes]
+Keyslots area: 	16744448 [bytes]
+UUID:          	3cf8a080-045d-4bc2-889c-994c9b4a18aa
+Label:         	(no label)
+Subsystem:     	(no subsystem)
+Flags:       	(no flags)
+
+Data segments:
+  0: crypt
+	offset: 16777216 [bytes]
+	length: (whole device)
+	cipher: aes-xts-plain64
+	sector: 512 [bytes]
+
+Keyslots:
+  0: luks2
+	Key:        512 bits
+	Priority:   normal
+	Cipher:     aes-xts-plain64
+	Cipher key: 512 bits
+	PBKDF:      argon2i
+	Time cost:  5
+	Memory:     1011024
+	Threads:    2
+	Salt:       6f cf ad e2 14 d8 fc 81 5e 72 ab 0a 47 6d 14 65
+	            25 0f 14 36 6a c8 0b 49 f6 5c 58 83 9c 9e d8 78
+	AF stripes: 4000
+	AF hash:    sha256
+	Area offset:32768 [bytes]
+	Area length:258048 [bytes]
+	Digest ID:  0
+Tokens:
+Digests:
+  0: pbkdf2
+	Hash:       sha256
+	Iterations: 457493
+	Salt:       05 b6 5b 1d f0 18 e5 ef 74 6a 82 a3 4d 84 89 a2
+	            3f 19 2e 24 6e 79 4a 1f 54 95 96 1b fe 2d ad 6c
+	Digest:     7f 6b 12 31 a2 65 87 9a 9b 75 55 18 4f e4 61 69
+	            b3 a6 12 2b 7d e8 a0 48 ab 49 6d cc 09 df 01 17
+# Releasing crypt device /dev/sda3 context.
+# Releasing device-mapper backend.
+# Closing read only fd for /dev/sda3.
+# Unlocking memory.
+Command successful.`
+
+var extractedJSON = `{
+  "keyslots":{
+    "0":{
+      "type":"luks2",
+      "key_size":64,
+      "af":{
+        "type":"luks1",
+        "stripes":4000,
+        "hash":"sha256"
+      },
+      "area":{
+        "type":"raw",
+        "offset":"32768",
+        "size":"258048",
+        "encryption":"aes-xts-plain64",
+        "key_size":64
+      },
+      "kdf":{
+        "type":"argon2i",
+        "time":5,
+        "memory":1011024,
+        "cpus":2,
+        "salt":"b8+t4hTY/IFecqsKR20UZSUPFDZqyAtJ9lxYg5ye2Hg="
+      }
+    }
+  },
+  "tokens":{
+  },
+  "segments":{
+    "0":{
+      "type":"crypt",
+      "offset":"16777216",
+      "size":"dynamic",
+      "iv_tweak":"0",
+      "encryption":"aes-xts-plain64",
+      "sector_size":512
+    }
+  },
+  "digests":{
+    "0":{
+      "type":"pbkdf2",
+      "keyslots":[
+        "0"
+      ],
+      "segments":[
+        "0"
+      ],
+      "hash":"sha256",
+      "iterations":457493,
+      "salt":"BbZbHfAY5e90aoKjTYSJoj8ZLiRueUofVJWWG/4trWw=",
+      "digest":"f2sSMaJlh5qbdVUYT+RhabOmEit96KBIq0ltzAnfARc="
+    }
+  },
+  "config":{
+    "json_size":"12288",
+    "keyslots_size":"16744448"
+  }
+}`
+
+func TestExtractJson(t *testing.T) {
+	json, err := extractJSON([]byte(output))
+	assert.NoError(t, err)
+	assert.Equal(t, extractedJSON, string(json))
+
+	_, err = extractJSON([]byte("no json"))
+	assert.Error(t, err)
+}

--- a/orbit/pkg/zenity/zenity.go
+++ b/orbit/pkg/zenity/zenity.go
@@ -2,7 +2,6 @@ package zenity
 
 import (
 	"bytes"
-	"context"
 	"errors"
 	"fmt"
 
@@ -14,7 +13,7 @@ const zenityProcessName = "zenity"
 
 type Zenity struct {
 	// cmdWithOutput can be set in tests to mock execution of the dialog.
-	cmdWithOutput func(ctx context.Context, args ...string) ([]byte, int, error)
+	cmdWithOutput func(args ...string) ([]byte, int, error)
 	// cmdWithWait can be set in tests to mock execution of the dialog.
 	cmdWithCancel func(args ...string) (func() error, error)
 }
@@ -45,7 +44,7 @@ func (z *Zenity) ShowEntry(opts dialog.EntryOptions) ([]byte, error) {
 		args = append(args, fmt.Sprintf("--timeout=%d", int(opts.TimeOut.Seconds())))
 	}
 
-	output, statusCode, err := z.cmdWithOutput(context.Background(), args...)
+	output, statusCode, err := z.cmdWithOutput(args...)
 	if err != nil {
 		switch statusCode {
 		case 1:
@@ -73,7 +72,7 @@ func (z *Zenity) ShowInfo(opts dialog.InfoOptions) error {
 		args = append(args, fmt.Sprintf("--timeout=%d", int(opts.TimeOut.Seconds())))
 	}
 
-	_, statusCode, err := z.cmdWithOutput(context.Background(), args...)
+	_, statusCode, err := z.cmdWithOutput(args...)
 	if err != nil {
 		switch statusCode {
 		case 5:
@@ -114,13 +113,13 @@ func (z *Zenity) ShowProgress(opts dialog.ProgressOptions) (func() error, error)
 	return cancel, nil
 }
 
-func execCmdWithOutput(ctx context.Context, args ...string) ([]byte, int, error) {
+func execCmdWithOutput(args ...string) ([]byte, int, error) {
 	var opts []execuser.Option
 	for _, arg := range args {
 		opts = append(opts, execuser.WithArg(arg, "")) // Using empty value for positional args
 	}
 
-	output, exitCode, err := execuser.RunWithOutput(ctx, zenityProcessName, opts...)
+	output, exitCode, err := execuser.RunWithOutput(zenityProcessName, opts...)
 
 	// Trim the newline from zenity output
 	output = bytes.TrimSuffix(output, []byte("\n"))

--- a/orbit/pkg/zenity/zenity_test.go
+++ b/orbit/pkg/zenity/zenity_test.go
@@ -1,7 +1,6 @@
 package zenity
 
 import (
-	"context"
 	"os/exec"
 	"testing"
 	"time"
@@ -18,7 +17,7 @@ type mockExecCmd struct {
 }
 
 // MockCommandContext simulates exec.CommandContext and captures arguments
-func (m *mockExecCmd) runWithOutput(ctx context.Context, args ...string) ([]byte, int, error) {
+func (m *mockExecCmd) runWithOutput(args ...string) ([]byte, int, error) {
 	m.capturedArgs = append(m.capturedArgs, args...)
 
 	if m.exitCode != 0 {
@@ -35,8 +34,6 @@ func (m *mockExecCmd) runWithStdin(args ...string) (func() error, error) {
 }
 
 func TestShowEntryArgs(t *testing.T) {
-	ctx := context.Background()
-
 	testCases := []struct {
 		name         string
 		opts         dialog.EntryOptions
@@ -70,7 +67,7 @@ func TestShowEntryArgs(t *testing.T) {
 			z := &Zenity{
 				cmdWithOutput: mock.runWithOutput,
 			}
-			output, err := z.ShowEntry(ctx, tt.opts)
+			output, err := z.ShowEntry(tt.opts)
 			assert.NoError(t, err)
 			assert.Equal(t, tt.expectedArgs, mock.capturedArgs)
 			assert.Equal(t, []byte("some output"), output)
@@ -79,8 +76,6 @@ func TestShowEntryArgs(t *testing.T) {
 }
 
 func TestShowEntryError(t *testing.T) {
-	ctx := context.Background()
-
 	testcases := []struct {
 		name        string
 		exitCode    int
@@ -111,7 +106,7 @@ func TestShowEntryError(t *testing.T) {
 			z := &Zenity{
 				cmdWithOutput: mock.runWithOutput,
 			}
-			output, err := z.ShowEntry(ctx, dialog.EntryOptions{})
+			output, err := z.ShowEntry(dialog.EntryOptions{})
 			require.ErrorIs(t, err, tt.expectedErr)
 			assert.Nil(t, output)
 		})
@@ -119,22 +114,18 @@ func TestShowEntryError(t *testing.T) {
 }
 
 func TestShowEntrySuccess(t *testing.T) {
-	ctx := context.Background()
-
 	mock := &mockExecCmd{
 		output: []byte("some output"),
 	}
 	z := &Zenity{
 		cmdWithOutput: mock.runWithOutput,
 	}
-	output, err := z.ShowEntry(ctx, dialog.EntryOptions{})
+	output, err := z.ShowEntry(dialog.EntryOptions{})
 	assert.NoError(t, err)
 	assert.Equal(t, []byte("some output"), output)
 }
 
 func TestShowInfoArgs(t *testing.T) {
-	ctx := context.Background()
-
 	testCases := []struct {
 		name         string
 		opts         dialog.InfoOptions
@@ -162,7 +153,7 @@ func TestShowInfoArgs(t *testing.T) {
 			z := &Zenity{
 				cmdWithOutput: mock.runWithOutput,
 			}
-			err := z.ShowInfo(ctx, tt.opts)
+			err := z.ShowInfo(tt.opts)
 			assert.NoError(t, err)
 			assert.Equal(t, tt.expectedArgs, mock.capturedArgs)
 		})
@@ -170,8 +161,6 @@ func TestShowInfoArgs(t *testing.T) {
 }
 
 func TestShowInfoError(t *testing.T) {
-	ctx := context.Background()
-
 	testcases := []struct {
 		name        string
 		exitCode    int
@@ -197,7 +186,7 @@ func TestShowInfoError(t *testing.T) {
 			z := &Zenity{
 				cmdWithOutput: mock.runWithOutput,
 			}
-			err := z.ShowInfo(ctx, dialog.InfoOptions{})
+			err := z.ShowInfo(dialog.InfoOptions{})
 			require.ErrorIs(t, err, tt.expectedErr)
 		})
 	}

--- a/orbit/pkg/zenity/zenity_test.go
+++ b/orbit/pkg/zenity/zenity_test.go
@@ -1,7 +1,6 @@
 package zenity
 
 import (
-	"context"
 	"os/exec"
 	"testing"
 	"time"
@@ -18,7 +17,7 @@ type mockExecCmd struct {
 }
 
 // MockCommandContext simulates exec.CommandContext and captures arguments
-func (m *mockExecCmd) runWithOutput(ctx context.Context, args ...string) ([]byte, int, error) {
+func (m *mockExecCmd) runWithOutput(args ...string) ([]byte, int, error) {
 	m.capturedArgs = append(m.capturedArgs, args...)
 
 	if m.exitCode != 0 {

--- a/orbit/pkg/zenity/zenity_test.go
+++ b/orbit/pkg/zenity/zenity_test.go
@@ -1,6 +1,7 @@
 package zenity
 
 import (
+	"context"
 	"os/exec"
 	"testing"
 	"time"
@@ -17,7 +18,7 @@ type mockExecCmd struct {
 }
 
 // MockCommandContext simulates exec.CommandContext and captures arguments
-func (m *mockExecCmd) runWithOutput(args ...string) ([]byte, int, error) {
+func (m *mockExecCmd) runWithOutput(ctx context.Context, args ...string) ([]byte, int, error) {
 	m.capturedArgs = append(m.capturedArgs, args...)
 
 	if m.exitCode != 0 {

--- a/tools/dialog/main.go
+++ b/tools/dialog/main.go
@@ -27,21 +27,20 @@ func main() {
 		panic(err)
 	}
 
-	ctx, cancelProgress := context.WithCancel(context.Background())
-
-	go func() {
-		err := prompt.ShowProgress(ctx, dialog.ProgressOptions{
-			Title: "Zenity Test Progress Title",
-			Text:  "Zenity Test Progress Text",
-		})
-		if err != nil {
-			fmt.Println("Err ShowProgress")
-			panic(err)
-		}
-	}()
+	cancelProgress, err := prompt.ShowProgress(dialog.ProgressOptions{
+		Title: "Zenity Test Progress Title",
+		Text:  "Zenity Test Progress Text",
+	})
+	if err != nil {
+		fmt.Println("Err ShowProgress")
+		panic(err)
+	}
 
 	time.Sleep(2 * time.Second)
-	cancelProgress()
+	if err := cancelProgress(); err != nil {
+		fmt.Println("Err cancelProgress")
+		panic(err)
+	}
 
 	err = prompt.ShowInfo(ctx, dialog.InfoOptions{
 		Title:   "Zenity Test Info Title",

--- a/tools/dialog/main.go
+++ b/tools/dialog/main.go
@@ -4,19 +4,30 @@ package main
 // It will show an entry dialog, a progress dialog, and an info dialog
 
 import (
-	"context"
+	"flag"
 	"fmt"
 	"time"
 
 	"github.com/fleetdm/fleet/v4/orbit/pkg/dialog"
+	"github.com/fleetdm/fleet/v4/orbit/pkg/kdialog"
 	"github.com/fleetdm/fleet/v4/orbit/pkg/zenity"
 )
 
 func main() {
-	prompt := zenity.New()
-	ctx := context.Background()
+	dialogTool := flag.String("dialog", "zenity", "Dialog to use: zenity or kdialog")
+	flag.Parse()
 
-	output, err := prompt.ShowEntry(ctx, dialog.EntryOptions{
+	var prompt dialog.Dialog
+
+	if *dialogTool == "zenity" {
+		fmt.Println("Using zenity")
+		prompt = zenity.New()
+	} else {
+		fmt.Println("Using kdialog")
+		prompt = kdialog.New()
+	}
+
+	output, err := prompt.ShowEntry(dialog.EntryOptions{
 		Title:    "Zenity Test Entry Title",
 		Text:     "Zenity Test Entry Text",
 		HideText: true,
@@ -42,7 +53,7 @@ func main() {
 		panic(err)
 	}
 
-	err = prompt.ShowInfo(ctx, dialog.InfoOptions{
+	err = prompt.ShowInfo(dialog.InfoOptions{
 		Title:   "Zenity Test Info Title",
 		Text:    "Result: " + string(output),
 		TimeOut: 10 * time.Second,

--- a/tools/luks/luks/main.go
+++ b/tools/luks/luks/main.go
@@ -24,7 +24,7 @@ func main() {
 	prompt := zenity.New()
 
 	// Prompt existing passphrase from the user.
-	currentPassphrase, err := prompt.ShowEntry(context.Background(), dialog.EntryOptions{
+	currentPassphrase, err := prompt.ShowEntry(dialog.EntryOptions{
 		Title:    "Enter Existing LUKS Passphrase",
 		Text:     "Enter your existing LUKS passphrase:",
 		HideText: true,
@@ -49,7 +49,7 @@ func main() {
 
 		if err := device.AddKey(context.Background(), devicePath, userKey, escrowKey); err != nil {
 			if errors.Is(err, encryption.ErrEncryptionKeyRejected) {
-				currentPassphrase, err = prompt.ShowEntry(context.Background(), dialog.EntryOptions{
+				currentPassphrase, err = prompt.ShowEntry(dialog.EntryOptions{
 					Title:    "Enter Existing LUKS Passphrase",
 					Text:     "Bad password. Enter your existing LUKS passphrase:",
 					HideText: true,


### PR DESCRIPTION
# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [ ] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/Committing-Changes.md#changes-files) for more information.
- [ ] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [ ] Added support on fleet's osquery simulator `cmd/osquery-perf` for new osquery data ingestion features.
- [ ] Added/updated tests
- [ ] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes
- [ ] If database migrations are included, checked table schema to confirm autoupdate
- For database migrations:
  - [ ] Checked schema for all modified table for columns that will auto-update timestamps during migration.
  - [ ] Confirmed that updating the timestamps is acceptable, and will not cause unwanted side effects.
  - [ ] Ensured the correct collation is explicitly set for character columns (`COLLATE utf8mb4_unicode_ci`).
- [ ] Manual QA for all new/changed functionality
- For Orbit and Fleet Desktop changes:
   - [ ] Orbit runs on macOS, Linux and Windows. Check if the orbit feature/bugfix should only apply to one platform (`runtime.GOOS`).
   - [ ] Manual QA must be performed in the three main OSs, macOS, Windows and Linux.
   - [ ] Auto-update manual QA, from released version of component to new version (see [tools/tuf/test](../tools/tuf/test/README.md)).
