### PR TITLE
Cherry-Pick: Map product/vendor for homebrew "pass" package, skip "jira" python package as it has no CVEs

### DIFF
--- a/changes/25597-false-positives
+++ b/changes/25597-false-positives
@@ -1,0 +1,1 @@
+* Resolved false-positives for the `pass` Homebrew package and `jira` Python package via a vulnerability feed update available to all Fleet versions on 2025-01-22

--- a/server/vulnerabilities/nvd/cpe_test.go
+++ b/server/vulnerabilities/nvd/cpe_test.go
@@ -1314,6 +1314,14 @@ func TestCPEFromSoftwareIntegration(t *testing.T) {
 				Version: "6.0.1",
 			}, cpe: "",
 		},
+		// 2025-01-20: there are no entries for the jira python package at the NVD dataset.
+		{
+			software: fleet.Software{
+				Name:    "jira",
+				Source:  "python_packages",
+				Version: "3.8.0",
+			}, cpe: "",
+		},
 		{ // checks vendor/product matching based on bundle name, including EAPs
 			software: fleet.Software{
 				Name:             "GoLand EAP.app",
@@ -1690,6 +1698,15 @@ func TestCPEFromSoftwareIntegration(t *testing.T) {
 				Vendor:           "",
 				BundleIdentifier: "",
 			}, cpe: "cpe:2.3:a:github:cli:2.61.0:*:*:*:*:macos:*:*",
+		},
+		{
+			software: fleet.Software{
+				Name:             "pass",
+				Source:           "homebrew_packages",
+				Version:          "1.7.4",
+				Vendor:           "",
+				BundleIdentifier: "",
+			}, cpe: "cpe:2.3:a:simple_password_store_project:simple_password_store:1.7.4:*:*:*:*:macos:*:*",
 		},
 	}
 

--- a/server/vulnerabilities/nvd/cpe_translations.json
+++ b/server/vulnerabilities/nvd/cpe_translations.json
@@ -12,6 +12,16 @@
   },
   {
     "software": {
+      "name": ["pass"],
+      "source": ["homebrew_packages"]
+    },
+    "filter": {
+      "product": ["simple_password_store"],
+      "vendor": ["simple_password_store_project"]
+    }
+  },
+  {
+    "software": {
       "name": ["/^ruby(@.*)?$/"],
       "source": ["homebrew_packages"]
     },
@@ -90,6 +100,15 @@
     "filter": {
       "product": ["docker_desktop"],
       "vendor": ["docker"]
+    }
+  },
+  {
+    "software": {
+      "name": ["jira"],
+      "source": ["python_packages"]
+    },
+    "filter": {
+      "skip": true
     }
   },
   {

--- a/server/vulnerabilities/nvd/cve_test.go
+++ b/server/vulnerabilities/nvd/cve_test.go
@@ -378,6 +378,9 @@ func TestTranslateCPEToCVE(t *testing.T) {
 		"cpe:2.3:a:iterm2:iterm2:3.5.2:*:*:*:*:*:*:*": {
 			includedCVEs: []cve{{ID: "CVE-2024-38395", resolvedInVersion: ""}},
 		},
+		"cpe:2.3:a:simple_password_store_project:simple_password_store:1.7.0:*:*:*:*:macos:*:*": {
+			includedCVEs: []cve{{ID: "CVE-2018-12356", resolvedInVersion: "1.7.2"}},
+		},
 	}
 
 	cveOSTests := []struct {


### PR DESCRIPTION
Merged into `main` in #25626. PR'd here to pick up the changelog.