### PR TITLE
Use webhooks settings from gitops even when empty

### DIFF
--- a/changes/24958-gitops-webhooks-disable
+++ b/changes/24958-gitops-webhooks-disable
@@ -1,0 +1,1 @@
+- Disable webhooks if not present in gitops

--- a/cmd/fleetctl/gitops_test.go
+++ b/cmd/fleetctl/gitops_test.go
@@ -3319,6 +3319,26 @@ func TestGitOpsWindowsMigration(t *testing.T) {
 	}
 }
 
+func TestGitOpsWebhooksDisable(t *testing.T) {
+	_, appConfig, _ := setupFullGitOpsPremiumServer(t)
+
+	webhook := &(*appConfig).WebhookSettings
+	webhook.ActivitiesWebhook.Enable = true
+	webhook.FailingPoliciesWebhook.Enable = true
+	webhook.HostStatusWebhook.Enable = true
+	webhook.VulnerabilitiesWebhook.Enable = true
+
+	// Run config with no webooks settings
+	_, err := runAppNoChecks([]string{"gitops", "-f", "testdata/gitops/global_config_windows_migration_true_true.yml"})
+	require.NoError(t, err)
+
+	webhook = &(*appConfig).WebhookSettings
+	require.False(t, webhook.ActivitiesWebhook.Enable)
+	require.False(t, webhook.FailingPoliciesWebhook.Enable)
+	require.False(t, webhook.HostStatusWebhook.Enable)
+	require.False(t, webhook.VulnerabilitiesWebhook.Enable)
+}
+
 type memKeyValueStore struct {
 	m sync.Map
 }

