### PR TITLE
BE: Return software title id in adding vpp response

### DIFF
--- a/ee/server/service/vpp.go
+++ b/ee/server/service/vpp.go
@@ -316,15 +316,15 @@ func getPlatformsFromSupportedDevices(supportedDevices []string) map[fleet.Apple
 	return platforms
 }
 
-func (svc *Service) AddAppStoreApp(ctx context.Context, teamID *uint, appID fleet.VPPAppTeam) error {
+func (svc *Service) AddAppStoreApp(ctx context.Context, teamID *uint, appID fleet.VPPAppTeam) (uint, error) {
 	if err := svc.authz.Authorize(ctx, &fleet.VPPApp{TeamID: teamID}, fleet.ActionWrite); err != nil {
-		return err
+		return 0, err
 	}
 	if appID.AddAutoInstallPolicy {
 		// Currently, same write permissions are applied on software and policies,
 		// but leaving this here in case it changes in the future.
 		if err := svc.authz.Authorize(ctx, &fleet.Policy{PolicyData: fleet.PolicyData{TeamID: teamID}}, fleet.ActionWrite); err != nil {
-			return err
+			return 0, err
 		}
 	}
 
@@ -333,47 +333,47 @@ func (svc *Service) AddAppStoreApp(ctx context.Context, teamID *uint, appID flee
 		appID.Platform = fleet.MacOSPlatform
 	}
 	if appID.Platform != fleet.IOSPlatform && appID.Platform != fleet.IPadOSPlatform && appID.Platform != fleet.MacOSPlatform {
-		return fleet.NewInvalidArgumentError("platform",
+		return 0, fleet.NewInvalidArgumentError("platform",
 			fmt.Sprintf("platform must be one of '%s', '%s', or '%s", fleet.IOSPlatform, fleet.IPadOSPlatform, fleet.MacOSPlatform))
 	}
 
 	validatedLabels, err := ValidateSoftwareLabels(ctx, svc, appID.LabelsIncludeAny, appID.LabelsExcludeAny)
 	if err != nil {
-		return ctxerr.Wrap(ctx, err, "validating software labels for adding vpp app")
+		return 0, ctxerr.Wrap(ctx, err, "validating software labels for adding vpp app")
 	}
 
 	var teamName string
 	if teamID != nil && *teamID != 0 {
 		tm, err := svc.ds.Team(ctx, *teamID)
 		if fleet.IsNotFound(err) {
-			return fleet.NewInvalidArgumentError("team_id", fmt.Sprintf("team %d does not exist", *teamID)).
+			return 0, fleet.NewInvalidArgumentError("team_id", fmt.Sprintf("team %d does not exist", *teamID)).
 				WithStatus(http.StatusNotFound)
 		} else if err != nil {
-			return ctxerr.Wrap(ctx, err, "checking if team exists")
+			return 0, ctxerr.Wrap(ctx, err, "checking if team exists")
 		}
 
 		teamName = tm.Name
 	}
 
 	if appID.SelfService && appID.Platform != fleet.MacOSPlatform {
-		return fleet.NewUserMessageError(errors.New("Currently, self-service is only supported on macOS, Windows, and Linux. Please add the app without self_service and manually install it on the Host details page."), http.StatusBadRequest)
+		return 0, fleet.NewUserMessageError(errors.New("Currently, self-service is only supported on macOS, Windows, and Linux. Please add the app without self_service and manually install it on the Host details page."), http.StatusBadRequest)
 	}
 	if appID.AddAutoInstallPolicy && appID.Platform != fleet.MacOSPlatform {
-		return fleet.NewUserMessageError(errors.New("Currently, automatic install is only supported on macOS, Windows, and Linux. Please add the app without automatic_install and manually install it on the Host details page."), http.StatusBadRequest)
+		return 0, fleet.NewUserMessageError(errors.New("Currently, automatic install is only supported on macOS, Windows, and Linux. Please add the app without automatic_install and manually install it on the Host details page."), http.StatusBadRequest)
 	}
 
 	vppToken, err := svc.getVPPToken(ctx, teamID)
 	if err != nil {
-		return ctxerr.Wrap(ctx, err, "retrieving VPP token")
+		return 0, ctxerr.Wrap(ctx, err, "retrieving VPP token")
 	}
 
 	assets, err := vpp.GetAssets(vppToken, &vpp.AssetFilter{AdamID: appID.AdamID})
 	if err != nil {
-		return ctxerr.Wrap(ctx, err, "retrieving VPP asset")
+		return 0, ctxerr.Wrap(ctx, err, "retrieving VPP asset")
 	}
 
 	if len(assets) == 0 {
-		return ctxerr.New(ctx,
+		return 0, ctxerr.New(ctx,
 			fmt.Sprintf("Error: Couldn't add software. %s isn't available in Apple Business Manager. Please purchase license in Apple Business Manager and try again.",
 				appID.AdamID))
 	}
@@ -382,25 +382,25 @@ func (svc *Service) AddAppStoreApp(ctx context.Context, teamID *uint, appID flee
 
 	assetMetadata, err := itunes.GetAssetMetadata([]string{asset.AdamID}, &itunes.AssetMetadataFilter{Entity: "software"})
 	if err != nil {
-		return ctxerr.Wrap(ctx, err, "fetching VPP asset metadata")
+		return 0, ctxerr.Wrap(ctx, err, "fetching VPP asset metadata")
 	}
 
 	assetMD := assetMetadata[asset.AdamID]
 
 	platforms := getPlatformsFromSupportedDevices(assetMD.SupportedDevices)
 	if _, ok := platforms[appID.Platform]; !ok {
-		return fleet.NewInvalidArgumentError("app_store_id", fmt.Sprintf("%s isn't available for %s", assetMD.TrackName, appID.Platform))
+		return 0, fleet.NewInvalidArgumentError("app_store_id", fmt.Sprintf("%s isn't available for %s", assetMD.TrackName, appID.Platform))
 	}
 
 	if appID.Platform == fleet.MacOSPlatform {
 		// Check if we've already added an installer for this app
 		exists, err := svc.ds.UploadedSoftwareExists(ctx, assetMD.BundleID, teamID)
 		if err != nil {
-			return ctxerr.Wrap(ctx, err, "checking existence of VPP app installer")
+			return 0, ctxerr.Wrap(ctx, err, "checking existence of VPP app installer")
 		}
 
 		if exists {
-			return ctxerr.New(ctx,
+			return 0, ctxerr.New(ctx,
 				fmt.Sprintf("Error: Couldn't add software. %s already has software available for install on the %s team.",
 					assetMD.TrackName, teamName))
 		}
@@ -411,11 +411,11 @@ func (svc *Service) AddAppStoreApp(ctx context.Context, teamID *uint, appID flee
 	appID.Categories = server.RemoveDuplicatesFromSlice(appID.Categories)
 	catIDs, err := svc.ds.GetSoftwareCategoryIDs(ctx, appID.Categories)
 	if err != nil {
-		return ctxerr.Wrap(ctx, err, "getting software category ids")
+		return 0, ctxerr.Wrap(ctx, err, "getting software category ids")
 	}
 
 	if len(catIDs) != len(appID.Categories) {
-		return &fleet.BadRequestError{
+		return 0, &fleet.BadRequestError{
 			Message:     "some or all of the categories provided don't exist",
 			InternalErr: fmt.Errorf("categories provided: %v", appID.Categories),
 		}
@@ -432,7 +432,7 @@ func (svc *Service) AddAppStoreApp(ctx context.Context, teamID *uint, appID flee
 
 	addedApp, err := svc.ds.InsertVPPAppWithTeam(ctx, app, teamID)
 	if err != nil {
-		return ctxerr.Wrap(ctx, err, "writing VPP app to db")
+		return 0, ctxerr.Wrap(ctx, err, "writing VPP app to db")
 	}
 
 	actLabelsIncl, actLabelsExcl := activitySoftwareLabelsFromValidatedLabels(addedApp.ValidatedLabels)
@@ -449,10 +449,10 @@ func (svc *Service) AddAppStoreApp(ctx context.Context, teamID *uint, appID flee
 		LabelsExcludeAny: actLabelsExcl,
 	}
 	if err := svc.NewActivity(ctx, authz.UserFromContext(ctx), act); err != nil {
-		return ctxerr.Wrap(ctx, err, "create activity for add app store app")
+		return 0, ctxerr.Wrap(ctx, err, "create activity for add app store app")
 	}
 
-	return nil
+	return addedApp.TitleID, nil
 }
 
 func getVPPAppsMetadata(ctx context.Context, ids []fleet.VPPAppTeam) ([]*fleet.VPPApp, error) {

--- a/server/fleet/service.go
+++ b/server/fleet/service.go
@@ -702,7 +702,7 @@ type Service interface {
 
 	GetAppStoreApps(ctx context.Context, teamID *uint) ([]*VPPApp, error)
 
-	AddAppStoreApp(ctx context.Context, teamID *uint, appTeam VPPAppTeam) error
+	AddAppStoreApp(ctx context.Context, teamID *uint, appTeam VPPAppTeam) (uint, error)
 	UpdateAppStoreApp(ctx context.Context, titleID uint, teamID *uint, selfService bool, labelsIncludeAny, labelsExcludeAny, categories []string) (*VPPAppStoreApp, error)
 
 	// MDMAppleProcessOTAEnrollment handles OTA enrollment requests.

--- a/server/fleet/service.go
+++ b/server/fleet/service.go
@@ -702,6 +702,7 @@ type Service interface {
 
 	GetAppStoreApps(ctx context.Context, teamID *uint) ([]*VPPApp, error)
 
+	// AddAppStoreApp persists a VPP app onto a team and returns the resulting title ID
 	AddAppStoreApp(ctx context.Context, teamID *uint, appTeam VPPAppTeam) (uint, error)
 	UpdateAppStoreApp(ctx context.Context, titleID uint, teamID *uint, selfService bool, labelsIncludeAny, labelsExcludeAny, categories []string) (*VPPAppStoreApp, error)
 

--- a/server/service/integration_mdm_test.go
+++ b/server/service/integration_mdm_test.go
@@ -11556,6 +11556,7 @@ func (s *integrationMDMTestSuite) TestVPPApps() {
 		addAppReq.LabelsExcludeAny = []string{}
 		s.DoJSON("POST", "/api/latest/fleet/software/app_store_apps", addAppReq, http.StatusOK, &addAppResp)
 		titleID := getSoftwareTitleIDFromApp(&includeAnyApp)
+		require.Equal(t, titleID, addAppResp.TitleID, "addAppResp should contain the correct software title ID")
 		activityData := `{"team_name": "%s", "software_title": "%s", "software_title_id": %d, "app_store_id": "%s", "team_id": %d, "platform": "%s", "self_service": true, "labels_include_any": [{"id": %d, "name": %q}]}`
 		s.lastActivityMatches(fleet.ActivityAddedAppStoreApp{}.ActivityName(),
 			fmt.Sprintf(activityData, team.Name,

--- a/server/service/software_installers_test.go
+++ b/server/service/software_installers_test.go
@@ -146,7 +146,7 @@ func TestSoftwareInstallersAuth(t *testing.T) {
 				checkAuthErr(t, true, err)
 			}
 
-			err = svc.AddAppStoreApp(ctx, tt.teamID, fleet.VPPAppTeam{VPPAppID: fleet.VPPAppID{AdamID: "123", Platform: fleet.IOSPlatform}})
+			_, err = svc.AddAppStoreApp(ctx, tt.teamID, fleet.VPPAppTeam{VPPAppID: fleet.VPPAppID{AdamID: "123", Platform: fleet.IOSPlatform}})
 			if tt.teamID == nil {
 				require.Error(t, err)
 			} else if tt.shouldFailWrite {

--- a/server/service/vpp.go
+++ b/server/service/vpp.go
@@ -61,14 +61,15 @@ type addAppStoreAppRequest struct {
 }
 
 type addAppStoreAppResponse struct {
-	Err error `json:"error,omitempty"`
+	TitleID uint  `json:"software_title_id,omitempty"`
+	Err     error `json:"error,omitempty"`
 }
 
 func (r addAppStoreAppResponse) Error() error { return r.Err }
 
 func addAppStoreAppEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (fleet.Errorer, error) {
 	req := request.(*addAppStoreAppRequest)
-	err := svc.AddAppStoreApp(ctx, req.TeamID, fleet.VPPAppTeam{
+	titleID, err := svc.AddAppStoreApp(ctx, req.TeamID, fleet.VPPAppTeam{
 		VPPAppID:             fleet.VPPAppID{AdamID: req.AppStoreID, Platform: req.Platform},
 		SelfService:          req.SelfService,
 		LabelsIncludeAny:     req.LabelsIncludeAny,
@@ -80,15 +81,15 @@ func addAppStoreAppEndpoint(ctx context.Context, request interface{}, svc fleet.
 		return &addAppStoreAppResponse{Err: err}, nil
 	}
 
-	return &addAppStoreAppResponse{}, nil
+	return &addAppStoreAppResponse{TitleID: titleID}, nil
 }
 
-func (svc *Service) AddAppStoreApp(ctx context.Context, _ *uint, _ fleet.VPPAppTeam) error {
+func (svc *Service) AddAppStoreApp(ctx context.Context, _ *uint, _ fleet.VPPAppTeam) (uint, error) {
 	// skipauth: No authorization check needed due to implementation returning
 	// only license error.
 	svc.authz.SkipAuthorization(ctx)
 
-	return fleet.ErrMissingLicense
+	return 0, fleet.ErrMissingLicense
 }
 
 //////////////////////////////////////////////////////////////////////////////

--- a/server/service/vpp_test.go
+++ b/server/service/vpp_test.go
@@ -97,7 +97,7 @@ func TestVPPAuth(t *testing.T) {
 				checkAuthErr(t, tt.shouldFailRead, err)
 			}
 
-			err = svc.AddAppStoreApp(ctx, tt.teamID, fleet.VPPAppTeam{VPPAppID: fleet.VPPAppID{AdamID: "123", Platform: fleet.IOSPlatform}})
+			_, err = svc.AddAppStoreApp(ctx, tt.teamID, fleet.VPPAppTeam{VPPAppID: fleet.VPPAppID{AdamID: "123", Platform: fleet.IOSPlatform}})
 			if tt.teamID == nil {
 				require.Error(t, err)
 			} else {


### PR DESCRIPTION
## Issue
For #28110 

## Description
- API response for adding VPP includes software title ID so user can be re-routed to software title details page after adding VPP app to be consistent with routing for FMA and custom packages


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->


- [x] Added/updated automated tests
- [x] Manual QA for all new/changed functionality
