### PR TITLE
Remove `GET /api/v1/fleet/vpp` (deprecated and not working)

### DIFF
--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -6532,31 +6532,6 @@ None.
 ]
 ```
 
-### Get Volume Purchasing Program (VPP)
-
-
-> **Experimental feature**. This feature is undergoing rapid improvement, which may result in breaking changes to the API or configuration surface. It is not recommended for use in automated workflows.
-
-_Available in Fleet Premium_
-
-`GET /api/v1/fleet/vpp`
-
-#### Example
-
-`GET /api/v1/fleet/vpp`
-
-##### Default response
-
-`Status: 200`
-
-```json
-{
-  "org_name": "Acme Inc.",
-  "renew_date": "2023-11-29T00:00:00Z",
-  "location": "Acme Inc. Main Address"
-}
-```
-
 ---
 
 ## Policies


### PR DESCRIPTION
I found that `GET /api/v1/fleet/vpp` isn't working, but is still documented. I believe we moved to new endpoint to manage VPP tokens: `GET /api/v1/fleet/vpp_tokens`
