### PR TITLE
fix: Detect file starting with comment in mdm.go as well

### DIFF
--- a/server/mdm/mdm.go
+++ b/server/mdm/mdm.go
@@ -65,7 +65,7 @@ func GetRawProfilePlatform(profile []byte) string {
 		return "darwin"
 	}
 
-	if prefixMatches(trimmedProfile, "<replace") || prefixMatches(trimmedProfile, "<add") {
+	if prefixMatches(trimmedProfile, "<replace") || prefixMatches(trimmedProfile, "<add") || prefixMatches(trimmedProfile, "<!--") {
 		return "windows"
 	}
 

--- a/server/mdm/mdm_test.go
+++ b/server/mdm/mdm_test.go
@@ -155,6 +155,11 @@ func TestGetRawProfilePlatform(t *testing.T) {
 			expected: "windows",
 		},
 		{
+			name:     "Windows xml with comment",
+			input:    []byte("<!-- this is a comment -->"),
+			expected: "windows",
+		},
+		{
 			name:     "Whitespace before prefix",
 			input:    []byte("   <?xml version=\"1.0\"?>"),
 			expected: "darwin",


### PR DESCRIPTION
Addresses https://github.com/fleetdm/fleet/issues/26443#issuecomment-2749360869 after https://github.com/fleetdm/fleet/pull/27176 was merged. Reading XML as a string in this way feels wrong, but I don't want to avoid a refactor, so I'm checking for a "comment" string in this PR.

I tested by building fleetctl locally and running:

```sh
$ make fleetctl; ./build/fleetctl gitops -f it-and-security/teams/test.yml --dry-run
...
Client Version:   tf-mod-addon-monitoring-v1.5.1-1091-g8eb9111c6-dirty
Server Version:  0.0.0-SNAPSHOT-85f4f65
[+] applying MDM profiles for team TEST
Error: applying custom settings for team "TEST": POST /api/latest/fleet/mdm/profiles/batch received status 422 Validation Failed: disable-onedrive is not a valid macOS or Windows configuration profile. macOS profiles must be valid .mobileconfig or .json files. Windows configuration profiles can only have <Replace> or <Add> top level elements.
```

I'm not sure if the error above ([code](https://github.com/fleetdm/fleet/blob/8eb9111c67c017d3a7b6e448b7e333c8e43f2f6a/server/service/mdm.go#L2160)) is caused by my test environment not yet having the updated server code. The `--dry-run` passed in my test, as seen by the `[+] applying MDM profiles for team TEST` line. I can't get any test code to be reflected in the server response, so my hunch is that the issue should be fixed after this PR.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/Committing-Changes.md#changes-files) for more information.
  - I did this in https://github.com/fleetdm/fleet/pull/27176, same change message.
- [x] Added/updated automated tests
- [x] Manual QA for all new/changed functionality
