### PR TITLE
Cherry-Pick: Fix typo in "clean up duplicate Zoom" migration query

### DIFF
--- a/server/datastore/mysql/migrations/tables/20250320200000_FMAv2.go
+++ b/server/datastore/mysql/migrations/tables/20250320200000_FMAv2.go
@@ -98,7 +98,7 @@ ALTER TABLE fleet_maintained_apps
 
 	// clear old Zoom FMA before swapping in new one
 	if len(slugs) > 1 || (len(slugs) == 1 && slugs[0] == "zoom/darwin") {
-		_, err = tx.Exec(`DELETE FROM fleet_maintaned_apps WHERE slug = 'zoom/darwin'`)
+		_, err = tx.Exec(`DELETE FROM fleet_maintained_apps WHERE slug = 'zoom/darwin'`)
 		if err != nil {
 			return fmt.Errorf("failed to remove duplicate Zoom FMA: %w", err)
 		}


### PR DESCRIPTION
Merged into `main` in #27420.