### PR TITLE
Add client-side logging for software installs, scripts, and setup experience

### DIFF
--- a/orbit/changes/25671-fleetd-setup-experience-logging
+++ b/orbit/changes/25671-fleetd-setup-experience-logging
@@ -1,0 +1,1 @@
+- Added more client-side logging for software installs, scripts, and MDM setup experience.

--- a/orbit/pkg/scripts/scripts.go
+++ b/orbit/pkg/scripts/scripts.go
@@ -68,7 +68,7 @@ func (r *Runner) Run(execIDs []string) error {
 			break
 		}
 
-		log.Info().Msgf("running script %v", execID)
+		log.Info().Msgf("proceeding to execution of script %v", execID)
 		if err := r.runOne(script); err != nil {
 			errs = append(errs, err)
 		}

--- a/orbit/pkg/scripts/scripts.go
+++ b/orbit/pkg/scripts/scripts.go
@@ -52,6 +52,7 @@ func (r *Runner) Run(execIDs []string) error {
 	var errs []error
 
 	for _, execID := range execIDs {
+		log.Info().Msgf("processing script %v", execID)
 		if !r.ScriptExecutionEnabled {
 			if err := r.runOneDisabled(execID); err != nil {
 				errs = append(errs, err)
@@ -59,6 +60,7 @@ func (r *Runner) Run(execIDs []string) error {
 			continue
 		}
 
+		log.Info().Msgf("getting script %v", execID)
 		script, err := r.Client.GetHostScript(execID)
 		if err != nil {
 			errs = append(errs, fmt.Errorf("get host script: %w", err))
@@ -66,7 +68,7 @@ func (r *Runner) Run(execIDs []string) error {
 			break
 		}
 
-		log.Debug().Msgf("running script %v", execID)
+		log.Info().Msgf("running script %v", execID)
 		if err := r.runOne(script); err != nil {
 			errs = append(errs, err)
 		}
@@ -114,6 +116,8 @@ func (r *Runner) runOne(script *fleet.HostScriptResult) (finalErr error) {
 		return fmt.Errorf("write script file: %w", err)
 	}
 
+	log.Info().Msgf("ready to execute script %v", script.ExecutionID)
+
 	ctx, cancel := context.WithTimeout(context.Background(), r.ScriptExecutionTimeout)
 	defer cancel()
 
@@ -139,6 +143,7 @@ func (r *Runner) runOne(script *fleet.HostScriptResult) (finalErr error) {
 		output = output[len(output)-(utf8.UTFMax*maxOutputRuneLen):]
 	}
 
+	log.Info().Msgf("saving script result %v with exit code %d", script.ExecutionID, exitCode)
 	err = r.Client.SaveHostScriptResult(&fleet.HostScriptResultPayload{
 		ExecutionID: script.ExecutionID,
 		Output:      string(output),

--- a/orbit/pkg/update/notifications.go
+++ b/orbit/pkg/update/notifications.go
@@ -365,14 +365,16 @@ func (h *runScriptsConfigReceiver) Run(cfg *fleet.OrbitConfig) error {
 
 	if runtime.GOOS == "darwin" {
 		if cfg.Notifications.RunSetupExperience && !CanRun(h.rootDirPath, "swiftDialog", SwiftDialogMacOSTarget) {
-			log.Debug().Msg("exiting scripts config runner early during setup experience: swiftDialog is not installed")
+			log.Info().Msg("exiting scripts config runner early during setup experience: swiftDialog is not installed")
 			return nil
 		}
 	}
 
 	if len(cfg.Notifications.PendingScriptExecutionIDs) > 0 {
+		log.Info().Msgf("received notification to run scripts %v", cfg.Notifications.PendingScriptExecutionIDs)
+
 		if h.mu.TryLock() {
-			log.Debug().Msgf("received request to run scripts %v", cfg.Notifications.PendingScriptExecutionIDs)
+			log.Info().Msgf("proceeding to run scripts %v", cfg.Notifications.PendingScriptExecutionIDs)
 
 			runner := &scripts.Runner{
 				ScriptExecutionEnabled: h.scriptsEnabled(),
@@ -393,7 +395,7 @@ func (h *runScriptsConfigReceiver) Run(cfg *fleet.OrbitConfig) error {
 					log.Info().Err(err).Msg("running scripts failed")
 					return
 				}
-				log.Debug().Msgf("running scripts %v succeeded", cfg.Notifications.PendingScriptExecutionIDs)
+				log.Info().Msgf("running scripts %v succeeded", cfg.Notifications.PendingScriptExecutionIDs)
 			}()
 		}
 	}

--- a/orbit/pkg/update/notifications_test.go
+++ b/orbit/pkg/update/notifications_test.go
@@ -425,7 +425,7 @@ func TestRunScripts(t *testing.T) {
 
 		waitForRun(t, runner)
 		require.Equal(t, int64(1), callsCount.Load()) // all scripts executed in a single run
-		require.Contains(t, logBuf.String(), "received request to run scripts [a b c]")
+		require.Contains(t, logBuf.String(), "received notification to run scripts [a b c]")
 		require.Contains(t, logBuf.String(), "running scripts [a b c] succeeded")
 	})
 
@@ -446,7 +446,7 @@ func TestRunScripts(t *testing.T) {
 
 		waitForRun(t, runner)
 		require.Equal(t, int64(1), callsCount.Load()) // all scripts executed in a single run
-		require.Contains(t, logBuf.String(), "received request to run scripts [a b c]")
+		require.Contains(t, logBuf.String(), "received notification to run scripts [a b c]")
 		require.Contains(t, logBuf.String(), "running scripts failed")
 		require.Contains(t, logBuf.String(), io.ErrUnexpectedEOF.Error())
 	})
@@ -475,7 +475,7 @@ func TestRunScripts(t *testing.T) {
 
 		waitForRun(t, runner)
 		require.Equal(t, int64(1), callsCount.Load()) // only called once because of mutex
-		require.Contains(t, logBuf.String(), "received request to run scripts [a b c]")
+		require.Contains(t, logBuf.String(), "received notification to run scripts [a b c]")
 		require.Contains(t, logBuf.String(), "running scripts [a b c] succeeded")
 	})
 
@@ -539,11 +539,11 @@ func TestRunScripts(t *testing.T) {
 
 		// validate the Scripts Enabled flags that were passed to the runScriptsFn
 		require.Equal(t, []bool{false, true, false}, scriptsEnabledCalls)
-		require.Contains(t, logBuf.String(), "received request to run scripts [a]")
+		require.Contains(t, logBuf.String(), "received notification to run scripts [a]")
 		require.Contains(t, logBuf.String(), "running scripts [a] succeeded")
-		require.Contains(t, logBuf.String(), "received request to run scripts [b]")
+		require.Contains(t, logBuf.String(), "received notification to run scripts [b]")
 		require.Contains(t, logBuf.String(), "running scripts [b] succeeded")
-		require.Contains(t, logBuf.String(), "received request to run scripts [c]")
+		require.Contains(t, logBuf.String(), "received notification to run scripts [c]")
 		require.Contains(t, logBuf.String(), "running scripts [c] succeeded")
 	})
 }


### PR DESCRIPTION
For #25671 

NOTE: Due to the limited nature of the changes in this PR (changes to logging only), Developer QA was also limited in the interest of time. I confirmed that fleetd built successfully for three main operating systems, but only tested installation of fleetd on macOS to confirm the additional logging appeared as expected. The planned release QA process will cover all three operating systems.

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
- [x] Manual QA for all new/changed functionality
- For Orbit and Fleet Desktop changes:
   - [ ] Orbit runs on macOS, Linux and Windows. Check if the orbit feature/bugfix should only apply to one platform (`runtime.GOOS`).
   - [ ] Manual QA must be performed in the three main OSs, macOS, Windows and Linux.
   - [ ] Auto-update manual QA, from released version of component to new version (see [tools/tuf/test](../tools/tuf/test/README.md)).

