### PR TITLE
Docs: Removed broken outdated link

### DIFF
--- a/orbit/README.md
+++ b/orbit/README.md
@@ -4,10 +4,6 @@ Orbit is a lightweight osquery installer and autoupdater. With Orbit, it's easy 
 
 Orbit is the recommended agent for Fleet. But Orbit can be used with or without Fleet, and Fleet can be used with or without Orbit.
 
-# Documentation
-
-- [Releasing Orbit](docs/Releasing-Orbit.md)
-
 ## How to build from source
 
 To build orbit we use [goreleaser](https://goreleaser.com/).


### PR DESCRIPTION
## Description
- Releasing orbit documentation was specifically removed in: https://github.com/fleetdm/fleet/pull/14681/files#diff-7bc88549f07361cceb8a59db3a9bd0bcbebddaccf5abe8a206858516b90519ec
- Removed link to removed documentation

