### PR TITLE
Host vitals page: clarify that Fleet checks the default disk on Linux

### DIFF
--- a/docs/queries.yml
+++ b/docs/queries.yml
@@ -43,7 +43,7 @@ kind: built-in
 spec:
   name: Disk encryption (Linux)
   platform: linux
-  description: Retrieves the disk encryption status of a device running Linux.
+  description: "Retrieves the default disk's (/) encryption status of a device running Linux."
   query: |
     SELECT 
       de.encrypted, m.path 


### PR DESCRIPTION
Update the description on this page: https://fleetdm.com/vitals/disk-encryption-linux#linux

More context in Slack here.
