### PR TITLE
23285 add attestation

### DIFF
--- a/.github/workflows/goreleaser-fleet.yaml
+++ b/.github/workflows/goreleaser-fleet.yaml
@@ -103,8 +103,8 @@ jobs:
         continue-on-error: true
         id: image_digests
         run: |
-          echo "digest_fleet=$(echo ${{ steps.goreleaser.outputs.artifacts }} | jq -r '.[]|select(.type == "Published Docker Image" and (.name | contains("fleetdm/fleet:${{ steps.commit.outputs.short_commit }}"))) | select(. != null)|.extra.Digest" >> "$GITHUB_OUTPUT"
-          echo "digest_fleetctl=$(echo ${{ steps.goreleaser.outputs.artifacts }} | jq -r '.[]|select(.type == "Published Docker Image" and (.name | contains("fleetdm/fleetctl:${{ steps.commit.outputs.short_commit }}"))) | select(. != null)|.extra.Digest" >> "$GITHUB_OUTPUT"
+          echo "digest_fleet=$(echo ${{ steps.goreleaser.outputs.artifacts }} | jq -r '.[]|select(.type == "Published Docker Image" and (.name | contains("fleetdm/fleet:${{ steps.commit.outputs.short_commit }}"))) | select(. != null)|.extra.Digest')" >> "$GITHUB_OUTPUT"
+          echo "digest_fleetctl=$(echo ${{ steps.goreleaser.outputs.artifacts }} | jq -r '.[]|select(.type == "Published Docker Image" and (.name | contains("fleetdm/fleetctl:${{ steps.commit.outputs.short_commit }}"))) | select(. != null)|.extra.Digest')" >> "$GITHUB_OUTPUT"
 
       - name: Attest Fleet image
         uses: actions/attest-build-provenance@619dbb2e03e0189af0c55118e7d3c5e129e99726 # v2.0

--- a/.github/workflows/goreleaser-fleet.yaml
+++ b/.github/workflows/goreleaser-fleet.yaml
@@ -72,6 +72,7 @@ jobs:
           popd
 
       - name: Run GoReleaser
+        id: goreleaser
         uses: goreleaser/goreleaser-action@f82d6c1c344bcacabba2c841718984797f664a6b
         with:
           distribution: goreleaser-pro
@@ -90,6 +91,35 @@ jobs:
         uses: actions/attest-build-provenance@619dbb2e03e0189af0c55118e7d3c5e129e99726 # v2.0
         with:
           subject-path: "dist/fleet*"
+      # Get the commit hash so we can get image digests
+      - name: Get the short commit hash
+        id: commit
+        run: echo "::set-output name=short_commit::$(git rev-parse --short HEAD)"
+
+      # Get the image digests from the goreleaser artifacts
+      # Adapted from https://github.com/goreleaser/goreleaser/issues/4852#issuecomment-2122790132
+      - name: Get image digests
+        continue-on-error: true
+        id: image_digests
+        run: |
+          echo "digest_fleet=$(echo ${{ steps.goreleaser.outputs.artifacts }} | jq -r '.[]|select(.type == "Published Docker Image" and (.name | contains("fleetdm/fleet:${{ steps.commit.outputs.short_commit }}"))) | select(. != null)|.extra.Digest" >> "$GITHUB_OUTPUT"
+          echo "digest_fleetctl=$(echo ${{ steps.goreleaser.outputs.artifacts }} | jq -r '.[]|select(.type == "Published Docker Image" and (.name | contains("fleetdm/fleetctl:${{ steps.commit.outputs.short_commit }}"))) | select(. != null)|.extra.Digest" >> "$GITHUB_OUTPUT"
+
+      - name: Attest Fleet image
+        uses: actions/attest-build-provenance@619dbb2e03e0189af0c55118e7d3c5e129e99726 # v2.0
+        continue-on-error: true
+        with:
+          subject-digest: ${{steps.image_digests.outputs.digest_fleet}}
+          subject-name: "fleetdm/fleet:${{ steps.commit.outputs.short_commit }}"
+          push-to-registry: true
+
+      - name: Attest FleetCtl image
+        uses: actions/attest-build-provenance@619dbb2e03e0189af0c55118e7d3c5e129e99726 # v2.0
+        continue-on-error: true
+        with:
+          subject-digest: ${{steps.image_digests.outputs.digest_fleetctl}}
+          subject-name: "fleetdm/fleetctl:${{ steps.commit.outputs.short_commit }}"
+          push-to-registry: true
 
       - name: Get tag
         run: |

