### PR TITLE
Fleet UI: Tooltip position bottom

### DIFF
--- a/frontend/pages/ManageControlsPage/SetupExperience/cards/InstallSoftware/components/AddInstallSoftware/AddInstallSoftware.tsx
+++ b/frontend/pages/ManageControlsPage/SetupExperience/cards/InstallSoftware/components/AddInstallSoftware/AddInstallSoftware.tsx
@@ -53,7 +53,7 @@ const AddInstallSoftware = ({
     ) : (
       <>
         {installDuringSetupCount} software will be{" "}
-        <TooltipWrapper position="top" tipContent="Software order will vary.">
+        <TooltipWrapper tipContent="Software order will vary.">
           installed during setup
         </TooltipWrapper>
         .


### PR DESCRIPTION
## Issue
For #25519 

## Description
- Tooltips without arrows always show up on the bottom of the underline text

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] A detailed QA plan exists on the associated ticket (if it isn't there, work with the product group's QA engineer to add it)
- [x] Manual QA for all new/changed functionality

