### PR TITLE
Improve error handling during host certificate ingestion

### DIFF
--- a/server/fleet/host_certificates.go
+++ b/server/fleet/host_certificates.go
@@ -3,7 +3,7 @@ package fleet
 import (
 	"crypto/sha1" // nolint:gosec // used for compatibility with existing osquery certificates table schema
 	"crypto/x509"
-	"errors"
+	"fmt"
 	"strings"
 	"time"
 )
@@ -195,7 +195,7 @@ func ExtractDetailsFromOsqueryDistinguishedName(str string) (*HostCertificateNam
 	for _, part := range parts {
 		kv := strings.Split(part, "=")
 		if len(kv) != 2 {
-			return nil, errors.New("invalid distinguished name, wrong key value pair format")
+			return nil, fmt.Errorf("invalid distinguished name, wrong key value pair format: %s", str)
 		}
 
 		switch strings.ToUpper(kv[0]) {

--- a/server/service/osquery_utils/queries.go
+++ b/server/service/osquery_utils/queries.go
@@ -2213,15 +2213,18 @@ func directIngestHostCertificates(
 	for _, row := range rows {
 		csum, err := hex.DecodeString(row["sha1"])
 		if err != nil {
-			return ctxerr.Wrap(ctx, err, "directIngestHostCertificates: decoding sha1")
+			level.Error(logger).Log("component", "service", "method", "directIngestHostCertificates", "msg", "decoding sha1", "err", err)
+			continue
 		}
 		subject, err := fleet.ExtractDetailsFromOsqueryDistinguishedName(row["subject"])
 		if err != nil {
-			return ctxerr.Wrap(ctx, err, "directIngestHostCertificates: extracting subject details")
+			level.Error(logger).Log("component", "service", "method", "directIngestHostCertificates", "msg", "extracting subject details", "err", err)
+			continue
 		}
 		issuer, err := fleet.ExtractDetailsFromOsqueryDistinguishedName(row["issuer"])
 		if err != nil {
-			return ctxerr.Wrap(ctx, err, "directIngestHostCertificates: extracting issuer details")
+			level.Error(logger).Log("component", "service", "method", "directIngestHostCertificates", "msg", "extracting issuer details", "err", err)
+			continue
 		}
 
 		certs = append(certs, &fleet.HostCertificateRecord{
@@ -2245,6 +2248,11 @@ func directIngestHostCertificates(
 			IssuerOrganization:        issuer.Organization,
 			IssuerCommonName:          issuer.CommonName,
 		})
+	}
+
+	if len(certs) == 0 {
+		// don't overwrite existing certs if we were unable to parse any new ones
+		return nil
 	}
 
 	return ds.UpdateHostCertificates(ctx, host.ID, certs)

--- a/server/service/osquery_utils/queries_test.go
+++ b/server/service/osquery_utils/queries_test.go
@@ -1903,6 +1903,22 @@ func TestDirectIngestHostCertificates(t *testing.T) {
 		"sha1":              "9c1e9c00d8120c1a9d96274d2a17c38ffa30fd31",
 	}
 
+	// row2 will not be ingeted because of the issue field containing an extra /
+	row2 := map[string]string{
+		"ca":                "1",
+		"common_name":       "Cert 2 Common Name",
+		"issuer":            `/C=US/O=Issuer 2 Inc.\/foobar/CN=Issuer 2 Common Name`,
+		"subject":           "/C=US/O=Subject 1 Inc./OU=Subject 1 Org Unit/CN=Subject 1 Common Name",
+		"key_algorithm":     "rsaEncryption",
+		"key_strength":      "2048",
+		"key_usage":         "Data Encipherment, Key Encipherment, Digital Signature",
+		"serial":            "123abcd",
+		"signing_algorithm": "sha256WithRSAEncryption",
+		"not_valid_after":   "1822755797",
+		"not_valid_before":  "1770228826",
+		"sha1":              "9c1e9c00d8120c1a9d96274d2a17c38ffa30fd32",
+	}
+
 	ds.UpdateHostCertificatesFunc = func(ctx context.Context, hostID uint, certs []*fleet.HostCertificateRecord) error {
 		require.Equal(t, host.ID, hostID)
 		require.Len(t, certs, 1)
@@ -1928,7 +1944,7 @@ func TestDirectIngestHostCertificates(t *testing.T) {
 		return nil
 	}
 
-	err := directIngestHostCertificates(ctx, logger, host, ds, []map[string]string{row1})
+	err := directIngestHostCertificates(ctx, logger, host, ds, []map[string]string{row2, row1})
 	require.NoError(t, err)
 	require.True(t, ds.UpdateHostCertificatesFuncInvoked)
 }


### PR DESCRIPTION
Updates error handling so that we ingest certs that can be successfully parsed (previously failure to parse one cert would result in none of the certs being ingested)

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Added/updated automated tests
- [x] A detailed QA plan exists on the associated ticket (if it isn't there, work with the product group's QA engineer to add it)
- [x] For unreleased bug fixes in a release candidate, confirmed that the fix is not expected to adversely impact load test results or alerted the release DRI if additional load testing is needed.
