### PR TITLE
Fleet UI: Surface policy count triggering automatic installations

### DIFF
--- a/changes/28054-surface-policy-count-triggering-install
+++ b/changes/28054-surface-policy-count-triggering-install
@@ -1,0 +1,1 @@
+* Fleet UI: Surfaced number of policies triggering automatic install of software in software table

--- a/frontend/components/TableContainer/DataTable/SoftwareNameCell/SoftwareNameCell.tests.tsx
+++ b/frontend/components/TableContainer/DataTable/SoftwareNameCell/SoftwareNameCell.tests.tsx
@@ -1,0 +1,107 @@
+import React from "react";
+import { screen } from "@testing-library/react";
+import { createCustomRenderer } from "test/test-utils";
+
+import SoftwareNameCell from "./SoftwareNameCell";
+
+// TODO: figure out how to mock the router properly.
+const mockRouter = {
+  push: jest.fn(),
+  replace: jest.fn(),
+  goBack: jest.fn(),
+  goForward: jest.fn(),
+  go: jest.fn(),
+  setRouteLeaveHook: jest.fn(),
+  isActive: jest.fn(),
+  createHref: jest.fn(),
+  createPath: jest.fn(),
+};
+
+describe("SoftwareNameCell", () => {
+  const defaultProps = {
+    name: "Fleet Desktop",
+    source: "fleet",
+  };
+
+  it("renders a non-clickable cell when no router or path is provided", () => {
+    const render = createCustomRenderer();
+    render(<SoftwareNameCell {...defaultProps} />);
+    expect(screen.getAllByText(/Fleet Desktop/i).length).toBeGreaterThan(0);
+    // Should not render as a link
+    expect(screen.queryByRole("link")).toBeNull();
+  });
+
+  it("renders with a suffix icon and tooltip when hasPackage is true", async () => {
+    const render = createCustomRenderer();
+    render(
+      <SoftwareNameCell
+        {...defaultProps}
+        router={mockRouter}
+        path="/software/1"
+        hasPackage
+        isSelfService={false}
+        installType="manual"
+      />
+    );
+    expect(
+      screen.getByText("Software can be installed on Host details page.")
+    ).toBeInTheDocument();
+  });
+
+  it("renders the correct count for tooltip for automatic installType", () => {
+    const render = createCustomRenderer();
+    render(
+      <SoftwareNameCell
+        {...defaultProps}
+        router={mockRouter}
+        path="/software/1"
+        hasPackage
+        installType="automatic"
+        automaticInstallPoliciesCount={2}
+      />
+    );
+    expect(screen.getByText("2 policies trigger install.")).toBeInTheDocument();
+  });
+
+  it("renders the correct tooltip for automaticSelfService", () => {
+    const render = createCustomRenderer();
+    render(
+      <SoftwareNameCell
+        {...defaultProps}
+        router={mockRouter}
+        path="/software/1"
+        hasPackage
+        isSelfService
+        installType="automatic"
+        automaticInstallPoliciesCount={1}
+      />
+    );
+    expect(screen.getByText(/A policy triggers install./)).toBeInTheDocument();
+    expect(screen.getByText(/End users can reinstall/)).toBeInTheDocument();
+  });
+
+  it("renders with SoftwareIcon and truncated tooltip on myDevicePage", () => {
+    const render = createCustomRenderer();
+    render(<SoftwareNameCell {...defaultProps} myDevicePage />);
+    expect(screen.getAllByText(/Fleet Desktop/i).length).toBeGreaterThan(0);
+    // Should not render as a link
+    expect(screen.queryByRole("link")).toBeNull();
+  });
+
+  it("renders the self-service tooltip when isSelfService is true and installType is not automatic", () => {
+    const render = createCustomRenderer();
+    render(
+      <SoftwareNameCell
+        {...defaultProps}
+        router={mockRouter}
+        path="/software/1"
+        hasPackage
+        isSelfService
+        installType="manual"
+      />
+    );
+
+    // Check for the SELF_SERVICE_TOOLTIP content
+    expect(screen.getByText(/End users can install/)).toBeInTheDocument();
+  });
+});

