### PR TITLE
UI for certificate details on host details and my device pages

### DIFF
--- a/changes/issue-25464-ui-host-certs
+++ b/changes/issue-25464-ui-host-certs
@@ -1,0 +1,1 @@
+- add UI for viewing certificate details on the host details and my device pages

--- a/frontend/__mocks__/certificatesMock.ts
+++ b/frontend/__mocks__/certificatesMock.ts
@@ -1,0 +1,47 @@
+import { IHostCertificate } from "interfaces/certificates";
+import { IGetHostCertificatesResponse } from "services/entities/hosts";
+
+const DEFAULT_HOST_CERTIFICATE_MOCK: IHostCertificate = {
+  id: 1,
+  not_valid_after: "2021-08-19T02:02:17Z",
+  not_valid_before: "2021-08-19T02:02:17Z",
+  certificate_authority: true,
+  common_name: "Test Cert",
+  key_algorithm: "rsaEncryption",
+  key_strength: 2048,
+  key_usage: "CRL Sign, Key Cert Sign",
+  serial: 1,
+  signing_algorithm: "sha256WithRSAEncryption",
+  subject: {
+    country: "US",
+    organization: "Test Inc.",
+    organizational_unit: "Test Inc.",
+    common_name: "Test Biz",
+  },
+  issuer: {
+    country: "US",
+    organization: "Test Inc.",
+    organizational_unit: "Test Inc.",
+    common_name: "Test Biz",
+  },
+};
+
+export const createMockHostCertificate = (
+  overrides?: Partial<IHostCertificate>
+): IHostCertificate => {
+  return { ...DEFAULT_HOST_CERTIFICATE_MOCK, ...overrides };
+};
+
+const DEFAULT_HOST_CERTIFICATES_RESPONSE_MOCK: IGetHostCertificatesResponse = {
+  certificates: [createMockHostCertificate()],
+  meta: {
+    has_next_results: false,
+    has_previous_results: false,
+  },
+};
+
+export const createMockGetHostCertificatesResponse = (
+  overrides?: Partial<IGetHostCertificatesResponse>
+): IGetHostCertificatesResponse => {
+  return { ...DEFAULT_HOST_CERTIFICATES_RESPONSE_MOCK, ...overrides };
+};

--- a/frontend/components/DataSet/DataSet.stories.tsx
+++ b/frontend/components/DataSet/DataSet.stories.tsx
@@ -6,7 +6,7 @@ const meta: Meta<typeof DataSet> = {
   title: "Components/DataSet",
   component: DataSet,
   args: {
-    title: "Data set",
+    title: "Data set title",
     value: "This is the value",
   },
 };
@@ -16,3 +16,9 @@ export default meta;
 type Story = StoryObj<typeof DataSet>;
 
 export const Basic: Story = {};
+
+export const HorizontalOrientation: Story = {
+  args: {
+    orientation: "horizontal",
+  },
+};

--- a/frontend/components/DataSet/DataSet.tsx
+++ b/frontend/components/DataSet/DataSet.tsx
@@ -6,15 +6,26 @@ const baseClass = "data-set";
 interface IDataSetProps {
   title: React.ReactNode;
   value: React.ReactNode;
+  orientation?: "horizontal" | "vertical";
   className?: string;
 }
 
