### PR TITLE
Fleet UI: Export to CSV does not trim leading zeros

### DIFF
--- a/changes/23803-leading-zeros-bug
+++ b/changes/23803-leading-zeros-bug
@@ -1,0 +1,1 @@
+- Fleet UI: Fix export to CSV from trimming leading zeros by treating those values as strings

--- a/frontend/utilities/convert_to_csv/index.ts
+++ b/frontend/utilities/convert_to_csv/index.ts
@@ -11,6 +11,12 @@ const formatFieldForCSV = (value: any): string => {
   if (typeof value === "object") {
     value = JSON.stringify(value);
   }
+
+  // Treat values with leading zeros as strings so csv file doesn't trim leading zeros
+  if (/^0\d+$/.test(value)) {
+    return `"=""${value}"""`;
+  }
+
   // Escape double quotes in the value by doubling them
   if (typeof value === "string") {
     value = value.replace(/"/g, '""');


### PR DESCRIPTION
## Issue
Cerra #23803 

## Description
- Export to CSV was trimming leading zeros
- Fix so leading zeros are preserved

### Other
Options found were:
- Using a .csvt file. In this file, specify the data types for each column (a lot of refactor and testing and maybe we don't want .csvt file
- Using data type prefixes: Some systems support adding prefixes to the CSV data itself to specify data types (again a lot of refactor and testing and maybe we don't want prefixes on everything
- Method of choice: reformat as `"=""<leadingzeronumber>"""` (e.g. `"=""00000409"""`) which will treat the number as text

## Screenshot of fix
<img width="1390" alt="Screenshot 2024-12-09 at 10 55 04 AM" src="https://github.com/user-attachments/assets/a0bc868d-c16b-4f1a-a6d5-85f011b1ab97">


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
- [x] Manual QA for all new/changed functionality

