### PR TITLE
Downgraded expected/common "BootstrapPackage not found" server error to a debug message.

### DIFF
--- a/changes/25265-boostrap-package-not-found
+++ b/changes/25265-boostrap-package-not-found
@@ -1,0 +1,1 @@
+Downgraded expected/common "BootstrapPackage not found" server error to a debug message. Occurs when UI/API checks if bootstrap package exists.

--- a/ee/server/service/software_installers.go
+++ b/ee/server/service/software_installers.go
@@ -836,7 +836,8 @@ func (svc *Service) getSoftwareInstallerBinary(ctx context.Context, storageID st
 		return nil, ctxerr.Wrap(ctx, err, "checking if installer exists")
 	}
 	if !exists {
-		return nil, ctxerr.Wrap(ctx, notFoundError{}, "does not exist in software installer store")
+		return nil, ctxerr.Wrapf(ctx, notFoundError{}, "%s with filename %s does not exist in software installer store", storageID,
+			filename)
 	}
 
 	// get the installer from the store

--- a/server/contexts/logging/logging.go
+++ b/server/contexts/logging/logging.go
@@ -115,10 +115,11 @@ func (l *LoggingContext) Log(ctx context.Context, logger kitlog.Logger) {
 	defer l.l.Unlock()
 
 	switch {
-	case len(l.Errs) > 0:
-		logger = level.Error(logger)
+	// Allow ForceLevel to override level.Error. Specific level can be set for benign/expected/user-caused errors.
 	case l.ForceLevel != nil:
 		logger = l.ForceLevel(logger)
+	case len(l.Errs) > 0:
+		logger = level.Error(logger)
 	default:
 		logger = level.Debug(logger)
 	}

--- a/server/contexts/logging/logging.go
+++ b/server/contexts/logging/logging.go
@@ -53,6 +53,14 @@ func WithNoUser(ctx context.Context) context.Context {
 	return ctx
 }
 
+// WithNoError returns a context with logging.SkipError set to true so error won't be logged at level=error
+func WithNoError(ctx context.Context) context.Context {
+	if logCtx, ok := FromContext(ctx); ok {
+		logCtx.SetSkipError()
+	}
+	return ctx
+}
+
 // WithExtras returns a context with logging.Extras set as the values provided
 func WithExtras(ctx context.Context, extras ...interface{}) context.Context {
 	if logCtx, ok := FromContext(ctx); ok {
@@ -61,6 +69,8 @@ func WithExtras(ctx context.Context, extras ...interface{}) context.Context {
 	return ctx
 }
 
+// WithLevel forces a log level for the current request/context.
+// Level may still be upgraded to Error if an error is present.
 func WithLevel(ctx context.Context, level func(kitlog.Logger) kitlog.Logger) context.Context {
 	if logCtx, ok := FromContext(ctx); ok {
 		logCtx.SetForceLevel(level)
@@ -77,6 +87,7 @@ type LoggingContext struct {
 	Extras     []interface{}
 	SkipUser   bool
 	ForceLevel func(kitlog.Logger) kitlog.Logger
+	SkipError  bool
 }
 
 func (l *LoggingContext) SetForceLevel(level func(kitlog.Logger) kitlog.Logger) {
@@ -97,6 +108,12 @@ func (l *LoggingContext) SetSkipUser() {
 	l.SkipUser = true
 }
 
+func (l *LoggingContext) SetSkipError() {
+	l.l.Lock()
+	defer l.l.Unlock()
+	l.SkipError = true
+}
+
 func (l *LoggingContext) SetStartTime() {
 	l.l.Lock()
 	defer l.l.Unlock()
@@ -115,11 +132,10 @@ func (l *LoggingContext) Log(ctx context.Context, logger kitlog.Logger) {
 	defer l.l.Unlock()
 
 	switch {
-	// Allow ForceLevel to override level.Error. Specific level can be set for benign/expected/user-caused errors.
+	case len(l.Errs) > 0 && !l.SkipError:
+		logger = level.Error(logger)
 	case l.ForceLevel != nil:
 		logger = l.ForceLevel(logger)
-	case len(l.Errs) > 0:
-		logger = level.Error(logger)
 	default:
 		logger = level.Debug(logger)
 	}

--- a/server/service/apple_mdm.go
+++ b/server/service/apple_mdm.go
@@ -2379,7 +2379,7 @@ func bootstrapPackageMetadataEndpoint(ctx context.Context, request interface{}, 
 	switch {
 	case fleet.IsNotFound(err):
 		// Don't log this response as error -- it's expected to happen when the bootstrap package is missing, which is a common case.
-		logging.WithLevel(ctx, level.Debug)
+		logging.WithNoError(ctx)
 		return bootstrapPackageMetadataResponse{Err: fleet.NewInvalidArgumentError("team_id",
 			"bootstrap package for this team does not exist").WithStatus(http.StatusNotFound)}, nil
 	case err != nil:

--- a/server/service/integration_logger_test.go
+++ b/server/service/integration_logger_test.go
@@ -148,7 +148,7 @@ func (s *integrationLoggerTestSuite) TestLoggerLogin() {
 		require.NotContains(t, logData, "user") // logger context is set to skip user
 
 		for _, e := range tt.expectedLogs {
-			assert.Equal(t, logData[e.key], e.val)
+			assert.Equal(t, e.val, logData[e.key], fmt.Sprintf("%+v", tt.expectedLogs))
 		}
 		s.buf.Reset()
 	}


### PR DESCRIPTION
For #25265
Downgraded expected/common "BootstrapPackage not found" server error to a debug message. Occurs when UI/API checks if bootstrap package exists.

# Checklist for submitter
- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
- [x] Manual QA for all new/changed functionality
