### PR TITLE
Update SQL parser to handle more modern syntax

### DIFF
--- a/changes/26366-update-sql-parser
+++ b/changes/26366-update-sql-parser
@@ -1,0 +1,1 @@
+- Updated the parser used when editing SQL in the UI to handle modern expressions like window functions

--- a/frontend/components/forms/validators/validate_query/index.js
+++ b/frontend/components/forms/validators/validate_query/index.js
@@ -1,12 +1,11 @@
-import sqliteParser from "sqlite-parser";
+import { Parser } from "node-sql-parser";
 import { includes, some } from "lodash";
 
-const BLACKLISTED_ACTIONS = [];
-const invalidQueryErrorMessage = "Blacklisted query action";
 const invalidQueryResponse = (message) => {
   return { valid: false, error: message };
 };
 const validQueryResponse = { valid: true, error: null };
+const parser = new Parser();
 
 export const validateQuery = (queryText) => {
   if (!queryText) {
@@ -14,19 +13,12 @@ export const validateQuery = (queryText) => {
   }
 
   try {
-    const ast = sqliteParser(queryText);
-    const { statement } = ast;
-    const invalidQuery = some(statement, (obj) => {
-      return includes(BLACKLISTED_ACTIONS, obj.variant.toLowerCase());
-    });
-
-    if (invalidQuery) {
-      return invalidQueryResponse(invalidQueryErrorMessage);
-    }
-
+    parser.astify(queryText, { database: "sqlite" });
     return validQueryResponse;
   } catch (error) {
-    return invalidQueryResponse(error.message);
+    return invalidQueryResponse(
+      "There is a syntax error in your query; please resolve in order to save."
+    );
   }
 };
 

--- a/frontend/components/forms/validators/validate_query/validate_query.tests.js
+++ b/frontend/components/forms/validators/validate_query/validate_query.tests.js
@@ -22,7 +22,9 @@ describe("validateQuery", () => {
       const { error, valid } = validateQuery(query);
 
       expect(valid).toEqual(false);
-      expect(error).toMatch(/Syntax error found near .+/);
+      expect(error).toMatch(
+        "There is a syntax error in your query; please resolve in order to save."
+      );
     });
   });
 

--- a/frontend/utilities/sql_tools.tests.ts
+++ b/frontend/utilities/sql_tools.tests.ts
@@ -1,0 +1,70 @@
+import { checkTable } from "./sql_tools";
+
+describe("checkTable", () => {
+  const SQL = `
+WITH extension_safety_hub_menu_notifications AS (
+	SELECT 
+		parse_json.key,
+		parse_json.fullkey,
+		parse_json.path,
+		parse_json.value
+	FROM (
+	    SELECT file.filename, file.path, file.btime FROM file WHERE path LIKE "/Users/%/Library/Application Support/Google/Chrome/%/Preferences" ORDER BY file.btime DESC limit 20
+	    ) as chrome_preferences
+	JOIN parse_json ON chrome_preferences.path = parse_json.path
+	WHERE parse_json.path LIKE "/Users/%/Library/Application Support/Google/Chrome/%/Preferences" AND (
+		fullkey IN ("profile/name", "profile/safety_hub_menu_notifications/extensions/isCurrentlyActive", "profile/safety_hub_menu_notifications/extensions/result/timestamp")
+		OR fullkey Like "profile/safety_hub_menu_notifications/extensions/result/triggeringExtensions%"
+	)
+),
+extension_details AS (
+	SELECT path,
+		CASE WHEN key = 'name' THEN value END AS profile_name,
+		CASE WHEN key = 'isCurrentlyActive' THEN value END AS notification_active,
+		CASE WHEN key GLOB '*[0-9]' THEN value END AS triggering_extension,
+		CASE WHEN key = 'timestamp' THEN value END AS timestamp
+	FROM extension_safety_hub_menu_notifications
+	GROUP BY path, profile_name, notification_active, triggering_extension, timestamp
+),
+problematic_extensions AS (
+	SELECT 
+		path,
+		MAX(profile_name) OVER (PARTITION by path) AS profile_name,
+		MAX(notification_active) AS notification_active,
+		MAX(timestamp) AS timestamp,
+		triggering_extension
+	FROM extension_details
+)
+SELECT path,
+	profile_name,
+	notification_active,
+	timestamp,
+	triggering_extension
+FROM problematic_extensions
+WHERE triggering_extension IS NOT NULL;
+`;
+  it("should return only real tables by default", () => {
+    const { tables, error } = checkTable(SQL);
+    expect(error).toBeNull();
+    expect(tables).toEqual(["file", "parse_json"]);
+  });
+
+  it("should return all tables if 'includeVirtualTables' is set", () => {
+    const { tables, error } = checkTable(SQL, true);
+    expect(error).toBeNull();
+    // Note that json_each is _not_ returned here, as it is a function table.
+    expect(tables).toEqual([
+      "file",
+      "parse_json",
+      "chrome_preferences",
+      "extension_safety_hub_menu_notifications",
+      "extension_details",
+      "problematic_extensions",
+    ]);
+  });
+
+  it("should return an error if SQL is in valid", () => {
+    const result = checkTable("SELECTx * FROM users");
+    expect(result.error).not.toBeNull();
+  });
+});