--- a/docs/Configuration/yaml-files.md
+++ b/docs/Configuration/yaml-files.md
@@ -565,6 +565,21 @@ For secrets, you can add [GitHub environment variables](https://docs.github.com/
 
 The `webhook_settings` section lets you define webhook settings for failing policy, vulnerability, and host status automations. Learn more about automations in Fleet [here](https://fleetdm.com/docs/using-fleet/automations).
 
+#### activities_webhook
+
+- `enable_activities_webhook` (default: `false`)
+- `destination_url` is the URL to `POST` to when an activity is generated (default: `""`)
+
+### Example
+
+```yaml
+org_settings:
+  webhook_settings:
+    activities_webhook:
+      enable_activities_webhook: true
+      destination_url: https://example.org/webhook_handler
+```
+
 #### failing_policies_webhook
 
 - `enable_failing_policies_webhook` (default: `false`)

--- a/server/service/appconfig.go
+++ b/server/service/appconfig.go
@@ -486,6 +486,12 @@ func (svc *Service) ModifyAppConfig(ctx context.Context, p []byte, applyOpts fle
 		}
 	}
 
+	// Webhook settings should always come from the new config,
+	// if there are no settings, disable webhooks. The unmarshal
+	// that merges the settings doesn't set the fields to the
+	// default values.
+	appConfig.WebhookSettings = newAppConfig.WebhookSettings
+
 	// If the license is Premium, we should always send usage statisics.
 	if license.IsPremium() {
 		appConfig.ServerSettings.EnableAnalytics = true

--- a/server/service/appconfig.go
+++ b/server/service/appconfig.go
@@ -486,12 +486,6 @@ func (svc *Service) ModifyAppConfig(ctx context.Context, p []byte, applyOpts fle
 		}
 	}
 
-	// Webhook settings should always come from the new config,
-	// if there are no settings, disable webhooks. The unmarshal
-	// that merges the settings doesn't set the fields to the
-	// default values.
-	appConfig.WebhookSettings = newAppConfig.WebhookSettings
-
 	// If the license is Premium, we should always send usage statisics.
 	if license.IsPremium() {
 		appConfig.ServerSettings.EnableAnalytics = true

--- a/server/service/client.go
+++ b/server/service/client.go
@@ -1536,7 +1536,7 @@ func (c *Client) DoGitOps(
 		}
 
 		vulnerabilitiesWebhook, ok := webhookSettings.(map[string]any)["vulnerabilities_webhook"]
-		if !ok || failingPoliciesWebhook == nil {
+		if !ok || vulnerabilitiesWebhook == nil {
 			vulnerabilitiesWebhook = map[string]any{}
 			webhookSettings.(map[string]any)["vulnerabilities_webhook"] = vulnerabilitiesWebhook
 		}

--- a/server/service/client.go
+++ b/server/service/client.go
@@ -1503,50 +1503,45 @@ func (c *Client) DoGitOps(
 		// Ensure webhooks settings exists
 		webhookSettings, ok := group.AppConfig.(map[string]any)["webhook_settings"]
 		if !ok || webhookSettings == nil {
-			webhookSettings = fleet.WebhookSettings{}
+			webhookSettings = map[string]any{}
 			group.AppConfig.(map[string]any)["webhook_settings"] = webhookSettings
 		}
 
 		activitiesWebhook, ok := webhookSettings.(map[string]any)["activities_webhook"]
 		if !ok || activitiesWebhook == nil {
-			activitiesWebhook = fleet.ActivitiesWebhookSettings{}
+			activitiesWebhook = map[string]any{}
 			webhookSettings.(map[string]any)["activities_webhook"] = activitiesWebhook
-		} else {
-			// exists, make sure the "enable" key wither
-			// exists, or we create it with "false"
-			if _, ok := activitiesWebhook.(map[string]any)["enable_activities_webhook"]; !ok {
-				activitiesWebhook.(map[string]any)["enable_activities_webhook"] = false
-			}
+		}
+		// make sure the "enable" key either exists, or set to false
+		if _, ok := activitiesWebhook.(map[string]any)["enable_activities_webhook"]; !ok {
+			activitiesWebhook.(map[string]any)["enable_activities_webhook"] = false
 		}
 
 		hostStatusWebhook, ok := webhookSettings.(map[string]any)["host_status_webhook"]
 		if !ok || hostStatusWebhook == nil {
-			hostStatusWebhook = fleet.HostStatusWebhookSettings{}
+			hostStatusWebhook = map[string]any{}
 			webhookSettings.(map[string]any)["host_status_webhook"] = hostStatusWebhook
-		} else {
-			if _, ok := hostStatusWebhook.(map[string]any)["enable_host_status_webhook"]; !ok {
-				hostStatusWebhook.(map[string]any)["enable_host_status_webhook"] = false
-			}
+		}
+		if _, ok := hostStatusWebhook.(map[string]any)["enable_host_status_webhook"]; !ok {
+			hostStatusWebhook.(map[string]any)["enable_host_status_webhook"] = false
 		}
 
 		failingPoliciesWebhook, ok := webhookSettings.(map[string]any)["failing_policies_webhook"]
 		if !ok || failingPoliciesWebhook == nil {
-			failingPoliciesWebhook = fleet.FailingPoliciesWebhookSettings{}
+			failingPoliciesWebhook = map[string]any{}
 			webhookSettings.(map[string]any)["failing_policies_webhook"] = failingPoliciesWebhook
-		} else {
-			if _, ok := failingPoliciesWebhook.(map[string]any)["enable_failing_policies_webhook"]; !ok {
-				failingPoliciesWebhook.(map[string]any)["enable_failing_policies_webhook"] = false
-			}
+		}
+		if _, ok := failingPoliciesWebhook.(map[string]any)["enable_failing_policies_webhook"]; !ok {
+			failingPoliciesWebhook.(map[string]any)["enable_failing_policies_webhook"] = false
 		}
 
 		vulnerabilitiesWebhook, ok := webhookSettings.(map[string]any)["vulnerabilities_webhook"]
 		if !ok || failingPoliciesWebhook == nil {
-			vulnerabilitiesWebhook = fleet.VulnerabilitiesWebhookSettings{}
+			vulnerabilitiesWebhook = map[string]any{}
 			webhookSettings.(map[string]any)["vulnerabilities_webhook"] = vulnerabilitiesWebhook
-		} else {
-			if _, ok := vulnerabilitiesWebhook.(map[string]any)["enable_vulnerabilities_webhook"]; !ok {
-				vulnerabilitiesWebhook.(map[string]any)["enable_vulnerabilities_webhook"] = false
-			}
+		}
+		if _, ok := vulnerabilitiesWebhook.(map[string]any)["enable_vulnerabilities_webhook"]; !ok {
+			vulnerabilitiesWebhook.(map[string]any)["enable_vulnerabilities_webhook"] = false
 		}
 
 		// Ensure mdm config exists

--- a/server/service/client.go
+++ b/server/service/client.go
@@ -1500,6 +1500,55 @@ func (c *Client) DoGitOps(
 			}
 		}
 
+		// Ensure webhooks settings exists
+		webhookSettings, ok := group.AppConfig.(map[string]any)["webhook_settings"]
+		if !ok || webhookSettings == nil {
+			webhookSettings = fleet.WebhookSettings{}
+			group.AppConfig.(map[string]any)["webhook_settings"] = webhookSettings
+		}
+
+		activitiesWebhook, ok := webhookSettings.(map[string]any)["activities_webhook"]
+		if !ok || activitiesWebhook == nil {
+			activitiesWebhook = fleet.ActivitiesWebhookSettings{}
+			webhookSettings.(map[string]any)["activities_webhook"] = activitiesWebhook
+		} else {
+			// exists, make sure the "enable" key wither
+			// exists, or we create it with "false"
+			if _, ok := activitiesWebhook.(map[string]any)["enable_activities_webhook"]; !ok {
+				activitiesWebhook.(map[string]any)["enable_activities_webhook"] = false
+			}
+		}
+
+		hostStatusWebhook, ok := webhookSettings.(map[string]any)["host_status_webhook"]
+		if !ok || hostStatusWebhook == nil {
+			hostStatusWebhook = fleet.HostStatusWebhookSettings{}
+			webhookSettings.(map[string]any)["host_status_webhook"] = hostStatusWebhook
+		} else {
+			if _, ok := hostStatusWebhook.(map[string]any)["enable_host_status_webhook"]; !ok {
+				hostStatusWebhook.(map[string]any)["enable_host_status_webhook"] = false
+			}
+		}
+
+		failingPoliciesWebhook, ok := webhookSettings.(map[string]any)["failing_policies_webhook"]
+		if !ok || failingPoliciesWebhook == nil {
+			failingPoliciesWebhook = fleet.FailingPoliciesWebhookSettings{}
+			webhookSettings.(map[string]any)["failing_policies_webhook"] = failingPoliciesWebhook
+		} else {
+			if _, ok := failingPoliciesWebhook.(map[string]any)["enable_failing_policies_webhook"]; !ok {
+				failingPoliciesWebhook.(map[string]any)["enable_failing_policies_webhook"] = false
+			}
+		}
+
+		vulnerabilitiesWebhook, ok := webhookSettings.(map[string]any)["vulnerabilities_webhook"]
+		if !ok || failingPoliciesWebhook == nil {
+			vulnerabilitiesWebhook = fleet.VulnerabilitiesWebhookSettings{}
+			webhookSettings.(map[string]any)["vulnerabilities_webhook"] = vulnerabilitiesWebhook
+		} else {
+			if _, ok := vulnerabilitiesWebhook.(map[string]any)["enable_vulnerabilities_webhook"]; !ok {
+				vulnerabilitiesWebhook.(map[string]any)["enable_vulnerabilities_webhook"] = false
+			}
+		}
+
 		// Ensure mdm config exists
 		mdmConfig, ok := group.AppConfig.(map[string]interface{})["mdm"]
 		if !ok || mdmConfig == nil {

--- a/server/service/integration_core_test.go
+++ b/server/service/integration_core_test.go
@@ -5081,23 +5081,6 @@ func (s *integrationTestSuite) TestActivitiesWebhookConfig() {
 		`{"webhook_url": "http://some/url"}`,
 		0,
 	)
-
-	s.DoRaw(
-		"PATCH", "/api/latest/fleet/config", []byte(
-			`{}`,
-		), http.StatusOK,
-	)
-
-	s.lastActivityOfTypeMatches(
-		fleet.ActivityTypeDisabledActivityAutomations{}.ActivityName(),
-		``,
-		0,
-	)
-
-	appConfig = s.getConfig()
-	require.False(t, appConfig.WebhookSettings.ActivitiesWebhook.Enable)
-	require.Empty(t, appConfig.WebhookSettings.ActivitiesWebhook.DestinationURL)
-
 }
 
 func (s *integrationTestSuite) TestHostStatusWebhookConfig() {

--- a/server/service/integration_core_test.go
+++ b/server/service/integration_core_test.go
@@ -5518,14 +5518,6 @@ func (s *integrationTestSuite) TestExternalIntegrationsConfig() {
 			"project_key": "qux",
 			"enable_software_vulnerabilities": false
 		}]
-		},
-		"webhook_settings": {
-			"vulnerabilities_webhook": {
-				"enable_vulnerabilities_webhook": true,
-				"destination_url": "http://some/url",
-				"host_batch_size": 1234
-			},
-			"interval": "1h"
 		}
 	}`, srvURL)), http.StatusOK)
 
@@ -5539,14 +5531,6 @@ func (s *integrationTestSuite) TestExternalIntegrationsConfig() {
 				"project_key": "qux",
 				"enable_software_vulnerabilities": true
 			}]
-		},
-		"webhook_settings": {
-			"vulnerabilities_webhook": {
-				"enable_vulnerabilities_webhook": true,
-				"destination_url": "http://some/url",
-				"host_batch_size": 1234
-			},
-			"interval": "1h"
 		}
 	}`, srvURL)), http.StatusUnprocessableEntity)
 
