### PR TITLE
Add UI for scoping software to  fleet apps and custom packages via labels

### DIFF
--- a/changes/24538-24542-UI-for-scope-software-via-labels
+++ b/changes/24538-24542-UI-for-scope-software-via-labels
@@ -1,0 +1,1 @@
+- add UI for scoping software via labels

--- a/frontend/components/PlatformSelector/PlatformSelector.tsx
+++ b/frontend/components/PlatformSelector/PlatformSelector.tsx
@@ -35,7 +35,7 @@ export const PlatformSelector = ({
 
   return (
     <div className={`${parentClass}__${baseClass} ${baseClass} form-field`}>
-      <span className={labelClasses}>Checks on:</span>
+      <span className={labelClasses}>Targets:</span>
       <span className={`${baseClass}__checkboxes`}>
         <Checkbox
           value={checkDarwin}
@@ -71,7 +71,8 @@ export const PlatformSelector = ({
         </Checkbox>
       </span>
       <div className="form-field__help-text">
-        Your policy will only be checked on the selected platform(s).
+        To apply the profile to new hosts, you&apos;ll have to delete it and
+        upload a new profile.
       </div>
     </div>
   );

--- a/frontend/components/PlatformSelector/_styles.scss
+++ b/frontend/components/PlatformSelector/_styles.scss
@@ -11,4 +11,8 @@
   .form-field__label--disabled {
     color: $ui-fleet-black-50;
   }
+
+  &__platform-checkbox-wrapper {
+    width: auto;
+  }
 }

--- a/frontend/components/TargetLabelSelector/TargetLabelSelector.tsx
+++ b/frontend/components/TargetLabelSelector/TargetLabelSelector.tsx
@@ -1,0 +1,205 @@
+import React, { ReactNode } from "react";
+import classnames from "classnames";
+
+// @ts-ignore
+import Dropdown from "components/forms/fields/Dropdown";
+import Radio from "components/forms/fields/Radio";
+import DataError from "components/DataError";
+import Spinner from "components/Spinner";
+import Checkbox from "components/forms/fields/Checkbox";
+import { IDropdownOption } from "interfaces/dropdownOption";
+import { ILabelSummary } from "interfaces/label";
+
+const baseClass = "target-label-selector";
+
+export const listNamesFromSelectedLabels = (dict: Record<string, boolean>) => {
+  return Object.entries(dict).reduce((acc, [labelName, isSelected]) => {
+    if (isSelected) {
+      acc.push(labelName);
+    }
+    return acc;
+  }, [] as string[]);
+};
+
+export const generateLabelKey = (
+  target: string,
+  customTargetOption: string,
+  selectedLabels: Record<string, boolean>
+) => {
+  if (target !== "Custom") {
+    return {};
+  }
+
+  return {
+    [customTargetOption]: listNamesFromSelectedLabels(selectedLabels),
+  };
+};
+
+interface ITargetChooserProps {
+  selectedTarget: string;
+  onSelect: (val: string) => void;
+}
+
+const TargetChooser = ({ selectedTarget, onSelect }: ITargetChooserProps) => {
+  return (
+    <div className={`form-field`}>
+      <div className="form-field__label">Target</div>
+      <Radio
+        className={`${baseClass}__radio-input`}
+        label="All hosts"
+        id="all-hosts-target-radio-btn"
+        checked={selectedTarget === "All hosts"}
+        value="All hosts"
+        name="target-type"
+        onChange={onSelect}
+      />
+      <Radio
+        className={`${baseClass}__radio-input`}
+        label="Custom"
+        id="custom-target-radio-btn"
+        checked={selectedTarget === "Custom"}
+        value="Custom"
+        name="target-type"
+        onChange={onSelect}
+      />
+    </div>
+  );
+};
+
+interface ILabelChooserProps {
+  isError: boolean;
+  isLoading: boolean;
+  labels: ILabelSummary[];
+  selectedLabels: Record<string, boolean>;
+  selectedCustomTarget: string;
+  customTargetOptions: IDropdownOption[];
+  dropdownHelpText?: ReactNode;
+  onSelectCustomTarget: (val: string) => void;
+  onSelectLabel: ({ name, value }: { name: string; value: boolean }) => void;
+}
+
+const LabelChooser = ({
+  isError,
+  isLoading,
+  labels,
+  dropdownHelpText,
+  selectedLabels,
+  selectedCustomTarget,
+  customTargetOptions,
+  onSelectCustomTarget,
+  onSelectLabel,
+}: ILabelChooserProps) => {
+  const getHelpText = (value: string) => {
+    if (dropdownHelpText) return dropdownHelpText;
+    return customTargetOptions.find((option) => option.value === value)
+      ?.helpText;
+  };
+
+  const renderLabels = () => {
+    if (isLoading) {
+      return <Spinner centered={false} />;
+    }
+
+    if (isError) {
+      return <DataError />;
+    }
+
+    if (!labels.length) {
+      return (
+        <div className={`${baseClass}__no-labels`}>
+          <b>No labels exist in Fleet</b>
+          <span>Add labels to target specific hosts.</span>
+        </div>
+      );
+    }
+
+    return labels.map((label) => {
+      return (
+        <div className={`${baseClass}__label`} key={label.name}>
+          <Checkbox
+            className={`${baseClass}__checkbox`}
+            name={label.name}
+            value={!!selectedLabels[label.name]}
+            onChange={onSelectLabel}
+            parseTarget
+          />
+          <div className={`${baseClass}__label-name`}>{label.name}</div>
+        </div>
+      );
+    });
+  };
+
+  return (
+    <div className={`${baseClass}__custom-label-chooser`}>
+      <Dropdown
+        value={selectedCustomTarget}
+        options={customTargetOptions}
+        searchable={false}
+        onChange={onSelectCustomTarget}
+      />
+      <div className={`${baseClass}__description`}>
+        {getHelpText(selectedCustomTarget)}
+      </div>
+      <div className={`${baseClass}__checkboxes`}>{renderLabels()}</div>
+    </div>
+  );
+};
+
+interface ITargetLabelSelectorProps {
+  selectedTargetType: string;
+  customTargetOptions: IDropdownOption[];
+  selectedCustomTarget: string;
+  selectedLabels: Record<string, boolean>;
+  labels: ILabelSummary[];
+  /** set this prop to show a help text. If it is encluded then it will override
+   * the selected options defined `helpText`
+   */
+  dropdownHelpText?: ReactNode;
+  isLoadingLabels?: boolean;
+  isErrorLabels?: boolean;
+  className?: string;
+  onSelectTargetType: (val: string) => void;
+  onSelectCustomTarget: (val: string) => void;
+  onSelectLabel: ({ name, value }: { name: string; value: boolean }) => void;
+}
+
+const TargetLabelSelector = ({
+  selectedTargetType,
+  selectedCustomTarget,
+  customTargetOptions,
+  selectedLabels,
+  dropdownHelpText,
+  className,
+  labels,
+  isLoadingLabels = false,
+  isErrorLabels = false,
+  onSelectTargetType,
+  onSelectCustomTarget,
+  onSelectLabel,
+}: ITargetLabelSelectorProps) => {
+  const classNames = classnames(baseClass, className);
+
+  return (
+    <div className={classNames}>
+      <TargetChooser
+        selectedTarget={selectedTargetType}
+        onSelect={onSelectTargetType}
+      />
+      {selectedTargetType === "Custom" && (
+        <LabelChooser
+          selectedCustomTarget={selectedCustomTarget}
+          customTargetOptions={customTargetOptions}
+          isError={isErrorLabels}
+          isLoading={isLoadingLabels}
+          labels={labels || []}
+          selectedLabels={selectedLabels}
+          dropdownHelpText={dropdownHelpText}
+          onSelectCustomTarget={onSelectCustomTarget}
+          onSelectLabel={onSelectLabel}
+        />
+      )}
+    </div>
+  );
+};
+
+export default TargetLabelSelector;

--- a/frontend/components/TargetLabelSelector/TargetLabelSelector.tsx
+++ b/frontend/components/TargetLabelSelector/TargetLabelSelector.tsx
@@ -1,5 +1,10 @@
 import React, { ReactNode } from "react";
+import { Link } from "react-router";
 import classnames from "classnames";
+
+import PATHS from "router/paths";
+import { IDropdownOption } from "interfaces/dropdownOption";
+import { ILabelSummary } from "interfaces/label";
 
 // @ts-ignore
 import Dropdown from "components/forms/fields/Dropdown";
@@ -7,8 +12,6 @@ import Radio from "components/forms/fields/Radio";
 import DataError from "components/DataError";
 import Spinner from "components/Spinner";
 import Checkbox from "components/forms/fields/Checkbox";
-import { IDropdownOption } from "interfaces/dropdownOption";
-import { ILabelSummary } from "interfaces/label";
 
 const baseClass = "target-label-selector";
 
@@ -107,8 +110,10 @@ const LabelChooser = ({
     if (!labels.length) {
       return (
         <div className={`${baseClass}__no-labels`}>
-          <b>No labels exist in Fleet</b>
-          <span>Add labels to target specific hosts.</span>
+          <span>
+            <Link to={PATHS.LABEL_NEW_DYNAMIC}>Add labels</Link> to target
+            specific hosts.
+          </span>
         </div>
       );
     }

--- a/frontend/components/TargetLabelSelector/TargetLabelSelector.tsx
+++ b/frontend/components/TargetLabelSelector/TargetLabelSelector.tsx
@@ -147,8 +147,8 @@ const LabelChooser = ({
 
 interface ITargetLabelSelectorProps {
   selectedTargetType: string;
-  customTargetOptions: IDropdownOption[];
   selectedCustomTarget: string;
+  customTargetOptions: IDropdownOption[];
   selectedLabels: Record<string, boolean>;
   labels: ILabelSummary[];
   /** set this prop to show a help text. If it is encluded then it will override

--- a/frontend/components/TargetLabelSelector/_styles.scss
+++ b/frontend/components/TargetLabelSelector/_styles.scss
@@ -1,4 +1,6 @@
 .target-label-selector {
+  font-size: $x-small;
+
   &__custom-label-chooser {
     margin-top: $pad-medium;
   }

--- a/frontend/components/TargetLabelSelector/_styles.scss
+++ b/frontend/components/TargetLabelSelector/_styles.scss
@@ -1,0 +1,55 @@
+.target-label-selector {
+  &__custom-label-chooser {
+    margin-top: $pad-medium;
+  }
+
+  &__description {
+    margin: $pad-medium 0;
+  }
+
+  &__no-labels {
+    display: flex;
+    height: 187px;
+    flex-direction: column;
+    align-items: center;
+    gap: $pad-small;
+    justify-content: center;
+
+    span {
+      color: $ui-fleet-black-75;
+    }
+  }
+
+  &__checkboxes {
+    display: flex;
+    max-height: 187px;
+    flex-direction: column;
+    border-radius: $border-radius;
+    border: 1px solid $ui-fleet-black-10;
+    overflow-y: auto;
+
+    .loading-spinner {
+      margin: 69.5px auto;
+    }
+  }
+
+  &__label {
+    width: 100%;
+    padding: $pad-small $pad-medium;
+    box-sizing: border-box;
+    display: flex;
+    align-items: center;
+
+    &:not(:last-child) {
+      border-bottom: 1px solid $ui-fleet-black-10;
+    }
+
+    .form-field--checkbox {
+      width: auto;
+    }
+  }
+
+  &__label-name {
+    padding-left: $pad-large;
+  }
+}

--- a/frontend/components/TargetLabelSelector/index.ts
+++ b/frontend/components/TargetLabelSelector/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./TargetLabelSelector";

--- a/frontend/interfaces/software.ts
+++ b/frontend/interfaces/software.ts
@@ -4,6 +4,7 @@ import PropTypes from "prop-types";
 import { IconNames } from "components/icons";
 
 import vulnerabilityInterface from "./vulnerability";
+import { ILabelSummary } from "./label";
 
 export default PropTypes.shape({
   type: PropTypes.string,
@@ -126,6 +127,8 @@ export interface ISoftwareTitleDetails {
   bundle_identifier?: string;
   browser?: BrowserType;
   versions_count?: number;
+  labels_include_any?: ILabelSummary[];
+  labels_exclude_any?: ILabelSummary[];
 }
 
 export interface ISoftwareVulnerability {

--- a/frontend/pages/ManageControlsPage/OSSettings/cards/CustomSettings/components/ProfileUploader/components/AddProfileModal/AddProfileModal.tsx
+++ b/frontend/pages/ManageControlsPage/OSSettings/cards/CustomSettings/components/ProfileUploader/components/AddProfileModal/AddProfileModal.tsx
@@ -11,16 +11,13 @@ import labelsAPI, { getCustomLabels } from "services/entities/labels";
 import mdmAPI from "services/entities/mdm";
 
 // @ts-ignore
-import Dropdown from "components/forms/fields/Dropdown";
 import Button from "components/buttons/Button";
 import Card from "components/Card";
-import Checkbox from "components/forms/fields/Checkbox";
 import DataError from "components/DataError";
 import Icon from "components/Icon";
 import Modal from "components/Modal";
-import Radio from "components/forms/fields/Radio";
 import Spinner from "components/Spinner";
-
+import TargetLabelSelector from "components/TargetLabelSelector";
 import ProfileGraphic from "../AddProfileGraphic";
 
 import {
@@ -30,9 +27,7 @@ import {
 } from "../../helpers";
 import {
   CUSTOM_TARGET_OPTIONS,
-  CustomTargetOption,
   generateLabelKey,
-  getDescriptionText,
   listNamesFromSelectedLabels,
 } from "./helpers";
 
@@ -91,118 +86,6 @@ const FileDetails = ({ details: { name, platform } }: IFileDetailsProps) => (
   </div>
 );
 
-interface ITargetChooserProps {
-  selectedTarget: string;
-  setSelectedTarget: React.Dispatch<React.SetStateAction<string>>;
-}
-
-const TargetChooser = ({
-  selectedTarget,
-  setSelectedTarget,
-}: ITargetChooserProps) => {
-  return (
-    <div className={`form-field`}>
-      <div className="form-field__label">Target</div>
-      <Radio
-        className={`${baseClass}__radio-input`}
-        label="All hosts"
-        id="all-hosts-target-radio-btn"
-        checked={selectedTarget === "All hosts"}
-        value="All hosts"
-        name="target-type"
-        onChange={setSelectedTarget}
-      />
-      <Radio
-        className={`${baseClass}__radio-input`}
-        label="Custom"
-        id="custom-target-radio-btn"
-        checked={selectedTarget === "Custom"}
-        value="Custom"
-        name="target-type"
-        onChange={setSelectedTarget}
-      />
-    </div>
-  );
-};
-
-interface ILabelChooserProps {
-  isError: boolean;
-  isLoading: boolean;
-  labels: ILabelSummary[];
-  selectedLabels: Record<string, boolean>;
-  customTargetOption: CustomTargetOption;
-  setSelectedLabels: React.Dispatch<
-    React.SetStateAction<Record<string, boolean>>
-  >;
-  onSelectCustomTargetOption: (val: CustomTargetOption) => void;
-}
-
-const LabelChooser = ({
-  isError,
-  isLoading,
-  labels,
-  selectedLabels,
-  customTargetOption,
-  setSelectedLabels,
-  onSelectCustomTargetOption,
-}: ILabelChooserProps) => {
-  const updateSelectedLabels = useCallback(
-    ({ name, value }: { name: string; value: boolean }) => {
-      setSelectedLabels((prevItems) => ({ ...prevItems, [name]: value }));
-    },
-    [setSelectedLabels]
-  );
-
-  const renderLabels = () => {
-    if (isLoading) {
-      return <Spinner centered={false} />;
-    }
-
-    if (isError) {
-      return <DataError />;
-    }
-
-    if (!labels.length) {
-      return (
-        <div className={`${baseClass}__no-labels`}>
-          <b>No labels exist in Fleet</b>
-          <span>Add labels to target specific hosts.</span>
-        </div>
-      );
-    }
-
-    return labels.map((label) => {
-      return (
-        <div className={`${baseClass}__label`} key={label.name}>
-          <Checkbox
-            className={`${baseClass}__checkbox`}
-            name={label.name}
-            value={!!selectedLabels[label.name]}
-            onChange={updateSelectedLabels}
-            parseTarget
-          />
-          <div className={`${baseClass}__label-name`}>{label.name}</div>
-        </div>
-      );
-    });
-  };
-
-  return (
-    <div className={`${baseClass}__custom-label-chooser`}>
-      <Dropdown
-        value={customTargetOption}
-        options={CUSTOM_TARGET_OPTIONS}
-        searchable={false}
-        onChange={onSelectCustomTargetOption}
-      />
-      <div className={`${baseClass}__description`}>
-        {getDescriptionText(customTargetOption)}
-      </div>
-      <div className={`${baseClass}__checkboxes`}>{renderLabels()}</div>
-    </div>
-  );
-};
-
 interface IAddProfileModalProps {
   currentTeamId: number;
   isPremiumTier: boolean;
@@ -223,14 +106,13 @@ const AddProfileModal = ({
     name: string;
     platform: string;
   } | null>(null);
-  const [selectedTarget, setSelectedTarget] = useState("All hosts"); // "All hosts" | "Custom"
+  const [selectedTargetType, setSelectedTargetType] = useState("All hosts");
   const [selectedLabels, setSelectedLabels] = useState<Record<string, boolean>>(
     {}
   );
-  const [
-    customTargetOption,
-    setCustomTargetOption,
-  ] = useState<CustomTargetOption>("labelsIncludeAll");
+  const [selectedCustomTarget, setSelectedCustomTarget] = useState(
+    "labelsIncludeAll"
+  );
 
   const fileRef = useRef<File | null>(null);
 
@@ -242,7 +124,6 @@ const AddProfileModal = ({
   } = useQuery<ILabelSummary[], Error>(
     ["custom_labels"],
     () => labelsAPI.summary().then((res) => getCustomLabels(res.labels)),
-
     {
       enabled: isPremiumTier,
       refetchOnWindowFocus: false,
@@ -268,8 +149,8 @@ const AddProfileModal = ({
     setIsLoading(true);
     try {
       const labelKey = generateLabelKey(
-        selectedTarget,
-        customTargetOption,
+        selectedTargetType,
+        selectedCustomTarget,
         selectedLabels
       );
       await mdmAPI.uploadProfile({
@@ -308,8 +189,16 @@ const AddProfileModal = ({
     }
   };
 
-  const onSelectCustomTargetOption = (val: CustomTargetOption) => {
-    setCustomTargetOption(val);
+  const onSelectTargetType = (val: string) => {
+    setSelectedTargetType(val);
+  };
+
+  const onSelectCustomTargetOption = (val: string) => {
+    setSelectedCustomTarget(val);
+  };
+
+  const onSelectLabel = ({ name, value }: { name: string; value: boolean }) => {
+    setSelectedLabels((prevItems) => ({ ...prevItems, [name]: value }));
   };
 
   return (
@@ -327,23 +216,19 @@ const AddProfileModal = ({
               )}
             </Card>
             {isPremiumTier && (
-              <div className={`${baseClass}__target`}>
-                <TargetChooser
-                  selectedTarget={selectedTarget}
-                  setSelectedTarget={setSelectedTarget}
-                />
-                {selectedTarget === "Custom" && (
-                  <LabelChooser
-                    customTargetOption={customTargetOption}
-                    isError={isErrorLabels}
-                    isLoading={isFetchingLabels}
-                    labels={labels || []}
-                    selectedLabels={selectedLabels}
-                    setSelectedLabels={setSelectedLabels}
-                    onSelectCustomTargetOption={onSelectCustomTargetOption}
-                  />
-                )}
-              </div>
+              <TargetLabelSelector
+                selectedTargetType={selectedTargetType}
+                selectedCustomTarget={selectedCustomTarget}
+                selectedLabels={selectedLabels}
+                customTargetOptions={CUSTOM_TARGET_OPTIONS}
+                className={`${baseClass}__target`}
+                onSelectTargetType={onSelectTargetType}
+                onSelectCustomTarget={onSelectCustomTargetOption}
+                onSelectLabel={onSelectLabel}
+                isErrorLabels={isErrorLabels}
+                isLoadingLabels={isFetchingLabels || isLoadingLabels}
+                labels={labels || []}
+              />
             )}
             <div className={`${baseClass}__button-wrap`}>
               <Button
@@ -352,7 +237,7 @@ const AddProfileModal = ({
                 onClick={onFileUpload}
                 isLoading={isLoading}
                 disabled={
-                  (selectedTarget === "Custom" &&
+                  (selectedTargetType === "Custom" &&
                     !listNamesFromSelectedLabels(selectedLabels).length) ||
                   !fileDetails
                 }

--- a/frontend/pages/ManageControlsPage/OSSettings/cards/CustomSettings/components/ProfileUploader/components/AddProfileModal/helpers.tsx
+++ b/frontend/pages/ManageControlsPage/OSSettings/cards/CustomSettings/components/ProfileUploader/components/AddProfileModal/helpers.tsx
@@ -47,14 +47,9 @@ export const listNamesFromSelectedLabels = (dict: Record<string, boolean>) => {
   }, [] as string[]);
 };
 
-export type CustomTargetOption =
-  | "labelsIncludeAll"
-  | "labelsIncldeAny"
-  | "labelsExcludeAny";
-
 export const generateLabelKey = (
   target: string,
-  customTargetOption: CustomTargetOption,
+  customTargetOption: string,
   selectedLabels: Record<string, boolean>
 ) => {
   if (target !== "Custom") {
@@ -64,9 +59,4 @@ export const generateLabelKey = (
   return {
     [customTargetOption]: listNamesFromSelectedLabels(selectedLabels),
   };
-};
-
-export const getDescriptionText = (value: string) => {
-  return CUSTOM_TARGET_OPTIONS.find((option) => option.value === value)
-    ?.helpText;
 };

--- a/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareCustomPackage/SoftwareCustomPackage.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareCustomPackage/SoftwareCustomPackage.tsx
@@ -4,7 +4,10 @@ import { useQuery } from "react-query";
 import { isAxiosError } from "axios";
 
 import PATHS from "router/paths";
-import { LEARN_MORE_ABOUT_BASE_LINK } from "utilities/constants";
+import {
+  DEFAULT_USE_QUERY_OPTIONS,
+  LEARN_MORE_ABOUT_BASE_LINK,
+} from "utilities/constants";
 import { getFileDetails, IFileDetails } from "utilities/file/fileUtils";
 import { buildQueryStringFromParams, QueryParams } from "utilities/url";
 import softwareAPI, {
@@ -54,16 +57,13 @@ const SoftwareCustomPackage = ({
   const {
     data: labels,
     isLoading: isLoadingLabels,
-    isFetching: isFetchingLabels,
     isError: isErrorLabels,
   } = useQuery<ILabelSummary[], Error>(
     ["custom_labels"],
     () => labelsAPI.summary().then((res) => getCustomLabels(res.labels)),
     {
+      ...DEFAULT_USE_QUERY_OPTIONS,
       enabled: isPremiumTier,
-      refetchOnWindowFocus: false,
-      retry: false,
-      staleTime: 10000,
     }
   );
 

--- a/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareCustomPackage/SoftwareCustomPackage.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareCustomPackage/SoftwareCustomPackage.tsx
@@ -1,5 +1,6 @@
 import React, { useContext, useEffect } from "react";
 import { InjectedRouter } from "react-router";
+import { useQuery } from "react-query";
 import { isAxiosError } from "axios";
 
 import PATHS from "router/paths";
@@ -10,10 +11,12 @@ import softwareAPI, {
   MAX_FILE_SIZE_BYTES,
   MAX_FILE_SIZE_MB,
 } from "services/entities/software";
+import labelsAPI, { getCustomLabels } from "services/entities/labels";
 
 import { NotificationContext } from "context/notification";
 import { AppContext } from "context/app";
 import { getErrorReason } from "interfaces/errors";
+import { ILabelSummary } from "interfaces/label";
 
 import CustomLink from "components/CustomLink";
 import FileProgressModal from "components/FileProgressModal";
@@ -44,6 +47,22 @@ const SoftwareCustomPackage = ({
   const [uploadProgress, setUploadProgress] = React.useState(0);
   const [uploadDetails, setUploadDetails] = React.useState<IFileDetails | null>(
     null
+  );
+
+  const {
+    data: labels,
+    isLoading: isLoadingLabels,
+    isFetching: isFetchingLabels,
+    isError: isErrorLabels,
+  } = useQuery<ILabelSummary[], Error>(
+    ["custom_labels"],
+    () => labelsAPI.summary().then((res) => getCustomLabels(res.labels)),
+    {
+      enabled: isPremiumTier,
+      refetchOnWindowFocus: false,
+      retry: false,
+      staleTime: 10000,
+    }
   );
 
   useEffect(() => {
@@ -168,6 +187,7 @@ const SoftwareCustomPackage = ({
   return (
     <div className={baseClass}>
       <PackageForm
+        labels={labels || []}
         showSchemaButton={!isSidePanelOpen}
         onClickShowSchema={() => setSidePanelOpen(true)}
         className={`${baseClass}__package-form`}

--- a/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareCustomPackage/SoftwareCustomPackage.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareCustomPackage/SoftwareCustomPackage.tsx
@@ -21,6 +21,8 @@ import { ILabelSummary } from "interfaces/label";
 import CustomLink from "components/CustomLink";
 import FileProgressModal from "components/FileProgressModal";
 import PremiumFeatureMessage from "components/PremiumFeatureMessage";
+import Spinner from "components/Spinner";
+import DataError from "components/DataError";
 
 import PackageForm from "pages/SoftwarePage/components/PackageForm";
 import { IPackageFormData } from "pages/SoftwarePage/components/PackageForm/PackageForm";
@@ -178,30 +180,42 @@ const SoftwareCustomPackage = ({
     setUploadDetails(null);
   };
 
+  const renderContent = () => {
+    if (isLoadingLabels) {
+      return <Spinner />;
+    }
+
+    if (isErrorLabels) {
+      return <DataError className={`${baseClass}__data-error`} />;
+    }
+
+    return (
+      <>
+        <PackageForm
+          labels={labels || []}
+          showSchemaButton={!isSidePanelOpen}
+          onClickShowSchema={() => setSidePanelOpen(true)}
+          className={`${baseClass}__package-form`}
+          onCancel={onCancel}
+          onSubmit={onSubmit}
+        />
+        {uploadDetails && (
+          <FileProgressModal
+            fileDetails={uploadDetails}
+            fileProgress={uploadProgress}
+          />
+        )}
+      </>
+    );
+  };
+
   if (!isPremiumTier) {
     return (
       <PremiumFeatureMessage className={`${baseClass}__premium-message`} />
     );
   }
 
-  return (
-    <div className={baseClass}>
-      <PackageForm
-        labels={labels || []}
-        showSchemaButton={!isSidePanelOpen}
-        onClickShowSchema={() => setSidePanelOpen(true)}
-        className={`${baseClass}__package-form`}
-        onCancel={onCancel}
-        onSubmit={onSubmit}
-      />
-      {uploadDetails && (
-        <FileProgressModal
-          fileDetails={uploadDetails}
-          fileProgress={uploadProgress}
-        />
-      )}
-    </div>
-  );
+  return <div className={baseClass}>{renderContent()}</div>;
 };
 
 export default SoftwareCustomPackage;

--- a/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareCustomPackage/_styles.scss
+++ b/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareCustomPackage/_styles.scss
@@ -3,6 +3,10 @@
     margin-top: $pad-xxxlarge;
   }
 
+  &__data-error {
+    margin-top: $pad-xxxlarge;
+  }
+
   // formatting the form buttons to be on the left. Tshis is done here because
   // this form can be used in other places where the buttons should be on
   // the right.

--- a/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareFleetMaintained/FleetMaintainedAppDetailsPage/FleetAppDetailsForm/FleetAppDetailsForm.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareFleetMaintained/FleetMaintainedAppDetailsPage/FleetAppDetailsForm/FleetAppDetailsForm.tsx
@@ -1,14 +1,21 @@
 import React, { useState } from "react";
 
+import { ILabelSummary } from "interfaces/label";
+
 import Checkbox from "components/forms/fields/Checkbox";
 import TooltipWrapper from "components/TooltipWrapper";
 import RevealButton from "components/buttons/RevealButton";
 import Button from "components/buttons/Button";
 import Radio from "components/forms/fields/Radio";
+import TargetLabelSelector from "components/TargetLabelSelector";
 
 import AdvancedOptionsFields from "pages/SoftwarePage/components/AdvancedOptionsFields";
 
-import { generateFormValidation } from "./helpers";
+import {
+  CUSTOM_TARGET_OPTIONS,
+  generateFormValidation,
+  generateHelpText,
+} from "./helpers";
 
 const baseClass = "fleet-app-details-form";
 
@@ -27,6 +34,7 @@ export interface IFormValidation {
 }
 
 interface IFleetAppDetailsFormProps {
+  labels: ILabelSummary[] | null;
   defaultInstallScript: string;
   defaultPostInstallScript: string;
   defaultUninstallScript: string;
@@ -37,6 +45,7 @@ interface IFleetAppDetailsFormProps {
 }
 
 const FleetAppDetailsForm = ({
+  labels,
   defaultInstallScript,
   defaultPostInstallScript,
   defaultUninstallScript,
@@ -59,6 +68,13 @@ const FleetAppDetailsForm = ({
     isValid: true,
     preInstallQuery: { isValid: false },
   });
+  const [selectedTargetType, setSelectedTargetType] = useState("All hosts");
+  const [selectedLabels, setSelectedLabels] = useState<Record<string, boolean>>(
+    {}
+  );
+  const [selectedCustomTarget, setSelectedCustomTarget] = useState(
+    "labelsIncludeAny"
+  );
 
   const onChangePreInstallQuery = (value?: string) => {
     const newData = { ...formData, preInstallQuery: value };
@@ -93,6 +109,18 @@ const FleetAppDetailsForm = ({
   const onChangeInstallType = (value: string) => {
     const newData = { ...formData, installType: value };
     setFormData(newData);
+  };
+
+  const onSelectTargetType = (value: string) => {
+    setSelectedTargetType(value);
+  };
+
+  const onSelectCustomTargetOption = (value: string) => {
+    setSelectedCustomTarget(value);
+  };
+
+  const onSelectLabel = ({ name, value }: { name: string; value: boolean }) => {
+    setSelectedLabels((prevItems) => ({ ...prevItems, [name]: value }));
   };
 
   const onSubmitForm = (evt: React.FormEvent<HTMLFormElement>) => {
@@ -136,6 +164,21 @@ const FleetAppDetailsForm = ({
           />
         </div>
       </fieldset>
+      <TargetLabelSelector
+        selectedTargetType={selectedTargetType}
+        selectedCustomTarget={selectedCustomTarget}
+        selectedLabels={selectedLabels}
+        customTargetOptions={CUSTOM_TARGET_OPTIONS}
+        className={`${baseClass}__target`}
+        dropdownHelpText={
+          selectedTargetType === "Custom" &&
+          generateHelpText(formData.installType, selectedCustomTarget)
+        }
+        onSelectTargetType={onSelectTargetType}
+        onSelectCustomTarget={onSelectCustomTargetOption}
+        onSelectLabel={onSelectLabel}
+        labels={labels || []}
+      />
       <Checkbox
         value={formData.selfService}
         onChange={onToggleSelfServiceCheckbox}

--- a/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareFleetMaintained/FleetMaintainedAppDetailsPage/FleetAppDetailsForm/FleetAppDetailsForm.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareFleetMaintained/FleetMaintainedAppDetailsPage/FleetAppDetailsForm/FleetAppDetailsForm.tsx
@@ -26,11 +26,15 @@ export interface IFleetMaintainedAppFormData {
   postInstallScript?: string;
   uninstallScript?: string;
   installType: string;
+  targetType: string;
+  customTarget: string;
+  labelTargets: Record<string, boolean>;
 }
 
 export interface IFormValidation {
   isValid: boolean;
   preInstallQuery?: { isValid: boolean; message?: string };
+  customTarget?: { isValid: boolean };
 }
 
 interface IFleetAppDetailsFormProps {
@@ -63,18 +67,14 @@ const FleetAppDetailsForm = ({
     postInstallScript: defaultPostInstallScript,
     uninstallScript: defaultUninstallScript,
     installType: "manual",
+    targetType: "All hosts",
+    customTarget: "labelsIncludeAny",
+    labelTargets: {},
   });
   const [formValidation, setFormValidation] = useState<IFormValidation>({
     isValid: true,
     preInstallQuery: { isValid: false },
   });
-  const [selectedTargetType, setSelectedTargetType] = useState("All hosts");
-  const [selectedLabels, setSelectedLabels] = useState<Record<string, boolean>>(
-    {}
-  );
-  const [selectedCustomTarget, setSelectedCustomTarget] = useState(
-    "labelsIncludeAny"
-  );
 
   const onChangePreInstallQuery = (value?: string) => {
     const newData = { ...formData, preInstallQuery: value };
@@ -112,15 +112,21 @@ const FleetAppDetailsForm = ({
   };
 
   const onSelectTargetType = (value: string) => {
-    setSelectedTargetType(value);
+    const newData = { ...formData, targetType: value };
+    setFormData(newData);
   };
 
   const onSelectCustomTargetOption = (value: string) => {
-    setSelectedCustomTarget(value);
+    const newData = { ...formData, customTarget: value };
+    setFormData(newData);
   };
 
   const onSelectLabel = ({ name, value }: { name: string; value: boolean }) => {
-    setSelectedLabels((prevItems) => ({ ...prevItems, [name]: value }));
+    const newData = {
+      ...formData,
+      labelTargets: { ...formData.labelTargets, [name]: value },
+    };
+    setFormData(newData);
   };
 
   const onSubmitForm = (evt: React.FormEvent<HTMLFormElement>) => {
@@ -165,14 +171,14 @@ const FleetAppDetailsForm = ({
         </div>
       </fieldset>
       <TargetLabelSelector
-        selectedTargetType={selectedTargetType}
-        selectedCustomTarget={selectedCustomTarget}
-        selectedLabels={selectedLabels}
+        selectedTargetType={formData.targetType}
+        selectedCustomTarget={formData.customTarget}
+        selectedLabels={formData.labelTargets}
         customTargetOptions={CUSTOM_TARGET_OPTIONS}
         className={`${baseClass}__target`}
         dropdownHelpText={
-          selectedTargetType === "Custom" &&
-          generateHelpText(formData.installType, selectedCustomTarget)
+          formData.targetType === "Custom" &&
+          generateHelpText(formData.installType, formData.customTarget)
         }
         onSelectTargetType={onSelectTargetType}
         onSelectCustomTarget={onSelectCustomTargetOption}

--- a/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareFleetMaintained/FleetMaintainedAppDetailsPage/FleetAppDetailsForm/FleetAppDetailsForm.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareFleetMaintained/FleetMaintainedAppDetailsPage/FleetAppDetailsForm/FleetAppDetailsForm.tsx
@@ -114,6 +114,7 @@ const FleetAppDetailsForm = ({
   const onSelectTargetType = (value: string) => {
     const newData = { ...formData, targetType: value };
     setFormData(newData);
+    setFormValidation(generateFormValidation(newData));
   };
 
   const onSelectCustomTargetOption = (value: string) => {
@@ -127,6 +128,7 @@ const FleetAppDetailsForm = ({
       labelTargets: { ...formData.labelTargets, [name]: value },
     };
     setFormData(newData);
+    setFormValidation(generateFormValidation(newData));
   };
 
   const onSubmitForm = (evt: React.FormEvent<HTMLFormElement>) => {

--- a/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareFleetMaintained/FleetMaintainedAppDetailsPage/FleetAppDetailsForm/helpers.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareFleetMaintained/FleetMaintainedAppDetailsPage/FleetAppDetailsForm/helpers.tsx
@@ -12,6 +12,7 @@ import {
 
 type IMessageFunc = (formData: IFleetMaintainedAppFormData) => string;
 type IValidationMessage = string | IMessageFunc;
+type IFormValidationKey = keyof Omit<IFormValidation, "isValid">;
 
 interface IValidation {
   name: string;
@@ -19,7 +20,10 @@ interface IValidation {
   message?: IValidationMessage;
 }
 
-const FORM_VALIDATION_CONFIG: Record<string, { validations: IValidation[] }> = {
+const FORM_VALIDATION_CONFIG: Record<
+  IFormValidationKey,
+  { validations: IValidation[] }
+> = {
   preInstallQuery: {
     validations: [
       {
@@ -37,8 +41,15 @@ const FORM_VALIDATION_CONFIG: Record<string, { validations: IValidation[] }> = {
   customTarget: {
     validations: [
       {
-        name: "required",
-        isValid: (formData) => formData.customTarget !== undefined,
+        name: "requiredLabelTargets",
+        isValid: (formData) => {
+          if (formData.targetType === "All hosts") return true;
+          return (
+            Object.keys(formData.labelTargets).find(
+              (key) => formData.labelTargets[key]
+            ) !== undefined
+          );
+        },
       },
     ],
   },
@@ -63,7 +74,7 @@ export const generateFormValidation = (
   };
 
   Object.keys(FORM_VALIDATION_CONFIG).forEach((key) => {
-    const objKey = key as keyof typeof FORM_VALIDATION_CONFIG;
+    const objKey = key as IFormValidationKey;
     const failedValidation = FORM_VALIDATION_CONFIG[objKey].validations.find(
       (validation) => !validation.isValid(formData)
     );

--- a/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareFleetMaintained/FleetMaintainedAppDetailsPage/FleetAppDetailsForm/helpers.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareFleetMaintained/FleetMaintainedAppDetailsPage/FleetAppDetailsForm/helpers.tsx
@@ -44,6 +44,7 @@ const FORM_VALIDATION_CONFIG: Record<
         name: "requiredLabelTargets",
         isValid: (formData) => {
           if (formData.targetType === "All hosts") return true;
+          // there must be at least one label target selected
           return (
             Object.keys(formData.labelTargets).find(
               (key) => formData.labelTargets[key]

--- a/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareFleetMaintained/FleetMaintainedAppDetailsPage/FleetAppDetailsForm/helpers.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareFleetMaintained/FleetMaintainedAppDetailsPage/FleetAppDetailsForm/helpers.tsx
@@ -19,10 +19,7 @@ interface IValidation {
   message?: IValidationMessage;
 }
 
-const FORM_VALIDATION_CONFIG: Record<
-  "preInstallQuery",
-  { validations: IValidation[] }
-> = {
+const FORM_VALIDATION_CONFIG: Record<string, { validations: IValidation[] }> = {
   preInstallQuery: {
     validations: [
       {
@@ -34,6 +31,14 @@ const FORM_VALIDATION_CONFIG: Record<
           );
         },
         message: (formData) => validateQuery(formData.preInstallQuery).error,
+      },
+    ],
+  },
+  customTarget: {
+    validations: [
+      {
+        name: "required",
+        isValid: (formData) => formData.customTarget !== undefined,
       },
     ],
   },

--- a/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareFleetMaintained/FleetMaintainedAppDetailsPage/FleetAppDetailsForm/helpers.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareFleetMaintained/FleetMaintainedAppDetailsPage/FleetAppDetailsForm/helpers.tsx
@@ -1,3 +1,7 @@
+import React from "react";
+
+import { IDropdownOption } from "interfaces/dropdownOption";
+
 // @ts-ignore
 import validateQuery from "components/forms/validators/validate_query";
 
@@ -73,4 +77,46 @@ export const generateFormValidation = (
   });
 
   return formValidation;
+};
+
+export const CUSTOM_TARGET_OPTIONS: IDropdownOption[] = [
+  {
+    value: "labelsIncludeAny",
+    label: "Include any",
+    disabled: false,
+  },
+  {
+    value: "labelsExcludeAny",
+    label: "Exclude any",
+    disabled: false,
+  },
+];
+
+export const generateHelpText = (installType: string, customTarget: string) => {
+  if (customTarget === "labelsIncludeAny") {
+    return installType === "manual" ? (
+      <>
+        Software will only be available for install on hosts that{" "}
+        <b>have any</b> of these labels:
+      </>
+    ) : (
+      <>
+        Software will only be installed on hosts that <b>have any</b> of these
+        labels:
+      </>
+    );
+  }
+
+  // this is the case for labelsExcludeAny
+  return installType === "manual" ? (
+    <>
+      Software will only be available for install on hosts that{" "}
+      <b>don&apos;t have any</b> of these labels:
+    </>
+  ) : (
+    <>
+      Software will only be installed on hosts that <b>don&apos;t have any</b>{" "}
+      of these labels:{" "}
+    </>
+  );
 };

--- a/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareFleetMaintained/FleetMaintainedAppDetailsPage/FleetMaintainedAppDetailsPage.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareFleetMaintained/FleetMaintainedAppDetailsPage/FleetMaintainedAppDetailsPage.tsx
@@ -269,6 +269,7 @@ const FleetMaintainedAppDetailsPage = ({
               version={fleetApp.version}
             />
             <FleetAppDetailsForm
+              labels={labels || []}
               showSchemaButton={!isSidePanelOpen}
               defaultInstallScript={fleetApp.install_script}
               defaultPostInstallScript={fleetApp.post_install_script}

--- a/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareFleetMaintained/FleetMaintainedAppDetailsPage/FleetMaintainedAppDetailsPage.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareFleetMaintained/FleetMaintainedAppDetailsPage/FleetMaintainedAppDetailsPage.tsx
@@ -132,7 +132,6 @@ const FleetMaintainedAppDetailsPage = ({
   const {
     data: labels,
     isLoading: isLoadingLabels,
-    isFetching: isFetchingLabels,
     isError: isErrorLabels,
   } = useQuery<ILabelSummary[], Error>(
     ["custom_labels"],
@@ -144,8 +143,6 @@ const FleetMaintainedAppDetailsPage = ({
       staleTime: 10000,
     }
   );
-
-  console.log(labels);
 
   const onOsqueryTableSelect = (tableName: string) => {
     setSelectedOsqueryTable(tableName);

--- a/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareFleetMaintained/FleetMaintainedAppDetailsPage/FleetMaintainedAppDetailsPage.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareFleetMaintained/FleetMaintainedAppDetailsPage/FleetMaintainedAppDetailsPage.tsx
@@ -247,7 +247,7 @@ const FleetMaintainedAppDetailsPage = ({
     }
 
     if (isErrorFleetApp || isErrorLabels) {
-      return <DataError />;
+      return <DataError className={`${baseClass}__data-error`} />;
     }
 
     if (fleetApp) {

--- a/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareFleetMaintained/FleetMaintainedAppDetailsPage/_styles.scss
+++ b/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareFleetMaintained/FleetMaintainedAppDetailsPage/_styles.scss
@@ -1,4 +1,8 @@
 .fleet-maintained-app-details-page {
+  &__data-error {
+    margin-top: $pad-xxlarge;
+  }
+
   &__back-to-add-software {
     margin-bottom: $pad-medium;
   }

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwarePackageCard/SoftwarePackageCard.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwarePackageCard/SoftwarePackageCard.tsx
@@ -399,7 +399,6 @@ const SoftwarePackageCard = ({
           teamId={teamId}
           software={softwarePackage}
           onExit={() => setShowEditSoftwareModal(false)}
-          router={router}
           refetchSoftwareTitle={refetchSoftwareTitle}
         />
       )}

--- a/frontend/pages/SoftwarePage/components/PackageForm/PackageForm.tsx
+++ b/frontend/pages/SoftwarePage/components/PackageForm/PackageForm.tsx
@@ -36,6 +36,7 @@ export interface IFormValidation {
   postInstallScript?: { isValid: boolean; message?: string };
   uninstallScript?: { isValid: boolean; message?: string };
   selfService?: { isValid: boolean };
+  customTarget?: { isValid: boolean };
 }
 
 interface IPackageFormProps {

--- a/frontend/pages/SoftwarePage/components/PackageForm/PackageForm.tsx
+++ b/frontend/pages/SoftwarePage/components/PackageForm/PackageForm.tsx
@@ -6,15 +6,17 @@ import { NotificationContext } from "context/notification";
 import { getFileDetails } from "utilities/file/fileUtils";
 import getDefaultInstallScript from "utilities/software_install_scripts";
 import getDefaultUninstallScript from "utilities/software_uninstall_scripts";
+import { ILabelSummary } from "interfaces/label";
 
 import Button from "components/buttons/Button";
 import Checkbox from "components/forms/fields/Checkbox";
 import FileUploader from "components/FileUploader";
 import TooltipWrapper from "components/TooltipWrapper";
+import TargetLabelSelector from "components/TargetLabelSelector";
 
 import PackageAdvancedOptions from "../PackageAdvancedOptions";
 
-import { generateFormValidation } from "./helpers";
+import { CUSTOM_TARGET_OPTIONS, generateFormValidation } from "./helpers";
 
 export const baseClass = "package-form";
 
@@ -37,6 +39,7 @@ export interface IFormValidation {
 }
 
 interface IPackageFormProps {
+  labels: ILabelSummary[];
   showSchemaButton?: boolean;
   onCancel: () => void;
   onSubmit: (formData: IPackageFormData) => void;
@@ -54,6 +57,7 @@ interface IPackageFormProps {
 const ACCEPTED_EXTENSIONS = ".pkg,.msi,.exe,.deb,.rpm";
 
 const PackageForm = ({
+  labels,
   showSchemaButton = false,
   onClickShowSchema,
   onCancel,
@@ -82,6 +86,13 @@ const PackageForm = ({
     isValid: false,
     software: { isValid: false },
   });
+  const [selectedTargetType, setSelectedTargetType] = useState("All hosts");
+  const [selectedLabels, setSelectedLabels] = useState<Record<string, boolean>>(
+    {}
+  );
+  const [selectedCustomTarget, setSelectedCustomTarget] = useState(
+    "labelsIncludeAny"
+  );
 
   const onFileSelect = (files: FileList | null) => {
     if (files && files.length > 0) {
@@ -156,6 +167,18 @@ const PackageForm = ({
     setFormValidation(generateFormValidation(newData));
   };
 
+  const onSelectTargetType = (value: string) => {
+    setSelectedTargetType(value);
+  };
+
+  const onSelectCustomTargetOption = (value: string) => {
+    setSelectedCustomTarget(value);
+  };
+
+  const onSelectLabel = ({ name, value }: { name: string; value: boolean }) => {
+    setSelectedLabels((prevItems) => ({ ...prevItems, [name]: value }));
+  };
+
   const isSubmitDisabled = !formValidation.isValid;
 
   const classNames = classnames(baseClass, className);
@@ -175,6 +198,17 @@ const PackageForm = ({
           fileDetails={
             formData.software ? getFileDetails(formData.software) : undefined
           }
+        />
+        <TargetLabelSelector
+          selectedTargetType={selectedTargetType}
+          selectedCustomTarget={selectedCustomTarget}
+          selectedLabels={selectedLabels}
+          customTargetOptions={CUSTOM_TARGET_OPTIONS}
+          className={`${baseClass}__target`}
+          onSelectTargetType={onSelectTargetType}
+          onSelectCustomTarget={onSelectCustomTargetOption}
+          onSelectLabel={onSelectLabel}
+          labels={labels || []}
         />
         <Checkbox
           value={formData.selfService}

--- a/frontend/pages/SoftwarePage/components/PackageForm/PackageForm.tsx
+++ b/frontend/pages/SoftwarePage/components/PackageForm/PackageForm.tsx
@@ -36,9 +36,6 @@ export interface IFormValidation {
   isValid: boolean;
   software: { isValid: boolean };
   preInstallQuery?: { isValid: boolean; message?: string };
-  postInstallScript?: { isValid: boolean; message?: string };
-  uninstallScript?: { isValid: boolean; message?: string };
-  selfService?: { isValid: boolean };
   customTarget?: { isValid: boolean };
 }
 
@@ -237,7 +234,6 @@ const PackageForm = ({
           selectedPackage={formData.software}
           errors={{
             preInstallQuery: formValidation.preInstallQuery?.message,
-            postInstallScript: formValidation.postInstallScript?.message,
           }}
           preInstallQuery={formData.preInstallQuery}
           installScript={formData.installScript}

--- a/frontend/pages/SoftwarePage/components/PackageForm/PackageForm.tsx
+++ b/frontend/pages/SoftwarePage/components/PackageForm/PackageForm.tsx
@@ -27,6 +27,9 @@ export interface IPackageFormData {
   postInstallScript?: string;
   uninstallScript?: string;
   selfService: boolean;
+  targetType: string;
+  customTarget: string;
+  labelTargets: Record<string, boolean>;
 }
 
 export interface IFormValidation {
@@ -74,26 +77,21 @@ const PackageForm = ({
 }: IPackageFormProps) => {
   const { renderFlash } = useContext(NotificationContext);
 
-  const initialFormData = {
+  const [formData, setFormData] = useState<IPackageFormData>({
     software: defaultSoftware || null,
     installScript: defaultInstallScript || "",
     preInstallQuery: defaultPreInstallQuery || "",
     postInstallScript: defaultPostInstallScript || "",
     uninstallScript: defaultUninstallScript || "",
     selfService: defaultSelfService || false,
-  };
-  const [formData, setFormData] = useState<IPackageFormData>(initialFormData);
+    targetType: "All hosts",
+    customTarget: "labelsIncludeAny",
+    labelTargets: {},
+  });
   const [formValidation, setFormValidation] = useState<IFormValidation>({
     isValid: false,
     software: { isValid: false },
   });
-  const [selectedTargetType, setSelectedTargetType] = useState("All hosts");
-  const [selectedLabels, setSelectedLabels] = useState<Record<string, boolean>>(
-    {}
-  );
-  const [selectedCustomTarget, setSelectedCustomTarget] = useState(
-    "labelsIncludeAny"
-  );
 
   const onFileSelect = (files: FileList | null) => {
     if (files && files.length > 0) {
@@ -169,15 +167,23 @@ const PackageForm = ({
   };
 
   const onSelectTargetType = (value: string) => {
-    setSelectedTargetType(value);
+    const newData = { ...formData, targetType: value };
+    setFormData(newData);
+    setFormValidation(generateFormValidation(newData));
   };
 
-  const onSelectCustomTargetOption = (value: string) => {
-    setSelectedCustomTarget(value);
+  const onSelectCustomTarget = (value: string) => {
+    const newData = { ...formData, customTarget: value };
+    setFormData(newData);
   };
 
   const onSelectLabel = ({ name, value }: { name: string; value: boolean }) => {
-    setSelectedLabels((prevItems) => ({ ...prevItems, [name]: value }));
+    const newData = {
+      ...formData,
+      labelTargets: { ...formData.labelTargets, [name]: value },
+    };
+    setFormData(newData);
+    setFormValidation(generateFormValidation(newData));
   };
 
   const isSubmitDisabled = !formValidation.isValid;
@@ -201,13 +207,13 @@ const PackageForm = ({
           }
         />
         <TargetLabelSelector
-          selectedTargetType={selectedTargetType}
-          selectedCustomTarget={selectedCustomTarget}
-          selectedLabels={selectedLabels}
+          selectedTargetType={formData.targetType}
+          selectedCustomTarget={formData.customTarget}
+          selectedLabels={formData.labelTargets}
           customTargetOptions={CUSTOM_TARGET_OPTIONS}
           className={`${baseClass}__target`}
           onSelectTargetType={onSelectTargetType}
-          onSelectCustomTarget={onSelectCustomTargetOption}
+          onSelectCustomTarget={onSelectCustomTarget}
           onSelectLabel={onSelectLabel}
           labels={labels || []}
         />

--- a/frontend/pages/SoftwarePage/components/PackageForm/helpers.ts
+++ b/frontend/pages/SoftwarePage/components/PackageForm/helpers.ts
@@ -1,3 +1,5 @@
+import { IDropdownOption } from "interfaces/dropdownOption";
+
 // @ts-ignore
 import validateQuery from "components/forms/validators/validate_query";
 
@@ -97,3 +99,16 @@ export const generateFormValidation = (formData: IPackageFormData) => {
 };
 
 export default generateFormValidation;
+
+export const CUSTOM_TARGET_OPTIONS: IDropdownOption[] = [
+  {
+    value: "labelsIncludeAny",
+    label: "Include any",
+    disabled: false,
+  },
+  {
+    value: "labelsExcludeAny",
+    label: "Exclude any",
+    disabled: false,
+  },
+];

--- a/frontend/pages/SoftwarePage/components/PackageForm/helpers.ts
+++ b/frontend/pages/SoftwarePage/components/PackageForm/helpers.ts
@@ -20,7 +20,7 @@ interface IValidation {
   message?: IValidationMessage;
 }
 
-/** configuration defines validations for each filed in the form. It defines rules
+/** configuration defines validations for each field in the form. It defines rules
  *  to determine if a field is valid, and rules for generating an error message.
  */
 const FORM_VALIDATION_CONFIG: Record<
@@ -46,6 +46,22 @@ const FORM_VALIDATION_CONFIG: Record<
           );
         },
         message: (formData) => validateQuery(formData.preInstallQuery).error,
+      },
+    ],
+  },
+  customTarget: {
+    validations: [
+      {
+        name: "requiredLabelTargets",
+        isValid: (formData) => {
+          if (formData.targetType === "All hosts") return true;
+          // there must be at least one label target selected
+          return (
+            Object.keys(formData.labelTargets).find(
+              (key) => formData.labelTargets[key]
+            ) !== undefined
+          );
+        },
       },
     ],
   },

--- a/frontend/pages/SoftwarePage/components/PackageForm/helpers.ts
+++ b/frontend/pages/SoftwarePage/components/PackageForm/helpers.ts
@@ -12,6 +12,7 @@ type IPackageFormValidatorKey = Exclude<
 
 type IMessageFunc = (formData: IPackageFormData) => string;
 type IValidationMessage = string | IMessageFunc;
+type IFormValidationKey = keyof Omit<IFormValidation, "isValid">;
 
 interface IValidation {
   name: string;
@@ -23,7 +24,7 @@ interface IValidation {
  *  to determine if a field is valid, and rules for generating an error message.
  */
 const FORM_VALIDATION_CONFIG: Record<
-  IPackageFormValidatorKey,
+  IFormValidationKey,
   { validations: IValidation[] }
 > = {
   software: {
@@ -47,14 +48,6 @@ const FORM_VALIDATION_CONFIG: Record<
         message: (formData) => validateQuery(formData.preInstallQuery).error,
       },
     ],
-  },
-  postInstallScript: {
-    // no validations related to postInstallScript
-    validations: [],
-  },
-  selfService: {
-    // no validations related to self service
-    validations: [],
   },
 };
 

--- a/frontend/pages/hosts/ManageHostsPage/components/DeleteLabelModal/DeleteLabelModal.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/components/DeleteLabelModal/DeleteLabelModal.tsx
@@ -24,7 +24,14 @@ const DeleteLabelModal = ({
       className={baseClass}
     >
       <>
-        <p>Are you sure you wish to delete this label?</p>
+        <p>
+          If a configuration profile uses this label as a custom target, the
+          profile will break: it won&apos;t be applied to new hosts.
+        </p>
+        <p>
+          To apply the profile to new hosts, you&apos;ll have to delete it and
+          upload a new profile.
+        </p>
         <div className="modal-cta-wrap">
           <Button
             onClick={onSubmit}

--- a/frontend/services/entities/software.ts
+++ b/frontend/services/entities/software.ts
@@ -17,6 +17,7 @@ import {
 } from "utilities/url";
 import { IPackageFormData } from "pages/SoftwarePage/components/PackageForm/PackageForm";
 import { IAddFleetMaintainedData } from "pages/SoftwarePage/SoftwareAddPage/SoftwareFleetMaintained/FleetMaintainedAppDetailsPage/FleetMaintainedAppDetailsPage";
+import { listNamesFromSelectedLabels } from "components/TargetLabelSelector/TargetLabelSelector";
 
 export interface ISoftwareApiParams {
   page?: number;
@@ -138,6 +139,8 @@ interface IAddFleetMaintainedAppPostBody {
   post_install_script?: string;
   uninstall_script?: string;
   self_service?: boolean;
+  labels_include_any?: string[];
+  labels_exclude_any?: string[];
 }
 
 const ORDER_KEY = "name";
@@ -276,6 +279,15 @@ export default {
       formData.append("post_install_script", data.postInstallScript);
     teamId && formData.append("team_id", teamId.toString());
 
+    if (data.targetType === "Custom") {
+      const selectedLabels = listNamesFromSelectedLabels(data.labelTargets);
+      if (data.customTarget === "labelsIncludeAny") {
+        formData.append("labels_include_any", selectedLabels.join(","));
+      } else {
+        formData.append("labels_exclude_any", selectedLabels.join(","));
+      }
+    }
+
     return sendRequestWithProgress({
       method: "POST",
       path: SOFTWARE_PACKAGE_ADD,
@@ -379,6 +391,15 @@ export default {
       uninstall_script: formData.uninstallScript,
       self_service: formData.selfService,
     };
+
+    if (formData.targetType === "Custom") {
+      const selectedLabels = listNamesFromSelectedLabels(formData.labelTargets);
+      if (formData.customTarget === "labelsIncludeAny") {
+        body.labels_include_any = selectedLabels;
+      } else {
+        body.labels_exclude_any = selectedLabels;
+      }
+    }
 
     return sendRequest("POST", SOFTWARE_FLEET_MAINTAINED_APPS, body);
   },


### PR DESCRIPTION
relates to #24538, #24542, #24540, #24537

implements the UI for scoping software to fleet maintained apps and custom packages. This includes:

**adding custom target label selection to fleet maintained app form**

<img width="824" alt="image" src="https://github.com/user-attachments/assets/b0e18841-e5c5-406a-b83f-ce2b5a8f8472" />

**adding custom target label selection to custom package form**

<img width="821" alt="image" src="https://github.com/user-attachments/assets/06279121-69bd-4663-aebd-930cd7c02190" />

***adding custom target label selection on edit software modals**

<img width="796" alt="image" src="https://github.com/user-attachments/assets/c15a8236-1b02-4d17-9245-e24967190eaf" />

also includes various small copy changes.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
- [ ] Added/updated tests
- [x] Manual QA for all new/changed functionality