### PR TITLE
Website: fix failing deploy

### DIFF
--- a/articles/creating-windows-csps.md
+++ b/articles/creating-windows-csps.md
@@ -54,7 +54,7 @@ Values can take one of the following types:
 3. List Element - The list element corresponds to a hive of REG_SZ registry strings and correspondingly to a grid to enter multiple strings in a policy panel display by gpedit.msc. 
     - PRO TIP: Each pair is a REG_SZ name/value key. When applying policies through gpedit, visit the corresponding registry location to understand how list values are stored.
 
-4. No Elements - Just an Enable/Disable of the policy, represented like <Enabled/>
+4. No Elements - Just an Enable/Disable of the policy, represented like `<Enabled/>`
 
 5. Enum - Think of these as options from a dropdown in gpedit. This is the data type we are working with in the example
 
@@ -172,6 +172,6 @@ Ready to take control of your Windows device configurations? Explore FleetDM’s
 <meta name="articleTitle" value="Creating Windows CSPs">
 <meta name="authorFullName" value="Harrison Ravazzolo">
 <meta name="authorGitHubUsername" value="harrisonravazzolo">
-<meta name="category" value="articles">
+<meta name="category" value="guides">
 <meta name="publishedOn" value="2024-12-12">
 <meta name="description" value="Learn how to create and deploy Windows CSPs with FleetDM, leveraging ADMX-backed policies for streamlined and secure device management.">


### PR DESCRIPTION
Changes:
- Updated the category meta tag value (`articles` » `guides`) of the "Creating Windows CSPs" article to resolve a build script error.
- Wrapped an HTML tag in the article in backticks so it won't be seen as an unregistered custom HTML element by the website