### PR TITLE
Exempt bootstrap package uploads from server-side request timeout 

### DIFF
--- a/changes/25533-read-timeout-bootstrap-packages
+++ b/changes/25533-read-timeout-bootstrap-packages
@@ -1,0 +1,1 @@
+* Removed request timeout on bootstrap package uploads for consistency with software package upload endpoints

--- a/cmd/fleet/serve.go
+++ b/cmd/fleet/serve.go
@@ -1203,10 +1203,11 @@ the way that the Fleet server works.
 				}
 
 				if (req.Method == http.MethodPost && strings.HasSuffix(req.URL.Path, "/fleet/software/package")) ||
-					(req.Method == http.MethodPatch && strings.HasSuffix(req.URL.Path, "/package") && strings.Contains(req.URL.Path, "/fleet/software/titles/")) {
+					(req.Method == http.MethodPatch && strings.HasSuffix(req.URL.Path, "/package") && strings.Contains(req.URL.Path, "/fleet/software/titles/")) ||
+					(req.Method == http.MethodPost && strings.HasSuffix(req.URL.Path, "/bootstrap")) {
 					var zeroTime time.Time
 					rc := http.NewResponseController(rw)
-					// For large software installers, the server time needs time to read the full
+					// For large software installers and bootstrap packages, the server time needs time to read the full
 					// request body so we use the zero value to remove the deadline and override the
 					// default read timeout.
 					// TODO: Is this really how we want to handle this? Or would an arbitrarily long


### PR DESCRIPTION
For #25533

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/Committing-Changes.md#changes-files) for more information.
- [x] A detailed QA plan exists on the associated ticket (if it isn't there, work with the product group's QA engineer to add it)
- [x] Manual QA for all new/changed functionality