### PR TITLE
Fleet UI: Add timestamps to host count on software detail pages

### DIFF
--- a/changes/24795-host-count
+++ b/changes/24795-host-count
@@ -1,0 +1,1 @@
+- Fleet UI: Added timestamp for software, OS, and vulnerability detail pages for host count last update time

--- a/frontend/components/LastUpdatedHostCount/LastUpdatedHostCount.stories.tsx
+++ b/frontend/components/LastUpdatedHostCount/LastUpdatedHostCount.stories.tsx
@@ -1,0 +1,23 @@
+import { Meta, StoryObj } from "@storybook/react";
+
+import LastUpdatedHostCount from "./LastUpdatedHostCount";
+
+const meta: Meta<typeof LastUpdatedHostCount> = {
+  title: "Components/LastUpdatedHostCount",
+  component: LastUpdatedHostCount,
+  args: {
+    // whatToRetrieve: "apples",
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof LastUpdatedHostCount>;
+
+export const Basic: Story = {};
+
+export const WithLastUpdatedAt: Story = {
+  args: {
+    lastUpdatedAt: "2021-01-01T00:00:00Z",
+  },
+};

--- a/frontend/components/LastUpdatedHostCount/LastUpdatedHostCount.stories.tsx
+++ b/frontend/components/LastUpdatedHostCount/LastUpdatedHostCount.stories.tsx
@@ -6,7 +6,7 @@ const meta: Meta<typeof LastUpdatedHostCount> = {
   title: "Components/LastUpdatedHostCount",
   component: LastUpdatedHostCount,
   args: {
-    // whatToRetrieve: "apples",
+    hostCount: 40,
   },
 };
 

--- a/frontend/components/LastUpdatedHostCount/LastUpdatedHostCount.tests.tsx
+++ b/frontend/components/LastUpdatedHostCount/LastUpdatedHostCount.tests.tsx
@@ -1,0 +1,37 @@
+import React from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+
+import LastUpdatedHostCount from ".";
+
+describe("Last updated host count", () => {
+  it("renders host count and updated text", () => {
+    const currentDate = new Date();
+    currentDate.setDate(currentDate.getDate() - 2);
+    const twoDaysAgo = currentDate.toISOString();
+
+    render(<LastUpdatedHostCount hostCount={40} lastUpdatedAt={twoDaysAgo} />);
+
+    const hostCount = screen.getByText(/40/i);
+    const updateText = screen.getByText("Updated 2 days ago");
+
+    expect(hostCount).toBeInTheDocument();
+    expect(updateText).toBeInTheDocument();
+  });
+  it("renders never if missing timestamp", () => {
+    render(<LastUpdatedHostCount />);
+
+    const text = screen.getByText("Updated never");
+
+    expect(text).toBeInTheDocument();
+  });
+
+  it("renders tooltip on hover", async () => {
+    render(<LastUpdatedHostCount hostCount={0} />);
+
+    await fireEvent.mouseEnter(screen.getByText("Updated never"));
+
+    expect(
+      screen.getByText(/last time host data was updated/i)
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/components/LastUpdatedHostCount/LastUpdatedHostCount.tsx
+++ b/frontend/components/LastUpdatedHostCount/LastUpdatedHostCount.tsx
@@ -1,0 +1,36 @@
+import React from "react";
+import LastUpdatedText from "components/LastUpdatedText";
+
+const baseClass = "last-updated-host-count";
+
+interface ILastUpdatedHostCount {
+  hostCount?: string | number;
+  lastUpdatedAt?: string;
+}
+
+const LastUpdatedHostCount = ({
+  hostCount,
+  lastUpdatedAt,
+}: ILastUpdatedHostCount): JSX.Element => {
+  const tooltipContent = (
+    <>
+      The last time host data was updated. <br />
+      Click <b>View all hosts</b> to see the most
+      <br /> up-to-date host count.
+    </>
+  );
+
+  return (
+    <div className={baseClass}>
+      <>{hostCount}</>
+      {lastUpdatedAt && (
+        <LastUpdatedText
+          lastUpdatedAt={lastUpdatedAt}
+          customTooltipText={tooltipContent}
+        />
+      )}
+    </div>
+  );
+};
+
+export default LastUpdatedHostCount;

--- a/frontend/components/LastUpdatedHostCount/LastUpdatedHostCount.tsx
+++ b/frontend/components/LastUpdatedHostCount/LastUpdatedHostCount.tsx
@@ -23,12 +23,10 @@ const LastUpdatedHostCount = ({
   return (
     <div className={baseClass}>
       <>{hostCount}</>
-      {lastUpdatedAt && (
-        <LastUpdatedText
-          lastUpdatedAt={lastUpdatedAt}
-          customTooltipText={tooltipContent}
-        />
-      )}
+      <LastUpdatedText
+        lastUpdatedAt={lastUpdatedAt}
+        customTooltipText={tooltipContent}
+      />
     </div>
   );
 };

--- a/frontend/components/LastUpdatedHostCount/_styles.scss
+++ b/frontend/components/LastUpdatedHostCount/_styles.scss
@@ -1,0 +1,9 @@
+.last-updated-host-count {
+  display: flex;
+  align-items: baseline;
+  gap: $pad-small;
+
+  .component__tooltip-wrapper__underline {
+    font-weight: $bold;
+  }
+}

--- a/frontend/components/LastUpdatedHostCount/_styles.scss
+++ b/frontend/components/LastUpdatedHostCount/_styles.scss
@@ -2,6 +2,7 @@
   display: flex;
   align-items: baseline;
   gap: $pad-small;
+  font-size: $x-small;
 
   .component__tooltip-wrapper__underline {
     font-weight: $bold;

--- a/frontend/components/LastUpdatedHostCount/_styles.scss
+++ b/frontend/components/LastUpdatedHostCount/_styles.scss
@@ -3,8 +3,4 @@
   align-items: baseline;
   gap: $pad-small;
   font-size: $x-small;
-
-  .component__tooltip-wrapper__underline {
-    font-weight: $bold;
-  }
 }

--- a/frontend/components/LastUpdatedHostCount/index.ts
+++ b/frontend/components/LastUpdatedHostCount/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./LastUpdatedHostCount";

--- a/frontend/components/LastUpdatedText/_styles.scss
+++ b/frontend/components/LastUpdatedText/_styles.scss
@@ -1,5 +1,6 @@
 .component__last-updated-text {
   font-size: $xx-small;
+  font-weight: $regular;
   color: $ui-fleet-black-75;
 
   .tooltip {

--- a/frontend/pages/SoftwarePage/SoftwareOSDetailsPage/SoftwareOSDetailsPage.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareOSDetailsPage/SoftwareOSDetailsPage.tsx
@@ -49,6 +49,11 @@ type ISoftwareOSDetailsPageProps = RouteComponentProps<
   ISoftwareOSDetailsRouteParams
 >;
 
+type QueryResult = {
+  os_version: IOperatingSystemVersion;
+  counts_updated_at?: string;
+};
+
 const SoftwareOSDetailsPage = ({
   routeParams,
   router,
@@ -72,13 +77,13 @@ const SoftwareOSDetailsPage = ({
   });
 
   const {
-    data: osVersionDetails,
+    data: { os_version: osVersionDetails, counts_updated_at } = {},
     isLoading,
     isError: isOsVersionError,
   } = useQuery<
     IOSVersionResponse,
     AxiosError,
-    IOperatingSystemVersion,
+    QueryResult,
     IGetOsVersionQueryKey[]
   >(
     [
@@ -93,7 +98,10 @@ const SoftwareOSDetailsPage = ({
       ...DEFAULT_USE_QUERY_OPTIONS,
       retry: false,
       enabled: !!osVersionIdFromURL,
-      select: (data) => data.os_version,
+      select: (data) => ({
+        os_version: data.os_version,
+        counts_updated_at: data.counts_updated_at,
+      }),
       onError: (error) => {
         if (!ignoreAxiosError(error, [403, 404])) {
           handlePageError(error);
@@ -154,7 +162,7 @@ const SoftwareOSDetailsPage = ({
             onTeamChange={onTeamChange}
           />
         )}
-        {isOsVersionError ? (
+        {isOsVersionError || !osVersionDetails ? (
           <DetailsNoHosts
             header="OS not detected"
             details="No hosts have this OS installed."
@@ -164,6 +172,7 @@ const SoftwareOSDetailsPage = ({
             <SoftwareDetailsSummary
               title={osVersionDetails.name}
               hosts={osVersionDetails.hosts_count}
+              countsUpdatedAt={counts_updated_at}
               queryParams={{
                 os_name: osVersionDetails.name_only,
                 os_version: osVersionDetails.version,

--- a/frontend/pages/SoftwarePage/SoftwareOSDetailsPage/SoftwareOSDetailsPage.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareOSDetailsPage/SoftwareOSDetailsPage.tsx
@@ -49,11 +49,6 @@ type ISoftwareOSDetailsPageProps = RouteComponentProps<
   ISoftwareOSDetailsRouteParams
 >;
 
-type QueryResult = {
-  os_version: IOperatingSystemVersion;
-  counts_updated_at?: string;
-};
-
 const SoftwareOSDetailsPage = ({
   routeParams,
   router,
@@ -83,7 +78,7 @@ const SoftwareOSDetailsPage = ({
   } = useQuery<
     IOSVersionResponse,
     AxiosError,
-    QueryResult,
+    IOSVersionResponse,
     IGetOsVersionQueryKey[]
   >(
     [

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwareTitleDetailsPage.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwareTitleDetailsPage.tsx
@@ -178,6 +178,7 @@ const SoftwareTitleDetailsPage = ({
             type={formatSoftwareType(softwareTitle)}
             versions={softwareTitle.versions?.length ?? 0}
             hosts={softwareTitle.hosts_count}
+            countsUpdatedAt={softwareTitle.counts_updated_at}
             queryParams={{
               software_title_id: softwareId,
               team_id: teamIdForApi,

--- a/frontend/pages/SoftwarePage/SoftwareVulnerabilityDetailsPage/SoftwareVulnSummary/SoftwareVulnSummary.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareVulnerabilityDetailsPage/SoftwareVulnSummary/SoftwareVulnSummary.tsx
@@ -11,7 +11,7 @@ import TooltipWrapper from "components/TooltipWrapper";
 import ViewAllHostsLink from "components/ViewAllHostsLink";
 import ProbabilityOfExploit from "components/ProbabilityOfExploit";
 import { HumanTimeDiffWithDateTip } from "components/HumanTimeDiffWithDateTip";
-import LastUpdatedText from "components/LastUpdatedText";
+import LastUpdatedHostCount from "components/LastUpdatedHostCount";
 
 const baseClass = "software-vuln-summary";
 
@@ -131,21 +131,10 @@ const SoftwareVulnSummary = ({
         <DataSet
           title="Affected hosts"
           value={
-            <>
-              {hosts_count}{" "}
-              {hosts_count_updated_at && (
-                <LastUpdatedText
-                  lastUpdatedAt={hosts_count_updated_at}
-                  customTooltipText={
-                    <>
-                      The last time host data was updated. <br />
-                      Click <b>View all hosts</b> to see the most
-                      <br /> up-to-date host count.
-                    </>
-                  }
-                />
-              )}
-            </>
+            <LastUpdatedHostCount
+              hostCount={hosts_count}
+              lastUpdatedAt={hosts_count_updated_at}
+            />
           }
         />
       </dl>

--- a/frontend/pages/SoftwarePage/SoftwareVulnerabilityDetailsPage/SoftwareVulnSummary/SoftwareVulnSummary.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareVulnerabilityDetailsPage/SoftwareVulnSummary/SoftwareVulnSummary.tsx
@@ -11,6 +11,7 @@ import TooltipWrapper from "components/TooltipWrapper";
 import ViewAllHostsLink from "components/ViewAllHostsLink";
 import ProbabilityOfExploit from "components/ProbabilityOfExploit";
 import { HumanTimeDiffWithDateTip } from "components/HumanTimeDiffWithDateTip";
+import LastUpdatedText from "components/LastUpdatedText";
 
 const baseClass = "software-vuln-summary";
 
@@ -35,6 +36,7 @@ const SoftwareVulnSummary = ({
     cve_published,
     created_at,
     hosts_count,
+    hosts_count_updated_at,
   } = vuln;
 
   return (
@@ -126,7 +128,26 @@ const SoftwareVulnSummary = ({
             />
           }
         />
-        <DataSet title="Affected hosts" value={hosts_count} />
+        <DataSet
+          title="Affected hosts"
+          value={
+            <>
+              {hosts_count}{" "}
+              {hosts_count_updated_at && (
+                <LastUpdatedText
+                  lastUpdatedAt={hosts_count_updated_at}
+                  customTooltipText={
+                    <>
+                      The last time host data was updated. <br />
+                      Click <b>View all hosts</b> to see the most
+                      <br /> up-to-date host count.
+                    </>
+                  }
+                />
+              )}
+            </>
+          }
+        />
       </dl>
     </Card>
   );

--- a/frontend/pages/SoftwarePage/components/SoftwareDetailsSummary/SoftwareDetailsSummary.tsx
+++ b/frontend/pages/SoftwarePage/components/SoftwareDetailsSummary/SoftwareDetailsSummary.tsx
@@ -10,7 +10,7 @@ import { QueryParams } from "utilities/url";
 
 import ViewAllHostsLink from "components/ViewAllHostsLink";
 import DataSet from "components/DataSet";
-import LastUpdatedText from "components/LastUpdatedText";
+import LastUpdatedHostCount from "components/LastUpdatedHostCount";
 
 import SoftwareIcon from "../icons/SoftwareIcon";
 
@@ -52,21 +52,10 @@ const SoftwareDetailsSummary = ({
           <DataSet
             title="Hosts"
             value={
-              <>
-                {hosts === 0 ? "---" : hosts}{" "}
-                {countsUpdatedAt && (
-                  <LastUpdatedText
-                    lastUpdatedAt={countsUpdatedAt}
-                    customTooltipText={
-                      <>
-                        The last time host data was updated. <br />
-                        Click <b>View all hosts</b> to see the most
-                        <br /> up-to-date host count.
-                      </>
-                    }
-                  />
-                )}
-              </>
+              <LastUpdatedHostCount
+                hostCount={hosts === 0 ? "---" : hosts}
+                lastUpdatedAt={countsUpdatedAt}
+              />
             }
           />
         </dl>

--- a/frontend/pages/SoftwarePage/components/SoftwareDetailsSummary/SoftwareDetailsSummary.tsx
+++ b/frontend/pages/SoftwarePage/components/SoftwareDetailsSummary/SoftwareDetailsSummary.tsx
@@ -10,6 +10,7 @@ import { QueryParams } from "utilities/url";
 
 import ViewAllHostsLink from "components/ViewAllHostsLink";
 import DataSet from "components/DataSet";
+import LastUpdatedText from "components/LastUpdatedText";
 
 import SoftwareIcon from "../icons/SoftwareIcon";
 
@@ -19,6 +20,7 @@ interface ISoftwareDetailsSummaryProps {
   title: string;
   type?: string;
   hosts: number;
+  countsUpdatedAt?: string;
   /** The query param that will be added when user clicks on "View all hosts" link */
   queryParams: QueryParams;
   name?: string;
@@ -31,6 +33,7 @@ const SoftwareDetailsSummary = ({
   title,
   type,
   hosts,
+  countsUpdatedAt,
   queryParams,
   name,
   source,
@@ -46,7 +49,26 @@ const SoftwareDetailsSummary = ({
           {!!type && <DataSet title="Type" value={type} />}
 
           {!!versions && <DataSet title="Versions" value={versions} />}
-          <DataSet title="Hosts" value={hosts === 0 ? "---" : hosts} />
+          <DataSet
+            title="Hosts"
+            value={
+              <>
+                {hosts === 0 ? "---" : hosts}{" "}
+                {countsUpdatedAt && (
+                  <LastUpdatedText
+                    lastUpdatedAt={countsUpdatedAt}
+                    customTooltipText={
+                      <>
+                        The last time host data was updated. <br />
+                        Click <b>View all hosts</b> to see the most
+                        <br /> up-to-date host count.
+                      </>
+                    }
+                  />
+                )}
+              </>
+            }
+          />
         </dl>
       </dl>
       <div>

--- a/frontend/pages/policies/ManagePoliciesPage/_styles.scss
+++ b/frontend/pages/policies/ManagePoliciesPage/_styles.scss
@@ -295,8 +295,4 @@
       }
     }
   }
-
-  .component__last-updated-text {
-    font-weight: normal;
-  }
 }

--- a/frontend/services/entities/operating_systems.ts
+++ b/frontend/services/entities/operating_systems.ts
@@ -48,6 +48,7 @@ export interface IGetOsVersionQueryKey extends IGetOsVersionOptions {
 }
 
 export interface IOSVersionResponse {
+  counts_updated_at?: string;
   os_version: IOperatingSystemVersion;
 }
 


### PR DESCRIPTION
## Issue
For #24975

## Description
- Add last updated at counts for the software details page, os details page, and vulnerabilities details page
- These counts are all baseline
- Fixed all last updated counts to not be bolded

## Screenshot of all 3
<img width="1240" alt="Screenshot 2025-01-06 at 12 02 47 PM" src="https://github.com/user-attachments/assets/aa24f526-19a9-47e4-bf44-b0d84df32ca8" />
<img width="924" alt="Screenshot 2025-01-06 at 12 02 29 PM" src="https://github.com/user-attachments/assets/514926ef-bdd4-4b41-b54b-333b7d387fc2" />
<img width="1254" alt="Screenshot 2025-01-06 at 12 02 15 PM" src="https://github.com/user-attachments/assets/cb74c82d-be3e-4c67-888d-ac252ad9ac40" />


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or 
- [x] Manual QA for all new/changed functionality

