### PR TITLE
Fleet can remove apps

### DIFF
--- a/website/views/pages/transparency.ejs
+++ b/website/views/pages/transparency.ejs
@@ -102,7 +102,7 @@
             <span class="fa fa-angle-down"></span>
           </p>
           <p id="accordion__body8" class="collapse" aria-labelledby="accordion__header8">
-            Fleet can install software and access a detailed list of the software installed on your device. This enables IT teams to better manage software update schedules, and reduce disruption to your workflow. Additionally, security teams can use this data to check if any software has been compromised by referencing the version numbers against known vulnerable software databases.
+            Fleet can add apps, remove apps, and access a detailed list of the apps and other software installed on your device. This enables IT teams to better manage software update schedules, and reduce disruption to your workflow. Additionally, security teams can use this data to check if any software has been compromised by referencing the version numbers against known vulnerable software databases.
           </p>
         </div>
         <div purpose="accordion-item">


### PR DESCRIPTION
- Use "apps" instead of "software" for end users
