### PR TITLE
Skip vulnerability checks on Docker DX VSCode plugin to avoid false positives due to overly broad Docker CPEs

### DIFF
--- a/server/vulnerabilities/nvd/cpe_test.go
+++ b/server/vulnerabilities/nvd/cpe_test.go
@@ -1426,6 +1426,15 @@ func TestCPEFromSoftwareIntegration(t *testing.T) {
 			},
 			cpe: "cpe:2.3:a:gitkraken:gitlens:14.9.0:*:*:*:*:visual_studio_code:*:*",
 		},
+		{ // skipped because the Docker DX VSCode extension has no vulnerabilities, so a CPE hasn't been built
+			software: fleet.Software{
+				Name:    "docker.docker",
+				Source:  "vscode_extensions",
+				Version: "0.6.0",
+				Vendor:  "Docker",
+			},
+			cpe: ``,
+		},
 		{
 			software: fleet.Software{
 				Name:    "ms-python.python",

--- a/server/vulnerabilities/nvd/cpe_translations.json
+++ b/server/vulnerabilities/nvd/cpe_translations.json
@@ -481,6 +481,15 @@
   },
   {
     "software": {
+      "name": ["docker.docker"],
+      "source": ["vscode_extensions"]
+    },
+    "filter": {
+      "skip": true
+    }
+  },
+  {
+    "software": {
       "name": ["oracle.mysql-shell-for-vs-code"],
       "source": ["vscode_extensions"]
     },


### PR DESCRIPTION
For #28983. No changes file since this is being released directly to the vulns feed.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.
- [x] Added/updated automated tests
- [x] Manual QA for all new/changed functionality