### PR TITLE
Remove restriction on setting both metadata and metadata_url

### DIFF
--- a/changes/26075-set-metadata_url-and-metadata
+++ b/changes/26075-set-metadata_url-and-metadata
@@ -1,0 +1,1 @@
+- Permit setting SSO metadata and metadata_url in gitops and UI

--- a/pkg/spec/testdata/global_config_no_paths.yml
+++ b/pkg/spec/testdata/global_config_no_paths.yml
@@ -140,7 +140,7 @@ org_settings:
     idp_image_url: ""
     idp_name: MockSAML
     issuer_uri: ""
-    metadata: ""
+    metadata: "unused metadata, the URL has priority"
     metadata_url: https://mocksaml.com/api/saml/metadata
   integrations:
     jira:

--- a/pkg/spec/testdata/global_config_no_paths.yml
+++ b/pkg/spec/testdata/global_config_no_paths.yml
@@ -140,7 +140,7 @@ org_settings:
     idp_image_url: ""
     idp_name: MockSAML
     issuer_uri: ""
-    metadata: "unused metadata, the URL has priority"
+    metadata: ""
     metadata_url: https://mocksaml.com/api/saml/metadata
   integrations:
     jira:

--- a/server/service/appconfig.go
+++ b/server/service/appconfig.go
@@ -1363,9 +1363,6 @@ func validateSSOProviderSettings(incoming, existing fleet.SSOProviderSettings, i
 			invalid.Append("metadata", "either metadata or metadata_url must be defined")
 		}
 	}
-	if incoming.Metadata != "" && incoming.MetadataURL != "" {
-		invalid.Append("metadata", "both metadata and metadata_url are defined, only one is allowed")
-	}
 	if incoming.EntityID == "" {
 		if existing.EntityID == "" {
 			invalid.Append("entity_id", "required")

--- a/server/service/appconfig_test.go
+++ b/server/service/appconfig_test.go
@@ -1087,7 +1087,7 @@ func TestMDMAppleConfig(t *testing.T) {
 				MetadataURL: "not-empty",
 				IDPName:     "onelogin",
 			}}},
-			expectedError: "metadata both metadata and metadata_url are defined, only one is allowed",
+			expectedError: "invalid URI for request",
 		}, {
 			name:        "ssoIdPName",
 			licenseTier: "premium",


### PR DESCRIPTION
For #26075 

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/Committing-Changes.md#changes-files) for more information.
- [x] Added/updated automated tests
- [x] A detailed QA plan exists on the associated ticket (if it isn't there, work with the product group's QA engineer to add it)
- [x] Manual QA for all new/changed functionality