### PR TITLE
Run CI tests in parallel

### DIFF
--- a/.github/workflows/test-go.yaml
+++ b/.github/workflows/test-go.yaml
@@ -144,7 +144,7 @@ jobs:
           SAML_IDP_TEST=1 \
           MAIL_TEST=1 \
           NETWORK_TEST_GITHUB_TOKEN=${{ secrets.FLEET_RELEASE_GITHUB_PAT }} \
-          CI_TEST_PKG="$(CI_TEST_PKG)" \
+          CI_TEST_PKG="${CI_TEST_PKG}" \
           make test-go 2>&1 | tee /tmp/gotest.log
 
     - name: Create mysql identifier without colon

--- a/.github/workflows/test-go.yaml
+++ b/.github/workflows/test-go.yaml
@@ -42,7 +42,7 @@ jobs:
   test-go:
     strategy:
       matrix:
-        suite: ["integration", "core", "migration", "fleetctl", "vuln"]
+        suite: ["integration", "core", "mysql", "fleetctl", "vuln"]
         os: [ubuntu-latest]
         mysql: ["mysql:8.0.36", "mysql:8.4.3", "mysql:9.1.0"] # make sure to update supported versions docs when this changes
         isCron:

--- a/.github/workflows/test-go.yaml
+++ b/.github/workflows/test-go.yaml
@@ -118,15 +118,20 @@ jobs:
     - name: Run Go Tests
       run: |
         if [[ "${{ matrix.suite }}" == "core" ]]; then
-          CI_TEST_PKG=main RUN_TESTS_ARG='-skip=^TestIntegrations'
+          CI_TEST_PKG=main
+          RUN_TESTS_ARG='-skip=^TestIntegrations'
         elif [[ "${{ matrix.suite }}" == "integration" ]]; then
-          CI_TEST_PKG=main RUN_TESTS_ARG='-run=^TestIntegrations'
+          CI_TEST_PKG=main
+          RUN_TESTS_ARG='-run=^TestIntegrations'
         elif [[ "${{ matrix.suite }}" == "fleetctl" ]]; then
-          CI_TEST_PKG=fleetctl RUN_TESTS_ARG=''
+          CI_TEST_PKG=fleetctl
+          RUN_TESTS_ARG=''
         elif [[ "${{ matrix.suite }}" == "migration" ]]; then
-          CI_TEST_PKG=migration RUN_TESTS_ARG=''
+          CI_TEST_PKG=migration
+          RUN_TESTS_ARG=''
         elif [[ "${{ matrix.suite }}" == "vuln" ]]; then
-          CI_TEST_PKG=vuln RUN_TESTS_ARG=''
+          CI_TEST_PKG=vuln
+          RUN_TESTS_ARG=''
         fi
         GO_TEST_EXTRA_FLAGS="-v -race=$RACE_ENABLED -timeout=$GO_TEST_TIMEOUT $RUN_TESTS_ARG" \
           TEST_LOCK_FILE_PATH=$(pwd)/lock \
@@ -139,6 +144,7 @@ jobs:
           SAML_IDP_TEST=1 \
           MAIL_TEST=1 \
           NETWORK_TEST_GITHUB_TOKEN=${{ secrets.FLEET_RELEASE_GITHUB_PAT }} \
+          CI_TEST_PKG="$(CI_TEST_PKG)" \
           make test-go 2>&1 | tee /tmp/gotest.log
 
     - name: Create mysql identifier without colon

--- a/.github/workflows/test-go.yaml
+++ b/.github/workflows/test-go.yaml
@@ -123,14 +123,8 @@ jobs:
         elif [[ "${{ matrix.suite }}" == "integration" ]]; then
           CI_TEST_PKG=main
           RUN_TESTS_ARG='-run=^TestIntegrations'
-        elif [[ "${{ matrix.suite }}" == "fleetctl" ]]; then
-          CI_TEST_PKG=fleetctl
-          RUN_TESTS_ARG=''
-        elif [[ "${{ matrix.suite }}" == "migration" ]]; then
-          CI_TEST_PKG=migration
-          RUN_TESTS_ARG=''
-        elif [[ "${{ matrix.suite }}" == "vuln" ]]; then
-          CI_TEST_PKG=vuln
+        else
+          CI_TEST_PKG="${{ matrix.suite }}"
           RUN_TESTS_ARG=''
         fi
         GO_TEST_EXTRA_FLAGS="-v -race=$RACE_ENABLED -timeout=$GO_TEST_TIMEOUT $RUN_TESTS_ARG" \

--- a/.github/workflows/test-go.yaml
+++ b/.github/workflows/test-go.yaml
@@ -42,7 +42,7 @@ jobs:
   test-go:
     strategy:
       matrix:
-        suite: ["integration", "core"]
+        suite: ["integration", "core", "migration", "fleetctl", "vuln"]
         os: [ubuntu-latest]
         mysql: ["mysql:8.0.36", "mysql:8.4.3", "mysql:9.1.0"] # make sure to update supported versions docs when this changes
         isCron:
@@ -118,11 +118,15 @@ jobs:
     - name: Run Go Tests
       run: |
         if [[ "${{ matrix.suite }}" == "core" ]]; then