--- a/frontend/utilities/sql_tools.tests.ts
+++ b/frontend/utilities/sql_tools.tests.ts
@@ -1,6 +1,7 @@
 import { checkTable } from "./sql_tools";
 
 describe("checkTable", () => {
+  // from https://github.com/fleetdm/fleet/issues/26366
   const SQL = `
 WITH extension_safety_hub_menu_notifications AS (
 	SELECT 

--- a/frontend/utilities/sql_tools.ts
+++ b/frontend/utilities/sql_tools.ts
@@ -85,6 +85,13 @@ export const parseSqlTables = (
       return;
     }
 
+    if (node.with) {
+      node.with.forEach((withNode: IAstNode) => {
+        if (withNode.name && _isNode(withNode.name) && withNode.name.type === "default") {
+          cteTables.push((withNode.name as IAstNode)?.value);
+        }
+      }
+    }
     if (
       (node.variant === "common" || node.variant === "recursive") &&
       node.format === "table" &&

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "@types/dompurify": "3.0.2",
-    "ace-builds": "1.4.12",
+    "ace-builds": "1.4.14",
     "axios": "1.8.3",
     "content-disposition": "0.5.4",
     "core-js": "3.25.1",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "js-yaml": "3.14.1",
     "lodash": "4.17.21",
     "memoize-one": "5.2.1",
+    "node-sql-parser": "5.3.8",
     "normalizr": "3.6.2",
     "prop-types": "15.8.1",
     "proxy-middleware": "0.15.0",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,6 @@
     "sass": "1.83.4",
     "select": "1.1.2",
     "sockjs-client": "1.6.1",
-    "sqlite-parser": "1.0.1",
     "use-debounce": "9.0.4",
     "uuid": "8.3.2",
     "validator": "13.11.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -137,6 +137,12 @@ const config = {
     extensions: [".tsx", ".ts", ".js", ".jsx", ".json"],
     modules: [path.resolve(path.join(repo, "./frontend")), "node_modules"],
     fallback: { path: require.resolve("path-browserify") },
+    alias: {
+      "node-sql-parser": path.resolve(
+        __dirname,
+        "node_modules/node-sql-parser/umd/sqlite.umd.js"
+      ),
+    },
   },
 };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -12544,11 +12544,6 @@ sprintf-js@~1.0.2:
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
   integrity sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==
 
-sqlite-parser@1.0.1:
-  version "1.0.1"
-  resolved "https://registry.npmjs.org/sqlite-parser/-/sqlite-parser-1.0.1.tgz"
-  integrity sha1-EQGD8mgvBKxsfYrQnEREbvl21ew=
-
 stack-utils@^2.0.3:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/stack-utils/-/stack-utils-2.0.5.tgz#d25265fca995154659dbbfba3b49254778d2fdd5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3677,6 +3677,11 @@
   resolved "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz"
   integrity sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==
 
+"@types/pegjs@^0.10.0":
+  version "0.10.6"
+  resolved "https://registry.yarnpkg.com/@types/pegjs/-/pegjs-0.10.6.tgz#bc20fc4809fed4cddab8d0dbee0e568803741a82"
+  integrity sha512-eLYXDbZWXh2uxf+w8sXS8d6KSoXTswfps6fvCUuVAGN8eRpfe7h9eSRydxiSJvo9Bf+GzifsDOr9TMQlmJdmkw==
+
 "@types/prettier@^2.1.5":
   version "2.7.1"
   resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-2.7.1.tgz#dfd20e2dc35f027cdd6c1908e80a5ddc7499670e"
@@ -4876,6 +4881,11 @@ big-integer@^1.6.16:
   version "1.6.51"
   resolved "https://registry.npmjs.org/big-integer/-/big-integer-1.6.51.tgz"
   integrity sha512-GPEid2Y9QU1Exl1rpO9B2IPJGHPSupF5GnVIP0blYvNOMer2bTvSWs1jGOUg04hTmu67nmLsQ9TBo1puaotBHg==
+
+big-integer@^1.6.48:
+  version "1.6.52"
+  resolved "https://registry.yarnpkg.com/big-integer/-/big-integer-1.6.52.tgz#60a887f3047614a8e1bffe5d7173490a97dc8c85"
+  integrity sha512-QxD8cf2eVqJOOz63z6JIN9BzvVs/dlySa5HGSBH5xtR8dPteIRQnBxxKqkNTiT6jbDTF6jAfrd4oMcND9RGbQg==
 
 big.js@^5.2.2:
   version "5.2.2"
@@ -10700,6 +10710,14 @@ node-sass-magic-importer@^5.3.3:
     object-hash "^2.0.3"
     postcss-scss "^3.0.2"
     resolve "^1.17.0"
+
+node-sql-parser@5.3.8:
+  version "5.3.8"
+  resolved "https://registry.yarnpkg.com/node-sql-parser/-/node-sql-parser-5.3.8.tgz#b71db4cb80dc5302fc77d7b6ca3bcb269b2124bf"
+  integrity sha512-aqGTzK8kPJAwQ6tqdS0l+vX358LXMmZDw902ePfiPn3PSDsg2HeR2tHFioXNHJW00YHoic6VVYY80waFb/zdxw==
+  dependencies:
+    "@types/pegjs" "^0.10.0"
+    big-integer "^1.6.48"
 
 normalize-path@^3.0.0, normalize-path@~3.0.0:
   version "3.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4271,12 +4271,7 @@ abab@^2.0.3, abab@^2.0.5, abab@^2.0.6:
   resolved "https://registry.yarnpkg.com/abab/-/abab-2.0.6.tgz#41b80f2c871d19686216b82309231cfd3cb3d291"
   integrity sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA==
 
-ace-builds@1.4.12:
-  version "1.4.12"
-  resolved "https://registry.npmjs.org/ace-builds/-/ace-builds-1.4.12.tgz"
-  integrity sha512-G+chJctFPiiLGvs3+/Mly3apXTcfgE45dT5yp12BcWZ1kUs+gm0qd3/fv4gsz6fVag4mM0moHVpjHDIgph6Psg==
-
-ace-builds@^1.4.6:
+ace-builds@1.4.14, ace-builds@^1.4.6:
   version "1.4.14"
   resolved "https://registry.npmjs.org/ace-builds/-/ace-builds-1.4.14.tgz"
   integrity sha512-NBOQlm9+7RBqRqZwimpgquaLeTJFayqb9UEPtTkpC3TkkwDnlsT/TwsCC0svjt9kEZ6G9mH5AEOHSz6Q/HrzQQ==


### PR DESCRIPTION
For #26366

# Checklist for submitter

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/Committing-Changes.md#changes-files) for more information.

# Details

This PR fixes an issue where the SQL parser in the UI doesn't recognize window functions like `OVER()` and marks the SQL as having syntax errors.  The fix here is to update to a more modern parsing library.  This involved updating some AST-parsing code we have for determining which tables are used in a query, for the purposes of feeding autocomplete and determining query compatibility.

# Testing

I tested this with the query mentioned in #26366 in Chrome, Firefox and Safari on MacOS.  I also added new unit tests for our SQL helper functions.

# Notes

During testing I discovered that we were bundling two versions of the ACE editor into our frontend package.  By upgrading one version by a couple of patches to make the two dependencies equal, we chop out ~300k from our bundle.