### PR TITLE
UI - Improve handling of long team names by teams dropdown

### DIFF
--- a/changes/23924-handle-long-team-names
+++ b/changes/23924-handle-long-team-names
@@ -1,0 +1,1 @@
+* Improve the teams dropdown so that it gracefully hides overflow from long team names

--- a/frontend/components/TeamsDropdown/TeamsDropdown.tsx
+++ b/frontend/components/TeamsDropdown/TeamsDropdown.tsx
@@ -118,12 +118,13 @@ const TeamsDropdown = ({
     );
   };
 
+  // see https://react-select.com/styles#the-styles-prop
+  // `provided` here corresponds to `baseStyles` in the docs
   const customStyles: StylesConfig<INumberDropdownOption, false> = {
     control: (provided, state) => ({
       ...provided,
       display: "flex",
       flexDirection: "row",
-      width: "max-content",
       padding: "8px 0",
       backgroundColor: "initial",
       border: 0,
@@ -180,6 +181,8 @@ const TeamsDropdown = ({
       paddingLeft: 0,
       paddingRight: "8px",
       margin: 0,
+      // omit grid-column-end for automatic width
+      gridArea: "1/1/2",
     }),
     dropdownIndicator: (provided) => ({
       ...provided,

--- a/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
@@ -1685,7 +1685,7 @@ const ManageHostsPage = ({
     <>
       <MainContent>
         <div className={`${baseClass}`}>
-          <div className="header-wrap">
+          <div className={`${baseClass}__header-wrap`}>
             {renderHeader()}
             <div className={`${baseClass} button-wrap`}>
               {!isSandboxMode && canEnrollHosts && !hasErrors && (

--- a/frontend/pages/hosts/ManageHostsPage/_styles.scss
+++ b/frontend/pages/hosts/ManageHostsPage/_styles.scss
@@ -1,12 +1,12 @@
 .manage-hosts {
-  .header-wrap {
+  &__header-wrap {
     @include normalize-team-header;
     margin-bottom: $pad-medium;
 
     .button-wrap {
       display: flex;
       justify-content: flex-end;
-      min-width: 266px;
+      white-space: nowrap;
     }
   }
 
@@ -17,7 +17,6 @@
   &__header {
     display: flex;
     align-items: center;
-    min-width: 125px;
 
     .form-field {
       margin-bottom: 0;


### PR DESCRIPTION
## For #23924 

- Disallow text wrapping on the "manage hosts" button
- Allow dynamic width of teams dropdown values
- Hide and ellipsize team name overflow from dropdown container


![ezgif-748697f5cc45e](https://github.com/user-attachments/assets/751c0032-b8d5-4402-94dd-aae804e0e9ba)

![ezgif-7d1797450417e](https://github.com/user-attachments/assets/c40ce7a5-3c9a-485b-95e3-c9af20c79a23)

- [x] Changes file added for user-visible changes in `changes/`
- [x] Manual QA for all new/changed functionality
