### PR TITLE
Fleet UI: New button dropdown does not render option over placeholder when selected

### DIFF
--- a/frontend/components/forms/fields/DropdownWrapper/DropdownWrapper.tests.tsx
+++ b/frontend/components/forms/fields/DropdownWrapper/DropdownWrapper.tests.tsx
@@ -99,4 +99,32 @@ describe("DropdownWrapper Component", () => {
 
     expect(screen.getByText(/no results found/i)).toBeInTheDocument();
   });
+
+  test("doesn't render selected value when variant is button", async () => {
+    const buttonText = "Click me";
+    render(
+      <DropdownWrapper
+        options={sampleOptions}
+        value="option1"
+        onChange={mockOnChange}
+        name="test-dropdown"
+        label="Test Dropdown"
+        placeholder={buttonText}
+        variant="button"
+      />
+    );
+
+    // Check if the button text is rendered
+    expect(screen.getByText(buttonText)).toBeInTheDocument();
+
+    // Open the dropdown
+    await userEvent.click(screen.getByText(buttonText));
+
+    // Select Option 2
+    await userEvent.click(screen.getByText(/option 2/i));
+
+    // Check if the button text is still rendered and not replaced by the selected option
+    expect(screen.getByText(buttonText)).toBeInTheDocument();
+    expect(screen.queryByText(/option 2/i)).not.toBeInTheDocument();
+  });
 });

--- a/frontend/components/forms/fields/DropdownWrapper/DropdownWrapper.tsx
+++ b/frontend/components/forms/fields/DropdownWrapper/DropdownWrapper.tsx
@@ -473,6 +473,7 @@ const DropdownWrapper = ({
         tabIndex={isDisabled ? -1 : 0} // Ensures disabled dropdown has no keyboard accessibility
         placeholder={placeholder}
         onMenuOpen={onMenuOpen}
+        controlShouldRenderValue={variant !== "button"}
       />
     </FormField>
   );


### PR DESCRIPTION
## Issue
For #25946

## Description
- Unreleased bug by me
- `variant === "button"` should prevent value text when selecting an option from replacing placeholder text in button
- Added test

## Screenshot of fix
<img width="1397" alt="Screenshot 2025-01-31 at 3 20 33 PM" src="https://github.com/user-attachments/assets/8c0f6974-b8bc-48e9-a226-229a74ee20ae" />



# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- unreleased so no changefile
- [x] Added/updated automated tests
- [x] Manual QA for all new/changed functionality

