### PR TITLE
Don't expire iOS devices prematurely

### DIFF
--- a/changes/25406-premature-ios-deletion
+++ b/changes/25406-premature-ios-deletion
@@ -1,1 +1,1 @@
-- Fix bug where iOS devices were being removed prematurely by expiration policy
+- Fixed bug where iOS devices were being removed prematurely by expiration policy

--- a/changes/25406-premature-ios-deletion
+++ b/changes/25406-premature-ios-deletion
@@ -1,0 +1,1 @@
+- Fix bug where iOS devices were being removed prematurely by expiration policy

--- a/server/datastore/mysql/hosts.go
+++ b/server/datastore/mysql/hosts.go
@@ -3119,7 +3119,11 @@ func (ds *Datastore) CleanupExpiredHosts(ctx context.Context) ([]uint, error) {
 	// DELETE FROM hosts WHERE id in (SELECT host_id FROM host_seen_times WHERE seen_time < DATE_SUB(NOW(), INTERVAL ? DAY))
 	// This means a full table scan for hosts, and for big deployments, that's not ideal
 	// so instead, we get the ids one by one and delete things one by one
-	// it might take longer, but it should lock only the row we need
+	// it might take longer, but it should lock only the row we need.
+	//
+	// host_seen_time entries are not available for ios/ipados devices, since they're updated on
+	// osquery check-in. Instead we fall back to detail_updated_at, which is updated every time a
+	// full detail refetch happens.
 	findHostsSql := `SELECT h.id FROM hosts h
 		LEFT JOIN host_seen_times hst
 		ON h.id = hst.host_id

--- a/server/datastore/mysql/hosts.go
+++ b/server/datastore/mysql/hosts.go
@@ -3123,7 +3123,7 @@ func (ds *Datastore) CleanupExpiredHosts(ctx context.Context) ([]uint, error) {
 	findHostsSql := `SELECT h.id FROM hosts h
 		LEFT JOIN host_seen_times hst
 		ON h.id = hst.host_id
-		WHERE COALESCE(hst.seen_time, h.created_at) < DATE_SUB(NOW(), INTERVAL ? DAY)`
+		WHERE COALESCE(hst.seen_time, h.detail_updated_at, h.created_at) < DATE_SUB(NOW(), INTERVAL ? DAY)`
 
 	var allIdsToDelete []uint
 	// Process hosts using global expiry


### PR DESCRIPTION
#25406 

The `last_seen_times` table is only updates when osquery hits one of its authenticated endpoints, meaning it isn't updated when devices without osquery, like iphones, are enrolled. I've left a [comment](https://github.com/fleetdm/fleet/issues/25406#issuecomment-2590637318) on the original issue explaining how this happens. Originally, if there was no `last_seen_time`, the fallback value would be the `created_at` value on the `hosts` table, so ios devices would always get deleted once they were added X number of days ago.

In its place, I've added the `detail_updated_at` column on the `hosts` table as the fallback value, and only use `created_at` if that is also empty. `detail_updated_at` is updated every time a full detail refetch completes. In the case of ios/ipados, [this is done using MDM](https://github.com/fleetdm/fleet/blob/cd5c0e8aed10664458f597b5d9600dd20bf3fdac/server/service/apple_mdm.go#L3101). `detail_updated_at` is updated less frequently than `last_seen_times`, only once every hour or so instead of every 30 seconds, but since expiration policies are set on the scale of days instead of hours, this should be fine.

The way I've QA'd this is by adding an iOS device to my fleet instance, waited 24 hours, and set the expiration policy to 24 hours.

Big thanks to @gillespi314 for helping me navigate the MDM internals!

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/Committing-Changes.md#changes-files) for more information.
- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [x] Added/updated automated tests
- [x] A detailed QA plan exists on the associated ticket (if it isn't there, work with the product group's QA engineer to add it)
- [x] Manual QA for all new/changed functionality