### PR TITLE
Fall back to FileVersion when an EXE installer has FileVersion but not ProductVersion

### DIFF
--- a/changes/23541-fileversion-fallback
+++ b/changes/23541-fileversion-fallback
@@ -1,0 +1,1 @@
+* Added fallback to FileVersion on EXE installers when FileVersion is set but ProductVersion isn't to allow more custom packages to be uploaded

--- a/pkg/file/pe.go
+++ b/pkg/file/pe.go
@@ -72,6 +72,8 @@ func ExtractPEMetadata(tfr *fleet.TempFileReader) (*InstallerMetadata, error) {
 		}
 		if productVersion != "" {
 			version = productVersion
+		} else if strings.TrimSpace(e["FileVersion"]) != "" {
+			version = strings.TrimSpace(e["FileVersion"])
 		}
 	}
 	if name == "" && sfxName != "" {


### PR DESCRIPTION
For #23541

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/Committing-Changes.md#changes-files) for more information.
- [x] Manual QA for all new/changed functionality