-const DataSet = ({ title, value, className }: IDataSetProps) => {
-  const classNames = classnames(baseClass, className);
+const DataSet = ({
+  title,
+  value,
+  orientation = "vertical",
+  className,
+}: IDataSetProps) => {
+  const classNames = classnames(baseClass, className, {
+    [`${baseClass}__horizontal`]: orientation === "horizontal",
+  });
 
   return (
     <div className={classNames}>
-      <dt>{title}</dt>
+      <dt>
+        {title}
+        {orientation === "horizontal" && ":"}
+      </dt>
       <dd>{value}</dd>
     </div>
   );

--- a/frontend/components/DataSet/_styles.scss
+++ b/frontend/components/DataSet/_styles.scss
@@ -1,6 +1,11 @@
 .data-set {
   font-size: $x-small;
 
+  &__horizontal {
+    display: flex;
+    gap: $pad-small;
+  }
+
   // ff only
   @-moz-document url-prefix() {
     display: flex;

--- a/frontend/interfaces/certificates.ts
+++ b/frontend/interfaces/certificates.ts
@@ -1,0 +1,24 @@
+export interface IHostCertificate {
+  id: number;
+  not_valid_after: string;
+  not_valid_before: string;
+  certificate_authority: boolean;
+  common_name: string;
+  key_algorithm: string;
+  key_strength: number;
+  key_usage: string;
+  serial: number;
+  signing_algorithm: string;
+  subject: {
+    country: string;
+    organization: string;
+    organizational_unit: string;
+    common_name: string;
+  };
+  issuer: {
+    country: string;
+    organization: string;
+    organizational_unit: string;
+    common_name: string;
+  };
+}

--- a/frontend/pages/hosts/details/DeviceUserPage/_styles.scss
+++ b/frontend/pages/hosts/details/DeviceUserPage/_styles.scss
@@ -27,6 +27,12 @@
     transform: scale(0.5);
   }
 
+  &__details-panel {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: $pad-large;
+  }
+
   &__error {
     display: flex;
     flex-direction: column;

--- a/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
@@ -72,10 +72,12 @@ import PoliciesCard from "../cards/Policies";
 import QueriesCard from "../cards/Queries";
 import PacksCard from "../cards/Packs";
 import PolicyDetailsModal from "../cards/Policies/HostPoliciesTable/PolicyDetailsModal";
-import UnenrollMdmModal from "./modals/UnenrollMdmModal";
+import CertificatesCard from "../cards/Certificates";
+
 import TransferHostModal from "../../components/TransferHostModal";
 import DeleteHostModal from "../../components/DeleteHostModal";
 
+import UnenrollMdmModal from "./modals/UnenrollMdmModal";
 import DiskEncryptionKeyModal from "./modals/DiskEncryptionKeyModal";
 import HostActionsDropdown from "./HostActionsDropdown/HostActionsDropdown";
 import OSSettingsModal from "../OSSettingsModal";
@@ -800,11 +802,13 @@ const HostDetailsPage = ({
     name: host?.mdm.macos_setup?.bootstrap_package_name,
   };
 
+  const isDarwinHost = host.platform === "darwin";
   const isIosOrIpadosHost =
     host.platform === "ios" || host.platform === "ipados";
 
   const detailsPanelClass = classNames(`${baseClass}__details-panel`, {
     [`${baseClass}__details-panel--ios-grid`]: isIosOrIpadosHost,
+    [`${baseClass}__details-panel--macos-grid`]: isDarwinHost,
   });
 
   return (
@@ -903,6 +907,9 @@ const HostDetailsPage = ({
                   onUsersTableSearchChange={onUsersTableSearchChange}
                   hostUsersEnabled={featuresConfig?.enable_host_users}
                 />
+              )}
+              {(isIosOrIpadosHost || isDarwinHost) && (
+                <CertificatesCard className={`${baseClass}__certs-card`} />
               )}
             </TabPanel>
             <TabPanel>

--- a/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
@@ -40,6 +40,7 @@ import {
   HOST_SUMMARY_DATA,
   HOST_ABOUT_DATA,
   HOST_OSQUERY_DATA,
+  DEFAULT_USE_QUERY_OPTIONS,
 } from "utilities/constants";
 
 import { isIPadOrIPhone } from "interfaces/platform";
@@ -446,6 +447,19 @@ const HostDetailsPage = ({
     {
       keepPreviousData: true,
       staleTime: 2000,
+    }
+  );
+
+  const {
+    data: hostCertificates,
+    isLoading: isLoadingHostCertificates,
+    isError: isErrorHostCertificates,
+  } = useQuery(
+    ["hostCertificates", host_id],
+    () => hostAPI.getHostCertificates(hostIdFromURL),
+    {
+      ...DEFAULT_USE_QUERY_OPTIONS,
+      enabled: !!hostIdFromURL,
     }
   );
 
@@ -908,7 +922,10 @@ const HostDetailsPage = ({
                   hostUsersEnabled={featuresConfig?.enable_host_users}
                 />
               )}
-              {(isIosOrIpadosHost || isDarwinHost) && <CertificatesCard />}
+              {(isIosOrIpadosHost || isDarwinHost) &&
+                hostCertificates?.certificates.length && (
+                  <CertificatesCard data={hostCertificates} />
+                )}
             </TabPanel>
             <TabPanel>
               <SoftwareCard

--- a/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
@@ -908,9 +908,7 @@ const HostDetailsPage = ({
                   hostUsersEnabled={featuresConfig?.enable_host_users}
                 />
               )}
-              {(isIosOrIpadosHost || isDarwinHost) && (
-                <CertificatesCard className={`${baseClass}__certs-card`} />
-              )}
+              {(isIosOrIpadosHost || isDarwinHost) && <CertificatesCard />}
             </TabPanel>
             <TabPanel>
               <SoftwareCard

--- a/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
@@ -32,6 +32,7 @@ import { IQueryStats } from "interfaces/query_stats";
 import { IHostSoftware } from "interfaces/software";
 import { ITeam } from "interfaces/team";
 import { IHostUpcomingActivity } from "interfaces/activity";
+import { IHostCertificate } from "interfaces/certificates";
 
 import { normalizeEmptyValues, wrapFleetHelper } from "utilities/helpers";
 import permissions from "utilities/permissions";
@@ -97,6 +98,8 @@ import SoftwareDetailsModal from "../cards/Software/SoftwareDetailsModal";
 import { parseHostSoftwareQueryParams } from "../cards/Software/HostSoftware";
 import { getErrorMessage } from "./helpers";
 import CancelActivityModal from "./modals/CancelActivityModal";
+import CertificateDetailsModal from "../modals/CertificateDetailsModal";
+import { createMockHostCertificate } from "__mocks__/certificatesMock";
 
 const baseClass = "host-details";
 
@@ -166,6 +169,7 @@ const HostDetailsPage = ({
   const [showLockHostModal, setShowLockHostModal] = useState(false);
   const [showUnlockHostModal, setShowUnlockHostModal] = useState(false);
   const [showWipeModal, setShowWipeModal] = useState(false);
+
   // Used in activities to show run script details modal
   const [scriptExecutionId, setScriptExecutiontId] = useState("");
   const [selectedPolicy, setSelectedPolicy] = useState<IHostPolicy | null>(
@@ -203,6 +207,10 @@ const HostDetailsPage = ({
     selectedCancelActivity,
     setSelectedCancelActivity,
   ] = useState<IHostUpcomingActivity | null>(null);
+  const [
+    selectedCertificate,
+    setSelectedCertificate,
+  ] = useState<IHostCertificate | null>(null);
 
   // activity states
   const [activeActivityTab, setActiveActivityTab] = useState<
@@ -721,6 +729,10 @@ const HostDetailsPage = ({
     setSelectedCancelActivity(activity);
   };
 
+  const onSelectCertificate = (certificate: IHostCertificate) => {
+    setSelectedCertificate(certificate);
+  };
+
   const renderActionDropdown = () => {
     if (!host) {
       return null;
@@ -927,6 +939,7 @@ const HostDetailsPage = ({
                   <CertificatesCard
                     data={hostCertificates}
                     hostPlatform={host.platform}
+                    onSelectCertificate={onSelectCertificate}
                   />
                 )}
             </TabPanel>
@@ -1112,6 +1125,13 @@ const HostDetailsPage = ({
             hostId={host.id}
             activity={selectedCancelActivity}
             onCancel={() => setSelectedCancelActivity(null)}
+          />
+        )}
+
+        {true && (
+          <CertificateDetailsModal
+            certificate={createMockHostCertificate()}
+            onExit={() => setSelectedCertificate(null)}
           />
         )}
       </>

--- a/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
@@ -1128,7 +1128,7 @@ const HostDetailsPage = ({
           />
         )}
 
-        {true && (
+        {selectedCertificate && (
           <CertificateDetailsModal
             certificate={createMockHostCertificate()}
             onExit={() => setSelectedCertificate(null)}

--- a/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
@@ -924,7 +924,10 @@ const HostDetailsPage = ({
               )}
               {(isIosOrIpadosHost || isDarwinHost) &&
                 hostCertificates?.certificates.length && (
-                  <CertificatesCard data={hostCertificates} />
+                  <CertificatesCard
+                    data={hostCertificates}
+                    hostPlatform={host.platform}
+                  />
                 )}
             </TabPanel>
             <TabPanel>

--- a/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
@@ -99,7 +99,6 @@ import { parseHostSoftwareQueryParams } from "../cards/Software/HostSoftware";
 import { getErrorMessage } from "./helpers";
 import CancelActivityModal from "./modals/CancelActivityModal";
 import CertificateDetailsModal from "../modals/CertificateDetailsModal";
-import { createMockHostCertificate } from "__mocks__/certificatesMock";
 
 const baseClass = "host-details";
 
@@ -1127,10 +1126,9 @@ const HostDetailsPage = ({
             onCancel={() => setSelectedCancelActivity(null)}
           />
         )}
-
         {selectedCertificate && (
           <CertificateDetailsModal
-            certificate={createMockHostCertificate()}
+            certificate={selectedCertificate}
             onExit={() => setSelectedCertificate(null)}
           />
         )}

--- a/frontend/pages/hosts/details/HostDetailsPage/_styles.scss
+++ b/frontend/pages/hosts/details/HostDetailsPage/_styles.scss
@@ -13,6 +13,7 @@
   }
 
   @media screen and (min-width: $break-md) {
+    // default grid to show for non macos, ios, or ipados hosts.
     &__details-panel.react-tabs__tab-panel--selected {
       // Must be selected to show grid
       grid-template-columns: 1fr 1fr;
@@ -21,17 +22,28 @@
         "activity agent-options"
         "activity labels"
         "users users";
-      grid-auto-flow: column;
     }
 
-    // No agent options card for i(Pad)OS, so extend Labels card vertically
+    // No agent options card for i(Pad)OS, so extend Labels card vertically.
+    // We also add the certs card to the grid layout on mac hosts
     &__details-panel--ios-grid.react-tabs__tab-panel--selected {
-      grid-template-columns: 1fr 1fr;
       grid-template-areas:
         "about about"
-        "activity labels";
-      grid-auto-flow: column;
+        "activity labels"
+        "certs certs";
     }
+
+
+    // We add the certs card to the grid layout on mac hosts
+    &__details-panel--macos-grid.react-tabs__tab-panel--selected {
+        grid-template-areas:
+          "about about"
+          "activity agent-options"
+          "activity labels"
+          "users users"
+          "certs certs";
+    }
+
 
     .about-card {
       grid-area: about;
@@ -51,6 +63,10 @@
 
     .users-card {
       grid-area: users;
+    }
+
+    &__certs-card {
+      grid-area: certs;
     }
   }
 

--- a/frontend/pages/hosts/details/HostDetailsPage/_styles.scss
+++ b/frontend/pages/hosts/details/HostDetailsPage/_styles.scss
@@ -65,7 +65,7 @@
       grid-area: users;
     }
 
-    &__certs-card {
+    .certificates-card {
       grid-area: certs;
     }
   }

--- a/frontend/pages/hosts/details/cards/About/About.tsx
+++ b/frontend/pages/hosts/details/cards/About/About.tsx
@@ -197,10 +197,10 @@ const About = ({
     <Card
       borderRadiusSize="xxlarge"
       includeShadow
-      paddingSize="large"
+      paddingSize="xxlarge"
       className={baseClass}
     >
-      <p className="card__header">About</p>
+      <h2>About</h2>
       <div className="info-flex">
         <DataSet
           title="Added to Fleet"

--- a/frontend/pages/hosts/details/cards/About/_styles.scss
+++ b/frontend/pages/hosts/details/cards/About/_styles.scss
@@ -1,4 +1,9 @@
 .about-card {
+  h2 {
+    font-size: $medium;
+    margin: 0 0 $pad-large;
+  }
+
   // Adjusts for edge cases of extra long MDM server URL and used by email
   .info-flex {
     display: flex;

--- a/frontend/pages/hosts/details/cards/Activity/_styles.scss
+++ b/frontend/pages/hosts/details/cards/Activity/_styles.scss
@@ -2,7 +2,7 @@
   position: relative;
 
   h2 {
-    font-size: 20px;
+    font-size: $medium;
     margin: 0 0 $pad-large;
   }
 

--- a/frontend/pages/hosts/details/cards/Certificates/Certificates.tsx
+++ b/frontend/pages/hosts/details/cards/Certificates/Certificates.tsx
@@ -2,6 +2,8 @@ import React from "react";
 
 import Card from "components/Card";
 
+import CertificatesTable from "./CertificatesTable";
+
 const baseClass = "certificates-card";
 
 interface ICertificatesProps {}
@@ -15,6 +17,7 @@ const CertificatesCard = ({}: ICertificatesProps) => {
       paddingSize="xxlarge"
     >
       <h2>Certificates</h2>
+      <CertificatesTable />
     </Card>
   );
 };

--- a/frontend/pages/hosts/details/cards/Certificates/Certificates.tsx
+++ b/frontend/pages/hosts/details/cards/Certificates/Certificates.tsx
@@ -1,5 +1,7 @@
 import React from "react";
 
+import { IHostCertificate } from "interfaces/certificates";
+import { HostPlatform } from "interfaces/platform";
 import { IGetHostCertificatesResponse } from "services/entities/hosts";
 
 import Card from "components/Card";
@@ -10,9 +12,15 @@ const baseClass = "certificates-card";
 
 interface ICertificatesProps {
   data: IGetHostCertificatesResponse;
+  hostPlatform: HostPlatform;
+  onSelectCertificate: (certificate: IHostCertificate) => void;
 }
 
-const CertificatesCard = ({ data }: ICertificatesProps) => {
+const CertificatesCard = ({
+  data,
+  hostPlatform,
+  onSelectCertificate,
+}: ICertificatesProps) => {
   return (
     <Card
       className={baseClass}
@@ -21,7 +29,11 @@ const CertificatesCard = ({ data }: ICertificatesProps) => {
       paddingSize="xxlarge"
     >
       <h2>Certificates</h2>
-      <CertificatesTable data={data.certificates} />
+      <CertificatesTable
+        data={data.certificates}
+        hostPlatform={hostPlatform}
+        onSelectCertificate={onSelectCertificate}
+      />
     </Card>
   );
 };

--- a/frontend/pages/hosts/details/cards/Certificates/Certificates.tsx
+++ b/frontend/pages/hosts/details/cards/Certificates/Certificates.tsx
@@ -1,0 +1,18 @@
+import React from "react";
+import classnames from "classnames";
+
+import Card from "components/Card";
+
+const baseClass = "certificates";
+
+interface ICertificatesProps {
+  className?: string;
+}
+
+const Certificates = ({ className }: ICertificatesProps) => {
+  const classNames = classnames(baseClass, className);
+
+  return <Card className={classNames}>Certs</Card>;
+};
+
+export default Certificates;

--- a/frontend/pages/hosts/details/cards/Certificates/Certificates.tsx
+++ b/frontend/pages/hosts/details/cards/Certificates/Certificates.tsx
@@ -13,12 +13,14 @@ const baseClass = "certificates-card";
 interface ICertificatesProps {
   data: IGetHostCertificatesResponse;
   hostPlatform: HostPlatform;
+  isMyDevicePage?: boolean;
   onSelectCertificate: (certificate: IHostCertificate) => void;
 }
 
 const CertificatesCard = ({
   data,
   hostPlatform,
+  isMyDevicePage = false,
   onSelectCertificate,
 }: ICertificatesProps) => {
   return (
@@ -31,7 +33,7 @@ const CertificatesCard = ({
       <h2>Certificates</h2>
       <CertificatesTable
         data={data.certificates}
-        hostPlatform={hostPlatform}
+        showHelpText={!isMyDevicePage && hostPlatform === "darwin"}
         onSelectCertificate={onSelectCertificate}
       />
     </Card>

--- a/frontend/pages/hosts/details/cards/Certificates/Certificates.tsx
+++ b/frontend/pages/hosts/details/cards/Certificates/Certificates.tsx
@@ -1,18 +1,22 @@
 import React from "react";
-import classnames from "classnames";
 
 import Card from "components/Card";
 
-const baseClass = "certificates";
+const baseClass = "certificates-card";
 
-interface ICertificatesProps {
-  className?: string;
-}
+interface ICertificatesProps {}
 
-const Certificates = ({ className }: ICertificatesProps) => {
-  const classNames = classnames(baseClass, className);
-
-  return <Card className={classNames}>Certs</Card>;
+const CertificatesCard = ({}: ICertificatesProps) => {
+  return (
+    <Card
+      className={baseClass}
+      borderRadiusSize="xxlarge"
+      includeShadow
+      paddingSize="xxlarge"
+    >
+      <h2>Certificates</h2>
+    </Card>
+  );
 };
 
-export default Certificates;
+export default CertificatesCard;

--- a/frontend/pages/hosts/details/cards/Certificates/Certificates.tsx
+++ b/frontend/pages/hosts/details/cards/Certificates/Certificates.tsx
@@ -1,12 +1,10 @@
 import React from "react";
 
-import { createMockHostCertificate } from "__mocks__/certificatesMock";
+import { IGetHostCertificatesResponse } from "services/entities/hosts";
 
 import Card from "components/Card";
 
 import CertificatesTable from "./CertificatesTable";
-import { IHostCertificate } from "interfaces/certificates";
-import { IGetHostCertificatesResponse } from "services/entities/hosts";
 
 const baseClass = "certificates-card";
 

--- a/frontend/pages/hosts/details/cards/Certificates/Certificates.tsx
+++ b/frontend/pages/hosts/details/cards/Certificates/Certificates.tsx
@@ -1,5 +1,7 @@
 import React from "react";
 
+import { createMockHostCertificate } from "__mocks__/certificatesMock";
+
 import Card from "components/Card";
 
 import CertificatesTable from "./CertificatesTable";
@@ -17,7 +19,7 @@ const CertificatesCard = ({}: ICertificatesProps) => {
       paddingSize="xxlarge"
     >
       <h2>Certificates</h2>
-      <CertificatesTable />
+      <CertificatesTable data={[createMockHostCertificate()]} />
     </Card>
   );
 };

--- a/frontend/pages/hosts/details/cards/Certificates/Certificates.tsx
+++ b/frontend/pages/hosts/details/cards/Certificates/Certificates.tsx
@@ -5,12 +5,16 @@ import { createMockHostCertificate } from "__mocks__/certificatesMock";
 import Card from "components/Card";
 
 import CertificatesTable from "./CertificatesTable";
+import { IHostCertificate } from "interfaces/certificates";
+import { IGetHostCertificatesResponse } from "services/entities/hosts";
 
 const baseClass = "certificates-card";
 
-interface ICertificatesProps {}
+interface ICertificatesProps {
+  data: IGetHostCertificatesResponse;
+}
 
-const CertificatesCard = ({}: ICertificatesProps) => {
+const CertificatesCard = ({ data }: ICertificatesProps) => {
   return (
     <Card
       className={baseClass}
@@ -19,7 +23,7 @@ const CertificatesCard = ({}: ICertificatesProps) => {
       paddingSize="xxlarge"
     >
       <h2>Certificates</h2>
-      <CertificatesTable data={[createMockHostCertificate()]} />
+      <CertificatesTable data={data.certificates} />
     </Card>
   );
 };

--- a/frontend/pages/hosts/details/cards/Certificates/CertificatesTable/CertificatesTable.tsx
+++ b/frontend/pages/hosts/details/cards/Certificates/CertificatesTable/CertificatesTable.tsx
@@ -1,7 +1,9 @@
-import React from "react";
+import React, { useCallback } from "react";
+import { Row } from "react-table";
 
 import createMockHost from "__mocks__/hostMock";
 import { createMockHostCertificate } from "__mocks__/certificatesMock";
+import { IHostCertificate } from "interfaces/certificates";
 
 import TableContainer from "components/TableContainer";
 
@@ -14,8 +16,12 @@ interface ICertificatesTableProps {}
 const CertificatesTable = ({}: ICertificatesTableProps) => {
   const tableConfig = generateTableConfig();
 
+  const onClickTableRow = (row: Row<IHostCertificate>) => {
+    console.log(row.original);
+  };
+
   return (
-    <TableContainer
+    <TableContainer<Row<IHostCertificate>>
       className={baseClass}
       columnConfigs={tableConfig}
       data={[createMockHostCertificate()]}
@@ -23,6 +29,7 @@ const CertificatesTable = ({}: ICertificatesTableProps) => {
       isAllPagesSelected={false}
       showMarkAllPages={false}
       isLoading={false}
+      onClickRow={onClickTableRow}
     />
   );
 };

--- a/frontend/pages/hosts/details/cards/Certificates/CertificatesTable/CertificatesTable.tsx
+++ b/frontend/pages/hosts/details/cards/Certificates/CertificatesTable/CertificatesTable.tsx
@@ -1,0 +1,29 @@
+import React from "react";
+
+import createMockHost from "__mocks__/hostMock";
+import { createMockHostCertificate } from "__mocks__/certificatesMock";
+
+import TableContainer from "components/TableContainer";
+
+import generateTableConfig from "./CertificatesTableConfig";
+
+const baseClass = "certificates-table";
+
+interface ICertificatesTableProps {}
+
+const CertificatesTable = ({}: ICertificatesTableProps) => {
+  const tableConfig = generateTableConfig();
+
+  return (
+    <TableContainer
+      className={baseClass}
+      columnConfigs={tableConfig}
+      data={[createMockHostCertificate()]}
+      emptyComponent={() => <>empty</>}
+      isAllPagesSelected={false}
+      showMarkAllPages={false}
+      isLoading={false}
+    />
+  );
+};
+export default CertificatesTable;

--- a/frontend/pages/hosts/details/cards/Certificates/CertificatesTable/CertificatesTable.tsx
+++ b/frontend/pages/hosts/details/cards/Certificates/CertificatesTable/CertificatesTable.tsx
@@ -1,8 +1,6 @@
-import React, { useCallback } from "react";
+import React from "react";
 import { Row } from "react-table";
 
-import createMockHost from "__mocks__/hostMock";
-import { createMockHostCertificate } from "__mocks__/certificatesMock";
 import { IHostCertificate } from "interfaces/certificates";
 
 import TableContainer from "components/TableContainer";
@@ -11,9 +9,11 @@ import generateTableConfig from "./CertificatesTableConfig";
 
 const baseClass = "certificates-table";
 
-interface ICertificatesTableProps {}
+interface ICertificatesTableProps {
+  data: IHostCertificate[];
+}
 
-const CertificatesTable = ({}: ICertificatesTableProps) => {
+const CertificatesTable = ({ data }: ICertificatesTableProps) => {
   const tableConfig = generateTableConfig();
 
   const onClickTableRow = (row: Row<IHostCertificate>) => {
@@ -24,8 +24,8 @@ const CertificatesTable = ({}: ICertificatesTableProps) => {
     <TableContainer<Row<IHostCertificate>>
       className={baseClass}
       columnConfigs={tableConfig}
-      data={[createMockHostCertificate()]}
-      emptyComponent={() => <>empty</>}
+      data={data}
+      emptyComponent={() => null}
       isAllPagesSelected={false}
       showMarkAllPages={false}
       isLoading={false}

--- a/frontend/pages/hosts/details/cards/Certificates/CertificatesTable/CertificatesTable.tsx
+++ b/frontend/pages/hosts/details/cards/Certificates/CertificatesTable/CertificatesTable.tsx
@@ -2,7 +2,6 @@ import React from "react";
 import { Row } from "react-table";
 
 import { IHostCertificate } from "interfaces/certificates";
-import { HostPlatform } from "interfaces/platform";
 
 import TableContainer from "components/TableContainer";
 import CustomLink from "components/CustomLink";
@@ -13,13 +12,13 @@ const baseClass = "certificates-table";
 
 interface ICertificatesTableProps {
   data: IHostCertificate[];
-  hostPlatform: HostPlatform;
+  showHelpText: boolean;
   onSelectCertificate: (certificate: IHostCertificate) => void;
 }
 
 const CertificatesTable = ({
   data,
-  hostPlatform,
+  showHelpText,
   onSelectCertificate,
 }: ICertificatesTableProps) => {
   const tableConfig = generateTableConfig();
@@ -28,18 +27,17 @@ const CertificatesTable = ({
     onSelectCertificate(row.original);
   };
 
-  const helpText =
-    hostPlatform === "darwin" ? (
-      <p>
-        Showing certificates in the system keychain. To get all certificates,
-        you can query the certificates table.{" "}
-        <CustomLink
-          text="Learn more"
-          url="https://fleetdm.com/learn-more-about/certificates-query"
-          newTab
-        />
-      </p>
-    ) : null;
+  const helpText = showHelpText ? (
+    <p>
+      Showing certificates in the system keychain. To get all certificates, you
+      can query the certificates table.{" "}
+      <CustomLink
+        text="Learn more"
+        url="https://fleetdm.com/learn-more-about/certificates-query"
+        newTab
+      />
+    </p>
+  ) : null;
 
   return (
     <TableContainer<Row<IHostCertificate>>

--- a/frontend/pages/hosts/details/cards/Certificates/CertificatesTable/CertificatesTable.tsx
+++ b/frontend/pages/hosts/details/cards/Certificates/CertificatesTable/CertificatesTable.tsx
@@ -14,13 +14,18 @@ const baseClass = "certificates-table";
 interface ICertificatesTableProps {
   data: IHostCertificate[];
   hostPlatform: HostPlatform;
+  onSelectCertificate: (certificate: IHostCertificate) => void;
 }
 
-const CertificatesTable = ({ data, hostPlatform }: ICertificatesTableProps) => {
+const CertificatesTable = ({
+  data,
+  hostPlatform,
+  onSelectCertificate,
+}: ICertificatesTableProps) => {
   const tableConfig = generateTableConfig();
 
   const onClickTableRow = (row: Row<IHostCertificate>) => {
-    console.log(row.original);
+    onSelectCertificate(row.original);
   };
 
   const helpText =

--- a/frontend/pages/hosts/details/cards/Certificates/CertificatesTable/CertificatesTable.tsx
+++ b/frontend/pages/hosts/details/cards/Certificates/CertificatesTable/CertificatesTable.tsx
@@ -2,8 +2,10 @@ import React from "react";
 import { Row } from "react-table";
 
 import { IHostCertificate } from "interfaces/certificates";
+import { HostPlatform } from "interfaces/platform";
 
 import TableContainer from "components/TableContainer";
+import CustomLink from "components/CustomLink";
 
 import generateTableConfig from "./CertificatesTableConfig";
 
@@ -11,14 +13,28 @@ const baseClass = "certificates-table";
 
 interface ICertificatesTableProps {
   data: IHostCertificate[];
+  hostPlatform: HostPlatform;
 }
 
-const CertificatesTable = ({ data }: ICertificatesTableProps) => {
+const CertificatesTable = ({ data, hostPlatform }: ICertificatesTableProps) => {
   const tableConfig = generateTableConfig();
 
   const onClickTableRow = (row: Row<IHostCertificate>) => {
     console.log(row.original);
   };
+
+  const helpText =
+    hostPlatform === "darwin" ? (
+      <p>
+        Showing certificates in the system keychain. To get all certificates,
+        you can query the certificates table.{" "}
+        <CustomLink
+          text="Learn more"
+          url="https://fleetdm.com/learn-more-about/certificates-query"
+          newTab
+        />
+      </p>
+    ) : null;
 
   return (
     <TableContainer<Row<IHostCertificate>>
@@ -30,6 +46,7 @@ const CertificatesTable = ({ data }: ICertificatesTableProps) => {
       showMarkAllPages={false}
       isLoading={false}
       onClickRow={onClickTableRow}
+      renderTableHelpText={() => helpText}
     />
   );
 };

--- a/frontend/pages/hosts/details/cards/Certificates/CertificatesTable/CertificatesTableConfig.tsx
+++ b/frontend/pages/hosts/details/cards/Certificates/CertificatesTable/CertificatesTableConfig.tsx
@@ -1,0 +1,54 @@
+import React from "react";
+import { CellProps, Column } from "react-table";
+
+import { IHostCertificate } from "interfaces/certificates";
+
+import HeaderCell from "components/TableContainer/DataTable/HeaderCell/HeaderCell";
+import TextCell from "components/TableContainer/DataTable/TextCell";
+import ViewAllHostsLink from "components/ViewAllHostsLink";
+import StatusIndicator from "components/StatusIndicator";
+import { monthDayYearFormat } from "utilities/date_format";
+
+type IHostCertificatesTableConfig = Column<IHostCertificate>;
+
+const generateTableConfig = (): IHostCertificatesTableConfig[] => {
+  return [
+    {
+      accessor: "common_name",
+      Header: (cellProps) => (
+        <HeaderCell value="Name" isSortedDesc={cellProps.column.isSortedDesc} />
+      ),
+      Cell: (cellProps) => <TextCell value={cellProps.cell.value} />,
+    },
+    {
+      accessor: "not_valid_after",
+      Header: (cellProps) => (
+        <HeaderCell
+          value="Expires"
+          isSortedDesc={cellProps.column.isSortedDesc}
+        />
+      ),
+      Cell: (cellProps) => {
+        return <StatusIndicator value={monthDayYearFormat(cellProps.value)} />;
+      },
+    },
+    {
+      Header: "",
+      id: "view-all-hosts",
+      disableSortBy: true,
+      Cell: (cellProps) => {
+        return (
+          <ViewAllHostsLink
+            className="view-cert-details"
+            noLink
+            rowHover
+            excludeChevron
+            customText="View details"
+          />
+        );
+      },
+    },
+  ];
+};
+
+export default generateTableConfig;

--- a/frontend/pages/hosts/details/cards/Certificates/CertificatesTable/CertificatesTableConfig.tsx
+++ b/frontend/pages/hosts/details/cards/Certificates/CertificatesTable/CertificatesTableConfig.tsx
@@ -1,13 +1,15 @@
 import React from "react";
-import { CellProps, Column } from "react-table";
+import { Column } from "react-table";
 
 import { IHostCertificate } from "interfaces/certificates";
+import { monthDayYearFormat } from "utilities/date_format";
+import { hasExpired, willExpireWithinXDays } from "utilities/helpers";
 
 import HeaderCell from "components/TableContainer/DataTable/HeaderCell/HeaderCell";
 import TextCell from "components/TableContainer/DataTable/TextCell";
 import ViewAllHostsLink from "components/ViewAllHostsLink";
 import StatusIndicator from "components/StatusIndicator";
-import { monthDayYearFormat } from "utilities/date_format";
+import { IIndicatorValue } from "components/StatusIndicator/StatusIndicator";
 
 type IHostCertificatesTableConfig = Column<IHostCertificate>;
 
@@ -29,14 +31,25 @@ const generateTableConfig = (): IHostCertificatesTableConfig[] => {
         />
       ),
       Cell: (cellProps) => {
-        return <StatusIndicator value={monthDayYearFormat(cellProps.value)} />;
+        let status: IIndicatorValue = "success";
+        if (hasExpired(cellProps.value)) {
+          status = "error";
+        } else if (willExpireWithinXDays(cellProps.value, 30)) {
+          status = "warning";
+        }
+        return (
+          <StatusIndicator
+            value={monthDayYearFormat(cellProps.value)}
+            indicator={status}
+          />
+        );
       },
     },
     {
       Header: "",
       id: "view-all-hosts",
       disableSortBy: true,
-      Cell: (cellProps) => {
+      Cell: () => {
         return (
           <ViewAllHostsLink
             className="view-cert-details"

--- a/frontend/pages/hosts/details/cards/Certificates/CertificatesTable/_styles.scss
+++ b/frontend/pages/hosts/details/cards/Certificates/CertificatesTable/_styles.scss
@@ -1,0 +1,3 @@
+.certificates-table {
+
+}

--- a/frontend/pages/hosts/details/cards/Certificates/CertificatesTable/index.ts
+++ b/frontend/pages/hosts/details/cards/Certificates/CertificatesTable/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./CertificatesTable";

--- a/frontend/pages/hosts/details/cards/Certificates/_styles.scss
+++ b/frontend/pages/hosts/details/cards/Certificates/_styles.scss
@@ -1,0 +1,3 @@
+.certificates {
+
+}

--- a/frontend/pages/hosts/details/cards/Certificates/_styles.scss
+++ b/frontend/pages/hosts/details/cards/Certificates/_styles.scss
@@ -1,3 +1,7 @@
-.certificates {
+.certificates-card {
+  h2 {
+    font-size: $medium;
+    margin: 0 0 $pad-large;
+  }
 
 }

--- a/frontend/pages/hosts/details/cards/Certificates/index.ts
+++ b/frontend/pages/hosts/details/cards/Certificates/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./Certificates";

--- a/frontend/pages/hosts/details/cards/Labels/Labels.tsx
+++ b/frontend/pages/hosts/details/cards/Labels/Labels.tsx
@@ -37,10 +37,10 @@ const Labels = ({ onLabelClick, labels }: ILabelsProps): JSX.Element => {
     <Card
       borderRadiusSize="xxlarge"
       includeShadow
-      largePadding
+      paddingSize="xxlarge"
       className={classNames}
     >
-      <p className="card__header">Labels</p>
+      <h2>Labels</h2>
       {labels.length === 0 ? (
         <p className="info-flex__item">
           No labels are associated with this host.

--- a/frontend/pages/hosts/details/cards/Labels/__styles.scss
+++ b/frontend/pages/hosts/details/cards/Labels/__styles.scss
@@ -1,0 +1,7 @@
+.labels-card {
+
+  h2 {
+    font-size: $medium;
+    margin: 0 0 $pad-large;
+  }
+}

--- a/frontend/pages/hosts/details/cards/Users/Users.tsx
+++ b/frontend/pages/hosts/details/cards/Users/Users.tsx
@@ -63,11 +63,11 @@ const Users = ({
     <Card
       borderRadiusSize="xxlarge"
       includeShadow
-      largePadding
+      paddingSize="xxlarge"
       className={baseClass}
     >
       <>
-        <p className="card__header">Users</p>
+        <h2 className="card__header">Users</h2>
         {users?.length ? (
           <TableContainer
             columnConfigs={tableHeaders}

--- a/frontend/pages/hosts/details/cards/Users/_styles.scss
+++ b/frontend/pages/hosts/details/cards/Users/_styles.scss
@@ -1,4 +1,9 @@
 .users-card {
+  h2 {
+    font-size: $medium;
+    margin: 0 0 $pad-large;
+  }
+
   .data-table-block {
     .data-table__table {
       thead {

--- a/frontend/pages/hosts/details/modals/CertificateDetailsModal/CertificateDetailsModal.tsx
+++ b/frontend/pages/hosts/details/modals/CertificateDetailsModal/CertificateDetailsModal.tsx
@@ -27,18 +27,22 @@ const CertificateDetailsModal = ({
               <DataSet
                 title="Country or region"
                 value={certificate.subject.country}
+                orientation="horizontal"
               />
               <DataSet
                 title="Organization"
                 value={certificate.subject.organization}
+                orientation="horizontal"
               />
               <DataSet
                 title="Organizational unit"
                 value={certificate.subject.organizational_unit}
+                orientation="horizontal"
               />
               <DataSet
                 title="Common name"
                 value={certificate.subject.common_name}
+                orientation="horizontal"
               />
             </dl>
           </div>
@@ -48,18 +52,22 @@ const CertificateDetailsModal = ({
               <DataSet
                 title="Country or region"
                 value={certificate.issuer.country}
+                orientation="horizontal"
               />
               <DataSet
                 title="Organization"
                 value={certificate.issuer.organization}
+                orientation="horizontal"
               />
               <DataSet
                 title="Organizational unit"
                 value={certificate.issuer.organizational_unit}
+                orientation="horizontal"
               />
               <DataSet
                 title="Common name"
                 value={certificate.issuer.common_name}
+                orientation="horizontal"
               />
             </dl>
           </div>
@@ -69,28 +77,48 @@ const CertificateDetailsModal = ({
               <DataSet
                 title="Not valid before"
                 value={certificate.not_valid_before}
+                orientation="horizontal"
               />
               <DataSet
                 title="Not valid after"
                 value={certificate.not_valid_after}
+                orientation="horizontal"
               />
             </dl>
           </div>
           <div className={`${baseClass}__section`}>
             <h3>Key info</h3>
             <dl>
-              <DataSet title="Algorithm" value={certificate.key_algorithm} />
-              <DataSet title="Key size" value={certificate.key_strength} />
-              <DataSet title="Key usage" value={certificate.key_usage} />
-              <DataSet title="Serial number" value={certificate.serial} />
+              <DataSet
+                title="Algorithm"
+                value={certificate.key_algorithm}
+                orientation="horizontal"
+              />
+              <DataSet
+                title="Key size"
+                value={certificate.key_strength}
+                orientation="horizontal"
+              />
+              <DataSet
+                title="Key usage"
+                value={certificate.key_usage}
+                orientation="horizontal"
+              />
+              <DataSet
+                title="Serial number"
+                value={certificate.serial}
+                orientation="horizontal"
+              />
             </dl>
           </div>
+
           <div className={`${baseClass}__section`}>
             <h3>Basic constraints</h3>
             <dl>
               <DataSet
                 title="Certificate authority"
                 value={certificate.certificate_authority ? "Yes" : "No"}
+                orientation="horizontal"
               />
             </dl>
           </div>
@@ -100,6 +128,7 @@ const CertificateDetailsModal = ({
               <DataSet
                 title="Algorithm"
                 value={certificate.signing_algorithm}
+                orientation="horizontal"
               />
             </dl>
           </div>

--- a/frontend/pages/hosts/details/modals/CertificateDetailsModal/CertificateDetailsModal.tsx
+++ b/frontend/pages/hosts/details/modals/CertificateDetailsModal/CertificateDetailsModal.tsx
@@ -1,0 +1,115 @@
+import React from "react";
+
+import { IHostCertificate } from "interfaces/certificates";
+
+import Modal from "components/Modal";
+import DataSet from "components/DataSet";
+import Button from "components/buttons/Button";
+
+const baseClass = "certificate-details-modal";
+
+interface ICertificateDetailsModalProps {
+  certificate: IHostCertificate;
+  onExit: () => void;
+}
+
+const CertificateDetailsModal = ({
+  certificate,
+  onExit,
+}: ICertificateDetailsModalProps) => {
+  return (
+    <Modal className={baseClass} title="Certificate details" onExit={onExit}>
+      <>
+        <div className={`${baseClass}__content`}>
+          <div className={`${baseClass}__section`}>
+            <h3>Subject Name</h3>
+            <dl>
+              <DataSet
+                title="Country or region"
+                value={certificate.subject.country}
+              />
+              <DataSet
+                title="Organization"
+                value={certificate.subject.organization}
+              />
+              <DataSet
+                title="Organizational unit"
+                value={certificate.subject.organizational_unit}
+              />
+              <DataSet
+                title="Common name"
+                value={certificate.subject.common_name}
+              />
+            </dl>
+          </div>
+          <div className={`${baseClass}__section`}>
+            <h3>Issuer name</h3>
+            <dl>
+              <DataSet
+                title="Country or region"
+                value={certificate.issuer.country}
+              />
+              <DataSet
+                title="Organization"
+                value={certificate.issuer.organization}
+              />
+              <DataSet
+                title="Organizational unit"
+                value={certificate.issuer.organizational_unit}
+              />
+              <DataSet
+                title="Common name"
+                value={certificate.issuer.common_name}
+              />
+            </dl>
+          </div>
+          <div className={`${baseClass}__section`}>
+            <h3>Validity period</h3>
+            <dl>
+              <DataSet
+                title="Not valid before"
+                value={certificate.not_valid_before}
+              />
+              <DataSet
+                title="Not valid after"
+                value={certificate.not_valid_after}
+              />
+            </dl>
+          </div>
+          <div className={`${baseClass}__section`}>
+            <h3>Key info</h3>
+            <dl>
+              <DataSet title="Algorithm" value={certificate.key_algorithm} />
+              <DataSet title="Key size" value={certificate.key_strength} />
+              <DataSet title="Key usage" value={certificate.key_usage} />
+              <DataSet title="Serial number" value={certificate.serial} />
+            </dl>
+          </div>
+          <div className={`${baseClass}__section`}>
+            <h3>Basic constraints</h3>
+            <dl>
+              <DataSet
+                title="Certificate authority"
+                value={certificate.certificate_authority ? "Yes" : "No"}
+              />
+            </dl>
+          </div>
+          <div className={`${baseClass}__section`}>
+            <h3>Signature</h3>
+            <dl>
+              <DataSet
+                title="Algorithm"
+                value={certificate.signing_algorithm}
+              />
+            </dl>
+          </div>
+        </div>
+        <div className="modal-cta-wrap">
+          <Button onClick={onExit}>Done</Button>
+        </div>
+      </>
+    </Modal>
+  );
+};
+
+export default CertificateDetailsModal;

--- a/frontend/pages/hosts/details/modals/CertificateDetailsModal/CertificateDetailsModal.tsx
+++ b/frontend/pages/hosts/details/modals/CertificateDetailsModal/CertificateDetailsModal.tsx
@@ -5,6 +5,7 @@ import { IHostCertificate } from "interfaces/certificates";
 import Modal from "components/Modal";
 import DataSet from "components/DataSet";
 import Button from "components/buttons/Button";
+import { monthDayYearFormat } from "utilities/date_format";
 
 const baseClass = "certificate-details-modal";
 
@@ -76,12 +77,12 @@ const CertificateDetailsModal = ({
             <dl>
               <DataSet
                 title="Not valid before"
-                value={certificate.not_valid_before}
+                value={monthDayYearFormat(certificate.not_valid_before)}
                 orientation="horizontal"
               />
               <DataSet
                 title="Not valid after"
-                value={certificate.not_valid_after}
+                value={monthDayYearFormat(certificate.not_valid_after)}
                 orientation="horizontal"
               />
             </dl>

--- a/frontend/pages/hosts/details/modals/CertificateDetailsModal/_styles.scss
+++ b/frontend/pages/hosts/details/modals/CertificateDetailsModal/_styles.scss
@@ -22,5 +22,11 @@
       padding-top: 0;
       border-top: none;
     }
+
+    dl {
+      display: flex;
+      flex-direction: column;
+      gap: $pad-xsmall;
+    }
   }
 }

--- a/frontend/pages/hosts/details/modals/CertificateDetailsModal/_styles.scss
+++ b/frontend/pages/hosts/details/modals/CertificateDetailsModal/_styles.scss
@@ -1,0 +1,26 @@
+.certificate-details-modal {
+
+  &__content {
+    display: flex;
+    flex-direction: column;
+    gap: $pad-xlarge;
+  }
+
+  h3 {
+    margin: 0;
+    font-size: $small;
+  }
+
+  &__section {
+    display: flex;
+    gap: $pad-small;
+    flex-direction: column;
+    padding-top: $pad-xlarge;
+    border-top: 1px solid $ui-fleet-black-10;
+
+    &:first-child {
+      padding-top: 0;
+      border-top: none;
+    }
+  }
+}

--- a/frontend/pages/hosts/details/modals/CertificateDetailsModal/index.ts
+++ b/frontend/pages/hosts/details/modals/CertificateDetailsModal/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./CertificateDetailsModal";

--- a/frontend/services/entities/device_user.ts
+++ b/frontend/services/entities/device_user.ts
@@ -1,8 +1,11 @@
 import { IDeviceUserResponse } from "interfaces/host";
 import { IDeviceSoftware } from "interfaces/software";
+import { IHostCertificate } from "interfaces/certificates";
 import sendRequest from "services";
 import endpoints from "utilities/endpoints";
 import { buildQueryStringFromParams } from "utilities/url";
+import { createMockGetHostCertificatesResponse } from "__mocks__/certificatesMock";
+
 import { IHostSoftwareQueryParams } from "./hosts";
 
 export type ILoadHostDetailsExtension = "device_mapping" | "macadmins";
@@ -25,6 +28,14 @@ export interface IGetDeviceSoftwareResponse {
 interface IGetDeviceDetailsRequest {
   token: string;
   exclude_software?: boolean;
+}
+
+export interface IGetDeviceCertificatesResponse {
+  certificates: IHostCertificate[];
+  meta: {
+    has_next_results: boolean;
+    has_previous_results: boolean;
+  };
 }
 
 export default {
@@ -73,5 +84,17 @@ export default {
     const path = DEVICE_SOFTWARE_INSTALL(deviceToken, softwareTitleId);
 
     return sendRequest("POST", path);
+  },
+
+  getDeviceCertificates: (
+    deviceToken: string
+  ): Promise<IGetDeviceCertificatesResponse> => {
+    const { DEVICE_CERTIFICATES } = endpoints;
+    const path = DEVICE_CERTIFICATES(deviceToken);
+
+    // return sendRequest("GET", path);
+    return new Promise((resolve) => {
+      resolve(createMockGetHostCertificatesResponse());
+    });
   },
 };

--- a/frontend/services/entities/hosts.ts
+++ b/frontend/services/entities/hosts.ts
@@ -24,7 +24,10 @@ import {
 import { IMunkiIssuesAggregate } from "interfaces/macadmins";
 import { PlatformValueOptions, PolicyResponse } from "utilities/constants";
 import { IHostCertificate } from "interfaces/certificates";
-import { createMockGetHostCertificatesResponse } from "__mocks__/certificatesMock";
+import {
+  createMockGetHostCertificatesResponse,
+  createMockHostCertificate,
+} from "__mocks__/certificatesMock";
 
 export interface ISortOption {
   key: string;
@@ -605,7 +608,15 @@ export default {
 
     // return sendRequest("GET", HOST_CERTIFICATES(hostId));
     return new Promise((resolve) => {
-      resolve(createMockGetHostCertificatesResponse());
+      resolve(
+        createMockGetHostCertificatesResponse({
+          certificates: [
+            createMockHostCertificate({
+              common_name: "Test 2",
+            }),
+          ],
+        })
+      );
     });
   },
 };

--- a/frontend/services/entities/hosts.ts
+++ b/frontend/services/entities/hosts.ts
@@ -23,6 +23,8 @@ import {
 } from "interfaces/mdm";
 import { IMunkiIssuesAggregate } from "interfaces/macadmins";
 import { PlatformValueOptions, PolicyResponse } from "utilities/constants";
+import { IHostCertificate } from "interfaces/certificates";
+import { createMockGetHostCertificatesResponse } from "__mocks__/certificatesMock";
 
 export interface ISortOption {
   key: string;
@@ -169,6 +171,14 @@ export interface IHostSoftwareQueryKey extends IHostSoftwareQueryParams {
   scope: "host_software";
   id: number;
   softwareUpdatedAt?: string;
+}
+
+export interface IGetHostCertificatesResponse {
+  certificates: IHostCertificate[];
+  meta: {
+    has_next_results: boolean;
+    has_previous_results: boolean;
+  };
 }
 
 export type ILoadHostDetailsExtension = "device_mapping" | "macadmins";
@@ -579,11 +589,23 @@ export default {
       HOST_SOFTWARE_PACKAGE_INSTALL(hostId, softwareId)
     );
   },
+
   uninstallHostSoftwarePackage: (hostId: number, softwareId: number) => {
     const { HOST_SOFTWARE_PACKAGE_UNINSTALL } = endpoints;
     return sendRequest(
       "POST",
       HOST_SOFTWARE_PACKAGE_UNINSTALL(hostId, softwareId)
     );
+  },
+
+  getHostCertificates: (
+    hostId: number
+  ): Promise<IGetHostCertificatesResponse> => {
+    const { HOST_CERTIFICATES } = endpoints;
+
+    // return sendRequest("GET", HOST_CERTIFICATES(hostId));
+    return new Promise((resolve) => {
+      resolve(createMockGetHostCertificatesResponse());
+    });
   },
 };

--- a/frontend/services/entities/hosts.ts
+++ b/frontend/services/entities/hosts.ts
@@ -613,6 +613,7 @@ export default {
           certificates: [
             createMockHostCertificate({
               common_name: "Test 2",
+              not_valid_after: "2025-05-01T00:00:00.000Z",
             }),
           ],
         })

--- a/frontend/utilities/endpoints.ts
+++ b/frontend/utilities/endpoints.ts
@@ -40,6 +40,9 @@ export default {
   DEVICE_TRIGGER_LINUX_DISK_ENCRYPTION_KEY_ESCROW: (token: string): string => {
     return `/${API_VERSION}/fleet/device/${token}/mdm/linux/trigger_escrow`;
   },
+  DEVICE_CERTIFICATES: (token: string): string => {
+    return `/${API_VERSION}/fleet/device/${token}/certificates`;
+  },
 
   // Host endpoints
   HOST_SUMMARY: `/${API_VERSION}/fleet/host_summary`,

--- a/frontend/utilities/endpoints.ts
+++ b/frontend/utilities/endpoints.ts
@@ -61,6 +61,8 @@ export default {
     `/${API_VERSION}/fleet/hosts/${hostId}/software/${softwareId}/install`,
   HOST_SOFTWARE_PACKAGE_UNINSTALL: (hostId: number, softwareId: number) =>
     `/${API_VERSION}/fleet/hosts/${hostId}/software/${softwareId}/uninstall`,
+  HOST_CERTIFICATES: (id: number) =>
+    `/${API_VERSION}/fleet/hosts/${id}/certificates`,
 
   INVITES: `/${API_VERSION}/fleet/invites`,
   INVITE_VERIFY: (token: string) => `/${API_VERSION}/fleet/invites/${token}`,

--- a/frontend/utilities/helpers.tsx
+++ b/frontend/utilities/helpers.tsx
@@ -639,6 +639,13 @@ export const hasLicenseExpired = (expiration: string): boolean => {
   return isAfter(new Date(), new Date(expiration));
 };
 
+// just a rename of hasLicenseExpired so that it can be used in other contexts.
+// TODO: change hasLicenseExpired instances to hasExpired
+/**
+ * determines if a date has expired. This will check against the current date and time.
+ */
+export const hasExpired = hasLicenseExpired;
+
 /**
  * determines if a date will expire within "x" number of days. If the date has
  * has already expired, this function will return false.


### PR DESCRIPTION
For #25464

Implements the UI for viewing certification details on the host details and my device pages.

This includes:

**Certs card and table on host details and my device page**

![image](https://github.com/user-attachments/assets/e685e55f-d982-43a7-91ff-e6d033b758f5)

**Cert details modal**

![image](https://github.com/user-attachments/assets/4a1d7421-85b8-4b3e-a010-ea752e7c6bdf)

- includes some work around normalising the details section card header styles on these pages.
- includes extending DataSet component to add a `horizontal` orientation when rendering the data


> NOTE: We still need to integrate with the API endpoints when they are ready.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
- [ ] Added/updated automated tests
- [x] Manual QA for all new/changed functionality
