### PR TITLE
update gcp cloud run to use h2c networking by default

### DIFF
--- a/infrastructure/dogfood/terraform/gcp/cloud_run.tf
+++ b/infrastructure/dogfood/terraform/gcp/cloud_run.tf
@@ -94,7 +94,7 @@ resource "google_cloud_run_service" "default" {
         }
         image = var.image
         ports {
-          name           = "http1"
+          name           = "h2c"
           container_port = 8080
         }
         env {


### PR DESCRIPTION
I missed this setting in https://github.com/fleetdm/fleet/pull/26799