### PR TITLE
Manual workflow to test `fleetd-base.msi`

### DIFF
--- a/.github/workflows/build-fleetd-base-msi.yml
+++ b/.github/workflows/build-fleetd-base-msi.yml
@@ -1,0 +1,109 @@
+# This workflow can be used to build a fleetd-base.msi package
+# that can be hosted on a local server to test Autopilot workflows.
+#
+# Output is the fleetd-base.msi itself and the corresponding meta.json.
+# Both files should be served at the stable/ path.
+name: Build and codesign fleetd-base.msi
+
+on:
+  workflow_dispatch: # allow manual action
+    inputs:
+      orbit-channel:
+        description: "TUF channel for the orbit component"
+        required: false
+        default: "stable"
+        type: string
+      osqueryd-channel:
+        description: "TUF channel for the osqueryd component"
+        required: false
+        default: "stable"
+        type: string
+      desktop-channel:
+        description: "TUF channel for the Fleet Desktop component"
+        required: false
+        default: "stable"
+        type: string
+      base-url:
+        description: "URL that will host the generated fleetd-base.msi and meta.json at stable/"
+        required: true
+        type: string
+
+defaults:
+  run:
+    # fail-fast using bash -eo pipefail. See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#exit-codes-and-error-action-preference
+    shell: bash
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@63c24ba6bd7ba022e95695ff85de572c04a18142 # v2.7.0
+        with:
+          egress-policy: audit
+
+      - name: Install fleetctl
+        run: npm install -g fleetctl
+
+      - name: Build MSI
+        id: build-msi
+        run: |
+          fleetctl package --type msi \
+            --fleet-desktop \
+            --fleet-url dummy \
+            --enroll-secret dummy \
+            --orbit-channel ${{ github.event.inputs.orbit-channel }} \
+            --osqueryd-channel ${{ github.event.inputs.osqueryd-channel }} \
+            --desktop-channel ${{ github.event.inputs.desktop-channel }}
+          mv fleet-osquery*.msi fleetd-base.msi
+
+      - name: Upload fleetd-base.msi for code signing
+        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # 4.3.3
+        with:
+          name: unsigned-windows
+          path: fleetd-base.msi
+
+  code-sign:
+    needs: build
+    uses: ./.github/workflows/code-sign-windows.yml
+    with:
+      filename: fleetd-base.msi
+      upload_name: fleetd-base-msi
+    secrets:
+      DIGICERT_KEYLOCKER_CERTIFICATE: ${{ secrets.DIGICERT_KEYLOCKER_CERTIFICATE }}
+      DIGICERT_KEYLOCKER_PASSWORD: ${{ secrets.DIGICERT_KEYLOCKER_PASSWORD }}
+      DIGICERT_KEYLOCKER_HOST_URL: ${{ secrets.DIGICERT_KEYLOCKER_HOST_URL }}
+      DIGICERT_API_KEY: ${{ secrets.DIGICERT_API_KEY }}
+      DIGICERT_KEYLOCKER_CERTIFICATE_FINGERPRINT: ${{ secrets.DIGICERT_KEYLOCKER_CERTIFICATE_FINGERPRINT }}
+
+  generate:
+    needs: [build, code-sign]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download signed artifact
+        uses: actions/download-artifact@9c19ed7fe5d278cd354c7dfd5d3b88589c7e2395 # v4.1.6
+        with:
+          name: fleetd-base-msi
+        
+      - name: Hash fleetd-base.msi
+        run: |
+          echo "fleetd_base_msi_sha256=$(shasum -a 256 fleetd-base.msi | cut -d ' ' -f 1)" >> $GITHUB_ENV
+
+      - name: Generate meta.json
+        run: |
+          
+          echo '{
+            "fleetd_base_msi_url": "${{ github.event.inputs.base-url }}/stable/fleetd-base.msi",
+            "fleetd_base_msi_sha256": "${{ env.fleetd_base_msi_sha256 }}"
+          }' > meta.json
+          : # Check that meta.json is valid
+          jq -e . >/dev/null 2>&1 <<< $(cat meta.json)
+
+      - name: Upload meta.json
+        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # 4.3.3
+        with:
+          name: meta.json
+          path: meta.json

--- a/docs/Contributing/Testing-and-local-development.md
+++ b/docs/Contributing/Testing-and-local-development.md
@@ -555,11 +555,11 @@ $ msiexec /i fleetd-base.msi FLEET_URL="<target_url>" FLEET_SECRET="<secret_to_u
 flow. Apple requires that applications installed via an `InstallEnterpriseApplication` command be
 signed with a development certificate.
 
-### Building and serving your own signed fleetd-base installer for macOS
+### Building and serving your own signed fleetd-base.pkg installer for macOS
 
-Signed fleetd-installers can be used during the ADE MDM enrollment flow. If you are
+Only signed fleetd installers can be used during the ADE MDM enrollment flow. If you are
 developing/testing logic that needs to run during that flow, you will need to build and serve a
-signed fleetd-base installer.
+signed fleetd-base.pkg installer.
 
 You will also need to serve the manifest for the fleetd-base installer. This manifest is used as
 part of the `InstallEnterpriseApplication` command that installs fleetd; it contains a checksum of
