### PR TITLE
Added disk encryption check policies

### DIFF
--- a/it-and-security/lib/macos/policies/disk-encryption-check.yml
+++ b/it-and-security/lib/macos/policies/disk-encryption-check.yml
@@ -1,0 +1,9 @@
+- name: macOS - Disk encryption enabled
+  query: SELECT 1 FROM filevault_status WHERE status LIKE '%on%';
+  critical: false
+  description: This policy checks if disk encryption is enabled.
+  resolution: |-
+    Disk encryption should be automatically enforced by Fleet. If you are failing this policy, you might need to logout or restart your Mac. After, open Fleet Desktop and click Refetch to clear this policy failure. 
+
+    If the issue persists, please reach out in #help-dogfooding. 
+  platform: darwin

--- a/it-and-security/lib/macos/policies/disk-encryption-check.yml
+++ b/it-and-security/lib/macos/policies/disk-encryption-check.yml
@@ -3,7 +3,7 @@
   critical: false
   description: This policy checks if disk encryption is enabled.
   resolution: |-
-    Disk encryption should be automatically enforced by Fleet. If you are failing this policy, you might need to logout or restart your Mac. After, open Fleet Desktop and click Refetch to clear this policy failure. 
+    Disk encryption should be automatically enforced by Fleet. If you are failing this policy, you might need to logout or restart your Mac. After logging back in or restarting, open Fleet Desktop and click Refetch to clear this policy failure. 
 
     If the issue persists, please reach out in #help-dogfooding. 
   platform: darwin

--- a/it-and-security/lib/windows/policies/disk-encrpytion-check.yml
+++ b/it-and-security/lib/windows/policies/disk-encrpytion-check.yml
@@ -1,0 +1,9 @@
+- name: Windows - Disk encryption enabled
+  query: SELECT 1 FROM bitlocker_info WHERE protection_status = 1;
+  critical: false
+  description: This policy checks if disk encryption is enabled.
+  resolution: |-
+    Disk encryption should be automatically enforced by Fleet. If you are failing this policy, please restart your device. After, open Fleet Desktop and click Refetch to clear this policy failure. 
+
+    If the issue persists, please reach out in #help-dogfooding. 
+  platform: windows

--- a/it-and-security/lib/windows/policies/disk-encrpytion-check.yml
+++ b/it-and-security/lib/windows/policies/disk-encrpytion-check.yml
@@ -3,7 +3,7 @@
   critical: false
   description: This policy checks if disk encryption is enabled.
   resolution: |-
-    Disk encryption should be automatically enforced by Fleet. If you are failing this policy, please restart your device. After, open Fleet Desktop and click Refetch to clear this policy failure. 
+    Disk encryption should be automatically enforced by Fleet. If you are failing this policy, please restart your device. After restarting, open Fleet Desktop and click Refetch to clear this policy failure. 
 
     If the issue persists, please reach out in #help-dogfooding. 
   platform: windows


### PR DESCRIPTION
Now that we are getting the new APNs certificate and enrollment profile distributed, devices need to reboot to have FileVault enabled and their keys escrowed the Fleet. These policies should hopefully encourage everyone affected to restart their device. 