### PR TITLE
Add "should have a QA plan on the associated ticket" to PR checklist

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,13 +8,14 @@ If some of the following don't apply, delete the relevant line.
   See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/Committing-Changes.md#changes-files) for more information.
 - [ ] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
 - [ ] Added support on fleet's osquery simulator `cmd/osquery-perf` for new osquery data ingestion features.
-- [ ] Added/updated tests
 - [ ] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes
 - [ ] If database migrations are included, checked table schema to confirm autoupdate
 - For database migrations:
   - [ ] Checked schema for all modified table for columns that will auto-update timestamps during migration.
   - [ ] Confirmed that updating the timestamps is acceptable, and will not cause unwanted side effects.
   - [ ] Ensured the correct collation is explicitly set for character columns (`COLLATE utf8mb4_unicode_ci`).
+- [ ] Added/updated automated tests
+- [ ] A detailed QA plan exists on the associated ticket (if it isn't there, add it)
 - [ ] Manual QA for all new/changed functionality
 - For Orbit and Fleet Desktop changes:
    - [ ] Orbit runs on macOS, Linux and Windows. Check if the orbit feature/bugfix should only apply to one platform (`runtime.GOOS`).

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -15,7 +15,7 @@ If some of the following don't apply, delete the relevant line.
   - [ ] Confirmed that updating the timestamps is acceptable, and will not cause unwanted side effects.
   - [ ] Ensured the correct collation is explicitly set for character columns (`COLLATE utf8mb4_unicode_ci`).
 - [ ] Added/updated automated tests
-- [ ] A detailed QA plan exists on the associated ticket (if it isn't there, add it)
+- [ ] A detailed QA plan exists on the associated ticket (if it isn't there, work with the product group's QA engineer to add it)
 - [ ] Manual QA for all new/changed functionality
 - For Orbit and Fleet Desktop changes:
    - [ ] Orbit runs on macOS, Linux and Windows. Check if the orbit feature/bugfix should only apply to one platform (`runtime.GOOS`).


### PR DESCRIPTION
Ideally we have a "to QA" section of a ticket prior to the PR being built, but there are plenty of tickets that get all the way to merged to `main` without having a clear QA plan, so QA has to hunt down engineers to get a proper QA plan some time after merge (which may be after the engineer has lost context on the ticket).

Having the (as-needed, just like other items in the list) checkbox on PRs nudges engineers to ensure we have a QA plan on the code they have context on at the time, including on bugs (and the bug template intentionally doesn't include expected behavior to reduce friction in reporting bugs).