### PR TITLE
Fleet UI (unreleased bugs): Related to code fields in modals

### DIFF
--- a/frontend/components/ActivityDetails/InstallDetails/AppInstallDetails/AppInstallDetails.tsx
+++ b/frontend/components/ActivityDetails/InstallDetails/AppInstallDetails/AppInstallDetails.tsx
@@ -116,21 +116,17 @@ export const AppInstallDetails = ({
           </span>
         </div>
         {showCommandPayload && (
-          <div className={`${baseClass}__script-output`}>
-            <Textarea label="Request payload:" variant="code">
-              {result.payload}
-            </Textarea>
-          </div>
+          <Textarea label="Request payload:" variant="code">
+            {result.payload}
+          </Textarea>
         )}
         {showCommandResponse && (
-          <div className={`${baseClass}__script-output`}>
-            <Textarea
-              label={`The response from ${formattedHost}:`}
-              variant="code"
-            >
-              {result.result}
-            </Textarea>
-          </div>
+          <Textarea
+            label={<>The response from {formattedHost}:</>}
+            variant="code"
+          >
+            {result.result}
+          </Textarea>
         )}
       </div>
     </>

--- a/frontend/components/ActivityDetails/InstallDetails/AppInstallDetails/_styles.scss
+++ b/frontend/components/ActivityDetails/InstallDetails/AppInstallDetails/_styles.scss
@@ -1,6 +1,12 @@
 .app-install-details {
   overflow-wrap: anywhere; // Prevent long software name overflow
 
+  &__software-install-details {
+    display: flex;
+    flex-direction: column;
+    gap: $pad-medium;
+  }
+
   .modal__content {
     margin-top: $pad-xlarge;
   }

--- a/frontend/components/ActivityDetails/InstallDetails/SoftwareInstallDetails/SoftwareInstallDetails.tsx
+++ b/frontend/components/ActivityDetails/InstallDetails/SoftwareInstallDetails/SoftwareInstallDetails.tsx
@@ -80,14 +80,12 @@ const Output = ({
   result: ISoftwareInstallResult;
 }) => {
   return (
-    <div className={`${baseClass}__script-output`}>
-      <Textarea
-        label={`${SOFTWARE_INSTALL_OUTPUT_DISPLAY_LABELS[displayKey]}:`}
-        variant="code"
-      >
-        {result[displayKey]}
-      </Textarea>
-    </div>
+    <Textarea
+      label={`${SOFTWARE_INSTALL_OUTPUT_DISPLAY_LABELS[displayKey]}:`}
+      variant="code"
+    >
+      {result[displayKey]}
+    </Textarea>
   );
 };
 

--- a/frontend/components/ActivityDetails/InstallDetails/SoftwareUninstallDetailsModal/SoftwareUninstallDetailsModal.tsx
+++ b/frontend/components/ActivityDetails/InstallDetails/SoftwareUninstallDetailsModal/SoftwareUninstallDetailsModal.tsx
@@ -128,17 +128,12 @@ const SoftwareUninstallDetailsModal = ({
         />
         {!isPendingStatus(status) && scriptResult && (
           <>
-            <div className={`${baseClass}__script-output`}>
-              <Textarea label="Uninstall script content:" variant="code">
-                {scriptResult.script_contents}
-              </Textarea>
-            </div>
-
-            <div className={`${baseClass}__script-output`}>
-              <Textarea label="Uninstall script output:" variant="code">
-                {scriptResult.output}
-              </Textarea>
-            </div>
+            <Textarea label="Uninstall script content:" variant="code">
+              {scriptResult.script_contents}
+            </Textarea>
+            <Textarea label="Uninstall script output:" variant="code">
+              {scriptResult.output}
+            </Textarea>
           </>
         )}
       </>

--- a/frontend/pages/DashboardPage/cards/ActivityFeed/components/ActivityAutomationDetailsModal/ActivityAutomationDetailsModal.tsx
+++ b/frontend/pages/DashboardPage/cards/ActivityFeed/components/ActivityAutomationDetailsModal/ActivityAutomationDetailsModal.tsx
@@ -20,15 +20,14 @@ const ActivityAutomationDetailsModal = ({
     return (
       <>
         <div className={`${baseClass}__modal-content`}>
-          <p>
-            Fleet will send a JSON payload to this URL whenever a new activity
-            is generated:
-          </p>
-          <div className={`${baseClass}__webhook-url`}>
-            <Textarea className={`${baseClass}__webhook-url-textarea`}>
-              {details.webhook_url}
-            </Textarea>
-          </div>
+          <Textarea
+            label="Fleet will send a JSON payload to this URL whenever a new activity
+            is generated:"
+            className={`${baseClass}__webhook-url`}
+            variant="code"
+          >
+            {details.webhook_url}
+          </Textarea>
         </div>
         <div className="modal-cta-wrap">
           <Button onClick={onCancel} variant="brand">

--- a/frontend/pages/DashboardPage/cards/ActivityFeed/components/ActivityAutomationDetailsModal/_styles.scss
+++ b/frontend/pages/DashboardPage/cards/ActivityFeed/components/ActivityAutomationDetailsModal/_styles.scss
@@ -10,10 +10,4 @@
       gap: 0;
     }
   }
-
-  &__webhook-url-textarea {
-    box-sizing: border-box;
-    font-family: "SourceCodePro";
-    word-break: break-all;
-  }
 }

--- a/frontend/pages/DashboardPage/cards/ActivityFeed/components/RunScriptDetailsModal/RunScriptDetailsModal.tsx
+++ b/frontend/pages/DashboardPage/cards/ActivityFeed/components/RunScriptDetailsModal/RunScriptDetailsModal.tsx
@@ -20,12 +20,9 @@ interface IScriptContentProps {
 
 const ScriptContent = ({ content }: IScriptContentProps) => {
   return (
-    <div className={`${baseClass}__script-content`}>
-      <span>Script content:</span>
-      <Textarea className={`${baseClass}__script-content-textarea`}>
-        {content}
-      </Textarea>
-    </div>
+    <Textarea label="Script content:" variant="code">
+      {content}
+    </Textarea>
   );
 };
 
@@ -126,20 +123,24 @@ interface IScriptOutputProps {
 
 const ScriptOutput = ({ output, hostname }: IScriptOutputProps) => {
   return (
-    <div className={`${baseClass}__script-output`}>
-      <p>
-        The{" "}
-        <TooltipWrapper
-          tipContent="Fleet records the last 10,000 characters to prevent downtime."
-          tooltipClass={`${baseClass}__output-tooltip`}
-          isDelayed
-        >
-          output recorded
-        </TooltipWrapper>{" "}
-        when <b>{hostname}</b> ran the script above:
-      </p>
-      <Textarea className={`${baseClass}__output-textarea`}>{output}</Textarea>
-    </div>
+    <Textarea
+      label={
+        <>
+          The{" "}
+          <TooltipWrapper
+            tipContent="Fleet records the last 10,000 characters to prevent downtime."
+            tooltipClass={`${baseClass}__output-tooltip`}
+            isDelayed
+          >
+            output recorded
+          </TooltipWrapper>{" "}
+          when <b>{hostname}</b> ran the script above:
+        </>
+      }
+      variant="code"
+    >
+      {output}
+    </Textarea>
   );
 };
 

--- a/frontend/pages/DashboardPage/cards/ActivityFeed/components/RunScriptDetailsModal/_styles.scss
+++ b/frontend/pages/DashboardPage/cards/ActivityFeed/components/RunScriptDetailsModal/_styles.scss
@@ -17,13 +17,6 @@
     gap: $pad-medium;
   }
 
-  &__script-content-textarea {
-    box-sizing: border-box;
-    max-height: 300px;
-    overflow-y: auto;
-    font-family: "SourceCodePro";
-  }
-
   &__status-message {
     p {
       display: flex;
@@ -45,23 +38,7 @@
     gap: $pad-xlarge;
   }
 
-  &__script-output {
-    display: flex;
-    flex-direction: column;
-    gap: $pad-medium;
-
-    p {
-      margin: 0;
-    }
-  }
-
   &__output-tooltip {
     width: 300px;
-  }
-
-  &__output-textarea {
-    font-family: "SourceCodePro";
-    max-height: 150px;
-    overflow: auto;
   }
 }


### PR DESCRIPTION
## Issue
For #28134 and For #28136
Introduced by scope creep of #27732 

## Description
- 1. Fix `variant="code"` to wrap so it doesn't overflow horizontally  (#28134)
- 2. Fix vertical gaps missing on App store app install details modal (#28136)
- 3. Accidentally injected html into a string, fixed (#28136)
- 4. Clean up code to all use `variant="code"` instead of one-off styling
- 5. Remove unnecessary `<div/>` wrappers on any `<Textarea/>`


## Screenshot of fixes

<img width="684" alt="Screenshot 2025-04-11 at 3 25 59 PM" src="https://github.com/user-attachments/assets/684d2316-7289-44c2-835b-4c691dfc627d" />
<img width="1317" alt="Screenshot 2025-04-11 at 1 51 36 PM" src="https://github.com/user-attachments/assets/cca96079-f48e-4495-be2e-061292f699a9" />


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->


- [x] A detailed QA plan exists on the associated ticket (if it isn't there, work with the product group's QA engineer to add it)
- [x] Manual QA for all new/changed functionality
