### PR TITLE
UI: Validate both org logo URLs, accept data URIs

### DIFF
--- a/changes/26271-fix-org-logo-url-validation
+++ b/changes/26271-fix-org-logo-url-validation
@@ -1,0 +1,1 @@
+* Add validation to both org logo URL fields, and accept data URIs as valid

--- a/frontend/pages/admin/OrgSettingsPage/cards/Info/Info.tsx
+++ b/frontend/pages/admin/OrgSettingsPage/cards/Info/Info.tsx
@@ -1,5 +1,7 @@
 import React, { useState } from "react";
 
+import isDataURI from "validator/lib/isDataURI";
+
 import Button from "components/buttons/Button";
 // @ts-ignore
 import InputField from "components/forms/fields/InputField";
@@ -29,6 +31,9 @@ interface IOrgInfoFormErrors {
 // other components in the app.
 const baseClass = "app-config-form";
 const cardClass = "org-info";
+
+const validateOrgLogoURL = (url: string) =>
+  isDataURI(url) || validUrl({ url, protocols: ["http", "https"] });
 
 const Info = ({
   appConfig,
@@ -67,11 +72,15 @@ const Info = ({
       errors.org_name = "Organization name must be present";
     }
 
-    if (
-      orgLogoURL &&
-      !validUrl({ url: orgLogoURL, protocols: ["http", "https"] })
-    ) {
+    if (orgLogoURL && !validateOrgLogoURL(orgLogoURL)) {
       errors.org_logo_url = `${orgLogoURL} is not a valid URL`;
+    }
+
+    if (
+      orgLogoURLLightBackground &&
+      !validateOrgLogoURL(orgLogoURLLightBackground)
+    ) {
+      errors.org_logo_url_light_background = `${orgLogoURL} is not a valid URL`;
     }
 
     if (!orgSupportURL) {


### PR DESCRIPTION
## For #26271 

![ezgif-582a8acaa8686e](https://github.com/user-attachments/assets/4284bbf7-8708-46f3-b020-f4039f8bd1b0)

- [x] Changes file added for user-visible changes in `changes/`
- [x] Manual QA for all new/changed functionality
