### PR TITLE
Docs: update wipe a host guide

### DIFF
--- a/articles/lock-wipe-hosts.md
+++ b/articles/lock-wipe-hosts.md
@@ -24,6 +24,8 @@ Currently, there's no **Lock** button for iOS and iPadOS. If an iOS or iPadOS ho
 3. Click the **Actions** dropdown, then click  **Wipe**.
 4. Confirm that you want to wipe the device in the dialog. The host will now be marked with a "Wipe pending" badge. Once the wipe command is acknowledged by the host, the badge will update to "Wiped".
 
+> To re-enroll a wiped Windows or Linux host, delete it from Fleet first. If you re-enroll without deletion, the existing host record will be used, and the new disk encryption key won’t be escrowed.
+
 ## Unlock a host
 
 1. Navigate to the **Hosts** page by clicking the "Hosts" tab in the main navigation header. Find the device you want to unlock. You can search by name, hostname, UUID, serial number, or private IP address in the search box in the upper right corner.

--- a/articles/lock-wipe-hosts.md
+++ b/articles/lock-wipe-hosts.md
@@ -24,7 +24,7 @@ Currently, there's no **Lock** button for iOS and iPadOS. If an iOS or iPadOS ho
 3. Click the **Actions** dropdown, then click  **Wipe**.
 4. Confirm that you want to wipe the device in the dialog. The host will now be marked with a "Wipe pending" badge. Once the wipe command is acknowledged by the host, the badge will update to "Wiped".
 
-> To re-enroll a wiped Windows or Linux host, delete it from Fleet first. If you re-enroll without deletion, the existing host record will be used, and the new disk encryption key won’t be escrowed.
+> When wiping and re-installing the operating system (OS) for a host, also delete it from Fleet before you re-enroll it. If you re-enroll without deleting, a new disk encryption key won’t be escrowed.
 
 ## Unlock a host
 


### PR DESCRIPTION
Related to: #24654

Added a callout to describe that the host should be deleted after it's wiped if a user wants to re-enroll the host and escrow a new disk encryption key.