### PR TITLE
Log rather than erroring when MSRC feed delete fails

### DIFF
--- a/changes/25090-msrc-delete
+++ b/changes/25090-msrc-delete
@@ -1,0 +1,1 @@
+* Dropped log from error to debug when cleaning up an old MSRC file fails when downloading vulnerability information.

--- a/cmd/fleet/cron.go
+++ b/cmd/fleet/cron.go
@@ -303,7 +303,7 @@ func checkWinVulnerabilities(
 
 	if !config.DisableDataSync {
 		// Sync MSRC definitions
-		err = msrc.SyncFromGithub(ctx, vulnPath, os)
+		err = msrc.SyncFromGithub(ctx, vulnPath, os, logger)
 		if err != nil {
 			errHandler(ctx, logger, "updating msrc definitions", err)
 		}

--- a/cmd/fleetctl/vulnerability_data_stream.go
+++ b/cmd/fleetctl/vulnerability_data_stream.go
@@ -89,7 +89,7 @@ Downloads (if needed) the data streams that can be used by the Fleet server to p
 
 			log(c, "[-] Downloading MSRC artifacts...")
 			ctx := context.Background()
-			err = msrc.SyncFromGithub(ctx, dir, nil)
+			err = msrc.SyncFromGithub(ctx, dir, nil, klog.NewNopLogger())
 			if err != nil {
 				return fmt.Errorf("Error downloading MSRC artifacts: %v", err)
 			}

--- a/server/vulnerabilities/msrc/sync_test.go
+++ b/server/vulnerabilities/msrc/sync_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/fleetdm/fleet/v4/server/fleet"
 	"github.com/fleetdm/fleet/v4/server/vulnerabilities/io"
+	kitlog "github.com/go-kit/log"
 	"github.com/stretchr/testify/require"
 )
 
@@ -80,7 +81,7 @@ func TestSync(t *testing.T) {
 			LocalList: []io.MetadataFileName{newMetadataFile(t, "Windows_10-2022_09_10.json")},
 		}
 
-		err := sync(ctx, os, fsMock{TestData: &testData}, ghMock{TestData: &testData})
+		err := sync(ctx, os, fsMock{TestData: &testData}, ghMock{TestData: &testData}, kitlog.NewNopLogger())
 		require.NoError(t, err)
 		require.ElementsMatch(t, testData.RemoteDownloaded, []string{"http://somebulletin.com"})
 


### PR DESCRIPTION
For #25090.

Not 100% sure why we're seeing this issue but this will drop the error severity, and even if a delete fails and leaves a file we'll pick the correct (latest) MSRC file for each OS anyway, so this is low-risk.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/Committing-Changes.md#changes-files) for more information.
- [ ] Added/updated automated tests
- [ ] A detailed QA plan exists on the associated ticket (if it isn't there, work with the product group's QA engineer to add it)
- [ ] Manual QA for all new/changed functionality