### PR TITLE
[API/YAML updates] Deploy certificates from DigiCert and custom SCEP

### DIFF
--- a/docs/Configuration/yaml-files.md
+++ b/docs/Configuration/yaml-files.md
@@ -613,7 +613,8 @@ org_settings:
         api_token: $DIGICERT_API_TOKEN
         profile_id: 926dbcdd-41c4-4fe5-96c3-b6a7f0da81d8
         certificate_common_name: $FLEET_VAR_HOST_HARDWARE_SERIAL@example.com
-        certificate_subject_alternative_name: $FLEET_VAR_HOST_HARDWARE_SERIAL@example.com
+        certificate_user_principal_names:
+          - $FLEET_VAR_HOST_HARDWARE_SERIAL@example.com
         certificate_seat_id: $FLEET_VAR_HOST_HARDWARE_SERIAL@example.com
     ndes_scep_proxy:
       url: https://example.com/certsrv/mscep/mscep.dll
@@ -653,7 +654,7 @@ For secrets, you can add [GitHub environment variables](https://docs.github.com/
 - `api_token` is the token used to authenticate requests to DigiCert.
 - `profile_id` is the ID of certificate profile in DigiCert.
 - `certificate_common_name` is the certificate's CN.
-- `certificate_subject_alternative_name` is the certificate's SAN name.
+- `certificate_user_principal_names` is the certificate's user principal names (UPN) attribute in Subject Alternative Name (SAN).
 - `certificate_seat_id` is the ID of the DigiCert's seat. Seats are license units in DigiCert.
 
 #### ndes_scep_proxy

--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -1675,7 +1675,7 @@ _Available in Fleet Premium._
 | Name                              | Type    | Description   |
 | ---------------------             | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | name   | string | Name of the certificate authority that will be used in variables in configuration profiles. Only letters, numbers, and underscores are allowed. |
-| url   | string | URL to DigiCert instance. It's used as base URL for DigiCert API requests. |
+| url   | string | DigiCert instance URL, used as base URL for DigiCert API requests. |
 | api_token        | string | API token used to authenticate requests to DigiCert. |
 | profile_id       | string  | The ID of certificate profile in DigiCert. |
 | certificate_common_name      | string  | The certificate's common name. |

--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -996,7 +996,9 @@ None.
         "api_token": "********",
         "profile_id": "7ed77396-9186-4bfa-9fa7-63dddc46b8a3",
         "certificate_common_name": "$FLEET_VAR_HOST_HARDWARE_SERIAL@example.com",
-        "certificate_subject_alternative_name": "$FLEET_VAR_HOST_HARDWARE_SERIAL@example.com",
+        "certificate_user_principal_names": [
+          "$FLEET_VAR_HOST_HARDWARE_SERIAL@example.com",
+        ]
         "certificate_seat_id": "$FLEET_VAR_HOST_HARDWARE_SERIAL@example.com"
       }
     ],
@@ -1675,9 +1677,8 @@ _Available in Fleet Premium._
 | api_token        | string | API token used to authenticate requests to DigiCert. |
 | profile_id       | string  | The ID of certificate profile in DigiCert. |
 | certificate_common_name      | string  | The certificate's common name. |
-| certificate_subject_alternative_name     | string  | The certificate's SAN name. |
+| certificate_user_principal_names    | array  | The certificate's user principal names (UPN) attribute in Subject Alternative Name (SAN). |
 | certificate_seat_id     | string  | The ID of the DigiCert seat. Seats are license units in DigiCert. |
-
 
 <br/>
 

--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -993,6 +993,7 @@ None.
       {
         "id": 0,
         "name": "DIGICERT_WIFI",
+        "url": "https://one.digicert.com",
         "api_token": "********",
         "profile_id": "7ed77396-9186-4bfa-9fa7-63dddc46b8a3",
         "certificate_common_name": "$FLEET_VAR_HOST_HARDWARE_SERIAL@example.com",
@@ -1012,13 +1013,13 @@ None.
       {
         "id": 0,
         "name": "SCEP_WIFI",
-        "server_url": "https://example.com/scep",
+        "url": "https://example.com/scep",
         "challenge": "********",
       },
       {
         "id": 1,
         "name": "SCEP_VPN",
-        "server_url": "https://example.com/scep",
+        "url": "https://example.com/scep",
         "challenge": "********",
       }
     ],
@@ -1674,6 +1675,7 @@ _Available in Fleet Premium._
 | Name                              | Type    | Description   |
 | ---------------------             | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | name   | string | Name of the certificate authority that will be used in variables in configuration profiles. Only letters, numbers, and underscores are allowed. |
+| url   | string | URL to DigiCert instance. It's used as base URL for DigiCert API requests. |
 | api_token        | string | API token used to authenticate requests to DigiCert. |
 | profile_id       | string  | The ID of certificate profile in DigiCert. |
 | certificate_common_name      | string  | The certificate's common name. |
@@ -1706,7 +1708,7 @@ Setting `integrations.ndes_scep_proxy` to `null` will clear existing settings. N
 | Name                              | Type    | Description   |
 | ---------------------             | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | name   | string | Name of the certificate authority that will be used in variables in configuration profiles. Only letters, numbers, and underscores are allowed. |
-| server_url        | boolean | URL of the Simple Certificate Enrollment Protocol (SCEP) server |
+| url        | boolean | URL of the Simple Certificate Enrollment Protocol (SCEP) server |
 | challenge         | string  | Static challenge password used to authenticate requests to SCEP server. |
 
 <br/>
@@ -1739,6 +1741,7 @@ Setting `integrations.ndes_scep_proxy` to `null` will clear existing settings. N
     "digicert": [
       {
         "name": "DIGICERT_WIFI",
+        "url": "https://one.digicert.com",
         "api_token": "********",
         "profile_id": "7ed77396-9186-4bfa-9fa7-63dddc46b8a3",
         "certificate_common_name": "$FLEET_VAR_HOST_HARDWARE_SERIAL@example.com",
@@ -1755,12 +1758,12 @@ Setting `integrations.ndes_scep_proxy` to `null` will clear existing settings. N
     "custom_scep_proxy": [
       {
         "name": "SCEP_WIFI",
-        "server_url": "https://example.com/scep",
+        "url": "https://example.com/scep",
         "challenge": "********"
       },
       {
         "name": "SCEP_VPN",
-        "server_url": "https://example.com/scep",
+        "url": "https://example.com/scep",
         "challenge": "********"
       }
     ]


### PR DESCRIPTION
Related to: 
- #25822

Main API design PR is already merged. This PR updates few smaller things (naming mostly). Main PR: #26484

Additional update to delete `id` from DigiCert and custom scep configs. #27076