### PR TITLE
Remove change files from 4.64.0

### DIFF
--- a/changes/16865-increase-statistics-frequency
+++ b/changes/16865-increase-statistics-frequency
@@ -1,1 +1,0 @@
-* Raised the frequency of sending anonymous statistics from every 24 hours to every 1 hour. (This is a fairly small packet and should have no impact on network traffic)

--- a/changes/22353-abm-hosts-upcoming-activities
+++ b/changes/22353-abm-hosts-upcoming-activities
@@ -1,1 +1,0 @@
-- Hosts that are restored from ABM no longer have old activities in their feed

--- a/changes/22464-list-hosts-populate-users-labels
+++ b/changes/22464-list-hosts-populate-users-labels
@@ -1,1 +1,0 @@
-- Added option to populate users and labels on list hosts endpoint

--- a/changes/22544-move-linux-lock-wipe
+++ b/changes/22544-move-linux-lock-wipe
@@ -1,1 +1,0 @@
-- Removed duplicate Linux lock and wipe scripts from repository

--- a/changes/22919-semver-util
+++ b/changes/22919-semver-util
@@ -1,1 +1,0 @@
-* Added util wrapper func around semver package to allow for custom preprocessing. Upgraded semver library to 3.3.1 and usage everywhere to version 3.  

--- a/changes/23096-fma-errors
+++ b/changes/23096-fma-errors
@@ -1,1 +1,0 @@
-- Fleet UI: Surfaced cleaner errors when adding Fleet-maintained apps

--- a/changes/23116-fma-dl-url
+++ b/changes/23116-fma-dl-url
@@ -1,1 +1,0 @@
-- Fleet UI: Surfaced download URL for Fleet-maintained app when adding the software to Fleet

--- a/changes/23241-lock-api-response
+++ b/changes/23241-lock-api-response
@@ -1,1 +1,0 @@
-* Included current host status and pending action in lock, unlock, and wipe API calls

--- a/changes/23312-update-policies-empty-state
+++ b/changes/23312-update-policies-empty-state
@@ -1,1 +1,0 @@
-- Clarified text on the Policies and Queries pages when no policies/queries exist for the selected team (or All Teams)

--- a/changes/23465-query-reports-support-event-format
+++ b/changes/23465-query-reports-support-event-format
@@ -1,1 +1,0 @@
-* Fixed a bug where query reports where not being recorded for hosts configured with `--logger_snapshot_event_type=true`.

--- a/changes/23770-fleetctl-linux-arm
+++ b/changes/23770-fleetctl-linux-arm
@@ -1,1 +1,0 @@
-- Added `fleetctl` on Linux ARM binary to releases.

--- a/changes/23924-handle-long-team-names
+++ b/changes/23924-handle-long-team-names
@@ -1,1 +1,0 @@
-* Improve the teams dropdown so that it gracefully hides overflow from long team names

--- a/changes/24035-team-agent-options-ui-resets
+++ b/changes/24035-team-agent-options-ui-resets
@@ -1,1 +1,0 @@
-* Maintain user's updates to the team agent options form when they navigate away and back again.

--- a/changes/24341-improve-ux-of-script-list-items
+++ b/changes/24341-improve-ux-of-script-list-items
@@ -1,1 +1,0 @@
-* Various UX improvements to the Scripts list

--- a/changes/24470-bash
+++ b/changes/24470-bash
@@ -1,1 +1,0 @@
-* Added bash interpreter support for script execution

--- a/changes/24486-error-for-invalid-invites
+++ b/changes/24486-error-for-invalid-invites
@@ -1,1 +1,0 @@
-- Check the server for validity of any Fleet invites

--- a/changes/24544-target-labels-vpp
+++ b/changes/24544-target-labels-vpp
@@ -1,3 +1,0 @@
-- Fleet UI: Added ability to target app store apps with include/exclude labels
-- Fleet UI: Added ability to edit targets or self service option for app store apps
-- Fleet UI: Added details modal for add, edit, and delete app store app global activities

