### PR TITLE
Fleet UI: Align update text baseline with neighboring text

### DIFF
--- a/frontend/components/SectionHeader/_styles.scss
+++ b/frontend/components/SectionHeader/_styles.scss
@@ -5,8 +5,9 @@
 
   &__left-header {
     display: flex;
-    align-items: center;
+    align-items: baseline;
     gap: $pad-small;
+
     &--vertical {
       flex-direction: column;
     }

--- a/frontend/components/TableContainer/_styles.scss
+++ b/frontend/components/TableContainer/_styles.scss
@@ -146,13 +146,17 @@
 
   &__results-count {
     display: flex;
-    align-items: center;
+    align-items: baseline;
     font-size: $x-small;
     font-weight: $bold;
     color: $core-fleet-black;
     margin: 0;
     height: 40px;
     gap: 12px;
+
+    > span {
+      line-height: 40px; // Match other header components' height but still align text baseline
+    }
 
     .count-error {
       color: $ui-error;

--- a/frontend/pages/DashboardPage/components/InfoCard/_styles.scss
+++ b/frontend/pages/DashboardPage/components/InfoCard/_styles.scss
@@ -34,6 +34,7 @@
   &__section-title-group {
     display: flex;
     gap: 0.75rem;
+    align-items: baseline;
   }
 
   &__section-title-detail {


### PR DESCRIPTION
## Issue
For #25180 

## Description
- Align text baseline in all places outlined in #25180

## Screenrecording examples of fixes (not all fixes are in recording)
*note baseline changing the vertical alignment of the text*

https://github.com/user-attachments/assets/3877f329-fb29-4549-8f9e-9a58469b927f



# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->
- [x] A detailed QA plan exists on the associated ticket (if it isn't there, work with the product group's QA engineer to add it)
- [x] Manual QA for all new/changed functionality

