### PR TITLE
Bump Go version from 1.23.1 to 1.23.4, Alpine on Docker images from 3.20 to 3.21

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.20.1@sha256:b89d9c93e9ed3597455c90a0b88a8bbb5cb7188438f70953fede212a0c4394e0
+FROM alpine:3.21@sha256:2c43f33bd1502ec7818bce9eea60e062d04eeadc4aa31cad9dabecb1e48b647b
 LABEL maintainer="Fleet Developers"
 
 RUN apk --update add ca-certificates

--- a/Dockerfile-desktop-linux
+++ b/Dockerfile-desktop-linux
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 golang:1.23.1-bullseye@sha256:45b43371f21ec51276118e6806a22cbb0bca087ddd54c491fdc7149be01035d5
+FROM --platform=linux/amd64 golang:1.23.4-bullseye@sha256:c046c91923e7285772f902b98b01f96f7d37387c6a4d5cdd353abc7cf74d2a2b
 LABEL maintainer="Fleet Developers"
 
 RUN mkdir -p /usr/src/fleet

--- a/changes/update-go1.23.4
+++ b/changes/update-go1.23.4
@@ -1,0 +1,1 @@
+* Updated Go version to 1.23.4

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/fleetdm/fleet/v4
 
-go 1.23.1
+go 1.23.4
 
 require (
 	cloud.google.com/go/pubsub v1.37.0

--- a/infrastructure/loadtesting/terraform/docker/loadtest.Dockerfile
+++ b/infrastructure/loadtesting/terraform/docker/loadtest.Dockerfile
@@ -1,9 +1,9 @@
-FROM golang:1.23.1-alpine3.20@sha256:436e2d978524b15498b98faa367553ba6c3655671226f500c72ceb7afb2ef0b1
+FROM golang:1.23.4-alpine3.21@sha256:052793ea3143a235a5b2d815ccead8910cfe547b36a1f4c8b070015b89da5eab
 ARG TAG
 RUN apk add git
 RUN git clone -b $TAG --depth=1 --no-tags --progress --no-recurse-submodules https://github.com/fleetdm/fleet.git && cd /go/fleet/cmd/osquery-perf/ && go build .
 
-FROM alpine:3.20@sha256:77726ef6b57ddf65bb551896826ec38bc3e53f75cdde31354fbffb4f25238ebd
+FROM alpine:3.21@sha256:2c43f33bd1502ec7818bce9eea60e062d04eeadc4aa31cad9dabecb1e48b647b
 LABEL maintainer="Fleet Developers"
 
 # Create FleetDM group and user

--- a/orbit/changes/update-go1.23.4
+++ b/orbit/changes/update-go1.23.4
@@ -1,0 +1,1 @@
+* Updated Go version to 1.23.4

--- a/terraform/addons/monitoring/lambda/go.mod
+++ b/terraform/addons/monitoring/lambda/go.mod
@@ -1,6 +1,6 @@
 module github.com/fleetdm/fleet/terraform/addons/monitoring/lambda
 
-go 1.23.1
+go 1.23.4
 
 require (
 	github.com/aws/aws-lambda-go v1.41.0

--- a/tools/fleet-docker/Dockerfile
+++ b/tools/fleet-docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.20.1@sha256:b89d9c93e9ed3597455c90a0b88a8bbb5cb7188438f70953fede212a0c4394e0
+FROM alpine:3.21@sha256:2c43f33bd1502ec7818bce9eea60e062d04eeadc4aa31cad9dabecb1e48b647b
 LABEL maintainer="Fleet Developers"
 
 RUN apk --update add ca-certificates

--- a/tools/mdm/migration/mdmproxy/Dockerfile
+++ b/tools/mdm/migration/mdmproxy/Dockerfile
@@ -1,9 +1,9 @@
-FROM golang:1.23.1-alpine3.20@sha256:436e2d978524b15498b98faa367553ba6c3655671226f500c72ceb7afb2ef0b1
+FROM golang:1.23.4-alpine3.21@sha256:052793ea3143a235a5b2d815ccead8910cfe547b36a1f4c8b070015b89da5eab
 ARG TAG
 RUN apk update && apk add --no-cache git
 RUN git clone -b $TAG --depth=1 --no-tags --progress --no-recurse-submodules https://github.com/fleetdm/fleet.git && cd /go/fleet/tools/mdm/migration/mdmproxy && go build .
 
-FROM alpine:3.20.1@sha256:b89d9c93e9ed3597455c90a0b88a8bbb5cb7188438f70953fede212a0c4394e0
+FROM alpine:3.21@sha256:2c43f33bd1502ec7818bce9eea60e062d04eeadc4aa31cad9dabecb1e48b647b
 LABEL maintainer="Fleet Developers"
 
 RUN apk update && apk add --no-cache tini

--- a/tools/mdm/windows/bitlocker/go.mod
+++ b/tools/mdm/windows/bitlocker/go.mod
@@ -1,6 +1,6 @@
 module bitlocker
 
-go 1.23.1
+go 1.23.4
 
 require github.com/go-ole/go-ole v1.3.0
 

--- a/tools/terraform/go.mod
+++ b/tools/terraform/go.mod
@@ -1,6 +1,6 @@
 module terraform-provider-fleetdm
 
-go 1.23.1
+go 1.23.4
 
 require (
 	github.com/hashicorp/terraform-plugin-framework v1.7.0


### PR DESCRIPTION
Kept the Debian-based image at Bullseye.

For #24517.

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/Committing-Changes.md#changes-files) for more information.
- [x] Manual QA for all new/changed functionality: Validated builds (Docker and make) all work after this change, except for BitLocker (requires Windows).