### PR TITLE
Website: Add support for new usage statistic

### DIFF
--- a/website/api/controllers/webhooks/receive-usage-analytics.js
+++ b/website/api/controllers/webhooks/receive-usage-analytics.js
@@ -44,6 +44,7 @@ module.exports = {
     maintenanceWindowsConfigured: {type: 'boolean', defaultsTo: false },
     numHostsFleetDesktopEnabled: {type: 'number', defaultsTo: 0 },
     numQueries: {type: 'number', defaultsTo: 0 },
+    numHostsABMPending: {type: 'number', defaultsTo: 0 },
   },
 
 

--- a/website/api/models/HistoricalUsageSnapshot.js
+++ b/website/api/models/HistoricalUsageSnapshot.js
@@ -48,6 +48,7 @@ module.exports = {
     maintenanceWindowsConfigured: {required: true, type: 'boolean'},
     numHostsFleetDesktopEnabled: {required: true, type: 'number'},
     numQueries: {required: true, type: 'number' },
+    numHostsABMPending: {required: true, type: 'number' },
 
     //  ╔═╗╔╦╗╔╗ ╔═╗╔╦╗╔═╗
     //  ║╣ ║║║╠╩╗║╣  ║║╚═╗


### PR DESCRIPTION
Closes: #28255

Changes:
- Updated the receive-usage-analytics webhook to support a new input `numHostsABMPending`
- Added a `numHostsABMPending` attribute to the `HistoricalUsageSnapshot` model
