### PR TITLE
Cleanup `host_certificates` table on host deletion

### DIFF
--- a/changes/23235-host-certificates
+++ b/changes/23235-host-certificates
@@ -1,0 +1,1 @@
+- Added new features to include certificates in host vitals for macOS, iOS, and iPadOS.

--- a/server/datastore/mysql/hosts.go
+++ b/server/datastore/mysql/hosts.go
@@ -549,6 +549,7 @@ var hostRefs = []string{
 	"host_mdm_actions",
 	"host_calendar_events",
 	"upcoming_activities",
+	"host_certificates",
 }
 
 // NOTE: The following tables are explicity excluded from hostRefs list and accordingly are not

--- a/server/datastore/mysql/hosts_test.go
+++ b/server/datastore/mysql/hosts_test.go
@@ -2,6 +2,7 @@ package mysql
 
 import (
 	"context"
+	"crypto/sha1"
 	"crypto/sha256"
 	"database/sql"
 	"encoding/json"
@@ -7056,6 +7057,13 @@ func testHostsDeleteHosts(t *testing.T, ds *Datastore) {
 	added, err := ds.EnqueueSetupExperienceItems(ctx, host.UUID, 0)
 	require.NoError(t, err)
 	require.True(t, added)
+
+	// Add a host certificate
+	require.NoError(t, ds.UpdateHostCertificates(ctx, host.ID, []*fleet.HostCertificateRecord{{
+		HostID:     host.ID,
+		CommonName: "foo",
+		SHA1Sum:    sha1.New().Sum([]byte("foo")),
+	}}))
 
 	// Check there's an entry for the host in all the associated tables.
 	for _, hostRef := range hostRefs {


### PR DESCRIPTION
For #23235 

# Checklist for submitter
- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
- [x] Added/updated automated tests
- [x] A detailed QA plan exists on the associated ticket (if it isn't there, work with the product group's QA engineer to add it)
- [x] Manual QA for all new/changed functionality

