### PR TITLE
UI - Cleanup, tweak logic for showing query "Manage automations" button

### DIFF
--- a/frontend/pages/policies/ManagePoliciesPage/ManagePoliciesPage.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/ManagePoliciesPage.tsx
@@ -836,7 +836,6 @@ const ManagePolicyPage = ({
         <PoliciesTable
           policiesList={globalPolicies || []}
           isLoading={isFetchingGlobalPolicies || isFetchingConfig}
-          onAddPolicyClick={onAddPolicyClick}
           onDeletePolicyClick={onDeletePolicyClick}
           canAddOrDeletePolicy={canAddOrDeletePolicy}
           hasPoliciesToDelete={hasPoliciesToAutomateOrDelete}
@@ -870,7 +869,6 @@ const ManagePolicyPage = ({
           isLoading={
             isFetchingTeamPolicies || isFetchingTeamConfig || isFetchingConfig
           }
-          onAddPolicyClick={onAddPolicyClick}
           onDeletePolicyClick={onDeletePolicyClick}
           canAddOrDeletePolicy={canAddOrDeletePolicy}
           hasPoliciesToDelete={hasPoliciesToAutomateOrDelete}

--- a/frontend/pages/policies/ManagePoliciesPage/components/PoliciesTable/PoliciesTable.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/components/PoliciesTable/PoliciesTable.tsx
@@ -5,7 +5,6 @@ import { IPolicyStats } from "interfaces/policy";
 import { ITeamSummary, APP_CONTEXT_ALL_TEAMS_ID } from "interfaces/team";
 import { IEmptyTableProps } from "interfaces/empty_table";
 
-import Button from "components/buttons/Button";
 import TableContainer from "components/TableContainer";
 import { ITableQueryData } from "components/TableContainer/TableContainer";
 import EmptyTable from "components/EmptyTable";
@@ -19,7 +18,6 @@ const DEFAULT_SORT_HEADER = "name";
 interface IPoliciesTableProps {
   policiesList: IPolicyStats[];
   isLoading: boolean;
-  onAddPolicyClick?: () => void;
   onDeletePolicyClick: (selectedTableIds: number[]) => void;
   canAddOrDeletePolicy?: boolean;
   hasPoliciesToDelete?: boolean;
@@ -38,7 +36,6 @@ interface IPoliciesTableProps {
 const PoliciesTable = ({
   policiesList,
   isLoading,
-  onAddPolicyClick,
   onDeletePolicyClick,
   canAddOrDeletePolicy,
   hasPoliciesToDelete,

--- a/frontend/pages/queries/ManageQueriesPage/ManageQueriesPage.tsx
+++ b/frontend/pages/queries/ManageQueriesPage/ManageQueriesPage.tsx
@@ -163,19 +163,11 @@ const ManageQueriesPage = ({
   const enhancedQueries = queriesResponse?.queries.map(enhanceQuery);
 
   const queriesAvailableToAutomate =
-    (teamIdForApi
+    (teamIdForApi !== API_ALL_TEAMS_ID
       ? enhancedQueries?.filter(
           (query: IEnhancedQuery) => query.team_id === currentTeamId
         )
       : enhancedQueries) ?? [];
-
-  const onlyInheritedQueries = useMemo(() => {
-    if (teamIdForApi === API_ALL_TEAMS_ID) {
-      // global scope
-      return false;
-    }
-    return !enhancedQueries?.some((query) => query.team_id === teamIdForApi);
-  }, [teamIdForApi, enhancedQueries]);
 
   const automatedQueryIds = queriesAvailableToAutomate
     .filter((query) => query.automations_enabled)
@@ -280,9 +272,8 @@ const ManageQueriesPage = ({
         queries={enhancedQueries || []}
         totalQueriesCount={queriesResponse?.count}
         hasNextResults={!!queriesResponse?.meta.has_next_results}
-        onlyInheritedQueries={onlyInheritedQueries}
+        curTeamScopeQueriesPresent={!!queriesAvailableToAutomate.length}
         isLoading={isLoadingQueries || isFetchingQueries}
-        onCreateQueryClick={onCreateQueryClick}
         onDeleteQueryClick={onDeleteQueryClick}
         isOnlyObserver={isOnlyObserver}
         isObserverPlus={isObserverPlus}
@@ -394,15 +385,16 @@ const ManageQueriesPage = ({
 
           {canCustomQuery && (
             <div className={`${baseClass}__action-button-container`}>
-              {(isGlobalAdmin || isTeamAdmin) && !onlyInheritedQueries && (
-                <Button
-                  onClick={onManageAutomationsClick}
-                  className={`${baseClass}__manage-automations button`}
-                  variant="inverse"
-                >
-                  Manage automations
-                </Button>
-              )}
+              {(isGlobalAdmin || isTeamAdmin) &&
+                !!queriesAvailableToAutomate.length && (
+                  <Button
+                    onClick={onManageAutomationsClick}
+                    className={`${baseClass}__manage-automations button`}
+                    variant="inverse"
+                  >
+                    Manage automations
+                  </Button>
+                )}
               {canCustomQuery && (
                 <Button
                   variant="brand"

--- a/frontend/pages/queries/ManageQueriesPage/components/QueriesTable/QueriesTable.tests.tsx
+++ b/frontend/pages/queries/ManageQueriesPage/components/QueriesTable/QueriesTable.tests.tsx
@@ -158,7 +158,7 @@ describe("QueriesTable", () => {
         queries: [],
         totalQueriesCount: 0,
         hasNextResults: false,
-        curTeamScopeQueriesPresent: false,
+        curTeamScopeQueriesPresent: true,
         isLoading: false,
         onDeleteQueryClick: jest.fn(),
         isOnlyObserver: false,
@@ -184,7 +184,7 @@ describe("QueriesTable", () => {
         queries: [],
         totalQueriesCount: 0,
         hasNextResults: false,
-        curTeamScopeQueriesPresent: false,
+        curTeamScopeQueriesPresent: true,
         isLoading: false,
         onDeleteQueryClick: jest.fn(),
         isOnlyObserver: false,
@@ -211,7 +211,7 @@ describe("QueriesTable", () => {
         queries: [],
         totalQueriesCount: 0,
         hasNextResults: false,
-        curTeamScopeQueriesPresent: false,
+        curTeamScopeQueriesPresent: true,
         isLoading: false,
         onDeleteQueryClick: jest.fn(),
         isOnlyObserver: false,
@@ -238,7 +238,7 @@ describe("QueriesTable", () => {
         queries: [...testGlobalQueries, ...testTeamQueries],
         totalQueriesCount: 4,
         hasNextResults: false,
-        curTeamScopeQueriesPresent: false,
+        curTeamScopeQueriesPresent: true,
         isLoading: false,
         onDeleteQueryClick: jest.fn(),
         isOnlyObserver: false,
@@ -268,7 +268,7 @@ describe("QueriesTable", () => {
       queries: [],
       totalQueriesCount: 0,
       hasNextResults: false,
-      curTeamScopeQueriesPresent: false,
+      curTeamScopeQueriesPresent: true,
       isLoading: false,
       onDeleteQueryClick: jest.fn(),
       isOnlyObserver: false,
@@ -306,7 +306,7 @@ describe("QueriesTable", () => {
         queries={testQueries}
         totalQueriesCount={1}
         hasNextResults={false}
-        curTeamScopeQueriesPresent={false}
+        curTeamScopeQueriesPresent={true}
         isLoading={false}
         onDeleteQueryClick={jest.fn()}
         isOnlyObserver={false}
@@ -346,7 +346,7 @@ describe("QueriesTable", () => {
         queries={testQueries}
         totalQueriesCount={1}
         hasNextResults={false}
-        curTeamScopeQueriesPresent={false}
+        curTeamScopeQueriesPresent={true}
         isLoading={false}
         onDeleteQueryClick={jest.fn()}
         isOnlyObserver={false}
@@ -385,7 +385,7 @@ describe("QueriesTable", () => {
         queries={testQueries}
         totalQueriesCount={1}
         hasNextResults={false}
-        curTeamScopeQueriesPresent={false}
+        curTeamScopeQueriesPresent={true}
         isLoading={false}
         onDeleteQueryClick={jest.fn()}
         isOnlyObserver={false}
@@ -413,7 +413,7 @@ describe("QueriesTable", () => {
         queries={[...testTeamQueries, ...testGlobalQueries]}
         totalQueriesCount={4}
         hasNextResults={false}
-        curTeamScopeQueriesPresent={false}
+        curTeamScopeQueriesPresent={true}
         isLoading={false}
         onDeleteQueryClick={jest.fn()}
         isOnlyObserver={false}

--- a/frontend/pages/queries/ManageQueriesPage/components/QueriesTable/QueriesTable.tests.tsx
+++ b/frontend/pages/queries/ManageQueriesPage/components/QueriesTable/QueriesTable.tests.tsx
@@ -161,7 +161,6 @@ describe("QueriesTable", () => {
         onlyInheritedQueries: false,
         isLoading: false,
         onDeleteQueryClick: jest.fn(),
-        onCreateQueryClick: jest.fn(),
         isOnlyObserver: false,
         isObserverPlus: false,
         isAnyTeamObserverPlus: false,
@@ -188,7 +187,6 @@ describe("QueriesTable", () => {
         onlyInheritedQueries: false,
         isLoading: false,
         onDeleteQueryClick: jest.fn(),
-        onCreateQueryClick: jest.fn(),
         isOnlyObserver: false,
         isObserverPlus: false,
         isAnyTeamObserverPlus: false,
@@ -208,15 +206,6 @@ describe("QueriesTable", () => {
   });
 
   it("Renders the page-wide empty state when no queries are present (specific team)", () => {
-    const render = createCustomRenderer({
-      context: {
-        app: {
-          isGlobalAdmin: true,
-          currentUser: createMockUser(),
-        },
-      },
-    });
-
     const testData: IQueriesTableProps[] = [
       {
         queries: [],
@@ -225,7 +214,6 @@ describe("QueriesTable", () => {
         onlyInheritedQueries: false,
         isLoading: false,
         onDeleteQueryClick: jest.fn(),
-        onCreateQueryClick: jest.fn(),
         isOnlyObserver: false,
         isObserverPlus: false,
         isAnyTeamObserverPlus: false,
@@ -253,7 +241,6 @@ describe("QueriesTable", () => {
         onlyInheritedQueries: false,
         isLoading: false,
         onDeleteQueryClick: jest.fn(),
-        onCreateQueryClick: jest.fn(),
         isOnlyObserver: false,
         isObserverPlus: false,
         isAnyTeamObserverPlus: false,
@@ -284,7 +271,6 @@ describe("QueriesTable", () => {
       onlyInheritedQueries: false,
       isLoading: false,
       onDeleteQueryClick: jest.fn(),
-      onCreateQueryClick: jest.fn(),
       isOnlyObserver: false,
       isObserverPlus: false,
       isAnyTeamObserverPlus: false,
@@ -323,7 +309,6 @@ describe("QueriesTable", () => {
         onlyInheritedQueries={false}
         isLoading={false}
         onDeleteQueryClick={jest.fn()}
-        onCreateQueryClick={jest.fn()}
         isOnlyObserver={false}
         isObserverPlus={false}
         isAnyTeamObserverPlus={false}
@@ -364,7 +349,6 @@ describe("QueriesTable", () => {
         onlyInheritedQueries={false}
         isLoading={false}
         onDeleteQueryClick={jest.fn()}
-        onCreateQueryClick={jest.fn()}
         isOnlyObserver={false}
         isObserverPlus={false}
         isAnyTeamObserverPlus={false}
@@ -404,7 +388,6 @@ describe("QueriesTable", () => {
         onlyInheritedQueries={false}
         isLoading={false}
         onDeleteQueryClick={jest.fn()}
-        onCreateQueryClick={jest.fn()}
         isOnlyObserver={false}
         isObserverPlus={false}
         isAnyTeamObserverPlus={false}
@@ -433,7 +416,6 @@ describe("QueriesTable", () => {
         onlyInheritedQueries={false}
         isLoading={false}
         onDeleteQueryClick={jest.fn()}
-        onCreateQueryClick={jest.fn()}
         isOnlyObserver={false}
         isObserverPlus={false}
         isAnyTeamObserverPlus={false}

--- a/frontend/pages/queries/ManageQueriesPage/components/QueriesTable/QueriesTable.tests.tsx
+++ b/frontend/pages/queries/ManageQueriesPage/components/QueriesTable/QueriesTable.tests.tsx
@@ -306,7 +306,7 @@ describe("QueriesTable", () => {
         queries={testQueries}
         totalQueriesCount={1}
         hasNextResults={false}
-        curTeamScopeQueriesPresent={true}
+        curTeamScopeQueriesPresent
         isLoading={false}
         onDeleteQueryClick={jest.fn()}
         isOnlyObserver={false}
@@ -346,7 +346,7 @@ describe("QueriesTable", () => {
         queries={testQueries}
         totalQueriesCount={1}
         hasNextResults={false}
-        curTeamScopeQueriesPresent={true}
+        curTeamScopeQueriesPresent
         isLoading={false}
         onDeleteQueryClick={jest.fn()}
         isOnlyObserver={false}
@@ -385,7 +385,7 @@ describe("QueriesTable", () => {
         queries={testQueries}
         totalQueriesCount={1}
         hasNextResults={false}
-        curTeamScopeQueriesPresent={true}
+        curTeamScopeQueriesPresent
         isLoading={false}
         onDeleteQueryClick={jest.fn()}
         isOnlyObserver={false}
@@ -413,7 +413,7 @@ describe("QueriesTable", () => {
         queries={[...testTeamQueries, ...testGlobalQueries]}
         totalQueriesCount={4}
         hasNextResults={false}
-        curTeamScopeQueriesPresent={true}
+        curTeamScopeQueriesPresent
         isLoading={false}
         onDeleteQueryClick={jest.fn()}
         isOnlyObserver={false}

--- a/frontend/pages/queries/ManageQueriesPage/components/QueriesTable/QueriesTable.tests.tsx
+++ b/frontend/pages/queries/ManageQueriesPage/components/QueriesTable/QueriesTable.tests.tsx
@@ -158,7 +158,7 @@ describe("QueriesTable", () => {
         queries: [],
         totalQueriesCount: 0,
         hasNextResults: false,
-        onlyInheritedQueries: false,
+        curTeamScopeQueriesPresent: false,
         isLoading: false,
         onDeleteQueryClick: jest.fn(),
         isOnlyObserver: false,
@@ -184,7 +184,7 @@ describe("QueriesTable", () => {
         queries: [],
         totalQueriesCount: 0,
         hasNextResults: false,
-        onlyInheritedQueries: false,
+        curTeamScopeQueriesPresent: false,
         isLoading: false,
         onDeleteQueryClick: jest.fn(),
         isOnlyObserver: false,
@@ -211,7 +211,7 @@ describe("QueriesTable", () => {
         queries: [],
         totalQueriesCount: 0,
         hasNextResults: false,
-        onlyInheritedQueries: false,
+        curTeamScopeQueriesPresent: false,
         isLoading: false,
         onDeleteQueryClick: jest.fn(),
         isOnlyObserver: false,
@@ -238,7 +238,7 @@ describe("QueriesTable", () => {
         queries: [...testGlobalQueries, ...testTeamQueries],
         totalQueriesCount: 4,
         hasNextResults: false,
-        onlyInheritedQueries: false,
+        curTeamScopeQueriesPresent: false,
         isLoading: false,
         onDeleteQueryClick: jest.fn(),
         isOnlyObserver: false,
@@ -268,7 +268,7 @@ describe("QueriesTable", () => {
       queries: [],
       totalQueriesCount: 0,
       hasNextResults: false,
-      onlyInheritedQueries: false,
+      curTeamScopeQueriesPresent: false,
       isLoading: false,
       onDeleteQueryClick: jest.fn(),
       isOnlyObserver: false,
@@ -306,7 +306,7 @@ describe("QueriesTable", () => {
         queries={testQueries}
         totalQueriesCount={1}
         hasNextResults={false}
-        onlyInheritedQueries={false}
+        curTeamScopeQueriesPresent={false}
         isLoading={false}
         onDeleteQueryClick={jest.fn()}
         isOnlyObserver={false}
@@ -346,7 +346,7 @@ describe("QueriesTable", () => {
         queries={testQueries}
         totalQueriesCount={1}
         hasNextResults={false}
-        onlyInheritedQueries={false}
+        curTeamScopeQueriesPresent={false}
         isLoading={false}
         onDeleteQueryClick={jest.fn()}
         isOnlyObserver={false}
@@ -385,7 +385,7 @@ describe("QueriesTable", () => {
         queries={testQueries}
         totalQueriesCount={1}
         hasNextResults={false}
-        onlyInheritedQueries={false}
+        curTeamScopeQueriesPresent={false}
         isLoading={false}
         onDeleteQueryClick={jest.fn()}
         isOnlyObserver={false}
@@ -413,7 +413,7 @@ describe("QueriesTable", () => {
         queries={[...testTeamQueries, ...testGlobalQueries]}
         totalQueriesCount={4}
         hasNextResults={false}
-        onlyInheritedQueries={false}
+        curTeamScopeQueriesPresent={false}
         isLoading={false}
         onDeleteQueryClick={jest.fn()}
         isOnlyObserver={false}

--- a/frontend/pages/queries/ManageQueriesPage/components/QueriesTable/QueriesTable.tsx
+++ b/frontend/pages/queries/ManageQueriesPage/components/QueriesTable/QueriesTable.tsx
@@ -15,7 +15,6 @@ import { getNextLocationPath } from "utilities/helpers";
 import { SingleValue } from "react-select-5";
 import DropdownWrapper from "components/forms/fields/DropdownWrapper";
 import { CustomOptionType } from "components/forms/fields/DropdownWrapper/DropdownWrapper";
-import Button from "components/buttons/Button";
 import TableContainer from "components/TableContainer";
 import TableCount from "components/TableContainer/TableCount";
 import CustomLink from "components/CustomLink";
@@ -31,7 +30,6 @@ export interface IQueriesTableProps {
   onlyInheritedQueries: boolean;
   isLoading: boolean;
   onDeleteQueryClick: (selectedTableQueryIds: number[]) => void;
-  onCreateQueryClick: () => void;
   isOnlyObserver?: boolean;
   isObserverPlus?: boolean;
   isAnyTeamObserverPlus: boolean;
@@ -89,7 +87,6 @@ const QueriesTable = ({
   onlyInheritedQueries,
   isLoading,
   onDeleteQueryClick,
-  onCreateQueryClick,
   isOnlyObserver,
   isObserverPlus,
   isAnyTeamObserverPlus,

--- a/frontend/pages/queries/ManageQueriesPage/components/QueriesTable/QueriesTable.tsx
+++ b/frontend/pages/queries/ManageQueriesPage/components/QueriesTable/QueriesTable.tsx
@@ -27,7 +27,7 @@ export interface IQueriesTableProps {
   queries: IEnhancedQuery[] | null;
   totalQueriesCount: number | undefined;
   hasNextResults: boolean;
-  onlyInheritedQueries: boolean;
+  curTeamScopeQueriesPresent: boolean;
   isLoading: boolean;
   onDeleteQueryClick: (selectedTableQueryIds: number[]) => void;
   isOnlyObserver?: boolean;
@@ -84,7 +84,7 @@ const QueriesTable = ({
   queries,
   totalQueriesCount,
   hasNextResults,
-  onlyInheritedQueries,
+  curTeamScopeQueriesPresent,
   isLoading,
   onDeleteQueryClick,
   isOnlyObserver,
@@ -252,9 +252,9 @@ const QueriesTable = ({
       generateColumnConfigs({
         currentUser,
         currentTeamId,
-        omitSelectionColumn: onlyInheritedQueries,
+        omitSelectionColumn: !curTeamScopeQueriesPresent,
       }),
-    [currentUser, currentTeamId, onlyInheritedQueries]
+    [currentUser, currentTeamId, curTeamScopeQueriesPresent]
   );
 
   const searchable =
@@ -296,7 +296,7 @@ const QueriesTable = ({
           onQueryChange={onQueryChange}
           searchable={searchable}
           customControl={searchable ? renderPlatformDropdown : undefined}
-          disableMultiRowSelect={onlyInheritedQueries}
+          disableMultiRowSelect={!curTeamScopeQueriesPresent}
           onClickRow={handleRowSelect}
           selectedDropdownFilter={curTargetedPlatformFilter}
         />


### PR DESCRIPTION
## For #23312 
### Follow-up for #26124 - see [here](https://github.com/fleetdm/fleet/pull/26124#issuecomment-2640795826)

Hide Queries > Manage automations button when no All teams queries present:

<img width="1392" alt="Screenshot 2025-02-06 at 12 10 50 PM" src="https://github.com/user-attachments/assets/88739e75-74b7-4a8c-83d7-b72e982ee73a" />

If some of the following don't apply, delete the relevant line.


- [x] Added/updated automated tests
- [x] Manual QA for all new/changed functionality
