### PR TITLE
UI: Query "frequency" -> "interval"

### DIFF
--- a/changes/28821-frequency-to-interval
+++ b/changes/28821-frequency-to-interval
@@ -1,0 +1,1 @@
+* Update UI references to "Frequency" to now say "Interval"

--- a/frontend/pages/queries/ManageQueriesPage/components/ManageQueryAutomationsModal/ManageQueryAutomationsModal.tsx
+++ b/frontend/pages/queries/ManageQueriesPage/components/ManageQueryAutomationsModal/ManageQueryAutomationsModal.tsx
@@ -124,7 +124,7 @@ const ManageQueryAutomationsModal = ({
       <div className={`${baseClass} form`}>
         <div className={`${baseClass}__heading`}>
           Query automations let you send data to your log destination on a
-          schedule. Data is sent according to a query&apos;s frequency.
+          schedule. Data is sent according to a query&apos;s interval.
         </div>
         {availableQueries?.length ? (
           <div className={`${baseClass}__select form-field`}>

--- a/frontend/pages/queries/ManageQueriesPage/components/QueriesTable/QueriesTable.tests.tsx
+++ b/frontend/pages/queries/ManageQueriesPage/components/QueriesTable/QueriesTable.tests.tsx
@@ -173,7 +173,7 @@ describe("QueriesTable", () => {
       expect(
         screen.getByText("You don't have any queries")
       ).toBeInTheDocument();
-      expect(screen.queryByText("Frequency")).toBeNull();
+      expect(screen.queryByText("Interval")).toBeNull();
       expect(screen.queryByPlaceholderText("Search by name")).toBeNull();
     });
   });
@@ -200,7 +200,7 @@ describe("QueriesTable", () => {
       expect(
         screen.getByText("You don't have any queries that apply to all teams")
       ).toBeInTheDocument();
-      expect(screen.queryByText("Frequency")).toBeNull();
+      expect(screen.queryByText("Interval")).toBeNull();
       expect(screen.queryByPlaceholderText("Search by name")).toBeNull();
     });
   });
@@ -227,7 +227,7 @@ describe("QueriesTable", () => {
       expect(
         screen.getByText("You don't have any queries that apply to this team")
       ).toBeInTheDocument();
-      expect(screen.queryByText("Frequency")).toBeNull();
+      expect(screen.queryByText("Interval")).toBeNull();
       expect(screen.queryByPlaceholderText("Search by name")).toBeNull();
     });
   });
