### PR TITLE
Fleet UI: Update hover and focus states for dropdowns and inputfields

### DIFF
--- a/frontend/components/buttons/DropdownButton/_styles.scss
+++ b/frontend/components/buttons/DropdownButton/_styles.scss
@@ -19,7 +19,7 @@
     padding: 0;
     margin: 0;
     display: none;
-    z-index: 2;
+    z-index: 99;
     border-radius: 2px;
     background-color: $core-white;
     box-shadow: 0 4px 10px rgba(52, 59, 96, 0.15);

--- a/frontend/components/forms/fields/Dropdown/_styles.scss
+++ b/frontend/components/forms/fields/Dropdown/_styles.scss
@@ -67,7 +67,7 @@
 
     &:hover:not(.is-disabled) {
       box-shadow: none;
-      border-color: $core-vibrant-blue;
+      border-color: $core-vibrant-blue-over;
     }
   }
 
@@ -135,16 +135,9 @@
     }
   }
 
-  &.is-focused {
+  &.is-focused:not(.is-disabled) {
     &.dropdown__select {
-      border: 1px solid $core-vibrant-blue;
-    }
-
-    &:not(.is-open) {
-      .Select-control {
-        box-shadow: none;
-        border-color: $core-vibrant-blue;
-      }
+      border: 1px solid $core-vibrant-blue-down;
     }
   }
 

--- a/frontend/components/forms/fields/DropdownWrapper/DropdownWrapper.tsx
+++ b/frontend/components/forms/fields/DropdownWrapper/DropdownWrapper.tsx
@@ -244,12 +244,25 @@ const DropdownWrapper = ({
               stroke: COLORS["core-vibrant-blue-over"],
             },
           },
-          "&.react-select__control--is-focused": {
+          ".react-select__control--is-focused": {
             backgroundColor: "rgba(25, 33, 71, 0.05)",
+            boxShadow: "none",
+            ".dropdown-wrapper__placeholder": {
+              color: COLORS["core-vibrant-blue-down"],
+            },
+            ".dropdown-wrapper__indicator path": {
+              stroke: COLORS["core-vibrant-blue-down"],
+            },
           },
-          "&:active .dropdown-wrapper__indicator path": {
-            stroke: COLORS["core-vibrant-blue-down"],
-          },
+          ...(state.isFocused && {
+            backgroundColor: "rgba(25, 33, 71, 0.05)",
+            ".dropdown-wrapper__placeholder": {
+              color: COLORS["core-vibrant-blue-down"],
+            },
+            ".dropdown-wrapper__indicator path": {
+              stroke: COLORS["core-vibrant-blue-down"],
+            },
+          }),
           // TODO: Figure out a way to apply separate &:focus-visible styling
           // Currently only relying on &:focus styling for tabbing through app
           ...(state.menuIsOpen && {
@@ -277,7 +290,7 @@ const DropdownWrapper = ({
           : COLORS["ui-fleet-black-10"],
         "&:hover": {
           boxShadow: "none",
-          borderColor: COLORS["core-fleet-blue"],
+          borderColor: COLORS["core-vibrant-blue-over"],
           ".dropdown-wrapper__single-value": {
             color: COLORS["core-vibrant-blue-over"],
           },
@@ -292,12 +305,23 @@ const DropdownWrapper = ({
         // Relies on --is-focused for styling as &:focus-visible cannot be applied
         "&.react-select__control--is-focused": {
           ".dropdown-wrapper__single-value": {
-            color: COLORS["core-vibrant-blue-over"],
+            color: COLORS["core-vibrant-blue-down"],
           },
           ".dropdown-wrapper__indicator path": {
-            stroke: COLORS["core-vibrant-blue-over"],
+            stroke: COLORS["core-vibrant-blue-down"],
+          },
+          ".filter-icon path": {
+            fill: COLORS["core-vibrant-blue-down"],
           },
         },
+        ...(state.isFocused && {
+          ".dropdown-wrapper__placeholder": {
+            color: COLORS["core-vibrant-blue-down"],
+          },
+          ".dropdown-wrapper__indicator path": {
+            stroke: COLORS["core-vibrant-blue-down"],
+          },
+        }),
         ...(state.isDisabled && {
           ".dropdown-wrapper__single-value": {
             color: COLORS["ui-fleet-black-50"],

--- a/frontend/components/forms/fields/DropdownWrapper/DropdownWrapper.tsx
+++ b/frontend/components/forms/fields/DropdownWrapper/DropdownWrapper.tsx
@@ -304,9 +304,7 @@ const DropdownWrapper = ({
         // When tabbing
         // Relies on --is-focused for styling as &:focus-visible cannot be applied
         "&.react-select__control--is-focused": {
-          ".dropdown-wrapper__single-value": {
-            color: COLORS["core-vibrant-blue-down"],
-          },
+          borderColor: COLORS["core-vibrant-blue-down"],
           ".dropdown-wrapper__indicator path": {
             stroke: COLORS["core-vibrant-blue-down"],
           },

--- a/frontend/components/forms/fields/InputField/InputField.stories.jsx
+++ b/frontend/components/forms/fields/InputField/InputField.stories.jsx
@@ -1,23 +1,126 @@
+import React from "react";
 import InputField from ".";
 
-const meta = {
+export default {
   component: InputField,
   title: "Components/FormFields/InputField",
-};
-
-export default meta;
-
-export const Basic = {};
-
-export const WithCopyEnabled = {
-  args: {
-    enableCopy: true,
+  argTypes: {
+    type: {
+      control: "select",
+      options: ["text", "password", "email", "number", "textarea"],
+    },
+    value: {
+      control: "text",
+    },
+    placeholder: {
+      control: "text",
+    },
+    label: {
+      control: "text",
+    },
+    error: {
+      control: "text",
+    },
+    helpText: {
+      control: "text",
+    },
+    disabled: {
+      control: "boolean",
+    },
+    readOnly: {
+      control: "boolean",
+    },
+    autofocus: {
+      control: "boolean",
+    },
+    enableCopy: {
+      control: "boolean",
+    },
+    copyButtonPosition: {
+      control: "radio",
+      options: ["inside", "outside"],
+    },
   },
 };
 
-export const WithCopyEnabledInsideInput = {
-  args: {
-    enableCopy: true,
-    copyButtonPosition: "inside",
-  },
+const Template = (args) => <InputField {...args} />;
+
+export const Basic = Template.bind({});
+Basic.args = {
+  name: "basic-input",
+  label: "Basic Input",
+  value: "",
+  placeholder: "Enter text here",
+};
+
+export const WithValue = Template.bind({});
+WithValue.args = {
+  ...Basic.args,
+  value: "Sample text",
+};
+
+export const WithError = Template.bind({});
+WithError.args = {
+  ...Basic.args,
+  error: "This field is required",
+};
+
+export const Disabled = Template.bind({});
+Disabled.args = {
+  ...Basic.args,
+  disabled: true,
+};
+
+export const ReadOnly = Template.bind({});
+ReadOnly.args = {
+  ...Basic.args,
+  readOnly: true,
+  value: "Read-only content",
+};
+
+export const WithHelpText = Template.bind({});
+WithHelpText.args = {
+  ...Basic.args,
+  helpText: "This is some helpful information about the input field.",
+};
+
+export const Password = Template.bind({});
+Password.args = {
+  ...Basic.args,
+  type: "password",
+  label: "Password",
+  placeholder: "Enter your password",
+};
+
+export const Textarea = Template.bind({});
+Textarea.args = {
+  ...Basic.args,
+  type: "textarea",
+  label: "Text Area",
+  placeholder: "Enter multiple lines of text",
+};
+
+export const WithCopyEnabled = Template.bind({});
+WithCopyEnabled.args = {
+  ...Basic.args,
+  enableCopy: true,
+  value: "This text can be copied",
+};
+
+export const WithCopyEnabledInsideInput = Template.bind({});
+WithCopyEnabledInsideInput.args = {
+  ...WithCopyEnabled.args,
+  copyButtonPosition: "inside",
+};
+
+export const WithTooltip = Template.bind({});
+WithTooltip.args = {
+  ...Basic.args,
+  tooltip: "This is a tooltip for the input field",
+};
+
+export const AutoFocus = Template.bind({});
+AutoFocus.args = {
+  ...Basic.args,
+  autofocus: true,
 };

--- a/frontend/components/forms/fields/InputField/InputField.stories.tsx
+++ b/frontend/components/forms/fields/InputField/InputField.stories.tsx
@@ -1,5 +1,5 @@
 import { Meta, StoryObj } from "@storybook/react";
-import { noop } from "lodash";
+import { action } from "@storybook/addon-actions";
 
 // @ts-ignore
 import InputField from ".";
@@ -9,20 +9,24 @@ import "../../../../index.scss";
 const meta: Meta<typeof InputField> = {
   component: InputField,
   title: "Components/FormFields/Input",
-  args: {
-    autofocus: false,
-    readOnly: false,
-    disabled: false,
-    error: "",
-    inputClassName: "",
-    inputWrapperClass: "",
-    inputOptions: {},
-    name: "",
-    placeholder: "Type here...",
-    type: "",
-    value: "",
-    onFocus: noop,
-    onChange: noop,
+  argTypes: {
+    type: {
+      control: "select",
+      options: ["text", "password", "email", "number", "textarea"],
+    },
+    autofocus: { control: "boolean" },
+    readOnly: { control: "boolean" },
+    disabled: { control: "boolean" },
+    blockAutoComplete: { control: "boolean" },
+    enableCopy: { control: "boolean" },
+    copyButtonPosition: {
+      control: "radio",
+      options: ["inside", "outside"],
+    },
+    labelTooltipPosition: {
+      control: "select",
+      options: ["top", "right", "bottom", "left"],
+    },
   },
 };
 
@@ -30,4 +34,94 @@ export default meta;
 
 type Story = StoryObj<typeof InputField>;
 
-export const Default: Story = {};
+export const Default: Story = {
+  args: {
+    name: "default-input",
+    label: "Default Input",
+    placeholder: "Type here...",
+    value: "",
+    onChange: action("onChange"),
+    onFocus: action("onFocus"),
+    onBlur: action("onBlur"),
+  },
+};
+
+export const WithError: Story = {
+  args: {
+    ...Default.args,
+    name: "error-input",
+    label: "Input with Error",
+    error: "This field is required",
+    value: "",
+  },
+};
+
+export const WithHelpText: Story = {
+  args: {
+    ...Default.args,
+    name: "help-text-input",
+    label: "Input with Help Text",
+    helpText: "This is some helpful information about the input field.",
+  },
+};
+
+export const WithTooltip: Story = {
+  args: {
+    ...Default.args,
+    name: "tooltip-input",
+    label: "Input with Tooltip",
+    tooltip: "This is additional information in a tooltip.",
+    labelTooltipPosition: "right",
+  },
+};
+
+export const Password: Story = {
+  args: {
+    ...Default.args,
+    name: "password-input",
+    label: "Password Input",
+    type: "password",
+    placeholder: "Enter password",
+  },
+};
+
+export const ReadOnly: Story = {
+  args: {
+    ...Default.args,
+    name: "readonly-input",
+    label: "Read-only Input",
+    readOnly: true,
+    value: "This is read-only content",
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    ...Default.args,
+    name: "disabled-input",
+    label: "Disabled Input",
+    disabled: true,
+    value: "This input is disabled",
+  },
+};
+
+export const WithCopyButton: Story = {
+  args: {
+    ...Default.args,
+    name: "copy-input",
+    label: "Input with Copy Button",
+    value: "Click to copy this text",
+    enableCopy: true,
+    copyButtonPosition: "outside",
+  },
+};
+
+export const Textarea: Story = {
+  args: {
+    ...Default.args,
+    name: "textarea-input",
+    label: "Textarea Input",
+    type: "textarea",
+    placeholder: "Enter multiple lines of text...",
+  },
+};

--- a/frontend/components/forms/fields/InputField/InputField.tests.tsx
+++ b/frontend/components/forms/fields/InputField/InputField.tests.tsx
@@ -1,6 +1,8 @@
 import React from "react";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+
+// @ts-ignore
 import InputField from "./InputField";
 
 describe("InputField Component", () => {

--- a/frontend/components/forms/fields/InputField/InputField.tests.tsx
+++ b/frontend/components/forms/fields/InputField/InputField.tests.tsx
@@ -1,0 +1,162 @@
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import InputField from "./InputField";
+
+describe("InputField Component", () => {
+  const mockOnChange = jest.fn();
+  const mockOnBlur = jest.fn();
+  const mockOnFocus = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test("renders with label and placeholder", () => {
+    render(
+      <InputField
+        value=""
+        onChange={mockOnChange}
+        label="Test Input"
+        placeholder="Enter text"
+        name="test-input"
+      />
+    );
+
+    expect(screen.getByText(/test input/i)).toBeInTheDocument();
+    expect(screen.getByPlaceholderText(/enter text/i)).toBeInTheDocument();
+  });
+
+  test("calls onChange when input value changes", async () => {
+    render(
+      <InputField
+        value=""
+        onChange={mockOnChange}
+        label="Test Input"
+        placeholder="Enter text"
+        name="test-input"
+      />
+    );
+
+    await userEvent.type(
+      screen.getByPlaceholderText(/enter text/i),
+      "New Value"
+    );
+    expect(mockOnChange).toHaveBeenCalledTimes(9); // 'New Value' has 9 characters
+  });
+
+  test("renders help text when provided", () => {
+    render(
+      <InputField
+        value=""
+        onChange={mockOnChange}
+        label="Test Input"
+        placeholder="Enter text"
+        name="test-input"
+        helpText="This is a help text."
+      />
+    );
+
+    expect(screen.getByText(/this is a help text/i)).toBeInTheDocument();
+  });
+
+  test("renders error message when provided", () => {
+    render(
+      <InputField
+        value=""
+        onChange={mockOnChange}
+        label="Test Input"
+        placeholder="Enter text"
+        name="test-input"
+        error="This is an error message."
+      />
+    );
+
+    expect(screen.getByText(/this is an error message/i)).toBeInTheDocument();
+  });
+
+  test("renders as textarea when type is textarea", () => {
+    render(
+      <InputField
+        value=""
+        onChange={mockOnChange}
+        label="Test Textarea"
+        placeholder="Enter text"
+        name="test-textarea"
+        type="textarea"
+      />
+    );
+
+    expect(screen.getByRole("textbox")).toHaveAttribute(
+      "name",
+      "test-textarea"
+    );
+  });
+
+  test("renders copy button when enableCopy is true", () => {
+    render(
+      <InputField
+        value="Some Value"
+        onChange={mockOnChange}
+        label="Test Input"
+        placeholder="Enter text"
+        name="test-input"
+        enableCopy
+      />
+    );
+
+    expect(screen.getByRole("button", { name: /copy/i })).toBeInTheDocument();
+  });
+
+  test("calls onBlur when input loses focus", async () => {
+    render(
+      <InputField
+        value=""
+        onChange={mockOnChange}
+        onBlur={mockOnBlur}
+        label="Test Input"
+        placeholder="Enter text"
+        name="test-input"
+      />
+    );
+
+    const input = screen.getByPlaceholderText(/enter text/i);
+    await userEvent.click(input);
+    await userEvent.tab();
+
+    expect(mockOnBlur).toHaveBeenCalledTimes(1);
+  });
+
+  test("calls onFocus when input gains focus", async () => {
+    render(
+      <InputField
+        value=""
+        onChange={mockOnChange}
+        onFocus={mockOnFocus}
+        label="Test Input"
+        placeholder="Enter text"
+        name="test-input"
+      />
+    );
+
+    const input = screen.getByPlaceholderText(/enter text/i);
+    await userEvent.click(input);
+
+    expect(mockOnFocus).toHaveBeenCalledTimes(1);
+  });
+
+  test("renders as disabled when disabled prop is true", () => {
+    render(
+      <InputField
+        value=""
+        onChange={mockOnChange}
+        label="Test Input"
+        placeholder="Enter text"
+        name="test-input"
+        disabled
+      />
+    );
+
+    expect(screen.getByPlaceholderText(/enter text/i)).toBeDisabled();
+  });
+});

--- a/frontend/components/forms/fields/InputField/_styles.scss
+++ b/frontend/components/forms/fields/InputField/_styles.scss
@@ -4,7 +4,7 @@
   border: solid 1px $ui-fleet-black-10;
   border-radius: $border-radius;
   font-size: $small;
-  padding: 7px 12px;
+  padding: $pad-small $pad-medium;
   color: $core-fleet-blue;
   font-family: "Inter", sans-serif;
   box-sizing: border-box;
@@ -16,14 +16,17 @@
     color: $ui-fleet-black-50;
   }
 
-  &:focus {
-    outline: none;
-    border-color: $core-vibrant-blue;
+  &:hover:not(.input-field--read-only) {
+    box-shadow: none;
+    border: 1px solid $core-vibrant-blue-over;
   }
 
-  &:hover &:not(.input-field--read-only) {
+  &:active:not(.input-field--read-only),
+  &:focus:not(.input-field--read-only),
+  &:focus-visible:not(.input-field--read-only) {
     box-shadow: none;
-    border: 1px solid $core-vibrant-blue;
+    outline: 0;
+    border: 1px solid $core-vibrant-blue-down;
   }
 
   &--disabled {

--- a/frontend/components/forms/fields/InputFieldWithIcon/InputFieldWithIcon.jsx
+++ b/frontend/components/forms/fields/InputFieldWithIcon/InputFieldWithIcon.jsx
@@ -2,8 +2,7 @@ import React from "react";
 import PropTypes from "prop-types";
 import classnames from "classnames";
 
-import Icon from "components/Icon/Icon";
-import FleetIcon from "components/icons/FleetIcon";
+import Icon, { IconNames } from "components/Icon/Icon";
 import TooltipWrapper from "components/TooltipWrapper";
 import Button from "components/buttons/Button";
 import InputField from "../InputField";
@@ -15,8 +14,7 @@ class InputFieldWithIcon extends InputField {
     autofocus: PropTypes.bool,
     error: PropTypes.string,
     helpText: PropTypes.oneOfType([PropTypes.array, PropTypes.string]),
-    iconName: PropTypes.string,
-    iconSvg: PropTypes.string,
+    iconSvg: IconNames,
     label: PropTypes.string,
     name: PropTypes.string,
     onChange: PropTypes.func,
@@ -27,7 +25,6 @@ class InputFieldWithIcon extends InputField {
     type: PropTypes.string,
     className: PropTypes.string,
     disabled: PropTypes.bool,
-    iconPosition: PropTypes.oneOf(["start", "end"]),
     inputOptions: PropTypes.object, // eslint-disable-line react/forbid-prop-types
     tooltip: PropTypes.string,
     ignore1Password: PropTypes.bool,
@@ -76,7 +73,6 @@ class InputFieldWithIcon extends InputField {
     const {
       className,
       error,
-      iconName,
       iconSvg,
       name,
       placeholder,
@@ -84,7 +80,6 @@ class InputFieldWithIcon extends InputField {
       type,
       value,
       disabled,
-      iconPosition,
       inputOptions,
       ignore1Password,
       onClick,
@@ -93,20 +88,14 @@ class InputFieldWithIcon extends InputField {
     } = this.props;
     const { onInputChange, renderHelpText } = this;
 
-    const wrapperClasses = classnames(baseClass, "form-field", {
-      [`${baseClass}--icon-start`]: iconPosition && iconPosition === "start",
-    });
+    const wrapperClasses = classnames(baseClass, "form-field");
 
     const inputClasses = classnames(
       `${baseClass}__input`,
       "input-with-icon",
       className,
       { [`${baseClass}__input--error`]: error },
-      { [`${baseClass}__input--password`]: type === "password" && value },
-      {
-        [`${baseClass}__input--icon-start`]:
-          iconPosition && iconPosition === "start",
-      }
+      { [`${baseClass}__input--password`]: type === "password" && value }
     );
 
     const iconClasses = classnames(
@@ -141,7 +130,6 @@ class InputFieldWithIcon extends InputField {
             data-1p-ignore={ignore1Password}
           />
           {iconSvg && <Icon name={iconSvg} className={iconClasses} />}
-          {iconName && <FleetIcon name={iconName} className={iconClasses} />}
           {clearButton && !!value && (
             <Button
               onClick={() => handleClear()}

--- a/frontend/components/forms/fields/InputFieldWithIcon/InputFieldWithIcon.jsx
+++ b/frontend/components/forms/fields/InputFieldWithIcon/InputFieldWithIcon.jsx
@@ -93,8 +93,8 @@ class InputFieldWithIcon extends InputField {
 
     const inputClasses = classnames(
       `${baseClass}__input`,
-      "input-with-icon",
       className,
+      { "input-with-icon": !!iconSvg },
       { [`${baseClass}__input--error`]: error },
       { [`${baseClass}__input--password`]: type === "password" && value }
     );

--- a/frontend/components/forms/fields/InputFieldWithIcon/InputFieldWithIcon.jsx
+++ b/frontend/components/forms/fields/InputFieldWithIcon/InputFieldWithIcon.jsx
@@ -31,11 +31,12 @@ class InputFieldWithIcon extends InputField {
   };
 
   renderHeading = () => {
-    const { error, placeholder, name, tooltip } = this.props;
+    const { error, placeholder, name, tooltip, disabled } = this.props;
     const label = this.props.label ?? placeholder;
 
     const labelClasses = classnames(`${baseClass}__label`, {
       [`${baseClass}__errors`]: !!error,
+      [`${baseClass}__label--disabled`]: disabled,
     });
 
     return (
@@ -98,6 +99,10 @@ class InputFieldWithIcon extends InputField {
       { [`${baseClass}__input--password`]: type === "password" && value }
     );
 
+    const inputWrapperClasses = classnames(`${baseClass}__input-wrapper`, {
+      [`${baseClass}__input-wrapper--disabled`]: disabled,
+    });
+
     const iconClasses = classnames(
       `${baseClass}__icon`,
       { [`${baseClass}__icon--error`]: error },
@@ -111,7 +116,7 @@ class InputFieldWithIcon extends InputField {
     return (
       <div className={wrapperClasses}>
         {this.props.label && this.renderHeading()}
-        <div className={`${baseClass}__input-wrapper`}>
+        <div className={inputWrapperClasses}>
           <input
             id={name}
             name={name}

--- a/frontend/components/forms/fields/InputFieldWithIcon/InputFieldWithIcon.jsx
+++ b/frontend/components/forms/fields/InputFieldWithIcon/InputFieldWithIcon.jsx
@@ -2,7 +2,8 @@ import React from "react";
 import PropTypes from "prop-types";
 import classnames from "classnames";
 
-import Icon, { IconNames } from "components/Icon/Icon";
+import { ICON_MAP } from "components/icons";
+import Icon from "components/Icon/Icon";
 import TooltipWrapper from "components/TooltipWrapper";
 import Button from "components/buttons/Button";
 import InputField from "../InputField";
@@ -14,7 +15,7 @@ class InputFieldWithIcon extends InputField {
     autofocus: PropTypes.bool,
     error: PropTypes.string,
     helpText: PropTypes.oneOfType([PropTypes.array, PropTypes.string]),
-    iconSvg: IconNames,
+    iconSvg: PropTypes.oneOf(Object.keys(ICON_MAP)),
     label: PropTypes.string,
     name: PropTypes.string,
     onChange: PropTypes.func,

--- a/frontend/components/forms/fields/InputFieldWithIcon/InputFieldWithIcon.stories.tsx
+++ b/frontend/components/forms/fields/InputFieldWithIcon/InputFieldWithIcon.stories.tsx
@@ -1,18 +1,38 @@
+import React from "react";
 import { Meta, StoryObj } from "@storybook/react";
-import { noop } from "lodash";
+import { action } from "@storybook/addon-actions";
 
-// @ts-ignore
+// Import the InputFieldWithIcon component
 import InputFieldWithIcon from ".";
 
 import "../../../../index.scss";
 
 const meta: Meta<typeof InputFieldWithIcon> = {
   component: InputFieldWithIcon,
-  title: "Components/FormFields/InputWithIcon",
+  title: "Components/FormFields/InputFieldWithIcon",
   argTypes: {
-    iconPosition: {
-      options: ["start", "end"],
-      control: "radio",
+    type: {
+      options: ["text", "password", "email", "number"],
+      control: "select",
+    },
+    value: {
+      control: "text",
+    },
+    disabled: {
+      control: "boolean",
+    },
+    error: {
+      control: "text",
+    },
+    helpText: {
+      control: "text",
+    },
+    tooltip: {
+      control: "text",
+    },
+    iconSvg: {
+      options: ["search", "filter"], // Add more icons as needed
+      control: "select",
     },
     iconName: {
       options: [
@@ -20,100 +40,12 @@ const meta: Meta<typeof InputFieldWithIcon> = {
         "chevronleft",
         "chevronright",
         "chevronup",
-        "cpu",
-        "downcaret",
-        "filter",
-        "mac",
-        "memory",
-        "storage",
-        "upcaret",
-        "uptime",
-        "world",
-        "osquery",
-        "join",
-        "add-button",
-        "packs",
-        "help",
-        "admin",
-        "config",
-        "success-check",
-        "offline",
-        "windows-original",
-        "centos-original",
-        "ubuntu-original",
-        "apple-original",
+        // Add more icon names here as needed
         "search",
-        "all-hosts",
-        "alerts",
-        "logout",
-        "account",
-        "clipboard",
-        "list-select",
-        "grid-select",
-        "label",
-        "docker",
-        "cloud",
-        "self-hosted",
-        "help-solid",
-        "help-stroke",
-        "warning-filled",
-        "delete-cloud",
-        "pdf",
-        "credit-card-small",
-        "billing-card",
-        "lock-big",
-        "link-big",
-        "briefcase",
-        "name-card",
-        "business",
-        "clock",
-        "host-large",
-        "single-host",
-        "username",
-        "password",
-        "email",
-        "hosts",
-        "query",
-        "import",
-        "pencil",
-        "add-plus",
-        "x",
-        "right-arrow",
-        "camera",
-        "plus-minus",
-        "bold-plus",
-        "linux-original",
-        "clock2",
-        "trash",
-        "laptop-plus",
-        "wrench-hand",
-        "external-link",
-        "fullscreen",
-        "windowed",
-        "heroku",
-        "ubuntu",
-        "windows",
-        "centos",
-        "apple",
-        "linux",
+        // Add other relevant icon names
       ],
       control: "select",
     },
-  },
-  args: {
-    autofocus: false,
-    iconPosition: "start",
-    iconName: "email",
-    disabled: false,
-    label: "Email",
-    placeholder: "Type here...",
-    error: "",
-    helpText: "",
-    name: "",
-    tabIndex: "",
-    type: "",
-    className: "",
-    onChange: noop,
   },
 };
 
@@ -121,4 +53,60 @@ export default meta;
 
 type Story = StoryObj<typeof InputFieldWithIcon>;
 
-export const Default: Story = {};
+const Template: Story = (args) => <InputFieldWithIcon {...args} />;
+
+export const Default: Story = Template.bind({});
+Default.args = {
+  label: "Email",
+  placeholder: "Enter your email",
+  type: "email",
+  onChange: action("onChange"),
+};
+
+export const PasswordInput: Story = Template.bind({});
+PasswordInput.args = {
+  ...Default.args,
+  iconName: "lock",
+  label: "Password",
+  placeholder: "Enter your password",
+  type: "password",
+};
+
+export const WithError: Story = Template.bind({});
+WithError.args = {
+  ...Default.args,
+  error: "Invalid email address",
+};
+
+export const WithHelpText: Story = Template.bind({});
+WithHelpText.args = {
+  ...Default.args,
+  helpText: "We'll never share your email with anyone else.",
+};
+
+export const Disabled: Story = Template.bind({});
+Disabled.args = {
+  ...Default.args,
+  disabled: true,
+};
+
+export const WithTooltip: Story = Template.bind({});
+WithTooltip.args = {
+  ...Default.args,
+  tooltip: "Enter the email address associated with your account",
+};
+
+export const WithClearButton: Story = Template.bind({});
+WithClearButton.args = {
+  ...Default.args,
+  clearButton: action("clearButton"),
+  value: "example@email.com",
+};
+
+export const CustomIcon: Story = Template.bind({});
+CustomIcon.args = {
+  ...Default.args,
+  iconSvg: "search", // Use an appropriate icon SVG name
+  label: "Search",
+  placeholder: "Search...",
+};

--- a/frontend/components/forms/fields/InputFieldWithIcon/InputFieldWithIcon.stories.tsx
+++ b/frontend/components/forms/fields/InputFieldWithIcon/InputFieldWithIcon.stories.tsx
@@ -1,15 +1,13 @@
-import React from "react";
-import { Meta, StoryObj } from "@storybook/react";
+import type { Meta, StoryObj } from "@storybook/react";
 import { action } from "@storybook/addon-actions";
 
-// Import the InputFieldWithIcon component
+// @ts-ignore
 import InputFieldWithIcon from ".";
 
-import "../../../../index.scss";
-
+// Define metadata for the story
 const meta: Meta<typeof InputFieldWithIcon> = {
-  component: InputFieldWithIcon,
   title: "Components/FormFields/InputFieldWithIcon",
+  component: InputFieldWithIcon,
   argTypes: {
     type: {
       options: ["text", "password", "email", "number"],
@@ -34,18 +32,6 @@ const meta: Meta<typeof InputFieldWithIcon> = {
       options: ["search", "filter"], // Add more icons as needed
       control: "select",
     },
-    iconName: {
-      options: [
-        "chevrondown",
-        "chevronleft",
-        "chevronright",
-        "chevronup",
-        // Add more icon names here as needed
-        "search",
-        // Add other relevant icon names
-      ],
-      control: "select",
-    },
   },
 };
 
@@ -53,60 +39,73 @@ export default meta;
 
 type Story = StoryObj<typeof InputFieldWithIcon>;
 
-const Template: Story = (args) => <InputFieldWithIcon {...args} />;
-
-export const Default: Story = Template.bind({});
-Default.args = {
-  label: "Email",
-  placeholder: "Enter your email",
-  type: "email",
-  onChange: action("onChange"),
+// Default story
+export const Default: Story = {
+  args: {
+    label: "Email",
+    placeholder: "Enter your email",
+    type: "email",
+    onChange: action("onChange"),
+  },
 };
 
-export const PasswordInput: Story = Template.bind({});
-PasswordInput.args = {
-  ...Default.args,
-  iconName: "lock",
-  label: "Password",
-  placeholder: "Enter your password",
-  type: "password",
+// Password input story
+export const PasswordInput: Story = {
+  args: {
+    ...Default.args,
+    label: "Password",
+    placeholder: "Enter your password",
+    type: "password",
+  },
 };
 
-export const WithError: Story = Template.bind({});
-WithError.args = {
-  ...Default.args,
-  error: "Invalid email address",
+// With error story
+export const WithError: Story = {
+  args: {
+    ...Default.args,
+    error: "Invalid email address",
+  },
 };
 
-export const WithHelpText: Story = Template.bind({});
-WithHelpText.args = {
-  ...Default.args,
-  helpText: "We'll never share your email with anyone else.",
+// With help text story
+export const WithHelpText: Story = {
+  args: {
+    ...Default.args,
+    helpText: "We'll never share your email with anyone else.",
+  },
 };
 
-export const Disabled: Story = Template.bind({});
-Disabled.args = {
-  ...Default.args,
-  disabled: true,
+// Disabled story
+export const Disabled: Story = {
+  args: {
+    ...Default.args,
+    disabled: true,
+  },
 };
 
-export const WithTooltip: Story = Template.bind({});
-WithTooltip.args = {
-  ...Default.args,
-  tooltip: "Enter the email address associated with your account",
+// With tooltip story
+export const WithTooltip: Story = {
+  args: {
+    ...Default.args,
+    tooltip: "Enter the email address associated with your account",
+  },
 };
 
-export const WithClearButton: Story = Template.bind({});
-WithClearButton.args = {
-  ...Default.args,
-  clearButton: action("clearButton"),
-  value: "example@email.com",
+// With clear button story
+export const WithClearButton: Story = {
+  args: {
+    ...Default.args,
+    clearButton: action("clearButton"),
+    value: "example@email.com",
+  },
 };
 
-export const CustomIcon: Story = Template.bind({});
-CustomIcon.args = {
-  ...Default.args,
-  iconSvg: "search", // Use an appropriate icon SVG name
-  label: "Search",
-  placeholder: "Search...",
+// Custom icon story
+export const CustomIcon: Story = {
+  args: {
+    ...Default.args,
+    iconSvg: "search", // Use an appropriate icon SVG name
+    label: "Search",
+    placeholder: "Search...",
+  },
 };

--- a/frontend/components/forms/fields/InputFieldWithIcon/_styles.scss
+++ b/frontend/components/forms/fields/InputFieldWithIcon/_styles.scss
@@ -35,7 +35,7 @@
     border: 1px solid $ui-fleet-black-10;
     background-color: $ui-light-grey;
     border-radius: $border-radius;
-    padding: 9.5px 12px 9.5px 36px; // New figma styling
+    padding: 9.5px 12px 9.5px $pad-medium;
     font-size: $x-small;
     text-indent: 1px;
     position: relative;
@@ -44,6 +44,10 @@
     color: $core-fleet-black;
     font-weight: $regular;
     transition: border-color 100ms;
+
+    &.input-with-icon {
+      padding-left: 36px;
+    }
 
     ::placeholder {
       color: $core-fleet-blue;

--- a/frontend/components/forms/fields/InputFieldWithIcon/_styles.scss
+++ b/frontend/components/forms/fields/InputFieldWithIcon/_styles.scss
@@ -3,8 +3,13 @@
 
   &__icon {
     position: absolute;
-    right: 6px;
-    top: 28px;
+    left: 12px;
+    top: 0;
+    height: 40px;
+    width: 16px;
+    flex-wrap: wrap;
+    align-content: center;
+    z-index: 1;
     color: $core-fleet-blue;
 
     &--active {
@@ -26,27 +31,11 @@
     align-items: center;
   }
 
-  // Refactor to include svg icons
-  &--icon-start {
-    margin-top: 0;
-
-    .input-icon-field__icon {
-      position: absolute;
-      left: 12px;
-      top: 0;
-      height: 40px;
-      width: 16px;
-      flex-wrap: wrap;
-      align-content: center;
-      z-index: 1;
-    }
-  }
-
   &__input {
     border: 1px solid $ui-fleet-black-10;
     background-color: $ui-light-grey;
     border-radius: $border-radius;
-    padding: 9px 30px 9px $pad-medium;
+    padding: 9.5px 12px 9.5px 36px; // New figma styling
     font-size: $x-small;
     text-indent: 1px;
     position: relative;
@@ -123,19 +112,6 @@
 
   &__errors {
     color: $core-vibrant-red;
-  }
-
-  // overwrite icon position and input padding
-  &--icon-start {
-    input {
-      padding: 9.5px 12px 9.5px 36px; // New figma styling
-    }
-    .fleeticon {
-      right: auto;
-      left: 16px;
-      top: 36px;
-      font-weight: 700;
-    }
   }
 
   /* removes the 'X' from IE input type=search */

--- a/frontend/components/forms/fields/InputFieldWithIcon/_styles.scss
+++ b/frontend/components/forms/fields/InputFieldWithIcon/_styles.scss
@@ -92,18 +92,21 @@
     }
   }
 
-  .input-icon-field__input:focus {
-    border: 1px solid $core-vibrant-blue-down;
+  &__input-wrapper {
+    .input-icon-field__input:focus {
+      border: 1px solid $core-vibrant-blue-down;
 
-    // Icon color matches border color on focus
-    + .input-icon-field__icon {
-      svg {
-        path {
-          fill: $core-vibrant-blue-down;
+      // Icon color matches border color on focus
+      + .input-icon-field__icon {
+        svg {
+          path {
+            fill: $core-vibrant-blue-down;
+          }
         }
       }
     }
   }
+
   &__label {
     display: block;
     font-size: $x-small;

--- a/frontend/components/forms/fields/InputFieldWithIcon/_styles.scss
+++ b/frontend/components/forms/fields/InputFieldWithIcon/_styles.scss
@@ -77,7 +77,7 @@
     }
   }
 
-  &__input-wrapper:hover {
+  &__input-wrapper:not(&__input-wrapper--disabled):hover {
     .input-icon-field__input {
       border: 1px solid $core-vibrant-blue-over;
     }
@@ -114,6 +114,10 @@
 
     &[data-has-tooltip="true"] {
       margin-bottom: $pad-small;
+    }
+
+    &--disabled {
+      color: $ui-fleet-black-50;
     }
   }
 

--- a/frontend/components/forms/fields/InputFieldWithIcon/_styles.scss
+++ b/frontend/components/forms/fields/InputFieldWithIcon/_styles.scss
@@ -8,7 +8,7 @@
     color: $core-fleet-blue;
 
     &--active {
-      color: $core-vibrant-blue;
+      color: $core-vibrant-blue-down;
     }
 
     &--error {
@@ -79,27 +79,27 @@
 
   &__input-wrapper:hover {
     .input-icon-field__input {
-      border: 1px solid $core-vibrant-blue;
+      border: 1px solid $core-vibrant-blue-over;
     }
 
-    // Icon color matches border color on focus and on hover
+    // Icon color matches border color on hover
     .input-icon-field__icon {
       svg {
         path {
-          fill: $core-vibrant-blue;
+          fill: $core-vibrant-blue-over;
         }
       }
     }
   }
 
   .input-icon-field__input:focus {
-    border: 1px solid $core-vibrant-blue;
+    border: 1px solid $core-vibrant-blue-down;
 
-    // Icon color matches border color on focus and on hover
+    // Icon color matches border color on focus
     + .input-icon-field__icon {
       svg {
         path {
-          fill: $core-vibrant-blue;
+          fill: $core-vibrant-blue-down;
         }
       }
     }

--- a/frontend/pages/admin/UserManagementPage/components/SelectedTeamsForm/_styles.scss
+++ b/frontend/pages/admin/UserManagementPage/components/SelectedTeamsForm/_styles.scss
@@ -13,7 +13,7 @@
     justify-content: space-between;
 
     .form-field--dropdown {
-      width: 154px; // Matches dropdown
+      width: 170px; // Fits content
     }
   }
 

--- a/frontend/styles/var/mixins.scss
+++ b/frontend/styles/var/mixins.scss
@@ -207,6 +207,7 @@ $max-width: 2560px;
 
 @mixin copy-message {
   font-weight: $regular;
+  font-size: $x-small;
   vertical-align: top;
   background-color: $ui-light-grey;
   border: solid 1px #e2e4ea;


### PR DESCRIPTION
## Issue
Part 3 for #26231 

## Description
- Aligns dropdowns with design system
  - Align phasing out component `<Dropdown/>`
  - Align phasing in component `<DropdownWrapper/>`
- Aligns input fields with design system
  - Align component `<InputField/>`
  - Align component `<InputFieldWithIcon/>` that should merge into `<InputField/>` in #26552
- All viewable on storybook
- Includes basic tests

## Screenshots
<img width="1362" alt="Screenshot 2025-02-27 at 4 49 41 PM" src="https://github.com/user-attachments/assets/d36ee0b3-948d-4f11-9055-ceb791efccd2" />
<img width="1357" alt="Screenshot 2025-02-27 at 4 49 26 PM" src="https://github.com/user-attachments/assets/9f41f15b-e5ba-4672-81ea-fba9e01115f6" />
<img width="1364" alt="Screenshot 2025-02-27 at 4 49 14 PM" src="https://github.com/user-attachments/assets/3178c5b4-f5ae-4108-86af-d9dae362dd20" />
<img width="1363" alt="Screenshot 2025-02-27 at 4 49 08 PM" src="https://github.com/user-attachments/assets/e2b46a15-99f7-4ad5-9dce-2011a60c7275" />


## Note
Created issue #26552 to track updating `InputField` to typescript, functional component and include `iconSvg` so we can remove redundant component `InputFieldWithIcon`

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
- [x] Added/updated automated tests
- [ ] A detailed QA plan exists on the associated ticket (if it isn't there, work with the product group's QA engineer to add it)
- [x] Manual QA for all new/changed functionality

