### PR TITLE
Add missing CIS checks

### DIFF
--- a/ee/cis/macos-15/cis-policy-queries.yml
+++ b/ee/cis/macos-15/cis-policy-queries.yml
@@ -3472,3 +3472,40 @@ spec:
   purpose: Informational
   tags: compliance, CIS, CIS_Level1
   contributors: sharon-fdm
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS -  Ensure Logging Is Enabled for Sudo (MDM Required)
+  platforms: macOS
+  platform: darwin
+  description: |
+    In order to properly monitor the use of the sudo command, logs events for any use of sudo should be captured in the unified log.
+  resolution: |
+    Ask your system administrator to deploy a script that will configure:
+      /usr/bin/sudo /usr/sbin/visudo -f /etc/sudoers
+      Remove the line, or comment out with # before the line, 'Defaults !log_allowed'
+  query: |
+    SELECT 1 
+    FROM file_lines 
+    WHERE path = '/etc/sudoers' 
+      AND (
+          -- No matching line
+          NOT EXISTS (
+              SELECT 1 
+              FROM file_lines 
+              WHERE path = '/etc/sudoers' 
+                AND line LIKE '%!log_allowed%'
+          ) 
+          -- OR line exists but is commented
+          OR EXISTS (
+              SELECT 1 
+              FROM file_lines 
+              WHERE path = '/etc/sudoers' 
+                AND line LIKE '%#%Defaults%!log_allowed%'
+          )
+      ) 
+    LIMIT 1;
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1
+  contributors: defensivedepth

--- a/ee/cis/macos-15/cis-policy-queries.yml
+++ b/ee/cis/macos-15/cis-policy-queries.yml
@@ -1890,6 +1890,7 @@ spec:
         4. Verify that Share Mac Analytics is not enabled
         5. Verify that Share with App Developers is not enabled
         6. Verify that Improve Siri & Dictation is not enabled
+        7. Verify that Improve Assistive Voice Features is not enabled 
   query: |
     SELECT 1 WHERE 
       EXISTS (
@@ -1903,6 +1904,13 @@ spec:
         SELECT 1 FROM managed_policies WHERE 
             domain='com.apple.applicationaccess' AND 
             name='allowDiagnosticSubmission' AND 
+            (value = 0 OR value = 'false') AND 
+            username = ''
+        )
+      AND EXISTS (
+        SELECT 1 FROM managed_policies WHERE 
+            domain='com.apple.Accessibility' AND 
+            name='AXSAudioDonationSiriImprovementEnabled' AND 
             (value = 0 OR value = 'false') AND 
             username = ''
         )

--- a/ee/cis/macos-15/cis-policy-queries.yml
+++ b/ee/cis/macos-15/cis-policy-queries.yml
@@ -3498,7 +3498,7 @@ spec:
                 AND line LIKE '%!log_allowed%'
           ) 
           -- OR line exists but is commented
-          OR EXISTS (
+          AND NOT EXISTS (
               SELECT 1 
               FROM file_lines 
               WHERE path = '/etc/sudoers' 


### PR DESCRIPTION
PR for https://github.com/fleetdm/fleet/issues/24647

Adds:
- 2.6.3.3: Ensure Improve Assistive Voice Features Is Disabled
- 5.11: Ensure Logging Is Enabled for Sudo (Automated)

2.6.3.1, 2.6.3.2, 2.6.3.4 were previously added.

2.7.2. is a `Manual` check, which is not supported here.
