### PR TITLE
Why this way: "OS settings" and "configuration profiles" instead of "CSP/XML"

### DIFF
--- a/handbook/company/why-this-way.md
+++ b/handbook/company/why-this-way.md
@@ -379,13 +379,13 @@ That means you can collect logs from Linux servers or Windows factory workstatio
 
 ## Why does Fleet us "OS settings" and "configuration profiles" instead of "Windows CSP/XML"
 
-IT and security tools should be easy to understand for everyone. This includes people who don't work in, or are new to, IT and security.
+IT and security tools should be easy to understand for everyone. This includes people who don't work in IT and security.
 
-In Fleet, the words "OS settings" mean the computer's operating system settings. All computers, regardless of operating system, have settings that can be changed and enforced using Fleet. A Fleet user can enforce OS settings with a script or, for some settings, a "configuration profile."
+In Fleet, the words "OS settings" mean the computer's operating system settings. All computers have settings that can be changed and enforced using Fleet. A Fleet user can enforce OS settings with a script or a "configuration profile."
 
-When some tools like Workspace ONE say "Windows CSP/XML" instead of "configuration profile," we've learned that "CSP/XML" is confusing even for people who work in IT and security.
+Some tools like Workspace ONE say "Windows CSP/XML" instead of "Windows configuration profile." We've learned that "CSP/XML" is confusing even for people who work in IT and security.
 
-By saying "configuration profiles," Fleet has one, cross-platform name for a feature used to enforce OS settings on macOS, iOS, iPadOS, Windows, and Linux hosts.
+By saying "configuration profile," Fleet has one, cross-platform name for a feature used to enforce OS settings on macOS, iOS, iPadOS, Windows, and Linux hosts.
 
 ## Why not mention the CEO in Slack threads?
 

--- a/handbook/company/why-this-way.md
+++ b/handbook/company/why-this-way.md
@@ -377,7 +377,7 @@ Since Fleet is more than MDM, you can collect logs and health data on any comput
 
 That means you can collect logs from Linux servers or Windows factory workstations without enabling remote script execution on those computers, even if you're using script execution on your Macs.
 
-## Why does Fleet us "OS settings" and "configuration profiles" instead of "Windows CSP/XML"
+## Why does Fleet use "OS settings" and "configuration profiles" instead of "Windows CSP/XML"
 
 IT and security tools should be easy to understand for everyone. This includes people who don't work in IT and security.
 

--- a/handbook/company/why-this-way.md
+++ b/handbook/company/why-this-way.md
@@ -371,7 +371,7 @@ MDM should be a capability, not a product category.
 
 In Fleet, the word "enrolled" means "the host shows up in the dashboard and API".
 
-When some tools like Workspace ONE say a host is "enrolled", they mean that data is being collected _and_ enforcement features are activated on that host.
+When some tools like Omnissa say a host is "enrolled", they mean that data is being collected _and_ enforcement features are activated on that host.
 
 Since Fleet is more than MDM, you can collect logs and health data on any computer.  You can also enforce OS settings on any computer.  But you don't have to enable both: for example, you can build an installer that only collects data, without enabling enforcement features like MDM protocol support and script execution.
 
@@ -383,7 +383,7 @@ IT and security tools should be easy to understand for everyone. This includes p
 
 In Fleet, the words "OS settings" mean the computer's operating system settings. All computers have settings that can be changed and enforced using Fleet. A Fleet user can enforce OS settings with a script or a "configuration profile."
 
-Some tools like Workspace ONE say "Windows CSP/XML" instead of "Windows configuration profile." We've learned that "CSP/XML" is confusing even for people who work in IT and security.
+Some tools like Omnissa say "Windows CSP/XML" instead of "Windows configuration profile." We've learned that "CSP/XML" is confusing even for people who work in IT and security.
 
 By saying "configuration profile," Fleet has one, cross-platform name for a feature used to enforce OS settings on macOS, iOS, iPadOS, Windows, and Linux hosts.
 

--- a/handbook/company/why-this-way.md
+++ b/handbook/company/why-this-way.md
@@ -377,6 +377,9 @@ Since Fleet is more than MDM, you can collect logs and health data on any comput
 
 That means you can collect logs from Linux servers or Windows factory workstations without enabling remote script execution on those computers, even if you're using script execution on your Macs.
 
+## Why does Fleet us "OS settings (configuration profiles)" instead of "Windows CSP/XML"
+
+This way, Fleet has one, cross-platform name for the feature used to enforcing OS settings on macOS, iOS, iPadOS, Windows, and Linux hosts.
 
 ## Why not mention the CEO in Slack threads?
 

--- a/handbook/company/why-this-way.md
+++ b/handbook/company/why-this-way.md
@@ -377,9 +377,15 @@ Since Fleet is more than MDM, you can collect logs and health data on any comput
 
 That means you can collect logs from Linux servers or Windows factory workstations without enabling remote script execution on those computers, even if you're using script execution on your Macs.
 
-## Why does Fleet us "OS settings (configuration profiles)" instead of "Windows CSP/XML"
+## Why does Fleet us "OS settings" and "configuration profiles" instead of "Windows CSP/XML"
 
-This way, Fleet has one, cross-platform name for the feature used to enforcing OS settings on macOS, iOS, iPadOS, Windows, and Linux hosts.
+IT and security tools should be easy to understand for everyone. This includes people who don't work in, or are new to, IT and security.
+
+In Fleet, the words "OS settings" mean the computer's operating system settings. All computers, regardless of operating system, have settings that can be changed and enforced using Fleet. A Fleet user can enforce OS settings with a script or, for some settings, a "configuration profile."
+
+When some tools like Workspace ONE say "Windows CSP/XML" instead of "configuration profile," we've learned that "CSP/XML" is confusing even for people who work in IT and security.
+
+By saying "confguration profiles," Fleet has one, cross-platform name for a feature used to enforcing OS settings on macOS, iOS, iPadOS, Windows, and Linux hosts.
 
 ## Why not mention the CEO in Slack threads?
 

--- a/handbook/company/why-this-way.md
+++ b/handbook/company/why-this-way.md
@@ -385,7 +385,7 @@ In Fleet, the words "OS settings" mean the computer's operating system settings.
 
 When some tools like Workspace ONE say "Windows CSP/XML" instead of "configuration profile," we've learned that "CSP/XML" is confusing even for people who work in IT and security.
 
-By saying "confguration profiles," Fleet has one, cross-platform name for a feature used to enforcing OS settings on macOS, iOS, iPadOS, Windows, and Linux hosts.
+By saying "configuration profiles," Fleet has one, cross-platform name for a feature used to enforce OS settings on macOS, iOS, iPadOS, Windows, and Linux hosts.
 
 ## Why not mention the CEO in Slack threads?
 


### PR DESCRIPTION
- @noahtalerman: this will be a spotlight in the next all hands
