### PR TITLE
Added debug logging to declaration configurations status.

### DIFF
--- a/changes/25812-ddm-profiles-stuck
+++ b/changes/25812-ddm-profiles-stuck
@@ -1,0 +1,1 @@
+Added server debug logging for unexpected Apple DDM configuration status.

--- a/server/fleet/apple_mdm.go
+++ b/server/fleet/apple_mdm.go
@@ -841,7 +841,7 @@ type MDMAppleDeclarationValidity string
 const (
 	MDMAppleDeclarationValid   MDMAppleDeclarationValidity = "valid"
 	MDMAppleDeclarationInvalid MDMAppleDeclarationValidity = "invalid"
-	MDMAppleDeclarationUnknown MDMAppleDeclarationValidity = "valid"
+	MDMAppleDeclarationUnknown MDMAppleDeclarationValidity = "unknown"
 )
 
 // MDMAppleDDMStatusDeclaration represents a processed declaration for the client.


### PR DESCRIPTION
For #25812 

I am adding some debug logging for DDM configuration profile status to assist in future potential debug. This change should have no noticeable functional changes.

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/Committing-Changes.md#changes-files) for more information.
- [x] Manual QA for all new/changed functionality
