### PR TITLE
Split .tar.gz extraction into installer and TUF implementations to remove permissions checks on installer implementation

### DIFF
--- a/orbit/pkg/installer/installer.go
+++ b/orbit/pkg/installer/installer.go
@@ -334,17 +334,7 @@ func (r *Runner) installSoftware(ctx context.Context, installID string, logger z
 		extractFn := r.extractTarGzFn
 		if extractFn == nil {
 			extractFn = func(path string, destDir string) error {
-				tarGzFile, err := os.Open(path)
-				if err != nil {
-					return fmt.Errorf("oepn file for extraction: %w", err)
-				}
-				defer tarGzFile.Close()
-
-				if err = update.ExtractOpenTarGzFile(tarGzFile, destDir); err != nil {
-					return fmt.Errorf("extract %q: %w", path, err)
-				}
-
-				return nil
+				return file.ExtractTarGz(path, destDir, 2*1024*1024*1024*1024) // 2 TiB limit per extracted file
 			}
 		}
 

--- a/orbit/pkg/update/update.go
+++ b/orbit/pkg/update/update.go
@@ -681,7 +681,7 @@ func (u *Updater) checkExec(target, tmpPath string, customCheckExec func(execPat
 	return nil
 }
 
-// extractTarGz extracts the contents of the provided tar.gz file.
+// extractTagGz extracts the contents of the provided tar.gz file.
 func extractTarGz(path string) error {
 	tarGzFile, err := secure.OpenFile(path, os.O_RDONLY, 0o755)
 	if err != nil {
@@ -689,17 +689,9 @@ func extractTarGz(path string) error {
 	}
 	defer tarGzFile.Close()
 
-	if err = ExtractOpenTarGzFile(tarGzFile, filepath.Dir(path)); err != nil {
-		return fmt.Errorf("extract %q: %w", path, err)
-	}
-
-	return nil
-}
-
-func ExtractOpenTarGzFile(tarGzFile *os.File, destDir string) error {
 	gzipReader, err := gzip.NewReader(tarGzFile)
 	if err != nil {
-		return fmt.Errorf("gzip reader: %w", err)
+		return fmt.Errorf("gzip reader %q: %w", path, err)
 	}
 	defer gzipReader.Close()
 
@@ -712,7 +704,7 @@ func ExtractOpenTarGzFile(tarGzFile *os.File, destDir string) error {
 		case errors.Is(err, io.EOF):
 			return nil
 		default:
-			return fmt.Errorf("tar reader: %w", err)
+			return fmt.Errorf("tar reader %q: %w", path, err)
 		}
 
 		// Prevent zip-slip attack.
@@ -720,7 +712,7 @@ func ExtractOpenTarGzFile(tarGzFile *os.File, destDir string) error {
 			return fmt.Errorf("invalid path in tar.gz: %q", header.Name)
 		}
 
-		targetPath := filepath.Join(destDir, header.Name)
+		targetPath := filepath.Join(filepath.Dir(path), header.Name)
 
 		switch header.Typeflag {
 		case tar.TypeDir:


### PR DESCRIPTION
Merged into `main` in #28888. Cherry-picking to ensure building from RC doesn't have issues, though we'll be building `fleetd` from `main`.