### PR TITLE
For R.C. - Fleet UI: Hide edit tarballs package (#28965)

### DIFF
--- a/frontend/pages/SoftwarePage/components/forms/PackageForm/PackageForm.tsx
+++ b/frontend/pages/SoftwarePage/components/forms/PackageForm/PackageForm.tsx
@@ -260,6 +260,8 @@ const PackageForm = ({
   const ext = getExtensionFromFileName(formData?.software?.name || "");
   const isExePackage = ext === "exe";
   const isTarballPackage = ext === "tar.gz";
+  // We currently don't support replacing a tarball package
+  const canEditFile = isEditingSoftware && !isTarballPackage;
 
   // If a user preselects automatic install and then uploads a .exe
   // which automatic install is not supported, the form will default
@@ -279,7 +281,7 @@ const PackageForm = ({
     <div className={classNames}>
       <form className={`${baseClass}__form`} onSubmit={onFormSubmit}>
         <FileUploader
-          canEdit={isEditingSoftware}
+          canEdit={canEditFile}
           graphicName="file-pkg"
           accept={ACCEPTED_EXTENSIONS}
           message=".pkg, .msi, .exe, .deb, .rpm, or .tar.gz"


### PR DESCRIPTION
## Issue
For #27337

> Note: Previously merged into `main` with #28965. This is for R.C. 4.68.0

```
 1476  git fetch fleetdm
 1477  git checkout fleetdm/rc-minor-fleet-v4.68.0
 1478  git log main
 1479  git cherry-pick fe087db01b24908e0c893fa15f4b3a1a4e111f46
 1480  git checkout -b tarballs-hide-edit-rc
 1481  git push -u fleetdm tarballs-hide-edit-rc
```

