### PR TITLE
Fleet UI: Disable Next when items on the page match exact page size

### DIFF
--- a/frontend/components/TableContainer/TableContainer.tsx
+++ b/frontend/components/TableContainer/TableContainer.tsx
@@ -62,10 +62,12 @@ interface ITableContainerProps<T = any> {
   searchable?: boolean;
   wideSearch?: boolean;
   disablePagination?: boolean;
-  disableNextPage?: boolean; // disableNextPage is a temporary workaround for the case
-  // where the number of items on the last page is equal to the page size.
-  // The old page controls for server-side pagination render a no results screen
-  // with a back button. This fix instead disables the next button in that case.
+  /**
+   * Disables the "Next" button when the last page contains exactly the page size items.
+   * This is determined using either the API's `meta.has_next_page` response
+   * or by calculating `isLastPage` in the frontend.
+   */
+  disableNextPage?: boolean;
   disableCount?: boolean;
   /** Main button after selecting a row */
   primarySelectAction?: IActionButtonProps;

--- a/frontend/pages/policies/ManagePoliciesPage/ManagePoliciesPage.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/ManagePoliciesPage.tsx
@@ -88,9 +88,9 @@ interface IManagePoliciesPageProps {
   };
 }
 
-const DEFAULT_SORT_DIRECTION = "asc";
-const DEFAULT_PAGE_SIZE = 20;
-const DEFAULT_SORT_COLUMN = "name";
+export const DEFAULT_SORT_DIRECTION = "asc";
+export const DEFAULT_PAGE_SIZE = 20;
+export const DEFAULT_SORT_COLUMN = "name";
 const [
   DEFAULT_AUTOMATION_UPDATE_SUCCESS_MSG,
   DEFAULT_AUTOMATION_UPDATE_ERR_MSG,
@@ -98,11 +98,6 @@ const [
   "Successfully updated policy automations.",
   "Could not update policy automations.",
 ];
-
-// isLastPage is removable if/when API is updated to include meta.has_next_results
-const isLastPage = (count: number, pageSize: number, page: number) => {
-  return count <= pageSize * (page + 1);
-};
 
 const baseClass = "manage-policies-page";
 
@@ -908,11 +903,7 @@ const ManagePolicyPage = ({
               globalPolicies
             )
           }
-          disableNextPage={isLastPage(
-            globalPoliciesCount || 0,
-            DEFAULT_PAGE_SIZE,
-            page
-          )}
+          count={globalPoliciesCount || 0}
           searchQuery={searchQuery}
           sortHeader={sortHeader}
           sortDirection={sortDirection}
@@ -945,11 +936,7 @@ const ManagePolicyPage = ({
             )
           }
           isPremiumTier={isPremiumTier}
-          disableNextPage={isLastPage(
-            teamPoliciesCountMergeInherited || 0,
-            DEFAULT_PAGE_SIZE,
-            page
-          )}
+          count={teamPoliciesCountMergeInherited || 0}
           searchQuery={searchQuery}
           sortHeader={sortHeader}
           sortDirection={sortDirection}

--- a/frontend/pages/policies/ManagePoliciesPage/ManagePoliciesPage.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/ManagePoliciesPage.tsx
@@ -99,6 +99,11 @@ const [
   "Could not update policy automations.",
 ];
 
+// isLastPage is removable if/when API is updated to include meta.has_next_results
+const isLastPage = (count: number, pageSize: number, page: number) => {
+  return count <= pageSize * (page + 1);
+};
+
 const baseClass = "manage-policies-page";
 
 const ManagePolicyPage = ({
@@ -903,6 +908,11 @@ const ManagePolicyPage = ({
               globalPolicies
             )
           }
+          disableNextPage={isLastPage(
+            globalPoliciesCount || 0,
+            DEFAULT_PAGE_SIZE,
+            page
+          )}
           searchQuery={searchQuery}
           sortHeader={sortHeader}
           sortDirection={sortDirection}
@@ -935,6 +945,11 @@ const ManagePolicyPage = ({
             )
           }
           isPremiumTier={isPremiumTier}
+          disableNextPage={isLastPage(
+            teamPoliciesCountMergeInherited || 0,
+            DEFAULT_PAGE_SIZE,
+            page
+          )}
           searchQuery={searchQuery}
           sortHeader={sortHeader}
           sortDirection={sortDirection}

--- a/frontend/pages/policies/ManagePoliciesPage/components/PoliciesTable/PoliciesTable.tests.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/components/PoliciesTable/PoliciesTable.tests.tsx
@@ -28,7 +28,7 @@ describe("Policies table", () => {
         page={0}
         onQueryChange={noop}
         renderPoliciesCount={() => null}
-        disableNextPage
+        count={0}
       />
     );
 
@@ -58,7 +58,7 @@ describe("Policies table", () => {
         page={0}
         onQueryChange={noop}
         renderPoliciesCount={() => null}
-        disableNextPage
+        count={0}
       />
     );
 
@@ -90,7 +90,7 @@ describe("Policies table", () => {
         page={0}
         onQueryChange={noop}
         renderPoliciesCount={() => null}
-        disableNextPage
+        count={0}
       />
     );
 
@@ -121,7 +121,7 @@ describe("Policies table", () => {
         page={0}
         onQueryChange={noop}
         renderPoliciesCount={() => null}
-        disableNextPage
+        count={0}
       />
     );
 
@@ -153,7 +153,7 @@ describe("Policies table", () => {
         page={0}
         onQueryChange={noop}
         renderPoliciesCount={() => null}
-        disableNextPage
+        count={[testCriticalPolicy].length}
       />
     );
 
@@ -191,7 +191,7 @@ describe("Policies table", () => {
         page={0}
         onQueryChange={noop}
         renderPoliciesCount={() => null}
-        disableNextPage
+        count={[testInheritedPolicy].length}
       />
     );
 
@@ -229,7 +229,7 @@ describe("Policies table", () => {
         page={0}
         onQueryChange={noop}
         renderPoliciesCount={() => null}
-        disableNextPage
+        count={[testGlobalPolicy].length}
       />
     );
 
@@ -257,9 +257,11 @@ describe("Policies table", () => {
       createMockPolicy({ id: 5, team_id: 2, name: "Team policy 2" }),
     ];
 
+    const policiesList = [...testInheritedPolicies, ...testTeamPolicies];
+
     const { container, user } = render(
       <PoliciesTable
-        policiesList={[...testInheritedPolicies, ...testTeamPolicies]}
+        policiesList={policiesList}
         isLoading={false}
         onDeletePolicyClick={noop}
         currentTeam={{ id: 2, name: "Team 2" }}
@@ -270,7 +272,7 @@ describe("Policies table", () => {
         renderPoliciesCount={() => null}
         canAddOrDeletePolicy
         hasPoliciesToDelete
-        disableNextPage
+        count={policiesList.length}
       />
     );
 

--- a/frontend/pages/policies/ManagePoliciesPage/components/PoliciesTable/PoliciesTable.tests.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/components/PoliciesTable/PoliciesTable.tests.tsx
@@ -28,6 +28,7 @@ describe("Policies table", () => {
         page={0}
         onQueryChange={noop}
         renderPoliciesCount={() => null}
+        disableNextPage
       />
     );
 
@@ -57,6 +58,7 @@ describe("Policies table", () => {
         page={0}
         onQueryChange={noop}
         renderPoliciesCount={() => null}
+        disableNextPage
       />
     );
 
@@ -88,6 +90,7 @@ describe("Policies table", () => {
         page={0}
         onQueryChange={noop}
         renderPoliciesCount={() => null}
+        disableNextPage
       />
     );
 
@@ -118,6 +121,7 @@ describe("Policies table", () => {
         page={0}
         onQueryChange={noop}
         renderPoliciesCount={() => null}
+        disableNextPage
       />
     );
 
@@ -149,6 +153,7 @@ describe("Policies table", () => {
         page={0}
         onQueryChange={noop}
         renderPoliciesCount={() => null}
+        disableNextPage
       />
     );
 
@@ -186,6 +191,7 @@ describe("Policies table", () => {
         page={0}
         onQueryChange={noop}
         renderPoliciesCount={() => null}
+        disableNextPage
       />
     );
 
@@ -223,6 +229,7 @@ describe("Policies table", () => {
         page={0}
         onQueryChange={noop}
         renderPoliciesCount={() => null}
+        disableNextPage
       />
     );
 
@@ -263,6 +270,7 @@ describe("Policies table", () => {
         renderPoliciesCount={() => null}
         canAddOrDeletePolicy
         hasPoliciesToDelete
+        disableNextPage
       />
     );
 

--- a/frontend/pages/policies/ManagePoliciesPage/components/PoliciesTable/PoliciesTable.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/components/PoliciesTable/PoliciesTable.tsx
@@ -4,16 +4,22 @@ import { AppContext } from "context/app";
 import { IPolicyStats } from "interfaces/policy";
 import { ITeamSummary, APP_CONTEXT_ALL_TEAMS_ID } from "interfaces/team";
 import { IEmptyTableProps } from "interfaces/empty_table";
-
 import TableContainer from "components/TableContainer";
 import { ITableQueryData } from "components/TableContainer/TableContainer";
 import EmptyTable from "components/EmptyTable";
 import { generateTableHeaders, generateDataSet } from "./PoliciesTableConfig";
+import {
+  DEFAULT_SORT_COLUMN,
+  DEFAULT_SORT_DIRECTION,
+  DEFAULT_PAGE_SIZE,
+} from "../../ManagePoliciesPage";
+
+// isLastPage is removable if/when API is updated to include meta.has_next_results
+const isLastPage = (count: number, pageSize: number, page: number) => {
+  return count <= pageSize * (page + 1);
+};
 
 const baseClass = "policies-table";
-
-const DEFAULT_SORT_DIRECTION = "asc";
-const DEFAULT_SORT_HEADER = "name";
 
 interface IPoliciesTableProps {
   policiesList: IPolicyStats[];
@@ -30,7 +36,7 @@ interface IPoliciesTableProps {
   sortHeader?: "name" | "failing_host_count";
   sortDirection?: "asc" | "desc";
   page: number;
-  disableNextPage: boolean;
+  count: number;
 }
 
 const PoliciesTable = ({
@@ -48,7 +54,7 @@ const PoliciesTable = ({
   sortHeader,
   sortDirection,
   page,
-  disableNextPage,
+  count,
 }: IPoliciesTableProps): JSX.Element => {
   const { config } = useContext(AppContext);
 
@@ -103,11 +109,11 @@ const PoliciesTable = ({
           config?.update_interval.osquery_policy
         )}
         isLoading={isLoading}
-        defaultSortHeader={sortHeader || DEFAULT_SORT_HEADER}
+        defaultSortHeader={sortHeader || DEFAULT_SORT_COLUMN}
         defaultSortDirection={sortDirection || DEFAULT_SORT_DIRECTION}
         defaultSearchQuery={searchQuery}
         pageIndex={page}
-        disableNextPage={disableNextPage}
+        disableNextPage={isLastPage(count, DEFAULT_PAGE_SIZE, page)}
         showMarkAllPages={false}
         isAllPagesSelected={false}
         primarySelectAction={{

--- a/frontend/pages/policies/ManagePoliciesPage/components/PoliciesTable/PoliciesTable.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/components/PoliciesTable/PoliciesTable.tsx
@@ -30,6 +30,7 @@ interface IPoliciesTableProps {
   sortHeader?: "name" | "failing_host_count";
   sortDirection?: "asc" | "desc";
   page: number;
+  disableNextPage: boolean;
 }
 
 const PoliciesTable = ({
@@ -47,6 +48,7 @@ const PoliciesTable = ({
   sortHeader,
   sortDirection,
   page,
+  disableNextPage,
 }: IPoliciesTableProps): JSX.Element => {
   const { config } = useContext(AppContext);
 
@@ -105,6 +107,7 @@ const PoliciesTable = ({
         defaultSortDirection={sortDirection || DEFAULT_SORT_DIRECTION}
         defaultSearchQuery={searchQuery}
         pageIndex={page}
+        disableNextPage={disableNextPage}
         showMarkAllPages={false}
         isAllPagesSelected={false}
         primarySelectAction={{


### PR DESCRIPTION
## Issue
For #27739

## Description
- Work around for isLastPage for global policies and team policies view

## Screenshot of fix (note no pagination with page size exactly 20 of a table that paginates after 20 results)
<img width="1125" alt="Screenshot 2025-04-01 at 4 48 46 PM" src="https://github.com/user-attachments/assets/8e82df12-d24d-44cb-8ce7-107337d2e6f5" />


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] A detailed QA plan exists on the associated ticket (if it isn't there, work with the product group's QA engineer to add it)
- [x] Manual QA for all new/changed functionality
