### PR TITLE
Allow team admins to view inherited policy details

### DIFF
--- a/frontend/pages/policies/PolicyPage/PolicyPage.tsx
+++ b/frontend/pages/policies/PolicyPage/PolicyPage.tsx
@@ -213,6 +213,7 @@ const PolicyPage = ({
     !isOnGlobalTeam &&
     !isStoredPolicyLoading &&
     storedPolicy?.team_id !== undefined &&
+    storedPolicy?.team_id !== null &&
     !(storedPolicy?.team_id?.toString() === location.query.team_id)
   ) {
     router.push(


### PR DESCRIPTION
## Details

Quick fix to an issue where when a team admin attempted to via an inherited policy, they would encounter an eternal spinner / flickering page.  The issue stemmed from a reload cycle being set off by the stored policy being returned with a team ID of `null`, and existing code that works around the fact that the `useTeamId` hook modifies the router state.

## Testing

1. Create an All Teams policy on an instance with at least one team
2. Create an admin for the team
3. Log in as the team admin
4. Go to Policies page, select the team from the dropdown, click on the inherited policy in the list to view its details.

On main, the details never load.  On this branch, they do.