### PR TITLE
Update goreleaser-fleet workflow to use ubuntu-22.04-4-cores runner

### DIFF
--- a/.github/workflows/goreleaser-fleet.yaml
+++ b/.github/workflows/goreleaser-fleet.yaml
@@ -20,7 +20,7 @@ permissions:
 
 jobs:
   goreleaser:
-    runs-on: ubuntu-20.04-4-cores
+    runs-on: ubuntu-22.04
     environment: Docker Hub
     permissions:
       contents: write

--- a/.github/workflows/goreleaser-fleet.yaml
+++ b/.github/workflows/goreleaser-fleet.yaml
@@ -20,7 +20,7 @@ permissions:
 
 jobs:
   goreleaser:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-22.04-4-cores
     environment: Docker Hub
     permissions:
       contents: write


### PR DESCRIPTION
For #26927 

See [actions/runner-images#11101](https://github.com/actions/runner-images/issues/11101) and https://github.com/fleetdm/fleet/pull/26466/files. Updating explicitly to `ubuntu-22.04-4-cores` to not have it float with `latest`.  [Other](https://github.com/fleetdm/fleet/blob/6e097988d5e1172660d81ec668d055d408e7a54e/.github/workflows/goreleaser-orbit.yaml#L81) [goreleaser](https://github.com/fleetdm/fleet/blob/6e097988d5e1172660d81ec668d055d408e7a54e/.github/workflows/goreleaser-snapshot-fleet.yaml#L40) workflows use 22.04.