### PR TITLE
Mention policy automation side effects of VPP token deletion/reassignment

### DIFF
--- a/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/VppPage/components/DeleteVppModal/DeleteVppModal.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/VppPage/components/DeleteVppModal/DeleteVppModal.tsx
@@ -49,7 +49,7 @@ const DeleteVppModal = ({
       <>
         <p>
           Apps purchased for the <b>{orgName}</b> location won&apos;t appear in
-          Fleet, and app install policy automations will be removed. Apps
+          Fleet, and policies that trigger automatic install of these apps will be removed. Apps
           won&apos;t be uninstalled from hosts.
         </p>
         <p>

--- a/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/VppPage/components/DeleteVppModal/DeleteVppModal.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/VppPage/components/DeleteVppModal/DeleteVppModal.tsx
@@ -50,7 +50,7 @@ const DeleteVppModal = ({
         <p>
           Apps purchased for the <b>{orgName}</b> location won&apos;t appear in
           Fleet, and policies that trigger automatic install of these apps will
-          be removed. Apps won&apos;t be uninstalled from hosts.
+          be deleted. Apps won&apos;t be uninstalled from hosts.
         </p>
         <p>
           If you want to enable VPP integration again, you&apos;ll have to

--- a/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/VppPage/components/DeleteVppModal/DeleteVppModal.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/VppPage/components/DeleteVppModal/DeleteVppModal.tsx
@@ -49,8 +49,8 @@ const DeleteVppModal = ({
       <>
         <p>
           Apps purchased for the <b>{orgName}</b> location won&apos;t appear in
-          Fleet, and policies that trigger automatic install of these apps will be removed. Apps
-          won&apos;t be uninstalled from hosts.
+          Fleet, and policies that trigger automatic install of these apps will
+          be removed. Apps won&apos;t be uninstalled from hosts.
         </p>
         <p>
           If you want to enable VPP integration again, you&apos;ll have to

--- a/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/VppPage/components/DeleteVppModal/DeleteVppModal.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/VppPage/components/DeleteVppModal/DeleteVppModal.tsx
@@ -49,7 +49,8 @@ const DeleteVppModal = ({
       <>
         <p>
           Apps purchased for the <b>{orgName}</b> location won&apos;t appear in
-          Fleet. Apps won&apos;t be uninstalled from hosts.
+          Fleet, and app install policy automations will be removed. Apps
+          won&apos;t be uninstalled from hosts.
         </p>
         <p>
           If you want to enable VPP integration again, you&apos;ll have to

--- a/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/VppPage/components/EditTeamsVppModal/EditTeamsVppModal.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/VppPage/components/EditTeamsVppModal/EditTeamsVppModal.tsx
@@ -204,8 +204,8 @@ const EditTeamsVppModal = ({
         </p>
         <p>
           If you remove a team, App Store apps will be removed from that team,
-          and policies that trigger automatic install of these apps will be removed.
-          Installed apps won&apos;t be uninstalled from hosts.
+          and policies that trigger automatic install of these apps will be
+          removed. Installed apps won&apos;t be uninstalled from hosts.
         </p>
         <form onSubmit={onSave} className={baseClass} autoComplete="off">
           <TooltipWrapper

--- a/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/VppPage/components/EditTeamsVppModal/EditTeamsVppModal.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/VppPage/components/EditTeamsVppModal/EditTeamsVppModal.tsx
@@ -205,7 +205,7 @@ const EditTeamsVppModal = ({
         <p>
           If you delete a team, App Store apps will be deleted from that team,
           and policies that trigger automatic install of these apps will be
-          removed. Installed apps won&apos;t be uninstalled from hosts.
+          deleted. Installed apps won&apos;t be uninstalled from hosts.
         </p>
         <form onSubmit={onSave} className={baseClass} autoComplete="off">
           <TooltipWrapper

--- a/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/VppPage/components/EditTeamsVppModal/EditTeamsVppModal.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/VppPage/components/EditTeamsVppModal/EditTeamsVppModal.tsx
@@ -203,8 +203,9 @@ const EditTeamsVppModal = ({
           Edit teams for <b>{currentToken.org_name}</b>.
         </p>
         <p>
-          If you remove a team, the App Store apps will be removed from that
-          team. They won&apos;t be uninstalled from hosts.
+          If you remove a team, App Store apps will be removed from that team,
+          and policy automations referencing those apps will be removed.
+          Installed apps won&apos;t be uninstalled from hosts.
         </p>
         <form onSubmit={onSave} className={baseClass} autoComplete="off">
           <TooltipWrapper

--- a/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/VppPage/components/EditTeamsVppModal/EditTeamsVppModal.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/VppPage/components/EditTeamsVppModal/EditTeamsVppModal.tsx
@@ -203,7 +203,7 @@ const EditTeamsVppModal = ({
           Edit teams for <b>{currentToken.org_name}</b>.
         </p>
         <p>
-          If you remove a team, App Store apps will be removed from that team,
+          If you delete a team, App Store apps will be deleted from that team,
           and policies that trigger automatic install of these apps will be
           removed. Installed apps won&apos;t be uninstalled from hosts.
         </p>

--- a/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/VppPage/components/EditTeamsVppModal/EditTeamsVppModal.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/VppPage/components/EditTeamsVppModal/EditTeamsVppModal.tsx
@@ -204,7 +204,7 @@ const EditTeamsVppModal = ({
         </p>
         <p>
           If you remove a team, App Store apps will be removed from that team,
-          and policy automations referencing those apps will be removed.
+          and policies that trigger automatic install of these apps will be removed.
           Installed apps won&apos;t be uninstalled from hosts.
         </p>
         <form onSubmit={onSave} className={baseClass} autoComplete="off">


### PR DESCRIPTION
For #23115. Review requested from @marko-lisica per @noahtalerman's [response](https://github.com/fleetdm/fleet/issues/23115#issuecomment-2599192980) to @jmwatts's comment on the ticket.

Skipping changes file as this is part of the larger feature and treated as an unreleased bug for change management purposes, assuming the copy revision looks good (or the copy revision looks good after more modifications). Will assign a dev reviewer once copy looks good, if we decide we want the copy here (vs. in docs).

@marko-lisica set for review to confirm whether we need this/whether the copy looks good. @jmwatts set for review to confirm this is what she had in mind for feedback. Of note, deleting a VPP token does _not_ cancel pending installs since at that point the MDM command is already sent, so we don't need that verbiage here.

## Edit VPP token teams

### Before

<img width="751" alt="image" src="https://github.com/user-attachments/assets/31154fed-abf5-4b36-9ebf-7d66dcab4694" />

### After

<img width="822" alt="image" src="https://github.com/user-attachments/assets/d95b68a6-3c0c-4576-9c41-9253be61e77b" />

## Delete VPP token

### Before

<img width="662" alt="image" src="https://github.com/user-attachments/assets/414dc1b2-6837-47a7-987b-439bd17be224" />

### After

<img width="665" alt="image" src="https://github.com/user-attachments/assets/423f1e11-3ecf-40cb-aa0d-479cef82623c" />

# Checklist for submitter
- [ ] Manual QA for all new/changed functionality
