### PR TITLE
UI - Ungate user form SSO field for non-admins, handle subtle UX bug

### DIFF
--- a/changes/24660-team-admins-cant-set-sso-mfa
+++ b/changes/24660-team-admins-cant-set-sso-mfa
@@ -1,0 +1,2 @@
+- Fix missing capabilities in the UI for team admins creating or editing a user by exposing
+  more information from the API for team admins.

--- a/frontend/components/AddHostsModal/PlatformWrapper/PlatformWrapper.tsx
+++ b/frontend/components/AddHostsModal/PlatformWrapper/PlatformWrapper.tsx
@@ -338,16 +338,17 @@ const PlatformWrapper = ({
   }
 }`,
     };
-    const getHelpTextForPackageType = (): string => {
-      if (packageType === "deb") {
-        return "Install this package to add hosts to Fleet. For CentOS, Red Hat, and Fedora Linux, use --type=rpm.";
-      } else if (packageType === "msi") {
-        return "Install this package to add hosts to Fleet. For Windows, this generates an MSI package.";
-      } else if (packageType === "pkg") {
-        return "Install this package to add hosts to Fleet.";
-      }
-      return "";
-    };
+
+    let packageTypeHelpText = "";
+    if (packageType === "deb") {
+      packageTypeHelpText =
+        "Install this package to add hosts to Fleet. For CentOS, Red Hat, and Fedora Linux, use --type=rpm.";
+    } else if (packageType === "msi") {
+      packageTypeHelpText =
+        "Install this package to add hosts to Fleet. For Windows, this generates an MSI package.";
+    } else if (packageType === "pkg") {
+      packageTypeHelpText = "Install this package to add hosts to Fleet.";
+    }
 
     if (packageType === "chromeos") {
       return (
@@ -555,7 +556,7 @@ const PlatformWrapper = ({
           label={renderLabel(packageType, renderInstallerString(packageType))}
           type="textarea"
           value={renderInstallerString(packageType)}
-          helpText={`${getHelpTextForPackageType()}`}
+          helpText={packageTypeHelpText}
         />
       </>
     );

--- a/frontend/pages/admin/UserManagementPage/components/UserForm/UserForm.tsx
+++ b/frontend/pages/admin/UserManagementPage/components/UserForm/UserForm.tsx
@@ -639,12 +639,11 @@ const UserForm = ({
           {renderNameAndEmailSection()}
           {renderAuthenticationSection()}
           {((isNewUser && formData.newUserType !== NewUserType.AdminInvited) ||
-            (!isNewUser && !isInvitePending && isModifiedByGlobalAdmin)) &&
+            (!isNewUser && !isInvitePending)) &&
             !formData.sso_enabled &&
             renderPasswordSection()}
           {(isPremiumTier || isMfaEnabled) &&
             !formData.sso_enabled &&
-            isModifiedByGlobalAdmin &&
             renderTwoFactorAuthenticationOption()}
           {isPremiumTier ? renderPremiumRoleOptions() : renderGlobalRoleForm()}
         </form>

--- a/frontend/pages/admin/UserManagementPage/components/UserForm/UserForm.tsx
+++ b/frontend/pages/admin/UserManagementPage/components/UserForm/UserForm.tsx
@@ -138,6 +138,8 @@ const UserForm = ({
 
   const [isGlobalUser, setIsGlobalUser] = useState(!!defaultGlobalRole);
 
+  const initiallyPasswordAuth = !isSsoEnabled;
+
   useEffect(() => {
     // If SSO is globally disabled but user previously signed in via SSO,
     // require password is automatically selected on first render
@@ -524,7 +526,9 @@ const UserForm = ({
         className={`${baseClass}__radio-input`}
         label="Password"
         id="password-authentication"
-        disabled={!(smtpConfigured || sesConfigured)}
+        // allow the user to change auth back to password if they only changed the form to SSO in
+        // the current session, that is, in the db, the user is still password authenticated
+        disabled={!(smtpConfigured || sesConfigured) && !initiallyPasswordAuth}
         checked={!formData.sso_enabled}
         value="false"
         name="authentication-type"

--- a/frontend/utilities/helpers.tsx
+++ b/frontend/utilities/helpers.tsx
@@ -2,10 +2,8 @@ import React from "react";
 import {
   isEmpty,
   flatMap,
-  find,
   omit,
   pick,
-  size,
   memoize,
   reduce,
   trim,
@@ -44,8 +42,6 @@ import { UserRole } from "interfaces/user";
 import PATHS from "router/paths";
 import stringUtils from "utilities/strings";
 import sortUtils from "utilities/sort";
-import { checkTable } from "utilities/sql_tools";
-import { osqueryTables } from "utilities/osquery_tables";
 import {
   DEFAULT_EMPTY_CELL_VALUE,
   DEFAULT_GRAVATAR_LINK,
@@ -59,7 +55,6 @@ import {
 } from "utilities/constants";
 import { ISchedulableQueryStats } from "interfaces/schedulable_query";
 import { IDropdownOption } from "interfaces/dropdownOption";
-import { IActivityDetails } from "interfaces/activity";
 
 const ORG_INFO_ATTRS = ["org_name", "org_logo_url"];
 const ADMIN_ATTRS = ["email", "name", "password", "password_confirmation"];
@@ -170,87 +165,6 @@ const filterTarget = (targetType: string) => {
       default:
         return [];
     }
-  };
-};
-
-export const formatConfigDataForServer = (config: any): any => {
-  const orgInfoAttrs = pick(config, ["org_logo_url", "org_name"]);
-  const serverSettingsAttrs = pick(config, [
-    "server_url",
-    "osquery_enroll_secret",
-    "live_query_disabled",
-    "enable_analytics",
-  ]);
-  const smtpSettingsAttrs = pick(config, [
-    "authentication_method",
-    "authentication_type",
-    "domain",
-    "enable_ssl_tls",
-    "enable_start_tls",
-    "password",
-    "port",
-    "sender_address",
-    "server",
-    "user_name",
-    "verify_ssl_certs",
-    "enable_smtp",
-  ]);
-  const ssoSettingsAttrs = pick(config, [
-    "entity_id",
-    "idp_image_url",
-    "metadata",
-    "metadata_url",
-    "idp_name",
-    "enable_sso",
-    "enable_sso_idp_login",
-  ]);
-  const hostExpirySettingsAttrs = pick(config, [
-    "host_expiry_enabled",
-    "host_expiry_window",
-  ]);
-  const webhookSettingsAttrs = pick(config, [
-    "enable_host_status_webhook",
-    "destination_url",
-    "host_percentage",
-    "days_count",
-  ]);
-  // because agent_options is already an object
-  const agentOptionsSettingsAttrs = config.agent_options;
-
-  const orgInfo = size(orgInfoAttrs) && { org_info: orgInfoAttrs };
-  const serverSettings = size(serverSettingsAttrs) && {
-    server_settings: serverSettingsAttrs,
-  };
-  const smtpSettings = size(smtpSettingsAttrs) && {
-    smtp_settings: smtpSettingsAttrs,
-  };
-  const ssoSettings = size(ssoSettingsAttrs) && {
-    sso_settings: ssoSettingsAttrs,
-  };
-  const hostExpirySettings = size(hostExpirySettingsAttrs) && {
-    host_expiry_settings: hostExpirySettingsAttrs,
-  };
-  const agentOptionsSettings = size(agentOptionsSettingsAttrs) && {
-    agent_options: yaml.load(agentOptionsSettingsAttrs),
-  };
-  const webhookSettings = size(webhookSettingsAttrs) && {
-    webhook_settings: { host_status_webhook: webhookSettingsAttrs }, // nested to server
-  };
-
-  if (hostExpirySettings) {
-    hostExpirySettings.host_expiry_settings.host_expiry_window = Number(
-      hostExpirySettings.host_expiry_settings.host_expiry_window
-    );
-  }
-
-  return {
-    ...orgInfo,
-    ...serverSettings,
-    ...smtpSettings,
-    ...ssoSettings,
-    ...hostExpirySettings,
-    ...agentOptionsSettings,
-    ...webhookSettings,
   };
 };
 
@@ -1002,7 +916,6 @@ export default {
   removeOSPrefix,
   compareVersions,
   createHostsByPolicyPath,
-  formatConfigDataForServer,
   formatLabelResponse,
   formatFloatAsPercentage,
   formatSeverity,

--- a/frontend/utilities/helpers.tsx
+++ b/frontend/utilities/helpers.tsx
@@ -20,13 +20,11 @@ import {
   isAfter,
   addDays,
 } from "date-fns";
-import yaml from "js-yaml";
 
 import { QueryParams, buildQueryStringFromParams } from "utilities/url";
 import { IHost } from "interfaces/host";
 import { ILabel } from "interfaces/label";
 import { IPack } from "interfaces/pack";
-import { IQueryTableColumn } from "interfaces/osquery_table";
 import {
   IScheduledQuery,
   IPackQueryFormData,


### PR DESCRIPTION
_Merge only _after_ https://github.com/fleetdm/fleet/pull/25322_
## For #25319 

- Team admin can access SSO and 2FA options in user form when they are enabled (see api response to right):

<img width="1799" alt="Screenshot 2025-01-10 at 1 36 10 PM" src="https://github.com/user-attachments/assets/66bd5eea-dc1d-4e5b-85fc-b377520f337a" />

- [x] Changes file added for user-visible changes in `changes/`,
- [x] A detailed QA plan exists on the associated ticket (if it isn't there, work with the product group's QA engineer to add it)
- [x] Manual QA for all new/changed functionality