### PR TITLE
My device page: Fix 'show details' to open software details modal

### DIFF
--- a/changes/26617-show-device-software-details
+++ b/changes/26617-show-device-software-details
@@ -1,0 +1,1 @@
+- My device page > Software > Software table: Fixed clicking "Show details" to open the software details modal

--- a/frontend/components/ViewAllHostsLink/ViewAllHostsLink.tsx
+++ b/frontend/components/ViewAllHostsLink/ViewAllHostsLink.tsx
@@ -18,7 +18,7 @@ interface IHostLinkProps {
   customText?: string;
   /** Table links shows on row hover and tab focus only */
   rowHover?: boolean;
-  // don't actually create a link, useful when click is handled by an ancestor
+  /** Don't actually create a link, useful when click is handled by an ancestor */
   noLink?: boolean;
 }
 
@@ -51,7 +51,9 @@ const ViewAllHostsLink = ({
       className={viewAllHostsLinkClass}
       to={noLink ? "" : path}
       onClick={(e) => {
-        e.stopPropagation(); // Allows for link to be clickable in a clickable row
+        if (!noLink) {
+          e.stopPropagation(); // Allows for link to have different onClick behavior than the row's onClick behavior
+        }
       }}
       onKeyDown={(e) => {
         if (e.key === "Enter") {


### PR DESCRIPTION
## Issue
For #26617 

## Description
- Changes to on row hover not doing far right action broke this "Show details" link
- Now fixed so clicking on "Show details" will open the modal
- Note: Also kept clicking on row will open the modal since there's no other action on this table

## Screenshot of fix
<img width="1065" alt="Screenshot 2025-03-03 at 12 54 34 PM" src="https://github.com/user-attachments/assets/d950aa24-3f32-4e23-a4d4-21d222be28e3" />


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
- [x] A detailed QA plan exists on the associated ticket (if it isn't there, work with the product group's QA engineer to add it)
- [x] Manual QA for all new/changed functionality
