### PR TITLE
Force a user to click through to redeem MFA if they aren't on a browser that started the MFA process

### DIFF
--- a/changes/26976-mfa-fe-tweaks
+++ b/changes/26976-mfa-fe-tweaks
@@ -1,0 +1,1 @@
+* Fixed an issue where link protection services would prematurely redeem MFA links.

--- a/frontend/pages/LoginPage/LoginPage.tsx
+++ b/frontend/pages/LoginPage/LoginPage.tsx
@@ -141,6 +141,7 @@ const LoginPage = ({ router, location }: ILoginPageProps) => {
         return router.push(redirectLocation || DASHBOARD);
       } catch (response) {
         if ((response as { status: number }).status === 202) {
+          local.setItem("auth_pending_mfa", "true");
           setPendingEmail(true);
         }
 

--- a/frontend/pages/LoginPage/LoginPage.tsx
+++ b/frontend/pages/LoginPage/LoginPage.tsx
@@ -141,6 +141,9 @@ const LoginPage = ({ router, location }: ILoginPageProps) => {
         return router.push(redirectLocation || DASHBOARD);
       } catch (response) {
         if ((response as { status: number }).status === 202) {
+          // This (plus associated code in MfaPage) adds an extra click for browsers hitting the MFA landing page without
+          // logging in first, ensuring MFA tokens don't get auto-redeemed in those cases. An example of such a browser
+          // is an email link scanner (e.g. Microsoft's); see #26976.
           local.setItem("auth_pending_mfa", "true");
           setPendingEmail(true);
         }

--- a/frontend/pages/MfaPage/MfaPage.tsx
+++ b/frontend/pages/MfaPage/MfaPage.tsx
@@ -99,7 +99,7 @@ const MfaPage = ({ router, params }: IMfaPage) => {
       <AuthenticationFormWrapper>
         <div className={baseClass}>
           <Button variant="brand" onClick={onClickFinishLoginButton}>
-            Finish logging in
+            Log in
           </Button>
         </div>
       </AuthenticationFormWrapper>

--- a/frontend/pages/MfaPage/MfaPage.tsx
+++ b/frontend/pages/MfaPage/MfaPage.tsx
@@ -33,6 +33,10 @@ const MfaPage = ({ router, params }: IMfaPage) => {
   } = useContext(AppContext);
   const { redirectLocation } = useContext(RoutingContext);
   const [isExpired, setIsExpired] = useState(false);
+  const [shouldFinishMFA, setShouldFinishMFA] = useState(
+    !!local.getItem("auth_pending_mfa")
+  );
+  local.removeItem("auth_pending_mfa");
 
   const finishMFA = async () => {
     const { DASHBOARD, RESET_PASSWORD, NO_ACCESS } = paths;
@@ -71,8 +75,10 @@ const MfaPage = ({ router, params }: IMfaPage) => {
   };
 
   useEffect(() => {
-    finishMFA();
-  });
+    if (shouldFinishMFA) {
+      finishMFA();
+    }
+  }, [shouldFinishMFA, finishMFA]);
 
   useEffect(() => {
     if (currentUser) {
@@ -83,6 +89,22 @@ const MfaPage = ({ router, params }: IMfaPage) => {
   const onClickLoginButton = () => {
     router.push(paths.LOGIN);
   };
+
+  const onClickFinishLoginButton = () => {
+    setShouldFinishMFA(true);
+  };
+
+  if (!shouldFinishMFA) {
+    return (
+      <AuthenticationFormWrapper>
+        <div className={baseClass}>
+          <Button variant="brand" onClick={onClickFinishLoginButton}>
+            Finish logging in
+          </Button>
+        </div>
+      </AuthenticationFormWrapper>
+    );
+  }
 
   if (isExpired) {
     return (


### PR DESCRIPTION
For #26976.

<img width="384" alt="image" src="https://github.com/user-attachments/assets/8d057ec2-c3b0-45d1-bb8c-9745b426e27d" />

An example of such a browser would be an email link scanner, so this *should* fix cases where link-scanning was redeeming the MFA link before the intended user could get to it. Real users can still click through if they wind up on this page, e.g. if they logged in with a different browser than the one used to open the MFA link.

Users redeeming MFA with the same browser that initiated the login skp the button and redeem/land on the dashboard automatically.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/Committing-Changes.md#changes-files) for more information.
- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [x] A detailed QA plan exists on the associated ticket (if it isn't there, work with the product group's QA engineer to add it)
- [x] Manual QA for all new/changed functionality