### PR TITLE
Fix issue with policy details modal causing 500 error page

### DIFF
--- a/frontend/components/ClickableUrls/ClickableUrls.tsx
+++ b/frontend/components/ClickableUrls/ClickableUrls.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import * as DOMPurify from "dompurify";
+import DOMPurify from "dompurify";
 import classnames from "classnames";
 
 interface IClickableUrls {


### PR DESCRIPTION
For #26604 

This PR fixes the way we import DOMPurify, so that we can access its `sanitize` method.

I'm not sure why this popped up now -- the last release was a month ago.  Perhaps a new release of webpack or a related dependency in our build chain?

**Before:**
![26604-broken](https://github.com/user-attachments/assets/629567a6-d989-45e2-a90c-eca8f69b1105)

---

**After:**
![26604-fixed](https://github.com/user-attachments/assets/4ec580f1-d189-4692-80d2-fee1d3ed8207)


