### PR TITLE
Replacing MySQL 8.4 with MySQL 9.X in our regular (every commit) tests.

### DIFF
--- a/.github/workflows/test-go.yaml
+++ b/.github/workflows/test-go.yaml
@@ -49,9 +49,9 @@ jobs:
           - ${{ github.event_name == 'schedule' }}
         exclude:
           - isCron: false
-            mysql: "mysql:9.3.0" # Only run MySQL 9 tests on cron schedule
+            mysql: "mysql:8.4.5" # Run MySQL 8.4.X tests on cron schedule and not every time. We run MySQL 9.X tests every time since they are faster than 8.X tests.
           - isCron: false
-            mysql: "mysql:8.0.32" # Only run MySQL 8.0.32 tests on cron schedule
+            mysql: "mysql:8.0.32" # Run MySQL 8.0.32 tests on cron schedule and not every time.
           # The suites below do not need MySQL, so we exclude additional MySQL options from the above matrix.
           - suite: "fast"
             mysql: "mysql:8.0.32" # We must make sure that at least 1 instance of this suite will run, which is 8.0.36 in this case


### PR DESCRIPTION
Replacing MySQL 8.4 with MySQL 9.X in our regular (every commit) tests to speed up dev feedback. The MySQL 8.4 tests will still run nightly.

The vulnerability feed download CI fails below are not related to this change.