### PR TITLE
Split .tar.gz extraction into installer and TUF implementations to remove permissions checks on installer implementation

### DIFF
--- a/orbit/pkg/installer/installer.go
+++ b/orbit/pkg/installer/installer.go
@@ -333,19 +333,7 @@ func (r *Runner) installSoftware(ctx context.Context, installID string, logger z
 
 		extractFn := r.extractTarGzFn
 		if extractFn == nil {
-			extractFn = func(path string, destDir string) error {
-				tarGzFile, err := os.Open(path)
-				if err != nil {
-					return fmt.Errorf("oepn file for extraction: %w", err)
-				}
-				defer tarGzFile.Close()
-
-				if err = update.ExtractOpenTarGzFile(tarGzFile, destDir); err != nil {
-					return fmt.Errorf("extract %q: %w", path, err)
-				}
-
-				return nil
-			}
+			extractFn = file.ExtractTarGz
 		}
 
 		if err = extractFn(installerPath, extractDestination); err != nil {

--- a/orbit/pkg/installer/installer.go
+++ b/orbit/pkg/installer/installer.go
@@ -333,7 +333,9 @@ func (r *Runner) installSoftware(ctx context.Context, installID string, logger z
 
 		extractFn := r.extractTarGzFn
 		if extractFn == nil {
-			extractFn = file.ExtractTarGz
+			extractFn = func(path string, destDir string) error {
+				return file.ExtractTarGz(path, destDir, 2*1024*1024*1024*1024) // 2 TiB limit per extracted file
+			}
 		}
 
 		if err = extractFn(installerPath, extractDestination); err != nil {

--- a/orbit/pkg/update/update.go
+++ b/orbit/pkg/update/update.go
@@ -681,7 +681,7 @@ func (u *Updater) checkExec(target, tmpPath string, customCheckExec func(execPat
 	return nil
 }
 
-// extractTarGz extracts the contents of the provided tar.gz file.
+// extractTagGz extracts the contents of the provided tar.gz file.
 func extractTarGz(path string) error {
 	tarGzFile, err := secure.OpenFile(path, os.O_RDONLY, 0o755)
 	if err != nil {
@@ -689,17 +689,9 @@ func extractTarGz(path string) error {
 	}
 	defer tarGzFile.Close()
 
-	if err = ExtractOpenTarGzFile(tarGzFile, filepath.Dir(path)); err != nil {
-		return fmt.Errorf("extract %q: %w", path, err)
-	}
-
-	return nil
-}
-
-func ExtractOpenTarGzFile(tarGzFile *os.File, destDir string) error {
 	gzipReader, err := gzip.NewReader(tarGzFile)
 	if err != nil {
-		return fmt.Errorf("gzip reader: %w", err)
+		return fmt.Errorf("gzip reader %q: %w", path, err)
 	}
 	defer gzipReader.Close()
 
@@ -712,7 +704,7 @@ func ExtractOpenTarGzFile(tarGzFile *os.File, destDir string) error {
 		case errors.Is(err, io.EOF):
 			return nil
 		default:
-			return fmt.Errorf("tar reader: %w", err)
+			return fmt.Errorf("tar reader %q: %w", path, err)
 		}
 
 		// Prevent zip-slip attack.
@@ -720,7 +712,7 @@ func ExtractOpenTarGzFile(tarGzFile *os.File, destDir string) error {
 			return fmt.Errorf("invalid path in tar.gz: %q", header.Name)
 		}
 
-		targetPath := filepath.Join(destDir, header.Name)
+		targetPath := filepath.Join(filepath.Dir(path), header.Name)
 
 		switch header.Typeflag {
 		case tar.TypeDir:

--- a/pkg/file/file.go
+++ b/pkg/file/file.go
@@ -267,6 +267,7 @@ func ExtractTarGz(path string, destDir string, maxFileSize int64) error {
 						}
 						return fmt.Errorf("failed to extract file %q inside %q: %w", header.Name, path, err)
 					}
+					readBytes += chunkSize
 				}
 
 				return nil


### PR DESCRIPTION
For #26692 (fixes permission issue when extracting dirs).

Reverts changes to `update.go` to remove TUF test surface.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [x] A detailed QA plan exists on the associated ticket (if it isn't there, work with the product group's QA engineer to add it)
- [x] Manual QA for all new/changed functionality
- For Orbit and Fleet Desktop changes:
   - [ ] Make sure fleetd is compatible with the latest released version of Fleet (see [Must rule](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/fleetd-development-and-release-strategy.md)).
   - [ ] Orbit runs on macOS, Linux and Windows. Check if the orbit feature/bugfix should only apply to one platform (`runtime.GOOS`).
   - [ ] Manual QA must be performed in the three main OSs, macOS, Windows and Linux.
   - [ ] Auto-update manual QA, from released version of component to new version (see [tools/tuf/test](../tools/tuf/test/README.md)).