### PR TITLE
Added settings for Windows MDM migration

### DIFF
--- a/it-and-security/default.yml
+++ b/it-and-security/default.yml
@@ -80,6 +80,11 @@ policies:
 queries:
   - path: ./lib/all/queries/collect-fleetd-update-channels.yml
 controls: 
+  enable_disk_encryption: true
+  macos_migration:
+    enable: true
+    mode: voluntary
+    webhook_url: $DOGFOOD_MACOS_MIGRATION_WEBHOOK_URL
   windows_enabled_and_configured: true
   windows_migration:
     enable: true

--- a/it-and-security/default.yml
+++ b/it-and-security/default.yml
@@ -79,3 +79,7 @@ org_settings:
 policies:
 queries:
   - path: ./lib/all/queries/collect-fleetd-update-channels.yml
+controls: 
+  windows_enabled_and_configured: true
+  windows_migration:
+    enable: true

--- a/it-and-security/teams/no-team.yml
+++ b/it-and-security/teams/no-team.yml
@@ -16,6 +16,8 @@ controls:
     deadline: "2023-06-13"
     minimum_version: 13.4.1
   windows_enabled_and_configured: true
+  windows_migration:
+    enable: true
   windows_settings:
     custom_settings: []
   windows_updates:

--- a/it-and-security/teams/no-team.yml
+++ b/it-and-security/teams/no-team.yml
@@ -1,24 +1,3 @@
 name: No team
 policies:
-controls:
-  enable_disk_encryption: true
-  macos_migration:
-    enable: true
-    mode: voluntary
-    webhook_url: $DOGFOOD_MACOS_MIGRATION_WEBHOOK_URL
-  macos_settings:
-    custom_settings: null
-  macos_setup:
-    bootstrap_package: ""
-    enable_end_user_authentication: false
-    macos_setup_assistant: null
-  macos_updates:
-    deadline: "2025-01-03"
-    minimum_version: 15.2
-  windows_settings:
-    custom_settings: []
-  windows_updates:
-    deadline_days: 3
-    grace_period_days: 2
-  scripts: []
-software:
+queries:

--- a/it-and-security/teams/no-team.yml
+++ b/it-and-security/teams/no-team.yml
@@ -13,11 +13,8 @@ controls:
     enable_end_user_authentication: false
     macos_setup_assistant: null
   macos_updates:
-    deadline: "2023-06-13"
-    minimum_version: 13.4.1
-  windows_enabled_and_configured: true
-  windows_migration:
-    enable: true
+    deadline: "2025-01-03"
+    minimum_version: 15.2
   windows_settings:
     custom_settings: []
   windows_updates:

--- a/it-and-security/teams/no-team.yml
+++ b/it-and-security/teams/no-team.yml
@@ -1,3 +1,4 @@
 name: No team
 policies:
 queries:
+software:


### PR DESCRIPTION
fleetdm/confidential#9172

Low risk as we currently don't have any Windows devices MDM-enabled to third-party servers. 