### PR TITLE
Updated policies and software installs

### DIFF
--- a/it-and-security/lib/linux/software/slack-deb.yml
+++ b/it-and-security/lib/linux/software/slack-deb.yml
@@ -1,4 +1,4 @@
 url: https://downloads.slack-edge.com/desktop-releases/linux/x64/4.41.105/slack-desktop-4.41.105-amd64.deb
 self-service: true
-pre_install_query:
-  path: ../queries/all-deb-hosts.yml
+labels_include_any:
+  - "Debian-based Linux hosts"

--- a/it-and-security/lib/linux/software/slack-rpm.yml
+++ b/it-and-security/lib/linux/software/slack-rpm.yml
@@ -1,4 +1,4 @@
 url: https://downloads.slack-edge.com/desktop-releases/linux/x64/4.41.105/slack-4.41.105-0.1.el8.x86_64.rpm
 self-service: true
-pre_install_query:
-  path: ../queries/all-rpm-hosts.yml
+labels_include_any:
+  - "RPM-based Linux hosts"

--- a/it-and-security/lib/linux/software/zoom-deb.yml
+++ b/it-and-security/lib/linux/software/zoom-deb.yml
@@ -1,4 +1,4 @@
 url: https://zoom.us/client/6.2.11.5069/zoom_amd64.deb
 self-service: true
-pre_install_query:
-  path: ../queries/all-deb-hosts.yml
+labels_include_any:
+  - "Debian-based Linux hosts"

--- a/it-and-security/lib/linux/software/zoom-rpm.yml
+++ b/it-and-security/lib/linux/software/zoom-rpm.yml
@@ -1,4 +1,4 @@
 url: https://zoom.us/client/6.3.0.5527/zoom_x86_64.rpm
 self-service: true
-pre_install_query:
-  path: ../queries/all-rpm-hosts.yml
+labels_include_any:
+  - "RPM-based Linux hosts"

--- a/it-and-security/lib/macos/policies/latest-macos.yml
+++ b/it-and-security/lib/macos/policies/latest-macos.yml
@@ -1,0 +1,8 @@
+- name: macOS - Operating system up to date
+  query: SELECT 1 FROM os_version WHERE version >= '15.2';
+  critical: true
+  description: Using an outdated macOS version risks exposure to security vulnerabilities and potential system instability.
+  resolution: Please find time to run Software Update.  > System Settings > Software Update
+  platform: darwin
+  calendar_events_enabled: false
+  

--- a/it-and-security/lib/macos/policies/update-firefox.yml
+++ b/it-and-security/lib/macos/policies/update-firefox.yml
@@ -1,0 +1,6 @@
+- name: macOS - Update Firefox
+  query: SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE name = 'Firefox.app') OR EXISTS (SELECT 1 FROM apps WHERE name = 'Firefox.app' AND version_compare(bundle_short_version, '134.0.2') >= 0);
+  critical: false
+  description: The host may have an outdated or non-existent version of Firefox, potentially risking security vulnerabilities or compatibility issues.
+  resolution: Download the latest version from self-service or check for updates using Firefox's built-in update functionality.
+  platform: darwin

--- a/it-and-security/lib/macos/policies/update-slack.yml
+++ b/it-and-security/lib/macos/policies/update-slack.yml
@@ -1,0 +1,7 @@
+- name: macOS - Update Slack
+  query: SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE name = 'Slack.app') OR EXISTS (SELECT 1 FROM apps WHERE name = 'Slack.app' AND version_compare(bundle_short_version, '4.42.116') >= 0);
+  critical: false
+  description: The host may be running an outdated version of Slack, which could pose security vulnerabilities or compatibility issues.
+  resolution: Slack can be updated by downloading the latest version from the App Store or by using Slack's built-in update functionality.
+  platform: darwin
+  calendar_events_enabled: false

--- a/it-and-security/lib/macos/policies/upgrade-firefox.yml
+++ b/it-and-security/lib/macos/policies/upgrade-firefox.yml
@@ -1,8 +1,0 @@
-- name: macOS - Upgrade Firefox
-  query: SELECT 1 FROM apps WHERE name = 'Firefox.app' AND version_compare(bundle_short_version, '132.0.0') >= 0;
-  critical: false
-  description: The host may have an outdated or non-existent version of Firefox, potentially risking security vulnerabilities or compatibility issues.
-  resolution: During maintenance, the Firefox app could be updated to the correct version or installed if it's missing.
-  platform: darwin
-  install_software:
-    package_path: "../software/mozilla-firefox.yml"

