### PR TITLE
Fleet UI: Fix small teamId routing bug

### DIFF
--- a/changes/26040-delete-app-reroute-bug
+++ b/changes/26040-delete-app-reroute-bug
@@ -1,1 +1,1 @@
-- Fleet UI: Properly re-route deleting a app on no team to no team software page insteal of all teams software page
+- Fleet UI: Properly re-routed deleting a app on no team to no team software page insteal of all teams software page

--- a/changes/26040-delete-app-reroute-bug
+++ b/changes/26040-delete-app-reroute-bug
@@ -1,0 +1,1 @@
+- Fleet UI: Properly re-route deleting a app on no team to no team software page insteal of all teams software page

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwareTitleDetailsPage.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwareTitleDetailsPage.tsx
@@ -23,6 +23,7 @@ import {
   APP_CONTEXT_ALL_TEAMS_ID,
   APP_CONTEXT_NO_TEAM_ID,
 } from "interfaces/team";
+import { buildQueryStringFromParams } from "utilities/url";
 import { DEFAULT_USE_QUERY_OPTIONS } from "utilities/constants";
 
 import Spinner from "components/Spinner";
@@ -110,12 +111,13 @@ const SoftwareTitleDetailsPage = ({
       refetchSoftwareTitle();
       return;
     }
+
+    const queryParams: string = buildQueryStringFromParams({
+      team_id: teamIdForApi,
+    });
+
     // redirect to software titles page if no versions are available
-    if (teamIdForApi) {
-      router.push(paths.SOFTWARE_TITLES.concat(`?team_id=${teamIdForApi}`));
-    } else {
-      router.push(paths.SOFTWARE_TITLES);
-    }
+    router.push(`${paths.SOFTWARE_TITLES}?${queryParams}`);
   }, [refetchSoftwareTitle, router, softwareTitle, teamIdForApi]);
 
   const onTeamChange = useCallback(


### PR DESCRIPTION
## Issue
For #26040 

## Description
- Fix teamId === 0 for no teams not being attached to the query parameter when routing back to team's software page
- Other: Cleanup of unused repetitive code that was replaced by a global solution in #25733

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
- [ ] A detailed QA plan exists on the associated ticket (if it isn't there, work with the product group's QA engineer to add it)
- [x] Manual QA for all new/changed functionality

