### PR TITLE
Added fleetd docker images to test/develop linux fleetd features

### DIFF
--- a/tools/fleetd-linux/README.md
+++ b/tools/fleetd-linux/README.md
@@ -1,0 +1,19 @@
+# fleetd-linux
+
+This directory contains scripts to build and run Docker Linux images with fleetd installed on them that connect to a Fleet instance running on the host (similar to [tools/osquery](../osquery/)).
+
+PS: In the future, we could push these images to Docker Hub and include some of them in `fleetctl preview` (to allow demoing script execution on Linux hosts).
+
+## Build fleetd docker images
+
+To build all docker images run:
+```sh
+./tools/fleetd-linux/build-all.sh
+```
+
+## Run fleetd containers
+
+To run all fleetd docker images and enroll them to your local Fleet instance, run:
+```sh
+ENROLL_SECRET=<...> docker compose -f ./tools/fleetd-linux/docker-compose.yml up
+```

--- a/tools/fleetd-linux/amazonlinux-2023/Dockerfile
+++ b/tools/fleetd-linux/amazonlinux-2023/Dockerfile
@@ -1,4 +1,4 @@
-FROM amazonlinux:2023@sha256:1b091808a98a0a1b0570073421866f5a76adfa43e8d7a42b2f5dd0c60053a567
+FROM amazonlinux:2023
 
 COPY fleet-osquery_amd64.rpm /
 COPY run-fleetd.sh /

--- a/tools/fleetd-linux/amazonlinux-2023/Dockerfile
+++ b/tools/fleetd-linux/amazonlinux-2023/Dockerfile
@@ -1,0 +1,12 @@
+FROM amazonlinux:2023@sha256:1b091808a98a0a1b0570073421866f5a76adfa43e8d7a42b2f5dd0c60053a567
+
+COPY fleet-osquery_amd64.rpm /
+COPY run-fleetd.sh /
+RUN chmod +x /run-fleetd.sh
+
+# For xargs
+RUN dnf install --assumeyes findutils
+
+RUN dnf install --assumeyes /fleet-osquery_amd64.rpm
+
+ENTRYPOINT ["/run-fleetd.sh"]

--- a/tools/fleetd-linux/build-all.sh
+++ b/tools/fleetd-linux/build-all.sh
@@ -9,6 +9,7 @@ fleetctl package --type=deb \
 	--fleet-url=https://host.docker.internal:8080 \
 	--enroll-secret=placeholder \
 	--fleet-certificate=../osquery/fleet.crt \
+    --disable-open-folder \
     --debug
 mv fleet-osquery_1*_amd64.deb fleet-osquery_amd64.deb
 
@@ -18,6 +19,7 @@ fleetctl package --type=rpm \
 	--fleet-url=https://host.docker.internal:8080 \
 	--enroll-secret=placeholder \
 	--fleet-certificate=../osquery/fleet.crt \
+    --disable-open-folder \
     --debug
 mv fleet-osquery-1*.x86_64.rpm fleet-osquery_amd64.rpm
 

--- a/tools/fleetd-linux/build-all.sh
+++ b/tools/fleetd-linux/build-all.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+script_dir=$(dirname -- "$(readlink -f -- "$BASH_SOURCE")")
+cd "$script_dir"
+
+echo "Building fleetd deb package..."
+fleetctl package --type=deb \
+	--enable-scripts \
+	--fleet-url=https://host.docker.internal:8080 \
+	--enroll-secret=placeholder \
+	--fleet-certificate=../osquery/fleet.crt \
+    --debug
+mv fleet-osquery_1*_amd64.deb fleet-osquery_amd64.deb
+
+echo "Building fleetd rpm package..."
+fleetctl package --type=rpm \
+	--enable-scripts \
+	--fleet-url=https://host.docker.internal:8080 \
+	--enroll-secret=placeholder \
+	--fleet-certificate=../osquery/fleet.crt \
+    --debug
+mv fleet-osquery-1*.x86_64.rpm fleet-osquery_amd64.rpm
+
+echo "Building docker images..."
+docker build -t fleetd-ubuntu-24.04 --platform=linux/amd64 -f ./ubuntu-24.04/Dockerfile .
+docker build -t fleetd-fedora-41 --platform=linux/amd64 -f ./fedora-41/Dockerfile .
+docker build -t fleetd-redhat-9.5 --platform=linux/amd64 -f ./redhat-9.5/Dockerfile .
+docker build -t fleetd-centos-stream-10 --platform=linux/amd64 -f ./centos-stream-10/Dockerfile .
+docker build -t fleetd-debian-12.8 --platform=linux/amd64 -f ./debian-12.8/Dockerfile .
+docker build -t fleetd-amazonlinux-2023 --platform=linux/amd64 -f ./amazonlinux-2023/Dockerfile .

