### PR TITLE
UI - Maintain user's updates to the team agent options form when they navigate away and back again

### DIFF
--- a/changes/24035-team-agent-options-ui-resets
+++ b/changes/24035-team-agent-options-ui-resets
@@ -1,0 +1,1 @@
+* Maintain user's updates to the team agent options form when they navigate away and back again.

--- a/frontend/pages/admin/TeamManagementPage/TeamDetailsWrapper/AgentOptionsPage/AgentOptionsPage.tsx
+++ b/frontend/pages/admin/TeamManagementPage/TeamDetailsWrapper/AgentOptionsPage/AgentOptionsPage.tsx
@@ -68,6 +68,7 @@ const AgentOptionsPage = ({
         setTeamName(data.name);
       },
       onError: (error) => handlePageError(error),
+      refetchOnWindowFocus: false,
     }
   );
 


### PR DESCRIPTION
## For #24035 

- disable associated `useQuery`'s `refetchOnWindowFocus`

![ezgif-7c05abdfe4c30](https://github.com/user-attachments/assets/434e8b9e-a795-4173-8875-794736620753)

- [x] Changes file added for user-visible changes in `changes/`
- [x] Manual QA for all new/changed functionality