@@ -5560,14 +5544,6 @@ func (s *integrationTestSuite) TestExternalIntegrationsConfig() {
 				"project_key": "qux",
 				"enable_software_vulnerabilities": true
 			}]
-		},
-		"webhook_settings": {
-			"vulnerabilities_webhook": {
-				"enable_vulnerabilities_webhook": false,
-				"destination_url": "http://some/url",
-				"host_batch_size": 1234
-			},
-			"interval": "1h"
 		}
 	}`, srvURL)), http.StatusBadRequest)
 
@@ -5582,14 +5558,6 @@ func (s *integrationTestSuite) TestExternalIntegrationsConfig() {
 				"project_key": "qux",
 				"enable_software_vulnerabilities": true
 			}]
-		},
-		"webhook_settings": {
-			"vulnerabilities_webhook": {
-				"enable_vulnerabilities_webhook": false,
-				"destination_url": "http://some/url",
-				"host_batch_size": 1234
-			},
-			"interval": "1h"
 		}
 	}`, srvURL)), http.StatusOK)
 

--- a/server/service/integration_core_test.go
+++ b/server/service/integration_core_test.go
@@ -6122,6 +6122,44 @@ func (s *integrationTestSuite) TestExternalIntegrationsConfig() {
 	config = s.getConfig()
 	require.Len(t, config.Integrations.Jira, 0)
 	require.Len(t, config.Integrations.Zendesk, 0)
+
+	// enable webhooks
+	s.DoRaw("PATCH", "/api/v1/fleet/config", []byte(`{
+		"webhook_settings": {
+			"activities_webhook": {
+				"enable_activities_webhook": true,
+				"destination_url": "http://some/url"
+    			},
+	    		"failing_policies_webhook": {
+	     	 		"enable_failing_policies_webhook": true,
+     		 		"destination_url": "http://some/url",
+				"host_batch_size": 1000
+	    		},
+	    		"host_status_webhook": {
+	     	 		"enable_host_status_webhook": true,
+	     	 		"destination_url": "http://some/url",
+					  "host_percentage": 2,
+						"days_count": 1
+	    		}
+		}
+	}`), http.StatusOK)
+	config = s.getConfig()
+	require.True(t, config.WebhookSettings.ActivitiesWebhook.Enable)
+	require.Equal(t, "http://some/url", config.WebhookSettings.ActivitiesWebhook.DestinationURL)
+	require.True(t, config.WebhookSettings.FailingPoliciesWebhook.Enable)
+	require.Equal(t, "http://some/url", config.WebhookSettings.FailingPoliciesWebhook.DestinationURL)
+	require.True(t, config.WebhookSettings.HostStatusWebhook.Enable)
+	require.Equal(t, "http://some/url", config.WebhookSettings.HostStatusWebhook.DestinationURL)
+
+	// No webhooks specified should disable webhooks
+	s.DoRaw("PATCH", "/api/v1/fleet/config", []byte(`{}`), http.StatusOK)
+	config = s.getConfig()
+	require.False(t, config.WebhookSettings.ActivitiesWebhook.Enable)
+	require.Equal(t, "", config.WebhookSettings.ActivitiesWebhook.DestinationURL)
+	require.False(t, config.WebhookSettings.FailingPoliciesWebhook.Enable)
+	require.Equal(t, "", config.WebhookSettings.FailingPoliciesWebhook.DestinationURL)
+	require.False(t, config.WebhookSettings.HostStatusWebhook.Enable)
+	require.Equal(t, "", config.WebhookSettings.HostStatusWebhook.DestinationURL)
 }
 
 func (s *integrationTestSuite) TestGoogleCalendarIntegrations() {

--- a/server/service/integration_core_test.go
+++ b/server/service/integration_core_test.go
@@ -5081,6 +5081,23 @@ func (s *integrationTestSuite) TestActivitiesWebhookConfig() {
 		`{"webhook_url": "http://some/url"}`,
 		0,
 	)
+
+	s.DoRaw(
+		"PATCH", "/api/latest/fleet/config", []byte(
+			`{}`,
+		), http.StatusOK,
+	)
+
+	s.lastActivityOfTypeMatches(
+		fleet.ActivityTypeDisabledActivityAutomations{}.ActivityName(),
+		``,
+		0,
+	)
+
+	appConfig = s.getConfig()
+	require.False(t, appConfig.WebhookSettings.ActivitiesWebhook.Enable)
+	require.Empty(t, appConfig.WebhookSettings.ActivitiesWebhook.DestinationURL)
+
 }
 
 func (s *integrationTestSuite) TestHostStatusWebhookConfig() {

--- a/server/service/integration_core_test.go
+++ b/server/service/integration_core_test.go
@@ -6150,16 +6150,6 @@ func (s *integrationTestSuite) TestExternalIntegrationsConfig() {
 	require.Equal(t, "http://some/url", config.WebhookSettings.FailingPoliciesWebhook.DestinationURL)
 	require.True(t, config.WebhookSettings.HostStatusWebhook.Enable)
 	require.Equal(t, "http://some/url", config.WebhookSettings.HostStatusWebhook.DestinationURL)
-
-	// No webhooks specified should disable webhooks
-	s.DoRaw("PATCH", "/api/v1/fleet/config", []byte(`{}`), http.StatusOK)
-	config = s.getConfig()
-	require.False(t, config.WebhookSettings.ActivitiesWebhook.Enable)
-	require.Equal(t, "", config.WebhookSettings.ActivitiesWebhook.DestinationURL)
-	require.False(t, config.WebhookSettings.FailingPoliciesWebhook.Enable)
-	require.Equal(t, "", config.WebhookSettings.FailingPoliciesWebhook.DestinationURL)
-	require.False(t, config.WebhookSettings.HostStatusWebhook.Enable)
-	require.Equal(t, "", config.WebhookSettings.HostStatusWebhook.DestinationURL)
 }
 
 func (s *integrationTestSuite) TestGoogleCalendarIntegrations() {

--- a/server/service/integration_core_test.go
+++ b/server/service/integration_core_test.go
@@ -4679,7 +4679,7 @@ func (s *integrationTestSuite) TestUsers() {
 	var modResp modifyUserResponse
 	s.DoJSON("PATCH", fmt.Sprintf("/api/latest/fleet/users/%d", 1), json.RawMessage(`{
 		"settings": {
-			"hidden_host_columns": ["osquery_version"]}	
+			"hidden_host_columns": ["osquery_version"]}
 	}`), http.StatusOK, &modResp)
 
 	// get session user with ui settings, should now be present, two endpoints
@@ -4701,7 +4701,7 @@ func (s *integrationTestSuite) TestUsers() {
 	// modify user ui settings, check they are returned modified
 	s.DoJSON("PATCH", fmt.Sprintf("/api/latest/fleet/users/%d", 1), json.RawMessage(`{
 		"settings": {
-			"hidden_host_columns": ["hostname", "osquery_version"]}	
+			"hidden_host_columns": ["hostname", "osquery_version"]}
 	}`), http.StatusOK, &modResp)
 
 	// get session user with ui settings, should now be modified, two endpoints
@@ -4723,7 +4723,7 @@ func (s *integrationTestSuite) TestUsers() {
 	// modify user ui settings, empty array, check they are returned correctly
 	s.DoJSON("PATCH", fmt.Sprintf("/api/latest/fleet/users/%d", 1), json.RawMessage(`{
 		"settings": {
-			"hidden_host_columns": []}	
+			"hidden_host_columns": []}
 	}`), http.StatusOK, &modResp)
 
 	// get session user with ui settings, should now be modified, two endpoints
@@ -5539,6 +5539,14 @@ func (s *integrationTestSuite) TestExternalIntegrationsConfig() {
 				"project_key": "qux",
 				"enable_software_vulnerabilities": true
 			}]
+		},
+		"webhook_settings": {
+			"vulnerabilities_webhook": {
+				"enable_vulnerabilities_webhook": true,
+				"destination_url": "http://some/url",
+				"host_batch_size": 1234
+			},
+			"interval": "1h"
 		}
 	}`, srvURL)), http.StatusUnprocessableEntity)
 
@@ -5954,6 +5962,14 @@ func (s *integrationTestSuite) TestExternalIntegrationsConfig() {
 				"group_id": 122,
 				"enable_software_vulnerabilities": true
 			}]
+		},
+		"webhook_settings": {
+			"vulnerabilities_webhook": {
+				"enable_vulnerabilities_webhook": true,
+				"destination_url": "http://some/url",
+				"host_batch_size": 1234
+			},
+			"interval": "1h"
 		}
 	}`, srvURL)), http.StatusUnprocessableEntity)
 

