### PR TITLE
Fixes issue verifying Windows CSP profiles that contain ADMX policies.

### DIFF
--- a/changes/24790-admx-policies
+++ b/changes/24790-admx-policies
@@ -1,0 +1,1 @@
+Fixes issue verifying Windows CSP profiles that contain ADMX policies.

--- a/server/mdm/microsoft/admx/admx.go
+++ b/server/mdm/microsoft/admx/admx.go
@@ -15,12 +15,9 @@ package admx
 import (
 	"encoding/xml"
 	"fmt"
-	"regexp"
 	"slices"
 	"strings"
 )
-
-var cdataRegexp = regexp.MustCompile(`(?s)<!\[CDATA\[(.*?)]]>`)
 
 func IsADMX(text string) bool {
 	// We try to unmarshal the string to see if it looks like a valid ADMX policy

--- a/server/mdm/microsoft/admx/admx.go
+++ b/server/mdm/microsoft/admx/admx.go
@@ -1,0 +1,123 @@
+// Package admx handles ADMX (Administrative Template File) policies for Microsoft MDM server.
+// See: https://learn.microsoft.com/en-us/windows/client-management/understanding-admx-backed-policies
+//
+// ADMX policy payload example:
+// <![CDATA[
+//
+//	<enabled/>
+//	<data id="Publishing_Server2_Name_Prompt" value="Name"/>
+//	<data id="Publishing_Server_URL_Prompt" value="http://someuri"/>
+//	<data id="Global_Publishing_Refresh_Options" value="1"/>
+//
+// ]]>
+package admx
+
+import (
+	"bytes"
+	"encoding/xml"
+	"errors"
+	"fmt"
+	"html"
+	"regexp"
+	"slices"
+	"strings"
+)
+
+var cdataRegexp = regexp.MustCompile(`(?s)<!\[CDATA\[(.*?)]]>`)
+
+func IsADMX(text string) bool {
+	// We try to unmarshal the string to see if it looks like a valid ADMX policy
+	policy, err := unmarshal(text)
+	if err != nil {
+		return false
+	}
+	return policy.Enabled.Local == "enabled" || policy.Disabled.Local == "disabled" || len(policy.Data) > 0
+}
+
+func Equal(a, b string) (bool, error) {
+	aPolicy, err := unmarshal(a)
+	if err != nil {
+		return false, fmt.Errorf("unmarshalling ADMX policy a: %w", err)
+	}
+	bPolicy, err := unmarshal(b)
+	if err != nil {
+		return false, fmt.Errorf("unmarshalling ADMX policy b: %w", err)
+	}
+	return aPolicy.Equal(bPolicy), nil
+}
+
+func unmarshal(a string) (admxPolicy, error) {
+	a, err := convertToXMLString(a)
+	if err != nil {
+		return admxPolicy{}, fmt.Errorf("converting ADMX policy to XML string: %w", err)
+	}
+	var policy admxPolicy
+	err = xml.NewDecoder(bytes.NewReader([]byte(a))).Decode(&policy)
+	if err != nil {
+		return admxPolicy{}, fmt.Errorf("unmarshalling ADMX policy: %w", err)
+	}
+	return policy, nil
+}
+
+func convertToXMLString(a string) (string, error) {
+	matches := cdataRegexp.FindAllStringSubmatch(a, -1)
+	if len(matches) > 1 {
+		return "", errors.New("multiple CDATA matches found in ADMX policy")
+	}
+	if len(matches) == 1 && len(matches[0]) > 1 {
+		// If CDATA is present, we extract the content. Otherwise, we use the original string.
+		a = matches[0][1]
+	}
+	a = html.UnescapeString(a)
+	// ADMX policy elements are not case-sensitive. For example: <enabled/> and <Enabled/> are equivalent
+	// For simplicity, we compare everything in lowercase.
+	a = strings.ToLower(a)
+	// We wrap the policy in a <policy> tag to ensure it can be unmarshalled by the XML decoder
+	a = `<policy>` + a + `</policy>`
+	return a, nil
+}
+
+type admxPolicy struct {
+	Enabled  xml.Name         `xml:"enabled,omitempty"`
+	Disabled xml.Name         `xml:"disabled,omitempty"`
+	Data     []admxPolicyItem `xml:"data"`
+}
+
+func (a admxPolicy) Equal(b admxPolicy) bool {
+	if a.Disabled.Local != b.Disabled.Local {
+		return false
+	}
+	if a.Disabled.Local == "disabled" {
+		// If the ADMX policy is disabled, the data is not relevant
+		return true
+	}
+	if a.Enabled.Local != b.Enabled.Local {
+		return false
+	}
+	if len(a.Data) != len(b.Data) {
+		return false
+	}
+	a.sortData()
+	b.sortData()
+	for i := range a.Data {
+		if !a.Data[i].Equal(b.Data[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+func (a *admxPolicy) sortData() {
+	slices.SortFunc(a.Data, func(i, j admxPolicyItem) int {
+		return strings.Compare(i.ID, j.ID)
+	})
+}
+
+type admxPolicyItem struct {
+	ID    string `xml:"id,attr"`
+	Value string `xml:"value,attr"`
+}
+
+func (a admxPolicyItem) Equal(b admxPolicyItem) bool {
+	return a.ID == b.ID && a.Value == b.Value
+}

--- a/server/mdm/microsoft/admx/admx_test.go
+++ b/server/mdm/microsoft/admx/admx_test.go
@@ -1,0 +1,140 @@
+package admx
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsADMX(t *testing.T) {
+	t.Parallel()
+	assert.False(t, IsADMX(""))
+	assert.False(t, IsADMX("not an ADMX policy"))
+	assert.False(t, IsADMX(`<![CDATA[bozo]]>`))
+	assert.False(t, IsADMX(`<![CDATA[<bozo/>]]>`))
+	assert.True(t, IsADMX(`<![CDATA[<enabled/>]]>`))
+	assert.True(t, IsADMX(`<![CDATA[<disabled/>]]>`))
+	assert.True(t, IsADMX(`<![CDATA[<data id="id" value="value"/>]]>`))
+	assert.True(t, IsADMX(
+		`	<![CDATA[
+				<enabled/>
+				]]>`))
+	assert.True(t,
+		IsADMX("&lt;Enabled/&gt;&lt;Data id=\"EnableScriptBlockInvocationLogging\" value=\"true\"/&gt;&lt;Data id=\"ExecutionPolicy\" value=\"AllSigned\"/&gt;&lt;Data id=\"Listbox_ModuleNames\" value=\"*\"/&gt;&lt;Data id=\"OutputDirectory\" value=\"false\"/&gt;&lt;Data id=\"SourcePathForUpdateHelp\" value=\"false\"/&gt;"))
+}
+
+func TestEqual(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		name, a, b, errorContains string
+		equal                     bool
+	}{
+		{
+			name:          "empty policies",
+			a:             "",
+			b:             "",
+			equal:         true,
+			errorContains: "",
+		},
+		{
+			name:          "enabled policies",
+			a:             "<![CDATA[<enabled/>]]>",
+			b:             "&lt;Enabled/&gt;",
+			equal:         true,
+			errorContains: "",
+		},
+		{
+			name:          "disabled policies",
+			a:             "<![CDATA[<disabled/>]]>",
+			b:             "&lt;Disabled/&gt;",
+			equal:         true,
+			errorContains: "",
+		},
+		{
+			name:          "unequal policies",
+			a:             "<![CDATA[<disabled/>]]>",
+			b:             "&lt;enabled/&gt;",
+			equal:         false,
+			errorContains: "",
+		},
+		{
+			name: "enabled policies with data",
+			a: `<![CDATA[<enabled/>
+				<data id="ExecutionPolicy" value="AllSigned"/>
+				<data id="Listbox_ModuleNames" value="*"/>
+				<data id="OutputDirectory" value="false"/>
+				<data id="EnableScriptBlockInvocationLogging" value="true"/>
+				<data id="SourcePathForUpdateHelp" value="false"/>]]>`,
+			b:             "&lt;Enabled/&gt;&lt;Data id=\"EnableScriptBlockInvocationLogging\" value=\"true\"/&gt;&lt;Data id=\"ExecutionPolicy\" value=\"AllSigned\"/&gt;&lt;Data id=\"Listbox_ModuleNames\" value=\"*\"/&gt;&lt;Data id=\"OutputDirectory\" value=\"false\"/&gt;&lt;Data id=\"SourcePathForUpdateHelp\" value=\"false\"/&gt;",
+			equal:         true,
+			errorContains: "",
+		},
+		{
+			name: "disabled policies with data",
+			a: `<![CDATA[<disabled/>
+				<data id="ExecutionPolicy" value="AllSigned"/>
+				<data id="SourcePathForUpdateHelp" value="false"/>]]>`,
+			b:             "&lt;Disabled/&gt;&lt;Data id=\"EnableScriptBlockInvocationLogging\" value=\"true\"/&gt;&lt;Data id=\"ExecutionPolicy\" value=\"AllSigned\"/&gt;&lt;Data id=\"Listbox_ModuleNames\" value=\"*\"/&gt;&lt;Data id=\"OutputDirectory\" value=\"false\"/&gt;&lt;Data id=\"SourcePathForUpdateHelp\" value=\"false\"/&gt;",
+			equal:         true,
+			errorContains: "",
+		},
+		{
+			name:          "unparsable policy",
+			a:             "",
+			b:             "<bozo",
+			equal:         false,
+			errorContains: "unmarshalling ADMX policy",
+		},
+		{
+			name:          "multiple CDATA",
+			a:             "<![CDATA[<enabled/>]]><![CDATA[<bozo>]]>",
+			b:             "",
+			equal:         false,
+			errorContains: "multiple CDATA matches found",
+		},
+		{
+			name: "unequal policies with missing enable",
+			a: `<![CDATA[<Xenabled/>
+				<data id="ExecutionPolicy" value="AllSigned"/>
+				<data id="Listbox_ModuleNames" value="*"/>
+				<data id="OutputDirectory" value="false"/>
+				<data id="EnableScriptBlockInvocationLogging" value="true"/>
+				<data id="SourcePathForUpdateHelp" value="false"/>]]>`,
+			b:             "&lt;Enabled/&gt;&lt;Data id=\"EnableScriptBlockInvocationLogging\" value=\"true\"/&gt;&lt;Data id=\"ExecutionPolicy\" value=\"AllSigned\"/&gt;&lt;Data id=\"Listbox_ModuleNames\" value=\"*\"/&gt;&lt;Data id=\"OutputDirectory\" value=\"false\"/&gt;&lt;Data id=\"SourcePathForUpdateHelp\" value=\"false\"/&gt;",
+			equal:         false,
+			errorContains: "",
+		},
+		{
+			name: "unequal policies with data 1",
+			a: `<![CDATA[<enabled/>
+				<data id="EnableScriptBlockInvocationLogging" value="true"/>
+				<data id="SourcePathForUpdateHelp" value="false"/>]]>`,
+			b:             "&lt;Enabled/&gt;&lt;Data id=\"EnableScriptBlockInvocationLogging\" value=\"true\"/&gt;&lt;Data id=\"ExecutionPolicy\" value=\"AllSigned\"/&gt;&lt;Data id=\"Listbox_ModuleNames\" value=\"*\"/&gt;&lt;Data id=\"OutputDirectory\" value=\"false\"/&gt;&lt;Data id=\"SourcePathForUpdateHelp\" value=\"false\"/&gt;",
+			equal:         false,
+			errorContains: "",
+		},
+		{
+			name: "unequal policies with data 2",
+			a: `<![CDATA[<enabled/>
+				<data id="ExecutionPolicy" value="XXXX"/>
+				<data id="Listbox_ModuleNames" value="*"/>
+				<data id="OutputDirectory" value="false"/>
+				<data id="EnableScriptBlockInvocationLogging" value="true"/>
+				<data id="SourcePathForUpdateHelp" value="false"/>]]>`,
+			b:             "&lt;Enabled/&gt;&lt;Data id=\"EnableScriptBlockInvocationLogging\" value=\"true\"/&gt;&lt;Data id=\"ExecutionPolicy\" value=\"AllSigned\"/&gt;&lt;Data id=\"Listbox_ModuleNames\" value=\"*\"/&gt;&lt;Data id=\"OutputDirectory\" value=\"false\"/&gt;&lt;Data id=\"SourcePathForUpdateHelp\" value=\"false\"/&gt;",
+			equal:         false,
+			errorContains: "",
+		},
+	}
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			equal, err := Equal(tt.a, tt.b)
+			if tt.errorContains == "" {
+				assert.NoError(t, err)
+			} else {
+				assert.ErrorContains(t, err, tt.errorContains)
+			}
+			assert.Equal(t, tt.equal, equal)
+		})
+	}
+}

--- a/server/mdm/microsoft/profile_verifier_test.go
+++ b/server/mdm/microsoft/profile_verifier_test.go
@@ -223,6 +223,41 @@ func TestVerifyHostMDMProfilesHappyPaths(t *testing.T) {
 			toFail:   []string{"N2", "N4"},
 			toRetry:  []string{"N1"},
 		},
+		{
+			name: "single profile with CDATA reported and verified",
+			hostProfiles: []hostProfile{
+				{"N1", syncml.ForTestWithData(map[string]string{
+					"L1": `
+      <![CDATA[<enabled/><data id="ExecutionPolicy" value="AllSigned"/>
+      <data id="Listbox_ModuleNames" value="*"/>
+      <data id="OutputDirectory" value="false"/>
+      <data id="EnableScriptBlockInvocationLogging" value="true"/>
+      <data id="SourcePathForUpdateHelp" value="false"/>]]>`,
+				}), 0},
+			},
+			report: []osqueryReport{{"N1", "200", "L1",
+				"&lt;Enabled/&gt;&lt;Data id=\"EnableScriptBlockInvocationLogging\" value=\"true\"/&gt;&lt;Data id=\"ExecutionPolicy\" value=\"AllSigned\"/&gt;&lt;Data id=\"Listbox_ModuleNames\" value=\"*\"/&gt;&lt;Data id=\"OutputDirectory\" value=\"false\"/&gt;&lt;Data id=\"SourcePathForUpdateHelp\" value=\"false\"/&gt;",
+			}},
+			toVerify: []string{"N1"},
+			toFail:   []string{},
+			toRetry:  []string{},
+		},
+		{
+			name: "single profile with CDATA to retry",
+			hostProfiles: []hostProfile{
+				{"N1", syncml.ForTestWithData(map[string]string{
+					"L1": `
+      <![CDATA[<enabled/><data id="ExecutionPolicy" value="AllSigned"/>
+      <data id="SourcePathForUpdateHelp" value="false"/>]]>`,
+				}), 0},
+			},
+			report: []osqueryReport{{"N1", "200", "L1",
+				"&lt;Enabled/&gt;&lt;Data id=\"EnableScriptBlockInvocationLogging\" value=\"true\"/&gt;&lt;Data id=\"ExecutionPolicy\" value=\"AllSigned\"/&gt;&lt;Data id=\"Listbox_ModuleNames\" value=\"*\"/&gt;&lt;Data id=\"OutputDirectory\" value=\"false\"/&gt;&lt;Data id=\"SourcePathForUpdateHelp\" value=\"false\"/&gt;",
+			}},
+			toVerify: []string{},
+			toFail:   []string{},
+			toRetry:  []string{"N1"},
+		},
 	}
 
 	for _, tt := range cases {

--- a/server/mdm/microsoft/profile_verifier_test.go
+++ b/server/mdm/microsoft/profile_verifier_test.go
@@ -38,7 +38,7 @@ func TestLoopHostMDMLocURIs(t *testing.T) {
 		uniqueHash  string
 	}
 	got := []wantStruct{}
-	err := LoopHostMDMLocURIs(ctx, ds, &fleet.Host{}, func(profile *fleet.ExpectedMDMProfile, hash, locURI, data string) {
+	err := LoopOverExpectedHostProfiles(ctx, ds, &fleet.Host{}, func(profile *fleet.ExpectedMDMProfile, hash, locURI, data string) {
 		got = append(got, wantStruct{
 			locURI:      locURI,
 			data:        data,
@@ -118,24 +118,6 @@ func TestVerifyHostMDMProfilesErrors(t *testing.T) {
 }
 
 func TestVerifyHostMDMProfilesHappyPaths(t *testing.T) {
-	ds := new(mock.Store)
-	ctx := context.Background()
-	host := &fleet.Host{
-		DetailUpdatedAt: time.Now(),
-	}
-
-	type osqueryReport struct {
-		Name   string
-		Status string
-		LocURI string
-		Data   string
-	}
-	type hostProfile struct {
-		Name        string
-		RawContents []byte
-		RetryCount  uint
-	}
-
 	cases := []struct {
 		name              string
 		hostProfiles      []hostProfile
@@ -276,6 +258,7 @@ func TestVerifyHostMDMProfilesHappyPaths(t *testing.T) {
 				}
 			}
 
+			ds := new(mock.Store)
 			ds.GetHostMDMProfilesExpectedForVerificationFunc = func(ctx context.Context, host *fleet.Host) (map[string]*fleet.ExpectedMDMProfile, error) {
 				installDate := host.DetailUpdatedAt.Add(-2 * time.Hour)
 				if tt.withinGracePeriod {
@@ -316,11 +299,26 @@ func TestVerifyHostMDMProfilesHappyPaths(t *testing.T) {
 
 			out, err := xml.Marshal(msg)
 			require.NoError(t, err)
-			require.NoError(t, VerifyHostMDMProfiles(ctx, ds, host, out))
+			require.NoError(t, VerifyHostMDMProfiles(context.Background(), ds, &fleet.Host{DetailUpdatedAt: time.Now()}, out))
 			require.True(t, ds.UpdateHostMDMProfilesVerificationFuncInvoked)
 			require.True(t, ds.GetHostMDMProfilesExpectedForVerificationFuncInvoked)
 			ds.UpdateHostMDMProfilesVerificationFuncInvoked = false
 			ds.GetHostMDMProfilesExpectedForVerificationFuncInvoked = false
 		})
 	}
+}
+
+// osqueryReport is used by TestVerifyHostMDMProfilesHappyPaths
+type osqueryReport struct {
+	Name   string
+	Status string
+	LocURI string
+	Data   string
+}
+
+// hostProfile is used by TestVerifyHostMDMProfilesHappyPaths
+type hostProfile struct {
+	Name        string
+	RawContents []byte
+	RetryCount  uint
 }

--- a/server/service/osquery_utils/queries.go
+++ b/server/service/osquery_utils/queries.go
@@ -2290,7 +2290,7 @@ func buildConfigProfilesWindowsQuery(
 	var sb strings.Builder
 	sb.WriteString("<SyncBody>")
 	gotProfiles := false
-	err := microsoft_mdm.LoopHostMDMLocURIs(ctx, ds, host, func(profile *fleet.ExpectedMDMProfile, hash, locURI, data string) {
+	err := microsoft_mdm.LoopOverExpectedHostProfiles(ctx, ds, host, func(profile *fleet.ExpectedMDMProfile, hash, locURI, data string) {
 		// Per the [docs][1], to `<Get>` configurations you must
 		// replace `/Policy/Config` with `Policy/Result`
 		// [1]: https://learn.microsoft.com/en-us/windows/client-management/mdm/policy-configuration-service-provider
@@ -2314,10 +2314,11 @@ func buildConfigProfilesWindowsQuery(
 		return ""
 	}
 	if !gotProfiles {
-		logger.Log(
+		level.Debug(logger).Log(
 			"component", "service",
 			"method", "QueryFunc - windows config profiles",
-			"info", "host doesn't have profiles to check",
+			"msg", "host doesn't have profiles to check",
+			"host_id", host.ID,
 		)
 		return ""
 	}


### PR DESCRIPTION
For #24790 

Support verifying Windows CSPs with ADMX policies.
https://learn.microsoft.com/en-us/windows/client-management/understanding-admx-backed-policies

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
- [x] Added/updated automated tests
- [x] Manual QA for all new/changed functionality
