### PR TITLE
UI – Include team-level queries in Select query modal, only call for queries when needed

### DIFF
--- a/changes/25114-include-team-queries-in-host-details-query-modal
+++ b/changes/25114-include-team-queries-in-host-details-query-modal
@@ -1,0 +1,2 @@
+* Include a host's team-level queries when the user is selecting a query to target for a specific
+host via the host details page.


### PR DESCRIPTION
## For #25114

- When host is on a team, include both the team's and global queries in list presented to the user
- Optimize by only calling queries API when needed

<img width="1464" alt="Screenshot 2025-01-08 at 6 47 06 PM" src="https://github.com/user-attachments/assets/9ed6fb1b-7cc3-4e34-a38d-4c7baecedf4c" />

- [x] Changes file added for user-visible changes in `changes/`
- [x] Manual QA for all new/changed functionality
