### PR TITLE
Add "Disk encryption" column to Hosts page

### DIFF
--- a/frontend/__mocks__/hostMock.ts
+++ b/frontend/__mocks__/hostMock.ts
@@ -109,6 +109,7 @@ const DEFAULT_HOST_MOCK: IHost = {
   users: [],
   policies: [],
   device_mapping: [],
+  disk_encryption_status: "ON",
 };
 
 const createMockHost = (overrides?: Partial<IHost>): IHost => {

--- a/frontend/interfaces/host.ts
+++ b/frontend/interfaces/host.ts
@@ -267,6 +267,7 @@ export interface IHostIssues {
 }
 
 export interface IHost {
+  disk_encryption_status: string;
   created_at: string;
   updated_at: string;
   software_updated_at?: string;

--- a/frontend/pages/hosts/ManageHostsPage/HostTableConfig.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/HostTableConfig.tsx
@@ -18,7 +18,6 @@ import TooltipTruncatedTextCell from "components/TableContainer/DataTable/Toolti
 import TooltipWrapper from "components/TooltipWrapper";
 import { HumanTimeDiffWithFleetLaunchCutoff } from "components/HumanTimeDiffWithDateTip";
 import NotSupported from "components/NotSupported";
-
 import {
   humanHostMemory,
   humanHostLastSeen,
@@ -638,6 +637,20 @@ const allHostTableHeaders: IHostTableColumnConfig[] = [
     accessor: "hardware_model",
     id: "hardware_model",
     Cell: (cellProps: IHostTableStringCellProps) => (
+      <TextCell value={cellProps.cell.value} />
+    ),
+  },
+  {
+    title: "Disk Encryption",
+    Header: (cellProps: IHostTableHeaderProps) => (
+      <HeaderCell
+        value="Disk Encryption"
+        isSortedDesc={cellProps.column.isSortedDesc}
+      />
+    ),
+    accessor: "disk_encryption_status",
+    id: "disk_encryption_enabled",
+    Cell: (cellProps: IHostTableHeaderProps) => (
       <TextCell value={cellProps.cell.value} />
     ),
   },

--- a/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
@@ -1608,7 +1608,7 @@ const ManageHostsPage = ({
 
       return statusText;
     };
-    // Loop through each host and assign `disk_encryption_status`
+    // This would be fixed by including the disk_encryption_status in the api response
     hostsData?.hosts.forEach((host) => {
       host.disk_encryption_status = generateDiskTableConfig({
         platform: host.platform,


### PR DESCRIPTION
# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->
Fix for #21984 

Hi @noahtalerman ,
This is possible fix for #21984 but I believe this would be simplified by adding the disk_encryption_status in the API response.