### PR TITLE
UI - Refactor to TooltipWrapper and add offset to the tooltips on hover of the profile aggregate status indicators

### DIFF
--- a/changes/25038-fix-profile-status-aggregate-tooltips-spacing
+++ b/changes/25038-fix-profile-status-aggregate-tooltips-spacing
@@ -1,0 +1,1 @@
+* Add offset to the tooltips on hover of the profile aggregate status indicators.

--- a/frontend/components/StatusIndicatorWithIcon/StatusIndicatorWithIcon.tsx
+++ b/frontend/components/StatusIndicatorWithIcon/StatusIndicatorWithIcon.tsx
@@ -1,11 +1,9 @@
 import React from "react";
-import ReactTooltip from "react-tooltip";
-import { uniqueId } from "lodash";
 import classnames from "classnames";
 
 import { IconNames } from "components/icons";
 import Icon from "components/Icon";
-import { COLORS } from "styles/var/colors";
+import TooltipWrapper from "components/TooltipWrapper";
 
 const baseClass = "status-indicator-with-icon";
 
@@ -46,7 +44,6 @@ const StatusIndicatorWithIcon = ({
   valueClassName,
 }: IStatusIndicatorWithIconProps) => {
   const classNames = classnames(baseClass, className);
-  const id = `status-${uniqueId()}`;
 
   const valueClasses = classnames(`${baseClass}__value`, valueClassName, {
     [`${baseClass}__value-vertical`]: layout === "vertical",
@@ -59,21 +56,30 @@ const StatusIndicatorWithIcon = ({
   );
 
   const indicatorContent = tooltip ? (
-    <>
-      <span data-tip data-for={id}>
-        {valueContent}
-      </span>
-      <ReactTooltip
-        className={`${baseClass}__tooltip`}
-        place={tooltip?.position ? tooltip.position : "top"}
-        type="dark"
-        effect="solid"
-        id={id}
-        backgroundColor={COLORS["tooltip-bg"]}
-      >
-        {tooltip.tooltipText}
-      </ReactTooltip>
-    </>
+    // <>
+    /* <div data-tooltip-id={id}>{valueContent}</div> */
+    // {/* <ReactTooltip
+    // className={`${baseClass}__tooltip`}
+    //   place={tooltip?.position ? tooltip.position : "top"}
+    //   type="dark"
+    //   effect="solid"
+    //   id={id}
+    //   backgroundColor={COLORS["tooltip-bg"]}
+    // > */
+    // {tooltip.tooltipText}
+    // </>
+    <TooltipWrapper
+      className={`${baseClass}__tooltip`}
+      tooltipClass="indicator-tip-text"
+      position="top"
+      tipContent={tooltip.tooltipText}
+      tipOffset={10}
+      showArrow
+      underline={false}
+      fixedPositionStrategy
+    >
+      {valueContent}
+    </TooltipWrapper>
   ) : (
     <span>{valueContent}</span>
   );

--- a/frontend/components/StatusIndicatorWithIcon/StatusIndicatorWithIcon.tsx
+++ b/frontend/components/StatusIndicatorWithIcon/StatusIndicatorWithIcon.tsx
@@ -56,18 +56,6 @@ const StatusIndicatorWithIcon = ({
   );
 
   const indicatorContent = tooltip ? (
-    // <>
-    /* <div data-tooltip-id={id}>{valueContent}</div> */
-    // {/* <ReactTooltip
-    // className={`${baseClass}__tooltip`}
-    //   place={tooltip?.position ? tooltip.position : "top"}
-    //   type="dark"
-    //   effect="solid"
-    //   id={id}
-    //   backgroundColor={COLORS["tooltip-bg"]}
-    // > */
-    // {tooltip.tooltipText}
-    // </>
     <TooltipWrapper
       className={`${baseClass}__tooltip`}
       tooltipClass="indicator-tip-text"

--- a/frontend/components/StatusIndicatorWithIcon/_styles.scss
+++ b/frontend/components/StatusIndicatorWithIcon/_styles.scss
@@ -19,4 +19,8 @@
     flex-direction: column;
     gap: $pad-xsmall;
   }
+
+  .indicator-tip-text {
+    text-align: center;
+  }
 }

--- a/frontend/pages/ManageControlsPage/OSSettings/ProfileStatusAggregate/_styles.scss
+++ b/frontend/pages/ManageControlsPage/OSSettings/ProfileStatusAggregate/_styles.scss
@@ -42,4 +42,8 @@
   &__status-indicator-value {
     font-weight: $bold;
   }
+
+  .icon {
+    margin-right: initial;
+  }
 }


### PR DESCRIPTION
## #25038 

Refactor to TooltipWrapper and add offset to the tooltips on hover of the profile aggregate status indicators.

<img width="1345" alt="Screenshot 2024-12-29 at 9 00 38 PM" src="https://github.com/user-attachments/assets/3bf5cf3c-e9fc-47dc-aa07-9cef42edcae0" />

- [x] Changes file added for user-visible changes in `changes/`, 
- [x] Manual QA for all new/changed functionality