### PR TITLE
Revert docs changes for #24989 (Setup experience: scope software via labels when Macs boot)

### DIFF
--- a/docs/Configuration/yaml-files.md
+++ b/docs/Configuration/yaml-files.md
@@ -257,6 +257,9 @@ controls:
     enable_end_user_authentication: true
     macos_setup_assistant: ../lib/dep-profile.json
     script: ../lib/macos-setup-script.sh
+    software:
+      - app_store_id: '1091189122'
+      - package_path: ../lib/software/adobe-acrobat.software.yml
   macos_migration: # Available in Fleet Premium
     enable: true
     mode: voluntary
@@ -303,6 +306,7 @@ The `macos_setup` section lets you control the out-of-the-box macOS [setup exper
 - `enable_end_user_authentication` specifies whether or not to require end user authentication when the user first sets up their macOS host. 
 - `macos_setup_assistant` is a path to a custom automatic enrollment (ADE) profile (.json).
 - `script` is the path to a custom setup script to run after the host is first set up.
+- `software` is a list of references to either a `package_path` matching a package in the `software` section below or an `app_store_id` to install when the host is first set up.
 
 ### macos_migration
 
@@ -356,7 +360,6 @@ Use `labels_include_any` to target hosts that have any label in the array or `la
 - `uninstall_script.path` is the script Fleet will run on hosts to uninstall software. The [default script](https://github.com/fleetdm/fleet/tree/main/pkg/file/scripts) is dependent on the software type (i.e. .pkg).
 - `post_install_script.path` is the script Fleet will run on hosts after the software install. There is no default.
 - `self_service` specifies whether or not end users can install from **Fleet Desktop > Self-service**.
-- `setup_experience` specifies whether the app will be installed when the host is first step up. Currently this works only for macOS apps (i.e. .pkg).
 
 #### Example
 
@@ -371,7 +374,6 @@ uninstall_script:
 post_install_script:
   path: ../lib/software/tailscale-config-script.ps1
 self_service: true
-setup_experience: true
 ```
 
 ### app_store_apps
@@ -381,7 +383,6 @@ setup_experience: true
 > Make sure to include only the ID itself, and not the `id` prefix shown in the URL. The ID must be wrapped in quotes as shown in the example so that it is processed as a string.
 
 - `self_service` only applies to macOS, and is ignored for other platforms. For example, if the app is supported on macOS, iOS, and iPadOS, and `self_service` is set to `true`, it will be self-service on macOS workstations but not iPhones or iPads.
-- `setup_experience` specifies whether the app will be installed when the host is first step up.
 
 ## org_settings and team_settings
 
@@ -473,6 +474,7 @@ org_settings:
 - `query_reports_disabled` disables query reports and deletes existing reports. (default: `false`)
 - `query_report_cap` sets the maximum number of results to store per query report before the report is clipped. If increasing this cap, we recommend enabling reports for one query at a time and monitoring your infrastructure. (default: `1000`)
 - `scripts_disabled` blocks access to run scripts. Scripts may still be added in the UI and CLI. (default: `false`)
+- `server_url` is the base URL of the Fleet instance. If this URL changes and Apple (macOS, iOS, iPadOS) hosts already have MDM turned on, the end users will have to turn MDM off and back on to use MDM features. (default: provided during Fleet setup)
 
 
 Can only be configured for all teams (`org_settings`).


### PR DESCRIPTION
#24989 is not in the 4.65.0 release.