### PR TITLE
Fleet UI: Handle SSO user auth when SSO is globally disabled

### DIFF
--- a/frontend/pages/admin/UserManagementPage/components/AddUserModal/AddUserModal.tsx
+++ b/frontend/pages/admin/UserManagementPage/components/AddUserModal/AddUserModal.tsx
@@ -59,7 +59,6 @@ const AddUserModal = ({
         onCancel={onCancel}
         onSubmit={onSubmit}
         availableTeams={availableTeams || []}
-        submitText="Add"
         isPremiumTier={isPremiumTier}
         smtpConfigured={smtpConfigured}
         sesConfigured={sesConfigured}

--- a/frontend/pages/admin/UserManagementPage/components/EditUserModal/EditUserModal.tsx
+++ b/frontend/pages/admin/UserManagementPage/components/EditUserModal/EditUserModal.tsx
@@ -69,7 +69,6 @@ const EditUserModal = ({
         onCancel={onCancel}
         onSubmit={onSubmit}
         availableTeams={availableTeams}
-        submitText="Save"
         isPremiumTier={isPremiumTier}
         smtpConfigured={smtpConfigured}
         sesConfigured={sesConfigured}

--- a/frontend/pages/admin/UserManagementPage/components/UserForm/UserForm.tests.tsx
+++ b/frontend/pages/admin/UserManagementPage/components/UserForm/UserForm.tests.tsx
@@ -96,7 +96,7 @@ describe("UserForm - component", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("displays disabled SSO option with tooltip when SSO is globally disabled but was previously enabled for the user", async () => {
+  it("displays disabled SSO option when SSO is globally disabled but was previously enabled for the user", async () => {
     const props = {
       ...defaultProps,
       defaultName: "User 1",

--- a/frontend/pages/admin/UserManagementPage/components/UserForm/UserForm.tests.tsx
+++ b/frontend/pages/admin/UserManagementPage/components/UserForm/UserForm.tests.tsx
@@ -11,7 +11,6 @@ describe("UserForm - component", () => {
     availableTeams: [],
     onCancel: noop,
     onSubmit: noop,
-    submitText: "Add",
     isModifiedByGlobalAdmin: true,
     isPremiumTier: true,
     smtpConfigured: true,
@@ -42,7 +41,7 @@ describe("UserForm - component", () => {
   it("renders SSO option when canUseSso is true", () => {
     render(<UserForm {...defaultProps} canUseSso />);
 
-    expect(screen.getByLabelText("Enable single sign-on")).toBeInTheDocument();
+    expect(screen.getByLabelText("Single sign-on")).toBeInTheDocument();
   });
 
   it("disables invite user option when SMTP and SES are not configured", () => {
@@ -72,20 +71,51 @@ describe("UserForm - component", () => {
     // Verify that non-premium elements are still present
     expect(screen.getByLabelText("Full name")).toBeInTheDocument();
     expect(screen.getByLabelText("Email")).toBeInTheDocument();
-    expect(screen.getByLabelText("Password")).toBeInTheDocument();
+    expect(
+      screen.queryByRole("radio", { name: "Password" })
+    ).toBeInTheDocument();
   });
 
-  it("does not render password and 2FA sections when SSO is enabled", () => {
+  it("does not render password and 2FA sections when SSO is selected", () => {
     render(<UserForm {...defaultProps} canUseSso />);
 
     // Enable SSO
-    const ssoRadio = screen.getByLabelText("Enable single sign-on");
+    const ssoRadio = screen.getByLabelText("Single sign-on");
     ssoRadio.click();
 
-    // Check that password and 2FA sections are not present
-    expect(screen.queryByText("Password")).not.toBeInTheDocument();
+    // Check that the password radio is present
+    const passwordRadio = screen.getByRole("radio", { name: "Password" });
+    expect(passwordRadio).not.toBeDisabled();
+
+    // Check that password input field and 2FA sections are not present
+    expect(
+      screen.queryByRole("input", { name: "Password" })
+    ).not.toBeInTheDocument();
     expect(
       screen.queryByText("Enable two-factor authentication")
     ).not.toBeInTheDocument();
+  });
+
+  it("displays disabled SSO option with tooltip when SSO is globally disabled but was previously enabled for the user", async () => {
+    const props = {
+      ...defaultProps,
+      defaultName: "User 1",
+      defaultEmail: "user@example.com",
+      currentUserId: 1,
+      canUseSso: false,
+      isSsoEnabled: true,
+      isNewUser: false,
+    };
+
+    const { user } = renderWithSetup(<UserForm {...props} />);
+
+    // Check that the SSO radio is disabled
+    const ssoRadio = screen.getByLabelText("Single sign-on");
+    expect(ssoRadio).toBeDisabled();
+
+    await user.click(screen.getByText("Save"));
+    expect(
+      screen.getByText(/Password field must be completed/i)
+    ).toBeInTheDocument();
   });
 });

--- a/frontend/pages/admin/UserManagementPage/components/UserForm/UserForm.tsx
+++ b/frontend/pages/admin/UserManagementPage/components/UserForm/UserForm.tsx
@@ -32,7 +32,7 @@ import SelectedTeamsForm from "../SelectedTeamsForm/SelectedTeamsForm";
 import SelectRoleForm from "../SelectRoleForm/SelectRoleForm";
 import { roleOptions } from "../../helpers/userManagementHelpers";
 
-const baseClass = "add-user-form";
+const baseClass = "user-form";
 
 export enum NewUserType {
   AdminInvited = "ADMIN_INVITED",
@@ -63,7 +63,6 @@ interface IUserFormProps {
   availableTeams: ITeam[];
   onCancel: () => void;
   onSubmit: (formData: IUserFormData) => void;
-  submitText: string;
   defaultName?: string;
   defaultEmail?: string;
   currentUserId?: number;
@@ -90,7 +89,6 @@ const UserForm = ({
   availableTeams,
   onCancel,
   onSubmit,
-  submitText,
   defaultName,
   defaultEmail,
   currentUserId,
@@ -499,7 +497,7 @@ const UserForm = ({
             </TooltipWrapper>
           )
         }
-        id="enable-single-sign-on"
+        id="single-sign-on-authentication"
         checked={!!formData.sso_enabled}
         value="true"
         name="authentication-type"
@@ -509,7 +507,7 @@ const UserForm = ({
       <Radio
         className={`${baseClass}__radio-input`}
         label="Password"
-        id="password"
+        id="password-authentication"
         disabled={!(smtpConfigured || sesConfigured)}
         checked={!formData.sso_enabled}
         value="false"
@@ -650,11 +648,11 @@ const UserForm = ({
             type="submit"
             variant="brand"
             onClick={onFormSubmit}
-            className={`${submitText === "Add" ? "add" : "save"}-loading
+            className={`${isNewUser ? "add" : "save"}-loading
           `}
             isLoading={isUpdatingUsers}
           >
-            {submitText}
+            {isNewUser ? "Add" : "Save"}
           </Button>
         </>
       }

--- a/frontend/pages/admin/UserManagementPage/components/UserForm/_styles.scss
+++ b/frontend/pages/admin/UserManagementPage/components/UserForm/_styles.scss
@@ -1,4 +1,4 @@
-.add-user-form {
+.user-form {
   max-height: 581px;
   overflow-y: auto;
 


### PR DESCRIPTION
## Issue
Unreleased expedited draft #24666 

## Description
- Handles disabling SSO globally for existing users with SSO enabled

## Other clean up
- Remove unneeded `submitText` prop and use `isNewUser` to decide if it shows "Add" or "Save" text
- Rename UserForm's `baseClass` from `new-user-form` to `user-form` because it's also used for editing users

## Screenshot of fixes
<img width="780" alt="Screenshot 2024-12-12 at 9 23 31 AM" src="https://github.com/user-attachments/assets/f8ee4eb4-19cd-437e-99c4-b3c3bbd736fb" />

<img width="759" alt="Screenshot 2024-12-12 at 9 43 28 AM" src="https://github.com/user-attachments/assets/161ad56e-e1d1-42b8-a7e6-93a915dafa11" />

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->


- [x] Added/updated tests
- [x] Manual QA for all new/changed functionality

