### PR TITLE
Fleet UI: Condensed view query report link accessibility

### DIFF
--- a/frontend/pages/hosts/details/cards/Queries/HostQueriesTableConfig.tsx
+++ b/frontend/pages/hosts/details/cards/Queries/HostQueriesTableConfig.tsx
@@ -8,6 +8,8 @@ import PerformanceImpactCell from "components/TableContainer/DataTable/Performan
 import TooltipWrapper from "components/TooltipWrapper";
 import ReportUpdatedCell from "pages/hosts/details/cards/Queries/ReportUpdatedCell";
 import Icon from "components/Icon";
+import { Link } from "react-router";
+import PATHS from "router/paths";
 
 interface IHostQueriesTableData extends Partial<IQueryStats> {
   performance: { indicator: string; id: number };
@@ -90,6 +92,7 @@ const generateColumnConfigs = (
       accessor: "performance",
       Cell: (cellProps: IPerformanceImpactCell) => {
         const baseClass = "performance-cell";
+        const queryId = cellProps.row.original.id;
         return (
           <span className={baseClass}>
             <PerformanceImpactCell
@@ -98,12 +101,21 @@ const generateColumnConfigs = (
               isHostSpecific
             />
             {!queryReportsDisabled &&
-              cellProps.row.original.should_link_to_hqr && (
-                <Icon
-                  name="chevron-right"
-                  className={`${baseClass}__link-icon`}
-                  color="core-fleet-blue"
-                />
+              cellProps.row.original.should_link_to_hqr &&
+              hostId &&
+              queryId && (
+                // parent row has same onClick functionality but link here is required for keyboard accessibility
+                <Link
+                  className={`${baseClass}__link`}
+                  title="link to host query report"
+                  to={PATHS.HOST_QUERY_REPORT(hostId, queryId)}
+                >
+                  <Icon
+                    name="chevron-right"
+                    className={`${baseClass}__link-icon`}
+                    color="core-fleet-blue"
+                  />
+                </Link>
               )}
           </span>
         );


### PR DESCRIPTION
## Issue
PR #23625 followup

## Description
- The condensed link uses completely different code that doesn't have a focusable state
- Added focusable state to that link so it can be accessed via the keyboard

## Screen recording

https://github.com/user-attachments/assets/82b7873d-0023-4bf7-a20f-da53a0c3e22f



# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Manual QA for all new/changed functionality