--- a/.github/workflows/goreleaser-fleet.yaml
+++ b/.github/workflows/goreleaser-fleet.yaml
@@ -91,10 +91,11 @@ jobs:
         uses: actions/attest-build-provenance@619dbb2e03e0189af0c55118e7d3c5e129e99726 # v2.0
         with:
           subject-path: "dist/fleet*"
+
       # Get the commit hash so we can get image digests
       - name: Get the short commit hash
         id: commit
-        run: echo "::set-output name=short_commit::$(git rev-parse --short HEAD)"
+        run: echo "short_commit=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
 
       # Get the image digests from the goreleaser artifacts
       # Adapted from https://github.com/goreleaser/goreleaser/issues/4852#issuecomment-2122790132

--- a/.github/workflows/goreleaser-fleet.yaml
+++ b/.github/workflows/goreleaser-fleet.yaml
@@ -86,6 +86,11 @@ jobs:
           APPLE_APP_STORE_CONNECT_KEY_ID: ${{ secrets.APPLE_APP_STORE_CONNECT_KEY_ID }}
           APPLE_APP_STORE_CONNECT_ISSUER_ID: ${{ secrets.APPLE_APP_STORE_CONNECT_ISSUER_ID }}
 
+      - name: Attest binaries and archives
+        uses: actions/attest-build-provenance@619dbb2e03e0189af0c55118e7d3c5e129e99726 # v2.0
+        with:
+          subject-path: "dist/fleet*"
+
       - name: Get tag
         run: |
           echo "TAG=$(git describe --tags |  sed -e "s/^fleet-//")" >> $GITHUB_OUTPUT

--- a/.github/workflows/goreleaser-orbit.yaml
+++ b/.github/workflows/goreleaser-orbit.yaml
@@ -62,6 +62,11 @@ jobs:
           AC_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
           CODESIGN_IDENTITY: 51049B247B25B3119FAE7E9C0CC4375A43E47237
 
+      - name: Attest binary
+        uses: actions/attest-build-provenance@619dbb2e03e0189af0c55118e7d3c5e129e99726 # v2.0
+        with:
+          subject-path: "dist/orbit-macos_darwin_all/orbit"
+
       - name: Upload
         uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # 4.3.3
         with:
@@ -94,6 +99,11 @@ jobs:
 
       - name: Run GoReleaser
         run: go run github.com/goreleaser/goreleaser/v2@606c0e724fe9b980cd01090d08cbebff63cd0f72 release --verbose --clean --skip=publish -f orbit/goreleaser-linux.yml # v2.4.4
+
+      - name: Attest binary
+        uses: actions/attest-build-provenance@619dbb2e03e0189af0c55118e7d3c5e129e99726 # v2.0
+        with:
+          subject-path: "dist/orbit_linux_amd64_v1/orbit"
 
       - name: Upload
         uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # 4.3.3
@@ -128,6 +138,11 @@ jobs:
       - name: Run GoReleaser
         run: go run github.com/goreleaser/goreleaser/v2@606c0e724fe9b980cd01090d08cbebff63cd0f72 release --verbose --clean --skip=publish -f orbit/goreleaser-linux-arm64.yml # v2.4.4
 
+      - name: Attest binary
+        uses: actions/attest-build-provenance@619dbb2e03e0189af0c55118e7d3c5e129e99726 # v2.0
+        with:
+          subject-path: "dist/orbit_linux_arm64/orbit"
+
       - name: Upload
         uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # 4.3.3
         with:
@@ -160,6 +175,11 @@ jobs:
 
       - name: Run GoReleaser
         run: go run github.com/goreleaser/goreleaser/v2@606c0e724fe9b980cd01090d08cbebff63cd0f72 release --verbose --clean --skip=publish -f orbit/goreleaser-windows.yml # v2.4.4
+
+      - name: Attest binary
+        uses: actions/attest-build-provenance@619dbb2e03e0189af0c55118e7d3c5e129e99726 # v2.0
+        with:
+          subject-path: "dist/orbit_windows_amd64_v1/orbit.exe"
 
       - name: Upload
         uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # 4.3.3

--- a/.github/workflows/goreleaser-snapshot-fleet.yaml
+++ b/.github/workflows/goreleaser-snapshot-fleet.yaml
@@ -85,30 +85,36 @@ jobs:
       - name: Publish Docker images
         run: docker push fleetdm/fleet --all-tags
 
-      # Get the commit hash so we can get image digests
+      # Get the commit hash so we can pull images
       - name: Get the short commit hash
         id: commit
         run: echo "::set-output name=short_commit::$(git rev-parse --short HEAD)"
 
