### PR TITLE
UI – Render default empty cell when host has no UUID

### DIFF
--- a/changes/23811-empty-cell-for-no-uuid
+++ b/changes/23811-empty-cell-for-no-uuid
@@ -1,0 +1,1 @@
+* Render the default empty value when a host has no UUID

--- a/frontend/pages/hosts/ManageHostsPage/HostTableConfig.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/HostTableConfig.tsx
@@ -530,9 +530,8 @@ const allHostTableHeaders: IHostTableColumnConfig[] = [
     ),
     accessor: "uuid",
     id: "uuid",
-    Cell: (cellProps: IHostTableStringCellProps) => (
-      <TooltipTruncatedTextCell value={cellProps.cell.value} />
-    ),
+    Cell: ({ cell: { value } }: IHostTableStringCellProps) =>
+      value ? <TooltipTruncatedTextCell value={value} /> : <TextCell />,
   },
   {
     title: "Last restarted",


### PR DESCRIPTION
## For #23811 
<img width="868" alt="Screenshot 2025-01-10 at 3 29 28 PM" src="https://github.com/user-attachments/assets/2f95a2d6-7050-4f64-be73-51b6f4a5d422" />

- [x] Changes file added for user-visible changes in `changes/`
- [x] Manual QA for all new/changed functionality
- [ ] Detailed QA plan on the issue