### PR TITLE
Fix height of masthead on device details page

### DIFF
--- a/frontend/pages/hosts/details/DeviceUserPage/DeviceUserPage.tsx
+++ b/frontend/pages/hosts/details/DeviceUserPage/DeviceUserPage.tsx
@@ -615,7 +615,7 @@ const DeviceUserPage = ({
       />
       <nav className="site-nav-container">
         <div className="site-nav-content">
-          <ul className="site-nav-list">
+          <ul className="site-nav-left">
             <li className="site-nav-item dup-org-logo" key="dup-org-logo">
               <div className="site-nav-item__logo-wrapper">
                 <div className="site-nav-item__logo">


### PR DESCRIPTION
For #26697 

This was using the wrong class (maybe outdated?) for the masthead, leading to incorrect margins and too much height.  Changing it to use the same class as the main Fleet nav fixes it.

Before:
<img width="1006" alt="image" src="https://github.com/user-attachments/assets/2c3171de-4d63-4817-a185-b1f492c230b6" />

After:
<img width="1008" alt="image" src="https://github.com/user-attachments/assets/cc4d9237-f82d-4b2a-b8b7-178553d97e7e" />

