### PR TITLE
Show "Manage Automations" dropdown when no policies are present

### DIFF
--- a/changes/23243-manage-automations-updates
+++ b/changes/23243-manage-automations-updates
@@ -1,0 +1,1 @@
+* Always show "Manage Automations" to permitted users

--- a/frontend/components/forms/fields/DropdownWrapper/DropdownWrapper.tsx
+++ b/frontend/components/forms/fields/DropdownWrapper/DropdownWrapper.tsx
@@ -337,6 +337,7 @@ const DropdownWrapper = ({
         fontWeight: "bold",
         lineHeight: "normal",
         paddingLeft: 0,
+        opacity: isDisabled ? 0.5 : 1,
         marginTop: variant === "button" ? "-1px" : "1px", // TODO: Figure out vertical centering to not need pixel fix
       };
 
@@ -358,6 +359,7 @@ const DropdownWrapper = ({
       svg: {
         transition: "transform 0.25s ease",
       },
+      opacity: isDisabled ? 0.5 : 1,
     }),
     menu: (provided) => ({
       ...provided,

--- a/frontend/components/forms/fields/DropdownWrapper/_styles.scss
+++ b/frontend/components/forms/fields/DropdownWrapper/_styles.scss
@@ -20,12 +20,4 @@
       height: 40px;
     }
   }
-
-  &--disabled {
-  .react-select__placeholder {
-      &--disabled {
-        color: red
-      }
-    }
-  }  
 }

--- a/frontend/components/forms/fields/DropdownWrapper/_styles.scss
+++ b/frontend/components/forms/fields/DropdownWrapper/_styles.scss
@@ -20,4 +20,12 @@
       height: 40px;
     }
   }
+
+  &--disabled {
+  .react-select__placeholder {
+      &--disabled {
+        color: red
+      }
+    }
+  }  
 }

