### PR TITLE
Batched getPoliciesBySoftwareTitleIDs

### DIFF
--- a/changes/26753-batch-software-titles
+++ b/changes/26753-batch-software-titles
@@ -1,0 +1,1 @@
+* Fixed an error when requesting /fleet/software/titles endpoint unpaginated with > 33k software titles by batching the policies by software title id query

--- a/server/datastore/mysql/policies.go
+++ b/server/datastore/mysql/policies.go
@@ -1832,23 +1832,7 @@ func (ds *Datastore) getPoliciesBySoftwareTitleIDs(
 		tmID = *teamID
 	}
 
-	// // https://dev.mysql.com/doc/refman/8.4/en/packet-too-large.html
-	// maxAllowedPacket := 16 * 1024 * 1024 // 16MB / 16,777,216 bytes
-	// maxPlaceholders := 65535             // mysql max placeholders
-	// var x uint
-	// sizePerPlaceholder := int(unsafe.Sizeof(x)) // 64 bits / 8 bytes for unsigned integers
-	// placeholdersPerID := 2
-
-	// // Calculate the size of the base query
-	// baseQuerySize := len(baseQuery) // 397
-
-	// // maximum number of IDs that can fit into a single query given maxAllowedPacket size
-	// maxBatchSizeQuerySize := (maxAllowedPacket - baseQuerySize) / ((sizePerPlaceholder * placeholdersPerID) + 8) // 8 for the team ID = 699034
-	// // maximum number of IDs that can fit into a single query given maxPlaceholders
-	// maxBatchSizePlaceholders := (maxPlaceholders / placeholdersPerID) - 1 // -1 for the team ID = 32766
-	// batchSize := min(maxBatchSizePlaceholders, maxBatchSizeQuerySize)     // 32766
-
-	batchSize := 32766
+	batchSize := 32000 // see https://github.com/fleetdm/fleet/issues/26753 on the math behind this number
 	var policies []fleet.AutomaticInstallPolicy
 	err := common_mysql.BatchProcessSimple(softwareTitleIDs, batchSize, func(softwareTitleIDsToProcess []uint) error {
 		query, args, err := sqlx.In(baseQuery, softwareTitleIDsToProcess, softwareTitleIDsToProcess, tmID)

--- a/server/datastore/mysql/policies_test.go
+++ b/server/datastore/mysql/policies_test.go
@@ -5695,6 +5695,17 @@ func testPoliciesBySoftwareTitleID(t *testing.T, ds *Datastore) {
 		require.Equal(t, expected[got.ID], got)
 	}
 
+	// performance test for 50_000 title ids, ensure batching works
+	megaTitleIDs := make([]uint, 0, 50_000)
+	megaTitleIDs = append(megaTitleIDs, *installer3.TitleID)
+	for i := uint(10); i < (50_010 - 2); i++ {
+		megaTitleIDs = append(megaTitleIDs, *installer4.TitleID+i)
+	}
+	megaTitleIDs = append(megaTitleIDs, *installer4.TitleID)
+	policies, err = ds.getPoliciesBySoftwareTitleIDs(ctx, megaTitleIDs, nil)
+	require.NoError(t, err)
+	require.Len(t, policies, 2)
+
 	// "No team" titles should not have any policies when filtering by team 1
 	policies, err = ds.getPoliciesBySoftwareTitleIDs(ctx, []uint{*installer3.TitleID, *installer4.TitleID}, ptr.Uint(1))
 	require.NoError(t, err)

--- a/server/datastore/mysql/policies_test.go
+++ b/server/datastore/mysql/policies_test.go
@@ -5698,8 +5698,8 @@ func testPoliciesBySoftwareTitleID(t *testing.T, ds *Datastore) {
 	// performance test for 50_000 title ids, ensure batching works
 	megaTitleIDs := make([]uint, 0, 50_000)
 	megaTitleIDs = append(megaTitleIDs, *installer3.TitleID)
-	for i := uint(10); i < (50_010 - 2); i++ {
-		megaTitleIDs = append(megaTitleIDs, *installer4.TitleID+i)
+	for i := uint(0); i < (50_000 - 2); i++ {
+		megaTitleIDs = append(megaTitleIDs, *installer4.TitleID+i+1)
 	}
 	megaTitleIDs = append(megaTitleIDs, *installer4.TitleID)
 	policies, err = ds.getPoliciesBySoftwareTitleIDs(ctx, megaTitleIDs, nil)


### PR DESCRIPTION
Mysql has a max of 65535 placeholders in a sql statement. When > 33k title ids are passed to `getPoliciesBySoftwareTitleIDs` this causes a `Prepared statement contains too many placeholders` error. Fixed this by splitting up the query into multiple queries and aggregating the results in memory.

https://github.com/fleetdm/fleet/issues/26753

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/Committing-Changes.md#changes-files) for more information.
- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [x] Added/updated automated tests
- [x] A detailed QA plan exists on the associated ticket (if it isn't there, work with the product group's QA engineer to add it)
- [x] Manual QA for all new/changed functionality