### PR TITLE
Don't update updated_at on OS vulnerabilities when nothing changed in the result

### DIFF
--- a/server/datastore/mysql/operating_system_vulnerabilities.go
+++ b/server/datastore/mysql/operating_system_vulnerabilities.go
@@ -113,10 +113,16 @@ func (ds *Datastore) InsertOSVulnerability(ctx context.Context, v fleet.OSVulner
 			operating_system_id = VALUES(operating_system_id),
 			source = VALUES(source),
 			resolved_in_version = VALUES(resolved_in_version),
-			updated_at = ?
+			updated_at = IF(
+				  VALUES(operating_system_id) = operating_system_id AND
+				  VALUES(source) = source
+				  AND VALUES(resolved_in_version) = resolved_in_version,
+			  updated_at,
+			  NOW()
+		  )
 	`
 
-	args = append(args, v.OSID, v.CVE, s, v.ResolvedInVersion, time.Now().UTC())
+	args = append(args, v.OSID, v.CVE, s, v.ResolvedInVersion)
 
 	res, err := ds.writer(ctx).ExecContext(ctx, sqlStmt, args...)
 	if err != nil {

--- a/server/datastore/mysql/operating_system_vulnerabilities_test.go
+++ b/server/datastore/mysql/operating_system_vulnerabilities_test.go
@@ -239,6 +239,9 @@ func testInsertOSVulnerability(t *testing.T, ds *Datastore) {
 	require.NoError(t, err)
 	assert.True(t, didInsertOrUpdate)
 
+	// make sure updated_at doesn't change on the next upsert call, as fields won't change
+	time.Sleep(1 * time.Second)
+
 	// Inserting the exact same vulnerability again should not insert and not update
 	didInsertOrUpdate, err = ds.InsertOSVulnerability(ctx, vulnsUpdate, fleet.MSRCSource)
 	require.NoError(t, err)


### PR DESCRIPTION
For #28368.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [x] Added/updated automated tests
- [x] Manual QA for all new/changed functionality