### PR TITLE
Update cis-policy-queries.yml

### DIFF
--- a/ee/cis/macos-15/cis-policy-queries.yml
+++ b/ee/cis/macos-15/cis-policy-queries.yml
@@ -3387,7 +3387,7 @@ spec:
       1. Open Safari
       2. Select Safari from the menu bar
       3. Select Settings
-      4. Select Security
+      4. Select Advanced
       5. Set Show full website address to enabled
     Automated method:
     Profile Method:


### PR DESCRIPTION
Updated steps to remediate "CIS: Ensure Show Full Website Address in Safari Is Enabled (MDM Required)" that have been changed in macOS 15.4.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)