### PR TITLE
Cherry-Pick: Fix detection of uninstall scripts when recording script results after a host has had MDM actions taken

### DIFF
--- a/changes/25144-uninstall-after-mdm-action
+++ b/changes/25144-uninstall-after-mdm-action
@@ -1,0 +1,1 @@
+* Fixed reporting of software uninstall results after a host has been locked/unlocked

--- a/server/datastore/mysql/scripts.go
+++ b/server/datastore/mysql/scripts.go
@@ -129,6 +129,12 @@ func (ds *Datastore) SetHostScriptExecutionResult(ctx context.Context, result *f
     execution_id = ?`
 
 	const hostMDMActionsStmt = `
+  SELECT 'uninstall' AS action
+  FROM
+	host_software_installs
+  WHERE
+	execution_id = :execution_id AND host_id = :host_id
+  UNION -- host_mdm_actions query (and thus row in union) must be last to avoid #25144
   SELECT
     CASE
       WHEN lock_ref = :execution_id THEN 'lock_ref'
@@ -140,12 +146,6 @@ func (ds *Datastore) SetHostScriptExecutionResult(ctx context.Context, result *f
     host_mdm_actions
   WHERE
     host_id = :host_id
-  UNION
-  SELECT 'uninstall' AS action
-  FROM
-	host_software_installs
-  WHERE
-	execution_id = :execution_id AND host_id = :host_id
 `
 
 	output := truncateScriptResult(result.Output)


### PR DESCRIPTION
For #25144. Merged into `main` in #25157.