### PR TITLE
Fleet UI: Added hover cursors to checkbox and radio components

### DIFF
--- a/changes/27909-hover-checkbox-radio
+++ b/changes/27909-hover-checkbox-radio
@@ -1,0 +1,1 @@
+* Fleet UI: Added hover cursors to checkbox and radio form elements

--- a/frontend/components/forms/fields/Checkbox/_styles.scss
+++ b/frontend/components/forms/fields/Checkbox/_styles.scss
@@ -10,7 +10,7 @@
     // Using selectors to avoid pointer cursor on  clickable white space right of checkbox
     .fleet-checkbox__label,
     .fleet-checkbox__icon,
-    .fleet-checkbox__label-tooltip > .component__tooltip-wrapper__underline {
+    .fleet-checkbox__label-tooltip {
       cursor: pointer;
     }
   }
@@ -87,8 +87,7 @@
         // Using selectors to avoid not allowed cursor on  clickable white space right of checkbox
         .fleet-checkbox__label,
         .fleet-checkbox__icon,
-        .fleet-checkbox__label-tooltip
-          > .component__tooltip-wrapper__underline {
+        .fleet-checkbox__label-tooltip {
           cursor: not-allowed;
         }
       }

--- a/frontend/components/forms/fields/Checkbox/_styles.scss
+++ b/frontend/components/forms/fields/Checkbox/_styles.scss
@@ -1,8 +1,19 @@
 .fleet-checkbox {
   @include clearfix;
   position: relative;
+  // inline-flex would prevents clickable white space right of the checkbox,
+  // but we need that clickable in some "rows" using checkbox
   display: flex;
   align-items: center;
+
+  &:hover {
+    // Using selectors to avoid pointer cursor on  clickable white space right of checkbox
+    .fleet-checkbox__label,
+    .fleet-checkbox__icon,
+    .fleet-checkbox__label-tooltip > .component__tooltip-wrapper__underline {
+      cursor: pointer;
+    }
+  }
 
   &:hover:not(.fleet-checkbox__label--disabled) {
     svg {
@@ -69,6 +80,16 @@
         .checkbox-unchecked-state {
           stroke: $ui-fleet-black-25;
           fill: $ui-fleet-black-25;
+        }
+      }
+
+      &:hover {
+        // Using selectors to avoid not allowed cursor on  clickable white space right of checkbox
+        .fleet-checkbox__label,
+        .fleet-checkbox__icon,
+        .fleet-checkbox__label-tooltip
+          > .component__tooltip-wrapper__underline {
+          cursor: not-allowed;
         }
       }
     }

--- a/frontend/components/forms/fields/Radio/_styles.scss
+++ b/frontend/components/forms/fields/Radio/_styles.scss
@@ -10,6 +10,12 @@
     align-items: center;
   }
 
+  &:hover:not(.radio__disabled) {
+    .radio__control-button {
+      border-color: $core-vibrant-blue-over;
+    }
+  }
+
   &__input,
   &__label {
     &:hover {

--- a/frontend/components/forms/fields/Radio/_styles.scss
+++ b/frontend/components/forms/fields/Radio/_styles.scss
@@ -10,6 +10,12 @@
     align-items: center;
   }
 
+  &__input,
+  &__label {
+    &:hover {
+      cursor: pointer;
+    }
+  }
   &__input {
     display: flex;
 
@@ -71,6 +77,13 @@
 
     .radio__help-text {
       color: $ui-fleet-black-50;
+    }
+
+    .radio__input,
+    .radio__label {
+      &:hover {
+        cursor: not-allowed;
+      }
     }
   }
 }


### PR DESCRIPTION
## Issue
For #27909 

## Description
- Radio hover color
- Radio hover cursor
- Checkbox cursor
- Ensure hover doesn't apply when disabled
- Ensure hover applies with tooltips in label


## Screen recording of fixes

https://github.com/user-attachments/assets/598b3a2b-6cec-4bdc-b531-15efee0c67e6



# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/Committing-Changes.md#changes-files) for more information.
- [x] A detailed QA plan exists on the associated ticket (if it isn't there, work with the product group's QA engineer to add it)
- [x] Manual QA for all new/changed functionality
