### PR TITLE
add configuration setting for forcing h2c

### DIFF
--- a/changes/issue-26963-gcp-software-limits
+++ b/changes/issue-26963-gcp-software-limits
@@ -1,0 +1,1 @@
+- add configuration to fleet server to enable h2c (forcing http2) to get around a limitation in GCP Cloud Run for upload file sizes

--- a/docs/Configuration/fleet-server-configuration.md
+++ b/docs/Configuration/fleet-server-configuration.md
@@ -604,6 +604,19 @@ Setting to true will disable the origin check.
     websockets_allow_unsafe_origin: true
   ```
 
+### server_force_h2c
+
+Setting this will force the Go webserver to attempt HTTP2. By default, HTTP2 support is only negotiated if the Go webserver
+is serving TLS, this setting is ignored if TLS is enabled. This configuration might be required if Fleet is hosted in certain
+cloud providers that have limitations on their API gateways, such as GCP Cloud Run.
+- Default value: false
+- Environment variable: FLEET_SERVER_FORCE_H2C
+- Config file format:
+  ```yaml
+  server:
+    force_h2c: true
+  ```
+
 ### server_private_key
 
 This key is required for enabling macOS MDM features and/or storing sensitive configs (passwords, API keys, etc.) in Fleet. If you are using the `FLEET_APPLE_APNS_*` and `FLEET_APPLE_SCEP_*` variables, Fleet will automatically encrypt the values of those variables using `FLEET_SERVER_PRIVATE_KEY` and save them in the database when you restart after updating.

--- a/infrastructure/dogfood/terraform/gcp/cloud_run.tf
+++ b/infrastructure/dogfood/terraform/gcp/cloud_run.tf
@@ -94,7 +94,7 @@ resource "google_cloud_run_service" "default" {
         }
         image = var.image
         ports {
-          name           = "http1"
+          name           = "h2c"
           container_port = 8080
         }
         env {

--- a/infrastructure/dogfood/terraform/gcp/cloud_run.tf
+++ b/infrastructure/dogfood/terraform/gcp/cloud_run.tf
@@ -94,7 +94,7 @@ resource "google_cloud_run_service" "default" {
         }
         image = var.image
         ports {
-          name           = "h2c"
+          name           = "http1"
           container_port = 8080
         }
         env {
@@ -132,6 +132,10 @@ resource "google_cloud_run_service" "default" {
         }
         env {
           name  = "FLEET_LOGGING_JSON"
+          value = "true"
+        }
+        env {
+          name = "FLEET_SERVER_FORCE_H2C"
           value = "true"
         }
         env {

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -1059,7 +1059,7 @@ func (man Manager) addConfigs() {
 		"When enabled, Fleet limits some features for the Sandbox")
 	man.addConfigBool("server.websockets_allow_unsafe_origin", false, "Disable checking the origin header on websocket connections, this is sometimes necessary when proxies rewrite origin headers between the client and the Fleet webserver")
 	man.addConfigBool("server.frequent_cleanups_enabled", false, "Enable frequent cleanups of expired data (15 minute interval)")
-	man.addConfigBool("server.force_h2c", false, "Force the fleet server to use HTTP2 cleartext aka h2c (ingored if using TLS)")
+	man.addConfigBool("server.force_h2c", false, "Force the fleet server to use HTTP2 cleartext aka h2c (ignored if using TLS)")
 	man.addConfigString("server.private_key", "", "Used for encrypting sensitive data, such as MDM certificates.")
 
 	// Hide the sandbox flag as we don't want it to be discoverable for users for now

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -104,8 +104,11 @@ type ServerConfig struct {
 func (s *ServerConfig) DefaultHTTPServer(ctx context.Context, handler http.Handler) *http.Server {
 	// Create the base server configuration
 	server := &http.Server{
-		Addr:              s.Address,
-		ReadTimeout:       25 * time.Second,
+		Addr:        s.Address,
+		ReadTimeout: 25 * time.Second,
+		// WriteTimeout is set for security purposes.
+		// If we don't set it, (bugy or malignant) clients making long running
+		// requests could DDOS Fleet.
 		WriteTimeout:      40 * time.Second,
 		ReadHeaderTimeout: 5 * time.Second,
 		IdleTimeout:       5 * time.Minute,

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -8,6 +8,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"golang.org/x/net/http2"
+	"golang.org/x/net/http2/h2c"
 	"net"
 	"net/http"
 	"net/url"
@@ -95,17 +97,15 @@ type ServerConfig struct {
 	SandboxEnabled              bool   `yaml:"sandbox_enabled"`
 	WebsocketsAllowUnsafeOrigin bool   `yaml:"websockets_allow_unsafe_origin"`
 	FrequentCleanupsEnabled     bool   `yaml:"frequent_cleanups_enabled"`
+	ForceH2C                    bool   `yaml:"force_h2c"`
 	PrivateKey                  string `yaml:"private_key"`
 }
 
 func (s *ServerConfig) DefaultHTTPServer(ctx context.Context, handler http.Handler) *http.Server {
-	return &http.Server{
-		Addr:        s.Address,
-		Handler:     handler,
-		ReadTimeout: 25 * time.Second,
-		// WriteTimeout is set for security purposes.
-		// If we don't set it, (bugy or malignant) clients making long running
-		// requests could DDOS Fleet.
+	// Create the base server configuration
+	server := &http.Server{
+		Addr:              s.Address,
+		ReadTimeout:       25 * time.Second,
 		WriteTimeout:      40 * time.Second,
 		ReadHeaderTimeout: 5 * time.Second,
 		IdleTimeout:       5 * time.Minute,
@@ -114,6 +114,21 @@ func (s *ServerConfig) DefaultHTTPServer(ctx context.Context, handler http.Handl
 			return ctx
 		},
 	}
+
+	// Check if H2C (HTTP/2 without TLS) is enabled
+	if s.ForceH2C && !s.TLS {
+		// Create an HTTP/2 server
+		h2s := &http2.Server{}
+
+		// Wrap the original handler with h2c handler
+		// This allows both HTTP/1.1 and HTTP/2 requests without TLS
+		server.Handler = h2c.NewHandler(handler, h2s)
+	} else {
+		// Use regular HTTP/1.1 handler
+		server.Handler = handler
+	}
+
+	return server
 }
 
 // AuthConfig defines configs related to user authorization
@@ -1041,6 +1056,7 @@ func (man Manager) addConfigs() {
 		"When enabled, Fleet limits some features for the Sandbox")
 	man.addConfigBool("server.websockets_allow_unsafe_origin", false, "Disable checking the origin header on websocket connections, this is sometimes necessary when proxies rewrite origin headers between the client and the Fleet webserver")
 	man.addConfigBool("server.frequent_cleanups_enabled", false, "Enable frequent cleanups of expired data (15 minute interval)")
+	man.addConfigBool("server.force_h2c", false, "Force the fleet server to use HTTP2 cleartext aka h2c (ingored if using TLS)")
 	man.addConfigString("server.private_key", "", "Used for encrypting sensitive data, such as MDM certificates.")
 
 	// Hide the sandbox flag as we don't want it to be discoverable for users for now
@@ -1447,6 +1463,7 @@ func (man Manager) LoadConfig() FleetConfig {
 			SandboxEnabled:              man.getConfigBool("server.sandbox_enabled"),
 			WebsocketsAllowUnsafeOrigin: man.getConfigBool("server.websockets_allow_unsafe_origin"),
 			FrequentCleanupsEnabled:     man.getConfigBool("server.frequent_cleanups_enabled"),
+			ForceH2C:                    man.getConfigBool("server.force_h2c"),
 			PrivateKey:                  man.getConfigString("server.private_key"),
 		},
 		Auth: AuthConfig{

--- a/server/config/config_test.go
+++ b/server/config/config_test.go
@@ -2,6 +2,12 @@ package config
 
 import (
 	"bytes"
+	"context"
+	"crypto/tls"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -12,6 +18,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/net/http2"
 	yaml "gopkg.in/yaml.v2"
 )
 
@@ -735,4 +742,82 @@ func TestValidateCloudfrontURL(t *testing.T) {
 			s3.ValidateCloudFrontURL(initFatal)
 		})
 	}
+}
+
+func TestServerConfigWithH2C(t *testing.T) {
+	ctx := context.Background()
+
+	// Create a simple mux
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		protocol := "HTTP/1.1"
+		if r.ProtoMajor == 2 {
+			protocol = "HTTP/2.0"
+		}
+		fmt.Fprintf(w, "ServerConfig test using %s", protocol)
+	})
+
+	// Create server config with a random available port
+	config := &ServerConfig{Address: ":0", ForceH2C: true}
+
+	// Create server using our ServerConfig
+	server := config.DefaultHTTPServer(ctx, mux)
+
+	// Start the server
+	listener, err := net.Listen("tcp", server.Addr)
+	if err != nil {
+		t.Fatalf("Failed to listen: %v", err)
+	}
+
+	// Get the actual port
+	port := listener.Addr().(*net.TCPAddr).Port
+	serverURL := fmt.Sprintf("http://localhost:%d", port)
+
+	// Start server in a goroutine
+	go func() {
+		if err := server.Serve(listener); err != http.ErrServerClosed {
+			t.Logf("Server error: %v", err)
+		}
+	}()
+
+	// Ensure server is closed at the end of the test
+	defer func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		server.Shutdown(ctx)
+	}()
+
+	// Test with HTTP/2 client
+	client := &http.Client{
+		Transport: &http2.Transport{
+			AllowHTTP: true,
+			DialTLSContext: func(ctx context.Context, network, addr string, cfg *tls.Config) (net.Conn, error) {
+				return net.Dial(network, addr)
+			},
+		},
+	}
+
+	// Make request
+	req, err := http.NewRequest("GET", serverURL, nil)
+	if err != nil {
+		t.Fatalf("Failed to create request: %v", err)
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("Failed to make request: %v", err)
+	}
+	defer resp.Body.Close()
+
+	// Check response
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("Failed to read body: %v", err)
+	}
+
+	if !strings.Contains(string(body), "HTTP/2.0") {
+		t.Errorf("Expected HTTP/2.0 in response, got: %s", string(body))
+	}
+
+	t.Logf("Response from ServerConfig: %s", string(body))
 }

--- a/server/config/config_test.go
+++ b/server/config/config_test.go
@@ -784,11 +784,11 @@ func TestServerConfigWithH2C(t *testing.T) {
 	defer func() {
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
-		server.Shutdown(ctx)
+		_ = server.Shutdown(ctx)
 	}()
 
 	// Test with HTTP/2 client
-	client := &http.Client{
+	client := &http.Client{ // nolint:gocritic
 		Transport: &http2.Transport{
 			AllowHTTP: true,
 			DialTLSContext: func(ctx context.Context, network, addr string, cfg *tls.Config) (net.Conn, error) {


### PR DESCRIPTION
For #26963.

When using Fleet on GCP via Cloud run you run into a limitation attempting to upload software packages

```
Request URL:
https://dogfoodgcp.fleetdm.com/api/latest/fleet/software/package
Request Method:
POST
Status Code:
413 Payload Too Large
```

https://cloud.google.com/run/quotas#request_limits

> 32 MiB if using HTTP/1 server. No limit if using HTTP/2 server.

Which means you can only upload packages that are <= 32 MiB.

However, if using HTTP/2 there is no limit. Typically HTTP/2 is only enabled in the Go webserver if using TLS, but we can force HTTP/2 via H2C and the associated packages in the X lib.

After pushing the docker image with the new server configuration and enabling H2C in Cloud Run as well as setting `FLEET_SERVER_FORCE_H2C=true` I can successfully upload software installers > 32 MiB in size.