### PR TITLE
For R.C. - Fleet UI: Fix unreleased VPP icon bug in self-service (#28926)

### DIFF
--- a/frontend/components/TableContainer/DataTable/SoftwareNameCell/SoftwareNameCell.tsx
+++ b/frontend/components/TableContainer/DataTable/SoftwareNameCell/SoftwareNameCell.tsx
@@ -114,6 +114,7 @@ interface ISoftwareNameCellProps {
   hasPackage?: boolean;
   isSelfService?: boolean;
   installType?: "manual" | "automatic";
+  /** e.g. app_store_app's override default icons with URLs */
   iconUrl?: string;
   automaticInstallPoliciesCount?: number;
 }

--- a/frontend/pages/hosts/details/cards/Software/SelfService/SelfServiceTableConfig.tsx
+++ b/frontend/pages/hosts/details/cards/Software/SelfService/SelfServiceTableConfig.tsx
@@ -273,11 +273,12 @@ export const generateSoftwareTableHeaders = ({
       disableSortBy: false,
       disableGlobalFilter: false,
       Cell: (cellProps: ITableStringCellProps) => {
-        const { name, source } = cellProps.row.original;
+        const { name, source, app_store_app } = cellProps.row.original;
         return (
           <SoftwareNameCell
             name={name}
             source={source}
+            iconUrl={app_store_app?.icon_url}
             myDevicePage
             isSelfService
           />


### PR DESCRIPTION
## Issue
For #28876

> Note: Previously merged into `main` with #28926. This is for R.C. 4.68.0

```
 1415  git checkout fleetdm/rc-minor-fleet-v4.68.0
 1416  git log main
 1417  git cherry-pick  f64753f72b1570f06b7a388e6da97e96422d14ee
 1418  git checkout -b 28876-rc
 1419  git push -u fleetdm 28876-rc
```

