### PR TITLE
add self closing successful Android enterprise connection page 

### DIFF
--- a/server/mdm/android/service/enterpriseCallback.html
+++ b/server/mdm/android/service/enterpriseCallback.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="robots" content="noindex, nofollow" />
+    <meta name="googlebot" content="noindex, nofollow" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Auto Close</title>
+    <script>
+      window.onload = function () {
+        window.close();
+      };
+    </script>
+  </head>
+  <body>
+    <p>If this page does not close automatically, please close it manually.</p>
+  </body>
+</html>

--- a/server/mdm/android/service/service.go
+++ b/server/mdm/android/service/service.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	_ "embed"
 	"fmt"
 	"net/http"
 	"strings"
@@ -144,10 +145,24 @@ type enterpriseSignupCallbackRequest struct {
 	EnterpriseToken string `query:"enterpriseToken"`
 }
 
+type enterpriseSignupCallbackResponse struct {
+	Err error `json:"error,omitempty"`
+}
+
+func (res enterpriseSignupCallbackResponse) Error() error { return res.Err }
+
+//go:embed enterpriseCallback.html
+var enterpriseCallbackHTML []byte
+
+func (res enterpriseSignupCallbackResponse) HijackRender(ctx context.Context, w http.ResponseWriter) {
+	w.Header().Set("Content-Type", "text/html; charset=UTF-8")
+	_, _ = w.Write(enterpriseCallbackHTML)
+}
+
 func enterpriseSignupCallbackEndpoint(ctx context.Context, request interface{}, svc android.Service) fleet.Errorer {
 	req := request.(*enterpriseSignupCallbackRequest)
 	err := svc.EnterpriseSignupCallback(ctx, req.SignupToken, req.EnterpriseToken)
-	return android.DefaultResponse{Err: err}
+	return enterpriseSignupCallbackResponse{Err: err}
 }
 
 // EnterpriseSignupCallback handles the callback from Google UI during signup flow.

--- a/server/mdm/android/tests/enterprise/enterprise_test.go
+++ b/server/mdm/android/tests/enterprise/enterprise_test.go
@@ -56,8 +56,13 @@ func (s *enterpriseTestSuite) TestEnterprise() {
 
 	s.FleetSvc.On("NewActivity", mock.Anything, mock.Anything, mock.AnythingOfType("fleet.ActivityTypeEnabledAndroidMDM")).Return(nil)
 	const enterpriseToken = "enterpriseToken"
-	s.DoJSON("GET", s.ProxyCallbackURL, nil, http.StatusOK, &resp, "enterpriseToken", enterpriseToken)
+	res := s.Do("GET", s.ProxyCallbackURL, nil, http.StatusOK, "enterpriseToken", enterpriseToken)
 	s.FleetSvc.AssertNumberOfCalls(s.T(), "NewActivity", 1)
+	body, err := io.ReadAll(res.Body)
+	require.NoError(s.T(), err)
+	assert.Equal(s.T(), "text/html; charset=UTF-8", res.Header.Get("Content-Type"))
+	assert.Contains(s.T(), string(body), "If this page does not close automatically, please close it manually.")
+	assert.Contains(s.T(), string(body), "window.close()")
 
 	// Now enterprise exists and we can retrieve it.
 	resp = android.GetEnterpriseResponse{}


### PR DESCRIPTION
For #26736

Cherrypick PR: adds a self closing page that is the final part of connecting with Android Enterprise. This allows the user to see the fleet page notification that android mdm is now enabled.

