### PR TITLE
"Security" and "IT"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,12 @@
 ## Fleet 4.65.0 (Mar 14, 2025)
 
-## Security engineering
+## Security
 - Added UI for viewing certificate details on the host details and my device pages.
 - Added new features to include certificates in host vitals for macOS, iOS, and iPadOS.
 - Added the list host certificates (and list device's certificates) endpoints.
 - Improved the copy for the delete and transfer host modal to be more clear about the disk encryption key behavior.
 - Permit setting SSO metadata and metadata_url in gitops and UI.
 - Fixed an issue where the Show Query modal would truncate large queries.
-
-## Vulnerability management
 - Fixed Python for Windows software version mutation to avoid panics on software ingestion in some cases.
 - Prevented an invalid `FLEET_VULNERABILITIES_MAX_CONCURRENCY` value from causing deadlocks during vulnerability processing.
 - Updated default for vulnerabilities max concurrency from 5 to 1.
@@ -19,7 +17,7 @@
 - Fixed an issue with increased resource usage during vulnerabilities processing by adding database indexes.
 - Fixed false-positives on released PowerShell versions for CVE-2025-21171 and all PowerShell versions on CVE-2023-48795.
 
-## IT engineering
+## IT
 - Implemented GitOps mode that locks settings in the UI that are managed by GitOps.
 - Allowed VPP apps to be automatically installed via a Fleet-created policy. 
 - Added ability for users to automatically install App Store Apps without writing a policy in the Fleet UI.

--- a/articles/fleet-4.65.0.md
+++ b/articles/fleet-4.65.0.md
@@ -27,15 +27,13 @@ The **Host details** page now displays a list of certificates for macOS, iOS, an
 
 ## Changes
 
-### Security engineering
+### Security
 - Added UI for viewing certificate details on the host details and my device pages.
 - Added new features to include certificates in host vitals for macOS, iOS, and iPadOS.
 - Added the list host certificates (and list device's certificates) endpoints.
 - Improved the copy for the delete and transfer host modal to be more clear about the disk encryption key behavior.
 - Permit setting SSO metadata and metadata_url in gitops and UI.
 - Fixed an issue where the Show Query modal would truncate large queries.
-
-### Vulnerability management
 - Fixed Python for Windows software version mutation to avoid panics on software ingestion in some cases.
 - Prevented an invalid `FLEET_VULNERABILITIES_MAX_CONCURRENCY` value from causing deadlocks during vulnerability processing.
 - Updated default for vulnerabilities max concurrency from 5 to 1.
@@ -46,7 +44,7 @@ The **Host details** page now displays a list of certificates for macOS, iOS, an
 - Fixed an issue with increased resource usage during vulnerabilities processing by adding database indexes.
 - Fixed false-positives on released PowerShell versions for CVE-2025-21171 and all PowerShell versions on CVE-2023-48795.
 
-### IT engineering
+### IT
 - Implemented GitOps mode that locks settings in the UI that are managed by GitOps.
 - Allowed VPP apps to be automatically installed via a Fleet-created policy. 
 - Added ability for users to automatically install App Store Apps without writing a policy in the Fleet UI.


### PR DESCRIPTION
UPDATE: @noahtalerman: I updated the releases page too: https://github.com/fleetdm/fleet/releases/tag/fleet-v4.65.0

---

- Update CHANGELOG and release article sections to just "IT" and "Security"
- Why?
  - Security looks smaller when VM is broken out. I think we can treat VM as security.
  - Trying the same in the upcoming roadmap preview article here: https://github.com/fleetdm/fleet/pull/26990/files
  - Security” and “IT” headers would fit nicely with our GitOps folder for dogfood: `/it-and-security`
