### PR TITLE
Update feature-request issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -3,7 +3,6 @@ name: 💡  Feature request
 about: Propose a new feature or enhancement in Fleet.
 title: ''
 labels: ':product'
-projects: 'fleetdm/67'
 assignees: ''
 
 ---


### PR DESCRIPTION
It's reported that the `projects:` key doesn't work in markdown (`.md`) issue templates:  https://github.com/orgs/community/discussions/9687#discussioncomment-12573283

Possible solution: switch to YAML (`.yml`) issue templates. We think this means we’d have to learn how to use YAML instead of markdown for elements like headers, checkboxes, etc.
