### PR TITLE
Feat UI byod landing page

### DIFF
--- a/changes/issue-26211-byod-android-ui
+++ b/changes/issue-26211-byod-android-ui
@@ -1,0 +1,1 @@
+- add UI to the BYOD enrollment page to support enrolling android devices into fleet mdm.

--- a/cmd/fleet/serve.go
+++ b/cmd/fleet/serve.go
@@ -1096,7 +1096,7 @@ the way that the Fleet server works.
 					config.Server.URLPrefix,
 					appCfg.MDM.EnabledAndConfigured,
 					appCfg.MDM.AndroidEnabledAndConfigured,
-					appCfg.MDM.AndroidEnabledAndConfigured, // TODO: remove android feature flag
+					os.Getenv("FLEET_DEV_ANDROID_ENABLED") == "1",
 					logger,
 				)
 			}

--- a/cmd/fleet/serve.go
+++ b/cmd/fleet/serve.go
@@ -1096,7 +1096,7 @@ the way that the Fleet server works.
 					config.Server.URLPrefix,
 					appCfg.MDM.EnabledAndConfigured,
 					appCfg.MDM.AndroidEnabledAndConfigured,
-					false, // TODO: remove android feature flag
+					appCfg.MDM.AndroidEnabledAndConfigured, // TODO: remove android feature flag
 					logger,
 				)
 			}

--- a/cmd/fleet/serve.go
+++ b/cmd/fleet/serve.go
@@ -1090,7 +1090,15 @@ the way that the Fleet server works.
 					frontendHandler = service.RedirectSetupToLogin(svc, logger, frontendHandler, config.Server.URLPrefix)
 				}
 
-				endUserEnrollOTAHandler = service.ServeEndUserEnrollOTA(svc, config.Server.URLPrefix, logger)
+				// TODO: need a mechanism to check if android feature is enabled
+				endUserEnrollOTAHandler = service.ServeEndUserEnrollOTA(
+					svc,
+					config.Server.URLPrefix,
+					appCfg.MDM.EnabledAndConfigured,
+					appCfg.MDM.AndroidEnabledAndConfigured,
+					false, // TODO: remove android feature flag
+					logger,
+				)
 			}
 
 			healthCheckers := make(map[string]health.Checker)

--- a/frontend/components/AddHostsModal/AddHostsModal.tests.tsx
+++ b/frontend/components/AddHostsModal/AddHostsModal.tests.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { screen } from "@testing-library/react";
 import { noop } from "lodash";
 import { createCustomRenderer } from "test/test-utils";
-import createMockConfig from "__mocks__/configMock";
+import createMockConfig, { createMockMdmConfig } from "__mocks__/configMock";
 
 import AddHostsModal from "./AddHostsModal";
 
