### PR TITLE
add and delete digicert

### DIFF
--- a/frontend/interfaces/config.ts
+++ b/frontend/interfaces/config.ts
@@ -169,10 +169,6 @@ export interface IConfig {
     disable_data_sync: boolean;
     recent_vulnerability_max_age: number;
   };
-  // Note: `vulnerability_settings` is deprecated and should not be used
-  // vulnerability_settings: {
-  //   databases_path: string;
-  // };
   webhook_settings: IWebhookSettings;
   integrations: IGlobalIntegrations;
   logging: {

--- a/frontend/interfaces/integration.ts
+++ b/frontend/interfaces/integration.ts
@@ -41,6 +41,8 @@ export interface ICertificatesIntegrationCustomSCEP {
   challenge: string;
 }
 
+export type ICertificateAuthorityType = "ndes" | "digicert" | "custom";
+
 /** all the types of certificate integrations */
 export type ICertificateIntegration =
   | ICertificatesIntegrationNDES

--- a/frontend/interfaces/integration.ts
+++ b/frontend/interfaces/integration.ts
@@ -25,7 +25,6 @@ export interface ICertificatesIntegrationNDES {
 }
 
 export interface ICertificatesIntegrationDigicert {
-  id: number;
   name: string;
   url: string;
   api_token: string;

--- a/frontend/interfaces/integration.ts
+++ b/frontend/interfaces/integration.ts
@@ -41,6 +41,12 @@ export interface ICertificatesIntegrationCustomSCEP {
   challenge: string;
 }
 
+/** all the types of certificate integrations */
+export type ICertificateIntegration =
+  | ICertificatesIntegrationNDES
+  | ICertificatesIntegrationDigicert
+  | ICertificatesIntegrationCustomSCEP;
+
 export interface IIntegration {
   url: string;
   username?: string;

--- a/frontend/interfaces/integration.ts
+++ b/frontend/interfaces/integration.ts
@@ -27,6 +27,7 @@ export interface ICertificatesIntegrationNDES {
 export interface ICertificatesIntegrationDigicert {
   id: number;
   name: string;
+  url: string;
   api_token: string;
   profile_id: string;
   certificate_common_name: string;
@@ -37,7 +38,7 @@ export interface ICertificatesIntegrationDigicert {
 export interface ICertificatesIntegrationCustomSCEP {
   id: number;
   name: string;
-  server_url: string;
+  url: string;
   challenge: string;
 }
 

--- a/frontend/pages/admin/IntegrationsPage/IntegrationNavItems.tsx
+++ b/frontend/pages/admin/IntegrationsPage/IntegrationNavItems.tsx
@@ -34,12 +34,12 @@ const integrationSettingsNavItems: ISideNavItem<any>[] = [
     Card: ChangeManagement,
   },
   // TODO: digicert update: add this back when the feature is ready
-  // {
-  //   title: "Certificates",
-  //   urlSection: "certificate-authorities",
-  //   path: PATHS.ADMIN_INTEGRATIONS_CERTIFICATE_AUTHORITIES,
-  //   Card: CertificateAuthorities,
-  // },
+  {
+    title: "Certificates",
+    urlSection: "certificate-authorities",
+    path: PATHS.ADMIN_INTEGRATIONS_CERTIFICATE_AUTHORITIES,
+    Card: CertificateAuthorities,
+  },
 ];
 
 export default integrationSettingsNavItems;

--- a/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/CertificateAuthorities.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/CertificateAuthorities.tsx
@@ -3,6 +3,7 @@ import { Link } from "react-router";
 
 import paths from "router/paths";
 import { AppContext } from "context/app";
+import { ICertificateIntegration } from "interfaces/integration";
 import createMockConfig from "__mocks__/configMock";
 
 import SectionHeader from "components/SectionHeader";
@@ -12,9 +13,10 @@ import CertificateAuthorityList from "./components/CertificateAuthorityList";
 import {
   generateListData,
   getCertificateAuthority,
-  ICertAuthority,
+  ICertAuthorityListData,
 } from "./helpers";
 import AddCertAuthorityCard from "./components/AddCertAuthorityCard";
+import DeleteCertificateAuthorityModal from "./components/DeleteCertificateAuthorityModal";
 
 const baseClass = "certificate-authorities";
 
@@ -70,6 +72,11 @@ const CertificateAuthorities = () => {
     setShowDeleteCertAuthorityModal,
   ] = useState(false);
 
+  const [
+    selectedCertAuthority,
+    setSelectedCertAuthority,
+  ] = useState<ICertificateIntegration | null>(null);
+
   const certificateAuthorities = useMemo(() => {
     if (!config) return [];
     return generateListData(
@@ -83,26 +90,27 @@ const CertificateAuthorities = () => {
     setShowAddCertAuthorityModal(true);
   };
 
-  const onEditCertAuthority = (cert: ICertAuthority) => {
+  const onEditCertAuthority = (cert: ICertAuthorityListData) => {
     // TODO: use useCallback
-    const ca = getCertificateAuthority(
+    const certAuthority = getCertificateAuthority(
       cert.id,
       config?.integrations.ndes_scep_proxy,
       config?.integrations.digicert,
       config?.integrations.custom_scep_proxy
     );
-    console.log(ca);
+    setSelectedCertAuthority(certAuthority);
     setShowEditCertAuthorityModal(true);
   };
 
-  const onDeleteCertAuthority = (cert: ICertAuthority) => {
+  const onDeleteCertAuthority = (cert: ICertAuthorityListData) => {
     // TODO: use useCallback
-    getCertificateAuthority(
+    const certAuthority = getCertificateAuthority(
       cert.id,
       config?.integrations.ndes_scep_proxy,
       config?.integrations.digicert,
       config?.integrations.custom_scep_proxy
     );
+    setSelectedCertAuthority(certAuthority);
     setShowDeleteCertAuthorityModal(true);
   };
 
@@ -140,7 +148,12 @@ const CertificateAuthorities = () => {
       {renderContent()}
       {showAddCertAuthorityModal && <div>Modal showing</div>}
       {showEditCertAuthorityModal && <div>Modal showing</div>}
-      {showDeleteCertAuthoirtyModal && <div>Modal showing</div>}
+      {showDeleteCertAuthoirtyModal && selectedCertAuthority && (
+        <DeleteCertificateAuthorityModal
+          certAuthority={selectedCertAuthority}
+          onExit={() => setShowDeleteCertAuthorityModal(false)}
+        />
+      )}
     </div>
   );
 };

--- a/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/CertificateAuthorities.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/CertificateAuthorities.tsx
@@ -22,45 +22,7 @@ import AddCertAuthorityModal from "./components/AddCertAuthorityModal";
 const baseClass = "certificate-authorities";
 
 const CertificateAuthorities = () => {
-  let { config } = useContext(AppContext);
-  config = createMockConfig({
-    integrations: {
-      zendesk: [],
-      jira: [],
-      digicert: [
-        {
-          name: "DigiCert CA",
-          id: 1,
-          api_token: "123456",
-          profile_id: "7ed77396-9186-4bfa-9fa7-63dddc46b8a3",
-          certificate_common_name:
-            "$FLEET_VAR_HOST_HARDWARE_SERIAL@example.com",
-          certificate_user_principal_names: ["$FLEET_VAR_HOST_HARDWARE_SERIAL"],
-          certificate_seat_id: "$FLEET_VAR_HOST_HARDWARE_SERIAL@example.com",
-        },
-      ],
-      ndes_scep_proxy: {
-        url: "https://ndes.scep.com",
-        admin_url: "https://ndes.scep.com/admin",
-        username: "ndes",
-        password: "password",
-      },
-      custom_scep_proxy: [
-        {
-          id: 1,
-          name: "Custom SCEP Proxy",
-          server_url: "https://custom.scep.com",
-          challenge: "challenge",
-        },
-        {
-          id: 2,
-          name: "Custom SCEP Proxy 2",
-          server_url: "https://custom.scep2.com",
-          challenge: "challenge-2",
-        },
-      ],
-    },
-  });
+  const { config } = useContext(AppContext);
 
   const [showAddCertAuthorityModal, setShowAddCertAuthorityModal] = useState(
     false

--- a/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/CertificateAuthorities.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/CertificateAuthorities.tsx
@@ -17,6 +17,7 @@ import {
 } from "./helpers";
 import AddCertAuthorityCard from "./components/AddCertAuthorityCard";
 import DeleteCertificateAuthorityModal from "./components/DeleteCertificateAuthorityModal";
+import AddCertAuthorityModal from "./components/AddCertAuthorityModal";
 
 const baseClass = "certificate-authorities";
 
@@ -151,7 +152,11 @@ const CertificateAuthorities = () => {
         />
       </p>
       {renderContent()}
-      {showAddCertAuthorityModal && <div>Modal showing</div>}
+      {showAddCertAuthorityModal && (
+        <AddCertAuthorityModal
+          onExit={() => setShowAddCertAuthorityModal(false)}
+        />
+      )}
       {showEditCertAuthorityModal && <div>Modal showing</div>}
       {showDeleteCertAuthoirtyModal &&
         selectedCertAuthority &&

--- a/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/CertificateAuthorities.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/CertificateAuthorities.tsx
@@ -72,6 +72,9 @@ const CertificateAuthorities = () => {
     setShowDeleteCertAuthorityModal,
   ] = useState(false);
 
+  const [selectedListItemId, setSelectedListItemId] = useState<string | null>(
+    null
+  );
   const [
     selectedCertAuthority,
     setSelectedCertAuthority,
@@ -98,6 +101,7 @@ const CertificateAuthorities = () => {
       config?.integrations.digicert,
       config?.integrations.custom_scep_proxy
     );
+    setSelectedListItemId(cert.id);
     setSelectedCertAuthority(certAuthority);
     setShowEditCertAuthorityModal(true);
   };
@@ -110,6 +114,7 @@ const CertificateAuthorities = () => {
       config?.integrations.digicert,
       config?.integrations.custom_scep_proxy
     );
+    setSelectedListItemId(cert.id);
     setSelectedCertAuthority(certAuthority);
     setShowDeleteCertAuthorityModal(true);
   };
@@ -148,12 +153,15 @@ const CertificateAuthorities = () => {
       {renderContent()}
       {showAddCertAuthorityModal && <div>Modal showing</div>}
       {showEditCertAuthorityModal && <div>Modal showing</div>}
-      {showDeleteCertAuthoirtyModal && selectedCertAuthority && (
-        <DeleteCertificateAuthorityModal
-          certAuthority={selectedCertAuthority}
-          onExit={() => setShowDeleteCertAuthorityModal(false)}
-        />
-      )}
+      {showDeleteCertAuthoirtyModal &&
+        selectedCertAuthority &&
+        selectedListItemId && (
+          <DeleteCertificateAuthorityModal
+            listItemId={selectedListItemId}
+            certAuthority={selectedCertAuthority}
+            onExit={() => setShowDeleteCertAuthorityModal(false)}
+          />
+        )}
     </div>
   );
 };

--- a/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/CertificateAuthorities.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/CertificateAuthorities.tsx
@@ -4,7 +4,6 @@ import { Link } from "react-router";
 import paths from "router/paths";
 import { AppContext } from "context/app";
 import { ICertificateIntegration } from "interfaces/integration";
-import createMockConfig from "__mocks__/configMock";
 
 import SectionHeader from "components/SectionHeader";
 import CustomLink from "components/CustomLink";

--- a/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/AddCertAuthorityModal/AddCertAuthorityModal.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/AddCertAuthorityModal/AddCertAuthorityModal.tsx
@@ -3,6 +3,7 @@ import React, { useContext, useState } from "react";
 import { NotificationContext } from "context/notification";
 import certificatesAPI from "services/entities/certificates";
 import { ICertificateAuthorityType } from "interfaces/integration";
+import { AppContext } from "context/app";
 
 // @ts-ignore
 import Dropdown from "components/forms/fields/Dropdown";
@@ -20,6 +21,7 @@ interface IAddCertAuthorityModalProps {
 }
 
 const AddCertAuthorityModal = ({ onExit }: IAddCertAuthorityModalProps) => {
+  const { setConfig } = useContext(AppContext);
   const { renderFlash } = useContext(NotificationContext);
   const [
     certAuthorityType,
@@ -51,12 +53,15 @@ const AddCertAuthorityModal = ({ onExit }: IAddCertAuthorityModalProps) => {
     const addPatchData = generateAddPatchData(formData);
     setIsAdding(true);
     try {
-      await certificatesAPI.addCertificateAuthority(addPatchData);
+      const newConfig = await certificatesAPI.addCertificateAuthority(
+        addPatchData
+      );
       renderFlash("success", "Successfully added your certificate authority.");
+      onExit();
+      setConfig(newConfig);
     } catch (e) {
       renderFlash("error", generateErrorMessage(e));
     }
-    onExit();
     setIsAdding(false);
   };
 

--- a/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/AddCertAuthorityModal/AddCertAuthorityModal.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/AddCertAuthorityModal/AddCertAuthorityModal.tsx
@@ -1,6 +1,5 @@
 import React, { useContext, useState } from "react";
 
-import Button from "components/buttons/Button";
 import Modal from "components/Modal";
 import { NotificationContext } from "context/notification";
 import DigicertForm from "../DigicertForm";
@@ -21,7 +20,7 @@ const AddCertAuthorityModal = ({ onExit }: IAddCertAuthorityModalProps) => {
     apiToken: "",
     profileId: "",
     commonName: "",
-    userPrincipalNames: "",
+    userPrincipalName: "",
     certificateSeatId: "",
   });
 

--- a/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/AddCertAuthorityModal/AddCertAuthorityModal.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/AddCertAuthorityModal/AddCertAuthorityModal.tsx
@@ -1,9 +1,13 @@
 import React, { useContext, useState } from "react";
 
-import Modal from "components/Modal";
 import { NotificationContext } from "context/notification";
+import certificatesAPI from "services/entities/certificates";
+
+import Modal from "components/Modal";
 import DigicertForm from "../DigicertForm";
 import { IDigicertFormData } from "../DigicertForm/DigicertForm";
+import { useCertAuthorityDataGenerator } from "../DeleteCertificateAuthorityModal/helpers";
+import { generateErrorMessage } from "./helpers";
 
 const baseClass = "add-cert-authority-modal";
 
@@ -12,6 +16,8 @@ interface IAddCertAuthorityModalProps {
 }
 
 const AddCertAuthorityModal = ({ onExit }: IAddCertAuthorityModalProps) => {
+  const { generateAddPatchData } = useCertAuthorityDataGenerator("digicert");
+
   const { renderFlash } = useContext(NotificationContext);
   const [isUpdating, setIsUpdating] = useState(false);
   const [formData, setFormData] = useState<IDigicertFormData>({
@@ -29,11 +35,15 @@ const AddCertAuthorityModal = ({ onExit }: IAddCertAuthorityModalProps) => {
   };
 
   const onAddCertAuthority = async () => {
+    const addPatchData = generateAddPatchData(formData);
+    console.log(addPatchData);
+
     setIsUpdating(true);
     try {
+      await certificatesAPI.addCertificateAuthority(addPatchData);
       renderFlash("success", "Successfully added your certificate authority.");
     } catch (e) {
-      renderFlash("error", "test");
+      renderFlash("error", generateErrorMessage(e));
     }
     setIsUpdating(false);
   };
@@ -45,15 +55,13 @@ const AddCertAuthorityModal = ({ onExit }: IAddCertAuthorityModalProps) => {
       width="large"
       onExit={onExit}
     >
-      <>
-        <DigicertForm
-          formData={formData}
-          submitBtnText="Add CA"
-          onChange={onChange}
-          onSubmit={onAddCertAuthority}
-          onCancel={onExit}
-        />
-      </>
+      <DigicertForm
+        formData={formData}
+        submitBtnText="Add CA"
+        onChange={onChange}
+        onSubmit={onAddCertAuthority}
+        onCancel={onExit}
+      />
     </Modal>
   );
 };

--- a/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/AddCertAuthorityModal/AddCertAuthorityModal.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/AddCertAuthorityModal/AddCertAuthorityModal.tsx
@@ -1,0 +1,50 @@
+import React, { useContext, useState } from "react";
+
+import Button from "components/buttons/Button";
+import Modal from "components/Modal";
+import { NotificationContext } from "context/notification";
+
+const baseClass = "add-cert-authority-modal";
+
+interface IAddCertAuthorityModalProps {
+  onExit: () => void;
+}
+
+const AddCertAuthorityModal = ({ onExit }: IAddCertAuthorityModalProps) => {
+  const { renderFlash } = useContext(NotificationContext);
+  const [isUpdating, setIsUpdating] = useState(false);
+
+  const onAddCertAuthority = async () => {
+    setIsUpdating(true);
+    try {
+      renderFlash("success", "Successfully added your certificate authority.");
+    } catch (e) {
+      renderFlash("error", "test");
+    }
+  };
+
+  return (
+    <Modal
+      className={baseClass}
+      title="Add certificate authority (CA)"
+      onExit={onExit}
+    >
+      <>
+        <div className="modal-cta-wrap">
+          <Button
+            onClick={onAddCertAuthority}
+            isLoading={isUpdating}
+            disabled={isUpdating}
+          >
+            Add CA
+          </Button>
+          <Button variant="text-link" onClick={onExit}>
+            Cancel
+          </Button>
+        </div>
+      </>
+    </Modal>
+  );
+};
+
+export default AddCertAuthorityModal;

--- a/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/AddCertAuthorityModal/AddCertAuthorityModal.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/AddCertAuthorityModal/AddCertAuthorityModal.tsx
@@ -4,6 +4,7 @@ import Button from "components/buttons/Button";
 import Modal from "components/Modal";
 import { NotificationContext } from "context/notification";
 import DigicertForm from "../DigicertForm";
+import { IDigicertFormData } from "../DigicertForm/DigicertForm";
 
 const baseClass = "add-cert-authority-modal";
 
@@ -14,6 +15,19 @@ interface IAddCertAuthorityModalProps {
 const AddCertAuthorityModal = ({ onExit }: IAddCertAuthorityModalProps) => {
   const { renderFlash } = useContext(NotificationContext);
   const [isUpdating, setIsUpdating] = useState(false);
+  const [formData, setFormData] = useState<IDigicertFormData>({
+    name: "",
+    url: "https://one.digicert.com",
+    apiToken: "",
+    profileId: "",
+    commonName: "",
+    userPrincipalNames: "",
+    certificateSeatId: "",
+  });
+
+  const onChange = (update: { name: string; value: string }) => {
+    setFormData({ ...formData, [update.name]: update.value });
+  };
 
   const onAddCertAuthority = async () => {
     setIsUpdating(true);
@@ -34,7 +48,9 @@ const AddCertAuthorityModal = ({ onExit }: IAddCertAuthorityModalProps) => {
     >
       <>
         <DigicertForm
+          formData={formData}
           submitBtnText="Add CA"
+          onChange={onChange}
           onSubmit={onAddCertAuthority}
           onCancel={onExit}
         />

--- a/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/AddCertAuthorityModal/AddCertAuthorityModal.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/AddCertAuthorityModal/AddCertAuthorityModal.tsx
@@ -3,6 +3,7 @@ import React, { useContext, useState } from "react";
 import Button from "components/buttons/Button";
 import Modal from "components/Modal";
 import { NotificationContext } from "context/notification";
+import DigicertForm from "../DigicertForm";
 
 const baseClass = "add-cert-authority-modal";
 
@@ -21,27 +22,22 @@ const AddCertAuthorityModal = ({ onExit }: IAddCertAuthorityModalProps) => {
     } catch (e) {
       renderFlash("error", "test");
     }
+    setIsUpdating(false);
   };
 
   return (
     <Modal
       className={baseClass}
       title="Add certificate authority (CA)"
+      width="large"
       onExit={onExit}
     >
       <>
-        <div className="modal-cta-wrap">
-          <Button
-            onClick={onAddCertAuthority}
-            isLoading={isUpdating}
-            disabled={isUpdating}
-          >
-            Add CA
-          </Button>
-          <Button variant="text-link" onClick={onExit}>
-            Cancel
-          </Button>
-        </div>
+        <DigicertForm
+          submitBtnText="Add CA"
+          onSubmit={onAddCertAuthority}
+          onCancel={onExit}
+        />
       </>
     </Modal>
   );

--- a/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/AddCertAuthorityModal/_styles.scss
+++ b/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/AddCertAuthorityModal/_styles.scss
@@ -1,3 +1,6 @@
 .add-cert-authority-modal {
 
+  &__cert-authority-dropdown {
+    margin-bottom: $pad-large;
+  }
 }

--- a/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/AddCertAuthorityModal/_styles.scss
+++ b/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/AddCertAuthorityModal/_styles.scss
@@ -1,0 +1,3 @@
+.add-cert-authority-modal {
+
+}

--- a/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/AddCertAuthorityModal/helpers.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/AddCertAuthorityModal/helpers.tsx
@@ -1,0 +1,7 @@
+const DEFAULT_ERROR_MESSAGE =
+  "Couldn't add certificate authority. Please try again.";
+
+// eslint-disable-next-line import/prefer-default-export
+export const generateErrorMessage = (e: unknown) => {
+  return DEFAULT_ERROR_MESSAGE;
+};

--- a/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/AddCertAuthorityModal/index.ts
+++ b/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/AddCertAuthorityModal/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./AddCertAuthorityModal";

--- a/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/CertAuthorityListItem/CertAuthorityListItem.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/CertAuthorityListItem/CertAuthorityListItem.tsx
@@ -60,7 +60,7 @@ const CertAuthorityListItem = ({
 }: ICertAuthorityListItemProps) => {
   return (
     <ListItem
-      className={`${baseClass}__list-item`}
+      className={baseClass}
       graphic="file-certificate"
       title={cert.name}
       details={cert.name}

--- a/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/CertAuthorityListItem/CertAuthorityListItem.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/CertAuthorityListItem/CertAuthorityListItem.tsx
@@ -5,7 +5,7 @@ import GitOpsModeTooltipWrapper from "components/GitOpsModeTooltipWrapper";
 import Button from "components/buttons/Button";
 import Icon from "components/Icon";
 
-import { ICertAuthority } from "../../helpers";
+import { ICertAuthorityListData } from "../../helpers";
 
 const baseClass = "cert-authority-list-item";
 
@@ -48,7 +48,7 @@ const Actions = ({ onEdit, onDelete }: IActionsProps) => {
 };
 
 interface ICertAuthorityListItemProps {
-  cert: ICertAuthority;
+  cert: ICertAuthorityListData;
   onClickEdit: () => void;
   onClickDelete: () => void;
 }

--- a/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/CertAuthorityListItem/CertAuthorityListItem.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/CertAuthorityListItem/CertAuthorityListItem.tsx
@@ -17,7 +17,7 @@ interface IActionsProps {
 const Actions = ({ onEdit, onDelete }: IActionsProps) => {
   return (
     <>
-      <GitOpsModeTooltipWrapper
+      {/* <GitOpsModeTooltipWrapper
         position="left"
         renderChildren={(disableChildren) => (
           <Button
@@ -29,7 +29,7 @@ const Actions = ({ onEdit, onDelete }: IActionsProps) => {
             <Icon name="pencil" color="ui-fleet-black-75" />
           </Button>
         )}
-      />
+      /> */}
       <GitOpsModeTooltipWrapper
         position="left"
         renderChildren={(disableChildren) => (

--- a/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/CertificateAuthorityList/CertificateAuthorityList.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/CertificateAuthorityList/CertificateAuthorityList.tsx
@@ -4,15 +4,15 @@ import UploadList from "pages/ManageControlsPage/components/UploadList";
 
 import CertAuthorityListHeader from "../CertAuthorityListHeader";
 import CertAuthorityListItem from "../CertAuthorityListItem";
-import { ICertAuthority } from "../../helpers";
+import { ICertAuthorityListData } from "../../helpers";
 
 const baseClass = "certificate-authority-list";
 
 interface ICertificateAuthorityListProps {
-  certAuthorities: ICertAuthority[];
+  certAuthorities: ICertAuthorityListData[];
   onAddCertAuthority: () => void;
-  onClickEdit: (cert: ICertAuthority) => void;
-  onClickDelete: (cert: ICertAuthority) => void;
+  onClickEdit: (cert: ICertAuthorityListData) => void;
+  onClickDelete: (cert: ICertAuthorityListData) => void;
 }
 
 const CertificateAuthorityList = ({
@@ -22,7 +22,7 @@ const CertificateAuthorityList = ({
   onClickDelete,
 }: ICertificateAuthorityListProps) => {
   return (
-    <UploadList<ICertAuthority>
+    <UploadList<ICertAuthorityListData>
       className={baseClass}
       keyAttribute="name"
       listItems={certAuthorities}

--- a/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/CertificateAuthorityList/_styles.scss
+++ b/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/CertificateAuthorityList/_styles.scss
@@ -1,3 +1,11 @@
 .certificate-authority-list {
+  .list-item__actions {
+    display: none;
+  }
 
+  &:hover {
+    .list-item__actions {
+      display: flex;
+    }
+  }
 }

--- a/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/DeleteCertificateAuthorityModal/DeleteCertificateAuthorityModal.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/DeleteCertificateAuthorityModal/DeleteCertificateAuthorityModal.tsx
@@ -1,0 +1,47 @@
+import React from "react";
+
+import { ICertificateIntegration } from "interfaces/integration";
+
+import Button from "components/buttons/Button";
+import Modal from "components/Modal";
+
+const baseClass = "delete-certificate-authority-modal";
+
+interface IDeleteCertificateAuthorityModalProps {
+  certAuthority: ICertificateIntegration;
+  onExit: () => void;
+}
+
+const DeleteCertificateAuthorityModal = ({
+  certAuthority,
+  onExit,
+}: IDeleteCertificateAuthorityModalProps) => {
+  const onDeleteCertAuthority = () => {
+    console.log("Delete certificate authority", certAuthority);
+  };
+
+  return (
+    <Modal
+      className={baseClass}
+      title="Delete certificate authority (CA)"
+      onExit={onExit}
+    >
+      <>
+        <p>
+          Fleet won&apos;t remove certificates from the certificate authority (
+          <b>SCEP_WIFI</b>) on existing hosts.
+        </p>
+        <div className="modal-cta-wrap">
+          <Button variant="alert" onClick={onDeleteCertAuthority}>
+            Delete
+          </Button>
+          <Button variant="inverse-alert" onClick={onExit}>
+            Cancel
+          </Button>
+        </div>
+      </>
+    </Modal>
+  );
+};
+
+export default DeleteCertificateAuthorityModal;

--- a/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/DeleteCertificateAuthorityModal/DeleteCertificateAuthorityModal.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/DeleteCertificateAuthorityModal/DeleteCertificateAuthorityModal.tsx
@@ -6,6 +6,7 @@ import {
 } from "interfaces/integration";
 import certificatesAPI from "services/entities/certificates";
 import { NotificationContext } from "context/notification";
+import { AppContext } from "context/app";
 
 import Button from "components/buttons/Button";
 import Modal from "components/Modal";
@@ -36,19 +37,21 @@ const DeleteCertificateAuthorityModal = ({
     certAuthorityType,
     certAuthority
   );
+  const { setConfig } = useContext(AppContext);
   const { renderFlash } = useContext(NotificationContext);
   const [isUpdating, setIsUpdating] = useState(false);
 
   const onDeleteCertAuthority = async () => {
     setIsUpdating(true);
     try {
-      await certificatesAPI.deleteCertificateAuthority(
+      const newConfig = await certificatesAPI.deleteCertificateAuthority(
         generateDeletePatchData()
       );
       renderFlash(
         "success",
         "Successfully deleted your certificate authority."
       );
+      setConfig(newConfig);
     } catch (e) {
       renderFlash(
         "error",

--- a/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/DeleteCertificateAuthorityModal/DeleteCertificateAuthorityModal.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/DeleteCertificateAuthorityModal/DeleteCertificateAuthorityModal.tsx
@@ -1,24 +1,68 @@
-import React from "react";
+import React, { useContext, useState } from "react";
 
-import { ICertificateIntegration } from "interfaces/integration";
+import {
+  ICertificateAuthorityType,
+  ICertificateIntegration,
+} from "interfaces/integration";
+import certificatesAPI from "services/entities/certificates";
+import { NotificationContext } from "context/notification";
 
 import Button from "components/buttons/Button";
 import Modal from "components/Modal";
 
+import {
+  generateCertAuthorityDisplayName,
+  useCertAuthorityDataGenerator,
+} from "./helpers";
+
 const baseClass = "delete-certificate-authority-modal";
 
 interface IDeleteCertificateAuthorityModalProps {
+  listItemId: string;
   certAuthority: ICertificateIntegration;
   onExit: () => void;
 }
 
 const DeleteCertificateAuthorityModal = ({
+  listItemId,
   certAuthority,
   onExit,
 }: IDeleteCertificateAuthorityModalProps) => {
-  const onDeleteCertAuthority = () => {
-    console.log("Delete certificate authority", certAuthority);
+  const certAuthorityType = listItemId.split(
+    "-"
+  )[0] as ICertificateAuthorityType;
+
+  const { generateDeletePatchData } = useCertAuthorityDataGenerator(
+    certAuthorityType,
+    certAuthority
+  );
+  const { renderFlash } = useContext(NotificationContext);
+  const [isUpdating, setIsUpdating] = useState(false);
+
+  const onDeleteCertAuthority = async () => {
+    setIsUpdating(true);
+    try {
+      await certificatesAPI.deleteCertificateAuthority(
+        generateDeletePatchData()
+      );
+      renderFlash(
+        "success",
+        "Successfully deleted your certificate authority."
+      );
+    } catch (e) {
+      renderFlash(
+        "error",
+        "Couldn't delete certificate authority. Please try again."
+      );
+    }
+    setIsUpdating(false);
+    onExit();
   };
+
+  const certAuthorityName = generateCertAuthorityDisplayName(
+    certAuthorityType,
+    certAuthority
+  );
 
   return (
     <Modal
@@ -29,10 +73,15 @@ const DeleteCertificateAuthorityModal = ({
       <>
         <p>
           Fleet won&apos;t remove certificates from the certificate authority (
-          <b>SCEP_WIFI</b>) on existing hosts.
+          <b>{certAuthorityName}</b>) on existing hosts.
         </p>
         <div className="modal-cta-wrap">
-          <Button variant="alert" onClick={onDeleteCertAuthority}>
+          <Button
+            variant="alert"
+            onClick={onDeleteCertAuthority}
+            isLoading={isUpdating}
+            disabled={isUpdating}
+          >
             Delete
           </Button>
           <Button variant="inverse-alert" onClick={onExit}>

--- a/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/DeleteCertificateAuthorityModal/_styles.scss
+++ b/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/DeleteCertificateAuthorityModal/_styles.scss
@@ -1,0 +1,3 @@
+.delete-certificate-authority-modal {
+
+}

--- a/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/DeleteCertificateAuthorityModal/helpers.ts
+++ b/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/DeleteCertificateAuthorityModal/helpers.ts
@@ -69,7 +69,7 @@ export const useCertAuthorityDataGenerator = (
         data.integrations.digicert = config.integrations.digicert?.filter(
           (cert) => {
             return (
-              (certAuthority as ICertificatesIntegrationDigicert).name ===
+              (certAuthority as ICertificatesIntegrationDigicert).name !==
               cert.name
             );
           }

--- a/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/DeleteCertificateAuthorityModal/helpers.ts
+++ b/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/DeleteCertificateAuthorityModal/helpers.ts
@@ -8,12 +8,46 @@ import {
   IGlobalIntegrations,
 } from "interfaces/integration";
 import { useContext } from "react";
+import { IDigicertFormData } from "../DigicertForm/DigicertForm";
 
 export const useCertAuthorityDataGenerator = (
   certAuthorityType: ICertificateAuthorityType,
-  certAuthority: ICertificateIntegration
+  certAuthority?: ICertificateIntegration
 ) => {
   const { config } = useContext(AppContext);
+
+  const generateAddPatchData = (formData: IDigicertFormData) => {
+    if (!config) return null;
+
+    const data: { integrations: Partial<IGlobalIntegrations> } = {
+      integrations: {},
+    };
+
+    switch (certAuthorityType) {
+      case "ndes":
+        break;
+      case "digicert":
+        data.integrations.digicert = [
+          ...(config.integrations.digicert || []),
+          {
+            name: formData.name,
+            url: formData.url,
+            api_token: formData.apiToken,
+            profile_id: formData.profileId,
+            certificate_common_name: formData.commonName,
+            certificate_user_principal_names: [formData.userPrincipalName],
+            certificate_seat_id: formData.certificateSeatId,
+          },
+        ];
+        break;
+      case "custom":
+        break;
+      default:
+        break;
+    }
+
+    return data;
+  };
 
   /**
    * generates the data to be sent to the API to delete the certificate authority.
@@ -35,7 +69,8 @@ export const useCertAuthorityDataGenerator = (
         data.integrations.digicert = config.integrations.digicert?.filter(
           (cert) => {
             return (
-              (certAuthority as ICertificatesIntegrationDigicert).id === cert.id
+              (certAuthority as ICertificatesIntegrationDigicert).name ===
+              cert.name
             );
           }
         );
@@ -62,11 +97,12 @@ export const useCertAuthorityDataGenerator = (
    * under the hood we are updating the app config object with the new data and
    * have to generate the correct data for the PATCH request.
    */
-  const generateEditPatchData = () => {
+  const generateEditPatchData = (formData: IDigicertFormData) => {
     if (!config) return null;
   };
 
   return {
+    generateAddPatchData,
     generateDeletePatchData,
     generateEditPatchData,
   };

--- a/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/DeleteCertificateAuthorityModal/helpers.ts
+++ b/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/DeleteCertificateAuthorityModal/helpers.ts
@@ -1,0 +1,89 @@
+import { AppContext } from "context/app";
+
+import {
+  ICertificateAuthorityType,
+  ICertificateIntegration,
+  ICertificatesIntegrationCustomSCEP,
+  ICertificatesIntegrationDigicert,
+  IGlobalIntegrations,
+} from "interfaces/integration";
+import { useContext } from "react";
+
+export const useCertAuthorityDataGenerator = (
+  certAuthorityType: ICertificateAuthorityType,
+  certAuthority: ICertificateIntegration
+) => {
+  const { config } = useContext(AppContext);
+
+  /**
+   * generates the data to be sent to the API to delete the certificate authority.
+   * under the hood we are updating the app config object with the new data and
+   * have to generate the correct data for the PATCH request.
+   */
+  const generateDeletePatchData = () => {
+    if (!config) return null;
+
+    const data: { integrations: Partial<IGlobalIntegrations> } = {
+      integrations: {},
+    };
+
+    switch (certAuthorityType) {
+      case "ndes":
+        data.integrations.ndes_scep_proxy = null;
+        break;
+      case "digicert":
+        data.integrations.digicert = config.integrations.digicert?.filter(
+          (cert) => {
+            return (
+              (certAuthority as ICertificatesIntegrationDigicert).id === cert.id
+            );
+          }
+        );
+        break;
+      case "custom":
+        data.integrations.custom_scep_proxy = config.integrations.custom_scep_proxy?.filter(
+          (cert) => {
+            return (
+              (certAuthority as ICertificatesIntegrationCustomSCEP).id ===
+              cert.id
+            );
+          }
+        );
+        break;
+      default:
+        break;
+    }
+
+    return data;
+  };
+
+  /**
+   * generates the data to be sent to the API to edit the certificate authority.
+   * under the hood we are updating the app config object with the new data and
+   * have to generate the correct data for the PATCH request.
+   */
+  const generateEditPatchData = () => {
+    if (!config) return null;
+  };
+
+  return {
+    generateDeletePatchData,
+    generateEditPatchData,
+  };
+};
+
+export const generateCertAuthorityDisplayName = (
+  certAuthorityType: ICertificateAuthorityType,
+  certAuthority: ICertificateIntegration
+) => {
+  switch (certAuthorityType) {
+    case "ndes":
+      return "NDES";
+    case "digicert":
+      return (certAuthority as ICertificatesIntegrationDigicert).name;
+    case "custom":
+      return (certAuthority as ICertificatesIntegrationCustomSCEP).name;
+    default:
+      return "";
+  }
+};

--- a/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/DeleteCertificateAuthorityModal/index.ts
+++ b/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/DeleteCertificateAuthorityModal/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./DeleteCertificateAuthorityModal";

--- a/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/DigicertForm/DigicertForm.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/DigicertForm/DigicertForm.tsx
@@ -1,0 +1,107 @@
+import React from "react";
+
+// @ts-ignore
+import InputField from "components/forms/fields/InputField";
+import Button from "components/buttons/Button";
+import CustomLink from "components/CustomLink";
+import TooltipWrapper from "components/TooltipWrapper";
+
+const baseClass = "digicert-form";
+
+export interface IDigicertFormData {
+  name: string;
+  url: string;
+  apiToken: string;
+  profileId: string;
+  commonName: string;
+  userPrincipalNames: string;
+  certificateSeatId: string;
+}
+
+interface IDigicertFormProps {
+  submitBtnText: string;
+  onSubmit: () => void;
+  onCancel: () => void;
+}
+
+const DigicertForm = ({
+  submitBtnText,
+  onSubmit,
+  onCancel,
+}: IDigicertFormProps) => {
+  const isUpdating = false;
+
+  return (
+    <form className={baseClass} onSubmit={onSubmit}>
+      <div className={`${baseClass}__fields`}>
+        <InputField
+          name="name"
+          label="Name"
+          helpText="Letters, numbers, and underscores only. Fleet will create configuration profile variables with the name as suffix (e.g. $FLEET_VAR_CERT_DATA_DIGICERT_WIFI)."
+          placeholder="DIGICERT_WIFI"
+        />
+        <InputField
+          name="url"
+          label="URL"
+          helpText="DigiCert ONE instance URL."
+          value={"https://one.digicert.com"}
+        />
+        <InputField
+          name="apiToken"
+          label="API token"
+          helpText="DigiCert One API token for service user."
+        />
+        <InputField
+          name="profileId"
+          label="Profile GUID"
+          helpText={
+            <>
+              You can find the <b>Profile GUID</b> by opening one of the{" "}
+              <CustomLink
+                text="Digicert profiles"
+                url="https://demo.one.digicert.com/mpki/policies/profiles"
+                newTab
+              />
+            </>
+          }
+        />
+        <InputField
+          name="commonName"
+          label="Certificate common name (CN)"
+          helpText="Certificates delivered to your hosts will have this CN in the subject."
+          placeholder="$FLEET_VAR_HOST_HARDWARE_SERIAL"
+        />
+        <InputField
+          name="userPrincipleNames"
+          label="User principal name (UPN)"
+          helpText="Certificates delivered to your hosts will have this UPN attribute in Subject Alternative Name (SAN)."
+          placeholder="$FLEET_VAR_HOST_HARDWARE_SERIAL"
+        />
+        <InputField
+          name="certificateSeatId"
+          label="Certificate seat ID"
+          helpText="Certificates delivered to your hosts will be assigned to this seat ID in DigiCert."
+          placeholder="$FLEET_VAR_HOST_HARDWARE_SERIAL"
+        />
+      </div>
+      <div className={`${baseClass}__cta`}>
+        <TooltipWrapper
+          tipContent="Complete all fields to save."
+          underline={false}
+          position="top"
+          showArrow
+          // TODO: disable when form is invalid
+        >
+          <Button isLoading={isUpdating} disabled={isUpdating}>
+            {submitBtnText}
+          </Button>
+        </TooltipWrapper>
+        <Button variant="inverse" onClick={onCancel}>
+          Cancel
+        </Button>
+      </div>
+    </form>
+  );
+};
+
+export default DigicertForm;

--- a/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/DigicertForm/DigicertForm.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/DigicertForm/DigicertForm.tsx
@@ -52,23 +52,26 @@ const DigicertForm = ({
     certificateSeatId,
   } = formData;
 
-  const onInputBlur = () => {
-    setFormValidation(generateFormValidation(formData));
+  const onSubmitForm = (evt: React.FormEvent<HTMLFormElement>) => {
+    evt.preventDefault();
+    onSubmit();
   };
 
   const onInputChange = (update: { name: string; value: string }) => {
+    setFormValidation(
+      generateFormValidation({ ...formData, [update.name]: update.value })
+    );
     onChange(update);
   };
 
   return (
-    <form className={baseClass} onSubmit={onSubmit}>
+    <form className={baseClass} onSubmit={onSubmitForm}>
       <div className={`${baseClass}__fields`}>
         <InputField
           name="name"
           label="Name"
           value={name}
           onChange={onInputChange}
-          onBlur={onInputBlur}
           error={formValidation.name?.message}
           helpText="Letters, numbers, and underscores only. Fleet will create configuration profile variables with the name as suffix (e.g. $FLEET_VAR_CERT_DATA_DIGICERT_WIFI)."
           parseTarget
@@ -79,7 +82,6 @@ const DigicertForm = ({
           label="URL"
           value={url}
           onChange={onInputChange}
-          onBlur={onInputBlur}
           error={formValidation.url?.message}
           parseTarget
           helpText="DigiCert ONE instance URL."
@@ -90,7 +92,6 @@ const DigicertForm = ({
           label="API token"
           value={apiToken}
           onChange={onInputChange}
-          onBlur={onInputBlur}
           parseTarget
           helpText="DigiCert One API token for service user."
         />
@@ -99,7 +100,6 @@ const DigicertForm = ({
           label="Profile GUID"
           value={profileId}
           onChange={onInputChange}
-          onBlur={onInputBlur}
           parseTarget
           helpText={
             <>
@@ -117,7 +117,6 @@ const DigicertForm = ({
           label="Certificate common name (CN)"
           value={commonName}
           onChange={onInputChange}
-          onBlur={onInputBlur}
           parseTarget
           helpText="Certificates delivered to your hosts will have this CN in the subject."
           placeholder="$FLEET_VAR_HOST_HARDWARE_SERIAL"
@@ -127,7 +126,6 @@ const DigicertForm = ({
           label="User principal name (UPN)"
           value={userPrincipalName}
           onChange={onInputChange}
-          onBlur={onInputBlur}
           parseTarget
           helpText="Certificates delivered to your hosts will have this UPN attribute in Subject Alternative Name (SAN). (optional)"
           placeholder="$FLEET_VAR_HOST_HARDWARE_SERIAL"
@@ -137,7 +135,6 @@ const DigicertForm = ({
           label="Certificate seat ID"
           value={certificateSeatId}
           onChange={onInputChange}
-          onBlur={onInputBlur}
           parseTarget
           helpText="Certificates delivered to your hosts will be assigned to this seat ID in DigiCert."
           placeholder="$FLEET_VAR_HOST_HARDWARE_SERIAL"
@@ -148,10 +145,14 @@ const DigicertForm = ({
           tipContent="Complete all required fields to save."
           underline={false}
           position="top"
-          disableTooltip={!formValidation.isValid}
+          disableTooltip={formValidation.isValid}
           showArrow
         >
-          <Button isLoading={isUpdating} disabled={!formValidation.isValid}>
+          <Button
+            isLoading={isUpdating}
+            disabled={!formValidation.isValid}
+            type="submit"
+          >
             {submitBtnText}
           </Button>
         </TooltipWrapper>

--- a/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/DigicertForm/DigicertForm.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/DigicertForm/DigicertForm.tsx
@@ -22,6 +22,7 @@ export interface IDigicertFormData {
 interface IDigicertFormProps {
   formData: IDigicertFormData;
   submitBtnText: string;
+  isSubmitting: boolean;
   onChange: (update: { name: string; value: string }) => void;
   onSubmit: () => void;
   onCancel: () => void;
@@ -30,12 +31,11 @@ interface IDigicertFormProps {
 const DigicertForm = ({
   formData,
   submitBtnText,
+  isSubmitting,
   onChange,
   onSubmit,
   onCancel,
 }: IDigicertFormProps) => {
-  const isUpdating = false;
-
   const [formValidation, setFormValidation] = useState<IDigicertFormValidation>(
     {
       isValid: false,
@@ -149,8 +149,8 @@ const DigicertForm = ({
           showArrow
         >
           <Button
-            isLoading={isUpdating}
-            disabled={!formValidation.isValid}
+            isLoading={isSubmitting}
+            disabled={!formValidation.isValid || isSubmitting}
             type="submit"
           >
             {submitBtnText}

--- a/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/DigicertForm/DigicertForm.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/DigicertForm/DigicertForm.tsx
@@ -19,17 +19,35 @@ export interface IDigicertFormData {
 }
 
 interface IDigicertFormProps {
+  formData: IDigicertFormData;
   submitBtnText: string;
+  onChange: (update: { name: string; value: string }) => void;
   onSubmit: () => void;
   onCancel: () => void;
 }
 
 const DigicertForm = ({
+  formData,
   submitBtnText,
+  onChange,
   onSubmit,
   onCancel,
 }: IDigicertFormProps) => {
   const isUpdating = false;
+
+  const {
+    name,
+    url,
+    apiToken,
+    profileId,
+    commonName,
+    userPrincipalNames,
+    certificateSeatId,
+  } = formData;
+
+  const onInputChange = (update: { name: string; value: string }) => {
+    onChange(update);
+  };
 
   return (
     <form className={baseClass} onSubmit={onSubmit}>
@@ -37,23 +55,34 @@ const DigicertForm = ({
         <InputField
           name="name"
           label="Name"
+          value={name}
+          onChange={onInputChange}
           helpText="Letters, numbers, and underscores only. Fleet will create configuration profile variables with the name as suffix (e.g. $FLEET_VAR_CERT_DATA_DIGICERT_WIFI)."
+          parseTarget
           placeholder="DIGICERT_WIFI"
         />
         <InputField
           name="url"
           label="URL"
+          value={url}
+          onChange={onChange}
+          parseTarget
           helpText="DigiCert ONE instance URL."
-          value={"https://one.digicert.com"}
         />
         <InputField
           name="apiToken"
           label="API token"
+          value={apiToken}
+          onChange={onChange}
+          parseTarget
           helpText="DigiCert One API token for service user."
         />
         <InputField
           name="profileId"
           label="Profile GUID"
+          value={profileId}
+          onChange={onChange}
+          parseTarget
           helpText={
             <>
               You can find the <b>Profile GUID</b> by opening one of the{" "}
@@ -68,18 +97,27 @@ const DigicertForm = ({
         <InputField
           name="commonName"
           label="Certificate common name (CN)"
+          value={commonName}
+          onChange={onChange}
+          parseTarget
           helpText="Certificates delivered to your hosts will have this CN in the subject."
           placeholder="$FLEET_VAR_HOST_HARDWARE_SERIAL"
         />
         <InputField
           name="userPrincipleNames"
           label="User principal name (UPN)"
+          value={userPrincipalNames}
+          onChange={onChange}
+          parseTarget
           helpText="Certificates delivered to your hosts will have this UPN attribute in Subject Alternative Name (SAN)."
           placeholder="$FLEET_VAR_HOST_HARDWARE_SERIAL"
         />
         <InputField
           name="certificateSeatId"
           label="Certificate seat ID"
+          value={certificateSeatId}
+          onChange={onChange}
+          parseTarget
           helpText="Certificates delivered to your hosts will be assigned to this seat ID in DigiCert."
           placeholder="$FLEET_VAR_HOST_HARDWARE_SERIAL"
         />

--- a/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/DigicertForm/DigicertForm.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/DigicertForm/DigicertForm.tsx
@@ -1,10 +1,11 @@
-import React from "react";
+import React, { useState } from "react";
 
 // @ts-ignore
 import InputField from "components/forms/fields/InputField";
 import Button from "components/buttons/Button";
 import CustomLink from "components/CustomLink";
 import TooltipWrapper from "components/TooltipWrapper";
+import { generateFormValidation, IDigicertFormValidation } from "./helpers";
 
 const baseClass = "digicert-form";
 
@@ -14,7 +15,7 @@ export interface IDigicertFormData {
   apiToken: string;
   profileId: string;
   commonName: string;
-  userPrincipalNames: string;
+  userPrincipalName: string;
   certificateSeatId: string;
 }
 
@@ -35,15 +36,25 @@ const DigicertForm = ({
 }: IDigicertFormProps) => {
   const isUpdating = false;
 
+  const [formValidation, setFormValidation] = useState<IDigicertFormValidation>(
+    {
+      isValid: false,
+    }
+  );
+
   const {
     name,
     url,
     apiToken,
     profileId,
     commonName,
-    userPrincipalNames,
+    userPrincipalName,
     certificateSeatId,
   } = formData;
+
+  const onInputBlur = () => {
+    setFormValidation(generateFormValidation(formData));
+  };
 
   const onInputChange = (update: { name: string; value: string }) => {
     onChange(update);
@@ -57,6 +68,8 @@ const DigicertForm = ({
           label="Name"
           value={name}
           onChange={onInputChange}
+          onBlur={onInputBlur}
+          error={formValidation.name?.message}
           helpText="Letters, numbers, and underscores only. Fleet will create configuration profile variables with the name as suffix (e.g. $FLEET_VAR_CERT_DATA_DIGICERT_WIFI)."
           parseTarget
           placeholder="DIGICERT_WIFI"
@@ -65,15 +78,19 @@ const DigicertForm = ({
           name="url"
           label="URL"
           value={url}
-          onChange={onChange}
+          onChange={onInputChange}
+          onBlur={onInputBlur}
+          error={formValidation.url?.message}
           parseTarget
           helpText="DigiCert ONE instance URL."
         />
         <InputField
+          type="password"
           name="apiToken"
           label="API token"
           value={apiToken}
-          onChange={onChange}
+          onChange={onInputChange}
+          onBlur={onInputBlur}
           parseTarget
           helpText="DigiCert One API token for service user."
         />
@@ -81,7 +98,8 @@ const DigicertForm = ({
           name="profileId"
           label="Profile GUID"
           value={profileId}
-          onChange={onChange}
+          onChange={onInputChange}
+          onBlur={onInputBlur}
           parseTarget
           helpText={
             <>
@@ -98,25 +116,28 @@ const DigicertForm = ({
           name="commonName"
           label="Certificate common name (CN)"
           value={commonName}
-          onChange={onChange}
+          onChange={onInputChange}
+          onBlur={onInputBlur}
           parseTarget
           helpText="Certificates delivered to your hosts will have this CN in the subject."
           placeholder="$FLEET_VAR_HOST_HARDWARE_SERIAL"
         />
         <InputField
-          name="userPrincipleNames"
+          name="userPrincipalName"
           label="User principal name (UPN)"
-          value={userPrincipalNames}
-          onChange={onChange}
+          value={userPrincipalName}
+          onChange={onInputChange}
+          onBlur={onInputBlur}
           parseTarget
-          helpText="Certificates delivered to your hosts will have this UPN attribute in Subject Alternative Name (SAN)."
+          helpText="Certificates delivered to your hosts will have this UPN attribute in Subject Alternative Name (SAN). (optional)"
           placeholder="$FLEET_VAR_HOST_HARDWARE_SERIAL"
         />
         <InputField
           name="certificateSeatId"
           label="Certificate seat ID"
           value={certificateSeatId}
-          onChange={onChange}
+          onChange={onInputChange}
+          onBlur={onInputBlur}
           parseTarget
           helpText="Certificates delivered to your hosts will be assigned to this seat ID in DigiCert."
           placeholder="$FLEET_VAR_HOST_HARDWARE_SERIAL"
@@ -124,13 +145,13 @@ const DigicertForm = ({
       </div>
       <div className={`${baseClass}__cta`}>
         <TooltipWrapper
-          tipContent="Complete all fields to save."
+          tipContent="Complete all required fields to save."
           underline={false}
           position="top"
+          disableTooltip={!formValidation.isValid}
           showArrow
-          // TODO: disable when form is invalid
         >
-          <Button isLoading={isUpdating} disabled={isUpdating}>
+          <Button isLoading={isUpdating} disabled={!formValidation.isValid}>
             {submitBtnText}
           </Button>
         </TooltipWrapper>

--- a/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/DigicertForm/_styles.scss
+++ b/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/DigicertForm/_styles.scss
@@ -1,0 +1,13 @@
+.digicert-form {
+  &__fields {
+    display: flex;
+    flex-direction: column;
+    gap: $pad-large;
+  }
+
+  &__cta {
+    display: flex;
+    flex-direction: row-reverse;
+    gap: $pad-medium;
+  }
+}

--- a/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/DigicertForm/helpers.ts
+++ b/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/DigicertForm/helpers.ts
@@ -1,0 +1,144 @@
+import valid_url from "components/forms/validators/valid_url";
+import { IDigicertFormData } from "./DigicertForm";
+
+// TODO: create a validator abstraction for this and the other form validation files
+
+export interface IDigicertFormValidation {
+  isValid: boolean;
+  name?: { isValid: boolean; message?: string };
+  url?: { isValid: boolean; message?: string };
+  apiToken?: { isValid: boolean };
+  profileId?: { isValid: boolean };
+  commonName?: { isValid: boolean };
+  certificateSeatId?: { isValid: boolean };
+}
+
+type IMessageFunc = (formData: IDigicertFormData) => string;
+type IValidationMessage = string | IMessageFunc;
+type IFormValidationKey = keyof Omit<IDigicertFormValidation, "isValid">;
+
+interface IValidation {
+  name: string;
+  isValid: (formData: IDigicertFormData) => boolean;
+  message?: IValidationMessage;
+}
+
+const FORM_VALIDATIONS: Record<
+  IFormValidationKey,
+  { validations: IValidation[] }
+> = {
+  name: {
+    validations: [
+      {
+        name: "required",
+        isValid: (formData: IDigicertFormData) => {
+          return formData.name.length > 0;
+        },
+      },
+      {
+        name: "invalidCharacters",
+        isValid: (formData: IDigicertFormData) => {
+          return /^[a-zA-Z0-9_]+$/.test(formData.name);
+        },
+        message:
+          "Inalid characters. Only letters, numbers and underscores allowed.",
+      },
+    ],
+  },
+  url: {
+    validations: [
+      {
+        name: "required",
+        isValid: (formData: IDigicertFormData) => {
+          return formData.url.length > 0;
+        },
+      },
+      {
+        name: "validUrl",
+        isValid: (formData: IDigicertFormData) => {
+          return valid_url({ url: formData.url });
+        },
+        message: (formData: IDigicertFormData) =>
+          `${formData.url} is not a valid URL`,
+      },
+    ],
+  },
+  apiToken: {
+    validations: [
+      {
+        name: "required",
+        isValid: (formData: IDigicertFormData) => {
+          return formData.apiToken.length > 0;
+        },
+      },
+    ],
+  },
+  profileId: {
+    validations: [
+      {
+        name: "required",
+        isValid: (formData: IDigicertFormData) => {
+          return formData.profileId.length > 0;
+        },
+      },
+    ],
+  },
+  commonName: {
+    validations: [
+      {
+        name: "required",
+        isValid: (formData: IDigicertFormData) => {
+          return formData.commonName.length > 0;
+        },
+      },
+    ],
+  },
+  certificateSeatId: {
+    validations: [
+      {
+        name: "required",
+        isValid: (formData: IDigicertFormData) => {
+          return formData.certificateSeatId.length > 0;
+        },
+      },
+    ],
+  },
+};
+
+const getErrorMessage = (
+  formData: IDigicertFormData,
+  message?: IValidationMessage
+) => {
+  if (message === undefined || typeof message === "string") {
+    return message;
+  }
+  return message(formData);
+};
+
+// eslint-disable-next-line import/prefer-default-export
+export const generateFormValidation = (formData: IDigicertFormData) => {
+  const formValidation: IDigicertFormValidation = {
+    isValid: true,
+  };
+
+  Object.keys(FORM_VALIDATIONS).forEach((key) => {
+    const objKey = key as keyof typeof FORM_VALIDATIONS;
+    const failedValidation = FORM_VALIDATIONS[objKey].validations.find(
+      (validation) => !validation.isValid(formData)
+    );
+
+    if (!failedValidation) {
+      formValidation[objKey] = {
+        isValid: true,
+      };
+    } else {
+      formValidation.isValid = false;
+      formValidation[objKey] = {
+        isValid: false,
+        message: getErrorMessage(formData, failedValidation.message),
+      };
+    }
+  });
+
+  return formValidation;
+};

--- a/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/DigicertForm/index.ts
+++ b/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/DigicertForm/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./DigicertForm";

--- a/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/helpers.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/helpers.tsx
@@ -51,6 +51,21 @@ export const generateListData = (
   );
 };
 
+export interface ICertIntegrationNDESWithListId
+  extends ICertificatesIntegrationNDES {
+  listId: string;
+}
+
+export interface ICertIntegrationDigicertWithListId
+  extends ICertificatesIntegrationDigicert {
+  listId: string;
+}
+
+export interface ICertIntegrationCustomSCEPWithListId
+  extends ICertificatesIntegrationCustomSCEP {
+  listId: string;
+}
+
 /**
  * Gets the original certificate aithority integration object from the id
  * of the data representing a certificate authority list item.

--- a/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/helpers.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/helpers.tsx
@@ -29,7 +29,7 @@ export const generateListData = (
   if (digicertCerts?.length) {
     digicertCerts.forEach((cert) => {
       listData.push({
-        id: `digicert-${cert.id}`,
+        id: `digicert-${cert.name}`,
         name: cert.name,
         description: "DigiCert",
       });
@@ -82,12 +82,13 @@ export const getCertificateAuthority = (
 
   if (id.includes("digicert")) {
     return digicertCerts?.find(
-      (cert) => id.split("digicert-")[1] === cert.id.toString()
+      (cert) => id.split("digicert-")[1] === cert.name
     ) as ICertificatesIntegrationDigicert;
   }
 
   if (id.includes("custom-scep-proxy")) {
     return customProxies?.find(
+      // TODO: remove custom scep id
       (cert) => id.split("custom-scep-proxy-")[1] === cert.id.toString()
     ) as ICertificatesIntegrationCustomSCEP;
   }

--- a/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/helpers.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/helpers.tsx
@@ -4,7 +4,7 @@ import {
   ICertificatesIntegrationNDES,
 } from "interfaces/integration";
 
-export interface ICertAuthority {
+export interface ICertAuthorityListData {
   id: string;
   name: string;
   description: string;
@@ -15,7 +15,7 @@ export const generateListData = (
   digicertCerts?: ICertificatesIntegrationDigicert[],
   customProxies?: ICertificatesIntegrationCustomSCEP[]
 ) => {
-  const listData: ICertAuthority[] = [];
+  const listData: ICertAuthorityListData[] = [];
 
   // these values for the certificateAuthority is meant to be a hard coded .
   if (ndesProxy) {
@@ -68,13 +68,13 @@ export const getCertificateAuthority = (
   if (id.includes("digicert")) {
     return digicertCerts?.find(
       (cert) => id.split("digicert-")[1] === cert.id.toString()
-    );
+    ) as ICertificatesIntegrationDigicert;
   }
 
   if (id.includes("custom-scep-proxy")) {
     return customProxies?.find(
       (cert) => id.split("custom-scep-proxy-")[1] === cert.id.toString()
-    );
+    ) as ICertificatesIntegrationCustomSCEP;
   }
 
   return null;

--- a/frontend/services/entities/certificates.ts
+++ b/frontend/services/entities/certificates.ts
@@ -1,0 +1,5 @@
+export default {
+  deleteCertificateAuthority: (id: number) => {
+    console.log("Delete certificate authority", id);
+  },
+};

--- a/frontend/services/entities/certificates.ts
+++ b/frontend/services/entities/certificates.ts
@@ -1,5 +1,7 @@
+import configAPI from "./config";
+
 export default {
-  deleteCertificateAuthority: (id: number) => {
-    console.log("Delete certificate authority", id);
+  deleteCertificateAuthority: (updateData: any): Promise<void> => {
+    return configAPI.update(updateData);
   },
 };

--- a/frontend/services/entities/certificates.ts
+++ b/frontend/services/entities/certificates.ts
@@ -1,7 +1,11 @@
 import configAPI from "./config";
 
 export default {
-  deleteCertificateAuthority: (updateData: any): Promise<void> => {
+  addCertificateAuthority: (updateData: any): Promise<any> => {
+    return configAPI.update(updateData);
+  },
+
+  deleteCertificateAuthority: (updateData: any): Promise<any> => {
     return configAPI.update(updateData);
   },
 };


### PR DESCRIPTION
For #26606

This adds the ability to add and delete digicert integrations in the fleet UI. this includes:

**The delete modal**

![image](https://github.com/user-attachments/assets/11ab33eb-4db3-4445-8647-2a40436fe2fc)

**the add digicert modal**

![image](https://github.com/user-attachments/assets/c6ae27dc-5a38-4c99-bafa-ef5b9f832ffa)

**integration with API to perform these actions**

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [ ] Added/updated automated tests
- [ ] Manual QA for all new/changed functionality
