### PR TITLE
Website: update text on policy details page

### DIFF
--- a/website/views/pages/policy-details.ejs
+++ b/website/views/pages/policy-details.ejs
@@ -39,7 +39,7 @@
           </div>
           <div purpose="policy-check">
             <h3>Check</h3>
-            <p>Use the policy below to verify</p>
+            <p>Use the policy below to verify:</p>
             <div purpose="codeblock">
               <div purpose="codeblock-tabs" >
                 <a purpose="codeblock-tab" :class="[ selectedTab === 'sql' ? 'selected' : '']" @click="selectedTab = 'sql'">Query</a>


### PR DESCRIPTION
Changes:
- Added a missing colon to the text above checks on the policy details page.