### PR TITLE
Fleet UI: Fix policy truncation and add tooltip

### DIFF
--- a/changes/24334-policy-truncation
+++ b/changes/24334-policy-truncation
@@ -1,0 +1,1 @@
+- Fix policy truncation UI bug

--- a/frontend/components/buttons/Button/_styles.scss
+++ b/frontend/components/buttons/Button/_styles.scss
@@ -70,7 +70,6 @@ $base-class: "button";
   border: 0;
   position: relative;
   cursor: pointer;
-  min-width: max-content;
 
   &:focus {
     outline: none;

--- a/frontend/pages/hosts/details/cards/Policies/HostPoliciesTable/HostPoliciesTableConfig.tsx
+++ b/frontend/pages/hosts/details/cards/Policies/HostPoliciesTable/HostPoliciesTableConfig.tsx
@@ -8,6 +8,7 @@ import Button from "components/buttons/Button";
 import HeaderCell from "components/TableContainer/DataTable/HeaderCell";
 import ViewAllHostsLink from "components/ViewAllHostsLink";
 import { IndicatorStatus } from "components/StatusIndicatorWithIcon/StatusIndicatorWithIcon";
+import TooltipTruncatedText from "components/TooltipTruncatedText";
 
 interface IHeaderProps {
   column: {
@@ -82,7 +83,7 @@ const generatePolicyTableHeaders = (
             onClick={onClickPolicyName}
             variant="text-icon"
           >
-            <span className={`policy-info-text`}>{name}</span>
+            <TooltipTruncatedText value={name} />
           </Button>
         );
       },

--- a/frontend/pages/hosts/details/cards/Policies/_styles.scss
+++ b/frontend/pages/hosts/details/cards/Policies/_styles.scss
@@ -23,6 +23,10 @@
         tr {
           .name__cell {
             max-width: 0; // sets ellipsis
+
+            .truncated-tooltip {
+              font-weight: $regular;
+            }
           }
 
           .policy-link {
@@ -38,12 +42,6 @@
           .policy-info {
             width: 100%; // sets ellipsis
             justify-content: left;
-
-            .policy-info-text {
-              overflow: hidden;
-              white-space: nowrap;
-              text-overflow: ellipsis;
-            }
 
             &::after {
               content: url("../assets/images/icon-arrow-right-vibrant-blue-10x18@2x.png");


### PR DESCRIPTION
## Issue
Cerra #24334 

## Description
- Fix policy truncation regression
- Add tooltip to truncation

## Screenshot
<img width="650" alt="Screenshot 2024-12-11 at 1 43 25 PM" src="https://github.com/user-attachments/assets/95d1205c-df7f-4153-bd01-bf2f86739073" />



# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
- [x] Manual QA must be performed in the three main OSs, macOS, Windows and Linux.

