### PR TITLE
Website: update height of platform icons on policy pages.

### DIFF
--- a/website/assets/styles/pages/policy-details.less
+++ b/website/assets/styles/pages/policy-details.less
@@ -338,6 +338,7 @@
     }
     h1 {
       font-size: 0px;
+      line-height: 0px;
     }
     img {
       height: 24px;


### PR DESCRIPTION
Changes:
- Removed extra whitespace from the platform icons on the policy details page that was caused by the wrapped `<h1>` tag.