### PR TITLE
Website: fix width of GitHub stars button

### DIFF
--- a/website/views/layouts/layout.ejs
+++ b/website/views/layouts/layout.ejs
@@ -233,7 +233,7 @@
                 <a purpose="header-nav-btn" button-text="Pricing" href="/pricing" class=" align-items-center <%= typeof currentSection !== 'undefined' && currentSection === 'pricing' ? 'current-section' : '' %>" style="text-decoration: none; line-height: 23px;">Pricing</a>
                 <span purpose="gh-button" class="d-flex align-items-center">
                   <iframe src="//ghbtns.com/github-btn.html?user=fleetdm&amp;repo=fleet&amp;type=watch&amp;count=true"
-                  allowtransparency="true" frameborder="0" scrolling="0" width="100" height="20"></iframe>
+                  allowtransparency="true" frameborder="0" scrolling="0" width="140" height="20"></iframe>
                 </span>
                 <%if(!hideGetStartedButton){%>
                   <a purpose="glass-header-btn" class="align-items-center d-flex" href="/register">Try it yourself</a>


### PR DESCRIPTION
Closes: #27965

Changes:
- Updated the width of the GitHub stars button in the website header to prevent the stars count from being hidden.