### PR TITLE
Agent configuration reference docs

### DIFF
--- a/docs/Configuration/agent-configuration.md
+++ b/docs/Configuration/agent-configuration.md
@@ -56,21 +56,9 @@ To see a description for all available settings, first [enroll your host](https:
 osquery > SELECT name, default_value, value, description FROM osquery_flags; 
 ```
 
-> Running the interactive osquery shell loads a standalone instance of osquery, with a default configuration rather than the one set in agent options. If you'd like to verify that your hosts are running with the latest settings set in `options`, run the query as a live query through Fleet.
+Running the interactive osquery shell loads a standalone instance of osquery, with a default configuration rather than the one set in agent options. If you'd like to verify that your hosts are running with the latest settings set in `options`, run the query as a live query in Fleet.
 
-> If you revoked an old enroll secret, the `command_line_flags` won't update for hosts that enrolled to Fleet using this old enroll secret. This is because fleetd uses the enroll secret to receive new flags from Fleet. For these hosts, all existing features will work as expected.
-
-How to rotate enroll secrets:
-
-1. Check which hosts need a new enroll secret by running the following query: `SELECT * FROM orbit_info WHERE enrolled = false`.
-
-> The hosts that don't have Fleetd installed will return an error because the `orbit_info` table doesn't exist. You can safely ignore these errors.
-
-2. In Fleet, head to the Hosts page and select **Add hosts** to find the fleetctl package command with an active enroll secret.
-
-3. Copy and run the fleetctl package command to create a new package. Distribute this package to the hosts that returned results in step 1.
-
-4. Done!
+> If you revoke an old enroll secret, the `command_line_flags` won't update for hosts that enrolled to Fleet using this old enroll secret. This is because fleetd uses the enroll secret to receive new flags from Fleet. For these hosts, all existing features will work as expected.
 
 #### Advanced
 

--- a/docs/Contributing/fleetctl-apply.md
+++ b/docs/Contributing/fleetctl-apply.md
@@ -123,7 +123,7 @@ Another reason you might want to use multiple enroll secrets is to use a certain
 
 ### Rotating enroll secrets
 
-1. In Fleet, head to **Hosts > Manage enroll** secret and add a new secret.
+1. In Fleet, head to **Hosts > Manage enroll secret** and add a new secret.
 2. Create a fleetd agent with the new enroll secret and install it on hosts.
 3. Delete the old enroll secret.
 

--- a/docs/Contributing/fleetctl-apply.md
+++ b/docs/Contributing/fleetctl-apply.md
@@ -123,64 +123,9 @@ Another reason you might want to use multiple enroll secrets is to use a certain
 
 ### Rotating enroll secrets
 
-Rotating enroll secrets follows this process:
-
-1. Add a new secret.
-2. Transition existing clients to the new secret. Note that existing clients may not need to be
-   updated, as the enroll secret is not used by already enrolled clients.
-3. Remove the old secret.
-
-To do this with `fleetctl` (assuming the existing secret is `oldsecret` and the new secret is `newsecret`):
-
-Begin by retrieving the existing secret configuration:
-
-```sh
-$ fleetctl get enroll_secret
----
-apiVersion: v1
-kind: enroll_secret
-spec:
-  secrets:
-  - created_at: "2021-11-17T00:39:50Z"
-    secret: oldsecret
-```
-
-Apply the new configuration with both secrets:
-
-```sh
-$ echo '
----
-apiVersion: v1
-kind: enroll_secret
-spec:
-  secrets:
-  - created_at: "2021-11-17T00:39:50Z"
-    secret: oldsecret
-  - secret: newsecret
-' > secrets.yml
-$ fleetctl apply -f secrets.yml
-```
-
-Now transition clients to using only the new secret. When the transition is completed, remove the
-old secret:
-
-```sh
-$ echo '
----
-apiVersion: v1
-kind: enroll_secret
-spec:
-  secrets:
-  - secret: newsecret
-' > secrets.yml
-$ fleetctl apply -f secrets.yml
-```
-
-At this point, the old secret will no longer be accepted for new enrollments and the rotation is
-complete.
-
-A similar process may be followed for rotating team-specific enroll secrets. For teams, the secrets
-are managed in the team yaml.
+1. In Fleet, head to **Hosts > Manage enroll** secret and add a new secret.
+2. Create a fleetd agent with the new enroll secret and install it on hosts.
+3. Delete the old enroll secret.
 
 ## Teams
 


### PR DESCRIPTION
- Remove rotate enroll secret instructions because they're wrong: #25755
- Update contributor docs to simplify: #24309
