### PR TITLE
Fix software naming migration duplicate software collection query, add host software installed path remapping to migration to avoid orphaned paths

### DIFF
--- a/changes/28586-hotfix-migration
+++ b/changes/28586-hotfix-migration
@@ -1,2 +1,2 @@
-* Fixed software deduplication when migrating from < 4.67.0 for cases where exactly two software entries would be merged into one.
+* Fixed software deduplication when migrating from < 4.67.0 for cases where exactly two software entries would be merged into one, and for cases where the same bundle ID has more than one version, each with more than one that needs to be converted into a single software entry.
 * Included host software installed paths migration in the above database migration, instead of waiting for software ingestion to repopulate/clean up affected rows.

--- a/changes/28586-hotfix-migration
+++ b/changes/28586-hotfix-migration
@@ -1,0 +1,1 @@
+* Fixed software deduplication when migrating from < 4.67.0 for cases where exactly two software entries would be merged into one.

--- a/changes/28586-hotfix-migration
+++ b/changes/28586-hotfix-migration
@@ -1,1 +1,2 @@
 * Fixed software deduplication when migrating from < 4.67.0 for cases where exactly two software entries would be merged into one.
+* Included host software installed paths migration in the above database migration, instead of waiting for software ingestion to repopulate/clean up affected rows.

