### PR TITLE
Hold off on policy queries until after setup experience

### DIFF
--- a/changes/28205-skip-policies-during-setup-experience
+++ b/changes/28205-skip-policies-during-setup-experience
@@ -1,0 +1,1 @@
+Stopped policy automations from running on macOS hosts until after setup experience finishes so that Fleet doesn't attempt to install software twice

--- a/server/service/osquery.go
+++ b/server/service/osquery.go
@@ -789,13 +789,11 @@ func (svc *Service) policyQueriesForHost(ctx context.Context, host *fleet.Host) 
 		return nil, false, ctxerr.Wrap(ctx, err, "check if host is in setup experience")
 	}
 	if disablePolicies {
-		level.Info(svc.logger).Log("msg", "skipping policy queries for host in setup experience", "host_id", host.ID)
+		level.Debug(svc.logger).Log("msg", "skipping policy queries for host in setup experience", "host_id", host.ID)
 		return nil, false, nil
 	}
-	level.Info(svc.logger).Log("msg", "evaluating if policy queries for host not in setup experience should run", "host_id", host.ID)
 	policyReportedAt := svc.task.GetHostPolicyReportedAt(ctx, host)
 	if !svc.shouldUpdate(policyReportedAt, svc.config.Osquery.PolicyUpdateInterval, host.ID) && !host.RefetchRequested {
-		level.Info(svc.logger).Log("msg", "skipping policy queries for host not in setup experience becaues !shouldUpdate", "host_id", host.ID)
 		return nil, false, nil
 	}
 	policyQueries, err = svc.ds.PolicyQueriesForHost(ctx, host)
@@ -803,10 +801,8 @@ func (svc *Service) policyQueriesForHost(ctx context.Context, host *fleet.Host) 
 		return nil, false, ctxerr.Wrap(ctx, err, "retrieve policy queries")
 	}
 	if len(policyQueries) == 0 {
-		level.Info(svc.logger).Log("msg", "skipping policy queries for host not in setup experience becaues no queries", "host_id", host.ID)
 		return nil, true, nil
 	}
-	level.Info(svc.logger).Log("msg", "running policy queries for host not in setup experience", "host_id", host.ID)
 	return policyQueries, false, nil
 }
 

