### PR TITLE
fix: properly indent service annotations

### DIFF
--- a/charts/fleet/templates/service.yaml
+++ b/charts/fleet/templates/service.yaml
@@ -10,7 +10,7 @@ metadata:
 {{- if .Values.serviceAnnotations }}
   annotations:
   {{- with .Values.serviceAnnotations}}
-  {{ toYaml . | trim | indent 2}}
+  {{- toYaml . | trim | nindent 4}}
   {{- end }}
 {{- end }}
   name: {{ $serviceName }}


### PR DESCRIPTION
When then was more than 1 annotation on the service, it would not be properly indented.

```
$ cat test-values.yaml 
serviceAnnotations:
  foo: bar
  bar: baz
  baz: qux
$ helm template fleet . -f test-values.yaml --show-only templates/service.yaml
---
# Source: fleet/templates/service.yaml
apiVersion: v1
kind: Service
metadata:
  labels:
    app: fleet
    chart: fleet
    heritage: Helm
    release: fleet
  annotations:
    bar: baz
    baz: qux
    foo: bar
  name: fleet-service
  namespace: fleet
spec:
  selector:
    app: fleet
    chart: fleet
    heritage: Helm
    release: fleet
  ports:
  - name: fleet
    port: 8080
    targetPort: 8080
```

before:

```
$ git checkout main
$ helm template fleet . -f test-values.yaml --show-only templates/service.yaml
---
# Source: fleet/templates/service.yaml
apiVersion: v1
kind: Service
metadata:
  labels:
    app: fleet
    chart: fleet
    heritage: Helm
    release: fleet
  annotations:
    bar: baz
  baz: qux
  foo: bar
  name: fleet-service
  namespace: fleet
spec:
  selector:
    app: fleet
    chart: fleet
    heritage: Helm
    release: fleet
  ports:
  - name: fleet
    port: 8080
    targetPort: 8080