### PR TITLE
Updated macOS/iOS/iPadOS update deadlines

### DIFF
--- a/it-and-security/lib/all/policies/mac-enrollment-profile-up-to-date.yml
+++ b/it-and-security/lib/all/policies/mac-enrollment-profile-up-to-date.yml
@@ -2,7 +2,7 @@
   query: SELECT 1 FROM mdm where topic = "com.apple.mgmt.External.ccfc8d43-e9f1-49ec-8ca4-10072077deec";
   critical: true
   description: This policy checks to see if you have the most recent enrollment profile installed. Not having this profile means this device is no longer communicating with Fleet via MDM.
-  resolution: >-
+  resolution: |-
     You must manually remove your enrollment profile to fix this issue. This can be done in one of two ways: 
 
     1.)  > System Settings > Profiles > Fleet enrollment > - 

--- a/it-and-security/teams/company-owned-ipads.yml
+++ b/it-and-security/teams/company-owned-ipads.yml
@@ -12,8 +12,8 @@ team_settings:
 agent_options:
 controls:
   ipados_updates:
-    deadline: "2025-01-06"
-    minimum_version: "18.2"
+    deadline: "2025-02-23"
+    minimum_version: "18.3"
   macos_settings:
     custom_settings:
       - path: ../lib/ipados/declaration-profiles/software-update-settings.json

--- a/it-and-security/teams/company-owned-iphones.yml
+++ b/it-and-security/teams/company-owned-iphones.yml
@@ -12,8 +12,8 @@ team_settings:
 agent_options:
 controls:
   ios_updates:
-    deadline: "2025-01-06"
-    minimum_version: "18.2"
+    deadline: "2025-02-23"
+    minimum_version: "18.3"
   macos_settings:
     custom_settings:
       - path: ../lib/ios/configuration-profiles/lock-screen-message.mobileconfig

--- a/it-and-security/teams/workstations-canary.yml
+++ b/it-and-security/teams/workstations-canary.yml
@@ -95,8 +95,8 @@ controls:
     enable_end_user_authentication: false
     macos_setup_assistant: null
   macos_updates:
-    deadline: "2025-01-07"
-    minimum_version: "15.2"
+    deadline: "2025-02-23"
+    minimum_version: "15.3"
   windows_settings:
     custom_settings:
       - path: ../lib/windows/configuration-profiles/enable-firewall-all-domains.xml

--- a/it-and-security/teams/workstations.yml
+++ b/it-and-security/teams/workstations.yml
@@ -69,8 +69,8 @@ controls:
       - package_path: ../lib/macos/software/zoom.yml # Zoom for macOS
       - app_store_id: '803453959' # Slack Desktop
   macos_updates:
-    deadline: "2025-01-07"
-    minimum_version: "15.2"
+    deadline: "2025-02-23"
+    minimum_version: "15.3"
   windows_settings:
     custom_settings: null
   windows_updates:


### PR DESCRIPTION
Updated macOS/iOS/iPadOS update deadlines to 2025-02-23 for their respective latest versions
Formatting updates on a policy