### PR TITLE
Fleet UI: VPP apps with self service shows correct install status

### DIFF
--- a/changes/28379-vpp-app-install-status
+++ b/changes/28379-vpp-app-install-status
@@ -1,0 +1,1 @@
+Fleet UI: Install Status correctly displays available for self-service for VPP apps

--- a/frontend/pages/hosts/details/cards/Software/InstallStatusCell/InstallStatusCell.tests.tsx
+++ b/frontend/pages/hosts/details/cards/Software/InstallStatusCell/InstallStatusCell.tests.tsx
@@ -1,9 +1,7 @@
 import React from "react";
 import { render, screen } from "@testing-library/react";
 import { renderWithSetup } from "test/test-utils";
-import userEvent from "@testing-library/user-event";
 import {
-  createMockHostSoftware,
   createMockHostAppStoreApp,
   createMockHostSoftwarePackage,
 } from "__mocks__/hostMock";
@@ -16,25 +14,12 @@ jest.mock("lodash", () => ({
   uniqueId: jest.fn(() => "test-tooltip-id"),
 }));
 
-const baseProps = {
-  id: 1,
-  name: "Test Software",
-  version: "1.0.0",
-  source: "test",
-  bundle_identifier: "com.test.software",
-  hosts_count: 1,
-  status: null,
-  software_package: null,
-  app_store_app: null,
-};
-
 const testSoftwarePackage = createMockHostSoftwarePackage();
 
 describe("InstallStatusCell - component", () => {
   it("renders 'Installed' status with tooltip", async () => {
     const { user } = renderWithSetup(
       <InstallStatusCell
-        {...baseProps}
         status="installed"
         software_package={testSoftwarePackage}
       />
@@ -49,7 +34,6 @@ describe("InstallStatusCell - component", () => {
   it("renders 'Installing (pending)' status with tooltip", async () => {
     const { user } = renderWithSetup(
       <InstallStatusCell
-        {...baseProps}
         status="pending_install"
         software_package={testSoftwarePackage}
       />
@@ -66,7 +50,6 @@ describe("InstallStatusCell - component", () => {
   it("renders 'Uninstalling (pending)' status with tooltip", async () => {
     const { user } = renderWithSetup(
       <InstallStatusCell
-        {...baseProps}
         status="pending_uninstall"
         software_package={testSoftwarePackage}
       />
@@ -83,7 +66,6 @@ describe("InstallStatusCell - component", () => {
   it("renders 'Install (failed)' status with tooltip", async () => {
     const { user } = renderWithSetup(
       <InstallStatusCell
-        {...baseProps}
         status="failed_install"
         software_package={testSoftwarePackage}
       />
@@ -100,7 +82,6 @@ describe("InstallStatusCell - component", () => {
   it("renders 'Uninstall (failed)' status with tooltip", async () => {
     const { user } = renderWithSetup(
       <InstallStatusCell
-        {...baseProps}
         status="failed_uninstall"
         software_package={testSoftwarePackage}
       />
@@ -116,11 +97,7 @@ describe("InstallStatusCell - component", () => {
 
   it("renders 'Available for install' for package", async () => {
     const { user } = renderWithSetup(
-      <InstallStatusCell
-        {...baseProps}
-        software_package={testSoftwarePackage}
-        status={null}
-      />
+      <InstallStatusCell software_package={testSoftwarePackage} status={null} />
     );
 
     expect(screen.getByText("Available for install")).toBeInTheDocument();
@@ -132,7 +109,6 @@ describe("InstallStatusCell - component", () => {
   it("renders 'Available for install' for App Store app", async () => {
     const { user } = renderWithSetup(
       <InstallStatusCell
-        {...baseProps}
         software_package={{ ...testSoftwarePackage, self_service: false }}
         status={null}
       />
@@ -147,7 +123,6 @@ describe("InstallStatusCell - component", () => {
   it("renders 'Self-service' for package with self_service true", async () => {
     const { user } = renderWithSetup(
       <InstallStatusCell
-        {...baseProps}
         software_package={{
           ...testSoftwarePackage,
           name: "SelfService Software",
@@ -166,7 +141,6 @@ describe("InstallStatusCell - component", () => {
   it("renders 'Self-service' for App Store app with self_service true", async () => {
     const { user } = renderWithSetup(
       <InstallStatusCell
-        {...baseProps}
         app_store_app={createMockHostAppStoreApp({ self_service: true })}
         status={null}
       />
@@ -179,7 +153,7 @@ describe("InstallStatusCell - component", () => {
   });
 
   it("renders placeholder for missing status and packages", () => {
-    render(<InstallStatusCell {...baseProps} />);
+    render(<InstallStatusCell status={null} />);
 
     expect(screen.getByText("---")).toBeInTheDocument();
   });

--- a/frontend/pages/hosts/details/cards/Software/InstallStatusCell/InstallStatusCell.tests.tsx
+++ b/frontend/pages/hosts/details/cards/Software/InstallStatusCell/InstallStatusCell.tests.tsx
@@ -1,0 +1,186 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { renderWithSetup } from "test/test-utils";
+import userEvent from "@testing-library/user-event";
+import {
+  createMockHostSoftware,
+  createMockHostAppStoreApp,
+  createMockHostSoftwarePackage,
+} from "__mocks__/hostMock";
+
+import InstallStatusCell from "./InstallStatusCell";
+
+// Mock lodash uniqueId to always return the same id for stable tests
+jest.mock("lodash", () => ({
+  ...jest.requireActual("lodash"),
+  uniqueId: jest.fn(() => "test-tooltip-id"),
+}));
+
+const baseProps = {
+  id: 1,
+  name: "Test Software",
+  version: "1.0.0",
+  source: "test",
+  bundle_identifier: "com.test.software",
+  hosts_count: 1,
+  status: null,
+  software_package: null,
+  app_store_app: null,
+};
+
+const testSoftwarePackage = createMockHostSoftwarePackage();
+
+describe("InstallStatusCell - component", () => {
+  it("renders 'Installed' status with tooltip", async () => {
+    const { user } = renderWithSetup(
+      <InstallStatusCell
+        {...baseProps}
+        status="installed"
+        software_package={testSoftwarePackage}
+      />
+    );
+
+    expect(screen.getByText("Installed")).toBeInTheDocument();
+
+    await user.hover(screen.getByText("Installed"));
+    expect(screen.getByText(/Software is installed/i)).toBeInTheDocument();
+  });
+
+  it("renders 'Installing (pending)' status with tooltip", async () => {
+    const { user } = renderWithSetup(
+      <InstallStatusCell
+        {...baseProps}
+        status="pending_install"
+        software_package={testSoftwarePackage}
+      />
+    );
+
+    expect(screen.getByText("Installing (pending)")).toBeInTheDocument();
+
+    await user.hover(screen.getByText("Installing (pending)"));
+    expect(
+      screen.getByText(/Fleet is installing or will install/i)
+    ).toBeInTheDocument();
+  });
+
+  it("renders 'Uninstalling (pending)' status with tooltip", async () => {
+    const { user } = renderWithSetup(
+      <InstallStatusCell
+        {...baseProps}
+        status="pending_uninstall"
+        software_package={testSoftwarePackage}
+      />
+    );
+
+    expect(screen.getByText("Uninstalling (pending)")).toBeInTheDocument();
+
+    await user.hover(screen.getByText("Uninstalling (pending)"));
+    expect(
+      screen.getByText(/Fleet is uninstalling or will uninstall/i)
+    ).toBeInTheDocument();
+  });
+
+  it("renders 'Install (failed)' status with tooltip", async () => {
+    const { user } = renderWithSetup(
+      <InstallStatusCell
+        {...baseProps}
+        status="failed_install"
+        software_package={testSoftwarePackage}
+      />
+    );
+
+    expect(screen.getByText("Install (failed)")).toBeInTheDocument();
+
+    await user.hover(screen.getByText("Install (failed)"));
+    expect(
+      screen.getByText(/The host failed to install software/i)
+    ).toBeInTheDocument();
+  });
+
+  it("renders 'Uninstall (failed)' status with tooltip", async () => {
+    const { user } = renderWithSetup(
+      <InstallStatusCell
+        {...baseProps}
+        status="failed_uninstall"
+        software_package={testSoftwarePackage}
+      />
+    );
+
+    expect(screen.getByText("Uninstall (failed)")).toBeInTheDocument();
+
+    await user.hover(screen.getByText("Uninstall (failed)"));
+    expect(
+      screen.getByText(/The host failed to uninstall software/i)
+    ).toBeInTheDocument();
+  });
+
+  it("renders 'Available for install' for package", async () => {
+    const { user } = renderWithSetup(
+      <InstallStatusCell
+        {...baseProps}
+        software_package={testSoftwarePackage}
+        status={null}
+      />
+    );
+
+    expect(screen.getByText("Available for install")).toBeInTheDocument();
+
+    await user.hover(screen.getByText("Available for install"));
+    expect(screen.getByText(/can be installed/i)).toBeInTheDocument();
+  });
+
+  it("renders 'Available for install' for App Store app", async () => {
+    const { user } = renderWithSetup(
+      <InstallStatusCell
+        {...baseProps}
+        software_package={{ ...testSoftwarePackage, self_service: false }}
+        status={null}
+      />
+    );
+
+    expect(screen.getByText("Available for install")).toBeInTheDocument();
+
+    await user.hover(screen.getByText("Available for install"));
+    expect(screen.getByText(/can be installed/i)).toBeInTheDocument();
+  });
+
+  it("renders 'Self-service' for package with self_service true", async () => {
+    const { user } = renderWithSetup(
+      <InstallStatusCell
+        {...baseProps}
+        software_package={{
+          ...testSoftwarePackage,
+          name: "SelfService Software",
+          self_service: true,
+        }}
+        status={null}
+      />
+    );
+
+    expect(screen.getAllByText("Self-service").length).toBeGreaterThan(0);
+
+    await user.hover(screen.getAllByText("Self-service")[0]);
+    expect(screen.getByText(/can be installed/i)).toBeInTheDocument();
+  });
+
+  it("renders 'Self-service' for App Store app with self_service true", async () => {
+    const { user } = renderWithSetup(
+      <InstallStatusCell
+        {...baseProps}
+        app_store_app={createMockHostAppStoreApp({ self_service: true })}
+        status={null}
+      />
+    );
+
+    expect(screen.getAllByText("Self-service").length).toBeGreaterThan(0);
+
+    await user.hover(screen.getAllByText("Self-service")[0]);
+    expect(screen.getByText(/Software can be installed/i)).toBeInTheDocument();
+  });
+
+  it("renders placeholder for missing status and packages", () => {
+    render(<InstallStatusCell {...baseProps} />);
+
+    expect(screen.getByText("---")).toBeInTheDocument();
+  });
+});

--- a/frontend/pages/hosts/details/cards/Software/InstallStatusCell/InstallStatusCell.tsx
+++ b/frontend/pages/hosts/details/cards/Software/InstallStatusCell/InstallStatusCell.tsx
@@ -123,10 +123,8 @@ export const INSTALL_STATUS_DISPLAY_OPTIONS: Record<
   },
 };
 
-type IInstallStatusCellProps = Pick<
-  IHostSoftware,
-  "status" | "software_package" | "app_store_app"
->;
+type IInstallStatusCellProps = Pick<IHostSoftware, "status"> &
+  Partial<Pick<IHostSoftware, "software_package" | "app_store_app">>;
 
 const InstallStatusCell = ({
   status,

--- a/frontend/pages/hosts/details/cards/Software/InstallStatusCell/InstallStatusCell.tsx
+++ b/frontend/pages/hosts/details/cards/Software/InstallStatusCell/InstallStatusCell.tsx
@@ -123,7 +123,10 @@ export const INSTALL_STATUS_DISPLAY_OPTIONS: Record<
   },
 };
 
-type IInstallStatusCellProps = IHostSoftware;
+type IInstallStatusCellProps = Pick<
+  IHostSoftware,
+  "status" | "software_package" | "app_store_app"
+>;
 
 const InstallStatusCell = ({
   status,
@@ -138,8 +141,7 @@ const InstallStatusCell = ({
 
   if (status !== null) {
     displayStatus = status;
-  } else if (software_package?.self_service) {
-    // currently only software packages can be self-service
+  } else if (software_package?.self_service || app_store_app?.self_service) {
     displayStatus = "selfService";
   } else if (hasPackage || hasAppStoreApp) {
     displayStatus = "avaiableForInstall";


### PR DESCRIPTION
## Issue
For #28379 

## Description
- VPP apps once didn't have self-service, when we added self-service, we missed updating the logic here to show self-service for VPP apps
- Added `InstallerStatusCell.tests.tsx`

## Screenshot of fix

<img width="1552" alt="Screenshot 2025-05-01 at 4 19 11 PM" src="https://github.com/user-attachments/assets/6c3582f7-54f7-4d76-ad2a-82e5b6da86e7" />

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/Committing-Changes.md#changes-files) for more information.
- [ ] A detailed QA plan exists on the associated ticket (if it isn't there, work with the product group's QA engineer to add it)
- [x] Manual QA for all new/changed functionality

