### PR TITLE
Allow empty values when parsing distinguished name

### DIFF
--- a/server/fleet/host_certificates.go
+++ b/server/fleet/host_certificates.go
@@ -203,10 +203,6 @@ func ExtractDetailsFromOsqueryDistinguishedName(str string) (*HostCertificateNam
 			return nil, errors.New("invalid distinguished name, wrong key value pair format")
 		}
 
-		if len(kv[1]) == 0 {
-			return nil, errors.New("invalid distinguished name, missing value")
-		}
-
 		switch strings.ToUpper(kv[0]) {
 		case "C":
 			details.Country = strings.Trim(kv[1], " ")

--- a/server/fleet/host_certificates_test.go
+++ b/server/fleet/host_certificates_test.go
@@ -73,7 +73,12 @@ func TestExtractHostCertificateNameDetails(t *testing.T) {
 		{
 			name:  "missing value",
 			input: "/C=US/O=Fleet Device Management Inc./OU=Fleet Device Management Inc./CN=",
-			err:   true,
+			expected: &HostCertificateNameDetails{
+				Country:            "US",
+				Organization:       "Fleet Device Management Inc.",
+				OrganizationalUnit: "Fleet Device Management Inc.",
+				CommonName:         "",
+			},
 		},
 		{
 			name:     "missing first slash",


### PR DESCRIPTION
Fix unreleased bug found in dev QA