### PR TITLE
Website: update content personalization to use new primaryBuyingSituation values.

### DIFF
--- a/website/assets/js/pages/contact.page.js
+++ b/website/assets/js/pages/contact.page.js
@@ -55,8 +55,9 @@ parasails.registerPage('contact', {
     }
     if(this.primaryBuyingSituation){ // If the user has a priamry buying situation set in their sesssion, pre-fill the form.
       // Note: this will be overriden if the user is logged in and has a primaryBuyingSituation set in the database.
-      this.formData.primaryBuyingSituation = this.primaryBuyingSituation;
+      this.$set(this.formData, 'primaryBuyingSituation', this.primaryBuyingSituation);
     }
+
     if(this.me){// prefill from database
       this.formDataToPrefillForLoggedInUsers.emailAddress = this.me.emailAddress;
       this.formDataToPrefillForLoggedInUsers.firstName = this.me.firstName;

--- a/website/assets/js/pages/pricing.page.js
+++ b/website/assets/js/pages/pricing.page.js
@@ -24,7 +24,7 @@ parasails.registerPage('pricing', {
       }
       window.location.hash = '';
     } else if(this.primaryBuyingSituation){
-      if(['eo-security', 'vm'].includes(this.primaryBuyingSituation)){
+      if(['security-misc', 'security-vm'].includes(this.primaryBuyingSituation)){
         this.pricingMode = 'Security';
       } else {
         this.pricingMode = 'IT';

--- a/website/views/layouts/layout.ejs
+++ b/website/views/layouts/layout.ejs
@@ -13,12 +13,12 @@
   var hideStartCTA;
   // Applies personalization for who people come from ads, so that the website makes more sense for them:
   var primaryBuyingSituation;
-  var defaultMetaDescription = 'Open-source '+(['mdm'].includes(primaryBuyingSituation) ? 'IT' : ['eo-security','vm'].includes(primaryBuyingSituation) ? 'security' : 'IT and security')+' for teams with lots of '+(primaryBuyingSituation === 'mdm' ? 'computers. (macOS, Windows, Linux, ChromeOS)' : 'workstations and servers. (Linux, macOS, Windows, cloud, data center, OT/ICS, Chrome)');
-  var corporationDisplayName = 'Fleet' + (primaryBuyingSituation === 'mdm' ? ' Device Management' : '') + ' Inc.'; // « Fleet has a DBA as "Fleet", with an official Delaware corporation name of "Fleet Device Management Inc".  -mikermcneil, 2024-03-01
+  var defaultMetaDescription = 'Open-source '+(['it-major-mdm', 'it-gap-filler-mdm', 'it-misc'].includes(primaryBuyingSituation) ? 'IT' : ['security-misc','security-vm'].includes(primaryBuyingSituation) ? 'security' : 'IT and security')+' for teams with lots of '+(['it-major-mdm', 'it-gap-filler-mdm'].includes(primaryBuyingSituation) ? 'computers. (macOS, Windows, Linux, ChromeOS)' : 'workstations and servers. (Linux, macOS, Windows, cloud, data center, OT/ICS, Chrome)');
+  var corporationDisplayName = 'Fleet' + (['it-major-mdm', 'it-gap-filler-mdm'].includes(primaryBuyingSituation) ? ' Device Management' : '') + ' Inc.'; // « Fleet has a DBA as "Fleet", with an official Delaware corporation name of "Fleet Device Management Inc".  -mikermcneil, 2024-03-01
 %><!DOCTYPE html>
 <html>
   <head>
-    <title>Fleet | <% if (typeof pageTitleForMeta !== 'undefined') { %><%= pageTitleForMeta %><% } else { %><%- partial('../partials/primary-tagline.partial.ejs') %><% } %></title>
+    <title>Fleet | <%= primaryBuyingSituation %> <% if (typeof pageTitleForMeta !== 'undefined') { %><%= pageTitleForMeta %><% } else { %><%- partial('../partials/primary-tagline.partial.ejs') %><% } %></title>
     <meta name="description" content="<%= typeof pageDescriptionForMeta !== 'undefined' ? pageDescriptionForMeta : defaultMetaDescription %>" />
 
     <% /* Viewport tag for sensible mobile support */ %>

--- a/website/views/layouts/layout.ejs
+++ b/website/views/layouts/layout.ejs
@@ -18,7 +18,7 @@
 %><!DOCTYPE html>
 <html>
   <head>
-    <title>Fleet | <%= primaryBuyingSituation %> <% if (typeof pageTitleForMeta !== 'undefined') { %><%= pageTitleForMeta %><% } else { %><%- partial('../partials/primary-tagline.partial.ejs') %><% } %></title>
+    <title>Fleet | <% if (typeof pageTitleForMeta !== 'undefined') { %><%= pageTitleForMeta %><% } else { %><%- partial('../partials/primary-tagline.partial.ejs') %><% } %></title>
     <meta name="description" content="<%= typeof pageDescriptionForMeta !== 'undefined' ? pageDescriptionForMeta : defaultMetaDescription %>" />
 
     <% /* Viewport tag for sensible mobile support */ %>

--- a/website/views/pages/contact.ejs
+++ b/website/views/pages/contact.ejs
@@ -138,7 +138,7 @@
       <p class="mt-3">A member of our team will get back to you soon.<br>Usually within one business day (or less!)</p>
     </div>
     <div purpose="quote-and-logos">
-      <div purpose="quote" v-if="!primaryBuyingSituation || primaryBuyingSituation === 'mdm'">
+      <div purpose="quote" v-if="!primaryBuyingSituation || ['it-major-mdm', 'it-gap-filler-mdm'].includes(primaryBuyingSituation)">
         <div purpose="logo" class="mb-4"><img height="32" alt="Stripe logo" src="/images/social-proof-logo-stripe-67x32@2x.png"></div>
         <p purpose="quote-text">
           We've been using Fleet for a few years at Stripe and we couldn't be happier. The fact that it's also open-source made it easy for us to try it out, customise it to our needs, and seamlessly integrate it into our existing environment.
@@ -153,7 +153,7 @@
           </div>
         </div>
       </div>
-      <div purpose="quote" v-else-if="primaryBuyingSituation === 'vm'">
+      <div purpose="quote" v-else-if="primaryBuyingSituation === 'security-vm'">
         <div purpose="logo" class="mb-4"><img height="32" alt="Rivian logo" src="/images/logo-rivian-dark-120x32@2x.png"></div>
         <p purpose="quote-text">
           The visibility down into the assets covered by the agent is phenomenal. Fleet has become the central source for a lot of things.
@@ -168,7 +168,7 @@
           </div>
         </div>
       </div>
-      <div purpose="quote" v-else-if="primaryBuyingSituation === 'eo-it'">
+      <div purpose="quote" v-else-if="primaryBuyingSituation === 'it-misc'">
         <div purpose="logo" class="mb-4"><img height="32" alt="Deputy logo" src="/images/social-proof-logo-stripe-67x32@2x.png"></div>
         <p purpose="quote-text">
           Mad props to how easy making a deploy pkg of the agent was. I wish everyone made stuff that easy.
@@ -183,7 +183,7 @@
           </div>
         </div>
       </div>
-      <div purpose="quote" v-else-if="primaryBuyingSituation === 'eo-security'">
+      <div purpose="quote" v-else-if="primaryBuyingSituation === 'security-misc'">
         <div purpose="logo" class="mb-4"><img height="32" alt="Deloitte logo" src="/images/social-proof-logo-deloitte-130x32@2x.png"></div>
         <p purpose="quote-text">
           Something I really appreciate about working with you guys is that it doesn't feel like I'm talking to a vendor. It actually feels like I'm talking to my team, and I really appreciate it.

--- a/website/views/pages/contact.ejs
+++ b/website/views/pages/contact.ejs
@@ -138,22 +138,7 @@
       <p class="mt-3">A member of our team will get back to you soon.<br>Usually within one business day (or less!)</p>
     </div>
     <div purpose="quote-and-logos">
-      <div purpose="quote" v-if="!primaryBuyingSituation || ['it-major-mdm', 'it-gap-filler-mdm'].includes(primaryBuyingSituation)">
-        <div purpose="logo" class="mb-4"><img height="32" alt="Stripe logo" src="/images/social-proof-logo-stripe-67x32@2x.png"></div>
-        <p purpose="quote-text">
-          We've been using Fleet for a few years at Stripe and we couldn't be happier. The fact that it's also open-source made it easy for us to try it out, customise it to our needs, and seamlessly integrate it into our existing environment.
-        </p>
-        <div purpose="quote-author-info" class="d-flex flex-row align-items-center">
-          <div purpose="profile-picture">
-            <img alt="Scott MacVicar" style="border-radius: 50%" src="/images/testimonial-author-scott-macvicar-100x100@2x.png">
-          </div>
-          <div class="d-flex flex-column align-self-top">
-            <p purpose="name" class="font-weight-bold m-0">Scott MacVicar</p>
-            <p purpose="job-title" class="m-0">Head of Developer Infrastructure &amp; Corporate Technology</p>
-          </div>
-        </div>
-      </div>
-      <div purpose="quote" v-else-if="primaryBuyingSituation === 'security-vm'">
+      <div purpose="quote" v-if="primaryBuyingSituation === 'security-vm'">
         <div purpose="logo" class="mb-4"><img height="32" alt="Rivian logo" src="/images/logo-rivian-dark-120x32@2x.png"></div>
         <p purpose="quote-text">
           The visibility down into the assets covered by the agent is phenomenal. Fleet has become the central source for a lot of things.
@@ -195,6 +180,21 @@
           <div class="d-flex flex-column align-self-top">
             <p purpose="name" class="font-weight-bold m-0">Chandra Majumdar</p>
             <p purpose="job-title" class="m-0">Partner - Cyber and Strategic Risk</p>
+          </div>
+        </div>
+      </div>
+      <div purpose="quote" v-else-if>
+        <div purpose="logo" class="mb-4"><img height="32" alt="Stripe logo" src="/images/social-proof-logo-stripe-67x32@2x.png"></div>
+        <p purpose="quote-text">
+          We've been using Fleet for a few years at Stripe and we couldn't be happier. The fact that it's also open-source made it easy for us to try it out, customise it to our needs, and seamlessly integrate it into our existing environment.
+        </p>
+        <div purpose="quote-author-info" class="d-flex flex-row align-items-center">
+          <div purpose="profile-picture">
+            <img alt="Scott MacVicar" style="border-radius: 50%" src="/images/testimonial-author-scott-macvicar-100x100@2x.png">
+          </div>
+          <div class="d-flex flex-column align-self-top">
+            <p purpose="name" class="font-weight-bold m-0">Scott MacVicar</p>
+            <p purpose="job-title" class="m-0">Head of Developer Infrastructure &amp; Corporate Technology</p>
           </div>
         </div>
       </div>

--- a/website/views/pages/device-management.ejs
+++ b/website/views/pages/device-management.ejs
@@ -7,7 +7,7 @@
           <h1>Manage everything in one place</h1>
         </div>
         <div purpose="testimonials" class="d-flex flex-md-row flex-column align-items-center justify-content-between">
-        <%if(['eo-security','vm'].includes(primaryBuyingSituation)) { %>
+        <%if(['security-misc','security-vm'].includes(primaryBuyingSituation)) { %>
           <div purpose="testimonial-quote">
             <div purpose="quote">
               <img alt="Deloitte logo" purpose="quote-logo" src="/images/social-proof-logo-deloitte-130x32@2x.png">

--- a/website/views/pages/entrance/login.ejs
+++ b/website/views/pages/entrance/login.ejs
@@ -32,23 +32,7 @@
         </div>
       </div>
       <div purpose="quote-and-logos" class="mx-auto mx-lg-0">
-        <% if(typeof primaryBuyingSituation === 'undefined' || ['it-major-mdm', 'it-gap-filler-mdm'].includes(primaryBuyingSituation)) { %>
-        <div purpose="quote">
-          <img alt="an opening quotation mark" style="width:20px; margin-bottom: 16px;" src="/images/icon-quote-21x17@2x.png">
-          <p purpose="quote-text">
-            We've been using Fleet for a few years at Stripe and we couldn't be happier. The fact that it's also open-source made it easy for us to try it out, customise it to our needs, and seamlessly integrate it into our existing environment.
-          </p>
-          <div purpose="quote-author-info" class="d-flex flex-row align-items-center">
-            <div purpose="profile-picture">
-              <img alt="Scott MacVicar" style="border-radius: 50%" src="/images/testimonial-author-scott-macvicar-100x100@2x.png">
-            </div>
-            <div class="d-flex flex-column align-self-top">
-              <p purpose="name" class="font-weight-bold m-0">Scott MacVicar</p>
-              <p purpose="job-title" class="m-0">Head of Developer Infrastructure &amp; Corporate Technology</p>
-            </div>
-          </div>
-        </div>
-        <% } else if (['it-misc'].includes(primaryBuyingSituation)) { %>
+        <% if (['it-misc'].includes(primaryBuyingSituation)) { %>
           <div purpose="quote">
             <img alt="an opening quotation mark" style="width:20px; margin-bottom: 16px;" src="/images/icon-quote-21x17@2x.png">
             <p purpose="quote-text">
@@ -93,6 +77,22 @@
               <div class="d-flex flex-column align-self-top">
                 <p purpose="name" class="font-weight-bold m-0">Andre Shields</p>
                 <p purpose="job-title" class="m-0">Staff Cybersecurity Engineer, Vulnerability Management</p>
+              </div>
+            </div>
+          </div>
+          <% } else { %>
+          <div purpose="quote">
+            <img alt="an opening quotation mark" style="width:20px; margin-bottom: 16px;" src="/images/icon-quote-21x17@2x.png">
+            <p purpose="quote-text">
+              We've been using Fleet for a few years at Stripe and we couldn't be happier. The fact that it's also open-source made it easy for us to try it out, customise it to our needs, and seamlessly integrate it into our existing environment.
+            </p>
+            <div purpose="quote-author-info" class="d-flex flex-row align-items-center">
+              <div purpose="profile-picture">
+                <img alt="Scott MacVicar" style="border-radius: 50%" src="/images/testimonial-author-scott-macvicar-100x100@2x.png">
+              </div>
+              <div class="d-flex flex-column align-self-top">
+                <p purpose="name" class="font-weight-bold m-0">Scott MacVicar</p>
+                <p purpose="job-title" class="m-0">Head of Developer Infrastructure &amp; Corporate Technology</p>
               </div>
             </div>
           </div>

--- a/website/views/pages/entrance/login.ejs
+++ b/website/views/pages/entrance/login.ejs
@@ -32,7 +32,7 @@
         </div>
       </div>
       <div purpose="quote-and-logos" class="mx-auto mx-lg-0">
-        <% if(typeof primaryBuyingSituation === 'undefined' || ['mdm'].includes(primaryBuyingSituation)) { %>
+        <% if(typeof primaryBuyingSituation === 'undefined' || ['it-major-mdm', 'it-gap-filler-mdm'].includes(primaryBuyingSituation)) { %>
         <div purpose="quote">
           <img alt="an opening quotation mark" style="width:20px; margin-bottom: 16px;" src="/images/icon-quote-21x17@2x.png">
           <p purpose="quote-text">
@@ -48,7 +48,7 @@
             </div>
           </div>
         </div>
-        <% } else if (['eo-it'].includes(primaryBuyingSituation)) { %>
+        <% } else if (['it-misc'].includes(primaryBuyingSituation)) { %>
           <div purpose="quote">
             <img alt="an opening quotation mark" style="width:20px; margin-bottom: 16px;" src="/images/icon-quote-21x17@2x.png">
             <p purpose="quote-text">
@@ -64,7 +64,7 @@
               </div>
             </div>
           </div>
-        <% } else if (['eo-security'].includes(primaryBuyingSituation)) { %>
+        <% } else if (['security-misc'].includes(primaryBuyingSituation)) { %>
           <div purpose="quote">
             <img alt="an opening quotation mark" style="width:20px; margin-bottom: 16px;" src="/images/icon-quote-21x17@2x.png">
             <p purpose="quote-text">
@@ -80,7 +80,7 @@
               </div>
             </div>
           </div>
-        <% } else if (['vm'].includes(primaryBuyingSituation)) { %>
+        <% } else if (['security-vm'].includes(primaryBuyingSituation)) { %>
           <div purpose="quote">
             <img alt="an opening quotation mark" style="width:20px; margin-bottom: 16px;" src="/images/icon-quote-21x17@2x.png">
             <p purpose="quote-text">

--- a/website/views/pages/entrance/signup.ejs
+++ b/website/views/pages/entrance/signup.ejs
@@ -60,23 +60,7 @@
         </div>
       </div>
       <div purpose="quote-and-logos" class="mx-auto mx-lg-0">
-        <% if(typeof primaryBuyingSituation === 'undefined' || ['it-major-mdm', 'it-gap-filler-mdm'].includes(primaryBuyingSituation)) { %>
-          <div purpose="quote">
-            <img alt="an opening quotation mark" style="width:20px; margin-bottom: 16px;" src="/images/icon-quote-21x17@2x.png">
-            <p purpose="quote-text">
-              We've been using Fleet for a few years at Stripe and we couldn't be happier. The fact that it's also open-source made it easy for us to try it out, customise it to our needs, and seamlessly integrate it into our existing environment.
-            </p>
-            <div purpose="quote-author-info" class="d-flex flex-row align-items-center">
-              <div purpose="profile-picture">
-                <img alt="Scott MacVicar" style="border-radius: 50%" src="/images/testimonial-author-scott-macvicar-100x100@2x.png">
-              </div>
-              <div class="d-flex flex-column align-self-top">
-                <p purpose="name" class="font-weight-bold m-0">Scott MacVicar</p>
-                <p purpose="job-title" class="m-0">Head of Developer Infrastructure &amp; Corporate Technology</p>
-              </div>
-            </div>
-          </div>
-        <% } else if (['it-misc'].includes(primaryBuyingSituation)) { %>
+        <% if (['it-misc'].includes(primaryBuyingSituation)) { %>
           <div purpose="quote">
             <img alt="an opening quotation mark" style="width:20px; margin-bottom: 16px;" src="/images/icon-quote-21x17@2x.png">
             <p purpose="quote-text">
@@ -121,6 +105,22 @@
               <div class="d-flex flex-column align-self-top">
                 <p purpose="name" class="font-weight-bold m-0">Andre Shields</p>
                 <p purpose="job-title" class="m-0">Staff Cybersecurity Engineer, Vulnerability Management</p>
+              </div>
+            </div>
+          </div>
+          <% } else { %>
+          <div purpose="quote">
+            <img alt="an opening quotation mark" style="width:20px; margin-bottom: 16px;" src="/images/icon-quote-21x17@2x.png">
+            <p purpose="quote-text">
+              We've been using Fleet for a few years at Stripe and we couldn't be happier. The fact that it's also open-source made it easy for us to try it out, customise it to our needs, and seamlessly integrate it into our existing environment.
+            </p>
+            <div purpose="quote-author-info" class="d-flex flex-row align-items-center">
+              <div purpose="profile-picture">
+                <img alt="Scott MacVicar" style="border-radius: 50%" src="/images/testimonial-author-scott-macvicar-100x100@2x.png">
+              </div>
+              <div class="d-flex flex-column align-self-top">
+                <p purpose="name" class="font-weight-bold m-0">Scott MacVicar</p>
+                <p purpose="job-title" class="m-0">Head of Developer Infrastructure &amp; Corporate Technology</p>
               </div>
             </div>
           </div>

--- a/website/views/pages/entrance/signup.ejs
+++ b/website/views/pages/entrance/signup.ejs
@@ -60,7 +60,7 @@
         </div>
       </div>
       <div purpose="quote-and-logos" class="mx-auto mx-lg-0">
-        <% if(typeof primaryBuyingSituation === 'undefined' || ['mdm'].includes(primaryBuyingSituation)) { %>
+        <% if(typeof primaryBuyingSituation === 'undefined' || ['it-major-mdm', 'it-gap-filler-mdm'].includes(primaryBuyingSituation)) { %>
           <div purpose="quote">
             <img alt="an opening quotation mark" style="width:20px; margin-bottom: 16px;" src="/images/icon-quote-21x17@2x.png">
             <p purpose="quote-text">
@@ -76,7 +76,7 @@
               </div>
             </div>
           </div>
-        <% } else if (['eo-it'].includes(primaryBuyingSituation)) { %>
+        <% } else if (['it-misc'].includes(primaryBuyingSituation)) { %>
           <div purpose="quote">
             <img alt="an opening quotation mark" style="width:20px; margin-bottom: 16px;" src="/images/icon-quote-21x17@2x.png">
             <p purpose="quote-text">
@@ -92,7 +92,7 @@
               </div>
             </div>
           </div>
-        <% } else if (['eo-security'].includes(primaryBuyingSituation)) { %>
+        <% } else if (['security-misc'].includes(primaryBuyingSituation)) { %>
           <div purpose="quote">
             <img alt="an opening quotation mark" style="width:20px; margin-bottom: 16px;" src="/images/icon-quote-21x17@2x.png">
             <p purpose="quote-text">
@@ -108,7 +108,7 @@
               </div>
             </div>
           </div>
-        <% } else if (['vm'].includes(primaryBuyingSituation)) { %>
+        <% } else if (['security-vm'].includes(primaryBuyingSituation)) { %>
           <div purpose="quote">
             <img alt="an opening quotation mark" style="width:20px; margin-bottom: 16px;" src="/images/icon-quote-21x17@2x.png">
             <p purpose="quote-text">

--- a/website/views/pages/software-management.ejs
+++ b/website/views/pages/software-management.ejs
@@ -115,7 +115,7 @@
           <p purpose="job-title">Cybersecurity Security Engineer, Vulnerability Management</p>
         </div>
       </div>
-      <% if(['security-misc', 'security-vm'].includes(primaryBuyingSituation)) { %>
+      <% if(typeof primaryBuyingSituation === 'undefined' || ['security-misc', 'security-vm'].includes(primaryBuyingSituation)) { %>
         <div purpose="feature-slides">
           <div purpose="feature-switch" class="d-flex flex-md-row flex-column justify-content-md-center justify-content-start">
             <div purpose="feature-option" :class="[visibleFeature === 'mitigate-cves-automatically' ? 'active' : '']"  @click="clickSwitchFeature('mitigate-cves-automatically')">

--- a/website/views/pages/software-management.ejs
+++ b/website/views/pages/software-management.ejs
@@ -115,94 +115,93 @@
           <p purpose="job-title">Cybersecurity Security Engineer, Vulnerability Management</p>
         </div>
       </div>
-      <%  if(['eo-security', 'vm'].includes(primaryBuyingSituation)){ %>
-
-      <div purpose="feature-slides">
-        <div purpose="feature-switch" class="d-flex flex-md-row flex-column justify-content-md-center justify-content-start">
-          <div purpose="feature-option" :class="[visibleFeature === 'mitigate-cves-automatically' ? 'active' : '']"  @click="clickSwitchFeature('mitigate-cves-automatically')">
-            Mitigate CVEs automatically
+      <% if(['security-misc', 'security-vm'].includes(primaryBuyingSituation)) { %>
+        <div purpose="feature-slides">
+          <div purpose="feature-switch" class="d-flex flex-md-row flex-column justify-content-md-center justify-content-start">
+            <div purpose="feature-option" :class="[visibleFeature === 'mitigate-cves-automatically' ? 'active' : '']"  @click="clickSwitchFeature('mitigate-cves-automatically')">
+              Mitigate CVEs automatically
+            </div>
+            <div purpose="feature-option" :class="[visibleFeature === 'on-demand-data' ? 'active' : '']" @click="clickSwitchFeature('on-demand-data')">
+              On-demand data
+            </div>
+            <div purpose="feature-option" :class="[visibleFeature === 'out-of-the-box-reporting' ? 'active' : '']" @click="clickSwitchFeature('out-of-the-box-reporting')">
+              Out-of-the-box reporting
+            </div>
           </div>
-          <div purpose="feature-option" :class="[visibleFeature === 'on-demand-data' ? 'active' : '']" @click="clickSwitchFeature('on-demand-data')">
-            On-demand data
+          <div purpose="feature-slide" :class="[visibleFeature === 'mitigate-cves-automatically' ? '' : 'invisible']" class="d-flex flex-md-row flex-column-reverse justify-content-center mx-auto align-items-start">
+            <div purpose="feature-image">
+              <img alt="Mitigate CVEs automatically" src="/images/software-management-feature-slide-mitigate-cves-automatically-528x377@2x.png">
+            </div>
+            <div purpose="feature-text" class="d-flex flex-column">
+              <h3>Mitigate CVEs automatically</h3>
+              <p>Build automations that close tickets or mitigate vulnerabilities by updating or removing software and running custom scripts.</p>
+              <div purpose="checklist" class="flex-column d-flex">
+                <p>Automatically detect when old vulnerabilities are reintroduced, or mitigations falter.</p>
+                <p>Track and mitigate zero days, with live queries and policies, even before they're officially published as CVEs.</p>
+                <p>Only create tickets for vulnerabilities that affect your environment. Automate ticketing with Jira, ServiceNow, or integrate your own system.</p>
+                <p>Deep-link live data with internal IT and platform teams.</p>
+              </div>
+            </div>
           </div>
-          <div purpose="feature-option" :class="[visibleFeature === 'out-of-the-box-reporting' ? 'active' : '']" @click="clickSwitchFeature('out-of-the-box-reporting')">
-            Out-of-the-box reporting
+          <div purpose="feature-slide" :class="[visibleFeature === 'on-demand-data' ? '' : 'invisible']" class="d-flex flex-md-row flex-column-reverse justify-content-center mx-auto align-items-start">
+            <div purpose="feature-image">
+              <img alt="Deep context from the environment" src="/images/software-management-feature-slide-on-demand-data-528x377@2x.png">
+            </div>
+            <div purpose="feature-text" class="d-flex flex-column">
+              <h3>Deep context from the environment</h3>
+              <p>Fleet gives you data down to the chip level on every endpoint to help you make sense of which vulnerabilities to prioritize.</p>
+              <div purpose="checklist" class="flex-column d-flex">
+                <p>Automate prioritization with an admin-level agent that has visibility down to the chipset of any endpoint</p>
+                <p>Access over 300 tables of system state data. Use presets or create your own queries.</p>
+                <p>Automatically match CVEs to your operating systems, apps, extensions, browser plugins, Python libraries, everything.</p>
+              </div>
+              <div purpose="feature-link">
+                <animated-arrow-button href="/tables">Explore data</animated-arrow-button>
+              </div>
+            </div>
+          </div>
+          <div purpose="feature-slide" :class="[visibleFeature === 'out-of-the-box-reporting' ? '' : 'invisible']" class="d-flex flex-md-row flex-column-reverse justify-content-center mx-auto align-items-start">
+            <div purpose="feature-image">
+              <img alt="Report what matters" src="/images/software-management-feature-slide-out-of-the-box-reporting-528x377@2x.png">
+            </div>
+            <div purpose="feature-text" class="d-flex flex-column">
+              <h3>Report what matters</h3>
+              <p>Let's face it, most built-in graphs leave you wanting more. Report MTTR and any other custom metrics exactly the way you want to using fresh data from real computers.</p>
+              <div purpose="checklist" class="flex-column d-flex">
+                <p>Track any “celebrity” CVE across every OS, every cloud, and every device, and show how quickly it was mitigated.</p>
+                <p>Avoid distracting your CISO with bloated reports. Only communicate facts important to your organization's KPIs. Show real-time mitigation progress (%) or sync with your favorite data tool like Microsoft BI.</p>
+              </div>
+            </div>
           </div>
         </div>
-        <div purpose="feature-slide" :class="[visibleFeature === 'mitigate-cves-automatically' ? '' : 'invisible']" class="d-flex flex-md-row flex-column-reverse justify-content-center mx-auto align-items-start">
+        <div purpose="feature" class="d-flex flex-md-row flex-column-reverse justify-content-center mx-auto align-items-center">
+          <div purpose="feature-text" class="d-flex flex-column">
+            <h3>Up-to-date data without scans</h3>
+            <p>Traditional network vulnerability scans can clog your network and even haunt your printers with pages full of wingdings. Fleet does things differently.</p>
+            <div purpose="checklist" class="flex-column d-flex">
+              <p>Eliminate the risk of side effects from scanning the network.</p>
+              <p>Lightweight enough for the most brittle environments (OT, data centers, embedded/BTS, low-latency gaming servers).</p>
+              <p>Quickly pull data about important CVEs and zero days during an incident or audit.</p>
+            </div>
+          </div>
           <div purpose="feature-image">
-            <img alt="Mitigate CVEs automatically" src="/images/software-management-feature-slide-mitigate-cves-automatically-528x377@2x.png">
+            <img alt="Up-to-date data without scans" src="/images/software-management-feature-image-up-to-date-data-without-scans-528x377@2x.png">
+          </div>
+        </div>
+        <div purpose="feature" class="d-flex flex-md-row flex-column justify-content-center mx-auto align-items-center">
+          <div purpose="feature-image">
+            <img alt="Untangle your security stack" src="/images/software-management-feature-image-untangle-your-security-stack-528x377@2x.png">
           </div>
           <div purpose="feature-text" class="d-flex flex-column">
-            <h3>Mitigate CVEs automatically</h3>
-            <p>Build automations that close tickets or mitigate vulnerabilities by updating or removing software and running custom scripts.</p>
+            <h3>Untangle your security stack</h3>
+            <p>Use open data and APIs to connect your vulnerability solution with osquery, the agent you might already have deployed.</p>
             <div purpose="checklist" class="flex-column d-flex">
-              <p>Automatically detect when old vulnerabilities are reintroduced, or mitigations falter.</p>
-              <p>Track and mitigate zero days, with live queries and policies, even before they're officially published as CVEs.</p>
-              <p>Only create tickets for vulnerabilities that affect your environment. Automate ticketing with Jira, ServiceNow, or integrate your own system.</p>
-              <p>Deep-link live data with internal IT and platform teams.</p>
+              <p>Normalize asset management data and software inventories from multiple tools and operating systems.</p>
+              <p>Help teams work on vulnerabilities that have actually been exploited (CISA KEVs) or have a high probability of being exploited (EPSS), or whatever is important in your environment.</p>
+              <p>Process CVEs across cloud and non-cloud assets in a single platform and see who's responsible for what.</p>
             </div>
           </div>
         </div>
-        <div purpose="feature-slide" :class="[visibleFeature === 'on-demand-data' ? '' : 'invisible']" class="d-flex flex-md-row flex-column-reverse justify-content-center mx-auto align-items-start">
-          <div purpose="feature-image">
-            <img alt="Deep context from the environment" src="/images/software-management-feature-slide-on-demand-data-528x377@2x.png">
-          </div>
-          <div purpose="feature-text" class="d-flex flex-column">
-            <h3>Deep context from the environment</h3>
-            <p>Fleet gives you data down to the chip level on every endpoint to help you make sense of which vulnerabilities to prioritize.</p>
-            <div purpose="checklist" class="flex-column d-flex">
-              <p>Automate prioritization with an admin-level agent that has visibility down to the chipset of any endpoint</p>
-              <p>Access over 300 tables of system state data. Use presets or create your own queries.</p>
-              <p>Automatically match CVEs to your operating systems, apps, extensions, browser plugins, Python libraries, everything.</p>
-            </div>
-            <div purpose="feature-link">
-              <animated-arrow-button href="/tables">Explore data</animated-arrow-button>
-            </div>
-          </div>
-        </div>
-        <div purpose="feature-slide" :class="[visibleFeature === 'out-of-the-box-reporting' ? '' : 'invisible']" class="d-flex flex-md-row flex-column-reverse justify-content-center mx-auto align-items-start">
-          <div purpose="feature-image">
-            <img alt="Report what matters" src="/images/software-management-feature-slide-out-of-the-box-reporting-528x377@2x.png">
-          </div>
-          <div purpose="feature-text" class="d-flex flex-column">
-            <h3>Report what matters</h3>
-            <p>Let's face it, most built-in graphs leave you wanting more. Report MTTR and any other custom metrics exactly the way you want to using fresh data from real computers.</p>
-            <div purpose="checklist" class="flex-column d-flex">
-              <p>Track any “celebrity” CVE across every OS, every cloud, and every device, and show how quickly it was mitigated.</p>
-              <p>Avoid distracting your CISO with bloated reports. Only communicate facts important to your organization's KPIs. Show real-time mitigation progress (%) or sync with your favorite data tool like Microsoft BI.</p>
-            </div>
-          </div>
-        </div>
-      </div>
-      <div purpose="feature" class="d-flex flex-md-row flex-column-reverse justify-content-center mx-auto align-items-center">
-        <div purpose="feature-text" class="d-flex flex-column">
-          <h3>Up-to-date data without scans</h3>
-          <p>Traditional network vulnerability scans can clog your network and even haunt your printers with pages full of wingdings. Fleet does things differently.</p>
-          <div purpose="checklist" class="flex-column d-flex">
-            <p>Eliminate the risk of side effects from scanning the network.</p>
-            <p>Lightweight enough for the most brittle environments (OT, data centers, embedded/BTS, low-latency gaming servers).</p>
-            <p>Quickly pull data about important CVEs and zero days during an incident or audit.</p>
-          </div>
-        </div>
-        <div purpose="feature-image">
-          <img alt="Up-to-date data without scans" src="/images/software-management-feature-image-up-to-date-data-without-scans-528x377@2x.png">
-        </div>
-      </div>
-      <div purpose="feature" class="d-flex flex-md-row flex-column justify-content-center mx-auto align-items-center">
-        <div purpose="feature-image">
-          <img alt="Untangle your security stack" src="/images/software-management-feature-image-untangle-your-security-stack-528x377@2x.png">
-        </div>
-        <div purpose="feature-text" class="d-flex flex-column">
-          <h3>Untangle your security stack</h3>
-          <p>Use open data and APIs to connect your vulnerability solution with osquery, the agent you might already have deployed.</p>
-          <div purpose="checklist" class="flex-column d-flex">
-            <p>Normalize asset management data and software inventories from multiple tools and operating systems.</p>
-            <p>Help teams work on vulnerabilities that have actually been exploited (CISA KEVs) or have a high probability of being exploited (EPSS), or whatever is important in your environment.</p>
-            <p>Process CVEs across cloud and non-cloud assets in a single platform and see who's responsible for what.</p>
-          </div>
-        </div>
-      </div>
       <% } %>
     </div><%// End of [purpose="page-content"]%>
   </div><%// End of [purpose="page-container"]%>

--- a/website/views/pages/software-management.ejs
+++ b/website/views/pages/software-management.ejs
@@ -115,7 +115,7 @@
           <p purpose="job-title">Cybersecurity Security Engineer, Vulnerability Management</p>
         </div>
       </div>
-      <% if(typeof primaryBuyingSituation === 'undefined' || ['security-misc', 'security-vm'].includes(primaryBuyingSituation)) { %>
+      <% if(typeof primaryBuyingSituation === 'undefined' || !['it-misc', 'it-major-mdm', 'it-gap-filler-mdm'].includes(primaryBuyingSituation)) { %>
         <div purpose="feature-slides">
           <div purpose="feature-switch" class="d-flex flex-md-row flex-column justify-content-md-center justify-content-start">
             <div purpose="feature-option" :class="[visibleFeature === 'mitigate-cves-automatically' ? 'active' : '']"  @click="clickSwitchFeature('mitigate-cves-automatically')">

--- a/website/views/pages/support.ejs
+++ b/website/views/pages/support.ejs
@@ -7,7 +7,7 @@
       <%primaryBuyingSituation%>
     </div>
     <div purpose="community-cards" class="d-flex justify-content-center flex-sm-row flex-column">
-      <a href="https://macadmins.org" target="_blank" class="<%= primaryBuyingSituation === 'mdm' || !primaryBuyingSituation ? 'd-flex' : 'd-none' %>" no-icon>
+      <a href="https://macadmins.org" target="_blank" class="<%= primaryBuyingSituation === 'mdm' || primaryBuyingSituation === 'eo-it' || !primaryBuyingSituation ? 'd-flex' : 'd-none' %>" no-icon>
         <div purpose="support-card" class="card d-flex justify-content-center" >
           <div class="d-flex flex-row align-items-center">
             <img alt="Macadmins logo" src="/images/logo-macadmins-48x48@2x.png">

--- a/website/views/pages/support.ejs
+++ b/website/views/pages/support.ejs
@@ -7,7 +7,7 @@
       <%primaryBuyingSituation%>
     </div>
     <div purpose="community-cards" class="d-flex justify-content-center flex-sm-row flex-column">
-      <a href="https://macadmins.org" target="_blank" class="<%= primaryBuyingSituation === 'mdm' || primaryBuyingSituation === 'eo-it' || !primaryBuyingSituation ? 'd-flex' : 'd-none' %>" no-icon>
+      <a href="https://macadmins.org" target="_blank" class="<%= !primaryBuyingSituation || ['it-misc', 'it-major-mdm', 'it-gap-filler-mdm'].includes(primaryBuyingSituation)  ? 'd-flex' : 'd-none' %>" no-icon>
         <div purpose="support-card" class="card d-flex justify-content-center" >
           <div class="d-flex flex-row align-items-center">
             <img alt="Macadmins logo" src="/images/logo-macadmins-48x48@2x.png">
@@ -16,14 +16,14 @@
           <p>Chat about next-gen MDM, packaging, Apple, Windows, desktop Linux, apps, scripting. (And all things IT.)</p>
         </div>
       </a>
-      <a href="https://chat.osquery.io/c/fleet" target="_blank" class="<%= primaryBuyingSituation === 'mdm' || primaryBuyingSituation === 'eo-it' ? 'd-none' : 'd-flex'%>" no-icon>
+      <a href="https://chat.osquery.io/c/fleet" target="_blank" class="<%= ['it-misc', 'it-major-mdm', 'it-gap-filler-mdm'].includes(primaryBuyingSituation) ? 'd-none' : 'd-flex'%>" no-icon>
         <div purpose="support-card" class="card d-flex justify-content-center">
           <div class="d-flex flex-row align-items-center">
             <img alt="Osquery logo" src="/images/logo-osquery-48x48@2x.png">
             <h3>osquery // #fleet</h3>
           </div>
-          <p><%= primaryBuyingSituation === 'eo-security' ? 'Chat about securing servers, laptops, and more.' :
-                primaryBuyingSituation === 'vm' ? 'Chat about the future of security engineering, vulnerability management, OT/ICS, cybersecurity, and more.' :
+          <p><%= primaryBuyingSituation === 'security-misc' ? 'Chat about securing servers, laptops, and more.' :
+                primaryBuyingSituation === 'security-vm' ? 'Chat about the future of security engineering, vulnerability management, OT/ICS, cybersecurity, and more.' :
                 'Chat about posture, detection, vulns, reporting.  (And all things cybersecurity.)'
               %>
           </p>

--- a/website/views/partials/primary-tagline.partial.ejs
+++ b/website/views/partials/primary-tagline.partial.ejs
@@ -1,7 +1,7 @@
 <%=
   typeof primaryBuyingSituation === 'undefined' ? 'Open device management for everyone' // Default (no buying situation)
-  : primaryBuyingSituation === 'vm' ? 'Focus on vulnerabilities, not vendors' // vm
-  : primaryBuyingSituation === 'eo-security' ? 'Easily get security data'// eo-security
-  : primaryBuyingSituation === 'eo-it' ? 'Untangle your endpoints' : // eo-it
-  'Open device management for everyone'// mdm
+  : primaryBuyingSituation === 'security-vm' ? 'Focus on vulnerabilities, not vendors' // security-vm
+  : primaryBuyingSituation === 'security-misc' ? 'Easily get security data'// security-misc
+  : primaryBuyingSituation === 'it-misc' ? 'Untangle your endpoints' : // it-misc
+  'Open device management for everyone'// it-major-mdm & it-gap-filler-mdm
 %>


### PR DESCRIPTION
Closes: #28336
Closes: #28656


Changes:
- Updated personalization on the /contact, /support, /login, /register, /pricing, /software-management, and /device-management pages to use new primary buying situation values.
- Updated the /software-management page to show the section of security content to users with no primaryBuyingSituation set
- Updated the support links shown to IT users