### PR TITLE
Adjust delete host message for iDevices

### DIFF
--- a/frontend/pages/hosts/components/DeleteHostModal/DeleteHostModal.tsx
+++ b/frontend/pages/hosts/components/DeleteHostModal/DeleteHostModal.tsx
@@ -80,7 +80,8 @@ const DeleteHostModal = ({
           <li>
             {/* TODO(android): iOS, iPadOS, and Android hosts will re-appear unless MDM is turned
             off. */}
-            iOS and iPadOS hosts will re-appear unless MDM is turned off.
+            iOS and iPadOS hosts will re-appear unless MDM is turned off. It may
+            take up to an hour to re-appear.
           </li>
         </ul>
         <div className="modal-cta-wrap">


### PR DESCRIPTION
For #22391 

As discussed on Slack with Marko:

> I think we should add that to the confirmation modal. I think if someone is testing and they don't see host right away, it's good to tell them that it takes up to 1hr.
> 
> I would do this as second bullet point:
> `iOS and iPadOS hosts will re-appear unless MDM is turned off. It may take up to an hour to re-appear.`

# Checklist for submitter

- [x] Manual QA for all new/changed functionality

![Screenshot From 2025-03-25 14-26-46](https://github.com/user-attachments/assets/2f2bda80-5df9-4a8e-bcc3-da2cc32004f6)