--- a/tools/fleetd-linux/centos-stream-10/Dockerfile
+++ b/tools/fleetd-linux/centos-stream-10/Dockerfile
@@ -1,4 +1,5 @@
-FROM quay.io/centos/centos
+FROM quay.io/centos/centos@sha256:3a3a88a9c8c47dc60b8af3be0779d74c2d3da11a32082ac1a4c329863c422df3
+# Pinning version because without the pin it's failing with host not found for mirrorlist.centos.org.
 
 COPY fleet-osquery_amd64.rpm /
 COPY run-fleetd.sh /

--- a/tools/fleetd-linux/centos-stream-10/Dockerfile
+++ b/tools/fleetd-linux/centos-stream-10/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/centos/centos@sha256:3a3a88a9c8c47dc60b8af3be0779d74c2d3da11a32082ac1a4c329863c422df3
+FROM quay.io/centos/centos
 
 COPY fleet-osquery_amd64.rpm /
 COPY run-fleetd.sh /

--- a/tools/fleetd-linux/centos-stream-10/Dockerfile
+++ b/tools/fleetd-linux/centos-stream-10/Dockerfile
@@ -1,0 +1,9 @@
+FROM quay.io/centos/centos@sha256:3a3a88a9c8c47dc60b8af3be0779d74c2d3da11a32082ac1a4c329863c422df3
+
+COPY fleet-osquery_amd64.rpm /
+COPY run-fleetd.sh /
+RUN chmod +x /run-fleetd.sh
+
+RUN dnf install --assumeyes /fleet-osquery_amd64.rpm
+
+ENTRYPOINT ["/run-fleetd.sh"]

--- a/tools/fleetd-linux/debian-12.8/Dockerfile
+++ b/tools/fleetd-linux/debian-12.8/Dockerfile
@@ -1,0 +1,9 @@
+FROM debian:12.8@sha256:b877a1a3fdf02469440f1768cf69c9771338a875b7add5e80c45b756c92ac20a
+
+COPY fleet-osquery_amd64.deb /
+COPY run-fleetd.sh /
+RUN chmod +x /run-fleetd.sh
+
+RUN dpkg --install /fleet-osquery_amd64.deb
+
+ENTRYPOINT ["/run-fleetd.sh"]

--- a/tools/fleetd-linux/debian-12.8/Dockerfile
+++ b/tools/fleetd-linux/debian-12.8/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:12.8@sha256:b877a1a3fdf02469440f1768cf69c9771338a875b7add5e80c45b756c92ac20a
+FROM debian:12.8
 
 COPY fleet-osquery_amd64.deb /
 COPY run-fleetd.sh /

--- a/tools/fleetd-linux/docker-compose.yml
+++ b/tools/fleetd-linux/docker-compose.yml
@@ -1,0 +1,68 @@
+---
+x-default-settings:
+  environment: &default-environment
+    ENROLL_SECRET: "${ENROLL_SECRET:?ENROLL_SECRET must be set for server authentication}"
+  ulimits: &default-ulimits
+    core:
+      hard: 1000000000
+      soft: 1000000000
+  network_mode: &default-network-mode bridge
+  extra_hosts: &extra-hosts
+    - "host.docker.internal:host-gateway"
+  platform: &default-platform linux/x86_64
+
+services:
+  ubuntu24.04-fleetd:
+    image: "fleetd-ubuntu-24.04"
+    privileged: true
+    user: 0:0
+    network_mode: *default-network-mode
+    platform: *default-platform
+    environment: *default-environment
+    ulimits: *default-ulimits
+    extra_hosts: *extra-hosts
+  fedora41-fleetd:
+    image: "fleetd-fedora-41"
+    privileged: true
+    user: 0:0
+    network_mode: *default-network-mode
+    platform: *default-platform
+    environment: *default-environment
+    ulimits: *default-ulimits
+    extra_hosts: *extra-hosts
+  redhat9.5-fleetd:
+    image: "fleetd-redhat-9.5"
+    privileged: true
+    user: 0:0
+    network_mode: *default-network-mode
+    platform: *default-platform
+    environment: *default-environment
+    ulimits: *default-ulimits
+    extra_hosts: *extra-hosts
+  centosstream10-fleetd:
+    image: "fleetd-centos-stream-10"
+    privileged: true
+    user: 0:0
+    network_mode: *default-network-mode
+    platform: *default-platform
+    environment: *default-environment
+    ulimits: *default-ulimits
+    extra_hosts: *extra-hosts
+  debian12.8-fleetd:
+    image: "fleetd-debian-12.8"
+    privileged: true
+    user: 0:0
+    network_mode: *default-network-mode
+    platform: *default-platform
+    environment: *default-environment
+    ulimits: *default-ulimits
+    extra_hosts: *extra-hosts
+  amazonlinux2023-fleetd:
+    image: "fleetd-amazonlinux-2023"
+    privileged: true
+    user: 0:0
+    network_mode: *default-network-mode
+    platform: *default-platform
+    environment: *default-environment
+    ulimits: *default-ulimits
+    extra_hosts: *extra-hosts

