### PR TITLE
Update wine to version 10, replace wine64 with wine

### DIFF
--- a/changes/25872-fleetctl-update-wine-10
+++ b/changes/25872-fleetctl-update-wine-10
@@ -1,0 +1,1 @@
+- Updated wine to version 10.0 to improve support macOS-to-Windows installer creation on M1 chips.

--- a/orbit/pkg/packaging/wix/wix.go
+++ b/orbit/pkg/packaging/wix/wix.go
@@ -9,12 +9,15 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strconv"
+	"strings"
 )
 
 const (
 	directoryReference = "ORBITROOT"
 	imageName          = "fleetdm/wix:latest"
 	dockerPlatform     = "linux/amd64"
+	Wine64Cmd          = "wine64"
 	WineCmd            = "wine"
 )
 
@@ -39,7 +42,11 @@ func Heat(path string, native bool, localWixDir string) error {
 	if localWixDir != "" {
 		heatPath = filepath.Join(localWixDir, `heat.exe`)
 		if runtime.GOOS == "darwin" {
-			args = append(args, WineCmd)
+			wineExec, err := darwinWineExecutable()
+			if err != nil {
+				return fmt.Errorf("determining wine executable: %w", err)
+			}
+			args = append(args, wineExec)
 		}
 	}
 
@@ -56,7 +63,7 @@ func Heat(path string, native bool, localWixDir string) error {
 	cmd := exec.Command(args[0], args[1:]...)
 	cmd.Stdout, cmd.Stderr = os.Stdout, os.Stderr
 
-	if args[0] == WineCmd {
+	if args[0] == WineCmd || args[0] == Wine64Cmd {
 		cmd.Env = append(os.Environ(), "WINEDEBUG=-all")
 	}
 
@@ -69,6 +76,25 @@ func Heat(path string, native bool, localWixDir string) error {
 	}
 
 	return nil
+}
+
+func darwinWineExecutable() (string, error) {
+	cmdOut, err := exec.Command("wine", "--version").Output()
+	if err != nil {
+		return "", fmt.Errorf("running wine to get version information: %w", err)
+	}
+	wineVerStr, found := strings.CutPrefix(string(cmdOut), "wine-")
+	if !found {
+		return "", fmt.Errorf("Unknown wine version: %q. Is Wine installed? Creating a fleetd agent for Windows (.msi) requires Wine. To install Wine see the script here: https://fleetdm.com/install-wine ", string(cmdOut))
+	}
+	wineVersion, err := strconv.ParseInt(strings.Split(wineVerStr, ".")[0], 10, 64)
+	if err != nil {
+		return "", fmt.Errorf("Unable to parse wine version: %q. Is Wine installed? Creating a fleetd agent for Windows (.msi) requires Wine. To install Wine see the script here: https://fleetdm.com/install-wine ", wineVerStr)
+	}
+	if wineVersion < 10 {
+		return Wine64Cmd, nil
+	}
+	return WineCmd, nil
 }
 
 // Candle runs the WiX Candle command on the provided directory.
@@ -91,7 +117,11 @@ func Candle(path string, native bool, localWixDir string) error {
 	if localWixDir != "" {
 		candlePath = filepath.Join(localWixDir, `candle.exe`)
 		if runtime.GOOS == "darwin" {
-			args = append(args, WineCmd)
+			wineExec, err := darwinWineExecutable()
+			if err != nil {
+				return fmt.Errorf("determining wine executable: %w", err)
+			}
+			args = append(args, wineExec)
 		}
 	}
 	args = append(args,
@@ -103,7 +133,7 @@ func Candle(path string, native bool, localWixDir string) error {
 	cmd := exec.Command(args[0], args[1:]...)
 	cmd.Stdout, cmd.Stderr = os.Stdout, os.Stderr
 
-	if args[0] == WineCmd {
+	if args[0] == WineCmd || args[0] == Wine64Cmd {
 		cmd.Env = append(os.Environ(), "WINEDEBUG=-all")
 	}
 
@@ -138,7 +168,11 @@ func Light(path string, native bool, localWixDir string) error {
 	if localWixDir != "" {
 		lightPath = filepath.Join(localWixDir, `light.exe`)
 		if runtime.GOOS == "darwin" {
-			args = append(args, WineCmd)
+			wineExec, err := darwinWineExecutable()
+			if err != nil {
+				return fmt.Errorf("determining wine executable: %w", err)
+			}
+			args = append(args, wineExec)
 		}
 	}
 	args = append(args,
@@ -152,7 +186,7 @@ func Light(path string, native bool, localWixDir string) error {
 	cmd := exec.Command(args[0], args[1:]...)
 	cmd.Stdout, cmd.Stderr = os.Stdout, os.Stderr
 
-	if args[0] == WineCmd {
+	if args[0] == WineCmd || args[0] == Wine64Cmd {
 		cmd.Env = append(os.Environ(), "WINEDEBUG=-all")
 	}
 

--- a/orbit/pkg/packaging/wix/wix.go
+++ b/orbit/pkg/packaging/wix/wix.go
@@ -15,7 +15,7 @@ const (
 	directoryReference = "ORBITROOT"
 	imageName          = "fleetdm/wix:latest"
 	dockerPlatform     = "linux/amd64"
-	WineCmd            = "wine64"
+	WineCmd            = "wine"
 )
 
 // Heat runs the WiX Heat command on the provided directory.

--- a/scripts/macos-install-wine.sh
+++ b/scripts/macos-install-wine.sh
@@ -7,7 +7,7 @@ set -eo pipefail
 brew_wine(){
 # Wine reference: https://wiki.winehq.org/MacOS
 # Wine can be installed without brew via a distribution such as https://github.com/Gcenx/macOS_Wine_builds/releases/tag/9.0 or by building from source.
-curl -O https://raw.githubusercontent.com/Homebrew/homebrew-cask/1ecfe82f84e0f3c3c6b741d3ddc19a164c2cb18d/Casks/w/wine-stable.rb
+curl -O https://raw.githubusercontent.com/Homebrew/homebrew-cask/bad613d274f9a646dace4a4cc7f2512f836be5b4/Casks/w/wine-stable.rb
 brew install --cask --no-quarantine wine-stable.rb; exit 0
 }
 
@@ -57,4 +57,3 @@ then
 else
     warn_wine
 fi
-

--- a/scripts/macos-install-wine.sh
+++ b/scripts/macos-install-wine.sh
@@ -5,10 +5,10 @@ set -eo pipefail
 
 
 brew_wine(){
-# Wine reference: https://wiki.winehq.org/MacOS
-# Wine can be installed without brew via a distribution such as https://github.com/Gcenx/macOS_Wine_builds/releases/tag/9.0 or by building from source.
-curl -O https://raw.githubusercontent.com/Homebrew/homebrew-cask/bad613d274f9a646dace4a4cc7f2512f836be5b4/Casks/w/wine-stable.rb
-brew install --cask --no-quarantine wine-stable.rb; exit 0
+    # Wine reference: https://wiki.winehq.org/MacOS
+    # Wine can be installed without brew via a distribution such as https://github.com/Gcenx/macOS_Wine_builds/releases/tag/10.0 or by building from source.
+    curl -O https://raw.githubusercontent.com/Homebrew/homebrew-cask/bad613d274f9a646dace4a4cc7f2512f836be5b4/Casks/w/wine-stable.rb
+    brew install --cask --no-quarantine wine-stable.rb; exit 0
 }
 
 


### PR DESCRIPTION
#25872

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/Committing-Changes.md#changes-files) for more information.
- [x] A detailed QA plan exists on the associated ticket (if it isn't there, work with the product group's QA engineer to add it)
	- Install wine version 10 on an M1 mac
	- Try to generate a package

	- fleetctl package --type=msi [...] on Intel macOS.
	- fleetctl package --type=msi on Apple silicon macOS with v9 installed.
	- fleetctl package --type=msi on Apple silicon macOS with v10 installed.
	- make fleetctl-docker && docker run fleetdm/fleetctl package --type=msi on macOS or Linux. (Which is using the fleetdm/fleetctl docker image.)
- [x] Manual QA for all new/changed functionality