### PR TITLE
Add validator for NVD feed items

### DIFF
--- a/cmd/cpe/validate/main.go
+++ b/cmd/cpe/validate/main.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/fleetdm/fleet/v4/server/vulnerabilities/macoffice"
+	"github.com/fleetdm/fleet/v4/server/vulnerabilities/msrc/parsed"
+	"github.com/fleetdm/fleet/v4/server/vulnerabilities/nvd"
+)
+
+func main() {
+	dbDir := flag.String("db_dir", "/tmp/vulndbs", "Path to the vulnerability database")
+	flag.Parse()
+
+	vulnPath := *dbDir
+	checkCPETranslations(vulnPath)
+	checkMacOfficeNotes(vulnPath)
+	checkMSRCVulnerabilities(vulnPath)
+}
+
+func checkCPETranslations(vulnPath string) {
+	// Check that the CPE translations file is parseable into an array of CPETranslationItem
+	_, err := nvd.LoadCPETranslations(filepath.Join(vulnPath, "cpe_translations.json"))
+	if err != nil {
+		panic(fmt.Sprintf("failed to load CPE translations: %v", err))
+	}
+}
+
+func checkMacOfficeNotes(vulnPath string) {
+	// Iterate over each file in the vulnPath directory that starts with `fleet_macoffice`
+	files, err := os.ReadDir(vulnPath)
+	if err != nil {
+		panic(fmt.Sprintf("failed to read directory: %v", err))
+	}
+	for _, file := range files {
+		if strings.HasPrefix(file.Name(), "fleet_macoffice") && strings.HasSuffix(file.Name(), ".json") {
+			filePath := filepath.Join(vulnPath, file.Name())
+
+			payload, err := os.ReadFile(filePath)
+			if err != nil {
+				panic(fmt.Sprintf("failed to read MacOffice release notes file: %v", err))
+			}
+			// Attempt to parse the file as a MacOffice release notes.
+			relNotes := macoffice.ReleaseNotes{}
+			err = json.Unmarshal(payload, &relNotes)
+			if err != nil {
+				panic(fmt.Sprintf("failed to parse MacOffice release notes: %v", err))
+			}
+		}
+	}
+}
+
+func checkMSRCVulnerabilities(vulnPath string) {
+	// Iterate over each file in the vulnPath directory that starts with `fleet_msrc`
+	files, err := os.ReadDir(vulnPath)
+	if err != nil {
+		panic(fmt.Sprintf("failed to read directory: %v", err))
+	}
+	for _, file := range files {
+		if strings.HasPrefix(file.Name(), "fleet_msrc") && strings.HasSuffix(file.Name(), ".json") {
+			filePath := filepath.Join(vulnPath, file.Name())
+			// Attempt to parse the file as a MSRC feed.
+			_, err := parsed.UnmarshalBulletin(filePath)
+			if err != nil {
+				panic(fmt.Sprintf("failed to parse MSRC feed: %v", err))
+			}
+		}
+	}
+}

--- a/cmd/cpe/validate/main.go
+++ b/cmd/cpe/validate/main.go
@@ -109,9 +109,14 @@ func checkSqliteDb(vulnPath string) {
 		panic(fmt.Sprintf("error creating new gzip reader: %v", err))
 	}
 	defer gzReader.Close()
-	_, err = io.Copy(sqliteFile, gzReader)
-	if err != nil {
-		panic(fmt.Sprintf("error unzipping sqlite file: %v", err))
+	for {
+		_, err := io.CopyN(sqliteFile, gzReader, 100*1024*1024)
+		if err != nil {
+			if err == io.EOF {
+				break
+			}
+			panic(fmt.Sprintf("error unzipping sqlite file: %v", err))
+		}
 	}
 	db, err := sqlx.Open("sqlite3", filepath.Join(vulnPath, "sqlite.db"))
 	if err != nil {

--- a/server/vulnerabilities/nvd/cpe_translations.go
+++ b/server/vulnerabilities/nvd/cpe_translations.go
@@ -18,6 +18,11 @@ import (
 
 const cpeTranslationsFilename = "cpe_translations.json"
 
+// Exported for testing.
+func LoadCPETranslations(path string) (CPETranslations, error) {
+	return loadCPETranslations(path)
+}
+
 func loadCPETranslations(path string) (CPETranslations, error) {
 	f, err := os.Open(path)
 	if err != nil {


### PR DESCRIPTION
for #21304 

# Checklist for submitter

- [X] Manual QA for all new/changed functionality

## Details

This PR adds a new validator for NVD feed files to be run as part of the nvd repo workflow.  The intention is for that workflow to fail if any of the files it creates are not valid (i.e. they would not be parseable by the Fleet server) so that we don't publish and tag a release with bad files in it.

This follows the pattern from https://github.com/fleetdm/fleet/issues/21300 as suggested by @iansltx.

## Testing

I downloaded all of the latest release files to my local system using
```bash
gh release download 202505190037 -D ~/Downloads/nvd
```
and then ran the validator on them with
```bash
go run cmd/cpe/validate/main.go --db_dir ~/Downloads/nvd
```
To simulate file issues, I modified one section of each file to change a value into the wrong type, and validated that this caused the validator to panic.  Examples:
```
panic: failed to load CPE translations: decode json: json: cannot unmarshal string into Go struct field CPETranslation.filter.vendor of type []string

goroutine 1 [running]:
main.checkCPETranslations({0x16dc975f9?, 0x14000192190?})
	/Users/scott/Development/fleet/cmd/cpe/validate/main.go:34 +0xa8
main.main()
	/Users/scott/Development/fleet/cmd/cpe/validate/main.go:24 +0xb0
exit status 2
```
---
```
panic: failed to parse MacOffice release notes fleet_macoffice_release_notes_macoffice-2025_05_19.json: parsing time "xyz" as "2006-01-02T15:04:05Z07:00": cannot parse "xyz" as "2006"

goroutine 1 [running]:
main.checkMacOfficeNotes({0x16f7af5f9, 0x1a})
	/Users/scott/Development/fleet/cmd/cpe/validate/main.go:56 +0x1f0
main.main()
	/Users/scott/Development/fleet/cmd/cpe/validate/main.go:25 +0xbc
exit status 2
```
---
```
panic: failed to parse MSRC feed fleet_msrc_Windows_Server_2012_R2-2025_05_19.json: json: cannot unmarshal array into Go struct field Vulnerability.Vulnerabities.RemediatedBy of type bool

goroutine 1 [running]:
main.checkMSRCVulnerabilities({0x16f49b5f9, 0x1a})
	/Users/scott/Development/fleet/cmd/cpe/validate/main.go:74 +0x1ac
main.main()
	/Users/scott/Development/fleet/cmd/cpe/validate/main.go:26 +0xc8
exit status 2
```

Additionally I tried the validator in [a run of the NVD workflow](https://github.com/fleetdm/nvd/actions/runs/15121687898/job/42505283781) and it executed successfully.