### PR TITLE
Remove rollback to old TUF

### DIFF
--- a/orbit/changes/remove-rollback-to-old-tuf
+++ b/orbit/changes/remove-rollback-to-old-tuf
@@ -1,0 +1,1 @@
+* Removed rollback to connect to Fleet's old TUF server (added in case 1.38.0 had an emergency bug).

--- a/orbit/cmd/orbit/orbit.go
+++ b/orbit/cmd/orbit/orbit.go
@@ -524,7 +524,6 @@ func main() {
 
 		opt.RootDirectory = c.String("root-dir")
 		opt.ServerURL = c.String("update-url")
-		checkAccessToNewTUF := false
 		if opt.ServerURL == update.OldFleetTUFURL {
 			//
 			// This only gets executed on orbit 1.38.0+
@@ -532,20 +531,7 @@ func main() {
 			// (fleetd instances packaged before the migration,
 			// built by fleetctl previous to v4.63.0).
 			//
-
-			if ok := update.HasAccessToNewTUFServer(opt); ok {
-				// orbit 1.38.0+ will use the new TUF server if it has access to the new TUF repository.
-				opt.ServerURL = update.DefaultURL
-			} else {
-				// orbit 1.38.0+ will use the old TUF server and old metadata path if it does not have access
-				// to the new TUF repository. During its execution (update.Runner) it will exit once it finds
-				// out it can access the new TUF server.
-				localStore, err = filestore.New(filepath.Join(c.String("root-dir"), update.OldMetadataFileName))
-				if err != nil {
-					log.Fatal().Err(err).Msg("create local old metadata store")
-				}
-				checkAccessToNewTUF = true
-			}
+			opt.ServerURL = update.DefaultURL
 		}
 		opt.LocalStore = localStore
 		opt.InsecureTransport = c.Bool("insecure")
@@ -614,7 +600,6 @@ func main() {
 				CheckInterval:              c.Duration("update-interval"),
 				Targets:                    targets,
 				SignaturesExpiredAtStartup: signaturesExpiredAtStartup,
-				CheckAccessToNewTUF:        checkAccessToNewTUF,
 			})
 			if err != nil {
 				return err

--- a/orbit/pkg/update/runner.go
+++ b/orbit/pkg/update/runner.go
@@ -39,11 +39,6 @@ type RunnerOptions struct {
 	// An expired signature for the "timestamp" role does not cause issues
 	// at start up (the go-tuf libary allows loading the targets).
 	SignaturesExpiredAtStartup bool
-
-	// CheckAccessToNewTUF, if set to true, will perform a check of access to the new Fleet TUF
-	// server on every update interval (once the access is confirmed it will store the confirmation
-	// of access to disk and will exit to restart).
-	CheckAccessToNewTUF bool
 }
 
 // Runner is a specialized runner for an Updater. It is designed with Execute and
@@ -216,13 +211,6 @@ func (r *Runner) Execute() error {
 			return nil
 		case <-ticker.C:
 			ticker.Reset(r.opt.CheckInterval)
-
-			if r.opt.CheckAccessToNewTUF {
-				if HasAccessToNewTUFServer(r.updater.opt) {
-					log.Info().Msg("detected access to new TUF repository, exiting")
-					return nil
-				}
-			}
 
 			if r.opt.SignaturesExpiredAtStartup {
 				if r.updater.SignaturesExpired() {


### PR DESCRIPTION
For #26108.

Removing rollback to old TUF repository for 1.39.0.

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/Committing-Changes.md#changes-files) for more information.
- [x] A detailed QA plan exists on the associated ticket (if it isn't there, work with the product group's QA engineer to add it)
- [x] Manual QA for all new/changed functionality
- For Orbit and Fleet Desktop changes:
   - [x] Orbit runs on macOS, Linux and Windows. Check if the orbit feature/bugfix should only apply to one platform (`runtime.GOOS`).
   - [x] Manual QA must be performed in the three main OSs, macOS, Windows and Linux.
   - [x] Auto-update manual QA, from released version of component to new version (see [tools/tuf/test](../tools/tuf/test/README.md)).