### PR TITLE
[API design] App Store apps (VPP): create policies for automatic install

### DIFF
--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -9104,38 +9104,24 @@ Returns information about the specified software. By default, `versions` are sor
     "id": 12,
     "name": "Falcon.app",
     "bundle_identifier": "crowdstrike.falcon.Agent",
-    "software_package": {
-      "name": "FalconSensor-6.44.pkg",
-      "version": "6.44",
-      "installer_id": 23,
-      "team_id": 3,
-      "uploaded_at": "2024-04-01T14:22:58Z",
-      "install_script": "sudo installer -pkg '$INSTALLER_PATH' -target /",
-      "pre_install_query": "SELECT 1 FROM macos_profiles WHERE uuid='c9f4f0d5-8426-4eb8-b61b-27c543c9d3db';",
-      "post_install_script": "sudo /Applications/Falcon.app/Contents/Resources/falconctl license 0123456789ABCDEFGHIJKLMNOPQRSTUV-WX",
-      "uninstall_script": "/Library/CS/falconctl uninstall",
-      "self_service": true,
-      "labels_include_any": [
-        {
-          "name": "Engineering",
-          "id": 294
-        }
-      ],
-      "automatic_install_policies": [
-        {
-          "id": 343,
-          "name": "[Install software] Crowdstrike Agent",
-        }
-      ],
+    "software_package": null,
+    "app_store_app": {
+      "app_store_id": "409183694",
+      "platform": "darwin",
+      "name": "Keynote",
+      "latest_version": "14.3",
+      "icon_url": "https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/64/f0/ae/64f0ae83-d1c5-cb3a-7f3f-df0c1dccb142/AppIcon-0-0-85-220-0-0-4-0-0-2x-0-0-0-0-0.png/512x512bb.png",
       "status": {
-        "installed": 3,
-        "pending_install": 1,
-        "failed_install": 0,
-        "pending_uninstall": 2,
-        "failed_uninstall": 1
-      }
+        "installed": 0,
+        "pending": 0,
+        "failed": 0
+      },
+      "self_service": true,
+      "automatic_install_policies": null,
+      "labels_include_any": null,
+      "labels_exclude_any": null,
+      "created_at": "2024-11-03T22:39:36Z"
     },
-    "app_store_app": null,
     "counts_updated_at": "2024-11-03T22:39:36Z",
     "source": "apps",
     "browser": "",


### PR DESCRIPTION
UPDATE: @noahtalerman: Opened a fresh PR here: https://github.com/fleetdm/fleet/pull/26449

---

DONT merge yet. Still TODO is add another example response.

- Additional API changes for the following user story:
  - #23744
- Note that the only API change is adding a new `created_at` timestamp. There are more changes in this PR to encompass an entire example response for an App Store (VPP).
- Other API changes are covered in a separate PR here: https://github.com/fleetdm/fleet/pull/25976


