### PR TITLE
Add CPE translation mapping for IntelliJ CE for Windows

### DIFF
--- a/changes/25662-ij-windows
+++ b/changes/25662-ij-windows
@@ -1,0 +1,1 @@
+* Resolved false negatives on vulnerabilities for IntelliJ IDEA Community Edition on Windows.

--- a/server/vulnerabilities/nvd/cpe_test.go
+++ b/server/vulnerabilities/nvd/cpe_test.go
@@ -1334,6 +1334,15 @@ func TestCPEFromSoftwareIntegration(t *testing.T) {
 		},
 		{
 			software: fleet.Software{
+				Name:    "IntelliJ IDEA Community Edition 2022.3.2",
+				Source:  "programs",
+				Version: "223.8617.56",
+				Vendor:  "",
+			},
+			cpe: "cpe:2.3:a:jetbrains:intellij_idea:223.8617.56:*:*:*:*:windows:*:*",
+		},
+		{
+			software: fleet.Software{
 				Name:             "IntelliJ IDEA.app",
 				Source:           "apps",
 				Version:          "2022.3.3",

--- a/server/vulnerabilities/nvd/cpe_translations.json
+++ b/server/vulnerabilities/nvd/cpe_translations.json
@@ -161,6 +161,16 @@
   },
   {
     "software": {
+      "name": ["/^IntelliJ IDEA Community Edition/"],
+      "source": ["programs"]
+    },
+    "filter": {
+      "product": ["intellij_idea"],
+      "vendor": ["jetbrains"]
+    }
+  },
+  {
+    "software": {
       "bundle_identifier": ["/^com\\.jetbrains\\.pycharm/"],
       "source": ["apps"]
     },


### PR DESCRIPTION
Won't solve the false positive issues due to version number mismatches, but will fix the false negative where CE wasn't matching at all, and this is a full fix for IJ CE installed via JetBrains Toolbox.

For #25662.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/Committing-Changes.md#changes-files) for more information.
- [x] Added/updated automated tests
- [x] A detailed QA plan exists on the associated ticket (if it isn't there, work with the product group's QA engineer to add it)
- [x] Manual QA for all new/changed functionality