### PR TITLE
fix: utilize custom SMTP domain if set

### DIFF
--- a/server/mail/mail.go
+++ b/server/mail/mail.go
@@ -198,6 +198,11 @@ func (m mailService) sendMail(e fleet.Email, msg []byte) error {
 	}
 	defer client.Close()
 
+	if e.SMTPSettings.SMTPDomain != "" {
+		if err = client.Hello(e.SMTPSettings.SMTPDomain); err != nil {
+			return fmt.Errorf("client hello error: %w", err)
+		}
+	}
 	if e.SMTPSettings.SMTPEnableStartTLS {
 		if ok, _ := client.Extension("STARTTLS"); ok {
 			if err = client.StartTLS(tlsConfig); err != nil {

--- a/server/mail/mail_test.go
+++ b/server/mail/mail_test.go
@@ -17,6 +17,7 @@ var testFunctions = [...]func(*testing.T, fleet.MailService){
 	testSMTPPlainAuthInvalidCreds,
 	testSMTPSkipVerify,
 	testSMTPNoAuthWithTLS,
+	testSMTPDomain,
 	testMailTest,
 }
 
@@ -157,6 +158,31 @@ func testSMTPNoAuthWithTLS(t *testing.T, mailer fleet.MailService) {
 
 	err := mailer.SendEmail(mail)
 	assert.Nil(t, err)
+}
+
+func testSMTPDomain(t *testing.T, mailer fleet.MailService) {
+	mail := fleet.Email{
+		Subject: "custom client hello",
+		To:      []string{"bob@foo.com"},
+		SMTPSettings: fleet.SMTPSettings{
+			SMTPConfigured:         true,
+			SMTPAuthenticationType: fleet.AuthTypeNameNone,
+			SMTPEnableTLS:          false,
+			SMTPVerifySSLCerts:     false,
+			SMTPEnableStartTLS:     false,
+			SMTPPort:               1027,
+			SMTPServer:             "localhost",
+			SMTPDomain:             "foo.com",
+			SMTPSenderAddress:      "test@example.com",
+		},
+		Mailer: &SMTPTestMailer{
+			BaseURL: "https://localhost:8080",
+		},
+	}
+
+	err := mailer.SendEmail(mail)
+	assert.Nil(t, err)
+
 }
 
 func testMailTest(t *testing.T, mailer fleet.MailService) {


### PR DESCRIPTION
Fixes #25241

Confirmed settings are accepted locally with the below config, after setting my domain as the STMP domain in Advanced settings.
<img width="962" alt="image" src="https://github.com/user-attachments/assets/368bff35-06e3-40eb-abbc-7a847f119314" />


# Checklist for submitter

- [X] Added/updated automated tests
- [ ] A detailed QA plan exists on the associated ticket (if it isn't there, work with the product group's QA engineer to add it)
- [x] Manual QA for all new/changed functionality