### PR TITLE
Website: add temporary redirect for Android MDM learn more link.

### DIFF
--- a/website/config/routes.js
+++ b/website/config/routes.js
@@ -879,6 +879,8 @@ module.exports.routes = {
   'GET /learn-more-about/certificates-query': '/tables/certificates',
   'GET /learn-more-about/gitops': 'https://github.com/fleetdm/fleet-gitops/',
   'GET /learn-more-about/unsigning-configuration-profiles': 'https://fleetdm.com/guides/custom-os-settings#enforce-os-settings',
+  // FUTURE: update the temporary redirect below to go to the documentation for connecting Android enterprise
+  'GET /learn-more-about/how-to-connect-android-enterprise': (req,res)=> { return res.redirect(302, '/contact');},
 
   // Sitemap
   // =============================================================================================================


### PR DESCRIPTION
Related to: https://github.com/fleetdm/fleet/issues/27290


Changes:
- Added a temporary redirect for the "Learn more" link on the Android enterprise setup page.