### PR TITLE
Dogfood: enforce macOS 15.2

### DIFF
--- a/it-and-security/teams/workstations-canary.yml
+++ b/it-and-security/teams/workstations-canary.yml
@@ -93,8 +93,8 @@ controls:
     enable_end_user_authentication: false
     macos_setup_assistant: null
   macos_updates:
-    deadline: "2024-12-04"
-    minimum_version: "15.1.1"
+    deadline: "2025-01-03"
+    minimum_version: "15.2"
   windows_settings:
     custom_settings:
       - path: ../lib/windows/configuration-profiles/windows-firewall.xml

--- a/it-and-security/teams/workstations.yml
+++ b/it-and-security/teams/workstations.yml
@@ -66,8 +66,8 @@ controls:
       - app_store_id: '803453959' # Slack Desktop
       - app_store_id: '1333542190' # 1Password 7 Desktop
   macos_updates:
-    deadline: "2024-12-04"
-    minimum_version: "15.1.1"
+    deadline: "2025-01-03"
+    minimum_version: "15.2"
   windows_settings:
     custom_settings: null
   windows_updates:


### PR DESCRIPTION
- Deadline is Friday after new year (2025-01-03) to give folks a couple of days after the holidays
- CVEs fixed in 15.2 are https://support.apple.com/en-us/121839
