### PR TITLE
Add note about script execution timeout config

### DIFF
--- a/docs/Configuration/agent-configuration.md
+++ b/docs/Configuration/agent-configuration.md
@@ -497,7 +497,7 @@ How to update agent options:
 
 The agents may take several seconds to update because Fleet has to wait for the hosts to check in. Additionally, hosts enrolled with removed enroll secrets must properly rotate their secret to have the new changes take effect.
 
-
+> When configuring a value for [`script_execution_timeout`](https://fleetdm.com/docs/configuration/agent-configuration#script-execution-timeout) in the UI, make sure to put the key at the top level of the YAML, _not_ as a child of `config`.  
 
 <meta name="pageOrderInSection" value="300">
 <meta name="description" value="Learn how to use configuration files and the fleetctl command line tool to configure agent options.">


### PR DESCRIPTION
relates to #24247 

There's nothing actually wrong in the current docs.  We document that to set `script_execution_timeout` in a YAML file you do:

```yaml
agent_options:
  script_execution_timeout: 600
```

which is correct.  It's just that in the UI we hide the top-level `agent_options` key entirely. This makes sense from a UX standpoint but it's easy to see how someone could get confused.  The _best_ option would be to have `script_execution_timeout` always returned from the config endpoint so that it appeared in the right place in the UI and the user would just have to edit it, but I'd wait for more reports on this before committing that level of effort.