### PR TITLE
Fleet UI: Team user table overflow unreleased

### DIFF
--- a/frontend/pages/admin/TeamManagementPage/TeamDetailsWrapper/UsersPage/_styles.scss
+++ b/frontend/pages/admin/TeamManagementPage/TeamDetailsWrapper/UsersPage/_styles.scss
@@ -26,6 +26,16 @@
           max-width: $col-sm;
         }
 
+        .email__cell {
+          max-width: 171px;
+        }
+
+        @media (min-width: $break-md) {
+          .email__cell {
+            max-width: $col-md;
+          }
+        }
+
         .actions__cell {
           width: auto;
         }


### PR DESCRIPTION
## Issue
More for #26631 

## Description
- Fix overflow still found in QA by Janis
- Bug: long email address / observer + pushing cells off table

## Screenrecording of fix
https://github.com/user-attachments/assets/9e2afcfe-1c5c-47bc-8b50-5a73de2bda12



# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->
 
   - [x] Manual QA must be performed in the three main OSs, macOS, Windows and Linux.

