### PR TITLE
Cherry-Pick: Move fleet_maintained_app_id from title level to package level in software title list endpoint

### DIFF
--- a/server/datastore/mysql/software_titles.go
+++ b/server/datastore/mysql/software_titles.go
@@ -130,6 +130,7 @@ func (ds *Datastore) ListSoftwareTitles(
 		VPPAppPlatform            *string `db:"vpp_app_platform"`
 		VPPAppIconURL             *string `db:"vpp_app_icon_url"`
 		VPPInstallDuringSetup     *bool   `db:"vpp_install_during_setup"`
+		FleetMaintainedAppID      *uint   `db:"fleet_maintained_app_id"`
 	}
 	var softwareList []*softwareTitle
 	getTitlesStmt, args = appendListOptionsWithCursorToSQL(getTitlesStmt, args, &opt.ListOptions)
@@ -157,7 +158,7 @@ func (ds *Datastore) ListSoftwareTitles(
 	// build an index to quickly access a title by its ID
 	titleIndex := make(map[uint]int, len(softwareList))
 	for i, title := range softwareList {
-		// promote the package name and version to the proper destination fields
+		// promote software installer properties to their proper destination fields
 		if title.PackageName != nil {
 			var version string
 			if title.PackageVersion != nil {
@@ -169,12 +170,13 @@ func (ds *Datastore) ListSoftwareTitles(
 			}
 
 			title.SoftwarePackage = &fleet.SoftwarePackageOrApp{
-				Name:               *title.PackageName,
-				Version:            version,
-				Platform:           platform,
-				SelfService:        title.PackageSelfService,
-				PackageURL:         title.PackageURL,
-				InstallDuringSetup: title.PackageInstallDuringSetup,
+				Name:                 *title.PackageName,
+				Version:              version,
+				Platform:             platform,
+				SelfService:          title.PackageSelfService,
+				PackageURL:           title.PackageURL,
+				InstallDuringSetup:   title.PackageInstallDuringSetup,
+				FleetMaintainedAppID: title.FleetMaintainedAppID,
 			}
 		}
 

--- a/server/fleet/software.go
+++ b/server/fleet/software.go
@@ -239,9 +239,8 @@ type SoftwareTitleListResult struct {
 	// BundleIdentifier is used by Apple installers to uniquely identify
 	// the software installed. It's surfaced in software_titles to match
 	// with existing software entries.
-	BundleIdentifier     *string `json:"bundle_identifier,omitempty" db:"bundle_identifier"`
-	HashSHA256           *string `json:"hash_sha256,omitempty" db:"package_storage_id"`
-	FleetMaintainedAppID *uint   `json:"fleet_maintained_app_id,omitempty" db:"fleet_maintained_app_id"`
+	BundleIdentifier *string `json:"bundle_identifier,omitempty" db:"bundle_identifier"`
+	HashSHA256       *string `json:"hash_sha256,omitempty" db:"package_storage_id"`
 }
 
 type SoftwareTitleListOptions struct {

--- a/server/fleet/software_installer.go
+++ b/server/fleet/software_installer.go
@@ -532,8 +532,9 @@ type SoftwarePackageOrApp struct {
 	PackageURL    *string                `json:"package_url"`
 	// InstallDuringSetup is a boolean that indicates if the package
 	// will be installed during the macos setup experience.
-	InstallDuringSetup *bool    `json:"install_during_setup,omitempty" db:"install_during_setup"`
-	Categories         []string `json:"categories,omitempty"`
+	InstallDuringSetup   *bool    `json:"install_during_setup,omitempty" db:"install_during_setup"`
+	FleetMaintainedAppID *uint    `json:"fleet_maintained_app_id,omitempty" db:"fleet_maintained_app_id"`
+	Categories           []string `json:"categories,omitempty"`
 }
 
 type SoftwarePackageSpec struct {


### PR DESCRIPTION
Merged into `main` in #29033.