### PR TITLE
allow turning off mdm for iphone and ipad hosts

### DIFF
--- a/changes/issue-23784-turn-off-mdm-iphone-ipad
+++ b/changes/issue-23784-turn-off-mdm-iphone-ipad
@@ -1,0 +1,1 @@
+- add ability to turn off mdm for iphone and ipad hosts on the hosts details page

--- a/frontend/pages/hosts/details/HostDetailsPage/HostActionsDropdown/HostActionsDropdown.tests.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/HostActionsDropdown/HostActionsDropdown.tests.tsx
@@ -1230,7 +1230,6 @@ describe("Host Actions Dropdown", () => {
       expect(
         screen.queryByText("Show disk encryption key")
       ).not.toBeInTheDocument();
-      expect(screen.queryByText("Turn off MDM")).not.toBeInTheDocument();
       expect(screen.queryByText("Lock")).not.toBeInTheDocument();
     });
 
@@ -1270,7 +1269,6 @@ describe("Host Actions Dropdown", () => {
       expect(
         screen.queryByText("Show disk encryption key")
       ).not.toBeInTheDocument();
-      expect(screen.queryByText("Turn off MDM")).not.toBeInTheDocument();
       expect(screen.queryByText("Lock")).not.toBeInTheDocument();
     });
   });

--- a/frontend/pages/hosts/details/HostDetailsPage/HostActionsDropdown/helpers.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/HostActionsDropdown/helpers.tsx
@@ -89,7 +89,7 @@ const canTransferTeam = (config: IHostActionConfigOptions) => {
   return isPremiumTier && (isGlobalAdmin || isGlobalMaintainer);
 };
 
