### PR TITLE
UI: Never show Software Details Modal > 'Install details' tab on My device page

### DIFF
--- a/frontend/pages/hosts/details/DeviceUserPage/DeviceUserPage.tsx
+++ b/frontend/pages/hosts/details/DeviceUserPage/DeviceUserPage.tsx
@@ -520,6 +520,7 @@ const DeviceUserPage = ({
             hostDisplayName={host.display_name}
             software={selectedSoftwareDetails}
             onExit={() => setSelectedSoftwareDetails(null)}
+            isMyDevicePage
           />
         )}
       </div>

--- a/frontend/pages/hosts/details/DeviceUserPage/DeviceUserPage.tsx
+++ b/frontend/pages/hosts/details/DeviceUserPage/DeviceUserPage.tsx
@@ -520,7 +520,7 @@ const DeviceUserPage = ({
             hostDisplayName={host.display_name}
             software={selectedSoftwareDetails}
             onExit={() => setSelectedSoftwareDetails(null)}
-            isMyDevicePage
+            hideInstallDetails
           />
         )}
       </div>

--- a/frontend/pages/hosts/details/cards/Software/SoftwareDetailsModal/SoftwareDetailsModal.tsx
+++ b/frontend/pages/hosts/details/cards/Software/SoftwareDetailsModal/SoftwareDetailsModal.tsx
@@ -94,6 +94,7 @@ interface ISoftwareDetailsModalProps {
   hostDisplayName: string;
   software: IHostSoftware;
   onExit: () => void;
+  isMyDevicePage?: boolean;
 }
 
 const SoftwareDetailsContent = ({
@@ -190,6 +191,7 @@ const TabsContent = ({
 const SoftwareDetailsModal = ({
   hostDisplayName,
   software,
+  isMyDevicePage = false,
   onExit,
 }: ISoftwareDetailsModalProps) => {
   const hasLastInstall =
@@ -198,10 +200,10 @@ const SoftwareDetailsModal = ({
   return (
     <Modal title={software.name} className={baseClass} onExit={onExit}>
       <>
-        {!hasLastInstall ? (
-          <SoftwareDetailsContent software={software} />
-        ) : (
+        {hasLastInstall && !isMyDevicePage ? (
           <TabsContent hostDisplayName={hostDisplayName} software={software} />
+        ) : (
+          <SoftwareDetailsContent software={software} />
         )}
         <div className="modal-cta-wrap">
           <Button type="submit" variant="brand" onClick={onExit}>

--- a/frontend/pages/hosts/details/cards/Software/SoftwareDetailsModal/SoftwareDetailsModal.tsx
+++ b/frontend/pages/hosts/details/cards/Software/SoftwareDetailsModal/SoftwareDetailsModal.tsx
@@ -94,7 +94,8 @@ interface ISoftwareDetailsModalProps {
   hostDisplayName: string;
   software: IHostSoftware;
   onExit: () => void;
-  isMyDevicePage?: boolean;
+  // install details will not be shown if Fleet doesn't have them, regardless of this setting
+  hideInstallDetails?: boolean;
 }
 
 const SoftwareDetailsContent = ({
@@ -191,7 +192,7 @@ const TabsContent = ({
 const SoftwareDetailsModal = ({
   hostDisplayName,
   software,
-  isMyDevicePage = false,
+  hideInstallDetails = false,
   onExit,
 }: ISoftwareDetailsModalProps) => {
   const hasLastInstall =
@@ -200,7 +201,7 @@ const SoftwareDetailsModal = ({
   return (
     <Modal title={software.name} className={baseClass} onExit={onExit}>
       <>
-        {hasLastInstall && !isMyDevicePage ? (
+        {hasLastInstall && !hideInstallDetails ? (
           <TabsContent hostDisplayName={hostDisplayName} software={software} />
         ) : (
           <SoftwareDetailsContent software={software} />


### PR DESCRIPTION
## Follow up for #23315

Since the `results` endpoint that the "Install details" tab for this modal currently doesn't support device authentication (see below), only show that tab on the host details page. Since the [original request](https://github.com/fleetdm/fleet/issues/23252) for this feature is for the "end user to be able to see the file path at which vulnerable software is installed", delivering this work without the "Install details" tab will still provide immediate value.

Once product weighs in on wether or not to include the Install details tab here as well (requires opening up the `results` endpoint for device authenticated requests), can add that functionality in a future iteration. Figma for this ticket did not include the tab, so this PR is assuming that's the intended funcitonality.

**Broken install details on My device page:**

<img width="966" alt="Screenshot 2024-12-27 at 12 13 11 PM" src="https://github.com/user-attachments/assets/918ccd61-c792-4196-b348-749fc2839a66" />
 
**Same view with Install details removed:**
<img width="966" alt="Screenshot 2024-12-27 at 12 14 19 PM" src="https://github.com/user-attachments/assets/2507d2df-21cb-4cd0-aaa1-53ad1b113135" />

**Confirmed "Install details" tab still available on host details page:**
<img width="1224" alt="Screenshot 2024-12-27 at 12 21 40 PM" src="https://github.com/user-attachments/assets/1d4631b9-9a61-42ba-8153-f390890b206a" />

- [x] Manual QA for all new/changed functionality