### PR TITLE
Make Noah DRI of product design

### DIFF
--- a/website/config/custom.js
+++ b/website/config/custom.js
@@ -165,7 +165,7 @@ module.exports.custom = {
     'handbook/company/testimonials.yml': 'mike-j-thomas',
     'handbook/company/product-groups.md': 'lukeheath',
     'handbook/engineering': 'lukeheath',
-    'handbook/product-design': 'sampfluger88',
+    'handbook/product-design': 'noahtalerman',
 
 
     // 🫧 Other brandfronts
@@ -300,9 +300,6 @@ module.exports.custom = {
     // "Secret handbook"
     // Standard operating procedures (SOP), etc that would be public handbook content except for that it's confidential.
     'README.md': ['mikermcneil'],// « about this repo
-
-    // GitHub issue templates
-    '.github/ISSUE_TEMPLATE': ['mikermcneil', 'sampfluger88', 'lukeheath'],// FUTURE: Bust out individual maintainership for issue templates once relevant DRIs are GitHub, markdown, and content design-certified
 
   },
 


### PR DESCRIPTION
- Make Noah DRI of product-design page
- Remove duplicative ` // GitHub issue templates` call-out  


FYI: @lukeheath and @noahtalerman, a lot of the time you two have better context on the changes than I do and I want to remove myself as any kind of perceived blocker.