### PR TITLE
Fleet UI: Allow select target search for labels and teams

### DIFF
--- a/changes/22448-searchable-query-targets
+++ b/changes/22448-searchable-query-targets
@@ -1,0 +1,1 @@
+- Fleet UI: Add searchable query targets and cleaner UI I for uses with many teams or labels

--- a/frontend/components/LiveQuery/SelectTargets.tsx
+++ b/frontend/components/LiveQuery/SelectTargets.tsx
@@ -83,7 +83,7 @@ interface ITargetsQueryKey {
 
 const DEBOUNCE_DELAY = 500;
 const STALE_TIME = 60000;
-const SECTION_CHARACTER_LIMIT = 100;
+const SECTION_CHARACTER_LIMIT = 600;
 
 const isLabel = (entity: ISelectTargetsEntity) => "label_type" in entity;
 const isBuiltInLabel = (

--- a/frontend/components/LiveQuery/SelectTargets.tsx
+++ b/frontend/components/LiveQuery/SelectTargets.tsx
@@ -38,7 +38,6 @@ import Icon from "components/Icon";
 import SearchField from "components/forms/fields/SearchField";
 import RevealButton from "components/buttons/RevealButton";
 import { generateTableHeaders } from "./TargetsInput/TargetsInputHostsTableConfig";
-import { isEmpty } from "lodash";
 
 interface ITargetPillSelectorProps {
   entity: ISelectLabel | ISelectTeam;

--- a/frontend/components/LiveQuery/SelectTargets.tsx
+++ b/frontend/components/LiveQuery/SelectTargets.tsx
@@ -38,6 +38,7 @@ import Icon from "components/Icon";
 import SearchField from "components/forms/fields/SearchField";
 import RevealButton from "components/buttons/RevealButton";
 import { generateTableHeaders } from "./TargetsInput/TargetsInputHostsTableConfig";
+import { isEmpty } from "lodash";
 
 interface ITargetPillSelectorProps {
   entity: ISelectLabel | ISelectTeam;
@@ -408,12 +409,12 @@ const SelectTargets = ({
     entityList: ISelectLabel[] | ISelectTeam[]
   ): JSX.Element => {
     const isSearchEnabled = header === "Teams" || header === "Labels";
+    const searchTerm: string =
+      (header === "Teams" ? searchTextTeams : searchTextLabels) || "";
     const arrFixed = entityList as Array<typeof entityList[number]>;
     const filteredEntities = arrFixed.filter(
       (entity: ISelectLabel | ISelectTeam) => {
         if (isSearchEnabled) {
-          const searchTerm: string =
-            (header === "Teams" ? searchTextTeams : searchTextLabels) || "";
           return searchTerm
             ? entity.name.toLowerCase().includes(searchTerm.toLowerCase())
             : true;
@@ -441,19 +442,39 @@ const SelectTargets = ({
       ? filteredEntities
       : truncatedEntities;
 
+    const emptySearchString = `No matching ${
+      header === "Teams" ? "teams" : "labels"
+    }.`;
+
+    const renderEmptySearchString = () => {
+      if (entitiesToDisplay.length === 0 && searchTerm !== "") {
+        return (
+          <div className={`${baseClass}__empty-entity-search`}>
+            {emptySearchString}
+          </div>
+        );
+      }
+      return undefined;
+    };
+
     return (
       <>
         {header && <h3>{header}</h3>}
         {isSearchEnabled && (
-          <SearchField
-            placeholder={header === "Teams" ? "Search teams" : "Search labels"}
-            onChange={(searchString) => {
-              header === "Teams"
-                ? setSearchTextTeams(searchString || undefined)
-                : setSearchTextLabels(searchString || undefined);
-            }}
-            clearButton
-          />
+          <>
+            <SearchField
+              placeholder={
+                header === "Teams" ? "Search teams" : "Search labels"
+              }
+              onChange={(searchString) => {
+                header === "Teams"
+                  ? setSearchTextTeams(searchString || undefined)
+                  : setSearchTextLabels(searchString || undefined);
+              }}
+              clearButton
+            />
+            {renderEmptySearchString()}
+          </>
         )}
         <div className="selector-block">
           {entitiesToDisplay?.map((entity: ISelectLabel | ISelectTeam) => {

--- a/frontend/components/LiveQuery/SelectTargets.tsx
+++ b/frontend/components/LiveQuery/SelectTargets.tsx
@@ -175,12 +175,8 @@ const SelectTargets = ({
 
   const [labels, setLabels] = useState<ILabelsByType | null>(null);
   const [searchTextHosts, setSearchTextHosts] = useState("");
-  const [searchTextTeams, setSearchTextTeams] = useState<string | undefined>(
-    ""
-  );
-  const [searchTextLabels, setSearchTextLabels] = useState<string | undefined>(
-    ""
-  );
+  const [searchTextTeams, setSearchTextTeams] = useState("");
+  const [searchTextLabels, setSearchTextLabels] = useState("");
   const [isTeamListExpanded, setIsTeamListExpanded] = useState(false);
   const [isLabelsListExpanded, setIsLabelsListExpanded] = useState(false);
   const [debouncedSearchText, setDebouncedSearchText] = useState("");

--- a/frontend/components/LiveQuery/TargetsInput/TargetsInput.tsx
+++ b/frontend/components/LiveQuery/TargetsInput/TargetsInput.tsx
@@ -108,7 +108,7 @@ const TargetsInput = ({
               emptyComponent={() => (
                 <div className="empty-search">
                   <div className="empty-search__inner">
-                    <h4>No hosts match the current search criteria.</h4>
+                    <h4>No matching hosts.</h4>
                     <p>
                       Expecting to see hosts? Try again in a few seconds as the
                       system catches up.

--- a/frontend/components/LiveQuery/TargetsInput/_styles.scss
+++ b/frontend/components/LiveQuery/TargetsInput/_styles.scss
@@ -47,6 +47,12 @@
       box-shadow: 0px 4px 10px rgba(52, 59, 96, 0.15);
       box-sizing: border-box;
 
+      &__inner {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+      }
+
       h4 {
         margin: 0;
         margin-bottom: 16px;

--- a/frontend/components/forms/fields/InputFieldWithIcon/InputFieldWithIcon.jsx
+++ b/frontend/components/forms/fields/InputFieldWithIcon/InputFieldWithIcon.jsx
@@ -148,7 +148,7 @@ class InputFieldWithIcon extends InputField {
               variant="icon"
               className={`${baseClass}__clear-button`}
             >
-              <Icon name="close-filled" />
+              <Icon name="close-filled" color="core-fleet-black" />
             </Button>
           )}
         </div>

--- a/frontend/components/forms/fields/InputFieldWithIcon/InputFieldWithIcon.jsx
+++ b/frontend/components/forms/fields/InputFieldWithIcon/InputFieldWithIcon.jsx
@@ -5,6 +5,7 @@ import classnames from "classnames";
 import Icon from "components/Icon/Icon";
 import FleetIcon from "components/icons/FleetIcon";
 import TooltipWrapper from "components/TooltipWrapper";
+import Button from "components/buttons/Button";
 import InputField from "../InputField";
 
 const baseClass = "input-icon-field";
@@ -20,6 +21,7 @@ class InputFieldWithIcon extends InputField {
     name: PropTypes.string,
     onChange: PropTypes.func,
     onClick: PropTypes.func,
+    clearButton: PropTypes.func,
     placeholder: PropTypes.string,
     tabIndex: PropTypes.number,
     type: PropTypes.string,
@@ -86,6 +88,8 @@ class InputFieldWithIcon extends InputField {
       inputOptions,
       ignore1Password,
       onClick,
+      onChange,
+      clearButton,
     } = this.props;
     const { onInputChange, renderHelpText } = this;
 
@@ -111,6 +115,10 @@ class InputFieldWithIcon extends InputField {
       { [`${baseClass}__icon--active`]: value }
     );
 
+    const handleClear = () => {
+      onChange("");
+    };
+
     return (
       <div className={wrapperClasses}>
         {this.props.label && this.renderHeading()}
@@ -134,6 +142,15 @@ class InputFieldWithIcon extends InputField {
           />
           {iconSvg && <Icon name={iconSvg} className={iconClasses} />}
           {iconName && <FleetIcon name={iconName} className={iconClasses} />}
+          {clearButton && !!value && (
+            <Button
+              onClick={() => handleClear()}
+              variant="icon"
+              className={`${baseClass}__clear-button`}
+            >
+              <Icon name="close-filled" />
+            </Button>
+          )}
         </div>
         {renderHelpText()}
       </div>

--- a/frontend/components/forms/fields/InputFieldWithIcon/InputFieldWithIcon.tests.tsx
+++ b/frontend/components/forms/fields/InputFieldWithIcon/InputFieldWithIcon.tests.tsx
@@ -1,0 +1,129 @@
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+// @ts-ignore
+import InputFieldWithIcon from "./InputFieldWithIcon";
+
+describe("InputFieldWithIcon Component", () => {
+  const mockOnChange = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test("renders with label and placeholder", () => {
+    render(
+      <InputFieldWithIcon
+        value=""
+        onChange={mockOnChange}
+        label="Test Input"
+        placeholder="Enter text"
+        name="test-input"
+      />
+    );
+
+    expect(screen.getByText(/test input/i)).toBeInTheDocument();
+    expect(screen.getByPlaceholderText(/enter text/i)).toBeInTheDocument();
+  });
+
+  test("calls onChange when input value changes", async () => {
+    render(
+      <InputFieldWithIcon
+        value=""
+        onChange={mockOnChange}
+        label="Test Input"
+        placeholder="Enter text"
+        name="test-input"
+      />
+    );
+
+    // Change the input value
+    await userEvent.type(
+      screen.getByPlaceholderText(/enter text/i),
+      "New Value"
+    );
+
+    expect(mockOnChange).toHaveBeenCalledTimes(9); // 'New Value' has 9 characters
+  });
+
+  test("renders help text when provided", () => {
+    render(
+      <InputFieldWithIcon
+        value=""
+        onChange={mockOnChange}
+        label="Test Input"
+        placeholder="Enter text"
+        name="test-input"
+        helpText="This is a help text."
+      />
+    );
+
+    expect(screen.getByText(/this is a help text/i)).toBeInTheDocument();
+  });
+
+  test("renders error message when provided", () => {
+    render(
+      <InputFieldWithIcon
+        value=""
+        onChange={mockOnChange}
+        label="Test Input"
+        placeholder="Enter text"
+        name="test-input"
+        error="This is an error message."
+      />
+    );
+
+    expect(screen.getByText(/this is an error message/i)).toBeInTheDocument();
+  });
+
+  test("renders clear button when clearButton is true and input has value", () => {
+    render(
+      <InputFieldWithIcon
+        value="Some Value"
+        onChange={mockOnChange}
+        label="Test Input"
+        placeholder="Enter text"
+        name="test-input"
+        clearButton
+      />
+    );
+
+    expect(screen.getByRole("button")).toBeInTheDocument();
+  });
+
+  test("clears input value when clear button is clicked", async () => {
+    render(
+      <InputFieldWithIcon
+        value="Some Value"
+        onChange={mockOnChange}
+        label="Test Input"
+        placeholder="Enter text"
+        name="test-input"
+        clearButton
+      />
+    );
+
+    // Click the clear button
+    await userEvent.click(screen.getByRole("button"));
+
+    expect(mockOnChange).toHaveBeenCalledTimes(1);
+    expect(mockOnChange).toHaveBeenCalledWith("");
+  });
+
+  test("renders tooltip when provided", async () => {
+    render(
+      <InputFieldWithIcon
+        value=""
+        onChange={mockOnChange}
+        label="Test Input"
+        placeholder="Enter text"
+        name="test-input"
+        tooltip="This is a tooltip."
+      />
+    );
+
+    await fireEvent.mouseEnter(screen.getByText(/test input/i));
+    const tooltip = screen.getByText("This is a tooltip.");
+    expect(tooltip).toBeInTheDocument();
+  });
+});

--- a/frontend/components/forms/fields/InputFieldWithIcon/_styles.scss
+++ b/frontend/components/forms/fields/InputFieldWithIcon/_styles.scss
@@ -150,4 +150,15 @@
   input[type="search"]::-webkit-search-results-decoration {
     display: none;
   }
+
+  &__clear-button {
+    position: absolute;
+    right: 12px;
+    top: 0;
+    height: 40px;
+    width: 16px;
+    flex-wrap: wrap;
+    align-content: center;
+    z-index: 1;
+  }
 }

--- a/frontend/components/forms/fields/SearchField/SearchField.tsx
+++ b/frontend/components/forms/fields/SearchField/SearchField.tsx
@@ -9,6 +9,7 @@ export interface ISearchFieldProps {
   defaultValue?: string;
   onChange: (value: string) => void;
   onClick?: (e: React.MouseEvent) => void;
+  clearButton?: boolean;
   icon?: IconNames;
 }
 
@@ -16,6 +17,7 @@ const SearchField = ({
   placeholder,
   defaultValue = "",
   onChange,
+  clearButton,
   onClick,
   icon = "search",
 }: ISearchFieldProps): JSX.Element => {
@@ -37,6 +39,7 @@ const SearchField = ({
       value={searchQueryInput}
       onChange={onInputChange}
       onClick={onClick}
+      clearButton={clearButton}
       iconPosition="start"
       iconSvg={icon}
     />

--- a/frontend/components/forms/fields/SelectTargetsDropdown/TargetDetails/TargetDetails.tsx
+++ b/frontend/components/forms/fields/SelectTargetsDropdown/TargetDetails/TargetDetails.tsx
@@ -4,9 +4,7 @@ import AceEditor from "react-ace";
 import classnames from "classnames";
 
 import { humanHostMemory } from "utilities/helpers";
-// @ts-ignore
 import FleetIcon from "components/icons/FleetIcon";
-// @ts-ignore
 import PlatformIcon from "components/icons/PlatformIcon";
 import { ISelectHost, ISelectLabel, ISelectTeam } from "interfaces/target";
 
@@ -25,27 +23,6 @@ const TargetDetails = ({
   className = "",
   handleBackToResults = noop,
 }: ITargetDetailsProps): JSX.Element => {
-  const onlineHosts = (
-    labelBaseClass: string,
-    count: number,
-    online: number
-  ) => {
-    const offline = count - online;
-    const percentCount = ((count - offline) / count) * 100;
-    const percentOnline = parseFloat(percentCount.toFixed(2));
-
-    if (online > 0) {
-      return (
-        <span className={`${labelBaseClass}__hosts-online`}>
-          {" "}
-          ({percentOnline}% ONLINE)
-        </span>
-      );
-    }
-
-    return false;
-  };
-
   const renderHost = (hostTarget: ISelectHost) => {
     const {
       display_text: displayText,
@@ -143,9 +120,9 @@ const TargetDetails = ({
       description,
       display_text: displayText,
       label_type: labelType,
-      // online,
       query,
     } = labelTarget;
+
     const labelBaseClass = "label-target";
     return (
       <div className={`${labelBaseClass} ${className}`}>
@@ -165,7 +142,6 @@ const TargetDetails = ({
           <span className={`${labelBaseClass}__hosts-count`}>
             <strong>{count}</strong>HOSTS
           </span>
-          {/* {onlineHosts(labelBaseClass, count, online)} */}
         </p>
 
         <p className={`${labelBaseClass}__description`}>

--- a/frontend/components/forms/fields/SelectTargetsDropdown/TargetDetails/TargetDetails.tsx
+++ b/frontend/components/forms/fields/SelectTargetsDropdown/TargetDetails/TargetDetails.tsx
@@ -147,7 +147,6 @@ const TargetDetails = ({
       query,
     } = labelTarget;
     const labelBaseClass = "label-target";
-    console.log("ERROR 1: labelTarget", labelTarget);
     return (
       <div className={`${labelBaseClass} ${className}`}>
         <button

--- a/frontend/components/forms/fields/SelectTargetsDropdown/TargetDetails/TargetDetails.tsx
+++ b/frontend/components/forms/fields/SelectTargetsDropdown/TargetDetails/TargetDetails.tsx
@@ -119,7 +119,6 @@ const TargetDetails = ({
       count,
       description,
       display_text: displayText,
-      label_type: labelType,
       query,
     } = labelTarget;
 

--- a/frontend/components/icons/PlatformIcon/PlatformIcon.tsx
+++ b/frontend/components/icons/PlatformIcon/PlatformIcon.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 import classnames from "classnames";
 
-// @ts-ignore
 import FleetIcon from "components/icons/FleetIcon";
 import platformIconClass from "utilities/platform_icon_class";
 

--- a/frontend/pages/policies/PolicyPage/_styles.scss
+++ b/frontend/pages/policies/PolicyPage/_styles.scss
@@ -57,6 +57,15 @@
       display: flex;
       align-items: center;
       flex-wrap: wrap;
+      margin-top: $pad-small;
+    }
+
+    .input-icon-field {
+      width: 600px;
+    }
+
+    .expand-button-wrap {
+      margin-top: -$pad-small;
     }
   }
   &__targets-button-wrap {

--- a/frontend/pages/policies/PolicyPage/_styles.scss
+++ b/frontend/pages/policies/PolicyPage/_styles.scss
@@ -68,6 +68,15 @@
       margin-top: -$pad-small;
     }
   }
+
+  &__empty-entity-search {
+    color: #000;
+    text-align: center;
+
+    font-size: $x-small;
+    line-height: 21px; /* 150% */
+  }
+
   &__targets-button-wrap {
     margin-top: 30px;
     display: flex;

--- a/frontend/pages/policies/PolicyPage/_styles.scss
+++ b/frontend/pages/policies/PolicyPage/_styles.scss
@@ -70,9 +70,7 @@
   }
 
   &__empty-entity-search {
-    color: #000;
-    text-align: center;
-
+    margin-top: $pad-small;
     font-size: $x-small;
     line-height: 21px; /* 150% */
   }

--- a/frontend/pages/queries/live/LiveQueryPage/_styles.scss
+++ b/frontend/pages/queries/live/LiveQueryPage/_styles.scss
@@ -36,6 +36,15 @@
       margin-top: -$pad-small;
     }
   }
+
+  &__empty-entity-search {
+    color: #000;
+    text-align: center;
+
+    font-size: $x-small;
+    line-height: 21px; /* 150% */
+  }
+
   &__targets-button-wrap {
     margin-top: 30px;
     display: flex;

--- a/frontend/pages/queries/live/LiveQueryPage/_styles.scss
+++ b/frontend/pages/queries/live/LiveQueryPage/_styles.scss
@@ -25,6 +25,15 @@
       display: flex;
       align-items: center;
       flex-wrap: wrap;
+      margin-top: $pad-small;
+    }
+
+    .input-icon-field {
+      width: 600px;
+    }
+
+    .expand-button-wrap {
+      margin-top: -$pad-small;
     }
   }
   &__targets-button-wrap {

--- a/frontend/pages/queries/live/LiveQueryPage/_styles.scss
+++ b/frontend/pages/queries/live/LiveQueryPage/_styles.scss
@@ -38,9 +38,7 @@
   }
 
   &__empty-entity-search {
-    color: #000;
-    text-align: center;
-
+    margin-top: $pad-small;
     font-size: $x-small;
     line-height: 21px; /* 150% */
   }


### PR DESCRIPTION
## Issue
Cerra #22448 

## Description
- Allow users to search labels and teams when selecting entities for live query or live policy
- QA:
- [x] Show more and show less toggle button shows if there are more than 600 characters in the labels/team names
- [x] When a team/label is selected within the show more "hidden" section, that section will automatically be open when coming back from running a query
- [x] Search bar will hide the show more/less button if there isn't any more items to show
- [x] Search bar has a button to clear search

## TODO
Tests

## Screenshot/screen recording
Note: This screenrecording had a character limit of 100 set for demo purposes, changed it to 600
https://github.com/user-attachments/assets/31578d10-214a-4812-af89-33403946ff58



- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
- [x] Added/updated tests
- [x] Manual QA for all new/changed functionality

