### PR TITLE
Bootstrap package and fleetd are installed in other scenarios

### DIFF
--- a/articles/macos-setup-experience.md
+++ b/articles/macos-setup-experience.md
@@ -44,6 +44,8 @@ Fleet supports installing a bootstrap package on macOS hosts that automatically 
 
 This enables installing tools like [Puppet](https://www.puppet.com/), [Munki](https://www.munki.org/munki/), or [Chef](https://www.chef.io/products/chef-infra) for configuration management and/or running custom scripts and installing tools like [DEP notify](https://gitlab.com/Mactroll/DEPNotify) to customize the setup experience for your end users.
 
+The bootstrap package is also installed during [MDM migration](https://fleetdm.com/guides/mdm-migration) and when the enrollment profile is renewed manually by running `sudo profiles renew -type enrollment`.
+
 The following are examples of what some organizations deploy using a bootstrap package:
 
 * Munki client to install and keep software up to date on your Macs

--- a/articles/macos-setup-experience.md
+++ b/articles/macos-setup-experience.md
@@ -44,7 +44,7 @@ Fleet supports installing a bootstrap package on macOS hosts that automatically 
 
 This enables installing tools like [Puppet](https://www.puppet.com/), [Munki](https://www.munki.org/munki/), or [Chef](https://www.chef.io/products/chef-infra) for configuration management and/or running custom scripts and installing tools like [DEP notify](https://gitlab.com/Mactroll/DEPNotify) to customize the setup experience for your end users.
 
-The bootstrap package, and Fleet's agent (fleetd), is also installed during [MDM migration](https://fleetdm.com/guides/mdm-migration) and when the enrollment profile is renewed manually by running `sudo profiles renew -type enrollment`.
+The bootstrap package, Fleet's agent (fleetd), and [custom OS settings (configuration profiles)](https://fleetdm.com/guides/custom-os-settings) are also delivered during [MDM migration](https://fleetdm.com/guides/mdm-migration). Only fleetd and configuration profiles are delivered when an enrollment profile is renewed manually by running `sudo profiles renew -type enrollment`.
 
 The following are examples of what some organizations deploy using a bootstrap package:
 

--- a/articles/macos-setup-experience.md
+++ b/articles/macos-setup-experience.md
@@ -44,7 +44,7 @@ Fleet supports installing a bootstrap package on macOS hosts that automatically 
 
 This enables installing tools like [Puppet](https://www.puppet.com/), [Munki](https://www.munki.org/munki/), or [Chef](https://www.chef.io/products/chef-infra) for configuration management and/or running custom scripts and installing tools like [DEP notify](https://gitlab.com/Mactroll/DEPNotify) to customize the setup experience for your end users.
 
-The bootstrap package is also installed during [MDM migration](https://fleetdm.com/guides/mdm-migration) and when the enrollment profile is renewed manually by running `sudo profiles renew -type enrollment`. Fleet's agent (fleetd) is also installed in these scenarios if you don't [manually install fleetd](#advanced).
+The bootstrap package is also installed during [MDM migration](https://fleetdm.com/guides/mdm-migration) and when the enrollment profile is renewed manually by running `sudo profiles renew -type enrollment`.
 
 The following are examples of what some organizations deploy using a bootstrap package:
 

--- a/articles/macos-setup-experience.md
+++ b/articles/macos-setup-experience.md
@@ -44,7 +44,7 @@ Fleet supports installing a bootstrap package on macOS hosts that automatically 
 
 This enables installing tools like [Puppet](https://www.puppet.com/), [Munki](https://www.munki.org/munki/), or [Chef](https://www.chef.io/products/chef-infra) for configuration management and/or running custom scripts and installing tools like [DEP notify](https://gitlab.com/Mactroll/DEPNotify) to customize the setup experience for your end users.
 
-The bootstrap package is also installed during [MDM migration](https://fleetdm.com/guides/mdm-migration) and when the enrollment profile is renewed manually by running `sudo profiles renew -type enrollment`.
+The bootstrap package, and Fleet's agent (fleetd), is also installed during [MDM migration](https://fleetdm.com/guides/mdm-migration) and when the enrollment profile is renewed manually by running `sudo profiles renew -type enrollment`.
 
 The following are examples of what some organizations deploy using a bootstrap package:
 

--- a/articles/macos-setup-experience.md
+++ b/articles/macos-setup-experience.md
@@ -44,7 +44,7 @@ Fleet supports installing a bootstrap package on macOS hosts that automatically 
 
 This enables installing tools like [Puppet](https://www.puppet.com/), [Munki](https://www.munki.org/munki/), or [Chef](https://www.chef.io/products/chef-infra) for configuration management and/or running custom scripts and installing tools like [DEP notify](https://gitlab.com/Mactroll/DEPNotify) to customize the setup experience for your end users.
 
-The bootstrap package is also installed during [MDM migration](https://fleetdm.com/guides/mdm-migration) and when the enrollment profile is renewed manually by running `sudo profiles renew -type enrollment`.
+The bootstrap package is also installed during [MDM migration](https://fleetdm.com/guides/mdm-migration) and when the enrollment profile is renewed manually by running `sudo profiles renew -type enrollment`. Fleet's agent (fleetd) is also installed in these scenarios if you don't [manually install fleetd](#advanced).
 
 The following are examples of what some organizations deploy using a bootstrap package:
 


### PR DESCRIPTION
When? MDM migration and `sudo profiles renew -type enrollment`
