### PR TITLE
Removed filename from fleet maintained apps response

### DIFF
--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -9553,7 +9553,6 @@ Returns information about the specified Fleet-maintained app.
   "fleet_maintained_app": {
     "id": 1,
     "name": "1Password",
-    "filename": "1Password-8.10.44-aarch64.zip",
     "version": "8.10.40",
     "platform": "darwin",
     "install_script": "#!/bin/sh\ninstaller -pkg \"$INSTALLER_PATH\" -target /",


### PR DESCRIPTION
This field was never implemented

<img width="876" alt="Screenshot 2025-01-21 at 8 33 56 PM" src="https://github.com/user-attachments/assets/8b110375-e2e2-4805-b42b-676a3030e9d8" />
