### PR TITLE
Fleet UI: Dropdown always scrolled to view in userform

### DIFF
--- a/frontend/components/forms/fields/DropdownWrapper/DropdownWrapper.tsx
+++ b/frontend/components/forms/fields/DropdownWrapper/DropdownWrapper.tsx
@@ -54,7 +54,8 @@ export interface IDropdownWrapper {
   isSearchable?: boolean;
   isDisabled?: boolean;
   placeholder?: string;
-  menuPortalTarget?: HTMLElement | null;
+  /** E.g. scroll to view dropdown menu in a scrollable parent container */
+  onMenuOpen?: () => void;
 }
 
 const baseClass = "dropdown-wrapper";
@@ -72,7 +73,7 @@ const DropdownWrapper = ({
   isSearchable,
   isDisabled = false,
   placeholder,
-  menuPortalTarget,
+  onMenuOpen,
 }: IDropdownWrapper) => {
   const wrapperClassNames = classnames(baseClass, className);
 
@@ -326,12 +327,10 @@ const DropdownWrapper = ({
         value={getCurrentValue()}
         onChange={handleChange}
         isDisabled={isDisabled}
-        menuPortalTarget={
-          menuPortalTarget === undefined ? document.body : menuPortalTarget
-        }
         noOptionsMessage={() => "No results found"}
         tabIndex={isDisabled ? -1 : 0} // Ensures disabled dropdown has no keyboard accessibility
         placeholder={placeholder}
+        onMenuOpen={onMenuOpen}
       />
     </FormField>
   );

--- a/frontend/pages/admin/UserManagementPage/components/SelectRoleForm/SelectRoleForm.tsx
+++ b/frontend/pages/admin/UserManagementPage/components/SelectRoleForm/SelectRoleForm.tsx
@@ -13,6 +13,7 @@ interface ISelectRoleFormProps {
   teams: ITeam[];
   onFormChange: (teams: ITeam[]) => void;
   isApiOnly?: boolean;
+  onMenuOpen?: () => void;
 }
 
 const generateSelectedTeamData = (
@@ -33,6 +34,7 @@ const SelectRoleForm = ({
   teams,
   onFormChange,
   isApiOnly,
+  onMenuOpen,
 }: ISelectRoleFormProps): JSX.Element => {
   const { isPremiumTier } = useContext(AppContext);
 
@@ -59,6 +61,7 @@ const SelectRoleForm = ({
       value={selectedRole}
       onChange={updateSelectedRole}
       isSearchable={false}
+      onMenuOpen={onMenuOpen}
     />
   );
 };

--- a/frontend/pages/admin/UserManagementPage/components/SelectedTeamsForm/SelectedTeamsForm.tsx
+++ b/frontend/pages/admin/UserManagementPage/components/SelectedTeamsForm/SelectedTeamsForm.tsx
@@ -17,6 +17,7 @@ interface ISelectedTeamsFormProps {
   usersCurrentTeams: ITeam[];
   onFormChange: (teams: ITeam[]) => void;
   isApiOnly?: boolean;
+  onMenuOpen?: () => void;
 }
 
 const baseClass = "selected-teams-form";
@@ -106,6 +107,7 @@ const SelectedTeamsForm = ({
   usersCurrentTeams,
   onFormChange,
   isApiOnly,
+  onMenuOpen,
 }: ISelectedTeamsFormProps): JSX.Element => {
   const [teamsFormList, updateSelectedTeams] = useSelectedTeamState(
     availableTeams,
@@ -137,6 +139,7 @@ const SelectedTeamsForm = ({
               onChange={(newValue: SingleValue<CustomOptionType>) =>
                 updateSelectedTeams(teamItem.id, newValue as CustomOptionType)
               }
+              onMenuOpen={onMenuOpen}
             />
           </div>
         );

--- a/frontend/pages/admin/UserManagementPage/components/UserForm/UserForm.tsx
+++ b/frontend/pages/admin/UserManagementPage/components/UserForm/UserForm.tsx
@@ -160,6 +160,19 @@ const UserForm = ({
     };
   };
 
+  // Used to show entire dropdown when a dropdown menu is open in scrollable component of a modal
+  // menuPortalTarget solution not used as scrolling is weird
+  const scrollToFitDropdownMenu = () => {
+    if (topDivRef?.current) {
+      setTimeout(() => {
+        if (topDivRef.current) {
+          topDivRef.current.scrollTop =
+            topDivRef.current.scrollHeight - topDivRef.current.clientHeight;
+        }
+      }, 50); // Delay needed for scrollHeight to update first
+    }
+  };
+
   const onCheckboxChange = (formField: string): ((evt: string) => void) => {
     return (evt: string) => {
       return onInputChange(formField)(evt);
@@ -308,6 +321,7 @@ const UserForm = ({
             }
           }}
           isSearchable={false}
+          onMenuOpen={scrollToFitDropdownMenu}
         />
       </>
     );
@@ -356,6 +370,7 @@ const UserForm = ({
                 usersCurrentTeams={formData.teams}
                 onFormChange={onSelectedTeamChange}
                 isApiOnly={isApiOnly}
+                onMenuOpen={scrollToFitDropdownMenu}
               />
             </>
           ) : (
@@ -365,6 +380,7 @@ const UserForm = ({
               defaultTeamRole={defaultTeamRole || "Observer"}
               onFormChange={onTeamRoleChange}
               isApiOnly={isApiOnly}
+              onMenuOpen={scrollToFitDropdownMenu}
             />
           ))}
         {!availableTeams.length && renderNoTeamsMessage()}


### PR DESCRIPTION
## Issue
Cerra #24443 

## Description
- Design decision to push scroll the parent container to view full dropdown instead of worrying about scroll behavior (from call with @rachaelshaw 12/11/24)
- This approach is aligned with react-select 5 behavior (vs. native behavior just doesn't allow any parent scrolling when the menu is open)
- Issue with using react-select 5 `scrollIntoView` is that it doesn't work when in a parent scrollable container, only page level

## Screenrecording

https://github.com/user-attachments/assets/bc5a20ca-248b-4605-b44a-cb520b0cf7c9



# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Manual QA for all new/changed functionality

