### PR TITLE
23971 Proposed API and schema changes

### DIFF
--- a/docs/Contributing/API-for-contributors.md
+++ b/docs/Contributing/API-for-contributors.md
@@ -12,6 +12,7 @@
 - [Setup](#setup)
 - [Scripts](#scripts)
 - [Software](#software)
+- [Users](#users)
 
 > These endpoints are used by the Fleet UI, Fleet Desktop, and `fleetctl` clients and frequently change to reflect current functionality.
 
@@ -4196,4 +4197,102 @@ Content-Type: application/octet-stream
 Content-Disposition: attachment
 Content-Length: <length>
 Body: <blob>
+```
+## Users
+
+### Update user-specific UI settings
+
+`PATCH /api/v1/fleet/users/:id`
+
+#### Parameters
+
+| Name      | Type   | In    | Description                                                                                                                                                           |
+| --------- | ------ | ----- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| settings  | object   | body  | The updated user settings. |
+
+#### Example
+
+`PATCH /api/v1/fleet/users/1`
+```json
+{
+  "hidden_host_columns": ["hostname"]
+}
+```
+
+##### Default response
+* Note that user settings are *not* included in this response. See below `GET`s for how to get user settings.
+`Status: 200`
+```json
+{
+    "user": {
+        "created_at": "2025-01-08T01:04:23Z",
+        "updated_at": "2025-01-09T00:08:19Z",
+        "id": 1,
+        "name": "Sum Bahdee",
+        "email": "sum@org.com",
+        "force_password_reset": false,
+        "gravatar_url": "",
+        "sso_enabled": false,
+        "mfa_enabled": false,
+        "global_role": "admin",
+        "api_only": false,
+        "teams": []
+    }
+}
+```
+
+### Include settings when getting a user
+
+`GET /api/v1/fleet/users/:id?include_ui_settings=true`
+
+Use of `include_ui_settings=true` is considered the contributor API functionality – without that
+param, this endpoint is considered a documented REST API endpoint
+
+#### Parameters
+
+| Name                | Type   | In    | Description                                                                                       |
+| ------------------- | ------ | ----- | --------------------------------------------------------------------------------------------------|
+| include_ui_settings | bool   | query | If `true`, will include the user's settings in the response. For now, this is a single ui setting.
+
+#### Example
+
+`GET /api/v1/fleet/users/2/?include_ui_settings=true`
+
+##### Default response
+
+`Status: 200`
+```json
+{
+  "user": {...},
+  "available_teams": {...}
+  "settings": {"hidden_host_columns": ["hostname"]},
+}
+```
+
+### Include settings when getting current user
+
+`GET /api/v1/fleet/me/?include_ui_settings=true`
+
+Use of `include_ui_settings=true` is considered the contributor API functionality – without that
+param, this endpoint is considered a documented REST API endpoint
+
+#### Parameters
+
+| Name                | Type   | In    | Description                                                                                       |
+| ------------------- | ------ | ----- | --------------------------------------------------------------------------------------------------|
+| include_ui_settings | bool   | query | If `true`, will include the user's settings in the response. For now, this is a single ui setting.
+
+#### Example
+
+`GET /api/v1/fleet/me?include_ui_settings=true`
+
+##### Default response
+
+`Status: 200`
+```json
+{
+  "user": {...},
+  "available_teams": {...}
+  "settings": {"hidden_host_columns": ["hostname"]},
+}
 ```

--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -299,9 +299,15 @@ Retrieves the user data for the authenticated user.
 
 `GET /api/v1/**fleet**/me`
 
+#### Parameters
+
+| Name                | Type    | In    | Description                                     |
+|:------------------- |:------- |:----- |:------------------------------------------------|
+| include_ui_settings | boolean | query | Include the user's ui settings (default: false) |
+
 #### Example
 
-`GET /api/v1/fleet/me`
+`GET /api/v1/fleet/me?include_ui_settings=true`
 
 ##### Default response
 
@@ -328,7 +334,25 @@ Retrieves the user data for the authenticated user.
       "name": "Workstations",
       "description": "Employee workstations"
     }
-  ]
+  ],
+  "ui_settings": {
+    "hidden_hosts_table_columns": [
+      "hostname",
+      "computer_name",
+      "device_mapping",
+      "primary_mac",
+      "public_ip",
+      "cpu_type",
+      "mdm.server_url",
+      "mdm.enrollment_status",
+      "memory",
+      "uptime",
+      "uuid",
+      "seen_time",
+      "hardware_model",
+      "hardware_serial",
+    ]
+  }
 }
 ```
 

--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -297,7 +297,7 @@ Resets a user's password. Which user is determined by the password reset token u
 
 Retrieves the user data for the authenticated user.
 
-`GET /api/v1/fleet/me`
+`GET /api/v1/**fleet**/me`
 
 #### Example
 
@@ -321,7 +321,14 @@ Retrieves the user data for the authenticated user.
     "gravatar_url": "",
     "sso_enabled": false,
     "teams": []
-  }
+  },
+  "available_teams" : [
+    {
+      "id": 1,
+      "name": "Workstations",
+      "description": "Employee workstations"
+    }
+  ]
 }
 ```
 

--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -299,15 +299,9 @@ Retrieves the user data for the authenticated user.
 
 `GET /api/v1/fleet/me`
 
-#### Parameters
-
-| Name                | Type    | In    | Description                                     |
-|:------------------- |:------- |:----- |:------------------------------------------------|
-| include_settings    | boolean | query | Include the user's settings (default: false)    |
-
 #### Example
 
-`GET /api/v1/fleet/me?include_settings=true`
+`GET /api/v1/fleet/me`
 
 ##### Default response
 
@@ -335,24 +329,6 @@ Retrieves the user data for the authenticated user.
       "description": "Employee workstations"
     }
   ],
-  "settings": {
-    "hidden_hosts_table_columns": [
-      "hostname",
-      "computer_name",
-      "device_mapping",
-      "primary_mac",
-      "public_ip",
-      "cpu_type",
-      "mdm.server_url",
-      "mdm.enrollment_status",
-      "memory",
-      "uptime",
-      "uuid",
-      "seen_time",
-      "hardware_model",
-      "hardware_serial",
-    ]
-  }
 }
 ```
 
@@ -11170,14 +11146,13 @@ Returns all information about a specific user.
 
 #### Parameters
 
-| Name             | Type    | In    | Description                                  |
-| ---------------- | ------- | -----| --------------------------------------------- |
-| id               | integer | path  | **Required**. The user's id.                 |
-| include_settings | boolean | query | Include the user's settings (default: false) |
+| Name | Type    | In   | Description                  |
+| ---- | ------- | ---- | ---------------------------- |
+| id   | integer | path | **Required**. The user's id. |
 
 #### Example
 
-`GET /api/v1/fleet/users/2?include_settings=true`
+`GET /api/v1/fleet/users/2`
 
 ##### Default response
 
@@ -11198,24 +11173,6 @@ Returns all information about a specific user.
     "global_role": "admin",
     "api_only": false,
     "teams": []
-  },
-  "settings": {
-    "hidden_hosts_table_columns": [
-      "hostname",
-      "computer_name",
-      "device_mapping",
-      "primary_mac",
-      "public_ip",
-      "cpu_type",
-      "mdm.server_url",
-      "mdm.enrollment_status",
-      "memory",
-      "uptime",
-      "uuid",
-      "seen_time",
-      "hardware_model",
-      "hardware_serial",
-    ]
   }
 }
 ```
@@ -11255,7 +11212,6 @@ Returns all information about a specific user.
 | new_password| string  | body | The user's new password. |
 | global_role | string  | body | The role assigned to the user. In Fleet 4.0.0, 3 user roles were introduced (`admin`, `maintainer`, and `observer`). If `global_role` is specified, `teams` cannot be specified.                                                                                                                                                                         |
 | teams       | array   | body | _Available in Fleet Premium_. The teams and respective roles assigned to the user. Should contain an array of objects in which each object includes the team's `id` and the user's `role` on each team. In Fleet 4.0.0, 3 user roles were introduced (`admin`, `maintainer`, and `observer`). If `teams` is specified, `global_role` cannot be specified. |
-| settings    | object  | body | Optional user-specific settings.
 
 #### Example
 
@@ -11266,25 +11222,7 @@ Returns all information about a specific user.
 ```json
 {
   "name": "Jane Doe",
-  "global_role": "admin",
-  "settings": {
-    "hidden_hosts_table_columns": [
-      "hostname",
-      "computer_name",
-      "device_mapping",
-      "primary_mac",
-      "public_ip",
-      "cpu_type",
-      "mdm.server_url",
-      "mdm.enrollment_status",
-      "memory",
-      "uptime",
-      "uuid",
-      "seen_time",
-      "hardware_model",
-      "hardware_serial",
-    ]
-  }
+  "global_role": "admin"
 }
 ```
 

--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -297,13 +297,13 @@ Resets a user's password. Which user is determined by the password reset token u
 
 Retrieves the user data for the authenticated user.
 
-`GET /api/v1/**fleet**/me`
+`GET /api/v1/fleet/me`
 
 #### Parameters
 
 | Name                | Type    | In    | Description                                     |
 |:------------------- |:------- |:----- |:------------------------------------------------|
-| include_ui_settings | boolean | query | Include the user's ui settings (default: false) |
+| include_settings    | boolean | query | Include the user's settings (default: false)    |
 
 #### Example
 
@@ -335,7 +335,7 @@ Retrieves the user data for the authenticated user.
       "description": "Employee workstations"
     }
   ],
-  "ui_settings": {
+  "settings": {
     "hidden_hosts_table_columns": [
       "hostname",
       "computer_name",
@@ -11170,13 +11170,14 @@ Returns all information about a specific user.
 
 #### Parameters
 
-| Name | Type    | In   | Description                  |
-| ---- | ------- | ---- | ---------------------------- |
-| id   | integer | path | **Required**. The user's id. |
+| Name             | Type    | In    | Description                                  |
+| ---------------- | ------- | -----| --------------------------------------------- |
+| id               | integer | path  | **Required**. The user's id.                 |
+| include_settings | boolean | query | Include the user's settings (default: false) |
 
 #### Example
 
-`GET /api/v1/fleet/users/2`
+`GET /api/v1/fleet/users/2?include_settings=true`
 
 ##### Default response
 
@@ -11197,6 +11198,24 @@ Returns all information about a specific user.
     "global_role": "admin",
     "api_only": false,
     "teams": []
+  },
+  "settings": {
+    "hidden_hosts_table_columns": [
+      "hostname",
+      "computer_name",
+      "device_mapping",
+      "primary_mac",
+      "public_ip",
+      "cpu_type",
+      "mdm.server_url",
+      "mdm.enrollment_status",
+      "memory",
+      "uptime",
+      "uuid",
+      "seen_time",
+      "hardware_model",
+      "hardware_serial",
+    ]
   }
 }
 ```
