### PR TITLE
Update endpoints that need to be exposed

### DIFF
--- a/articles/what-api-endpoints-to-expose-to-the-public-internet.md
+++ b/articles/what-api-endpoints-to-expose-to-the-public-internet.md
@@ -11,7 +11,7 @@ If you would like to manage hosts that can travel outside your VPN or intranet, 
 
 ## Using Fleet Desktop on remote devices
 
-If you're using Fleet Desktop `/api/*/fleet/device/*` and `/api/*/assets/*`must be exposed (for the end user's **Fleet Desktop > My device** page).
+If you're using Fleet Desktop `/api/*/fleet/device/*` and `/api/*/assets/*` must be exposed (for the end user's **Fleet Desktop > My device** page).
 
 For full Fleet Desktop and scripts functionality, `/api/fleet/orbit/*` and`/api/fleet/device/ping` must also be exposed.
 

--- a/articles/what-api-endpoints-to-expose-to-the-public-internet.md
+++ b/articles/what-api-endpoints-to-expose-to-the-public-internet.md
@@ -11,7 +11,7 @@ If you would like to manage hosts that can travel outside your VPN or intranet, 
 
 ## Using Fleet Desktop on remote devices
 
-If you are using Fleet Desktop and want it to work on remote devices, the bare minimum API to expose is `/api/*/fleet/device/*/desktop`. This minimal endpoint will only provide the number of failing policies.
+If you are using Fleet Desktop and want the **My device** page to work, `/api/*/fleet/device/*` must be exposed.
 
 For full Fleet Desktop and scripts functionality, `/api/fleet/orbit/*` and`/api/fleet/device/ping` must also be exposed.
 

--- a/articles/what-api-endpoints-to-expose-to-the-public-internet.md
+++ b/articles/what-api-endpoints-to-expose-to-the-public-internet.md
@@ -11,7 +11,7 @@ If you would like to manage hosts that can travel outside your VPN or intranet, 
 
 ## Using Fleet Desktop on remote devices
 
-If you are using Fleet Desktop `/api/*/fleet/device/*` and `/api/*/assets/*`must be exposed (for the end user's **Fleet Desktop > My device** page).
+If you're using Fleet Desktop `/api/*/fleet/device/*` and `/api/*/assets/*`must be exposed (for the end user's **Fleet Desktop > My device** page).
 
 For full Fleet Desktop and scripts functionality, `/api/fleet/orbit/*` and`/api/fleet/device/ping` must also be exposed.
 

--- a/articles/what-api-endpoints-to-expose-to-the-public-internet.md
+++ b/articles/what-api-endpoints-to-expose-to-the-public-internet.md
@@ -11,7 +11,7 @@ If you would like to manage hosts that can travel outside your VPN or intranet, 
 
 ## Using Fleet Desktop on remote devices
 
-If you're using Fleet Desktop `/api/*/fleet/device/*` and `/api/*/assets/*` must be exposed (for the end user **Fleet Desktop > My device** page).
+If you're using Fleet Desktop `/api/*/fleet/device/*/desktop` must be exposed in the API, and for the end user **Fleet Desktop > My device** page `/device/*` and `/assets/*` must be exposed.
 
 For full Fleet Desktop and scripts functionality, `/api/fleet/orbit/*` and`/api/fleet/device/ping` must also be exposed.
 

--- a/articles/what-api-endpoints-to-expose-to-the-public-internet.md
+++ b/articles/what-api-endpoints-to-expose-to-the-public-internet.md
@@ -11,7 +11,7 @@ If you would like to manage hosts that can travel outside your VPN or intranet, 
 
 ## Using Fleet Desktop on remote devices
 
-If you are using Fleet Desktop and want the **My device** page to work, `/api/*/fleet/device/*` must be exposed.
+If you are using Fleet Desktop `/api/*/fleet/device/*` and `/api/*/assets/*`must be exposed (for the end user's **Fleet Desktop > My device** page).
 
 For full Fleet Desktop and scripts functionality, `/api/fleet/orbit/*` and`/api/fleet/device/ping` must also be exposed.
 

--- a/articles/what-api-endpoints-to-expose-to-the-public-internet.md
+++ b/articles/what-api-endpoints-to-expose-to-the-public-internet.md
@@ -11,7 +11,7 @@ If you would like to manage hosts that can travel outside your VPN or intranet, 
 
 ## Using Fleet Desktop on remote devices
 
-If you're using Fleet Desktop `/api/*/fleet/device/*` and `/api/*/assets/*` must be exposed (for the end user's **Fleet Desktop > My device** page).
+If you're using Fleet Desktop `/api/*/fleet/device/*` and `/api/*/assets/*` must be exposed (for the end user **Fleet Desktop > My device** page).
 
 For full Fleet Desktop and scripts functionality, `/api/fleet/orbit/*` and`/api/fleet/device/ping` must also be exposed.
 


### PR DESCRIPTION
Most Fleet users want Fleet Desktop > My device page to work. I think let's document that as the best practice

Feedback from @pacokleitz here: https://github.com/fleetdm/fleet/issues/27491
