### PR TITLE
Update WLAN XML profile verification so they aren't resent

### DIFF
--- a/changes/24394-wlan-xml-profile-verification
+++ b/changes/24394-wlan-xml-profile-verification
@@ -1,0 +1,1 @@
+- Updated verification of Windows Wireless profiles to avoid resending already-applied profiles

--- a/orbit/pkg/table/mdm/mdm_windows.go
+++ b/orbit/pkg/table/mdm/mdm_windows.go
@@ -395,7 +395,7 @@ func executeMDMcommand(inputCMD string) (string, error) {
 	// confusion about the status of the call.
 	var outputStrBuffer *uint16
 	if returnCode, _, _ := procSendSyncMLcommand.Call(uintptr(unsafe.Pointer(&inputCmdPtr[0])), uintptr(unsafe.Pointer(&outputStrBuffer))); returnCode != uintptr(windows.ERROR_SUCCESS) {
-		return "", fmt.Errorf("there was an error calling ApplyLocalManagementSyncML(): (0x%X)", err, returnCode)
+		return "", fmt.Errorf("there was an error calling ApplyLocalManagementSyncML(): (0x%X)", returnCode)
 	}
 
 	// converting Windows MDM UTF16 output string into go string

--- a/server/mdm/microsoft/admx/admx_test.go
+++ b/server/mdm/microsoft/admx/admx_test.go
@@ -13,6 +13,37 @@ func TestIsADMX(t *testing.T) {
 	assert.False(t, IsADMX(`<![CDATA[bozo]]>`))
 	assert.False(t, IsADMX(`<![CDATA[<bozo/>]]>`))
 	assert.False(t, IsADMX(`<![CDATA[<bozo]]>`))
+
+	// This is a WLAN XML profile
+	assert.False(t, IsADMX(
+		`&lt;?xml version=&quot;1.0&quot;?&gt;
+&lt;WLANProfile xmlns=&quot;http://www.microsoft.com/networking/WLAN/profile/v1&quot;&gt;
+	&lt;name&gt;Test&lt;/name&gt;
+	&lt;SSIDConfig&gt;
+		&lt;SSID&gt;
+                    &lt;hex&gt;54657374&lt;/hex&gt;
+                    &lt;name&gt;Test&lt;/name&gt;
+                &lt;/SSID&gt;
+                &lt;nonBroadcast&gt;false&lt;/nonBroadcast&gt;
+	&lt;/SSIDConfig&gt;
+	&lt;connectionType&gt;ESS&lt;/connectionType&gt;
+	&lt;connectionMode&gt;auto&lt;/connectionMode&gt;
+	&lt;MSM&gt;
+		&lt;security&gt;
+			&lt;authEncryption&gt;
+				&lt;authentication&gt;WPA2PSK&lt;/authentication&gt;
+				&lt;encryption&gt;AES&lt;/encryption&gt;
+				&lt;useOneX&gt;false&lt;/useOneX&gt;
+			&lt;/authEncryption&gt;
+			&lt;sharedKey&gt;
+				&lt;keyType&gt;passPhrase&lt;/keyType&gt;
+				&lt;protected&gt;false&lt;/protected&gt;
+				&lt;keyMaterial&gt;sup3rs3cr3t&lt;/keyMaterial&gt;
+			&lt;/sharedKey&gt;
+		&lt;/security&gt;
+	&lt;/MSM&gt;
+&lt;/WLANProfile&gt;`))
+
 	assert.True(t, IsADMX(`<![CDATA[<enabled/>]]>`))
 	assert.True(t, IsADMX(`<![CDATA[<disabled/>]]>`))
 	assert.True(t, IsADMX(`<![CDATA[<data id="id" value="value"/>]]>`))

--- a/server/mdm/microsoft/syncml/syncml.go
+++ b/server/mdm/microsoft/syncml/syncml.go
@@ -317,18 +317,24 @@ const (
 	SyncMLVerProto = "DM/" + SyncMLSupportedVersion
 )
 
-func ForTestWithData(locURIs map[string]string) []byte {
+type TestCommand struct {
+	Verb   string
+	LocURI string
+	Data   string
+}
+
+func ForTestWithData(commands []TestCommand) []byte {
 	var syncMLBuf bytes.Buffer
-	for locURI, data := range locURIs {
+	for _, command := range commands {
 		syncMLBuf.WriteString(fmt.Sprintf(`
-<Replace>
+<%s>
   <Item>
     <Target>
       <LocURI>%s</LocURI>
     </Target>
     <Data>%s</Data>
   </Item>
-</Replace>`, locURI, data))
+</%s>`, command.Verb, command.LocURI, command.Data, command.Verb))
 	}
 	return syncMLBuf.Bytes()
 }

--- a/server/mdm/microsoft/wlanxml/wlanxml.go
+++ b/server/mdm/microsoft/wlanxml/wlanxml.go
@@ -87,21 +87,18 @@ type wlanXmlPolicySSIDPrefix struct {
 // Because of this we have opted for a simple comparison that ensures a profile matching
 // basic fields like name, SSID and (non-)broadcast status is considered equal.
 func (a wlanXmlPolicy) Equal(b wlanXmlPolicy) bool {
-	fmt.Printf("Comparing %s and %s\n", a.Name, b.Name)
 	if a.Name != b.Name {
 		return false
 	}
 
-	fmt.Printf("Comparing %t and %t\n", a.SSIDConfig.NonBroadcast, b.SSIDConfig.NonBroadcast)
 	if a.SSIDConfig.NonBroadcast != b.SSIDConfig.NonBroadcast {
 		return false
 	}
-	fmt.Printf("Comparing %s and %s\n", a.SSIDConfig.SSIDPrefix.Name, b.SSIDConfig.SSIDPrefix.Name)
+
 	if a.SSIDConfig.SSIDPrefix.Name != b.SSIDConfig.SSIDPrefix.Name {
 		return false
 	}
 
-	fmt.Printf("Comparing %d and %d\n", len(a.SSIDConfig.SSID), len(b.SSIDConfig.SSID))
 	if len(a.SSIDConfig.SSID) != len(b.SSIDConfig.SSID) {
 		return false
 	}
@@ -109,7 +106,6 @@ func (a wlanXmlPolicy) Equal(b wlanXmlPolicy) bool {
 	a.sortSSIDs()
 	b.sortSSIDs()
 	for i := range a.SSIDConfig.SSID {
-		fmt.Printf("Comparing %s %s and %s %s\n", a.SSIDConfig.SSID[i].Hex, a.SSIDConfig.SSID[i].Name, b.SSIDConfig.SSID[i].Hex, b.SSIDConfig.SSID[i].Name)
 		if !a.SSIDConfig.SSID[i].Equal(b.SSIDConfig.SSID[i]) {
 			return false
 		}

--- a/server/mdm/microsoft/wlanxml/wlanxml.go
+++ b/server/mdm/microsoft/wlanxml/wlanxml.go
@@ -61,11 +61,9 @@ type wlanXmlProfile struct {
 }
 
 type wlanXmlProfileSSIDConfig struct {
-	SSID []wlanXmlProfileSSID `xml:"SSID"`
-	// Note that this field is optional so if we ever do more inspection of these policies
-	// we likely need to
-	SSIDPrefix   wlanXmlProfileSSID `xml:"SSIDPrefix"`
-	NonBroadcast bool               `xml:"nonBroadcast"`
+	SSID         []wlanXmlProfileSSID `xml:"SSID"`
+	SSIDPrefix   wlanXmlProfileSSID   `xml:"SSIDPrefix"`
+	NonBroadcast bool                 `xml:"nonBroadcast"`
 }
 
 type wlanXmlProfileSSID struct {

--- a/server/mdm/microsoft/wlanxml/wlanxml.go
+++ b/server/mdm/microsoft/wlanxml/wlanxml.go
@@ -12,90 +12,84 @@ import (
 )
 
 func IsWLANXML(text string) bool {
-	// We try to unmarshal the string to see if it looks like a valid WLAN XML policy
+	// We try to unmarshal the string to see if it looks like a valid WLAN XML profile
 	_, err := unmarshal(text)
-	if err != nil {
-		return false
-	}
-	return true
+	return err == nil
 }
 
 func Equal(a, b string) (bool, error) {
-	aPolicy, err := unmarshal(a)
+	aProfile, err := unmarshal(a)
 	if err != nil {
-		return false, fmt.Errorf("unmarshalling WLAN XML policy a: %w", err)
+		return false, fmt.Errorf("unmarshalling WLAN XML profile a: %w", err)
 	}
-	bPolicy, err := unmarshal(b)
+	bProfile, err := unmarshal(b)
 	if err != nil {
-		return false, fmt.Errorf("unmarshalling WLAN XML policy b: %w", err)
+		return false, fmt.Errorf("unmarshalling WLAN XML profile b: %w", err)
 	}
-	return aPolicy.Equal(bPolicy), nil
+	return aProfile.Equal(bProfile), nil
 }
 
-func unmarshal(a string) (wlanXmlPolicy, error) {
+func unmarshal(w string) (wlanXmlProfile, error) {
 	// This whole thing will be XML Encoded so step 1 is just to decode it
 	var unescaped string
-	err := xml.Unmarshal([]byte("<wlanxml>"+a+"</wlanxml>"), &unescaped)
+	err := xml.Unmarshal([]byte("<wlanxml>"+w+"</wlanxml>"), &unescaped)
 	if err != nil {
-		return wlanXmlPolicy{}, fmt.Errorf("unmarshalling WLAN XML policy to string: %w", err)
+		return wlanXmlProfile{}, fmt.Errorf("unmarshalling WLAN XML profile to string: %w", err)
 	}
 
-	var policy wlanXmlPolicy
-	err = xml.Unmarshal([]byte(unescaped), &policy)
+	var profile wlanXmlProfile
+	err = xml.Unmarshal([]byte(unescaped), &profile)
 	if err != nil {
-		return wlanXmlPolicy{}, fmt.Errorf("unmarshalling WLAN XML policy: %w", err)
+		return wlanXmlProfile{}, fmt.Errorf("unmarshalling WLAN XML profile: %w", err)
 	}
-	if policy.XMLName.Local != "WLANProfile" {
-		return wlanXmlPolicy{}, fmt.Errorf("unmarshalling WLAN XML policy: expected <WLANProfile> tag, got <%s>", policy.XMLName.Local)
+	if profile.XMLName.Local != "WLANProfile" {
+		return wlanXmlProfile{}, fmt.Errorf("unmarshalling WLAN XML profile: expected <WLANProfile> tag, got <%s>", profile.XMLName.Local)
 	}
 
-	// Much of the policy settings are case sensitive however the hex representation of the SSID is not and
-	// in some cases Windows converts it to uppercase when writing a policy to the system which was provided
-	// with uppercase alpha characters.
-	for i := 0; i < len(policy.SSIDConfig.SSID); i++ {
-		policy.SSIDConfig.SSID[i].normalize()
+	for i := 0; i < len(profile.SSIDConfig.SSID); i++ {
+		profile.SSIDConfig.SSID[i].normalize()
 	}
-	policy.SSIDConfig.SSIDPrefix.normalize()
+	profile.SSIDConfig.SSIDPrefix.normalize()
 
-	return policy, nil
+	return profile, nil
 }
 
-type wlanXmlPolicy struct {
+type wlanXmlProfile struct {
 	XMLName    xml.Name
-	Name       string                  `xml:"name"`
-	SSIDConfig wlanXmlPolicySSIDConfig `xml:"SSIDConfig"`
+	Name       string                   `xml:"name"`
+	SSIDConfig wlanXmlProfileSSIDConfig `xml:"SSIDConfig"`
 }
 
-type wlanXmlPolicySSIDConfig struct {
-	SSID []wlanXmlPolicySSID `xml:"SSID"`
+type wlanXmlProfileSSIDConfig struct {
+	SSID []wlanXmlProfileSSID `xml:"SSID"`
 	// Note that this field is optional so if we ever do more inspection of these policies
 	// we likely need to
-	SSIDPrefix   wlanXmlPolicySSID `xml:"SSIDPrefix"`
-	NonBroadcast bool              `xml:"nonBroadcast"`
+	SSIDPrefix   wlanXmlProfileSSID `xml:"SSIDPrefix"`
+	NonBroadcast bool               `xml:"nonBroadcast"`
 }
 
-type wlanXmlPolicySSID struct {
+type wlanXmlProfileSSID struct {
 	Hex  string `xml:"hex"`
 	Name string `xml:"name"`
 }
 
-func (s *wlanXmlPolicySSID) normalize() {
+func (s *wlanXmlProfileSSID) normalize() {
 	// Microsoft's documentation says that the hex representation overrides the Name when both are
-	// present. In testing, if a policy is provided with only the Name and not the hex
-	// representation, Microsoft generates Hex and it is present in the policy returned. As such we
+	// present. In testing, if a profile is provided with only the Name and not the hex
+	// representation, Microsoft generates Hex and it is present in the profile returned. As such we
 	// will convert name to hex on the way in for use in comparisons
 	if s.Hex == "" && s.Name != "" {
 		s.Hex = fmt.Sprintf("%x", s.Name)
 	}
 
-	// Most of the policy settings are case sensitive however the hex representation of the SSID is not and
-	// in some cases Windows converts it to uppercase when writing a policy to the system which was provided
+	// Most of the profile settings are case sensitive however the hex representation of the SSID is not and
+	// in some cases Windows converts it to uppercase when writing a profile to the system which was provided
 	// with uppercase alpha characters.
 	s.Hex = strings.ToUpper(s.Hex)
 }
 
-func (a wlanXmlPolicySSID) Equal(b wlanXmlPolicySSID) bool {
-	return a.Hex == b.Hex
+func (s wlanXmlProfileSSID) Equal(b wlanXmlProfileSSID) bool {
+	return s.Hex == b.Hex
 }
 
 // We have seen cases where Windows will "upgrade" a profile based on what it sees when it actually
@@ -104,7 +98,7 @@ func (a wlanXmlPolicySSID) Equal(b wlanXmlPolicySSID) bool {
 // the device. This behavior is undocumented but precludes comparing profiles too strictly.
 // Because of this we have opted for a simple comparison that ensures a profile matching
 // basic fields like name, SSID and (non-)broadcast status is considered equal.
-func (a wlanXmlPolicy) Equal(b wlanXmlPolicy) bool {
+func (a wlanXmlProfile) Equal(b wlanXmlProfile) bool {
 	if a.Name != b.Name {
 		return false
 	}
@@ -132,8 +126,8 @@ func (a wlanXmlPolicy) Equal(b wlanXmlPolicy) bool {
 }
 
 // a profile may have multiple SSIDs.
-func (a *wlanXmlPolicy) sortSSIDs() {
-	slices.SortFunc(a.SSIDConfig.SSID, func(i, j wlanXmlPolicySSID) int {
+func (a *wlanXmlProfile) sortSSIDs() {
+	slices.SortFunc(a.SSIDConfig.SSID, func(i, j wlanXmlProfileSSID) int {
 		return strings.Compare(i.Hex, j.Hex)
 	})
 }

--- a/server/mdm/microsoft/wlanxml/wlanxml.go
+++ b/server/mdm/microsoft/wlanxml/wlanxml.go
@@ -1,0 +1,131 @@
+// Package wlanxml handles WLAN Profiles for Microsoft MDM server.
+// See: https://learn.microsoft.com/en-us/windows/win32/nativewifi/wlan-profileschema-schema
+// for samples: https://learn.microsoft.com/en-us/windows/win32/nativewifi/wireless-profile-samples
+// finally for multi-SSID uses: https://learn.microsoft.com/en-us/windows-hardware/drivers/mobilebroadband/handling-large-numbers-of-ssids
+package wlanxml
+
+import (
+	"encoding/xml"
+	"fmt"
+	"slices"
+	"strings"
+)
+
+func IsWLANXML(text string) bool {
+	// We try to unmarshal the string to see if it looks like a valid WLAN XML policy
+	_, err := unmarshal(text)
+	if err != nil {
+		return false
+	}
+	return true
+}
+
+func Equal(a, b string) (bool, error) {
+	aPolicy, err := unmarshal(a)
+	if err != nil {
+		return false, fmt.Errorf("unmarshalling WLAN XML policy a: %w", err)
+	}
+	bPolicy, err := unmarshal(b)
+	if err != nil {
+		return false, fmt.Errorf("unmarshalling WLAN XML policy b: %w", err)
+	}
+	return aPolicy.Equal(bPolicy), nil
+}
+
+func unmarshal(a string) (wlanXmlPolicy, error) {
+	// This whole thing will be XML Encoded so step 1 is just to decode it
+	var unescaped string
+	err := xml.Unmarshal([]byte("<wlanxml>"+a+"</wlanxml>"), &unescaped)
+	if err != nil {
+		return wlanXmlPolicy{}, fmt.Errorf("unmarshalling WLAN XML policy to string: %w", err)
+	}
+
+	var policy wlanXmlPolicy
+	err = xml.Unmarshal([]byte(unescaped), &policy)
+	if err != nil {
+		return wlanXmlPolicy{}, fmt.Errorf("unmarshalling WLAN XML policy: %w", err)
+	}
+	if policy.XMLName.Local != "WLANProfile" {
+		return wlanXmlPolicy{}, fmt.Errorf("unmarshalling WLAN XML policy: expected <WLANProfile> tag, got <%s>", policy.XMLName.Local)
+	}
+
+	// Much of the policy settings are case sensitive however the hex representation of the SSID is not and
+	// in some cases Windows seems to convert it to lowercase when writing the policy to the system
+	for i := 0; i < len(policy.SSIDConfig.SSID); i++ {
+		policy.SSIDConfig.SSID[i].Hex = strings.ToLower(policy.SSIDConfig.SSID[i].Hex)
+	}
+	return policy, nil
+}
+
+type wlanXmlPolicy struct {
+	XMLName    xml.Name
+	Name       string                  `xml:"name"`
+	SSIDConfig wlanXmlPolicySSIDConfig `xml:"SSIDConfig"`
+}
+
+type wlanXmlPolicySSIDConfig struct {
+	SSID []wlanXmlPolicySSID `xml:"SSID"`
+	// Note that this field is optional so if we ever do more inspection of these policies
+	// we likely need to
+	SSIDPrefix   wlanXmlPolicySSIDPrefix `xml:"SSIDPrefix"`
+	NonBroadcast bool                    `xml:"nonBroadcast"`
+}
+
+type wlanXmlPolicySSID struct {
+	Hex  string `xml:"hex"`
+	Name string `xml:"name"`
+}
+
+type wlanXmlPolicySSIDPrefix struct {
+	Name string `xml:"name"`
+}
+
+// We have seen cases where Windows will "upgrade" a profile based on what it sees when it actually
+// connects to a network, for instance if a profile specifies WPA2 but the interface and network
+// support WPA3 it will "upgrade" the profile to WPA3 and that is what gets returned when querying
+// the device. This behavior is undocumented but precludes comparing profiles too strictly.
+// Because of this we have opted for a simple comparison that ensures a profile matching
+// basic fields like name, SSID and (non-)broadcast status is considered equal.
+func (a wlanXmlPolicy) Equal(b wlanXmlPolicy) bool {
+	fmt.Printf("Comparing %s and %s\n", a.Name, b.Name)
+	if a.Name != b.Name {
+		return false
+	}
+
+	fmt.Printf("Comparing %t and %t\n", a.SSIDConfig.NonBroadcast, b.SSIDConfig.NonBroadcast)
+	if a.SSIDConfig.NonBroadcast != b.SSIDConfig.NonBroadcast {
+		return false
+	}
+	fmt.Printf("Comparing %s and %s\n", a.SSIDConfig.SSIDPrefix.Name, b.SSIDConfig.SSIDPrefix.Name)
+	if a.SSIDConfig.SSIDPrefix.Name != b.SSIDConfig.SSIDPrefix.Name {
+		return false
+	}
+
+	fmt.Printf("Comparing %d and %d\n", len(a.SSIDConfig.SSID), len(b.SSIDConfig.SSID))
+	if len(a.SSIDConfig.SSID) != len(b.SSIDConfig.SSID) {
+		return false
+	}
+
+	a.sortSSIDs()
+	b.sortSSIDs()
+	for i := range a.SSIDConfig.SSID {
+		fmt.Printf("Comparing %s %s and %s %s\n", a.SSIDConfig.SSID[i].Hex, a.SSIDConfig.SSID[i].Name, b.SSIDConfig.SSID[i].Hex, b.SSIDConfig.SSID[i].Name)
+		if !a.SSIDConfig.SSID[i].Equal(b.SSIDConfig.SSID[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+func (a *wlanXmlPolicy) sortSSIDs() {
+	slices.SortFunc(a.SSIDConfig.SSID, func(i, j wlanXmlPolicySSID) int {
+		if i.Hex == j.Hex {
+			return strings.Compare(i.Name, j.Name)
+		}
+		return strings.Compare(i.Hex, j.Hex)
+	})
+}
+
+func (a wlanXmlPolicySSID) Equal(b wlanXmlPolicySSID) bool {
+	return a.Hex == b.Hex && a.Name == b.Name
+}

--- a/server/mdm/microsoft/wlanxml/wlanxml_test.go
+++ b/server/mdm/microsoft/wlanxml/wlanxml_test.go
@@ -207,7 +207,7 @@ func TestEqual(t *testing.T) {
 		equal                     bool
 	}{
 		{
-			name:          "empty policies",
+			name:          "empty profiles",
 			a:             "",
 			b:             "",
 			equal:         false,
@@ -228,42 +228,42 @@ func TestEqual(t *testing.T) {
 			errorContains: "unmarshalling WLAN XML profile",
 		},
 		{
-			name:          "equal policies",
+			name:          "equal profiles",
 			a:             xmlEncodedProfile1,
 			b:             xmlEncodedProfile1,
 			equal:         true,
 			errorContains: "",
 		},
 		{
-			name:          "equal policies but different SSID order",
+			name:          "equal profiles but different SSID order",
 			a:             xmlEncodedProfile3,
 			b:             xmlEncodedProfile3SortVariant,
 			equal:         true,
 			errorContains: "",
 		},
 		{
-			name:          "equal policies but different SSID order - swapped invocation order",
+			name:          "equal profiles but different SSID order - swapped invocation order",
 			a:             xmlEncodedProfile3SortVariant,
 			b:             xmlEncodedProfile3,
 			equal:         true,
 			errorContains: "",
 		},
 		{
-			name:          "equal policies but SSIDs as hex for one",
+			name:          "equal profiles but SSIDs as hex for one",
 			a:             xmlEncodedProfile3,
 			b:             xmlEncodedProfile3HexVariant,
 			equal:         true,
 			errorContains: "",
 		},
 		{
-			name:          "different policies",
+			name:          "different profiles",
 			a:             xmlEncodedProfile1,
 			b:             xmlEncodedProfile2,
 			equal:         false,
 			errorContains: "",
 		},
 		{
-			name:          "similar policies with different SSID prefix settings",
+			name:          "similar profiles with different SSID prefix settings",
 			a:             xmlEncodedProfile3,
 			b:             xmlEncodedProfile4,
 			equal:         false,

--- a/server/mdm/microsoft/wlanxml/wlanxml_test.go
+++ b/server/mdm/microsoft/wlanxml/wlanxml_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 const (
-	// Policy 1 is a pretty simple single SSID policy
+	// Policy 1 is a simple single SSID policy
 	xmlEncodedPolicy1 = `&lt;?xml version=&quot;1.0&quot;?&gt;
 &lt;WLANProfile xmlns=&quot;http://www.microsoft.com/networking/WLAN/profile/v1&quot;&gt;
 	&lt;name&gt;Test&lt;/name&gt;
@@ -91,7 +91,8 @@ const (
   &lt;/MSM&gt;
 &lt;/WLANProfile&gt;`
 
-	xmlEncodedPolicy3Variant = `&lt;WLANProfile xmlns=&quot;http://www.microsoft.com/networking/CarrierControl/WLAN/v1&quot;
+	// An equal variant of policy 3 with SSID order swapped
+	xmlEncodedPolicy3SortVariant = `&lt;WLANProfile xmlns=&quot;http://www.microsoft.com/networking/CarrierControl/WLAN/v1&quot;
              xmlns:v2=&quot;http://www.microsoft.com/networking/CarrierControl/WLAN/v2&quot;&gt;
   &lt;name&gt;SampleProfile&lt;/name&gt;
   &lt;SSIDConfig&gt;
@@ -103,6 +104,58 @@ const (
     &lt;/SSID&gt;
     &lt;v2:SSIDPrefix&gt;
         &lt;v2:name&gt;MySSIDPrefix&lt;/v2:name&gt;
+    &lt;/v2:SSIDPrefix&gt;
+  &lt;/SSIDConfig&gt;
+  &lt;MSM&gt;
+    &lt;security&gt;
+        &lt;authEncryption&gt;
+            &lt;authentication&gt;open&lt;/authentication&gt;
+            &lt;encryption&gt;none&lt;/encryption&gt;
+            &lt;useOneX&gt;false&lt;/useOneX&gt;
+        &lt;/authEncryption&gt;
+    &lt;/security&gt;
+  &lt;/MSM&gt;
+&lt;/WLANProfile&gt;`
+
+	// an equal variant of policy 3 with Hex SSIDs in lieu of names
+	xmlEncodedPolicy3HexVariant = `&lt;WLANProfile xmlns=&quot;http://www.microsoft.com/networking/CarrierControl/WLAN/v1&quot;
+             xmlns:v2=&quot;http://www.microsoft.com/networking/CarrierControl/WLAN/v2&quot;&gt;
+  &lt;name&gt;SampleProfile&lt;/name&gt;
+  &lt;SSIDConfig&gt;
+    &lt;SSID&gt;
+        &lt;hex&gt;4d795353494431&lt;/hex&gt;
+    &lt;/SSID&gt;
+    &lt;v2:SSID&gt;
+        &lt;v2:hex&gt;4d795353494432&lt;/v2:hex&gt;
+    &lt;/v2:SSID&gt;
+    &lt;v2:SSIDPrefix&gt;
+        &lt;v2:hex&gt;4d7953534944507265666978&lt;/v2:hex&gt;
+    &lt;/v2:SSIDPrefix&gt;
+  &lt;/SSIDConfig&gt;
+  &lt;MSM&gt;
+    &lt;security&gt;
+        &lt;authEncryption&gt;
+            &lt;authentication&gt;open&lt;/authentication&gt;
+            &lt;encryption&gt;none&lt;/encryption&gt;
+            &lt;useOneX&gt;false&lt;/useOneX&gt;
+        &lt;/authEncryption&gt;
+    &lt;/security&gt;
+  &lt;/MSM&gt;
+&lt;/WLANProfile&gt;`
+
+	// Policy 4 is a variant of policy 3 with a different prefix
+	xmlEncodedPolicy4 = `&lt;WLANProfile xmlns=&quot;http://www.microsoft.com/networking/CarrierControl/WLAN/v1&quot;
+             xmlns:v2=&quot;http://www.microsoft.com/networking/CarrierControl/WLAN/v2&quot;&gt;
+  &lt;name&gt;SampleProfile&lt;/name&gt;
+  &lt;SSIDConfig&gt;
+    &lt;SSID&gt;
+        &lt;name&gt;MySSID1&lt;/name&gt;
+    &lt;/SSID&gt;
+    &lt;v2:SSID&gt;
+        &lt;v2:name&gt;MySSID2&lt;/v2:name&gt;
+    &lt;/v2:SSID&gt;
+    &lt;v2:SSIDPrefix&gt;
+        &lt;v2:name&gt;MyOtherSSIDPrefix&lt;/v2:name&gt;
     &lt;/v2:SSIDPrefix&gt;
   &lt;/SSIDConfig&gt;
   &lt;MSM&gt;
@@ -184,14 +237,21 @@ func TestEqual(t *testing.T) {
 		{
 			name:          "equal policies but different SSID order",
 			a:             xmlEncodedPolicy3,
-			b:             xmlEncodedPolicy3Variant,
+			b:             xmlEncodedPolicy3SortVariant,
 			equal:         true,
 			errorContains: "",
 		},
 		{
 			name:          "equal policies but different SSID order - swapped invocation order",
-			a:             xmlEncodedPolicy3Variant,
+			a:             xmlEncodedPolicy3SortVariant,
 			b:             xmlEncodedPolicy3,
+			equal:         true,
+			errorContains: "",
+		},
+		{
+			name:          "equal policies but SSIDs as hex for one",
+			a:             xmlEncodedPolicy3,
+			b:             xmlEncodedPolicy3HexVariant,
 			equal:         true,
 			errorContains: "",
 		},
@@ -199,6 +259,13 @@ func TestEqual(t *testing.T) {
 			name:          "different policies",
 			a:             xmlEncodedPolicy1,
 			b:             xmlEncodedPolicy2,
+			equal:         false,
+			errorContains: "",
+		},
+		{
+			name:          "similar policies with different SSID prefix settings",
+			a:             xmlEncodedPolicy3,
+			b:             xmlEncodedPolicy4,
 			equal:         false,
 			errorContains: "",
 		},

--- a/server/mdm/microsoft/wlanxml/wlanxml_test.go
+++ b/server/mdm/microsoft/wlanxml/wlanxml_test.go
@@ -7,8 +7,8 @@ import (
 )
 
 const (
-	// Policy 1 is a simple single SSID policy
-	xmlEncodedPolicy1 = `&lt;?xml version=&quot;1.0&quot;?&gt;
+	// Profile 1 is a simple single SSID profile
+	xmlEncodedProfile1 = `&lt;?xml version=&quot;1.0&quot;?&gt;
 &lt;WLANProfile xmlns=&quot;http://www.microsoft.com/networking/WLAN/profile/v1&quot;&gt;
 	&lt;name&gt;Test&lt;/name&gt;
 	&lt;SSIDConfig&gt;
@@ -36,8 +36,8 @@ const (
 	&lt;/MSM&gt;
 &lt;/WLANProfile&gt;`
 
-	// Policy 2 is a variant of policy 1 with a non-broadcast SSID
-	xmlEncodedPolicy2 = `&lt;?xml version=&quot;1.0&quot;?&gt;
+	// Profile 2 is a variant of profile 1 with a non-broadcast SSID
+	xmlEncodedProfile2 = `&lt;?xml version=&quot;1.0&quot;?&gt;
 &lt;WLANProfile xmlns=&quot;http://www.microsoft.com/networking/WLAN/profile/v1&quot;&gt;
 	&lt;name&gt;Test&lt;/name&gt;
 	&lt;SSIDConfig&gt;
@@ -65,8 +65,8 @@ const (
 	&lt;/MSM&gt;
 &lt;/WLANProfile&gt;`
 
-	// Policy 3 is a more complex policy with multiple SSIDs
-	xmlEncodedPolicy3 = `&lt;WLANProfile xmlns=&quot;http://www.microsoft.com/networking/CarrierControl/WLAN/v1&quot;
+	// Profile 3 is a more complex profile with multiple SSIDs
+	xmlEncodedProfile3 = `&lt;WLANProfile xmlns=&quot;http://www.microsoft.com/networking/CarrierControl/WLAN/v1&quot;
              xmlns:v2=&quot;http://www.microsoft.com/networking/CarrierControl/WLAN/v2&quot;&gt;
   &lt;name&gt;SampleProfile&lt;/name&gt;
   &lt;SSIDConfig&gt;
@@ -91,8 +91,8 @@ const (
   &lt;/MSM&gt;
 &lt;/WLANProfile&gt;`
 
-	// An equal variant of policy 3 with SSID order swapped
-	xmlEncodedPolicy3SortVariant = `&lt;WLANProfile xmlns=&quot;http://www.microsoft.com/networking/CarrierControl/WLAN/v1&quot;
+	// An equal variant of profile 3 with SSID order swapped
+	xmlEncodedProfile3SortVariant = `&lt;WLANProfile xmlns=&quot;http://www.microsoft.com/networking/CarrierControl/WLAN/v1&quot;
              xmlns:v2=&quot;http://www.microsoft.com/networking/CarrierControl/WLAN/v2&quot;&gt;
   &lt;name&gt;SampleProfile&lt;/name&gt;
   &lt;SSIDConfig&gt;
@@ -117,8 +117,8 @@ const (
   &lt;/MSM&gt;
 &lt;/WLANProfile&gt;`
 
-	// an equal variant of policy 3 with Hex SSIDs in lieu of names
-	xmlEncodedPolicy3HexVariant = `&lt;WLANProfile xmlns=&quot;http://www.microsoft.com/networking/CarrierControl/WLAN/v1&quot;
+	// An equal variant of profile 3 with Hex SSIDs in lieu of names
+	xmlEncodedProfile3HexVariant = `&lt;WLANProfile xmlns=&quot;http://www.microsoft.com/networking/CarrierControl/WLAN/v1&quot;
              xmlns:v2=&quot;http://www.microsoft.com/networking/CarrierControl/WLAN/v2&quot;&gt;
   &lt;name&gt;SampleProfile&lt;/name&gt;
   &lt;SSIDConfig&gt;
@@ -143,8 +143,8 @@ const (
   &lt;/MSM&gt;
 &lt;/WLANProfile&gt;`
 
-	// Policy 4 is a variant of policy 3 with a different prefix
-	xmlEncodedPolicy4 = `&lt;WLANProfile xmlns=&quot;http://www.microsoft.com/networking/CarrierControl/WLAN/v1&quot;
+	// Profile 4 is a variant of profile 3 with a different prefix
+	xmlEncodedProfile4 = `&lt;WLANProfile xmlns=&quot;http://www.microsoft.com/networking/CarrierControl/WLAN/v1&quot;
              xmlns:v2=&quot;http://www.microsoft.com/networking/CarrierControl/WLAN/v2&quot;&gt;
   &lt;name&gt;SampleProfile&lt;/name&gt;
   &lt;SSIDConfig&gt;
@@ -180,12 +180,12 @@ const (
 func TestIsWLANXML(t *testing.T) {
 	t.Parallel()
 	assert.False(t, IsWLANXML(""))
-	assert.False(t, IsWLANXML("not a policy"))
+	assert.False(t, IsWLANXML("not a profile"))
 	assert.False(t, IsWLANXML(`<![CDATA[bozo]]>`))
 	assert.False(t, IsWLANXML(`<![CDATA[<bozo/>]]>`))
 	assert.False(t, IsWLANXML(`<![CDATA[<bozo]]>`))
 
-	// These are all valid ADMX policies but not WLAN XML policies
+	// These are all valid ADMX policies but not WLAN XML profiles
 	assert.False(t, IsWLANXML(`<![CDATA[<enabled/>]]>`))
 	assert.False(t, IsWLANXML(`<![CDATA[<disabled/>]]>`))
 	assert.False(t, IsWLANXML(`<![CDATA[<data id="id" value="value"/>]]>`))
@@ -197,7 +197,7 @@ func TestIsWLANXML(t *testing.T) {
 		IsWLANXML("&lt;Enabled/&gt;&lt;Data id=\"EnableScriptBlockInvocationLogging\" value=\"true\"/&gt;&lt;Data id=\"ExecutionPolicy\" value=\"AllSigned\"/&gt;&lt;Data id=\"Listbox_ModuleNames\" value=\"*\"/&gt;&lt;Data id=\"OutputDirectory\" value=\"false\"/&gt;&lt;Data id=\"SourcePathForUpdateHelp\" value=\"false\"/&gt;"))
 	assert.False(t, IsWLANXML(admxPolicy))
 
-	assert.True(t, IsWLANXML(xmlEncodedPolicy1))
+	assert.True(t, IsWLANXML(xmlEncodedProfile1))
 }
 
 func TestEqual(t *testing.T) {
@@ -211,61 +211,61 @@ func TestEqual(t *testing.T) {
 			a:             "",
 			b:             "",
 			equal:         false,
-			errorContains: "unmarshalling WLAN XML policy",
+			errorContains: "unmarshalling WLAN XML profile",
 		},
 		{
 			name:          "a is an ADMX policy",
 			a:             admxPolicy,
-			b:             xmlEncodedPolicy1,
+			b:             xmlEncodedProfile1,
 			equal:         false,
-			errorContains: "unmarshalling WLAN XML policy",
+			errorContains: "unmarshalling WLAN XML profile",
 		},
 		{
 			name:          "b is an ADMX policy",
-			a:             xmlEncodedPolicy1,
+			a:             xmlEncodedProfile1,
 			b:             admxPolicy,
 			equal:         false,
-			errorContains: "unmarshalling WLAN XML policy",
+			errorContains: "unmarshalling WLAN XML profile",
 		},
 		{
 			name:          "equal policies",
-			a:             xmlEncodedPolicy1,
-			b:             xmlEncodedPolicy1,
+			a:             xmlEncodedProfile1,
+			b:             xmlEncodedProfile1,
 			equal:         true,
 			errorContains: "",
 		},
 		{
 			name:          "equal policies but different SSID order",
-			a:             xmlEncodedPolicy3,
-			b:             xmlEncodedPolicy3SortVariant,
+			a:             xmlEncodedProfile3,
+			b:             xmlEncodedProfile3SortVariant,
 			equal:         true,
 			errorContains: "",
 		},
 		{
 			name:          "equal policies but different SSID order - swapped invocation order",
-			a:             xmlEncodedPolicy3SortVariant,
-			b:             xmlEncodedPolicy3,
+			a:             xmlEncodedProfile3SortVariant,
+			b:             xmlEncodedProfile3,
 			equal:         true,
 			errorContains: "",
 		},
 		{
 			name:          "equal policies but SSIDs as hex for one",
-			a:             xmlEncodedPolicy3,
-			b:             xmlEncodedPolicy3HexVariant,
+			a:             xmlEncodedProfile3,
+			b:             xmlEncodedProfile3HexVariant,
 			equal:         true,
 			errorContains: "",
 		},
 		{
 			name:          "different policies",
-			a:             xmlEncodedPolicy1,
-			b:             xmlEncodedPolicy2,
+			a:             xmlEncodedProfile1,
+			b:             xmlEncodedProfile2,
 			equal:         false,
 			errorContains: "",
 		},
 		{
 			name:          "similar policies with different SSID prefix settings",
-			a:             xmlEncodedPolicy3,
-			b:             xmlEncodedPolicy4,
+			a:             xmlEncodedProfile3,
+			b:             xmlEncodedProfile4,
 			equal:         false,
 			errorContains: "",
 		},

--- a/server/mdm/microsoft/wlanxml/wlanxml_test.go
+++ b/server/mdm/microsoft/wlanxml/wlanxml_test.go
@@ -1,0 +1,217 @@
+package wlanxml
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	// Policy 1 is a pretty simple single SSID policy
+	xmlEncodedPolicy1 = `&lt;?xml version=&quot;1.0&quot;?&gt;
+&lt;WLANProfile xmlns=&quot;http://www.microsoft.com/networking/WLAN/profile/v1&quot;&gt;
+	&lt;name&gt;Test&lt;/name&gt;
+	&lt;SSIDConfig&gt;
+		&lt;SSID&gt;
+                    &lt;hex&gt;54657374&lt;/hex&gt;
+                    &lt;name&gt;Test&lt;/name&gt;
+                &lt;/SSID&gt;
+                &lt;nonBroadcast&gt;false&lt;/nonBroadcast&gt;
+	&lt;/SSIDConfig&gt;
+	&lt;connectionType&gt;ESS&lt;/connectionType&gt;
+	&lt;connectionMode&gt;auto&lt;/connectionMode&gt;
+	&lt;MSM&gt;
+		&lt;security&gt;
+			&lt;authEncryption&gt;
+				&lt;authentication&gt;WPA2PSK&lt;/authentication&gt;
+				&lt;encryption&gt;AES&lt;/encryption&gt;
+				&lt;useOneX&gt;false&lt;/useOneX&gt;
+			&lt;/authEncryption&gt;
+			&lt;sharedKey&gt;
+				&lt;keyType&gt;passPhrase&lt;/keyType&gt;
+				&lt;protected&gt;false&lt;/protected&gt;
+				&lt;keyMaterial&gt;sup3rs3cr3t&lt;/keyMaterial&gt;
+			&lt;/sharedKey&gt;
+		&lt;/security&gt;
+	&lt;/MSM&gt;
+&lt;/WLANProfile&gt;`
+
+	// Policy 2 is a variant of policy 1 with a non-broadcast SSID
+	xmlEncodedPolicy2 = `&lt;?xml version=&quot;1.0&quot;?&gt;
+&lt;WLANProfile xmlns=&quot;http://www.microsoft.com/networking/WLAN/profile/v1&quot;&gt;
+	&lt;name&gt;Test&lt;/name&gt;
+	&lt;SSIDConfig&gt;
+		&lt;SSID&gt;
+                    &lt;hex&gt;54657374&lt;/hex&gt;
+                    &lt;name&gt;Test&lt;/name&gt;
+                &lt;/SSID&gt;
+                &lt;nonBroadcast&gt;true&lt;/nonBroadcast&gt;
+	&lt;/SSIDConfig&gt;
+	&lt;connectionType&gt;ESS&lt;/connectionType&gt;
+	&lt;connectionMode&gt;auto&lt;/connectionMode&gt;
+	&lt;MSM&gt;
+		&lt;security&gt;
+			&lt;authEncryption&gt;
+				&lt;authentication&gt;WPA2PSK&lt;/authentication&gt;
+				&lt;encryption&gt;AES&lt;/encryption&gt;
+				&lt;useOneX&gt;false&lt;/useOneX&gt;
+			&lt;/authEncryption&gt;
+			&lt;sharedKey&gt;
+				&lt;keyType&gt;passPhrase&lt;/keyType&gt;
+				&lt;protected&gt;false&lt;/protected&gt;
+				&lt;keyMaterial&gt;sup3rs3cr3t&lt;/keyMaterial&gt;
+			&lt;/sharedKey&gt;
+		&lt;/security&gt;
+	&lt;/MSM&gt;
+&lt;/WLANProfile&gt;`
+
+	// Policy 3 is a more complex policy with multiple SSIDs
+	xmlEncodedPolicy3 = `&lt;WLANProfile xmlns=&quot;http://www.microsoft.com/networking/CarrierControl/WLAN/v1&quot;
+             xmlns:v2=&quot;http://www.microsoft.com/networking/CarrierControl/WLAN/v2&quot;&gt;
+  &lt;name&gt;SampleProfile&lt;/name&gt;
+  &lt;SSIDConfig&gt;
+    &lt;SSID&gt;
+        &lt;name&gt;MySSID1&lt;/name&gt;
+    &lt;/SSID&gt;
+    &lt;v2:SSID&gt;
+        &lt;v2:name&gt;MySSID2&lt;/v2:name&gt;
+    &lt;/v2:SSID&gt;
+    &lt;v2:SSIDPrefix&gt;
+        &lt;v2:name&gt;MySSIDPrefix&lt;/v2:name&gt;
+    &lt;/v2:SSIDPrefix&gt;
+  &lt;/SSIDConfig&gt;
+  &lt;MSM&gt;
+    &lt;security&gt;
+        &lt;authEncryption&gt;
+            &lt;authentication&gt;open&lt;/authentication&gt;
+            &lt;encryption&gt;none&lt;/encryption&gt;
+            &lt;useOneX&gt;false&lt;/useOneX&gt;
+        &lt;/authEncryption&gt;
+    &lt;/security&gt;
+  &lt;/MSM&gt;
+&lt;/WLANProfile&gt;`
+
+	xmlEncodedPolicy3Variant = `&lt;WLANProfile xmlns=&quot;http://www.microsoft.com/networking/CarrierControl/WLAN/v1&quot;
+             xmlns:v2=&quot;http://www.microsoft.com/networking/CarrierControl/WLAN/v2&quot;&gt;
+  &lt;name&gt;SampleProfile&lt;/name&gt;
+  &lt;SSIDConfig&gt;
+    &lt;v2:SSID&gt;
+        &lt;v2:name&gt;MySSID2&lt;/v2:name&gt;
+    &lt;/v2:SSID&gt;
+    &lt;SSID&gt;
+        &lt;name&gt;MySSID1&lt;/name&gt;
+    &lt;/SSID&gt;
+    &lt;v2:SSIDPrefix&gt;
+        &lt;v2:name&gt;MySSIDPrefix&lt;/v2:name&gt;
+    &lt;/v2:SSIDPrefix&gt;
+  &lt;/SSIDConfig&gt;
+  &lt;MSM&gt;
+    &lt;security&gt;
+        &lt;authEncryption&gt;
+            &lt;authentication&gt;open&lt;/authentication&gt;
+            &lt;encryption&gt;none&lt;/encryption&gt;
+            &lt;useOneX&gt;false&lt;/useOneX&gt;
+        &lt;/authEncryption&gt;
+    &lt;/security&gt;
+  &lt;/MSM&gt;
+&lt;/WLANProfile&gt;`
+
+	admxPolicy = `&lt;Enabled/&gt;
+      <![CDATA[<data id="ExecutionPolicy" value="AllSigned"/>]]>
+      <![CDATA[<data id="Listbox_ModuleNames" value="*"/>
+      <data id="OutputDirectory" value="false"/>
+      <data id="EnableScriptBlockInvocationLogging" value="true"/>
+      <data id="SourcePathForUpdateHelp" value="false"/>]]>`
+)
+
+func TestIsWLANXML(t *testing.T) {
+	t.Parallel()
+	assert.False(t, IsWLANXML(""))
+	assert.False(t, IsWLANXML("not a policy"))
+	assert.False(t, IsWLANXML(`<![CDATA[bozo]]>`))
+	assert.False(t, IsWLANXML(`<![CDATA[<bozo/>]]>`))
+	assert.False(t, IsWLANXML(`<![CDATA[<bozo]]>`))
+
+	// These are all valid ADMX policies but not WLAN XML policies
+	assert.False(t, IsWLANXML(`<![CDATA[<enabled/>]]>`))
+	assert.False(t, IsWLANXML(`<![CDATA[<disabled/>]]>`))
+	assert.False(t, IsWLANXML(`<![CDATA[<data id="id" value="value"/>]]>`))
+	assert.False(t, IsWLANXML(
+		`	<![CDATA[
+				<enabled/>
+				]]>`))
+	assert.False(t,
+		IsWLANXML("&lt;Enabled/&gt;&lt;Data id=\"EnableScriptBlockInvocationLogging\" value=\"true\"/&gt;&lt;Data id=\"ExecutionPolicy\" value=\"AllSigned\"/&gt;&lt;Data id=\"Listbox_ModuleNames\" value=\"*\"/&gt;&lt;Data id=\"OutputDirectory\" value=\"false\"/&gt;&lt;Data id=\"SourcePathForUpdateHelp\" value=\"false\"/&gt;"))
+	assert.False(t, IsWLANXML(admxPolicy))
+
+	assert.True(t, IsWLANXML(xmlEncodedPolicy1))
+}
+
+func TestEqual(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		name, a, b, errorContains string
+		equal                     bool
+	}{
+		{
+			name:          "empty policies",
+			a:             "",
+			b:             "",
+			equal:         false,
+			errorContains: "unmarshalling WLAN XML policy",
+		},
+		{
+			name:          "a is an ADMX policy",
+			a:             admxPolicy,
+			b:             xmlEncodedPolicy1,
+			equal:         false,
+			errorContains: "unmarshalling WLAN XML policy",
+		},
+		{
+			name:          "b is an ADMX policy",
+			a:             xmlEncodedPolicy1,
+			b:             admxPolicy,
+			equal:         false,
+			errorContains: "unmarshalling WLAN XML policy",
+		},
+		{
+			name:          "equal policies",
+			a:             xmlEncodedPolicy1,
+			b:             xmlEncodedPolicy1,
+			equal:         true,
+			errorContains: "",
+		},
+		{
+			name:          "equal policies but different SSID order",
+			a:             xmlEncodedPolicy3,
+			b:             xmlEncodedPolicy3Variant,
+			equal:         true,
+			errorContains: "",
+		},
+		{
+			name:          "equal policies but different SSID order - swapped invocation order",
+			a:             xmlEncodedPolicy3Variant,
+			b:             xmlEncodedPolicy3,
+			equal:         true,
+			errorContains: "",
+		},
+		{
+			name:          "different policies",
+			a:             xmlEncodedPolicy1,
+			b:             xmlEncodedPolicy2,
+			equal:         false,
+			errorContains: "",
+		},
+	}
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			equal, err := Equal(tt.a, tt.b)
+			if tt.errorContains == "" {
+				assert.NoError(t, err)
+			} else {
+				assert.ErrorContains(t, err, tt.errorContains)
+			}
+			assert.Equal(t, tt.equal, equal)
+		})
+	}
+}

--- a/server/service/integration_mdm_profiles_test.go
+++ b/server/service/integration_mdm_profiles_test.go
@@ -860,8 +860,8 @@ func (s *integrationMDMTestSuite) TestWindowsProfileRetries() {
 	ctx := context.Background()
 
 	testProfiles := []fleet.MDMProfileBatchPayload{
-		{Name: "N1", Contents: syncml.ForTestWithData(map[string]string{"L1": "D1"})},
-		{Name: "N2", Contents: syncml.ForTestWithData(map[string]string{"L2": "D2", "L3": "D3"})},
+		{Name: "N1", Contents: syncml.ForTestWithData([]syncml.TestCommand{{Verb: "Replace", LocURI: "L1", Data: "D1"}})},
+		{Name: "N2", Contents: syncml.ForTestWithData([]syncml.TestCommand{{Verb: "Replace", LocURI: "L2", Data: "D2"}, {Verb: "Add", LocURI: "L3", Data: "D3"}})},
 	}
 
 	h, mdmDevice := createWindowsHostThenEnrollMDM(s.ds, s.server.URL, t)
@@ -1023,7 +1023,7 @@ func (s *integrationMDMTestSuite) TestWindowsProfileRetries() {
 
 	t.Run("retry after device error", func(t *testing.T) {
 		// add another profile
-		newProfile := syncml.ForTestWithData(map[string]string{"L3": "D3"})
+		newProfile := syncml.ForTestWithData([]syncml.TestCommand{{Verb: "Replace", LocURI: "L3", Data: "D3"}})
 		testProfiles = append(testProfiles, fleet.MDMProfileBatchPayload{
 			Name:     "N3",
 			Contents: newProfile,
@@ -1059,7 +1059,7 @@ func (s *integrationMDMTestSuite) TestWindowsProfileRetries() {
 		// add another profile
 		testProfiles = append(testProfiles, fleet.MDMProfileBatchPayload{
 			Name:     "N4",
-			Contents: syncml.ForTestWithData(map[string]string{"L4": "D4"}),
+			Contents: syncml.ForTestWithData([]syncml.TestCommand{{Verb: "Replace", LocURI: "L4", Data: "D4"}}),
 		})
 		s.Do("POST", "/api/v1/fleet/mdm/profiles/batch", batchSetMDMProfilesRequest{Profiles: testProfiles}, http.StatusNoContent)
 		// trigger a profile sync and confirm that the install profile command for N4 was sent and
@@ -1086,7 +1086,7 @@ func (s *integrationMDMTestSuite) TestWindowsProfileRetries() {
 		// add another profile
 		testProfiles = append(testProfiles, fleet.MDMProfileBatchPayload{
 			Name:     "N5",
-			Contents: syncml.ForTestWithData(map[string]string{"L5": "D5"}),
+			Contents: syncml.ForTestWithData([]syncml.TestCommand{{Verb: "Replace", LocURI: "L5", Data: "D5"}}),
 		})
 		// hostProfsByIdent["N5"] = &fleet.HostMacOSProfile{Identifier: "N5", DisplayName: "N5", InstallDate: time.Now()}
 		s.Do("POST", "/api/v1/fleet/mdm/profiles/batch", batchSetMDMProfilesRequest{Profiles: testProfiles}, http.StatusNoContent)
@@ -1133,8 +1133,8 @@ func (s *integrationMDMTestSuite) TestWindowsProfileResend() {
 	ctx := context.Background()
 
 	testProfiles := []fleet.MDMProfileBatchPayload{
-		{Name: "N1", Contents: syncml.ForTestWithData(map[string]string{"L1": "D1"})},
-		{Name: "N2", Contents: syncml.ForTestWithData(map[string]string{"L2": "D2", "L3": "D3"})},
+		{Name: "N1", Contents: syncml.ForTestWithData([]syncml.TestCommand{{Verb: "Replace", LocURI: "L1", Data: "D1"}})},
+		{Name: "N2", Contents: syncml.ForTestWithData([]syncml.TestCommand{{Verb: "Replace", LocURI: "L2", Data: "D2"}, {Verb: "Replace", LocURI: "L3", Data: "D3"}})},
 	}
 
 	h, mdmDevice := createWindowsHostThenEnrollMDM(s.ds, s.server.URL, t)
@@ -1285,7 +1285,7 @@ func (s *integrationMDMTestSuite) TestWindowsProfileResend() {
 		// Change one profile and upload
 		copiedTestProfiles := make([]fleet.MDMProfileBatchPayload, len(testProfiles))
 		copy(copiedTestProfiles, testProfiles)
-		copiedTestProfiles[0].Contents = syncml.ForTestWithData(map[string]string{"L1": "D1-modified"})
+		copiedTestProfiles[0].Contents = syncml.ForTestWithData([]syncml.TestCommand{{Verb: "Replace", LocURI: "L1", Data: "D1-Modified"}})
 		s.Do("POST", "/api/v1/fleet/mdm/profiles/batch", batchSetMDMProfilesRequest{Profiles: copiedTestProfiles}, http.StatusNoContent)
 		// Confirm that one profile was sent and its status
 		verifyCommands(1, syncml.CmdStatusOK)
@@ -4744,7 +4744,7 @@ func (s *integrationMDMTestSuite) TestMDMBatchSetProfilesKeepsReservedNames() {
 	checkWinProfs(nil, servermdm.ListFleetReservedWindowsProfileNames()...)
 
 	// batch set only windows profiles doesn't remove the reserved names
-	newWinProfile := syncml.ForTestWithData(map[string]string{"l1": "d1"})
+	newWinProfile := syncml.ForTestWithData([]syncml.TestCommand{{Verb: "Replace", LocURI: "l1", Data: "d1"}})
 	var testProfiles []fleet.MDMProfileBatchPayload
 	testProfiles = append(testProfiles, fleet.MDMProfileBatchPayload{
 		Name:     "n1",

--- a/server/service/osquery_utils/queries_test.go
+++ b/server/service/osquery_utils/queries_test.go
@@ -1728,21 +1728,27 @@ func TestDirectIngestWindowsProfiles(t *testing.T) {
 		{nil, ""},
 		{
 			[]*fleet.ExpectedMDMProfile{
-				{Name: "N1", RawProfile: syncml.ForTestWithData(map[string]string{})},
+				{Name: "N1", RawProfile: syncml.ForTestWithData([]syncml.TestCommand{})},
 			},
 			"",
 		},
 		{
 			[]*fleet.ExpectedMDMProfile{
-				{Name: "N1", RawProfile: syncml.ForTestWithData(map[string]string{"L1": "D1"})},
+				{Name: "N1", RawProfile: syncml.ForTestWithData([]syncml.TestCommand{{Verb: "Replace", LocURI: "L1", Data: "D1"}})},
 			},
 			"SELECT raw_mdm_command_output FROM mdm_bridge WHERE mdm_command_input = '<SyncBody><Get><CmdID>1255198959</CmdID><Item><Target><LocURI>L1</LocURI></Target></Item></Get></SyncBody>';",
 		},
 		{
 			[]*fleet.ExpectedMDMProfile{
-				{Name: "N1", RawProfile: syncml.ForTestWithData(map[string]string{"L1": "D1"})},
-				{Name: "N2", RawProfile: syncml.ForTestWithData(map[string]string{"L2": "D2"})},
-				{Name: "N3", RawProfile: syncml.ForTestWithData(map[string]string{"L3": "D3", "L3.1": "D3.1"})},
+				{Name: "N1", RawProfile: syncml.ForTestWithData([]syncml.TestCommand{{Verb: "Add", LocURI: "L1", Data: "D1"}})},
+			},
+			"SELECT raw_mdm_command_output FROM mdm_bridge WHERE mdm_command_input = '<SyncBody><Get><CmdID>1255198959</CmdID><Item><Target><LocURI>L1</LocURI></Target></Item></Get></SyncBody>';",
+		},
+		{
+			[]*fleet.ExpectedMDMProfile{
+				{Name: "N1", RawProfile: syncml.ForTestWithData([]syncml.TestCommand{{Verb: "Replace", LocURI: "L1", Data: "D1"}})},
+				{Name: "N2", RawProfile: syncml.ForTestWithData([]syncml.TestCommand{{Verb: "Add", LocURI: "L2", Data: "D2"}})},
+				{Name: "N3", RawProfile: syncml.ForTestWithData([]syncml.TestCommand{{Verb: "Replace", LocURI: "L3", Data: "D3"}, {Verb: "Add", LocURI: "L3.1", Data: "D3.1"}})},
 			},
 			"SELECT raw_mdm_command_output FROM mdm_bridge WHERE mdm_command_input = '<SyncBody><Get><CmdID>1255198959</CmdID><Item><Target><LocURI>L1</LocURI></Target></Item></Get><Get><CmdID>2736786183</CmdID><Item><Target><LocURI>L2</LocURI></Target></Item></Get><Get><CmdID>894211447</CmdID><Item><Target><LocURI>L3</LocURI></Target></Item></Get><Get><CmdID>3410477854</CmdID><Item><Target><LocURI>L3.1</LocURI></Target></Item></Get></SyncBody>';",
 		},


### PR DESCRIPTION
Fixes https://github.com/fleetdm/fleet/issues/24394 by adding new verification logic to detect and verify these profiles. We only verify a subset of the properties because there are certain settings such as the Authentication which Windows seems to upgrade in circumstances where it can(e.g. WPA2 specified but interface + router supports WPA3 results in WPA3 on the client and there are likely other similar scenarios).  After discussion with design team we've decided the limited verification is better than what we had before and a good solution for now.

I know this is extremely heavy on comments but the behavior is strange and non obvious.

Also see latest comment on the issue for some testing discussion: https://github.com/fleetdm/fleet/issues/24394#issuecomment-2810261844

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/Committing-Changes.md#changes-files) for more information.
- [x] Added/updated automated tests
- [x] A detailed QA plan exists on the associated ticket (if it isn't there, work with the product group's QA engineer to add it)
- [x] Manual QA for all new/changed functionality

