### PR TITLE
Add troubleshooting note to README.md

### DIFF
--- a/tools/tuf/test/README.md
+++ b/tools/tuf/test/README.md
@@ -144,3 +144,13 @@ Solution: Set the `MACOSX_DEPLOYMENT_TARGET` environment variable to the lowest 
 ```
 export MACOSX_DEPLOYMENT_TARGET=13 # replace '13' with your target macOS version
 ```
+
+#### Issue generating linux-arm64 packages when running Docker Desktop on macOS using Apple Silicon
+
+When running Docker Desktop on macOS using Apple Silicon, enrollment packages for ARM Linux may fail to generate and you may see a warning similar to:
+
+```
+WARNING: The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested
+```
+
+Solution: In Docker Desktop go to Settings >> General >> Virtual Machine Options and choose the "Docker VMM (BETA)" option. Restart Docker Desktop.

--- a/tools/tuf/test/README.md
+++ b/tools/tuf/test/README.md
@@ -151,6 +151,9 @@ When running Docker Desktop on macOS using Apple Silicon, enrollment packages fo
 
 ```
 WARNING: The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested
+[...]
+/usr/local/go/pkg/tool/linux_amd64/compile: signal: illegal instruction
+make: *** [desktop-linux] Error 1
 ```
 
 Solution: In Docker Desktop go to Settings >> General >> Virtual Machine Options and choose the "Docker VMM (BETA)" option. Restart Docker Desktop.


### PR DESCRIPTION
Adding a troubleshooting note to the README.md to address failures to generate ARM Linux enrollment packages when running Docker Desktop on an Apple Silicon Mac.

