### PR TITLE
Add config option to disable usage statistics for premium users

### DIFF
--- a/changes/28220-disable-premium-statistics
+++ b/changes/28220-disable-premium-statistics
@@ -1,0 +1,1 @@
+- Add config option to disable statistics for approved premium users

--- a/cmd/fleet/cron.go
+++ b/cmd/fleet/cron.go
@@ -1119,8 +1119,11 @@ func trySendStatistics(ctx context.Context, ds fleet.Datastore, frequency time.D
 		return err
 	}
 
+	// Some premium users are allowed to disable statistics
+	sendPremiumStatistics := license.IsPremium(ctx) && config.License.EnableAnalytics
+
 	// If the license is Premium, we should always send usage statisics.
-	if !ac.ServerSettings.EnableAnalytics && !license.IsPremium(ctx) {
+	if !ac.ServerSettings.EnableAnalytics && !sendPremiumStatistics {
 		return nil
 	}
 

--- a/cmd/fleet/serve.go
+++ b/cmd/fleet/serve.go
@@ -687,9 +687,9 @@ the way that the Fleet server works.
 				}
 			}
 
-			// Some premium users are allowed to disable statistics with a flag
-			if !config.License.EnableAnalytics {
-				appCfg.ServerSettings.EnableAnalytics = false
+			// Some premium users are allowed to disable statistics with a flag, default enabled
+			if license.IsPremium() {
+				appCfg.ServerSettings.EnableAnalytics = config.License.EnableAnalytics
 			}
 
 			// save the app config with the updated MDM.Enabled value

--- a/cmd/fleet/serve.go
+++ b/cmd/fleet/serve.go
@@ -687,6 +687,11 @@ the way that the Fleet server works.
 				}
 			}
 
