### PR TITLE
goreleaser fleetctl archive

### DIFF
--- a/.github/workflows/goreleaser-fleet.yaml
+++ b/.github/workflows/goreleaser-fleet.yaml
@@ -95,10 +95,10 @@ jobs:
         with:
           subject-path: "dist/**"
 
-      # Get the commit hash so we can get image digests
-      - name: Get the short commit hash
-        id: commit
-        run: echo "short_commit=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
+      - name: Get tag
+        run: |
+          echo "TAG=$(git describe --tags |  sed -e "s/^fleet-//")" >> $GITHUB_OUTPUT
+        id: docker
 
       # Get the image digests from the goreleaser artifacts
       # Adapted from https://github.com/goreleaser/goreleaser/issues/4852#issuecomment-2122790132
@@ -106,15 +106,17 @@ jobs:
         continue-on-error: true
         id: image_digests
         run: |
-          echo "digest_fleet=$(cat ./dist/artifacts.json | jq -r '.[]|select(.type == "Published Docker Image" and (.name | contains("fleetdm/fleet:${{ steps.commit.outputs.short_commit }}"))) | select(. != null)|.extra.Digest')" >> "$GITHUB_OUTPUT"
-          echo "digest_fleetctl=$(cat ./dist/artifacts.json | jq -r '.[]|select(.type == "Published Docker Image" and (.name | contains("fleetdm/fleetctl:${{ steps.commit.outputs.short_commit }}"))) | select(. != null)|.extra.Digest')" >> "$GITHUB_OUTPUT"
+          digest_fleet=$(cat ./dist/artifacts.json | jq -r 'first(.[]|select(.type == "Published Docker Image" and (.name == "fleetdm/fleet:${{ steps.docker.outputs.tag }}")) | select(. != null)|.extra.Digest)')
+          echo "digest_fleet=$digest_fleet" >> "$GITHUB_OUTPUT"
+          digest_fleetctl=$(cat ./dist/artifacts.json | jq -r 'first(.[]|select(.type == "Published Docker Image" and (.name  == "fleetdm/fleetctl:${{ steps.docker.outputs.tag }}")) | select(. != null)|.extra.Digest)')
+          echo "digest_fleetctl=$digest_fleetctl" >> "$GITHUB_OUTPUT"
 
       - name: Attest Fleet image
         uses: actions/attest-build-provenance@619dbb2e03e0189af0c55118e7d3c5e129e99726 # v2.0
         continue-on-error: true
         with:
           subject-digest: ${{steps.image_digests.outputs.digest_fleet}}
-          subject-name: "fleetdm/fleet"
+          subject-name: "docker.io/fleetdm/fleet"
           push-to-registry: true
 
       - name: Attest FleetCtl image
@@ -122,13 +124,8 @@ jobs:
         continue-on-error: true
         with:
           subject-digest: ${{steps.image_digests.outputs.digest_fleetctl}}
-          subject-name: "fleetdm/fleetctl"
+          subject-name: "docker.io/fleetdm/fleetctl"
           push-to-registry: true
-
-      - name: Get tag
-        run: |
-          echo "TAG=$(git describe --tags |  sed -e "s/^fleet-//")" >> $GITHUB_OUTPUT
-        id: docker
 
       - name: List tags for push
         run: |

--- a/.github/workflows/goreleaser-fleet.yaml
+++ b/.github/workflows/goreleaser-fleet.yaml
@@ -76,7 +76,8 @@ jobs:
 
       - name: Run GoReleaser
         id: goreleaser
-        uses: goreleaser/goreleaser-action@f82d6c1c344bcacabba2c841718984797f664a6b
+        uses: goreleaser/goreleaser-action@90a3faa9d0182683851fbfa97ca1a2cb983bfca3 # v6.2.1
+
         with:
           distribution: goreleaser-pro
           version: "~> 2"

--- a/.github/workflows/goreleaser-snapshot-fleet.yaml
+++ b/.github/workflows/goreleaser-snapshot-fleet.yaml
@@ -69,7 +69,7 @@ jobs:
         run: make deps
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@f82d6c1c344bcacabba2c841718984797f664a6b
+        uses: goreleaser/goreleaser-action@90a3faa9d0182683851fbfa97ca1a2cb983bfca3 # v6.2.1
         with:
           distribution: goreleaser-pro
           version: "~> 2"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -99,13 +99,13 @@ archives:
   - id: fleetctl
     builds:
       - fleetctl
-    name_template: fleetctl_v{{.Version}}_{{- if eq .Os "darwin" }}macos{{- else }}{{ .Os }}{{ end }}
+    name_template: fleetctl_v{{.Version}}_{{- if eq .Os "darwin" }}macos{{- else }}{{ .Os }}{{ end }}_{{.Arch}}
     wrap_in_directory: true
 
   - id: fleetctl-zip
     builds:
       - fleetctl
-    name_template: fleetctl_v{{.Version}}_{{- if eq .Os "darwin" }}macos{{- else }}{{ .Os }}{{ end }}
+    name_template: fleetctl_v{{.Version}}_{{- if eq .Os "darwin" }}macos{{- else }}{{ .Os }}{{ end }}_{{.Arch}}
     format: zip
     wrap_in_directory: true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,55 @@
+## Fleet 4.63.0 (Feb 03, 2025)
+
+## Device management (MDM)
+- Allowed the delivery of bootstrap packages and software installers using signed URLs from CloudFront CDN. To enable, configured the following server settings:  
+  - `s3_software_installers_cloudfront_url`
+  - `s3_software_installers_cloudfront_url_signing_public_key_id`
+  - `s3_software_installers_cloudfront_url_signing_private_key`
+- Downgraded the expected or common "BootstrapPackage not found" server error to a debug message. This occurred when the UI or API checked if a bootstrap package existed.
+- Removed the arrow icon from the MDM solution table on the dashboard page.
+
+## Orchestration
+- Added the ability to install VPP apps on policy failure.
+- Implemented user-level settings and used them to persist a user's selection of which columns to display on the hosts table. 
+- Included a host's team-level queries when the user selected a query to target a specific host via the host details page.
+- Included osquery pre-releases in the daily UI constant update GitHub Actions job.
+- Displayed the correct path for agent options when a key was placed in the wrong object.
+- When running a live query from the edit query form, considered the results of the run in calculating an existing query's performance impact if the user did not change the query from the stored version.  
+- Improved the validation workflow on the SMTP settings page.
+- Clarified the expected behavior of policy host counts, dashboard controls software count, and controls OS updates versions count.
+- Rendered the default empty value when a host had no UUID.
+- Used an email logo compatible with dark modes.
+- Improved readability of the success message on email update by never including the sender address.
+
+## Software
+- Added the ability to install VPP apps on policy failure.
+- Allowed filtering of titles by "any of these platforms" in `GET /api/v1/fleet/software/titles`.
+- Added VPP apps to the automatic installation dropdown for failed policies and included auto-install information on the VPP app details page.
+- Updated Fleet-maintained app install scripts for non-PKG-based installers to allow the apps to be installed over an existing installation.
+- Clarified that editing VPP teams would remove App Store apps available to the team, not uninstall apps from hosts.
+- Pushed the correct paths to the URL on the "My device" page when self-service was not enabled for the host.
+- Displayed command line installation instructions when a package was generated.
+- Added a fallback for extracting the app name from `.pkg` installers that had default or incorrect title attributes in their distribution file.
+- Stopped VPP apps from being removed from teams whenever the VPP token team assignment was updated.
+- Improved software installation for failed policies by adding platform-specific filtering in the software dropdown so that only compatible software was displayed based on each policy's targeted platforms.
+- Added a timestamp for the software, OS, and vulnerability detail pages for the host count last update time.
+
+## Bug fixes and improvements
+- Fixed an issue where the vulnerabilities cron failed in large environments due to large SQL queries.
+- Fixed two broken links in the setup experience.
+- Fixed a UI bug on the "My device" page where the "Software" tab included filter elements that did not match the expected design.
+- Fixed a UI bug on the "Controls" page where incorrect timestamp information was displayed while the "Current versions" table was loading.
+- Fixed an issue for batch upload of Apple DDM profiles with `fleetctl gitops` where the activity feed showed a change even when profiles did not actually change.
+- Fixed a software name overflow in various modals.
+- Fixed form validation behavior on the SSO settings form.
+- Fixed MSI parsing for packages that included long interned strings (e.g., licenses for the OpenVPN Connect installer).
+- Fixed a software actions dropdown styling bug.
+- Fixed an issue where identical MDM commands were sent twice to the same device when the replica database was being used.
+- Fixed a redirect when clicking on any column in the Fleet Maintained Apps table.
+- Fixed an issue where deleted Apple config profiles were installed on devices because the devices were offline when the profile was added.
+- Fixed a CVE-2024-10327 false positive on Fleet-supported platforms (the vulnerability was iOS-only and iOS vulnerability checking was not supported).
+- Fixed missing capabilities in the UI for team admins when creating or editing a user by exposing more information from the API for team admins.
+
 ## Fleet 4.62.3 (Jan 28, 2025)
 
 ### Bug fixes
@@ -20,7 +72,7 @@
 
 ### Bug fixes
 
-* Fixed issue when identical MDM commands were sent twice to the same device when replica DB was being used.
+- Fixed issue when identical MDM commands were sent twice to the same device when replica DB was being used.
 
 ## Fleet 4.62.0 (Jan 09, 2025)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,84 @@
+## Fleet 4.64.0 (Feb 18, 2025)
+
+## Device management (MDM)
+- Included current host status and pending action in lock, unlock, and wipe API calls.
+- Disk encryption keys are now archived when they are created or updated. They are never fully deleted from the database.
+- Hosts that are restored from ABM no longer have old activities in their feed.
+
+## Orchestration
+- Added bash interpreter support for script execution.
+- Updated the activities feed with new design.
+- Added `fleetctl` on Linux ARM binary to releases.
+- Added clearer error states to metadata-related fields in the SSO settings form.
+- Enforced consistency of on-click behavior of table rows.
+- Added gzip compression for static CSS and JS assets to decrease bundle download times.
+- Added API endpoint for updating script contents.
+- Implemented various UI improvements to the scripts list.
+- Added option to populate users and labels on list hosts endpoint.
+- Checked the server for validity of any Fleet invites on load.
+- Updateed user form validation to require a password be present when switching a user from SSO to password authentication.
+- Updated the way new manual labels are created to better support adding large numbers of hosts at one time.
+- Replaced "Include Fleet desktop" with host type radio selection buttons when adding Windows or Linux hosts.
+- Disabled webhooks if not present in gitops.
+
+## Software
+- Added ability to target app store apps with include/exclude labels.
+- Added ability to edit targets or self service option for app store apps.
+- Added details modal for add, edit, and delete app store app global activities.
+- Added modal to edit script contents.
+- Added download url for fleet maintained apps as `url` property on `fleet/software/fleet_maintained_apps/:id`.
+- Added "exclude_fleet_maintained_apps" option to `GET /api/v1/fleet/software/titles`.
+- Surfaced download URL for Fleet-maintained app when adding the software to Fleet.
+- Surfaced cleaner errors when adding Fleet-maintained apps.
+- Revised software installer package validation to mark installers with no version as "unknown" for version rather than rejecting them.
+- Resolved false negatives on vulnerabilities for IntelliJ IDEA Community Edition on Windows.
+- Resolved false-positives for the `pass` Homebrew package and `jira` Python package via a vulnerability feed update available to all Fleet versions on 2025-01-22.
+- Fixed a false negative vulnerability reporting for iTerm2 (available to all recent Fleet releases as of January 17th via a vulnerability feed update).
+
+## Bug fixes and improvements
+- Removed duplicate Linux lock and wipe scripts from repository.
+- Clarified text on the policies and queries pages when no policies/queries exist for the selected team (or All Teams).
+- Updated the help text for 3 tabs of the Add hosts modal.
+- Improved the look and feel of dropdowns in the UI.
+- Improved look and feel of dashboard host count cards including hiding platforms with 0 count.
+- Added util wrapper func around semver package to allow for custom preprocessing. Upgraded semver library to 3.3.1 and usage everywhere to version 3. 
+- Added link to information about installing fleetd when packages are generated.
+- Optimized software ingestion queries to use existing DB indexes in the software titles table.
+- Normalized padding spacing for list headers, lists, and help text across various modals.
+- Removed the resend button for failed windows disk encryption profiles and add messaging that tells the user that Fleet with automatically retry this profile again.
+- Refactored upstream error logic to allow disabling submit button when form errors are present.
+- Improved the verified and verifying tooltips on the Profile Status on OS settings page.
+- Improved settings context so that user's updates to the team agent options form when they navigate away and back again.
+- Improved the teams dropdown so that it gracefully hides overflow from long team names.
+- Updated the os settings Target form deadline input tooltip to make it more clear how the deadline works for hosts.
+- Updated language in query comppatibility tooltip to clarify that compatibility is based only on tables.
+- Optimized logging by ensuring illegal argument errors will no longer be logged at the ERROR level on the server. Since these are client errors, they will be logged at the DEBUG level instead. This will reduce the amount of noise in the server logs and help debugging other issues.
+- Raised the frequency of sending anonymous statistics from every 24 hours to every 1 hour.
+- Bumped Node.js version to 20.18.1.
+- Bumped github cache action to 4.2.0.
+- Added server debug logging for unexpected Apple DDM configuration status.
+- Removed `fleetctl` binary from the `fleetdm/fleet` docker image.
+- Removed erroneous "manage automations" link on dashboard for maintainers.
+- Fixed window profiles error message being cut off in the OS settings modal.
+- Fixed user page responsiveness to not overflow horizontally.
+- Fixed case consistency for "Disk encryption" in host OS settings modal.
+- Fixed styling for manage automation buttons and dropdown.
+- Fixed a bug where query reports where not being recorded for hosts configured with `--logger_snapshot_event_type=true`.
+- Fixed incorrect source value in device mapping REST API documentation.
+- Fixed a bug in Fleet's handling of VPP token renewal requests.
+- Fixed mail being sent with the incorrect SMTP Domain (thank you @mccormickt).
+- Fixed filtering by vulnerable software for ios or ipad host.
+- Fixed issue where some Windows MDM profiles were not being sent to hosts when hosts came back online.
+- Fixed a bug where adding or removing a host with an identical name to/from a label caused the same action to be performed on other host(s) with the same name as well.
+- Fixed Windows MDM issue where SessionID of 0 was not allowed.
+- Fixed a bug with paginating team policies.
+- Fixed a bug "software not found for checksum" in software ingestion transaction retries.
+- Fixed issue with Windows disk encryption where status updates from "Verifying" to "Verified" were sometimes stuck in the "Verifying" state.
+- Fixed a bug where server errors returned from the API were not successfully being incorporated into the user form error states.
+- Fixed a bug where team admins are unable to enable or disable MFA for a user.
+- Fixed a bug where only the first of multiple software titles with the same name and source but different bundle IDs would be successfully inserted into the database.
+- Fixed issue verifying Windows CSP profiles that contain ADMX policies.
+
 ## Fleet 4.63.0 (Feb 03, 2025)
 
 ## Device management (MDM)

--- a/changes/16865-increase-statistics-frequency
+++ b/changes/16865-increase-statistics-frequency
@@ -1,1 +1,0 @@
-* Raised the frequency of sending anonymous statistics from every 24 hours to every 1 hour. (This is a fairly small packet and should have no impact on network traffic)

--- a/changes/21827-edit-vpp-teams
+++ b/changes/21827-edit-vpp-teams
@@ -1,1 +1,0 @@
-- Fleet UI: Clarify editing VPP teams will remove App Store apps available to team, not uninstalling apps from hosts.

--- a/changes/22353-abm-hosts-upcoming-activities
+++ b/changes/22353-abm-hosts-upcoming-activities
@@ -1,1 +1,0 @@
-- Hosts that are restored from ABM no longer have old activities in their feed

--- a/changes/22364-vuln-cron
+++ b/changes/22364-vuln-cron
@@ -1,1 +1,0 @@
-* fixed issue where the vulnerabilities cron was failing in large environments due to large SQL queries

--- a/changes/22464-list-hosts-populate-users-labels
+++ b/changes/22464-list-hosts-populate-users-labels
@@ -1,1 +1,0 @@
-- Added option to populate users and labels on list hosts endpoint

--- a/changes/22544-move-linux-lock-wipe
+++ b/changes/22544-move-linux-lock-wipe
@@ -1,1 +1,0 @@
-- Removed duplicate Linux lock and wipe scripts from repository

--- a/changes/22919-semver-util
+++ b/changes/22919-semver-util
@@ -1,1 +1,0 @@
-* Added util wrapper func around semver package to allow for custom preprocessing. Upgraded semver library to 3.3.1 and usage everywhere to version 3.  

--- a/changes/23096-fma-errors
+++ b/changes/23096-fma-errors
@@ -1,1 +1,0 @@
-- Fleet UI: Surfaced cleaner errors when adding Fleet-maintained apps

--- a/changes/23115-vpp-policy
+++ b/changes/23115-vpp-policy
@@ -1,2 +1,0 @@
-* Added ability to install VPP apps on policy failure
-* Allowed filtering titles by "any of these platforms" in `GET /api/v1/fleet/software/titles`

--- a/changes/23116-fma-dl-url
+++ b/changes/23116-fma-dl-url
@@ -1,1 +1,0 @@
-- Fleet UI: Surfaced download URL for Fleet-maintained app when adding the software to Fleet

--- a/changes/23241-lock-api-response
+++ b/changes/23241-lock-api-response
@@ -1,1 +1,0 @@
-* Included current host status and pending action in lock, unlock, and wipe API calls

--- a/changes/23302-fma-click-bug
+++ b/changes/23302-fma-click-bug
@@ -1,1 +1,0 @@
-- Fleet UI: Fixed redirect when clicking on any column in the Fleet Maintained Apps table

--- a/changes/23312-update-policies-empty-state
+++ b/changes/23312-update-policies-empty-state
@@ -1,1 +1,0 @@
-- Clarified text on the Policies and Queries pages when no policies/queries exist for the selected team (or All Teams)

--- a/changes/23312-update-policies-empty-state
+++ b/changes/23312-update-policies-empty-state
@@ -1,1 +1,1 @@
-- Clarified text on the Policies page when no policies exist for the selected team (or All Teams)
+- Clarified text on the Policies and Queries pages when no policies/queries exist for the selected team (or All Teams)

--- a/changes/23465-query-reports-support-event-format
+++ b/changes/23465-query-reports-support-event-format
@@ -1,1 +1,0 @@
-* Fixed a bug where query reports where not being recorded for hosts configured with `--logger_snapshot_event_type=true`.

--- a/changes/23512-clarify-expected-behavior-of-host-counts
+++ b/changes/23512-clarify-expected-behavior-of-host-counts
@@ -1,2 +1,0 @@
-- Clarify expected behavior of policy host counts, dashboard controls software count, and controls
-  os updates versions count.

--- a/changes/23528-install-software-policy-filter
+++ b/changes/23528-install-software-policy-filter
@@ -1,2 +1,0 @@
-- Improved software installation for failed policies: Added platform-specific filtering in the software dropdown, ensuring only compatible software are displayed based on each policy's targeted platforms
-- Add VPP app to automatic installation dropdown for failed policies and auto install information on VPP app details page

--- a/changes/23770-fleetctl-linux-arm
+++ b/changes/23770-fleetctl-linux-arm
@@ -1,1 +1,0 @@
-- Added `fleetctl` on Linux ARM binary to releases.

--- a/changes/23811-empty-cell-for-no-uuid
+++ b/changes/23811-empty-cell-for-no-uuid
@@ -1,1 +1,0 @@
-* Render the default empty value when a host has no UUID

--- a/changes/23823-cloudfront-cdn
+++ b/changes/23823-cloudfront-cdn
@@ -1,4 +1,0 @@
-Allow delivery of bootstrap packages and software installers using signed URLs from CloudFront CDN. To enable, configure server settings:
-- s3_software_installers_cloudfront_url
-- s3_software_installers_cloudfront_url_signing_public_key_id
-- s3_software_installers_cloudfront_url_signing_private_key

