### PR TITLE
disabled manual agent install checkbox when setup experience software and run script is already added

### DIFF
--- a/frontend/__mocks__/setupExperienceMock.ts
+++ b/frontend/__mocks__/setupExperienceMock.ts
@@ -1,4 +1,10 @@
-import { IGetSetupExperienceScriptResponse } from "services/entities/mdm";
+import {
+  IGetBootstrapPackageMetadataResponse,
+  IGetBootstrapPackageSummaryResponse,
+  IGetSetupExperienceScriptResponse,
+  IGetSetupExperienceSoftwareResponse,
+} from "services/entities/mdm";
+import { createMockSoftwareTitle } from "./softwareMock";
 
 const DEFAULT_SETUP_EXPIERENCE_SCRIPT: IGetSetupExperienceScriptResponse = {
   id: 1,
@@ -9,8 +15,50 @@ const DEFAULT_SETUP_EXPIERENCE_SCRIPT: IGetSetupExperienceScriptResponse = {
 };
 
 // eslint-disable-next-line import/prefer-default-export
-export const createMockSetupExperienceScript = (
+export const createMockSetupExperienceScriptResponse = (
   overrides?: Partial<IGetSetupExperienceScriptResponse>
 ): IGetSetupExperienceScriptResponse => {
   return { ...DEFAULT_SETUP_EXPIERENCE_SCRIPT, ...overrides };
+};
+
+const DEFAULT_SETUP_EXPERIENCE_SOFTWARE_RESPONSE: IGetSetupExperienceSoftwareResponse = {
+  counts_updated_at: "2023-10-01T00:00:00Z",
+  count: 1,
+  software_titles: [createMockSoftwareTitle()],
+  meta: {
+    has_next_results: false,
+    has_previous_results: false,
+  },
+};
+
+export const createMockSetupExperienceSoftwareResponse = (
+  overrides?: Partial<IGetSetupExperienceSoftwareResponse>
+): IGetSetupExperienceSoftwareResponse => {
+  return { ...DEFAULT_SETUP_EXPERIENCE_SOFTWARE_RESPONSE, ...overrides };
+};
+
+const DEFAULT_BOOTSTRAP_PACKAGE_METADATA: IGetBootstrapPackageMetadataResponse = {
+  name: "test-package.pkg",
+  team_id: 0,
+  sha256: "123abc-sha256",
+  token: "123abc-token",
+  created_at: "2021-01-01T00:00:00Z",
+};
+
+export const createMockBootstrapPackageMetadataResponse = (
+  overrides?: Partial<IGetBootstrapPackageMetadataResponse>
+): IGetBootstrapPackageMetadataResponse => {
+  return { ...DEFAULT_BOOTSTRAP_PACKAGE_METADATA, ...overrides };
+};
+
+const DEFAULT_BOOTSTRAP_SUMMARY_RESPONSE: IGetBootstrapPackageSummaryResponse = {
+  installed: 1,
+  pending: 2,
+  failed: 3,
+};
+
+export const createMockBootstrapPackageSummaryResponse = (
+  overrides?: Partial<IGetBootstrapPackageSummaryResponse>
+): IGetBootstrapPackageSummaryResponse => {
+  return { ...DEFAULT_BOOTSTRAP_SUMMARY_RESPONSE, ...overrides };
 };

--- a/frontend/pages/ManageControlsPage/SetupExperience/cards/BootstrapPackage/BootstrapPackage.tests.tsx
+++ b/frontend/pages/ManageControlsPage/SetupExperience/cards/BootstrapPackage/BootstrapPackage.tests.tsx
@@ -1,0 +1,141 @@
+import React from "react";
+import { screen } from "@testing-library/react";
+
+import { createCustomRenderer } from "test/test-utils";
+import mockServer from "test/mock-server";
+import {
+  createSetupExperienceBootstrapPackageHandler,
+  createSetupExperienceScriptHandler,
+  createSetupExperienceSoftwareHandler,
+  createSetuUpExperienceBootstrapSummaryHandler,
+  errorNoBootstrapPackageMetadataHandler,
+  errorNoSetupExperienceScriptHandler,
+} from "test/handlers/setup-experience-handlers";
+import { createGetConfigHandler } from "test/handlers/config-handlers";
+import {
+  createMockSoftwarePackage,
+  createMockSoftwareTitle,
+} from "__mocks__/softwareMock";
+
+import BootstrapPackage from "./BootstrapPackage";
+
+/**
+ * sets up some default backend mocks for the tests. Override what you need
+ * with mockServer.use() in the test itself.
+ */
+const setuDefaultBackendMocks = () => {
+  mockServer.use(createGetConfigHandler());
+
+  // default is no run script or install software already added
+  mockServer.use(errorNoSetupExperienceScriptHandler);
+  mockServer.use(createSetupExperienceSoftwareHandler());
+
+  // default will be a bootstrap package already uploaded
+  mockServer.use(
+    createSetupExperienceBootstrapPackageHandler({ name: "foo-package.pkg" })
+  );
+  mockServer.use(
+    createSetuUpExperienceBootstrapSummaryHandler({
+      installed: 1,
+      pending: 2,
+      failed: 3,
+    })
+  );
+};
+
+describe("BootstrapPackage", () => {
+  it("renders the status table and bootstrap package if a package has been uploaded", async () => {
+    setuDefaultBackendMocks();
+
+    const render = createCustomRenderer({ withBackendMock: true });
+    render(<BootstrapPackage currentTeamId={0} />);
+
+    await screen.findByText(/status/gi);
+
+    // table is showing
+    expect(screen.getByText("Status")).toBeVisible();
+    expect(screen.getByText("Hosts")).toBeVisible();
+
+    // bootstrap package preview is showing
+    expect(screen.getByText("foo-package.pkg")).toBeVisible();
+  });
+
+  it("render the bootstrap package uploader if a package has not been uploaded", async () => {
+    setuDefaultBackendMocks();
+    mockServer.use(errorNoBootstrapPackageMetadataHandler);
+
+    const render = createCustomRenderer({ withBackendMock: true });
+    render(<BootstrapPackage currentTeamId={0} />);
+
+    await screen.findByText(/Upload a bootstrap package/gi);
+
+    // upload description is showing
+    expect(
+      screen.getByText(
+        /Upload a bootstrap package to install a configuration/gi
+      )
+    ).toBeVisible();
+
+    // uploader is showing
+    expect(screen.getByText("Package (.pkg)")).toBeVisible();
+    expect(screen.getByText("Upload")).toBeVisible();
+  });
+
+  it("renders the advanced options as disabled if there is no bootstrap package uploaded", async () => {
+    setuDefaultBackendMocks();
+    mockServer.use(errorNoBootstrapPackageMetadataHandler);
+
+    const render = createCustomRenderer({ withBackendMock: true });
+    const { user } = render(<BootstrapPackage currentTeamId={0} />);
+
+    await screen.findByText("Show advanced options");
+    await user.click(screen.getByText("Show advanced options"));
+
+    expect(
+      screen.getByLabelText("Install Fleet's agent (fleetd) manually")
+    ).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Save" })).toBeDisabled();
+  });
+
+  it("renders the advanced options as disabled if there are already added install software", async () => {
+    setuDefaultBackendMocks();
+    mockServer.use(
+      createSetupExperienceSoftwareHandler({
+        software_titles: [
+          createMockSoftwareTitle({
+            software_package: createMockSoftwarePackage({
+              install_during_setup: true,
+            }),
+          }),
+        ],
+      })
+    );
+
+    const render = createCustomRenderer({ withBackendMock: true });
+    const { user } = render(<BootstrapPackage currentTeamId={0} />);
+
+    await screen.findByText("Show advanced options");
+    await user.click(screen.getByText("Show advanced options"));
+
+    expect(
+      screen.getByLabelText("Install Fleet's agent (fleetd) manually")
+    ).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Save" })).toBeDisabled();
+  });
+
+  it("renders the advanced options as disabled if there is alreaddy a run script added", async () => {
+    setuDefaultBackendMocks();
+    mockServer.use(createSetupExperienceScriptHandler());
+
+    const render = createCustomRenderer({ withBackendMock: true });
+    const { user } = render(<BootstrapPackage currentTeamId={0} />);
+
+    await screen.findByText("Show advanced options");
+    await user.click(screen.getByText("Show advanced options"));
+
+    expect(
+      screen.getByLabelText("Install Fleet's agent (fleetd) manually")
+    ).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Save" })).toBeDisabled();
+  });
+});

--- a/frontend/pages/ManageControlsPage/SetupExperience/cards/BootstrapPackage/BootstrapPackage.tsx
+++ b/frontend/pages/ManageControlsPage/SetupExperience/cards/BootstrapPackage/BootstrapPackage.tsx
@@ -1,12 +1,16 @@
 import React, { useContext, useState } from "react";
 import { useQuery } from "react-query";
-import { AxiosResponse } from "axios";
+import { AxiosError, AxiosResponse } from "axios";
 
 import { IBootstrapPackageMetadata } from "interfaces/mdm";
 import { IApiError } from "interfaces/errors";
 import { IConfig } from "interfaces/config";
 import { API_NO_TEAM_ID, ITeamConfig } from "interfaces/team";
-import mdmAPI from "services/entities/mdm";
+import { ISoftwareTitle } from "interfaces/software";
+import mdmAPI, {
+  IGetSetupExperienceScriptResponse,
+  IGetSetupExperienceSoftwareResponse,
+} from "services/entities/mdm";
 import configAPI from "services/entities/config";
 import teamsAPI, { ILoadTeamResponse } from "services/entities/teams";
 import { NotificationContext } from "context/notification";
@@ -19,10 +23,15 @@ import BootstrapPackagePreview from "./components/BootstrapPackagePreview";
 import PackageUploader from "./components/BootstrapPackageUploader";
 import UploadedPackageView from "./components/UploadedPackageView";
 import DeleteBootstrapPackageModal from "./components/DeleteBootstrapPackageModal";
-import SetupExperienceContentContainer from "../../components/SetupExperienceContentContainer";
 import BootstrapAdvancedOptions from "./components/BootstrapAdvancedOptions";
+import SetupExperienceContentContainer from "../../components/SetupExperienceContentContainer";
+import { getInstallSoftwareDuringSetupCount } from "../InstallSoftware/components/AddInstallSoftware/helpers";
 
 const baseClass = "bootstrap-package";
+
+// This is so large because we want to get all the software titles that are
+// available for install so we can correctly display the selected count.
+const PER_PAGE_SIZE = 3000;
 
 export const getManualAgentInstallSetting = (
   currentTeamId: number,
@@ -49,6 +58,32 @@ const BootstrapPackage = ({ currentTeamId }: IBootstrapPackageProps) => {
     showDeleteBootstrapPackageModal,
     setShowDeleteBootstrapPackageModal,
   ] = useState(false);
+
+  const { data: softwareTitles, isLoading: isLoadingSoftware } = useQuery<
+    IGetSetupExperienceSoftwareResponse,
+    AxiosError,
+    ISoftwareTitle[] | null
+  >(
+    ["install-software", currentTeamId],
+    () =>
+      mdmAPI.getSetupExperienceSoftware({
+        team_id: currentTeamId,
+        per_page: PER_PAGE_SIZE,
+      }),
+    {
+      ...DEFAULT_USE_QUERY_OPTIONS,
+      select: (res) => res.software_titles,
+    }
+  );
+
+  const { data: script, isLoading: isLoadingScript } = useQuery<
+    IGetSetupExperienceScriptResponse,
+    AxiosError
+  >(
+    ["setup-experience-script", currentTeamId],
+    () => mdmAPI.getSetupExperienceScript(currentTeamId),
+    { ...DEFAULT_USE_QUERY_OPTIONS }
+  );
 
   const {
     isLoading: isLoadingGlobalConfig,
@@ -87,8 +122,8 @@ const BootstrapPackage = ({ currentTeamId }: IBootstrapPackageProps) => {
 
   const {
     data: bootstrapMetadata,
-    isLoading,
-    error,
+    isLoading: isloadingBootstrapMetadata,
+    error: errorBootstrapMetadata,
     refetch: refretchBootstrapMetadata,
   } = useQuery<
     IBootstrapPackageMetadata,
@@ -98,8 +133,7 @@ const BootstrapPackage = ({ currentTeamId }: IBootstrapPackageProps) => {
     ["bootstrap-metadata", currentTeamId],
     () => mdmAPI.getBootstrapPackageMetadata(currentTeamId),
     {
-      retry: false,
-      refetchOnWindowFocus: false,
+      ...DEFAULT_USE_QUERY_OPTIONS,
       cacheTime: 0,
     }
   );
@@ -132,7 +166,11 @@ const BootstrapPackage = ({ currentTeamId }: IBootstrapPackageProps) => {
   // we are relying on the API to tell us this resource does not exist to
   // determine if the user has uploaded a bootstrap package.
   const noPackageUploaded =
-    (error && error.status === 404) || !bootstrapMetadata;
+    (errorBootstrapMetadata && errorBootstrapMetadata.status === 404) ||
+    !bootstrapMetadata;
+  const hasSetupExperienceInstallSoftware =
+    getInstallSoftwareDuringSetupCount(softwareTitles) !== 0;
+  const hasSetupExperienceScript = !!script;
 
   const renderBootstrapView = () => {
     const bootstrapPackageView = noPackageUploaded ? (
@@ -151,7 +189,11 @@ const BootstrapPackage = ({ currentTeamId }: IBootstrapPackageProps) => {
           {bootstrapPackageView}
           <BootstrapAdvancedOptions
             currentTeamId={currentTeamId}
-            enableInstallManually={!noPackageUploaded}
+            disableInstallManually={
+              noPackageUploaded ||
+              hasSetupExperienceInstallSoftware ||
+              hasSetupExperienceScript
+            }
             selectManualAgentInstall={selectedManualAgentInstall}
             onChange={(manualAgentInstall) => {
               setSelectedManualAgentInstall(manualAgentInstall);
@@ -165,14 +207,17 @@ const BootstrapPackage = ({ currentTeamId }: IBootstrapPackageProps) => {
     );
   };
 
+  const isLoading =
+    isloadingBootstrapMetadata ||
+    isLoadingGlobalConfig ||
+    isLoadingTeamConfig ||
+    isLoadingScript ||
+    isLoadingSoftware;
+
   return (
     <section className={baseClass}>
       <SectionHeader title="Bootstrap package" />
-      {isLoading || isLoadingGlobalConfig || isLoadingTeamConfig ? (
-        <Spinner />
-      ) : (
-        renderBootstrapView()
-      )}
+      {isLoading ? <Spinner /> : renderBootstrapView()}
       {showDeleteBootstrapPackageModal && (
         <DeleteBootstrapPackageModal
           onDelete={onDelete}

--- a/frontend/pages/ManageControlsPage/SetupExperience/cards/BootstrapPackage/BootstrapPackage.tsx
+++ b/frontend/pages/ManageControlsPage/SetupExperience/cards/BootstrapPackage/BootstrapPackage.tsx
@@ -2,12 +2,12 @@ import React, { useContext, useState } from "react";
 import { useQuery } from "react-query";
 import { AxiosError, AxiosResponse } from "axios";
 
-import { IBootstrapPackageMetadata } from "interfaces/mdm";
 import { IApiError } from "interfaces/errors";
 import { IConfig } from "interfaces/config";
 import { API_NO_TEAM_ID, ITeamConfig } from "interfaces/team";
 import { ISoftwareTitle } from "interfaces/software";
 import mdmAPI, {
+  IGetBootstrapPackageMetadataResponse,
   IGetSetupExperienceScriptResponse,
   IGetSetupExperienceSoftwareResponse,
 } from "services/entities/mdm";
@@ -125,11 +125,7 @@ const BootstrapPackage = ({ currentTeamId }: IBootstrapPackageProps) => {
     isLoading: isloadingBootstrapMetadata,
     error: errorBootstrapMetadata,
     refetch: refretchBootstrapMetadata,
-  } = useQuery<
-    IBootstrapPackageMetadata,
-    AxiosResponse<IApiError>,
-    IBootstrapPackageMetadata
-  >(
+  } = useQuery<IGetBootstrapPackageMetadataResponse, AxiosResponse<IApiError>>(
     ["bootstrap-metadata", currentTeamId],
     () => mdmAPI.getBootstrapPackageMetadata(currentTeamId),
     {

--- a/frontend/pages/ManageControlsPage/SetupExperience/cards/BootstrapPackage/components/BootstrapAdvancedOptions/BootstrapAdvancedOptions.tsx
+++ b/frontend/pages/ManageControlsPage/SetupExperience/cards/BootstrapPackage/components/BootstrapAdvancedOptions/BootstrapAdvancedOptions.tsx
@@ -13,14 +13,14 @@ const baseClass = "bootstrap-advanced-options";
 
 interface IBootstrapAdvancedOptionsProps {
   currentTeamId: number;
-  enableInstallManually: boolean;
+  disableInstallManually: boolean;
   selectManualAgentInstall: boolean;
   onChange: (value: boolean) => void;
 }
 
 const BootstrapAdvancedOptions = ({
   currentTeamId,
-  enableInstallManually,
+  disableInstallManually,
   selectManualAgentInstall,
   onChange,
 }: IBootstrapAdvancedOptionsProps) => {
@@ -44,7 +44,8 @@ const BootstrapAdvancedOptions = ({
     <>
       Use this option if you&apos;re deploying a custom fleetd via bootstrap
       package. If enabled, Fleet won&apos;t install fleetd automatically. To use
-      this option upload a bootstrap package first.
+      this option upload a bootstrap package first, and make sure to not use{" "}
+      <b>Install software</b> and <b>Run script</b>.
     </>
   );
 
@@ -66,7 +67,7 @@ const BootstrapAdvancedOptions = ({
                 <Checkbox
                   value={selectManualAgentInstall}
                   onChange={onChange}
-                  disabled={gitopsDisable || !enableInstallManually}
+                  disabled={gitopsDisable || disableInstallManually}
                 >
                   <TooltipWrapper
                     tipContent={tooltip}
@@ -76,7 +77,7 @@ const BootstrapAdvancedOptions = ({
                   </TooltipWrapper>
                 </Checkbox>
                 <Button
-                  disabled={gitopsDisable || !enableInstallManually}
+                  disabled={gitopsDisable || disableInstallManually}
                   type="submit"
                 >
                   Save

--- a/frontend/pages/ManageControlsPage/SetupExperience/cards/InstallSoftware/components/AddInstallSoftware/AddInstallSoftware.tsx
+++ b/frontend/pages/ManageControlsPage/SetupExperience/cards/InstallSoftware/components/AddInstallSoftware/AddInstallSoftware.tsx
@@ -11,6 +11,11 @@ import LinkWithContext from "components/LinkWithContext";
 import TooltipWrapper from "components/TooltipWrapper";
 import GitOpsModeTooltipWrapper from "components/GitOpsModeTooltipWrapper";
 
+import {
+  getInstallSoftwareDuringSetupCount,
+  hasNoSoftwareUploaded,
+} from "./helpers";
+
 const baseClass = "add-install-software";
 
 interface IAddInstallSoftwareProps {
@@ -26,10 +31,13 @@ const AddInstallSoftware = ({
   softwareTitles,
   onAddSoftware,
 }: IAddInstallSoftwareProps) => {
-  const hasNoSoftware = !softwareTitles || softwareTitles.length === 0;
+  const noSoftwareUploaded = hasNoSoftwareUploaded(softwareTitles);
+  const installSoftwareDuringSetupCount = getInstallSoftwareDuringSetupCount(
+    softwareTitles
+  );
 
   const getAddedText = () => {
-    if (hasNoSoftware) {
+    if (noSoftwareUploaded) {
       return (
         <>
           No software available to add. Please{" "}
@@ -45,17 +53,11 @@ const AddInstallSoftware = ({
       );
     }
 
-    const installDuringSetupCount = softwareTitles.filter(
-      (software) =>
-        software.software_package?.install_during_setup ||
-        software.app_store_app?.install_during_setup
-    ).length;
-
-    return installDuringSetupCount === 0 ? (
+    return installSoftwareDuringSetupCount === 0 ? (
       "No software added."
     ) : (
       <>
-        {installDuringSetupCount} software will be{" "}
+        {installSoftwareDuringSetupCount} software will be{" "}
         <TooltipWrapper tipContent="Software order will vary.">
           installed during setup
         </TooltipWrapper>
@@ -65,17 +67,11 @@ const AddInstallSoftware = ({
   };
 
   const getButtonText = () => {
-    if (hasNoSoftware) {
+    if (noSoftwareUploaded) {
       return "Add software";
     }
 
-    const installDuringSetupCount = softwareTitles.filter(
-      (software) =>
-        software.software_package?.install_during_setup ||
-        software.app_store_app?.install_during_setup
-    ).length;
-
-    return installDuringSetupCount === 0
+    return installSoftwareDuringSetupCount === 0
       ? "Add software"
       : "Show selected software";
   };
@@ -117,7 +113,9 @@ const AddInstallSoftware = ({
               <Button
                 className={`${baseClass}__button`}
                 onClick={onAddSoftware}
-                disabled={disableChildren || hasManualAgentInstall}
+                disabled={
+                  disableChildren || hasManualAgentInstall || noSoftwareUploaded
+                }
               >
                 {buttonText}
               </Button>

--- a/frontend/pages/ManageControlsPage/SetupExperience/cards/InstallSoftware/components/AddInstallSoftware/helpers.tsx
+++ b/frontend/pages/ManageControlsPage/SetupExperience/cards/InstallSoftware/components/AddInstallSoftware/helpers.tsx
@@ -1,0 +1,21 @@
+import { ISoftwareTitle } from "interfaces/software";
+
+export const hasNoSoftwareUploaded = (
+  softwareTitles?: ISoftwareTitle[] | null
+) => {
+  return !softwareTitles || softwareTitles.length === 0;
+};
+
+export const getInstallSoftwareDuringSetupCount = (
+  softwareTitles?: ISoftwareTitle[] | null
+) => {
+  if (!softwareTitles) {
+    return 0;
+  }
+
+  return softwareTitles.filter(
+    (software) =>
+      software.software_package?.install_during_setup ||
+      software.app_store_app?.install_during_setup
+  ).length;
+};

--- a/frontend/pages/ManageControlsPage/SetupExperience/cards/RunScript/RunScript.tests.tsx
+++ b/frontend/pages/ManageControlsPage/SetupExperience/cards/RunScript/RunScript.tests.tsx
@@ -4,15 +4,15 @@ import { screen } from "@testing-library/react";
 import mockServer from "test/mock-server";
 import { createCustomRenderer } from "test/test-utils";
 import {
-  defaultSetupExperienceScriptHandler,
-  errorNoSetupExperienceScript,
+  createSetupExperienceScriptHandler,
+  errorNoSetupExperienceScriptHandler,
 } from "test/handlers/setup-experience-handlers";
 
 import RunScript from "./RunScript";
 
 describe("RunScript", () => {
   it("should render the script uploader when no script has been uploaded", async () => {
-    mockServer.use(errorNoSetupExperienceScript);
+    mockServer.use(errorNoSetupExperienceScriptHandler);
     const render = createCustomRenderer({ withBackendMock: true });
 
     render(<RunScript currentTeamId={1} />);
@@ -21,7 +21,7 @@ describe("RunScript", () => {
   });
 
   it("should render the uploaded script uploader when a script has been uploaded", async () => {
-    mockServer.use(defaultSetupExperienceScriptHandler);
+    mockServer.use(createSetupExperienceScriptHandler());
     const render = createCustomRenderer({ withBackendMock: true });
 
     render(<RunScript currentTeamId={1} />);

--- a/frontend/pages/ManageControlsPage/SetupExperience/cards/RunScript/RunScript.tsx
+++ b/frontend/pages/ManageControlsPage/SetupExperience/cards/RunScript/RunScript.tsx
@@ -76,7 +76,6 @@ const RunScript = ({ currentTeamId }: IRunScriptProps) => {
     refetchScript();
   };
 
-  const scriptUploaded = true;
   const hasManualAgentInstall = getManualAgentInstallSetting(
     currentTeamId,
     globalConfig,
@@ -104,7 +103,7 @@ const RunScript = ({ currentTeamId }: IRunScriptProps) => {
             url={`${LEARN_MORE_ABOUT_BASE_LINK}/setup-assistant`}
             text="Learn how"
           />
-          {!scriptUploaded || !script ? (
+          {!script ? (
             <SetupExperienceScriptUploader
               currentTeamId={currentTeamId}
               hasManualAgentInstall={hasManualAgentInstall}

--- a/frontend/services/entities/mdm.ts
+++ b/frontend/services/entities/mdm.ts
@@ -1,4 +1,6 @@
 import {
+  IBootstrapPackageAggregate,
+  IBootstrapPackageMetadata,
   IHostMdmProfile,
   IMdmCommandResult,
   IMdmProfile,
@@ -92,6 +94,9 @@ export type IGetSetupExperienceSoftwareResponse = ISoftwareTitlesResponse & {
   software_titles: ISoftwareTitle[] | null;
 };
 
+export type IGetBootstrapPackageMetadataResponse = IBootstrapPackageMetadata;
+export type IGetBootstrapPackageSummaryResponse = IBootstrapPackageAggregate;
+
 const mdmService = {
   unenrollHostFromMdm: (hostId: number, timeout?: number) => {
     const { HOST_MDM_UNENROLL } = endpoints;
@@ -184,7 +189,9 @@ const mdmService = {
     return sendRequest("POST", MDM_APPLE_SSO, {});
   },
 
-  getBootstrapPackageMetadata: (teamId: number) => {
+  getBootstrapPackageMetadata: (
+    teamId: number
+  ): Promise<IGetBootstrapPackageMetadataResponse> => {
     const { MDM_BOOTSTRAP_PACKAGE_METADATA } = endpoints;
 
     return sendRequest("GET", MDM_BOOTSTRAP_PACKAGE_METADATA(teamId));
@@ -208,7 +215,9 @@ const mdmService = {
     return sendRequest("DELETE", `${MDM_BOOTSTRAP_PACKAGE}/${teamId}`);
   },
 
-  getBootstrapPackageAggregate: (teamId?: number) => {
+  getBootstrapPackageAggregate: (
+    teamId?: number
+  ): Promise<IGetBootstrapPackageSummaryResponse> => {
     let { MDM_BOOTSTRAP_PACKAGE_SUMMARY: path } = endpoints;
 
     if (teamId) {

--- a/frontend/test/default-handlers.ts
+++ b/frontend/test/default-handlers.ts
@@ -14,6 +14,11 @@ export const baseUrl = (path: string) => {
 // These can be overridden in individual tests using the .use() method on the
 // mock server within the desired test.
 // More info on .use() here: https://mswjs.io/docs/api/setup-worker/use/
+
+// NOTE: adding default handlers here is an anti-pattern we are moving away from.
+// It is an anti-pattern because it makes it difficult to understand what
+// handlers are being used in a test. The preferred way is to use the mockServer.use()
+// method in the test file itself.
 const handlers = [
   defaultDeviceHandler,
   defaultDeviceMappingHandler,

--- a/frontend/test/handlers/config-handlers.ts
+++ b/frontend/test/handlers/config-handlers.ts
@@ -1,0 +1,13 @@
+import createMockConfig from "__mocks__/configMock";
+import { IConfig } from "interfaces/config";
+import { http, HttpResponse } from "msw";
+import { baseUrl } from "test/test-utils";
+
+const configUrl = baseUrl("/config");
+
+// eslint-disable-next-line import/prefer-default-export
+export const createGetConfigHandler = (overrides?: Partial<IConfig>) => {
+  return http.get(configUrl, () => {
+    return HttpResponse.json(createMockConfig({ ...overrides }));
+  });
+};

--- a/frontend/test/handlers/label-handlers.ts
+++ b/frontend/test/handlers/label-handlers.ts
@@ -6,7 +6,6 @@ import { createMockHostsResponse } from "__mocks__/hostMock";
 import { ILabel } from "interfaces/label";
 import { IHost } from "interfaces/host";
 
-// eslint-disable-next-line import/prefer-default-export
 export const getLabelHandler = (overrides: Partial<ILabel>) =>
   http.get(baseUrl("/labels/:id"), () => {
     return HttpResponse.json({

--- a/frontend/test/handlers/setup-experience-handlers.ts
+++ b/frontend/test/handlers/setup-experience-handlers.ts
@@ -1,20 +1,82 @@
 import { http, HttpResponse } from "msw";
 
 import { baseUrl } from "test/test-utils";
-import { createMockSetupExperienceScript } from "__mocks__/setupExperienceMock";
+import {
+  createMockBootstrapPackageMetadataResponse,
+  createMockBootstrapPackageSummaryResponse,
+  createMockSetupExperienceScriptResponse,
+  createMockSetupExperienceSoftwareResponse,
+} from "__mocks__/setupExperienceMock";
+import {
+  IGetBootstrapPackageMetadataResponse,
+  IGetBootstrapPackageSummaryResponse,
+  IGetSetupExperienceScriptResponse,
+  IGetSetupExperienceSoftwareResponse,
+} from "services/entities/mdm";
 
 const setupExperienceScriptUrl = baseUrl("/setup_experience/script");
+const setupExperienceInstallSoftwareUrl = baseUrl("/setup_experience/software");
+const setupExperienceBootstrapMetadataUrl = baseUrl(
+  "/mdm/bootstrap/:teamId/metadata"
+);
+const setupExperienceBootstrapSummaryUrl = baseUrl("/mdm/bootstrap/summary");
 
 export const defaultSetupExperienceScriptHandler = http.get(
   setupExperienceScriptUrl,
   () => {
-    return HttpResponse.json(createMockSetupExperienceScript());
+    return HttpResponse.json(createMockSetupExperienceScriptResponse());
   }
 );
 
-export const errorNoSetupExperienceScript = http.get(
+export const createSetupExperienceScriptHandler = (
+  overrides?: Partial<IGetSetupExperienceScriptResponse>
+) =>
+  http.get(setupExperienceScriptUrl, () => {
+    return HttpResponse.json(
+      createMockSetupExperienceScriptResponse({ ...overrides })
+    );
+  });
+
+export const errorNoSetupExperienceScriptHandler = http.get(
   setupExperienceScriptUrl,
   () => {
     return new HttpResponse("Not found", { status: 404 });
   }
 );
+
+export const createSetupExperienceSoftwareHandler = (
+  overrides?: Partial<IGetSetupExperienceSoftwareResponse>
+) =>
+  http.get(setupExperienceInstallSoftwareUrl, () => {
+    return HttpResponse.json(
+      createMockSetupExperienceSoftwareResponse({ ...overrides })
+    );
+  });
+
+export const createSetupExperienceBootstrapPackageHandler = (
+  overrides?: Partial<IGetBootstrapPackageMetadataResponse>
+) =>
+  http.get(setupExperienceBootstrapMetadataUrl, () => {
+    return HttpResponse.json(
+      createMockBootstrapPackageMetadataResponse({ ...overrides })
+    );
+  });
+
+export const errorNoBootstrapPackageMetadataHandler = http.get(
+  setupExperienceBootstrapMetadataUrl,
+  () => {
+    return new HttpResponse("Not found", { status: 404 });
+  }
+);
+
+export const createSetuUpExperienceBootstrapSummaryHandler = (
+  overrides?: Partial<IGetBootstrapPackageSummaryResponse>
+) => {
+  return http.get(setupExperienceBootstrapSummaryUrl, () => {
+    return HttpResponse.json(
+      createMockBootstrapPackageSummaryResponse({
+        ...overrides,
+      })
+    );
+  });
+};

--- a/frontend/test/handlers/team-handlers.ts
+++ b/frontend/test/handlers/team-handlers.ts
@@ -1,0 +1,13 @@
+import createMockConfig from "__mocks__/configMock";
+import { IConfig } from "interfaces/config";
+import { http, HttpResponse } from "msw";
+import { baseUrl } from "test/test-utils";
+
+const teamUrl = baseUrl("/teams/:id");
+
+// eslint-disable-next-line import/prefer-default-export
+export const createGetTeamHandler = (overrides?: Partial<IConfig>) => {
+  return http.get(teamUrl, () => {
+    return HttpResponse.json(createMockConfig({ ...overrides }));
+  });
+};


### PR DESCRIPTION
For [#28629](https://github.com/fleetdm/fleet/issues/28629)

this disabled the manual agent install checkbox if the user has already uploaded install software or a run script for setup experience


- [x] Added/updated automated tests
- [x] Manual QA for all new/changed functionality
