### PR TITLE
Fleet UI: Unreleased bug separating card from details summary component

### DIFF
--- a/frontend/pages/SoftwarePage/SoftwareOSDetailsPage/SoftwareOSDetailsPage.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareOSDetailsPage/SoftwareOSDetailsPage.tsx
@@ -164,17 +164,23 @@ const SoftwareOSDetailsPage = ({
           />
         ) : (
           <>
-            <SoftwareDetailsSummary
-              title={osVersionDetails.name}
-              hosts={osVersionDetails.hosts_count}
-              countsUpdatedAt={counts_updated_at}
-              queryParams={{
-                os_name: osVersionDetails.name_only,
-                os_version: osVersionDetails.version,
-                team_id: teamIdForApi,
-              }}
-              name={osVersionDetails.platform}
-            />
+            <Card
+              borderRadiusSize="xxlarge"
+              includeShadow
+              className={`${baseClass}__summary-section`}
+            >
+              <SoftwareDetailsSummary
+                title={osVersionDetails.name}
+                hosts={osVersionDetails.hosts_count}
+                countsUpdatedAt={counts_updated_at}
+                queryParams={{
+                  os_name: osVersionDetails.name_only,
+                  os_version: osVersionDetails.version,
+                  team_id: teamIdForApi,
+                }}
+                name={osVersionDetails.platform}
+              />
+            </Card>
             <Card
               borderRadiusSize="xxlarge"
               includeShadow

--- a/frontend/pages/SoftwarePage/SoftwareVersionDetailsPage/SoftwareVersionDetailsPage.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareVersionDetailsPage/SoftwareVersionDetailsPage.tsx
@@ -159,17 +159,23 @@ const SoftwareVersionDetailsPage = ({
           />
         ) : (
           <>
-            <SoftwareDetailsSummary
-              title={`${softwareVersion.name}, ${softwareVersion.version}`}
-              type={formatSoftwareType(softwareVersion)}
-              hosts={hostsCount ?? 0}
-              queryParams={{
-                software_version_id: softwareVersion.id,
-                team_id: teamIdForApi,
-              }}
-              name={softwareVersion.name}
-              source={softwareVersion.source}
-            />
+            <Card
+              borderRadiusSize="xxlarge"
+              includeShadow
+              className={`${baseClass}__summary-section`}
+            >
+              <SoftwareDetailsSummary
+                title={`${softwareVersion.name}, ${softwareVersion.version}`}
+                type={formatSoftwareType(softwareVersion)}
+                hosts={hostsCount ?? 0}
+                queryParams={{
+                  software_version_id: softwareVersion.id,
+                  team_id: teamIdForApi,
+                }}
+                name={softwareVersion.name}
+                source={softwareVersion.source}
+              />
+            </Card>
             <Card
               borderRadiusSize="xxlarge"
               includeShadow


### PR DESCRIPTION
## Issue
For #28053 

## Description
I had to pull `<Card/>` out of `<SoftwareDetailsSummary/>` to encapsulate VersionsTable within the `<Card/>` on title details page but forgot to wrap `<Card/>` around the other two instances of `<SoftwareDetailsSummary/>` (on the version details page and os details page)


## Screenshot of 1 of 2 instances of unreleased bug (whoops)

### Unreleased bug
<img width="1274" alt="Screenshot 2025-05-13 at 4 43 04 PM" src="https://github.com/user-attachments/assets/316bd8a2-1e87-4693-9cc3-c0e6145cf4d3" />

### Fix
<img width="1279" alt="Screenshot 2025-05-13 at 4 47 08 PM" src="https://github.com/user-attachments/assets/9665e758-5f72-4452-ba52-a592a5c842ab" />


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

   - [x] Manual QA must be performed in the three main OSs, macOS, Windows and Linux.
