### PR TITLE
Clear db before restoring from backup

### DIFF
--- a/tools/backup_db/backup.sh
+++ b/tools/backup_db/backup.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 set -euo pipefail
 BACKUP_NAME="${1:-backup.sql.gz}"
-docker run --rm --network fleet_default ${FLEET_MYSQL_IMAGE:-mysql:8.0.36} bash -c 'mysqldump -hmysql -uroot -ptoor --default-character-set=utf8mb4 fleet | gzip -' > $BACKUP_NAME
+docker run --rm --network fleet_default ${FLEET_MYSQL_IMAGE:-mysql:8.0.36} bash -c "mysqldump -hmysql -uroot -ptoor --default-character-set=utf8mb4 --add-drop-database $EXTRA_ARGS --databases fleet | gzip -" > $BACKUP_NAME

--- a/tools/backup_db/backup.sh
+++ b/tools/backup_db/backup.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 set -euo pipefail
 BACKUP_NAME="${1:-backup.sql.gz}"
-docker run --rm --network fleet_default ${FLEET_MYSQL_IMAGE:-mysql:8.0.36} bash -c "mysqldump -hmysql -uroot -ptoor --default-character-set=utf8mb4 --add-drop-database $EXTRA_ARGS --databases fleet | gzip -" > $BACKUP_NAME
+docker run --rm --network fleet_default ${FLEET_MYSQL_IMAGE:-mysql:8.0.36} bash -c "mysqldump -hmysql -uroot -ptoor --default-character-set=utf8mb4 --add-drop-database --databases fleet | gzip -" > $BACKUP_NAME


### PR DESCRIPTION
For #26478 

## Details

This PR updates the db snapshot script to have it add a `drop database if exists` line to the top.  This means that snapshots will start from a clean state, so that they won't get out of sync with migrations.

## Testing

I tested this by:

1. starting with an up-to-date database, restoring an old snapshot while on the main code branch, then trying `fleet prepare db`.  
2. This failed because the migrations it tried to run were creating tables that already existed in the database.  
3. I made a new copy of this snapshot by dropping my db and doing `create database fleet`, restoring the snapshot and snapshotting again.  
4. On the main branch, I reset my db using `make db-reset` and then restore my new snapshot
5. Finally, did `fleet prepare db` and this time it worked since the new snapshot dropped the database before restoring.