### PR TITLE
Fleet UI: Fix dropdowns and use newer react-select

### DIFF
--- a/frontend/components/TableContainer/DataTable/DefaultColumnFilter/_styles.scss
+++ b/frontend/components/TableContainer/DataTable/DefaultColumnFilter/_styles.scss
@@ -4,7 +4,7 @@
   }
 
   input {
-    height: 40px;
+    height: 38px;
     width: 100%;
     font-size: $x-small;
     background-color: transparent;

--- a/frontend/components/TableContainer/DataTable/DefaultColumnFilter/_styles.scss
+++ b/frontend/components/TableContainer/DataTable/DefaultColumnFilter/_styles.scss
@@ -4,7 +4,7 @@
   }
 
   input {
-    height: 38px;
+    height: 40px;
     width: 100%;
     font-size: $x-small;
     background-color: transparent;

--- a/frontend/components/TableContainer/_styles.scss
+++ b/frontend/components/TableContainer/_styles.scss
@@ -77,7 +77,7 @@
     margin-top: 3px; // Fits button highlight during tabbing
 
     .input-icon-field {
-      height: 38px; // Height 38px on table headers
+      height: 40px; // Height 40px on table headers
     }
 
     &.stack-table-controls {
@@ -109,7 +109,7 @@
     // filter and search bar height
     .dropdown__select,
     .input-with-icon {
-      height: 38px;
+      height: 40px;
     }
   }
 
@@ -137,11 +137,11 @@
     font-weight: $bold;
     color: $core-fleet-black;
     margin: 0;
-    height: 38px;
+    height: 40px;
     gap: 12px;
 
     > span {
-      line-height: 38px; // Match other header components' height but still align text baseline
+      line-height: 40px; // Match other header components' height but still align text baseline
     }
 
     .count-error {

--- a/frontend/components/TableContainer/_styles.scss
+++ b/frontend/components/TableContainer/_styles.scss
@@ -142,6 +142,7 @@
 
     > span {
       line-height: 40px; // Match other header components' height but still align text baseline
+      min-width: fit-content;
     }
 
     .count-error {

--- a/frontend/components/TableContainer/_styles.scss
+++ b/frontend/components/TableContainer/_styles.scss
@@ -76,6 +76,10 @@
     gap: $pad-small;
     margin-top: 3px; // Fits button highlight during tabbing
 
+    .input-icon-field {
+      height: 38px; // Height 38px on table headers
+    }
+
     &.stack-table-controls {
       align-items: start;
 

--- a/frontend/components/TableContainer/_styles.scss
+++ b/frontend/components/TableContainer/_styles.scss
@@ -1,8 +1,4 @@
 .table-container {
-  .form-field {
-    width: initial; // 100% causes weird rendering in dropdown
-  }
-
   // Container is responsive design used when customFilters is rendered
   .container {
     display: grid;
@@ -109,7 +105,7 @@
     // filter and search bar height
     .dropdown__select,
     .input-with-icon {
-      height: 40px;
+      height: 38px;
     }
   }
 
@@ -137,11 +133,11 @@
     font-weight: $bold;
     color: $core-fleet-black;
     margin: 0;
-    height: 40px;
+    height: 38px;
     gap: 12px;
 
     > span {
-      line-height: 40px; // Match other header components' height but still align text baseline
+      line-height: 38px; // Match other header components' height but still align text baseline
     }
 
     .count-error {

--- a/frontend/components/forms/fields/DropdownWrapper/DropdownWrapper.tsx
+++ b/frontend/components/forms/fields/DropdownWrapper/DropdownWrapper.tsx
@@ -59,7 +59,7 @@ export interface IDropdownWrapper {
   placeholder?: string;
   /** E.g. scroll to view dropdown menu in a scrollable parent container */
   onMenuOpen?: () => void;
-  /** Table filter dropdowns have height: 40px  */
+  /** Table filter dropdowns have filter icon and height: 40px  */
   tableFilter?: boolean;
 }
 
@@ -85,8 +85,6 @@ const DropdownWrapper = ({
   const wrapperClassNames = classnames(baseClass, className, {
     [`${baseClass}__table-filter`]: tableFilter,
   });
-  console.log("tableFilter", tableFilter);
-  console.log("wrapperClassNames", wrapperClassNames);
 
   const handleChange = (newValue: SingleValue<CustomOptionType>) => {
     onChange(newValue);
@@ -154,11 +152,13 @@ const DropdownWrapper = ({
   };
 
   const ValueContainer = ({ children, ...props }: any) => {
+    const iconToDisplay = iconName || (tableFilter ? "filter" : null);
+
     return (
       components.ValueContainer && (
         <components.ValueContainer {...props}>
-          {!!children && iconName && (
-            <Icon name={iconName} className="filter-icon" />
+          {!!children && iconToDisplay && (
+            <Icon name={iconToDisplay} className="filter-icon" />
           )}
           {children}
         </components.ValueContainer>

--- a/frontend/components/forms/fields/DropdownWrapper/DropdownWrapper.tsx
+++ b/frontend/components/forms/fields/DropdownWrapper/DropdownWrapper.tsx
@@ -59,6 +59,8 @@ export interface IDropdownWrapper {
   placeholder?: string;
   /** E.g. scroll to view dropdown menu in a scrollable parent container */
   onMenuOpen?: () => void;
+  /** Table filter dropdowns have height: 40px  */
+  tableFilter?: boolean;
 }
 
 const baseClass = "dropdown-wrapper";
@@ -78,8 +80,13 @@ const DropdownWrapper = ({
   iconName,
   placeholder,
   onMenuOpen,
+  tableFilter = false,
 }: IDropdownWrapper) => {
-  const wrapperClassNames = classnames(baseClass, className);
+  const wrapperClassNames = classnames(baseClass, className, {
+    [`${baseClass}__table-filter`]: tableFilter,
+  });
+  console.log("tableFilter", tableFilter);
+  console.log("wrapperClassNames", wrapperClassNames);
 
   const handleChange = (newValue: SingleValue<CustomOptionType>) => {
     onChange(newValue);

--- a/frontend/components/forms/fields/DropdownWrapper/_styles.scss
+++ b/frontend/components/forms/fields/DropdownWrapper/_styles.scss
@@ -14,6 +14,8 @@
 
   // Table dropdowns have height 38px
   &__table-filter {
+    height: 38px;
+
     .react-select__control {
       height: 38px;
     }

--- a/frontend/components/forms/fields/DropdownWrapper/_styles.scss
+++ b/frontend/components/forms/fields/DropdownWrapper/_styles.scss
@@ -11,4 +11,11 @@
       color: $ui-fleet-black-50;
     }
   }
+
+  // Table dropdowns have height 38px
+  &__table-filter {
+    .react-select__control {
+      height: 38px;
+    }
+  }
 }

--- a/frontend/components/forms/fields/DropdownWrapper/_styles.scss
+++ b/frontend/components/forms/fields/DropdownWrapper/_styles.scss
@@ -12,12 +12,12 @@
     }
   }
 
-  // Table dropdowns have height 38px
+  // Table dropdowns have height 40px
   &__table-filter {
-    height: 38px;
+    height: 40px;
 
     .react-select__control {
-      height: 38px;
+      height: 40px;
     }
   }
 }

--- a/frontend/pages/SoftwarePage/SoftwareOS/SoftwareOSTable/SoftwareOSTable.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareOS/SoftwareOSTable/SoftwareOSTable.tsx
@@ -8,13 +8,14 @@ import PATHS from "router/paths";
 
 import { GITHUB_NEW_ISSUE_LINK } from "utilities/constants";
 
-// @ts-ignore
-import Dropdown from "components/forms/fields/Dropdown";
 import CustomLink from "components/CustomLink";
 import TableContainer from "components/TableContainer";
 import LastUpdatedText from "components/LastUpdatedText";
 import { ITableQueryData } from "components/TableContainer/TableContainer";
 import TableCount from "components/TableContainer/TableCount";
+import { SingleValue } from "react-select-5";
+import DropdownWrapper from "components/forms/fields/DropdownWrapper";
+import { CustomOptionType } from "components/forms/fields/DropdownWrapper/DropdownWrapper";
 
 import EmptySoftwareTable from "pages/SoftwarePage/components/EmptySoftwareTable";
 import { IOSVersionsResponse } from "services/entities/operating_systems";
@@ -214,7 +215,9 @@ const SoftwareOSTable = ({
     );
   };
 
-  const handlePlatformFilterDropdownChange = (platformSelected: string) => {
+  const handlePlatformFilterDropdownChange = (
+    platformSelected: SingleValue<CustomOptionType>
+  ) => {
     router?.replace(
       getNextLocationPath({
         pathPrefix: PATHS.SOFTWARE_OS,
@@ -223,7 +226,7 @@ const SoftwareOSTable = ({
           order_direction: orderDirection,
           order_key: orderKey,
           page: 0,
-          platform: platformSelected,
+          platform: platformSelected?.value,
         },
       })
     );
@@ -231,13 +234,13 @@ const SoftwareOSTable = ({
 
   const renderPlatformDropdown = () => {
     return (
-      <Dropdown
+      <DropdownWrapper
+        name="os-platform-dropdown"
         value={platform || "all"}
         className={`${baseClass}__platform-dropdown`}
         options={PLATFORM_FILTER_OPTIONS}
-        searchable={false}
         onChange={handlePlatformFilterDropdownChange}
-        tableFilterDropdown
+        tableFilter
       />
     );
   };

--- a/frontend/pages/SoftwarePage/SoftwareTitles/SoftwareTable/SoftwareTable.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitles/SoftwareTable/SoftwareTable.tsx
@@ -299,7 +299,7 @@ const SoftwareTable = ({
         <DropdownWrapper
           name="software-filter"
           value={softwareFilter}
-          className={`${baseClass}__filter-dropdown`}
+          className={`${baseClass}__software-filter`}
           options={SOFTWARE_TITLES_DROPDOWN_OPTIONS}
           onChange={(newValue: SingleValue<CustomOptionType>) =>
             newValue &&
@@ -307,7 +307,6 @@ const SoftwareTable = ({
               newValue.value as ISoftwareDropdownFilterVal
             )
           }
-          iconName="filter"
           tableFilter
         />
       </div>

--- a/frontend/pages/SoftwarePage/SoftwareTitles/SoftwareTable/SoftwareTable.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitles/SoftwareTable/SoftwareTable.tsx
@@ -308,6 +308,7 @@ const SoftwareTable = ({
             )
           }
           iconName="filter"
+          tableFilter
         />
       </div>
     );

--- a/frontend/pages/SoftwarePage/SoftwareTitles/SoftwareTable/_styles.scss
+++ b/frontend/pages/SoftwarePage/SoftwareTitles/SoftwareTable/_styles.scss
@@ -33,6 +33,7 @@
 
       .input-icon-field__input {
         min-width: 213px;
+        height: 40px;
       }
 
       @media (min-width: $table-controls-break) {

--- a/frontend/pages/SoftwarePage/SoftwareTitles/SoftwareTable/_styles.scss
+++ b/frontend/pages/SoftwarePage/SoftwareTitles/SoftwareTable/_styles.scss
@@ -1,5 +1,5 @@
 .software-table {
-  &__filter-dropdown {
+  &__software-filter {
     min-width: 213px;
   }
 

--- a/frontend/pages/SoftwarePage/SoftwareVulnerabilities/SoftwareVulnerabilitiesTable/SoftwareVulnerabilitiesTable.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareVulnerabilities/SoftwareVulnerabilitiesTable/SoftwareVulnerabilitiesTable.tsx
@@ -238,14 +238,13 @@ const SoftwareVulnerabilitiesTable = ({
   const renderExploitedVulnerabilitiesDropdown = () => {
     return (
       <DropdownWrapper
-        name="exploited-vuln-dropdown"
+        name="exploited-vuln-filter"
         value={showExploitedVulnerabilitiesOnly.toString()}
-        className={`${baseClass}__exploited-vulnerabilities-dropdown`}
+        className={`${baseClass}__exploited-vulnerabilities-filter`}
         options={getExploitedVulnerabilitiesDropdownOptions(isPremiumTier)}
         onChange={(newValue: SingleValue<CustomOptionType>) =>
           newValue && handleExploitedVulnFilterDropdownChange(newValue.value)
         }
-        iconName="filter"
         tableFilter
       />
     );

--- a/frontend/pages/SoftwarePage/SoftwareVulnerabilities/SoftwareVulnerabilitiesTable/SoftwareVulnerabilitiesTable.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareVulnerabilities/SoftwareVulnerabilitiesTable/SoftwareVulnerabilitiesTable.tsx
@@ -246,6 +246,7 @@ const SoftwareVulnerabilitiesTable = ({
           newValue && handleExploitedVulnFilterDropdownChange(newValue.value)
         }
         iconName="filter"
+        tableFilter
       />
     );
   };

--- a/frontend/pages/SoftwarePage/SoftwareVulnerabilities/SoftwareVulnerabilitiesTable/_styles.scss
+++ b/frontend/pages/SoftwarePage/SoftwareVulnerabilities/SoftwareVulnerabilitiesTable/_styles.scss
@@ -1,5 +1,5 @@
 .software-vulnerabilities-table {
-  &__exploited-vulnerabilities-dropdown {
+  &__exploited-vulnerabilities-filter {
     min-width: 250px;
   }
 

--- a/frontend/pages/hosts/ManageHostsPage/HostsPageConfig.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/HostsPageConfig.tsx
@@ -58,48 +58,38 @@ export const DEFAULT_SORT_DIRECTION = "asc";
 export const DEFAULT_PAGE_SIZE = 50;
 export const DEFAULT_PAGE_INDEX = 0;
 
-export const getHostSelectStatuses = (isSandboxMode = false) => {
-  return [
-    {
-      disabled: false,
-      label: "All hosts",
-      value: "",
-      helpText: "All hosts added to Fleet.",
-    },
-    {
-      disabled: false,
-      label: "Online hosts",
-      value: "online",
-      helpText: "Hosts that will respond to a live query.",
-    },
-    {
-      disabled: false,
-      label: "Offline hosts",
-      value: "offline",
-      helpText: "Hosts that won’t respond to a live query.",
-    },
-    {
-      disabled: false,
-      label: isSandboxMode ? (
-        <span>
-          <span>Missing hosts</span>
-          <Icon name="premium-feature" className="premium-feature-icon" />
-          {/* <PremiumFeatureIconWithTooltip /> */}
-        </span>
-      ) : (
-        "Missing hosts"
-      ),
-      value: "missing",
-      helpText: "Hosts that have been offline for 30 days or more.",
-    },
-    {
-      disabled: false,
-      label: "New hosts",
-      value: "new",
-      helpText: "Hosts added to Fleet in the last 24 hours.",
-    },
-  ];
-};
+export const hostSelectStatuses = [
+  {
+    disabled: false,
+    label: "All hosts",
+    value: "",
+    helpText: "All hosts added to Fleet.",
+  },
+  {
+    disabled: false,
+    label: "Online hosts",
+    value: "online",
+    helpText: "Hosts that will respond to a live query.",
+  },
+  {
+    disabled: false,
+    label: "Offline hosts",
+    value: "offline",
+    helpText: "Hosts that won’t respond to a live query.",
+  },
+  {
+    disabled: false,
+    label: "Missing hosts",
+    value: "missing",
+    helpText: "Hosts that have been offline for 30 days or more.",
+  },
+  {
+    disabled: false,
+    label: "New hosts",
+    value: "new",
+    helpText: "Hosts added to Fleet in the last 24 hours.",
+  },
+];
 
 export const OS_SETTINGS_FILTER_OPTIONS = [
   {

--- a/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
@@ -71,8 +71,9 @@ import { getNextLocationPath } from "utilities/helpers";
 
 import Button from "components/buttons/Button";
 import Icon from "components/Icon/Icon";
-// @ts-ignore
-import Dropdown from "components/forms/fields/Dropdown";
+import { SingleValue } from "react-select-5";
+import DropdownWrapper from "components/forms/fields/DropdownWrapper";
+import { CustomOptionType } from "components/forms/fields/DropdownWrapper/DropdownWrapper";
 import TableContainer from "components/TableContainer";
 import InfoBanner from "components/InfoBanner/InfoBanner";
 import { ITableQueryData } from "components/TableContainer/TableContainer";
@@ -94,7 +95,7 @@ import {
   DEFAULT_SORT_DIRECTION,
   DEFAULT_PAGE_SIZE,
   DEFAULT_PAGE_INDEX,
-  getHostSelectStatuses,
+  hostSelectStatuses,
   MANAGE_HOSTS_PAGE_FILTER_KEYS,
   MANAGE_HOSTS_PAGE_LABEL_INCOMPATIBLE_QUERY_PARAMS,
 } from "./HostsPageConfig";
@@ -721,7 +722,9 @@ const ManageHostsPage = ({
     );
   };
 
-  const handleStatusDropdownChange = (statusName: string) => {
+  const handleStatusDropdownChange = (
+    statusName: SingleValue<CustomOptionType>
+  ) => {
     handleResetPageIndex();
 
     router.replace(
@@ -731,7 +734,7 @@ const ManageHostsPage = ({
         routeParams,
         queryParams: {
           ...queryParams,
-          status: statusName,
+          status: statusName?.value,
           page: 0, // resets page index
         },
       })
@@ -1459,13 +1462,14 @@ const ManageHostsPage = ({
 
     return (
       <div className={`${baseClass}__filter-dropdowns`}>
-        <Dropdown
+        <DropdownWrapper
           value={status || ""}
           className={`${baseClass}__status_dropdown`}
-          options={getHostSelectStatuses(isSandboxMode)}
-          searchable={false}
+          name="status-dropdown"
+          options={hostSelectStatuses}
           onChange={handleStatusDropdownChange}
           iconName="filter"
+          tableFilter
         />
         <LabelFilterSelect
           className={`${baseClass}__label-filter-dropdown`}

--- a/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
@@ -1463,12 +1463,11 @@ const ManageHostsPage = ({
     return (
       <div className={`${baseClass}__filter-dropdowns`}>
         <DropdownWrapper
+          name="status-filter"
           value={status || ""}
-          className={`${baseClass}__status_dropdown`}
-          name="status-dropdown"
+          className={`${baseClass}__status-filter`}
           options={hostSelectStatuses}
           onChange={handleStatusDropdownChange}
-          iconName="filter"
           tableFilter
         />
         <LabelFilterSelect

--- a/frontend/pages/hosts/ManageHostsPage/_styles.scss
+++ b/frontend/pages/hosts/ManageHostsPage/_styles.scss
@@ -107,6 +107,7 @@
           display: flex;
           flex-direction: row;
           margin-left: $pad-medium;
+          align-items: center;
 
           // Dropdown height matches search bar height
           .manage-hosts__status_dropdown {

--- a/frontend/pages/hosts/ManageHostsPage/_styles.scss
+++ b/frontend/pages/hosts/ManageHostsPage/_styles.scss
@@ -110,7 +110,7 @@
           align-items: center;
 
           // Dropdown height matches search bar height
-          .manage-hosts__status_dropdown {
+          .manage-hosts__status-filter {
             .Select-control,
             .Select-input {
               height: 33px;
@@ -171,7 +171,7 @@
               flex: 1;
             }
 
-            .manage-hosts__status_dropdown {
+            .manage-hosts__status-filter {
               width: auto;
             }
           }
@@ -222,7 +222,7 @@
     margin: 0;
   }
 
-  &__status_dropdown {
+  &__status-filter {
     width: 175px;
 
     @media (min-width: $table-controls-break) {

--- a/frontend/pages/hosts/ManageHostsPage/_styles.scss
+++ b/frontend/pages/hosts/ManageHostsPage/_styles.scss
@@ -116,7 +116,7 @@
               height: 33px;
             }
             .Select-value {
-              line-height: 38px;
+              line-height: 40px;
             }
           }
         }

--- a/frontend/pages/hosts/ManageHostsPage/components/BootstrapPackageStatusFilter/BootstrapPackageStatusFilter.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/components/BootstrapPackageStatusFilter/BootstrapPackageStatusFilter.tsx
@@ -41,7 +41,7 @@ const BootstrapPackageStatusFilter = ({
     <div className={baseClass}>
       <Dropdown
         value={value}
-        className={`${baseClass}__status_dropdown`}
+        className={`${baseClass}__status-filter`}
         options={BOOTSTRAP_PACKAGE_STATUS}
         searchable={false}
         onChange={onChange}

--- a/frontend/pages/hosts/ManageHostsPage/components/BootstrapPackageStatusFilter/_styles.scss
+++ b/frontend/pages/hosts/ManageHostsPage/components/BootstrapPackageStatusFilter/_styles.scss
@@ -3,7 +3,7 @@
   justify-content: flex-start;
   align-items: center;
 
-  &__status_dropdown {
+  &__status-filter {
     width: 170px;
 
     .Select-menu-outer {

--- a/frontend/pages/hosts/ManageHostsPage/components/DiskEncryptionStatusFilter/DiskEncryptionStatusFilter.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/components/DiskEncryptionStatusFilter/DiskEncryptionStatusFilter.tsx
@@ -56,7 +56,7 @@ const DiskEncryptionStatusFilter = ({
     <div className={baseClass}>
       <Dropdown
         value={value}
-        className={`${baseClass}__status_dropdown`}
+        className={`${baseClass}__status-filter`}
         options={DISK_ENCRYPTION_STATUS_OPTIONS}
         searchable={false}
         onChange={onChange}

--- a/frontend/pages/hosts/ManageHostsPage/components/DiskEncryptionStatusFilter/_styles.scss
+++ b/frontend/pages/hosts/ManageHostsPage/components/DiskEncryptionStatusFilter/_styles.scss
@@ -3,7 +3,7 @@
   justify-content: flex-start;
   align-items: center;
 
-  &__status_dropdown {
+  &__status-filter {
     width: 240px;
 
     .Select-menu-outer {

--- a/frontend/pages/hosts/ManageHostsPage/components/LabelFilterSelect/_styles.scss
+++ b/frontend/pages/hosts/ManageHostsPage/components/LabelFilterSelect/_styles.scss
@@ -24,7 +24,7 @@
     border: 1px solid $ui-fleet-black-10;
     background-color: $ui-light-grey;
     border-radius: $border-radius;
-    height: 40px;
+    height: 38px;
 
     :hover {
       cursor: pointer;

--- a/frontend/pages/hosts/ManageHostsPage/components/LabelFilterSelect/_styles.scss
+++ b/frontend/pages/hosts/ManageHostsPage/components/LabelFilterSelect/_styles.scss
@@ -24,7 +24,7 @@
     border: 1px solid $ui-fleet-black-10;
     background-color: $ui-light-grey;
     border-radius: $border-radius;
-    height: 38px;
+    height: 40px;
 
     :hover {
       cursor: pointer;

--- a/frontend/pages/hosts/ManageHostsPage/components/PoliciesFilter/PoliciesFilter.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/components/PoliciesFilter/PoliciesFilter.tsx
@@ -35,7 +35,7 @@ const PoliciesFilter = ({
     <div className={baseClass}>
       <Dropdown
         value={value}
-        className={`${baseClass}__status_dropdown`}
+        className={`${baseClass}__status-filter`}
         options={POLICY_RESPONSE_OPTIONS}
         searchable={false}
         onChange={onChange}

--- a/frontend/pages/hosts/details/cards/Software/HostSoftwareTable/HostSoftwareTable.tsx
+++ b/frontend/pages/hosts/details/cards/Software/HostSoftwareTable/HostSoftwareTable.tsx
@@ -17,8 +17,9 @@ import {
 
 import TableContainer from "components/TableContainer";
 import { ITableQueryData } from "components/TableContainer/TableContainer";
-// @ts-ignore
-import Dropdown from "components/forms/fields/Dropdown";
+import { SingleValue } from "react-select-5";
+import DropdownWrapper from "components/forms/fields/DropdownWrapper";
+import { CustomOptionType } from "components/forms/fields/DropdownWrapper/DropdownWrapper";
 
 import EmptySoftwareTable from "pages/SoftwarePage/components/EmptySoftwareTable";
 import TableCount from "components/TableContainer/TableCount";
@@ -30,7 +31,7 @@ const DEFAULT_PAGE_SIZE = 20;
 
 const baseClass = "host-software-table";
 
-export const DROPDOWN_OPTIONS = [
+const DROPDOWN_OPTIONS = [
   {
     disabled: false,
     label: "All software",
@@ -50,7 +51,7 @@ export const DROPDOWN_OPTIONS = [
     value: "installableSoftware",
     helpText: "Software that can be installed on your hosts.",
   },
-] as const;
+];
 
 interface IHostSoftwareRowProps extends Row {
   original: IHostSoftware;
@@ -91,7 +92,7 @@ const HostSoftwareTable = ({
   onShowSoftwareDetails,
 }: IHostSoftwareTableProps) => {
   const handleFilterDropdownChange = useCallback(
-    (val: IHostSoftwareDropdownFilterVal) => {
+    (selectedFilter: SingleValue<CustomOptionType>) => {
       const newParams: QueryParams = {
         query: searchQuery,
         order_key: sortHeader,
@@ -100,9 +101,9 @@ const HostSoftwareTable = ({
       };
 
       // mutually exclusive
-      if (val === "installableSoftware") {
+      if (selectedFilter?.value === "installableSoftware") {
         newParams.available_for_install = true.toString();
-      } else if (val === "vulnerableSoftware") {
+      } else if (selectedFilter?.value === "vulnerableSoftware") {
         newParams.vulnerable = true.toString();
       }
 
@@ -125,12 +126,13 @@ const HostSoftwareTable = ({
 
   const memoizedFilterDropdown = useCallback(() => {
     return (
-      <Dropdown
+      <DropdownWrapper
+        name="host-software-filter"
         value={hostSoftwareFilter}
+        className={`${baseClass}__software-filter`}
         options={DROPDOWN_OPTIONS}
-        searchable={false}
         onChange={handleFilterDropdownChange}
-        iconName="filter"
+        tableFilter
       />
     );
   }, [handleFilterDropdownChange, hostSoftwareFilter]);

--- a/frontend/pages/hosts/details/cards/Software/_styles.scss
+++ b/frontend/pages/hosts/details/cards/Software/_styles.scss
@@ -4,26 +4,8 @@
   }
 
   .host-software-table {
-    .controls {
-      // software filter
-      .Select {
-        .Select-menu-outer {
-          width: 364px;
-          max-height: min-content;
-
-          .Select-menu {
-            max-height: none;
-          }
-        }
-        .Select-value {
-          padding-left: $pad-medium;
-          padding-right: $pad-medium;
-        }
-
-        .dropdown__custom-value-label {
-          width: 155px; // Override 105px for longer text options
-        }
-      }
+    &__software-filter {
+      min-width: 235px;
     }
 
     .data-table-block {

--- a/frontend/pages/queries/ManageQueriesPage/_styles.scss
+++ b/frontend/pages/queries/ManageQueriesPage/_styles.scss
@@ -50,13 +50,6 @@
   }
 
   .queries-table {
-    .controls {
-      .form-field {
-        &--dropdown {
-          margin: 0;
-        }
-      }
-    }
     &__platform-dropdown {
       width: 200px;
     }

--- a/frontend/pages/queries/ManageQueriesPage/_styles.scss
+++ b/frontend/pages/queries/ManageQueriesPage/_styles.scss
@@ -58,31 +58,7 @@
       }
     }
     &__platform-dropdown {
-      .Select-menu-outer {
-        width: 364px;
-        max-height: min-content;
-
-        .Select-menu {
-          max-height: none;
-        }
-      }
-      .Select-value {
-        padding-left: $pad-medium;
-        padding-right: $pad-medium;
-
-        &::before {
-          display: inline-block;
-          position: absolute;
-          padding: 5px 0 0 0; // centers spin
-          content: url(../assets/images/icon-filter-black-16x16@2x.png);
-          transform: scale(0.5);
-          height: 26px;
-          left: 2px;
-        }
-      }
-      .Select-value-label {
-        padding-left: $pad-medium;
-      }
+      width: 200px;
     }
 
     .data-table-block {

--- a/frontend/pages/queries/ManageQueriesPage/components/QueriesTable/QueriesTable.tsx
+++ b/frontend/pages/queries/ManageQueriesPage/components/QueriesTable/QueriesTable.tsx
@@ -9,7 +9,6 @@ import { IEnhancedQuery } from "interfaces/schedulable_query";
 import { ITableQueryData } from "components/TableContainer/TableContainer";
 import PATHS from "router/paths";
 import { getNextLocationPath } from "utilities/helpers";
-import { QueryValues } from "utilities/url";
 
 import { SingleValue } from "react-select-5";
 import DropdownWrapper from "components/forms/fields/DropdownWrapper";
@@ -233,7 +232,6 @@ const QueriesTable = ({
         name="platform-dropdown"
         options={PLATFORM_FILTER_OPTIONS}
         onChange={handlePlatformFilterDropdownChange}
-        iconName="filter"
         tableFilter
       />
     );

--- a/frontend/pages/queries/ManageQueriesPage/components/QueriesTable/QueriesTable.tsx
+++ b/frontend/pages/queries/ManageQueriesPage/components/QueriesTable/QueriesTable.tsx
@@ -9,13 +9,16 @@ import { IEnhancedQuery } from "interfaces/schedulable_query";
 import { ITableQueryData } from "components/TableContainer/TableContainer";
 import PATHS from "router/paths";
 import { getNextLocationPath } from "utilities/helpers";
+import { QueryValues } from "utilities/url";
+
+import { SingleValue } from "react-select-5";
+import DropdownWrapper from "components/forms/fields/DropdownWrapper";
+import { CustomOptionType } from "components/forms/fields/DropdownWrapper/DropdownWrapper";
 import Button from "components/buttons/Button";
 import TableContainer from "components/TableContainer";
 import TableCount from "components/TableContainer/TableCount";
 import CustomLink from "components/CustomLink";
 import EmptyTable from "components/EmptyTable";
-// @ts-ignore
-import Dropdown from "components/forms/fields/Dropdown";
 
 import generateColumnConfigs from "./QueriesTableConfig";
 
@@ -202,7 +205,7 @@ const QueriesTable = ({
   ]);
 
   const handlePlatformFilterDropdownChange = useCallback(
-    (selectedTargetedPlatform: string) => {
+    (selectedTargetedPlatform: SingleValue<CustomOptionType>) => {
       router?.push(
         getNextLocationPath({
           pathPrefix: PATHS.MANAGE_QUERIES,
@@ -212,9 +215,9 @@ const QueriesTable = ({
             platform:
               // separate URL & API 0-values of `platform` (undefined) from dropdown
               // 0-value of "all"
-              selectedTargetedPlatform === "all"
+              selectedTargetedPlatform?.value === "all"
                 ? undefined
-                : selectedTargetedPlatform,
+                : selectedTargetedPlatform?.value,
           },
         })
       );
@@ -224,13 +227,14 @@ const QueriesTable = ({
 
   const renderPlatformDropdown = useCallback(() => {
     return (
-      <Dropdown
+      <DropdownWrapper
         value={curTargetedPlatformFilter}
         className={`${baseClass}__platform-dropdown`}
+        name="platform-dropdown"
         options={PLATFORM_FILTER_OPTIONS}
-        searchable={false}
         onChange={handlePlatformFilterDropdownChange}
         iconName="filter"
+        tableFilter
       />
     );
   }, [curTargetedPlatformFilter, queryParams, router]);


### PR DESCRIPTION
## Issue
For #25369


## Description
- Fixes table dropdowns and headers to be consistently 40px tall
- Fix widths of 3 dropdown options that were much wider than the dropdown and 1 width that was smaller than dropdown
- Add filter icon to queries dropdown (only table dropdown that didn't have an icon)
- Convert all table dropdowns from react-select 1.3.0 to react-select 5.4.0

## Screenshots of fixes

<img width="984" alt="Screenshot 2025-01-14 at 8 25 42 AM" src="https://github.com/user-attachments/assets/5c3cbc68-3e4b-440a-b355-c89b847b3968" />
<img width="1113" alt="Screenshot 2025-01-13 at 12 44 45 PM" src="https://github.com/user-attachments/assets/91c888a2-14ae-46b5-a00a-f9cf10ecef4b" />
<img width="422" alt="Screenshot 2025-01-13 at 12 44 27 PM" src="https://github.com/user-attachments/assets/7a48a3d7-f750-43d9-a56a-127cae313d82" />
<img width="931" alt="Screenshot 2025-01-14 at 8 11 55 AM" src="https://github.com/user-attachments/assets/8e66b637-9dd2-47d8-88aa-69a23c8e6776" />
<img width="1165" alt="Screenshot 2025-01-14 at 7 38 27 AM" src="https://github.com/user-attachments/assets/2b786ab3-5b1f-40da-b488-9b89200daa53" />



# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Manual QA for all new/changed functionality
