### PR TITLE
update docs about disk_info table

### DIFF
--- a/changes/26674-update-disk-info-docs
+++ b/changes/26674-update-disk-info-docs
@@ -1,0 +1,1 @@
+- Updated the notes for the `disk_info` table to clarify usage in ChromeOS.

--- a/schema/osquery_fleet_schema.json
+++ b/schema/osquery_fleet_schema.json
@@ -6847,7 +6847,7 @@
     ],
     "evented": false,
     "cacheable": false,
-    "notes": "- On ChromeOS, this table requires the [fleetd Chrome extension](https://fleetdm.com/docs/using-fleet/chromeos).\n\n- Available for ChromeOS 91+.",
+    "notes": "- On ChromeOS, this table requires the [fleetd Chrome extension](https://fleetdm.com/docs/using-fleet/chromeos).\n\n- On ChromeOS, this table will only display information about _removable_ storage media, such as USB sticks or external hard drives.\n\n- Available for ChromeOS 91+.",
     "examples": "```\nSELECT * FROM disk_info;\n```",
     "columns": [
       {

--- a/schema/osquery_fleet_schema.json
+++ b/schema/osquery_fleet_schema.json
@@ -6847,7 +6847,7 @@
     ],
     "evented": false,
     "cacheable": false,
-    "notes": "- On ChromeOS, this table requires the [fleetd Chrome extension](https://fleetdm.com/docs/using-fleet/chromeos).\n\n- On ChromeOS, this table will only display information about _removable_ storage media, such as USB sticks or external hard drives.\n\n- Available for ChromeOS 91+.",
+    "notes": "- On ChromeOS, this table requires the [fleetd Chrome extension](https://fleetdm.com/docs/using-fleet/chromeos).\n- On ChromeOS, this table will only display information about _removable_ storage media, such as USB sticks or external hard drives.\n- Available for ChromeOS 91+.",
     "examples": "```\nSELECT * FROM disk_info;\n```",
     "columns": [
       {

--- a/schema/tables/disk_info.yml
+++ b/schema/tables/disk_info.yml
@@ -48,5 +48,5 @@ columns:
 evented: false
 notes: |-
   - On ChromeOS, this table requires the [fleetd Chrome extension](https://fleetdm.com/docs/using-fleet/chromeos).
-  
+  - On ChromeOS, this table will only display information about _removable_ storage media, such as USB sticks or external hard drives.
   - Available for ChromeOS 91+.


### PR DESCRIPTION
for #26674 

# Checklist for submitter

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/Committing-Changes.md#changes-files) for more information.

## Details

This PR adds text to the existing `disk_info` notes in the UI, clarifying that in ChromeOS, the table will only return data about removable storage media.  After researching the issue and trying various alternatives, my conclusion is that ChromeOS is purposely designed to make it very difficult to obtain hardware information (including internal disk space and usage) via extensions.  In order to actual do this reporting, we'd need to integrate the [Chrome Admin API](https://developers.google.com/workspace/admin/directory/reference/rest/v1/chromeosdevices#ChromeOsDevice) into Fleet, which requires more design and planning.