### PR TITLE
Add new archive URL as data source for Mac Office release notes

### DIFF
--- a/changes/26977-macoffice-archives
+++ b/changes/26977-macoffice-archives
@@ -1,0 +1,1 @@
+* Added new (as of 2025-03-07) archives page to data source for MS Mac Office vulnerability feed (applies to vulnerabilities feed rather than a specific Fleet release).

--- a/cmd/macoffice/generate.go
+++ b/cmd/macoffice/generate.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"net/http"
 	"os"
 	"path/filepath"
 	"time"
@@ -26,22 +25,9 @@ func main() {
 	panicif(err)
 
 	fmt.Println("Downloading and parsing Mac Office rel notes...")
-	res, err := http.Get(macoffice.RelNotesURL)
-	panicif(err)
-	defer res.Body.Close()
 
-	parsed, err := macoffice.ParseReleaseHTML(res.Body)
+	relNotes, err := macoffice.GetReleaseNotes(false)
 	panicif(err)
-
-	var relNotes macoffice.ReleaseNotes
-	for _, rn := range parsed {
-		// We only care about release notes that have a version set (because we need that for
-		// matching software entries) and also that contain some
-		// security updates (because we only intented to use the release notes for vulnerability processing).
-		if rn.Valid() {
-			relNotes = append(relNotes, rn)
-		}
-	}
 
 	err = relNotes.Serialize(time.Now(), outPath)
 	panicif(err)

--- a/server/datastore/mysql/migrations/tables/20250127162751_AddUnifiedQueueTable_test.go
+++ b/server/datastore/mysql/migrations/tables/20250127162751_AddUnifiedQueueTable_test.go
@@ -45,5 +45,5 @@ func TestUp_20250127162751(t *testing.T) {
 	  FROM information_schema.COLUMNS
 	  WHERE collation_name != "utf8mb4_unicode_ci" AND table_schema = (SELECT database())`)
 	require.NoError(t, err)
-	require.Equal(t, []string{"secret", "node_key", "orbit_node_key", "name_bin"}, columns)
+	require.ElementsMatch(t, []string{"secret", "node_key", "orbit_node_key", "name_bin"}, columns)
 }

--- a/server/vulnerabilities/macoffice/integration_parser_test.go
+++ b/server/vulnerabilities/macoffice/integration_parser_test.go
@@ -1,7 +1,6 @@
 package macoffice_test
 
 import (
-	"net/http"
 	"testing"
 	"time"
 
@@ -656,11 +655,7 @@ var expected = []macoffice.ReleaseNote{
 func TestIntegrationsParseReleaseHTML(t *testing.T) {
 	nettest.Run(t)
 
-	res, err := http.Get(macoffice.RelNotesURL)
-	require.NoError(t, err)
-	defer res.Body.Close()
-
-	actual, err := macoffice.ParseReleaseHTML(res.Body)
+	actual, err := macoffice.GetReleaseNotes(true)
 	require.NoError(t, err)
 	require.NotEmpty(t, actual)
 

--- a/server/vulnerabilities/macoffice/release_note.go
+++ b/server/vulnerabilities/macoffice/release_note.go
@@ -11,8 +11,6 @@ import (
 	"github.com/fleetdm/fleet/v4/server/vulnerabilities/utils"
 )
 
-const RelNotesURL = "https://learn.microsoft.com/en-us/officeupdates/release-notes-office-for-mac"
-
 type ProductType int
 
 const (


### PR DESCRIPTION
For #26977.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/Committing-Changes.md#changes-files) for more information.
- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [x] Added/updated automated tests
- [x] A detailed QA plan exists on the associated ticket (if it isn't there, work with the product group's QA engineer to add it)
- [x] Manual QA for all new/changed functionality