### PR TITLE
Force enrollment profile sync when an Apple device was added to ABM. (#29147)

### DIFF
--- a/changes/27854-force-profile-assign-on-abm-add
+++ b/changes/27854-force-profile-assign-on-abm-add
@@ -1,0 +1,1 @@
+Fixed issue that when Apple device was removed/re-added to ABM, it was not getting an enrollment profile.

--- a/tools/mdm/apple/troubleshooting.md
+++ b/tools/mdm/apple/troubleshooting.md
@@ -13,3 +13,17 @@ fleetctl apple-mdm enqueue-command InstallProfile --device-ids=<TARGET_DEVICE_ID
 ```sh
 log stream --info --debug --predicate 'processImagePath contains "mdmclient"' | tee mdm_logs.txt
 ```
+
+## Checking and redelivering MDM enrollment profile
+
+To check if a host has the correct MDM enrollment profile installed, run the following command on the host:
+```bash
+sudo profiles show -type configuration
+```
+
+To trigger a redelivery of enrollment profile, run the following command on the host:
+```
+sudo profiles renew -type enrollment
+```
+
+If the host does not have the right enrollment profile, try transferring the host to another team, wait for 10 minutes, then transfer it back and wait another 10 minutes.


### PR DESCRIPTION
For #27854

I was able to reproduce the issue by simply unassigning device from an MDM server, and then assigning back. Once assigned back, Fleet did not resend the profile to ABM, and device was not able to enroll into MDM.

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
See [Changes
files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/Committing-Changes.md#changes-files) for more information.
- [x] Added/updated automated tests
- [x] Manual QA for all new/changed functionality

(cherry picked from commit 890042d27aeb8e9151c557f263409791956150c9)
