### PR TITLE
Fleet UI: Surface download URL for Fleet-maintained app when adding

### DIFF
--- a/changes/23116-fma-dl-url
+++ b/changes/23116-fma-dl-url
@@ -1,0 +1,1 @@
+- Fleet UI: Surfaced download URL for Fleet-maintained app when adding the software to Fleet

--- a/frontend/__mocks__/softwareMock.ts
+++ b/frontend/__mocks__/softwareMock.ts
@@ -290,6 +290,7 @@ const DEFAULT_FLEET_MAINTAINED_APP_DETAILS_MOCK: IFleetMaintainedAppDetails = {
   post_install_script: 'echo "Installed"',
   uninstall_script:
     "#!/bin/sh\n\n# Fleet extracts and saves package IDs\npkg_ids=$PACKAGE_ID",
+  url: "http://www.testurl1234abcd.com/testapp",
 };
 
 export const createMockFleetMaintainedAppDetails = (

--- a/frontend/components/DataSet/_styles.scss
+++ b/frontend/components/DataSet/_styles.scss
@@ -1,6 +1,7 @@
 .data-set {
   font-size: $x-small;
-  min-width: max-content;
+  max-width: min-content;
+  overflow: hidden;
 
   // ff only
   @-moz-document url-prefix() {

--- a/frontend/components/TableContainer/DataTable/PlatformCell/PlatformCell.tests.tsx
+++ b/frontend/components/TableContainer/DataTable/PlatformCell/PlatformCell.tests.tsx
@@ -1,8 +1,6 @@
 import React from "react";
 import { render, screen } from "@testing-library/react";
 
-import { DEFAULT_EMPTY_CELL_VALUE } from "utilities/constants";
-
 import { ScheduledQueryablePlatform } from "interfaces/platform";
 import PlatformCell from "./PlatformCell";
 

--- a/frontend/interfaces/software.ts
+++ b/frontend/interfaces/software.ts
@@ -463,4 +463,5 @@ export interface IFleetMaintainedAppDetails {
   install_script: string;
   post_install_script: string; // TODO: is this needed?
   uninstall_script: string;
+  url: string;
 }

--- a/frontend/pages/DashboardPage/cards/ActivityFeed/components/SoftwareDetailsModal/_styles.scss
+++ b/frontend/pages/DashboardPage/cards/ActivityFeed/components/SoftwareDetailsModal/_styles.scss
@@ -1,11 +1,8 @@
 .software-details-modal {
   &__modal-content {
     display: flex;
-    align-items: flex-start;
-    align-content: flex-start;
-    gap: 40px;
-    align-self: stretch;
-    flex-wrap: wrap;
+    column-gap: $pad-xxlarge;
+    row-gap: $pad-xlarge;
   }
 
   .react-tooltip {

--- a/frontend/pages/DashboardPage/cards/ActivityFeed/components/SoftwareDetailsModal/_styles.scss
+++ b/frontend/pages/DashboardPage/cards/ActivityFeed/components/SoftwareDetailsModal/_styles.scss
@@ -3,6 +3,7 @@
     display: flex;
     column-gap: $pad-xxlarge;
     row-gap: $pad-xlarge;
+    flex-wrap: wrap;
   }
 
   .react-tooltip {

--- a/frontend/pages/DashboardPage/cards/ActivityFeed/components/SoftwareDetailsModal/_styles.scss
+++ b/frontend/pages/DashboardPage/cards/ActivityFeed/components/SoftwareDetailsModal/_styles.scss
@@ -1,8 +1,10 @@
 .software-details-modal {
   &__modal-content {
     display: flex;
-    column-gap: $pad-xxlarge;
-    row-gap: $pad-xlarge;
+    align-items: flex-start;
+    align-content: flex-start;
+    gap: 40px;
+    align-self: stretch;
     flex-wrap: wrap;
   }
 

--- a/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareFleetMaintained/FleetMaintainedAppDetailsPage/AddFleetAppSoftwareModal/AddFleetAppSoftwareModal.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareFleetMaintained/FleetMaintainedAppDetailsPage/AddFleetAppSoftwareModal/AddFleetAppSoftwareModal.tsx
@@ -1,7 +1,8 @@
+import React from "react";
+import { noop } from "lodash";
+
 import Modal from "components/Modal";
 import Spinner from "components/Spinner";
-import { noop } from "lodash";
-import React from "react";
 
 const baseClass = "add-fleet-app-software-modal";
 

--- a/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareFleetMaintained/FleetMaintainedAppDetailsPage/FleetAppDetailsModal/FleetAppDetailsModal.tests.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareFleetMaintained/FleetMaintainedAppDetailsPage/FleetAppDetailsModal/FleetAppDetailsModal.tests.tsx
@@ -11,6 +11,7 @@ describe("FleetAppDetailsModal", () => {
     platform: "macOS",
     version: "1.0.0",
     url: "https://example.com/app",
+    onCancel: noop,
   };
 
   it("renders modal with correct title", () => {

--- a/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareFleetMaintained/FleetMaintainedAppDetailsPage/FleetAppDetailsModal/FleetAppDetailsModal.tests.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareFleetMaintained/FleetMaintainedAppDetailsPage/FleetAppDetailsModal/FleetAppDetailsModal.tests.tsx
@@ -35,9 +35,9 @@ describe("FleetAppDetailsModal", () => {
     expect(screen.getByText("Version")).toBeInTheDocument();
     expect(screen.getByText("1.0.0")).toBeInTheDocument();
     expect(screen.getByText("URL")).toBeInTheDocument();
-    expect(
-      screen.getByText(/https:\/\/example\.com\/app/i)
-    ).toBeInTheDocument();
+    expect(screen.getByText("URL").nextSibling).toHaveTextContent(
+      "https://example.com/app"
+    );
   });
 
   it("does not render URL field when url prop is not provided", () => {

--- a/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareFleetMaintained/FleetMaintainedAppDetailsPage/FleetAppDetailsModal/FleetAppDetailsModal.tests.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareFleetMaintained/FleetMaintainedAppDetailsPage/FleetAppDetailsModal/FleetAppDetailsModal.tests.tsx
@@ -35,7 +35,9 @@ describe("FleetAppDetailsModal", () => {
     expect(screen.getByText("Version")).toBeInTheDocument();
     expect(screen.getByText("1.0.0")).toBeInTheDocument();
     expect(screen.getByText("URL")).toBeInTheDocument();
-    expect(screen.getByText("https://example.com/app")).toBeInTheDocument();
+    expect(
+      screen.getByText(/https:\/\/example\.com\/app/i)
+    ).toBeInTheDocument();
   });
 
   it("does not render URL field when url prop is not provided", () => {

--- a/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareFleetMaintained/FleetMaintainedAppDetailsPage/FleetAppDetailsModal/FleetAppDetailsModal.tests.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareFleetMaintained/FleetMaintainedAppDetailsPage/FleetAppDetailsModal/FleetAppDetailsModal.tests.tsx
@@ -1,0 +1,48 @@
+import React from "react";
+import { screen } from "@testing-library/react";
+import { noop } from "lodash";
+import { createCustomRenderer } from "test/test-utils";
+
+import FleetAppDetailsModal from "./FleetAppDetailsModal";
+
+describe("FleetAppDetailsModal", () => {
+  const defaultProps = {
+    name: "Test App",
+    platform: "macOS",
+    version: "1.0.0",
+    url: "https://example.com/app",
+  };
+
+  it("renders modal with correct title", () => {
+    const render = createCustomRenderer();
+
+    render(<FleetAppDetailsModal {...defaultProps} />);
+
+    const modalTitle = screen.getByText("Software details");
+    expect(modalTitle).toBeInTheDocument();
+  });
+
+  it("displays correct app details", () => {
+    const render = createCustomRenderer();
+
+    render(<FleetAppDetailsModal {...defaultProps} />);
+
+    expect(screen.getByText("Name")).toBeInTheDocument();
+    expect(screen.getByText("Test App")).toBeInTheDocument();
+    expect(screen.getByText("Platform")).toBeInTheDocument();
+    expect(screen.getByText("macOS")).toBeInTheDocument();
+    expect(screen.getByText("Version")).toBeInTheDocument();
+    expect(screen.getByText("1.0.0")).toBeInTheDocument();
+    expect(screen.getByText("URL")).toBeInTheDocument();
+    expect(screen.getByText("https://example.com/app")).toBeInTheDocument();
+  });
+
+  it("does not render URL field when url prop is not provided", () => {
+    const render = createCustomRenderer();
+    const propsWithoutUrl = { ...defaultProps, url: undefined };
+
+    render(<FleetAppDetailsModal {...propsWithoutUrl} />);
+
+    expect(screen.queryByText("URL")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareFleetMaintained/FleetMaintainedAppDetailsPage/FleetAppDetailsModal/FleetAppDetailsModal.tests.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareFleetMaintained/FleetMaintainedAppDetailsPage/FleetAppDetailsModal/FleetAppDetailsModal.tests.tsx
@@ -35,9 +35,9 @@ describe("FleetAppDetailsModal", () => {
     expect(screen.getByText("Version")).toBeInTheDocument();
     expect(screen.getByText("1.0.0")).toBeInTheDocument();
     expect(screen.getByText("URL")).toBeInTheDocument();
-    expect(screen.getByText("URL").nextSibling).toHaveTextContent(
-      "https://example.com/app"
-    );
+    expect(
+      screen.getAllByText("https://example.com/app").length
+    ).toBeGreaterThan(0); // Tooltip renders text twice causing use of toBeInTheDocument to fail
   });
 
   it("does not render URL field when url prop is not provided", () => {

--- a/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareFleetMaintained/FleetMaintainedAppDetailsPage/FleetAppDetailsModal/FleetAppDetailsModal.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareFleetMaintained/FleetMaintainedAppDetailsPage/FleetAppDetailsModal/FleetAppDetailsModal.tsx
@@ -4,6 +4,7 @@ import { noop } from "lodash";
 import Modal from "components/Modal";
 import DataSet from "components/DataSet";
 import TooltipWrapper from "components/TooltipWrapper";
+import TooltipTruncatedText from "components/TooltipTruncatedText";
 
 const baseClass = "fleet-app-details-modal";
 
@@ -12,6 +13,7 @@ interface IFleetAppDetailsModalProps {
   platform: string;
   version: string;
   url?: string;
+  onCancel: () => void;
 }
 
 const TOOLTIP_MESSAGE =
@@ -22,9 +24,10 @@ const FleetAppDetailsModal = ({
   platform,
   version,
   url,
+  onCancel,
 }: IFleetAppDetailsModalProps) => {
   return (
-    <Modal className={baseClass} title="Software details" onExit={noop}>
+    <Modal className={baseClass} title="Software details" onExit={onCancel}>
       <>
         <div className={`${baseClass}__modal-content`}>
           <DataSet title="Name" value={name} />
@@ -37,7 +40,7 @@ const FleetAppDetailsModal = ({
                   URL
                 </TooltipWrapper>
               }
-              value={url}
+              value={<TooltipTruncatedText value={url} />}
             />
           )}
         </div>

--- a/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareFleetMaintained/FleetMaintainedAppDetailsPage/FleetAppDetailsModal/FleetAppDetailsModal.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareFleetMaintained/FleetMaintainedAppDetailsPage/FleetAppDetailsModal/FleetAppDetailsModal.tsx
@@ -1,0 +1,49 @@
+import React from "react";
+import { noop } from "lodash";
+
+import Modal from "components/Modal";
+import DataSet from "components/DataSet";
+import TooltipWrapper from "components/TooltipWrapper";
+
+const baseClass = "fleet-app-details-modal";
+
+interface IFleetAppDetailsModalProps {
+  name: string;
+  platform: string;
+  version: string;
+  url?: string;
+}
+
+const TOOLTIP_MESSAGE =
+  "Fleet downloads the package from the URL and stores it. Hosts download it from Fleet before install.";
+
+const FleetAppDetailsModal = ({
+  name,
+  platform,
+  version,
+  url,
+}: IFleetAppDetailsModalProps) => {
+  return (
+    <Modal className={baseClass} title="Software details" onExit={noop}>
+      <>
+        <div className={`${baseClass}__modal-content`}>
+          <DataSet title="Name" value={name} />
+          <DataSet title="Platform" value={platform} />
+          <DataSet title="Version" value={version} />
+          {url && (
+            <DataSet
+              title={
+                <TooltipWrapper tipContent={TOOLTIP_MESSAGE}>
+                  URL
+                </TooltipWrapper>
+              }
+              value={url}
+            />
+          )}
+        </div>
+      </>
+    </Modal>
+  );
+};
+
+export default FleetAppDetailsModal;

--- a/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareFleetMaintained/FleetMaintainedAppDetailsPage/FleetAppDetailsModal/FleetAppDetailsModal.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareFleetMaintained/FleetMaintainedAppDetailsPage/FleetAppDetailsModal/FleetAppDetailsModal.tsx
@@ -1,10 +1,10 @@
 import React from "react";
-import { noop } from "lodash";
 
 import Modal from "components/Modal";
 import DataSet from "components/DataSet";
 import TooltipWrapper from "components/TooltipWrapper";
 import TooltipTruncatedText from "components/TooltipTruncatedText";
+import Button from "components/buttons/Button";
 
 const baseClass = "fleet-app-details-modal";
 
@@ -43,6 +43,11 @@ const FleetAppDetailsModal = ({
               value={<TooltipTruncatedText value={url} />}
             />
           )}
+        </div>
+        <div className="modal-cta-wrap">
+          <Button onClick={onCancel} variant="brand">
+            Done
+          </Button>
         </div>
       </>
     </Modal>

--- a/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareFleetMaintained/FleetMaintainedAppDetailsPage/FleetAppDetailsModal/_styles.scss
+++ b/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareFleetMaintained/FleetMaintainedAppDetailsPage/FleetAppDetailsModal/_styles.scss
@@ -1,0 +1,12 @@
+.fleet-app-details-modal {
+  &__modal-content {
+    display: flex;
+    column-gap: $pad-xxlarge;
+    row-gap: $pad-xlarge;
+    flex-wrap: wrap;
+  }
+
+  .react-tooltip {
+    min-width: 120px;
+  }
+}

--- a/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareFleetMaintained/FleetMaintainedAppDetailsPage/FleetAppDetailsModal/index.ts
+++ b/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareFleetMaintained/FleetMaintainedAppDetailsPage/FleetAppDetailsModal/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./FleetAppDetailsModal";

--- a/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareFleetMaintained/FleetMaintainedAppDetailsPage/FleetMaintainedAppDetailsPage.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareFleetMaintained/FleetMaintainedAppDetailsPage/FleetMaintainedAppDetailsPage.tsx
@@ -47,7 +47,6 @@ interface IFleetAppSummaryProps {
   name: string;
   platform: string;
   version: string;
-  url: string;
   onClickShowAppDetails: (event: MouseEvent) => void;
 }
 
@@ -55,7 +54,6 @@ const FleetAppSummary = ({
   name,
   platform,
   version,
-  url,
   onClickShowAppDetails,
 }: IFleetAppSummaryProps) => {
   return (
@@ -291,7 +289,6 @@ const FleetMaintainedAppDetailsPage = ({
               name={fleetApp.name}
               platform={fleetApp.platform}
               version={fleetApp.version}
-              url={fleetApp.url || "http://www.fakeurl.com"}
               onClickShowAppDetails={onClickShowAppDetails}
             />
             <FleetAppDetailsForm

--- a/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareFleetMaintained/FleetMaintainedAppDetailsPage/FleetMaintainedAppDetailsPage.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareFleetMaintained/FleetMaintainedAppDetailsPage/FleetMaintainedAppDetailsPage.tsx
@@ -332,6 +332,7 @@ const FleetMaintainedAppDetailsPage = ({
           platform={fleetApp.platform}
           version={fleetApp.version}
           url={fleetApp.url}
+          onCancel={() => setShowAppDetailsModal(false)}
         />
       )}
     </>

--- a/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareFleetMaintained/FleetMaintainedAppDetailsPage/FleetMaintainedAppDetailsPage.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareFleetMaintained/FleetMaintainedAppDetailsPage/FleetMaintainedAppDetailsPage.tsx
@@ -25,12 +25,14 @@ import SidePanelContent from "components/SidePanelContent";
 import QuerySidePanel from "components/side_panels/QuerySidePanel";
 import PremiumFeatureMessage from "components/PremiumFeatureMessage";
 import Card from "components/Card";
-
 import SoftwareIcon from "pages/SoftwarePage/components/icons/SoftwareIcon";
-
+import Button from "components/buttons/Button";
+import Icon from "components/Icon";
 import FleetAppDetailsForm from "./FleetAppDetailsForm";
 import { IFleetMaintainedAppFormData } from "./FleetAppDetailsForm/FleetAppDetailsForm";
+
 import AddFleetAppSoftwareModal from "./AddFleetAppSoftwareModal";
+import FleetAppDetailsModal from "./FleetAppDetailsModal";
 
 import {
   getErrorMessage,
@@ -41,34 +43,50 @@ import {
 
 const baseClass = "fleet-maintained-app-details-page";
 
-interface ISoftwareSummaryProps {
+interface IFleetAppSummaryProps {
   name: string;
   platform: string;
   version: string;
+  url: string;
+  onClickShowAppDetails: (event: MouseEvent) => void;
 }
 
 const FleetAppSummary = ({
   name,
   platform,
   version,
-}: ISoftwareSummaryProps) => {
+  url,
+  onClickShowAppDetails,
+}: IFleetAppSummaryProps) => {
   return (
     <Card
       className={`${baseClass}__fleet-app-summary`}
       borderRadiusSize="medium"
+      color="gray"
     >
-      <SoftwareIcon name={name} size="medium" />
-      <div className={`${baseClass}__fleet-app-summary--details`}>
-        <div className={`${baseClass}__fleet-app-summary--title`}>{name}</div>
-        <div className={`${baseClass}__fleet-app-summary--info`}>
-          <div className={`${baseClass}__fleet-app-summary--details--platform`}>
-            {PLATFORM_DISPLAY_NAMES[platform as Platform]}
-          </div>
-          &bull;
-          <div className={`${baseClass}__fleet-app-summary--details--version`}>
-            {version}
+      <div className={`${baseClass}__fleet-app-summary--left`}>
+        <SoftwareIcon name={name} size="medium" />
+        <div className={`${baseClass}__fleet-app-summary--details`}>
+          <div className={`${baseClass}__fleet-app-summary--title`}>{name}</div>
+          <div className={`${baseClass}__fleet-app-summary--info`}>
+            <div
+              className={`${baseClass}__fleet-app-summary--details--platform`}
+            >
+              {PLATFORM_DISPLAY_NAMES[platform as Platform]}
+            </div>
+            &bull;
+            <div
+              className={`${baseClass}__fleet-app-summary--details--version`}
+            >
+              {version}
+            </div>
           </div>
         </div>
+      </div>
+      <div className={`${baseClass}__fleet-app-summary--show-details`}>
+        <Button variant="text-icon" onClick={onClickShowAppDetails}>
+          <Icon name="info" /> Show details
+        </Button>
       </div>
     </Card>
   );
@@ -116,6 +134,7 @@ const FleetMaintainedAppDetailsPage = ({
     showAddFleetAppSoftwareModal,
     setShowAddFleetAppSoftwareModal,
   ] = useState(false);
+  const [showAppDetailsModal, setShowAppDetailsModal] = useState(false);
 
   const {
     data: fleetApp,
@@ -150,6 +169,10 @@ const FleetMaintainedAppDetailsPage = ({
 
   const onOsqueryTableSelect = (tableName: string) => {
     setSelectedOsqueryTable(tableName);
+  };
+
+  const onClickShowAppDetails = () => {
+    setShowAppDetailsModal(true);
   };
 
   const backToAddSoftwareUrl = `${
@@ -268,6 +291,8 @@ const FleetMaintainedAppDetailsPage = ({
               name={fleetApp.name}
               platform={fleetApp.platform}
               version={fleetApp.version}
+              url={fleetApp.url || "http://www.fakeurl.com"}
+              onClickShowAppDetails={onClickShowAppDetails}
             />
             <FleetAppDetailsForm
               labels={labels || []}
@@ -304,6 +329,14 @@ const FleetMaintainedAppDetailsPage = ({
         </SidePanelContent>
       )}
       {showAddFleetAppSoftwareModal && <AddFleetAppSoftwareModal />}
+      {showAppDetailsModal && fleetApp && (
+        <FleetAppDetailsModal
+          name={fleetApp.name}
+          platform={fleetApp.platform}
+          version={fleetApp.version}
+          url={fleetApp.url}
+        />
+      )}
     </>
   );
 };

--- a/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareFleetMaintained/FleetMaintainedAppDetailsPage/_styles.scss
+++ b/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareFleetMaintained/FleetMaintainedAppDetailsPage/_styles.scss
@@ -19,6 +19,11 @@
 
   &__fleet-app-summary {
     display: flex;
+    justify-content: space-between;
+  }
+
+  &__fleet-app-summary--left {
+    display: flex;
     gap: $pad-medium;
   }
 


### PR DESCRIPTION
## Issue
For #25250 

## Description
- Create "Software details" modal that shows details of FMA when adding the software to Fleet
See ticket for more info and QA plan
- +48 lines of basic test

## Screenshots (long, medium, short, and missing URL)
<img width="1175" alt="Screenshot 2025-01-27 at 12 51 24 PM" src="https://github.com/user-attachments/assets/f79f721f-dc9b-4c40-93b6-ce48d4fe197d" />
<img width="1271" alt="Screenshot 2025-01-27 at 12 49 44 PM" src="https://github.com/user-attachments/assets/8dedb5eb-a786-4ebf-8937-345a2106ee9e" />
<img width="1226" alt="Screenshot 2025-01-27 at 12 49 17 PM" src="https://github.com/user-attachments/assets/93cee1fa-a0b6-46fa-9141-c1377f61b311" />
<img width="1201" alt="Screenshot 2025-01-27 at 12 48 44 PM" src="https://github.com/user-attachments/assets/16be2937-eb43-4742-a46c-693af27f12a5" />

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/Committing-Changes.md#changes-files) for more information.
- [x] Added/updated automated tests
- [x] A detailed QA plan exists on the associated ticket (if it isn't there, work with the product group's QA engineer to add it)
- [x] Manual QA for all new/changed functionality
