### PR TITLE
Edible Scripts Backend

### DIFF
--- a/changes/24602-editable-scripts
+++ b/changes/24602-editable-scripts
@@ -1,0 +1,1 @@
+- Added API endpoint for updating script contents

--- a/server/fleet/activities.go
+++ b/server/fleet/activities.go
@@ -1332,6 +1332,28 @@ func (a ActivityTypeAddedScript) Documentation() (activity, details, detailsExam
 }`
 }
 
+type ActivityTypeUpdatedScript struct {
+	ScriptName string  `json:"script_name"`
+	TeamID     *uint   `json:"team_id"`
+	TeamName   *string `json:"team_name"`
+}
+
+func (a ActivityTypeUpdatedScript) ActivityName() string {
+	return "updated_script"
+}
+
+func (a ActivityTypeUpdatedScript) Documentation() (activity, details, detailsExample string) {
+	return `Generated when a script is updated.`,
+		`This activity contains the following fields:
+- "script_name": Name of the script.
+- "team_id": The ID of the team that the script applies to, ` + "`null`" + ` if it applies to devices that are not in a team.
+- "team_name": The name of the team that the script applies to, ` + "`null`" + ` if it applies to devices that are not in a team.`, `{
+  "script_name": "set-timezones.sh",
+  "team_id": 123,
+  "team_name": "Workstations"
+}`
+}
+
 type ActivityTypeDeletedScript struct {
 	ScriptName string  `json:"script_name"`
 	TeamID     *uint   `json:"team_id"`

--- a/server/fleet/datastore.go
+++ b/server/fleet/datastore.go
@@ -1640,6 +1640,9 @@ type Datastore interface {
 	// NewScript creates a new saved script.
 	NewScript(ctx context.Context, script *Script) (*Script, error)
 
+	// UpdateScriptContents replaces the script contents of a script
+	UpdateScriptContents(ctx context.Context, scriptID uint, scriptContents string) (*Script, error)
+
 	// Script returns the saved script corresponding to id.
 	Script(ctx context.Context, id uint) (*Script, error)
 

--- a/server/fleet/service.go
+++ b/server/fleet/service.go
@@ -1123,6 +1123,9 @@ type Service interface {
 	// io.Reader r.
 	NewScript(ctx context.Context, teamID *uint, name string, r io.Reader) (*Script, error)
 
+	// UpdateScript updates a saved script with the contents of io.Reader r
+	UpdateScript(ctx context.Context, scriptID uint, r io.Reader) (*Script, error)
+
 	// DeleteScript deletes an existing (saved) script.
 	DeleteScript(ctx context.Context, scriptID uint) error
 

--- a/server/mock/datastore_mock.go
+++ b/server/mock/datastore_mock.go
@@ -1047,6 +1047,8 @@ type ListPendingHostScriptExecutionsFunc func(ctx context.Context, hostID uint, 
 
 type NewScriptFunc func(ctx context.Context, script *fleet.Script) (*fleet.Script, error)
 
+type UpdateScriptContentsFunc func(ctx context.Context, scriptID uint, scriptContents string) (*fleet.Script, error)
+
 type ScriptFunc func(ctx context.Context, id uint) (*fleet.Script, error)
 
 type GetScriptContentsFunc func(ctx context.Context, id uint) ([]byte, error)
@@ -2746,6 +2748,9 @@ type DataStore struct {
 
 	NewScriptFunc        NewScriptFunc
 	NewScriptFuncInvoked bool
+
+	UpdateScriptContentsFunc        UpdateScriptContentsFunc
+	UpdateScriptContentsFuncInvoked bool
 
 	ScriptFunc        ScriptFunc
 	ScriptFuncInvoked bool
@@ -6579,6 +6584,13 @@ func (s *DataStore) NewScript(ctx context.Context, script *fleet.Script) (*fleet
 	s.NewScriptFuncInvoked = true
 	s.mu.Unlock()
 	return s.NewScriptFunc(ctx, script)
+}
+
+func (s *DataStore) UpdateScriptContents(ctx context.Context, scriptID uint, scriptContents string) (*fleet.Script, error) {
+	s.mu.Lock()
+	s.UpdateScriptContentsFuncInvoked = true
+	s.mu.Unlock()
+	return s.UpdateScriptContentsFunc(ctx, scriptID, scriptContents)
 }
 
 func (s *DataStore) Script(ctx context.Context, id uint) (*fleet.Script, error) {

--- a/server/service/handler.go
+++ b/server/service/handler.go
@@ -513,6 +513,7 @@ func attachFleetAPIRoutes(r *mux.Router, svc fleet.Service, config config.FleetC
 	ue.POST("/api/_version_/fleet/scripts", createScriptEndpoint, createScriptRequest{})
 	ue.GET("/api/_version_/fleet/scripts", listScriptsEndpoint, listScriptsRequest{})
 	ue.GET("/api/_version_/fleet/scripts/{script_id:[0-9]+}", getScriptEndpoint, getScriptRequest{})
+	ue.PATCH("/api/_version_/fleet/scripts/{script_id:[0-9]+}", updateScriptEndpoint, updateScriptRequest{})
 	ue.DELETE("/api/_version_/fleet/scripts/{script_id:[0-9]+}", deleteScriptEndpoint, deleteScriptRequest{})
 	ue.POST("/api/_version_/fleet/scripts/batch", batchSetScriptsEndpoint, batchSetScriptsRequest{})
 

--- a/server/service/integration_enterprise_test.go
+++ b/server/service/integration_enterprise_test.go
@@ -7203,7 +7203,7 @@ func (s *integrationEnterpriseTestSuite) TestSavedScripts() {
 	// Update a script
 	updateScriptRep := updateScriptResponse{}
 	body, headers = generateNewScriptMultipartRequest(t,
-		"script1.sh", []byte(`echo "updated script"`), s.token, map[string][]string{"id": {fmt.Sprintf("%d", tmScriptID)}})
+		"script1.sh", []byte(`echo "updated script"`), s.token, nil)
 	res = s.DoRawWithHeaders("PATCH", fmt.Sprintf("/api/latest/fleet/scripts/%d", tmScriptID), body.Bytes(), http.StatusOK, headers)
 	err = json.NewDecoder(res.Body).Decode(&updateScriptRep)
 	require.NoError(t, err)
@@ -7222,8 +7222,8 @@ func (s *integrationEnterpriseTestSuite) TestSavedScripts() {
 	// Try updating a non-existant script
 	updateScriptRep = updateScriptResponse{}
 	body, headers = generateNewScriptMultipartRequest(t,
-		"script1.sh", []byte(`echo "updated script"`), s.token, map[string][]string{"id": {fmt.Sprintf("%d", 99999999999)}})
-	res = s.DoRawWithHeaders("PATCH", fmt.Sprintf("/api/latest/fleet/scripts/%d", tmScriptID), body.Bytes(), http.StatusNotFound, headers)
+		"script1.sh", []byte(`echo "updated script"`), s.token, nil)
+	res = s.DoRawWithHeaders("PATCH", fmt.Sprintf("/api/latest/fleet/scripts/%d", 999999999999), body.Bytes(), http.StatusNotFound, headers)
 	err = json.NewDecoder(res.Body).Decode(&updateScriptRep)
 	require.NoError(t, err)
 

--- a/server/service/scripts.go
+++ b/server/service/scripts.go
@@ -20,6 +20,7 @@ import (
 	"github.com/fleetdm/fleet/v4/server/contexts/logging"
 	"github.com/fleetdm/fleet/v4/server/fleet"
 	"github.com/fleetdm/fleet/v4/server/ptr"
+	"github.com/gorilla/mux"
 )
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -765,6 +766,18 @@ func (updateScriptRequest) DecodeRequest(ctx context.Context, r *http.Request) (
 			InternalErr: err,
 		}
 	}
+
+	vars := mux.Vars(r)
+	scriptIDStr, ok := vars["script_id"]
+	if !ok {
+		return nil, &fleet.BadRequestError{Message: "missing script id"}
+	}
+	scriptID, err := strconv.ParseUint(scriptIDStr, 10, 64)
+	if err != nil {
+		return nil, &fleet.BadRequestError{Message: "invalid script id"}
+	}
+
+	decoded.ScriptID = uint(scriptID)
 
 	fhs, ok := r.MultipartForm.File["script"]
 	if !ok || len(fhs) < 1 {

--- a/server/service/scripts.go
+++ b/server/service/scripts.go
@@ -766,15 +766,6 @@ func (updateScriptRequest) DecodeRequest(ctx context.Context, r *http.Request) (
 		}
 	}
 
-	val := r.MultipartForm.Value["team_id"]
-	if len(val) > 0 {
-		teamID, err := strconv.ParseUint(val[0], 10, 64)
-		if err != nil {
-			return nil, &fleet.BadRequestError{Message: fmt.Sprintf("failed to decode team_id in multipart form: %s", err.Error())}
-		}
-		decoded.TeamID = ptr.Uint(uint(teamID))
-	}
-
 	fhs, ok := r.MultipartForm.File["script"]
 	if !ok || len(fhs) < 1 {
 		return nil, &fleet.BadRequestError{Message: "no file headers for script"}

--- a/server/service/scripts.go
+++ b/server/service/scripts.go
@@ -776,6 +776,10 @@ func (updateScriptRequest) DecodeRequest(ctx context.Context, r *http.Request) (
 	if err != nil {
 		return nil, &fleet.BadRequestError{Message: "invalid script id"}
 	}
+	// Check if scriptID exceeds the maximum value for uint, code linter
+	if scriptID > uint64(^uint(0)) {
+		return nil, &fleet.BadRequestError{Message: "script id out of bounds"}
+	}
 
 	decoded.ScriptID = uint(scriptID)
 

--- a/server/service/scripts.go
+++ b/server/service/scripts.go
@@ -766,6 +766,16 @@ func (updateScriptRequest) DecodeRequest(ctx context.Context, r *http.Request) (
 		}
 	}
 
+	val := r.MultipartForm.Value["id"]
+	if len(val) < 1 {
+		return nil, &fleet.BadRequestError{Message: "no script id"}
+	}
+	scriptID, err := strconv.ParseUint(val[0], 10, 0)
+	if err != nil {
+		return nil, &fleet.BadRequestError{Message: fmt.Sprintf("failed to decode id in multipart form: %s", err.Error())}
+	}
+	decoded.ScriptID = uint(scriptID)
+
 	fhs, ok := r.MultipartForm.File["script"]
 	if !ok || len(fhs) < 1 {
 		return nil, &fleet.BadRequestError{Message: "no file headers for script"}

--- a/server/service/scripts.go
+++ b/server/service/scripts.go
@@ -766,16 +766,6 @@ func (updateScriptRequest) DecodeRequest(ctx context.Context, r *http.Request) (
 		}
 	}
 
-	val := r.MultipartForm.Value["id"]
-	if len(val) < 1 {
-		return nil, &fleet.BadRequestError{Message: "no script id"}
-	}
-	scriptID, err := strconv.ParseUint(val[0], 10, 0)
-	if err != nil {
-		return nil, &fleet.BadRequestError{Message: fmt.Sprintf("failed to decode id in multipart form: %s", err.Error())}
-	}
-	decoded.ScriptID = uint(scriptID)
-
 	fhs, ok := r.MultipartForm.File["script"]
 	if !ok || len(fhs) < 1 {
 		return nil, &fleet.BadRequestError{Message: "no file headers for script"}


### PR DESCRIPTION
#24602

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/Committing-Changes.md#changes-files) for more information.
- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [x] Added/updated automated tests
