### PR TITLE
Hide manage automations from maintainers

### DIFF
--- a/changes/25346-fix-manage-automations-link-on-dash
+++ b/changes/25346-fix-manage-automations-link-on-dash
@@ -1,0 +1,1 @@
+- Removed erroneous "manage automations" link on dashboard for maintainers

--- a/frontend/pages/DashboardPage/DashboardPage.tsx
+++ b/frontend/pages/DashboardPage/DashboardPage.tsx
@@ -185,7 +185,7 @@ const DashboardPage = ({ router, location }: IDashboardProps): JSX.Element => {
     isGlobalAdmin || isGlobalMaintainer || isTeamAdmin || isTeamMaintainer;
   const canEnrollGlobalHosts = isGlobalAdmin || isGlobalMaintainer;
   const canEditActivityFeedAutomations =
-    (isGlobalAdmin || isGlobalMaintainer) && teamIdForApi === API_ALL_TEAMS_ID;
+    isGlobalAdmin && teamIdForApi === API_ALL_TEAMS_ID;
 
   const { data: config, refetch: refetchConfig } = useQuery<
     IConfig,


### PR DESCRIPTION
for #25346

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/Committing-Changes.md#changes-files) for more information.

This PR removes the "manage automations" link in the activity feed for anyone who isn't an admin.  Previously this link appeared for maintainers as well, but they [don't have permission](https://github.com/fleetdm/fleet/blob/sgress454/23312-update-all-teams-policies-empty-state/articles/role-based-access.md#user-permissions) to manage automations.