--- a/server/service/osquery.go
+++ b/server/service/osquery.go
@@ -766,13 +766,6 @@ func (svc *Service) disablePoliciesDuringSetupExperience(ctx context.Context, ho
 	if host.Platform != string(fleet.MacOSPlatform) {
 		return false, nil
 	}
-	connectedToFleetMDM, err := svc.ds.IsHostConnectedToFleetMDM(ctx, host)
-	if err != nil {
-		return false, ctxerr.Wrap(ctx, err, "check if host is connected to fleet mdm")
-	}
-	if !connectedToFleetMDM {
-		return false, nil
-	}
 	inSetupExperience, err := svc.ds.GetHostAwaitingConfiguration(ctx, host.UUID)
 	if err != nil && !fleet.IsNotFound(err) {
 		return false, ctxerr.Wrap(ctx, err, "check if host is in setup experience")

--- a/server/service/osquery_test.go
+++ b/server/service/osquery_test.go
@@ -1264,7 +1264,7 @@ func TestQueriesAndHostFeatures(t *testing.T) {
 		return map[string]string{}, nil
 	}
 
-	ds.IsHostConnectedToFleetMDMFunc = func(ctx context.Context, host *fleet.Host) (bool, error) {
+	ds.GetHostAwaitingConfigurationFunc = func(ctx context.Context, hostuuid string) (bool, error) {
 		return false, nil
 	}
 
@@ -1368,7 +1368,7 @@ func TestGetDistributedQueriesEmptyQuery(t *testing.T) {
 	ds.PolicyQueriesForHostFunc = func(ctx context.Context, host *fleet.Host) (map[string]string, error) {
 		return map[string]string{"empty_policy_query": ""}, nil
 	}
-	ds.IsHostConnectedToFleetMDMFunc = func(ctx context.Context, host *fleet.Host) (bool, error) {
+	ds.GetHostAwaitingConfigurationFunc = func(ctx context.Context, hostuuid string) (bool, error) {
 		return false, nil
 	}
 
@@ -1412,7 +1412,7 @@ func TestLabelQueries(t *testing.T) {
 			EnableSoftwareInventory: true,
 		}}, nil
 	}
-	ds.IsHostConnectedToFleetMDMFunc = func(ctx context.Context, host *fleet.Host) (bool, error) {
+	ds.GetHostAwaitingConfigurationFunc = func(ctx context.Context, hostuuid string) (bool, error) {
 		return false, nil
 	}
 	ds.PolicyQueriesForHostFunc = func(ctx context.Context, host *fleet.Host) (map[string]string, error) {
@@ -1581,7 +1581,7 @@ func TestDetailQueriesWithEmptyStrings(t *testing.T) {
 	ds.PolicyQueriesForHostFunc = func(ctx context.Context, host *fleet.Host) (map[string]string, error) {
 		return map[string]string{}, nil
 	}
-	ds.IsHostConnectedToFleetMDMFunc = func(ctx context.Context, host *fleet.Host) (bool, error) {
+	ds.GetHostAwaitingConfigurationFunc = func(ctx context.Context, hostuuid string) (bool, error) {
 		return false, nil
 	}
 	ds.HostLiteFunc = func(ctx context.Context, id uint) (*fleet.Host, error) {
@@ -1815,7 +1815,7 @@ func TestDetailQueries(t *testing.T) {
 		}
 		return host, nil
 	}
-	ds.IsHostConnectedToFleetMDMFunc = func(ctx context.Context, host *fleet.Host) (bool, error) {
+	ds.GetHostAwaitingConfigurationFunc = func(ctx context.Context, hostuuid string) (bool, error) {
 		return false, nil
 	}
 
@@ -3144,7 +3144,7 @@ func TestPolicyQueries(t *testing.T) {
 			EnableSoftwareInventory: true,
 		}}, nil
 	}
-	ds.IsHostConnectedToFleetMDMFunc = func(ctx context.Context, host *fleet.Host) (bool, error) {
+	ds.GetHostAwaitingConfigurationFunc = func(ctx context.Context, hostuuid string) (bool, error) {
 		return false, nil
 	}
 
@@ -3336,10 +3336,6 @@ func TestPolicyQueriesDuringSetupExperience(t *testing.T) {
 		}}, nil
 	}
 
-	ds.IsHostConnectedToFleetMDMFunc = func(ctx context.Context, host *fleet.Host) (bool, error) {
-		return true, nil
-	}
-
 	ds.GetHostAwaitingConfigurationFunc = func(ctx context.Context, hostUUID string) (bool, error) {
 		return true, nil
 	}
@@ -3418,7 +3414,7 @@ func TestPolicyWebhooks(t *testing.T) {
 		host = gotHost
 		return nil
 	}
-	ds.IsHostConnectedToFleetMDMFunc = func(ctx context.Context, host *fleet.Host) (bool, error) {
+	ds.GetHostAwaitingConfigurationFunc = func(ctx context.Context, hostuuid string) (bool, error) {
 		return false, nil
 	}
 	ds.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {
@@ -3701,7 +3697,7 @@ func TestLiveQueriesFailing(t *testing.T) {
 	ds.PolicyQueriesForHostFunc = func(ctx context.Context, host *fleet.Host) (map[string]string, error) {
 		return map[string]string{}, nil
 	}
-	ds.IsHostConnectedToFleetMDMFunc = func(ctx context.Context, host *fleet.Host) (bool, error) {
+	ds.GetHostAwaitingConfigurationFunc = func(ctx context.Context, hostuuid string) (bool, error) {
 		return false, nil
 	}
 

--- a/server/service/osquery_test.go
+++ b/server/service/osquery_test.go
@@ -1412,6 +1412,9 @@ func TestLabelQueries(t *testing.T) {
 			EnableSoftwareInventory: true,
 		}}, nil
 	}
+	ds.IsHostConnectedToFleetMDMFunc = func(ctx context.Context, host *fleet.Host) (bool, error) {
+		return false, nil
+	}
 	ds.PolicyQueriesForHostFunc = func(ctx context.Context, host *fleet.Host) (map[string]string, error) {
 		return map[string]string{}, nil
 	}
@@ -1577,6 +1580,9 @@ func TestDetailQueriesWithEmptyStrings(t *testing.T) {
 	}
 	ds.PolicyQueriesForHostFunc = func(ctx context.Context, host *fleet.Host) (map[string]string, error) {
 		return map[string]string{}, nil
+	}
+	ds.IsHostConnectedToFleetMDMFunc = func(ctx context.Context, host *fleet.Host) (bool, error) {
+		return false, nil
 	}
 	ds.HostLiteFunc = func(ctx context.Context, id uint) (*fleet.Host, error) {
 		if id != 1 {
@@ -1808,6 +1814,9 @@ func TestDetailQueries(t *testing.T) {
 			return nil, errors.New("not found")
 		}
 		return host, nil
+	}
+	ds.IsHostConnectedToFleetMDMFunc = func(ctx context.Context, host *fleet.Host) (bool, error) {
+		return false, nil
 	}
 
 	// With a new host, we should get the detail queries (and accelerated
@@ -3135,6 +3144,9 @@ func TestPolicyQueries(t *testing.T) {
 			EnableSoftwareInventory: true,
 		}}, nil
 	}
+	ds.IsHostConnectedToFleetMDMFunc = func(ctx context.Context, host *fleet.Host) (bool, error) {
+		return false, nil
+	}
 
 	lq.On("QueriesForHost", uint(0)).Return(map[string]string{}, nil)
 
@@ -3409,6 +3421,9 @@ func TestPolicyWebhooks(t *testing.T) {
 	ds.UpdateHostFunc = func(ctx context.Context, gotHost *fleet.Host) error {
 		host = gotHost
 		return nil
+	}
+	ds.IsHostConnectedToFleetMDMFunc = func(ctx context.Context, host *fleet.Host) (bool, error) {
+		return false, nil
 	}
 	ds.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {
 		return &fleet.AppConfig{
@@ -3689,6 +3704,9 @@ func TestLiveQueriesFailing(t *testing.T) {
 	}
 	ds.PolicyQueriesForHostFunc = func(ctx context.Context, host *fleet.Host) (map[string]string, error) {
 		return map[string]string{}, nil
+	}
+	ds.IsHostConnectedToFleetMDMFunc = func(ctx context.Context, host *fleet.Host) (bool, error) {
+		return false, nil
 	}
 
 	ctx = hostctx.NewContext(ctx, host)

--- a/server/service/osquery_test.go
+++ b/server/service/osquery_test.go
@@ -1264,6 +1264,10 @@ func TestQueriesAndHostFeatures(t *testing.T) {
 		return map[string]string{}, nil
 	}
 
+	ds.IsHostConnectedToFleetMDMFunc = func(ctx context.Context, host *fleet.Host) (bool, error) {
+		return false, nil
+	}
+
 	lq := live_query_mock.New(t)
 	lq.On("QueriesForHost", uint(1)).Return(map[string]string{}, nil)
 	lq.On("QueriesForHost", uint(2)).Return(map[string]string{}, nil)
@@ -1363,6 +1367,9 @@ func TestGetDistributedQueriesEmptyQuery(t *testing.T) {
 	}
 	ds.PolicyQueriesForHostFunc = func(ctx context.Context, host *fleet.Host) (map[string]string, error) {
 		return map[string]string{"empty_policy_query": ""}, nil
+	}
+	ds.IsHostConnectedToFleetMDMFunc = func(ctx context.Context, host *fleet.Host) (bool, error) {
+		return false, nil
 	}
 
 	lq.On("QueriesForHost", uint(0)).Return(map[string]string{"empty_live_query": ""}, nil)
@@ -3289,6 +3296,89 @@ func TestPolicyQueries(t *testing.T) {
 	require.Equal(t, len(expectedDetailQueriesForPlatform(host.Platform)), len(queries), distQueriesMapKeys(queries))
 	verifyDiscovery(t, queries, discovery)
 	noPolicyResults(queries)
+}
+
+func TestPolicyQueriesDuringSetupExperience(t *testing.T) {
+	ds := new(mock.Store)
+	lq := live_query_mock.New(t)
+	svc, ctx := newTestService(t, ds, nil, lq)
+
+	host := &fleet.Host{
+		Platform: "darwin",
+	}
+
+	ds.LabelQueriesForHostFunc = func(ctx context.Context, host *fleet.Host) (map[string]string, error) {
+		return map[string]string{}, nil
+	}
+	ds.HostLiteFunc = func(ctx context.Context, id uint) (*fleet.Host, error) {
+		return host, nil
+	}
+	ds.UpdateHostFunc = func(ctx context.Context, gotHost *fleet.Host) error {
+		host = gotHost
+		return nil
+	}
+	ds.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {
+		return &fleet.AppConfig{Features: fleet.Features{
+			EnableHostUsers:         true,
+			EnableSoftwareInventory: true,
+		}}, nil
+	}
+
+	ds.IsHostConnectedToFleetMDMFunc = func(ctx context.Context, host *fleet.Host) (bool, error) {
+		return true, nil
+	}
+
+	ds.GetHostAwaitingConfigurationFunc = func(ctx context.Context, hostUUID string) (bool, error) {
+		return true, nil
+	}
+
+	lq.On("QueriesForHost", uint(0)).Return(map[string]string{}, nil)
+
+	ds.PolicyQueriesForHostFunc = func(ctx context.Context, host *fleet.Host) (map[string]string, error) {
+		return map[string]string{"1": "select 1", "2": "select 42;"}, nil
+	}
+
+	ds.FlippingPoliciesForHostFunc = func(ctx context.Context, hostID uint, incomingResults map[uint]*bool) (newFailing []uint, newPassing []uint, err error) {
+		return nil, nil, nil
+	}
+
+	ctx = hostctx.NewContext(ctx, host)
+
+	queries, discovery, _, err := svc.GetDistributedQueries(ctx)
+	require.NoError(t, err)
+
+	// Should not return the 2 policy queries because we're in setup experience
+	require.Equal(t, len(expectedDetailQueriesForPlatform(host.Platform)), len(queries), distQueriesMapKeys(queries))
+	verifyDiscovery(t, queries, discovery)
+
+	checkPolicyResults := func(queries map[string]string, shouldHavePolicies bool) {
+		hasPolicy1, hasPolicy2 := false, false
+		for name := range queries {
+			if strings.HasPrefix(name, hostPolicyQueryPrefix) {
+				if name[len(hostPolicyQueryPrefix):] == "1" {
+					hasPolicy1 = true
+				}
+				if name[len(hostPolicyQueryPrefix):] == "2" {
+					hasPolicy2 = true
+				}
+			}
+		}
+		assert.Equal(t, hasPolicy1, shouldHavePolicies)
+		assert.Equal(t, hasPolicy2, shouldHavePolicies)
+	}
+
+	// Make it appear the host is out of setup experience and ask again for policies
+	ds.GetHostAwaitingConfigurationFunc = func(ctx context.Context, hostUUID string) (bool, error) {
+		return false, nil
+	}
+
+	queries, discovery, _, err = svc.GetDistributedQueries(ctx)
+	require.NoError(t, err)
+	// Should now return the 2 additional policy queries because we're out of setup experience
+	assert.Equal(t, len(expectedDetailQueriesForPlatform(host.Platform))+2, len(queries), distQueriesMapKeys(queries))
+	verifyDiscovery(t, queries, discovery)
+
+	checkPolicyResults(queries, true)
 }
 
 func TestPolicyWebhooks(t *testing.T) {

--- a/server/service/osquery_test.go
+++ b/server/service/osquery_test.go
@@ -3350,10 +3350,6 @@ func TestPolicyQueriesDuringSetupExperience(t *testing.T) {
 		return map[string]string{"1": "select 1", "2": "select 42;"}, nil
 	}
 
-	ds.FlippingPoliciesForHostFunc = func(ctx context.Context, hostID uint, incomingResults map[uint]*bool) (newFailing []uint, newPassing []uint, err error) {
-		return nil, nil, nil
-	}
-
 	ctx = hostctx.NewContext(ctx, host)
 
 	queries, discovery, _, err := svc.GetDistributedQueries(ctx)


### PR DESCRIPTION
For #28205 

During setup experience customers often install all or most of the software that would otherwise be installed based on the results of policy queries.  If we run policy queries during setup experience we end up trying to install some software twice which, at best, leads to confusing activities listed for the host. With these changes we will not run policy queries on macOS hosts until after the host has exited setup experience, at which point we should be able to avoid duplicate installs

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/Committing-Changes.md#changes-files) for more information.
- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [x] Added/updated automated tests
- [x] Manual QA for all new/changed functionality
