### PR TITLE
Fix double "Target" heading in Save Query modal

### DIFF
--- a/frontend/pages/queries/edit/components/SaveQueryModal/SaveQueryModal.tsx
+++ b/frontend/pages/queries/edit/components/SaveQueryModal/SaveQueryModal.tsx
@@ -297,6 +297,7 @@ const SaveQueryModal = ({
                 Query will target hosts that <b>have any</b> of these labels:
               </span>
             }
+            suppressTitle
           />
         )}
         <RevealButton


### PR DESCRIPTION
For #28170

Before:
<img width="416" alt="image" src="https://github.com/user-attachments/assets/03663571-cad2-44f5-bd4d-c94a14e4957b" />

---

After:

<img width="382" alt="image" src="https://github.com/user-attachments/assets/f14a032a-85c8-4d1e-b4fc-617c6e5223ac" />
