### PR TITLE
Exclude certain sections from var interpolation when running gitops cmd

### DIFF
--- a/changes/27477-do-not-interpolate-gitops-text-sections
+++ b/changes/27477-do-not-interpolate-gitops-text-sections
@@ -1,0 +1,1 @@
+- Fixed an issue where selections made on the Queries page were cleared a few seconds after page load.

--- a/changes/27477-do-not-interpolate-gitops-text-sections
+++ b/changes/27477-do-not-interpolate-gitops-text-sections
@@ -1,1 +1,1 @@
-- Fixed an issue where selections made on the Queries page were cleared a few seconds after page load.
+- Fixed an issue with the gitops command caused when trying to interpolate variables inside the 'description'/'remediation' sections.

--- a/pkg/spec/testdata/global_config_no_paths.yml
+++ b/pkg/spec/testdata/global_config_no_paths.yml
@@ -84,8 +84,11 @@ policies:
   - name: 😊😊 Failing policy
     platform: linux
     description: This policy should always fail.
-    resolution: There is no resolution for this policy.
-    query: SELECT 1 FROM osquery_info WHERE start_time < 0;
+    resolution: |
+      Automated method:
+      Ask your system administrator to deploy the following script which will ensure proper Security Auditing Retention:
+      cp /etc/security/audit_control ./tmp.txt; origExpire=$(cat ./tmp.txt  | grep expire-after);  sed "s/${origExpire}/expire-after:60d OR 5G/" ./tmp.txt > /etc/security/audit_control; rm ./tmp.txt;
+    query: SELECT 1;
 agent_options:
   command_line_flags:
     distributed_denylist_duration: 0

--- a/pkg/spec/testdata/policies/policies.yml
+++ b/pkg/spec/testdata/policies/policies.yml
@@ -6,7 +6,10 @@
 - name: Passing policy
   platform: linux,windows,darwin,chrome
   description: This policy should always pass.
-  resolution: There is no resolution for this policy.
+  resolution: |
+    Automated method:
+    Ask your system administrator to deploy the following script which will ensure proper Security Auditing Retention:
+    cp /etc/security/audit_control ./tmp.txt; origExpire=$(cat ./tmp.txt  | grep expire-after);  sed "s/${origExpire}/expire-after:60d OR 5G/" ./tmp.txt > /etc/security/audit_control; rm ./tmp.txt;
   query: SELECT 1;
 - name: No root logins (macOS, Linux)
   platform: linux,darwin

--- a/server/datastore/mysql/secret_variables.go
+++ b/server/datastore/mysql/secret_variables.go
@@ -149,7 +149,7 @@ func (ds *Datastore) expandEmbeddedSecrets(ctx context.Context, document string)
 		return "", nil, fleet.MissingSecretsError{MissingSecrets: missingSecrets}
 	}
 
-	expanded := fleet.MaybeExpand(document, func(s string) (string, bool) {
+	expanded := fleet.MaybeExpand(document, func(s string, startPos, endPos int) (string, bool) {
 		if !strings.HasPrefix(s, fleet.ServerSecretPrefix) {
 			return "", false
 		}

--- a/server/fleet/fleet_vars.go
+++ b/server/fleet/fleet_vars.go
@@ -26,10 +26,10 @@ func ContainsPrefixVars(text, prefix string) []string {
 }
 
 // MaybeExpand conditionally replaces ${var} or $var in the string based on the mapping function.
-// Only repalces the variable with the mapper string if it returns true.
+// Only replaces the variable with the mapper string if it returns true.
 // The mapper returning false will leave the original variable unchanged.
 // Based on os.Expand
-func MaybeExpand(s string, mapping func(string) (string, bool)) string {
+func MaybeExpand(s string, mapping func(string, int, int) (string, bool)) string {
 	var buf []byte
 	// ${} is all ASCII, so bytes are fine for this operation.
 	i := 0
@@ -47,7 +47,7 @@ func MaybeExpand(s string, mapping func(string) (string, bool)) string {
 				w = 0
 				buf = append(buf, s[j])
 			} else {
-				replacement, shouldReplace := mapping(name)
+				replacement, shouldReplace := mapping(name, j, j+w+1)
 				if shouldReplace {
 					buf = append(buf, replacement...)
 				} else {

--- a/server/fleet/fleet_vars_test.go
+++ b/server/fleet/fleet_vars_test.go
@@ -33,15 +33,27 @@ This is $OTHER_VAR, $ $$ $* ${} in a sentence with${ALSO_OTHER_VAR}in the middle
 We want to remember BREAD and alsoSHORTCAKEare important.
 `
 
-	mapping := map[string]string{
+	envVars := map[string]string{
 		"BANANA":     "BREAD",
 		"STRAWBERRY": "SHORTCAKE",
 	}
 
-	mapper := func(s string) (string, bool) {
+	expectedPositions := [][]int{
+		{9, 19},
+		{23, 25},
+		{26, 28},
+		{51, 68},
+		{103, 123},
+		{132, 158},
+	}
+
+	mapper := func(s string, startPos, endPos int) (string, bool) {
+		require.Contains(t, expectedPositions, []int{startPos, endPos}, script[startPos:endPos])
+
 		if strings.HasPrefix(s, ServerSecretPrefix) {
-			return mapping[strings.TrimPrefix(s, ServerSecretPrefix)], true
+			return envVars[strings.TrimPrefix(s, ServerSecretPrefix)], true
 		}
+
 		return "", false
 	}
 


### PR DESCRIPTION
Fixes #27477 

 When running the gitops command do not perform variable interpolation inside the 'description' nor the 'resolution' sections.

# Checklist for submitter

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/Committing-Changes.md#changes-files) for more information.
- [X] Added/updated automated tests
- [X] A detailed QA plan exists on the associated ticket (if it isn't there, work with the product group's QA engineer to add it)
- [X] Manual QA for all new/changed functionality
- [X] For unreleased bug fixes in a release candidate, confirmed that the fix is not expected to adversely impact load test results or alerted the release DRI if additional load testing is needed.
