### PR TITLE
Pin Python version in GitHub Actions for osquery version updater, use Python HTTP client directly to avoid needing to figure out how to pin requests lib

### DIFF
--- a/.github/scripts/update_osquery_versions.py
+++ b/.github/scripts/update_osquery_versions.py
@@ -1,6 +1,7 @@
 import os
-import requests
 import re
+import json
+import http.client
 
 # Use GITHUB_WORKSPACE to get the root of your repository
 repo_root = os.environ.get('GITHUB_WORKSPACE', '')
@@ -8,8 +9,13 @@ FILE_PATH = os.path.join(repo_root, 'frontend', 'utilities', 'constants.tsx')
 
 
 def fetch_osquery_versions():
-    response = requests.get('https://api.github.com/repos/osquery/osquery/releases')
-    releases = response.json()
+    conn = http.client.HTTPSConnection('api.github.com')
+    conn.request('GET', '/repos/osquery/osquery/releases', headers={"User-Agent": "Fleet/osquery-checker"})
+    resp = conn.getresponse()
+    content = resp.read()
+    conn.close()
+    releases = json.loads(content.decode('utf-8'))
+
     return [release['tag_name'] for release in releases if not release['prerelease']]
 
 def update_min_osquery_version_options(new_versions):

--- a/.github/workflows/update-osquery-versions.yml
+++ b/.github/workflows/update-osquery-versions.yml
@@ -16,9 +16,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@65d7f2d534ac1bc67fcd62888c5f4f3d2cb2b236 # v4.7.1
         with:
-          python-version: "3.x"
-      - name: Install dependencies
-        run: pip install requests
+          python-version: "3.13.1"
       - name: Update Osquery versions in UI
         run: python .github/scripts/update_osquery_versions.py
       - name: PR changes


### PR DESCRIPTION
For #24274. Skipping changes file since this is an internal tool.

# Checklist for submitter
- [x] Manual QA for all new/changed functionality