### PR TITLE
fix issue where team maintainers were not allowed to edit their teams os updates 

### DIFF
--- a/changes/issue-25367-fix-team-maintainer-write-min-os-version
+++ b/changes/issue-25367-fix-team-maintainer-write-min-os-version
@@ -1,0 +1,1 @@
+- fixes an issue where team maintainers were not allowed update their teams minium os version.

--- a/server/authz/policy.rego
+++ b/server/authz/policy.rego
@@ -110,10 +110,10 @@ allow {
   action == write
 }
 
-# Team admins and gitops can write their teams.
+# Team admins, maintainers, and gitops can write their teams.
 allow {
   object.type == "team"
-  team_role(subject, object.id) == [admin, gitops][_]
+  team_role(subject, object.id) == [admin, maintainer, gitops][_]
   action == write
 }
 


### PR DESCRIPTION
For #25367

This fixes an issue where team maintainers were not allowed to update their teams minimum os version.

This is done by giving team maintainers write permissions to their team.


- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
- [ ] Added/updated automated tests
- [x] Manual QA for all new/changed functionality
