### PR TITLE
Fix path for go-version-file in FMA ingest job

### DIFF
--- a/.github/workflows/ingest-maintained-apps.yml
+++ b/.github/workflows/ingest-maintained-apps.yml
@@ -45,7 +45,7 @@ jobs:
         uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
         with:
           cache: false
-          go-version-file: 'go.mod' 
+          go-version-file: 'fleet/go.mod'
 
       - name: Ingest maintained apps
         run: |


### PR DESCRIPTION
When Go version switched from being hardcoded to being based off of the deps file, Fleet being checked out into a subdir wasn't taken into account, so FMA ingest jobs started failing. This adds the (hopefully) correct dir to fix the issue and get FMA ingest working again.