### PR TITLE
Fleet UI: Clarify Host software/self-service status and version columns

### DIFF
--- a/frontend/pages/hosts/details/cards/Software/DeviceSoftwareTableConfig.tsx
+++ b/frontend/pages/hosts/details/cards/Software/DeviceSoftwareTableConfig.tsx
@@ -15,7 +15,6 @@ import VulnerabilitiesCell from "pages/SoftwarePage/components/tables/Vulnerabil
 import VersionCell from "pages/SoftwarePage/components/tables/VersionCell";
 import { getVulnerabilities } from "pages/SoftwarePage/SoftwareTitles/SoftwareTable/SoftwareTitlesTableConfig";
 import SoftwareNameCell from "components/TableContainer/DataTable/SoftwareNameCell";
-import TooltipWrapper from "components/TooltipWrapper";
 
 type ISoftwareTableConfig = Column<IHostSoftware>;
 type ITableHeaderProps = IHeaderProps<IHostSoftware>;

--- a/frontend/pages/hosts/details/cards/Software/DeviceSoftwareTableConfig.tsx
+++ b/frontend/pages/hosts/details/cards/Software/DeviceSoftwareTableConfig.tsx
@@ -15,7 +15,7 @@ import VulnerabilitiesCell from "pages/SoftwarePage/components/tables/Vulnerabil
 import VersionCell from "pages/SoftwarePage/components/tables/VersionCell";
 import { getVulnerabilities } from "pages/SoftwarePage/SoftwareTitles/SoftwareTable/SoftwareTitlesTableConfig";
 import SoftwareNameCell from "components/TableContainer/DataTable/SoftwareNameCell";
-import ViewAllHostsLink from "components/ViewAllHostsLink";
+import TooltipWrapper from "components/TooltipWrapper";
 
 type ISoftwareTableConfig = Column<IHostSoftware>;
 type ITableHeaderProps = IHeaderProps<IHostSoftware>;
