### PR TITLE
Add learn more links for Custom SCEP profile errors

### DIFF
--- a/frontend/pages/ManageControlsPage/OSSettings/cards/CustomSettings/components/ProfileUploader/helpers.tsx
+++ b/frontend/pages/ManageControlsPage/OSSettings/cards/CustomSettings/components/ProfileUploader/helpers.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { AxiosResponse } from "axios";
 import { IApiError } from "interfaces/errors";
 import { generateSecretErrMsg } from "pages/SoftwarePage/helpers";
+import CustomLink from "components/CustomLink";
 
 export const parseFile = async (file: File): Promise<[string, string]> => {
   // get the file name and extension
@@ -34,6 +35,34 @@ const generateUnsupportedVariableErrMsg = (errMsg: string) => {
   return varName
     ? `Couldn't add. Variable "${varName[0]}" doesn't exist.`
     : DEFAULT_ERROR_MESSAGE;
+};
+
+const generateCAVarsErrMsg = (errMsg: string) => {
+  return (
+    <>
+      Couldn&apos;t add. {errMsg}{" "}
+      <CustomLink
+        url="https://fleetdm.com/learn-more-about/certificate-authorities"
+        text="Learn more"
+        variant="flash-message-link"
+        newTab
+      />
+    </>
+  );
+};
+
+const generateCustomSCEPProfileErrMsg = (errMsg: string) => {
+  return (
+    <span>
+      Couldn&apos;t add. {errMsg}{" "}
+      <CustomLink
+        url="https://fleetdm.com/learn-more-about/custom-scep-configuration-profile"
+        text="Learn more"
+        variant="flash-message-link"
+        newTab
+      />
+    </span>
+  );
 };
 
 /** We want to add some additional messageing to some of the error messages so
@@ -93,6 +122,22 @@ export const getErrorMessage = (err: AxiosResponse<IApiError>) => {
     apiReason.includes("not supported in configuration profiles")
   ) {
     return generateUnsupportedVariableErrMsg(apiReason);
+  }
+
+  if (
+    apiReason.includes(
+      "can't be used if variables for SCEP URL and Challenge are not specified"
+    )
+  ) {
+    return generateCAVarsErrMsg(apiReason);
+  }
+
+  if (
+    apiReason.includes(
+      "SCEP profile for custom SCEP certificate authority requires"
+    )
+  ) {
+    return generateCustomSCEPProfileErrMsg(apiReason);
   }
 
   return `Couldn't add. ${apiReason}` || DEFAULT_ERROR_MESSAGE;


### PR DESCRIPTION
For #28870 

Adds the proper "learn more" links to these errors as shown in the Custom SCEP renewal Figma https://www.figma.com/design/R4HhMXjwTjRelmq3V6n8aS/-27984-Renew-certificates-from-custom-SCEP-certificate-authority-on-macOS?node-id=7304-92:
![Screenshot 2025-05-07 at 9 50 59 AM](https://github.com/user-attachments/assets/f11fb064-0fab-42ad-b8b0-c28705eda921)
![Screenshot 2025-05-07 at 9 51 16 AM](https://github.com/user-attachments/assets/c8822e03-71f7-4fb1-b323-02422f8497b2)


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] A detailed QA plan exists on the associated ticket (if it isn't there, work with the product group's QA engineer to add it)
- [x] Manual QA for all new/changed functionality
- [x] For unreleased bug fixes in a release candidate, confirmed that the fix is not expected to adversely impact load test results or alerted the release DRI if additional load testing is needed.