-      # Get the image digests (only available after we push to the registry)
+      # Pull the images so we can get their digests
+      - name: Pull Docker fleetdm
+        run: |
+          docker pull fleetdm/fleet:${{ steps.commit.outputs.short_commit }}
+          docker pull fleetdm/fleetctl:${{ steps.commit.outputs.short_commit }}
+
+      # Get the image digests
       - name: Get image digests
         id: image_digests
         run: |
-          echo "::set-output name=digest_fleet::$(docker inspect --format='{{index .RepoDigests 0}}' fleetdm/fleet:${{ steps.commit.outputs.short_commit }})"
-          echo "::set-output name=digest_fleetctl::$(docker inspect --format='{{index .RepoDigests 0}}' fleetdm/fleetctl:${{ steps.commit.outputs.short_commit }})"
+          echo "digest_fleet=$(docker inspect --format='{{index .RepoDigests 0}}' fleetdm/fleet:${{ steps.commit.outputs.short_commit }} | awk -F'@' '{print $2}')" >> ${GITHUB_OUTPUT}
+          echo "digest_fleetctl=$(docker inspect --format='{{index .RepoDigests 0}}' fleetdm/fleetctl:${{ steps.commit.outputs.short_commit }} | awk -F'@' '{print $2}')" >> ${GITHUB_OUTPUT}
 
       - name: Attest Fleet image
         uses: actions/attest-build-provenance@173725a1209d09b31f9d30a3890cf2757ebbff0d # v1.1.2
         with:
           subject-digest: ${{steps.image_digests.outputs.digest_fleet}}
-          subject-name: "fleetdm/fleet:${{ steps.commit.outputs.short_commit }}"
+          subject-name: "fleetdm/fleet"
           push-to-registry: true
 
       - name: Attest FleetCtl image
         uses: actions/attest-build-provenance@173725a1209d09b31f9d30a3890cf2757ebbff0d # v1.1.2
         with:
           subject-digest: ${{steps.image_digests.outputs.digest_fleetctl}}
-          subject-name: "fleetdm/fleetctl:${{ steps.commit.outputs.short_commit }}"
+          subject-name: "fleetdm/fleetctl"
           push-to-registry: true
 
       - name: Get tag

--- a/.github/workflows/goreleaser-snapshot-fleet.yaml
+++ b/.github/workflows/goreleaser-snapshot-fleet.yaml
@@ -94,13 +94,6 @@ jobs:
       - name: Get image digests
         id: image_digests
         run: |
-          IMAGE1=""
-          IMAGE2="fleetdm/fleetctl:${{ steps.commit.outputs.short_commit }}"
-
-          # Fetch digests for both images
-          DIGEST1=$(docker inspect --format='{{index .RepoDigests 0}}' $IMAGE1)
-          DIGEST2=$(docker inspect --format='{{index .RepoDigests 0}}' $IMAGE2)
-
           echo "::set-output name=digest_fleet::$(docker inspect --format='{{index .RepoDigests 0}}' fleetdm/fleet:${{ steps.commit.outputs.short_commit }})"
           echo "::set-output name=digest_fleetctl::$(docker inspect --format='{{index .RepoDigests 0}}' fleetdm/fleetctl:${{ steps.commit.outputs.short_commit }})"
 

--- a/.github/workflows/goreleaser-snapshot-fleet.yaml
+++ b/.github/workflows/goreleaser-snapshot-fleet.yaml
@@ -69,6 +69,7 @@ jobs:
         run: make deps
 
       - name: Run GoReleaser
+        id: goreleaser
         uses: goreleaser/goreleaser-action@f82d6c1c344bcacabba2c841718984797f664a6b
         with:
           distribution: goreleaser-pro
@@ -83,6 +84,39 @@ jobs:
       # Explicitly push the docker images as GoReleaser will not do so in snapshot mode
       - name: Publish Docker images
         run: docker push fleetdm/fleet --all-tags
