### PR TITLE
Check for invalid default serial number when fetching host details

### DIFF
--- a/changes/25993-default-serial-number
+++ b/changes/25993-default-serial-number
@@ -1,0 +1,1 @@
+- Fixed invalid default serial numbers being displayed for some hosts

--- a/server/service/osquery_test.go
+++ b/server/service/osquery_test.go
@@ -1634,7 +1634,7 @@ func TestDetailQueriesWithEmptyStrings(t *testing.T) {
       "cpu_subtype": "Intel x86-64h Haswell",
       "cpu_type": "x86_64h",
       "hardware_model": "MacBookPro11,4",
-      "hardware_serial": "NEW_HW_SERIAL",
+      "hardware_serial": "NEW_HW_SRL",
       "hardware_vendor": "Apple Inc.",
       "hardware_version": "1.0",
       "hostname": "computer.local",
@@ -1701,7 +1701,7 @@ func TestDetailQueriesWithEmptyStrings(t *testing.T) {
 	assert.Equal(t, int64(17179869184), gotHost.Memory)
 	assert.Equal(t, "computer.local", gotHost.Hostname)
 	assert.Equal(t, "uuid", gotHost.UUID)
-	assert.Equal(t, "NEW_HW_SERIAL", gotHost.HardwareSerial)
+	assert.Equal(t, "NEW_HW_SRL", gotHost.HardwareSerial)
 
 	// os_version
 	assert.Equal(t, "Mac OS X 10.10.6", gotHost.OSVersion)
@@ -1748,7 +1748,7 @@ func TestDetailQueries(t *testing.T) {
 	host := &fleet.Host{
 		ID:             1,
 		Platform:       "linux",
-		HardwareSerial: "HW_SERIAL",
+		HardwareSerial: "HW_SRL",
 	}
 	ctx = hostctx.NewContext(ctx, host)
 
@@ -2012,7 +2012,7 @@ func TestDetailQueries(t *testing.T) {
 	assert.Equal(t, "computer.local", gotHost.Hostname)
 	assert.Equal(t, "uuid", gotHost.UUID)
 	// The hardware serial should not have updated because return value was -1. See: https://github.com/fleetdm/fleet/issues/19789
-	assert.Equal(t, "HW_SERIAL", gotHost.HardwareSerial)
+	assert.Equal(t, "HW_SRL", gotHost.HardwareSerial)
 
 	// os_version
 	assert.Equal(t, "Mac OS X 10.10.6", gotHost.OSVersion)

--- a/server/service/osquery_utils/queries.go
+++ b/server/service/osquery_utils/queries.go
@@ -29,6 +29,10 @@ import (
 	"github.com/spf13/cast"
 )
 
+// Some machines don't have a correctly set serial number, create a default ignore list
+// https://github.com/fleetdm/fleet/issues/25993
+var invalidHardwareSerialRegexp = regexp.MustCompile("(?i)(?:default|serial|string)")
+
 type DetailQuery struct {
 	// Description is an optional description of the query to be displayed in the
 	// Host Vitals documentation https://fleetdm.com/docs/using-fleet/understanding-host-vitals
@@ -339,7 +343,9 @@ var hostDetailQueries = map[string]DetailQuery{
 			host.HardwareVendor = rows[0]["hardware_vendor"]
 			host.HardwareModel = rows[0]["hardware_model"]
 			host.HardwareVersion = rows[0]["hardware_version"]
-			if rows[0]["hardware_serial"] != "-1" { // ignoring the default -1 serial. See: https://github.com/fleetdm/fleet/issues/19789
+			// ignoring the default -1 serial. See: https://github.com/fleetdm/fleet/issues/19789
+			invalidHardwareSerial := rows[0]["hardware_serial"] == "-1" || invalidHardwareSerialRegexp.Match([]byte(rows[0]["hardware_serial"]))
+			if !invalidHardwareSerial {
 				host.HardwareSerial = rows[0]["hardware_serial"]
 			}
 			host.ComputerName = rows[0]["computer_name"]

--- a/server/service/osquery_utils/queries.go
+++ b/server/service/osquery_utils/queries.go
@@ -343,11 +343,11 @@ var hostDetailQueries = map[string]DetailQuery{
 			host.HardwareVendor = rows[0]["hardware_vendor"]
 			host.HardwareModel = rows[0]["hardware_model"]
 			host.HardwareVersion = rows[0]["hardware_version"]
-			// ignoring the default -1 serial. See: https://github.com/fleetdm/fleet/issues/19789
-			invalidHardwareSerial := rows[0]["hardware_serial"] == "-1" || invalidHardwareSerialRegexp.Match([]byte(rows[0]["hardware_serial"]))
-			if invalidHardwareSerial {
+			if invalidHardwareSerialRegexp.Match([]byte(rows[0]["hardware_serial"])) {
+				// If the serial number is a default (uninitialize) value, set to empty
 				host.HardwareSerial = ""
-			} else {
+			} else if rows[0]["hardware_serial"] != "-1" {
+				// ignoring the default -1 serial. See: https://github.com/fleetdm/fleet/issues/19789
 				host.HardwareSerial = rows[0]["hardware_serial"]
 			}
 			host.ComputerName = rows[0]["computer_name"]

--- a/server/service/osquery_utils/queries.go
+++ b/server/service/osquery_utils/queries.go
@@ -345,7 +345,9 @@ var hostDetailQueries = map[string]DetailQuery{
 			host.HardwareVersion = rows[0]["hardware_version"]
 			// ignoring the default -1 serial. See: https://github.com/fleetdm/fleet/issues/19789
 			invalidHardwareSerial := rows[0]["hardware_serial"] == "-1" || invalidHardwareSerialRegexp.Match([]byte(rows[0]["hardware_serial"]))
-			if !invalidHardwareSerial {
+			if invalidHardwareSerial {
+				host.HardwareSerial = ""
+			} else {
 				host.HardwareSerial = rows[0]["hardware_serial"]
 			}
 			host.ComputerName = rows[0]["computer_name"]


### PR DESCRIPTION
For #25993

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/Committing-Changes.md#changes-files) for more information.
- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [x] A detailed QA plan exists on the associated ticket (if it isn't there, work with the product group's QA engineer to add it)
	- Create a VM (windows or Linux)
	- Install and enroll in osquery
	- Check default valid serial number
	- [Change the serial number](https://kb.parallels.com/123455) to the string "Default Serial" or "System Serial Number", from the original ticket
	- Refetch host vitals
	- Serial number should be blank instead of displaying "Default Serial"
- [x] Manual QA for all new/changed functionality