### PR TITLE
Apple Intelligence enabled?

### DIFF
--- a/docs/01-Using-Fleet/standard-query-library/standard-query-library.yml
+++ b/docs/01-Using-Fleet/standard-query-library/standard-query-library.yml
@@ -1,17 +1,3 @@
----
-apiVersion: v1
-kind: policy
-spec:
-  name: Apple Intelligence disabled?
-  platforms: macOS
-  description: Checks that Apple Intelligence is disabled.
-  resolution: |
-    To disable Apple Intelligence on your iPhone, iPad, or Mac, go to Settings (or System Settings on Mac), then tap or click "Apple Intelligence & Siri" and toggle off the "Apple Intelligence" option.
-  query: |-
-    SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM plist WHERE path LIKE '/Users/%/Library/Preferences/com.apple.CloudSubscriptionFeatures.optIn.plist' AND value = 1);
-  tags: apple-intelligence
-  contributors: allenhouchins
----
 apiVersion: v1
 kind: policy
 spec:

--- a/docs/01-Using-Fleet/standard-query-library/standard-query-library.yml
+++ b/docs/01-Using-Fleet/standard-query-library/standard-query-library.yml
@@ -2,6 +2,19 @@
 apiVersion: v1
 kind: policy
 spec:
+  name: Apple Intelligence disabled?
+  platforms: macOS
+  description: Checks that Apple Intelligence is disabled.
+  resolution: |
+    To disable Apple Intelligence on your iPhone, iPad, or Mac, go to Settings (or System Settings on Mac), then tap or click "Apple Intelligence & Siri" and toggle off the "Apple Intelligence" option.
+  query: |-
+    SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM plist WHERE path LIKE '/Users/%/Library/Preferences/com.apple.CloudSubscriptionFeatures.optIn.plist' AND value = 1);
+  tags: apple-intelligence
+  contributors: allenhouchins
+---
+apiVersion: v1
+kind: policy
+spec:
   name: Ensure a password is required to wake the computer from sleep or screen saver is enabled
   platforms: macOS
   platform: darwin

--- a/docs/01-Using-Fleet/standard-query-library/standard-query-library.yml
+++ b/docs/01-Using-Fleet/standard-query-library/standard-query-library.yml
@@ -2088,3 +2088,64 @@ spec:
   purpose: Informational
   tags: fleet, osquery, table, schema
   contributors: nonpunctual
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: Ensure Apple Intelligence is disabled
+  platform: darwin
+  description: |
+    This policy detects if Apple Intelligence is disabled.
+  resolution: |
+    Manual method: 
+    Navigate to System Settings > Apple Intelligence & Siri > Toggle Apple Intelligence to off
+    Automatic method:
+    Ask your system administrator to deploy a configuration profile to disable this feature. 
+  query: |
+    SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM plist WHERE path LIKE '/Users/%/Library/Preferences/com.apple.CloudSubscriptionFeatures.optIn.plist' AND value = 1);
+  purpose: Informational
+  tags: 
+  contributors: allenhouchins
+  configuration_profile: |
+    <?xml version="1.0" encoding="UTF-8"?>
+    <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+    <plist version="1.0">
+    <dict>
+      <key>PayloadContent</key>
+      <array>
+        <dict>
+          <key>PayloadDisplayName</key>
+          <string>Restrictions</string>
+          <key>PayloadIdentifier</key>
+          <string>com.apple.applicationaccess.B0BBE2AE-80C3-4182-9934-2A08ECED7DB4</string>
+          <key>PayloadType</key>
+          <string>com.apple.applicationaccess</string>
+          <key>PayloadUUID</key>
+          <string>B0BBE2AE-80C3-4182-9934-2A08ECED7DB4</string>
+          <key>PayloadVersion</key>
+          <integer>1</integer>
+          <key>allowGenmoji</key>
+          <false/>
+          <key>allowImagePlayground</key>
+          <false/>
+          <key>allowWritingTools</key>
+          <false/>
+        </dict>
+      </array>
+      <key>PayloadDisplayName</key>
+      <string>Disable Apple Intelligence</string>
+      <key>PayloadIdentifier</key>
+      <string>com.example.disable_apple_intelligence</string>
+      <key>PayloadOrganization</key>
+      <string>Example Payload Organization</string>
+      <key>PayloadRemovalDisallowed</key>
+      <false/>
+      <key>PayloadType</key>
+      <string>Configuration</string>
+      <key>PayloadUUID</key>
+      <string>B3EAD179-9679-4B08-A421-4B03D081C5DC</string>
+      <key>PayloadVersion</key>
+      <integer>1</integer>
+    </dict>
+    </plist>
+---

--- a/docs/01-Using-Fleet/standard-query-library/standard-query-library.yml
+++ b/docs/01-Using-Fleet/standard-query-library/standard-query-library.yml
@@ -2148,4 +2148,4 @@ spec:
       <integer>1</integer>
     </dict>
     </plist>
----
+

--- a/docs/queries.yml
+++ b/docs/queries.yml
@@ -1650,6 +1650,18 @@ spec:
 #   ╚══▀▀═╝  ╚═════╝ ╚══════╝╚═╝  ╚═╝╚═╝╚══════╝╚══════╝
 #                                                       
 # From docs/01-Using-Fleet/standard-query-library/standard-query-library.yml
+---
+apiVersion: v1
+kind: query
+spec:
+  name: Detect if Apple Intelligence is enabled
+  platform: darwin
+  description: Detects if Apple Intelligence has been enabled. Value = 1 is on, 0 is off.
+  query: SELECT * FROM plist WHERE path LIKE '/Users/%/Library/Preferences/com.apple.CloudSubscriptionFeatures.optIn.plist';
+  purpose: Informational
+  tags: inventory
+  contributors: allenhouchins
+---
 apiVersion: v1
 kind: query
 spec:

--- a/docs/queries.yml
+++ b/docs/queries.yml
@@ -1640,7 +1640,6 @@ spec:
   discovery: windows_update_history
   purpose: Informational
   tags: built-in
----
 #  
 #   ██████╗ ██╗   ██╗███████╗██████╗ ██╗███████╗███████╗
 #  ██╔═══██╗██║   ██║██╔════╝██╔══██╗██║██╔════╝██╔════╝


### PR DESCRIPTION
Add Allen's Apple Intelligence check to the policy library so that any user can import/copy+paste and use it directly without writing SQL.

https://www.linkedin.com/posts/allenhouchins_fleet-it-infosec-activity-7257454593012322304-yvek