### PR TITLE
YAML reference docs: fix indenting

### DIFF
--- a/docs/Configuration/yaml-files.md
+++ b/docs/Configuration/yaml-files.md
@@ -347,9 +347,9 @@ software:
         - Customer Support
   app_store_apps:
     - app_store_id: '1091189122'
-        labels_include_any:
-          - Product
-          - Marketing
+      labels_include_any:
+        - Product
+        - Marketing
 ```
 
 Use `labels_include_any` to target hosts that have any label in the array or `labels_exclude_any` to target hosts that don't have any label in the array. Only one of `labels_include_any` or `labels_exclude_any` can be specified. If neither are specified, all hosts are targeted.


### PR DESCRIPTION
Fix example [here](https://fleetdm.com/docs/configuration/yaml-files#example5):

![Screenshot 2025-02-24 at 3 18 38 PM](https://github.com/user-attachments/assets/64524043-190a-4194-af3a-b2ad2fb47358)

