### PR TITLE
Fleet UI: Do not render password or 2fa option if sso is selected

### DIFF
--- a/frontend/pages/admin/UserManagementPage/components/UserForm/UserForm.tests.tsx
+++ b/frontend/pages/admin/UserManagementPage/components/UserForm/UserForm.tests.tsx
@@ -74,4 +74,18 @@ describe("UserForm - component", () => {
     expect(screen.getByLabelText("Email")).toBeInTheDocument();
     expect(screen.getByLabelText("Password")).toBeInTheDocument();
   });
+
+  it("does not render password and 2FA sections when SSO is enabled", () => {
+    render(<UserForm {...defaultProps} canUseSso />);
+
+    // Enable SSO
+    const ssoRadio = screen.getByLabelText("Enable single sign-on");
+    ssoRadio.click();
+
+    // Check that password and 2FA sections are not present
+    expect(screen.queryByText("Password")).not.toBeInTheDocument();
+    expect(
+      screen.queryByText("Enable two-factor authentication")
+    ).not.toBeInTheDocument();
+  });
 });

--- a/frontend/pages/admin/UserManagementPage/components/UserForm/UserForm.tsx
+++ b/frontend/pages/admin/UserManagementPage/components/UserForm/UserForm.tsx
@@ -221,6 +221,7 @@ const UserForm = ({
       // if an existing user is converted to sso, the API expects `new_password` to be null
       if (formData.sso_enabled) {
         submitData.new_password = null;
+        submitData.mfa_enabled = false; // Edge case a user sets mfa, and then sets sso, we need to remove mfa
       }
     }
 
@@ -628,6 +629,7 @@ const UserForm = ({
             !formData.sso_enabled &&
             renderPasswordSection()}
           {(isPremiumTier || isMfaEnabled) &&
+            !formData.sso_enabled &&
             renderTwoFactorAuthenticationOption()}
           {isPremiumTier ? renderPremiumRoleOptions() : renderGlobalRoleForm()}
         </form>


### PR DESCRIPTION
## Issue
Unreleased bug #24598 

## Screenshot of fix

<img width="820" alt="Screenshot 2024-12-10 at 12 37 38 PM" src="https://github.com/user-attachments/assets/32bc3d1f-feb7-47f8-9428-2f05ea384c19">

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Added/updated tests
- [x] Manual QA for all new/changed functionality

