### PR TITLE
Fleet UI: Never truncate host count on Dashboard > Software table

### DIFF
--- a/changes/26776-never-truncate-host-count
+++ b/changes/26776-never-truncate-host-count
@@ -1,0 +1,1 @@
+- Fleet UI: Fixed Dashboard > Software table from ever truncating host count

--- a/frontend/components/TableContainer/DataTable/_styles.scss
+++ b/frontend/components/TableContainer/DataTable/_styles.scss
@@ -320,6 +320,11 @@ $shadow-transition-width: 10px;
           min-width: 100%;
           text-align: left;
         }
+        .w150 {
+          max-width: calc(150px - 48px);
+          min-width: 100%;
+          text-align: left;
+        }
         .italic-cell {
           font-style: italic;
           .__react_component_tooltip {

--- a/frontend/components/TableContainer/DataTable/_styles.scss
+++ b/frontend/components/TableContainer/DataTable/_styles.scss
@@ -311,17 +311,17 @@ $shadow-transition-width: 10px;
           }
         }
         .w400 {
-          max-width: calc(400px - 48px);
+          max-width: 352px; // 400px - 48px padding
           min-width: 100%;
           text-align: left;
         }
         .w250 {
-          max-width: calc(250px - 48px);
+          max-width: 202px; //  250px - 48px padding
           min-width: 100%;
           text-align: left;
         }
         .w150 {
-          max-width: calc(150px - 48px);
+          max-width: 102px; //  250px - 48px padding
           min-width: 100%;
           text-align: left;
         }

--- a/frontend/pages/DashboardPage/cards/Software/DashboardSoftware.tests.tsx
+++ b/frontend/pages/DashboardPage/cards/Software/DashboardSoftware.tests.tsx
@@ -78,9 +78,11 @@ describe("Dashboard software card", () => {
     expect(screen.getByText("Hosts")).toBeInTheDocument();
 
     Object.keys(noVulnSwInfo).forEach((key) => {
-      expect(
-        screen.getByText(noVulnSwInfo[key as keyof typeof noVulnSwInfo])
-      ).toBeInTheDocument();
+      const value = noVulnSwInfo[key as keyof typeof noVulnSwInfo];
+      const elements = screen.getAllByText((content, element) => {
+        return element?.textContent === String(value);
+      });
+      expect(elements.length).toBeGreaterThan(0);
     });
   });
   it("renders vulnerable software normally when present", () => {
@@ -133,9 +135,11 @@ describe("Dashboard software card", () => {
     expect(screen.getByText("Hosts")).toBeInTheDocument();
 
     Object.keys(vulnSwInfo).forEach((key) => {
-      expect(
-        screen.getByText(vulnSwInfo[key as keyof typeof vulnSwInfo])
-      ).toBeInTheDocument();
+      const value = vulnSwInfo[key as keyof typeof vulnSwInfo];
+      const elements = screen.getAllByText((content, element) => {
+        return element?.textContent === String(value);
+      });
+      expect(elements.length).toBeGreaterThan(0);
     });
   });
 });

--- a/frontend/pages/DashboardPage/cards/Software/SoftwareTableConfig.tsx
+++ b/frontend/pages/DashboardPage/cards/Software/SoftwareTableConfig.tsx
@@ -3,6 +3,7 @@ import { ISoftware } from "interfaces/software";
 
 import TextCell from "components/TableContainer/DataTable/TextCell";
 import ViewAllHostsLink from "components/ViewAllHostsLink";
+import TooltipTruncatedTextCell from "components/TableContainer/DataTable/TooltipTruncatedTextCell";
 
 // NOTE: cellProps come from react-table
 // more info here https://react-table.tanstack.com/docs/api/useTable#cell-properties
