### PR TITLE
Use build date for version for local TUF orbits

### DIFF
--- a/.github/workflows/fleet-and-orbit.yml
+++ b/.github/workflows/fleet-and-orbit.yml
@@ -310,9 +310,9 @@ jobs:
       - name: Upload DEB installer
         uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b # v4.5.0
         with:
-          name: fleet-osquery_42.0.0_amd64.deb
+          name: fleet-osquery_amd64.deb
           path: |
-            fleet-osquery_42.0.0_amd64.deb
+            fleet-osquery_*_amd64.deb
 
       - name: Upload MSI installer
         uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b # v4.5.0
@@ -397,7 +397,7 @@ jobs:
         id: download
         uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
         with:
-          name: fleet-osquery_42.0.0_amd64.deb
+          name: fleet-osquery_amd64.deb
 
       - name: Wait until fleet address is reachable and fleet responds
         run: |
@@ -410,7 +410,7 @@ jobs:
       - name: Install deb
         run: |
           sudo hostname orbit-ubuntu
-          sudo dpkg --install ${{ steps.download.outputs.download-path }}/fleet-osquery_42.0.0_amd64.deb
+          sudo dpkg --install ${{ steps.download.outputs.download-path }}/fleet-osquery_*_amd64.deb
 
       - name: Wait enroll
         run: |

--- a/tools/tuf/test/Fleetd-auto-update-test-guide.md
+++ b/tools/tuf/test/Fleetd-auto-update-test-guide.md
@@ -11,33 +11,38 @@ Follow the setup in the [README.md](./README.md).
 
 ## Build and push fleetd N+1
 
+First, load new version Orbit variables:
+```sh
+source ./tools/tuf/test/load_orbit_version_vars.sh
+```
+
 ### orbit
 
 Build:
 ```sh
-GOOS=darwin GOARCH=amd64 go build -ldflags="-X github.com/fleetdm/fleet/v4/orbit/pkg/build.Version=43" -o orbit-darwin ./orbit/cmd/orbit
-GOOS=linux GOARCH=amd64 go build -ldflags="-X github.com/fleetdm/fleet/v4/orbit/pkg/build.Version=43" -o orbit-linux ./orbit/cmd/orbit
-GOOS=windows GOARCH=amd64 go build -ldflags="-X github.com/fleetdm/fleet/v4/orbit/pkg/build.Version=43" -o orbit.exe ./orbit/cmd/orbit
+GOOS=darwin GOARCH=amd64 go build -ldflags="-X github.com/fleetdm/fleet/v4/orbit/pkg/build.Version=$ORBIT_VERSION" -o orbit-darwin ./orbit/cmd/orbit
+GOOS=linux GOARCH=amd64 go build -ldflags="-X github.com/fleetdm/fleet/v4/orbit/pkg/build.Version=$ORBIT_VERSION" -o orbit-linux ./orbit/cmd/orbit
+GOOS=windows GOARCH=amd64 go build -ldflags="-X github.com/fleetdm/fleet/v4/orbit/pkg/build.Version=$ORBIT_VERSION" -o orbit.exe ./orbit/cmd/orbit
 ```
 Push:
 ```sh
-./tools/tuf/test/push_target.sh macos orbit orbit-darwin 43
-./tools/tuf/test/push_target.sh linux orbit orbit-linux 43
-./tools/tuf/test/push_target.sh windows orbit orbit.exe 43
+./tools/tuf/test/push_target.sh macos orbit orbit-darwin $ORBIT_VERSION
+./tools/tuf/test/push_target.sh linux orbit orbit-linux $ORBIT_VERSION
+./tools/tuf/test/push_target.sh windows orbit orbit.exe $ORBIT_VERSION
 ```
 
 ### desktop
 
 Build:
 ```sh
-FLEET_DESKTOP_VERSION=43 make desktop-app-tar-gz
-FLEET_DESKTOP_VERSION=43.0.0 make desktop-windows
-FLEET_DESKTOP_VERSION=43 make desktop-linux
+FLEET_DESKTOP_VERSION=$ORBIT_VERSION make desktop-app-tar-gz
+FLEET_DESKTOP_VERSION=$ORBIT_VERSION make desktop-windows
+FLEET_DESKTOP_VERSION=$ORBIT_VERSION make desktop-linux
 ```
 ```sh
-./tools/tuf/test/push_target.sh macos desktop desktop.app.tar.gz 43
-./tools/tuf/test/push_target.sh windows desktop fleet-desktop.exe 43.0.0
-./tools/tuf/test/push_target.sh linux desktop desktop.tar.gz 43
+./tools/tuf/test/push_target.sh macos desktop desktop.app.tar.gz $ORBIT_VERSION
+./tools/tuf/test/push_target.sh windows desktop fleet-desktop.exe $ORBIT_VERSION
+./tools/tuf/test/push_target.sh linux desktop desktop.tar.gz $ORBIT_VERSION
 ```
 
 ### osqueryd
