### PR TITLE
Remove default EXE install/uninstall scripts, require entering install/uninstall scripts on EXE upload

### DIFF
--- a/.github/workflows/test-packaging.yml
+++ b/.github/workflows/test-packaging.yml
@@ -87,7 +87,7 @@ jobs:
       - name: Install wine and wix
         if: startsWith(matrix.os, 'macos')
         run: |
-          ./scripts/macos-install-wine.sh -n
+          ./it-and-security/lib/macos/scripts/install-wine.sh -n
           wget https://github.com/wixtoolset/wix3/releases/download/wix3112rtm/wix311-binaries.zip -nv -O wix.zip
           mkdir wix
           unzip wix.zip -d wix

--- a/changes/27267-drop-exe-install-scripts
+++ b/changes/27267-drop-exe-install-scripts
@@ -1,0 +1,1 @@
+* Removed unreliable default (un)install scripts for EXE software packages.

--- a/changes/27267-drop-exe-install-scripts
+++ b/changes/27267-drop-exe-install-scripts
@@ -1,1 +1,2 @@
-* Removed unreliable default (un)install scripts for EXE software packages.
+* Removed unreliable default (un)install scripts for .exe software packages; install and uninstall scripts are now required when adding .exe packages.
+* Added software URL validation in GitOps to catch URL parse errors earlier.

