### PR TITLE
Website: update docs header link & docs sidebar links

### DIFF
--- a/website/assets/styles/layout.less
+++ b/website/assets/styles/layout.less
@@ -440,7 +440,7 @@ html, body {
     [purpose='header-nav-btn'][aria-expanded='true'] {
       font-weight: 700;
       outline: none;
-      color: @core-fleet-black-75;;
+      color: @core-fleet-black-75;
     }
     [purpose='header-nav-btn']:before {
       display: block;
@@ -468,6 +468,7 @@ html, body {
       cursor: pointer;
       display: inline-block;
       padding: 6px 16px;
+      text-decoration: none;
     }
     [purpose='header-nav-btn']:hover {
       font-weight: 700;

--- a/website/assets/styles/pages/docs/basic-documentation.less
+++ b/website/assets/styles/pages/docs/basic-documentation.less
@@ -358,7 +358,7 @@
       box-shadow: 1px 2px 2px rgba(197, 199, 209, 0.2);
       border-radius: 6px;
       padding: 20px;
-      margin-top: 8px;
+      margin-top: 24px;
       color: @core-fleet-black;
       width: 200px;
       position: sticky;
@@ -919,7 +919,10 @@
             padding-bottom: 16px;
 
           }
-
+          [purpose='modal-docs-links'] {
+            border-bottom: 1px solid @core-fleet-black-25;
+            margin-bottom: 16px;
+          }
           [purpose='modal-nav-link'] {
             font-family: Inter;
             font-size: 14px;

--- a/website/views/layouts/layout.ejs
+++ b/website/views/layouts/layout.ejs
@@ -173,26 +173,7 @@
                     <a purpose="mobile-dropdown-link" href="/integrations">Integrations</a>
                   </div>
                   <hr>
-                  <a purpose="mobile-dropdown-toggle" class="d-flex align-items-center collapsed"  data-toggle="collapse" data-target="#mobileNavbarToggleDocumentation" aria-haspopup="true" aria-expanded="false">Docs</a>
-                  <div id="mobileNavbarToggleDocumentation" purpose="mobile-dropdown" class="collapse" data-parent="#mobileDropdowns">
-                    <a purpose="mobile-dropdown-link" href="/docs">Get started</a>
-                    <a purpose="mobile-dropdown-link" href="/docs/get-started/tutorials-and-guides">Guides</a>
-                    <a purpose="mobile-dropdown-link" href="/vitals">Vitals</a>
-                    <a purpose="mobile-dropdown-link" href="/queries">Queries</a>
-                    <a purpose="mobile-dropdown-link" href="/policies">Policies</a>
-                    <a purpose="mobile-dropdown-link" href="/app-library">Software</a>
-                    <a purpose="mobile-dropdown-link" href="/os-settings">OS settings</a>
-                    <a purpose="mobile-dropdown-link" href="/tables">Data tables</a>
-                    <a purpose="mobile-dropdown-link" href="/docs/rest-api">API</a>
-                    <span class="mt-2 mb-2">SUPPORT</span>
-                    <div purpose="indented-mobile-links">
-                      <a purpose="mobile-dropdown-link" href="/support">Chat</a>
-                      <a purpose="mobile-dropdown-link" href="/contribute">Contribute</a>
-                      <a purpose="mobile-dropdown-link" href="/releases">Release notes</a>
-                      <a purpose="mobile-dropdown-link" href="/better">"Why is Fleet on my computer?"</a>
-                      <a purpose="mobile-dropdown-link" href="/new-license">Get your license</a>
-                    </div>
-                  </div>
+                  <a purpose="mobile-dropdown-link" class="d-flex align-items-center" href="/docs">Docs</a>
                   <hr>
                   <a purpose="mobile-dropdown-toggle" class="d-flex align-items-center mr-4 collapsed" data-toggle="collapse" data-target="#mobileNavbarToggleCommunity">Stories</a>
                   <div id="mobileNavbarToggleCommunity" purpose="mobile-dropdown" class="collapse" data-parent="#mobileDropdowns">
@@ -240,24 +221,7 @@
                   </div>
                 </div>
                 <div purpose="dropdown-button" class="btn-group" style="width: 74px;">
-                  <a purpose="header-nav-btn" button-text="Documentation" class="dropdown-toggle  align-items-center <%= typeof currentSection !== 'undefined' && currentSection === 'documentation' ? 'current-section' : '' %>" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Docs</a>
-                  <div purpose="header-dropdown" class="dropdown-menu">
-                    <a class="dropdown-item" href="/docs">Get started</a>
-                    <a class="dropdown-item" href="/docs/get-started/tutorials-and-guides">Guides</a>
-                    <a class="dropdown-item" href="/vitals">Vitals</a>
-                    <a class="dropdown-item" href="/queries">Queries</a>
-                    <a class="dropdown-item" href="/policies">Policies</a>
-                    <a class="dropdown-item" href="/app-library">Software</a>
-                    <a class="dropdown-item" href="/os-settings">OS settings</a>
-                    <a class="dropdown-item" href="/tables">Data tables</a>
-                    <a class="dropdown-item" href="/docs/rest-api">API</a>
-                    <span class="muted dropdown-header">SUPPORT</span>
-                    <a class="dropdown-item" href="/support">Chat</a>
-                    <a class="dropdown-item" href="/contribute">Contribute</a>
-                    <a class="dropdown-item" href="/releases">Release notes</a>
-                    <a class="dropdown-item" href="/better">"Why is Fleet on my computer?"</a>
-                    <a class="dropdown-item" href="/new-license">Get your license</a>
-                  </div>
+                  <a purpose="header-nav-btn" button-text="Documentation" class="dropdown-toggle  align-items-center <%= typeof currentSection !== 'undefined' && currentSection === 'documentation' ? 'current-section' : '' %>" href="/docs">Docs</a>
                 </div>
                 <div purpose="dropdown-button" class="btn-group" style="width: 89px;">
                   <a purpose="header-nav-btn" button-text="Community" class="dropdown-toggle  align-items-center <%= typeof currentSection !== 'undefined' && currentSection === 'community' ? 'current-section' : '' %>" data-toggle="dropdown">Stories</a>

--- a/website/views/pages/contact.ejs
+++ b/website/views/pages/contact.ejs
@@ -223,5 +223,6 @@
     </div>
   </div>
   </div>
+  <p style="opacity: 0; line-height: 0px; font-size: 0px; margin: 0;">537c652d-cb1a-440e-ae35-0f0bf5743e75</p>
 </div>
 <%- /* Expose locals as `window.SAILS_LOCALS` :: */ exposeLocalsToBrowser() %>

--- a/website/views/pages/docs/basic-documentation.ejs
+++ b/website/views/pages/docs/basic-documentation.ejs
@@ -31,7 +31,7 @@
           <a purpose="subpage-link" href="/new-license" no-icon>Get your license</a>
           <a purpose="subpage-link" href="/docs/contributing" target="_blank" no-icon>Contribute</a>
           <a purpose="subpage-link" target="_blank" href="/releases" no-icon>Release notes</a>
-          <a purpose="subpage-link" target="_blank" href="/support" no-icon>Support</a>
+          <a purpose="subpage-link" href="/support" no-icon>Support</a>
           <a purpose="subpage-link" href="/contact">Take a tour</a>
           <a purpose="subpage-link" href="/better">“Why is Fleet on my computer?”</a>
         </div>

--- a/website/views/pages/docs/basic-documentation.ejs
+++ b/website/views/pages/docs/basic-documentation.ejs
@@ -28,7 +28,7 @@
               </div>
             </div>
           </div>
-          <a purpose="subpage-link" target="_blank" href="/new-license" no-icon>Get your license</a>
+          <a purpose="subpage-link" href="/new-license" no-icon>Get your license</a>
           <a purpose="subpage-link" href="/docs/contributing" target="_blank" no-icon>Contribute</a>
           <a purpose="subpage-link" target="_blank" href="/releases" no-icon>Release notes</a>
           <a purpose="subpage-link" target="_blank" href="/support" no-icon>Support</a>

--- a/website/views/pages/docs/basic-documentation.ejs
+++ b/website/views/pages/docs/basic-documentation.ejs
@@ -30,7 +30,7 @@
           </div>
           <a purpose="subpage-link" href="/new-license" no-icon>Get your license</a>
           <a purpose="subpage-link" href="/docs/contributing" target="_blank" no-icon>Contribute</a>
-          <a purpose="subpage-link" target="_blank" href="/releases" no-icon>Release notes</a>
+          <a purpose="subpage-link" href="/releases" no-icon>Release notes</a>
           <a purpose="subpage-link" href="/support" no-icon>Support</a>
           <a purpose="subpage-link" href="/contact">Take a tour</a>
           <a purpose="subpage-link" href="/better">“Why is Fleet on my computer?”</a>

--- a/website/views/pages/docs/basic-documentation.ejs
+++ b/website/views/pages/docs/basic-documentation.ejs
@@ -28,12 +28,14 @@
               </div>
             </div>
           </div>
+          <a purpose="subpage-link" target="_blank" href="/new-license" no-icon>Get your license</a>
+          <a purpose="subpage-link" href="/docs/contributing" target="_blank" no-icon>Contribute</a>
           <a purpose="subpage-link" target="_blank" href="/releases" no-icon>Release notes</a>
-          <a purpose="subpage-link" href="/docs/contributing" target="_blank" no-icon>Contributing</a>
           <a purpose="subpage-link" target="_blank" href="/support" no-icon>Support</a>
           <a purpose="subpage-link" href="/contact">Take a tour</a>
+          <a purpose="subpage-link" href="/better">“Why is Fleet on my computer?”</a>
         </div>
-        <div class="d-none d-lg-block" purpose="swag-cta" v-if="showSwagForm">
+        <div class="d-none d-lg-block" purpose="swag-cta" v-if="!showSwagForm">
           <a class="d-flex align-items-center justify-content-center" @click="clickSwagRequestCTA()">
             <div class="d-flex flex-column align-items-center">
             <img style="height: auto; width: 47px; margin-bottom: 8px;" alt="A very nice Fleet branded shirt" src="/images/fleet-shirt-60x55@2x.png">
@@ -114,6 +116,7 @@
   <div purpose="table-of-contents-modal">
   <modal v-if="modal === 'table-of-contents'" @close="closeModal()">
     <div purpose="modal-links">
+      <div  purpose="modal-docs-links">
       <div v-for="page in findPagesByUrl()" :key="page.title">
         <p purpose="section-title">{{page.title}}</p>
         <div purpose="expanded-nav">
@@ -122,6 +125,13 @@
           </a>
         </div>
       </div>
+      </div>
+      <a purpose="modal-nav-link" target="_blank" href="/new-license" no-icon>Get your license</a>
+      <a purpose="modal-nav-link" href="/docs/contributing" target="_blank" no-icon>Contribute</a>
+      <a purpose="modal-nav-link" href="/releases" no-icon>Release notes</a>
+      <a purpose="modal-nav-link" href="/support" no-icon>Support</a>
+      <a purpose="modal-nav-link" href="/contact">Take a tour</a>
+      <a purpose="modal-nav-link" href="/better">“Why is Fleet on my computer?”</a>
     </div>
   </modal>
   </div>

--- a/website/views/pages/docs/basic-documentation.ejs
+++ b/website/views/pages/docs/basic-documentation.ejs
@@ -35,7 +35,7 @@
           <a purpose="subpage-link" href="/contact">Take a tour</a>
           <a purpose="subpage-link" href="/better">“Why is Fleet on my computer?”</a>
         </div>
-        <div class="d-none d-lg-block" purpose="swag-cta" v-if="!showSwagForm">
+        <div class="d-none d-lg-block" purpose="swag-cta" v-if="showSwagForm">
           <a class="d-flex align-items-center justify-content-center" @click="clickSwagRequestCTA()">
             <div class="d-flex flex-column align-items-center">
             <img style="height: auto; width: 47px; margin-bottom: 8px;" alt="A very nice Fleet branded shirt" src="/images/fleet-shirt-60x55@2x.png">

--- a/website/views/pages/homepage.ejs
+++ b/website/views/pages/homepage.ejs
@@ -539,5 +539,6 @@
   <modal purpose="video-modal" v-if="modal === 'calendar'" @close="closeModal()">
     <iframe width="560" height="315" src="https://www.youtube.com/embed/nhufmzGUeNk?si=rtAF6sFZuA7PhYRS&autoplay=1" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
   </modal>
+  <p style="opacity: 0; line-height: 0px; font-size: 0px; margin: 0;">537c652d-cb1a-440e-ae35-0f0bf5743e75</p>
 </div>
 <%- /* Expose locals as `window.SAILS_LOCALS` :: */ exposeLocalsToBrowser() %>

--- a/website/views/pages/pricing.ejs
+++ b/website/views/pages/pricing.ejs
@@ -404,5 +404,6 @@
       <a :href="selectedFeature.documentationUrl" target="_blank" v-if="selectedFeature.documentationUrl" no-icon>Learn more</a>
     </div>
   </modal>
+  <p style="opacity: 0; line-height: 0px; font-size: 0px; margin: 0;">537c652d-cb1a-440e-ae35-0f0bf5743e75</p>
 </div>
 <%- /* Expose locals as `window.SAILS_LOCALS` :: */ exposeLocalsToBrowser() %>


### PR DESCRIPTION
Closes: #27218

Changes:
- Replaced the "Docs" dropdown navigation menu with a link to `/docs`
- Reordered the sidebar links on documentation pages and added links to the self-service license dispenser and the transparency page.