### PR TITLE
Add spot check on 2024 and 2025 NVD feeds to ensure VulnCheck enrichment

### DIFF
--- a/changes/28857-vuln-checks
+++ b/changes/28857-vuln-checks
@@ -1,0 +1,1 @@
+* Added additional checks to vulnerability feed validation to prevent deploying an un-enriched NVD feed.

--- a/cmd/cve/validate/main.go
+++ b/cmd/cve/validate/main.go
@@ -42,7 +42,7 @@ func checkNVDVulnerabilities(vulnPath string, logger log.Logger) {
 	}
 
 	// make sure VulnCheck enrichment is working
-	vulns, err := cvefeed.LoadJSONDictionary(filepath.Join(vulnPath, "nvdcve-1.1-2025.json"))
+	vulns, err := cvefeed.LoadJSONDictionary(filepath.Join(vulnPath, "nvdcve-1.1-2025.json.gz"))
 	if err != nil {
 		panic(err)
 	}
@@ -55,7 +55,7 @@ func checkNVDVulnerabilities(vulnPath string, logger log.Logger) {
 		panic(errors.New("enriched vulnerability spot-check failed for Python on CVE-2025-0938"))
 	}
 
-	vulns, err = cvefeed.LoadJSONDictionary(filepath.Join(vulnPath, "nvdcve-1.1-2024.json"))
+	vulns, err = cvefeed.LoadJSONDictionary(filepath.Join(vulnPath, "nvdcve-1.1-2024.json.gz"))
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
For #28857.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/Committing-Changes.md#changes-files) for more information.
- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [x] Manual QA for all new/changed functionality