--- a/changes/24601-editable-scripts-frontend
+++ b/changes/24601-editable-scripts-frontend
@@ -1,1 +1,0 @@
-- Added modal to edit script contents

--- a/changes/24602-editable-scripts
+++ b/changes/24602-editable-scripts
@@ -1,1 +1,0 @@
-- Added API endpoint for updating script contents

--- a/changes/24732-gzip
+++ b/changes/24732-gzip
@@ -1,1 +1,0 @@
-* Added gzip compression for static CSS and JS assets to decrease bundle download times

--- a/changes/24754-require-pw-for-pw-auth
+++ b/changes/24754-require-pw-for-pw-auth
@@ -1,4 +1,0 @@
-- Update user form validation to require a password be present when switching a user from
-  SSO to password authentication
-- Refactor upstream error logic to allow disabling submit button when form errors are present
-- Add similar check for password presence on server, update integration test accordingly

--- a/changes/24766-clickable-row-behavior
+++ b/changes/24766-clickable-row-behavior
@@ -1,1 +1,0 @@
-- Fleet UI: Created consistency of on-click behavior of table rows: View all host link must be clicked directly, clicking on a row of a table directs the user to the details of that row

--- a/changes/24790-admx-policies
+++ b/changes/24790-admx-policies
@@ -1,1 +1,0 @@
-Fixes issue verifying Windows CSP profiles that contain ADMX policies.

--- a/changes/24876-dashboard-cards
+++ b/changes/24876-dashboard-cards
@@ -1,1 +1,0 @@
-- Fleet UI: Changed look and feel of dashboard host count cards including hiding platforms with 0 count

--- a/changes/24886-fix-pagination-on-policies-page
+++ b/changes/24886-fix-pagination-on-policies-page
@@ -1,1 +1,0 @@
-- Fix a bug with paginating team policies

--- a/changes/24948-display-api-errors-in-user-form
+++ b/changes/24948-display-api-errors-in-user-form
@@ -1,2 +1,0 @@
-- Fix a bug where server errors returned from the API were not successfully being incorporated into
-  the user form error states.

--- a/changes/24958-gitops-webhooks-disable
+++ b/changes/24958-gitops-webhooks-disable
@@ -1,1 +1,0 @@
-- Disable webhooks if not present in gitops

--- a/changes/25015-user-page-responsive
+++ b/changes/25015-user-page-responsive
@@ -1,1 +1,0 @@
-- Fleet UI: Fixed user page responsiveness to not overflow horizontally

--- a/changes/25130-iterm-false-neg
+++ b/changes/25130-iterm-false-neg
@@ -1,1 +1,0 @@
-- Fixed a false negative vulnerability reporting for iTerm2 (available to all recent Fleet releases as of January 17th via a vulnerability feed update)

--- a/changes/25160-optimize-software-during-enrollment
+++ b/changes/25160-optimize-software-during-enrollment
@@ -1,2 +1,0 @@
-* Optimized software ingestion queries to use existing DB indexes in the software titles table.
-* Fixed a bug "software not found for checksum" in software ingestion transaction retries.

--- a/changes/25191-disk-encryption-sentence-case
+++ b/changes/25191-disk-encryption-sentence-case
@@ -1,1 +1,0 @@
-* Fixed case consistency for "Disk encryption" in host OS settings modal

--- a/changes/25201-unknown-installer-version
+++ b/changes/25201-unknown-installer-version
@@ -1,1 +1,0 @@
-* Revised software installer package validation to mark installers with no version as "unknown" for version rather than rejecting them

--- a/changes/25235-software-titles-uniqueness
+++ b/changes/25235-software-titles-uniqueness
@@ -1,1 +1,0 @@
-* Fixed a bug where only the first of multiple software titles with the same name and source but different bundle IDs would be successfully inserted into the database.

--- a/changes/25241-smtp-helo-domain
+++ b/changes/25241-smtp-helo-domain
@@ -1,1 +1,0 @@
-- Fixed mail being sent with the incorrect SMTP Domain (thank you mccormickt)

