### PR TITLE
Update save/edit query forms to be consistent with save/edit policy

### DIFF
--- a/frontend/pages/queries/edit/components/EditQueryForm/EditQueryForm.tsx
+++ b/frontend/pages/queries/edit/components/EditQueryForm/EditQueryForm.tsx
@@ -40,6 +40,7 @@ import {
 import { getPathWithQueryParams } from "utilities/url";
 
 import usePlatformCompatibility from "hooks/usePlatformCompatibility";
+import usePlatformSelector from "hooks/usePlatformSelector";
 
 import { getErrorReason, IApiError } from "interfaces/errors";
 import {
@@ -198,6 +199,14 @@ const EditQueryForm = ({
   const [queryWasChanged, setQueryWasChanged] = useState(false);
   const [selectedTargetType, setSelectedTargetType] = useState("");
   const [selectedLabels, setSelectedLabels] = useState({});
+
+  const platformSelector = usePlatformSelector(
+    lastEditedQueryPlatforms,
+    baseClass,
+    false,
+    undefined,
+    undefined
+  );
 
   useEffect(() => {
     setSelectedTargetType(
@@ -900,6 +909,7 @@ const EditQueryForm = ({
               >
                 Observers can run
               </Checkbox>
+              {savedQueryMode && platformSelector.render()}
               {isPremiumTier && (
                 <TargetLabelSelector
                   selectedTargetType={selectedTargetType}
@@ -914,6 +924,7 @@ const EditQueryForm = ({
                       labels:
                     </span>
                   }
+                  suppressTitle
                 />
               )}
               <RevealButton
@@ -926,16 +937,6 @@ const EditQueryForm = ({
               />
               {showAdvancedOptions && (
                 <>
-                  <Dropdown
-                    options={SCHEDULE_PLATFORM_DROPDOWN_OPTIONS}
-                    placeholder="Select"
-                    label="Platform"
-                    onChange={onChangeSelectPlatformOptions}
-                    value={lastEditedQueryPlatforms.replace(/\s/g, "")} // NOTE: FE requires no whitespace to render UI
-                    multi
-                    wrapperClassName={`${baseClass}__form-field form-field--platform`}
-                    helpText="By default, your query collects data on all compatible platforms."
-                  />
                   <Dropdown
                     options={MIN_OSQUERY_VERSION_OPTIONS}
                     onChange={onChangeMinOsqueryVersionOptions}

--- a/frontend/pages/queries/edit/components/EditQueryForm/EditQueryForm.tsx
+++ b/frontend/pages/queries/edit/components/EditQueryForm/EditQueryForm.tsx
@@ -471,6 +471,9 @@ const EditQueryForm = ({
 
     if (valid) {
       if (!savedQueryMode) {
+        platformSelector.setSelectedPlatforms(
+          platformCompatibility.getCompatiblePlatforms()
+        );
         setShowSaveQueryModal(true);
       } else {
         const newPlatformString = platformSelector
@@ -499,14 +502,6 @@ const EditQueryForm = ({
         });
       }
     }
-  };
-
-  const saveQueryModalSubmit = (formData: ICreateQueryRequestBody) => {
-    const newPlatformString = platformSelector
-      .getSelectedPlatforms()
-      .join(",") as CommaSeparatedPlatformString;
-    formData.platform = newPlatformString;
-    onSubmitNewQuery(formData);
   };
 
   const renderAuthor = (): JSX.Element | null => {
@@ -1052,7 +1047,7 @@ const EditQueryForm = ({
           <SaveQueryModal
             queryValue={lastEditedQueryBody}
             apiTeamIdForQuery={apiTeamIdForQuery}
-            saveQuery={saveQueryModalSubmit}
+            saveQuery={onSubmitNewQuery}
             toggleSaveQueryModal={toggleSaveQueryModal}
             backendValidators={backendValidators}
             isLoading={isQuerySaving}

--- a/frontend/pages/queries/edit/components/EditQueryForm/EditQueryForm.tsx
+++ b/frontend/pages/queries/edit/components/EditQueryForm/EditQueryForm.tsx
@@ -30,7 +30,6 @@ import {
 } from "utilities/helpers";
 import {
   FREQUENCY_DROPDOWN_OPTIONS,
-  SCHEDULE_PLATFORM_DROPDOWN_OPTIONS,
   MIN_OSQUERY_VERSION_OPTIONS,
   LOGGING_TYPE_OPTIONS,
   INVALID_PLATFORMS_REASON,
@@ -386,6 +385,10 @@ const EditQueryForm = ({
     valid = isValidated;
 
     if (valid) {
+      const newPlatformString = platformSelector
+        .getSelectedPlatforms()
+        .join(",") as CommaSeparatedPlatformString;
+
       setIsSaveAsNewLoading(true);
       const apiProps = {
         description: lastEditedQueryDescription,
@@ -394,7 +397,7 @@ const EditQueryForm = ({
         observer_can_run: lastEditedQueryObserverCanRun,
         interval: lastEditedQueryFrequency,
         automations_enabled: lastEditedQueryAutomationsEnabled,
-        platform: lastEditedQueryPlatforms,
+        platform: newPlatformString,
         min_osquery_version: lastEditedQueryMinOsqueryVersion,
         logging: lastEditedQueryLoggingType,
         labels_include_any:
@@ -489,6 +492,10 @@ const EditQueryForm = ({
       if (!savedQueryMode) {
         setShowSaveQueryModal(true);
       } else {
+        const newPlatformString = platformSelector
+          .getSelectedPlatforms()
+          .join(",") as CommaSeparatedPlatformString;
+
         onUpdate({
           // name should already be trimmed at this point due to associated onBlurs, but this
           // doesn't hurt
@@ -498,7 +505,7 @@ const EditQueryForm = ({
           observer_can_run: lastEditedQueryObserverCanRun,
           interval: lastEditedQueryFrequency,
           automations_enabled: lastEditedQueryAutomationsEnabled,
-          platform: lastEditedQueryPlatforms,
+          platform: newPlatformString,
           min_osquery_version: lastEditedQueryMinOsqueryVersion,
           logging: lastEditedQueryLoggingType,
           discard_data: lastEditedQueryDiscardData,
@@ -806,6 +813,7 @@ const EditQueryForm = ({
     const disableSaveFormErrors =
       (lastEditedQueryName === "" && !!lastEditedQueryId) ||
       !!size(errors) ||
+      !platformSelector.isAnyPlatformSelected ||
       (selectedTargetType === "Custom" &&
         !Object.entries(selectedLabels).some(([, value]) => {
           return value;

--- a/frontend/pages/queries/edit/components/EditQueryForm/EditQueryForm.tsx
+++ b/frontend/pages/queries/edit/components/EditQueryForm/EditQueryForm.tsx
@@ -797,7 +797,7 @@ const EditQueryForm = ({
     const disableSaveFormErrors =
       (lastEditedQueryName === "" && !!lastEditedQueryId) ||
       !!size(errors) ||
-      !platformSelector.isAnyPlatformSelected ||
+      (savedQueryMode && !platformSelector.isAnyPlatformSelected) ||
       (selectedTargetType === "Custom" &&
         !Object.entries(selectedLabels).some(([, value]) => {
           return value;

--- a/frontend/pages/queries/edit/components/EditQueryForm/EditQueryForm.tsx
+++ b/frontend/pages/queries/edit/components/EditQueryForm/EditQueryForm.tsx
@@ -334,25 +334,6 @@ const EditQueryForm = ({
     setShowAdvancedOptions(!showAdvancedOptions);
   };
 
-  const onChangeSelectPlatformOptions = useCallback(
-    (values: string) => {
-      const valArray = values.split(",");
-
-      // Remove All if another OS is chosen
-      // else if Remove OS if All is chosen
-      if (valArray.indexOf("") === 0 && valArray.length > 1) {
-        setLastEditedQueryPlatforms(
-          pull(valArray, "").join(",") as CommaSeparatedPlatformString
-        );
-      } else if (valArray.length > 1 && valArray.indexOf("") > -1) {
-        setLastEditedQueryPlatforms("");
-      } else {
-        setLastEditedQueryPlatforms(values as CommaSeparatedPlatformString);
-      }
-    },
-    [setLastEditedQueryPlatforms]
-  );
-
   const onChangeMinOsqueryVersionOptions = useCallback(
     (value: string) => {
       setLastEditedQueryMinOsqueryVersion(value);
@@ -518,6 +499,14 @@ const EditQueryForm = ({
         });
       }
     }
+  };
+
+  const saveQueryModalSubmit = (formData: ICreateQueryRequestBody) => {
+    const newPlatformString = platformSelector
+      .getSelectedPlatforms()
+      .join(",") as CommaSeparatedPlatformString;
+    formData.platform = newPlatformString;
+    onSubmitNewQuery(formData);
   };
 
   const renderAuthor = (): JSX.Element | null => {
@@ -1063,11 +1052,12 @@ const EditQueryForm = ({
           <SaveQueryModal
             queryValue={lastEditedQueryBody}
             apiTeamIdForQuery={apiTeamIdForQuery}
-            saveQuery={onSubmitNewQuery}
+            saveQuery={saveQueryModalSubmit}
             toggleSaveQueryModal={toggleSaveQueryModal}
             backendValidators={backendValidators}
             isLoading={isQuerySaving}
             queryReportsDisabled={queryReportsDisabled}
+            platformSelector={platformSelector}
           />
         )}
         {showConfirmSaveChangesModal && (

--- a/frontend/pages/queries/edit/components/SaveQueryModal/SaveQueryModal.tests.tsx
+++ b/frontend/pages/queries/edit/components/SaveQueryModal/SaveQueryModal.tests.tsx
@@ -7,6 +7,7 @@ import createMockConfig from "__mocks__/configMock";
 import userEvent from "@testing-library/user-event";
 import { http, HttpResponse } from "msw";
 import mockServer from "test/mock-server";
+import { QueryablePlatform } from "interfaces/platform";
 
 import SaveQueryModal from "./SaveQueryModal";
 
@@ -47,6 +48,12 @@ describe("SaveQueryModal", () => {
     backendValidators: {},
     existingQuery: mockQuery,
     queryReportsDisabled: false,
+    platformSelector: {
+      getSelectedPlatforms: () => ["linux"] as QueryablePlatform[],
+      setSelectedPlatforms: jest.fn(),
+      isAnyPlatformSelected: true,
+      render: () => <></>,
+    },
   };
 
   it("renders the modal with initial values and allows editing", async () => {
@@ -92,13 +99,10 @@ describe("SaveQueryModal", () => {
     const advancedOptionsButton = screen.getByText("Show advanced options");
     await user.click(advancedOptionsButton);
 
-    expect(screen.getByText("Platforms")).toBeInTheDocument();
     expect(screen.getByText("Minimum osquery version")).toBeInTheDocument();
     expect(screen.getByText("Logging")).toBeInTheDocument();
 
     await user.click(advancedOptionsButton);
-
-    expect(screen.queryByText("Platforms")).not.toBeInTheDocument();
   });
 
   it("displays error when query name is empty", async () => {
@@ -139,6 +143,76 @@ describe("SaveQueryModal", () => {
 
     // Check that the target selector is not present.
     expect(screen.queryByText("All hosts")).not.toBeInTheDocument();
+  });
+
+  it("should disable the save button in when no platforms are selected", async () => {
+    const render = createCustomRenderer({
+      withBackendMock: true,
+      context: {
+        app: {
+          currentUser: createMockUser(),
+          isGlobalObserver: false,
+          isGlobalAdmin: true,
+          isGlobalMaintainer: false,
+          isOnGlobalTeam: true,
+          isPremiumTier: false,
+          isSandboxMode: false,
+          config: createMockConfig(),
+        },
+      },
+    });
+
+    const props = {
+      ...defaultProps,
+      platformSelector: {
+        getSelectedPlatforms: () => [] as QueryablePlatform[],
+        setSelectedPlatforms: jest.fn(),
+        isAnyPlatformSelected: false,
+        render: () => <></>,
+      },
+    };
+
+    render(<SaveQueryModal {...props} />);
+    const saveButton = screen.getByRole("button", { name: "Save" });
+    expect(saveButton).toBeDisabled();
+  });
+
+  it("should send platforms when saving a new query", async () => {
+    const saveQuery = jest.fn();
+    const props = {
+      ...defaultProps,
+      platformSelector: {
+        getSelectedPlatforms: () => ["linux", "macos"] as QueryablePlatform[],
+        setSelectedPlatforms: jest.fn(),
+        isAnyPlatformSelected: true,
+        render: () => <></>,
+      },
+      saveQuery,
+    };
+    const render = createCustomRenderer({
+      withBackendMock: true,
+      context: {
+        app: {
+          currentUser: createMockUser(),
+          isGlobalObserver: false,
+          isGlobalAdmin: true,
+          isGlobalMaintainer: false,
+          isOnGlobalTeam: true,
+          isPremiumTier: false,
+          isSandboxMode: false,
+          config: createMockConfig(),
+        },
+      },
+    });
+    render(<SaveQueryModal {...props} />);
+    await waitFor(() => {
+      expect(screen.getByLabelText("Name")).toBeInTheDocument();
+    });
+    // Set a name.
+    await userEvent.type(screen.getByLabelText("Name"), "A Brand New Query!");
+    // Set a label.
+    await userEvent.click(screen.getByRole("button", { name: "Save" }));
+    expect(saveQuery.mock.calls[0][0].platform).toEqual("linux,macos");
   });
 
   describe("in premium tier", () => {

--- a/frontend/pages/queries/edit/components/SaveQueryModal/SaveQueryModal.tsx
+++ b/frontend/pages/queries/edit/components/SaveQueryModal/SaveQueryModal.tsx
@@ -86,10 +86,6 @@ const SaveQueryModal = ({
     existingQuery?.interval ?? 3600
   );
   const [
-    selectedPlatformOptions,
-    setSelectedPlatformOptions,
-  ] = useState<CommaSeparatedPlatformString>(existingQuery?.platform ?? "");
-  const [
     selectedMinOsqueryVersionOptions,
     setSelectedMinOsqueryVersionOptions,
   ] = useState(existingQuery?.min_osquery_version ?? "");
@@ -168,6 +164,10 @@ const SaveQueryModal = ({
     });
     setName(trimmedName);
 
+    const newPlatformString = platformSelector
+      .getSelectedPlatforms()
+      .join(",") as CommaSeparatedPlatformString;
+
     if (valid) {
       saveQuery({
         // from modal fields
@@ -177,7 +177,7 @@ const SaveQueryModal = ({
         observer_can_run: observerCanRun,
         automations_enabled: automationsEnabled,
         discard_data: discardData,
-        platform: selectedPlatformOptions,
+        platform: newPlatformString,
         min_osquery_version: selectedMinOsqueryVersionOptions,
         logging: selectedLoggingType,
         // from previous New query page
@@ -193,26 +193,6 @@ const SaveQueryModal = ({
       });
     }
   };
-
-  const onChangeSelectPlatformOptions = useCallback(
-    (values: string) => {
-      const valArray = values.split(",");
-
-      // Remove All if another OS is chosen
-      // else if Remove OS if All is chosen
-      if (valArray.indexOf("") === 0 && valArray.length > 1) {
-        // TODO - inmprove type safety of all 3 options
-        setSelectedPlatformOptions(
-          pull(valArray, "").join(",") as CommaSeparatedPlatformString
-        );
-      } else if (valArray.length > 1 && valArray.indexOf("") > -1) {
-        setSelectedPlatformOptions("");
-      } else {
-        setSelectedPlatformOptions(values as CommaSeparatedPlatformString);
-      }
-    },
-    [setSelectedPlatformOptions]
-  );
 
   return (
     <Modal title="Save query" onExit={toggleSaveQueryModal}>

--- a/frontend/pages/queries/edit/components/SaveQueryModal/SaveQueryModal.tsx
+++ b/frontend/pages/queries/edit/components/SaveQueryModal/SaveQueryModal.tsx
@@ -6,6 +6,7 @@ import { pull, size } from "lodash";
 import { AppContext } from "context/app";
 
 import useDeepEffect from "hooks/useDeepEffect";
+import { IPlatformSelector } from "hooks/usePlatformSelector";
 
 import {
   FREQUENCY_DROPDOWN_OPTIONS,
@@ -52,6 +53,7 @@ export interface ISaveQueryModalProps {
   backendValidators: { [key: string]: string };
   existingQuery?: ISchedulableQuery;
   queryReportsDisabled?: boolean;
+  platformSelector: IPlatformSelector;
 }
 
 const validateQueryName = (name: string) => {
@@ -74,6 +76,7 @@ const SaveQueryModal = ({
   backendValidators,
   existingQuery,
   queryReportsDisabled,
+  platformSelector,
 }: ISaveQueryModalProps): JSX.Element => {
   const { config, isPremiumTier } = useContext(AppContext);
 
@@ -147,10 +150,11 @@ const SaveQueryModal = ({
 
   // Disable saving if "Custom" targeting is selected, but no labels are selected.
   const canSave =
-    selectedTargetType === "All hosts" ||
-    Object.entries(selectedLabels).some(([, value]) => {
-      return value;
-    });
+    platformSelector.isAnyPlatformSelected &&
+    (selectedTargetType === "All hosts" ||
+      Object.entries(selectedLabels).some(([, value]) => {
+        return value;
+      }));
 
   const onClickSaveQuery = (evt: React.MouseEvent<HTMLFormElement>) => {
     evt.preventDefault();
@@ -299,6 +303,7 @@ const SaveQueryModal = ({
             </>
           }
         />
+        {platformSelector.render()}
         {isPremiumTier && (
           <TargetLabelSelector
             selectedTargetType={selectedTargetType}
@@ -324,16 +329,6 @@ const SaveQueryModal = ({
         />
         {showAdvancedOptions && (
           <>
-            <Dropdown
-              options={SCHEDULE_PLATFORM_DROPDOWN_OPTIONS}
-              placeholder="Select"
-              label="Platforms"
-              onChange={onChangeSelectPlatformOptions}
-              value={selectedPlatformOptions}
-              multi
-              wrapperClassName={`${baseClass}__form-field form-field--platform`}
-              helpText="By default, your query collects data on all compatible platforms."
-            />
             <Dropdown
               options={MIN_OSQUERY_VERSION_OPTIONS}
               onChange={setSelectedMinOsqueryVersionOptions}


### PR DESCRIPTION
For #27601 

## Details

A couple of updates to the save/edit Query screens to bring them in line with how save/edit Policy screens work, as described in [the Figma](https://www.figma.com/design/LzGmucdJQgbQCuHMZhGKCM/-24097-Custom-targets--labels--for-policies?node-id=2-130&p=f&t=9iFB2FRnIkn98NSg-0):

* Moved platform selector out from under Advanced
* Use checkboxes for selecting platforms
* Disable Save button when no platforms are selected
* In the "Save new query" modal, pre-select the platforms that are compatible with the query

## Testing

1. Add a new query with the SQL "SELECT * FROM privacy_preferences;".  Verify that only ChromeOS is checked in the modal when you click Save.
2. Verify that if you deselect ChromeOS (so that no platforms are selected), the save button is disabled in the modal.
3. Select one or more platforms and save the query.
4. After saving the query, edit it and verify that the platforms you selected are checked.
5. Verify that deselecting all platforms disables the edit button on the Edit Query screen.
6. Select different platforms, save, and refresh to verify that the platforms you selected were persisted.