### PR TITLE
Fleet Design: Add software icons into storybook

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -45,6 +45,7 @@ const config: StorybookConfig = {
   stories: [
     "../frontend/components/**/*.stories.mdx",
     "../frontend/components/**/*.stories.@(js|jsx|ts|tsx)",
+    "../frontend/pages/SoftwarePage/components/**/*.stories.@(js|jsx|ts|tsx)",
   ],
   addons: [
     "@storybook/addon-links",
@@ -53,7 +54,7 @@ const config: StorybookConfig = {
     "@storybook/addon-a11y",
     "@storybook/test-runner",
     "@storybook/addon-designs",
-    "@storybook/addon-webpack5-compiler-babel"
+    "@storybook/addon-webpack5-compiler-babel",
   ],
   typescript: {
     check: false,

--- a/frontend/pages/SoftwarePage/components/icons/Icon.stories.tsx
+++ b/frontend/pages/SoftwarePage/components/icons/Icon.stories.tsx
@@ -6,7 +6,7 @@ import getMatchedSoftwareIcon, {
   SOFTWARE_SOURCE_TO_ICON_MAP,
 } from ".";
 
-// Extend the props type to include the new selection prop
+// Extend the props type to include the new selection prop because name and source are mutually exclusive
 type IconWrapperProps = Pick<ISoftware, "name" | "source"> & {
   selection?: string;
 };
@@ -23,9 +23,11 @@ const meta: Meta<typeof IconWrapper> = {
     selection: {
       control: "select",
       options: [
-        ...Object.keys(SOFTWARE_NAME_TO_ICON_MAP).map((name) => `name:${name}`),
+        ...Object.keys(SOFTWARE_NAME_TO_ICON_MAP).map(
+          (name) => `${name} (name)`
+        ),
         ...Object.keys(SOFTWARE_SOURCE_TO_ICON_MAP).map(
-          (source) => `source:${source}`
+          (source) => `${source} (source)`
         ),
       ],
     },
@@ -40,9 +42,10 @@ export const Default: Story = {
   render: ({ selection }) => {
     if (!selection) return <IconWrapper name="" source="" />;
 
-    const [type, value] = selection.split(":");
+    const [value, type] = selection.split(" (");
+    const cleanType = type.slice(0, -1); // Remove the closing parenthesis
     const props =
-      type === "name"
+      cleanType === "name"
         ? { name: value, source: "" }
         : { name: "", source: value };
     return <IconWrapper {...props} />;

--- a/frontend/pages/SoftwarePage/components/icons/Icon.stories.tsx
+++ b/frontend/pages/SoftwarePage/components/icons/Icon.stories.tsx
@@ -1,0 +1,50 @@
+import React from "react";
+import { Meta, StoryObj } from "@storybook/react";
+import { ISoftware } from "interfaces/software";
+import getMatchedSoftwareIcon, {
+  SOFTWARE_NAME_TO_ICON_MAP,
+  SOFTWARE_SOURCE_TO_ICON_MAP,
+} from ".";
+
+// Extend the props type to include the new selection prop
+type IconWrapperProps = Pick<ISoftware, "name" | "source"> & {
+  selection?: string;
+};
+
+const IconWrapper: React.FC<IconWrapperProps> = ({ selection, ...props }) => {
+  const Icon = getMatchedSoftwareIcon(props);
+  return <Icon />;
+};
+
+const meta: Meta<typeof IconWrapper> = {
+  title: "Components/Icon/SoftwareIcon",
+  component: IconWrapper,
+  argTypes: {
+    selection: {
+      control: "select",
+      options: [
+        ...Object.keys(SOFTWARE_NAME_TO_ICON_MAP).map((name) => `name:${name}`),
+        ...Object.keys(SOFTWARE_SOURCE_TO_ICON_MAP).map(
+          (source) => `source:${source}`
+        ),
+      ],
+    },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof IconWrapper>;
+
+export const Default: Story = {
+  render: ({ selection }) => {
+    if (!selection) return <IconWrapper name="" source="" />;
+
+    const [type, value] = selection.split(":");
+    const props =
+      type === "name"
+        ? { name: value, source: "" }
+        : { name: "", source: value };
+    return <IconWrapper {...props} />;
+  },
+};

--- a/frontend/pages/SoftwarePage/components/icons/Postman.tsx
+++ b/frontend/pages/SoftwarePage/components/icons/Postman.tsx
@@ -5,15 +5,6 @@ import type { SVGProps } from "react";
 const Postman = (props: SVGProps<SVGSVGElement>) => (
   <svg fill="none" xmlns="http://www.w3.org/2000/svg" {...props}>
     <path fill="#EEE" d="M0 0h32v32H0z" />
-    <rect
-      x="-15.5"
-      y="-975.5"
-      width="63"
-      height="1551"
-      rx="4.5"
-      stroke="#9747FF"
-      strokeDasharray="10 5"
-    />
     <path fill="#FF6C37" d="M0 0h32v32H0z" />
     <path
       d="M11.567 17.011a.06.06 0 0 0 .07.032l2.56-.552-1.076-1.091-1.534 1.534a.06.06 0 0 0-.02.077ZM23.555 6.02a2.386 2.386 0 1 0 1.005 4.55l-1.623-1.623a.2.2 0 0 1 0-.283l2.12-2.118a2.386 2.386 0 0 0-1.502-.527Z"

--- a/frontend/pages/SoftwarePage/components/icons/index.ts
+++ b/frontend/pages/SoftwarePage/components/icons/index.ts
@@ -45,7 +45,7 @@ const LINUX_OS_NAME_TO_ICON_MAP = HOST_LINUX_PLATFORMS.reduce(
 // SOFTWARE_NAME_TO_ICON_MAP list "special" applications that have a defined
 // icon for them, keys refer to application names, and are intended to be fuzzy
 // matched in the application logic.
-const SOFTWARE_NAME_TO_ICON_MAP = {
+export const SOFTWARE_NAME_TO_ICON_MAP = {
   appStore: AppStore,
   "adobe acrobat reader": AcrobatReader,
   "microsoft excel": Excel,
@@ -82,7 +82,7 @@ const SOFTWARE_NAME_TO_ICON_MAP = {
 
 // SOFTWARE_SOURCE_TO_ICON_MAP maps different software sources to a defined
 // icon.
-const SOFTWARE_SOURCE_TO_ICON_MAP = {
+export const SOFTWARE_SOURCE_TO_ICON_MAP = {
   package: Package,
   apt_sources: Package,
   deb_packages: Package,


### PR DESCRIPTION
## Issue
For #27236 

## Description
- Add software icons into storybook for better internal documentation

## Screenshot of fix
<img width="1457" alt="Screenshot 2025-03-18 at 1 17 47 PM" src="https://github.com/user-attachments/assets/1f2c7c22-3603-4987-9e53-0cc6a2f30678" />


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] A detailed QA plan exists on the associated ticket (if it isn't there, work with the product group's QA engineer to add it)
- [x] Manual QA for all new/changed functionality
