### PR TITLE
Fleet UI: Clean up Policies > Manage automation > Software options .tar.gz / missing version

### DIFF
--- a/frontend/pages/policies/ManagePoliciesPage/components/InstallSoftwareModal/InstallSoftwareModal.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/components/InstallSoftwareModal/InstallSoftwareModal.tsx
@@ -13,6 +13,7 @@ import { IPaginatedListHandle } from "components/PaginatedList";
 
 import { DEFAULT_USE_QUERY_OPTIONS } from "utilities/constants";
 import { getPathWithQueryParams } from "utilities/url";
+import { getExtensionFromFileName } from "utilities/file/fileUtils";
 
 // @ts-ignore
 import Dropdown from "components/forms/fields/Dropdown";
@@ -29,7 +30,6 @@ import {
 import PoliciesPaginatedList, {
   IFormPolicy,
 } from "../PoliciesPaginatedList/PoliciesPaginatedList";
-import { getExtensionFromFileName } from "utilities/file/fileUtils";
 
 const SOFTWARE_TITLE_LIST_LENGTH = 1000;
 

--- a/frontend/pages/policies/ManagePoliciesPage/components/InstallSoftwareModal/InstallSoftwareModal.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/components/InstallSoftwareModal/InstallSoftwareModal.tsx
@@ -29,6 +29,7 @@ import {
 import PoliciesPaginatedList, {
   IFormPolicy,
 } from "../PoliciesPaginatedList/PoliciesPaginatedList";
+import { getExtensionFromFileName } from "utilities/file/fileUtils";
 
 const SOFTWARE_TITLE_LIST_LENGTH = 1000;
 
@@ -64,15 +65,17 @@ const generateSoftwareOptionHelpText = (title: IEnhancedSoftwareTitle) => {
   let versionString = "";
 
   if (vppOption) {
-    platformString = "macOS (App Store) • ";
+    platformString = "macOS (App Store)";
     versionString = title.app_store_app?.version || "";
   } else {
     if (title.platform && title.extension) {
       platformString = `${PLATFORM_DISPLAY_NAMES[title.platform]} (.${
         title.extension
-      }) • `;
+      })`;
     }
-    versionString = title.software_package?.version || "";
+    versionString = title.software_package?.version
+      ? ` • ${title.software_package?.version}`
+      : "";
   }
 
   return `${platformString}${versionString}`;
@@ -115,7 +118,11 @@ const InstallSoftwareModal = ({
     {
       select: (data): IEnhancedSoftwareTitle[] =>
         data.software_titles.map((title) => {
-          const extension = title.software_package?.name.split(".").pop();
+          const extension =
+            (title.software_package &&
+              getExtensionFromFileName(title.software_package?.name)) ||
+            undefined;
+
           return {
             ...title,
             platform: formatSoftwarePlatform(title.source),


### PR DESCRIPTION
## Issue
For #27337 

## Description
- Fix code for double dot .tar.gz extensions
- Hide separator of version if there is no version returned from API

## Screenshot
BEFORE

<img width="1533" alt="Screenshot 2025-05-02 at 11 18 00 AM" src="https://github.com/user-attachments/assets/621a7f0e-2c94-442a-90fc-0613afb8822e" />

AFTER
<img width="318" alt="Screenshot 2025-05-02 at 11 51 31 AM" src="https://github.com/user-attachments/assets/ed2f13ec-02c9-468e-abde-2c2ef3372c43" />



# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [ ] A detailed QA plan exists on the associated ticket (if it isn't there, work with the product group's QA engineer to add it)
- [x] Manual QA for all new/changed functionality
