### PR TITLE
Change date release candidate is cut

### DIFF
--- a/handbook/engineering/README.md
+++ b/handbook/engineering/README.md
@@ -116,7 +116,7 @@ To provide full-time focus to the role, the on-call engineer is not expected to 
 
 ### Create a release candidate
 
-All minor releases go through the release candidate process before they are published. A release candidate for the next minor release is created on the Tuesday before the release at 11:00 AM Pacific. A release candidate branch is created at `minor-fleet-v4.x.x` and no additional feature work is merged without EM and QA approval.
+All minor releases go through the release candidate process before they are published. A release candidate for the next minor release is created on the first Monday of each sprint at 9:00 AM Pacific. A release candidate branch is created at `minor-fleet-v4.x.x` and no additional feature work is merged without EM and QA approval.
 
 [Run the first step](https://github.com/fleetdm/fleet/tree/main/tools/release#minor-release-typically-end-of-sprint) of the minor release section of the Fleet releases script to create the release candidate branch, the release QA issue, and announce the release candidate in Slack.
 

--- a/handbook/engineering/README.md
+++ b/handbook/engineering/README.md
@@ -116,7 +116,7 @@ To provide full-time focus to the role, the on-call engineer is not expected to 
 
 ### Create a release candidate
 
-All minor releases go through the release candidate process before they are published. A release candidate for the next minor release is created on the first Monday of each sprint at 9:00 AM Pacific. A release candidate branch is created at `minor-fleet-v4.x.x` and no additional feature work is merged without EM and QA approval.
+All minor releases go through the release candidate process before they are published. A release candidate for the next minor release is created on the last Friday of each sprint at 8:00 AM Pacific. A release candidate branch is created at `minor-fleet-v4.x.x` and no additional feature work or released bug fixes are merged without EM and QA approval.
 
 [Run the first step](https://github.com/fleetdm/fleet/tree/main/tools/release#minor-release-typically-end-of-sprint) of the minor release section of the Fleet releases script to create the release candidate branch, the release QA issue, and announce the release candidate in Slack.
 


### PR DESCRIPTION
I want to try cutting the release candidate on the first day of each sprint. 

Since moving to the release train model, it's created a situation where the last week of every sprint is work going towards the next release, not the current release. 

This change will have the following benefits: 

1. The business will be able to more accurately forecast what will be delivered each sprint. 
2. The work produced during the sprint will ship sooner and provide value to our customers sooner. 
3. From the first day to the last day of each sprint, work can be merged into `main`, and all of that work will ship with the next release. 

The cost I see are: 

1. QA won't be fully smoke testing the release until the next sprint kicks off, which means engineers will get called back for unreleased bugs. 

But, this is happening already, because the last week of the sprint the engineers are shifting to next release.