### PR TITLE
Fleet UI: Pass device user to use correct device user API

### DIFF
--- a/frontend/components/ActivityDetails/InstallDetails/SoftwareInstallDetails/SoftwareInstallDetails.tsx
+++ b/frontend/components/ActivityDetails/InstallDetails/SoftwareInstallDetails/SoftwareInstallDetails.tsx
@@ -175,7 +175,10 @@ export const SoftwareInstallDetailsModal = ({
     >
       <>
         <div className={`${baseClass}__modal-content`}>
-          <SoftwareInstallDetails {...details} />
+          <SoftwareInstallDetails
+            {...details}
+            deviceAuthToken={deviceAuthToken}
+          />
         </div>
         <div className="modal-cta-wrap">
           <Button onClick={onCancel}>Done</Button>


### PR DESCRIPTION
## Issue
For #28745

## Description
- Pass device auth token which will ternary use the correct device user API

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->


- [x] Manual QA for all new/changed functionality