### PR TITLE
Cherry-pick: Fix unreleased bug when parsing distinguished name from host certificates

### DIFF
--- a/server/fleet/host_certificates.go
+++ b/server/fleet/host_certificates.go
@@ -189,11 +189,6 @@ type MDMAppleErrorChainItem struct {
 func ExtractDetailsFromOsqueryDistinguishedName(str string) (*HostCertificateNameDetails, error) {
 	str = strings.TrimSpace(str)
 	str = strings.Trim(str, "/")
-
-	if !strings.Contains(str, "/") {
-		return nil, errors.New("invalid format, wrong separator")
-	}
-
 	parts := strings.Split(str, "/")
 
 	var details HostCertificateNameDetails

--- a/server/fleet/host_certificates_test.go
+++ b/server/fleet/host_certificates_test.go
@@ -90,6 +90,31 @@ func TestExtractHostCertificateNameDetails(t *testing.T) {
 			input:    "/C=US/O=Fleet Device Management Inc./OU=Fleet Device Management Inc./CN=FleetDM/",
 			expected: &expected,
 		},
+		{
+			name:  "simple common name",
+			input: "/CN=FleetDM",
+			expected: &HostCertificateNameDetails{
+				Country:            "",
+				Organization:       "",
+				OrganizationalUnit: "",
+				CommonName:         "FleetDM",
+			},
+		},
+		{
+			name:  "simple common name with no leading slash",
+			input: "CN=FleetDM",
+			expected: &HostCertificateNameDetails{
+				Country:            "",
+				Organization:       "",
+				OrganizationalUnit: "",
+				CommonName:         "FleetDM",
+			},
+		},
+		{
+			name:  "invalid separator",
+			input: "/C=US,O=Fleet Device Management Inc.,OU=Fleet Device Management Inc.,CN=FleetDM",
+			err:   true,
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
Cherry-pick #27070 

- [x] For unreleased bug fixes in a release candidate, confirmed that the fix is not expected to adversely impact load test results or alerted the release DRI if additional load testing is needed.
