### PR TITLE
Update Rust in `fleetctl-docker` image

### DIFF
--- a/tools/fleetctl-docker/Dockerfile
+++ b/tools/fleetctl-docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:latest@sha256:56418f03475cf7b107f87d7fabe99ce9a4a9f9904daafa99be7c50d9e7b8f84d AS builder
+FROM rust:latest@sha256:563b33de55d0add224b2e301182660b59bf3cf7219e9dc0fda68f8500e5fe14a AS builder
 
 ARG transporter_url=https://itunesconnect.apple.com/WebObjects/iTunesConnect.woa/ra/resources/download/public/Transporter__Linux/bin
 


### PR DESCRIPTION
The merged changed in https://github.com/fleetdm/fleet/pull/23843 requires updating Rust in the builder image.