### PR TITLE
Fleet attestation: add command for fleetd on Windows

### DIFF
--- a/articles/fleet-software-attestation.md
+++ b/articles/fleet-software-attestation.md
@@ -22,13 +22,17 @@ Verify the [fleetctl binary](https://github.com/fleetdm/fleet/releases) (CLI):
 gh attestation verify --owner fleetdm fleetdm /path/to/fleetctl
 ```
 
-After, installing Fleet's agent (fleetd) on a macOS host, run this command on the host to verify:
+After, installing Fleet's agent (fleetd) on a macOS or Linux host, run this command on the host to verify:
 
 ```
 gh attestation verify --owner fleetdm /usr/local/bin/orbit
 ```
 
-TODO: Filepath for Windows and Linux
+To verify fleetd on Windows, run this command:
+
+```
+gh attestation verify --owner fleetdm "C:\Program Files\Orbit\bin\orbit\orbit.exe"
+```
 
 <meta name="authorGitHubUsername" value="sgress454">
 <meta name="authorFullName" value="Scott Gress">

--- a/articles/fleet-software-attestation.md
+++ b/articles/fleet-software-attestation.md
@@ -19,7 +19,7 @@ gh attestation verify --owner fleetdm /path/to/fleet
 Verify the [fleetctl binary](https://github.com/fleetdm/fleet/releases) (CLI):
 
 ```
-gh attestation verify --owner fleetdm fleetdm /path/to/fleetctl
+gh attestation verify --owner fleetdm /path/to/fleetctl
 ```
 
 After, installing Fleet's agent (fleetd) on a macOS or Linux host, run this command on the host to verify:


### PR DESCRIPTION
UPDATE: @noahtalerman: currently, you can attest fleetd (Orbit) on macOS and Linux. Not Windows yet. Follow up work to add attestation for Windows is here: https://github.com/fleetdm/fleet/issues/26382

Closed this PR and opened a new one to remove the TODO and fix typo: https://github.com/fleetdm/fleet/pull/26487

---