### PR TITLE
add cancel upcoming host activities in the UI

### DIFF
--- a/changes/issue-27410-add-cancel-upcoming-host-activities-ui
+++ b/changes/issue-27410-add-cancel-upcoming-host-activities-ui
@@ -1,0 +1,1 @@
+- add ability to cancel upcoming host activities in the UI

--- a/frontend/__mocks__/activityMock.ts
+++ b/frontend/__mocks__/activityMock.ts
@@ -32,5 +32,3 @@ export const createMockHostPastActivity = (
 ): IHostPastActivity => {
   return { ...DEFAULT_HOST_PAST_ACTIVITY_MOCK, ...overrides };
 };
-
-export default createMockActivity;

--- a/frontend/interfaces/activity.ts
+++ b/frontend/interfaces/activity.ts
@@ -107,8 +107,10 @@ export enum ActivityType {
   EnabledActivityAutomations = "enabled_activity_automations",
   EditedActivityAutomations = "edited_activity_automations",
   DisabledActivityAutomations = "disabled_activity_automations",
-  CanceledScript = "canceled_script",
-  CanceledSoftwareInstall = "canceled_software_install",
+  CanceledRunScript = "canceled_run_script",
+  CanceledInstallAppStoreApp = "canceled_install_app_store_app",
+  CanceledInstallSoftware = "canceled_install_software",
+  CanceledUninstallSoftware = "canceled_uninstall_software",
   EnabledAndroidMdm = "enabled_android_mdm",
   DisabledAndroidMdm = "disabled_android_mdm",
 }
@@ -121,8 +123,10 @@ export type IHostPastActivityType =
   | ActivityType.InstalledSoftware
   | ActivityType.UninstalledSoftware
   | ActivityType.InstalledAppStoreApp
-  | ActivityType.CanceledScript
-  | ActivityType.CanceledSoftwareInstall;
+  | ActivityType.CanceledRunScript
+  | ActivityType.CanceledInstallAppStoreApp
+  | ActivityType.CanceledInstallSoftware
+  | ActivityType.CanceledUninstallSoftware;
 
 /** This is a subset of ActivityType that are shown only for the host upcoming activities */
 export type IHostUpcomingActivityType =
@@ -155,55 +159,55 @@ export type IHostUpcomingActivity = Omit<IActivity, "type" | "details"> & {
 };
 
 export interface IActivityDetails {
+  app_store_id?: number;
+  bootstrap_package_name?: string;
+  command_uuid?: string;
+  deadline_days?: number;
+  deadline?: string;
+  email?: string;
+  global?: boolean;
+  grace_period_days?: number;
+  host_display_name?: string;
+  host_display_names?: string[];
+  host_id?: number;
+  host_ids?: number[];
+  host_platform?: string;
+  host_serial?: string;
+  install_uuid?: string;
+  installed_from_dep?: boolean;
+  labels_exclude_any?: ILabelSoftwareTitle[];
+  labels_include_any?: ILabelSoftwareTitle[];
+  location?: string; // name of location associated with VPP token
+  mdm_platform?: "microsoft" | "apple";
+  minimum_version?: string;
+  name?: string;
   pack_id?: number;
   pack_name?: string;
+  platform?: Platform; // software platform
   policy_id?: number;
   policy_name?: string;
+  profile_identifier?: string;
+  profile_name?: string;
+  public_ip?: string;
   query_id?: number;
+  query_ids?: number[];
   query_name?: string;
   query_sql?: string;
-  query_ids?: number[];
+  role?: UserRole;
+  script_execution_id?: string;
+  script_name?: string;
+  self_service?: boolean;
+  software_package?: string;
+  software_title_id?: number;
+  software_title?: string;
+  specs?: IQuery[] | IPolicy[];
+  stats?: ISchedulableQueryStats;
+  status?: string;
+  targets_count?: number;
   team_id?: number | null;
   team_name?: string | null;
   teams?: ITeamSummary[];
-  targets_count?: number;
-  specs?: IQuery[] | IPolicy[];
-  global?: boolean;
-  public_ip?: string;
-  user_id?: number;
   user_email?: string;
-  email?: string;
-  role?: UserRole;
-  host_serial?: string;
-  host_display_name?: string;
-  host_display_names?: string[];
-  host_ids?: number[];
-  host_id?: number;
-  host_platform?: string;
-  installed_from_dep?: boolean;
-  mdm_platform?: "microsoft" | "apple";
-  minimum_version?: string;
-  deadline?: string;
-  profile_name?: string;
-  profile_identifier?: string;
-  bootstrap_package_name?: string;
-  name?: string;
-  script_execution_id?: string;
-  script_name?: string;
-  deadline_days?: number;
-  grace_period_days?: number;
-  stats?: ISchedulableQueryStats;
-  software_title?: string;
-  software_package?: string;
-  platform?: Platform; // software platform
-  status?: string;
-  install_uuid?: string;
-  self_service?: boolean;
-  command_uuid?: string;
-  app_store_id?: number;
-  location?: string; // name of location associated with VPP token
+  user_id?: number;
   webhook_url?: string;
-  software_title_id?: number;
-  labels_include_any?: ILabelSoftwareTitle[];
-  labels_exclude_any?: ILabelSoftwareTitle[];
 }