--- a/changes/23924-handle-long-team-names
+++ b/changes/23924-handle-long-team-names
@@ -1,1 +1,0 @@
-* Improve the teams dropdown so that it gracefully hides overflow from long team names

--- a/changes/23971-persist-hosts-column-settings-across-sessions
+++ b/changes/23971-persist-hosts-column-settings-across-sessions
@@ -1,2 +1,0 @@
-- Implement user-level settings, use them to persist a user's selection of which columns to display
-  on the hosts table.

--- a/changes/24035-team-agent-options-ui-resets
+++ b/changes/24035-team-agent-options-ui-resets
@@ -1,1 +1,0 @@
-* Maintain user's updates to the team agent options form when they navigate away and back again.

--- a/changes/24038-agent-options-key-error
+++ b/changes/24038-agent-options-key-error
@@ -1,1 +1,0 @@
-- Display the correct path for agent options when a key is placed in the wrong object

--- a/changes/24148-re-install-fma
+++ b/changes/24148-re-install-fma
@@ -1,1 +1,0 @@
-- Updated Fleet-maintained app install scripts for non-PKG-based installers to allow the apps to be installed over an existing installation.

--- a/changes/24335-dropdown-styling-bug
+++ b/changes/24335-dropdown-styling-bug
@@ -1,1 +1,0 @@
-- Fleet UI: Fix software actions dropdown styling bug

--- a/changes/24341-improve-ux-of-script-list-items
+++ b/changes/24341-improve-ux-of-script-list-items
@@ -1,1 +1,0 @@
-* Various UX improvements to the Scripts list

--- a/changes/24366-success-email-message
+++ b/changes/24366-success-email-message
@@ -1,1 +1,0 @@
-- Improve readability of success message on email update by never including the sender address.

--- a/changes/24418-bad-links
+++ b/changes/24418-bad-links
@@ -1,1 +1,0 @@
-- Fleet UI: Fixed two broken links in Setup experience

--- a/changes/24421-fix-my-device-paths
+++ b/changes/24421-fix-my-device-paths
@@ -1,1 +1,0 @@
-* Push correct paths to the URL on the my device page when self-service is not enabled for the host.

--- a/changes/24470-bash
+++ b/changes/24470-bash
@@ -1,1 +1,0 @@
-* Added bash interpreter support for script execution

--- a/changes/24486-error-for-invalid-invites
+++ b/changes/24486-error-for-invalid-invites
@@ -1,1 +1,0 @@
-- Check the server for validity of any Fleet invites

--- a/changes/24544-target-labels-vpp
+++ b/changes/24544-target-labels-vpp
@@ -1,3 +1,0 @@
-- Fleet UI: Added ability to target app store apps with include/exclude labels
-- Fleet UI: Added ability to edit targets or self service option for app store apps
-- Fleet UI: Added details modal for add, edit, and delete app store app global activities

--- a/changes/24601-editable-scripts-frontend
+++ b/changes/24601-editable-scripts-frontend
@@ -1,1 +1,0 @@
-- Added modal to edit script contents

--- a/changes/24602-editable-scripts
+++ b/changes/24602-editable-scripts
@@ -1,1 +1,0 @@
-- Added API endpoint for updating script contents

--- a/changes/24618-make-email-logo-dark-mode-compatible
+++ b/changes/24618-make-email-logo-dark-mode-compatible
@@ -1,1 +1,0 @@
-* Use an email logo compatible with dark modes

--- a/changes/24629-ui-os-updates-table
+++ b/changes/24629-ui-os-updates-table
@@ -1,2 +1,0 @@
-- Fixed UI bug on the "Controls" page where incorrect timestamp information was displayed while the
-  "Current versions" table was loading.

--- a/changes/24653-live-query-from-edit-affects-performance-stats
+++ b/changes/24653-live-query-from-edit-affects-performance-stats
@@ -1,2 +1,0 @@
-- When running a live query from the edit query form, consider the results of the run in calculating
-  an existing query's performance impact if the user didn't change the query from the stored version.

--- a/changes/24660-team-admins-cant-set-sso-mfa
+++ b/changes/24660-team-admins-cant-set-sso-mfa
@@ -1,2 +1,0 @@
-- Fix missing capabilities in the UI for team admins creating or editing a user by exposing
-  more information from the API for team admins.

--- a/changes/24720-msi-large-interned-strings
+++ b/changes/24720-msi-large-interned-strings
@@ -1,1 +1,0 @@
-* Fixed MSI parsing for packages including long interned strings (e.g. licenses for the OpenVPN Connect installer)

--- a/changes/24732-gzip
+++ b/changes/24732-gzip
@@ -1,1 +1,0 @@
-* Added gzip compression for static CSS and JS assets to decrease bundle download times

--- a/changes/24754-require-pw-for-pw-auth
+++ b/changes/24754-require-pw-for-pw-auth
@@ -1,4 +1,0 @@
-- Update user form validation to require a password be present when switching a user from
-  SSO to password authentication
-- Refactor upstream error logic to allow disabling submit button when form errors are present
-- Add similar check for password presence on server, update integration test accordingly

--- a/changes/24766-clickable-row-behavior
+++ b/changes/24766-clickable-row-behavior
@@ -1,1 +1,0 @@
-- Fleet UI: Created consistency of on-click behavior of table rows: View all host link must be clicked directly, clicking on a row of a table directs the user to the details of that row

--- a/changes/24790-admx-policies
+++ b/changes/24790-admx-policies
@@ -1,1 +1,0 @@
-Fixes issue verifying Windows CSP profiles that contain ADMX policies.

--- a/changes/24795-host-count
+++ b/changes/24795-host-count
@@ -1,1 +1,0 @@
-- Fleet UI: Added timestamp for software, OS, and vulnerability detail pages for host count last update time

--- a/changes/24804-deleted-profiles
+++ b/changes/24804-deleted-profiles
@@ -1,1 +1,0 @@
-Fixed issue where deleted Apple config profiles were installing on devices because devices were offline when the profile was added.

--- a/changes/24816-fix-double-mdm-commands
+++ b/changes/24816-fix-double-mdm-commands
@@ -1,1 +1,0 @@
-Fix issue when identical MDM commands are sent twice to the same device when replica DB is being used.

--- a/changes/24873-pkg-name
+++ b/changes/24873-pkg-name
@@ -1,1 +1,0 @@
-- Added a fallback for extracting app name from .pkg installers that have default or incorrect title attributes in their distribution file.

--- a/changes/24876-dashboard-cards
+++ b/changes/24876-dashboard-cards
@@ -1,1 +1,0 @@
-- Fleet UI: Changed look and feel of dashboard host count cards including hiding platforms with 0 count

--- a/changes/24886-fix-pagination-on-policies-page
+++ b/changes/24886-fix-pagination-on-policies-page
@@ -1,1 +1,0 @@
-- Fix a bug with paginating team policies

--- a/changes/24948-display-api-errors-in-user-form
+++ b/changes/24948-display-api-errors-in-user-form
@@ -1,2 +1,0 @@
-- Fix a bug where server errors returned from the API were not successfully being incorporated into
-  the user form error states.

--- a/changes/24958-gitops-webhooks-disable
+++ b/changes/24958-gitops-webhooks-disable
@@ -1,1 +1,0 @@
-- Disable webhooks if not present in gitops

--- a/changes/24959-ui-my-device-software-filter
+++ b/changes/24959-ui-my-device-software-filter
@@ -1,2 +1,0 @@
-- Fixed UI bug in "My device" page where the "Software" tab included filter elements that did not
-  match the expected design.

--- a/changes/24962-ui-dashboard-mdm-solutions-table
+++ b/changes/24962-ui-dashboard-mdm-solutions-table
@@ -1,1 +1,0 @@
-- Removed arrow icon from MDM solution table on dashboard page.

--- a/changes/25004-fleetctl-packge-cli-instructions
+++ b/changes/25004-fleetctl-packge-cli-instructions
@@ -1,1 +1,0 @@
-- Display command line installation instructions when a package is generated

--- a/changes/25009-smtp-page-validation
+++ b/changes/25009-smtp-page-validation
@@ -1,1 +1,0 @@
-- Improve validation workflow on SMTP settings page

--- a/changes/25015-user-page-responsive
+++ b/changes/25015-user-page-responsive
@@ -1,1 +1,0 @@
-- Fleet UI: Fixed user page responsiveness to not overflow horizontally

--- a/changes/25072-25073-software-name-overflow
+++ b/changes/25072-25073-software-name-overflow
@@ -1,1 +1,0 @@
-* Fleet UI: Fixed software name overflow in various modals

--- a/changes/25075-false-positive
+++ b/changes/25075-false-positive
@@ -1,1 +1,0 @@
-* Fixed CVE-2024-10327 false positive on Fleet-supported platforms (vuln is iOS-only and iOS vuln checking is not supported)

--- a/changes/25114-include-team-queries-in-host-details-query-modal
+++ b/changes/25114-include-team-queries-in-host-details-query-modal
@@ -1,2 +1,0 @@
-* Include a host's team-level queries when the user is selecting a query to target for a specific
-host via the host details page.

--- a/changes/25130-iterm-false-neg
+++ b/changes/25130-iterm-false-neg
@@ -1,1 +1,0 @@
-- Fixed a false negative vulnerability reporting for iTerm2 (available to all recent Fleet releases as of January 17th via a vulnerability feed update)

--- a/changes/25144-uninstall-after-mdm-action
+++ b/changes/25144-uninstall-after-mdm-action
@@ -1,1 +1,0 @@
-* Fixed reporting of software uninstall results after a host has been locked/unlocked

--- a/changes/25160-optimize-software-during-enrollment
+++ b/changes/25160-optimize-software-during-enrollment
@@ -1,2 +1,0 @@
-* Optimized software ingestion queries to use existing DB indexes in the software titles table.
-* Fixed a bug "software not found for checksum" in software ingestion transaction retries.

--- a/changes/25191-disk-encryption-sentence-case
+++ b/changes/25191-disk-encryption-sentence-case
@@ -1,1 +1,0 @@
-* Fixed case consistency for "Disk encryption" in host OS settings modal

--- a/changes/25194-vpp-app-clear
+++ b/changes/25194-vpp-app-clear
@@ -1,1 +1,0 @@
-- Stopped VPP apps from being removed from teams whenever the VPP token team assignment is updated.

--- a/changes/25201-unknown-installer-version
+++ b/changes/25201-unknown-installer-version
@@ -1,1 +1,0 @@
-* Revised software installer package validation to mark installers with no version as "unknown" for version rather than rejecting them

--- a/changes/25235-software-titles-uniqueness
+++ b/changes/25235-software-titles-uniqueness
@@ -1,1 +1,0 @@
-* Fixed a bug where only the first of multiple software titles with the same name and source but different bundle IDs would be successfully inserted into the database.

--- a/changes/25241-smtp-helo-domain
+++ b/changes/25241-smtp-helo-domain
@@ -1,1 +1,0 @@
-- Fixed mail being sent with the incorrect SMTP Domain (thank you mccormickt)

--- a/changes/25244-batch-set-declarations
+++ b/changes/25244-batch-set-declarations
@@ -1,1 +1,0 @@
-For batch upload of Apple DDM profiles with `fleetctl gitops`, fixed issue where activity feed was showing a change when profiles didn't actually change.

--- a/changes/25251-url-fleet-app-response
+++ b/changes/25251-url-fleet-app-response
@@ -1,1 +1,0 @@
-* Added download url for fleet maintained apps as `url` property on `fleet/software/fleet_maintained_apps/:id`

--- a/changes/25257-dropdown-improvements
+++ b/changes/25257-dropdown-improvements
@@ -1,1 +1,0 @@
-- Fleet UI: Improved the look and feel of dropdowns

--- a/changes/25261-identical-hostnames-label-membership
+++ b/changes/25261-identical-hostnames-label-membership
@@ -1,2 +1,0 @@
-- Fixed a bug where adding or removing a host with an identical name to/from a label caused the
-  same action to be performed on other host(s) with the same name as well.

--- a/changes/25264-sso-form-validation
+++ b/changes/25264-sso-form-validation
@@ -1,2 +1,0 @@
-- Fix form validation behavior on the SSO settings form.
--

--- a/changes/25265-boostrap-package-not-found
+++ b/changes/25265-boostrap-package-not-found
@@ -1,1 +1,0 @@
-Downgraded expected/common "BootstrapPackage not found" server error to a debug message. Occurs when UI/API checks if bootstrap package exists.

--- a/changes/25273-hde-windows-verifying
+++ b/changes/25273-hde-windows-verifying
@@ -1,2 +1,0 @@
-- Fixed issue where Windows disk encryption where status updates from "Verifying" to "Verified" were
-  sometimes stuck in the "Verifying" state.

--- a/changes/25305-update-add-hosts-help-text
+++ b/changes/25305-update-add-hosts-help-text
@@ -1,1 +1,0 @@
-- Update the help text for 3 tabs of the Add hosts modal

--- a/changes/25306-add-windows-linux-hosts-radios
+++ b/changes/25306-add-windows-linux-hosts-radios
@@ -1,2 +1,0 @@
-* Replace "Include Fleet desktop" with host type radio selection buttons when adding Windows or
-Linux hosts.

--- a/changes/25307-fleetctl-package-link
+++ b/changes/25307-fleetctl-package-link
@@ -1,1 +1,0 @@
-- Added link to information about installing fleetd when packages are generated

--- a/changes/25318-update-sso-settings-error-states
+++ b/changes/25318-update-sso-settings-error-states
@@ -1,1 +1,0 @@
-* Add clearer error states to metadata-related fields in the SSO settings form

--- a/changes/25346-fix-manage-automations-link-on-dash
+++ b/changes/25346-fix-manage-automations-link-on-dash
@@ -1,1 +1,0 @@
-- Removed erroneous "manage automations" link on dashboard for maintainers

--- a/changes/25366-manage-automation-dropdown-styling
+++ b/changes/25366-manage-automation-dropdown-styling
@@ -1,1 +1,0 @@
-- Fleet UI: Fixed styling for manage automation buttons and dropdown

--- a/changes/25427-allow-excluding-fma-from-software-titles
+++ b/changes/25427-allow-excluding-fma-from-software-titles
@@ -1,1 +1,0 @@
-- Add "exclude_fleet_maintained_apps" option to `GET /api/v1/fleet/software/titles`

--- a/changes/25553-update-compatibility-tooltip
+++ b/changes/25553-update-compatibility-tooltip
@@ -1,2 +1,0 @@
-
-- Updates language in query comppatibility tooltip to clarify that comppatibility is based only on tables.

--- a/changes/25555-batch-hostnames-on-new-label
+++ b/changes/25555-batch-hostnames-on-new-label
@@ -1,1 +1,0 @@
-- Updated the way new manual labels are created to better support adding large numbers of hosts at one time.

--- a/changes/25567-renew-vpp
+++ b/changes/25567-renew-vpp
@@ -1,1 +1,0 @@
-* Fixed a bug in Fleet's handling of VPP token renewal requests

--- a/changes/25581-session-id
+++ b/changes/25581-session-id
@@ -1,1 +1,0 @@
-Fix Windows MDM issue where SessionID of 0 was not allowed.

--- a/changes/25590-node
+++ b/changes/25590-node
@@ -1,1 +1,0 @@
-* Bump Node.js version to 20.18.1

--- a/changes/25597-false-positives
+++ b/changes/25597-false-positives
@@ -1,1 +1,0 @@
-* Resolved false-positives for the `pass` Homebrew package and `jira` Python package via a vulnerability feed update available to all Fleet versions on 2025-01-22

--- a/changes/25609-archive-encryption-keys
+++ b/changes/25609-archive-encryption-keys
@@ -1,1 +1,0 @@
-Disk encryption keys are now archived when they are created or updated. They are never fully deleted from the database.

--- a/changes/25615-windows-mdm-profiles
+++ b/changes/25615-windows-mdm-profiles
@@ -1,1 +1,0 @@
-Fixed issue where some Windows MDM profiles were not being sent to hosts when hosts came back online.

--- a/changes/25640-fix-idp-source
+++ b/changes/25640-fix-idp-source
@@ -1,1 +1,0 @@
-- Fixes incorrect source value in device mapping REST API documentation

--- a/changes/25662-ij-windows
+++ b/changes/25662-ij-windows
@@ -1,1 +1,0 @@
-* Resolved false negatives on vulnerabilities for IntelliJ IDEA Community Edition on Windows.

--- a/changes/25662-ij-windows
+++ b/changes/25662-ij-windows
@@ -1,0 +1,1 @@
+* Resolved false negatives on vulnerabilities for IntelliJ IDEA Community Edition on Windows.

--- a/changes/25748-remove-fleetctl-from-fleetdm-fleet-docker-image
+++ b/changes/25748-remove-fleetctl-from-fleetdm-fleet-docker-image
@@ -1,1 +1,0 @@
-* Removed `fleetctl` binary from the `fleetdm/fleet` docker image.

--- a/changes/25759-illegal-argument-errors
+++ b/changes/25759-illegal-argument-errors
@@ -1,1 +1,0 @@
-Illegal argument errors will no longer be logged at the ERROR level on the server. Since these are client errors, they will be logged at the DEBUG level instead. This will reduce the amount of noise in the server logs and help debugging other issues.

--- a/changes/25812-ddm-profiles-stuck
+++ b/changes/25812-ddm-profiles-stuck
@@ -1,1 +1,0 @@
-Added server debug logging for unexpected Apple DDM configuration status.

--- a/changes/25956-fix-buggy-efa-editing
+++ b/changes/25956-fix-buggy-efa-editing
@@ -1,1 +1,0 @@
-- Fix a bug where team admins are unable to enable or disable MFA for a user

--- a/changes/issue-21691-windows-disk-encryption-dont-resend
+++ b/changes/issue-21691-windows-disk-encryption-dont-resend
@@ -1,2 +1,0 @@
-- remove the resend button for failed windows disk encryption profiles and add messaging that tells
-the user that Fleet with automatically retry this profile again.

--- a/changes/issue-23912-ui-for-activities
+++ b/changes/issue-23912-ui-for-activities
@@ -1,1 +1,0 @@
-- update the UI a new activities design

--- a/changes/issue-24824-tooltip-verified-verifying
+++ b/changes/issue-24824-tooltip-verified-verifying
@@ -1,1 +1,0 @@
-- improve the verified and verifying tooltips on the Profile Status on OS settings page.

--- a/changes/issue-24901-fixes-error-cutoff
+++ b/changes/issue-24901-fixes-error-cutoff
@@ -1,1 +1,0 @@
-- fix in UI for window profiles error message being cut off in the OS settings modal

--- a/changes/issue-24992-padding-fixes-around-lists
+++ b/changes/issue-24992-padding-fixes-around-lists
@@ -1,1 +1,0 @@
-- normalise padding spacing for list headers, lists, and help text across various modals.

--- a/changes/issue-25159-update-deadline-tooltip
+++ b/changes/issue-25159-update-deadline-tooltip
@@ -1,2 +1,0 @@
-- update the os settings Target form deadline input tooltip to make the it more correct for how the
-deadline works for hosts

--- a/changes/issue-25507-upgrade-github-cache-action
+++ b/changes/issue-25507-upgrade-github-cache-action
@@ -1,1 +1,0 @@
-- bump github cache action to 4.2.0

--- a/changes/issue-25735-fix-500-vulnerable-host-software
+++ b/changes/issue-25735-fix-500-vulnerable-host-software
@@ -1,1 +1,0 @@
-- fix when trying to filter by vulnerable software for ios or ipad host.

--- a/changes/osquery-constant-prerelease
+++ b/changes/osquery-constant-prerelease
@@ -1,1 +1,0 @@
-* Included osquery pre-releases in daily UI constant update GitHub Actions job

--- a/charts/fleet/Chart.yaml
+++ b/charts/fleet/Chart.yaml
@@ -4,11 +4,11 @@ name: fleet
 keywords:
   - fleet
   - osquery
