### PR TITLE
Fleet UI: Open a modal moves updates active element to modal elements

### DIFF
--- a/frontend/components/Modal/Modal.tsx
+++ b/frontend/components/Modal/Modal.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from "react";
+import React, { useEffect, useRef, useLayoutEffect } from "react";
 import classnames from "classnames";
 import Button from "components/buttons/Button/Button";
 import Icon from "components/Icon/Icon";
@@ -52,11 +52,45 @@ const Modal = ({
   className,
 }: IModalProps): JSX.Element => {
   const contentRef = useRef<HTMLDivElement>(null);
+  const previousActiveElement = useRef<HTMLElement | null>(null);
+  const isClosingRef = useRef(false);
+
+  // This returns focus to the previous active element before opening the modal
+  useLayoutEffect(() => {
+    previousActiveElement.current = document.activeElement as HTMLElement;
+  }, []);
+
+  useEffect(() => {
+    const observer = new MutationObserver(() => {
+      if (
+        !isClosingRef.current &&
+        !document.body.contains(contentRef.current)
+      ) {
+        isClosingRef.current = true;
+        if (previousActiveElement.current) {
+          previousActiveElement.current.focus();
+        }
+      }
+    });
+
+    observer.observe(document.body, { childList: true, subtree: true });
+
+    return () => {
+      observer.disconnect();
+      if (previousActiveElement.current) {
+        previousActiveElement.current.focus();
+      }
+    };
+  }, []);
 
   /** Allows keyboard accessibility to modals -- Because of loading,
-   * we cannot have a global fix to access focusable elements within
-   * children, but we can access the close button within Modal.tsx */
+   * we cannot have a global fix to access focusable elements *within*
+   * children, but we can access the close button on the Modal */
   useEffect(() => {
+    previousActiveElement.current = document.activeElement as HTMLElement;
+
+    // This just grabs the x button, left it robust incase we use it to grab
+    // a different focusable element in the future
     if (contentRef.current) {
       const focusableElements = contentRef.current.querySelectorAll(
         'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
@@ -66,7 +100,13 @@ const Modal = ({
         (focusableElements[0] as HTMLElement).focus();
       }
     }
-  }, [isHidden]);
+
+    return () => {
+      if (previousActiveElement.current) {
+        previousActiveElement.current.focus();
+      }
+    };
+  }, []);
 
   useEffect(() => {
     const closeWithEscapeKey = (e: KeyboardEvent) => {

--- a/frontend/components/Modal/Modal.tsx
+++ b/frontend/components/Modal/Modal.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React, { useEffect, useRef } from "react";
 import classnames from "classnames";
 import Button from "components/buttons/Button/Button";
 import Icon from "components/Icon/Icon";
@@ -51,6 +51,23 @@ const Modal = ({
   disableClosingModal = false,
   className,
 }: IModalProps): JSX.Element => {
+  const contentRef = useRef<HTMLDivElement>(null);
+
+  /** Allows keyboard accessibility to modals -- Because of loading,
+   * we cannot have a global fix to access focusable elements within
+   * children, but we can access the close button within Modal.tsx */
+  useEffect(() => {
+    if (contentRef.current) {
+      const focusableElements = contentRef.current.querySelectorAll(
+        'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+      );
+
+      if (focusableElements.length > 0) {
+        (focusableElements[0] as HTMLElement).focus();
+      }
+    }
+  }, [isHidden]);
+
   useEffect(() => {
     const closeWithEscapeKey = (e: KeyboardEvent) => {
       if (e.key === "Escape") {
@@ -107,7 +124,7 @@ const Modal = ({
   });
 
   return (
-    <div className={backgroundClasses}>
+    <div ref={contentRef} className={backgroundClasses}>
       <div className={modalContainerClasses}>
         <div className={`${baseClass}__header`}>
           <span>{title}</span>


### PR DESCRIPTION
## Issue
Part of #23266 

## Description
- Better keyboard accessibility for modals
  - When opening a modal, the keyboard active element is now within the modal and not back on the main page
  - Figured out how to make the focusable element go back to the original element when closing the modal :) 
  - Works on current FF, Chrome, not Safari

## Screenrecording


https://github.com/user-attachments/assets/0bae96f9-0768-46cd-8566-b94e9777c538


## QA
- When opening any modal with a keyboard in Chrome or FF, you now can to tab through the modal immediately as it moves the focus to an element within the modal
- When exiting the modal with keyboard, make the focusable element go back to the original element that was focused before opening the modal

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Manual QA for all new/changed functionality