@@ -251,7 +251,7 @@ describe("QueriesTable", () => {
       "Global query 1",
       "Global query 2",
       "Inherited",
-      "Frequency",
+      "Interval",
       "Team query 1",
       "Team query 2",
     ];

--- a/frontend/pages/queries/ManageQueriesPage/components/QueriesTable/QueriesTableConfig.tsx
+++ b/frontend/pages/queries/ManageQueriesPage/components/QueriesTable/QueriesTableConfig.tsx
@@ -216,8 +216,8 @@ const generateColumnConfigs = ({
       },
     },
     {
-      title: "Frequency",
-      Header: "Frequency",
+      title: "Interval",
+      Header: "Interval",
       disableSortBy: true,
       accessor: "interval",
       Cell: (cellProps: INumberCellProps): JSX.Element => {
@@ -228,7 +228,7 @@ const generateColumnConfigs = ({
           <TextCell
             value={val}
             emptyCellTooltipText={
-              <>Assign a frequency to collect data at an interval.</>
+              <>Assign an interval to collect data on a schedule.</>
             }
           />
         );

--- a/frontend/pages/queries/ManageQueriesPage/components/QueryAutomationsStatusIndicator/QueryAutomationsStatusIndicator.tsx
+++ b/frontend/pages/queries/ManageQueriesPage/components/QueryAutomationsStatusIndicator/QueryAutomationsStatusIndicator.tsx
@@ -26,8 +26,8 @@ const QueryAutomationsStatusIndicator = ({
       ? {
           tooltipText: (
             <>
-              <strong>Automations</strong> will resume for this query when a
-              frequency is set.
+              <strong>Automations</strong> will resume for this query when an
+              interval is set.
             </>
           ),
         }

--- a/frontend/pages/queries/details/QueryDetailsPage/QueryDetailsPage.tsx
+++ b/frontend/pages/queries/details/QueryDetailsPage/QueryDetailsPage.tsx
@@ -351,7 +351,7 @@ const QueryDetailsPage = ({
                       destination on a schedule. When automations are <b>
                         on
                       </b>, <br />
-                      data is sent according to a query&apos;s frequency.
+                      data is sent according to a query&apos;s interval.
                     </>
                   }
                 >

--- a/frontend/pages/queries/details/components/NoResults/NoResults.tsx
+++ b/frontend/pages/queries/details/components/NoResults/NoResults.tsx
@@ -123,8 +123,9 @@ const NoResults = ({
       return [
         "Nothing to report",
         <>
-          This query does not collect data on a schedule. Add <br />a{" "}
-          <strong>frequency</strong> or run this as a live query to see results.
+          This query does not collect data on a schedule. Add <br />
+          an <strong>interval</strong> or run this as a live query to see
+          results.
         </>,
       ];
     }

--- a/frontend/pages/queries/edit/components/EditQueryForm/EditQueryForm.tests.tsx
+++ b/frontend/pages/queries/edit/components/EditQueryForm/EditQueryForm.tests.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode } from "react";
+import React from "react";
 import { screen, waitFor, within } from "@testing-library/react";
 import { createCustomRenderer } from "test/test-utils";
 import { http, HttpResponse } from "msw";
@@ -250,15 +250,15 @@ describe("EditQueryForm - component", () => {
       />
     );
 
-    // Find the frequency dropdown
-    const frequencyDropdown = screen
-      .getByText("Frequency")
+    // Find the interval dropdown
+    const intervalDropdown = screen
+      .getByText("Interval")
       .closest(".form-field--dropdown") as HTMLElement;
-    expect(frequencyDropdown).toBeInTheDocument();
+    expect(intervalDropdown).toBeInTheDocument();
 
-    // Check if the frequency is set to "Never"
-    const selectedFrequency = within(frequencyDropdown).getByText("Never");
-    expect(selectedFrequency).toBeInTheDocument();
+    // Check if the interval is set to "Never"
+    const selectedInterval = within(intervalDropdown).getByText("Never");
+    expect(selectedInterval).toBeInTheDocument();
 
     // Find the automations slider
     const automationsSlider = screen

--- a/frontend/pages/queries/edit/components/EditQueryForm/EditQueryForm.tsx
+++ b/frontend/pages/queries/edit/components/EditQueryForm/EditQueryForm.tsx
@@ -844,7 +844,7 @@ const EditQueryForm = ({
                 onChange={onChangeSelectFrequency}
                 placeholder="Every day"
                 value={lastEditedQueryFrequency}
-                label="Frequency"
+                label="Interval"
                 wrapperClassName={`${baseClass}__form-field form-field--frequency`}
                 helpText="This is how often your query collects data."
               />
@@ -863,7 +863,7 @@ const EditQueryForm = ({
                         tipContent={
                           <>
                             Automations and reporting will be paused <br />
-                            for this query until a frequency is set.
+                            for this query until an interval is set.
                           </>
                         }
                         position="right"

--- a/frontend/pages/queries/edit/components/SaveQueryModal/SaveQueryModal.tests.tsx
+++ b/frontend/pages/queries/edit/components/SaveQueryModal/SaveQueryModal.tests.tsx
@@ -72,7 +72,7 @@ describe("SaveQueryModal", () => {
 
     expect(screen.getByLabelText("Name")).toBeInTheDocument();
     expect(screen.getByLabelText("Description")).toBeInTheDocument();
-    expect(screen.getByText("Frequency")).toBeInTheDocument();
+    expect(screen.getByText("Interval")).toBeInTheDocument();
     expect(screen.getByText("Observers can run")).toBeInTheDocument();
     expect(screen.getByText("Automations off")).toBeInTheDocument();
     expect(screen.getByText("Show advanced options")).toBeInTheDocument();

--- a/frontend/pages/queries/edit/components/SaveQueryModal/SaveQueryModal.tsx
+++ b/frontend/pages/queries/edit/components/SaveQueryModal/SaveQueryModal.tsx
@@ -1,7 +1,7 @@
-import React, { useState, useEffect, useCallback, useContext } from "react";
+import React, { useState, useEffect, useContext } from "react";
 import { useQuery } from "react-query";
 
-import { pull, size } from "lodash";
+import { size } from "lodash";
 
 import { AppContext } from "context/app";
 
@@ -12,7 +12,6 @@ import {
   FREQUENCY_DROPDOWN_OPTIONS,
   LOGGING_TYPE_OPTIONS,
   MIN_OSQUERY_VERSION_OPTIONS,
-  SCHEDULE_PLATFORM_DROPDOWN_OPTIONS,
   DEFAULT_USE_QUERY_OPTIONS,
 } from "utilities/constants";
 
@@ -231,7 +230,7 @@ const SaveQueryModal = ({
           }}
           placeholder="Every hour"
           value={selectedFrequency}
-          label="Frequency"
+          label="Interval"
           wrapperClassName={`${baseClass}__form-field form-field--frequency`}
           helpText="This is how often your query collects data."
         />
@@ -255,7 +254,7 @@ const SaveQueryModal = ({
                   tipContent={
                     <>
                       Automations and reporting will be paused <br />
-                      for this query until a frequency is set.
+                      for this query until an interval is set.
                     </>
                   }
                   position="right"


### PR DESCRIPTION
## For #28821 

- Update UI-rendered references to `/(F|f)requency/` to refer to `/(I|i)nterval/` instead 

![ezgif-60c1b29b41ce29](https://github.com/user-attachments/assets/d2012116-bfe7-4a0c-8056-e4d3e61e623d)

- More info: Note that this PR only changes copy actually rendered in the UI (and an associated test), and is low-risk, so can be merged and QAed quickly. [This branch](https://github.com/fleetdm/fleet/tree/28821-add-on-update-code) contains updates to variables, constants, and class names, more error-prone changes that, if review and QA capacity allow, can be PRed for consistency between the code and the copy, but is not critical for the desired UI updates.

- [x] Changes file added for user-visible changes in `changes/`
- [x] Added/updated automated tests
- [x] Manual QA for all new/changed functionality
