### PR TITLE
Drop assignees from FMA automated PRs

### DIFF
--- a/.github/workflows/ingest-maintained-apps.yml
+++ b/.github/workflows/ingest-maintained-apps.yml
@@ -93,7 +93,7 @@ jobs:
 
             Generated automatically with cmd/maintained-apps.
           body: Automated ingestion of latest Fleet-maintained app data.
-          assignees: ${{ steps.get_assignee_ids.outputs.github_ids }}
+#          assignees: ${{ steps.get_assignee_ids.outputs.github_ids }}
 
       - name: Close Existing PRs
         if: steps.search_pr.outputs.result != '[]'


### PR DESCRIPTION
Due to modifications in the Fleet-maintained apps update process, #g-software engineers are no longer the DRIs for moving update PRs along.