### PR TITLE
Fix bug where last request timestamp wasn't being updated. (#28157)

### DIFF
--- a/server/datastore/mysql/scim.go
+++ b/server/datastore/mysql/scim.go
@@ -909,10 +909,10 @@ func (ds *Datastore) UpdateScimLastRequest(ctx context.Context, lastRequest *fle
 	}
 
 	return ds.withRetryTxx(ctx, func(tx sqlx.ExtContext) error {
-		// Try to update first
+		// Try to update first. We always update the timestamp since success requests all look the same.
 		const updateQuery = `
 				UPDATE scim_last_request
-				SET status = ?, details = ?
+				SET status = ?, details = ?, updated_at = NOW(6)
 				`
 		result, err := tx.ExecContext(
 			ctx,


### PR DESCRIPTION
Unreleased SCIM bug
For #23236

(cherry picked from commit 4c97c4390fc1b640b6ce31d797eb64141ff2c5c0)
