### PR TITLE
Disallow user-scoped profiles for Windows MDM

### DIFF
--- a/changes/25731-mdm-windows-user-scoped
+++ b/changes/25731-mdm-windows-user-scoped
@@ -1,0 +1,3 @@
+- Added validations to UI and CLI for Windows MDM profiles; Fleet currently supports only
+  device-scoped profiles for Windows and will reject user-scoped profiles (i.e. any profile where the LocURI
+  begins with `./User/Vendor`).

--- a/server/fleet/windows_mdm.go
+++ b/server/fleet/windows_mdm.go
@@ -154,7 +154,7 @@ func validateFleetProvidedLocURI(locURI string) error {
 func validateUserScopedLocURI(locURI string) error {
 	sanitizedLocURI := strings.TrimSpace(locURI)
 	if strings.Contains(sanitizedLocURI, syncml.FleetUserScopedTargetLocURI) {
-		return errors.New(`The configuration profile can't be user scoped ("./User/"). <LocURI> must start with "./Device/".`)
+		return errors.New(`The configuration profile can't be user scoped ("./User/"). <LocURI> must start with "./Device/" ("./Device/" can be omitted, it will default to device scope).`)
 	}
 
 	return nil

--- a/server/fleet/windows_mdm.go
+++ b/server/fleet/windows_mdm.go
@@ -122,6 +122,9 @@ func (m *MDMWindowsConfigProfile) ValidateUserProvided() error {
 
 		case xml.CharData:
 			if inLocURI {
+				if err := validateUserScopedLocURI(string(t)); err != nil {
+					return err
+				}
 				if err := validateFleetProvidedLocURI(string(t)); err != nil {
 					return err
 				}
@@ -143,6 +146,15 @@ func validateFleetProvidedLocURI(locURI string) error {
 		if strings.Contains(sanitizedLocURI, fleetLocURI) {
 			return fmt.Errorf("Custom configuration profiles can't include %s settings. To control these settings, use the %s option.", errHints[0], errHints[1])
 		}
+	}
+
+	return nil
+}
+
+func validateUserScopedLocURI(locURI string) error {
+	sanitizedLocURI := strings.TrimSpace(locURI)
+	if strings.Contains(sanitizedLocURI, syncml.FleetUserScopedTargetLocURI) {
+		return errors.New(`The configuration profile can't be user scoped ("./User/"). <LocURI> must start with "./Device/".`)
 	}
 
 	return nil

--- a/server/mdm/microsoft/syncml/syncml.go
+++ b/server/mdm/microsoft/syncml/syncml.go
@@ -169,8 +169,9 @@ const (
 )
 
 const (
-	FleetBitLockerTargetLocURI = "/Vendor/MSFT/BitLocker"
-	FleetOSUpdateTargetLocURI  = "/Vendor/MSFT/Policy/Config/Update"
+	FleetBitLockerTargetLocURI  = "/Vendor/MSFT/BitLocker"
+	FleetOSUpdateTargetLocURI   = "/Vendor/MSFT/Policy/Config/Update"
+	FleetUserScopedTargetLocURI = "./User/Vendor"
 )
 
 // Supported MS-MDE2 enrollment versions

--- a/server/service/integration_mdm_profiles_test.go
+++ b/server/service/integration_mdm_profiles_test.go
@@ -2173,7 +2173,8 @@ func (s *integrationMDMTestSuite) TestBatchSetMDMAppleProfiles() {
 			mobileconfigForTest(p, p),
 		}}, http.StatusUnprocessableEntity, "team_id", fmt.Sprint(tm.ID))
 		errMsg := extractServerErrorText(res.Body)
-		require.Contains(t, errMsg, fmt.Sprintf("Validation Failed: payload identifier %s is not allowed", p))
+		require.Contains(t, errMsg, "Validation Failed")
+		require.Contains(t, errMsg, fmt.Sprintf("payload identifier %s is not allowed", p))
 	}
 
 	// payloads with reserved types
@@ -2182,7 +2183,8 @@ func (s *integrationMDMTestSuite) TestBatchSetMDMAppleProfiles() {
 			mobileconfigForTestWithContent("N1", "I1", "II1", p, ""),
 		}}, http.StatusUnprocessableEntity, "team_id", fmt.Sprint(tm.ID))
 		errMsg := extractServerErrorText(res.Body)
-		require.Contains(t, errMsg, fmt.Sprintf("Validation Failed: unsupported PayloadType(s): %s", p))
+		require.Contains(t, errMsg, "Validation Failed")
+		require.Contains(t, errMsg, fmt.Sprintf("unsupported PayloadType(s): %s", p))
 	}
 
 	// payloads with reserved identifiers
