### PR TITLE
Add stale issues workflow

### DIFF
--- a/.github/workflows/close-stale-eng-initiated-issues.yml
+++ b/.github/workflows/close-stale-eng-initiated-issues.yml
@@ -5,9 +5,8 @@ name: Close stale eng-initiated issues
 
 on:
   schedule:
-    # Daily at 8pm CDT (1am UTC) -- run during off-hours to prevent hitting GitHub API rate limit
-    - cron: "0 1 * * *"
-  pull_request: # TODO: remove
+    # Daily at 8:10pm CDT (1:10am UTC) -- run during off-hours to prevent hitting GitHub API rate limit
+    - cron: "10 1 * * *"
   workflow_dispatch: # Manual
 
 # This allows a subsequently queued workflow run to interrupt previous runs
@@ -37,7 +36,7 @@ jobs:
         uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639 # v9.1.0
         with:
           only-issue-labels: "~engineering-initiated" # comma separated labels that must ALL be present
-          days-before-issue-stale: 1000
+          days-before-issue-stale: 365
           days-before-issue-close: 14
           stale-issue-label: "stale"
           stale-issue-message: "This issue is stale because it has been open for 365 days with no activity. Please update the issue if it is still relevant."
@@ -45,5 +44,5 @@ jobs:
           days-before-pr-stale: -1 # Stale PRs not checked
           days-before-pr-close: -1
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          debug-only: false # TODO: remove
+          debug-only: false
           operations-per-run: 200 # This number has to be high enough to capture all the recent issues we want to process

--- a/.github/workflows/close-stale-eng-initiated-issues.yml
+++ b/.github/workflows/close-stale-eng-initiated-issues.yml
@@ -36,8 +36,7 @@ jobs:
       - name: Close issues
         uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639 # v9.1.0
         with:
-          only-issue-labels:
-            - "~engineering-initiated"
+          only-issue-labels: ["~engineering-initiated"]
           days-before-issue-stale: 365
           days-before-issue-close: 14
           stale-issue-label: "stale"

--- a/.github/workflows/close-stale-eng-initiated-issues.yml
+++ b/.github/workflows/close-stale-eng-initiated-issues.yml
@@ -7,8 +7,7 @@ on:
   schedule:
     # Daily at 1pm CDT (6pm UTC)
     - cron: "0 18 * * *"
-  pull_request:
-  push:
+  pull_request: # TODO: remove
   workflow_dispatch: # Manual
 
 # This allows a subsequently queued workflow run to interrupt previous runs
@@ -33,7 +32,7 @@ jobs:
         uses: step-security/harden-runner@63c24ba6bd7ba022e95695ff85de572c04a18142 # v2.7.0
         with:
           egress-policy: audit
-      - close-issues:
+      - name: Close issues
         uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639 # v9.1.0
         with:
           only-issue-labels:

--- a/.github/workflows/close-stale-eng-initiated-issues.yml
+++ b/.github/workflows/close-stale-eng-initiated-issues.yml
@@ -8,6 +8,8 @@ on:
     # Daily at 1pm CDT (6pm UTC)
     - cron: "0 18 * * *"
   pull_request:
+  push:
+  workflow_dispatch: # Manual
 
 # This allows a subsequently queued workflow run to interrupt previous runs
 concurrency:

--- a/.github/workflows/close-stale-eng-initiated-issues.yml
+++ b/.github/workflows/close-stale-eng-initiated-issues.yml
@@ -37,7 +37,7 @@ jobs:
         uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639 # v9.1.0
         with:
           only-issue-labels: "~engineering-initiated" # comma separated labels that must ALL be present
-          days-before-issue-stale: 600
+          days-before-issue-stale: 1000
           days-before-issue-close: 14
           stale-issue-label: "stale"
           stale-issue-message: "This issue is stale because it has been open for 365 days with no activity. Please update the issue if it is still relevant."
@@ -45,5 +45,5 @@ jobs:
           days-before-pr-stale: -1 # Stale PRs not checked
           days-before-pr-close: -1
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          debug-only: true # TODO: remove
-          operations-per-run: 100 # This number has to be high enough to capture all the recent issues we want to process
+          debug-only: false # TODO: remove
+          operations-per-run: 200 # This number has to be high enough to capture all the recent issues we want to process

--- a/.github/workflows/close-stale-eng-initiated-issues.yml
+++ b/.github/workflows/close-stale-eng-initiated-issues.yml
@@ -25,6 +25,7 @@ permissions:
 
 jobs:
   close-stale-issues:
