### PR TITLE
Amend VEX to support both docker scout and trivy (#28899)

### DIFF
--- a/security/vex/fleet/CVE-2025-46569.vex.json
+++ b/security/vex/fleet/CVE-2025-46569.vex.json
@@ -15,6 +15,9 @@
           "@id": "fleet"
         },
         {
+          "@id": "pkg:golang/github.com/open-policy-agent/opa@v0.44.0"
+        },
+        {
           "@id": "pkg:golang/github.com/open-policy-agent/opa@0.44.0"
         }
       ],


### PR DESCRIPTION
For #28837.