### PR TITLE
Drop request timeout on FMA add endpoint

### DIFF
--- a/changes/27548-installer-download-fail
+++ b/changes/27548-installer-download-fail
@@ -1,1 +1,1 @@
-- Fixed software installer download errors by extending the timeout for the download endpoints.
+- Fixed software installer download and Fleet Maintained App add errors by extending the timeout for the download and FMA add endpoints.

--- a/cmd/fleet/serve.go
+++ b/cmd/fleet/serve.go
@@ -1224,6 +1224,7 @@ the way that the Fleet server works.
 					(req.Method == http.MethodPatch && strings.HasSuffix(req.URL.Path, "/package") && strings.Contains(req.URL.Path,
 						"/fleet/software/titles/")) ||
 					(req.Method == http.MethodPost && strings.HasSuffix(req.URL.Path, "/bootstrap")) ||
+					(req.Method == http.MethodPost && strings.HasSuffix(req.URL.Path, "/fleet_maintained_apps")) ||
 					(req.Method == http.MethodGet && strings.Contains(req.URL.Path, "/package/token")) ||
 					(req.Method == http.MethodPost && strings.Contains(req.URL.Path, "orbit/software_install/package")) {
 					var zeroTime time.Time


### PR DESCRIPTION
If the Fleet server is on a connection that can't pull ~150 Mbps down, it'll time out before being able to add Microsoft Word for macOS, due to the 100-second default timeout. This skips that behavior.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/Committing-Changes.md#changes-files) for more information.