### PR TITLE
Handbook: Point broken link at correct 2FA anchor

### DIFF
--- a/handbook/digital-experience/security.md
+++ b/handbook/digital-experience/security.md
@@ -362,7 +362,7 @@ Because they are the only type of Two-Factor Authentication (2FA) that protects 
 phishing, we will make them **mandatory for everyone** soon. 
 
 See the [Google Workspace security
-section](https://fleetdm.com/handbook/digital-experience/security#google-workspace-security-authentication) for more
+section](https://fleetdm.com/handbook/digital-experience/security#2-step-verification) for more
 information on the security of different types of 2FA.
 
 


### PR DESCRIPTION
Noticed this broken link while browsing the handbook. Pointed it at the 2FA section under Google Workspace Security which seems to be the intended reference