### PR TITLE
Full-stack: Make "Server url" validation conditions consistent across Fleet, update Web Address form validation and submission logic per Fleet best practices (`frontend/docs/patterns.md`)

### DIFF
--- a/changes/27454-validation
+++ b/changes/27454-validation
@@ -1,1 +1,1 @@
-- Accept any string for the Fleet web URL
+- Accept any "http://" or "https://" prefixed Fleet web URL

--- a/changes/27454-validation
+++ b/changes/27454-validation
@@ -1,0 +1,1 @@
+- Accept any string for the Fleet web URL

--- a/frontend/components/forms/RegistrationForm/FleetDetails/FleetDetails.tests.jsx
+++ b/frontend/components/forms/RegistrationForm/FleetDetails/FleetDetails.tests.jsx
@@ -29,23 +29,6 @@ describe("FleetDetails - form", () => {
     ).toBeInTheDocument();
   });
 
-  it("validates the fleet web address field starts with https://", async () => {
-    const { user } = renderWithSetup(
-      <FleetDetails handleSubmit={handleSubmitSpy} currentPage />
-    );
-
-    await user.type(
-      screen.getByRole("textbox", { name: "Fleet web address" }),
-      "http://gnar.Fleet.co"
-    );
-    await user.click(screen.getByRole("button", { name: "Next" }));
-
-    expect(handleSubmitSpy).not.toHaveBeenCalled();
-    expect(
-      screen.getByText("Fleet web address must start with https://")
-    ).toBeInTheDocument();
-  });
-
   it("submits the form when valid", async () => {
     const { user } = renderWithSetup(
       <FleetDetails handleSubmit={handleSubmitSpy} currentPage />

--- a/frontend/components/forms/RegistrationForm/FleetDetails/FleetDetails.tests.jsx
+++ b/frontend/components/forms/RegistrationForm/FleetDetails/FleetDetails.tests.jsx
@@ -5,6 +5,8 @@ import { renderWithSetup } from "test/test-utils";
 
 import FleetDetails from "components/forms/RegistrationForm/FleetDetails";
 
+import INVALID_SERVER_URL_MESSAGE from "utilities/error_messages";
+
 describe("FleetDetails - form", () => {
   const handleSubmitSpy = jest.fn();
   it("renders", () => {
@@ -29,7 +31,30 @@ describe("FleetDetails - form", () => {
     ).toBeInTheDocument();
   });
 
-  it("submits the form when valid", async () => {
+  it("validates the Fleet server URL field starts with 'https://' or 'http://'", async () => {
+    const { user } = renderWithSetup(
+      <FleetDetails handleSubmit={handleSubmitSpy} currentPage />
+    );
+
+    const inputField = screen.getByRole("textbox", {
+      name: "Fleet web address",
+    });
+    const nextButton = screen.getByRole("button", { name: "Next" });
+
+    await user.type(inputField, "gnar.Fleet.co");
+    await user.click(nextButton);
+
+    expect(handleSubmitSpy).not.toHaveBeenCalled();
+    expect(screen.getByText(INVALID_SERVER_URL_MESSAGE)).toBeInTheDocument();
+
+    await user.type(inputField, "localhost:8080");
+    await user.click(nextButton);
+
+    expect(handleSubmitSpy).not.toHaveBeenCalled();
+    expect(screen.getByText(INVALID_SERVER_URL_MESSAGE)).toBeInTheDocument();
+  });
+
+  it("submits the form with valid https link", async () => {
     const { user } = renderWithSetup(
       <FleetDetails handleSubmit={handleSubmitSpy} currentPage />
     );
@@ -42,6 +67,21 @@ describe("FleetDetails - form", () => {
     // then
     expect(handleSubmitSpy).toHaveBeenCalledWith({
       server_url: "https://gnar.Fleet.co",
+    });
+  });
+  it("submits the form with valid http link", async () => {
+    const { user } = renderWithSetup(
+      <FleetDetails handleSubmit={handleSubmitSpy} currentPage />
+    );
+    // when
+    await user.type(
+      screen.getByRole("textbox", { name: "Fleet web address" }),
+      "http://localhost:8080"
+    );
+    await user.click(screen.getByRole("button", { name: "Next" }));
+    // then
+    expect(handleSubmitSpy).toHaveBeenCalledWith({
+      server_url: "http://localhost:8080",
     });
   });
 });

--- a/frontend/components/forms/RegistrationForm/FleetDetails/helpers.js
+++ b/frontend/components/forms/RegistrationForm/FleetDetails/helpers.js
@@ -1,14 +1,23 @@
 import { size } from "lodash";
 
+import validUrl from "components/forms/validators/valid_url";
+
 const validate = (formData) => {
   const errors = {};
   const { server_url: fleetWebAddress } = formData;
 
   if (!fleetWebAddress) {
     errors.server_url = "Fleet web address must be completed";
+  } else if (
+    !validUrl({
+      url: fleetWebAddress,
+      protocols: ["http", "https"],
+      allowAnyLocalHost: true,
+    })
+  ) {
+    errors.server_url =
+      "Fleet web address must be a valid https, http, or localhost URL";
   }
-
-  // explicitly removed check for "https" scheme
 
   const valid = !size(errors);
 

--- a/frontend/components/forms/RegistrationForm/FleetDetails/helpers.js
+++ b/frontend/components/forms/RegistrationForm/FleetDetails/helpers.js
@@ -2,6 +2,8 @@ import { size } from "lodash";
 
 import validUrl from "components/forms/validators/valid_url";
 
+import INVALID_SERVER_URL_MESSAGE from "utilities/error_messages";
+
 const validate = (formData) => {
   const errors = {};
   const { server_url: fleetWebAddress } = formData;
@@ -12,11 +14,10 @@ const validate = (formData) => {
     !validUrl({
       url: fleetWebAddress,
       protocols: ["http", "https"],
-      allowAnyLocalHost: true,
+      allowLocalHost: true,
     })
   ) {
-    errors.server_url =
-      "Fleet web address must be a valid https, http, or localhost URL";
+    errors.server_url = INVALID_SERVER_URL_MESSAGE;
   }
 
   const valid = !size(errors);

--- a/frontend/components/forms/RegistrationForm/FleetDetails/helpers.js
+++ b/frontend/components/forms/RegistrationForm/FleetDetails/helpers.js
@@ -8,10 +8,6 @@ const validate = (formData) => {
     errors.server_url = "Fleet web address must be completed";
   }
 
-  if (fleetWebAddress && !startsWith(fleetWebAddress, "https://")) {
-    errors.server_url = "Fleet web address must start with https://";
-  }
-
   const valid = !size(errors);
 
   return { valid, errors };

--- a/frontend/components/forms/RegistrationForm/FleetDetails/helpers.js
+++ b/frontend/components/forms/RegistrationForm/FleetDetails/helpers.js
@@ -1,4 +1,4 @@
-import { size, startsWith } from "lodash";
+import { size } from "lodash";
 
 const validate = (formData) => {
   const errors = {};
@@ -7,6 +7,8 @@ const validate = (formData) => {
   if (!fleetWebAddress) {
     errors.server_url = "Fleet web address must be completed";
   }
+
+  // explicitly removed check for "https" scheme
 
   const valid = !size(errors);
 

--- a/frontend/components/forms/validators/valid_url/valid_url.ts
+++ b/frontend/components/forms/validators/valid_url/valid_url.ts
@@ -6,8 +6,16 @@ interface IValidUrl {
   url: string;
   /**  Validate protocols specified */
   protocols?: ("http" | "https")[];
+  allowAnyLocalHost?: boolean;
 }
 
-export default ({ url, protocols }: IValidUrl): boolean => {
-  return isURL(url, { protocols });
+export default ({
+  url,
+  protocols,
+  allowAnyLocalHost = false,
+}: IValidUrl): boolean => {
+  if (allowAnyLocalHost && url.includes("localhost")) return true;
+  // this function also has a `require_valid_protocol` option, though as called it seems to already validate
+  // that the URL's protocol is one of those specified
+  return isURL(url, { protocols, require_protocol: !!protocols?.length });
 };

--- a/frontend/components/forms/validators/valid_url/valid_url.ts
+++ b/frontend/components/forms/validators/valid_url/valid_url.ts
@@ -6,16 +6,22 @@ interface IValidUrl {
   url: string;
   /**  Validate protocols specified */
   protocols?: ("http" | "https")[];
-  allowAnyLocalHost?: boolean;
+  allowLocalHost?: boolean;
 }
 
-export default ({
-  url,
-  protocols,
-  allowAnyLocalHost = false,
-}: IValidUrl): boolean => {
-  if (allowAnyLocalHost && url.includes("localhost")) return true;
+export default ({ url, protocols, allowLocalHost }: IValidUrl) => {
   // this function also has a `require_valid_protocol` option, though as called it seems to already validate
   // that the URL's protocol is one of those specified
-  return isURL(url, { protocols, require_protocol: !!protocols?.length });
+  if (allowLocalHost) {
+    if (
+      url.startsWith("http://localhost") ||
+      url.startsWith("https://localhost")
+    ) {
+      return true;
+    }
+  }
+  return isURL(url, {
+    protocols,
+    require_protocol: !!protocols?.length,
+  });
 };

--- a/frontend/components/forms/validators/valid_url/valid_url.ts
+++ b/frontend/components/forms/validators/valid_url/valid_url.ts
@@ -9,19 +9,10 @@ interface IValidUrl {
   allowLocalHost?: boolean;
 }
 
-export default ({ url, protocols, allowLocalHost }: IValidUrl) => {
-  // this function also has a `require_valid_protocol` option, though as called it seems to already validate
-  // that the URL's protocol is one of those specified
-  if (allowLocalHost) {
-    if (
-      url.startsWith("http://localhost") ||
-      url.startsWith("https://localhost")
-    ) {
-      return true;
-    }
-  }
+export default ({ url, protocols, allowLocalHost = false }: IValidUrl) => {
   return isURL(url, {
     protocols,
     require_protocol: !!protocols?.length,
+    require_tld: !allowLocalHost,
   });
 };

--- a/frontend/docs/patterns.md
+++ b/frontend/docs/patterns.md
@@ -208,10 +208,10 @@ When building a React-controlled form:
 - Use the native HTML `form` element to wrap the form.
 - Use a `Button` component with `type="submit"` for its submit button.
 - Write a submit handler, e.g. `handleSubmit`, that accepts an `evt:
-React.FormEvent<HTMLFormElement>` argument and, critically, calls `evt.preventDefault()` in its
-body. This prevents the HTML `form`'s default submit behavior from interfering with our custom
+React.FormEvent<HTMLFormElement>` argument and, critically:
+  - calls `evt.preventDefault()` in its body. This prevents the HTML `form`'s default submit behavior from interfering with our custom
 handler's logic.
-- This handler should do nothing if the form is in an invalid state, preventing submission by all means.
+  - does nothing (e.g., returns `null`) if the form is in an invalid state, preventing submission by any means.
 - Assign that handler to the `form`'s `onSubmit` property (*not* the submit button's `onClick`)
 
 ### Data validation
@@ -249,7 +249,9 @@ const onInputChange = ({ name, value }: IFormField) => {
   // new errors are only set onBlur
   const errsToSet: Record<string, string> = {};
   Object.keys(formErrors).forEach((k) => {
+    // @ts-ignore
     if (newErrs[k]) {
+      // @ts-ignore
       errsToSet[k] = newErrs[k];
     }
   });
@@ -271,7 +273,6 @@ const onInputBlur = () => {
 ```tsx
 const onFormSubmit = (evt: React.MouseEvent<HTMLFormElement>) => {
   evt.preventDefault();
-
   // return null if there are errors
   const errs = validateFormData(formData);
   if (Object.keys(errs).length > 0) {

--- a/frontend/docs/patterns.md
+++ b/frontend/docs/patterns.md
@@ -211,6 +211,7 @@ When building a React-controlled form:
 React.FormEvent<HTMLFormElement>` argument and, critically, calls `evt.preventDefault()` in its
 body. This prevents the HTML `form`'s default submit behavior from interfering with our custom
 handler's logic.
+- This handler should do nothing if the form is in an invalid state, preventing submission by all means.
 - Assign that handler to the `form`'s `onSubmit` property (*not* the submit button's `onClick`)
 
 ### Data validation

--- a/frontend/pages/admin/OrgSettingsPage/cards/WebAddress/WebAddress.tsx
+++ b/frontend/pages/admin/OrgSettingsPage/cards/WebAddress/WebAddress.tsx
@@ -3,7 +3,6 @@ import React, { useState } from "react";
 import Button from "components/buttons/Button";
 // @ts-ignore
 import InputField from "components/forms/fields/InputField";
-import validUrl from "components/forms/validators/valid_url";
 import SectionHeader from "components/SectionHeader";
 import GitOpsModeTooltipWrapper from "components/GitOpsModeTooltipWrapper";
 
@@ -11,10 +10,6 @@ import { IAppConfigFormProps, IFormField } from "../constants";
 
 interface IWebAddressFormData {
   serverURL: string;
-}
-
-interface IWebAddressFormErrors {
-  server_url?: string | null;
 }
 
 const baseClass = "app-config-form";
@@ -32,22 +27,8 @@ const WebAddress = ({
 
   const { serverURL } = formData;
 
-  const [formErrors, setFormErrors] = useState<IWebAddressFormErrors>({});
-
   const onInputChange = ({ name, value }: IFormField) => {
     setFormData({ ...formData, [name]: value });
-    setFormErrors({});
-  };
-
-  const validateForm = () => {
-    const errors: IWebAddressFormErrors = {};
-    if (!serverURL) {
-      errors.server_url = "Fleet server URL must be present";
-    } else if (!validUrl({ url: serverURL, protocols: ["http", "https"] })) {
-      errors.server_url = `${serverURL} is not a valid URL`;
-    }
-
-    setFormErrors(errors);
   };
 
   const onFormSubmit = (evt: React.MouseEvent<HTMLFormElement>) => {
@@ -79,8 +60,6 @@ const WebAddress = ({
             name="serverURL"
             value={serverURL}
             parseTarget
-            onBlur={validateForm}
-            error={formErrors.server_url}
             tooltip="The base URL of this instance for use in Fleet links."
             disabled={gitOpsModeEnabled}
           />
@@ -90,7 +69,7 @@ const WebAddress = ({
               <Button
                 type="submit"
                 variant="brand"
-                disabled={Object.keys(formErrors).length > 0 || disableChildren}
+                disabled={disableChildren}
                 className="button-wrap"
                 isLoading={isUpdatingSettings}
               >

--- a/frontend/pages/admin/OrgSettingsPage/cards/WebAddress/WebAddress.tsx
+++ b/frontend/pages/admin/OrgSettingsPage/cards/WebAddress/WebAddress.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+import { size } from "lodash";
 
 import Button from "components/buttons/Button";
 // @ts-ignore
@@ -53,8 +54,12 @@ const WebAddress = ({
 
     setFormErrors(errors);
   };
+
+  const formInvalid = !!size(formErrors);
+
   const onFormSubmit = (evt: React.MouseEvent<HTMLFormElement>) => {
     evt.preventDefault();
+    if (formInvalid) return;
 
     // Formatting of API not UI
     const formDataToSubmit = {
@@ -93,7 +98,7 @@ const WebAddress = ({
               <Button
                 type="submit"
                 variant="brand"
-                disabled={Object.keys(formErrors).length > 0 || disableChildren}
+                disabled={formInvalid || disableChildren}
                 className="button-wrap"
                 isLoading={isUpdatingSettings}
               >

--- a/frontend/pages/admin/OrgSettingsPage/cards/WebAddress/WebAddress.tsx
+++ b/frontend/pages/admin/OrgSettingsPage/cards/WebAddress/WebAddress.tsx
@@ -3,6 +3,7 @@ import React, { useState } from "react";
 import Button from "components/buttons/Button";
 // @ts-ignore
 import InputField from "components/forms/fields/InputField";
+import validUrl from "components/forms/validators/valid_url";
 import SectionHeader from "components/SectionHeader";
 import GitOpsModeTooltipWrapper from "components/GitOpsModeTooltipWrapper";
 
@@ -12,6 +13,9 @@ interface IWebAddressFormData {
   serverURL: string;
 }
 
+interface IWebAddressFormErrors {
+  server_url?: string | null;
+}
 const baseClass = "app-config-form";
 
 const WebAddress = ({
@@ -27,10 +31,28 @@ const WebAddress = ({
 
   const { serverURL } = formData;
 
+  const [formErrors, setFormErrors] = useState<IWebAddressFormErrors>({});
   const onInputChange = ({ name, value }: IFormField) => {
     setFormData({ ...formData, [name]: value });
+    setFormErrors({});
   };
 
+  const validateForm = () => {
+    const errors: IWebAddressFormErrors = {};
+    if (!serverURL) {
+      errors.server_url = "Fleet server URL must be present";
+    } else if (
+      !validUrl({
+        url: serverURL,
+        protocols: ["http", "https"],
+        allowAnyLocalHost: true,
+      })
+    ) {
+      errors.server_url = `${serverURL} is not a valid URL`;
+    }
+
+    setFormErrors(errors);
+  };
   const onFormSubmit = (evt: React.MouseEvent<HTMLFormElement>) => {
     evt.preventDefault();
 
@@ -60,6 +82,8 @@ const WebAddress = ({
             name="serverURL"
             value={serverURL}
             parseTarget
+            onBlur={validateForm}
+            error={formErrors.server_url}
             tooltip="The base URL of this instance for use in Fleet links."
             disabled={gitOpsModeEnabled}
           />
@@ -69,7 +93,7 @@ const WebAddress = ({
               <Button
                 type="submit"
                 variant="brand"
-                disabled={disableChildren}
+                disabled={Object.keys(formErrors).length > 0 || disableChildren}
                 className="button-wrap"
                 isLoading={isUpdatingSettings}
               >

--- a/frontend/pages/admin/OrgSettingsPage/cards/WebAddress/WebAddress.tsx
+++ b/frontend/pages/admin/OrgSettingsPage/cards/WebAddress/WebAddress.tsx
@@ -8,6 +8,8 @@ import validUrl from "components/forms/validators/valid_url";
 import SectionHeader from "components/SectionHeader";
 import GitOpsModeTooltipWrapper from "components/GitOpsModeTooltipWrapper";
 
+import INVALID_SERVER_URL_MESSAGE from "utilities/error_messages";
+
 import { IAppConfigFormProps, IFormField } from "../constants";
 
 interface IWebAddressFormData {
@@ -27,10 +29,10 @@ const validateFormData = ({ serverURL }: IWebAddressFormData) => {
     !validUrl({
       url: serverURL,
       protocols: ["http", "https"],
-      allowAnyLocalHost: true,
+      allowLocalHost: true,
     })
   ) {
-    errors.server_url = `${serverURL} is not a valid URL`;
+    errors.server_url = INVALID_SERVER_URL_MESSAGE;
   }
 
   return errors;

--- a/frontend/utilities/error_messages.ts
+++ b/frontend/utilities/error_messages.ts
@@ -1,0 +1,3 @@
+const INVALID_SERVER_URL_MESSAGE = `Fleet server URL must use “https” or “http”.`;
+
+export default INVALID_SERVER_URL_MESSAGE;

--- a/frontend/utilities/error_messages.ts
+++ b/frontend/utilities/error_messages.ts
@@ -1,3 +1,3 @@
-const INVALID_SERVER_URL_MESSAGE = `Fleet server URL must use “https” or “http”.`;
+const INVALID_SERVER_URL_MESSAGE = `Fleet server address must be a valid “https” or “http” URL.`;
 
 export default INVALID_SERVER_URL_MESSAGE;

--- a/server/fleet/errors.go
+++ b/server/fleet/errors.go
@@ -629,7 +629,7 @@ const (
 	InvalidLabelSpecifiedErrMsg = "Invalid label name(s):"
 
 	// Config
-	InvalidServerURLMsg = "Server URL must use https or http scheme with valid host, or localhost."
+	InvalidServerURLMsg = `Fleet server URL must use “https” or “http”.`
 )
 
 // ConflictError is used to indicate a conflict, such as a UUID conflict in the DB.

--- a/server/fleet/errors.go
+++ b/server/fleet/errors.go
@@ -627,6 +627,9 @@ const (
 
 	// Labels
 	InvalidLabelSpecifiedErrMsg = "Invalid label name(s):"
+
+	// Config
+	InvalidServerURLMsg = "Server URL must use https or http scheme with valid host, or localhost."
 )
 
 // ConflictError is used to indicate a conflict, such as a UUID conflict in the DB.

--- a/server/service/appconfig.go
+++ b/server/service/appconfig.go
@@ -417,6 +417,10 @@ func (svc *Service) ModifyAppConfig(ctx context.Context, p []byte, applyOpts fle
 	}
 	if appConfig.ServerSettings.ServerURL == "" {
 		invalid.Append("server_url", "Fleet server URL must be present")
+	} else {
+		if err := ValidateServerURL(appConfig.ServerSettings.ServerURL); err != nil {
+			invalid.Append("server_url", err.Error())
+		}
 	}
 
 	if appConfig.ActivityExpirySettings.ActivityExpiryEnabled && appConfig.ActivityExpirySettings.ActivityExpiryWindow < 1 {
@@ -924,8 +928,8 @@ func (svc *Service) ModifyAppConfig(ctx context.Context, p []byte, applyOpts fle
 }
 
 func (svc *Service) processAppConfigCAs(ctx context.Context, newAppConfig *fleet.AppConfig, oldAppConfig *fleet.AppConfig,
-	appConfig *fleet.AppConfig, invalid *fleet.InvalidArgumentError) (appConfigCAStatus, error) {
-
+	appConfig *fleet.AppConfig, invalid *fleet.InvalidArgumentError,
+) (appConfigCAStatus, error) {
 	var invalidLicense bool
 	fleetLicense, _ := license.FromContext(ctx)
 	if newAppConfig.Integrations.NDESSCEPProxy.Set && newAppConfig.Integrations.NDESSCEPProxy.Valid && !fleetLicense.IsPremium() {
@@ -1249,7 +1253,8 @@ func (svc *Service) populateCustomSCEPChallenges(ctx context.Context, remainingO
 // filterDeletedDigiCertCAs identifies deleted DigiCert integrations in the provided configs.
 // It mutates the provided result to set a deleted status where applicable and returns a list of the remaining (non-deleted) integrations.
 func filterDeletedDigiCertCAs(oldAppConfig *fleet.AppConfig, newAppConfig *fleet.AppConfig,
-	result *appConfigCAStatus) []fleet.DigiCertIntegration {
+	result *appConfigCAStatus,
+) []fleet.DigiCertIntegration {
 	remainingOldCAs := make([]fleet.DigiCertIntegration, 0, len(oldAppConfig.Integrations.DigiCert.Value))
 	for _, oldCA := range oldAppConfig.Integrations.DigiCert.Value {
 		var found bool
@@ -1271,7 +1276,8 @@ func filterDeletedDigiCertCAs(oldAppConfig *fleet.AppConfig, newAppConfig *fleet
 // filterDeletedCustomSCEPCAs identifies deleted custom SCEP integrations in the provided configs.
 // It mutates the provided result to set a deleted status where applicable and returns a list of the remaining (non-deleted) integrations.
 func filterDeletedCustomSCEPCAs(oldAppConfig *fleet.AppConfig, newAppConfig *fleet.AppConfig,
-	result *appConfigCAStatus) []fleet.CustomSCEPProxyIntegration {
+	result *appConfigCAStatus,
+) []fleet.CustomSCEPProxyIntegration {
 	remainingOldCAs := make([]fleet.CustomSCEPProxyIntegration, 0, len(oldAppConfig.Integrations.CustomSCEPProxy.Value))
 	for _, oldCA := range oldAppConfig.Integrations.CustomSCEPProxy.Value {
 		var found bool

--- a/server/service/appconfig.go
+++ b/server/service/appconfig.go
@@ -419,7 +419,7 @@ func (svc *Service) ModifyAppConfig(ctx context.Context, p []byte, applyOpts fle
 		invalid.Append("server_url", "Fleet server URL must be present")
 	} else {
 		if err := ValidateServerURL(appConfig.ServerSettings.ServerURL); err != nil {
-			invalid.Append("server_url", err.Error())
+			invalid.Append("server_url", "Couldn't update settings: "+err.Error())
 		}
 	}
 

--- a/server/service/validation_setup.go
+++ b/server/service/validation_setup.go
@@ -38,8 +38,9 @@ func ValidateServerURL(urlString string) error {
 			return errors.New(fleet.InvalidServerURLMsg)
 		}
 	} else {
+		// serverURL.Host doesn't contain the path in this case
 		// invalid scheme, permit only localhost URLs
-		if !strings.Contains(serverURL.Host, "localhost") {
+		if !strings.Contains(serverURL.Path, "localhost") {
 			return errors.New(fleet.InvalidServerURLMsg)
 		}
 	}

--- a/server/service/validation_setup.go
+++ b/server/service/validation_setup.go
@@ -32,26 +32,14 @@ func ValidateServerURL(urlString string) error {
 
 	// no valid scheme provided
 	if !(strings.HasPrefix(urlString, "http://") || strings.HasPrefix(urlString, "https://")) {
-		// left-append valid scheme to leverage `url.Parse`
-		parsed, err := url.Parse("https://" + urlString)
-		if err != nil {
-			return err
-		}
-		// "localhost" only acceptable host if no valid scheme (protocol) provided.
-		// Hostname() will pull out the substring directly after the left-appended scheme, excluding
-		// port. This has the added benefit of catching an invalid scheme provided (e.g. ftp) and will correctly invalidate
-		if parsed.Hostname() != "localhost" {
-			return errors.New(fleet.InvalidServerURLMsg)
-		}
-		return nil
+		return errors.New(fleet.InvalidServerURLMsg)
 	}
 
-	// valid scheme provided
+	// valid scheme provided - require host
 	parsed, err := url.Parse(urlString)
 	if err != nil {
 		return err
 	}
-	// host required with scheme if provided
 	if parsed.Host == "" {
 		return errors.New(fleet.InvalidServerURLMsg)
 	}

--- a/server/service/validation_setup.go
+++ b/server/service/validation_setup.go
@@ -29,18 +29,23 @@ func (mw validationMiddleware) NewAppConfig(ctx context.Context, payload fleet.A
 
 func ValidateServerURL(urlString string) error {
 	// TODO - implement more robust URL validation here
-	var parsed *url.URL
+
+	// no valid scheme provided
 	if !(strings.HasPrefix(urlString, "http://") || strings.HasPrefix(urlString, "https://")) {
 		parsed, err := url.Parse("https://" + urlString)
 		if err != nil {
 			return err
 		}
-		// localhost only acceptable host if no schem (protocol) provided
-		if parsed.Host != "localhost" {
+		// localhost only acceptable host if no schem (protocol) provided. .Host will include port (e.g.
+		// 8080), so we check for "localhost" prefix
+		// by checking for prefix, we also invalidate unsupported schemes like "ftp://"
+		if !strings.HasPrefix(parsed.Host, "localhost") {
 			return errors.New(fleet.InvalidServerURLMsg)
 		}
+		return nil
 	}
 
+	// scheme provided
 	parsed, err := url.Parse(urlString)
 	if err != nil {
 		return err

--- a/server/service/validation_setup.go
+++ b/server/service/validation_setup.go
@@ -12,6 +12,7 @@ func (mw validationMiddleware) NewAppConfig(ctx context.Context, payload fleet.A
 	if payload.ServerSettings.ServerURL == "" {
 		invalid.Append("server_url", "missing required argument")
 	}
+	// explicitly removed check for "https" scheme
 	if invalid.HasErrors() {
 		return nil, ctxerr.Wrap(ctx, invalid)
 	}

--- a/server/service/validation_setup.go
+++ b/server/service/validation_setup.go
@@ -28,6 +28,7 @@ func (mw validationMiddleware) NewAppConfig(ctx context.Context, payload fleet.A
 }
 
 func ValidateServerURL(urlString string) error {
+	// TODO - implement more robust URL validation here
 	var parsed *url.URL
 	if !(strings.HasPrefix(urlString, "http://") || strings.HasPrefix(urlString, "https://")) {
 		parsed, err := url.Parse("https://" + urlString)

--- a/server/service/validation_setup.go
+++ b/server/service/validation_setup.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"net/url"
-	"strings"
 
 	"github.com/fleetdm/fleet/v4/server/contexts/ctxerr"
 	"github.com/fleetdm/fleet/v4/server/fleet"
@@ -33,16 +32,12 @@ func ValidateServerURL(urlString string) error {
 		return err
 	}
 
-	if serverURL.Scheme == "https" || serverURL.Scheme == "http" {
-		if serverURL.Host == "" {
-			return errors.New(fleet.InvalidServerURLMsg)
-		}
-	} else {
-		// serverURL.Host doesn't contain the path in this case
-		// invalid scheme, permit only localhost URLs
-		if !strings.Contains(serverURL.Path, "localhost") {
-			return errors.New(fleet.InvalidServerURLMsg)
-		}
+	// scheme present, or "localhost" host. When no scheme, `url.Parse` incorreclty parses "localhost"
+	// as the scheme - obviously "localhost" not a scheme
+	// Since "localhost" host is the only case we want to allow no included scheme, for now, this
+	// works for us:
+	if !(serverURL.Scheme == "https" || serverURL.Scheme == "http" || serverURL.Scheme == "localhost") {
+		return errors.New(fleet.InvalidServerURLMsg)
 	}
 	return nil
 }

--- a/server/service/validation_setup.go
+++ b/server/service/validation_setup.go
@@ -2,9 +2,6 @@ package service
 
 import (
 	"context"
-	"errors"
-	"net/url"
-	"strings"
 
 	"github.com/fleetdm/fleet/v4/server/contexts/ctxerr"
 	"github.com/fleetdm/fleet/v4/server/fleet"
@@ -28,14 +25,14 @@ func (mw validationMiddleware) NewAppConfig(ctx context.Context, payload fleet.A
 }
 
 func validateServerURL(urlString string) error {
-	serverURL, err := url.Parse(urlString)
-	if err != nil {
-		return err
-	}
+	// serverURL, err := url.Parse(urlString)
+	// if err != nil {
+	// 	return err
+	// }
 
-	if serverURL.Scheme != "https" && !strings.Contains(serverURL.Host, "localhost") {
-		return errors.New("url scheme must be https")
-	}
+	// if serverURL.Scheme != "https" && !strings.Contains(serverURL.Host, "localhost") {
+	// 	return errors.New("url scheme must be https")
+	// }
 
 	return nil
 }

--- a/server/service/validation_setup.go
+++ b/server/service/validation_setup.go
@@ -9,30 +9,11 @@ import (
 
 func (mw validationMiddleware) NewAppConfig(ctx context.Context, payload fleet.AppConfig) (*fleet.AppConfig, error) {
 	invalid := &fleet.InvalidArgumentError{}
-	var serverURLString string
 	if payload.ServerSettings.ServerURL == "" {
 		invalid.Append("server_url", "missing required argument")
-	} else {
-		serverURLString = cleanupURL(payload.ServerSettings.ServerURL)
-	}
-	if err := validateServerURL(serverURLString); err != nil {
-		invalid.Append("server_url", err.Error())
 	}
 	if invalid.HasErrors() {
 		return nil, ctxerr.Wrap(ctx, invalid)
 	}
 	return mw.Service.NewAppConfig(ctx, payload)
-}
-
-func validateServerURL(urlString string) error {
-	// serverURL, err := url.Parse(urlString)
-	// if err != nil {
-	// 	return err
-	// }
-
-	// if serverURL.Scheme != "https" && !strings.Contains(serverURL.Host, "localhost") {
-	// 	return errors.New("url scheme must be https")
-	// }
-
-	return nil
 }

--- a/server/service/validation_setup.go
+++ b/server/service/validation_setup.go
@@ -46,7 +46,7 @@ func ValidateServerURL(urlString string) error {
 		return nil
 	}
 
-	// scheme provided
+	// valid scheme provided
 	parsed, err := url.Parse(urlString)
 	if err != nil {
 		return err

--- a/server/service/validation_setup.go
+++ b/server/service/validation_setup.go
@@ -32,14 +32,15 @@ func ValidateServerURL(urlString string) error {
 
 	// no valid scheme provided
 	if !(strings.HasPrefix(urlString, "http://") || strings.HasPrefix(urlString, "https://")) {
+		// left-append valid scheme to leverage `url.Parse`
 		parsed, err := url.Parse("https://" + urlString)
 		if err != nil {
 			return err
 		}
-		// localhost only acceptable host if no schem (protocol) provided. .Host will include port (e.g.
-		// 8080), so we check for "localhost" prefix
-		// by checking for prefix, we also invalidate unsupported schemes like "ftp://"
-		if !strings.HasPrefix(parsed.Host, "localhost") {
+		// "localhost" only acceptable host if no valid scheme (protocol) provided.
+		// Hostname() will pull out the substring directly after the left-appended scheme, excluding
+		// port. This has the added benefit of catching an invalid scheme provided (e.g. ftp) and will correctly invalidate
+		if parsed.Hostname() != "localhost" {
 			return errors.New(fleet.InvalidServerURLMsg)
 		}
 		return nil


### PR DESCRIPTION
## For #27454 

Consider Fleet web URL to be valid if it:

- (Front end and back end): uses “https://” or “http://” scheme
 and
- (Front end) accepts only valid or "localhost" hosts (e.g., "a.b.cc" or "localhost", but not "a.b")
- (Back end) accepts any host (e.g., "localhost", "a.b.cc", or even "a.b")


### Setup flow UI URL validation:
![setup](https://github.com/user-attachments/assets/34a428d2-5731-46f2-b708-c88b790e3667)

### Org settings UI URL validation:
![org-settings](https://github.com/user-attachments/assets/147916c8-9c5b-4ae7-9e14-625c65b42d0a)

### Server URL validation:
<img width="1464" alt="invalid-url-server" src="https://github.com/user-attachments/assets/83a112e1-6318-4b09-864d-fe66a223835d" />

### Invalid Fleet server URL in DB error:
![invalid-url-in-db](https://github.com/user-attachments/assets/aae591fb-6cc3-49bd-8556-22129be4c2c4)


- [x] Changes file added for user-visible changes in `changes/`,
- [x] Added/updated automated tests
- [ ] A detailed QA plan exists on the associated ticket (if it isn't there, work with the product group's QA engineer to add it)
- [x] Manual QA for all new/changed functionality