### PR TITLE
My Device Page: Software link instead of view details hover link

### DIFF
--- a/frontend/components/TableContainer/DataTable/InternalLinkCell/InternalLinkCell.tsx
+++ b/frontend/components/TableContainer/DataTable/InternalLinkCell/InternalLinkCell.tsx
@@ -8,7 +8,7 @@ import { IconNames } from "components/icons";
 const baseClass = "internal-link-cell";
 
 interface IInternalLinkCellProps {
-  value: string;
+  value: string | JSX.Element;
   onClick?: () => void;
   className?: string;
   /** iconName is the name of the icon that will be dislayed to the right

--- a/frontend/components/TableContainer/DataTable/InternalLinkCell/_styles.scss
+++ b/frontend/components/TableContainer/DataTable/InternalLinkCell/_styles.scss
@@ -1,11 +1,16 @@
 .internal-link-cell {
-
   &__content {
-    font: $x-small;
+    font-size: $x-small;
     color: $core-vibrant-blue;
     font-weight: $bold;
     display: inline-flex;
     gap: $pad-small;
+
+    span {
+      display: inline-flex;
+      gap: $pad-small;
+      align-items: center;
+    }
 
     &:hover {
       cursor: pointer;

--- a/frontend/components/TableContainer/DataTable/SoftwareNameCell/SoftwareNameCell.tsx
+++ b/frontend/components/TableContainer/DataTable/SoftwareNameCell/SoftwareNameCell.tsx
@@ -9,6 +9,7 @@ import Icon from "components/Icon";
 import { IconNames } from "components/icons";
 import SoftwareIcon from "pages/SoftwarePage/components/icons/SoftwareIcon";
 import LinkCell from "../LinkCell";
+import InternalLinkCell from "../InternalLinkCell";
 
 const baseClass = "software-name-cell";
 
@@ -99,6 +100,8 @@ interface ISoftwareNameCellProps {
   /** pass in a `path` that this cell will link to */
   path?: string;
   router?: InjectedRouter;
+  /** Open details modal onClick */
+  myDevicePage?: boolean;
   hasPackage?: boolean;
   isSelfService?: boolean;
   installType?: "manual" | "automatic";
@@ -110,11 +113,26 @@ const SoftwareNameCell = ({
   source,
   path,
   router,
+  myDevicePage = false,
   hasPackage = false,
   isSelfService = false,
   installType,
   iconUrl,
 }: ISoftwareNameCellProps) => {
+  // My device page
+  if (myDevicePage) {
+    return (
+      <InternalLinkCell
+        value={
+          <>
+            <SoftwareIcon name={name} source={source} url={iconUrl} />
+            <span className="software-name">{name}</span>
+          </>
+        }
+      />
+    );
+  }
+
   // NO path or router means it's not clickable. return
   // a non-clickable cell early
   if (!router || !path) {

--- a/frontend/pages/hosts/details/cards/Software/DeviceSoftwareTableConfig.tsx
+++ b/frontend/pages/hosts/details/cards/Software/DeviceSoftwareTableConfig.tsx
@@ -50,7 +50,7 @@ export const generateSoftwareTableHeaders = (): ISoftwareTableConfig[] => {
       disableGlobalFilter: false,
       Cell: (cellProps: ITableStringCellProps) => {
         const { name, source } = cellProps.row.original;
-        return <SoftwareNameCell name={name} source={source} />;
+        return <SoftwareNameCell name={name} source={source} myDevicePage />;
       },
       sortType: "caseInsensitive",
     },
@@ -84,21 +84,6 @@ export const generateSoftwareTableHeaders = (): ISoftwareTableConfig[] => {
         const vulnerabilities = getVulnerabilities(cellProps.cell.value ?? []);
         return <VulnerabilitiesCell vulnerabilities={vulnerabilities} />;
       },
-    },
-    {
-      Header: "",
-      // accessor ends up defining the classname for this column (`id__header` in this case), but is
-      // type restricted, so using "id" here, which is unsued by another column
-      accessor: "id",
-      disableSortBy: true,
-      Cell: () => (
-        <ViewAllHostsLink
-          rowHover
-          noLink
-          excludeChevron
-          customText="Show details"
-        />
-      ),
     },
   ];
 


### PR DESCRIPTION
## Issue
Followup for #26617 

## Description
- Move the "View details" link that shows up on hover to just be a link on the software name

## Screenrecording of change

https://github.com/user-attachments/assets/cc130570-6c2e-4c37-adf1-43ce660466cb




# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->


- [x] A detailed QA plan exists on the associated ticket (if it isn't there, work with the product group's QA engineer to add it)
- [x] Manual QA for all new/changed functionality