-const canEditMdm = (config: IHostActionConfigOptions) => {
+const canTurnOffMdm = (config: IHostActionConfigOptions) => {
   const {
     hostPlatform,
     isGlobalAdmin,
@@ -102,7 +102,7 @@ const canEditMdm = (config: IHostActionConfigOptions) => {
   } = config;
   return (
     !isAndroid(hostPlatform) && // TODO(android): confirm can't turn off MDM for windows, iOS, iPadOS?
-    hostPlatform === "darwin" &&
+    isAppleDevice(hostPlatform) &&
     isMacMdmEnabledAndConfigured &&
     isEnrolledInMdm &&
     isConnectedToFleetMdm &&
@@ -257,7 +257,7 @@ const removeUnavailableOptions = (
     options = options.filter((option) => option.value !== "diskEncryption");
   }
 
-  if (!canEditMdm(config)) {
+  if (!canTurnOffMdm(config)) {
     options = options.filter((option) => option.value !== "mdmOff");
   }
 
@@ -386,7 +386,6 @@ const modifyOptions = (
  * many variations of the options that are shown/not shown or disabled/enabled
  * which are all controlled by the configurations options argument.
  */
-// eslint-disable-next-line import/prefer-default-export
 export const generateHostActionOptions = (config: IHostActionConfigOptions) => {
   // deep clone to always start with a fresh copy of the default options.
   let options: IDropdownOption[] = cloneDeep([...DEFAULT_OPTIONS]);

--- a/frontend/pages/hosts/details/HostDetailsPage/HostActionsDropdown/helpers.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/HostActionsDropdown/helpers.tsx
@@ -7,6 +7,7 @@ import {
   isAppleDevice,
   isMobilePlatform,
   isAndroid,
+  isIPadOrIPhone,
 } from "interfaces/platform";
 import { isScriptSupportedPlatform } from "interfaces/script";
 
@@ -339,7 +340,7 @@ const modifyOptions = (
 
   let optionsToDisable: IDropdownOption[] = [];
   if (
-    !isHostOnline ||
+    (!isIPadOrIPhone(hostPlatform) && !isHostOnline) ||
     isDeviceStatusUpdating(hostMdmDeviceStatus) ||
     hostMdmDeviceStatus === "locked" ||
     hostMdmDeviceStatus === "wiped"

--- a/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
@@ -1160,7 +1160,12 @@ const HostDetailsPage = ({
           />
         )}
         {showUnenrollMdmModal && !!host && (
-          <UnenrollMdmModal hostId={host.id} onClose={toggleUnenrollMdmModal} />
+          <UnenrollMdmModal
+            hostId={host.id}
+            hostPlatform={host.platform}
+            hostName={host.display_name}
+            onClose={toggleUnenrollMdmModal}
+          />
         )}
         {showDiskEncryptionModal && host && (
           <DiskEncryptionKeyModal

--- a/frontend/pages/hosts/details/HostDetailsPage/modals/UnenrollMdmModal/UnenrollMdmModal.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/modals/UnenrollMdmModal/UnenrollMdmModal.tsx
@@ -38,12 +38,10 @@ const UnenrollMdmModal = ({
         "success",
         "Turning off MDM or will turn off when the host comes online."
       );
-      onClose();
     } catch (unenrollMdmError: unknown) {
       renderFlash("error", "Couldn't turn off MDM. Please try again.");
-      console.log(unenrollMdmError);
-      onClose();
     }
+    onClose();
   };
 
   const renderModalContent = () => {

--- a/frontend/pages/hosts/details/HostDetailsPage/modals/UnenrollMdmModal/UnenrollMdmModal.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/modals/UnenrollMdmModal/UnenrollMdmModal.tsx
@@ -6,15 +6,24 @@ import Modal from "components/Modal";
 import { NotificationContext } from "context/notification";
 
 import mdmAPI from "services/entities/mdm";
+import { isIPadOrIPhone } from "interfaces/platform";
+import CustomLink from "components/CustomLink";
 
 interface IUnenrollMdmModalProps {
   hostId: number;
+  hostPlatform: string;
+  hostName: string;
   onClose: () => void;
 }
 
 const baseClass = "unenroll-mdm-modal";
 
-const UnenrollMdmModal = ({ hostId, onClose }: IUnenrollMdmModalProps) => {
+const UnenrollMdmModal = ({
+  hostId,
+  hostPlatform,
+  hostName,
+  onClose,
+}: IUnenrollMdmModalProps) => {
   const [requestState, setRequestState] = useState<
     undefined | "unenrolling" | "error"
   >(undefined);
@@ -41,14 +50,30 @@ const UnenrollMdmModal = ({ hostId, onClose }: IUnenrollMdmModalProps) => {
     if (requestState === "error") {
       return <DataError />;
     }
+
+    const turnOnMDMInstructions = isIPadOrIPhone(hostPlatform) ? (
+      <>
+        invite the end user to{" "}
+        <CustomLink
+          text="enroll a BYOD iPhone or iPad"
+          url="https://fleetdm.com/guides/enroll-byod-ios-ipados-hosts"
+          newTab
+        />
+      </>
+    ) : (
+      <>
+        ask the device user to follow the <b>Turn on MDM</b> instructions on
+        their <b>My device</b> page.
+      </>
+    );
+
     return (
       <>
         <p className={`${baseClass}__description`}>
           Settings configured by Fleet will be removed.
           <br />
           <br />
-          To turn on MDM again, ask the device user to follow the{" "}
-          <b>Turn on MDM</b> instructions on their <b>My device</b> page.
+          To turn on MDM again, {turnOnMDMInstructions}
         </p>
         <div className="modal-cta-wrap">
           <Button
@@ -72,7 +97,7 @@ const UnenrollMdmModal = ({ hostId, onClose }: IUnenrollMdmModalProps) => {
       title="Turn off MDM"
       onExit={onClose}
       className={baseClass}
-      width="large"
+      width="medium"
     >
       {renderModalContent()}
     </Modal>

--- a/frontend/pages/hosts/details/HostDetailsPage/modals/UnenrollMdmModal/UnenrollMdmModal.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/modals/UnenrollMdmModal/UnenrollMdmModal.tsx
@@ -36,10 +36,18 @@ const UnenrollMdmModal = ({
       await mdmAPI.unenrollHostFromMdm(hostId, 5000);
       renderFlash(
         "success",
-        "Turning off MDM or will turn off when the host comes online."
+        <>
+          MDM will be turned off for <b>{hostName}</b> next time this host
+          checks in.
+        </>
       );
     } catch (unenrollMdmError: unknown) {
-      renderFlash("error", "Couldn't turn off MDM. Please try again.");
+      renderFlash(
+        "error",
+        <>
+          Failed to turn off MDM for <b>{hostName}</b>.
+        </>
+      );
     }
     onClose();
   };

--- a/server/fleet/errors.go
+++ b/server/fleet/errors.go
@@ -27,7 +27,6 @@ var (
 	AppleMDMNotConfiguredMessage         = "macOS MDM isn't turned on. Visit https://fleetdm.com/docs/using-fleet to learn how to turn on MDM."
 	AppleABMDefaultTeamDeprecatedMessage = "mdm.apple_bm_default_team has been deprecated. Please use the new mdm.apple_business_manager key documented here: https://fleetdm.com/learn-more-about/apple-business-manager-gitops"
 	CantTurnOffMDMForWindowsHostsMessage = "Can't turn off MDM for Windows hosts."
-	CantTurnOffMDMForIOSOrIPadOSMessage  = "Can't turn off MDM for iOS or iPadOS hosts. Use wipe instead."
 )
 
 // ErrWithStatusCode is an interface for errors that should set a specific HTTP

--- a/server/service/apple_mdm.go
+++ b/server/service/apple_mdm.go
@@ -674,9 +674,11 @@ func additionalCustomSCEPValidation(contents string, customSCEPVars *customSCEPV
 			if len(payloadChallenge) > maxValueCharsInError {
 				payloadChallenge = payloadChallenge[:maxValueCharsInError] + "..."
 			}
-			return &fleet.BadRequestError{Message: "Variable \"$FLEET_VAR_" +
-				fleet.FleetVarCustomSCEPChallengePrefix + ca + "\" must be in the SCEP certificate's \"Challenge\" field.",
-				InternalErr: fmt.Errorf("Challenge: %s", payloadChallenge)}
+			return &fleet.BadRequestError{
+				Message: "Variable \"$FLEET_VAR_" +
+					fleet.FleetVarCustomSCEPChallengePrefix + ca + "\" must be in the SCEP certificate's \"Challenge\" field.",
+				InternalErr: fmt.Errorf("Challenge: %s", payloadChallenge),
+			}
 		}
 		urlPrefix := "FLEET_VAR_" + fleet.FleetVarCustomSCEPProxyURLPrefix
 		if scepPayloadContent.URL != "$"+urlPrefix+ca && scepPayloadContent.URL != "${"+urlPrefix+ca+"}" {
@@ -684,9 +686,11 @@ func additionalCustomSCEPValidation(contents string, customSCEPVars *customSCEPV
 			if len(payloadURL) > maxValueCharsInError {
 				payloadURL = payloadURL[:maxValueCharsInError] + "..."
 			}
-			return &fleet.BadRequestError{Message: "Variable \"$FLEET_VAR_" +
-				fleet.FleetVarCustomSCEPProxyURLPrefix + ca + "\" must be in the SCEP certificate's \"URL\" field.",
-				InternalErr: fmt.Errorf("URL: %s", payloadURL)}
+			return &fleet.BadRequestError{
+				Message: "Variable \"$FLEET_VAR_" +
+					fleet.FleetVarCustomSCEPProxyURLPrefix + ca + "\" must be in the SCEP certificate's \"URL\" field.",
+				InternalErr: fmt.Errorf("URL: %s", payloadURL),
+			}
 		}
 		foundCAs = append(foundCAs, ca)
 	}
@@ -809,9 +813,11 @@ func additionalNDESValidation(contents string, ndesVars *ndesVarsFound) error {
 		if len(payloadChallenge) > maxValueCharsInError {
 			payloadChallenge = payloadChallenge[:maxValueCharsInError] + "..."
 		}
-		return &fleet.BadRequestError{Message: "Variable \"$FLEET_VAR_" +
-			fleet.FleetVarNDESSCEPChallenge + "\" must be in the SCEP certificate's \"Challenge\" field.",
-			InternalErr: fmt.Errorf("Challenge: %s", payloadChallenge)}
+		return &fleet.BadRequestError{
+			Message: "Variable \"$FLEET_VAR_" +
+				fleet.FleetVarNDESSCEPChallenge + "\" must be in the SCEP certificate's \"Challenge\" field.",
+			InternalErr: fmt.Errorf("Challenge: %s", payloadChallenge),
+		}
 	}
 	ndesURL := "FLEET_VAR_" + fleet.FleetVarNDESSCEPProxyURL
 	if scepPayloadContent.URL != "$"+ndesURL && scepPayloadContent.URL != "${"+ndesURL+"}" {
@@ -819,9 +825,11 @@ func additionalNDESValidation(contents string, ndesVars *ndesVarsFound) error {
 		if len(payloadURL) > maxValueCharsInError {
 			payloadURL = payloadURL[:maxValueCharsInError] + "..."
 		}
-		return &fleet.BadRequestError{Message: "Variable \"$FLEET_VAR_" +
-			fleet.FleetVarNDESSCEPProxyURL + "\" must be in the SCEP certificate's \"URL\" field.",
-			InternalErr: fmt.Errorf("URL: %s", payloadURL)}
+		return &fleet.BadRequestError{
+			Message: "Variable \"$FLEET_VAR_" +
+				fleet.FleetVarNDESSCEPProxyURL + "\" must be in the SCEP certificate's \"URL\" field.",
+			InternalErr: fmt.Errorf("URL: %s", payloadURL),
+		}
 	}
 	return nil
 }
@@ -1987,12 +1995,6 @@ func (svc *Service) EnqueueMDMAppleCommandRemoveEnrollmentProfile(ctx context.Co
 	}
 
 	switch h.Platform {
-	case "ios":
-		fallthrough
-	case "ipados":
-		return &fleet.BadRequestError{
-			Message: fleet.CantTurnOffMDMForIOSOrIPadOSMessage,
-		}
 	case "windows":
 		return &fleet.BadRequestError{
 			Message: fleet.CantTurnOffMDMForWindowsHostsMessage,
@@ -4869,7 +4871,6 @@ func (n *ndesVarsFound) Found() bool {
 
 func (n *ndesVarsFound) RenewalOnly() bool {
 	return n != nil && !n.urlFound && !n.challengeFound && n.renewalIdFound
-
 }
 
 func (n *ndesVarsFound) ErrorMessage() string {

--- a/server/service/integration_mdm_test.go
+++ b/server/service/integration_mdm_test.go
@@ -14972,20 +14972,8 @@ func (s *integrationMDMTestSuite) TestWindowsMigrationEnabled() {
 
 func (s *integrationMDMTestSuite) TestHostsCantTurnMDMOff() {
 	t := s.T()
-	iOSHost, _ := s.createAppleMobileHostThenEnrollMDM("ios")
-	require.NoError(t, s.ds.SetOrUpdateMDMData(context.Background(), iOSHost.ID, false, true, "https://foo.com", true, "", ""))
-
-	r := s.Do("DELETE", fmt.Sprintf("/api/latest/fleet/hosts/%d/mdm", iOSHost.ID), nil, http.StatusBadRequest)
-	require.Contains(t, extractServerErrorText(r.Body), fleet.CantTurnOffMDMForIOSOrIPadOSMessage)
-
-	iPadOSHost, _ := s.createAppleMobileHostThenEnrollMDM("ipados")
-	require.NoError(t, s.ds.SetOrUpdateMDMData(context.Background(), iPadOSHost.ID, false, true, "https://foo.com", true, "", ""))
-
-	r = s.Do("DELETE", fmt.Sprintf("/api/latest/fleet/hosts/%d/mdm", iPadOSHost.ID), nil, http.StatusBadRequest)
-	require.Contains(t, extractServerErrorText(r.Body), fleet.CantTurnOffMDMForIOSOrIPadOSMessage)
-
 	winHost, _ := createWindowsHostThenEnrollMDM(s.ds, s.server.URL, t)
-	r = s.Do("DELETE", fmt.Sprintf("/api/latest/fleet/hosts/%d/mdm", winHost.ID), nil, http.StatusBadRequest)
+	r := s.Do("DELETE", fmt.Sprintf("/api/latest/fleet/hosts/%d/mdm", winHost.ID), nil, http.StatusBadRequest)
 	require.Contains(t, extractServerErrorText(r.Body), fleet.CantTurnOffMDMForWindowsHostsMessage)
 }
 


### PR DESCRIPTION
For [#23784](https://github.com/fleetdm/fleet/issues/23784)

This adds the "turn off mdm" option don't he host details page for iPhone and iPad devices.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
- [ ] Added/updated automated tests
- [ ] Manual QA for all new/changed functionality
