### PR TITLE
Correct fix for long MSI interned strings

### DIFF
--- a/tools/custom-package-parser/main.go
+++ b/tools/custom-package-parser/main.go
@@ -31,8 +31,8 @@ func main() {
 	}
 
 	fmt.Printf(
-		"- Name: '%s'\n- Bundle Identifier: '%s'\n- Package IDs: '%s'\n",
-		metadata.Name, metadata.BundleIdentifier, strings.Join(metadata.PackageIDs, ","),
+		"- Name: '%s'\n- Bundle Identifier: '%s'\n- Package IDs: '%s'\n- Version: %s\n\n",
+		metadata.Name, metadata.BundleIdentifier, strings.Join(metadata.PackageIDs, ","), metadata.Version,
 	)
 }
 


### PR DESCRIPTION
h/t https://github.com/binref/refinery/issues/72, for #24720. No changes file as this is an unreleased bug.

Also added output for version in the custom package parser tool.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/Committing-Changes.md#changes-files) for more information.
- [x] Manual QA for all new/changed functionality