### PR TITLE
Clean up Python 3.12 vulns test expectations, fix continue-on-error behavior for integration and vulns suites

### DIFF
--- a/.github/workflows/test-go.yaml
+++ b/.github/workflows/test-go.yaml
@@ -51,7 +51,9 @@ jobs:
         exclude:
           - isCron: false
             mysql: "mysql:9.1.0"
-    continue-on-error: ${{ matrix.suite == 'integration' }} # Since integration tests have a higher chance of failing, often for unrelated reasons, we don't want to fail the whole job if they fail
+    # Don't cancel all tests if an integration suite fails as integration suites are more likely to be flakey.
+    # Don't cancel all tests if the vulns suite fails as vulns may start failing for unrelated reasons to PR'd code.
+    continue-on-error: ${{ matrix.suite == 'vuln' || startsWith(matrix.suite, 'integration-') }}
     runs-on: ${{ matrix.os }}
 
     env:

--- a/server/vulnerabilities/nvd/cve_test.go
+++ b/server/vulnerabilities/nvd/cve_test.go
@@ -440,12 +440,6 @@ func TestTranslateCPEToCVE(t *testing.T) {
 					resolvedInVersion: "3.12.3",
 				},
 				{
-					// This one might be an issue with feed generation (outputting an OR
-					// incorrectly). TODO: investigate this further.
-					ID:                "CVE-2024-50602",
-					resolvedInVersion: "",
-				},
-				{
 					ID:                "CVE-2024-12254",
 					resolvedInVersion: "3.12.9",
 				},
@@ -492,6 +486,7 @@ func TestTranslateCPEToCVE(t *testing.T) {
 					resolvedInVersion: "3.12.6",
 				},
 			},
+			continuesToUpdate: true,
 		},
 		"cpe:2.3:a:python:python:3.14.0:alpha1:*:*:*:macos:*:*": {
 			includedCVEs: []cve{


### PR DESCRIPTION
From what I can tell, continue-on-error has been false for the integration suites since the suites were renamed to `integration-*`, so this fixes that issue in addition to continuing to run test suites when the vulns suite fails (which may be due to vulns feed updates).

This also makes the vulns test more resilient to new CVEs being reported on Python 3.12.0, which is rather likely to collect new CVEs.

# Checklist for submitter

- [x] Added/updated automated tests