### PR TITLE
Fleet UI: Fleet maintained app 404 sends to 404 page

### DIFF
--- a/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareFleetMaintained/FleetMaintainedAppDetailsPage/FleetMaintainedAppDetailsPage.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareFleetMaintained/FleetMaintainedAppDetailsPage/FleetMaintainedAppDetailsPage.tsx
@@ -127,6 +127,7 @@ const FleetMaintainedAppDetailsPage = ({
     {
       ...DEFAULT_USE_QUERY_OPTIONS,
       enabled: isPremiumTier,
+      retry: false,
       select: (res) => res.fleet_maintained_app,
       onError: (error) => handlePageError(error),
     }

--- a/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareFleetMaintained/FleetMaintainedAppDetailsPage/FleetMaintainedAppDetailsPage.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareFleetMaintained/FleetMaintainedAppDetailsPage/FleetMaintainedAppDetailsPage.tsx
@@ -2,6 +2,7 @@ import React, { useContext, useState } from "react";
 import { Location } from "history";
 import { useQuery } from "react-query";
 import { InjectedRouter } from "react-router";
+import { useErrorHandler } from "react-error-boundary";
 
 import PATHS from "router/paths";
 import { buildQueryStringFromParams } from "utilities/url";
@@ -105,6 +106,7 @@ const FleetMaintainedAppDetailsPage = ({
   }
 
   const { renderFlash } = useContext(NotificationContext);
+  const handlePageError = useErrorHandler();
   const { isPremiumTier } = useContext(AppContext);
   const { selectedOsqueryTable, setSelectedOsqueryTable } = useContext(
     QueryContext
@@ -126,6 +128,7 @@ const FleetMaintainedAppDetailsPage = ({
       ...DEFAULT_USE_QUERY_OPTIONS,
       enabled: isPremiumTier,
       select: (res) => res.fleet_maintained_app,
+      onError: (error) => handlePageError(error),
     }
   );
 


### PR DESCRIPTION
## Issue
For #24638 

## Description
- Fleet maintained app 404 sends to 404 page
- Remove 3 retries to match other pages that send to 404 immediately after first try (e.g. host details page 404)

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Manual QA for all new/changed functionality