-version: v6.3.5
+version: v6.3.6
 home: https://github.com/fleetdm/fleet
 sources:
   - https://github.com/fleetdm/fleet.git
-appVersion: v4.63.0
+appVersion: v4.64.0
 dependencies:
   - name: mysql
     condition: mysql.enabled

--- a/charts/fleet/Chart.yaml
+++ b/charts/fleet/Chart.yaml
@@ -4,11 +4,11 @@ name: fleet
 keywords:
   - fleet
   - osquery
-version: v6.3.4
+version: v6.3.5
 home: https://github.com/fleetdm/fleet
 sources:
   - https://github.com/fleetdm/fleet.git
-appVersion: v4.62.3
+appVersion: v4.63.0
 dependencies:
   - name: mysql
     condition: mysql.enabled

--- a/charts/fleet/values.yaml
+++ b/charts/fleet/values.yaml
@@ -3,7 +3,7 @@
 hostName: fleet.localhost
 replicas: 3 # The number of Fleet instances to deploy
 imageRepository: fleetdm/fleet
-imageTag: v4.63.0 # Version of Fleet to deploy
+imageTag: v4.64.0 # Version of Fleet to deploy
 podAnnotations: {} # Additional annotations to add to the Fleet pod
 serviceAnnotations: {} # Additional annotations to add to the Fleet service
 serviceAccountAnnotations: {} # Additional annotations to add to the Fleet service account

--- a/charts/fleet/values.yaml
+++ b/charts/fleet/values.yaml
@@ -3,7 +3,7 @@
 hostName: fleet.localhost
 replicas: 3 # The number of Fleet instances to deploy
 imageRepository: fleetdm/fleet
-imageTag: v4.62.3 # Version of Fleet to deploy
+imageTag: v4.63.0 # Version of Fleet to deploy
 podAnnotations: {} # Additional annotations to add to the Fleet pod
 serviceAnnotations: {} # Additional annotations to add to the Fleet service
 serviceAccountAnnotations: {} # Additional annotations to add to the Fleet service account

--- a/docs/Contributing/Audit-logs.md
+++ b/docs/Contributing/Audit-logs.md
@@ -952,25 +952,6 @@ This activity contains the following fields:
 }
 ```
 
-## modified_script
-
-Generated when a script is modified on a team (or no team).
-
-This activity contains the following fields:
-- "script_name": Name of the script.
-- "team_id": The ID of the team that the script applies to, `null` if it applies to devices that are not in a team.
-- "team_name": The name of the team that the script applies to, `null` if it applies to devices that are not in a team.
-
-#### Example
-
-```json
-{
-  "script_name": "set-timezones.sh",
-  "team_id": 123,
-  "team_name": "Workstations"
-}
-```
-
 ## deleted_script
 
 Generated when a script is deleted from a team (or no team).
@@ -1428,40 +1409,6 @@ This activity contains the following fields:
 }
 ```
 
-## edited_app_store_app
-
-Generated when an App Store app is updated in Fleet.
-
-This activity contains the following fields:
-- "software_title": Name of the App Store app.
-- "app_store_id": ID of the app on the Apple App Store.
-- "platform": Platform of the app (`darwin`, `ios`, or `ipados`).
-- "self_service": App installation can be initiated by device owner.
-- "team_name": Name of the team to which this App Store app was added, or `null` if it was added to no team.
-- "team_id": ID of the team to which this App Store app was added, or `null`if it was added to no team.
-- "labels_include_any": Target hosts that have any label in the array.
-- "labels_exclude_any": Target hosts that don't have any label in the array.
-
-
-#### Example
-
-```json
-{
-  "software_title": "Logic Pro",
-  "app_store_id": "1234567",
-  "platform": "darwin",
-  "self_service": false,
-  "team_name": "Workstations",
-  "team_id": 1,
-  "labels_exclude_any": [
-    {
-      "name": "Engineering",
-      "id": 12
-    }
-  ]
-}
-```
-
 ## deleted_app_store_app
 
 Generated when an App Store app is deleted from Fleet.
@@ -1473,7 +1420,7 @@ This activity contains the following fields:
 - "team_name": Name of the team from which this App Store app was deleted, or `null` if it was deleted from no team.
 - "team_id": ID of the team from which this App Store app was deleted, or `null`if it was deleted from no team.
 - "labels_include_any": Target hosts that have any label in the array.
-- "labels_exclude_any": Target hosts that don't have any label in the array.
+- "labels_exclude_any": Target hosts that don't have any label in the array
 
 #### Example
 
@@ -1484,10 +1431,14 @@ This activity contains the following fields:
   "platform": "darwin",
   "team_name": "Workstations",
   "team_id": 1,
-  "labels_exclude_any": [
+  "labels_include_any": [
     {
       "name": "Engineering",
       "id": 12
+    },
+    {
+      "name": "Product",
+      "id": 17
     }
   ]
 }

--- a/ee/server/service/software_installers.go
+++ b/ee/server/service/software_installers.go
@@ -468,7 +468,7 @@ func (svc *Service) UpdateSoftwareInstaller(ctx context.Context, payload *fleet.
 
 				// We clear the policy status here because otherwise the policy automation machinery
 				// won't pick this up and the software won't install.
-				if err := svc.ds.ClearAutoInstallPolicyStatusForHosts(ctx, payload.InstallerID, hostsToClear); err != nil {
+				if err := svc.ds.ClearSoftwareInstallerAutoInstallPolicyStatusForHosts(ctx, payload.InstallerID, hostsToClear); err != nil {
 					return nil, ctxerr.Wrap(ctx, err, "failed to clear auto install policy status for host")
 				}
 			}

--- a/frontend/components/CustomLink/CustomLink.tsx
+++ b/frontend/components/CustomLink/CustomLink.tsx
@@ -11,10 +11,16 @@ interface ICustomLinkProps {
   newTab?: boolean;
   /** Icon wraps on new line with last word */
   multiline?: boolean;
+  // TODO: Refactor to use variant
   iconColor?: Colors;
+  // TODO: Refactor to use variant
   color?: "core-fleet-blue" | "core-fleet-black" | "core-fleet-white";
   /** Restricts access via keyboard when CustomLink is part of disabled UI */
   disableKeyboardNavigation?: boolean;
+  /** Longterm: refactor 14 instances away from iconColor/color combo, which
+   * usually are identical and repetitive, toward variants e.g. "banner-link"
+   */
+  variant?: "tooltip-link" | "default";
 }
 
 const baseClass = "custom-link";
@@ -28,10 +34,21 @@ const CustomLink = ({
   iconColor = "core-fleet-blue",
   color = "core-fleet-blue",
   disableKeyboardNavigation = false,
+  variant = "default",
 }: ICustomLinkProps): JSX.Element => {
+  const getIconColor = (): Colors => {
+    switch (variant) {
+      case "tooltip-link":
+        return "core-fleet-white";
+      default:
+        return iconColor;
+    }
+  };
+
   const customLinkClass = classnames(baseClass, className, {
     [`${baseClass}--black`]: color === "core-fleet-black",
     [`${baseClass}--white`]: color === "core-fleet-white",
+    [`${baseClass}--${variant}`]: variant !== "default",
   });
 
   const target = newTab ? "_blank" : "";
@@ -48,7 +65,7 @@ const CustomLink = ({
           <Icon
             name="external-link"
             className={`${baseClass}__external-icon`}
-            color={iconColor}
+            color={getIconColor()}
           />
         )}
       </span>
@@ -60,7 +77,7 @@ const CustomLink = ({
         <Icon
           name="external-link"
           className={`${baseClass}__external-icon`}
-          color={iconColor}
+          color={getIconColor()}
         />
       )}
     </>

--- a/frontend/components/CustomLink/_styles.scss
+++ b/frontend/components/CustomLink/_styles.scss
@@ -10,15 +10,18 @@
     }
   }
 
-  &--black {
-    color: $core-fleet-black;
-  }
-
+  // Legacy
   &--black {
     color: $core-fleet-black;
   }
 
   &--white {
     color: $core-fleet-white;
+  }
+
+  // Variants
+  &--tooltip-link {
+    color: $core-fleet-white;
+    font-size: $xx-small;
   }
 }

