### PR TITLE
Adjust vuln host count batch size

### DIFF
--- a/server/datastore/mysql/vulnerabilities.go
+++ b/server/datastore/mysql/vulnerabilities.go
@@ -374,13 +374,13 @@ func (ds *Datastore) batchFetchVulnerabilityCounts(
 	maxRoutines int,
 ) ([]hostCount, error) {
 	const (
-		batchSize = 20
+		batchSize = 10
 	)
 
 	// Fetch distinct CVEs
 	allCVEs, err := ds.distinctCVEs(ctx)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("fetching distinct CVEs: %w", err)
 	}
 
 	query := getVulnHostCountQuery(scope)


### PR DESCRIPTION
When testing #22364 in the loadtest environment, the original error (mysql temp table size too big) still occurred in the vulnerabilities cron.  After adjusting the batch size down, the cron completed successfully in ~15m.