### PR TITLE
Fleet desktop: Self-service stale time causing previous searches not to recall API

### DIFF
--- a/frontend/pages/hosts/details/cards/Software/SelfService/SelfService.tsx
+++ b/frontend/pages/hosts/details/cards/Software/SelfService/SelfService.tsx
@@ -98,6 +98,7 @@ const SoftwareSelfService = ({
     ];
   }, [deviceToken, queryParams.page, queryParams.query]);
 
+  console.log("queryKey", queryKey);
   // Fetch self-service software (regular API call)
   const { isLoading, isError, isFetching } = useQuery<
     IGetDeviceSoftwareResponse,
@@ -108,7 +109,6 @@ const SoftwareSelfService = ({
     ...DEFAULT_USE_QUERY_OPTIONS,
     enabled: isSoftwareEnabled,
     keepPreviousData: true,
-    staleTime: 7000,
     onSuccess: (response) => {
       setSelfServiceData(response);
     },

--- a/frontend/pages/hosts/details/cards/Software/SelfService/SelfService.tsx
+++ b/frontend/pages/hosts/details/cards/Software/SelfService/SelfService.tsx
@@ -98,7 +98,6 @@ const SoftwareSelfService = ({
     ];
   }, [deviceToken, queryParams.page, queryParams.query]);
 
-  console.log("queryKey", queryKey);
   // Fetch self-service software (regular API call)
   const { isLoading, isError, isFetching } = useQuery<
     IGetDeviceSoftwareResponse,


### PR DESCRIPTION
## Issue
For #28137 
Unreleased bug found by @jahzielv 

## Description
- Removed `staleTime` from React Query options for software search.
- Bug Fix: Previously, searching for "braa" (no results) and then backspacing to "bra" (should show "Brave" installer) within 7 seconds would not trigger a new API call. This was due to React Query's `staleTime` caching, which prevented fetching fresh results for recently used queries.
- Resolution: By removing `staleTime`, every search now triggers an API call, ensuring the search results update immediately and accurately as the user modifies their query.


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->


- [x] A detailed QA plan exists on the associated ticket (if it isn't there, work with the product group's QA engineer to add it)
- [x] Manual QA for all new/changed functionality
