### PR TITLE
fixes for editing certificate authorities in UI.

### DIFF
--- a/frontend/interfaces/integration.ts
+++ b/frontend/interfaces/integration.ts
@@ -30,7 +30,7 @@ export interface ICertificatesIntegrationDigicert {
   api_token: string;
   profile_id: string;
   certificate_common_name: string;
-  certificate_user_principal_names: string[];
+  certificate_user_principal_names: string[] | null;
   certificate_seat_id: string;
 }
 

--- a/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/AddCertAuthorityModal/helpers.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/AddCertAuthorityModal/helpers.tsx
@@ -5,7 +5,7 @@ import { IDropdownOption } from "interfaces/dropdownOption";
 import { getErrorReason } from "interfaces/errors";
 
 const DEFAULT_CERT_AUTHORITY_OPTIONS: IDropdownOption[] = [
-  { label: "Digicert", value: "digicert" },
+  { label: "DigiCert", value: "digicert" },
   {
     label: "Microsoft NDES (Network Device Enrollment Service)",
     value: "ndes",

--- a/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/AddCertAuthorityModal/helpers.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/AddCertAuthorityModal/helpers.tsx
@@ -92,5 +92,7 @@ export const getDisplayErrMessage = (err: unknown) => {
 };
 
 export const getErrorMessage = (err: unknown) => {
-  return `Couldn't add certificate authority. ${getDisplayErrMessage(err)}`;
+  return (
+    <>Couldn&apos;t add certificate authority. {getDisplayErrMessage(err)}</>
+  );
 };

--- a/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/DeleteCertificateAuthorityModal/helpers.ts
+++ b/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/DeleteCertificateAuthorityModal/helpers.ts
@@ -188,7 +188,8 @@ export const useCertAuthorityDataGenerator = (
                   api_token: apiToken,
                   profile_id: profileId,
                   certificate_common_name: commonName,
-                  certificate_user_principal_names: [userPrincipalName],
+                  certificate_user_principal_names:
+                    userPrincipalName !== "" ? [userPrincipalName] : [],
                   certificate_seat_id: certificateSeatId,
                 };
               }

--- a/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/EditCertAuthorityModal/helpers.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/EditCertAuthorityModal/helpers.tsx
@@ -38,7 +38,9 @@ export const generateDefaultFormData = (
       apiToken: certAuthority.api_token,
       profileId: certAuthority.profile_id,
       commonName: certAuthority.certificate_common_name,
-      userPrincipalName: certAuthority.certificate_user_principal_names[0],
+      userPrincipalName: certAuthority.certificate_user_principal_names
+        ? certAuthority.certificate_user_principal_names[0]
+        : "",
       certificateSeatId: certAuthority.certificate_seat_id,
     };
   }

--- a/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/EditCertAuthorityModal/helpers.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/EditCertAuthorityModal/helpers.tsx
@@ -9,6 +9,7 @@ import {
 
 import { ICertFormData } from "../AddCertAuthorityModal/AddCertAuthorityModal";
 import { getDisplayErrMessage } from "../AddCertAuthorityModal/helpers";
+import { IDigicertFormData } from "../DigicertForm/DigicertForm";
 
 export const getCertificateAuthorityType = (
   certAuthority: ICertificateIntegration
@@ -58,6 +59,7 @@ export const updateFormData = (
   // for some inputs that change we want to reset one of the other inputs
   // and force users to re-enter it.
   if (isDigicertCertIntegration(certAuthority)) {
+    const formData = prevFormData as IDigicertFormData;
     if (
       update.name === "name" ||
       update.name === "url" ||
@@ -65,7 +67,11 @@ export const updateFormData = (
     ) {
       return {
         ...newData,
-        apiToken: "",
+        // we only want to clear the apiToken value if it has not been updated.
+        // The characters "********" is the value the API sends back for
+        // apiToken so we can check for that value to determine if its been
+        // changed or not.
+        apiToken: formData.apiToken === "********" ? "" : formData.apiToken,
       };
     }
   } else if (isNDESCertIntegration(certAuthority)) {

--- a/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/EditCertAuthorityModal/helpers.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/EditCertAuthorityModal/helpers.tsx
@@ -10,6 +10,8 @@ import {
 import { ICertFormData } from "../AddCertAuthorityModal/AddCertAuthorityModal";
 import { getDisplayErrMessage } from "../AddCertAuthorityModal/helpers";
 import { IDigicertFormData } from "../DigicertForm/DigicertForm";
+import { INDESFormData } from "../NDESForm/NDESForm";
+import { ICustomSCEPFormData } from "../CustomSCEPForm/CustomSCEPForm";
 
 export const getCertificateAuthorityType = (
   certAuthority: ICertificateIntegration
@@ -57,7 +59,9 @@ export const updateFormData = (
   const newData = { ...prevFormData, [update.name]: update.value };
 
   // for some inputs that change we want to reset one of the other inputs
-  // and force users to re-enter it.
+  // and force users to re-enter it. we only want to clear these values if it
+  // has not been updated. The characters "********" is the value the API sends
+  // back so we check for that value to determine if its been changed or not.
   if (isDigicertCertIntegration(certAuthority)) {
     const formData = prevFormData as IDigicertFormData;
     if (
@@ -67,25 +71,23 @@ export const updateFormData = (
     ) {
       return {
         ...newData,
-        // we only want to clear the apiToken value if it has not been updated.
-        // The characters "********" is the value the API sends back for
-        // apiToken so we can check for that value to determine if its been
-        // changed or not.
         apiToken: formData.apiToken === "********" ? "" : formData.apiToken,
       };
     }
   } else if (isNDESCertIntegration(certAuthority)) {
+    const formData = prevFormData as INDESFormData;
     if (update.name === "adminURL" || update.name === "username") {
       return {
         ...newData,
-        password: "",
+        password: formData.password === "********" ? "" : formData.password,
       };
     }
   } else if (isCustomSCEPCertIntegration(certAuthority)) {
+    const formData = prevFormData as ICustomSCEPFormData;
     if (update.name === "name" || update.name === "scepURL") {
       return {
         ...newData,
-        challenge: "",
+        challenge: formData.challenge === "********" ? "" : formData.challenge,
       };
     }
   }


### PR DESCRIPTION
For #27581, #27584, #27612

contains a couple of fixes with editing CAs in UI:

- fix for only removing API token, password, or challenge inputs when the user has not yet made a change to those fields.
- fix for sending empty array when UPN input is empty
- fix for error for private key
- fix when editing a digicert CA when UPN is set from gitops and is null 

- [x] Manual QA for all new/changed functionality
