### PR TITLE
Switch "Disk encryption" casing for Windows/Linux profiles

### DIFF
--- a/changes/25191-disk-encryption-sentence-case
+++ b/changes/25191-disk-encryption-sentence-case
@@ -1,0 +1,1 @@
+* Fixed case consistency for "Disk encryption" in host OS settings modal

--- a/frontend/pages/hosts/details/OSSettingsModal/OSSettingsTable/OSSettingsTableConfig.tsx
+++ b/frontend/pages/hosts/details/OSSettingsModal/OSSettingsTable/OSSettingsTableConfig.tsx
@@ -86,7 +86,7 @@ const generateTableConfig = (
         const { name, platform, status } = cellProps.row.original;
         const isFailedWindowsDiskEncryption =
           platform === "windows" &&
-          name === "Disk Encryption" &&
+          name === "Disk encryption" &&
           status === "failed";
         return (
           <OSSettingsErrorCell

--- a/frontend/pages/hosts/details/helpers.ts
+++ b/frontend/pages/hosts/details/helpers.ts
@@ -37,7 +37,7 @@ export const generateWinDiskEncryptionSetting = (
   return {
     profile_uuid: "0", // This is the only type of profile that can have this value
     platform: "windows",
-    name: "Disk Encryption",
+    name: "Disk encryption",
     status: convertWinDiskEncryptionStatusToSettingStatus(diskEncryptionStatus),
     detail: generateWindowsDiskEncryptionMessage(diskEncryptionStatus, detail),
     operation_type: null,
@@ -57,7 +57,7 @@ export const generateLinuxDiskEncryptionSetting = (
   return {
     profile_uuid: "0", // This is the only type of profile that can have this value
     platform: "linux",
-    name: "Disk Encryption",
+    name: "Disk encryption",
     status: diskEncryptionStatus,
     detail,
     operation_type: null,


### PR DESCRIPTION
For #25191

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/Committing-Changes.md#changes-files) for more information.
- [x] Manual QA for all new/changed functionality

I can QA this later but @RachelElysia lmk if you can beat me to it. Requires a Linux host and a Windows host enrolled, which I'll have soon but don't have right this second.