### PR TITLE
minio vulnerability

### DIFF
--- a/changes/23557-minio
+++ b/changes/23557-minio
@@ -1,0 +1,1 @@
+* fixed issue where minio software was not scanned for vulnerabilities correctly because of unexpected trailing characters in the version string

--- a/server/service/osquery_utils/queries.go
+++ b/server/service/osquery_utils/queries.go
@@ -1689,7 +1689,12 @@ var (
 				return s.Name == "minio" && strings.Contains(s.Version, "RELEASE.")
 			},
 			mutateSoftware: func(s *fleet.Software, logger log.Logger) {
+				// trim the "RELEASE." prefix from the version
 				s.Version = strings.TrimPrefix(s.Version, "RELEASE.")
+				// trim any unexpected trailing characters
+				if idx := strings.Index(s.Version, "_"); idx != -1 {
+					s.Version = s.Version[:idx]
+				}
 			},
 		},
 		{

--- a/server/service/osquery_utils/queries_test.go
+++ b/server/service/osquery_utils/queries_test.go
@@ -1921,6 +1921,18 @@ func TestSanitizeSoftware(t *testing.T) {
 			},
 		},
 		{
+			name: "minio with trailing garbage",
+			h:    &fleet.Host{},
+			s: &fleet.Software{
+				Name:    "minio",
+				Version: "RELEASE.2022-03-10T00-00-00Z_1",
+			},
+			sanitized: &fleet.Software{
+				Name:    "minio",
+				Version: "2022-03-10T00-00-00Z",
+			},
+		},
+		{
 			name: "JetBrains non-EAP",
 			h:    &fleet.Host{},
 			s: &fleet.Software{


### PR DESCRIPTION
# Checklist for submitter

removing trailing characters from minio version string

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/Committing-Changes.md#changes-files) for more information.
- [X] Added/updated tests
- [ ] Manual QA for all new/changed functionality