### PR TITLE
Don't allow gitops to disable gitops mode (#26794)

### DIFF
--- a/cmd/fleetctl/gitops_test.go
+++ b/cmd/fleetctl/gitops_test.go
@@ -234,7 +234,13 @@ func TestGitOpsBasicGlobalPremium(t *testing.T) {
 	// Mock appConfig
 	savedAppConfig := &fleet.AppConfig{}
 	ds.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {
-		return &fleet.AppConfig{}, nil
+		return &fleet.AppConfig{
+			// Set a GitOps UI mode to verify that applying GitOps config won't overwrite it.
+			UIGitOpsMode: fleet.UIGitOpsModeConfig{
+				GitopsModeEnabled: true,
+				RepositoryURL:     "https://didsomeonesaygitops.biz",
+			},
+		}, nil
 	}
 	ds.SaveAppConfigFunc = func(ctx context.Context, config *fleet.AppConfig) error {
 		savedAppConfig = config
@@ -326,6 +332,9 @@ software:
 	assert.Empty(t, enrolledSecrets)
 	assert.True(t, savedAppConfig.Integrations.NDESSCEPProxy.Valid)
 	assert.Equal(t, "https://ndes.example.com/scep", savedAppConfig.Integrations.NDESSCEPProxy.Value.URL)
+	// GitOps should not overwrite GitOps UI Mode.
+	assert.Equal(t, savedAppConfig.UIGitOpsMode.GitopsModeEnabled, true)
+	assert.Equal(t, savedAppConfig.UIGitOpsMode.RepositoryURL, "https://didsomeonesaygitops.biz")
 }
 
 func TestGitOpsBasicTeam(t *testing.T) {

--- a/server/service/client.go
+++ b/server/service/client.go
@@ -574,6 +574,14 @@ func (c *Client) ApplyGroup(
 			specs.AppConfig.(map[string]interface{})["yara_rules"] = rulePayloads
 		}
 
+		// Keep any existing GitOps mode config rather than attempting to set via GitOps.
+		if appconfig != nil {
+			specs.AppConfig.(map[string]interface{})["gitops"] = fleet.UIGitOpsModeConfig{
+				GitopsModeEnabled: appconfig.UIGitOpsMode.GitopsModeEnabled,
+				RepositoryURL:     appconfig.UIGitOpsMode.RepositoryURL,
+			}
+		}
+
 		if err := c.ApplyAppConfig(specs.AppConfig, opts.ApplySpecOptions); err != nil {
 			return nil, nil, nil, nil, fmt.Errorf("applying fleet config: %w", err)
 		}


### PR DESCRIPTION
Cherry pick of #26794 (unreleased bug) into 4.65.0 release