### PR TITLE
Fix issues related to architecture-namespaced binaries

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -99,12 +99,14 @@ archives:
   - id: fleetctl
     builds:
       - fleetctl
+    # Note -- changing this can break GitOps and other workflows that expect these filenames to be deterministic!
     name_template: fleetctl_v{{.Version}}_{{- if eq .Os "darwin" }}macos{{- else }}{{ .Os }}_{{.Arch}}{{ end }}
     wrap_in_directory: true
 
   - id: fleetctl-zip
     builds:
       - fleetctl
+    # Note -- changing this can break GitOps and other workflows that expect these filenames to be deterministic!
     name_template: fleetctl_v{{.Version}}_{{- if eq .Os "darwin" }}macos{{- else }}{{ .Os }}_{{.Arch}}{{ end }}
     format: zip
     wrap_in_directory: true

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -99,13 +99,13 @@ archives:
   - id: fleetctl
     builds:
       - fleetctl
-    name_template: fleetctl_v{{.Version}}_{{- if eq .Os "darwin" }}macos{{- else }}{{ .Os }}{{ end }}_{{.Arch}}
+    name_template: fleetctl_v{{.Version}}_{{- if eq .Os "darwin" }}macos{{- else }}{{ .Os }}_{{.Arch}}{{ end }}
     wrap_in_directory: true
 
   - id: fleetctl-zip
     builds:
       - fleetctl
-    name_template: fleetctl_v{{.Version}}_{{- if eq .Os "darwin" }}macos{{- else }}{{ .Os }}{{ end }}_{{.Arch}}
+    name_template: fleetctl_v{{.Version}}_{{- if eq .Os "darwin" }}macos{{- else }}{{ .Os }}_{{.Arch}}{{ end }}
     format: zip
     wrap_in_directory: true
 

--- a/tools/fleetctl-npm/run.js
+++ b/tools/fleetctl-npm/run.js
@@ -30,7 +30,7 @@ const platform = (() => {
     case "Windows_NT":
       return `windows_${arch}`;
     case "Linux":
-      return `linux_${arch}`;
+      return `linux_${arch === "arm64" ? "arm64" : "amd64"}`;
     case "Darwin":
       return "macos";
     default:

--- a/tools/fleetctl-npm/run.js
+++ b/tools/fleetctl-npm/run.js
@@ -28,7 +28,7 @@ const installDir = join(binDir, strippedVersion);
 const platform = (() => {
   switch (type()) {
     case "Windows_NT":
-      return `windows_${arch}`;
+      return `windows_${arch === "arm64" ? "arm64" : "amd64"}`;
     case "Linux":
       return `linux_${arch === "arm64" ? "arm64" : "amd64"}`;
     case "Darwin":

--- a/tools/fleetctl-npm/run.js
+++ b/tools/fleetctl-npm/run.js
@@ -5,6 +5,7 @@ const { spawnSync } = require("child_process");
 const { existsSync, mkdirSync } = require("fs");
 const { type } = require("os");
 const { join } = require("path");
+const { arch } = require("process");
 
 const axios = require("axios");
 const { rimrafSync } = require("rimraf");
@@ -27,9 +28,9 @@ const installDir = join(binDir, strippedVersion);
 const platform = (() => {
   switch (type()) {
     case "Windows_NT":
-      return "windows";
+      return `windows_${arch}`;
     case "Linux":
-      return "linux";
+      return `linux_${arch}`;
     case "Darwin":
       return "macos";
     default:

--- a/website/assets/resources/install-fleetctl.sh
+++ b/website/assets/resources/install-fleetctl.sh
@@ -30,7 +30,15 @@ OS="$(uname -s)"
 # Determine architecture (x86_64 or arm64)
 ARCH="$(uname -m)"
 # Standardize x86_64 to amd64
-if [ $ARCH != "arm64" ]; then ARCH="amd64"; fi
+if [[ $ARCH != "arm64" &&
+      $ARCH != "aarch64" &&
+      $ARCH != "aarch64_be" &&
+      $ARCH != "armv8b" &&
+      $ARCH != "armv8l"
+    ]];
+then
+  ARCH="amd64";
+fi
 
 # Standardize OS name for file download
 case "${OS}" in

--- a/website/assets/resources/install-fleetctl.sh
+++ b/website/assets/resources/install-fleetctl.sh
@@ -26,9 +26,10 @@ version_gt() {
 
 # Determine operating system (Linux or MacOS)
 OS="$(uname -s)"
+ARCH="$(uname -m)"
 
 case "${OS}" in
-    Linux*)     OS='linux' OS_DISPLAY_NAME='Linux';;
+    Linux*)     OS="linux_${ARCH}" OS_DISPLAY_NAME='Linux';;
     Darwin*)    OS='macos' OS_DISPLAY_NAME='macOS';;
     *)          echo "Unsupported operating system: ${OS}"; exit 1;;
 esac

--- a/website/assets/resources/install-fleetctl.sh
+++ b/website/assets/resources/install-fleetctl.sh
@@ -26,8 +26,13 @@ version_gt() {
 
 # Determine operating system (Linux or MacOS)
 OS="$(uname -s)"
-ARCH="$(uname -m)"
 
+# Determine architecture (x86_64 or arm64)
+ARCH="$(uname -m)"
+# Standardize x86_64 to amd64
+if [ $ARCH != "arm64" ]; then ARCH="amd64"; fi
+
+# Standardize OS name for file download
 case "${OS}" in
     Linux*)     OS="linux_${ARCH}" OS_DISPLAY_NAME='Linux';;
     Darwin*)    OS='macos' OS_DISPLAY_NAME='macOS';;


### PR DESCRIPTION
For #26496
This PR fixes a couple of issues introduced when we started releasing separate amd64 and arm64 versions of our windows and linux binaries:

* Adds the architecture string to the download url in the fleetctl npm package
* Updates the goreleaser templates to only add the architecture to non-macos (i.e. windows and linux) packages
* Updates the script that the website uses to download fleetctl

I did a weak test of the fleetctl npm installer by hardcoding what was returned for my system type and at least verified that the download url worked.  Doing some more checks on VMs now.