### PR TITLE
reset some form inputs if others are changed to force users to reenter their values

### DIFF
--- a/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/CustomSCEPForm/CustomSCEPForm.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/CustomSCEPForm/CustomSCEPForm.tsx
@@ -102,7 +102,6 @@ const CustomSCEPForm = ({
           value={challenge}
           onChange={onInputChange}
           parseTarget
-          placeholder="••••••••••••"
           helpText="Password to authenticate with a SCEP server."
         />
       </div>

--- a/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/EditCertAuthorityModal/EditCertAuthorityModal.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/EditCertAuthorityModal/EditCertAuthorityModal.tsx
@@ -15,6 +15,7 @@ import {
   generateDefaultFormData,
   getErrorMessage,
   getCertificateAuthorityType,
+  updateFormData,
 } from "./helpers";
 
 import DigicertForm from "../DigicertForm";
@@ -49,11 +50,7 @@ const EditCertAuthorityModal = ({
   const onChangeForm = (update: { name: string; value: string }) => {
     setFormData((prevFormData) => {
       if (!prevFormData) return prevFormData;
-
-      return {
-        ...prevFormData,
-        [update.name]: update.value,
-      };
+      return updateFormData(certAuthority, prevFormData, update);
     });
   };
 

--- a/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/EditCertAuthorityModal/helpers.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/EditCertAuthorityModal/helpers.tsx
@@ -48,6 +48,45 @@ export const generateDefaultFormData = (
   };
 };
 
+export const updateFormData = (
+  certAuthority: ICertificateIntegration,
+  prevFormData: ICertFormData,
+  update: { name: string; value: string }
+) => {
+  const newData = { ...prevFormData, [update.name]: update.value };
+
+  // for some inputs that change we want to reset one of the other inputs
+  // and force users to re-enter it.
+  if (isDigicertCertIntegration(certAuthority)) {
+    if (
+      update.name === "name" ||
+      update.name === "url" ||
+      update.name === "profileId"
+    ) {
+      return {
+        ...newData,
+        apiToken: "",
+      };
+    }
+  } else if (isNDESCertIntegration(certAuthority)) {
+    if (update.name === "adminURL" || update.name === "username") {
+      return {
+        ...newData,
+        password: "",
+      };
+    }
+  } else if (isCustomSCEPCertIntegration(certAuthority)) {
+    if (update.name === "name" || update.name === "scepURL") {
+      return {
+        ...newData,
+        challenge: "",
+      };
+    }
+  }
+
+  return newData;
+};
+
 export const getErrorMessage = (err: unknown) => {
   return `Couldn't edit certificate authority. ${getDisplayErrMessage(err)}`;
 };

--- a/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/NDESForm/NDESForm.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/NDESForm/NDESForm.tsx
@@ -92,7 +92,6 @@ const NDESForm = ({
           type="password"
           onChange={onInputChange}
           parseTarget
-          placeholder="••••••••"
           blockAutoComplete
           helpText="The password required to log in to the SCEP admin page."
         />


### PR DESCRIPTION
For #26606

This makes a change to empty out the API token, Password, or Challange inputs when other inputs on their form changes. This forces the user to put in that value again so that their change can be authenticated.

