### PR TITLE
Fleet UI: Normalize team header styling

### DIFF
--- a/frontend/components/MainContent/MainContent.tsx
+++ b/frontend/components/MainContent/MainContent.tsx
@@ -1,12 +1,9 @@
 import React, { ReactNode, useContext } from "react";
 import classnames from "classnames";
-import { formatDistanceToNow } from "date-fns";
-import { hasLicenseExpired, willExpireWithinXDays } from "utilities/helpers";
+import { hasLicenseExpired } from "utilities/helpers";
 
-import SandboxExpiryMessage from "components/Sandbox/SandboxExpiryMessage";
 import AppleBMTermsMessage from "components/MDM/AppleBMTermsMessage";
 
-import SandboxGate from "components/Sandbox/SandboxGate";
 import { AppContext } from "context/app";
 import LicenseExpirationBanner from "components/LicenseExpirationBanner";
 import ApplePNCertRenewalMessage from "components/MDM/ApplePNCertRenewalMessage";
@@ -33,10 +30,8 @@ const MainContent = ({
 }: IMainContentProps): JSX.Element => {
   const classes = classnames(baseClass, className);
   const {
-    sandboxExpiry,
     config,
     isPremiumTier,
-    noSandboxHosts,
     isApplePnsExpired,
     isAppleBmExpired,
     isVppExpired,
@@ -45,11 +40,6 @@ const MainContent = ({
     willApplePnsExpire,
     willVppExpire,
   } = useContext(AppContext);
-
-  const sandboxExpiryTime =
-    sandboxExpiry === undefined
-      ? "..."
-      : formatDistanceToNow(new Date(sandboxExpiry));
 
   const renderAppWideBanner = () => {
     const isFleetLicenseExpired = hasLicenseExpired(
@@ -73,24 +63,18 @@ const MainContent = ({
     }
 
     if (banner) {
-      return <div className={`${baseClass}__warning-banner`}>{banner}</div>;
+      return (
+        <div className={`${baseClass}--animation-disabled`}>
+          <div className={`${baseClass}__warning-banner`}>{banner}</div>
+        </div>
+      );
     }
 
     return null;
   };
   return (
     <div className={classes}>
-      <div className={`${baseClass}--animation-disabled`}>
-        {renderAppWideBanner()}
-        <SandboxGate
-          fallbackComponent={() => (
-            <SandboxExpiryMessage
-              expiry={sandboxExpiryTime}
-              noSandboxHosts={noSandboxHosts}
-            />
-          )}
-        />
-      </div>
+      {renderAppWideBanner()}
       {children}
     </div>
   );

--- a/frontend/pages/DashboardPage/_styles.scss
+++ b/frontend/pages/DashboardPage/_styles.scss
@@ -24,10 +24,7 @@
   }
 
   &__header {
-    height: 38px;
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
+    @include normalize-team-header;
     margin-bottom: $pad-large;
 
     .Select-control {

--- a/frontend/pages/ManageControlsPage/_styles.scss
+++ b/frontend/pages/ManageControlsPage/_styles.scss
@@ -1,9 +1,6 @@
 .manage-controls-page {
   &__header-wrap {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    height: 38px;
+    @include normalize-team-header;
 
     .button-wrap {
       display: flex;

--- a/frontend/pages/SoftwarePage/SoftwareOSDetailsPage/_styles.scss
+++ b/frontend/pages/SoftwarePage/SoftwareOSDetailsPage/_styles.scss
@@ -4,6 +4,10 @@
   flex-direction: column;
   gap: $pad-medium;
 
+  .team-dropdown-wrapper {
+    @include normalize-team-header;
+  }
+
   h2 {
     font-size: $small;
   }

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/_styles.scss
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/_styles.scss
@@ -4,6 +4,10 @@
   flex-direction: column;
   gap: $pad-medium;
 
+  .team-dropdown-wrapper {
+    @include normalize-team-header;
+  }
+
   h2 {
     font-size: $small;
   }

--- a/frontend/pages/SoftwarePage/SoftwareVersionDetailsPage/_styles.scss
+++ b/frontend/pages/SoftwarePage/SoftwareVersionDetailsPage/_styles.scss
@@ -4,6 +4,10 @@
   flex-direction: column;
   gap: $pad-medium;
 
+  .team-dropdown-wrapper {
+    @include normalize-team-header;
+  }
+
   h2 {
     font-size: $small;
   }

--- a/frontend/pages/SoftwarePage/SoftwareVulnerabilityDetailsPage/_styles.scss
+++ b/frontend/pages/SoftwarePage/SoftwareVulnerabilityDetailsPage/_styles.scss
@@ -2,6 +2,10 @@
   background-color: $ui-off-white;
   @include page;
 
+  .team-dropdown-wrapper {
+    @include normalize-team-header;
+  }
+
   .card {
     display: flex;
     flex-direction: column;

--- a/frontend/pages/SoftwarePage/_styles.scss
+++ b/frontend/pages/SoftwarePage/_styles.scss
@@ -1,9 +1,6 @@
 .software-page {
   &__header-wrap {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    height: 38px;
+    @include normalize-team-header;
 
     .button-wrap {
       display: flex;

--- a/frontend/pages/hosts/ManageHostsPage/_styles.scss
+++ b/frontend/pages/hosts/ManageHostsPage/_styles.scss
@@ -1,10 +1,7 @@
 .manage-hosts {
   .header-wrap {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
+    @include normalize-team-header;
     margin-bottom: $pad-medium;
-    height: 38px;
 
     .button-wrap {
       display: flex;

--- a/frontend/pages/policies/ManagePoliciesPage/_styles.scss
+++ b/frontend/pages/policies/ManagePoliciesPage/_styles.scss
@@ -1,9 +1,6 @@
 .manage-policies-page {
   &__header-wrap {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    height: 38px;
+    @include normalize-team-header;
 
     .button-wrap {
       display: flex;

--- a/frontend/pages/queries/ManageQueriesPage/_styles.scss
+++ b/frontend/pages/queries/ManageQueriesPage/_styles.scss
@@ -1,9 +1,6 @@
 .manage-queries-page {
   &__header-wrap {
-    height: 38px;
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
+    @include normalize-team-header;
   }
 
   &__header {

--- a/frontend/styles/var/mixins.scss
+++ b/frontend/styles/var/mixins.scss
@@ -25,6 +25,14 @@ $max-width: 2560px;
   }
 }
 
+// Used to normalize styling of team header wrapper on various pages
+@mixin normalize-team-header {
+  display: flex;
+  align-items: center;
+  height: 38px;
+  justify-content: space-between;
+}
+
 //  Used to keep the settings description sticky under the main nav and sub nav.
 // TODO: figure out how to calculate these values with variables. Will be tedious to change otherwise
 @mixin sticky-settings-description {


### PR DESCRIPTION
## Issue
For #24960 

## Description
- Removes empty div on some pages (if no info banner on any kind of software/os/vuln details page) causing an extra gap
- Clean up code by adding a reusable CSS mixin for team header
 
## Other
- Remove unused sandbox code

## Screenrecording of fix

https://github.com/user-attachments/assets/14d0dfae-0cf6-4a74-9277-e59a5eaef338



# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

Not a big enough user facing fix to need a changelog.
- [x] Manual QA for all new/changed functionality

