### PR TITLE
Update label membership by host IDs directly

### DIFF
--- a/changes/25261-identical-hostnames-label-membership
+++ b/changes/25261-identical-hostnames-label-membership
@@ -1,0 +1,2 @@
+- Fixed a bug where adding or removing a host with an identical name to/from a label caused the
+  same action to be performed on other host(s) with the same name as well.

--- a/frontend/components/LiveQuery/TargetsInput/TargetsInput.tsx
+++ b/frontend/components/LiveQuery/TargetsInput/TargetsInput.tsx
@@ -12,7 +12,6 @@ import TableContainer from "components/TableContainer";
 import { ITargestInputHostTableConfig } from "./TargetsInputHostsTableConfig";
 
 interface ITargetsInputProps {
-  tabIndex?: number;
   searchText: string;
   searchResults: IHost[];
   isTargetsLoading: boolean;
@@ -35,7 +34,6 @@ const baseClass = "targets-input";
 const DEFAULT_LABEL = "Target specific hosts";
 
 const TargetsInput = ({
-  tabIndex,
   searchText,
   searchResults,
   isTargetsLoading,
@@ -52,7 +50,7 @@ const TargetsInput = ({
 }: ITargetsInputProps): JSX.Element => {
   const dropdownRef = useRef<HTMLDivElement | null>(null);
   const dropdownHosts =
-    searchResults && pullAllBy(searchResults, targetedHosts, "display_name");
+    searchResults && pullAllBy(searchResults, targetedHosts, "id");
 
   const [isActiveSearch, setIsActiveSearch] = useState(false);
 

--- a/frontend/pages/labels/components/ManualLabelForm/ManualLabelForm.tsx
+++ b/frontend/pages/labels/components/ManualLabelForm/ManualLabelForm.tsx
@@ -71,7 +71,7 @@ const ManualLabelForm = ({
   }, [debounceSearch, searchQuery]);
 
   const {
-    data: hostTargets,
+    data: searchResults,
     isLoading: isLoadingSearchResults,
     isError: isErrorSearchResults,
   } = useQuery<ITargetsSearchResponse, Error, IHost[], ITargetsQueryKey[]>(
@@ -139,7 +139,7 @@ const ManualLabelForm = ({
             selectedHostsTableConifg={selectedHostsTableConfig}
             isTargetsLoading={isLoadingSearchResults || isDebouncing}
             hasFetchError={isErrorSearchResults}
-            searchResults={hostTargets ?? []}
+            searchResults={searchResults ?? []}
             targetedHosts={targetedHosts}
             setSearchText={onChangeSearchQuery}
             handleRowSelect={onHostSelect}

--- a/server/datastore/mysql/labels.go
+++ b/server/datastore/mysql/labels.go
@@ -1053,9 +1053,6 @@ func (ds *Datastore) LabelsByName(ctx context.Context, names []string) (map[stri
 	return result, nil
 }
 
-// AsyncBatchUpdateLabelMembership first clears the label_membership table of all label_id + host_id
-// tuples for the label_id, then inserts the batch of label_id + host_id tuples represented by the [2]uint array.
-
 // AsyncBatchInsertLabelMembership inserts into the label_membership table the
 // batch of label_id + host_id tuples represented by the [2]uint array.
 func (ds *Datastore) AsyncBatchInsertLabelMembership(ctx context.Context, batch [][2]uint) error {

--- a/server/datastore/mysql/labels.go
+++ b/server/datastore/mysql/labels.go
@@ -123,7 +123,7 @@ func batchHostnames(hostnames []string) [][]string {
 	return batches
 }
 
-func (ds *Datastore) UpdateLabelMembershipByHostIds(ctx context.Context, labelID uint, hostIds []uint) (err error) {
+func (ds *Datastore) UpdateLabelMembershipByHostIDs(ctx context.Context, labelID uint, hostIds []uint) (err error) {
 	err = ds.withRetryTxx(ctx, func(tx sqlx.ExtContext) error {
 		// delete all label membership
 		sql := `
@@ -166,7 +166,7 @@ VALUES ` + strings.Join(placeholders, ", ")
 		return nil
 	})
 
-	return ctxerr.Wrap(ctx, err, "UpdateLabelMembershipByHostIds transaction")
+	return ctxerr.Wrap(ctx, err, "UpdateLabelMembershipByHostIDs transaction")
 }
 
 func batchHostIds(hostIds []uint) [][]uint {

--- a/server/datastore/mysql/labels_test.go
+++ b/server/datastore/mysql/labels_test.go
@@ -41,6 +41,27 @@ func TestBatchHostnamesLarge(t *testing.T) {
 	assert.Equal(t, large[200000:230000], batched[4])
 }
 
+func TestBatchHostIdsSmall(t *testing.T) {
+	small := []uint{1, 2, 3}
+	batched := batchHostIds(small)
+	require.Equal(t, 1, len(batched))
+	assert.Equal(t, small, batched[0])
+}
+
+func TestBatchHostIdsLarge(t *testing.T) {
+	large := []uint{}
+	for i := 0; i < 230000; i++ {
+		large = append(large, uint(i))
+	}
+	batched := batchHostIds(large)
+	require.Equal(t, 5, len(batched))
+	assert.Equal(t, large[:50000], batched[0])
+	assert.Equal(t, large[50000:100000], batched[1])
+	assert.Equal(t, large[100000:150000], batched[2])
+	assert.Equal(t, large[150000:200000], batched[3])
+	assert.Equal(t, large[200000:230000], batched[4])
+}
+
 func TestLabels(t *testing.T) {
 	ds := CreateMySQLDS(t)
 
@@ -60,6 +81,7 @@ func TestLabels(t *testing.T) {
 		{"ChangeDetails", testLabelsChangeDetails},
 		{"GetSpec", testLabelsGetSpec},
 		{"ApplySpecsRoundtrip", testLabelsApplySpecsRoundtrip},
+		{"UpdateLabelMembershipByHostIDs", testUpdateLabelMembershipByHostIDs},
 		{"IDsByName", testLabelsIDsByName},
 		{"ByName", testLabelsByName},
 		{"Save", testLabelsSave},
@@ -1743,4 +1765,147 @@ func labelIDFromName(t *testing.T, ds fleet.Datastore, name string) uint {
 		}
 	}
 	return 0
+}
+
+func testUpdateLabelMembershipByHostIDs(t *testing.T, ds *Datastore) {
+	ctx := context.Background()
+	host1, err := ds.NewHost(ctx, &fleet.Host{
+		OsqueryHostID: ptr.String("1"),
+		NodeKey:       ptr.String("1"),
+		UUID:          "1",
+		Hostname:      "foo.local",
+		Platform:      "darwin",
+	})
+	require.NoError(t, err)
+	host2, err := ds.NewHost(ctx, &fleet.Host{
+		OsqueryHostID: ptr.String("2"),
+		NodeKey:       ptr.String("2"),
+		UUID:          "2",
+		Hostname:      "bar.local",
+		Platform:      "windows",
+	})
+	require.NoError(t, err)
+	// hosts 2 and 3 have the same hostname
+	host3, err := ds.NewHost(ctx, &fleet.Host{
+		OsqueryHostID: ptr.String("3"),
+		NodeKey:       ptr.String("3"),
+		UUID:          "3",
+		Hostname:      "bar.local",
+		Platform:      "windows",
+	})
+	require.NoError(t, err)
+
+	label1, err := ds.NewLabel(ctx, &fleet.Label{
+		Name:                "label1",
+		Query:               "",
+		LabelType:           fleet.LabelTypeRegular,
+		LabelMembershipType: fleet.LabelMembershipTypeManual,
+	})
+	require.NoError(t, err)
+
+	// add hosts 1 and 2 to the label
+	err = ds.UpdateLabelMembershipByHostIDs(ctx, label1.ID, []uint{host1.ID, host2.ID})
+	require.NoError(t, err)
+
+	// expect hosts 1 and 2 to be in the label, but not 3
+
+	label, err := ds.GetLabelSpec(ctx, label1.Name)
+	require.NoError(t, err)
+	// label.Hosts contains hostnames
+	require.Len(t, label.Hosts, 2)
+	require.Equal(t, host1.Hostname, label.Hosts[0])
+	require.Equal(t, host2.Hostname, label.Hosts[1])
+
+	labels, err := ds.ListLabelsForHost(ctx, host1.ID)
+	require.NoError(t, err)
+	require.Len(t, labels, 1)
+	require.Equal(t, "label1", labels[0].Name)
+
+	labels, err = ds.ListLabelsForHost(ctx, host2.ID)
+	require.NoError(t, err)
+	require.Len(t, labels, 1)
+	require.Equal(t, "label1", labels[0].Name)
+
+	labels, err = ds.ListLabelsForHost(ctx, host3.ID)
+	require.NoError(t, err)
+	require.Len(t, labels, 0)
+
+	// modify the label to contain hosts 1 and 3, confirm
+	err = ds.UpdateLabelMembershipByHostIDs(ctx, label1.ID, []uint{host1.ID, host3.ID})
+	require.NoError(t, err)
+
+	labels, err = ds.ListLabelsForHost(ctx, host1.ID)
+	require.NoError(t, err)
+	require.Len(t, labels, 1)
+	require.Equal(t, "label1", labels[0].Name)
+
+	labels, err = ds.ListLabelsForHost(ctx, host2.ID)
+	require.NoError(t, err)
+	require.Len(t, labels, 0)
+
+	labels, err = ds.ListLabelsForHost(ctx, host3.ID)
+	require.NoError(t, err)
+	require.Len(t, labels, 1)
+	require.Equal(t, "label1", labels[0].Name)
+
+	// modify the label to contain hosts 2 and 3, confirm
+	err = ds.UpdateLabelMembershipByHostIDs(ctx, label1.ID, []uint{host2.ID, host3.ID})
+	require.NoError(t, err)
+
+	labels, err = ds.ListLabelsForHost(ctx, host1.ID)
+	require.NoError(t, err)
+	require.Len(t, labels, 0)
+
+	labels, err = ds.ListLabelsForHost(ctx, host2.ID)
+	require.NoError(t, err)
+	require.Len(t, labels, 1)
+	require.Equal(t, "label1", labels[0].Name)
+
+	labels, err = ds.ListLabelsForHost(ctx, host3.ID)
+	require.NoError(t, err)
+	require.Len(t, labels, 1)
+	require.Equal(t, "label1", labels[0].Name)
+
+	// modify the label to contain no hosts, confirm
+	err = ds.UpdateLabelMembershipByHostIDs(ctx, label1.ID, []uint{})
+	require.NoError(t, err)
+
+	labels, err = ds.ListLabelsForHost(ctx, host1.ID)
+	require.NoError(t, err)
+	require.Len(t, labels, 0)
+
+	labels, err = ds.ListLabelsForHost(ctx, host2.ID)
+	require.NoError(t, err)
+	require.Len(t, labels, 0)
+
+	labels, err = ds.ListLabelsForHost(ctx, host3.ID)
+	require.NoError(t, err)
+	require.Len(t, labels, 0)
+
+	// modify the label to contain all 3 hosts, confirm
+	err = ds.UpdateLabelMembershipByHostIDs(ctx, label1.ID, []uint{host1.ID, host2.ID, host3.ID})
+	require.NoError(t, err)
+
+	labels, err = ds.ListLabelsForHost(ctx, host1.ID)
+	require.NoError(t, err)
+	require.Len(t, labels, 1)
+	require.Equal(t, "label1", labels[0].Name)
+
+	labels, err = ds.ListLabelsForHost(ctx, host2.ID)
+	require.NoError(t, err)
+	require.Len(t, labels, 1)
+	require.Equal(t, "label1", labels[0].Name)
+
+	labels, err = ds.ListLabelsForHost(ctx, host3.ID)
+	require.NoError(t, err)
+	require.Len(t, labels, 1)
+	require.Equal(t, "label1", labels[0].Name)
+
+	label, err = ds.GetLabelSpec(ctx, label1.Name)
+	require.NoError(t, err)
+	require.Len(t, label.Hosts, 3)
+	require.Equal(t, host1.Hostname, label.Hosts[0])
+	// 2 and 3 have same name
+	require.Equal(t, host2.Hostname, label.Hosts[1])
+	require.Equal(t, host3.Hostname, label.Hosts[2])
 }

--- a/server/datastore/mysql/labels_test.go
+++ b/server/datastore/mysql/labels_test.go
@@ -51,7 +51,7 @@ func TestBatchHostIdsSmall(t *testing.T) {
 func TestBatchHostIdsLarge(t *testing.T) {
 	large := []uint{}
 	for i := 0; i < 230000; i++ {
-		large = append(large, uint(i))
+		large = append(large, uint(i)) //nolint:gosec // dismiss G115
 	}
 	batched := batchHostIds(large)
 	require.Equal(t, 5, len(batched))

--- a/server/fleet/datastore.go
+++ b/server/fleet/datastore.go
@@ -191,7 +191,7 @@ type Datastore interface {
 
 	// UpdateLabelMembershipByHostIDs updates the label membership for the given label ID with host
 	// IDs, applied in batches
-	UpdateLabelMembershipByHostIds(ctx context.Context, labelID uint, hostIds []uint) (err error)
+	UpdateLabelMembershipByHostIDs(ctx context.Context, labelID uint, hostIds []uint) (err error)
 
 	NewLabel(ctx context.Context, Label *Label, opts ...OptionalArg) (*Label, error)
 	// SaveLabel updates the label and returns the label and an array of host IDs

--- a/server/fleet/datastore.go
+++ b/server/fleet/datastore.go
@@ -189,6 +189,10 @@ type Datastore interface {
 	// If a host is already not a member of a label then such label will be ignored.
 	RemoveLabelsFromHost(ctx context.Context, hostID uint, labelIDs []uint) error
 
+	// UpdateLabelMembershipByHostIDs updates the label membership for the given label ID with host
+	// IDs, applied in batches
+	UpdateLabelMembershipByHostIds(ctx context.Context, labelID uint, hostIds []uint) (err error)
+
 	NewLabel(ctx context.Context, Label *Label, opts ...OptionalArg) (*Label, error)
 	// SaveLabel updates the label and returns the label and an array of host IDs
 	// members of this label, or an error.

--- a/server/mock/datastore_mock.go
+++ b/server/mock/datastore_mock.go
@@ -129,6 +129,8 @@ type ListPacksForHostFunc func(ctx context.Context, hid uint) (packs []*fleet.Pa
 
 type ApplyLabelSpecsFunc func(ctx context.Context, specs []*fleet.LabelSpec) error
 
+type UpdateLabelMembershipByHostIDsFunc func(ctx context.Context, labelID uint, hostIDs []uint) (err error)
+
 type GetLabelSpecsFunc func(ctx context.Context) ([]*fleet.LabelSpec, error)
 
 type GetLabelSpecFunc func(ctx context.Context, name string) (*fleet.LabelSpec, error)
@@ -1369,6 +1371,9 @@ type DataStore struct {
 
 	ApplyLabelSpecsFunc        ApplyLabelSpecsFunc
 	ApplyLabelSpecsFuncInvoked bool
+
+	UpdateLabelMembershipByHostIDsFunc				UpdateLabelMembershipByHostIDsFunc
+	UpdateLabelMembershipByHostIDsFuncInvoked bool
 
 	GetLabelSpecsFunc        GetLabelSpecsFunc
 	GetLabelSpecsFuncInvoked bool
@@ -3366,6 +3371,13 @@ func (s *DataStore) ApplyLabelSpecs(ctx context.Context, specs []*fleet.LabelSpe
 	s.ApplyLabelSpecsFuncInvoked = true
 	s.mu.Unlock()
 	return s.ApplyLabelSpecsFunc(ctx, specs)
+}
+
+func (s *DataStore) UpdateLabelMembershipByHostIDs(ctx context.Context, labelID uint, hostIDs []uint) (err error) {
+	s.mu.Lock()
+	s.UpdateLabelMembershipByHostIDsFuncInvoked = true
+	s.mu.Unlock()
+	return s.UpdateLabelMembershipByHostIDsFunc(ctx, labelID, hostIDs)
 }
 
 func (s *DataStore) GetLabelSpecs(ctx context.Context) ([]*fleet.LabelSpec, error) {

--- a/server/service/labels.go
+++ b/server/service/labels.go
@@ -169,7 +169,6 @@ func (svc *Service) ModifyLabel(ctx context.Context, id uint, payload fleet.Modi
 	if label.LabelType == fleet.LabelTypeBuiltIn {
 		return nil, nil, fleet.NewInvalidArgumentError("label_type", fmt.Sprintf("cannot modify built-in label '%s'", label.Name))
 	}
-	originalLabelName := label.Name
 	if payload.Name != nil {
 		// Check if the new name is a reserved label name
 		for name := range fleet.ReservedLabelNames() {
@@ -186,37 +185,20 @@ func (svc *Service) ModifyLabel(ctx context.Context, id uint, payload fleet.Modi
 		return nil, nil, fleet.NewInvalidArgumentError("hosts", "cannot provide a list of hosts for a dynamic label")
 	}
 
-	// if membership type is manual and the Hosts membership is provided, must
-	// use ApplyLabelSpecs (as SaveLabel does not update label memberships),
-	// otherwise SaveLabel works for dynamic membership. Must resolve the host
-	// identifiers to hostname so that ApplySpecs can be used (it expects only
-	// hostnames).
-	if label.LabelMembershipType == fleet.LabelMembershipTypeManual && payload.Hosts != nil {
-		spec := fleet.LabelSpec{
-			Name:                originalLabelName,
-			Description:         label.Description,
-			Query:               label.Query,
-			Platform:            label.Platform,
-			LabelType:           label.LabelType,
-			LabelMembershipType: label.LabelMembershipType,
-		}
-		hostnames, err := svc.ds.HostnamesByIdentifiers(ctx, payload.Hosts)
+	// use SaveLabel to update label info, and UpdateLabelMembershipByHostIds to update membership. Approach using label
+	// names and ApplyLabelSpecs doesn't work for multiple hosts with the same name.
+
+	if payload.Hosts != nil {
+		// get host ids for valid hosts. since this endpoint will contain hosts identified by serial
+		// number, there should be no duplicates
+
+		hostIds, err := svc.ds.HostIDsByIdentifier(ctx, filter, payload.Hosts)
 		if err != nil {
 			return nil, nil, err
 		}
-		spec.Hosts = hostnames
-		// Note: ApplyLabelSpecs cannot update label name since it uses the name as a key.
-		// So, we must handle it later.
-		if err := svc.ds.ApplyLabelSpecs(ctx, []*fleet.LabelSpec{&spec}); err != nil {
+		if err := svc.ds.UpdateLabelMembershipByHostIds(ctx, label.ID, hostIds); err != nil {
 			return nil, nil, err
 		}
-		// If the label name has changed, we must update it.
-		if originalLabelName != label.Name {
-			return svc.ds.SaveLabel(ctx, label, filter)
-		}
-		// Otherwise, simply reload label to get the host counts information
-		ctx = ctxdb.RequirePrimary(ctx, true)
-		return svc.ds.Label(ctx, id, filter)
 	}
 	return svc.ds.SaveLabel(ctx, label, filter)
 }

--- a/server/service/labels.go
+++ b/server/service/labels.go
@@ -185,7 +185,7 @@ func (svc *Service) ModifyLabel(ctx context.Context, id uint, payload fleet.Modi
 		return nil, nil, fleet.NewInvalidArgumentError("hosts", "cannot provide a list of hosts for a dynamic label")
 	}
 
-	// use SaveLabel to update label info, and UpdateLabelMembershipByHostIds to update membership. Approach using label
+	// use SaveLabel to update label info, and UpdateLabelMembershipByHostIDs to update membership. Approach using label
 	// names and ApplyLabelSpecs doesn't work for multiple hosts with the same name.
 
 	if payload.Hosts != nil {
@@ -196,7 +196,7 @@ func (svc *Service) ModifyLabel(ctx context.Context, id uint, payload fleet.Modi
 		if err != nil {
 			return nil, nil, err
 		}
-		if err := svc.ds.UpdateLabelMembershipByHostIds(ctx, label.ID, hostIds); err != nil {
+		if err := svc.ds.UpdateLabelMembershipByHostIDs(ctx, label.ID, hostIds); err != nil {
 			return nil, nil, err
 		}
 	}


### PR DESCRIPTION
## For #25261 

<img width="826" alt="Screenshot 2025-01-23 at 11 07 19 AM" src="https://github.com/user-attachments/assets/3a2f5d75-c0bf-445a-80dc-976914ff434e" />

### [Demo video](https://drive.google.com/file/d/1ZFcrizkZ6zNODnTXjRC1f-Oeght5zOP4/view?usp=sharing)
- [x] Changes file added for user-visible changes in `changes/`, 
- [x] Added/updated automated tests
- [ ] A detailed QA plan exists on the associated ticket (if it isn't there, work with the product group's QA engineer to add it)
- [x] Manual QA for all new/changed functionality