### PR TITLE
Fix deadlock: reduce number rows deleted at per iter, add retry

### DIFF
--- a/changes/27002-cron-cleanup-deadlock
+++ b/changes/27002-cron-cleanup-deadlock
@@ -1,1 +1,1 @@
-- Added retry on deadlock when deleting thousands of expired queries
+- Split up expired query deletion to avoid deadlocks in zero-trust flows

--- a/changes/27002-cron-cleanup-deadlock
+++ b/changes/27002-cron-cleanup-deadlock
@@ -1,0 +1,1 @@
+- Added retry on deadlock when deleting thousands of expired queries

--- a/server/datastore/mysql/activities.go
+++ b/server/datastore/mysql/activities.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"slices"
 	"strings"
 	"time"
 
@@ -16,7 +17,7 @@ import (
 )
 
 var automationActivityAuthor = "Fleet"
-var deleteUnsavedQueriesBatchSize = 1000
+var deleteIDsBatchSize = 1000
 
 // NewActivity stores an activity item that the user performed
 func (ds *Datastore) NewActivity(
@@ -571,68 +572,113 @@ func (ds *Datastore) CleanupActivitiesAndAssociatedData(ctx context.Context, max
 		}
 	}
 
-	//
 	// `activities` and `queries` are not tied because the activity itself holds
 	// the query SQL so they don't need to be executed on the same transaction.
 	//
 	// All expired live queries are deleted in batch sizes of
-	// `deleteUnsavedQueriesBatchSize` to ensure the table size is kept in check
+	// `deleteIDsBatchSize` to ensure the table size is kept in check
 	// with high volumes of live queries (zero-trust workflows). This differs
 	// from the `activities` cleanup which uses maxCount as a limit to the
 	// number of activities to delete.
