### PR TITLE
Fix instability of ubuntu-latest

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -37,7 +37,8 @@ jobs:
       fail-fast: false
       matrix:
         # See #9943, we just need to add windows-latest here once all issues are fixed.
-        os: [ubuntu-latest, macos-latest]
+        # Pinning to ubuntu-22.04 instead of using ubuntu-latest (updated to 24.04) to fix instability.
+        os: [ubuntu-22.04, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Harden Runner
@@ -54,7 +55,7 @@ jobs:
           go-version-file: 'go.mod'
 
       - name: Install dependencies (Linux)
-        if: matrix.os == 'ubuntu-latest'
+        if: matrix.os == 'ubuntu-22.04'
         run: |
           # The following packages are needed to build Fleet Desktop on Ubuntu.
           sudo apt update -y && sudo apt install -y gcc libgtk-3-dev libayatana-appindicator3-dev

--- a/.github/workflows/test-go.yaml
+++ b/.github/workflows/test-go.yaml
@@ -43,7 +43,8 @@ jobs:
     strategy:
       matrix:
         suite: ["integration", "core"]
-        os: [ubuntu-latest]
+        # Pinning to 22.04 instead of using ubuntu-latest (updated to 24.04) to fix instability.
+        os: [ubuntu-22.04]
         mysql: ["mysql:8.0.36", "mysql:8.4.3", "mysql:9.1.0"] # make sure to update supported versions docs when this changes
         isCron:
           - ${{ github.event_name == 'schedule' }}
@@ -194,7 +195,8 @@ jobs:
 
   # Based on https://github.com/micromdm/nanomdm/blob/main/.github/workflows/on-push-pr.yml#L87
   test-go-nanomdm:
-    runs-on: 'ubuntu-latest'
+    # Pinning to 22.04 instead of using ubuntu-latest (updated to 24.04) to fix instability.
+    runs-on: 'ubuntu-22.04'
     services:
       mysql:
         image: mysql:8.0.36
@@ -298,7 +300,8 @@ jobs:
   # We upload all backend coverage in one step so that we're less like to end up in a situation with a partial coverage report.
   upload-coverage:
     needs: [test-go, test-go-nanomdm]
-    runs-on: ubuntu-latest
+    # Pinning to 22.04 instead of using ubuntu-latest (updated to 24.04) to fix instability.
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout Code
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3


### PR DESCRIPTION
Sample failure: https://github.com/fleetdm/fleet/actions/runs/12683380540/job/35350357359

See https://github.com/actions/runner-images/issues/10636.
![Screenshot 2025-01-09 at 11 48 31 AM](https://github.com/user-attachments/assets/9d0b5b49-2355-4278-b095-37186151d3f9)


We can fix other workflows if need be, let's start with the most used ones and that we've seen failures in.