### PR TITLE
pad macOS versions with an extra 0 during CPE generations so that we can match vulncheck versions

### DIFF
--- a/changes/26561-macos-false-positive
+++ b/changes/26561-macos-false-positive
@@ -1,0 +1,1 @@
+- Fixed a false positive on macOS 15.3 by making sure we match the version format reported by Vulncheck.

--- a/server/vulnerabilities/nvd/cve.go
+++ b/server/vulnerabilities/nvd/cve.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"runtime"
+	"strings"
 	"sync"
 	"time"
 
@@ -355,6 +356,13 @@ func GetMacOSCPEs(ctx context.Context, ds fleet.Datastore) ([]osCPEWithNVDMeta, 
 
 	for _, os := range oses {
 		for _, variant := range macosVariants {
+			versionParts := strings.Split(os.Version, ".")
+			if len(versionParts) == 2 {
+				// Vulncheck reports versions with all 3 parts, so pad with an extra 0 if we only
+				// have 2 parts (15.3 -> 15.3.0)
+				versionParts = append(versionParts, "0")
+				os.Version = strings.Join(versionParts, ".")
+			}
 			cpe := osCPEWithNVDMeta{
 				OperatingSystem: os,
 				meta: &wfn.Attributes{

--- a/server/vulnerabilities/nvd/cve_test.go
+++ b/server/vulnerabilities/nvd/cve_test.go
@@ -535,6 +535,7 @@ func TestTranslateCPEToCVE(t *testing.T) {
 		version      string
 		osID         uint
 		includedCVEs []string
+		excludedCVEs []string
 	}{
 		{
 			platform: "darwin",
@@ -600,6 +601,13 @@ func TestTranslateCPEToCVE(t *testing.T) {
 				"CVE-2023-32396",
 				"CVE-2023-29497",
 			},
+		},
+		{
+			platform: "darwin",
+			version:  "15.3",
+			osID:     3,
+			// This was resolved in 15.3, so it should be excluded. See https://github.com/fleetdm/fleet/issues/26561.
+			excludedCVEs: []string{"CVE-2025-24176"},
 		},
 	}
 
@@ -699,6 +707,9 @@ func TestTranslateCPEToCVE(t *testing.T) {
 		for _, tc := range cveOSTests {
 			for _, cve := range tc.includedCVEs {
 				require.Contains(t, osCVEsFound[tc.osID], cve)
+			}
+			for _, cve := range tc.excludedCVEs {
+				require.NotContains(t, osCVEsFound[tc.osID], cve)
 			}
 		}
 	})


### PR DESCRIPTION
> For #26561

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/Committing-Changes.md#changes-files) for more information.
- [x] Added/updated automated tests
- [x] A detailed QA plan exists on the associated ticket (if it isn't there, work with the product group's QA engineer to add it)
- [x] Manual QA for all new/changed functionality
