### PR TITLE
Error out while parsing when script entries in a GitOps YAML file are missing paths

### DIFF
--- a/changes/22444-gitops-script-missing-path
+++ b/changes/22444-gitops-script-missing-path
@@ -1,0 +1,1 @@
+* Added a descriptive error when a GitOps file contains script references that are missing paths

--- a/pkg/spec/gitops_test.go
+++ b/pkg/spec/gitops_test.go
@@ -964,6 +964,18 @@ software:
 	assert.ErrorContains(t, err, "failed to unmarshal install_software.package_path file")
 }
 
+func TestGitOpsWithStrayScriptEntryWithNoPath(t *testing.T) {
+	t.Parallel()
+	config := getTeamConfig([]string{"controls"})
+	config += `
+controls:
+  scripts:
+    -
+`
+	_, err := gitOpsFromString(t, config)
+	assert.ErrorContains(t, err, `check for a stray "-"`)
+}
+
 func TestGitOpsTeamPolicyWithInvalidRunScript(t *testing.T) {
 	t.Parallel()
 	config := getTeamConfig([]string{"policies"})


### PR DESCRIPTION
For #22244. Previously empty script entries would get parsed and then cause a panic later in the process.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/Committing-Changes.md#changes-files) for more information.
- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [x] Added/updated tests
- [x] Manual QA for all new/changed functionality