### PR TITLE
Fix `make` so that it builds both binaries again

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,7 +86,8 @@ all: build
 	$(eval APP_NAME = fleetctl)
 
 # For the build target, decide which binaries to build.
-BINS_TO_BUILD =
+# Default to building both
+BINS_TO_BUILD = fleet fleetctl
 ifeq (build,$(filter build,$(MAKECMDGOALS)))
 	BINS_TO_BUILD = fleet fleetctl
 	ifeq ($(ARG1), fleet)


### PR DESCRIPTION
Previous work on the makefile broke the default `make` action.  This restores it by setting default binaries to be built.