### PR TITLE
Check if runAsUser and/or runAsGroup are not supplied in In Fleet Helm Chart Values

### DIFF
--- a/charts/fleet/Chart.yaml
+++ b/charts/fleet/Chart.yaml
@@ -4,7 +4,7 @@ name: fleet
 keywords:
   - fleet
   - osquery
-version: v6.6.2
+version: v6.6.3
 home: https://github.com/fleetdm/fleet
 sources:
   - https://github.com/fleetdm/fleet.git

--- a/charts/fleet/templates/cron-vulnprocessing.yaml
+++ b/charts/fleet/templates/cron-vulnprocessing.yaml
@@ -168,9 +168,12 @@ spec:
                 {{- end }}
               privileged: false
               readOnlyRootFilesystem: true
+              {{- if .Values.fleet.securityContext.runAsGroup }}
               runAsGroup: {{ int64 .Values.fleet.securityContext.runAsGroup }}
+              {{- end }}
+              {{- if .Values.fleet.securityContext.runAsUser }}
               runAsUser: {{ int64 .Values.fleet.securityContext.runAsUser }}
-              runAsNonRoot: true
+              {{- end }}
             volumeMounts:
               - name: tmp
                 mountPath: /tmp
@@ -199,8 +202,12 @@ spec:
                 drop: [ALL]
               privileged: false
               readOnlyRootFilesystem: true
+              {{- if .Values.fleet.securityContext.runAsGroup }}
               runAsGroup: {{ int64 .Values.fleet.securityContext.runAsGroup }}
+              {{- end }}
+              {{- if .Values.fleet.securityContext.runAsUser }}
               runAsUser: {{ int64 .Values.fleet.securityContext.runAsUser }}
+              {{- end }}
               runAsNonRoot: true
           {{- end }}
           {{- with .Values.imagePullSecrets }}

--- a/charts/fleet/templates/cron-vulnprocessing.yaml
+++ b/charts/fleet/templates/cron-vulnprocessing.yaml
@@ -174,6 +174,7 @@ spec:
               {{- if .Values.fleet.securityContext.runAsUser }}
               runAsUser: {{ int64 .Values.fleet.securityContext.runAsUser }}
               {{- end }}
+              runAsNonRoot: true
             volumeMounts:
               - name: tmp
                 mountPath: /tmp

--- a/charts/fleet/templates/deployment.yaml
+++ b/charts/fleet/templates/deployment.yaml
@@ -304,8 +304,12 @@ spec:
             drop: [ALL]
           privileged: false
           readOnlyRootFilesystem: true
+          {{- if .Values.fleet.securityContext.runAsGroup }}
           runAsGroup: {{ int64 .Values.fleet.securityContext.runAsGroup }}
+          {{- end }}
+          {{- if .Values.fleet.securityContext.runAsUser }}
           runAsUser: {{ int64 .Values.fleet.securityContext.runAsUser }}
+          {{- end }}
           runAsNonRoot: true
         livenessProbe:
           httpGet:
@@ -363,8 +367,12 @@ spec:
             drop: [ALL]
           privileged: false
           readOnlyRootFilesystem: true
+          {{- if .Values.fleet.securityContext.runAsGroup }}
           runAsGroup: {{ int64 .Values.fleet.securityContext.runAsGroup }}
+          {{- end }}
+          {{- if .Values.fleet.securityContext.runAsUser }}
           runAsUser: {{ int64 .Values.fleet.securityContext.runAsUser }}
+          {{- end }}
           runAsNonRoot: true
       {{- end }}
       hostPID: false

--- a/charts/fleet/templates/job-migration.yaml
+++ b/charts/fleet/templates/job-migration.yaml
@@ -131,8 +131,12 @@ spec:
             {{- end }}
           privileged: false
           readOnlyRootFilesystem: true
+          {{- if .Values.fleet.securityContext.runAsGroup }}
           runAsGroup: {{ int64 .Values.fleet.securityContext.runAsGroup }}
+          {{- end }}
+          {{- if .Values.fleet.securityContext.runAsUser }}
           runAsUser: {{ int64 .Values.fleet.securityContext.runAsUser }}
+          {{- end }}
           runAsNonRoot: true
         volumeMounts:
           {{- if .Values.database.tls.enabled }}
@@ -160,8 +164,12 @@ spec:
             drop: [ALL]
           privileged: false
           readOnlyRootFilesystem: true
+          {{- if .Values.fleet.securityContext.runAsGroup }}
           runAsGroup: {{ int64 .Values.fleet.securityContext.runAsGroup }}
+          {{- end }}
+          {{- if .Values.fleet.securityContext.runAsUser }}
           runAsUser: {{ int64 .Values.fleet.securityContext.runAsUser }}
+          {{- end }}
           runAsNonRoot: true
       {{- end }}
       {{- with .Values.imagePullSecrets }}


### PR DESCRIPTION
Add logic around runAsUser and runAsGroup to Fleet Helm Chart
- Resolves #29460 
- Added to deployment, migration, and cronjob for vulnprocessing.