### PR TITLE
bump action/cache to version 4.2.0

### DIFF
--- a/.github/workflows/build-binaries.yaml
+++ b/.github/workflows/build-binaries.yaml
@@ -44,7 +44,7 @@ jobs:
 
       - name: JS Dependency Cache
         id: js-cache
-        uses: actions/cache@69d9d449aced6a2ede0bc19182fadc3a0a42d2b0 # v2
+        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         with:
           path: |
             **/node_modules
@@ -56,7 +56,7 @@ jobs:
 
       - name: Go Cache
         id: go-cache
-        uses: actions/cache@69d9d449aced6a2ede0bc19182fadc3a0a42d2b0 # v2
+        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         with:
           # In order:
           # * Module download cache

--- a/.github/workflows/test-fleetd-chrome.yml
+++ b/.github/workflows/test-fleetd-chrome.yml
@@ -41,7 +41,7 @@ jobs:
 
       - name: JS Dependency Cache
         id: js-cache
-        uses: actions/cache@69d9d449aced6a2ede0bc19182fadc3a0a42d2b0 # v2
+        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         with:
           path: |
             **/node_modules

--- a/.github/workflows/test-js.yml
+++ b/.github/workflows/test-js.yml
@@ -52,7 +52,7 @@ jobs:
 
       - name: JS Dependency Cache
         id: js-cache
-        uses: actions/cache@69d9d449aced6a2ede0bc19182fadc3a0a42d2b0 # v2
+        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         with:
           path: |
             **/node_modules
@@ -97,7 +97,7 @@ jobs:
 
       - name: JS Dependency Cache
         id: js-cache
-        uses: actions/cache@69d9d449aced6a2ede0bc19182fadc3a0a42d2b0 # v2
+        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         with:
           path: |
             **/node_modules

--- a/changes/issue-25507-upgrade-github-cache-action
+++ b/changes/issue-25507-upgrade-github-cache-action
@@ -1,0 +1,1 @@
+- bump github cache action to 4.2.0


### PR DESCRIPTION
For #25507

A bump to the latest version to the github `cache` action to 4.2.0. our current version (v2) was deprecated. more info for the deprecation can be found here https://github.com/actions/cache/discussions/1510

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
