### PR TITLE
Fix `concurrent map writes` crashes in orbit

### DIFF
--- a/orbit/changes/28576-fix-concurrent-map-writes
+++ b/orbit/changes/28576-fix-concurrent-map-writes
@@ -1,0 +1,1 @@
+* Fixed "concurrent map writes" crashes in orbit when both `EscrowBuddy` and `swiftDialog` components are updated/fetched.

--- a/orbit/pkg/update/update.go
+++ b/orbit/pkg/update/update.go
@@ -67,10 +67,18 @@ const (
 // Updater supports updating plain executables and
 // .tar.gz compressed executables.
 type Updater struct {
-	opt     Options
-	client  *client.Client
+	opt Options
+	// targetsMu protects access to opt.Targets.
+	targetsMu sync.Mutex
+
+	client *client.Client
+	// clientMu protects access to client.
+	//
+	// There have been some race conditions when concurrently operating on
+	// go-tuf `client` (see #28576) thus we protect its access with a mutex.
+	clientMu sync.Mutex
+
 	retryer *retry.LimitedWithCooldown
-	mu      sync.Mutex
 }
 
 // Options are the options that can be provided when creating an Updater.
@@ -111,15 +119,15 @@ func (ts Targets) SetTargetChannel(target, channel string) {
 
 // SetTargetInfo sets/updates the TargetInfo for the given target.
 func (u *Updater) SetTargetInfo(name string, info TargetInfo) {
-	u.mu.Lock()
-	defer u.mu.Unlock()
+	u.targetsMu.Lock()
+	defer u.targetsMu.Unlock()
 	u.opt.Targets[name] = info
 }
 
 // RemoveTargetInfo removes the TargetInfo for the given target.
 func (u *Updater) RemoveTargetInfo(name string) {
-	u.mu.Lock()
-	defer u.mu.Unlock()
+	u.targetsMu.Lock()
+	defer u.targetsMu.Unlock()
 	delete(u.opt.Targets, name)
 }
 
@@ -206,6 +214,9 @@ func NewDisabled(opt Options) *Updater {
 
 // UpdateMetadata downloads and verifies remote repository metadata.
 func (u *Updater) UpdateMetadata() error {
+	u.clientMu.Lock()
+	defer u.clientMu.Unlock()
+
 	if _, err := u.client.Update(); err != nil {
 		return fmt.Errorf("client update: %w", err)
 	}
@@ -241,8 +252,8 @@ func (u *Updater) LookupsFail() bool {
 
 // repoPath returns the path of the target in the remote repository.
 func (u *Updater) repoPath(target string) (string, error) {
-	u.mu.Lock()
-	defer u.mu.Unlock()
+	u.targetsMu.Lock()
+	defer u.targetsMu.Unlock()
 
 	t, ok := u.opt.Targets[target]
 	if !ok {
@@ -343,8 +354,8 @@ type LocalTarget struct {
 
 // localTarget returns the info and local path of a target.
 func (u *Updater) localTarget(target string) (*LocalTarget, error) {
-	u.mu.Lock()
-	defer u.mu.Unlock()
+	u.targetsMu.Lock()
+	defer u.targetsMu.Unlock()
 
 	t, ok := u.opt.Targets[target]
 	if !ok {
@@ -367,6 +378,10 @@ func (u *Updater) Lookup(target string) (*data.TargetFileMeta, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	u.clientMu.Lock()
+	defer u.clientMu.Unlock()
+
 	t, err := u.client.Target(repoPath)
 	if err != nil {
 		return nil, fmt.Errorf("lookup %s: %w", target, err)
@@ -376,6 +391,9 @@ func (u *Updater) Lookup(target string) (*data.TargetFileMeta, error) {
 
 // Targets gets all of the known targets
 func (u *Updater) Targets() (data.TargetFiles, error) {
+	u.clientMu.Lock()
+	defer u.clientMu.Unlock()
+
 	targets, err := u.client.Targets()
 	if err != nil {
 		return nil, fmt.Errorf("get targets: %w", err)
@@ -537,9 +555,12 @@ func (u *Updater) download(target, repoPath, localPath string, customCheckExec f
 	}
 
 	// The go-tuf client handles checking of max size and hash.
+	u.clientMu.Lock()
 	if err := u.client.Download(repoPath, &fileDestination{tmp}); err != nil {
+		u.clientMu.Unlock()
 		return fmt.Errorf("download target %s: %w", repoPath, err)
 	}
+	u.clientMu.Unlock()
 	if err := tmp.Close(); err != nil {
 		return fmt.Errorf("close tmp file: %w", err)
 	}

--- a/tools/tuf/test/README.md
+++ b/tools/tuf/test/README.md
@@ -20,7 +20,7 @@ Scripts in this directory aim to ease the testing of Orbit and the [TUF](https:/
 
 The `main.sh` creates and runs the TUF repository and optionally generate the installers (GENERATE_PKGS):
 ```sh
-SYSTEMS="macos windows linux linux-arm64" \
+SYSTEMS="macos windows linux linux-arm64 windows-arm64" \
 PKG_FLEET_URL=https://localhost:8080 \
 PKG_TUF_URL=http://localhost:8081 \
 DEB_FLEET_URL=https://host.docker.internal:8080 \
@@ -35,6 +35,7 @@ GENERATE_DEB_ARM64=1 \
 GENERATE_RPM=1 \
 GENERATE_RPM_ARM64=1 \
 GENERATE_MSI=1 \
+GENERATE_MSI_ARM64=1 \
 ENROLL_SECRET=6/EzU/+jPkxfTamWnRv1+IJsO4T9Etju \
 FLEET_DESKTOP=1 \
 USE_FLEET_SERVER_CERTIFICATE=1 \
@@ -118,7 +119,7 @@ make osqueryd-app-tar-gz version=5.5.1 out-path=.
 # Push the osqueryd target as a new version
 ./tools/tuf/test/push_target.sh macos-app osqueryd osqueryd.app.tar.gz 5.5.1
 ```
-NOTE: Contributors on macOS with Apple silicon ran into issues running osqueryd downloaded from GitHub. Until this issue is root caused, the workaround is to download osqueryd from [Fleet's TUF](https://tuf.fleetctl.com/).
+NOTE: Contributors on macOS with Apple silicon ran into issues running osqueryd downloaded from GitHub. Until this issue is root caused, the workaround is to download osqueryd from [Fleet's TUF](https://updates.fleetdm.com/).
 
 E.g. to add a new version of `desktop` for macOS:
 ```sh

--- a/tools/tuf/test/create_repository.sh
+++ b/tools/tuf/test/create_repository.sh
@@ -31,7 +31,7 @@ NUDGE_VERSION=stable
 ESCROW_BUDDY_PKG_VERSION=1.0.0
 
 if [[ -z "$OSQUERY_VERSION" ]]; then
-    OSQUERY_VERSION=5.14.1
+    OSQUERY_VERSION=5.16.0
 fi
 
 mkdir -p $TUF_PATH/tmp
@@ -60,7 +60,7 @@ for system in $SYSTEMS; do
     else
         osqueryd_path="$TUF_PATH/tmp/$osqueryd"
     fi
-    curl https://tuf.fleetctl.com/targets/osqueryd/$osqueryd_system/$OSQUERY_VERSION/$osqueryd --output $osqueryd_path
+    curl https://updates.fleetdm.com/targets/osqueryd/$osqueryd_system/$OSQUERY_VERSION/$osqueryd --output $osqueryd_path
 
     major=$(echo "$OSQUERY_VERSION" | cut -d "." -f 1)
     min=$(echo "$OSQUERY_VERSION" | cut -d "." -f 2)
@@ -154,7 +154,7 @@ for system in $SYSTEMS; do
 
     # Add Nudge application on macos (if enabled).
     if [[ $system == "macos" && -n "$NUDGE" ]]; then
-        curl https://tuf.fleetctl.com/targets/nudge/macos/$NUDGE_VERSION/nudge.app.tar.gz --output nudge.app.tar.gz
+        curl https://updates.fleetdm.com/targets/nudge/macos/$NUDGE_VERSION/nudge.app.tar.gz --output nudge.app.tar.gz
         ./build/fleetctl updates add \
             --path $TUF_PATH \
             --target nudge.app.tar.gz \
@@ -166,7 +166,7 @@ for system in $SYSTEMS; do
 
     # Add swiftDialog on macos (if enabled).
     if [[ $system == "macos" && -n "$SWIFT_DIALOG" ]]; then
-        curl https://tuf.fleetctl.com/targets/swiftDialog/macos/stable/swiftDialog.app.tar.gz --output swiftDialog.app.tar.gz
+        curl https://updates.fleetdm.com/targets/swiftDialog/macos/stable/swiftDialog.app.tar.gz --output swiftDialog.app.tar.gz
 
         ./build/fleetctl updates add \
             --path $TUF_PATH \


### PR DESCRIPTION
#28576

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/Committing-Changes.md#changes-files) for more information.
- [x] A detailed QA plan exists on the associated ticket (if it isn't there, work with the product group's QA engineer to add it)
- [x] Manual QA for all new/changed functionality
- For Orbit and Fleet Desktop changes:
   - [x] Make sure fleetd is compatible with the latest released version of Fleet (see [Must rule](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/fleetd-development-and-release-strategy.md)).
   - [x] Orbit runs on macOS, Linux and Windows. Check if the orbit feature/bugfix should only apply to one platform (`runtime.GOOS`).
   - [x] Manual QA must be performed in the three main OSs, macOS, Windows and Linux.
   - [x] Auto-update manual QA, from released version of component to new version (see [tools/tuf/test](../tools/tuf/test/README.md)).