### PR TITLE
Add fix for software installers breaking with old fleet version

### DIFF
--- a/changes/26283-software-stuck-pending
+++ b/changes/26283-software-stuck-pending
@@ -1,0 +1,1 @@
+- Fixed a bug where new fleetd could not install software from old fleet server

--- a/server/service/orbit.go
+++ b/server/service/orbit.go
@@ -1147,6 +1147,7 @@ type orbitGetSoftwareInstallRequest struct {
 // interface implementation required by the OrbitClient
 func (r *orbitGetSoftwareInstallRequest) setOrbitNodeKey(nodeKey string) {
 	r.OrbitNodeKey = nodeKey
+	r.OrbotNodeKey = nodeKey // legacy typo -- keep for backwards compatability with fleet server < 4.63.0
 }
 
 // interface implementation required by the OrbitClient


### PR DESCRIPTION
#26283

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/Committing-Changes.md#changes-files) for more information.
- [x] A detailed QA plan exists on the associated ticket (if it isn't there, work with the product group's QA engineer to add it)
	- Install run the latest orbit code on a client
	- Run fleet server v4.62.0
	- Try to install software on client
	- It should download the installer just fine
- [x] Manual QA for all new/changed functionality
- For Orbit and Fleet Desktop changes:
   - [x] Auto-update manual QA, from released version of component to new version (see [tools/tuf/test](../tools/tuf/test/README.md)).
