### PR TITLE
Fleet UI: Consistent icon for device user error as data error

### DIFF
--- a/frontend/components/DeviceUserError/DeviceUserError.tsx
+++ b/frontend/components/DeviceUserError/DeviceUserError.tsx
@@ -10,7 +10,7 @@ const DeviceUserError = (): JSX.Element => {
       <div className={`${baseClass}__inner`}>
         <div className="info">
           <span className="info__header">
-            <Icon name="error-outline" />
+            <Icon name="error" />
             This URL is invalid or expired.
           </span>
           <span className="info__data">


### PR DESCRIPTION
## Issue
Followup for #27185 (Figma design system <> Storybook consistency)

## Description
- QA noticed the icon in Device User Error (that's been there for 2 years) is inconsistent with the icon in Figma design system and the main UI Error page

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Manual QA for all new/changed functionality

