### PR TITLE
Fleet UI: Fix overflow of software title in 2 more modals

### DIFF
--- a/changes/25072-25073-software-name-overflow
+++ b/changes/25072-25073-software-name-overflow
@@ -1,0 +1,1 @@
+* Fleet UI: Fixed software name overflow in various modals

--- a/changes/25072-software-name-overflow
+++ b/changes/25072-software-name-overflow
@@ -1,1 +1,0 @@
-* Fleet UI: Fixed software name overflow

--- a/frontend/components/ActivityDetails/InstallDetails/AppInstallDetails/_styles.scss
+++ b/frontend/components/ActivityDetails/InstallDetails/AppInstallDetails/_styles.scss
@@ -1,4 +1,6 @@
 .app-install-details {
+  overflow-wrap: anywhere; // Prevent long software name overflow
+
   .modal__content {
     margin-top: $pad-xlarge;
   }

--- a/frontend/components/ActivityDetails/InstallDetails/SoftwareInstallDetails/_styles.scss
+++ b/frontend/components/ActivityDetails/InstallDetails/SoftwareInstallDetails/_styles.scss
@@ -1,4 +1,6 @@
 .software-install-details {
+  overflow-wrap: anywhere; // Prevent long software name overflow
+
   &__status-message {
     display: flex;
     align-items: center;


### PR DESCRIPTION
## Issue
For #25073 

## Description
- Fix long software file names overflow in modals

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or 
- [x] Manual QA for all new/changed functionality

