### PR TITLE
API, Environment variable for bespoke functionality for customer-preston

### DIFF
--- a/server/config/config.go
+++ b/server/config/config.go
@@ -622,6 +622,7 @@ type FleetConfig struct {
 
 type PartnershipsConfig struct {
 	EnableSecureframe bool `yaml:"enable_secureframe"`
+	EnablePrimo       bool `yaml:"enable_primo"`
 }
 
 type MDMConfig struct {
@@ -1169,6 +1170,7 @@ func (man Manager) addConfigs() {
 
 	// Email
 	man.addConfigString("email.backend", "", "Provide the email backend type, acceptable values are currently \"ses\" and \"default\" or empty string which will default to SMTP")
+
 	// SES
 	man.addConfigString("ses.region", "", "AWS Region to use")
 	man.addConfigString("ses.endpoint_url", "", "AWS Service Endpoint to use (leave empty for default service endpoints)")
@@ -1412,6 +1414,7 @@ func (man Manager) addConfigs() {
 
 	// Partnerships
 	man.addConfigBool("partnerships.enable_secureframe", false, "Point transparency URL at Secureframe landing page")
+	man.addConfigBool("partnerships.enable_primo", false, "Disable teams for Primo")
 }
 
 func (man Manager) hideConfig(name string) {
@@ -1692,6 +1695,7 @@ func (man Manager) LoadConfig() FleetConfig {
 		},
 		Partnerships: PartnershipsConfig{
 			EnableSecureframe: man.getConfigBool("partnerships.enable_secureframe"),
+			EnablePrimo:       man.getConfigBool("partnerships.enable_primo"),
 		},
 	}
 

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -1414,7 +1414,7 @@ func (man Manager) addConfigs() {
 
 	// Partnerships
 	man.addConfigBool("partnerships.enable_secureframe", false, "Point transparency URL at Secureframe landing page")
-	man.addConfigBool("partnerships.enable_primo", false, "Disable teams for Primo")
+	man.addConfigBool("partnerships.enable_primo", false, "Cosmetically disables team capabilities in the UI")
 }
 
 func (man Manager) hideConfig(name string) {

--- a/server/fleet/app.go
+++ b/server/fleet/app.go
@@ -1319,6 +1319,11 @@ const (
 	TierTrial = "trial"
 )
 
+// Partnerships contains specialized configuration options for Fleet partners.
+type Partnerships struct {
+	EnablePrimo bool `json:"enable_primo,omitempty"`
+}
+
 // LicenseInfo contains information about the Fleet license.
 type LicenseInfo struct {
 	// Tier is the license tier (currently "free" or "premium")

--- a/server/fleet/service.go
+++ b/server/fleet/service.go
@@ -473,6 +473,9 @@ type Service interface {
 	// License returns the licensing information.
 	License(ctx context.Context) (*LicenseInfo, error)
 
+	// PartnershipsConfig returns Fleet partnership-specific configuration
+	PartnershipsConfig(ctx context.Context) (*Partnerships, error)
+
 	// LoggingConfig parses config.FleetConfig instance and returns a Logging.
 	LoggingConfig(ctx context.Context) (*Logging, error)
 

--- a/server/service/appconfig.go
+++ b/server/service/appconfig.go
@@ -52,9 +52,11 @@ type appConfigResponseFields struct {
 	// Email is returned when the email backend is something other than SMTP, for example SES
 	Email *fleet.EmailConfig `json:"email,omitempty"`
 	// SandboxEnabled is true if fleet serve was ran with server.sandbox_enabled=true
-	SandboxEnabled bool  `json:"sandbox_enabled,omitempty"`
-	Err            error `json:"error,omitempty"`
-	AndroidEnabled bool  `json:"android_enabled,omitempty"`
+	SandboxEnabled bool                `json:"sandbox_enabled,omitempty"`
+	Err            error               `json:"error,omitempty"`
+	AndroidEnabled bool                `json:"android_enabled,omitempty"`
+	Partnerships   *fleet.Partnerships `json:"partnerships,omitempty"`
+	// Partnerships   *fleet.Partnerships `json:"partnerships,omitempty"`
 }
 
 // UnmarshalJSON implements the json.Unmarshaler interface to make sure we serialize
@@ -130,6 +132,10 @@ func getAppConfigEndpoint(ctx context.Context, request interface{}, svc fleet.Se
 	if err != nil {
 		return nil, err
 	}
+	partnerships, err := svc.PartnershipsConfig(ctx)
+	if err != nil {
+		return nil, err
+	}
 
 	isGlobalAdmin := vc.User.GlobalRole != nil && *vc.User.GlobalRole == fleet.RoleAdmin
 	isAnyTeamAdmin := false
@@ -198,6 +204,7 @@ func getAppConfigEndpoint(ctx context.Context, request interface{}, svc fleet.Se
 			Email:           emailConfig,
 			SandboxEnabled:  svc.SandboxEnabled(),
 			AndroidEnabled:  os.Getenv("FLEET_DEV_ANDROID_ENABLED") == "1", // Temporary feature flag that will be removed.
+			Partnerships:    partnerships,
 		},
 	}
 	return response, nil

--- a/server/service/appconfig.go
+++ b/server/service/appconfig.go
@@ -56,7 +56,6 @@ type appConfigResponseFields struct {
 	Err            error               `json:"error,omitempty"`
 	AndroidEnabled bool                `json:"android_enabled,omitempty"`
 	Partnerships   *fleet.Partnerships `json:"partnerships,omitempty"`
-	// Partnerships   *fleet.Partnerships `json:"partnerships,omitempty"`
 }
 
 // UnmarshalJSON implements the json.Unmarshaler interface to make sure we serialize

--- a/server/service/service_appconfig.go
+++ b/server/service/service_appconfig.go
@@ -243,3 +243,17 @@ func (svc *Service) EmailConfig(ctx context.Context) (*fleet.EmailConfig, error)
 
 	return email, nil
 }
+
+func (svc *Service) PartnershipsConfig(ctx context.Context) (*fleet.Partnerships, error) {
+	if err := svc.authz.Authorize(ctx, &fleet.AppConfig{}, fleet.ActionRead); err != nil {
+		return nil, err
+	}
+	enablePrimo := svc.config.Partnerships.EnablePrimo
+	if !enablePrimo {
+		// for now, since this is the only partnership of this type, exclude the whole struct if not enabled
+		return nil, nil
+	}
+	return &fleet.Partnerships{
+		EnablePrimo: svc.config.Partnerships.EnablePrimo,
+	}, nil
+}


### PR DESCRIPTION
## For #28221

- Add support for env var / flag
- surface as `config.partnerships.enable_primo` if `true`, omit from response otherwise

### when `FLEET_PARTNERSHIPS_ENABLE_PRIMO=true`:
![Screenshot 2025-05-06 at 6 14 01 PM](https://github.com/user-attachments/assets/f7a0c705-37e7-4491-ad8b-492f456ca924)

### when `FLEET_PARTNERSHIPS_ENABLE_PRIMO=false` or not set:
![Screenshot 2025-05-06 at 6 13 57 PM](https://github.com/user-attachments/assets/e8a88b15-43ef-4d56-ab6c-3fbe832b6ddd)


~Changes file added for user-visible changes in `changes/`~ in companion frontend PR
- [x] A detailed QA plan exists on the associated ticket (if it isn't there, work with the product group's QA engineer to add it)
- [x] Manual QA for all new/changed functionality