### PR TITLE
Revert to first-in-wins on names in the software table

### DIFF
--- a/changes/28565-software-inventory
+++ b/changes/28565-software-inventory
@@ -1,0 +1,1 @@
+* Removed updates of existing macOS software names on software ingestion to remediate a significant database performance regression introduced in 4.67.0.

--- a/server/datastore/mysql/software.go
+++ b/server/datastore/mysql/software.go
@@ -391,10 +391,6 @@ func (ds *Datastore) applyChangesForNewSoftwareDB(
 				return err
 			}
 
-			if err = updateExistingBundleIDs(ctx, tx, hostID, existingBundleIDsToUpdate); err != nil {
-				return err
-			}
-
 			if err = updateSoftwareUpdatedAt(ctx, tx, hostID); err != nil {
 				return err
 			}

--- a/server/datastore/mysql/software.go
+++ b/server/datastore/mysql/software.go
@@ -403,6 +403,7 @@ func (ds *Datastore) applyChangesForNewSoftwareDB(
 	return r, err
 }
 
+//nolint:unused
 func updateExistingBundleIDs(ctx context.Context, tx sqlx.ExtContext, hostID uint, bundleIDsToSoftware map[string]fleet.Software) error {
 	if len(bundleIDsToSoftware) == 0 {
 		return nil

--- a/server/datastore/mysql/software_test.go
+++ b/server/datastore/mysql/software_test.go
@@ -295,8 +295,8 @@ func testSoftwareDifferentNameSameBundleIdentifier(t *testing.T, ds *Datastore) 
 	// hasn't updated yet because we haven't called updateExistingBundleIDs yet
 	require.Equal(t, "GoLand.app", software[0].Name)
 
-	err = updateExistingBundleIDs(ctx, ds.writer(ctx), host1.ID, existingBundleIDsToUpdate)
-	require.NoError(t, err)
+	// err = updateExistingBundleIDs(ctx, ds.writer(ctx), host1.ID, existingBundleIDsToUpdate)
+	// require.NoError(t, err)
 
 	err = sqlx.SelectContext(ctx, ds.reader(ctx),
 		&software, `SELECT id, name, bundle_identifier, title_id FROM software`,
@@ -307,7 +307,9 @@ func testSoftwareDifferentNameSameBundleIdentifier(t *testing.T, ds *Datastore) 
 	require.Len(t, software, 1)
 	require.NotEmpty(t, software[0].TitleID)
 	// software.name is updated now
-	require.Equal(t, "GoLand 2.app", software[0].Name)
+	// TODO: rename should happen in the future
+	// require.Equal(t, "GoLand 2.app", software[0].Name)
+	require.Equal(t, "GoLand.app", software[0].Name)
 
 	err = sqlx.SelectContext(ctx, ds.reader(ctx),
 		&softwareTitle, `SELECT id, name FROM software_titles`,
@@ -327,7 +329,9 @@ func testSoftwareDifferentNameSameBundleIdentifier(t *testing.T, ds *Datastore) 
 	)
 	require.NoError(t, err)
 	require.Len(t, softwareTitle, 1)
-	require.Equal(t, "GoLand 2.app", softwareTitle[0].Name)
+	// TODO: we want this to be renamed eventually
+	// require.Equal(t, "GoLand 2.app", softwareTitle[0].Name)
+	require.Equal(t, "GoLand.app", softwareTitle[0].Name)
 
 	// Now ingest software from host2, with a rename
 	sw, err = fleet.SoftwareFromOsqueryRow("GoLand 3.app", "2024.3", "apps", "", "", "", "", "com.jetbrains.goland", "", "", "")
@@ -350,7 +354,8 @@ func testSoftwareDifferentNameSameBundleIdentifier(t *testing.T, ds *Datastore) 
 		require.NotEmpty(t, s.TitleID)
 		// software.name is updated now for GoLand
 		if s.BundleIdentifier == "com.jetbrains.goland" {
-			require.Equal(t, "GoLand 3.app", s.Name)
+			// require.Equal(t, "GoLand 3.app", s.Name) // TODO: the name should change eventually
+			require.Equal(t, "GoLand.app", s.Name)
 		}
 	}
 
@@ -364,7 +369,9 @@ func testSoftwareDifferentNameSameBundleIdentifier(t *testing.T, ds *Datastore) 
 		&goland, `SELECT id, name FROM software_titles WHERE bundle_identifier = 'com.jetbrains.goland'`,
 	)
 	require.NoError(t, err)
-	require.Equal(t, "GoLand 3.app", goland.Name)
+	// TODO: the name should change eventually
+	// require.Equal(t, "GoLand 3.app", goland.Name)
+	require.Equal(t, "GoLand.app", goland.Name)
 }
 
 func testSoftwareDuplicateNameDifferentBundleIdentifier(t *testing.T, ds *Datastore) {


### PR DESCRIPTION
For #28565.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/Committing-Changes.md#changes-files) for more information.
- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [x] Added/updated automated tests