### PR TITLE
Don't validate software/profile labels in dry run mode

### DIFF
--- a/changes/28154-fix-gitops-dry-run-labels
+++ b/changes/28154-fix-gitops-dry-run-labels
@@ -1,0 +1,1 @@
+- Fixed issue where `fleetctl gitops --dry-run` would sometimes fail when creating and using labels in the same run

--- a/ee/server/service/software_installers.go
+++ b/ee/server/service/software_installers.go
@@ -1501,12 +1501,13 @@ func (svc *Service) BatchSetSoftwareInstallers(
 				fmt.Sprintf("Couldn't edit software. URL (%q) is invalid", payload.URL),
 			)
 		}
-		validatedLabels, err := ValidateSoftwareLabels(ctx, svc, payload.LabelsIncludeAny, payload.LabelsExcludeAny)
-		if err != nil {
-			return "", err
+		if !dryRun {
+			validatedLabels, err := ValidateSoftwareLabels(ctx, svc, payload.LabelsIncludeAny, payload.LabelsExcludeAny)
+			if err != nil {
+				return "", err
+			}
+			payload.ValidatedLabels = validatedLabels
 		}
-		payload.ValidatedLabels = validatedLabels
-
 		allScripts = append(allScripts, payload.InstallScript, payload.PostInstallScript, payload.UninstallScript)
 	}
 

--- a/server/service/mdm.go
+++ b/server/service/mdm.go
@@ -1635,9 +1635,12 @@ func (svc *Service) BatchSetMDMProfiles(
 		labels = append(labels, profiles[i].LabelsIncludeAny...)
 		labels = append(labels, profiles[i].LabelsExcludeAny...)
 	}
-	labelMap, err := svc.batchValidateProfileLabels(ctx, labels)
-	if err != nil {
-		return ctxerr.Wrap(ctx, err, "validating labels")
+	var labelMap map[string]fleet.ConfigurationProfileLabel
+	if !dryRun {
+		labelMap, err = svc.batchValidateProfileLabels(ctx, labels)
+		if err != nil {
+			return ctxerr.Wrap(ctx, err, "validating labels")
+		}
 	}
 
 	// We will not validate the profiles containing secret variables during dry run.


### PR DESCRIPTION
For #28154

This PR fixes a bug where GitOps dry runs would fail when software installers or profiles referenced labels that were created in the same run.  The issue is that GitOps utilizes the real APIs for batch software/profile creation for validation, sending a `dryRun` flag to prevent those APIs from actually writing data.  In dry run mode, no labels are actually created, so validation checks for "don't use labels that don't exist" will always fail when new labels are referenced.  Recent updates to GitOps have given it the ability to validate the labels itself, removing the need to use the API for this check.  

I added a new test for this in the mdm profiles tests.  The test suite for software installers is a little more challenging to update for this case, and since it's not a happy path test I'm not prioritizing it, but will try to add one time permitting.