### PR TITLE
FDM updates: `fdm serve`, snapshot/restore improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -125,10 +125,15 @@ fdm:
 	@echo "Start the fleet server"
 .help-short--up: 
 	@echo "Start the fleet server (alias for \`serve\`)"
+.help-long--serve: SERVE_CMD:=serve
+.help-long--up: SERVE_CMD:=up
 .help-long--serve .help-long--up:
-	@echo "Starts an instance of the Fleet web and API server. If no arguments are provided, the server will start with the last used arguments."
+	@echo "Starts an instance of the Fleet web and API server." 
 	@echo
-	@echo "  To see all available options, run \`$(TOOL_CMD) serve --help\`"
+	@echo "  By default the server will listen on localhost:8080, in development mode with a premium license."
+	@echo "  If different options are used to start the server, the options will become 'sticky' and will be used the next time \`$(TOOL_CMD) $(SERVE_CMD)\` is called."
+	@echo
+	@echo "  To see all available options, run \`$(TOOL_CMD) $(SERVE_CMD) --help\`"
 .help-options--serve .help-options--up:
 	@echo "HELP"
 	@echo "Show all options for the fleet serve command"
@@ -139,7 +144,9 @@ fdm:
 	@echo "SHOW"
 	@echo "Show the last arguments used to start the server"
 
+up: SERVE_CMD:=up
 up: serve
+serve: SERVE_CMD:=serve
 serve: TARGET_ARGS := --use-ip --no-save --show
 ifdef USE_IP
 serve: EXTRA_CLI_ARGS := $(EXTRA_CLI_ARGS) --server_address=$(shell ipconfig getifaddr en0):8080
@@ -153,6 +160,9 @@ serve:
 else ifdef HELP
 serve:
 	@./build/fleet serve --help
+else ifdef RESET
+serve:
+	@touch ~/.fleet/last-serve-invocation && rm ~/.fleet/last-serve-invocation
 else
 serve:
 	$(call filter_args)
@@ -165,12 +175,11 @@ serve:
 		fi; \
 		./build/fleet serve $(FORWARDED_ARGS); \
 	else \
-		if [[  -f ~/.fleet/last-serve-invocation ]]; then \
-			cat ~/.fleet/last-serve-invocation; \
-			$$(cat ~/.fleet/last-serve-invocation); \
-		else \
-			./build/fleet serve; \
+		if ! [[ -f ~/.fleet/last-serve-invocation ]]; then \
+			echo "./build/fleet serve --server_address=localhost:8080 --dev --dev_license" > ~/.fleet/last-serve-invocation; \
 		fi; \
+		cat ~/.fleet/last-serve-invocation; \
+		$$(cat ~/.fleet/last-serve-invocation); \
 	fi
 endif
 

--- a/Makefile
+++ b/Makefile
@@ -183,10 +183,6 @@ serve:
 	fi
 endif
 
-build/fleet: | .pre-build .pre-fleet
-	@ make .prefix
-	CGO_ENABLED=1 go build -race=${GO_BUILD_RACE_ENABLED_VAR} -tags full,fts5,netgo -o build/${OUTPUT} -ldflags ${LDFLAGS_VERSION} ./cmd/fleet
-
 fleet: .prefix .pre-build .pre-fleet
 	CGO_ENABLED=1 go build -race=${GO_BUILD_RACE_ENABLED_VAR} -tags full,fts5,netgo -o build/${OUTPUT} -ldflags ${LDFLAGS_VERSION} ./cmd/fleet
 

--- a/Makefile
+++ b/Makefile
@@ -139,6 +139,8 @@ fdm:
 	@echo "Show all options for the fleet serve command"
 	@echo "USE_IP"
 	@echo "Start the server on the IP address of the host machine"
+	@echo "NO_BUILD"
+	@echo "Don't build the fleet binary before starting the server"
 	@echo "NO_SAVE"
 	@echo "Don't save the current arguments for the next invocation"
 	@echo "SHOW"
