### PR TITLE
[YAML design] Policy automations: install App Store apps on macOS

### DIFF
--- a/docs/Configuration/yaml-files.md
+++ b/docs/Configuration/yaml-files.md
@@ -76,7 +76,8 @@ policies:
   resolution: "Install Logic Pro App Store app if not installed"
   query: "SELECT 1 FROM apps WHERE name = 'Logic Pro'"
   install_software:
-    app_store_app_id: "1487937127"
+    package_path: ../lib/linux-firefox.deb.package.yml
+    # app_store_id: "1487937127" (for App Store apps)
 ```
 
 `default.yml` (for policies that neither install software nor run scripts), `teams/team-name.yml`, or `teams/no-team.yml`


### PR DESCRIPTION
Follow up to the [original YAML design](https://github.com/fleetdm/fleet/pull/24585) for the following user story:
- https://github.com/fleetdm/fleet/issues/23115

Changes:
- Use `app_store_id` to be consistent with existing YAML: https://fleetdm.com/docs/configuration/yaml-files#example5
- Make `app_store_id` an example to show both custom package and App Store app example

More context in Slack [here](https://fleetdm.slack.com/archives/C02A8BRABB5/p1736802131152929).
