### PR TITLE
For R.C. - Fleet UI: handle undefined sig info, edited yaml modal, responsiveness, icon

### DIFF
--- a/frontend/components/DeviceUserError/DeviceUserError.tsx
+++ b/frontend/components/DeviceUserError/DeviceUserError.tsx
@@ -10,7 +10,7 @@ const DeviceUserError = (): JSX.Element => {
       <div className={`${baseClass}__inner`}>
         <div className="info">
           <span className="info__header">
-            <Icon name="error-outline" />
+            <Icon name="error" />
             This URL is invalid or expired.
           </span>
           <span className="info__data">

--- a/frontend/components/InfoBanner/_styles.scss
+++ b/frontend/components/InfoBanner/_styles.scss
@@ -14,7 +14,7 @@
 
   &__info {
     p {
-      margin: $pad-small 0 0 0;
+      margin: $pad-small 0 0 0; // TOFIX: this causes weird top margin noticed in #28110
     }
   }
 

--- a/frontend/components/SQLEditor/_styles.scss
+++ b/frontend/components/SQLEditor/_styles.scss
@@ -58,5 +58,8 @@
 .sql-editor * {
   letter-spacing: normal !important;
   word-spacing: normal !important;
-  font-family: 'SourceCodePro', monospace !important;
+}
+
+.sql-editor .ace_editor {
+  font-family: "SourceCodePro", monospace !important;
 }

--- a/frontend/interfaces/software.ts
+++ b/frontend/interfaces/software.ts
@@ -374,7 +374,7 @@ export interface ISoftwareInstallVersion {
   last_opened_at: string | null;
   vulnerabilities: string[] | null;
   installed_paths: string[];
-  signature_information: SignatureInformation[];
+  signature_information?: SignatureInformation[];
 }
 
 export interface IHostSoftwarePackage {

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/EditSoftwareModal/EditSoftwareModal.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/EditSoftwareModal/EditSoftwareModal.tsx
@@ -196,7 +196,7 @@ const EditSoftwareModal = ({
         software.title_id &&
         gitOpsModeEnabled
       ) {
-        // No longer refetch as we open YAML modal if editing with gitOpsModeEnabled
+        // No longer flash message, we open YAML modal if editing with gitOpsModeEnabled
         const newQueryParams: QueryParams = {
           team_id: teamId,
           gitops_yaml: "true",
@@ -217,8 +217,8 @@ const EditSoftwareModal = ({
               : ""}
           </>
         );
-        refetchSoftwareTitle();
       }
+      refetchSoftwareTitle();
       onExit();
     } catch (e) {
       renderFlash("error", getErrorMessage(e, software as IAppStoreApp));

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwareInstallerCard/SoftwareInstallerCard.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwareInstallerCard/SoftwareInstallerCard.tsx
@@ -351,61 +351,65 @@ const SoftwareInstallerCard = ({
 
   return (
     <Card borderRadiusSize="xxlarge" includeShadow className={baseClass}>
-      <div className={`${baseClass}__row-1`}>
-        <div className={`${baseClass}__row-1--responsive`}>
-          <InstallerDetailsWidget
-            softwareName={softwareInstaller?.name || name}
-            installerType={installerType}
-            versionInfo={versionInfo}
-            addedTimestamp={addedTimestamp}
-            sha256={sha256}
-            isFma={isFleetMaintainedApp}
-          />
-          <div className={`${baseClass}__tags-wrapper`}>
-            {Array.isArray(automaticInstallPolicies) &&
-              automaticInstallPolicies.length > 0 && (
+      <div className={`${baseClass}__installer-header`}>
+        <div className={`${baseClass}__row-1`}>
+          <div className={`${baseClass}__row-1--responsive-wrap`}>
+            <InstallerDetailsWidget
+              softwareName={softwareInstaller?.name || name}
+              installerType={installerType}
+              versionInfo={versionInfo}
+              addedTimestamp={addedTimestamp}
+              sha256={sha256}
+              isFma={isFleetMaintainedApp}
+            />
+            <div className={`${baseClass}__tags-wrapper`}>
+              {Array.isArray(automaticInstallPolicies) &&
+                automaticInstallPolicies.length > 0 && (
+                  <TooltipWrapper
+                    showArrow
+                    position="top"
+                    tipContent={
+                      automaticInstallPolicies.length === 1
+                        ? "A policy triggers install."
+                        : `${automaticInstallPolicies.length} policies trigger install.`
+                    }
+                    underline={false}
+                  >
+                    <Tag icon="refresh" text="Automatic install" />
+                  </TooltipWrapper>
+                )}
+              {isSelfService && (
                 <TooltipWrapper
                   showArrow
                   position="top"
-                  tipContent={
-                    automaticInstallPolicies.length === 1
-                      ? "A policy triggers install."
-                      : `${automaticInstallPolicies.length} policies trigger install.`
-                  }
+                  tipContent={SELF_SERVICE_TOOLTIP}
                   underline={false}
                 >
-                  <Tag icon="refresh" text="Automatic install" />
+                  <Tag icon="user" text="Self-service" />
                 </TooltipWrapper>
               )}
-            {isSelfService && (
-              <TooltipWrapper
-                showArrow
-                position="top"
-                tipContent={SELF_SERVICE_TOOLTIP}
-                underline={false}
-              >
-                <Tag icon="user" text="Self-service" />
-              </TooltipWrapper>
+            </div>
+          </div>
+          <div className={`${baseClass}__actions-wrapper`}>
+            {showActions && (
+              <SoftwareActionButtons
+                installerType={installerType}
+                onDownloadClick={onDownloadClick}
+                onDeleteClick={onDeleteClick}
+                onEditSoftwareClick={onEditSoftwareClick}
+                gitOpsModeEnabled={gitOpsModeEnabled}
+                repoURL={repoURL}
+              />
             )}
           </div>
         </div>
-        <div className={`${baseClass}__actions-wrapper`}>
-          {showActions && (
-            <SoftwareActionButtons
-              installerType={installerType}
-              onDownloadClick={onDownloadClick}
-              onDeleteClick={onDeleteClick}
-              onEditSoftwareClick={onEditSoftwareClick}
-              gitOpsModeEnabled={gitOpsModeEnabled}
-              repoURL={repoURL}
-            />
+        <div className={`${baseClass}__row-2`}>
+          {gitOpsModeEnabled && isCustomPackage && (
+            <div className={`${baseClass}__yaml-button-wrapper`}>
+              <Button onClick={onToggleViewYaml}>View YAML</Button>
+            </div>
           )}
         </div>
-        {gitOpsModeEnabled && isCustomPackage && (
-          <div className={`${baseClass}__yaml-button-wrapper`}>
-            <Button onClick={onToggleViewYaml}>View YAML</Button>
-          </div>
-        )}
       </div>
       <div className={`${baseClass}__installer-status-table`}>
         <InstallerStatusTable

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwareInstallerCard/_styles.scss
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwareInstallerCard/_styles.scss
@@ -18,19 +18,38 @@
     width: 100%;
   }
 
+  &__installer-header,
   &__row-1 {
     display: flex;
     width: 100%;
     gap: $pad-medium;
   }
 
-  // SoftwareDetailsWidget and Tags wrap onto 2 lines on low widths
   &__row-1--responsive {
     display: flex;
     flex-grow: 1;
     justify-content: space-between;
+  }
 
-    @media (max-width: ($break-md - 1)) {
+  // Lots of data (10 items) on one line responsive fix (#29397)
+  @media (max-width: ($table-controls-break)) {
+    .installer-details-widget__details {
+      flex-wrap: wrap;
+    }
+    // SoftwareDetailsWidget and Tags wrap onto 2 lines on low widths
+    &__row-1--responsive-wrap {
+      flex-direction: column;
+      gap: $pad-medium;
+    }
+
+    // Buttons align top of card when alone (not middle with pills/yaml button)
+    &__actions {
+      .children-wrapper {
+        align-self: top;
+      }
+    }
+    // View YAML (gitops) button wrapped onto third line
+    &__installer-header {
       flex-direction: column;
       gap: $pad-medium;
     }

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/ViewYamlModal/ViewYamlModal.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/ViewYamlModal/ViewYamlModal.tsx
@@ -16,7 +16,7 @@ import InputField from "components/forms/fields/InputField";
 import Editor from "components/Editor";
 
 import { hyphenateString } from "utilities/strings/stringUtils";
-import { createPackageYaml, renderYamlHelperText } from "./helpers";
+import { createPackageYaml, renderDownloadFilesText } from "./helpers";
 
 const baseClass = "view-yaml-modal";
 
@@ -136,8 +136,9 @@ const ViewYamlModal = ({
         <InfoBanner className={`${baseClass}__info-banner`}>
           <p>
             To complete your GitOps configuration, follow the instructions
-            below. If the YAML is not added, the package will be deleted on the
-            next GitOps run.&nbsp;
+            below. If the YAML is not added, new installers will be deleted on
+            the next GitOps run, and edited installers will cause the GitOps run
+            to fail.&nbsp;
             <CustomLink
               url={`${LEARN_MORE_ABOUT_BASE_LINK}/yaml-software`}
               text="How to use YAML"
@@ -162,29 +163,28 @@ const ViewYamlModal = ({
             label="Filename"
             value={`${hyphenatedSoftwareTitle}.yml`}
           />
-          <Editor
-            label="Contents"
-            helpText={renderYamlHelperText({
-              preInstallQuery,
-              installScript,
-              postInstallScript,
-              uninstallScript,
-              onClickPreInstallQuery: preInstallQuery
-                ? onDownloadPreInstallQuery
-                : undefined,
-              onClickInstallScript: installScript
-                ? onDownloadInstallScript
-                : undefined,
-              onClickPostInstallScript: postInstallScript
-                ? onDownloadPostInstallScript
-                : undefined,
-              onClickUninstallScript: uninstallScript
-                ? onDownloadUninstallScript
-                : undefined,
-            })}
-            value={packageYaml}
-          />
+          <Editor label="Contents" value={packageYaml} enableCopy />
         </div>
+        <p>
+          {renderDownloadFilesText({
+            preInstallQuery,
+            installScript,
+            postInstallScript,
+            uninstallScript,
+            onClickPreInstallQuery: preInstallQuery
+              ? onDownloadPreInstallQuery
+              : undefined,
+            onClickInstallScript: installScript
+              ? onDownloadInstallScript
+              : undefined,
+            onClickPostInstallScript: postInstallScript
+              ? onDownloadPostInstallScript
+              : undefined,
+            onClickUninstallScript: uninstallScript
+              ? onDownloadUninstallScript
+              : undefined,
+          })}
+        </p>
         <div className="modal-cta-wrap">
           <Button onClick={onExit}>Done</Button>
         </div>

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/ViewYamlModal/_styles.scss
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/ViewYamlModal/_styles.scss
@@ -1,6 +1,11 @@
 .view-yaml-modal {
   overflow-wrap: anywhere; // Prevent long overflow
 
+  .info-banner__info {
+    p {
+      margin: 0; // Undo weird top margin from info-banner component
+    }
+  }
   &__form-fields {
     display: flex;
     flex-direction: column;

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/ViewYamlModal/helpers.tests.ts
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/ViewYamlModal/helpers.tests.ts
@@ -2,7 +2,7 @@ import { render, screen } from "@testing-library/react";
 import { createMockSoftwarePackage } from "__mocks__/softwareMock";
 import { noop } from "lodash";
 
-import { createPackageYaml, renderYamlHelperText } from "./helpers";
+import { createPackageYaml, renderDownloadFilesText } from "./helpers";
 
 describe("createPackageYaml", () => {
   const {
@@ -145,21 +145,21 @@ describe("renderYamlHelperText", () => {
 
   it("renders nothing if no scripts/queries are present", () => {
     // Empty to simulate 'no items'
-    const { container } = render(renderYamlHelperText({}));
+    const { container } = render(renderDownloadFilesText({}));
     expect(container).toBeEmptyDOMElement();
   });
 
   it("renders correctly with one item", () => {
     // Only install_script present
-    render(renderYamlHelperText({ installScript, onClickInstallScript: noop }));
+    render(
+      renderDownloadFilesText({ installScript, onClickInstallScript: noop })
+    );
     expect(
       screen.getByRole("button", { name: "install script" })
     ).toBeInTheDocument();
     expect(
       screen.getByText((content) =>
-        content.includes(
-          "add it to your repository (please use the above path)."
-        )
+        content.includes("add it to your repository using the path above.")
       )
     ).toBeInTheDocument();
     expect(screen.queryByText("and")).not.toBeInTheDocument();
@@ -167,7 +167,7 @@ describe("renderYamlHelperText", () => {
 
   it("renders correctly with two items", () => {
     const { container } = render(
-      renderYamlHelperText({
+      renderDownloadFilesText({
         installScript,
         uninstallScript,
         onClickInstallScript: noop,
@@ -181,10 +181,10 @@ describe("renderYamlHelperText", () => {
       screen.getByRole("button", { name: "uninstall script" })
     ).toBeInTheDocument();
 
-    // In "Next," only
+    // In "Next," and "Advanced options," only
     const text = container.textContent ?? "";
     const commaCount = (text.match(/,/g) || []).length;
-    expect(commaCount).toBe(1);
+    expect(commaCount).toBe(2);
 
     // No oxford comma for two items
     expect(
@@ -192,9 +192,7 @@ describe("renderYamlHelperText", () => {
     ).not.toBeInTheDocument();
     expect(
       screen.getByText((content) =>
-        content.includes(
-          "add them to your repository (please use the above paths)."
-        )
+        content.includes("add them to your repository using the paths above.")
       )
     ).toBeInTheDocument();
   });
@@ -202,7 +200,7 @@ describe("renderYamlHelperText", () => {
   it("renders correctly with all items", () => {
     // All present (default)
     const { container } = render(
-      renderYamlHelperText({
+      renderDownloadFilesText({
         preInstallQuery,
         installScript,
         uninstallScript,
@@ -226,10 +224,10 @@ describe("renderYamlHelperText", () => {
       screen.getByRole("button", { name: "uninstall script" })
     ).toBeInTheDocument();
 
-    // In "Next," and 3 more commas
+    // In "Next," "Advanced options," and 3 more commas
     const text = container.textContent ?? "";
     const commaCount = (text.match(/,/g) || []).length;
-    expect(commaCount).toBe(4);
+    expect(commaCount).toBe(5);
 
     // Oxford comma for four items
     expect(
@@ -237,9 +235,7 @@ describe("renderYamlHelperText", () => {
     ).toBeInTheDocument();
     expect(
       screen.getByText((content) =>
-        content.includes(
-          "add them to your repository (please use the above paths)."
-        )
+        content.includes("add them to your repository using the paths above.")
       )
     ).toBeInTheDocument();
   });
@@ -247,7 +243,7 @@ describe("renderYamlHelperText", () => {
   it("renders comma correctly for three items (with Oxford comma)", () => {
     // pre_install_query, install_script, uninstall_script present
     const { container } = render(
-      renderYamlHelperText({
+      renderDownloadFilesText({
         preInstallQuery,
         installScript,
         uninstallScript,
@@ -267,10 +263,10 @@ describe("renderYamlHelperText", () => {
       screen.getByRole("button", { name: "uninstall script" })
     ).toBeInTheDocument();
 
-    // In "Next," and 2 more commas
+    // In "Next," "Advanced options," and 2 more commas
     const text = container.textContent ?? "";
     const commaCount = (text.match(/,/g) || []).length;
-    expect(commaCount).toBe(3);
+    expect(commaCount).toBe(4);
 
     // Oxford comma for three items
     expect(
@@ -278,9 +274,7 @@ describe("renderYamlHelperText", () => {
     ).toBeInTheDocument();
     expect(
       screen.getByText((content) =>
-        content.includes(
-          "add them to your repository (please use the above paths)."
-        )
+        content.includes("add them to your repository using the paths above.")
       )
     ).toBeInTheDocument();
   });

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/ViewYamlModal/helpers.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/ViewYamlModal/helpers.tsx
@@ -35,7 +35,7 @@ const joinWithCommasAnd = (
   });
 };
 
-export const renderYamlHelperText = ({
+export const renderDownloadFilesText = ({
   preInstallQuery,
   installScript,
   postInstallScript,
@@ -105,8 +105,11 @@ export const renderYamlHelperText = ({
   return (
     <>
       Next, download your {joinWithCommasAnd(items)} and add{" "}
-      {items.length === 1 ? "it" : "them"} to your repository (please use the
-      above {items.length === 1 ? "path" : "paths"}).
+      {items.length === 1 ? "it" : "them"} to your repository using the{" "}
+      {items.length === 1 ? "path" : "paths"} above. If you edited{" "}
+      <b>Advanced options</b>, download and replace the{" "}
+      {items.length === 1 ? "file" : "files"} in your repository with the
+      updated {items.length === 1 ? "one" : "ones"}.
     </>
   );
 };

--- a/frontend/pages/hosts/details/cards/Software/SoftwareDetailsModal/SoftwareDetailsModal.tests.tsx
+++ b/frontend/pages/hosts/details/cards/Software/SoftwareDetailsModal/SoftwareDetailsModal.tests.tsx
@@ -1,0 +1,95 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+
+import { createMockHostSoftware } from "__mocks__/hostMock";
+import SoftwareDetailsModal from "./SoftwareDetailsModal";
+
+// Mock current time for time stamp test
+beforeAll(() => {
+  jest.useFakeTimers();
+  jest.setSystemTime(new Date("2022-05-08T10:00:00Z"));
+});
+
+describe("SoftwareDetailsModal", () => {
+  it("renders details including hash, vulnerabilities, and paths", () => {
+    const mockSoftware = createMockHostSoftware();
+    render(
+      <SoftwareDetailsModal
+        hostDisplayName="Test Host"
+        software={mockSoftware}
+        onExit={jest.fn()}
+      />
+    );
+
+    // Modal title
+    expect(screen.getByText(mockSoftware.name)).toBeVisible();
+
+    // Version, Type, Bundle identifier, Last used
+    expect(screen.getByText("Version")).toBeVisible();
+    expect(screen.getByText("1.0.0")).toBeVisible();
+    expect(screen.getByText("Type")).toBeVisible();
+    expect(screen.getByText("Application (macOS)")).toBeVisible();
+    expect(screen.getByText("Bundle identifier")).toBeVisible();
+    expect(screen.getByText("com.test.mock")).toBeVisible();
+    expect(screen.getByText("Last used")).toBeVisible();
+    expect(screen.getByText("4 months ago")).toBeVisible();
+
+    // File path
+    expect(screen.getByText("File path")).toBeVisible();
+    expect(screen.getByText("/Applications/mock.app")).toBeVisible();
+
+    // Hash
+    expect(screen.getByText("Hash")).toBeVisible();
+    expect(screen.getByText("mockhashhere")).toBeVisible();
+
+    // Vulnerabilities
+    expect(screen.getByText(/CVE-2020-0001/)).toBeVisible();
+
+    // Tabs: Software details and Install details
+    expect(screen.getByText("Software details")).toBeVisible();
+    expect(screen.getByText("Install details")).toBeVisible();
+
+    // Done button
+    expect(screen.getByRole("button", { name: "Done" })).toBeVisible();
+  });
+
+  it("does not render hash if signature_information is missing", () => {
+    const mockSoftware = createMockHostSoftware({
+      installed_versions: [
+        {
+          version: "1.0.0",
+          last_opened_at: "2022-01-01T12:00:00Z",
+          vulnerabilities: ["CVE-2020-0001"],
+          installed_paths: ["/Applications/mock.app"],
+          bundle_identifier: "com.mock.software",
+          signature_information: undefined,
+        },
+      ],
+    });
+    render(
+      <SoftwareDetailsModal
+        hostDisplayName="Test Host"
+        software={mockSoftware}
+        onExit={jest.fn()}
+      />
+    );
+
+    expect(screen.queryByText("Hash")).not.toBeInTheDocument();
+    expect(screen.queryByText("mockhashhere")).not.toBeInTheDocument();
+  });
+
+  it("renders only software type if there are no installed versions", () => {
+    const mockSoftware = createMockHostSoftware({ installed_versions: [] });
+    render(
+      <SoftwareDetailsModal
+        hostDisplayName="Test Host"
+        software={mockSoftware}
+        onExit={jest.fn()}
+      />
+    );
+    expect(screen.getByText("Type")).toBeVisible();
+    expect(screen.getByText("Application (macOS)")).toBeVisible();
+    expect(screen.queryByText("Version")).not.toBeInTheDocument();
+    expect(screen.queryByText("File path")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/pages/hosts/details/cards/Software/SoftwareDetailsModal/SoftwareDetailsModal.tsx
+++ b/frontend/pages/hosts/details/cards/Software/SoftwareDetailsModal/SoftwareDetailsModal.tsx
@@ -53,7 +53,7 @@ const SoftwareDetailsInfo = ({
     signature_information,
   } = installedVersion;
 
-  const { hash_sha256: sha256 } = signature_information[0];
+  const sha256 = signature_information?.[0]?.hash_sha256;
 
   return (
     <div className={`${baseClass}__details-info`}>


### PR DESCRIPTION
## Issue
Follow ups:
For #27185
For #29397
For #28110 
For #29513 

> Note: Previously merged into `main` with #29550, #29545, #29541, and #29535. This is for R.C. 4.69.0

```
 1182  git checkout fleetdm/rc-minor-fleet-v4.69.0
 1183  git log main
 1184  git cherry-pick 94ae5ab8dd6aaeab82393677681556904a9dd62e fd1a1cccf306f71e1cc8cdb02dd3c065cbca28ac 21f7a0001f32928472a97921d68776855e0bca16 b3ee06c5c4c32e8f385e1322651ff5cb19b9193a 
 1185  git log
 1186  git status
 1187  git add frontend/
 1188  git cherry-pick --continue
 1189  git log
 1190  git branch
 1191  git checkout -b fe-sw-cherrypicks
 1192  git push -u fleetdm fe-sw-cherrypicks
```

> Note: the cherry-pick conflict that was in `21f7a0001f32928472a97921d68776855e0bca16` was between `<Editor label="Contents" value={packageYaml} enableCopy />` with and without the `renderHelperText` prop was getting flagged for no reason