### PR TITLE
SCIM Entra ID support -- PATCH User with op:replace

### DIFF
--- a/ee/server/integrationtest/scim/scim_test.go
+++ b/ee/server/integrationtest/scim/scim_test.go
@@ -959,7 +959,7 @@ func testPatchUserFailure(t *testing.T, s *Suite) {
 	s.DoJSON(t, "POST", scimPath("/Users"), createUserPayload, http.StatusCreated, &createResp)
 	userID := createResp["id"].(string)
 
-	// Test 1: Patch with unsupported operation (add instead of replace)
+	// Test: Patch with unsupported operation (add instead of replace)
 	unsupportedOpPayload := map[string]interface{}{
 		"schemas": []string{"urn:ietf:params:scim:api:messages:2.0:PatchOp"},
 		"Operations": []map[string]interface{}{
@@ -976,24 +976,7 @@ func testPatchUserFailure(t *testing.T, s *Suite) {
 	assert.EqualValues(t, errorResp1["schemas"], []interface{}{"urn:ietf:params:scim:api:messages:2.0:Error"})
 	assert.Contains(t, errorResp1["detail"], "Bad Request.")
 
-	// Test 2: Patch with unsupported field (userName instead of active)
-	unsupportedFieldPayload := map[string]interface{}{
-		"schemas": []string{"urn:ietf:params:scim:api:messages:2.0:PatchOp"},
-		"Operations": []map[string]interface{}{
-			{
-				"op":    "replace",
-				"path":  "userName", // Only "active" is supported
-				"value": "new-username@example.com",
-			},
-		},
-	}
-
-	var errorResp2 map[string]interface{}
-	s.DoJSON(t, "PATCH", scimPath("/Users/"+userID), unsupportedFieldPayload, http.StatusBadRequest, &errorResp2)
-	assert.EqualValues(t, errorResp2["schemas"], []interface{}{"urn:ietf:params:scim:api:messages:2.0:Error"})
-	assert.Contains(t, errorResp2["detail"], "Bad Request.")
-
-	// Test 3: Patch with no path and invalid value format
+	// Test: Patch with no path and invalid value format
 	invalidValuePayload := map[string]interface{}{
 		"schemas": []string{"urn:ietf:params:scim:api:messages:2.0:PatchOp"},
 		"Operations": []map[string]interface{}{
@@ -1968,7 +1951,7 @@ func testPatchUserEmails(t *testing.T, s *Suite) {
 	s.DoJSON(t, "PATCH", scimPath("/Users/"+userID), patchEmptyEmailsPayload, http.StatusOK, &emptyEmailsResp)
 
 	// Verify the emails were updated (should be empty or not present)
-	noEmails, _ := emptyEmailsResp["emails"]
+	noEmails := emptyEmailsResp["emails"]
 	assert.Empty(t, noEmails, "Emails should be empty after patch")
 
 	// Verify that patching with invalid email format fails

--- a/ee/server/integrationtest/scim/scim_test.go
+++ b/ee/server/integrationtest/scim/scim_test.go
@@ -2549,149 +2549,6 @@ func testPatchUserAttributes(t *testing.T, s *Suite) {
 		assert.Equal(t, "Updates", name["familyName"], "familyName should be updated")
 	})
 
-	// Failure Tests
-
-	t.Run("Patch with invalid userName (empty string)", func(t *testing.T) {
-		patchInvalidUserNamePayload := map[string]interface{}{
-			"schemas": []string{"urn:ietf:params:scim:api:messages:2.0:PatchOp"},
-			"Operations": []map[string]interface{}{
-				{
-					"op": "replace",
-					"value": map[string]interface{}{
-						"userName": "", // Empty userName
-					},
-				},
-			},
-		}
-
-		var invalidUserNameResp map[string]interface{}
-		s.DoJSON(t, "PATCH", scimPath("/Users/"+userID), patchInvalidUserNamePayload, http.StatusBadRequest, &invalidUserNameResp)
-		assert.EqualValues(t, invalidUserNameResp["schemas"], []interface{}{"urn:ietf:params:scim:api:messages:2.0:Error"})
-		assert.Contains(t, invalidUserNameResp["detail"], "Bad Request")
-	})
-
-	t.Run("Patch with userName as wrong type (number)", func(t *testing.T) {
-		patchUserNameAsNumberPayload := map[string]interface{}{
-			"schemas": []string{"urn:ietf:params:scim:api:messages:2.0:PatchOp"},
-			"Operations": []map[string]interface{}{
-				{
-					"op": "replace",
-					"value": map[string]interface{}{
-						"userName": 12345, // Number instead of string
-					},
-				},
-			},
-		}
-
-		var userNameAsNumberResp map[string]interface{}
-		s.DoJSON(t, "PATCH", scimPath("/Users/"+userID), patchUserNameAsNumberPayload, http.StatusBadRequest, &userNameAsNumberResp)
-		assert.EqualValues(t, userNameAsNumberResp["schemas"], []interface{}{"urn:ietf:params:scim:api:messages:2.0:Error"})
-		assert.Contains(t, userNameAsNumberResp["detail"], errors.ScimErrorInvalidValue.Detail)
-	})
-
-	t.Run("Patch with name as wrong type (string instead of object)", func(t *testing.T) {
-		patchNameAsStringPayload := map[string]interface{}{
-			"schemas": []string{"urn:ietf:params:scim:api:messages:2.0:PatchOp"},
-			"Operations": []map[string]interface{}{
-				{
-					"op": "replace",
-					"value": map[string]interface{}{
-						"name": "John Doe", // String instead of object
-					},
-				},
-			},
-		}
-
-		var nameAsStringResp map[string]interface{}
-		s.DoJSON(t, "PATCH", scimPath("/Users/"+userID), patchNameAsStringPayload, http.StatusBadRequest, &nameAsStringResp)
-		assert.EqualValues(t, nameAsStringResp["schemas"], []interface{}{"urn:ietf:params:scim:api:messages:2.0:Error"})
-		assert.Contains(t, nameAsStringResp["detail"], errors.ScimErrorInvalidValue.Detail)
-	})
-
-	t.Run("Patch name.givenName -- family name is required", func(t *testing.T) {
-		patchGivenNamePayload := map[string]interface{}{
-			"schemas": []string{"urn:ietf:params:scim:api:messages:2.0:PatchOp"},
-			"Operations": []map[string]interface{}{
-				{
-					"op": "replace",
-					"value": map[string]interface{}{
-						"name": map[string]interface{}{
-							"givenName": "NewFirstName",
-						},
-					},
-				},
-			},
-		}
-
-		var patchGivenNameResp map[string]interface{}
-		s.DoJSON(t, "PATCH", scimPath("/Users/"+userID), patchGivenNamePayload, http.StatusBadRequest, &patchGivenNameResp)
-		assert.EqualValues(t, patchGivenNameResp["schemas"], []interface{}{"urn:ietf:params:scim:api:messages:2.0:Error"})
-		assert.Contains(t, patchGivenNameResp["detail"], errors.ScimErrorInvalidValue.Detail)
-	})
-
-	t.Run("Patch with givenName as wrong type (number)", func(t *testing.T) {
-		patchGivenNameAsNumberPayload := map[string]interface{}{
-			"schemas": []string{"urn:ietf:params:scim:api:messages:2.0:PatchOp"},
-			"Operations": []map[string]interface{}{
-				{
-					"op": "replace",
-					"value": map[string]interface{}{
-						"name": map[string]interface{}{
-							"givenName":  12345, // Number instead of string
-							"familyName": "NewLastName",
-						},
-					},
-				},
-			},
-		}
-
-		var givenNameAsNumberResp map[string]interface{}
-		s.DoJSON(t, "PATCH", scimPath("/Users/"+userID), patchGivenNameAsNumberPayload, http.StatusBadRequest, &givenNameAsNumberResp)
-		assert.EqualValues(t, givenNameAsNumberResp["schemas"], []interface{}{"urn:ietf:params:scim:api:messages:2.0:Error"})
-		assert.Contains(t, givenNameAsNumberResp["detail"], errors.ScimErrorInvalidValue.Detail)
-	})
-
-	t.Run("Patch with familyName as wrong type (boolean)", func(t *testing.T) {
-		patchFamilyNameAsBoolPayload := map[string]interface{}{
-			"schemas": []string{"urn:ietf:params:scim:api:messages:2.0:PatchOp"},
-			"Operations": []map[string]interface{}{
-				{
-					"op": "replace",
-					"value": map[string]interface{}{
-						"name": map[string]interface{}{
-							"givenName":  "NewFirstName",
-							"familyName": true, // Boolean instead of string
-						},
-					},
-				},
-			},
-		}
-
-		var familyNameAsBoolResp map[string]interface{}
-		s.DoJSON(t, "PATCH", scimPath("/Users/"+userID), patchFamilyNameAsBoolPayload, http.StatusBadRequest, &familyNameAsBoolResp)
-		assert.EqualValues(t, familyNameAsBoolResp["schemas"], []interface{}{"urn:ietf:params:scim:api:messages:2.0:Error"})
-		assert.Contains(t, familyNameAsBoolResp["detail"], errors.ScimErrorInvalidValue.Detail)
-	})
-
-	t.Run("Patch with active as wrong type (string)", func(t *testing.T) {
-		patchActiveAsStringPayload := map[string]interface{}{
-			"schemas": []string{"urn:ietf:params:scim:api:messages:2.0:PatchOp"},
-			"Operations": []map[string]interface{}{
-				{
-					"op": "replace",
-					"value": map[string]interface{}{
-						"active": "true", // String instead of boolean
-					},
-				},
-			},
-		}
-
-		var activeAsStringResp map[string]interface{}
-		s.DoJSON(t, "PATCH", scimPath("/Users/"+userID), patchActiveAsStringPayload, http.StatusBadRequest, &activeAsStringResp)
-		assert.EqualValues(t, activeAsStringResp["schemas"], []interface{}{"urn:ietf:params:scim:api:messages:2.0:Error"})
-		assert.Contains(t, activeAsStringResp["detail"], errors.ScimErrorInvalidValue.Detail)
-	})
-
 	// ///////////////////////////////////////////////
 	// Tests for patching with explicit operation path
 
@@ -2769,60 +2626,180 @@ func testPatchUserAttributes(t *testing.T, s *Suite) {
 		assert.Equal(t, false, patchActiveWithPathResp["active"], "active should be updated to false with explicit path")
 	})
 
-	// Additional failure tests moved from testPatchUserFailure
-
-	t.Run("Patch with unsupported operation (add instead of replace)", func(t *testing.T) {
-		unsupportedOpPayload := map[string]interface{}{
-			"schemas": []string{"urn:ietf:params:scim:api:messages:2.0:PatchOp"},
-			"Operations": []map[string]interface{}{
-				{
-					"op":    "add", // Only "replace" is supported
-					"path":  "active",
-					"value": false,
+	// Failure tests using table-driven approach
+	t.Run("Failure cases", func(t *testing.T) {
+		testCases := []struct {
+			name         string
+			payload      map[string]interface{}
+			errorMessage string
+		}{
+			{
+				name: "Invalid userName (empty string)",
+				payload: map[string]interface{}{
+					"schemas": []string{"urn:ietf:params:scim:api:messages:2.0:PatchOp"},
+					"Operations": []map[string]interface{}{
+						{
+							"op": "replace",
+							"value": map[string]interface{}{
+								"userName": "", // Empty userName
+							},
+						},
+					},
 				},
+				errorMessage: "Bad Request",
+			},
+			{
+				name: "userName as wrong type (number)",
+				payload: map[string]interface{}{
+					"schemas": []string{"urn:ietf:params:scim:api:messages:2.0:PatchOp"},
+					"Operations": []map[string]interface{}{
+						{
+							"op": "replace",
+							"value": map[string]interface{}{
+								"userName": 12345, // Number instead of string
+							},
+						},
+					},
+				},
+				errorMessage: errors.ScimErrorInvalidValue.Detail,
+			},
+			{
+				name: "name as wrong type (string instead of object)",
+				payload: map[string]interface{}{
+					"schemas": []string{"urn:ietf:params:scim:api:messages:2.0:PatchOp"},
+					"Operations": []map[string]interface{}{
+						{
+							"op": "replace",
+							"value": map[string]interface{}{
+								"name": "John Doe", // String instead of object
+							},
+						},
+					},
+				},
+				errorMessage: errors.ScimErrorInvalidValue.Detail,
+			},
+			{
+				name: "name.givenName without required familyName",
+				payload: map[string]interface{}{
+					"schemas": []string{"urn:ietf:params:scim:api:messages:2.0:PatchOp"},
+					"Operations": []map[string]interface{}{
+						{
+							"op": "replace",
+							"value": map[string]interface{}{
+								"name": map[string]interface{}{
+									"givenName": "NewFirstName",
+									// Missing familyName
+								},
+							},
+						},
+					},
+				},
+				errorMessage: errors.ScimErrorInvalidValue.Detail,
+			},
+			{
+				name: "givenName as wrong type (number)",
+				payload: map[string]interface{}{
+					"schemas": []string{"urn:ietf:params:scim:api:messages:2.0:PatchOp"},
+					"Operations": []map[string]interface{}{
+						{
+							"op": "replace",
+							"value": map[string]interface{}{
+								"name": map[string]interface{}{
+									"givenName":  12345, // Number instead of string
+									"familyName": "NewLastName",
+								},
+							},
+						},
+					},
+				},
+				errorMessage: errors.ScimErrorInvalidValue.Detail,
+			},
+			{
+				name: "familyName as wrong type (boolean)",
+				payload: map[string]interface{}{
+					"schemas": []string{"urn:ietf:params:scim:api:messages:2.0:PatchOp"},
+					"Operations": []map[string]interface{}{
+						{
+							"op": "replace",
+							"value": map[string]interface{}{
+								"name": map[string]interface{}{
+									"givenName":  "NewFirstName",
+									"familyName": true, // Boolean instead of string
+								},
+							},
+						},
+					},
+				},
+				errorMessage: errors.ScimErrorInvalidValue.Detail,
+			},
+			{
+				name: "active as wrong type (string)",
+				payload: map[string]interface{}{
+					"schemas": []string{"urn:ietf:params:scim:api:messages:2.0:PatchOp"},
+					"Operations": []map[string]interface{}{
+						{
+							"op": "replace",
+							"value": map[string]interface{}{
+								"active": "true", // String instead of boolean
+							},
+						},
+					},
+				},
+				errorMessage: errors.ScimErrorInvalidValue.Detail,
+			},
+			{
+				name: "unsupported operation (add instead of replace)",
+				payload: map[string]interface{}{
+					"schemas": []string{"urn:ietf:params:scim:api:messages:2.0:PatchOp"},
+					"Operations": []map[string]interface{}{
+						{
+							"op":    "add", // Only "replace" is supported
+							"path":  "active",
+							"value": false,
+						},
+					},
+				},
+				errorMessage: "Bad Request",
+			},
+			{
+				name: "no path and invalid value format",
+				payload: map[string]interface{}{
+					"schemas": []string{"urn:ietf:params:scim:api:messages:2.0:PatchOp"},
+					"Operations": []map[string]interface{}{
+						{
+							"op": "replace",
+							// No path specified
+							"value": "not-a-map", // Should be a map with attributes
+						},
+					},
+				},
+				errorMessage: "A required value was missing",
+			},
+			{
+				name: "wrong value type for active using path",
+				payload: map[string]interface{}{
+					"schemas": []string{"urn:ietf:params:scim:api:messages:2.0:PatchOp"},
+					"Operations": []map[string]interface{}{
+						{
+							"op":    "replace",
+							"path":  "active",
+							"value": "not-a-boolean", // Should be a boolean
+						},
+					},
+				},
+				errorMessage: "A required value was missing",
 			},
 		}
 
-		var errorResp map[string]interface{}
-		s.DoJSON(t, "PATCH", scimPath("/Users/"+userID), unsupportedOpPayload, http.StatusBadRequest, &errorResp)
-		assert.EqualValues(t, errorResp["schemas"], []interface{}{"urn:ietf:params:scim:api:messages:2.0:Error"})
-		assert.Contains(t, errorResp["detail"], "Bad Request.")
-	})
-
-	t.Run("Patch with no path and invalid value format", func(t *testing.T) {
-		invalidValuePayload := map[string]interface{}{
-			"schemas": []string{"urn:ietf:params:scim:api:messages:2.0:PatchOp"},
-			"Operations": []map[string]interface{}{
-				{
-					"op": "replace",
-					// No path specified
-					"value": "not-a-map", // Should be a map with attributes
-				},
-			},
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel() // Since these failure tests do not modify state, we can run them in parallel
+				var errorResp map[string]interface{}
+				s.DoJSON(t, "PATCH", scimPath("/Users/"+userID), tc.payload, http.StatusBadRequest, &errorResp)
+				assert.EqualValues(t, errorResp["schemas"], []interface{}{"urn:ietf:params:scim:api:messages:2.0:Error"})
+				assert.Contains(t, errorResp["detail"], tc.errorMessage)
+			})
 		}
-
-		var errorResp map[string]interface{}
-		s.DoJSON(t, "PATCH", scimPath("/Users/"+userID), invalidValuePayload, http.StatusBadRequest, &errorResp)
-		assert.EqualValues(t, errorResp["schemas"], []interface{}{"urn:ietf:params:scim:api:messages:2.0:Error"})
-		assert.Contains(t, errorResp["detail"], "A required value was missing")
-	})
-
-	t.Run("Patch with wrong value type for active using path", func(t *testing.T) {
-		wrongTypePayload := map[string]interface{}{
-			"schemas": []string{"urn:ietf:params:scim:api:messages:2.0:PatchOp"},
-			"Operations": []map[string]interface{}{
-				{
-					"op":    "replace",
-					"path":  "active",
-					"value": "not-a-boolean", // Should be a boolean
-				},
-			},
-		}
-
-		var errorResp map[string]interface{}
-		s.DoJSON(t, "PATCH", scimPath("/Users/"+userID), wrongTypePayload, http.StatusBadRequest, &errorResp)
-		assert.EqualValues(t, errorResp["schemas"], []interface{}{"urn:ietf:params:scim:api:messages:2.0:Error"})
-		assert.Contains(t, errorResp["detail"], "A required value was missing")
 	})
 }
 

--- a/ee/server/integrationtest/scim/scim_test.go
+++ b/ee/server/integrationtest/scim/scim_test.go
@@ -1006,51 +1006,7 @@ func testPatchUserFailure(t *testing.T, s *Suite) {
 	assert.EqualValues(t, errorResp3["schemas"], []interface{}{"urn:ietf:params:scim:api:messages:2.0:Error"})
 	assert.Contains(t, errorResp3["detail"], "A required value was missing")
 
-	// Test 4 A: Patch with multiple operations (only one is supported)
-	multipleOpsPayload := map[string]interface{}{
-		"schemas": []string{"urn:ietf:params:scim:api:messages:2.0:PatchOp"},
-		"Operations": []map[string]interface{}{
-			{
-				"op":    "replace",
-				"path":  "active",
-				"value": false,
-			},
-			{
-				"op":    "replace",
-				"path":  "active",
-				"value": true,
-			},
-		},
-	}
-
-	var errorResp4 map[string]interface{}
-	s.DoJSON(t, "PATCH", scimPath("/Users/"+userID), multipleOpsPayload, http.StatusBadRequest, &errorResp4)
-	assert.EqualValues(t, errorResp4["schemas"], []interface{}{"urn:ietf:params:scim:api:messages:2.0:Error"})
-	assert.Contains(t, errorResp4["detail"], "Bad Request. Invalid parameter provided in request: Operations")
-
-	// Test 4 B: Patch with multiple values, only one is supported
-	multipleValuesPayload := map[string]interface{}{
-		"schemas": []string{"urn:ietf:params:scim:api:messages:2.0:PatchOp"},
-		"Operations": []map[string]interface{}{
-			{
-				"op": "replace",
-				"value": map[string]interface{}{
-					"active": false,
-					"name": map[string]interface{}{
-						"givenName":  "Updated",
-						"familyName": "Updated",
-					},
-				},
-			},
-		},
-	}
-
-	var errorResp4B map[string]interface{}
-	s.DoJSON(t, "PATCH", scimPath("/Users/"+userID), multipleValuesPayload, http.StatusBadRequest, &errorResp4B)
-	assert.EqualValues(t, errorResp4B["schemas"], []interface{}{"urn:ietf:params:scim:api:messages:2.0:Error"})
-	assert.Contains(t, errorResp4B["detail"], "Bad Request")
-
-	// Test 5: Patch with wrong value type for active
+	// Test: Patch with wrong value type for active
 	wrongTypePayload := map[string]interface{}{
 		"schemas": []string{"urn:ietf:params:scim:api:messages:2.0:PatchOp"},
 		"Operations": []map[string]interface{}{

--- a/ee/server/integrationtest/scim/scim_test.go
+++ b/ee/server/integrationtest/scim/scim_test.go
@@ -1818,454 +1818,467 @@ func testPatchUserEmails(t *testing.T, s *Suite) {
 	s.DoJSON(t, "POST", scimPath("/Users"), createUserPayload, http.StatusCreated, &createResp)
 	userID := createResp["id"].(string)
 
-	// Patch the user to replace emails with a new set of emails
-	patchEmailsPayload := map[string]interface{}{
-		"schemas": []string{"urn:ietf:params:scim:api:messages:2.0:PatchOp"},
-		"Operations": []map[string]interface{}{
-			{
-				"op": "replace",
-				"value": map[string]interface{}{
-					"emails": []map[string]interface{}{
+	t.Run("Patch the user to replace emails with a new set of emails", func(t *testing.T) {
+		patchEmailsPayload := map[string]interface{}{
+			"schemas": []string{"urn:ietf:params:scim:api:messages:2.0:PatchOp"},
+			"Operations": []map[string]interface{}{
+				{
+					"op": "replace",
+					"value": map[string]interface{}{
+						"emails": []map[string]interface{}{
+							{
+								"value":   "new-primary@example.com",
+								"type":    "work",
+								"primary": true,
+							},
+							{
+								"value":   "secondary@example.com",
+								"type":    "home",
+								"primary": false,
+							},
+						},
+					},
+				},
+			},
+		}
+
+		var patchResp map[string]interface{}
+		s.DoJSON(t, "PATCH", scimPath("/Users/"+userID), patchEmailsPayload, http.StatusOK, &patchResp)
+
+		// Verify the emails were updated
+		emails, _ := patchResp["emails"].([]interface{})
+		assert.Equal(t, 2, len(emails), "Should have 2 emails after patch")
+
+		// Verify the email values
+		emailValues := make([]string, 0, 2)
+		primaryFound := false
+		for _, e := range emails {
+			email, ok := e.(map[string]interface{})
+			assert.True(t, ok, "Email should be an object")
+			emailValues = append(emailValues, email["value"].(string))
+
+			// Check if this is the primary email
+			if primary, ok := email["primary"].(bool); ok && primary {
+				primaryFound = true
+				assert.Equal(t, "new-primary@example.com", email["value"], "Primary email should be new-primary@example.com")
+				assert.Equal(t, "work", email["type"], "Primary email should be of type work")
+			}
+		}
+		assert.EqualValues(t, []string{"new-primary@example.com", "secondary@example.com"}, emailValues,
+			"Emails should be new-primary@example.com and secondary@example.com")
+		assert.True(t, primaryFound, "One email should be marked as primary")
+	})
+
+	t.Run("Verify that patching with multiple primary emails fails", func(t *testing.T) {
+		patchMultiplePrimaryPayload := map[string]interface{}{
+			"schemas": []string{"urn:ietf:params:scim:api:messages:2.0:PatchOp"},
+			"Operations": []map[string]interface{}{
+				{
+					"op": "replace",
+					"value": map[string]interface{}{
+						"emails": []map[string]interface{}{
+							{
+								"value":   "primary1@example.com",
+								"type":    "work",
+								"primary": true,
+							},
+							{
+								"value":   "primary2@example.com",
+								"type":    "home",
+								"primary": true, // Second primary email
+							},
+						},
+					},
+				},
+			},
+		}
+
+		var errorResp map[string]interface{}
+		s.DoJSON(t, "PATCH", scimPath("/Users/"+userID), patchMultiplePrimaryPayload, http.StatusBadRequest, &errorResp)
+		assert.EqualValues(t, errorResp["schemas"], []interface{}{"urn:ietf:params:scim:api:messages:2.0:Error"})
+		assert.Contains(t, errorResp["detail"], "Only one email can be marked as primary")
+	})
+
+	t.Run("Verify that patching with no primary email is allowed", func(t *testing.T) {
+		patchNoPrimaryPayload := map[string]interface{}{
+			"schemas": []string{"urn:ietf:params:scim:api:messages:2.0:PatchOp"},
+			"Operations": []map[string]interface{}{
+				{
+					"op": "replace",
+					"value": map[string]interface{}{
+						"emails": []map[string]interface{}{
+							{
+								"value": "no-primary1@example.com",
+								"type":  "work",
+								// No primary field
+							},
+							{
+								"value": "no-primary2@example.com",
+								"type":  "home",
+								// No primary field
+							},
+						},
+					},
+				},
+			},
+		}
+
+		var noPrimaryResp map[string]interface{}
+		s.DoJSON(t, "PATCH", scimPath("/Users/"+userID), patchNoPrimaryPayload, http.StatusOK, &noPrimaryResp)
+
+		// Verify the emails were updated
+		noPrimaryEmails, _ := noPrimaryResp["emails"].([]interface{})
+		assert.Equal(t, 2, len(noPrimaryEmails), "Should have 2 emails after patch")
+
+		// Verify the email values
+		noPrimaryEmailValues := make([]string, 0, 2)
+		for _, e := range noPrimaryEmails {
+			email, ok := e.(map[string]interface{})
+			assert.True(t, ok, "Email should be an object")
+			noPrimaryEmailValues = append(noPrimaryEmailValues, email["value"].(string))
+		}
+		assert.EqualValues(t, []string{"no-primary1@example.com", "no-primary2@example.com"}, noPrimaryEmailValues,
+			"Emails should be no-primary1@example.com and no-primary2@example.com")
+	})
+
+	t.Run("Verify that patching with an empty emails array removes all emails", func(t *testing.T) {
+		patchEmptyEmailsPayload := map[string]interface{}{
+			"schemas": []string{"urn:ietf:params:scim:api:messages:2.0:PatchOp"},
+			"Operations": []map[string]interface{}{
+				{
+					"op": "replace",
+					"value": map[string]interface{}{
+						"emails": []map[string]interface{}{},
+					},
+				},
+			},
+		}
+
+		var emptyEmailsResp map[string]interface{}
+		s.DoJSON(t, "PATCH", scimPath("/Users/"+userID), patchEmptyEmailsPayload, http.StatusOK, &emptyEmailsResp)
+
+		// Verify the emails were updated (should be empty or not present)
+		noEmails := emptyEmailsResp["emails"]
+		assert.Empty(t, noEmails, "Emails should be empty after patch")
+	})
+
+	t.Run("Verify that patching with invalid email format fails", func(t *testing.T) {
+		patchInvalidEmailFormatPayload := map[string]interface{}{
+			"schemas": []string{"urn:ietf:params:scim:api:messages:2.0:PatchOp"},
+			"Operations": []map[string]interface{}{
+				{
+					"op": "replace",
+					"value": map[string]interface{}{
+						"emails": []map[string]interface{}{
+							{
+								"value":   "not-an-email", // Invalid email format (missing @ and domain)
+								"type":    "work",
+								"primary": true,
+							},
+						},
+					},
+				},
+			},
+		}
+
+		var invalidEmailFormatResp map[string]interface{}
+		s.DoJSON(t, "PATCH", scimPath("/Users/"+userID), patchInvalidEmailFormatPayload, http.StatusBadRequest, &invalidEmailFormatResp)
+		assert.EqualValues(t, invalidEmailFormatResp["schemas"], []interface{}{"urn:ietf:params:scim:api:messages:2.0:Error"})
+		assert.Contains(t, invalidEmailFormatResp["detail"], "Bad Request")
+	})
+
+	t.Run("Verify that patching with empty email value fails", func(t *testing.T) {
+		patchEmptyEmailValuePayload := map[string]interface{}{
+			"schemas": []string{"urn:ietf:params:scim:api:messages:2.0:PatchOp"},
+			"Operations": []map[string]interface{}{
+				{
+					"op": "replace",
+					"value": map[string]interface{}{
+						"emails": []map[string]interface{}{
+							{
+								"value":   "", // Empty email value
+								"type":    "work",
+								"primary": true,
+							},
+						},
+					},
+				},
+			},
+		}
+
+		var emptyEmailValueResp map[string]interface{}
+		s.DoJSON(t, "PATCH", scimPath("/Users/"+userID), patchEmptyEmailValuePayload, http.StatusBadRequest, &emptyEmailValueResp)
+		assert.EqualValues(t, emptyEmailValueResp["schemas"], []interface{}{"urn:ietf:params:scim:api:messages:2.0:Error"})
+		assert.Contains(t, emptyEmailValueResp["detail"], "Bad Request")
+	})
+
+	t.Run("Verify that patching with email missing @ symbol fails", func(t *testing.T) {
+		patchEmailMissingAtPayload := map[string]interface{}{
+			"schemas": []string{"urn:ietf:params:scim:api:messages:2.0:PatchOp"},
+			"Operations": []map[string]interface{}{
+				{
+					"op": "replace",
+					"value": map[string]interface{}{
+						"emails": []map[string]interface{}{
+							{
+								"value":   "testinvalid.com", // Email missing @ symbol
+								"type":    "work",
+								"primary": true,
+							},
+						},
+					},
+				},
+			},
+		}
+
+		var emailMissingAtResp map[string]interface{}
+		s.DoJSON(t, "PATCH", scimPath("/Users/"+userID), patchEmailMissingAtPayload, http.StatusBadRequest, &emailMissingAtResp)
+		assert.EqualValues(t, emailMissingAtResp["schemas"], []interface{}{"urn:ietf:params:scim:api:messages:2.0:Error"})
+		assert.Contains(t, emailMissingAtResp["detail"], "Bad Request")
+	})
+
+	t.Run("Verify that patching with email value as a number fails", func(t *testing.T) {
+		patchEmailValueAsNumberPayload := map[string]interface{}{
+			"schemas": []string{"urn:ietf:params:scim:api:messages:2.0:PatchOp"},
+			"Operations": []map[string]interface{}{
+				{
+					"op": "replace",
+					"value": map[string]interface{}{
+						"emails": []map[string]interface{}{
+							{
+								"value":   123, // Number instead of string
+								"type":    "work",
+								"primary": true,
+							},
+						},
+					},
+				},
+			},
+		}
+
+		var emailValueAsNumberResp map[string]interface{}
+		s.DoJSON(t, "PATCH", scimPath("/Users/"+userID), patchEmailValueAsNumberPayload, http.StatusBadRequest, &emailValueAsNumberResp)
+		assert.EqualValues(t, emailValueAsNumberResp["schemas"], []interface{}{"urn:ietf:params:scim:api:messages:2.0:Error"})
+		assert.Contains(t, emailValueAsNumberResp["detail"], errors.ScimErrorInvalidValue.Detail)
+	})
+
+	t.Run("Verify that patching with email value as a boolean fails", func(t *testing.T) {
+		patchEmailValueAsBoolPayload := map[string]interface{}{
+			"schemas": []string{"urn:ietf:params:scim:api:messages:2.0:PatchOp"},
+			"Operations": []map[string]interface{}{
+				{
+					"op": "replace",
+					"value": map[string]interface{}{
+						"emails": []map[string]interface{}{
+							{
+								"value":   true, // Boolean instead of string
+								"type":    "work",
+								"primary": true,
+							},
+						},
+					},
+				},
+			},
+		}
+
+		var emailValueAsBoolResp map[string]interface{}
+		s.DoJSON(t, "PATCH", scimPath("/Users/"+userID), patchEmailValueAsBoolPayload, http.StatusBadRequest, &emailValueAsBoolResp)
+		assert.EqualValues(t, emailValueAsBoolResp["schemas"], []interface{}{"urn:ietf:params:scim:api:messages:2.0:Error"})
+		assert.Contains(t, emailValueAsBoolResp["detail"], errors.ScimErrorInvalidValue.Detail)
+	})
+
+	t.Run("Verify that patching with email type as a number fails", func(t *testing.T) {
+		patchEmailTypeAsNumberPayload := map[string]interface{}{
+			"schemas": []string{"urn:ietf:params:scim:api:messages:2.0:PatchOp"},
+			"Operations": []map[string]interface{}{
+				{
+					"op": "replace",
+					"value": map[string]interface{}{
+						"emails": []map[string]interface{}{
+							{
+								"value":   "valid@example.com",
+								"type":    123, // Number instead of string
+								"primary": true,
+							},
+						},
+					},
+				},
+			},
+		}
+
+		var emailTypeAsNumberResp map[string]interface{}
+		s.DoJSON(t, "PATCH", scimPath("/Users/"+userID), patchEmailTypeAsNumberPayload, http.StatusBadRequest, &emailTypeAsNumberResp)
+		assert.EqualValues(t, emailTypeAsNumberResp["schemas"], []interface{}{"urn:ietf:params:scim:api:messages:2.0:Error"})
+		assert.Contains(t, emailTypeAsNumberResp["detail"], errors.ScimErrorInvalidValue.Detail)
+	})
+
+	t.Run("Verify that patching with email type as a boolean fails", func(t *testing.T) {
+		patchEmailTypeAsBoolPayload := map[string]interface{}{
+			"schemas": []string{"urn:ietf:params:scim:api:messages:2.0:PatchOp"},
+			"Operations": []map[string]interface{}{
+				{
+					"op": "replace",
+					"value": map[string]interface{}{
+						"emails": []map[string]interface{}{
+							{
+								"value":   "valid@example.com",
+								"type":    true, // Boolean instead of string
+								"primary": true,
+							},
+						},
+					},
+				},
+			},
+		}
+
+		var emailTypeAsBoolResp map[string]interface{}
+		s.DoJSON(t, "PATCH", scimPath("/Users/"+userID), patchEmailTypeAsBoolPayload, http.StatusBadRequest, &emailTypeAsBoolResp)
+		assert.EqualValues(t, emailTypeAsBoolResp["schemas"], []interface{}{"urn:ietf:params:scim:api:messages:2.0:Error"})
+		assert.Contains(t, emailTypeAsBoolResp["detail"], errors.ScimErrorInvalidValue.Detail)
+	})
+
+	t.Run("Verify that patching with primary flag as a string fails", func(t *testing.T) {
+		patchPrimaryAsStringPayload := map[string]interface{}{
+			"schemas": []string{"urn:ietf:params:scim:api:messages:2.0:PatchOp"},
+			"Operations": []map[string]interface{}{
+				{
+					"op": "replace",
+					"value": map[string]interface{}{
+						"emails": []map[string]interface{}{
+							{
+								"value":   "valid@example.com",
+								"type":    "work",
+								"primary": "true", // String instead of boolean
+							},
+						},
+					},
+				},
+			},
+		}
+
+		var primaryAsStringResp map[string]interface{}
+		s.DoJSON(t, "PATCH", scimPath("/Users/"+userID), patchPrimaryAsStringPayload, http.StatusBadRequest, &primaryAsStringResp)
+		assert.EqualValues(t, primaryAsStringResp["schemas"], []interface{}{"urn:ietf:params:scim:api:messages:2.0:Error"})
+		assert.Contains(t, primaryAsStringResp["detail"], errors.ScimErrorInvalidValue.Detail)
+	})
+
+	t.Run("Verify that patching with primary flag as a number fails", func(t *testing.T) {
+		patchPrimaryAsNumberPayload := map[string]interface{}{
+			"schemas": []string{"urn:ietf:params:scim:api:messages:2.0:PatchOp"},
+			"Operations": []map[string]interface{}{
+				{
+					"op": "replace",
+					"value": map[string]interface{}{
+						"emails": []map[string]interface{}{
+							{
+								"value":   "valid@example.com",
+								"type":    "work",
+								"primary": 1, // Number instead of boolean
+							},
+						},
+					},
+				},
+			},
+		}
+
+		var primaryAsNumberResp map[string]interface{}
+		s.DoJSON(t, "PATCH", scimPath("/Users/"+userID), patchPrimaryAsNumberPayload, http.StatusBadRequest, &primaryAsNumberResp)
+		assert.EqualValues(t, primaryAsNumberResp["schemas"], []interface{}{"urn:ietf:params:scim:api:messages:2.0:Error"})
+		assert.Contains(t, primaryAsNumberResp["detail"], errors.ScimErrorInvalidValue.Detail)
+	})
+
+	t.Run("Verify that patching with null email value fails", func(t *testing.T) {
+		patchNullEmailValuePayload := map[string]interface{}{
+			"schemas": []string{"urn:ietf:params:scim:api:messages:2.0:PatchOp"},
+			"Operations": []map[string]interface{}{
+				{
+					"op": "replace",
+					"value": map[string]interface{}{
+						"emails": []map[string]interface{}{
+							{
+								"value":   nil, // Null email value
+								"type":    "work",
+								"primary": true,
+							},
+						},
+					},
+				},
+			},
+		}
+
+		var nullEmailResp map[string]interface{}
+		s.DoJSON(t, "PATCH", scimPath("/Users/"+userID), patchNullEmailValuePayload, http.StatusBadRequest, &nullEmailResp)
+		assert.EqualValues(t, nullEmailResp["schemas"], []interface{}{"urn:ietf:params:scim:api:messages:2.0:Error"})
+		assert.Contains(t, nullEmailResp["detail"], "Bad Request. Invalid parameter provided in request")
+	})
+
+	t.Run("Verify that patching with null emails field results in an error", func(t *testing.T) {
+		patchNullEmailsFieldPayload := map[string]interface{}{
+			"schemas": []string{"urn:ietf:params:scim:api:messages:2.0:PatchOp"},
+			"Operations": []map[string]interface{}{
+				{
+					"op": "replace",
+					"value": map[string]interface{}{
+						"emails": nil,
+					},
+				},
+			},
+		}
+
+		var nullEmailsResp map[string]interface{}
+		s.DoJSON(t, "PATCH", scimPath("/Users/"+userID), patchNullEmailsFieldPayload, http.StatusBadRequest, &nullEmailsResp)
+		assert.EqualValues(t, nullEmailsResp["schemas"], []interface{}{"urn:ietf:params:scim:api:messages:2.0:Error"})
+		assert.Contains(t, nullEmailsResp["detail"], "A required value was missing")
+	})
+
+	t.Run("Patch emails with explicit path", func(t *testing.T) {
+		patchEmailsWithPathPayload := map[string]interface{}{
+			"schemas": []string{"urn:ietf:params:scim:api:messages:2.0:PatchOp"},
+			"Operations": []map[string]interface{}{
+				{
+					"op":   "replace",
+					"path": "emails",
+					"value": []map[string]interface{}{
 						{
-							"value":   "new-primary@example.com",
+							"value":   "explicit-path-primary@example.com",
 							"type":    "work",
 							"primary": true,
 						},
 						{
-							"value":   "secondary@example.com",
+							"value":   "explicit-path-secondary@example.com",
 							"type":    "home",
 							"primary": false,
 						},
 					},
 				},
 			},
-		},
-	}
-
-	var patchResp map[string]interface{}
-	s.DoJSON(t, "PATCH", scimPath("/Users/"+userID), patchEmailsPayload, http.StatusOK, &patchResp)
-
-	// Verify the emails were updated
-	emails, _ := patchResp["emails"].([]interface{})
-	assert.Equal(t, 2, len(emails), "Should have 2 emails after patch")
-
-	// Verify the email values
-	emailValues := make([]string, 0, 2)
-	primaryFound := false
-	for _, e := range emails {
-		email, ok := e.(map[string]interface{})
-		assert.True(t, ok, "Email should be an object")
-		emailValues = append(emailValues, email["value"].(string))
-
-		// Check if this is the primary email
-		if primary, ok := email["primary"].(bool); ok && primary {
-			primaryFound = true
-			assert.Equal(t, "new-primary@example.com", email["value"], "Primary email should be new-primary@example.com")
-			assert.Equal(t, "work", email["type"], "Primary email should be of type work")
 		}
-	}
-	assert.EqualValues(t, []string{"new-primary@example.com", "secondary@example.com"}, emailValues,
-		"Emails should be new-primary@example.com and secondary@example.com")
-	assert.True(t, primaryFound, "One email should be marked as primary")
 
-	// Verify that patching with multiple primary emails fails
-	patchMultiplePrimaryPayload := map[string]interface{}{
-		"schemas": []string{"urn:ietf:params:scim:api:messages:2.0:PatchOp"},
-		"Operations": []map[string]interface{}{
-			{
-				"op": "replace",
-				"value": map[string]interface{}{
-					"emails": []map[string]interface{}{
-						{
-							"value":   "primary1@example.com",
-							"type":    "work",
-							"primary": true,
-						},
-						{
-							"value":   "primary2@example.com",
-							"type":    "home",
-							"primary": true, // Second primary email
-						},
-					},
-				},
-			},
-		},
-	}
+		var patchEmailsWithPathResp map[string]interface{}
+		s.DoJSON(t, "PATCH", scimPath("/Users/"+userID), patchEmailsWithPathPayload, http.StatusOK, &patchEmailsWithPathResp)
+		emails, ok := patchEmailsWithPathResp["emails"].([]interface{})
+		require.True(t, ok, "Response should have emails array")
+		assert.Equal(t, 2, len(emails), "Should have 2 emails after patch with explicit path")
 
-	var errorResp map[string]interface{}
-	s.DoJSON(t, "PATCH", scimPath("/Users/"+userID), patchMultiplePrimaryPayload, http.StatusBadRequest, &errorResp)
-	assert.EqualValues(t, errorResp["schemas"], []interface{}{"urn:ietf:params:scim:api:messages:2.0:Error"})
-	assert.Contains(t, errorResp["detail"], "Only one email can be marked as primary")
+		// Verify the email values
+		emailValues := make([]string, 0, 2)
+		primaryFound := false
+		for _, e := range emails {
+			email, ok := e.(map[string]interface{})
+			assert.True(t, ok, "Email should be an object")
+			emailValues = append(emailValues, email["value"].(string))
 
-	// Verify that patching with no primary email is allowed
-	patchNoPrimaryPayload := map[string]interface{}{
-		"schemas": []string{"urn:ietf:params:scim:api:messages:2.0:PatchOp"},
-		"Operations": []map[string]interface{}{
-			{
-				"op": "replace",
-				"value": map[string]interface{}{
-					"emails": []map[string]interface{}{
-						{
-							"value": "no-primary1@example.com",
-							"type":  "work",
-							// No primary field
-						},
-						{
-							"value": "no-primary2@example.com",
-							"type":  "home",
-							// No primary field
-						},
-					},
-				},
-			},
-		},
-	}
-
-	var noPrimaryResp map[string]interface{}
-	s.DoJSON(t, "PATCH", scimPath("/Users/"+userID), patchNoPrimaryPayload, http.StatusOK, &noPrimaryResp)
-
-	// Verify the emails were updated
-	noPrimaryEmails, _ := noPrimaryResp["emails"].([]interface{})
-	assert.Equal(t, 2, len(noPrimaryEmails), "Should have 2 emails after patch")
-
-	// Verify the email values
-	noPrimaryEmailValues := make([]string, 0, 2)
-	for _, e := range noPrimaryEmails {
-		email, ok := e.(map[string]interface{})
-		assert.True(t, ok, "Email should be an object")
-		noPrimaryEmailValues = append(noPrimaryEmailValues, email["value"].(string))
-	}
-	assert.EqualValues(t, []string{"no-primary1@example.com", "no-primary2@example.com"}, noPrimaryEmailValues,
-		"Emails should be no-primary1@example.com and no-primary2@example.com")
-
-	// Verify that patching with an empty emails array removes all emails
-	patchEmptyEmailsPayload := map[string]interface{}{
-		"schemas": []string{"urn:ietf:params:scim:api:messages:2.0:PatchOp"},
-		"Operations": []map[string]interface{}{
-			{
-				"op": "replace",
-				"value": map[string]interface{}{
-					"emails": []map[string]interface{}{},
-				},
-			},
-		},
-	}
-
-	var emptyEmailsResp map[string]interface{}
-	s.DoJSON(t, "PATCH", scimPath("/Users/"+userID), patchEmptyEmailsPayload, http.StatusOK, &emptyEmailsResp)
-
-	// Verify the emails were updated (should be empty or not present)
-	noEmails := emptyEmailsResp["emails"]
-	assert.Empty(t, noEmails, "Emails should be empty after patch")
-
-	// Verify that patching with invalid email format fails
-	patchInvalidEmailFormatPayload := map[string]interface{}{
-		"schemas": []string{"urn:ietf:params:scim:api:messages:2.0:PatchOp"},
-		"Operations": []map[string]interface{}{
-			{
-				"op": "replace",
-				"value": map[string]interface{}{
-					"emails": []map[string]interface{}{
-						{
-							"value":   "not-an-email", // Invalid email format (missing @ and domain)
-							"type":    "work",
-							"primary": true,
-						},
-					},
-				},
-			},
-		},
-	}
-
-	var invalidEmailFormatResp map[string]interface{}
-	s.DoJSON(t, "PATCH", scimPath("/Users/"+userID), patchInvalidEmailFormatPayload, http.StatusBadRequest, &invalidEmailFormatResp)
-	assert.EqualValues(t, invalidEmailFormatResp["schemas"], []interface{}{"urn:ietf:params:scim:api:messages:2.0:Error"})
-	assert.Contains(t, invalidEmailFormatResp["detail"], "Bad Request")
-
-	// Verify that patching with empty email value fails
-	patchEmptyEmailValuePayload := map[string]interface{}{
-		"schemas": []string{"urn:ietf:params:scim:api:messages:2.0:PatchOp"},
-		"Operations": []map[string]interface{}{
-			{
-				"op": "replace",
-				"value": map[string]interface{}{
-					"emails": []map[string]interface{}{
-						{
-							"value":   "", // Empty email value
-							"type":    "work",
-							"primary": true,
-						},
-					},
-				},
-			},
-		},
-	}
-
-	var emptyEmailValueResp map[string]interface{}
-	s.DoJSON(t, "PATCH", scimPath("/Users/"+userID), patchEmptyEmailValuePayload, http.StatusBadRequest, &emptyEmailValueResp)
-	assert.EqualValues(t, emptyEmailValueResp["schemas"], []interface{}{"urn:ietf:params:scim:api:messages:2.0:Error"})
-	assert.Contains(t, emptyEmailValueResp["detail"], "Bad Request")
-
-	// Verify that patching with email missing @ symbol fails
-	patchEmailMissingAtPayload := map[string]interface{}{
-		"schemas": []string{"urn:ietf:params:scim:api:messages:2.0:PatchOp"},
-		"Operations": []map[string]interface{}{
-			{
-				"op": "replace",
-				"value": map[string]interface{}{
-					"emails": []map[string]interface{}{
-						{
-							"value":   "testinvalid.com", // Email missing @ symbol
-							"type":    "work",
-							"primary": true,
-						},
-					},
-				},
-			},
-		},
-	}
-
-	var emailMissingAtResp map[string]interface{}
-	s.DoJSON(t, "PATCH", scimPath("/Users/"+userID), patchEmailMissingAtPayload, http.StatusBadRequest, &emailMissingAtResp)
-	assert.EqualValues(t, emailMissingAtResp["schemas"], []interface{}{"urn:ietf:params:scim:api:messages:2.0:Error"})
-	assert.Contains(t, emailMissingAtResp["detail"], "Bad Request")
-
-	// Verify that patching with email value as a number fails
-	patchEmailValueAsNumberPayload := map[string]interface{}{
-		"schemas": []string{"urn:ietf:params:scim:api:messages:2.0:PatchOp"},
-		"Operations": []map[string]interface{}{
-			{
-				"op": "replace",
-				"value": map[string]interface{}{
-					"emails": []map[string]interface{}{
-						{
-							"value":   123, // Number instead of string
-							"type":    "work",
-							"primary": true,
-						},
-					},
-				},
-			},
-		},
-	}
-
-	var emailValueAsNumberResp map[string]interface{}
-	s.DoJSON(t, "PATCH", scimPath("/Users/"+userID), patchEmailValueAsNumberPayload, http.StatusBadRequest, &emailValueAsNumberResp)
-	assert.EqualValues(t, emailValueAsNumberResp["schemas"], []interface{}{"urn:ietf:params:scim:api:messages:2.0:Error"})
-	assert.Contains(t, emailValueAsNumberResp["detail"], errors.ScimErrorInvalidValue.Detail)
-
-	// Verify that patching with email value as a boolean fails
-	patchEmailValueAsBoolPayload := map[string]interface{}{
-		"schemas": []string{"urn:ietf:params:scim:api:messages:2.0:PatchOp"},
-		"Operations": []map[string]interface{}{
-			{
-				"op": "replace",
-				"value": map[string]interface{}{
-					"emails": []map[string]interface{}{
-						{
-							"value":   true, // Boolean instead of string
-							"type":    "work",
-							"primary": true,
-						},
-					},
-				},
-			},
-		},
-	}
-
-	var emailValueAsBoolResp map[string]interface{}
-	s.DoJSON(t, "PATCH", scimPath("/Users/"+userID), patchEmailValueAsBoolPayload, http.StatusBadRequest, &emailValueAsBoolResp)
-	assert.EqualValues(t, emailValueAsBoolResp["schemas"], []interface{}{"urn:ietf:params:scim:api:messages:2.0:Error"})
-	assert.Contains(t, emailValueAsBoolResp["detail"], errors.ScimErrorInvalidValue.Detail)
-
-	// Verify that patching with email type as a number fails
-	patchEmailTypeAsNumberPayload := map[string]interface{}{
-		"schemas": []string{"urn:ietf:params:scim:api:messages:2.0:PatchOp"},
-		"Operations": []map[string]interface{}{
-			{
-				"op": "replace",
-				"value": map[string]interface{}{
-					"emails": []map[string]interface{}{
-						{
-							"value":   "valid@example.com",
-							"type":    123, // Number instead of string
-							"primary": true,
-						},
-					},
-				},
-			},
-		},
-	}
-
-	var emailTypeAsNumberResp map[string]interface{}
-	s.DoJSON(t, "PATCH", scimPath("/Users/"+userID), patchEmailTypeAsNumberPayload, http.StatusBadRequest, &emailTypeAsNumberResp)
-	assert.EqualValues(t, emailTypeAsNumberResp["schemas"], []interface{}{"urn:ietf:params:scim:api:messages:2.0:Error"})
-	assert.Contains(t, emailTypeAsNumberResp["detail"], errors.ScimErrorInvalidValue.Detail)
-
-	// Verify that patching with email type as a boolean fails
-	patchEmailTypeAsBoolPayload := map[string]interface{}{
-		"schemas": []string{"urn:ietf:params:scim:api:messages:2.0:PatchOp"},
-		"Operations": []map[string]interface{}{
-			{
-				"op": "replace",
-				"value": map[string]interface{}{
-					"emails": []map[string]interface{}{
-						{
-							"value":   "valid@example.com",
-							"type":    true, // Boolean instead of string
-							"primary": true,
-						},
-					},
-				},
-			},
-		},
-	}
-
-	var emailTypeAsBoolResp map[string]interface{}
-	s.DoJSON(t, "PATCH", scimPath("/Users/"+userID), patchEmailTypeAsBoolPayload, http.StatusBadRequest, &emailTypeAsBoolResp)
-	assert.EqualValues(t, emailTypeAsBoolResp["schemas"], []interface{}{"urn:ietf:params:scim:api:messages:2.0:Error"})
-	assert.Contains(t, emailTypeAsBoolResp["detail"], errors.ScimErrorInvalidValue.Detail)
-
-	// Verify that patching with primary flag as a string fails
-	patchPrimaryAsStringPayload := map[string]interface{}{
-		"schemas": []string{"urn:ietf:params:scim:api:messages:2.0:PatchOp"},
-		"Operations": []map[string]interface{}{
-			{
-				"op": "replace",
-				"value": map[string]interface{}{
-					"emails": []map[string]interface{}{
-						{
-							"value":   "valid@example.com",
-							"type":    "work",
-							"primary": "true", // String instead of boolean
-						},
-					},
-				},
-			},
-		},
-	}
-
-	var primaryAsStringResp map[string]interface{}
-	s.DoJSON(t, "PATCH", scimPath("/Users/"+userID), patchPrimaryAsStringPayload, http.StatusBadRequest, &primaryAsStringResp)
-	assert.EqualValues(t, primaryAsStringResp["schemas"], []interface{}{"urn:ietf:params:scim:api:messages:2.0:Error"})
-	assert.Contains(t, primaryAsStringResp["detail"], errors.ScimErrorInvalidValue.Detail)
-
-	// Verify that patching with primary flag as a number fails
-	patchPrimaryAsNumberPayload := map[string]interface{}{
-		"schemas": []string{"urn:ietf:params:scim:api:messages:2.0:PatchOp"},
-		"Operations": []map[string]interface{}{
-			{
-				"op": "replace",
-				"value": map[string]interface{}{
-					"emails": []map[string]interface{}{
-						{
-							"value":   "valid@example.com",
-							"type":    "work",
-							"primary": 1, // Number instead of boolean
-						},
-					},
-				},
-			},
-		},
-	}
-
-	var primaryAsNumberResp map[string]interface{}
-	s.DoJSON(t, "PATCH", scimPath("/Users/"+userID), patchPrimaryAsNumberPayload, http.StatusBadRequest, &primaryAsNumberResp)
-	assert.EqualValues(t, primaryAsNumberResp["schemas"], []interface{}{"urn:ietf:params:scim:api:messages:2.0:Error"})
-	assert.Contains(t, primaryAsNumberResp["detail"], errors.ScimErrorInvalidValue.Detail)
-
-	// Verify that patching with null email value fails
-	patchNullEmailValuePayload := map[string]interface{}{
-		"schemas": []string{"urn:ietf:params:scim:api:messages:2.0:PatchOp"},
-		"Operations": []map[string]interface{}{
-			{
-				"op": "replace",
-				"value": map[string]interface{}{
-					"emails": []map[string]interface{}{
-						{
-							"value":   nil, // Null email value
-							"type":    "work",
-							"primary": true,
-						},
-					},
-				},
-			},
-		},
-	}
-
-	var nullEmailResp map[string]interface{}
-	s.DoJSON(t, "PATCH", scimPath("/Users/"+userID), patchNullEmailValuePayload, http.StatusBadRequest, &nullEmailResp)
-	assert.EqualValues(t, nullEmailResp["schemas"], []interface{}{"urn:ietf:params:scim:api:messages:2.0:Error"})
-	assert.Contains(t, nullEmailResp["detail"], "Bad Request. Invalid parameter provided in request")
-
-	// Now verify that patching with null emails field results in an error.
-	patchNullEmailsFieldPayload := map[string]interface{}{
-		"schemas": []string{"urn:ietf:params:scim:api:messages:2.0:PatchOp"},
-		"Operations": []map[string]interface{}{
-			{
-				"op": "replace",
-				"value": map[string]interface{}{
-					"emails": nil,
-				},
-			},
-		},
-	}
-
-	var nullEmailsResp map[string]interface{}
-	s.DoJSON(t, "PATCH", scimPath("/Users/"+userID), patchNullEmailsFieldPayload, http.StatusBadRequest, &nullEmailsResp)
-	assert.EqualValues(t, nullEmailsResp["schemas"], []interface{}{"urn:ietf:params:scim:api:messages:2.0:Error"})
-	assert.Contains(t, nullEmailsResp["detail"], "A required value was missing")
-
-	// Patch emails with explicit path
-	patchEmailsWithPathPayload := map[string]interface{}{
-		"schemas": []string{"urn:ietf:params:scim:api:messages:2.0:PatchOp"},
-		"Operations": []map[string]interface{}{
-			{
-				"op":   "replace",
-				"path": "emails",
-				"value": []map[string]interface{}{
-					{
-						"value":   "explicit-path-primary@example.com",
-						"type":    "work",
-						"primary": true,
-					},
-					{
-						"value":   "explicit-path-secondary@example.com",
-						"type":    "home",
-						"primary": false,
-					},
-				},
-			},
-		},
-	}
-
-	var patchEmailsWithPathResp map[string]interface{}
-	s.DoJSON(t, "PATCH", scimPath("/Users/"+userID), patchEmailsWithPathPayload, http.StatusOK, &patchEmailsWithPathResp)
-	emails, ok := patchEmailsWithPathResp["emails"].([]interface{})
-	require.True(t, ok, "Response should have emails array")
-	assert.Equal(t, 2, len(emails), "Should have 2 emails after patch with explicit path")
-
-	// Verify the email values
-	emailValues = make([]string, 0, 2)
-	primaryFound = false
-	for _, e := range emails {
-		email, ok := e.(map[string]interface{})
-		assert.True(t, ok, "Email should be an object")
-		emailValues = append(emailValues, email["value"].(string))
-
-		// Check if this is the primary email
-		if primary, ok := email["primary"].(bool); ok && primary {
-			primaryFound = true
-			assert.Equal(t, "explicit-path-primary@example.com", email["value"], "Primary email should be explicit-path-primary@example.com")
-			assert.Equal(t, "work", email["type"], "Primary email should be of type work")
+			// Check if this is the primary email
+			if primary, ok := email["primary"].(bool); ok && primary {
+				primaryFound = true
+				assert.Equal(t, "explicit-path-primary@example.com", email["value"], "Primary email should be explicit-path-primary@example.com")
+				assert.Equal(t, "work", email["type"], "Primary email should be of type work")
+			}
 		}
-	}
-	assert.EqualValues(t, []string{"explicit-path-primary@example.com", "explicit-path-secondary@example.com"}, emailValues,
-		"Email values should be updated.")
-	assert.True(t, primaryFound, "One email should be marked as primary")
-
-	// Delete the user we created
-	s.Do(t, "DELETE", scimPath("/Users/"+userID), nil, http.StatusNoContent)
+		assert.EqualValues(t, []string{"explicit-path-primary@example.com", "explicit-path-secondary@example.com"}, emailValues,
+			"Email values should be updated.")
+		assert.True(t, primaryFound, "One email should be marked as primary")
+	})
 }
 
 func testPatchUserAttributes(t *testing.T, s *Suite) {

--- a/ee/server/scim/path_test.go
+++ b/ee/server/scim/path_test.go
@@ -1,0 +1,22 @@
+package scim
+
+import (
+	"testing"
+
+	"github.com/scim2/filter-parser/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParsePath(t *testing.T) {
+	path, err := filter.ParsePath([]byte("emails[type eq \"work\"].primary"))
+	require.NoError(t, err)
+	assert.Equal(t, "emails", path.AttributePath.String())
+	attrExpression, ok := path.ValueExpression.(*filter.AttributeExpression)
+	require.True(t, ok)
+	assert.Equal(t, "type", attrExpression.AttributePath.String())
+	assert.Equal(t, filter.EQ, attrExpression.Operator)
+	assert.Equal(t, "work", attrExpression.CompareValue)
+	require.NotNil(t, path.SubAttribute)
+	assert.Equal(t, "primary", *path.SubAttribute)
+}

--- a/server/datastore/mysql/scim.go
+++ b/server/datastore/mysql/scim.go
@@ -250,6 +250,8 @@ func (ds *Datastore) ReplaceScimUser(ctx context.Context, user *fleet.ScimUser) 
 		// 2. Insert all new emails
 		// This is less efficient and can be optimized if we notice a load on these tables in production.
 
+		// TODO: Check if emails need to be updated at all. If so, update the user updated_at timestamp if emails have been updated
+
 		const deleteEmailsQuery = `DELETE FROM scim_user_emails WHERE scim_user_id = ?`
 		_, err = tx.ExecContext(ctx, deleteEmailsQuery, user.ID)
 		if err != nil {

--- a/server/datastore/mysql/scim.go
+++ b/server/datastore/mysql/scim.go
@@ -251,6 +251,7 @@ func (ds *Datastore) ReplaceScimUser(ctx context.Context, user *fleet.ScimUser) 
 		// This is less efficient and can be optimized if we notice a load on these tables in production.
 
 		// TODO: Check if emails need to be updated at all. If so, update the user updated_at timestamp if emails have been updated
+		// TODO: Check that only 1 email is primary
 
 		const deleteEmailsQuery = `DELETE FROM scim_user_emails WHERE scim_user_id = ?`
 		_, err = tx.ExecContext(ctx, deleteEmailsQuery, user.ID)


### PR DESCRIPTION
For #28196

This PR adds the capability to SCIM API to PATCH a User using op:replace. This brings us closer to fully supporting Entra ID SCIM.

In future PR:
- Add support op:add
- Add support for op:remove
- Add support for PATCH to Group
- Add filter support

# Checklist for submitter
- [x] Added/updated automated tests
- [x] Manual QA for all new/changed functionality
