### PR TITLE
Add "engineering alerts" to on-call responsibilities.

### DIFF
--- a/handbook/company/product-groups.md
+++ b/handbook/company/product-groups.md
@@ -544,6 +544,8 @@ Fleet's documentation for contributors can be found in the [Fleet GitHub repo](h
 
 The on-call developer is asked to read, understand, test, correct, and improve at least one doc page per week. Our goal is to 1, ensure accuracy and verify that our deployment guides and tutorials are up to date and work as expected. And 2, improve the readability, consistency, and simplicity of our documentation – with empathy towards first-time users. See [Writing documentation](https://fleetdm.com/handbook/marketing#writing-documentation) for writing guidelines, and don't hesitate to reach out to [#g-digital-experience](https://fleetdm.slack.com/archives/C01GQUZ91TN) on Slack for writing support. A backlog of documentation improvement needs is kept [here](https://github.com/fleetdm/fleet/issues?q=is%3Aopen+is%3Aissue+label%3A%22%3Aimprove+documentation%22).
 
+- **Engineering alerts**
+The on-call developer is responsible for triaging alerts that come to #help-engineering Slack channel, such as failing unit tests. If the on-call developer has the knowledge and confidence to make the fix, they should do so. Otherwise, they should request help from the appropriate team. Filing a bug is also an option if the issue is not urgent.
 
 ### Escalations
 

--- a/handbook/company/product-groups.md
+++ b/handbook/company/product-groups.md
@@ -545,7 +545,7 @@ Fleet's documentation for contributors can be found in the [Fleet GitHub repo](h
 The on-call developer is asked to read, understand, test, correct, and improve at least one doc page per week. Our goal is to 1, ensure accuracy and verify that our deployment guides and tutorials are up to date and work as expected. And 2, improve the readability, consistency, and simplicity of our documentation – with empathy towards first-time users. See [Writing documentation](https://fleetdm.com/handbook/marketing#writing-documentation) for writing guidelines, and don't hesitate to reach out to [#g-digital-experience](https://fleetdm.slack.com/archives/C01GQUZ91TN) on Slack for writing support. A backlog of documentation improvement needs is kept [here](https://github.com/fleetdm/fleet/issues?q=is%3Aopen+is%3Aissue+label%3A%22%3Aimprove+documentation%22).
 
 - **Engineering alerts**
-The on-call developer is responsible for triaging alerts that come to #help-engineering Slack channel, such as failing unit tests. If the on-call developer has the knowledge and confidence to make the fix, they should do so. Otherwise, they should request help from the appropriate team. Filing a bug is also an option if the issue is not urgent.
+The on-call developer is responsible for triaging new alerts in the #help-engineering Slack channel, such as failing unit tests. If the on-call developer has the ability to make the fix, they should do so. Otherwise, they should request help from the appropriate team. Filing a bug is also an option if the issue is not urgent.
 
 ### Escalations
 


### PR DESCRIPTION
Propose to add alerts in #help-engineering to on-call responsibilities.

Why? With multiple product teams, we may experience a tragedy of the commons—without a DRI, alerts may not be looked at.