--- a/frontend/pages/DashboardPage/cards/ActivityFeed/GlobalActivityItem/GlobalActivityItem.tests.tsx
+++ b/frontend/pages/DashboardPage/cards/ActivityFeed/GlobalActivityItem/GlobalActivityItem.tests.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { render, screen } from "@testing-library/react";
 
-import createMockActivity from "__mocks__/activityMock";
+import { createMockActivity } from "__mocks__/activityMock";
 import createMockQuery from "__mocks__/queryMock";
 import { createMockTeamSummary } from "__mocks__/teamMock";
 import { ActivityType } from "interfaces/activity";

--- a/frontend/pages/DashboardPage/cards/ActivityFeed/GlobalActivityItem/GlobalActivityItem.tsx
+++ b/frontend/pages/DashboardPage/cards/ActivityFeed/GlobalActivityItem/GlobalActivityItem.tsx
@@ -17,22 +17,6 @@ import { ShowActivityDetailsHandler } from "components/ActivityItem/ActivityItem
 
 const baseClass = "global-activity-item";
 
-const PREMIUM_ACTIVITIES = new Set([
-  "created_team",
-  "deleted_team",
-  "applied_spec_team",
-  "changed_user_team_role",
-  "deleted_user_team_role",
-  "read_host_disk_encryption_key",
-  "enabled_macos_disk_encryption",
-  "disabled_macos_disk_encryption",
-  "enabled_macos_setup_end_user_auth",
-  "disabled_macos_setup_end_user_auth",
-  "tranferred_hosts",
-  "enabled_windows_mdm_migration",
-  "disabled_windows_mdm_migration",
-]);
-
 const ACTIVITIES_WITH_DETAILS = new Set([
   ActivityType.RanScript,
   ActivityType.AddedSoftware,
@@ -1086,6 +1070,37 @@ const TAGGED_TEMPLATES = {
   disabledAndroidMdm: () => {
     return <> turned off Android MDM.</>;
   },
+  canceledRunScript: (activity: IActivity) => {
+    const { script_name: scriptName, host_display_name: hostName } =
+      activity.details || {};
+    return (
+      <>
+        {" "}
+        canceled {formatScriptNameForActivityItem(scriptName)} on{" "}
+        <b>{hostName}</b>.
+      </>
+    );
+  },
+  canceledInstallSoftware: (activity: IActivity) => {
+    const { software_title: title, host_display_name: hostName } =
+      activity.details || {};
+    return (
+      <>
+        {" "}
+        canceled <b>{title}</b> install on <b>{hostName}</b>.
+      </>
+    );
+  },
+  canceledUninstallSoftware: (activity: IActivity) => {
+    const { software_title: title, host_display_name: hostName } =
+      activity.details || {};
+    return (
+      <>
+        {" "}
+        canceled <b>{title}</b> uninstall on <b>{hostName}</b>.
+      </>
+    );
+  },
 };
 
 const getDetail = (activity: IActivity, isPremiumTier: boolean) => {
@@ -1345,6 +1360,16 @@ const getDetail = (activity: IActivity, isPremiumTier: boolean) => {
     }
     case ActivityType.DisabledAndroidMdm: {
       return TAGGED_TEMPLATES.disabledAndroidMdm();
+    }
+    case ActivityType.CanceledRunScript: {
+      return TAGGED_TEMPLATES.canceledRunScript(activity);
+    }
+    case ActivityType.CanceledInstallSoftware:
+    case ActivityType.CanceledInstallAppStoreApp: {
+      return TAGGED_TEMPLATES.canceledInstallSoftware(activity);
+    }
+    case ActivityType.CanceledUninstallSoftware: {
+      return TAGGED_TEMPLATES.canceledUninstallSoftware(activity);
     }
 
     default: {

--- a/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
@@ -1235,7 +1235,7 @@ const HostDetailsPage = ({
           <CancelActivityModal
             hostId={host.id}
             activity={selectedCancelActivity}
-            onCancel={() => setSelectedCancelActivity(null)}
+            onExit={() => setSelectedCancelActivity(null)}
           />
         )}
         {selectedCertificate && (

--- a/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
@@ -503,6 +503,7 @@ const HostDetailsPage = ({
       );
     },
     {
+      ...DEFAULT_USE_QUERY_OPTIONS,
       keepPreviousData: true,
       staleTime: 2000,
     }
@@ -1235,6 +1236,7 @@ const HostDetailsPage = ({
           <CancelActivityModal
             hostId={host.id}
             activity={selectedCancelActivity}
+            onCancelActivity={() => refetchUpcomingActivities()}
             onExit={() => setSelectedCancelActivity(null)}
           />
         )}

--- a/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
@@ -670,6 +670,10 @@ const HostDetailsPage = ({
     [host?.display_name]
   );
 
+  const onCancelActivity = (activity: IHostUpcomingActivity) => {
+    setSelectedCancelActivity(activity);
+  };
+
   const onLabelClick = (label: ILabel) => {
     return label.name === "All Hosts"
       ? router.push(PATHS.MANAGE_HOSTS)
@@ -760,10 +764,6 @@ const HostDetailsPage = ({
         break;
       default: // do nothing
     }
-  };
-
-  const onCancelActivity = (activity: IHostUpcomingActivity) => {
-    setSelectedCancelActivity(activity);
   };
 
   const onSelectCertificate = (certificate: IHostCertificate) => {

--- a/frontend/pages/hosts/details/HostDetailsPage/modals/CancelActivityModal/CancelActivityModal.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/modals/CancelActivityModal/CancelActivityModal.tsx
@@ -43,13 +43,19 @@ const CancelActivityModal = ({
   return (
     <Modal className={baseClass} title="Cancel activity" onExit={onCancel}>
       <>
-        <ActivityItemComponent
-          tab="upcoming"
-          activity={activity}
-          onCancel={noop}
-          onShowDetails={noop}
-          isSoloActivity
-        />
+        <div className={`${baseClass}__content`}>
+          <p>
+            If the activity is happening on the host it will still complete.
+            Results won&apos;t appear in Fleet.
+          </p>
+          <ActivityItemComponent
+            tab="upcoming"
+            activity={activity}
+            onCancel={noop}
+            onShowDetails={noop}
+            isSoloActivity
+          />
+        </div>
         <div className="modal-cta-wrap">
           <Button variant="alert" onClick={onCancelActivity}>
             Cancel activity

--- a/frontend/pages/hosts/details/HostDetailsPage/modals/CancelActivityModal/CancelActivityModal.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/modals/CancelActivityModal/CancelActivityModal.tsx
@@ -17,13 +17,13 @@ const baseClass = "cancel-activity-modal";
 interface ICancelActivityModalProps {
   hostId: number;
   activity: IHostUpcomingActivity;
-  onCancel: () => void;
+  onExit: () => void;
 }
 
 const CancelActivityModal = ({
   hostId,
   activity,
-  onCancel,
+  onExit,
 }: ICancelActivityModalProps) => {
   const { renderFlash } = useContext(NotificationContext);
 
@@ -37,11 +37,11 @@ const CancelActivityModal = ({
       // TODO: hook up error message when API is updated
       renderFlash("error", getErrorMessage(error));
     }
-    onCancel();
+    onExit();
   };
 
   return (
-    <Modal className={baseClass} title="Cancel activity" onExit={onCancel}>
+    <Modal className={baseClass} title="Cancel activity" onExit={onExit}>
       <>
         <div className={`${baseClass}__content`}>
           <p>
@@ -60,7 +60,7 @@ const CancelActivityModal = ({
           <Button variant="alert" onClick={onCancelActivity}>
             Cancel activity
           </Button>
-          <Button variant="inverse-alert" onClick={onCancel}>
+          <Button variant="inverse-alert" onClick={onExit}>
             Back
           </Button>
         </div>

--- a/frontend/pages/hosts/details/HostDetailsPage/modals/CancelActivityModal/CancelActivityModal.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/modals/CancelActivityModal/CancelActivityModal.tsx
@@ -17,31 +17,40 @@ const baseClass = "cancel-activity-modal";
 interface ICancelActivityModalProps {
   hostId: number;
   activity: IHostUpcomingActivity;
+  onCancelActivity: () => void;
   onExit: () => void;
 }
 
 const CancelActivityModal = ({
   hostId,
   activity,
+  onCancelActivity,
   onExit,
 }: ICancelActivityModalProps) => {
   const { renderFlash } = useContext(NotificationContext);
+  const [isCanceling, setIsCanceling] = React.useState(false);
 
   const ActivityItemComponent = upcomingActivityComponentMap[activity.type];
 
-  const onCancelActivity = async () => {
+  const onAttemptyCancel = async () => {
+    setIsCanceling(true);
     try {
       await activitiesAPI.cancelHostActivity(hostId, activity.uuid);
       renderFlash("success", "Activity successfully canceled.");
-    } catch (error) {
-      // TODO: hook up error message when API is updated
-      renderFlash("error", getErrorMessage(error));
+    } catch (err) {
+      renderFlash("error", getErrorMessage(err));
     }
+    onCancelActivity();
     onExit();
   };
 
   return (
-    <Modal className={baseClass} title="Cancel activity" onExit={onExit}>
+    <Modal
+      className={baseClass}
+      title="Cancel activity"
+      onExit={onExit}
+      isContentDisabled={isCanceling}
+    >
       <>
         <div className={`${baseClass}__content`}>
           <p>
@@ -57,7 +66,12 @@ const CancelActivityModal = ({
           />
         </div>
         <div className="modal-cta-wrap">
-          <Button variant="alert" onClick={onCancelActivity}>
+          <Button
+            disabled={isCanceling}
+            isLoading={isCanceling}
+            variant="alert"
+            onClick={onAttemptyCancel}
+          >
             Cancel activity
           </Button>
           <Button variant="inverse-alert" onClick={onExit}>

--- a/frontend/pages/hosts/details/HostDetailsPage/modals/CancelActivityModal/_styles.scss
+++ b/frontend/pages/hosts/details/HostDetailsPage/modals/CancelActivityModal/_styles.scss
@@ -1,0 +1,11 @@
+.cancel-activity-modal {
+  &__content {
+    display: flex;
+    flex-direction: column;
+    gap: $pad-medium;
+
+    > p {
+      margin: 0;
+    }
+  }
+}

--- a/frontend/pages/hosts/details/HostDetailsPage/modals/CancelActivityModal/helpers.ts
+++ b/frontend/pages/hosts/details/HostDetailsPage/modals/CancelActivityModal/helpers.ts
@@ -1,7 +1,10 @@
 import { getErrorReason } from "interfaces/errors";
 
+const DEFAULT_ERROR_MESSAGE = "An error occurred. Please try again.";
+
 // eslint-disable-next-line import/prefer-default-export
 export const getErrorMessage = (err: unknown) => {
   const reason = getErrorReason(err);
-  return reason;
+
+  return `Couldn't cancel activity. ${reason || DEFAULT_ERROR_MESSAGE}`;
 };

--- a/frontend/pages/hosts/details/cards/Activity/Activity.tsx
+++ b/frontend/pages/hosts/details/cards/Activity/Activity.tsx
@@ -70,7 +70,7 @@ const Activity = ({
     >
       {isLoading && (
         <div className={`${baseClass}__loading-overlay`}>
-          <Spinner />
+          <Spinner centered />
         </div>
       )}
       <CardHeader header="Activity" />

--- a/frontend/pages/hosts/details/cards/Activity/ActivityConfig.tsx
+++ b/frontend/pages/hosts/details/cards/Activity/ActivityConfig.tsx
@@ -14,8 +14,9 @@ import RanScriptActivityItem from "./ActivityItems/RanScriptActivityItem";
 import LockedHostActivityItem from "./ActivityItems/LockedHostActivityItem";
 import UnlockedHostActivityItem from "./ActivityItems/UnlockedHostActivityItem";
 import InstalledSoftwareActivityItem from "./ActivityItems/InstalledSoftwareActivityItem";
-import CanceledScriptActivityItem from "./ActivityItems/CanceledScriptActivityItem";
-import CanceledSoftwareInstallActivityItem from "./ActivityItems/CanceledSoftwareInstallActivityItem";
+import CanceledRunScriptActivityItem from "./ActivityItems/CanceledRunScriptActivityItem";
+import CanceledInstallSoftwareActivityItem from "./ActivityItems/CanceledInstallSoftwareActivityItem";
+import CanceledUninstallSoftwareActivtyItem from "./ActivityItems/CanceledUninstallSoftwareActivtyItem";
 
 /** The component props that all host activity items must adhere to */
 export interface IHostActivityItemComponentProps {
@@ -49,8 +50,10 @@ export const pastActivityComponentMap: Record<
   [ActivityType.InstalledSoftware]: InstalledSoftwareActivityItem,
   [ActivityType.UninstalledSoftware]: InstalledSoftwareActivityItem,
   [ActivityType.InstalledAppStoreApp]: InstalledSoftwareActivityItem,
-  [ActivityType.CanceledScript]: CanceledScriptActivityItem,
-  [ActivityType.CanceledSoftwareInstall]: CanceledSoftwareInstallActivityItem,
+  [ActivityType.CanceledRunScript]: CanceledRunScriptActivityItem,
+  [ActivityType.CanceledInstallSoftware]: CanceledInstallSoftwareActivityItem,
+  [ActivityType.CanceledInstallAppStoreApp]: CanceledInstallSoftwareActivityItem,
+  [ActivityType.CanceledUninstallSoftware]: CanceledUninstallSoftwareActivtyItem,
 };
 
 export const upcomingActivityComponentMap: Record<

--- a/frontend/pages/hosts/details/cards/Activity/ActivityItems/CanceledInstallSoftwareActivityItem/CanceledInstallSoftwareActivityItem.tests.tsx
+++ b/frontend/pages/hosts/details/cards/Activity/ActivityItems/CanceledInstallSoftwareActivityItem/CanceledInstallSoftwareActivityItem.tests.tsx
@@ -1,0 +1,41 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+
+import { createMockHostPastActivity } from "__mocks__/activityMock";
+import { ActivityType } from "interfaces/activity";
+
+import CanceledInstallSoftwareActivityItem from "./CanceledInstallSoftwareActivityItem";
+
+describe("CanceledInstallSoftwareActivityItem", () => {
+  const mockActivity = createMockHostPastActivity({
+    type: ActivityType.CanceledInstallSoftware,
+    details: { software_title: "test.app" },
+  });
+
+  it("renders the activity content", () => {
+    render(
+      <CanceledInstallSoftwareActivityItem tab="past" activity={mockActivity} />
+    );
+
+    expect(screen.getByText("Test User")).toBeVisible();
+    expect(screen.getByText(/canceled/i)).toBeVisible();
+    expect(screen.getByText(/test.app/i)).toBeVisible();
+    expect(screen.getByText(/install on this host/i)).toBeVisible();
+  });
+
+  it("does not render the cancel icon", () => {
+    render(
+      <CanceledInstallSoftwareActivityItem tab="past" activity={mockActivity} />
+    );
+
+    expect(screen.queryByTestId("close-icon")).not.toBeInTheDocument();
+  });
+
+  it("does not render the show details icon", () => {
+    render(
+      <CanceledInstallSoftwareActivityItem tab="past" activity={mockActivity} />
+    );
+
+    expect(screen.queryByTestId("info-outline-icon")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/pages/hosts/details/cards/Activity/ActivityItems/CanceledInstallSoftwareActivityItem/CanceledInstallSoftwareActivityItem.tsx
+++ b/frontend/pages/hosts/details/cards/Activity/ActivityItems/CanceledInstallSoftwareActivityItem/CanceledInstallSoftwareActivityItem.tsx
@@ -17,7 +17,7 @@ const CanceledInstallSoftwareActivityItem = ({
     >
       <>
         <b>{activity.actor_full_name}</b> canceled{" "}
-        <b>{activity.details.software_title}</b> uninstall on this host.
+        <b>{activity.details.software_title}</b> install on this host.
       </>
     </ActivityItem>
   );

--- a/frontend/pages/hosts/details/cards/Activity/ActivityItems/CanceledInstallSoftwareActivityItem/CanceledInstallSoftwareActivityItem.tsx
+++ b/frontend/pages/hosts/details/cards/Activity/ActivityItems/CanceledInstallSoftwareActivityItem/CanceledInstallSoftwareActivityItem.tsx
@@ -1,31 +1,26 @@
 import React from "react";
 
-import { formatScriptNameForActivityItem } from "utilities/helpers";
-
 import ActivityItem from "components/ActivityItem";
-
 import { IHostActivityItemComponentProps } from "../../ActivityConfig";
 
-const baseClass = "canceled-script-activity-item";
+const baseClass = "canceled-install-software-activity-item";
 
-const CanceledScriptActivityItem = ({
+const CanceledInstallSoftwareActivityItem = ({
   activity,
-  hideCancel,
 }: IHostActivityItemComponentProps) => {
   return (
     <ActivityItem
       className={baseClass}
       activity={activity}
-      hideCancel={hideCancel}
+      hideCancel
       hideShowDetails
     >
       <>
         <b>{activity.actor_full_name}</b> canceled{" "}
-        <b>{formatScriptNameForActivityItem(activity.details?.script_name)}</b>{" "}
-        script on this host.
+        <b>{activity.details.software_title}</b> uninstall on this host.
       </>
     </ActivityItem>
   );
 };
 
-export default CanceledScriptActivityItem;
+export default CanceledInstallSoftwareActivityItem;

--- a/frontend/pages/hosts/details/cards/Activity/ActivityItems/CanceledInstallSoftwareActivityItem/index.ts
+++ b/frontend/pages/hosts/details/cards/Activity/ActivityItems/CanceledInstallSoftwareActivityItem/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./CanceledInstallSoftwareActivityItem";

--- a/frontend/pages/hosts/details/cards/Activity/ActivityItems/CanceledRunScriptActivityItem/CanceledRunScriptActivityItem.tests.tsx
+++ b/frontend/pages/hosts/details/cards/Activity/ActivityItems/CanceledRunScriptActivityItem/CanceledRunScriptActivityItem.tests.tsx
@@ -1,0 +1,40 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+
+import { createMockHostPastActivity } from "__mocks__/activityMock";
+import { ActivityType } from "interfaces/activity";
+
+import CanceledRunScriptActivityItem from "./CanceledRunScriptActivityItem";
+
+describe("CanceledRunScriptActivityItem", () => {
+  const mockActivity = createMockHostPastActivity({
+    type: ActivityType.CanceledRunScript,
+    details: { script_name: "test.sh" },
+  });
+
+  it("renders the activity content", () => {
+    render(
+      <CanceledRunScriptActivityItem tab="past" activity={mockActivity} />
+    );
+
+    expect(screen.getByText("Test User")).toBeVisible();
+    expect(screen.getByText(/canceled/i)).toBeVisible();
+    expect(screen.getByText(/test.sh/i)).toBeVisible();
+  });
+
+  it("does not render the cancel icon", () => {
+    render(
+      <CanceledRunScriptActivityItem tab="past" activity={mockActivity} />
+    );
+
+    expect(screen.queryByTestId("close-icon")).not.toBeInTheDocument();
+  });
+
+  it("does not render the show details icon", () => {
+    render(
+      <CanceledRunScriptActivityItem tab="past" activity={mockActivity} />
+    );
+
+    expect(screen.queryByTestId("info-outline-icon")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/pages/hosts/details/cards/Activity/ActivityItems/CanceledRunScriptActivityItem/CanceledRunScriptActivityItem.tsx
+++ b/frontend/pages/hosts/details/cards/Activity/ActivityItems/CanceledRunScriptActivityItem/CanceledRunScriptActivityItem.tsx
@@ -20,8 +20,8 @@ const CanceledRunScriptActivityItem = ({
     >
       <>
         <b>{activity.actor_full_name}</b> canceled{" "}
-        <b>{formatScriptNameForActivityItem(activity.details.script_name)}</b>{" "}
-        script on this host.
+        {formatScriptNameForActivityItem(activity.details.script_name)} on this
+        host.
       </>
     </ActivityItem>
   );

--- a/frontend/pages/hosts/details/cards/Activity/ActivityItems/CanceledRunScriptActivityItem/CanceledRunScriptActivityItem.tsx
+++ b/frontend/pages/hosts/details/cards/Activity/ActivityItems/CanceledRunScriptActivityItem/CanceledRunScriptActivityItem.tsx
@@ -1,27 +1,30 @@
 import React from "react";
 
+import { formatScriptNameForActivityItem } from "utilities/helpers";
+
 import ActivityItem from "components/ActivityItem";
+
 import { IHostActivityItemComponentProps } from "../../ActivityConfig";
 
-const baseClass = "canceled-software-install-activity-item";
+const baseClass = "canceled-run-script-activity-item";
 
-const CanceledSoftwareInstallActivityItem = ({
+const CanceledRunScriptActivityItem = ({
   activity,
-  hideCancel,
 }: IHostActivityItemComponentProps) => {
   return (
     <ActivityItem
       className={baseClass}
       activity={activity}
-      hideCancel={hideCancel}
+      hideCancel
       hideShowDetails
     >
       <>
         <b>{activity.actor_full_name}</b> canceled{" "}
-        <b>{activity.details?.software_title}</b> install on this host.
+        <b>{formatScriptNameForActivityItem(activity.details.script_name)}</b>{" "}
+        script on this host.
       </>
     </ActivityItem>
   );
 };
 
-export default CanceledSoftwareInstallActivityItem;
+export default CanceledRunScriptActivityItem;

--- a/frontend/pages/hosts/details/cards/Activity/ActivityItems/CanceledRunScriptActivityItem/index.ts
+++ b/frontend/pages/hosts/details/cards/Activity/ActivityItems/CanceledRunScriptActivityItem/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./CanceledRunScriptActivityItem";

--- a/frontend/pages/hosts/details/cards/Activity/ActivityItems/CanceledScriptActivityItem/index.ts
+++ b/frontend/pages/hosts/details/cards/Activity/ActivityItems/CanceledScriptActivityItem/index.ts
@@ -1,1 +1,0 @@
-export { default } from "./CanceledScriptActivityItem";

--- a/frontend/pages/hosts/details/cards/Activity/ActivityItems/CanceledSoftwareInstallActivityItem/index.ts
+++ b/frontend/pages/hosts/details/cards/Activity/ActivityItems/CanceledSoftwareInstallActivityItem/index.ts
@@ -1,1 +1,0 @@
-export { default } from "./CanceledSoftwareInstallActivityItem";

--- a/frontend/pages/hosts/details/cards/Activity/ActivityItems/CanceledUninstallSoftwareActivtyItem/CanceledUninstallSoftwareActivityItem.tests.tsx
+++ b/frontend/pages/hosts/details/cards/Activity/ActivityItems/CanceledUninstallSoftwareActivtyItem/CanceledUninstallSoftwareActivityItem.tests.tsx
@@ -1,0 +1,50 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+
+import { createMockHostPastActivity } from "__mocks__/activityMock";
+import { ActivityType } from "interfaces/activity";
+
+import CanceledUninstallSoftwareActivtyItem from "./CanceledUninstallSoftwareActivtyItem";
+
+describe("CanceledUninstallSoftwareActivityItem", () => {
+  const mockActivity = createMockHostPastActivity({
+    type: ActivityType.CanceledUninstallSoftware,
+    details: { software_title: "test.sh" },
+  });
+
+  it("renders the activity content", () => {
+    render(
+      <CanceledUninstallSoftwareActivtyItem
+        tab="past"
+        activity={mockActivity}
+      />
+    );
+
+    expect(screen.getByText("Test User")).toBeVisible();
+    expect(screen.getByText(/canceled/i)).toBeVisible();
+    expect(screen.getByText(/test.sh/i)).toBeVisible();
+    expect(screen.getByText(/uninstall on this host/i)).toBeVisible();
+  });
+
+  it("does not render the cancel icon", () => {
+    render(
+      <CanceledUninstallSoftwareActivtyItem
+        tab="past"
+        activity={mockActivity}
+      />
+    );
+
+    expect(screen.queryByTestId("close-icon")).not.toBeInTheDocument();
+  });
+
+  it("does not render the show details icon", () => {
+    render(
+      <CanceledUninstallSoftwareActivtyItem
+        tab="past"
+        activity={mockActivity}
+      />
+    );
+
+    expect(screen.queryByTestId("info-outline-icon")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/pages/hosts/details/cards/Activity/ActivityItems/CanceledUninstallSoftwareActivtyItem/CanceledUninstallSoftwareActivtyItem.tsx
+++ b/frontend/pages/hosts/details/cards/Activity/ActivityItems/CanceledUninstallSoftwareActivtyItem/CanceledUninstallSoftwareActivtyItem.tsx
@@ -1,0 +1,27 @@
+import React from "react";
+
+import ActivityItem from "components/ActivityItem";
+
+import { IHostActivityItemComponentProps } from "../../ActivityConfig";
+
+const baseClass = "canceled-uninstall-software-activty-item";
+
+const CanceledUninstallSoftwareActivtyItem = ({
+  activity,
+}: IHostActivityItemComponentProps) => {
+  return (
+    <ActivityItem
+      className={baseClass}
+      activity={activity}
+      hideCancel
+      hideShowDetails
+    >
+      <>
+        <b>{activity.actor_full_name}</b> canceled{" "}
+        <b>{activity.details.software_title}</b> install on this host.
+      </>
+    </ActivityItem>
+  );
+};
+
+export default CanceledUninstallSoftwareActivtyItem;

--- a/frontend/pages/hosts/details/cards/Activity/ActivityItems/CanceledUninstallSoftwareActivtyItem/CanceledUninstallSoftwareActivtyItem.tsx
+++ b/frontend/pages/hosts/details/cards/Activity/ActivityItems/CanceledUninstallSoftwareActivtyItem/CanceledUninstallSoftwareActivtyItem.tsx
@@ -18,7 +18,7 @@ const CanceledUninstallSoftwareActivtyItem = ({
     >
       <>
         <b>{activity.actor_full_name}</b> canceled{" "}
-        <b>{activity.details.software_title}</b> install on this host.
+        <b>{activity.details.software_title}</b> uninstall on this host.
       </>
     </ActivityItem>
   );

--- a/frontend/pages/hosts/details/cards/Activity/ActivityItems/CanceledUninstallSoftwareActivtyItem/index.ts
+++ b/frontend/pages/hosts/details/cards/Activity/ActivityItems/CanceledUninstallSoftwareActivtyItem/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./CanceledUninstallSoftwareActivtyItem";

--- a/frontend/pages/hosts/details/cards/Activity/ActivityItems/InstalledSoftwareActivityItem/InstalledSoftwareActivityItem.tsx
+++ b/frontend/pages/hosts/details/cards/Activity/ActivityItems/InstalledSoftwareActivityItem/InstalledSoftwareActivityItem.tsx
@@ -12,7 +12,9 @@ const InstalledSoftwareActivityItem = ({
   tab,
   activity,
   onShowDetails,
+  onCancel,
   hideCancel,
+  isSoloActivity,
 }: IHostActivityItemComponentPropsWithShowDetails) => {
   const { actor_full_name: actorName, details } = activity;
   const { self_service, software_title: title } = details;
@@ -37,6 +39,8 @@ const InstalledSoftwareActivityItem = ({
       activity={activity}
       hideCancel={hideCancel}
       onShowDetails={onShowDetails}
+      onCancel={onCancel}
+      isSoloActivity={isSoloActivity}
     >
       <>{actorDisplayName}</> {installedSoftwarePrefix} <b>{title}</b> on this
       host{self_service && " (self-service)"}.{" "}

--- a/frontend/pages/hosts/details/cards/Activity/ActivityItems/RanScriptActivityItem/RanScriptActivityItem.tsx
+++ b/frontend/pages/hosts/details/cards/Activity/ActivityItems/RanScriptActivityItem/RanScriptActivityItem.tsx
@@ -11,6 +11,7 @@ const RanScriptActivityItem = ({
   tab,
   activity,
   onShowDetails,
+  onCancel,
   isSoloActivity,
   hideCancel,
 }: IHostActivityItemComponentPropsWithShowDetails) => {
@@ -24,6 +25,7 @@ const RanScriptActivityItem = ({
       className={baseClass}
       activity={activity}
       onShowDetails={onShowDetails}
+      onCancel={onCancel}
       isSoloActivity={isSoloActivity}
       hideCancel={hideCancel}
     >

--- a/frontend/pages/hosts/details/cards/Activity/UpcomingActivityFeed/UpcomingActivityFeed.tsx
+++ b/frontend/pages/hosts/details/cards/Activity/UpcomingActivityFeed/UpcomingActivityFeed.tsx
@@ -61,7 +61,6 @@ const UpcomingActivityFeed = ({
               tab="upcoming"
               activity={activity}
               onShowDetails={onShowDetails}
-              hideCancel // TODO: remove this when canceling is implemented in API
               onCancel={() => onCancel(activity)}
             />
           );

--- a/frontend/pages/hosts/details/cards/Activity/UpcomingActivityFeed/UpcomingActivityFeed.tsx
+++ b/frontend/pages/hosts/details/cards/Activity/UpcomingActivityFeed/UpcomingActivityFeed.tsx
@@ -1,7 +1,8 @@
-import React from "react";
+import React, { useContext } from "react";
 
 import { IHostUpcomingActivity } from "interfaces/activity";
 import { IHostUpcomingActivitiesResponse } from "services/entities/activities";
+import { AppContext } from "context/app";
 
 import DataError from "components/DataError";
 import Pagination from "components/Pagination";
@@ -29,6 +30,12 @@ const UpcomingActivityFeed = ({
   onNextPage,
   onPreviousPage,
 }: IUpcomingActivityFeedProps) => {
+  const {
+    isTeamMaintainerOrTeamAdmin,
+    isGlobalAdmin,
+    isGlobalMaintainer,
+  } = useContext(AppContext);
+
   if (isError) {
     return <DataError />;
   }
@@ -49,6 +56,9 @@ const UpcomingActivityFeed = ({
     );
   }
 
+  const canCancel =
+    isGlobalAdmin || isGlobalMaintainer || isTeamMaintainerOrTeamAdmin;
+
   return (
     <div className={baseClass}>
       <div className={`${baseClass}__feed-list`}>
@@ -61,6 +71,7 @@ const UpcomingActivityFeed = ({
               tab="upcoming"
               activity={activity}
               onShowDetails={onShowDetails}
+              hideCancel={!canCancel}
               onCancel={() => onCancel(activity)}
             />
           );

--- a/frontend/pages/hosts/details/cards/Activity/_styles.scss
+++ b/frontend/pages/hosts/details/cards/Activity/_styles.scss
@@ -2,6 +2,11 @@
   position: relative;
 
   &__loading-overlay {
+    // this is to center the loading spinner in the card
+    display: flex;
+    align-items: center;
+    justify-content: center;
+
     height: 100%;
     width: 100%;
     position: absolute;

--- a/frontend/test/handlers/activity-handlers.ts
+++ b/frontend/test/handlers/activity-handlers.ts
@@ -1,6 +1,6 @@
 import { http, HttpResponse } from "msw";
 
-import createMockActivity from "__mocks__/activityMock";
+import { createMockActivity } from "__mocks__/activityMock";
 import { baseUrl } from "test/test-utils";
 
 export const defaultActivityHandler = http.get(baseUrl("/activities"), () => {


### PR DESCRIPTION
For #27410

add UI for canceling upcoming host activities and displaying canceled activities in global and past activity feeds. This includes:

**ability to cancel upcoming activity**

![image](https://github.com/user-attachments/assets/1fdafb05-dc0c-4025-8389-e9a0b9da2673)

**Confirmation modal to cancel activity**

![image](https://github.com/user-attachments/assets/e765c60b-2b5e-43ca-a31b-2a7af0d64247)

**new global activities when upcoming activities are canceled**

![image](https://github.com/user-attachments/assets/04f368cb-f66c-4802-b3fb-79fd5f7b06bb)

**new past activities when upcoming activities are canceled**

![image](https://github.com/user-attachments/assets/b2d0a50e-58e8-4677-84bd-9c645651b9ab)


<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
- [x] Added/updated automated tests
- [x] Manual QA for all new/changed functionality
