### PR TITLE
UI: Add configuration option for customer-preston

### DIFF
--- a/changes/28221-customer-ask
+++ b/changes/28221-customer-ask
@@ -1,1 +1,0 @@
-* Add bespoke functionality for a customer

--- a/changes/28221-customer-ask
+++ b/changes/28221-customer-ask
@@ -1,0 +1,1 @@
+* Add bespoke functionality for a customer

--- a/frontend/components/GitOpsModeTooltipWrapper/GitOpsModeTooltipWrapper.tsx
+++ b/frontend/components/GitOpsModeTooltipWrapper/GitOpsModeTooltipWrapper.tsx
@@ -1,9 +1,9 @@
-import CustomLink from "components/CustomLink";
 import TooltipWrapper, {
   ITooltipWrapper,
 } from "components/TooltipWrapper/TooltipWrapper";
 import { AppContext } from "context/app";
 import React, { useContext } from "react";
+import { getGitOpsModeTipContent } from "utilities/helpers";
 
 interface IGitOpsModeTooltipWrapper {
   renderChildren: (disableChildren?: boolean) => React.ReactNode;
@@ -29,16 +29,8 @@ const GitOpsModeTooltipWrapper = ({
   }
 
   const tipContent = (
-    // at this point repoURL will always be defined
     <div className={`${baseClass}__tooltip-content`}>
-      {repoURL && (
-        <span>
-          Manage in{" "}
-          <CustomLink newTab text="YAML" variant="tooltip-link" url={repoURL} />
-          <br />
-        </span>
-      )}
-      <span>(GitOps mode enabled)</span>
+      {repoURL && getGitOpsModeTipContent(repoURL)}
     </div>
   );
 

--- a/frontend/components/TableContainer/TableContainer.tsx
+++ b/frontend/components/TableContainer/TableContainer.tsx
@@ -9,7 +9,7 @@ import SearchField from "components/forms/fields/SearchField";
 import Pagination from "components/Pagination";
 import Button from "components/buttons/Button";
 import Icon from "components/Icon/Icon";
-import GitOpsModeTooltipWrapper from "components/GitOpsModeTooltipWrapper";
+import TooltipWrapper from "components/TooltipWrapper";
 
 import { COLORS } from "styles/var/colors";
 
@@ -31,8 +31,9 @@ interface IRowProps extends Row {
   };
 }
 
+// TODO - there are 2 `IActionButtonProps` - reconcile
 interface ITableContainerActionButtonProps extends IActionButtonProps {
-  gitOpsModeCompatible?: boolean;
+  disabledTooltipContent?: React.ReactNode;
 }
 
 interface ITableContainerProps<T = any> {
@@ -297,29 +298,11 @@ const TableContainer = <T,>({
   const renderFilterActionButton = () => {
     // always !!actionButton here, this is for type checker
     if (actionButton) {
-      if (actionButton.gitOpsModeCompatible) {
-        return (
-          <GitOpsModeTooltipWrapper
-            tipOffset={8}
-            renderChildren={(disableChildren) => (
-              <Button
-                disabled={disableActionButton || disableChildren}
-                onClick={actionButton.onClick}
-                variant={actionButton.variant || "default"}
-                className={`${baseClass}__table-action-button`}
-              >
-                <>
-                  {actionButton.buttonText}
-                  {actionButton.iconSvg && <Icon name={actionButton.iconSvg} />}
-                </>
-              </Button>
-            )}
-          />
-        );
-      }
-      return (
+      const button = (
         <Button
-          disabled={disableActionButton}
+          disabled={
+            !!actionButton.disabledTooltipContent || disableActionButton
+          }
           onClick={actionButton.onClick}
           variant={actionButton.variant || "default"}
           className={`${baseClass}__table-action-button`}
@@ -330,9 +313,20 @@ const TableContainer = <T,>({
           </>
         </Button>
       );
+      return actionButton.disabledTooltipContent ? (
+        <TooltipWrapper
+          tipContent={actionButton.disabledTooltipContent}
+          position="top"
+          underline={false}
+          showArrow
+          tipOffset={8}
+        >
+          {button}
+        </TooltipWrapper>
+      ) : (
+        button
+      );
     }
-    // should never reach here
-    return null;
   };
 
   const renderFilters = useCallback(() => {

--- a/frontend/components/buttons/ActionButtons/ActionButtons.tsx
+++ b/frontend/components/buttons/ActionButtons/ActionButtons.tsx
@@ -8,6 +8,8 @@ import Icon from "components/Icon/Icon";
 import { IconNames } from "components/icons";
 import GitOpsModeTooltipWrapper from "components/GitOpsModeTooltipWrapper";
 
+// TODO - there are two `IActionButtonProps` in the codebase, one specifically used in
+// TableContainer. Disambiguate these names or combine into a single abstraction.
 export interface IActionButtonProps {
   type: "primary" | "secondary";
   label: string;

--- a/frontend/interfaces/config.ts
+++ b/frontend/interfaces/config.ts
@@ -190,6 +190,11 @@ export interface IConfig {
   };
   mdm: IMdmConfig;
   gitops: IGitOpsModeConfig;
+  partnerships?: IFleetPartnerships;
+}
+
+interface IFleetPartnerships {
+  enable_primo: boolean;
 }
 
 export interface IWebhookSettings {

--- a/frontend/pages/DashboardPage/DashboardPage.tsx
+++ b/frontend/pages/DashboardPage/DashboardPage.tsx
@@ -853,7 +853,7 @@ const DashboardPage = ({ router, location }: IDashboardProps): JSX.Element => {
   };
 
   const renderDashboardHeader = () => {
-    if (isPremiumTier) {
+    if (isPremiumTier && !config?.partnerships?.enable_primo) {
       if (userTeams) {
         if (userTeams.length > 1 || isOnGlobalTeam) {
           return (

--- a/frontend/pages/DashboardPage/DashboardPage.tsx
+++ b/frontend/pages/DashboardPage/DashboardPage.tsx
@@ -871,7 +871,6 @@ const DashboardPage = ({ router, location }: IDashboardProps): JSX.Element => {
       // userTeams.length should have at least 1 element
       return null;
     }
-    // Free tier
     return <h1>{config?.org_info.org_name}</h1>;
   };
   return !isRouteOk ? (

--- a/frontend/pages/ManageControlsPage/ManageControlsPage.tsx
+++ b/frontend/pages/ManageControlsPage/ManageControlsPage.tsx
@@ -138,8 +138,8 @@ const ManageControlsPage = ({
     );
   };
 
-  const renderPremiumHeader = () => {
-    if (userTeams) {
+  const renderHeaderContent = () => {
+    if (isPremiumTier && !config?.partnerships?.enable_primo && userTeams) {
       if (userTeams.length > 1 || isOnGlobalTeam) {
         return (
           <TeamsDropdown
@@ -155,18 +155,13 @@ const ManageControlsPage = ({
         return <h1>{userTeams[0].name}</h1>;
       }
     }
+    return <h1>Controls</h1>;
   };
 
   const renderHeader = () => (
     <div className={`${baseClass}__header`}>
       <div className={`${baseClass}__text`}>
-        <div className={`${baseClass}__title`}>
-          {isPremiumTier && !config?.partnerships?.enable_primo ? (
-            renderPremiumHeader()
-          ) : (
-            <h1>Controls</h1>
-          )}
-        </div>
+        <div className={`${baseClass}__title`}>{renderHeaderContent()}</div>
       </div>
     </div>
   );

--- a/frontend/pages/ManageControlsPage/ManageControlsPage.tsx
+++ b/frontend/pages/ManageControlsPage/ManageControlsPage.tsx
@@ -73,7 +73,7 @@ const ManageControlsPage = ({
 }: IManageControlsPageProps): JSX.Element => {
   const page = parseInt(location?.query?.page || "", 10) || 0;
 
-  const { isFreeTier, isOnGlobalTeam, isPremiumTier } = useContext(AppContext);
+  const { config, isOnGlobalTeam, isPremiumTier } = useContext(AppContext);
 
   const {
     currentTeamId,
@@ -138,34 +138,44 @@ const ManageControlsPage = ({
     );
   };
 
+  const renderPremiumHeader = () => {
+    if (userTeams) {
+      if (userTeams.length > 1 || isOnGlobalTeam) {
+        return (
+          <TeamsDropdown
+            currentUserTeams={userTeams}
+            selectedTeamId={currentTeamId}
+            onChange={handleTeamChange}
+            includeAll={false}
+            includeNoTeams
+          />
+        );
+      }
+      if (!isOnGlobalTeam && userTeams.length === 1) {
+        return <h1>{userTeams[0].name}</h1>;
+      }
+    }
+  };
+
+  const renderHeader = () => (
+    <div className={`${baseClass}__header`}>
+      <div className={`${baseClass}__text`}>
+        <div className={`${baseClass}__title`}>
+          {isPremiumTier && !config?.partnerships?.enable_primo ? (
+            renderPremiumHeader()
+          ) : (
+            <h1>Controls</h1>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+
   return (
     <MainContent>
       <div className={`${baseClass}__wrapper`}>
         <div className={`${baseClass}__header-wrap`}>
-          <div className={`${baseClass}__header-wrap`}>
-            <div className={`${baseClass}__header`}>
-              <div className={`${baseClass}__text`}>
-                <div className={`${baseClass}__title`}>
-                  {isFreeTier && <h1>Controls</h1>}
-                  {isPremiumTier &&
-                    userTeams &&
-                    (userTeams.length > 1 || isOnGlobalTeam) && (
-                      <TeamsDropdown
-                        currentUserTeams={userTeams}
-                        selectedTeamId={currentTeamId}
-                        onChange={handleTeamChange}
-                        includeAll={false}
-                        includeNoTeams
-                      />
-                    )}
-                  {isPremiumTier &&
-                    !isOnGlobalTeam &&
-                    userTeams &&
-                    userTeams.length === 1 && <h1>{userTeams[0].name}</h1>}
-                </div>
-              </div>
-            </div>
-          </div>
+          <div className={`${baseClass}__header-wrap`}>{renderHeader()}</div>
         </div>
         {renderBody()}
       </div>

--- a/frontend/pages/SoftwarePage/SoftwarePage.tsx
+++ b/frontend/pages/SoftwarePage/SoftwarePage.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useContext, useState, useEffect } from "react";
+import React, { useCallback, useContext, useState } from "react";
 import { InjectedRouter } from "react-router";
 import { useQuery } from "react-query";
 import { Tab, TabList, Tabs } from "react-tabs";
@@ -352,22 +352,6 @@ const SoftwarePage = ({ children, router, location }: ISoftwarePageProps) => {
     [location, router]
   );
 
-  const renderTitle = () => {
-    return (
-      <>
-        {isFreeTier && <h1>Software</h1>}
-        {isPremiumTier && (
-          <TeamsHeader
-            isOnGlobalTeam={isOnGlobalTeam}
-            currentTeamId={currentTeamId}
-            userTeams={userTeams}
-            onTeamChange={onTeamChange}
-          />
-        )}
-      </>
-    );
-  };
-
   const renderPageActions = () => {
     const canManageAutomations = isGlobalAdmin && isPremiumTier;
 
@@ -480,7 +464,18 @@ const SoftwarePage = ({ children, router, location }: ISoftwarePageProps) => {
         <div className={`${baseClass}__header-wrap`}>
           <div className={`${baseClass}__header`}>
             <div className={`${baseClass}__text`}>
-              <div className={`${baseClass}__title`}>{renderTitle()}</div>
+              <div className={`${baseClass}__title`}>
+                {isPremiumTier && !globalConfig?.partnerships?.enable_primo ? (
+                  <TeamsHeader
+                    isOnGlobalTeam={isOnGlobalTeam}
+                    currentTeamId={currentTeamId}
+                    userTeams={userTeams}
+                    onTeamChange={onTeamChange}
+                  />
+                ) : (
+                  <h1>Software</h1>
+                )}
+              </div>
             </div>
           </div>
           {renderPageActions()}

--- a/frontend/pages/admin/TeamManagementPage/TeamManagementPage.tsx
+++ b/frontend/pages/admin/TeamManagementPage/TeamManagementPage.tsx
@@ -255,7 +255,7 @@ const TeamManagementPage = (): JSX.Element => {
     return <TableCount name="teams" count={teams?.length} />;
   }, [teams]);
 
-  const getDisabledPrimaryActionTooltip = () => {
+  const disabledPrimaryActionTooltip = (() => {
     if (config?.partnerships?.enable_primo) {
       return PRIMO_TOOLTIP;
     }
@@ -263,7 +263,7 @@ const TeamManagementPage = (): JSX.Element => {
       return getGitOpsModeTipContent(config.gitops.repository_url);
     }
     return null;
-  };
+  })();
 
   return (
     <div className={`${baseClass}`}>
@@ -292,13 +292,14 @@ const TeamManagementPage = (): JSX.Element => {
               variant: "default",
               onClick: toggleCreateTeamModal,
               hideButton: teams && teams.length === 0,
-              disabledTooltipContent: getDisabledPrimaryActionTooltip(),
+              disabledTooltipContent: disabledPrimaryActionTooltip,
             }}
             resultsTitle="teams"
             emptyComponent={() => (
               <EmptyTeamsTable
                 className={noTeamsClass}
                 onActionButtonClick={toggleCreateTeamModal}
+                disabledPrimaryActionTooltip={disabledPrimaryActionTooltip}
               />
             )}
             showMarkAllPages={false}

--- a/frontend/pages/admin/TeamManagementPage/TeamManagementPage.tsx
+++ b/frontend/pages/admin/TeamManagementPage/TeamManagementPage.tsx
@@ -2,6 +2,9 @@ import React, { useState, useCallback, useContext, useMemo } from "react";
 import { useQuery } from "react-query";
 import { useErrorHandler } from "react-error-boundary";
 
+import { PRIMO_TOOLTIP } from "utilities/constants";
+import { getGitOpsModeTipContent } from "utilities/helpers";
+
 import { NotificationContext } from "context/notification";
 import { AppContext } from "context/app";
 import { ITeam } from "interfaces/team";
@@ -36,7 +39,9 @@ const TeamManagementPage = (): JSX.Element => {
     setCurrentUser,
     setAvailableTeams,
     setUserSettings,
+    config,
   } = useContext(AppContext);
+
   const [isUpdatingTeams, setIsUpdatingTeams] = useState(false);
   const [showCreateTeamModal, setShowCreateTeamModal] = useState(false);
   const [showDeleteTeamModal, setShowDeleteTeamModal] = useState(false);
@@ -250,6 +255,16 @@ const TeamManagementPage = (): JSX.Element => {
     return <TableCount name="teams" count={teams?.length} />;
   }, [teams]);
 
+  const getDisabledPrimaryActionTooltip = () => {
+    if (config?.partnerships?.enable_primo) {
+      return PRIMO_TOOLTIP;
+    }
+    if (config?.gitops?.gitops_mode_enabled && config?.gitops?.repository_url) {
+      return getGitOpsModeTipContent(config.gitops.repository_url);
+    }
+    return null;
+  };
+
   return (
     <div className={`${baseClass}`}>
       <SandboxGate
@@ -277,7 +292,7 @@ const TeamManagementPage = (): JSX.Element => {
               variant: "default",
               onClick: toggleCreateTeamModal,
               hideButton: teams && teams.length === 0,
-              gitOpsModeCompatible: true,
+              disabledTooltipContent: getDisabledPrimaryActionTooltip(),
             }}
             resultsTitle="teams"
             emptyComponent={() => (

--- a/frontend/pages/admin/TeamManagementPage/components/EmptyTeamsTable.tsx
+++ b/frontend/pages/admin/TeamManagementPage/components/EmptyTeamsTable.tsx
@@ -3,15 +3,41 @@ import React from "react";
 import Button from "components/buttons/Button";
 import EmptyTable from "components/EmptyTable";
 import CustomLink from "components/CustomLink";
-import GitOpsModeTooltipWrapper from "components/GitOpsModeTooltipWrapper";
+import TooltipWrapper from "components/TooltipWrapper";
 
 const EmptyTeamsTable = ({
   className,
   onActionButtonClick,
+  disabledPrimaryActionTooltip,
 }: {
   className: string;
   onActionButtonClick: () => void;
+  // covers both disabling teams UI for Primo and GitOps mode, with correct precedence
+  disabledPrimaryActionTooltip: React.ReactNode;
 }) => {
+  const rawButton = (
+    <Button
+      disabled={!!disabledPrimaryActionTooltip}
+      onClick={onActionButtonClick}
+      className={`${className}__create-button`}
+    >
+      Create team
+    </Button>
+  );
+  const primaryButton = disabledPrimaryActionTooltip ? (
+    <TooltipWrapper
+      tipContent={disabledPrimaryActionTooltip}
+      position="top"
+      underline={false}
+      showArrow
+      tipOffset={8}
+    >
+      {rawButton}
+    </TooltipWrapper>
+  ) : (
+    rawButton
+  );
+
   return (
     <EmptyTable
       graphicName="empty-teams"
@@ -28,20 +54,7 @@ const EmptyTeamsTable = ({
           />
         </>
       }
-      primaryButton={
-        <GitOpsModeTooltipWrapper
-          tipOffset={8}
-          renderChildren={(disableChildren) => (
-            <Button
-              className={`${className}__create-button`}
-              onClick={onActionButtonClick}
-              disabled={disableChildren}
-            >
-              Create team
-            </Button>
-          )}
-        />
-      }
+      primaryButton={primaryButton}
     />
   );
 };

--- a/frontend/pages/admin/UserManagementPage/components/UserForm/UserForm.tsx
+++ b/frontend/pages/admin/UserManagementPage/components/UserForm/UserForm.tsx
@@ -34,6 +34,7 @@ import TooltipWrapper from "components/TooltipWrapper";
 import SelectedTeamsForm from "../SelectedTeamsForm/SelectedTeamsForm";
 import SelectRoleForm from "../SelectRoleForm/SelectRoleForm";
 import { roleOptions } from "../../helpers/userManagementHelpers";
+import { PRIMO_TOOLTIP } from "utilities/constants";
 
 const baseClass = "user-form";
 
@@ -682,7 +683,7 @@ const UserForm = ({
     if (priMode) {
       return (
         <TooltipWrapper
-          tipContent="Teams are disabled while using Primo"
+          tipContent={PRIMO_TOOLTIP}
           tipOffset={20}
           position="right"
           showArrow

--- a/frontend/pages/admin/UserManagementPage/components/UserForm/UserForm.tsx
+++ b/frontend/pages/admin/UserManagementPage/components/UserForm/UserForm.tsx
@@ -179,7 +179,7 @@ const UserForm = ({
     currentUserId,
   });
 
-  const [isGlobalUser, setIsGlobalUser] = useState(!!defaultGlobalRole);
+  const isGlobalUser = formData.global_role !== null;
 
   const initiallyPasswordAuth = !isSsoEnabled;
 
@@ -269,7 +269,7 @@ const UserForm = ({
     setIsGlobalUser(isGlobalUserChange);
     setFormData({
       ...formData,
-      global_role: isGlobalUserChange ? "observer" : null,
+      global_role: value === UserTeamType.GlobalUser ? "observer" : null,
     });
   };
 

--- a/frontend/pages/admin/UserManagementPage/components/UserForm/UserForm.tsx
+++ b/frontend/pages/admin/UserManagementPage/components/UserForm/UserForm.tsx
@@ -8,6 +8,8 @@ import React, {
 import { Link } from "react-router";
 import PATHS from "router/paths";
 
+import { PRIMO_TOOLTIP } from "utilities/constants";
+
 import { NotificationContext } from "context/notification";
 import { AppContext } from "context/app";
 
@@ -34,7 +36,6 @@ import TooltipWrapper from "components/TooltipWrapper";
 import SelectedTeamsForm from "../SelectedTeamsForm/SelectedTeamsForm";
 import SelectRoleForm from "../SelectRoleForm/SelectRoleForm";
 import { roleOptions } from "../../helpers/userManagementHelpers";
-import { PRIMO_TOOLTIP } from "utilities/constants";
 
 const baseClass = "user-form";
 

--- a/frontend/pages/admin/UserManagementPage/components/UserForm/_styles.scss
+++ b/frontend/pages/admin/UserManagementPage/components/UserForm/_styles.scss
@@ -92,4 +92,10 @@
   &__tooltip-text {
     width: 300px;
   }
+
+  .team-field .component__tooltip-wrapper__element {
+    display: flex;
+    flex-direction: column;
+    gap: $pad-small;
+  }
 }

--- a/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
@@ -1309,9 +1309,6 @@ const ManageHostsPage = ({
   );
 
   const renderPremiumHeader = () => {
-    if (config?.partnerships?.enable_primo) {
-      return <h1>Hosts</h1>;
-    }
     if (userTeams) {
       if (userTeams.length > 1 || isOnGlobalTeam) {
         return (
@@ -1334,7 +1331,11 @@ const ManageHostsPage = ({
     <div className={`${baseClass}__header`}>
       <div className={`${baseClass}__text`}>
         <div className={`${baseClass}__title`}>
-          {isPremiumTier ? renderPremiumHeader() : <h1>Hosts</h1>}
+          {isPremiumTier && !config?.partnerships?.enable_primo ? (
+            renderPremiumHeader()
+          ) : (
+            <h1>Hosts</h1>
+          )}
         </div>
       </div>
     </div>

--- a/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
@@ -1308,14 +1308,13 @@ const ManageHostsPage = ({
     />
   );
 
-  const renderPremiumHeader = () => {
-    if (userTeams) {
+  const renderHeaderContent = () => {
+    if (isPremiumTier && !config?.partnerships?.enable_primo && userTeams) {
       if (userTeams.length > 1 || isOnGlobalTeam) {
         return (
           <TeamsDropdown
             currentUserTeams={userTeams || []}
             selectedTeamId={currentTeamId}
-            isDisabled={isLoadingHosts || isLoadingHostsCount} // TODO: why?
             onChange={onTeamChange}
             includeNoTeams
           />
@@ -1325,18 +1324,13 @@ const ManageHostsPage = ({
         return <h1>{userTeams[0].name}</h1>;
       }
     }
+    return <h1>Hosts</h1>;
   };
 
   const renderHeader = () => (
     <div className={`${baseClass}__header`}>
       <div className={`${baseClass}__text`}>
-        <div className={`${baseClass}__title`}>
-          {isPremiumTier && !config?.partnerships?.enable_primo ? (
-            renderPremiumHeader()
-          ) : (
-            <h1>Hosts</h1>
-          )}
-        </div>
+        <div className={`${baseClass}__title`}>{renderHeaderContent()}</div>
       </div>
     </div>
   );

--- a/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
@@ -1208,16 +1208,6 @@ const ManageHostsPage = ({
     }
   };
 
-  const renderTeamsFilterDropdown = () => (
-    <TeamsDropdown
-      currentUserTeams={userTeams || []}
-      selectedTeamId={currentTeamId}
-      isDisabled={isLoadingHosts || isLoadingHostsCount} // TODO: why?
-      onChange={onTeamChange}
-      includeNoTeams
-    />
-  );
-
   const renderEditColumnsModal = () => {
     if (!config || !currentUser) {
       return null;
@@ -1318,19 +1308,33 @@ const ManageHostsPage = ({
     />
   );
 
+  const renderPremiumHeader = () => {
+    if (config?.partnerships?.enable_primo) {
+      return <h1>Hosts</h1>;
+    }
+    if (userTeams) {
+      if (userTeams.length > 1 || isOnGlobalTeam) {
+        return (
+          <TeamsDropdown
+            currentUserTeams={userTeams || []}
+            selectedTeamId={currentTeamId}
+            isDisabled={isLoadingHosts || isLoadingHostsCount} // TODO: why?
+            onChange={onTeamChange}
+            includeNoTeams
+          />
+        );
+      }
+      if (!isOnGlobalTeam && userTeams.length === 1) {
+        return <h1>{userTeams[0].name}</h1>;
+      }
+    }
+  };
+
   const renderHeader = () => (
     <div className={`${baseClass}__header`}>
       <div className={`${baseClass}__text`}>
         <div className={`${baseClass}__title`}>
-          {isFreeTier && <h1>Hosts</h1>}
-          {isPremiumTier &&
-            userTeams &&
-            (userTeams.length > 1 || isOnGlobalTeam) &&
-            renderTeamsFilterDropdown()}
-          {isPremiumTier &&
-            !isOnGlobalTeam &&
-            userTeams &&
-            userTeams.length === 1 && <h1>{userTeams[0].name}</h1>}
+          {isPremiumTier ? renderPremiumHeader() : <h1>Hosts</h1>}
         </div>
       </div>
     </div>

--- a/frontend/pages/policies/ManagePoliciesPage/ManagePoliciesPage.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/ManagePoliciesPage.tsx
@@ -1202,6 +1202,26 @@ const ManagePolicyPage = ({
     return <Spinner />;
   }
 
+  const renderHeader = () => {
+    if (isPremiumTier && !globalConfigFromContext?.partnerships?.enable_primo) {
+      if ((userTeams && userTeams.length > 1) || isOnGlobalTeam) {
+        return (
+          <TeamsDropdown
+            currentUserTeams={userTeams || []}
+            selectedTeamId={currentTeamId}
+            onChange={onTeamChange}
+            includeNoTeams
+          />
+        );
+      }
+      if (!isOnGlobalTeam && userTeams && userTeams.length === 1) {
+        return <h1>{userTeams[0].name}</h1>;
+      }
+    }
+
+    return <h1>Policies</h1>;
+  };
+
   let teamsDropdownHelpText: string;
   if (teamIdForApi === API_NO_TEAM_ID) {
     teamsDropdownHelpText =
@@ -1219,22 +1239,7 @@ const ManagePolicyPage = ({
         <div className={`${baseClass}__header-wrap`}>
           <div className={`${baseClass}__header`}>
             <div className={`${baseClass}__text`}>
-              <div className={`${baseClass}__title`}>
-                {isFreeTier && <h1>Policies</h1>}
-                {isPremiumTier &&
-                  ((userTeams && userTeams.length > 1) || isOnGlobalTeam) && (
-                    <TeamsDropdown
-                      currentUserTeams={userTeams || []}
-                      selectedTeamId={currentTeamId}
-                      onChange={onTeamChange}
-                      includeNoTeams
-                    />
-                  )}
-                {isPremiumTier &&
-                  !isOnGlobalTeam &&
-                  userTeams &&
-                  userTeams.length === 1 && <h1>{userTeams[0].name}</h1>}
-              </div>
+              <div className={`${baseClass}__title`}>{renderHeader()}</div>
             </div>
           </div>
           {showCtaButtons && (

--- a/frontend/pages/queries/ManageQueriesPage/ManageQueriesPage.tsx
+++ b/frontend/pages/queries/ManageQueriesPage/ManageQueriesPage.tsx
@@ -32,7 +32,6 @@ import { API_ALL_TEAMS_ID } from "interfaces/team";
 import queriesAPI, { IQueriesResponse } from "services/entities/queries";
 import PATHS from "router/paths";
 
-import { ITableQueryData } from "components/TableContainer/TableContainer";
 import Button from "components/buttons/Button";
 import TableDataError from "components/DataError";
 import MainContent from "components/MainContent";
@@ -261,19 +260,18 @@ const ManageQueriesPage = ({
   }, [refetchQueries, selectedQueryIds, toggleDeleteQueryModal]);
 
   const renderHeader = () => {
-    if (isPremiumTier) {
-      if (userTeams) {
-        if (userTeams.length > 1 || isOnGlobalTeam) {
-          return (
-            <TeamsDropdown
-              currentUserTeams={userTeams}
-              selectedTeamId={currentTeamId}
-              onChange={onTeamChange}
-            />
-          );
-        } else if (!isOnGlobalTeam && userTeams.length === 1) {
-          return <h1>{userTeams[0].name}</h1>;
-        }
+    if (isPremiumTier && userTeams && !config?.partnerships?.enable_primo) {
+      if (userTeams.length > 1 || isOnGlobalTeam) {
+        return (
+          <TeamsDropdown
+            currentUserTeams={userTeams}
+            selectedTeamId={currentTeamId}
+            onChange={onTeamChange}
+          />
+        );
+      }
+      if (userTeams.length === 1 && !isOnGlobalTeam) {
+        return <h1>{userTeams[0].name}</h1>;
       }
     }
     return <h1>Queries</h1>;

--- a/frontend/utilities/constants.tsx
+++ b/frontend/utilities/constants.tsx
@@ -379,6 +379,8 @@ export const BATTERY_TOOLTIP: Record<string, string | React.ReactNode> = {
   ),
 };
 
+export const PRIMO_TOOLTIP = "Teams are disabled while using Primo";
+
 /** Must pass agent options config as empty object */
 export const EMPTY_AGENT_OPTIONS = {
   config: {},

--- a/frontend/utilities/helpers.tsx
+++ b/frontend/utilities/helpers.tsx
@@ -51,6 +51,7 @@ import {
 } from "utilities/constants";
 import { ISchedulableQueryStats } from "interfaces/schedulable_query";
 import { IDropdownOption } from "interfaces/dropdownOption";
+import CustomLink from "components/CustomLink";
 
 const ORG_INFO_ATTRS = ["org_name", "org_logo_url"];
 const ADMIN_ATTRS = ["email", "name", "password", "password_confirmation"];
@@ -894,6 +895,17 @@ export function getCustomDropdownOptions(
         ...defaultOptions,
       ];
 }
+
+export const getGitOpsModeTipContent = (repoURL: string) => (
+  <>
+    <span>
+      Manage in{" "}
+      <CustomLink newTab text="YAML" variant="tooltip-link" url={repoURL} />
+      <br />
+    </span>
+    <span>GitOps mode enabled</span>
+  </>
+);
 
 export default {
   addGravatarUrlToResource,


### PR DESCRIPTION
## For #28221, frontend portion

- In desired places, read new config option and render desired UI accordingly
- Code refactors to more elegantly support this functionality
- Backend branch [here](https://github.com/fleetdm/fleet/pull/28893) for testing
![Screenshot 2025-05-07 at 2 38 14 PM](https://github.com/user-attachments/assets/5130a96d-ee6e-480f-a1f7-9ff0b3c0dda3)
![Screenshot 2025-05-07 at 2 37 36 PM](https://github.com/user-attachments/assets/f487212d-2620-4c01-9f9d-534fc34396e5)
![Screenshot 2025-05-07 at 2 29 17 PM](https://github.com/user-attachments/assets/d3814704-8d72-4a57-9d81-3f5345d60d46)
<img width="1012" alt="Screenshot 2025-05-07 at 12 00 04 PM" src="https://github.com/user-attachments/assets/81519388-7696-4a7e-a55a-0d0874c17aad" />

**Teams dropdowns:**
![ezgif-7e20570dcd7c58](https://github.com/user-attachments/assets/2bf2b8ca-0d55-495d-8653-ab564320aa13)


- [x] Changes file added for user-visible changes in `changes/
- [x] A detailed QA plan exists on the associated ticket (if it isn't there, work with the product group's QA engineer to add it)
- [x] Manual QA for all new/changed functionality
