### PR TITLE
Cherry-Pick: Don't show custom package warning on auto-install checkbox for FMAs

### DIFF
--- a/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareFleetMaintained/FleetMaintainedAppDetailsPage/FleetAppDetailsForm/FleetAppDetailsForm.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareFleetMaintained/FleetMaintainedAppDetailsPage/FleetAppDetailsForm/FleetAppDetailsForm.tsx
@@ -147,7 +147,6 @@ const FleetAppDetailsForm = ({
             formData={formData}
             onToggleAutomaticInstall={onToggleAutomaticInstallCheckbox}
             onToggleSelfService={onToggleSelfServiceCheckbox}
-            isCustomPackage
           />
         </Card>
         <Card paddingSize="medium" borderRadiusSize="large">


### PR DESCRIPTION
Merged into `main` as #26871. Unreleased bug.