### PR TITLE
Fleet UI: Disable unsupported auto install of .exe during add flow

### DIFF
--- a/changes/27230-exe-auto-installer-disabled
+++ b/changes/27230-exe-auto-installer-disabled
@@ -1,0 +1,1 @@
+* Fleet UI: Disable unsupported automatic install option during add flow of .exe custom packages

--- a/frontend/components/SoftwareOptionsSelector/SoftwareOptionsSelector.tsx
+++ b/frontend/components/SoftwareOptionsSelector/SoftwareOptionsSelector.tsx
@@ -46,11 +46,8 @@ const SoftwareOptionsSelector = ({
   const isAutomaticInstallDisabled =
     platform === "ios" || platform === "ipados" || isExePackage;
 
-  /** Tooltip if enabled or exe package */
-  const automaticInstallDisabledTooltip = (): JSX.Element | undefined => {
-    if (!isAutomaticInstallDisabled) {
-      return <>Automatically install only on hosts missing this software.</>;
-    }
+  /** Tooltip for auto install is enabled or exe package */
+  const getAutomaticInstallTooltip = (): JSX.Element => {
     if (isExePackage) {
       return (
         <>
@@ -61,6 +58,7 @@ const SoftwareOptionsSelector = ({
         </>
       );
     }
+    return <>Automatically install only on hosts missing this software.</>;
   };
 
   return (
@@ -87,7 +85,10 @@ const SoftwareOptionsSelector = ({
           value={formData.automaticInstall}
           onChange={(newVal: boolean) => onToggleAutomaticInstall(newVal)}
           className={`${baseClass}__automatic-install-checkbox`}
-          tooltipContent={automaticInstallDisabledTooltip()}
+          tooltipContent={
+            (!isAutomaticInstallDisabled || isExePackage) &&
+            getAutomaticInstallTooltip()
+          }
           disabled={isAutomaticInstallDisabled}
         >
           Automatic install

--- a/frontend/components/SoftwareOptionsSelector/SoftwareOptionsSelector.tsx
+++ b/frontend/components/SoftwareOptionsSelector/SoftwareOptionsSelector.tsx
@@ -24,6 +24,8 @@ interface ISoftwareOptionsSelector {
   platform?: string;
   className?: string;
   isCustomPackage?: boolean;
+  /** Exe packages do not have ability to select automatic install */
+  isExePackage?: boolean;
   /** Edit mode does not have ability to change automatic install */
   isEditingSoftware?: boolean;
 }
@@ -35,13 +37,31 @@ const SoftwareOptionsSelector = ({
   platform,
   className,
   isCustomPackage,
+  isExePackage,
   isEditingSoftware,
 }: ISoftwareOptionsSelector) => {
   const classNames = classnames(baseClass, className);
 
   const isSelfServiceDisabled = platform === "ios" || platform === "ipados";
   const isAutomaticInstallDisabled =
-    platform === "ios" || platform === "ipados";
+    platform === "ios" || platform === "ipados" || isExePackage;
+
+  /** Tooltip if enabled or exe package */
+  const automaticInstallDisabledTooltip = (): JSX.Element | undefined => {
+    if (!isAutomaticInstallDisabled) {
+      return <>Automatically install only on hosts missing this software.</>;
+    }
+    if (isExePackage) {
+      return (
+        <>
+          Fleet can&apos;t create a policy to detect existing installations for
+          .exe packages. To automatically install an .exe, add a custom policy
+          and enable the install software automation on the <b>Policies</b>{" "}
+          page.
+        </>
+      );
+    }
+  };
 
   return (
     <div className="form-field">
@@ -67,11 +87,7 @@ const SoftwareOptionsSelector = ({
           value={formData.automaticInstall}
           onChange={(newVal: boolean) => onToggleAutomaticInstall(newVal)}
           className={`${baseClass}__automatic-install-checkbox`}
-          tooltipContent={
-            !isAutomaticInstallDisabled && (
-              <>Automatically install only on hosts missing this software.</>
-            )
-          }
+          tooltipContent={automaticInstallDisabledTooltip()}
           disabled={isAutomaticInstallDisabled}
         >
           Automatic install

--- a/frontend/pages/SoftwarePage/components/PackageForm/PackageForm.tsx
+++ b/frontend/pages/SoftwarePage/components/PackageForm/PackageForm.tsx
@@ -269,6 +269,7 @@ const PackageForm = ({
                 onToggleSelfService={onToggleSelfServiceCheckbox}
                 isCustomPackage
                 isEditingSoftware={isEditingSoftware}
+                isExePackage={isExePackage}
               />
             </Card>
             <Card


### PR DESCRIPTION
## Issue
For #27230 

## Description
- Edge case where .exe is incompatible with auto install option got lost with design change from radio button to checkboxes across installer form UI
- Add edge case back in with tooltip outlined in original ticket Figma

## Screenshot of fix
<img width="1444" alt="Screenshot 2025-03-19 at 4 28 49 PM" src="https://github.com/user-attachments/assets/d1dc788a-d157-4bba-80f8-a773ddfbb817" />


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/Committing-Changes.md#changes-files) for more information.
- [ ] Added/updated automated tests
- [ ] A detailed QA plan exists on the associated ticket (if it isn't there, work with the product group's QA engineer to add it)
- [x] Manual QA for all new/changed functionality
