### PR TITLE
UI: only `setEditingExistingQuery` in the edit query form if the query has been modified

### DIFF
--- a/changes/24653-live-query-from-edit-affects-performance-stats
+++ b/changes/24653-live-query-from-edit-affects-performance-stats
@@ -1,0 +1,2 @@
+- When running a live query from the edit query form, consider the results of the run in calculating
+  an existing query's performance impact if the user didn't change the query from the stored version.

--- a/frontend/pages/queries/edit/components/EditQueryForm/EditQueryForm.tsx
+++ b/frontend/pages/queries/edit/components/EditQueryForm/EditQueryForm.tsx
@@ -184,6 +184,7 @@ const EditQueryForm = ({
   const [isEditingDescription, setIsEditingDescription] = useState(false);
   const [isSaveAsNewLoading, setIsSaveAsNewLoading] = useState(false);
   const [showAdvancedOptions, setShowAdvancedOptions] = useState(false);
+  const [queryWasChanged, setQueryWasChanged] = useState(false);
 
   const platformCompatibility = usePlatformCompatibility();
   const { setCompatiblePlatforms } = platformCompatibility;
@@ -233,6 +234,7 @@ const EditQueryForm = ({
   };
 
   const onChangeQuery = (sqlString: string) => {
+    setQueryWasChanged(true);
     setLastEditedQueryBody(sqlString);
   };
 
@@ -882,7 +884,17 @@ const EditQueryForm = ({
                 className={`${baseClass}__run`}
                 variant="blue-green"
                 onClick={() => {
-                  setEditingExistingQuery(true); // Persists edited query data through live query flow
+                  // calling `setEditingExistingQuery` here prevents
+                  // inclusion of `query_id` in the subsequent `run` API call, which prevents counting
+                  // this live run in performance impact. Since we DO want to count this run in those
+                  // stats if the query is the same as the saved one, only set below IF the query
+                  // has been changed.
+                  // TODO - product: should host details > action > query > <select existing query>
+                  // go to the host details page instead of the edit query page, where the user has
+                  // the choice to edit the query or run it live directly?
+                  if (queryWasChanged) {
+                    setEditingExistingQuery(true); // Persists edited query data through live query flow
+                  }
                   router.push(
                     PATHS.LIVE_QUERY(queryIdForEdit) +
                       TAGGED_TEMPLATES.queryByHostRoute(hostId, currentTeamId)


### PR DESCRIPTION
## #24653 

- This bug was more generally that live query runs from the Edit query form did not  include the `query_id` in the `run` API call. 

![ezgif-6-8ef29273dc](https://github.com/user-attachments/assets/d6792037-5d91-4f6f-84d9-640133df0522)


- [x] Changes file added for user-visible changes in `changes/`
- [x] Manual QA for all new/changed functionality