### PR TITLE
Typo in gitops yaml file

### DIFF
--- a/docs/Configuration/yaml-files.md
+++ b/docs/Configuration/yaml-files.md
@@ -424,7 +424,7 @@ org_settings:
 
 ### org_info
 
-- `name` is the name of your organization (default: `""`)
+- `org_name` is the name of your organization (default: `""`)
 - `logo_url` is a public URL of the logo for your organization (default: Fleet logo).
 - `org_logo_url_light_background` is a public URL of the logo for your organization that can be used with light backgrounds (default: Fleet logo).
 - `contact_url` is a URL that appears in error messages presented to end users (default: `"https://fleetdm.com/company/contact"`)


### PR DESCRIPTION
Update `name` to proper syntax `org_name`