@@ -2191,7 +2193,8 @@ func (s *integrationMDMTestSuite) TestBatchSetMDMAppleProfiles() {
 			mobileconfigForTestWithContent("N1", "I1", p, "random", ""),
 		}}, http.StatusUnprocessableEntity, "team_id", fmt.Sprint(tm.ID))
 		errMsg := extractServerErrorText(res.Body)
-		require.Contains(t, errMsg, fmt.Sprintf("Validation Failed: unsupported PayloadIdentifier(s): %s", p))
+		require.Contains(t, errMsg, "Validation Failed")
+		require.Contains(t, errMsg, fmt.Sprintf("unsupported PayloadIdentifier(s): %s", p))
 	}
 
 	// successfully apply a profile for the team
@@ -4079,7 +4082,7 @@ func (s *integrationMDMTestSuite) TestBatchSetMDMProfiles() {
 	// Profile is too big
 	resp := s.Do("POST", "/api/v1/fleet/mdm/profiles/batch", batchSetMDMProfilesRequest{Profiles: []fleet.MDMProfileBatchPayload{{Contents: []byte(bigString)}}},
 		http.StatusUnprocessableEntity)
-	require.Contains(t, extractServerErrorText(resp.Body), "Validation Failed: maximum configuration profile file size is 1 MB")
+	require.Contains(t, extractServerErrorText(resp.Body), "maximum configuration profile file size is 1 MB")
 
 	// apply an empty set to no-team
 	s.Do("POST", "/api/v1/fleet/mdm/profiles/batch", batchSetMDMProfilesRequest{Profiles: nil}, http.StatusNoContent)
@@ -4125,7 +4128,8 @@ func (s *integrationMDMTestSuite) TestBatchSetMDMProfiles() {
 			{Name: "N4", Contents: declarationForTest("D1")},
 		}}, http.StatusUnprocessableEntity, "team_id", fmt.Sprint(tm.ID))
 		errMsg := extractServerErrorText(res.Body)
-		require.Contains(t, errMsg, fmt.Sprintf("Validation Failed: payload identifier %s is not allowed", p))
+		require.Contains(t, errMsg, "Validation Failed")
+		require.Contains(t, errMsg, fmt.Sprintf("payload identifier %s is not allowed", p))
 	}
 
 	// payloads with reserved types
@@ -4136,7 +4140,8 @@ func (s *integrationMDMTestSuite) TestBatchSetMDMProfiles() {
 			{Name: "N4", Contents: declarationForTest("D1")},
 		}}, http.StatusUnprocessableEntity, "team_id", fmt.Sprint(tm.ID))
 		errMsg := extractServerErrorText(res.Body)
-		require.Contains(t, errMsg, fmt.Sprintf("Validation Failed: unsupported PayloadType(s): %s", p))
+		require.Contains(t, errMsg, "Validation Failed")
+		require.Contains(t, errMsg, fmt.Sprintf("unsupported PayloadType(s): %s", p))
 	}
 
 	// payloads with reserved identifiers
@@ -4147,7 +4152,8 @@ func (s *integrationMDMTestSuite) TestBatchSetMDMProfiles() {
 			{Name: "N4", Contents: declarationForTest("D1")},
 		}}, http.StatusUnprocessableEntity, "team_id", fmt.Sprint(tm.ID))
 		errMsg := extractServerErrorText(res.Body)
-		require.Contains(t, errMsg, fmt.Sprintf("Validation Failed: unsupported PayloadIdentifier(s): %s", p))
+		require.Contains(t, errMsg, "Validation Failed")
+		require.Contains(t, errMsg, fmt.Sprintf("unsupported PayloadIdentifier(s): %s", p))
 	}
 
 	// profiles with forbidden declaration types
@@ -4400,7 +4406,8 @@ func (s *integrationMDMTestSuite) TestBatchSetMDMProfilesBackwardsCompat() {
 			"N3": syncMLForTest("./Foo/Bar"),
 		}}, http.StatusUnprocessableEntity, "team_id", fmt.Sprint(tm.ID))
 		errMsg := extractServerErrorText(res.Body)
-		require.Contains(t, errMsg, fmt.Sprintf("Validation Failed: payload identifier %s is not allowed", p))
+		require.Contains(t, errMsg, "Validation Failed")
+		require.Contains(t, errMsg, fmt.Sprintf("payload identifier %s is not allowed", p))
 	}
 
 	// payloads with reserved types
