### PR TITLE
Add bounds checks on Windows Python software mutation to avoid panics when we don't have as many version components as we expect

### DIFF
--- a/.github/workflows/test-go.yaml
+++ b/.github/workflows/test-go.yaml
@@ -51,7 +51,9 @@ jobs:
         exclude:
           - isCron: false
             mysql: "mysql:9.1.0"
-    continue-on-error: ${{ matrix.suite == 'integration' }} # Since integration tests have a higher chance of failing, often for unrelated reasons, we don't want to fail the whole job if they fail
+    # Don't cancel all tests if an integration suite fails as integration suites are more likely to be flakey.
+    # Don't cancel all tests if the vulns suite fails as vulns may start failing for unrelated reasons to PR'd code.
+    continue-on-error: ${{ matrix.suite == 'vuln' || startsWith(matrix.suite, 'integration-') }}
     runs-on: ${{ matrix.os }}
 
     env:

--- a/changes/python-bounds-check
+++ b/changes/python-bounds-check
@@ -1,0 +1,1 @@
+* Fixed Python for Windows software version mutation to avoid panics on software ingestion in some cases

--- a/server/service/osquery_utils/queries.go
+++ b/server/service/osquery_utils/queries.go
@@ -1795,6 +1795,17 @@ var (
 			},
 			mutateSoftware: func(s *fleet.Software, logger log.Logger) {
 				versionComponents := strings.Split(s.Version, ".")
+				// Python 3 versions on Windows should always look like 3.14.102.0; if they don't we
+				// should bail out to avoid bad indexing panics.
+				if len(versionComponents) < 4 {
+					level.Debug(logger).Log("msg", "expected 4 version components", "gotCount", len(versionComponents))
+					return
+				}
+				if len(versionComponents[2]) < 3 {
+					level.Debug(logger).Log("msg", "got a patch version component with unexpected length", "gotPatchVersion", versionComponents[2])
+					return
+				}
+
 				patchVersion := versionComponents[2][0 : len(versionComponents[2])-3]
 				releaseLevel := versionComponents[2][len(versionComponents[2])-3 : len(versionComponents[2])-1]
 				releaseSerial := versionComponents[2][len(versionComponents[2])-1 : len(versionComponents[2])]

--- a/server/service/osquery_utils/queries_test.go
+++ b/server/service/osquery_utils/queries_test.go
@@ -1978,6 +1978,20 @@ func TestSanitizeSoftware(t *testing.T) {
 			},
 		},
 		{
+			name: "Python for Windows shouldn't panic",
+			h:    &fleet.Host{},
+			s: &fleet.Software{
+				Name:    "Python 3.12 (64-bit)",
+				Version: "3.12",
+				Source:  "programs",
+			},
+			sanitized: &fleet.Software{
+				Name:    "Python 3.12 (64-bit)",
+				Version: "3.12",
+				Source:  "programs",
+			},
+		},
+		{
 			name: "Python for Windows GA dot-zero",
 			h:    &fleet.Host{},
 			s: &fleet.Software{

--- a/server/vulnerabilities/nvd/cve_test.go
+++ b/server/vulnerabilities/nvd/cve_test.go
@@ -440,12 +440,6 @@ func TestTranslateCPEToCVE(t *testing.T) {
 					resolvedInVersion: "3.12.3",
 				},
 				{
-					// This one might be an issue with feed generation (outputting an OR
-					// incorrectly). TODO: investigate this further.
-					ID:                "CVE-2024-50602",
-					resolvedInVersion: "",
-				},
-				{
 					ID:                "CVE-2024-12254",
 					resolvedInVersion: "3.12.9",
 				},
@@ -492,6 +486,7 @@ func TestTranslateCPEToCVE(t *testing.T) {
 					resolvedInVersion: "3.12.6",
 				},
 			},
+			continuesToUpdate: true,
 		},
 		"cpe:2.3:a:python:python:3.14.0:alpha1:*:*:*:macos:*:*": {
 			includedCVEs: []cve{


### PR DESCRIPTION
For #26944. Backport of a fix that was part of #24784.

Also cherry-picks #26903 to ensure tests run properly.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/Committing-Changes.md#changes-files) for more information.
- [x] Added/updated automated tests
- [x] Manual QA for all new/changed functionality