### PR TITLE
Added Software Update Settings DDM for Workstations (canary) and made Zoom for Ubuntu available in Self-service

### DIFF
--- a/it-and-security/lib/linux/software/zoom.yml
+++ b/it-and-security/lib/linux/software/zoom.yml
@@ -1,4 +1,4 @@
 url: https://zoom.us/client/6.2.11.5069/zoom_amd64.deb
 self-service: true
 pre_install_query:
-  path: ./queries/all-debian-hosts.yml
+  path: ../queries/all-debian-hosts.yml

--- a/it-and-security/lib/macos/declaration-profiles/software-update-settings.json
+++ b/it-and-security/lib/macos/declaration-profiles/software-update-settings.json
@@ -1,0 +1,16 @@
+{
+    "Type": "com.apple.configuration.softwareupdate.settings",
+    "Identifier": "com.fleetdm.config.softwareupdate.settings",
+    "Payload": {
+        "AllowStandardUserOSUpdates": true,
+        "AutomaticActions": {
+            "Download": "AlwaysOn",
+            "InstallOSUpdates": "Allowed",
+            "InstallSecurityUpdate": "AlwaysOn"
+        },
+        "Notifications": true,
+        "RapidSecurityResponse": {
+            "Enabled": true
+        }
+    }
+}

--- a/it-and-security/teams/compliance-exclusions.yml
+++ b/it-and-security/teams/compliance-exclusions.yml
@@ -31,4 +31,5 @@ controls:
 policies:
 queries:
 software:
+  packages:
     - path: ../lib/linux/software/zoom.yml # Zoom for Ubuntu

--- a/it-and-security/teams/compliance-exclusions.yml
+++ b/it-and-security/teams/compliance-exclusions.yml
@@ -31,3 +31,4 @@ controls:
 policies:
 queries:
 software:
+    - path: ../lib/linux/software/zoom.yml # Zoom for Ubuntu

--- a/it-and-security/teams/workstations-canary.yml
+++ b/it-and-security/teams/workstations-canary.yml
@@ -87,6 +87,7 @@ controls:
       - path: ../lib/macos/configuration-profiles/disable-update-notifications.mobileconfig
       - path: ../lib/macos/configuration-profiles/ensure-show-status-bar-is-enabled.mobileconfig
       - path: ../lib/macos/declaration-profiles/passcode-settings.json
+      - path: ../lib/macos/declaration-profiles/software-update-settings.json
   macos_setup:
     bootstrap_package: ""
     enable_end_user_authentication: false

--- a/it-and-security/teams/workstations-canary.yml
+++ b/it-and-security/teams/workstations-canary.yml
@@ -151,6 +151,7 @@ queries:
 software:
   packages:
     - path: ../lib/macos/software/mozilla-firefox.yml # Mozilla Firefox for MacOS (universal)
+    - path: ../lib/linux/software/zoom.yml # Zoom for Ubuntu
   app_store_apps:
       - app_store_id: '803453959' # Slack Desktop
       - app_store_id: '1333542190' # 1Password 7 Desktop


### PR DESCRIPTION
Added DDM for software update settings and assigned it to the Workstations (canary) team. 

Also updated Workstations (canary) and Compliance exclusions to see Zoom for Ubuntu available in Self-service. 