### PR TITLE
Fleet UI: Fix 404 button styling

### DIFF
--- a/frontend/pages/errors/Fleet404/_styles.scss
+++ b/frontend/pages/errors/Fleet404/_styles.scss
@@ -5,7 +5,6 @@
   }
 
   button {
-    margin: $pad-medium;
     width: 197px;
     font-size: $small;
 
@@ -17,6 +16,11 @@
   }
 
   &__button-wrapper {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: $pad-medium;
+
     margin-bottom: $pad-large;
   }
 

--- a/frontend/pages/errors/Fleet404/_styles.scss
+++ b/frontend/pages/errors/Fleet404/_styles.scss
@@ -20,7 +20,6 @@
     align-items: center;
     justify-content: center;
     gap: $pad-medium;
-
     margin-bottom: $pad-large;
   }
 


### PR DESCRIPTION
## Issue
For #25168 

## Description
- Second button was on a row by itself and aligned left, fix to match old 404 page found on figma

## Screenshot of fix
<img width="1250" alt="Screenshot 2025-01-06 at 11 19 46 AM" src="https://github.com/user-attachments/assets/1fb98add-bff5-4703-be37-1f791a77ae4d" />



# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Manual QA for all new/changed functionality
