### PR TITLE
Fleet UI: Prevent software card from disappearing when no vulns detected on software

### DIFF
--- a/frontend/pages/DashboardPage/DashboardPage.tsx
+++ b/frontend/pages/DashboardPage/DashboardPage.tsx
@@ -330,7 +330,11 @@ const DashboardPage = ({ router, location }: IDashboardProps): JSX.Element => {
       keepPreviousData: true,
       staleTime: 30000, // stale time can be adjusted if fresher data is desired based on software inventory interval
       onSuccess: (data) => {
-        if (data.software?.length > 0) {
+        const hasSoftwareResults = data.software?.length > 0;
+        const viewingVulnSoftwareTab = softwareNavTabIndex === 1;
+
+        // Prevent card from hiding if returns results or on-clicking vuln tab if software has no vulnerabilities
+        if (hasSoftwareResults || viewingVulnSoftwareTab) {
           setSoftwareTitleDetail &&
             setSoftwareTitleDetail(
               <LastUpdatedText


### PR DESCRIPTION
## Issues
For #28213 

## Description 
- If viewing vuln software, card no longer hides if there's zero vulns on installed software for that team, it now shows the empty state

## Screenshot of fix
<img width="685" alt="Screenshot 2025-04-30 at 4 15 01 PM" src="https://github.com/user-attachments/assets/a0df2679-0e6d-4382-853f-f50977c87b33" />


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] A detailed QA plan exists on the associated ticket (if it isn't there, work with the product group's QA engineer to add it)
- [x] Manual QA for all new/changed functionality
