### PR TITLE
Enable disk encryption for "Compliance exclusions"

### DIFF
--- a/it-and-security/teams/compliance-exclusions.yml
+++ b/it-and-security/teams/compliance-exclusions.yml
@@ -28,6 +28,7 @@ agent_options:
     orbit: edge
     desktop: edge
 controls:
+  enable_disk_encryption: true
 policies:
 queries:
 software:


### PR DESCRIPTION
- @noahtalerman: I'm using a test Windows computer to write a guide about disk encryption keys (more info [here](https://github.com/fleetdm/confidential/issues/9031)). This Windows computer isn't used for work so we want to add it to our "Compliance exclusions" team so it doesn't show up in Vanta compliance reports.
