### PR TITLE
Change default vuln feed concurrency from 5 to 1

### DIFF
--- a/changes/vulns-max-concurrency
+++ b/changes/vulns-max-concurrency
@@ -1,0 +1,1 @@
+* Updated default for vulnerabilities max concurrency from 5 to 1.

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -1312,7 +1312,7 @@ func (man Manager) addConfigs() {
 	)
 	man.addConfigInt(
 		"vulnerabilities.max_concurrency",
-		5,
+		1,
 		"Maximum number of concurrent database queries to use for processing vulnerabilities.",
 	)
 


### PR DESCRIPTION
We're seeing database load issues at the default concurrency level, so need to pick a significantly more conservative default, which we've rolled out to a number of environments already as an override.

QA'd by adding the following at the top of `newVulnerabilitiesSchedule` in `cron.go`:

```go
	fmt.Printf("%+v\n", config)
```

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/Committing-Changes.md#changes-files) for more information.
- [x] A detailed QA plan exists on the associated ticket (if it isn't there, work with the product group's QA engineer to add it)
- [x] Manual QA for all new/changed functionality