@@ -55,7 +55,8 @@ export const generateSoftwareTableHeaders = (): ISoftwareTableConfig[] => {
       sortType: "caseInsensitive",
     },
     {
-      Header: "Version",
+      Header: "Installed version",
+      id: "version",
       disableSortBy: true,
       // we use function as accessor because we have two columns that
       // need to access the same data. This is not supported with a string

--- a/frontend/pages/hosts/details/cards/Software/HostSoftwareTableConfig.tsx
+++ b/frontend/pages/hosts/details/cards/Software/HostSoftwareTableConfig.tsx
@@ -25,6 +25,7 @@ import HeaderCell from "components/TableContainer/DataTable/HeaderCell/HeaderCel
 import TextCell from "components/TableContainer/DataTable/TextCell";
 import SoftwareNameCell from "components/TableContainer/DataTable/SoftwareNameCell";
 import ActionsDropdown from "components/ActionsDropdown";
+import TooltipWrapper from "components/TooltipWrapper";
 
 import VulnerabilitiesCell from "pages/SoftwarePage/components/tables/VulnerabilitiesCell";
 import VersionCell from "pages/SoftwarePage/components/tables/VersionCell";
@@ -32,7 +33,6 @@ import { getVulnerabilities } from "pages/SoftwarePage/SoftwareTitles/SoftwareTa
 
 import InstallStatusCell from "./InstallStatusCell";
 import { getDropdownOptionTooltipContent } from "../../HostDetailsPage/HostActionsDropdown/helpers";
-import TooltipWrapper from "components/TooltipWrapper";
 
 export const DEFAULT_ACTION_OPTIONS: IDropdownOption[] = [
   { value: "showDetails", label: "Show details", disabled: false },

--- a/frontend/pages/hosts/details/cards/Software/HostSoftwareTableConfig.tsx
+++ b/frontend/pages/hosts/details/cards/Software/HostSoftwareTableConfig.tsx
@@ -32,6 +32,7 @@ import { getVulnerabilities } from "pages/SoftwarePage/SoftwareTitles/SoftwareTa
 
 import InstallStatusCell from "./InstallStatusCell";
 import { getDropdownOptionTooltipContent } from "../../HostDetailsPage/HostActionsDropdown/helpers";
+import TooltipWrapper from "components/TooltipWrapper";
 
 export const DEFAULT_ACTION_OPTIONS: IDropdownOption[] = [
   { value: "showDetails", label: "Show details", disabled: false },
@@ -201,7 +202,15 @@ export const generateSoftwareTableHeaders = ({
       },
     },
     {
-      Header: "Install status",
+      Header: () => (
+        <HeaderCell
+          value={
+            <TooltipWrapper tipContent="Indicates the results of Fleet-managed installions only.">
+              Install status
+            </TooltipWrapper>
+          }
+        />
+      ),
       disableSortBy: true,
       accessor: "status",
       Cell: ({ row: { original } }: IInstalledStatusCellProps) => {
@@ -209,7 +218,24 @@ export const generateSoftwareTableHeaders = ({
       },
     },
     {
-      Header: "Version",
+      Header: () => (
+        <HeaderCell
+          value={
+            <TooltipWrapper
+              tipContent={
+                <>
+                  The current version installed on
+                  <br />
+                  this host verified with osquery.
+                </>
+              }
+            >
+              Installed version
+            </TooltipWrapper>
+          }
+        />
+      ),
+      id: "version",
       disableSortBy: true,
       // we use function as accessor because we have two columns that
       // need to access the same data. This is not supported with a string

--- a/frontend/pages/hosts/details/cards/Software/HostSoftwareTableConfig.tsx
+++ b/frontend/pages/hosts/details/cards/Software/HostSoftwareTableConfig.tsx
@@ -205,7 +205,7 @@ export const generateSoftwareTableHeaders = ({
       Header: () => (
         <HeaderCell
           value={
-            <TooltipWrapper tipContent="Indicates the results of Fleet-managed installions only.">
+            <TooltipWrapper tipContent="Indicates the results of Fleet-managed installations only.">
               Install status
             </TooltipWrapper>
           }

--- a/frontend/pages/hosts/details/cards/Software/HostSoftwareTableConfig.tsx
+++ b/frontend/pages/hosts/details/cards/Software/HostSoftwareTableConfig.tsx
@@ -205,7 +205,15 @@ export const generateSoftwareTableHeaders = ({
       Header: () => (
         <HeaderCell
           value={
-            <TooltipWrapper tipContent="Indicates the results of Fleet-managed installations only.">
+            <TooltipWrapper
+              tipContent={
+                <>
+                  The status of the last time <br />
+                  Fleet attempted an install <br />
+                  or uninstall.
+                </>
+              }
+            >
               Install status
             </TooltipWrapper>
           }
@@ -224,9 +232,9 @@ export const generateSoftwareTableHeaders = ({
             <TooltipWrapper
               tipContent={
                 <>
-                  The current version installed on
+                  The current verified version
                   <br />
-                  this host verified with osquery.
+                  installed on host.
                 </>
               }
             >

--- a/frontend/pages/hosts/details/cards/Software/SelfService/SelfServiceTableConfig.tsx
+++ b/frontend/pages/hosts/details/cards/Software/SelfService/SelfServiceTableConfig.tsx
@@ -392,7 +392,11 @@ export const generateSoftwareTableHeaders = ({
     {
       Header: (cellProps: ITableHeaderProps) => (
         <HeaderCell
-          value="Status"
+          value={
+            <TooltipWrapper tipContent="Indicates the results of installations performed by this management system.">
+              Install status
+            </TooltipWrapper>
+          }
           isSortedDesc={cellProps.column.isSortedDesc}
         />
       ),

--- a/frontend/pages/hosts/details/cards/Software/SelfService/SelfServiceTableConfig.tsx
+++ b/frontend/pages/hosts/details/cards/Software/SelfService/SelfServiceTableConfig.tsx
@@ -393,7 +393,14 @@ export const generateSoftwareTableHeaders = ({
       Header: (cellProps: ITableHeaderProps) => (
         <HeaderCell
           value={
-            <TooltipWrapper tipContent="Indicates the results of installations performed by this management system.">
+            <TooltipWrapper
+              tipContent={
+                <>
+                  Indicates the results of installations <br />
+                  performed by this management system.
+                </>
+              }
+            >
               Install status
             </TooltipWrapper>
           }

--- a/frontend/pages/hosts/details/cards/Software/SelfService/SelfServiceTableConfig.tsx
+++ b/frontend/pages/hosts/details/cards/Software/SelfService/SelfServiceTableConfig.tsx
@@ -34,11 +34,8 @@ import { IStatusDisplayConfig } from "../InstallStatusCell/InstallStatusCell";
 type ISoftwareTableConfig = Column<IHostSoftware>;
 type ITableHeaderProps = IHeaderProps<IHostSoftware>;
 type ITableStringCellProps = IStringCellProps<IHostSoftware>;
-type IInstalledVersionsCellProps = CellProps<
-  IHostSoftware,
-  IHostSoftware["installed_versions"]
->;
-type IVulnerabilitiesCellProps = IInstalledVersionsCellProps;
+type IStatusCellProps = CellProps<IHostSoftware, IHostSoftware["status"]>;
+type IActionCellProps = CellProps<IHostSoftware, IHostSoftware["status"]>;
 
 const baseClass = "self-service-table";
 
@@ -392,25 +389,14 @@ export const generateSoftwareTableHeaders = ({
     {
       Header: (cellProps: ITableHeaderProps) => (
         <HeaderCell
-          value={
-            <TooltipWrapper
-              tipContent={
-                <>
-                  Indicates the results of installations <br />
-                  performed by this management system.
-                </>
-              }
-            >
-              Install status
-            </TooltipWrapper>
-          }
+          value="Install status"
           isSortedDesc={cellProps.column.isSortedDesc}
         />
       ),
       disableSortBy: false,
       disableGlobalFilter: true,
-      accessor: "source",
-      Cell: (cellProps: ITableStringCellProps) => (
+      accessor: "status",
+      Cell: (cellProps: IStatusCellProps) => (
         <InstallerStatus
           status={cellProps.row.original.status}
           last_install={
@@ -426,7 +412,7 @@ export const generateSoftwareTableHeaders = ({
       Header: "Actions",
       accessor: (originalRow) => originalRow.status,
       disableSortBy: true,
-      Cell: (cellProps: IVulnerabilitiesCellProps) => {
+      Cell: (cellProps: IActionCellProps) => {
         return (
           <InstallerStatusAction
             deviceToken={deviceToken}


### PR DESCRIPTION
## Issue
#29010 

## Description
- Add tooltips to clarify install status and version
- OTHER: Found and fixed unreleased bug with sorting install status column on self-service, fixed

## Screenshot of fixes
<img width="393" alt="Screenshot 2025-05-16 at 2 52 03 PM" src="https://github.com/user-attachments/assets/728c4c98-e046-4041-81b9-7e2b7c54408d" />
<img width="382" alt="Screenshot 2025-05-16 at 2 51 58 PM" src="https://github.com/user-attachments/assets/72da4b8d-e296-4a6f-93a3-6fb271cf3507" />

### Screen recording of self service sort working properly


https://github.com/user-attachments/assets/c0e60ed7-24e1-4824-943e-2bf994590eea




# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->


- [x] A detailed QA plan exists on the associated ticket (if it isn't there, work with the product group's QA engineer to add it)
- [x] Manual QA for all new/changed functionality