@@ -4410,7 +4417,8 @@ func (s *integrationMDMTestSuite) TestBatchSetMDMProfilesBackwardsCompat() {
 			"N3": syncMLForTest("./Foo/Bar"),
 		}}, http.StatusUnprocessableEntity, "team_id", fmt.Sprint(tm.ID))
 		errMsg := extractServerErrorText(res.Body)
-		require.Contains(t, errMsg, fmt.Sprintf("Validation Failed: unsupported PayloadType(s): %s", p))
+		require.Contains(t, errMsg, "Validation Failed")
+		require.Contains(t, errMsg, fmt.Sprintf("unsupported PayloadType(s): %s", p))
 	}
 
 	// payloads with reserved identifiers
@@ -4420,7 +4428,8 @@ func (s *integrationMDMTestSuite) TestBatchSetMDMProfilesBackwardsCompat() {
 			"N3": syncMLForTest("./Foo/Bar"),
 		}}, http.StatusUnprocessableEntity, "team_id", fmt.Sprint(tm.ID))
 		errMsg := extractServerErrorText(res.Body)
-		require.Contains(t, errMsg, fmt.Sprintf("Validation Failed: unsupported PayloadIdentifier(s): %s", p))
+		require.Contains(t, errMsg, "Validation Failed")
+		require.Contains(t, errMsg, fmt.Sprintf("unsupported PayloadIdentifier(s): %s", p))
 	}
 
 	// profiles with reserved Windows location URIs

