### PR TITLE
Website: add trial license expiration details to /try-fleet page

### DIFF
--- a/website/views/pages/fleetctl-preview.ejs
+++ b/website/views/pages/fleetctl-preview.ejs
@@ -49,6 +49,12 @@
                 <p>Your Fleet Premium trial license has expired. You can still run the free version of Fleet locally.</p>
               </div>
             </blockquote>
+            <blockquote purpose="tip" v-if="trialLicenseKey && !userHasExpiredTrialLicense">
+              <img src="/images/icon-info-16x16@2x.png" alt="An icon indicating that this section has important information">
+              <div class="d-block">
+                <p>This license key is valid for 30 days.</p>
+              </div>
+            </blockquote>
           </div>
           <div purpose="step">
             <p>The Fleet UI is now available at <a href="http://localhost:1337" target="_blank">http://localhost:1337</a>. Use the credentials below to login:</p>
@@ -84,6 +90,12 @@
                 <p>Your Fleet Premium trial license has expired. You can still run the free version of Fleet locally.</p>
               </div>
             </blockquote>
+            <blockquote purpose="tip" v-if="trialLicenseKey && !userHasExpiredTrialLicense">
+              <img src="/images/icon-info-16x16@2x.png" alt="An icon indicating that this section has important information">
+              <div class="d-block">
+                <p>This license key is valid for 30 days.</p>
+              </div>
+            </blockquote>
           </div>
           <div purpose="step">
             <p>The Fleet UI is now available at <a href="http://localhost:1337" target="_blank">http://localhost:1337</a>. Use the credentials below to login:</p>
@@ -117,6 +129,12 @@
               <img src="/images/icon-info-16x16@2x.png" alt="An icon indicating that this section has important information">
               <div class="d-block">
                 <p>Your Fleet Premium trial license has expired. You can still run the free version of Fleet locally.</p>
+              </div>
+            </blockquote>
+            <blockquote purpose="tip" v-if="trialLicenseKey && !userHasExpiredTrialLicense">
+              <img src="/images/icon-info-16x16@2x.png" alt="An icon indicating that this section has important information">
+              <div class="d-block">
+                <p>This license key is valid for 30 days.</p>
               </div>
             </blockquote>
           </div>
@@ -159,6 +177,12 @@
               <img src="/images/icon-info-16x16@2x.png" alt="An icon indicating that this section has important information">
               <div class="d-block">
                 <p>Your Fleet Premium trial license has expired. You can still run the free version of Fleet locally.</p>
+              </div>
+            </blockquote>
+            <blockquote purpose="tip" v-if="trialLicenseKey && !userHasExpiredTrialLicense">
+              <img src="/images/icon-info-16x16@2x.png" alt="An icon indicating that this section has important information">
+              <div class="d-block">
+                <p>This license key is valid for 30 days.</p>
               </div>
             </blockquote>
           </div>


### PR DESCRIPTION
Closes: https://github.com/fleetdm/confidential/issues/9991

Changes:
- Added a note to the /try-fleet page telling users with a trial license key that the license is valid for 30 days.