### PR TITLE
Handle long interned strings in MSI parsing

### DIFF
--- a/changes/24720-msi-large-interned-strings
+++ b/changes/24720-msi-large-interned-strings
@@ -1,0 +1,1 @@
+* Fixed MSI parsing for packages including long interned strings (e.g. licenses for the OpenVPN Connect installer)

--- a/pkg/file/msi.go
+++ b/pkg/file/msi.go
@@ -244,7 +244,7 @@ func decodeStrings(dataReader, poolReader io.Reader) ([]string, error) {
 		}
 		stringEntrySize := int(stringEntry.Size)
 
-		// For string pool entries too long for the size to fit in a single 4-byte entry, we get an 8-byte entry instead,
+		// For string pool entries too long for the size to fit in a single uint16, entry size is 8 bytes instead of 4,
 		// with the first two bytes as zeroes, the next two are the two most-significant bytes of the size, shifted
 		// 17 (?!?) bits to the left, the following two are the less-significant bits of the size, and the last two are
 		// the reference count. Verified with the OpenVPN Connect v3 installer, which has a large string blob for


### PR DESCRIPTION
For #24720. Used https://github.com/ChaelChu/msi-props-reader/blob/master/src/msiPropsReader.ts as inspiration. Not sure why the shift is 17 bits rather than 16 here but confirmed that 17 works and 16 doesn't.

Tested against both existing GDrive MSIs for regression testing, plus the one mentioned in the ticket.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/Committing-Changes.md#changes-files) for more information.
- [x] Manual QA for all new/changed functionality
