### PR TITLE
Fleet UI: Unreleased icon hover color bug

### DIFF
--- a/frontend/components/forms/fields/DropdownWrapper/DropdownWrapper.tsx
+++ b/frontend/components/forms/fields/DropdownWrapper/DropdownWrapper.tsx
@@ -269,6 +269,9 @@ const DropdownWrapper = ({
           ".dropdown-wrapper__indicator path": {
             stroke: COLORS["core-vibrant-blue-over"],
           },
+          ".filter-icon path": {
+            fill: COLORS["core-vibrant-blue-over"],
+          },
         },
         // When tabbing
         // Relies on --is-focused for styling as &:focus-visible cannot be applied
@@ -279,9 +282,6 @@ const DropdownWrapper = ({
           ".dropdown-wrapper__indicator path": {
             stroke: COLORS["core-vibrant-blue-over"],
           },
-        },
-        ".filter-icon path": {
-          fill: COLORS["core-vibrant-blue-over"],
         },
         ...(state.isDisabled && {
           ".dropdown-wrapper__single-value": {


### PR DESCRIPTION
## Issue
Introduced when fixing #25257 

## Description 
- Fix unreleased bug where icon was rendering blue by default to rendering blue on hover only

## Screenshot of icon in question (used across multiple tables)
<img width="1217" alt="Screenshot 2025-02-05 at 3 14 57 PM" src="https://github.com/user-attachments/assets/746af7f6-d273-44ff-ba27-d34c474763a7" />


- [x] Manual QA for all new/changed functionality