-          RUN_TESTS_ARG='-skip=^TestIntegrations'
+          CI_TEST_PKG=main RUN_TESTS_ARG='-skip=^TestIntegrations'
         elif [[ "${{ matrix.suite }}" == "integration" ]]; then
-          RUN_TESTS_ARG='-run=^TestIntegrations'
-        else
-          RUN_TESTS_ARG=''
+          CI_TEST_PKG=main RUN_TESTS_ARG='-run=^TestIntegrations'
+        elif [[ "${{ matrix.suite }}" == "fleetctl" ]]; then
+          CI_TEST_PKG=fleetctl RUN_TESTS_ARG=''
+        elif [[ "${{ matrix.suite }}" == "migration" ]]; then
+          CI_TEST_PKG=migration RUN_TESTS_ARG=''
+        elif [[ "${{ matrix.suite }}" == "vuln" ]]; then
+          CI_TEST_PKG=vuln RUN_TESTS_ARG=''
         fi
         GO_TEST_EXTRA_FLAGS="-v -race=$RACE_ENABLED -timeout=$GO_TEST_TIMEOUT $RUN_TESTS_ARG" \
           TEST_LOCK_FILE_PATH=$(pwd)/lock \

--- a/Makefile
+++ b/Makefile
@@ -201,7 +201,7 @@ debug-go-tests:
 	@MYSQL_TEST=1 REDIS_TEST=1 MINIO_STORAGE_TEST=1 SAML_IDP_TEST=1 NETWORK_TEST=1 make .debug-go-tests
 
 # Command used in CI to run all tests.
-test-go: # dump-test-schema generate-mock
+test-go: dump-test-schema generate-mock
 	make .run-go-tests PKG_TO_TEST="$(CI_PKG_TO_TEST)"
 
 analyze-go:

--- a/Makefile
+++ b/Makefile
@@ -157,9 +157,9 @@ dlv_test_pkg_to_test := $(addprefix github.com/fleetdm/fleet/v4/,$(PKG_TO_TEST))
 
 DEFAULT_PKG_TO_TEST := ./cmd/... ./ee/... ./orbit/pkg/... ./orbit/cmd/orbit ./pkg/... ./server/... ./tools/...
 ifeq ($(CI_TEST_PKG), main)
-	CI_PKG_TO_TEST=$(shell go list ${DEFAULT_PKG_TO_TEST} | grep -v "server/datastore/mysql/migrations" | grep -v "cmd/fleetctl" | grep -v "server/vulnerabilities" | sed -e 's|github.com/fleetdm/fleet/v4/||g')
-else ifeq ($(CI_TEST_PKG), migration)
-	CI_PKG_TO_TEST="server/datastore/mysql/migrations/..."
+	CI_PKG_TO_TEST=$(shell go list ${DEFAULT_PKG_TO_TEST} | grep -v "server/datastore/mysql" | grep -v "cmd/fleetctl" | grep -v "server/vulnerabilities" | sed -e 's|github.com/fleetdm/fleet/v4/||g')
+else ifeq ($(CI_TEST_PKG), mysql)
+	CI_PKG_TO_TEST="server/datastore/mysql/..."
 else ifeq ($(CI_TEST_PKG), fleetctl)
 	CI_PKG_TO_TEST="cmd/fleetctl/..."
 else ifeq ($(CI_TEST_PKG), vuln)

--- a/Makefile
+++ b/Makefile
@@ -157,7 +157,7 @@ dlv_test_pkg_to_test := $(addprefix github.com/fleetdm/fleet/v4/,$(PKG_TO_TEST))
 
 DEFAULT_PKG_TO_TEST := ./cmd/... ./ee/... ./orbit/pkg/... ./orbit/cmd/orbit ./pkg/... ./server/... ./tools/...
 ifeq ($(CI_TEST_PKG), main)
-	CI_PKG_TO_TEST=$(shell go list ${DEFAULT_PKG_TO_TEST} | sed -e 's|github.com/fleetdm/fleet/v4/||g')
+	CI_PKG_TO_TEST=$(shell go list ${DEFAULT_PKG_TO_TEST} | grep -v "server/datastore/mysql/migrations" | grep -v "cmd/fleetctl" | grep -v "server/vulnerabilities" | sed -e 's|github.com/fleetdm/fleet/v4/||g')
 else ifeq ($(CI_TEST_PKG), migration)
 	CI_PKG_TO_TEST="server/datastore/mysql/migrations/..."
 else ifeq ($(CI_TEST_PKG), fleetctl)
@@ -168,7 +168,7 @@ else
 	CI_PKG_TO_TEST=$(DEFAULT_PKG_TO_TEST)
 endif
 
-ci-pkg:
+ci-pkg-list:
 	@echo $(CI_PKG_TO_TEST)
 
 .run-go-tests:


### PR DESCRIPTION
#21774

Improves run time by about 30%.

Things have been arranged in such a way that splitting modules out further will be trivial in the future, such as breaking the different integration test suited into their own units.

![image](https://github.com/user-attachments/assets/ead46e4c-6f14-406d-a29b-b25abc79c384)

![image](https://github.com/user-attachments/assets/3f7fd7f3-d7a8-4ff8-a184-646a72f1d015)
