### PR TITLE
Tests for self service vpp apps & weird installed vpp app edge case

### DIFF
--- a/server/datastore/mysql/software.go
+++ b/server/datastore/mysql/software.go
@@ -3732,8 +3732,15 @@ func (ds *Datastore) ListHostSoftware(ctx context.Context, host *fleet.Host, opt
 						softwareTitleRecord.BundleIdentifierList = ptr.String("")
 						seperator = ""
 					}
-
-					if !strings.Contains(*softwareTitleRecord.SoftwareIDList, softwareIDStr) {
+					softwareIDList := strings.Split(*softwareTitleRecord.SoftwareIDList, ",")
+					found := false
+					for _, id := range softwareIDList {
+						if id == softwareIDStr {
+							found = true
+							break
+						}
+					}
+					if !found {
 						*softwareTitleRecord.SoftwareIDList += seperator + softwareIDStr
 						*softwareTitleRecord.SoftwareSourceList += seperator + s.Source
 						*softwareTitleRecord.VersionList += seperator + *s.Version

--- a/server/datastore/mysql/software.go
+++ b/server/datastore/mysql/software.go
@@ -2395,7 +2395,10 @@ func hostInstalledSoftware(ds *Datastore, ctx context.Context, hostID uint) ([]*
 			software_titles.id AS id,
 			host_software.software_id AS software_id,
 			host_software.last_opened_at,
-			NULL AS status
+			software.source AS software_source,
+			software.version AS version,
+			software.bundle_identifier AS bundle_identifier,
+			'installed' AS status
 		FROM 
 			host_software
 		INNER JOIN
@@ -3013,6 +3016,7 @@ func (ds *Datastore) ListHostSoftware(ctx context.Context, host *fleet.Host, opt
 
 	hostInstalledSoftware, err := hostInstalledSoftware(ds, ctx, host.ID)
 	hostInstalledSoftwareTitleSet := make(map[uint]struct{})
+	hostInstalledSoftwareSet := make(map[uint]*hostSoftware)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -3026,6 +3030,7 @@ func (ds *Datastore) ListHostSoftware(ctx context.Context, host *fleet.Host, opt
 		hostInstalledSoftwareTitleSet[s.ID] = struct{}{}
 		if s.SoftwareID != nil {
 			bySoftwareID[*s.SoftwareID] = s
+			hostInstalledSoftwareSet[*s.SoftwareID] = s
 		}
 	}
 
@@ -3711,6 +3716,31 @@ func (ds *Datastore) ListHostSoftware(ctx context.Context, host *fleet.Host, opt
 		deduplicatedList := make([]*hostSoftware, 0, len(hostSoftwareList))
 		for _, softwareTitleRecord := range hostSoftwareList {
 			softwareTitle := bySoftwareTitleID[softwareTitleRecord.ID]
+
+			if softwareTitle != nil && softwareTitle.SoftwareID != nil {
+				// if we have a software id, that means that this record has been installed on the host,
+				// we should double check the hostInstalledSoftwareSet,
+				// but we want to make sure that software id is present on the InstalledVersions list to be processed
+				if s, ok := hostInstalledSoftwareSet[*softwareTitle.SoftwareID]; ok {
+					softwareIDStr := strconv.FormatUint(uint64(*softwareTitle.SoftwareID), 10)
+
+					seperator := ","
+					if softwareTitleRecord.SoftwareIDList == nil {
+						softwareTitleRecord.SoftwareIDList = ptr.String("")
+						softwareTitleRecord.SoftwareSourceList = ptr.String("")
+						softwareTitleRecord.VersionList = ptr.String("")
+						softwareTitleRecord.BundleIdentifierList = ptr.String("")
+						seperator = ""
+					}
+
+					if !strings.Contains(*softwareTitleRecord.SoftwareIDList, softwareIDStr) {
+						*softwareTitleRecord.SoftwareIDList += seperator + softwareIDStr
+						*softwareTitleRecord.SoftwareSourceList += seperator + s.Source
+						*softwareTitleRecord.VersionList += seperator + *s.Version
+						*softwareTitleRecord.BundleIdentifierList += seperator + *s.BundleIdentifier
+					}
+				}
+			}
 
 			if softwareTitleRecord.SoftwareIDList != nil {
 				softwareIDList := strings.Split(*softwareTitleRecord.SoftwareIDList, ",")

--- a/server/datastore/mysql/software_test.go
+++ b/server/datastore/mysql/software_test.go
@@ -5001,6 +5001,7 @@ func testListHostSoftwareVPPSelfService(t *testing.T, ds *Datastore) {
 		VPPAppTeam:       fleet.VPPAppTeam{SelfService: true, VPPAppID: fleet.VPPAppID{AdamID: "adam_vpp_1", Platform: fleet.MacOSPlatform}},
 		Name:             "vpp1",
 		BundleIdentifier: "com.app.vpp1",
+		LatestVersion:    "1.0.0",
 	}
 	va1, err := ds.InsertVPPAppWithTeam(ctx, vPPApp, &tm.ID)
 	require.NoError(t, err)
@@ -5013,6 +5014,7 @@ func testListHostSoftwareVPPSelfService(t *testing.T, ds *Datastore) {
 		VPPAppTeam:       fleet.VPPAppTeam{SelfService: true, VPPAppID: fleet.VPPAppID{AdamID: "adam_vpp_2", Platform: fleet.MacOSPlatform}},
 		Name:             "vpp2",
 		BundleIdentifier: "com.app.vpp2",
+		LatestVersion:    "1.0.1",
 	}
 	_, err = ds.InsertVPPAppWithTeam(ctx, vPPApp2, &tm.ID)
 	require.NoError(t, err)
@@ -5020,7 +5022,7 @@ func testListHostSoftwareVPPSelfService(t *testing.T, ds *Datastore) {
         INSERT INTO software (name, version, source, bundle_identifier, title_id, checksum)
         VALUES (?, ?, ?, ?, ?, ?)
 	`,
-		vPPApp2.Name, vPPApp2.LatestVersion, "apps", vPPApp2.BundleIdentifier, vPPApp2.TitleID, hex.EncodeToString([]byte("vpp2")),
+		vPPApp2.Name, "0.5.0", "apps", vPPApp2.BundleIdentifier, vPPApp2.TitleID, hex.EncodeToString([]byte("vpp2")),
 	)
 	require.NoError(t, err)
 	time.Sleep(time.Second)
@@ -5041,6 +5043,15 @@ func testListHostSoftwareVPPSelfService(t *testing.T, ds *Datastore) {
 	sw, _, err := ds.ListHostSoftware(ctx, host, opts)
 	require.NoError(t, err)
 	assert.Len(t, sw, 2)
+
+	assert.NotNil(t, sw[0].AppStoreApp)
+	assert.Equal(t, "1.0.0", sw[0].AppStoreApp.Version)
+	assert.Nil(t, sw[0].InstalledVersions)
+
+	assert.NotNil(t, sw[1].AppStoreApp)
+	assert.Equal(t, "1.0.1", sw[1].AppStoreApp.Version)
+	assert.NotNil(t, sw[1].InstalledVersions)
+	assert.Equal(t, "0.5.0", sw[1].InstalledVersions[0].Version)
 }
 
 func testSetHostSoftwareInstallResult(t *testing.T, ds *Datastore) {


### PR DESCRIPTION
https://github.com/fleetdm/fleet/issues/28345

When a vpp app is marked as self service, it should be returned and the data about it should be hydrated.
When writing tests for this, another bug was found around vpp apps that were installed and present in host software. These apps need to be retrieved and the data about them needs to be merged onto the host `hostInstalledSoftware` record.

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [x] Added/updated automated tests
- [x] A detailed QA plan exists on the associated ticket (if it isn't there, work with the product group's QA engineer to add it)
- [x] Manual QA for all new/changed functionality
- [x] For unreleased bug fixes in a release candidate, confirmed that the fix is not expected to adversely impact load test results or alerted the release DRI if additional load testing is needed.
