### PR TITLE
Product Design rituals

### DIFF
--- a/handbook/product-design/product-design.rituals.yml
+++ b/handbook/product-design/product-design.rituals.yml
@@ -82,7 +82,7 @@
   task: "Pre-sprint prioritization" # 2024-03-06 TODO: Link to responsibility or corresponding "how to" info e.g. https://fleetdm.com/handbook/company/product-groups#making-changes
   startedOn: "2024-02-27" 
   frequency: "Triweekly"
-  description: "Align on priorities for upcoming sprint."
+  description: "Decide which stories and bugs to bring in to the upcoming sprint. Ahead of the call, Engineering Managers (EM) for each product group prepare their team's estimated capacity that factors in time off (PTO) and the on-call rotation."
   dri: "noahtalerman"
 -
   task: "User story review"


### PR DESCRIPTION
- Capacity is added to the [agenda doc](https://docs.google.com/document/d/1DFWTqiWSNCPvqD-MNJ40cg2kmJUvQRJ4rz2EJJeuAH0/edit?tab=t.0) before the call. Why? It's hard to do live. Easy to rush and mess up.