--- a/server/service/mdm.go
+++ b/server/service/mdm.go
@@ -1976,7 +1976,7 @@ func getAppleProfiles(
 
 		if err := mdmProf.ValidateUserProvided(); err != nil {
 			return nil, nil, ctxerr.Wrap(ctx,
-				fleet.NewInvalidArgumentError(prof.Name, err.Error()))
+				fleet.NewInvalidArgumentError("mdm", fmt.Sprintf("macos_settings: %s: %s", prof.Name, err.Error())))
 		}
 
 		if mdmProf.Name != prof.Name {
@@ -2070,7 +2070,7 @@ func getWindowsProfiles(
 
 		if err := mdmProf.ValidateUserProvided(); err != nil {
 			return nil, ctxerr.Wrap(ctx,
-				fleet.NewInvalidArgumentError(fmt.Sprintf("profiles[%s]", profile.Name), err.Error()))
+				fleet.NewInvalidArgumentError("mdm", fmt.Sprintf("windows_settings: %s: %s", profile.Name, err.Error())))
 		}
 
 		profs[i] = mdmProf

--- a/server/service/mdm_test.go
+++ b/server/service/mdm_test.go
@@ -1213,7 +1213,7 @@ func TestUploadWindowsMDMConfigProfileValidations(t *testing.T) {
 		{"BitLocker profile", 0, `<Replace><Item><Target><LocURI>./Device/Vendor/MSFT/BitLocker/AllowStandardUserEncryption</LocURI></Target></Item></Replace>`, true, "Custom configuration profiles can't include BitLocker settings."},
 		{"Windows updates profile", 0, `<Replace><Item><Target><LocURI> ./Device/Vendor/MSFT/Policy/Config/Update/ConfigureDeadlineNoAutoRebootForFeatureUpdates </LocURI></Target></Item></Replace>`, true, "Custom configuration profiles can't include Windows updates settings."},
 		{"unsupported Fleet variable", 0, `<Replace>$FLEET_VAR_BOZO</Replace>`, true, "Fleet variable"},
-		{"unsupported user-scoped profile", 0, `<Replace><Item><Target><LocURI>./User/Vendor/MSFT/Policy/Config/Bluetooth/AllowDiscoverableMode</LocURI></Target></Item></Replace>`, true, `The configuration profile can't be user scoped ("./User/"). <LocURI> must start with "./Device/".`},
+		{"unsupported user-scoped profile", 0, `<Replace><Item><Target><LocURI>./User/Vendor/MSFT/Policy/Config/Bluetooth/AllowDiscoverableMode</LocURI></Target></Item></Replace>`, true, `The configuration profile can't be user scoped ("./User/"). <LocURI> must start with "./Device/" ("./Device/" can be omitted, it will default to device scope).`},
 
 		{"team empty profile", 1, "", true, "The file should include valid XML."},
 		{"team plist data", 1, string(mcBytesForTest("Foo", "Bar", "UUID")), true, "The file should include valid XML: processing instructions are not allowed."},
@@ -1225,7 +1225,7 @@ func TestUploadWindowsMDMConfigProfileValidations(t *testing.T) {
 		{"team Replace and non-Replace", 1, `<Replace>a</Replace><Get>b</Get>`, true, "Windows configuration profiles can only have <Replace> or <Add> top level elements."},
 		{"team BitLocker profile", 1, `<Replace><Item><Target><LocURI>./Device/Vendor/MSFT/BitLocker/AllowStandardUserEncryption</LocURI></Target></Item></Replace>`, true, "Custom configuration profiles can't include BitLocker settings."},
 		{"team Windows updates profile", 1, `<Replace><Item><Target><LocURI> ./Device/Vendor/MSFT/Policy/Config/Update/ConfigureDeadlineNoAutoRebootForFeatureUpdates </LocURI></Target></Item></Replace>`, true, "Custom configuration profiles can't include Windows updates settings."},
-		{"team unsupported user-scoped profile", 1, `<Replace><Item><Target><LocURI>./User/Vendor/MSFT/Policy/Config/Bluetooth/AllowDiscoverableMode</LocURI></Target></Item></Replace>`, true, `The configuration profile can't be user scoped ("./User/"). <LocURI> must start with "./Device/".`},
+		{"team unsupported user-scoped profile", 1, `<Replace><Item><Target><LocURI>./User/Vendor/MSFT/Policy/Config/Bluetooth/AllowDiscoverableMode</LocURI></Target></Item></Replace>`, true, `The configuration profile can't be user scoped ("./User/"). <LocURI> must start with "./Device/" ("./Device/" can be omitted, it will default to device scope).`},
 		{"invalid team", 2, `<Replace></Replace>`, true, "not found"},
 	}
 

--- a/server/service/mdm_test.go
+++ b/server/service/mdm_test.go
@@ -1213,6 +1213,7 @@ func TestUploadWindowsMDMConfigProfileValidations(t *testing.T) {
 		{"BitLocker profile", 0, `<Replace><Item><Target><LocURI>./Device/Vendor/MSFT/BitLocker/AllowStandardUserEncryption</LocURI></Target></Item></Replace>`, true, "Custom configuration profiles can't include BitLocker settings."},
 		{"Windows updates profile", 0, `<Replace><Item><Target><LocURI> ./Device/Vendor/MSFT/Policy/Config/Update/ConfigureDeadlineNoAutoRebootForFeatureUpdates </LocURI></Target></Item></Replace>`, true, "Custom configuration profiles can't include Windows updates settings."},
 		{"unsupported Fleet variable", 0, `<Replace>$FLEET_VAR_BOZO</Replace>`, true, "Fleet variable"},
+		{"unsupported user-scoped profile", 0, `<Replace><Item><Target><LocURI>./User/Vendor/MSFT/Policy/Config/Bluetooth/AllowDiscoverableMode</LocURI></Target></Item></Replace>`, true, `The configuration profile can't be user scoped ("./User/"). <LocURI> must start with "./Device/".`},
 
 		{"team empty profile", 1, "", true, "The file should include valid XML."},
 		{"team plist data", 1, string(mcBytesForTest("Foo", "Bar", "UUID")), true, "The file should include valid XML: processing instructions are not allowed."},
@@ -1224,7 +1225,7 @@ func TestUploadWindowsMDMConfigProfileValidations(t *testing.T) {
 		{"team Replace and non-Replace", 1, `<Replace>a</Replace><Get>b</Get>`, true, "Windows configuration profiles can only have <Replace> or <Add> top level elements."},
 		{"team BitLocker profile", 1, `<Replace><Item><Target><LocURI>./Device/Vendor/MSFT/BitLocker/AllowStandardUserEncryption</LocURI></Target></Item></Replace>`, true, "Custom configuration profiles can't include BitLocker settings."},
 		{"team Windows updates profile", 1, `<Replace><Item><Target><LocURI> ./Device/Vendor/MSFT/Policy/Config/Update/ConfigureDeadlineNoAutoRebootForFeatureUpdates </LocURI></Target></Item></Replace>`, true, "Custom configuration profiles can't include Windows updates settings."},
-
+		{"team unsupported user-scoped profile", 1, `<Replace><Item><Target><LocURI>./User/Vendor/MSFT/Policy/Config/Bluetooth/AllowDiscoverableMode</LocURI></Target></Item></Replace>`, true, `The configuration profile can't be user scoped ("./User/"). <LocURI> must start with "./Device/".`},
 		{"invalid team", 2, `<Replace></Replace>`, true, "not found"},
 	}
 


### PR DESCRIPTION
For #25713 

# Checklist for submitter
- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
- [x] Added/updated automated tests
- [x] A detailed QA plan exists on the associated ticket (if it isn't there, work with the product group's QA engineer to add it)
- [x] Manual QA for all new/changed functionality

