### PR TITLE
28434 Setup experience reliability

### DIFF
--- a/orbit/changes/28434-setup-experience-reliability
+++ b/orbit/changes/28434-setup-experience-reliability
@@ -1,0 +1,1 @@
+* Made the Setup Experience dialog more reliable by preventing system sleep while it is shown, changing the key combo to cmd+shift+x to exit, keeping it ion top of all other windows and making sure it closes once it completes

--- a/orbit/changes/28434-setup-experience-reliability
+++ b/orbit/changes/28434-setup-experience-reliability
@@ -1,1 +1,1 @@
-* Made the Setup Experience dialog more reliable by preventing system sleep while it is shown, changing the key combo to cmd+shift+x to exit, keeping it ion top of all other windows and making sure it closes once it completes
+* Made the macOS Setup Experience dialog more reliable by preventing system sleep while it is shown, changing the key combo to cmd+shift+x to exit, keeping it ion top of all other windows and making sure it closes once it completes

--- a/orbit/changes/28434-setup-experience-reliability
+++ b/orbit/changes/28434-setup-experience-reliability
@@ -1,1 +1,1 @@
-* Made the macOS Setup Experience dialog more reliable by preventing system sleep while it is shown, changing the key combo to cmd+shift+x to exit, keeping it ion top of all other windows and making sure it closes once it completes
+* Made the macOS Setup Experience dialog more reliable by preventing system sleep while it is shown, changing the key combo to cmd+shift+x to exit, keeping it on top of all other windows and making sure it closes once it completes

