### PR TITLE
Add cron failure monitoring SNS topic to IAM policy for Lambda

### DIFF
--- a/terraform/addons/monitoring/main.tf
+++ b/terraform/addons/monitoring/main.tf
@@ -448,7 +448,10 @@ data "aws_iam_policy_document" "cron_monitoring_lambda" {
       "sns:Publish"
     ]
 
-    resources = lookup(var.sns_topic_arns_map, "cron_monitoring", var.default_sns_topic_arns)
+    resources = distinct(concat(
+      lookup(var.sns_topic_arns_map, "cron_monitoring", var.default_sns_topic_arns),
+      lookup(var.sns_topic_arns_map, "cron_job_failure_monitoring", var.default_sns_topic_arns)
+    ))
 
     effect = "Allow"
   }


### PR DESCRIPTION
for #25267

This was missed in the TF config for the cron-monitoring Lambda updates, leading to a failure when trying to publish to the `#help-p2` topic.