### PR TITLE
Update product-design.rituals.yml

### DIFF
--- a/handbook/product-design/product-design.rituals.yml
+++ b/handbook/product-design/product-design.rituals.yml
@@ -16,7 +16,7 @@
   task: "Design sprint kickoff" # 2024-03-06 TODO: Link to responsibility or corresponding "how to" info e.g. https://fleetdm.com/handbook/company/product-groups#making-changes
   startedOn: "2024-03-07" 
   frequency: "Triweekly" 
-  description: "Create stories for feature requests prioritized during Feature fest and add these stories to the Drafting board, add stories to the roadmap chart, assign stories to Product Designers, align on priorities, and create upcoming reference docs release branch." 
+  description: "Create stories (and, as needed, engineering research tasks) for feature requests prioritized during Feature fest and add these stories to the Drafting board, add stories to the roadmap chart, assign stories to Product Designers, align on priorities, and create upcoming reference docs release branch."
   moreInfoUrl: 
   dri: "noahtalerman"
 -

--- a/handbook/product-design/product-design.rituals.yml
+++ b/handbook/product-design/product-design.rituals.yml
@@ -16,7 +16,7 @@
   task: "Design sprint kickoff" # 2024-03-06 TODO: Link to responsibility or corresponding "how to" info e.g. https://fleetdm.com/handbook/company/product-groups#making-changes
   startedOn: "2024-03-07" 
   frequency: "Triweekly" 
-  description: "Create stories (and, as needed, engineering research stories) for feature requests prioritized during Feature fest; add these stories to the Drafting board and the roadmap chart; assign Product Designers (PD) and Engineering Support Individuals (ESP) to stories; align on priorities; and create an upcoming reference docs release branch."
+  description: "Review stories (and, as needed, create engineering research stories) for feature requests prioritized during Feature fest; assign Engineering DRIs to stories; align on priorities; and create an upcoming reference docs release branch."
   moreInfoUrl: 
   dri: "noahtalerman"
 -

--- a/handbook/product-design/product-design.rituals.yml
+++ b/handbook/product-design/product-design.rituals.yml
@@ -16,7 +16,7 @@
   task: "Design sprint kickoff" # 2024-03-06 TODO: Link to responsibility or corresponding "how to" info e.g. https://fleetdm.com/handbook/company/product-groups#making-changes
   startedOn: "2024-03-07" 
   frequency: "Triweekly" 
-  description: "Create stories (and, as needed, engineering research tasks) for feature requests prioritized during Feature fest and add these stories to the Drafting board, add stories to the roadmap chart, assign stories to Product Designers, align on priorities, and create upcoming reference docs release branch."
+  description: "Create stories (and, as needed, engineering research stories) for feature requests prioritized during Feature fest and add these stories to the Drafting board, add stories to the roadmap chart, assign stories to Product Designers, align on priorities, and create upcoming reference docs release branch."
   moreInfoUrl: 
   dri: "noahtalerman"
 -

--- a/handbook/product-design/product-design.rituals.yml
+++ b/handbook/product-design/product-design.rituals.yml
@@ -16,7 +16,7 @@
   task: "Design sprint kickoff" # 2024-03-06 TODO: Link to responsibility or corresponding "how to" info e.g. https://fleetdm.com/handbook/company/product-groups#making-changes
   startedOn: "2024-03-07" 
   frequency: "Triweekly" 
-  description: "Create stories (and, as needed, engineering research stories) for feature requests prioritized during Feature fest and add these stories to the Drafting board, add stories to the roadmap chart, assign stories to Product Designers, align on priorities, and create upcoming reference docs release branch."
+  description: "Create stories (and, as needed, engineering research stories) for feature requests prioritized during Feature fest; add these stories to the Drafting board and the roadmap chart; assign Product Designers (PD) and Engineering Support Individuals (ESP) to stories; align on priorities; and create an upcoming reference docs release branch."
   moreInfoUrl: 
   dri: "noahtalerman"
 -


### PR DESCRIPTION
- @noahtalerman: Engineerings Managers (EMs) attend the design sprint kickoff. EMs decide if we create research stories. This way, we can create and estimate them on the call so that they can be included in engineering sprint planning.

---

In #g-software retro we discussed how often tickets reqiure research or greater dev input during the design process, and how that work is adopted but not tracked/pointed, which ends up stressing dev resources.

One thing that's worked well is having devs in design reviews, but we also realize it's untenable to have a single dev attend and be responsible for giving dev input throughout.

We agreed to try implementing a ritual whereby stories are reviewed with dev before sprint planning so that everyone can have a better understanding of scope and what input is needed into a ticket. We also agreed to start writing and estimating tickets where dev research is needed so that it can be brought into sprint planning and resourcing can be properly allocated.

An additional bonus is that once a research story is assigned then there's a point person who can be invited to and contribute to design review / be a resource to design during the design process, which relieves the burden of individuals feeling they should always be the point person b/c no one has been assigned..