### PR TITLE
Add temporary index during migration to update host software installed paths more quickly

### DIFF
--- a/changes/migration-speedup
+++ b/changes/migration-speedup
@@ -1,0 +1,1 @@
+* Added a temporary index during macOS software names migration to speed up host software installed paths cleanup introduced in 4.67(.2).


### PR DESCRIPTION
For #28814.

Found while migration testing ahead of cloud environment migrations. Speedup is on the order of 75x.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/Committing-Changes.md#changes-files) for more information.
- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [x] If database migrations are included, checked table schema to confirm autoupdate
- For database migrations:
  - [x] Checked schema for all modified table for columns that will auto-update timestamps during migration.
  - [x] Confirmed that updating the timestamps is acceptable, and will not cause unwanted side effects.
  - [x] Ensured the correct collation is explicitly set for character columns (`COLLATE utf8mb4_unicode_ci`).
- [x] Manual QA for all new/changed functionality