### PR TITLE
Website: Update admin query generator to work in production.

### DIFF
--- a/website/api/controllers/admin/get-llm-generated-sql.js
+++ b/website/api/controllers/admin/get-llm-generated-sql.js
@@ -26,7 +26,7 @@ module.exports = {
 
   fn: async function ({naturalLanguageQuestion}) {
 
-    let completeTables = await sails.helpers.getExtendedOsquerySchema();
+    let completeTables = sails.config.builtStaticContent.schemaTables;
     let prunedTables = completeTables.map((table)=>{
       let newTable = _.pick(table,['name','description','platforms', 'examples']);
       newTable.columns = table.columns.map((column) => _.pick(column, ['name', 'description', 'type', 'platforms', 'required']));

--- a/website/api/controllers/admin/view-query-generator.js
+++ b/website/api/controllers/admin/view-query-generator.js
@@ -11,13 +11,15 @@ module.exports = {
 
     success: {
       viewTemplatePath: 'pages/admin/query-generator'
-    }
-
+    },
+    badConfig: { responseType: 'badConfig' },
   },
 
 
   fn: async function () {
-
+    if (!_.isObject(sails.config.builtStaticContent) || !_.isArray(sails.config.builtStaticContent.schemaTables)) {
+      throw {badConfig: 'builtStaticContent.schemaTables'};
+    }
     // Respond with view.
     return {};
 

--- a/website/scripts/build-static-content.js
+++ b/website/scripts/build-static-content.js
@@ -725,7 +725,8 @@ module.exports = {
         } else {
           expandedTables = await sails.helpers.getExtendedOsquerySchema();
         }
-
+        // Add the expanded tables to the website's configuration as builtStaticContent.osqueryTables.
+        builtStaticContent.schemaTables = expandedTables;
         // Once we have our merged schema, we'll create ejs partials for each table.
         for(let table of expandedTables) {
           let keywordsForSyntaxHighlighting = [];


### PR DESCRIPTION
Changes:
- Updated the `build-static-content` script to add the merged osquery schema JSON to the website's `builtStaticContent` configuration
- Updated view-query-generator to have a badConfig exit that is used if the website has an invalid `builtStaticContent.schemaTables` configuration
- Updated `get-llm-generated-sql` to use the `builtStaticContent.schemaTables` instead of attempting to use `sails.helpers.getExtendedOsquerySchema()` (Which does not work as intended when run in a production environment.)