### PR TITLE
Don't allow fleetctl apply with builtin label type

### DIFF
--- a/changes/28338-apply-builtin-label
+++ b/changes/28338-apply-builtin-label
@@ -1,0 +1,1 @@
+- Improved error when trying to apply builtin labels

--- a/cmd/fleetctl/fleetctl/apply_test.go
+++ b/cmd/fleetctl/fleetctl/apply_test.go
@@ -1817,16 +1817,11 @@ func TestApplyLabels(t *testing.T) {
 	}
 
 	name = writeTmpYml(t, builtinLabelSpec)
-	assert.Equal(t, "[+] applied 1 labels\n", RunAppForTest(t, []string{"apply", "-f", name}))
-	assert.False(t, ds.ApplyLabelSpecsWithAuthorFuncInvoked)
-	assert.True(t, ds.LabelsByNameFuncInvoked)
-
-	// Apply built-in label (with changes)
-	ubuntuLabel.Description = "CHANGED"
-	name = writeTmpYml(t, builtinLabelSpec)
 	_, err = RunAppNoChecks([]string{"apply", "-f", name})
 	require.Error(t, err)
-	require.ErrorContains(t, err, "cannot modify or add built-in label")
+	assert.ErrorContains(t, err, "Cannot import built-in labels. Please remove labels with a label_type of builtin and try again.")
+	assert.False(t, ds.ApplyLabelSpecsWithAuthorFuncInvoked)
+	assert.False(t, ds.LabelsByNameFuncInvoked)
 }
 
 func TestApplyPacks(t *testing.T) {

--- a/server/service/client.go
+++ b/server/service/client.go
@@ -449,6 +449,11 @@ func (c *Client) ApplyGroup(
 		if opts.DryRun {
 			logfn("[!] ignoring labels, dry run mode only supported for 'config' and 'team' specs\n")
 		} else {
+			for _, label := range specs.Labels {
+				if label.LabelType == fleet.LabelTypeBuiltIn {
+					return nil, nil, nil, nil, errors.New("Cannot import built-in labels. Please remove labels with a label_type of builtin and try again.")
+				}
+			}
 			if err := c.ApplyLabels(specs.Labels); err != nil {
 				return nil, nil, nil, nil, fmt.Errorf("applying labels: %w", err)
 			}


### PR DESCRIPTION
#28338

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.
- [x] Added/updated automated tests
- [x] Manual QA for all new/changed functionality
