### PR TITLE
Website: add  create-historical-event helper

### DIFF
--- a/website/api/controllers/create-or-update-one-newsletter-subscription.js
+++ b/website/api/controllers/create-or-update-one-newsletter-subscription.js
@@ -49,14 +49,24 @@ module.exports = {
         psychologicalStageChangeReason = this.req.session.adAttributionString;
       }
     }
+    sails.helpers.flow.build(async()=>{
+      let recordIds = await sails.helpers.salesforce.updateOrCreateContactAndAccount.with({
+        emailAddress: emailAddress,
+        contactSource: 'Website - Newsletter',
+        description: `Subscribed to the Fleet newsletter`,
+        psychologicalStage: '3 - Intrigued',
+        psychologicalStageChangeReason,
+      });
 
-    sails.helpers.salesforce.updateOrCreateContactAndAccount.with({
-      emailAddress: emailAddress,
-      contactSource: 'Website - Newsletter',
-      description: `Subscribed to the Fleet newsletter`,
-      psychologicalStage: '3 - Intrigued',
-      psychologicalStageChangeReason,
-      intentSignal: 'Subscribed to the Fleet newsletter',
+      await sails.helpers.salesforce.createHistoricalEvent.with({
+        salesforceAccountId: recordIds.salesforceAccountId,
+        salesforceContactId: recordIds.salesforceContactId,
+        eventType: 'Intent signal',
+        intentSignal: 'Subscribed to the Fleet newsletter',
+      }).intercept((err)=>{
+        sails.log.warn(`When the receive-from-clay webhook received information about LinkedIn activity, a historical event record could not be created. Full error: ${require('util').inspect(err)}`);
+        return 'couldNotCreateActivity';
+      });
     }).exec((err)=>{// Use .exec() to run the salesforce helpers in the background.
       if(err) {
         sails.log.warn(`Background task failed: When a user signed up for a newsletter, a lead/contact could not be updated in the CRM for this email address: ${emailAddress}.`, err);

--- a/website/api/controllers/create-or-update-one-newsletter-subscription.js
+++ b/website/api/controllers/create-or-update-one-newsletter-subscription.js
@@ -63,9 +63,6 @@ module.exports = {
         salesforceContactId: recordIds.salesforceContactId,
         eventType: 'Intent signal',
         intentSignal: 'Subscribed to the Fleet newsletter',
-      }).intercept((err)=>{
-        sails.log.warn(`When the receive-from-clay webhook received information about LinkedIn activity, a historical event record could not be created. Full error: ${require('util').inspect(err)}`);
-        return 'couldNotCreateActivity';
       });
     }).exec((err)=>{// Use .exec() to run the salesforce helpers in the background.
       if(err) {

--- a/website/api/controllers/webhooks/receive-from-clay.js
+++ b/website/api/controllers/webhooks/receive-from-clay.js
@@ -87,26 +87,14 @@ module.exports = {
     let trimmedLinkedinUrl = linkedinUrl.replace(sails.config.custom.RX_PROTOCOL_AND_COMMON_SUBDOMAINS, '');
 
     // Create the new Fleet website page view record.
-    let newHistoricalRecord = await sails.helpers.flow.build(async ()=>{
-
-      let jsforce = require('jsforce');
-
-      // login to Salesforce
-      let salesforceConnection = new jsforce.Connection({
-        loginUrl : 'https://fleetdm.my.salesforce.com'
-      });
-      await salesforceConnection.login(sails.config.custom.salesforceIntegrationUsername, sails.config.custom.salesforceIntegrationPasskey);
-
-      return await salesforceConnection.sobject('fleet_website_page_views__c')
-      .create({
-        Contact__c: recordIds.salesforceContactId,// eslint-disable-line camelcase
-        Account__c: recordIds.salesforceAccountId,// eslint-disable-line camelcase
-        Event_type__c: 'Intent signal',// eslint-disable-line camelcase
-        Intent_signal__c: intentSignal,// eslint-disable-line camelcase
-        Content__c: historicalContent,// eslint-disable-line camelcase
-        Content_url__c: historicalContentUrl,// eslint-disable-line camelcase
-        Interactor_profile_url__c: trimmedLinkedinUrl,// eslint-disable-line camelcase
-      });
+    let newHistoricalRecordId = await sails.helpers.salesforce.createHistoricalEvent.with({
+      salesforceAccountId: recordIds.salesforceAccountId,
+      salesforceContactId: recordIds.salesforceContactId,
+      eventType: 'Intent signal',
+      intentSignal: intentSignal,
+      eventContent: historicalContent,
+      eventContentUrl: historicalContentUrl,
+      linkedinUrl: trimmedLinkedinUrl,
     }).intercept((err)=>{
       sails.log.warn(`When the receive-from-clay webhook received information about LinkedIn activity, a historical event record could not be created. Full error: ${require('util').inspect(err)}`);
       return 'couldNotCreateActivity';
@@ -114,7 +102,7 @@ module.exports = {
 
     // All done.
     return {
-      historicalRecordId: newHistoricalRecord.id,
+      historicalRecordId: newHistoricalRecordId,
       contactId: recordIds.salesforceContactId,
       accountId: recordIds.salesforceAccountId
     };

--- a/website/api/helpers/salesforce/create-historical-event.js
+++ b/website/api/helpers/salesforce/create-historical-event.js
@@ -1,0 +1,140 @@
+module.exports = {
+
+
+  friendlyName: 'Create Historical event',
+
+
+  description: 'Create a historical event related to a particular contact and account in Salesforce.',
+
+
+  inputs: {
+    salesforceAccountId: {
+      type: 'string',
+      required: true,
+      extendedDescription: 'This ID of the account associated with this historical event'
+    },
+    salesforceContactId: {
+      type: 'string',
+      required: true,
+      extendedDescription: 'This ID of the contact associated with this historical event'
+    },
+    eventType: {
+      type: 'string',
+      required: true,
+      isIn: [
+        'Intent signal',
+        'Website page view',
+      ],
+    },
+
+    // For "Website page view" type historical events:
+    fleetWebsitePageUrl: {
+      type: 'string',
+      description: 'The url of the page this user viewed.',
+      extendedDescription: 'This input is required when the event type is "Website page view".'
+    },
+    websiteVisitReason: {
+      type: 'string',
+      description: ''
+    },
+
+    // For "Intent signal" type historical events:
+    intentSignal: {
+      type: 'string',
+    },
+    eventContent: {
+      type: 'string',
+    },
+    eventContentUrl: {
+      type: 'string',
+    },
+    linkedinUrl: {
+      type: 'string',
+    },
+  },
+
+
+  exits: {
+
+    success: {
+      extendedDescription: 'Note that this deliberately has no return value.',
+      outputType: {
+        salesforceHistoricalEventId: 'string',
+      },
+    },
+
+  },
+
+
+  fn: async function ({ salesforceAccountId, salesforceContactId, eventType, linkedinUrl, intentSignal, eventContent, eventContentUrl, fleetWebsitePageUrl, websiteVisitReason}) {
+    // Return undefined if we're not running in a production environment.
+    if(sails.config.environment !== 'production') {
+      sails.log.verbose('Skipping Salesforce integration...');
+      return {
+        salesforceHistoricalEventId: undefined
+      };
+    }
+
+    require('assert')(sails.config.custom.salesforceIntegrationPasskey);
+    require('assert')(sails.config.custom.salesforceIntegrationUsername);
+    require('assert')(sails.config.custom.RX_PROTOCOL_AND_COMMON_SUBDOMAINS);
+
+    // Normalize the provided linkedin url.
+    if(linkedinUrl){
+      linkedinUrl = linkedinUrl.replace(sails.config.custom.RX_PROTOCOL_AND_COMMON_SUBDOMAINS, '');
+    }
+    // Check for required values depending on the eventType value.
+    if(eventType === 'Intent signal') {
+      if(!intentSignal) {
+        throw new Error(`A intentSignal value is required when creating "Intent signal" type historical events`);
+      }
+      if(!eventContent) {
+        throw new Error(`A eventContentUrl value is required when creating "Intent signal" type historical events`);
+      }
+    } else if(eventType === 'Website page view') {
+      if(!fleetWebsitePageUrl){
+        throw new Error(`A fleetWebsitePageUrl value is required when creating "Website page view" type historical events`);
+      }
+    }
+
+    // Use sails.helpers.flow.build to login to salesforce and create the new histrocial event record.
+    let newHistoricalRecord = await sails.helpers.flow.build(async ()=>{
+
+
+      // login to Salesforce
+      let jsforce = require('jsforce');
+      let salesforceConnection = new jsforce.Connection({
+        loginUrl : 'https://fleetdm.my.salesforce.com'
+      });
+      await salesforceConnection.login(sails.config.custom.salesforceIntegrationUsername, sails.config.custom.salesforceIntegrationPasskey);
+
+      return await salesforceConnection.sobject('fleet_website_page_views__c')
+      .create({
+        Contact__c: salesforceContactId,// eslint-disable-line camelcase
+        Account__c: salesforceAccountId,// eslint-disable-line camelcase
+        Event_type__c: eventType,// eslint-disable-line camelcase
+
+        Intent_signal__c: intentSignal,// eslint-disable-line camelcase
+        Content__c: eventContent,// eslint-disable-line camelcase
+        Content_url__c: eventContentUrl,// eslint-disable-line camelcase
+        Interactor_profile_url__c: linkedinUrl,// eslint-disable-line camelcase
+
+        Page_URL__c: fleetWebsitePageUrl,// eslint-disable-line camelcase
+        Website_visit_reason__c: websiteVisitReason// eslint-disable-line camelcase
+      });
+    }).intercept((err)=>{
+      return new Error(`An error occured when creating a new Historical event record in Salesforce. full error ${require('util').inpsect(err, {depth: null})}`);
+    });
+
+
+
+
+    return {
+      salesforceHistoricalEventId: newHistoricalRecord.id
+    };
+
+  }
+
+
+};
+

--- a/website/api/helpers/salesforce/create-historical-event.js
+++ b/website/api/helpers/salesforce/create-historical-event.js
@@ -8,6 +8,7 @@ module.exports = {
 
 
   inputs: {
+    // Required values on new historical event records.
     salesforceAccountId: {
       type: 'string',
       required: true,
@@ -41,6 +42,21 @@ module.exports = {
     // For "Intent signal" type historical events:
     intentSignal: {
       type: 'string',
+      isIn: [
+        'Followed the Fleet LinkedIn company page',
+        'LinkedIn comment',
+        'LinkedIn share',
+        'LinkedIn reaction',
+        'Fleet channel member in MacAdmins Slack',
+        'Fleet channel member in osquery Slack',
+        'Implemented a trial key',
+        'Engaged with fleetie at community event',
+        'Attended a Fleet happy hour',
+        'Stared the fleetdm/fleet repo on GitHub',
+        'Forked the fleetdm/fleet repo on GitHub',
+        'Subscribed to the Fleet newsletter',
+        'Attended a Fleet training course'
+      ]
     },
     eventContent: {
       type: 'string',
@@ -87,9 +103,6 @@ module.exports = {
     if(eventType === 'Intent signal') {
       if(!intentSignal) {
         throw new Error(`A intentSignal value is required when creating "Intent signal" type historical events`);
-      }
-      if(!eventContent) {
-        throw new Error(`A eventContentUrl value is required when creating "Intent signal" type historical events`);
       }
     } else if(eventType === 'Website page view') {
       if(!fleetWebsitePageUrl){

--- a/website/api/hooks/custom/index.js
+++ b/website/api/hooks/custom/index.js
@@ -341,12 +341,6 @@ will be disabled and/or hidden in the UI.
                       organization: sanitizedUser.organization,
                       contactSource: 'Website - Sign up',// Note: this is only set on new contacts.
                     });
-                    let jsforce = require('jsforce');
-                    // login to Salesforce
-                    let salesforceConnection = new jsforce.Connection({
-                      loginUrl : 'https://fleetdm.my.salesforce.com'
-                    });
-                    await salesforceConnection.login(sails.config.custom.salesforceIntegrationUsername, sails.config.custom.salesforceIntegrationPasskey);
                     let websiteVisitReason;
                     if(req.session.adAttributionString && this.req.session.visitedSiteFromAdAt) {
                       let thirtyMinutesAgoAt = Date.now() - (1000 * 60 * 30);
@@ -356,15 +350,12 @@ will be disabled and/or hidden in the UI.
                       }
                     }
                     // Create the new Fleet website page view record.
-                    return await sails.helpers.flow.build(async ()=>{
-                      return await salesforceConnection.sobject('fleet_website_page_views__c')
-                      .create({
-                        Contact__c: recordIds.salesforceContactId,// eslint-disable-line camelcase
-                        Account__c: recordIds.salesforceAccountId,// eslint-disable-line camelcase
-                        Page_URL__c: `https://fleetdm.com${req.url}`,// eslint-disable-line camelcase
-                        Event_type__c: 'Website page view',// eslint-disable-line camelcase
-                        Website_visit_reason__c: websiteVisitReason// eslint-disable-line camelcase
-                      });
+                    await sails.helpers.salesforce.createHistoricalEvent.with({
+                      salesforceContactId: recordIds.salesforceContactId,// eslint-disable-line camelcase
+                      salesforceAccountId: recordIds.salesforceAccountId,// eslint-disable-line camelcase
+                      fleetWebsitePageUrl: `https://fleetdm.com${req.url}`,// eslint-disable-line camelcase
+                      eventType: 'Website page view',// eslint-disable-line camelcase
+                      websiteVisitReason: websiteVisitReason// eslint-disable-line camelcase
                     }).intercept((err)=>{
                       return new Error(`Could not create new Fleet website page view record. Error: ${err}`);
                     });

--- a/website/api/hooks/custom/index.js
+++ b/website/api/hooks/custom/index.js
@@ -351,11 +351,11 @@ will be disabled and/or hidden in the UI.
                     }
                     // Create the new Fleet website page view record.
                     await sails.helpers.salesforce.createHistoricalEvent.with({
-                      salesforceContactId: recordIds.salesforceContactId,// eslint-disable-line camelcase
-                      salesforceAccountId: recordIds.salesforceAccountId,// eslint-disable-line camelcase
-                      fleetWebsitePageUrl: `https://fleetdm.com${req.url}`,// eslint-disable-line camelcase
-                      eventType: 'Website page view',// eslint-disable-line camelcase
-                      websiteVisitReason: websiteVisitReason// eslint-disable-line camelcase
+                      salesforceContactId: recordIds.salesforceContactId,
+                      salesforceAccountId: recordIds.salesforceAccountId,
+                      fleetWebsitePageUrl: `https://fleetdm.com${req.url}`,
+                      eventType: 'Website page view',
+                      websiteVisitReason: websiteVisitReason
                     }).intercept((err)=>{
                       return new Error(`Could not create new Fleet website page view record. Error: ${err}`);
                     });


### PR DESCRIPTION
Closes: https://github.com/fleetdm/confidential/issues/10718
Related to: https://github.com/fleetdm/confidential/issues/10719

Changes:
- Created a new helper (`sails.helpers.salesforce.createHistoricalEvent`) to create Historical event records in our CRM.
- Updated the custom hook, receive-from-clay webhook, and create-or-update-one-newsletter-subscription action to create historical event records using the new helper.