### PR TITLE
Fleet UI: Fix vuln page banner padding and flex direction

### DIFF
--- a/frontend/pages/SoftwarePage/SoftwareVulnerabilityDetailsPage/_styles.scss
+++ b/frontend/pages/SoftwarePage/SoftwareVulnerabilityDetailsPage/_styles.scss
@@ -6,12 +6,6 @@
     @include normalize-team-header;
   }
 
-  .card {
-    display: flex;
-    flex-direction: column;
-    padding: $pad-xxlarge;
-  }
-
   * > h1,
   h2 {
     margin: 0;


### PR DESCRIPTION
## Issue
For #29578 

## Description
- Card styling was being set locally for entire page (16 month old styling bug)
- Ensured card styling for other cards still were set at the component level

## Screenshot of fix
<img width="1297" alt="Screenshot 2025-05-29 at 2 17 48 PM" src="https://github.com/user-attachments/assets/b9925eb9-4585-4b5c-a372-f983e336602f" />


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Manual QA for all new/changed functionality