--- a/changes/25251-url-fleet-app-response
+++ b/changes/25251-url-fleet-app-response
@@ -1,1 +1,0 @@
-* Added download url for fleet maintained apps as `url` property on `fleet/software/fleet_maintained_apps/:id`

--- a/changes/25257-dropdown-improvements
+++ b/changes/25257-dropdown-improvements
@@ -1,1 +1,0 @@
-- Fleet UI: Improved the look and feel of dropdowns

--- a/changes/25261-identical-hostnames-label-membership
+++ b/changes/25261-identical-hostnames-label-membership
@@ -1,2 +1,0 @@
-- Fixed a bug where adding or removing a host with an identical name to/from a label caused the
-  same action to be performed on other host(s) with the same name as well.

--- a/changes/25273-hde-windows-verifying
+++ b/changes/25273-hde-windows-verifying
@@ -1,2 +1,0 @@
-- Fixed issue where Windows disk encryption where status updates from "Verifying" to "Verified" were
-  sometimes stuck in the "Verifying" state.

--- a/changes/25305-update-add-hosts-help-text
+++ b/changes/25305-update-add-hosts-help-text
@@ -1,1 +1,0 @@
-- Update the help text for 3 tabs of the Add hosts modal

--- a/changes/25306-add-windows-linux-hosts-radios
+++ b/changes/25306-add-windows-linux-hosts-radios
@@ -1,2 +1,0 @@
-* Replace "Include Fleet desktop" with host type radio selection buttons when adding Windows or
-Linux hosts.

--- a/changes/25307-fleetctl-package-link
+++ b/changes/25307-fleetctl-package-link
@@ -1,1 +1,0 @@
-- Added link to information about installing fleetd when packages are generated

--- a/changes/25318-update-sso-settings-error-states
+++ b/changes/25318-update-sso-settings-error-states
@@ -1,1 +1,0 @@
-* Add clearer error states to metadata-related fields in the SSO settings form

--- a/changes/25346-fix-manage-automations-link-on-dash
+++ b/changes/25346-fix-manage-automations-link-on-dash
@@ -1,1 +1,0 @@
-- Removed erroneous "manage automations" link on dashboard for maintainers

--- a/changes/25366-manage-automation-dropdown-styling
+++ b/changes/25366-manage-automation-dropdown-styling
@@ -1,1 +1,0 @@
-- Fleet UI: Fixed styling for manage automation buttons and dropdown

--- a/changes/25553-update-compatibility-tooltip
+++ b/changes/25553-update-compatibility-tooltip
@@ -1,2 +1,0 @@
-
-- Updates language in query comppatibility tooltip to clarify that comppatibility is based only on tables.

--- a/changes/25555-batch-hostnames-on-new-label
+++ b/changes/25555-batch-hostnames-on-new-label
@@ -1,1 +1,0 @@
-- Updated the way new manual labels are created to better support adding large numbers of hosts at one time.

--- a/changes/25567-renew-vpp
+++ b/changes/25567-renew-vpp
@@ -1,1 +1,0 @@
-* Fixed a bug in Fleet's handling of VPP token renewal requests

--- a/changes/25581-session-id
+++ b/changes/25581-session-id
@@ -1,1 +1,0 @@
-Fix Windows MDM issue where SessionID of 0 was not allowed.

--- a/changes/25590-node
+++ b/changes/25590-node
@@ -1,1 +1,0 @@
-* Bump Node.js version to 20.18.1

--- a/changes/25597-false-positives
+++ b/changes/25597-false-positives
@@ -1,1 +1,0 @@
-* Resolved false-positives for the `pass` Homebrew package and `jira` Python package via a vulnerability feed update available to all Fleet versions on 2025-01-22

--- a/changes/25609-archive-encryption-keys
+++ b/changes/25609-archive-encryption-keys
@@ -1,1 +1,0 @@
-Disk encryption keys are now archived when they are created or updated. They are never fully deleted from the database.

