### PR TITLE
added Zoom for debian Linux

### DIFF
--- a/it-and-security/lib/linux/queries/all-debian-hosts.yml
+++ b/it-and-security/lib/linux/queries/all-debian-hosts.yml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: query
+spec:
+  name: All debian hosts
+  query: SELECT * FROM os_version WHERE platform_like = 'debian';
+  platform: "darwin"

--- a/it-and-security/lib/linux/software/zoom.yml
+++ b/it-and-security/lib/linux/software/zoom.yml
@@ -1,0 +1,4 @@
+url: https://zoom.us/client/6.2.11.5069/zoom_amd64.deb
+self-service: true
+pre_install_query:
+  path: ./queries/all-debian-hosts.yml


### PR DESCRIPTION
Adding a Linux self-service example app (Zoom) for debian Linux. 

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [ ] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/Committing-Changes.md#changes-files) for more information.
- [ ] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [ ] Added support on fleet's osquery simulator `cmd/osquery-perf` for new osquery data ingestion features.
- [ ] Added/updated tests
- [ ] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes
- [ ] If database migrations are included, checked table schema to confirm autoupdate
- For database migrations:
  - [ ] Checked schema for all modified table for columns that will auto-update timestamps during migration.
  - [ ] Confirmed that updating the timestamps is acceptable, and will not cause unwanted side effects.
  - [ ] Ensured the correct collation is explicitly set for character columns (`COLLATE utf8mb4_unicode_ci`).
- [ ] Manual QA for all new/changed functionality
- For Orbit and Fleet Desktop changes:
   - [ ] Orbit runs on macOS, Linux and Windows. Check if the orbit feature/bugfix should only apply to one platform (`runtime.GOOS`).
   - [ ] Manual QA must be performed in the three main OSs, macOS, Windows and Linux.
   - [ ] Auto-update manual QA, from released version of component to new version (see [tools/tuf/test](../tools/tuf/test/README.md)).
