### PR TITLE
Website: Update get-bug-and-pr-report script.

### DIFF
--- a/website/scripts/get-bug-and-pr-report.js
+++ b/website/scripts/get-bug-and-pr-report.js
@@ -253,7 +253,10 @@ module.exports = {
           // Get commits on this PR.
           // [?] https://docs.github.com/en/rest/commits/commits#list-commits
           let commitsOnThisPullRequest = await sails.helpers.http.get(pullRequest.commits_url, {}, baseHeaders).retry();
-
+          if(commitsOnThisPullRequest.length === 0) {
+            sails.log.warn(`A pull request #${pullRequest.number} (${pullRequest.html_url}) was found that has no commits. This PR will be not counted in the commit to merge time metric.`);
+            return;
+          }
           // Create a new Date from the timestamp of the first commit on this pull request.
           let firstCommitAt = new Date(commitsOnThisPullRequest[0].commit.author.date); // https://docs.github.com/en/rest/commits/commits#list-commits--code-samples
           // Get the amount of time this issue has been open in milliseconds.


### PR DESCRIPTION
Closes: #27662

Changes:
- Updated the `get-bug-and-pr-report` script to not count pull requests with no commits in the commit to merge time metric, and to log a warning if one is found.