### PR TITLE
Fleet UI: Software headers more responsive

### DIFF
--- a/frontend/components/TableContainer/TableContainer.tsx
+++ b/frontend/components/TableContainer/TableContainer.tsx
@@ -83,7 +83,7 @@ interface ITableContainerProps<T = any> {
   onQueryChange?:
     | ((queryData: ITableQueryData) => void)
     | ((queryData: ITableQueryData) => number);
-  customControl?: () => JSX.Element;
+  customControl?: () => JSX.Element | null;
   /** Filter button right of the search rendering alternative responsive design where search bar moves to new line but filter button remains inline with other table headers */
   customFiltersButton?: () => JSX.Element;
   stackControls?: boolean;
@@ -292,7 +292,7 @@ const TableContainer = <T,>({
     if (customFiltersButton) {
       return (
         <div className="container">
-          <div className="box">
+          <div className="header">
             {renderCount && !disableCount && (
               <div
                 className={`${baseClass}__results-count ${
@@ -304,8 +304,9 @@ const TableContainer = <T,>({
               </div>
             )}
           </div>
-          <div className="box">
-            {actionButton && !actionButton.hideButton && (
+
+          {actionButton && !actionButton.hideButton && (
+            <div className="header">
               <Button
                 disabled={disableActionButton}
                 onClick={actionButton.onActionButtonClick}
@@ -317,10 +318,10 @@ const TableContainer = <T,>({
                   {actionButton.iconSvg && <Icon name={actionButton.iconSvg} />}
                 </>
               </Button>
-            )}
-            {customControl && customControl()}
-          </div>
-          <div className="box search">
+            </div>
+          )}
+          <div className="header top-shift-header">
+            {customControl ? customControl() : undefined}
             {searchable && !wideSearch && (
               <div className={`${baseClass}__search`}>
                 <div
@@ -347,8 +348,8 @@ const TableContainer = <T,>({
                 </ReactTooltip>
               </div>
             )}
+            {customFiltersButton()}
           </div>
-          <div className="box"> {customFiltersButton()} </div>
         </div>
       );
     }

--- a/frontend/components/TableContainer/TableContainer.tsx
+++ b/frontend/components/TableContainer/TableContainer.tsx
@@ -288,7 +288,7 @@ const TableContainer = <T,>({
     const opacity = isLoading ? { opacity: 0.4 } : { opacity: 1 };
 
     // New preferred pattern uses grid container/box to allow for more dynamic responsiveness
-    // At low widths, search bar (3rd div of 4) moves above other 3 divs
+    // At low widths, right header stacks on top of left header
     if (stackControls) {
       return (
         <div className="container">
@@ -321,7 +321,7 @@ const TableContainer = <T,>({
             </div>
           )}
           <div className="stackable-header top-shift-header">
-            {customControl ? customControl() : undefined}
+            {customControl && customControl()}
             {searchable && !wideSearch && (
               <div className={`${baseClass}__search`}>
                 <div

--- a/frontend/components/TableContainer/TableContainer.tsx
+++ b/frontend/components/TableContainer/TableContainer.tsx
@@ -289,10 +289,10 @@ const TableContainer = <T,>({
 
     // New preferred pattern uses grid container/box to allow for more dynamic responsiveness
     // At low widths, search bar (3rd div of 4) moves above other 3 divs
-    if (customFiltersButton) {
+    if (stackControls) {
       return (
         <div className="container">
-          <div className="header">
+          <div className="stackable-header">
             {renderCount && !disableCount && (
               <div
                 className={`${baseClass}__results-count ${
@@ -306,7 +306,7 @@ const TableContainer = <T,>({
           </div>
 
           {actionButton && !actionButton.hideButton && (
-            <div className="header">
+            <div className="stackable-header">
               <Button
                 disabled={disableActionButton}
                 onClick={actionButton.onActionButtonClick}
@@ -320,7 +320,7 @@ const TableContainer = <T,>({
               </Button>
             </div>
           )}
-          <div className="header top-shift-header">
+          <div className="stackable-header top-shift-header">
             {customControl ? customControl() : undefined}
             {searchable && !wideSearch && (
               <div className={`${baseClass}__search`}>
@@ -348,7 +348,7 @@ const TableContainer = <T,>({
                 </ReactTooltip>
               </div>
             )}
-            {customFiltersButton()}
+            {customFiltersButton && customFiltersButton()}
           </div>
         </div>
       );

--- a/frontend/components/TableContainer/_styles.scss
+++ b/frontend/components/TableContainer/_styles.scss
@@ -13,7 +13,7 @@
     gap: $pad-small $pad-medium;
   }
 
-  .header {
+  .stackable-header {
     min-width: max-content;
     align-content: center;
     display: flex;
@@ -23,6 +23,11 @@
     > div {
       display: flex;
       flex-direction: row;
+    }
+
+    // only if in stackable header
+    .table-container__search {
+      width: 100%;
     }
   }
 
@@ -36,7 +41,7 @@
     }
   }
 
-  .header:nth-child(1) {
+  .stackable-header:nth-child(1) {
     grid-column: 1 / span 2; /* Make Header 1 expand across two columns */
     grid-row: 2;
 
@@ -46,7 +51,7 @@
   }
 
   /* Media query for larger screens */
-  @media (min-width: $table-controls-break) {
+  @media (min-width: $break-md) {
     .container {
       grid-template-columns: 1fr auto; /* First column takes all remaining space */
       grid-template-rows: auto; /* Single row */
@@ -56,7 +61,7 @@
       grid-column: 2; /* Single row */
     }
 
-    .header:nth-child(1) {
+    .stackable-header:nth-child(1) {
       grid-column: 1; /* Ensure Header 1 stays in the first column */
       grid-row: 1; /* Single row */
     }

--- a/frontend/components/TableContainer/_styles.scss
+++ b/frontend/components/TableContainer/_styles.scss
@@ -6,14 +6,14 @@
   // Container is responsive design used when customFilters is rendered
   .container {
     display: grid;
-    grid-template-columns: 1fr auto auto; /* First column takes all remaining space */
-    grid-template-rows: auto auto; /* Two rows */
+    grid-template-columns: 1fr auto; /* First column takes all remaining space */
+    grid-template-rows: auto auto; /* Two rows for smaller screens*/
     width: 100%;
     height: max-content;
     gap: $pad-small $pad-medium;
   }
 
-  .box {
+  .header {
     min-width: max-content;
     align-content: center;
     display: flex;
@@ -26,54 +26,39 @@
     }
   }
 
-  .search {
+  .top-shift-header {
     grid-column: 1 / -1; /* Span across all columns */
     grid-row: 1; /* Place in the first row */
+
+    .Select-multi-value-wrapper {
+      height: 36px; // Fixes height issues
+      width: 236px;
+    }
   }
 
-  .box:nth-child(1) {
-    grid-column: 1 / span 2; /* Make Box 1 expand across two columns */
+  .header:nth-child(1) {
+    grid-column: 1 / span 2; /* Make Header 1 expand across two columns */
     grid-row: 2;
-  }
 
-  .box:nth-child(2) {
-    grid-column: 2; /* Place Box 2 in the second row, second column */
-    grid-row: 2;
-  }
-
-  .box:nth-child(4) {
-    grid-column: 3; /* Place Box 4 in the second row, third column */
-    grid-row: 2;
-    max-width: min-content;
+    .form-field--dropdown {
+      width: 235px;
+    }
   }
 
   /* Media query for larger screens */
   @media (min-width: $table-controls-break) {
     .container {
-      grid-template-columns: 1fr auto auto auto; /* First column takes all remaining space */
+      grid-template-columns: 1fr auto; /* First column takes all remaining space */
       grid-template-rows: auto; /* Single row */
     }
 
-    .search {
-      grid-column: 1 / -1; /* Keep spanning across all columns if needed */
-      grid-row: auto;
+    .top-shift-header {
+      grid-column: 2; /* Single row */
     }
 
-    .box:nth-child(1) {
-      grid-column: 1; /* Ensure Box 1 stays in the first column */
-    }
-
-    .box:nth-child(2) {
-      grid-column: 2; /* Place Box 2 in the second column */
-    }
-
-    .box:nth-child(3) {
-      grid-column: 3; /* Place Box 3 in the third column */
-      grid-row: 2;
-    }
-
-    .box:nth-child(4) {
-      grid-column: 4; /* Place Box 4 in the fourth column */
+    .header:nth-child(1) {
+      grid-column: 1; /* Ensure Header 1 stays in the first column */
+      grid-row: 1; /* Single row */
     }
   }
 
@@ -137,10 +122,6 @@
       @media (min-width: $break-md) {
         justify-content: space-between;
       }
-    }
-
-    .Select-multi-value-wrapper {
-      height: 38px; // Fixes overlap with .Select outline
     }
   }
 

--- a/frontend/components/forms/fields/DropdownWrapper/DropdownWrapper.stories.tsx
+++ b/frontend/components/forms/fields/DropdownWrapper/DropdownWrapper.stories.tsx
@@ -1,62 +1,81 @@
 // stories/DropdownWrapper.stories.tsx
 
 import React from "react";
-import { Meta, Story } from "@storybook/react";
-import DropdownWrapper, {
-  IDropdownWrapper,
-  CustomOptionType,
-} from "./DropdownWrapper";
+import type { Meta, StoryObj } from "@storybook/react";
+import DropdownWrapper, { CustomOptionType } from "./DropdownWrapper";
 
 // Define metadata for the story
-export default {
+const meta: Meta<typeof DropdownWrapper> = {
   title: "Components/DropdownWrapper",
   component: DropdownWrapper,
   argTypes: {
     onChange: { action: "changed" },
   },
-} as Meta;
+  // Padding added to view tooltips
+  decorators: [
+    (Story) => (
+      <div style={{ overflow: "visible", padding: "150px" }}>
+        <Story />
+      </div>
+    ),
+  ],
+};
 
-// Define a template for the stories
-const Template: Story<IDropdownWrapper> = (args) => (
-  <DropdownWrapper {...args} />
-);
+export default meta;
+
+type Story = StoryObj<typeof DropdownWrapper>;
 
 // Sample options to be used in the dropdown
 const sampleOptions: CustomOptionType[] = [
-  { label: "Option 1", value: "option1", helpText: "Help text for option 1" },
   {
-    label: "Option 2",
+    label: "Option 1 - just help text",
+    value: "option1",
+    helpText: "Help text for option 1",
+  },
+  {
+    label: "Option 2 - just tooltip",
     value: "option2",
     tooltipContent: "Tooltip for option 2",
   },
-  { label: "Option 3", value: "option3", isDisabled: true },
+  { label: "Option 3 - just disabled", value: "option3", isDisabled: true },
+  {
+    label: "Option 4 - help text, disabled, and tooltip",
+    value: "option4",
+    helpText: "Help text for option 4",
+    isDisabled: true,
+    tooltipContent: "Tooltip for option 4",
+  },
 ];
 
 // Default story
-export const Default = Template.bind({});
-Default.args = {
-  options: sampleOptions,
-  name: "dropdown-example",
-  label: "Select an option",
+export const Default: Story = {
+  args: {
+    options: sampleOptions,
+    name: "dropdown-example",
+    label: "Select an option",
+  },
 };
 
 // Disabled story
-export const Disabled = Template.bind({});
-Disabled.args = {
-  ...Default.args,
-  isDisabled: true,
+export const Disabled: Story = {
+  args: {
+    ...Default.args,
+    isDisabled: true,
+  },
 };
 
 // With Help Text story
-export const WithHelpText = Template.bind({});
-WithHelpText.args = {
-  ...Default.args,
-  helpText: "This is some help text for the dropdown",
+export const WithHelpText: Story = {
+  args: {
+    ...Default.args,
+    helpText: "This is some help text for the dropdown",
+  },
 };
 
 // With Error story
-export const WithError = Template.bind({});
-WithError.args = {
-  ...Default.args,
-  error: "This is an error message",
+export const WithError: Story = {
+  args: {
+    ...Default.args,
+    error: "This is an error message",
+  },
 };

--- a/frontend/components/forms/fields/DropdownWrapper/DropdownWrapper.tsx
+++ b/frontend/components/forms/fields/DropdownWrapper/DropdownWrapper.tsx
@@ -280,7 +280,6 @@ const DropdownWrapper = ({
         color: COLORS["ui-fleet-black-50"],
         fontStyle: "italic",
         cursor: "not-allowed",
-        pointerEvents: "none",
       }),
       // Styles for custom option
       ".dropdown-wrapper__option": {

--- a/frontend/components/forms/fields/DropdownWrapper/DropdownWrapper.tsx
+++ b/frontend/components/forms/fields/DropdownWrapper/DropdownWrapper.tsx
@@ -26,6 +26,7 @@ import { PADDING } from "styles/var/padding";
 import FormField from "components/forms/FormField";
 import DropdownOptionTooltipWrapper from "components/forms/fields/Dropdown/DropdownOptionTooltipWrapper";
 import Icon from "components/Icon";
+import { IconNames } from "components/icons";
 
 const getOptionBackgroundColor = (state: any) => {
   return state.isSelected || state.isFocused
@@ -39,6 +40,7 @@ export interface CustomOptionType {
   tooltipContent?: string;
   helpText?: string;
   isDisabled?: boolean;
+  iconName?: IconNames;
 }
 
 export interface IDropdownWrapper {
@@ -53,6 +55,7 @@ export interface IDropdownWrapper {
   helpText?: JSX.Element | string;
   isSearchable?: boolean;
   isDisabled?: boolean;
+  iconName?: IconNames;
   placeholder?: string;
   /** E.g. scroll to view dropdown menu in a scrollable parent container */
   onMenuOpen?: () => void;
@@ -70,8 +73,9 @@ const DropdownWrapper = ({
   error,
   label,
   helpText,
-  isSearchable,
+  isSearchable = false,
   isDisabled = false,
+  iconName,
   placeholder,
   onMenuOpen,
 }: IDropdownWrapper) => {
@@ -120,7 +124,7 @@ const DropdownWrapper = ({
   };
 
   const CustomDropdownIndicator = (
-    props: DropdownIndicatorProps<any, false, any>
+    props: DropdownIndicatorProps<CustomOptionType, false, any>
   ) => {
     const { isFocused, selectProps } = props;
     const color =
@@ -139,6 +143,19 @@ const DropdownWrapper = ({
           className={`${baseClass}__icon`}
         />
       </components.DropdownIndicator>
+    );
+  };
+
+  const ValueContainer = ({ children, ...props }: any) => {
+    return (
+      components.ValueContainer && (
+        <components.ValueContainer {...props}>
+          {!!children && iconName && (
+            <Icon name={iconName} className="filter-icon" />
+          )}
+          {children}
+        </components.ValueContainer>
+      )
     );
   };
 
@@ -235,10 +252,13 @@ const DropdownWrapper = ({
     menuList: (provided) => ({
       ...provided,
       padding: PADDING["pad-small"],
+      maxHeight: "none",
     }),
     valueContainer: (provided) => ({
       ...provided,
       padding: 0,
+      display: "flex",
+      gap: PADDING["pad-small"],
     }),
     option: (provided, state) => ({
       ...provided,
@@ -323,6 +343,7 @@ const DropdownWrapper = ({
           Option: CustomOption,
           DropdownIndicator: CustomDropdownIndicator,
           IndicatorSeparator: () => null,
+          ValueContainer,
         }}
         value={getCurrentValue()}
         onChange={handleChange}

--- a/frontend/pages/SoftwarePage/SoftwareTitles/SoftwareTable/SoftwareTable.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitles/SoftwareTable/SoftwareTable.tsx
@@ -21,8 +21,6 @@ import {
 } from "services/entities/software";
 import { ISoftwareTitle, ISoftwareVersion } from "interfaces/software";
 
-// @ts-ignore
-import Dropdown from "components/forms/fields/Dropdown";
 import TableContainer from "components/TableContainer";
 import Slider from "components/forms/fields/Slider";
 import CustomLink from "components/CustomLink";
@@ -32,6 +30,9 @@ import TableCount from "components/TableContainer/TableCount";
 import Button from "components/buttons/Button";
 import Icon from "components/Icon";
 import TooltipWrapper from "components/TooltipWrapper";
+import { SingleValue } from "react-select-5";
+import DropdownWrapper from "components/forms/fields/DropdownWrapper";
+import { CustomOptionType } from "components/forms/fields/DropdownWrapper/DropdownWrapper";
 
 import EmptySoftwareTable from "pages/SoftwarePage/components/EmptySoftwareTable";
 
@@ -284,28 +285,36 @@ const SoftwareTable = ({
             }
           />
         )}
-      </>
-    );
-  };
-
-  const renderCustomControls = () => {
-    return (
-      <div className={`${baseClass}__filter-controls`}>
-        {!showVersions && ( // Hidden when viewing versions table
-          <Dropdown
-            value={softwareFilter}
-            className={`${baseClass}__vuln_dropdown`}
-            options={SOFTWARE_TITLES_DROPDOWN_OPTIONS}
-            searchable={false}
-            onChange={handleCustomFilterDropdownChange}
-            iconName="filter"
-          />
-        )}
         <Slider
           value={showVersions}
           onChange={handleShowVersionsToggle}
           inactiveText="Show versions"
           activeText="Show versions"
+        />
+      </>
+    );
+  };
+
+  const renderCustomControls = () => {
+    // Hidden when viewing versions table
+    if (showVersions) {
+      return null;
+    }
+
+    return (
+      <div className={`${baseClass}__filter-controls`}>
+        <DropdownWrapper
+          name="software-filter"
+          value={softwareFilter}
+          className={`${baseClass}__filter-dropdown`}
+          options={SOFTWARE_TITLES_DROPDOWN_OPTIONS}
+          onChange={(newValue: SingleValue<CustomOptionType>) =>
+            newValue &&
+            handleCustomFilterDropdownChange(
+              newValue.value as ISoftwareDropdownFilterVal
+            )
+          }
+          iconName="filter"
         />
       </div>
     );

--- a/frontend/pages/SoftwarePage/SoftwareTitles/SoftwareTable/_styles.scss
+++ b/frontend/pages/SoftwarePage/SoftwareTitles/SoftwareTable/_styles.scss
@@ -1,6 +1,6 @@
 .software-table {
   &__filter-dropdown {
-    min-width: 234px;
+    min-width: 213px;
   }
 
   &__filter-controls {
@@ -47,7 +47,7 @@
       width: 100%; // Search bar across entire table
 
       .input-icon-field__input {
-        width: 100%;
+        min-width: 213px;
       }
 
       @media (min-width: $table-controls-break) {

--- a/frontend/pages/SoftwarePage/SoftwareTitles/SoftwareTable/_styles.scss
+++ b/frontend/pages/SoftwarePage/SoftwareTitles/SoftwareTable/_styles.scss
@@ -1,22 +1,6 @@
 .software-table {
-  &__vuln_dropdown {
-    .Select-menu-outer {
-      width: 250px;
-      max-height: 310px;
-
-      .Select-menu {
-        max-height: none;
-      }
-    }
-
-    .Select-value {
-      padding-left: $pad-medium;
-      padding-right: $pad-medium;
-    }
-
-    .dropdown__custom-value-label {
-      width: 155px; // Override 105px for longer text options
-    }
+  &__filter-dropdown {
+    min-width: 234px;
   }
 
   &__filter-controls {

--- a/frontend/pages/SoftwarePage/SoftwareVulnerabilities/SoftwareVulnerabilitiesTable/SoftwareVulnerabilitiesTable.tests.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareVulnerabilities/SoftwareVulnerabilitiesTable/SoftwareVulnerabilitiesTable.tests.tsx
@@ -2,10 +2,7 @@ import React from "react";
 import { screen, waitFor } from "@testing-library/react";
 import { createCustomRenderer } from "test/test-utils";
 
-import {
-  createMockVulnerabilitiesResponse,
-  createMockVulnerability,
-} from "__mocks__/vulnerabilitiesMock";
+import { createMockVulnerabilitiesResponse } from "__mocks__/vulnerabilitiesMock";
 import createMockUser from "__mocks__/userMock";
 
 import SoftwareVulnerabilitiesTable from "./SoftwareVulnerabilitiesTable";
@@ -353,7 +350,7 @@ describe("Software Vulnerabilities table", () => {
     expect(
       screen.getByText("Exploited vulnerabilities").parentElement?.parentElement
         ?.parentElement
-    ).toHaveClass("is-disabled");
+    ).toHaveClass("react-select__option--is-disabled");
 
     await waitFor(() => {
       waitFor(() => {

--- a/frontend/pages/SoftwarePage/SoftwareVulnerabilities/SoftwareVulnerabilitiesTable/SoftwareVulnerabilitiesTable.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareVulnerabilities/SoftwareVulnerabilitiesTable/SoftwareVulnerabilitiesTable.tsx
@@ -13,13 +13,14 @@ import {
 } from "utilities/constants";
 import { isIncompleteQuoteQuery } from "utilities/strings/stringUtils";
 
-// @ts-ignore
-import Dropdown from "components/forms/fields/Dropdown";
 import CustomLink from "components/CustomLink";
 import TableContainer from "components/TableContainer";
 import LastUpdatedText from "components/LastUpdatedText";
 import { ITableQueryData } from "components/TableContainer/TableContainer";
 import TableCount from "components/TableContainer/TableCount";
+import { SingleValue } from "react-select-5";
+import DropdownWrapper from "components/forms/fields/DropdownWrapper";
+import { CustomOptionType } from "components/forms/fields/DropdownWrapper/DropdownWrapper";
 
 import EmptyVulnerabilitiesTable from "pages/SoftwarePage/components/EmptyVulnerabilitiesTable";
 
@@ -165,7 +166,7 @@ const SoftwareVulnerabilitiesTable = ({
   }, [data, router, teamId]);
 
   const handleExploitedVulnFilterDropdownChange = (
-    isFilterExploited: boolean
+    isFilterExploited: string
   ) => {
     router.replace(
       getNextLocationPath({
@@ -176,7 +177,7 @@ const SoftwareVulnerabilitiesTable = ({
           team_id: teamId,
           order_direction: orderDirection,
           order_key: orderKey,
-          exploit: isFilterExploited.toString(),
+          exploit: isFilterExploited,
           page: 0, // resets page index
         },
       })
@@ -236,12 +237,14 @@ const SoftwareVulnerabilitiesTable = ({
   // Exploited vulnerabilities is a premium feature
   const renderExploitedVulnerabilitiesDropdown = () => {
     return (
-      <Dropdown
-        value={showExploitedVulnerabilitiesOnly}
+      <DropdownWrapper
+        name="exploited-vuln-dropdown"
+        value={showExploitedVulnerabilitiesOnly.toString()}
         className={`${baseClass}__exploited-vulnerabilities-dropdown`}
         options={getExploitedVulnerabilitiesDropdownOptions(isPremiumTier)}
-        searchable={false}
-        onChange={handleExploitedVulnFilterDropdownChange}
+        onChange={(newValue: SingleValue<CustomOptionType>) =>
+          newValue && handleExploitedVulnFilterDropdownChange(newValue.value)
+        }
         iconName="filter"
       />
     );
@@ -280,6 +283,7 @@ const SoftwareVulnerabilitiesTable = ({
         customControl={
           searchable ? renderExploitedVulnerabilitiesDropdown : undefined
         }
+        stackControls
         renderCount={renderVulnerabilityCount}
         renderTableHelpText={renderTableHelpText}
         disableMultiRowSelect

--- a/frontend/pages/SoftwarePage/SoftwareVulnerabilities/SoftwareVulnerabilitiesTable/_styles.scss
+++ b/frontend/pages/SoftwarePage/SoftwareVulnerabilities/SoftwareVulnerabilitiesTable/_styles.scss
@@ -1,6 +1,6 @@
 .software-vulnerabilities-table {
   &__exploited-vulnerabilities-dropdown {
-    min-width: 234px;
+    min-width: 250px;
   }
 
   &__count {

--- a/frontend/pages/SoftwarePage/SoftwareVulnerabilities/SoftwareVulnerabilitiesTable/_styles.scss
+++ b/frontend/pages/SoftwarePage/SoftwareVulnerabilities/SoftwareVulnerabilitiesTable/_styles.scss
@@ -1,4 +1,8 @@
 .software-vulnerabilities-table {
+  &__exploited-vulnerabilities-dropdown {
+    min-width: 234px;
+  }
+
   &__count {
     display: flex;
     gap: 12px;

--- a/frontend/pages/SoftwarePage/SoftwareVulnerabilities/SoftwareVulnerabilitiesTable/helpers.ts
+++ b/frontend/pages/SoftwarePage/SoftwareVulnerabilities/SoftwareVulnerabilitiesTable/helpers.ts
@@ -7,16 +7,16 @@ export const getExploitedVulnerabilitiesDropdownOptions = (
     {
       disabled: false,
       label: "All vulnerabilities",
-      value: false,
+      value: "false",
       helpText: "All vulnerabilities detected on your hosts.",
     },
     {
       disabled: !isPremiumTier,
       label: "Exploited vulnerabilities",
-      value: true,
+      value: "true",
       helpText:
         "Vulnerabilities that have been actively exploited in the wild.",
-      tooltipContent: !isPremiumTier && disabledTooltipContent,
+      tooltipContent: !isPremiumTier ? disabledTooltipContent : undefined,
     },
   ];
 };

--- a/frontend/pages/SoftwarePage/SoftwareVulnerabilities/SoftwareVulnerabilitiesTable/helpers.ts
+++ b/frontend/pages/SoftwarePage/SoftwareVulnerabilities/SoftwareVulnerabilitiesTable/helpers.ts
@@ -16,7 +16,7 @@ export const getExploitedVulnerabilitiesDropdownOptions = (
       value: "true",
       helpText:
         "Vulnerabilities that have been actively exploited in the wild.",
-      tooltipContent: !isPremiumTier && disabledTooltipContent,
+      tooltipContent: !isPremiumTier ? disabledTooltipContent : undefined,
     },
   ];
 };

--- a/frontend/pages/SoftwarePage/SoftwareVulnerabilities/SoftwareVulnerabilitiesTable/helpers.ts
+++ b/frontend/pages/SoftwarePage/SoftwareVulnerabilities/SoftwareVulnerabilitiesTable/helpers.ts
@@ -5,13 +5,13 @@ export const getExploitedVulnerabilitiesDropdownOptions = (
 
   return [
     {
-      disabled: false,
+      isDisabled: false,
       label: "All vulnerabilities",
       value: "false",
       helpText: "All vulnerabilities detected on your hosts.",
     },
     {
-      disabled: !isPremiumTier,
+      isDisabled: !isPremiumTier,
       label: "Exploited vulnerabilities",
       value: "true",
       helpText:

--- a/frontend/pages/SoftwarePage/SoftwareVulnerabilities/SoftwareVulnerabilitiesTable/helpers.ts
+++ b/frontend/pages/SoftwarePage/SoftwareVulnerabilities/SoftwareVulnerabilitiesTable/helpers.ts
@@ -16,7 +16,7 @@ export const getExploitedVulnerabilitiesDropdownOptions = (
       value: "true",
       helpText:
         "Vulnerabilities that have been actively exploited in the wild.",
-      tooltipContent: !isPremiumTier ? disabledTooltipContent : undefined,
+      tooltipContent: !isPremiumTier && disabledTooltipContent,
     },
   ];
 };

--- a/frontend/pages/SoftwarePage/SoftwareVulnerabilities/_styles.scss
+++ b/frontend/pages/SoftwarePage/SoftwareVulnerabilities/_styles.scss
@@ -1,5 +1,2 @@
 .software-vulnerabilities {
-  .dropdown__custom-value-label {
-    width: 260px; // Override 105px for longer text options
-  }
 }


### PR DESCRIPTION
## Issue
For #24512 

## Description
- Software headers more responsive
- Update so versions toggle is on left header
- Update so headers break up to two lines at 990px
- Update so dropdown filter and search filter aren't as wide causing issues at lower widths

## Other
- Convert both `<Dropdown/>` that uses outdated react select 1.3.0 to `<DropdownWrapper/>` which uses react select 5.4.0

## Screenshots of fixes
<img width="1039" alt="Screenshot 2025-01-07 at 1 54 23 PM" src="https://github.com/user-attachments/assets/eb4cc010-c53c-41cd-9621-4f50541461c5" />
<img width="1037" alt="Screenshot 2025-01-07 at 1 54 12 PM" src="https://github.com/user-attachments/assets/3c0fc4cc-ddac-4ccf-a1e6-0c48dcbf26ff" />
<img width="621" alt="Screenshot 2025-01-07 at 1 53 53 PM" src="https://github.com/user-attachments/assets/51b384ab-9048-48ad-8182-9a3cedbc7a0a" />
<img width="776" alt="Screenshot 2025-01-07 at 1 53 36 PM" src="https://github.com/user-attachments/assets/7b253eb5-c933-412e-88e9-a52b9e10c973" />
<img width="801" alt="Screenshot 2025-01-07 at 1 53 28 PM" src="https://github.com/user-attachments/assets/bbb51727-6653-4f59-8758-c608398e1d1a" />

## Screenshot of fleet free still behaving as expected
<img width="1172" alt="Screenshot 2025-01-08 at 1 58 12 PM" src="https://github.com/user-attachments/assets/5d3de938-e2c6-422e-968d-9225295a8903" />


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Manual QA for all new/changed functionality