@@ -71,6 +76,6 @@ Release:
 
 ## Verify auto-update
 
-1. Run the following live query on the hosts: `SELECT * FROM orbit_info;`. The query should now return `version=43`.
+1. Run the following live query on the hosts: `SELECT * FROM orbit_info;`. The query should now return `version=$ORBIT_VERSION`.
 2. Run the following live query on the hosts: `SELECT * FROM osquery_info;`. The query should now return `version=5.11.0`.
-3. Verify all hosts now show "Fleet Desktop v43.0.0" on the Fleet Desktop menu.
+3. Verify all hosts now show "Fleet Desktop $ORBIT_VERSION" on the Fleet Desktop menu.

--- a/tools/tuf/test/README.md
+++ b/tools/tuf/test/README.md
@@ -91,24 +91,33 @@ To add new updates (osqueryd or orbit), use `push_target.sh`.
 
 E.g. to add a new version of `orbit` for Windows:
 ```sh
+source ./tools/tuf/test/load_orbit_version_vars.sh
+
 # Compile a new version of Orbit:
-GOOS=windows GOARCH=amd64 go build -o orbit-windows.exe ./orbit/cmd/orbit
+GOOS=windows GOARCH=amd64 go build \
+    -o orbit-windows.exe \
+    -ldflags="-X github.com/fleetdm/fleet/v4/orbit/pkg/build.Version=$ORBIT_VERSION \
+    -X github.com/fleetdm/fleet/v4/orbit/pkg/build.Commit=$ORBIT_COMMIT" \
+    ./orbit/cmd/orbit
 
 # Push the compiled Orbit as a new version
-./tools/tuf/test/push_target.sh windows orbit orbit-windows.exe 43
+./tools/tuf/test/push_target.sh windows orbit orbit-windows.exe $ORBIT_VERSION
 ```
 
 If the script was executed on a macOS host, the Orbit binary will be a universal binary. To push updates you can do:
 
 ```sh
+source ./tools/tuf/test/load_orbit_version_vars.sh
+
 # Compile a universal binary of Orbit:
 CGO_ENABLED=1 \
-ORBIT_VERSION=42 \
+ORBIT_VERSION=$ORBIT_VERSION \
+ORBIT_COMMIT=$ORBIT_COMMIT \
 ORBIT_BINARY_PATH="orbit-macos" \
 go run ./orbit/tools/build/build.go
 
 # Push the compiled Orbit as a new version
-./tools/tuf/test/push_target.sh macos orbit orbit-macos 43
+./tools/tuf/test/push_target.sh macos orbit orbit-macos $ORBIT_VERSION
 ```
 
 E.g. to add a new version of `osqueryd` for macOS:
