### PR TITLE
Cherry-Pick: Add CPE translation mapping for IntelliJ CE for Windows

### DIFF
--- a/changes/25662-ij-windows
+++ b/changes/25662-ij-windows
@@ -1,0 +1,1 @@
+* Resolved false negatives on vulnerabilities for IntelliJ IDEA Community Edition on Windows.

--- a/server/vulnerabilities/nvd/cpe_test.go
+++ b/server/vulnerabilities/nvd/cpe_test.go
@@ -1343,6 +1343,15 @@ func TestCPEFromSoftwareIntegration(t *testing.T) {
 		},
 		{
 			software: fleet.Software{
+				Name:    "IntelliJ IDEA Community Edition 2022.3.2",
+				Source:  "programs",
+				Version: "223.8617.56",
+				Vendor:  "",
+			},
+			cpe: "cpe:2.3:a:jetbrains:intellij_idea:223.8617.56:*:*:*:*:windows:*:*",
+		},
+		{
+			software: fleet.Software{
 				Name:             "IntelliJ IDEA.app",
 				Source:           "apps",
 				Version:          "2022.3.3",

--- a/server/vulnerabilities/nvd/cpe_translations.json
+++ b/server/vulnerabilities/nvd/cpe_translations.json
@@ -171,6 +171,16 @@
   },
   {
     "software": {
+      "name": ["/^IntelliJ IDEA Community Edition/"],
+      "source": ["programs"]
+    },
+    "filter": {
+      "product": ["intellij_idea"],
+      "vendor": ["jetbrains"]
+    }
+  },
+  {
+    "software": {
       "bundle_identifier": ["/^com\\.jetbrains\\.pycharm/"],
       "source": ["apps"]
     },


### PR DESCRIPTION
Merged into `main` as #25971. PR to RC to get the changelog in the right place, as this change goes out with the vulns feed update at midnight UTC.