### PR TITLE
Temporarily comment out goreleaser tag prefix

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -2,9 +2,9 @@ version: 2
 
 project_name: fleet
 
-monorepo:
-  tag_prefix: fleet-
-  dir: .
+# monorepo:
+#  tag_prefix: fleet-
+#  dir: .
 
 before:
   hooks:


### PR DESCRIPTION
I believe goreleaser is failing on the `rc-fleetctl` tag because of this. Commenting out temporarily to test. 