### PR TITLE
add Learn more link for cert key error when turning on windows mdm

### DIFF
--- a/frontend/components/CustomLink/CustomLink.tsx
+++ b/frontend/components/CustomLink/CustomLink.tsx
@@ -8,6 +8,9 @@ interface ICustomLinkProps {
   url: string;
   text: string;
   className?: string;
+  /** open the link in a new tab
+   * @default false
+   */
   newTab?: boolean;
   /** Icon wraps on new line with last word */
   multiline?: boolean;
@@ -17,10 +20,16 @@ interface ICustomLinkProps {
   color?: "core-fleet-blue" | "core-fleet-black" | "core-fleet-white";
   /** Restricts access via keyboard when CustomLink is part of disabled UI */
   disableKeyboardNavigation?: boolean;
-  /** Longterm: refactor 14 instances away from iconColor/color combo, which
+  /**
+   * Changes the appearance of the link.
+   *
+   * @default "default"
+   *
+   * TODO:
+   * Longterm: refactor 14 instances away from iconColor/color combo, which
    * usually are identical and repetitive, toward variants e.g. "banner-link"
    */
-  variant?: "tooltip-link" | "default";
+  variant?: "tooltip-link" | "default" | "flash-message-link";
 }
 
 const baseClass = "custom-link";
@@ -39,6 +48,7 @@ const CustomLink = ({
   const getIconColor = (): Colors => {
     switch (variant) {
       case "tooltip-link":
+      case "flash-message-link":
         return "core-fleet-white";
       default:
         return iconColor;

--- a/frontend/context/notification.tsx
+++ b/frontend/context/notification.tsx
@@ -17,7 +17,14 @@ type InitialStateType = {
   renderFlash: (
     alertType: "success" | "error" | "warning-filled" | null,
     message: JSX.Element | string | null,
-    options?: { persistOnPageChange?: boolean }
+    options?: {
+      /** `persistOnPageChange` is used to keep the flash message showing after a
+       * router change if set to `true`.
+       *
+       * @default undefined
+       * */
+      persistOnPageChange?: boolean;
+    }
   ) => void;
   hideFlash: () => void;
 };

--- a/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareCustomPackage/helpers.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareCustomPackage/helpers.tsx
@@ -29,6 +29,7 @@ export const getErrorMessage = (err: unknown) => {
           url={`${LEARN_MORE_ABOUT_BASE_LINK}/package-metadata-extraction`}
           text="Learn more"
           newTab
+          variant="flash-message-link"
         />
       </>
     );

--- a/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/WindowsMdmPage/helpers.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/WindowsMdmPage/helpers.tsx
@@ -1,0 +1,38 @@
+import React from "react";
+
+import { getErrorReason } from "interfaces/errors";
+import { FLEET_GUIDES_BASE_LINK } from "utilities/constants";
+
+import CustomLink from "components/CustomLink";
+
+const DEFAULT_ERROR_MESSAGE = "Unable to update Windows MDM. Please try again.";
+
+// eslint-disable-next-line import/prefer-default-export
+export const getErrorMessage = (err: unknown) => {
+  let message = getErrorReason(err, {
+    nameEquals: "mdm.windows_enabled_and_configured",
+  });
+  if (message) {
+    return (
+      <>
+        Couldn&apos;t turn on Windows MDM. Please configure Fleet with a
+        certificate and key pair first.{" "}
+        <CustomLink
+          url={`${FLEET_GUIDES_BASE_LINK}/windows-mdm-setup`}
+          text="Learn more"
+          newTab
+          variant="flash-message-link"
+        />
+      </>
+    );
+  }
+
+  message = getErrorReason(err, {
+    nameEquals: "mdm.windows_migration_enabled",
+  });
+  if (message) {
+    return message;
+  }
+
+  return DEFAULT_ERROR_MESSAGE;
+};

--- a/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/WindowsMdmPage/helpers.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/WindowsMdmPage/helpers.tsx
@@ -18,7 +18,7 @@ export const getErrorMessage = (err: unknown) => {
         Couldn&apos;t turn on Windows MDM. Please configure Fleet with a
         certificate and key pair first.{" "}
         <CustomLink
-          url={`${FLEET_GUIDES_BASE_LINK}/windows-mdm-setup`}
+          url={`${FLEET_GUIDES_BASE_LINK}/windows-mdm-setup#step-1-generate-your-certificate-and-key`}
           text="Learn more"
           newTab
           variant="flash-message-link"

--- a/frontend/utilities/constants.tsx
+++ b/frontend/utilities/constants.tsx
@@ -60,13 +60,12 @@ export const HOST_STATUS_WEBHOOK_WINDOW_DROPDOWN_OPTIONS: IDropdownOption[] = [
 export const GITHUB_NEW_ISSUE_LINK =
   "https://github.com/fleetdm/fleet/issues/new?assignees=&labels=bug%2C%3Areproduce&template=bug-report.md";
 
+/** website links */
 export const FLEET_WEBSITE_URL = "https://fleetdm.com";
-
 export const SUPPORT_LINK = `${FLEET_WEBSITE_URL}/support`;
-
 export const CONTACT_FLEET_LINK = `${FLEET_WEBSITE_URL}/contact`;
-
 export const LEARN_MORE_ABOUT_BASE_LINK = `${FLEET_WEBSITE_URL}/learn-more-about`;
+export const FLEET_GUIDES_BASE_LINK = `${FLEET_WEBSITE_URL}/guides`;
 
 /**  July 28, 2016 is the date of the initial commit to fleet/fleet. */
 export const INITIAL_FLEET_DATE = "2016-07-28T00:00:00Z";


### PR DESCRIPTION
For #26047

adds a "learn more" link on the cert/key pair error when turning on windows.

![image](https://github.com/user-attachments/assets/011e6111-f694-4345-81f2-44c4c3d29ed2)

This also updates the CustomLink to add new variant for when we want to display this in a flash message

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
- [x] Manual QA for all new/changed functionality
