### PR TITLE
Ignore iOS-only Firefox vulnerability (CVE-2024-10004) since we don't support iOS vulns

### DIFF
--- a/changes/23579-cve-2024-10004-false-positive
+++ b/changes/23579-cve-2024-10004-false-positive
@@ -1,0 +1,1 @@
+* Fixed CVE-2024-10004 false positive on Fleet-supported platforms (vuln is iOS-only and iOS vuln checking is not supported)

--- a/server/vulnerabilities/nvd/cpe_matching_rules.go
+++ b/server/vulnerabilities/nvd/cpe_matching_rules.go
@@ -249,6 +249,8 @@ func GetKnownNVDBugRules() (CPEMatchingRules, error) {
 				return cpeMeta.TargetSW != "windows"
 			},
 		},
+		// CVE-2024-10004 only targets iOS, and we don't yet support iOS vuln scanning (and can't tell iOS/Mac CPEs apart yet)
+		CPEMatchingRule{CVEs: map[string]struct{}{"CVE-2024-10004": {}}, IgnoreAll: true},
 	}
 
 	for i, rule := range rules {

--- a/server/vulnerabilities/nvd/cve_test.go
+++ b/server/vulnerabilities/nvd/cve_test.go
@@ -359,6 +359,10 @@ func TestTranslateCPEToCVE(t *testing.T) {
 			},
 			continuesToUpdate: true,
 		},
+		"cpe:2.3:a:mozilla:firefox:*:*:*:*:*:*:*:*": {
+			excludedCVEs:      []string{"CVE-2024-10004"},
+			continuesToUpdate: true,
+		},
 	}
 
 	cveOSTests := []struct {


### PR DESCRIPTION
For #23579

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/Committing-Changes.md#changes-files) for more information.
- [x] Added/updated tests
- [x] Manual QA for all new/changed functionality

QA'd locally successfully. It just took a bit longer for the vuln showed up.