### PR TITLE
For R.C. - Fleet UI: Help text button font size fix (#29489)

### DIFF
--- a/frontend/styles/var/mixins.scss
+++ b/frontend/styles/var/mixins.scss
@@ -146,7 +146,9 @@ $max-width: 2560px;
   font-size: $xx-small;
   font-weight: $regular;
   @include grey-text;
-  .custom-link {
+
+  .custom-link,
+  button {
     font-size: inherit;
   }
 }


### PR DESCRIPTION
## Issue
For #28110 

> Note: Previously merged into `main` with #29489. This is for R.C. 4.69.0

```
 1099  git checkout fleetdm/rc-minor-fleet-v4.69.0
 1100  git cherry-pick bd51c35ba69b7e67489b83a40806c0d79d7f6695
```

