### PR TITLE
Different errors for configuration_profiles and batch endpoints.

### DIFF
--- a/server/fleet/apple_mdm_test.go
+++ b/server/fleet/apple_mdm_test.go
@@ -114,17 +114,17 @@ func TestMDMAppleConfigProfileScreenPayloadContent(t *testing.T) {
 		{
 			testName:     "AllFileVaultScreened",
 			payloadTypes: []string{"com.apple.security.FDERecoveryKeyEscrow", "com.apple.MCX.FileVault2", "com.apple.security.FDERecoveryRedirect"},
-			shouldFail:   []string{"The configuration profile can't include FileVault settings."},
+			shouldFail:   []string{mobileconfig.DiskEncryptionProfileRestrictionErrMsg},
 		},
 		{
 			testName:     "FileVault2Screened",
 			payloadTypes: []string{"com.apple.MCX.FileVault2"},
-			shouldFail:   []string{"The configuration profile can't include FileVault settings."},
+			shouldFail:   []string{mobileconfig.DiskEncryptionProfileRestrictionErrMsg},
 		},
 		{
 			testName:     "FDERecoveryKeyEscrowScreened",
 			payloadTypes: []string{"com.apple.security.FDERecoveryKeyEscrow"},
-			shouldFail:   []string{"The configuration profile can't include FileVault settings."},
+			shouldFail:   []string{mobileconfig.DiskEncryptionProfileRestrictionErrMsg},
 		},
 		{
 			testName:     "FDERecoveryRedirectScreened",
@@ -139,7 +139,7 @@ func TestMDMAppleConfigProfileScreenPayloadContent(t *testing.T) {
 		{
 			testName:     "FileVaultMixedWithOtherPayloadTypes",
 			payloadTypes: []string{"com.apple.MCX.FileVault2", "com.apple.security.firewall", "com.apple.security.FDERecoveryKeyEscrow", "com.apple.MCX"},
-			shouldFail:   []string{"The configuration profile can't include FileVault settings."},
+			shouldFail:   []string{mobileconfig.DiskEncryptionProfileRestrictionErrMsg},
 		},
 		{
 			testName:     "NoPayloadContent",

--- a/server/fleet/windows_mdm.go
+++ b/server/fleet/windows_mdm.go
@@ -156,7 +156,7 @@ func validateFleetProvidedLocURI(locURI string) error {
 	for fleetLocURI, errHints := range fleetProvidedLocURIValidationMap {
 		if strings.Contains(sanitizedLocURI, fleetLocURI) {
 			if fleetLocURI == syncml.FleetBitLockerTargetLocURI {
-				return errors.New("The configuration profile can't include BitLocker settings. To control these settings use disk encryption endpoint.")
+				return errors.New(syncml.DiskEncryptionProfileRestrictionErrMsg)
 			}
 			if len(errHints) == 2 {
 				return fmt.Errorf("Custom configuration profiles can't include %s settings. To control these settings, use the %s option.",

--- a/server/fleet/windows_mdm_test.go
+++ b/server/fleet/windows_mdm_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/fleetdm/fleet/v4/server/mdm"
+	"github.com/fleetdm/fleet/v4/server/mdm/microsoft/syncml"
 	"github.com/stretchr/testify/require"
 )
 
@@ -65,7 +66,7 @@ func TestValidateUserProvided(t *testing.T) {
 </Replace>
 `),
 			},
-			wantErr: "The configuration profile can't include BitLocker settings.",
+			wantErr: syncml.DiskEncryptionProfileRestrictionErrMsg,
 		},
 		{
 			name: "Reserved LocURI with implicit ./Device prefix",
@@ -78,7 +79,7 @@ func TestValidateUserProvided(t *testing.T) {
 </Replace>
 `),
 			},
-			wantErr: "The configuration profile can't include BitLocker settings.",
+			wantErr: syncml.DiskEncryptionProfileRestrictionErrMsg,
 		},
 		{
 			name: "XML with Multiple Replace Elements",
@@ -121,7 +122,7 @@ func TestValidateUserProvided(t *testing.T) {
 </Replace>
 `),
 			},
-			wantErr: "The configuration profile can't include BitLocker settings.",
+			wantErr: syncml.DiskEncryptionProfileRestrictionErrMsg,
 		},
 		{
 			name: "XML with Mixed Replace and Add",

--- a/server/mdm/apple/mobileconfig/mobileconfig.go
+++ b/server/mdm/apple/mobileconfig/mobileconfig.go
@@ -18,10 +18,11 @@ import (
 const (
 	// FleetFileVaultPayloadIdentifier is the value for the PayloadIdentifier
 	// used by Fleet to configure FileVault and FileVault Escrow.
-	FleetFileVaultPayloadIdentifier   = "com.fleetdm.fleet.mdm.filevault"
-	FleetFileVaultPayloadType         = "com.apple.MCX.FileVault2"
-	FleetFileVaultOptionsPayloadType  = "com.apple.MCX"
-	FleetRecoveryKeyEscrowPayloadType = "com.apple.security.FDERecoveryKeyEscrow"
+	FleetFileVaultPayloadIdentifier        = "com.fleetdm.fleet.mdm.filevault"
+	FleetFileVaultPayloadType              = "com.apple.MCX.FileVault2"
+	FleetFileVaultOptionsPayloadType       = "com.apple.MCX"
+	FleetRecoveryKeyEscrowPayloadType      = "com.apple.security.FDERecoveryKeyEscrow"
+	DiskEncryptionProfileRestrictionErrMsg = "Couldn't add. The configuration profile can't include FileVault settings."
 
 	// FleetdConfigPayloadIdentifier is the value for the PayloadIdentifier used
 	// by fleetd to read configuration values from the system.
@@ -252,8 +253,7 @@ func (mc *Mobileconfig) ScreenPayloads() error {
 		for _, t := range screenedTypes {
 			switch t {
 			case FleetFileVaultPayloadType, FleetFileVaultOptionsPayloadType, FleetRecoveryKeyEscrowPayloadType:
-				return errors.New("Couldn't add. The configuration profile can't include FileVault settings. " +
-					"To control these settings use disk encryption endpoint.")
+				return errors.New(DiskEncryptionProfileRestrictionErrMsg)
 			}
 		}
 		return fmt.Errorf("unsupported PayloadType(s): %s", strings.Join(screenedTypes, ", "))

--- a/server/mdm/microsoft/syncml/syncml.go
+++ b/server/mdm/microsoft/syncml/syncml.go
@@ -171,6 +171,8 @@ const (
 const (
 	FleetBitLockerTargetLocURI = "/Vendor/MSFT/BitLocker"
 	FleetOSUpdateTargetLocURI  = "/Vendor/MSFT/Policy/Config/Update"
+
+	DiskEncryptionProfileRestrictionErrMsg = "Couldn't add. The configuration profile can't include BitLocker settings."
 )
 
 // Supported MS-MDE2 enrollment versions

--- a/server/service/apple_mdm.go
+++ b/server/service/apple_mdm.go
@@ -405,6 +405,9 @@ func (svc *Service) NewMDMAppleConfigProfile(ctx context.Context, teamID uint, r
 	}
 
 	if err := cp.ValidateUserProvided(); err != nil {
+		if strings.Contains(err.Error(), mobileconfig.DiskEncryptionProfileRestrictionErrMsg) {
+			return nil, ctxerr.Wrap(ctx, &fleet.BadRequestError{Message: err.Error() + ` To control these settings use disk encryption endpoint.`})
+		}
 		return nil, ctxerr.Wrap(ctx, &fleet.BadRequestError{Message: err.Error()})
 	}
 	appConfig, err := svc.ds.AppConfig(ctx)

--- a/server/service/apple_mdm_test.go
+++ b/server/service/apple_mdm_test.go
@@ -1825,7 +1825,7 @@ func TestMDMBatchSetAppleProfiles(t *testing.T) {
 				<integer>1</integer>
 			</dict>
 			</plist>`, mobileconfig.FleetFileVaultPayloadType))},
-			"The configuration profile can't include FileVault settings.",
+			mobileconfig.DiskEncryptionProfileRestrictionErrMsg,
 		},
 	}
 	for name := range fleetmdm.FleetReservedProfileNames() {

--- a/server/service/integration_mdm_profiles_test.go
+++ b/server/service/integration_mdm_profiles_test.go
@@ -2352,7 +2352,7 @@ func (s *integrationMDMTestSuite) TestBatchSetMDMAppleProfiles() {
 		errMsg := extractServerErrorText(res.Body)
 		switch p {
 		case mobileconfig.FleetFileVaultPayloadType, mobileconfig.FleetFileVaultOptionsPayloadType, mobileconfig.FleetRecoveryKeyEscrowPayloadType:
-			assert.Contains(t, errMsg, "Validation Failed: Couldn't add. The configuration profile can't include FileVault settings.")
+			assert.Contains(t, errMsg, mobileconfig.DiskEncryptionProfileRestrictionErrMsg)
 		default:
 			assert.Contains(t, errMsg, fmt.Sprintf("Validation Failed: unsupported PayloadType(s): %s", p))
 		}
@@ -3209,7 +3209,7 @@ func (s *integrationMDMTestSuite) TestMDMConfigProfileCRUD() {
 
 	// Windows-reserved LocURI
 	assertWindowsProfile("bitlocker.xml", syncml.FleetBitLockerTargetLocURI, 0, nil, http.StatusBadRequest,
-		"Couldn't add. The configuration profile can't include BitLocker settings.")
+		syncml.DiskEncryptionProfileRestrictionErrMsg)
 	assertWindowsProfile("updates.xml", syncml.FleetOSUpdateTargetLocURI, testTeam.ID, nil, http.StatusBadRequest,
 		"Couldn't add. Custom configuration profiles can't include Windows updates settings.")
 
@@ -4313,7 +4313,7 @@ func (s *integrationMDMTestSuite) TestBatchSetMDMProfiles() {
 		errMsg := extractServerErrorText(res.Body)
 		switch p {
 		case mobileconfig.FleetFileVaultPayloadType, mobileconfig.FleetFileVaultOptionsPayloadType, mobileconfig.FleetRecoveryKeyEscrowPayloadType:
-			assert.Contains(t, errMsg, "Validation Failed: Couldn't add. The configuration profile can't include FileVault settings.")
+			assert.Contains(t, errMsg, mobileconfig.DiskEncryptionProfileRestrictionErrMsg)
 		default:
 			assert.Contains(t, errMsg, fmt.Sprintf("Validation Failed: unsupported PayloadType(s): %s", p))
 		}
@@ -4366,7 +4366,7 @@ func (s *integrationMDMTestSuite) TestBatchSetMDMProfiles() {
 		{Name: "N3", Contents: syncMLForTest("./Foo/Bar")},
 	}}, http.StatusUnprocessableEntity, "team_id", fmt.Sprint(tm.ID))
 	errMsg = extractServerErrorText(res.Body)
-	assert.Contains(t, errMsg, "Validation Failed: The configuration profile can't include BitLocker settings.")
+	assert.Contains(t, errMsg, syncml.DiskEncryptionProfileRestrictionErrMsg)
 
 	// os updates
 	res = s.Do("POST", "/api/v1/fleet/mdm/profiles/batch", batchSetMDMProfilesRequest{Profiles: []fleet.MDMProfileBatchPayload{
@@ -4592,7 +4592,7 @@ func (s *integrationMDMTestSuite) TestBatchSetMDMProfilesBackwardsCompat() {
 		errMsg := extractServerErrorText(res.Body)
 		switch p {
 		case mobileconfig.FleetFileVaultPayloadType, mobileconfig.FleetFileVaultOptionsPayloadType, mobileconfig.FleetRecoveryKeyEscrowPayloadType:
-			assert.Contains(t, errMsg, "Validation Failed: Couldn't add. The configuration profile can't include FileVault settings.")
+			assert.Contains(t, errMsg, mobileconfig.DiskEncryptionProfileRestrictionErrMsg)
 		default:
 			assert.Contains(t, errMsg, fmt.Sprintf("Validation Failed: unsupported PayloadType(s): %s", p))
 		}
@@ -4616,7 +4616,7 @@ func (s *integrationMDMTestSuite) TestBatchSetMDMProfilesBackwardsCompat() {
 		"N3":                              syncMLForTest("./Foo/Bar"),
 	}}, http.StatusUnprocessableEntity, "team_id", fmt.Sprint(tm.ID))
 	errMsg := extractServerErrorText(res.Body)
-	assert.Contains(t, errMsg, "Validation Failed: The configuration profile can't include BitLocker settings.")
+	assert.Contains(t, errMsg, syncml.DiskEncryptionProfileRestrictionErrMsg)
 
 	// os updates
 	res = s.Do("POST", "/api/v1/fleet/mdm/profiles/batch", map[string]any{"profiles": map[string][]byte{

--- a/server/service/mdm.go
+++ b/server/service/mdm.go
@@ -2101,7 +2101,7 @@ func getWindowsProfiles(
 		if err := mdmProf.ValidateUserProvided(); err != nil {
 			msg := err.Error()
 			if strings.Contains(msg, syncml.DiskEncryptionProfileRestrictionErrMsg) {
-				msg = msg + ` To control disk encryption use config API endpoint or add "enable_disk_encryption" to your YAML file.`
+				msg += ` To control disk encryption use config API endpoint or add "enable_disk_encryption" to your YAML file.`
 			}
 			return nil, ctxerr.Wrap(ctx,
 				fleet.NewInvalidArgumentError(fmt.Sprintf("profiles[%s]", profile.Name), msg))

--- a/server/service/mdm.go
+++ b/server/service/mdm.go
@@ -30,8 +30,10 @@ import (
 	"github.com/fleetdm/fleet/v4/server/fleet"
 	"github.com/fleetdm/fleet/v4/server/mdm"
 	apple_mdm "github.com/fleetdm/fleet/v4/server/mdm/apple"
+	"github.com/fleetdm/fleet/v4/server/mdm/apple/mobileconfig"
 	"github.com/fleetdm/fleet/v4/server/mdm/assets"
 	"github.com/fleetdm/fleet/v4/server/mdm/cryptoutil"
+	"github.com/fleetdm/fleet/v4/server/mdm/microsoft/syncml"
 	nanomdm "github.com/fleetdm/fleet/v4/server/mdm/nanomdm/mdm"
 	"github.com/fleetdm/fleet/v4/server/ptr"
 	"github.com/fleetdm/fleet/v4/server/service/middleware/endpoint_utils"
@@ -1406,9 +1408,14 @@ func (svc *Service) NewMDMWindowsConfigProfile(ctx context.Context, teamID uint,
 		SyncML: b,
 	}
 	if err := cp.ValidateUserProvided(); err != nil {
+		msg := err.Error()
+		if strings.Contains(msg, syncml.DiskEncryptionProfileRestrictionErrMsg) {
+			return nil, ctxerr.Wrap(ctx,
+				&fleet.BadRequestError{Message: msg + " To control these settings use disk encryption endpoint."})
+		}
+
 		// this is not great, but since the validations are shared between the CLI
 		// and the API, we must make some changes to error message here.
-		msg := err.Error()
 		if ix := strings.Index(msg, "To control these settings,"); ix >= 0 {
 			msg = strings.TrimSpace(msg[:ix])
 		}
@@ -1992,8 +1999,14 @@ func getAppleProfiles(
 		}
 
 		if err := mdmProf.ValidateUserProvided(); err != nil {
-			return nil, nil, ctxerr.Wrap(ctx,
-				fleet.NewInvalidArgumentError(prof.Name, err.Error()))
+			var iae *fleet.InvalidArgumentError
+			if strings.Contains(err.Error(), mobileconfig.DiskEncryptionProfileRestrictionErrMsg) {
+				iae = fleet.NewInvalidArgumentError(prof.Name,
+					mobileconfig.DiskEncryptionProfileRestrictionErrMsg+` To control disk encryption use config API endpoint or add "enable_disk_encryption" to your YAML file.`)
+			} else {
+				iae = fleet.NewInvalidArgumentError(prof.Name, err.Error())
+			}
+			return nil, nil, ctxerr.Wrap(ctx, iae)
 		}
 
 		if mdmProf.Name != prof.Name {
@@ -2086,8 +2099,12 @@ func getWindowsProfiles(
 		}
 
 		if err := mdmProf.ValidateUserProvided(); err != nil {
+			msg := err.Error()
+			if strings.Contains(msg, syncml.DiskEncryptionProfileRestrictionErrMsg) {
+				msg = msg + ` To control disk encryption use config API endpoint or add "enable_disk_encryption" to your YAML file.`
+			}
 			return nil, ctxerr.Wrap(ctx,
-				fleet.NewInvalidArgumentError(fmt.Sprintf("profiles[%s]", profile.Name), err.Error()))
+				fleet.NewInvalidArgumentError(fmt.Sprintf("profiles[%s]", profile.Name), msg))
 		}
 
 		profs[i] = mdmProf

--- a/server/service/mdm_test.go
+++ b/server/service/mdm_test.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"github.com/fleetdm/fleet/v4/server/mdm/apple/mobileconfig"
+	"github.com/fleetdm/fleet/v4/server/mdm/microsoft/syncml"
 	nanodep_client "github.com/fleetdm/fleet/v4/server/mdm/nanodep/client"
 	nanodep_mock "github.com/fleetdm/fleet/v4/server/mock/nanodep"
 	"github.com/jmoiron/sqlx"
@@ -1220,7 +1221,7 @@ func TestUploadWindowsMDMConfigProfileValidations(t *testing.T) {
 		{"Replace and non-Replace", 0, `<Replace>a</Replace><Get>b</Get>`, true, "Windows configuration profiles can only have <Replace> or <Add> top level elements."},
 		{"BitLocker profile", 0,
 			`<Replace><Item><Target><LocURI>./Device/Vendor/MSFT/BitLocker/AllowStandardUserEncryption</LocURI></Target></Item></Replace>`, true,
-			"The configuration profile can't include BitLocker settings."},
+			syncml.DiskEncryptionProfileRestrictionErrMsg},
 		{"Windows updates profile", 0, `<Replace><Item><Target><LocURI> ./Device/Vendor/MSFT/Policy/Config/Update/ConfigureDeadlineNoAutoRebootForFeatureUpdates </LocURI></Target></Item></Replace>`, true, "Custom configuration profiles can't include Windows updates settings."},
 		{"unsupported Fleet variable", 0, `<Replace>$FLEET_VAR_BOZO</Replace>`, true, "Fleet variable"},
 
@@ -1234,7 +1235,7 @@ func TestUploadWindowsMDMConfigProfileValidations(t *testing.T) {
 		{"team Replace and non-Replace", 1, `<Replace>a</Replace><Get>b</Get>`, true, "Windows configuration profiles can only have <Replace> or <Add> top level elements."},
 		{"team BitLocker profile", 1,
 			`<Replace><Item><Target><LocURI>./Device/Vendor/MSFT/BitLocker/AllowStandardUserEncryption</LocURI></Target></Item></Replace>`, true,
-			"The configuration profile can't include BitLocker settings."},
+			syncml.DiskEncryptionProfileRestrictionErrMsg},
 		{"team Windows updates profile", 1, `<Replace><Item><Target><LocURI> ./Device/Vendor/MSFT/Policy/Config/Update/ConfigureDeadlineNoAutoRebootForFeatureUpdates </LocURI></Target></Item></Replace>`, true, "Custom configuration profiles can't include Windows updates settings."},
 
 		{"invalid team", 2, `<Replace></Replace>`, true, "not found"},
@@ -1582,7 +1583,7 @@ func TestMDMBatchSetProfiles(t *testing.T) {
 			</plist>`, mobileconfig.FleetFileVaultPayloadType)),
 				},
 			},
-			"The configuration profile can't include FileVault settings.",
+			mobileconfig.DiskEncryptionProfileRestrictionErrMsg,
 		},
 		{
 			"unsupported Apple config profile Fleet variable",


### PR DESCRIPTION
For #24862 

Unreleased bug.
Made disk encryption errors different between `configuration_profiles` and `batch` endpoints.

# Checklist for submitter
- [x] Added/updated automated tests
- [x] A detailed QA plan exists on the associated ticket (if it isn't there, work with the product group's QA engineer to add it)
- [x] Manual QA for all new/changed functionality
- [x] For unreleased bug fixes in a release candidate, confirmed that the fix is not expected to adversely impact load test results or alerted the release DRI if additional load testing is needed.