@@ -123,11 +132,13 @@ NOTE: Contributors on macOS with Apple silicon ran into issues running osqueryd 
 
 E.g. to add a new version of `desktop` for macOS:
 ```sh
+source ./tools/tuf/test/load_orbit_version_vars.sh
+
 # Compile a new version of fleet-desktop
-make desktop-app-tar-gz
+FLEET_DESKTOP_VERSION=$ORBIT_VERSION make desktop-app-tar-gz
 
 # Push the desktop target as a new version
-./tools/tuf/test/push_target.sh macos desktop desktop.app.tar.gz 43
+./tools/tuf/test/push_target.sh macos desktop desktop.app.tar.gz $ORBIT_VERSION
 ```
 
 ### Troubleshooting

--- a/tools/tuf/test/create_repository.sh
+++ b/tools/tuf/test/create_repository.sh
@@ -3,7 +3,7 @@
 set -xe
 
 # This script initializes a test Fleet TUF repository.
-# All targets are created with version 42.
+# All targets are created with version set to YY.MM.DD.HHMM (build time date)
 
 # Input:
 # TUF_PATH: directory path for the test TUF repository.
@@ -18,9 +18,21 @@ if [[ -z "$TUF_PATH" ]]; then
     echo "Must set the TUF_PATH environment variable."
     exit 1
 fi
+
 if [[ -d "$TUF_PATH" ]]; then
-    echo "$TUF_PATH directory already exists, nothing to do."
-    exit 0
+    set +x
+    echo "Do you want to remove the existing $TUF_PATH directory?"
+    echo "Type 'yes/no' to continue... "
+    while read -r word;
+    do
+        if [[ "$word" == "yes" ]]; then
+            rm -rf "$TUF_PATH"
+            break
+        elif [[ "$word" == "no" ]]; then
+            break
+        fi
+    done
+    set -x
 fi
 
 SYSTEMS=${SYSTEMS:-macos linux linux-arm64 windows windows-arm64}
@@ -37,6 +49,8 @@ fi
 mkdir -p $TUF_PATH/tmp
 
 ./build/fleetctl updates init --path $TUF_PATH
+
+source ./tools/tuf/test/load_orbit_version_vars.sh
 
 for system in $SYSTEMS; do
 
@@ -103,7 +117,8 @@ for system in $SYSTEMS; do
     if [ $system == "macos" ] && [ "$(uname -s)" = "Darwin" ] && [ "$(uname -m)" = "arm64" ]; then
        CGO_ENABLED=1 \
        CODESIGN_IDENTITY=$CODESIGN_IDENTITY \
-       ORBIT_VERSION=42 \
+       ORBIT_VERSION=$ORBIT_VERSION \
+       ORBIT_COMMIT=$ORBIT_COMMIT \
        ORBIT_BINARY_PATH=$orbit_target \
        go run ./orbit/tools/build/build.go
     else
@@ -122,7 +137,8 @@ for system in $SYSTEMS; do
       GOARCH=$goarch_value \
       go build \
       -race=$race_value \
-      -ldflags="-X github.com/fleetdm/fleet/v4/orbit/pkg/build.Version=42" \
+      -ldflags="-X github.com/fleetdm/fleet/v4/orbit/pkg/build.Version=$ORBIT_VERSION \
+        -X github.com/fleetdm/fleet/v4/orbit/pkg/build.Commit=$ORBIT_COMMIT" \
       -o $orbit_target ./orbit/cmd/orbit
     fi
 
@@ -131,14 +147,14 @@ for system in $SYSTEMS; do
         --target $orbit_target \
         --platform $system \
         --name orbit \
-        --version 42.0.0 -t 42.0 -t 42 -t stable
+        --version $ORBIT_VERSION -t $ORBIT_MAJOR.$ORBIT_MINOR -t $ORBIT_MAJOR -t stable
     rm $orbit_target
 
     # Add Fleet Desktop application on macos (if enabled).
     if [[ $system == "macos" && -n "$FLEET_DESKTOP" ]]; then
         if [[ -z "$MACOS_USE_PREBUILT_DESKTOP_APP_TAR_GZ" ]]; then
             FLEET_DESKTOP_VERBOSE=1 \
