### PR TITLE
Fleet UI: Hide auto install tag if null

### DIFF
--- a/frontend/components/SoftwareOptionsSelector/SoftwareOptionsSelector.tsx
+++ b/frontend/components/SoftwareOptionsSelector/SoftwareOptionsSelector.tsx
@@ -6,6 +6,7 @@ import InfoBanner from "components/InfoBanner";
 import CustomLink from "components/CustomLink";
 import { LEARN_MORE_ABOUT_BASE_LINK } from "utilities/constants";
 
+import { SELF_SERVICE_TOOLTIP } from "pages/SoftwarePage/helpers";
 import { ISoftwareVppFormData } from "pages/SoftwarePage/SoftwareAddPage/SoftwareAppStoreVpp/SoftwareVppForm/SoftwareVppForm";
 import { IFleetMaintainedAppFormData } from "pages/SoftwarePage/SoftwareAddPage/SoftwareFleetMaintained/FleetMaintainedAppDetailsPage/FleetAppDetailsForm/FleetAppDetailsForm";
 import { IPackageFormData } from "pages/SoftwarePage/components/PackageForm/PackageForm";
@@ -56,14 +57,7 @@ const SoftwareOptionsSelector = ({
         value={formData.selfService}
         onChange={(newVal: boolean) => onToggleSelfService(newVal)}
         className={`${baseClass}__self-service-checkbox`}
-        tooltipContent={
-          !isSelfServiceDisabled && (
-            <>
-              End users can install from <b>Fleet Desktop</b> {">"}{" "}
-              <b>Self-service</b>.
-            </>
-          )
-        }
+        tooltipContent={!isSelfServiceDisabled && SELF_SERVICE_TOOLTIP}
         disabled={isSelfServiceDisabled}
       >
         Self-service

--- a/frontend/components/TableContainer/DataTable/SoftwareNameCell/SoftwareNameCell.tsx
+++ b/frontend/components/TableContainer/DataTable/SoftwareNameCell/SoftwareNameCell.tsx
@@ -3,10 +3,11 @@ import { InjectedRouter } from "react-router";
 import ReactTooltip from "react-tooltip";
 import { uniqueId } from "lodash";
 
+import { SELF_SERVICE_TOOLTIP } from "pages/SoftwarePage/helpers";
+
 import Icon from "components/Icon";
 import { IconNames } from "components/icons";
 import SoftwareIcon from "pages/SoftwarePage/components/icons/SoftwareIcon";
-
 import LinkCell from "../LinkCell";
 
 const baseClass = "software-name-cell";
@@ -29,11 +30,7 @@ const installIconMap: Record<InstallType, installIconConfig> = {
   },
   selfService: {
     iconName: "user",
-    tooltip: (
-      <>
-        End users can install from <b>Fleet Desktop {">"} Self-service</b>.
-      </>
-    ),
+    tooltip: SELF_SERVICE_TOOLTIP,
   },
   automatic: {
     iconName: "refresh",

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwareInstallerCard/SoftwareInstallerCard.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwareInstallerCard/SoftwareInstallerCard.tsx
@@ -11,6 +11,7 @@ import {
 import softwareAPI from "services/entities/software";
 
 import { getPathWithQueryParams } from "utilities/url";
+import { SELF_SERVICE_TOOLTIP } from "pages/SoftwarePage/helpers";
 
 import Card from "components/Card";
 
@@ -322,7 +323,16 @@ const SoftwareInstallerCard = ({
                   />
                 </TooltipWrapper>
               )}
-            {isSelfService && <Tag icon="user" text="Self-service" />}
+            {isSelfService && (
+              <TooltipWrapper
+                showArrow
+                position="top"
+                tipContent={SELF_SERVICE_TOOLTIP}
+                underline={false}
+              >
+                <Tag icon="user" text="Self-service" />
+              </TooltipWrapper>
+            )}
           </div>
         </div>
         <div className={`${baseClass}__actions-wrapper`}>

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwareInstallerCard/SoftwareInstallerCard.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwareInstallerCard/SoftwareInstallerCard.tsx
@@ -307,21 +307,21 @@ const SoftwareInstallerCard = ({
             addedTimestamp={addedTimestamp}
           />
           <div className={`${baseClass}__tags-wrapper`}>
-            {(!softwareInstaller?.automatic_install_policies ||
-              softwareInstaller?.automatic_install_policies.length > 0) && (
-              <TooltipWrapper
-                showArrow
-                position="top"
-                tipContent="Click to see policy that triggers automatic install."
-                underline={false}
-              >
-                <Tag
-                  icon="refresh"
-                  text="Automatic install"
-                  onClick={() => setShowAutomaticInstallModal(true)}
-                />
-              </TooltipWrapper>
-            )}
+            {Array.isArray(softwareInstaller.automatic_install_policies) &&
+              softwareInstaller.automatic_install_policies.length > 0 && (
+                <TooltipWrapper
+                  showArrow
+                  position="top"
+                  tipContent="Click to see policy that triggers automatic install."
+                  underline={false}
+                >
+                  <Tag
+                    icon="refresh"
+                    text="Automatic install"
+                    onClick={() => setShowAutomaticInstallModal(true)}
+                  />
+                </TooltipWrapper>
+              )}
             {isSelfService && <Tag icon="user" text="Self-service" />}
           </div>
         </div>

--- a/frontend/pages/SoftwarePage/helpers.tsx
+++ b/frontend/pages/SoftwarePage/helpers.tsx
@@ -13,12 +13,6 @@ import { getErrorReason } from "interfaces/errors";
 import { ISoftwarePackage, IAppStoreApp } from "interfaces/software";
 import { IDropdownOption } from "interfaces/dropdownOption";
 
-import Radio from "components/forms/fields/Radio";
-import TooltipWrapper from "components/TooltipWrapper";
-import InfoBanner from "components/InfoBanner";
-import CustomLink from "components/CustomLink";
-import { LEARN_MORE_ABOUT_BASE_LINK } from "utilities/constants";
-
 /**
  * helper function to generate error message for secret variables based
  * on the error reason.
@@ -166,3 +160,9 @@ export const CUSTOM_TARGET_OPTIONS: IDropdownOption[] = [
     disabled: false,
   },
 ];
+
+export const SELF_SERVICE_TOOLTIP = (
+  <>
+    End users can install from <b>Fleet Desktop</b> &gt; <b>Self-service</b>.
+  </>
+);

--- a/frontend/pages/hosts/details/cards/Software/InstallStatusCell/InstallStatusCell.tsx
+++ b/frontend/pages/hosts/details/cards/Software/InstallStatusCell/InstallStatusCell.tsx
@@ -4,6 +4,7 @@ import ReactTooltip from "react-tooltip";
 import { uniqueId } from "lodash";
 
 import { IHostSoftware, SoftwareInstallStatus } from "interfaces/software";
+import { SELF_SERVICE_TOOLTIP } from "pages/SoftwarePage/helpers";
 
 import Icon from "components/Icon";
 import TextCell from "components/TableContainer/DataTable/TextCell";
@@ -102,8 +103,7 @@ export const INSTALL_STATUS_DISPLAY_OPTIONS: Record<
     tooltip: ({ softwareName }) => (
       <>
         {softwareName ? <b>{softwareName}</b> : "Software"} can be installed on
-        the host. End users can install from{" "}
-        <b>Fleet Desktop {">"} Self-service</b>.
+        the host. {SELF_SERVICE_TOOLTIP}
       </>
     ),
   },


### PR DESCRIPTION
## Issue
Unreleased for #26636

## Description
- Remove the OR that was showing the pill for both not having auto install  and having auto install 😅

## Screenshot of fix

### Auto install is now hidden if API returns null and added self-service tooltip
<img width="1277" alt="Screenshot 2025-02-27 at 11 54 03 AM" src="https://github.com/user-attachments/assets/fc1efc0f-e647-4f0b-8b2c-6df111418d4a" />


### Helper constant of self-service tooltip used in 4 places (here's the most intricate example)
<img width="1007" alt="Screenshot 2025-02-27 at 12 02 02 PM" src="https://github.com/user-attachments/assets/71c62b59-e127-4d5c-b8bb-d2bceeec7a52" />


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->


- [x] Manual QA for all new/changed functionality

