### PR TITLE
 Audit log docs: Add `host_id` to `fleet_enrolled` audit activity

### DIFF
--- a/docs/Contributing/Audit-logs.md
+++ b/docs/Contributing/Audit-logs.md
@@ -533,6 +533,7 @@ This activity contains the following fields:
 
 ```json
 {
+  "host_id": 123,
   "host_serial": "B04FL3ALPT21",
   "host_display_name": "WIN-DESKTOP-JGS78KJ7C"
 }


### PR DESCRIPTION
For #26695 

(Draft PR for design purposes, not to be merged.)