### PR TITLE
Docs: update OS settings status explanation

### DIFF
--- a/articles/custom-os-settings.md
+++ b/articles/custom-os-settings.md
@@ -30,7 +30,7 @@ In the Fleet UI, head to the **Controls > OS settings** tab.
 
 In the top box, with "Verified," "Verifying," "Pending," and "Failed" statuses, click each status to view a list of hosts:
 
-* **Verified**: hosts that applied all OS settings. Fleet verified with osquery on macOS and Windows hosts (declarations are verified with [DDM](https://support.apple.com/en-gb/guide/deployment/depb1bab77f8/web)).
+* **Verified**: hosts that applied all OS settings. Fleet verified by running an osquery query on macOS and Windows hosts (declarations profiles are verified with [DDM](https://support.apple.com/en-gb/guide/deployment/depb1bab77f8/web)).
 
 * Verifying: hosts that have acknowledged all MDM commands to apply OS settings. Fleet is verifying the OS settings are applied with osquery on macOS (declarations are verified with [DDM](https://support.apple.com/en-gb/guide/deployment/depb1bab77f8/web)) and Windows hosts. If the profile wasn't installed, Fleet will redeliver the profile.
 

--- a/articles/custom-os-settings.md
+++ b/articles/custom-os-settings.md
@@ -30,7 +30,7 @@ In the Fleet UI, head to the **Controls > OS settings** tab.
 
 In the top box, with "Verified," "Verifying," "Pending," and "Failed" statuses, click each status to view a list of hosts:
 
-* **Verified**: hosts that applied all OS settings. Fleet verified by running an osquery query on macOS and Windows hosts (declarations profiles are verified with [DDM](https://support.apple.com/en-gb/guide/deployment/depb1bab77f8/web)).
+* **Verified**: hosts that applied all OS settings. Fleet verified by running an osquery query on macOS and Windows hosts (declarations profiles are verified with [DDM](https://support.apple.com/en-gb/guide/deployment/depb1bab77f8/web)). Currently,iOS and iPadOS hosts will have "Verified" status after they acknowledge all MDM commands to apply OS settings.
 
 * Verifying: hosts that have acknowledged all MDM commands to apply OS settings. Fleet is verifying the OS settings are applied with osquery on macOS (declarations are verified with [DDM](https://support.apple.com/en-gb/guide/deployment/depb1bab77f8/web)) and Windows hosts. If the profile wasn't installed, Fleet will redeliver the profile.
 

--- a/articles/custom-os-settings.md
+++ b/articles/custom-os-settings.md
@@ -30,7 +30,7 @@ In the Fleet UI, head to the **Controls > OS settings** tab.
 
 In the top box, with "Verified," "Verifying," "Pending," and "Failed" statuses, click each status to view a list of hosts:
 
-* **Verified**: hosts that applied all OS settings. Fleet verified by running an osquery query on macOS and Windows hosts (declarations profiles are verified with [DDM](https://support.apple.com/en-gb/guide/deployment/depb1bab77f8/web)). Currently,iOS and iPadOS hosts will have "Verified" status after they acknowledge all MDM commands to apply OS settings.
+* **Verified**: hosts that applied all OS settings. Fleet verified by running an osquery query on macOS and Windows hosts (declarations profiles are verified with [DDM](https://support.apple.com/en-gb/guide/deployment/depb1bab77f8/web)). Currently, iOS and iPadOS hosts are "Verified" after they acknowledge all MDM commands to apply OS settings.
 
 * Verifying: hosts that have acknowledged all MDM commands to apply OS settings. Fleet is verifying the OS settings are applied with osquery on macOS (declarations are verified with [DDM](https://support.apple.com/en-gb/guide/deployment/depb1bab77f8/web)) and Windows hosts. If the profile wasn't installed, Fleet will redeliver the profile.
 

--- a/articles/custom-os-settings.md
+++ b/articles/custom-os-settings.md
@@ -30,7 +30,7 @@ In the Fleet UI, head to the **Controls > OS settings** tab.
 
 In the top box, with "Verified," "Verifying," "Pending," and "Failed" statuses, click each status to view a list of hosts:
 
-* **Verified**: hosts that applied all OS settings. Fleet verified by running an osquery query on macOS and Windows hosts (declarations profiles are verified with [DDM](https://support.apple.com/en-gb/guide/deployment/depb1bab77f8/web)). Currently, iOS and iPadOS hosts are "Verified" after they acknowledge all MDM commands to apply OS settings.
+* **Verified**: hosts that applied all OS settings. Fleet verified by running an osquery query on Windows and macOS hosts (declarations profiles are verified with [DDM](https://support.apple.com/en-gb/guide/deployment/depb1bab77f8/web)). Currently, iOS and iPadOS hosts are "Verified" after they acknowledge all MDM commands to apply OS settings.
 
 * Verifying: hosts that have acknowledged all MDM commands to apply OS settings. Fleet is verifying the OS settings are applied with osquery on macOS (declarations are verified with [DDM](https://support.apple.com/en-gb/guide/deployment/depb1bab77f8/web)) and Windows hosts. If the profile wasn't installed, Fleet will redeliver the profile.
 

--- a/articles/custom-os-settings.md
+++ b/articles/custom-os-settings.md
@@ -32,7 +32,7 @@ In the top box, with "Verified," "Verifying," "Pending," and "Failed" statuses, 
 
 * **Verified**: hosts that applied all OS settings. Fleet verified by running an osquery query on Windows and macOS hosts (declarations profiles are verified with [DDM](https://support.apple.com/en-gb/guide/deployment/depb1bab77f8/web)). Currently, iOS and iPadOS hosts are "Verified" after they acknowledge all MDM commands to apply OS settings.
 
-* Verifying: hosts that have acknowledged all MDM commands to apply OS settings. Fleet is verifying the OS settings are applied with osquery on macOS (declarations are verified with [DDM](https://support.apple.com/en-gb/guide/deployment/depb1bab77f8/web)) and Windows hosts. If the profile wasn't installed, Fleet will redeliver the profile.
+* Verifying: hosts that have acknowledged all MDM commands to apply OS settings. Fleet is verifying the OS settings are applied with osquery on Windows and macOS hosts (declarations are verified with [DDM](https://support.apple.com/en-gb/guide/deployment/depb1bab77f8/web)). If the profile wasn't installed, Fleet will redeliver the profile.
 
 * Pending: hosts that will receive MDM commands to apply OS settings when the hosts come online.
 

--- a/articles/custom-os-settings.md
+++ b/articles/custom-os-settings.md
@@ -30,13 +30,13 @@ In the Fleet UI, head to the **Controls > OS settings** tab.
 
 In the top box, with "Verified," "Verifying," "Pending," and "Failed" statuses, click each status to view a list of hosts:
 
-* Verified: hosts that installed all configuration profiles. Fleet has verified with osquery.
+* **Verified**: hosts that applied all OS settings. Fleet verified with osquery on macOS and Windows hosts (declarations are verified with [DDM](https://support.apple.com/en-gb/guide/deployment/depb1bab77f8/web)).
 
-* Verifying: hosts that have acknowledged all MDM commands to install configuration profiles. Fleet is verifying the profiles are installed with osquery. If the profile wasn't installed, Fleet will redeliver the profile.
+* Verifying: hosts that have acknowledged all MDM commands to apply OS settings. Fleet is verifying the OS settings are applied with osquery on macOS (declarations are verified with [DDM](https://support.apple.com/en-gb/guide/deployment/depb1bab77f8/web)) and Windows hosts. If the profile wasn't installed, Fleet will redeliver the profile.
 
-* Pending: hosts that will receive MDM commands to install configuration profiles when the hosts come online.
+* Pending: hosts that will receive MDM commands to apply OS settings when the hosts come online.
 
-* Failed: hosts that failed to install configuration profiles. For Windows profiles, the status codes are documented in Microsoft's documentation [here](https://learn.microsoft.com/en-us/windows/client-management/oma-dm-protocol-support#syncml-response-status-codes).
+* Failed: hosts that failed to apply OS settings. For Windows profiles, the status codes are documented in Microsoft's documentation [here](https://learn.microsoft.com/en-us/windows/client-management/oma-dm-protocol-support#syncml-response-status-codes).
 
 In the list of hosts, click on an individual host and click the **OS settings** item to see the status for a specific setting.
 

--- a/articles/custom-os-settings.md
+++ b/articles/custom-os-settings.md
@@ -34,7 +34,7 @@ In the top box, with "Verified," "Verifying," "Pending," and "Failed" statuses, 
 
 * Verifying: hosts that have acknowledged all MDM commands to apply OS settings. Fleet is verifying the OS settings are applied with osquery on Windows and macOS hosts (declarations are verified with [DDM](https://support.apple.com/en-gb/guide/deployment/depb1bab77f8/web)). If the profile wasn't installed, Fleet will redeliver the profile.
 
-* Pending: hosts that will receive MDM commands to apply OS settings when the hosts come online.
+* Pending: hosts that are running MDM commands or will run MDM commands to apply OS settings when they come online.
 
 * Failed: hosts that failed to apply OS settings. For Windows profiles, the status codes are documented in Microsoft's documentation [here](https://learn.microsoft.com/en-us/windows/client-management/oma-dm-protocol-support#syncml-response-status-codes).
 

--- a/articles/custom-os-settings.md
+++ b/articles/custom-os-settings.md
@@ -30,7 +30,7 @@ In the Fleet UI, head to the **Controls > OS settings** tab.
 
 In the top box, with "Verified," "Verifying," "Pending," and "Failed" statuses, click each status to view a list of hosts:
 
-* **Verified**: hosts that applied all OS settings. Fleet verified by running an osquery query on Windows and macOS hosts (declarations profiles are verified with [DDM](https://support.apple.com/en-gb/guide/deployment/depb1bab77f8/web)). Currently, iOS and iPadOS hosts are "Verified" after they acknowledge all MDM commands to apply OS settings.
+* **Verified**: hosts that applied all OS settings. Fleet verified by running an osquery query on Windows and macOS hosts (declarations profiles are verified with a [DDM StatusReport](https://developer.apple.com/documentation/devicemanagement/statusreport). Currently, iOS and iPadOS hosts are "Verified" after they acknowledge all MDM commands to apply OS settings.
 
 * Verifying: hosts that have acknowledged all MDM commands to apply OS settings. Fleet is verifying the OS settings are applied with osquery on Windows and macOS hosts (declarations are verified with [DDM](https://support.apple.com/en-gb/guide/deployment/depb1bab77f8/web)). If the profile wasn't installed, Fleet will redeliver the profile.
 

--- a/articles/custom-os-settings.md
+++ b/articles/custom-os-settings.md
@@ -30,9 +30,9 @@ In the Fleet UI, head to the **Controls > OS settings** tab.
 
 In the top box, with "Verified," "Verifying," "Pending," and "Failed" statuses, click each status to view a list of hosts:
 
-* **Verified**: hosts that applied all OS settings. Fleet verified by running an osquery query on Windows and macOS hosts (declarations profiles are verified with a [DDM StatusReport](https://developer.apple.com/documentation/devicemanagement/statusreport). Currently, iOS and iPadOS hosts are "Verified" after they acknowledge all MDM commands to apply OS settings.
+* **Verified**: hosts that applied all OS settings. Fleet verified by running an osquery query on Windows and macOS hosts (declarations profiles are verified with a [DDM StatusReport](https://developer.apple.com/documentation/devicemanagement/statusreport)). Currently, iOS and iPadOS hosts are "Verified" after they acknowledge all MDM commands to apply OS settings.
 
-* Verifying: hosts that have acknowledged all MDM commands to apply OS settings. Fleet is verifying the OS settings are applied with osquery on Windows and macOS hosts (declarations are verified with [DDM](https://support.apple.com/en-gb/guide/deployment/depb1bab77f8/web)). If the profile wasn't installed, Fleet will redeliver the profile.
+* Verifying: hosts that acknowledged all MDM commands to apply OS settings. Fleet is verifying the OS settings are applied with osquery on Windows and macOS hosts (declarations are verified with [DDM](https://support.apple.com/en-gb/guide/deployment/depb1bab77f8/web)). If the profile wasn't installed, Fleet will redeliver the profile.
 
 * Pending: hosts that are running MDM commands or will run MDM commands to apply OS settings when they come online.
 

--- a/articles/custom-os-settings.md
+++ b/articles/custom-os-settings.md
@@ -32,7 +32,7 @@ In the top box, with "Verified," "Verifying," "Pending," and "Failed" statuses, 
 
 * **Verified**: hosts that applied all OS settings. Fleet verified by running an osquery query on Windows and macOS hosts (declarations profiles are verified with a [DDM StatusReport](https://developer.apple.com/documentation/devicemanagement/statusreport)). Currently, iOS and iPadOS hosts are "Verified" after they acknowledge all MDM commands to apply OS settings.
 
-* Verifying: hosts that acknowledged all MDM commands to apply OS settings. Fleet is verifying the OS settings are applied with osquery on Windows and macOS hosts (declarations are verified with [DDM](https://support.apple.com/en-gb/guide/deployment/depb1bab77f8/web)). If the profile wasn't installed, Fleet will redeliver the profile.
+* Verifying: hosts that acknowledged all MDM commands to apply OS settings. Fleet is verifying. If the profile wasn't delivered, Fleet will redeliver the profile.
 
 * Pending: hosts that are running MDM commands or will run MDM commands to apply OS settings when they come online.
 


### PR DESCRIPTION
Related to: 
- #25656

I simplified language that we use in the tooltips in UI to not mention osquery. In this PR I'm adding additional information to the guide and improving language to match what we're using in the product (instead of "installed configuration profiles" -> "applied OS settings").