### PR TITLE
Fixed bug with editing DigiCert config

### DIFF
--- a/server/fleet/integrations.go
+++ b/server/fleet/integrations.go
@@ -374,6 +374,13 @@ func (d *DigiCertIntegration) Equals(other *DigiCertIntegration) bool {
 		d.CertificateSeatID == other.CertificateSeatID
 }
 
+func (d *DigiCertIntegration) NeedToVerify(other *DigiCertIntegration) bool {
+	return d.Name != other.Name ||
+		d.URL != other.URL ||
+		!(d.APIToken == "" || d.APIToken == MaskedPassword || d.APIToken == other.APIToken) ||
+		d.ProfileID != other.ProfileID
+}
+
 // NDESSCEPProxyIntegration configures SCEP proxy for NDES SCEP server. Premium feature.
 type NDESSCEPProxyIntegration struct {
 	URL      string `json:"url"`


### PR DESCRIPTION
For #26603 

Issue: when editing DigiCert config, we were making a call to DigiCert when admin modified CN, UPN, or Seat ID.

Fix: when editing these DigiCert fields, API token is required to be re-entered (for security):
- Name
- URL
- Profile GUID

# Checklist for submitter
- [x] Added/updated automated tests
- [x] Manual QA for all new/changed functionality
