### PR TITLE
Removing iOS and iPadOS apps from the 💻🐣 Workstations (canary) team

### DIFF
--- a/it-and-security/teams/workstations-canary.yml
+++ b/it-and-security/teams/workstations-canary.yml
@@ -155,5 +155,3 @@ software:
   app_store_apps:
       - app_store_id: '803453959' # Slack Desktop
       - app_store_id: '1333542190' # 1Password 7 Desktop
-      - app_store_id: '1477376905' # GitHub
-      - app_store_id: '1152747299' # Figma


### PR DESCRIPTION
Removing Figma and GitHub iOS/iPadOS apps from the 💻🐣 Workstations (canary) team. 

<img width="1394" alt="Screenshot 2024-12-12 at 10 49 32 AM" src="https://github.com/user-attachments/assets/7c4151d3-7aab-4aab-b8a7-66c9c30aaab3" />
