### PR TITLE
enable fleet secret variables in the macos setup script in gitops

### DIFF
--- a/changes/issue-28215-allow-fleet-secrets-for-macos-setup-script
+++ b/changes/issue-28215-allow-fleet-secrets-for-macos-setup-script
@@ -1,0 +1,1 @@
+- allow fleet secret environment variables for the macos setup script

--- a/pkg/spec/gitops.go
+++ b/pkg/spec/gitops.go
@@ -489,6 +489,21 @@ func parseControls(top map[string]json.RawMessage, result *GitOps, multiError *m
 		}
 	}
 
+	// Find the Fleet Secrets in the macos setup script file
+	if result.Controls.MacOSSetup != nil {
+		if result.Controls.MacOSSetup.Script.Set {
+			startupScriptPath := resolveApplyRelativePath(controlsDir, result.Controls.MacOSSetup.Script.Value)
+			fileBytes, err := os.ReadFile(startupScriptPath)
+			if err != nil {
+				return multierror.Append(multiError, fmt.Errorf("failed to read macos_setup script file %s: %v", startupScriptPath, err))
+			}
+			err = LookupEnvSecrets(string(fileBytes), result.FleetSecrets)
+			if err != nil {
+				return multierror.Append(multiError, err)
+			}
+		}
+	}
+
 	// Find Fleet secrets in profiles
 	if result.Controls.MacOSSettings != nil {
 		// We are marshalling/unmarshalling to get the data into the fleet.MacOSSettings struct.

--- a/server/service/client.go
+++ b/server/service/client.go
@@ -2097,14 +2097,15 @@ func (c *Client) doGitOpsNoTeamSetupAndSoftware(
 	if err != nil {
 		return nil, nil, fmt.Errorf("applying software installers: %w", err)
 	}
-
-	if macosSetupScript != nil {
-		logFn("[+] applying macos setup experience script for 'No team'\n")
-		if err := c.uploadMacOSSetupScript(macosSetupScript.Filename, macosSetupScript.Content, nil); err != nil {
-			return nil, nil, fmt.Errorf("uploading setup experience script for No team: %w", err)
+	if !dryRun {
+		if macosSetupScript != nil {
+			logFn("[+] applying macos setup experience script for 'No team'\n")
+			if err := c.uploadMacOSSetupScript(macosSetupScript.Filename, macosSetupScript.Content, nil); err != nil {
+				return nil, nil, fmt.Errorf("uploading setup experience script for No team: %w", err)
+			}
+		} else if err := c.deleteMacOSSetupScript(nil); err != nil {
+			return nil, nil, fmt.Errorf("deleting setup experience script for No team: %w", err)
 		}
-	} else if err := c.deleteMacOSSetupScript(nil); err != nil {
-		return nil, nil, fmt.Errorf("deleting setup experience script for No team: %w", err)
 	}
 
 	logFn("[+] applying %d software packages for 'No team'\n", len(swPkgPayload))


### PR DESCRIPTION
For #28215

Allows users to use fleet secret variables for macos setup script for gitops.


- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
- [ ] Added/updated automated tests
- [x] Manual QA for all new/changed functionality
