### PR TITLE
Fix missing actor for policy-initiated app store installs

### DIFF
--- a/server/datastore/mysql/activities.go
+++ b/server/datastore/mysql/activities.go
@@ -41,14 +41,8 @@ func (ds *Datastore) NewActivity(
 		}
 		userName = &user.Name
 		userEmail = &user.Email
-	} else if ranScriptActivity, ok := activity.(fleet.ActivityTypeRanScript); ok {
-		if ranScriptActivity.PolicyID != nil {
-			userName = &automationActivityAuthor
-		}
-	} else if softwareInstallActivity, ok := activity.(fleet.ActivityTypeInstalledSoftware); ok {
-		if softwareInstallActivity.PolicyID != nil {
-			userName = &automationActivityAuthor
-		}
+	} else if automatableActivity, ok := activity.(fleet.AutomatableActivity); ok && automatableActivity.WasFromAutomation() {
+		userName = &automationActivityAuthor
 	}
 
 	cols := []string{"user_id", "user_name", "activity_type", "details", "created_at"}

--- a/server/datastore/mysql/activities_test.go
+++ b/server/datastore/mysql/activities_test.go
@@ -285,9 +285,27 @@ func testActivityEmptyUser(t *testing.T, ds *Datastore) {
 			}, nil, timestamp,
 		),
 	)
+
+	require.NoError(
+		t, ds.NewActivity(
+			ctx, nil, fleet.ActivityInstalledAppStoreApp{
+				HostID:          1,
+				HostDisplayName: "A Host",
+				SoftwareTitle:   "Trello",
+				AppStoreID:      "123456",
+				CommandUUID:     "some uuid",
+				Status:          string(fleet.SoftwareInstalled),
+				SelfService:     false,
+				PolicyID:        ptr.Uint(1),
+				PolicyName:      ptr.String("Sample Policy"),
+			}, nil, timestamp,
+		),
+	)
+
 	activities, _, err := ds.ListActivities(context.Background(), fleet.ListActivitiesOptions{})
 	require.NoError(t, err)
-	assert.Len(t, activities, 1)
+	assert.Len(t, activities, 2)
+	assert.Equal(t, "Fleet", *activities[1].ActorFullName)
 }
 
 func testActivityPaginationMetadata(t *testing.T, ds *Datastore) {


### PR DESCRIPTION
For #25481 (unreleased).

Had updated the logic for webhooks but missed it for inserting the activity because we have to change things in two places.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [x] Added/updated automated tests
- [x] A detailed QA plan exists on the associated ticket (if it isn't there, work with the product group's QA engineer to add it)
- [x] Manual QA for all new/changed functionality