### PR TITLE
Fleet UI: Reroute to software details page on add of FMA, VPP, custom pkg

### DIFF
--- a/frontend/__mocks__/softwareMock.ts
+++ b/frontend/__mocks__/softwareMock.ts
@@ -201,6 +201,7 @@ export const createMockSoftwareVersionResponse = (
 
 const DEFAULT_SOFTWARE_PACKAGE_MOCK: ISoftwarePackage = {
   name: "TestPackage-1.2.3.pkg",
+  title_id: 2,
   version: "1.2.3",
   uploaded_at: "2020-01-01T00:00:00.000Z",
   install_script: "sudo installer -pkg /temp/FalconSensor-6.44.pkg -target /",
@@ -220,7 +221,8 @@ const DEFAULT_SOFTWARE_PACKAGE_MOCK: ISoftwarePackage = {
   automatic_install_policies: [],
   last_install: null,
   last_uninstall: null,
-  package_url: "",
+  url: "https://fakeurl.testpackageurlforfalconapp.fake/test/package",
+  hash_sha256: "abcd1234",
   labels_include_any: null,
   labels_exclude_any: null,
 };

--- a/frontend/interfaces/software.ts
+++ b/frontend/interfaces/software.ts
@@ -84,9 +84,10 @@ export interface ISoftwareAppStoreAppStatus {
 
 export interface ISoftwarePackage {
   name: string;
+  title_id: number;
   last_install: string | null;
   last_uninstall: string | null;
-  package_url: string;
+  url: string;
   version: string;
   uploaded_at: string;
   install_script: string;

--- a/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareAppStoreVpp/SoftwareAppStoreVpp.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareAppStoreVpp/SoftwareAppStoreVpp.tsx
@@ -167,9 +167,9 @@ const SoftwareAppStoreVpp = ({
     setIsLoading(true);
 
     try {
-      const softwareVppTitleId: number = await mdmAppleAPI
-        .addVppApp(currentTeamId, formData)
-        .then((data) => data.software_title_id);
+      const {
+        software_title_id: softwareVppTitleId,
+      } = await mdmAppleAPI.addVppApp(currentTeamId, formData);
 
       renderFlash(
         "success",

--- a/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareAppStoreVpp/SoftwareAppStoreVpp.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareAppStoreVpp/SoftwareAppStoreVpp.tsx
@@ -167,7 +167,10 @@ const SoftwareAppStoreVpp = ({
     setIsLoading(true);
 
     try {
-      await mdmAppleAPI.addVppApp(currentTeamId, formData);
+      const softwareVppTitleId: number = await mdmAppleAPI
+        .addVppApp(currentTeamId, formData)
+        .then((data) => data.software_title_id);
+
       renderFlash(
         "success",
         <>
@@ -176,7 +179,12 @@ const SoftwareAppStoreVpp = ({
         { persistOnPageChange: true }
       );
 
-      goBackToSoftwareTitles(true);
+      router.push(
+        getPathWithQueryParams(
+          PATHS.SOFTWARE_TITLE_DETAILS(softwareVppTitleId.toString()),
+          { team_id: currentTeamId }
+        )
+      );
     } catch (e) {
       renderFlash("error", getErrorMessage(e));
     }

--- a/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareCustomPackage/SoftwareCustomPackage.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareCustomPackage/SoftwareCustomPackage.tsx
@@ -119,18 +119,18 @@ const SoftwareCustomPackage = ({
     // Note: This TODO is copied to onSaveSoftwareChanges in EditSoftwareModal
     // TODO: confirm we are deleting the second sentence (not modifying it) for non-self-service installers
     try {
-      const softwarePackageTitleId: number = await softwareAPI
-        .addSoftwarePackage({
-          data: formData,
-          teamId: currentTeamId,
-          onUploadProgress: (progressEvent) => {
-            const progress = progressEvent.progress || 0;
-            // for large uploads it seems to take a bit for the server to finalize its response so we'll keep the
-            // progress bar at 97% until the server response is received
-            setUploadProgress(Math.max(progress - 0.03, 0.01));
-          },
-        })
-        .then((data) => data.software_package.title_id);
+      const {
+        software_package: { title_id: softwarePackageTitleId },
+      } = await softwareAPI.addSoftwarePackage({
+        data: formData,
+        teamId: currentTeamId,
+        onUploadProgress: (progressEvent) => {
+          const progress = progressEvent.progress || 0;
+          // for large uploads it seems to take a bit for the server to finalize its response so we'll keep the
+          // progress bar at 97% until the server response is received
+          setUploadProgress(Math.max(progress - 0.03, 0.01));
+        },
+      });
 
       const newQueryParams: QueryParams = {
         team_id: currentTeamId,

--- a/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareCustomPackage/SoftwareCustomPackage.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareCustomPackage/SoftwareCustomPackage.tsx
@@ -119,35 +119,27 @@ const SoftwareCustomPackage = ({
     // Note: This TODO is copied to onSaveSoftwareChanges in EditSoftwareModal
     // TODO: confirm we are deleting the second sentence (not modifying it) for non-self-service installers
     try {
-      await softwareAPI.addSoftwarePackage({
-        data: formData,
-        teamId: currentTeamId,
-        onUploadProgress: (progressEvent) => {
-          const progress = progressEvent.progress || 0;
-          // for large uploads it seems to take a bit for the server to finalize its response so we'll keep the
-          // progress bar at 97% until the server response is received
-          setUploadProgress(Math.max(progress - 0.03, 0.01));
-        },
-      });
+      const softwarePackageTitleId: number = await softwareAPI
+        .addSoftwarePackage({
+          data: formData,
+          teamId: currentTeamId,
+          onUploadProgress: (progressEvent) => {
+            const progress = progressEvent.progress || 0;
+            // for large uploads it seems to take a bit for the server to finalize its response so we'll keep the
+            // progress bar at 97% until the server response is received
+            setUploadProgress(Math.max(progress - 0.03, 0.01));
+          },
+        })
+        .then((data) => data.software_package.title_id);
 
-      const newQueryParams: QueryParams = { team_id: currentTeamId };
-      if (formData.selfService) {
-        newQueryParams.self_service = true;
-      } else {
-        newQueryParams.available_for_install = true;
-      }
+      const newQueryParams: QueryParams = {
+        team_id: currentTeamId,
+      };
       router.push(
-        getPathWithQueryParams(PATHS.SOFTWARE_TITLES, newQueryParams)
-      );
-
-      renderFlash(
-        "success",
-        <>
-          <b>{formData.software?.name}</b> successfully added.
-          {formData.selfService
-            ? " The end user can install from Fleet Desktop."
-            : ""}
-        </>
+        getPathWithQueryParams(
+          PATHS.SOFTWARE_TITLE_DETAILS(softwarePackageTitleId.toString()),
+          newQueryParams
+        )
       );
     } catch (e) {
       renderFlash("error", getErrorMessage(e));

--- a/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareFleetMaintained/FleetMaintainedAppDetailsPage/FleetMaintainedAppDetailsPage.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareFleetMaintained/FleetMaintainedAppDetailsPage/FleetMaintainedAppDetailsPage.tsx
@@ -126,6 +126,7 @@ const FleetMaintainedAppDetailsPage = ({
 
   const handlePageError = useErrorHandler();
   const { isPremiumTier } = useContext(AppContext);
+
   const { selectedOsqueryTable, setSelectedOsqueryTable } = useContext(
     QueryContext
   );
@@ -198,22 +199,21 @@ const FleetMaintainedAppDetailsPage = ({
 
     setShowAddFleetAppSoftwareModal(true);
 
-    let titleId: number | undefined;
     try {
-      const res = await softwareAPI.addFleetMaintainedApp(
-        parseInt(teamId, 10),
-        {
+      const softwareFmaTitleId: number = await softwareAPI
+        .addFleetMaintainedApp(parseInt(teamId, 10), {
           ...formData,
           appId,
-        }
-      );
-      titleId = res.software_title_id;
+        })
+        .then((data) => data.software_title_id);
 
       router.push(
-        getPathWithQueryParams(PATHS.SOFTWARE_TITLES, {
-          team_id: teamId,
-          available_for_install: true,
-        })
+        getPathWithQueryParams(
+          PATHS.SOFTWARE_TITLE_DETAILS(softwareFmaTitleId.toString()),
+          {
+            team_id: teamId,
+          }
+        )
       );
 
       renderFlash(

--- a/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareFleetMaintained/FleetMaintainedAppDetailsPage/FleetMaintainedAppDetailsPage.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareFleetMaintained/FleetMaintainedAppDetailsPage/FleetMaintainedAppDetailsPage.tsx
@@ -200,12 +200,12 @@ const FleetMaintainedAppDetailsPage = ({
     setShowAddFleetAppSoftwareModal(true);
 
     try {
-      const softwareFmaTitleId: number = await softwareAPI
-        .addFleetMaintainedApp(parseInt(teamId, 10), {
-          ...formData,
-          appId,
-        })
-        .then((data) => data.software_title_id);
+      const {
+        software_title_id: softwareFmaTitleId,
+      } = await softwareAPI.addFleetMaintainedApp(parseInt(teamId, 10), {
+        ...formData,
+        appId,
+      });
 
       router.push(
         getPathWithQueryParams(

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/helpers.tests.ts
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/helpers.tests.ts
@@ -28,7 +28,7 @@ describe("SoftwareTitleDetailsPage helpers", () => {
           automatic_install_policies: [],
           last_install: null,
           last_uninstall: null,
-          package_url: "",
+          url: "",
         },
         app_store_app: null,
         source: "apps",

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/helpers.tests.ts
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/helpers.tests.ts
@@ -12,6 +12,7 @@ describe("SoftwareTitleDetailsPage helpers", () => {
           labels_include_any: null,
           labels_exclude_any: null,
           name: "TestPackage.pkg",
+          title_id: 2,
           version: "1.0.0",
           self_service: true,
           uploaded_at: "2021-01-01T00:00:00Z",


### PR DESCRIPTION
## Issue
Prerequisite for #28110 

## Description
- Updates to behavior that is needed to have #28110 functional (Breaking apart feature PR #29274 for review-ability)
- Clean up mismatched types FE <> API
- Reroute on adding software (FMA, VPP, and custom package) to the software title details page instead of software titles table page

## Screen recording of new behavior

https://github.com/user-attachments/assets/94afbcad-78d7-4d64-918f-08865318eef4


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->


- [x] Manual QA for all new/changed functionality

