### PR TITLE
Fleet UI: Add premium tooltip

### DIFF
--- a/frontend/pages/SoftwarePage/SoftwarePage.tsx
+++ b/frontend/pages/SoftwarePage/SoftwarePage.tsx
@@ -405,7 +405,9 @@ const SoftwarePage = ({ children, router, location }: ISoftwarePageProps) => {
             underline={false}
             tipContent={
               <div className={`${baseClass}__header__tooltip`}>
-                Select a team to add software.
+                {isPremiumTier
+                  ? "Select a team to add software."
+                  : "This feature is included in Fleet Premium."}
               </div>
             }
             disableTooltip={!isAllTeamsSelected}


### PR DESCRIPTION
## Issue
For #27641 

## Description
- Add premium tooltip to free instead of telling free to select a team

## Screenshot of fix
<img width="375" alt="Screenshot 2025-04-02 at 1 46 03 PM" src="https://github.com/user-attachments/assets/d5f60b55-881c-46ae-9bcb-cfa7357076f8" />


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] A detailed QA plan exists on the associated ticket (if it isn't there, work with the product group's QA engineer to add it)
- [x] Manual QA for all new/changed functionality
