### PR TITLE
add UI for turning android mdm on/off

### DIFF
--- a/changes/issue-26207-ui-for-turn-on-off-android-mdm
+++ b/changes/issue-26207-ui-for-turn-on-off-android-mdm
@@ -1,0 +1,1 @@
+- add UI to turn on and and off android mdm

--- a/frontend/__mocks__/configMock.ts
+++ b/frontend/__mocks__/configMock.ts
@@ -8,6 +8,7 @@ const DEFAULT_CONFIG_MDM_MOCK: IMdmConfig = {
   apple_bm_enabled_and_configured: true,
   apple_bm_terms_expired: false,
   enabled_and_configured: true,
+  android_enabled_and_configured: false,
   macos_updates: {
     minimum_version: "",
     deadline: "",

--- a/frontend/__mocks__/configMock.ts
+++ b/frontend/__mocks__/configMock.ts
@@ -57,6 +57,7 @@ export const createMockMdmConfig = (
 };
 
 const DEFAULT_CONFIG_MOCK: IConfig = {
+  android_enabled: false, // TODO: feature flag, remove when feature releases.
   org_info: {
     org_name: "fleet",
     org_logo_url: "",

--- a/frontend/context/app.tsx
+++ b/frontend/context/app.tsx
@@ -143,6 +143,7 @@ type InitialStateType = {
   isPremiumTier?: boolean;
   isMacMdmEnabledAndConfigured?: boolean;
   isWindowsMdmEnabledAndConfigured?: boolean;
+  isAndroidMdmEnabledAndConfigured?: boolean;
   isGlobalAdmin?: boolean;
   isGlobalMaintainer?: boolean;
   isGlobalObserver?: boolean;
@@ -210,6 +211,7 @@ export const initialState = {
   isPremiumTier: undefined,
   isMacMdmEnabledAndConfigured: undefined,
   isWindowsMdmEnabledAndConfigured: undefined,
+  isAndroidMdmEnabledAndConfigured: undefined,
   isGlobalAdmin: undefined,
   isGlobalMaintainer: undefined,
   isGlobalObserver: undefined,
@@ -280,6 +282,9 @@ const setPermissions = (
       config
     ),
     isWindowsMdmEnabledAndConfigured: permissions.isWindowsMdmEnabledAndConfigured(
+      config
+    ),
+    isAndroidMdmEnabledAndConfigured: permissions.isAndroidMdmEnabledAndConfigured(
       config
     ),
     isGlobalAdmin: permissions.isGlobalAdmin(user),
@@ -481,6 +486,7 @@ const AppProvider = ({ children }: Props): JSX.Element => {
       isPremiumTier: state.isPremiumTier,
       isMacMdmEnabledAndConfigured: state.isMacMdmEnabledAndConfigured,
       isWindowsMdmEnabledAndConfigured: state.isWindowsMdmEnabledAndConfigured,
+      isAndroidMdmEnabledAndConfigured: state.isAndroidMdmEnabledAndConfigured,
       isGlobalAdmin: state.isGlobalAdmin,
       isGlobalMaintainer: state.isGlobalMaintainer,
       isGlobalObserver: state.isGlobalObserver,
@@ -600,6 +606,7 @@ const AppProvider = ({ children }: Props): JSX.Element => {
       state.isTeamObserver,
       state.isVppExpired,
       state.isWindowsMdmEnabledAndConfigured,
+      state.isAndroidMdmEnabledAndConfigured,
       state.needsAbmTermsRenewal,
       state.noSandboxHosts,
       state.sandboxExpiry,

--- a/frontend/interfaces/config.ts
+++ b/frontend/interfaces/config.ts
@@ -58,6 +58,7 @@ export interface IMdmConfig {
   apple_bm_enabled_and_configured: boolean;
   windows_enabled_and_configured: boolean;
   windows_migration_enabled: boolean;
+  android_enabled_and_configured: boolean;
   end_user_authentication: IEndUserAuthentication;
   macos_updates: IAppleDeviceUpdates;
   ios_updates: IAppleDeviceUpdates;

--- a/frontend/interfaces/config.ts
+++ b/frontend/interfaces/config.ts
@@ -108,6 +108,7 @@ export interface IConfigServerSettings {
 }
 
 export interface IConfig {
+  android_enabled: boolean; // TODO: feature flag, remove when feature releases.
   org_info: {
     org_name: string;
     org_logo_url: string;

--- a/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/AndroidMdmPage/AndroidMdmPage.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/AndroidMdmPage/AndroidMdmPage.tsx
@@ -28,7 +28,10 @@ const TurnOnAndroidMdm = () => {
   const onConnectMdm = async () => {
     setFetchingSignupUrl(true);
     try {
-      await mdmAndroidAPI.getSignupUrl();
+      const res = await mdmAndroidAPI.getSignupUrl();
+
+      // TODO: set up SSE for successful android mdm turned on here.
+      window.open(res.android_enterprise_signup_url, "_blank");
     } catch (e) {
       renderFlash("error", "Couldn't connect. Please try again");
     }

--- a/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/AndroidMdmPage/AndroidMdmPage.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/AndroidMdmPage/AndroidMdmPage.tsx
@@ -17,11 +17,9 @@ import TurnOffAndroidMdmModal from "./components/TurnOffAndroidMdmModal";
 
 const baseClass = "android-mdm-page";
 
-interface ITurnOnAndroidMdmProps {
-  onClickConnect: () => void;
-}
+interface ITurnOnAndroidMdmProps {}
 
-const TurnOnAndroidMdm = ({ onClickConnect }: ITurnOnAndroidMdmProps) => {
+const TurnOnAndroidMdm = ({}: ITurnOnAndroidMdmProps) => {
   const { renderFlash } = useContext(NotificationContext);
   const [fetchingSignupUrl, setFetchingSignupUrl] = useState(false);
 
@@ -90,19 +88,12 @@ interface IAndroidMdmPageProps {
 }
 
 const AndroidMdmPage = ({ router }: IAndroidMdmPageProps) => {
-  const { isAndroidMdmEnabledAndConfigured } = useContext(AppContext);
+  let { isAndroidMdmEnabledAndConfigured } = useContext(AppContext);
+  isAndroidMdmEnabledAndConfigured = true;
+
   const { renderFlash } = useContext(NotificationContext);
-  const [fetchingSignupUrl, setFetchingSignupUrl] = useState(false);
 
   const [showTurnOffMdmModal, setShowTurnOffMdmModal] = useState(false);
-
-  const onConnectMdm = async () => {
-    try {
-      await mdmAndroidAPI.getSignupUrl();
-    } catch (e) {
-      renderFlash("error", "Couldn't connect. Please try again");
-    }
-  };
 
   return (
     <MainContent className={baseClass}>
@@ -115,7 +106,7 @@ const AndroidMdmPage = ({ router }: IAndroidMdmPageProps) => {
 
       <div className={`${baseClass}__content`}>
         {!isAndroidMdmEnabledAndConfigured ? (
-          <TurnOnAndroidMdm onClickConnect={onConnectMdm} />
+          <TurnOnAndroidMdm />
         ) : (
           <TurnOffAndroidMdm
             onClickTurnOff={() => setShowTurnOffMdmModal(true)}
@@ -123,7 +114,10 @@ const AndroidMdmPage = ({ router }: IAndroidMdmPageProps) => {
         )}
       </div>
       {showTurnOffMdmModal && (
-        <TurnOffAndroidMdmModal onExit={() => setShowTurnOffMdmModal(false)} />
+        <TurnOffAndroidMdmModal
+          router={router}
+          onExit={() => setShowTurnOffMdmModal(false)}
+        />
       )}
     </MainContent>
   );

--- a/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/AndroidMdmPage/AndroidMdmPage.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/AndroidMdmPage/AndroidMdmPage.tsx
@@ -3,6 +3,8 @@ import { InjectedRouter } from "react-router";
 
 import PATHS from "router/paths";
 import { AppContext } from "context/app";
+import { NotificationContext } from "context/notification";
+import mdmAndroidAPI from "services/entities/mdm_android";
 
 import MainContent from "components/MainContent";
 import BackLink from "components/BackLink";
@@ -20,6 +22,19 @@ interface ITurnOnAndroidMdmProps {
 }
 
 const TurnOnAndroidMdm = ({ onClickConnect }: ITurnOnAndroidMdmProps) => {
+  const { renderFlash } = useContext(NotificationContext);
+  const [fetchingSignupUrl, setFetchingSignupUrl] = useState(false);
+
+  const onConnectMdm = async () => {
+    setFetchingSignupUrl(true);
+    try {
+      await mdmAndroidAPI.getSignupUrl();
+    } catch (e) {
+      renderFlash("error", "Couldn't connect. Please try again");
+    }
+    setFetchingSignupUrl(false);
+  };
+
   return (
     <>
       <div className={`${baseClass}__turn-on-description`}>
@@ -30,7 +45,9 @@ const TurnOnAndroidMdm = ({ onClickConnect }: ITurnOnAndroidMdmProps) => {
           url="https://fleetdm.com/learn-more-about/how-to-connect-android-enterprise"
         />
       </div>
-      <Button onClick={onClickConnect}>Connect</Button>
+      <Button isLoading={fetchingSignupUrl} onClick={onConnectMdm}>
+        Connect
+      </Button>
     </>
   );
 };
@@ -73,14 +90,18 @@ interface IAndroidMdmPageProps {
 }
 
 const AndroidMdmPage = ({ router }: IAndroidMdmPageProps) => {
-  let { isAndroidMdmEnabledAndConfigured } = useContext(AppContext);
-
-  isAndroidMdmEnabledAndConfigured = true;
+  const { isAndroidMdmEnabledAndConfigured } = useContext(AppContext);
+  const { renderFlash } = useContext(NotificationContext);
+  const [fetchingSignupUrl, setFetchingSignupUrl] = useState(false);
 
   const [showTurnOffMdmModal, setShowTurnOffMdmModal] = useState(false);
 
-  const onConnectMdm = () => {
-    return false;
+  const onConnectMdm = async () => {
+    try {
+      await mdmAndroidAPI.getSignupUrl();
+    } catch (e) {
+      renderFlash("error", "Couldn't connect. Please try again");
+    }
   };
 
   return (

--- a/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/AndroidMdmPage/AndroidMdmPage.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/AndroidMdmPage/AndroidMdmPage.tsx
@@ -1,10 +1,12 @@
 import React, { useContext, useState } from "react";
 import { InjectedRouter } from "react-router";
+import { useQuery } from "react-query";
 
 import PATHS from "router/paths";
 import { AppContext } from "context/app";
 import { NotificationContext } from "context/notification";
 import mdmAndroidAPI from "services/entities/mdm_android";
+import { DEFAULT_USE_QUERY_OPTIONS } from "utilities/constants";
 
 import MainContent from "components/MainContent";
 import BackLink from "components/BackLink";
@@ -12,14 +14,14 @@ import Button from "components/buttons/Button";
 import DataSet from "components/DataSet";
 import TooltipWrapper from "components/TooltipWrapper";
 import CustomLink from "components/CustomLink";
+import Spinner from "components/Spinner";
+import DataError from "components/DataError";
 
 import TurnOffAndroidMdmModal from "./components/TurnOffAndroidMdmModal";
 
 const baseClass = "android-mdm-page";
 
-interface ITurnOnAndroidMdmProps {}
-
-const TurnOnAndroidMdm = ({}: ITurnOnAndroidMdmProps) => {
+const TurnOnAndroidMdm = () => {
   const { renderFlash } = useContext(NotificationContext);
   const [fetchingSignupUrl, setFetchingSignupUrl] = useState(false);
 
@@ -55,6 +57,24 @@ interface ITurnOffAndroidMdmProps {
 }
 
 const TurnOffAndroidMdm = ({ onClickTurnOff }: ITurnOffAndroidMdmProps) => {
+  const { data, isLoading, isError } = useQuery(
+    ["androidEnterprise"],
+    () => mdmAndroidAPI.getAndroidEnterprise(),
+    {
+      ...DEFAULT_USE_QUERY_OPTIONS,
+    }
+  );
+
+  if (isLoading) {
+    return <Spinner />;
+  }
+
+  if (isError) {
+    return <DataError />;
+  }
+
+  if (!data) return null;
+
   return (
     <>
       <DataSet
@@ -76,7 +96,7 @@ const TurnOffAndroidMdm = ({ onClickTurnOff }: ITurnOffAndroidMdmProps) => {
             Android Enterprise Id
           </TooltipWrapper>
         }
-        value="1234"
+        value={data.android_enterprise_id}
       />
       <Button onClick={onClickTurnOff}>Turn off Android MDM</Button>
     </>
@@ -88,8 +108,7 @@ interface IAndroidMdmPageProps {
 }
 
 const AndroidMdmPage = ({ router }: IAndroidMdmPageProps) => {
-  let { isAndroidMdmEnabledAndConfigured } = useContext(AppContext);
-  isAndroidMdmEnabledAndConfigured = true;
+  const { isAndroidMdmEnabledAndConfigured } = useContext(AppContext);
 
   const { renderFlash } = useContext(NotificationContext);
 

--- a/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/AndroidMdmPage/AndroidMdmPage.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/AndroidMdmPage/AndroidMdmPage.tsx
@@ -1,0 +1,11 @@
+import React from "react";
+
+const baseClass = "android-mdm-page";
+
+interface IAndroidMdmPageProps {}
+
+const AndroidMdmPage = ({}: IAndroidMdmPageProps) => {
+  return <div className={baseClass}>Android Page</div>;
+};
+
+export default AndroidMdmPage;

--- a/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/AndroidMdmPage/AndroidMdmPage.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/AndroidMdmPage/AndroidMdmPage.tsx
@@ -1,11 +1,111 @@
-import React from "react";
+import React, { useContext, useState } from "react";
+import { InjectedRouter } from "react-router";
+
+import PATHS from "router/paths";
+import { AppContext } from "context/app";
+
+import MainContent from "components/MainContent";
+import BackLink from "components/BackLink";
+import Button from "components/buttons/Button";
+import DataSet from "components/DataSet";
+import TooltipWrapper from "components/TooltipWrapper";
+import CustomLink from "components/CustomLink";
+
+import TurnOffAndroidMdmModal from "./components/TurnOffAndroidMdmModal";
 
 const baseClass = "android-mdm-page";
 
-interface IAndroidMdmPageProps {}
+interface ITurnOnAndroidMdmProps {
+  onClickConnect: () => void;
+}
 
-const AndroidMdmPage = ({}: IAndroidMdmPageProps) => {
-  return <div className={baseClass}>Android Page</div>;
+const TurnOnAndroidMdm = ({ onClickConnect }: ITurnOnAndroidMdmProps) => {
+  return (
+    <>
+      <div className={`${baseClass}__turn-on-description`}>
+        <p>Connect Android Enterprise to turn on Android MDM. </p>
+        <CustomLink
+          text="Learn More"
+          newTab
+          url="https://fleetdm.com/learn-more-about/how-to-connect-android-enterprise"
+        />
+      </div>
+      <Button onClick={onClickConnect}>Connect</Button>
+    </>
+  );
+};
+
+interface ITurnOffAndroidMdmProps {
+  onClickTurnOff: () => void;
+}
+
+const TurnOffAndroidMdm = ({ onClickTurnOff }: ITurnOffAndroidMdmProps) => {
+  return (
+    <>
+      <DataSet
+        title={
+          <TooltipWrapper
+            position="top"
+            tipContent={
+              <>
+                Android Enterprise in{" "}
+                <CustomLink
+                  newTab
+                  text="Google Admin Console"
+                  url="https://fleetdm.com/learn-more-about/google-admin-emm"
+                  variant="tooltip-link"
+                />
+              </>
+            }
+          >
+            Android Enterprise Id
+          </TooltipWrapper>
+        }
+        value="1234"
+      />
+      <Button onClick={onClickTurnOff}>Turn off Android MDM</Button>
+    </>
+  );
+};
+
+interface IAndroidMdmPageProps {
+  router: InjectedRouter;
+}
+
+const AndroidMdmPage = ({ router }: IAndroidMdmPageProps) => {
+  let { isAndroidMdmEnabledAndConfigured } = useContext(AppContext);
+
+  isAndroidMdmEnabledAndConfigured = true;
+
+  const [showTurnOffMdmModal, setShowTurnOffMdmModal] = useState(false);
+
+  const onConnectMdm = () => {
+    return false;
+  };
+
+  return (
+    <MainContent className={baseClass}>
+      <BackLink
+        text="Back to MDM"
+        path={PATHS.ADMIN_INTEGRATIONS_MDM}
+        className={`${baseClass}__back-to-mdm`}
+      />
+      <h1>Android Enterprise</h1>
+
+      <div className={`${baseClass}__content`}>
+        {!isAndroidMdmEnabledAndConfigured ? (
+          <TurnOnAndroidMdm onClickConnect={onConnectMdm} />
+        ) : (
+          <TurnOffAndroidMdm
+            onClickTurnOff={() => setShowTurnOffMdmModal(true)}
+          />
+        )}
+      </div>
+      {showTurnOffMdmModal && (
+        <TurnOffAndroidMdmModal onExit={() => setShowTurnOffMdmModal(false)} />
+      )}
+    </MainContent>
+  );
 };
 
 export default AndroidMdmPage;

--- a/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/AndroidMdmPage/_styles.scss
+++ b/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/AndroidMdmPage/_styles.scss
@@ -1,3 +1,27 @@
 .android-mdm-page {
+  &__back-to-mdm {
+    margin-bottom: $pad-xlarge;
+  }
 
+  h1 {
+    margin-bottom: $pad-large;
+    font-size: $x-large;
+  }
+
+  &__content {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: $pad-large;
+  }
+
+  &__turn-on-description {
+    display: flex;
+    gap: $pad-small;
+    align-items: center;
+
+    p {
+      margin: 0;
+    }
+  }
 }

--- a/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/AndroidMdmPage/_styles.scss
+++ b/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/AndroidMdmPage/_styles.scss
@@ -1,0 +1,3 @@
+.android-mdm-page {
+
+}

--- a/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/AndroidMdmPage/components/TurnOffAndroidMdmModal/TurnOffAndroidMdmModal.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/AndroidMdmPage/components/TurnOffAndroidMdmModal/TurnOffAndroidMdmModal.tsx
@@ -1,4 +1,9 @@
-import React from "react";
+import React, { useContext } from "react";
+import { InjectedRouter } from "react-router";
+
+import PATHS from "router/paths";
+import mdmAndroidAPI from "services/entities/mdm_android";
+import { NotificationContext } from "context/notification";
 
 import Modal from "components/Modal";
 import Button from "components/buttons/Button";
@@ -7,9 +12,28 @@ const baseClass = "turn-off-android-mdm-modal";
 
 interface ITurnOffAndroidMdmModalProps {
   onExit: () => void;
+  router: InjectedRouter;
 }
 
-const TurnOffAndroidMdmModal = ({ onExit }: ITurnOffAndroidMdmModalProps) => {
+const TurnOffAndroidMdmModal = ({
+  onExit,
+  router,
+}: ITurnOffAndroidMdmModalProps) => {
+  const { renderFlash } = useContext(NotificationContext);
+
+  const onTurnOffAndroidMdm = async () => {
+    try {
+      await mdmAndroidAPI.turnOffAndroidMdm();
+      renderFlash("success", "Android MDM turned off successfully.", {
+        persistOnPageChange: true,
+      });
+      router.push(PATHS.ADMIN_INTEGRATIONS_MDM);
+    } catch (e) {
+      onExit();
+      renderFlash("error", "Couldn't turn off Android MDM. Please try again.");
+    }
+  };
+
   return (
     <Modal title="Turn off Android MDM" className={baseClass} onExit={onExit}>
       <>
@@ -22,7 +46,7 @@ const TurnOffAndroidMdmModal = ({ onExit }: ITurnOffAndroidMdmModalProps) => {
           their Android work partition.
         </p>
         <div className="modal-cta-wrap">
-          <Button onClick={onExit} variant="alert">
+          <Button onClick={onTurnOffAndroidMdm} variant="alert">
             Turn off
           </Button>
           <Button onClick={onExit} variant="inverse-alert">

--- a/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/AndroidMdmPage/components/TurnOffAndroidMdmModal/TurnOffAndroidMdmModal.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/AndroidMdmPage/components/TurnOffAndroidMdmModal/TurnOffAndroidMdmModal.tsx
@@ -1,0 +1,37 @@
+import React from "react";
+
+import Modal from "components/Modal";
+import Button from "components/buttons/Button";
+
+const baseClass = "turn-off-android-mdm-modal";
+
+interface ITurnOffAndroidMdmModalProps {
+  onExit: () => void;
+}
+
+const TurnOffAndroidMdmModal = ({ onExit }: ITurnOffAndroidMdmModalProps) => {
+  return (
+    <Modal title="Turn off Android MDM" className={baseClass} onExit={onExit}>
+      <>
+        <p>
+          If you want to use MDM features again, you&apos;ll have to reconnect
+          Android Enterprise.
+        </p>
+        <p>
+          End users will lose access to organization resources and all data in
+          their Android work partition.
+        </p>
+        <div className="modal-cta-wrap">
+          <Button onClick={onExit} variant="alert">
+            Turn off
+          </Button>
+          <Button onClick={onExit} variant="inverse-alert">
+            Cancel
+          </Button>
+        </div>
+      </>
+    </Modal>
+  );
+};
+
+export default TurnOffAndroidMdmModal;

--- a/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/AndroidMdmPage/components/TurnOffAndroidMdmModal/_styles.scss
+++ b/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/AndroidMdmPage/components/TurnOffAndroidMdmModal/_styles.scss
@@ -1,0 +1,3 @@
+.turn-off-android-mdm-modal {
+
+}

--- a/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/AndroidMdmPage/components/TurnOffAndroidMdmModal/index.ts
+++ b/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/AndroidMdmPage/components/TurnOffAndroidMdmModal/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./TurnOffAndroidMdmModal";

--- a/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/AndroidMdmPage/index.ts
+++ b/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/AndroidMdmPage/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./AndroidMdmPage";

--- a/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/components/MdmSettingsSection/AndroidMdmCard/AndroidMdmCard.tests.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/components/MdmSettingsSection/AndroidMdmCard/AndroidMdmCard.tests.tsx
@@ -1,0 +1,35 @@
+import React from "react";
+import { noop } from "lodash";
+import { screen } from "@testing-library/react";
+
+import { createCustomRenderer } from "test/test-utils";
+
+import AndroidMdmCard from "./AndroidMdmCard";
+
+describe("AndroidMdmCard", () => {
+  test("render the expected content when Android MDM is turned off", () => {
+    const render = createCustomRenderer({
+      context: {
+        app: { isAndroidMdmEnabledAndConfigured: false },
+      },
+    });
+
+    render(<AndroidMdmCard turnOffAndroidMdm={noop} editAndroidMdm={noop} />);
+
+    expect(screen.getByText("Turn on Android MDM")).toBeVisible();
+    expect(screen.getByRole("button", { name: "Turn on" })).toBeVisible();
+  });
+
+  test("render the expected content when Android MDM is turned on", () => {
+    const render = createCustomRenderer({
+      context: {
+        app: { isAndroidMdmEnabledAndConfigured: true },
+      },
+    });
+
+    render(<AndroidMdmCard turnOffAndroidMdm={noop} editAndroidMdm={noop} />);
+
+    expect(screen.getByText("Android MDM turned on.")).toBeVisible();
+    expect(screen.getByRole("button", { name: "Edit" })).toBeVisible();
+  });
+});

--- a/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/components/MdmSettingsSection/AndroidMdmCard/AndroidMdmCard.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/components/MdmSettingsSection/AndroidMdmCard/AndroidMdmCard.tsx
@@ -1,0 +1,79 @@
+import React, { useContext } from "react";
+
+import { AppContext } from "context/app";
+
+import Button from "components/buttons/Button";
+import Icon from "components/Icon";
+
+import SectionCard from "../../SectionCard";
+
+const baseClass = "android-mdm-card";
+
+interface ITurnOnAndroidMdmCardProps {
+  onClickTurnOn: () => void;
+}
+
+const TurnOnAndroidMdmCard = ({
+  onClickTurnOn,
+}: ITurnOnAndroidMdmCardProps) => {
+  return (
+    <SectionCard
+      className={baseClass}
+      header="Turn on Android MDM"
+      cta={
+        <Button variant="brand" onClick={onClickTurnOn}>
+          Turn on
+        </Button>
+      }
+    >
+      Enforce settings, OS updates, and more.
+    </SectionCard>
+  );
+};
+
+interface ITurnOffAndroidMdmCardProps {
+  onClickEdit: () => void;
+}
+
+const TurnOffAndroidMdmCard = ({
+  onClickEdit,
+}: ITurnOffAndroidMdmCardProps) => {
+  return (
+    <SectionCard
+      className={baseClass}
+      iconName="success"
+      cta={
+        <Button onClick={onClickEdit} variant="text-icon">
+          <Icon name="pencil" />
+          Edit
+        </Button>
+      }
+    >
+      Android MDM turned on.
+    </SectionCard>
+  );
+};
+
+interface IAndroidMdmCardProps {
+  turnOffAndroidMdm: () => void;
+  editAndroidMdm: () => void;
+}
+
+const AndroidMdmCard = ({
+  turnOffAndroidMdm,
+  editAndroidMdm,
+}: IAndroidMdmCardProps) => {
+  const { isAndroidMdmEnabledAndConfigured } = useContext(AppContext);
+
+  if (isAndroidMdmEnabledAndConfigured === undefined) {
+    return null;
+  }
+
+  return isAndroidMdmEnabledAndConfigured ? (
+    <TurnOffAndroidMdmCard onClickEdit={editAndroidMdm} />
+  ) : (
+    <TurnOnAndroidMdmCard onClickTurnOn={turnOffAndroidMdm} />
+  );
+};
+
+export default AndroidMdmCard;

--- a/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/components/MdmSettingsSection/AndroidMdmCard/_styles.scss
+++ b/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/components/MdmSettingsSection/AndroidMdmCard/_styles.scss
@@ -1,0 +1,3 @@
+.android-mdm-card {
+
+}

--- a/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/components/MdmSettingsSection/AndroidMdmCard/index.ts
+++ b/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/components/MdmSettingsSection/AndroidMdmCard/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./AndroidMdmCard";

--- a/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/components/MdmSettingsSection/MdmSettingsSection.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/components/MdmSettingsSection/MdmSettingsSection.tsx
@@ -11,6 +11,7 @@ import SettingsSection from "pages/admin/components/SettingsSection";
 
 import AppleMdmCard from "./AppleMdmCard";
 import WindowsMdmCard from "./WindowsMdmCard";
+import AndroidMdmCard from "./AndroidMdmCard";
 
 const baseClass = "mdm-settings-section";
 
@@ -58,6 +59,7 @@ const MdmSettingsSection = ({
           turnOnWindowsMdm={navigateToWindowsMdm}
           editWindowsMdm={navigateToWindowsMdm}
         />
+        <AndroidMdmCard />
       </div>
     );
   };

--- a/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/components/MdmSettingsSection/MdmSettingsSection.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/components/MdmSettingsSection/MdmSettingsSection.tsx
@@ -1,9 +1,10 @@
-import React from "react";
+import React, { useContext } from "react";
 import { InjectedRouter } from "react-router";
 import { AxiosError } from "axios";
 
 import PATHS from "router/paths";
 import { IMdmApple } from "interfaces/mdm";
+import { AppContext } from "context/app";
 
 import Spinner from "components/Spinner";
 import DataError from "components/DataError";
@@ -30,6 +31,9 @@ const MdmSettingsSection = ({
   router,
   appleAPNSInfo,
 }: IMdmSectionProps) => {
+  // TODO: feature flag check, remove when feature releases
+  const { config } = useContext(AppContext);
+
   const navigateToAppleMdm = () => {
     router.push(PATHS.ADMIN_INTEGRATIONS_MDM_APPLE);
   };
@@ -63,10 +67,13 @@ const MdmSettingsSection = ({
           turnOnWindowsMdm={navigateToWindowsMdm}
           editWindowsMdm={navigateToWindowsMdm}
         />
-        <AndroidMdmCard
-          turnOffAndroidMdm={navigateToAndroidMdm}
-          editAndroidMdm={navigateToAndroidMdm}
-        />
+        {/* TODO: feature flag check, remove when feature releases */}
+        {config?.android_enabled && (
+          <AndroidMdmCard
+            turnOffAndroidMdm={navigateToAndroidMdm}
+            editAndroidMdm={navigateToAndroidMdm}
+          />
+        )}
       </div>
     );
   };

--- a/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/components/MdmSettingsSection/MdmSettingsSection.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/components/MdmSettingsSection/MdmSettingsSection.tsx
@@ -38,6 +38,10 @@ const MdmSettingsSection = ({
     router.push(PATHS.ADMIN_INTEGRATIONS_MDM_WINDOWS);
   };
 
+  const navigateToAndroidMdm = () => {
+    router.push(PATHS.ADMIN_INTEGRATIONS_MDM_ANDROID);
+  };
+
   const renderContent = () => {
     if (isLoading) {
       return <Spinner />;
@@ -59,7 +63,10 @@ const MdmSettingsSection = ({
           turnOnWindowsMdm={navigateToWindowsMdm}
           editWindowsMdm={navigateToWindowsMdm}
         />
-        <AndroidMdmCard />
+        <AndroidMdmCard
+          turnOffAndroidMdm={navigateToAndroidMdm}
+          editAndroidMdm={navigateToAndroidMdm}
+        />
       </div>
     );
   };

--- a/frontend/router/index.tsx
+++ b/frontend/router/index.tsx
@@ -64,6 +64,7 @@ import OSSettings from "pages/ManageControlsPage/OSSettings";
 import SetupExperience from "pages/ManageControlsPage/SetupExperience/SetupExperience";
 import WindowsMdmPage from "pages/admin/IntegrationsPage/cards/MdmSettings/WindowsMdmPage";
 import AppleMdmPage from "pages/admin/IntegrationsPage/cards/MdmSettings/AppleMdmPage";
+import AndroidMdmPage from "pages/admin/IntegrationsPage/cards/MdmSettings/AndroidMdmPage";
 import ScepPage from "pages/admin/IntegrationsPage/cards/MdmSettings/ScepPage";
 import Scripts from "pages/ManageControlsPage/Scripts/Scripts";
 import WindowsAutomaticEnrollmentPage from "pages/admin/IntegrationsPage/cards/MdmSettings/WindowsAutomaticEnrollmentPage";
@@ -197,6 +198,7 @@ const routes = (
             </Route>
             <Route path="integrations/mdm/windows" component={WindowsMdmPage} />
             <Route path="integrations/mdm/apple" component={AppleMdmPage} />
+            <Route path="integrations/mdm/android" component={AndroidMdmPage} />
             <Route path="integrations/mdm/scep" component={ScepPage} />
             {/* This redirect is used to handle old apple automatic enrollments page */}
             <Redirect

--- a/frontend/router/paths.ts
+++ b/frontend/router/paths.ts
@@ -43,6 +43,7 @@ export default {
   ADMIN_INTEGRATIONS_MDM: `${URL_PREFIX}/settings/integrations/mdm`,
   ADMIN_INTEGRATIONS_MDM_APPLE: `${URL_PREFIX}/settings/integrations/mdm/apple`,
   ADMIN_INTEGRATIONS_MDM_WINDOWS: `${URL_PREFIX}/settings/integrations/mdm/windows`,
+  ADMIN_INTEGRATIONS_MDM_ANDROID: `${URL_PREFIX}/settings/integrations/mdm/android`,
   ADMIN_INTEGRATIONS_APPLE_BUSINESS_MANAGER: `${URL_PREFIX}/settings/integrations/mdm/abm`,
   ADMIN_INTEGRATIONS_AUTOMATIC_ENROLLMENT_WINDOWS: `${URL_PREFIX}/settings/integrations/automatic-enrollment/windows`,
   ADMIN_INTEGRATIONS_SCEP: `${URL_PREFIX}/settings/integrations/mdm/scep`,

--- a/frontend/services/entities/mdm_android.ts
+++ b/frontend/services/entities/mdm_android.ts
@@ -10,4 +10,9 @@ export default {
     const { MDM_ANDROID_SIGNUP_URL } = endpoints;
     return sendRequest("GET", MDM_ANDROID_SIGNUP_URL);
   },
+
+  turnOffAndroidMdm: (): Promise<void> => {
+    const { MDM_ANDROID_ENTERPRISE } = endpoints;
+    return sendRequest("DELETE", MDM_ANDROID_ENTERPRISE);
+  },
 };

--- a/frontend/services/entities/mdm_android.ts
+++ b/frontend/services/entities/mdm_android.ts
@@ -5,10 +5,19 @@ interface IGetAndroidSignupUrlResponse {
   android_enterprise_signup_url: string;
 }
 
+interface IGetAndroidEnterpriseResponse {
+  android_enterprise_id: boolean;
+}
+
 export default {
   getSignupUrl: (): Promise<IGetAndroidSignupUrlResponse> => {
     const { MDM_ANDROID_SIGNUP_URL } = endpoints;
     return sendRequest("GET", MDM_ANDROID_SIGNUP_URL);
+  },
+
+  getAndroidEnterprise: (): Promise<IGetAndroidEnterpriseResponse> => {
+    const { MDM_ANDROID_ENTERPRISE } = endpoints;
+    return sendRequest("GET", MDM_ANDROID_ENTERPRISE);
   },
 
   turnOffAndroidMdm: (): Promise<void> => {

--- a/frontend/services/entities/mdm_android.ts
+++ b/frontend/services/entities/mdm_android.ts
@@ -1,0 +1,13 @@
+import sendRequest from "services";
+import endpoints from "utilities/endpoints";
+
+interface IGetAndroidSignupUrlResponse {
+  android_enterprise_signup_url: string;
+}
+
+export default {
+  getSignupUrl: (): Promise<IGetAndroidSignupUrlResponse> => {
+    const { MDM_ANDROID_SIGNUP_URL } = endpoints;
+    return sendRequest("GET", MDM_ANDROID_SIGNUP_URL);
+  },
+};

--- a/frontend/utilities/endpoints.ts
+++ b/frontend/utilities/endpoints.ts
@@ -87,6 +87,8 @@ export default {
 
   MDM_SUMMARY: `/${API_VERSION}/fleet/hosts/summary/mdm`,
 
+  MDM_ANDROID_SIGNUP_URL: `/${API_VERSION}/fleet/android_enterprise/signup_url`,
+
   // apple mdm endpoints
   MDM_APPLE: `/${API_VERSION}/fleet/mdm/apple`,
 

--- a/frontend/utilities/endpoints.ts
+++ b/frontend/utilities/endpoints.ts
@@ -87,6 +87,7 @@ export default {
 
   MDM_SUMMARY: `/${API_VERSION}/fleet/hosts/summary/mdm`,
 
+  MDM_ANDROID_ENTERPRISE: `/${API_VERSION}/fleet/android_enterprise`,
   MDM_ANDROID_SIGNUP_URL: `/${API_VERSION}/fleet/android_enterprise/signup_url`,
 
   // apple mdm endpoints

--- a/frontend/utilities/permissions/permissions.ts
+++ b/frontend/utilities/permissions/permissions.ts
@@ -21,6 +21,10 @@ export const isWindowsMdmEnabledAndConfigured = (config: IConfig): boolean => {
   return Boolean(config.mdm.windows_enabled_and_configured);
 };
 
+export const isAndroidMdmEnabledAndConfigured = (config: IConfig): boolean => {
+  return Boolean(config.mdm.android_enabled_and_configured);
+};
+
 export const isGlobalAdmin = (user: IUser): boolean => {
   return user.global_role === "admin";
 };
@@ -148,6 +152,7 @@ export default {
   isPremiumTier,
   isMacMdmEnabledAndConfigured,
   isWindowsMdmEnabledAndConfigured,
+  isAndroidMdmEnabledAndConfigured,
   isGlobalAdmin,
   isGlobalMaintainer,
   isGlobalObserver,


### PR DESCRIPTION
For #26207

Adds UI for turning the android mdm on and off. This is currently hidden behind a feature flag. To enable use FLEET_DEV_ANDROID_ENABLED=1 when running your fleet server.

This includes:

**android mdm on and off card:**

![image](https://github.com/user-attachments/assets/4205f364-7c90-47c5-bb67-37a571e6a713)

![image](https://github.com/user-attachments/assets/67839f8f-fc51-43bc-b1ce-86b793b60ed2)

**Android mdm page off state**

![image](https://github.com/user-attachments/assets/fe12d0ac-9395-42a2-ab10-ea027bc560ba)

**Andoid mdm page on state**

![image](https://github.com/user-attachments/assets/d1ca80b1-6794-47ce-ab16-d0603295d581)

**Turn off android mdm modal**

![image](https://github.com/user-attachments/assets/18e69319-5b29-4d70-a9e0-7ff3c489e2aa)

> NOTE: will need to come back and revisit this for the SSE handling when android mdm is successfully turned on.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/Committing-Changes.md#changes-files) for more information.
- [ ] Added/updated automated tests
- [x] Manual QA for all new/changed functionality
