### PR TITLE
fix: remove cron stats data to stop jobs

### DIFF
--- a/.github/workflows/test-go.yaml
+++ b/.github/workflows/test-go.yaml
@@ -22,8 +22,7 @@ on:
       - 'server/authz/policy.rego'
       - 'docker-compose.yml'
   workflow_dispatch: # Manual
-  schedule:
-    - cron: '0 4 * * *'
+
 
 # This allows a subsequently queued workflow run to interrupt previous runs
 concurrency:
@@ -89,7 +88,6 @@ jobs:
         make generate-go
 
     - name: Set Go race setting on schedule
-      if: github.event.schedule == '0 4 * * *'
       run: |
         echo "RACE_ENABLED=true" >> $GITHUB_ENV
         echo "GO_TEST_TIMEOUT=1h" >> $GITHUB_ENV

--- a/server/service/integration_mdm_test.go
+++ b/server/service/integration_mdm_test.go
@@ -640,6 +640,11 @@ func (s *integrationMDMTestSuite) TearDownTest() {
 		return err
 	})
 
+	mysql.ExecAdhocSQL(t, s.ds, func(q sqlx.ExtContext) error {
+		_, err := q.ExecContext(ctx, "DELETE FROM cron_stats")
+		return err
+	})
+
 	// clear any host dep assignments
 	mysql.ExecAdhocSQL(t, s.ds, func(q sqlx.ExtContext) error {
 		_, err := q.ExecContext(ctx, "DELETE FROM host_dep_assignments")


### PR DESCRIPTION
> No issue, trying to fix [CI fail](https://github.com/fleetdm/fleet/actions/runs/12366100089/job/34512213110)

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [ ] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/Committing-Changes.md#changes-files) for more information.
- [ ] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [ ] Added support on fleet's osquery simulator `cmd/osquery-perf` for new osquery data ingestion features.
- [ ] Added/updated tests
- [ ] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes
- [ ] If database migrations are included, checked table schema to confirm autoupdate
- For database migrations:
  - [ ] Checked schema for all modified table for columns that will auto-update timestamps during migration.
  - [ ] Confirmed that updating the timestamps is acceptable, and will not cause unwanted side effects.
  - [ ] Ensured the correct collation is explicitly set for character columns (`COLLATE utf8mb4_unicode_ci`).
- [ ] Manual QA for all new/changed functionality
- For Orbit and Fleet Desktop changes:
   - [ ] Orbit runs on macOS, Linux and Windows. Check if the orbit feature/bugfix should only apply to one platform (`runtime.GOOS`).
   - [ ] Manual QA must be performed in the three main OSs, macOS, Windows and Linux.
   - [ ] Auto-update manual QA, from released version of component to new version (see [tools/tuf/test](../tools/tuf/test/README.md)).
