### PR TITLE
Fleet UI: Unreleased handle undefined signature_information

### DIFF
--- a/frontend/interfaces/software.ts
+++ b/frontend/interfaces/software.ts
@@ -374,7 +374,7 @@ export interface ISoftwareInstallVersion {
   last_opened_at: string | null;
   vulnerabilities: string[] | null;
   installed_paths: string[];
-  signature_information: SignatureInformation[];
+  signature_information?: SignatureInformation[];
 }
 
 export interface IHostSoftwarePackage {

--- a/frontend/pages/hosts/details/cards/Software/SoftwareDetailsModal/SoftwareDetailsModal.tests.tsx
+++ b/frontend/pages/hosts/details/cards/Software/SoftwareDetailsModal/SoftwareDetailsModal.tests.tsx
@@ -1,0 +1,95 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+
+import { createMockHostSoftware } from "__mocks__/hostMock";
+import SoftwareDetailsModal from "./SoftwareDetailsModal";
+
+// Mock current time for time stamp test
+beforeAll(() => {
+  jest.useFakeTimers();
+  jest.setSystemTime(new Date("2022-05-08T10:00:00Z"));
+});
+
+describe("SoftwareDetailsModal", () => {
+  it("renders details including hash, vulnerabilities, and paths", () => {
+    const mockSoftware = createMockHostSoftware();
+    render(
+      <SoftwareDetailsModal
+        hostDisplayName="Test Host"
+        software={mockSoftware}
+        onExit={jest.fn()}
+      />
+    );
+
+    // Modal title
+    expect(screen.getByText(mockSoftware.name)).toBeVisible();
+
+    // Version, Type, Bundle identifier, Last used
+    expect(screen.getByText("Version")).toBeVisible();
+    expect(screen.getByText("1.0.0")).toBeVisible();
+    expect(screen.getByText("Type")).toBeVisible();
+    expect(screen.getByText("Application (macOS)")).toBeVisible();
+    expect(screen.getByText("Bundle identifier")).toBeVisible();
+    expect(screen.getByText("com.test.mock")).toBeVisible();
+    expect(screen.getByText("Last used")).toBeVisible();
+    expect(screen.getByText("4 months ago")).toBeVisible();
+
+    // File path
+    expect(screen.getByText("File path")).toBeVisible();
+    expect(screen.getByText("/Applications/mock.app")).toBeVisible();
+
+    // Hash
+    expect(screen.getByText("Hash")).toBeVisible();
+    expect(screen.getByText("mockhashhere")).toBeVisible();
+
+    // Vulnerabilities
+    expect(screen.getByText(/CVE-2020-0001/)).toBeVisible();
+
+    // Tabs: Software details and Install details
+    expect(screen.getByText("Software details")).toBeVisible();
+    expect(screen.getByText("Install details")).toBeVisible();
+
+    // Done button
+    expect(screen.getByRole("button", { name: "Done" })).toBeVisible();
+  });
+
+  it("does not render hash if signature_information is missing", () => {
+    const mockSoftware = createMockHostSoftware({
+      installed_versions: [
+        {
+          version: "1.0.0",
+          last_opened_at: "2022-01-01T12:00:00Z",
+          vulnerabilities: ["CVE-2020-0001"],
+          installed_paths: ["/Applications/mock.app"],
+          bundle_identifier: "com.mock.software",
+          signature_information: undefined,
+        },
+      ],
+    });
+    render(
+      <SoftwareDetailsModal
+        hostDisplayName="Test Host"
+        software={mockSoftware}
+        onExit={jest.fn()}
+      />
+    );
+
+    expect(screen.queryByText("Hash")).not.toBeInTheDocument();
+    expect(screen.queryByText("mockhashhere")).not.toBeInTheDocument();
+  });
+
+  it("renders only software type if there are no installed versions", () => {
+    const mockSoftware = createMockHostSoftware({ installed_versions: [] });
+    render(
+      <SoftwareDetailsModal
+        hostDisplayName="Test Host"
+        software={mockSoftware}
+        onExit={jest.fn()}
+      />
+    );
+    expect(screen.getByText("Type")).toBeVisible();
+    expect(screen.getByText("Application (macOS)")).toBeVisible();
+    expect(screen.queryByText("Version")).not.toBeInTheDocument();
+    expect(screen.queryByText("File path")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/pages/hosts/details/cards/Software/SoftwareDetailsModal/SoftwareDetailsModal.tsx
+++ b/frontend/pages/hosts/details/cards/Software/SoftwareDetailsModal/SoftwareDetailsModal.tsx
@@ -53,7 +53,7 @@ const SoftwareDetailsInfo = ({
     signature_information,
   } = installedVersion;
 
-  const { hash_sha256: sha256 } = signature_information[0];
+  const sha256 = signature_information?.[0]?.hash_sha256;
 
   return (
     <div className={`${baseClass}__details-info`}>


### PR DESCRIPTION
## Issue
For #29513

## Description
- `signature_information` can be undefined: update interface and handle undefined gracefully
- Add tests to modal including testing undefined `signature_information`

## Screenshot of modal originally causing 500 if `signature_information` was undefined
<img width="644" alt="Screenshot 2025-05-28 at 3 32 53 PM" src="https://github.com/user-attachments/assets/7317567f-8974-4285-a01c-e3a4eae2f2b7" />

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Added/updated automated tests
~~- [ ] Manual QA for all new/changed functionality~~ Need assistance on this
