### PR TITLE
Revert documentation changes for #25545 (add software hash for macOS apps to host vitals)

### DIFF
--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -4087,8 +4087,7 @@ Resends a configuration profile for the specified host.
           "signature_information": [
             {
               "installed_path": "/Applications/Google Chrome.app",
-              "team_identifier": "EQHXZ8M8AV",
-              "hash_sha256": "3r639b6d7c99f6d79e50aeb4226b4662de3e377dc0957b2fd4d075859205a3d7"
+              "team_identifier": "EQHXZ8M8AV"
             }
           ]
         }
@@ -4139,8 +4138,7 @@ Resends a configuration profile for the specified host.
           "signature_information": [
             {
               "installed_path": "/Applications/Logic Pro.app",
-              "team_identifier": "",
-              "hash_sha256": "3r639b6d7c99f6d79e50aeb4226b4662de3e377dc0957b2fd4d075859205a3d7" 
+              "team_identifier": ""
             }
           ]
         }


### PR DESCRIPTION
Reverts changes from https://github.com/fleetdm/fleet/pull/28057

#25545 is now expected in 4.69.0.