### PR TITLE
Fix database and caching setup on fleet helm chart

### DIFF
--- a/charts/fleet/README.md
+++ b/charts/fleet/README.md
@@ -10,20 +10,35 @@ This Helm chart does not auto-provision a namespace. You can add one with `kubec
 
 #### 2. Create the necessary secrets
 
-This Helm chart does not create the Kubernetes `Secret`s necessary for Fleet to operate. At a minimum, secrets for the MySQL password must be created. For example, if you are deploying into a namespace called `fleet`:
+This Helm chart does not create the Kubernetes `Secret`s necessary for Fleet to operate. You'll need to create secrets for both MySQL and Redis. For example, if you are deploying into a namespace called `fleet`:
 
 ```yaml
----
+# MySQL secret
 kind: Secret
 apiVersion: v1
 metadata:
   name: mysql
   namespace: fleet
 stringData:
-  mysql-password: this-is-a-bad-password
+  mysql-password: your-mysql-password
+  mysql-root-password: your-mysql-root-password
+
+---
+# Redis secret
+kind: Secret
+apiVersion: v1
+metadata:
+  name: redis
+  namespace: fleet
+stringData:
+  redis-password: your-redis-password
 ```
 
-If you use Fleet's TLS capabilities, TLS connections to the MySQL server, or AWS access secret keys, additional secrets and keys are needed. The name of each `Secret` must match the value of `secretName` for each section in the `values.yaml` file and the key of each secret must match the related key value from the values file. For example, to configure Fleet's TLS, you would use a Secret like the one below.
+The secret names and keys must match the values specified in your `values.yaml` file:
+- For MySQL: `database.secretName` and `mysql.auth.existingSecret`
+- For Redis: `cache.secretName` and `redis.auth.existingSecret`
+
+If you use Fleet's TLS capabilities, you'll need additional secrets. For example, to configure Fleet's TLS:
 
 ```yaml
 kind: Secret
@@ -40,13 +55,54 @@ stringData:
 
 Once all of your secrets are configured, use `kubectl apply -f <secret_file_name.yaml> --namespace <your_namespace>` to create them in the cluster.
 
-#### 3. Further Configuration
+#### 3. Configuration
+
+The chart includes built-in MySQL and Redis deployments that can be enabled through the `values.yaml` file. Key configuration options include:
+
+##### Database Configuration
+```yaml
+mysql:
+  enabled: true  # Set to true to use the built-in MySQL
+  auth:
+    database: fleet
+    username: fleet
+    existingSecret: mysql
+    passwordKey: mysql-password
+    rootPasswordKey: mysql-root-password
+    createDatabase: true
+
+database:
+  secretName: mysql
+  address: fleet-mysql-headless:3306  # Use this address for the built-in MySQL
+  database: fleet
+  username: fleet
+  passwordKey: mysql-password
+```
+
+##### Redis Configuration
+```yaml
+redis:
+  enabled: true  # Set to true to use the built-in Redis
+  auth:
+    enabled: true
+    existingSecret: redis
+    existingSecretPasswordKey: redis-password
+  replica:
+    replicaCount: 3  # Number of Redis replicas
+
+cache:
+  address: fleet-redis-master:6379  # Use this address for the built-in Redis
+  database: "0"
+  usePassword: true
+  secretName: redis
+  passwordKey: redis-password
+```
 
 To configure how Fleet runs, such as specifying the number of Fleet instances to deploy or changing the logger plugin for Fleet, edit the `values.yaml` file to your desired settings.
 
 #### 4. Deploy Fleet
 
-Once the secrets have been created and you have updated the values to match your required configuration, you can deploy with the following command.
+Once the secrets have been created and you have updated the values to match your required configuration, you can deploy with the following command:
 
 ```sh
 helm upgrade --install fleet fleet \

--- a/charts/fleet/values.yaml
+++ b/charts/fleet/values.yaml
@@ -70,7 +70,7 @@ fleet:
   # Add extra annotations to the migration Job
   migrationJobAnnotations:
   tls:
-    enabled: false
+    enabled: true
     # Set to true if you need a separate secret for just TLS data.
     # Useful with cert-manager and similar deployments.
     uniqueTLSSecret: false

--- a/charts/fleet/values.yaml
+++ b/charts/fleet/values.yaml
@@ -70,7 +70,7 @@ fleet:
   # Add extra annotations to the migration Job
   migrationJobAnnotations:
   tls:
-    enabled: true
+    enabled: false
     # Set to true if you need a separate secret for just TLS data.
     # Useful with cert-manager and similar deployments.
     uniqueTLSSecret: false
@@ -179,7 +179,7 @@ osquery:
 database:
   # Name of the Secret resource containing MySQL password and TLS secrets
   secretName: mysql
-  address: 127.0.0.1:3306
+  address: fleet-mysql-headless:3306
   database: fleet
   username: fleet
   passwordKey: mysql-password
@@ -199,9 +199,9 @@ database:
 ## Section: cache
 # All of the connection settings for Redis
 cache:
-  address: 127.0.0.1:6379
+  address: fleet-redis-master:6379
   database: "0"
-  usePassword: false
+  usePassword: true
   secretName: redis
   passwordKey: redis-password
 
@@ -248,7 +248,21 @@ environments:
 #       key: secret-key-name
 
 mysql:
-  enabled: false
+  enabled: true
+  auth:
+    database: fleet
+    username: fleet
+    existingSecret: mysql
+    passwordKey: mysql-password
+    rootPasswordKey: mysql-root-password
+    createDatabase: true
+ 
 
 redis:
-  enabled: false
+  enabled: true
+  auth:
+    enabled: true
+    existingSecret: redis
+    existingSecretPasswordKey: redis-password
+  replica:
+    replicaCount: 3


### PR DESCRIPTION
Updated Fleet Helm chart configuration to improve database and caching setup:

- Enabled and configured built-in MySQL and Redis deployments in default values.yaml
- Added proper authentication for Redis with support for password-protected connections
- Updated database connection settings to use correct service endpoints
- Improved MySQL initialization and connection handling
- Enhanced documentation with detailed examples for MySQL and Redis secret creation
- Added comprehensive configuration examples in README.md for both database and cache settings

These changes make it easier to deploy Fleet with its dependencies while following security best practices for authentication and connection management.

https://github.com/fleetdm/fleet/issues/26580