### PR TITLE
Fixes 29044: UI bug due to missing style for tooltip.

### DIFF
--- a/changes/29044-add-missing-tooltip-styles
+++ b/changes/29044-add-missing-tooltip-styles
@@ -1,0 +1,1 @@
+* Fixed bug with the 'Observers can run this query' tooltip due to missing styling rules.

--- a/frontend/pages/queries/ManageQueriesPage/_styles.scss
+++ b/frontend/pages/queries/ManageQueriesPage/_styles.scss
@@ -105,9 +105,6 @@
               .inherited-badge {
                 overflow: initial;
               }
-              .observer-can-run-badge {
-                @include tooltip5-arrow-styles;
-              }
             }
 
             @media (max-width: $break-md) {

--- a/frontend/pages/queries/ManageQueriesPage/components/QueriesTable/QueriesTableConfig.tsx
+++ b/frontend/pages/queries/ManageQueriesPage/components/QueriesTable/QueriesTableConfig.tsx
@@ -154,30 +154,19 @@ const generateColumnConfigs = ({
             suffix={
               <>
                 {!isCurrentTeamObserverOrGlobalObserver && observer_can_run && (
-                  <div className="observer-can-run-badge">
-                    <span
-                      className="observer-can-run-icon"
-                      data-tooltip-id={`observer-can-run-tooltip-${id}`}
-                    >
-                      <Icon
-                        className="observer-can-run-query-icon"
-                        name="query"
-                        size="small"
-                        color="core-fleet-blue"
-                      />
-                    </span>
-                    <ReactTooltip5
-                      className="observer-can-run-tooltip"
-                      disableStyleInjection
-                      place="top"
-                      opacity={1}
-                      id={`observer-can-run-tooltip-${id}`}
-                      offset={8}
-                      positionStrategy="fixed"
-                    >
-                      Observers can run this query.
-                    </ReactTooltip5>
-                  </div>
+                  <TooltipWrapper
+                    tipContent="Observers can run this query."
+                    underline={false}
+                    showArrow
+                    position="top"
+                  >
+                    <Icon
+                      className="observer-can-run-query-icon"
+                      name="query"
+                      size="small"
+                      color="ui-fleet-black-50"
+                    />
+                  </TooltipWrapper>
                 )}
                 {viewingTeamScope &&
                   // inherited

--- a/frontend/pages/queries/ManageQueriesPage/components/QueriesTable/_styles.scss
+++ b/frontend/pages/queries/ManageQueriesPage/components/QueriesTable/_styles.scss
@@ -1,0 +1,9 @@
+.observer-can-run-badge{
+  @include tooltip5-arrow-styles;
+
+  .react-tooltip {
+    @include tooltip-text;
+    font-style: normal;
+    text-align: center;
+  }
+}

--- a/frontend/pages/queries/ManageQueriesPage/components/QueriesTable/_styles.scss
+++ b/frontend/pages/queries/ManageQueriesPage/components/QueriesTable/_styles.scss
@@ -1,9 +1,0 @@
-.observer-can-run-badge{
-  @include tooltip5-arrow-styles;
-
-  .react-tooltip {
-    @include tooltip-text;
-    font-style: normal;
-    text-align: center;
-  }
-}


### PR DESCRIPTION
For #29044 

Fixed bug with the 'Observers can run this query' tooltip on the queries page due to missing styling rules.

https://drive.google.com/file/d/1EmVPwOR6r8NmNKdmc7co8HLqHiGnErsS/view?usp=sharing

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.
- [ ] Manual QA for all new/changed functionality