### PR TITLE
Reducing "waiting for mysql" timeout to 1 minute to speed up dev feedback.

### DIFF
--- a/.github/workflows/test-go.yaml
+++ b/.github/workflows/test-go.yaml
@@ -157,7 +157,7 @@ jobs:
         # Function to wait for MySQL with timeout
         wait_for_mysql() {
           local container_name=$1
-          local timeout_seconds=300  # 5 minutes
+          local timeout_seconds=60  # 1 minute
           local start_time=$(date +%s)
           local attempt_logs=""
           


### PR DESCRIPTION
I'm seeing it takes ~10 seconds to MySQL to come up, so 1 minute should be plenty. 5 minutes was too long to wait.