### PR TITLE
Documentation: 4.66 no longer includes search, moved to 4.67

### DIFF
--- a/articles/filtering-software-by-vulnerability.md
+++ b/articles/filtering-software-by-vulnerability.md
@@ -37,7 +37,7 @@ In Fleet version 4.66 or later, the same vulnerability filtering functionality i
 
 3. **Access the Software tab**: On the Host details page, click on the **Software** tab. This will display a list of all software detected on the host.
 
-4. **Filter software**: Follow steps 2 through 6 from the previous section to filter software by severity, known exploit, etc.
+4. **Filter software**: Follow steps 3 through 6 from the previous section to filter software by severity, known exploit, etc.
 
 ### Using the REST API to filter software for vulnerabilities
 


### PR DESCRIPTION
## Issue
For #22632 

## Description
- Searching by CVE on host details page is moved onto a different ticket that has been pushed to 4.67 in #27003
- Removed from 4.66 documentation

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->


