### PR TITLE
Cherry-Pick: Include pre-releases when building osquery version list constant

### DIFF
--- a/.github/scripts/update_osquery_versions.py
+++ b/.github/scripts/update_osquery_versions.py
@@ -14,9 +14,8 @@ def fetch_osquery_versions():
     resp = conn.getresponse()
     content = resp.read()
     conn.close()
-    releases = json.loads(content.decode('utf-8'))
 
-    return [release['tag_name'] for release in releases if not release['prerelease']]
+    return [release['tag_name'] for release in json.loads(content.decode('utf-8'))]
 
 def update_min_osquery_version_options(new_versions):
     with open(FILE_PATH, 'r') as file:

--- a/changes/osquery-constant-prerelease
+++ b/changes/osquery-constant-prerelease
@@ -1,0 +1,1 @@
+* Included osquery pre-releases in daily UI constant update GitHub Actions job

--- a/frontend/utilities/constants.tsx
+++ b/frontend/utilities/constants.tsx
@@ -84,6 +84,7 @@ export const MAX_OSQUERY_SCHEDULED_QUERY_INTERVAL = 604800;
 
 export const MIN_OSQUERY_VERSION_OPTIONS = [
   { label: "All", value: "" },
+  { label: "5.15.0 +", value: "5.15.0" },
   { label: "5.14.1 +", value: "5.14.1" },
   { label: "5.13.1 +", value: "5.13.1" },
   { label: "5.12.2 +", value: "5.12.2" },


### PR DESCRIPTION
Merged into `main` as #25089. Cherry-picking to get the constant update for osquery 5.15.0 into 4.62.0.