### PR TITLE
Set correct default webhook batch size

### DIFF
--- a/server/webhooks/failing_policies.go
+++ b/server/webhooks/failing_policies.go
@@ -46,8 +46,9 @@ func SendFailingPoliciesBatchedPOSTs(
 		return hosts[i].ID < hosts[j].ID
 	})
 
+	// Default to "no batching", i.e. send one webhook request at a time.
 	if hostBatchSize == 0 {
-		hostBatchSize = len(hosts)
+		hostBatchSize = 1
 	}
 	for i := 0; i < len(hosts); i += hostBatchSize {
 		end := i + hostBatchSize

--- a/server/webhooks/failing_policies_test.go
+++ b/server/webhooks/failing_policies_test.go
@@ -466,10 +466,10 @@ func TestSendBatchedPOSTs(t *testing.T) {
 			expRequestCount: 1,
 		},
 		{
-			name:            "100k-hosts-no-batching",
+			name:            "100k-hosts-all-in-one-batch",
 			hostCount:       100000,
-			batchSize:       0,
-			expRequestCount: 100000,
+			batchSize:       100000,
+			expRequestCount: 1,
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
This PR fixes the default webhook host batch size to align with [the documentation](https://fleetdm.com/docs/configuration/yaml-files#failing-policies-webhook), which states that:
> A value of 0 means no batching (default: 0).

Currently we're explicitly setting the batch size to `len(hosts)` i.e. "send a batch with all host IDs".  This PR sets the batch size to 1 if it's set to 0 in the config, which results in one webhook request at a time.

Note that with this change, there's no consistent way to return to the previous behavior of "send all host IDs" other than just setting a very high number for `host-batch-size` in the config.  One option would be to interpret `host-batch-size: -1` as "send all".  