### PR TITLE
[API design] Uninstall App Store (VPP) apps

### DIFF
--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -10250,7 +10250,7 @@ _Available in Fleet Premium._
 
 Get the results of a Fleet-maintained app or custom package install. To get uninstall results, use the [List activities](#list-activities) and [Get script result](#get-script-result) API endpoints.
 
-To get the results of an App Store app install, use the [List MDM commands](#list-mdm-commands) and [Get MDM command results](#get-mdm-command-results) API endpoints. Fleet uses an MDM command to install App Store apps.
+To get the results of an App Store app install or uninstall, use the [List MDM commands](#list-mdm-commands) and [Get MDM command results](#get-mdm-command-results) API endpoints. Fleet uses an MDM command to install App Store apps.
 
 | Name            | Type    | In   | Description                                      |
 | ----            | ------- | ---- | --------------------------------------------     |


### PR DESCRIPTION
Rebuild of relevant parts of #27159 against v4.70 docs branch. The original PR was merged and then had changes backed out, so the actual diff in this case is tiny since the majority of changes in the previous PR (other than activities) were valid without the feature.

Activities are kept out of this PR as they'll be added in the implementation PR in 4.70.