### PR TITLE
Change Philly meetup URL

### DIFF
--- a/website/views/pages/meetups.ejs
+++ b/website/views/pages/meetups.ejs
@@ -31,7 +31,7 @@
           <p purpose="meetup-description">
             This group is intended for anyone who supports or manages a group of Macs or iOS devices of any size (from less than a dozen to ten of thousands) for an institution of any stripe (Small/Medium Business, Non-profit, Enterprise, Education) in the Greater Philadelphia area (South Eastern PA, South Jersey, Delaware) to swap ideas and solutions, network, and hang out.
           </p>
-          <animated-arrow-button arrow-color="#3E4771" href="https://www.eventbrite.com/o/greater-philadelphia-mac-admins-32189358193" target="_blank">View details</animated-arrow-button>
+          <animated-arrow-button arrow-color="#3E4771" href="https://phillymacadmins.com" target="_blank">View details</animated-arrow-button>
         </div>
       </div>
       <div purpose="meetup-card">


### PR DESCRIPTION
Hello Fleet team! I wasn't sure the checklist template was applicable to this change, so I removed it. Please let me know if that was the wrong thing to do. In this PR, I changed the URL for Greater Philadelphia Mac Admins to our website, in case we ever move away from Eventbrite.

Also, the Meetups page on the website is fantastic! It was really awesome to see us on there. Thanks for including us, and for supporting the community! 😄 