--- a/changes/25615-windows-mdm-profiles
+++ b/changes/25615-windows-mdm-profiles
@@ -1,1 +1,0 @@
-Fixed issue where some Windows MDM profiles were not being sent to hosts when hosts came back online.

--- a/changes/25640-fix-idp-source
+++ b/changes/25640-fix-idp-source
@@ -1,1 +1,0 @@
-- Fixes incorrect source value in device mapping REST API documentation

--- a/changes/25662-ij-windows
+++ b/changes/25662-ij-windows
@@ -1,1 +1,0 @@
-* Resolved false negatives on vulnerabilities for IntelliJ IDEA Community Edition on Windows.

--- a/changes/25748-remove-fleetctl-from-fleetdm-fleet-docker-image
+++ b/changes/25748-remove-fleetctl-from-fleetdm-fleet-docker-image
@@ -1,1 +1,0 @@
-* Removed `fleetctl` binary from the `fleetdm/fleet` docker image.

--- a/changes/25759-illegal-argument-errors
+++ b/changes/25759-illegal-argument-errors
@@ -1,1 +1,0 @@
-Illegal argument errors will no longer be logged at the ERROR level on the server. Since these are client errors, they will be logged at the DEBUG level instead. This will reduce the amount of noise in the server logs and help debugging other issues.

--- a/changes/25812-ddm-profiles-stuck
+++ b/changes/25812-ddm-profiles-stuck
@@ -1,1 +1,0 @@
-Added server debug logging for unexpected Apple DDM configuration status.

--- a/changes/25956-fix-buggy-efa-editing
+++ b/changes/25956-fix-buggy-efa-editing
@@ -1,1 +1,0 @@
-- Fix a bug where team admins are unable to enable or disable MFA for a user

--- a/changes/issue-21691-windows-disk-encryption-dont-resend
+++ b/changes/issue-21691-windows-disk-encryption-dont-resend
@@ -1,2 +1,0 @@
-- remove the resend button for failed windows disk encryption profiles and add messaging that tells
-the user that Fleet with automatically retry this profile again.

--- a/changes/issue-23912-ui-for-activities
+++ b/changes/issue-23912-ui-for-activities
@@ -1,1 +1,0 @@
-- update the UI a new activities design

--- a/changes/issue-24824-tooltip-verified-verifying
+++ b/changes/issue-24824-tooltip-verified-verifying
@@ -1,1 +1,0 @@
-- improve the verified and verifying tooltips on the Profile Status on OS settings page.

--- a/changes/issue-24901-fixes-error-cutoff
+++ b/changes/issue-24901-fixes-error-cutoff
@@ -1,1 +1,0 @@
-- fix in UI for window profiles error message being cut off in the OS settings modal

--- a/changes/issue-24992-padding-fixes-around-lists
+++ b/changes/issue-24992-padding-fixes-around-lists
@@ -1,1 +1,0 @@
-- normalise padding spacing for list headers, lists, and help text across various modals.

--- a/changes/issue-25159-update-deadline-tooltip
+++ b/changes/issue-25159-update-deadline-tooltip
@@ -1,2 +1,0 @@
-- update the os settings Target form deadline input tooltip to make the it more correct for how the
-deadline works for hosts

--- a/changes/issue-25507-upgrade-github-cache-action
+++ b/changes/issue-25507-upgrade-github-cache-action
@@ -1,1 +1,0 @@
-- bump github cache action to 4.2.0

--- a/changes/issue-25735-fix-500-vulnerable-host-software
+++ b/changes/issue-25735-fix-500-vulnerable-host-software
@@ -1,1 +1,0 @@
-- fix when trying to filter by vulnerable software for ios or ipad host.


### PR DESCRIPTION
I made a mistake when publishing. I meant to merge the 4.64.0 changes into my branch and then merge that into the 4.65.0 RC, then cherry-pick that commit. But I accidentally merged the 4.64.0 into the RC, then merged, then only cherry-picked the 4.65.0 changes in my PR back to `main`. The result was these waiting to bite me next time a ran `make changelog`. 