### PR TITLE
Added signup_token for Android signup callback authentication.

### DIFF
--- a/server/mdm/android/datastore.go
+++ b/server/mdm/android/datastore.go
@@ -9,6 +9,7 @@ import (
 type Datastore interface {
 	CreateEnterprise(ctx context.Context, userID uint) (uint, error)
 	GetEnterpriseByID(ctx context.Context, ID uint) (*EnterpriseDetails, error)
+	GetEnterpriseBySignupToken(ctx context.Context, signupToken string) (*EnterpriseDetails, error)
 	GetEnterprise(ctx context.Context) (*Enterprise, error)
 	UpdateEnterprise(ctx context.Context, enterprise *EnterpriseDetails) error
 	DeleteAllEnterprises(ctx context.Context) error

--- a/server/mdm/android/mock/datastore.go
+++ b/server/mdm/android/mock/datastore.go
@@ -16,6 +16,8 @@ type CreateEnterpriseFunc func(ctx context.Context, userID uint) (uint, error)
 
 type GetEnterpriseByIDFunc func(ctx context.Context, ID uint) (*android.EnterpriseDetails, error)
 
+type GetEnterpriseBySignupTokenFunc func(ctx context.Context, signupToken string) (*android.EnterpriseDetails, error)
+
 type GetEnterpriseFunc func(ctx context.Context) (*android.Enterprise, error)
 
 type UpdateEnterpriseFunc func(ctx context.Context, enterprise *android.EnterpriseDetails) error
@@ -34,6 +36,9 @@ type Datastore struct {
 
 	GetEnterpriseByIDFunc        GetEnterpriseByIDFunc
 	GetEnterpriseByIDFuncInvoked bool
+
+	GetEnterpriseBySignupTokenFunc        GetEnterpriseBySignupTokenFunc
+	GetEnterpriseBySignupTokenFuncInvoked bool
 
 	GetEnterpriseFunc        GetEnterpriseFunc
 	GetEnterpriseFuncInvoked bool
@@ -68,6 +73,13 @@ func (ds *Datastore) GetEnterpriseByID(ctx context.Context, ID uint) (*android.E
 	ds.GetEnterpriseByIDFuncInvoked = true
 	ds.mu.Unlock()
 	return ds.GetEnterpriseByIDFunc(ctx, ID)
+}
+
+func (ds *Datastore) GetEnterpriseBySignupToken(ctx context.Context, signupToken string) (*android.EnterpriseDetails, error) {
+	ds.mu.Lock()
+	ds.GetEnterpriseBySignupTokenFuncInvoked = true
+	ds.mu.Unlock()
+	return ds.GetEnterpriseBySignupTokenFunc(ctx, signupToken)
 }
 
 func (ds *Datastore) GetEnterprise(ctx context.Context) (*android.Enterprise, error) {

--- a/server/mdm/android/mock/datastore_setup.go
+++ b/server/mdm/android/mock/datastore_setup.go
@@ -2,6 +2,7 @@ package mock
 
 import (
 	"context"
+	"errors"
 
 	"github.com/fleetdm/fleet/v4/server/mdm/android"
 )
@@ -19,10 +20,24 @@ func (s *Datastore) InitCommonMocks() {
 	s.GetEnterpriseByIDFunc = func(ctx context.Context, ID uint) (*android.EnterpriseDetails, error) {
 		return &android.EnterpriseDetails{}, nil
 	}
+	s.GetEnterpriseBySignupTokenFunc = func(ctx context.Context, signupToken string) (*android.EnterpriseDetails, error) {
+		if signupToken == "signup_token" {
+			return &android.EnterpriseDetails{}, nil
+		}
+		return nil, &notFoundError{errors.New("not found")}
+	}
 	s.DeleteAllEnterprisesFunc = func(ctx context.Context) error {
 		return nil
 	}
 	s.DeleteOtherEnterprisesFunc = func(ctx context.Context, ID uint) error {
 		return nil
 	}
+}
+
+type notFoundError struct {
+	error
+}
+
+func (e *notFoundError) IsNotFound() bool {
+	return true
 }

--- a/server/mdm/android/mysql/enterprises.go
+++ b/server/mdm/android/mysql/enterprises.go
@@ -35,6 +35,19 @@ func (ds *Datastore) GetEnterpriseByID(ctx context.Context, id uint) (*android.E
 	return &enterprise, nil
 }
 
+func (ds *Datastore) GetEnterpriseBySignupToken(ctx context.Context, signupToken string) (*android.EnterpriseDetails, error) {
+	stmt := `SELECT id, signup_name, enterprise_id, pubsub_topic_id, signup_token, user_id FROM android_enterprises WHERE signup_token = ?`
+	var enterprise android.EnterpriseDetails
+	err := sqlx.GetContext(ctx, ds.reader(ctx), &enterprise, stmt, signupToken)
+	switch {
+	case errors.Is(err, sql.ErrNoRows):
+		return nil, common_mysql.NotFound("Android enterprise")
+	case err != nil:
+		return nil, ctxerr.Wrap(ctx, err, "getting enterprise by signup token")
+	}
+	return &enterprise, nil
+}
+
 func (ds *Datastore) GetEnterprise(ctx context.Context) (*android.Enterprise, error) {
 	stmt := `SELECT id, enterprise_id FROM android_enterprises WHERE enterprise_id != '' LIMIT 1`
 	var enterprise android.Enterprise

--- a/server/mdm/android/mysql/enterprises_test.go
+++ b/server/mdm/android/mysql/enterprises_test.go
@@ -73,6 +73,10 @@ func testUpdateEnterprise(t *testing.T, ds *Datastore) {
 	require.NoError(t, err)
 	assert.Equal(t, enterprise, resultEnriched)
 
+	resultEnrichedByToken, err := ds.GetEnterpriseBySignupToken(testCtx(), enterprise.SignupToken)
+	require.NoError(t, err)
+	assert.Equal(t, enterprise, resultEnrichedByToken)
+
 	result, err := ds.GetEnterprise(testCtx())
 	require.NoError(t, err)
 	assert.Equal(t, enterprise.Enterprise, *result)

--- a/server/mdm/android/service.go
+++ b/server/mdm/android/service.go
@@ -6,7 +6,7 @@ import (
 
 type Service interface {
 	EnterpriseSignup(ctx context.Context) (*SignupDetails, error)
-	EnterpriseSignupCallback(ctx context.Context, enterpriseID uint, enterpriseToken string) error
+	EnterpriseSignupCallback(ctx context.Context, signupToken string, enterpriseToken string) error
 	GetEnterprise(ctx context.Context) (*Enterprise, error)
 	DeleteEnterprise(ctx context.Context) error
 	EnterpriseSignupSSE(ctx context.Context) (chan string, error)

--- a/server/mdm/android/service/enterprises_test.go
+++ b/server/mdm/android/service/enterprises_test.go
@@ -110,8 +110,10 @@ func TestEnterprisesAuth(t *testing.T) {
 	}
 
 	t.Run("unauthorized", func(t *testing.T) {
-		err := svc.EnterpriseSignupCallback(context.Background(), 1, "token")
+		err := svc.EnterpriseSignupCallback(context.Background(), "signup_token", "token")
 		checkAuthErr(t, false, err)
+		err = svc.EnterpriseSignupCallback(context.Background(), "bad_token", "token")
+		checkAuthErr(t, true, err)
 	})
 }
 

--- a/server/mdm/android/service/handler.go
+++ b/server/mdm/android/service/handler.go
@@ -32,7 +32,7 @@ func attachFleetAPIRoutes(r *mux.Router, fleetSvc fleet.Service, svc android.Ser
 	// These endpoints should do custom one-time authentication by verifying that a valid secret token is provided with the request.
 	ne := newNoAuthEndpointer(fleetSvc, svc, opts, r, apiVersions()...)
 
-	ne.GET("/api/_version_/fleet/android_enterprise/{id:[0-9]+}/connect", enterpriseSignupCallbackEndpoint, enterpriseSignupCallbackRequest{})
+	ne.GET("/api/_version_/fleet/android_enterprise/connect/{token}", enterpriseSignupCallbackEndpoint, enterpriseSignupCallbackRequest{})
 	ne.GET("/api/_version_/fleet/android_enterprise/enrollment_token", enrollmentTokenEndpoint, enrollmentTokenRequest{})
 	ne.POST(pubSubPushPath, pubSubPushEndpoint, pubSubPushRequest{})
 


### PR DESCRIPTION
For #26218

- Added signup_token authentication for Android enterprise callback and fixed API path to match API doc

# Checklist for submitter

- [x] Added/updated automated tests
- [x] Manual QA for all new/changed functionality
