### PR TITLE
Updated anatomy and teams guide

### DIFF
--- a/articles/teams.md
+++ b/articles/teams.md
@@ -36,7 +36,7 @@ You can add hosts to a team in Fleet by either enrolling the host with a team's 
 1. In Fleet UI, navigate to **Settings > Teams** and select the team you wish to add a host to.
 2. Select **Add hosts** and follow the on-screen instructions.
 
-> Quick tip: When viewing a specific team (from the Teams dropdown), Selecting **Add hosts** will display instructions to add new hosts directly to that team.
+> Quick tip: When viewing a specific team (from the **Teams** dropdown), Selecting **Add hosts** will display instructions to add new hosts directly to that team.
 
 ### Transfer a host
 

--- a/articles/teams.md
+++ b/articles/teams.md
@@ -40,7 +40,7 @@ You can add hosts to a team in Fleet by either enrolling the host with a team's 
 
 ### Transfer a host
 
-1. In FleetUI, navigate to the **Hosts** page and select the host you wish to transfer.
+1. In Fleet UI, navigate to the **Hosts** page and select the host you wish to transfer.
 2. From the host details page, press **Actions > Transfer** and follow the on-screen instructions.
 
 > Quick tip: You can hit the checkbox next to the host you wish to transfer to access its quick menu. From there, select **Transfer** and follow the on-screen instructions.

--- a/articles/teams.md
+++ b/articles/teams.md
@@ -1,14 +1,17 @@
 # Teams
 
-_Available in Fleet Premium_
+> Teams are available in Fleet Premium.
 
-In Fleet, you can group hosts together in a "team" in Fleet. This way, you can apply queries, policies, scripts, and more that are tailored to a host's risk/compliance needs.
+In Fleet, you can organize hosts into 'teams' to apply queries, policies, scripts, and other configurations tailored to their specific risk and compliance requirements.
 
-A host can only belong to one team. 
+To manage teams:
 
-You can give users access to only some teams.
+1. Select your avatar in the top navigation.
+2. Choose **Settings > Teams**.
 
-You can manage teams by selecting your avatar in the top navigation and then **Settings > Teams**.
+> **Note:** 
+> - A host can only belong to one team. 
+> - You can give users access to only some teams.
 
 ## Best practice
 
@@ -22,11 +25,25 @@ Fleet's best practice teams:
 - `🔳🏢 Company-owned iPads`: iPads purchased by the organization that enroll to Fleet automatically via Apple Business Manager. For example, conference-room iPads.
 - `📱🔐 Personally-owned iPhones`: End users' personal iPhones, like those enrolled through a BYOD program, that have access to company resources.
 
-If some of your hosts don't fall under the above teams, what are these hosts for? The answer determines the the hosts' risk/compliance needs, and thus their security basline, and thus their "team" in Fleet. If the hosts' have a different compliance needs, and thus different security baseline, then it's time to create a new team in Fleet.
+If some of your hosts don't fit into the teams listed above, consider their purpose. This will help determine their risk and compliance requirements, which in turn define their security baseline and appropriate team in Fleet. If these hosts have distinct compliance needs and security baselines, it's advisable to create a new team in Fleet.
 
-## Adding hosts to a team
+## Add hosts to a team
 
-You can add hosts to a new team in Fleet by either enrolling the host with a team's enroll secret or by transferring the host via the Fleet UI after the host has been enrolled to Fleet.
+You can add hosts to a team in Fleet by either enrolling the host with a team's enroll secret or by transferring the host via Fleet UI after the host has been enrolled to Fleet.
+
+### Enroll hosts with a team's enroll secret
+
+1. In FleetUI, navigate to **Settings > Teams** and select the team you wish to add a host.
+2. Select **Add hosts** and follow the on-screen instructions.
+
+> Quick tip: When viewing a specific team (from the Teams dropdown), Selecting **Add hosts** will display instructions to add new hosts directly to that team.
+
+### Transfer a host
+
+1. In FleetUI, navigate to the **Hosts** page and select the host you wish to transfer.
+1. From the host details page, press **Actions > Transfer** and follow the on-screen instructions.
+
+> Quick tip: You can hit the checkbox next to the host you wish to transfer to access its quick menu. From there, select **Transfer** and follow the on-screen instructions.
 
 ## Advanced
 

--- a/articles/teams.md
+++ b/articles/teams.md
@@ -33,7 +33,7 @@ You can add hosts to a team in Fleet by either enrolling the host with a team's 
 
 ### Enroll hosts with a team's enroll secret
 
-1. In FleetUI, navigate to **Settings > Teams** and select the team you wish to add a host.
+1. In FleetUI, navigate to **Settings > Teams** and select the team you wish to add a host to.
 2. Select **Add hosts** and follow the on-screen instructions.
 
 > Quick tip: When viewing a specific team (from the Teams dropdown), Selecting **Add hosts** will display instructions to add new hosts directly to that team.
@@ -41,7 +41,7 @@ You can add hosts to a team in Fleet by either enrolling the host with a team's 
 ### Transfer a host
 
 1. In FleetUI, navigate to the **Hosts** page and select the host you wish to transfer.
-1. From the host details page, press **Actions > Transfer** and follow the on-screen instructions.
+2. From the host details page, press **Actions > Transfer** and follow the on-screen instructions.
 
 > Quick tip: You can hit the checkbox next to the host you wish to transfer to access its quick menu. From there, select **Transfer** and follow the on-screen instructions.
 

