### PR TITLE
Use `sync.Map` to prevent race on map access in `osquery-perf`

### DIFF
--- a/cmd/osquery-perf/agent.go
+++ b/cmd/osquery-perf/agent.go
@@ -776,7 +776,6 @@ func (a *agent) runLoop(i int, onlyAlreadyEnrolled bool) {
 		// check if we have any scheduled queries that should be returning results
 		var results []resultLog
 		now := time.Now().Unix()
-		// a.scheduledQueriesMu.Lock()
 		prevCount := a.countBuffered()
 
 		a.scheduledQueryData.Range(func(key, value any) bool {

--- a/cmd/osquery-perf/agent.go
+++ b/cmd/osquery-perf/agent.go
@@ -2427,7 +2427,6 @@ func (a *agent) submitLogs(results []resultLog) error {
 	}
 
 	body := []byte(`{"node_key": "` + a.nodeKey + `", "log_type": "result", "data": [` + string(resultLogs) + `]}`)
-
 	request, err := http.NewRequest("POST", a.serverAddress+"/api/osquery/log", bytes.NewReader(body))
 	if err != nil {
 		return err

--- a/cmd/osquery-perf/agent.go
+++ b/cmd/osquery-perf/agent.go
@@ -779,6 +779,12 @@ func (a *agent) runLoop(i int, onlyAlreadyEnrolled bool) {
 		now := time.Now().Unix()
 		prevCount := a.countBuffered()
 
+		// NOTE The goroutine that pulls in new configurations
+		// MAY replace this map if it happens to run at the
+		// exact same time. The result would be. The result
+		// would be that the query lastRun does not get
+		// updated and cause the query to run more times than
+		// expected.
 		queryData := a.scheduledQueryData
 		queryData.Range(func(key, value any) bool {
 			queryName := key.(string)

--- a/cmd/osquery-perf/agent.go
+++ b/cmd/osquery-perf/agent.go
@@ -814,9 +814,7 @@ func (a *agent) countBuffered() int {
 }
 
 func (a *agent) addToBuffer(results []resultLog) {
-	fmt.Println("addToBuffer called!!")
 	for _, result := range results {
-		fmt.Printf("adding buffered result: %+v\n", result)
 		a.bufferedResults[result] += 1
 	}
 }

--- a/cmd/osquery-perf/agent.go
+++ b/cmd/osquery-perf/agent.go
@@ -779,7 +779,8 @@ func (a *agent) runLoop(i int, onlyAlreadyEnrolled bool) {
 		now := time.Now().Unix()
 		prevCount := a.countBuffered()
 
-		a.scheduledQueryData.Range(func(key, value any) bool {
+		queryData := a.scheduledQueryData
+		queryData.Range(func(key, value any) bool {
 			queryName := key.(string)
 			query := value.(scheduledQuery)
 
@@ -791,7 +792,7 @@ func (a *agent) runLoop(i int, onlyAlreadyEnrolled bool) {
 				})
 				// Update lastRun
 				query.lastRun = now
-				a.scheduledQueryData.Store(queryName, query)
+				queryData.Store(queryName, query)
 			}
 
 			return true


### PR DESCRIPTION
#24381

Do we add `changes/` for `osquery-perf`?
- [x] Manual QA for all new/changed functionality