@@ -147,7 +149,7 @@ fdm:
 up: SERVE_CMD:=up
 up: serve
 serve: SERVE_CMD:=serve
-serve: TARGET_ARGS := --use-ip --no-save --show
+serve: TARGET_ARGS := --use-ip --no-save --show --no-build
 ifdef USE_IP
 serve: EXTRA_CLI_ARGS := $(EXTRA_CLI_ARGS) --server_address=$(shell ipconfig getifaddr en0):8080
 endif
@@ -165,6 +167,7 @@ serve:
 	@touch ~/.fleet/last-serve-invocation && rm ~/.fleet/last-serve-invocation
 else
 serve:
+	@if [[ "$(NO_BUILD)" != "true" ]]; then make fleet; fi
 	$(call filter_args)
 # If FORWARDED_ARGS is not empty, run the command with the forwarded arguments.
 # Unless NO_SAVE is set to true, save the command to the last invocation file.

--- a/Makefile
+++ b/Makefile
@@ -119,8 +119,23 @@ fdm:
 		sudo ln -sf "$$(pwd)/build/fdm" /usr/local/bin/fdm; \
 	fi
 
-.help-short--serve .help-short--up:
+.help-short--serve: 
 	@echo "Start the fleet server"
+.help-short--up: 
+	@echo "Start the fleet server (alias for \`serve\`)"
+.help-long--serve .help-long--up:
+	@echo "Starts an instance of the Fleet web and API server. If no arguments are provided, the server will start with the last used arguments."
+	@echo
+	@echo "  To see all available options, run \`$(TOOL_CMD) serve --help\`"
+.help-options--serve .help-options--up:
+	@echo "HELP"
+	@echo "Show all options for the fleet serve command"
+	@echo "USE_IP"
+	@echo "Start the server on the IP address of the host machine"
+	@echo "NO_SAVE"
+	@echo "Don't save the current arguments for the next invocation"
+	@echo "SHOW"
+	@echo "Show the last arguments used to start the server"
 
 serve up: TARGET_ARGS := --use-ip --no-save --show
 ifdef USE_IP
