### PR TITLE
Allow patch release of fleetd via releaser script

### DIFF
--- a/.github/workflows/generate-desktop-targets.yml
+++ b/.github/workflows/generate-desktop-targets.yml
@@ -9,15 +9,11 @@ on:
       - '.github/workflows/generate-desktop-targets.yml'
     tags:
       - "orbit-*" # For testing, use a pre-release tag like 'orbit-1.24.0-1'    
-  workflow_dispatch:
 
 defaults:
   run:
     # fail-fast using bash -eo pipefail. See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#exit-codes-and-error-action-preference
     shell: bash
-
-env:
-  FLEET_DESKTOP_VERSION_FALLBACK: 1.40.1
 
 permissions:
   contents: write
@@ -34,12 +30,8 @@ jobs:
       - name: Set FLEET_DESKTOP_VERSION
         id: set-version
         run: |
-          if [[ "$GITHUB_REF" == refs/tags/orbit-* ]]; then
-            VERSION="${${GITHUB_REF#refs/tags/orbit-}#v}"   # Strip 'orbit-v'
-          else
-            VERSION="${FLEET_DESKTOP_VERSION_FALLBACK}"
-          fi
-          echo "FLEET_DESKTOP_VERSION=$VERSION" >> "$GITHUB_OUTPUT"
+          VERSION="${${GITHUB_REF#refs/tags/orbit-}#v}"   # Strip 'orbit-v'
+          "FLEET_DESKTOP_VERSION=$VERSION" >> "$GITHUB_OUTPUT"
   
   desktop-macos:
     # Set macOS version to '13' (previously was macos-12, and it was deprecated) for

--- a/.github/workflows/generate-desktop-targets.yml
+++ b/.github/workflows/generate-desktop-targets.yml
@@ -2,11 +2,6 @@ name: Generate Fleet Desktop targets for Orbit
 
 on:
   push:
-    branches:
-      - main
-    paths:
-      # The workflow can be triggered by modifying FLEET_DESKTOP_VERSION env.
-      - '.github/workflows/generate-desktop-targets.yml'
     tags:
       - "orbit-*" # For testing, use a pre-release tag like 'orbit-1.24.0-1'    
 

--- a/.github/workflows/generate-desktop-targets.yml
+++ b/.github/workflows/generate-desktop-targets.yml
@@ -8,7 +8,7 @@ on:
       # The workflow can be triggered by modifying FLEET_DESKTOP_VERSION env.
       - '.github/workflows/generate-desktop-targets.yml'
     tags:
-      - "orbit-*" # For testing, use a pre-release tag like 'orbit-1.24.0-1'
+      - "orbit-*" # For testing, use a pre-release tag like 'orbit-1.24.0-1'    
   workflow_dispatch:
 
 defaults:
@@ -17,7 +17,7 @@ defaults:
     shell: bash
 
 env:
-  FLEET_DESKTOP_VERSION: 1.40.1
+  FLEET_DESKTOP_VERSION_FALLBACK: 1.40.1
 
 permissions:
   contents: write
@@ -26,11 +26,27 @@ permissions:
   packages: write
 
 jobs:
+  set-version:
+    runs-on: ubuntu-latest
+    outputs:
+      FLEET_DESKTOP_VERSION: ${{ steps.set-version.outputs.FLEET_DESKTOP_VERSION }}
+    steps:
+      - name: Set FLEET_DESKTOP_VERSION
+        id: set-version
+        run: |
+          if [[ "$GITHUB_REF" == refs/tags/orbit-* ]]; then
+            VERSION="${${GITHUB_REF#refs/tags/orbit-}#v}"   # Strip 'orbit-v'
+          else
+            VERSION="${FLEET_DESKTOP_VERSION_FALLBACK}"
+          fi
+          echo "FLEET_DESKTOP_VERSION=$VERSION" >> "$GITHUB_OUTPUT"
+  
   desktop-macos:
     # Set macOS version to '13' (previously was macos-12, and it was deprecated) for
     # building the binary. This ensures compatibility with macOS version 13 and
     # later, avoiding runtime errors on systems using macOS 13 or newer.
     runs-on: macos-13
+    needs: set-version
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@63c24ba6bd7ba022e95695ff85de572c04a18142 # v2.7.0
@@ -72,7 +88,7 @@ jobs:
           AC_TEAM_ID=$AC_TEAM_ID \
           FLEET_DESKTOP_APPLE_AUTHORITY=$CODESIGN_IDENTITY \
           FLEET_DESKTOP_NOTARIZE=true \
