### PR TITLE
Add OVAL supported OS mappings for Ubuntu 24.10 and 25.04

### DIFF
--- a/changes/29345-new-ubuntus
+++ b/changes/29345-new-ubuntus
@@ -1,0 +1,1 @@
+* Added vulnerability detection via OVAL for Ubuntu 24.10 and 25.04.

--- a/server/vulnerabilities/oval/oval_platform.go
+++ b/server/vulnerabilities/oval/oval_platform.go
@@ -104,6 +104,8 @@ func (op Platform) IsSupported() bool {
 		"ubuntu_2304",
 		"ubuntu_2310",
 		"ubuntu_2404",
+		"ubuntu_2410",
+		"ubuntu_2504",
 		"rhel_05",
 		"rhel_06",
 		"rhel_07",


### PR DESCRIPTION
For #29345.

Tested with Ubuntu 24.10. Can test again with 25.04 once https://github.com/fleetdm/nvd/pull/42 is merged.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.
- [x] Manual QA for all new/changed functionality