### PR TITLE
Fleet UI: Unreleased darwin rendering instead of macOS

### DIFF
--- a/frontend/interfaces/software.ts
+++ b/frontend/interfaces/software.ts
@@ -3,7 +3,7 @@ import PropTypes from "prop-types";
 
 import { IconNames } from "components/icons";
 
-import { HOST_APPLE_PLATFORMS } from "./platform";
+import { HOST_APPLE_PLATFORMS, Platform } from "./platform";
 import vulnerabilityInterface from "./vulnerability";
 import { ILabelSoftwareTitle } from "./label";
 
@@ -455,14 +455,14 @@ export interface IFleetMaintainedApp {
   id: number;
   name: string;
   version: string;
-  platform: string;
+  platform: Platform;
 }
 
 export interface IFleetMaintainedAppDetails {
   id: number;
   name: string;
   version: string;
-  platform: string;
+  platform: Platform;
   pre_install_script: string; // TODO: is this needed?
   install_script: string;
   post_install_script: string; // TODO: is this needed?

--- a/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareFleetMaintained/FleetMaintainedAppDetailsPage/FleetAppDetailsModal/FleetAppDetailsModal.tests.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareFleetMaintained/FleetMaintainedAppDetailsPage/FleetAppDetailsModal/FleetAppDetailsModal.tests.tsx
@@ -8,7 +8,7 @@ import FleetAppDetailsModal from "./FleetAppDetailsModal";
 describe("FleetAppDetailsModal", () => {
   const defaultProps = {
     name: "Test App",
-    platform: "macOS",
+    platform: "darwin",
     version: "1.0.0",
     url: "https://example.com/app",
     onCancel: noop,

--- a/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareFleetMaintained/FleetMaintainedAppDetailsPage/FleetAppDetailsModal/FleetAppDetailsModal.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareFleetMaintained/FleetMaintainedAppDetailsPage/FleetAppDetailsModal/FleetAppDetailsModal.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 
+import { PLATFORM_DISPLAY_NAMES } from "utilities/constants";
 import Modal from "components/Modal";
 import DataSet from "components/DataSet";
 import TooltipWrapper from "components/TooltipWrapper";
@@ -31,7 +32,7 @@ const FleetAppDetailsModal = ({
       <>
         <div className={`${baseClass}__modal-content`}>
           <DataSet title="Name" value={name} />
-          <DataSet title="Platform" value={platform} />
+          <DataSet title="Platform" value={PLATFORM_DISPLAY_NAMES[platform]} />
           <DataSet title="Version" value={version} />
           {url && (
             <DataSet


### PR DESCRIPTION
## Issue
Unreleased bug for #23116 

## Description
- Copy bug in UI showing "darwin" instead of "macOS"

## Screenshot of fix
<img width="1180" alt="Screenshot 2025-02-06 at 11 08 11 AM" src="https://github.com/user-attachments/assets/29ccee65-4a90-427e-b227-183c4252a182" />


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Manual QA for all new/changed functionality

