### PR TITLE
Clarify engineering-initiated story process

### DIFF
--- a/handbook/engineering/README.md
+++ b/handbook/engineering/README.md
@@ -57,7 +57,7 @@ It's important to frame engineering-initiated user stories the same way we frame
 
 The engineering output and architecture DRI reviews and triages engineering-initiated stories weekly on the [Engineering board](https://app.zenhub.com/workspaces/engineering-672a4556609a0d000f391584/board) and selects stories to prioritize for drafting by adding the `:product` label, placing it in the "Ready" column, and assigning to the engineer listed as the product designer. 
 
-1. The assigned engineer is responsible for completing the user story drafting process by completing the specs and [defining done]([url](https://fleetdm.com/handbook/company/product-groups#defining-done)). TMove the issue into "In progress" on the drafting board and populate all TODOs in the issue description, define implementation details, and draft the first version of the test plan.
+1. The assigned engineer is responsible for completing the user story drafting process by completing the specs and [defining done]([url](https://fleetdm.com/handbook/company/product-groups#defining-done)). Move the issue into "In progress" on the drafting board and populate all TODOs in the issue description, define implementation details, and draft the first version of the test plan.
 
 2. When all sections have been populated, move it to the "User story review" column on the drafting board and assign to your EM. The EM will bring the story to [weekly user story review]([url](https://fleetdm.com/handbook/company/product-groups#user-story-reviews)), and then to estimation before prioritizing into an upcoming sprint. 
 

--- a/handbook/engineering/README.md
+++ b/handbook/engineering/README.md
@@ -38,17 +38,28 @@ We write [guides](https://fleetdm.com/guides) for all new features. Feature guid
 
 Engineering-initiated stories are types of user stories created by engineers to make technical changes to Fleet. Technical changes should improve the user experience or contributor experience. For example, optimizing SQL that improves the response time of an API endpoint improves user experience by reducing latency. A script that generates common boilerplate, or automated tests to cover important business logic, improves the quality of life for contributors, making them happier and more productive, resulting in faster delivery of features to our customers.
 
-It is important to frame engineering-initiated user stories the same way we frame all user stories. Stay focused on how this technical change will drive value for our users.
+It's important to frame engineering-initiated user stories the same way we frame all user stories. Stay focused on how this technical change will drive value for our users.
 
-To [create an engineering-initiated user story](https://fleetdm.com/handbook/engineering#creating-an-engineering-initiated-story), follow the [user story drafting process](https://fleetdm.com/handbook/company/development-groups#drafting). Once your user story is created using the [new story template](https://github.com/fleetdm/fleet/issues/new?assignees=lukeheath&labels=story,~engineering-initiated&projects=&template=story.md&title=), make sure the `~engineering-initiated` label is added, the `:product` label is removed, and the engineering output and architecture DRI (@lukeheath) is assigned. 
+1. Create a new engineering-initiated story using the [new story template](https://github.com/fleetdm/fleet/issues/new?assignees=lukeheath&labels=story,~engineering-initiated&projects=&template=story.md&title=). Make sure the `~engineering-initiated` label is added, the `:product` label is removed, and the engineering output and architecture DRI (@lukeheath) is assigned.
 
-What happens next? The engineering output and architecture DRI reviews and triages engineering-initiated stories weekly on the [engineering board](https://app.zenhub.com/workspaces/engineering-672a4556609a0d000f391584/board). 
+2. If the user story contributes to an OKR, explain how in the "Key result" section. If not, explain what key result we can measure to determine if this story is successful.
 
-If there are product changes (i.e. interface, documentation, or dependency changes), leave the default labels in place so that it is triaged on the product [drafting board](https://app.zenhub.com/workspaces/drafting-6192dd66ea2562000faea25c/board).
+3. Set yourself as the product designer for the user story if another engineer is not DRI. By default, the engineer creating the engineering-initiated story is DRI for the story and will design and implement it.
 
-If there are no product changes, and the DRI decides to prioritize the story, the story is added to the "Specified" column on the drafting board so that it can be estimated.
+4. Remove the "Product" section and checklist from the issue description. 
+
+5. Create the issue. The new user story will be automatically placed in the "New Requests" column of the [engineering ZenHub board](https://app.zenhub.com/workspaces/engineering-672a4556609a0d000f391584/board). If you feel the issue is urgent, tag your EM or the engineering output and architecture DRI (@lukeheath) in a comment.
 
 > We prefer the term engineering-initiated stories over technical debt because the user story format helps keep us focused on our users and contributors.
+
+
+### Draft an engineering-initiated story
+
+The engineering output and architecture DRI reviews and triages engineering-initiated stories weekly on the [Engineering board](https://app.zenhub.com/workspaces/engineering-672a4556609a0d000f391584/board) and selects stories to prioritize for drafting by adding the `:product` label, placing it in the "Ready" column, and assigning to the engineer listed as the product designer. 
+
+1. The assigned engineer is responsible for completing the user story drafting process by completing the specs and [defining done]([url](https://fleetdm.com/handbook/company/product-groups#defining-done)). TMove the issue into "In progress" on the drafting board and populate all TODOs in the issue description, define implementation details, and draft the first version of the test plan.
+
+2. When all sections have been populated, move it to the "User story review" column on the drafting board and assign to your EM. The EM will bring the story to [weekly user story review]([url](https://fleetdm.com/handbook/company/product-groups#user-story-reviews)), and then to estimation before prioritizing into an upcoming sprint. 
 
 
 ### Fix a bug


### PR DESCRIPTION
Clarifying that there are two processes. The first is creating the engineering-initiated story and sending it to the engineering board for review.

If the story is prioritized for drafting, the second process kicks in, which is the engineer drafting the changes and bringing through the drafting board to user story review.