### PR TITLE
feat: add more vuln software to oqp

### DIFF
--- a/cmd/osquery-perf/macos_vulnerable.software
+++ b/cmd/osquery-perf/macos_vulnerable.software
@@ -106,3 +106,7 @@ stashcat##3.9.2
 endpoint_antivirus##6.8.1.0
 webex_meetings##40.1.8.5
 autocad_lt##2022
+safari##16.3
+firefox##123.0
+chrome##126.0.6478.127
+edge_chromium##122.0.2365.92


### PR DESCRIPTION
> no issue. trying to make loadtests with vulnerable software more accurate. these are the sw versions with most vulns from dogfood.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Manual QA for all new/changed functionality

