### PR TITLE
Website: add platform icons to osquery table schema pages

### DIFF
--- a/website/assets/styles/pages/osquery-table-details.less
+++ b/website/assets/styles/pages/osquery-table-details.less
@@ -691,7 +691,7 @@
         height: 24px;
         position: absolute;
         right: 0;
-        top: 95px;
+        top: 75px;
       }
       table {
         td:nth-child(3) {

--- a/website/views/pages/osquery-table-details.ejs
+++ b/website/views/pages/osquery-table-details.ejs
@@ -55,6 +55,20 @@
 
             <div purpose="table-container" class="d-flex flex-column">
               <div purpose="schema-table">
+                <div purpose="platform-logos" class="d-flex flex-row align-items-center justify-content-end">
+                    <% if(_.contains(tableToDisplay.platforms, 'darwin')){%>
+                      <img class="ml-3" style="height: 25px" src="/images/os-macos-dark-24x24@2x.png" alt="macOS logo">
+                    <%}%>
+                    <% if(_.contains(tableToDisplay.platforms, 'windows')){%>
+                     <img class="ml-3" style="height: 24px" src="/images/os-windows-dark-24x24@2x.png" alt="Windows logo">
+                    <%}%>
+                    <% if(_.contains(tableToDisplay.platforms, 'linux')){%>
+                      <img class="ml-3" style="height: 24px" src="/images/os-linux-dark-24x24@2x.png" alt="Linux logo">
+                    <% }%>
+                    <% if(_.contains(tableToDisplay.platforms, 'chromeos')){%>
+                      <img class="ml-3" style="height: 25px" src="/images/os-chromeos-dark-24x24@2x.png" alt="ChromeOS logo">
+                    <%}%>
+                 </div>
                 <%- partial(path.relative(path.dirname(__filename), path.resolve( sails.config.appPath, path.join(sails.config.builtStaticContent.compiledPagePartialsAppPath, tableToDisplay.htmlId)))) %>
               </div>
 


### PR DESCRIPTION
Closes: https://github.com/fleetdm/confidential/issues/9976

Changes:
- Brought back the platform icons to the osquery table schema pages.