### PR TITLE
Include current host status and pending action in lock, unlock, and wipe API calls

### DIFF
--- a/changes/23241-lock-api-response
+++ b/changes/23241-lock-api-response
@@ -1,0 +1,1 @@
+* Included current host status and pending action in lock, unlock, and wipe API calls

--- a/server/fleet/scripts.go
+++ b/server/fleet/scripts.go
@@ -436,6 +436,47 @@ type ScriptResponse struct {
 	Name string `json:"name" db:"name"`
 }
 
+type DeviceStatus string
+
+const (
+	DeviceStatusWiped    DeviceStatus = "wiped"
+	DeviceStatusLocked   DeviceStatus = "locked"
+	DeviceStatusUnlocked DeviceStatus = "unlocked"
+)
+
+func (s HostLockWipeStatus) DeviceStatus() DeviceStatus {
+	switch {
+	case s.IsWiped():
+		return DeviceStatusWiped
+	case s.IsLocked():
+		return DeviceStatusLocked
+	default:
+		return DeviceStatusUnlocked
+	}
+}
+
+type PendingDeviceAction string
+
+const (
+	PendingActionLock   PendingDeviceAction = "lock"
+	PendingActionUnlock PendingDeviceAction = "unlock"
+	PendingActionWipe   PendingDeviceAction = "wipe"
+	PendingActionNone   PendingDeviceAction = ""
+)
+
+func (s HostLockWipeStatus) PendingAction() PendingDeviceAction {
+	switch {
+	case s.IsPendingLock():
+		return PendingActionLock
+	case s.IsPendingUnlock():
+		return PendingActionUnlock
+	case s.IsPendingWipe():
+		return PendingActionWipe
+	default:
+		return PendingActionNone
+	}
+}
+
 func (s *HostLockWipeStatus) IsPendingLock() bool {
 	if s.HostFleetPlatform == "darwin" || s.HostFleetPlatform == "ios" || s.HostFleetPlatform == "ipados" {
 		// pending lock if an MDM command is queued but no result received yet

--- a/server/service/hosts.go
+++ b/server/service/hosts.go
@@ -1301,27 +1301,8 @@ func (svc *Service) getHostDetails(ctx context.Context, host *fleet.Host, opts f
 		return nil, ctxerr.Wrap(ctx, err, "get host mdm lock/wipe status")
 	}
 
-	// unlocked with no pending action is the default state
-	// TODO(mna): make constants for those values
-	host.MDM.DeviceStatus = ptr.String("unlocked")
-	host.MDM.PendingAction = ptr.String("")
-	// device status
-	switch {
-	case mdmActions.IsWiped():
-		host.MDM.DeviceStatus = ptr.String("wiped")
-	case mdmActions.IsLocked():
-		host.MDM.DeviceStatus = ptr.String("locked")
-	}
-
-	// pending action, if any
-	switch {
-	case mdmActions.IsPendingLock():
-		host.MDM.PendingAction = ptr.String("lock")
-	case mdmActions.IsPendingUnlock():
-		host.MDM.PendingAction = ptr.String("unlock")
-	case mdmActions.IsPendingWipe():
-		host.MDM.PendingAction = ptr.String("wipe")
-	}
+	host.MDM.DeviceStatus = ptr.String(string(mdmActions.DeviceStatus()))
+	host.MDM.PendingAction = ptr.String(string(mdmActions.PendingAction()))
 
 	host.Policies = policies
 

--- a/server/service/integration_enterprise_test.go
+++ b/server/service/integration_enterprise_test.go
@@ -12527,14 +12527,14 @@ func (s *integrationEnterpriseTestSuite) TestSoftwareInstallerHostRequests() {
 		}`, *h.OrbitNodeKey, installUUID)), http.StatusNoContent)
 
 	// simulate a lock/unlock; this creates the host_mdm_actions table, which reproduces #25144
-	s.Do("POST", fmt.Sprintf("/api/latest/fleet/hosts/%d/lock", h.ID), nil, http.StatusNoContent)
+	s.Do("POST", fmt.Sprintf("/api/latest/fleet/hosts/%d/lock", h.ID), nil, http.StatusOK)
 	status, err := s.ds.GetHostLockWipeStatus(context.Background(), h)
 	require.NoError(t, err)
 	var orbitScriptResp orbitPostScriptResultResponse
 	s.DoJSON("POST", "/api/fleet/orbit/scripts/result",
 		json.RawMessage(fmt.Sprintf(`{"orbit_node_key": %q, "execution_id": %q, "exit_code": 0, "output": "ok"}`, *h.OrbitNodeKey, status.LockScript.ExecutionID)),
 		http.StatusOK, &orbitScriptResp)
-	s.Do("POST", fmt.Sprintf("/api/latest/fleet/hosts/%d/unlock", h.ID), nil, http.StatusNoContent)
+	s.Do("POST", fmt.Sprintf("/api/latest/fleet/hosts/%d/unlock", h.ID), nil, http.StatusOK)
 	status, err = s.ds.GetHostLockWipeStatus(context.Background(), h)
 	require.NoError(t, err)
 	s.DoJSON("POST", "/api/fleet/orbit/scripts/result",

--- a/server/service/integration_enterprise_test.go
+++ b/server/service/integration_enterprise_test.go
@@ -9138,7 +9138,7 @@ func (s *integrationEnterpriseTestSuite) TestLockUnlockWipeWindowsLinux() {
 	require.NoError(t, err)
 
 	// try to lock/unlock/wipe the Linux host succeeds, no MDM constraints
-	s.Do("POST", fmt.Sprintf("/api/latest/fleet/hosts/%d/lock", linuxHost.ID), nil, http.StatusNoContent)
+	s.Do("POST", fmt.Sprintf("/api/latest/fleet/hosts/%d/lock", linuxHost.ID), nil, http.StatusOK)
 
 	// simulate a successful script result for the lock command
 	status, err := s.ds.GetHostLockWipeStatus(ctx, linuxHost)
@@ -9149,7 +9149,7 @@ func (s *integrationEnterpriseTestSuite) TestLockUnlockWipeWindowsLinux() {
 		json.RawMessage(fmt.Sprintf(`{"orbit_node_key": %q, "execution_id": %q, "exit_code": 0, "output": "ok"}`, *linuxHost.OrbitNodeKey, status.LockScript.ExecutionID)),
 		http.StatusOK, &orbitScriptResp)
 
-	s.Do("POST", fmt.Sprintf("/api/latest/fleet/hosts/%d/unlock", linuxHost.ID), nil, http.StatusNoContent)
+	s.Do("POST", fmt.Sprintf("/api/latest/fleet/hosts/%d/unlock", linuxHost.ID), nil, http.StatusOK)
 
 	// windows host status is unchanged, linux is locked pending unlock
 	s.DoJSON("GET", fmt.Sprintf("/api/latest/fleet/hosts/%d", winHost.ID), nil, http.StatusOK, &getHostResp)

--- a/server/service/integration_mdm_lifecycle_test.go
+++ b/server/service/integration_mdm_lifecycle_test.go
@@ -288,7 +288,7 @@ func (s *integrationMDMTestSuite) TestTurnOnLifecycleEventsWindows() {
 					"POST",
 					fmt.Sprintf("/api/latest/fleet/hosts/%d/wipe", host.ID),
 					nil,
-					http.StatusNoContent,
+					http.StatusOK,
 				)
 
 				status, err := s.ds.GetHostLockWipeStatus(context.Background(), host)
@@ -333,7 +333,7 @@ func (s *integrationMDMTestSuite) TestTurnOnLifecycleEventsWindows() {
 					"POST",
 					fmt.Sprintf("/api/latest/fleet/hosts/%d/lock", host.ID),
 					nil,
-					http.StatusNoContent,
+					http.StatusOK,
 				)
 
 				status, err := s.ds.GetHostLockWipeStatus(context.Background(), host)

--- a/server/service/integration_mdm_lifecycle_test.go
+++ b/server/service/integration_mdm_lifecycle_test.go
@@ -60,7 +60,7 @@ func (s *integrationMDMTestSuite) TestTurnOnLifecycleEventsApple() {
 					"POST",
 					fmt.Sprintf("/api/latest/fleet/hosts/%d/wipe", host.ID),
 					nil,
-					http.StatusNoContent,
+					http.StatusOK,
 				)
 
 				cmd, err := device.Idle()
@@ -80,7 +80,7 @@ func (s *integrationMDMTestSuite) TestTurnOnLifecycleEventsApple() {
 					"POST",
 					fmt.Sprintf("/api/latest/fleet/hosts/%d/lock", host.ID),
 					nil,
-					http.StatusNoContent,
+					http.StatusOK,
 				)
 
 				cmd, err := device.Idle()

--- a/server/service/scripts.go
+++ b/server/service/scripts.go
@@ -998,7 +998,7 @@ func unlockHostEndpoint(ctx context.Context, request interface{}, svc fleet.Serv
 	}
 
 	// We bail if a host is unlocked or wiped, so we can assume the host is locked at this point
-	resp := unlockHostResponse{DeviceStatus: fleet.DeviceStatusLocked, PendingAction: fleet.PendingActionUnlock}
+	resp := unlockHostResponse{HostID: &req.HostID, DeviceStatus: fleet.DeviceStatusLocked, PendingAction: fleet.PendingActionUnlock}
 	// only macOS hosts return an unlock PIN, for other platforms the UnlockHost
 	// call triggers the unlocking without further user action.
 	if pin != "" {

--- a/server/service/scripts.go
+++ b/server/service/scripts.go
@@ -941,17 +941,12 @@ type lockHostRequest struct {
 }
 
 type lockHostResponse struct {
-	Err        error  `json:"error,omitempty"`
-	UnlockPIN  string `json:"unlock_pin,omitempty"`
-	StatusCode int    `json:"-"`
+	Err           error                     `json:"error,omitempty"`
+	DeviceStatus  fleet.DeviceStatus        `json:"device_status,omitempty"`
+	PendingAction fleet.PendingDeviceAction `json:"pending_action,omitempty"`
+	UnlockPIN     string                    `json:"unlock_pin,omitempty"`
 }
 
-func (r lockHostResponse) Status() int {
-	if r.StatusCode != 0 {
-		return r.StatusCode
-	}
-	return http.StatusNoContent
-}
 func (r lockHostResponse) error() error { return r.Err }
 
 func lockHostEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (errorer, error) {
@@ -960,10 +955,13 @@ func lockHostEndpoint(ctx context.Context, request interface{}, svc fleet.Servic
 	if err != nil {
 		return lockHostResponse{Err: err}, nil
 	}
+	// We bail from locking if the host is locked or wiped, so we can assume the host is unlocked at this point
+	response := &lockHostResponse{DeviceStatus: fleet.DeviceStatusUnlocked, PendingAction: fleet.PendingActionLock}
+
 	if req.ViewPin && unlockPIN != "" {
-		return lockHostResponse{UnlockPIN: unlockPIN, StatusCode: http.StatusOK}, nil
+		response.UnlockPIN = unlockPIN
 	}
-	return lockHostResponse{}, nil
+	return response, nil
 }
 
 func (svc *Service) LockHost(ctx context.Context, _ uint, _ bool) (string, error) {
@@ -983,19 +981,13 @@ type unlockHostRequest struct {
 }
 
 type unlockHostResponse struct {
-	HostID    *uint  `json:"host_id,omitempty"`
-	UnlockPIN string `json:"unlock_pin,omitempty"`
-	Err       error  `json:"error,omitempty"`
+	HostID        *uint                     `json:"host_id,omitempty"`
+	UnlockPIN     string                    `json:"unlock_pin,omitempty"`
+	DeviceStatus  fleet.DeviceStatus        `json:"device_status,omitempty"`
+	PendingAction fleet.PendingDeviceAction `json:"pending_action,omitempty"`
+	Err           error                     `json:"error,omitempty"`
 }
 
-func (r unlockHostResponse) Status() int {
-	if r.HostID != nil {
-		// there is a response body
-		return http.StatusOK
-	}
-	// no response body
-	return http.StatusNoContent
-}
 func (r unlockHostResponse) error() error { return r.Err }
 
 func unlockHostEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (errorer, error) {
@@ -1005,11 +997,11 @@ func unlockHostEndpoint(ctx context.Context, request interface{}, svc fleet.Serv
 		return unlockHostResponse{Err: err}, nil
 	}
 
-	var resp unlockHostResponse
+	// We bail if a host is unlocked or wiped, so we can assume the host is locked at this point
+	resp := unlockHostResponse{DeviceStatus: fleet.DeviceStatusLocked, PendingAction: fleet.PendingActionUnlock}
 	// only macOS hosts return an unlock PIN, for other platforms the UnlockHost
 	// call triggers the unlocking without further user action.
 	if pin != "" {
-		resp.HostID = &req.HostID
 		resp.UnlockPIN = pin
 	}
 	return resp, nil
@@ -1032,10 +1024,11 @@ type wipeHostRequest struct {
 }
 
 type wipeHostResponse struct {
-	Err error `json:"error,omitempty"`
+	Err           error                     `json:"error,omitempty"`
+	DeviceStatus  fleet.DeviceStatus        `json:"device_status,omitempty"`
+	PendingAction fleet.PendingDeviceAction `json:"pending_action,omitempty"`
 }
 
-func (r wipeHostResponse) Status() int  { return http.StatusNoContent }
 func (r wipeHostResponse) error() error { return r.Err }
 
 func wipeHostEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (errorer, error) {
@@ -1043,7 +1036,8 @@ func wipeHostEndpoint(ctx context.Context, request interface{}, svc fleet.Servic
 	if err := svc.WipeHost(ctx, req.HostID); err != nil {
 		return wipeHostResponse{Err: err}, nil
 	}
-	return wipeHostResponse{}, nil
+	// We bail if a host is locked or wiped, so we can assume the host is unlocked at this point
+	return wipeHostResponse{DeviceStatus: fleet.DeviceStatusUnlocked, PendingAction: fleet.PendingActionWipe}, nil
 }
 
 func (svc *Service) WipeHost(ctx context.Context, hostID uint) error {


### PR DESCRIPTION
For #23241.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/Committing-Changes.md#changes-files) for more information.
- [x] Added/updated automated tests
- [x] A detailed QA plan exists on the associated ticket (if it isn't there, work with the product group's QA engineer to add it)
- [x] Manual QA for all new/changed functionality
- [x] Docs re-PR'd