### PR TITLE
Fleet UI: Do not remove team selection when creating a label

### DIFF
--- a/changes/24025-add-label-team-bug
+++ b/changes/24025-add-label-team-bug
@@ -1,0 +1,1 @@
+- Fix bug when creating a label to preserve the selected team

--- a/frontend/pages/labels/NewLabelPage/DynamicLabel/DynamicLabel.tsx
+++ b/frontend/pages/labels/NewLabelPage/DynamicLabel/DynamicLabel.tsx
@@ -3,7 +3,9 @@ import { RouteComponentProps } from "react-router";
 
 import PATHS from "router/paths";
 import labelsAPI from "services/entities/labels";
+import { AppContext } from "context/app";
 import { NotificationContext } from "context/notification";
+import { buildQueryStringFromParams } from "utilities/url";
 import { IApiError } from "interfaces/errors";
 
 import DynamicLabelForm from "pages/labels/components/DynamicLabelForm";
@@ -26,6 +28,7 @@ const DynamicLabel = ({
   onOpenSidebar,
   onOsqueryTableSelect,
 }: IDynamicLabelProps) => {
+  const { currentTeam } = useContext(AppContext);
   const { renderFlash } = useContext(NotificationContext);
 
   const onSaveNewLabel = useCallback(
@@ -33,8 +36,11 @@ const DynamicLabel = ({
       labelsAPI
         .create(formData)
         .then((res) => {
-          router.push(PATHS.MANAGE_HOSTS_LABEL(res.label.id));
-          renderFlash("success", "Label added successfully.");
+          router.push(
+            `${PATHS.MANAGE_HOSTS_LABEL(
+              res.label.id
+            )}?${buildQueryStringFromParams({ team_id: currentTeam?.id })}`
+          );
         })
         .catch((error: { data: IApiError }) => {
           renderFlash(

--- a/frontend/pages/labels/NewLabelPage/DynamicLabel/DynamicLabel.tsx
+++ b/frontend/pages/labels/NewLabelPage/DynamicLabel/DynamicLabel.tsx
@@ -41,6 +41,7 @@ const DynamicLabel = ({
               res.label.id
             )}?${buildQueryStringFromParams({ team_id: currentTeam?.id })}`
           );
+          renderFlash("success", "Label added successfully.");
         })
         .catch((error: { data: IApiError }) => {
           renderFlash(

--- a/frontend/pages/labels/NewLabelPage/ManualLabel/ManualLabel.tsx
+++ b/frontend/pages/labels/NewLabelPage/ManualLabel/ManualLabel.tsx
@@ -3,7 +3,9 @@ import { RouteComponentProps } from "react-router";
 
 import PATHS from "router/paths";
 import labelsAPI from "services/entities/labels";
+import { AppContext } from "context/app";
 import { NotificationContext } from "context/notification";
+import { buildQueryStringFromParams } from "utilities/url";
 import { IApiError } from "interfaces/errors";
 
 import ManualLabelForm from "pages/labels/components/ManualLabelForm";
@@ -17,6 +19,7 @@ export const DUPLICATE_ENTRY_ERROR =
 type IManualLabelProps = RouteComponentProps<never, never>;
 
 const ManualLabel = ({ router }: IManualLabelProps) => {
+  const { currentTeam } = useContext(AppContext);
   const { renderFlash } = useContext(NotificationContext);
 
   const onSaveNewLabel = useCallback(
@@ -24,7 +27,11 @@ const ManualLabel = ({ router }: IManualLabelProps) => {
       labelsAPI
         .create(formData)
         .then((res) => {
-          router.push(PATHS.MANAGE_HOSTS_LABEL(res.label.id));
+          router.push(
+            `${PATHS.MANAGE_HOSTS_LABEL(
+              res.label.id
+            )}?${buildQueryStringFromParams({ team_id: currentTeam?.id })}`
+          );
           renderFlash("success", "Label added successfully.");
         })
         .catch((error: { data: IApiError }) => {


### PR DESCRIPTION
## Issue
Cerra #24025 

## Description
- Preserves the team parameter to keep the team selected after creating a new label

## Screenshot of fix
<img width="1438" alt="Screenshot 2024-12-10 at 10 42 47 AM" src="https://github.com/user-attachments/assets/9e6e21d2-7213-4fce-862f-34ecaba4fd12">


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
- [x] Manual QA for all new/changed functionality

