### PR TITLE
Fleet UI: Update osquery version options (#28316)

### DIFF
--- a/frontend/utilities/constants.tsx
+++ b/frontend/utilities/constants.tsx
@@ -83,6 +83,7 @@ export const MAX_OSQUERY_SCHEDULED_QUERY_INTERVAL = 604800;
 
 export const MIN_OSQUERY_VERSION_OPTIONS = [
   { label: "All", value: "" },
+  { label: "5.17.0 +", value: "5.17.0" },
   { label: "5.16.0 +", value: "5.16.0" },
   { label: "5.15.0 +", value: "5.15.0" },
   { label: "5.14.1 +", value: "5.14.1" },


### PR DESCRIPTION
Automated update of MIN_OSQUERY_VERSION_OPTIONS with any new osquery release. (Note: This automatic update is the solution to issue #21431)