### PR TITLE
fix path to artifacts json

### DIFF
--- a/.github/workflows/goreleaser-fleet.yaml
+++ b/.github/workflows/goreleaser-fleet.yaml
@@ -106,8 +106,8 @@ jobs:
         continue-on-error: true
         id: image_digests
         run: |
-          echo "digest_fleet=$(cat ./dist/artifact.json | jq -r '.[]|select(.type == "Published Docker Image" and (.name | contains("fleetdm/fleet:${{ steps.commit.outputs.short_commit }}"))) | select(. != null)|.extra.Digest')" >> "$GITHUB_OUTPUT"
-          echo "digest_fleetctl=$(cat ./dist/artifact.json | jq -r '.[]|select(.type == "Published Docker Image" and (.name | contains("fleetdm/fleetctl:${{ steps.commit.outputs.short_commit }}"))) | select(. != null)|.extra.Digest')" >> "$GITHUB_OUTPUT"
+          echo "digest_fleet=$(cat ./dist/artifacts.json | jq -r '.[]|select(.type == "Published Docker Image" and (.name | contains("fleetdm/fleet:${{ steps.commit.outputs.short_commit }}"))) | select(. != null)|.extra.Digest')" >> "$GITHUB_OUTPUT"
+          echo "digest_fleetctl=$(cat ./dist/artifacts.json | jq -r '.[]|select(.type == "Published Docker Image" and (.name | contains("fleetdm/fleetctl:${{ steps.commit.outputs.short_commit }}"))) | select(. != null)|.extra.Digest')" >> "$GITHUB_OUTPUT"
 
       - name: Attest Fleet image
         uses: actions/attest-build-provenance@619dbb2e03e0189af0c55118e7d3c5e129e99726 # v2.0


### PR DESCRIPTION
The Docker image SLSA verification failed in the last release due to it not being able to find the artifacts.json file.  I verified that the file generated by goreleaser [in my test repo](https://github.com/sgress454/test-slack-webhook-action/actions/runs/12379686018/job/34554385122#step:8:1) is `artifacts.json`, so correcting that here.  

Unfortunately the full metadata needed to create a SLSA attestation (namely the image SHA) is only created when you actually publish an image, which makes this a bit tricky to test.