### PR TITLE
Update CHANGELOG.md

### DIFF
--- a/orbit/CHANGELOG.md
+++ b/orbit/CHANGELOG.md
@@ -1,9 +1,5 @@
 ## Orbit 1.40.1 (Mar 14, 2025)
 
-* Fixed build scripts to use `ubuntu-20.04` to build orbit (to not crash on Ubuntu 20.04).
-
-## Orbit 1.40.0 (Mar 11, 2025)
-
 * Fixed LUKS key escrow in non-English system locales.
 
 * Added logic to ensure only one instance of Fleet Desktop is running at a time.


### PR DESCRIPTION
Removing 1.40.0 because it was not released to `stable` due to a build issue.