### PR TITLE
Update story issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/story.md
+++ b/.github/ISSUE_TEMPLATE/story.md
@@ -2,7 +2,7 @@
 name: 🎟  Story
 about: Specify an iterative change to the Fleet product.  (e.g. "As a user, I want to sign in with SSO.")
 title: ''
-labels: 'story,:product'
+labels: 'story'
 assignees: ''
 
 ---


### PR DESCRIPTION
User stories that are yet to be prioritized are clogging up the "New requests" column on the drafting board. Only new feature requests should show up in this column
