### PR TITLE
Fleet UI: Clean up table text wrapping

### DIFF
--- a/changes/8903c-table-text-wrapping
+++ b/changes/8903c-table-text-wrapping
@@ -1,0 +1,1 @@
+- Fleet UI: Clean up some table text wrapping

--- a/frontend/pages/ManageControlsPage/OSSettings/cards/DiskEncryption/components/DiskEncryptionTable/_styles.scss
+++ b/frontend/pages/ManageControlsPage/OSSettings/cards/DiskEncryption/components/DiskEncryptionTable/_styles.scss
@@ -13,10 +13,10 @@
     width: auto;
     max-width: 120px;
   }
-
 }
 
-@media (max-width: 1120px) {
+@media (max-width: 1250px) {
+  // Prevents unnecessary status new line wrap
   .view-hosts-link {
     span {
       display: none;
@@ -32,6 +32,5 @@
     &__cell {
       width: min-content;
     }
-
   }
 }

--- a/frontend/pages/ManageControlsPage/OSUpdates/components/CurrentVersionSection/_styles.scss
+++ b/frontend/pages/ManageControlsPage/OSUpdates/components/CurrentVersionSection/_styles.scss
@@ -1,5 +1,4 @@
 .os-updates-current-version-section {
-
   &__title {
     display: flex;
     align-items: center;
@@ -18,5 +17,21 @@
 
   &__error {
     padding: $pad-xxlarge;
+  }
+
+  .linkToFilteredHosts__header {
+    width: auto;
+    max-width: 120px;
+  }
+
+  td {
+    width: 100%;
+    max-width: $col-lg;
+  }
+
+  @media (max-width: $break-md) {
+    td {
+      max-width: $col-md !important;
+    }
   }
 }

--- a/frontend/pages/ManageControlsPage/OSUpdates/components/OSTypeCell/OSTypeCell.tsx
+++ b/frontend/pages/ManageControlsPage/OSUpdates/components/OSTypeCell/OSTypeCell.tsx
@@ -16,7 +16,12 @@ const OSTypeCell = ({ platform, versionName }: IOSTypeCellProps) => {
   return (
     <div className={baseClass}>
       <Icon name={platform} />
-      <TooltipTruncatedText value={versionName} />
+      <div className={`${baseClass}__tooltip-wrapper`}>
+        <TooltipTruncatedText
+          value={versionName}
+          className={`${baseClass}__inner-text`}
+        />
+      </div>
     </div>
   );
 };

--- a/frontend/pages/ManageControlsPage/OSUpdates/components/OSTypeCell/OSTypeCell.tsx
+++ b/frontend/pages/ManageControlsPage/OSUpdates/components/OSTypeCell/OSTypeCell.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 
 import Icon from "components/Icon";
+import TooltipTruncatedText from "components/TooltipTruncatedText";
 
 import { OSUpdatesSupportedPlatform } from "../../OSUpdates";
 
@@ -15,7 +16,7 @@ const OSTypeCell = ({ platform, versionName }: IOSTypeCellProps) => {
   return (
     <div className={baseClass}>
       <Icon name={platform} />
-      <span>{versionName}</span>
+      <TooltipTruncatedText value={versionName} />
     </div>
   );
 };

--- a/frontend/pages/ManageControlsPage/OSUpdates/components/OSTypeCell/_styles.scss
+++ b/frontend/pages/ManageControlsPage/OSUpdates/components/OSTypeCell/_styles.scss
@@ -1,5 +1,16 @@
+// Allows tooltip truncation on initial render
 .os-type-cell {
   display: flex;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
   align-items: center;
   gap: $pad-small;
+
+  &__tooltip-wrapper {
+    display: flex;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
 }


### PR DESCRIPTION
## Issue
Cerra confidential 8903

## Description
- Clean up table text wrapping as much as possible
- TooltipTruncatedText has limitations with responsiveness, but on first render it looks and feels great no matter the screen width

## Screenshots of fixes
https://github.com/user-attachments/assets/8e2a6808-f429-4a43-8155-a233c693285c

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
- [x] Manual QA for all new/changed functionality

