### PR TITLE
hook up SSE for UI android sse

### DIFF
--- a/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/AndroidMdmPage/AndroidMdmPage.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/AndroidMdmPage/AndroidMdmPage.tsx
@@ -30,8 +30,19 @@ const TurnOnAndroidMdm = () => {
     try {
       const res = await mdmAndroidAPI.getSignupUrl();
 
+      const width = 885;
+      const height = 600;
+
+      // Calculate the center position
+      const left = window.screenX + (window.innerWidth - width) / 2;
+      const top = window.screenY + (window.innerHeight - height) / 2;
+
       // TODO: set up SSE for successful android mdm turned on here.
-      window.open(res.android_enterprise_signup_url, "_blank");
+      window.open(
+        res.android_enterprise_signup_url,
+        "_blank",
+        `width=${width},height=${height},top=${top},left=${left}`
+      );
     } catch (e) {
       renderFlash("error", "Couldn't connect. Please try again");
     }

--- a/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/AndroidMdmPage/AndroidMdmPage.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/AndroidMdmPage/AndroidMdmPage.tsx
@@ -1,9 +1,14 @@
-import React, { useContext, useEffect, useState } from "react";
+import React, {
+  useCallback,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
 import { InjectedRouter } from "react-router";
 import { useQuery } from "react-query";
 
 import PATHS from "router/paths";
-import endpoints from "utilities/endpoints";
 import { AppContext } from "context/app";
 import { NotificationContext } from "context/notification";
 import mdmAndroidAPI from "services/entities/mdm_android";
@@ -32,39 +37,41 @@ interface ITurnOnAndroidMdmProps {
 const TurnOnAndroidMdm = ({ router }: ITurnOnAndroidMdmProps) => {
   const { renderFlash } = useContext(NotificationContext);
 
+  // TODO: figure out issue with aborting the SSE fetch when the window is closed
+  const newWindow = useRef<Window | null>(null);
+
   const [fetchingSignupUrl, setFetchingSignupUrl] = useState(false);
   const [setupSse, setSetupSse] = useState(false);
 
-  useEffect(() => {
-    if (setupSse) {
-      const eventSource = new EventSource(endpoints.MDM_ANDOIR_SSE_URL);
-
-      eventSource.onmessage = (event) => {
-        console.log("onmessage", event);
-        const data = JSON.parse(event.data);
-        console.log(data);
-        if (data === "Android Enterprise successfully connected") {
-          renderFlash("success", "Android MDM turned on successfully.", {
-            persistOnPageChange: true,
-          });
-          setSetupSse(false);
-          eventSource.close();
-          router.push(PATHS.ADMIN_INTEGRATIONS_MDM);
-        }
-      };
-
-      eventSource.onerror = () => {
-        console.log("error");
+  const handleSSE = useCallback(
+    async (abortController: AbortController) => {
+      try {
+        await mdmAndroidAPI.startSSE(abortController.signal);
+        abortController.abort();
+        renderFlash("success", "Android MDM turned on successfully.", {
+          persistOnPageChange: true,
+        });
+        setSetupSse(false);
+        router.push(PATHS.ADMIN_INTEGRATIONS_MDM);
+      } catch {
         renderFlash("error", "Couldn't turn on Android MDM. Please try again.");
         setSetupSse(false);
-        eventSource.close();
-      };
+      }
+    },
+    [renderFlash, router]
+  );
+
+  useEffect(() => {
+    const abortController = new AbortController();
+
+    if (setupSse) {
+      handleSSE(abortController);
 
       return () => {
-        eventSource.close();
+        abortController.abort();
       };
     }
-  }, [setupSse, router, renderFlash]);
+  }, [setupSse, router, renderFlash, handleSSE]);
 
   const onConnectMdm = async () => {
     setFetchingSignupUrl(true);
@@ -75,8 +82,8 @@ const TurnOnAndroidMdm = ({ router }: ITurnOnAndroidMdmProps) => {
       const left = window.screenX + (window.innerWidth - POPUP_WIDTH) / 2;
       const top = window.screenY + (window.innerHeight - POPUP_HEIGHT) / 2;
 
-      // TODO: set up SSE for successful android mdm turned on here.
-      window.open(
+      // TODO: figure out issue with aborting the SSE fetch when the window is closed
+      newWindow.current = window.open(
         res.android_enterprise_signup_url,
         "_blank",
         `width=${POPUP_WIDTH},height=${POPUP_HEIGHT},top=${top},left=${left}`
@@ -162,9 +169,6 @@ interface IAndroidMdmPageProps {
 
 const AndroidMdmPage = ({ router }: IAndroidMdmPageProps) => {
   const { isAndroidMdmEnabledAndConfigured } = useContext(AppContext);
-
-  const { renderFlash } = useContext(NotificationContext);
-
   const [showTurnOffMdmModal, setShowTurnOffMdmModal] = useState(false);
 
   return (

--- a/frontend/services/entities/mdm_android.ts
+++ b/frontend/services/entities/mdm_android.ts
@@ -1,5 +1,6 @@
 import sendRequest from "services";
 import endpoints from "utilities/endpoints";
+import { authToken } from "utilities/local";
 
 interface IGetAndroidSignupUrlResponse {
   android_enterprise_signup_url: string;
@@ -23,5 +24,47 @@ export default {
   turnOffAndroidMdm: (): Promise<void> => {
     const { MDM_ANDROID_ENTERPRISE } = endpoints;
     return sendRequest("DELETE", MDM_ANDROID_ENTERPRISE);
+  },
+
+  /**
+   * This function starts a Server-Sent Events connection with the fleet server
+   * to get messages about a successful Android mdm connection. We have to use
+   * fetch here because the EventSource API does not support setting headers,
+   * which we need to authenticate the request.
+   */
+  startSSE: (abortSignal: AbortSignal): Promise<void> => {
+    return new Promise(async (resolve, reject) => {
+      try {
+        const response = await fetch(endpoints.MDM_ANDROID_SSE_URL, {
+          method: "GET",
+          headers: {
+            Authorization: `Bearer ${authToken()}`,
+          },
+          signal: abortSignal,
+        });
+
+        const reader = response?.body?.getReader();
+        const decoder = new TextDecoder();
+
+        while (true) {
+          // @ts-ignore
+          // eslint-disable-next-line no-await-in-loop
+          const { done, value } = await reader?.read();
+          if (done) break;
+          const text = decoder.decode(value);
+          if (text === "Android Enterprise successfully connected") {
+            resolve();
+            break;
+          }
+        }
+      } catch (error) {
+        if ((error as Error).name === "AbortError") {
+          // we want to ignore abort errors
+          console.error("SSE Fetch aborted");
+        } else {
+          reject(error);
+        }
+      }
+    });
   },
 };

--- a/frontend/utilities/endpoints.ts
+++ b/frontend/utilities/endpoints.ts
@@ -89,7 +89,7 @@ export default {
 
   MDM_ANDROID_ENTERPRISE: `/${API_VERSION}/fleet/android_enterprise`,
   MDM_ANDROID_SIGNUP_URL: `/${API_VERSION}/fleet/android_enterprise/signup_url`,
-  MDM_ANDOIR_SSE_URL: `/${API_VERSION}/fleet/android_enterprise/signup_sse`,
+  MDM_ANDROID_SSE_URL: `/api/${API_VERSION}/fleet/android_enterprise/signup_sse`,
 
   // apple mdm endpoints
   MDM_APPLE: `/${API_VERSION}/fleet/mdm/apple`,

--- a/frontend/utilities/endpoints.ts
+++ b/frontend/utilities/endpoints.ts
@@ -89,6 +89,7 @@ export default {
 
   MDM_ANDROID_ENTERPRISE: `/${API_VERSION}/fleet/android_enterprise`,
   MDM_ANDROID_SIGNUP_URL: `/${API_VERSION}/fleet/android_enterprise/signup_url`,
+  MDM_ANDOIR_SSE_URL: `/${API_VERSION}/fleet/android_enterprise/signup_sse`,
 
   // apple mdm endpoints
   MDM_APPLE: `/${API_VERSION}/fleet/mdm/apple`,


### PR DESCRIPTION
For #26207

add server side event setup for the UI when turning on android MDM.

- [ ] Manual QA must be performed in the three main OSs, macOS, Windows and Linux.
