### PR TITLE
Added optional team_id parameter to query report endpoint

### DIFF
--- a/changes/24006-host-query-report-team-id
+++ b/changes/24006-host-query-report-team-id
@@ -1,1 +1,1 @@
-* Added optional team_id parameter to queries report endpoint (/api/latest/fleet/queries/{query_id}/report) that filters report results by team. 
+* Fixed cases where showing results of an inherited query viewed inside a team would include results from hosts not on thta team by adding an optional team_id parameter to queries report endpoint (`GET /api/latest/fleet/queries/{query_id}/report`)

--- a/changes/24006-host-query-report-team-id
+++ b/changes/24006-host-query-report-team-id
@@ -1,0 +1,1 @@
+* Added optional team_id parameter to queries report endpoint (/api/latest/fleet/queries/{query_id}/report) that filters report results by team. 

--- a/frontend/pages/queries/details/QueryDetailsPage/QueryDetailsPage.tsx
+++ b/frontend/pages/queries/details/QueryDetailsPage/QueryDetailsPage.tsx
@@ -191,6 +191,7 @@ const QueryDetailsPage = ({
     [],
     () =>
       queryReportAPI.load({
+        teamId: currentTeamId,
         sortBy: serverSortBy,
         id: queryId,
       }),

--- a/frontend/services/entities/query_report.ts
+++ b/frontend/services/entities/query_report.ts
@@ -12,6 +12,13 @@ export interface ISortOption {
 export interface ILoadQueryReportOptions {
   id: number;
   sortBy: ISortOption[];
+  teamId?: number;
+}
+
+interface ILoadQueryReportQueryParams {
+  order_key: string | undefined;
+  order_direction: string | undefined;
+  team_id?: number;
 }
 
 const getSortParams = (sortOptions?: ISortOption[]) => {
@@ -27,13 +34,16 @@ const getSortParams = (sortOptions?: ISortOption[]) => {
 };
 
 export default {
-  load: ({ id, sortBy }: ILoadQueryReportOptions) => {
+  load: ({ id, sortBy, teamId }: ILoadQueryReportOptions) => {
     const sortParams = getSortParams(sortBy);
 
-    const queryParams = {
+    const queryParams: ILoadQueryReportQueryParams = {
       order_key: sortParams.order_key,
       order_direction: sortParams.order_direction,
     };
+    if (teamId && teamId > 0) {
+      queryParams.team_id = teamId;
+    }
 
     const queryString = buildQueryStringFromParams(queryParams);
 

--- a/server/fleet/service.go
+++ b/server/fleet/service.go
@@ -280,7 +280,7 @@ type Service interface {
 	GetQuery(ctx context.Context, id uint) (*Query, error)
 	// GetQueryReportResults returns all the stored results of a query for hosts the requestor has access to.
 	// Returns a boolean indicating whether the report is clipped.
-	GetQueryReportResults(ctx context.Context, id uint) ([]HostQueryResultRow, bool, error)
+	GetQueryReportResults(ctx context.Context, id uint, teamID *uint) ([]HostQueryResultRow, bool, error)
 	// GetHostQueryReportResults returns all stored results of a query for a specific host
 	GetHostQueryReportResults(ctx context.Context, hid uint, queryID uint) (rows []HostQueryReportResult, lastFetched *time.Time, err error)
 	// QueryReportIsClipped returns true if the number of query report rows exceeds the maximum

--- a/server/service/queries.go
+++ b/server/service/queries.go
@@ -151,7 +151,8 @@ func (svc *Service) ListQueries(ctx context.Context, opt fleet.ListOptions, team
 ////////////////////////////////////////////////////////////////////////////////
 
 type getQueryReportRequest struct {
-	ID uint `url:"id"`
+	ID     uint  `url:"id"`
+	TeamID *uint `query:"team_id,optional"`
 }
 
 type getQueryReportResponse struct {
@@ -165,7 +166,7 @@ func (r getQueryReportResponse) error() error { return r.Err }
 
 func getQueryReportEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (errorer, error) {
 	req := request.(*getQueryReportRequest)
-	queryReportResults, reportClipped, err := svc.GetQueryReportResults(ctx, req.ID)
+	queryReportResults, reportClipped, err := svc.GetQueryReportResults(ctx, req.ID, req.TeamID)
 	if err != nil {
 		return listQueriesResponse{Err: err}, nil
 	}
@@ -181,7 +182,7 @@ func getQueryReportEndpoint(ctx context.Context, request interface{}, svc fleet.
 	}, nil
 }
 
-func (svc *Service) GetQueryReportResults(ctx context.Context, id uint) ([]fleet.HostQueryResultRow, bool, error) {
+func (svc *Service) GetQueryReportResults(ctx context.Context, id uint, teamID *uint) ([]fleet.HostQueryResultRow, bool, error) {
 	// Load query first to get its teamID.
 	query, err := svc.ds.Query(ctx, id)
 	if err != nil {
@@ -200,7 +201,7 @@ func (svc *Service) GetQueryReportResults(ctx context.Context, id uint) ([]fleet
 	if !ok {
 		return nil, false, fleet.ErrNoContext
 	}
-	filter := fleet.TeamFilter{User: vc.User, IncludeObserver: true}
+	filter := fleet.TeamFilter{User: vc.User, IncludeObserver: true, TeamID: teamID}
 
 	queryReportResultRows, err := svc.ds.QueryResultRows(ctx, id, filter)
 	if err != nil {

--- a/server/service/queries_test.go
+++ b/server/service/queries_test.go
@@ -725,7 +725,7 @@ func TestQueryReportReturnsNilIfDiscardDataIsTrue(t *testing.T) {
 		}, nil
 	}
 
-	results, reportClipped, err := svc.GetQueryReportResults(viewerCtx, 1)
+	results, reportClipped, err := svc.GetQueryReportResults(viewerCtx, 1, nil)
 	require.NoError(t, err)
 	require.Nil(t, results)
 	require.False(t, reportClipped)


### PR DESCRIPTION
If the `team_id` parameter is included the query report will filter the hosts by the team id specified. The `team_id` parameter is included by default from the front end queries pages.

https://github.com/fleetdm/fleet/issues/24006

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/Committing-Changes.md#changes-files) for more information.
- [X] Added/updated tests
- [X] Manual QA for all new/changed functionality