### PR TITLE
Revert "Add SystemDrive env var to osqueryd if present in orbit"

### DIFF
--- a/orbit/changes/8986-systemdrive-env-passthrough
+++ b/orbit/changes/8986-systemdrive-env-passthrough
@@ -1,1 +1,0 @@
-- Pass `SystemDrive` Environemt variable to osqueryd when present in Orbit

--- a/orbit/cmd/orbit/orbit.go
+++ b/orbit/cmd/orbit/orbit.go
@@ -771,12 +771,6 @@ func main() {
 			)
 		}
 
-		if runtime.GOOS == "windows" {
-			if systemDrive, ok := os.LookupEnv("SystemDrive"); ok {
-				options = append(options, osquery.WithEnv([]string{fmt.Sprintf("SystemDrive=%s", systemDrive)}))
-			}
-		}
-
 		var certPath string
 		if fleetURL != "https://" && c.Bool("insecure") {
 			proxy, err := insecure.NewTLSProxy(fleetURL)


### PR DESCRIPTION
Reverts fleetdm/fleet#2520

Was asked to revert this PR so we can include it in the next release instead