### PR TITLE
Update node version used in website workflows.

### DIFF
--- a/.github/workflows/deploy-fleet-website.yml
+++ b/.github/workflows/deploy-fleet-website.yml
@@ -31,7 +31,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.x]
+        node-version: [20.x]
 
     steps:
     - name: Harden Runner

--- a/.github/workflows/test-website.yml
+++ b/.github/workflows/test-website.yml
@@ -29,7 +29,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.x]
+        node-version: [20.x]
 
     steps:
       - name: Harden Runner


### PR DESCRIPTION

Changes:
- Bumped the node version used in the "Deploy Fleet website" and "Test Fleet website" workflows (`16.x` » `20.x`) to fix an [error with the upgraded version of Storybook](https://github.com/fleetdm/fleet/actions/runs/12872094872/job/35886819520?pr=25601) (which requires node 18 or higher).