### PR TITLE
Website: remove duplicate contact CTA from handbook sidebar

### DIFF
--- a/website/views/pages/handbook/basic-handbook.ejs
+++ b/website/views/pages/handbook/basic-handbook.ejs
@@ -17,22 +17,10 @@
               </li>
             </ul>
           </div>
-
-        </div>
-        <div class="d-block d-md-none">
-          <a href="/contact" purpose="sidebar-cta" class="d-flex flex-row justify-content-start">
-          <div class="d-flex align-self-start">
-            <img alt="Ask us anything" src="/images/icon-question-20x19@2x.png">
-          </div>
-          <div>
-            <p class="mb-0">Questions?</p>
-            <animated-arrow-button text-color="#515774" class="py-0" style="font-weight: 400" href="/contact">Ask us anything</animated-arrow-button>
-          </div>
-          </a>
         </div>
         <div class="border-bottom py-3 d-flex d-md-none"></div>
       </div>
-        <div purpose="sidebar-cta" class="d-none d-md-block">
+        <div purpose="sidebar-cta" class="d-none d-lg-block">
           <a href="/contact"  class="d-flex flex-row justify-content-start">
           <div class="d-flex align-self-start">
             <img alt="Ask us anything" src="/images/icon-question-20x19@2x.png">


### PR DESCRIPTION
Closes: #28375

Changes:
- Removed the duplicate contact form CTA in the handbook sidebar.