### PR TITLE
Remove sotware paths error

### DIFF
--- a/changes/28619-remove-paths-err
+++ b/changes/28619-remove-paths-err
@@ -1,0 +1,1 @@
+removed error caused by macOS electron helper apps during ingestion

--- a/server/datastore/mysql/software.go
+++ b/server/datastore/mysql/software.go
@@ -168,12 +168,12 @@ func hostSoftwareInstalledPathsDelta(
 		parts := strings.SplitN(key, fleet.SoftwareFieldSeparator, 3)
 		installedPath, teamIdentifier, unqStr := parts[0], parts[1], parts[2]
 
-		// Shouldn't be possible ... everything 'reported' should be in the the software table
+		// Shouldn't be a common occurance ... everything 'reported' should be in the the software table
 		// because this executes after 'ds.UpdateHostSoftware'
 		s, ok := sUnqStrLook[unqStr]
 		if !ok {
-			err = fmt.Errorf("reported installed path for %s does not belong to any stored software entry", unqStr)
-			return
+			// this condition is only expected occur for electron helper apps on macOS where multiple helper apps share the same bundle identifier
+			continue
 		}
 
 		if _, ok := iSPathLookup[key]; ok {

--- a/server/datastore/mysql/software.go
+++ b/server/datastore/mysql/software.go
@@ -168,7 +168,7 @@ func hostSoftwareInstalledPathsDelta(
 		parts := strings.SplitN(key, fleet.SoftwareFieldSeparator, 3)
 		installedPath, teamIdentifier, unqStr := parts[0], parts[1], parts[2]
 
-		// Shouldn't be a common occurance ... everything 'reported' should be in the the software table
+		// Shouldn't be a common occurence ... everything 'reported' should be in the the software table
 		// because this executes after 'ds.UpdateHostSoftware'
 		s, ok := sUnqStrLook[unqStr]
 		if !ok {

--- a/server/datastore/mysql/software.go
+++ b/server/datastore/mysql/software.go
@@ -66,7 +66,7 @@ func (ds *Datastore) UpdateHostSoftwareInstalledPaths(
 		return err
 	}
 
-	toI, toD, err := hostSoftwareInstalledPathsDelta(hostID, reported, hsip, currS)
+	toI, toD, err := hostSoftwareInstalledPathsDelta(hostID, reported, hsip, currS, ds.logger)
 	if err != nil {
 		return err
 	}
@@ -122,6 +122,7 @@ func hostSoftwareInstalledPathsDelta(
 	reported map[string]struct{},
 	stored []fleet.HostSoftwareInstalledPath,
 	hostSoftware []fleet.Software,
+	logger log.Logger,
 ) (
 	toInsert []fleet.HostSoftwareInstalledPath,
 	toDelete []uint,
@@ -172,7 +173,7 @@ func hostSoftwareInstalledPathsDelta(
 		// because this executes after 'ds.UpdateHostSoftware'
 		s, ok := sUnqStrLook[unqStr]
 		if !ok {
-			// this condition is only expected occur for electron helper apps on macOS where multiple helper apps share the same bundle identifier
+			level.Debug(logger).Log("msg", "skipping installed path for software not found", "host_id", hostID, "unq_str", unqStr)
 			continue
 		}
 

--- a/server/datastore/mysql/software_test.go
+++ b/server/datastore/mysql/software_test.go
@@ -2927,7 +2927,7 @@ func testHostSoftwareInstalledPathsDelta(t *testing.T, ds *Datastore) {
 	}
 
 	t.Run("empty args", func(t *testing.T) {
-		toI, toD, err := hostSoftwareInstalledPathsDelta(host.ID, nil, nil, nil)
+		toI, toD, err := hostSoftwareInstalledPathsDelta(host.ID, nil, nil, nil, nil)
 		require.Empty(t, toI)
 		require.Empty(t, toD)
 		require.NoError(t, err)
@@ -2944,7 +2944,7 @@ func testHostSoftwareInstalledPathsDelta(t *testing.T, ds *Datastore) {
 			})
 		}
 
-		toI, toD, err := hostSoftwareInstalledPathsDelta(host.ID, nil, stored, software)
+		toI, toD, err := hostSoftwareInstalledPathsDelta(host.ID, nil, stored, software, nil)
 		require.NoError(t, err)
 
 		require.Empty(t, toI)
@@ -2966,7 +2966,7 @@ func testHostSoftwareInstalledPathsDelta(t *testing.T, ds *Datastore) {
 		reported[fmt.Sprintf("/some/path/%d%s%s%s%s", software[2].ID, fleet.SoftwareFieldSeparator, "", fleet.SoftwareFieldSeparator, software[2].ToUniqueStr())] = struct{}{}
 
 		var stored []fleet.HostSoftwareInstalledPath
-		_, _, err := hostSoftwareInstalledPathsDelta(host.ID, reported, stored, nil)
+		_, _, err := hostSoftwareInstalledPathsDelta(host.ID, reported, stored, nil, nil)
 		require.Error(t, err)
 	})
 
@@ -3005,7 +3005,7 @@ func testHostSoftwareInstalledPathsDelta(t *testing.T, ds *Datastore) {
 			InstalledPath: fmt.Sprintf("/some/path/%d", software[3].ID),
 		})
 
-		toI, toD, err := hostSoftwareInstalledPathsDelta(host.ID, reported, stored, software)
+		toI, toD, err := hostSoftwareInstalledPathsDelta(host.ID, reported, stored, software, nil)
 		require.NoError(t, err)
 
 		require.Len(t, toD, 3)


### PR DESCRIPTION
# Checklist for submitter
For #28619 
Removing error caused by macOS electron helper apps using the same bundle identifier attribute 

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/Committing-Changes.md#changes-files) for more information.
- [X] Manual QA for all new/changed functionality