### PR TITLE
Update missing old URL

### DIFF
--- a/orbit/cmd/orbit/orbit.go
+++ b/orbit/cmd/orbit/orbit.go
@@ -103,7 +103,7 @@ func main() {
 		&cli.StringFlag{
 			Name:    "update-url",
 			Usage:   "URL for update server",
-			Value:   "https://tuf.fleetctl.com",
+			Value:   update.DefaultURL,
 			EnvVars: []string{"ORBIT_UPDATE_URL"},
 		},
 		&cli.StringFlag{


### PR DESCRIPTION
Changing this to reduce confusion moving forward. It didn't cause any issues because fleetd package always passes this flag to the configured URL (so the default value is never used when running orbit in fleetd).

"tuf.fleetctl.com" in tooling will be modified (copied) soon.