### PR TITLE
Fleet internal: Better metrics for PR "open" time

### DIFF
--- a/website/scripts/get-bug-and-pr-report.js
+++ b/website/scripts/get-bug-and-pr-report.js
@@ -227,11 +227,11 @@ module.exports = {
           let closedPullRequests = await sails.helpers.http.get(
             `https://api.github.com/repos/fleetdm/fleet/pulls`,
             {
-              state: 'closed',
-              sort: 'updated',
-              direction: 'desc',
-              per_page: NUMBER_OF_RESULTS_REQUESTED,
-              page: pageNumberForPaginatedResults,
+              'state': 'closed',
+              'sort': 'updated',
+              'direction': 'desc',
+              'per_page': NUMBER_OF_RESULTS_REQUESTED,
+              'page': pageNumberForPaginatedResults,
             },
             baseHeaders,
           ).retry();
@@ -242,7 +242,7 @@ module.exports = {
               !pullRequest.draft &&
               pullRequest.merged_at && // Ensure it's merged
               sevenDaysAgo <= new Date(pullRequest.merged_at) &&
-              pullRequest.user.type !== 'Bot' && 
+              pullRequest.user.type !== 'Bot' &&
               !pullRequest.labels.some(label => label.name === '#handbook' || label.name === '~ceo' || label.name === ':improve documentation')
             );
           });

--- a/website/scripts/get-bug-and-pr-report.js
+++ b/website/scripts/get-bug-and-pr-report.js
@@ -281,10 +281,22 @@ module.exports = {
               readyToReviewToMergeTimesInDays.push(
                 prReadyToReviewToMergeTimeInDays,
               );
+            } else {
+              // If no ready_for_review event, use the created_at timestamp
+              let pullRequestCreationTime = new Date(pullRequest.created_at);
+              let readyToReviewToMergeTimeInMS = Math.abs(
+                    pullRequestMergedOn - pullRequestCreationTime
+              );
+              let prReadyToReviewToMergeTimeInDays =
+                    readyToReviewToMergeTimeInMS / ONE_DAY_IN_MILLISECONDS;
+              readyToReviewToMergeTimesInDays.push(
+                    prReadyToReviewToMergeTimeInDays
+              );
             }
           },
         );
       },
+
 
       //   ██████╗ ██████╗ ███████╗███╗   ██╗    ██████╗ ██████╗ ███████╗
       //  ██╔═══██╗██╔══██╗██╔════╝████╗  ██║    ██╔══██╗██╔══██╗██╔════╝


### PR DESCRIPTION
## Improve the analysis of pull request merge times by using the time a pull request spends in the "ready for review" state.

- Uses the time difference between when a pull request is last marked as "ready for review" and when it is actually merged.
- Retrieve events associated with each merged pull request to identify the last "ready_for_review" event
- Calculates the time difference between the last "ready_for_review" event and the pull request's merge time
- If no "ready_for_review" events are found, uses time difference between "created_at" event and the pull request's merge time (e.g. If wasn't a draft to begin with)

## Implications

- A more accurate measure of how long it takes for a pull request to be merged after it's considered ready
- Helps identify bottlenecks in the review process