### PR TITLE
Use get label hosts endpoint on Edit Label page

### DIFF
--- a/frontend/__mocks__/hostMock.ts
+++ b/frontend/__mocks__/hostMock.ts
@@ -117,6 +117,16 @@ const createMockHost = (overrides?: Partial<IHost>): IHost => {
 
 export const createMockHostResponse = { host: createMockHost() };
 
+export const createMockHostsResponse = (overrides?: Partial<IHost>[]) => {
+  const numHosts = overrides?.length || 1;
+  const hosts = Array(numHosts)
+    .fill(null)
+    .map((_, i) => createMockHost(overrides?.[i]));
+  return {
+    hosts,
+  };
+};
+
 export const createMockIosHostResponse = {
   host: createMockHost({
     hostname: "Test device (iPhone)",

--- a/frontend/pages/labels/EditLabelPage/EditLabelPage.tests.tsx
+++ b/frontend/pages/labels/EditLabelPage/EditLabelPage.tests.tsx
@@ -3,7 +3,10 @@ import React from "react";
 import { screen } from "@testing-library/react";
 import { createCustomRenderer } from "test/test-utils";
 import mockServer from "test/mock-server";
-import { getLabelHandler } from "test/handlers/label-handlers";
+import {
+  getLabelHandler,
+  getLabelHostsHandler,
+} from "test/handlers/label-handlers";
 
 import EditLabelPage from "./EditLabelPage";
 
@@ -60,6 +63,28 @@ describe("EditLabelPage", () => {
 
   it("renders the ManualLabelForm when the label is manual", async () => {
     mockServer.use(getLabelHandler({ label_membership_type: "manual" }));
+    mockServer.use(
+      getLabelHostsHandler([
+        {
+          hostname: "hosty numero uno",
+          display_name: "Test host #1",
+          team_id: 2,
+          team_name: "Mobile",
+          platform: "ios",
+          os_version: "iOS 14.7.1",
+          hardware_serial: "test-serial-1",
+        },
+        {
+          hostname: "hosty numero dos",
+          display_name: "Test host #2",
+          team_id: 2,
+          team_name: "Mobile",
+          platform: "ios",
+          os_version: "iOS 14.7.1",
+          hardware_serial: "test-serial-2",
+        },
+      ])
+    );
     const render = createCustomRenderer({ withBackendMock: true });
 
     const routerProps = generateMockRouterProps({
@@ -71,5 +96,11 @@ describe("EditLabelPage", () => {
     const selectHostsLabel = await screen.findByText("Select hosts");
 
     expect(selectHostsLabel).toBeInTheDocument();
+
+    // expect host info to be on the page
+    const host1 = await screen.findByText("Test host #1");
+    const host2 = await screen.findByText("Test host #2");
+    expect(host1).toBeInTheDocument();
+    expect(host2).toBeInTheDocument();
   });
 });

--- a/frontend/pages/labels/EditLabelPage/EditLabelPage.tsx
+++ b/frontend/pages/labels/EditLabelPage/EditLabelPage.tsx
@@ -4,8 +4,10 @@ import { RouteComponentProps } from "react-router";
 import { AxiosError } from "axios";
 
 import PATHS from "router/paths";
-import labelsAPI, { IGetLabelResonse } from "services/entities/labels";
-import hostAPI from "services/entities/hosts";
+import labelsAPI, {
+  IGetHostsInLabelResponse,
+  IGetLabelResonse,
+} from "services/entities/labels";
 import { DEFAULT_USE_QUERY_OPTIONS } from "utilities/constants";
 import { ILabel } from "interfaces/label";
 import { IHost } from "interfaces/host";
@@ -49,21 +51,18 @@ const EditLabelPage = ({ routeParams, router }: IEditLabelPageProps) => {
     }
   );
 
-  // TODO: clean this up when API allows getting hosts by
-  // host ids in a single request. We need to make another request when
-  // the label is manual to get the host data for the targeted hosts.
   const {
     data: targetedHosts,
     isLoading: isLoadingHosts,
     isError: isErrorHosts,
-  } = useQuery<{ host: IHost }[], AxiosError, IHost[]>(
+  } = useQuery<IGetHostsInLabelResponse, AxiosError, IHost[]>(
     ["hosts"],
     () => {
-      return hostAPI.getHosts(label?.host_ids ?? []);
+      return labelsAPI.getHostsInLabel(labelId);
     },
     {
       ...DEFAULT_USE_QUERY_OPTIONS,
-      select: (res) => res.map((host) => host.host),
+      select: (data) => data.hosts,
       enabled: label?.label_membership_type === "manual",
     }
   );

--- a/frontend/services/entities/hosts.ts
+++ b/frontend/services/entities/hosts.ts
@@ -351,17 +351,6 @@ export default {
 
     return sendRequest("GET", path);
   },
-  // TODO: change/remove this when backend implments way for client to get
-  // a collection of hosts based on ho  st ids
-  getHosts: (hostIds: number[]) => {
-    return Promise.all(
-      hostIds.map((hostId) => {
-        const { HOSTS } = endpoints;
-        const path = `${HOSTS}/${hostId}`;
-        return sendRequest("GET", path);
-      })
-    );
-  },
 
   loadHosts: ({
     page = 0,

--- a/frontend/services/entities/labels.ts
+++ b/frontend/services/entities/labels.ts
@@ -21,6 +21,10 @@ export interface ICreateLabelResponse {
 export type IUpdateLabelResponse = ICreateLabelResponse;
 export type IGetLabelResonse = ICreateLabelResponse;
 
+export interface IGetHostsInLabelResponse {
+  hosts: IHost[];
+}
+
 const isManualLabelFormData = (
   formData: IDynamicLabelFormData | IManualLabelFormData
 ): formData is IManualLabelFormData => {
@@ -122,5 +126,10 @@ export default {
   getLabel: (labelId: number): Promise<IGetLabelResonse> => {
     const { LABEL } = endpoints;
     return sendRequest("GET", LABEL(labelId));
+  },
+
+  getHostsInLabel: (labelId: number): Promise<IGetHostsInLabelResponse> => {
+    const { LABEL_HOSTS } = endpoints;
+    return sendRequest("GET", LABEL_HOSTS(labelId));
   },
 };

--- a/frontend/test/handlers/label-handlers.ts
+++ b/frontend/test/handlers/label-handlers.ts
@@ -2,7 +2,9 @@ import { http, HttpResponse } from "msw";
 
 import { baseUrl } from "test/test-utils";
 import { createMockLabel } from "__mocks__/labelsMock";
+import { createMockHostsResponse } from "__mocks__/hostMock";
 import { ILabel } from "interfaces/label";
+import { IHost } from "interfaces/host";
 
 // eslint-disable-next-line import/prefer-default-export
 export const getLabelHandler = (overrides: Partial<ILabel>) =>
@@ -10,4 +12,9 @@ export const getLabelHandler = (overrides: Partial<ILabel>) =>
     return HttpResponse.json({
       label: createMockLabel({ ...overrides }),
     });
+  });
+
+export const getLabelHostsHandler = (mockHosts: Partial<IHost>[] | undefined) =>
+  http.get(baseUrl("/labels/:id/hosts"), () => {
+    return HttpResponse.json(createMockHostsResponse(mockHosts));
   });


### PR DESCRIPTION
For #25555 

This PR fixes a failure when attempting to go to the "Edit Label" page in the UI for manual label with a large # of hosts.  Rather than making one API request per host in the label, we instead use the "get hosts for label" API to get them all at once.

https://github.com/user-attachments/assets/5144efa1-d466-4565-9c5b-5a1456fe0de1

