### PR TITLE
Bugfix: Activate next activity on batch-set scripts (delete/edit)

### DIFF
--- a/server/datastore/mysql/activities.go
+++ b/server/datastore/mysql/activities.go
@@ -1056,7 +1056,8 @@ func (ds *Datastore) GetHostUpcomingActivityMeta(ctx context.Context, hostID uin
 func (ds *Datastore) activateNextUpcomingActivityForBatchOfHosts(ctx context.Context, hostIDs []uint) error {
 	const maxHostIDsPerBatch = 500
 
-	slices.Sort(hostIDs) // sorting can help avoid deadlocks
+	slices.Sort(hostIDs)              // sorting can help avoid deadlocks
+	hostIDs = slices.Compact(hostIDs) // dedupe IDs (must be sorted first)
 
 	var errs []error
 	for batch := range slices.Chunk(hostIDs, maxHostIDsPerBatch) {

--- a/server/datastore/mysql/scripts.go
+++ b/server/datastore/mysql/scripts.go
@@ -1261,7 +1261,7 @@ ON DUPLICATE KEY UPDATE
 			}
 			activateAffectedHosts = append(activateAffectedHosts, affectedHosts...)
 
-			if _, err := tx.ExecContext(ctx, clearPendingExecutionsWithObsoleteScriptUA, int(constants.MaxServerWaitTime.Seconds()), scriptID, contentID); err != nil {
+			if _, err = tx.ExecContext(ctx, clearPendingExecutionsWithObsoleteScriptUA, int(constants.MaxServerWaitTime.Seconds()), scriptID, contentID); err != nil {
 				return ctxerr.Wrapf(ctx, err, "clear obsolete upcoming pending script executions with name %q", s.Name)
 			}
 		}

--- a/server/datastore/mysql/scripts.go
+++ b/server/datastore/mysql/scripts.go
@@ -668,7 +668,7 @@ func (ds *Datastore) DeleteScript(ctx context.Context, id uint) error {
 		// activateNextUpcomingActivity for those hosts.
 		loadAffectedHostsStmt := `
 			SELECT
-				host_id
+				DISTINCT host_id
 			FROM
 				upcoming_activities ua
 				INNER JOIN script_upcoming_activities sua
@@ -755,7 +755,7 @@ func (ds *Datastore) deletePendingHostScriptExecutionsForPolicy(ctx context.Cont
 
 	loadAffectedHostsStmt := `
 		SELECT
-			host_id
+			DISTINCT host_id
 		FROM
 			upcoming_activities ua
 			INNER JOIN script_upcoming_activities sua
@@ -1018,6 +1018,19 @@ WHERE
 		exit_code IS NULL AND (sync_request = 0 OR created_at >= NOW() - INTERVAL ? SECOND)
 		AND script_id IN (SELECT id FROM scripts WHERE global_or_team_id = ?)`
 
+	const loadAffectedHostsAllPendingExecutionsUA = `
+		SELECT
+			DISTINCT host_id
+		FROM
+			upcoming_activities ua
+			INNER JOIN script_upcoming_activities sua
+				ON ua.id = sua.upcoming_activity_id
+		WHERE
+			ua.activity_type = 'script'
+			AND ua.activated_at IS NOT NULL
+			AND (ua.payload->'$.sync_request' = 0 OR ua.created_at >= NOW() - INTERVAL ? SECOND)
+			AND sua.script_id IN (SELECT id FROM scripts WHERE global_or_team_id = ?)`
+
 	const clearAllPendingExecutionsUA = `DELETE FROM upcoming_activities
 		USING
 			upcoming_activities
@@ -1045,6 +1058,19 @@ WHERE
 		exit_code IS NULL AND (sync_request = 0 OR created_at >= NOW() - INTERVAL ? SECOND)
 		AND script_id IN (SELECT id FROM scripts WHERE global_or_team_id = ? AND name NOT IN (?))`
 
+	const loadAffectedHostsPendingExecutionsNotInListUA = `
+		SELECT
+			DISTINCT host_id
+		FROM
+			upcoming_activities ua
+			INNER JOIN script_upcoming_activities sua
+				ON ua.id = sua.upcoming_activity_id
+		WHERE
+			ua.activity_type = 'script'
+			AND ua.activated_at IS NOT NULL
+			AND (ua.payload->'$.sync_request' = 0 OR ua.created_at >= NOW() - INTERVAL ? SECOND)
+			AND sua.script_id IN (SELECT id FROM scripts WHERE global_or_team_id = ? AND name NOT IN (?))`
+
 	const clearPendingExecutionsNotInListUA = `DELETE FROM upcoming_activities
 		USING
 			upcoming_activities
@@ -1069,6 +1095,19 @@ ON DUPLICATE KEY UPDATE
 	const clearPendingExecutionsWithObsoleteScriptHSR = `DELETE FROM host_script_results WHERE
 		exit_code IS NULL AND (sync_request = 0 OR created_at >= NOW() - INTERVAL ? SECOND)
 		AND script_id = ? AND script_content_id != ?`
+
+	const loadAffectedHostsPendingExecutionsWithObsoleteScriptUA = `
+		SELECT
+			DISTINCT host_id
+		FROM
+			upcoming_activities ua
+			INNER JOIN script_upcoming_activities sua
+				ON ua.id = sua.upcoming_activity_id
+		WHERE
+			ua.activity_type = 'script'
+			AND ua.activated_at IS NOT NULL
+			AND (ua.payload->'$.sync_request' = 0 OR ua.created_at >= NOW() - INTERVAL ? SECOND)
+			AND sua.script_id = ? AND sua.script_content_id != ?`
 
 	const clearPendingExecutionsWithObsoleteScriptUA = `DELETE FROM upcoming_activities
 		USING
@@ -1100,6 +1139,8 @@ ON DUPLICATE KEY UPDATE
 	}
 
 	var insertedScripts []fleet.ScriptResponse
+	var activateAffectedHosts []uint
+
 	if err := ds.withRetryTxx(ctx, func(tx sqlx.ExtContext) error {
 		var existingScripts []*fleet.Script
 
@@ -1123,15 +1164,16 @@ ON DUPLICATE KEY UPDATE
 		}
 
 		var (
-			scriptsStmt    string
-			scriptsArgs    []any
-			policiesStmt   string
-			policiesArgs   []any
-			executionsStmt string
-			executionsArgs []any
-			extraExecStmt  string
-			extraExecArgs  []any
-			err            error
+			scriptsStmt     string
+			scriptsArgs     []any
+			policiesStmt    string
+			policiesArgs    []any
+			executionsStmt  string
+			executionsArgs  []any
+			extraExecStmt   string
+			extraExecArgs   []any
+			err             error
+			affectedHostIDs []uint
 		)
 		if len(keepNames) > 0 {
 			// delete the obsolete scripts
@@ -1150,6 +1192,15 @@ ON DUPLICATE KEY UPDATE
 				return ctxerr.Wrap(ctx, err, "build statement to clear pending script executions from obsolete scripts")
 			}
 
+			loadAffectedStmt, args, err := sqlx.In(loadAffectedHostsPendingExecutionsNotInListUA,
+				int(constants.MaxServerWaitTime.Seconds()), globalOrTeamID, keepNames)
+			if err != nil {
+				return ctxerr.Wrap(ctx, err, "build query to load affected hosts for upcoming script executions")
+			}
+			if err := sqlx.SelectContext(ctx, tx, &affectedHostIDs, loadAffectedStmt, args...); err != nil {
+				return ctxerr.Wrap(ctx, err, "load affected hosts for upcoming script executions")
+			}
+
 			extraExecStmt, extraExecArgs, err = sqlx.In(clearPendingExecutionsNotInListUA, int(constants.MaxServerWaitTime.Seconds()), globalOrTeamID, keepNames)
 			if err != nil {
 				return ctxerr.Wrap(ctx, err, "build statement to clear upcoming pending script executions from obsolete scripts")
@@ -1163,6 +1214,11 @@ ON DUPLICATE KEY UPDATE
 
 			executionsStmt = clearAllPendingExecutionsHSR
 			executionsArgs = []any{int(constants.MaxServerWaitTime.Seconds()), globalOrTeamID}
+
+			if err := sqlx.SelectContext(ctx, tx, &affectedHostIDs,
+				loadAffectedHostsAllPendingExecutionsUA, int(constants.MaxServerWaitTime.Seconds()), globalOrTeamID); err != nil {
+				return ctxerr.Wrap(ctx, err, "load affected hosts for upcoming script executions")
+			}
 
 			extraExecStmt = clearAllPendingExecutionsUA
 			extraExecArgs = []any{int(constants.MaxServerWaitTime.Seconds()), globalOrTeamID}
@@ -1179,6 +1235,7 @@ ON DUPLICATE KEY UPDATE
 		if _, err := tx.ExecContext(ctx, scriptsStmt, scriptsArgs...); err != nil {
 			return ctxerr.Wrap(ctx, err, "delete obsolete scripts")
 		}
+		activateAffectedHosts = affectedHostIDs
 
 		// insert the new scripts and the ones that have changed
 		for _, s := range incomingScripts {
@@ -1192,9 +1249,18 @@ ON DUPLICATE KEY UPDATE
 				return ctxerr.Wrapf(ctx, err, "insert new/edited script with name %q", s.Name)
 			}
 			scriptID, _ := insertRes.LastInsertId()
+
 			if _, err := tx.ExecContext(ctx, clearPendingExecutionsWithObsoleteScriptHSR, int(constants.MaxServerWaitTime.Seconds()), scriptID, contentID); err != nil {
 				return ctxerr.Wrapf(ctx, err, "clear obsolete pending script executions with name %q", s.Name)
 			}
+
+			var affectedHosts []uint
+			if err := sqlx.SelectContext(ctx, tx, &affectedHosts, loadAffectedHostsPendingExecutionsWithObsoleteScriptUA,
+				int(constants.MaxServerWaitTime.Seconds()), scriptID, contentID); err != nil {
+				return ctxerr.Wrapf(ctx, err, "load affected hosts for upcoming script executions with name %q", s.Name)
+			}
+			activateAffectedHosts = append(activateAffectedHosts, affectedHosts...)
+
 			if _, err := tx.ExecContext(ctx, clearPendingExecutionsWithObsoleteScriptUA, int(constants.MaxServerWaitTime.Seconds()), scriptID, contentID); err != nil {
 				return ctxerr.Wrapf(ctx, err, "clear obsolete upcoming pending script executions with name %q", s.Name)
 			}
@@ -1207,6 +1273,10 @@ ON DUPLICATE KEY UPDATE
 		return nil
 	}); err != nil {
 		return nil, err
+	}
+
+	if err := ds.activateNextUpcomingActivityForBatchOfHosts(ctx, activateAffectedHosts); err != nil {
+		return nil, ctxerr.Wrap(ctx, err, "activate next upcoming activity for batch of hosts")
 	}
 
 	return insertedScripts, nil

--- a/server/datastore/mysql/scripts_test.go
+++ b/server/datastore/mysql/scripts_test.go
@@ -2103,7 +2103,7 @@ func testBatchSetScriptActivatesNextActivity(t *testing.T, ds *Datastore) {
 	checkUpcomingActivities(t, ds, hosts[3], execHost3ScriptA.ExecutionID, execHost3ScriptB.ExecutionID, execHost3ScriptC.ExecutionID)
 
 	// no change
-	scripts, err = ds.BatchSetScripts(ctx, nil, []*fleet.Script{
+	_, err = ds.BatchSetScripts(ctx, nil, []*fleet.Script{
 		{Name: "A", ScriptContents: "C1"},
 		{Name: "B", ScriptContents: "C2"},
 		{Name: "C", ScriptContents: "C3"},
@@ -2116,7 +2116,7 @@ func testBatchSetScriptActivatesNextActivity(t *testing.T, ds *Datastore) {
 	checkUpcomingActivities(t, ds, hosts[3], execHost3ScriptA.ExecutionID, execHost3ScriptB.ExecutionID, execHost3ScriptC.ExecutionID)
 
 	// batch-set removes A, updates B and creates D, cancelling any pending A and B executions
-	scripts, err = ds.BatchSetScripts(ctx, nil, []*fleet.Script{
+	_, err = ds.BatchSetScripts(ctx, nil, []*fleet.Script{
 		{Name: "B", ScriptContents: "C2updated"},
 		{Name: "C", ScriptContents: "C3"},
 		{Name: "D", ScriptContents: "C4"},
@@ -2129,7 +2129,7 @@ func testBatchSetScriptActivatesNextActivity(t *testing.T, ds *Datastore) {
 	checkUpcomingActivities(t, ds, hosts[3], execHost3ScriptC.ExecutionID)
 
 	// batch-set remove all
-	scripts, err = ds.BatchSetScripts(ctx, nil, []*fleet.Script{})
+	_, err = ds.BatchSetScripts(ctx, nil, []*fleet.Script{})
 	require.NoError(t, err)
 
 	checkUpcomingActivities(t, ds, hosts[0])

--- a/server/datastore/mysql/scripts_test.go
+++ b/server/datastore/mysql/scripts_test.go
@@ -45,6 +45,7 @@ func TestScripts(t *testing.T) {
 		{"UpdateDeletingUpcomingScriptExecutions", testUpdateDeletingUpcomingScriptExecutions},
 		{"BatchExecute", testBatchExecute},
 		{"DeleteScriptActivatesNextActivity", testDeleteScriptActivatesNextActivity},
+		{"BatchSetScriptActivatesNextActivity", testBatchSetScriptActivatesNextActivity},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
@@ -2006,4 +2007,133 @@ func testDeleteScriptActivatesNextActivity(t *testing.T, ds *Datastore) {
 	checkUpcomingActivities(t, ds, hosts[1], execHost1ScriptB.ExecutionID)
 	checkUpcomingActivities(t, ds, hosts[2], execHost2ScriptB.ExecutionID)
 	checkUpcomingActivities(t, ds, hosts[3], execHost3ScriptB.ExecutionID)
+}
+
+func testBatchSetScriptActivatesNextActivity(t *testing.T, ds *Datastore) {
+	ctx := t.Context()
+
+	// batch-set some scripts
+	scripts, err := ds.BatchSetScripts(ctx, nil, []*fleet.Script{
+		{Name: "A", ScriptContents: "C1"},
+		{Name: "B", ScriptContents: "C2"},
+		{Name: "C", ScriptContents: "C3"},
+	})
+	require.NoError(t, err)
+
+	// index scripts by name
+	scriptByName := make(map[string]uint)
+	for _, s := range scripts {
+		scriptByName[s.Name] = s.ID
+	}
+
+	// create some hosts
+	hosts := make([]*fleet.Host, 4)
+	for i := range hosts {
+		host, err := ds.NewHost(context.Background(), &fleet.Host{
+			DetailUpdatedAt: time.Now(),
+			LabelUpdatedAt:  time.Now(),
+			SeenTime:        time.Now(),
+			NodeKey:         ptr.String(fmt.Sprint(i)),
+			UUID:            fmt.Sprint(i),
+			Hostname:        fmt.Sprintf("%d-foo.local", i),
+			PrimaryIP:       fmt.Sprintf("192.168.1.%d", i),
+			PrimaryMac:      fmt.Sprintf("30-65-EC-6F-C4-5%d", i),
+		})
+		require.NoError(t, err)
+		hosts[i] = host
+	}
+
+	// enqeue script executions:
+	// * hosts[0]: A, C, A, B
+	// * hosts[1]: B, B, C
+	// * hosts[2]: C, A
+	// * hosts[3]: A, B, C
+	execHost0ScriptA, err := ds.NewHostScriptExecutionRequest(ctx, &fleet.HostScriptRequestPayload{
+		HostID: hosts[0].ID, ScriptID: ptr.Uint(scriptByName["A"]), SyncRequest: true, ScriptContents: "C1",
+	})
+	require.NoError(t, err)
+	execHost0ScriptC, err := ds.NewHostScriptExecutionRequest(ctx, &fleet.HostScriptRequestPayload{
+		HostID: hosts[0].ID, ScriptID: ptr.Uint(scriptByName["C"]), SyncRequest: true, ScriptContents: "C3",
+	})
+	require.NoError(t, err)
+	execHost0ScriptA2, err := ds.NewHostScriptExecutionRequest(ctx, &fleet.HostScriptRequestPayload{
+		HostID: hosts[0].ID, ScriptID: ptr.Uint(scriptByName["A"]), SyncRequest: true, ScriptContents: "C1",
+	})
+	require.NoError(t, err)
+	execHost0ScriptB, err := ds.NewHostScriptExecutionRequest(ctx, &fleet.HostScriptRequestPayload{
+		HostID: hosts[0].ID, ScriptID: ptr.Uint(scriptByName["B"]), SyncRequest: true, ScriptContents: "C2",
+	})
+	require.NoError(t, err)
+	execHost1ScriptB, err := ds.NewHostScriptExecutionRequest(ctx, &fleet.HostScriptRequestPayload{
+		HostID: hosts[1].ID, ScriptID: ptr.Uint(scriptByName["B"]), SyncRequest: true, ScriptContents: "C2",
+	})
+	require.NoError(t, err)
+	execHost1ScriptB2, err := ds.NewHostScriptExecutionRequest(ctx, &fleet.HostScriptRequestPayload{
+		HostID: hosts[1].ID, ScriptID: ptr.Uint(scriptByName["B"]), SyncRequest: true, ScriptContents: "C2",
+	})
+	require.NoError(t, err)
+	execHost1ScriptC, err := ds.NewHostScriptExecutionRequest(ctx, &fleet.HostScriptRequestPayload{
+		HostID: hosts[1].ID, ScriptID: ptr.Uint(scriptByName["C"]), SyncRequest: true, ScriptContents: "C3",
+	})
+	require.NoError(t, err)
+	execHost2ScriptC, err := ds.NewHostScriptExecutionRequest(ctx, &fleet.HostScriptRequestPayload{
+		HostID: hosts[2].ID, ScriptID: ptr.Uint(scriptByName["C"]), SyncRequest: true, ScriptContents: "C3",
+	})
+	require.NoError(t, err)
+	execHost2ScriptA, err := ds.NewHostScriptExecutionRequest(ctx, &fleet.HostScriptRequestPayload{
+		HostID: hosts[2].ID, ScriptID: ptr.Uint(scriptByName["A"]), SyncRequest: true, ScriptContents: "C1",
+	})
+	require.NoError(t, err)
+	execHost3ScriptA, err := ds.NewHostScriptExecutionRequest(ctx, &fleet.HostScriptRequestPayload{
+		HostID: hosts[3].ID, ScriptID: ptr.Uint(scriptByName["A"]), SyncRequest: true, ScriptContents: "C1",
+	})
+	require.NoError(t, err)
+	execHost3ScriptB, err := ds.NewHostScriptExecutionRequest(ctx, &fleet.HostScriptRequestPayload{
+		HostID: hosts[3].ID, ScriptID: ptr.Uint(scriptByName["B"]), SyncRequest: true, ScriptContents: "C2",
+	})
+	require.NoError(t, err)
+	execHost3ScriptC, err := ds.NewHostScriptExecutionRequest(ctx, &fleet.HostScriptRequestPayload{
+		HostID: hosts[3].ID, ScriptID: ptr.Uint(scriptByName["C"]), SyncRequest: true, ScriptContents: "C3",
+	})
+	require.NoError(t, err)
+
+	checkUpcomingActivities(t, ds, hosts[0], execHost0ScriptA.ExecutionID, execHost0ScriptC.ExecutionID, execHost0ScriptA2.ExecutionID, execHost0ScriptB.ExecutionID)
+	checkUpcomingActivities(t, ds, hosts[1], execHost1ScriptB.ExecutionID, execHost1ScriptB2.ExecutionID, execHost1ScriptC.ExecutionID)
+	checkUpcomingActivities(t, ds, hosts[2], execHost2ScriptC.ExecutionID, execHost2ScriptA.ExecutionID)
+	checkUpcomingActivities(t, ds, hosts[3], execHost3ScriptA.ExecutionID, execHost3ScriptB.ExecutionID, execHost3ScriptC.ExecutionID)
+
+	// no change
+	scripts, err = ds.BatchSetScripts(ctx, nil, []*fleet.Script{
+		{Name: "A", ScriptContents: "C1"},
+		{Name: "B", ScriptContents: "C2"},
+		{Name: "C", ScriptContents: "C3"},
+	})
+	require.NoError(t, err)
+
+	checkUpcomingActivities(t, ds, hosts[0], execHost0ScriptA.ExecutionID, execHost0ScriptC.ExecutionID, execHost0ScriptA2.ExecutionID, execHost0ScriptB.ExecutionID)
+	checkUpcomingActivities(t, ds, hosts[1], execHost1ScriptB.ExecutionID, execHost1ScriptB2.ExecutionID, execHost1ScriptC.ExecutionID)
+	checkUpcomingActivities(t, ds, hosts[2], execHost2ScriptC.ExecutionID, execHost2ScriptA.ExecutionID)
+	checkUpcomingActivities(t, ds, hosts[3], execHost3ScriptA.ExecutionID, execHost3ScriptB.ExecutionID, execHost3ScriptC.ExecutionID)
+
+	// batch-set removes A, updates B and creates D, cancelling any pending A and B executions
+	scripts, err = ds.BatchSetScripts(ctx, nil, []*fleet.Script{
+		{Name: "B", ScriptContents: "C2updated"},
+		{Name: "C", ScriptContents: "C3"},
+		{Name: "D", ScriptContents: "C4"},
+	})
+	require.NoError(t, err)
+
+	checkUpcomingActivities(t, ds, hosts[0], execHost0ScriptC.ExecutionID)
+	checkUpcomingActivities(t, ds, hosts[1], execHost1ScriptC.ExecutionID)
+	checkUpcomingActivities(t, ds, hosts[2], execHost2ScriptC.ExecutionID)
+	checkUpcomingActivities(t, ds, hosts[3], execHost3ScriptC.ExecutionID)
+
+	// batch-set remove all
+	scripts, err = ds.BatchSetScripts(ctx, nil, []*fleet.Script{})
+	require.NoError(t, err)
+
+	checkUpcomingActivities(t, ds, hosts[0])
+	checkUpcomingActivities(t, ds, hosts[1])
+	checkUpcomingActivities(t, ds, hosts[2])
+	checkUpcomingActivities(t, ds, hosts[3])
 }

--- a/server/datastore/mysql/software_installers.go
+++ b/server/datastore/mysql/software_installers.go
@@ -829,7 +829,7 @@ func (ds *Datastore) deletePendingSoftwareInstallsForPolicy(ctx context.Context,
 
 	const loadAffectedHostsStmt = `
 		SELECT
-			host_id
+			DISTINCT host_id
 		FROM
 			upcoming_activities ua
 			INNER JOIN software_install_upcoming_activities siua


### PR DESCRIPTION
Addresses the "Batch-set scripts" scenario for https://github.com/fleetdm/fleet/issues/29357

# Checklist for submitter

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [x] Added/updated automated tests
