### PR TITLE
Fix detected CVEs and docker scout exit code to fail the Github Action

### DIFF
--- a/.github/workflows/build-and-check-fleetctl-docker-and-deps.yml
+++ b/.github/workflows/build-and-check-fleetctl-docker-and-deps.yml
@@ -74,7 +74,7 @@ jobs:
             fleetdm/fleetctl
 
       - name: Run Trivy vulnerability scanner on fleetdm/wix
-        uses: aquasecurity/trivy-action@6e7b7d1fd3e4fef0c5fa8cce1229c54b2c9bd0d8
+        uses: aquasecurity/trivy-action@6c175e9c4083a92bbca2f9724c8a5e33bc2d97a5 # 0.30.0
         env:
           TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db
           TRIVY_JAVA_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-java-db
@@ -87,7 +87,7 @@ jobs:
           severity: "CRITICAL"
 
       - name: Run Trivy vulnerability scanner on fleetdm/bomutils
-        uses: aquasecurity/trivy-action@6e7b7d1fd3e4fef0c5fa8cce1229c54b2c9bd0d8
+        uses: aquasecurity/trivy-action@6c175e9c4083a92bbca2f9724c8a5e33bc2d97a5 # 0.30.0
         env:
           TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db
           TRIVY_JAVA_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-java-db

--- a/.github/workflows/goreleaser-snapshot-fleet.yaml
+++ b/.github/workflows/goreleaser-snapshot-fleet.yaml
@@ -127,6 +127,7 @@ jobs:
           only-vex-affected: true
           write-comment: false
           vex-location: ./security/vex/fleet
+          exit-code: true
             
       # Explicitly push the docker images as GoReleaser will not do so in snapshot mode
       - name: Publish Docker images

--- a/.github/workflows/trivy-scan.yml
+++ b/.github/workflows/trivy-scan.yml
@@ -53,7 +53,7 @@ jobs:
           aws-region: ${{ env.AWS_REGION }}
 
       - name: Run Trivy vulnerability scanner in repo mode
-        uses: aquasecurity/trivy-action@062f2592684a31eb3aa050cc61e7ca1451cecd3d # 0.18.0
+        uses: aquasecurity/trivy-action@6c175e9c4083a92bbca2f9724c8a5e33bc2d97a5 # 0.30.0
         env:
           TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db
           TRIVY_JAVA_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-java-db

--- a/Dockerfile-desktop-linux
+++ b/Dockerfile-desktop-linux
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 golang:1.24.1-bullseye@sha256:3c669c8fed069d80d199073b806243c4bf79ad117b797b96f18177ad9c521cff
+FROM --platform=linux/amd64 golang:1.24.2-bullseye@sha256:f50ff25f8331682b44c1582974eb9e620fcb08052fc6ed434f93ca24636fc4d6
 LABEL maintainer="Fleet Developers"
 
 RUN mkdir -p /usr/src/fleet

--- a/changes/update-go-1.24.2
+++ b/changes/update-go-1.24.2
@@ -1,0 +1,1 @@
+* Updated go to 1.24.2.

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/fleetdm/fleet/v4
 