--- a/articles/teams.md
+++ b/articles/teams.md
@@ -33,7 +33,7 @@ You can add hosts to a team in Fleet by either enrolling the host with a team's 
 
 ### Enroll hosts with a team's enroll secret
 
-1. In FleetUI, navigate to **Settings > Teams** and select the team you wish to add a host to.
+1. In Fleet UI, navigate to **Settings > Teams** and select the team you wish to add a host to.
 2. Select **Add hosts** and follow the on-screen instructions.
 
 > Quick tip: When viewing a specific team (from the Teams dropdown), Selecting **Add hosts** will display instructions to add new hosts directly to that team.

--- a/docs/Get started/anatomy.md
+++ b/docs/Get started/anatomy.md
@@ -2,43 +2,40 @@
 This page details the core concepts you need to know to use Fleet.
 
 ## Fleet UI
-Fleet UI is the GUI (graphical user interface) used to control Fleet. [Docs](https://fleetdm.com/docs/using-fleet/fleet-ui).
+Fleet UI is the GUI (graphical user interface) used to control Fleet. [Learn more](https://youtu.be/1VNvg3_drow?si=SWyQSEQMoHUYDZ8C).
 
 ## Fleetctl
 Fleetctl (pronouced “fleet control”) is a CLI (command line interface) tool for managing Fleet from the command line. [Docs](https://fleetdm.com/docs/using-fleet/fleetctl-cli).
 
 ## Fleetd
-Fleetd is a bundle of agents provided by Fleet to gather information about your devices. Fleetd includes [osquery](https://www.osquery.io/), [Orbit](https://github.com/fleetdm/fleet/blob/main/orbit/README.md), Fleet Desktop, and the [Fleetd Chrome extension](https://github.com/fleetdm/fleet/blob/main/ee/fleetd-chrome/README.md).
-
-## Osquery
-Osquery is an open-source tool for gathering information about the state of any device that the osquery agent has been installed on. [Learn more](https://www.osquery.io/).
-
-## Orbit
-Orbit is an osquery version and configuration manager, built by Fleet.
+Fleetd is a bundle of agents provided by Fleet to gather information about your devices. Fleetd includes:
+- **Osquery:** an open-source tool for gathering information about the state of any device that the osquery agent has been installed on. [Learn more](https://www.osquery.io/).
+- **Orbit:** an osquery version and configuration manager, built by Fleet. [Learn more](https://github.com/fleetdm/fleet/blob/main/orbit/README.md)
+- **Fleetd Chrome extension:** enrolls ChromeOS devices in Fleet. [Docs](https://github.com/fleetdm/fleet/blob/main/ee/fleetd-chrome/README.md).
 
 ## Fleet Desktop
 Fleet Desktop is a menu bar icon that gives end users visibility into the security and status of their machine. [Docs](https://fleetdm.com/docs/using-fleet/fleet-desktop).
-
-## Fleetd Chrome extension
-The Fleetd Chrome extension enrolls ChromeOS devices in Fleet. [Docs](https://github.com/fleetdm/fleet/blob/main/ee/fleetd-chrome/README.md).
 
 ## Host
 A host is a computer, server, or other endpoint. Fleet gathers information from Fleet's agent (fleetd) installed on each of your hosts. [Docs](https://fleetdm.com/docs/using-fleet/adding-hosts).
 
 ## Team
-A team is a group of hosts. Use teams to segment your hosts into groups that reflect your organization's IT and security policies. [Docs](https://fleetdm.com/docs/using-fleet/teams).
+
+A team is a group of hosts. Organize hosts into teams to apply queries, policies, scripts, and other configurations tailored to their specific risk and compliance requirements. [Read the guide](https://fleetdm.com/guides/teams).
 
 ## Query
 A query in Fleet refers to an osquery query. Osquery uses basic SQL commands to request data from hosts. Use queries to manage, monitor, and identify threats on your devices. [Docs](https://fleetdm.com/docs/using-fleet/fleet-ui).
 
 ## Policy
 A policy is a specific “yes” or “no” query. Use policies to manage security compliance in your
-organization. Learn more [here](https://fleetdm.com/securing/what-are-fleet-policies).
+organization. [Read the guide](https://fleetdm.com/securing/what-are-fleet-policies).
 
 ## Host vitals
-Host vitals are the hard-coded queries Fleet uses to populate device details.
+Fleet's built-in queries for collecting and storing important device information.
 
-## Software library
-An inventory of each host’s installed software, including information about detected vulnerabilities (CVEs).
+## Software
+Software in Fleet refers to the following:
+- **Software library:** a collection of Fleet-maintained apps, VPP, and custom install packages that can be installed on your hosts. [See available software](https://fleetdm.com/app-library).
+- **Software inventory** an inventory of each host’s installed software, including information about detected vulnerabilities (CVEs). 
 
 <meta name="pageOrderInSection" value="200">


### PR DESCRIPTION
Closes https://github.com/fleetdm/fleet/issues/24615

Updated anatomy to:
- Include a more accurate definition of teams
- Updated out-of-date links. Specifically FleetUI that linked to the queries guide. I updated to link directly to the FleetUI YouTube video.
- Consolidated osquery, Orbit, and Fleetd Chrome extension definitions under "Fleetd."
- Updated Host vitals and Software definitions

Updated teams guide.
- Fixed some typos and re-phrased a couple of paragraphs for easier readability
- I provided the missing instructions for adding hosts to teams (probably should have PR'd this separately, but got carried away)