### PR TITLE
Fleet UI: Fix squished dropdown on safari

### DIFF
--- a/frontend/pages/SoftwarePage/SoftwareTitles/SoftwareTable/_styles.scss
+++ b/frontend/pages/SoftwarePage/SoftwareTitles/SoftwareTable/_styles.scss
@@ -1,6 +1,6 @@
 .software-table {
   &__software-filter {
-    min-width: 213px;
+    min-width: 215px;
   }
 
   &__filter-controls {


### PR DESCRIPTION
## Issue
For #28202 

## Description
- No squished dropdown on Safari

## Screenshot of fix
<img width="1402" alt="Screenshot 2025-04-29 at 4 53 56 PM" src="https://github.com/user-attachments/assets/17eb15ca-5f73-4410-a460-450bfad3c0d6" />


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] A detailed QA plan exists on the associated ticket (if it isn't there, work with the product group's QA engineer to add it)
- [x] Manual QA for all new/changed functionality

