### PR TITLE
Update "IT engineering" CTA

### DIFF
--- a/website/views/pages/homepage.ejs
+++ b/website/views/pages/homepage.ejs
@@ -84,7 +84,7 @@
           <strong>In the cloud or on-prem</strong>
           <p>Fleet uses the same open-source code base regardless of where it’s installed. You can deploy and configure it to fit your needs.</p>
           <div>
-            <a purpose="category-button" class="text-nowrap btn btn-primary" href="/orchestration?purpose=it">More about IT engineering</a>
+            <a purpose="category-button" class="text-nowrap btn btn-primary" href="/docs/get-started/why-fleet">See the docs</a>
           </div>
         </div>
       </div>


### PR DESCRIPTION
Updated the "IT engineering" CTA. Idea being that it may resonate better with IT engineers if we link them straight into the "Why Fleet" section of the docs.