### PR TITLE
fix: Also set `inValidNode` when CSP starts with comment

### DIFF
--- a/server/fleet/windows_mdm.go
+++ b/server/fleet/windows_mdm.go
@@ -97,6 +97,7 @@ func (m *MDMWindowsConfigProfile) ValidateUserProvided() error {
 			return errors.New("The file should include valid XML: processing instructions are not allowed.")
 
 		case xml.Comment:
+			inValidNode = true
 			continue
 
 		case xml.StartElement:

--- a/server/fleet/windows_mdm_test.go
+++ b/server/fleet/windows_mdm_test.go
@@ -423,6 +423,23 @@ func TestValidateUserProvided(t *testing.T) {
 			wantErr: "",
 		},
 		{
+			name: "XML with top level comment followed by invalid element",
+			profile: MDMWindowsConfigProfile{
+				SyncML: []byte(`
+				  <!-- this is a comment -->
+				  <!-- this is another comment -->
+					<LocURI>Custom/URI</LocURI>
+				  <Replace>
+				  <!-- this is a comment inside replace -->
+				    <Target>
+				      <LocURI>Custom/URI</LocURI>
+				    </Target>
+				  </Replace>
+				`),
+			},
+			wantErr: "Windows configuration profiles can only have <Replace> or <Add> top level elements after comments",
+		},
+		{
 			name: "XML with nested root element in data",
 			profile: MDMWindowsConfigProfile{
 				SyncML: []byte(`

--- a/server/fleet/windows_mdm_test.go
+++ b/server/fleet/windows_mdm_test.go
@@ -428,7 +428,7 @@ func TestValidateUserProvided(t *testing.T) {
 				SyncML: []byte(`
 				  <!-- this is a comment -->
 				  <!-- this is another comment -->
-					<LocURI>Custom/URI</LocURI>
+				  <LocURI>Custom/URI</LocURI>
 				  <Replace>
 				  <!-- this is a comment inside replace -->
 				    <Target>


### PR DESCRIPTION
Addresses https://github.com/fleetdm/fleet/issues/26443#issuecomment-2737439271 after https://github.com/fleetdm/fleet/pull/27176 was merged.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/Committing-Changes.md#changes-files) for more information.
  - I did this in https://github.com/fleetdm/fleet/pull/27176, same change message.
- [x] Added/updated automated tests
- [x] Manual QA for all new/changed functionality
