### PR TITLE
Update minimum os versions for macOS, iOS, and iPadOS

### DIFF
--- a/it-and-security/teams/company-owned-ipads.yml
+++ b/it-and-security/teams/company-owned-ipads.yml
@@ -12,8 +12,8 @@ team_settings:
 agent_options:
 controls:
   ipados_updates:
-    deadline: "2025-02-23"
-    minimum_version: "18.3"
+    deadline: "2025-04-26"
+    minimum_version: "18.4"
   macos_settings:
     custom_settings:
       - path: ../lib/ipados/declaration-profiles/software-update-settings.json

--- a/it-and-security/teams/company-owned-iphones.yml
+++ b/it-and-security/teams/company-owned-iphones.yml
@@ -12,8 +12,8 @@ team_settings:
 agent_options:
 controls:
   ios_updates:
-    deadline: "2025-02-23"
-    minimum_version: "18.3"
+    deadline: "2025-04-26"
+    minimum_version: "18.4"
   macos_settings:
     custom_settings:
       - path: ../lib/ios/configuration-profiles/lock-screen-message.mobileconfig

--- a/it-and-security/teams/personally-owned-iphones.yml
+++ b/it-and-security/teams/personally-owned-iphones.yml
@@ -12,8 +12,8 @@ team_settings:
 agent_options:
 controls:
   ios_updates:
-    deadline: "2025-01-06"
-    minimum_version: "18.2"
+    deadline: "2025-04-26"
+    minimum_version: "18.4"
   macos_settings:
     custom_settings:
       - path: ../lib/ios/declaration-profiles/passcode-settings.json

--- a/it-and-security/teams/workstations-canary.yml
+++ b/it-and-security/teams/workstations-canary.yml
@@ -110,8 +110,8 @@ controls:
     enable_end_user_authentication: false
     macos_setup_assistant: null
   macos_updates:
-    deadline: "2025-02-23"
-    minimum_version: "15.3"
+    deadline: "2025-04-26"
+    minimum_version: "15.4"
   windows_settings:
     custom_settings:
       - path: ../lib/windows/configuration-profiles/enable-firewall-all-domains.xml

--- a/it-and-security/teams/workstations.yml
+++ b/it-and-security/teams/workstations.yml
@@ -70,8 +70,8 @@ controls:
       - package_path: ../lib/macos/software/1password.yml # 1Password for macOS
       - app_store_id: '803453959' # Slack Desktop
   macos_updates:
-    deadline: "2025-02-23"
-    minimum_version: "15.3"
+    deadline: "2025-04-26"
+    minimum_version: "15.4"
   windows_settings:
     custom_settings: null
   windows_updates:


### PR DESCRIPTION
macOS: 15.4
  Deadline: April 26, 2025

iOS: 18.4
  Deadline: April 26, 2025

iPadOS: 18.4
  Deadline: April 26, 2025