### PR TITLE
Update alpine to patch vulnerability with severity "HIGH"

### DIFF
--- a/infrastructure/loadtesting/terraform/docker/loadtest.Dockerfile
+++ b/infrastructure/loadtesting/terraform/docker/loadtest.Dockerfile
@@ -3,7 +3,7 @@ ARG TAG
 RUN apk add git
 RUN git clone -b $TAG --depth=1 --no-tags --progress --no-recurse-submodules https://github.com/fleetdm/fleet.git && cd /go/fleet/cmd/osquery-perf/ && go build .
 
-FROM alpine:3.21@sha256:2c43f33bd1502ec7818bce9eea60e062d04eeadc4aa31cad9dabecb1e48b647b
+FROM alpine:3.21.3@sha256:a8560b36e8b8210634f77d9f7f9efd7ffa463e380b75e2e74aff4511df3ef88c
 LABEL maintainer="Fleet Developers"
 
 # Create FleetDM group and user

--- a/server/mdm/scep/Dockerfile
+++ b/server/mdm/scep/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3@sha256:c5b1261d6d3e43071626931fc004f70149baeba2c8ec672bd4f27761f8e1ad6b
+FROM alpine:3.21.3@sha256:a8560b36e8b8210634f77d9f7f9efd7ffa463e380b75e2e74aff4511df3ef88c
 
 COPY ./scepclient-linux-amd64 /usr/bin/scepclient
 COPY ./scepserver-linux-amd64 /usr/bin/scepserver

--- a/tools/fleet-docker/Dockerfile
+++ b/tools/fleet-docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.21@sha256:2c43f33bd1502ec7818bce9eea60e062d04eeadc4aa31cad9dabecb1e48b647b
+FROM alpine:3.21.3@sha256:a8560b36e8b8210634f77d9f7f9efd7ffa463e380b75e2e74aff4511df3ef88c
 LABEL maintainer="Fleet Developers"
 
 RUN apk --update add ca-certificates

--- a/tools/mdm/migration/mdmproxy/Dockerfile
+++ b/tools/mdm/migration/mdmproxy/Dockerfile
@@ -3,7 +3,7 @@ ARG TAG
 RUN apk update && apk add --no-cache git
 RUN git clone -b $TAG --depth=1 --no-tags --progress --no-recurse-submodules https://github.com/fleetdm/fleet.git && cd /go/fleet/tools/mdm/migration/mdmproxy && go build .
 
-FROM alpine:3.21@sha256:2c43f33bd1502ec7818bce9eea60e062d04eeadc4aa31cad9dabecb1e48b647b
+FROM alpine:3.21.3@sha256:a8560b36e8b8210634f77d9f7f9efd7ffa463e380b75e2e74aff4511df3ef88c
 LABEL maintainer="Fleet Developers"
 
 RUN apk update && apk add --no-cache tini


### PR DESCRIPTION
The vulnerability was posted by a prospect.

Posting manual command until we get #25902 done.
```sh
trivy image --ignore-unfixed --pkg-types os,library --severity CRITICAL,HIGH --show-suppressed fleetdm/fleet:v4.64.1
[...]
fleetdm/fleet:v4.64.1 (alpine 3.21.0)

Total: 2 (HIGH: 2, CRITICAL: 0)

┌────────────┬────────────────┬──────────┬────────┬───────────────────┬───────────────┬──────────────────────────────────────────────────────────┐
│  Library   │ Vulnerability  │ Severity │ Status │ Installed Version │ Fixed Version │                          Title                           │
├────────────┼────────────────┼──────────┼────────┼───────────────────┼───────────────┼──────────────────────────────────────────────────────────┤
│ libcrypto3 │ CVE-2024-12797 │ HIGH     │ fixed  │ 3.3.2-r4          │ 3.3.3-r0      │ openssl: RFC7250 handshakes with unauthenticated servers │
│            │                │          │        │                   │               │ don't abort as expected                                  │
│            │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2024-12797               │
├────────────┤                │          │        │                   │               │                                                          │
│ libssl3    │                │          │        │                   │               │                                                          │
│            │                │          │        │                   │               │                                                          │
│            │                │          │        │                   │               │                                                          │
└────────────┴────────────────┴──────────┴────────┴───────────────────┴───────────────┴──────────────────────────────────────────────────────────┘
```