### PR TITLE
Fix typo in flash message

### DIFF
--- a/frontend/pages/admin/IntegrationsPage/cards/ChangeManagement/ChangeManagement.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/ChangeManagement/ChangeManagement.tsx
@@ -108,7 +108,7 @@ const ChangeManagement = () => {
       refetchConfig();
     } catch (e) {
       const message = getErrorReason(e);
-      renderFlash("error", message || "Failed ot update settings");
+      renderFlash("error", message || "Failed to update settings");
       setIsUpdating(false);
     }
   };


### PR DESCRIPTION
"Failed ot" -> "Failed to"

![Screenshot 2025-03-03 at 5 38 16 PM](https://github.com/user-attachments/assets/3c9ab2b9-62a2-4eb8-bec5-94d159f2bcb9)
