### PR TITLE
UI - Display the correct percentage of hosts online, 0, when there are no hosts online.

### DIFF
--- a/changes/23800-host-online-pctage
+++ b/changes/23800-host-online-pctage
@@ -1,0 +1,1 @@
+* Display the correct percentage of hosts online, 0, when there are no hosts online.

--- a/frontend/components/LiveQuery/SelectTargets.tsx
+++ b/frontend/components/LiveQuery/SelectTargets.tsx
@@ -386,7 +386,7 @@ const SelectTargets = ({
 
     const { targets_count: total, targets_online: online } = counts;
     const onlinePercentage = () => {
-      if (total === 0) {
+      if (total === 0 || online === 0) {
         return 0;
       }
       // If at least 1 host is online, displays <1% instead of 0%


### PR DESCRIPTION
## #23800 

<img width="535" alt="Screenshot 2024-12-17 at 6 13 37 PM" src="https://github.com/user-attachments/assets/5600a288-9b97-4b69-a561-43244c936de5" />

- [x] Changes file added for user-visible changes in `changes/`
- [x] Manual QA for all new/changed functionality