### PR TITLE
Update release-qa.md with new team labels

### DIFF
--- a/.github/ISSUE_TEMPLATE/release-qa.md
+++ b/.github/ISSUE_TEMPLATE/release-qa.md
@@ -2,7 +2,7 @@
 name:  Release QA
 about: Checklist of required tests prior to release
 title: 'Release QA:'
-labels: '#g-mdm,#g-endpoint-ops,:release'
+labels: '#g-mdm,#g-orchestration,#g-software:release'
 assignees: 'xpkoala,pezhub,jmwatts'
 
 ---


### PR DESCRIPTION
Only changed #g-endpoint-ops to #g-orchestration and added #g-software