--- a/frontend/pages/policies/ManagePoliciesPage/ManagePoliciesPage.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/ManagePoliciesPage.tsx
@@ -1006,21 +1006,27 @@ const ManagePolicyPage = ({
       </div>
     );
     if (!hasPoliciesToAutomateOrDelete) {
-      let tipContent = (
-        <p>
-          To manage automations add a policy to this team.
-          <br />
-          For inherited policies select “All teams”.
-        </p>
-      );
-      if (currentTeamId === APP_CONTEXT_ALL_TEAMS_ID) {
-        tipContent = (
-          <p>
-            To manage automations, first add a policy.
-            <br />
-            Select a different team to manage team-specific automations.
-          </p>
-        );
+      let tipContent;
+      if (isPremiumTier) {
+        if (currentTeamId === APP_CONTEXT_ALL_TEAMS_ID) {
+          tipContent = (
+            <p>
+              To manage automations, first add a policy.
+              <br />
+              Select a different team to manage team-specific automations.
+            </p>
+          );
+        } else {
+          tipContent = (
+            <p>
+              To manage automations add a policy to this team.
+              <br />
+              For inherited policies select “All teams”.
+            </p>
+          );
+        }
+      } else {
+        tipContent = <p>To manage automations, first add a policy.</p>;
       }
       automationsDropdown = (
         <TooltipWrapper underline={false} tipContent={tipContent}>

--- a/frontend/pages/policies/ManagePoliciesPage/ManagePoliciesPage.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/ManagePoliciesPage.tsx
@@ -47,6 +47,7 @@ import TeamsDropdown from "components/TeamsDropdown";
 import TableDataError from "components/DataError";
 import MainContent from "components/MainContent";
 import LastUpdatedText from "components/LastUpdatedText";
+import TooltipWrapper from "components/TooltipWrapper";
 
 import PoliciesTable from "./components/PoliciesTable";
 import OtherWorkflowsModal from "./components/OtherWorkflowsModal";
@@ -759,8 +760,7 @@ const ManagePolicyPage = ({
 
   const automationsConfig = !isAllTeamsSelected ? teamConfig : config;
   const hasPoliciesToAutomateOrDelete = policiesAvailableToAutomate.length > 0;
-  const showAutomationsDropdown =
-    canManageAutomations && hasPoliciesToAutomateOrDelete;
+  const showAutomationsDropdown = canManageAutomations;
 
   // NOTE: backend uses webhook_settings to store automated policy ids for both webhooks and integrations
   let currentAutomatedPolicies: number[] = [];
@@ -980,6 +980,44 @@ const ManagePolicyPage = ({
     return options;
   };
 
+  let automationsDropdown = null;
+  if (showAutomationsDropdown) {
+    automationsDropdown = (
+      <div className={`${baseClass}__manage-automations-wrapper`}>
+        <DropdownWrapper
+          isDisabled={!hasPoliciesToAutomateOrDelete}
+          className={`${baseClass}__manage-automations-dropdown`}
+          name="policy-automations"
+          onChange={onSelectAutomationOption}
+          placeholder="Manage automations"
+          options={
+            hasPoliciesToAutomateOrDelete
+              ? getAutomationsDropdownOptions(!!automationsConfig)
+              : []
+          }
+          variant="button"
+          nowrapMenu
+        />
+      </div>
+    );
+    if (!hasPoliciesToAutomateOrDelete) {
+      automationsDropdown = (
+        <TooltipWrapper
+          underline={false}
+          tipContent={
+            <p>
+              To manage automations add a policy to this team.
+              <br />
+              For inherited policies select “All teams”.
+            </p>
+          }
+        >
+          {automationsDropdown}
+        </TooltipWrapper>
+      );
+    }
+  }
+
   if (!isRouteOk) {
     return <Spinner />;
   }
@@ -1021,19 +1059,7 @@ const ManagePolicyPage = ({
           </div>
           {showCtaButtons && (
             <div className={`${baseClass} button-wrap`}>
-              {showAutomationsDropdown && (
-                <div className={`${baseClass}__manage-automations-wrapper`}>
-                  <DropdownWrapper
-                    className={`${baseClass}__manage-automations-dropdown`}
-                    name="policy-automations"
-                    onChange={onSelectAutomationOption}
-                    placeholder="Manage automations"
-                    options={getAutomationsDropdownOptions(!!automationsConfig)}
-                    variant="button"
-                    nowrapMenu
-                  />
-                </div>
-              )}
+              {automationsDropdown}
               {canAddOrDeletePolicy && (
                 <div className={`${baseClass}__action-button-container`}>
                   <Button

--- a/frontend/pages/policies/ManagePoliciesPage/ManagePoliciesPage.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/ManagePoliciesPage.tsx
@@ -1007,29 +1007,24 @@ const ManagePolicyPage = ({
     );
     if (!hasPoliciesToAutomateOrDelete) {
       let tipContent;
-      if (isPremiumTier) {
-        if (currentTeamId === APP_CONTEXT_ALL_TEAMS_ID) {
-          tipContent = (
-            <p>
-              To manage automations, first add a policy.
-              <br />
-              Select a different team to manage team-specific automations.
-            </p>
-          );
-        } else {
-          tipContent = (
-            <p>
-              To manage automations add a policy to this team.
-              <br />
-              For inherited policies select &ldquo;All teams&rdquo;.
-            </p>
-          );
-        }
+      if (isPremiumTier && currentTeamId !== APP_CONTEXT_ALL_TEAMS_ID) {
+        tipContent = (
+          <p className={`${baseClass}__header__tooltip`}>
+            To manage automations add a policy to this team.
+            <br />
+            For inherited policies select &ldquo;All teams&rdquo;.
+          </p>
+        );
       } else {
-        tipContent = <p>To manage automations, first add a policy.</p>;
+        tipContent = (
+          <p className={`${baseClass}__header__tooltip`}>
+            To manage automations add a policy.
+          </p>
+        );
       }
+
       automationsDropdown = (
-        <TooltipWrapper underline={false} tipContent={tipContent}>
+        <TooltipWrapper underline={false} tipContent={tipContent} showArrow>
           {automationsDropdown}
         </TooltipWrapper>
       );

--- a/frontend/pages/policies/ManagePoliciesPage/ManagePoliciesPage.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/ManagePoliciesPage.tsx
@@ -1006,25 +1006,26 @@ const ManagePolicyPage = ({
       </div>
     );
     if (!hasPoliciesToAutomateOrDelete) {
-      let tipContent;
-      if (isPremiumTier && currentTeamId !== APP_CONTEXT_ALL_TEAMS_ID) {
-        tipContent = (
-          <p className={`${baseClass}__header__tooltip`}>
+      const tipContent =
+        isPremiumTier && currentTeamId !== APP_CONTEXT_ALL_TEAMS_ID ? (
+          <div className={`${baseClass}__header__tooltip`}>
             To manage automations add a policy to this team.
             <br />
             For inherited policies select &ldquo;All teams&rdquo;.
-          </p>
-        );
-      } else {
-        tipContent = (
-          <p className={`${baseClass}__header__tooltip`}>
+          </div>
+        ) : (
+          <div className={`${baseClass}__header__tooltip`}>
             To manage automations add a policy.
-          </p>
+          </div>
         );
-      }
 
       automationsDropdown = (
-        <TooltipWrapper underline={false} tipContent={tipContent} showArrow>
+        <TooltipWrapper
+          underline={false}
+          tipContent={tipContent}
+          position="top"
+          showArrow
+        >
           {automationsDropdown}
         </TooltipWrapper>
       );

--- a/frontend/pages/policies/ManagePoliciesPage/ManagePoliciesPage.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/ManagePoliciesPage.tsx
@@ -1021,7 +1021,7 @@ const ManagePolicyPage = ({
             <p>
               To manage automations add a policy to this team.
               <br />
-              For inherited policies select “All teams”.
+              For inherited policies select &ldquo;All teams&rdquo;.
             </p>
           );
         }

--- a/frontend/pages/policies/ManagePoliciesPage/ManagePoliciesPage.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/ManagePoliciesPage.tsx
@@ -21,7 +21,12 @@ import {
   IPoliciesCountResponse,
   IPolicy,
 } from "interfaces/policy";
-import { API_ALL_TEAMS_ID, API_NO_TEAM_ID, ITeamConfig } from "interfaces/team";
+import {
+  API_ALL_TEAMS_ID,
+  API_NO_TEAM_ID,
+  APP_CONTEXT_ALL_TEAMS_ID,
+  ITeamConfig,
+} from "interfaces/team";
 import { TooltipContent } from "interfaces/dropdownOption";
 
 import configAPI from "services/entities/config";
@@ -1001,17 +1006,24 @@ const ManagePolicyPage = ({
       </div>
     );
     if (!hasPoliciesToAutomateOrDelete) {
+      let tipContent = (
+        <p>
+          To manage automations add a policy to this team.
+          <br />
+          For inherited policies select “All teams”.
+        </p>
+      );
+      if (currentTeamId === APP_CONTEXT_ALL_TEAMS_ID) {
+        tipContent = (
+          <p>
+            To manage automations, first add a policy.
+            <br />
+            Select a different team to manage team-specific automations.
+          </p>
+        );
+      }
       automationsDropdown = (
-        <TooltipWrapper
-          underline={false}
-          tipContent={
-            <p>
-              To manage automations add a policy to this team.
-              <br />
-              For inherited policies select “All teams”.
-            </p>
-          }
-        >
+        <TooltipWrapper underline={false} tipContent={tipContent}>
           {automationsDropdown}
         </TooltipWrapper>
       );

--- a/frontend/pages/policies/ManagePoliciesPage/_styles.scss
+++ b/frontend/pages/policies/ManagePoliciesPage/_styles.scss
@@ -55,6 +55,10 @@
     .form-field {
       margin-bottom: 0;
     }
+
+    &__tooltip {
+      text-align: center;
+    }
   }
 
   &__text {


### PR DESCRIPTION
For #23243 

# Checklist for submitter

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/Committing-Changes.md#changes-files) for more information.

## Details

This PR changes the behavior of the Manage Automations dropdown on the Manage Policies page.  Any user that has permission to manage policies will now always see the dropdown.  If there are no policies added for the selected team (or no policies at all, in the case of "All teams" or users on the free tier), the dropdown is disabled with a tooltip.

## Screenshots

**Free tier:**
<img width="753" alt="image" src="https://github.com/user-attachments/assets/37a3b97a-74b3-4495-ace4-bfece30b3822" />

---

**Premium tier, All Teams:**
<img width="736" alt="image" src="https://github.com/user-attachments/assets/bedd9a5f-e2aa-49da-8943-61bc69af9744" />

---

**Premium tier, team selected:**
<img width="744" alt="image" src="https://github.com/user-attachments/assets/e1c2397b-1d19-46f2-b78d-e7a923f91c8f" />
