### PR TITLE
Optimized software versions endpoint

### DIFF
--- a/changes/23679-optimize-software-versions
+++ b/changes/23679-optimize-software-versions
@@ -1,1 +1,1 @@
-* Added `without_vulnerability_details` to software versions endpoint so the CVE details can be truncated
+* Added `without_vulnerability_details` to software versions endpoint (/api/latest/fleet/software/versions) so CVE details can be truncated when on Fleet Premium

--- a/changes/23679-optimize-software-versions
+++ b/changes/23679-optimize-software-versions
@@ -1,0 +1,1 @@
+* Added `without_vulnerability_details` to software versions endpoint so the CVE details can be truncated

--- a/ee/server/service/software.go
+++ b/ee/server/service/software.go
@@ -8,7 +8,11 @@ import (
 
 func (svc *Service) ListSoftware(ctx context.Context, opts fleet.SoftwareListOptions) ([]fleet.Software, *fleet.PaginationMetadata, error) {
 	// reuse ListSoftware, but include cve scores in premium version
-	opts.IncludeCVEScores = true
+	// unless without_vulnerability_details is set to true
+	// including these details causes a lot of memory bloat
+	if !opts.WithoutVulnerabilityDetails {
+		opts.IncludeCVEScores = true
+	}
 	return svc.Service.ListSoftware(ctx, opts)
 }
 

--- a/frontend/pages/SoftwarePage/SoftwareTitles/SoftwareTitles.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitles/SoftwareTitles.tsx
@@ -125,6 +125,7 @@ const SoftwareTitles = ({
         teamId,
         addedSoftwareToken,
         ...vulnFilters,
+        ...(showVersions ? { without_vulnerability_details: true } : {}),
       },
     ],
     ({ queryKey: [queryKey] }) =>

--- a/server/fleet/software.go
+++ b/server/fleet/software.go
@@ -305,13 +305,14 @@ type SoftwareListOptions struct {
 	ListOptions ListOptions `url:"list_options"`
 
 	// HostID filters software to the specified host if not nil.
-	HostID           *uint
-	TeamID           *uint `query:"team_id,optional"`
-	VulnerableOnly   bool  `query:"vulnerable,optional"`
-	IncludeCVEScores bool
-	KnownExploit     bool    `query:"exploit,optional"`
-	MinimumCVSS      float64 `query:"min_cvss_score,optional"`
-	MaximumCVSS      float64 `query:"max_cvss_score,optional"`
+	HostID                      *uint
+	TeamID                      *uint `query:"team_id,optional"`
+	VulnerableOnly              bool  `query:"vulnerable,optional"`
+	WithoutVulnerabilityDetails bool  `query:"without_vulnerability_details,optional"`
+	IncludeCVEScores            bool
+	KnownExploit                bool    `query:"exploit,optional"`
+	MinimumCVSS                 float64 `query:"min_cvss_score,optional"`
+	MaximumCVSS                 float64 `query:"max_cvss_score,optional"`
 
 	// WithHostCounts indicates that the list of software should include the
 	// counts of hosts per software, and include only those software that have

--- a/server/service/integration_core_test.go
+++ b/server/service/integration_core_test.go
@@ -7300,6 +7300,25 @@ func (s *integrationTestSuite) TestListSoftwareAndSoftwareDetails() {
 		"GET", fmt.Sprintf("/api/latest/fleet/software/versions/%d", versResp.Software[0].ID), nil, http.StatusNotFound, &detailsResp,
 		"team_id", "999999",
 	)
+
+	// a request with without_vulnerability_details set to false does not return extra details
+	respVersions := listSoftwareVersionsResponse{}
+	s.DoJSON(
+		"GET", "/api/latest/fleet/software/versions",
+		listSoftwareRequest{},
+		http.StatusOK, &respVersions,
+		"without_vulnerability_details", "false",
+	)
+	for _, s := range respVersions.Software {
+		for _, cve := range s.Vulnerabilities {
+			require.Nil(t, cve.CVSSScore)
+			require.Nil(t, cve.EPSSProbability)
+			require.Nil(t, cve.CISAKnownExploit)
+			require.Nil(t, cve.CVEPublished)
+			require.Nil(t, cve.Description)
+			require.Nil(t, cve.ResolvedInVersion)
+		}
+	}
 }
 
 func (s *integrationTestSuite) TestChangeUserEmail() {

--- a/server/service/integration_enterprise_test.go
+++ b/server/service/integration_enterprise_test.go
@@ -5210,6 +5210,22 @@ func (s *integrationEnterpriseTestSuite) TestListSoftware() {
 	s.DoJSON(
 		"GET", "/api/latest/fleet/software/versions",
 		listSoftwareRequest{},
+		http.StatusOK, &respVersions,
+		"without_vulnerability_details", "true",
+	)
+	for _, s := range respVersions.Software {
+		for _, cve := range s.Vulnerabilities {
+			require.Nil(t, cve.CVSSScore)
+			require.Nil(t, cve.EPSSProbability)
+			require.Nil(t, cve.CISAKnownExploit)
+			require.Nil(t, cve.CVEPublished)
+			require.Nil(t, cve.Description)
+			require.Nil(t, cve.ResolvedInVersion)
+		}
+	}
+	s.DoJSON(
+		"GET", "/api/latest/fleet/software/versions",
+		listSoftwareRequest{},
 		http.StatusUnprocessableEntity, &respVersions,
 		"exploit", "true",
 	)


### PR DESCRIPTION
The software versions endpoint cve details can be truncated using the `without_vulnerability_details` flag.

https://github.com/fleetdm/fleet/issues/23679

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/Committing-Changes.md#changes-files) for more information.
- [x] Added/updated tests
- [x] Manual QA for all new/changed functionality