### PR TITLE
Correct vuln processing false positive cleanup timeout

### DIFF
--- a/articles/vulnerability-processing.md
+++ b/articles/vulnerability-processing.md
@@ -25,7 +25,7 @@ Currently, only software names with all ASCII characters are supported. Vulnerab
 
 For Ubuntu Linux, kernel vulnerabilities with known variants (ie. `-generic`) are detected using OVAL. Custom kernels (unknown variants) are detected using NVD.
 
-If you find that Fleet is incorrectly marking software as vulnerable (false positive) or missing a vulnerability (false negative), please file a [bug](https://github.com/fleetdm/fleet/issues/new?template=bug-report.md). When false positives are fixed, it may take an hour for the false positive to dissapear after upgrading Fleet. 
+If you find that Fleet is incorrectly marking software as vulnerable (false positive) or missing a vulnerability (false negative), please file a [bug](https://github.com/fleetdm/fleet/issues/new?template=bug-report.md). When false positives are fixed, it may take two hous for the false positive to disappear after upgrading Fleet. 
 
 ## Sources
 


### PR DESCRIPTION
The timeout is hardcoded to 2x vulns job periodicity (default one hour). See http://github.com/fleetdm/fleet/blob/main/docs/Contributing/Vulnerability-processing.md#false-positive-cleanup for contributor docs on this.