### PR TITLE
Fleet UI: Update FMA API errors in UI

### DIFF
--- a/changes/23096-fma-errors
+++ b/changes/23096-fma-errors
@@ -1,1 +1,1 @@
-- Fleet UI: Surface cleaner errors for errors adding fleet maintained app
+- Fleet UI: Surfaced cleaner errors when adding Fleet-maintained apps

--- a/changes/23096-fma-errors
+++ b/changes/23096-fma-errors
@@ -1,0 +1,1 @@
+- Fleet UI: Surface cleaner errors for errors adding fleet maintained app

--- a/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareFleetMaintained/FleetMaintainedAppDetailsPage/FleetMaintainedAppDetailsPage.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareFleetMaintained/FleetMaintainedAppDetailsPage/FleetMaintainedAppDetailsPage.tsx
@@ -40,6 +40,12 @@ import {
   getFleetAppPolicyQuery,
 } from "./helpers";
 
+const DEFAULT_ERROR_MESSAGE = "Couldn't add. Please try again.";
+const REQUEST_TIMEOUT_ERROR_MESSAGE =
+  "Couldn't upload. Request timeout. Please make sure your server and load balancer timeout is long enough.";
+const AUTOMATIC_POLICY_ERROR_MESSAGE =
+  "Couldn't add automatic install policy. Software is successfully added. To retry, delete software and add it again.";
+
 const baseClass = "fleet-maintained-app-details-page";
 
 interface ISoftwareSummaryProps {
@@ -199,17 +205,20 @@ const FleetMaintainedAppDetailsPage = ({
       // creation.
 
       const ae = (typeof error === "object" ? error : {}) as AxiosResponse;
+
+      const errorMessage = getErrorMessage(ae);
+
       if (
         ae.status === 408 ||
-        getErrorMessage(error).includes("json decoder error") // 400 bad request when really slow
+        errorMessage.includes("json decoder error") // 400 bad request when really slow
       ) {
-        renderFlash(
-          "error",
-          "Couldn't upload. Request timeout. Please make sure your server and load balancer timeout is long enough."
-        );
+        renderFlash("error", REQUEST_TIMEOUT_ERROR_MESSAGE);
+      } else if (errorMessage) {
+        renderFlash("error", errorMessage);
       } else {
-        renderFlash("error", "Couldn't add. Please try again.");
+        renderFlash("error", DEFAULT_ERROR_MESSAGE);
       }
+
       setShowAddFleetAppSoftwareModal(false);
       return;
     }
@@ -234,11 +243,9 @@ const FleetMaintainedAppDetailsPage = ({
           { persistOnPageChange: true }
         );
       } catch (e) {
-        renderFlash(
-          "error",
-          "Couldn't add automatic install policy. Software is successfully added. To retry, delete software and add it again.",
-          { persistOnPageChange: true }
-        );
+        renderFlash("error", AUTOMATIC_POLICY_ERROR_MESSAGE, {
+          persistOnPageChange: true,
+        });
       }
 
       // for automatic install we redirect on both a successful and error policy

--- a/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareFleetMaintained/FleetMaintainedAppDetailsPage/FleetMaintainedAppDetailsPage.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareFleetMaintained/FleetMaintainedAppDetailsPage/FleetMaintainedAppDetailsPage.tsx
@@ -201,7 +201,6 @@ const FleetMaintainedAppDetailsPage = ({
       const ae = (typeof error === "object" ? error : {}) as AxiosResponse;
       if (
         ae.status === 408 ||
-        ae.status === 500 ||
         getErrorMessage(error).includes("json decoder error") // 400 bad request when really slow
       ) {
         renderFlash(

--- a/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareFleetMaintained/FleetMaintainedAppDetailsPage/FleetMaintainedAppDetailsPage.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareFleetMaintained/FleetMaintainedAppDetailsPage/FleetMaintainedAppDetailsPage.tsx
@@ -1,4 +1,5 @@
 import React, { useContext, useState } from "react";
+import { AxiosResponse } from "axios";
 import { Location } from "history";
 import { useQuery } from "react-query";
 import { InjectedRouter } from "react-router";
@@ -196,7 +197,20 @@ const FleetMaintainedAppDetailsPage = ({
     } catch (error) {
       // quick exit if there was an error adding the software. Skip the policy
       // creation.
-      renderFlash("error", getErrorMessage(error));
+
+      const ae = (typeof error === "object" ? error : {}) as AxiosResponse;
+      if (
+        ae.status === 408 ||
+        ae.status === 500 ||
+        getErrorMessage(error).includes("json decoder error") // 400 bad request when really slow
+      ) {
+        renderFlash(
+          "error",
+          "Couldn't upload. Request timeout. Please make sure your server and load balancer timeout is long enough."
+        );
+      } else {
+        renderFlash("error", "Couldn't add. Please try again.");
+      }
       setShowAddFleetAppSoftwareModal(false);
       return;
     }


### PR DESCRIPTION
## Issue
For #23096 

## Description
- Render errors provided by original Figma for this section
  - If connection is too slow (error 408 or "json decoder error") render default time out error
  - Else if render error provided by API
  - If no error provided by API, render generic error

## Screenshots of fixes
<img width="1051" alt="Screenshot 2025-01-21 at 4 44 29 PM" src="https://github.com/user-attachments/assets/de761127-2a27-4224-b771-238ae9190262" />
<img width="1325" alt="Screenshot 2025-01-21 at 4 44 12 PM" src="https://github.com/user-attachments/assets/3f78c1b5-0bb3-4cab-b6f9-7d5b60c4d18e" />


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
- [ ] A detailed QA plan exists on the associated ticket (if it isn't there, work with the product group's QA engineer to add it)
- [x] Manual QA for all new/changed functionality
