### PR TITLE
Fleet UI: Fix app id link not row id

### DIFF
--- a/changes/23302-fma-click-bug
+++ b/changes/23302-fma-click-bug
@@ -1,0 +1,1 @@
+- Fleet UI: Fix clicking on a fleet maintained app will link to correct app

--- a/changes/23302-fma-click-bug
+++ b/changes/23302-fma-click-bug
@@ -1,1 +1,1 @@
-- Fleet UI: Fix clicking on a fleet maintained app will link to correct app
+- Fleet UI: Fixed redirect when clicking on any column in the Fleet Maintained Apps table

--- a/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareFleetMaintained/FleetMaintainedAppsTable/FleetMaintainedAppsTable.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareFleetMaintained/FleetMaintainedAppsTable/FleetMaintainedAppsTable.tsx
@@ -123,7 +123,6 @@ const FleetMaintainedAppsTable = ({
   );
 
   const handleRowClick = (row: IRowProps) => {
-    console.log("row", row);
     const path = `${PATHS.SOFTWARE_FLEET_MAINTAINED_DETAILS(
       row.original.id
     )}?${buildQueryStringFromParams({

--- a/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareFleetMaintained/FleetMaintainedAppsTable/FleetMaintainedAppsTable.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareFleetMaintained/FleetMaintainedAppsTable/FleetMaintainedAppsTable.tsx
@@ -47,6 +47,10 @@ interface IFleetMaintainedAppsTableProps {
   data?: ISoftwareFleetMaintainedAppsResponse;
 }
 
+interface IRowProps {
+  original: IFleetMaintainedApp;
+}
+
 const FleetMaintainedAppsTable = ({
   teamId,
   isLoading,
@@ -118,9 +122,10 @@ const FleetMaintainedAppsTable = ({
     [determineQueryParamChange, generateNewQueryParams, router]
   );
 
-  const handleRowClick = (row: IFleetMaintainedApp) => {
+  const handleRowClick = (row: IRowProps) => {
+    console.log("row", row);
     const path = `${PATHS.SOFTWARE_FLEET_MAINTAINED_DETAILS(
-      row.id
+      row.original.id
     )}?${buildQueryStringFromParams({
       team_id: teamId,
     })}`;
@@ -156,7 +161,7 @@ const FleetMaintainedAppsTable = ({
   };
 
   return (
-    <TableContainer<IFleetMaintainedApp>
+    <TableContainer<IRowProps>
       className={baseClass}
       columnConfigs={tableHeadersConfig}
       data={data?.fleet_maintained_apps ?? []}


### PR DESCRIPTION
## Issue
Cerra #23302

## Description
- Code pointed at row ID instead of app ID
- Fix

## Screenrecording of fix

https://github.com/user-attachments/assets/fe5cf009-af33-4c25-ac2b-2b05d5ad6838



# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
- [x] Manual QA for all new/changed functionality
