### PR TITLE
Refactoring Android datastore interface

### DIFF
--- a/server/datastore/mysql/android.go
+++ b/server/datastore/mysql/android.go
@@ -15,10 +15,6 @@ import (
 	"github.com/jmoiron/sqlx"
 )
 
-func (ds *Datastore) GetAndroidDS() android.Datastore {
-	return ds.androidDS
-}
-
 func (ds *Datastore) NewAndroidHost(ctx context.Context, host *fleet.AndroidHost) (*fleet.AndroidHost, error) {
 	if !host.IsValid() {
 		return nil, ctxerr.New(ctx, "valid Android host is required")
@@ -116,7 +112,7 @@ func (ds *Datastore) NewAndroidHost(ctx context.Context, host *fleet.AndroidHost
 			return ctxerr.Wrap(ctx, err, "new Android host MDM info")
 		}
 
-		host.Device, err = ds.androidDS.CreateDeviceTx(ctx, tx, host.Device)
+		host.Device, err = ds.Datastore.CreateDeviceTx(ctx, tx, host.Device)
 		if err != nil {
 			return ctxerr.Wrap(ctx, err, "creating new Android device")
 		}
@@ -191,7 +187,7 @@ func (ds *Datastore) UpdateAndroidHost(ctx context.Context, host *fleet.AndroidH
 			}
 		}
 
-		err = ds.androidDS.UpdateDeviceTx(ctx, tx, host.Device)
+		err = ds.Datastore.UpdateDeviceTx(ctx, tx, host.Device)
 		if err != nil {
 			return ctxerr.Wrap(ctx, err, "update Android device")
 		}

--- a/server/datastore/mysql/android_test.go
+++ b/server/datastore/mysql/android_test.go
@@ -243,7 +243,7 @@ func testAndroidMDMStats(t *testing.T, ds *Datastore) {
 	require.Equal(t, serverURL, solutionsStats[0].ServerURL)
 
 	// turn MDM off for android
-	err = ds.androidDS.DeleteAllEnterprises(testCtx())
+	err = ds.DeleteAllEnterprises(testCtx())
 	require.NoError(t, err)
 	err = ds.BulkSetAndroidHostsUnenrolled(testCtx())
 	require.NoError(t, err)

--- a/server/datastore/mysql/mysql.go
+++ b/server/datastore/mysql/mysql.go
@@ -51,11 +51,11 @@ type Datastore struct {
 	replica fleet.DBReader // so it cannot be used to perform writes
 	primary *sqlx.DB
 
-	logger    log.Logger
-	clock     clock.Clock
-	config    config.MysqlConfig
-	pusher    nano_push.Pusher
-	androidDS android.Datastore
+	logger log.Logger
+	clock  clock.Clock
+	config config.MysqlConfig
+	pusher nano_push.Pusher
+	android.Datastore
 
 	// nil if no read replica
 	readReplicaConfig *config.MysqlConfig
@@ -259,7 +259,7 @@ func New(config config.MysqlConfig, c clock.Clock, opts ...DBOption) (*Datastore
 		stmtCache:           make(map[string]*sqlx.Stmt),
 		minLastOpenedAtDiff: options.MinLastOpenedAtDiff,
 		serverPrivateKey:    options.PrivateKey,
-		androidDS:           android_mysql.New(options.Logger, dbWriter, dbReader),
+		Datastore:           android_mysql.New(options.Logger, dbWriter, dbReader),
 	}
 
 	go ds.writeChanLoop()

--- a/server/fleet/datastore.go
+++ b/server/fleet/datastore.go
@@ -394,14 +394,6 @@ type Datastore interface {
 	OSVersion(ctx context.Context, osVersionID uint, teamFilter *TeamFilter) (*OSVersion, *time.Time, error)
 	UpdateOSVersions(ctx context.Context) error
 
-	// ////////////////////////////////////////////////////////////////////////////
-	// Android
-
-	GetAndroidDS() android.Datastore
-	NewAndroidHost(ctx context.Context, host *AndroidHost) (*AndroidHost, error)
-	UpdateAndroidHost(ctx context.Context, host *AndroidHost, fromEnroll bool) error
-	AndroidHostLite(ctx context.Context, enterpriseSpecificID string) (*AndroidHost, error)
-
 	///////////////////////////////////////////////////////////////////////////////
 	// TargetStore
 
@@ -1999,8 +1991,23 @@ type Datastore interface {
 	// /////////////////////////////////////////////////////////////////////////////
 	// Android
 
-	SetAndroidEnabledAndConfigured(ctx context.Context, configured bool) error
+	AndroidDatastore
+}
+
+type AndroidDatastore interface {
+	android.Datastore
+	AndroidHostLite(ctx context.Context, enterpriseSpecificID string) (*AndroidHost, error)
+	AppConfig(ctx context.Context) (*AppConfig, error)
 	BulkSetAndroidHostsUnenrolled(ctx context.Context) error
+	DeleteMDMConfigAssetsByName(ctx context.Context, assetNames []MDMAssetName) error
+	GetAllMDMConfigAssetsByName(ctx context.Context, assetNames []MDMAssetName,
+		queryerContext sqlx.QueryerContext) (map[MDMAssetName]MDMConfigAsset, error)
+	InsertOrReplaceMDMConfigAsset(ctx context.Context, asset MDMConfigAsset) error
+	NewAndroidHost(ctx context.Context, host *AndroidHost) (*AndroidHost, error)
+	SetAndroidEnabledAndConfigured(ctx context.Context, configured bool) error
+	UpdateAndroidHost(ctx context.Context, host *AndroidHost, fromEnroll bool) error
+	UserOrDeletedUserByID(ctx context.Context, id uint) (*User, error)
+	VerifyEnrollSecret(ctx context.Context, secret string) (*EnrollSecret, error)
 }
 
 // MDMAppleStore wraps nanomdm's storage and adds methods to deal with

--- a/server/mdm/android/service/pubsub.go
+++ b/server/mdm/android/service/pubsub.go
@@ -75,7 +75,7 @@ func (svc *Service) authenticatePubSub(ctx context.Context, token string) error 
 	//
 	// Note: We could also check that the device belongs to our enterprise, for additional security. We would need an Android cached_mysql for that.
 	// "name": "enterprises/LC044q09r2/devices/3dc9d72fbd517bbc",
-	assets, err := svc.fleetDS.GetAllMDMConfigAssetsByName(ctx, []fleet.MDMAssetName{fleet.MDMAssetAndroidPubSubToken}, nil)
+	assets, err := svc.ds.GetAllMDMConfigAssetsByName(ctx, []fleet.MDMAssetName{fleet.MDMAssetAndroidPubSubToken}, nil)
 	switch {
 	case fleet.IsNotFound(err):
 		return fleet.NewAuthFailedError("missing Android PubSub token in Fleet")
@@ -173,7 +173,7 @@ func (svc *Service) enrollHost(ctx context.Context, device *androidmanagement.De
 	if host != nil {
 		level.Debug(svc.logger).Log("msg", "The enrolling Android host is already present in Fleet. Updating team if needed",
 			"device.name", device.Name, "device.enterpriseSpecificId", device.HardwareInfo.EnterpriseSpecificId)
-		enrollSecret, err := svc.fleetDS.VerifyEnrollSecret(ctx, device.EnrollmentTokenData)
+		enrollSecret, err := svc.ds.VerifyEnrollSecret(ctx, device.EnrollmentTokenData)
 		if err != nil && !fleet.IsNotFound(err) {
 			return ctxerr.Wrap(ctx, err, "verifying enroll secret")
 		}
@@ -251,7 +251,7 @@ func (svc *Service) updateHost(ctx context.Context, device *androidmanagement.De
 	}
 	host.SetNodeKey(device.HardwareInfo.EnterpriseSpecificId)
 
-	err = svc.fleetDS.UpdateAndroidHost(ctx, host, fromEnroll)
+	err = svc.ds.UpdateAndroidHost(ctx, host, fromEnroll)
 	if err != nil {
 		return ctxerr.Wrap(ctx, err, "enrolling Android host")
 	}
@@ -259,7 +259,7 @@ func (svc *Service) updateHost(ctx context.Context, device *androidmanagement.De
 }
 
 func (svc *Service) addNewHost(ctx context.Context, device *androidmanagement.Device) error {
-	enrollSecret, err := svc.fleetDS.VerifyEnrollSecret(ctx, device.EnrollmentTokenData)
+	enrollSecret, err := svc.ds.VerifyEnrollSecret(ctx, device.EnrollmentTokenData)
 	if err != nil && !fleet.IsNotFound(err) {
 		return ctxerr.Wrap(ctx, err, "verifying enroll secret")
 	}
@@ -301,7 +301,7 @@ func (svc *Service) addNewHost(ctx context.Context, device *androidmanagement.De
 		host.Device.LastPolicySyncTime = ptr.Time(policySyncTime)
 	}
 	host.SetNodeKey(device.HardwareInfo.EnterpriseSpecificId)
-	_, err = svc.fleetDS.NewAndroidHost(ctx, host)
+	_, err = svc.ds.NewAndroidHost(ctx, host)
 	if err != nil {
 		return ctxerr.Wrap(ctx, err, "enrolling Android host")
 	}
@@ -314,7 +314,7 @@ func (svc *Service) getComputerName(device *androidmanagement.Device) string {
 }
 
 func (svc *Service) getHostIfPresent(ctx context.Context, enterpriseSpecificID string) (*fleet.AndroidHost, error) {
-	host, err := svc.fleetDS.AndroidHostLite(ctx, enterpriseSpecificID)
+	host, err := svc.ds.AndroidHostLite(ctx, enterpriseSpecificID)
 	switch {
 	case fleet.IsNotFound(err):
 		return nil, nil

--- a/server/mdm/android/tests/enterprise/enterprise_test.go
+++ b/server/mdm/android/tests/enterprise/enterprise_test.go
@@ -108,7 +108,7 @@ func (s *enterpriseTestSuite) TestEnterpriseSSE() {
 	assert.Equal(s.T(), service.SignupSSESuccess, string(data))
 
 	// Test with error
-	s.WithServer.FleetDS.AppConfigFunc = func(_ context.Context) (*fleet.AppConfig, error) {
+	s.WithServer.DS.AppConfigFunc = func(_ context.Context) (*fleet.AppConfig, error) {
 		return nil, assert.AnError
 	}
 	resp = s.Do("GET", "/api/v1/fleet/android_enterprise/signup_sse", nil, http.StatusOK)

--- a/server/mock/mockimpl/impl.go
+++ b/server/mock/mockimpl/impl.go
@@ -377,6 +377,17 @@ func main() {
 		fatal(err)
 	}
 
+	// Remove duplicates from fns
+	uniqueFns := make(map[string]Func, len(fns))
+	dedupedFns := make([]Func, 0, len(fns))
+	for _, fn := range fns {
+		if _, exists := uniqueFns[fn.Name]; !exists {
+			uniqueFns[fn.Name] = fn
+			dedupedFns = append(dedupedFns, fn)
+		}
+	}
+	fns = dedupedFns
+
 	src := genStubs(recv, fns)
 	recName := strings.SplitN(recv, " ", 2)
 	name := strings.TrimPrefix(recName[1], "*")


### PR DESCRIPTION
For #26219 

Refactoring the interface between Android service and Android datastore to use 1 common datastore interface: `fleet.AndroidDatastore`

These changes are based on feedback from the recent Backend Sync.

```mermaid
---
title: Partial class diagram
---
classDiagram
    direction LR
    class `android.Service`
    <<interface>> `android.Service`
    class `android/service.Service`
    `android/service.Service` ..|> `android.Service`: implements

    class `fleet.AndroidDatastore`
    <<interface>> `fleet.AndroidDatastore`
    class `fleet.Datastore`
    <<interface>> `fleet.Datastore`
    class `android.Datastore`
    <<interface>> `android.Datastore`
    `android/service.Service` *-- `fleet.AndroidDatastore`: USES (THIS IS THE KEY CHANGE)
    `fleet.Datastore` *-- `fleet.AndroidDatastore`: contains
    `mysql.Datastore` ..|> `fleet.Datastore`: implements
    `fleet.AndroidDatastore` *-- `android.Datastore`: contains
    `mysql.Datastore` *-- `android.Datastore`: contains
    `android/mysql.Datastore` ..|> `android.Datastore`: implements
```