### PR TITLE
Contributing Feet-maintained apps

### DIFF
--- a/ee/maintained-apps/README.md
+++ b/ee/maintained-apps/README.md
@@ -14,15 +14,7 @@
       "slug": "box-drive/darwin",
       "unique_identifier": "com.box.desktop",
       "token": "box-drive",
-      "installer_format": "pkg",
-      "pre_uninstall_scripts": [
-         "(cd /Users/$LOGGED_IN_USER; sudo -u $LOGGED_IN_USER fileproviderctl domain remove -A com.box.desktop.boxfileprovider)",
-         "(cd /Users/$LOGGED_IN_USER; sudo -u $LOGGED_IN_USER /Applications/Box.app/Contents/MacOS/fpe/streem --remove-fpe-domain-and-archive-unsynced-content Box)",
-         "(cd /Users/$LOGGED_IN_USER; sudo -u $LOGGED_IN_USER /Applications/Box.app/Contents/MacOS/fpe/streem --remove-fpe-domain-and-preserve-unsynced-content Box)",
-         "(cd /Users/$LOGGED_IN_USER; defaults delete com.box.desktop)",
-         "echo \"${LOGGED_IN_USER} ALL = (root) NOPASSWD: /Library/Application\\ Support/Box/uninstall_box_drive_r\" >> /etc/sudoers.d/box_uninstall"
-      ],
-      "post_uninstall_scripts": ["rm /etc/sudoers.d/box_uninstall"]
+      "installer_format": "pkg"
    }
    ```
 5. Open a PR to the `fleet` repository with the new app file. This will trigger a CI job which will automatically update your PR with the required output files. These files contain important data such as the install and uninstall scripts for the app.


### PR DESCRIPTION
I think adding a Fleet-maintained looks scary than it needs to. 

`pre_uninstall_scripts` and `post_uninstall_scripts` are currently used by Fleet contributors to take on additions to the auto-generated uninstall script.

<img width="357" alt="Screenshot 2025-03-21 at 1 18 14 PM" src="https://github.com/user-attachments/assets/70f94e3e-5502-46f8-aab7-3f68bfb39ff6" />
