### PR TITLE
Hide updated time when loading OS versions table data

### DIFF
--- a/changes/24629-ui-os-updates-table
+++ b/changes/24629-ui-os-updates-table
@@ -1,0 +1,2 @@
+- Fixed UI bug on the "Controls" page where incorrect timestamp information was displayed while the
+  "Current versions" table was loading.

--- a/frontend/pages/ManageControlsPage/OSUpdates/components/CurrentVersionSection/CurrentVersionSection.tsx
+++ b/frontend/pages/ManageControlsPage/OSUpdates/components/CurrentVersionSection/CurrentVersionSection.tsx
@@ -145,7 +145,7 @@ const CurrentVersionSection = ({
     <div className={baseClass}>
       <SectionHeader
         title="Current versions"
-        subTitle={generateSubTitleText()}
+        subTitle={!isLoadingOsVersions ? generateSubTitleText() : null}
         wrapperCustomClass={`${baseClass}__header`}
       />
       {renderTable()}

--- a/frontend/pages/ManageControlsPage/OSUpdates/components/CurrentVersionSection/CurrentVersionSection.tsx
+++ b/frontend/pages/ManageControlsPage/OSUpdates/components/CurrentVersionSection/CurrentVersionSection.tsx
@@ -145,7 +145,7 @@ const CurrentVersionSection = ({
     <div className={baseClass}>
       <SectionHeader
         title="Current versions"
-        subTitle={!isLoadingOsVersions ? generateSubTitleText() : null}
+        subTitle={isLoadingOsVersions ? null : generateSubTitleText()}
         wrapperCustomClass={`${baseClass}__header`}
       />
       {renderTable()}


### PR DESCRIPTION
For #24629 

# Checklist for submitter
- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
- [x] Manual QA for all new/changed functionality

