### PR TITLE
Fix broken link in LinkedIn post

### DIFF
--- a/website/config/routes.js
+++ b/website/config/routes.js
@@ -653,6 +653,7 @@ module.exports.routes = {
   'GET /docs/using-fleet/log-destinations': (req,res)=> { return res.redirect(301, '/guides/log-destinations');},
   'GET /guides/how-to-uninstall-osquery': (req,res)=> { return res.redirect(301, '/guides/how-to-uninstall-fleetd');},
   'GET /guides/sysadmin-diaries-lost-device': (req,res)=> { return res.redirect(301, '/guides/lock-wipe-hosts');},
+  'GET /guides/secret-variables': '/guides/secrets-in-scripts-and-configuration-profiles',
 
   // Release note article redirects.
   'GET /releases/fleet-3.10.0': '/releases/fleet-3-10-0',


### PR DESCRIPTION
Add redirect for broken link in this LinkedIn post (image): https://www.linkedin.com/posts/fleetdm_fleet-how-to-use-secret-variables-in-fleet-activity-7285712339541082114-E7rH?utm_source=share&utm_medium=member_desktop
