### PR TITLE
Docs: Update vitals in queries.yml

### DIFF
--- a/docs/queries.yml
+++ b/docs/queries.yml
@@ -194,6 +194,25 @@ spec:
   discovery: google_chrome_profiles
   purpose: Informational
   tags: built-in
+---
+apiVersion: v1
+kind: built-in
+spec:
+  name: Host certificates (macOS)
+  platform: darwin
+  description: Retrieves certificates from an Apple device.
+  query: |
+    SELECT
+        ca, common_name, subject, issuer,
+        key_algorithm, key_strength, key_usage, signing_algorithm,
+        not_valid_after, not_valid_before,
+        serial, sha1
+      FROM
+        certificates
+      WHERE
+        path = '/Library/Keychains/System.keychain';
+  purpose: Informational
+  tags: built-in
 # --- # Note: this vital is commented out because it requires the kubequery osquery extension.
 # apiVersion: v1
 # kind: built-in
@@ -949,19 +968,7 @@ spec:
       '' AS vendor,
       '' AS arch,
       path AS installed_path
-    FROM cached_users CROSS JOIN firefox_addons USING (uid)
-    UNION
-    SELECT
-      name AS name,
-      version AS version,
-      '' AS extension_id,
-      '' AS browser,
-      'python_packages' AS source,
-      '' AS release,
-      '' AS vendor,
-      '' AS arch,
-      path AS installed_path
-    FROM python_packages
+    FROM cached_users CROSS JOIN firefox_addons USING (uid);
   purpose: Informational
   tags: built-in
 ---
@@ -1098,6 +1105,50 @@ spec:
           LEFT JOIN remoting_name ON apps.path = REPLACE(remoting_name.path, '/Contents/Resources/application.ini', '')
           WHERE apps.bundle_identifier = 'org.mozilla.firefox'
   discovery: parse_ini
+  purpose: Informational
+  tags: built-in
+---
+apiVersion: v1
+kind: built-in
+spec:
+  name: Software Python packages
+  platform: darwin, windows, linux
+  description: Retrieves python packages installed on a host.
+  query: |
+    SELECT
+          name AS name,
+          version AS version,
+          '' AS extension_id,
+          '' AS browser,
+          'python_packages' AS source,
+          '' AS vendor,
+          path AS installed_path
+        FROM python_packages;
+  discovery: osquery_info
+  purpose: Informational
+  tags: built-in
+---
+apiVersion: v1
+kind: built-in
+spec:
+  name: Software Python packages including user directory
+  platform: darwin, windows, linux
+  description: Retrieves python packages installed on a host. As of osquery version 5.16.0, the python_packages table searches user directories with support from a cross join on users. See <a href="https://fleetdm.com/guides/osquery-consider-joining-against-the-users-table">this guide</a> for more information.
+  query: |
+    WITH cached_users AS (WITH cached_groups AS (select * from groups)
+     SELECT uid, username, type, groupname, shell
+     FROM users LEFT JOIN cached_groups USING (gid)
+     WHERE type <> 'special' AND shell NOT LIKE '%/false' AND shell NOT LIKE '%/nologin' AND shell NOT LIKE '%/shutdown' AND shell NOT LIKE '%/halt' AND username NOT LIKE '%$' AND username NOT LIKE '\_%' ESCAPE '\' AND NOT (username = 'sync' AND shell ='/bin/sync' AND directory <> ''))
+        SELECT
+          name AS name,
+          version AS version,
+          '' AS extension_id,
+          '' AS browser,
+          'python_packages' AS source,
+          '' AS vendor,
+          path AS installed_path
+        FROM cached_users CROSS JOIN python_packages USING (uid);
+  discovery: osquery_info
   purpose: Informational
   tags: built-in
 ---
@@ -1248,16 +1299,6 @@ spec:
       publisher AS vendor,
       install_location AS installed_path
     FROM programs
-    UNION
-    SELECT
-      name AS name,
-      version AS version,
-      '' AS extension_id,
-      '' AS browser,
-      'python_packages' AS source,
-      '' AS vendor,
-      path AS installed_path
-    FROM python_packages
     UNION
     SELECT
       name AS name,


### PR DESCRIPTION
Closes: https://github.com/fleetdm/confidential/issues/10005

Changes:
- Updated the vitals in docs/queries.yml to have the latest changes from docs/contributing/understanding-host-vitals.md (updated the software vitals for Windows and macOS, added the host certificate vital, added two python packages vitals)