-          FLEET_DESKTOP_VERSION=$FLEET_DESKTOP_VERSION \
+          FLEET_DESKTOP_VERSION=${{ needs.set-version.outputs.FLEET_DESKTOP_VERSION }} \
           make desktop-app-tar-gz
 
       - name: Attest binary
@@ -88,6 +104,7 @@ jobs:
           path: desktop.app.tar.gz
 
   desktop-windows:
+    needs: set-version
     runs-on: ubuntu-latest
     steps:
       - name: Harden Runner
@@ -105,7 +122,7 @@ jobs:
 
       - name: Generate fleet-desktop.exe
         run: |
-          FLEET_DESKTOP_VERSION=$FLEET_DESKTOP_VERSION \
+          FLEET_DESKTOP_VERSION=${{ needs.set-version.outputs.FLEET_DESKTOP_VERSION }} \
           make desktop-windows
 
       - name: Attest binary
@@ -134,6 +151,7 @@ jobs:
       DIGICERT_KEYLOCKER_CERTIFICATE_FINGERPRINT: ${{ secrets.DIGICERT_KEYLOCKER_CERTIFICATE_FINGERPRINT }}
 
   desktop-linux:
+    needs: set-version
     runs-on: ubuntu-latest
     steps:
       - name: Harden Runner
@@ -151,7 +169,7 @@ jobs:
 
       - name: Generate desktop.tar.gz
         run: |
-          FLEET_DESKTOP_VERSION=$FLEET_DESKTOP_VERSION \
+          FLEET_DESKTOP_VERSION=${{ needs.set-version.outputs.FLEET_DESKTOP_VERSION }} \
           make desktop-linux
 
       - name: Attest binary
@@ -167,6 +185,7 @@ jobs:
           path: desktop.tar.gz
 
   desktop-linux-arm64:
+    needs: set-version
     runs-on: ubuntu-latest
     steps:
       - name: Harden Runner
@@ -184,7 +203,7 @@ jobs:
 
       - name: Generate desktop.tar.gz
         run: |
-          FLEET_DESKTOP_VERSION=$FLEET_DESKTOP_VERSION \
+          FLEET_DESKTOP_VERSION=${{ needs.set-version.outputs.FLEET_DESKTOP_VERSION }} \
           make desktop-linux-arm64
 
       - name: Attest binary

--- a/.github/workflows/generate-desktop-targets.yml
+++ b/.github/workflows/generate-desktop-targets.yml
@@ -7,10 +7,8 @@ on:
     paths:
       # The workflow can be triggered by modifying FLEET_DESKTOP_VERSION env.
       - '.github/workflows/generate-desktop-targets.yml'
-  pull_request:
-    paths:
-      # The workflow can be triggered by modifying FLEET_DESKTOP_VERSION env.
-      - '.github/workflows/generate-desktop-targets.yml'
+    tags:
+      - "orbit-*" # For testing, use a pre-release tag like 'orbit-1.24.0-1'
   workflow_dispatch:
 
 defaults:

--- a/tools/tuf/README.md
+++ b/tools/tuf/README.md
@@ -296,7 +296,7 @@ ACTION=release-to-production ./tools/tuf/releaser.sh
 
 ### Doing a patch release of fleetd
 
-Patch releases follow the same process as releasing a minor version, except instead of checking out the `main` branch of fleet locally, you check out a patch branch of fleet, e.g.:
+Patch releases follow the same process as releasing a minor version, except instead of checking out the `main` branch of Fleet locally, you check out a patch branch of Fleet, e.g.:
 
 ```
 git checkout rc-minor-fleetd-v1.41.1

--- a/tools/tuf/README.md
+++ b/tools/tuf/README.md
@@ -294,6 +294,32 @@ TIMESTAMP_PASSPHRASE_1PASSWORD_PATH="Private/UPDATES TIMESTAMP/password" \
 ACTION=release-to-production ./tools/tuf/releaser.sh
 ```
 
