### PR TITLE
Docs: Break tutorials and guides page into two sections

### DIFF
--- a/docs/Get started/tutorials-and-guides.md
+++ b/docs/Get started/tutorials-and-guides.md
@@ -2,33 +2,53 @@
 
 A collection of guides to help you with Fleet.
 
+## Get set up
+
 <!--Deploying Fleet-->
-- [MDM migration](https://fleetdm.com/guides/mdm-migration)
-- [Deploy Fleet](https://fleetdm.com/docs/deploy)
-- [macOS MDM setup](https://fleetdm.com/guides/macos-mdm-setup)
-- [Windows MDM setup](https://fleetdm.com/guides/windows-mdm-setup)
+[MDM migration](https://fleetdm.com/guides/mdm-migration)
+
+[Deploy Fleet](https://fleetdm.com/docs/deploy)
+
+[macOS MDM setup](https://fleetdm.com/guides/macos-mdm-setup)
+
+[Windows MDM setup](https://fleetdm.com/guides/windows-mdm-setup)
+
+[Enroll hosts](https://fleetdm.com/guides/enroll-hosts)
+
+## Further learning
 <!--Highest level organizational unit-->
-- [Teams](https://fleetdm.com/guides/teams)
-- [Enroll hosts](https://fleetdm.com/guides/enroll-hosts)
-- [Enroll BYOD iOS/iPadOS hosts](https://fleetdm.com/guides/enroll-byod-ios-ipados-hosts)
-- [Queries](https://fleetdm.com/guides/queries)
-- [Labels](https://fleetdm.com/guides/managing-labels-in-fleet)
-- [Policies](https://fleetdm.com/securing/what-are-fleet-policies)
+[Teams](https://fleetdm.com/guides/teams)
+
+[Enroll BYOD iOS/iPadOS hosts](https://fleetdm.com/guides/enroll-byod-ios-ipados-hosts)
+
+[Queries](https://fleetdm.com/guides/queries)
+
+[Labels](https://fleetdm.com/guides/managing-labels-in-fleet)
+
+[Policies](https://fleetdm.com/securing/what-are-fleet-policies)
+
 <!--Controls-->
-- [Enforce OS updates](https://fleetdm.com/guides/enforce-os-updates)
-- [Enforce disk encryption](https://fleetdm.com/guides/enforce-disk-encryption)
-- [Custom OS settings](https://fleetdm.com/guides/custom-os-settings)
-- [Automatically run scripts](https://fleetdm.com/guides/policy-automation-run-script)
+
+[Enforce disk encryption](https://fleetdm.com/guides/enforce-disk-encryption)
+
+[Automatically run scripts](https://fleetdm.com/guides/policy-automation-run-script)
+
 <!--Installing software-->
-- [Fleet-maintained apps](https://fleetdm.com/guides/install-fleet-maintained-apps-on-macos-hosts)
-- [Deploy software](https://fleetdm.com/guides/deploy-software-packages)
-- [Automatically install software](https://fleetdm.com/guides/automatic-software-install-in-fleet)
-- [Install App Store (VPP) apps](https://fleetdm.com/guides/install-vpp-apps-on-macos-using-fleet)
+[Fleet-maintained apps](https://fleetdm.com/guides/install-fleet-maintained-apps-on-macos-hosts)
+
+[Deploy software](https://fleetdm.com/guides/deploy-software-packages)
+
+[Automatically install software](https://fleetdm.com/guides/automatic-software-install-in-fleet)
+
+[Install App Store (VPP) apps](https://fleetdm.com/guides/install-vpp-apps-on-macos-using-fleet)
 <!--Admin-->
-- [Fleetctl](https://fleetdm.com/guides/fleetctl)
-- [Fleetd updates](https://fleetdm.com/guides/fleetd-updates)
-- [How to uninstall Fleet's agent (fleetd)](https://fleetdm.com/guides/how-to-uninstall-fleetd)
-- [How to configure logging destinations](https://fleetdm.com/guides/how-to-configure-logging-destinations)  
+[Fleetctl](https://fleetdm.com/guides/fleetctl)
+
+[Fleetd updates](https://fleetdm.com/guides/fleetd-updates)
+
+[How to uninstall Fleet's agent (fleetd)](https://fleetdm.com/guides/how-to-uninstall-fleetd)
+
+[How to configure logging destinations](https://fleetdm.com/guides/how-to-configure-logging-destinations)  
 
 
 <a style="text-decoration: none;" href="https://fleetdm.com/guides"><animated-arrow-button>See all guides</animated-arrow-button></a>


### PR DESCRIPTION
Closes: #27261

Changes:
- Updated the tutorials-and-guides docs page to have two lists of guides: "Get set up" and "Further learning"