### PR TITLE
For R.C. - Fleet UI: Fix unreleased app store app timestamp broken (#28934)

### DIFF
--- a/frontend/interfaces/software.ts
+++ b/frontend/interfaces/software.ts
@@ -365,7 +365,7 @@ export interface ISoftwareInstallVersion {
 export interface IHostSoftwarePackage {
   name: string;
   self_service: boolean;
-  icon_url: string;
+  icon_url: string | null;
   version: string;
   last_install: ISoftwareLastInstall | null;
   categories?: SoftwareCategory[];

--- a/frontend/pages/hosts/details/cards/Software/SelfService/SelfServiceTableConfig.tsx
+++ b/frontend/pages/hosts/details/cards/Software/SelfService/SelfServiceTableConfig.tsx
@@ -45,8 +45,11 @@ const STATUS_CONFIG: Record<
   installed: {
     iconName: "success",
     displayText: "Installed",
-    tooltip: ({ lastInstalledAt = "" }) =>
-      `Software is installed (${dateAgo(lastInstalledAt as string)}).`,
+    tooltip: ({ lastInstalledAt = null }) => {
+      return `Software is installed${
+        lastInstalledAt ? ` (${dateAgo(lastInstalledAt)})` : ""
+      }.`;
+    },
   },
   pending_install: {
     iconName: "pending-outline",
@@ -56,7 +59,7 @@ const STATUS_CONFIG: Record<
   failed_install: {
     iconName: "error",
     displayText: "Failed",
-    tooltip: ({ lastInstalledAt = "" }) => (
+    tooltip: ({ lastInstalledAt = null }) => (
       <>
         Software failed to install
         {lastInstalledAt ? ` (${dateAgo(lastInstalledAt)})` : ""}. Select{" "}
@@ -299,7 +302,9 @@ export const generateSoftwareTableHeaders = ({
         <InstallerStatus
           status={cellProps.row.original.status}
           last_install={
-            cellProps.row.original.software_package?.last_install || null
+            cellProps.row.original.software_package?.last_install ||
+            cellProps.row.original.app_store_app?.last_install ||
+            null
           }
           onShowInstallerDetails={onShowInstallerDetails}
         />


### PR DESCRIPTION
## Issue
For #28875

> Note: Previously merged into `main` with #28934 . This is for R.C. 4.68.0

```
 1410  git checkout fleetdm/rc-minor-fleet-v4.68.0
 1411  git log main
 1412  git cherry-pick 5ec2deba9cdbb86ff4f650b04e72315ee8356ebb
 1413  git checkout -b 28875-rc
 1414  git push -u fleetdm 28875-rc
```