-            FLEET_DESKTOP_VERSION=42.0.0 \
+            FLEET_DESKTOP_VERSION=$ORBIT_VERSION \
             make desktop-app-tar-gz
         fi
         ./build/fleetctl updates add \
@@ -146,7 +162,7 @@ for system in $SYSTEMS; do
         --target desktop.app.tar.gz \
         --platform macos \
         --name desktop \
-        --version 42.0.0 -t 42.0 -t 42 -t stable
+        --version $ORBIT_VERSION -t $ORBIT_MAJOR.$ORBIT_MINOR -t $ORBIT_MAJOR -t stable
         if [[ -z "$MACOS_USE_PREBUILT_DESKTOP_APP_TAR_GZ" ]]; then
             rm desktop.app.tar.gz
         fi
@@ -160,7 +176,7 @@ for system in $SYSTEMS; do
             --target nudge.app.tar.gz \
             --platform macos \
             --name nudge \
-            --version 42.0.0 -t 42.0 -t 42 -t stable
+            --version $ORBIT_VERSION -t $ORBIT_MAJOR.$ORBIT_MINOR -t $ORBIT_MAJOR -t stable
         rm nudge.app.tar.gz
     fi
 
@@ -173,7 +189,7 @@ for system in $SYSTEMS; do
             --target swiftDialog.app.tar.gz \
             --platform macos \
             --name swiftDialog \
-            --version 42.0.0 -t 42.0 -t 42 -t stable
+            --version $ORBIT_VERSION -t $ORBIT_MAJOR.$ORBIT_MINOR -t $ORBIT_MAJOR -t stable
         rm swiftDialog.app.tar.gz
     fi
 
@@ -186,60 +202,60 @@ for system in $SYSTEMS; do
             --target escrowBuddy.pkg \
             --platform macos \
             --name escrowBuddy \
-            --version 42.0.0 -t 42.0 -t 42 -t stable
+            --version $ORBIT_VERSION -t $ORBIT_MAJOR.$ORBIT_MINOR -t $ORBIT_MAJOR -t stable
         rm escrowBuddy.pkg
     fi
 
 
-    # Add Fleet Desktop application on windows (if enabled).
+    # Add Fleet Desktop application on indows (if enabled).
     if [[ $system == "windows" && -n "$FLEET_DESKTOP" ]]; then
-        FLEET_DESKTOP_VERSION=42.0.0 \
+        FLEET_DESKTOP_VERSION=$ORBIT_VERSION \
         make desktop-windows
         ./build/fleetctl updates add \
         --path $TUF_PATH \
         --target fleet-desktop.exe \
         --platform windows \
         --name desktop \
-        --version 42.0.0 -t 42.0 -t 42 -t stable
+        --version $ORBIT_VERSION -t $ORBIT_MAJOR.$ORBIT_MINOR -t $ORBIT_MAJOR -t stable
         rm fleet-desktop.exe
     fi
 
     # Add Fleet Desktop application on windows-arm64 (if enabled).
     if [[ $system == "windows-arm64" && -n "$FLEET_DESKTOP" ]]; then
-        FLEET_DESKTOP_VERSION=42.0.0 \
+        FLEET_DESKTOP_VERSION=$ORBIT_VERSION \
         make desktop-windows-arm64
         ./build/fleetctl updates add \
         --path $TUF_PATH \
         --target fleet-desktop.exe \
         --platform windows-arm64 \
         --name desktop \
-        --version 42.0.0 -t 42.0 -t 42 -t stable
+        --version $ORBIT_VERSION -t $ORBIT_MAJOR.$ORBIT_MINOR -t $ORBIT_MAJOR -t stable
         rm fleet-desktop.exe
     fi
 
     # Add Fleet Desktop application on linux (if enabled).
     if [[ $system == "linux" && -n "$FLEET_DESKTOP" ]]; then
-        FLEET_DESKTOP_VERSION=42.0.0 \
+        FLEET_DESKTOP_VERSION=$ORBIT_VERSION \
         make desktop-linux
         ./build/fleetctl updates add \
         --path $TUF_PATH \
         --target desktop.tar.gz \
         --platform linux \
         --name desktop \
