### PR TITLE
[API design] Fleet-maintained apps for Windows

### DIFF
--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -9511,8 +9511,7 @@ List available Fleet-maintained apps.
       "id": 1,
       "name": "1Password",
       "version": "8.10.40",
-      "platform": "darwin",
-      "software_added": false
+      "platform": "darwin"
     },
     {
       "id": 2,

--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -9523,8 +9523,7 @@ List available Fleet-maintained apps.
       "id": 3,
       "name": "Box Drive",
       "version": "2.39.179",
-      "platform": "darwin",
-      "software_title_id": 1
+      "platform": "darwin"
     },
     ...
   ],

--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -9569,6 +9569,7 @@ Returns information about the specified Fleet-maintained app.
     "platform": "darwin",
     "install_script": "#!/bin/sh\ninstaller -pkg \"$INSTALLER_PATH\" -target /",
     "uninstall_script": "#!/bin/sh\npkg_ids=$PACKAGE_ID\nfor pkg_id in '${pkg_ids[@]}'...",
+    "software_added": false
   }
 }
 ```

--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -9518,15 +9518,14 @@ List available Fleet-maintained apps.
       "id": 2,
       "name": "1Password",
       "version": "8.10.40",
-      "platform": "windows",
-      "software_added": false
+      "platform": "windows"
     },
     {
       "id": 3,
       "name": "Box Drive",
       "version": "2.39.179",
       "platform": "darwin",
-      "software_added": true
+      "software_title_id": 1
     },
     ...
   ],
@@ -9569,7 +9568,7 @@ Returns information about the specified Fleet-maintained app.
     "platform": "darwin",
     "install_script": "#!/bin/sh\ninstaller -pkg \"$INSTALLER_PATH\" -target /",
     "uninstall_script": "#!/bin/sh\npkg_ids=$PACKAGE_ID\nfor pkg_id in '${pkg_ids[@]}'...",
-    "software_added": false
+    "software_title_id": 3
   }
 }
 ```

--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -9511,20 +9511,24 @@ List available Fleet-maintained apps.
       "id": 1,
       "name": "1Password",
       "version": "8.10.40",
-      "platform": "darwin"
+      "platform": "darwin",
+      "software_added": false
     },
     {
       "id": 2,
-      "name": "Adobe Acrobat Reader",
-      "version": "24.002.21005",
-      "platform": "darwin"
+      "name": "1Password",
+      "version": "8.10.40",
+      "platform": "windows",
+      "software_added": false
     },
     {
       "id": 3,
       "name": "Box Drive",
       "version": "2.39.179",
-      "platform": "darwin"
+      "platform": "darwin",
+      "software_added": true
     },
+    ...
   ],
   "meta": {
     "has_next_results": false,


### PR DESCRIPTION
API changes for the following user story:

- #23118

Notes:
- `software_added` will inform the UI that we want to disabled the "+ Add" button (Figma [here](https://www.figma.com/design/L2KLDw5WzIHRCvHT0T6RWd/%2323118-Fleet-maintained-apps-for-Windows?node-id=5445-6904&t=wNA3W4UXvdRpfgTk-1)):

![Screenshot 2025-02-17 at 1 15 57 PM](https://github.com/user-attachments/assets/4b55ce7d-9db9-4022-a815-33e19d27694b)

![Screenshot 2025-02-17 at 1 14 23 PM](https://github.com/user-attachments/assets/56f74123-c45e-4923-986d-fe36f7fe28fe)
