### PR TITLE
UI - Update targeted platforms display logic in the queries table 

### DIFF
--- a/frontend/components/TableContainer/DataTable/PlatformCell/PlatformCell.tests.tsx
+++ b/frontend/components/TableContainer/DataTable/PlatformCell/PlatformCell.tests.tsx
@@ -1,33 +1,55 @@
 import React from "react";
 import { render, screen } from "@testing-library/react";
+
 import { DEFAULT_EMPTY_CELL_VALUE } from "utilities/constants";
 
-import { QueryablePlatform } from "interfaces/platform";
+import { ScheduledQueryablePlatform } from "interfaces/platform";
 import PlatformCell from "./PlatformCell";
 
-const PLATFORMS: QueryablePlatform[] = ["windows", "darwin", "linux", "chrome"];
+const SCHEDULED_QUERYABLE_PLATFORMS: ScheduledQueryablePlatform[] = [
+  "windows",
+  "darwin",
+  "linux",
+];
 
 describe("Platform cell", () => {
   it("renders platform icons in correct order", () => {
-    render(<PlatformCell platforms={PLATFORMS} />);
+    render(
+      <PlatformCell
+        platforms={SCHEDULED_QUERYABLE_PLATFORMS}
+        queryIsScheduled
+      />
+    );
 
     const icons = screen.queryByTestId("icons");
     const appleIcon = screen.queryByTestId("darwin-icon");
     const linuxIcon = screen.queryByTestId("linux-icon");
     const windowsIcon = screen.queryByTestId("windows-icon");
-    const chromeIcon = screen.queryByTestId("chrome-icon");
 
     expect(icons?.firstChild).toBe(appleIcon);
     expect(icons?.firstChild?.nextSibling).toBe(windowsIcon);
     expect(icons?.firstChild?.nextSibling?.nextSibling).toBe(linuxIcon);
-    expect(icons?.firstChild?.nextSibling?.nextSibling?.nextSibling).toBe(
-      chromeIcon
-    );
   });
-  it("renders empty state", () => {
+  it("renders all platforms targeted when no platforms passed in and scheduled", () => {
+    render(<PlatformCell platforms={[]} queryIsScheduled />);
+
+    const icons = screen.queryByTestId("icons");
+    const appleIcon = screen.queryByTestId("darwin-icon");
+    const linuxIcon = screen.queryByTestId("linux-icon");
+    const windowsIcon = screen.queryByTestId("windows-icon");
+
+    expect(icons?.firstChild).toBe(appleIcon);
+    expect(icons?.firstChild?.nextSibling).toBe(windowsIcon);
+    expect(icons?.firstChild?.nextSibling?.nextSibling).toBe(linuxIcon);
+  });
+  it("renders empty cell when not scheduled", () => {
     render(<PlatformCell platforms={[]} />);
 
     const emptyText = screen.queryByText(DEFAULT_EMPTY_CELL_VALUE);
+
+    expect(emptyText).toBeInTheDocument();
+
+    render(<PlatformCell platforms={["darwin"]} />);
 
     expect(emptyText).toBeInTheDocument();
   });

--- a/frontend/components/TableContainer/DataTable/PlatformCell/PlatformCell.tests.tsx
+++ b/frontend/components/TableContainer/DataTable/PlatformCell/PlatformCell.tests.tsx
@@ -14,12 +14,7 @@ const SCHEDULED_QUERYABLE_PLATFORMS: ScheduledQueryablePlatform[] = [
 
 describe("Platform cell", () => {
   it("renders platform icons in correct order", () => {
-    render(
-      <PlatformCell
-        platforms={SCHEDULED_QUERYABLE_PLATFORMS}
-        queryIsScheduled
-      />
-    );
+    render(<PlatformCell platforms={SCHEDULED_QUERYABLE_PLATFORMS} />);
 
     const icons = screen.queryByTestId("icons");
     const appleIcon = screen.queryByTestId("darwin-icon");
@@ -31,7 +26,7 @@ describe("Platform cell", () => {
     expect(icons?.firstChild?.nextSibling?.nextSibling).toBe(linuxIcon);
   });
   it("renders all platforms targeted when no platforms passed in and scheduled", () => {
-    render(<PlatformCell platforms={[]} queryIsScheduled />);
+    render(<PlatformCell platforms={[]} />);
 
     const icons = screen.queryByTestId("icons");
     const appleIcon = screen.queryByTestId("darwin-icon");
@@ -41,16 +36,5 @@ describe("Platform cell", () => {
     expect(icons?.firstChild).toBe(appleIcon);
     expect(icons?.firstChild?.nextSibling).toBe(windowsIcon);
     expect(icons?.firstChild?.nextSibling?.nextSibling).toBe(linuxIcon);
-  });
-  it("renders empty cell when not scheduled", () => {
-    render(<PlatformCell platforms={[]} />);
-
-    const emptyText = screen.queryByText(DEFAULT_EMPTY_CELL_VALUE);
-
-    expect(emptyText).toBeInTheDocument();
-
-    render(<PlatformCell platforms={["darwin"]} />);
-
-    expect(emptyText).toBeInTheDocument();
   });
 });

--- a/frontend/components/TableContainer/DataTable/PlatformCell/PlatformCell.tsx
+++ b/frontend/components/TableContainer/DataTable/PlatformCell/PlatformCell.tsx
@@ -21,32 +21,24 @@ const DISPLAY_ORDER: QueryablePlatform[] = [
   "windows",
   "linux",
   "chrome",
-  // "None",
-  // "Invalid query",
 ];
 
 const PlatformCell = ({ platforms }: IPlatformCellProps): JSX.Element => {
-  const orderedList = DISPLAY_ORDER.filter((platform) =>
-    platforms.includes(platform)
-  );
+  const orderedList = platforms.length
+    ? DISPLAY_ORDER.filter((platform) => platforms.includes(platform))
+    : DISPLAY_ORDER;
   return (
     <span className={`${baseClass}__wrapper`} data-testid="icons">
-      {orderedList.length ? (
-        orderedList.map((platform) => {
-          return ICONS[platform] ? (
-            <Icon
-              className={`${baseClass}__icon`}
-              name={ICONS[platform]}
-              size="small"
-              key={ICONS[platform]}
-            />
-          ) : null;
-        })
-      ) : (
-        <span className={`${baseClass}__muted`}>
-          {DEFAULT_EMPTY_CELL_VALUE}
-        </span>
-      )}
+      {orderedList.map((platform) => {
+        return ICONS[platform] ? (
+          <Icon
+            className={`${baseClass}__icon`}
+            name={ICONS[platform]}
+            size="small"
+            key={ICONS[platform]}
+          />
+        ) : null;
+      })}
     </span>
   );
 };

--- a/frontend/components/TableContainer/DataTable/PlatformCell/PlatformCell.tsx
+++ b/frontend/components/TableContainer/DataTable/PlatformCell/PlatformCell.tsx
@@ -1,11 +1,9 @@
 import React from "react";
 import Icon from "components/Icon";
 import { ScheduledQueryablePlatform } from "interfaces/platform";
-import { DEFAULT_EMPTY_CELL_VALUE } from "utilities/constants";
 
 interface IPlatformCellProps {
   platforms: ScheduledQueryablePlatform[];
-  queryIsScheduled?: boolean;
 }
 
 const baseClass = "platform-cell";
@@ -22,35 +20,24 @@ const DISPLAY_ORDER: ScheduledQueryablePlatform[] = [
   "linux",
 ];
 
-const PlatformCell = ({
-  platforms,
-  queryIsScheduled = false,
-}: IPlatformCellProps): JSX.Element => {
+const PlatformCell = ({ platforms }: IPlatformCellProps): JSX.Element => {
   let orderedList: ScheduledQueryablePlatform[] = [];
-  if (queryIsScheduled) {
-    orderedList = platforms.length
-      ? // if no platforms, interpret as targeting all schedule-targetable platforms
-        DISPLAY_ORDER.filter((platform) => platforms.includes(platform))
-      : DISPLAY_ORDER;
-  }
+  orderedList = platforms.length
+    ? // if no platforms, interpret as targeting all schedule-targetable platforms
+      DISPLAY_ORDER.filter((platform) => platforms.includes(platform))
+    : DISPLAY_ORDER;
   return (
     <span className={`${baseClass}__wrapper`} data-testid="icons">
-      {orderedList.length ? (
-        orderedList.map((platform) => {
-          return ICONS[platform] ? (
-            <Icon
-              className={`${baseClass}__icon`}
-              name={ICONS[platform]}
-              size="small"
-              key={ICONS[platform]}
-            />
-          ) : null;
-        })
-      ) : (
-        <span className={`${baseClass}__muted`}>
-          {DEFAULT_EMPTY_CELL_VALUE}
-        </span>
-      )}
+      {orderedList.map((platform) => {
+        return ICONS[platform] ? (
+          <Icon
+            className={`${baseClass}__icon`}
+            name={ICONS[platform]}
+            size="small"
+            key={ICONS[platform]}
+          />
+        ) : null;
+      })}
     </span>
   );
 };

--- a/frontend/components/TableContainer/DataTable/PlatformCell/PlatformCell.tsx
+++ b/frontend/components/TableContainer/DataTable/PlatformCell/PlatformCell.tsx
@@ -1,44 +1,56 @@
 import React from "react";
 import Icon from "components/Icon";
-import { QueryablePlatform } from "interfaces/platform";
+import { ScheduledQueryablePlatform } from "interfaces/platform";
 import { DEFAULT_EMPTY_CELL_VALUE } from "utilities/constants";
 
 interface IPlatformCellProps {
-  platforms: QueryablePlatform[];
+  platforms: ScheduledQueryablePlatform[];
+  queryIsScheduled?: boolean;
 }
 
 const baseClass = "platform-cell";
 
-const ICONS: Record<string, QueryablePlatform> = {
+const ICONS: Record<string, ScheduledQueryablePlatform> = {
   darwin: "darwin",
   windows: "windows",
   linux: "linux",
-  chrome: "chrome",
 };
 
-const DISPLAY_ORDER: QueryablePlatform[] = [
+const DISPLAY_ORDER: ScheduledQueryablePlatform[] = [
   "darwin",
   "windows",
   "linux",
-  "chrome",
 ];
 
-const PlatformCell = ({ platforms }: IPlatformCellProps): JSX.Element => {
-  const orderedList = platforms.length
-    ? DISPLAY_ORDER.filter((platform) => platforms.includes(platform))
-    : DISPLAY_ORDER;
+const PlatformCell = ({
+  platforms,
+  queryIsScheduled = false,
+}: IPlatformCellProps): JSX.Element => {
+  let orderedList: ScheduledQueryablePlatform[] = [];
+  if (queryIsScheduled) {
+    orderedList = platforms.length
+      ? // if no platforms, interpret as targeting all schedule-targetable platforms
+        DISPLAY_ORDER.filter((platform) => platforms.includes(platform))
+      : DISPLAY_ORDER;
+  }
   return (
     <span className={`${baseClass}__wrapper`} data-testid="icons">
-      {orderedList.map((platform) => {
-        return ICONS[platform] ? (
-          <Icon
-            className={`${baseClass}__icon`}
-            name={ICONS[platform]}
-            size="small"
-            key={ICONS[platform]}
-          />
-        ) : null;
-      })}
+      {orderedList.length ? (
+        orderedList.map((platform) => {
+          return ICONS[platform] ? (
+            <Icon
+              className={`${baseClass}__icon`}
+              name={ICONS[platform]}
+              size="small"
+              key={ICONS[platform]}
+            />
+          ) : null;
+        })
+      ) : (
+        <span className={`${baseClass}__muted`}>
+          {DEFAULT_EMPTY_CELL_VALUE}
+        </span>
+      )}
     </span>
   );
 };

--- a/frontend/interfaces/platform.ts
+++ b/frontend/interfaces/platform.ts
@@ -20,6 +20,7 @@ export type QueryableDisplayPlatform = Exclude<
   DisplayPlatform,
   "iOS" | "iPadOS"
 >;
+
 export type QueryablePlatform = Exclude<Platform, "ios" | "ipados">;
 
 export const QUERYABLE_PLATFORMS: QueryablePlatform[] = [
@@ -33,6 +34,21 @@ export const isQueryablePlatform = (
   platform: string | undefined
 ): platform is QueryablePlatform =>
   QUERYABLE_PLATFORMS.includes(platform as QueryablePlatform);
+
+export const SCHEDULED_QUERYABLE_PLATFORMS: ScheduledQueryablePlatform[] = [
+  "darwin",
+  "windows",
+  "linux",
+];
+
+export type ScheduledQueryablePlatform = Exclude<QueryablePlatform, "chrome">;
+
+export const isScheduledQueryablePlatform = (
+  platform: string | undefined
+): platform is ScheduledQueryablePlatform =>
+  SCHEDULED_QUERYABLE_PLATFORMS.includes(
+    platform as ScheduledQueryablePlatform
+  );
 
 // TODO - add "iOS" and "iPadOS" once we support them
 export const VULN_SUPPORTED_PLATFORMS: Platform[] = ["darwin", "windows"];

--- a/frontend/pages/queries/ManageQueriesPage/components/QueriesTable/QueriesTableConfig.tsx
+++ b/frontend/pages/queries/ManageQueriesPage/components/QueriesTable/QueriesTableConfig.tsx
@@ -189,6 +189,10 @@ const generateTableHeaders = ({
       disableSortBy: true,
       accessor: "platform",
       Cell: (cellProps: IPlatformCellProps): JSX.Element => {
+        if (!cellProps.row.original.interval) {
+          // if the query isn't scheduled to run, return default empty call
+          return <TextCell />;
+        }
         const platforms = cellProps.cell.value
           .split(",")
           .map((s) => s.trim())
@@ -197,12 +201,7 @@ const generateTableHeaders = ({
           .filter((s) =>
             isScheduledQueryablePlatform(s)
           ) as ScheduledQueryablePlatform[];
-        return (
-          <PlatformCell
-            platforms={platforms}
-            queryIsScheduled={!!cellProps.row.original.interval}
-          />
-        );
+        return <PlatformCell platforms={platforms} />;
       },
     },
     {

--- a/frontend/pages/queries/ManageQueriesPage/components/QueriesTable/QueriesTableConfig.tsx
+++ b/frontend/pages/queries/ManageQueriesPage/components/QueriesTable/QueriesTableConfig.tsx
@@ -13,8 +13,8 @@ import {
   ISchedulableQuery,
 } from "interfaces/schedulable_query";
 import {
-  isQueryablePlatform,
-  QueryablePlatform,
+  isScheduledQueryablePlatform,
+  ScheduledQueryablePlatform,
   SelectedPlatformString,
 } from "interfaces/platform";
 import { API_ALL_TEAMS_ID } from "interfaces/team";
@@ -194,8 +194,15 @@ const generateTableHeaders = ({
           .map((s) => s.trim())
           // this casting is necessary because make generate for some reason doesn't recognize the
           // type guarding of `isQueryablePlatform` even though the language server in VSCode does
-          .filter((s) => isQueryablePlatform(s)) as QueryablePlatform[];
-        return <PlatformCell platforms={platforms} />;
+          .filter((s) =>
+            isScheduledQueryablePlatform(s)
+          ) as ScheduledQueryablePlatform[];
+        return (
+          <PlatformCell
+            platforms={platforms}
+            queryIsScheduled={!!cellProps.row.original.interval}
+          />
+        );
       },
     },
     {


### PR DESCRIPTION
### Unreleased bug where queries targeting all platforms display as targeting no platforms in the Queries table.

The below query is set to target _all_ platforms.

**Bug:**
<img width="1248" alt="Screenshot 2024-12-29 at 8 24 50 PM" src="https://github.com/user-attachments/assets/90c9a498-f7d8-4d86-88f1-061c985fb4fa" />

**Fix:**
Targeting all platforms, frequency set, displays platform icons:
<img width="1248" alt="Screenshot 2024-12-29 at 8 25 25 PM" src="https://github.com/user-attachments/assets/d03c1bba-e5ea-461a-b506-1840cf4ffa8e" />

Targeting all paltforms but no frequency set (i.e., no schedule), no targeted platforms displayed:
<img width="1248" alt="Screenshot 2024-12-29 at 8 25 38 PM" src="https://github.com/user-attachments/assets/9b08a8c3-b682-4eb0-aeb4-59a6e0144e14" />

- [x] Manual QA for all new/changed functionality
- [x] Updated tests 