@@ -559,8 +574,10 @@ $(SNAPSHOT_BINARY): tools/snapshot/*.go
 .help-short--restore:
 	@echo "Restore a database snapshot"
 .help-long--restore:
-	@echo "Restore database state using a snapshot taken with \`$(TOOL_CMD) snapshot\`."	
-
+	@echo "Interactively restore database state using a snapshot taken with \`$(TOOL_CMD) snapshot\`."	
+.help-options--restore:
+	@echo "PREPARE (alias: PREP)"
+	@echo "Run migrations after restoring the snapshot"
 
 restore: $(SNAPSHOT_BINARY)
 	@$(SNAPSHOT_BINARY) restore

--- a/Makefile
+++ b/Makefile
@@ -770,7 +770,3 @@ db-replica-run: fleet
 	FLEET_MYSQL_ADDRESS=127.0.0.1:3308 FLEET_MYSQL_READ_REPLICA_ADDRESS=127.0.0.1:3309 FLEET_MYSQL_READ_REPLICA_USERNAME=fleet FLEET_MYSQL_READ_REPLICA_DATABASE=fleet FLEET_MYSQL_READ_REPLICA_PASSWORD=insecure ./build/fleet serve --dev --dev_license
 
 include ./tools/makefile-support/helpsystem-targets
-
-foo:
-	@echo $(MAKECMDGOALS)
-

--- a/Makefile
+++ b/Makefile
@@ -119,6 +119,9 @@ fdm:
 		sudo ln -sf "$$(pwd)/build/fdm" /usr/local/bin/fdm; \
 	fi
 
+.help-short--serve .help-short--up:
+	@echo "Start the fleet server"
+
 serve up: TARGET_ARGS := --use-ip --no-save --show
 ifdef USE_IP
 serve up: EXTRA_CLI_ARGS := $(EXTRA_CLI_ARGS) --server_address=$(shell ipconfig getifaddr en0):8080
@@ -129,6 +132,9 @@ serve up:
 	if [[ $$? -eq 0 ]]; then \
 		echo "$$SAVED_ARGS"; \
 	fi
+else ifdef HELP
+serve up:
+	@./build/fleet serve --help
 else
 serve up:
 	$(call filter_args)

--- a/Makefile
+++ b/Makefile
@@ -119,20 +119,24 @@ fdm:
 		sudo ln -sf "$$(pwd)/build/fdm" /usr/local/bin/fdm; \
 	fi
 
-serve up: TARGET_ARGS := --use-ip 
+serve up: TARGET_ARGS := --use-ip --no-save
 ifdef USE_IP
 serve up: EXTRA_CLI_ARGS := $(EXTRA_CLI_ARGS) --server_address=$(shell ipconfig getifaddr en0):8080
 endif
 serve up:
 	$(call filter_args)
 	@if [[ "$(FORWARDED_ARGS)" != "" ]]; then \
-		echo "./build/fleet serve $(FORWARDED_ARGS)" > ~/.fleet/last-serve-invocation; \
-	fi; 
-	@if [[ -f ~/.fleet/last-serve-invocation ]]; then \
-		cat ~/.fleet/last-serve-invocation; \
-		$$(cat ~/.fleet/last-serve-invocation); \
+		if [[ "$(NO_SAVE)" != "true" ]]; then \
+			echo "./build/fleet serve $(FORWARDED_ARGS)" > ~/.fleet/last-serve-invocation; \
+		fi; \
+		./build/fleet serve $(FORWARDED_ARGS); \
 	else \
-		./build/fleet serve; \
+		if [[  -f ~/.fleet/last-serve-invocation ]]; then \
+			cat ~/.fleet/last-serve-invocation; \
+			$$(cat ~/.fleet/last-serve-invocation); \
+		else \
+			./build/fleet serve; \
+		fi; \
 	fi
 
 build/fleet: | .pre-build .pre-fleet

--- a/Makefile
+++ b/Makefile
@@ -539,13 +539,30 @@ db-restore:
 
 
 # Interactive snapshot / restore
+.help-short--snap .help-short--snapshot:
+	@echo "Snapshot the database"
+.help-long--snap .help-long--snapshot:
+	@echo "Interactively take a snapshot of the present database state. Restore snapshots with \`$(TOOL_CMD) restore\`."	
+
 SNAPSHOT_BINARY = ./build/snapshot
 snap snapshot: $(SNAPSHOT_BINARY)
 	@ $(SNAPSHOT_BINARY) snapshot
 $(SNAPSHOT_BINARY): tools/snapshot/*.go
 	cd tools/snapshot && go build -o ../../build/snapshot
+
+.help-short--restore:
+	@echo "Restore a database snapshot"
+.help-long--restore:
+	@echo "Restore database state using a snapshot taken with \`$(TOOL_CMD) snapshot\`."	
+
+
 restore: $(SNAPSHOT_BINARY)
-	@ $(SNAPSHOT_BINARY) restore
+	@$(SNAPSHOT_BINARY) restore
+	@if [[ "$(PREP)" == "true" || "$(PREPARE)" == "true" ]]; then \
+		echo "Running migrations..."; \
+		./build/fleet prepare db --dev; \
+	fi
+	@echo Done!
 
 # Generate osqueryd.app.tar.gz bundle from osquery.io.
 #

--- a/Makefile
+++ b/Makefile
@@ -119,10 +119,17 @@ fdm:
 		sudo ln -sf "$$(pwd)/build/fdm" /usr/local/bin/fdm; \
 	fi
 
-serve up: TARGET_ARGS := --use-ip --no-save
+serve up: TARGET_ARGS := --use-ip --no-save --show
 ifdef USE_IP
 serve up: EXTRA_CLI_ARGS := $(EXTRA_CLI_ARGS) --server_address=$(shell ipconfig getifaddr en0):8080
 endif
+ifdef SHOW
+serve up:
+	@SAVED_ARGS=$$(cat ~/.fleet/last-serve-invocation); \
+	if [[ $$? -eq 0 ]]; then \
+		echo "$$SAVED_ARGS"; \
+	fi
+else
 serve up:
 	$(call filter_args)
 	@if [[ "$(FORWARDED_ARGS)" != "" ]]; then \
@@ -138,6 +145,7 @@ serve up:
 			./build/fleet serve; \
 		fi; \
 	fi
+endif
 
 build/fleet: | .pre-build .pre-fleet
 	@ make .prefix

--- a/tools/backup_db/restore.sh
+++ b/tools/backup_db/restore.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 set -euo pipefail
 BACKUP_NAME="${1:-backup.sql.gz}"
-docker run --rm -i --network fleet_default ${FLEET_MYSQL_IMAGE:-mysql:8.0.36} bash -c 'gzip -dc - | mysql -hmysql -uroot -ptoor fleet' < ${BACKUP_NAME}
+docker run --rm -i --network fleet_default ${FLEET_MYSQL_IMAGE:-mysql:8.0.36} bash -c 'gzip -dc - | MYSQL_PWD=toor mysql -hmysql -uroot fleet' < ${BACKUP_NAME}

--- a/tools/fdm/main.go
+++ b/tools/fdm/main.go
@@ -67,6 +67,7 @@ func main() {
 func splitArgs(args []string) (map[string]string, []string) {
 	options := make(map[string]string)
 	var makeArgs []string
+	cliArgs := " "
 	positionalArgsIndex := 1
 	isMakeArgs := false
 	skipNext := false
@@ -96,13 +97,16 @@ func splitArgs(args []string) (map[string]string, []string) {
 			// Handle options like --name=foo
 			case len(parts) == 2:
 				options[parts[0]] = parts[1]
+				cliArgs += arg + " "
 			// Handle options like --name foo
 			case idx+1 < len(args) && !strings.HasPrefix(args[idx+1], "--"):
 				options[arg[2:]] = args[idx+1]
+				cliArgs += arg + " " + args[idx+1] + " "
 				skipNext = true
 			// Handle options like --useturbocharge by assuming they're booleans.
 			default:
 				options[parts[0]] = "true"
+				cliArgs += arg + " "
 			}
 		// Otherwise assume we're dealing with a positional argument.
 		default:
@@ -110,7 +114,7 @@ func splitArgs(args []string) (map[string]string, []string) {
 			positionalArgsIndex++
 		}
 	}
-
+	options["CLI_ARGS"] = cliArgs
 	return options, makeArgs
 }
 


### PR DESCRIPTION
For #27889 

This PR introduces several improvements to the Makefile/`fdm` tool for development:
 
### `fdm serve` (alias `fdm up`)

Starts a local Fleet server (building the binary first).  The first time this is called, it will start the server on `localhost:8080` with the `--dev` and `--dev_license` flags, but the command accepts all of the options that you can pass to `fleet serve`.  If you pass options to `fdm serve`, then subsequent invocations _without_ options will replay your last command.  Additionally, `fdm serve` supports the following:

- `--use-ip`: start the local server on your system's local IP address rather than `localhost`.  This makes it easier to point VMs on your system to the fleet server to act as hosts.
- `--no-build`: don't rebuild the fleet binary before starting the server.
- `--no-save`: don't save the current command for future invocations (useful for scripting)
- `--show`: show options for the last-invoked `fdm serve` command
- `--reset`: reset the options for `fdm serve`.  The next time `fdm serve` is invoked, it will use the default options.
- `--help`: show all of the Fleet server options

### `fdm snapshot` improvements

* Added `fdm snap` alias
* Tracks the name of the last snapshot saved, to use as the default for `fdm restore`
* Suppresses the "don't use password in CLI" warning when saving the snapshot

### `fdm restore` improvements

* Added `--prep` / `--prepare` option to run db migrations after restoring snapshot.
* Improved UI (more options displayed, and clearer indicator for selected option)
* Now defaults to last snapshot restored
