### PR TITLE
Fleet UI: More truncation fixes after QA

### DIFF
--- a/frontend/pages/DashboardPage/cards/OperatingSystems/OSTableConfig.tsx
+++ b/frontend/pages/DashboardPage/cards/OperatingSystems/OSTableConfig.tsx
@@ -65,7 +65,7 @@ const generateDefaultTableHeaders = (
         );
       }
 
-      const { name, os_version_id } = cellProps.row.original;
+      const { name, os_version_id, platform } = cellProps.row.original;
 
       const softwareOsDetailsPath = getPathWithQueryParams(
         PATHS.SOFTWARE_OS_DETAILS(os_version_id),
@@ -83,12 +83,9 @@ const generateDefaultTableHeaders = (
         <LinkCell
           path={softwareOsDetailsPath}
           customOnClick={onClickSoftware}
-          value={
-            <>
-              <SoftwareIcon name={cellProps.row.original.platform} />
-              <span className="software-name">{name}</span>
-            </>
-          }
+          tooltipTruncate
+          prefix={<SoftwareIcon name={platform} />}
+          value={name}
         />
       );
     },

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwareInstallerCard/SoftwareInstallerCard.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwareInstallerCard/SoftwareInstallerCard.tsx
@@ -1,3 +1,5 @@
+/** software/titles/:id > Second section */
+
 import React, { useCallback, useContext, useState } from "react";
 
 import PATHS from "router/paths";

--- a/frontend/pages/SoftwarePage/SoftwareTitles/SoftwareTable/SoftwareTable.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitles/SoftwareTable/SoftwareTable.tsx
@@ -245,14 +245,13 @@ const SoftwareTable = ({
   };
 
   const handleRowSelect = (row: IRowProps) => {
-    if (row.original.id) {
-      const path = getPathWithQueryParams(
-        PATHS.SOFTWARE_TITLE_DETAILS(row.original.id.toString()),
-        { team_id: teamId }
-      );
+    if (!row.original.id) return;
 
-      router.push(path);
-    }
+    const detailsPath = showVersions
+      ? PATHS.SOFTWARE_VERSION_DETAILS(row.original.id.toString())
+      : PATHS.SOFTWARE_TITLE_DETAILS(row.original.id.toString());
+
+    router.push(getPathWithQueryParams(detailsPath, { team_id: teamId }));
   };
 
   const renderSoftwareCount = () => {

--- a/frontend/pages/SoftwarePage/SoftwareVulnerabilityDetailsPage/SoftwareVulnOSVersions/SwVulnOSTableConfig.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareVulnerabilityDetailsPage/SoftwareVulnOSVersions/SwVulnOSTableConfig.tsx
@@ -44,12 +44,9 @@ const generateColumnConfigs = (
         return (
           <LinkCell
             path={path}
-            value={
-              <>
-                <SoftwareIcon name={platform} />
-                <span className="os-version-name">{name}</span>
-              </>
-            }
+            tooltipTruncate
+            prefix={<SoftwareIcon name={platform} />}
+            value={name}
           />
         );
       },

--- a/frontend/pages/SoftwarePage/SoftwareVulnerabilityDetailsPage/SoftwareVulnSoftwareVersions/SwVulnSwTableConfig.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareVulnerabilityDetailsPage/SoftwareVulnSoftwareVersions/SwVulnSwTableConfig.tsx
@@ -43,12 +43,9 @@ const generateColumnConfigs = (
         return (
           <LinkCell
             path={path}
-            value={
-              <>
-                <SoftwareIcon name={name} />
-                <span className="vuln-sw-name">{name}</span>
-              </>
-            }
+            tooltipTruncate
+            prefix={<SoftwareIcon name={name} />}
+            value={name}
           />
         );
       },

--- a/frontend/styles/var/mixins.scss
+++ b/frontend/styles/var/mixins.scss
@@ -241,6 +241,13 @@ $max-width: 2560px;
   z-index: 100;
   line-height: 1.375;
   white-space: initial;
+
+  // Hyphenated words will still break at hyphens first
+  //  while non-hyphenated strings will break only when necessary
+  overflow-wrap: break-word; // Preferred property for modern browsers
+  word-wrap: break-word; // Fallback for older browsers e.g. IE
+  word-break: break-word; // Ensures words break when necessary
+
   p {
     margin: 0;
   }


### PR DESCRIPTION
## Issue
For #27772 

## Description
Fixes for bugs found in QA
- 1. Fix related bug with tooltips not wrapping for tooltips that have `"ALongStringWithoutAnyHyphensLikeAFilenameForASoftwareAndItOverflowsTooltipWrapper"
- 2. Fix using enter on the software > versions table will correctly route to the versions details page and not the title details page
- 3. Fix Vulnerabilities Details Page > Vulnerable Software table to use truncation

Fixes for bugs found from fixing bugs found in QA
- 4. Fix Vulnerabilities Details Page > Vulnerable OS table to use truncation
- 5. Fix Software > OS > OS table to use truncation

## Note
- I added to the original ticket QA plan to include scope of these fixes and tagged QA accordingly

## Screenshots of fixes

1.
<img width="998" alt="Screenshot 2025-04-14 at 11 09 41 AM" src="https://github.com/user-attachments/assets/1b284a62-9654-4a21-857b-921ec093dfca" />

2.
https://github.com/user-attachments/assets/9467d6a1-596d-4672-8cde-982bba2b4feb

3.
<img width="969" alt="Screenshot 2025-04-14 at 1 49 47 PM" src="https://github.com/user-attachments/assets/47e9c605-0ca1-49fb-b823-9996ac1f54b7" />

5.
<img width="1009" alt="Screenshot 2025-04-14 at 1 45 19 PM" src="https://github.com/user-attachments/assets/03234d74-af58-481b-a91c-12eb7e3b5329" />


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] A detailed QA plan exists on the associated ticket (if it isn't there, work with the product group's QA engineer to add it)
- [x] Manual QA for all new/changed functionality
