### PR TITLE
Removing usage of semver in resolved in version resolution

### DIFF
--- a/changes/24810-cve-no-semver
+++ b/changes/24810-cve-no-semver
@@ -1,0 +1,1 @@
+* Changed software version cve resolved in version parsing and comparison to use custom code rather than semver,

--- a/server/vulnerabilities/nvd/cve.go
+++ b/server/vulnerabilities/nvd/cve.go
@@ -676,10 +676,6 @@ func findCPEMatch(nodes []*schema.NVDCVEFeedJSON10DefNode) []*schema.NVDCVEFeedJ
 
 // checkVersion checks if the host software version matches the CPEMatch rule
 func checkVersion(rule *schema.NVDCVEFeedJSON10DefCPEMatch, softwareVersionStr string) (string, error) {
-	if softwareVersionStr == "" {
-		return "", nil
-	}
-
 	if rule.VersionStartIncluding == "" && rule.VersionStartExcluding == "" && rule.VersionEndExcluding == "" {
 		return rule.VersionEndExcluding, nil
 	}

--- a/server/vulnerabilities/nvd/cve.go
+++ b/server/vulnerabilities/nvd/cve.go
@@ -676,6 +676,10 @@ func findCPEMatch(nodes []*schema.NVDCVEFeedJSON10DefNode) []*schema.NVDCVEFeedJ
 
 // checkVersion checks if the host software version matches the CPEMatch rule
 func checkVersion(rule *schema.NVDCVEFeedJSON10DefCPEMatch, softwareVersionStr string) (string, error) {
+	if softwareVersionStr == "" {
+		return "", nil
+	}
+
 	if rule.VersionStartIncluding == "" && rule.VersionStartExcluding == "" && rule.VersionEndExcluding == "" {
 		return rule.VersionEndExcluding, nil
 	}

--- a/server/vulnerabilities/nvd/cve.go
+++ b/server/vulnerabilities/nvd/cve.go
@@ -10,11 +10,9 @@ import (
 	"path/filepath"
 	"regexp"
 	"runtime"
-	"strings"
 	"sync"
 	"time"
 
-	"github.com/Masterminds/semver"
 	"github.com/fleetdm/fleet/v4/pkg/fleethttp"
 	"github.com/fleetdm/fleet/v4/server/contexts/ctxerr"
 	"github.com/fleetdm/fleet/v4/server/fleet"
@@ -34,12 +32,6 @@ import (
 const (
 	vulnRepo = "vulnerabilities"
 )
-
-// Define a regex pattern for semver (simplified)
-var semverPattern = regexp.MustCompile(`^v?(\d+\.\d+\.\d+)`)
-
-// Define a regex pattern for splitting version strings into subparts
-var nonNumericPartRegex = regexp.MustCompile(`(\d+)(\D.*)`)
 
 // DownloadNVDCVEFeed downloads CVEs information from the NVD 2.0 API
 // and supplements the data with CPE information from the Vulncheck API.
@@ -630,13 +622,6 @@ func getMatchingVersionEndExcluding(ctx context.Context, cve string, hostSoftwar
 		return "", nil
 	}
 
-	// convert the host software version to semver for later comparison
-	formattedVersion := preprocessVersion(wfn.StripSlashes(hostSoftwareMeta.Version))
-	softwareVersion, err := semver.NewVersion(formattedVersion)
-	if err != nil {
-		return "", ctxerr.Wrap(ctx, err, "parsing software version", hostSoftwareMeta.Product, hostSoftwareMeta.Version)
-	}
-
 	// Check if the host software version matches any of the CPEMatch rules.
 	// CPEMatch rules can include version strings for the following:
 	// - versionStartIncluding
@@ -660,7 +645,7 @@ func getMatchingVersionEndExcluding(ctx context.Context, cve string, hostSoftwar
 		}
 
 		// versionEnd is the version string that the vulnerable host software version must be less than
-		versionEnd, err := checkVersion(ctx, rule, softwareVersion, cve)
+		versionEnd, err := checkVersion(rule, hostSoftwareMeta.Version)
 		if err != nil {
 			return "", ctxerr.Wrap(ctx, err, "checking version")
 		}
@@ -690,74 +675,28 @@ func findCPEMatch(nodes []*schema.NVDCVEFeedJSON10DefNode) []*schema.NVDCVEFeedJ
 }
 
 // checkVersion checks if the host software version matches the CPEMatch rule
-func checkVersion(ctx context.Context, rule *schema.NVDCVEFeedJSON10DefCPEMatch, softwareVersion *semver.Version, cve string) (string, error) {
-	constraintStr := buildConstraintString(rule.VersionStartIncluding, rule.VersionStartExcluding, rule.VersionEndExcluding)
-	if constraintStr == "" {
+func checkVersion(rule *schema.NVDCVEFeedJSON10DefCPEMatch, softwareVersionStr string) (string, error) {
+	if rule.VersionStartIncluding == "" && rule.VersionStartExcluding == "" && rule.VersionEndExcluding == "" {
 		return rule.VersionEndExcluding, nil
 	}
 
-	constraint, err := semver.NewConstraint(constraintStr)
-	if err != nil {
-		return "", ctxerr.Wrapf(ctx, err, "parsing constraint: %s for cve: %s", constraintStr, cve)
+	if rule.VersionStartIncluding == "" && rule.VersionStartExcluding == "" {
+		// "softwareVersionStr < endExcluding",
+		if feednvd.SmartVerCmp(softwareVersionStr, rule.VersionEndExcluding) == -1 {
+			return rule.VersionEndExcluding, nil
+		}
 	}
-
-	if constraint.Check(softwareVersion) {
+	if rule.VersionStartIncluding != "" {
+		// "softwareVersionStr >= startIncluding && softwareVersionStr < endExcluding"
+		if (feednvd.SmartVerCmp(softwareVersionStr, rule.VersionStartIncluding) == 1 || feednvd.SmartVerCmp(softwareVersionStr, rule.VersionStartIncluding) == 0) &&
+			feednvd.SmartVerCmp(softwareVersionStr, rule.VersionEndExcluding) == -1 {
+			return rule.VersionEndExcluding, nil
+		}
+	}
+	// "softwareVersionStr > startExcluding && softwareVersionStr < endExcluding"
+	if feednvd.SmartVerCmp(softwareVersionStr, rule.VersionStartExcluding) == 1 && feednvd.SmartVerCmp(softwareVersionStr, rule.VersionEndExcluding) == -1 {
 		return rule.VersionEndExcluding, nil
 	}
 
 	return "", nil
-}
-
-// buildConstraintString builds a semver constraint string from the startIncluding,
-// startExcluding, and endExcluding strings
-func buildConstraintString(startIncluding, startExcluding, endExcluding string) string {
-	startIncluding = preprocessVersion(startIncluding)
-	startExcluding = preprocessVersion(startExcluding)
-	endExcluding = preprocessVersion(endExcluding)
-
-	if startIncluding == "" && startExcluding == "" {
-		return fmt.Sprintf("< %s", endExcluding)
-	}
-
-	if startIncluding != "" {
-		return fmt.Sprintf(">= %s, < %s", startIncluding, endExcluding)
-	}
-	return fmt.Sprintf("> %s, < %s", startExcluding, endExcluding)
-}
-
-// Products using 4 part versioning scheme (ie. docker desktop)
-// need to be converted to 3 part versioning scheme (2.3.0.2 -> 2.3.0-3) for use with
-// the semver library.
-func preprocessVersion(version string) string {
-	// If "-" is already present, validate the part before "-" as a semver
-	if strings.Contains(version, "-") {
-		parts := strings.Split(version, "-")
-		if semverPattern.MatchString(parts[0]) {
-			return version
-		}
-	}
-
-	if strings.Contains(version, "+") {
-		part := strings.Split(version, "+")[0]
-		if semverPattern.MatchString(part) {
-			return version
-		}
-	}
-
-	// If the version string contains more than 3 parts, convert it to 3 parts
-	parts := strings.Split(version, ".")
-	if len(parts) > 3 {
-		return parts[0] + "." + parts[1] + "." + parts[2] + "-" + strings.Join(parts[3:], ".")
-	}
-
-	// If the version string ends with a non-numeric character (like '1.0.0b'), replace
-	// it with '-<char>' (like '1.0.0-b')
-	if len(parts) == 3 {
-		matches := nonNumericPartRegex.FindStringSubmatch(parts[2])
-		if len(matches) > 2 {
-			parts[2] = matches[1] + "-" + matches[2]
-		}
-	}
-
-	return strings.Join(parts, ".")
 }

--- a/server/vulnerabilities/nvd/cve_test.go
+++ b/server/vulnerabilities/nvd/cve_test.go
@@ -739,34 +739,6 @@ func TestGetMatchingVersionEndExcluding(t *testing.T) {
 	}
 }
 
-func TestPreprocessVersion(t *testing.T) {
-	testCases := []struct {
-		input    string
-		expected string
-	}{
-		{"2.3.0.2", "2.3.0-2"},
-		{"2.3.0+2", "2.3.0+2"},
-		{"v5.3.0.2", "v5.3.0-2"},
-		{"5.3.0-2", "5.3.0-2"},
-		{"2.3.0.2.5", "2.3.0-2.5"},
-		{"2.3.0", "2.3.0"},
-		{"2.3", "2.3"},
-		{"v2.3.0", "v2.3.0"},
-		{"notAVersion", "notAVersion"},
-		{"2.0.0+svn315-7fakesync1ubuntu0.22.04.1", "2.0.0+svn315-7fakesync1ubuntu0.22.04.1"},
-		{"1.21.1ubuntu2", "1.21.1-ubuntu2"},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.input, func(t *testing.T) {
-			output := preprocessVersion(tc.input)
-			if output != tc.expected {
-				t.Fatalf("input: %s, expected: %s, got: %s", tc.input, tc.expected, output)
-			}
-		})
-	}
-}
-
 func TestGetMacOSCPEs(t *testing.T) {
 	ctx := context.Background()
 	ds := new(mock.Store)

--- a/server/vulnerabilities/nvd/cve_test.go
+++ b/server/vulnerabilities/nvd/cve_test.go
@@ -222,10 +222,10 @@ func TestTranslateCPEToCVE(t *testing.T) {
 		},
 		"cpe:2.3:a:clickstudios:passwordstate:9.5.8.4:*:*:*:*:chrome:*:*": {
 			includedCVEs: []cve{
-				{ID: "CVE-2022-4610"},
-				{ID: "CVE-2022-4611"},
-				{ID: "CVE-2022-4613"},
-				{ID: "CVE-2022-4612"},
+				{ID: "CVE-2022-4610", resolvedInVersion: "9.5"},
+				{ID: "CVE-2022-4611", resolvedInVersion: "9.5"},
+				{ID: "CVE-2022-4613", resolvedInVersion: "9.5"},
+				{ID: "CVE-2022-4612", resolvedInVersion: "9.5"},
 			},
 			continuesToUpdate: true,
 		},
@@ -368,7 +368,7 @@ func TestTranslateCPEToCVE(t *testing.T) {
 			continuesToUpdate: true,
 		},
 		"cpe:2.3:a:jetbrains:goland:2022.3.99.123.456:*:*:*:*:macos:*:*": {
-			includedCVEs:      []cve{{ID: "CVE-2024-37051", resolvedInVersion: ""}},
+			includedCVEs:      []cve{{ID: "CVE-2024-37051", resolvedInVersion: "2023.1.6"}},
 			continuesToUpdate: true,
 		},
 		"cpe:2.3:a:jetbrains:goland:2024.3:*:*:*:*:macos:*:*": {


### PR DESCRIPTION
The host software version and VersionEndExcluding did not always get parsed by semver properly. Switching to using `SmartVerCmp` from the nvdtools code. This is much more relaxed when parsing versions.

https://github.com/fleetdm/fleet/issues/24810

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/Committing-Changes.md#changes-files) for more information.
- [x] Added/updated automated tests
- [ ] A detailed QA plan exists on the associated ticket (if it isn't there, work with the product group's QA engineer to add it)
- [x] Manual QA for all new/changed functionality