### PR TITLE
Unreleased bug fix: Hide install options from editing software modal

### DIFF
--- a/frontend/pages/SoftwarePage/components/PackageForm/PackageForm.tsx
+++ b/frontend/pages/SoftwarePage/components/PackageForm/PackageForm.tsx
@@ -241,12 +241,14 @@ const PackageForm = ({
             formData.software ? getFileDetails(formData.software) : undefined
           }
         />
-        <InstallTypeSection
-          isCustomPackage
-          isExeCustomPackage={isExePackage}
-          installType={formData.installType}
-          onChangeInstallType={onChangeInstallType}
-        />
+        {!isEditingSoftware && (
+          <InstallTypeSection
+            isCustomPackage
+            isExeCustomPackage={isExePackage}
+            installType={formData.installType}
+            onChangeInstallType={onChangeInstallType}
+          />
+        )}
         <TargetLabelSelector
           selectedTargetType={formData.targetType}
           selectedCustomTarget={formData.customTarget}


### PR DESCRIPTION
## Issue
Cerra #25060 
Will need to merge to R.C.

## Description
- Editing software cannot change install type, remove from UI

## Screenshot of fix
<img width="1088" alt="Screenshot 2025-01-03 at 10 08 47 AM" src="https://github.com/user-attachments/assets/a7767000-999b-4540-8f1d-bc04384e872d" />


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->


- [x] Manual QA for all new/changed functionality

