### PR TITLE
Ignore comments at the top of XML files

### DIFF
--- a/changes/26443-xml-comments
+++ b/changes/26443-xml-comments
@@ -1,0 +1,1 @@
+* Allow for any number of comments at the top of XML files for Windows MDM profile CSPs

--- a/server/fleet/windows_mdm.go
+++ b/server/fleet/windows_mdm.go
@@ -96,6 +96,9 @@ func (m *MDMWindowsConfigProfile) ValidateUserProvided() error {
 		case xml.ProcInst:
 			return errors.New("The file should include valid XML: processing instructions are not allowed.")
 
+		case xml.Comment:
+			continue
+
 		case xml.StartElement:
 			switch t.Name.Local {
 			case "Replace", "Add":

--- a/server/fleet/windows_mdm_test.go
+++ b/server/fleet/windows_mdm_test.go
@@ -411,7 +411,9 @@ func TestValidateUserProvided(t *testing.T) {
 			profile: MDMWindowsConfigProfile{
 				SyncML: []byte(`
 				  <!-- this is a comment -->
+					<!-- this is another comment -->
 				  <Replace>
+					<!-- this is a comment inside replace -->
 				    <Target>
 				      <LocURI>Custom/URI</LocURI>
 				    </Target>

--- a/server/fleet/windows_mdm_test.go
+++ b/server/fleet/windows_mdm_test.go
@@ -411,9 +411,9 @@ func TestValidateUserProvided(t *testing.T) {
 			profile: MDMWindowsConfigProfile{
 				SyncML: []byte(`
 				  <!-- this is a comment -->
-					<!-- this is another comment -->
+				  <!-- this is another comment -->
 				  <Replace>
-					<!-- this is a comment inside replace -->
+				  <!-- this is a comment inside replace -->
 				    <Target>
 				      <LocURI>Custom/URI</LocURI>
 				    </Target>


### PR DESCRIPTION
Allows comments to be at the top of Fleet XML CSP files (addresses https://github.com/fleetdm/fleet/issues/26443)

We should validate that this fixes the errors with GitOps pushes, but I don't know how to do that without pushing this change through to QA.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/Committing-Changes.md#changes-files) for more information.
- [x] Added/updated automated tests
- [x] Manual QA for all new/changed functionality