--- a/ee/server/service/software_installers.go
+++ b/ee/server/service/software_installers.go
@@ -374,7 +374,7 @@ func (svc *Service) UpdateSoftwareInstaller(ctx context.Context, payload *fleet.
 			installScript = file.GetInstallScript(existingInstaller.Extension)
 		}
 		if installScript == "" {
-			return nil, ctxerr.New(ctx, fmt.Sprintf("install script must be provided for %s packages", strings.ToUpper(existingInstaller.Extension)))
+			return nil, ctxerr.New(ctx, fmt.Sprintf("install script must be provided for .%s packages", strings.ToLower(existingInstaller.Extension)))
 		}
 
 		if installScript != existingInstaller.InstallScript {
@@ -397,7 +397,7 @@ func (svc *Service) UpdateSoftwareInstaller(ctx context.Context, payload *fleet.
 			uninstallScript = file.GetUninstallScript(existingInstaller.Extension)
 		}
 		if uninstallScript == "" {
-			return nil, ctxerr.New(ctx, fmt.Sprintf("uninstall script must be provided for %s packages", strings.ToUpper(existingInstaller.Extension)))
+			return nil, ctxerr.New(ctx, fmt.Sprintf("uninstall script must be provided for .%s packages", strings.ToLower(existingInstaller.Extension)))
 		}
 
 		payloadForUninstallScript := &fleet.UploadSoftwareInstallerPayload{
@@ -1415,14 +1415,14 @@ func (svc *Service) addMetadataToSoftwarePayload(ctx context.Context, payload *f
 		payload.InstallScript = file.GetInstallScript(meta.Extension)
 	}
 	if payload.InstallScript == "" {
-		return meta.Extension, ctxerr.New(ctx, fmt.Sprintf("install script must be provided for %s packages", strings.ToUpper(meta.Extension)))
+		return meta.Extension, ctxerr.New(ctx, fmt.Sprintf("install script must be provided for .%s packages", strings.ToLower(meta.Extension)))
 	}
 
 	if payload.UninstallScript == "" {
 		payload.UninstallScript = file.GetUninstallScript(meta.Extension)
 	}
 	if payload.UninstallScript == "" {
-		return meta.Extension, ctxerr.New(ctx, fmt.Sprintf("uninstall script must be provided for %s packages", strings.ToUpper(meta.Extension)))
+		return meta.Extension, ctxerr.New(ctx, fmt.Sprintf("uninstall script must be provided for .%s packages", strings.ToLower(meta.Extension)))
 	}
 
 	if payload.BundleIdentifier != "" {

--- a/ee/server/service/software_installers.go
+++ b/ee/server/service/software_installers.go
@@ -373,6 +373,9 @@ func (svc *Service) UpdateSoftwareInstaller(ctx context.Context, payload *fleet.
 		if installScript == "" {
 			installScript = file.GetInstallScript(existingInstaller.Extension)
 		}
+		if installScript == "" {
+			return nil, ctxerr.New(ctx, fmt.Sprintf("install script must be provided for %s packages", strings.ToUpper(existingInstaller.Extension)))
+		}
 
 		if installScript != existingInstaller.InstallScript {
 			dirty["InstallScript"] = true
@@ -392,6 +395,9 @@ func (svc *Service) UpdateSoftwareInstaller(ctx context.Context, payload *fleet.
 		uninstallScript := file.Dos2UnixNewlines(*payload.UninstallScript)
 		if uninstallScript == "" { // extension can't change on an edit so we can generate off of the existing file
 			uninstallScript = file.GetUninstallScript(existingInstaller.Extension)
+		}
+		if uninstallScript == "" {
+			return nil, ctxerr.New(ctx, fmt.Sprintf("uninstall script must be provided for %s packages", strings.ToUpper(existingInstaller.Extension)))
 		}
 
 		payloadForUninstallScript := &fleet.UploadSoftwareInstallerPayload{
@@ -1408,9 +1414,15 @@ func (svc *Service) addMetadataToSoftwarePayload(ctx context.Context, payload *f
 	if payload.InstallScript == "" {
 		payload.InstallScript = file.GetInstallScript(meta.Extension)
 	}
+	if payload.InstallScript == "" {
+		return meta.Extension, ctxerr.New(ctx, fmt.Sprintf("install script must be provided for %s packages", strings.ToUpper(meta.Extension)))
+	}
 
 	if payload.UninstallScript == "" {
 		payload.UninstallScript = file.GetUninstallScript(meta.Extension)
+	}
+	if payload.UninstallScript == "" {
+		return meta.Extension, ctxerr.New(ctx, fmt.Sprintf("uninstall script must be provided for %s packages", strings.ToUpper(meta.Extension)))
 	}
 
 	if payload.BundleIdentifier != "" {

--- a/ee/server/service/software_installers.go
+++ b/ee/server/service/software_installers.go
@@ -374,7 +374,9 @@ func (svc *Service) UpdateSoftwareInstaller(ctx context.Context, payload *fleet.
 			installScript = file.GetInstallScript(existingInstaller.Extension)
 		}
 		if installScript == "" {
-			return nil, ctxerr.New(ctx, fmt.Sprintf("install script must be provided for .%s packages", strings.ToLower(existingInstaller.Extension)))
+			return nil, &fleet.BadRequestError{
+				Message: fmt.Sprintf("Couldn't edit. Install script is required for .%s packages.", strings.ToLower(existingInstaller.Extension)),
+			}
 		}
 
 		if installScript != existingInstaller.InstallScript {
@@ -397,7 +399,9 @@ func (svc *Service) UpdateSoftwareInstaller(ctx context.Context, payload *fleet.
 			uninstallScript = file.GetUninstallScript(existingInstaller.Extension)
 		}
 		if uninstallScript == "" {
-			return nil, ctxerr.New(ctx, fmt.Sprintf("uninstall script must be provided for .%s packages", strings.ToLower(existingInstaller.Extension)))
+			return nil, &fleet.BadRequestError{
+				Message: fmt.Sprintf("Couldn't edit. Uninstall script is required for .%s packages.", strings.ToLower(existingInstaller.Extension)),
+			}
 		}
 
 		payloadForUninstallScript := &fleet.UploadSoftwareInstallerPayload{
@@ -1415,14 +1419,18 @@ func (svc *Service) addMetadataToSoftwarePayload(ctx context.Context, payload *f
 		payload.InstallScript = file.GetInstallScript(meta.Extension)
 	}
 	if payload.InstallScript == "" {
-		return meta.Extension, ctxerr.New(ctx, fmt.Sprintf("install script must be provided for .%s packages", strings.ToLower(meta.Extension)))
+		return "", &fleet.BadRequestError{
+			Message: fmt.Sprintf("Couldn't add. Install script is required for .%s packages.", strings.ToLower(payload.Extension)),
+		}
 	}
 
 	if payload.UninstallScript == "" {
 		payload.UninstallScript = file.GetUninstallScript(meta.Extension)
 	}
 	if payload.UninstallScript == "" {
-		return meta.Extension, ctxerr.New(ctx, fmt.Sprintf("uninstall script must be provided for .%s packages", strings.ToLower(meta.Extension)))
+		return "", &fleet.BadRequestError{
+			Message: fmt.Sprintf("Couldn't add. Uninstall script is required for .%s packages.", strings.ToLower(payload.Extension)),
+		}
 	}
 
 	if payload.BundleIdentifier != "" {

--- a/frontend/pages/SoftwarePage/components/PackageAdvancedOptions/PackageAdvancedOptions.tsx
+++ b/frontend/pages/SoftwarePage/components/PackageAdvancedOptions/PackageAdvancedOptions.tsx
@@ -34,13 +34,14 @@ const getInstallHelpText = (pkgType: PackageType) => {
   if (pkgType === "exe") {
     return (
       <>
-        For Windows, Fleet only creates install scripts for .msi packages. Use the $INSTALLER_PATH variable to point to the installer. {" "}
-        {getSupportedScriptTypeText(pkgType)}.{" "}
+        For Windows, Fleet only creates install scripts for .msi packages. Use
+        the $INSTALLER_PATH variable to point to the installer.{" "}
+        {getSupportedScriptTypeText(pkgType)}{" "}
         <CustomLink
           url={`${LEARN_MORE_ABOUT_BASE_LINK}/exe-install-scripts`}
           text="Learn more"
           newTab
-        />{" "}
+        />
       </>
     );
   }
@@ -64,7 +65,7 @@ const getPostInstallHelpText = (pkgType: PackageType) => {
 
 const getUninstallHelpText = (pkgType: PackageType) => {
   if (isFleetMaintainedPackageType(pkgType)) {
-    return "Currently, shell scripts are supported";
+    return "Currently, shell scripts are supported.";
   }
 
   if (pkgType === "exe") {

--- a/frontend/pages/SoftwarePage/components/PackageAdvancedOptions/PackageAdvancedOptions.tsx
+++ b/frontend/pages/SoftwarePage/components/PackageAdvancedOptions/PackageAdvancedOptions.tsx
@@ -34,15 +34,13 @@ const getInstallHelpText = (pkgType: PackageType) => {
   if (pkgType === "exe") {
     return (
       <>
-        Use the $INSTALLER_PATH variable to point to the installer.{" "}
+        For Windows, Fleet only creates install scripts for .msi packages. Use the $INSTALLER_PATH variable to point to the installer. {" "}
         {getSupportedScriptTypeText(pkgType)}.{" "}
         <CustomLink
           url={`${LEARN_MORE_ABOUT_BASE_LINK}/exe-install-scripts`}
-          text="EXE install scripts must be built manually."
+          text="Learn more"
           newTab
         />{" "}
-        Fleet can automatically build install and uninstall scripts for MSI
-        packages and Fleet-maintained Apps.
       </>
     );
   }

--- a/frontend/pages/SoftwarePage/components/PackageAdvancedOptions/PackageAdvancedOptions.tsx
+++ b/frontend/pages/SoftwarePage/components/PackageAdvancedOptions/PackageAdvancedOptions.tsx
@@ -30,17 +30,35 @@ const PKG_TYPE_TO_ID_TEXT = {
   exe: "software name",
 } as const;
 
-const getInstallHelpText = (pkgType: PackageType) => (
-  <>
-    Use the $INSTALLER_PATH variable to point to the installer.{" "}
-    {getSupportedScriptTypeText(pkgType)}{" "}
-    <CustomLink
-      url={`${LEARN_MORE_ABOUT_BASE_LINK}/install-scripts`}
-      text="Learn more about install scripts"
-      newTab
-    />
-  </>
-);
+const getInstallHelpText = (pkgType: PackageType) => {
+  if (pkgType === "exe") {
+    return (
+      <>
+        Use the $INSTALLER_PATH variable to point to the installer.{" "}
+        {getSupportedScriptTypeText(pkgType)}.{" "}
+        <CustomLink
+          url={`${LEARN_MORE_ABOUT_BASE_LINK}/exe-install-scripts`}
+          text="EXE install scripts must be built manually."
+          newTab
+        />{" "}
+        Fleet can automatically build install and uninstall scripts for MSI
+        packages and Fleet-maintained Apps.
+      </>
+    );
+  }
+
+  return (
+    <>
+      Use the $INSTALLER_PATH variable to point to the installer.{" "}
+      {getSupportedScriptTypeText(pkgType)}{" "}
+      <CustomLink
+        url={`${LEARN_MORE_ABOUT_BASE_LINK}/install-scripts`}
+        text="Learn more about install scripts"
+        newTab
+      />
+    </>
+  );
+};
 
 const getPostInstallHelpText = (pkgType: PackageType) => {
   return getSupportedScriptTypeText(pkgType);
@@ -49,6 +67,23 @@ const getPostInstallHelpText = (pkgType: PackageType) => {
 const getUninstallHelpText = (pkgType: PackageType) => {
   if (isFleetMaintainedPackageType(pkgType)) {
     return "Currently, shell scripts are supported";
+  }
+
+  if (pkgType === "exe") {
+    return (
+      <>
+        $PACKAGE_ID will be populated with the {PKG_TYPE_TO_ID_TEXT[pkgType]}{" "}
+        from the .{pkgType} file after the software is added.{" "}
+        {getSupportedScriptTypeText(pkgType)}{" "}
+        <CustomLink
+          url={`${LEARN_MORE_ABOUT_BASE_LINK}/exe-install-scripts`}
+          text="EXE uninstall scripts must be built manually."
+          newTab
+        />{" "}
+        Fleet can automatically build install and uninstall scripts for MSI
+        packages and Fleet-maintained Apps.
+      </>
+    );
   }
 
   return (
@@ -97,14 +132,15 @@ const PackageAdvancedOptions = ({
   onChangeUninstallScript,
 }: IPackageAdvancedOptionsProps) => {
   const [showAdvancedOptions, setShowAdvancedOptions] = useState(false);
+  const name = selectedPackage?.name || "";
+  const ext = name.split(".").pop() as PackageType;
 
   const renderAdvancedOptions = () => {
-    const name = selectedPackage?.name || "";
-    const ext = name.split(".").pop() as PackageType;
     if (!isPackageType(ext)) {
       // this should never happen
       return null;
     }
+
     return (
       <AdvancedOptionsFields
         className={`${baseClass}__input-fields`}
@@ -143,7 +179,9 @@ const PackageAdvancedOptions = ({
           </>
         }
       />
-      {showAdvancedOptions && !!selectedPackage && renderAdvancedOptions()}
+      {(showAdvancedOptions || ext === "exe") &&
+        !!selectedPackage &&
+        renderAdvancedOptions()}
     </div>
   );
 };

--- a/frontend/pages/SoftwarePage/components/PackageAdvancedOptions/PackageAdvancedOptions.tsx
+++ b/frontend/pages/SoftwarePage/components/PackageAdvancedOptions/PackageAdvancedOptions.tsx
@@ -78,7 +78,7 @@ const getUninstallHelpText = (pkgType: PackageType) => {
           text="EXE uninstall scripts must be built manually."
           newTab
         />{" "}
-        Fleet can automatically build install and uninstall scripts for MSI
+        Fleet automatically builds install and uninstall scripts for .msi
         packages and Fleet-maintained Apps.
       </>
     );

--- a/frontend/pages/SoftwarePage/components/PackageAdvancedOptions/PackageAdvancedOptions.tsx
+++ b/frontend/pages/SoftwarePage/components/PackageAdvancedOptions/PackageAdvancedOptions.tsx
@@ -79,7 +79,7 @@ const getUninstallHelpText = (pkgType: PackageType) => {
           newTab
         />{" "}
         Fleet automatically builds install and uninstall scripts for .msi
-        packages and Fleet-maintained Apps.
+        packages and Fleet-maintained apps.
       </>
     );
   }

--- a/frontend/pages/SoftwarePage/components/PackageAdvancedOptions/PackageAdvancedOptions.tsx
+++ b/frontend/pages/SoftwarePage/components/PackageAdvancedOptions/PackageAdvancedOptions.tsx
@@ -71,16 +71,15 @@ const getUninstallHelpText = (pkgType: PackageType) => {
   if (pkgType === "exe") {
     return (
       <>
-        $PACKAGE_ID will be populated with the {PKG_TYPE_TO_ID_TEXT[pkgType]}{" "}
-        from the .{pkgType} file after the software is added.{" "}
+        For Windows, Fleet only creates uninstall scripts for .msi packages.
+        $PACKAGE_ID will be populated with the software name from the .exe file
+        after it&apos;s added.
         {getSupportedScriptTypeText(pkgType)}{" "}
         <CustomLink
           url={`${LEARN_MORE_ABOUT_BASE_LINK}/exe-install-scripts`}
-          text="EXE uninstall scripts must be built manually."
+          text="Learn more"
           newTab
-        />{" "}
-        Fleet automatically builds install and uninstall scripts for .msi
-        packages and Fleet-maintained apps.
+        />
       </>
     );
   }

--- a/frontend/pages/SoftwarePage/components/PackageForm/PackageForm.tsx
+++ b/frontend/pages/SoftwarePage/components/PackageForm/PackageForm.tsx
@@ -11,6 +11,7 @@ import { ILabelSummary } from "interfaces/label";
 import { PackageType } from "interfaces/package_type";
 
 import Button from "components/buttons/Button";
+import TooltipWrapper from "components/TooltipWrapper";
 import FileUploader from "components/FileUploader";
 import {
   CUSTOM_TARGET_OPTIONS,
@@ -27,8 +28,6 @@ import SoftwareOptionsSelector from "components/SoftwareOptionsSelector";
 import PackageAdvancedOptions from "../PackageAdvancedOptions";
 
 import { createTooltipContent, generateFormValidation } from "./helpers";
-import TooltipWrapper from "components/TooltipWrapper";
-import { Tooltip } from "react-tooltip-5";
 
 export const baseClass = "package-form";
 

--- a/frontend/pages/SoftwarePage/components/PackageForm/PackageForm.tsx
+++ b/frontend/pages/SoftwarePage/components/PackageForm/PackageForm.tsx
@@ -26,7 +26,9 @@ import SoftwareOptionsSelector from "components/SoftwareOptionsSelector";
 
 import PackageAdvancedOptions from "../PackageAdvancedOptions";
 
-import { generateFormValidation } from "./helpers";
+import { createTooltipContent, generateFormValidation } from "./helpers";
+import TooltipWrapper from "components/TooltipWrapper";
+import { Tooltip } from "react-tooltip-5";
 
 export const baseClass = "package-form";
 
@@ -47,6 +49,8 @@ export interface IPackageFormValidation {
   isValid: boolean;
   software: { isValid: boolean };
   preInstallQuery?: { isValid: boolean; message?: string };
+  installScript?: { isValid: boolean; message?: string };
+  uninstallScript?: { isValid: boolean; message?: string };
   customTarget?: { isValid: boolean };
 }
 
@@ -212,6 +216,7 @@ const PackageForm = ({
   };
 
   const isSubmitDisabled = !formValidation.isValid;
+  const submitTooltipContent = createTooltipContent(formValidation);
 
   const classNames = classnames(baseClass, className);
 
@@ -316,15 +321,33 @@ const PackageForm = ({
         <div className={`${baseClass}__action-buttons`}>
           <GitOpsModeTooltipWrapper
             tipOffset={6}
-            renderChildren={(disableChildren) => (
-              <Button
-                type="submit"
-                variant="brand"
-                disabled={disableChildren || isSubmitDisabled}
-              >
-                {isEditingSoftware ? "Save" : "Add software"}
-              </Button>
-            )}
+            renderChildren={(disableChildren) =>
+              submitTooltipContent ? (
+                <TooltipWrapper
+                  tipContent={submitTooltipContent}
+                  underline={false}
+                  showArrow
+                  tipOffset={10}
+                  position="left"
+                >
+                  <Button
+                    type="submit"
+                    variant="brand"
+                    disabled={disableChildren || isSubmitDisabled}
+                  >
+                    {isEditingSoftware ? "Save" : "Add software"}
+                  </Button>
+                </TooltipWrapper>
+              ) : (
+                <Button
+                  type="submit"
+                  variant="brand"
+                  disabled={disableChildren || isSubmitDisabled}
+                >
+                  {isEditingSoftware ? "Save" : "Add software"}
+                </Button>
+              )
+            }
           />
         </div>
       </form>

--- a/frontend/pages/SoftwarePage/components/PackageForm/helpers.tsx
+++ b/frontend/pages/SoftwarePage/components/PackageForm/helpers.tsx
@@ -28,6 +28,7 @@ const FORM_VALIDATION_CONFIG: Record<
       },
     ],
   },
+  // TODO mark (un)install script as invalid when blank with an EXE
   preInstallQuery: {
     validations: [
       {

--- a/frontend/pages/SoftwarePage/components/PackageForm/helpers.tsx
+++ b/frontend/pages/SoftwarePage/components/PackageForm/helpers.tsx
@@ -49,7 +49,7 @@ const FORM_VALIDATION_CONFIG: Record<
       {
         name: "requiredForExe",
         isValid: (formData) => {
-          if (formData.software?.type !== "exe") {
+          if (formData.software?.type === "exe") {
             // Handle undefined safely with nullish coalescing
             return (formData.installScript ?? "").trim().length > 0;
           }
@@ -64,7 +64,7 @@ const FORM_VALIDATION_CONFIG: Record<
       {
         name: "requiredForExe",
         isValid: (formData) => {
-          if (formData.software?.type !== "exe") {
+          if (formData.software?.type === "exe") {
             // Handle undefined safely with nullish coalescing
             return (formData.uninstallScript ?? "").trim().length > 0;
           }

--- a/frontend/pages/SoftwarePage/components/PackageForm/helpers.tsx
+++ b/frontend/pages/SoftwarePage/components/PackageForm/helpers.tsx
@@ -1,3 +1,5 @@
+import React from "react";
+
 // @ts-ignore
 import validateQuery from "components/forms/validators/validate_query";
 
@@ -28,7 +30,6 @@ const FORM_VALIDATION_CONFIG: Record<
       },
     ],
   },
-  // TODO mark (un)install script as invalid when blank with an EXE
   preInstallQuery: {
     validations: [
       {
@@ -40,6 +41,36 @@ const FORM_VALIDATION_CONFIG: Record<
           );
         },
         message: (formData) => validateQuery(formData.preInstallQuery).error,
+      },
+    ],
+  },
+  installScript: {
+    validations: [
+      {
+        name: "requiredForExe",
+        isValid: (formData) => {
+          if (formData.software?.type !== "exe") {
+            // Handle undefined safely with nullish coalescing
+            return (formData.installScript ?? "").trim().length > 0;
+          }
+          return true;
+        },
+        message: "Install script is required for .exe files.",
+      },
+    ],
+  },
+  uninstallScript: {
+    validations: [
+      {
+        name: "requiredForExe",
+        isValid: (formData) => {
+          if (formData.software?.type !== "exe") {
+            // Handle undefined safely with nullish coalescing
+            return (formData.uninstallScript ?? "").trim().length > 0;
+          }
+          return true;
+        },
+        message: "Uninstall script is required for .exe files.",
       },
     ],
   },
@@ -99,6 +130,29 @@ export const generateFormValidation = (formData: IPackageFormData) => {
   });
 
   return formValidation;
+};
+
+export const createTooltipContent = (
+  formValidation: IPackageFormValidation
+) => {
+  const messages = Object.values(formValidation)
+    .filter((field) => field.isValid === false && field.message)
+    .map((field) => field.message);
+
+  if (messages.length === 0) {
+    return null;
+  }
+
+  return (
+    <>
+      {messages.map((message, index) => (
+        <>
+          {message}
+          {index < messages.length - 1 && <br />}
+        </>
+      ))}
+    </>
+  );
 };
 
 export default generateFormValidation;

--- a/frontend/utilities/software_install_scripts.ts
+++ b/frontend/utilities/software_install_scripts.ts
@@ -3,8 +3,6 @@ import installPkg from "../../pkg/file/scripts/install_pkg.sh";
 // @ts-ignore
 import installMsi from "../../pkg/file/scripts/install_msi.ps1";
 // @ts-ignore
-import installExe from "../../pkg/file/scripts/install_exe.ps1";
-// @ts-ignore
 import installDeb from "../../pkg/file/scripts/install_deb.sh";
 // @ts-ignore
 import installRPM from "../../pkg/file/scripts/install_rpm.sh";
@@ -25,7 +23,7 @@ const getDefaultInstallScript = (fileName: string): string => {
     case "rpm":
       return installRPM;
     case "exe":
-      return installExe;
+      return "";
     default:
       throw new Error(`unsupported file extension: ${extension}`);
   }

--- a/frontend/utilities/software_uninstall_scripts.ts
+++ b/frontend/utilities/software_uninstall_scripts.ts
@@ -3,8 +3,6 @@ import uninstallPkg from "../../pkg/file/scripts/uninstall_pkg.sh";
 // @ts-ignore
 import uninstallMsi from "../../pkg/file/scripts/uninstall_msi.ps1";
 // @ts-ignore
-import uninstallExe from "../../pkg/file/scripts/uninstall_exe.ps1";
-// @ts-ignore
 import uninstallDeb from "../../pkg/file/scripts/uninstall_deb.sh";
 // @ts-ignore
 import uninstallRPM from "../../pkg/file/scripts/uninstall_rpm.sh";
@@ -25,7 +23,7 @@ const getDefaultUninstallScript = (fileName: string): string => {
     case "rpm":
       return uninstallRPM;
     case "exe":
-      return uninstallExe;
+      return "";
     default:
       throw new Error(`unsupported file extension: ${extension}`);
   }

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.99.99",
   "description": "The premier osquery fleet manager.",
   "engines": {
-    "node": "20.18.1",
+    "node": "20.18.2",
     "yarn": ">=1.22.21"
   },
   "private": true,

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.99.99",
   "description": "The premier osquery fleet manager.",
   "engines": {
-    "node": "20.18.2",
+    "node": "20.18.1",
     "yarn": ">=1.22.21"
   },
   "private": true,

--- a/pkg/file/management.go
+++ b/pkg/file/management.go
@@ -10,9 +10,6 @@ var installPkgScript string
 //go:embed scripts/install_msi.ps1
 var installMsiScript string
 
-//go:embed scripts/install_exe.ps1
-var installExeScript string
-
 //go:embed scripts/install_deb.sh
 var installDebScript string
 
@@ -30,8 +27,6 @@ func GetInstallScript(extension string) string {
 		return installRPMScript
 	case "pkg":
 		return installPkgScript
-	case "exe":
-		return installExeScript
 	default:
 		return ""
 	}
@@ -71,9 +66,6 @@ func GetRemoveScript(extension string) string {
 	}
 }
 
-//go:embed scripts/uninstall_exe.ps1
-var uninstallExeScript string
-
 //go:embed scripts/uninstall_pkg.sh
 var uninstallPkgScript string
 
@@ -98,8 +90,6 @@ func GetUninstallScript(extension string) string {
 		return uninstallRPMScript
 	case "pkg":
 		return uninstallPkgScript
-	case "exe":
-		return uninstallExeScript
 	default:
 		return ""
 	}

--- a/pkg/file/management_test.go
+++ b/pkg/file/management_test.go
@@ -45,9 +45,9 @@ func TestGetInstallAndRemoveScript(t *testing.T) {
 			"uninstall": "./scripts/uninstall_rpm.sh",
 		},
 		"exe": {
-			"install":   "./scripts/install_exe.ps1",
+			"install":   "",
 			"remove":    "./scripts/remove_exe.ps1",
-			"uninstall": "./scripts/uninstall_exe.ps1",
+			"uninstall": "",
 		},
 	}
 
@@ -65,6 +65,11 @@ func TestGetInstallAndRemoveScript(t *testing.T) {
 
 func assertGoldenMatches(t *testing.T, goldenFile string, actual string, update bool) {
 	t.Helper()
+	if goldenFile == "" {
+		require.Empty(t, actual)
+		return
+	}
+
 	goldenPath := filepath.Join("testdata", goldenFile+".golden")
 
 	f, err := os.OpenFile(goldenPath, os.O_RDWR|os.O_CREATE, 0o644)

--- a/server/service/integration_enterprise_test.go
+++ b/server/service/integration_enterprise_test.go
@@ -13482,7 +13482,7 @@ func (s *integrationEnterpriseTestSuite) TestPKGNoBundleIdentifier() {
 	s.uploadSoftwareInstaller(t, payload, http.StatusBadRequest, "Couldn't add. Unable to extract necessary metadata.")
 }
 
-func (s *integrationEnterpriseTestSuite) TestAutomaticPoliciesWithExeFails() {
+func (s *integrationEnterpriseTestSuite) TestEXEPackageUploads() {
 	t := s.T()
 	ctx := context.Background()
 
@@ -13490,7 +13490,21 @@ func (s *integrationEnterpriseTestSuite) TestAutomaticPoliciesWithExeFails() {
 	require.NoError(t, err)
 
 	payload := &fleet.UploadSoftwareInstallerPayload{
+		InstallScript: "some installer script",
+		Filename:      "hello-world-installer.exe",
+		TeamID:        &team.ID,
+	}
+	s.uploadSoftwareInstaller(t, payload, http.StatusBadRequest, "Couldn't add. Uninstall script is required for .exe packages.")
+
+	payload = &fleet.UploadSoftwareInstallerPayload{
+		Filename: "hello-world-installer.exe",
+		TeamID:   &team.ID,
+	}
+	s.uploadSoftwareInstaller(t, payload, http.StatusBadRequest, "Couldn't add. Install script is required for .exe packages.")
+
+	payload = &fleet.UploadSoftwareInstallerPayload{
 		InstallScript:    "some installer script",
+		UninstallScript:  "some uninstall script",
 		Filename:         "hello-world-installer.exe",
 		TeamID:           &team.ID,
 		AutomaticInstall: true,


### PR DESCRIPTION
For #27267.

Below is what's shown immediately after selecting an EXE:

<img width="1254" alt="image" src="https://github.com/user-attachments/assets/a28d8565-de88-448a-bdbc-92aefc34ad55" />


TODO:

* Tests
* GitOps requirements changes
* Disabling add button/adding errors when required scripts aren't specified

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/Committing-Changes.md#changes-files) for more information.
- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [x] Added/updated automated tests
- [x] A detailed QA plan exists on the associated ticket (if it isn't there, work with the product group's QA engineer to add it)
- [x] Manual QA for all new/changed functionality