### PR TITLE
Drop support for macOS 13

### DIFF
--- a/changes/26525-drop-macos-thirteen
+++ b/changes/26525-drop-macos-thirteen
@@ -1,0 +1,1 @@
+Drop support for macOS 13.x.

--- a/docs/Get started/FAQ.md
+++ b/docs/Get started/FAQ.md
@@ -75,7 +75,7 @@ Fleet supports the following operating system versions on hosts.
 
 | OS         | Supported version(s)                    |
 | :--------- | :-------------------------------------- |
-| macOS      | 13+ (Ventura)                           |
+| macOS      | 14+ (Sonoma)                            |
 | iOS/iPadOS | 17+                                     |
 | Windows    | Pro and Enterprise 10+, Server 2012+    |
 | Linux      | CentOS 7.1+, Ubuntu 20.04+, Fedora 38+, Debian 11+ |


### PR DESCRIPTION
Drop support for macOS 13 and no longer need to validate nudge updates