### PR TITLE
Website: update query generator to use socket requests.

### DIFF
--- a/website/config/routes.js
+++ b/website/config/routes.js
@@ -914,5 +914,5 @@ module.exports.routes = {
   'POST /api/v1/deliver-deal-registration-submission': { action: 'deliver-deal-registration-submission' },
   '/api/v1/unsubscribe-from-marketing-emails': { action: 'unsubscribe-from-marketing-emails' },
   'POST /api/v1/customers/get-stripe-checkout-session-url': { action: 'customers/get-stripe-checkout-session-url' },
-  'POST /api/v1/query-generator/get-llm-generated-sql': { action: 'query-generator/get-llm-generated-sql' },
+  '/api/v1/query-generator/get-llm-generated-sql': { action: 'query-generator/get-llm-generated-sql' },
 };

--- a/website/views/pages/admin/query-generator.ejs
+++ b/website/views/pages/admin/query-generator.ejs
@@ -2,10 +2,10 @@
   <div purpose="page-container">
     <div purpose="page-content">
 
-      <ajax-form :handle-submitting="handleSubmittingForm" :syncing.sync="syncing" :cloud-error.sync="cloudError" :form-errors.sync="formErrors" :form-data="formData" :form-rules="formRules" @submitted="submittedQueryForm()" v-if="!showGeneratedQuery">
+      <ajax-form :handle-submitting="handleSubmittingForm" :cloud-error.sync="cloudError" :form-errors.sync="formErrors" :form-data="formData" :form-rules="formRules" v-if="!showGeneratedQuery">
         <h3 class="mb-4">Query generator</h3>
         <div class="form-group">
-          <label for="email-address">Ask a question</label>
+          <label for="email-address">Ask a question about your devices to generate queries</label>
           <textarea class="form-control" type="textarea" id="email-address"  :class="[formErrors.naturalLanguageQuestion ? 'is-invalid' : '']" v-model.trim="formData.naturalLanguageQuestion"></textarea>
           <div class="invalid-feedback" v-if="formErrors.naturalLanguageQuestion" focus-first>Ask your question.</div>
         </div>


### PR DESCRIPTION
Closes: #25465 

Changes:
- Updated the query generator page to use socket requests to call the `get-llm-generated-sql` action to bypass Heroku's 30-second request timeout. 