### PR TITLE
Fixes 28109: UI bug related to policy reported results

### DIFF
--- a/changes/28109-zero-result-when-running-policy
+++ b/changes/28109-zero-result-when-running-policy
@@ -1,0 +1,1 @@
+* Fixed result count shown when running a policy.

--- a/frontend/pages/policies/PolicyPage/components/PolicyResults/PolicyResults.tsx
+++ b/frontend/pages/policies/PolicyPage/components/PolicyResults/PolicyResults.tsx
@@ -188,7 +188,8 @@ const PolicyResults = ({
         <div className={`${baseClass}__results-table-header`}>
           <span className={`${baseClass}__results-meta`}>
             <span className={`${baseClass}__results-count`}>
-              {totalRowsCount} result{totalRowsCount !== 1 && "s"}
+              {uiHostCounts.successful} result
+              {uiHostCounts.successful !== 1 && "s"}
             </span>
             {isQueryFinished && renderPassFailPcts()}
           </span>


### PR DESCRIPTION
For #28109 

When running a policy, base the number of results on the number of 'sucessful' hosts.

https://drive.google.com/file/d/19ADezCeh214WeRdXE-YuzsVsXXxFCxrH/view?usp=drive_link

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.
- [X] Manual QA for all new/changed functionality