### PR TITLE
Remove security marketing fluff from 

### DIFF
--- a/website/views/pages/observability.ejs
+++ b/website/views/pages/observability.ejs
@@ -234,14 +234,14 @@
 
         <div purpose="feature-item" class="pr-0 pr-lg-4 pl-lg-0 col-12 col-sm-6 col-lg-4 mb-lg-0">
           <img alt="Attack surface management" src="/images/icon-attack-surface-management-48x48@2x.png" class="mx-auto mx-sm-0">
-          <h5>Attack surface management</h5>
-          <p>Discover security misconfigurations and vulnerabilities and prioritize risks that matter to your organization.</p>
+          <h5>Security posture</h5>
+          <p>Identify security misconfigurations and vulnerabilities and prioritize risks that matter to your organization.</p>
         </div>
 
         <div purpose="feature-item" class="pl-0 pl-lg-4 col-12 col-sm-6 col-lg-4 mb-sm-0">
           <img alt="Malware detection" src="/images/icon-malware-detection-48x48@2x.png" class="mx-auto mx-sm-0">
-          <h5>Malware detection</h5>
-          <p>Continuously scan host filesystems for indicators of compromise (IOC). Import malware signatures from threat intelligence sources.</p>
+          <h5>Threat management</h5>
+          <p>Use attack signatures from threat intelligence sources to scan and resolve indicators of compromise (IOC).</p>
         </div>
 
         <div purpose="feature-item" class="pr-0 pr-lg-4 col-12 col-sm-6 col-lg-4 mb-0">


### PR DESCRIPTION
I updated the orchestration page with @allenhouchins to remove marketing fluff for security users.

Closes https://github.com/fleetdm/fleet/issues/24640