### PR TITLE
Add validation extension to the make decoder flow, validate order_key

### DIFF
--- a/server/service/devices.go
+++ b/server/service/devices.go
@@ -695,6 +695,13 @@ type listDeviceCertificatesRequest struct {
 	fleet.ListOptions
 }
 
+func (r *listDeviceCertificatesRequest) ValidateRequest() error {
+	if r.ListOptions.OrderKey != "" && !listHostCertificatesSortCols[r.ListOptions.OrderKey] {
+		return badRequest("invalid order key")
+	}
+	return nil
+}
+
 func (r *listDeviceCertificatesRequest) deviceAuthToken() string {
 	return r.Token
 }

--- a/server/service/endpoint_utils.go
+++ b/server/service/endpoint_utils.go
@@ -41,12 +41,6 @@ func decodeBody(ctx context.Context, r *http.Request, v reflect.Value, body io.R
 	return nil
 }
 
-// A value that implements listOptionsValidator is called with the decoded
-// ListOptions struct to validate its options.
-type listOptionsValidator interface {
-	ValidateListOptions(opts fleet.ListOptions) error
-}
-
 func parseCustomTags(urlTagValue string, r *http.Request, field reflect.Value) (bool, error) {
 	switch urlTagValue {
 	case "list_options":

--- a/server/service/endpoint_utils.go
+++ b/server/service/endpoint_utils.go
@@ -47,52 +47,41 @@ type listOptionsValidator interface {
 	ValidateListOptions(opts fleet.ListOptions) error
 }
 
-func parseCustomTags(urlTagValue string, r *http.Request, requestStruct, field reflect.Value) (bool, error) {
-	var listOpts fleet.ListOptions
-
+func parseCustomTags(urlTagValue string, r *http.Request, field reflect.Value) (bool, error) {
 	switch urlTagValue {
 	case "list_options":
 		opts, err := listOptionsFromRequest(r)
 		if err != nil {
 			return false, err
 		}
-		listOpts = opts
 		field.Set(reflect.ValueOf(opts))
+		return true, nil
 
 	case "user_options":
 		opts, err := userListOptionsFromRequest(r)
 		if err != nil {
 			return false, err
 		}
-		listOpts = opts.ListOptions
 		field.Set(reflect.ValueOf(opts))
+		return true, nil
 
 	case "host_options":
 		opts, err := hostListOptionsFromRequest(r)
 		if err != nil {
 			return false, err
 		}
-		listOpts = opts.ListOptions
 		field.Set(reflect.ValueOf(opts))
+		return true, nil
 
 	case "carve_options":
 		opts, err := carveListOptionsFromRequest(r)
 		if err != nil {
 			return false, err
 		}
-		listOpts = opts.ListOptions
 		field.Set(reflect.ValueOf(opts))
-
-	default:
-		return false, nil
+		return true, nil
 	}
-
-	if lov, ok := requestStruct.Interface().(listOptionsValidator); ok {
-		if err := lov.ValidateListOptions(listOpts); err != nil {
-			return false, err
-		}
-	}
-	return true, nil
+	return false, nil
 }
 
 func jsonDecode(body io.Reader, req any) error {

--- a/server/service/integration_core_test.go
+++ b/server/service/integration_core_test.go
@@ -13068,18 +13068,13 @@ func (s *integrationTestSuite) TestHostCertificates() {
 		return names
 	}
 
-	// invalid sort column silently defaults to "common_name"
+	// fails if order_key  is invalid
 	certResp = listHostCertificatesResponse{}
-	s.DoJSON("GET", fmt.Sprintf("/api/latest/fleet/hosts/%d/certificates", host.ID), nil, http.StatusOK, &certResp, "order_key", "no-such-column")
-	require.Len(t, certResp.Certificates, len(certNames))
-	require.Equal(t, certNames, pluckCertNames(certResp.Certificates))
+	s.DoJSON("GET", fmt.Sprintf("/api/latest/fleet/hosts/%d/certificates", host.ID), nil, http.StatusBadRequest, &certResp, "order_key", "no-such-column")
 
 	certResp = listHostCertificatesResponse{}
-	res = s.DoRawNoAuth("GET", "/api/latest/fleet/device/"+token+"/certificates", nil, http.StatusOK, "order_key", "no-such-column")
-	err = json.NewDecoder(res.Body).Decode(&certResp)
-	require.NoError(t, err)
-	require.Len(t, certResp.Certificates, len(certNames))
-	require.Equal(t, certNames, pluckCertNames(certResp.Certificates))
+	res = s.DoRawNoAuth("GET", "/api/latest/fleet/device/"+token+"/certificates", nil, http.StatusBadRequest, "order_key", "no-such-column")
+	require.Contains(t, extractServerErrorText(res.Body), "invalid order key")
 
 	// test the pagination options
 	cases := []struct {

--- a/server/service/middleware/endpoint_utils/endpoint_utils.go
+++ b/server/service/middleware/endpoint_utils/endpoint_utils.go
@@ -330,7 +330,7 @@ type requestValidator interface {
 func MakeDecoder(
 	iface interface{},
 	jsonUnmarshal func(body io.Reader, req any) error,
-	parseCustomTags func(urlTagValue string, r *http.Request, requestStruct, field reflect.Value) (bool, error),
+	parseCustomTags func(urlTagValue string, r *http.Request, field reflect.Value) (bool, error),
 	isBodyDecoder func(reflect.Value) bool,
 	decodeBody func(ctx context.Context, r *http.Request, v reflect.Value, body io.Reader) error,
 ) kithttp.DecodeRequestFunc {
@@ -393,7 +393,7 @@ func MakeDecoder(
 				}
 				foundValue := false
 				if parseCustomTags != nil {
-					foundValue, err = parseCustomTags(urlTagValue, r, v, field)
+					foundValue, err = parseCustomTags(urlTagValue, r, field)
 					if err != nil {
 						return nil, err
 					}


### PR DESCRIPTION
For #25460 , added a generic validation extension hook to do the validation of sort column.

# Checklist for submitter

- [x] Added/updated automated tests
