### PR TITLE
Fleet UI: View YAML modal updated

### DIFF
--- a/frontend/components/InfoBanner/_styles.scss
+++ b/frontend/components/InfoBanner/_styles.scss
@@ -14,7 +14,7 @@
 
   &__info {
     p {
-      margin: $pad-small 0 0 0;
+      margin: $pad-small 0 0 0; // TOFIX: this causes weird top margin noticed in #28110
     }
   }
 

--- a/frontend/components/SQLEditor/_styles.scss
+++ b/frontend/components/SQLEditor/_styles.scss
@@ -58,5 +58,8 @@
 .sql-editor * {
   letter-spacing: normal !important;
   word-spacing: normal !important;
-  font-family: 'SourceCodePro', monospace !important;
+}
+
+.sql-editor .ace_editor {
+  font-family: "SourceCodePro", monospace !important;
 }

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/EditSoftwareModal/EditSoftwareModal.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/EditSoftwareModal/EditSoftwareModal.tsx
@@ -196,7 +196,7 @@ const EditSoftwareModal = ({
         software.title_id &&
         gitOpsModeEnabled
       ) {
-        // No longer refetch as we open YAML modal if editing with gitOpsModeEnabled
+        // No longer flash message, we open YAML modal if editing with gitOpsModeEnabled
         const newQueryParams: QueryParams = {
           team_id: teamId,
           gitops_yaml: "true",
@@ -217,8 +217,8 @@ const EditSoftwareModal = ({
               : ""}
           </>
         );
-        refetchSoftwareTitle();
       }
+      refetchSoftwareTitle();
       onExit();
     } catch (e) {
       renderFlash("error", getErrorMessage(e, software as IAppStoreApp));

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/ViewYamlModal/ViewYamlModal.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/ViewYamlModal/ViewYamlModal.tsx
@@ -16,7 +16,7 @@ import InputField from "components/forms/fields/InputField";
 import Editor from "components/Editor";
 
 import { hyphenateString } from "utilities/strings/stringUtils";
-import { createPackageYaml, renderYamlHelperText } from "./helpers";
+import { createPackageYaml, renderDownloadFilesText } from "./helpers";
 
 const baseClass = "view-yaml-modal";
 
@@ -136,8 +136,9 @@ const ViewYamlModal = ({
         <InfoBanner className={`${baseClass}__info-banner`}>
           <p>
             To complete your GitOps configuration, follow the instructions
-            below. If the YAML is not added, the package will be deleted on the
-            next GitOps run.&nbsp;
+            below. If the YAML is not added, new installers will be deleted on
+            the next GitOps run, and edited installers will cause the GitOps run
+            to fail.&nbsp;
             <CustomLink
               url={`${LEARN_MORE_ABOUT_BASE_LINK}/yaml-software`}
               text="How to use YAML"
@@ -162,30 +163,28 @@ const ViewYamlModal = ({
             label="Filename"
             value={`${hyphenatedSoftwareTitle}.yml`}
           />
-          <Editor
-            label="Contents"
-            helpText={renderYamlHelperText({
-              preInstallQuery,
-              installScript,
-              postInstallScript,
-              uninstallScript,
-              onClickPreInstallQuery: preInstallQuery
-                ? onDownloadPreInstallQuery
-                : undefined,
-              onClickInstallScript: installScript
-                ? onDownloadInstallScript
-                : undefined,
-              onClickPostInstallScript: postInstallScript
-                ? onDownloadPostInstallScript
-                : undefined,
-              onClickUninstallScript: uninstallScript
-                ? onDownloadUninstallScript
-                : undefined,
-            })}
-            value={packageYaml}
-            enableCopy
-          />
+          <Editor label="Contents" value={packageYaml} enableCopy />
         </div>
+        <p>
+          {renderDownloadFilesText({
+            preInstallQuery,
+            installScript,
+            postInstallScript,
+            uninstallScript,
+            onClickPreInstallQuery: preInstallQuery
+              ? onDownloadPreInstallQuery
+              : undefined,
+            onClickInstallScript: installScript
+              ? onDownloadInstallScript
+              : undefined,
+            onClickPostInstallScript: postInstallScript
+              ? onDownloadPostInstallScript
+              : undefined,
+            onClickUninstallScript: uninstallScript
+              ? onDownloadUninstallScript
+              : undefined,
+          })}
+        </p>
         <div className="modal-cta-wrap">
           <Button onClick={onExit}>Done</Button>
         </div>

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/ViewYamlModal/_styles.scss
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/ViewYamlModal/_styles.scss
@@ -1,6 +1,11 @@
 .view-yaml-modal {
   overflow-wrap: anywhere; // Prevent long overflow
 
+  .info-banner__info {
+    p {
+      margin: 0; // Undo weird top margin from info-banner component
+    }
+  }
   &__form-fields {
     display: flex;
     flex-direction: column;

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/ViewYamlModal/helpers.tests.ts
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/ViewYamlModal/helpers.tests.ts
@@ -159,9 +159,7 @@ describe("renderYamlHelperText", () => {
     ).toBeInTheDocument();
     expect(
       screen.getByText((content) =>
-        content.includes(
-          "add it to your repository (please use the above path)."
-        )
+        content.includes("add it to your repository using the path above.")
       )
     ).toBeInTheDocument();
     expect(screen.queryByText("and")).not.toBeInTheDocument();
@@ -183,10 +181,10 @@ describe("renderYamlHelperText", () => {
       screen.getByRole("button", { name: "uninstall script" })
     ).toBeInTheDocument();
 
-    // In "Next," only
+    // In "Next," and "Advanced options," only
     const text = container.textContent ?? "";
     const commaCount = (text.match(/,/g) || []).length;
-    expect(commaCount).toBe(1);
+    expect(commaCount).toBe(2);
 
     // No oxford comma for two items
     expect(
@@ -194,9 +192,7 @@ describe("renderYamlHelperText", () => {
     ).not.toBeInTheDocument();
     expect(
       screen.getByText((content) =>
-        content.includes(
-          "add them to your repository (please use the above paths)."
-        )
+        content.includes("add them to your repository using the paths above.")
       )
     ).toBeInTheDocument();
   });
@@ -228,10 +224,10 @@ describe("renderYamlHelperText", () => {
       screen.getByRole("button", { name: "uninstall script" })
     ).toBeInTheDocument();
 
-    // In "Next," and 3 more commas
+    // In "Next," "Advanced options," and 3 more commas
     const text = container.textContent ?? "";
     const commaCount = (text.match(/,/g) || []).length;
-    expect(commaCount).toBe(4);
+    expect(commaCount).toBe(5);
 
     // Oxford comma for four items
     expect(
@@ -239,9 +235,7 @@ describe("renderYamlHelperText", () => {
     ).toBeInTheDocument();
     expect(
       screen.getByText((content) =>
-        content.includes(
-          "add them to your repository (please use the above paths)."
-        )
+        content.includes("add them to your repository using the paths above.")
       )
     ).toBeInTheDocument();
   });
@@ -269,10 +263,10 @@ describe("renderYamlHelperText", () => {
       screen.getByRole("button", { name: "uninstall script" })
     ).toBeInTheDocument();
 
-    // In "Next," and 2 more commas
+    // In "Next," "Advanced options," and 2 more commas
     const text = container.textContent ?? "";
     const commaCount = (text.match(/,/g) || []).length;
-    expect(commaCount).toBe(3);
+    expect(commaCount).toBe(4);
 
     // Oxford comma for three items
     expect(
@@ -280,9 +274,7 @@ describe("renderYamlHelperText", () => {
     ).toBeInTheDocument();
     expect(
       screen.getByText((content) =>
-        content.includes(
-          "add them to your repository (please use the above paths)."
-        )
+        content.includes("add them to your repository using the paths above.")
       )
     ).toBeInTheDocument();
   });

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/ViewYamlModal/helpers.tests.ts
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/ViewYamlModal/helpers.tests.ts
@@ -2,7 +2,7 @@ import { render, screen } from "@testing-library/react";
 import { createMockSoftwarePackage } from "__mocks__/softwareMock";
 import { noop } from "lodash";
 
-import { createPackageYaml, renderYamlHelperText } from "./helpers";
+import { createPackageYaml, renderDownloadFilesText } from "./helpers";
 
 describe("createPackageYaml", () => {
   const {
@@ -145,13 +145,15 @@ describe("renderYamlHelperText", () => {
 
   it("renders nothing if no scripts/queries are present", () => {
     // Empty to simulate 'no items'
-    const { container } = render(renderYamlHelperText({}));
+    const { container } = render(renderDownloadFilesText({}));
     expect(container).toBeEmptyDOMElement();
   });
 
   it("renders correctly with one item", () => {
     // Only install_script present
-    render(renderYamlHelperText({ installScript, onClickInstallScript: noop }));
+    render(
+      renderDownloadFilesText({ installScript, onClickInstallScript: noop })
+    );
     expect(
       screen.getByRole("button", { name: "install script" })
     ).toBeInTheDocument();
@@ -167,7 +169,7 @@ describe("renderYamlHelperText", () => {
 
   it("renders correctly with two items", () => {
     const { container } = render(
-      renderYamlHelperText({
+      renderDownloadFilesText({
         installScript,
         uninstallScript,
         onClickInstallScript: noop,
@@ -202,7 +204,7 @@ describe("renderYamlHelperText", () => {
   it("renders correctly with all items", () => {
     // All present (default)
     const { container } = render(
-      renderYamlHelperText({
+      renderDownloadFilesText({
         preInstallQuery,
         installScript,
         uninstallScript,
@@ -247,7 +249,7 @@ describe("renderYamlHelperText", () => {
   it("renders comma correctly for three items (with Oxford comma)", () => {
     // pre_install_query, install_script, uninstall_script present
     const { container } = render(
-      renderYamlHelperText({
+      renderDownloadFilesText({
         preInstallQuery,
         installScript,
         uninstallScript,

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/ViewYamlModal/helpers.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/ViewYamlModal/helpers.tsx
@@ -35,7 +35,7 @@ const joinWithCommasAnd = (
   });
 };
 
-export const renderYamlHelperText = ({
+export const renderDownloadFilesText = ({
   preInstallQuery,
   installScript,
   postInstallScript,
@@ -105,8 +105,11 @@ export const renderYamlHelperText = ({
   return (
     <>
       Next, download your {joinWithCommasAnd(items)} and add{" "}
-      {items.length === 1 ? "it" : "them"} to your repository (please use the
-      above {items.length === 1 ? "path" : "paths"}).
+      {items.length === 1 ? "it" : "them"} to your repository using the{" "}
+      {items.length === 1 ? "path" : "paths"} above. If you edited{" "}
+      <b>Advanced options</b>, download and replace the{" "}
+      {items.length === 1 ? "file" : "files"} in your repository with the
+      updated {items.length === 1 ? "one" : "ones"}.
     </>
   );
 };


### PR DESCRIPTION
## Issue
Followup for #28110 for unreleased bugs found by QA https://github.com/fleetdm/fleet/issues/28110#issuecomment-2905863969

## Description
- Needed to refetch data to show proper download buttons after edit (not showing correct download buttons after editing unreleased bug)
- Worked with @eugkuo to solve dynamic YAML instructions bug with replacing it with universal instructions for adding/editing installer (dynamic instruction bug)
- Help text actually part of instruction and not helper text for sql editor (font size and spacing unreleased bug)

Other fixed:
- Fixed weird top margin within info-banner (locally only)
- Fixed code font showing on label and help text of `SQLEditor` introduced in #28878 

## Screenrecording

https://github.com/user-attachments/assets/59b26fa2-2c26-485b-bee2-3da0d3fdac3d



# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Manual QA for all new/changed functionality