### PR TITLE
Changed Metadata URL in SSO configuration to 127.0.0.1 due to product validation update

### DIFF
--- a/docs/Contributing/Testing-and-local-development.md
+++ b/docs/Contributing/Testing-and-local-development.md
@@ -339,7 +339,7 @@ Configure SSO on the Organization Settings page with the following:
 ```
 Identity Provider Name: SimpleSAML
 Entity ID: https://localhost:8080
-Metadata URL: http://localhost:9080/simplesaml/saml2/idp/metadata.php
+Metadata URL: http://127.0.0.1:9080/simplesaml/saml2/idp/metadata.php
 ```
 
 The identity provider is configured with four users:


### PR DESCRIPTION
Fleet now has a validation check in the Metadata URL field. Updated instructions from 

Metadata URL: http://localhost:9080/simplesaml/saml2/idp/metadata.php

TO

Metadata URL: http://127.0.0.1:9080/simplesaml/saml2/idp/metadata.php