@@ -11236,6 +11255,7 @@ Returns all information about a specific user.
 | new_password| string  | body | The user's new password. |
 | global_role | string  | body | The role assigned to the user. In Fleet 4.0.0, 3 user roles were introduced (`admin`, `maintainer`, and `observer`). If `global_role` is specified, `teams` cannot be specified.                                                                                                                                                                         |
 | teams       | array   | body | _Available in Fleet Premium_. The teams and respective roles assigned to the user. Should contain an array of objects in which each object includes the team's `id` and the user's `role` on each team. In Fleet 4.0.0, 3 user roles were introduced (`admin`, `maintainer`, and `observer`). If `teams` is specified, `global_role` cannot be specified. |
+| settings    | object  | body | Optional user-specific settings.
 
 #### Example
 
@@ -11246,7 +11266,25 @@ Returns all information about a specific user.
 ```json
 {
   "name": "Jane Doe",
-  "global_role": "admin"
+  "global_role": "admin",
+  "settings": {
+    "hidden_hosts_table_columns": [
+      "hostname",
+      "computer_name",
+      "device_mapping",
+      "primary_mac",
+      "public_ip",
+      "cpu_type",
+      "mdm.server_url",
+      "mdm.enrollment_status",
+      "memory",
+      "uptime",
+      "uuid",
+      "seen_time",
+      "hardware_model",
+      "hardware_serial",
+    ]
+  }
 }
 ```
 

