### PR TITLE
Fix software name to match unique identifier for non-Mac FMAs

### DIFF
--- a/ee/server/service/maintained_apps.go
+++ b/ee/server/service/maintained_apps.go
@@ -115,6 +115,15 @@ func (svc *Service) AddFleetMaintainedApp(
 		maintainedAppID = nil // don't set app as maintained if scripts have been modified
 	}
 
+	// For platforms other than macOS, installer name has to match what we see in software inventory,
+	// so we have the UniqueIdentifier field to indicate what that should be (independent of the name we
+	// display when listing the FMA). For macOS, unique identifier is bundle name, and we use bundle
+	// identifier to link installers with inventory, so we set the name to the FMA's display name instead.
+	appName := app.UniqueIdentifier
+	if app.Platform == "darwin" || appName == "" {
+		appName = app.Name
+	}
+
 	payload := &fleet.UploadSoftwareInstallerPayload{
 		InstallerFile:         installerTFR,
 		Title:                 app.Name,

--- a/ee/server/service/maintained_apps.go
+++ b/ee/server/service/maintained_apps.go
@@ -126,7 +126,7 @@ func (svc *Service) AddFleetMaintainedApp(
 
 	payload := &fleet.UploadSoftwareInstallerPayload{
 		InstallerFile:         installerTFR,
-		Title:                 app.Name,
+		Title:                 appName,
 		UserID:                vc.UserID(),
 		TeamID:                teamID,
 		Version:               app.Version,


### PR DESCRIPTION
This is because for Windows the installed software may show up in software inventory with an unexpected name, and we want to make sure that the FMA package shows up on the same software title as where installs of that package show.

To QA:

1. Ensure macOS FMA still uploads as the app name (e.g. Figma)
2. Ensure that `unique_identifier` changes in a Windows FMA result in corresponding changes to the software title name (e.g. Figma Machine MSI).