### PR TITLE
Fleet UI: Fix Manage automation dropdown styling

### DIFF
--- a/changes/25366-manage-automation-dropdown-styling
+++ b/changes/25366-manage-automation-dropdown-styling
@@ -1,0 +1,1 @@
+- Fleet UI: Fixed styling for manage automation buttons and dropdown

--- a/frontend/components/forms/fields/DropdownWrapper/DropdownWrapper.tsx
+++ b/frontend/components/forms/fields/DropdownWrapper/DropdownWrapper.tsx
@@ -182,80 +182,145 @@ const DropdownWrapper = ({
   };
 
   const customStyles: StylesConfig<CustomOptionType, false> = {
-    container: (provided) => ({
-      ...provided,
-      width: "100%",
-      height: "40px",
-    }),
-    control: (provided, state) => ({
-      ...provided,
-      display: "flex",
-      flexDirection: "row",
-      width: "100%",
-      backgroundColor: COLORS["ui-off-white"],
-      paddingLeft: "8px", // TODO: Update to match styleguide of (16px) when updating rest of UI (8px)
-      paddingRight: "8px",
-      cursor: "pointer",
-      boxShadow: "none",
-      borderRadius: "4px",
-      borderColor: state.isFocused
-        ? COLORS["core-fleet-blue"]
-        : COLORS["ui-fleet-black-10"],
-      "&:hover": {
+    container: (provided) => {
+      const buttonVariantContainer = {
+        borderRadius: "6px",
+        "&:active": {
+          backgroundColor: "rgba(25, 33, 71, 0.05)", // confirm
+        },
+      };
+
+      return {
+        ...provided,
+        width: "100%",
+        height: "40px",
+        ...(variant === "button" && buttonVariantContainer),
+      };
+    },
+
+    control: (provided, state) => {
+      if (variant === "button")
+        return {
+          backgroundColor: "initial",
+          borderColor: "none",
+          display: "flex",
+          flexDirection: "row",
+          width: "max-content",
+          padding: PADDING["pad-small"], // configrm
+          border: 0,
+          borderRadius: "6px",
+          boxShadow: "none",
+          cursor: "pointer",
+          ".dropdown-wrapper__indicator path": {
+            stroke: COLORS["core-fleet-blue"],
+          },
+          "&:hover": {
+            backgroundColor: "rgba(25, 33, 71, 0.05)",
+            boxShadow: "none",
+            ".dropdown-wrapper__placeholder": {
+              color: COLORS["core-vibrant-blue-over"],
+            },
+            ".dropdown-wrapper__indicator path": {
+              stroke: COLORS["core-vibrant-blue-over"],
+            },
+          },
+          "&:active .dropdown-wrapper__indicator path": {
+            stroke: COLORS["core-vibrant-blue-down"],
+          },
+          // TODO: Figure out a way to apply separate &:focus-visible styling
+          // Currently only relying on &:focus styling for tabbing through app
+          ...(state.menuIsOpen && {
+            ".dropdown-wrapper__indicator svg": {
+              transform: "rotate(180deg)",
+              transition: "transform 0.25s ease",
+            },
+          }),
+        };
+
+      return {
+        ...provided,
+        display: "flex",
+        flexDirection: "row",
+        width: "100%",
+        backgroundColor: COLORS["ui-off-white"],
+        paddingLeft: "8px", // TODO: Update to match styleguide of (16px) when updating rest of UI (8px)
+        paddingRight: "8px",
+        cursor: "pointer",
         boxShadow: "none",
-        borderColor: COLORS["core-fleet-blue"],
-        ".dropdown-wrapper__single-value": {
-          color: COLORS["core-vibrant-blue-over"],
+        borderRadius: "4px",
+        borderColor: state.isFocused
+          ? COLORS["core-fleet-blue"]
+          : COLORS["ui-fleet-black-10"],
+        "&:hover": {
+          boxShadow: "none",
+          borderColor: COLORS["core-fleet-blue"],
+          ".dropdown-wrapper__single-value": {
+            color: COLORS["core-vibrant-blue-over"],
+          },
+          ".dropdown-wrapper__indicator path": {
+            stroke: COLORS["core-vibrant-blue-over"],
+          },
         },
-        ".dropdown-wrapper__indicator path": {
-          stroke: COLORS["core-vibrant-blue-over"],
+        // When tabbing
+        // Relies on --is-focused for styling as &:focus-visible cannot be applied
+        "&.dropdown-wrapper__control--is-focused": {
+          ".dropdown-wrapper__single-value": {
+            color: COLORS["core-vibrant-blue-over"],
+          },
+          ".dropdown-wrapper__indicator path": {
+            stroke: COLORS["core-vibrant-blue-over"],
+          },
         },
         ".filter-icon path": {
           fill: COLORS["core-vibrant-blue-over"],
         },
-      },
-      // When tabbing
-      // Relies on --is-focused for styling as &:focus-visible cannot be applied
-      "&.dropdown-wrapper__control--is-focused": {
-        ".dropdown-wrapper__single-value": {
-          color: COLORS["core-vibrant-blue-over"],
+        ...(state.isDisabled && {
+          ".dropdown-wrapper__single-value": {
+            color: COLORS["ui-fleet-black-50"],
+          },
+          ".dropdown-wrapper__indicator path": {
+            stroke: COLORS["ui-fleet-black-50"],
+          },
+          ".filter-icon path": {
+            fill: COLORS["ui-fleet-black-50"],
+          },
+        }),
+        "&:active": {
+          ".dropdown-wrapper__single-value": {
+            color: COLORS["core-vibrant-blue-down"],
+          },
+          ".dropdown-wrapper__indicator path": {
+            stroke: COLORS["core-vibrant-blue-down"],
+          },
+          ".filter-icon path": {
+            fill: COLORS["core-vibrant-blue-down"],
+          },
         },
-        ".dropdown-wrapper__indicator path": {
-          stroke: COLORS["core-vibrant-blue-over"],
-        },
-        ".filter-icon path": {
-          fill: COLORS["core-vibrant-blue-over"],
-        },
-      },
-      ...(state.isDisabled && {
-        ".dropdown-wrapper__single-value": {
-          color: COLORS["ui-fleet-black-50"],
-        },
-        ".dropdown-wrapper__indicator path": {
-          stroke: COLORS["ui-fleet-black-50"],
-        },
-        ".filter-icon path": {
-          fill: COLORS["ui-fleet-black-50"],
-        },
-      }),
-      "&:active": {
-        ".dropdown-wrapper__single-value": {
-          color: COLORS["core-vibrant-blue-down"],
-        },
-        ".dropdown-wrapper__indicator path": {
-          stroke: COLORS["core-vibrant-blue-down"],
-        },
-        ".filter-icon path": {
-          fill: COLORS["core-vibrant-blue-down"],
-        },
-      },
-      ...(state.menuIsOpen && {
-        ".dropdown-wrapper__indicator svg": {
-          transform: "rotate(180deg)",
-          transition: "transform 0.25s ease",
-        },
-      }),
-    }),
+        ...(state.menuIsOpen && {
+          ".dropdown-wrapper__indicator svg": {
+            transform: "rotate(180deg)",
+            transition: "transform 0.25s ease",
+          },
+        }),
+      };
+    },
+    placeholder: (provided, state) => {
+      const buttonVariantPlaceholder = {
+        color: state.isFocused
+          ? COLORS["core-vibrant-blue-over"]
+          : COLORS["core-fleet-blue"],
+        fontSize: "14px",
+        fontWeight: "bold",
+        lineHeight: "normal",
+        paddingLeft: 0,
+        marginTop: "1px",
+      };
+
+      return {
+        ...provided,
+        ...(variant === "button" && buttonVariantPlaceholder),
+      };
+    },
     singleValue: (provided) => ({
       ...provided,
       fontSize: "16px",
@@ -292,7 +357,7 @@ const DropdownWrapper = ({
       ...provided,
       padding: 0,
       display: "flex",
-      gap: PADDING["pad-small"],
+      gap: PADDING[variant === "button" ? "pad-xsmall" : "pad-small"],
     }),
     option: (provided, state) => ({
       ...provided,
@@ -306,6 +371,7 @@ const DropdownWrapper = ({
         backgroundColor: state.isDisabled
           ? "transparent"
           : COLORS["ui-vibrant-blue-10"],
+        cursor: state.isDisabled ? "not-allowed" : "pointer",
       },
       "&:active": {
         backgroundColor: state.isDisabled

--- a/frontend/components/forms/fields/DropdownWrapper/DropdownWrapper.tsx
+++ b/frontend/components/forms/fields/DropdownWrapper/DropdownWrapper.tsx
@@ -29,6 +29,7 @@ import FormField from "components/forms/FormField";
 import DropdownOptionTooltipWrapper from "components/forms/fields/Dropdown/DropdownOptionTooltipWrapper";
 import Icon from "components/Icon";
 import { IconNames } from "components/icons";
+import { TooltipContent } from "interfaces/dropdownOption";
 
 const getOptionBackgroundColor = (
   state: OptionProps<CustomOptionType, false>
@@ -37,9 +38,9 @@ const getOptionBackgroundColor = (
 };
 
 export interface CustomOptionType {
-  label: string;
+  label: React.ReactNode;
   value: string;
-  tooltipContent?: string;
+  tooltipContent?: TooltipContent;
   helpText?: string;
   isDisabled?: boolean;
   iconName?: IconNames;
@@ -64,6 +65,7 @@ export interface IDropdownWrapper {
   onMenuOpen?: () => void;
   /** Table filter dropdowns have filter icon and height: 40px  */
   tableFilter?: boolean;
+  variant?: "button";
 }
 
 const baseClass = "dropdown-wrapper";
@@ -85,6 +87,7 @@ const DropdownWrapper = ({
   placeholder,
   onMenuOpen,
   tableFilter = false,
+  variant,
 }: IDropdownWrapper) => {
   const wrapperClassNames = classnames(baseClass, className, {
     [`${baseClass}__table-filter`]: tableFilter,

--- a/frontend/components/forms/fields/DropdownWrapper/DropdownWrapper.tsx
+++ b/frontend/components/forms/fields/DropdownWrapper/DropdownWrapper.tsx
@@ -345,7 +345,7 @@ const DropdownWrapper = ({
       zIndex: 6,
       overflow: "hidden",
       border: 0,
-      marginTop: 0,
+      marginTop: variant === "button" ? "7px" : 0,
       left: 0,
       maxHeight: "none",
       position: "absolute",

--- a/frontend/components/forms/fields/DropdownWrapper/DropdownWrapper.tsx
+++ b/frontend/components/forms/fields/DropdownWrapper/DropdownWrapper.tsx
@@ -63,9 +63,10 @@ export interface IDropdownWrapper {
   placeholder?: string;
   /** E.g. scroll to view dropdown menu in a scrollable parent container */
   onMenuOpen?: () => void;
-  /** Table filter dropdowns have filter icon and height: 40px  */
-  tableFilter?: boolean;
-  variant?: "button";
+  /** Table filter dropdowns have filter icon and height: 40px
+   *  Button dropdowns have hover/active state, padding, height like actual buttons
+   */
+  variant?: "table-filter" | "button";
   nowrapMenu?: boolean;
 }
 
@@ -87,12 +88,11 @@ const DropdownWrapper = ({
   iconName,
   placeholder,
   onMenuOpen,
-  tableFilter = false,
   variant,
   nowrapMenu,
 }: IDropdownWrapper) => {
   const wrapperClassNames = classnames(baseClass, className, {
-    [`${baseClass}__table-filter`]: tableFilter,
+    [`${baseClass}__table-filter`]: variant === "table-filter",
     [`${wrapperClassname}`]: !!wrapperClassname,
   });
 
@@ -169,7 +169,8 @@ const DropdownWrapper = ({
     children,
     ...props
   }: ValueContainerProps<CustomOptionType, false>) => {
-    const iconToDisplay = iconName || (tableFilter ? "filter" : null);
+    const iconToDisplay =
+      iconName || (variant === "table-filter" ? "filter" : null);
 
     return (
       components.ValueContainer && (
@@ -238,6 +239,7 @@ const DropdownWrapper = ({
               transition: "transform 0.25s ease",
             },
           }),
+          ...(variant === "button" && { height: "22px" }),
         };
 
       return {
@@ -316,7 +318,7 @@ const DropdownWrapper = ({
         fontWeight: "bold",
         lineHeight: "normal",
         paddingLeft: 0,
-        marginTop: "1px",
+        marginTop: variant === "button" ? "-1px" : "1px", // TODO: Figure out vertical centering to not need pixel fix
       };
 
       return {
@@ -345,7 +347,7 @@ const DropdownWrapper = ({
       zIndex: 6,
       overflow: "hidden",
       border: 0,
-      marginTop: variant === "button" ? "7px" : 0,
+      marginTop: variant === "button" ? "3px" : 0,
       left: 0,
       maxHeight: "none",
       position: "absolute",

--- a/frontend/components/forms/fields/DropdownWrapper/DropdownWrapper.tsx
+++ b/frontend/components/forms/fields/DropdownWrapper/DropdownWrapper.tsx
@@ -66,6 +66,7 @@ export interface IDropdownWrapper {
   /** Table filter dropdowns have filter icon and height: 40px  */
   tableFilter?: boolean;
   variant?: "button";
+  nowrapMenu?: boolean;
 }
 
 const baseClass = "dropdown-wrapper";
@@ -88,6 +89,7 @@ const DropdownWrapper = ({
   onMenuOpen,
   tableFilter = false,
   variant,
+  nowrapMenu,
 }: IDropdownWrapper) => {
   const wrapperClassNames = classnames(baseClass, className, {
     [`${baseClass}__table-filter`]: tableFilter,
@@ -186,8 +188,9 @@ const DropdownWrapper = ({
       const buttonVariantContainer = {
         borderRadius: "6px",
         "&:active": {
-          backgroundColor: "rgba(25, 33, 71, 0.05)", // confirm
+          backgroundColor: "rgba(25, 33, 71, 0.05)",
         },
+        height: "38px",
       };
 
       return {
@@ -206,7 +209,7 @@ const DropdownWrapper = ({
           display: "flex",
           flexDirection: "row",
           width: "max-content",
-          padding: PADDING["pad-small"], // configrm
+          padding: PADDING["pad-small"],
           border: 0,
           borderRadius: "6px",
           boxShadow: "none",
@@ -343,15 +346,21 @@ const DropdownWrapper = ({
       overflow: "hidden",
       border: 0,
       marginTop: 0,
+      left: 0,
       maxHeight: "none",
       position: "absolute",
-      left: "0",
       animation: "fade-in 150ms ease-out",
+      ...(nowrapMenu && {
+        width: "fit-content",
+        left: "auto",
+        right: "0",
+      }),
     }),
     menuList: (provided) => ({
       ...provided,
       padding: PADDING["pad-small"],
       maxHeight: "none",
+      ...(nowrapMenu && { width: "fit-content" }),
     }),
     valueContainer: (provided) => ({
       ...provided,
@@ -389,11 +398,15 @@ const DropdownWrapper = ({
         flexDirection: "column",
         gap: "8px",
         width: "100%",
+        whiteSpace: nowrapMenu ? "nowrap" : "normal",
       },
       ".dropdown-wrapper__help-text": {
         fontSize: "12px",
-        whiteSpace: "normal",
-        color: COLORS["ui-fleet-black-75"],
+        width: "100%",
+        whiteSpace: nowrapMenu ? "nowrap" : "normal",
+        color: state.isDisabled
+          ? COLORS["ui-fleet-black-50"]
+          : COLORS["ui-fleet-black-75"],
         fontStyle: "italic",
         fontWeight: "normal",
       },

--- a/frontend/components/forms/fields/DropdownWrapper/DropdownWrapper.tsx
+++ b/frontend/components/forms/fields/DropdownWrapper/DropdownWrapper.tsx
@@ -64,9 +64,10 @@ export interface IDropdownWrapper {
   /** E.g. scroll to view dropdown menu in a scrollable parent container */
   onMenuOpen?: () => void;
   /** Table filter dropdowns have filter icon and height: 40px
-   *  Button dropdowns have hover/active state, padding, height like actual buttons
-   */
+   *  Button dropdowns have hover/active state, padding, height like actual buttons */
   variant?: "table-filter" | "button";
+  /** This makes the menu fit all text without wrapping,
+   * aligning right to fit text on screen */
   nowrapMenu?: boolean;
 }
 
@@ -228,6 +229,9 @@ const DropdownWrapper = ({
               stroke: COLORS["core-vibrant-blue-over"],
             },
           },
+          "&.react-select__control--is-focused": {
+            backgroundColor: "rgba(25, 33, 71, 0.05)",
+          },
           "&:active .dropdown-wrapper__indicator path": {
             stroke: COLORS["core-vibrant-blue-down"],
           },
@@ -268,7 +272,7 @@ const DropdownWrapper = ({
         },
         // When tabbing
         // Relies on --is-focused for styling as &:focus-visible cannot be applied
-        "&.dropdown-wrapper__control--is-focused": {
+        "&.react-select__control--is-focused": {
           ".dropdown-wrapper__single-value": {
             color: COLORS["core-vibrant-blue-over"],
           },

--- a/frontend/pages/SoftwarePage/SoftwareOS/SoftwareOSTable/SoftwareOSTable.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareOS/SoftwareOSTable/SoftwareOSTable.tsx
@@ -240,7 +240,7 @@ const SoftwareOSTable = ({
         className={`${baseClass}__platform-dropdown`}
         options={PLATFORM_FILTER_OPTIONS}
         onChange={handlePlatformFilterDropdownChange}
-        tableFilter
+        variant="table-filter"
       />
     );
   };

--- a/frontend/pages/SoftwarePage/SoftwareTitles/SoftwareTable/SoftwareTable.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitles/SoftwareTable/SoftwareTable.tsx
@@ -307,7 +307,7 @@ const SoftwareTable = ({
               newValue.value as ISoftwareDropdownFilterVal
             )
           }
-          tableFilter
+          variant="table-filter"
         />
       </div>
     );

--- a/frontend/pages/SoftwarePage/SoftwareVulnerabilities/SoftwareVulnerabilitiesTable/SoftwareVulnerabilitiesTable.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareVulnerabilities/SoftwareVulnerabilitiesTable/SoftwareVulnerabilitiesTable.tsx
@@ -245,7 +245,7 @@ const SoftwareVulnerabilitiesTable = ({
         onChange={(newValue: SingleValue<CustomOptionType>) =>
           newValue && handleExploitedVulnFilterDropdownChange(newValue.value)
         }
-        tableFilter
+        variant="table-filter"
       />
     );
   };

--- a/frontend/pages/SoftwarePage/_styles.scss
+++ b/frontend/pages/SoftwarePage/_styles.scss
@@ -9,10 +9,6 @@
     }
   }
 
-  &__manage-automations {
-    padding: $pad-small $pad-medium;
-  }
-
   &__header {
     display: flex;
     align-items: center;

--- a/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
@@ -1468,7 +1468,7 @@ const ManageHostsPage = ({
           className={`${baseClass}__status-filter`}
           options={hostSelectStatuses}
           onChange={handleStatusDropdownChange}
-          tableFilter
+          variant="table-filter"
         />
         <LabelFilterSelect
           className={`${baseClass}__label-filter-dropdown`}

--- a/frontend/pages/hosts/details/cards/Software/HostSoftwareTable/HostSoftwareTable.tsx
+++ b/frontend/pages/hosts/details/cards/Software/HostSoftwareTable/HostSoftwareTable.tsx
@@ -132,7 +132,7 @@ const HostSoftwareTable = ({
         className={`${baseClass}__software-filter`}
         options={DROPDOWN_OPTIONS}
         onChange={handleFilterDropdownChange}
-        tableFilter
+        variant="table-filter"
       />
     );
   }, [handleFilterDropdownChange, hostSoftwareFilter]);

--- a/frontend/pages/policies/ManagePoliciesPage/ManagePoliciesPage.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/ManagePoliciesPage.tsx
@@ -22,7 +22,7 @@ import {
   IPolicy,
 } from "interfaces/policy";
 import { API_ALL_TEAMS_ID, API_NO_TEAM_ID, ITeamConfig } from "interfaces/team";
-import { IDropdownOption, TooltipContent } from "interfaces/dropdownOption";
+import { TooltipContent } from "interfaces/dropdownOption";
 
 import configAPI from "services/entities/config";
 import globalPoliciesAPI, {
@@ -1027,6 +1027,7 @@ const ManagePolicyPage = ({
                     onChange={onSelectAutomationOption}
                     placeholder="Manage automations"
                     options={getAutomationsDropdownOptions(!!automationsConfig)}
+                    variant="button"
                   />
                 </div>
               )}

--- a/frontend/pages/policies/ManagePoliciesPage/ManagePoliciesPage.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/ManagePoliciesPage.tsx
@@ -38,8 +38,10 @@ import teamsAPI, { ILoadTeamResponse } from "services/entities/teams";
 import { ITableQueryData } from "components/TableContainer/TableContainer";
 import TableCount from "components/TableContainer/TableCount";
 import Button from "components/buttons/Button";
-// @ts-ignore
-import Dropdown from "components/forms/fields/Dropdown";
+
+import { SingleValue } from "react-select-5";
+import DropdownWrapper from "components/forms/fields/DropdownWrapper";
+import { CustomOptionType } from "components/forms/fields/DropdownWrapper/DropdownWrapper";
 import Spinner from "components/Spinner";
 import TeamsDropdown from "components/TeamsDropdown";
 import TableDataError from "components/DataError";
@@ -489,8 +491,8 @@ const ManagePolicyPage = ({
     setShowCalendarEventsModal(!showCalendarEventsModal);
   };
 
-  const onSelectAutomationOption = (option: string) => {
-    switch (option) {
+  const onSelectAutomationOption = (option: SingleValue<CustomOptionType>) => {
+    switch (option?.value) {
       case "calendar_events":
         toggleCalendarEventsModal();
         break;
@@ -939,25 +941,25 @@ const ManagePolicyPage = ({
       );
     }
 
-    const options: IDropdownOption[] = [
+    const options: CustomOptionType[] = [
       {
         label: "Calendar events",
         value: "calendar_events",
-        disabled: !!disabledCalendarTooltipContent,
+        isDisabled: !!disabledCalendarTooltipContent,
         helpText: "Automatically reserve time to resolve failing policies.",
         tooltipContent: disabledCalendarTooltipContent,
       },
       {
         label: "Install software",
         value: "install_software",
-        disabled: !!disabledInstallTooltipContent,
+        isDisabled: !!disabledInstallTooltipContent,
         helpText: "Install software to resolve failing policies.",
         tooltipContent: disabledInstallTooltipContent,
       },
       {
         label: "Run script",
         value: "run_script",
-        disabled: !!disabledRunScriptTooltipContent,
+        isDisabled: !!disabledRunScriptTooltipContent,
         helpText: "Run script to resolve failing policies.",
         tooltipContent: disabledRunScriptTooltipContent,
       },
@@ -968,7 +970,7 @@ const ManagePolicyPage = ({
       options.push({
         label: "Other workflows",
         value: "other_workflows",
-        disabled: false,
+        isDisabled: false,
         helpText: "Create tickets or fire webhooks for failing policies.",
       });
     }
@@ -1019,11 +1021,11 @@ const ManagePolicyPage = ({
             <div className={`${baseClass} button-wrap`}>
               {showAutomationsDropdown && (
                 <div className={`${baseClass}__manage-automations-wrapper`}>
-                  <Dropdown
+                  <DropdownWrapper
                     className={`${baseClass}__manage-automations-dropdown`}
+                    name="policy-automations"
                     onChange={onSelectAutomationOption}
                     placeholder="Manage automations"
-                    searchable={false}
                     options={getAutomationsDropdownOptions(!!automationsConfig)}
                   />
                 </div>

--- a/frontend/pages/policies/ManagePoliciesPage/ManagePoliciesPage.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/ManagePoliciesPage.tsx
@@ -1028,6 +1028,7 @@ const ManagePolicyPage = ({
                     placeholder="Manage automations"
                     options={getAutomationsDropdownOptions(!!automationsConfig)}
                     variant="button"
+                    nowrapMenu
                   />
                 </div>
               )}

--- a/frontend/pages/policies/ManagePoliciesPage/_styles.scss
+++ b/frontend/pages/policies/ManagePoliciesPage/_styles.scss
@@ -27,6 +27,10 @@
       left: -186px;
       width: 360px;
     }
+    .Select-input {
+      padding: 8px;
+    }
+
     .Select-control {
       margin-top: 0;
       gap: 6px;

--- a/frontend/pages/queries/ManageQueriesPage/components/QueriesTable/QueriesTable.tsx
+++ b/frontend/pages/queries/ManageQueriesPage/components/QueriesTable/QueriesTable.tsx
@@ -232,7 +232,7 @@ const QueriesTable = ({
         name="platform-dropdown"
         options={PLATFORM_FILTER_OPTIONS}
         onChange={handlePlatformFilterDropdownChange}
-        tableFilter
+        variant="table-filter"
       />
     );
   }, [curTargetedPlatformFilter, queryParams, router]);


### PR DESCRIPTION
## Issue
For #25366 

## Description
- Cleaned up manage automation dropdown styling and manage automation button consistency
- Code:
  - Refactored `tableFilter` to a variant `"table-filter"` and added variant `"button"` to `<DropdownWrapper/>` (Majority of the code was adding variant button to <DropdownWrapper/> to look and feel like a button)
  - Added `nowrapMenu` since Figma for this doesn't wrap text to keep the menu the width of the Dropdown button
  - Clean up types
 
## Screenrecording of fixes

https://github.com/user-attachments/assets/ba152077-5924-4ced-8d53-28cec8c31c74

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
- [x] A detailed QA plan exists on the associated ticket (if it isn't there, work with the product group's QA engineer to add it)
- [x] Manual QA for all new/changed functionality

