### PR TITLE
Update Software Attestation guide

### DIFF
--- a/articles/fleet-software-attestation.md
+++ b/articles/fleet-software-attestation.md
@@ -1,6 +1,6 @@
 # Fleet software attestation
 
-At Fleet, we understand the importance of having a secure software supply chain.  Our core value of 🟣 [Openness](https://fleetdm.com/handbook/company#openness) extends to ensuring that our users can verify the provenance and authenticity of any Fleet software they install.  With that in mind, as of version 4.63.0 Fleet we will be adding [SLSA attestations](https://slsa.dev/) to our released binaries and container images.  This includes the Fleet and Fleetctl server software, the Orbit and Fleet Desktop software for hosts, and the osqueryd updates periodically downloaded by hosts.
+As of version 4.63.0 Fleet we will be adding [SLSA attestations](https://slsa.dev/) to our released binaries and container images.  This includes the `fleet` and `fleetctl` server software, the Orbit and Fleet Desktop software for hosts, and the `osqueryd` updates periodically downloaded by hosts.
 
 ## What is software attestation?
 


### PR DESCRIPTION
For #25334 

Implementing changes suggested by @zayhanlon 

> @sharon-fdm or @sgress454 in the style of our current articles, i think its okay to cut the fluff 'At Fleet, we understand the importance of having a secure software supply chain. Our core value of 🟣 [Openness](https://fleetdm.com/handbook/company#openness) extends to ensuring that our users can verify the provenance and authenticity of any Fleet software they install. With that in mind,' and start with "As of version 4.63.0 Fleet has added"

Done

> fleetctl we don't capitalize correct?

Updated references to `fleet`, `fleetctl` and `osqueryd` to be lowercased and use code styling, to be consistent with usage in other articles.

> I think orbit we also dont capitalize

It's pretty inconsistent but it looks like we mostly do capitalize it, which makes sense to me as it's not a command you run (as opposed to `fleet`, `fleetctl` or `osqueryd`).  I left it for now but can change to `orbit` if that's the official style guide policy.