### PR TITLE
Speeding up Go tests in CI.

### DIFF
--- a/.github/workflows/test-go.yaml
+++ b/.github/workflows/test-go.yaml
@@ -88,6 +88,7 @@ jobs:
     - name: Install Go Dependencies
       run: make deps-go
 
+    # This step takes >20 seconds and should be skipped for jobs that don't need it. https://github.com/fleetdm/fleet/issues/27435
     - name: Install ZSH
       run: sudo apt update && sudo apt install -y zsh
 

--- a/.github/workflows/test-go.yaml
+++ b/.github/workflows/test-go.yaml
@@ -84,12 +84,14 @@ jobs:
         sudo cp tools/smtp4dev/fleet.crt /usr/local/share/ca-certificates/
         sudo update-ca-certificates
 
-    # It seems faster not to cache Go dependencies
+    # Go dependencies are cached by actions/setup-go
     - name: Install Go Dependencies
-      run: make deps-go
+      run: go get .
 
     - name: Install ZSH
-      run: sudo apt update && sudo apt install -y zsh
+      # We may not get the latest zsh because we are NOT running 'sudo apt update' since it adds ~20s to each test.
+      # If you need the latest zsh, please create a separate job for that test.
+      run: sudo apt install -y zsh
 
     - name: Generate static files
       run: |

--- a/.github/workflows/test-go.yaml
+++ b/.github/workflows/test-go.yaml
@@ -86,12 +86,10 @@ jobs:
 
     # Go dependencies are cached by actions/setup-go
     - name: Install Go Dependencies
-      run: go get .
+      run: make deps-go
 
     - name: Install ZSH
-      # We may not get the latest zsh because we are NOT running 'sudo apt update' since it adds ~20s to each test.
-      # If you need the latest zsh, please create a separate job for that test.
-      run: sudo apt install -y zsh
+      run: sudo apt update && sudo apt install -y zsh
 
     - name: Generate static files
       run: |

--- a/Makefile
+++ b/Makefile
@@ -313,8 +313,9 @@ deps: deps-js deps-go
 deps-js:
 	yarn
 
+# We found that 'go get .' is faster than 'go mod download' in CI (dependencies are cached by actions/setup-go)
 deps-go:
-	go mod download
+	GOFLAGS=-mod=readonly go get .
 
 # check that the generated files in tools/cloner-check/generated_files match
 # the current version of the cloneable structures.

--- a/Makefile
+++ b/Makefile
@@ -314,9 +314,8 @@ deps-js:
 	yarn
 
 # We found that 'go get .' is faster than 'go mod download' in CI (dependencies are cached by actions/setup-go)
-# GOFLAGS=-mod=readonly go get .
 deps-go:
-	go mod download
+	GOFLAGS=-mod=readonly go get .
 
 # check that the generated files in tools/cloner-check/generated_files match
 # the current version of the cloneable structures.

--- a/Makefile
+++ b/Makefile
@@ -314,8 +314,9 @@ deps-js:
 	yarn
 
 # We found that 'go get .' is faster than 'go mod download' in CI (dependencies are cached by actions/setup-go)
+# GOFLAGS=-mod=readonly go get .
 deps-go:
-	GOFLAGS=-mod=readonly go get .
+	go mod download
 
 # check that the generated files in tools/cloner-check/generated_files match
 # the current version of the cloneable structures.


### PR DESCRIPTION
Using `go get .` (~3s) is faster than `go mod download` (~13s) in CI.