@@ -567,7 +567,8 @@ the fleetd-base installer file, as well as the URL at which the MDM protocol can
 installer file.
 
 #### Pre-requisites
-- An ngrok URL for serving the fleetd-base installer and the manifest .plist file
+
+- An ngrok URL for serving the `fleetd-base.pkg` installer and the manifest `.plist` file
 
 #### Building a signed fleetd-base installer from `edge`
 
@@ -586,7 +587,7 @@ To use the workflow, follow these steps:
   - `fleet-base.pkg`
 4. Download them to your workstation.
 
-#### Serving the signed fleetd-base installer
+#### Serving the signed fleetd-base.pkg installer
 
 1. Create a directory named `fleetd-base-dir` and a subdirectory named `stable`. Tip: we have the `$FLEET_REPO_ROOT_DIR/tmp`
    directory gitignored, so that's a convenient place to create the directories:
@@ -594,14 +595,60 @@ To use the workflow, follow these steps:
 # From the Fleet repo root dir
 mkdir -p ./tmp/fleetd-base-dir/stable
 ```
-2. Move `fleet-base.pkg` to `/fleetd-base-dir`.
-3. Move `fleet-base-manifest.plist` to `/fleetd-base-dir/stable`.
+2. Move `fleet-base.pkg` to `./tmp/fleetd-base-dir`.
+3. Move `fleet-base-manifest.plist` to `./tmp/fleetd-base-dir/stable`.
 4. Start up an HTTP file server from the Fleet repo root directory using the [`tools/file-server`](../../tools/file-server/README.md) tool: `go run ./tools/file-server 8085 ./tmp/fleetd-base-dir`
 5. Start your second ngrok tunnel and forward to http://localhost:8085.
 	- Example: `ngrok http --domain=more.pezhub.ngrok.app http://localhost:8085`
 6. Start your fleet server with `FLEET_DEV_DOWNLOAD_FLEETDM_URL` to point to the ngrok URL.
 	- Example: `FLEET_DEV_DOWNLOAD_FLEETDM_URL="https://more.pezhub.ngrok.app"`
 7. Enroll your mac with ADE. Tip: You can watch ngrok traffic via the inspect web interface url to ensure the two hosted packages are in the correct place and successfully reached by the host.
+
+### Building and serving your own signed fleetd-base.msi installer for Windows
+
+Only signed fleetd installers can be used during the Autopilot MDM enrollment flow. If you are
+developing/testing logic that needs to run during that flow, you will need to build and serve a
+signed fleetd-base.msi installer.
+
+You will also need to serve the `meta.json` for the fleetd-base.msi installer. 
+
+#### Pre-requisites
+
+- An ngrok URL for serving the `fleetd-base.msi` installer and the `meta.json` file under the `stable/` path.
+
+#### Building a signed fleetd-base.msi installer from `edge`
+
+We have a [GitHub workflow](../../.github/workflows/build-fleetd-base-msi.yml) that can build a signed
+fleetd-base installer using fleetd components from any of the release channels we support. You'll
+most likely use `edge` since we release fleetd components built from an RC branch to `edge` for
+QA before an official release.
+
+To use the workflow, follow these steps:
+
+1. Trigger the build and codesign fleetd-base.msi workflow at https://github.com/fleetdm/fleet/actions/workflows/build-fleetd-base-msi.yml.
+2. Click the run workflow drop down and fill in `"edge"` for the first 3 fields. Fill in the ngrok URL
+  from the "Pre-requisites" above in the last field.
+3. Click the Run workflow button. This will generate two files:
+  - `meta.json`
+  - `fleet-base.msi`
+4. Download them to your workstation.
+
+#### Serving the signed fleetd-base.msi installer
+
+1. Create a directory named `fleetd-base-dir` and a subdirectory named `stable`. Tip: we have the `$FLEET_REPO_ROOT_DIR/tmp`
+   directory gitignored, so that's a convenient place to create the directories:
+```sh
+# From the Fleet repo root dir
+mkdir -p ./tmp/fleetd-base-dir/stable
+```
+2. Move `fleet-base.msi` to `./tmp/fleetd-base-dir/stable`.
+3. Move `meta.json` to `./tmp/fleetd-base-dir/stable`.
+4. Start up an HTTP file server from the Fleet repo root directory using the [`tools/file-server`](../../tools/file-server/README.md) tool: `go run ./tools/file-server 8085 ./tmp/fleetd-base-dir`
+5. Start your second ngrok tunnel and forward to http://localhost:8085.
+	- Example: `ngrok http --domain=more.pezhub.ngrok.app http://localhost:8085`
+6. Start your fleet server with `FLEET_DEV_DOWNLOAD_FLEETDM_URL` to point to the ngrok URL.
+	- Example: `FLEET_DEV_DOWNLOAD_FLEETDM_URL="https://more.pezhub.ngrok.app"`
+7. Enroll your Windows device with Autopilot. Tip: You can watch ngrok traffic via the inspect web interface url to ensure the two hosted packages are in the correct place and successfully reached by the host.
 
 ## MDM setup and testing
 


### PR DESCRIPTION
Manual workflow to test `fleetd-base.msi` using e.g. `edge` channels.

Similar to the existing: https://github.com/fleetdm/fleet/blob/main/.github/workflows/build-fleetd-base-pkg.yml