### PR TITLE
Fleet UI: Fix dropdown from changing when vuln filters change

### DIFF
--- a/frontend/pages/SoftwarePage/SoftwareTitles/SoftwareTable/helpers.ts
+++ b/frontend/pages/SoftwarePage/SoftwareTitles/SoftwareTable/helpers.ts
@@ -88,6 +88,7 @@ export const buildSoftwareFilterQueryParams = (
   }
 };
 
+// TODO: Consider parsing SoftwarePage query params to change from type string
 export const getSoftwareFilterFromQueryParams = (queryParams: QueryParams) => {
   const { available_for_install, self_service } = queryParams;
   switch (true) {

--- a/frontend/pages/hosts/details/cards/Software/HostSoftware.tsx
+++ b/frontend/pages/hosts/details/cards/Software/HostSoftware.tsx
@@ -30,14 +30,17 @@ import SoftwareFiltersModal from "pages/SoftwarePage/components/SoftwareFiltersM
 import {
   buildSoftwareFilterQueryParams,
   buildSoftwareVulnFiltersQueryParams,
-  getSoftwareFilterFromQueryParams,
   getSoftwareVulnFiltersFromQueryParams,
   ISoftwareVulnFiltersParams,
 } from "pages/SoftwarePage/SoftwareTitles/SoftwareTable/helpers";
 import { generateSoftwareTableHeaders as generateHostSoftwareTableConfig } from "./HostSoftwareTableConfig";
 import { generateSoftwareTableHeaders as generateDeviceSoftwareTableConfig } from "./DeviceSoftwareTableConfig";
 import HostSoftwareTable from "./HostSoftwareTable";
-import { getInstallErrorMessage, getUninstallErrorMessage } from "./helpers";
+import {
+  getHostSoftwareFilterFromQueryParams,
+  getInstallErrorMessage,
+  getUninstallErrorMessage,
+} from "./helpers";
 
 const baseClass = "software-card";
 
@@ -131,7 +134,7 @@ const HostSoftware = ({
 
   const isUnsupported =
     isAndroid(platform) || (isIPadOrIPhone(platform) && queryParams.vulnerable); // no Android software and no vulnerable software for iOS
-  const softwareFilter = getSoftwareFilterFromQueryParams(queryParams);
+  const softwareFilter = getHostSoftwareFilterFromQueryParams(queryParams);
 
   // disables install/uninstall actions after click
   const [softwareIdActionPending, setSoftwareIdActionPending] = useState<
@@ -330,11 +333,6 @@ const HostSoftware = ({
     ]
   );
 
-  const getHostSoftwareFilterFromQueryParams = useCallback(() => {
-    const { available_for_install } = queryParams;
-    return available_for_install ? "installableSoftware" : "allSoftware";
-  }, [queryParams]);
-
   const tableConfig = useMemo(() => {
     return isMyDevicePage
       ? generateDeviceSoftwareTableConfig()
@@ -393,7 +391,7 @@ const HostSoftware = ({
             searchQuery={queryParams.query}
             page={queryParams.page}
             pagePath={pathname}
-            hostSoftwareFilter={getHostSoftwareFilterFromQueryParams()}
+            hostSoftwareFilter={softwareFilter}
             vulnFilters={getSoftwareVulnFiltersFromQueryParams(queryParams)}
             onAddFiltersClick={toggleSoftwareFiltersModal}
             pathPrefix={pathname}

--- a/frontend/pages/hosts/details/cards/Software/helpers.tsx
+++ b/frontend/pages/hosts/details/cards/Software/helpers.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { QueryParams } from "utilities/url";
 import { getErrorReason } from "interfaces/errors";
 import { trimEnd, upperFirst } from "lodash";
 
@@ -68,4 +69,13 @@ export const getUninstallErrorMessage = (e: unknown) => {
   }
 
   return DEFAULT_UNINSTALL_ERROR_MESSAGE;
+};
+
+// available_for_install string > boolean conversion in parseHostSoftwareQueryParams
+export const getHostSoftwareFilterFromQueryParams = (
+  queryParams: QueryParams
+) => {
+  const { available_for_install } = queryParams;
+
+  return available_for_install ? "installableSoftware" : "allSoftware";
 };


### PR DESCRIPTION
## Issue
For #27504 

## Description
- Issue with bool <> string as SoftwarePage has similar dropdown so I reused its helper function except, that page uses `type string` meanwhile HostSoftware component already parsed query params to correct types (e.g. `type boolean`)
- Solution: Single function `getHostSoftwareFilterFromQueryParams` used to determine/change filter that uses correct type `boolean` in local `./helpers` directory instead of using the one from SoftwarePage

## Screen recording of fix


https://github.com/user-attachments/assets/c055443a-973d-4546-a5f3-3da81bad59ff


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->


- [x] A detailed QA plan exists on the associated ticket (if it isn't there, work with the product group's QA engineer to add it)
- [x] Manual QA for all new/changed functionality

