### PR TITLE
fix the secret error message for windows profile

### DIFF
--- a/frontend/pages/SoftwarePage/helpers.ts
+++ b/frontend/pages/SoftwarePage/helpers.ts
@@ -20,8 +20,11 @@ export const generateSecretErrMsg = (err: unknown) => {
   }
 
   if (errorType === "profile") {
-    return reason
-      .split(":")[1]
+    // for profiles we can get two different error messages. One contains a colon
+    // and the other doesn't. We need to handle both cases.
+    const message = reason.split(":").pop() ?? "";
+
+    return message
       .replace(/Secret variables?/i, "Variable")
       .replace("missing from database", "doesn't exist.");
   }


### PR DESCRIPTION
relates to #25155

fixes an issue where we weren't showing an error message for a windows profile with incorrect secret

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Manual QA for all new/changed functionality
