### PR TITLE
Fleet UI: Platform of policy mismatch current selected software unrelease bug fix

### DIFF
--- a/frontend/pages/policies/ManagePoliciesPage/components/InstallSoftwareModal/InstallSoftwareModal.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/components/InstallSoftwareModal/InstallSoftwareModal.tsx
@@ -66,6 +66,26 @@ interface IInstallSoftwareModal {
   teamId: number;
 }
 
+const generateSoftwareOptionHelpText = (title: IEnhancedSoftwareTitle) => {
+  const vppOption = title.source === "apps" && !!title.app_store_app;
+  let platformString = "";
+  let versionString = "";
+
+  if (vppOption) {
+    platformString = "macOS (App Store) • ";
+    versionString = title.app_store_app?.version || "";
+  } else {
+    if (title.platform && title.extension) {
+      platformString = `${PLATFORM_DISPLAY_NAMES[title.platform]} (.${
+        title.extension
+      }) • `;
+    }
+    versionString = title.software_package?.version || "";
+  }
+
+  return `${platformString}${versionString}`;
+};
+
 const InstallSoftwareModal = ({
   onExit,
   onSubmit,
@@ -174,28 +194,10 @@ const InstallSoftwareModal = ({
           (title) => title.platform && policyPlatforms.includes(title.platform)
         )
         .map((title) => {
-          const vppOption = title.source === "apps" && !!title.app_store_app;
-          const platformString = () => {
-            if (vppOption) {
-              return "macOS (App Store) • ";
-            }
-
-            return title.extension
-              ? `${
-                  title.platform && PLATFORM_DISPLAY_NAMES[title.platform]
-                } (.${title.extension}) • `
-              : "";
-          };
-          const versionString = () => {
-            return vppOption
-              ? title.app_store_app?.version
-              : title.software_package?.version ?? "";
-          };
-
           return {
             label: title.name,
             value: title.id,
-            helpText: `${platformString()}${versionString()}`,
+            helpText: generateSoftwareOptionHelpText(title),
           };
         });
     },
@@ -229,11 +231,7 @@ const InstallSoftwareModal = ({
               {
                 label: currentSoftware.name,
                 value: currentSoftware.id,
-                helpText: `${
-                  currentSoftware.platform
-                    ? PLATFORM_DISPLAY_NAMES[currentSoftware.platform]
-                    : ""
-                } • ${currentSoftware.software_package?.version || ""}`,
+                helpText: generateSoftwareOptionHelpText(currentSoftware),
               },
               ...options,
             ];


### PR DESCRIPTION
## Issue
For #25480 

## Description
- The cache key is now more unique, combining policy.platform with policy.swIdToInstall when there's a platform mismatch.
- If there's a mismatch, it adds the currently selected software to the options list, even if it doesn't match the current platform filter.

## Screenshots of mismatch of selected platform for policy and sw set to install
(shows the selected sw to install on the top of the dropdown even though it doesn't match selected platform)
<img width="1390" alt="Screenshot 2025-01-15 at 5 03 07 PM" src="https://github.com/user-attachments/assets/1678b865-8c27-4132-a8f4-d78f74e4fbca" />
<img width="1348" alt="Screenshot 2025-01-15 at 5 03 01 PM" src="https://github.com/user-attachments/assets/fb79c81a-9554-4335-9779-9c4c267c891c" />


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->
- [x] Manual QA for all new/changed functionality

