### PR TITLE
Fix broken Windows installation instructions

### DIFF
--- a/website/assets/js/pages/fleetctl-preview.page.js
+++ b/website/assets/js/pages/fleetctl-preview.page.js
@@ -7,7 +7,7 @@ parasails.registerPage('fleetctl-preview', {
     installCommands: {
       macos: 'curl -sSL https://fleetdm.com/resources/install-fleetctl.sh | bash',
       linux: 'curl -sSL https://fleetdm.com/resources/install-fleetctl.sh | bash',
-      windows: `for /f "tokens=1,* delims=:" %a in ('curl -s https://api.github.com/repos/fleetdm/fleet/releases/latest ^| findstr "browser_download_url" ^| findstr "_windows.zip"') do (curl -kOL %b) && if not exist "%USERPROFILE%\\.fleetctl" mkdir "%USERPROFILE%\\.fleetctl" && for /f "delims=" %a in ('dir /b fleetctl_*_windows.zip') do tar -xf "%a" --strip-components=1 -C "%USERPROFILE%\\.fleetctl" && del "%a"`,
+      windows: `for /f "tokens=1,* delims=:" %a in ('curl -s https://api.github.com/repos/fleetdm/fleet/releases/latest ^| findstr "browser_download_url" ^| findstr "_windows_amd64.zip"') do (curl -kOL %b) && if not exist "%USERPROFILE%\\.fleetctl" mkdir "%USERPROFILE%\\.fleetctl" && for /f "delims=" %a in ('dir /b fleetctl_*_windows_amd64.zip') do tar -xf "%a" --strip-components=1 -C "%USERPROFILE%\\.fleetctl" && del "%a"`,
       npm: 'npm install fleetctl -g',
     },
     fleetctlPreviewTerminalCommand: {


### PR DESCRIPTION
I'm experiencing problems with the "Install the fleetctl command line tool" step on https://fleetdm.com/try-fleet for trying out Fleet hosting on Windows. The root cause seem to be a mismatch between the Windows ZIP-file naming in the script vs. on https://api.github.com/repos/fleetdm/fleet/releases/latest

I was able to overcome the problem by changing `_windows.zip` to `_windows_amd64.zip` in the script.
