### PR TITLE
Webhook logging destination

### DIFF
--- a/changes/27445-webhook-automation-backend
+++ b/changes/27445-webhook-automation-backend
@@ -1,0 +1,1 @@
+- Added webhook query automation logging

--- a/cmd/fleet/serve.go
+++ b/cmd/fleet/serve.go
@@ -343,12 +343,7 @@ the way that the Fleet server works.
 					MaxAge:               config.Filesystem.MaxAge,
 					MaxBackups:           config.Filesystem.MaxBackups,
 				},
-				Webhook: logging.WebhookConfig{
-					BasicAuthUser: config.Webhook.BasicAuthUser,
-					BasicAuthPass: config.Webhook.BasicAuthPass,
-					BearerToken:   config.Webhook.BearerToken,
-					Timeout:       time.Second * time.Duration(config.Webhook.Timeout),
-				},
+				Webhook: logging.WebhookConfig{},
 				Firehose: logging.FirehoseConfig{
 					Region:           config.Firehose.Region,
 					EndpointURL:      config.Firehose.EndpointURL,

--- a/cmd/fleet/serve.go
+++ b/cmd/fleet/serve.go
@@ -343,6 +343,12 @@ the way that the Fleet server works.
 					MaxAge:               config.Filesystem.MaxAge,
 					MaxBackups:           config.Filesystem.MaxBackups,
 				},