+### Doing a patch release of fleetd
+
+Patch releases follow the same process as releasing a minor version, except instead of checking out the `main` branch of fleet locally, you check out a patch branch of fleet, e.g.:
+
+```
+git checkout rc-minor-fleet-v.4.65.1
+```
+
+As always, the `VERSION` env var used when running `releaser.sh` should match the version of the fleetd release, e.g.
+
+```sh
+TUF_DIRECTORY=/Users/foobar/updates-staging.fleetdm.com \
+COMPONENT=fleetd \
+ACTION=release-to-edge \
+VERSION=1.23.1 # <-- note the patch version \
+KEYS_SOURCE_DIRECTORY=/Volumes/FLEET-UPD/keys \
+TARGETS_PASSPHRASE_1PASSWORD_PATH="Private/UPDATES TARGETS/password" \
+SNAPSHOT_PASSPHRASE_1PASSWORD_PATH="Private/UPDATES SNAPSHOT/password" \
+TIMESTAMP_PASSPHRASE_1PASSWORD_PATH="Private/UPDATES TIMESTAMP/password" \
+GITHUB_USERNAME=foobar \
+GITHUB_TOKEN_1PASSWORD_PATH="Private/Github Token/password" \
+./tools/tuf/releaser.sh
+```
+
+After following the rest of the "Releasing to edge" steps above, publish your release using the instructions in "Promoting from edge to stable" above as you would for a minor release, again remembering to set the `VERSION` accordingly.
+
 ## Testing and improving the script
 
 - You can specify `GIT_REPOSITORY_DIRECTORY` to set a separate path for the Fleet repository (it uses the current by default).

--- a/tools/tuf/README.md
+++ b/tools/tuf/README.md
@@ -299,7 +299,7 @@ ACTION=release-to-production ./tools/tuf/releaser.sh
 Patch releases follow the same process as releasing a minor version, except instead of checking out the `main` branch of fleet locally, you check out a patch branch of fleet, e.g.:
 
 ```
-git checkout rc-minor-fleet-v4.65.1
+git checkout rc-minor-fleetd-v1.41.1
 ```
 
 As always, the `VERSION` env var used when running `releaser.sh` should match the version of the fleetd release, e.g.
@@ -308,7 +308,7 @@ As always, the `VERSION` env var used when running `releaser.sh` should match th
 TUF_DIRECTORY=/Users/foobar/updates-staging.fleetdm.com \
 COMPONENT=fleetd \
 ACTION=release-to-edge \
-VERSION=1.23.1 # <-- note the patch version \
+VERSION=1.41.1 # <-- note the patch version \
 KEYS_SOURCE_DIRECTORY=/Volumes/FLEET-UPD/keys \
 TARGETS_PASSPHRASE_1PASSWORD_PATH="Private/UPDATES TARGETS/password" \
 SNAPSHOT_PASSPHRASE_1PASSWORD_PATH="Private/UPDATES SNAPSHOT/password" \

--- a/tools/tuf/README.md
+++ b/tools/tuf/README.md
@@ -299,7 +299,7 @@ ACTION=release-to-production ./tools/tuf/releaser.sh
 Patch releases follow the same process as releasing a minor version, except instead of checking out the `main` branch of fleet locally, you check out a patch branch of fleet, e.g.:
 
 ```
-git checkout rc-minor-fleet-v.4.65.1
+git checkout rc-minor-fleet-v4.65.1
 ```
 
 As always, the `VERSION` env var used when running `releaser.sh` should match the version of the fleetd release, e.g.
