### PR TITLE
fix issue with gitops not removing custom profiles when they were removed from default.yml file 

### DIFF
--- a/cmd/fleetctl/integrationtest/gitops/gitops_enterprise_integration_test.go
+++ b/cmd/fleetctl/integrationtest/gitops/gitops_enterprise_integration_test.go
@@ -929,13 +929,6 @@ func (s *enterpriseIntegrationGitopsTestSuite) TestRemoveCustomSettingsFromDefau
 	err = profileFile.Close()
 	require.NoError(t, err)
 
-	contents, err := os.ReadFile(profileFile.Name())
-	if err != nil {
-		fmt.Println("Error reading profile file:", err)
-	} else {
-		fmt.Println("Profile contents:\n", string(contents))
-	}
-
 	// global file setup with custom settings
 	const (
 		globalTemplateWithCustomSettings = `

--- a/cmd/fleetctl/integrationtest/gitops/gitops_enterprise_integration_test.go
+++ b/cmd/fleetctl/integrationtest/gitops/gitops_enterprise_integration_test.go
@@ -919,7 +919,7 @@ func (s *enterpriseIntegrationGitopsTestSuite) TestRemoveCustomSettingsFromDefau
 	fleetctlConfig := s.createFleetctlConfig(t, user)
 
 	// Set the required environment variables
-	t.Setenv("FLEET_URL", s.server.URL)
+	t.Setenv("FLEET_URL", s.Server.URL)
 
 	// setup custom settings profile
 	profileFile, err := os.CreateTemp(t.TempDir(), "*.mobileconfig")
@@ -955,10 +955,10 @@ queries:
 	err = globalFile.Close()
 	require.NoError(t, err)
 
-	_ = runAppForTest(t, []string{"gitops", "--config", fleetctlConfig.Name(), "-f", globalFile.Name(), "--dry-run"})
-	_ = runAppForTest(t, []string{"gitops", "--config", fleetctlConfig.Name(), "-f", globalFile.Name()})
+	_ = fleetctl.RunAppForTest(t, []string{"gitops", "--config", fleetctlConfig.Name(), "-f", globalFile.Name(), "--dry-run"})
+	_ = fleetctl.RunAppForTest(t, []string{"gitops", "--config", fleetctlConfig.Name(), "-f", globalFile.Name()})
 
-	profiles, err := s.ds.ListMDMAppleConfigProfiles(ctx, nil)
+	profiles, err := s.DS.ListMDMAppleConfigProfiles(ctx, nil)
 	require.NoError(t, err)
 	require.Equal(t, 1, len(profiles))
 
@@ -985,11 +985,11 @@ queries:
 	err = globalFile.Close()
 	require.NoError(t, err)
 
-	_ = runAppForTest(t, []string{"gitops", "--config", fleetctlConfig.Name(), "-f", globalFile.Name(), "--dry-run"})
-	_ = runAppForTest(t, []string{"gitops", "--config", fleetctlConfig.Name(), "-f", globalFile.Name()})
+	_ = fleetctl.RunAppForTest(t, []string{"gitops", "--config", fleetctlConfig.Name(), "-f", globalFile.Name(), "--dry-run"})
+	_ = fleetctl.RunAppForTest(t, []string{"gitops", "--config", fleetctlConfig.Name(), "-f", globalFile.Name()})
 
 	// Check profile does not exist
-	profiles, err = s.ds.ListMDMAppleConfigProfiles(ctx, nil)
+	profiles, err = s.DS.ListMDMAppleConfigProfiles(ctx, nil)
 	require.NoError(t, err)
 	require.Equal(t, 0, len(profiles))
 }

--- a/server/service/client.go
+++ b/server/service/client.go
@@ -565,6 +565,15 @@ func (c *Client) ApplyGroup(
 			logfn("[+] applied fleet config\n")
 		}
 
+		if viaGitOps && (windowsCustomSettings == nil || macosCustomSettings == nil) {
+			if windowsCustomSettings == nil {
+				windowsCustomSettings = []fleet.MDMProfileSpec{}
+			}
+			if macosCustomSettings == nil {
+				macosCustomSettings = []fleet.MDMProfileSpec{}
+			}
+		}
+
 		// We apply profiles after the main AppConfig org_settings because profiles may
 		// contain Fleet variables that are set in org_settings, such as $FLEET_VAR_DIGICERT_PASSWORD_My_CA
 		//

--- a/server/service/client.go
+++ b/server/service/client.go
@@ -565,15 +565,6 @@ func (c *Client) ApplyGroup(
 			logfn("[+] applied fleet config\n")
 		}
 
-		if viaGitOps && (windowsCustomSettings == nil || macosCustomSettings == nil) {
-			if windowsCustomSettings == nil {
-				windowsCustomSettings = []fleet.MDMProfileSpec{}
-			}
-			if macosCustomSettings == nil {
-				macosCustomSettings = []fleet.MDMProfileSpec{}
-			}
-		}
-
 		// We apply profiles after the main AppConfig org_settings because profiles may
 		// contain Fleet variables that are set in org_settings, such as $FLEET_VAR_DIGICERT_PASSWORD_My_CA
 		//
@@ -1861,7 +1852,9 @@ func (c *Client) DoGitOps(
 		if config.Controls.MacOSSettings != nil {
 			mdmAppConfig["macos_settings"] = config.Controls.MacOSSettings
 		} else {
-			mdmAppConfig["macos_settings"] = fleet.MacOSSettings{}
+			mdmAppConfig["macos_settings"] = fleet.MacOSSettings{
+				CustomSettings: []fleet.MDMProfileSpec{},
+			}
 		}
 		// Put in default values for macos_updates
 		if config.Controls.MacOSUpdates != nil {
@@ -1913,7 +1906,9 @@ func (c *Client) DoGitOps(
 		if config.Controls.WindowsSettings != nil {
 			mdmAppConfig["windows_settings"] = config.Controls.WindowsSettings
 		} else {
-			mdmAppConfig["windows_settings"] = fleet.WindowsSettings{}
+			mdmAppConfig["windows_settings"] = fleet.WindowsSettings{
+				CustomSettings: optjson.Slice[fleet.MDMProfileSpec]{Value: []fleet.MDMProfileSpec{}},
+			}
 		}
 		// Put in default values for windows_updates
 		if config.Controls.WindowsUpdates != nil {


### PR DESCRIPTION
For [#27249](https://github.com/fleetdm/fleet/issues/27249)

fix issue where we custom profiles were not removed when they were removed from default.yml  and running gitops.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
- [x] Added/updated automated tests
- [x] Manual QA for all new/changed functionality