### PR TITLE
Fix incorrect source in device mapping REST API docs

### DIFF
--- a/changes/25640-fix-idp-source
+++ b/changes/25640-fix-idp-source
@@ -1,0 +1,1 @@
+- Fixes incorrect source value in device mapping REST API documentation

--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -3468,7 +3468,7 @@ Note that IdP email is only supported on macOS hosts. It's collected once, durin
   "device_mapping": [
     {
       "email": "user@example.com",
-      "source": "identity_provider"
+      "source": "mdm_idp_accounts"
     },
     {
       "email": "user@example.com",
@@ -3519,7 +3519,7 @@ Updates the email for the `custom` data source in the human-device mapping. This
   "device_mapping": [
     {
       "email": "user@example.com",
-      "source": "identity_provider"
+      "source": "mdm_idp_accounts"
     },
     {
       "email": "user@example.com",


### PR DESCRIPTION
### Summary

This PR closes #25640 by fixing the incorrect `source` value in the device mapping REST API docs.

The real value is `mdm_idp_accounts` which can be found [here](https://github.com/fleetdm/fleet/blob/15ac79323858c7344677edd5eb01b9a0d548120f/server/fleet/hosts.go#L894). 

### Test Plan

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/Committing-Changes.md#changes-files) for more information.

I couldn't find any other references to `identity_provider`, so I think these two were all of them.