### PR TITLE
Update CODEOWNERS: reference docs

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -65,9 +65,9 @@ go.mod @fleetdm/go
 #
 # (see website/config/custom.js for DRIs of other paths not listed here)
 ##############################################################################################
-/docs                                           @rachaelshaw @noahtalerman
-/docs/REST\ API/rest-api.md                     @rachaelshaw @noahtalerman # « REST API reference documentation
-/docs/Contributing/API-for-contributors.md      @rachaelshaw @noahtalerman # « Advanced / contributors-only API reference documentation
+/docs                                           @rachaelshaw
+/docs/REST\ API/rest-api.md                     @rachaelshaw # « REST API reference documentation
+/docs/Contributing/API-for-contributors.md      @rachaelshaw # « Advanced / contributors-only API reference documentation
 /schema                                         @eashaw # « Data tables (osquery/fleetd schema) documentation
 /render.yaml                                    @edwardsb
 


### PR DESCRIPTION
Remove @noahtalerman so there's always one reviewer (@rachaelshaw)

I think I was added as backup when Rachael was out last week. I think in the future, let's do a full swap: remove @rachaelshaw and add @noahtalerman. That way we always have one reviewer. It's clear who's responsible for helping get the PR merged.
