### PR TITLE
Fleet UI: Unreleased bug side effect fix

### DIFF
--- a/frontend/pages/policies/PolicyPage/components/PolicyResults/_styles.scss
+++ b/frontend/pages/policies/PolicyPage/components/PolicyResults/_styles.scss
@@ -11,7 +11,7 @@
     min-width: 140px;
     padding-left: 0px;
     padding-right: $pad-large;
-    border-right: 0;
+    border-left: 0;
 
     &:first-of-type {
       padding-left: $pad-large;

--- a/frontend/pages/queries/edit/components/QueryResults/_styles.scss
+++ b/frontend/pages/queries/edit/components/QueryResults/_styles.scss
@@ -16,7 +16,7 @@
     min-width: 140px;
     padding-left: 0px;
     padding-right: $pad-large;
-    border-right: 0;
+    border-left: 0;
 
     &:first-of-type {
       padding-left: $pad-large;


### PR DESCRIPTION
## Issue
For #26079 

## Description
- Unreleased bug, changing headers to border-left instead of border-right broke hiding the border-right in a table that needed no borders

- [x] Manual QA for all new/changed functionality

