### PR TITLE
Add helpful tooltip to install software setup experience

### DIFF
--- a/changes/24795-add-helpful-tooltip-setup-experience
+++ b/changes/24795-add-helpful-tooltip-setup-experience
@@ -1,0 +1,1 @@
+- add helpful tooltip for the install software setup experience page

--- a/frontend/pages/ManageControlsPage/SetupExperience/cards/InstallSoftware/components/AddInstallSoftware/AddInstallSoftware.tests.tsx
+++ b/frontend/pages/ManageControlsPage/SetupExperience/cards/InstallSoftware/components/AddInstallSoftware/AddInstallSoftware.tests.tsx
@@ -60,7 +60,10 @@ describe("AddInstallSoftware", () => {
     );
 
     expect(
-      screen.getByText(/2 software will be installed during setup/)
+      screen.getByText(
+        (_, element) =>
+          element?.textContent === "2 software will be installed during setup."
+      )
     ).toBeVisible();
     expect(
       screen.getByRole("button", { name: "Show selected software" })

--- a/frontend/pages/ManageControlsPage/SetupExperience/cards/InstallSoftware/components/AddInstallSoftware/AddInstallSoftware.tsx
+++ b/frontend/pages/ManageControlsPage/SetupExperience/cards/InstallSoftware/components/AddInstallSoftware/AddInstallSoftware.tsx
@@ -6,6 +6,7 @@ import Button from "components/buttons/Button";
 import CustomLink from "components/CustomLink";
 import { ISoftwareTitle } from "interfaces/software";
 import LinkWithContext from "components/LinkWithContext";
+import TooltipWrapper from "components/TooltipWrapper";
 
 const baseClass = "add-install-software";
 
@@ -45,9 +46,17 @@ const AddInstallSoftware = ({
         software.app_store_app?.install_during_setup
     ).length;
 
-    return installDuringSetupCount === 0
-      ? "No software added."
-      : `${installDuringSetupCount} software will be installed during setup.`;
+    return installDuringSetupCount === 0 ? (
+      "No software added."
+    ) : (
+      <>
+        {installDuringSetupCount} software will be{" "}
+        <TooltipWrapper position="top" tipContent="Software order will vary.">
+          installed during setup
+        </TooltipWrapper>
+        .
+      </>
+    );
   };
 
   const getButtonText = () => {


### PR DESCRIPTION
relates to #24795

Add a helpful tooltip to the install software section for the setup experience page

<img width="445" alt="image" src="https://github.com/user-attachments/assets/49b0d9d5-0126-4165-abfb-b5cf9a2f8321" />

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
- [x] Manual QA for all new/changed functionality