--- a/server/service/integration_core_test.go
+++ b/server/service/integration_core_test.go
@@ -5941,14 +5941,6 @@ func (s *integrationTestSuite) TestExternalIntegrationsConfig() {
 				"group_id": 122,
 				"enable_software_vulnerabilities": false
 			}]
-		},
-		"webhook_settings": {
-			"vulnerabilities_webhook": {
-				"enable_vulnerabilities_webhook": true,
-				"destination_url": "http://some/url",
-				"host_batch_size": 1234
-			},
-			"interval": "1h"
 		}
 	}`, srvURL)), http.StatusOK)
 
@@ -5962,14 +5954,6 @@ func (s *integrationTestSuite) TestExternalIntegrationsConfig() {
 				"group_id": 122,
 				"enable_software_vulnerabilities": true
 			}]
-		},
-		"webhook_settings": {
-			"vulnerabilities_webhook": {
-				"enable_vulnerabilities_webhook": true,
-				"destination_url": "http://some/url",
-				"host_batch_size": 1234
-			},
-			"interval": "1h"
 		}
 	}`, srvURL)), http.StatusUnprocessableEntity)
 

--- a/server/service/integration_core_test.go
+++ b/server/service/integration_core_test.go
@@ -5539,14 +5539,6 @@ func (s *integrationTestSuite) TestExternalIntegrationsConfig() {
 				"project_key": "qux",
 				"enable_software_vulnerabilities": true
 			}]
