### PR TITLE
fix showing add user button on user card on host details page

### DIFF
--- a/frontend/pages/hosts/details/DeviceUserPage/DeviceUserPage.tsx
+++ b/frontend/pages/hosts/details/DeviceUserPage/DeviceUserPage.tsx
@@ -16,7 +16,6 @@ import {
   IMacadminsResponse,
   IDeviceUserResponse,
   IHostDevice,
-  IHostEndUser,
 } from "interfaces/host";
 import { IListSort } from "interfaces/list_options";
 import { IHostPolicy } from "interfaces/policy";

--- a/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
@@ -966,7 +966,7 @@ const HostDetailsPage = ({
                   endUsers={host.end_users ?? []}
                   enableAddEndUser={
                     isDarwinHost &&
-                    generateUsernameValues(host.end_users ?? []).length !== 0
+                    generateUsernameValues(host.end_users ?? []).length === 0
                   }
                   onAddEndUser={() => setShowAddEndUserModal(true)}
                 />


### PR DESCRIPTION
correctly conditionally show the "add user" button on the users card on the host details page