### PR TITLE
Fleet installed vpp apps, prior to being inventoried, correctly pull self service flag

### DIFF
--- a/server/datastore/mysql/software.go
+++ b/server/datastore/mysql/software.go
@@ -2898,6 +2898,7 @@ func hostVPPInstalls(ds *Datastore, ctx context.Context, hostID uint, globalOrTe
                 ua.execution_id AS last_install_install_uuid,
                 ua.created_at AS last_install_installed_at,
                 vaua.adam_id AS vpp_app_adam_id,
+				vat.self_service AS vpp_app_self_service,
                 'pending_install' AS status
             FROM
                 upcoming_activities ua
@@ -2928,6 +2929,7 @@ func hostVPPInstalls(ds *Datastore, ctx context.Context, hostID uint, globalOrTe
                 hvsi.command_uuid AS last_install_install_uuid,
                 hvsi.created_at AS last_install_installed_at,
                 hvsi.adam_id AS vpp_app_adam_id,
+				vat.self_service AS vpp_app_self_service,
 				-- vppAppHostStatusNamedQuery(hvsi, ncr, status)
                 %s
             FROM


### PR DESCRIPTION
https://github.com/fleetdm/fleet/issues/29240

Prior to being accounted for in software inventory we store vpp app installs in `host_vpp_software_installs`. The query pull data from this table was not getting self service flag information which was necessary for label scoping logic later on while fetching software available for install on the service service page.

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [x] Added/updated automated tests
- [x] Manual QA for all new/changed functionality
- [x] For unreleased bug fixes in a release candidate, confirmed that the fix is not expected to adversely impact load test results or alerted the release DRI if additional load testing is needed.
