### PR TITLE
UI: Hide script contents for saved script run activity details

### DIFF
--- a/changes/27255-hide-script-content-for-saved-scripts
+++ b/changes/27255-hide-script-content-for-saved-scripts
@@ -1,0 +1,2 @@
+- To prevent misleading UI when a saved script's contents have changed, only show a run script
+  activity's script contents if the script run was ad-hoc

--- a/frontend/pages/DashboardPage/cards/ActivityFeed/components/RunScriptDetailsModal/RunScriptDetailsModal.tsx
+++ b/frontend/pages/DashboardPage/cards/ActivityFeed/components/RunScriptDetailsModal/RunScriptDetailsModal.tsx
@@ -119,10 +119,15 @@ const StatusMessage = ({
 interface IScriptOutputProps {
   output: string;
   hostname: string;
+  wasAdHoc: boolean;
 }
 
-const ScriptOutput = ({ output, hostname }: IScriptOutputProps) => {
-  return (
+const ScriptOutput = ({
+  output,
+  hostname,
+  wasAdHoc = false,
+}: IScriptOutputProps) => (
+  <div className={`${baseClass}__script-result`}>
     <Textarea
       label={
         <>
@@ -134,29 +139,15 @@ const ScriptOutput = ({ output, hostname }: IScriptOutputProps) => {
           >
             output recorded
           </TooltipWrapper>{" "}
-          when <b>{hostname}</b> ran the script above:
+          when <b>{hostname}</b> ran the script{wasAdHoc && " above"}:
         </>
       }
       variant="code"
     >
       {output}
     </Textarea>
-  );
-};
-
-interface IScriptResultProps {
-  hostname: string;
-  output: string;
-}
-
-const ScriptResult = ({ hostname, output }: IScriptResultProps) => {
-  return (
-    <div className={`${baseClass}__script-result`}>
-      <ScriptOutput output={output} hostname={hostname} />
-    </div>
-  );
-};
-
+  </div>
+);
 interface IRunScriptDetailsModalProps {
   scriptExecutionId: string;
   onCancel: () => void;
@@ -209,6 +200,7 @@ const RunScriptDetailsModal = ({
         data.exit_code === null && data.host_timeout === false;
       const showOutputText =
         !hostTimedOut && !scriptsDisabledForHost && !scriptStillRunning;
+      const ranAdHocScript = data.script_id === null;
 
       content = (
         <>
@@ -217,9 +209,13 @@ const RunScriptDetailsModal = ({
             exitCode={data.exit_code}
             message={data.output}
           />
-          <ScriptContent content={data.script_contents} />
+          {ranAdHocScript && <ScriptContent content={data.script_contents} />}
           {showOutputText && (
-            <ScriptResult hostname={data.hostname} output={data.output} />
+            <ScriptOutput
+              hostname={data.hostname}
+              output={data.output}
+              wasAdHoc={ranAdHocScript}
+            />
           )}
         </>
       );

--- a/frontend/services/entities/scripts.ts
+++ b/frontend/services/entities/scripts.ts
@@ -33,7 +33,7 @@ export interface IScriptResultResponse {
   host_id: number;
   execution_id: string;
   script_contents: string;
-  script_id: number;
+  script_id: number | null; // null for ad-hoc script run via API
   exit_code: number | null;
   output: string;
   message: string;


### PR DESCRIPTION
## For #27255 

- Hide script contents when a saved script was run
- Clean up code

<img width="1276" alt="Screenshot 2025-05-12 at 3 39 32 PM" src="https://github.com/user-attachments/assets/e057820e-3db0-4ac0-be7c-38abf20cfadc" />


- [x] Changes file added for user-visible changes in `changes/`
- [x] Manual QA for all new/changed functionality