--- a/it-and-security/lib/macos/software/mozilla-firefox.yml
+++ b/it-and-security/lib/macos/software/mozilla-firefox.yml
@@ -1,2 +1,2 @@
-url: https://download-installer.cdn.mozilla.net/pub/firefox/releases/132.0.2/mac/en-US/Firefox%20132.0.2.pkg
+url: https://download-installer.cdn.mozilla.net/pub/firefox/releases/134.0.2/mac/en-US/Firefox%20134.0.2.pkg
 self_service: true

--- a/it-and-security/teams/workstations-canary.yml
+++ b/it-and-security/teams/workstations-canary.yml
@@ -122,30 +122,11 @@ controls:
     - path: ../lib/windows/scripts/enable-ms-defender.ps1
 policies:
   - path: ../lib/macos/policies/device-health.yml
-  - path: ../lib/macos/policies/upgrade-firefox.yml
+  - path: ../lib/macos/policies/update-firefox.yml
+  - path: ../lib/macos/policies/update-slack.yml
+  - path: ../lib/macos/policies/latest-macos.yml
   - path: ../lib/windows/policies/device-health.yml
   - path: ../lib/linux/policies/linux-device-health.yml
-  - name: macOS - Check if latest version
-    query: SELECT 1 FROM os_version WHERE (major = '15' AND minor = '1' AND patch = '1');
-    critical: true
-    description: Using an outdated macOS version risks exposure to security vulnerabilities and potential system instability.
-    resolution: We will update your macOS to the latest version.
-    platform: darwin
-    calendar_events_enabled: false
-  - name: macOS - System maintenance complete
-    query: SELECT 1 AS result FROM system_info WHERE computer_name NOT IN ('Drew’s MacBook Pro','Anthony’s MacBook Pro','Patricia’s MacBook Pro','Paul’s MacBook Pro','Tom’s MacBook Air');
-    critical: false
-    description: Determines if the device has completed system maintenance.
-    resolution: We will perform system maintenance on your device.
-    platform: darwin
-    calendar_events_enabled: true
-  - name: macOS - Upgrade Slack
-    query: SELECT 1 FROM apps WHERE name = 'Slack.app' AND version_compare(bundle_short_version, '4.40.126') >= 0;
-    critical: false
-    description: The host may be running an outdated version of Slack, which could pose security vulnerabilities or compatibility issues.
-    resolution: The host's Slack application will likely be updated to a version that is greater than or equal to '4.40.126'.
-    platform: darwin
-    calendar_events_enabled: false
 queries:
   - path: ../lib/macos/queries/collect-failed-login-attempts.yml
   - path: ../lib/all/queries/collect-fleetd-information.yml
@@ -167,4 +148,3 @@ software:
     - path: ../lib/windows/software/google-chrome.yml # Google Chrome for Windows
   app_store_apps:
       - app_store_id: '803453959' # Slack Desktop
-      - app_store_id: '1333542190' # 1Password 7 Desktop

--- a/it-and-security/teams/workstations.yml
+++ b/it-and-security/teams/workstations.yml
@@ -84,17 +84,12 @@ controls:
     - path: ../lib/windows/scripts/turn-off-mdm.ps1
 policies:
   - path: ../lib/macos/policies/device-health.yml
+  - path: ../lib/macos/policies/update-firefox.yml
   - path: ../lib/macos/policies/cis.yml
+  - path: ../lib/macos/policies/latest-macos.yml
   - path: ../lib/windows/policies/device-health.yml
   - path: ../lib/windows/policies/cis.yml
   - path: ../lib/linux/policies/linux-device-health.yml
-  - name: macOS - Check if latest version
-    query: SELECT 1 FROM os_version WHERE (major = '15' AND minor = '1' AND patch = '1');
-    critical: true
-    description: Using an outdated macOS version risks exposure to security vulnerabilities and potential system instability.
-    resolution: We will update your macOS to the latest version.
-    platform: darwin
-    calendar_events_enabled: false
 queries:
   - path: ../lib/macos/queries/collect-failed-login-attempts.yml
   - path: ../lib/all/queries/collect-usb-devices.yml


### PR DESCRIPTION
- Fixed patch logic and updated version strings in Firefox and Slack policies: fleetdm/confidential#9389
- Implemented custom target scoping for Linux software: fleetdm/confidential#9348
- Updated and consolidated macOS latest operating system check policy
- Copied policies from "💻🐣 Workstations (canary)" to "💻 Workstations" team