### PR TITLE
Update API message for Windows MDM not configured error

### DIFF
--- a/changes/24209-windows-mdm-error-msg
+++ b/changes/24209-windows-mdm-error-msg
@@ -1,0 +1,1 @@
+- Updated error message and related documentation for Windows MDM configuration.

--- a/server/fleet/errors.go
+++ b/server/fleet/errors.go
@@ -22,7 +22,7 @@ var (
 	ErrNotConfigured         = &NotConfiguredError{}
 
 	MDMNotConfiguredMessage              = "MDM features aren't turned on in Fleet. For more information about setting up MDM, please visit https://fleetdm.com/docs/using-fleet"
-	WindowsMDMNotConfiguredMessage       = "Windows MDM isn't turned on. Visit https://fleetdm.com/docs/using-fleet to learn how to turn on MDM."
+	WindowsMDMNotConfiguredMessage       = "Windows MDM isn't turned on. For more information about setting up MDM, please visit https://fleetdm.com/learn-more-about/windows-mdm"
 	AppleMDMNotConfiguredMessage         = "macOS MDM isn't turned on. Visit https://fleetdm.com/docs/using-fleet to learn how to turn on MDM."
 	AppleABMDefaultTeamDeprecatedMessage = "mdm.apple_bm_default_team has been deprecated. Please use the new mdm.apple_business_manager key documented here: https://fleetdm.com/learn-more-about/apple-business-manager-gitops"
 	CantTurnOffMDMForWindowsHostsMessage = "Can't turn off MDM for Windows hosts."


### PR DESCRIPTION
Issue #24209 

Note error is expected when devices attempt to unenroll when Windows MDM is turned off. Per the linked ticket, documentation has been updated to reflect the expected behavior and this PR updates the error message returned by the API to link to the updated documentation.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.

