### PR TITLE
API Docs: Add sort params to host certificates endpoints

### DIFF
--- a/docs/Contributing/API-for-contributors.md
+++ b/docs/Contributing/API-for-contributors.md
@@ -3207,6 +3207,8 @@ Lists the certificates installed on the current device.
 | token | string | path | The device's authentication token. |
 | page | integer | query | Page number of the results to fetch.|
 | per_page | integer | query | Results per page.|
+| order_key | string | query | What to order results by. Options include `common_name` and `not_valid_after`. Default is `common_name`. |
+| order_direction | string | query | **Requires `order_key`**. The direction of the order given the order key. Options include `asc` and `desc`. Default is `asc`. |
 
 ##### Example
 

--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -4150,6 +4150,8 @@ Retrieves the certificates installed on a host.
 | id   | integer | path | **Required**. The host's id. |
 | page | integer | query | Page number of the results to fetch.|
 | per_page | integer | query | Results per page.|
+| order_key | string | query | What to order results by. Options include `common_name` and `not_valid_after`. Default is `common_name` |
+| order_direction | string | query | **Requires `order_key`**. The direction of the order given the order key. Options include `asc` and `desc`. Default is `asc`. |
 
 #### Example
 


### PR DESCRIPTION
For #23235 

Figma original specified client-side sort when certs were included in host details response. Now that host certs are standalone endpoints, we need to include server-side sort on the paginated results.