+
+      # Get the commit hash so we can get image digests
+      - name: Get the short commit hash
+        id: commit
+        run: echo "::set-output name=short_commit::$(git rev-parse --short HEAD)"
+
+      # Get the image digests (only available after we push to the registry)
+      - name: Get image digests
+        id: image_digests
+        run: |
+          IMAGE1=""
+          IMAGE2="fleetdm/fleetctl:${{ steps.commit.outputs.short_commit }}"
+
+          # Fetch digests for both images
+          DIGEST1=$(docker inspect --format='{{index .RepoDigests 0}}' $IMAGE1)
+          DIGEST2=$(docker inspect --format='{{index .RepoDigests 0}}' $IMAGE2)
+
+          echo "::set-output name=digest_fleet::$(docker inspect --format='{{index .RepoDigests 0}}' fleetdm/fleet:${{ steps.commit.outputs.short_commit }})"
+          echo "::set-output name=digest_fleetctl::$(docker inspect --format='{{index .RepoDigests 0}}' fleetdm/fleetctl:${{ steps.commit.outputs.short_commit }})"
+
+      - name: Attest Fleet image
+        uses: actions/attest-build-provenance@173725a1209d09b31f9d30a3890cf2757ebbff0d # v1.1.2
+        with:
+          subject-digest: ${{steps.image_digests.outputs.digest_fleet}}
+          subject-name: "fleetdm/fleet:${{ steps.commit.outputs.short_commit }}"
+          push-to-registry: true
+
+      - name: Attest FleetCtl image
+        uses: actions/attest-build-provenance@173725a1209d09b31f9d30a3890cf2757ebbff0d # v1.1.2
+        with:
+          subject-digest: ${{steps.image_digests.outputs.digest_fleetctl}}
+          subject-name: "fleetdm/fleetctl:${{ steps.commit.outputs.short_commit }}"
+          push-to-registry: true
 
       - name: Get tag
         run: |

--- a/.github/workflows/goreleaser-snapshot-fleet.yaml
+++ b/.github/workflows/goreleaser-snapshot-fleet.yaml
@@ -69,7 +69,6 @@ jobs:
         run: make deps
 
       - name: Run GoReleaser
-        id: goreleaser
         uses: goreleaser/goreleaser-action@f82d6c1c344bcacabba2c841718984797f664a6b
         with:
           distribution: goreleaser-pro
@@ -84,38 +83,6 @@ jobs:
       # Explicitly push the docker images as GoReleaser will not do so in snapshot mode
       - name: Publish Docker images
         run: docker push fleetdm/fleet --all-tags
-
-      # Get the commit hash so we can pull images
-      - name: Get the short commit hash
-        id: commit
-        run: echo "::set-output name=short_commit::$(git rev-parse --short HEAD)"
-
-      # Pull the images so we can get their digests
-      - name: Pull Docker fleetdm
-        run: |
-          docker pull fleetdm/fleet:${{ steps.commit.outputs.short_commit }}
-          docker pull fleetdm/fleetctl:${{ steps.commit.outputs.short_commit }}
-
-      # Get the image digests
-      - name: Get image digests
-        id: image_digests
-        run: |
-          echo "digest_fleet=$(docker inspect --format='{{index .RepoDigests 0}}' fleetdm/fleet:${{ steps.commit.outputs.short_commit }} | awk -F'@' '{print $2}')" >> ${GITHUB_OUTPUT}
-          echo "digest_fleetctl=$(docker inspect --format='{{index .RepoDigests 0}}' fleetdm/fleetctl:${{ steps.commit.outputs.short_commit }} | awk -F'@' '{print $2}')" >> ${GITHUB_OUTPUT}
-
-      - name: Attest Fleet image
-        uses: actions/attest-build-provenance@173725a1209d09b31f9d30a3890cf2757ebbff0d # v1.1.2
-        with:
-          subject-digest: ${{steps.image_digests.outputs.digest_fleet}}
-          subject-name: "fleetdm/fleet"
-          push-to-registry: true
-
-      - name: Attest FleetCtl image
-        uses: actions/attest-build-provenance@173725a1209d09b31f9d30a3890cf2757ebbff0d # v1.1.2
-        with:
-          subject-digest: ${{steps.image_digests.outputs.digest_fleetctl}}
-          subject-name: "fleetdm/fleetctl"
-          push-to-registry: true
 
       - name: Get tag
         run: |


### PR DESCRIPTION
for #23825 

This PR adds Github artifact attestation to binaries and archive files deployed during Fleet releases.  Specifically this refers to:

* Orbit binaries 
* Fleet binaries
* Fleet and FleetCtl archives (e.g. Zip and Tarball files added to releases)
* Fleet and FleetCtl binaries (these are contained in the archives)
* Fleet and FleetCtl docker images

Attestation works by uploading provenance info to a repo for a file with a known hash, rather than adding any metadata to the file itself.  That means that I can zip file foo.txt into archive.tar.gz, create an attestation for foo.txt, and if someone downloads archive.tar.gz and unzips it they'll still be able to verify the provenance of foo.txt.

### Testing

I used a [separate repo](https://github.com/sgress454/test-slack-webhook-action) to test attestation of binaries and archives created by Goreleaser.