### PR TITLE
UI: Enable Integrations > Advanced save button in GitOps Mode

### DIFF
--- a/changes/28747-allow-advanced-save-in-GOM
+++ b/changes/28747-allow-advanced-save-in-GOM
@@ -1,0 +1,1 @@
+* Enable saving Integrations > Advanced in GitOps mode

--- a/frontend/pages/admin/OrgSettingsPage/cards/Advanced/Advanced.tsx
+++ b/frontend/pages/admin/OrgSettingsPage/cards/Advanced/Advanced.tsx
@@ -486,19 +486,14 @@ const Advanced = ({
               )}
             />
           </div>
-          <GitOpsModeTooltipWrapper
-            tipOffset={-8}
-            renderChildren={(disableChildren) => (
-              <Button
-                type="submit"
-                disabled={Object.keys(formErrors).length > 0 || disableChildren}
-                className="save-loading button-wrap"
-                isLoading={isUpdatingSettings}
-              >
-                Save
-              </Button>
-            )}
-          />
+          <Button
+            type="submit"
+            disabled={Object.keys(formErrors).length > 0}
+            className="save-loading button-wrap"
+            isLoading={isUpdatingSettings}
+          >
+            Save
+          </Button>
         </form>
       </div>
     </div>


### PR DESCRIPTION
## For #28747 

<img width="639" alt="Screenshot 2025-05-01 at 4 28 22 PM" src="https://github.com/user-attachments/assets/0808d9fd-8866-4eb1-a84e-bef1efdd6919" />

- [x] Changes file added for user-visible changes in `changes/
- [x] Manual QA for all new/changed functionality