### PR TITLE
Fleet UI: Remove wrap from disk encryption status, table scroll horiz

### DIFF
--- a/frontend/components/StatusIndicatorWithIcon/_styles.scss
+++ b/frontend/components/StatusIndicatorWithIcon/_styles.scss
@@ -8,6 +8,10 @@
     .icon {
       margin-right: $pad-xsmall;
     }
+
+    span {
+      white-space: nowrap;
+    }
   }
 
   // overrides for different layout

--- a/frontend/pages/ManageControlsPage/OSSettings/_styles.scss
+++ b/frontend/pages/ManageControlsPage/OSSettings/_styles.scss
@@ -15,12 +15,16 @@
     }
   }
 
-  .side-nav__card-container > .custom-settings {
-    max-width: none;
-  }
-  @media (max-width: 1120px) {
-    .side-nav__nav-list {
-      padding-right: 0;
+  .side-nav__card-container {
+    overflow-x: hidden;
+
+    > .custom-settings {
+      max-width: none;
+    }
+    @media (max-width: 1120px) {
+      .side-nav__nav-list {
+        padding-right: 0;
+      }
     }
   }
 }

--- a/frontend/pages/ManageControlsPage/OSSettings/cards/DiskEncryption/_styles.scss
+++ b/frontend/pages/ManageControlsPage/OSSettings/cards/DiskEncryption/_styles.scss
@@ -19,4 +19,13 @@
     font-size: inherit;
     color: inherit;
   }
+
+  .data-table {
+    &__wrapper {
+      // Keeps table data within the table container at smaller screen sizes
+      overflow-x: auto;
+      // Prevent border from causing .side-nav__card-container horizontal scroll
+      box-sizing: border-box;
+    }
+  }
 }

--- a/frontend/pages/ManageControlsPage/OSSettings/cards/DiskEncryption/components/DiskEncryptionTable/_styles.scss
+++ b/frontend/pages/ManageControlsPage/OSSettings/cards/DiskEncryption/components/DiskEncryptionTable/_styles.scss
@@ -12,13 +12,13 @@
   .linkToFilteredHosts__header {
     width: auto;
     max-width: 120px;
-    padding-left: 0 !important;
+    padding-left: 0 !important; // Removes 24px of unnecessary table scroll
   }
 
   .linkToFilteredHosts__cell {
     width: auto;
     max-width: 120px;
-    padding-left: 0 !important;
+    padding-left: 0 !important; // Removes 24px of unnecessary table scroll
   }
 }
 

--- a/frontend/pages/ManageControlsPage/OSSettings/cards/DiskEncryption/components/DiskEncryptionTable/_styles.scss
+++ b/frontend/pages/ManageControlsPage/OSSettings/cards/DiskEncryption/components/DiskEncryptionTable/_styles.scss
@@ -12,6 +12,13 @@
   .linkToFilteredHosts__header {
     width: auto;
     max-width: 120px;
+    padding-left: 0 !important;
+  }
+
+  .linkToFilteredHosts__cell {
+    width: auto;
+    max-width: 120px;
+    padding-left: 0 !important;
   }
 }
 


### PR DESCRIPTION
## Issue
Cerra confidential 8903

## Description
- Per product update to spec, instead of wrapping the text or truncating with a tooltip, allow horizontal scroll on the disk encryption status table

## Screenrecording of new solution

https://github.com/user-attachments/assets/5958e6d2-5026-4b09-b6bf-e18653aefc0f



# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->


- [x] Manual QA for all new/changed functionality

