### PR TITLE
Skip failing TestTranslateCPEToCVE/find_vulns_on_cpes test

### DIFF
--- a/server/vulnerabilities/nvd/cve_test.go
+++ b/server/vulnerabilities/nvd/cve_test.go
@@ -588,6 +588,7 @@ func TestTranslateCPEToCVE(t *testing.T) {
 	}
 
 	t.Run("find_vulns_on_cpes", func(t *testing.T) {
+		t.Skip("Skipping failing test: https://github.com/fleetdm/fleet/issues/26748")
 		t.Parallel()
 
 		ds := new(mock.Store)


### PR DESCRIPTION
Skip failing TestTranslateCPEToCVE/find_vulns_on_cpes test due to https://github.com/fleetdm/fleet/issues/26748
