### PR TITLE
Fix verify fleetd-base files > verify-fleetd-base-msi powershell script

### DIFF
--- a/.github/workflows/verify-fleetd-base.yml
+++ b/.github/workflows/verify-fleetd-base.yml
@@ -114,9 +114,7 @@ jobs:
           Start-Sleep -Seconds 5
           cd "C:\Windows\System32\config\systemprofile\AppData\Local\FleetDM\Orbit\Logs"
           Get-ChildItem
-          if (!(Test-Path
-          "C:\Windows\System32\config\systemprofile\AppData\Local\FleetDM\Orbit\Logs\orbit-osquery.log"
-          -PathType Leaf)) { exit 1 }
+          if (!(Test-Path "C:\Windows\System32\config\systemprofile\AppData\Local\FleetDM\Orbit\Logs\orbit-osquery.log" -PathType Leaf)) { exit 1 }
       - name: Slack Notification
         if: failure()
         uses: slackapi/slack-github-action@e28cf165c92ffef168d23c5c9000cffc8a25e117 # v1.24.0

--- a/.prettierignore
+++ b/.prettierignore
@@ -34,3 +34,6 @@ website/
 # certain frontend files that are not meant to be formatted
 frontend/components/FleetAce/mode.ts
 frontend/components/FleetAce/theme.ts
+
+# github workflow yaml, which may contain shell scripts that shouldn't be formatted
+.github/workflows/*


### PR DESCRIPTION
See failed workflow run [here](https://github.com/fleetdm/fleet/actions/runs/12555703803)

- Fix the powershell script that was broken by `.yml` auto-format
- Exclude github workflow `.yml` files from prettier autoformating, since they often contain non-yaml code as part of job definitions

- [ ] Manual QA for all new/changed functionality