### PR TITLE
Update foreign vitals guide (IdP)

### DIFF
--- a/articles/foreign-vitals-map-idp-users-to-hosts.md
+++ b/articles/foreign-vitals-map-idp-users-to-hosts.md
@@ -62,6 +62,8 @@ After following steps above, you should be able to see latest requests from your
 
 To verify that user information is added to a host, go to the host that has IdP username assigned, and verify that **Full name (IdP)** and **Groups (IdP)** are populated correctly.
 
+> Currently, the IdP username is supported only on macOS hosts. It is added during automatic enrollment (DEP) if [end user authentication](https://fleetdm.com/docs/rest-api/rest-api#mdm-macos-setup) is enabled.
+
 ### Troubleshooting
 
 If you find that information from IdP (e.g full name or groups) is missing on the host, and host has IdP username assigned to it, follow steps below to resolve.

--- a/articles/foreign-vitals-map-idp-users-to-hosts.md
+++ b/articles/foreign-vitals-map-idp-users-to-hosts.md
@@ -62,7 +62,7 @@ After following steps above, you should be able to see latest requests from your
 
 To verify that user information is added to a host, go to the host that has IdP username assigned, and verify that **Full name (IdP)** and **Groups (IdP)** are populated correctly.
 
-> Currently, the IdP username is supported only on macOS hosts. It is added during automatic enrollment (DEP) if [end user authentication](https://fleetdm.com/docs/rest-api/rest-api#mdm-macos-setup) is enabled and if `await_device_configured` is present in the [automatic enrollment profile](https://fleetdm.com/guides/macos-setup-experience#step-1-create-an-automatic-enrollment-profile).
+> Currently, the IdP username is only supported on macOS hosts. It's collected once, during automatic enrollment (DEP), only if the [end user authenticates](https://fleetdm.com/docs/rest-api/rest-api#mdm-macos-setup) with the IdP and the DEP profile has `await_device_configured` set to `true` (default in the [automatic enrollment profile](https://fleetdm.com/guides/macos-setup-experience#step-1-create-an-automatic-enrollment-profile)).
 
 ### Troubleshooting
 

--- a/articles/foreign-vitals-map-idp-users-to-hosts.md
+++ b/articles/foreign-vitals-map-idp-users-to-hosts.md
@@ -62,7 +62,7 @@ After following steps above, you should be able to see latest requests from your
 
 To verify that user information is added to a host, go to the host that has IdP username assigned, and verify that **Full name (IdP)** and **Groups (IdP)** are populated correctly.
 
-> Currently, the IdP username is supported only on macOS hosts. It is added during automatic enrollment (DEP) if [end user authentication](https://fleetdm.com/docs/rest-api/rest-api#mdm-macos-setup) is enabled.
+> Currently, the IdP username is supported only on macOS hosts. It is added during automatic enrollment (DEP) if [end user authentication](https://fleetdm.com/docs/rest-api/rest-api#mdm-macos-setup) is enabled and if `await_device_configured` is present in the [automatic enrollment profile](https://fleetdm.com/guides/macos-setup-experience#step-1-create-an-automatic-enrollment-profile).
 
 ### Troubleshooting
 


### PR DESCRIPTION
Added note that IdP username can be added only to macOS hosts during ADE if end user authentication is enabled.