### PR TITLE
Updated custom lint rules to include Android datastore.

### DIFF
--- a/tools/ci/rules.go
+++ b/tools/ci/rules.go
@@ -24,6 +24,7 @@ func createHttpClient(m dsl.Matcher) {
 
 func txCheck(m dsl.Matcher) {
 	m.Import("github.com/fleetdm/fleet/v4/server/datastore/mysql")
+	m.Import("github.com/fleetdm/fleet/v4/server/mdm/android/mysql")
 	m.Import("github.com/jmoiron/sqlx")
 
 	isDatastoreType := func(v dsl.Var) bool {
@@ -31,14 +32,15 @@ func txCheck(m dsl.Matcher) {
 	}
 
 	containsIllegal := func(v dsl.Var) bool {
-		return v.Contains(`$ds.writer`) || v.Contains(`$ds.reader`)
+		return v.Contains(`$ds.writer`) || v.Contains(`$ds.reader`) ||
+			v.Contains(`$ds.Writer`) || v.Contains(`$ds.Reader`)
 	}
 
 	isSqlxIface := func(v dsl.Var) bool {
 		return (v.Type.Is(`sqlx.ExtContext`) || v.Type.Is(`sqlx.ExecContext`))
 	}
 
-	m.Match(`$ds.withTx($_, $fn)`, `$ds.withRetryTxx($_, $fn)`).
+	m.Match(`$ds.withTx($_, $fn)`, `$ds.withRetryTxx($_, $fn)`, `$ds.WithRetryTxx($_, $fn)`).
 		Where(isDatastoreType(m["ds"]) && containsIllegal(m["fn"])).
 		Report("improper use of ds.reader or ds.writer in a transaction")
 


### PR DESCRIPTION
For #26218 

### Observations
The custom lint rules don't catch many issues. For example: this checks for an illegal use of reader/writer in a function (`containsIllegal(m["fn"]))`), but if the reader/writer code is refactored into a different function, then this check will not fail.

Also, the rules lack tests, making them hard to maintain and potentially irrelevant after code is refactored.