+    runs-on: ubuntu-latest
     permissions:
       issues: write
     steps:

--- a/.github/workflows/close-stale-eng-initiated-issues.yml
+++ b/.github/workflows/close-stale-eng-initiated-issues.yml
@@ -5,8 +5,8 @@ name: Close stale eng-initiated issues
 
 on:
   schedule:
-    # Daily at 1pm CDT (6pm UTC)
-    - cron: "0 18 * * *"
+    # Daily at 8pm CDT (1am UTC) -- run during off-hours to prevent hitting GitHub API rate limit
+    - cron: "0 1 * * *"
   pull_request: # TODO: remove
   workflow_dispatch: # Manual
 
@@ -45,4 +45,5 @@ jobs:
           days-before-pr-stale: -1 # Stale PRs not checked
           days-before-pr-close: -1
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          debug-only: true
+          debug-only: true # TODO: remove
+          operations-per-run: 1000

--- a/.github/workflows/close-stale-eng-initiated-issues.yml
+++ b/.github/workflows/close-stale-eng-initiated-issues.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Close issues
         uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639 # v9.1.0
         with:
-          only-issue-labels: ["~engineering-initiated"]
+          only-issue-labels: "~engineering-initiated" # comma separated labels that must ALL be present
           days-before-issue-stale: 365
           days-before-issue-close: 14
           stale-issue-label: "stale"

--- a/.github/workflows/close-stale-eng-initiated-issues.yml
+++ b/.github/workflows/close-stale-eng-initiated-issues.yml
@@ -1,0 +1,47 @@
+name: Close stale eng-initiated issues
+
+# This action will mark old engineering-initiated issues as stale.
+# If stale issues don't have activity after 14 days, they will be closed.
+
+on:
+  schedule:
+    # Daily at 1pm CDT (6pm UTC)
+    - cron: "0 18 * * *"
+  pull_request:
+
+# This allows a subsequently queued workflow run to interrupt previous runs
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id}}
+  cancel-in-progress: true
+
+defaults:
+  run:
+    # fail-fast using bash -eo pipefail. See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#exit-codes-and-error-action-preference
+    shell: bash
+
+permissions:
+  contents: read
+
+jobs:
+  close-stale-issues:
+    permissions:
+      issues: write
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@63c24ba6bd7ba022e95695ff85de572c04a18142 # v2.7.0
+        with:
+          egress-policy: audit
+      - close-issues:
+        uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639 # v9.1.0
+        with:
+          only-issue-labels:
+            - "~engineering-initiated"
+          days-before-issue-stale: 365
+          days-before-issue-close: 14
+          stale-issue-label: "stale"
+          stale-issue-message: "This issue is stale because it has been open for 365 days with no activity. Please update the issue if it is still relevant."
+          close-issue-message: "This issue was closed because it has been inactive for 14 days since being marked as stale."
+          days-before-pr-stale: -1 # Stale PRs not checked
+          days-before-pr-close: -1
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          debug-only: true

--- a/.github/workflows/close-stale-eng-initiated-issues.yml
+++ b/.github/workflows/close-stale-eng-initiated-issues.yml
@@ -37,7 +37,7 @@ jobs:
         uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639 # v9.1.0
         with:
           only-issue-labels: "~engineering-initiated" # comma separated labels that must ALL be present
-          days-before-issue-stale: 365
+          days-before-issue-stale: 600
           days-before-issue-close: 14
           stale-issue-label: "stale"
           stale-issue-message: "This issue is stale because it has been open for 365 days with no activity. Please update the issue if it is still relevant."
@@ -46,4 +46,4 @@ jobs:
           days-before-pr-close: -1
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           debug-only: true # TODO: remove
-          operations-per-run: 1000
+          operations-per-run: 100 # This number has to be high enough to capture all the recent issues we want to process


### PR DESCRIPTION
Add stale issues workflow which:
- marks `~engineering-initiated` issues with `stale` label and comment if they had no activity in the last 365 days (we have ~74 such issues right now)
- closes `stale` issues after 14 days with no activity

Examples of "recent" stale issues:
- https://github.com/fleetdm/fleet/issues/13984
- https://github.com/fleetdm/fleet/issues/15571
- https://github.com/fleetdm/fleet/issues/16117
- https://github.com/fleetdm/fleet/issues/16352

Here's an example issue with a `stale` label. I ran the workflow and marked 27 issues as `stale` that had no activity for 1000 days.
- https://github.com/fleetdm/fleet/issues/4631
