### PR TITLE
Fleet UI: Updates to dropdown selected states

### DIFF
--- a/changes/25257-dropdown-improvements
+++ b/changes/25257-dropdown-improvements
@@ -1,0 +1,1 @@
+- Fleet UI: Improvements to the look and feel of dropdowns

--- a/changes/25257-dropdown-improvements
+++ b/changes/25257-dropdown-improvements
@@ -1,1 +1,1 @@
-- Fleet UI: Improvements to the look and feel of dropdowns
+- Fleet UI: Improved the look and feel of dropdowns

--- a/frontend/components/ActionsDropdown/ActionsDropdown.tsx
+++ b/frontend/components/ActionsDropdown/ActionsDropdown.tsx
@@ -198,6 +198,7 @@ const ActionsDropdown = ({
     option: (provided, state) => ({
       ...provided,
       padding: "10px 8px",
+      borderRadius: "4px",
       fontSize: "14px",
       backgroundColor: getOptionBackgroundColor(state),
       whiteSpace: "nowrap",
@@ -209,7 +210,7 @@ const ActionsDropdown = ({
       "&:active": {
         backgroundColor: state.isDisabled
           ? "transparent"
-          : COLORS["ui-vibrant-blue-10"],
+          : COLORS["ui-vibrant-blue-25"],
       },
       ...(state.isDisabled && {
         color: COLORS["ui-fleet-black-50"],

--- a/frontend/components/ActionsDropdown/ActionsDropdown.tsx
+++ b/frontend/components/ActionsDropdown/ActionsDropdown.tsx
@@ -157,7 +157,7 @@ const ActionsDropdown = ({
     placeholder: (provided, state) => ({
       ...provided,
       color: state.isFocused
-        ? COLORS["core-fleet-blue"]
+        ? COLORS["core-vibrant-blue"]
         : COLORS["core-fleet-black"],
       fontSize: "14px",
       lineHeight: "normal",

--- a/frontend/components/ActionsDropdown/ActionsDropdown.tsx
+++ b/frontend/components/ActionsDropdown/ActionsDropdown.tsx
@@ -157,7 +157,7 @@ const ActionsDropdown = ({
     placeholder: (provided, state) => ({
       ...provided,
       color: state.isFocused
-        ? COLORS["core-vibrant-blue"]
+        ? COLORS["core-fleet-blue"]
         : COLORS["core-fleet-black"],
       fontSize: "14px",
       lineHeight: "normal",

--- a/frontend/components/AddHostsModal/DownloadInstallers/_styles.scss
+++ b/frontend/components/AddHostsModal/DownloadInstallers/_styles.scss
@@ -43,7 +43,7 @@
     width: 247px;
 
     border: 1px solid #c5c7d1;
-    border-radius: 4px;
+    border-radius: $border-radius;
 
     span {
       display: flex;

--- a/frontend/components/EnrollSecrets/EnrollSecretModal/_styles.scss
+++ b/frontend/components/EnrollSecrets/EnrollSecretModal/_styles.scss
@@ -9,7 +9,7 @@
     background-color: $ui-off-white;
     color: $core-fleet-blue;
     border: 1px solid $ui-fleet-black-10;
-    border-radius: 4px;
+    border-radius: $border-radius;
     padding: 7px $pad-medium;
     margin: $pad-large 0 0 44px;
   }

--- a/frontend/components/EnrollSecrets/SecretEditorModal/_styles.scss
+++ b/frontend/components/EnrollSecrets/SecretEditorModal/_styles.scss
@@ -14,7 +14,7 @@
     background-color: $ui-off-white;
     color: $core-fleet-blue;
     border: 1px solid $ui-fleet-black-10;
-    border-radius: 4px;
+    border-radius: $border-radius;
     padding: 7px $pad-medium;
     margin: $pad-large 0 0 44px;
   }

--- a/frontend/components/InheritedBadge/_styles.scss
+++ b/frontend/components/InheritedBadge/_styles.scss
@@ -4,7 +4,7 @@
     font-size: $xxx-small;
     color: $core-fleet-black;
     line-height: 15px;
-    border-radius: 4px;
+    border-radius: $border-radius;
     background: $ui-vibrant-blue-10;
     padding: 4px;
   }

--- a/frontend/components/LiveQuery/_styles.scss
+++ b/frontend/components/LiveQuery/_styles.scss
@@ -45,6 +45,6 @@
   &:focus-visible {
     outline: 2px solid $ui-vibrant-blue-25;
     outline-offset: 1px;
-    border-radius: 4px;
+    border-radius: $border-radius;
   }
 }

--- a/frontend/components/TableContainer/DataTable/DefaultColumnFilter/_styles.scss
+++ b/frontend/components/TableContainer/DataTable/DefaultColumnFilter/_styles.scss
@@ -9,7 +9,7 @@
     font-size: $x-small;
     background-color: transparent;
     border: 1px solid $ui-fleet-black-10;
-    border-radius: 4px;
+    border-radius: $border-radius;
     padding: 4px;
     padding-left: 32px;
   }

--- a/frontend/components/TeamsDropdown/TeamsDropdown.tsx
+++ b/frontend/components/TeamsDropdown/TeamsDropdown.tsx
@@ -1,8 +1,10 @@
 import React, { useMemo } from "react";
 import Select, {
-  StylesConfig,
-  DropdownIndicatorProps,
   components,
+  DropdownIndicatorProps,
+  GroupBase,
+  OptionProps,
+  StylesConfig,
 } from "react-select-5";
 
 import { COLORS } from "styles/var/colors";
@@ -48,10 +50,14 @@ const generateDropdownOptions = (
   return filtered;
 };
 
-const getOptionBackgroundColor = (state: any) => {
-  return state.isSelected || state.isFocused
-    ? COLORS["ui-vibrant-blue-10"]
-    : "transparent";
+const getOptionBackgroundColor = (
+  state: OptionProps<
+    INumberDropdownOption,
+    false,
+    GroupBase<INumberDropdownOption>
+  >
+) => {
+  return state.isFocused ? COLORS["ui-vibrant-blue-10"] : "transparent";
 };
 
 interface ITeamsDropdownProps {

--- a/frontend/components/TeamsDropdown/TeamsDropdown.tsx
+++ b/frontend/components/TeamsDropdown/TeamsDropdown.tsx
@@ -13,7 +13,7 @@ import { IDropdownOption } from "interfaces/dropdownOption";
 import {
   APP_CONTEXT_ALL_TEAMS_SUMMARY,
   ITeamSummary,
-  APP_CONTEX_NO_TEAM_SUMMARY,
+  APP_CONTEXT_NO_TEAM_SUMMARY,
 } from "interfaces/team";
 
 import Icon from "components/Icon";
@@ -40,7 +40,7 @@ const generateDropdownOptions = (
   const filtered = options.filter(
     (o) =>
       !(
-        (o.label === APP_CONTEX_NO_TEAM_SUMMARY.name && !includeNoTeams) ||
+        (o.label === APP_CONTEXT_NO_TEAM_SUMMARY.name && !includeNoTeams) ||
         (o.label === APP_CONTEXT_ALL_TEAMS_SUMMARY.name && !includeAll)
       )
   );
@@ -121,12 +121,13 @@ const TeamsDropdown = ({
       padding: "8px 0",
       backgroundColor: "initial",
       border: 0,
+      borderRadius: "4px",
       boxShadow: "none",
       cursor: "pointer",
       "&:hover": {
         boxShadow: "none",
         ".team-dropdown__single-value": {
-          color: COLORS["core-vibrant-blue-over"],
+          color: COLORS["core-vibrant-blue"],
         },
         ".team-dropdown__indicator path": {
           stroke: COLORS["core-vibrant-blue-over"],
@@ -210,7 +211,9 @@ const TeamsDropdown = ({
       ...provided,
       padding: "10px 8px",
       fontSize: "14px",
+      borderRadius: "4px",
       backgroundColor: getOptionBackgroundColor(state),
+      fontWeight: state.isSelected ? "bold" : "normal",
       color: COLORS["core-fleet-black"],
       "&:hover": {
         backgroundColor: state.isDisabled

--- a/frontend/components/TeamsDropdown/TeamsDropdown.tsx
+++ b/frontend/components/TeamsDropdown/TeamsDropdown.tsx
@@ -133,7 +133,7 @@ const TeamsDropdown = ({
       "&:hover": {
         boxShadow: "none",
         ".team-dropdown__single-value": {
-          color: COLORS["core-vibrant-blue"],
+          color: COLORS["core-fleet-blue"],
         },
         ".team-dropdown__indicator path": {
           stroke: COLORS["core-vibrant-blue-over"],

--- a/frontend/components/TeamsDropdown/TeamsDropdown.tsx
+++ b/frontend/components/TeamsDropdown/TeamsDropdown.tsx
@@ -229,7 +229,7 @@ const TeamsDropdown = ({
       "&:active": {
         backgroundColor: state.isDisabled
           ? "transparent"
-          : COLORS["ui-vibrant-blue-10"],
+          : COLORS["ui-vibrant-blue-25"],
       },
       ...(state.isDisabled && {
         color: COLORS["ui-fleet-black-50"],

--- a/frontend/components/forms/fields/Checkbox/_styles.scss
+++ b/frontend/components/forms/fields/Checkbox/_styles.scss
@@ -36,7 +36,7 @@
     svg {
       outline: 2px solid $ui-vibrant-blue-25;
       outline-offset: 1px;
-      border-radius: 4px;
+      border-radius: $border-radius;
     }
   }
 

--- a/frontend/components/forms/fields/Dropdown/Dropdown.jsx
+++ b/frontend/components/forms/fields/Dropdown/Dropdown.jsx
@@ -138,7 +138,13 @@ class Dropdown extends Component {
       );
     }
     return (
-      <div className={`${baseClass}__option`}>
+      <div
+        className={`${baseClass}__option`}
+        style={{
+          backgroundColor: option.isSelected ? "#E5F7FF" : "#FFFFFF",
+          padding: "8px",
+        }}
+      >
         {option.label}
         {option.helpText && (
           <span className={`${baseClass}__help-text`}>{option.helpText}</span>

--- a/frontend/components/forms/fields/Dropdown/Dropdown.jsx
+++ b/frontend/components/forms/fields/Dropdown/Dropdown.jsx
@@ -139,13 +139,7 @@ class Dropdown extends Component {
       );
     }
     return (
-      <div
-        className={`${baseClass}__option`}
-        style={{
-          backgroundColor: option.isSelected ? "#E5F7FF" : "#FFFFFF",
-          padding: "8px",
-        }}
-      >
+      <div className={`${baseClass}__option`}>
         {option.label}
         {option.helpText && (
           <span className={`${baseClass}__help-text`}>{option.helpText}</span>
@@ -215,38 +209,6 @@ class Dropdown extends Component {
       [`${baseClass}__select--disabled`]: disabled,
     });
 
-    const customStyles = {
-      option: (provided, state) => ({
-        ...provided,
-        color: COLORS["core-fleet-black"],
-        fontSize: "14px", // Assuming $x-small is 14px
-        margin: 0,
-        padding: "10px",
-        display: "block",
-        backgroundColor: "transparent",
-        fontWeight: state.isSelected ? "bold" : "normal",
-        "&:hover": {
-          backgroundColor: state.isDisabled
-            ? "transparent"
-            : COLORS["ui-vibrant-blue-10"],
-        },
-        "&:active": {
-          backgroundColor: state.isDisabled
-            ? "transparent"
-            : COLORS["ui-vibrant-blue-10"],
-        },
-        ".dropdown-wrapper__option": {
-          backgroundColor: "transparent",
-          padding: 0,
-        },
-        ...(state.isDisabled && {
-          color: COLORS["ui-fleet-black-50"],
-          fontStyle: "italic",
-          cursor: "not-allowed",
-        }),
-      }),
-    };
-
     return (
       <FormField
         {...formFieldProps}
@@ -254,7 +216,6 @@ class Dropdown extends Component {
         className={wrapperClassName}
       >
         <Select
-          styles={customStyles}
           className={selectClasses}
           clearable={clearable}
           disabled={disabled}

--- a/frontend/components/forms/fields/Dropdown/Dropdown.jsx
+++ b/frontend/components/forms/fields/Dropdown/Dropdown.jsx
@@ -4,7 +4,6 @@ import classnames from "classnames";
 import { noop, pick } from "lodash";
 import Select from "react-select";
 
-import { COLORS } from "styles/var/colors";
 import dropdownOptionInterface from "interfaces/dropdownOption";
 import FormField from "components/forms/FormField";
 import Icon from "components/Icon";

--- a/frontend/components/forms/fields/Dropdown/Dropdown.jsx
+++ b/frontend/components/forms/fields/Dropdown/Dropdown.jsx
@@ -4,6 +4,7 @@ import classnames from "classnames";
 import { noop, pick } from "lodash";
 import Select from "react-select";
 
+import { COLORS } from "styles/var/colors";
 import dropdownOptionInterface from "interfaces/dropdownOption";
 import FormField from "components/forms/FormField";
 import Icon from "components/Icon";
@@ -214,6 +215,38 @@ class Dropdown extends Component {
       [`${baseClass}__select--disabled`]: disabled,
     });
 
+    const customStyles = {
+      option: (provided, state) => ({
+        ...provided,
+        color: COLORS["core-fleet-black"],
+        fontSize: "14px", // Assuming $x-small is 14px
+        margin: 0,
+        padding: "10px",
+        display: "block",
+        backgroundColor: "transparent",
+        fontWeight: state.isSelected ? "bold" : "normal",
+        "&:hover": {
+          backgroundColor: state.isDisabled
+            ? "transparent"
+            : COLORS["ui-vibrant-blue-10"],
+        },
+        "&:active": {
+          backgroundColor: state.isDisabled
+            ? "transparent"
+            : COLORS["ui-vibrant-blue-10"],
+        },
+        ".dropdown-wrapper__option": {
+          backgroundColor: "transparent",
+          padding: 0,
+        },
+        ...(state.isDisabled && {
+          color: COLORS["ui-fleet-black-50"],
+          fontStyle: "italic",
+          cursor: "not-allowed",
+        }),
+      }),
+    };
+
     return (
       <FormField
         {...formFieldProps}
@@ -221,6 +254,7 @@ class Dropdown extends Component {
         className={wrapperClassName}
       >
         <Select
+          styles={customStyles}
           className={selectClasses}
           clearable={clearable}
           disabled={disabled}

--- a/frontend/components/forms/fields/Dropdown/_styles.scss
+++ b/frontend/components/forms/fields/Dropdown/_styles.scss
@@ -37,7 +37,7 @@
           color: $core-vibrant-red;
           border: 1px solid $core-vibrant-red;
           box-sizing: border-box;
-          border-radius: 4px;
+          border-radius: $border-radius;
         }
 
         .Select-arrow {
@@ -237,13 +237,15 @@
     margin: 0;
     padding: 10px;
     display: block;
+    border-radius: $border-radius;
+
+    &.is-selected {
+      background-color: transparent;
+      font-weight: bold;
+    }
 
     &.is-focused {
       background-color: $ui-vibrant-blue-10;
-
-      .dropdown__option {
-        background-color: $ui-vibrant-blue-10;
-      }
 
       .Select-icon {
         color: $ui-vibrant-blue-10;
@@ -328,7 +330,6 @@
         &.is-focused {
           background-color: $ui-vibrant-blue-10;
           color: $core-white;
-          font-weight: $bold;
         }
       }
     }

--- a/frontend/components/forms/fields/Dropdown/_styles.scss
+++ b/frontend/components/forms/fields/Dropdown/_styles.scss
@@ -241,6 +241,10 @@
     &.is-focused {
       background-color: $ui-vibrant-blue-10;
 
+      .dropdown__option {
+        background-color: $ui-vibrant-blue-10;
+      }
+
       .Select-icon {
         color: $ui-vibrant-blue-10;
       }

--- a/frontend/components/forms/fields/Dropdown/_styles.scss
+++ b/frontend/components/forms/fields/Dropdown/_styles.scss
@@ -55,9 +55,7 @@
   }
 
   &__help-text {
-    font-size: $xx-small;
-    white-space: normal;
-    color: $ui-fleet-black-50;
+    @include help-text;
     font-style: italic;
   }
 }
@@ -326,6 +324,7 @@
         &.is-focused {
           background-color: $ui-vibrant-blue-10;
           color: $core-white;
+          font-weight: $bold;
         }
       }
     }

--- a/frontend/components/forms/fields/Dropdown/_styles.scss
+++ b/frontend/components/forms/fields/Dropdown/_styles.scss
@@ -252,6 +252,10 @@
       }
     }
 
+    &:active {
+      background-color: $core-vibrant-blue-down;
+    }
+
     &:last-child {
       border-bottom-right-radius: 0;
       border-bottom-left-radius: 0;

--- a/frontend/components/forms/fields/DropdownWrapper/DropdownWrapper.tsx
+++ b/frontend/components/forms/fields/DropdownWrapper/DropdownWrapper.tsx
@@ -184,11 +184,11 @@ const DropdownWrapper = ({
       boxShadow: "none",
       borderRadius: "4px",
       borderColor: state.isFocused
-        ? COLORS["core-fleet-blue"]
+        ? COLORS["core-vibrant-blue"]
         : COLORS["ui-fleet-black-10"],
       "&:hover": {
         boxShadow: "none",
-        borderColor: COLORS["core-fleet-blue"],
+        borderColor: COLORS["core-vibrant-blue"],
         ".dropdown-wrapper__single-value": {
           color: COLORS["core-vibrant-blue-over"],
         },
@@ -271,7 +271,9 @@ const DropdownWrapper = ({
       ...provided,
       padding: "10px 8px",
       fontSize: "14px",
+      borderRadius: "4px",
       backgroundColor: getOptionBackgroundColor(state),
+      fontWeight: state.isSelected ? "bold" : "normal",
       color: COLORS["core-fleet-black"],
       "&:hover": {
         backgroundColor: state.isDisabled
@@ -298,8 +300,9 @@ const DropdownWrapper = ({
       ".dropdown-wrapper__help-text": {
         fontSize: "12px",
         whiteSpace: "normal",
-        color: COLORS["ui-fleet-black-50"],
+        color: COLORS["ui-fleet-black-75"],
         fontStyle: "italic",
+        fontWeight: "normal",
       },
     }),
     menuPortal: (base) => ({ ...base, zIndex: 999 }), // Not hidden beneath scrollable sections

--- a/frontend/components/forms/fields/DropdownWrapper/DropdownWrapper.tsx
+++ b/frontend/components/forms/fields/DropdownWrapper/DropdownWrapper.tsx
@@ -12,12 +12,14 @@
 import classnames from "classnames";
 import React from "react";
 import Select, {
-  StylesConfig,
-  DropdownIndicatorProps,
-  OptionProps,
   components,
+  DropdownIndicatorProps,
+  GroupBase,
+  OptionProps,
   PropsValue,
   SingleValue,
+  StylesConfig,
+  ValueContainerProps,
 } from "react-select-5";
 
 import { COLORS } from "styles/var/colors";
@@ -28,10 +30,10 @@ import DropdownOptionTooltipWrapper from "components/forms/fields/Dropdown/Dropd
 import Icon from "components/Icon";
 import { IconNames } from "components/icons";
 
-const getOptionBackgroundColor = (state: any) => {
-  return state.isSelected || state.isFocused
-    ? COLORS["ui-vibrant-blue-10"]
-    : "transparent";
+const getOptionBackgroundColor = (
+  state: OptionProps<CustomOptionType, false>
+) => {
+  return state.isFocused ? COLORS["ui-vibrant-blue-10"] : "transparent";
 };
 
 export interface CustomOptionType {
@@ -129,7 +131,11 @@ const DropdownWrapper = ({
   };
 
   const CustomDropdownIndicator = (
-    props: DropdownIndicatorProps<CustomOptionType, false, any>
+    props: DropdownIndicatorProps<
+      CustomOptionType,
+      false,
+      GroupBase<CustomOptionType>
+    >
   ) => {
     const { isFocused, selectProps } = props;
     const color =
@@ -151,7 +157,10 @@ const DropdownWrapper = ({
     );
   };
 
-  const ValueContainer = ({ children, ...props }: any) => {
+  const ValueContainer = ({
+    children,
+    ...props
+  }: ValueContainerProps<CustomOptionType, false>) => {
     const iconToDisplay = iconName || (tableFilter ? "filter" : null);
 
     return (
@@ -195,6 +204,9 @@ const DropdownWrapper = ({
         ".dropdown-wrapper__indicator path": {
           stroke: COLORS["core-vibrant-blue-over"],
         },
+        ".filter-icon path": {
+          fill: COLORS["core-vibrant-blue-over"],
+        },
       },
       // When tabbing
       // Relies on --is-focused for styling as &:focus-visible cannot be applied
@@ -205,6 +217,9 @@ const DropdownWrapper = ({
         ".dropdown-wrapper__indicator path": {
           stroke: COLORS["core-vibrant-blue-over"],
         },
+        ".filter-icon path": {
+          fill: COLORS["core-vibrant-blue-over"],
+        },
       },
       ...(state.isDisabled && {
         ".dropdown-wrapper__single-value": {
@@ -213,6 +228,9 @@ const DropdownWrapper = ({
         ".dropdown-wrapper__indicator path": {
           stroke: COLORS["ui-fleet-black-50"],
         },
+        ".filter-icon path": {
+          fill: COLORS["ui-fleet-black-50"],
+        },
       }),
       "&:active": {
         ".dropdown-wrapper__single-value": {
@@ -220,6 +238,9 @@ const DropdownWrapper = ({
         },
         ".dropdown-wrapper__indicator path": {
           stroke: COLORS["core-vibrant-blue-down"],
+        },
+        ".filter-icon path": {
+          fill: COLORS["core-vibrant-blue-down"],
         },
       },
       ...(state.menuIsOpen && {

--- a/frontend/components/forms/fields/DropdownWrapper/DropdownWrapper.tsx
+++ b/frontend/components/forms/fields/DropdownWrapper/DropdownWrapper.tsx
@@ -307,7 +307,7 @@ const DropdownWrapper = ({
       "&:active": {
         backgroundColor: state.isDisabled
           ? "transparent"
-          : COLORS["ui-vibrant-blue-10"],
+          : COLORS["ui-vibrant-blue-25"],
       },
       ...(state.isDisabled && {
         color: COLORS["ui-fleet-black-50"],

--- a/frontend/components/forms/fields/DropdownWrapper/DropdownWrapper.tsx
+++ b/frontend/components/forms/fields/DropdownWrapper/DropdownWrapper.tsx
@@ -51,6 +51,7 @@ export interface IDropdownWrapper {
   onChange: (newValue: SingleValue<CustomOptionType>) => void;
   name: string;
   className?: string;
+  wrapperClassname?: string;
   labelClassname?: string;
   error?: string;
   label?: JSX.Element | string;
@@ -74,6 +75,7 @@ const DropdownWrapper = ({
   name,
   className,
   labelClassname,
+  wrapperClassname,
   error,
   label,
   helpText,
@@ -86,6 +88,7 @@ const DropdownWrapper = ({
 }: IDropdownWrapper) => {
   const wrapperClassNames = classnames(baseClass, className, {
     [`${baseClass}__table-filter`]: tableFilter,
+    [`${wrapperClassname}`]: !!wrapperClassname,
   });
 
   const handleChange = (newValue: SingleValue<CustomOptionType>) => {

--- a/frontend/components/forms/fields/DropdownWrapper/DropdownWrapper.tsx
+++ b/frontend/components/forms/fields/DropdownWrapper/DropdownWrapper.tsx
@@ -196,11 +196,11 @@ const DropdownWrapper = ({
       boxShadow: "none",
       borderRadius: "4px",
       borderColor: state.isFocused
-        ? COLORS["core-vibrant-blue"]
+        ? COLORS["core-fleet-blue"]
         : COLORS["ui-fleet-black-10"],
       "&:hover": {
         boxShadow: "none",
-        borderColor: COLORS["core-vibrant-blue"],
+        borderColor: COLORS["core-fleet-blue"],
         ".dropdown-wrapper__single-value": {
           color: COLORS["core-vibrant-blue-over"],
         },

--- a/frontend/components/forms/fields/InputField/_styles.scss
+++ b/frontend/components/forms/fields/InputField/_styles.scss
@@ -2,7 +2,7 @@
   line-height: 1.5;
   background-color: $ui-light-grey;
   border: solid 1px $ui-fleet-black-10;
-  border-radius: 4px;
+  border-radius: $border-radius;
   font-size: $small;
   padding: 7px 12px;
   color: $core-fleet-blue;
@@ -39,7 +39,7 @@
     color: $core-vibrant-red;
     border: 1px solid $core-vibrant-red;
     box-sizing: border-box;
-    border-radius: 4px;
+    border-radius: $border-radius;
 
     &:focus {
       border-color: $ui-error;

--- a/frontend/components/forms/fields/InputField/_styles.scss
+++ b/frontend/components/forms/fields/InputField/_styles.scss
@@ -97,7 +97,6 @@
     right: 12px;
   }
 
-
   &__input-container.copy-enabled {
     &.copy-outside {
       display: flex;

--- a/frontend/components/forms/fields/InputFieldWithIcon/_styles.scss
+++ b/frontend/components/forms/fields/InputFieldWithIcon/_styles.scss
@@ -14,7 +14,7 @@
     &--error {
       border: 1px solid $core-vibrant-red;
       box-sizing: border-box;
-      border-radius: 4px;
+      border-radius: $border-radius;
     }
   }
 
@@ -73,7 +73,7 @@
       color: $core-vibrant-red;
       border: 1px solid $core-vibrant-red;
       box-sizing: border-box;
-      border-radius: 4px;
+      border-radius: $border-radius;
     }
   }
 

--- a/frontend/components/forms/fields/Radio/_styles.scss
+++ b/frontend/components/forms/fields/Radio/_styles.scss
@@ -59,8 +59,7 @@
   }
 
   &__help-text {
-    color: $ui-fleet-black-75;
-    font-size: $xx-small;
+    @include help-text;
     margin-top: $pad-xxsmall;
     margin-left: calc(20px + #{$pad-small});
   }

--- a/frontend/components/side_panels/QuerySidePanel/_styles.scss
+++ b/frontend/components/side_panels/QuerySidePanel/_styles.scss
@@ -110,7 +110,7 @@
     font-size: $x-small;
     font-weight: $bold;
     padding: 2px 4px;
-    border-radius: 4px;
+    border-radius: $border-radius;
     position: relative;
     top: -2px;
     min-width: 95px;

--- a/frontend/components/top_nav/UserMenu/UserMenu.tsx
+++ b/frontend/components/top_nav/UserMenu/UserMenu.tsx
@@ -229,11 +229,7 @@ const UserMenu = ({
       fontSize: "15px",
       borderRadius: "4px",
       backgroundColor: getOptionBackgroundColor(state),
-      fontWeight: state.isSelected ? "bold" : "normal",
-      "> .dropdown-wrapper__help-text": {
-        fontWeight: "normal", // TODO: Get this working and make sure tooltips don't bold either
-      },
-      color: COLORS["tooltip-bg"], // TODO: Why the mismatch in names in colors.scss and colors.ts
+      color: COLORS["tooltip-bg"],
       whiteSpace: "nowrap",
       "&:hover": {
         backgroundColor: COLORS["ui-vibrant-blue-10"],

--- a/frontend/components/top_nav/UserMenu/UserMenu.tsx
+++ b/frontend/components/top_nav/UserMenu/UserMenu.tsx
@@ -1,11 +1,11 @@
 import React, { useEffect, useState } from "react";
 import { keyframes } from "@emotion/react";
 import Select, {
-  StylesConfig,
-  DropdownIndicatorProps,
-  OptionProps,
   components,
+  DropdownIndicatorProps,
   GroupBase,
+  OptionProps,
+  StylesConfig,
 } from "react-select-5";
 import { IUser } from "interfaces/user";
 import { ITeam } from "interfaces/team";
@@ -38,7 +38,9 @@ const bounceDownAnimation = keyframes`
   }
 `;
 
-const getOptionBackgroundColor = (state: any) => {
+const getOptionBackgroundColor = (
+  state: OptionProps<IDropdownOption, false, GroupBase<IDropdownOption>>
+) => {
   return state.isFocused ? COLORS["ui-vibrant-blue-10"] : "transparent";
 };
 
@@ -229,7 +231,7 @@ const UserMenu = ({
       backgroundColor: getOptionBackgroundColor(state),
       fontWeight: state.isSelected ? "bold" : "normal",
       "> .dropdown-wrapper__help-text": {
-        fontWeight: "normal", // TODO: Get this working
+        fontWeight: "normal", // TODO: Get this working and make sure tooltips don't bold either
       },
       color: COLORS["tooltip-bg"], // TODO: Why the mismatch in names in colors.scss and colors.ts
       whiteSpace: "nowrap",

--- a/frontend/components/top_nav/UserMenu/UserMenu.tsx
+++ b/frontend/components/top_nav/UserMenu/UserMenu.tsx
@@ -225,7 +225,12 @@ const UserMenu = ({
       ...provided,
       padding: "10px 8px",
       fontSize: "15px",
+      borderRadius: "4px",
       backgroundColor: getOptionBackgroundColor(state),
+      fontWeight: state.isSelected ? "bold" : "normal",
+      "> .dropdown-wrapper__help-text": {
+        fontWeight: "normal", // TODO: Get this working
+      },
       color: COLORS["tooltip-bg"], // TODO: Why the mismatch in names in colors.scss and colors.ts
       whiteSpace: "nowrap",
       "&:hover": {

--- a/frontend/components/top_nav/UserMenu/UserMenu.tsx
+++ b/frontend/components/top_nav/UserMenu/UserMenu.tsx
@@ -235,7 +235,7 @@ const UserMenu = ({
         backgroundColor: COLORS["ui-vibrant-blue-10"],
       },
       "&:active": {
-        backgroundColor: COLORS["ui-vibrant-blue-10"],
+        backgroundColor: COLORS["ui-vibrant-blue-25"],
       },
       "&:last-child, &:nth-last-of-type(2)": {
         borderTop: `1px solid ${COLORS["ui-fleet-black-10"]}`,

--- a/frontend/context/app.tsx
+++ b/frontend/context/app.tsx
@@ -5,7 +5,7 @@ import { IEnrollSecret } from "interfaces/enroll_secret";
 import {
   APP_CONTEXT_ALL_TEAMS_SUMMARY,
   ITeamSummary,
-  APP_CONTEX_NO_TEAM_SUMMARY,
+  APP_CONTEXT_NO_TEAM_SUMMARY,
   APP_CONTEXT_NO_TEAM_ID,
 } from "interfaces/team";
 import { IUser } from "interfaces/user";
@@ -324,12 +324,12 @@ const reducer = (state: InitialStateType, action: IAction) => {
       sortedTeams = sortedTeams.filter(
         (t) =>
           t.name !== APP_CONTEXT_ALL_TEAMS_SUMMARY.name &&
-          t.name !== APP_CONTEX_NO_TEAM_SUMMARY.name
+          t.name !== APP_CONTEXT_NO_TEAM_SUMMARY.name
       );
       if (user && permissions.isOnGlobalTeam(user)) {
         sortedTeams.unshift(
           APP_CONTEXT_ALL_TEAMS_SUMMARY,
-          APP_CONTEX_NO_TEAM_SUMMARY
+          APP_CONTEXT_NO_TEAM_SUMMARY
         );
       }
 

--- a/frontend/interfaces/team.ts
+++ b/frontend/interfaces/team.ts
@@ -132,7 +132,7 @@ export const APP_CONTEXT_ALL_TEAMS_SUMMARY: ITeamSummary = {
 
 export const API_NO_TEAM_ID = 0;
 export const APP_CONTEXT_NO_TEAM_ID = 0;
-export const APP_CONTEX_NO_TEAM_SUMMARY: ITeamSummary = {
+export const APP_CONTEXT_NO_TEAM_SUMMARY: ITeamSummary = {
   id: APP_CONTEXT_NO_TEAM_ID,
   name: "No team",
 } as const;

--- a/frontend/pages/DashboardPage/DashboardPage.tsx
+++ b/frontend/pages/DashboardPage/DashboardPage.tsx
@@ -54,8 +54,9 @@ import { ITableQueryData } from "components/TableContainer/TableContainer";
 import TeamsDropdown from "components/TeamsDropdown";
 import Spinner from "components/Spinner";
 import CustomLink from "components/CustomLink";
-// @ts-ignore
-import Dropdown from "components/forms/fields/Dropdown";
+import { SingleValue } from "react-select-5";
+import DropdownWrapper from "components/forms/fields/DropdownWrapper";
+import { CustomOptionType } from "components/forms/fields/DropdownWrapper/DropdownWrapper";
 import MainContent from "components/MainContent";
 import LastUpdatedText from "components/LastUpdatedText";
 
@@ -883,14 +884,14 @@ const DashboardPage = ({ router, location }: IDashboardProps): JSX.Element => {
         </div>
         <div className={`${baseClass}__platforms`}>
           <span>Platform:&nbsp;</span>
-          <Dropdown
+          <DropdownWrapper
+            name="platform-filter"
             value={selectedPlatform || ""}
-            className={`${baseClass}__platform_dropdown`}
+            className={`${baseClass}__platform-filter`}
             options={PLATFORM_DROPDOWN_OPTIONS}
-            searchable={false}
-            onChange={(value: PlatformValueOptions) => {
+            onChange={(option: SingleValue<CustomOptionType>) => {
               const selectedPlatformOption = PLATFORM_DROPDOWN_OPTIONS.find(
-                (platform) => platform.value === value
+                (platform) => platform.value === option?.value
               );
               router.push(
                 (selectedPlatformOption?.path || paths.DASHBOARD)

--- a/frontend/pages/DashboardPage/_styles.scss
+++ b/frontend/pages/DashboardPage/_styles.scss
@@ -60,16 +60,8 @@
     }
   }
 
-  &__platform_dropdown {
+  &__platform-filter {
     width: 138px;
-
-    .Select-menu-outer {
-      max-height: none;
-
-      .Select-menu {
-        max-height: none;
-      }
-    }
   }
 
   &__section {

--- a/frontend/pages/SoftwarePage/components/SoftwareFiltersModal/SoftwareFiltersModal.tsx
+++ b/frontend/pages/SoftwarePage/components/SoftwareFiltersModal/SoftwareFiltersModal.tsx
@@ -1,7 +1,8 @@
 import React, { useState } from "react";
 
-// @ts-ignore
-import Dropdown from "components/forms/fields/Dropdown";
+import { SingleValue } from "react-select-5";
+import DropdownWrapper from "components/forms/fields/DropdownWrapper";
+import { CustomOptionType } from "components/forms/fields/DropdownWrapper/DropdownWrapper";
 import Modal from "components/Modal";
 import Button from "components/buttons/Button";
 import Slider from "components/forms/fields/Slider";
@@ -39,9 +40,11 @@ const SoftwareFiltersModal = ({
   );
   const [hasKnownExploit, setHasKnownExploit] = useState(vulnFilters.exploit);
 
-  const onChangeSeverity = (value: string) => {
+  const onChangeSeverity = (
+    selectedSeverity: SingleValue<CustomOptionType>
+  ) => {
     const selectedOption = SEVERITY_DROPDOWN_OPTIONS.find(
-      (option) => option.value === value
+      (option) => option.value === selectedSeverity?.value
     );
     if (selectedOption) {
       setSeverity(selectedOption);
@@ -60,7 +63,13 @@ const SoftwareFiltersModal = ({
   const renderSeverityLabel = () => {
     return (
       <TooltipWrapper
-        tipContent="The worst case impact across different environments (CVSS version 3.x base score)."
+        tipContent={
+          <>
+            The worst case impact across different environments
+            <br />
+            (CVSS version 3.x base score).
+          </>
+        }
         clickable={false}
       >
         Severity
@@ -80,14 +89,15 @@ const SoftwareFiltersModal = ({
           activeText="Vulnerable software"
         />
         {isPremiumTier && (
-          <Dropdown
+          <DropdownWrapper
+            name="severity-filter"
             label={renderSeverityLabel()}
             options={SEVERITY_DROPDOWN_OPTIONS}
             value={severity}
             onChange={onChangeSeverity}
             placeholder="Any severity"
             className={`${baseClass}__select-severity`}
-            disabled={!vulnSoftwareFilterEnabled}
+            isDisabled={!vulnSoftwareFilterEnabled}
           />
         )}
         {isPremiumTier && (

--- a/frontend/pages/admin/IntegrationsPage/cards/Integrations/components/AddIntegrationModal/AddIntegrationModal.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/Integrations/components/AddIntegrationModal/AddIntegrationModal.tsx
@@ -1,8 +1,9 @@
 import React, { useState, useEffect } from "react";
 
 import Modal from "components/Modal";
-// @ts-ignore
-import Dropdown from "components/forms/fields/Dropdown";
+import { SingleValue } from "react-select-5";
+import DropdownWrapper from "components/forms/fields/DropdownWrapper";
+import { CustomOptionType } from "components/forms/fields/DropdownWrapper/DropdownWrapper";
 import CustomLink from "components/CustomLink";
 import { IIntegration, IZendeskJiraIntegrations } from "interfaces/integration";
 import IntegrationForm from "../IntegrationForm";
@@ -38,8 +39,10 @@ const AddIntegrationModal = ({
   );
   const [destination, setDestination] = useState("jira");
 
-  const onDestinationChange = (value: string) => {
-    setDestination(value);
+  const onDestinationChange = (
+    selectedDestination: SingleValue<CustomOptionType>
+  ) => {
+    setDestination(selectedDestination?.value || "jira");
   };
 
   useEffect(() => {
@@ -51,14 +54,14 @@ const AddIntegrationModal = ({
       <div className="form">
         {!testingConnection && (
           <>
-            <Dropdown
-              label="Ticket destination"
+            <DropdownWrapper
               name="destination"
+              label="Ticket destination"
               onChange={onDestinationChange}
               value={destination}
               options={destinationOptions}
-              classname={`${baseClass}__destination-dropdown`}
-              wrapperClassName={`${baseClass}__form-field ${baseClass}__form-field--platform`}
+              className={`${baseClass}__destination-dropdown`}
+              wrapperClassname={`${baseClass}__form-field ${baseClass}__form-field--platform`}
             />
             <CustomLink
               url="https://github.com/fleetdm/fleet/issues/new?assignees=&labels=idea&template=feature-request.md&title="

--- a/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/AppleBusinessManagerPage/components/EditTeamsAbmModal/EditTeamsAbmModal.tests.ts
+++ b/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/AppleBusinessManagerPage/components/EditTeamsAbmModal/EditTeamsAbmModal.tests.ts
@@ -1,5 +1,5 @@
 import {
-  APP_CONTEX_NO_TEAM_SUMMARY,
+  APP_CONTEXT_NO_TEAM_SUMMARY,
   APP_CONTEXT_ALL_TEAMS_SUMMARY,
 } from "interfaces/team";
 import { getOptions, getSelectedTeamIds } from "./EditTeamsAbmModal";
@@ -7,7 +7,7 @@ import { getOptions, getSelectedTeamIds } from "./EditTeamsAbmModal";
 describe("EditTeamsAbmModal", () => {
   const availableTeams = [
     APP_CONTEXT_ALL_TEAMS_SUMMARY,
-    APP_CONTEX_NO_TEAM_SUMMARY,
+    APP_CONTEXT_NO_TEAM_SUMMARY,
     { name: "Team 1", id: 1 },
     { name: "Team 2", id: 2 },
   ];

--- a/frontend/pages/admin/UserManagementPage/components/UsersTable/UsersTableConfig.tsx
+++ b/frontend/pages/admin/UserManagementPage/components/UsersTable/UsersTableConfig.tsx
@@ -207,6 +207,7 @@ const generateTableHeaders = (
             actionSelectHandler(value, cellProps.row.original)
           }
           placeholder="Actions"
+          menuAlign="right"
         />
       ),
     },

--- a/frontend/pages/hosts/ManageHostsPage/components/LabelFilterSelect/_styles.scss
+++ b/frontend/pages/hosts/ManageHostsPage/components/LabelFilterSelect/_styles.scss
@@ -108,9 +108,14 @@
       cursor: pointer;
     }
 
-    &--is-selected,
-    &:active {
-      background-color: $ui-vibrant-blue-25;
+    &--is-selected {
+      > span {
+        font-weight: $bold;
+      }
+
+      &:active {
+        background-color: $ui-vibrant-blue-25;
+      }
     }
 
     &--is-focused {

--- a/frontend/pages/hosts/ManageHostsPage/components/LabelFilterSelect/_styles.scss
+++ b/frontend/pages/hosts/ManageHostsPage/components/LabelFilterSelect/_styles.scss
@@ -110,8 +110,13 @@
     }
 
     &--is-selected {
-      font-weight: $bold;
       background-color: transparent;
+
+      .option-label {
+        span {
+          font-weight: $bold;
+        }
+      }
     }
 
     &--is-focused {

--- a/frontend/pages/hosts/ManageHostsPage/components/LabelFilterSelect/_styles.scss
+++ b/frontend/pages/hosts/ManageHostsPage/components/LabelFilterSelect/_styles.scss
@@ -103,23 +103,23 @@
 
   .label-filter-select__option {
     padding: 10px 1rem;
+    border-radius: $border-radius;
 
     &:hover {
       cursor: pointer;
     }
 
     &--is-selected {
-      > span {
-        font-weight: $bold;
-      }
-
-      &:active {
-        background-color: $ui-vibrant-blue-25;
-      }
+      font-weight: $bold;
+      background-color: transparent;
     }
 
     &--is-focused {
       background-color: $ui-vibrant-blue-10;
+
+      &:active {
+        background-color: $ui-vibrant-blue-25;
+      }
     }
 
     &--is-disabled {

--- a/frontend/styles/var/colors.ts
+++ b/frontend/styles/var/colors.ts
@@ -3,10 +3,11 @@ export type Colors = keyof typeof COLORS;
 export const COLORS = {
   // core colors
   "core-fleet-black": "#192147",
-  "core-fleet-blue": "#6A67FE", // TODO: Why does this match ui-vibrant-blue and not core-fleet-blue
+  "core-fleet-blue": "#3e4771",
   "core-fleet-red": "#FF5C83",
   "core-fleet-purple": "#AE6DDF",
   "core-fleet-white": "#FFFFFF",
+  "core-vibrant-blue": "#6a67fe",
 
   // ui colors
   "ui-fleet-black-75": "#515774",

--- a/frontend/styles/var/colors.ts
+++ b/frontend/styles/var/colors.ts
@@ -3,11 +3,10 @@ export type Colors = keyof typeof COLORS;
 export const COLORS = {
   // core colors
   "core-fleet-black": "#192147",
-  "core-fleet-blue": "#3e4771",
+  "core-fleet-blue": "#6A67FE", // TODO: lots of work to correctly match scss core-fleet-blue and not ui-vibrant-blue
   "core-fleet-red": "#FF5C83",
   "core-fleet-purple": "#AE6DDF",
   "core-fleet-white": "#FFFFFF",
-  "core-vibrant-blue": "#6a67fe",
 
   // ui colors
   "ui-fleet-black-75": "#515774",


### PR DESCRIPTION
## Issue
For #25257 

## Description
- Selected options are **bold**
- Focused options only are highlighted (so selected option starts highlighted since it's focused, and then isn't highlighted when another option is in focus)
- Add rounded border to dropdown options

## Other code cleanup
- fix typo `APP_CONTEX_NO_TEAM_SUMMARY`
- update several type `any` with the proper type
- replace one helptext scss with `help-text` mixin
- replace a lot of border-radius: 4px with the `border-radius` mixin
- convert a few low hanging fruit `<Dropdown/>` using react-select 1.3.0 to `<DropdownWrapper/>` using react-select 5.4.0 (in an ideal world I'd have time to convert all of them)
- Fix 1 awkwardly wide tooltip (on a label of a dropdown I updated)

## Screenrecording of example fixes

https://github.com/user-attachments/assets/c959d5cc-c041-4951-90ad-d503b5c04230



# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
- [x] A detailed QA plan exists on the associated ticket (if it isn't there, work with the product group's QA engineer to add it)
- [x] Manual QA for all new/changed functionality

