### PR TITLE
Cherry-Pick: Correct fix for long MSI interned strings

### DIFF
--- a/tools/custom-package-parser/main.go
+++ b/tools/custom-package-parser/main.go
@@ -31,8 +31,8 @@ func main() {
 	}
 
 	fmt.Printf(
-		"- Name: '%s'\n- Bundle Identifier: '%s'\n- Package IDs: '%s'\n",
-		metadata.Name, metadata.BundleIdentifier, strings.Join(metadata.PackageIDs, ","),
+		"- Name: '%s'\n- Bundle Identifier: '%s'\n- Package IDs: '%s'\n- Version: %s\n\n",
+		metadata.Name, metadata.BundleIdentifier, strings.Join(metadata.PackageIDs, ","), metadata.Version,
 	)
 }
 


### PR DESCRIPTION
For #24720 unreleased bug, merged to `main` in #25104.