### PR TITLE
Fleet UI: Unify manage automations > paginated list footer styling

### DIFF
--- a/frontend/components/Pagination/_styles.scss
+++ b/frontend/components/Pagination/_styles.scss
@@ -2,7 +2,6 @@
   display: flex;
   justify-content: flex-end;
   margin-top: $pad-small;
-  margin-bottom: $pad-small;
   margin-left: auto;
   text-align: right;
   gap: $pad-large;

--- a/frontend/pages/policies/ManagePoliciesPage/components/CalendarEventsModal/CalendarEventsModal.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/components/CalendarEventsModal/CalendarEventsModal.tsx
@@ -295,7 +295,7 @@ const CalendarEventsModal = ({
             );
           }}
           footer={
-            <div className="form-field__help-text">
+            <>
               A calendar event will be created for end users if one of their
               hosts fail any of these policies.{" "}
               <CustomLink
@@ -304,7 +304,7 @@ const CalendarEventsModal = ({
                 newTab
                 disableKeyboardNavigation={!formData.enabled}
               />
-            </div>
+            </>
           }
           isUpdating={isUpdating}
           onSubmit={onUpdateCalendarEvents}

--- a/frontend/pages/policies/ManagePoliciesPage/components/CalendarEventsModal/_styles.scss
+++ b/frontend/pages/policies/ManagePoliciesPage/components/CalendarEventsModal/_styles.scss
@@ -33,10 +33,6 @@
     margin: 0;
   }
 
-  .form-field__help-text {
-    margin-top: $pad-large;
-  }
-
   &__hide-main {
     visibility: hidden;
   }

--- a/frontend/pages/policies/ManagePoliciesPage/components/InstallSoftwareModal/InstallSoftwareModal.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/components/InstallSoftwareModal/InstallSoftwareModal.tsx
@@ -288,7 +288,7 @@ const InstallSoftwareModal = ({
                 ) : null;
               }}
               footer={
-                <p className="form-field__help-text">
+                <>
                   If compatible with the host, the selected software will be
                   installed when hosts fail the policy. Host counts will reset
                   when new software is selected.{" "}
@@ -297,7 +297,7 @@ const InstallSoftwareModal = ({
                     text="Learn more"
                     newTab
                   />
-                </p>
+                </>
               }
               isUpdating={isUpdating}
               onSubmit={onUpdateInstallSoftware}

--- a/frontend/pages/policies/ManagePoliciesPage/components/InstallSoftwareModal/_styles.scss
+++ b/frontend/pages/policies/ManagePoliciesPage/components/InstallSoftwareModal/_styles.scss
@@ -1,11 +1,5 @@
 .manage-policies-page {
   .install-software-modal {
-    .form-field__help-text {
-      font-size: 14px;
-      line-height: 21px;
-      margin-top: $pad-large;
-    }
-
     .form-field--dropdown {
       width: 276px;
       .Select-placeholder {

--- a/frontend/pages/policies/ManagePoliciesPage/components/OtherWorkflowsModal/OtherWorkflowsModal.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/components/OtherWorkflowsModal/OtherWorkflowsModal.tsx
@@ -370,7 +370,7 @@ const OtherWorkflowsModal = ({
                 return item;
               }}
               footer={
-                <p className={`${baseClass}__help-text`}>
+                <>
                   The workflow will be triggered when hosts fail these policies.{" "}
                   <CustomLink
                     url="https://www.fleetdm.com/learn-more-about/policy-automations"
@@ -378,7 +378,7 @@ const OtherWorkflowsModal = ({
                     newTab
                     disableKeyboardNavigation={!isPolicyAutomationsEnabled}
                   />
-                </p>
+                </>
               }
               isUpdating={isUpdating}
               onSubmit={onUpdateOtherWorkflows}

--- a/frontend/pages/policies/ManagePoliciesPage/components/OtherWorkflowsModal/_styles.scss
+++ b/frontend/pages/policies/ManagePoliciesPage/components/OtherWorkflowsModal/_styles.scss
@@ -19,8 +19,4 @@
   &__no-integrations a {
     display: block;
   }
-
-  &__help-text {
-    @include help-text;
-  }
 }

--- a/frontend/pages/policies/ManagePoliciesPage/components/PoliciesPaginatedList/PoliciesPaginatedList.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/components/PoliciesPaginatedList/PoliciesPaginatedList.tsx
@@ -198,22 +198,20 @@ function PoliciesPaginatedList(
   return (
     <div className={`${baseClass} form`}>
       <div className="form-field">
-        <div>
-          <PaginatedList<IFormPolicy>
-            ref={paginatedListRef}
-            fetchPage={fetchPage}
-            fetchCount={fetchCount}
-            isSelected={isSelected}
-            onToggleItem={onToggleItem}
-            renderItemRow={renderItemRow}
-            pageSize={DEFAULT_PAGE_SIZE}
-            onUpdate={onUpdate}
-            disabled={disabled || gitOpsModeEnabled}
-            heading={<span className={`${baseClass}__header`}>Policies</span>}
-          />
-          {footer}
-        </div>
+        <PaginatedList<IFormPolicy>
+          ref={paginatedListRef}
+          fetchPage={fetchPage}
+          fetchCount={fetchCount}
+          isSelected={isSelected}
+          onToggleItem={onToggleItem}
+          renderItemRow={renderItemRow}
+          pageSize={DEFAULT_PAGE_SIZE}
+          onUpdate={onUpdate}
+          disabled={disabled || gitOpsModeEnabled}
+          heading={<span className={`${baseClass}__header`}>Policies</span>}
+        />
       </div>
+      {footer && <p className="form-field__help-text">{footer}</p>}
       <div className="modal-cta-wrap">
         <GitOpsModeTooltipWrapper
           position="right"

--- a/frontend/pages/policies/ManagePoliciesPage/components/PolicyRunScriptModal/PolicyRunScriptModal.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/components/PolicyRunScriptModal/PolicyRunScriptModal.tsx
@@ -186,7 +186,7 @@ const PolicyRunScriptModal = ({
                 ) : null;
               }}
               footer={
-                <p className="form-field__help-text">
+                <>
                   If{" "}
                   <TooltipWrapper tipContent={compatibleTipContent}>
                     compatible
@@ -200,7 +200,7 @@ const PolicyRunScriptModal = ({
                     text="Learn more"
                     newTab
                   />
-                </p>
+                </>
               }
               isUpdating={isUpdating}
               onSubmit={onUpdate}

--- a/frontend/pages/policies/ManagePoliciesPage/components/PolicyRunScriptModal/_styles.scss
+++ b/frontend/pages/policies/ManagePoliciesPage/components/PolicyRunScriptModal/_styles.scss
@@ -1,11 +1,5 @@
 .manage-policies-page {
   .policy-run-script-modal {
-    .form-field__help-text {
-      font-size: 14px;
-      line-height: 21px;
-      margin-top: $pad-large;
-    }
-
     .form-field--dropdown {
       width: 276px;
       .Select-placeholder {
@@ -34,7 +28,7 @@
       justify-content: center;
       font-size: $small;
 
-      div  {
+      div {
         color: $ui-fleet-black-75;
         font-size: $xx-small;
         a {


### PR DESCRIPTION
## Issue
For #27804 

## Description
- Policies > Manage automations modals had one off styling for all their footers
- Unify styling to play nice with Paginated List component <> Pagination component <> footer
- Removes redundant styling code

## Screenshots of fixes (not exhaustive of all cases fixed)

Example with pagination
<img width="1280" alt="Screenshot 2025-04-03 at 11 02 37 AM" src="https://github.com/user-attachments/assets/0bb2d40b-dec9-4341-95fe-ff162bfcd155" />

Example without pagination
<img width="1404" alt="Screenshot 2025-04-03 at 11 01 32 AM" src="https://github.com/user-attachments/assets/2fe0f7b2-7adb-478c-9988-c957d62b7221" />

Another example without pagination
<img width="1345" alt="Screenshot 2025-04-03 at 11 01 21 AM" src="https://github.com/user-attachments/assets/ca23aa01-1e06-4cb0-9027-818fc5bd6b26" />


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] A detailed QA plan exists on the associated ticket (if it isn't there, work with the product group's QA engineer to add it)
- [x] Manual QA for all new/changed functionality
