### PR TITLE
Fleet UI: Fix unreleased VPP icon bug in self-service

### DIFF
--- a/frontend/components/TableContainer/DataTable/SoftwareNameCell/SoftwareNameCell.tsx
+++ b/frontend/components/TableContainer/DataTable/SoftwareNameCell/SoftwareNameCell.tsx
@@ -114,6 +114,7 @@ interface ISoftwareNameCellProps {
   hasPackage?: boolean;
   isSelfService?: boolean;
   installType?: "manual" | "automatic";
+  /** e.g. app_store_app's override default icons with URLs */
   iconUrl?: string;
   automaticInstallPoliciesCount?: number;
 }

--- a/frontend/pages/hosts/details/cards/Software/SelfService/SelfServiceTableConfig.tsx
+++ b/frontend/pages/hosts/details/cards/Software/SelfService/SelfServiceTableConfig.tsx
@@ -273,11 +273,12 @@ export const generateSoftwareTableHeaders = ({
       disableSortBy: false,
       disableGlobalFilter: false,
       Cell: (cellProps: ITableStringCellProps) => {
-        const { name, source } = cellProps.row.original;
+        const { name, source, app_store_app } = cellProps.row.original;
         return (
           <SoftwareNameCell
             name={name}
             source={source}
+            iconUrl={app_store_app?.icon_url}
             myDevicePage
             isSelfService
           />


### PR DESCRIPTION
## Issue
For #28876 

## Description
- Accidentally didn't pass vpp app `icon_url` to `<SoftwareNameCell/>` `iconUrl` to override default icon for VPP apps


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->


- [x] A detailed QA plan exists on the associated ticket (if it isn't there, work with the product group's QA engineer to add it)
- [x] Manual QA for all new/changed functionality
