### PR TITLE
Remove change files from v4.63.0

### DIFF
--- a/changes/24790-admx-policies
+++ b/changes/24790-admx-policies
@@ -1,1 +1,0 @@
-Fixes issue verifying Windows CSP profiles that contain ADMX policies.

--- a/changes/25130-iterm-false-neg
+++ b/changes/25130-iterm-false-neg
@@ -1,1 +1,0 @@
-- Fixed a false negative vulnerability reporting for iTerm2 (available to all recent Fleet releases as of January 17th via a vulnerability feed update)

--- a/changes/25305-update-add-hosts-help-text
+++ b/changes/25305-update-add-hosts-help-text
@@ -1,1 +1,0 @@
-- Update the help text for 3 tabs of the Add hosts modal

--- a/changes/25597-false-positives
+++ b/changes/25597-false-positives
@@ -1,1 +1,0 @@
-* Resolved false-positives for the `pass` Homebrew package and `jira` Python package via a vulnerability feed update available to all Fleet versions on 2025-01-22

--- a/changes/25609-archive-encryption-keys
+++ b/changes/25609-archive-encryption-keys
@@ -1,1 +1,0 @@
-Disk encryption keys are now archived when they are created or updated. They are never fully deleted from the database.

--- a/changes/25615-windows-mdm-profiles
+++ b/changes/25615-windows-mdm-profiles
@@ -1,1 +1,0 @@
-Fixed issue where some Windows MDM profiles were not being sent to hosts when hosts came back online.

--- a/changes/issue-21691-windows-disk-encryption-dont-resend
+++ b/changes/issue-21691-windows-disk-encryption-dont-resend
@@ -1,2 +1,0 @@
-- remove the resend button for failed windows disk encryption profiles and add messaging that tells
-the user that Fleet with automatically retry this profile again.

--- a/changes/issue-25735-fix-500-vulnerable-host-software
+++ b/changes/issue-25735-fix-500-vulnerable-host-software
@@ -1,1 +1,0 @@
-- fix when trying to filter by vulnerable software for ios or ipad host.


### PR DESCRIPTION
Another release mistake in 4.63.0. I ran `make changelog` in the RC branch to get these changes included, but I didn't commit the deletions and cherry-pick them, which resulted in them getting rolled into every `make changelog` since then and confusing me, and likely resulting in us announcing fixes multiple times. 