### PR TITLE
cherrypick: Add newly reported CVE-2025-1795 to test for Python 3.12.0 expected vulns

### DIFF
--- a/server/vulnerabilities/nvd/cve_test.go
+++ b/server/vulnerabilities/nvd/cve_test.go
@@ -424,6 +424,10 @@ func TestTranslateCPEToCVE(t *testing.T) {
 		"cpe:2.3:a:python:python:3.12.0:-:*:*:*:macos:*:*": {
 			includedCVEs: []cve{
 				{
+					ID:                "CVE-2025-1795",
+					resolvedInVersion: "3.12.3",
+				},
+				{
 					ID:                "CVE-2024-7592",
 					resolvedInVersion: "3.12.6",
 				},


### PR DESCRIPTION
For #26748

cherrypick pr for https://github.com/fleetdm/fleet/pull/26751

