### PR TITLE
Ensure MacOS desktop app launched as correct user

### DIFF
--- a/orbit/changes/25924-change-how-macos-desktop-launches
+++ b/orbit/changes/25924-change-how-macos-desktop-launches
@@ -1,0 +1,1 @@
+- changed the way macos opens the fleet desktop app to better ensure successful launch

--- a/orbit/cmd/orbit/orbit.go
+++ b/orbit/cmd/orbit/orbit.go
@@ -1622,14 +1622,18 @@ func (d *desktopRunner) Execute() error {
 			// On MacOS, if we attempt to run Fleet Desktop while the user is not logged in through
 			// the GUI, MacOS returns an error. See https://github.com/fleetdm/fleet/issues/14698
 			// for more details.
-			loggedInGui, err := user.IsUserLoggedInViaGui()
+			loggedInUser, err := user.UserLoggedInViaGui()
 			if err != nil {
 				log.Debug().Err(err).Msg("desktop.IsUserLoggedInGui")
 				return true
 			}
 
-			if !loggedInGui {
+			if loggedInUser == nil {
 				return true
+			}
+
+			if *loggedInUser != "" {
+				opts = append(opts, execuser.WithUser(*loggedInUser))
 			}
 
 			log.Info().Msg("killing any pre-existing fleet-desktop instances")

--- a/orbit/pkg/execuser/execuser.go
+++ b/orbit/pkg/execuser/execuser.go
@@ -12,6 +12,7 @@ type eopts struct {
 	args       [][2]string
 	stderrPath string //nolint:structcheck,unused
 	timeout    time.Duration
+	user       string
 }
 
 // Option allows configuring the application.
@@ -35,6 +36,13 @@ func WithArg(name, value string) Option {
 func WithTimeout(duration time.Duration) Option {
 	return func(a *eopts) {
 		a.timeout = duration
+	}
+}
+
+// WithUser sets the user to run the application as. Currently only supported on MacOS.
+func WithUser(user string) Option {
+	return func(a *eopts) {
+		a.user = user
 	}
 }
 

--- a/orbit/pkg/execuser/execuser_darwin.go
+++ b/orbit/pkg/execuser/execuser_darwin.go
@@ -41,7 +41,8 @@ func run(path string, opts eopts) (lastLogs string, err error) {
 		}
 	}
 
-	cmd := exec.Command("/usr/bin/open", arg...)
+	arg = append([]string{"-u", opts.user, "/usr/bin/open"}, arg...)
+	cmd := exec.Command("sudo", arg...)
 	tw := &TransientWriter{}
 	cmd.Stderr = io.MultiWriter(tw, os.Stderr)
 	cmd.Stdout = io.MultiWriter(tw, os.Stdout)

--- a/orbit/pkg/user/user_darwin.go
+++ b/orbit/pkg/user/user_darwin.go
@@ -9,6 +9,8 @@ import (
 	"regexp"
 )
 
+var re *regexp.Regexp = regexp.MustCompile(`\s+Name : (\S+)`)
+
 // UserLoggedInViaGui returns the name of the user logged into the machine via the GUI.
 func UserLoggedInViaGui() (*string, error) {
 	// Attempt to get the console user.
@@ -22,7 +24,6 @@ func UserLoggedInViaGui() (*string, error) {
 
 	// Extract all "Name : username" entries, and return the first one that
 	// isn't _mbsetupuser (if any).
-	re := regexp.MustCompile(`\s+Name : (\S+)`)
 	matches := re.FindAllStringSubmatch(out.String(), -1)
 
 	for _, match := range matches {

--- a/orbit/pkg/user/user_darwin.go
+++ b/orbit/pkg/user/user_darwin.go
@@ -14,7 +14,7 @@ var re *regexp.Regexp = regexp.MustCompile(`\s+Name : (\S+)`)
 // UserLoggedInViaGui returns the name of the user logged into the machine via the GUI.
 func UserLoggedInViaGui() (*string, error) {
 	// Attempt to get the console user.
-	cmd := exec.Command("sh", "-c", `scutil <<< "show State:/Users/ConsoleUser"`)
+	cmd := exec.Command("/bin/sh", "-c", `scutil <<< "show State:/Users/ConsoleUser"`)
 	var out bytes.Buffer
 	cmd.Stdout = &out
 	err := cmd.Run()

--- a/orbit/pkg/user/user_darwin.go
+++ b/orbit/pkg/user/user_darwin.go
@@ -4,27 +4,33 @@
 package user
 
 import (
-	"errors"
+	"bytes"
 	"os/exec"
-	"strings"
+	"regexp"
 )
 
-// IsUserLoggedInViaGui returns whether or not a user is logged into the machine via the GUI.
-func IsUserLoggedInViaGui() (bool, error) {
-	output, err := exec.Command("/usr/bin/stat", "-f", "%Su", "/dev/console").Output()
+// UserLoggedInViaGui returns the name of the user logged into the machine via the GUI.
+func UserLoggedInViaGui() (*string, error) {
+	// Attempt to get the console user.
+	cmd := exec.Command("sh", "-c", `scutil <<< "show State:/Users/ConsoleUser"`)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	err := cmd.Run()
 	if err != nil {
-		var ee *exec.ExitError
-		if errors.As(err, &ee) && len(ee.Stderr) > 0 {
-			return false, errors.Join(err, errors.New(string(ee.Stderr)))
+		return nil, err
+	}
+
+	// Extract all "Name : username" entries, and return the first one that
+	// isn't _mbsetupuser (if any).
+	re := regexp.MustCompile(`\s+Name : (\S+)`)
+	matches := re.FindAllStringSubmatch(out.String(), -1)
+
+	for _, match := range matches {
+		if len(match) > 1 && match[1] != "" && match[1] != "_mbsetupuser" {
+			return &match[1], nil
 		}
-
-		return false, err
 	}
 
-	// If no user is logged in via GUI, the command line returns "root".
-	if strings.TrimSpace(string(output)) == "root" {
-		return false, nil
-	}
-
-	return true, nil
+	// No valid user found
+	return nil, nil
 }

--- a/orbit/pkg/user/user_darwin.go
+++ b/orbit/pkg/user/user_darwin.go
@@ -9,7 +9,7 @@ import (
 	"regexp"
 )
 
-var re *regexp.Regexp = regexp.MustCompile(`\s+Name : (\S+)`)
+var re = regexp.MustCompile(`\s+Name : (\S+)`)
 
 // UserLoggedInViaGui returns the name of the user logged into the machine via the GUI.
 func UserLoggedInViaGui() (*string, error) {

--- a/orbit/pkg/user/user_notdarwin.go
+++ b/orbit/pkg/user/user_notdarwin.go
@@ -3,9 +3,10 @@
 
 package user
 
-// IsUserLoggedInViaGui returns whether or not a user is logged into the machine via the GUI. This
+// UserLoggedInViaGui returns the name of the user logged into the machine via the GUI. This
 // function is only relevant on MacOS, where it is used to prevent errors when launching Fleet
-// Desktop. We assume yes (effectively a no-op) on all other platforms.
-func IsUserLoggedInViaGui() (bool, error) {
-	return true, nil
+// Desktop. For other platforms we return an empty string which can be ignored.
+func UserLoggedInViaGui() (*string, error) {
+	user := ""
+	return &user, nil
 }


### PR DESCRIPTION
For #25924  

This PR attempts to fix the issue where the Fleet desktop icon sometimes fails to appear on MacOS hosts until the hosts are rebooted.  Anecdotal evidence points to this being an issue when system setup is happening, leading to the theory that Orbit is attempting to launch the app as  `_mbsetupuser` rather than the real logged-in user.  The fix here is to use a different command to get the name of the logged-in user (ignoring `_mbsetupuser` if it appears), and to launch the desktop app as that user using `sudo`.  

I have tested this on MacOS and Ubuntu hosts, and verified that the desktop app launches as expected on both.

We don't have a solid reproduction scenario for the issue, but we do have [some ways to look for relevant errors](https://github.com/fleetdm/fleet/issues/19172#issuecomment-2627812786), so we can try this out and see if those errors cease.