### PR TITLE
Added query to detect APNs certificates

### DIFF
--- a/it-and-security/default.yml
+++ b/it-and-security/default.yml
@@ -88,6 +88,7 @@ queries:
   - path: ./lib/all/queries/collect-fleetd-information.yml
   - path: ./lib/all/queries/collect-operating-system-information.yml
   - path: ./lib/all/queries/collect-known-vulnerable-chrome-extensions.yml
+  - path: ./lib/macos/queries/detect-apns-certificate.yml
 controls: 
   enable_disk_encryption: true
   macos_migration:

--- a/it-and-security/lib/macos/queries/detect-apns-certificate.yml
+++ b/it-and-security/lib/macos/queries/detect-apns-certificate.yml
@@ -1,0 +1,9 @@
+- name: Detect APNs certificate by topic
+  automations_enabled: true
+  description: Detects macOS devices that are enrolled using an invalid APNs certificate.
+  discard_data: false
+  interval: 300
+  logging: snapshot
+  observer_can_run: true
+  platform: "darwin"
+  query: SELECT topic FROM mdm WHERE topic NOT LIKE 'com.apple.mgmt.External.8a3367bf-49d7-4dc3-ae41-c9de95f7b424';


### PR DESCRIPTION
Create a query and assigned it to all teams to identify which macOS devices are no longer communicating with Fleet via MDM. 