### PR TITLE
Ignore EOF errors when sending QUIT to mail server

### DIFF
--- a/server/mail/mail.go
+++ b/server/mail/mail.go
@@ -240,7 +240,7 @@ func (m mailService) sendMail(e fleet.Email, msg []byte) error {
 	if err := client.Quit(); err != nil {
 		// Ignore EOF errors on quit, which can happen if the server
 		// closes the connection after the message is sent.
-		if err.Error() == "EOF" {
+		if err.Error() != "EOF" {
 			return fmt.Errorf("error on client quit: %w", err)
 		}
 	}

--- a/server/mail/mail.go
+++ b/server/mail/mail.go
@@ -238,7 +238,11 @@ func (m mailService) sendMail(e fleet.Email, msg []byte) error {
 	}
 
 	if err := client.Quit(); err != nil {
-		return fmt.Errorf("error on client quit: %w", err)
+		// Ignore EOF errors on quit, which can happen if the server
+		// closes the connection after the message is sent.
+		if err.Error() == "EOF" {
+			return fmt.Errorf("error on client quit: %w", err)
+		}
 	}
 	return nil
 }

--- a/server/mail/mail.go
+++ b/server/mail/mail.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"html/template"
+	"io"
 	"net"
 	"net/smtp"
 	"strings"
@@ -240,7 +241,7 @@ func (m mailService) sendMail(e fleet.Email, msg []byte) error {
 	if err := client.Quit(); err != nil {
 		// Ignore EOF errors on quit, which can happen if the server
 		// closes the connection after the message is sent.
-		if err.Error() != "EOF" {
+		if !errors.Is(err, io.EOF) {
 			return fmt.Errorf("error on client quit: %w", err)
 		}
 	}


### PR DESCRIPTION
For #28000 

We started seeing errors in one of our mail tests do to an EOF being received from the mail client when sending the QUIT command.  This should be non-fatal (the mail should already have been sent) and it can happen especially in localhost scenarios where things move very fast, and the mail server closes the connection before we have a chance to send QUIT.  It's not clear why it started failing consistently when it did; I tried [reverting the commit after the last known good run](https://github.com/fleetdm/fleet/pull/27989) and it had no effect.