### PR TITLE
Fleet UI: Uninstall self service status change bug

### DIFF
--- a/frontend/pages/hosts/details/cards/Software/SelfService/SelfService.tsx
+++ b/frontend/pages/hosts/details/cards/Software/SelfService/SelfService.tsx
@@ -264,7 +264,7 @@ const SoftwareSelfService = ({
   const onSuccessUninstallSoftwareModal = () => {
     selectedSoftware.current = null;
     setShowUninstallSoftwareModal(false);
-    onInstallOrUninstall;
+    onInstallOrUninstall();
   };
 
   const onNextPage = useCallback(() => {

--- a/frontend/pages/hosts/details/cards/Software/SelfService/_styles.scss
+++ b/frontend/pages/hosts/details/cards/Software/SelfService/_styles.scss
@@ -33,8 +33,10 @@
       gap: $pad-small;
     }
 
+    // No column shift when changed statuses
+    // min-width longest status: "Failed (uninstall)"
     .self-service-table__status-content {
-      min-width: 100px; // No table layout shift when changed to pending status
+      min-width: 138px;
     }
 
     .self-service-table__item-status-button {
@@ -56,7 +58,7 @@
     display: none;
   }
 
-  @media (min-width: $break-sm) {
+  @media (min-width: $break-md) {
     .categories-menu {
       display: flex;
       flex-direction: column;


### PR DESCRIPTION
## Issue
Followup For #28845 

## Description
- Forgot to call function that immediately updates install status to pending and button disabling
- Styling fixes so the column width isn't jumpy when install status becomes long string

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Manual QA for all new/changed functionality