--- a/frontend/components/TargetLabelSelector/TargetLabelSelector.tsx
+++ b/frontend/components/TargetLabelSelector/TargetLabelSelector.tsx
@@ -156,7 +156,7 @@ interface ITargetLabelSelectorProps {
   customTargetOptions: IDropdownOption[];
   selectedLabels: Record<string, boolean>;
   labels: ILabelSummary[];
-  /** set this prop to show a help text. If it is encluded then it will override
+  /** set this prop to show a help text. If it is included then it will override
    * the selected options defined `helpText`
    */
   dropdownHelpText?: ReactNode;

--- a/frontend/components/forms/fields/DropdownWrapper/DropdownWrapper.tsx
+++ b/frontend/components/forms/fields/DropdownWrapper/DropdownWrapper.tsx
@@ -31,12 +31,6 @@ import Icon from "components/Icon";
 import { IconNames } from "components/icons";
 import { TooltipContent } from "interfaces/dropdownOption";
 
-const getOptionBackgroundColor = (
-  state: OptionProps<CustomOptionType, false>
-) => {
-  return state.isFocused ? COLORS["ui-vibrant-blue-10"] : "transparent";
-};
-
 export interface CustomOptionType {
   label: React.ReactNode;
   value: string;
@@ -45,6 +39,8 @@ export interface CustomOptionType {
   isDisabled?: boolean;
   iconName?: IconNames;
 }
+
+type DropdownWrapperVariant = "table-filter" | "button";
 
 export interface IDropdownWrapper {
   options: CustomOptionType[];
@@ -64,12 +60,31 @@ export interface IDropdownWrapper {
   /** E.g. scroll to view dropdown menu in a scrollable parent container */
   onMenuOpen?: () => void;
   /** Table filter dropdowns have filter icon and height: 40px
-   *  Button dropdowns have hover/active state, padding, height like actual buttons */
-  variant?: "table-filter" | "button";
+   *  Button dropdowns have hover/active state, padding, height matching actual buttons, and no selected option styling */
+  variant?: DropdownWrapperVariant;
   /** This makes the menu fit all text without wrapping,
    * aligning right to fit text on screen */
   nowrapMenu?: boolean;
 }
+
+const getOptionBackgroundColor = (
+  state: OptionProps<CustomOptionType, false>
+) => {
+  return state.isFocused ? COLORS["ui-vibrant-blue-10"] : "transparent";
+};
+
+const getOptionFontWeight = (
+  state: OptionProps<CustomOptionType, false>,
+  variant?: DropdownWrapperVariant
+) => {
+  // For "button" dropdowns, selected options are not styled differently
+  if (variant === "button") {
+    return "normal";
+  }
+
+  // For other variants, selected options are bold
+  return state.isSelected ? "bold" : "normal";
+};
 
 const baseClass = "dropdown-wrapper";
 
@@ -380,7 +395,7 @@ const DropdownWrapper = ({
       fontSize: "14px",
       borderRadius: "4px",
       backgroundColor: getOptionBackgroundColor(state),
-      fontWeight: state.isSelected ? "bold" : "normal",
+      fontWeight: getOptionFontWeight(state, variant),
       color: COLORS["core-fleet-black"],
       "&:hover": {
         backgroundColor: state.isDisabled
@@ -473,7 +488,7 @@ const DropdownWrapper = ({
         tabIndex={isDisabled ? -1 : 0} // Ensures disabled dropdown has no keyboard accessibility
         placeholder={placeholder}
         onMenuOpen={onMenuOpen}
-        controlShouldRenderValue={variant !== "button"}
+        controlShouldRenderValue={variant !== "button"} // Control doesn't change placeholder to selected value
       />
     </FormField>
   );

--- a/frontend/interfaces/software.ts
+++ b/frontend/interfaces/software.ts
@@ -3,7 +3,7 @@ import PropTypes from "prop-types";
 
 import { IconNames } from "components/icons";
 
-import { HOST_APPLE_PLATFORMS } from "./platform";
+import { HOST_APPLE_PLATFORMS, Platform } from "./platform";
 import vulnerabilityInterface from "./vulnerability";
 import { ILabelSoftwareTitle } from "./label";
 
@@ -455,14 +455,14 @@ export interface IFleetMaintainedApp {
   id: number;
   name: string;
   version: string;
-  platform: string;
+  platform: Platform;
 }
 
 export interface IFleetMaintainedAppDetails {
   id: number;
   name: string;
   version: string;
-  platform: string;
+  platform: Platform;
   pre_install_script: string; // TODO: is this needed?
   install_script: string;
   post_install_script: string; // TODO: is this needed?

--- a/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareAppStoreVpp/SoftwareVppForm/SoftwareVppForm.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareAppStoreVpp/SoftwareVppForm/SoftwareVppForm.tsx
@@ -15,6 +15,7 @@ import TargetLabelSelector from "components/TargetLabelSelector";
 import SoftwareIcon from "pages/SoftwarePage/components/icons/SoftwareIcon";
 import {
   CUSTOM_TARGET_OPTIONS,
+  generateHelpText,
   generateSelectedLabels,
   getCustomTarget,
   getTargetType,
@@ -224,6 +225,9 @@ const SoftwareVppForm = ({
             onSelectCustomTarget={onSelectCustomTargetOption}
             onSelectLabel={onSelectLabel}
             labels={labels || []}
+            dropdownHelpText={
+              generateHelpText("manual", formData.customTarget) // maps to manual install help text
+            }
           />
           {renderSelfServiceContent(softwareVppForEdit.platform)}
         </div>
@@ -253,6 +257,9 @@ const SoftwareVppForm = ({
             onSelectCustomTarget={onSelectCustomTargetOption}
             onSelectLabel={onSelectLabel}
             labels={labels || []}
+            dropdownHelpText={
+              generateHelpText("manual", formData.customTarget) // maps to manual install help text
+            }
           />
           {renderSelfServiceContent(
             ("selectedApp" in formData &&

--- a/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareFleetMaintained/FleetMaintainedAppDetailsPage/FleetAppDetailsModal/FleetAppDetailsModal.tests.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareFleetMaintained/FleetMaintainedAppDetailsPage/FleetAppDetailsModal/FleetAppDetailsModal.tests.tsx
@@ -8,7 +8,7 @@ import FleetAppDetailsModal from "./FleetAppDetailsModal";
 describe("FleetAppDetailsModal", () => {
   const defaultProps = {
     name: "Test App",
-    platform: "macOS",
+    platform: "darwin",
     version: "1.0.0",
     url: "https://example.com/app",
     onCancel: noop,

--- a/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareFleetMaintained/FleetMaintainedAppDetailsPage/FleetAppDetailsModal/FleetAppDetailsModal.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareFleetMaintained/FleetMaintainedAppDetailsPage/FleetAppDetailsModal/FleetAppDetailsModal.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 
+import { PLATFORM_DISPLAY_NAMES } from "utilities/constants";
 import Modal from "components/Modal";
 import DataSet from "components/DataSet";
 import TooltipWrapper from "components/TooltipWrapper";
@@ -31,7 +32,7 @@ const FleetAppDetailsModal = ({
       <>
         <div className={`${baseClass}__modal-content`}>
           <DataSet title="Name" value={name} />
-          <DataSet title="Platform" value={platform} />
+          <DataSet title="Platform" value={PLATFORM_DISPLAY_NAMES[platform]} />
           <DataSet title="Version" value={version} />
           {url && (
             <DataSet

--- a/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareFleetMaintained/FleetMaintainedAppDetailsPage/FleetAppDetailsModal/_styles.scss
+++ b/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareFleetMaintained/FleetMaintainedAppDetailsPage/FleetAppDetailsModal/_styles.scss
@@ -9,4 +9,11 @@
   .react-tooltip {
     min-width: 120px;
   }
+
+  // DataSet must have overflow hidden to be used in conjunction with child tooltip truncation
+  // Local fix as global fix caused DataSet width bugs across other DataSet use cases
+  .data-set {
+    max-width: min-content;
+    overflow: hidden;
+  }
 }

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwareInstallerCard/SoftwareInstallerCard.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwareInstallerCard/SoftwareInstallerCard.tsx
@@ -327,13 +327,12 @@ const SoftwareInstallerCard = ({
     <TooltipWrapper
       tipContent={
         <span>
-          Fleet couldn&apos;t read the version from ${name}.{" "}
+          Fleet couldn&apos;t read the version from {name}.{" "}
           <CustomLink
             newTab
             url={`${LEARN_MORE_ABOUT_BASE_LINK}/read-package-version`}
             text="Learn more"
-            color="core-fleet-white"
-            iconColor="core-fleet-white"
+            variant="tooltip-link"
           />
         </span>
       }

--- a/frontend/pages/policies/ManagePoliciesPage/ManagePoliciesPage.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/ManagePoliciesPage.tsx
@@ -754,9 +754,8 @@ const ManagePolicyPage = ({
     ? teamPolicies && teamPolicies.length > 0
     : globalPolicies && globalPolicies.length > 0;
 
-  // Show CTA buttons if there is no errors AND there are policy results or a search filter
-  const showCtaButtons =
-    !policiesErrors && (policyResults || searchQuery !== "");
+  // Show CTA buttons if there are no errors
+  const showCtaButtons = !policiesErrors;
 
   const automationsConfig = !isAllTeamsSelected ? teamConfig : config;
   const hasPoliciesToAutomateOrDelete = policiesAvailableToAutomate.length > 0;
@@ -837,7 +836,6 @@ const ManagePolicyPage = ({
         <PoliciesTable
           policiesList={globalPolicies || []}
           isLoading={isFetchingGlobalPolicies || isFetchingConfig}
-          onAddPolicyClick={onAddPolicyClick}
           onDeletePolicyClick={onDeletePolicyClick}
           canAddOrDeletePolicy={canAddOrDeletePolicy}
           hasPoliciesToDelete={hasPoliciesToAutomateOrDelete}
@@ -871,7 +869,6 @@ const ManagePolicyPage = ({
           isLoading={
             isFetchingTeamPolicies || isFetchingTeamConfig || isFetchingConfig
           }
-          onAddPolicyClick={onAddPolicyClick}
           onDeletePolicyClick={onDeletePolicyClick}
           canAddOrDeletePolicy={canAddOrDeletePolicy}
           hasPoliciesToDelete={hasPoliciesToAutomateOrDelete}

--- a/frontend/pages/policies/ManagePoliciesPage/components/PoliciesTable/PoliciesTable.tests.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/components/PoliciesTable/PoliciesTable.tests.tsx
@@ -8,6 +8,35 @@ import createMockPolicy from "__mocks__/policyMock";
 import PoliciesTable from "./PoliciesTable";
 
 describe("Policies table", () => {
+  it("Renders the page-wide empty state when no policies are present (free tier)", async () => {
+    const render = createCustomRenderer({
+      context: {
+        app: {
+          isGlobalAdmin: true,
+          currentUser: createMockUser(),
+        },
+      },
+    });
+
+    render(
+      <PoliciesTable
+        policiesList={[]}
+        isLoading={false}
+        onDeletePolicyClick={noop}
+        currentTeam={{ id: -1, name: "All teams" }}
+        searchQuery=""
+        page={0}
+        onQueryChange={noop}
+        renderPoliciesCount={() => null}
+        resetPageIndex={false}
+      />
+    );
+
+    expect(screen.getByText("You don't have any policies")).toBeInTheDocument();
+    expect(screen.queryByText("Name")).toBeNull();
+    expect(screen.queryByPlaceholderText("Search by name")).toBeNull();
+  });
+
   it("Renders the page-wide empty state when no policies are present (all teams)", async () => {
     const render = createCustomRenderer({
       context: {
@@ -37,6 +66,7 @@ describe("Policies table", () => {
       screen.getByText("You don't have any policies that apply to all teams")
     ).toBeInTheDocument();
     expect(screen.queryByText("Name")).toBeNull();
+    expect(screen.queryByPlaceholderText("Search by name")).toBeNull();
   });
 
   it("Renders the page-wide empty state when no policies are present (specific team)", async () => {
@@ -96,6 +126,7 @@ describe("Policies table", () => {
     );
 
     expect(screen.getByText("No matching policies")).toBeInTheDocument();
+    expect(screen.queryByPlaceholderText("Search by name")).toBeInTheDocument();
     expect(screen.queryByText("Name")).toBeNull();
   });
 

--- a/frontend/pages/policies/ManagePoliciesPage/components/PoliciesTable/PoliciesTable.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/components/PoliciesTable/PoliciesTable.tsx
@@ -5,7 +5,6 @@ import { IPolicyStats } from "interfaces/policy";
 import { ITeamSummary, APP_CONTEXT_ALL_TEAMS_ID } from "interfaces/team";
 import { IEmptyTableProps } from "interfaces/empty_table";
 
-import Button from "components/buttons/Button";
 import TableContainer from "components/TableContainer";
 import { ITableQueryData } from "components/TableContainer/TableContainer";
 import EmptyTable from "components/EmptyTable";
@@ -19,7 +18,6 @@ const DEFAULT_SORT_HEADER = "name";
 interface IPoliciesTableProps {
   policiesList: IPolicyStats[];
   isLoading: boolean;
-  onAddPolicyClick?: () => void;
   onDeletePolicyClick: (selectedTableIds: number[]) => void;
   canAddOrDeletePolicy?: boolean;
   hasPoliciesToDelete?: boolean;
@@ -38,7 +36,6 @@ interface IPoliciesTableProps {
 const PoliciesTable = ({
   policiesList,
   isLoading,
-  onAddPolicyClick,
   onDeletePolicyClick,
   canAddOrDeletePolicy,
   hasPoliciesToDelete,
@@ -62,26 +59,18 @@ const PoliciesTable = ({
       "Add policies to detect device health issues and trigger automations.",
   };
 
-  if (
-    currentTeam?.id === null ||
-    currentTeam?.id === APP_CONTEXT_ALL_TEAMS_ID
-  ) {
-    emptyState.header += " that apply to all teams";
-  } else {
-    emptyState.header += " that apply to this team";
+  if (isPremiumTier) {
+    if (
+      currentTeam?.id === null ||
+      currentTeam?.id === APP_CONTEXT_ALL_TEAMS_ID
+    ) {
+      emptyState.header += " that apply to all teams";
+    } else {
+      emptyState.header += " that apply to this team";
+    }
   }
 
-  if (canAddOrDeletePolicy) {
-    emptyState.primaryButton = (
-      <Button
-        variant="brand"
-        className={`${baseClass}__select-policy-button`}
-        onClick={onAddPolicyClick}
-      >
-        Add policy
-      </Button>
-    );
-  } else {
+  if (!canAddOrDeletePolicy) {
     emptyState.info = "";
   }
 

--- a/frontend/pages/policies/PolicyPage/components/PolicyResults/_styles.scss
+++ b/frontend/pages/policies/PolicyPage/components/PolicyResults/_styles.scss
@@ -11,7 +11,7 @@
     min-width: 140px;
     padding-left: 0px;
     padding-right: $pad-large;
-    border-right: 0;
+    border-left: 0;
 
     &:first-of-type {
       padding-left: $pad-large;

--- a/frontend/pages/queries/ManageQueriesPage/ManageQueriesPage.tsx
+++ b/frontend/pages/queries/ManageQueriesPage/ManageQueriesPage.tsx
@@ -163,19 +163,11 @@ const ManageQueriesPage = ({
   const enhancedQueries = queriesResponse?.queries.map(enhanceQuery);
 
   const queriesAvailableToAutomate =
-    (teamIdForApi
+    (teamIdForApi !== API_ALL_TEAMS_ID
       ? enhancedQueries?.filter(
           (query: IEnhancedQuery) => query.team_id === currentTeamId
         )
       : enhancedQueries) ?? [];
-
-  const onlyInheritedQueries = useMemo(() => {
-    if (teamIdForApi === API_ALL_TEAMS_ID) {
-      // global scope
-      return false;
-    }
-    return !enhancedQueries?.some((query) => query.team_id === teamIdForApi);
-  }, [teamIdForApi, enhancedQueries]);
 
   const automatedQueryIds = queriesAvailableToAutomate
     .filter((query) => query.automations_enabled)
@@ -280,9 +272,8 @@ const ManageQueriesPage = ({
         queries={enhancedQueries || []}
         totalQueriesCount={queriesResponse?.count}
         hasNextResults={!!queriesResponse?.meta.has_next_results}
-        onlyInheritedQueries={onlyInheritedQueries}
+        curTeamScopeQueriesPresent={!!queriesAvailableToAutomate.length}
         isLoading={isLoadingQueries || isFetchingQueries}
-        onCreateQueryClick={onCreateQueryClick}
         onDeleteQueryClick={onDeleteQueryClick}
         isOnlyObserver={isOnlyObserver}
         isObserverPlus={isObserverPlus}
@@ -291,6 +282,7 @@ const ManageQueriesPage = ({
         router={router}
         queryParams={location.query}
         currentTeamId={teamIdForApi}
+        isPremiumTier={isPremiumTier}
       />
     );
   };
@@ -381,13 +373,6 @@ const ManageQueriesPage = ({
     isTeamMaintainer ||
     isObserverPlus; // isObserverPlus checks global and selected team
 
-  const hideQueryActions =
-    // there are no filters and no returned queries, indicating there are no global/team queries at all
-    !(!!location.query.query || !!location.query.platform) &&
-    !queriesResponse?.count &&
-    // the user has permission
-    (!isOnlyObserver || isObserverPlus || isAnyTeamObserverPlus);
-
   return (
     <MainContent className={baseClass}>
       <div className={`${baseClass}__wrapper`}>
@@ -398,17 +383,18 @@ const ManageQueriesPage = ({
             </div>
           </div>
 
-          {!hideQueryActions && (
+          {canCustomQuery && (
             <div className={`${baseClass}__action-button-container`}>
-              {(isGlobalAdmin || isTeamAdmin) && !onlyInheritedQueries && (
-                <Button
-                  onClick={onManageAutomationsClick}
-                  className={`${baseClass}__manage-automations button`}
-                  variant="inverse"
-                >
-                  Manage automations
-                </Button>
-              )}
+              {(isGlobalAdmin || isTeamAdmin) &&
+                !!queriesAvailableToAutomate.length && (
+                  <Button
+                    onClick={onManageAutomationsClick}
+                    className={`${baseClass}__manage-automations button`}
+                    variant="inverse"
+                  >
+                    Manage automations
+                  </Button>
+                )}
               {canCustomQuery && (
                 <Button
                   variant="brand"

--- a/frontend/pages/queries/ManageQueriesPage/components/QueriesTable/QueriesTable.tests.tsx
+++ b/frontend/pages/queries/ManageQueriesPage/components/QueriesTable/QueriesTable.tests.tsx
@@ -143,16 +143,24 @@ const renderAsPremiumGlobalAdmin = createCustomRenderer({
   },
 });
 describe("QueriesTable", () => {
-  it("Renders the page-wide empty state when no queries are present", () => {
+  it("Renders the page-wide empty state when no queries are present (free tier)", () => {
+    const render = createCustomRenderer({
+      context: {
+        app: {
+          isGlobalAdmin: true,
+          currentUser: createMockUser(),
+        },
+      },
+    });
+
     const testData: IQueriesTableProps[] = [
       {
         queries: [],
         totalQueriesCount: 0,
         hasNextResults: false,
-        onlyInheritedQueries: false,
+        curTeamScopeQueriesPresent: true,
         isLoading: false,
         onDeleteQueryClick: jest.fn(),
-        onCreateQueryClick: jest.fn(),
         isOnlyObserver: false,
         isObserverPlus: false,
         isAnyTeamObserverPlus: false,
@@ -161,23 +169,78 @@ describe("QueriesTable", () => {
     ];
 
     testData.forEach((tableProps) => {
-      renderAsPremiumGlobalAdmin(<QueriesTable {...tableProps} />);
+      render(<QueriesTable {...tableProps} />);
       expect(
         screen.getByText("You don't have any queries")
       ).toBeInTheDocument();
       expect(screen.queryByText("Frequency")).toBeNull();
+      expect(screen.queryByPlaceholderText("Search by name")).toBeNull();
     });
   });
-  it("Renders inherited global queries and team queries when viewing a team, then renders the 'no-matching' empty state when a search string is entered that matches no queries", async () => {
+
+  it("Renders the page-wide empty state when no queries are present (all teams)", () => {
+    const testData: IQueriesTableProps[] = [
+      {
+        queries: [],
+        totalQueriesCount: 0,
+        hasNextResults: false,
+        curTeamScopeQueriesPresent: true,
+        isLoading: false,
+        onDeleteQueryClick: jest.fn(),
+        isOnlyObserver: false,
+        isObserverPlus: false,
+        isAnyTeamObserverPlus: false,
+        currentTeamId: undefined,
+        isPremiumTier: true,
+      },
+    ];
+
+    testData.forEach((tableProps) => {
+      renderAsPremiumGlobalAdmin(<QueriesTable {...tableProps} />);
+      expect(
+        screen.getByText("You don't have any queries that apply to all teams")
+      ).toBeInTheDocument();
+      expect(screen.queryByText("Frequency")).toBeNull();
+      expect(screen.queryByPlaceholderText("Search by name")).toBeNull();
+    });
+  });
+
+  it("Renders the page-wide empty state when no queries are present (specific team)", () => {
+    const testData: IQueriesTableProps[] = [
+      {
+        queries: [],
+        totalQueriesCount: 0,
+        hasNextResults: false,
+        curTeamScopeQueriesPresent: true,
+        isLoading: false,
+        onDeleteQueryClick: jest.fn(),
+        isOnlyObserver: false,
+        isObserverPlus: false,
+        isAnyTeamObserverPlus: false,
+        isPremiumTier: true,
+        currentTeamId: 1,
+      },
+    ];
+
+    testData.forEach((tableProps) => {
+      renderAsPremiumGlobalAdmin(<QueriesTable {...tableProps} />);
+      expect(
+        screen.getByText("You don't have any queries that apply to this team")
+      ).toBeInTheDocument();
+      expect(screen.queryByText("Frequency")).toBeNull();
+      expect(screen.queryByPlaceholderText("Search by name")).toBeNull();
+    });
+  });
+
+  it("Renders inherited global queries and team queries when viewing a team", async () => {
     const testData: IQueriesTableProps[] = [
       {
         queries: [...testGlobalQueries, ...testTeamQueries],
         totalQueriesCount: 4,
         hasNextResults: false,
-        onlyInheritedQueries: false,
+        curTeamScopeQueriesPresent: true,
         isLoading: false,
         onDeleteQueryClick: jest.fn(),
-        onCreateQueryClick: jest.fn(),
         isOnlyObserver: false,
         isObserverPlus: false,
         isAnyTeamObserverPlus: false,
@@ -193,24 +256,32 @@ describe("QueriesTable", () => {
       "Team query 2",
     ];
 
-    testData.forEach(async (tableProps) => {
-      // will have no context to get current user from
-      const { user } = renderAsPremiumGlobalAdmin(
-        <QueriesTable {...tableProps} />
-      );
-      dataStrings.forEach((val) => {
-        expect(screen.getAllByText(val)[0]).toBeInTheDocument();
-      });
-
-      await user.type(
-        screen.getByPlaceholderText("Search by name"),
-        "shouldn't match anything"
-      );
-      expect(screen.getByText("No matching queries")).toBeInTheDocument();
-      dataStrings.forEach((val) => {
-        expect(screen.getAllByText(val)).toHaveLength(0);
-      });
+    // will have no context to get current user from
+    renderAsPremiumGlobalAdmin(<QueriesTable {...testData[0]} />);
+    dataStrings.forEach((val) => {
+      expect(screen.getAllByText(val)[0]).toBeInTheDocument();
     });
+  });
+
+  it("renders the 'no-matching' empty state when a search string is entered that matches no queries", async () => {
+    const testData: IQueriesTableProps = {
+      queries: [],
+      totalQueriesCount: 0,
+      hasNextResults: false,
+      curTeamScopeQueriesPresent: true,
+      isLoading: false,
+      onDeleteQueryClick: jest.fn(),
+      isOnlyObserver: false,
+      isObserverPlus: false,
+      isAnyTeamObserverPlus: false,
+      currentTeamId: 1,
+      queryParams: {
+        query: "dont match me bro",
+      },
+    };
+    // will have no context to get current user from
+    renderAsPremiumGlobalAdmin(<QueriesTable {...testData} />);
+    expect(screen.getByText("No matching queries")).toBeInTheDocument();
   });
 
   it("Renders an observer can run badge and tooltip for a observer can run query", async () => {
@@ -235,10 +306,9 @@ describe("QueriesTable", () => {
         queries={testQueries}
         totalQueriesCount={1}
         hasNextResults={false}
-        onlyInheritedQueries={false}
+        curTeamScopeQueriesPresent
         isLoading={false}
         onDeleteQueryClick={jest.fn()}
-        onCreateQueryClick={jest.fn()}
         isOnlyObserver={false}
         isObserverPlus={false}
         isAnyTeamObserverPlus={false}
@@ -276,10 +346,9 @@ describe("QueriesTable", () => {
         queries={testQueries}
         totalQueriesCount={1}
         hasNextResults={false}
-        onlyInheritedQueries={false}
+        curTeamScopeQueriesPresent
         isLoading={false}
         onDeleteQueryClick={jest.fn()}
-        onCreateQueryClick={jest.fn()}
         isOnlyObserver={false}
         isObserverPlus={false}
         isAnyTeamObserverPlus={false}
@@ -316,10 +385,9 @@ describe("QueriesTable", () => {
         queries={testQueries}
         totalQueriesCount={1}
         hasNextResults={false}
-        onlyInheritedQueries={false}
+        curTeamScopeQueriesPresent
         isLoading={false}
         onDeleteQueryClick={jest.fn()}
-        onCreateQueryClick={jest.fn()}
         isOnlyObserver={false}
         isObserverPlus={false}
         isAnyTeamObserverPlus={false}
@@ -345,10 +413,9 @@ describe("QueriesTable", () => {
         queries={[...testTeamQueries, ...testGlobalQueries]}
         totalQueriesCount={4}
         hasNextResults={false}
-        onlyInheritedQueries={false}
+        curTeamScopeQueriesPresent
         isLoading={false}
         onDeleteQueryClick={jest.fn()}
-        onCreateQueryClick={jest.fn()}
         isOnlyObserver={false}
         isObserverPlus={false}
         isAnyTeamObserverPlus={false}

--- a/frontend/pages/queries/edit/components/QueryResults/_styles.scss
+++ b/frontend/pages/queries/edit/components/QueryResults/_styles.scss
@@ -16,7 +16,7 @@
     min-width: 140px;
     padding-left: 0px;
     padding-right: $pad-large;
-    border-right: 0;
+    border-left: 0;
 
     &:first-of-type {
       padding-left: $pad-large;

--- a/frontend/styles/var/colors.scss
+++ b/frontend/styles/var/colors.scss
@@ -1,11 +1,11 @@
 // Core
 $core-fleet-black: #192147;
-$core-fleet-white: #ffffff;
+$core-fleet-white: #ffffff; // TODO: merge with core-white
 $core-fleet-blue: #3e4771;
 $core-vibrant-blue: #6a67fe;
 $core-vibrant-red: #ff5c83;
 $core-fleet-purple: #ae6ddf;
-$core-white: #ffffff;
+$core-white: #ffffff; // TODO: merge with core-fleet-white
 $core-dark-blue-grey: #506e92;
 $site-nav-on-hover: #0e1533;
 

--- a/infrastructure/dogfood/terraform/aws/variables.tf
+++ b/infrastructure/dogfood/terraform/aws/variables.tf
@@ -56,7 +56,7 @@ variable "database_name" {
 
 variable "fleet_image" {
   description = "the name of the container image to run"
-  default     = "fleetdm/fleet:v4.63.0"
+  default     = "fleetdm/fleet:v4.64.0"
 
 variable "software_inventory" {
   description = "enable/disable software inventory (default is enabled)"

--- a/infrastructure/dogfood/terraform/aws/variables.tf
+++ b/infrastructure/dogfood/terraform/aws/variables.tf
@@ -56,8 +56,7 @@ variable "database_name" {
 
 variable "fleet_image" {
   description = "the name of the container image to run"
-  default     = "fleetdm/fleet:v4.62.3"
-}
+  default     = "fleetdm/fleet:v4.63.0"
 
 variable "software_inventory" {
   description = "enable/disable software inventory (default is enabled)"

--- a/infrastructure/dogfood/terraform/gcp/variables.tf
+++ b/infrastructure/dogfood/terraform/gcp/variables.tf
@@ -68,7 +68,7 @@ variable "redis_mem" {
 }
 
 variable "image" {
-  default = "fleetdm/fleet:v4.63.0"
+  default = "fleetdm/fleet:v4.64.0"
 }
 
 variable "software_installers_bucket_name" {

--- a/infrastructure/dogfood/terraform/gcp/variables.tf
+++ b/infrastructure/dogfood/terraform/gcp/variables.tf
@@ -68,7 +68,7 @@ variable "redis_mem" {
 }
 
 variable "image" {
-  default = "fleetdm/fleet:v4.62.3"
+  default = "fleetdm/fleet:v4.63.0"
 }
 
 variable "software_installers_bucket_name" {

--- a/server/datastore/mysql/software.go
+++ b/server/datastore/mysql/software.go
@@ -2459,7 +2459,10 @@ INNER JOIN software_cve scve ON scve.software_id = s.id
 						SELECT
 							COUNT(*) AS count_installer_labels,
 							COUNT(lm.label_id) AS count_host_labels,
-							SUM(CASE WHEN lbl.created_at IS NOT NULL AND :host_label_updated_at >= lbl.created_at THEN 1 ELSE 0 END) as count_host_updated_after_labels
+							SUM(CASE 
+							WHEN lbl.created_at IS NOT NULL AND lbl.label_membership_type = 0 AND :host_label_updated_at >= lbl.created_at THEN 1
+							WHEN lbl.created_at IS NOT NULL AND lbl.label_membership_type = 1 THEN 1
+							ELSE 0 END) as count_host_updated_after_labels
 						FROM
 							vpp_app_team_labels vatl
 							LEFT OUTER JOIN labels lbl
@@ -2618,7 +2621,10 @@ INNER JOIN software_cve scve ON scve.software_id = s.id
 						SELECT
 							COUNT(*) AS count_installer_labels,
 							COUNT(lm.label_id) AS count_host_labels,
-							SUM(CASE WHEN lbl.created_at IS NOT NULL AND :host_label_updated_at >= lbl.created_at THEN 1 ELSE 0 END) as count_host_updated_after_labels
+							SUM(CASE 
+							WHEN lbl.created_at IS NOT NULL AND lbl.label_membership_type = 0 AND :host_label_updated_at >= lbl.created_at THEN 1
+							WHEN lbl.created_at IS NOT NULL AND lbl.label_membership_type = 1 THEN 1
+							ELSE 0 END) as count_host_updated_after_labels
 						FROM
 							vpp_app_team_labels vatl
 							LEFT OUTER JOIN labels lbl

--- a/server/datastore/mysql/software_installers.go
+++ b/server/datastore/mysql/software_installers.go
@@ -1071,13 +1071,14 @@ func (ds *Datastore) CleanupUnusedSoftwareInstallers(ctx context.Context, softwa
 func (ds *Datastore) BatchSetSoftwareInstallers(ctx context.Context, tmID *uint, installers []*fleet.UploadSoftwareInstallerPayload) error {
 	const upsertSoftwareTitles = `
 INSERT INTO software_titles
-  (name, source, browser)
+  (name, source, browser, bundle_identifier)
 VALUES
   %s
 ON DUPLICATE KEY UPDATE
   name = VALUES(name),
   source = VALUES(source),
-  browser = VALUES(browser)
+  browser = VALUES(browser),
+  bundle_identifier = VALUES(bundle_identifier)
 `
 
 	const loadSoftwareTitles = `
@@ -1085,7 +1086,7 @@ SELECT
   id
 FROM
   software_titles
-WHERE (name, source, browser) IN (%s)
+WHERE (unique_identifier, source, browser) IN (%s)
 `
 
 	const unsetAllInstallersFromPolicies = `
@@ -1190,7 +1191,7 @@ COALESCE(post_install_script_content_id != ? OR
 	(post_install_script_content_id IS NULL AND ? IS NOT NULL) OR
 	(? IS NULL AND post_install_script_content_id IS NOT NULL)
 , FALSE) is_metadata_modified FROM software_installers
-WHERE global_or_team_id = ?	AND title_id IN (SELECT id FROM software_titles WHERE name = ? AND source = ? AND browser = '')
+WHERE global_or_team_id = ?	AND title_id IN (SELECT id FROM software_titles WHERE unique_identifier = ? AND source = ? AND browser = '')
 `
 
 	const insertNewOrEditedInstaller = `
@@ -1216,7 +1217,7 @@ INSERT INTO software_installers (
 	install_during_setup
 ) VALUES (
   ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
-  (SELECT id FROM software_titles WHERE name = ? AND source = ? AND browser = ''),
+  (SELECT id FROM software_titles WHERE unique_identifier = ? AND source = ? AND browser = ''),
   ?, (SELECT name FROM users WHERE id = ?), (SELECT email FROM users WHERE id = ?), ?, ?, COALESCE(?, false)
 )
 ON DUPLICATE KEY UPDATE
@@ -1245,7 +1246,7 @@ FROM
 WHERE
 	global_or_team_id = ?	AND
 	-- this is guaranteed to select a single title_id, due to unique index
-	title_id IN (SELECT id FROM software_titles WHERE name = ? AND source = ? AND browser = '')
+	title_id IN (SELECT id FROM software_titles WHERE unique_identifier = ? AND source = ? AND browser = '')
 `
 
 	const deleteInstallerLabelsNotInList = `
@@ -1330,11 +1331,22 @@ WHERE
 
 		var args []any
 		for _, installer := range installers {
-			args = append(args, installer.Title, installer.Source, "")
+			args = append(
+				args,
+				installer.Title,
+				installer.Source,
+				"",
+				func() *string {
+					if strings.TrimSpace(installer.BundleIdentifier) != "" {
+						return &installer.BundleIdentifier
+					}
+					return nil
+				}(),
+			)
 		}
 
 		values := strings.TrimSuffix(
-			strings.Repeat("(?,?,?),", len(installers)),
+			strings.Repeat("(?,?,?,?),", len(installers)),
 			",",
 		)
 		if _, err := tx.ExecContext(ctx, fmt.Sprintf(upsertSoftwareTitles, values), args...); err != nil {
@@ -1342,6 +1354,20 @@ WHERE
 		}
 
 		var titleIDs []uint
+		args = []any{}
+		for _, installer := range installers {
+			args = append(
+				args,
+				BundleIdentifierOrName(installer.BundleIdentifier, installer.Title),
+				installer.Source,
+				"",
+			)
+		}
+		values = strings.TrimSuffix(
+			strings.Repeat("(?,?,?),", len(installers)),
+			",",
+		)
+
 		if err := sqlx.SelectContext(ctx, tx, &titleIDs, fmt.Sprintf(loadSoftwareTitles, values), args...); err != nil {
 			return ctxerr.Wrap(ctx, err, "load existing titles")
 		}
@@ -1441,7 +1467,7 @@ WHERE
 				postInstallScriptID,
 				// WHERE clause
 				globalOrTeamID,
-				installer.Title,
+				BundleIdentifierOrName(installer.BundleIdentifier, installer.Title),
 				installer.Source,
 			}
 
@@ -1472,7 +1498,7 @@ WHERE
 				postInstallScriptID,
 				installer.Platform,
 				installer.SelfService,
-				installer.Title,
+				BundleIdentifierOrName(installer.BundleIdentifier, installer.Title),
 				installer.Source,
 				installer.UserID,
 				installer.UserID,
@@ -1495,7 +1521,7 @@ WHERE
 			// ID (cannot use res.LastInsertID due to the upsert statement, won't
 			// give the id in case of update)
 			var installerID uint
-			if err := sqlx.GetContext(ctx, tx, &installerID, loadSoftwareInstallerID, globalOrTeamID, installer.Title, installer.Source); err != nil {
+			if err := sqlx.GetContext(ctx, tx, &installerID, loadSoftwareInstallerID, globalOrTeamID, BundleIdentifierOrName(installer.BundleIdentifier, installer.Title), installer.Source); err != nil {
 				return ctxerr.Wrapf(ctx, err, "load id of new/edited installer with name %q", installer.Filename)
 			}
 

--- a/server/datastore/mysql/software_installers.go
+++ b/server/datastore/mysql/software_installers.go
@@ -1784,7 +1784,7 @@ FROM (
 			0 AS count_installer_labels,
 			0 AS count_host_labels,
 			0 AS count_host_updated_after_labels
-		WHERE NOT EXISTS ( SELECT 1 FROM software_installer_labels sil WHERE sil.software_installer_id = ?)
+		WHERE NOT EXISTS ( SELECT 1 FROM %[1]s_labels sil WHERE sil.%[1]s_id = ?)
 
 		UNION
 
@@ -1794,11 +1794,11 @@ FROM (
 			COUNT(lm.label_id) AS count_host_labels,
 			0 AS count_host_updated_after_labels
 		FROM
-			software_installer_labels sil
+			%[1]s_labels sil
 		LEFT OUTER JOIN label_membership lm ON lm.label_id = sil.label_id
 		AND lm.host_id = h.id
 		WHERE
-			sil.software_installer_id = ?
+			sil.%[1]s_id = ?
 			AND sil.exclude = 0
 		HAVING
 			count_installer_labels > 0
@@ -1819,18 +1819,18 @@ FROM (
 						SELECT
 							label_updated_at FROM hosts
 						WHERE
-							id = 1) >= lbl.created_at THEN
+							id = h.id) >= lbl.created_at THEN
 					1
 				ELSE
 					0
 				END) AS count_host_updated_after_labels
 		FROM
-			software_installer_labels sil
+			%[1]s_labels sil
 		LEFT OUTER JOIN labels lbl ON lbl.id = sil.label_id
 	LEFT OUTER JOIN label_membership lm ON lm.label_id = sil.label_id
 		AND lm.host_id = h.id
 WHERE
-	sil.software_installer_id = ?
+	sil.%[1]s_id = ?
 	AND sil.exclude = 1
 HAVING
 	count_installer_labels > 0
@@ -1838,17 +1838,22 @@ HAVING
 	AND count_host_labels = 0) t`
 
 func (ds *Datastore) GetIncludedHostIDMapForSoftwareInstaller(ctx context.Context, installerID uint) (map[uint]struct{}, error) {
+	return ds.getIncludedHostIDMapForSoftware(ctx, ds.writer(ctx), installerID, softwareTypeInstaller)
+}
+
+func (ds *Datastore) getIncludedHostIDMapForSoftware(ctx context.Context, tx sqlx.ExtContext, softwareID uint, swType softwareType) (map[uint]struct{}, error) {
+	filter := fmt.Sprintf(labelScopedFilter, swType)
 	stmt := fmt.Sprintf(`SELECT
 	h.id
 FROM
 	hosts h
 WHERE
 	EXISTS (%s)
-`, labelScopedFilter)
+`, filter)
 
 	var hostIDs []uint
-	if err := sqlx.SelectContext(ctx, ds.reader(ctx), &hostIDs, stmt, installerID, installerID, installerID); err != nil {
-		return nil, ctxerr.Wrap(ctx, err, "listing hosts included in software installer scope")
+	if err := sqlx.SelectContext(ctx, tx, &hostIDs, stmt, softwareID, softwareID, softwareID); err != nil {
+		return nil, ctxerr.Wrap(ctx, err, "listing hosts included in software scope")
 	}
 
 	res := make(map[uint]struct{}, len(hostIDs))
@@ -1860,17 +1865,22 @@ WHERE
 }
 
 func (ds *Datastore) GetExcludedHostIDMapForSoftwareInstaller(ctx context.Context, installerID uint) (map[uint]struct{}, error) {
+	return ds.getExcludedHostIDMapForSoftware(ctx, installerID, softwareTypeInstaller)
+}
+
+func (ds *Datastore) getExcludedHostIDMapForSoftware(ctx context.Context, softwareID uint, swType softwareType) (map[uint]struct{}, error) {
+	filter := fmt.Sprintf(labelScopedFilter, swType)
 	stmt := fmt.Sprintf(`SELECT
 	h.id
 FROM
 	hosts h
 WHERE
 	NOT EXISTS (%s)
-`, labelScopedFilter)
+`, filter)
 
 	var hostIDs []uint
-	if err := sqlx.SelectContext(ctx, ds.reader(ctx), &hostIDs, stmt, installerID, installerID, installerID); err != nil {
-		return nil, ctxerr.Wrap(ctx, err, "listing hosts excluded from software installer scope")
+	if err := sqlx.SelectContext(ctx, ds.writer(ctx), &hostIDs, stmt, softwareID, softwareID, softwareID); err != nil {
+		return nil, ctxerr.Wrap(ctx, err, "listing hosts excluded from software scope")
 	}
 
 	res := make(map[uint]struct{}, len(hostIDs))

--- a/server/datastore/mysql/software_installers.go
+++ b/server/datastore/mysql/software_installers.go
@@ -1761,7 +1761,9 @@ func (ds *Datastore) isSoftwareLabelScoped(ctx context.Context, softwareID, host
 				COUNT(lm.label_id) AS count_host_labels,
 				SUM(CASE
 				WHEN
-					lbl.created_at IS NOT NULL AND (SELECT label_updated_at FROM hosts WHERE id = :host_id) >= lbl.created_at THEN 1
+					lbl.created_at IS NOT NULL AND lbl.label_membership_type = 0 AND (SELECT label_updated_at FROM hosts WHERE id = :host_id) >= lbl.created_at THEN 1
+				WHEN 
+					lbl.created_at IS NOT NULL AND lbl.label_membership_type = 1 THEN 1
 				ELSE
 					0
 				END) as count_host_updated_after_labels
@@ -1840,21 +1842,14 @@ FROM (
 			COUNT(*) AS count_installer_labels,
 			COUNT(lm.label_id) AS count_host_labels,
 			SUM(
-				CASE WHEN lbl.created_at IS NOT NULL
-					AND(
-						SELECT
-							label_updated_at FROM hosts
-						WHERE
-							id = h.id) >= lbl.created_at THEN
-					1
-				ELSE
-					0
-				END) AS count_host_updated_after_labels
+				CASE 
+				WHEN lbl.created_at IS NOT NULL AND lbl.label_membership_type = 0 AND (SELECT label_updated_at FROM hosts WHERE id = h.id) >= lbl.created_at THEN 1
+				WHEN lbl.created_at IS NOT NULL AND lbl.label_membership_type = 1 THEN 1
+				ELSE 0 END) AS count_host_updated_after_labels
 		FROM
 			%[1]s_labels sil
 		LEFT OUTER JOIN labels lbl ON lbl.id = sil.label_id
-	LEFT OUTER JOIN label_membership lm ON lm.label_id = sil.label_id
-		AND lm.host_id = h.id
+		LEFT OUTER JOIN label_membership lm ON lm.label_id = sil.label_id AND lm.host_id = h.id
 WHERE
 	sil.%[1]s_id = ?
 	AND sil.exclude = 1

--- a/server/datastore/mysql/software_installers_test.go
+++ b/server/datastore/mysql/software_installers_test.go
@@ -753,18 +753,19 @@ func testBatchSetSoftwareInstallers(t *testing.T, ds *Datastore) {
 	tfr0, err := fleet.NewTempFileReader(ins0File, t.TempDir)
 	require.NoError(t, err)
 	err = ds.BatchSetSoftwareInstallers(ctx, &team.ID, []*fleet.UploadSoftwareInstallerPayload{{
-		InstallScript:   "install",
-		InstallerFile:   tfr0,
-		StorageID:       ins0,
-		Filename:        "installer0",
-		Title:           "ins0",
-		Source:          "apps",
-		Version:         "1",
-		PreInstallQuery: "foo",
-		UserID:          user1.ID,
-		Platform:        "darwin",
-		URL:             "https://example.com",
-		ValidatedLabels: &fleet.LabelIdentsWithScope{},
+		InstallScript:    "install",
+		InstallerFile:    tfr0,
+		StorageID:        ins0,
+		Filename:         "installer0",
+		Title:            "ins0",
+		Source:           "apps",
+		Version:          "1",
+		PreInstallQuery:  "foo",
+		UserID:           user1.ID,
+		Platform:         "darwin",
+		URL:              "https://example.com",
+		ValidatedLabels:  &fleet.LabelIdentsWithScope{},
+		BundleIdentifier: "com.example.ins0",
 	}})
 	require.NoError(t, err)
 	softwareInstallers, err = ds.GetSoftwareInstallers(ctx, team.ID)
@@ -948,6 +949,54 @@ func testBatchSetSoftwareInstallers(t *testing.T, ds *Datastore) {
 	require.Empty(t, softwareInstallers[0].URL)
 	assertSoftware([]fleet.SoftwareTitle{
 		{Name: ins1, Source: "apps", Browser: ""},
+	})
+
+	// Add software installer with same name different bundle id
+	err = ds.BatchSetSoftwareInstallers(ctx, &team.ID, []*fleet.UploadSoftwareInstallerPayload{{
+		InstallScript:    "install",
+		InstallerFile:    tfr0,
+		StorageID:        ins0,
+		Filename:         "installer0",
+		Title:            "ins0",
+		Source:           "apps",
+		Version:          "1",
+		PreInstallQuery:  "foo",
+		UserID:           user1.ID,
+		Platform:         "darwin",
+		URL:              "https://example.com",
+		ValidatedLabels:  &fleet.LabelIdentsWithScope{},
+		BundleIdentifier: "com.example.different.ins0",
+	}})
+	require.NoError(t, err)
+	softwareInstallers, err = ds.GetSoftwareInstallers(ctx, team.ID)
+	require.NoError(t, err)
+	require.Len(t, softwareInstallers, 1)
+	assertSoftware([]fleet.SoftwareTitle{
+		{Name: ins0, Source: "apps", Browser: "", BundleIdentifier: ptr.String("com.example.different.ins0")},
+	})
+
+	// Add software installer with the same bundle id but different name
+	err = ds.BatchSetSoftwareInstallers(ctx, &team.ID, []*fleet.UploadSoftwareInstallerPayload{{
+		InstallScript:    "install",
+		InstallerFile:    tfr0,
+		StorageID:        ins0,
+		Filename:         "installer0",
+		Title:            "ins0-different",
+		Source:           "apps",
+		Version:          "1",
+		PreInstallQuery:  "foo",
+		UserID:           user1.ID,
+		Platform:         "darwin",
+		URL:              "https://example.com",
+		ValidatedLabels:  &fleet.LabelIdentsWithScope{},
+		BundleIdentifier: "com.example.ins0",
+	}})
+	require.NoError(t, err)
+	softwareInstallers, err = ds.GetSoftwareInstallers(ctx, team.ID)
+	require.NoError(t, err)
+	require.Len(t, softwareInstallers, 1)
+	assertSoftware([]fleet.SoftwareTitle{
+		{Name: "ins0-different", Source: "apps", Browser: "", BundleIdentifier: ptr.String("com.example.ins0")},
 	})
 
 	// remove everything

--- a/server/datastore/mysql/software_test.go
+++ b/server/datastore/mysql/software_test.go
@@ -5609,7 +5609,7 @@ func testListHostSoftwareWithLabelScoping(t *testing.T, ds *Datastore) {
 	}
 
 	// Add a new label and apply it to the installer. There are no hosts with this label.
-	label4, err := ds.NewLabel(ctx, &fleet.Label{Name: "label4" + t.Name()})
+	label4, err := ds.NewLabel(ctx, &fleet.Label{Name: "label4" + t.Name(), LabelMembershipType: fleet.LabelMembershipTypeDynamic})
 	require.NoError(t, err)
 
 	err = setOrUpdateSoftwareInstallerLabelsDB(ctx, ds.writer(ctx), installerID3, fleet.LabelIdentsWithScope{
@@ -5629,6 +5629,11 @@ func testListHostSoftwareWithLabelScoping(t *testing.T, ds *Datastore) {
 	require.NoError(t, err)
 	require.True(t, scoped)
 
+	// TODO(JVE): dump labels table and check type
+	ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
+		DumpTable(t, q, "labels")
+		return nil
+	})
 	// installer3 is not in scope yet, because label is "exclude any" and host doesn't have results
 	scoped, err = ds.IsSoftwareInstallerLabelScoped(ctx, installerID3, host.ID)
 	require.NoError(t, err)

--- a/server/datastore/mysql/software_test.go
+++ b/server/datastore/mysql/software_test.go
@@ -5810,6 +5810,14 @@ func testListHostSoftwareWithLabelScopingVPP(t *testing.T, ds *Datastore) {
 	require.NoError(t, err)
 	checkSoftware(software, installer1.Filename)
 
+	hostsNotInScope, err := ds.GetExcludedHostIDMapForVPPApp(ctx, vppAppTeamID)
+	require.NoError(t, err)
+	require.Empty(t, hostsNotInScope)
+
+	hostsInScope, err := ds.GetIncludedHostIDMapForVPPApp(ctx, vppAppTeamID)
+	require.NoError(t, err)
+	require.Equal(t, map[uint]struct{}{host.ID: {}}, hostsInScope)
+
 	// Assign the label to the VPP app. Now we should have an empty list
 	err = setOrUpdateSoftwareInstallerLabelsDB(ctx, ds.writer(ctx), vppAppTeamID, fleet.LabelIdentsWithScope{
 		LabelScope: fleet.LabelScopeExcludeAny,
@@ -5820,6 +5828,14 @@ func testListHostSoftwareWithLabelScopingVPP(t *testing.T, ds *Datastore) {
 	software, _, err = ds.ListHostSoftware(ctx, host, opts)
 	require.NoError(t, err)
 	checkSoftware(software, installer1.Filename, vppApp.Name)
+
+	hostsNotInScope, err = ds.GetExcludedHostIDMapForVPPApp(ctx, vppAppTeamID)
+	require.NoError(t, err)
+	require.Equal(t, map[uint]struct{}{host.ID: {}}, hostsNotInScope)
+
+	hostsInScope, err = ds.GetIncludedHostIDMapForVPPApp(ctx, vppAppTeamID)
+	require.NoError(t, err)
+	require.Empty(t, hostsInScope)
 
 	// Make the label include any. We should have both of them back.
 	err = setOrUpdateSoftwareInstallerLabelsDB(ctx, ds.writer(ctx), installerID1, fleet.LabelIdentsWithScope{

--- a/server/datastore/mysql/vpp.go
+++ b/server/datastore/mysql/vpp.go
@@ -247,7 +247,7 @@ func (ds *Datastore) getExistingLabels(ctx context.Context, vppAppTeamID uint) (
 		return &labels, nil
 
 	case len(inclAny) > 0:
-		labels.LabelScope = fleet.LabelScopeExcludeAny
+		labels.LabelScope = fleet.LabelScopeIncludeAny
 		labels.ByName = make(map[string]fleet.LabelIdent, len(inclAny))
 		for _, l := range inclAny {
 			labels.ByName[l.LabelName] = fleet.LabelIdent{LabelName: l.LabelName, LabelID: l.LabelID}

--- a/server/datastore/mysql/vpp.go
+++ b/server/datastore/mysql/vpp.go
@@ -293,9 +293,11 @@ func (ds *Datastore) SetTeamVPPApps(ctx context.Context, teamID *uint, appFleets
 		}
 	}
 
+	appsWithChangedLabels := make(map[uint]map[uint]struct{})
 	for _, appFleet := range appFleets {
 		// upsert it if it does not exist or labels or SelfService or InstallDuringSetup flags are changed
 		existingApp, isExistingApp := existingApps[appFleet.VPPAppID]
+		appFleet.AppTeamID = existingApp.AppTeamID
 		var labelsChanged bool
 		if isExistingApp {
 			existingLabels, err := ds.getExistingLabels(ctx, appFleet.AppTeamID)
@@ -304,6 +306,17 @@ func (ds *Datastore) SetTeamVPPApps(ctx context.Context, teamID *uint, appFleets
 			}
 
 			labelsChanged = !existingLabels.Equal(appFleet.ValidatedLabels)
+
+		}
+
+		// Get the hosts that are NOT in label scope currently (before the update happens)
+		if labelsChanged {
+			hostsNotInScope, err := ds.GetExcludedHostIDMapForVPPApp(ctx, appFleet.AppTeamID)
+			if err != nil {
+				return ctxerr.Wrap(ctx, err, "getting hosts not in scope for vpp app")
+			}
+			appsWithChangedLabels[appFleet.AppTeamID] = hostsNotInScope
+
 		}
 
 		if !isExistingApp ||
@@ -336,6 +349,28 @@ func (ds *Datastore) SetTeamVPPApps(ctx context.Context, teamID *uint, appFleets
 					return ctxerr.Wrap(ctx, err, "failed to update labels on vpp apps batch operation")
 				}
 			}
+
+			if hostsNotInScope, ok := appsWithChangedLabels[toAdd.AppTeamID]; ok {
+				hostsInScope, err := ds.GetIncludedHostIDMapForVPPAppTx(ctx, tx, toAdd.AppTeamID)
+				if err != nil {
+					return ctxerr.Wrap(ctx, err, "getting hosts in scope for vpp app")
+				}
+
+				var hostsToClear []uint
+				for id := range hostsInScope {
+					if _, ok := hostsNotInScope[id]; ok {
+						// it was not in scope but now it is, so we should clear policy status
+						hostsToClear = append(hostsToClear, id)
+					}
+				}
+
+				// We clear the policy status here because otherwise the policy automation machinery
+				// won't pick this up and the software won't install.
+				if err := ds.ClearVPPAppAutoInstallPolicyStatusForHostsTx(ctx, tx, toAdd.AppTeamID, hostsToClear); err != nil {
+					return ctxerr.Wrap(ctx, err, "failed to clear auto install policy status for host")
+				}
+			}
+
 		}
 
 		for _, toRemove := range toRemoveApps {
@@ -410,7 +445,7 @@ func (ds *Datastore) GetVPPApps(ctx context.Context, teamID *uint) ([]fleet.VPPA
 func (ds *Datastore) GetAssignedVPPApps(ctx context.Context, teamID *uint) (map[fleet.VPPAppID]fleet.VPPAppTeam, error) {
 	stmt := `
 SELECT
-	adam_id, platform, self_service, install_during_setup
+	adam_id, platform, self_service, install_during_setup, id
 FROM
 	vpp_apps_teams vat
 WHERE
@@ -495,8 +530,8 @@ ON DUPLICATE KEY UPDATE
 	if insertOnDuplicateDidInsertOrUpdate(res) {
 		id, _ = res.LastInsertId()
 	} else {
-		stmt := `SELECT id FROM vpp_apps_teams WHERE adam_id = ? AND platform = ?`
-		if err := sqlx.GetContext(ctx, tx, &id, stmt, appID.AdamID, appID.Platform); err != nil {
+		stmt := `SELECT id FROM vpp_apps_teams WHERE adam_id = ? AND platform = ? AND global_or_team_id = ?`
+		if err := sqlx.GetContext(ctx, tx, &id, stmt, appID.AdamID, appID.Platform, globalOrTmID); err != nil {
 			return 0, ctxerr.Wrap(ctx, err, "vpp app teams id")
 		}
 	}
@@ -1469,4 +1504,16 @@ func checkVPPNullTeam(ctx context.Context, tx sqlx.ExtContext, currentID *uint, 
 	}
 
 	return nil
+}
+
+func (ds *Datastore) GetIncludedHostIDMapForVPPApp(ctx context.Context, vppAppTeamID uint) (map[uint]struct{}, error) {
+	return ds.getIncludedHostIDMapForSoftware(ctx, ds.writer(ctx), vppAppTeamID, softwareTypeVPP)
+}
+
+func (ds *Datastore) GetIncludedHostIDMapForVPPAppTx(ctx context.Context, tx sqlx.ExtContext, vppAppTeamID uint) (map[uint]struct{}, error) {
+	return ds.getIncludedHostIDMapForSoftware(ctx, tx, vppAppTeamID, softwareTypeVPP)
+}
+
+func (ds *Datastore) GetExcludedHostIDMapForVPPApp(ctx context.Context, vppAppTeamID uint) (map[uint]struct{}, error) {
+	return ds.getExcludedHostIDMapForSoftware(ctx, vppAppTeamID, softwareTypeVPP)
 }

--- a/server/datastore/mysql/vpp_test.go
+++ b/server/datastore/mysql/vpp_test.go
@@ -629,16 +629,29 @@ func testVPPApps(t *testing.T, ds *Datastore) {
 	// Check that getting the assigned apps works
 	appSet, err := ds.GetAssignedVPPApps(ctx, &team.ID)
 	require.NoError(t, err)
+	meta, err := ds.GetVPPAppMetadataByAdamIDPlatformTeamID(ctx, app1.AdamID, app1.Platform, &team.ID)
+	require.NoError(t, err)
+	appTeamID1 := meta.AppTeamID
+	meta, err = ds.GetVPPAppMetadataByAdamIDPlatformTeamID(ctx, app2.AdamID, app2.Platform, &team.ID)
+	require.NoError(t, err)
+	appTeamID2 := meta.AppTeamID
 	assert.Equal(t, map[fleet.VPPAppID]fleet.VPPAppTeam{
-		app1.VPPAppID: {VPPAppID: app1.VPPAppID, InstallDuringSetup: ptr.Bool(false)},
-		app2.VPPAppID: {VPPAppID: app2.VPPAppID, InstallDuringSetup: ptr.Bool(false)},
+		app1.VPPAppID: {VPPAppID: app1.VPPAppID, InstallDuringSetup: ptr.Bool(false), AppTeamID: appTeamID1},
+		app2.VPPAppID: {VPPAppID: app2.VPPAppID, InstallDuringSetup: ptr.Bool(false), AppTeamID: appTeamID2},
 	}, appSet)
 
 	appSet, err = ds.GetAssignedVPPApps(ctx, nil)
 	require.NoError(t, err)
+	meta, err = ds.GetVPPAppMetadataByAdamIDPlatformTeamID(ctx, appNoTeam1.AdamID, app1.Platform, nil)
+	require.NoError(t, err)
+	appTeamID1 = meta.AppTeamID
+	meta, err = ds.GetVPPAppMetadataByAdamIDPlatformTeamID(ctx, appNoTeam2.AdamID, app2.Platform, nil)
+	require.NoError(t, err)
+	appTeamID2 = meta.AppTeamID
+	require.NoError(t, err)
 	assert.Equal(t, map[fleet.VPPAppID]fleet.VPPAppTeam{
-		appNoTeam1.VPPAppID: {VPPAppID: appNoTeam1.VPPAppID, InstallDuringSetup: ptr.Bool(false)},
-		appNoTeam2.VPPAppID: {VPPAppID: appNoTeam2.VPPAppID, InstallDuringSetup: ptr.Bool(false)},
+		appNoTeam1.VPPAppID: {VPPAppID: appNoTeam1.VPPAppID, InstallDuringSetup: ptr.Bool(false), AppTeamID: appTeamID1},
+		appNoTeam2.VPPAppID: {VPPAppID: appNoTeam2.VPPAppID, InstallDuringSetup: ptr.Bool(false), AppTeamID: appTeamID2},
 	}, appSet)
 
 	var appTitles []fleet.SoftwareTitle

--- a/server/fleet/datastore.go
+++ b/server/fleet/datastore.go
@@ -1723,16 +1723,16 @@ type Datastore interface {
 	//
 
 	// GetIncludedHostIDMapForSoftwareInstaller gets the set of hosts that are targeted/in scope for the
-	// given software installer, based label membership.
+	// given software installer, based on label membership.
 	GetIncludedHostIDMapForSoftwareInstaller(ctx context.Context, installerID uint) (map[uint]struct{}, error)
 
 	// GetExcludedHostIDMapForSoftwareInstaller gets the set of hosts that are NOT targeted/in scope for the
-	// given software installer, based label membership.
+	// given software installer, based on label membership.
 	GetExcludedHostIDMapForSoftwareInstaller(ctx context.Context, installerID uint) (map[uint]struct{}, error)
 
-	// ClearAutoInstallPolicyStatusForHosts clears out the status of the policy related to the given
+	// ClearSoftwareInstallerAutoInstallPolicyStatusForHosts clears out the status of the policy related to the given
 	// software installer for all the given hosts.
-	ClearAutoInstallPolicyStatusForHosts(ctx context.Context, installerID uint, hostIDs []uint) error
+	ClearSoftwareInstallerAutoInstallPolicyStatusForHosts(ctx context.Context, installerID uint, hostIDs []uint) error
 
 	// GetSoftwareInstallDetails returns details required to fetch and
 	// run software installers
@@ -1836,6 +1836,18 @@ type Datastore interface {
 	GetPastActivityDataForVPPAppInstall(ctx context.Context, commandResults *mdm.CommandResults) (*User, *ActivityInstalledAppStoreApp, error)
 
 	GetVPPTokenByLocation(ctx context.Context, loc string) (*VPPTokenDB, error)
+
+	// GetIncludedHostIDMapForVPPApp gets the set of hosts that are targeted/in scope for the
+	// given VPP app, based on label membership.
+	GetIncludedHostIDMapForVPPApp(ctx context.Context, vppAppTeamID uint) (map[uint]struct{}, error)
+
+	// GetExcludedHostIDMapForVPPApp gets the set of hosts that are NOT targeted/in scope for the
+	// given VPP app, based on label membership.
+	GetExcludedHostIDMapForVPPApp(ctx context.Context, vppAppTeamID uint) (map[uint]struct{}, error)
+
+	// ClearVPPAppAutoInstallPolicyStatusForHosts clears out the status of the policy related to the given
+	// VPP app for all the given hosts.
+	ClearVPPAppAutoInstallPolicyStatusForHosts(ctx context.Context, vppAppTeamID uint, hostIDs []uint) error
 
 	////////////////////////////////////////////////////////////////////////////////////
 	// Setup Experience

--- a/server/mock/datastore_mock.go
+++ b/server/mock/datastore_mock.go
@@ -1093,7 +1093,7 @@ type GetIncludedHostIDMapForSoftwareInstallerFunc func(ctx context.Context, inst
 
 type GetExcludedHostIDMapForSoftwareInstallerFunc func(ctx context.Context, installerID uint) (map[uint]struct{}, error)
 
-type ClearAutoInstallPolicyStatusForHostsFunc func(ctx context.Context, installerID uint, hostIDs []uint) error
+type ClearSoftwareInstallerAutoInstallPolicyStatusForHostsFunc func(ctx context.Context, installerID uint, hostIDs []uint) error
 
 type GetSoftwareInstallDetailsFunc func(ctx context.Context, executionId string) (*fleet.SoftwareInstallDetails, error)
 
@@ -1162,6 +1162,12 @@ type InsertHostVPPSoftwareInstallFunc func(ctx context.Context, hostID uint, app
 type GetPastActivityDataForVPPAppInstallFunc func(ctx context.Context, commandResults *mdm.CommandResults) (*fleet.User, *fleet.ActivityInstalledAppStoreApp, error)
 
 type GetVPPTokenByLocationFunc func(ctx context.Context, loc string) (*fleet.VPPTokenDB, error)
+
+type GetIncludedHostIDMapForVPPAppFunc func(ctx context.Context, vppAppTeamID uint) (map[uint]struct{}, error)
+
+type GetExcludedHostIDMapForVPPAppFunc func(ctx context.Context, vppAppTeamID uint) (map[uint]struct{}, error)
+
+type ClearVPPAppAutoInstallPolicyStatusForHostsFunc func(ctx context.Context, vppAppTeamID uint, hostIDs []uint) error
 
 type SetSetupExperienceSoftwareTitlesFunc func(ctx context.Context, teamID uint, titleIDs []uint) error
 
@@ -2822,8 +2828,8 @@ type DataStore struct {
 	GetExcludedHostIDMapForSoftwareInstallerFunc        GetExcludedHostIDMapForSoftwareInstallerFunc
 	GetExcludedHostIDMapForSoftwareInstallerFuncInvoked bool
 
-	ClearAutoInstallPolicyStatusForHostsFunc        ClearAutoInstallPolicyStatusForHostsFunc
-	ClearAutoInstallPolicyStatusForHostsFuncInvoked bool
+	ClearSoftwareInstallerAutoInstallPolicyStatusForHostsFunc        ClearSoftwareInstallerAutoInstallPolicyStatusForHostsFunc
+	ClearSoftwareInstallerAutoInstallPolicyStatusForHostsFuncInvoked bool
 
 	GetSoftwareInstallDetailsFunc        GetSoftwareInstallDetailsFunc
 	GetSoftwareInstallDetailsFuncInvoked bool
@@ -2926,6 +2932,15 @@ type DataStore struct {
 
 	GetVPPTokenByLocationFunc        GetVPPTokenByLocationFunc
 	GetVPPTokenByLocationFuncInvoked bool
+
+	GetIncludedHostIDMapForVPPAppFunc        GetIncludedHostIDMapForVPPAppFunc
+	GetIncludedHostIDMapForVPPAppFuncInvoked bool
+
+	GetExcludedHostIDMapForVPPAppFunc        GetExcludedHostIDMapForVPPAppFunc
+	GetExcludedHostIDMapForVPPAppFuncInvoked bool
+
+	ClearVPPAppAutoInstallPolicyStatusForHostsFunc        ClearVPPAppAutoInstallPolicyStatusForHostsFunc
+	ClearVPPAppAutoInstallPolicyStatusForHostsFuncInvoked bool
 
 	SetSetupExperienceSoftwareTitlesFunc        SetSetupExperienceSoftwareTitlesFunc
 	SetSetupExperienceSoftwareTitlesFuncInvoked bool
@@ -6757,11 +6772,11 @@ func (s *DataStore) GetExcludedHostIDMapForSoftwareInstaller(ctx context.Context
 	return s.GetExcludedHostIDMapForSoftwareInstallerFunc(ctx, installerID)
 }
 
-func (s *DataStore) ClearAutoInstallPolicyStatusForHosts(ctx context.Context, installerID uint, hostIDs []uint) error {
+func (s *DataStore) ClearSoftwareInstallerAutoInstallPolicyStatusForHosts(ctx context.Context, installerID uint, hostIDs []uint) error {
 	s.mu.Lock()
-	s.ClearAutoInstallPolicyStatusForHostsFuncInvoked = true
+	s.ClearSoftwareInstallerAutoInstallPolicyStatusForHostsFuncInvoked = true
 	s.mu.Unlock()
-	return s.ClearAutoInstallPolicyStatusForHostsFunc(ctx, installerID, hostIDs)
+	return s.ClearSoftwareInstallerAutoInstallPolicyStatusForHostsFunc(ctx, installerID, hostIDs)
 }
 
 func (s *DataStore) GetSoftwareInstallDetails(ctx context.Context, executionId string) (*fleet.SoftwareInstallDetails, error) {
@@ -7000,6 +7015,27 @@ func (s *DataStore) GetVPPTokenByLocation(ctx context.Context, loc string) (*fle
 	s.GetVPPTokenByLocationFuncInvoked = true
 	s.mu.Unlock()
 	return s.GetVPPTokenByLocationFunc(ctx, loc)
+}
+
+func (s *DataStore) GetIncludedHostIDMapForVPPApp(ctx context.Context, vppAppTeamID uint) (map[uint]struct{}, error) {
+	s.mu.Lock()
+	s.GetIncludedHostIDMapForVPPAppFuncInvoked = true
+	s.mu.Unlock()
+	return s.GetIncludedHostIDMapForVPPAppFunc(ctx, vppAppTeamID)
+}
+
+func (s *DataStore) GetExcludedHostIDMapForVPPApp(ctx context.Context, vppAppTeamID uint) (map[uint]struct{}, error) {
+	s.mu.Lock()
+	s.GetExcludedHostIDMapForVPPAppFuncInvoked = true
+	s.mu.Unlock()
+	return s.GetExcludedHostIDMapForVPPAppFunc(ctx, vppAppTeamID)
+}
+
+func (s *DataStore) ClearVPPAppAutoInstallPolicyStatusForHosts(ctx context.Context, vppAppTeamID uint, hostIDs []uint) error {
+	s.mu.Lock()
+	s.ClearVPPAppAutoInstallPolicyStatusForHostsFuncInvoked = true
+	s.mu.Unlock()
+	return s.ClearVPPAppAutoInstallPolicyStatusForHostsFunc(ctx, vppAppTeamID, hostIDs)
 }
 
 func (s *DataStore) SetSetupExperienceSoftwareTitles(ctx context.Context, teamID uint, titleIDs []uint) error {

--- a/server/service/integration_mdm_profiles_test.go
+++ b/server/service/integration_mdm_profiles_test.go
@@ -3017,13 +3017,13 @@ func (s *integrationMDMTestSuite) TestMDMConfigProfileCRUD() {
 	// identifier must be unique, it conflicts with existing declaration
 	assertAppleDeclaration("apple-declaration.json", "test-declaration-ident", 0, nil, http.StatusConflict, "test-declaration-ident already exists")
 	// name is pulled from filename, it conflicts with existing declaration
-	assertAppleDeclaration("apple-declaration.json", "test-declaration-ident-2", 0, nil, http.StatusConflict, "apple-declaration already exists")
+	assertAppleDeclaration("apple-declaration.json", "test-declaration-ident-2", 0, nil, http.StatusConflict, SameProfileNameUploadErrorMsg)
 	// uniqueness is checked only within team, so it's fine to have the same name and identifier in different teams
 	assertAppleDeclaration("apple-declaration.json", "test-declaration-ident", testTeam.ID, nil, http.StatusOK, "")
 	// name is pulled from filename, it conflicts with existing macOS config profile
-	assertAppleDeclaration("apple-global-profile.json", "test-declaration-ident-2", 0, nil, http.StatusConflict, "apple-global-profile already exists")
+	assertAppleDeclaration("apple-global-profile.json", "test-declaration-ident-2", 0, nil, http.StatusConflict, SameProfileNameUploadErrorMsg)
 	// name is pulled from filename, it conflicts with existing macOS config profile
-	assertAppleDeclaration("win-global-profile.json", "test-declaration-ident-2", 0, nil, http.StatusConflict, "win-global-profile already exists")
+	assertAppleDeclaration("win-global-profile.json", "test-declaration-ident-2", 0, nil, http.StatusConflict, SameProfileNameUploadErrorMsg)
 	// windows profile name conflicts with existing declaration
 	assertWindowsProfile("apple-declaration.xml", "./Test", 0, nil, http.StatusConflict, SameProfileNameUploadErrorMsg)
 	// macOS profile name conflicts with existing declaration

--- a/server/service/integration_mdm_test.go
+++ b/server/service/integration_mdm_test.go
@@ -11183,6 +11183,102 @@ func (s *integrationMDMTestSuite) TestVPPApps() {
 		s.lastActivityMatches(fleet.ActivityDeletedAppStoreApp{}.ActivityName(),
 			fmt.Sprintf(activityData, team.Name,
 				excludeAnyApp.Name, excludeAnyApp.AdamID, team.ID, excludeAnyApp.Platform, l2.ID, l2.Name), 0)
+
+		// iOS and iPadOS
+
+		iOSApp := fleet.VPPApp{
+			VPPAppTeam: fleet.VPPAppTeam{
+				VPPAppID: fleet.VPPAppID{
+					AdamID:   "2",
+					Platform: fleet.IOSPlatform,
+				},
+			},
+			Name:             "App 2",
+			BundleIdentifier: "b-2",
+			IconURL:          "https://example.com/images/2",
+			LatestVersion:    "2.0.0",
+		}
+
+		iPadOSApp := fleet.VPPApp{
+			VPPAppTeam: fleet.VPPAppTeam{
+				VPPAppID: fleet.VPPAppID{
+					AdamID:   "2",
+					Platform: fleet.IPadOSPlatform,
+				},
+			},
+			Name:             "App 2",
+			BundleIdentifier: "b-2",
+			IconURL:          "https://example.com/images/2",
+			LatestVersion:    "2.0.0",
+		}
+
+		testCases := []struct {
+			desc      string
+			app       fleet.VPPApp
+			addAppReq *addAppStoreAppRequest
+		}{
+			{
+				desc: "ios device",
+				app:  iOSApp,
+				addAppReq: &addAppStoreAppRequest{
+					TeamID:           &team.ID,
+					AppStoreID:       iOSApp.AdamID,
+					LabelsIncludeAny: []string{l2.Name},
+					Platform:         iOSApp.Platform,
+				},
+			},
+
+			{
+				desc: "ipados device",
+				app:  iPadOSApp,
+				addAppReq: &addAppStoreAppRequest{
+					TeamID:           &team.ID,
+					AppStoreID:       iPadOSApp.AdamID,
+					LabelsIncludeAny: []string{l2.Name},
+					Platform:         iPadOSApp.Platform,
+				},
+			},
+		}
+		for _, tc := range testCases {
+			t.Run(tc.desc, func(t *testing.T) {
+				mobileHost, mobileMDMDevice := s.createAppleMobileHostThenEnrollMDM(string(tc.app.Platform))
+				s.Do("POST", "/api/latest/fleet/hosts/transfer", &addHostsToTeamRequest{HostIDs: []uint{mobileHost.ID}, TeamID: &team.ID}, http.StatusOK)
+
+				s.Do("POST", "/api/latest/fleet/software/app_store_apps", tc.addAppReq, http.StatusOK)
+				titleID = getSoftwareTitleIDFromApp(&tc.app)
+				s.appleVPPConfigSrvConfig.SerialNumbers = append(s.appleVPPConfigSrvConfig.SerialNumbers, mobileMDMDevice.SerialNumber)
+
+				// Should fail because label is include_any and the host doesn't have it
+				res = s.Do("POST", fmt.Sprintf("/api/latest/fleet/hosts/%d/software/%d/install", mobileHost.ID, titleID), &installSoftwareRequest{}, http.StatusBadRequest)
+				require.Contains(t, extractServerErrorText(res.Body), "Couldn't install. This host isn't a member of the labels defined for this software title.")
+
+				// Create a new label
+				s.DoJSON("POST", "/api/latest/fleet/labels", &fleet.LabelPayload{Name: "label3" + t.Name(), Hosts: []string{mobileMDMDevice.SerialNumber}}, http.StatusOK, &createLabelResp)
+				l3 := createLabelResp.Label
+				require.NotNil(t, l3)
+
+				// Should fail because label is exclude_any and the host does have it
+				updateAppReq = &updateAppStoreAppRequest{TeamID: &team.ID, LabelsExcludeAny: []string{l3.Name}}
+				s.DoJSON("PATCH", fmt.Sprintf("/api/latest/fleet/software/titles/%d/app_store_app", titleID), updateAppReq, http.StatusOK, &updateAppResp)
+				res = s.Do("POST", fmt.Sprintf("/api/latest/fleet/hosts/%d/software/%d/install", mobileHost.ID, titleID), &installSoftwareRequest{}, http.StatusBadRequest)
+				require.Contains(t, extractServerErrorText(res.Body), "Couldn't install. This host isn't a member of the labels defined for this software title.")
+
+				// Should succeed because the label is include_any and the host does have it
+				updateAppReq = &updateAppStoreAppRequest{TeamID: &team.ID, LabelsIncludeAny: []string{l3.Name}}
+				s.DoJSON("PATCH", fmt.Sprintf("/api/latest/fleet/software/titles/%d/app_store_app", titleID), updateAppReq, http.StatusOK, &updateAppResp)
+				s.Do("POST", fmt.Sprintf("/api/latest/fleet/hosts/%d/software/%d/install", mobileHost.ID, titleID), &installSoftwareRequest{}, http.StatusAccepted)
+
+				// Create a new host
+				mobileHost, mobileMDMDevice = s.createAppleMobileHostThenEnrollMDM(string(tc.app.Platform))
+				s.Do("POST", "/api/latest/fleet/hosts/transfer", &addHostsToTeamRequest{HostIDs: []uint{mobileHost.ID}, TeamID: &team.ID}, http.StatusOK)
+				s.appleVPPConfigSrvConfig.SerialNumbers = append(s.appleVPPConfigSrvConfig.SerialNumbers, mobileMDMDevice.SerialNumber)
+
+				// Should succeed because the label is exclude_any and the iOS host doesn't have it
+				updateAppReq = &updateAppStoreAppRequest{TeamID: &team.ID, LabelsExcludeAny: []string{l3.Name}}
+				s.DoJSON("PATCH", fmt.Sprintf("/api/latest/fleet/software/titles/%d/app_store_app", titleID), updateAppReq, http.StatusOK, &updateAppResp)
+				s.Do("POST", fmt.Sprintf("/api/latest/fleet/hosts/%d/software/%d/install", mobileHost.ID, titleID), &installSoftwareRequest{}, http.StatusAccepted)
+			})
+		}
 	})
 
 	// Create a team

--- a/server/service/integration_mdm_test.go
+++ b/server/service/integration_mdm_test.go
@@ -10570,11 +10570,14 @@ func (s *integrationMDMTestSuite) TestBatchAssociateAppStoreApps() {
 	assert.Contains(t, assoc, fleet.VPPAppID{AdamID: s.appleVPPConfigSrvConfig.Assets[0].AdamID, Platform: fleet.MacOSPlatform})
 	assert.Contains(t, assoc, fleet.VPPAppID{AdamID: s.appleVPPConfigSrvConfig.Assets[1].AdamID, Platform: fleet.IOSPlatform})
 	assert.Contains(t, assoc, fleet.VPPAppID{AdamID: s.appleVPPConfigSrvConfig.Assets[1].AdamID, Platform: fleet.IPadOSPlatform})
+	meta, err := s.ds.GetVPPAppMetadataByAdamIDPlatformTeamID(ctx, s.appleVPPConfigSrvConfig.Assets[1].AdamID, fleet.MacOSPlatform, &tmGood.ID)
+	require.NoError(t, err)
 	// Only macOS version should be self-service
 	assert.Equal(t, fleet.VPPAppTeam{
 		VPPAppID:           fleet.VPPAppID{AdamID: s.appleVPPConfigSrvConfig.Assets[1].AdamID, Platform: fleet.MacOSPlatform},
 		SelfService:        true,
 		InstallDuringSetup: ptr.Bool(false),
+		AppTeamID:          meta.AppTeamID,
 	},
 		assoc[fleet.VPPAppID{AdamID: s.appleVPPConfigSrvConfig.Assets[1].AdamID, Platform: fleet.MacOSPlatform}])
 
@@ -10593,22 +10596,34 @@ func (s *integrationMDMTestSuite) TestBatchAssociateAppStoreApps() {
 	assoc, err = s.ds.GetAssignedVPPApps(ctx, &tmGood.ID)
 	require.NoError(t, err)
 	require.Len(t, assoc, 4)
+	meta, err = s.ds.GetVPPAppMetadataByAdamIDPlatformTeamID(ctx, s.appleVPPConfigSrvConfig.Assets[0].AdamID, fleet.MacOSPlatform, &tmGood.ID)
+	require.NoError(t, err)
 	assert.Equal(t, fleet.VPPAppTeam{
 		VPPAppID:           fleet.VPPAppID{AdamID: s.appleVPPConfigSrvConfig.Assets[0].AdamID, Platform: fleet.MacOSPlatform},
 		SelfService:        true,
 		InstallDuringSetup: ptr.Bool(false),
+		AppTeamID:          meta.AppTeamID,
 	}, assoc[fleet.VPPAppID{AdamID: s.appleVPPConfigSrvConfig.Assets[0].AdamID, Platform: fleet.MacOSPlatform}])
+	meta, err = s.ds.GetVPPAppMetadataByAdamIDPlatformTeamID(ctx, s.appleVPPConfigSrvConfig.Assets[1].AdamID, fleet.IOSPlatform, &tmGood.ID)
+	require.NoError(t, err)
 	assert.Equal(t, fleet.VPPAppTeam{
 		VPPAppID:           fleet.VPPAppID{AdamID: s.appleVPPConfigSrvConfig.Assets[1].AdamID, Platform: fleet.IOSPlatform},
 		InstallDuringSetup: ptr.Bool(false),
+		AppTeamID:          meta.AppTeamID,
 	}, assoc[fleet.VPPAppID{AdamID: s.appleVPPConfigSrvConfig.Assets[1].AdamID, Platform: fleet.IOSPlatform}])
+	meta, err = s.ds.GetVPPAppMetadataByAdamIDPlatformTeamID(ctx, s.appleVPPConfigSrvConfig.Assets[1].AdamID, fleet.IPadOSPlatform, &tmGood.ID)
+	require.NoError(t, err)
 	assert.Equal(t, fleet.VPPAppTeam{
 		VPPAppID:           fleet.VPPAppID{AdamID: s.appleVPPConfigSrvConfig.Assets[1].AdamID, Platform: fleet.IPadOSPlatform},
 		InstallDuringSetup: ptr.Bool(false),
+		AppTeamID:          meta.AppTeamID,
 	}, assoc[fleet.VPPAppID{AdamID: s.appleVPPConfigSrvConfig.Assets[1].AdamID, Platform: fleet.IPadOSPlatform}])
+	meta, err = s.ds.GetVPPAppMetadataByAdamIDPlatformTeamID(ctx, s.appleVPPConfigSrvConfig.Assets[1].AdamID, fleet.MacOSPlatform, &tmGood.ID)
+	require.NoError(t, err)
 	assert.Equal(t, fleet.VPPAppTeam{
 		VPPAppID:           fleet.VPPAppID{AdamID: s.appleVPPConfigSrvConfig.Assets[1].AdamID, Platform: fleet.MacOSPlatform},
 		InstallDuringSetup: ptr.Bool(false),
+		AppTeamID:          meta.AppTeamID,
 	}, assoc[fleet.VPPAppID{AdamID: s.appleVPPConfigSrvConfig.Assets[1].AdamID, Platform: fleet.MacOSPlatform}])
 
 	// Associate an app with a team with no team members
@@ -13281,4 +13296,240 @@ func (s *integrationMDMTestSuite) TestHostsCantTurnMDMOff() {
 	winHost, _ := createWindowsHostThenEnrollMDM(s.ds, s.server.URL, t)
 	r = s.Do("DELETE", fmt.Sprintf("/api/latest/fleet/hosts/%d/mdm", winHost.ID), nil, http.StatusBadRequest)
 	require.Contains(t, extractServerErrorText(r.Body), fleet.CantTurnOffMDMForWindowsHostsMessage)
+}
+
+func (s *integrationMDMTestSuite) TestVPPPolicyAutomationLabelScopingRetrigger() {
+	t := s.T()
+	ctx := context.Background()
+	batchURL := "/api/latest/fleet/software/app_store_apps/batch"
+
+	// Set up VPP token
+	orgName := "Fleet Device Management Inc."
+	token := "mycooltoken"
+	expTime := time.Now().Add(200 * time.Hour).UTC().Round(time.Second)
+	expDate := expTime.Format(fleet.VPPTimeFormat)
+	tokenJSON := fmt.Sprintf(`{"expDate":"%s","token":"%s","orgName":"%s"}`, expDate, token, orgName)
+	t.Setenv("FLEET_DEV_VPP_URL", s.appleVPPConfigSrv.URL)
+	var validToken uploadVPPTokenResponse
+	s.uploadDataViaForm("/api/latest/fleet/vpp_tokens", "token", "token.vpptoken", []byte(base64.StdEncoding.EncodeToString([]byte(tokenJSON))), http.StatusAccepted, "", &validToken)
+
+	// Get the token
+	var resp getVPPTokensResponse
+	s.DoJSON("GET", "/api/latest/fleet/vpp_tokens", &getVPPTokensRequest{}, http.StatusOK, &resp)
+	require.NoError(t, resp.Err)
+
+	// Create a team
+	var newTeamResp teamResponse
+	s.DoJSON("POST", "/api/latest/fleet/teams", &createTeamRequest{TeamPayload: fleet.TeamPayload{Name: ptr.String("Team 1")}}, http.StatusOK, &newTeamResp)
+	team := newTeamResp.Team
+
+	// Create a host and add to team
+	host, _ := createHostThenEnrollMDM(s.ds, s.server.URL, t)
+	nodeKey := setOrbitEnrollment(t, host, s.ds)
+	host.OrbitNodeKey = &nodeKey
+	s.Do("POST", "/api/latest/fleet/hosts/transfer", &addHostsToTeamRequest{HostIDs: []uint{host.ID}, TeamID: &team.ID}, http.StatusOK)
+
+	s.appleVPPConfigSrvConfig.SerialNumbers = append(s.appleVPPConfigSrvConfig.SerialNumbers, host.HardwareSerial)
+
+	// Associate team to the VPP token.
+	var resPatchVPP patchVPPTokensTeamsResponse
+	s.DoJSON("PATCH", fmt.Sprintf("/api/latest/fleet/vpp_tokens/%d/teams", resp.Tokens[0].ID), patchVPPTokensTeamsRequest{TeamIDs: []uint{team.ID}}, http.StatusOK, &resPatchVPP)
+
+	// Create a few labels
+	var newLabelResp createLabelResponse
+	s.DoJSON("POST", "/api/v1/fleet/labels", fleet.LabelPayload{
+		Name:  uuid.NewString(),
+		Query: "SELECT 1",
+	}, http.StatusOK, &newLabelResp)
+	label1 := newLabelResp.Label
+
+	newLabelResp = createLabelResponse{}
+	s.DoJSON("POST", "/api/v1/fleet/labels", fleet.LabelPayload{
+		Name:  uuid.NewString(),
+		Query: "SELECT 2",
+	}, http.StatusOK, &newLabelResp)
+	label2 := newLabelResp.Label
+
+	newLabelResp = createLabelResponse{}
+	s.DoJSON("POST", "/api/v1/fleet/labels", fleet.LabelPayload{
+		Name:  uuid.NewString(),
+		Query: "SELECT 3",
+	}, http.StatusOK, &newLabelResp)
+	label3 := newLabelResp.Label
+
+	// Sleep to guarantee that host label updated at timestamp is greater than the label creation timestamps
+	time.Sleep(1 * time.Second)
+
+	// Add label1 and label2 to the host
+	host.LabelUpdatedAt = time.Now()
+	err := s.ds.RecordLabelQueryExecutions(context.Background(), host, map[uint]*bool{label1.ID: ptr.Bool(true), label2.ID: ptr.Bool(true)}, host.LabelUpdatedAt, false)
+	require.NoError(t, err)
+
+	// add VPP app. Add label1 and label3 as "exclude any" labels.
+	var appResp getAppStoreAppsResponse
+	s.DoJSON("GET", "/api/latest/fleet/software/app_store_apps", &getAppStoreAppsRequest{}, http.StatusOK, &appResp, "team_id",
+		fmt.Sprint(team.ID))
+	require.NoError(t, appResp.Err)
+	addedApp := appResp.AppStoreApps[0]
+	var addedMacOSApp addAppStoreAppResponse
+	s.DoJSON("POST", "/api/latest/fleet/software/app_store_apps", &addAppStoreAppRequest{
+		TeamID:           &team.ID,
+		Platform:         addedApp.Platform,
+		AppStoreID:       addedApp.AdamID,
+		SelfService:      true,
+		LabelsExcludeAny: []string{label1.Name, label3.Name},
+	}, http.StatusOK, &addedMacOSApp)
+
+	// Get software title ID of the added VPP app
+	listSWTitlesResp := listSoftwareTitlesResponse{}
+	s.DoJSON(
+		"GET", "/api/latest/fleet/software/titles",
+		listSoftwareTitlesRequest{},
+		http.StatusOK, &listSWTitlesResp,
+		"query", addedApp.Name,
+		"team_id", fmt.Sprintf("%d", team.ID),
+	)
+	require.Len(t, listSWTitlesResp.SoftwareTitles, 1)
+	require.NotNil(t, listSWTitlesResp.SoftwareTitles[0].AppStoreApp)
+	vppAppTitleID := listSWTitlesResp.SoftwareTitles[0].ID
+
+	var vppAppDetail getSoftwareTitleResponse
+	s.DoJSON("GET", fmt.Sprintf("/api/latest/fleet/software/titles/%d", vppAppTitleID), nil, http.StatusOK, &vppAppDetail, "team_id", fmt.Sprintf("%d", team.ID))
+	require.NotNil(t, vppAppDetail.SoftwareTitle)
+	require.NotNil(t, vppAppDetail.SoftwareTitle.AppStoreApp)
+
+	policy1, err := s.ds.NewTeamPolicy(ctx, team.ID, nil, fleet.PolicyPayload{
+		Name:     "policy1",
+		Query:    "SELECT 1;",
+		Platform: "darwin",
+	})
+	require.NoError(t, err)
+
+	mtplr := modifyTeamPolicyResponse{}
+	s.DoJSON("PATCH", fmt.Sprintf("/api/latest/fleet/teams/%d/policies/%d", team.ID, policy1.ID), modifyTeamPolicyRequest{
+		ModifyPolicyPayload: fleet.ModifyPolicyPayload{
+			SoftwareTitleID: optjson.Any[uint]{Set: true, Valid: true, Value: vppAppTitleID},
+		},
+	}, http.StatusOK, &mtplr)
+
+	// Send back a failed result for the policy.
+	distributedResp := submitDistributedQueryResultsResponse{}
+	s.DoJSONWithoutAuth("POST", "/api/osquery/distributed/write", genDistributedReqWithPolicyResults(
+		host,
+		map[uint]*bool{
+			policy1.ID: ptr.Bool(false),
+		},
+	), http.StatusOK, &distributedResp)
+	err = s.ds.UpdateHostPolicyCounts(ctx)
+	require.NoError(t, err)
+	policy1, err = s.ds.Policy(ctx, policy1.ID)
+	require.NoError(t, err)
+
+	// Note: host has label1, label2, and at this point the app has exclude_any: label1, label3
+	// Because the VPP app is out of scope, the policy doesn't have a status
+	require.Equal(t, uint(0), policy1.PassingHostCount)
+	require.Equal(t, uint(0), policy1.FailingHostCount)
+
+	// Update the include any labels. The host has label2, so this means that the software
+	// moved in scope.
+	updateAppReq := &updateAppStoreAppRequest{TeamID: &team.ID, SelfService: false, LabelsIncludeAny: []string{label2.Name}}
+	s.Do("PATCH", fmt.Sprintf("/api/latest/fleet/software/titles/%d/app_store_app", vppAppTitleID), updateAppReq, http.StatusOK)
+
+	// Send back a failed result for the policy.
+	distributedResp = submitDistributedQueryResultsResponse{}
+	s.DoJSONWithoutAuth("POST", "/api/osquery/distributed/write", genDistributedReqWithPolicyResults(
+		host,
+		map[uint]*bool{
+			policy1.ID: ptr.Bool(false),
+		},
+	), http.StatusOK, &distributedResp)
+	err = s.ds.UpdateHostPolicyCounts(ctx)
+	require.NoError(t, err)
+	policy1, err = s.ds.Policy(ctx, policy1.ID)
+	require.NoError(t, err)
+
+	// Note: host has label1, label2, and at this point the app has include_any: label2
+	// Because the VPP app is in scope, the policy is failing
+	require.Equal(t, uint(0), policy1.PassingHostCount)
+	require.Equal(t, uint(1), policy1.FailingHostCount)
+
+	// Update to exclude_any: label 2. This moves the software out of scope. The policy is still failing.
+	updateAppReq = &updateAppStoreAppRequest{TeamID: &team.ID, SelfService: false, LabelsExcludeAny: []string{label2.Name}}
+	s.Do("PATCH", fmt.Sprintf("/api/latest/fleet/software/titles/%d/app_store_app", vppAppTitleID), updateAppReq, http.StatusOK)
+
+	err = s.ds.UpdateHostPolicyCounts(ctx)
+	require.NoError(t, err)
+	policy1, err = s.ds.Policy(ctx, policy1.ID)
+	require.NoError(t, err)
+	require.Equal(t, uint(0), policy1.PassingHostCount)
+	require.Equal(t, uint(1), policy1.FailingHostCount)
+
+	// Update to exclude_any: label3. Host has label1, label2, so the app is in scope again and
+	// status should clear.
+
+	var batchAssociateResponse batchAssociateAppStoreAppsResponse
+	s.DoJSON("POST", batchURL, batchAssociateAppStoreAppsRequest{Apps: []fleet.VPPBatchPayload{
+		{AppStoreID: addedApp.AdamID, LabelsExcludeAny: []string{label3.Name}},
+	}}, http.StatusOK, &batchAssociateResponse, "team_name", team.Name)
+	require.Len(t, batchAssociateResponse.Apps, 1)
+
+	err = s.ds.UpdateHostPolicyCounts(ctx)
+	require.NoError(t, err)
+	policy1, err = s.ds.Policy(ctx, policy1.ID)
+	require.NoError(t, err)
+	require.Equal(t, uint(0), policy1.PassingHostCount)
+	require.Equal(t, uint(0), policy1.FailingHostCount)
+
+	// Sending back another failed response
+	s.DoJSONWithoutAuth("POST", "/api/osquery/distributed/write", genDistributedReqWithPolicyResults(
+		host,
+		map[uint]*bool{
+			policy1.ID: ptr.Bool(false),
+		},
+	), http.StatusOK, &distributedResp)
+	err = s.ds.UpdateHostPolicyCounts(ctx)
+	require.NoError(t, err)
+	policy1, err = s.ds.Policy(ctx, policy1.ID)
+	require.NoError(t, err)
+	// Because the app is in scope, the policy should be failing again.
+	require.Equal(t, uint(0), policy1.PassingHostCount)
+	require.Equal(t, uint(1), policy1.FailingHostCount)
+
+	// Update to exclude_any: label 2. This moves the software out of scope. The policy is still failing.
+	updateAppReq = &updateAppStoreAppRequest{TeamID: &team.ID, SelfService: false, LabelsExcludeAny: []string{label2.Name}}
+	s.Do("PATCH", fmt.Sprintf("/api/latest/fleet/software/titles/%d/app_store_app", vppAppTitleID), updateAppReq, http.StatusOK)
+
+	err = s.ds.UpdateHostPolicyCounts(ctx)
+	require.NoError(t, err)
+	policy1, err = s.ds.Policy(ctx, policy1.ID)
+	require.NoError(t, err)
+	require.Equal(t, uint(0), policy1.PassingHostCount)
+	require.Equal(t, uint(1), policy1.FailingHostCount)
+
+	// Update to exclude_any: label3. Host has label1, label2, so the app is in scope again and
+	// status should clear.
+	updateAppReq = &updateAppStoreAppRequest{TeamID: &team.ID, SelfService: false, LabelsExcludeAny: []string{label3.Name}}
+	s.Do("PATCH", fmt.Sprintf("/api/latest/fleet/software/titles/%d/app_store_app", vppAppTitleID), updateAppReq, http.StatusOK)
+
+	err = s.ds.UpdateHostPolicyCounts(ctx)
+	require.NoError(t, err)
+	policy1, err = s.ds.Policy(ctx, policy1.ID)
+	require.NoError(t, err)
+	require.Equal(t, uint(0), policy1.PassingHostCount)
+	require.Equal(t, uint(0), policy1.FailingHostCount)
+
+	// Sending back another failed response
+	s.DoJSONWithoutAuth("POST", "/api/osquery/distributed/write", genDistributedReqWithPolicyResults(
+		host,
+		map[uint]*bool{
+			policy1.ID: ptr.Bool(false),
+		},
+	), http.StatusOK, &distributedResp)
+	err = s.ds.UpdateHostPolicyCounts(ctx)
+	require.NoError(t, err)
+	policy1, err = s.ds.Policy(ctx, policy1.ID)
+	require.NoError(t, err)
+	// Because the app is in scope, the policy should be failing again.
+	require.Equal(t, uint(0), policy1.PassingHostCount)
+	require.Equal(t, uint(1), policy1.FailingHostCount)
 }

--- a/server/service/mdm.go
+++ b/server/service/mdm.go
@@ -1320,6 +1320,12 @@ func newMDMConfigProfileEndpoint(ctx context.Context, request interface{}, svc f
 		if isJSON {
 			decl, err := svc.NewMDMAppleDeclaration(ctx, req.TeamID, ff, labels, profileName, labelsMode)
 			if err != nil {
+				errStr := err.Error()
+				if strings.Contains(errStr, "MDMAppleDeclaration.Name") && strings.Contains(errStr, "already exists") {
+					return &newMDMConfigProfileResponse{
+						Err: fleet.NewInvalidArgumentError("profile name", SameProfileNameUploadErrorMsg).WithStatus(http.StatusConflict),
+					}, nil
+				}
 				return &newMDMConfigProfileResponse{Err: err}, nil
 			}
 

--- a/server/vulnerabilities/nvd/cpe_test.go
+++ b/server/vulnerabilities/nvd/cpe_test.go
@@ -1343,6 +1343,15 @@ func TestCPEFromSoftwareIntegration(t *testing.T) {
 		},
 		{
 			software: fleet.Software{
+				Name:    "IntelliJ IDEA Community Edition 2022.3.2",
+				Source:  "programs",
+				Version: "223.8617.56",
+				Vendor:  "",
+			},
+			cpe: "cpe:2.3:a:jetbrains:intellij_idea:223.8617.56:*:*:*:*:windows:*:*",
+		},
+		{
+			software: fleet.Software{
 				Name:             "IntelliJ IDEA.app",
 				Source:           "apps",
 				Version:          "2022.3.3",

--- a/server/vulnerabilities/nvd/cpe_translations.json
+++ b/server/vulnerabilities/nvd/cpe_translations.json
@@ -171,6 +171,16 @@
   },
   {
     "software": {
+      "name": ["/^IntelliJ IDEA Community Edition/"],
+      "source": ["programs"]
+    },
+    "filter": {
+      "product": ["intellij_idea"],
+      "vendor": ["jetbrains"]
+    }
+  },
+  {
+    "software": {
       "bundle_identifier": ["/^com\\.jetbrains\\.pycharm/"],
       "source": ["apps"]
     },

--- a/terraform/addons/vuln-processing/variables.tf
+++ b/terraform/addons/vuln-processing/variables.tf
@@ -24,7 +24,7 @@ variable "fleet_config" {
     vuln_processing_cpu                  = optional(number, 2048)
     vuln_data_stream_mem                 = optional(number, 1024)
     vuln_data_stream_cpu                 = optional(number, 512)
-    image                                = optional(string, "fleetdm/fleet:v4.62.3")
+    image                                = optional(string, "fleetdm/fleet:v4.63.0")
     family                               = optional(string, "fleet-vuln-processing")
     sidecars                             = optional(list(any), [])
     extra_environment_variables          = optional(map(string), {})
@@ -82,7 +82,7 @@ variable "fleet_config" {
     vuln_processing_cpu                  = 2048
     vuln_data_stream_mem                 = 1024
     vuln_data_stream_cpu                 = 512
-    image                                = "fleetdm/fleet:v4.62.3"
+    image                                = "fleetdm/fleet:v4.63.0"
     family                               = "fleet-vuln-processing"
     sidecars                             = []
     extra_environment_variables          = {}

--- a/terraform/addons/vuln-processing/variables.tf
+++ b/terraform/addons/vuln-processing/variables.tf
@@ -24,7 +24,7 @@ variable "fleet_config" {
     vuln_processing_cpu                  = optional(number, 2048)
     vuln_data_stream_mem                 = optional(number, 1024)
     vuln_data_stream_cpu                 = optional(number, 512)
-    image                                = optional(string, "fleetdm/fleet:v4.63.0")
+    image                                = optional(string, "fleetdm/fleet:v4.64.0")
     family                               = optional(string, "fleet-vuln-processing")
     sidecars                             = optional(list(any), [])
     extra_environment_variables          = optional(map(string), {})
@@ -82,7 +82,7 @@ variable "fleet_config" {
     vuln_processing_cpu                  = 2048
     vuln_data_stream_mem                 = 1024
     vuln_data_stream_cpu                 = 512
-    image                                = "fleetdm/fleet:v4.63.0"
+    image                                = "fleetdm/fleet:v4.64.0"
     family                               = "fleet-vuln-processing"
     sidecars                             = []
     extra_environment_variables          = {}

--- a/terraform/byo-vpc/byo-db/byo-ecs/variables.tf
+++ b/terraform/byo-vpc/byo-db/byo-ecs/variables.tf
@@ -16,7 +16,7 @@ variable "fleet_config" {
     mem                          = optional(number, 4096)
     cpu                          = optional(number, 512)
     pid_mode                     = optional(string, null)
-    image                        = optional(string, "fleetdm/fleet:v4.62.3")
+    image                        = optional(string, "fleetdm/fleet:v4.63.0")
     family                       = optional(string, "fleet")
     sidecars                     = optional(list(any), [])
     depends_on                   = optional(list(any), [])
@@ -119,7 +119,7 @@ variable "fleet_config" {
     mem                          = 512
     cpu                          = 256
     pid_mode                     = null
-    image                        = "fleetdm/fleet:v4.62.3"
+    image                        = "fleetdm/fleet:v4.63.0"
     family                       = "fleet"
     sidecars                     = []
     depends_on                   = []

--- a/terraform/byo-vpc/byo-db/byo-ecs/variables.tf
+++ b/terraform/byo-vpc/byo-db/byo-ecs/variables.tf
@@ -16,7 +16,7 @@ variable "fleet_config" {
     mem                          = optional(number, 4096)
     cpu                          = optional(number, 512)
     pid_mode                     = optional(string, null)
-    image                        = optional(string, "fleetdm/fleet:v4.63.0")
+    image                        = optional(string, "fleetdm/fleet:v4.64.0")
     family                       = optional(string, "fleet")
     sidecars                     = optional(list(any), [])
     depends_on                   = optional(list(any), [])
@@ -119,7 +119,7 @@ variable "fleet_config" {
     mem                          = 512
     cpu                          = 256
     pid_mode                     = null
-    image                        = "fleetdm/fleet:v4.63.0"
+    image                        = "fleetdm/fleet:v4.64.0"
     family                       = "fleet"
     sidecars                     = []
     depends_on                   = []

--- a/terraform/byo-vpc/byo-db/variables.tf
+++ b/terraform/byo-vpc/byo-db/variables.tf
@@ -77,7 +77,7 @@ variable "fleet_config" {
     mem                          = optional(number, 4096)
     cpu                          = optional(number, 512)
     pid_mode                     = optional(string, null)
-    image                        = optional(string, "fleetdm/fleet:v4.62.3")
+    image                        = optional(string, "fleetdm/fleet:v4.63.0")
     family                       = optional(string, "fleet")
     sidecars                     = optional(list(any), [])
     depends_on                   = optional(list(any), [])
@@ -205,7 +205,7 @@ variable "fleet_config" {
     mem                          = 512
     cpu                          = 256
     pid_mode                     = null
-    image                        = "fleetdm/fleet:v4.62.3"
+    image                        = "fleetdm/fleet:v4.63.0"
     family                       = "fleet"
     sidecars                     = []
     depends_on                   = []

--- a/terraform/byo-vpc/byo-db/variables.tf
+++ b/terraform/byo-vpc/byo-db/variables.tf
@@ -77,7 +77,7 @@ variable "fleet_config" {
     mem                          = optional(number, 4096)
     cpu                          = optional(number, 512)
     pid_mode                     = optional(string, null)
-    image                        = optional(string, "fleetdm/fleet:v4.63.0")
+    image                        = optional(string, "fleetdm/fleet:v4.64.0")
     family                       = optional(string, "fleet")
     sidecars                     = optional(list(any), [])
     depends_on                   = optional(list(any), [])
@@ -205,7 +205,7 @@ variable "fleet_config" {
     mem                          = 512
     cpu                          = 256
     pid_mode                     = null
-    image                        = "fleetdm/fleet:v4.63.0"
+    image                        = "fleetdm/fleet:v4.64.0"
     family                       = "fleet"
     sidecars                     = []
     depends_on                   = []

--- a/terraform/byo-vpc/example/main.tf
+++ b/terraform/byo-vpc/example/main.tf
@@ -17,7 +17,7 @@ provider "aws" {
 }
 
 locals {
-  fleet_image = "fleetdm/fleet:v4.62.3"
+  fleet_image = "fleetdm/fleet:v4.63.0"
   domain_name = "example.com"
 }
 

--- a/terraform/byo-vpc/variables.tf
+++ b/terraform/byo-vpc/variables.tf
@@ -170,7 +170,7 @@ variable "fleet_config" {
     mem                          = optional(number, 4096)
     cpu                          = optional(number, 512)
     pid_mode                     = optional(string, null)
-    image                        = optional(string, "fleetdm/fleet:v4.62.3")
+    image                        = optional(string, "fleetdm/fleet:v4.63.0")
     family                       = optional(string, "fleet")
     sidecars                     = optional(list(any), [])
     depends_on                   = optional(list(any), [])
@@ -298,7 +298,7 @@ variable "fleet_config" {
     mem                          = 512
     cpu                          = 256
     pid_mode                     = null
-    image                        = "fleetdm/fleet:v4.62.3"
+    image                        = "fleetdm/fleet:v4.63.0"
     family                       = "fleet"
     sidecars                     = []
     depends_on                   = []

--- a/terraform/byo-vpc/variables.tf
+++ b/terraform/byo-vpc/variables.tf
@@ -170,7 +170,7 @@ variable "fleet_config" {
     mem                          = optional(number, 4096)
     cpu                          = optional(number, 512)
     pid_mode                     = optional(string, null)
-    image                        = optional(string, "fleetdm/fleet:v4.63.0")
+    image                        = optional(string, "fleetdm/fleet:v4.64.0")
     family                       = optional(string, "fleet")
     sidecars                     = optional(list(any), [])
     depends_on                   = optional(list(any), [])
@@ -298,7 +298,7 @@ variable "fleet_config" {
     mem                          = 512
     cpu                          = 256
     pid_mode                     = null
-    image                        = "fleetdm/fleet:v4.63.0"
+    image                        = "fleetdm/fleet:v4.64.0"
     family                       = "fleet"
     sidecars                     = []
     depends_on                   = []

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -218,7 +218,7 @@ variable "fleet_config" {
     mem                          = optional(number, 4096)
     cpu                          = optional(number, 512)
     pid_mode                     = optional(string, null)
-    image                        = optional(string, "fleetdm/fleet:v4.62.3")
+    image                        = optional(string, "fleetdm/fleet:v4.63.0")
     family                       = optional(string, "fleet")
     sidecars                     = optional(list(any), [])
     depends_on                   = optional(list(any), [])
@@ -346,7 +346,7 @@ variable "fleet_config" {
     mem                          = 512
     cpu                          = 256
     pid_mode                     = null
-    image                        = "fleetdm/fleet:v4.62.3"
+    image                        = "fleetdm/fleet:v4.63.0"
     family                       = "fleet"
     sidecars                     = []
     depends_on                   = []

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -218,7 +218,7 @@ variable "fleet_config" {
     mem                          = optional(number, 4096)
     cpu                          = optional(number, 512)
     pid_mode                     = optional(string, null)
-    image                        = optional(string, "fleetdm/fleet:v4.63.0")
+    image                        = optional(string, "fleetdm/fleet:v4.64.0")
     family                       = optional(string, "fleet")
     sidecars                     = optional(list(any), [])
     depends_on                   = optional(list(any), [])
@@ -346,7 +346,7 @@ variable "fleet_config" {
     mem                          = 512
     cpu                          = 256
     pid_mode                     = null
-    image                        = "fleetdm/fleet:v4.63.0"
+    image                        = "fleetdm/fleet:v4.64.0"
     family                       = "fleet"
     sidecars                     = []
     depends_on                   = []

--- a/tools/fleetctl-npm/package.json
+++ b/tools/fleetctl-npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fleetctl",
-  "version": "v4.63.0",
+  "version": "v4.64.0",
   "description": "Installer for the fleetctl CLI tool",
   "bin": {
     "fleetctl": "./run.js"

--- a/tools/fleetctl-npm/package.json
+++ b/tools/fleetctl-npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fleetctl",
-  "version": "v4.62.3",
+  "version": "v4.63.0",
   "description": "Installer for the fleetctl CLI tool",
   "bin": {
     "fleetctl": "./run.js"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6131,9 +6131,9 @@ electron-to-chromium@^1.5.73:
   integrity sha512-LcUDPqSt+V0QmI47XLzZrz5OqILSMGsPFkDYus22rIbgorSvBYEFqq854ltTmUdHkY92FSdAAvsh4jWEULMdfQ==
 
 elliptic@^6.5.3, elliptic@^6.5.4:
-  version "6.6.0"
-  resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-6.6.0.tgz#5919ec723286c1edf28685aa89261d4761afa210"
-  integrity sha512-dpwoQcLc/2WLQvJvLRHKZ+f9FgOdjnq11rurqwekGQygGPsYSK29OMMD2WalatiqQ+XGFDglTNixpPfI+lpaAA==
+  version "6.6.1"
+  resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-6.6.1.tgz#3b8ffb02670bf69e382c7f65bf524c97c5405c06"
+  integrity sha512-RaddvvMatK2LJHqFJ+YA4WysVN5Ita9E35botqIYspQ4TkRAlCicdzKOjlyv/1Za5RyTNn7di//eEV0uTAfe3g==
   dependencies:
     bn.js "^4.11.9"
     brorand "^1.1.0"


### PR DESCRIPTION
- **Adding changes for Fleet v4.63.0 (#25433) (#26039)**
- **For R.C. - 23116 unreleased bug (#26050) (#26069)**
- **Cherry pick 23835 to 4.64.0 (#26053)**
- **For R.C. - Fleet UI: Unreleased bug side effect fix (#26085)**
- **For R.C. - Fleet UI: Unreleased tooltip bugs (#26111) (#26132)**
- **For R.C. - Fleet UI: Unreleased darwin rendering instead of macOS (#26139) (#26141)**
- **To RC: 2 follow-ups for 23312 (#26159)**
- **add error message for ddm profiles same name upload (#26129) (#26174)**
- **fix: generate docs in rc branch (#26172)**
- **fix: clear auto install policy statuses for vpp app scope changes (#26121) (#26167)**
- **For R.C. - Fleet UI: Unreleased selected option bug (#26217) (#26235)**
- **Fix goreleaser CI (#26267)**
- **Cherry-Pick: Updated BatchSetSoftwareInstallers to use bundle_identifier (#26268)**
- **Cherry-Pick: Add CPE translation mapping for IntelliJ CE for Windows (#26116)**
- **fix: exclude any label edge case for VPP apps (#26289) (#26303)**
- **fix: make sure going from include to exclude labels in gitops works (#26302) (#26311)**
- **For R.C. - Fleet UI: Add missing custom install vpp help text (Unreleased) (#26299) (#26301)**
- **Bump elliptic from 6.6.0 to 6.6.1 (#26344) (#26363)**
- **Adding changes for Fleet v4.64.0 (#26033)**
- **Add architecture to fleetctl archive for Linux**
