### PR TITLE
Add retry when applying queries

### DIFF
--- a/changes/48642-add-retry-to-apply-queries
+++ b/changes/48642-add-retry-to-apply-queries
@@ -1,0 +1,1 @@
+- Fixed issue where GitOps may fail to apply new queries due to deadlocks.


### PR DESCRIPTION
for #28642

> Note: this PR diff is easier to view [with whitespace off](https://github.com/fleetdm/fleet/pull/28951/files?w=1).

## Details

This PR adds retry to the "Apply Queries" logic, in an attempt to alleviate deadlock issues when applying queries via GitOps.  The `applyQueriesInTx` now uses `withRetryTxx` instead of starting a transaction with `BeginTxx`.  This requires some downstream updates to `updateQueryLabels` and `updateQueryLabelsInTx`, see PR comments for details.

This is a first (and hopefully only necessary) step to fixing the deadlock issues.  If needed, we have other steps we can take like batching the query inserts and splitting the read/write in saveHostPackStatsDB 
 (see https://github.com/fleetdm/fleet/issues/28642#issuecomment-2845804689)

## Testing

I tested this manually using `fleetctl gitops` to apply queries with and without labels.  Existing automated tests for Apply Queries still pass.

