### PR TITLE
Delete Android PubSub topic when deleting enterprise.

### DIFF
--- a/server/mdm/android/mock/proxy.go
+++ b/server/mdm/android/mock/proxy.go
@@ -20,7 +20,7 @@ type EnterprisesPoliciesPatchFunc func(enterpriseID string, policyName string, p
 
 type EnterprisesEnrollmentTokensCreateFunc func(enterpriseName string, token *androidmanagement.EnrollmentToken) (*androidmanagement.EnrollmentToken, error)
 
-type EnterpriseDeleteFunc func(enterpriseID string) error
+type EnterpriseDeleteFunc func(ctx context.Context, enterpriseID string) error
 
 type Proxy struct {
 	SignupURLsCreateFunc        SignupURLsCreateFunc
@@ -69,9 +69,9 @@ func (p *Proxy) EnterprisesEnrollmentTokensCreate(enterpriseName string, token *
 	return p.EnterprisesEnrollmentTokensCreateFunc(enterpriseName, token)
 }
 
-func (p *Proxy) EnterpriseDelete(enterpriseID string) error {
+func (p *Proxy) EnterpriseDelete(ctx context.Context, enterpriseID string) error {
 	p.mu.Lock()
 	p.EnterpriseDeleteFuncInvoked = true
 	p.mu.Unlock()
-	return p.EnterpriseDeleteFunc(enterpriseID)
+	return p.EnterpriseDeleteFunc(ctx, enterpriseID)
 }

--- a/server/mdm/android/mock/proxy_setup.go
+++ b/server/mdm/android/mock/proxy_setup.go
@@ -8,7 +8,7 @@ import (
 )
 
 func (p *Proxy) InitCommonMocks() {
-	p.EnterpriseDeleteFunc = func(enterpriseID string) error {
+	p.EnterpriseDeleteFunc = func(ctx context.Context, enterpriseID string) error {
 		return nil
 	}
 	p.SignupURLsCreateFunc = func(callbackURL string) (*android.SignupDetails, error) {

--- a/server/mdm/android/proxy.go
+++ b/server/mdm/android/proxy.go
@@ -11,7 +11,7 @@ type Proxy interface {
 	EnterprisesCreate(ctx context.Context, req ProxyEnterprisesCreateRequest) (string, string, error)
 	EnterprisesPoliciesPatch(enterpriseID string, policyName string, policy *androidmanagement.Policy) error
 	EnterprisesEnrollmentTokensCreate(enterpriseName string, token *androidmanagement.EnrollmentToken) (*androidmanagement.EnrollmentToken, error)
-	EnterpriseDelete(enterpriseID string) error
+	EnterpriseDelete(ctx context.Context, enterpriseID string) error
 }
 
 type ProxyEnterprisesCreateRequest struct {

--- a/server/mdm/android/service/proxy/proxy.go
+++ b/server/mdm/android/service/proxy/proxy.go
@@ -5,9 +5,11 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strings"
 	"time"
 
 	"cloud.google.com/go/pubsub"
+	"github.com/fleetdm/fleet/v4/server/contexts/ctxerr"
 	"github.com/fleetdm/fleet/v4/server/mdm/android"
 	"github.com/go-json-experiment/json"
 	kitlog "github.com/go-kit/log"
@@ -182,9 +184,9 @@ func (p *Proxy) EnterpriseDelete(ctx context.Context, enterpriseID string) error
 	// To find out the enterprise's PubSub topic, we need to get the enterprise first
 	enterprise, err := p.mgmt.Enterprises.Get("enterprises/" + enterpriseID).Do()
 	if err != nil {
-		return fmt.Errorf("getting enterprise %s: %w", enterpriseID, err)
+		level.Error(p.logger).Log("msg", "getting enterprise; perhaps it was already deleted?", "err", err, "enterprise_id", enterpriseID)
+		return nil
 	}
-	pubSubTopic := enterprise.PubsubTopic
 
 	_, err = p.mgmt.Enterprises.Delete("enterprises/" + enterpriseID).Do()
 	switch {
@@ -195,15 +197,33 @@ func (p *Proxy) EnterpriseDelete(ctx context.Context, enterpriseID string) error
 		return fmt.Errorf("deleting enterprise %s: %w", enterpriseID, err)
 	}
 
+	// Delete the PubSub topic if it exists
+	if enterprise == nil || len(enterprise.PubsubTopic) == 0 {
+		return nil
+	}
+	topicID, err := getLastPart(ctx, enterprise.PubsubTopic)
+	if err != nil || len(topicID) == 0 {
+		level.Error(p.logger).Log("msg", "getting last part of PubSub topic", "err", err, "topic", enterprise.PubsubTopic)
+		return nil
+	}
+
 	pubSubClient, err := pubsub.NewClient(ctx, androidProjectID, option.WithCredentialsJSON([]byte(androidServiceCredentials)))
 	if err != nil {
 		return fmt.Errorf("creating PubSub client: %w", err)
 	}
 	defer pubSubClient.Close()
-	err = pubSubClient.Topic(pubSubTopic).Delete(ctx)
+	err = pubSubClient.Topic(topicID).Delete(ctx)
 	if err != nil {
-		return fmt.Errorf("deleting PubSub topic %s: %w", pubSubTopic, err)
+		return fmt.Errorf("deleting PubSub topic %s: %w", enterprise.PubsubTopic, err)
 	}
 
 	return nil
+}
+
+func getLastPart(ctx context.Context, name string) (string, error) {
+	nameParts := strings.Split(name, "/")
+	if len(nameParts) == 0 {
+		return "", ctxerr.Errorf(ctx, "invalid Google resource name: %s", name)
+	}
+	return nameParts[len(nameParts)-1], nil
 }

--- a/server/mdm/android/service/proxy/proxy.go
+++ b/server/mdm/android/service/proxy/proxy.go
@@ -180,7 +180,7 @@ func (p *Proxy) EnterpriseDelete(ctx context.Context, enterpriseID string) error
 	}
 
 	// To find out the enterprise's PubSub topic, we need to get the enterprise first
-	enterprise, err := p.mgmt.Enterprises.Get(enterpriseID).Do()
+	enterprise, err := p.mgmt.Enterprises.Get("enterprises/" + enterpriseID).Do()
 	if err != nil {
 		return fmt.Errorf("getting enterprise %s: %w", enterpriseID, err)
 	}

--- a/server/mdm/android/service/service.go
+++ b/server/mdm/android/service/service.go
@@ -306,7 +306,7 @@ func (svc *Service) DeleteEnterprise(ctx context.Context) error {
 	case err != nil:
 		return ctxerr.Wrap(ctx, err, "getting enterprise")
 	default:
-		err = svc.proxy.EnterpriseDelete(enterprise.EnterpriseID)
+		err = svc.proxy.EnterpriseDelete(ctx, enterprise.EnterpriseID)
 		if err != nil {
 			return ctxerr.Wrap(ctx, err, "deleting enterprise via Google API")
 		}

--- a/server/mdm/android/tests/testing_utils.go
+++ b/server/mdm/android/tests/testing_utils.go
@@ -118,7 +118,7 @@ func (ts *WithServer) createCommonProxyMocks(t *testing.T) {
 		assert.Equal(t, EnterpriseID, enterpriseID)
 		return nil
 	}
-	ts.Proxy.EnterpriseDeleteFunc = func(enterpriseID string) error {
+	ts.Proxy.EnterpriseDeleteFunc = func(ctx context.Context, enterpriseID string) error {
 		assert.Equal(t, EnterpriseID, enterpriseID)
 		return nil
 	}


### PR DESCRIPTION
For #26218

This is a dev helper feature (since it will be implemented in fleetdm.com). It fixes the issue of stale PubSub topics. Having stale PubSub topics around may cause extra traffic/errors on dev server.

- [x] Manual QA for all new/changed functionality
