### PR TITLE
Add bundle ID based CPE product matching for more JetBrains macOS products

### DIFF
--- a/server/vulnerabilities/nvd/cpe_test.go
+++ b/server/vulnerabilities/nvd/cpe_test.go
@@ -1314,6 +1314,16 @@ func TestCPEFromSoftwareIntegration(t *testing.T) {
 				Version: "6.0.1",
 			}, cpe: "",
 		},
+		{ // checks vendor/product matching based on bundle name, including EAPs
+			software: fleet.Software{
+				Name:             "GoLand EAP.app",
+				Source:           "apps",
+				Version:          "2022.3.99.123.456",
+				Vendor:           "",
+				BundleIdentifier: "com.jetbrains.goland-EAP",
+			},
+			cpe: "cpe:2.3:a:jetbrains:goland:2022.3.99.123.456:*:*:*:*:macos:*:*",
+		},
 		{
 			software: fleet.Software{
 				Name:             "IntelliJ IDEA.app",

--- a/server/vulnerabilities/nvd/cpe_translations.json
+++ b/server/vulnerabilities/nvd/cpe_translations.json
@@ -162,6 +162,116 @@
   },
   {
     "software": {
+      "bundle_identifier": ["/^com\\.jetbrains\\.PhpStorm/"],
+      "source": ["apps"]
+    },
+    "filter": {
+      "product": ["phpstorm"],
+      "vendor": ["jetbrains"]
+    }
+  },
+  {
+    "software": {
+      "bundle_identifier": ["/^com\\.jetbrains\\.aqua/"],
+      "source": ["apps"]
+    },
+    "filter": {
+      "product": ["aqua"],
+      "vendor": ["jetbrains"]
+    }
+  },
+  {
+    "software": {
+      "bundle_identifier": ["/^com\\.jetbrains\\.CLion/"],
+      "source": ["apps"]
+    },
+    "filter": {
+      "product": ["clion"],
+      "vendor": ["jetbrains"]
+    }
+  },
+  {
+    "software": {
+      "bundle_identifier": ["/^com\\.jetbrains\\.datagrip/"],
+      "source": ["apps"]
+    },
+    "filter": {
+      "product": ["datagrip"],
+      "vendor": ["jetbrains"]
+    }
+  },
+  {
+    "software": {
+      "bundle_identifier": ["/^com\\.jetbrains\\.dataspell/"],
+      "source": ["apps"]
+    },
+    "filter": {
+      "product": ["dataspell"],
+      "vendor": ["jetbrains"]
+    }
+  },
+  {
+    "software": {
+      "bundle_identifier": ["/^com\\.jetbrains\\.goland/"],
+      "source": ["apps"]
+    },
+    "filter": {
+      "product": ["goland"],
+      "vendor": ["jetbrains"]
+    }
+  },
+  {
+    "software": {
+      "bundle_identifier": ["/^com\\.jetbrains\\.rider/"],
+      "source": ["apps"]
+    },
+    "filter": {
+      "product": ["rider"],
+      "vendor": ["jetbrains"]
+    }
+  },
+  {
+    "software": {
+      "bundle_identifier": ["/^com\\.jetbrains\\.rubymine/"],
+      "source": ["apps"]
+    },
+    "filter": {
+      "product": ["rubymine"],
+      "vendor": ["jetbrains"]
+    }
+  },
+  {
+    "software": {
+      "bundle_identifier": ["/^com\\.jetbrains\\.rustrover/"],
+      "source": ["apps"]
+    },
+    "filter": {
+      "product": ["rustrover"],
+      "vendor": ["jetbrains"]
+    }
+  },
+  {
+    "software": {
+      "bundle_identifier": ["/^com\\.jetbrains\\.WebStorm/"],
+      "source": ["apps"]
+    },
+    "filter": {
+      "product": ["webstorm"],
+      "vendor": ["jetbrains"]
+    }
+  },
+  {
+    "software": {
+      "bundle_identifier": ["/^com\\.jetbrains\\.mps/"],
+      "source": ["apps"]
+    },
+    "filter": {
+      "product": ["mps"],
+      "vendor": ["jetbrains"]
+    }
+  },
+  {
+    "software": {
       "name": ["ms-python.python"],
       "source": ["vscode_extensions"]
     },

--- a/server/vulnerabilities/nvd/cve_test.go
+++ b/server/vulnerabilities/nvd/cve_test.go
@@ -367,6 +367,14 @@ func TestTranslateCPEToCVE(t *testing.T) {
 			excludedCVEs:      []string{"CVE-2024-10327"},
 			continuesToUpdate: true,
 		},
+		"cpe:2.3:a:jetbrains:goland:2022.3.99.123.456:*:*:*:*:macos:*:*": {
+			includedCVEs:      []cve{{ID: "CVE-2024-37051", resolvedInVersion: ""}},
+			continuesToUpdate: true,
+		},
+		"cpe:2.3:a:jetbrains:goland:2024.3:*:*:*:*:macos:*:*": {
+			excludedCVEs:      []string{"CVE-2024-37051"},
+			continuesToUpdate: true,
+		},
 	}
 
 	cveOSTests := []struct {


### PR DESCRIPTION
For #22723.

Bundle IDs pulled from installs of the software, with regexes being starts-with matches to include EAPs in matches. Used the products list from CVE-2024-37051 to match up NVD product names (which is why Writerside isn't included here; it doesn't have any published vulns yet).

This fixes vuln detection in e.g. GoLand EAPs when the app name is something other than the product name, similar to what we've done with IntelliJ and PyCharm (but omitting homebrew handling for now).

No changes file as this doesn't need to be cherry-picked, and it will go out in the next NVD pull after merged to `main`.

# Checklist for submitter
- [x] Added/updated automated tests
- [x] A detailed QA plan exists on the associated ticket (if it isn't there, work with the product group's QA engineer to add it)
- [x] Manual QA for all new/changed functionality