@@ -73,9 +73,10 @@ describe("AddHostsModal", () => {
     expect(screen.queryByText(/--enable-scripts/i)).not.toBeInTheDocument();
 
     await user.click(screen.getByRole("tab", { name: "iOS & iPadOS" }));
-    expect(
-      screen.queryByText(/Send this to your end users:/i)
-    ).toBeInTheDocument();
+    expect(screen.queryByText(/Turn on Apple MDM/i)).toBeInTheDocument();
+
+    await user.click(screen.getByRole("tab", { name: "Android" }));
+    expect(screen.queryByText(/Turn on Android MDM/i)).toBeInTheDocument();
 
     await user.click(screen.getByRole("tab", { name: "Advanced" }));
     const advancedText = screen.getByText(/--type=YOUR_TYPE/i);
@@ -92,6 +93,60 @@ describe("AddHostsModal", () => {
     );
     expect(osquerydCommand).toBeInTheDocument();
     expect(screen.queryByText(/--enable-scripts/i)).not.toBeInTheDocument();
+  });
+
+  it("renders enroll url input for ios & ipadOS if mac mdm is enabled", async () => {
+    const render = createCustomRenderer({
+      withBackendMock: true,
+      context: {
+        app: {
+          isMacMdmEnabledAndConfigured: true,
+          isPreviewMode: false,
+          config: createMockConfig(),
+        },
+      },
+    });
+
+    const { user } = render(
+      <AddHostsModal
+        isAnyTeamSelected
+        enrollSecret={ENROLL_SECRET}
+        isLoading={false}
+        onCancel={noop}
+      />
+    );
+
+    await user.click(screen.getByRole("tab", { name: "iOS & iPadOS" }));
+    expect(
+      screen.queryByText(/Send this to your end users:/i)
+    ).toBeInTheDocument();
+  });
+
+  it("renders enroll url input for android if android mdm is enabled", async () => {
+    const render = createCustomRenderer({
+      withBackendMock: true,
+      context: {
+        app: {
+          isAndroidMdmEnabledAndConfigured: true,
+          isPreviewMode: false,
+          config: createMockConfig(),
+        },
+      },
+    });
+
+    const { user } = render(
+      <AddHostsModal
+        isAnyTeamSelected
+        enrollSecret={ENROLL_SECRET}
+        isLoading={false}
+        onCancel={noop}
+      />
+    );
+
+    await user.click(screen.getByRole("tab", { name: "Android" }));
+    expect(
+      screen.queryByText(/Send this to your end users:/i)
+    ).toBeInTheDocument();
   });
 
   it("renders installer with secret", async () => {

--- a/frontend/components/AddHostsModal/PlatformWrapper/AndroidPanel/AndroidPanel.tsx
+++ b/frontend/components/AddHostsModal/PlatformWrapper/AndroidPanel/AndroidPanel.tsx
@@ -1,0 +1,55 @@
+import React, { useContext } from "react";
+import { Link } from "react-router";
+
+import PATHS from "router/paths";
+import { AppContext } from "context/app";
+
+// @ts-ignore
+import InputField from "components/forms/fields/InputField";
+
+const generateUrl = (serverUrl: string, enrollSecret: string) => {
+  return `${serverUrl}/enroll?enroll_secret=${encodeURIComponent(
+    enrollSecret
+  )}`;
+};
+
+const baseClass = "android-panel";
+
+interface IAndroidPanelProps {
+  enrollSecret: string;
+}
+
+const AndroidPanel = ({ enrollSecret }: IAndroidPanelProps) => {
+  const { config, isAndroidMdmEnabledAndConfigured } = useContext(AppContext);
+
+  if (!config) return null;
+
+  if (!isAndroidMdmEnabledAndConfigured) {
+    return (
+      <p>
+        <Link to={PATHS.ADMIN_INTEGRATIONS_MDM_ANDROID}>
+          Turn on Android MDM
+        </Link>{" "}
+        to enroll Android hosts.
+      </p>
+    );
+  }
+
+  const url = generateUrl(config.server_settings.server_url, enrollSecret);
+
+  return (
+    <div className={baseClass}>
+      <InputField
+        label="Send this to your end users:"
+        enableCopy
+        copyButtonPosition="inside"
+        readOnly
+        inputWrapperClass
+        name="enroll-link"
+        value={url}
+      />
+    </div>
+  );
+};
+
+export default AndroidPanel;

--- a/frontend/components/AddHostsModal/PlatformWrapper/AndroidPanel/_styles.scss
+++ b/frontend/components/AddHostsModal/PlatformWrapper/AndroidPanel/_styles.scss
@@ -1,0 +1,3 @@
+.android-panel {
+
+}

--- a/frontend/components/AddHostsModal/PlatformWrapper/AndroidPanel/index.ts
+++ b/frontend/components/AddHostsModal/PlatformWrapper/AndroidPanel/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./AndroidPanel";

--- a/frontend/components/AddHostsModal/PlatformWrapper/IosIpadosPanel/IosIpadosPanel.tsx
+++ b/frontend/components/AddHostsModal/PlatformWrapper/IosIpadosPanel/IosIpadosPanel.tsx
@@ -1,5 +1,7 @@
 import React, { useContext } from "react";
+import { Link } from "react-router";
 
+import PATHS from "router/paths";
 import { AppContext } from "context/app";
 
 // @ts-ignore
@@ -18,7 +20,7 @@ interface IosIpadosPanelProps {
 }
 
 const IosIpadosPanel = ({ enrollSecret }: IosIpadosPanelProps) => {
-  const { config } = useContext(AppContext);
+  const { config, isMacMdmEnabledAndConfigured } = useContext(AppContext);
 
   const helpText =
     "When the end user navigates to this URL, the enrollment profile " +
@@ -26,6 +28,15 @@ const IosIpadosPanel = ({ enrollSecret }: IosIpadosPanelProps) => {
     "to enroll to Fleet.";
 
   if (!config) return null;
+
+  if (!isMacMdmEnabledAndConfigured) {
+    return (
+      <p>
+        <Link to={PATHS.ADMIN_INTEGRATIONS_MDM_APPLE}>Turn on Apple MDM</Link>{" "}
+        to enroll iOS & iPadOS hosts.
+      </p>
+    );
+  }
 
   const url = generateUrl(config.server_settings.server_url, enrollSecret);
 

--- a/frontend/components/AddHostsModal/PlatformWrapper/PlatformWrapper.tsx
+++ b/frontend/components/AddHostsModal/PlatformWrapper/PlatformWrapper.tsx
@@ -21,6 +21,7 @@ import TabText from "components/TabText";
 
 import { isValidPemCertificate } from "../../../pages/hosts/ManageHostsPage/helpers";
 import IosIpadosPanel from "./IosIpadosPanel";
+import AndroidPanel from "./AndroidPanel";
 
 interface IPlatformSubNav {
   name: string;
@@ -47,6 +48,10 @@ const platformSubNav: IPlatformSubNav[] = [
   {
     name: "iOS & iPadOS",
     type: "ios-ipados",
+  },
+  {
+    name: "Android",
+    type: "android",
   },
   {
     name: "Advanced",
@@ -411,6 +416,10 @@ const PlatformWrapper = ({
 
     if (packageType === "ios-ipados") {
       return <IosIpadosPanel enrollSecret={enrollSecret} />;
+    }
+
+    if (packageType === "android") {
+      return <AndroidPanel enrollSecret={enrollSecret} />;
     }
 
     if (packageType === "advanced") {

--- a/frontend/templates/enroll-ota.html
+++ b/frontend/templates/enroll-ota.html
@@ -145,8 +145,7 @@
     </style>
   </head>
   <body>
-    <!-- templates for android and ios, ipad content -->
-
+    <!-- unsupported platform content -->
     <template id="unsupported-template">
       <h1>Enroll your device to Fleet</h1>
       <p class="page-description">
@@ -376,7 +375,7 @@
 
       // TODO: get from server
       const ANDROID_MDM_ENABLED = true;
-      const MAC_MDM_ENABLED = true;
+      const MAC_MDM_ENABLED = false;
 
       // here we render the page content
       document.addEventListener("DOMContentLoaded", async function () {

--- a/frontend/templates/enroll-ota.html
+++ b/frontend/templates/enroll-ota.html
@@ -358,11 +358,6 @@
       const getEnrollmentToken = async () => {
         const enrollSecret = getEnrollmentSecret();
 
-        // TODO: remove
-        return new Promise((resolve, reject) => {
-          resolve({ token: "123456" });
-        });
-
         const response = await fetch(
           `${ANDROID_GET_TOKEN_URL}?enroll_secret=${enrollSecret}`,
           {

--- a/frontend/templates/enroll-ota.html
+++ b/frontend/templates/enroll-ota.html
@@ -260,6 +260,11 @@
       const ANDROID_ENROLL_URL = "https://enterprise.google.com/android/enroll";
       const ANDROID_GET_TOKEN_URL =
         "{{.URLPrefix}}/api/v1/fleet/android/enterprise/enrollment_token";
+      // using string comparison to satisfy the linter.
+      const ANDROID_MDM_ENABLED = "{{.AndroidMDMEnabled}}" === "true";
+      const MAC_MDM_ENABLED = "{{.MacMDMEnabled}}" == "true";
+      // TODO: remove android feature flag
+      const ANDROID_FEATURE_ENABLED = "{{.AndroidFeatureEnabled}}" === "true";
 
       const getPlatform = () => {
         const userAgent = navigator.userAgent;
@@ -373,16 +378,15 @@
         return await response.json();
       };
 
-      // TODO: get from server
-      const ANDROID_MDM_ENABLED = true;
-      const MAC_MDM_ENABLED = false;
-
       // here we render the page content
       document.addEventListener("DOMContentLoaded", async function () {
         const platform = getPlatform();
 
         // quick exit if platform is unsupported
-        if (platform === "unsupported") {
+        if (
+          platform === "unsupported" ||
+          (!ANDROID_FEATURE_ENABLED && platform === "android") // TODO: remove android feature flag
+        ) {
           renderContent("unsupported-template");
           return;
         }

--- a/frontend/templates/enroll-ota.html
+++ b/frontend/templates/enroll-ota.html
@@ -163,7 +163,7 @@
           Select <b>Enroll</b> and it will open settings on your Android device.
           Follow wizard to finish enrollment.
         </p>
-        <a class="enroll-link" href="test.com">Enroll</a>
+        <a class="enroll-link" href="" target="_blank">Enroll</a>
       </div>
     </template>
 
@@ -257,6 +257,11 @@
     <section id="main-content"></section>
 
     <script>
+      // TODO: does this need to come from server?
+      const ANDROID_ENROLL_URL = "https://enterprise.google.com/android/enroll";
+      const ANDROID_GET_TOKEN_URL =
+        "{{.URLPrefix}}/api/v1/fleet/android/enterprise/enrollment_token";
+
       const getPlatform = () => {
         const userAgent = navigator.userAgent;
         const isIPhone = /iPhone/.test(userAgent);
@@ -278,9 +283,7 @@
         return "unsupported";
       };
 
-      const getTemplateIdFromPlatform = () => {
-        const platform = getPlatform();
-
+      const getTemplateIdFromPlatform = (platform) => {
         let templateId = "";
         if (platform === "android") {
           templateId = "android-template";
@@ -293,7 +296,7 @@
         return templateId;
       };
 
-      // renders the content based on the platform
+      // renders the content based on the template id
       const renderContent = (templateId) => {
         const template = document.getElementById(templateId);
         if (template) {
@@ -303,8 +306,14 @@
         }
       };
 
+      const setEnrollTokenUrl = (token) => {
+        document
+          .querySelector(".enroll-link")
+          .setAttribute("href", `${ANDROID_ENROLL_URL}?et=${token}`);
+      };
+
       // dynmaic content rendering for ios and ipad only
-      const renderIosIpadContent = (platform) => {
+      const setIosIpadContent = (platform) => {
         if (platform === "ios") {
           deviceType = "iPhone";
         } else if (platform === "ipad") {
@@ -345,44 +354,33 @@
       const getEnrollmentToken = async () => {
         const enrollSecret = getEnrollmentSecret();
 
-        if (!enrollSecret) {
-          renderError(
-            "This URL is invalid.",
-            "Enroll secret is invalid. Please contact your IT admin."
-          );
-          return;
-        }
+        // TODO: remove
+        return new Promise((resolve, reject) => {
+          resolve({ token: "123456" });
+        });
 
-        try {
-          const response = await fetch(
-            `{{.URLPrefix}}/api/v1/fleet/android/enterprise/enrollment_token?enroll_secret=${enrollSecret}`,
-            {
-              method: "POST",
-              headers: {
-                "Content-Type": "application/json",
-              },
-            }
-          );
-          const data = await response.json();
-
-          if (data.error) {
-            renderError("Error", data.error);
-            return;
+        const response = await fetch(
+          `${ANDROID_GET_TOKEN_URL}?enroll_secret=${enrollSecret}`,
+          {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+            },
           }
-
-          return data;
-        } catch (error) {
-          renderError("Error", "Failed to fetch enrollment token.");
+        );
+        if (!response.ok) {
+          throw new Error("Failed to get enrollment token");
         }
+        return await response.json();
       };
 
-      const ANDROID_MDM_ENABLED = false;
-      const MAC_MDM_ENABLED = false;
+      // TODO: get from server
+      const ANDROID_MDM_ENABLED = true;
+      const MAC_MDM_ENABLED = true;
 
-      // set up the page content
-      document.addEventListener("DOMContentLoaded", function () {
-        // const platform = getPlatform();
-        const platform = "android";
+      // here we render the page content
+      document.addEventListener("DOMContentLoaded", async function () {
+        const platform = getPlatform();
 
         // quick exit if platform is unsupported
         if (platform === "unsupported") {
@@ -390,7 +388,7 @@
           return;
         }
 
-        // check if the enroll secret is valid
+        // check if the enroll secret is valid.
         if (!getEnrollmentSecret()) {
           renderError(
             "This URL is invalid.",
@@ -399,7 +397,7 @@
           return;
         }
 
-        let templateId = "";
+        let templateId = getTemplateIdFromPlatform(platform);
 
         // handle android rendering
         if (platform === "android") {
@@ -410,37 +408,33 @@
             );
             return;
           }
+
+          // we need to get the token and then place it in the enroll link
+          try {
+            const data = await getEnrollmentToken();
+            renderContent(templateId);
+            setEnrollTokenUrl(data.token);
+          } catch (error) {
+            renderError(
+              "This URL is invalid.",
+              "Enroll secret is invalid. Please contact your IT admin."
+            );
+            return;
+          }
         }
 
-        if ((platform === "ios" || platform === "ipad") && !MAC_MDM_ENABLED) {
-          const description = `To enroll your ${
-            platform === "ios" ? "iPhone" : "iPad"
-          } please contact your IT admin.`;
-          renderError("The Apple MDM is turned off.", description);
+        // handle rendering for ios and ipad
+        if (platform === "ios" || platform === "ipad") {
+          if (!MAC_MDM_ENABLED) {
+            const description = `To enroll your ${
+              platform === "ios" ? "iPhone" : "iPad"
+            } please contact your IT admin.`;
+            renderError("The Apple MDM is turned off.", description);
+            return;
+          }
+          renderContent(templateId);
+          setIosIpadContent(platform);
         }
-
-        if (platform === "android") {
-          templateId = "android-template";
-        } else if (platform === "ios" || platform === "ipad") {
-          templateId = "ios-ipad-template";
-        } else {
-          templateId = "unsupported-template";
-        }
-
-        // const token = getEnrollmentToken();
-
-        // renderContent("unsupported-template");
-
-        // renderContent(templateId);
-
-        renderError(
-          "This URL is invalid.",
-          "Enroll secret is invalid. Please contact your IT admin."
-        );
-
-        // if (platform === "ios" || platform === "ipad") {
-        //   renderIosIpadContent(platform);
-        // }
       });
     </script>
   </body>

--- a/frontend/templates/enroll-ota.html
+++ b/frontend/templates/enroll-ota.html
@@ -115,10 +115,24 @@
     </style>
   </head>
   <body>
-    <header>
-      <img src="{{.URLPrefix}}/assets/images/fleet-logo.svg" />
-    </header>
-    <section id="main-content">
+    <!-- templates for android and ios, ipad content -->
+
+    <template id="unsupported-template">
+      <h1>Enroll your device to Fleet</h1>
+      <p class="page-description">
+        To enroll your iPhone, iPad, or Android device, please open this page on
+        your mobile device.
+      </p>
+    </template>
+
+    <!-- android content -->
+    <template id="android-template">
+      <h1>Welcome, Android User!</h1>
+      <p>This is the Android-specific version.</p>
+    </template>
+
+    <!-- ios, ipados content -->
+    <template id="ios-ipad-template">
       <h1>
         Enroll your
         <span data-attribute="dynamic-device-type">iPhone or iPad</span> to
@@ -129,74 +143,119 @@
         <span data-attribute="dynamic-device-type">iPhone or iPad</span>, follow
         the instructions below to download and install the Fleet profile.
       </p>
-      <section class="enroll-section">
-        <ol>
-          <li>
-            <p>
-              <span>1.</span>
-              <span>
-                <b>Download</b> the Fleet profile and select <b>Allow</b> in the
-                pop-up.
-              </span>
-            </p>
-            <a class="download-link" href="{{.EnrollURL}}">Download</a>
-          </li>
-          <li>
-            <p>
-              <span>2.</span>
-              <span>
-                Navigate to <b>Settings</b> and select
-                <b>Profile Downloaded</b>.
-              </span>
-            </p>
-            <div class="profile-downloaded-container">
-              <img
-                class="profile-downloaded-img"
-                src=""
-                alt="select profile downloaded in settings"
-              />
-            </div>
-          </li>
-          <li>
-            <p>
-              <span>3.</span>
-              <span>Select <b>Install</b>.</span>
-            </p>
-            <div class="install-profile-container">
-              <img class="install-profile-img" src="" alt="select install" />
-            </div>
-            <p>
-              You will see an UNVERIFIED PROFILE warning and a MOBILE DEVICE
-              MANAGEMENT warning. Click <b>Install</b> again for each warning.
-              When you see a <b>Remote Management</b> prompt, click
-              <b>Trust</b> to complete enrollment.
-            </p>
-          </li>
-        </ol>
-      </section>
+      <ol>
+        <li>
+          <p>
+            <span>1.</span>
+            <span>
+              <b>Download</b> the Fleet profile and select <b>Allow</b> in the
+              pop-up.
+            </span>
+          </p>
+          <a class="download-link" href="{{.EnrollURL}}">Download</a>
+        </li>
+        <li>
+          <p>
+            <span>2.</span>
+            <span>
+              Navigate to <b>Settings</b> and select <b>Profile Downloaded</b>.
+            </span>
+          </p>
+          <div class="profile-downloaded-container">
+            <img
+              class="profile-downloaded-img"
+              src=""
+              alt="select profile downloaded in settings"
+            />
+          </div>
+        </li>
+        <li>
+          <p>
+            <span>3.</span>
+            <span>Select <b>Install</b>.</span>
+          </p>
+          <div class="install-profile-container">
+            <img class="install-profile-img" src="" alt="select install" />
+          </div>
+          <p>
+            You will see an UNVERIFIED PROFILE warning and a MOBILE DEVICE
+            MANAGEMENT warning. Click <b>Install</b> again for each warning.
+            When you see a <b>Remote Management</b> prompt, click
+            <b>Trust</b> to complete enrollment.
+          </p>
+        </li>
+      </ol>
       <p class="device-enroll-message">
         <img src="{{.URLPrefix}}/assets/images/check.svg" />
         Your device will now be enrolled in Fleet.
       </p>
-    </section>
+    </template>
+
+    <header>
+      <img src="{{.URLPrefix}}/assets/images/fleet-logo.svg" />
+    </header>
+
+    <!-- container for the dynamic content -->
+    <section id="main-content"></section>
+
     <script>
-      document.addEventListener("DOMContentLoaded", function () {
+      const getPlatform = () => {
         const userAgent = navigator.userAgent;
         const isIPhone = /iPhone/.test(userAgent);
         const isIPad =
           /iPad/.test(userAgent) ||
-          (/Macintosh/i.test(navigator.userAgent) &&
-            navigator.maxTouchPoints &&
+          (/Macintosh/i.test(userAgent) &&
+            navigator.maxTouchPoints !== undefined &&
             navigator.maxTouchPoints > 1);
         const isAndroid = /Android/i.test(userAgent);
 
-        // update text content for device type
-        let deviceType = "iPhone or iPad";
-        if (isIPhone) {
-          deviceType = "iPhone";
+        if (isAndroid) {
+          return "android";
+        } else if (isIPhone) {
+          return "ios";
         } else if (isIPad) {
+          return "ipad";
+        }
+
+        return "unsupported";
+      };
+
+      const getTemplateId = () => {
+        const platform = getPlatform();
+
+        let templateId = "";
+        if (platform === "android") {
+          templateId = "android-template";
+        } else if (platform === "ios" || platform === "ipad") {
+          templateId = "ios-ipad-template";
+        } else {
+          templateId = "unsupported-template";
+        }
+
+        return templateId;
+      };
+
+      // renders the content based on the platform
+      const renderContent = () => {
+        const platform = getPlatform();
+        let templateId = getTemplateId();
+
+        const template = document.getElementById(templateId);
+        if (template) {
+          document
+            .getElementById("main-content")
+            .appendChild(template.content.cloneNode(true));
+        }
+      };
+
+      // dynmaic content rendering for ios and ipad only
+      const renderIosIpadContent = (platform) => {
+        if (platform === "ios") {
+          deviceType = "iPhone";
+        } else if (platform === "ipad") {
           deviceType = "iPad";
         }
+
         document
           .querySelectorAll('[data-attribute="dynamic-device-type"]')
           .forEach((el) => {
@@ -204,13 +263,24 @@
           });
 
         // update image src based on OS
-        const osImagePrefix = isIPhone ? "ios" : "iPadOS";
+        const osImagePrefix = platform === "ios" ? "ios" : "iPadOS";
         document.querySelector(
           ".profile-downloaded-img"
         ).src = `{{.URLPrefix}}/assets/images/${osImagePrefix}-profile-downloaded.png`;
         document.querySelector(
           ".install-profile-img"
         ).src = `{{.URLPrefix}}/assets/images/${osImagePrefix}-install-profile.png`;
+      };
+
+      // set up the page content
+      document.addEventListener("DOMContentLoaded", function () {
+        const platform = getPlatform();
+
+        renderContent();
+
+        if (platform === "ios" || platform === "ipad") {
+          renderIosIpadContent(platform);
+        }
       });
     </script>
   </body>

--- a/frontend/templates/enroll-ota.html
+++ b/frontend/templates/enroll-ota.html
@@ -28,7 +28,7 @@
       *,
       *:before,
       *:after {
-        box-sizing: inherit;
+        box-sizing: border-box;
       }
 
       body,
@@ -37,7 +37,9 @@
         margin: 0;
       }
 
-      .download-link {
+      .download-link,
+      .enroll-link {
+        display: inline-block;
         color: #fff;
         background-color: #6a67fe;
         padding: 8px 16px;
@@ -45,8 +47,8 @@
         text-decoration: none;
         font-weight: 700;
         font-size: 14px;
-        width: 100px;
         line-height: 21px;
+        text-align: center;
       }
 
       header {
@@ -73,6 +75,15 @@
       li {
         display: flex;
         flex-direction: column;
+        gap: 20px;
+        align-items: flex-start;
+      }
+
+      .android-content {
+        margin-top: 48px;
+        display: flex;
+        flex-direction: column;
+        align-items: flex-start;
         gap: 20px;
       }
 
@@ -112,6 +123,12 @@
         display: flex;
         gap: 8px;
       }
+
+      @media screen and (max-width: 430px) {
+        .enroll-link {
+          width: 100%;
+        }
+      }
     </style>
   </head>
   <body>
@@ -127,8 +144,14 @@
 
     <!-- android content -->
     <template id="android-template">
-      <h1>Welcome, Android User!</h1>
-      <p>This is the Android-specific version.</p>
+      <h1>Enroll your Android device to Fleet</h1>
+      <div class="android-content">
+        <p>
+          Select <b>Enroll</b> and it will open settings on your Android device.
+          Follow wizard to finish enrollment.
+        </p>
+        <a class="enroll-link" href="test.com">Enroll</a>
+      </div>
     </template>
 
     <!-- ios, ipados content -->
@@ -208,6 +231,8 @@
             navigator.maxTouchPoints !== undefined &&
             navigator.maxTouchPoints > 1);
         const isAndroid = /Android/i.test(userAgent);
+
+        return "android";
 
         if (isAndroid) {
           return "android";

--- a/frontend/templates/enroll-ota.html
+++ b/frontend/templates/enroll-ota.html
@@ -102,7 +102,9 @@
       }
 
       #main-content {
+        margin: 0 auto;
         padding: 48px 24px;
+        max-width: 800px;
       }
 
       .device-enroll-message {
@@ -127,48 +129,51 @@
         <span data-attribute="dynamic-device-type">iPhone or iPad</span>, follow
         the instructions below to download and install the Fleet profile.
       </p>
-      <ol>
-        <li>
-          <p>
-            <span>1.</span>
-            <span>
-              <b>Download</b> the Fleet profile and select <b>Allow</b> in the
-              pop-up.
-            </span>
-          </p>
-          <a class="download-link" href="{{.EnrollURL}}">Download</a>
-        </li>
-        <li>
-          <p>
-            <span>2.</span>
-            <span>
-              Navigate to <b>Settings</b> and select <b>Profile Downloaded</b>.
-            </span>
-          </p>
-          <div class="profile-downloaded-container">
-            <img
-              class="profile-downloaded-img"
-              src=""
-              alt="select profile downloaded in settings"
-            />
-          </div>
-        </li>
-        <li>
-          <p>
-            <span>3.</span>
-            <span>Select <b>Install</b>.</span>
-          </p>
-          <div class="install-profile-container">
-            <img class="install-profile-img" src="" alt="select install" />
-          </div>
-          <p>
-            You will see an UNVERIFIED PROFILE warning and a MOBILE DEVICE
-            MANAGEMENT warning. Click <b>Install</b> again for each warning.
-            When you see a <b>Remote Management</b> prompt, click
-            <b>Trust</b> to complete enrollment.
-          </p>
-        </li>
-      </ol>
+      <section class="enroll-section">
+        <ol>
+          <li>
+            <p>
+              <span>1.</span>
+              <span>
+                <b>Download</b> the Fleet profile and select <b>Allow</b> in the
+                pop-up.
+              </span>
+            </p>
+            <a class="download-link" href="{{.EnrollURL}}">Download</a>
+          </li>
+          <li>
+            <p>
+              <span>2.</span>
+              <span>
+                Navigate to <b>Settings</b> and select
+                <b>Profile Downloaded</b>.
+              </span>
+            </p>
+            <div class="profile-downloaded-container">
+              <img
+                class="profile-downloaded-img"
+                src=""
+                alt="select profile downloaded in settings"
+              />
+            </div>
+          </li>
+          <li>
+            <p>
+              <span>3.</span>
+              <span>Select <b>Install</b>.</span>
+            </p>
+            <div class="install-profile-container">
+              <img class="install-profile-img" src="" alt="select install" />
+            </div>
+            <p>
+              You will see an UNVERIFIED PROFILE warning and a MOBILE DEVICE
+              MANAGEMENT warning. Click <b>Install</b> again for each warning.
+              When you see a <b>Remote Management</b> prompt, click
+              <b>Trust</b> to complete enrollment.
+            </p>
+          </li>
+        </ol>
+      </section>
       <p class="device-enroll-message">
         <img src="{{.URLPrefix}}/assets/images/check.svg" />
         Your device will now be enrolled in Fleet.
@@ -183,6 +188,7 @@
           (/Macintosh/i.test(navigator.userAgent) &&
             navigator.maxTouchPoints &&
             navigator.maxTouchPoints > 1);
+        const isAndroid = /Android/i.test(userAgent);
 
         // update text content for device type
         let deviceType = "iPhone or iPad";

--- a/frontend/templates/enroll-ota.html
+++ b/frontend/templates/enroll-ota.html
@@ -124,6 +124,19 @@
         gap: 8px;
       }
 
+      .error-header {
+        display: flex;
+        gap: 8px;
+        align-items: center;
+        justify-content: center;
+        margin-bottom: 24px;
+        font-size: 14px;
+      }
+
+      .error-description {
+        text-align: center;
+      }
+
       @media screen and (max-width: 430px) {
         .enroll-link {
           width: 100%;
@@ -214,6 +227,28 @@
       </p>
     </template>
 
+    <!-- Error content -->
+    <template id="error-template">
+      <h1 class="error-header">
+        <svg
+          width="16"
+          height="17"
+          viewBox="0 0 16 17"
+          fill="none"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            fill-rule="evenodd"
+            clip-rule="evenodd"
+            d="M8 0.5C3.58 0.5 0 4.08 0 8.5C0 12.92 3.58 16.5 8 16.5C12.42 16.5 16 12.92 16 8.5C16 4.08 12.42 0.5 8 0.5ZM8 3.75C8.41421 3.75 8.75 4.08579 8.75 4.5V9.5C8.75 9.91421 8.41421 10.25 8 10.25C7.58579 10.25 7.25 9.91421 7.25 9.5V4.5C7.25 4.08579 7.58579 3.75 8 3.75ZM8 13.5C8.55229 13.5 9 13.0523 9 12.5C9 11.9477 8.55229 11.5 8 11.5C7.44772 11.5 7 11.9477 7 12.5C7 13.0523 7.44772 13.5 8 13.5Z"
+            fill="#D66C7B"
+          />
+        </svg>
+        <p class="error-title"></p>
+      </h1>
+      <p class="error-description"></p>
+    </template>
+
     <header>
       <img src="{{.URLPrefix}}/assets/images/fleet-logo.svg" />
     </header>
@@ -232,8 +267,6 @@
             navigator.maxTouchPoints > 1);
         const isAndroid = /Android/i.test(userAgent);
 
-        return "android";
-
         if (isAndroid) {
           return "android";
         } else if (isIPhone) {
@@ -245,7 +278,7 @@
         return "unsupported";
       };
 
-      const getTemplateId = () => {
+      const getTemplateIdFromPlatform = () => {
         const platform = getPlatform();
 
         let templateId = "";
@@ -261,10 +294,7 @@
       };
 
       // renders the content based on the platform
-      const renderContent = () => {
-        const platform = getPlatform();
-        let templateId = getTemplateId();
-
+      const renderContent = (templateId) => {
         const template = document.getElementById(templateId);
         if (template) {
           document
@@ -297,15 +327,120 @@
         ).src = `{{.URLPrefix}}/assets/images/${osImagePrefix}-install-profile.png`;
       };
 
+      const renderError = (title, description) => {
+        const template = document.getElementById("error-template");
+        if (template) {
+          const clone = template.content.cloneNode(true);
+          clone.querySelector(".error-title").textContent = title;
+          clone.querySelector(".error-description").textContent = description;
+          document.getElementById("main-content").appendChild(clone);
+        }
+      };
+
+      const getEnrollmentSecret = () => {
+        const urlParams = new URLSearchParams(window.location.search);
+        return urlParams.get("enroll_secret");
+      };
+
+      const getEnrollmentToken = async () => {
+        const enrollSecret = getEnrollmentSecret();
+
+        if (!enrollSecret) {
+          renderError(
+            "This URL is invalid.",
+            "Enroll secret is invalid. Please contact your IT admin."
+          );
+          return;
+        }
+
+        try {
+          const response = await fetch(
+            `{{.URLPrefix}}/api/v1/fleet/android/enterprise/enrollment_token?enroll_secret=${enrollSecret}`,
+            {
+              method: "POST",
+              headers: {
+                "Content-Type": "application/json",
+              },
+            }
+          );
+          const data = await response.json();
+
+          if (data.error) {
+            renderError("Error", data.error);
+            return;
+          }
+
+          return data;
+        } catch (error) {
+          renderError("Error", "Failed to fetch enrollment token.");
+        }
+      };
+
+      const ANDROID_MDM_ENABLED = false;
+      const MAC_MDM_ENABLED = false;
+
       // set up the page content
       document.addEventListener("DOMContentLoaded", function () {
-        const platform = getPlatform();
+        // const platform = getPlatform();
+        const platform = "android";
 
-        renderContent();
-
-        if (platform === "ios" || platform === "ipad") {
-          renderIosIpadContent(platform);
+        // quick exit if platform is unsupported
+        if (platform === "unsupported") {
+          renderContent("unsupported-template");
+          return;
         }
+
+        // check if the enroll secret is valid
+        if (!getEnrollmentSecret()) {
+          renderError(
+            "This URL is invalid.",
+            "Enroll secret is invalid. Please contact your IT admin."
+          );
+          return;
+        }
+
+        let templateId = "";
+
+        // handle android rendering
+        if (platform === "android") {
+          if (!ANDROID_MDM_ENABLED) {
+            renderError(
+              "The Android MDM is turned off.",
+              "To enroll your Android device please contact your IT admin."
+            );
+            return;
+          }
+        }
+
+        if ((platform === "ios" || platform === "ipad") && !MAC_MDM_ENABLED) {
+          const description = `To enroll your ${
+            platform === "ios" ? "iPhone" : "iPad"
+          } please contact your IT admin.`;
+          renderError("The Apple MDM is turned off.", description);
+        }
+
+        if (platform === "android") {
+          templateId = "android-template";
+        } else if (platform === "ios" || platform === "ipad") {
+          templateId = "ios-ipad-template";
+        } else {
+          templateId = "unsupported-template";
+        }
+
+        // const token = getEnrollmentToken();
+
+        // renderContent("unsupported-template");
+
+        // renderContent(templateId);
+
+        renderError(
+          "This URL is invalid.",
+          "Enroll secret is invalid. Please contact your IT admin."
+        );
+
+        // if (platform === "ios" || platform === "ipad") {
+        //   renderIosIpadContent(platform);
+        // }
       });
     </script>
   </body>

--- a/frontend/templates/enroll-ota.html
+++ b/frontend/templates/enroll-ota.html
@@ -268,9 +268,9 @@
 
       const getPlatform = () => {
         const userAgent = navigator.userAgent;
-        const isIPhone = /iPhone/.test(userAgent);
+        const isIPhone = /iPhone/i.test(userAgent);
         const isIPad =
-          /iPad/.test(userAgent) ||
+          /iPad/i.test(userAgent) ||
           (/Macintosh/i.test(userAgent) &&
             navigator.maxTouchPoints !== undefined &&
             navigator.maxTouchPoints > 1);
@@ -401,7 +401,7 @@
         if (platform === "android") {
           if (!ANDROID_MDM_ENABLED) {
             renderError(
-              "The Android MDM is turned off.",
+              "Android MDM is turned off.",
               "To enroll your Android device please contact your IT admin."
             );
             return;
@@ -427,7 +427,7 @@
             const description = `To enroll your ${
               platform === "ios" ? "iPhone" : "iPad"
             } please contact your IT admin.`;
-            renderError("The Apple MDM is turned off.", description);
+            renderError("Apple MDM is turned off.", description);
             return;
           }
           renderContent(templateId);

--- a/frontend/templates/enroll-ota.html
+++ b/frontend/templates/enroll-ota.html
@@ -256,8 +256,6 @@
     <section id="main-content"></section>
 
     <script>
-      // TODO: does this need to come from server?
-      const ANDROID_ENROLL_URL = "https://enterprise.google.com/android/enroll";
       const ANDROID_GET_TOKEN_URL =
         "{{.URLPrefix}}/api/v1/fleet/android/enterprise/enrollment_token";
       // using string comparison to satisfy the linter.
@@ -310,10 +308,8 @@
         }
       };
 
-      const setEnrollTokenUrl = (token) => {
-        document
-          .querySelector(".enroll-link")
-          .setAttribute("href", `${ANDROID_ENROLL_URL}?et=${token}`);
+      const setEnrollTokenUrl = (url) => {
+        document.querySelector(".enroll-link").setAttribute("href", url);
       };
 
       // dynmaic content rendering for ios and ipad only
@@ -410,8 +406,11 @@
           // we need to get the token and then place it in the enroll link
           try {
             const data = await getEnrollmentToken();
-            renderContent(templateId);
-            setEnrollTokenUrl(data.token);
+            renderContent();
+            if (!data.android_enrollment_url) {
+              throw new Error("Failed to get enrollment token");
+            }
+            setEnrollTokenUrl(data.android_enrollment_url);
           } catch (error) {
             renderError(
               "This URL is invalid.",

--- a/server/service/frontend.go
+++ b/server/service/frontend.go
@@ -73,7 +73,14 @@ func ServeFrontend(urlPrefix string, sandbox bool, logger log.Logger) http.Handl
 	})
 }
 
-func ServeEndUserEnrollOTA(svc fleet.Service, urlPrefix string, logger log.Logger) http.Handler {
+func ServeEndUserEnrollOTA(
+	svc fleet.Service,
+	urlPrefix string,
+	isMacMDMEnabled bool,
+	isAndroidMDMEnabled bool,
+	isAndroidFeatureEnabled bool, // TODO: remove android feature flag
+	logger log.Logger,
+) http.Handler {
 	herr := func(w http.ResponseWriter, err string) {
 		logger.Log("err", err)
 		http.Error(w, err, http.StatusInternalServerError)
@@ -117,11 +124,17 @@ func ServeEndUserEnrollOTA(svc fleet.Service, urlPrefix string, logger log.Logge
 			return
 		}
 		if err := t.Execute(w, struct {
-			EnrollURL string
-			URLPrefix string
+			EnrollURL             string
+			URLPrefix             string
+			AndroidMDMEnabled     bool
+			MacMDMEnabled         bool
+			AndroidFeatureEnabled bool
 		}{
-			URLPrefix: urlPrefix,
-			EnrollURL: enrollURL,
+			URLPrefix:             urlPrefix,
+			EnrollURL:             enrollURL,
+			AndroidMDMEnabled:     isAndroidMDMEnabled,
+			MacMDMEnabled:         isMacMDMEnabled,
+			AndroidFeatureEnabled: isAndroidFeatureEnabled,
 		}); err != nil {
 			herr(w, "execute react template: "+err.Error())
 			return

--- a/server/service/frontend_test.go
+++ b/server/service/frontend_test.go
@@ -56,7 +56,7 @@ func TestServeEndUserEnrollOTA(t *testing.T) {
 	svc, _ := newTestService(t, ds, nil, nil)
 
 	logger := log.NewLogfmtLogger(os.Stdout)
-	h := ServeEndUserEnrollOTA(svc, "", logger)
+	h := ServeEndUserEnrollOTA(svc, "", true, true, true, logger)
 	ts := httptest.NewServer(h)
 	t.Cleanup(func() {
 		ts.Close()
@@ -74,4 +74,5 @@ func TestServeEndUserEnrollOTA(t *testing.T) {
 	require.NoError(t, err)
 	bodyString := string(bodyBytes)
 	require.Contains(t, bodyString, "api/v1/fleet/enrollment_profiles/ota?enroll_secret=foo")
+	require.Contains(t, bodyString, "/api/v1/fleet/android/enterprise/enrollment_token")
 }


### PR DESCRIPTION
For #26211 and #26210

Add Android to byod enrollment landing page. this includes:

**new android section in add hosts modal:**

![image](https://github.com/user-attachments/assets/f951df0c-4654-4434-8c95-8b57634d4921)

**messaging when visiting from non android, ios, ipad device:**

![image](https://github.com/user-attachments/assets/169903a9-8d5e-4e3b-9b78-378a0e791b22)

**enroll into android mdm UI:**

![image](https://github.com/user-attachments/assets/79c9c116-e003-4a80-b0e9-8fbe8775a82c)

**various error states (secret is invalid, android or mac os mdm not enabled):**

![image](https://github.com/user-attachments/assets/bc0035ac-b2ed-47e5-8e25-8716fc642e70)

![image](https://github.com/user-attachments/assets/87b8ca87-3352-47fe-8dbf-1bc2a49553b1)

![image](https://github.com/user-attachments/assets/5a378f5f-84d3-4738-aab3-0f68760d317d)

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
- [x] Manual QA for all new/changed functionality
