### PR TITLE
Loadtest preston (placeholder)

### DIFF
--- a/infrastructure/loadtesting/terraform/ecs.tf
+++ b/infrastructure/loadtesting/terraform/ecs.tf
@@ -50,8 +50,8 @@ resource "aws_ecs_task_definition" "backend" {
   requires_compatibilities = ["FARGATE"]
   execution_role_arn       = aws_iam_role.main.arn
   task_role_arn            = aws_iam_role.main.arn
-  cpu                      = 1024
-  memory                   = 4096
+  cpu                      = 256
+  memory                   = 512
   container_definitions = jsonencode(
     [
       {

--- a/infrastructure/loadtesting/terraform/ecs.tf
+++ b/infrastructure/loadtesting/terraform/ecs.tf
@@ -84,8 +84,8 @@ resource "aws_ecs_task_definition" "backend" {
       {
         name        = "fleet"
         image       = docker_registry_image.fleet.name
-        cpu         = 1024
-        memory      = 4096
+        cpu         = 256
+        memory      = 512
         mountPoints = []
         volumesFrom = []
         essential   = true
@@ -118,10 +118,10 @@ resource "aws_ecs_task_definition" "backend" {
             name      = "FLEET_MYSQL_PASSWORD"
             valueFrom = aws_secretsmanager_secret.database_password_secret.arn
           },
-          {
-            name      = "FLEET_MYSQL_READ_REPLICA_PASSWORD"
-            valueFrom = aws_secretsmanager_secret.database_password_secret.arn
-          },
+#           {
+#             name      = "FLEET_MYSQL_READ_REPLICA_PASSWORD"
+#             valueFrom = aws_secretsmanager_secret.database_password_secret.arn
+#           },
           {
             name      = "FLEET_LICENSE_KEY"
             valueFrom = data.aws_secretsmanager_secret.license.arn
@@ -148,22 +148,22 @@ resource "aws_ecs_task_definition" "backend" {
             name  = "FLEET_MYSQL_MAX_OPEN_CONNS"
             value = "10"
           },
-          {
-            name  = "FLEET_MYSQL_READ_REPLICA_USERNAME"
-            value = module.aurora_mysql.cluster_master_username
-          },
-          {
-            name  = "FLEET_MYSQL_READ_REPLICA_DATABASE"
-            value = module.aurora_mysql.cluster_database_name
-          },
-          {
-            name  = "FLEET_MYSQL_READ_REPLICA_ADDRESS"
-            value = "${module.aurora_mysql.cluster_reader_endpoint}:3306"
-          },
-          {
-            name  = "FLEET_MYSQL_READ_REPLICA_MAX_OPEN_CONNS"
-            value = "10"
-          },
+#           {
+#             name  = "FLEET_MYSQL_READ_REPLICA_USERNAME"
+#             value = module.aurora_mysql.cluster_master_username
+#           },
+#           {
+#             name  = "FLEET_MYSQL_READ_REPLICA_DATABASE"
+#             value = module.aurora_mysql.cluster_database_name
+#           },
+#           {
+#             name  = "FLEET_MYSQL_READ_REPLICA_ADDRESS"
+#             value = "${module.aurora_mysql.cluster_reader_endpoint}:3306"
+#           },
+#           {
+#             name  = "FLEET_MYSQL_READ_REPLICA_MAX_OPEN_CONNS"
+#             value = "10"
+#           },
           {
             name  = "FLEET_REDIS_ADDRESS"
             value = "${aws_elasticache_replication_group.default.primary_endpoint_address}:6379"

--- a/infrastructure/loadtesting/terraform/loadtesting.tf
+++ b/infrastructure/loadtesting/terraform/loadtesting.tf
@@ -51,14 +51,14 @@ resource "aws_ecs_task_definition" "loadtest" {
         command = [
           "/go/osquery-perf",
           "-enroll_secret", data.aws_secretsmanager_secret_version.enroll_secret.secret_string,
-          "-host_count", "100",
+          "-host_count", "250",
           "-server_url", "http://${aws_lb.internal.dns_name}",
           "--policy_pass_prob", "0.5",
           "--start_period", "5m",
           "--orbit_prob", "1",
           "--mdm_prob", "1",
           "--mdm_scep_challenge", "foo",
-          "--os_templates", "macos_14.1.2:100",
+          "--os_templates", "macos_14.1.2:250",
           "--mdm_check_in_interval", "1m"
         ]
       }

--- a/infrastructure/loadtesting/terraform/loadtesting.tf
+++ b/infrastructure/loadtesting/terraform/loadtesting.tf
@@ -51,11 +51,15 @@ resource "aws_ecs_task_definition" "loadtest" {
         command = [
           "/go/osquery-perf",
           "-enroll_secret", data.aws_secretsmanager_secret_version.enroll_secret.secret_string,
-          "-host_count", "500",
+          "-host_count", "100",
           "-server_url", "http://${aws_lb.internal.dns_name}",
           "--policy_pass_prob", "0.5",
           "--start_period", "5m",
-          "--orbit_prob", "0.0"
+          "--orbit_prob", "1",
+          "--mdm_prob", "1",
+          "--mdm_scep_challenge", "foo",
+          "--os_templates", "macos_14.1.2:100",
+          "--mdm_check_in_interval", "1m"
         ]
       }
   ])

--- a/infrastructure/loadtesting/terraform/rds.tf
+++ b/infrastructure/loadtesting/terraform/rds.tf
@@ -33,7 +33,7 @@ module "aurora_mysql" { #tfsec:ignore:aws-rds-enable-performance-insights-encryp
 
   instances = {
     one = {}
-    two = {}
+#    two = {}
   }
 
   iam_database_authentication_enabled = true

--- a/server/datastore/mysql/common_mysql/retry.go
+++ b/server/datastore/mysql/common_mysql/retry.go
@@ -1,0 +1,93 @@
+package common_mysql
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"time"
+
+	"github.com/VividCortex/mysqlerr"
+	"github.com/cenkalti/backoff/v4"
+	"github.com/fleetdm/fleet/v4/server/contexts/ctxerr"
+	"github.com/go-kit/log"
+	"github.com/go-sql-driver/mysql"
+	"github.com/jmoiron/sqlx"
+)
+
+var DoRetryErr = errors.New("fleet datastore retry")
+
+type TxFn func(tx sqlx.ExtContext) error
+
+// WithRetryTxx provides a common way to commit/rollback a txFn wrapped in a retry with exponential backoff
+func WithRetryTxx(ctx context.Context, db *sqlx.DB, fn TxFn, logger log.Logger) error {
+	operation := func() error {
+		tx, err := db.BeginTxx(ctx, nil)
+		if err != nil {
+			return ctxerr.Wrap(ctx, err, "create transaction")
+		}
+
+		defer func() {
+			if p := recover(); p != nil {
+				if err := tx.Rollback(); err != nil {
+					logger.Log("err", err, "msg", "error encountered during transaction panic rollback")
+				}
+				panic(p)
+			}
+		}()
+
+		if err := fn(tx); err != nil {
+			rbErr := tx.Rollback()
+			if rbErr != nil && rbErr != sql.ErrTxDone {
+				// Consider rollback errors to be non-retryable
+				return backoff.Permanent(ctxerr.Wrapf(ctx, err, "got err '%s' rolling back after err", rbErr.Error()))
+			}
+
+			if retryableError(err) {
+				return err
+			}
+
+			// Consider any other errors to be non-retryable
+			return backoff.Permanent(err)
+		}
+
+		if err := tx.Commit(); err != nil {
+			err = ctxerr.Wrap(ctx, err, "commit transaction")
+
+			if retryableError(err) {
+				return err
+			}
+
+			return backoff.Permanent(err)
+		}
+
+		return nil
+	}
+
+	expBo := backoff.NewExponentialBackOff()
+	// MySQL innodb_lock_wait_timeout default is 50 seconds, so transaction can be waiting for a lock for several seconds.
+	// Setting a higher MaxElapsedTime to increase probability that transaction will be retried.
+	// This will reduce the number of retryable 'Deadlock found' errors. However, with a loaded DB, we will still see
+	// 'Context cancelled' errors when the server drops long-lasting connections.
+	expBo.MaxElapsedTime = 1 * time.Minute
+	bo := backoff.WithMaxRetries(expBo, 5)
+	return backoff.Retry(operation, bo)
+}
+
+// retryableError determines whether a MySQL error can be retried. By default
+// errors are considered non-retryable. Only errors that we know have a
+// possibility of succeeding on a retry should return true in this function.
+func retryableError(err error) bool {
+	base := ctxerr.Cause(err)
+	if b, ok := base.(*mysql.MySQLError); ok {
+		switch b.Number {
+		// Consider lock related errors to be retryable
+		case mysqlerr.ER_LOCK_DEADLOCK, mysqlerr.ER_LOCK_WAIT_TIMEOUT:
+			return true
+		}
+	}
+	if errors.Is(err, DoRetryErr) {
+		return true
+	}
+
+	return false
+}

--- a/server/datastore/mysql/nanomdm_storage.go
+++ b/server/datastore/mysql/nanomdm_storage.go
@@ -10,6 +10,7 @@ import (
 
 	abmctx "github.com/fleetdm/fleet/v4/server/contexts/apple_bm"
 	"github.com/fleetdm/fleet/v4/server/contexts/ctxerr"
+	"github.com/fleetdm/fleet/v4/server/datastore/mysql/common_mysql"
 	"github.com/fleetdm/fleet/v4/server/fleet"
 	"github.com/fleetdm/fleet/v4/server/mdm/assets"
 	nanodep_client "github.com/fleetdm/fleet/v4/server/mdm/nanodep/client"
@@ -125,7 +126,7 @@ func (s *NanoMDMStorage) EnqueueDeviceLockCommand(
 	cmd *mdm.Command,
 	pin string,
 ) error {
-	return withRetryTxx(ctx, s.db, func(tx sqlx.ExtContext) error {
+	return common_mysql.WithRetryTxx(ctx, s.db, func(tx sqlx.ExtContext) error {
 		if err := enqueueCommandDB(ctx, tx, []string{host.UUID}, cmd); err != nil {
 			return err
 		}
@@ -154,7 +155,7 @@ func (s *NanoMDMStorage) EnqueueDeviceLockCommand(
 
 // EnqueueDeviceWipeCommand enqueues a EraseDevice command for the given host.
 func (s *NanoMDMStorage) EnqueueDeviceWipeCommand(ctx context.Context, host *fleet.Host, cmd *mdm.Command) error {
-	return withRetryTxx(ctx, s.db, func(tx sqlx.ExtContext) error {
+	return common_mysql.WithRetryTxx(ctx, s.db, func(tx sqlx.ExtContext) error {
 		if err := enqueueCommandDB(ctx, tx, []string{host.UUID}, cmd); err != nil {
 			return err
 		}

--- a/server/datastore/mysql/operating_systems.go
+++ b/server/datastore/mysql/operating_systems.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 
 	"github.com/fleetdm/fleet/v4/server/contexts/ctxerr"
+	"github.com/fleetdm/fleet/v4/server/datastore/mysql/common_mysql"
 	"github.com/fleetdm/fleet/v4/server/fleet"
 	"github.com/jmoiron/sqlx"
 )
@@ -93,7 +94,7 @@ func newOperatingSystemDB(ctx context.Context, tx sqlx.ExtContext, hostOS fleet.
 	case err == nil:
 		return storedOS, nil
 	case errors.Is(err, sql.ErrNoRows):
-		return nil, doRetryErr
+		return nil, common_mysql.DoRetryErr
 	default:
 		return nil, ctxerr.Wrap(ctx, err, "get new operating system")
 	}

--- a/server/datastore/mysql/policies.go
+++ b/server/datastore/mysql/policies.go
@@ -13,6 +13,7 @@ import (
 	"golang.org/x/text/unicode/norm"
 
 	"github.com/fleetdm/fleet/v4/server/contexts/ctxerr"
+	"github.com/fleetdm/fleet/v4/server/datastore/mysql/common_mysql"
 	"github.com/fleetdm/fleet/v4/server/fleet"
 	"github.com/fleetdm/fleet/v4/server/ptr"
 	kitlog "github.com/go-kit/log"
@@ -238,7 +239,7 @@ func cleanupPolicy(
 		}
 		if _, isDB := extContext.(*sqlx.DB); isDB {
 			// wrapping in a retry to avoid deadlocks with the cleanups_then_aggregation cron job
-			err = withRetryTxx(ctx, extContext.(*sqlx.DB), fn, logger)
+			err = common_mysql.WithRetryTxx(ctx, extContext.(*sqlx.DB), fn, logger)
 		} else {
 			err = fn(extContext)
 		}

--- a/server/mdm/apple/profile_verifier.go
+++ b/server/mdm/apple/profile_verifier.go
@@ -3,6 +3,7 @@ package apple_mdm
 import (
 	"context"
 
+	"github.com/fleetdm/fleet/v4/server/contexts/ctxerr"
 	"github.com/fleetdm/fleet/v4/server/fleet"
 	"github.com/fleetdm/fleet/v4/server/mdm"
 )
@@ -118,11 +119,15 @@ func HandleHostMDMProfileInstallResult(ctx context.Context, ds fleet.ProfileVeri
 	}
 
 	// otherwise update status and detail as usual
-	return ds.UpdateOrDeleteHostMDMAppleProfile(ctx, &fleet.HostMDMAppleProfile{
+	err := ds.UpdateOrDeleteHostMDMAppleProfile(ctx, &fleet.HostMDMAppleProfile{
 		CommandUUID:   cmdUUID,
 		HostUUID:      hostUUID,
 		Status:        status,
 		Detail:        detail,
 		OperationType: fleet.MDMOperationTypeInstall,
 	})
+	if err != nil {
+		return ctxerr.Wrap(ctx, err, "updating host MDM Apple profile install result")
+	}
+	return nil
 }

--- a/server/mdm/nanomdm/storage/mysql/queue.go
+++ b/server/mdm/nanomdm/storage/mysql/queue.go
@@ -8,11 +8,14 @@ import (
 	"strings"
 
 	"github.com/fleetdm/fleet/v4/server/contexts/ctxerr"
+	"github.com/fleetdm/fleet/v4/server/datastore/mysql/common_mysql"
 	"github.com/fleetdm/fleet/v4/server/mdm/nanomdm/mdm"
 	"github.com/google/uuid"
+	"github.com/jmoiron/sqlx"
+	"github.com/micromdm/nanolib/log"
 )
 
-func enqueue(ctx context.Context, tx *sql.Tx, ids []string, cmd *mdm.Command) error {
+func enqueue(ctx context.Context, tx sqlx.ExtContext, ids []string, cmd *mdm.Command) error {
 	if len(ids) < 1 {
 		return errors.New("no id(s) supplied to queue command to")
 	}
@@ -50,19 +53,22 @@ func enqueue(ctx context.Context, tx *sql.Tx, ids []string, cmd *mdm.Command) er
 	return nil
 }
 
+type loggerWrapper struct {
+	logger log.Logger
+}
+
+func (l loggerWrapper) Log(keyvals ...interface{}) error {
+	l.logger.Info(keyvals...)
+	return nil
+}
+
 func (m *MySQLStorage) EnqueueCommand(ctx context.Context, ids []string, cmd *mdm.Command) (map[string]error, error) {
-	// TODO: We need to fix the deadlock caused by simultaneously updating seen_times and enqueuing a command.
-	tx, err := m.db.BeginTx(ctx, nil)
-	if err != nil {
-		return nil, err
-	}
-	if err = enqueue(ctx, tx, ids, cmd); err != nil {
-		if rbErr := tx.Rollback(); rbErr != nil {
-			return nil, fmt.Errorf("rollback error: %w; while trying to handle error: %v", rbErr, err)
-		}
-		return nil, err
-	}
-	return nil, tx.Commit()
+	// We need to retry because this transaction may deadlock with updates to nano_enrollment.last_seen_at
+	// Deadlock seen in 2024/12/12 loadtest: https://docs.google.com/document/d/1-Q6qFTd7CDm-lh7MVRgpNlNNJijk6JZ4KO49R1fp80U
+	err := common_mysql.WithRetryTxx(ctx, sqlx.NewDb(m.db, ""), func(tx sqlx.ExtContext) error {
+		return enqueue(ctx, tx, ids, cmd)
+	}, loggerWrapper{m.logger})
+	return nil, err
 }
 
 func (m *MySQLStorage) deleteCommand(ctx context.Context, tx *sql.Tx, id, uuid string) error {

--- a/server/mdm/nanomdm/storage/mysql/queue.go
+++ b/server/mdm/nanomdm/storage/mysql/queue.go
@@ -51,6 +51,7 @@ func enqueue(ctx context.Context, tx *sql.Tx, ids []string, cmd *mdm.Command) er
 }
 
 func (m *MySQLStorage) EnqueueCommand(ctx context.Context, ids []string, cmd *mdm.Command) (map[string]error, error) {
+	// TODO: We need to fix the deadlock caused by simultaneously updating seen_times and enqueuing a command.
 	tx, err := m.db.BeginTx(ctx, nil)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [ ] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/Committing-Changes.md#changes-files) for more information.
- [ ] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [ ] Added support on fleet's osquery simulator `cmd/osquery-perf` for new osquery data ingestion features.
- [ ] Added/updated tests
- [ ] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes
- [ ] If database migrations are included, checked table schema to confirm autoupdate
- For database migrations:
  - [ ] Checked schema for all modified table for columns that will auto-update timestamps during migration.
  - [ ] Confirmed that updating the timestamps is acceptable, and will not cause unwanted side effects.
  - [ ] Ensured the correct collation is explicitly set for character columns (`COLLATE utf8mb4_unicode_ci`).
- [ ] Manual QA for all new/changed functionality
- For Orbit and Fleet Desktop changes:
   - [ ] Orbit runs on macOS, Linux and Windows. Check if the orbit feature/bugfix should only apply to one platform (`runtime.GOOS`).
   - [ ] Manual QA must be performed in the three main OSs, macOS, Windows and Linux.
   - [ ] Auto-update manual QA, from released version of component to new version (see [tools/tuf/test](../tools/tuf/test/README.md)).
