### PR TITLE
Add docs for labels in queries

### DIFF
--- a/articles/queries.md
+++ b/articles/queries.md
@@ -34,7 +34,7 @@ How to create a query:
 
 ## Targeting hosts using labels
 
-When creating or editing a query, you can restrict the set of hosts that it will run on by using [labels](https://fleetdm.com/guides/labels).  By default, a new query will target all hosts, indicated by the **All Hosts** option being selected beneath the **Targets** setting.  If you select **Custom** instead, you will be able to select one or more labels for the query to target. Note that the query will run on any host that matches __any__ of the selected labels. To learn more about labels, see [Managing labels in Fleet](https://fleetdm.com/guides/labels).
+When creating or editing a query, you can restrict the set of hosts that it will run on by using [labels](https://fleetdm.com/guides/managing-labels-in-fleet).  By default, a new query will target all hosts, indicated by the **All Hosts** option being selected beneath the **Targets** setting.  If you select **Custom** instead, you will be able to select one or more labels for the query to target. Note that the query will run on any host that matches __any__ of the selected labels. To learn more about labels, see [Managing labels in Fleet](https://fleetdm.com/guides/managing-labels-in-fleet).
 
 ## View a query report
 

--- a/articles/queries.md
+++ b/articles/queries.md
@@ -32,6 +32,9 @@ How to create a query:
 
 4. Select **Save**, enter a name and description for your query, select the frequency that the query should run at, and select **Save query**.
 
+## Targeting hosts using labels
+
+You can restrict the set of hosts that a query will run on by using [labels](https://fleetdm.com/guides/labels).  By default, a new query will target all hosts, indicated by the **All Hosts** option being selected beneath the **Targets** setting.  If you select **Custom** instead, you will be able to select one or more labels for the query to target. Note that the query will run on any host that matches __any__ of the selected labels. To learn more about labels, see [Managing labels in Fleet](https://fleetdm.com/guides/labels).
 
 ## View a query report
 

--- a/articles/queries.md
+++ b/articles/queries.md
@@ -34,7 +34,7 @@ How to create a query:
 
 ## Targeting hosts using labels
 
-You can restrict the set of hosts that a query will run on by using [labels](https://fleetdm.com/guides/labels).  By default, a new query will target all hosts, indicated by the **All Hosts** option being selected beneath the **Targets** setting.  If you select **Custom** instead, you will be able to select one or more labels for the query to target. Note that the query will run on any host that matches __any__ of the selected labels. To learn more about labels, see [Managing labels in Fleet](https://fleetdm.com/guides/labels).
+When creating or editing a query, you can restrict the set of hosts that it will run on by using [labels](https://fleetdm.com/guides/labels).  By default, a new query will target all hosts, indicated by the **All Hosts** option being selected beneath the **Targets** setting.  If you select **Custom** instead, you will be able to select one or more labels for the query to target. Note that the query will run on any host that matches __any__ of the selected labels. To learn more about labels, see [Managing labels in Fleet](https://fleetdm.com/guides/labels).
 
 ## View a query report
 

--- a/articles/queries.md
+++ b/articles/queries.md
@@ -34,6 +34,8 @@ How to create a query:
 
 ## Targeting hosts using labels
 
+_Available in Fleet Premium._
+
 When creating or editing a query, you can restrict the set of hosts that it will run on by using [labels](https://fleetdm.com/guides/managing-labels-in-fleet).  By default, a new query will target all hosts, indicated by the **All Hosts** option being selected beneath the **Targets** setting.  If you select **Custom** instead, you will be able to select one or more labels for the query to target. Note that the query will run on any host that matches __any__ of the selected labels. To learn more about labels, see [Managing labels in Fleet](https://fleetdm.com/guides/managing-labels-in-fleet).
 
 ## View a query report


### PR DESCRIPTION
For https://github.com/fleetdm/fleet/issues/27638

Small update to docs indicating that labels can be used to target queries.

I'd like to add something about platforms as well, but this UI will change in the next release (4.67) so I'll hold off until then.