### PR TITLE
Make `read_host_disk_encryption_key` a host activity

### DIFF
--- a/changes/28521-host-activity-read-disk-key
+++ b/changes/28521-host-activity-read-disk-key
@@ -1,0 +1,1 @@
+- Fixed reading disk encryption key not showing up in host activities

--- a/frontend/interfaces/activity.ts
+++ b/frontend/interfaces/activity.ts
@@ -126,6 +126,7 @@ export type IHostPastActivityType =
   | ActivityType.RanScript
   | ActivityType.LockedHost
   | ActivityType.WipedHost
+  | ActivityType.ReadHostDiskEncryptionKey
   | ActivityType.UnlockedHost
   | ActivityType.InstalledSoftware
   | ActivityType.UninstalledSoftware

--- a/frontend/pages/hosts/details/cards/Activity/ActivityConfig.tsx
+++ b/frontend/pages/hosts/details/cards/Activity/ActivityConfig.tsx
@@ -14,6 +14,7 @@ import RanScriptActivityItem from "./ActivityItems/RanScriptActivityItem";
 import LockedHostActivityItem from "./ActivityItems/LockedHostActivityItem";
 import WipedHostActivityItem from "./ActivityItems/WipedHostActivityItem";
 import UnlockedHostActivityItem from "./ActivityItems/UnlockedHostActivityItem";
+import ReadHostDiskEncryptionKeyActivityItem from "./ActivityItems/ReadHostDiskEncryptionKey";
 import InstalledSoftwareActivityItem from "./ActivityItems/InstalledSoftwareActivityItem";
 import CanceledRunScriptActivityItem from "./ActivityItems/CanceledRunScriptActivityItem";
 import CanceledInstallSoftwareActivityItem from "./ActivityItems/CanceledInstallSoftwareActivityItem";
@@ -48,6 +49,7 @@ export const pastActivityComponentMap: Record<
   [ActivityType.RanScript]: RanScriptActivityItem,
   [ActivityType.LockedHost]: LockedHostActivityItem,
   [ActivityType.WipedHost]: WipedHostActivityItem,
+  [ActivityType.ReadHostDiskEncryptionKey]: ReadHostDiskEncryptionKeyActivityItem,
   [ActivityType.UnlockedHost]: UnlockedHostActivityItem,
   [ActivityType.InstalledSoftware]: InstalledSoftwareActivityItem,
   [ActivityType.UninstalledSoftware]: InstalledSoftwareActivityItem,

--- a/frontend/pages/hosts/details/cards/Activity/ActivityItems/ReadHostDiskEncryptionKey/ReadHostDiskEncryptionKey.tests.tsx
+++ b/frontend/pages/hosts/details/cards/Activity/ActivityItems/ReadHostDiskEncryptionKey/ReadHostDiskEncryptionKey.tests.tsx
@@ -1,0 +1,41 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { createMockHostPastActivity } from "__mocks__/activityMock";
+
+import ReadHostDiskEncryptionKeyActivityItem from "./ReadHostDiskEncryptionKey";
+
+describe("ReadHostDiskEncryptionKeyActivityItem", () => {
+  it("renders the activity content", () => {
+    render(
+      <ReadHostDiskEncryptionKeyActivityItem
+        activity={createMockHostPastActivity({ actor_full_name: "Test User" })}
+        tab="past"
+      />
+    );
+
+    expect(screen.getByText("Test User")).toBeVisible();
+    expect(screen.getByText(/locked this host/i)).toBeVisible();
+  });
+
+  it("does not render the cancel icon", () => {
+    render(
+      <ReadHostDiskEncryptionKeyActivityItem
+        activity={createMockHostPastActivity({ actor_full_name: "Test User" })}
+        tab="past"
+      />
+    );
+
+    expect(screen.queryByTestId("close-icon")).not.toBeInTheDocument();
+  });
+
+  it("does not render the show details icon", () => {
+    render(
+      <ReadHostDiskEncryptionKeyActivityItem
+        activity={createMockHostPastActivity({ actor_full_name: "Test User" })}
+        tab="past"
+      />
+    );
+
+    expect(screen.queryByTestId("info-outline-icon")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/pages/hosts/details/cards/Activity/ActivityItems/ReadHostDiskEncryptionKey/ReadHostDiskEncryptionKey.tests.tsx
+++ b/frontend/pages/hosts/details/cards/Activity/ActivityItems/ReadHostDiskEncryptionKey/ReadHostDiskEncryptionKey.tests.tsx
@@ -14,7 +14,7 @@ describe("ReadHostDiskEncryptionKeyActivityItem", () => {
     );
 
     expect(screen.getByText("Test User")).toBeVisible();
-    expect(screen.getByText(/locked this host/i)).toBeVisible();
+    expect(screen.getByText(/viewed the disk encryption key/i)).toBeVisible();
   });
 
   it("does not render the cancel icon", () => {

--- a/frontend/pages/hosts/details/cards/Activity/ActivityItems/ReadHostDiskEncryptionKey/ReadHostDiskEncryptionKey.tsx
+++ b/frontend/pages/hosts/details/cards/Activity/ActivityItems/ReadHostDiskEncryptionKey/ReadHostDiskEncryptionKey.tsx
@@ -1,0 +1,25 @@
+import React from "react";
+
+import ActivityItem from "components/ActivityItem";
+
+import { IHostActivityItemComponentProps } from "../../ActivityConfig";
+
+const baseClass = "locked-host-activity-item";
+
+const ReadHostDiskEncryptionKeyActivityItem = ({
+  activity,
+}: IHostActivityItemComponentProps) => {
+  return (
+    <ActivityItem
+      className={baseClass}
+      activity={activity}
+      hideCancel
+      hideShowDetails
+    >
+      <b>{activity.actor_full_name} </b>
+      viewed the disk encryption key for this host.
+    </ActivityItem>
+  );
+};
+
+export default ReadHostDiskEncryptionKeyActivityItem;

--- a/frontend/pages/hosts/details/cards/Activity/ActivityItems/ReadHostDiskEncryptionKey/index.ts
+++ b/frontend/pages/hosts/details/cards/Activity/ActivityItems/ReadHostDiskEncryptionKey/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./ReadHostDiskEncryptionKey";

--- a/server/fleet/activities.go
+++ b/server/fleet/activities.go
@@ -1042,6 +1042,10 @@ func (a ActivityTypeReadHostDiskEncryptionKey) ActivityName() string {
 	return "read_host_disk_encryption_key"
 }
 
+func (a ActivityTypeReadHostDiskEncryptionKey) HostIDs() []uint {
+	return []uint{a.HostID}
+}
+
 func (a ActivityTypeReadHostDiskEncryptionKey) Documentation() (activity string, details string, detailsExample string) {
 	return `Generated when a user reads the disk encryption key for a host.`,
 		`This activity contains the following fields:

--- a/server/service/hosts_test.go
+++ b/server/service/hosts_test.go
@@ -1382,6 +1382,7 @@ func TestHostEncryptionKey(t *testing.T) {
 			) error {
 				act := activity.(fleet.ActivityTypeReadHostDiskEncryptionKey)
 				require.Equal(t, tt.host.ID, act.HostID)
+				require.Equal(t, []uint{tt.host.ID}, act.HostIDs())
 				require.EqualValues(t, act.HostDisplayName, tt.host.DisplayName())
 				return nil
 			}


### PR DESCRIPTION
#28521

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/Committing-Changes.md#changes-files) for more information.
- [x] Added/updated automated tests
- [x] Manual QA for all new/changed functionality
