### PR TITLE
Never include sender address in update email success message

### DIFF
--- a/changes/24366-success-email-message
+++ b/changes/24366-success-email-message
@@ -1,0 +1,1 @@
+- Improve readability of success message on email update by never including the sender address.

--- a/frontend/pages/admin/UserManagementPage/components/UsersTable/UsersTable.tsx
+++ b/frontend/pages/admin/UserManagementPage/components/UsersTable/UsersTable.tsx
@@ -300,10 +300,7 @@ const UsersTable = ({ router }: IUsersTableProps): JSX.Element => {
 
     let userUpdatedFlashMessage = `Successfully edited ${formData.name}`;
     if (userData?.email !== formData.email) {
-      const senderAddressMessage = config?.smtp_settings?.sender_address
-        ? ` from ${config?.smtp_settings?.sender_address}`
-        : "";
-      userUpdatedFlashMessage += `: A confirmation email was sent${senderAddressMessage} to ${formData.email}`;
+      userUpdatedFlashMessage += `. A confirmation email was sent to ${formData.email}.`;
     }
     const userUpdatedEmailError =
       "A user with this email address already exists";


### PR DESCRIPTION
## For #24366

![ezgif-1-7fab23822d](https://github.com/user-attachments/assets/486286af-db0d-4ce9-9667-fe8471b36f76)

- [x] Changes file added for user-visible changes in `changes/`
- [x] Manual QA for all new/changed functionality
