### PR TITLE
Fixing permissions for aws-backup where policy names were flipped

### DIFF
--- a/infrastructure/dogfood/terraform/aws-tf-module/aws-backup.tf
+++ b/infrastructure/dogfood/terraform/aws-tf-module/aws-backup.tf
@@ -435,12 +435,12 @@ resource "aws_iam_role" "aws_backup" {
 
   inline_policy {
     name   = "aws-backup-restore-policy"
-    policy = data.aws_iam_policy_document.aws_backup_policy.json
+    policy = data.aws_iam_policy_document.aws_restore_policy.json
   }
 
   inline_policy {
     name   = "aws-backup-backup-policy"
-    policy = data.aws_iam_policy_document.aws_restore_policy.json
+    policy = data.aws_iam_policy_document.aws_backup_policy.json
   }
 }
 


### PR DESCRIPTION
Fixed restore policies to be tied to the correct policy names
- restore -> restore vs restore -> backup
- backup -> backup vs backup -> restore

Fixing the typos. Permissions remain unchanged.