### PR TITLE
Error when deleting non managed GitOps labels #28440

### DIFF
--- a/changes/28440-deleting-non-managed-gitops-labels
+++ b/changes/28440-deleting-non-managed-gitops-labels
@@ -1,0 +1,1 @@
+* Fixed issue with the gitops command that prevented non-managed labels to be deleted if used by software installations.

--- a/cmd/fleetctl/integrationtest/gitops/gitops_integration_test.go
+++ b/cmd/fleetctl/integrationtest/gitops/gitops_integration_test.go
@@ -220,5 +220,4 @@ func (s *integrationGitopsTestSuite) TestFleetGitopsWithFleetSecrets() {
 	winProfile, err := s.DS.GetMDMWindowsConfigProfile(ctx, windowsProfileUUID)
 	require.NoError(t, err)
 	assert.Contains(t, string(winProfile.SyncML), "${FLEET_SECRET_"+secretName2+"}")
-
 }

--- a/server/service/client.go
+++ b/server/service/client.go
@@ -1592,7 +1592,7 @@ func (c *Client) DoGitOps(
 	dryRun bool,
 	teamDryRunAssumptions *fleet.TeamSpecsDryRunAssumptions,
 	appConfig *fleet.EnrichedAppConfig,
-// pass-by-ref to build lists
+	// pass-by-ref to build lists
 	teamsSoftwareInstallers map[string][]fleet.SoftwarePackageResponse,
 	teamsVPPApps map[string][]fleet.VPPAppResponse,
 	teamsScripts map[string][]fleet.ScriptResponse,

--- a/server/service/client.go
+++ b/server/service/client.go
@@ -2161,12 +2161,13 @@ func (c *Client) doGitOpsLabels(config *spec.GitOps, logFn func(format string, a
 		if numUpdates > 0 {
 			logFn("[+] would've updated %d label%s\n", numUpdates, pluralize(numUpdates, "", "s"))
 		}
-	} else {
-		logFn("[+] syncing %d label%s (%d new and %d updated)\n", len(config.Labels), pluralize(len(config.Labels), "", "s"), len(config.Labels)-numUpdates, numUpdates)
-		err = c.ApplyLabels(config.Labels)
-		if err != nil {
-			return nil, err
-		}
+		return nil, nil
+	}
+
+	logFn("[+] syncing %d label%s (%d new and %d updated)\n", len(config.Labels), pluralize(len(config.Labels), "", "s"), len(config.Labels)-numUpdates, numUpdates)
+	err = c.ApplyLabels(config.Labels)
+	if err != nil {
+		return nil, err
 	}
 	return labelsToDelete, nil
 }

--- a/server/service/client.go
+++ b/server/service/client.go
@@ -1592,11 +1592,11 @@ func (c *Client) DoGitOps(
 	dryRun bool,
 	teamDryRunAssumptions *fleet.TeamSpecsDryRunAssumptions,
 	appConfig *fleet.EnrichedAppConfig,
-	// pass-by-ref to build lists
+// pass-by-ref to build lists
 	teamsSoftwareInstallers map[string][]fleet.SoftwarePackageResponse,
 	teamsVPPApps map[string][]fleet.VPPAppResponse,
 	teamsScripts map[string][]fleet.ScriptResponse,
-) (*fleet.TeamSpecsDryRunAssumptions, error) {
+) (*fleet.TeamSpecsDryRunAssumptions, []func() error, error) {
 	baseDir := filepath.Dir(fullFilename)
 	filename := filepath.Base(fullFilename)
 	var teamAssumptions *fleet.TeamSpecsDryRunAssumptions
@@ -1613,6 +1613,9 @@ func (c *Client) DoGitOps(
 	}
 	var mdmAppConfig map[string]interface{}
 	var team map[string]interface{}
+
+	var postOps []func() error
+
 	if config.TeamName == nil {
 		group.AppConfig = config.OrgSettings
 		group.EnrollSecret = &fleet.EnrollSecretSpec{Secrets: config.OrgSettings["secrets"].([]*fleet.EnrollSecret)}
@@ -1621,10 +1624,19 @@ func (c *Client) DoGitOps(
 
 		// Labels
 		if config.Labels == nil || len(config.Labels) > 0 {
-			err = c.doGitOpsLabels(config, logFn, dryRun)
+			labelsToDelete, err := c.doGitOpsLabels(config, logFn, dryRun)
 			if err != nil {
-				return nil, err
+				return nil, nil, err
 			}
+			postOps = append(postOps, func() error {
+				for _, labelToDelete := range labelsToDelete {
+					logFn("[-] deleting label '%s'\n", labelToDelete)
+					if err := c.DeleteLabel(labelToDelete); err != nil {
+						return err
+					}
+				}
+				return nil
+			})
 		}
 
 		// Integrations
@@ -1636,7 +1648,7 @@ func (c *Client) DoGitOps(
 		}
 		integrations, ok = integrations.(map[string]interface{})
 		if !ok {
-			return nil, errors.New("org_settings.integrations config is not a map")
+			return nil, nil, errors.New("org_settings.integrations config is not a map")
 		}
 		if jira, ok := integrations.(map[string]interface{})["jira"]; !ok || jira == nil {
 			integrations.(map[string]interface{})["jira"] = []interface{}{}
@@ -1652,7 +1664,7 @@ func (c *Client) DoGitOps(
 			integrations.(map[string]interface{})["ndes_scep_proxy"] = nil
 		} else {
 			if _, ok = ndesSCEPProxy.(map[string]interface{}); !ok {
-				return nil, errors.New("org_settings.integrations.ndes_scep_proxy config is not a map")
+				return nil, nil, errors.New("org_settings.integrations.ndes_scep_proxy config is not a map")
 			}
 		}
 		if digicertIntegration, ok := integrations.(map[string]interface{})["digicert"]; !ok || digicertIntegration == nil {
@@ -1661,12 +1673,12 @@ func (c *Client) DoGitOps(
 			// We unmarshal DigiCert integration into its dedicated type for additional validation.
 			digicertJSON, err := json.Marshal(integrations.(map[string]interface{})["digicert"])
 			if err != nil {
-				return nil, fmt.Errorf("org_settings.integrations.digicert cannot be marshalled into JSON: %w", err)
+				return nil, nil, fmt.Errorf("org_settings.integrations.digicert cannot be marshalled into JSON: %w", err)
 			}
 			var digicertData optjson.Slice[fleet.DigiCertIntegration]
 			err = json.Unmarshal(digicertJSON, &digicertData)
 			if err != nil {
-				return nil, fmt.Errorf("org_settings.integrations.digicert cannot be parsed: %w", err)
+				return nil, nil, fmt.Errorf("org_settings.integrations.digicert cannot be parsed: %w", err)
 			}
 			integrations.(map[string]interface{})["digicert"] = digicertData
 		}
@@ -1676,12 +1688,12 @@ func (c *Client) DoGitOps(
 			// We unmarshal Custom SCEP integration into its dedicated type for additional validation
 			custonSCEPJSON, err := json.Marshal(integrations.(map[string]interface{})["custom_scep_proxy"])
 			if err != nil {
-				return nil, fmt.Errorf("org_settings.integrations.custom_scep_proxy cannot be marshalled into JSON: %w", err)
+				return nil, nil, fmt.Errorf("org_settings.integrations.custom_scep_proxy cannot be marshalled into JSON: %w", err)
 			}
 			var customSCEPData optjson.Slice[fleet.CustomSCEPProxyIntegration]
 			err = json.Unmarshal(custonSCEPJSON, &customSCEPData)
 			if err != nil {
-				return nil, fmt.Errorf("org_settings.integrations.custom_scep_proxy cannot be parsed: %w", err)
+				return nil, nil, fmt.Errorf("org_settings.integrations.custom_scep_proxy cannot be parsed: %w", err)
 			}
 			integrations.(map[string]interface{})["custom_scep_proxy"] = customSCEPData
 		}
@@ -1738,7 +1750,7 @@ func (c *Client) DoGitOps(
 		}
 		mdmAppConfig, ok = mdmConfig.(map[string]interface{})
 		if !ok {
-			return nil, errors.New("org_settings.mdm config is not a map")
+			return nil, nil, errors.New("org_settings.mdm config is not a map")
 		}
 
 		if _, ok := mdmAppConfig["apple_bm_default_team"]; !ok && appConfig.License.IsPremium() {
@@ -1831,14 +1843,14 @@ func (c *Client) DoGitOps(
 		team["integrations"] = integrations
 		_, ok = integrations.(map[string]interface{})
 		if !ok {
-			return nil, errors.New("team_settings.integrations config is not a map")
+			return nil, nil, errors.New("team_settings.integrations config is not a map")
 		}
 		if googleCal, ok := integrations.(map[string]interface{})["google_calendar"]; !ok || googleCal == nil {
 			integrations.(map[string]interface{})["google_calendar"] = map[string]interface{}{}
 		} else {
 			_, ok = googleCal.(map[string]interface{})
 			if !ok {
-				return nil, errors.New("team_settings.integrations.google_calendar config is not a map")
+				return nil, nil, errors.New("team_settings.integrations.google_calendar config is not a map")
 			}
 		}
 
@@ -1936,7 +1948,7 @@ func (c *Client) DoGitOps(
 			team["gitops_filename"] = filename
 			rawTeam, err := json.Marshal(team)
 			if err != nil {
-				return nil, fmt.Errorf("error marshalling team spec: %w", err)
+				return nil, nil, fmt.Errorf("error marshalling team spec: %w", err)
 			}
 			group.Teams = []json.RawMessage{rawTeam}
 			group.TeamsDryRunAssumptions = teamDryRunAssumptions
@@ -1951,7 +1963,7 @@ func (c *Client) DoGitOps(
 		ExpandEnvConfigProfiles: true,
 	}, teamsSoftwareInstallers, teamsVPPApps, teamsScripts)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	var teamSoftwareInstallers []fleet.SoftwarePackageResponse
@@ -1961,15 +1973,15 @@ func (c *Client) DoGitOps(
 	if config.TeamName != nil {
 		if !config.IsNoTeam() {
 			if len(teamIDsByName) != 1 {
-				return nil, fmt.Errorf("expected 1 team spec to be applied, got %d", len(teamIDsByName))
+				return nil, nil, fmt.Errorf("expected 1 team spec to be applied, got %d", len(teamIDsByName))
 			}
 			teamID, ok := teamIDsByName[*config.TeamName]
 			if ok && teamID == 0 {
 				if dryRun {
 					logFn("[+] would've added any policies/queries to new team %s\n", *config.TeamName)
-					return nil, nil
+					return nil, postOps, nil
 				}
-				return nil, fmt.Errorf("team %s not created", *config.TeamName)
+				return nil, nil, fmt.Errorf("team %s not created", *config.TeamName)
 			}
 			for _, teamID = range teamIDsByName {
 				config.TeamID = &teamID
@@ -1980,7 +1992,7 @@ func (c *Client) DoGitOps(
 		} else {
 			noTeamSoftwareInstallers, noTeamVPPApps, err := c.doGitOpsNoTeamSetupAndSoftware(config, baseDir, appConfig, logFn, dryRun)
 			if err != nil {
-				return nil, err
+				return nil, nil, err
 			}
 			teamSoftwareInstallers = noTeamSoftwareInstallers
 			teamVPPApps = noTeamVPPApps
@@ -1990,7 +2002,7 @@ func (c *Client) DoGitOps(
 
 	err = c.doGitOpsPolicies(config, teamSoftwareInstallers, teamVPPApps, teamScripts, logFn, dryRun)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	// We currently don't support queries for "No team" thus
@@ -1998,11 +2010,11 @@ func (c *Client) DoGitOps(
 	if !config.IsNoTeam() {
 		err = c.doGitOpsQueries(config, logFn, dryRun)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 	}
 
-	return teamAssumptions, nil
+	return teamAssumptions, postOps, nil
 }
 
 func (c *Client) doGitOpsNoTeamSetupAndSoftware(
@@ -2121,10 +2133,10 @@ func pluralize(count int, ifSingle string, ifPlural string) string {
 	return ifPlural
 }
 
-func (c *Client) doGitOpsLabels(config *spec.GitOps, logFn func(format string, args ...interface{}), dryRun bool) error {
+func (c *Client) doGitOpsLabels(config *spec.GitOps, logFn func(format string, args ...interface{}), dryRun bool) ([]string, error) {
 	persistedLabels, err := c.GetLabels()
 	if err != nil {
-		return err
+		return nil, err
 	}
 	var numUpdates int
 	var labelsToDelete []string
@@ -2153,18 +2165,10 @@ func (c *Client) doGitOpsLabels(config *spec.GitOps, logFn func(format string, a
 		logFn("[+] syncing %d label%s (%d new and %d updated)\n", len(config.Labels), pluralize(len(config.Labels), "", "s"), len(config.Labels)-numUpdates, numUpdates)
 		err = c.ApplyLabels(config.Labels)
 		if err != nil {
-			return err
-		}
-
-		for _, labelToDelete := range labelsToDelete {
-			logFn("[-] deleting label '%s'\n", labelToDelete)
-			err = c.DeleteLabel(labelToDelete)
-			if err != nil {
-				return err
-			}
+			return nil, err
 		}
 	}
-	return nil
+	return labelsToDelete, nil
 }
 
 func (c *Client) doGitOpsPolicies(config *spec.GitOps, teamSoftwareInstallers []fleet.SoftwarePackageResponse, teamVPPApps []fleet.VPPAppResponse, teamScripts []fleet.ScriptResponse, logFn func(format string, args ...interface{}), dryRun bool) error {

--- a/server/service/client_test.go
+++ b/server/service/client_test.go
@@ -800,7 +800,7 @@ func TestGitOpsErrors(t *testing.T) {
 			err = json.Unmarshal([]byte(tt.rawJSON), &config.OrgSettings)
 			require.NoError(t, err)
 			config.OrgSettings["secrets"] = []*fleet.EnrollSecret{}
-			_, err = client.DoGitOps(ctx, config, "/filename", nil, false, nil, nil, nil, nil, nil)
+			_, _, err = client.DoGitOps(ctx, config, "/filename", nil, false, nil, nil, nil, nil, nil)
 			assert.ErrorContains(t, err, tt.wantErr)
 		})
 	}


### PR DESCRIPTION
Fixes #28440 

When running GitOps, delete any non-managed labels as the last step to avoid any DB constraint issues.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/Committing-Changes.md#changes-files) for more information.
- [X] Added/updated automated tests
- [X] Manual QA for all new/changed functionality