### PR TITLE
Added DDM profile for iOS and iPadOS and copied macOS DDM profile to Workstations team

### DIFF
--- a/it-and-security/lib/ios/declaration-profiles/software-update-settings.json
+++ b/it-and-security/lib/ios/declaration-profiles/software-update-settings.json
@@ -1,0 +1,15 @@
+{
+    "Type": "com.apple.configuration.softwareupdate.settings",
+    "Identifier": "com.fleetdm.config.softwareupdate.settings",
+    "Payload": {
+        "AutomaticActions": {
+            "Download": "AlwaysOn",
+            "InstallOSUpdates": "Allowed",
+            "InstallSecurityUpdate": "AlwaysOn"
+        },
+        "Notifications": true,
+        "RapidSecurityResponse": {
+            "Enabled": true
+        }
+    }
+}

--- a/it-and-security/lib/ipados/declaration-profiles/software-update-settings.json
+++ b/it-and-security/lib/ipados/declaration-profiles/software-update-settings.json
@@ -1,0 +1,15 @@
+{
+    "Type": "com.apple.configuration.softwareupdate.settings",
+    "Identifier": "com.fleetdm.config.softwareupdate.settings",
+    "Payload": {
+        "AutomaticActions": {
+            "Download": "AlwaysOn",
+            "InstallOSUpdates": "Allowed",
+            "InstallSecurityUpdate": "AlwaysOn"
+        },
+        "Notifications": true,
+        "RapidSecurityResponse": {
+            "Enabled": true
+        }
+    }
+}

--- a/it-and-security/teams/company-owned-ipads.yml
+++ b/it-and-security/teams/company-owned-ipads.yml
@@ -16,6 +16,7 @@ controls:
     minimum_version: "17.6"
   macos_settings:
     custom_settings:
+      - path: ../lib/ipados/declaration-profiles/software-update-settings.json
   scripts:
 policies:
 queries:

--- a/it-and-security/teams/company-owned-iphones.yml
+++ b/it-and-security/teams/company-owned-iphones.yml
@@ -20,6 +20,7 @@ controls:
       - path: ../lib/ios/configuration-profiles/lock-screen-message.mobileconfig
       - path: ../lib/ios/configuration-profiles/content-filtering.mobileconfig
       - path: ../lib/ios/declaration-profiles/passcode-settings-ddm.json
+      - path: ../lib/ios/declaration-profiles/software-update-settings.json
   scripts:
 policies:
 queries:

--- a/it-and-security/teams/workstations.yml
+++ b/it-and-security/teams/workstations.yml
@@ -56,6 +56,7 @@ controls:
       - path: ../lib/macos/configuration-profiles/prevent-autologon.mobileconfig
       - path: ../lib/macos/configuration-profiles/secure-terminal-keyboard.mobileconfig
       - path: ../lib/macos/declaration-profiles/passcode-settings.json
+      - path: ../lib/macos/declaration-profiles/software-update-settings.json
   macos_setup:
     bootstrap_package: ""
     enable_end_user_authentication: true


### PR DESCRIPTION
- Added DDM profile for iOS and iPadOS: fleetdm/confidential#9127
- Verified that the macOS Software Update Settings DDM profile in Workstations (canary) group that was deployed last week is working as expected so this has been copied to the Workstations team.