### PR TITLE
Add backend for uninstalls in My device UI

### DIFF
--- a/changes/28038-uninstall
+++ b/changes/28038-uninstall
@@ -1,0 +1,1 @@
+* Added ability to uninstall software via Self-service tab of My device.

--- a/docs/Contributing/API-for-contributors.md
+++ b/docs/Contributing/API-for-contributors.md
@@ -3046,6 +3046,8 @@ Device-authenticated routes are routes used by the Fleet Desktop application. Un
 - [Get device's software](#get-devices-software)
 - [Get device's software install results](#get-devices-software-install-results)
 - [Get device's software MDM command results](#get-devices-software-mdm-command-results)
+- [Install self-service software](#install-self-service-software)
+- [Uninstall software via self-service](#uninstall-software-via-self-service)
 - [Get device's policies](#get-devices-policies)
 - [Get device's certificate](#get-devices-certificate)
 - [Get device's API features](#get-devices-api-features)
@@ -3344,6 +3346,27 @@ Install self-service software on macOS, Windows, or Linux (Ubuntu) host. The sof
 ##### Example
 
 `POST /api/v1/fleet/device/22aada07-dc73-41f2-8452-c0987543fd29/software/install/123`
+
+##### Default response
+
+`Status: 202`
+
+### Uninstall software via self-service
+
+Uninstalls software from a host via the My device page.
+
+`POST /api/v1/fleet/device/{token}/software/uninstall/:software_title_id`
+
+#### Parameters
+
+| Name              | Type       | In   | Description                                      |
+| ---------         | ---------- | ---- | --------------------------------------------     |
+| token | string | path | **Required**. The device's authentication token. |
+| software_title_id | integer    | path | **Required**. The software title's ID.           |
+
+#### Example
+
+`POST /api/v1/fleet/device/22aada07-dc73-41f2-8452-c0987543fd29/software/uninstall/123`
 
 ##### Default response
 

--- a/ee/server/service/software_installers.go
+++ b/ee/server/service/software_installers.go
@@ -1246,8 +1246,10 @@ func (svc *Service) UninstallSoftwareTitle(ctx context.Context, hostID uint, sof
 		// if error is because the host does not exist, check first if the user
 		// had access to install/uninstall software (to prevent leaking valid host ids).
 		if fleet.IsNotFound(err) {
-			if err := svc.authz.Authorize(ctx, &fleet.HostSoftwareInstallerResultAuthz{}, fleet.ActionWrite); err != nil {
-				return err
+			if !svc.authz.IsAuthenticatedWith(ctx, authz_ctx.AuthnDeviceToken) {
+				if err := svc.authz.Authorize(ctx, &fleet.HostSoftwareInstallerResultAuthz{}, fleet.ActionWrite); err != nil {
+					return err
+				}
 			}
 		}
 		svc.authz.SkipAuthorization(ctx)
@@ -1268,8 +1270,10 @@ func (svc *Service) UninstallSoftwareTitle(ctx context.Context, hostID uint, sof
 	}
 
 	// authorize with the host's team
-	if err := svc.authz.Authorize(ctx, &fleet.HostSoftwareInstallerResultAuthz{HostTeamID: host.TeamID}, fleet.ActionWrite); err != nil {
-		return err
+	if !svc.authz.IsAuthenticatedWith(ctx, authz_ctx.AuthnDeviceToken) {
+		if err := svc.authz.Authorize(ctx, &fleet.HostSoftwareInstallerResultAuthz{HostTeamID: host.TeamID}, fleet.ActionWrite); err != nil {
+			return err
+		}
 	}
 
 	installer, err := svc.ds.GetSoftwareInstallerMetadataByTeamAndTitleID(ctx, host.TeamID, softwareTitleID, false)
@@ -2164,112 +2168,6 @@ func (svc *Service) SelfServiceInstallSoftwareTitle(ctx context.Context, host *f
 		SelfService: true,
 	})
 	return err
-}
-
-func (svc *Service) SelfServiceUninstallSoftwareTitle(ctx context.Context, host *fleet.Host, softwareTitleID uint) error {
-	if host.OrbitNodeKey == nil || *host.OrbitNodeKey == "" {
-		// fleetd is required to uninstall software so if the host is enrolled via plain osquery we return an error
-		return fleet.NewUserMessageError(errors.New("host does not have fleetd installed"), http.StatusUnprocessableEntity)
-	}
-
-	// If scripts are disabled (according to the last detail query), we return an error.
-	// host.ScriptsEnabled may be nil for older orbit versions.
-	if host.ScriptsEnabled != nil && !*host.ScriptsEnabled {
-		return fleet.NewUserMessageError(errors.New(fleet.RunScriptsOrbitDisabledErrMsg), http.StatusUnprocessableEntity)
-	}
-
-	installer, err := svc.ds.GetSoftwareInstallerMetadataByTeamAndTitleID(ctx, host.TeamID, softwareTitleID, false)
-	if err != nil {
-		if fleet.IsNotFound(err) {
-			return &fleet.BadRequestError{
-				Message: "Couldn't uninstall software. Software title is not available for uninstall. Please add software package to install/uninstall.",
-				InternalErr: ctxerr.WrapWithData(
-					ctx, err, "couldn't find an installer for software title",
-					map[string]any{"host_id": host.ID, "team_id": host.TeamID, "title_id": softwareTitleID},
-				),
-			}
-		}
-		return ctxerr.Wrap(ctx, err, "finding software installer for title")
-	}
-
-	if !installer.SelfService {
-		return &fleet.BadRequestError{
-			Message: "Software title is not available through self-service",
-			InternalErr: ctxerr.NewWithData(
-				ctx, "software title not available through self-service",
-				map[string]any{"host_id": host.ID, "team_id": host.TeamID, "title_id": softwareTitleID},
-			),
-		}
-	}
-
-	scoped, err := svc.ds.IsSoftwareInstallerLabelScoped(ctx, installer.InstallerID, host.ID)
-	if err != nil {
-		return ctxerr.Wrap(ctx, err, "checking label scoping during software uninstall attempt")
-	}
-
-	if !scoped {
-		return &fleet.BadRequestError{
-			Message: "Couldn't uninstall. Host isn't member of the labels defined for this software title.",
-		}
-	}
-
-	lastInstallRequest, err := svc.ds.GetHostLastInstallData(ctx, host.ID, installer.InstallerID)
-	if err != nil {
-		return ctxerr.Wrapf(ctx, err, "getting last install data for host %d and installer %d", host.ID, installer.InstallerID)
-	}
-	if lastInstallRequest != nil && lastInstallRequest.Status != nil &&
-		(*lastInstallRequest.Status == fleet.SoftwareInstallPending || *lastInstallRequest.Status == fleet.SoftwareUninstallPending) {
-		return &fleet.BadRequestError{
-			Message: "Couldn't uninstall software. Host has a pending install/uninstall request.",
-			InternalErr: ctxerr.WrapWithData(
-				ctx, err, "host already has a pending install/uninstall for this installer",
-				map[string]any{
-					"host_id":               host.ID,
-					"software_installer_id": installer.InstallerID,
-					"team_id":               host.TeamID,
-					"title_id":              softwareTitleID,
-					"status":                *lastInstallRequest.Status,
-				},
-			),
-		}
-	}
-
-	// Validate platform
-	ext := filepath.Ext(installer.Name)
-	requiredPlatform := packageExtensionToPlatform(ext)
-	if requiredPlatform == "" {
-		// this should never happen
-		return ctxerr.Errorf(ctx, "software installer has unsupported type %s", ext)
-	}
-
-	if host.FleetPlatform() != requiredPlatform {
-		return &fleet.BadRequestError{
-			Message: fmt.Sprintf("Package (%s) can be uninstalled only on %s hosts.", ext, requiredPlatform),
-			InternalErr: ctxerr.NewWithData(
-				ctx, "invalid host platform for requested uninstall",
-				map[string]any{"host_id": host.ID, "team_id": host.TeamID, "title_id": installer.TitleID},
-			),
-		}
-	}
-
-	// Get the uninstall script to validate there is one, will use the standard
-	// script infrastructure to run it.
-	_, err = svc.ds.GetAnyScriptContents(ctx, installer.UninstallScriptContentID)
-	if err != nil {
-		if fleet.IsNotFound(err) {
-			return ctxerr.Wrap(ctx,
-				fleet.NewInvalidArgumentError("software_title_id", `No uninstall script exists for the provided "software_title_id".`).
-					WithStatus(http.StatusNotFound), "getting uninstall script contents")
-		}
-		return err
-	}
-
-	// Pending uninstalls will automatically show up in the UI Host Details -> Activity -> Upcoming tab.
-	execID := uuid.NewString()
-	if err = svc.insertSoftwareUninstallRequest(ctx, execID, host, installer); err != nil {
-		return err
-	}
-	return nil
 }
 
 // packageExtensionToPlatform returns the platform name based on the

--- a/server/datastore/mysql/software_installers.go
+++ b/server/datastore/mysql/software_installers.go
@@ -1044,10 +1044,8 @@ VALUES
 	}
 
 	var userID *uint
-	fleetInitiated := true
 	if ctxUser := authz.UserFromContext(ctx); ctxUser != nil {
 		userID = &ctxUser.ID
-		fleetInitiated = false
 	}
 
 	err = ds.withRetryTxx(ctx, func(tx sqlx.ExtContext) error {
@@ -1055,7 +1053,7 @@ VALUES
 			hostID,
 			0, // Uninstalls are never used in setup experience, so always default priority
 			userID,
-			fleetInitiated,
+			false,
 			executionID,
 			installerDetails.TitleName,
 			userID,

--- a/server/fleet/service.go
+++ b/server/fleet/service.go
@@ -694,10 +694,6 @@ type Service interface {
 	// initiated by the user
 	SelfServiceInstallSoftwareTitle(ctx context.Context, host *Host, softwareTitleID uint) error
 
-	// SelfServiceUninstallSoftwareTitle uninstalls a software title
-	// initiated by the user
-	SelfServiceUninstallSoftwareTitle(ctx context.Context, host *Host, softwareTitleID uint) error
-
 	// HasSelfServiceSoftwareInstallers returns whether the host has self-service software installers
 	HasSelfServiceSoftwareInstallers(ctx context.Context, host *Host) (bool, error)
 

--- a/server/fleet/service.go
+++ b/server/fleet/service.go
@@ -694,6 +694,10 @@ type Service interface {
 	// initiated by the user
 	SelfServiceInstallSoftwareTitle(ctx context.Context, host *Host, softwareTitleID uint) error
 
+	// SelfServiceUninstallSoftwareTitle uninstalls a software title
+	// initiated by the user
+	SelfServiceUninstallSoftwareTitle(ctx context.Context, host *Host, softwareTitleID uint) error
+
 	// HasSelfServiceSoftwareInstallers returns whether the host has self-service software installers
 	HasSelfServiceSoftwareInstallers(ctx context.Context, host *Host) (bool, error)
 

--- a/server/service/handler.go
+++ b/server/service/handler.go
@@ -806,6 +806,9 @@ func attachFleetAPIRoutes(r *mux.Router, svc fleet.Service, config config.FleetC
 		errorLimiter.Limit("install_self_service", desktopQuota),
 	).POST("/api/_version_/fleet/device/{token}/software/install/{software_title_id}", submitSelfServiceSoftwareInstall, fleetSelfServiceSoftwareInstallRequest{})
 	de.WithCustomMiddleware(
+		errorLimiter.Limit("uninstall_self_service", desktopQuota),
+	).POST("/api/_version_/fleet/device/{token}/software/uninstall/{software_title_id}", submitSelfServiceSoftwareUninstall, fleetSelfServiceSoftwareUninstallRequest{})
+	de.WithCustomMiddleware(
 		errorLimiter.Limit("get_device_software_install_results", desktopQuota),
 	).GET("/api/_version_/fleet/device/{token}/software/install/{install_uuid}/results", getDeviceSoftwareInstallResultsEndpoint,
 		getDeviceSoftwareInstallResultsRequest{})

--- a/server/service/handler.go
+++ b/server/service/handler.go
@@ -807,7 +807,7 @@ func attachFleetAPIRoutes(r *mux.Router, svc fleet.Service, config config.FleetC
 	).POST("/api/_version_/fleet/device/{token}/software/install/{software_title_id}", submitSelfServiceSoftwareInstall, fleetSelfServiceSoftwareInstallRequest{})
 	de.WithCustomMiddleware(
 		errorLimiter.Limit("uninstall_self_service", desktopQuota),
-	).POST("/api/_version_/fleet/device/{token}/software/uninstall/{software_title_id}", submitSelfServiceSoftwareUninstall, fleetSelfServiceSoftwareUninstallRequest{})
+	).POST("/api/_version_/fleet/device/{token}/software/uninstall/{software_title_id}", submitDeviceSoftwareUninstall, fleetDeviceSoftwareUninstallRequest{})
 	de.WithCustomMiddleware(
 		errorLimiter.Limit("get_device_software_install_results", desktopQuota),
 	).GET("/api/_version_/fleet/device/{token}/software/install/{install_uuid}/results", getDeviceSoftwareInstallResultsEndpoint,

--- a/server/service/software_installers.go
+++ b/server/service/software_installers.go
@@ -775,43 +775,35 @@ func (svc *Service) SelfServiceInstallSoftwareTitle(ctx context.Context, host *f
 	return fleet.ErrMissingLicense
 }
 
-type fleetSelfServiceSoftwareUninstallRequest struct {
+type fleetDeviceSoftwareUninstallRequest struct {
 	Token           string `url:"token"`
 	SoftwareTitleID uint   `url:"software_title_id"`
 }
 
-func (r *fleetSelfServiceSoftwareUninstallRequest) deviceAuthToken() string {
+func (r *fleetDeviceSoftwareUninstallRequest) deviceAuthToken() string {
 	return r.Token
 }
 
-type submitSelfServiceSoftwareUninstallResponse struct {
+type submitDeviceSoftwareUninstallResponse struct {
 	Err error `json:"error,omitempty"`
 }
 
-func (r submitSelfServiceSoftwareUninstallResponse) Error() error { return r.Err }
-func (r submitSelfServiceSoftwareUninstallResponse) Status() int  { return http.StatusAccepted }
+func (r submitDeviceSoftwareUninstallResponse) Error() error { return r.Err }
+func (r submitDeviceSoftwareUninstallResponse) Status() int  { return http.StatusAccepted }
 
-func submitSelfServiceSoftwareUninstall(ctx context.Context, request interface{}, svc fleet.Service) (fleet.Errorer, error) {
+func submitDeviceSoftwareUninstall(ctx context.Context, request interface{}, svc fleet.Service) (fleet.Errorer, error) {
 	host, ok := hostctx.FromContext(ctx)
 	if !ok {
 		err := ctxerr.Wrap(ctx, fleet.NewAuthRequiredError("internal error: missing host from request context"))
-		return submitSelfServiceSoftwareUninstallResponse{Err: err}, nil
+		return submitDeviceSoftwareUninstallResponse{Err: err}, nil
 	}
 
-	req := request.(*fleetSelfServiceSoftwareUninstallRequest)
-	if err := svc.SelfServiceUninstallSoftwareTitle(ctx, host, req.SoftwareTitleID); err != nil {
-		return submitSelfServiceSoftwareUninstallResponse{Err: err}, nil
+	req := request.(*fleetDeviceSoftwareUninstallRequest)
+	if err := svc.UninstallSoftwareTitle(ctx, host.ID, req.SoftwareTitleID); err != nil {
+		return submitDeviceSoftwareUninstallResponse{Err: err}, nil
 	}
 
-	return submitSelfServiceSoftwareUninstallResponse{}, nil
-}
-
-func (svc *Service) SelfServiceUninstallSoftwareTitle(ctx context.Context, host *fleet.Host, softwareTitleID uint) error {
-	// skipauth: No authorization check needed due to implementation returning
-	// only license error.
-	svc.authz.SkipAuthorization(ctx)
-
-	return fleet.ErrMissingLicense
+	return submitDeviceSoftwareUninstallResponse{}, nil
 }
 
 func (svc *Service) HasSelfServiceSoftwareInstallers(ctx context.Context, host *fleet.Host) (bool, error) {


### PR DESCRIPTION
For #28846. Intentionally not limited to self-service/in-scope apps, though we don't have any software listing changes in this PR to show more titles in the self-service list.

QA plan is a bit light due to ticket being underspec'd. Can figure out how we deal with that later.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/Committing-Changes.md#changes-files) for more information.
- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [x] Added/updated automated tests
- [ ] A detailed QA plan exists on the associated ticket (if it isn't there, work with the product group's QA engineer to add it)
- [x] Manual QA for all new/changed functionality