### PR TITLE
Revert 4.69.0 API reference changes

### DIFF
--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -2396,8 +2396,6 @@ If `after` is being used with `created_at` or `updated_at`, the table must be sp
       "label_updated_at": "2020-11-05T05:14:51Z",
       "policy_updated_at": "2023-06-26T18:33:15Z",
       "last_enrolled_at": "2023-02-26T22:33:12Z",
-      "last_mdm_checked_in_at": "2023-02-26T22:33:12Z",
-      "last_mdm_enrolled_at": "2023-02-26T22:33:12Z", 
       "seen_time": "2020-11-05T06:03:39Z",
       "hostname": "Annas-MacBook-Pro.local",
       "uuid": "392547dc-0000-0000-a87a-d701ff75bc65",


### PR DESCRIPTION
These changes, originally part of [this user story](https://github.com/fleetdm/fleet/issues/17710) (shipped in 4.68), are now part of a [separate user story](https://github.com/fleetdm/fleet/issues/29009) (target for 4.70).
