### PR TITLE
clarify: gitops is optional and you can configure it to work however you want -- Update device-management.ejs:

### DIFF
--- a/website/views/pages/device-management.ejs
+++ b/website/views/pages/device-management.ejs
@@ -544,7 +544,7 @@
             <div purpose="checklist" class="flex-column d-flex">
               <p>Democratize change with GitOps so everyone can contribute to device management and security.</p>
               <p>Maintain reliable employee experiences with version-controlled changes and enhancements.</p>
-              <p>Use CI/CD and peer reviews to look before you leap.</p>
+              <p>Use CI/CD and peer reviews to look before you leap. (Configurable)</p>
             </div>
           </div>
         </div>


### PR DESCRIPTION
it'd be cool if there was a way to squeeze something about being able to share the logs with security in here, or all the really intense stuff Fleet does w/ logging, and webhooks, and log destinations, and all that jazz.

But whatever, this at least clarifies that "there is hope!" for our friends on the website from IT teams who are basically a 1-person-show and won't necessarily want to spend the time to mess around with a repo  (and plenty of other folks who simply prefer to have things work their way)