-		},
-		"webhook_settings": {
-			"vulnerabilities_webhook": {
-				"enable_vulnerabilities_webhook": true,
-				"destination_url": "http://some/url",
-				"host_batch_size": 1234
-			},
-			"interval": "1h"
 		}
 	}`, srvURL)), http.StatusUnprocessableEntity)
 
@@ -5941,6 +5933,14 @@ func (s *integrationTestSuite) TestExternalIntegrationsConfig() {
 				"group_id": 122,
 				"enable_software_vulnerabilities": false
 			}]
+		},
+		"webhook_settings": {
+			"vulnerabilities_webhook": {
+				"enable_vulnerabilities_webhook": true,
+				"destination_url": "http://some/url",
+				"host_batch_size": 1234
+			},
+			"interval": "1h"
 		}
 	}`, srvURL)), http.StatusOK)
 

--- a/server/service/integration_core_test.go
+++ b/server/service/integration_core_test.go
@@ -5518,6 +5518,14 @@ func (s *integrationTestSuite) TestExternalIntegrationsConfig() {
 			"project_key": "qux",
 			"enable_software_vulnerabilities": false
 		}]
+		},
+		"webhook_settings": {
+			"vulnerabilities_webhook": {
+				"enable_vulnerabilities_webhook": true,
+				"destination_url": "http://some/url",
+				"host_batch_size": 1234
+			},
+			"interval": "1h"
 		}
 	}`, srvURL)), http.StatusOK)
 
@@ -5531,6 +5539,14 @@ func (s *integrationTestSuite) TestExternalIntegrationsConfig() {
 				"project_key": "qux",
 				"enable_software_vulnerabilities": true
 			}]
+		},
+		"webhook_settings": {
+			"vulnerabilities_webhook": {
+				"enable_vulnerabilities_webhook": true,
+				"destination_url": "http://some/url",
+				"host_batch_size": 1234
+			},
+			"interval": "1h"
 		}
 	}`, srvURL)), http.StatusUnprocessableEntity)
 
