### PR TITLE
Cherry-pick: Batch host_software inserts in macOS names migration to improve performance for large host counts

### DIFF
--- a/changes/24087-migration-perf-improvement
+++ b/changes/24087-migration-perf-improvement
@@ -1,0 +1,1 @@
+* Further improved performance on database migration from 4.66 and earlier for instances with large macOS host counts.


### PR DESCRIPTION
Merged into `main` in #29238. Including to ensure that migrations 4.66 -> 4.68 get the speedup.