### PR TITLE
UI: User menu- restore 2 dividers, remove border radius

### DIFF
--- a/frontend/components/top_nav/UserMenu/UserMenu.tsx
+++ b/frontend/components/top_nav/UserMenu/UserMenu.tsx
@@ -227,7 +227,6 @@ const UserMenu = ({
       ...provided,
       padding: "10px 8px",
       fontSize: "15px",
-      borderRadius: "4px",
       backgroundColor: getOptionBackgroundColor(state),
       color: COLORS["tooltip-bg"],
       whiteSpace: "nowrap",
@@ -236,6 +235,9 @@ const UserMenu = ({
       },
       "&:active": {
         backgroundColor: COLORS["ui-vibrant-blue-25"],
+      },
+      "&:last-child, &:nth-last-of-type(2)": {
+        borderTop: `1px solid ${COLORS["ui-fleet-black-10"]}`,
       },
     }),
   };


### PR DESCRIPTION
## For #27609 

<img width="179" alt="Screenshot 2025-05-21 at 4 53 45 PM" src="https://github.com/user-attachments/assets/acfb15c1-a743-4a3a-9e6b-c2a7c9521f5b" />

This PR implements [the desired UI](https://github.com/fleetdm/fleet/issues/27609#issuecomment-2885250756) for the user menu

- ~[ ] Changes file added for user-visible changes in `changes/`~ [added in previous PR](https://github.com/fleetdm/fleet/pull/29066/files#diff-a072b167801f952e1d37dc5fdb98a4c292f95832b4d9c5e4eff40161ca3a40eaR1)
- [x] Manual QA for all new/changed functionality