### PR TITLE
FE: Remove explicit variant for default variant

### DIFF
--- a/frontend/pages/admin/IntegrationsPage/cards/ConditionalAccess/ConditionalAccess.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/ConditionalAccess/ConditionalAccess.tsx
@@ -315,7 +315,6 @@ const ConditionalAccess = () => {
             />
             <Button
               type="submit"
-              variant="brand"
               disabled={!!size(formErrors)}
               className="button-wrap"
               isLoading={isUpdating}

--- a/frontend/pages/policies/ManagePoliciesPage/components/ConditionalAccessModal/ConditionalAccessModal.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/components/ConditionalAccessModal/ConditionalAccessModal.tsx
@@ -78,7 +78,6 @@ const ConditionalAccessModal = ({
             renderChildren={(disableChildren) => (
               <Button
                 type="submit"
-                variant="brand"
                 disabled={disableChildren || !isAdmin}
                 className="button-wrap"
                 isLoading={isUpdating}
@@ -104,9 +103,7 @@ const ConditionalAccessModal = ({
       <br />
       {learnMoreLink}
       <div className="modal-cta-wrap">
-        <Button onClick={onExit} variant="brand">
-          Done
-        </Button>
+        <Button onClick={onExit}>Done</Button>
       </div>
     </>
   );


### PR DESCRIPTION
New buttons that got merged in 19 hours ago didn't get remove default variant and are erroing out because default variant was renamed from "brand" to "default"