### PR TITLE
UI - use new db user settings to persist user's host table column preferences

### DIFF
--- a/changes/23971-persist-hosts-column-settings-across-sessions
+++ b/changes/23971-persist-hosts-column-settings-across-sessions
@@ -1,0 +1,2 @@
+- Implement user-level settings, use them to persist a user's selection of which columns to display
+  on the hosts table.

--- a/frontend/components/App/App.tsx
+++ b/frontend/components/App/App.tsx
@@ -77,7 +77,7 @@ const App = ({ children, location }: IAppProps): JSX.Element => {
     isOnlyObserver,
     isAnyTeamMaintainerOrTeamAdmin,
     setAvailableTeams,
-    setUISettings,
+    setUserSettings,
     setCurrentUser,
     setConfig,
     setEnrollSecret,
@@ -166,10 +166,14 @@ const App = ({ children, location }: IAppProps): JSX.Element => {
 
   const fetchCurrentUser = async () => {
     try {
-      const { user, available_teams, ui_settings } = await usersAPI.me();
+      const {
+        user,
+        available_teams,
+        settings: user_settings,
+      } = await usersAPI.me();
       setCurrentUser(user);
       setAvailableTeams(user, available_teams);
-      setUISettings(ui_settings);
+      setUserSettings(user_settings);
       fetchConfig();
     } catch (error) {
       if (

--- a/frontend/components/App/App.tsx
+++ b/frontend/components/App/App.tsx
@@ -77,6 +77,7 @@ const App = ({ children, location }: IAppProps): JSX.Element => {
     isOnlyObserver,
     isAnyTeamMaintainerOrTeamAdmin,
     setAvailableTeams,
+    setUISettings,
     setCurrentUser,
     setConfig,
     setEnrollSecret,
@@ -165,9 +166,10 @@ const App = ({ children, location }: IAppProps): JSX.Element => {
 
   const fetchCurrentUser = async () => {
     try {
-      const { user, available_teams } = await usersAPI.me();
+      const { user, available_teams, ui_settings } = await usersAPI.me();
       setCurrentUser(user);
       setAvailableTeams(user, available_teams);
+      setUISettings(ui_settings);
       fetchConfig();
     } catch (error) {
       if (

--- a/frontend/components/App/App.tsx
+++ b/frontend/components/App/App.tsx
@@ -166,10 +166,10 @@ const App = ({ children, location }: IAppProps): JSX.Element => {
 
   const fetchCurrentUser = async () => {
     try {
-      const { user, available_teams, user_settings } = await usersAPI.me();
+      const { user, available_teams, settings } = await usersAPI.me();
       setCurrentUser(user);
       setAvailableTeams(user, available_teams);
-      setUserSettings(user_settings);
+      setUserSettings(settings);
       fetchConfig();
     } catch (error) {
       if (

--- a/frontend/components/App/App.tsx
+++ b/frontend/components/App/App.tsx
@@ -166,11 +166,7 @@ const App = ({ children, location }: IAppProps): JSX.Element => {
 
   const fetchCurrentUser = async () => {
     try {
-      const {
-        user,
-        available_teams,
-        settings: user_settings,
-      } = await usersAPI.me();
+      const { user, available_teams, user_settings } = await usersAPI.me();
       setCurrentUser(user);
       setAvailableTeams(user, available_teams);
       setUserSettings(user_settings);

--- a/frontend/context/app.tsx
+++ b/frontend/context/app.tsx
@@ -1,6 +1,6 @@
 import React, { createContext, useReducer, useMemo, ReactNode } from "react";
 
-import { IConfig } from "interfaces/config";
+import { IConfig, IUserUISettings } from "interfaces/config";
 import { IEnrollSecret } from "interfaces/enroll_secret";
 import {
   APP_CONTEXT_ALL_TEAMS_SUMMARY,
@@ -15,6 +15,7 @@ import { hasLicenseExpired, willExpireWithinXDays } from "utilities/helpers";
 
 enum ACTIONS {
   SET_AVAILABLE_TEAMS = "SET_AVAILABLE_TEAMS",
+  SET_UI_SETTINGS = "SET_UI_SETTINGS",
   SET_CURRENT_USER = "SET_CURRENT_USER",
   SET_CURRENT_TEAM = "SET_CURRENT_TEAM",
   SET_CONFIG = "SET_CONFIG",
@@ -34,6 +35,11 @@ interface ISetAvailableTeamsAction {
   type: ACTIONS.SET_AVAILABLE_TEAMS;
   user: IUser | null;
   availableTeams: ITeamSummary[];
+}
+
+interface ISetUISettingsAction {
+  type: ACTIONS.SET_UI_SETTINGS;
+  uiSettings: IUserUISettings;
 }
 
 interface ISetConfigAction {
@@ -105,6 +111,7 @@ interface ISetFilteredPoliciesPathAction {
 }
 type IAction =
   | ISetAvailableTeamsAction
+  | ISetUISettingsAction
   | ISetConfigAction
   | ISetCurrentTeamAction
   | ISetCurrentUserAction
@@ -125,6 +132,7 @@ type Props = {
 
 type InitialStateType = {
   availableTeams?: ITeamSummary[];
+  uiSettings?: IUserUISettings;
   config: IConfig | null;
   currentUser: IUser | null;
   currentTeam?: ITeamSummary;
@@ -171,6 +179,7 @@ type InitialStateType = {
     user: IUser | null,
     availableTeams: ITeamSummary[]
   ) => void;
+  setUISettings: (uiSettings: IUserUISettings) => void;
   setCurrentUser: (user: IUser) => void;
   setCurrentTeam: (team?: ITeamSummary) => void;
   setConfig: (config: IConfig) => void;
@@ -190,6 +199,7 @@ export type IAppContext = InitialStateType;
 
 export const initialState = {
   availableTeams: undefined,
+  uiSettings: undefined,
   config: null,
   currentUser: null,
   currentTeam: undefined,
@@ -227,6 +237,7 @@ export const initialState = {
   willApplePnsExpire: false,
   willVppExpire: false,
   setAvailableTeams: () => null,
+  setUISettings: () => null,
   setCurrentUser: () => null,
   setCurrentTeam: () => null,
   setConfig: () => null,
@@ -296,6 +307,13 @@ const setPermissions = (
 
 const reducer = (state: InitialStateType, action: IAction) => {
   switch (action.type) {
+    case ACTIONS.SET_UI_SETTINGS: {
+      const { uiSettings } = action;
+      return {
+        ...state,
+        uiSettings,
+      };
+    }
     case ACTIONS.SET_AVAILABLE_TEAMS: {
       const { user, availableTeams } = action;
 
@@ -436,6 +454,7 @@ const AppProvider = ({ children }: Props): JSX.Element => {
   const value = useMemo(
     () => ({
       availableTeams: state.availableTeams,
+      uiSettings: state.uiSettings,
       config: state.config,
       currentUser: state.currentUser,
       currentTeam: state.currentTeam,
@@ -486,6 +505,9 @@ const AppProvider = ({ children }: Props): JSX.Element => {
           user,
           availableTeams,
         });
+      },
+      setUISettings: (uiSettings: IUserUISettings) => {
+        dispatch({ type: ACTIONS.SET_UI_SETTINGS, uiSettings });
       },
       setCurrentUser: (currentUser: IUser) => {
         dispatch({ type: ACTIONS.SET_CURRENT_USER, currentUser });
@@ -546,6 +568,7 @@ const AppProvider = ({ children }: Props): JSX.Element => {
       state.abmExpiry,
       state.apnsExpiry,
       state.availableTeams,
+      state.uiSettings,
       state.config,
       state.currentTeam,
       state.currentUser,

--- a/frontend/context/app.tsx
+++ b/frontend/context/app.tsx
@@ -1,6 +1,6 @@
 import React, { createContext, useReducer, useMemo, ReactNode } from "react";
 
-import { IConfig, IUserUISettings } from "interfaces/config";
+import { IConfig, IUserSettings } from "interfaces/config";
 import { IEnrollSecret } from "interfaces/enroll_secret";
 import {
   APP_CONTEXT_ALL_TEAMS_SUMMARY,
@@ -15,7 +15,7 @@ import { hasLicenseExpired, willExpireWithinXDays } from "utilities/helpers";
 
 enum ACTIONS {
   SET_AVAILABLE_TEAMS = "SET_AVAILABLE_TEAMS",
-  SET_UI_SETTINGS = "SET_UI_SETTINGS",
+  SET_USER_SETTINGS = "SET_USER_SETTINGS",
   SET_CURRENT_USER = "SET_CURRENT_USER",
   SET_CURRENT_TEAM = "SET_CURRENT_TEAM",
   SET_CONFIG = "SET_CONFIG",
@@ -37,9 +37,9 @@ interface ISetAvailableTeamsAction {
   availableTeams: ITeamSummary[];
 }
 
-interface ISetUISettingsAction {
-  type: ACTIONS.SET_UI_SETTINGS;
-  uiSettings: IUserUISettings;
+interface ISetUserSettingsAction {
+  type: ACTIONS.SET_USER_SETTINGS;
+  userSettings: IUserSettings;
 }
 
 interface ISetConfigAction {
@@ -111,7 +111,7 @@ interface ISetFilteredPoliciesPathAction {
 }
 type IAction =
   | ISetAvailableTeamsAction
-  | ISetUISettingsAction
+  | ISetUserSettingsAction
   | ISetConfigAction
   | ISetCurrentTeamAction
   | ISetCurrentUserAction
@@ -132,7 +132,7 @@ type Props = {
 
 type InitialStateType = {
   availableTeams?: ITeamSummary[];
-  uiSettings?: IUserUISettings;
+  userSettings?: IUserSettings;
   config: IConfig | null;
   currentUser: IUser | null;
   currentTeam?: ITeamSummary;
@@ -179,7 +179,7 @@ type InitialStateType = {
     user: IUser | null,
     availableTeams: ITeamSummary[]
   ) => void;
-  setUISettings: (uiSettings: IUserUISettings) => void;
+  setUserSettings: (userSettings: IUserSettings) => void;
   setCurrentUser: (user: IUser) => void;
   setCurrentTeam: (team?: ITeamSummary) => void;
   setConfig: (config: IConfig) => void;
@@ -199,7 +199,7 @@ export type IAppContext = InitialStateType;
 
 export const initialState = {
   availableTeams: undefined,
-  uiSettings: undefined,
+  userSettings: undefined,
   config: null,
   currentUser: null,
   currentTeam: undefined,
@@ -237,7 +237,7 @@ export const initialState = {
   willApplePnsExpire: false,
   willVppExpire: false,
   setAvailableTeams: () => null,
-  setUISettings: () => null,
+  setUserSettings: () => null,
   setCurrentUser: () => null,
   setCurrentTeam: () => null,
   setConfig: () => null,
@@ -307,11 +307,11 @@ const setPermissions = (
 
 const reducer = (state: InitialStateType, action: IAction) => {
   switch (action.type) {
-    case ACTIONS.SET_UI_SETTINGS: {
-      const { uiSettings } = action;
+    case ACTIONS.SET_USER_SETTINGS: {
+      const { userSettings } = action;
       return {
         ...state,
-        uiSettings,
+        userSettings,
       };
     }
     case ACTIONS.SET_AVAILABLE_TEAMS: {
@@ -454,7 +454,7 @@ const AppProvider = ({ children }: Props): JSX.Element => {
   const value = useMemo(
     () => ({
       availableTeams: state.availableTeams,
-      uiSettings: state.uiSettings,
+      userSettings: state.userSettings,
       config: state.config,
       currentUser: state.currentUser,
       currentTeam: state.currentTeam,
@@ -506,8 +506,8 @@ const AppProvider = ({ children }: Props): JSX.Element => {
           availableTeams,
         });
       },
-      setUISettings: (uiSettings: IUserUISettings) => {
-        dispatch({ type: ACTIONS.SET_UI_SETTINGS, uiSettings });
+      setUserSettings: (userSettings: IUserSettings) => {
+        dispatch({ type: ACTIONS.SET_USER_SETTINGS, userSettings });
       },
       setCurrentUser: (currentUser: IUser) => {
         dispatch({ type: ACTIONS.SET_CURRENT_USER, currentUser });
@@ -568,7 +568,7 @@ const AppProvider = ({ children }: Props): JSX.Element => {
       state.abmExpiry,
       state.apnsExpiry,
       state.availableTeams,
-      state.uiSettings,
+      state.userSettings,
       state.config,
       state.currentTeam,
       state.currentUser,

--- a/frontend/interfaces/config.ts
+++ b/frontend/interfaces/config.ts
@@ -223,8 +223,6 @@ export type IAutomationsConfig = Pick<
 
 export const CONFIG_DEFAULT_RECENT_VULNERABILITY_MAX_AGE_IN_DAYS = 30;
 
-export interface IUserUISettings {
-  // backend will be typed as string, so this matches that
-  // UI checks these values further down
-  hosts_table_columns: string[];
+export interface IUserSettings {
+  hidden_hosts_table_columns: string[];
 }

--- a/frontend/interfaces/config.ts
+++ b/frontend/interfaces/config.ts
@@ -222,3 +222,9 @@ export type IAutomationsConfig = Pick<
 >;
 
 export const CONFIG_DEFAULT_RECENT_VULNERABILITY_MAX_AGE_IN_DAYS = 30;
+
+export interface IUserUISettings {
+  // backend will be typed as string, so this matches that
+  // UI checks these values further down
+  hosts_table_columns: string[];
+}

--- a/frontend/interfaces/config.ts
+++ b/frontend/interfaces/config.ts
@@ -224,5 +224,5 @@ export type IAutomationsConfig = Pick<
 export const CONFIG_DEFAULT_RECENT_VULNERABILITY_MAX_AGE_IN_DAYS = 30;
 
 export interface IUserSettings {
-  hidden_hosts_table_columns: string[];
+  hidden_host_columns: string[];
 }

--- a/frontend/interfaces/user.ts
+++ b/frontend/interfaces/user.ts
@@ -1,5 +1,6 @@
 import PropTypes from "prop-types";
 import teamInterface, { ITeam } from "./team";
+import { IUserSettings } from "./config";
 
 export default PropTypes.shape({
   created_at: PropTypes.string,
@@ -110,6 +111,7 @@ export interface IUpdateUserFormData {
   sso_enabled?: boolean;
   mfa_enabled?: boolean;
   teams?: ITeam[];
+  settings?: IUserSettings;
 }
 
 export interface ICreateUserWithInvitationFormData {

--- a/frontend/pages/RegistrationPage/RegistrationPage.tsx
+++ b/frontend/pages/RegistrationPage/RegistrationPage.tsx
@@ -61,10 +61,10 @@ const RegistrationPage = ({ router }: IRegistrationPageProps) => {
       const { token } = await usersAPI.setup(formData);
       local.setItem("auth_token", token);
 
-      const { user, available_teams, user_settings } = await usersAPI.me();
+      const { user, available_teams, settings } = await usersAPI.me();
       setCurrentUser(user);
       setAvailableTeams(user, available_teams);
-      setUserSettings(user_settings);
+      setUserSettings(settings);
       router.push(DASHBOARD);
       window.location.reload();
     } catch (error) {

--- a/frontend/pages/RegistrationPage/RegistrationPage.tsx
+++ b/frontend/pages/RegistrationPage/RegistrationPage.tsx
@@ -34,7 +34,7 @@ const RegistrationPage = ({ router }: IRegistrationPageProps) => {
     currentUser,
     setCurrentUser,
     setAvailableTeams,
-    setUISettings,
+    setUserSettings,
   } = useContext(AppContext);
   const [page, setPage] = useState(1);
   const [pageProgress, setPageProgress] = useState(1);
@@ -61,10 +61,10 @@ const RegistrationPage = ({ router }: IRegistrationPageProps) => {
       const { token } = await usersAPI.setup(formData);
       local.setItem("auth_token", token);
 
-      const { user, available_teams, ui_settings } = await usersAPI.me();
+      const { user, available_teams, user_settings } = await usersAPI.me();
       setCurrentUser(user);
       setAvailableTeams(user, available_teams);
-      setUISettings(ui_settings);
+      setUserSettings(user_settings);
       router.push(DASHBOARD);
       window.location.reload();
     } catch (error) {

--- a/frontend/pages/RegistrationPage/RegistrationPage.tsx
+++ b/frontend/pages/RegistrationPage/RegistrationPage.tsx
@@ -30,9 +30,12 @@ interface IRegistrationPageProps {
 const baseClass = "registration-page";
 
 const RegistrationPage = ({ router }: IRegistrationPageProps) => {
-  const { currentUser, setCurrentUser, setAvailableTeams } = useContext(
-    AppContext
-  );
+  const {
+    currentUser,
+    setCurrentUser,
+    setAvailableTeams,
+    setUISettings,
+  } = useContext(AppContext);
   const [page, setPage] = useState(1);
   const [pageProgress, setPageProgress] = useState(1);
   const [showSetupError, setShowSetupError] = useState(false);
@@ -58,9 +61,10 @@ const RegistrationPage = ({ router }: IRegistrationPageProps) => {
       const { token } = await usersAPI.setup(formData);
       local.setItem("auth_token", token);
 
-      const { user, available_teams } = await usersAPI.me();
+      const { user, available_teams, ui_settings } = await usersAPI.me();
       setCurrentUser(user);
       setAvailableTeams(user, available_teams);
+      setUISettings(ui_settings);
       router.push(DASHBOARD);
       window.location.reload();
     } catch (error) {

--- a/frontend/pages/admin/TeamManagementPage/TeamDetailsWrapper/TeamDetailsWrapper.tsx
+++ b/frontend/pages/admin/TeamManagementPage/TeamDetailsWrapper/TeamDetailsWrapper.tsx
@@ -97,6 +97,7 @@ const TeamDetailsWrapper = ({
     isGlobalAdmin,
     isPremiumTier,
     setAvailableTeams,
+    setUISettings,
     setCurrentUser,
   } = useContext(AppContext);
 
@@ -140,9 +141,10 @@ const TeamDetailsWrapper = ({
 
   const { refetch: refetchMe } = useQuery(["me"], () => usersAPI.me(), {
     enabled: false,
-    onSuccess: ({ user, available_teams }: IGetMeResponse) => {
+    onSuccess: ({ user, available_teams, ui_settings }: IGetMeResponse) => {
       setCurrentUser(user);
       setAvailableTeams(user, available_teams);
+      setUISettings(ui_settings);
     },
   });
 

--- a/frontend/pages/admin/TeamManagementPage/TeamDetailsWrapper/TeamDetailsWrapper.tsx
+++ b/frontend/pages/admin/TeamManagementPage/TeamDetailsWrapper/TeamDetailsWrapper.tsx
@@ -141,10 +141,10 @@ const TeamDetailsWrapper = ({
 
   const { refetch: refetchMe } = useQuery(["me"], () => usersAPI.me(), {
     enabled: false,
-    onSuccess: ({ user, available_teams, user_settings }: IGetMeResponse) => {
+    onSuccess: ({ user, available_teams, settings }: IGetMeResponse) => {
       setCurrentUser(user);
       setAvailableTeams(user, available_teams);
-      setUserSettings(user_settings);
+      setUserSettings(settings);
     },
   });
 

--- a/frontend/pages/admin/TeamManagementPage/TeamDetailsWrapper/TeamDetailsWrapper.tsx
+++ b/frontend/pages/admin/TeamManagementPage/TeamDetailsWrapper/TeamDetailsWrapper.tsx
@@ -97,7 +97,7 @@ const TeamDetailsWrapper = ({
     isGlobalAdmin,
     isPremiumTier,
     setAvailableTeams,
-    setUISettings,
+    setUserSettings,
     setCurrentUser,
   } = useContext(AppContext);
 
@@ -141,10 +141,10 @@ const TeamDetailsWrapper = ({
 
   const { refetch: refetchMe } = useQuery(["me"], () => usersAPI.me(), {
     enabled: false,
-    onSuccess: ({ user, available_teams, ui_settings }: IGetMeResponse) => {
+    onSuccess: ({ user, available_teams, user_settings }: IGetMeResponse) => {
       setCurrentUser(user);
       setAvailableTeams(user, available_teams);
-      setUISettings(ui_settings);
+      setUserSettings(user_settings);
     },
   });
 

--- a/frontend/pages/admin/TeamManagementPage/TeamManagementPage.tsx
+++ b/frontend/pages/admin/TeamManagementPage/TeamManagementPage.tsx
@@ -49,10 +49,10 @@ const TeamManagementPage = (): JSX.Element => {
 
   const { refetch: refetchMe } = useQuery(["me"], () => usersAPI.me(), {
     enabled: false,
-    onSuccess: ({ user, available_teams, user_settings }: IGetMeResponse) => {
+    onSuccess: ({ user, available_teams, settings }: IGetMeResponse) => {
       setCurrentUser(user);
       setAvailableTeams(user, available_teams);
-      setUserSettings(user_settings);
+      setUserSettings(settings);
     },
   });
 

--- a/frontend/pages/admin/TeamManagementPage/TeamManagementPage.tsx
+++ b/frontend/pages/admin/TeamManagementPage/TeamManagementPage.tsx
@@ -35,7 +35,7 @@ const TeamManagementPage = (): JSX.Element => {
     setCurrentTeam,
     setCurrentUser,
     setAvailableTeams,
-    setUISettings,
+    setUserSettings,
   } = useContext(AppContext);
   const [isUpdatingTeams, setIsUpdatingTeams] = useState(false);
   const [showCreateTeamModal, setShowCreateTeamModal] = useState(false);
@@ -49,10 +49,10 @@ const TeamManagementPage = (): JSX.Element => {
 
   const { refetch: refetchMe } = useQuery(["me"], () => usersAPI.me(), {
     enabled: false,
-    onSuccess: ({ user, available_teams, ui_settings }: IGetMeResponse) => {
+    onSuccess: ({ user, available_teams, user_settings }: IGetMeResponse) => {
       setCurrentUser(user);
       setAvailableTeams(user, available_teams);
-      setUISettings(ui_settings);
+      setUserSettings(user_settings);
     },
   });
 

--- a/frontend/pages/admin/TeamManagementPage/TeamManagementPage.tsx
+++ b/frontend/pages/admin/TeamManagementPage/TeamManagementPage.tsx
@@ -35,6 +35,7 @@ const TeamManagementPage = (): JSX.Element => {
     setCurrentTeam,
     setCurrentUser,
     setAvailableTeams,
+    setUISettings,
   } = useContext(AppContext);
   const [isUpdatingTeams, setIsUpdatingTeams] = useState(false);
   const [showCreateTeamModal, setShowCreateTeamModal] = useState(false);
@@ -48,9 +49,10 @@ const TeamManagementPage = (): JSX.Element => {
 
   const { refetch: refetchMe } = useQuery(["me"], () => usersAPI.me(), {
     enabled: false,
-    onSuccess: ({ user, available_teams }: IGetMeResponse) => {
+    onSuccess: ({ user, available_teams, ui_settings }: IGetMeResponse) => {
       setCurrentUser(user);
       setAvailableTeams(user, available_teams);
+      setUISettings(ui_settings);
     },
   });
 

--- a/frontend/pages/hosts/ManageHostsPage/HostTableConfig.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/HostTableConfig.tsx
@@ -675,15 +675,14 @@ const generateAvailableTableHeaders = ({
   return allHostTableHeaders.reduce(
     (columns: Column<IHost>[], currentColumn: Column<IHost>) => {
       // skip over column headers that are not shown in free observer tier
-      if (isFreeTier && isOnlyObserver) {
+      if (isFreeTier) {
         if (
-          currentColumn.id === "team_name" ||
-          currentColumn.id === "selection"
+          isOnlyObserver &&
+          ["selection", "team_name"].includes(currentColumn.id || "")
         ) {
           return columns;
+          // skip over column headers that are not shown in free admin/maintainer
         }
-        // skip over column headers that are not shown in free admin/maintainer
-      } else if (isFreeTier) {
         if (
           currentColumn.id === "team_name" ||
           currentColumn.id === "mdm.server_url" ||
@@ -691,11 +690,9 @@ const generateAvailableTableHeaders = ({
         ) {
           return columns;
         }
-      } else if (isOnlyObserver) {
+      } else if (isOnlyObserver && currentColumn.id === "selection") {
         // In premium tier, we want to check user role to enable/disable select column
-        if (currentColumn.id === "selection") {
-          return columns;
-        }
+        return columns;
       }
 
       columns.push(currentColumn);

--- a/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
@@ -207,7 +207,7 @@ const ManageHostsPage = ({
   const [showTransferHostModal, setShowTransferHostModal] = useState(false);
   const [showDeleteHostModal, setShowDeleteHostModal] = useState(false);
   const [hiddenColumns, setHiddenColumns] = useState<string[]>(
-    userSettings?.hidden_hosts_table_columns || defaultHiddenColumns
+    userSettings?.hidden_host_columns || defaultHiddenColumns
   );
   const [selectedHostIds, setSelectedHostIds] = useState<number[]>([]);
   const [isAllMatchingHostsSelected, setIsAllMatchingHostsSelected] = useState(
@@ -767,7 +767,7 @@ const ManageHostsPage = ({
     }
     try {
       await usersAPI.update(currentUser.id, {
-        settings: { hidden_hosts_table_columns: newHiddenColumns },
+        settings: { hidden_host_columns: newHiddenColumns },
       });
       // No success renderFlash, to make column setting more seamless
     } catch (response) {

--- a/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
@@ -176,27 +176,6 @@ const ManageHostsPage = ({
     },
   });
 
-  // migrate users with current local storage based solution to db persistence
-  const locallyHiddenCols = localStorage.getItem("hostHiddenColumns");
-  if (locallyHiddenCols) {
-    (async () => {
-      if (!currentUser) {
-        // for type checker
-        return;
-      }
-      const parsed = JSON.parse(locallyHiddenCols) as string[];
-      try {
-        await usersAPI.update(currentUser.id, {
-          settings: { ...userSettings, hidden_host_columns: parsed },
-        });
-        localStorage.removeItem("hostHiddenColumns");
-      } catch {
-        // don't remove local storage, proceed with setting context with local storage value
-      }
-      setUserSettings({ ...userSettings, hidden_host_columns: parsed });
-    })();
-  }
-
   // Functions to avoid race conditions
   const initialSortBy: ISortOption[] = (() => {
     let key = DEFAULT_SORT_HEADER;
@@ -483,6 +462,29 @@ const ManageHostsPage = ({
       select: (data) => data.count,
     }
   );
+
+  // migrate users with current local storage based solution to db persistence
+  const locallyHiddenCols = localStorage.getItem("hostHiddenColumns");
+  if (locallyHiddenCols) {
+    console.log("found local hidden columns: ", locallyHiddenCols);
+    console.log("migrating to server persistence...");
+    (async () => {
+      if (!currentUser) {
+        // for type checker
+        return;
+      }
+      const parsed = JSON.parse(locallyHiddenCols) as string[];
+      try {
+        await usersAPI.update(currentUser.id, {
+          settings: { ...userSettings, hidden_host_columns: parsed },
+        });
+        localStorage.removeItem("hostHiddenColumns");
+      } catch {
+        // don't remove local storage, proceed with setting context with local storage value
+      }
+      setHiddenColumns(parsed);
+    })();
+  }
 
   const refetchHosts = () => {
     refetchHostsAPI();

--- a/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
@@ -173,11 +173,6 @@ const ManageHostsPage = ({
     },
   });
 
-  const hostHiddenColumns = localStorage.getItem("hostHiddenColumns");
-  const storedHiddenColumns = hostHiddenColumns
-    ? JSON.parse(hostHiddenColumns)
-    : null;
-
   // Functions to avoid race conditions
   const initialSortBy: ISortOption[] = (() => {
     let key = DEFAULT_SORT_HEADER;
@@ -209,9 +204,12 @@ const ManageHostsPage = ({
   const [showAddHostsModal, setShowAddHostsModal] = useState(false);
   const [showTransferHostModal, setShowTransferHostModal] = useState(false);
   const [showDeleteHostModal, setShowDeleteHostModal] = useState(false);
+
+  const { userSettings } = useContext(AppContext);
   const [hiddenColumns, setHiddenColumns] = useState<string[]>(
-    storedHiddenColumns || defaultHiddenColumns
+    userSettings?.hidden_hosts_table_columns || defaultHiddenColumns
   );
+
   const [selectedHostIds, setSelectedHostIds] = useState<number[]>([]);
   const [isAllMatchingHostsSelected, setIsAllMatchingHostsSelected] = useState(
     false

--- a/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
@@ -770,12 +770,14 @@ const ManageHostsPage = ({
         settings: { hidden_host_columns: newHiddenColumns },
       });
       // No success renderFlash, to make column setting more seamless
+      // only set state and close modal if server persist succeeds, keeping UI and server state in
+      // sync.
+      // Can also add local storage fallback behavior in next iteration if we want.
+      setHiddenColumns(newHiddenColumns);
+      setShowEditColumnsModal(false);
     } catch (response) {
       renderFlash("error", "Couldn't save column settings. Please try again.");
     }
-
-    setHiddenColumns(newHiddenColumns);
-    setShowEditColumnsModal(false);
   };
 
   // NOTE: this is called once on initial render and every time the query changes

--- a/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
@@ -13,6 +13,7 @@ import { format } from "date-fns";
 import FileSaver from "file-saver";
 
 import enrollSecretsAPI from "services/entities/enroll_secret";
+import usersAPI from "services/entities/users";
 import labelsAPI, { ILabelsResponse } from "services/entities/labels";
 import teamsAPI, { ILoadTeamsResponse } from "services/entities/teams";
 import globalPoliciesAPI from "services/entities/global_policies";
@@ -141,6 +142,7 @@ const ManageHostsPage = ({
     isPremiumTier,
     isFreeTier,
     isSandboxMode,
+    userSettings,
     setFilteredHostsPath,
     setFilteredPoliciesPath,
     setFilteredQueriesPath,
@@ -204,12 +206,9 @@ const ManageHostsPage = ({
   const [showAddHostsModal, setShowAddHostsModal] = useState(false);
   const [showTransferHostModal, setShowTransferHostModal] = useState(false);
   const [showDeleteHostModal, setShowDeleteHostModal] = useState(false);
-
-  const { userSettings } = useContext(AppContext);
   const [hiddenColumns, setHiddenColumns] = useState<string[]>(
     userSettings?.hidden_hosts_table_columns || defaultHiddenColumns
   );
-
   const [selectedHostIds, setSelectedHostIds] = useState<number[]>([]);
   const [isAllMatchingHostsSelected, setIsAllMatchingHostsSelected] = useState(
     false
@@ -762,8 +761,18 @@ const ManageHostsPage = ({
     router.push(`${PATHS.EDIT_LABEL(parseInt(labelID, 10))}`);
   };
 
-  const onSaveColumns = (newHiddenColumns: string[]) => {
-    localStorage.setItem("hostHiddenColumns", JSON.stringify(newHiddenColumns));
+  const onSaveColumns = async (newHiddenColumns: string[]) => {
+    // localStorage.setItem("hostHiddenColumns", JSON.stringify(newHiddenColumns));
+    try {
+      await usersAPI.update(currentUser!.id, {
+        settings: { hidden_hosts_table_columns: newHiddenColumns },
+      });
+      // No renderFlash, to make column setting more seamless
+      return true;
+    } catch (response) {
+      renderFlash("error", "Couldn't save column settings. Please try again.");
+    }
+
     setHiddenColumns(newHiddenColumns);
     setShowEditColumnsModal(false);
   };

--- a/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
@@ -762,8 +762,11 @@ const ManageHostsPage = ({
   };
 
   const onSaveColumns = async (newHiddenColumns: string[]) => {
+    if (!currentUser) {
+      return;
+    }
     try {
-      await usersAPI.update(currentUser!.id, {
+      await usersAPI.update(currentUser.id, {
         settings: { hidden_hosts_table_columns: newHiddenColumns },
       });
       // No success renderFlash, to make column setting more seamless

--- a/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
@@ -762,7 +762,6 @@ const ManageHostsPage = ({
   };
 
   const onSaveColumns = async (newHiddenColumns: string[]) => {
-    // localStorage.setItem("hostHiddenColumns", JSON.stringify(newHiddenColumns));
     try {
       await usersAPI.update(currentUser!.id, {
         settings: { hidden_hosts_table_columns: newHiddenColumns },

--- a/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
@@ -767,8 +767,7 @@ const ManageHostsPage = ({
       await usersAPI.update(currentUser!.id, {
         settings: { hidden_hosts_table_columns: newHiddenColumns },
       });
-      // No renderFlash, to make column setting more seamless
-      return true;
+      // No success renderFlash, to make column setting more seamless
     } catch (response) {
       renderFlash("error", "Couldn't save column settings. Please try again.");
     }

--- a/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
@@ -178,12 +178,12 @@ const ManageHostsPage = ({
 
   // migrate users with current local storage based solution to db persistence
   const locallyHiddenCols = localStorage.getItem("hostHiddenColumns");
-  if (!currentUser) {
-    // for type checker
-    return <></>;
-  }
   if (locallyHiddenCols) {
     (async () => {
+      if (!currentUser) {
+        // for type checker
+        return;
+      }
       const parsed = JSON.parse(locallyHiddenCols) as string[];
       try {
         await usersAPI.update(currentUser.id, {

--- a/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
@@ -789,7 +789,7 @@ const ManageHostsPage = ({
     }
     try {
       await usersAPI.update(currentUser.id, {
-        settings: { hidden_host_columns: newHiddenColumns },
+        settings: { ...userSettings, hidden_host_columns: newHiddenColumns },
       });
       // No success renderFlash, to make column setting more seamless
       // only set state and close modal if server persist succeeds, keeping UI and server state in

--- a/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
@@ -11,7 +11,6 @@ import { RouteProps } from "react-router/lib/Route";
 import { find, isEmpty, isEqual, omit } from "lodash";
 import { format } from "date-fns";
 import FileSaver from "file-saver";
-import classNames from "classnames";
 
 import enrollSecretsAPI from "services/entities/enroll_secret";
 import labelsAPI, { ILabelsResponse } from "services/entities/labels";
@@ -46,7 +45,6 @@ import {
   IEnrollSecret,
   IEnrollSecretsResponse,
 } from "interfaces/enroll_secret";
-import { getErrorReason } from "interfaces/errors";
 import { ILabel } from "interfaces/label";
 import { IOperatingSystemVersion } from "interfaces/operating_system";
 import { IPolicy, IStoredPolicyResponse } from "interfaces/policy";

--- a/frontend/services/entities/users.ts
+++ b/frontend/services/entities/users.ts
@@ -114,7 +114,7 @@ export default {
   },
   me: (): Promise<IGetMeResponse> => {
     // include the user's settings when calling from the UI
-    const path = `${endpoints.ME}?include_settings=true`;
+    const path = `${endpoints.ME}?include_ui_settings=true`;
     return sendRequest("GET", path).then(
       ({ user, available_teams, settings }) => {
         return {

--- a/frontend/services/entities/users.ts
+++ b/frontend/services/entities/users.ts
@@ -42,7 +42,7 @@ interface IRequirePasswordReset {
 export interface IGetMeResponse {
   user: IUser;
   available_teams: ITeamSummary[];
-  user_settings: IUserSettings;
+  settings: IUserSettings;
 }
 
 export default {
@@ -116,11 +116,11 @@ export default {
     // include the user's settings when calling from the UI
     const path = `${endpoints.ME}?include_settings=true`;
     return sendRequest("GET", path).then(
-      ({ user, available_teams, user_settings }) => {
+      ({ user, available_teams, settings }) => {
         return {
           user: helpers.addGravatarUrlToResource(user),
           available_teams,
-          user_settings,
+          settings,
         };
       }
     );

--- a/frontend/services/entities/users.ts
+++ b/frontend/services/entities/users.ts
@@ -11,7 +11,7 @@ import {
   ICreateUserWithInvitationFormData,
 } from "interfaces/user";
 import { ITeamSummary } from "interfaces/team";
-import { IUserUISettings } from "interfaces/config";
+import { IUserSettings } from "interfaces/config";
 
 export interface ISortOption {
   id: number;
@@ -42,7 +42,7 @@ interface IRequirePasswordReset {
 export interface IGetMeResponse {
   user: IUser;
   available_teams: ITeamSummary[];
-  ui_settings: IUserUISettings;
+  user_settings: IUserSettings;
 }
 
 export default {
@@ -113,14 +113,14 @@ export default {
     });
   },
   me: (): Promise<IGetMeResponse> => {
-    // include the user's UI settings when calling from the UI
-    const path = `${endpoints.ME}?include_ui_settings=true`;
+    // include the user's settings when calling from the UI
+    const path = `${endpoints.ME}?include_settings=true`;
     return sendRequest("GET", path).then(
-      ({ user, available_teams, ui_settings }) => {
+      ({ user, available_teams, user_settings }) => {
         return {
           user: helpers.addGravatarUrlToResource(user),
           available_teams,
-          ui_settings,
+          user_settings,
         };
       }
     );

--- a/frontend/services/entities/users.ts
+++ b/frontend/services/entities/users.ts
@@ -11,6 +11,7 @@ import {
   ICreateUserWithInvitationFormData,
 } from "interfaces/user";
 import { ITeamSummary } from "interfaces/team";
+import { IUserUISettings } from "interfaces/config";
 
 export interface ISortOption {
   id: number;
@@ -41,6 +42,7 @@ interface IRequirePasswordReset {
 export interface IGetMeResponse {
   user: IUser;
   available_teams: ITeamSummary[];
+  ui_settings: IUserUISettings;
 }
 
 export default {
@@ -111,14 +113,17 @@ export default {
     });
   },
   me: (): Promise<IGetMeResponse> => {
-    const { ME } = endpoints;
-
-    return sendRequest("GET", ME).then(({ user, available_teams }) => {
-      return {
-        user: helpers.addGravatarUrlToResource(user),
-        available_teams,
-      };
-    });
+    // include the user's UI settings when calling from the UI
+    const path = `${endpoints.ME}?include_ui_settings=true`;
+    return sendRequest("GET", path).then(
+      ({ user, available_teams, ui_settings }) => {
+        return {
+          user: helpers.addGravatarUrlToResource(user),
+          available_teams,
+          ui_settings,
+        };
+      }
+    );
   },
   performRequiredPasswordReset: (new_password: string) => {
     const { PERFORM_REQUIRED_PASSWORD_RESET } = endpoints;


### PR DESCRIPTION
## For #25032

<img width="1792" alt="Screenshot 2025-01-07 at 6 50 39 PM" src="https://github.com/user-attachments/assets/17a63b3d-a983-433a-a3c4-6c66dbb08fce" />

- Add new `include_ui_settings` query param to `GET` `/me` calls
- Use new `settings` in response to set settings into UI context
- On hosts page, use that context, if present, to set which columns are hidden. Fallback to a default set of hidden columns.
- When updating visible columns, persist preference via `PATCH` to `/users/:id` with a new `settings` payload

- [x] Changes file added for user-visible changes in `changes/`
- [x] Manual QA for all new/changed functionality
