### PR TITLE
Cherry-pick: Add certificates support on macOS to `osquery-perf`

### DIFF
--- a/cmd/osquery-perf/agent.go
+++ b/cmd/osquery-perf/agent.go
@@ -4,9 +4,11 @@ import (
 	"bytes"
 	"compress/bzip2"
 	cryptorand "crypto/rand"
+	"crypto/sha1" // nolint:gosec
 	"crypto/tls"
 	"embed"
 	"encoding/base64"
+	"encoding/hex"
 	"encoding/json"
 	"encoding/xml"
 	"errors"
@@ -287,7 +289,11 @@ type agent struct {
 	MDMCheckInInterval    time.Duration
 	DiskEncryptionEnabled bool
 
-	scheduledQueryData *sync.Map
+	// Note that a sync.Map is safe for concurrent use, but we still need a mutex
+	// because we read and write the field itself (not data in the map) from
+	// different goroutines (the write is in a.config).
+	scheduledQueryMapMutex sync.RWMutex
+	scheduledQueryData     *sync.Map
 	// bufferedResults contains result logs that are buffered when
 	// /api/v1/osquery/log requests to the Fleet server fail.
 	//
@@ -295,6 +301,13 @@ type agent struct {
 	// increase indefinitely (we sacrifice accuracy of logs but that's
 	// a-ok for osquery-perf and load testing).
 	bufferedResults map[resultLog]int
+
+	// cache of certificates returned by this agent. Note that this requires
+	// a mutex even though only used in a.processQuery, that's because both
+	// the runLoop and the live query goroutines may call DistributedWrite
+	// (which calls processQuery).
+	certificatesMutex sync.RWMutex
+	certificatesCache []map[string]string
 }
 
 func (a *agent) GetSerialNumber() string {
@@ -563,7 +576,9 @@ func (a *agent) runLoop(i int, onlyAlreadyEnrolled bool) {
 		// would be that the query lastRun does not get
 		// updated and cause the query to run more times than
 		// expected.
+		a.scheduledQueryMapMutex.RLock()
 		queryData := a.scheduledQueryData
+		a.scheduledQueryMapMutex.RUnlock()
 		queryData.Range(func(key, value any) bool {
 			queryName := key.(string)
 			query := value.(scheduledQuery)
@@ -1318,7 +1333,10 @@ func (a *agent) config() error {
 
 	existingLastRunData := make(map[string]int64)
 
-	a.scheduledQueryData.Range(func(key, value any) bool {
+	a.scheduledQueryMapMutex.RLock()
+	queryData := a.scheduledQueryData
+	a.scheduledQueryMapMutex.RUnlock()
+	queryData.Range(func(key, value any) bool {
 		existingLastRunData[key.(string)] = value.(scheduledQuery).lastRun
 
 		return true
@@ -1360,7 +1378,9 @@ func (a *agent) config() error {
 		}
 	}
 
+	a.scheduledQueryMapMutex.Lock()
 	a.scheduledQueryData = newScheduledQueryData
+	a.scheduledQueryMapMutex.Unlock()
 
 	return nil
 }
@@ -1657,7 +1677,11 @@ func (a *agent) runPolicy(query string) []map[string]string {
 
 func (a *agent) randomQueryStats() []map[string]string {
 	var stats []map[string]string
-	a.scheduledQueryData.Range(func(key, value any) bool {
+	a.scheduledQueryMapMutex.RLock()
+	queryData := a.scheduledQueryData
+	a.scheduledQueryMapMutex.RUnlock()
+
+	queryData.Range(func(key, value any) bool {
 		queryName := key.(string)
 
 		stats = append(stats, map[string]string{
@@ -1845,6 +1869,50 @@ func (a *agent) diskEncryptionLinux() []map[string]string {
 		{"path": "/etc", "encrypted": "0"},
 		{"path": "/tmp", "encrypted": "0"},
 	}
+}
+
+func (a *agent) certificates() []map[string]string {
+	a.certificatesMutex.RLock()
+	cache := a.certificatesCache
+	a.certificatesMutex.RUnlock()
+
+	// 90% of the time certificates do not change
+	if rand.Intn(100) < 90 && len(cache) > 0 {
+		return cache
+	}
+
+	// between 2 and 10 certificates (probably impossible to have 0, quick check
+	// on dogfood gives between 4-7)
+	count := rand.Intn(9) + 2
+
+	const day = 24 * time.Hour
+	results := make([]map[string]string, count)
+	for i := range count {
+		m := make(map[string]string, 12)
+		m["ca"] = fmt.Sprint(rand.Intn(2))
+		m["common_name"] = uuid.NewString()
+		m["issuer"] = fmt.Sprintf("/C=US/O=Issuer %d Inc./CN=Issuer %d Common Name", i, i)
+		m["subject"] = fmt.Sprintf("/C=US/O=Subject %d Inc./OU=Subject %d Org Unit/CN=Subject %d Common Name", i, i, i)
+		m["key_algorithm"] = "rsaEncryption"
+		m["key_strength"] = "2048"
+		m["key_usage"] = "Data Encipherment, Key Encipherment, Digital Signature"
+		m["serial"] = uuid.NewString()
+		m["signing_algorithm"] = "sha256WithRSAEncryption"
+		// generate so that it may be expired
+		m["not_valid_after"] = fmt.Sprint(time.Now().Add(-1 * day).Add(time.Duration(rand.Intn(100)) * day).Unix())
+		// notBefore is always in the past (1-10 days in the past)
+		m["not_valid_before"] = fmt.Sprint(time.Now().Add(-time.Duration(rand.Intn(10)+1) * day).Unix())
+		rawHash := sha1.Sum([]byte(m["serial"])) //nolint: gosec
+		hash := hex.EncodeToString(rawHash[:])
+		m["sha1"] = hash
+
+		results[i] = m
+	}
+
+	a.certificatesMutex.Lock()
+	a.certificatesCache = results
+	a.certificatesMutex.Unlock()
+	return results
 }
 
 func (a *agent) orbitInfo() []map[string]string {
@@ -2165,6 +2233,14 @@ func (a *agent) processQuery(name, query string, cachedResults *cachedResults) (
 			return true, nil, &statusNotOK, nil, nil
 		}
 		return true, a.orbitInfo(), &statusOK, nil, nil
+	case strings.HasPrefix(name, hostDetailQueryPrefix+"certificates_darwin"):
+		// NOTE: feels exaggerated to fail osquery 50% of the time but this is how
+		// most other osquery queries are handled.
+		ss := fleet.OsqueryStatus(rand.Intn(2))
+		if ss == fleet.StatusOK {
+			results = a.certificates()
+		}
+		return true, results, &ss, nil, nil
 	default:
 		// Look for results in the template file.
 		if t := a.templates.Lookup(name); t == nil {


### PR DESCRIPTION
Cherry-pick #27004