### PR TITLE
Cherry-Pick: Ignore CVE-2024-10327 since it's iOS-only

### DIFF
--- a/changes/25075-false-positive
+++ b/changes/25075-false-positive
@@ -1,0 +1,1 @@
+* Fixed CVE-2024-10327 false positive on Fleet-supported platforms (vuln is iOS-only and iOS vuln checking is not supported)

--- a/server/vulnerabilities/nvd/cpe_matching_rules.go
+++ b/server/vulnerabilities/nvd/cpe_matching_rules.go
@@ -249,8 +249,14 @@ func GetKnownNVDBugRules() (CPEMatchingRules, error) {
 				return cpeMeta.TargetSW != "windows"
 			},
 		},
-		// CVE-2024-10004 only targets iOS, and we don't yet support iOS vuln scanning (and can't tell iOS/Mac CPEs apart yet)
-		CPEMatchingRule{CVEs: map[string]struct{}{"CVE-2024-10004": {}}, IgnoreAll: true},
+		// these CVEs only target iOS, and we don't yet support iOS vuln scanning (and can't tell iOS/Mac CPEs apart yet)
+		CPEMatchingRule{
+			CVEs: map[string]struct{}{
+				"CVE-2024-10004": {},
+				"CVE-2024-10327": {}, // also missing a CPE as of 2025-01-01
+			},
+			IgnoreAll: true,
+		},
 	}
 
 	for i, rule := range rules {

--- a/server/vulnerabilities/nvd/cve_test.go
+++ b/server/vulnerabilities/nvd/cve_test.go
@@ -363,6 +363,10 @@ func TestTranslateCPEToCVE(t *testing.T) {
 			excludedCVEs:      []string{"CVE-2024-10004"},
 			continuesToUpdate: true,
 		},
+		"cpe:2.3:a:okta:verify:9.27.0:*:*:*:*:macos:*:*": {
+			excludedCVEs:      []string{"CVE-2024-10327"},
+			continuesToUpdate: true,
+		},
 	}
 
 	cveOSTests := []struct {


### PR DESCRIPTION
For #25075. Merged into `main` via #25083.