+			// Some premium users are allowed to disable statistics with a flag
+			if !config.License.EnableAnalytics {
+				appCfg.ServerSettings.EnableAnalytics = false
+			}
+
 			// save the app config with the updated MDM.Enabled value
 			if err := ds.SaveAppConfig(context.Background(), appCfg); err != nil {
 				initFatal(err, "saving app config")

--- a/frontend/pages/admin/OrgSettingsPage/cards/Statistics/Statistics.tsx
+++ b/frontend/pages/admin/OrgSettingsPage/cards/Statistics/Statistics.tsx
@@ -72,7 +72,7 @@ const Statistics = ({
           <Checkbox
             onChange={onInputChange}
             name="enableUsageStatistics"
-            value={isPremiumTier ? true : enableUsageStatistics} // Set to true for all premium customers
+            value={enableUsageStatistics} // Set to true for all premium customers
             parseTarget
             disabled={isPremiumTier}
           >

--- a/frontend/pages/admin/OrgSettingsPage/cards/Statistics/Statistics.tsx
+++ b/frontend/pages/admin/OrgSettingsPage/cards/Statistics/Statistics.tsx
@@ -72,7 +72,7 @@ const Statistics = ({
           <Checkbox
             onChange={onInputChange}
             name="enableUsageStatistics"
-            value={enableUsageStatistics} // Set to true for all premium customers
+            value={enableUsageStatistics}
             parseTarget
             disabled={isPremiumTier}
           >

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -2052,6 +2052,9 @@ func TestConfig() FleetConfig {
 			MaxSize:       500,
 		},
 		Server: ServerConfig{PrivateKey: "72414F4A688151F75D032F5CDA095FC4"},
+		License: LicenseConfig{
+			EnableAnalytics: true,
+		},
 	}
 }
 

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -528,6 +528,7 @@ type KafkaRESTConfig struct {
 type LicenseConfig struct {
 	Key              string `yaml:"key"`
 	EnforceHostLimit bool   `yaml:"enforce_host_limit"`
+	EnableAnalytics  bool   `yaml:"enable_analytics"`
 }
 
 // VulnerabilitiesConfig defines configs related to vulnerability processing within Fleet.
@@ -1320,6 +1321,7 @@ func (man Manager) addConfigs() {
 	// License
 	man.addConfigString("license.key", "", "Fleet license key (to enable Fleet Premium features)")
 	man.addConfigBool("license.enforce_host_limit", false, "Enforce license limit of enrolled hosts")
+	man.addConfigBool("license.enable_analytics", true, "For approved Fleet Premium customers only. Whether to send anonymous usage statistics")
 
 	// Vulnerability processing
 	man.addConfigString("vulnerabilities.databases_path", "/tmp/vulndbs",
@@ -1617,6 +1619,7 @@ func (man Manager) LoadConfig() FleetConfig {
 		License: LicenseConfig{
 			Key:              man.getConfigString("license.key"),
 			EnforceHostLimit: man.getConfigBool("license.enforce_host_limit"),
+			EnableAnalytics:  man.getConfigBool("license.enable_analytics"),
 		},
 		Vulnerabilities: VulnerabilitiesConfig{
 			DatabasesPath:               man.getConfigString("vulnerabilities.databases_path"),

--- a/server/service/appconfig.go
+++ b/server/service/appconfig.go
@@ -453,7 +453,7 @@ func (svc *Service) ModifyAppConfig(ctx context.Context, p []byte, applyOpts fle
 	}
 
 	// If the license is Premium, we should always send usage statisics.
-	if license.IsPremium() {
+	if license.IsPremium() && svc.config.License.EnableAnalytics {
 		appConfig.ServerSettings.EnableAnalytics = true
 	}
 

--- a/server/service/appconfig.go
+++ b/server/service/appconfig.go
@@ -452,9 +452,9 @@ func (svc *Service) ModifyAppConfig(ctx context.Context, p []byte, applyOpts fle
 		}
 	}
 
-	// If the license is Premium, we should always send usage statisics.
-	if license.IsPremium() && svc.config.License.EnableAnalytics {
-		appConfig.ServerSettings.EnableAnalytics = true
+	// Premium users cannot change this setting in the UI, only by launch flag
+	if license.IsPremium() {
+		appConfig.ServerSettings.EnableAnalytics = oldAppConfig.ServerSettings.EnableAnalytics
 	}
 
 	fleet.ValidateGoogleCalendarIntegrations(appConfig.Integrations.GoogleCalendar, invalid)

--- a/server/service/appconfig_test.go
+++ b/server/service/appconfig_test.go
@@ -1448,35 +1448,49 @@ func TestModifyEnableAnalytics(t *testing.T) {
 	admin := &fleet.User{GlobalRole: ptr.String(fleet.RoleAdmin)}
 
 	testCases := []struct {
-		name             string
-		expectedEnabled  bool
-		newEnabled       bool
-		initialEnabled   bool
-		licenseTier      string
-		initialURL       string
-		newURL           string
-		expectedURL      string
-		shouldFailModify bool
+		name                    string
+		expectedEnabled         bool
+		newEnabled              bool
+		initialEnabled          bool
+		licenseTier             string
+		initialURL              string
+		newURL                  string
+		expectedURL             string
+		shouldFailModify        bool
+		licenseAnalyticsEnabled bool
+		enableDefault           bool
 	}{
 		{
 			name:            "fleet free",
 			expectedEnabled: false,
 			initialEnabled:  true,
 			newEnabled:      false,
+			enableDefault:   true,
 			licenseTier:     fleet.TierFree,
 		},
 		{
-			name:            "fleet premium",
-			expectedEnabled: true,
-			initialEnabled:  true,
-			newEnabled:      false,
-			licenseTier:     fleet.TierPremium,
+			name:                    "fleet premium default analytics",
+			expectedEnabled:         true,
+			initialEnabled:          true,
+			newEnabled:              false,
+			licenseTier:             fleet.TierPremium,
+			licenseAnalyticsEnabled: true,
+			enableDefault:           true,
+		},
+		{
+			name:                    "fleet premium analytics disabled",
+			expectedEnabled:         false,
+			initialEnabled:          false,
+			newEnabled:              true,
+			licenseTier:             fleet.TierPremium,
+			licenseAnalyticsEnabled: false,
+			enableDefault:           false,
 		},
 	}
 
 	for _, tt := range testCases {
 		t.Run(tt.name, func(t *testing.T) {
-			svc, ctx := newTestService(t, ds, nil, nil, &TestServerOpts{License: &fleet.LicenseInfo{Tier: tt.licenseTier}})
+			svc, ctx := newTestService(t, ds, nil, nil, &TestServerOpts{License: &fleet.LicenseInfo{Tier: tt.licenseTier}, LicenseEnableAnalytics: &tt.licenseAnalyticsEnabled})
 			ctx = viewer.NewContext(ctx, viewer.Viewer{User: admin})
 
 			dsAppConfig := &fleet.AppConfig{
@@ -1484,7 +1498,7 @@ func TestModifyEnableAnalytics(t *testing.T) {
 					OrgName: "Test",
 				},
 				ServerSettings: fleet.ServerSettings{
-					EnableAnalytics: true,
+					EnableAnalytics: tt.enableDefault,
 					ServerURL:       "https://localhost:8080",
 				},
 			}

--- a/server/service/testing_utils.go
+++ b/server/service/testing_utils.go
@@ -140,6 +140,9 @@ func newTestServiceWithConfig(t *testing.T, ds fleet.Datastore, fleetConfig conf
 		}
 		// allow to explicitly set mdm pusher to nil
 		mdmPusher = opts[0].MDMPusher
+		if opts[0].LicenseEnableAnalytics != nil {
+			fleetConfig.License.EnableAnalytics = *opts[0].LicenseEnableAnalytics
+		}
 	}
 
 	ctx := license.NewContext(context.Background(), lic)
@@ -324,38 +327,39 @@ func (svc *mockMailService) CanSendEmail(smtpSettings fleet.SMTPSettings) bool {
 type TestNewScheduleFunc func(ctx context.Context, ds fleet.Datastore) fleet.NewCronScheduleFunc
 
 type TestServerOpts struct {
-	Logger                kitlog.Logger
-	License               *fleet.LicenseInfo
-	SkipCreateTestUsers   bool
-	Rs                    fleet.QueryResultStore
-	Lq                    fleet.LiveQueryStore
-	Pool                  fleet.RedisPool
-	FailingPolicySet      fleet.FailingPolicySet
-	Clock                 clock.Clock
-	Task                  *async.Task
-	EnrollHostLimiter     fleet.EnrollHostLimiter
-	Is                    fleet.InstallerStore
-	FleetConfig           *config.FleetConfig
-	MDMStorage            fleet.MDMAppleStore
-	DEPStorage            nanodep_storage.AllDEPStorage
-	SCEPStorage           scep_depot.Depot
-	MDMPusher             nanomdm_push.Pusher
-	HTTPServerConfig      *http.Server
-	StartCronSchedules    []TestNewScheduleFunc
-	UseMailService        bool
-	APNSTopic             string
-	ProfileMatcher        fleet.ProfileMatcher
-	EnableCachedDS        bool
-	NoCacheDatastore      bool
-	SoftwareInstallStore  fleet.SoftwareInstallerStore
-	BootstrapPackageStore fleet.MDMBootstrapPackageStore
-	KeyValueStore         fleet.KeyValueStore
-	EnableSCEPProxy       bool
-	WithDEPWebview        bool
-	FeatureRoutes         []endpoint_utils.HandlerRoutesFunc
-	SCEPConfigService     fleet.SCEPConfigService
-	DigiCertService       fleet.DigiCertService
-	EnableSCIM            bool
+	Logger                 kitlog.Logger
+	License                *fleet.LicenseInfo
+	SkipCreateTestUsers    bool
+	Rs                     fleet.QueryResultStore
+	Lq                     fleet.LiveQueryStore
+	Pool                   fleet.RedisPool
+	FailingPolicySet       fleet.FailingPolicySet
+	Clock                  clock.Clock
+	Task                   *async.Task
+	EnrollHostLimiter      fleet.EnrollHostLimiter
+	Is                     fleet.InstallerStore
+	FleetConfig            *config.FleetConfig
+	MDMStorage             fleet.MDMAppleStore
+	DEPStorage             nanodep_storage.AllDEPStorage
+	SCEPStorage            scep_depot.Depot
+	MDMPusher              nanomdm_push.Pusher
+	HTTPServerConfig       *http.Server
+	StartCronSchedules     []TestNewScheduleFunc
+	UseMailService         bool
+	APNSTopic              string
+	ProfileMatcher         fleet.ProfileMatcher
+	EnableCachedDS         bool
+	NoCacheDatastore       bool
+	SoftwareInstallStore   fleet.SoftwareInstallerStore
+	BootstrapPackageStore  fleet.MDMBootstrapPackageStore
+	KeyValueStore          fleet.KeyValueStore
+	EnableSCEPProxy        bool
+	WithDEPWebview         bool
+	FeatureRoutes          []endpoint_utils.HandlerRoutesFunc
+	SCEPConfigService      fleet.SCEPConfigService
+	DigiCertService        fleet.DigiCertService
+	EnableSCIM             bool
+	LicenseEnableAnalytics *bool
 }
 
 func RunServerForTestsWithDS(t *testing.T, ds fleet.Datastore, opts ...*TestServerOpts) (map[string]fleet.User, *httptest.Server) {


### PR DESCRIPTION
#28220

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/Committing-Changes.md#changes-files) for more information.
- [x] Added/updated automated tests
- [x] A detailed QA plan exists on the associated ticket (if it isn't there, work with the product group's QA engineer to add it)
- [x] Manual QA for all new/changed functionality
