### PR TITLE
Update README.md

### DIFF
--- a/handbook/company/product-groups.md
+++ b/handbook/company/product-groups.md
@@ -178,7 +178,6 @@ A user story is considered ready for implementation once:
 
 > All user stories intended for the next sprint are estimated by the last estimation session before the sprint begins. This makes sure contributors have adequate time to complete the current sprint and provide accurate estimates for the next sprint.
 
-> If the issue was drafted by a different product group's designer than it is assigned to during a sprint, the product designer listed in the issue is changed to the new product group's designer. The new product designer should be ramped up on the story or bug so they are prepared to answers questions during stand up.
 
 #### Writing a good user story
 

--- a/handbook/company/product-groups.md
+++ b/handbook/company/product-groups.md
@@ -178,6 +178,7 @@ A user story is considered ready for implementation once:
 
 > All user stories intended for the next sprint are estimated by the last estimation session before the sprint begins. This makes sure contributors have adequate time to complete the current sprint and provide accurate estimates for the next sprint.
 
+> If the issue was drafted by a different product group's designer than it is assigned to during a sprint, the product designer listed in the issue is changed to the new product group's designer. The new product designer should be ramped up on the story or bug so they are prepared to answers questions during stand up.
 
 #### Writing a good user story
 

--- a/handbook/product-design/README.md
+++ b/handbook/product-design/README.md
@@ -109,7 +109,7 @@ If the story is tied to a customer feature request, the Head of Product Design (
 
 Once a bug is approved in design review, The Product Designer is responsible for moving the bug to the appropriate release board.
 
-If the ticket was designed for a different team than the one that takes it into a sprint the primary designer should be transferred to the designer matching the team doing the work. The new designer should be ramped up on the story or bug to be able to field product questions and the new primary contact for the team to sync with during standup.
+If the issue was drafted by a different product group's designer than it is assigned to during a sprint, the product designer listed in the issue is changed to the new product group's designer. The new product designer should be ramped up on the story or bug so they are prepared to answers questions during stand up.
 
 
 ### Revise a draft currently in development

--- a/handbook/product-design/README.md
+++ b/handbook/product-design/README.md
@@ -107,7 +107,7 @@ Before assigning an EM, double-check that the "Product" section of the user stor
 
 If the story is tied to a customer feature request, the Head of Product Design (HPD) is responsible for adding the feature request issue to the [🏹 #g-customer-success board](https://github.com/fleetdm/fleet/issues#workspaces/g-customer-success-642c83a53e96760014c978bd/board). This way the Customer Success Manager (CSM) can review the wireframes and provide feedback on whether the proposed changes solve the customer's problem. If the changes don't, it's up to the HPD to decide whether to bring the user story back for more drafting or file a follow up user story (iteration).
 
-Once a bug is approved in design review, The Product Designer is responsible for moving the bug to the appropriate release board.
+Sometimes, a Product Designer from one product group will draft a user story or bug that is implemented by a different product group. This happens when the original product group is constrained by design or engineering capacity. If this happens, it's up to the original Product Designer to update the "Product Designer" mentioned in the user story or bug and ramp up the new Product Designer so they are prepared to answers questions.
 
 ### Revise a draft currently in development
 

--- a/handbook/product-design/README.md
+++ b/handbook/product-design/README.md
@@ -109,9 +109,6 @@ If the story is tied to a customer feature request, the Head of Product Design (
 
 Once a bug is approved in design review, The Product Designer is responsible for moving the bug to the appropriate release board.
 
-If the issue was drafted by a different product group's designer than it is assigned to during a sprint, the product designer listed in the issue is changed to the new product group's designer. The new product designer should be ramped up on the story or bug so they are prepared to answers questions during stand up.
-
-
 ### Revise a draft currently in development
 
 Expedited drafting is the revision of drafted changes currently being developed by

--- a/handbook/product-design/README.md
+++ b/handbook/product-design/README.md
@@ -109,6 +109,8 @@ If the story is tied to a customer feature request, the Head of Product Design (
 
 Once a bug is approved in design review, The Product Designer is responsible for moving the bug to the appropriate release board.
 
+If the ticket was designed for a different team than the one that takes it into a sprint the primary designer should be transferred to the designer matching the team doing the work. The new designer should be ramped up on the story or bug to be able to field product questions and the new primary contact for the team to sync with during standup.
+
 
 ### Revise a draft currently in development
 


### PR DESCRIPTION
This is just a callout that we would love to see implemented so that it can speed up dev / designer feedback during the sprint.

Why? The previous designer might be less available than the designer that works within the team and this transfer of ownership would help us move faster when encountering issues / discrepancies in the tickets.