### PR TITLE
Add `To:` header when constructing emails

### DIFF
--- a/changes/28032-email-to-header
+++ b/changes/28032-email-to-header
@@ -1,1 +1,1 @@
-- Fixed missing To: or Bcc: email headers
+- Fixed missing To: email header

--- a/changes/28032-email-to-header
+++ b/changes/28032-email-to-header
@@ -1,0 +1,1 @@
+- Fixed missing To: or Bcc: email headers

--- a/server/mail/mail.go
+++ b/server/mail/mail.go
@@ -82,9 +82,7 @@ func getMessageBody(e fleet.Email, f fromFunc) ([]byte, error) {
 	if len(e.To) == 1 {
 		to = "To: " + e.To[0] + "\r\n"
 	} else if len(e.To) > 1 {
-		// Splitting the header into multiple lines as a precaution
-		// https://www.rfc-editor.org/rfc/rfc2822.html#section-2.2.3
-		to = "Bcc: " + strings.Join(e.To, ",\r\n    ") + "\r\n"
+		to = "To: undisclosed-recipients\r\n"
 	}
 	msg := []byte(subject + from + to + mime + content + "\r\n" + string(body) + "\r\n")
 	return msg, nil

--- a/server/mail/mail.go
+++ b/server/mail/mail.go
@@ -78,7 +78,15 @@ func getMessageBody(e fleet.Email, f fromFunc) ([]byte, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to obtain from address: %w", err)
 	}
-	msg := []byte(subject + from + mime + content + "\r\n" + string(body) + "\r\n")
+	to := ""
+	if len(e.To) == 1 {
+		to = "To: " + e.To[0] + "\r\n"
+	} else if len(e.To) > 1 {
+		// Splitting the header into multiple lines as a precaution
+		// https://www.rfc-editor.org/rfc/rfc2822.html#section-2.2.3
+		to = "Bcc: " + strings.Join(e.To, ",\r\n    ") + "\r\n"
+	}
+	msg := []byte(subject + from + to + mime + content + "\r\n" + string(body) + "\r\n")
 	return msg, nil
 }
 


### PR DESCRIPTION
#28032

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/Committing-Changes.md#changes-files) for more information.
- [x] Manual QA for all new/changed functionality

The way I tested this locally was by going through the flow to setup SMTP settings using a local mailhog service, and then check the headers on the incoming mail for the `To: ` line
