### PR TITLE
Corrected available for install software that is vulnerabilities

### DIFF
--- a/server/datastore/mysql/software.go
+++ b/server/datastore/mysql/software.go
@@ -3008,7 +3008,7 @@ func (ds *Datastore) ListHostSoftware(ctx context.Context, host *fleet.Host, opt
 
 	var stmtAvailable string
 
-	if (opts.OnlyAvailableForInstall) || (opts.IncludeAvailableForInstall) {
+	if opts.OnlyAvailableForInstall || opts.IncludeAvailableForInstall {
 		namedArgs["vpp_apps_platforms"] = fleet.VPPAppsPlatforms
 		namedArgs["host_compatible_platforms"] = host.FleetPlatform()
 

--- a/server/datastore/mysql/software.go
+++ b/server/datastore/mysql/software.go
@@ -3008,214 +3008,217 @@ func (ds *Datastore) ListHostSoftware(ctx context.Context, host *fleet.Host, opt
 
 	var stmtAvailable string
 
-	if (opts.OnlyAvailableForInstall && !opts.VulnerableOnly) || (opts.IncludeAvailableForInstall && !opts.VulnerableOnly) {
+	if (opts.OnlyAvailableForInstall) || (opts.IncludeAvailableForInstall) {
 		namedArgs["vpp_apps_platforms"] = fleet.VPPAppsPlatforms
 		namedArgs["host_compatible_platforms"] = host.FleetPlatform()
 
-		stmtAvailable = `
-			SELECT
-			st.id,
-			st.name,
-			st.source,
-			si.self_service as package_self_service,
-			si.filename as package_name,
-			si.version as package_version,
-			si.platform as package_platform,
-			vat.self_service as vpp_app_self_service,
-			vat.adam_id as vpp_app_adam_id,
-			vap.latest_version as vpp_app_version,
-			vap.platform as vpp_app_platform,
-			NULLIF(vap.icon_url, '') as vpp_app_icon_url,
-			NULL as last_install_installed_at,
-			NULL as last_install_install_uuid,
-			NULL as last_uninstall_uninstalled_at,
-			NULL as last_uninstall_script_execution_id,
-			NULL as status
-		FROM
-			software_titles st
-		LEFT OUTER JOIN
-			-- filter out software that is not available for install on the host's platform
-			software_installers si ON st.id = si.title_id AND si.platform = :host_compatible_platforms AND si.global_or_team_id = :global_or_team_id
-		LEFT OUTER JOIN
-			-- include VPP apps only if the host is on a supported platform
-			vpp_apps vap ON st.id = vap.title_id AND :host_platform IN (:vpp_apps_platforms)
-		LEFT OUTER JOIN
-			vpp_apps_teams vat ON vap.adam_id = vat.adam_id AND vap.platform = vat.platform AND vat.global_or_team_id = :global_or_team_id
-		WHERE
-			-- software is not installed on host (but is available in host's team)
-			NOT EXISTS (
-				SELECT 1
-				FROM
-					host_software hs
-				INNER JOIN
-					software s ON hs.software_id = s.id
-				WHERE
-					hs.host_id = :host_id AND
-					s.title_id = st.id
-			) AND
-			-- sofware install has not been attempted on host
-			NOT EXISTS (
-				SELECT 1
-				FROM
-					host_software_installs hsi
-				WHERE
-					hsi.host_id = :host_id AND
-					hsi.software_installer_id = si.id AND
-					hsi.removed = 0 AND
-					hsi.canceled = 0
-			) AND
-			-- sofware install/uninstall is not upcoming on host
-			NOT EXISTS (
-				SELECT 1
-				FROM
-					upcoming_activities ua
-					INNER JOIN
-						software_install_upcoming_activities siua ON siua.upcoming_activity_id = ua.id
-				WHERE
-					ua.host_id = :host_id AND
-					ua.activity_type IN ('software_install', 'software_uninstall') AND
-					siua.software_installer_id = si.id
-			) AND
-			-- VPP install has not been attempted on host
-			NOT EXISTS (
-				SELECT 1
-				FROM
-					host_vpp_software_installs hvsi
-				WHERE
-					hvsi.host_id = :host_id AND
-					hvsi.adam_id = vat.adam_id AND
-					hvsi.removed = 0 AND
-					hvsi.canceled = 0
-			) AND
-			-- VPP install is not upcoming on host
-			NOT EXISTS (
-				SELECT 1
-				FROM
-					upcoming_activities ua
-					INNER JOIN
-						vpp_app_upcoming_activities vaua ON vaua.upcoming_activity_id = ua.id
-				WHERE
-					ua.host_id = :host_id AND
-					ua.activity_type = 'vpp_app_install' AND
-					vaua.adam_id = vat.adam_id
-			) AND
-			-- either the software installer or the vpp app exists for the host's team
-			( si.id IS NOT NULL OR vat.platform = :host_platform ) AND
-			-- label membership check
-			(
-			 	-- do the label membership check for software installers and VPP apps
-					EXISTS (
-
-					SELECT 1 FROM (
-
-						-- no labels
-						SELECT 0 AS count_installer_labels, 0 AS count_host_labels, 0 as count_host_updated_after_labels
-						WHERE NOT EXISTS (
-							SELECT 1 FROM software_installer_labels sil WHERE sil.software_installer_id = si.id
-						) AND NOT EXISTS (SELECT 1 FROM vpp_app_team_labels vatl WHERE vatl.vpp_app_team_id = vat.id)
-
-						UNION
-
-						-- include any
-						SELECT
-							COUNT(*) AS count_installer_labels,
-							COUNT(lm.label_id) AS count_host_labels,
-							0 as count_host_updated_after_labels
-						FROM
-							software_installer_labels sil
-							LEFT OUTER JOIN label_membership lm ON lm.label_id = sil.label_id
-							AND lm.host_id = :host_id
-						WHERE
-							sil.software_installer_id = si.id
-							AND sil.exclude = 0
-						HAVING
-							count_installer_labels > 0 AND count_host_labels > 0
-
-						UNION
-
-						-- exclude any, ignore software that depends on labels created
-						-- _after_ the label_updated_at timestamp of the host (because
-						-- we don't have results for that label yet, the host may or may
-						-- not be a member).
-						SELECT
-							COUNT(*) AS count_installer_labels,
-							COUNT(lm.label_id) AS count_host_labels,
-							SUM(CASE WHEN lbl.created_at IS NOT NULL AND :host_label_updated_at >= lbl.created_at THEN 1 ELSE 0 END) as count_host_updated_after_labels
-						FROM
-							software_installer_labels sil
-							LEFT OUTER JOIN labels lbl
-								ON lbl.id = sil.label_id
-							LEFT OUTER JOIN label_membership lm
-								ON lm.label_id = sil.label_id AND lm.host_id = :host_id
-						WHERE
-							sil.software_installer_id = si.id
-							AND sil.exclude = 1
-						HAVING
-							count_installer_labels > 0 AND count_installer_labels = count_host_updated_after_labels AND count_host_labels = 0
-
-						UNION
-
-						-- vpp include any
-						SELECT
-							COUNT(*) AS count_installer_labels,
-							COUNT(lm.label_id) AS count_host_labels,
-							0 as count_host_updated_after_labels
-						FROM
-							vpp_app_team_labels vatl
-							LEFT OUTER JOIN label_membership lm ON lm.label_id = vatl.label_id
-							AND lm.host_id = :host_id
-						WHERE
-							vatl.vpp_app_team_id = vat.id
-							AND vatl.exclude = 0
-						HAVING
-							count_installer_labels > 0 AND count_host_labels > 0
-
-						UNION
-
-						-- vpp exclude any
-						SELECT
-							COUNT(*) AS count_installer_labels,
-							COUNT(lm.label_id) AS count_host_labels,
-							SUM(CASE
-							WHEN lbl.created_at IS NOT NULL AND lbl.label_membership_type = 0 AND :host_label_updated_at >= lbl.created_at THEN 1
-							WHEN lbl.created_at IS NOT NULL AND lbl.label_membership_type = 1 THEN 1
-							ELSE 0 END) as count_host_updated_after_labels
-						FROM
-							vpp_app_team_labels vatl
-							LEFT OUTER JOIN labels lbl
-								ON lbl.id = vatl.label_id
-							LEFT OUTER JOIN label_membership lm
-								ON lm.label_id = vatl.label_id AND lm.host_id = :host_id
-						WHERE
-							vatl.vpp_app_team_id = vat.id
-							AND vatl.exclude = 1
-						HAVING
-							count_installer_labels > 0 AND count_installer_labels = count_host_updated_after_labels AND count_host_labels = 0
-						) t
-					)
-			)
-		`
-		if opts.SelfServiceOnly {
-			stmtAvailable += "\nAND ( si.self_service = 1 OR ( vat.self_service = 1 AND :is_mdm_enrolled ) )"
-		}
-
-		if !opts.IsMDMEnrolled {
-			stmtAvailable += "\nAND vat.id IS NULL"
-		}
-
-		stmtAvailable, args, err := sqlx.Named(stmtAvailable, namedArgs)
-		if err != nil {
-			return nil, nil, err
-		}
-		stmtAvailable, args, err = sqlx.In(stmtAvailable, args...)
-		if err != nil {
-			return nil, nil, err
-		}
-
 		var availableSoftwareTitles []*hostSoftware
-		err = sqlx.SelectContext(ctx, ds.reader(ctx), &availableSoftwareTitles, stmtAvailable, args...)
-		if err != nil {
-			return nil, nil, err
+
+		if !opts.VulnerableOnly {
+			stmtAvailable = `
+				SELECT
+				st.id,
+				st.name,
+				st.source,
+				si.self_service as package_self_service,
+				si.filename as package_name,
+				si.version as package_version,
+				si.platform as package_platform,
+				vat.self_service as vpp_app_self_service,
+				vat.adam_id as vpp_app_adam_id,
+				vap.latest_version as vpp_app_version,
+				vap.platform as vpp_app_platform,
+				NULLIF(vap.icon_url, '') as vpp_app_icon_url,
+				NULL as last_install_installed_at,
+				NULL as last_install_install_uuid,
+				NULL as last_uninstall_uninstalled_at,
+				NULL as last_uninstall_script_execution_id,
+				NULL as status
+			FROM
+				software_titles st
+			LEFT OUTER JOIN
+				-- filter out software that is not available for install on the host's platform
+				software_installers si ON st.id = si.title_id AND si.platform = :host_compatible_platforms AND si.global_or_team_id = :global_or_team_id
+			LEFT OUTER JOIN
+				-- include VPP apps only if the host is on a supported platform
+				vpp_apps vap ON st.id = vap.title_id AND :host_platform IN (:vpp_apps_platforms)
+			LEFT OUTER JOIN
+				vpp_apps_teams vat ON vap.adam_id = vat.adam_id AND vap.platform = vat.platform AND vat.global_or_team_id = :global_or_team_id
+			WHERE
+				-- software is not installed on host (but is available in host's team)
+				NOT EXISTS (
+					SELECT 1
+					FROM
+						host_software hs
+					INNER JOIN
+						software s ON hs.software_id = s.id
+					WHERE
+						hs.host_id = :host_id AND
+						s.title_id = st.id
+				) AND
+				-- sofware install has not been attempted on host
+				NOT EXISTS (
+					SELECT 1
+					FROM
+						host_software_installs hsi
+					WHERE
+						hsi.host_id = :host_id AND
+						hsi.software_installer_id = si.id AND
+						hsi.removed = 0 AND
+						hsi.canceled = 0
+				) AND
+				-- sofware install/uninstall is not upcoming on host
+				NOT EXISTS (
+					SELECT 1
+					FROM
+						upcoming_activities ua
+						INNER JOIN
+							software_install_upcoming_activities siua ON siua.upcoming_activity_id = ua.id
+					WHERE
+						ua.host_id = :host_id AND
+						ua.activity_type IN ('software_install', 'software_uninstall') AND
+						siua.software_installer_id = si.id
+				) AND
+				-- VPP install has not been attempted on host
+				NOT EXISTS (
+					SELECT 1
+					FROM
+						host_vpp_software_installs hvsi
+					WHERE
+						hvsi.host_id = :host_id AND
+						hvsi.adam_id = vat.adam_id AND
+						hvsi.removed = 0 AND
+						hvsi.canceled = 0
+				) AND
+				-- VPP install is not upcoming on host
+				NOT EXISTS (
+					SELECT 1
+					FROM
+						upcoming_activities ua
+						INNER JOIN
+							vpp_app_upcoming_activities vaua ON vaua.upcoming_activity_id = ua.id
+					WHERE
+						ua.host_id = :host_id AND
+						ua.activity_type = 'vpp_app_install' AND
+						vaua.adam_id = vat.adam_id
+				) AND
+				-- either the software installer or the vpp app exists for the host's team
+				( si.id IS NOT NULL OR vat.platform = :host_platform ) AND
+				-- label membership check
+				(
+					-- do the label membership check for software installers and VPP apps
+						EXISTS (
+
+						SELECT 1 FROM (
+
+							-- no labels
+							SELECT 0 AS count_installer_labels, 0 AS count_host_labels, 0 as count_host_updated_after_labels
+							WHERE NOT EXISTS (
+								SELECT 1 FROM software_installer_labels sil WHERE sil.software_installer_id = si.id
+							) AND NOT EXISTS (SELECT 1 FROM vpp_app_team_labels vatl WHERE vatl.vpp_app_team_id = vat.id)
+
+							UNION
+
+							-- include any
+							SELECT
+								COUNT(*) AS count_installer_labels,
+								COUNT(lm.label_id) AS count_host_labels,
+								0 as count_host_updated_after_labels
+							FROM
+								software_installer_labels sil
+								LEFT OUTER JOIN label_membership lm ON lm.label_id = sil.label_id
+								AND lm.host_id = :host_id
+							WHERE
+								sil.software_installer_id = si.id
+								AND sil.exclude = 0
+							HAVING
+								count_installer_labels > 0 AND count_host_labels > 0
+
+							UNION
+
+							-- exclude any, ignore software that depends on labels created
+							-- _after_ the label_updated_at timestamp of the host (because
+							-- we don't have results for that label yet, the host may or may
+							-- not be a member).
+							SELECT
+								COUNT(*) AS count_installer_labels,
+								COUNT(lm.label_id) AS count_host_labels,
+								SUM(CASE WHEN lbl.created_at IS NOT NULL AND :host_label_updated_at >= lbl.created_at THEN 1 ELSE 0 END) as count_host_updated_after_labels
+							FROM
+								software_installer_labels sil
+								LEFT OUTER JOIN labels lbl
+									ON lbl.id = sil.label_id
+								LEFT OUTER JOIN label_membership lm
+									ON lm.label_id = sil.label_id AND lm.host_id = :host_id
+							WHERE
+								sil.software_installer_id = si.id
+								AND sil.exclude = 1
+							HAVING
+								count_installer_labels > 0 AND count_installer_labels = count_host_updated_after_labels AND count_host_labels = 0
+
+							UNION
+
+							-- vpp include any
+							SELECT
+								COUNT(*) AS count_installer_labels,
+								COUNT(lm.label_id) AS count_host_labels,
+								0 as count_host_updated_after_labels
+							FROM
+								vpp_app_team_labels vatl
+								LEFT OUTER JOIN label_membership lm ON lm.label_id = vatl.label_id
+								AND lm.host_id = :host_id
+							WHERE
+								vatl.vpp_app_team_id = vat.id
+								AND vatl.exclude = 0
+							HAVING
+								count_installer_labels > 0 AND count_host_labels > 0
+
+							UNION
+
+							-- vpp exclude any
+							SELECT
+								COUNT(*) AS count_installer_labels,
+								COUNT(lm.label_id) AS count_host_labels,
+								SUM(CASE
+								WHEN lbl.created_at IS NOT NULL AND lbl.label_membership_type = 0 AND :host_label_updated_at >= lbl.created_at THEN 1
+								WHEN lbl.created_at IS NOT NULL AND lbl.label_membership_type = 1 THEN 1
+								ELSE 0 END) as count_host_updated_after_labels
+							FROM
+								vpp_app_team_labels vatl
+								LEFT OUTER JOIN labels lbl
+									ON lbl.id = vatl.label_id
+								LEFT OUTER JOIN label_membership lm
+									ON lm.label_id = vatl.label_id AND lm.host_id = :host_id
+							WHERE
+								vatl.vpp_app_team_id = vat.id
+								AND vatl.exclude = 1
+							HAVING
+								count_installer_labels > 0 AND count_installer_labels = count_host_updated_after_labels AND count_host_labels = 0
+							) t
+						)
+				)
+			`
+			if opts.SelfServiceOnly {
+				stmtAvailable += "\nAND ( si.self_service = 1 OR ( vat.self_service = 1 AND :is_mdm_enrolled ) )"
+			}
+
+			if !opts.IsMDMEnrolled {
+				stmtAvailable += "\nAND vat.id IS NULL"
+			}
+
+			stmtAvailable, args, err := sqlx.Named(stmtAvailable, namedArgs)
+			if err != nil {
+				return nil, nil, err
+			}
+			stmtAvailable, args, err = sqlx.In(stmtAvailable, args...)
+			if err != nil {
+				return nil, nil, err
+			}
+
+			err = sqlx.SelectContext(ctx, ds.reader(ctx), &availableSoftwareTitles, stmtAvailable, args...)
+			if err != nil {
+				return nil, nil, err
+			}
 		}
 
 		// These slices are meant to keep track of software that is available for install.
@@ -3230,11 +3233,13 @@ func (ds *Datastore) ListHostSoftware(ctx context.Context, host *fleet.Host, opt
 			for _, s := range hostSoftwareUninstalls {
 				tempBySoftwareTitleID[s.ID] = s
 			}
-			for _, s := range hostSoftwareInstalls {
-				tempBySoftwareTitleID[s.ID] = s
-			}
-			for _, s := range hostVPPInstalls {
-				tmpByVPPAdamID[*s.VPPAppAdamID] = s
+			if !opts.VulnerableOnly {
+				for _, s := range hostSoftwareInstalls {
+					tempBySoftwareTitleID[s.ID] = s
+				}
+				for _, s := range hostVPPInstalls {
+					tmpByVPPAdamID[*s.VPPAppAdamID] = s
+				}
 			}
 			// software installed on the host not by fleet and there exists a software installer that matches this software
 			// so that makes it available for install

--- a/server/datastore/mysql/software_test.go
+++ b/server/datastore/mysql/software_test.go
@@ -4522,11 +4522,9 @@ func testListHostSoftware(t *testing.T, ds *Datastore) {
 	sw, _, err = ds.ListHostSoftware(ctx, host, opts)
 	require.NoError(t, err)
 	found = false
-	index = -1
-	for i, s := range sw {
+	for _, s := range sw {
 		if s.Name == softwareAlreadyInstalled.Name && s.Source == softwareAlreadyInstalled.Source {
 			found = true
-			index = i
 			break
 		}
 	}
@@ -4541,11 +4539,9 @@ func testListHostSoftware(t *testing.T, ds *Datastore) {
 	sw, _, err = ds.ListHostSoftware(ctx, host, opts)
 	require.NoError(t, err)
 	found = false
-	index = -1
-	for i, s := range sw {
+	for _, s := range sw {
 		if s.Name == softwareAlreadyInstalled.Name && s.Source == softwareAlreadyInstalled.Source {
 			found = true
-			index = i
 			break
 		}
 	}

--- a/server/datastore/mysql/software_test.go
+++ b/server/datastore/mysql/software_test.go
@@ -4388,11 +4388,11 @@ func testListHostSoftware(t *testing.T, ds *Datastore) {
 		})
 	}
 
-	// Host has software installed, but not by fleet, and there is a matching software installer.
-	// Ensure it is surfaced as "available for install"
 	darwinHost := test.NewHost(t, ds, "hostD", "", "hostDkey", "hostDuuid", time.Now(), test.WithPlatform("darwin"))
 	softwareAlreadyInstalled := fleet.Software{Name: "DummyApp.app", Version: "1.0.1", Source: "apps", BundleIdentifier: "com.example.dummy"}
 
+	// Host has software installed, but not by fleet, and there is no matching software installer.
+	// Ensure it is not surfaced as "available for install" when filtering by `VulnerableOnly`
 	ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
 		res, err := q.ExecContext(ctx, `INSERT INTO software_titles (name, source, bundle_identifier) VALUES (?, ?, ?)`,
 			softwareAlreadyInstalled.Name, softwareAlreadyInstalled.Source, softwareAlreadyInstalled.BundleIdentifier)
@@ -4403,6 +4403,8 @@ func testListHostSoftware(t *testing.T, ds *Datastore) {
 		if err != nil {
 			return err
 		}
+		titleIDUint := uint(titleID)
+		softwareAlreadyInstalled.TitleID = &titleIDUint
 		res, err = q.ExecContext(ctx, `INSERT INTO software (name, source, bundle_identifier, version, title_id) VALUES (?, ?, ?, ?, ?)`,
 			softwareAlreadyInstalled.Name, softwareAlreadyInstalled.Source, softwareAlreadyInstalled.BundleIdentifier, softwareAlreadyInstalled.Version, titleID)
 		if err != nil {
@@ -4412,13 +4414,38 @@ func testListHostSoftware(t *testing.T, ds *Datastore) {
 		if err != nil {
 			return err
 		}
+		softwareAlreadyInstalled.ID = uint(softwareID)
 		_, err = q.ExecContext(ctx, `INSERT INTO host_software (host_id, software_id) VALUES (?, ?)`,
 			darwinHost.ID, softwareID)
 		if err != nil {
 			return err
 		}
+
+		return nil
+	})
+	opts = fleet.HostSoftwareTitleListOptions{ListOptions: fleet.ListOptions{PerPage: 11, IncludeMetadata: true, OrderKey: "name", TestSecondaryOrderKey: "source"}}
+	opts.OnlyAvailableForInstall = true
+	opts.VulnerableOnly = true
+	sw, _, err = ds.ListHostSoftware(ctx, darwinHost, opts)
+	require.NoError(t, err)
+	assert.Len(t, sw, 0, "Expected to find no software in the list")
+
+	// Now add a vulnerability to DummyApp.pkg, it should still not come back because we are filtering for "available for install"
+	_, err = ds.InsertSoftwareVulnerability(ctx, fleet.SoftwareVulnerability{SoftwareID: softwareAlreadyInstalled.ID, CVE: "CVE-2025-10101"}, fleet.NVDSource)
+	require.NoError(t, err)
+	opts = fleet.HostSoftwareTitleListOptions{ListOptions: fleet.ListOptions{PerPage: 11, IncludeMetadata: true, OrderKey: "name", TestSecondaryOrderKey: "source"}}
+	opts.OnlyAvailableForInstall = true
+	opts.VulnerableOnly = true
+	sw, _, err = ds.ListHostSoftware(ctx, darwinHost, opts)
+	require.NoError(t, err)
+	assert.Len(t, sw, 0, "Expected to find no software in the list")
+
+	// Add a matching software installer
+	// Ensure it is surfaced as "available for install"
+	var SoftwareInstallerID uint
+	ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
 		installScript := `install 'DummyApp.app'`
-		res, err = q.ExecContext(ctx, `INSERT INTO script_contents (md5_checksum, contents) VALUES (UNHEX(md5(?)), ?)`, installScript, installScript)
+		res, err := q.ExecContext(ctx, `INSERT INTO script_contents (md5_checksum, contents) VALUES (UNHEX(md5(?)), ?)`, installScript, installScript)
 		if err != nil {
 			return err
 		}
@@ -4430,28 +4457,33 @@ func testListHostSoftware(t *testing.T, ds *Datastore) {
 			return err
 		}
 		uninstallScriptContentID, _ := resUninstall.LastInsertId()
-		_, err = q.ExecContext(ctx, `
+		res, err = q.ExecContext(ctx, `
 							INSERT INTO software_installers
 								(team_id, global_or_team_id, title_id, filename, extension, version, install_script_content_id, uninstall_script_content_id, storage_id, platform, self_service)
 							VALUES
 								(?, ?, ?, ?, ?, ?, ?, ?, unhex(?), ?, ?)`,
-			darwinHost.TeamID, 0, titleID, "DummyApp.pkg", "pkg", "2.0.0",
+			darwinHost.TeamID, 0, softwareAlreadyInstalled.TitleID, "DummyApp.pkg", "pkg", "2.0.0",
 			scriptContentID, uninstallScriptContentID,
 			hex.EncodeToString([]byte("test")), "darwin", true)
 		if err != nil {
 			return err
 		}
+		lastInsertID, err := res.LastInsertId()
+		if err != nil {
+			return err
+		}
+		SoftwareInstallerID = uint(lastInsertID)
 
 		return nil
 	})
 	require.NoError(t, err)
-
+	opts = fleet.HostSoftwareTitleListOptions{ListOptions: fleet.ListOptions{PerPage: 11, IncludeMetadata: true, OrderKey: "name", TestSecondaryOrderKey: "source"}}
 	opts.OnlyAvailableForInstall = true
 	sw, _, err = ds.ListHostSoftware(ctx, darwinHost, opts)
 	require.NoError(t, err)
 
 	var found bool
-	var index int
+	index := -1
 	for i, s := range sw {
 		if s.Name == softwareAlreadyInstalled.Name && s.Source == softwareAlreadyInstalled.Source {
 			found = true
@@ -4464,6 +4496,60 @@ func testListHostSoftware(t *testing.T, ds *Datastore) {
 	assert.Equal(t, sw[index].SoftwarePackage.Name, "DummyApp.pkg")
 	assert.Equal(t, sw[index].SoftwarePackage.Version, "2.0.0")
 	assert.Equal(t, sw[index].SoftwarePackage.Platform, "darwin")
+
+	// Now with matching software installer, if filtering by `VulnerableOnly` we should get the software, as it has a vulnerability
+	opts = fleet.HostSoftwareTitleListOptions{ListOptions: fleet.ListOptions{PerPage: 11, IncludeMetadata: true, OrderKey: "name", TestSecondaryOrderKey: "source"}}
+	opts.OnlyAvailableForInstall = true
+	opts.VulnerableOnly = true
+	sw, _, err = ds.ListHostSoftware(ctx, darwinHost, opts)
+	require.NoError(t, err)
+	found = false
+	index = -1
+	for i, s := range sw {
+		if s.Name == softwareAlreadyInstalled.Name && s.Source == softwareAlreadyInstalled.Source {
+			found = true
+			index = i
+			break
+		}
+	}
+	require.True(t, found, "Expected to find software %s in the list", softwareAlreadyInstalled.Name)
+	assert.Equal(t, sw[index].InstalledVersions[0].Version, softwareAlreadyInstalled.Version)
+
+	// This vulnerable software is not installed on the host, however, has a software installer available for install, should not be returned
+	opts = fleet.HostSoftwareTitleListOptions{ListOptions: fleet.ListOptions{PerPage: 11, IncludeMetadata: true, OrderKey: "name", TestSecondaryOrderKey: "source"}}
+	opts.OnlyAvailableForInstall = true
+	opts.VulnerableOnly = true
+	sw, _, err = ds.ListHostSoftware(ctx, host, opts)
+	require.NoError(t, err)
+	found = false
+	index = -1
+	for i, s := range sw {
+		if s.Name == softwareAlreadyInstalled.Name && s.Source == softwareAlreadyInstalled.Source {
+			found = true
+			index = i
+			break
+		}
+	}
+	require.False(t, found, "Expected not find software %s in the list", softwareAlreadyInstalled.Name)
+
+	// Attempt to install the vulnerable software on the host (pending), if filtering by `VulnerableOnly`, should not be returned
+	_, err = ds.InsertSoftwareInstallRequest(ctx, host.ID, SoftwareInstallerID, fleet.HostSoftwareInstallOptions{})
+	require.NoError(t, err)
+	opts = fleet.HostSoftwareTitleListOptions{ListOptions: fleet.ListOptions{PerPage: 11, IncludeMetadata: true, OrderKey: "name", TestSecondaryOrderKey: "source"}}
+	opts.OnlyAvailableForInstall = true
+	opts.VulnerableOnly = true
+	sw, _, err = ds.ListHostSoftware(ctx, host, opts)
+	require.NoError(t, err)
+	found = false
+	index = -1
+	for i, s := range sw {
+		if s.Name == softwareAlreadyInstalled.Name && s.Source == softwareAlreadyInstalled.Source {
+			found = true
+			index = i
+			break
+		}
+	}
+	require.False(t, found, "Expected not find software %s in the list", softwareAlreadyInstalled.Name)
 }
 
 func testListIOSHostSoftware(t *testing.T, ds *Datastore) {

--- a/server/datastore/mysql/software_test.go
+++ b/server/datastore/mysql/software_test.go
@@ -4391,7 +4391,7 @@ func testListHostSoftware(t *testing.T, ds *Datastore) {
 	darwinHost := test.NewHost(t, ds, "hostD", "", "hostDkey", "hostDuuid", time.Now(), test.WithPlatform("darwin"))
 	softwareAlreadyInstalled := fleet.Software{Name: "DummyApp.app", Version: "1.0.1", Source: "apps", BundleIdentifier: "com.example.dummy"}
 
-	// Host has software installed, but not by fleet, and there is no matching software installer.
+	// Host has software installed, but not by Fleet, and there is no matching software installer.
 	// Ensure it is not surfaced as "available for install" when filtering by `VulnerableOnly`
 	ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
 		res, err := q.ExecContext(ctx, `INSERT INTO software_titles (name, source, bundle_identifier) VALUES (?, ?, ?)`,


### PR DESCRIPTION
https://github.com/fleetdm/fleet/issues/28203

If software has not been installed on the host but has vulnerabilities it should not be returned when filtering by "VulnerableOnly"


- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [x] Added/updated automated tests
- [x] A detailed QA plan exists on the associated ticket (if it isn't there, work with the product group's QA engineer to add it)
- [x] Manual QA for all new/changed functionality
- [x] For unreleased bug fixes in a release candidate, confirmed that the fix is not expected to adversely impact load test results or alerted the release DRI if additional load testing is needed.
