### PR TITLE
Fix nil pointer dereference on CVEs when OS versions list hasn't been populated yet

### DIFF
--- a/changes/22523-cve-500
+++ b/changes/22523-cve-500
@@ -1,0 +1,1 @@
+* Fixed a panic (and resulting failure to load CVE details) on new installs when OS versions have not been populated yet.

--- a/server/datastore/mysql/vulnerabilities.go
+++ b/server/datastore/mysql/vulnerabilities.go
@@ -118,7 +118,9 @@ func (ds *Datastore) OSVersionsByCVE(ctx context.Context, cve string, teamID *ui
 		return nil, updatedAt, ctxerr.Wrap(ctx, err, "fetching team OS versions")
 	}
 
-	updatedAt = osvs.CountsUpdatedAt
+	if osvs == nil {
+		return nil, updatedAt, nil
+	}
 
 	type osVersionWithResolvedType struct {
 		OSVersionID     uint    `db:"os_version_id"`

--- a/server/datastore/mysql/vulnerabilities_test.go
+++ b/server/datastore/mysql/vulnerabilities_test.go
@@ -22,6 +22,7 @@ func TestVulnerabilities(t *testing.T) {
 		{"TestListVulnerabilities", testListVulnerabilities},
 		{"TestVulnerabilityWithOS", testVulnerabilityWithOS},
 		{"TestVulnerabilityWithSoftware", testVulnerabilityWithSoftware},
+		{"TestOSVersionsByCVEFailsGracefullyWithNoOSVersionRows", testOSVersionsByCVEFailsGracefullyWithNoOSVersionRows},
 		{"TestOSVersionsByCVE", testOSVersionsByCVE},
 		{"TestSoftwareByCVE", testSoftwareByCVE},
 		{"TestVulnerabilitiesPagination", testVulnerabilitiesPagination},
@@ -897,6 +898,12 @@ func testVulnerabilityHostCountBatchInserts(t *testing.T, ds *Datastore) {
 	for _, vuln := range list {
 		require.Equal(t, uint(2), vuln.HostsCount)
 	}
+}
+
+func testOSVersionsByCVEFailsGracefullyWithNoOSVersionRows(t *testing.T, ds *Datastore) {
+	osv, _, err := ds.OSVersionsByCVE(context.Background(), "CVE-2020-1238", nil)
+	require.NoError(t, err)
+	require.Nil(t, osv)
 }
 
 func testOSVersionsByCVE(t *testing.T, ds *Datastore) {


### PR DESCRIPTION
For #22523.

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/Committing-Changes.md#changes-files) for more information.
- [x] Added/updated tests
- [x] Manual QA for all new/changed functionality