### PR TITLE
It may take up to 2 hours to get Apple encryption keys.

### DIFF
--- a/articles/enforce-disk-encryption.md
+++ b/articles/enforce-disk-encryption.md
@@ -34,7 +34,7 @@ In the Fleet UI, head to the **Controls > OS settings > Disk encryption** tab. Y
 
 * Verifying: the host acknowledged the MDM command to install the disk encryption profile. Fleet is verifying with osquery and retrieving the disk encryption key.
 
-> It may take up to one hour for Fleet to collect and store the disk encryption keys from all hosts.
+> It may take up to two hours for Fleet to collect and store the disk encryption keys from all hosts.
 
 * Action required (pending): the end user must take action to turn disk encryption on or reset their disk encryption key. 
 


### PR DESCRIPTION
It may take up to 2 hours to get Apple encryption keys.
- 1 hour for detailed query
- 1 hour for cleanups_then_aggregation.verify_disk_encryption_keys job