### PR TITLE
Update OS settings guide

### DIFF
--- a/articles/custom-os-settings.md
+++ b/articles/custom-os-settings.md
@@ -2,7 +2,7 @@
 
 In Fleet you can enforce OS settings like security restrictions, screen lock, Wi-Fi etc., on your your macOS, iOS, iPadOS, and Windows hosts using configuration profiles.
 
-Currently, Fleet only supports [system level](https://support.apple.com/guide/deployment/intro-to-mdm-profiles-depc0aadd3fe/1/web/1.0#:~:text=Device%20and%20user%20settings%20vary%20according%20to%20where%20they%20reside%3A%20Settings%20installed%20at%20the%20system%20level%20reside%20in%20a%20device%20channel.%20Settings%20installed%20for%20a%20user%20reside%20in%20a%20user%20channel.) configuration profiles.
+Currently, Fleet only supports system (device) level configuration profiles.
 
 ## Enforce OS settings
 


### PR DESCRIPTION
- Remove link to Apple docs because this applies to macOS and Windows profiles
- Windows calls this "device level" (from docs [here](https://learn.microsoft.com/en-us/windows/client-management/mdm/policy-configuration-service-provider#:~:text=Policy%20scope%20is%20the%20level%20at%20which%20a%20policy%20can%20be%20configured.%20Some%20policies%20can%20only%20be%20configured%20at%20the%20device%20level%2C%20meaning%20the%20policy%20will%20take%20effect%20independent%20of%20who%20is%20logged%20into%20the%20device))
