### PR TITLE
Remove cancel icon for all past activities and fix install vpp activity show details

### DIFF
--- a/frontend/__mocks__/activityMock.ts
+++ b/frontend/__mocks__/activityMock.ts
@@ -1,4 +1,8 @@
-import { IActivity, ActivityType } from "interfaces/activity";
+import {
+  IActivity,
+  ActivityType,
+  IHostPastActivity,
+} from "interfaces/activity";
 
 const DEFAULT_ACTIVITY_MOCK: IActivity = {
   created_at: "2022-11-03T17:22:14Z",
@@ -11,8 +15,22 @@ const DEFAULT_ACTIVITY_MOCK: IActivity = {
   type: ActivityType.EditedAgentOptions,
 };
 
-const createMockActivity = (overrides?: Partial<IActivity>): IActivity => {
+export const createMockActivity = (
+  overrides?: Partial<IActivity>
+): IActivity => {
   return { ...DEFAULT_ACTIVITY_MOCK, ...overrides };
+};
+
+const DEFAULT_HOST_PAST_ACTIVITY_MOCK: IHostPastActivity = {
+  ...DEFAULT_ACTIVITY_MOCK,
+  type: ActivityType.LockedHost,
+  details: {},
+};
+
+export const createMockHostPastActivity = (
+  overrides?: Partial<IHostPastActivity>
+): IHostPastActivity => {
+  return { ...DEFAULT_HOST_PAST_ACTIVITY_MOCK, ...overrides };
 };
 
 export default createMockActivity;

--- a/frontend/pages/DashboardPage/cards/ActivityFeed/GlobalActivityItem/GlobalActivityItem.tsx
+++ b/frontend/pages/DashboardPage/cards/ActivityFeed/GlobalActivityItem/GlobalActivityItem.tsx
@@ -46,6 +46,7 @@ const ACTIVITIES_WITH_DETAILS = new Set([
   ActivityType.EnabledActivityAutomations,
   ActivityType.EditedActivityAutomations,
   ActivityType.LiveQuery,
+  ActivityType.InstalledAppStoreApp,
 ]);
 
 const getProfileMessageSuffix = (

--- a/frontend/pages/hosts/details/cards/Activity/ActivityItems/CanceledScriptActivityItem/CanceledScriptActivityItem.tsx
+++ b/frontend/pages/hosts/details/cards/Activity/ActivityItems/CanceledScriptActivityItem/CanceledScriptActivityItem.tsx
@@ -10,9 +10,14 @@ const baseClass = "canceled-script-activity-item";
 
 const CanceledScriptActivityItem = ({
   activity,
+  hideCancel,
 }: IHostActivityItemComponentProps) => {
   return (
-    <ActivityItem className={baseClass} activity={activity}>
+    <ActivityItem
+      className={baseClass}
+      activity={activity}
+      hideCancel={hideCancel}
+    >
       <>
         <b>{activity.actor_full_name}</b> canceled{" "}
         <b>{formatScriptNameForActivityItem(activity.details?.script_name)}</b>{" "}

--- a/frontend/pages/hosts/details/cards/Activity/ActivityItems/CanceledScriptActivityItem/CanceledScriptActivityItem.tsx
+++ b/frontend/pages/hosts/details/cards/Activity/ActivityItems/CanceledScriptActivityItem/CanceledScriptActivityItem.tsx
@@ -17,6 +17,7 @@ const CanceledScriptActivityItem = ({
       className={baseClass}
       activity={activity}
       hideCancel={hideCancel}
+      hideShowDetails
     >
       <>
         <b>{activity.actor_full_name}</b> canceled{" "}

--- a/frontend/pages/hosts/details/cards/Activity/ActivityItems/CanceledSoftwareInstallActivityItem/CanceledSoftwareInstallActivityItem.tsx
+++ b/frontend/pages/hosts/details/cards/Activity/ActivityItems/CanceledSoftwareInstallActivityItem/CanceledSoftwareInstallActivityItem.tsx
@@ -14,6 +14,7 @@ const CanceledSoftwareInstallActivityItem = ({
       className={baseClass}
       activity={activity}
       hideCancel={hideCancel}
+      hideShowDetails
     >
       <>
         <b>{activity.actor_full_name}</b> canceled{" "}

--- a/frontend/pages/hosts/details/cards/Activity/ActivityItems/CanceledSoftwareInstallActivityItem/CanceledSoftwareInstallActivityItem.tsx
+++ b/frontend/pages/hosts/details/cards/Activity/ActivityItems/CanceledSoftwareInstallActivityItem/CanceledSoftwareInstallActivityItem.tsx
@@ -7,9 +7,14 @@ const baseClass = "canceled-software-install-activity-item";
 
 const CanceledSoftwareInstallActivityItem = ({
   activity,
+  hideCancel,
 }: IHostActivityItemComponentProps) => {
   return (
-    <ActivityItem className={baseClass} activity={activity}>
+    <ActivityItem
+      className={baseClass}
+      activity={activity}
+      hideCancel={hideCancel}
+    >
       <>
         <b>{activity.actor_full_name}</b> canceled{" "}
         <b>{activity.details?.software_title}</b> install on this host.

--- a/frontend/pages/hosts/details/cards/Activity/ActivityItems/LockedHostActivityItem/LockHostActivityItem.tests.tsx
+++ b/frontend/pages/hosts/details/cards/Activity/ActivityItems/LockedHostActivityItem/LockHostActivityItem.tests.tsx
@@ -1,0 +1,41 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { createMockHostPastActivity } from "__mocks__/activityMock";
+
+import LockHostActivityItem from "./LockedHostActivityItem";
+
+describe("LockHostActivityItem", () => {
+  it("renders the activity content", () => {
+    render(
+      <LockHostActivityItem
+        activity={createMockHostPastActivity({ actor_full_name: "Test User" })}
+        tab="past"
+      />
+    );
+
+    expect(screen.getByText("Test User")).toBeVisible();
+    expect(screen.getByText(/locked this host/i)).toBeVisible();
+  });
+
+  it("does not render the cancel icon", () => {
+    render(
+      <LockHostActivityItem
+        activity={createMockHostPastActivity({ actor_full_name: "Test User" })}
+        tab="past"
+      />
+    );
+
+    expect(screen.queryByTestId("close-icon")).not.toBeInTheDocument();
+  });
+
+  it("does not render the show details icon", () => {
+    render(
+      <LockHostActivityItem
+        activity={createMockHostPastActivity({ actor_full_name: "Test User" })}
+        tab="past"
+      />
+    );
+
+    expect(screen.queryByTestId("info-outline-icon")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/pages/hosts/details/cards/Activity/ActivityItems/LockedHostActivityItem/LockedHostActivityItem.tsx
+++ b/frontend/pages/hosts/details/cards/Activity/ActivityItems/LockedHostActivityItem/LockedHostActivityItem.tsx
@@ -15,6 +15,7 @@ const LockedHostActivityItem = ({
       className={baseClass}
       activity={activity}
       hideCancel={hideCancel}
+      hideShowDetails
     >
       <b>{activity.actor_full_name}</b> locked this host.
     </ActivityItem>

--- a/frontend/pages/hosts/details/cards/Activity/ActivityItems/LockedHostActivityItem/LockedHostActivityItem.tsx
+++ b/frontend/pages/hosts/details/cards/Activity/ActivityItems/LockedHostActivityItem/LockedHostActivityItem.tsx
@@ -8,13 +8,12 @@ const baseClass = "locked-host-activity-item";
 
 const LockedHostActivityItem = ({
   activity,
-  hideCancel,
 }: IHostActivityItemComponentProps) => {
   return (
     <ActivityItem
       className={baseClass}
       activity={activity}
-      hideCancel={hideCancel}
+      hideCancel
       hideShowDetails
     >
       <b>{activity.actor_full_name}</b> locked this host.

--- a/frontend/pages/hosts/details/cards/Activity/ActivityItems/LockedHostActivityItem/LockedHostActivityItem.tsx
+++ b/frontend/pages/hosts/details/cards/Activity/ActivityItems/LockedHostActivityItem/LockedHostActivityItem.tsx
@@ -8,9 +8,14 @@ const baseClass = "locked-host-activity-item";
 
 const LockedHostActivityItem = ({
   activity,
+  hideCancel,
 }: IHostActivityItemComponentProps) => {
   return (
-    <ActivityItem className={baseClass} activity={activity}>
+    <ActivityItem
+      className={baseClass}
+      activity={activity}
+      hideCancel={hideCancel}
+    >
       <b>{activity.actor_full_name}</b> locked this host.
     </ActivityItem>
   );

--- a/frontend/pages/hosts/details/cards/Activity/ActivityItems/RanScriptActivityItem/RanScriptActivityItem.tsx
+++ b/frontend/pages/hosts/details/cards/Activity/ActivityItems/RanScriptActivityItem/RanScriptActivityItem.tsx
@@ -11,7 +11,6 @@ const RanScriptActivityItem = ({
   tab,
   activity,
   onShowDetails,
-  onCancel,
   isSoloActivity,
   hideCancel,
 }: IHostActivityItemComponentPropsWithShowDetails) => {
@@ -25,7 +24,6 @@ const RanScriptActivityItem = ({
       className={baseClass}
       activity={activity}
       onShowDetails={onShowDetails}
-      onCancel={onCancel}
       isSoloActivity={isSoloActivity}
       hideCancel={hideCancel}
     >

--- a/frontend/pages/hosts/details/cards/Activity/ActivityItems/UnlockedHostActivityItem/UnlockHostActivityItem.tests.tsx
+++ b/frontend/pages/hosts/details/cards/Activity/ActivityItems/UnlockedHostActivityItem/UnlockHostActivityItem.tests.tsx
@@ -1,0 +1,58 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { createMockHostPastActivity } from "__mocks__/activityMock";
+
+import UnlockHostActivityItem from "./UnlockedHostActivityItem";
+
+describe("UnlockHostActivityItem", () => {
+  it("renders the activity content for darwin hosts", () => {
+    render(
+      <UnlockHostActivityItem
+        activity={createMockHostPastActivity({
+          actor_full_name: "Test User",
+          details: { host_platform: "darwin" },
+        })}
+        tab="past"
+      />
+    );
+
+    expect(screen.getByText("Test User")).toBeVisible();
+    expect(
+      screen.getByText("viewed the six-digit unlock PIN for this host.")
+    ).toBeVisible();
+  });
+
+  it("renders the activity content for non-darwin hosts", () => {
+    render(
+      <UnlockHostActivityItem
+        activity={createMockHostPastActivity({ actor_full_name: "Test User" })}
+        tab="past"
+      />
+    );
+
+    expect(screen.getByText("Test User")).toBeVisible();
+    expect(screen.getByText(/unlocked this host/i)).toBeVisible();
+  });
+
+  it("does not render the cancel icon", () => {
+    render(
+      <UnlockHostActivityItem
+        activity={createMockHostPastActivity({ actor_full_name: "Test User" })}
+        tab="past"
+      />
+    );
+
+    expect(screen.queryByTestId("close-icon")).not.toBeInTheDocument();
+  });
+
+  it("does not render the show details icon", () => {
+    render(
+      <UnlockHostActivityItem
+        activity={createMockHostPastActivity({ actor_full_name: "Test User" })}
+        tab="past"
+      />
+    );
+
+    expect(screen.queryByTestId("info-outline-icon")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/pages/hosts/details/cards/Activity/ActivityItems/UnlockedHostActivityItem/UnlockedHostActivityItem.tsx
+++ b/frontend/pages/hosts/details/cards/Activity/ActivityItems/UnlockedHostActivityItem/UnlockedHostActivityItem.tsx
@@ -7,7 +7,6 @@ const baseClass = "unlocked-host-activity-item";
 
 const UnlockedHostActivityItem = ({
   activity,
-  hideCancel,
 }: IHostActivityItemComponentProps) => {
   let desc = "unlocked this host.";
   if (activity.details?.host_platform === "darwin") {
@@ -17,10 +16,10 @@ const UnlockedHostActivityItem = ({
     <ActivityItem
       className={baseClass}
       activity={activity}
-      hideCancel={hideCancel}
+      hideCancel
       hideShowDetails
     >
-      <b>{activity.actor_full_name} </b> {desc}
+      <b>{activity.actor_full_name}</b> {desc}
     </ActivityItem>
   );
 };

--- a/frontend/pages/hosts/details/cards/Activity/ActivityItems/UnlockedHostActivityItem/UnlockedHostActivityItem.tsx
+++ b/frontend/pages/hosts/details/cards/Activity/ActivityItems/UnlockedHostActivityItem/UnlockedHostActivityItem.tsx
@@ -7,13 +7,18 @@ const baseClass = "unlocked-host-activity-item";
 
 const UnlockedHostActivityItem = ({
   activity,
+  hideCancel,
 }: IHostActivityItemComponentProps) => {
   let desc = "unlocked this host.";
   if (activity.details?.host_platform === "darwin") {
     desc = "viewed the six-digit unlock PIN for this host.";
   }
   return (
-    <ActivityItem className={baseClass} activity={activity}>
+    <ActivityItem
+      className={baseClass}
+      activity={activity}
+      hideCancel={hideCancel}
+    >
       <b>{activity.actor_full_name} </b> {desc}
     </ActivityItem>
   );

--- a/frontend/pages/hosts/details/cards/Activity/ActivityItems/UnlockedHostActivityItem/UnlockedHostActivityItem.tsx
+++ b/frontend/pages/hosts/details/cards/Activity/ActivityItems/UnlockedHostActivityItem/UnlockedHostActivityItem.tsx
@@ -18,6 +18,7 @@ const UnlockedHostActivityItem = ({
       className={baseClass}
       activity={activity}
       hideCancel={hideCancel}
+      hideShowDetails
     >
       <b>{activity.actor_full_name} </b> {desc}
     </ActivityItem>


### PR DESCRIPTION
For #26821, #26838

- fixes issue of cancel icon showing for lock and unlocked activities as that feature is supported yet.

- fixed missing show details icon on the global install app store app activity.

