### PR TITLE
[API changes] See individual profile status & resend profile to all failed hosts 

### DIFF
--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -5722,7 +5722,6 @@ Get status counts of a single OS settings (configuration profile) enforced on ho
   "verifying": 123,
   "failed": 123,
   "pending": 123,
-  "counts_updated_at": "2024-10-04T10:00:00Z"
 }
 ```
 


### PR DESCRIPTION
Additional update for:

- #28273 

We found out that status counts are computed on-the-fly, so there's no need for `counts_updated_at`.