### PR TITLE
add telemetry for fleet desktop failing to launch because of missing domain

### DIFF
--- a/orbit/cmd/orbit/orbit.go
+++ b/orbit/cmd/orbit/orbit.go
@@ -63,6 +63,8 @@ const (
 	logErrorLaunchServicesMsg    logError = "LaunchServices kLSServerCommunicationErr (-10822)"
 	logErrorMissingExecSubstr    logError = "The application cannot be opened because its executable is missing."
 	logErrorMissingExecMsg       logError = "bad desktop executable"
+	logErrorMissingDomainSubstr  logError = "Domain=OSLaunchdErrorDomain Code=112"
+	logErrorMissingDomainMsg     logError = "missing specified domain"
 )
 
 func main() {
@@ -1724,7 +1726,10 @@ func (d *desktopRunner) processLog(log string) {
 		// To get this message, delete Fleet Desktop.app directory, make an empty Fleet Desktop.app directory,
 		// and kill the fleet-desktop process. Orbit will try to re-start Fleet Desktop and log this message.
 		msg = string(logErrorMissingExecMsg)
+	case strings.Contains(log, string(logErrorMissingDomainSubstr)):
+		msg = string(logErrorMissingDomainMsg)
 	}
+
 	if msg == "" {
 		return
 	}


### PR DESCRIPTION
For #25689, #19499

We wanted to add some additional telemetry for fleet desktop to know when it was failing to launch based on the error message from a [recent bug] https://github.com/fleetdm/fleet/issues/25689. This bug and some related ones seemed intermittent and we were unable to reproduced so we are hoping adding this telemetry to give some more analytics on this issue.

