### PR TITLE
Clarify automation reset

### DIFF
--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -6790,7 +6790,7 @@ _Available in Fleet Premium_
 - [Add policy](#add-policy)
 - [Remove policies](#remove-policies)
 - [Edit policy](#edit-policy)
-- [Run automation for all failing hosts of a policy](#run-automation-for-all-failing-hosts-of-a-policy)
+- [Reset automations for all failing hosts of a policy](#run-automation-for-all-failing-hosts-of-a-policy)
 
 Policies are yes or no questions you can ask about your hosts.
 

--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -7084,7 +7084,7 @@ For example, a policy might ask “Is Gatekeeper enabled on macOS devices?“ Th
 }
 ```
 
-### Reset automations for all hosts failing a policy
+### Reset automations for all hosts failing policies
 
 Resets [automation](https://fleetdm.com/docs/using-fleet/automations#policy-automations) status for *all* hosts failing the specified policies. On the next automation run, any failing host will be considered newly failing.
 

--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -6790,7 +6790,7 @@ _Available in Fleet Premium_
 - [Add policy](#add-policy)
 - [Remove policies](#remove-policies)
 - [Edit policy](#edit-policy)
-- [Reset automations for all hosts failing a policy](#reset-automations-for-all-hosts-failing-a-policy)
+- [Reset automations for all hosts failing policies](#reset-automations-for-all-hosts-failing-policies)
 
 Policies are yes or no questions you can ask about your hosts.
 

--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -6790,7 +6790,7 @@ _Available in Fleet Premium_
 - [Add policy](#add-policy)
 - [Remove policies](#remove-policies)
 - [Edit policy](#edit-policy)
-- [Reset automations for all failing hosts of a policy](#reset-automations-for-all-failing-hosts-of-a-policy)
+- [Reset automations for all hosts failing a policy](#reset-automations-for-all-hosts-failing-a-policy)
 
 Policies are yes or no questions you can ask about your hosts.
 

--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -7086,7 +7086,7 @@ For example, a policy might ask “Is Gatekeeper enabled on macOS devices?“ Th
 
 ### Reset automations for all failing hosts of a policy
 
-Resets [automation](https://fleetdm.com/docs/using-fleet/automations#policy-automations) status for *all* hosts failing the specified policies. On the next automation run, any failing host will considered newly failing,
+Resets [automation](https://fleetdm.com/docs/using-fleet/automations#policy-automations) status for *all* hosts failing the specified policies. On the next automation run, any failing host will be considered newly failing.
 
 `POST /api/v1/fleet/automations/reset`
 

--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -7084,9 +7084,9 @@ For example, a policy might ask “Is Gatekeeper enabled on macOS devices?“ Th
 }
 ```
 
-### Run automation for all failing hosts of a policy
+### Reset automations for all failing hosts of a policy
 
-Triggers [automations](https://fleetdm.com/docs/using-fleet/automations#policy-automations) for *all* hosts failing the specified policies, regardless of whether the policies were previously failing on those hosts.
+Resets [automation](https://fleetdm.com/docs/using-fleet/automations#policy-automations) status for *all* hosts failing the specified policies. On the next automation run, any failing host will considered newly failing,
 
 `POST /api/v1/fleet/automations/reset`
 

--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -7084,7 +7084,7 @@ For example, a policy might ask “Is Gatekeeper enabled on macOS devices?“ Th
 }
 ```
 
-### Reset automations for all failing hosts of a policy
+### Reset automations for all hosts failing a policy
 
 Resets [automation](https://fleetdm.com/docs/using-fleet/automations#policy-automations) status for *all* hosts failing the specified policies. On the next automation run, any failing host will be considered newly failing.
 

--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -6790,7 +6790,7 @@ _Available in Fleet Premium_
 - [Add policy](#add-policy)
 - [Remove policies](#remove-policies)
 - [Edit policy](#edit-policy)
-- [Reset automations for all failing hosts of a policy](#run-automation-for-all-failing-hosts-of-a-policy)
+- [Reset automations for all failing hosts of a policy](#reset-automations-for-all-failing-hosts-of-a-policy)
 
 Policies are yes or no questions you can ask about your hosts.
 


### PR DESCRIPTION
Updated /automations/reset description to reflect that this endpoint does not immediately trigger automations, but resets the status of hosts so that they are seen as newly failing on the next automation run.

# Checklist for submitter
