### PR TITLE
Amend community PR process.

### DIFF
--- a/handbook/engineering/README.md
+++ b/handbook/engineering/README.md
@@ -232,7 +232,7 @@ The EM will be the contact point for the contributor and will ensure the PR is r
 - Set the PR to draft.
 - Thank the contributor for their hard work, explain that all changes to the product go through Fleet's [prioritization process](https://fleetdm.com/handbook/company/product-groups#how-feature-requests-are-prioritized), and ask them to file a [feature request](https://github.com/fleetdm/fleet/issues/new?assignees=&labels=%3Aproduct&projects=&template=feature-request.md&title=) that describe the change their PR is introducing.
 
-#### For PRs that will not be merged:
+**For PRs that will not be merged:**
 
 - Thank the contributor for their effort and explain why the changes won't be merged.
 - Close the PR.

--- a/handbook/engineering/README.md
+++ b/handbook/engineering/README.md
@@ -222,7 +222,7 @@ If you're assigned a community pull request for review, it is important to keep 
 
 If the PR is a quick fix (i.e. typo) or obvious technical improvement that doesn't change the product, it can be merged.
 
-#### For PRs that change the product:
+**For PRs that change the product:**
 
 - Assign the PR to the appropriate product group EM (Engineering Manager).
 - Notify the EM in the #help-engineering Slack channel.

--- a/handbook/engineering/README.md
+++ b/handbook/engineering/README.md
@@ -222,12 +222,17 @@ If you're assigned a community pull request for review, it is important to keep 
 
 If the PR is a quick fix (i.e. typo) or obvious technical improvement that doesn't change the product, it can be merged.
 
-For PRs that change the product:
+#### For PRs that change the product:
+
+- Assign the PR to the appropriate product group EM (Engineering Manager).
+- Notify the EM in the #help-engineering Slack channel.
+
+The EM will be the contact point for the contributor and will ensure the PR is reviewed by the appropriate team member when ready. The EM should:
 
 - Set the PR to draft.
 - Thank the contributor for their hard work, explain that all changes to the product go through Fleet's [prioritization process](https://fleetdm.com/handbook/company/product-groups#how-feature-requests-are-prioritized), and ask them to file a [feature request](https://github.com/fleetdm/fleet/issues/new?assignees=&labels=%3Aproduct&projects=&template=feature-request.md&title=) that describe the change their PR is introducing.
 
-For PRs that will not be merged:
+#### For PRs that will not be merged:
 
 - Thank the contributor for their effort and explain why the changes won't be merged.
 - Close the PR.


### PR DESCRIPTION
We discussed this in MDM retro and I discussed this change with George in our one-on-one.

The problem is that a feature-changing community PR does not need engineering work until product signs off on it and it is pulled in for the sprint. By getting engineering involved earlier than that, the engineer becomes the de facto contact point for the community contributor. This means the engineer is on the hook to answer questions and give updates to the community contributor for a PR that may be many weeks away from merging.

In the future, we may want a dedicated community manager role to interface with community contributors. In the near term, the engineering manager should be the default contact point for community contributors.
