### PR TITLE
Don't truncate text in SQL editor

### DIFF
--- a/changes/25921-fix-show-query-truncation
+++ b/changes/25921-fix-show-query-truncation
@@ -1,0 +1,1 @@
+- Fixed an issue where the Show Query modal would truncate large queries.

--- a/frontend/components/SQLEditor/theme.css
+++ b/frontend/components/SQLEditor/theme.css
@@ -29,7 +29,7 @@
 }
 
 .ace-fleet .ace_content {
-  height: 100% !important;
+  height: 100%;
 }
 
 .ace-fleet .ace_gutter {


### PR DESCRIPTION
For #25921 

# Checklist for submitter

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/Committing-Changes.md#changes-files) for more information.

## Details

This PR fixes an issue where the SQL editor would truncate large queries, because it was setting a mandatory height on the content element rather than letting the element use its own computed height.

## Screenshots

**Before:**
![25921-before](https://github.com/user-attachments/assets/19e6e4ea-6ec4-4451-80c7-c5fa061353d7)

**After:**
![25921-after](https://github.com/user-attachments/assets/26c80f89-4bd7-4f43-9d28-531fff945aba)
