### PR TITLE
UI: Prevent wrong background color on custom settings tooltip hover

### DIFF
--- a/frontend/pages/ManageControlsPage/OSSettings/cards/CustomSettings/_styles.scss
+++ b/frontend/pages/ManageControlsPage/OSSettings/cards/CustomSettings/_styles.scss
@@ -19,7 +19,7 @@
       .list-item__actions {
         display: none;
       }
-      :hover {
+      :hover:not(.component__tooltip-wrapper__tip-text):not(.custom-link--tooltip-link) {
         background-color: $ui-fleet-blue-10;
         .list-item__labels {
           display: none;


### PR DESCRIPTION
## For a small unreleased bug:

### The bug: 
**(Cursor not captured by screenshots, moving into and out of the tooltip)**
![ezgif-19a136d8ef938f](https://github.com/user-attachments/assets/66ce9403-fcbf-42ba-804d-7c0e917e6416)

### Fixed:
**(Cursor not captured by screenshots, moving into and out of the tooltip)**
![ezgif-176a42a2e2c05c](https://github.com/user-attachments/assets/f17b35e4-a44c-4a5c-a11c-d66c5bb9edc4)

- [x] Manual QA for all new/changed functionality
