### PR TITLE
add self closing successful Android enterprise connection page

### DIFF
--- a/server/mdm/android/service/enterpriseCallback.html
+++ b/server/mdm/android/service/enterpriseCallback.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="robots" content="noindex, nofollow" />
+    <meta name="googlebot" content="noindex, nofollow" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Auto Close</title>
+    <script>
+      window.onload = function () {
+        window.close();
+      };
+    </script>
+  </head>
+  <body>
+    <p>If this page does not close automatically, please close it manually.</p>
+  </body>
+</html>

--- a/server/mdm/android/service/service.go
+++ b/server/mdm/android/service/service.go
@@ -156,7 +156,7 @@ var enterpriseCallbackHTML []byte
 
 func (res enterpriseSignupCallbackResponse) HijackRender(ctx context.Context, w http.ResponseWriter) {
 	w.Header().Set("Content-Type", "text/html; charset=UTF-8")
-	w.Write(enterpriseCallbackHTML)
+	_, _ = w.Write(enterpriseCallbackHTML)
 }
 
 func enterpriseSignupCallbackEndpoint(ctx context.Context, request interface{}, svc android.Service) fleet.Errorer {

--- a/server/mdm/android/tests/enterprise/enterprise_test.go
+++ b/server/mdm/android/tests/enterprise/enterprise_test.go
@@ -2,13 +2,11 @@ package enterprise_test
 
 import (
 	"context"
-	"fmt"
 	"io"
 	"net/http"
 	"testing"
 	"time"
 
-	"github.com/fleetdm/fleet/v4/server/datastore/mysql"
 	"github.com/fleetdm/fleet/v4/server/fleet"
 	"github.com/fleetdm/fleet/v4/server/mdm/android"
 	"github.com/fleetdm/fleet/v4/server/mdm/android/service"
@@ -112,42 +110,4 @@ func (s *enterpriseTestSuite) TestEnterpriseSSE() {
 	data, err = io.ReadAll(resp.Body)
 	assert.NoError(s.T(), err)
 	assert.Contains(s.T(), string(data), assert.AnError.Error())
-}
-
-func (s *enterpriseTestSuite) TestEnterpriseSignupCallback() {
-	s.SetupTest()
-
-	mysql.ExecAdhocSQL(s.T(), s.DS, "INSERT INTO android_enterprises (signup_name, user_id) VALUES ('', ?)")
-
-	// TODO: setup database. add seed data to android_enterprises table
-	// user := &fleet.User{
-	// 	ID: 1,
-	// }
-	// id, err := s.DS.CreateEnterprise(user.ID)
-	// enterprise := &fleet.AndroidEnterprise{
-	// 	ID:        tests.EnterpriseID,
-	// 	Token:     "enterpriseToken",
-	// 	CreatedAt: time.Now(),
-	// 	UpdatedAt: time.Now(),
-	// }
-	// err := s.WithServer.FleetDS.enterprise(context.Background(), enterprise)
-	// require.NoError(s.T(), err)
-
-	// Test happy path assuming enterprise exists
-	s.FleetDS.GetAndroidDS().GetEnterpriseBySignupTokenFunc = func(_ ctx.Context, signupToken string) (*android.EnterpriseDetails, error) {
-		return android.EnterpriseDetails{
-			android.Enterprise: {ID: 1, EnterpriseID: "test-enterprise"},
-			SignupToken:        "12345",
-			SignupName:         "test-enterprise-signup",
-			TopicID:            "test-topic-id",
-			UserID:             1,
-		}
-	}
-
-	resp := s.Do("GET", fmt.Sprintf("/api/v1/fleet/android_enterprise/connect/%s", "test-token"), nil, http.StatusOK)
-	assert.Equal(s.T(), "text/html; charset=utf-8", resp.Header.Get("Content-Type"))
-	body, err := io.ReadAll(resp.Body)
-	require.NoError(s.T(), err)
-	assert.Contains(s.T(), string(body), "If this page does not close automatically, please close it manually.")
-	assert.Contains(s.T(), string(body), "window.close()")
 }

--- a/server/mdm/android/tests/enterprise/enterprise_test.go
+++ b/server/mdm/android/tests/enterprise/enterprise_test.go
@@ -56,8 +56,13 @@ func (s *enterpriseTestSuite) TestEnterprise() {
 
 	s.FleetSvc.On("NewActivity", mock.Anything, mock.Anything, mock.AnythingOfType("fleet.ActivityTypeEnabledAndroidMDM")).Return(nil)
 	const enterpriseToken = "enterpriseToken"
-	s.DoJSON("GET", s.ProxyCallbackURL, nil, http.StatusOK, &resp, "enterpriseToken", enterpriseToken)
+	res := s.Do("GET", s.ProxyCallbackURL, nil, http.StatusOK, "enterpriseToken", enterpriseToken)
 	s.FleetSvc.AssertNumberOfCalls(s.T(), "NewActivity", 1)
+	body, err := io.ReadAll(res.Body)
+	require.NoError(s.T(), err)
+	assert.Equal(s.T(), "text/html; charset=UTF-8", res.Header.Get("Content-Type"))
+	assert.Contains(s.T(), string(body), "If this page does not close automatically, please close it manually.")
+	assert.Contains(s.T(), string(body), "window.close()")
 
 	// Now enterprise exists and we can retrieve it.
 	resp = android.GetEnterpriseResponse{}

--- a/server/mdm/android/tests/enterprise/enterprise_test.go
+++ b/server/mdm/android/tests/enterprise/enterprise_test.go
@@ -2,11 +2,13 @@ package enterprise_test
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"net/http"
 	"testing"
 	"time"
 
+	"github.com/fleetdm/fleet/v4/server/datastore/mysql"
 	"github.com/fleetdm/fleet/v4/server/fleet"
 	"github.com/fleetdm/fleet/v4/server/mdm/android"
 	"github.com/fleetdm/fleet/v4/server/mdm/android/service"
@@ -110,4 +112,42 @@ func (s *enterpriseTestSuite) TestEnterpriseSSE() {
 	data, err = io.ReadAll(resp.Body)
 	assert.NoError(s.T(), err)
 	assert.Contains(s.T(), string(data), assert.AnError.Error())
+}
+
+func (s *enterpriseTestSuite) TestEnterpriseSignupCallback() {
+	s.SetupTest()
+
+	mysql.ExecAdhocSQL(s.T(), s.DS, "INSERT INTO android_enterprises (signup_name, user_id) VALUES ('', ?)")
+
+	// TODO: setup database. add seed data to android_enterprises table
+	// user := &fleet.User{
+	// 	ID: 1,
+	// }
+	// id, err := s.DS.CreateEnterprise(user.ID)
+	// enterprise := &fleet.AndroidEnterprise{
+	// 	ID:        tests.EnterpriseID,
+	// 	Token:     "enterpriseToken",
+	// 	CreatedAt: time.Now(),
+	// 	UpdatedAt: time.Now(),
+	// }
+	// err := s.WithServer.FleetDS.enterprise(context.Background(), enterprise)
+	// require.NoError(s.T(), err)
+
+	// Test happy path assuming enterprise exists
+	s.FleetDS.GetAndroidDS().GetEnterpriseBySignupTokenFunc = func(_ ctx.Context, signupToken string) (*android.EnterpriseDetails, error) {
+		return android.EnterpriseDetails{
+			android.Enterprise: {ID: 1, EnterpriseID: "test-enterprise"},
+			SignupToken:        "12345",
+			SignupName:         "test-enterprise-signup",
+			TopicID:            "test-topic-id",
+			UserID:             1,
+		}
+	}
+
+	resp := s.Do("GET", fmt.Sprintf("/api/v1/fleet/android_enterprise/connect/%s", "test-token"), nil, http.StatusOK)
+	assert.Equal(s.T(), "text/html; charset=utf-8", resp.Header.Get("Content-Type"))
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(s.T(), err)
+	assert.Contains(s.T(), string(body), "If this page does not close automatically, please close it manually.")
+	assert.Contains(s.T(), string(body), "window.close()")
 }


### PR DESCRIPTION
For #26736

adds a self closing page that is the final part of connecting with Android Enterprise. This allows the user to see the fleet  page notification that android mdm is now enabled.

