### PR TITLE
Fix #27888

### DIFF
--- a/changes/27888-CIS-issue
+++ b/changes/27888-CIS-issue
@@ -1,0 +1,2 @@
+* fixed a CIS query (Ensure Show Full Website Address in Safari Is Enabled)
+ 

--- a/ee/cis/macos-15/cis-policy-queries.yml
+++ b/ee/cis/macos-15/cis-policy-queries.yml
@@ -3401,8 +3401,7 @@ spec:
         SELECT 1 FROM managed_policies WHERE 
             domain='com.apple.Safari' AND 
             name='ShowFullURLInSmartSearchField' AND 
-            (value = 1 OR value = 'true') AND 
-            username = ''
+            (value = 1 OR value = 'true') 
         )
       AND NOT EXISTS (
         SELECT 1 FROM managed_policies WHERE 


### PR DESCRIPTION
This is fixing a misinterpretation of the [CIS document](https://drive.google.com/file/d/1Bq6GSn_wRMp2JKbYsRt51V5BXV1gizDp/view?usp=drive_link) for Macos 15/

In the doc search for:  "show full Website". 
The Audit bash script is:
```
% /usr/bin/sudo /usr/sbin/system_profiler SPConfigurationProfileDataType |
/usr/bin/grep ShowFullURLInSmartSearchField | /usr/bin/tr -d ' '

Result on my Mac:
ShowFullURLInSmartSearchField = 1;
```
This should be interpreted as 'Any user who has this setting is ok'. Not looking for an empty user.
We have 48 other occurrences that we will discuss outside the scope of this issue.

QA:
Applying the profile for my main user worked.
Adding a test user
The configuration was applied to it without the need to redeploy the profile.

--> Hence, we are good with the way CIS recommends auditing.

checking with a query finds both accounts with the proper settign:
![image](https://github.com/user-attachments/assets/258c4183-dc76-49aa-a022-63954f1733dc)



# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/Committing-Changes.md#changes-files) for more information.

