### PR TITLE
Fleet UI: (Unreleased) fix logic with versions in left header, update css

### DIFF
--- a/frontend/pages/SoftwarePage/SoftwareTitles/SoftwareTable/SoftwareTable.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitles/SoftwareTable/SoftwareTable.tsx
@@ -195,17 +195,12 @@ const SoftwareTable = ({
   const hasData = tableData && tableData.length > 0;
   const hasQuery = query !== "";
   const hasSoftwareFilter = softwareFilter !== "allSoftware";
-  const hasVersionFilter = showVersions;
   const vulnFilterDetails = getVulnFilterRenderDetails(vulnFilters);
   const hasVulnFilters = vulnFilterDetails.filterCount > 0;
 
   const showFilterHeaders =
     isSoftwareEnabled &&
-    (hasData ||
-      hasQuery ||
-      hasSoftwareFilter ||
-      hasVersionFilter ||
-      hasVulnFilters);
+    (hasData || hasQuery || hasSoftwareFilter || hasVulnFilters);
 
   const handleShowVersionsToggle = () => {
     const queryParams: Record<string, string | number | boolean | undefined> = {
@@ -268,8 +263,6 @@ const SoftwareTable = ({
   };
 
   const renderSoftwareCount = () => {
-    if (!tableData || !data) return null;
-
     return (
       <>
         <TableCount name="items" count={data?.count} />

--- a/frontend/pages/SoftwarePage/SoftwareTitles/SoftwareTable/_styles.scss
+++ b/frontend/pages/SoftwarePage/SoftwareTitles/SoftwareTable/_styles.scss
@@ -21,24 +21,9 @@
   }
 
   .table-container {
-    &__header {
-      flex-direction: column-reverse; // Search bar on top
-
-      @media (min-width: $table-controls-break) {
-        flex-direction: row;
-      }
-    }
-
-    &__header-left {
-      flex-direction: row; // Filter dropdown aligned with count
-
-      .controls {
-        .form-field--dropdown {
-          margin: 0;
-        }
-        .form-field {
-          width: initial; // Negate form-field styling on slider
-        }
+    &__results-count {
+      .form-field--slider {
+        align-self: center;
       }
     }
 


### PR DESCRIPTION
## Issue
For #25365 

## Description
- Because toggle is now on left side, code to hide/show right side headers needed to be updated
- Updated left side headers to always show to match OS/vuln header empty state behavior
- Align toggle center on left side
- Code cleanup: Remove unused CSS from when we only had a search bar

## Screen recording of fix


https://github.com/user-attachments/assets/b0bb26a0-98fc-48c1-ade1-1cd90441c367




# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Manual QA for all new/changed functionality