-        --version 42.0.0 -t 42.0 -t 42 -t stable
+        --version $ORBIT_VERSION -t $ORBIT_MAJOR.$ORBIT_MINOR -t $ORBIT_MAJOR -t stable
         rm desktop.tar.gz
     fi
 
     # Add Fleet Desktop application on linux-arm64 (if enabled).
     if [[ $system == "linux-arm64" && -n "$FLEET_DESKTOP" ]]; then
-        FLEET_DESKTOP_VERSION=42.0.0 \
+        FLEET_DESKTOP_VERSION=$ORBIT_VERSION \
         make desktop-linux-arm64
         ./build/fleetctl updates add \
                          --path $TUF_PATH \
                          --target desktop.tar.gz \
                          --platform linux-arm64 \
                          --name desktop \
-                         --version 42.0.0 -t 42.0 -t 42 -t stable
+                         --version $ORBIT_VERSION -t $ORBIT_MAJOR.$ORBIT_MINOR -t $ORBIT_MAJOR -t stable
         rm desktop.tar.gz
     fi
 
@@ -254,7 +270,7 @@ for system in $SYSTEMS; do
                 --target $extension \
                 --platform macos \
                 --name "extensions/$extensionName" \
-                --version 42.0.0 -t 42.0 -t 42 -t stable
+                --version $ORBIT_VERSION -t $ORBIT_MAJOR.$ORBIT_MINOR -t $ORBIT_MAJOR -t stable
         done
     fi
 
@@ -269,7 +285,7 @@ for system in $SYSTEMS; do
                 --target $extension \
                 --platform linux \
                 --name "extensions/$extensionName" \
-                --version 42.0.0 -t 42.0 -t 42 -t stable
+                --version $ORBIT_VERSION -t $ORBIT_MAJOR.$ORBIT_MINOR -t $ORBIT_MAJOR -t stable
         done
     fi
 
@@ -284,7 +300,7 @@ for system in $SYSTEMS; do
                              --target $extension \
                              --platform linux-arm64 \
                              --name "extensions/$extensionName" \
-                             --version 42.0.0 -t 42.0 -t 42 -t stable
+                             --version $ORBIT_VERSION -t $ORBIT_MAJOR.$ORBIT_MINOR -t $ORBIT_MAJOR -t stable
         done
     fi
 
@@ -300,7 +316,7 @@ for system in $SYSTEMS; do
                 --target $extension \
                 --platform windows \
                 --name "extensions/$extensionName" \
-                --version 42.0.0 -t 42.0 -t 42 -t stable
+                --version $ORBIT_VERSION -t $ORBIT_MAJOR.$ORBIT_MINOR -t $ORBIT_MAJOR -t stable
         done
     fi
 done

--- a/tools/tuf/test/create_repository.sh
+++ b/tools/tuf/test/create_repository.sh
@@ -3,7 +3,8 @@
 set -xe
 
 # This script initializes a test Fleet TUF repository.
-# All targets are created with version set to YY.MM.DD.HHMM (build time date)
+# All targets are created with version set to YY.MM.XXXXX, e.g. 25.5.56178
+# (patch version is a 16-bit number made from day, hour and minute).
 
 # Input:
 # TUF_PATH: directory path for the test TUF repository.

--- a/tools/tuf/test/load_orbit_version_vars.sh
+++ b/tools/tuf/test/load_orbit_version_vars.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# Orbit (test) version number are currently constrained by this error from WiX:
+# "Z:\wix\main.wxs(3): error CNDL0242 : Invalid product version '10.250525.0913'. Product version
+# must have a major version less than 256, a minor version less than 256, and a build version less than 65536."
+ORBIT_MAJOR=$(date +"%y")
+ORBIT_MINOR=$(date +"%m")
+ORBIT_PATCH=$(date +"%d")
+ORBIT_BUILD=$(date +"%H%M")
+ORBIT_VERSION="$ORBIT_MAJOR.$ORBIT_MINOR.$ORBIT_PATCH.$ORBIT_BUILD"
+ORBIT_COMMIT=$(git rev-parse HEAD)
+
+export ORBIT_MAJOR
+export ORBIT_MINOR
+export ORBIT_PATCH
+export ORBIT_BUILD
+export ORBIT_VERSION
+export ORBIT_COMMIT

