### PR TITLE
Fleet UI: Surface policy automation scripts error messages

### DIFF
--- a/changes/26231-component-cleanup
+++ b/changes/26231-component-cleanup
@@ -1,1 +1,0 @@
-- Fleet UI: Cleaned up components with new styling

--- a/changes/26231-component-cleanup
+++ b/changes/26231-component-cleanup
@@ -1,0 +1,1 @@
+- Fleet UI: Cleaned up components with new styling

--- a/changes/26710-scripts-error
+++ b/changes/26710-scripts-error
@@ -1,1 +1,1 @@
-- Fleet UI: Policy automation with scripts errors fixed to surface to user instead of rendering false success message
+- Fleet UI: Fixed policy automation with scripts to surface errors to user instead of rendering false success message

--- a/changes/26710-scripts-error
+++ b/changes/26710-scripts-error
@@ -1,0 +1,1 @@
+- Fleet UI: Policy automation with scripts errors fixed to surface to user instead of rendering false success message

--- a/frontend/pages/policies/ManagePoliciesPage/ManagePoliciesPage.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/ManagePoliciesPage.tsx
@@ -621,6 +621,7 @@ const ManagePolicyPage = ({
         renderFlash("success", DEFAULT_AUTOMATION_UPDATE_SUCCESS_MSG);
       }
 
+      await wait(100); // Wait 100ms to avoid race conditions with refetch
       refetchTeamPolicies();
     } catch {
       renderFlash("error", DEFAULT_AUTOMATION_UPDATE_ERR_MSG);
@@ -708,6 +709,7 @@ const ManagePolicyPage = ({
         renderFlash("success", DEFAULT_AUTOMATION_UPDATE_SUCCESS_MSG);
       }
 
+      await wait(100); // Wait 100ms to avoid race conditions with refetch
       refetchTeamPolicies();
     } catch {
       renderFlash("error", DEFAULT_AUTOMATION_UPDATE_ERR_MSG);

--- a/frontend/pages/policies/ManagePoliciesPage/components/PoliciesPaginatedList/PoliciesPaginatedList.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/components/PoliciesPaginatedList/PoliciesPaginatedList.tsx
@@ -28,6 +28,7 @@ export interface IFormPolicy extends IPolicy {
   swNameToInstall?: string;
   runScriptEnabled: boolean;
   scriptIdToRun?: number;
+  scriptNameToRun?: string;
 }
 
 interface IPoliciesPaginatedListProps {
@@ -88,7 +89,7 @@ function PoliciesPaginatedList(
     if (paginatedListRef.current) {
       changedItems = paginatedListRef.current.getDirtyItems();
     }
-    console.log("changedItems", changedItems);
+
     onSubmit(changedItems);
   };
 
@@ -155,6 +156,7 @@ function PoliciesPaginatedList(
         swIdToInstall: policy.install_software?.software_title_id,
         runScriptEnabled: !!policy.run_script,
         scriptIdToRun: policy.run_script?.id,
+        scriptNameToRun: policy.run_script?.name,
       })) as IFormPolicy[];
     });
   }, []);

