### PR TITLE
Fleet UI: Make OS copies in dashboard are consistent

### DIFF
--- a/frontend/pages/DashboardPage/DashboardPage.tsx
+++ b/frontend/pages/DashboardPage/DashboardPage.tsx
@@ -239,29 +239,29 @@ const DashboardPage = ({ router, location }: IDashboardProps): JSX.Element => {
           (platform: IHostSummaryPlatforms) => platform.platform === "windows"
         ) || { platform: "windows", hosts_count: 0 };
 
-        const chromebooks = data.platforms?.find(
+        const chomeOSHosts = data.platforms?.find(
           (platform: IHostSummaryPlatforms) => platform.platform === "chrome"
         ) || { platform: "chrome", hosts_count: 0 };
 
-        const iphones = data.platforms?.find(
+        const iOSHosts = data.platforms?.find(
           (platform: IHostSummaryPlatforms) => platform.platform === "ios"
         ) || { platform: "ios", hosts_count: 0 };
 
-        const ipads = data.platforms?.find(
+        const iPadOSHosts = data.platforms?.find(
           (platform: IHostSummaryPlatforms) => platform.platform === "ipados"
         ) || { platform: "ipados", hosts_count: 0 };
 
-        const android = data.platforms?.find(
+        const androidHosts = data.platforms?.find(
           (platform: IHostSummaryPlatforms) => platform.platform === "android"
         ) || { platform: "android", hosts_count: 0 };
 
         setMacCount(macHosts.hosts_count);
         setWindowsCount(windowsHosts.hosts_count);
         setLinuxCount(data.all_linux_count);
-        setChromeCount(chromebooks.hosts_count);
-        setIosCount(iphones.hosts_count);
-        setIpadosCount(ipads.hosts_count);
-        setAndroidCount(android.hosts_count);
+        setChromeCount(chomeOSHosts.hosts_count);
+        setIosCount(iOSHosts.hosts_count);
+        setIpadosCount(iPadOSHosts.hosts_count);
+        setAndroidCount(androidHosts.hosts_count);
         setShowHostsUI(true);
       },
     }

--- a/frontend/pages/DashboardPage/cards/OperatingSystems/OperatingSystems.tsx
+++ b/frontend/pages/DashboardPage/cards/OperatingSystems/OperatingSystems.tsx
@@ -78,7 +78,7 @@ const OperatingSystems = ({
           auto-update expiration date.{" "}
           <CustomLink
             url="https://fleetdm.com/learn-more-about/chromeos-updates"
-            text="See supported devices"
+            text="Learn more"
             newTab
             multiline
           />

--- a/frontend/pages/DashboardPage/sections/PlatformHostCounts/PlatformHostCounts.tsx
+++ b/frontend/pages/DashboardPage/sections/PlatformHostCounts/PlatformHostCounts.tsx
@@ -138,7 +138,7 @@ const PlatformHostCounts = ({
       <HostCountCard
         iconName="chrome"
         count={chromeCount}
-        title="Chromebooks"
+        title="ChromeOS"
         path={getPathWithQueryParams(PATHS.MANAGE_HOSTS_LABEL(chromeLabelId), {
           team_id: teamId,
         })}
@@ -161,7 +161,7 @@ const PlatformHostCounts = ({
       <HostCountCard
         iconName="iOS"
         count={iosCount}
-        title="iPhones"
+        title="iOS"
         path={getPathWithQueryParams(PATHS.MANAGE_HOSTS_LABEL(iosLabelId), {
           team_id: teamId,
         })}
@@ -184,7 +184,7 @@ const PlatformHostCounts = ({
       <HostCountCard
         iconName="iPadOS"
         count={ipadosCount}
-        title="iPads"
+        title="iPadOS"
         path={getPathWithQueryParams(PATHS.MANAGE_HOSTS_LABEL(ipadosLabelId), {
           team_id: teamId,
         })}

--- a/server/mdm/apple/apple_mdm.go
+++ b/server/mdm/apple/apple_mdm.go
@@ -1203,7 +1203,7 @@ func IOSiPadOSRefetch(ctx context.Context, ds fleet.Datastore, commander *MDMApp
 	start := time.Now()
 	devices, err := ds.ListIOSAndIPadOSToRefetch(ctx, 1*time.Hour)
 	if err != nil {
-		return ctxerr.Wrap(ctx, err, "list ios and ipad devices to refetch")
+		return ctxerr.Wrap(ctx, err, "list ios and ipados devices to refetch")
 	}
 	if len(devices) == 0 {
 		return nil


### PR DESCRIPTION
## Issue
For #26356 

## Description
- Small copy changes to make OS platform naming consistent

## Screenshot of fix
<img width="984" alt="Screenshot 2025-03-18 at 3 49 18 PM" src="https://github.com/user-attachments/assets/1d23db00-4f02-4e18-ac1e-ef6d547894e7" />


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

Note: No change file as this is such a small copy change
- [x] A detailed QA plan exists on the associated ticket (if it isn't there, work with the product group's QA engineer to add it)
- [x] Manual QA for all new/changed functionality

