### PR TITLE
Improve secret variables error on software upload.

### DIFF
--- a/ee/server/service/maintained_apps.go
+++ b/ee/server/service/maintained_apps.go
@@ -46,14 +46,12 @@ func (svc *Service) AddFleetMaintainedApp(
 	if err := svc.ds.ValidateEmbeddedSecrets(ctx, []string{installScript, postInstallScript, uninstallScript}); err != nil {
 		// We redo the validation on each script to find out which script has the missing secret.
 		// This is done to provide a more informative error message to the UI user.
-		if errInstallScript := svc.ds.ValidateEmbeddedSecrets(ctx, []string{installScript}); errInstallScript != nil {
-			return 0, fleet.NewInvalidArgumentError("install script", errInstallScript.Error())
-		}
-		if errPostInstallScript := svc.ds.ValidateEmbeddedSecrets(ctx, []string{postInstallScript}); errPostInstallScript != nil {
-			return 0, fleet.NewInvalidArgumentError("post-install script", errPostInstallScript.Error())
-		}
-		if errUninstallScript := svc.ds.ValidateEmbeddedSecrets(ctx, []string{uninstallScript}); errUninstallScript != nil {
-			return 0, fleet.NewInvalidArgumentError("uninstall script", errUninstallScript.Error())
+		var argErr *fleet.InvalidArgumentError
+		argErr = svc.validateEmbeddedSecretsOnScript(ctx, "install script", &installScript, argErr)
+		argErr = svc.validateEmbeddedSecretsOnScript(ctx, "post-install script", &postInstallScript, argErr)
+		argErr = svc.validateEmbeddedSecretsOnScript(ctx, "uninstall script", &uninstallScript, argErr)
+		if argErr != nil {
+			return 0, argErr
 		}
 		// We should not get to this point. If we did, it means we have another issue, such as large read replica latency.
 		return 0, ctxerr.Wrap(ctx, err, "transient server issue validating embedded secrets")

--- a/server/service/base_client_errors.go
+++ b/server/service/base_client_errors.go
@@ -104,17 +104,24 @@ type serverError struct {
 }
 
 func extractServerErrorText(body io.Reader) string {
+	_, reason := extractServerErrorNameReason(body)
+	return reason
+}
+
+func extractServerErrorNameReason(body io.Reader) (string, string) {
 	var serverErr serverError
 	if err := json.NewDecoder(body).Decode(&serverErr); err != nil {
-		return "unknown"
+		return "", "unknown"
 	}
 
-	errText := serverErr.Message
+	errName := ""
+	errReason := serverErr.Message
 	if len(serverErr.Errors) > 0 {
-		errText += ": " + serverErr.Errors[0].Reason
+		errReason += ": " + serverErr.Errors[0].Reason
+		errName = serverErr.Errors[0].Name
 	}
 
-	return errText
+	return errName, errReason
 }
 
 type statusCodeErr struct {

--- a/server/service/base_client_errors.go
+++ b/server/service/base_client_errors.go
@@ -124,6 +124,22 @@ func extractServerErrorNameReason(body io.Reader) (string, string) {
 	return errName, errReason
 }
 
+func extractServerErrorNameReasons(body io.Reader) ([]string, []string) {
+	var serverErr serverError
+	if err := json.NewDecoder(body).Decode(&serverErr); err != nil {
+		return []string{""}, []string{"unknown"}
+	}
+
+	var errName []string
+	var errReason []string
+	for _, err := range serverErr.Errors {
+		errName = append(errName, err.Name)
+		errReason = append(errReason, err.Reason)
+	}
+
+	return errName, errReason
+}
+
 type statusCodeErr struct {
 	code int
 	body string

--- a/server/service/integration_enterprise_test.go
+++ b/server/service/integration_enterprise_test.go
@@ -8930,7 +8930,8 @@ func (s *integrationEnterpriseTestSuite) TestAllSoftwareTitles() {
 		PostInstallScript: "d",
 		SelfService:       true,
 	}
-	s.uploadSoftwareInstaller(t, payloadEmacsMissingSecret, http.StatusUnprocessableEntity, "$FLEET_SECRET_INVALID")
+	s.uploadSoftwareInstallerWithErrorNameReason(t, payloadEmacsMissingSecret, http.StatusUnprocessableEntity, "$FLEET_SECRET_INVALID",
+		"install script")
 
 	payloadEmacsMissingPostSecret := &fleet.UploadSoftwareInstallerPayload{
 		InstallScript:     "install",
@@ -8938,7 +8939,8 @@ func (s *integrationEnterpriseTestSuite) TestAllSoftwareTitles() {
 		PostInstallScript: "d $FLEET_SECRET_INVALID",
 		SelfService:       true,
 	}
-	s.uploadSoftwareInstaller(t, payloadEmacsMissingPostSecret, http.StatusUnprocessableEntity, "$FLEET_SECRET_INVALID")
+	s.uploadSoftwareInstallerWithErrorNameReason(t, payloadEmacsMissingPostSecret, http.StatusUnprocessableEntity, "$FLEET_SECRET_INVALID",
+		"post-install script")
 
 	payloadEmacsMissingUnSecret := &fleet.UploadSoftwareInstallerPayload{
 		InstallScript:     "install",
@@ -8947,7 +8949,8 @@ func (s *integrationEnterpriseTestSuite) TestAllSoftwareTitles() {
 		UninstallScript:   "delet $FLEET_SECRET_INVALID",
 		SelfService:       true,
 	}
-	s.uploadSoftwareInstaller(t, payloadEmacsMissingUnSecret, http.StatusUnprocessableEntity, "$FLEET_SECRET_INVALID")
+	s.uploadSoftwareInstallerWithErrorNameReason(t, payloadEmacsMissingUnSecret, http.StatusUnprocessableEntity, "$FLEET_SECRET_INVALID",
+		"uninstall script")
 
 	payloadEmacs := &fleet.UploadSoftwareInstallerPayload{
 		InstallScript: "install",
@@ -15943,10 +15946,37 @@ func (s *integrationEnterpriseTestSuite) TestMaintainedApps() {
 		UninstallScript:   "echo $FLEET_SECRET_INVALID3",
 	}
 	respBadSecret := s.Do("POST", "/api/latest/fleet/software/fleet_maintained_apps", reqInvalidSecret, http.StatusUnprocessableEntity)
-	errMsg := extractServerErrorText(respBadSecret.Body)
-	require.Contains(t, errMsg, "$FLEET_SECRET_INVALID1")
-	require.Contains(t, errMsg, "$FLEET_SECRET_INVALID2")
-	require.Contains(t, errMsg, "$FLEET_SECRET_INVALID3")
+	errName, errMsg := extractServerErrorNameReason(respBadSecret.Body)
+	assert.Equal(t, "install script", errName)
+	assert.Contains(t, errMsg, "$FLEET_SECRET_INVALID1")
+
+	reqInvalidSecret = &addFleetMaintainedAppRequest{
+		AppID:             1,
+		TeamID:            &team.ID,
+		SelfService:       true,
+		PreInstallQuery:   "SELECT 1",
+		InstallScript:     "echo foo",
+		PostInstallScript: "echo done $FLEET_SECRET_INVALID2",
+		UninstallScript:   "echo $FLEET_SECRET_INVALID3",
+	}
+	respBadSecret = s.Do("POST", "/api/latest/fleet/software/fleet_maintained_apps", reqInvalidSecret, http.StatusUnprocessableEntity)
+	errName, errMsg = extractServerErrorNameReason(respBadSecret.Body)
+	assert.Equal(t, "post-install script", errName)
+	assert.Contains(t, errMsg, "$FLEET_SECRET_INVALID2")
+
+	reqInvalidSecret = &addFleetMaintainedAppRequest{
+		AppID:             1,
+		TeamID:            &team.ID,
+		SelfService:       true,
+		PreInstallQuery:   "SELECT 1",
+		InstallScript:     "echo foo",
+		PostInstallScript: "echo done",
+		UninstallScript:   "echo $FLEET_SECRET_INVALID3",
+	}
+	respBadSecret = s.Do("POST", "/api/latest/fleet/software/fleet_maintained_apps", reqInvalidSecret, http.StatusUnprocessableEntity)
+	errName, errMsg = extractServerErrorNameReason(respBadSecret.Body)
+	assert.Equal(t, "uninstall script", errName)
+	assert.Contains(t, errMsg, "$FLEET_SECRET_INVALID3")
 
 	// Add an ingested app to the team
 	var addMAResp addFleetMaintainedAppResponse


### PR DESCRIPTION
#24899
Better errors when secret variables used in software scripts are missing in the database. The `name` field indicates which script has the issue.
```
{
  "message": "Validation Failed",
  "errors": [
    {
      "name": "install script",
      "reason": "Couldn't add. Secret variables \"$FLEET_SECRET_INVALID1\", \"$FLEET_SECRET_INVALID0\" missing from database"
    },
    {
      "name": "post-install script",
      "reason": "Couldn't add. Secret variable \"$FLEET_SECRET_INVALID2\" missing from database"
    },
    {
      "name": "uninstall script",
      "reason": "Couldn't add. Secret variable \"$FLEET_SECRET_INVALID3\" missing from database"
    }
  ],
  "uuid": "49d671dc-636a-4966-ba2a-c159302f0f5c"
}
```

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Added/updated tests
- [x] Manual QA for all new/changed functionality