--- a/server/datastore/mysql/migrations/tables/20250410104321_UpdateMacOSSoftwareNames_test.go
+++ b/server/datastore/mysql/migrations/tables/20250410104321_UpdateMacOSSoftwareNames_test.go
@@ -25,9 +25,9 @@ func computeRawChecksumIncludingName(sw fleet.Software) ([]byte, error) {
 func TestUp_20250410104321(t *testing.T) {
 	db := applyUpToPrev(t)
 
-	// 13 pieces of software, 10 of which are unique, 11 of which are macOS apps
+	// 16 pieces of software, 14 (pre-dedupe) of which are macOS apps, 11 of which are unique (relative to software table)
 	// Each piece of software is on a different host, other than MacApp Duplicate 3, which is on the same host
-	// as another of the MacApps (same bundle ID). This means we'll start with 13 host_software entries and
+	// as another of the MacApps (same bundle ID). This means we'll start with 16 host_software entries and
 	// expect one of those entries to go away.
 	softwares := []fleet.Software{
 		{Name: "MacApp.app", Source: "apps", BundleIdentifier: "com.example.foo", Version: "1"},
@@ -37,6 +37,9 @@ func TestUp_20250410104321(t *testing.T) {
 		{Name: "no_bundle_id.app", Source: "apps", BundleIdentifier: "", Version: "42"},
 		{Name: "no_bundle_id_2.app", Source: "apps", BundleIdentifier: "", Version: "24"},
 		{Name: "MacApp2.app", Source: "apps", BundleIdentifier: "com.example.foo2", Version: "2"},
+		{Name: "MacApp2 2.app", Source: "apps", BundleIdentifier: "com.example.foo2", Version: "2"},
+		{Name: "MacApp2.1.app", Source: "apps", BundleIdentifier: "com.example.foo2", Version: "2.1"},   // should be a different software post-migration
+		{Name: "MacApp2.1 2.app", Source: "apps", BundleIdentifier: "com.example.foo2", Version: "2.1"}, // should be the same software as the line above
 		{Name: "Chrome Extension", Source: "chrome_extensions", Browser: "chrome", Version: "3"},
 		{Name: "Microsoft Teams.exe", Source: "programs", Version: "4"},
 		{Name: "Live Captions.app", Source: "apps", BundleIdentifier: "com.apple.accessibility.LiveTranscriptionAgent", Version: "1.0"},
@@ -47,11 +50,11 @@ func TestUp_20250410104321(t *testing.T) {
 
 	// add some software titles
 	dataStmt := `INSERT INTO software_titles (name, source, browser, bundle_identifier) VALUES (?, ?, ?, ?)`
-
 	for i, s := range softwares {
 		if (i > 0 && s.BundleIdentifier == "com.example.foo") ||
 			s.Name == "LiveTranscriptionAgent.app" ||
-			s.Name == "Postman Helper.app" {
+			s.Name == "Postman Helper.app" ||
+			s.Version == "2.1" || s.Name == "MacApp2 2.app" {
 			continue
 		}
 		var bid any = ptr.String(s.BundleIdentifier)
@@ -69,11 +72,14 @@ func TestUp_20250410104321(t *testing.T) {
 		softwares[i].TitleID = ptr.Uint(uint(id)) //nolint:gosec // dismiss G115
 
 		// More duplicate mapping to existing software title ID
+		if s.BundleIdentifier == "com.example.foo2" {
+			softwares[8].TitleID = ptr.Uint(uint(id)) //nolint:gosec // dismiss G115
+		}
 		if s.BundleIdentifier == "com.apple.accessibility.LiveTranscriptionAgent" {
-			softwares[10].TitleID = ptr.Uint(uint(id)) //nolint:gosec // dismiss G115
+			softwares[12].TitleID = ptr.Uint(uint(id)) //nolint:gosec // dismiss G115
 		}
 		if s.BundleIdentifier == "com.postmanlabs.mac.helper" {
-			softwares[10].TitleID = ptr.Uint(uint(id)) //nolint:gosec // dismiss G115
+			softwares[14].TitleID = ptr.Uint(999) // throwing in a broken title ID to reflect some deployed environments
 		}
 	}
 
@@ -106,7 +112,7 @@ func TestUp_20250410104321(t *testing.T) {
 		}
 		execNoErr(t, db, "INSERT INTO host_software (host_id, software_id) VALUES (?, ?)", hostID, uint(id)) //nolint:gosec // dismiss G115
 
-		// insert installed paths for macOS apps to make sure all 11 get migrated over
+		// insert installed paths for macOS apps to make sure all get migrated over
 		if s.Source == "apps" {
 			execNoErr(t, db, "INSERT INTO host_software_installed_paths (host_id, software_id, installed_path) VALUES (?, ?, ?)",
 				hostID,
@@ -135,14 +141,14 @@ func TestUp_20250410104321(t *testing.T) {
 	// macOS apps should be modified, others should not
 
 	var gotSoftware []fleet.Software
-	err = db.Select(&gotSoftware, `SELECT id, name, checksum, name_source FROM software`)
+	err = db.Select(&gotSoftware, `SELECT id, name, checksum, name_source, version FROM software ORDER BY id ASC`)
 	require.NoError(t, err)
-	require.Len(t, gotSoftware, 8)
+	require.Len(t, gotSoftware, 9)
 
 	var gotSoftwareTitles []fleet.SoftwareTitle
 	err = db.Select(&gotSoftwareTitles, "SELECT id, name, source, browser, bundle_identifier FROM software_titles")
 	require.NoError(t, err)
-	require.Len(t, gotSoftwareTitles, 8)
+	require.Len(t, gotSoftwareTitles, 8) // two versions of MacApp2
 
 	for _, got := range gotSoftwareTitles {
 		switch got.ID {
@@ -164,18 +170,23 @@ func TestUp_20250410104321(t *testing.T) {
 		default:
 			require.NotContains(t, got.Name, ".app")
 			require.Equal(t, "basic", got.NameSource)
-			require.NotContains(t, got.Name, ".app")
 		}
 	}
+
+	// Rows in the set are MacApp (duplicates deleted), no_bundle_id, no_bundle_id_2, MacApp2 v2, MacApp2 v2.1, etc.
+	require.Equal(t, "MacApp2", gotSoftware[3].Name)
+	require.Equal(t, "2", gotSoftware[3].Version)
+	require.Equal(t, "MacApp2.1", gotSoftware[4].Name)
+	require.Equal(t, "2.1", gotSoftware[4].Version)
 
 	var count int
 	err = db.Get(&count, "SELECT COUNT(*) FROM software_cve")
 	require.NoError(t, err)
-	require.Equal(t, 8, count)
+	require.Equal(t, 9, count)
 
 	err = db.Get(&count, "SELECT COUNT(*) FROM host_software")
 	require.NoError(t, err)
-	require.Equal(t, 12, count)
+	require.Equal(t, 15, count)
 
 	// ensure no orphaned host software installed paths
 	err = db.Get(&count, `SELECT COUNT(*) FROM host_software_installed_paths WHERE software_id NOT IN (SELECT id FROM software)`)
@@ -184,12 +195,12 @@ func TestUp_20250410104321(t *testing.T) {
 
 	err = db.Get(&count, `SELECT COUNT(*) FROM host_software_installed_paths WHERE software_id IN (SELECT id FROM software)`)
 	require.NoError(t, err)
-	require.Equal(t, 11, count)
+	require.Equal(t, 14, count) // one per install; one host has two paths
 
 	// ensure we have the expected number of unique software IDs on host software installed paths (same as software count with source apps)
 	err = db.Get(&count, `SELECT COUNT(DISTINCT software_id) FROM host_software_installed_paths`)
 	require.NoError(t, err)
-	require.Equal(t, 6, count)
+	require.Equal(t, 7, count)
 
 	// ensure both copies of the same app are listed in installed paths for the host that has this case
 	var getSoftwarePaths []fleet.HostSoftwareInstalledPath
@@ -197,8 +208,8 @@ func TestUp_20250410104321(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, getSoftwarePaths, 2)
 	require.Equal(t, getSoftwarePaths[0].SoftwareID, getSoftwarePaths[1].SoftwareID)
-	require.Equal(t, getSoftwarePaths[0].InstalledPath, "/Applications/MacApp Duplicate 2.app")
-	require.Equal(t, getSoftwarePaths[1].InstalledPath, "/Applications/MacApp Duplicate 3.app")
+	require.Equal(t, "/Applications/MacApp Duplicate 2.app", getSoftwarePaths[0].InstalledPath)
+	require.Equal(t, "/Applications/MacApp Duplicate 3.app", getSoftwarePaths[1].InstalledPath)
 
 	err = db.Get(&count, `SELECT COUNT(*) FROM host_software WHERE software_id IN (?, ?)`, softwareIDs[1], softwareIDs[2])
 	require.NoError(t, err)
@@ -207,4 +218,48 @@ func TestUp_20250410104321(t *testing.T) {
 	err = db.Get(&count, `SELECT COUNT(*) FROM host_software WHERE software_id = ?`, softwareIDs[0])
 	require.NoError(t, err)
 	require.Equal(t, count, 3)
+
+	var hostIDs []uint
+
+	// ensure MacApp2 v2 has the expected (two) hosts associated
+	err = db.Select(&hostIDs, `SELECT host_id FROM host_software JOIN software ON software.id = host_software.software_id
+			WHERE bundle_identifier = "com.example.foo2" AND version = "2" ORDER BY host_id`)
+	require.NoError(t, err)
+	require.Len(t, hostIDs, 2)
+	require.Equal(t, uint(7), hostIDs[0])
+	require.Equal(t, uint(8), hostIDs[1])
+
+	// ensure installed paths map from the correct host to the correct software for MacApp2 v2
+	err = db.Select(&getSoftwarePaths, `SELECT host_id, software_id, installed_path FROM host_software_installed_paths
+    		JOIN software ON software.id = host_software_installed_paths.software_id
+			WHERE bundle_identifier = "com.example.foo2" AND version = "2" ORDER BY host_id`)
+	require.NoError(t, err)
+	require.Len(t, getSoftwarePaths, 2)
+	require.Equal(t, uint(7), getSoftwarePaths[0].HostID)
+	require.Equal(t, gotSoftware[3].ID, getSoftwarePaths[0].SoftwareID)
+	require.Equal(t, "/Applications/MacApp2.app", getSoftwarePaths[0].InstalledPath)
+	require.Equal(t, uint(8), getSoftwarePaths[1].HostID)
+	require.Equal(t, gotSoftware[3].ID, getSoftwarePaths[1].SoftwareID)
+	require.Equal(t, "/Applications/MacApp2 2.app", getSoftwarePaths[1].InstalledPath)
+
+	// ensure MacApp2 v2.1 has the expected (two) hosts associated
+	err = db.Select(&hostIDs, `SELECT host_id FROM host_software JOIN software ON software.id = host_software.software_id
+			WHERE bundle_identifier = "com.example.foo2" AND version = "2.1" ORDER BY host_id`)
+	require.NoError(t, err)
+	require.Len(t, hostIDs, 2)
+	require.Equal(t, uint(9), hostIDs[0])
+	require.Equal(t, uint(10), hostIDs[1])
+
+	// ensure installed paths map from the correct host to the correct software for MacApp2 v2.1
+	err = db.Select(&getSoftwarePaths, `SELECT host_id, software_id, installed_path FROM host_software_installed_paths
+    		JOIN software ON software.id = host_software_installed_paths.software_id
+			WHERE bundle_identifier = "com.example.foo2" AND version = "2.1" ORDER BY host_id`)
+	require.NoError(t, err)
+	require.Len(t, getSoftwarePaths, 2)
+	require.Equal(t, uint(9), getSoftwarePaths[0].HostID)
+	require.Equal(t, gotSoftware[4].ID, getSoftwarePaths[0].SoftwareID)
+	require.Equal(t, "/Applications/MacApp2.1.app", getSoftwarePaths[0].InstalledPath)
+	require.Equal(t, uint(10), getSoftwarePaths[1].HostID)
+	require.Equal(t, gotSoftware[4].ID, getSoftwarePaths[1].SoftwareID)
+	require.Equal(t, "/Applications/MacApp2.1 2.app", getSoftwarePaths[1].InstalledPath)
 }

--- a/server/datastore/mysql/migrations/tables/20250410104321_UpdateMacOSSoftwareNames_test.go
+++ b/server/datastore/mysql/migrations/tables/20250410104321_UpdateMacOSSoftwareNames_test.go
@@ -1,7 +1,7 @@
 package tables
 
 import (
-	"crypto/md5"
+	"crypto/md5" // nolint:gosec // used only to hash for efficient comparisons
 	"fmt"
 	"strings"
 	"testing"


### PR DESCRIPTION
For #28586.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/Committing-Changes.md#changes-files) for more information.
- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [x] If database migrations are included, checked table schema to confirm autoupdate
- For database migrations:
  - [x] Checked schema for all modified table for columns that will auto-update timestamps during migration.
  - [x] Confirmed that updating the timestamps is acceptable, and will not cause unwanted side effects.
  - [x] Ensured the correct collation is explicitly set for character columns (`COLLATE utf8mb4_unicode_ci`).
- [x] Added/updated automated tests
- [x] Manual QA for all new/changed functionality