### PR TITLE
CIS Benchmarks guide: macOS 15 is supported

### DIFF
--- a/articles/cis-benchmarks.md
+++ b/articles/cis-benchmarks.md
@@ -8,6 +8,7 @@ For more information about CIS Benchmarks check out [Center for Internet Securit
 Fleet has implemented native support for CIS Benchmarks for the following platforms:
 - macOS 13.0 Ventura
 - macOS 14.0 Sonoma
+- macOS 15.0 Sequoia
 - Windows 10 Enterprise
 - Windows 11 Enterprise
 
@@ -103,6 +104,7 @@ Certain benchmarks cannot be automated by a policy in Fleet. For a list of speci
 
 - [macOS 13.0 Ventura](https://github.com/fleetdm/fleet/blob/main/ee/cis/macos-13/README.md)
 - [macOS 14.0 Sonoma](https://github.com/fleetdm/fleet/blob/main/ee/cis/macos-14/README.md)
+- [macos 15.0 Sequoia](https://github.com/fleetdm/fleet/blob/main/ee/cis/macos-15/README.md)
 - [Windows 10 Enterprise](https://github.com/fleetdm/fleet/blob/main/ee/cis/win-10/README.md)
 - [Windows 11 Enterprise](https://github.com/fleetdm/fleet/blob/main/ee/cis/win-11/README.md)
 


### PR DESCRIPTION
CIS Benchmarks for macOS 15 were added in this user story: #23611
