### PR TITLE
Fix 404 link on GitOps settings page

### DIFF
--- a/website/config/routes.js
+++ b/website/config/routes.js
@@ -873,6 +873,7 @@ module.exports.routes = {
   'GET /learn-more-about/windows-mdm': '/guides/windows-mdm-setup',
   'GET /learn-more-about/ui-gitops-mode': 'https://github.com/fleetdm/fleet-gitops/?tab=readme-ov-file#fleet-ui',
   'GET /learn-more-about/certificates-query': '/tables/certificates',
+  'GET /learn-more-about/gitops': 'https://github.com/fleetdm/fleet-gitops/',
 
   // Sitemap
   // =============================================================================================================


### PR DESCRIPTION
Add redirect for "Learn more" link on `/settings/integrations/change-management`