### PR TITLE
Fleet UI: Confirmed toast messages to end user for self-service install/uninstall

### DIFF
--- a/frontend/pages/hosts/details/cards/Software/SelfService/SelfServiceTableConfig.tsx
+++ b/frontend/pages/hosts/details/cards/Software/SelfService/SelfServiceTableConfig.tsx
@@ -293,6 +293,7 @@ const InstallerStatusAction = ({
         onInstallOrUninstall();
       }
     } catch (error) {
+      // We only show toast message if API returns an error
       renderFlash("error", "Couldn't install. Please try again.");
     }
   }, [deviceToken, id, onInstallOrUninstall, renderFlash]);

--- a/frontend/pages/hosts/details/cards/Software/SelfService/UninstallSoftwareModal/UninstallSoftwareModal.tsx
+++ b/frontend/pages/hosts/details/cards/Software/SelfService/UninstallSoftwareModal/UninstallSoftwareModal.tsx
@@ -36,10 +36,9 @@ const UninstallSoftwareModal = ({
     setIsUninstalling(true);
     try {
       await deviceUserAPI.uninstallSelfServiceSoftware(token, softwareId);
-      // TODO: Change this toast message or hide it all together?
-      // renderFlash("success", "Software uninstalled successfully!");
       onSuccess();
     } catch (error) {
+      // We only show toast message to end user if API returns an error
       renderFlash("error", "Couldn't uninstall. Please try again.");
     }
     setIsUninstalling(false);


### PR DESCRIPTION
## Issue
For #28845 

## Description
- Follow up on toast messages, confirmed with @eugkuo 
- (no code changes required) Follow up after testing global activity feed

## Screenshot of global activity
<img width="861" alt="Screenshot 2025-05-15 at 1 56 59 PM" src="https://github.com/user-attachments/assets/de51668a-c50a-46d1-9aaa-9a32a64a9a81" />


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Manual QA for all new/changed functionality

