### PR TITLE
update UI tooltip for deadline input on the os settings target form

### DIFF
--- a/changes/issue-25159-update-deadline-tooltip
+++ b/changes/issue-25159-update-deadline-tooltip
@@ -1,0 +1,2 @@
+- update the os settings Target form deadline input tooltip to make the it more correct for how the
+deadline works for hosts

--- a/frontend/pages/ManageControlsPage/OSUpdates/components/AppleOSTargetForm/AppleOSTargetForm.tsx
+++ b/frontend/pages/ManageControlsPage/OSUpdates/components/AppleOSTargetForm/AppleOSTargetForm.tsx
@@ -181,18 +181,6 @@ const AppleOSTargetForm = ({
     );
   };
 
-  const getDeadlineTooltip = (platform: ApplePlatform) => {
-    switch (platform) {
-      case "darwin":
-        return "The end user can't dismiss the window once they reach this deadline. Deadline is at 12:00 (Noon) Pacific Standard Time (GMT-8).";
-      case "ios":
-      case "ipados":
-        return "Deadline is at 12:00 (Noon) Pacific Standard Time (GMT-8).";
-      default:
-        return "";
-    }
-  };
-
   return (
     <form className={baseClass} onSubmit={handleSubmit}>
       <InputField
@@ -214,7 +202,7 @@ const AppleOSTargetForm = ({
       />
       <InputField
         label="Deadline"
-        tooltip={getDeadlineTooltip(applePlatform)}
+        tooltip="The end user can't dismiss the OS update once they reach this deadline. Deadline is 12:00 (Noon), the host's local time."
         helpText="YYYY-MM-DD format only (e.g., “2024-07-01”)."
         value={deadline}
         error={deadlineError}


### PR DESCRIPTION
For #25159

This updates the os settings Target form deadline input tooltip to make it more correct for how the
deadline works for hosts. Macos, ios, and iPad all return the same tooltip text now.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
- [x] Manual QA for all new/changed functionality