--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -307,7 +307,7 @@ Retrieves the user data for the authenticated user.
 
 #### Example
 
-`GET /api/v1/fleet/me?include_ui_settings=true`
+`GET /api/v1/fleet/me?include_settings=true`
 
 ##### Default response
 


### PR DESCRIPTION
## For #25034

### API changes:
[this PR diff](https://github.com/fleetdm/fleet/pull/25013/files) ("available_teams" change is adding missing documentation for current API behavior) 

### schema changes:
- new col in `users` table, `settings`, type `json`. Defaults to `{}`. New setting, `hidden_host_columns`, added or updated on first relevant API call per user.

### semantics

- **null** `"hidden_host_columns"` field means "not yet set, use defaults": `{"settings":{"hidden_host_columns": null}}`
- **included and empty** `"hidden_host_columns"` field means "no columns hidden, show all columns in the UI": `{"settings":{"hidden_host_columns": []}}`

### Updates 1/7/25 per discussion with @rachaelshaw @lucasmrod @sgress454:
- Optional query param `include_ui_settings=true` included with `GET`s to `/me` or `/users/:id` will trigger considering the API call to be a contributor API call, giving more flexibility for future changes. Note that this is the first time we have one endpoint that can be conditionally considered a contributor endpoint depending on how it is called.