### PR TITLE
Build orbit on ubuntu-20.04

### DIFF
--- a/.github/workflows/goreleaser-orbit.yaml
+++ b/.github/workflows/goreleaser-orbit.yaml
@@ -78,7 +78,7 @@ jobs:
           path: dist/orbit-macos_darwin_all/orbit
 
   goreleaser-linux:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-20.04
     permissions:
       contents: write
       id-token: write

--- a/orbit/changes/27155-build-for-ubuntu-20.04
+++ b/orbit/changes/27155-build-for-ubuntu-20.04
@@ -1,0 +1,1 @@
+* Fixed build scripts to use `ubuntu-20.04` to build orbit (to not crash on Ubuntu 20.04).


### PR DESCRIPTION
For #27155.

Reverting to use ubuntu-20.04 to unblock the release of fleetd 1.40.1.
We'll need a proper solution for 1.41.0 given that ubuntu-20.04 will be removed on April 1st 2025.

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/Committing-Changes.md#changes-files) for more information.