### PR TITLE
Update permissions in workflows to be more restrictive

### DIFF
--- a/.github/workflows/generate-desktop-targets.yml
+++ b/.github/workflows/generate-desktop-targets.yml
@@ -11,10 +11,8 @@ defaults:
     shell: bash
 
 permissions:
-  contents: write
   id-token: write
   attestations: write
-  packages: write
 
 jobs:
   set-version:

--- a/.github/workflows/generate-osqueryd-targets.yml
+++ b/.github/workflows/generate-osqueryd-targets.yml
@@ -27,10 +27,8 @@ env:
   OSQUERY_VERSION: 5.16.0
 
 permissions:
-  contents: write
   id-token: write
   attestations: write
-  packages: write
 
 jobs:
   generate-macos:


### PR DESCRIPTION
We got an alert from our automated code-scanner about permissive top-level permissions in one of our Github workflows.  Upon review, I think the offending permissions can be removed from a couple of workflows.  Neither appears to need the `content: write` permission (they don't push commits or tags to the repo) or `packages: write` (they don't push anything to Github packages).