### PR TITLE
Dedupe MSRC downloads/deletes when enrolled hosts include multiple builds of the same version of Windows

### DIFF
--- a/changes/25090-msrc-dedupe
+++ b/changes/25090-msrc-dedupe
@@ -1,0 +1,1 @@
+* Removed duplicate download/delete attempts for MSRC bulletins when hosts are enrolled spanning multiple builds of the same version of Windows

--- a/server/vulnerabilities/msrc/sync_test.go
+++ b/server/vulnerabilities/msrc/sync_test.go
@@ -104,6 +104,12 @@ func TestSync(t *testing.T) {
 					Arch:          "64-bit",
 					KernelVersion: "10.0.19044",
 				},
+				{ // multiple versions of the same OS map to one file, should only be downloaded/deleted once
+					Name:          "Microsoft Windows 10 Pro",
+					Version:       "10.0.19045",
+					Arch:          "64-bit",
+					KernelVersion: "10.0.19045",
+				},
 			}
 			t.Run("without remote bulletins", func(t *testing.T) {
 				var remote []io.MetadataFileName


### PR DESCRIPTION
For #25090.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/Committing-Changes.md#changes-files) for more information.
- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [x] Added/updated automated tests
- [x] A detailed QA plan exists on the associated ticket (if it isn't there, work with the product group's QA engineer to add it)
- [x] Manual QA for all new/changed functionality