### PR TITLE
Cherry-Pick: Add missing role label on team admin role selection in user edit

### DIFF
--- a/frontend/pages/admin/UserManagementPage/components/SelectRoleForm/SelectRoleForm.tsx
+++ b/frontend/pages/admin/UserManagementPage/components/SelectRoleForm/SelectRoleForm.tsx
@@ -55,6 +55,7 @@ const SelectRoleForm = ({
   return (
     <DropdownWrapper
       name="Team role"
+      label="Role"
       options={roleOptions({ isPremiumTier, isApiOnly })}
       value={selectedRole}
       onChange={updateSelectedRole}


### PR DESCRIPTION
For #24667, merged into `main` as #24683.