### PR TITLE
fix 500 page when filtering by vulnerabilities on host software

### DIFF
--- a/changes/issue-25735-fix-500-vulnerable-host-software
+++ b/changes/issue-25735-fix-500-vulnerable-host-software
@@ -1,0 +1,1 @@
+- fix when trying to filter by vulnerable software for ios or ipad host.

--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -1337,7 +1337,7 @@ Modifies the Fleet's configuration with the supplied information.
 {
   "server_settings": {
     "server_url": "https://localhost:8080",
-    "enable_analytics": true, 
+    "enable_analytics": true,
     "live_query_disabled": false,
     "query_reports_disabled": false,
     "ai_features_disabled": false
@@ -1837,7 +1837,7 @@ _Available in Fleet Premium._
           "path": "path/to/profile3.xml",
           "labels": ["Label 1", "Label 2"]
         }
-      ]     
+      ]
     },
     "end_user_authentication": {
       "entity_id": "",
@@ -3912,6 +3912,7 @@ Resends a configuration profile for the specified host.
 | id   | integer | path | **Required**. The host's ID. |
 | query   | string | query | Search query keywords. Searchable fields include `name`. |
 | available_for_install | boolean | query | If `true` or `1`, only list software that is available for install (added by the user). Default is `false`. |
+| vulnerable | boolean | query | If `true` or `1`, only list software that have vulnerabilities. Default is `false`. |
 | page | integer | query | Page number of the results to fetch.|
 | per_page | integer | query | Results per page.|
 
@@ -3970,7 +3971,7 @@ Resends a configuration profile for the specified host.
           "uninstalled_at": "2024-05-15T15:23:57Z"
         }
       },
-      "app_store_app": null,    
+      "app_store_app": null,
       "source": "",
       "status": "pending_uninstall",
       "installed_versions": [],
@@ -4279,7 +4280,7 @@ To wipe a macOS, iOS, iPadOS, or Windows host, the host must have MDM turned on.
         "script_execution_id": "ecf22dba-07dc-40a9-b122-5480e948b756",
         "status": "failed_uninstall"
       }
-    }, 
+    },
     {
       "created_at": "2023-07-27T14:35:08Z",
       "actor_id": 1,
@@ -5418,7 +5419,7 @@ Get aggregate status counts of profiles for to macOS and Windows hosts that are 
 - [Set custom MDM setup enrollment profile](#set-custom-mdm-setup-enrollment-profile)
 - [Get custom MDM setup enrollment profile](#get-custom-mdm-setup-enrollment-profile)
 - [Delete custom MDM setup enrollment profile](#delete-custom-mdm-setup-enrollment-profile)
-- [Get Over-the-Air (OTA) enrollment profile](#get-over-the-air-ota-enrollment-profile) 
+- [Get Over-the-Air (OTA) enrollment profile](#get-over-the-air-ota-enrollment-profile)
 - [Get manual enrollment profile](#get-manual-enrollment-profile)
 - [Upload a bootstrap package](#upload-a-bootstrap-package)
 - [Get metadata about a bootstrap package](#get-metadata-about-a-bootstrap-package)

--- a/frontend/components/EmptyTable/_styles.scss
+++ b/frontend/components/EmptyTable/_styles.scss
@@ -60,6 +60,7 @@
       justify-content: center;
       margin-bottom: 20px;
       min-height: 155px;
+      max-width: none;
     }
   }
 }

--- a/frontend/pages/hosts/details/cards/Software/HostSoftware.tsx
+++ b/frontend/pages/hosts/details/cards/Software/HostSoftware.tsx
@@ -306,19 +306,7 @@ const HostSoftware = ({
             isLoading={
               isMyDevicePage ? deviceSoftwareFetching : hostSoftwareFetching
             }
-            // this could be cleaner, however, we are going to revert this commit anyway once vulns are
-            // supported for iPad/iPhone, by the end of next sprint
-            data={
-              vulnFilterAndNotSupported
-                ? ({
-                    count: 0,
-                    meta: {
-                      has_next_results: false,
-                      has_previous_results: false,
-                    },
-                  } as IGetHostSoftwareResponse)
-                : data
-            } // eshould be mpty for iPad/iPhone since API call is disabled, but to be sure to trigger empty state
+            data={data}
             platform={platform}
             router={router}
             tableConfig={tableConfig}


### PR DESCRIPTION
For #25735

This is a fix for the 500 page appearing when filtering for vulnerable software on the host details page.

Also adds some missing docs for vulnerable query param filter on `GET hosts/:id/software` endpoint

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/Committing-Changes.md#changes-files) for more information.
- [x] Manual QA for all new/changed functionality
