### PR TITLE
Fleet UI: Surface copyable SHA256 hash on software details page

### DIFF
--- a/changes/28099-sha-hash
+++ b/changes/28099-sha-hash
@@ -1,0 +1,1 @@
+- Fleet UI: Added copyable SHA256 hash to the software details page

--- a/frontend/interfaces/software.ts
+++ b/frontend/interfaces/software.ts
@@ -103,6 +103,7 @@ export interface ISoftwarePackage {
   labels_exclude_any: ILabelSoftwareTitle[] | null;
   categories?: SoftwareCategory[];
   fleet_maintained_app_id?: number | null;
+  hash_sha256?: string | null;
 }
 
 export const isSoftwarePackage = (

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwareInstallerCard/InstallerDetailsWidget/InstallerDetailsWidget.tests.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwareInstallerCard/InstallerDetailsWidget/InstallerDetailsWidget.tests.tsx
@@ -86,7 +86,7 @@ describe("InstallerDetailsWidget", () => {
       "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890";
     render(<InstallerDetailsWidget {...defaultProps} sha256={sha256} />);
     // The component shows the first 6 chars + ellipsis
-    expect(screen.getByText(/^abcdef…$/)).toBeInTheDocument();
+    expect(screen.getByText(/^abcdef1…$/)).toBeInTheDocument();
     const copyIcon = screen.getByTestId("copy-icon");
     const copyButton = copyIcon.closest("button");
     expect(copyButton).toBeInTheDocument();

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwareInstallerCard/InstallerDetailsWidget/InstallerDetailsWidget.tests.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwareInstallerCard/InstallerDetailsWidget/InstallerDetailsWidget.tests.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import InstallerDetailsWidget from "./InstallerDetailsWidget";
 
 // Mock current time for time stamp test
@@ -78,5 +79,16 @@ describe("InstallerDetailsWidget", () => {
     render(<InstallerDetailsWidget {...defaultProps} />);
     // TooltipWrapper is mocked, so we just check that the child is rendered
     expect(screen.getByText("Test Software")).toBeInTheDocument();
+  });
+
+  it("renders the sha256 hash when provided and a copy button", () => {
+    const sha256 =
+      "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890";
+    render(<InstallerDetailsWidget {...defaultProps} sha256={sha256} />);
+    // The component shows the first 6 chars + ellipsis
+    expect(screen.getByText(/^abcdef…$/)).toBeInTheDocument();
+    const copyIcon = screen.getByTestId("copy-icon");
+    const copyButton = copyIcon.closest("button");
+    expect(copyButton).toBeInTheDocument();
   });
 });

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwareInstallerCard/InstallerDetailsWidget/InstallerDetailsWidget.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwareInstallerCard/InstallerDetailsWidget/InstallerDetailsWidget.tsx
@@ -120,7 +120,7 @@ const InstallerDetailsWidget = ({
               showArrow
               underline={false}
             >
-              {sha256.slice(0, 6)}&hellip;
+              {sha256.slice(0, 7)}&hellip;
             </TooltipWrapper>
             <div className={`${baseClass}__sha-copy-button`}>
               <Button variant="icon" iconStroke onClick={onCopySha256}>

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwareInstallerCard/InstallerDetailsWidget/_styles.scss
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwareInstallerCard/InstallerDetailsWidget/_styles.scss
@@ -17,6 +17,29 @@
   }
 
   &__details {
+    display: flex;
+    gap: $pad-xsmall;
     font-size: $xx-small;
+  }
+
+  &__sha256 {
+    display: flex;
+    align-items: center;
+    margin: -$pad-small 0; // Remove vertical padding but keep clickable area
+  }
+
+  &__copy-overlay {
+    display: flex;
+    position: relative;
+    left: -95px;
+  }
+
+  &__sha-copy-button {
+    display: flex;
+    align-items: center;
+  }
+
+  &__copy-message {
+    @include copy-message;
   }
 }

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwareInstallerCard/SoftwareInstallerCard.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwareInstallerCard/SoftwareInstallerCard.tsx
@@ -219,6 +219,10 @@ const SoftwareInstallerCard = ({
   const isFleetMaintainedApp =
     "fleet_maintained_app_id" in softwareInstaller &&
     !!softwareInstaller.fleet_maintained_app_id;
+  const sha256 =
+    "hash_sha256" in softwareInstaller
+      ? softwareInstaller.hash_sha256
+      : undefined;
 
   const {
     automatic_install_policies: automaticInstallPolicies,
@@ -312,6 +316,7 @@ const SoftwareInstallerCard = ({
             installerType={installerType}
             versionInfo={versionInfo}
             addedTimestamp={addedTimestamp}
+            sha256={sha256}
             isFma={isFleetMaintainedApp}
           />
           <div className={`${baseClass}__tags-wrapper`}>


### PR DESCRIPTION
## Issue
For #28099 

## Description
- Add copyable SHA256 hash to software package installer section of software details page

## Screenrecording

https://github.com/user-attachments/assets/df110532-d59c-421b-830b-8aeecabcdedf


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
- [ ] Added/updated automated tests
- [ ] Manual QA for all new/changed functionality
