### PR TITLE
Update personal-mobile-devices.yml

### DIFF
--- a/it-and-security/teams/personal-mobile-devices.yml
+++ b/it-and-security/teams/personal-mobile-devices.yml
@@ -20,7 +20,6 @@ controls:
   macos_settings:
     custom_settings:
       - path: ../lib/ios/declaration-profiles/passcode-settings.json
-      - path: ../lib/ios/declaration-profiles/software-update-settings.json
   scripts:
 policies:
 queries:


### PR DESCRIPTION
- Removed incompatible DDM profile for unsupervised devices