--- a/tools/tuf/test/load_orbit_version_vars.sh
+++ b/tools/tuf/test/load_orbit_version_vars.sh
@@ -1,18 +1,21 @@
 #!/bin/bash
 
-# Orbit (test) version number are currently constrained by this error from WiX:
-# "Z:\wix\main.wxs(3): error CNDL0242 : Invalid product version '10.250525.0913'. Product version
-# must have a major version less than 256, a minor version less than 256, and a build version less than 65536."
-ORBIT_MAJOR=$(date +"%y")
-ORBIT_MINOR=$(date +"%m")
-ORBIT_PATCH=$(date +"%d")
-ORBIT_BUILD=$(date +"%H%M")
-ORBIT_VERSION="$ORBIT_MAJOR.$ORBIT_MINOR.$ORBIT_PATCH.$ORBIT_BUILD"
+# Constraints for orbit versioning:
+# - WiX fails with "Z:\wix\main.wxs(3): error CNDL0242 : Invalid product version '10.250525.0913'. Product version
+#   must have a major version less than 256, a minor version less than 256, and a build version less than 65536."
+# - Cannot use "-build", WiX/Windows prefers three dots X.Y.Z.P format.
+# - Must be with three parts X.Y.Z (otherwise breaks orbit semantic versioning)
+ORBIT_MAJOR=$(date +"%-y") # year
+ORBIT_MINOR=$(date +"%-m") # month
+day=$(date +"%-d")
+hour=$(date +"%-H")
+minute=$(date +"%-M")
+ORBIT_PATCH=$(( (day << 11) | (hour << 6) | minute )) # must fit into 16-bit number
+ORBIT_VERSION="$ORBIT_MAJOR.$ORBIT_MINOR.$ORBIT_PATCH"
 ORBIT_COMMIT=$(git rev-parse HEAD)
 
 export ORBIT_MAJOR
 export ORBIT_MINOR
 export ORBIT_PATCH
-export ORBIT_BUILD
 export ORBIT_VERSION
 export ORBIT_COMMIT

--- a/tools/tuf/test/push_target.sh
+++ b/tools/tuf/test/push_target.sh
@@ -3,7 +3,7 @@
 system=$1
 target_name=$2
 target_path=$3
-major_version=$4
+version=$4
 
 if [ -z "$TUF_PATH" ]; then
   TUF_PATH=test_tuf
@@ -15,4 +15,7 @@ export FLEET_TARGETS_PASSPHRASE=p4ssphr4s3
 export FLEET_SNAPSHOT_PASSPHRASE=p4ssphr4s3
 export FLEET_TIMESTAMP_PASSPHRASE=p4ssphr4s3
 
-./build/fleetctl updates add --path $TUF_PATH --target $target_path --platform $system --name $target_name --version $major_version.0.0 -t $major_version.0 -t $major_version -t stable
+major=$(echo $version | cut -d. -f1)
+minor=$(echo $version | cut -d. -f2)
+
+./build/fleetctl updates add --path $TUF_PATH --target $target_path --platform $system --name $target_name --version $version -t "$major.$minor" -t "$major" -t stable


### PR DESCRIPTION
Two new improvements for local TUF after feedback from @iansltx and QA folks:

1. The static `42` was confusing when making or sharing several builds of locally built fleetd. Locally TUF-built version of orbit will now be: `YY.MM.XXXXX`,  e.g. `25.5.56178` (patch version is a 16-bit number made from day, hour and minute).
2. Also prompting user to delete `test_tuf` which is usually a source of confusion/errors.
