### PR TITLE
UI: Fix live policy response percentage rounding

### DIFF
--- a/changes/27052-round-live-policy-percentages
+++ b/changes/27052-round-live-policy-percentages
@@ -1,0 +1,1 @@
+- Fix a small bug with the way live policy result percentages were being rounded

--- a/frontend/pages/policies/PolicyPage/components/PolicyResults/PolicyResults.tsx
+++ b/frontend/pages/policies/PolicyPage/components/PolicyResults/PolicyResults.tsx
@@ -144,11 +144,11 @@ const PolicyResults = ({
         {" "}
         (Yes:{" "}
         <TooltipWrapper tipContent={`${yesCt} host${yesCt !== 1 ? "s" : ""}`}>
-          {Math.ceil((yesCt / uiHostCounts.successful) * 100)}%
+          {Math.round((yesCt / uiHostCounts.successful) * 100)}%
         </TooltipWrapper>
         , No:{" "}
         <TooltipWrapper tipContent={`${noCt} host${noCt !== 1 ? "s" : ""}`}>
-          {Math.floor((noCt / uiHostCounts.successful) * 100)}%
+          {Math.round((noCt / uiHostCounts.successful) * 100)}%
         </TooltipWrapper>
         )
       </span>


### PR DESCRIPTION
## For #27052 

- Use `round` instead of `ceil` and `floor`

<img width="144" alt="Screenshot 2025-04-30 at 10 20 09 PM" src="https://github.com/user-attachments/assets/48a64558-6aca-4cd0-be9e-a526f9e6219d" />


- [x] Changes file added for user-visible changes in `changes/`
- [x] Manual QA for all new/changed functionality