### PR TITLE
Fleet UI: Fix unreleased app store app timestamp broken

### DIFF
--- a/frontend/interfaces/software.ts
+++ b/frontend/interfaces/software.ts
@@ -365,7 +365,7 @@ export interface ISoftwareInstallVersion {
 export interface IHostSoftwarePackage {
   name: string;
   self_service: boolean;
-  icon_url: string;
+  icon_url: string | null;
   version: string;
   last_install: ISoftwareLastInstall | null;
   categories?: SoftwareCategory[];

--- a/frontend/pages/hosts/details/cards/Software/SelfService/SelfServiceTableConfig.tsx
+++ b/frontend/pages/hosts/details/cards/Software/SelfService/SelfServiceTableConfig.tsx
@@ -45,8 +45,11 @@ const STATUS_CONFIG: Record<
   installed: {
     iconName: "success",
     displayText: "Installed",
-    tooltip: ({ lastInstalledAt = "" }) =>
-      `Software is installed (${dateAgo(lastInstalledAt as string)}).`,
+    tooltip: ({ lastInstalledAt = null }) => {
+      return `Software is installed${
+        lastInstalledAt ? ` (${dateAgo(lastInstalledAt)})` : ""
+      }.`;
+    },
   },
   pending_install: {
     iconName: "pending-outline",
@@ -56,7 +59,7 @@ const STATUS_CONFIG: Record<
   failed_install: {
     iconName: "error",
     displayText: "Failed",
-    tooltip: ({ lastInstalledAt = "" }) => (
+    tooltip: ({ lastInstalledAt = null }) => (
       <>
         Software failed to install
         {lastInstalledAt ? ` (${dateAgo(lastInstalledAt)})` : ""}. Select{" "}
@@ -299,7 +302,9 @@ export const generateSoftwareTableHeaders = ({
         <InstallerStatus
           status={cellProps.row.original.status}
           last_install={
-            cellProps.row.original.software_package?.last_install || null
+            cellProps.row.original.software_package?.last_install ||
+            cellProps.row.original.app_store_app?.last_install ||
+            null
           }
           onShowInstallerDetails={onShowInstallerDetails}
         />


### PR DESCRIPTION
## Issue
For #28875 

## Description
- app store app install string wasn't being passed into installedAt for tooltip
- Other: update `icon_url` to allow null since I got type errors when I hardcoded response data returned for Janis

## Screenshot of fix (ignore app icons since that fix is on another ticket)
<img width="1058" alt="Screenshot 2025-05-07 at 4 17 19 PM" src="https://github.com/user-attachments/assets/61863aaf-ddea-4696-9cfc-854420dc135a" />


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [ ] Added/updated automated tests
- [x] A detailed QA plan exists on the associated ticket (if it isn't there, work with the product group's QA engineer to add it)
- [x] Manual QA for all new/changed functionality
