### PR TITLE
Fleet UI: Fix platform resetting on pagination of OS table

### DIFF
--- a/changes/27326-os-platform-reset-bug
+++ b/changes/27326-os-platform-reset-bug
@@ -1,0 +1,1 @@
+* Fleet UI: Fixed pagination resetting the platform filter on the Operating System UI table

--- a/frontend/pages/SoftwarePage/SoftwareOS/SoftwareOSTable/SoftwareOSTable.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareOS/SoftwareOSTable/SoftwareOSTable.tsx
@@ -124,9 +124,10 @@ const SoftwareOSTable = ({
         order_direction: newTableQuery.sortDirection,
         order_key: newTableQuery.sortHeader,
         page: changedParam === "pageIndex" ? newTableQuery.pageIndex : 0,
+        platform,
       };
     },
-    [teamId]
+    [teamId, platform]
   );
 
   const onQueryChange = useCallback(
@@ -134,7 +135,6 @@ const SoftwareOSTable = ({
       // we want to determine which query param has changed in order to
       // reset the page index to 0 if any other param has changed.
       const changedParam = determineQueryParamChange(newTableQuery);
-
       // if nothing has changed, don't update the route. this can happen when
       // this handler is called on the initial render.
       if (changedParam === "") return;


### PR DESCRIPTION
## Issue
For #27326 

## Description
- Fixed pagination resetting `platform` when paginating
- Missing `platform` query param in the useCallback

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/Committing-Changes.md#changes-files) for more information.
- [x] A detailed QA plan exists on the associated ticket (if it isn't there, work with the product group's QA engineer to add it)
- [x] Manual QA for all new/changed functionality

