### PR TITLE
Update deploying-sentinelone-with-fleet.md

### DIFF
--- a/articles/deploying-sentinelone-with-fleet.md
+++ b/articles/deploying-sentinelone-with-fleet.md
@@ -10,7 +10,7 @@ SentinelOne is a cybersecurity platform that provides endpoint protection, detec
 
 SentinelOne requires 5 separate mobileconfig files in order to properly function on macOS. Each of these serves an important operational function. These 5 profiles are available to download on my GitHub repo [here](https://github.com/harrisonravazzolo/Bluth-Company-GitOps/tree/main/lib/macos/SentinelOne). Let's quickly run through each one and highlight what it's actually doing on your endpoints.
 
-> It's possible these profiles can be combined into one payload, but we've kept them seperate here for troubleshooting purposes.
+> It's possible these profiles can be combined into one payload, but we've kept them separate here for troubleshooting purposes.
 
 `s1_install_token.mobileconfig` - The simplest of the payloads. Find the key S1InstallRegistrationToken and replace the corresponding string value with your site token. This token can be found under the Sentinels tab for the corresponding site where you want to enroll your hosts.
 


### PR DESCRIPTION

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [ ] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/Committing-Changes.md#changes-files) for more information.
- [ ] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [ ] Added support on fleet's osquery simulator `cmd/osquery-perf` for new osquery data ingestion features.
- [ ] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes
- [ ] If database migrations are included, checked table schema to confirm autoupdate
- For database migrations:
  - [ ] Checked schema for all modified table for columns that will auto-update timestamps during migration.
  - [ ] Confirmed that updating the timestamps is acceptable, and will not cause unwanted side effects.
  - [ ] Ensured the correct collation is explicitly set for character columns (`COLLATE utf8mb4_unicode_ci`).
- [ ] Added/updated automated tests
- [ ] A detailed QA plan exists on the associated ticket (if it isn't there, work with the product group's QA engineer to add it)
- [ ] Manual QA for all new/changed functionality
- For Orbit and Fleet Desktop changes:
   - [ ] Make sure fleetd is compatible with the latest released version of Fleet (see [Must rule](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/fleetd-development-and-release-strategy.md)).
   - [ ] Orbit runs on macOS, Linux and Windows. Check if the orbit feature/bugfix should only apply to one platform (`runtime.GOOS`).
   - [ ] Manual QA must be performed in the three main OSs, macOS, Windows and Linux.
   - [ ] Auto-update manual QA, from released version of component to new version (see [tools/tuf/test](../tools/tuf/test/README.md)).
- [ ] For unreleased bug fixes in a release candidate, confirmed that the fix is not expected to adversely impact load test results or alerted the release DRI if additional load testing is needed.
