### PR TITLE
API Docs: Match request format for script edit vs. script add

### DIFF
--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -8818,19 +8818,30 @@ Modifies an existing script.
 | Name            | Type    | In   | Description                                           |
 | ----            | ------- | ---- | --------------------------------------------          |
 | id              | integer | path | **Required**. The ID of the script to modify. |
-| script_contents | string  | body | **Required**. The contents of the script to be updated. |
+| script          | file    | form | **Required**. The file containing the script. Filename will be ignored. |
 
 #### Example
 
 `PATCH /api/v1/fleet/scripts/1`
 
 
+##### Request headers
+
+```http
+Content-Length: 306
+Content-Type: multipart/form-data; boundary=------------------------f02md47480und42y
+```
+
 ##### Request body
 
-```json
-{
-  "script_contents": "#!/bin/sh\\n\\n#!/usr/bin/env bash\\n\\nsudo systemsetup -settimezone Pacific/Ponape"
-}
+```http
+--------------------------f02md47480und42y
+Content-Disposition: form-data; name="script"; filename="myscript.sh"
+Content-Type: application/octet-stream
+
+echo "hello"
+--------------------------f02md47480und42y--
+
 ```
 
 ##### Default response


### PR DESCRIPTION
For #24195.

The existing POST /scripts method uses a multipart request, and I figure that since we use multipart for both create and edit on installers, we want the same level of consistency on scripts.

If we _don't_ want this, and want a JSON payload instead, we probably still want to rename `script_contents` to `script` for consistency with the field name in the create API.