--- a/frontend/components/TableContainer/DataTable/SoftwareNameCell/SoftwareNameCell.tsx
+++ b/frontend/components/TableContainer/DataTable/SoftwareNameCell/SoftwareNameCell.tsx
@@ -20,28 +20,36 @@ type InstallType =
 
 interface installIconConfig {
   iconName: IconNames;
-  tooltip: JSX.Element;
+  tooltip: (automaticInstallPolicyCount?: number) => JSX.Element;
 }
 
 const installIconMap: Record<InstallType, installIconConfig> = {
   manual: {
     iconName: "install",
-    tooltip: <>Software can be installed on Host details page.</>,
+    tooltip: () => <>Software can be installed on Host details page.</>,
   },
   selfService: {
     iconName: "user",
-    tooltip: SELF_SERVICE_TOOLTIP,
+    tooltip: () => SELF_SERVICE_TOOLTIP,
   },
   automatic: {
     iconName: "refresh",
-    tooltip: <>Software will be automatically installed on each host.</>,
+    tooltip: (count = 0) => (
+      <>
+        {count === 1
+          ? "A policy triggers install."
+          : `${count} policies trigger install.`}
+      </>
+    ),
   },
   automaticSelfService: {
     iconName: "automatic-self-service",
-    tooltip: (
+    tooltip: (count = 0) => (
       <>
-        Software will be automatically installed on each host. End users can
-        reinstall from <b>Fleet Desktop {">"} Self-service</b>.
+        {count === 1
+          ? "A policy triggers install."
+          : `${count} policies trigger install.`}{" "}
+        End users can reinstall from <b>Fleet Desktop {">"} Self-service</b>.
       </>
     ),
   },
@@ -50,11 +58,13 @@ const installIconMap: Record<InstallType, installIconConfig> = {
 interface IInstallIconWithTooltipProps {
   isSelfService: boolean;
   installType?: "manual" | "automatic";
+  automaticInstallPoliciesCount?: number;
 }
 
 const InstallIconWithTooltip = ({
   isSelfService,
   installType,
+  automaticInstallPoliciesCount,
 }: IInstallIconWithTooltipProps) => {
   let iconType: InstallType = "manual";
   if (installType === "automatic") {
@@ -86,7 +96,7 @@ const InstallIconWithTooltip = ({
         data-html
       >
         <span className={`${baseClass}__install-tooltip-text`}>
-          {installIconMap[iconType].tooltip}
+          {installIconMap[iconType].tooltip(automaticInstallPoliciesCount)}
         </span>
       </ReactTooltip>
     </div>
@@ -105,6 +115,7 @@ interface ISoftwareNameCellProps {
   isSelfService?: boolean;
   installType?: "manual" | "automatic";
   iconUrl?: string;
+  automaticInstallPoliciesCount?: number;
 }
 
 const SoftwareNameCell = ({
@@ -117,6 +128,7 @@ const SoftwareNameCell = ({
   isSelfService = false,
   installType,
   iconUrl,
+  automaticInstallPoliciesCount,
 }: ISoftwareNameCellProps) => {
   // My device page
   if (myDevicePage) {
@@ -159,6 +171,7 @@ const SoftwareNameCell = ({
           <InstallIconWithTooltip
             isSelfService={isSelfService}
             installType={installType}
+            automaticInstallPoliciesCount={automaticInstallPoliciesCount}
           />
         ) : undefined
       }

--- a/frontend/pages/SoftwarePage/SoftwareTitles/SoftwareTable/SoftwareTitlesTableConfig.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitles/SoftwareTable/SoftwareTitlesTableConfig.tsx
@@ -72,6 +72,7 @@ const getSoftwareNameCellData = (
   let isSelfService = false;
   let installType: "manual" | "automatic" | undefined;
   let iconUrl: string | null = null;
+  let automaticInstallPoliciesCount = 0;
   if (software_package) {
     hasPackage = true;
     isSelfService = software_package.self_service;
@@ -80,6 +81,8 @@ const getSoftwareNameCellData = (
       software_package.automatic_install_policies.length > 0
         ? "automatic"
         : "manual";
+    automaticInstallPoliciesCount =
+      software_package.automatic_install_policies?.length || 0;
   } else if (app_store_app) {
     hasPackage = true;
     isSelfService = app_store_app.self_service;
@@ -89,6 +92,8 @@ const getSoftwareNameCellData = (
       app_store_app.automatic_install_policies.length > 0
         ? "automatic"
         : "manual";
+    automaticInstallPoliciesCount =
+      app_store_app.automatic_install_policies?.length || 0;
   }
 
   const isAllTeams = teamId === undefined;
@@ -101,6 +106,7 @@ const getSoftwareNameCellData = (
     isSelfService,
     installType,
     iconUrl,
+    automaticInstallPoliciesCount,
   };
 };
 
@@ -131,6 +137,9 @@ const generateTableHeaders = (
             isSelfService={nameCellData.isSelfService}
             installType={nameCellData.installType}
             iconUrl={nameCellData.iconUrl ?? undefined}
+            automaticInstallPoliciesCount={
+              nameCellData.automaticInstallPoliciesCount
+            }
           />
         );
       },


### PR DESCRIPTION
## Issue
For #28054 

## Description
- Change tooltips to show policy count

## Screenshots
<img width="619" alt="Screenshot 2025-05-01 at 10 56 05 AM" src="https://github.com/user-attachments/assets/cf4f1dc4-356d-407c-a4b8-895c00cb1572" />
<img width="325" alt="Screenshot 2025-05-01 at 10 55 17 AM" src="https://github.com/user-attachments/assets/9aabaced-a9cf-4322-8331-62125bec7139" />



# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/Committing-Changes.md#changes-files) for more information.
- [ ] Added/updated automated tests
- [ ] A detailed QA plan exists on the associated ticket (if it isn't there, work with the product group's QA engineer to add it)
- [x] Manual QA for all new/changed functionality