@@ -5544,6 +5560,14 @@ func (s *integrationTestSuite) TestExternalIntegrationsConfig() {
 				"project_key": "qux",
 				"enable_software_vulnerabilities": true
 			}]
+		},
+		"webhook_settings": {
+			"vulnerabilities_webhook": {
+				"enable_vulnerabilities_webhook": false,
+				"destination_url": "http://some/url",
+				"host_batch_size": 1234
+			},
+			"interval": "1h"
 		}
 	}`, srvURL)), http.StatusBadRequest)
 
@@ -5558,6 +5582,14 @@ func (s *integrationTestSuite) TestExternalIntegrationsConfig() {
 				"project_key": "qux",
 				"enable_software_vulnerabilities": true
 			}]
+		},
+		"webhook_settings": {
+			"vulnerabilities_webhook": {
+				"enable_vulnerabilities_webhook": false,
+				"destination_url": "http://some/url",
+				"host_batch_size": 1234
+			},
+			"interval": "1h"
 		}
 	}`, srvURL)), http.StatusOK)
 


### PR DESCRIPTION
#24958

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/Committing-Changes.md#changes-files) for more information.
- [x] Added/updated automated tests
- [x] A detailed QA plan exists on the associated ticket (if it isn't there, work with the product group's QA engineer to add it)
- [x] Manual QA for all new/changed functionality