-	//
-	for {
-		if ctx.Err() != nil {
-			return ctx.Err()
-		}
 
-		var rowsAffected int64
+	const selectUnsavedQueryIDs = `
+		SELECT id
+		FROM queries
+		WHERE NOT saved
+		AND created_at < DATE_SUB(NOW(), INTERVAL ? DAY)
+		ORDER BY id`
+	var allUnsavedQueryIDs []uint
 
-		// Start a new transaction for each batch of deletions.
-		err := ds.withRetryTxx(ctx, func(tx sqlx.ExtContext) error {
-			// Delete expired live queries (aka "not saved")
-			result, err := tx.ExecContext(ctx,
-				`DELETE FROM queries
-			WHERE NOT saved AND created_at < DATE_SUB(NOW(), INTERVAL ? DAY)
-			LIMIT ?`,
-				expiredWindowDays, deleteUnsavedQueriesBatchSize,
-			)
+	if err := sqlx.SelectContext(ctx, ds.reader(ctx), &allUnsavedQueryIDs, selectUnsavedQueryIDs, expiredWindowDays); err != nil {
+		return ctxerr.Wrap(ctx, err, "selecting expired unsaved query IDs")
+	}
+
+	unsavedQueryIter := slices.Chunk(allUnsavedQueryIDs, deleteIDsBatchSize)
+
+	for unsavedQueryIDs := range unsavedQueryIter {
+		if err := ds.withRetryTxx(ctx, func(tx sqlx.ExtContext) error {
+			const deleteStmt = `DELETE FROM queries WHERE id IN (?)`
+			deleteQuery, args, err := sqlx.In(deleteStmt, unsavedQueryIDs)
 			if err != nil {
-				return ctxerr.Wrap(ctx, err, "delete expired non-saved queries")
+				return err
 			}
-
-			rowsAffected, err = result.RowsAffected()
-			if err != nil {
-				return ctxerr.Wrap(ctx, err, "retrieving rows affected from delete query")
-			}
-
-			// Cleanup orphaned distributed campaigns that reference non-existing queries.
-			if _, err := tx.ExecContext(ctx,
-				`DELETE distributed_query_campaigns FROM distributed_query_campaigns
-			LEFT JOIN queries ON (distributed_query_campaigns.query_id=queries.id)
-			WHERE queries.id IS NULL`,
-			); err != nil {
-				return ctxerr.Wrap(ctx, err, "delete expired orphaned distributed_query_campaigns")
-			}
-
-			// Cleanup orphaned distributed campaign targets that reference non-existing distributed campaigns.
-			if _, err := tx.ExecContext(ctx,
-				`DELETE distributed_query_campaign_targets FROM distributed_query_campaign_targets
-			LEFT JOIN distributed_query_campaigns ON (distributed_query_campaign_targets.distributed_query_campaign_id=distributed_query_campaigns.id)
-			WHERE distributed_query_campaigns.id IS NULL`,
-			); err != nil {
-				return ctxerr.Wrap(ctx, err, "delete expired orphaned distributed_query_campaign_targets")
+			if _, err := tx.ExecContext(ctx, deleteQuery, args...); err != nil {
+				return err
 			}
 
 			return nil
-		})
-		if err != nil {
-			return ctxerr.Wrap(ctx, err, "delete expired queries in batch")
+		}); err != nil {
+			return ctxerr.Wrap(ctx, err, "deleting expired unsaved queries")
 		}
+	}
 
-		// Break the loop if no rows were deleted in the current batch.
-		if rowsAffected == 0 {
-			break
+	// Cleanup orphaned distributed campaigns that reference non-existing queries.
+	const selectCampaignIDs = `
+		SELECT id
+		FROM distributed_query_campaigns dqc
+		WHERE NOT EXISTS (
+			SELECT 1
+			FROM queries q
+			WHERE q.id = dqc.query_id
+		)
+		ORDER BY id`
+	var allCampaignIDs []uint
+
+	if err := sqlx.SelectContext(ctx, ds.reader(ctx), &allCampaignIDs, selectCampaignIDs); err != nil {
+		return ctxerr.Wrap(ctx, err, "selecting expired distributed query campaigns")
+	}
+
+	campaignIter := slices.Chunk(allCampaignIDs, deleteIDsBatchSize)
+
+	for campaignIDs := range campaignIter {
+		if err := ds.withRetryTxx(ctx, func(tx sqlx.ExtContext) error {
+			const deleteStmt = `DELETE FROM distributed_query_campaigns WHERE id IN (?)`
+			deleteQuery, args, err := sqlx.In(deleteStmt, campaignIDs)
+			if err != nil {
+				return err
+			}
+			if _, err := tx.ExecContext(ctx, deleteQuery, args...); err != nil {
+				return err
+			}
+
+			return nil
+		}); err != nil {
+			return ctxerr.Wrap(ctx, err, "deleting expired distributed query campaigns")
+		}
+	}
+
+	// Cleanup orphaned distributed campaign targets that reference non-existing distributed campaigns.
+	const selectCampaignTargets = `
+		SELECT id
+		FROM distributed_query_campaign_targets dqct
+		WHERE NOT EXISTS (
+			SELECT 1
+			FROM distributed_query_campaigns dqc
+			WHERE dqc.id = dqct.distributed_query_campaign_id
+		)
+		ORDER BY id`
+	var allCampaignTargetIDs []uint
+
+	if err := sqlx.SelectContext(ctx, ds.reader(ctx), &allCampaignTargetIDs, selectCampaignTargets); err != nil {
+		return ctxerr.Wrap(ctx, err, "selecting expired distributed query campaign targets")
+	}
+
+	campaignTargetIter := slices.Chunk(allCampaignTargetIDs, deleteIDsBatchSize)
+
+	for campaignTargetIDs := range campaignTargetIter {
+		if err := ds.withRetryTxx(ctx, func(tx sqlx.ExtContext) error {
+			const deleteStmt = `DELETE FROM distributed_query_campaigns WHERE id IN (?)`
+			deleteQuery, args, err := sqlx.In(deleteStmt, campaignTargetIDs)
+			if err != nil {
+				return err
+			}
+			if _, err := tx.ExecContext(ctx, deleteQuery, args...); err != nil {
+				return err
+			}
+
+			return nil
+		}); err != nil {
+			return ctxerr.Wrap(ctx, err, "deleting expired distributed query campaign targets")
 		}
 	}
 

--- a/server/datastore/mysql/activities.go
+++ b/server/datastore/mysql/activities.go
@@ -667,7 +667,7 @@ func (ds *Datastore) CleanupActivitiesAndAssociatedData(ctx context.Context, max
 
 	for campaignTargetIDs := range campaignTargetIter {
 		if err := ds.withRetryTxx(ctx, func(tx sqlx.ExtContext) error {
-			const deleteStmt = `DELETE FROM distributed_query_campaigns WHERE id IN (?)`
+			const deleteStmt = `DELETE FROM distributed_query_campaign_targets WHERE id IN (?)`
 			deleteQuery, args, err := sqlx.In(deleteStmt, campaignTargetIDs)
 			if err != nil {
 				return err

--- a/server/datastore/mysql/activities.go
+++ b/server/datastore/mysql/activities.go
@@ -599,14 +599,11 @@ func (ds *Datastore) CleanupActivitiesAndAssociatedData(ctx context.Context, max
 		const deleteStmt = `DELETE FROM queries WHERE id IN (?)`
 		deleteQuery, args, err := sqlx.In(deleteStmt, unsavedQueryIDs)
 		if err != nil {
-			return err
+			return ctxerr.Wrap(ctx, err, "creating query to delete unsaved queries")
 		}
 		if _, err := ds.writer(ctx).ExecContext(ctx, deleteQuery, args...); err != nil {
 			return ctxerr.Wrap(ctx, err, "deleting expired unsaved queries")
 		}
-
-		return nil
-
 	}
 
 	// Cleanup orphaned distributed campaigns that reference non-existing queries.
@@ -636,8 +633,6 @@ func (ds *Datastore) CleanupActivitiesAndAssociatedData(ctx context.Context, max
 		if _, err := ds.writer(ctx).ExecContext(ctx, deleteQuery, args...); err != nil {
 			return ctxerr.Wrap(ctx, err, "deleting expired distributed query campaigns")
 		}
-
-		return nil
 	}
 
 	// Cleanup orphaned distributed campaign targets that reference non-existing distributed campaigns.
@@ -662,13 +657,11 @@ func (ds *Datastore) CleanupActivitiesAndAssociatedData(ctx context.Context, max
 		const deleteStmt = `DELETE FROM distributed_query_campaign_targets WHERE id IN (?)`
 		deleteQuery, args, err := sqlx.In(deleteStmt, campaignTargetIDs)
 		if err != nil {
-			return err
+			return ctxerr.Wrap(ctx, err, "creating query to delete expired query campaign targets")
 		}
 		if _, err := ds.writer(ctx).ExecContext(ctx, deleteQuery, args...); err != nil {
 			return ctxerr.Wrap(ctx, err, "deleting expired distributed query campaign targets")
 		}
-
-		return nil
 	}
 
 	return nil


### PR DESCRIPTION
#27002

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/Committing-Changes.md#changes-files) for more information.
- [x] A detailed QA plan exists on the associated ticket (if it isn't there, work with the product group's QA engineer to add it)
  - Make sure cron completes successfully with thousands of unsaved expired queries
- [x] Manual QA for all new/changed functionality