--- a/orbit/pkg/setup_experience/setup_experience.go
+++ b/orbit/pkg/setup_experience/setup_experience.go
@@ -270,7 +270,7 @@ func (s *SetupExperiencer) startSwiftDialog(binaryPath, orgLogo string) error {
 			Button1Disabled:  true,
 			BlurScreen:       true,
 			OnTop:            true,
-			QuitKey:          "x",
+			QuitKey:          "X", // Capital X to require command+shift+x
 		}
 
 		if err := s.sd.Start(context.Background(), initOpts, true); err != nil {

--- a/orbit/pkg/setup_experience/setup_experience.go
+++ b/orbit/pkg/setup_experience/setup_experience.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/fleetdm/fleet/v4/orbit/pkg/swiftdialog"
 	"github.com/fleetdm/fleet/v4/orbit/pkg/update"
@@ -206,6 +207,10 @@ func (s *SetupExperiencer) Run(oc *fleet.OrbitConfig) error {
 		if err := s.sd.EnableButton1(true); err != nil {
 			log.Info().Err(err).Msg("enabling close button in setup experience UI")
 		}
+
+		// Sleep for a few seconds to let the user see the done message before closing
+		// the UI
+		time.Sleep(3 * time.Second)
 
 		if err := s.sd.Quit(); err != nil {
 			log.Info().Err(err).Msg("quitting setup experience UI on completion")

--- a/orbit/pkg/setup_experience/setup_experience.go
+++ b/orbit/pkg/setup_experience/setup_experience.go
@@ -206,6 +206,10 @@ func (s *SetupExperiencer) Run(oc *fleet.OrbitConfig) error {
 		if err := s.sd.EnableButton1(true); err != nil {
 			log.Info().Err(err).Msg("enabling close button in setup experience UI")
 		}
+
+		if err := s.sd.Quit(); err != nil {
+			log.Info().Err(err).Msg("quitting setup experience UI on completion")
+		}
 	}
 
 	return nil
@@ -264,9 +268,12 @@ func (s *SetupExperiencer) startSwiftDialog(binaryPath, orgLogo string) error {
 			ProgressText:     "Configuring your device...",
 			Button1Text:      "Close",
 			Button1Disabled:  true,
+			BlurScreen:       true,
+			OnTop:            true,
+			QuitKey:          "x",
 		}
 
-		if err := s.sd.Start(context.Background(), initOpts); err != nil {
+		if err := s.sd.Start(context.Background(), initOpts, true); err != nil {
 			log.Error().Err(err).Msg("starting swiftDialog instance")
 		}
 

--- a/orbit/pkg/swiftdialog/run.go
+++ b/orbit/pkg/swiftdialog/run.go
@@ -110,11 +110,12 @@ func (s *SwiftDialog) Start(ctx context.Context, opts *SwiftDialogOptions, caffe
 	}
 
 	if caffeinate {
-		// This will stop the display and system from sleeping and mark the user as active, and
+		// This will stop the display, disk system from sleeping and mark the user as active, and
 		// will wait for the swiftDialog process to exit before exiting and allowing the system to
 		// resume normal sleep/idle behavior. Note that the actual system sleep can only be
 		// completely blocked while on AC power(per the manpage) so this solution is not perfect.
-		caffeinateCmd := exec.CommandContext(ctx, "caffeinate", "-dimsu", "-w", fmt.Sprintf("%d", cmd.Process.Pid))
+		// nb: Disabling gosec warning about tainted arguments below because we know the PID is OK
+		caffeinateCmd := exec.CommandContext(ctx, "caffeinate", "-dimsu", "-w", fmt.Sprintf("%d", cmd.Process.Pid)) //nolint:gosec
 		caffeinateCmd.Stdout = nil
 		caffeinateCmd.Stderr = nil
 		caffeinateCmd.Stdin = nil

--- a/orbit/pkg/swiftdialog/run.go
+++ b/orbit/pkg/swiftdialog/run.go
@@ -115,7 +115,7 @@ func (s *SwiftDialog) Start(ctx context.Context, opts *SwiftDialogOptions, caffe
 		// resume normal sleep/idle behavior. Note that the actual system sleep can only be
 		// completely blocked while on AC power(per the manpage) so this solution is not perfect.
 		// nb: Disabling gosec warning about tainted arguments below because we know the PID is OK
-		caffeinateCmd := exec.CommandContext(ctx, "caffeinate", "-dimsu", "-w", fmt.Sprintf("%d", cmd.Process.Pid)) //nolint:gosec
+		caffeinateCmd := exec.CommandContext(ctx, "/usr/bin/caffeinate", "-dimsu", "-w", fmt.Sprintf("%d", cmd.Process.Pid)) //nolint:gosec
 		caffeinateCmd.Stdout = nil
 		caffeinateCmd.Stderr = nil
 		caffeinateCmd.Stdin = nil

--- a/orbit/pkg/update/escrow_buddy.go
+++ b/orbit/pkg/update/escrow_buddy.go
@@ -59,6 +59,11 @@ func (e *EscrowBuddyRunner) Run(cfg *fleet.OrbitConfig) error {
 		return nil
 	}
 
+	if cfg.Notifications.RunSetupExperience {
+		log.Debug().Msg("EscrowBuddyRunner: skipping any actions related to disk encryption, setup experience is running")
+		return nil
+	}
+
 	// For #25928 we are going to always install escrowBuddy as a target
 	updaterHasTarget := e.updateRunner.HasRunnerOptTarget("escrowBuddy")
 	runnerHasLocalHash := e.updateRunner.HasLocalHash("escrowBuddy")


### PR DESCRIPTION
For  #28434 

This ticket is largely changing the options we invoke Swift Dialog with so that it is more reliable. The only small divergence from the ticket is that the command to exit was changed to command+shift+x due to limitations in Swift Dialog(no way to require control + key)

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/Committing-Changes.md#changes-files) for more information.
- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [x] A detailed QA plan exists on the associated ticket (if it isn't there, work with the product group's QA engineer to add it)
- [x] Manual QA for all new/changed functionality
- For Orbit and Fleet Desktop changes:
   - [x] Make sure fleetd is compatible with the latest released version of Fleet (see [Must rule](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/fleetd-development-and-release-strategy.md)).
   - [x] Orbit runs on macOS, Linux and Windows. Check if the orbit feature/bugfix should only apply to one platform (`runtime.GOOS`).
   - [x] Manual QA must be performed in the three main OSs, macOS, Windows and Linux.
   - [x] Auto-update manual QA, from released version of component to new version (see [tools/tuf/test](../tools/tuf/test/README.md)).