### PR TITLE
Correct a URL in the documentation so it doesn't 404

### DIFF
--- a/docs/Deploy/deploy-fleet.md
+++ b/docs/Deploy/deploy-fleet.md
@@ -81,7 +81,7 @@ This workflow takes about 30 minutes to complete and supports between 10 and 350
 
 ### Instructions
 
-1. [Download](https://github.com/fleetdm/fleet-terraform/tree/mainexample/main.tf) the Fleet `main.tf` Terraform file.
+1. [Download](https://github.com/fleetdm/fleet-terraform/blob/main/example/main.tf) the Fleet `main.tf` Terraform file.
 
 2. Edit the following variables in the `main.tf` Terraform file you just downloaded to match your environment:
     


### PR DESCRIPTION
The URL was pointing to a file in the fleet-terraform repo that didn't exist causing it to 404.
