### PR TITLE
Revert "Fleet-maintained apps: scripts are updated for you (#26352)"

### DIFF
--- a/articles/install-fleet-maintained-apps-on-macos-hosts.md
+++ b/articles/install-fleet-maintained-apps-on-macos-hosts.md
@@ -22,7 +22,7 @@ Fleet maintains these [celebrity apps](https://github.com/fleetdm/fleet/blob/mai
    - Post-install script
    - Uninstall scripts
 
-If you find that a script doesn't work as expected, please file a [bug](https://github.com/fleetdm/fleet/issues/new?template=bug-report.md). When scripts are fixed, after upgrading Fleet, they are automatically updated for you unless you edited any of the scripts.
+These scripts are auto-generated based on the app's Homebrew Cask formula, but you can modify them. Modifying these scripts allows you to tailor the app installation process to your organization's needs, such as automating additional setup tasks or custom configurations post-installation.
 
 ## Install the app
 


### PR DESCRIPTION
This reverts commit 7477da389cca5cc200ad4a9a29cf906f1bf403c2.

See [this comment](https://github.com/fleetdm/fleet/issues/25734#issuecomment-2664193526) for background. tl;dr: we _don't_, and _won't for now_, push script updates down to installers when the scripts are updated on the FMA side.