### PR TITLE
docs: fix example response of Create Teams endpoint

### DIFF
--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -10316,11 +10316,11 @@ _Available in Fleet Premium_
 
 ```json
 {
-"team": {
-    "name": "workstations",
-    "id": 1,
-    "user_count": 0,
-    "host_count": 0,
+  "team": {
+  "name": "workstations",
+  "id": 1,
+  "user_count": 0,
+  "host_count": 0,
     "agent_options": {
       "config": {
         "options": {

--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -10316,43 +10316,41 @@ _Available in Fleet Premium_
 
 ```json
 {
-  "teams": [
-    {
-      "name": "workstations",
-      "id": 1,
-      "user_count": 0,
-      "host_count": 0,
-      "agent_options": {
-        "config": {
-          "options": {
-            "pack_delimiter": "/",
-            "logger_tls_period": 10,
-            "distributed_plugin": "tls",
-            "disable_distributed": false,
-            "logger_tls_endpoint": "/api/v1/osquery/log",
-            "distributed_interval": 10,
-            "distributed_tls_max_attempts": 3
-          },
-          "decorators": {
-            "load": [
-              "SELECT uuid AS host_uuid FROM system_info;",
-              "SELECT hostname AS hostname FROM system_info;"
-            ]
-          }
+"teams": {
+    "name": "workstations",
+    "id": 1,
+    "user_count": 0,
+    "host_count": 0,
+    "agent_options": {
+      "config": {
+        "options": {
+          "pack_delimiter": "/",
+          "logger_tls_period": 10,
+          "distributed_plugin": "tls",
+          "disable_distributed": false,
+          "logger_tls_endpoint": "/api/v1/osquery/log",
+          "distributed_interval": 10,
+          "distributed_tls_max_attempts": 3
         },
-        "overrides": {},
-        "command_line_flags": {}
-      },
-      "webhook_settings": {
-        "failing_policies_webhook": {
-          "enable_failing_policies_webhook": false,
-          "destination_url": "",
-          "policy_ids": null,
-          "host_batch_size": 0
+        "decorators": {
+          "load": [
+            "SELECT uuid AS host_uuid FROM system_info;",
+            "SELECT hostname AS hostname FROM system_info;"
+          ]
         }
+      },
+      "overrides": {},
+      "command_line_flags": {}
+    },
+    "webhook_settings": {
+      "failing_policies_webhook": {
+        "enable_failing_policies_webhook": false,
+        "destination_url": "",
+        "policy_ids": null,
+        "host_batch_size": 0
       }
     }
-  ]
+  }
 }
 ```
 

--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -10316,7 +10316,7 @@ _Available in Fleet Premium_
 
 ```json
 {
-"teams": {
+"team": {
     "name": "workstations",
     "id": 1,
     "user_count": 0,

--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -10317,10 +10317,10 @@ _Available in Fleet Premium_
 ```json
 {
   "team": {
-  "name": "workstations",
-  "id": 1,
-  "user_count": 0,
-  "host_count": 0,
+    "name": "workstations",
+    "id": 1,
+    "user_count": 0,
+    "host_count": 0,
     "agent_options": {
       "config": {
         "options": {


### PR DESCRIPTION
Previously the docs suggested that an array of teams is returned when creating a new team. This is not the case. 

This commit fixes the api docs and clarifies the example response.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

Deleted all lines as none seems to be relevant.
