### PR TITLE
Product groups handbook

### DIFF
--- a/handbook/engineering/README.md
+++ b/handbook/engineering/README.md
@@ -273,12 +273,12 @@ In these cases there are two differences in our pull request process:
 
 ### Notify stakeholders when a user story is pushed to the next release
 
-[User stories](https://fleetdm.com/handbook/company/product-groups#scrum-items) are intended to be completed in a single sprint. When a user story selected for a release has not merged into `main` by the time the release candidate is created, it is the product group EM's responsibility to notify stakeholders:
+[User stories](https://fleetdm.com/handbook/company/product-groups#scrum-items) are intended to be completed in a single sprint. When the EM suspects a user story is at risk for getting pushed, it is the product group EM's responsibility to notify stakeholders:
 
 1. Add the `~pushed` label to the user story.
 2. Update the user story's milestone to the next minor version milestone.
-3. Comment on the GitHub issue and at-mention the PM and anyone listed in the requester field.
-4. If `customer-` labels are applied to the user story, at-mention the [VP of Customer Success](https://fleetdm.com/handbook/customer-success#team).
+3. Comment on the GitHub issue and at-mention the Head of Product Design and anyone listed in the requester field.
+4. If `customer-` labels are applied to the user story, at-mention the [VP of Customer Success](https://fleetdm.com/handbook/customer-success#team) in the #g-mdm, #g-software, or #g-orchestration Slack channel.
 
 
 ### Run Fleet locally for QA purposes


### PR DESCRIPTION
- Notify stakeholders when we _think_ a story is going to be pushed. Changed from when we _know_ a story is going to be pushed. 
  - Why? So we can notify stakeholders sooner, give us the opportunity to discuss, and maybe re-prioritize.
