### PR TITLE
Fix detection of uninstall scripts when recording script results after a host has had MDM actions taken

### DIFF
--- a/changes/25144-uninstall-after-mdm-action
+++ b/changes/25144-uninstall-after-mdm-action
@@ -1,0 +1,1 @@
+* Fixed reporting of software uninstall results after a host has been locked/unlocked

--- a/server/datastore/mysql/scripts.go
+++ b/server/datastore/mysql/scripts.go
@@ -129,6 +129,12 @@ func (ds *Datastore) SetHostScriptExecutionResult(ctx context.Context, result *f
     execution_id = ?`
 
 	const hostMDMActionsStmt = `
+  SELECT 'uninstall' AS action
+  FROM
+	host_software_installs
+  WHERE
+	execution_id = :execution_id AND host_id = :host_id
+  UNION -- host_mdm_actions query (and thus row in union) must be last to avoid #25144
   SELECT
     CASE
       WHEN lock_ref = :execution_id THEN 'lock_ref'
@@ -140,12 +146,6 @@ func (ds *Datastore) SetHostScriptExecutionResult(ctx context.Context, result *f
     host_mdm_actions
   WHERE
     host_id = :host_id
-  UNION
-  SELECT 'uninstall' AS action
-  FROM
-	host_software_installs
-  WHERE
-	execution_id = :execution_id AND host_id = :host_id
 `
 
 	output := truncateScriptResult(result.Output)


### PR DESCRIPTION
For #25144.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/Committing-Changes.md#changes-files) for more information.
- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [x] Added/updated automated tests
- [x] A detailed QA plan exists on the associated ticket (if it isn't there, work with the product group's QA engineer to add it)
- [x] Manual QA for all new/changed functionality
