### PR TITLE
Identify if the release is older than npm, publish with tag

### DIFF
--- a/changes/26520-npm-publish-tagged
+++ b/changes/26520-npm-publish-tagged
@@ -1,0 +1,1 @@
+- Stop fleetctl npm publishing script from tagging patch releases for old versions as "latest"

--- a/package.json
+++ b/package.json
@@ -131,6 +131,7 @@
     "babel-plugin-dynamic-import-node": "2.3.3",
     "bourbon": "5.1.0",
     "classnames": "2.2.5",
+    "compare-versions": "6.1.1",
     "css-loader": "6.7.3",
     "esbuild-loader": "2.18.0",
     "eslint": "7.32.0",

--- a/tools/release/publish_release.sh
+++ b/tools/release/publish_release.sh
@@ -557,15 +557,15 @@ publish() {
             fi
             show_spinner 200
             dogfood_deploy=$(gh run list --workflow=dogfood-deploy.yml --status in_progress -L 1 --json url | jq -r '.[] | .url')
-            latest_npm=$(npm view fleetctl --json | jq -r '.version')
-            latest_local=$(jq -r '.version' tools/fleetctl-npm/package.json)
+            latest_npm=$(npm view fleetctl --json | jq -r '.version' | sed -e 's/^v//')
+            latest_local=$(jq -r '.version' tools/fleetctl-npm/package.json | sed -e 's/^v//')
 
-            if [ node -e "console.log(require('compare-versions').compareVersions('${latest_local}', '${latest_npm}'))" = "1" ]; then
-                # We're publishing the latest version
-                cd tools/fleetctl-npm && npm publish
-            else
+            if [ "$(node -e "console.log(require('compare-versions').compareVersions('${latest_local}', '${latest_npm}'))")" = "-1" ]; then
                 # We're publishing a patch to an older version
                 cd tools/fleetctl-npm && npm publish "--tag=v${target_version}"
+            else
+                # We're publishing the latest version
+                cd tools/fleetctl-npm && npm publish
             fi
 
 

--- a/tools/release/publish_release.sh
+++ b/tools/release/publish_release.sh
@@ -562,7 +562,7 @@ publish() {
 
             if [ "$(node -e "console.log(require('compare-versions').compareVersions('${latest_local}', '${latest_npm}'))")" = "-1" ]; then
                 # We're publishing a patch to an older version
-                cd tools/fleetctl-npm && npm publish "--tag=v${target_version}"
+                cd tools/fleetctl-npm && npm publish "--tag=last-patched-version"
             else
                 # We're publishing the latest version
                 cd tools/fleetctl-npm && npm publish

--- a/yarn.lock
+++ b/yarn.lock
@@ -5481,6 +5481,11 @@ commondir@^1.0.1:
   resolved "https://registry.yarnpkg.com/commondir/-/commondir-1.0.1.tgz#ddd800da0c66127393cca5950ea968a3aaf1253b"
   integrity sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==
 
+compare-versions@6.1.1:
+  version "6.1.1"
+  resolved "https://registry.yarnpkg.com/compare-versions/-/compare-versions-6.1.1.tgz#7af3cc1099ba37d244b3145a9af5201b629148a9"
+  integrity sha512-4hm4VPpIecmlg59CHXnRDnqGplJFrbLG4aFEl5vl6cK1u76ws3LLvX7ikFnTDl5vo39sjWD6AaDPYodJp/NNHg==
+
 concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"


### PR DESCRIPTION
#26520

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/Committing-Changes.md#changes-files) for more information.
