### PR TITLE
Website: Update /try-fleet redirect

### DIFF
--- a/website/api/controllers/view-fleetctl-preview.js
+++ b/website/api/controllers/view-fleetctl-preview.js
@@ -30,6 +30,9 @@ module.exports = {
 
   fn: async function ({start}) {
 
+    if(!this.req.me) {
+      throw {redirect: '/register#tryfleet'};
+    }
     let trialLicenseKey;
     // Check to see if this user has a Fleet premium trial license key.
     let userHasTrialLicense = this.req.me.fleetPremiumTrialLicenseKey;

--- a/website/assets/js/pages/entrance/login.page.js
+++ b/website/assets/js/pages/entrance/login.page.js
@@ -38,18 +38,24 @@ parasails.registerPage('login', {
       this.showCustomerLogin = false;
     }
 
-    // If we're redirecting this user to the license dispenser after they log in, modify the link to the /register page and the pageToRedirectToAfterLogin.
-    if(window.location.hash && window.location.hash === '#purchaseLicense'){
-      this.registerSlug = '/register#purchaseLicense';
-      this.pageToRedirectToAfterLogin = '/new-license#login';
-      window.location.hash = '';
+    if(window.location.hash){
+      // If we're redirecting this user to the license dispenser after they log in, modify the link to the /register page and the pageToRedirectToAfterLogin.
+      if(window.location.hash === '#purchaseLicense'){
+        this.registerSlug = '/register#purchaseLicense';
+        this.pageToRedirectToAfterLogin = '/new-license#login';
+        window.location.hash = '';
+      // If we're redirecting this user to the contact form after they log in, modify the link to the /register page and the pageToRedirectToAfterLogin.
+      } else if(window.location.hash === '#contact'){
+        this.registerSlug = '/register';
+        this.pageToRedirectToAfterLogin = '/contact?sendMessage';
+        window.location.hash = '';
+      } else if(window.location.hash === '#tryfleet'){
+        this.registerSlug = '/register#tryfleet';
+        this.pageToRedirectToAfterLogin = '/try-fleet';
+        window.location.hash = '';
+      }
     }
-    // If we're redirecting this user to the contact form after they log in, modify the link to the /register page and the pageToRedirectToAfterLogin.
-    if(window.location.hash && window.location.hash === '#contact'){
-      this.registerSlug = '/register';
-      this.pageToRedirectToAfterLogin = '/contact?sendMessage';
-      window.location.hash = '';
-    }
+
   },
   mounted: async function() {
     //…

--- a/website/assets/js/pages/entrance/signup.page.js
+++ b/website/assets/js/pages/entrance/signup.page.js
@@ -35,10 +35,17 @@ parasails.registerPage('signup', {
   //  ╩═╝╩╚  ╚═╝╚═╝ ╩ ╚═╝╩═╝╚═╝
   beforeMount: function() {
     // If we're redirecting this user to the license dispenser after they sign up, modify the link to the login page and the pageToRedirectToAfterRegistration
-    if(window.location.hash && window.location.hash === '#purchaseLicense'){
-      this.loginSlug = '/login#purchaseLicense';
-      this.pageToRedirectToAfterRegistration = '/new-license#signup';
-      window.location.hash = '';
+    if(window.location.hash){
+
+      if(window.location.hash === '#purchaseLicense'){
+        this.loginSlug = '/login#purchaseLicense';
+        this.pageToRedirectToAfterRegistration = '/new-license#signup';
+        window.location.hash = '';
+      } else if(window.location.hash === '#tryfleet') {
+        this.loginSlug = '/login#tryfleet';
+        this.pageToRedirectToAfterRegistration = '/try-fleet';
+        window.location.hash = '';
+      }
     }
   },
   mounted: async function() {

--- a/website/config/policies.js
+++ b/website/config/policies.js
@@ -66,6 +66,7 @@ module.exports.policies = {
   'view-app-details': true,
   'view-meetups': true,
   'view-os-settings': true,
+  'view-fleetctl-preview': true,
   'get-llm-generated-configuration-profile': true,
   'account/update-start-cta-visibility': true,
 };


### PR DESCRIPTION
Closes: #28364

Changes:
- Updated the /try-fleet page to redirect logged-out users to the /register page
- Updated the signup and login forms to redirect users to the try-fleet page (if they navigated it that page before signing up/logging in)