### PR TITLE
Don't clear SMTP settings if not supplied in GitOps

### DIFF
--- a/cmd/fleetctl/fleetctl/gitops_test.go
+++ b/cmd/fleetctl/fleetctl/gitops_test.go
@@ -2961,7 +2961,24 @@ func TestGitOpsSMTPSettings(t *testing.T) {
 	_, err := RunAppNoChecks([]string{"gitops", "-f", globalFileBasic.Name()})
 	require.NoError(t, err)
 
-	require.Nil(t, appConfig.SMTPSettings)
+	// Currently we do NOT clear the SMTP settings if they are not in the config,
+	// because the smtp_settings key is not documented in the GitOps config.
+	// TODO - update this test if we change this behavior.
+	require.Equal(t, &fleet.SMTPSettings{
+		SMTPEnabled:              true,
+		SMTPConfigured:           true,
+		SMTPSenderAddress:        "http://example.com",
+		SMTPServer:               "server.example.com",
+		SMTPPort:                 587,
+		SMTPAuthenticationType:   "smoooth",
+		SMTPUserName:             "uzer",
+		SMTPPassword:             "********",
+		SMTPEnableTLS:            true,
+		SMTPAuthenticationMethod: "crunchy",
+		SMTPDomain:               "smtp.example.com",
+		SMTPVerifySSLCerts:       true,
+		SMTPEnableStartTLS:       true,
+	}, appConfig.SMTPSettings)
 }
 
 func TestGitOpsMDMAuthSettings(t *testing.T) {

--- a/server/service/appconfig.go
+++ b/server/service/appconfig.go
@@ -357,7 +357,6 @@ func (svc *Service) ModifyAppConfig(ctx context.Context, p []byte, applyOpts fle
 	if applyOpts.Overwrite {
 		appConfig.Features = newAppConfig.Features
 		appConfig.SSOSettings = newAppConfig.SSOSettings
-		appConfig.SMTPSettings = newAppConfig.SMTPSettings
 		appConfig.MDM.EndUserAuthentication = newAppConfig.MDM.EndUserAuthentication
 	}
 


### PR DESCRIPTION
Revering [this change](https://github.com/fleetdm/fleet/pull/29215/files#diff-ff669b9f96ea80679f4651e9cf45ded57d5cd939d1e4e24977eb72d37d71e8bcR360) because the `smtp_settings` key is not documented in the GitOps docs, so we can't assume that people have it set already.