### PR TITLE
Utilize custom SMTP domain if set

### DIFF
--- a/changes/25241-smtp-helo-domain
+++ b/changes/25241-smtp-helo-domain
@@ -1,0 +1,1 @@
+- Fixed mail being sent with the incorrect SMTP Domain (thank you mccormickt)

--- a/server/mail/mail.go
+++ b/server/mail/mail.go
@@ -198,6 +198,11 @@ func (m mailService) sendMail(e fleet.Email, msg []byte) error {
 	}
 	defer client.Close()
 
+	if e.SMTPSettings.SMTPDomain != "" {
+		if err = client.Hello(e.SMTPSettings.SMTPDomain); err != nil {
+			return fmt.Errorf("client hello error: %w", err)
+		}
+	}
 	if e.SMTPSettings.SMTPEnableStartTLS {
 		if ok, _ := client.Extension("STARTTLS"); ok {
 			if err = client.StartTLS(tlsConfig); err != nil {

--- a/server/mail/mail_test.go
+++ b/server/mail/mail_test.go
@@ -1,13 +1,18 @@
 package mail
 
 import (
+	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/fleetdm/fleet/v4/server/config"
 	"github.com/fleetdm/fleet/v4/server/fleet"
 	"github.com/fleetdm/fleet/v4/server/test"
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -50,6 +55,7 @@ func TestMail(t *testing.T) {
 	}
 
 	for _, f := range testFunctions {
+
 		r, err := NewService(config.TestConfig())
 		require.NoError(t, err)
 
@@ -161,19 +167,24 @@ func testSMTPNoAuthWithTLS(t *testing.T, mailer fleet.MailService) {
 }
 
 func testSMTPDomain(t *testing.T, mailer fleet.MailService) {
+	randomAddress := uuid.NewString() + "@example.com"
+
 	mail := fleet.Email{
 		Subject: "custom client hello",
 		To:      []string{"bob@foo.com"},
 		SMTPSettings: fleet.SMTPSettings{
-			SMTPConfigured:         true,
-			SMTPAuthenticationType: fleet.AuthTypeNameNone,
-			SMTPEnableTLS:          false,
-			SMTPVerifySSLCerts:     false,
-			SMTPEnableStartTLS:     false,
-			SMTPPort:               1027,
-			SMTPServer:             "localhost",
-			SMTPDomain:             "foo.com",
-			SMTPSenderAddress:      "test@example.com",
+			SMTPConfigured:           true,
+			SMTPAuthenticationType:   fleet.AuthTypeNameUserNamePassword,
+			SMTPAuthenticationMethod: fleet.AuthMethodNamePlain,
+			SMTPUserName:             "mailpit-username",
+			SMTPPassword:             "mailpit-password",
+			SMTPEnableTLS:            false,
+			SMTPVerifySSLCerts:       false,
+			SMTPEnableStartTLS:       false,
+			SMTPPort:                 1026,
+			SMTPServer:               "localhost",
+			SMTPDomain:               "custom.domain.example.com",
+			SMTPSenderAddress:        randomAddress,
 		},
 		Mailer: &SMTPTestMailer{
 			BaseURL: "https://localhost:8080",
@@ -183,6 +194,54 @@ func testSMTPDomain(t *testing.T, mailer fleet.MailService) {
 	err := mailer.SendEmail(mail)
 	assert.Nil(t, err)
 
+	rawMsg := getLastRawMailpitMessageFrom(t, randomAddress)
+
+	require.Contains(t, rawMsg, "Received: from custom.domain.example.com")
+}
+
+// Only what we need for the current test. If you need more, fill the struct out.
+// https://mailpit.axllent.org/docs/api-v1/view.html#get-/api/v1/messages
+type MailpitMessages struct {
+	Messages []struct {
+		Created time.Time
+		From    struct {
+			Address string `json:"Address"`
+			Name    string `json:"Name"`
+		}
+		ID string `json:"ID"`
+		To []struct {
+			Address string `json:"Address"`
+			Name    string `json:"Name"`
+		} `json:"To"`
+		BCC []struct {
+			Address string `json:"Address"`
+			Name    string `json:"Name"`
+		} `json:"Bcc"`
+	} `json:"messages"`
+}
+
+func getLastRawMailpitMessageFrom(t *testing.T, address string) string {
+	res, err := http.Get("http://127.0.0.1:8026/api/v1/messages")
+	require.NoError(t, err)
+
+	var messages MailpitMessages
+	err = json.NewDecoder(res.Body).Decode(&messages)
+	require.NoError(t, err)
+
+	var messageID string
+	for _, message := range messages.Messages {
+		if message.From.Address == address {
+			messageID = message.ID
+		}
+	}
+	require.NotNilf(t, messageID, "could not find message from %s in mailpit", address)
+
+	res, err = http.Get(fmt.Sprintf("http://127.0.0.1:8026/api/v1/message/%s/raw", messageID))
+
+	rawMail, err := io.ReadAll(res.Body)
+	require.NoError(t, err)
+
+	return string(rawMail)
 }
 
 func testMailTest(t *testing.T, mailer fleet.MailService) {

--- a/server/mail/mail_test.go
+++ b/server/mail/mail_test.go
@@ -237,6 +237,7 @@ func getLastRawMailpitMessageFrom(t *testing.T, address string) string {
 	require.NotNilf(t, messageID, "could not find message from %s in mailpit", address)
 
 	res, err = http.Get(fmt.Sprintf("http://127.0.0.1:8026/api/v1/message/%s/raw", messageID))
+	require.NoError(t, err)
 
 	rawMail, err := io.ReadAll(res.Body)
 	require.NoError(t, err)

--- a/server/mail/mail_test.go
+++ b/server/mail/mail_test.go
@@ -55,7 +55,6 @@ func TestMail(t *testing.T) {
 	}
 
 	for _, f := range testFunctions {
-
 		r, err := NewService(config.TestConfig())
 		require.NoError(t, err)
 

--- a/server/mail/mail_test.go
+++ b/server/mail/mail_test.go
@@ -17,6 +17,7 @@ var testFunctions = [...]func(*testing.T, fleet.MailService){
 	testSMTPPlainAuthInvalidCreds,
 	testSMTPSkipVerify,
 	testSMTPNoAuthWithTLS,
+	testSMTPDomain,
 	testMailTest,
 }
 
@@ -157,6 +158,31 @@ func testSMTPNoAuthWithTLS(t *testing.T, mailer fleet.MailService) {
 
 	err := mailer.SendEmail(mail)
 	assert.Nil(t, err)
+}
+
+func testSMTPDomain(t *testing.T, mailer fleet.MailService) {
+	mail := fleet.Email{
+		Subject: "custom client hello",
+		To:      []string{"bob@foo.com"},
+		SMTPSettings: fleet.SMTPSettings{
+			SMTPConfigured:         true,
+			SMTPAuthenticationType: fleet.AuthTypeNameNone,
+			SMTPEnableTLS:          false,
+			SMTPVerifySSLCerts:     false,
+			SMTPEnableStartTLS:     false,
+			SMTPPort:               1027,
+			SMTPServer:             "localhost",
+			SMTPDomain:             "foo.com",
+			SMTPSenderAddress:      "test@example.com",
+		},
+		Mailer: &SMTPTestMailer{
+			BaseURL: "https://localhost:8080",
+		},
+	}
+
+	err := mailer.SendEmail(mail)
+	assert.Nil(t, err)
+
 }
 
 func testMailTest(t *testing.T, mailer fleet.MailService) {


### PR DESCRIPTION
#25241

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/Committing-Changes.md#changes-files) for more information.
- [x] Added/updated automated tests
- [x] Manual QA for all new/changed functionality
- [x] A detailed QA plan exists on the associated ticket (if it isn't there, work with the product group's QA engineer to add it)

  For this I used the unauthenticated SMTP test server part of the docker compose environment. (http://localhost:8025/)
  - Setup SMTP in the org settings (note, the port is 1025)

![image](https://github.com/user-attachments/assets/2d024c8f-3b1e-4348-9025-d40d802d876a)

  - Setup the custom SMTP domain name in Advanced settings (maybe this should be next to the other mail settings?)
![image](https://github.com/user-attachments/assets/9af8c57a-cfa3-4fdc-b269-e88c327341c8)

  - Open the mailhog web UI (http://localhost:8025/)
  - Click the message you just got
  - Click the "Source" tab on the message
  - Look for the `Received: from` line, it should contain your custom domain
 
![image](https://github.com/user-attachments/assets/069236bc-8638-45f2-abdb-d17a7b1727ef)
