### PR TITLE
Fleet UI: Fix radio help text font size

### DIFF
--- a/frontend/components/forms/fields/Radio/_styles.scss
+++ b/frontend/components/forms/fields/Radio/_styles.scss
@@ -60,6 +60,7 @@
 
   &__help-text {
     color: $ui-fleet-black-75;
+    font-size: $xx-small;
     margin-top: $pad-xxsmall;
     margin-left: calc(20px + #{$pad-small});
   }

--- a/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareFleetMaintained/FleetMaintainedAppDetailsPage/FleetAppDetailsForm/FleetAppDetailsForm.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareFleetMaintained/FleetMaintainedAppDetailsPage/FleetAppDetailsForm/FleetAppDetailsForm.tsx
@@ -89,7 +89,11 @@ export const InstallTypeSection = ({
           name="install-type"
           label="Manual"
           onChange={onChangeInstallType}
-          helpText="Manually install on Host details page for each host."
+          helpText={
+            <>
+              Manually install on <b>Host details</b> page for each host.
+            </>
+          }
         />
         <Radio
           checked={installType === "automatic"}


### PR DESCRIPTION
## Issue
Cerra #24885 

## Description
- Bold 2 words
- Radio help text font should be 12pt not 14pt, fixed globally

## Screenshot of fix
<img width="959" alt="Screenshot 2025-01-02 at 2 58 17 PM" src="https://github.com/user-attachments/assets/40d3f125-58d0-43a2-bec6-499ec1a79a4c" />

## Change file
- Such a small change, no change file

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

   - [x] Manual QA must be performed in the three main OSs, macOS, Windows and 
