### PR TITLE
Website: Allow double curly brace templates in Markdown code blocks.

### DIFF
--- a/website/api/helpers/strings/to-html.js
+++ b/website/api/helpers/strings/to-html.js
@@ -107,13 +107,13 @@ module.exports = {
       if(infostring === 'mermaid') {
         return `<code class="mermaid">${_.escape(code)}</code>`;
       } else if(infostring === 'js') {// Interpret `js` as `javascript`
-        return `<pre><code class="hljs javascript">${_.escape(code)}</code></pre>`;
+        return `<pre><code class="hljs javascript" v-pre>${_.escape(code)}</code></pre>`;
       } else if(infostring === 'bash' || infostring === 'sh') {// Interpret `sh` and `bash` as `bash`
-        return `<pre><code class="hljs bash">${_.escape(code)}</code></pre>`;
+        return `<pre><code class="hljs bash" v-pre>${_.escape(code)}</code></pre>`;
       } else if(infostring !== '') {// leaving the code language as-is if the infoString is anything else.
-        return `<pre><code class="hljs ${_.escape(infostring)}">${_.escape(code)}</code></pre>`;
+        return `<pre><code class="hljs ${_.escape(infostring)}" v-pre>${_.escape(code)}</code></pre>`;
       } else {// When unspecified, default to `text`
-        return `<pre><code class="nohighlight">${_.escape(code)}</code></pre>`;
+        return `<pre><code class="nohighlight" v-pre>${_.escape(code)}</code></pre>`;
       }
     };
 

--- a/website/scripts/build-static-content.js
+++ b/website/scripts/build-static-content.js
@@ -259,10 +259,11 @@ module.exports = {
               if(mdString.match(/(-|\d\.)\s.*\n<!-+\n/g)) {
                 throw new Error(`A Markdown file (${pageSourcePath}) contains an HTML comment directly after a list that will cause rendering issues when converted to HTML. To resolve this error, add a blank newline before the start of the HTML comment in this file.`);
               }
-              // Look for anything in markdown content that could be interpreted as a Vue template when converted to HTML (e.g. {{ foo }}). If any are found, throw an error.
-              if(mdString.match(/\{\{([^}]+)\}\}/gi)) {
-                throw new Error(`A Markdown file (${pageSourcePath}) contains a Vue template (${mdString.match(/\{\{([^}]+)\}\}/gi)[0]}) that will cause client-side javascript errors when converted to HTML. To resolve this error, change or remove the double curly brackets in this file.`);
+              // Look for anything outside of code blocks in markdown content that could be interpreted as a Vue template when converted to HTML (e.g. {{ foo }}). If any are found, throw an error.
+              if (mdString.match(/(?<!```.*)(?<!`){{([^}]+)}}(?!`)/gi)) {
+                throw new Error(`A Markdown file (${pageSourcePath}) contains a Vue template (${mdString.match(/(?<!```.*)(?<!`){{([^}]+)}}(?!`)/gi)[0]}) that will cause client-side JavaScript errors when converted to HTML. To resolve this error, change or remove the double curly brackets in this file.`);
               }
+
               mdString = mdString.replace(/(<call-to-action[\s\S]+[^>\n+])\n+(>)/g, '$1$2'); // « Removes any newlines that might exist before the closing `>` when the <call-to-action> compontent is added to markdown files.
               // [?] Looking for code that used to be here related to syntax highlighting?  Please see https://github.com/fleetdm/fleet/pull/14124/files  -mikermcneil, 2023-09-25
               let htmlString = await sails.helpers.strings.toHtml(mdString);


### PR DESCRIPTION
Closes: https://github.com/fleetdm/fleet/issues/25176

Changes:
- Updated the to-html helper to add the `v-pre` directive to Markdown code blocks, This directive will prevent any of the content inside of it from being interpreted as a Vue template.
- Updated the regex in build-static-content that looks for vue templates to not match any templates inside code blocks.