### PR TITLE
Updated minimum OS version for iOS and iPadOS

### DIFF
--- a/it-and-security/teams/company-owned-ipads.yml
+++ b/it-and-security/teams/company-owned-ipads.yml
@@ -12,7 +12,7 @@ team_settings:
 agent_options:
 controls:
   ipados_updates:
-    deadline: "2024-01-06"
+    deadline: "2025-01-06"
     minimum_version: "18.2"
   macos_settings:
     custom_settings:

--- a/it-and-security/teams/company-owned-ipads.yml
+++ b/it-and-security/teams/company-owned-ipads.yml
@@ -12,8 +12,8 @@ team_settings:
 agent_options:
 controls:
   ipados_updates:
-    deadline: "2024-08-23"
-    minimum_version: "17.6"
+    deadline: "2024-01-06"
+    minimum_version: "18.2"
   macos_settings:
     custom_settings:
   scripts:

--- a/it-and-security/teams/company-owned-iphones.yml
+++ b/it-and-security/teams/company-owned-iphones.yml
@@ -12,7 +12,7 @@ team_settings:
 agent_options:
 controls:
   ios_updates:
-    deadline: "2024-01-06"
+    deadline: "2025-01-06"
     minimum_version: "18.2"
   macos_settings:
     custom_settings:

--- a/it-and-security/teams/company-owned-iphones.yml
+++ b/it-and-security/teams/company-owned-iphones.yml
@@ -12,8 +12,8 @@ team_settings:
 agent_options:
 controls:
   ios_updates:
-    deadline: "2024-08-23"
-    minimum_version: "17.6"
+    deadline: "2024-01-06"
+    minimum_version: "18.2"
   macos_settings:
     custom_settings:
       - path: ../lib/ios/configuration-profiles/restrictions.mobileconfig


### PR DESCRIPTION
Updated minimum OS version for iOS and iPadOS in their respective teams to 18.2 and a deadline of 2025-01-06.