### PR TITLE
Update enroll hosts docu to include arm64 support

### DIFF
--- a/articles/enroll-hosts.md
+++ b/articles/enroll-hosts.md
@@ -27,6 +27,8 @@ The `--type` flag is used to specify the fleetd installer type.
 
 A `--fleet-url` (Fleet instance URL) and `--enroll-secret` (Fleet enrollment secret) must be specified in order to communicate with Fleet instance.
 
+To build an installer for ARM-based Linux, use the `--arch=arm64` flag with fleetctl.
+
 #### Example
 
 Generate fleetd on macOS (.pkg)


### PR DESCRIPTION
Add a blurb to host enroll docu to highlight using the arch=arm64 flag on Linux builds.