### PR TITLE
Fix UI cancel error message lock wipe

### DIFF
--- a/frontend/pages/hosts/ManageHostsPage/helpers.ts
+++ b/frontend/pages/hosts/ManageHostsPage/helpers.ts
@@ -24,7 +24,7 @@ export const isValidPemCertificate = (cert: string): boolean => {
   return regexPemHeader.test(cert) && regexPemFooter.test(cert);
 };
 
-const hasStatusKey = (value: unknown): value is { status: number } => {
+export const hasStatusKey = (value: unknown): value is { status: number } => {
   return (
     typeof value === "object" &&
     value !== null &&

--- a/frontend/pages/hosts/details/HostDetailsPage/modals/CancelActivityModal/CancelActivityModal.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/modals/CancelActivityModal/CancelActivityModal.tsx
@@ -17,7 +17,8 @@ const baseClass = "cancel-activity-modal";
 interface ICancelActivityModalProps {
   hostId: number;
   activity: IHostUpcomingActivity;
-  onCancelActivity: () => void;
+  onCancelActivity: (activity: IHostUpcomingActivity) => void;
+  onSuccessCancel: (activity: IHostUpcomingActivity) => void;
   onExit: () => void;
 }
 
@@ -25,6 +26,7 @@ const CancelActivityModal = ({
   hostId,
   activity,
   onCancelActivity,
+  onSuccessCancel,
   onExit,
 }: ICancelActivityModalProps) => {
   const { renderFlash } = useContext(NotificationContext);
@@ -37,10 +39,11 @@ const CancelActivityModal = ({
     try {
       await activitiesAPI.cancelHostActivity(hostId, activity.uuid);
       renderFlash("success", "Activity successfully canceled.");
+      onSuccessCancel(activity);
     } catch (err) {
       renderFlash("error", getErrorMessage(err));
     }
-    onCancelActivity();
+    onCancelActivity(activity);
     onExit();
   };
 

--- a/frontend/pages/hosts/details/HostDetailsPage/modals/CancelActivityModal/helpers.ts
+++ b/frontend/pages/hosts/details/HostDetailsPage/modals/CancelActivityModal/helpers.ts
@@ -1,3 +1,5 @@
+import { hasStatusKey } from "pages/hosts/ManageHostsPage/helpers";
+
 const DEFAULT_ERR_MESSAGE = "Couldn't cancel activity. Please try again.";
 const LOCK_WIPE_ERR_MESSAGE =
   "Couldn't cancel activity. Lock and wipe can't be canceled if they're about to run to prevent you from losing access to the host.";
@@ -6,7 +8,7 @@ const ACTIVITY_ALREADY_HAPPENED_ERR_MESSAGE =
 
 // eslint-disable-next-line import/prefer-default-export
 export const getErrorMessage = (err: unknown) => {
-  if (typeof err === "object" && err !== null && "status" in err) {
+  if (hasStatusKey(err)) {
     if (err.status === 404) return ACTIVITY_ALREADY_HAPPENED_ERR_MESSAGE;
 
     // display server error message if error is 400

--- a/frontend/pages/hosts/details/HostDetailsPage/modals/CancelActivityModal/helpers.ts
+++ b/frontend/pages/hosts/details/HostDetailsPage/modals/CancelActivityModal/helpers.ts
@@ -1,5 +1,3 @@
-import { isAxiosError } from "axios";
-
 const DEFAULT_ERR_MESSAGE = "Couldn't cancel activity. Please try again.";
 const LOCK_WIPE_ERR_MESSAGE =
   "Couldn't cancel activity. Lock and wipe can't be canceled if they're about to run to prevent you from losing access to the host.";
@@ -8,7 +6,7 @@ const ACTIVITY_ALREADY_HAPPENED_ERR_MESSAGE =
 
 // eslint-disable-next-line import/prefer-default-export
 export const getErrorMessage = (err: unknown) => {
-  if (isAxiosError(err)) {
+  if (typeof err === "object" && err !== null && "status" in err) {
     if (err.status === 404) return ACTIVITY_ALREADY_HAPPENED_ERR_MESSAGE;
 
     // display server error message if error is 400

--- a/frontend/pages/hosts/details/cards/Activity/Activity.tsx
+++ b/frontend/pages/hosts/details/cards/Activity/Activity.tsx
@@ -39,6 +39,7 @@ interface IActivityProps {
   isError?: boolean;
   className?: string;
   upcomingCount: number;
+  canCancelActivities: boolean;
   onChangeTab: (index: number, last: number, event: Event) => void;
   onNextPage: () => void;
   onPreviousPage: () => void;
@@ -53,6 +54,7 @@ const Activity = ({
   isError,
   className,
   upcomingCount,
+  canCancelActivities,
   onChangeTab,
   onNextPage,
   onPreviousPage,
@@ -107,6 +109,7 @@ const Activity = ({
               isError={isError}
               onNextPage={onNextPage}
               onPreviousPage={onPreviousPage}
+              canCancelActivities={canCancelActivities}
             />
           </TabPanel>
         </Tabs>

--- a/frontend/pages/hosts/details/cards/Activity/UpcomingActivityFeed/UpcomingActivityFeed.tsx
+++ b/frontend/pages/hosts/details/cards/Activity/UpcomingActivityFeed/UpcomingActivityFeed.tsx
@@ -1,8 +1,7 @@
-import React, { useContext } from "react";
+import React from "react";
 
 import { IHostUpcomingActivity } from "interfaces/activity";
 import { IHostUpcomingActivitiesResponse } from "services/entities/activities";
-import { AppContext } from "context/app";
 
 import DataError from "components/DataError";
 import Pagination from "components/Pagination";
@@ -16,6 +15,7 @@ const baseClass = "upcoming-activity-feed";
 interface IUpcomingActivityFeedProps {
   activities?: IHostUpcomingActivitiesResponse;
   isError?: boolean;
+  canCancelActivities: boolean;
   onShowDetails: ShowActivityDetailsHandler;
   onCancel: (activity: IHostUpcomingActivity) => void;
   onNextPage: () => void;
@@ -25,17 +25,12 @@ interface IUpcomingActivityFeedProps {
 const UpcomingActivityFeed = ({
   activities,
   isError = false,
+  canCancelActivities,
   onShowDetails,
   onCancel,
   onNextPage,
   onPreviousPage,
 }: IUpcomingActivityFeedProps) => {
-  const {
-    isTeamMaintainerOrTeamAdmin,
-    isGlobalAdmin,
-    isGlobalMaintainer,
-  } = useContext(AppContext);
-
   if (isError) {
     return <DataError />;
   }
@@ -56,9 +51,6 @@ const UpcomingActivityFeed = ({
     );
   }
 
-  const canCancel =
-    isGlobalAdmin || isGlobalMaintainer || isTeamMaintainerOrTeamAdmin;
-
   return (
     <div className={baseClass}>
       <div className={`${baseClass}__feed-list`}>
@@ -71,7 +63,7 @@ const UpcomingActivityFeed = ({
               tab="upcoming"
               activity={activity}
               onShowDetails={onShowDetails}
-              hideCancel={!canCancel}
+              hideCancel={!canCancelActivities}
               onCancel={() => onCancel(activity)}
             />
           );


### PR DESCRIPTION
For #28018

some fixes for the UI of cancel activities including:

- showing proper error message
- correct permission checking for allowing users to cancel activity
- refresh all host details after lock or wipe command to get updated host status.

