### PR TITLE
UI - Fix team admin ability to edit MFA

### DIFF
--- a/changes/25956-fix-buggy-efa-editing
+++ b/changes/25956-fix-buggy-efa-editing
@@ -1,0 +1,1 @@
+- Fix a bug where team admins are unable to enable or disable MFA for a user

--- a/frontend/pages/admin/TeamManagementPage/TeamDetailsWrapper/UsersPage/UsersPageTableConfig.tsx
+++ b/frontend/pages/admin/TeamManagementPage/TeamDetailsWrapper/UsersPage/UsersPageTableConfig.tsx
@@ -217,6 +217,7 @@ const enhanceUsersData = (
       role: generateRole(teamId, user.teams),
       teams: user.teams,
       sso_enabled: user.sso_enabled,
+      mfa_enabled: user.mfa_enabled,
       global_role: user.global_role,
       actions: generateActionDropdownOptions(),
       id: user.id,

--- a/frontend/pages/admin/UserManagementPage/helpers/userManagementHelpers.ts
+++ b/frontend/pages/admin/UserManagementPage/helpers/userManagementHelpers.ts
@@ -32,6 +32,7 @@ const generateUpdateData = (
     "name",
     "email",
     "sso_enabled",
+    "mfa_enabled",
   ];
   return Object.keys(formData).reduce<IUserUpdateBody | any>(
     (updatedAttributes, attr) => {


### PR DESCRIPTION
## For #25956 

- include the `mfa_enabled` field when rendering the edit user modal
- Include `mfa_enabled` as a changeable field in the form submission logic

![ezgif-119080b112463](https://github.com/user-attachments/assets/83baafff-d7ec-4732-a5c0-c1878965d8ce)

- [x] Changes file added for user-visible changes in `changes/`
- [x] A detailed QA plan exists on the associated ticket (if it isn't there, work with the product group's QA engineer to add it)
- [x] Manual QA for all new/changed functionality