### PR TITLE
Fleet UI: More pixel grace for zoomed out screensize

### DIFF
--- a/frontend/pages/SoftwarePage/SoftwareOS/SoftwareOSTable/_styles.scss
+++ b/frontend/pages/SoftwarePage/SoftwareOS/SoftwareOSTable/_styles.scss
@@ -1,6 +1,6 @@
 .software-os-table {
   &__platform-dropdown {
-    width: 175px;
+    width: 200px;
 
     .Select-menu-outer {
       width: 160px;

--- a/frontend/pages/SoftwarePage/SoftwareTitles/SoftwareTable/_styles.scss
+++ b/frontend/pages/SoftwarePage/SoftwareTitles/SoftwareTable/_styles.scss
@@ -1,6 +1,6 @@
 .software-table {
   &__software-filter {
-    min-width: 215px;
+    min-width: 220px;
   }
 
   &__filter-controls {

--- a/frontend/pages/SoftwarePage/SoftwareTitles/SoftwareTable/_styles.scss
+++ b/frontend/pages/SoftwarePage/SoftwareTitles/SoftwareTable/_styles.scss
@@ -1,6 +1,6 @@
 .software-table {
   &__software-filter {
-    min-width: 220px;
+    min-width: 240px;
   }
 
   &__filter-controls {

--- a/frontend/pages/SoftwarePage/SoftwareVulnerabilities/SoftwareVulnerabilitiesTable/_styles.scss
+++ b/frontend/pages/SoftwarePage/SoftwareVulnerabilities/SoftwareVulnerabilitiesTable/_styles.scss
@@ -1,6 +1,6 @@
 .software-vulnerabilities-table {
   &__exploited-vulnerabilities-filter {
-    min-width: 250px;
+    min-width: 255px;
   }
 
   &__count {

--- a/frontend/pages/hosts/ManageHostsPage/_styles.scss
+++ b/frontend/pages/hosts/ManageHostsPage/_styles.scss
@@ -222,11 +222,7 @@
   }
 
   &__status-filter {
-    width: 175px;
-
-    @media (min-width: $table-controls-break) {
-      width: 190px;
-    }
+    width: 195px;
 
     .Select-menu-outer {
       width: 364px;

--- a/frontend/pages/hosts/ManageHostsPage/components/LabelFilterSelect/_styles.scss
+++ b/frontend/pages/hosts/ManageHostsPage/components/LabelFilterSelect/_styles.scss
@@ -1,5 +1,5 @@
 .label-filter-select {
-  width: 300px;
+  width: 305px;
 
   svg {
     transition: transform 0.25s ease;
@@ -165,7 +165,7 @@
 
 @media (min-width: $table-controls-break) {
   .label-filter-select {
-    min-width: 220px;
+    min-width: 305px;
 
     &__single-value {
       max-width: 210px !important; // Must override default styling of .css-qc6sy-singleValue

--- a/frontend/pages/hosts/details/cards/Software/_styles.scss
+++ b/frontend/pages/hosts/details/cards/Software/_styles.scss
@@ -19,8 +19,8 @@
 
   .host-software-table {
     &__software-filter {
-      min-width: 220px;
-      width: 220px; // Override .form-field 100%
+      min-width: 240px;
+      width: 240px; // Override .form-field 100%
     }
 
     &__filters {

--- a/frontend/pages/hosts/details/cards/Software/_styles.scss
+++ b/frontend/pages/hosts/details/cards/Software/_styles.scss
@@ -19,8 +19,8 @@
 
   .host-software-table {
     &__software-filter {
-      min-width: 215px;
-      width: 215px; // Override .form-field 100%
+      min-width: 220px;
+      width: 220px; // Override .form-field 100%
     }
 
     &__filters {

--- a/frontend/styles/var/breakpoints.scss
+++ b/frontend/styles/var/breakpoints.scss
@@ -9,4 +9,4 @@ $break-mobile-md: 576px;
 $break-mobile-sm: 480px;
 $break-mobile-xs: 320px;
 $tooltip-break-md: 1000px; // Prevents horizontal scrolling off viewport
-$table-controls-break: 1150px;
+$table-controls-break: 1180px;


### PR DESCRIPTION
## Issue
For #28202 

## Description
More pixel width that don't squish when zoomed out in browser

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] A detailed QA plan exists on the associated ticket (if it isn't there, work with the product group's QA engineer to add it)
- [x] Manual QA for all new/changed functionality
