### PR TITLE
Prevent GitOps mode tooltip on 'Cancel' button hover in  policies automations modals

### DIFF
--- a/frontend/pages/policies/ManagePoliciesPage/components/PoliciesPaginatedList/PoliciesPaginatedList.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/components/PoliciesPaginatedList/PoliciesPaginatedList.tsx
@@ -214,11 +214,11 @@ function PoliciesPaginatedList(
           {footer}
         </div>
       </div>
-      <GitOpsModeTooltipWrapper
-        position="right"
-        tipOffset={8}
-        renderChildren={(disableChildren) => (
-          <div className="modal-cta-wrap">
+      <div className="modal-cta-wrap">
+        <GitOpsModeTooltipWrapper
+          position="right"
+          tipOffset={8}
+          renderChildren={(disableChildren) => (
             <TooltipWrapper
               showArrow
               position="top"
@@ -237,12 +237,12 @@ function PoliciesPaginatedList(
                 Save
               </Button>
             </TooltipWrapper>
-            <Button onClick={onCancel} variant="inverse">
-              Cancel
-            </Button>
-          </div>
-        )}
-      />
+          )}
+        />
+        <Button onClick={onCancel} variant="inverse">
+          Cancel
+        </Button>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## For #26997 

<img width="1001" alt="Screenshot 2025-03-10 at 10 16 04 AM" src="https://github.com/user-attachments/assets/bf23a3b0-d5b9-4d3c-8df6-dc3ebcf93a6d" />

- [x] Manual QA for all new/changed functionality