### PR TITLE
Msp dashboard: Improve speed of profile-related actions

### DIFF
--- a/ee/bulk-operations-dashboard/api/controllers/get-profiles.js
+++ b/ee/bulk-operations-dashboard/api/controllers/get-profiles.js
@@ -30,12 +30,12 @@ module.exports = {
     let allTeams = teamsResponseData.teams;
 
     let teams = [];
-    for(let team of allTeams) {
-      teams.push({
+    let teams = allTeams.map((team)=>{
+      return {
         fleetApid: team.id,
-        teamName: team.name,
-      });
-    }
+        teamName: team.name
+      };
+    });
     // Add the "team" for hosts with no team
     teams.push({
       fleetApid: 0,

--- a/ee/bulk-operations-dashboard/api/controllers/get-profiles.js
+++ b/ee/bulk-operations-dashboard/api/controllers/get-profiles.js
@@ -29,7 +29,6 @@ module.exports = {
 
     let allTeams = teamsResponseData.teams;
 
-    let teams = [];
     let teams = allTeams.map((team)=>{
       return {
         fleetApid: team.id,

--- a/ee/bulk-operations-dashboard/api/controllers/profiles/upload-profile.js
+++ b/ee/bulk-operations-dashboard/api/controllers/profiles/upload-profile.js
@@ -86,7 +86,7 @@ module.exports = {
       profileToReturn = await UndeployedProfile.create(newProfileInfo).fetch();
     } else {
       let newTeams = [];
-      for(let teamApid of teams){
+      await sails.helpers.flow.simultaneouslyForEach(teams, async (teamApid)=>{
         let bodyForThisRequest = {
           team_id: teamApid,// eslint-disable-line camelcase
           labels_exclude_any: labelTargetBehavior === 'exclude' ? labels : undefined,// eslint-disable-line camelcase
@@ -123,7 +123,7 @@ module.exports = {
           fleetApid: teamApid,
           uuid: JSON.parse(newProfileResponse.body).profile_uuid
         });
-      }
+      });
       newProfileInfo.teams = newTeams;
       profileToReturn = newProfileInfo;
     }

--- a/ee/bulk-operations-dashboard/api/controllers/profiles/view-profiles.js
+++ b/ee/bulk-operations-dashboard/api/controllers/profiles/view-profiles.js
@@ -30,20 +30,17 @@ module.exports = {
     .retry(['requestFailed', {name: 'TimeoutError'}]);
 
     let allTeams = teamsResponseData.teams;
-
-    let teams = [];
-    for(let team of allTeams) {
-      teams.push({
+    let teams = allTeams.map((team)=>{
+      return {
         fleetApid: team.id,
-        teamName: team.name,
-      });
-    }
+        teamName: team.name
+      };
+    });
     // Add the "team" for hosts with no team
     teams.push({
       fleetApid: 0,
       teamName: 'No team',
     });
-
 
     let allProfiles = [];
     let teamApids = _.pluck(allTeams, 'id');

--- a/ee/bulk-operations-dashboard/api/controllers/profiles/view-profiles.js
+++ b/ee/bulk-operations-dashboard/api/controllers/profiles/view-profiles.js
@@ -48,7 +48,7 @@ module.exports = {
     let allProfiles = [];
     let teamApids = _.pluck(allTeams, 'id');
     // Get all of the configuration profiles on the Fleet instance.
-    for(let teamApid of teamApids){
+    await sails.helpers.flow.simultaneouslyForEach(teamApids, async (teamApid)=>{
       let configurationProfilesResponseData = await sails.helpers.http.get.with({
         url: `/api/v1/fleet/configuration_profiles?team_id=${teamApid}`,
         baseUrl: sails.config.custom.fleetBaseUrl,
@@ -60,7 +60,7 @@ module.exports = {
       .retry(['requestFailed', {name: 'TimeoutError'}]);
       let profilesForThisTeam = configurationProfilesResponseData.profiles;
       allProfiles = allProfiles.concat(profilesForThisTeam);
-    }
+    });
     // Add the configurations profiles that are assigned to the "no team" team.
     let noTeamConfigurationProfilesResponseData = await sails.helpers.http.get.with({
       url: '/api/v1/fleet/configuration_profiles',
@@ -76,7 +76,7 @@ module.exports = {
     allProfiles = allProfiles.concat(profilesForNoTeam);
 
     let profilesInformation = [];
-    for(let profile of allProfiles) {
+    await sails.helpers.flow.simultaneouslyForEach(allProfiles, async (profile)=>{
       let profileInformation = {
         name: profile.name,
         identifier: profile.identifier,
@@ -99,7 +99,7 @@ module.exports = {
         profileInformation.labelTargetBehavior = 'exclude';
       }
       profilesInformation.push(profileInformation);
-    }
+    });
     // Group the profiles based on identifier, labels, and labelTargetBehavior
     let profilesGroupedbyLabelsAndIdentifier = _.groupBy(profilesInformation, (profile)=>{
       return `${profile.identifier}|${JSON.stringify(profile.labels)}|${profile.labelTargetBehavior}`;


### PR DESCRIPTION
Related to: #25170

Changes:
- Updated the `view-profiles`, `get-profiles`, `edit-profile`, and `upload-profile` actions to send requests to the connected Fleet instances and process results simultaneously.


I tested these changes while connected to a Fleet instance running on the same network as my device, here is what I saw:
- Loading the profiles page with four profiles assigned to 22 teams:
	- Current version: 3232ms
	- This PR: 699ms
- Uploading a configuration profile with custom label targets to 22 teams:
	- Current version: 5660ms
	- This PR: 865ms
- Editing a configuration profile that is assigned to 22 teams labels:
	- Current version: 6622ms
	- This PR: 1300ms
- Replacing an existing configuration profile assigned to 22 teams:
	- Current version: 6483ms
	- This PR: 1773ms
- Fetching up-to-date configuration profile information from the Fleet instance after a change is made:
	- Current version: 2857ms
	- This PR: 736ms