### PR TITLE
Try unmarshalling query pack logs only once

### DIFF
--- a/server/fleet/service.go
+++ b/server/fleet/service.go
@@ -65,7 +65,7 @@ type OsqueryService interface {
 		stats map[string]*Stats,
 	) (err error)
 	SubmitStatusLogs(ctx context.Context, logs []json.RawMessage) (err error)
-	SubmitResultLogs(ctx context.Context, logs []json.RawMessage) (err error)
+	SubmitResultLogs(ctx context.Context, logs []*ScheduledQueryResult) (err error)
 	YaraRuleByName(ctx context.Context, name string) (*YaraRule, error)
 }
 

--- a/server/launcher/launcher.go
+++ b/server/launcher/launcher.go
@@ -103,9 +103,14 @@ func (svc *launcherWrapper) PublishLogs(ctx context.Context, nodeKey string, log
 		err = svc.tls.SubmitStatusLogs(newCtx, statuses)
 		return "", "", false, ctxerr.Wrap(ctx, err, "submit status logs from launcher")
 	case logger.LogTypeSnapshot, logger.LogTypeString:
-		var results []json.RawMessage
+		var results []*fleet.ScheduledQueryResult
 		for _, log := range logs {
-			results = append(results, []byte(log))
+			var result *fleet.ScheduledQueryResult
+			err := json.Unmarshal([]byte(log), result)
+			if err != nil {
+				return "", "", false, err
+			}
+			results = append(results, result)
 		}
 		err = svc.tls.SubmitResultLogs(newCtx, results)
 		return "", "", false, ctxerr.Wrap(ctx, err, "submit result logs from launcher")

--- a/server/mock/datastore_mock.go
+++ b/server/mock/datastore_mock.go
@@ -49,8 +49,6 @@ type UserByEmailFunc func(ctx context.Context, email string) (*fleet.User, error
 
 type UserByIDFunc func(ctx context.Context, id uint) (*fleet.User, error)
 
-type UserSettingsFunc func(ctx context.Context, userID uint) (*fleet.UserSettings, error)
-
 type SaveUserFunc func(ctx context.Context, user *fleet.User) error
 
 type SaveUsersFunc func(ctx context.Context, users []*fleet.User) error
@@ -60,6 +58,8 @@ type DeleteUserFunc func(ctx context.Context, id uint) error
 type PendingEmailChangeFunc func(ctx context.Context, userID uint, newEmail string, token string) error
 
 type ConfirmPendingEmailChangeFunc func(ctx context.Context, userID uint, token string) (string, error)
+
+type UserSettingsFunc func(ctx context.Context, userID uint) (*fleet.UserSettings, error)
 
 type ApplyQueriesFunc func(ctx context.Context, authorID uint, queries []*fleet.Query, queriesToDiscardResults map[uint]struct{}) error
 
@@ -1238,9 +1238,6 @@ type DataStore struct {
 	UserByIDFunc        UserByIDFunc
 	UserByIDFuncInvoked bool
 
-	UserSettingsFunc				UserSettingsFunc
-	UserSettingsFuncInvoked bool
-
 	SaveUserFunc        SaveUserFunc
 	SaveUserFuncInvoked bool
 
@@ -1255,6 +1252,9 @@ type DataStore struct {
 
 	ConfirmPendingEmailChangeFunc        ConfirmPendingEmailChangeFunc
 	ConfirmPendingEmailChangeFuncInvoked bool
+
+	UserSettingsFunc        UserSettingsFunc
+	UserSettingsFuncInvoked bool
 
 	ApplyQueriesFunc        ApplyQueriesFunc
 	ApplyQueriesFuncInvoked bool
@@ -3058,13 +3058,6 @@ func (s *DataStore) UserByID(ctx context.Context, id uint) (*fleet.User, error) 
 	return s.UserByIDFunc(ctx, id)
 }
 
-func (s *DataStore) UserSettings(ctx context.Context, userID uint) (*fleet.UserSettings, error) {
-	s.mu.Lock()
-	s.UserSettingsFuncInvoked = true
-	s.mu.Unlock()
-	return s.UserSettingsFunc(ctx, userID)
-}
-
 func (s *DataStore) SaveUser(ctx context.Context, user *fleet.User) error {
 	s.mu.Lock()
 	s.SaveUserFuncInvoked = true
@@ -3098,6 +3091,13 @@ func (s *DataStore) ConfirmPendingEmailChange(ctx context.Context, userID uint, 
 	s.ConfirmPendingEmailChangeFuncInvoked = true
 	s.mu.Unlock()
 	return s.ConfirmPendingEmailChangeFunc(ctx, userID, token)
+}
+
+func (s *DataStore) UserSettings(ctx context.Context, userID uint) (*fleet.UserSettings, error) {
+	s.mu.Lock()
+	s.UserSettingsFuncInvoked = true
+	s.mu.Unlock()
+	return s.UserSettingsFunc(ctx, userID)
 }
 
 func (s *DataStore) ApplyQueries(ctx context.Context, authorID uint, queries []*fleet.Query, queriesToDiscardResults map[uint]struct{}) error {

--- a/server/mock/mdm/bootstrap_package_store.go
+++ b/server/mock/mdm/bootstrap_package_store.go
@@ -42,37 +42,37 @@ type MDMBootstrapPackageStore struct {
 	mu sync.Mutex
 }
 
-func (fs *MDMBootstrapPackageStore) Get(ctx context.Context, packageID string) (io.ReadCloser, int64, error) {
-	fs.mu.Lock()
-	fs.GetFuncInvoked = true
-	fs.mu.Unlock()
-	return fs.GetFunc(ctx, packageID)
+func (s *MDMBootstrapPackageStore) Get(ctx context.Context, packageID string) (io.ReadCloser, int64, error) {
+	s.mu.Lock()
+	s.GetFuncInvoked = true
+	s.mu.Unlock()
+	return s.GetFunc(ctx, packageID)
 }
 
-func (fs *MDMBootstrapPackageStore) Put(ctx context.Context, packageID string, content io.ReadSeeker) error {
-	fs.mu.Lock()
-	fs.PutFuncInvoked = true
-	fs.mu.Unlock()
-	return fs.PutFunc(ctx, packageID, content)
+func (s *MDMBootstrapPackageStore) Put(ctx context.Context, packageID string, content io.ReadSeeker) error {
+	s.mu.Lock()
+	s.PutFuncInvoked = true
+	s.mu.Unlock()
+	return s.PutFunc(ctx, packageID, content)
 }
 
-func (fs *MDMBootstrapPackageStore) Exists(ctx context.Context, packageID string) (bool, error) {
-	fs.mu.Lock()
-	fs.ExistsFuncInvoked = true
-	fs.mu.Unlock()
-	return fs.ExistsFunc(ctx, packageID)
+func (s *MDMBootstrapPackageStore) Exists(ctx context.Context, packageID string) (bool, error) {
+	s.mu.Lock()
+	s.ExistsFuncInvoked = true
+	s.mu.Unlock()
+	return s.ExistsFunc(ctx, packageID)
 }
 
-func (fs *MDMBootstrapPackageStore) Cleanup(ctx context.Context, usedPackageIDs []string, removeCreatedBefore time.Time) (int, error) {
-	fs.mu.Lock()
-	fs.CleanupFuncInvoked = true
-	fs.mu.Unlock()
-	return fs.CleanupFunc(ctx, usedPackageIDs, removeCreatedBefore)
+func (s *MDMBootstrapPackageStore) Cleanup(ctx context.Context, usedPackageIDs []string, removeCreatedBefore time.Time) (int, error) {
+	s.mu.Lock()
+	s.CleanupFuncInvoked = true
+	s.mu.Unlock()
+	return s.CleanupFunc(ctx, usedPackageIDs, removeCreatedBefore)
 }
 
-func (fs *MDMBootstrapPackageStore) Sign(ctx context.Context, fileID string) (string, error) {
-	fs.mu.Lock()
-	fs.SignFuncInvoked = true
-	fs.mu.Unlock()
-	return fs.SignFunc(ctx, fileID)
+func (s *MDMBootstrapPackageStore) Sign(ctx context.Context, fileID string) (string, error) {
+	s.mu.Lock()
+	s.SignFuncInvoked = true
+	s.mu.Unlock()
+	return s.SignFunc(ctx, fileID)
 }

--- a/server/service/mock/service_osquery.go
+++ b/server/service/mock/service_osquery.go
@@ -24,7 +24,7 @@ type SubmitDistributedQueryResultsFunc func(ctx context.Context, results fleet.O
 
 type SubmitStatusLogsFunc func(ctx context.Context, logs []json.RawMessage) (err error)
 
-type SubmitResultLogsFunc func(ctx context.Context, logs []json.RawMessage) (err error)
+type SubmitResultLogsFunc func(ctx context.Context, logs []*fleet.ScheduledQueryResult) (err error)
 
 type YaraRuleByNameFunc func(ctx context.Context, name string) (*fleet.YaraRule, error)
 
@@ -98,7 +98,7 @@ func (s *TLSService) SubmitStatusLogs(ctx context.Context, logs []json.RawMessag
 	return s.SubmitStatusLogsFunc(ctx, logs)
 }
 
-func (s *TLSService) SubmitResultLogs(ctx context.Context, logs []json.RawMessage) (err error) {
+func (s *TLSService) SubmitResultLogs(ctx context.Context, logs []*fleet.ScheduledQueryResult) (err error) {
 	s.mu.Lock()
 	s.SubmitResultLogsFuncInvoked = true
 	s.mu.Unlock()


### PR DESCRIPTION
# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [ ] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/Committing-Changes.md#changes-files) for more information.
- [ ] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [ ] Added support on fleet's osquery simulator `cmd/osquery-perf` for new osquery data ingestion features.
- [ ] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes
- [ ] If database migrations are included, checked table schema to confirm autoupdate
- For database migrations:
  - [ ] Checked schema for all modified table for columns that will auto-update timestamps during migration.
  - [ ] Confirmed that updating the timestamps is acceptable, and will not cause unwanted side effects.
  - [ ] Ensured the correct collation is explicitly set for character columns (`COLLATE utf8mb4_unicode_ci`).
- [ ] Added/updated automated tests
- [ ] A detailed QA plan exists on the associated ticket (if it isn't there, work with the product group's QA engineer to add it)
- [ ] Manual QA for all new/changed functionality
- For Orbit and Fleet Desktop changes:
   - [ ] Orbit runs on macOS, Linux and Windows. Check if the orbit feature/bugfix should only apply to one platform (`runtime.GOOS`).
   - [ ] Manual QA must be performed in the three main OSs, macOS, Windows and Linux.
   - [ ] Auto-update manual QA, from released version of component to new version (see [tools/tuf/test](../tools/tuf/test/README.md)).
