### PR TITLE
For R.C. - Fleet UI: Disable Next when items on the page match exact page size (#27743)

### DIFF
--- a/frontend/components/TableContainer/TableContainer.tsx
+++ b/frontend/components/TableContainer/TableContainer.tsx
@@ -62,10 +62,12 @@ interface ITableContainerProps<T = any> {
   searchable?: boolean;
   wideSearch?: boolean;
   disablePagination?: boolean;
-  disableNextPage?: boolean; // disableNextPage is a temporary workaround for the case
-  // where the number of items on the last page is equal to the page size.
-  // The old page controls for server-side pagination render a no results screen
-  // with a back button. This fix instead disables the next button in that case.
+  /**
+   * Disables the "Next" button when the last page contains exactly the page size items.
+   * This is determined using either the API's `meta.has_next_page` response
+   * or by calculating `isLastPage` in the frontend.
+   */
+  disableNextPage?: boolean;
   disableCount?: boolean;
   /** Main button after selecting a row */
   primarySelectAction?: IActionButtonProps;

--- a/frontend/pages/policies/ManagePoliciesPage/ManagePoliciesPage.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/ManagePoliciesPage.tsx
@@ -88,9 +88,9 @@ interface IManagePoliciesPageProps {
   };
 }
 
-const DEFAULT_SORT_DIRECTION = "asc";
-const DEFAULT_PAGE_SIZE = 20;
-const DEFAULT_SORT_COLUMN = "name";
+export const DEFAULT_SORT_DIRECTION = "asc";
+export const DEFAULT_PAGE_SIZE = 20;
+export const DEFAULT_SORT_COLUMN = "name";
 const [
   DEFAULT_AUTOMATION_UPDATE_SUCCESS_MSG,
   DEFAULT_AUTOMATION_UPDATE_ERR_MSG,
@@ -903,6 +903,7 @@ const ManagePolicyPage = ({
               globalPolicies
             )
           }
+          count={globalPoliciesCount || 0}
           searchQuery={searchQuery}
           sortHeader={sortHeader}
           sortDirection={sortDirection}
@@ -935,6 +936,7 @@ const ManagePolicyPage = ({
             )
           }
           isPremiumTier={isPremiumTier}
+          count={teamPoliciesCountMergeInherited || 0}
           searchQuery={searchQuery}
           sortHeader={sortHeader}
           sortDirection={sortDirection}

--- a/frontend/pages/policies/ManagePoliciesPage/components/PoliciesTable/PoliciesTable.tests.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/components/PoliciesTable/PoliciesTable.tests.tsx
@@ -28,6 +28,7 @@ describe("Policies table", () => {
         page={0}
         onQueryChange={noop}
         renderPoliciesCount={() => null}
+        count={0}
       />
     );
 
@@ -57,6 +58,7 @@ describe("Policies table", () => {
         page={0}
         onQueryChange={noop}
         renderPoliciesCount={() => null}
+        count={0}
       />
     );
 
@@ -88,6 +90,7 @@ describe("Policies table", () => {
         page={0}
         onQueryChange={noop}
         renderPoliciesCount={() => null}
+        count={0}
       />
     );
 
@@ -118,6 +121,7 @@ describe("Policies table", () => {
         page={0}
         onQueryChange={noop}
         renderPoliciesCount={() => null}
+        count={0}
       />
     );
 
@@ -149,6 +153,7 @@ describe("Policies table", () => {
         page={0}
         onQueryChange={noop}
         renderPoliciesCount={() => null}
+        count={[testCriticalPolicy].length}
       />
     );
 
@@ -186,6 +191,7 @@ describe("Policies table", () => {
         page={0}
         onQueryChange={noop}
         renderPoliciesCount={() => null}
+        count={[testInheritedPolicy].length}
       />
     );
 
@@ -223,6 +229,7 @@ describe("Policies table", () => {
         page={0}
         onQueryChange={noop}
         renderPoliciesCount={() => null}
+        count={[testGlobalPolicy].length}
       />
     );
 
@@ -250,9 +257,11 @@ describe("Policies table", () => {
       createMockPolicy({ id: 5, team_id: 2, name: "Team policy 2" }),
     ];
 
+    const policiesList = [...testInheritedPolicies, ...testTeamPolicies];
+
     const { container, user } = render(
       <PoliciesTable
-        policiesList={[...testInheritedPolicies, ...testTeamPolicies]}
+        policiesList={policiesList}
         isLoading={false}
         onDeletePolicyClick={noop}
         currentTeam={{ id: 2, name: "Team 2" }}
@@ -263,6 +272,7 @@ describe("Policies table", () => {
         renderPoliciesCount={() => null}
         canAddOrDeletePolicy
         hasPoliciesToDelete
+        count={policiesList.length}
       />
     );
 

--- a/frontend/pages/policies/ManagePoliciesPage/components/PoliciesTable/PoliciesTable.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/components/PoliciesTable/PoliciesTable.tsx
@@ -4,16 +4,22 @@ import { AppContext } from "context/app";
 import { IPolicyStats } from "interfaces/policy";
 import { ITeamSummary, APP_CONTEXT_ALL_TEAMS_ID } from "interfaces/team";
 import { IEmptyTableProps } from "interfaces/empty_table";
-
 import TableContainer from "components/TableContainer";
 import { ITableQueryData } from "components/TableContainer/TableContainer";
 import EmptyTable from "components/EmptyTable";
 import { generateTableHeaders, generateDataSet } from "./PoliciesTableConfig";
+import {
+  DEFAULT_SORT_COLUMN,
+  DEFAULT_SORT_DIRECTION,
+  DEFAULT_PAGE_SIZE,
+} from "../../ManagePoliciesPage";
+
+// isLastPage is removable if/when API is updated to include meta.has_next_results
+const isLastPage = (count: number, pageSize: number, page: number) => {
+  return count <= pageSize * (page + 1);
+};
 
 const baseClass = "policies-table";
-
-const DEFAULT_SORT_DIRECTION = "asc";
-const DEFAULT_SORT_HEADER = "name";
 
 interface IPoliciesTableProps {
   policiesList: IPolicyStats[];
@@ -30,6 +36,7 @@ interface IPoliciesTableProps {
   sortHeader?: "name" | "failing_host_count";
   sortDirection?: "asc" | "desc";
   page: number;
+  count: number;
 }
 
 const PoliciesTable = ({
@@ -47,6 +54,7 @@ const PoliciesTable = ({
   sortHeader,
   sortDirection,
   page,
+  count,
 }: IPoliciesTableProps): JSX.Element => {
   const { config } = useContext(AppContext);
 
@@ -101,10 +109,11 @@ const PoliciesTable = ({
           config?.update_interval.osquery_policy
         )}
         isLoading={isLoading}
-        defaultSortHeader={sortHeader || DEFAULT_SORT_HEADER}
+        defaultSortHeader={sortHeader || DEFAULT_SORT_COLUMN}
         defaultSortDirection={sortDirection || DEFAULT_SORT_DIRECTION}
         defaultSearchQuery={searchQuery}
         pageIndex={page}
+        disableNextPage={isLastPage(count, DEFAULT_PAGE_SIZE, page)}
         showMarkAllPages={false}
         isAllPagesSelected={false}
         primarySelectAction={{


### PR DESCRIPTION
## Issue
For #27739


> [!NOTE]
> This PR is already merged in `main`, see #27743  This is against the release branch so it can be included in 4.66.0 


```
 1635  git checkout fleetdm/rc-minor-fleet-v4.66.0
 1636  git log main
 1637  git cherry-pick f2872c4dab8b8c4f4d0e9397517001913af89e65
 1638  git checkout -b 27739-rc
 1639  git push -u fleetdm 27739-rc
```