--- a/frontend/pages/policies/ManagePoliciesPage/components/PolicyRunScriptModal/PolicyRunScriptModal.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/components/PolicyRunScriptModal/PolicyRunScriptModal.tsx
@@ -81,9 +81,18 @@ const PolicyRunScriptModal = ({
     item: IFormPolicy,
     { value }: IScriptDropdownField
   ) => {
+    // Script name needed for error message rendering
+    const findScriptNameById = () => {
+      const foundScript = availableScripts?.find(
+        (script) => script.id === value
+      );
+      return foundScript ? foundScript.name : "";
+    };
+
     return {
       ...item,
       scriptIdToRun: value,
+      scriptNameToRun: findScriptNameById(),
     };
   };
 

--- a/frontend/pages/policies/ManagePoliciesPage/helpers.tests.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/helpers.tests.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { getErrorMessage } from "./helpers";
+import { getInstallSoftwareErrorMessage } from "./helpers";
 import { IInstallSoftwareFormData } from "./components/InstallSoftwareModal/InstallSoftwareModal";
 
 describe("getErrorMessage", () => {
@@ -75,7 +75,11 @@ describe("getErrorMessage", () => {
 
     const currentTeamName = "1a - Workstations (canary)";
 
-    const result = getErrorMessage(mockResult, mockFormData, currentTeamName);
+    const result = getInstallSoftwareErrorMessage(
+      mockResult,
+      mockFormData,
+      currentTeamName
+    );
     const resultString = renderToString(result);
 
     expect(resultString).toBe(
@@ -97,7 +101,7 @@ describe("getErrorMessage", () => {
       status: "rejected",
     };
 
-    const result = getErrorMessage(mockResult, mockFormData);
+    const result = getInstallSoftwareErrorMessage(mockResult, mockFormData);
     const resultString = renderToString(result);
 
     expect(resultString).toBe(
@@ -119,7 +123,7 @@ describe("getErrorMessage", () => {
       status: "rejected",
     };
 
-    const result = getErrorMessage(mockResult, mockFormData);
+    const result = getInstallSoftwareErrorMessage(mockResult, mockFormData);
     const resultString = renderToString(result);
 
     expect(resultString).toBe(

--- a/frontend/pages/policies/ManagePoliciesPage/helpers.tests.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/helpers.tests.tsx
@@ -1,8 +1,12 @@
 import React from "react";
-import { getInstallSoftwareErrorMessage } from "./helpers";
+import {
+  getInstallSoftwareErrorMessage,
+  getRunScriptErrorMessage,
+} from "./helpers";
 import { IInstallSoftwareFormData } from "./components/InstallSoftwareModal/InstallSoftwareModal";
+import { IPolicyRunScriptFormData } from "./components/PolicyRunScriptModal/PolicyRunScriptModal";
 
-describe("getErrorMessage", () => {
+describe("getInstallSoftwareErrorMessage", () => {
   const mockFormData: IInstallSoftwareFormData = [
     {
       swIdToInstall: 178,
@@ -65,7 +69,7 @@ describe("getErrorMessage", () => {
           errors: [
             {
               reason:
-                "software_title_id 178 on team_id 789 does not have associated package",
+                "Software title with ID 178 on team ID 789 does not have associated package",
             },
           ],
         },
@@ -87,13 +91,13 @@ describe("getErrorMessage", () => {
     );
   });
 
-  it("handles unknown software_title_id", () => {
+  it("handles unknown software title id", () => {
     const mockResult: PromiseRejectedResult = {
       reason: {
         data: {
           errors: [
             {
-              reason: "Error with software_title_id 999",
+              reason: "Error with software title with ID 999",
             },
           ],
         },
@@ -105,7 +109,7 @@ describe("getErrorMessage", () => {
     const resultString = renderToString(result);
 
     expect(resultString).toBe(
-      "Could not update policy. Error with software_title_id 999"
+      "Could not update policy. Error with software title with ID 999"
     );
   });
 
@@ -115,7 +119,7 @@ describe("getErrorMessage", () => {
         data: {
           errors: [
             {
-              reason: "Error with team_id 789",
+              reason: "Error with team ID 789",
             },
           ],
         },
@@ -127,7 +131,136 @@ describe("getErrorMessage", () => {
     const resultString = renderToString(result);
 
     expect(resultString).toBe(
-      "Could not update policy. Error with team_id 789"
+      "Could not update policy. Error with team ID 789"
+    );
+  });
+});
+
+describe("getRunScriptErrorMessage", () => {
+  const mockFormData: IPolicyRunScriptFormData = [
+    {
+      scriptIdToRun: 123,
+      scriptNameToRun: "Test Script",
+      name: "Test policy",
+      id: 1,
+      installSoftwareEnabled: false,
+      platform: "darwin",
+      runScriptEnabled: true,
+      query: "",
+      description: "",
+      author_id: 0,
+      author_name: "",
+      author_email: "",
+      resolution: "",
+      team_id: null,
+      created_at: "",
+      updated_at: "",
+      critical: false,
+      calendar_events_enabled: false,
+    },
+    {
+      scriptIdToRun: 456,
+      scriptNameToRun: "Another Script",
+      name: "Another test policy",
+      id: 2,
+      installSoftwareEnabled: false,
+      platform: "darwin",
+      runScriptEnabled: true,
+      query: "",
+      description: "",
+      author_id: 0,
+      author_name: "",
+      author_email: "",
+      resolution: "",
+      team_id: null,
+      created_at: "",
+      updated_at: "",
+      critical: false,
+      calendar_events_enabled: false,
+    },
+  ];
+
+  const renderToString = (element: JSX.Element): string => {
+    return React.Children.toArray(element.props.children)
+      .map((child) => {
+        if (typeof child === "string") return child;
+        if (React.isValidElement(child)) {
+          return renderToString(child);
+        }
+        return "";
+      })
+      .join("");
+  };
+
+  it("returns a JSX element with the correct error message for script and team", () => {
+    const mockResult: PromiseRejectedResult = {
+      reason: {
+        data: {
+          errors: [
+            {
+              reason: "Script with ID 123 does not belong to team ID 789",
+            },
+          ],
+        },
+      },
+      status: "rejected",
+    };
+
+    const currentTeamName = "1a - Workstations (canary)";
+
+    const result = getRunScriptErrorMessage(
+      mockResult,
+      mockFormData,
+      currentTeamName
+    );
+    const resultString = renderToString(result);
+
+    expect(resultString).toBe(
+      "Could not update policy. Test Script (ID: 123) does not belong to 1a - Workstations (canary)"
+    );
+  });
+
+  it("handles unknown script id", () => {
+    const mockResult: PromiseRejectedResult = {
+      reason: {
+        data: {
+          errors: [
+            {
+              reason: "Error with script with ID 999",
+            },
+          ],
+        },
+      },
+      status: "rejected",
+    };
+
+    const result = getRunScriptErrorMessage(mockResult, mockFormData);
+    const resultString = renderToString(result);
+
+    expect(resultString).toBe(
+      "Could not update policy. Error with script with ID 999"
+    );
+  });
+
+  it("handles missing currentTeamName", () => {
+    const mockResult: PromiseRejectedResult = {
+      reason: {
+        data: {
+          errors: [
+            {
+              reason: "Error with team ID 789",
+            },
+          ],
+        },
+      },
+      status: "rejected",
+    };
+
+    const result = getRunScriptErrorMessage(mockResult, mockFormData);
+    const resultString = renderToString(result);
+
+    expect(resultString).toBe(
+      "Could not update policy. Error with team ID 789"
     );
   });
 });

--- a/frontend/pages/policies/ManagePoliciesPage/helpers.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/helpers.tsx
@@ -11,7 +11,7 @@ export const getInstallSoftwareErrorMessage = (
 ): JSX.Element => {
   const apiErrorMessage = result.reason.data.errors[0].reason;
   const parts = apiErrorMessage.split(
-    /(Software title with ID \d+|team ID \d+)/
+    /(Software title with ID \d+|team ID \d+)/i
   );
 
   const jsxElement = parts.map((part: string) => {
@@ -42,7 +42,7 @@ export const getRunScriptErrorMessage = (
   currentTeamName?: string
 ): JSX.Element => {
   const apiErrorMessage = result.reason.data.errors[0].reason;
-  const parts = apiErrorMessage.split(/(Script with ID \d+|team ID \d+)/);
+  const parts = apiErrorMessage.split(/(Script with ID \d+|team ID \d+)/i);
 
   const jsxElement = parts.map((part: string) => {
     if (part.startsWith("Script with ID")) {

--- a/frontend/pages/policies/ManagePoliciesPage/helpers.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/helpers.tsx
@@ -1,31 +1,64 @@
 import React from "react";
 
 import { IInstallSoftwareFormData } from "./components/InstallSoftwareModal/InstallSoftwareModal";
+import { IPolicyRunScriptFormData } from "./components/PolicyRunScriptModal/PolicyRunScriptModal";
 
 /** Creates a readable JSX element from the error message */
-// eslint-disable-next-line import/prefer-default-export
-export const getErrorMessage = (
+export const getInstallSoftwareErrorMessage = (
   result: PromiseRejectedResult,
   formData: IInstallSoftwareFormData,
   currentTeamName?: string
 ): JSX.Element => {
   const apiErrorMessage = result.reason.data.errors[0].reason;
-  const parts = apiErrorMessage.split(/(software_title_id \d+|team_id \d+)/);
+  const parts = apiErrorMessage.split(
+    /(Software title with ID \d+|team ID \d+)/
+  );
 
   const jsxElement = parts.map((part: string) => {
-    if (part.startsWith("software_title_id")) {
-      const swId = part.split(" ")[1];
-      const software = formData.find(
+    if (part.startsWith("Software title with ID")) {
+      const swId = part.match(/\d+/)?.[0];
+      const policy = formData.find(
         (item) => item.swIdToInstall?.toString() === swId
       );
-      return software ? (
+      return policy ? (
         <React.Fragment key={part}>
-          <b>{software.swNameToInstall}</b> (ID: {swId})
+          <b>{policy.swNameToInstall}</b> (ID: {swId})
         </React.Fragment>
       ) : (
         part
       );
-    } else if (part.startsWith("team_id")) {
+    } else if (part.startsWith("team ID")) {
+      return currentTeamName ? <b key={part}>{currentTeamName}</b> : part;
+    }
+    return <React.Fragment key={part}>{part}</React.Fragment>;
+  });
+
+  return <>Could not update policy. {jsxElement}</>;
+};
+
+export const getRunScriptErrorMessage = (
+  result: PromiseRejectedResult,
+  formData: IPolicyRunScriptFormData,
+  currentTeamName?: string
+): JSX.Element => {
+  const apiErrorMessage = result.reason.data.errors[0].reason;
+  const parts = apiErrorMessage.split(/(Script with ID \d+|team ID \d+)/);
+
+  const jsxElement = parts.map((part: string) => {
+    if (part.startsWith("Script with ID")) {
+      const scriptId = part.match(/\d+/)?.[0];
+      const policy = formData.find(
+        (item) => item.scriptIdToRun?.toString() === scriptId
+      );
+
+      return policy ? (
+        <React.Fragment key={part}>
+          <b>{policy.scriptNameToRun}</b> (ID: {scriptId})
+        </React.Fragment>
+      ) : (
+        part
+      );
+    } else if (part.startsWith("team ID")) {
       return currentTeamName ? <b key={part}>{currentTeamName}</b> : part;
     }
     return <React.Fragment key={part}>{part}</React.Fragment>;

--- a/frontend/pages/queries/edit/components/EditQueryForm/EditQueryForm.tsx
+++ b/frontend/pages/queries/edit/components/EditQueryForm/EditQueryForm.tsx
@@ -737,7 +737,6 @@ const EditQueryForm = ({
     const disableSaveFormErrors =
       (lastEditedQueryName === "" && !!lastEditedQueryId) || !!size(errors);
 
-    console.log("hostId", hostId);
     return (
       <>
         <form className={`${baseClass}`} autoComplete="off">

--- a/server/datastore/mysql/policies.go
+++ b/server/datastore/mysql/policies.go
@@ -181,11 +181,6 @@ func (ds *Datastore) SavePolicy(ctx context.Context, p *fleet.Policy, shouldRemo
 	)
 }
 
-var (
-	errMismatchedInstallerTeam = &fleet.BadRequestError{Message: "software installer is associated with a different team"}
-	errMismatchedScriptTeam    = &fleet.BadRequestError{Message: "script is associated with a different team"}
-)
-
 func assertTeamMatches(ctx context.Context, db sqlx.QueryerContext, teamID uint, softwareInstallerID *uint, scriptID *uint, vppAppsTeamsID *uint) error {
 	if softwareInstallerID != nil {
 		var softwareInstallerTeamID uint
@@ -194,7 +189,7 @@ func assertTeamMatches(ctx context.Context, db sqlx.QueryerContext, teamID uint,
 		if err != nil {
 			if errors.Is(err, sql.ErrNoRows) {
 				return ctxerr.Wrap(ctx, &fleet.BadRequestError{
-					Message: fmt.Sprintf("A software installer with the supplied ID %d does not exist", *softwareInstallerID),
+					Message: fmt.Sprintf("Software installer with ID %d does not exist", *softwareInstallerID),
 				})
 			}
 			return ctxerr.Wrap(ctx, err, "querying software installer")

--- a/server/datastore/mysql/policies.go
+++ b/server/datastore/mysql/policies.go
@@ -193,11 +193,15 @@ func assertTeamMatches(ctx context.Context, db sqlx.QueryerContext, teamID uint,
 
 		if err != nil {
 			if errors.Is(err, sql.ErrNoRows) {
-				return &fleet.BadRequestError{Message: "A software installer with the supplied ID does not exist"}
+				return ctxerr.Wrap(ctx, &fleet.BadRequestError{
+					Message: fmt.Sprintf("A software installer with the supplied ID %d does not exist", *softwareInstallerID),
+				})
 			}
-			return err
+			return ctxerr.Wrap(ctx, err, "querying software installer")
 		} else if softwareInstallerTeamID != teamID {
-			return errMismatchedInstallerTeam
+			return ctxerr.Wrap(ctx, &fleet.BadRequestError{
+				Message: fmt.Sprintf("Software installer with ID %d does not belong to team ID %d", *softwareInstallerID, teamID),
+			})
 		}
 	}
 
@@ -207,11 +211,15 @@ func assertTeamMatches(ctx context.Context, db sqlx.QueryerContext, teamID uint,
 
 		if err != nil {
 			if errors.Is(err, sql.ErrNoRows) {
-				return &fleet.BadRequestError{Message: "A VPP app with the supplied ID does not exist"}
+				return ctxerr.Wrap(ctx, &fleet.BadRequestError{
+					Message: fmt.Sprintf("VPP app with ID %d does not exist", *vppAppsTeamsID),
+				})
 			}
-			return err
+			return ctxerr.Wrap(ctx, err, "querying VPP app")
 		} else if vppAppTeamID != teamID {
-			return errMismatchedInstallerTeam
+			return ctxerr.Wrap(ctx, &fleet.BadRequestError{
+				Message: fmt.Sprintf("VPP app with ID %d does not belong to team ID %d", *vppAppsTeamsID, teamID),
+			})
 		}
 	}
 
@@ -221,11 +229,15 @@ func assertTeamMatches(ctx context.Context, db sqlx.QueryerContext, teamID uint,
 
 		if err != nil {
 			if errors.Is(err, sql.ErrNoRows) {
-				return &fleet.BadRequestError{Message: "A script with the supplied ID does not exist"}
+				return ctxerr.Wrap(ctx, &fleet.BadRequestError{
+					Message: fmt.Sprintf("Script with ID %d does not exist", *scriptID),
+				})
 			}
-			return err
+			return ctxerr.Wrap(ctx, err, "querying script")
 		} else if scriptTeamID != teamID {
-			return errMismatchedScriptTeam
+			return ctxerr.Wrap(ctx, &fleet.BadRequestError{
+				Message: fmt.Sprintf("Script with ID %d does not belong to team ID %d", *scriptID, teamID),
+			})
 		}
 	}
 

--- a/server/service/team_policies.go
+++ b/server/service/team_policies.go
@@ -597,7 +597,7 @@ func (svc *Service) getInstallerOrVPPAppForTitle(ctx context.Context, teamID *ui
 
 	if teamID == nil {
 		return nil, nil, ctxerr.Wrap(ctx, &fleet.BadRequestError{
-			Message: "software_title_id cannot be set on global policies",
+			Message: "Software title ID cannot be set on global policies",
 		})
 	}
 
@@ -605,7 +605,7 @@ func (svc *Service) getInstallerOrVPPAppForTitle(ctx context.Context, teamID *ui
 	if err != nil {
 		if fleet.IsNotFound(err) {
 			return nil, nil, ctxerr.Wrap(ctx, &fleet.BadRequestError{
-				Message: fmt.Sprintf("software_title_id %d on team_id %d not found", *softwareTitleID, *teamID),
+				Message: fmt.Sprintf("Software title with ID %d does not belong to team ID %d", *softwareTitleID, *teamID),
 			})
 		}
 		return nil, nil, ctxerr.Wrap(ctx, err, "software title by id")
@@ -614,7 +614,7 @@ func (svc *Service) getInstallerOrVPPAppForTitle(ctx context.Context, teamID *ui
 		if softwareTitle.AppStoreApp.Platform != fleet.MacOSPlatform {
 			return nil, nil, ctxerr.Wrap(ctx, &fleet.BadRequestError{
 				Message: fmt.Sprintf(
-					"software_title_id %d on team_id %d is associated to an iOS or iPadOS VPP app, only software installers or macOS VPP apps are supported",
+					"Software title with ID %d on team ID %d is associated to an iOS or iPadOS VPP app, only software installers or macOS VPP apps are supported",
 					*softwareTitleID,
 					*teamID,
 				),
@@ -625,7 +625,7 @@ func (svc *Service) getInstallerOrVPPAppForTitle(ctx context.Context, teamID *ui
 	}
 	if softwareTitle.SoftwarePackage == nil {
 		return nil, nil, ctxerr.Wrap(ctx, &fleet.BadRequestError{
-			Message: fmt.Sprintf("software_title_id %d on team_id %d does not have associated package", *softwareTitleID, *teamID),
+			Message: fmt.Sprintf("Software title with ID %d on team ID %d does not have an associated package", *softwareTitleID, *teamID),
 		})
 	}
 


### PR DESCRIPTION
## Issue
For #26710 

## Description
- Scripts policy automation errors now showing in UI, similar to software install automation errors
- Aligned API errors to have similar formats

## Screenshot of fix
<img width="1251" alt="Screenshot 2025-03-03 at 11 08 40 AM" src="https://github.com/user-attachments/assets/01cdefd5-6c1d-4ad7-bb43-7ce93ae99c8c" />


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/Committing-Changes.md#changes-files) for more information.
- [x] Added/updated automated tests
- [x] A detailed QA plan exists on the associated ticket (if it isn't there, work with the product group's QA engineer to add it)
- [x] Manual QA for all new/changed functionality