-go 1.24.1
+go 1.24.2
 
 require (
 	cloud.google.com/go/pubsub v1.37.0

--- a/infrastructure/loadtesting/terraform/docker/loadtest.Dockerfile
+++ b/infrastructure/loadtesting/terraform/docker/loadtest.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24.1-alpine3.21@sha256:43c094ad24b6ac0546c62193baeb3e6e49ce14d3250845d166c77c25f64b0386
+FROM golang:1.24.2-alpine3.21@sha256:7772cb5322baa875edd74705556d08f0eeca7b9c4b5367754ce3f2f00041ccee
 ARG TAG
 RUN apk add git
 RUN git clone -b $TAG --depth=1 --no-tags --progress --no-recurse-submodules https://github.com/fleetdm/fleet.git && cd /go/fleet/cmd/osquery-perf/ && go build .

--- a/orbit/changes/update-go-1.24.2
+++ b/orbit/changes/update-go-1.24.2
@@ -1,0 +1,1 @@
+* Updated go to 1.24.2.

--- a/security/README.md
+++ b/security/README.md
@@ -43,7 +43,7 @@ Similarly, for `CVE-2024-8260` on package `github.com/open-policy-agent/opa` whi
 vexctl create --product="fleet,pkg:golang/github.com/open-policy-agent/opa" \
   --vuln="CVE-2024-8260" \
   --status="not_affected" \
-  --author="@luacsmrod" \
+  --author="@lucasmrod" \
   --justification="vulnerable_code_cannot_be_controlled_by_adversary" \
   --status-note="Fleet doesn't run on Windows, so it's not affected by this vulnerability." > security/vex/fleetctl/CVE-2024-8260.vex.json
 ```

--- a/security/status.md
+++ b/security/status.md
@@ -55,6 +55,16 @@ Following is the vulnerability report of Fleet components.
 - **Justification:** `vulnerable_code_not_in_execute_path`
 - **Timestamp:** 2025-04-10T15:42:55.967763-03:00
 
+### CVE-2024-8260
+- **Author:** @lucasmrod
+- **Status:** `not_affected`
+- **Status notes:** Fleet doesn't run on Windows, so it's not affected by this vulnerability.
+- **Products:**
+  - `fleet`
+  - `pkg:golang/github.com/open-policy-agent/opa`
+- **Justification:** `vulnerable_code_cannot_be_controlled_by_adversary`
+- **Timestamp:** 2025-05-05T20:54:14.90724-03:00
+
 ### CVE-2024-12797
 - **Author:** @lucasmrod
 - **Status:** `not_affected`

--- a/security/status.md
+++ b/security/status.md
@@ -88,6 +88,16 @@ Following is the vulnerability report of Fleet components.
 
 ## `fleetdm/fleetctl` docker image
 
+### CVE-2025-46569
+- **Author:** @lucasmrod
+- **Status:** `not_affected`
+- **Status notes:** fleetctl does not use OPA.
+- **Products:**
+  - `fleetctl`
+  - `pkg:golang/github.com/open-policy-agent/opa`
+- **Justification:** `vulnerable_code_not_in_execute_path`
+- **Timestamp:** 2025-05-06T07:47:31.187848-03:00
+
 ### CVE-2025-31115
 - **Author:** @lucasmrod
 - **Status:** `not_affected`

--- a/security/status.md
+++ b/security/status.md
@@ -5,15 +5,55 @@ Following is the vulnerability report of Fleet components.
 
 ## `fleetdm/fleet` docker image
 
-### CVE-2023-32698
+### CVE-2025-46569
+- **Author:** @lucasmrod
+- **Status:** `not_affected`
+- **Status notes:** fleet does not use OPA in server mode, it uses it as a library
+- **Products:**
+  - `fleet`
+  - `pkg:golang/github.com/open-policy-agent/opa@0.44.0`
+- **Justification:** `vulnerable_code_not_in_execute_path`
+- **Timestamp:** 2025-05-05T20:29:07.016171-03:00
+
+### CVE-2025-30204
+- **Author:** @lucasmrod
+- **Status:** `not_affected`
+- **Status notes:** The token format being validated before the call to ParseUnverified
+- **Products:**
+  - `fleet`
+  - `pkg:golang/github.com/golang-jwt/jwt/v4`
+- **Justification:** `inline_mitigations_already_exist`
+- **Timestamp:** 2025-04-10T15:23:54.60648-03:00
+
+### CVE-2025-26519
+- **Author:** @lucasmrod
+- **Status:** `not_affected`
+- **Status notes:** fleet does not perform any EUC-KR to UTF-8 translation by libc
+- **Products:**
+  - `fleet`
+  - `pkg:apk/alpine/musl@1.2.5-r8?os_name=alpine&os_version=3.21`
+- **Justification:** `vulnerable_code_not_in_execute_path`
+- **Timestamp:** 2025-04-14T16:30:01.904498-03:00
+
+### CVE-2025-21614
 - **Author:** @lucasmrod
 - **Status:** `not_affected`
 - **Status notes:** The fleetctl executable is unused in the fleetdm/fleet docker image. The executable was removed in v4.64.0.
 - **Products:**
   - `fleet`
-  - `pkg:golang/github.com/goreleaser/nfpm/v2`
+  - `pkg:golang/github.com/go-git/go-git/v5`
 - **Justification:** `vulnerable_code_not_in_execute_path`
-- **Timestamp:** 2025-04-10T15:28:30.406734-03:00
+- **Timestamp:** 2025-04-10T15:43:15.232143-03:00
+
+### CVE-2025-21613
+- **Author:** @lucasmrod
+- **Status:** `not_affected`
+- **Status notes:** The fleetctl executable is unused in the fleetdm/fleet docker image. The executable was removed in v4.64.0.
+- **Products:**
+  - `fleet`
+  - `pkg:golang/github.com/go-git/go-git/v5`
+- **Justification:** `vulnerable_code_not_in_execute_path`
+- **Timestamp:** 2025-04-10T15:42:55.967763-03:00
 
 ### CVE-2024-12797
 - **Author:** @lucasmrod
@@ -26,107 +66,27 @@ Following is the vulnerability report of Fleet components.
 - **Justification:** `vulnerable_code_not_in_execute_path`
 - **Timestamp:** 2025-04-10T15:15:53.847365-03:00
 
-### CVE-2025-21613
+### CVE-2023-32698
 - **Author:** @lucasmrod
 - **Status:** `not_affected`
 - **Status notes:** The fleetctl executable is unused in the fleetdm/fleet docker image. The executable was removed in v4.64.0.
 - **Products:**
   - `fleet`
-  - `pkg:golang/github.com/go-git/go-git/v5`
+  - `pkg:golang/github.com/goreleaser/nfpm/v2`
 - **Justification:** `vulnerable_code_not_in_execute_path`
-- **Timestamp:** 2025-04-10T15:42:55.967763-03:00
-
-### CVE-2025-21614
-- **Author:** @lucasmrod
-- **Status:** `not_affected`
-- **Status notes:** The fleetctl executable is unused in the fleetdm/fleet docker image. The executable was removed in v4.64.0.
-- **Products:**
-  - `fleet`
-  - `pkg:golang/github.com/go-git/go-git/v5`
-- **Justification:** `vulnerable_code_not_in_execute_path`
-- **Timestamp:** 2025-04-10T15:43:15.232143-03:00
-
-### CVE-2025-26519
-- **Author:** @lucasmrod
-- **Status:** `not_affected`
-- **Status notes:** fleet does not perform any EUC-KR to UTF-8 translation by libc
-- **Products:**
-  - `fleet`
-  - `pkg:apk/alpine/musl@1.2.5-r8?os_name=alpine&os_version=3.21`
-- **Justification:** `vulnerable_code_not_in_execute_path`
-- **Timestamp:** 2025-04-14T16:30:01.904498-03:00
-
-### CVE-2025-30204
-- **Author:** @lucasmrod
-- **Status:** `not_affected`
-- **Status notes:** The token format being validated before the call to ParseUnverified
-- **Products:**
-  - `fleet`
-  - `pkg:golang/github.com/golang-jwt/jwt/v4`
-- **Justification:** `inline_mitigations_already_exist`
-- **Timestamp:** 2025-04-10T15:23:54.60648-03:00
+- **Timestamp:** 2025-04-10T15:28:30.406734-03:00
 
 ## `fleetdm/fleetctl` docker image
 
-### CVE-2012-0881
+### CVE-2025-31115
 - **Author:** @lucasmrod
 - **Status:** `not_affected`
-- **Status notes:** fleetctl does not use Java
+- **Status notes:** fleetctl does not use liblzma5
 - **Products:**
   - `fleetctl`
-  - `pkg:maven/xerces/xercesImpl`
+  - `pkg:deb/debian/liblzma5`
 - **Justification:** `vulnerable_code_not_in_execute_path`
-- **Timestamp:** 2025-04-10T14:46:52.709835-03:00
-
-### CVE-2013-4002
-- **Author:** @lucasmrod
-- **Status:** `not_affected`
-- **Status notes:** fleetctl does not use Java
-- **Products:**
-  - `fleetctl`
-  - `pkg:maven/xerces/xercesImpl`
-- **Justification:** `vulnerable_code_not_in_execute_path`
-- **Timestamp:** 2025-04-10T07:36:31.1157-03:00
-
-### CVE-2019-10202
-- **Author:** @lucasmrod
-- **Status:** `not_affected`
-- **Status notes:** fleetctl does not use Java
-- **Products:**
-  - `fleetctl`
-  - `pkg:maven/org.codehaus.jackson/jackson-mapper-asl`
-- **Justification:** `vulnerable_code_not_in_execute_path`
-- **Timestamp:** 2025-04-15T10:31:31.924953-03:00
-
-### CVE-2023-32698
-- **Author:** @getvictor
-- **Status:** `not_affected`
-- **Status notes:** When packaging linux files, fleetctl does not use global permissions. It was verified that packed fleetd package files do not have group/global write permissions.
-- **Products:**
-  - `fleetctl`
-  - `pkg:golang/github.com/goreleaser/nfpm/v2`
-- **Justification:** `vulnerable_code_cannot_be_controlled_by_adversary`
-- **Timestamp:** 2025-04-09T10:26:02.350338-03:00
-
-### CVE-2023-45853
-- **Author:** @lucasmrod
-- **Status:** `not_affected`
-- **Status notes:** fleetctl does not use zlib C library
-- **Products:**
-  - `fleetctl`
-  - `pkg:deb/debian/zlib1g`
-- **Justification:** `vulnerable_code_not_in_execute_path`
-- **Timestamp:** 2025-04-15T10:17:19.625099-03:00
-
-### CVE-2023-6879
-- **Author:** @lucasmrod
-- **Status:** `not_affected`
-- **Status notes:** fleetctl does not use libaom3
-- **Products:**
-  - `fleetctl`
-  - `pkg:deb/debian/libaom3`
-- **Justification:** `vulnerable_code_not_in_execute_path`
-- **Timestamp:** 2025-04-15T10:28:21.796437-03:00
+- **Timestamp:** 2025-04-09T13:24:20.950928-03:00
 
 ### CVE-2024-7254
 - **Author:** @lucasmrod
@@ -138,13 +98,63 @@ Following is the vulnerability report of Fleet components.
 - **Justification:** `vulnerable_code_not_in_execute_path`
 - **Timestamp:** 2025-04-10T07:34:26.535559-03:00
 
-### CVE-2025-31115
+### CVE-2023-6879
 - **Author:** @lucasmrod
 - **Status:** `not_affected`
-- **Status notes:** fleetctl does not use liblzma5
+- **Status notes:** fleetctl does not use libaom3
 - **Products:**
   - `fleetctl`
-  - `pkg:deb/debian/liblzma5`
+  - `pkg:deb/debian/libaom3`
 - **Justification:** `vulnerable_code_not_in_execute_path`
-- **Timestamp:** 2025-04-09T13:24:20.950928-03:00
+- **Timestamp:** 2025-04-15T10:28:21.796437-03:00
+
+### CVE-2023-45853
+- **Author:** @lucasmrod
+- **Status:** `not_affected`
+- **Status notes:** fleetctl does not use zlib C library
+- **Products:**
+  - `fleetctl`
+  - `pkg:deb/debian/zlib1g`
+- **Justification:** `vulnerable_code_not_in_execute_path`
+- **Timestamp:** 2025-04-15T10:17:19.625099-03:00
+
+### CVE-2023-32698
+- **Author:** @getvictor
+- **Status:** `not_affected`
+- **Status notes:** When packaging linux files, fleetctl does not use global permissions. It was verified that packed fleetd package files do not have group/global write permissions.
+- **Products:**
+  - `fleetctl`
+  - `pkg:golang/github.com/goreleaser/nfpm/v2`
+- **Justification:** `vulnerable_code_cannot_be_controlled_by_adversary`
+- **Timestamp:** 2025-04-09T10:26:02.350338-03:00
+
+### CVE-2019-10202
+- **Author:** @lucasmrod
+- **Status:** `not_affected`
+- **Status notes:** fleetctl does not use Java
+- **Products:**
+  - `fleetctl`
+  - `pkg:maven/org.codehaus.jackson/jackson-mapper-asl`
+- **Justification:** `vulnerable_code_not_in_execute_path`
+- **Timestamp:** 2025-04-15T10:31:31.924953-03:00
+
+### CVE-2013-4002
+- **Author:** @lucasmrod
+- **Status:** `not_affected`
+- **Status notes:** fleetctl does not use Java
+- **Products:**
+  - `fleetctl`
+  - `pkg:maven/xerces/xercesImpl`
+- **Justification:** `vulnerable_code_not_in_execute_path`
+- **Timestamp:** 2025-04-10T07:36:31.1157-03:00
+
+### CVE-2012-0881
+- **Author:** @lucasmrod
+- **Status:** `not_affected`
+- **Status notes:** fleetctl does not use Java
+- **Products:**
+  - `fleetctl`
+  - `pkg:maven/xerces/xercesImpl`
+- **Justification:** `vulnerable_code_not_in_execute_path`
+- **Timestamp:** 2025-04-10T14:46:52.709835-03:00
 

--- a/security/vex/fleet/CVE-2024-8260.vex.json
+++ b/security/vex/fleet/CVE-2024-8260.vex.json
@@ -1,0 +1,26 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://openvex.dev/docs/public/vex-137e02a5f143abc344e45fbd3641a2ecd6e6fe8d0794207ec7d3ad29620241bc",
+  "author": "@lucasmrod",
+  "timestamp": "2025-05-05T20:54:14.907235-03:00",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2024-8260"
+      },
+      "timestamp": "2025-05-05T20:54:14.90724-03:00",
+      "products": [
+        {
+          "@id": "fleet"
+        },
+        {
+          "@id": "pkg:golang/github.com/open-policy-agent/opa"
+        }
+      ],
+      "status": "not_affected",
+      "status_notes": "Fleet doesn't run on Windows, so it's not affected by this vulnerability.",
+      "justification": "vulnerable_code_cannot_be_controlled_by_adversary"
+    }
+  ]
+}

--- a/security/vex/fleet/CVE-2025-46569.vex.json
+++ b/security/vex/fleet/CVE-2025-46569.vex.json
@@ -1,0 +1,26 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://openvex.dev/docs/public/vex-409b8b71e09dc326354da3ec0bc9a44bc0215e4bf3552400398192979df9ff71",
+  "author": "@lucasmrod",
+  "timestamp": "2025-05-05T20:29:07.016166-03:00",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2025-46569"
+      },
+      "timestamp": "2025-05-05T20:29:07.016171-03:00",
+      "products": [
+        {
+          "@id": "fleet"
+        },
+        {
+          "@id": "pkg:golang/github.com/open-policy-agent/opa@0.44.0"
+        }
+      ],
+      "status": "not_affected",
+      "status_notes": "fleet does not use OPA in server mode, it uses it as a library",
+      "justification": "vulnerable_code_not_in_execute_path"
+    }
+  ]
+}

--- a/security/vex/fleetctl/CVE-2025-46569.vex.json
+++ b/security/vex/fleetctl/CVE-2025-46569.vex.json
@@ -1,0 +1,26 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://openvex.dev/docs/public/vex-44fea98cce6ba07bcbf47bb1a9fb2a7513d9867059bf4537b75931e1f93b0c44",
+  "author": "@lucasmrod",
+  "timestamp": "2025-05-06T07:47:31.187844-03:00",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2025-46569"
+      },
+      "timestamp": "2025-05-06T07:47:31.187848-03:00",
+      "products": [
+        {
+          "@id": "fleetctl"
+        },
+        {
+          "@id": "pkg:golang/github.com/open-policy-agent/opa"
+        }
+      ],
+      "status": "not_affected",
+      "status_notes": "fleetctl does not use OPA.",
+      "justification": "vulnerable_code_not_in_execute_path"
+    }
+  ]
+}

--- a/tools/mdm/migration/mdmproxy/Dockerfile
+++ b/tools/mdm/migration/mdmproxy/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24.1-alpine3.21@sha256:43c094ad24b6ac0546c62193baeb3e6e49ce14d3250845d166c77c25f64b0386
+FROM golang:1.24.2-alpine3.21@sha256:7772cb5322baa875edd74705556d08f0eeca7b9c4b5367754ce3f2f00041ccee
 ARG TAG
 RUN apk update && apk add --no-cache git
 RUN git clone -b $TAG --depth=1 --no-tags --progress --no-recurse-submodules https://github.com/fleetdm/fleet.git && cd /go/fleet/tools/mdm/migration/mdmproxy && go build .

--- a/tools/mdm/windows/bitlocker/go.mod
+++ b/tools/mdm/windows/bitlocker/go.mod
@@ -1,6 +1,6 @@
 module bitlocker
 
-go 1.24.1
+go 1.24.2
 
 require github.com/go-ole/go-ole v1.3.0
 

--- a/tools/snapshot/go.mod
+++ b/tools/snapshot/go.mod
@@ -1,6 +1,6 @@
 module github.com/fleetdm/fleet/v4/tools/snapshot
 
-go 1.24.1
+go 1.24.2
 
 require (
 	github.com/manifoldco/promptui v0.9.0

--- a/tools/terraform/go.mod
+++ b/tools/terraform/go.mod
@@ -1,6 +1,6 @@
 module terraform-provider-fleetdm
 
-go 1.24.1
+go 1.24.2
 
 require (
 	github.com/hashicorp/terraform-plugin-framework v1.7.0

--- a/tools/vex-parser/vex-parser.go
+++ b/tools/vex-parser/vex-parser.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 )
 
@@ -96,6 +97,9 @@ func main() {
 		return
 	}
 
+	sort.Slice(vexPaths, func(i, j int) bool {
+		return vexPaths[i] > vexPaths[j]
+	})
 	for _, vexPath := range vexPaths {
 		outputMarkdown(vexPath)
 	}


### PR DESCRIPTION
For #28837.

Fixing this all of this because we got multiple reports from the community and customers and these were also detected by Amazon Inspector.

- Fixes CVE-2025-22871 by upgrading Go from 1.24.1 to 1.24.2.
- `docker scout` now fails the daily scheduled action if there are CRITICAL,HIGH CVEs (we missed setting `exit-code: true`).
- Report CVE-2025-46569 as not affected by it because of our use of OPA's go package.
- Report CVE-2024-8260 as not affected by it because Fleet doesn't run on Windows.
- The `security/status.md` shows a lot of changes because we are now sorting CVEs so that newest come first.

---

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/Committing-Changes.md#changes-files) for more information.
- [x] Manual QA for all new/changed functionality
- For Orbit and Fleet Desktop changes:
   - [x] Make sure fleetd is compatible with the latest released version of Fleet (see [Must rule](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/fleetd-development-and-release-strategy.md)).
   - [x] Orbit runs on macOS, Linux and Windows. Check if the orbit feature/bugfix should only apply to one platform (`runtime.GOOS`).
   - [x] Manual QA must be performed in the three main OSs, macOS, Windows and Linux.
   - [x] Auto-update manual QA, from released version of component to new version (see [tools/tuf/test](../tools/tuf/test/README.md)).
- [x] For unreleased bug fixes in a release candidate, confirmed that the fix is not expected to adversely impact load test results or alerted the release DRI if additional load testing is needed.
