### PR TITLE
Fleet UI components; Editor copy button added, File details/uploader gitopsCompatible can now be false

### DIFF
--- a/frontend/components/Editor/Editor.stories.tsx
+++ b/frontend/components/Editor/Editor.stories.tsx
@@ -1,0 +1,170 @@
+import { Meta, StoryObj } from "@storybook/react";
+import { action } from "@storybook/addon-actions";
+
+import Editor from ".";
+
+const meta: Meta<typeof Editor> = {
+  component: Editor,
+  title: "Components/FormFields/Editor",
+  argTypes: {
+    mode: {
+      control: "select",
+      options: ["sh", "powershell"],
+      description: "Syntax highlighting mode",
+    },
+    readOnly: { control: "boolean" },
+    enableCopy: { control: "boolean" },
+    wrapEnabled: { control: "boolean" },
+    isFormField: { control: "boolean" },
+    focus: { control: "boolean" },
+    label: { control: "text" },
+    labelTooltip: { control: "text" },
+    error: { control: "text" },
+    helpText: { control: "text" },
+    value: { control: "text" },
+    defaultValue: { control: "text" },
+    maxLines: { control: "number" },
+    name: { control: "text" },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Editor>;
+
+export const Default: Story = {
+  args: {
+    name: "default-editor",
+    label: "Shell Script Editor",
+    value: "#!/bin/bash\necho 'Hello, World!'",
+    mode: "sh",
+    onChange: action("onChange"),
+    onBlur: action("onBlur"),
+  },
+};
+
+export const WithError: Story = {
+  args: {
+    ...Default.args,
+    name: "error-editor",
+    label: "Editor with Error",
+    error: "There is a syntax error",
+    value: "echo 'Missing closing quote",
+  },
+};
+
+export const WithHelpText: Story = {
+  args: {
+    ...Default.args,
+    name: "help-text-editor",
+    label: "Editor with Help Text",
+    helpText: "Write your shell script here. Supports Bash and PowerShell.",
+  },
+};
+
+export const WithTooltip: Story = {
+  args: {
+    ...Default.args,
+    name: "tooltip-editor",
+    label: "Editor with Tooltip",
+    labelTooltip: "This editor supports syntax highlighting for shell scripts.",
+  },
+};
+
+export const ReadOnly: Story = {
+  args: {
+    ...Default.args,
+    name: "readonly-editor",
+    label: "Read-only Editor",
+    readOnly: true,
+    value: "# This editor is read-only\nls -la",
+  },
+};
+
+export const WithCopyButton: Story = {
+  args: {
+    ...Default.args,
+    name: "copy-editor",
+    label: "Editor with Copy Button",
+    value: "echo 'Copy this script!'",
+    enableCopy: true,
+  },
+};
+
+export const PowerShellMode: Story = {
+  args: {
+    ...Default.args,
+    name: "powershell-editor",
+    label: "PowerShell Editor",
+    value: "Write-Host 'Hello from PowerShell!'",
+    mode: "powershell",
+  },
+};
+
+export const WrappedLines: Story = {
+  args: {
+    ...Default.args,
+    name: "wrapped-lines-editor",
+    label: "Editor with Wrapped Lines",
+    value:
+      "# This is a very long line that should wrap to the next line in the editor to demonstrate the wrapEnabled prop in action.",
+    wrapEnabled: true,
+  },
+};
+
+export const CustomMaxLines: Story = {
+  args: {
+    ...Default.args,
+    name: "custom-maxlines-editor",
+    label: "Editor with Custom Max Lines",
+    value: "echo 'Line 1'\necho 'Line 2'\necho 'Line 3'\n",
+    maxLines: 3,
+  },
+};
+
+export const LongScriptWithCopy: Story = {
+  args: {
+    name: "long-script-editor",
+    label: "Long Script with Copy Button",
+    enableCopy: true,
+    mode: "sh",
+    value: `#!/bin/bash
+# This is a long example script to test the editor's UI with overflow and copy button interaction.
+
+echo "Starting system update..."
+sudo apt-get update -y && sudo apt-get upgrade -y
+
+echo "Installing dependencies..."
+sudo apt-get install -y git curl wget unzip build-essential python3 python3-pip
+
+echo "Cloning repository..."
+git clone https://github.com/example/repo.git /opt/example-repo
+
+echo "Setting up environment variables..."
+export APP_ENV=production
+export DB_HOST=localhost
+export DB_PORT=5432
+export DB_USER=admin
+export DB_PASSWORD=supersecurepassword1234567890
+
+echo "Configuring application..."
+cd /opt/example-repo
+cp config.example.json config.json
+sed -i 's/localhost/127.0.0.1/g' config.json
+
+echo "Running database migrations..."
+python3 manage.py migrate
+
+echo "Starting application..."
+nohup python3 manage.py runserver 0.0.0.0:8000 &
+
+echo "Setup complete! Application is running."
+`,
+    wrapEnabled: false, // Try toggling this to true to see the difference!
+    maxLines: 20,
+    helpText:
+      "This is a realistic, long shell script. Try copying it or scrolling horizontally.",
+    onChange: action("onChange"),
+    onBlur: action("onBlur"),
+  },
+};

--- a/frontend/components/Editor/Editor.tsx
+++ b/frontend/components/Editor/Editor.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode, useState } from "react";
+import React, { MouseEvent, ReactNode, useState, useCallback } from "react";
 
 import classnames from "classnames";
 import AceEditor from "react-ace";
@@ -84,13 +84,12 @@ const Editor = ({
   const classNames = classnames(baseClass, className, {
     "form-field": isFormField,
     [`${baseClass}__error`]: !!error,
-    [`${baseClass}__wrapper--copy-enabled`]: enableCopy,
   });
 
   const [showCopiedMessage, setShowCopiedMessage] = useState(false);
 
-  const renderCopyButton = () => {
-    const copyValue = (e: React.MouseEvent) => {
+  const onClickCopy = useCallback(
+    (e: MouseEvent) => {
       e.preventDefault();
       stringToClipboard(value).then(() => {
         setShowCopiedMessage(true);
@@ -98,8 +97,11 @@ const Editor = ({
           setShowCopiedMessage(false);
         }, 2000);
       });
-    };
+    },
+    [value]
+  );
 
+  const renderCopyButton = () => {
     const copyButtonValue = <Icon name="copy" />;
     const wrapperClasses = classnames(`${baseClass}__copy-wrapper`);
 
@@ -112,7 +114,7 @@ const Editor = ({
         {showCopiedMessage && (
           <span className={copiedConfirmationClasses}>Copied!</span>
         )}
-        <Button variant={"icon"} onClick={copyValue} iconStroke>
+        <Button variant={"icon"} onClick={onClickCopy} iconStroke>
           {copyButtonValue}
         </Button>
       </div>
@@ -167,7 +169,7 @@ const Editor = ({
   return (
     <div className={classNames}>
       {renderLabel()}
-      {renderCopyButton()}
+      {enableCopy && renderCopyButton()}
       <AceEditor
         mode={mode}
         wrapEnabled={wrapEnabled}

--- a/frontend/components/Editor/Editor.tsx
+++ b/frontend/components/Editor/Editor.tsx
@@ -1,10 +1,16 @@
+import React, { ReactNode, useState } from "react";
+
 import classnames from "classnames";
-import TooltipWrapper from "components/TooltipWrapper";
-import React, { ReactNode } from "react";
 import AceEditor from "react-ace";
 import "ace-builds/src-noconflict/mode-sh";
 import "ace-builds/src-noconflict/mode-powershell";
 import { IAceEditor } from "react-ace/lib/types";
+
+import { stringToClipboard } from "utilities/copy_text";
+
+import TooltipWrapper from "components/TooltipWrapper";
+import Button from "components/buttons/Button";
+import Icon from "components/Icon";
 
 const baseClass = "editor";
 
@@ -24,6 +30,10 @@ interface IEditorProps {
   /** Sets the default value of the input. Use this if you'd like the editor
    * to be an uncontrolled component */
   defaultValue?: string;
+  /** Enable copying the value of the editor.
+   * @default false
+   */
+  enableCopy?: boolean;
   /** Enabled wrapping lines.
    * @default false
    */
@@ -36,7 +46,7 @@ interface IEditorProps {
    */
   mode?: string;
   /** Include correct styles as a form field.
-   * @default false
+   * @default true
    */
   isFormField?: boolean;
   maxLines?: number;
@@ -61,10 +71,11 @@ const Editor = ({
   value,
   defaultValue,
   readOnly = false,
+  enableCopy = false,
   wrapEnabled = false,
   name = "editor",
   mode,
-  isFormField = false,
+  isFormField = true,
   maxLines = 20,
   className,
   onChange,
@@ -73,7 +84,40 @@ const Editor = ({
   const classNames = classnames(baseClass, className, {
     "form-field": isFormField,
     [`${baseClass}__error`]: !!error,
+    [`${baseClass}__wrapper--copy-enabled`]: enableCopy,
   });
+
+  const [showCopiedMessage, setShowCopiedMessage] = useState(false);
+
+  const renderCopyButton = () => {
+    const copyValue = (e: React.MouseEvent) => {
+      e.preventDefault();
+      stringToClipboard(value).then(() => {
+        setShowCopiedMessage(true);
+        setTimeout(() => {
+          setShowCopiedMessage(false);
+        }, 2000);
+      });
+    };
+
+    const copyButtonValue = <Icon name="copy" />;
+    const wrapperClasses = classnames(`${baseClass}__copy-wrapper`);
+
+    const copiedConfirmationClasses = classnames(
+      `${baseClass}__copied-confirmation`
+    );
+
+    return (
+      <div className={wrapperClasses}>
+        {showCopiedMessage && (
+          <span className={copiedConfirmationClasses}>Copied!</span>
+        )}
+        <Button variant={"icon"} onClick={copyValue} iconStroke>
+          {copyButtonValue}
+        </Button>
+      </div>
+    );
+  };
 
   const onLoadHandler = (editor: IAceEditor) => {
     // Lose focus using the Escape key so you can Tab forward (or Shift+Tab backwards) through app
@@ -123,6 +167,7 @@ const Editor = ({
   return (
     <div className={classNames}>
       {renderLabel()}
+      {renderCopyButton()}
       <AceEditor
         mode={mode}
         wrapEnabled={wrapEnabled}

--- a/frontend/components/Editor/_styles.scss
+++ b/frontend/components/Editor/_styles.scss
@@ -1,4 +1,5 @@
 .editor {
+  position: relative; // needed for copy button
 
   &__label {
     font-size: $x-small;
@@ -17,5 +18,19 @@
     .ace-fleet {
       border: 1px solid $core-vibrant-red;
     }
+  }
+
+  /* Matches inputfield copy button position */
+  &__copy-wrapper {
+    position: absolute;
+    top: 28px;
+    right: 5px;
+    z-index: 2; /* Ensure it's above the editor */
+    display: flex;
+    align-items: center;
+  }
+
+  &__copied-confirmation {
+    @include copy-message;
   }
 }

--- a/frontend/components/FileDetails/FileDetails.tsx
+++ b/frontend/components/FileDetails/FileDetails.tsx
@@ -23,6 +23,8 @@ interface IFileDetailsProps {
   onFileSelect?: (e: React.ChangeEvent<HTMLInputElement>) => void;
   accept?: string;
   progress?: number;
+  /** Set to false for one instance we allow users to edit a file as it shows them the YAML */
+  gitopsCompatible?: boolean;
   gitOpsModeEnabled?: boolean;
 }
 
@@ -35,10 +37,12 @@ const FileDetails = ({
   onFileSelect,
   accept,
   progress,
+  gitopsCompatible = true,
   gitOpsModeEnabled = false,
 }: IFileDetailsProps) => {
   const infoClasses = classnames(`${baseClass}__info`, {
-    [`${baseClass}__info--disabled-by-gitops-mode`]: gitOpsModeEnabled,
+    [`${baseClass}__info--disabled-by-gitops-mode`]:
+      gitOpsModeEnabled && gitopsCompatible,
   });
   return (
     <div className={baseClass}>
@@ -58,32 +62,49 @@ const FileDetails = ({
           )}
         </div>
       </div>
-      {!progress && canEdit && onFileSelect && (
-        <GitOpsModeTooltipWrapper
-          position="left"
-          tipOffset={-8}
-          renderChildren={(disableChildren) => (
-            <div className={`${baseClass}__edit`}>
-              <Button
-                disabled={disableChildren}
-                className={`${baseClass}__edit-button`}
-                variant="icon"
-              >
-                <label htmlFor="edit-file">
-                  <Icon name="pencil" color="ui-fleet-black-75" />
-                </label>
-              </Button>
-              <input
-                disabled={disableChildren}
-                accept={accept}
-                id="edit-file"
-                type="file"
-                onChange={onFileSelect}
-              />
-            </div>
-          )}
-        />
-      )}
+      {!progress &&
+        canEdit &&
+        onFileSelect &&
+        (gitopsCompatible ? (
+          <GitOpsModeTooltipWrapper
+            position="left"
+            tipOffset={4}
+            renderChildren={(disableChildren) => (
+              <div className={`${baseClass}__edit`}>
+                <Button
+                  disabled={disableChildren}
+                  className={`${baseClass}__edit-button`}
+                  variant="icon"
+                >
+                  <label htmlFor="edit-file">
+                    <Icon name="pencil" color="ui-fleet-black-75" />
+                  </label>
+                </Button>
+                <input
+                  disabled={disableChildren}
+                  accept={accept}
+                  id="edit-file"
+                  type="file"
+                  onChange={onFileSelect}
+                />
+              </div>
+            )}
+          />
+        ) : (
+          <div className={`${baseClass}__edit`}>
+            <Button className={`${baseClass}__edit-button`} variant="icon">
+              <label htmlFor="edit-file">
+                <Icon name="pencil" color="ui-fleet-black-75" />
+              </label>
+            </Button>
+            <input
+              accept={accept}
+              id="edit-file"
+              type="file"
+              onChange={onFileSelect}
+            />
+          </div>
+        ))}
       {!!progress && (
         <div className={`${baseClass}__progress-wrapper`}>
           <div className={`${baseClass}__progress-bar`}>

--- a/frontend/components/FileUploader/FileUploader.tsx
+++ b/frontend/components/FileUploader/FileUploader.tsx
@@ -216,7 +216,8 @@ export const FileUploader = ({
           canEdit={canEdit}
           onFileSelect={onFileSelect}
           accept={accept}
-          gitOpsModeEnabled={gitopsCompatible && gitOpsModeEnabled}
+          gitopsCompatible={gitopsCompatible}
+          gitOpsModeEnabled={gitOpsModeEnabled}
         />
       ) : (
         renderFileUploader()

--- a/frontend/components/forms/fields/InputField/InputField.jsx
+++ b/frontend/components/forms/fields/InputField/InputField.jsx
@@ -107,6 +107,16 @@ class InputField extends Component {
     return false;
   };
 
+  onClickCopy = (e) => {
+    e.preventDefault();
+    stringToClipboard(this.props.value).then(() => {
+      this.setState({ copied: true });
+      setTimeout(() => {
+        this.setState({ copied: false });
+      }, 2000);
+    });
+  };
+
   renderShowSecretButton = () => {
     const { onToggleSecret } = this;
 
@@ -122,17 +132,7 @@ class InputField extends Component {
   };
 
   renderCopyButton = () => {
-    const { value } = this.props;
-
-    const copyValue = (e) => {
-      e.preventDefault();
-      stringToClipboard(value).then(() => {
-        this.setState({ copied: true });
-        setTimeout(() => {
-          this.setState({ copied: false });
-        }, 2000);
-      });
-    };
+    const { onClickCopy } = this;
 
     const copyButtonValue = <Icon name="copy" />;
     const wrapperClasses = classnames(`${baseClass}__copy-wrapper`);
@@ -146,7 +146,7 @@ class InputField extends Component {
         {this.state.copied && (
           <span className={copiedConfirmationClasses}>Copied!</span>
         )}
-        <Button variant={"icon"} onClick={copyValue} iconStroke>
+        <Button variant={"icon"} onClick={onClickCopy} iconStroke>
           {copyButtonValue}
         </Button>
         {this.props.enableShowSecret && this.renderShowSecretButton()}

--- a/frontend/components/forms/fields/InputField/_styles.scss
+++ b/frontend/components/forms/fields/InputField/_styles.scss
@@ -110,14 +110,14 @@
 
   &__input-container.copy-enabled {
     position: relative;
+
+    .input-field {
+      padding-right: 35px; // horizontal scroll of long inputs will not be hidden by copy button
+    }
   }
 
   &__copied-confirmation {
-    font-size: $x-small;
-    background-color: $ui-light-grey;
-    border: solid 1px $ui-fleet-black-10;
-    border-radius: $border-radius-xlarge;
-    padding: $pad-xxsmall 6px;
+    @include copy-message;
   }
 
   &__copied-confirmation-outside {

--- a/frontend/pages/ManageControlsPage/Scripts/components/EditScriptModal/EditScriptModal.tsx
+++ b/frontend/pages/ManageControlsPage/Scripts/components/EditScriptModal/EditScriptModal.tsx
@@ -172,7 +172,6 @@ const EditScriptModal = ({
           <Editor
             mode={mode}
             error={formError}
-            isFormField
             label="Script"
             onBlur={onBlur}
             onChange={onChange}

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/AdvancedOptionsModal/AdvancedOptionsModal.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/AdvancedOptionsModal/AdvancedOptionsModal.tsx
@@ -38,7 +38,6 @@ const AdvancedOptionsModal = ({
             helpText="Fleet will run this command on hosts to install software."
             label="Install script"
             labelTooltip="For security agents, add the script provided by the vendor."
-            isFormField
           />
           {preInstallQuery && (
             <div className={`${baseClass}__input-field`}>
@@ -73,7 +72,6 @@ const AdvancedOptionsModal = ({
                 maxLines={10}
                 value={postInstallScript}
                 helpText="Shell (macOS and Linux) or PowerShell (Windows)."
-                isFormField
               />
             </div>
           )}

--- a/frontend/pages/SoftwarePage/components/forms/AdvancedOptionsFields/AdvancedOptionsFields.tsx
+++ b/frontend/pages/SoftwarePage/components/forms/AdvancedOptionsFields/AdvancedOptionsFields.tsx
@@ -86,7 +86,6 @@ const AdvancedOptionsFields = ({
         helpText={installScriptHelpText}
         label="Install script"
         labelTooltip={installScriptTooltip}
-        isFormField
       />
       <Editor
         label="Post-install script"
@@ -98,7 +97,6 @@ const AdvancedOptionsFields = ({
         onChange={onChangePostInstallScript}
         value={postInstallScript}
         helpText={postInstallScriptHelpText}
-        isFormField
       />
       <Editor
         label="Uninstall script"
@@ -110,7 +108,6 @@ const AdvancedOptionsFields = ({
         onChange={onChangeUninstallScript}
         value={uninstallScript}
         helpText={uninstallScriptHelpText}
-        isFormField
       />
     </div>
   );


### PR DESCRIPTION
## Issue
For #28110 

## Description
- Updates to components that are needed to have #28110 functional (Breaking apart feature PR #29274 for review-ability)
- `Editor` now has an optional `enableCopy` prop for a copy button styled and in the same position as `InputField`'s `enableCopy`
- `FileUploader` and `FileDetails `need to allow for gitopsCompatible to allow uploading custom packages and editing custom packages and FMAs when gitops mode is enabled. Needed to add `gitopsCompatible` prop to account for that logic
- Cleaned up some redundant CSS
- `isFormField` prop is set on _all_ Editors which properly styles the Editor. Default to true to to remove prop

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

~~- [ ] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.~~
Changefile included in main ticket
- [x] Manual QA for all new/changed functionality