@@ -37,14 +38,18 @@ const generateTableHeaders = (teamId?: number): IDataColumn[] => [
     Header: "Name",
     disableSortBy: true,
     accessor: "name",
-    Cell: (cellProps: ICellProps) => <TextCell value={cellProps.cell.value} />,
+    Cell: (cellProps: ICellProps) => (
+      <TooltipTruncatedTextCell value={cellProps.cell.value} className="w150" />
+    ),
   },
   {
     title: "Version",
     Header: "Version",
     disableSortBy: true,
     accessor: "version",
-    Cell: (cellProps: ICellProps) => <TextCell value={cellProps.cell.value} />,
+    Cell: (cellProps: ICellProps) => (
+      <TooltipTruncatedTextCell value={cellProps.cell.value} className="w150" />
+    ),
   },
   {
     title: "Hosts",

--- a/frontend/pages/DashboardPage/cards/Software/SoftwareTableConfig.tsx
+++ b/frontend/pages/DashboardPage/cards/Software/SoftwareTableConfig.tsx
@@ -39,7 +39,11 @@ const generateTableHeaders = (teamId?: number): IDataColumn[] => [
     disableSortBy: true,
     accessor: "name",
     Cell: (cellProps: ICellProps) => (
-      <TooltipTruncatedTextCell value={cellProps.cell.value} className="w150" />
+      <TooltipTruncatedTextCell
+        value={cellProps.cell.value}
+        className="w150"
+        key={cellProps.cell.value}
+      />
     ),
   },
   {
@@ -48,7 +52,11 @@ const generateTableHeaders = (teamId?: number): IDataColumn[] => [
     disableSortBy: true,
     accessor: "version",
     Cell: (cellProps: ICellProps) => (
-      <TooltipTruncatedTextCell value={cellProps.cell.value} className="w150" />
+      <TooltipTruncatedTextCell
+        value={cellProps.cell.value}
+        className="w150"
+        key={`${cellProps.row.original.name}-${cellProps.cell.value}`}
+      />
     ),
   },
   {

--- a/frontend/pages/DashboardPage/cards/Software/_styles.scss
+++ b/frontend/pages/DashboardPage/cards/Software/_styles.scss
@@ -65,16 +65,10 @@
 
       tbody {
         .name__cell {
-          // overflow: hidden;
-          // white-space: nowrap;
-          // text-overflow: ellipsis;
           width: 50%;
         }
 
         .version__cell {
-          // overflow: hidden;
-          // white-space: nowrap;
-          // text-overflow: ellipsis;
           width: 30%;
         }
 

--- a/frontend/pages/DashboardPage/cards/Software/_styles.scss
+++ b/frontend/pages/DashboardPage/cards/Software/_styles.scss
@@ -80,6 +80,10 @@
           white-space: nowrap;
           text-overflow: ellipsis;
           width: 30%;
+
+          .text-cell {
+            max-width: 100px;
+          }
         }
 
         .hosts_count__cell {

--- a/frontend/pages/DashboardPage/cards/Software/_styles.scss
+++ b/frontend/pages/DashboardPage/cards/Software/_styles.scss
@@ -41,11 +41,12 @@
 
   .data-table-block {
     .data-table__table {
-      table-layout: fixed;
+      table-layout: auto;
+      width: 100%;
 
       thead {
         .name__header {
-          width: 60%;
+          width: 50%;
         }
         .version__header {
           width: 30%;
@@ -53,7 +54,7 @@
         }
         .hosts_count__header {
           padding-right: 0;
-          width: 60px;
+          width: auto;
         }
         .id__header {
           padding: 0;
@@ -63,12 +64,28 @@
       }
 
       tbody {
-        .name__cell,
+        .name__cell {
+          overflow: hidden;
+          white-space: nowrap;
+          text-overflow: ellipsis;
+          width: 50%;
+
+          .text-cell {
+            max-width: 100px;
+          }
+        }
+
         .version__cell {
           overflow: hidden;
           white-space: nowrap;
           text-overflow: ellipsis;
+          width: 30%;
         }
+
+        .hosts_count__cell {
+          width: auto;
+        }
+
         .id__cell {
           padding: 0;
           width: 40px;

--- a/frontend/pages/DashboardPage/cards/Software/_styles.scss
+++ b/frontend/pages/DashboardPage/cards/Software/_styles.scss
@@ -83,7 +83,7 @@
         }
 
         .hosts_count__cell {
-          width: auto;
+          width: auto; // Never truncates hosts count
         }
 
         .id__cell {

--- a/frontend/pages/DashboardPage/cards/Software/_styles.scss
+++ b/frontend/pages/DashboardPage/cards/Software/_styles.scss
@@ -82,7 +82,7 @@
           width: 30%;
 
           .text-cell {
-            max-width: 100px;
+            max-width: 65px;
           }
         }
 

--- a/frontend/pages/DashboardPage/cards/Software/_styles.scss
+++ b/frontend/pages/DashboardPage/cards/Software/_styles.scss
@@ -65,16 +65,16 @@
 
       tbody {
         .name__cell {
-          overflow: hidden;
-          white-space: nowrap;
-          text-overflow: ellipsis;
+          // overflow: hidden;
+          // white-space: nowrap;
+          // text-overflow: ellipsis;
           width: 50%;
         }
 
         .version__cell {
-          overflow: hidden;
-          white-space: nowrap;
-          text-overflow: ellipsis;
+          // overflow: hidden;
+          // white-space: nowrap;
+          // text-overflow: ellipsis;
           width: 30%;
         }
 

--- a/frontend/pages/DashboardPage/cards/Software/_styles.scss
+++ b/frontend/pages/DashboardPage/cards/Software/_styles.scss
@@ -69,10 +69,6 @@
           white-space: nowrap;
           text-overflow: ellipsis;
           width: 50%;
-
-          .text-cell {
-            max-width: 100px;
-          }
         }
 
         .version__cell {
@@ -80,10 +76,6 @@
           white-space: nowrap;
           text-overflow: ellipsis;
           width: 30%;
-
-          .text-cell {
-            max-width: 65px;
-          }
         }
 
         .hosts_count__cell {


### PR DESCRIPTION
## Issue
For #26776 

## Description
- Modify Dashboard > Software Table styling to never truncate host count but can/will truncate name and version

## Screenrecordings of fix

### Never truncate host count screenrecording

https://github.com/user-attachments/assets/ee13fb01-2ea3-4ce9-b9bc-e548c2929013

### Truncate version screenrecording

https://github.com/user-attachments/assets/01238be1-4441-47b1-9eda-90ce8f8ad5f3

## Tooltip on truncation added 3/5/25
<img width="668" alt="Screenshot 2025-03-05 at 2 20 19 PM" src="https://github.com/user-attachments/assets/97497efa-d4d9-4eaf-b91c-a40e3ba58a0a" />


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/Committing-Changes.md#changes-files) for more information.
- [x] A detailed QA plan exists on the associated ticket (if it isn't there, work with the product group's QA engineer to add it)
- [x] Manual QA for all new/changed functionality
