### PR TITLE
add host filtering by mdm config profile and the profile status

### DIFF
--- a/changes/issue-28761-filter-list-hosts-by-profile
+++ b/changes/issue-28761-filter-list-hosts-by-profile
@@ -1,0 +1,1 @@
+- add filtering for hosts endpoints by mdm config profile and status

--- a/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
@@ -1430,6 +1430,8 @@ const ManageHostsPage = ({
       bootstrapPackageStatus,
       vulnerability,
       visibleColumns,
+      configProfileUUID,
+      configProfileStatus,
     };
 
     options = {

--- a/frontend/services/entities/hosts.ts
+++ b/frontend/services/entities/hosts.ts
@@ -124,6 +124,8 @@ export interface IExportHostsOptions {
   bootstrapPackageStatus?: BootstrapPackageStatus;
   osSettings?: MdmProfileStatus;
   diskEncryptionStatus?: DiskEncryptionStatus;
+  configProfileUUID?: string;
+  configProfileStatus?: string;
 }
 
 export interface IActionByFilter {
@@ -337,6 +339,8 @@ export default {
     const osSettings = options?.osSettings;
     const diskEncryptionStatus = options?.diskEncryptionStatus;
     const vulnerability = options?.vulnerability;
+    const configProfileUUID = options?.configProfileUUID;
+    const configProfileStatus = options?.configProfileStatus;
 
     if (!sortBy.length) {
       throw Error("sortBy is a required field.");
@@ -372,6 +376,8 @@ export default {
         bootstrapPackageStatus,
         diskEncryptionStatus,
         vulnerability,
+        configProfileUUID,
+        configProfileStatus,
       }),
       status,
       label_id: label,

--- a/server/datastore/mysql/hosts.go
+++ b/server/datastore/mysql/hosts.go
@@ -1255,6 +1255,7 @@ func (ds *Datastore) applyHostFilters(
 	sqlStmt, whereParams = filterHostsByMDMBootstrapPackageStatus(sqlStmt, opt, whereParams)
 	sqlStmt, whereParams = filterHostsByOS(sqlStmt, opt, whereParams)
 	sqlStmt, whereParams = filterHostsByVulnerability(sqlStmt, opt, whereParams)
+	sqlStmt, whereParams = filterHostsByProfileStatus(sqlStmt, opt, whereParams)
 	sqlStmt, whereParams, _ = hostSearchLike(sqlStmt, whereParams, opt.MatchQuery, append(hostSearchColumns, "display_name")...)
 	sqlStmt, whereParams = appendListOptionsWithCursorToSQL(sqlStmt, whereParams, &opt.ListOptions)
 
@@ -1689,6 +1690,31 @@ func filterHostsByVulnerability(sqlstmt string, opt fleet.HostListOptions, param
 			WHERE osv.cve = ?)`
 
 		params = append(params, opt.VulnerabilityFilter, opt.VulnerabilityFilter)
+	}
+
+	return sqlstmt, params
+}
+
+func filterHostsByProfileStatus(sqlstmt string, opt fleet.HostListOptions, params []interface{}) (string, []interface{}) {
+	if opt.ProfileUUIDFilter != nil && opt.ProfileStatusFilter != nil {
+		sqlstmt += ` AND EXISTS (
+		SELECT
+			1
+		FROM
+			host_mdm_apple_profiles hmap
+		WHERE
+			hmap.host_uuid = h.uuid
+			AND hmap.profile_uuid = ?
+			AND hmap.status = ?)
+		OR(
+			SELECT
+				1 FROM host_mdm_windows_profiles hwap
+			WHERE
+				hwap.host_uuid = h.uuid
+				AND hwap.profile_uuid = ?
+				AND hwap.status = ?)`
+
+		params = append(params, opt.ProfileUUIDFilter, opt.ProfileStatusFilter, opt.ProfileUUIDFilter, opt.ProfileStatusFilter)
 	}
 
 	return sqlstmt, params

--- a/server/fleet/hosts.go
+++ b/server/fleet/hosts.go
@@ -221,6 +221,11 @@ type HostListOptions struct {
 	// ConnectedToFleetFilter filters hosts that have an active MDM
 	// connection with this Fleet instance.
 	ConnectedToFleetFilter *bool
+
+	// ProfileUUID is the UUID of the MDM configuration profile and filters hosts by that profile.
+	ProfileUUIDFilter *string
+	// ProfileStatus is the status of the MDM configuration profile and filters hosts by that status.
+	ProfileStatusFilter *OSSettingsStatus
 }
 
 // TODO(Sarah): Are we missing any filters here? Should all MDM filters be included?
@@ -249,7 +254,9 @@ func (h HostListOptions) Empty() bool {
 		h.MunkiIssueIDFilter == nil &&
 		h.LowDiskSpaceFilter == nil &&
 		h.OSSettingsFilter == "" &&
-		h.OSSettingsDiskEncryptionFilter == ""
+		h.OSSettingsDiskEncryptionFilter == "" &&
+		h.ProfileUUIDFilter == nil &&
+		h.ProfileStatusFilter == nil
 }
 
 type HostUser struct {

--- a/server/service/transport.go
+++ b/server/service/transport.go
@@ -459,9 +459,9 @@ func hostListOptionsFromRequest(r *http.Request) (fleet.HostListOptions, error) 
 			return hopt, ctxerr.Wrap(r.Context(), badRequest(fmt.Sprintf("Invalid profile_status: %s", profileStatus)))
 		}
 	} else if profileUUID != "" && profileStatus == "" {
-		return hopt, ctxerr.Wrap(r.Context(), badRequest("profile_status is required when profile_uuid is specified"))
+		return hopt, ctxerr.Wrap(r.Context(), badRequest("Missing profile_status (it must be present when profile_uuid is specified)"))
 	} else if profileUUID == "" && profileStatus != "" {
-		return hopt, ctxerr.Wrap(r.Context(), badRequest("profile_uuid is required when profile_status is specified"))
+		return hopt, ctxerr.Wrap(r.Context(), badRequest("Missing profile_uuid (it must be present when profile_status is specified)"))
 	}
 
 	munkiIssueID := r.URL.Query().Get("munki_issue_id")

--- a/server/service/transport.go
+++ b/server/service/transport.go
@@ -450,7 +450,8 @@ func hostListOptionsFromRequest(r *http.Request) (fleet.HostListOptions, error) 
 
 	profileUUID := r.URL.Query().Get("profile_uuid")
 	profileStatus := r.URL.Query().Get("profile_status")
-	if profileUUID != "" && profileStatus != "" {
+	switch {
+	case profileUUID != "" && profileStatus != "":
 		hopt.ProfileUUIDFilter = &profileUUID
 		if fleet.OSSettingsStatus(profileStatus).IsValid() {
 			psf := fleet.OSSettingsStatus(profileStatus)
@@ -458,9 +459,9 @@ func hostListOptionsFromRequest(r *http.Request) (fleet.HostListOptions, error) 
 		} else {
 			return hopt, ctxerr.Wrap(r.Context(), badRequest(fmt.Sprintf("Invalid profile_status: %s", profileStatus)))
 		}
-	} else if profileUUID != "" && profileStatus == "" {
+	case profileUUID != "" && profileStatus == "":
 		return hopt, ctxerr.Wrap(r.Context(), badRequest("Missing profile_status (it must be present when profile_uuid is specified)"))
-	} else if profileUUID == "" && profileStatus != "" {
+	case profileUUID == "" && profileStatus != "":
 		return hopt, ctxerr.Wrap(r.Context(), badRequest("Missing profile_uuid (it must be present when profile_status is specified)"))
 	}
 

--- a/server/service/transport_test.go
+++ b/server/service/transport_test.go
@@ -129,6 +129,7 @@ func TestListOptionsFromRequest(t *testing.T) {
 }
 
 func TestHostListOptionsFromRequest(t *testing.T) {
+	verified := fleet.OSSettingsVerified
 	hostListOptionsTests := map[string]struct {
 		// url string to parse
 		url string
@@ -158,7 +159,7 @@ func TestHostListOptionsFromRequest(t *testing.T) {
 				"&os_name=osName&os_version=osVersion&os_version_id=5&disable_failing_policies=0&disable_issues=1&macos_settings=verified" +
 				"&macos_settings_disk_encryption=enforcing&os_settings=pending&os_settings_disk_encryption=failed" +
 				"&bootstrap_package=installed&mdm_id=6&mdm_name=mdmName&mdm_enrollment_status=automatic" +
-				"&munki_issue_id=7&low_disk_space=99&vulnerability=CVE-2023-42887&populate_policies=true",
+				"&munki_issue_id=7&low_disk_space=99&vulnerability=CVE-2023-42887&populate_policies=true&profile_uuid=123-abc&profile_status=verified",
 			hostListOptions: fleet.HostListOptions{
 				ListOptions: fleet.ListOptions{
 					OrderKey:       "foo",
@@ -190,6 +191,8 @@ func TestHostListOptionsFromRequest(t *testing.T) {
 				LowDiskSpaceFilter:                ptr.Int(99),
 				VulnerabilityFilter:               ptr.String("CVE-2023-42887"),
 				PopulatePolicies:                  true,
+				ProfileUUIDFilter:                 ptr.String("123-abc"),
+				ProfileStatusFilter:               &verified,
 			},
 		},
 		"policy_id and policy_response params (for coverage)": {
@@ -352,6 +355,20 @@ func TestHostListOptionsFromRequest(t *testing.T) {
 		"invalid populate_policies": {
 			url:          "/foo?populate_policies=foo",
 			errorMessage: "populate_policies",
+		},
+		"invalid combination profile_uuid wihtout profile_status": {
+			url: "/foo?profile_uuid=123-abc",
+			hostListOptions: fleet.HostListOptions{
+				ProfileUUIDFilter: ptr.String("123-abc"),
+			},
+			errorMessage: "Missing profile_status (it must be present when profile_uuid is specified)",
+		},
+		"invalid combination profile_status wihtout profile_uuid": {
+			url: "/foo?profile_status=verified",
+			hostListOptions: fleet.HostListOptions{
+				ProfileStatusFilter: &verified,
+			},
+			errorMessage: "Missing profile_uuid (it must be present when profile_status is specified)",
 		},
 	}
 


### PR DESCRIPTION
For [#28761](https://github.com/fleetdm/fleet/issues/28761)

This adds the ability to filter the hosts by `profile_uuid` and `profile_status` query params. This was added for the following endpoints:

```
GET /hosts
GET /hosts/count
GET /hosts/reports
```

This also adds the UI needed to send the query params to the API correctly when exporting a CSV of the hosts

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
- [x] Added/updated automated tests
- [x] Manual QA for all new/changed functionality