+				Webhook: logging.WebhookConfig{
+					BasicAuthUser: config.Webhook.BasicAuthUser,
+					BasicAuthPass: config.Webhook.BasicAuthPass,
+					BearerToken:   config.Webhook.BearerToken,
+					Timeout:       time.Second * time.Duration(config.Webhook.Timeout),
+				},
 				Firehose: logging.FirehoseConfig{
 					Region:           config.Firehose.Region,
 					EndpointURL:      config.Firehose.EndpointURL,
@@ -379,6 +385,7 @@ the way that the Fleet server works.
 			// Set specific configuration to osqueryd status logs.
 			loggingConfig.Plugin = config.Osquery.StatusLogPlugin
 			loggingConfig.Filesystem.LogFile = config.Filesystem.StatusLogFile
+			loggingConfig.Webhook.URL = config.Webhook.StatusURL
 			loggingConfig.Firehose.StreamName = config.Firehose.StatusStream
 			loggingConfig.Kinesis.StreamName = config.Kinesis.StatusStream
 			loggingConfig.Lambda.Function = config.Lambda.StatusFunction
@@ -394,6 +401,7 @@ the way that the Fleet server works.
 			// Set specific configuration to osqueryd result logs.
 			loggingConfig.Plugin = config.Osquery.ResultLogPlugin
 			loggingConfig.Filesystem.LogFile = config.Filesystem.ResultLogFile
+			loggingConfig.Webhook.URL = config.Webhook.ResultURL
 			loggingConfig.Firehose.StreamName = config.Firehose.ResultStream
 			loggingConfig.Kinesis.StreamName = config.Kinesis.ResultStream
 			loggingConfig.Lambda.Function = config.Lambda.ResultFunction

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -509,6 +509,15 @@ type FilesystemConfig struct {
 	MaxBackups           int    `json:"max_backups" yaml:"max_backups"`
 }
 
+type WebhookConfig struct {
+	StatusURL     string `json:"status_webhook_url" yaml:"status_webhook_url"`
+	ResultURL     string `json:"result_webhook_url" yaml:"result_webhook_url"`
+	BasicAuthUser string `json:"basic_auth_user" yaml:"basic_auth_user"`
+	BasicAuthPass string `json:"basic_auth_pass" yaml:"basic_auth_pass"`
+	BearerToken   string `json:"bearer_token" yaml:"bearer_token"`
+	Timeout       int    `json:"timeout" yaml:"timeout"`
+}
+
 // KafkaRESTConfig defines configs for the Kafka REST Proxy logging plugin.
 type KafkaRESTConfig struct {
 	StatusTopic      string `json:"status_topic" yaml:"status_topic"`
@@ -601,6 +610,7 @@ type FleetConfig struct {
 	SES              SESConfig
 	PubSub           PubSubConfig
 	Filesystem       FilesystemConfig
+	Webhook          WebhookConfig
 	KafkaREST        KafkaRESTConfig
 	License          LicenseConfig
 	Vulnerabilities  VulnerabilitiesConfig
@@ -1591,6 +1601,14 @@ func (man Manager) LoadConfig() FleetConfig {
 			MaxSize:              man.getConfigInt("filesystem.max_size"),
 			MaxAge:               man.getConfigInt("filesystem.max_age"),
 			MaxBackups:           man.getConfigInt("filesystem.max_backups"),
+		},
+		Webhook: WebhookConfig{
+			StatusURL:     man.getConfigString("webhook.status_webhook_url"),
+			ResultURL:     man.getConfigString("webhook.result_webhook_url"),
+			BasicAuthUser: man.getConfigString("webhook.basic_auth_user"),
+			BasicAuthPass: man.getConfigString("webhook.basic_auth_pass"),
+			BearerToken:   man.getConfigString("webhook.bearer_token"),
+			Timeout:       man.getConfigString("webhook.timeout"),
 		},
 		KafkaREST: KafkaRESTConfig{
 			StatusTopic:      man.getConfigString("kafkarest.status_topic"),

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -510,12 +510,8 @@ type FilesystemConfig struct {
 }
 
 type WebhookConfig struct {
-	StatusURL     string `json:"status_webhook_url" yaml:"status_webhook_url"`
-	ResultURL     string `json:"result_webhook_url" yaml:"result_webhook_url"`
-	BasicAuthUser string `json:"basic_auth_user" yaml:"basic_auth_user"`
-	BasicAuthPass string `json:"basic_auth_pass" yaml:"basic_auth_pass"`
-	BearerToken   string `json:"bearer_token" yaml:"bearer_token"`
-	Timeout       int    `json:"timeout" yaml:"timeout"`
+	StatusURL string `json:"status_webhook_url" yaml:"status_webhook_url"`
+	ResultURL string `json:"result_webhook_url" yaml:"result_webhook_url"`
 }
 
 // KafkaRESTConfig defines configs for the Kafka REST Proxy logging plugin.
@@ -1603,12 +1599,8 @@ func (man Manager) LoadConfig() FleetConfig {
 			MaxBackups:           man.getConfigInt("filesystem.max_backups"),
 		},
 		Webhook: WebhookConfig{
-			StatusURL:     man.getConfigString("webhook.status_webhook_url"),
-			ResultURL:     man.getConfigString("webhook.result_webhook_url"),
-			BasicAuthUser: man.getConfigString("webhook.basic_auth_user"),
-			BasicAuthPass: man.getConfigString("webhook.basic_auth_pass"),
-			BearerToken:   man.getConfigString("webhook.bearer_token"),
-			Timeout:       man.getConfigString("webhook.timeout"),
+			StatusURL: man.getConfigString("webhook.status_webhook_url"),
+			ResultURL: man.getConfigString("webhook.result_webhook_url"),
 		},
 		KafkaREST: KafkaRESTConfig{
 			StatusTopic:      man.getConfigString("kafkarest.status_topic"),

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -510,8 +510,8 @@ type FilesystemConfig struct {
 }
 
 type WebhookConfig struct {
-	StatusURL string `json:"status_webhook_url" yaml:"status_webhook_url"`
-	ResultURL string `json:"result_webhook_url" yaml:"result_webhook_url"`
+	StatusURL string `json:"status_url" yaml:"status_url"`
+	ResultURL string `json:"result_url" yaml:"result_url"`
 }
 
 // KafkaRESTConfig defines configs for the Kafka REST Proxy logging plugin.
@@ -1304,6 +1304,10 @@ func (man Manager) addConfigs() {
 	man.addConfigInt("filesystem.max_age", 28, "Maximum number of days to retain old log files based on the timestamp encoded in their filename. Setting to zero wil retain old log files indefinitely (only valid if enable_log_rotation is true) default is 28 days")
 	man.addConfigInt("filesystem.max_backups", 3, "Maximum number of old log files to retain. Setting to zero will retain all old log files (only valid if enable_log_rotation is true) default is 3")
 
+	// Webhook
+	man.addConfigString("webhook.status_url", "", "Webhook URL for osquery status logs")
+	man.addConfigString("webhook.result_url", "", "Webhook URL for osquery result logs")
+
 	// KafkaREST
 	man.addConfigString("kafkarest.status_topic", "", "Kafka REST topic for status logs")
 	man.addConfigString("kafkarest.result_topic", "", "Kafka REST topic for result logs")
@@ -1599,8 +1603,8 @@ func (man Manager) LoadConfig() FleetConfig {
 			MaxBackups:           man.getConfigInt("filesystem.max_backups"),
 		},
 		Webhook: WebhookConfig{
-			StatusURL: man.getConfigString("webhook.status_webhook_url"),
-			ResultURL: man.getConfigString("webhook.result_webhook_url"),
+			StatusURL: man.getConfigString("webhook.status_url"),
+			ResultURL: man.getConfigString("webhook.result_url"),
 		},
 		KafkaREST: KafkaRESTConfig{
 			StatusTopic:      man.getConfigString("kafkarest.status_topic"),

--- a/server/fleet/app.go
+++ b/server/fleet/app.go
@@ -1400,6 +1400,10 @@ type FilesystemConfig struct {
 	config.FilesystemConfig
 }
 
+type WebhookConfig struct {
+	config.WebhookConfig
+}
+
 type PubSubConfig struct {
 	config.PubSubConfig
 }

--- a/server/logging/logging.go
+++ b/server/logging/logging.go
@@ -22,11 +22,6 @@ type FilesystemConfig struct {
 
 type WebhookConfig struct {
 	URL string
-
-	BasicAuthUser string
-	BasicAuthPass string
-	BearerToken   string
-	Timeout       time.Duration
 }
 
 type FirehoseConfig struct {
@@ -112,7 +107,11 @@ func NewJSONLogger(name string, config Config, logger log.Logger) (fleet.JSONLog
 		}
 		return fleet.JSONLogger(writer), nil
 	case "webhook":
-
+		writer, err := NewWebhookLogWriter(config.Webhook.URL, logger)
+		if err != nil {
+			return nil, fmt.Errorf("create webhook %s logger: %w", name, err)
+		}
+		return fleet.JSONLogger(writer), nil
 	case "firehose":
 		writer, err := NewFirehoseLogWriter(
 			config.Firehose.Region,

--- a/server/logging/logging.go
+++ b/server/logging/logging.go
@@ -3,6 +3,7 @@ package logging
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/fleetdm/fleet/v4/server/fleet"
 	"github.com/go-kit/log"
@@ -17,6 +18,15 @@ type FilesystemConfig struct {
 	MaxSize              int
 	MaxAge               int
 	MaxBackups           int
+}
+
+type WebhookConfig struct {
+	URL string
+
+	BasicAuthUser string
+	BasicAuthPass string
+	BearerToken   string
+	Timeout       time.Duration
 }
 
 type FirehoseConfig struct {
@@ -70,6 +80,7 @@ type Config struct {
 	Plugin string
 
 	Filesystem FilesystemConfig
+	Webhook    WebhookConfig
 	Firehose   FirehoseConfig
 	Kinesis    KinesisConfig
 	Lambda     LambdaConfig
@@ -100,6 +111,8 @@ func NewJSONLogger(name string, config Config, logger log.Logger) (fleet.JSONLog
 			return nil, fmt.Errorf("create filesystem %s logger: %w", name, err)
 		}
 		return fleet.JSONLogger(writer), nil
+	case "webhook":
+
 	case "firehose":
 		writer, err := NewFirehoseLogWriter(
 			config.Firehose.Region,

--- a/server/logging/logging.go
+++ b/server/logging/logging.go
@@ -3,7 +3,6 @@ package logging
 
 import (
 	"fmt"
-	"time"
 
 	"github.com/fleetdm/fleet/v4/server/fleet"
 	"github.com/go-kit/log"

--- a/server/logging/webhook.go
+++ b/server/logging/webhook.go
@@ -71,15 +71,12 @@ func (w *webhookLogWriter) Write(ctx context.Context, logs []json.RawMessage) er
 		"url", server.MaskSecretURLParams(w.url),
 	)
 
-	// Submit logs in a goroutine so it doesn't hold up the request
-	go func(lg []webhookDetails) {
-		if err := w.sendWebhookJson(ctx, detailLogs); err != nil {
-			level.Error(w.logger).Log(
-				"msg", fmt.Sprintf("failed to send automation webhook to %s", server.MaskSecretURLParams(w.url)),
-				"err", server.MaskURLError(err).Error(),
-			)
-		}
-	}(detailLogs)
+	if err := w.sendWebhookJson(ctx, detailLogs); err != nil {
+		level.Error(w.logger).Log(
+			"msg", fmt.Sprintf("failed to send automation webhook to %s", server.MaskSecretURLParams(w.url)),
+			"err", server.MaskURLError(err).Error(),
+		)
+	}
 
 	return nil
 }

--- a/server/logging/webhook.go
+++ b/server/logging/webhook.go
@@ -69,7 +69,7 @@ func (w *webhookLogWriter) Write(ctx context.Context, logs []json.RawMessage) er
 
 	level.Debug(w.logger).Log(
 		"msg", "sending webhook request",
-		"url", w.url,
+		"url", server.MaskSecretURLParams(w.url),
 	)
 
 	if err := w.sendWebhookJson(ctx, detailLogs); err != nil {

--- a/server/logging/webhook.go
+++ b/server/logging/webhook.go
@@ -1,0 +1,132 @@
+package logging
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/fleetdm/fleet/v4/pkg/fleethttp"
+	"github.com/fleetdm/fleet/v4/server"
+	"github.com/fleetdm/fleet/v4/server/contexts/ctxerr"
+	"github.com/go-kit/log"
+)
+
+var defaultTimeout = 30 * time.Second
+
+type webhookLogWriter struct {
+	url           string
+	basicAuthUser string
+	basicAuthPass string
+	bearerToken   string
+	timeout       time.Duration
+	logger        log.Logger
+}
+
+func NewWebhookLogWriter(webhookURL, basicAuthUser, basicAuthPass, bearerToken string, timeout time.Duration, logger log.Logger) (*webhookLogWriter, error) {
+	if webhookURL == "" {
+		return nil, errors.New("webhook URL missing")
+	}
+
+	// We can only have basic auth or bearer, not both
+	if (basicAuthUser != "" || basicAuthPass != "") && bearerToken != "" {
+		return nil, errors.New("basic auth and bearer token cannot be used at the same time")
+	}
+
+	if timeout == 0 {
+		timeout = defaultTimeout
+	}
+
+	return &webhookLogWriter{
+		url:           webhookURL,
+		basicAuthUser: basicAuthUser,
+		basicAuthPass: basicAuthPass,
+		bearerToken:   bearerToken,
+		timeout:       timeout,
+		logger:        logger,
+	}, nil
+}
+
+type webhookDetails struct {
+	Timestamp time.Time       `json:"timestamp"`
+	Details   json.RawMessage `json:"details"`
+}
+
+func (w *webhookLogWriter) Write(ctx context.Context, logs []json.RawMessage) error {
+	detailLogs := make([]webhookDetails, 0, len(logs))
+
+	for _, log := range logs {
+		detailLogs = append(detailLogs, webhookDetails{
+			Timestamp: time.Now(),
+			Details:   log,
+		})
+	}
+
+	if err := w.sendWebhookJson(ctx, detailLogs); err != nil {
+		return ctxerr.Wrap(ctx, err, "writing webhook logs")
+	}
+
+	return nil
+}
+
+func (w *webhookLogWriter) sendWebhookJson(ctx context.Context, v any) error {
+	jsonBytes, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	client := fleethttp.NewClient(fleethttp.WithTimeout(w.timeout))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, w.url, bytes.NewBuffer(jsonBytes))
+	if err != nil {
+		return err
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+
+	// We already check that only one auth type is set
+	if w.basicAuthUser != "" || w.basicAuthPass != "" {
+		req.SetBasicAuth(w.basicAuthUser, w.basicAuthPass)
+	}
+
+	if w.bearerToken != "" {
+		req.Header.Set("Authorization", "Bearer "+w.bearerToken)
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to POST to %s: %s, request-size=%d", server.MaskSecretURLParams(w.url), server.MaskURLError(err), len(jsonBytes))
+	}
+	defer resp.Body.Close()
+
+	if !httpSuccessStatus(resp.StatusCode) {
+		body, _ := io.ReadAll(resp.Body)
+		return &errWithStatus{err: fmt.Sprintf("error posting to %s: %d. %s", server.MaskSecretURLParams(w.url), resp.StatusCode, string(body)), statusCode: resp.StatusCode}
+	}
+
+	return nil
+
+}
+
+func httpSuccessStatus(statusCode int) bool {
+	return statusCode >= 200 && statusCode <= 299
+}
+
+// errWithStatus is an error with a particular status code.
+type errWithStatus struct {
+	err        string
+	statusCode int
+}
+
+// Error implements the error interface
+func (e *errWithStatus) Error() string {
+	return e.err
+}
+
+// StatusCode implements the StatusCoder interface for returning custom status codes.
+func (e *errWithStatus) StatusCode() int {
+	return e.statusCode
+}

--- a/server/logging/webhook.go
+++ b/server/logging/webhook.go
@@ -13,6 +13,7 @@ import (
 	"github.com/fleetdm/fleet/v4/pkg/fleethttp"
 	"github.com/fleetdm/fleet/v4/server"
 	"github.com/fleetdm/fleet/v4/server/contexts/ctxerr"
+	"github.com/go-kit/kit/log/level"
 	"github.com/go-kit/log"
 )
 
@@ -66,8 +67,16 @@ func (w *webhookLogWriter) Write(ctx context.Context, logs []json.RawMessage) er
 		})
 	}
 
+	level.Debug(w.logger).Log(
+		"msg", "sending webhook request",
+		"url", w.url,
+	)
+
 	if err := w.sendWebhookJson(ctx, detailLogs); err != nil {
-		return ctxerr.Wrap(ctx, err, "writing webhook logs")
+		level.Error(w.logger).Log(
+			"msg", fmt.Sprintf("failed to send automation webhook to %s", server.MaskSecretURLParams(w.url)),
+			"err", server.MaskURLError(err).Error(),
+		)
 	}
 
 	return nil

--- a/server/logging/webhook.go
+++ b/server/logging/webhook.go
@@ -1,16 +1,12 @@
 package logging
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
-	"net/http"
 	"time"
 
-	"github.com/fleetdm/fleet/v4/pkg/fleethttp"
 	"github.com/fleetdm/fleet/v4/server"
 	"github.com/go-kit/kit/log/level"
 	"github.com/go-kit/log"
@@ -19,35 +15,18 @@ import (
 var defaultTimeout = 15 * time.Second
 
 type webhookLogWriter struct {
-	url           string
-	basicAuthUser string
-	basicAuthPass string
-	bearerToken   string
-	timeout       time.Duration
-	logger        log.Logger
+	url    string
+	logger log.Logger
 }
 
-func NewWebhookLogWriter(webhookURL, basicAuthUser, basicAuthPass, bearerToken string, timeout time.Duration, logger log.Logger) (*webhookLogWriter, error) {
+func NewWebhookLogWriter(webhookURL string, logger log.Logger) (*webhookLogWriter, error) {
 	if webhookURL == "" {
 		return nil, errors.New("webhook URL missing")
 	}
 
-	// We can only have basic auth or bearer, not both
-	if (basicAuthUser != "" || basicAuthPass != "") && bearerToken != "" {
-		return nil, errors.New("basic auth and bearer token cannot be used at the same time")
-	}
-
-	if timeout == 0 {
-		timeout = defaultTimeout
-	}
-
 	return &webhookLogWriter{
-		url:           webhookURL,
-		basicAuthUser: basicAuthUser,
-		basicAuthPass: basicAuthPass,
-		bearerToken:   bearerToken,
-		timeout:       timeout,
-		logger:        logger,
+		url:    webhookURL,
+		logger: logger,
 	}, nil
 }
 
@@ -71,7 +50,7 @@ func (w *webhookLogWriter) Write(ctx context.Context, logs []json.RawMessage) er
 		"url", server.MaskSecretURLParams(w.url),
 	)
 
-	if err := w.sendWebhookJson(ctx, detailLogs); err != nil {
+	if err := server.PostJSONWithTimeout(ctx, w.url, detailLogs); err != nil {
 		level.Error(w.logger).Log(
 			"msg", fmt.Sprintf("failed to send automation webhook to %s", server.MaskSecretURLParams(w.url)),
 			"err", server.MaskURLError(err).Error(),
@@ -79,62 +58,4 @@ func (w *webhookLogWriter) Write(ctx context.Context, logs []json.RawMessage) er
 	}
 
 	return nil
-}
-
-func (w *webhookLogWriter) sendWebhookJson(ctx context.Context, v any) error {
-	jsonBytes, err := json.Marshal(v)
-	if err != nil {
-		return err
-	}
-
-	client := fleethttp.NewClient(fleethttp.WithTimeout(w.timeout))
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, w.url, bytes.NewBuffer(jsonBytes))
-	if err != nil {
-		return err
-	}
-
-	req.Header.Set("Content-Type", "application/json")
-
-	// We already check that only one auth type is set
-	if w.basicAuthUser != "" || w.basicAuthPass != "" {
-		req.SetBasicAuth(w.basicAuthUser, w.basicAuthPass)
-	}
-
-	if w.bearerToken != "" {
-		req.Header.Set("Authorization", "Bearer "+w.bearerToken)
-	}
-
-	resp, err := client.Do(req)
-	if err != nil {
-		return fmt.Errorf("failed to POST to %s: %s, request-size=%d", server.MaskSecretURLParams(w.url), server.MaskURLError(err), len(jsonBytes))
-	}
-	defer resp.Body.Close()
-
-	if !httpSuccessStatus(resp.StatusCode) {
-		body, _ := io.ReadAll(resp.Body)
-		return &errWithStatus{err: fmt.Sprintf("error posting to %s: %d. %s", server.MaskSecretURLParams(w.url), resp.StatusCode, string(body)), statusCode: resp.StatusCode}
-	}
-
-	return nil
-
-}
-
-func httpSuccessStatus(statusCode int) bool {
-	return statusCode >= 200 && statusCode <= 299
-}
-
-// errWithStatus is an error with a particular status code.
-type errWithStatus struct {
-	err        string
-	statusCode int
-}
-
-// Error implements the error interface
-func (e *errWithStatus) Error() string {
-	return e.err
-}
-
-// StatusCode implements the StatusCoder interface for returning custom status codes.
-func (e *errWithStatus) StatusCode() int {
-	return e.statusCode
 }

--- a/server/logging/webhook.go
+++ b/server/logging/webhook.go
@@ -12,8 +12,6 @@ import (
 	"github.com/go-kit/log"
 )
 
-var defaultTimeout = 15 * time.Second
-
 type webhookLogWriter struct {
 	url    string
 	logger log.Logger

--- a/server/logging/webhook_test.go
+++ b/server/logging/webhook_test.go
@@ -39,3 +39,24 @@ func TestWebhookSubmission(t *testing.T) {
 	require.Len(t, body.Details, 3)
 	require.Equal(t, logs, body.Details)
 }
+
+func TestWebhookFailure(t *testing.T) {
+	ctx := context.Background()
+	logger := log.NewNopLogger()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "bad", http.StatusBadRequest)
+	}))
+	writer, err := NewWebhookLogWriter(server.URL, logger)
+	require.NoError(t, err)
+
+	// Should always return no error and not stall, even if bad things happen
+
+	// Bad return code
+	err = writer.Write(ctx, []json.RawMessage{json.RawMessage("{}")})
+	require.NoError(t, err)
+
+	// No server
+	server.Close()
+	err = writer.Write(ctx, []json.RawMessage{json.RawMessage("{}")})
+	require.NoError(t, err)
+}

--- a/server/logging/webhook_test.go
+++ b/server/logging/webhook_test.go
@@ -1,0 +1,41 @@
+package logging
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWebhookSubmission(t *testing.T) {
+	ctx := context.Background()
+	logger := log.NewNopLogger()
+	var body struct {
+		Timestamp time.Time         `json:"timestamp"`
+		Details   []json.RawMessage `json:"details"`
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "application/json", r.Header.Get("Content-Type"))
+		err := json.NewDecoder(r.Body).Decode(&body)
+		require.NoError(t, err)
+	}))
+	writer, err := NewWebhookLogWriter(server.URL, logger)
+	require.NoError(t, err)
+
+	logs := []json.RawMessage{
+		json.RawMessage(`{"pack":"fruit"}`),
+		json.RawMessage(`{"information":213}`),
+		json.RawMessage(`{"gordon":"freeman"}`),
+	}
+
+	err = writer.Write(ctx, logs)
+	require.NoError(t, err)
+
+	require.Len(t, body.Details, 3)
+	require.Equal(t, logs, body.Details)
+}

--- a/server/service/service_appconfig.go
+++ b/server/service/service_appconfig.go
@@ -157,6 +157,13 @@ func (svc *Service) LoggingConfig(ctx context.Context) (*fleet.Logging, error) {
 					FilesystemConfig: conf.Filesystem,
 				},
 			}
+		case "webhook":
+			*lp.target = fleet.LoggingPlugin{
+				Plugin: "webhook",
+				Config: fleet.WebhookConfig{
+					WebhookConfig: conf.Webhook,
+				},
+			}
 		case "kinesis":
 			*lp.target = fleet.LoggingPlugin{
 				Plugin: "kinesis",


### PR DESCRIPTION
#28164 (parent #27445)

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/Committing-Changes.md#changes-files) for more information.
- [x] Added/updated automated tests
- [x] A detailed QA plan exists on the associated ticket (if it isn't there, work with the product group's QA engineer to add it)
	- Set `FLEET_OSQUERY_RESULT_LOG_PLUGIN="webhook"`
	- I tested this using this [self-hosted webhook tester](https://github.com/tarampampam/webhook-tester).
	- Set `FLEET_WEBHOOK_STATUS_URL="<webhook tester URL>"`
	- Set `FLEET_WEBHOOK_RESULT_URL="<webhook tester URL>"`
- [x] Manual QA for all new/changed functionality
