### PR TITLE
Fleet UI: Unreleased tooltip bugs

### DIFF
--- a/frontend/components/CustomLink/CustomLink.tsx
+++ b/frontend/components/CustomLink/CustomLink.tsx
@@ -11,10 +11,16 @@ interface ICustomLinkProps {
   newTab?: boolean;
   /** Icon wraps on new line with last word */
   multiline?: boolean;
+  // TODO: Refactor to use variant
   iconColor?: Colors;
+  // TODO: Refactor to use variant
   color?: "core-fleet-blue" | "core-fleet-black" | "core-fleet-white";
   /** Restricts access via keyboard when CustomLink is part of disabled UI */
   disableKeyboardNavigation?: boolean;
+  /** Longterm: refactor 14 instances away from iconColor/color combo, which
+   * usually are identical and repetitive, toward variants e.g. "banner-link"
+   */
+  variant?: "tooltip-link" | "default";
 }
 
 const baseClass = "custom-link";
@@ -28,10 +34,21 @@ const CustomLink = ({
   iconColor = "core-fleet-blue",
   color = "core-fleet-blue",
   disableKeyboardNavigation = false,
+  variant = "default",
 }: ICustomLinkProps): JSX.Element => {
+  const getIconColor = (): Colors => {
+    switch (variant) {
+      case "tooltip-link":
+        return "core-fleet-white";
+      default:
+        return iconColor;
+    }
+  };
+
   const customLinkClass = classnames(baseClass, className, {
     [`${baseClass}--black`]: color === "core-fleet-black",
     [`${baseClass}--white`]: color === "core-fleet-white",
+    [`${baseClass}--${variant}`]: variant !== "default",
   });
 
   const target = newTab ? "_blank" : "";
@@ -48,7 +65,7 @@ const CustomLink = ({
           <Icon
             name="external-link"
             className={`${baseClass}__external-icon`}
-            color={iconColor}
+            color={getIconColor()}
           />
         )}
       </span>
@@ -60,7 +77,7 @@ const CustomLink = ({
         <Icon
           name="external-link"
           className={`${baseClass}__external-icon`}
-          color={iconColor}
+          color={getIconColor()}
         />
       )}
     </>

--- a/frontend/components/CustomLink/_styles.scss
+++ b/frontend/components/CustomLink/_styles.scss
@@ -10,15 +10,18 @@
     }
   }
 
-  &--black {
-    color: $core-fleet-black;
-  }
-
+  // Legacy
   &--black {
     color: $core-fleet-black;
   }
 
   &--white {
     color: $core-fleet-white;
+  }
+
+  // Variants
+  &--tooltip-link {
+    color: $core-fleet-white;
+    font-size: $xx-small;
   }
 }

--- a/frontend/components/TooltipWrapper/_styles.scss
+++ b/frontend/components/TooltipWrapper/_styles.scss
@@ -17,10 +17,6 @@
 
   &__tip-text {
     @include tooltip-text;
-
-    .custom-link {
-      font-size: $xx-small;
-    }
   }
 }
 

--- a/frontend/components/TooltipWrapper/_styles.scss
+++ b/frontend/components/TooltipWrapper/_styles.scss
@@ -17,6 +17,10 @@
 
   &__tip-text {
     @include tooltip-text;
+
+    .custom-link {
+      font-size: $xx-small;
+    }
   }
 }
 

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwareInstallerCard/SoftwareInstallerCard.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwareInstallerCard/SoftwareInstallerCard.tsx
@@ -327,13 +327,12 @@ const SoftwareInstallerCard = ({
     <TooltipWrapper
       tipContent={
         <span>
-          Fleet couldn&apos;t read the version from ${name}.{" "}
+          Fleet couldn&apos;t read the version from {name}.{" "}
           <CustomLink
             newTab
             url={`${LEARN_MORE_ABOUT_BASE_LINK}/read-package-version`}
             text="Learn more"
-            color="core-fleet-white"
-            iconColor="core-fleet-white"
+            variant="tooltip-link"
           />
         </span>
       }

--- a/frontend/styles/var/colors.scss
+++ b/frontend/styles/var/colors.scss
@@ -1,11 +1,11 @@
 // Core
 $core-fleet-black: #192147;
-$core-fleet-white: #ffffff;
+$core-fleet-white: #ffffff; // TODO: merge with core-white
 $core-fleet-blue: #3e4771;
 $core-vibrant-blue: #6a67fe;
 $core-vibrant-red: #ff5c83;
 $core-fleet-purple: #ae6ddf;
-$core-white: #ffffff;
+$core-white: #ffffff; // TODO: merge with core-fleet-white
 $core-dark-blue-grey: #506e92;
 $site-nav-on-hover: #0e1533;
 


### PR DESCRIPTION
## Issue
For #26110 

## Description
- Fix $
- Fix size bug of link within tooltip

## Screenshot of fix
<img width="1089" alt="Screenshot 2025-02-05 at 4 34 37 PM" src="https://github.com/user-attachments/assets/37dc9a75-1290-4531-b63b-11e806908d77" />

## Note
- Tech debt to replace 14 instances of `<CustomLink/>` `color` and `iconColor` props with single `variant` prop

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

   - [x] Manual QA must be performed in the three main OSs, macOS, Windows and Linux.