@@ -317,6 +317,8 @@ GITHUB_USERNAME=foobar \
 GITHUB_TOKEN_1PASSWORD_PATH="Private/Github Token/password" \
 ./tools/tuf/releaser.sh
 ```
+
+See https://github.com/fleetdm/fleet/blob/main/orbit/TUF.md to find the latest released version.
 
 After following the rest of the "Releasing to edge" steps above, publish your release using the instructions in "Promoting from edge to stable" above as you would for a minor release, again remembering to set the `VERSION` accordingly.
 

--- a/tools/tuf/releaser.sh
+++ b/tools/tuf/releaser.sh
@@ -165,7 +165,8 @@ release_fleetd_to_edge () {
 }
 
 create_fleetd_release_pr () {
-    echo "Creating a PR for fleetd release changelog..."
+    CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+    echo "Creating a PR against '$CURRENT_BRANCH' for fleetd release changelog..."
     BRANCH_NAME=release-fleetd-v$VERSION
     pushd "$GIT_REPOSITORY_DIRECTORY"
     git checkout -b "$BRANCH_NAME"
@@ -175,7 +176,7 @@ create_fleetd_release_pr () {
     git commit -m "Release fleetd $VERSION"
     git push origin "$BRANCH_NAME"
     # Create a new PR with the changelog.
-    gh pr create -f -B main -t "Release fleetd $VERSION"
+    gh pr create -f -B $CURRENT_BRANCH -t "Release fleetd $VERSION"
     popd
 }
 
@@ -282,6 +283,8 @@ print_reminder () {
         :
     elif [[ $ACTION == "release-to-production" ]]; then
         prompt "To smoke test the release make sure to generate and install fleetd with on Linux amd64, Linux arm64, Windows, and macOS. Use 'fleetctl package [...] --update-interval=1m --orbit-channel=edge --desktop-channel=edge' if you are releasing fleetd to 'edge' or 'fleetctl package [...] --update-interval=1m --osqueryd-channel=edge' if you are releasing osquery to 'edge'."
+    elif [[ $ACTION == "create-fleetd-release-pr" ]]; then
+        :
     else
         echo "Unsupported action: $ACTION"
         exit 1

--- a/tools/tuf/releaser.sh
+++ b/tools/tuf/releaser.sh
@@ -319,6 +319,8 @@ elif [[ $ACTION == "update-timestamp" ]]; then
     push_to_staging
 elif [[ $ACTION == "release-to-production" ]]; then
     release_to_production
+elif [[ $ACTION == "create-fleetd-release-pr" ]]; then
+    create_fleetd_release_pr
 else
     echo "Unsupported action: $ACTION"
     exit 1

--- a/tools/tuf/releaser.sh
+++ b/tools/tuf/releaser.sh
@@ -132,7 +132,7 @@ release_fleetd_to_edge () {
     BRANCH_NAME="release-fleetd-v$VERSION"
     ORBIT_TAG="orbit-v$VERSION"
     if [[ "$SKIP_PR_AND_TAG_PUSH" != "1" ]]; then
-        prompt "A PR will be created to for the release of fleetd $VERSION, and a tag will be pushed to trigger a Github Action to build desktop and orbit."
+        prompt "A PR will be created for the release of fleetd $VERSION, and a tag will be pushed to trigger a Github Action to build desktop and orbit."
         pushd "$GIT_REPOSITORY_DIRECTORY"
         git checkout -b "$BRANCH_NAME"
         make changelog-orbit version="$VERSION"

--- a/tools/tuf/releaser.sh
+++ b/tools/tuf/releaser.sh
@@ -142,6 +142,7 @@ release_fleetd_to_edge () {
         git commit -m "Release fleetd $VERSION"
         git tag "$ORBIT_TAG"
         git push origin "$BRANCH_NAME" --follow-tags
+        # Create a new PR with the changelog.
         gh pr create -f -B main -t "Release fleetd $VERSION"
         popd
     fi

--- a/tools/tuf/releaser.sh
+++ b/tools/tuf/releaser.sh
@@ -132,7 +132,7 @@ release_fleetd_to_edge () {
     BRANCH_NAME="release-fleetd-v$VERSION"
     ORBIT_TAG="orbit-v$VERSION"
     if [[ "$SKIP_PR_AND_TAG_PUSH" != "1" ]]; then
-        prompt "A PR will be created to trigger a Github Action to build desktop."
+        prompt "A PR will be created to for the release of fleetd $VERSION, and a tag will be pushed to trigger a Github Action to build desktop and orbit."
         pushd "$GIT_REPOSITORY_DIRECTORY"
         git checkout -b "$BRANCH_NAME"
         make changelog-orbit version="$VERSION"
@@ -140,11 +140,9 @@ release_fleetd_to_edge () {
         "$GO_TOOLS_DIRECTORY/replace" .github/workflows/generate-desktop-targets.yml "FLEET_DESKTOP_VERSION: .+\n" "FLEET_DESKTOP_VERSION: $VERSION\n"
         git add .github/workflows/generate-desktop-targets.yml "$ORBIT_CHANGELOG"
         git commit -m "Release fleetd $VERSION"
-        git push origin "$BRANCH_NAME"
-        gh pr create -f -B main -t "Release fleetd $VERSION"
-        prompt "A 'git tag' will be created to trigger a Github Action to build orbit."
         git tag "$ORBIT_TAG"
-        git push origin "$ORBIT_TAG"
+        git push origin "$BRANCH_NAME" --follow-tags
+        gh pr create -f -B main -t "Release fleetd $VERSION"
         popd
     fi
     DESKTOP_ARTIFACT_DOWNLOAD_DIRECTORY="$ARTIFACTS_DOWNLOAD_DIRECTORY/desktop"


### PR DESCRIPTION
For #21396

# Details

This PR updates the automated release cycle for Orbit desktop, so that it triggers based on a pushed _tag_ rather than a pushed PR.  This has the following benefits:

* The release can be based off of any branch, rather than always using `main` as the base, so we can safely do patch release of desktop without including in-progress code from main
* It brings the desktop release process more in line with the main Orbit release process -- both are now triggered by a tag push.

We still create a PR for the release, to include a changelog.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

   - [ ] Manual QA must be performed in the three main OSs, macOS, Windows and Linux.
   - [ ] Auto-update manual QA, from released version of component to new version (see [tools/tuf/test](../tools/tuf/test/README.md)).

## Testing

To do -- will discuss with @lucasmrod 