### PR TITLE
Update YAML docs w/ more info on labels

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -54,6 +54,11 @@
             "buildFlags": "-tags='full,fts5'",
             "cwd": "${workspaceFolder}",
             "program": "${workspaceFolder}/cmd/fleet",
+            "debugAdapter": "dlv-dap",
+            "env": {
+                "DLV_LOG": "true",
+                "DLV_LOG_OUTPUT": "debugger,gdbwire,rpc"
+            },
             "args": [
                 "serve",
                 "--dev",
@@ -61,6 +66,20 @@
                 "--dev_license"
             ]
         },
+        {
+            "name": "Fleet ctl gitops",
+            "type": "go",
+            "request": "launch",
+            "mode": "auto",
+            "buildFlags": "-tags='full,fts5'",
+            "cwd": "${workspaceFolder}",
+            "program": "${workspaceFolder}/cmd/fleetctl",
+            "args": [
+                "gitops",
+                "-f",
+                "/Users/scott/Development/test-fleet-gitops/teams/27301.yml"
+            ]
+        },        
         {
             "name": "Fleet vuln_processing (licensed)",
             "type": "go",
@@ -126,6 +145,6 @@
             ],
             "console": "integratedTerminal",
             "internalConsoleOptions": "neverOpen"
-        }
+        }          
     ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -54,11 +54,6 @@
             "buildFlags": "-tags='full,fts5'",
             "cwd": "${workspaceFolder}",
             "program": "${workspaceFolder}/cmd/fleet",
-            "debugAdapter": "dlv-dap",
-            "env": {
-                "DLV_LOG": "true",
-                "DLV_LOG_OUTPUT": "debugger,gdbwire,rpc"
-            },
             "args": [
                 "serve",
                 "--dev",
@@ -66,20 +61,6 @@
                 "--dev_license"
             ]
         },
-        {
-            "name": "Fleet ctl gitops",
-            "type": "go",
-            "request": "launch",
-            "mode": "auto",
-            "buildFlags": "-tags='full,fts5'",
-            "cwd": "${workspaceFolder}",
-            "program": "${workspaceFolder}/cmd/fleetctl",
-            "args": [
-                "gitops",
-                "-f",
-                "/Users/scott/Development/test-fleet-gitops/teams/27301.yml"
-            ]
-        },        
         {
             "name": "Fleet vuln_processing (licensed)",
             "type": "go",
@@ -145,6 +126,6 @@
             ],
             "console": "integratedTerminal",
             "internalConsoleOptions": "neverOpen"
-        }          
+        }
     ]
 }

--- a/docs/Configuration/yaml-files.md
+++ b/docs/Configuration/yaml-files.md
@@ -45,6 +45,7 @@ labels:
     hosts:
       - "ceo-laptop"
       - "the-CFOs-computer"
+```
 
 #### Separate file
  

--- a/docs/Configuration/yaml-files.md
+++ b/docs/Configuration/yaml-files.md
@@ -21,7 +21,7 @@ team_settings: # Only teams/team-name.yml
 
 ## labels
 
-Labels can be specified inline in your `default.yml` file.  This is an _optional_ key; if it is omitted, any existing labels created via the UI or API will remain untouched by GitOps. If it is added, GitOps will replace all existing labels with those specified in the YAML, and any labels referenced in other sections (like [policies](https://fleetdm.com/docs/configuration/yaml-files#policies), [queries](https://fleetdm.com/docs/configuration/yaml-files#queries) or [software](https://fleetdm.com/docs/configuration/yaml-files#software)) _must_ be specified in the `labels` section.
+Labels can be specified in your `default.yml` file using inline configuration or references to separate files in your `lib/` folder.  The `labels:` key is _optional_ in your YAML configuration; if it is omitted, any existing labels created via the UI or API will remain untouched by GitOps. If it is added, GitOps will replace all existing labels with those specified in the YAML, and any labels referenced in other sections (like [policies](https://fleetdm.com/docs/configuration/yaml-files#policies), [queries](https://fleetdm.com/docs/configuration/yaml-files#queries) or [software](https://fleetdm.com/docs/configuration/yaml-files#software)) _must_ be specified in the `labels` section.
 
 ### Options
 


### PR DESCRIPTION
For #27883 

* Adds section on managing labels via YAML
* Adds `labels_include_any` to examples under the queries section
* Adds `labels_exclude_any` to examples under the policies section (I didn't see that @rachaelshaw had already added examples for policies, but one more won't hurt)