### PR TITLE
Fleet UI: Add copy for policy tied to install software

### DIFF
--- a/frontend/components/PlatformSelector/PlatformSelector.tsx
+++ b/frontend/components/PlatformSelector/PlatformSelector.tsx
@@ -1,6 +1,12 @@
 import React from "react";
 import classNames from "classnames";
+
+import { IPolicySoftwareToInstall } from "interfaces/policy";
 import Checkbox from "components/forms/fields/Checkbox";
+import CustomLink from "components/CustomLink";
+import TooltipWrapper from "components/TooltipWrapper";
+import { buildQueryStringFromParams } from "utilities/url";
+import paths from "router/paths";
 
 interface IPlatformSelectorProps {
   baseClass?: string;
@@ -13,6 +19,8 @@ interface IPlatformSelectorProps {
   setCheckLinux: (val: boolean) => void;
   setCheckChrome: (val: boolean) => void;
   disabled?: boolean;
+  installSoftware?: IPolicySoftwareToInstall;
+  currentTeamId?: number;
 }
 
 export const PlatformSelector = ({
@@ -26,6 +34,8 @@ export const PlatformSelector = ({
   setCheckLinux,
   setCheckChrome,
   disabled = false,
+  installSoftware,
+  currentTeamId,
 }: IPlatformSelectorProps): JSX.Element => {
   const baseClass = "platform-selector";
 
@@ -33,9 +43,39 @@ export const PlatformSelector = ({
     [`form-field__label--disabled`]: disabled,
   });
 
+  const renderInstallSoftwareHelpText = () => {
+    if (!installSoftware) {
+      return null;
+    }
+    const softwareName = installSoftware.name;
+    const softwareId = installSoftware.software_title_id.toString();
+    const softwareLink = `${paths.SOFTWARE_TITLE_DETAILS(
+      softwareId
+    )}?${buildQueryStringFromParams({ team_id: currentTeamId })}`;
+
+    return (
+      <span className={`${baseClass}__install-software`}>
+        <CustomLink text={softwareName} url={softwareLink} /> will only install
+        on{" "}
+        <TooltipWrapper
+          tipContent={
+            <>
+              To see targets, select{" "}
+              <b>{softwareName} &gt; Actions &gt; Edit</b>. Currently, hosts
+              that aren&apos;t targeted show an empty (---) policy status.
+            </>
+          }
+        >
+          targeted hosts
+        </TooltipWrapper>
+        .
+      </span>
+    );
+  };
+
   return (
     <div className={`${parentClass}__${baseClass} ${baseClass} form-field`}>
-      <span className={labelClasses}>Targets:</span>
+      <span className={labelClasses}>Target:</span>
       <span className={`${baseClass}__checkboxes`}>
         <Checkbox
           value={checkDarwin}
@@ -71,9 +111,8 @@ export const PlatformSelector = ({
         </Checkbox>
       </span>
       <div className="form-field__help-text">
-        Your policy will only run on the selected platform(s). Additionally, if
-        install software automation is enabled, it will only be installed on
-        hosts defined in the software scope.
+        Policy runs on all hosts with these platform(s).
+        {renderInstallSoftwareHelpText()}
       </div>
     </div>
   );

--- a/frontend/components/PlatformSelector/_styles.scss
+++ b/frontend/components/PlatformSelector/_styles.scss
@@ -2,7 +2,7 @@
   // override global form-field width: 100%
   width: auto;
 
-  span {
+  &__checkboxes {
     display: flex;
     align-items: center;
     gap: 12px;
@@ -14,5 +14,11 @@
 
   &__platform-checkbox-wrapper {
     width: auto;
+  }
+
+  .form-field__help-text {
+    display: flex;
+    flex-direction: column;
+    gap: $pad-medium;
   }
 }

--- a/frontend/hooks/usePlatformSelector.tsx
+++ b/frontend/hooks/usePlatformSelector.tsx
@@ -6,6 +6,7 @@ import {
   QUERYABLE_PLATFORMS,
   QueryablePlatform,
 } from "interfaces/platform";
+import { IPolicySoftwareToInstall } from "interfaces/policy";
 
 import PlatformSelector from "components/PlatformSelector";
 
@@ -15,12 +16,16 @@ export interface IPlatformSelector {
   isAnyPlatformSelected: boolean;
   render: () => JSX.Element;
   disabled?: boolean;
+  installSoftware?: IPolicySoftwareToInstall;
+  currentTeamId?: number;
 }
 
 const usePlatformSelector = (
   platformContext: SelectedPlatformString | null | undefined,
   baseClass = "",
-  disabled = false
+  disabled = false,
+  installSoftware: IPolicySoftwareToInstall | undefined,
+  currentTeamId: number | undefined
 ): IPlatformSelector => {
   const [checkDarwin, setCheckDarwin] = useState(false);
   const [checkWindows, setCheckWindows] = useState(false);
@@ -73,6 +78,8 @@ const usePlatformSelector = (
         setCheckLinux={setCheckLinux}
         setCheckChrome={setCheckChrome}
         disabled={disabled}
+        installSoftware={installSoftware}
+        currentTeamId={currentTeamId}
       />
     );
   }, [checkDarwin, checkWindows, checkLinux, checkChrome, disabled]);

--- a/frontend/pages/policies/PolicyPage/components/PolicyForm/PolicyForm.tsx
+++ b/frontend/pages/policies/PolicyPage/components/PolicyForm/PolicyForm.tsx
@@ -8,7 +8,9 @@ import { size } from "lodash";
 import classnames from "classnames";
 import { COLORS } from "styles/var/colors";
 
+import paths from "router/paths";
 import { addGravatarUrlToResource } from "utilities/helpers";
+import { buildQueryStringFromParams } from "utilities/url";
 import { AppContext } from "context/app";
 import { PolicyContext } from "context/policy";
 import usePlatformCompatibility from "hooks/usePlatformCompatibility";
@@ -29,6 +31,7 @@ import TooltipWrapper from "components/TooltipWrapper";
 import Spinner from "components/Spinner";
 import Icon from "components/Icon/Icon";
 import AutoSizeInputField from "components/forms/fields/AutoSizeInputField";
+import CustomLink from "components/CustomLink";
 import SaveNewPolicyModal from "../SaveNewPolicyModal";
 
 const baseClass = "policy-form";
@@ -116,6 +119,7 @@ const PolicyForm = ({
 
   const {
     currentUser,
+    currentTeam,
     isGlobalObserver,
     isGlobalAdmin,
     isGlobalMaintainer,
@@ -474,6 +478,37 @@ const PolicyForm = ({
     return platformCompatibility.render();
   };
 
+  const renderInstallSoftware = () => {
+    if (!storedPolicy?.install_software) {
+      return null;
+    }
+
+    const softwareName = storedPolicy.install_software.name;
+    const softwareId = storedPolicy.install_software.software_title_id.toString();
+    const softwareLink = `${paths.SOFTWARE_TITLE_DETAILS(
+      softwareId
+    )}?${buildQueryStringFromParams({ team_id: currentTeam?.id })}`;
+
+    return (
+      <div>
+        <CustomLink text={softwareName} url={softwareLink} /> will only install
+        on{" "}
+        <TooltipWrapper
+          tipContent={
+            <>
+              To see targets, select{" "}
+              <b>{softwareName} &gt; Actions &gt; Edit</b>. Currently, hosts
+              that aren&apos;t targeted show an empty (---) policy status.
+            </>
+          }
+        >
+          targeted hosts
+        </TooltipWrapper>
+        .
+      </div>
+    );
+  };
+
   const renderCriticalPolicy = () => {
     return (
       <div className="critical-checkbox-wrapper">
@@ -590,6 +625,7 @@ const PolicyForm = ({
           />
           {renderPlatformCompatibility()}
           {(isEditMode || defaultPolicy) && platformSelector.render()}
+          {isEditMode && renderInstallSoftware()}
           {isEditMode && isPremiumTier && renderCriticalPolicy()}
           {renderLiveQueryWarning()}
           <div className="button-wrap">

--- a/frontend/pages/policies/PolicyPage/components/PolicyForm/PolicyForm.tsx
+++ b/frontend/pages/policies/PolicyPage/components/PolicyForm/PolicyForm.tsx
@@ -8,9 +8,7 @@ import { size } from "lodash";
 import classnames from "classnames";
 import { COLORS } from "styles/var/colors";
 
-import paths from "router/paths";
 import { addGravatarUrlToResource } from "utilities/helpers";
-import { buildQueryStringFromParams } from "utilities/url";
 import { AppContext } from "context/app";
 import { PolicyContext } from "context/policy";
 import usePlatformCompatibility from "hooks/usePlatformCompatibility";
@@ -31,7 +29,6 @@ import TooltipWrapper from "components/TooltipWrapper";
 import Spinner from "components/Spinner";
 import Icon from "components/Icon/Icon";
 import AutoSizeInputField from "components/forms/fields/AutoSizeInputField";
-import CustomLink from "components/CustomLink";
 import SaveNewPolicyModal from "../SaveNewPolicyModal";
 
 const baseClass = "policy-form";
@@ -150,7 +147,9 @@ const PolicyForm = ({
   const platformSelector = usePlatformSelector(
     lastEditedQueryPlatform,
     baseClass,
-    platformSelectorDisabled
+    platformSelectorDisabled,
+    storedPolicy?.install_software,
+    currentTeam?.id
   );
 
   const {
@@ -478,37 +477,6 @@ const PolicyForm = ({
     return platformCompatibility.render();
   };
 
-  const renderInstallSoftware = () => {
-    if (!storedPolicy?.install_software) {
-      return null;
-    }
-
-    const softwareName = storedPolicy.install_software.name;
-    const softwareId = storedPolicy.install_software.software_title_id.toString();
-    const softwareLink = `${paths.SOFTWARE_TITLE_DETAILS(
-      softwareId
-    )}?${buildQueryStringFromParams({ team_id: currentTeam?.id })}`;
-
-    return (
-      <div>
-        <CustomLink text={softwareName} url={softwareLink} /> will only install
-        on{" "}
-        <TooltipWrapper
-          tipContent={
-            <>
-              To see targets, select{" "}
-              <b>{softwareName} &gt; Actions &gt; Edit</b>. Currently, hosts
-              that aren&apos;t targeted show an empty (---) policy status.
-            </>
-          }
-        >
-          targeted hosts
-        </TooltipWrapper>
-        .
-      </div>
-    );
-  };
-
   const renderCriticalPolicy = () => {
     return (
       <div className="critical-checkbox-wrapper">
@@ -625,7 +593,6 @@ const PolicyForm = ({
           />
           {renderPlatformCompatibility()}
           {(isEditMode || defaultPolicy) && platformSelector.render()}
-          {isEditMode && renderInstallSoftware()}
           {isEditMode && isPremiumTier && renderCriticalPolicy()}
           {renderLiveQueryWarning()}
           <div className="button-wrap">


### PR DESCRIPTION
## Issue
For #25245 (Addition to #22813)

## Description
- Adds help text sentence to policy that has `install_software` key
- Links to software details page, tooltip
- Shorten other help text according to Figma
- Change Targets to Target

## Note
API doesn't return extension like shown in figma design so UI does not show extension on the software name
<img width="912" alt="Screenshot 2025-01-08 at 10 03 51 AM" src="https://github.com/user-attachments/assets/5a16e639-5427-4d86-b3c1-9ccb56f03a80" />


## Screenshot
<img width="1414" alt="Screenshot 2025-01-08 at 10 45 33 AM" src="https://github.com/user-attachments/assets/140132b8-7106-4ef5-9ff3-14491f0ab43b" />



# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->


- [x] Manual QA for all new/changed functionality
