### PR TITLE
Website: use latest version information from dogfood for Fleet maintained apps pages.

### DIFF
--- a/.github/workflows/deploy-fleet-website.yml
+++ b/.github/workflows/deploy-fleet-website.yml
@@ -92,7 +92,7 @@ jobs:
     - run: cd website/ && npm test
 
     # Compile browser assets & markdown content into generated collateral
-    - run: cd website/ && BUILD_SCRIPT_ARGS="--githubAccessToken=${{ secrets.FLEET_GITHUB_TOKEN_FOR_WEBSITE_TEST }}" npm run build-for-prod
+    - run: cd website/ && BUILD_SCRIPT_ARGS="--githubAccessToken=${{ secrets.FLEET_GITHUB_TOKEN_FOR_WEBSITE_TEST }} --dogfoodAccessToken=${{ secrets.DOGFOOD_API_TOKEN }}" npm run build-for-prod
 
     # Build the go binary we use to sign APNS certificates in the website/.tools/ folder.
     - run: cd ee/tools/mdm/ && GOOS=linux GOARCH=amd64 go build -o ../../../website/.tools/mdm-gen-cert .

--- a/.github/workflows/test-website.yml
+++ b/.github/workflows/test-website.yml
@@ -66,4 +66,4 @@ jobs:
       - run: cd website/ && npm test
 
       # Compile assets
-      - run: cd website/ && BUILD_SCRIPT_ARGS="--githubAccessToken=${{ secrets.FLEET_GITHUB_TOKEN_FOR_WEBSITE_TEST }}" npm run build-for-prod
+      - run: cd website/ && BUILD_SCRIPT_ARGS="--githubAccessToken=${{ secrets.FLEET_GITHUB_TOKEN_FOR_WEBSITE_TEST }} --dogfoodAccessToken=${{ secrets.DOGFOOD_API_TOKEN }}" npm run build-for-prod


### PR DESCRIPTION
Closes: #24379

Changes:
- Updated the `build-static-content` script to accept a new input: `dogfoodAccessToken`. If provided, the script will pull the latest version information for Fleet maintained apps from Fleet's dogfood instance when the website deploys.
- Updated the `test-website` and `deploy-fleet-website` workflows  to pass in the dogfood API token secret to the `build-static-content` script