### PR TITLE
Cherry-Pick: Fix duplicate queries when pulling query stats for a host

### DIFF
--- a/changes/23488-host-duplicate-queries
+++ b/changes/23488-host-duplicate-queries
@@ -1,0 +1,1 @@
+* Fix duplicate queries in query stats list in host details

--- a/server/datastore/mysql/hosts.go
+++ b/server/datastore/mysql/hosts.go
@@ -467,7 +467,12 @@ func loadHostScheduledQueryStatsDB(ctx context.Context, db sqlx.QueryerContext, 
 		GROUP BY q.id
 	`
 
-	sqlQuery := baseQuery + filter1 + " UNION ALL " + baseQuery + filter2
+	finalColumns := `id, name, description, team_id, schedule_interval, discard_data, automations_enabled,
+		last_fetched, average_memory, denylisted, executions, last_executed, output_size, system_time,
+		user_time, wall_time`
+
+	sqlQuery := `SELECT ` + finalColumns + ` FROM (` +
+		baseQuery + filter1 + " UNION ALL " + baseQuery + filter2 + `) qs GROUP BY ` + finalColumns
 
 	args := []interface{}{
 		pastDate,


### PR DESCRIPTION
For #23488. Merged into `main` via #24514.