### PR TITLE
Allow team gitops to run without global config

### DIFF
--- a/changes/26171-gitops-per-team
+++ b/changes/26171-gitops-per-team
@@ -1,0 +1,1 @@
+- Allow team gitops to run without global config

--- a/cmd/fleetctl/gitops.go
+++ b/cmd/fleetctl/gitops.go
@@ -125,7 +125,7 @@ func gitopsCommand() *cli.Command {
 				isGlobalConfig := config.TeamName == nil
 				if isGlobalConfig {
 					if globalConfigLoaded {
-						return errors.New("Only one global config file may be provided to fleetctl gitops")
+						return errors.New("only one global config file may be provided to fleetctl gitops")
 					}
 					globalConfigLoaded = true
 				}

--- a/cmd/fleetctl/gitops.go
+++ b/cmd/fleetctl/gitops.go
@@ -129,7 +129,14 @@ func gitopsCommand() *cli.Command {
 					}
 					globalConfigLoaded = true
 				}
-				configs = append(configs, ConfigFile{Config: config, Filename: flFilename, IsGlobalConfig: isGlobalConfig})
+				configFile := ConfigFile{Config: config, Filename: flFilename, IsGlobalConfig: isGlobalConfig}
+				if isGlobalConfig {
+					// If it's a global file, put it at the beginning
+					// of the array so it gets processed first
+					configs = append([]ConfigFile{configFile}, configs...)
+				} else {
+					configs = append(configs, configFile)
+				}
 			}
 
 			for _, configFile := range configs {

--- a/cmd/fleetctl/gitops.go
+++ b/cmd/fleetctl/gitops.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/fleetdm/fleet/v4/pkg/spec"
 	"github.com/fleetdm/fleet/v4/server/fleet"
-	"github.com/fleetdm/fleet/v4/server/ptr"
 	"github.com/fleetdm/fleet/v4/server/service"
 	"github.com/urfave/cli/v2"
 	"golang.org/x/text/unicode/norm"
@@ -33,7 +32,7 @@ func gitopsCommand() *cli.Command {
 				Required:    true,
 				EnvVars:     []string{"FILENAME"},
 				Destination: &flFilenames,
-				Usage:       "The file(s) with the GitOps configuration. If multiple files are provided, the first file must be the global configuration and the rest must be team configurations.",
+				Usage:       "The file(s) with the GitOps configuration.",
 			},
 			&cli.BoolFlag{
 				Name:        "delete-other-teams",
@@ -90,13 +89,9 @@ func gitopsCommand() *cli.Command {
 			var originalABMConfig []any
 			var originalVPPConfig []any
 			var teamNames []string
-			var firstFileMustBeGlobal *bool
 			var teamDryRunAssumptions *fleet.TeamSpecsDryRunAssumptions
 			var abmTeams, vppTeams []string
 			var hasMissingABMTeam, hasMissingVPPTeam, usesLegacyABMConfig bool
-			if totalFilenames > 1 {
-				firstFileMustBeGlobal = ptr.Bool(true)
-			}
 
 			// we keep track of team software installers and scripts for correct policy application
 			teamsSoftwareInstallers := make(map[string][]fleet.SoftwarePackageResponse)

--- a/cmd/fleetctl/gitops_test.go
+++ b/cmd/fleetctl/gitops_test.go
@@ -1360,8 +1360,11 @@ software:
 
 	// Files out of order
 	_, err = runAppNoChecks([]string{"gitops", "-f", teamFile.Name(), "-f", globalFile.Name(), "--dry-run"})
-	require.Error(t, err)
-	assert.True(t, strings.Contains(err.Error(), "must be the global config"))
+	require.NoError(t, err)
+
+	// No global file, only team file
+	_, err = runAppNoChecks([]string{"gitops", "-f", teamFile.Name(), "--dry-run"})
+	require.NoError(t, err)
 
 	// Global file specified multiple times
 	_, err = runAppNoChecks([]string{"gitops", "-f", globalFile.Name(), "-f", teamFile.Name(), "-f", globalFile.Name(), "--dry-run"})

--- a/cmd/fleetctl/gitops_test.go
+++ b/cmd/fleetctl/gitops_test.go
@@ -1370,7 +1370,7 @@ software:
 	_, err = runAppNoChecks([]string{"gitops", "-f", globalFile.Name(), "-f", teamFile.Name(), "-f", globalFile.Name(), "--dry-run"})
 	require.Error(t, err)
 	fmt.Printf("err.Error(): %v\n", err.Error())
-	assert.Contains(t, err.Error(), "Only one global config file may be provided")
+	assert.Contains(t, err.Error(), "only one global config file may be provided")
 
 	// Duplicate secret
 	_, err = runAppNoChecks([]string{"gitops", "-f", globalFile.Name(), "-f", teamFileDupSecret.Name(), "--dry-run"})

--- a/cmd/fleetctl/gitops_test.go
+++ b/cmd/fleetctl/gitops_test.go
@@ -1369,7 +1369,8 @@ software:
 	// Global file specified multiple times
 	_, err = runAppNoChecks([]string{"gitops", "-f", globalFile.Name(), "-f", teamFile.Name(), "-f", globalFile.Name(), "--dry-run"})
 	require.Error(t, err)
-	assert.True(t, strings.Contains(err.Error(), "only the first file can be the global config"))
+	fmt.Printf("err.Error(): %v\n", err.Error())
+	assert.Contains(t, err.Error(), "Only one global config file may be provided")
 
 	// Duplicate secret
 	_, err = runAppNoChecks([]string{"gitops", "-f", globalFile.Name(), "-f", teamFileDupSecret.Name(), "--dry-run"})

--- a/ee/server/service/mdm_test.go
+++ b/ee/server/service/mdm_test.go
@@ -176,7 +176,7 @@ func TestCountABMTokensAuth(t *testing.T) {
 			{"observer can read", test.UserObserver, false},
 			{"observer+ can read", test.UserObserverPlus, false},
 			{"admin can read", test.UserAdmin, false},
-			{"tm1 gitops cannot read", test.UserTeamGitOpsTeam1, true},
+			{"tm1 gitops can read", test.UserTeamGitOpsTeam1, false},
 			{"tm1 maintainer can read", test.UserTeamMaintainerTeam1, false},
 			{"tm1 observer can read", test.UserTeamObserverTeam1, false},
 			{"tm1 observer+ can read", test.UserTeamObserverPlusTeam1, false},

--- a/server/authz/policy.rego
+++ b/server/authz/policy.rego
@@ -61,8 +61,8 @@ allow {
 # Team admin, maintainer, observer_plus and observer can read global config.
 allow {
   object.type == "app_config"
-  # If role is admin, maintainer, observer_plus or observer on any team.
-  team_role(subject, subject.teams[_].id) == [admin, maintainer, observer_plus, observer][_]
+  # If role is admin, gitops, maintainer, observer_plus or observer on any team.
+  team_role(subject, subject.teams[_].id) == [admin, gitops, maintainer, observer_plus, observer][_]
   action == read
 }
 

--- a/server/authz/policy_test.go
+++ b/server/authz/policy_test.go
@@ -80,7 +80,7 @@ func TestAuthorizeAppConfig(t *testing.T) {
 		{user: test.UserTeamObserverPlusTeam1, object: config, action: read, allow: true},
 		{user: test.UserTeamObserverPlusTeam1, object: config, action: write, allow: false},
 
-		{user: test.UserTeamGitOpsTeam1, object: config, action: read, allow: false},
+		{user: test.UserTeamGitOpsTeam1, object: config, action: read, allow: true},
 		{user: test.UserTeamGitOpsTeam1, object: config, action: write, allow: false},
 	})
 }

--- a/server/service/appconfig_test.go
+++ b/server/service/appconfig_test.go
@@ -130,7 +130,7 @@ func TestAppConfigAuth(t *testing.T) {
 			"team gitops",
 			&fleet.User{Teams: []fleet.UserTeam{{Team: fleet.Team{ID: 1}, Role: fleet.RoleGitOps}}},
 			true,
-			true,
+			false,
 		},
 		{
 			"user without roles",
@@ -607,7 +607,7 @@ func TestAppConfigSecretsObfuscated(t *testing.T) {
 		{
 			"team gitops",
 			&fleet.User{Teams: []fleet.UserTeam{{Team: fleet.Team{ID: 1}, Role: fleet.RoleGitOps}}},
-			true,
+			false,
 		},
 		{
 			"user without roles",


### PR DESCRIPTION
#26171

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/Committing-Changes.md#changes-files) for more information.
- [x] Added/updated automated tests
- [x] A detailed QA plan exists on the associated ticket (if it isn't there, work with the product group's QA engineer to add it)
- [x] Manual QA for all new/changed functionality
