### PR TITLE
Fleet UI: Do not allow clicking a button that doesn't work

### DIFF
--- a/frontend/pages/SoftwarePage/SoftwarePage.tsx
+++ b/frontend/pages/SoftwarePage/SoftwarePage.tsx
@@ -394,7 +394,7 @@ const SoftwarePage = ({ children, router, location }: ISoftwarePageProps) => {
             underline={false}
             tipContent={
               <div className={`${baseClass}__header__tooltip`}>
-                To manage automations select &ldquo;All teams&rdquo;.
+                Select &ldquo;All teams&rdquo; to manage automations.
               </div>
             }
             disableTooltip={isAllTeamsSelected}
@@ -412,9 +412,25 @@ const SoftwarePage = ({ children, router, location }: ISoftwarePageProps) => {
           </TooltipWrapper>
         )}
         {canAddSoftware && (
-          <Button onClick={onAddSoftware} variant="brand">
-            <span>Add software</span>
-          </Button>
+          <TooltipWrapper
+            underline={false}
+            tipContent={
+              <div className={`${baseClass}__header__tooltip`}>
+                Select a team to add software.
+              </div>
+            }
+            disableTooltip={!isAllTeamsSelected}
+            position="top"
+            showArrow
+          >
+            <Button
+              onClick={onAddSoftware}
+              variant="brand"
+              disabled={isAllTeamsSelected}
+            >
+              <span>Add software</span>
+            </Button>
+          </TooltipWrapper>
         )}
       </div>
     );


### PR DESCRIPTION
## Issue
For #27382 

## Description
- Quick win 
- When members of Fleet's software team gets fooled to click a button that doesn't work 23049830 times, I wonder how many times our users are getting fooled.

## Screenshot of fix
<img width="926" alt="Screenshot 2025-03-20 at 4 56 21 PM" src="https://github.com/user-attachments/assets/2dc3999e-bcd2-4d45-912e-696f669937d2" />




# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [ ] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
- [ ] Added/updated automated tests
- [x] A detailed QA plan exists on the associated ticket (if it isn't there, work with the product group's QA engineer to add it)
- [x] Manual QA for all new/changed functionality
