### PR TITLE
Sentence case fix in SMTP options form

### DIFF
--- a/docs/Contributing/Testing-and-local-development.md
+++ b/docs/Contributing/Testing-and-local-development.md
@@ -280,7 +280,7 @@ Visit [localhost:8025](http://localhost:8025) to view MailHog's admin interface 
 Alternatively, if you need to test a SMTP server with plain basic authentication enabled, set:
 - "SMTP server" to `localhost` on port `1026`
 - "Use SSL/TLS to connect (recommended)" to unchecked.
-- "Authentication type" to `Username and Password`
+- "Authentication type" to `Username and password`
 - "SMTP username" to `mailpit-username`
 - "SMTP password" to `mailpit-password`
 - "Auth method" to `Plain`

--- a/frontend/pages/admin/OrgSettingsPage/cards/constants.ts
+++ b/frontend/pages/admin/OrgSettingsPage/cards/constants.ts
@@ -27,7 +27,7 @@ export const authMethodOptions = [
 ];
 
 export const authTypeOptions = [
-  { label: "Username and Password", value: "authtype_username_password" },
+  { label: "Username and password", value: "authtype_username_password" },
   { label: "None", value: "authtype_none" },
 ];
 


### PR DESCRIPTION
"Username and Password" -> "Username and password"