### PR TITLE
GitOps reference: labels and categories

### DIFF
--- a/docs/Configuration/yaml-files.md
+++ b/docs/Configuration/yaml-files.md
@@ -481,9 +481,6 @@ software:
   packages:
     - path: ../lib/software-name.package.yml
     - path: ../lib/software-name2.package.yml
-      labels_include_any:
-        - Engineering
-        - Customer Support
   app_store_apps:
     - app_store_id: "1091189122"
       labels_include_any: # Available in Fleet Premium
@@ -502,15 +499,17 @@ software:
         - Productivity
 ```
 
-Use `labels_include_any` to target hosts that have any label or `labels_exclude_any` to target hosts that don't have any label. Only one of `labels_include_any` or `labels_exclude_any` can be specified. If neither are specified, all hosts are targeted.
+#### Labels and categories
 
-##### Supported software categories
+Use `labels_include_any` to target hosts that have any label or `labels_exclude_any` to target hosts that don't have any label. Only one of `labels_include_any` or `labels_exclude_any` can be specified. If neither are specified, all hosts are targeted.
 
 Use `categories` to group self-service software on your end users' **Fleet Desktop > My device** page. Here are the supported categories:
 - `Browsers`: group under **🌎 Browsers**
 - `Communication`: group under **👬 Communication**
 - `Developer tools`: group under **🧰 Developer tools**
 - `Productivity`: group under **🖥️ Productivity**
+
+Currently, `labels_` and `categories` keys are specified in the team YAML (`teams/team-name.yml`, or `teams/no-team.yml`) for Fleet-maintained apps and App Store (VPP) apps. For custom packages, they keys are specified in the packages YAML (`lib/software-name.package.yml`).
 
 ### packages
 
@@ -521,7 +520,7 @@ Use `categories` to group self-service software on your end users' **Fleet Deskt
 - `uninstall_script.path` is the script Fleet will run on hosts to uninstall software. The [default script](https://github.com/fleetdm/fleet/tree/main/pkg/file/scripts) is dependent on the software type (i.e. .pkg).
 - `post_install_script.path` is the script Fleet will run on hosts after the software install. There is no default.
 - `self_service` specifies whether or not end users can install from **Fleet Desktop > Self-service**.
-- `categories` is an array of categories. See [supported categories](#supported-software-categories).
+- `categories` is an array of categories. See [supported categories](#labels-and-categories).
 
 > Without specifying a hash, Fleet downloads each installer for each team on each GitOps run.
 
@@ -549,7 +548,7 @@ self_service: true
 > Make sure to include only the ID itself, and not the `id` prefix shown in the URL. The ID must be wrapped in quotes as shown in the example so that it is processed as a string.
 
 - `self_service` only applies to macOS, and is ignored for other platforms. For example, if the app is supported on macOS, iOS, and iPadOS, and `self_service` is set to `true`, it will be self-service on macOS workstations but not iPhones or iPads.
-- `categories` is an array of categories. See [supported categories](#supported-software-categories).
+- `categories` is an array of categories. See [supported categories](#labels-and-categories).
 
 ### fleet_maintained_apps
 

--- a/docs/Configuration/yaml-files.md
+++ b/docs/Configuration/yaml-files.md
@@ -509,7 +509,7 @@ Use `categories` to group self-service software on your end users' **Fleet Deskt
 - `Developer tools`: group under **🧰 Developer tools**
 - `Productivity`: group under **🖥️ Productivity**
 
-Currently, `labels_` and `categories` keys are specified in the team YAML (`teams/team-name.yml`, or `teams/no-team.yml`) for Fleet-maintained apps and App Store (VPP) apps. For custom packages, they keys are specified in the packages YAML (`lib/software-name.package.yml`).
+Currently, for Fleet-maintained apps and App Store (VPP) apps, the `labels_` and `categories` keys are specified in the team YAML (`teams/team-name.yml`, or `teams/no-team.yml`). For custom packages, they keys are specified in the package YAML (`lib/software-name.package.yml`).
 
 ### packages
 


### PR DESCRIPTION
Addresses the bug here: #29011

Currently, labels and categories work at the team level for Fleet maintained apps and App Store apps but labels and categories ONLY work at the package level for custom packages.
