### PR TITLE
For R.C. - Fleet UI: Default to All in dropdown instead of Select place holder (#29015)

### DIFF
--- a/frontend/pages/hosts/details/cards/Software/SelfService/SelfService.tsx
+++ b/frontend/pages/hosts/details/cards/Software/SelfService/SelfService.tsx
@@ -291,7 +291,7 @@ const SoftwareSelfService = ({
             ...category,
             value: String(category.id), // DropdownWrapper only accepts string
           }))}
-          value={String(queryParams.category_id) || ""}
+          value={String(queryParams.category_id || 0)}
           onChange={onCategoriesDropdownChange}
           name="categories-dropdown"
           className={`${baseClass}__categories-dropdown`}


### PR DESCRIPTION
## Issue
For #29014 

> Note: Previously merged into `main` with #29015. This is for R.C. 4.68.0

```
 1627  git fetch fleetdm
 1628  git checkout fleetdm/rc-minor-fleet-v4.68.0
 1629  git log main
 1630  git cherry-pick 025678a8690e888a40113d148522260660ce1a2e
 1631  git checkout -b 29014-default-all-dropdown-rc
 1632  git push -u fleetdm 29014-default-all-dropdown-rc
```

