### PR TITLE
Fleet UI: Unreleased broken software dropdown

### DIFF
--- a/frontend/pages/SoftwarePage/SoftwareTitles/SoftwareTable/helpers.ts
+++ b/frontend/pages/SoftwarePage/SoftwareTitles/SoftwareTable/helpers.ts
@@ -91,9 +91,9 @@ export const buildSoftwareFilterQueryParams = (
 export const getSoftwareFilterFromQueryParams = (queryParams: QueryParams) => {
   const { available_for_install, self_service } = queryParams;
   switch (true) {
-    case available_for_install:
+    case available_for_install === "true":
       return "installableSoftware";
-    case self_service:
+    case self_service === "true":
       return "selfServiceSoftware";
     default:
       return "allSoftware";


### PR DESCRIPTION
## Issue
Unreleased bug for #22445 
Pushed 2 days ago in #26995 

## Description
- I think I was testing changing this function and accidentally left it modified https://github.com/fleetdm/fleet/pull/26995/files#r1995605358
- TLDR: queryParams are strings so switch case needs to treat them as such

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Manual QA for all new/changed functionality

