### PR TITLE
Update ubuntu-20.04 to ubuntu-22.04 on CI actions due to deprecation

### DIFF
--- a/.github/workflows/fleetctl-preview.yml
+++ b/.github/workflows/fleetctl-preview.yml
@@ -23,7 +23,7 @@ jobs:
         #   - Linux Docker containers are not supported in Windows.
         #   - Unattended installation of Docker on macOS fails. (see
         #   https://github.com/docker/for-mac/issues/6450)
-        os: [ubuntu-20.04, ubuntu-22.04]
+        os: ubuntu-22.04
     runs-on: ${{ matrix.os }}
     steps:
 

--- a/.github/workflows/goreleaser-orbit.yaml
+++ b/.github/workflows/goreleaser-orbit.yaml
@@ -78,7 +78,7 @@ jobs:
           path: dist/orbit-macos_darwin_all/orbit
 
   goreleaser-linux:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     permissions:
       contents: write
       id-token: write
@@ -120,7 +120,7 @@ jobs:
           path: dist/orbit_linux_amd64_v1/orbit
 
   goreleaser-linux-arm64:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     permissions:
       contents: write
       id-token: write

--- a/.github/workflows/goreleaser-snapshot-fleet.yaml
+++ b/.github/workflows/goreleaser-snapshot-fleet.yaml
@@ -37,7 +37,7 @@ jobs:
     #
     # Also not run if author is dependabot (it doesn't have access to Github secrets).
     if: ${{ (github.repository == 'fleetdm/fleet') && (github.actor != 'dependabot[bot]') }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     environment: Docker Hub
     steps:
       - name: Harden Runner

--- a/.github/workflows/pr-helm.yaml
+++ b/.github/workflows/pr-helm.yaml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       matrix:
         kube-version: [1.16.0, 1.17.0, 1.18.0] # kubeval is currently lagging behind the active schema versions, so these are the ones we can test against. see https://github.com/instrumenta/kubernetes-json-schema/issues/26
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - name: Harden Runner
       uses: step-security/harden-runner@63c24ba6bd7ba022e95695ff85de572c04a18142 # v2.7.0

--- a/.github/workflows/release-helm.yaml
+++ b/.github/workflows/release-helm.yaml
@@ -22,7 +22,7 @@ jobs:
   publish-chart:
     permissions:
       contents: write  # to push helm charts
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - name: Harden Runner
       uses: step-security/harden-runner@63c24ba6bd7ba022e95695ff85de572c04a18142 # v2.7.0


### PR DESCRIPTION
> We will soon start the deprecation process for Ubuntu 20.04. While the image is being deprecated, you may experience longer queue times during peak usage hours. Deprecation will begin on 2025-02-01 and the image will be fully unsupported by 2025-04-01.

From https://github.com/actions/runner-images/issues/11101.

![Screenshot 2025-02-19 at 4 39 10 PM](https://github.com/user-attachments/assets/803e8ed3-31b0-4221-9d29-446a0d305567)
