### PR TITLE
Stop legacy query packs from spamming errors

### DIFF
--- a/changes/24386-fleet-legacy-query-pack
+++ b/changes/24386-fleet-legacy-query-pack
@@ -1,0 +1,1 @@
+- Stop older scheduled queries from filling logs with errors

--- a/server/fleet/osquery.go
+++ b/server/fleet/osquery.go
@@ -1,5 +1,7 @@
 package fleet
 
+import "errors"
+
 // OsqueryDistributedQueryResults represents the format of the results of an
 // osquery distributed query.
 type OsqueryDistributedQueryResults map[string][]map[string]string
@@ -7,6 +9,8 @@ type OsqueryDistributedQueryResults map[string][]map[string]string
 // OsqueryStatus represents osquery status codes (0 = success, nonzero =
 // failure)
 type OsqueryStatus int
+
+var ErrLegacyQueryPack = errors.New("legacy query pack, storage not supported")
 
 // Stats contains the performance statistics about the execution of a specific osquery query.
 type Stats struct {

--- a/server/service/osquery.go
+++ b/server/service/osquery.go
@@ -2463,7 +2463,7 @@ func getQueryNameAndTeamIDFromResult(path string) (*uint, string, error) {
 		// scheduled queries).
 
 		// We can't infer the team from this and it can't be stored, but it's still valid
-		if strings.HasPrefix(path, "pack"+sep) && strings.Count(path, "/") == 2 {
+		if strings.HasPrefix(path, "pack/") && strings.Count(path, "/") == 2 {
 			return nil, "", fleet.ErrLegacyQueryPack
 		}
 

--- a/server/service/osquery.go
+++ b/server/service/osquery.go
@@ -2146,6 +2146,8 @@ func (svc *Service) preProcessOsqueryResults(
 		}
 		teamID, queryName, err := getQueryNameAndTeamIDFromResult(queryResult.QueryName)
 		if errors.Is(err, fleet.ErrLegacyQueryPack) {
+			// Legacy query. Cannot be stored and cannot
+			// infer team ID, but still used by some customers
 			continue
 		}
 		if err != nil {

--- a/server/service/osquery.go
+++ b/server/service/osquery.go
@@ -2461,6 +2461,13 @@ func getQueryNameAndTeamIDFromResult(path string) (*uint, string, error) {
 		// 2017/legacy packs with the format "pack/<Pack name>/<Query name> are
 		// considered unknown format (they are not considered global or team
 		// scheduled queries).
+
+		// We can't infer the team from this and it can't be stored, but it's still valid
+		if strings.HasPrefix(path, "pack"+sep) && strings.Count(path, "/") == 2 {
+			return nil, "", fleet.ErrLegacyQueryPack
+		}
+
+		// Truly unknown
 		return nil, "", fmt.Errorf("unknown format: %q", path)
 	}
 
@@ -2493,11 +2500,6 @@ func getQueryNameAndTeamIDFromResult(path string) (*uint, string, error) {
 		return &teamNumber, teamIDAndQueryNameParts[1], nil
 	}
 
-	// Legacy query packs: path/<anything>/Name
-	// We can't infer the team from this and it can't be stored, but it's still valid
-	if strings.HasPrefix(path, "path"+sep) && strings.Count(path, "/") == 2 {
-		return nil, "", fleet.ErrLegacyQueryPack
-	}
 	// If none of the above patterns match, return error
 	return nil, "", fmt.Errorf("unknown format: %q", path)
 }


### PR DESCRIPTION
#24386

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/Committing-Changes.md#changes-files) for more information.
- [x] Manual QA for all new/changed functionality