### PR TITLE
`fleetctl`:  Handle "password reset required" errors

### DIFF
--- a/changes/25952-fleetctl-handle-required-password-reset
+++ b/changes/25952-fleetctl-handle-required-password-reset
@@ -1,0 +1,2 @@
+- Print an informative error message when `fleetctl` is authenticated with a user who is required to
+  reset their password.

--- a/server/service/base_client.go
+++ b/server/service/base_client.go
@@ -49,6 +49,10 @@ func (bc *baseClient) parseResponse(verb, path string, response *http.Response, 
 			msg: extractServerErrorText(response.Body),
 		}
 	case http.StatusUnauthorized:
+		errText := extractServerErrorText(response.Body)
+		if strings.Contains(errText, "password reset required") {
+			return ErrPasswordResetRequired
+		}
 		return ErrUnauthenticated
 	case http.StatusPaymentRequired:
 		return ErrMissingLicense

--- a/server/service/base_client_errors.go
+++ b/server/service/base_client_errors.go
@@ -11,8 +11,9 @@ import (
 )
 
 var (
-	ErrUnauthenticated = errors.New("unauthenticated, or invalid token")
-	ErrMissingLicense  = errors.New("missing or invalid license")
+	ErrUnauthenticated       = errors.New("unauthenticated, or invalid token")
+	ErrPasswordResetRequired = errors.New("Password reset required. Please sign into the Fleet UI to update your password, then log in again with: fleetctl login.")
+	ErrMissingLicense        = errors.New("missing or invalid license")
 )
 
 type SetupAlreadyErr interface {


### PR DESCRIPTION
## For #25952
Sample (applies to any operations that require a valid `fleetctl` session token):

<img width="1395" alt="Screenshot 2025-03-13 at 5 36 03 PM" src="https://github.com/user-attachments/assets/c7736dce-1a74-4fc1-9e48-c7a9652141d8" />

- [x] Changes file added for user-visible changes in `changes/`
- [x] A detailed QA plan exists on the associated ticket (if it isn't there, work with the product group's QA engineer to add it)
- [x] Manual QA for all new/changed functionality
