### PR TITLE
Fleet UI: Help text button font size fix

### DIFF
--- a/frontend/styles/var/mixins.scss
+++ b/frontend/styles/var/mixins.scss
@@ -146,7 +146,9 @@ $max-width: 2560px;
   font-size: $xx-small;
   font-weight: $regular;
   @include grey-text;
-  .custom-link {
+
+  .custom-link,
+  button {
     font-size: inherit;
   }
 }


### PR DESCRIPTION
## Issue
Followup for #28110 

## Description
- Font size of button within help text should be the same as help text font size
- Global fix for unreleased bug

## Screenshot of fix
<img width="667" alt="Screenshot 2025-05-27 at 12 42 40 PM" src="https://github.com/user-attachments/assets/784fa6da-41bf-49b7-9ee0-dd9df1696b88" />


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Manual QA for all new/changed functionality