### PR TITLE
[CHERRY-PICK] remove the standard timeout for software installer downloads (#27550)

### DIFF
--- a/changes/27548-installer-download-fail
+++ b/changes/27548-installer-download-fail
@@ -1,0 +1,1 @@
+- Fixed software installer download errors by extending the timeout for the download endpoints.

--- a/cmd/fleet/serve.go
+++ b/cmd/fleet/serve.go
@@ -1211,7 +1211,9 @@ the way that the Fleet server works.
 				if (req.Method == http.MethodPost && strings.HasSuffix(req.URL.Path, "/fleet/software/package")) ||
 					(req.Method == http.MethodPatch && strings.HasSuffix(req.URL.Path, "/package") && strings.Contains(req.URL.Path,
 						"/fleet/software/titles/")) ||
-					(req.Method == http.MethodPost && strings.HasSuffix(req.URL.Path, "/bootstrap")) {
+					(req.Method == http.MethodPost && strings.HasSuffix(req.URL.Path, "/bootstrap")) ||
+					(req.Method == http.MethodGet && strings.Contains(req.URL.Path, "/package/token")) ||
+					(req.Method == http.MethodPost && strings.Contains(req.URL.Path, "orbit/software_install/package")) {
 					var zeroTime time.Time
 					rc := http.NewResponseController(rw)
 					// For large software installers and bootstrap packages, the server time needs time to read the full


### PR DESCRIPTION
cherry pick for https://github.com/fleetdm/fleet/pull/27550
