### PR TITLE
Cherry pick: Clear cron schedule errors before each run (#26775)

### DIFF
--- a/server/service/schedule/schedule.go
+++ b/server/service/schedule/schedule.go
@@ -461,6 +461,8 @@ func (s *Schedule) runWithStats(statsType fleet.CronStatsType) {
 
 // runAllJobs runs all jobs in the schedule.
 func (s *Schedule) runAllJobs() {
+	// Clear errors from the schedule before each run.
+	s.errors = make(fleet.CronScheduleErrors)
 	for _, job := range s.jobs {
 		level.Debug(s.logger).Log("msg", "starting", "jobID", job.ID)
 		if err := runJob(s.ctx, job.Fn); err != nil {


### PR DESCRIPTION
Cherry picking this into next release to quiet error alerts, as per thread [here](https://fleetdm.slack.com/archives/C03EG80BM2A/p1741038997595819)

For #26657