--- a/tools/fleetd-linux/docker-compose.yml
+++ b/tools/fleetd-linux/docker-compose.yml
@@ -11,6 +11,12 @@ x-default-settings:
     - "host.docker.internal:host-gateway"
   platform: &default-platform linux/x86_64
 
+#
+# We are running the containers with `privileged: true` to fix osquery errors like
+# `[... processes.cpp:510] Cannot read /proc/50/io (is osquery running as root?)`
+# (it is running as `root` but seems it's missing some privileges in the container).
+#
+
 services:
   ubuntu24.04-fleetd:
     image: "fleetd-ubuntu-24.04"

--- a/tools/fleetd-linux/fedora-41/Dockerfile
+++ b/tools/fleetd-linux/fedora-41/Dockerfile
@@ -1,4 +1,4 @@
-FROM fedora:41@sha256:3ec60eb34fa1a095c0c34dd37cead9fd38afb62612d43892fcf1d3425c32bc1e
+FROM fedora:41
 
 COPY fleet-osquery_amd64.rpm /
 COPY run-fleetd.sh /

--- a/tools/fleetd-linux/fedora-41/Dockerfile
+++ b/tools/fleetd-linux/fedora-41/Dockerfile
@@ -1,0 +1,9 @@
+FROM fedora:41@sha256:3ec60eb34fa1a095c0c34dd37cead9fd38afb62612d43892fcf1d3425c32bc1e
+
+COPY fleet-osquery_amd64.rpm /
+COPY run-fleetd.sh /
+RUN chmod +x /run-fleetd.sh
+
+RUN dnf install --assumeyes /fleet-osquery_amd64.rpm
+
+ENTRYPOINT ["/run-fleetd.sh"]

--- a/tools/fleetd-linux/redhat-9.5/Dockerfile
+++ b/tools/fleetd-linux/redhat-9.5/Dockerfile
@@ -1,0 +1,9 @@
+FROM redhat/ubi9:9.5@sha256:38791b293262ac2169eca2717e68e626a047d2b89fbd1da544db24ed0204efeb
+
+COPY fleet-osquery_amd64.rpm /
+COPY run-fleetd.sh /
+RUN chmod +x /run-fleetd.sh
+
+RUN dnf install --assumeyes /fleet-osquery_amd64.rpm
+
+ENTRYPOINT ["/run-fleetd.sh"]

--- a/tools/fleetd-linux/redhat-9.5/Dockerfile
+++ b/tools/fleetd-linux/redhat-9.5/Dockerfile
@@ -1,4 +1,4 @@
-FROM redhat/ubi9:9.5@sha256:38791b293262ac2169eca2717e68e626a047d2b89fbd1da544db24ed0204efeb
+FROM redhat/ubi9:9.5
 
 COPY fleet-osquery_amd64.rpm /
 COPY run-fleetd.sh /

--- a/tools/fleetd-linux/run-fleetd.sh
+++ b/tools/fleetd-linux/run-fleetd.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+sed -i "s/placeholder/${ENROLL_SECRET}/g" /etc/default/orbit
+export $(cat /etc/default/orbit | xargs)
+
+while true; do
+	echo "Starting orbit..."
+	/opt/orbit/bin/orbit/orbit
+	echo "orbit exit code: $?"
+	sleep 5
+done

--- a/tools/fleetd-linux/ubuntu-24.04/Dockerfile
+++ b/tools/fleetd-linux/ubuntu-24.04/Dockerfile
@@ -1,0 +1,11 @@
+FROM ubuntu:24.04@sha256:80dd3c3b9c6cecb9f1667e9290b3bc61b78c2678c02cbdae5f0fea92cc6734ab
+
+COPY fleet-osquery_amd64.deb /
+COPY run-fleetd.sh /
+RUN chmod +x /run-fleetd.sh
+
+RUN apt-get update && apt-get install -y ca-certificates
+
+RUN dpkg --install /fleet-osquery_amd64.deb
+
+ENTRYPOINT ["/run-fleetd.sh"]

--- a/tools/fleetd-linux/ubuntu-24.04/Dockerfile
+++ b/tools/fleetd-linux/ubuntu-24.04/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:24.04@sha256:80dd3c3b9c6cecb9f1667e9290b3bc61b78c2678c02cbdae5f0fea92cc6734ab
+FROM ubuntu:24.04
 
 COPY fleet-osquery_amd64.deb /
 COPY run-fleetd.sh /


### PR DESCRIPTION
Useful while testing/developing #24385.

In the future we can push some of these to Fleet's Docker Hub and include them in `fleetctl preview` to allow demoing of e.g. script execution on linux devices.