### PR TITLE
UI: Filter hosts by batch execution status

### DIFF
--- a/changes/29444-filter-hosts-by-batch-execution-status
+++ b/changes/29444-filter-hosts-by-batch-execution-status
@@ -1,0 +1,1 @@
+- Support filtering the hosts page for hosts with any of the 3 batch script execution statuses

--- a/frontend/pages/DashboardPage/cards/ActivityFeed/components/ScriptBatchHostCountCell/ScriptBatchHostCountCell.tsx
+++ b/frontend/pages/DashboardPage/cards/ActivityFeed/components/ScriptBatchHostCountCell/ScriptBatchHostCountCell.tsx
@@ -2,7 +2,6 @@ import React from "react";
 import { Link } from "react-router";
 import Button from "components/buttons/Button";
 import PATHS from "router/paths";
-import { DEFAULT_EMPTY_CELL_VALUE } from "utilities/constants";
 import { buildQueryStringFromParams } from "utilities/url";
 
 const baseClass = "script-batch-host-count-cell";
@@ -28,14 +27,6 @@ const ScriptBatchHostCountCell = ({
     team_id: teamId,
   })}`;
 
-  const renderCount = () => {
-    if (count === 0) {
-      return DEFAULT_EMPTY_CELL_VALUE;
-    }
-
-    return <Link to={hostPath}>{count}</Link>;
-  };
-
   const renderCancelButton = () => {
     if (status !== "pending" || count === 0) {
       return null;
@@ -54,7 +45,7 @@ const ScriptBatchHostCountCell = ({
 
   return (
     <div className={baseClass}>
-      {renderCount()}
+      <Link to={hostPath}>{count}</Link>
       {renderCancelButton()}
     </div>
   );

--- a/frontend/pages/DashboardPage/cards/ActivityFeed/components/ScriptBatchHostCountCell/ScriptBatchHostCountCell.tsx
+++ b/frontend/pages/DashboardPage/cards/ActivityFeed/components/ScriptBatchHostCountCell/ScriptBatchHostCountCell.tsx
@@ -12,6 +12,7 @@ interface IScriptBatchHostCountCellProps {
   status: string;
   count: number;
   onClickCancel: () => void;
+  teamId?: number;
 }
 
 const ScriptBatchHostCountCell = ({
@@ -19,10 +20,12 @@ const ScriptBatchHostCountCell = ({
   status,
   count,
   onClickCancel,
+  teamId,
 }: IScriptBatchHostCountCellProps) => {
   const hostPath = `${PATHS.MANAGE_HOSTS}?${buildQueryStringFromParams({
     script_batch_execution_status: status,
     script_batch_execution_id: batchExecutionId,
+    team_id: teamId,
   })}`;
 
   const renderCount = () => {

--- a/frontend/pages/DashboardPage/cards/ActivityFeed/components/ScriptBatchHostCountCell/ScriptBatchHostCountCell.tsx
+++ b/frontend/pages/DashboardPage/cards/ActivityFeed/components/ScriptBatchHostCountCell/ScriptBatchHostCountCell.tsx
@@ -1,0 +1,60 @@
+import React from "react";
+import { Link } from "react-router";
+import Button from "components/buttons/Button";
+import PATHS from "router/paths";
+import { DEFAULT_EMPTY_CELL_VALUE } from "utilities/constants";
+import { buildQueryStringFromParams } from "utilities/url";
+
+const baseClass = "script-batch-host-count-cell";
+
+interface IScriptBatchHostCountCellProps {
+  batchExecutionId: string;
+  status: string;
+  count: number;
+  onClickCancel: () => void;
+}
+
+const ScriptBatchHostCountCell = ({
+  batchExecutionId,
+  status,
+  count,
+  onClickCancel,
+}: IScriptBatchHostCountCellProps) => {
+  const hostPath = `${PATHS.MANAGE_HOSTS}?${buildQueryStringFromParams({
+    script_batch_execution_status: status,
+    script_batch_execution_id: batchExecutionId,
+  })}`;
+
+  const renderCount = () => {
+    if (count === 0) {
+      return DEFAULT_EMPTY_CELL_VALUE;
+    }
+
+    return <Link to={hostPath}>{count}</Link>;
+  };
+
+  const renderCancelButton = () => {
+    if (status !== "pending" || count === 0) {
+      return null;
+    }
+
+    return (
+      <Button
+        className={`${baseClass}__cancel-button`}
+        onClick={onClickCancel}
+        variant="text-icon"
+      >
+        Cancel
+      </Button>
+    );
+  };
+
+  return (
+    <div className={baseClass}>
+      {renderCount()}
+      {renderCancelButton()}
+    </div>
+  );
+};
+
+export default ScriptBatchHostCountCell;

--- a/frontend/pages/DashboardPage/cards/ActivityFeed/components/ScriptBatchHostCountCell/_styles.scss
+++ b/frontend/pages/DashboardPage/cards/ActivityFeed/components/ScriptBatchHostCountCell/_styles.scss
@@ -1,0 +1,16 @@
+.script-batch-host-count-cell {
+  &__cancel-button {
+    transition: opacity 250ms;
+    opacity: 0;
+  }
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+
+  .children-wrapper {
+    .icon {
+      vertical-align: middle;
+      margin-right: 8px;
+    }
+  }
+}

--- a/frontend/pages/DashboardPage/cards/ActivityFeed/components/ScriptBatchHostCountCell/index.ts
+++ b/frontend/pages/DashboardPage/cards/ActivityFeed/components/ScriptBatchHostCountCell/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./ScriptBatchHostCountCell";

--- a/frontend/pages/DashboardPage/cards/ActivityFeed/components/ScriptBatchStatusTable/ScriptBatchStatusTable.tsx
+++ b/frontend/pages/DashboardPage/cards/ActivityFeed/components/ScriptBatchStatusTable/ScriptBatchStatusTable.tsx
@@ -11,16 +11,18 @@ const baseClass = "script-batch-status-table";
 
 interface IScriptBatchStatusTableProps {
   statusData: IScriptBatchSummaryResponse;
+  batchExecutionId: string;
   onClickCancel: () => void;
 }
 
 const ScriptBatchStatusTable = ({
   statusData,
+  batchExecutionId,
   onClickCancel,
 }: IScriptBatchStatusTableProps) => {
   const columnConfigs = useMemo(() => {
-    return generateTableConfig(onClickCancel);
-  }, [onClickCancel]);
+    return generateTableConfig(batchExecutionId, onClickCancel);
+  }, [batchExecutionId, onClickCancel]);
   const tableData = generateTableData(statusData);
 
   return (

--- a/frontend/pages/DashboardPage/cards/ActivityFeed/components/ScriptBatchStatusTable/ScriptBatchStatusTable.tsx
+++ b/frontend/pages/DashboardPage/cards/ActivityFeed/components/ScriptBatchStatusTable/ScriptBatchStatusTable.tsx
@@ -21,8 +21,12 @@ const ScriptBatchStatusTable = ({
   onClickCancel,
 }: IScriptBatchStatusTableProps) => {
   const columnConfigs = useMemo(() => {
-    return generateTableConfig(batchExecutionId, onClickCancel);
-  }, [batchExecutionId, onClickCancel]);
+    return generateTableConfig(
+      batchExecutionId,
+      onClickCancel,
+      statusData.team_id
+    );
+  }, [batchExecutionId, onClickCancel, statusData.team_id]);
   const tableData = generateTableData(statusData);
 
   return (

--- a/frontend/pages/DashboardPage/cards/ActivityFeed/components/ScriptBatchStatusTable/ScriptBatchStatusTableConfig.tsx
+++ b/frontend/pages/DashboardPage/cards/ActivityFeed/components/ScriptBatchStatusTable/ScriptBatchStatusTableConfig.tsx
@@ -45,7 +45,8 @@ type IHostCellProps = INumberCellProps<IRowData>;
 
 export const generateTableConfig = (
   batchExecutionId: string,
-  onClickCancel: () => void
+  onClickCancel: () => void,
+  teamId?: number
 ): IColumnConfig[] => {
   return [
     {
@@ -74,6 +75,7 @@ export const generateTableConfig = (
             status={cell.row.original.status}
             batchExecutionId={batchExecutionId}
             onClickCancel={onClickCancel}
+            teamId={teamId}
           />
         );
       },

--- a/frontend/pages/DashboardPage/cards/ActivityFeed/components/ScriptBatchStatusTable/ScriptBatchStatusTableConfig.tsx
+++ b/frontend/pages/DashboardPage/cards/ActivityFeed/components/ScriptBatchStatusTable/ScriptBatchStatusTableConfig.tsx
@@ -7,35 +7,7 @@ import {
   IStringCellProps,
 } from "interfaces/datatable_config";
 import { IScriptBatchSummaryResponse } from "services/entities/scripts";
-import Button from "components/buttons/Button";
-
-interface IHostCountCellProps {
-  status: string;
-  count: number;
-  onClickCancel: () => void;
-}
-
-const HostCountCell = ({
-  status,
-  count,
-  onClickCancel,
-}: IHostCountCellProps) => {
-  const baseClass = "script-batch-status-host-count-cell";
-  return (
-    <div className={baseClass}>
-      <div>{count}</div>
-      {status === "pending" && (
-        <Button
-          className={`${baseClass}__cancel-button`}
-          onClick={onClickCancel}
-          variant="text-icon"
-        >
-          <span>Cancel</span>
-        </Button>
-      )}
-    </div>
-  );
-};
+import ScriptBatchHostCountCell from "../ScriptBatchHostCountCell/ScriptBatchHostCountCell";
 
 type IStatus = "ran" | "pending" | "errored";
 
@@ -72,6 +44,7 @@ type IStatusCellProps = IStringCellProps<IRowData>;
 type IHostCellProps = INumberCellProps<IRowData>;
 
 export const generateTableConfig = (
+  batchExecutionId: string,
   onClickCancel: () => void
 ): IColumnConfig[] => {
   return [
@@ -96,9 +69,10 @@ export const generateTableConfig = (
       disableSortBy: true,
       Cell: ({ cell }: IHostCellProps) => {
         return (
-          <HostCountCell
+          <ScriptBatchHostCountCell
             count={cell.value}
             status={cell.row.original.status}
+            batchExecutionId={batchExecutionId}
             onClickCancel={onClickCancel}
           />
         );

--- a/frontend/pages/DashboardPage/cards/ActivityFeed/components/ScriptBatchStatusTable/_styles.scss
+++ b/frontend/pages/DashboardPage/cards/ActivityFeed/components/ScriptBatchStatusTable/_styles.scss
@@ -1,23 +1,7 @@
 .script-batch-status-table {
   tr:hover {
-    .script-batch-status-host-count-cell__cancel-button {
+    .script-batch-host-count-cell__cancel-button {
       opacity: 1;
-    }
-  }
-  .script-batch-status-host-count-cell {
-    &__cancel-button {
-      transition: opacity 250ms;
-      opacity: 0;
-    }
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-
-    .children-wrapper {
-      .icon {
-        vertical-align: middle;
-        margin-right: 8px;
-      }
     }
   }
 }

--- a/frontend/pages/DashboardPage/cards/ActivityFeed/components/ScriptBatchSummaryModal/ScriptBatchSummaryModal.tsx
+++ b/frontend/pages/DashboardPage/cards/ActivityFeed/components/ScriptBatchSummaryModal/ScriptBatchSummaryModal.tsx
@@ -74,6 +74,7 @@ const ScriptBatchSummaryModal = ({
     return (
       <ScriptBatchStatusTable
         statusData={statusData}
+        batchExecutionId={details.batch_execution_id || ""}
         onClickCancel={toggleCancelModal}
       />
     );

--- a/frontend/pages/hosts/ManageHostsPage/HostsPageConfig.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/HostsPageConfig.tsx
@@ -1,6 +1,3 @@
-import React from "react";
-
-import Icon from "components/Icon";
 import { HOSTS_QUERY_PARAMS } from "services/entities/hosts";
 
 export const MANAGE_HOSTS_PAGE_FILTER_KEYS = [
@@ -23,6 +20,8 @@ export const MANAGE_HOSTS_PAGE_FILTER_KEYS = [
   HOSTS_QUERY_PARAMS.OS_SETTINGS,
   HOSTS_QUERY_PARAMS.DISK_ENCRYPTION,
   "bootstrap_package",
+  HOSTS_QUERY_PARAMS.SCRIPT_BATCH_EXECUTION_STATUS,
+  HOSTS_QUERY_PARAMS.SCRIPT_BATCH_EXECUTION_ID,
 ] as const;
 
 /*
@@ -40,6 +39,8 @@ export const MANAGE_HOSTS_PAGE_LABEL_INCOMPATIBLE_QUERY_PARAMS = [
   "macos_settings",
   HOSTS_QUERY_PARAMS.OS_SETTINGS,
   HOSTS_QUERY_PARAMS.DISK_ENCRYPTION,
+  HOSTS_QUERY_PARAMS.SCRIPT_BATCH_EXECUTION_STATUS,
+  HOSTS_QUERY_PARAMS.SCRIPT_BATCH_EXECUTION_ID,
 ] as const;
 
 // TODO: refactor to use this type as the location.query prop of the page

--- a/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
@@ -191,6 +191,12 @@ const ManageHostsPage = ({
       // remove the software status filter when selecting All teams
       [HOSTS_QUERY_PARAMS.SOFTWARE_STATUS]: (newTeamId?: number) =>
         newTeamId === API_ALL_TEAMS_ID,
+      // remove batch script summary results filters on team change
+      [HOSTS_QUERY_PARAMS.SCRIPT_BATCH_EXECUTION_ID]: (newTeamId?: number) =>
+        newTeamId !== currentTeamId,
+      [HOSTS_QUERY_PARAMS.SCRIPT_BATCH_EXECUTION_STATUS]: (
+        newTeamId?: number
+      ) => newTeamId !== currentTeamId,
     },
   });
 
@@ -298,7 +304,7 @@ const ManageHostsPage = ({
     queryParams?.[HOSTS_QUERY_PARAMS.SCRIPT_BATCH_EXECUTION_ID];
   const scriptBatchExecutionStatus =
     queryParams?.[HOSTS_QUERY_PARAMS.SCRIPT_BATCH_EXECUTION_STATUS] ??
-    (scriptBatchExecutionId ? "success" : undefined);
+    (scriptBatchExecutionId ? "ran" : undefined);
 
   // ========= routeParams
   const { active_label: activeLabel, label_id: labelID } = routeParams;

--- a/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
@@ -13,6 +13,10 @@ import { find, isEmpty, isEqual, omit } from "lodash";
 import { format } from "date-fns";
 import FileSaver from "file-saver";
 
+import scriptsAPI, {
+  IScriptBatchSummaryQueryKey,
+  IScriptBatchSummaryResponse,
+} from "services/entities/scripts";
 import enrollSecretsAPI from "services/entities/enroll_secret";
 import usersAPI from "services/entities/users";
 import labelsAPI, { ILabelsResponse } from "services/entities/labels";
@@ -68,6 +72,7 @@ import {
 
 import sortUtils from "utilities/sort";
 import {
+  DEFAULT_USE_QUERY_OPTIONS,
   HOSTS_SEARCH_BOX_PLACEHOLDER,
   HOSTS_SEARCH_BOX_TOOLTIP,
   MAX_SCRIPT_BATCH_TARGETS,
@@ -289,6 +294,11 @@ const ManageHostsPage = ({
     queryParams?.bootstrap_package;
   const configProfileStatus = queryParams?.profile_status;
   const configProfileUUID = queryParams?.profile_uuid;
+  const scriptBatchExecutionId =
+    queryParams?.[HOSTS_QUERY_PARAMS.SCRIPT_BATCH_EXECUTION_ID];
+  const scriptBatchExecutionStatus =
+    queryParams?.[HOSTS_QUERY_PARAMS.SCRIPT_BATCH_EXECUTION_STATUS] ??
+    (scriptBatchExecutionId ? "success" : undefined);
 
   // ========= routeParams
   const { active_label: activeLabel, label_id: labelID } = routeParams;
@@ -324,7 +334,11 @@ const ManageHostsPage = ({
   //   missingHosts ||
   //   osSettingsStatus ||
   //   diskEncryptionStatus ||
-  //   vulnerability
+  //   vulnerability ||
+  // scriptBatchExecutionId ||
+  // scriptBatchExecutionStatus
+  // configProfileStatus ||
+  // configProfileUUID
 
   const runScriptBatchFilterNotSupported = !!(
     // all above, except acceptable filters
@@ -358,7 +372,11 @@ const ManageHostsPage = ({
       missingHosts ||
       osSettingsStatus ||
       diskEncryptionStatus ||
-      vulnerability
+      vulnerability ||
+      scriptBatchExecutionId ||
+      scriptBatchExecutionStatus ||
+      configProfileStatus ||
+      configProfileUUID
     )
   );
 
@@ -440,6 +458,30 @@ const ManageHostsPage = ({
   );
 
   const {
+    data: scriptBatchSummary,
+    isLoading: isLoadingScriptBatchSummary,
+    isError: isErrorScriptBatchSummary,
+  } = useQuery<
+    IScriptBatchSummaryResponse,
+    Error,
+    IScriptBatchSummaryResponse,
+    IScriptBatchSummaryQueryKey[]
+  >(
+    [
+      {
+        scope: "script_batch_summary",
+        batch_execution_id: scriptBatchExecutionId,
+      },
+    ],
+    ({ queryKey: [{ batch_execution_id }] }) =>
+      scriptsAPI.getRunScriptBatchSummary({ batch_execution_id }),
+    {
+      enabled: !!scriptBatchExecutionId && isRouteOk,
+      ...DEFAULT_USE_QUERY_OPTIONS,
+    }
+  );
+
+  const {
     data: configProfile,
     isLoading: isLoadingConfigProfile,
     error: errorConfigProfile,
@@ -448,7 +490,6 @@ const ManageHostsPage = ({
     () => configProfileAPI.getConfigProfile(configProfileUUID),
     {
       enabled: isRouteOk && !!configProfileUUID,
-      // select: (data) => data.policy,
     }
   );
 
@@ -508,6 +549,8 @@ const ManageHostsPage = ({
         macSettingsStatus,
         configProfileStatus,
         configProfileUUID,
+        scriptBatchExecutionStatus,
+        scriptBatchExecutionId,
       },
     ],
     ({ queryKey }) => hostsAPI.loadHosts(queryKey[0]),
@@ -551,6 +594,8 @@ const ManageHostsPage = ({
         macSettingsStatus,
         configProfileStatus,
         configProfileUUID,
+        scriptBatchExecutionStatus,
+        scriptBatchExecutionId,
       },
     ],
     ({ queryKey }) => hostCountAPI.load(queryKey[0]),
@@ -591,7 +636,11 @@ const ManageHostsPage = ({
   };
 
   const hasErrors =
-    !!errorHosts || !!errorHostsCount || !!errorPolicy || !!errorConfigProfile;
+    !!errorHosts ||
+    !!errorHostsCount ||
+    !!errorPolicy ||
+    !!errorConfigProfile ||
+    isErrorScriptBatchSummary;
 
   const toggleDeleteSecretModal = () => {
     // open and closes delete modal
@@ -862,6 +911,21 @@ const ManageHostsPage = ({
     );
   };
 
+  const handleChangeScriptBatchStatusFilter = (newStatus: string) => {
+    router.replace(
+      getNextLocationPath({
+        pathPrefix: PATHS.MANAGE_HOSTS,
+        routeTemplate,
+        routeParams,
+        queryParams: {
+          ...queryParams,
+          [HOSTS_QUERY_PARAMS.SCRIPT_BATCH_EXECUTION_STATUS]: newStatus,
+          page: 0, // resets page index
+        },
+      })
+    );
+  };
+
   const handleRowSelect = (row: IRowProps) => {
     if (row.original.id) {
       const path = PATHS.HOST_DETAILS(row.original.id);
@@ -1002,6 +1066,13 @@ const ManageHostsPage = ({
       } else if (configProfileStatus && configProfileUUID) {
         newQueryParams.profile_status = configProfileStatus;
         newQueryParams.profile_uuid = configProfileUUID;
+      } else if (scriptBatchExecutionStatus && scriptBatchExecutionId) {
+        newQueryParams[
+          HOSTS_QUERY_PARAMS.SCRIPT_BATCH_EXECUTION_STATUS
+        ] = scriptBatchExecutionStatus;
+        newQueryParams[
+          HOSTS_QUERY_PARAMS.SCRIPT_BATCH_EXECUTION_ID
+        ] = scriptBatchExecutionId;
       }
 
       router.replace(
@@ -1041,6 +1112,8 @@ const ManageHostsPage = ({
       bootstrapPackageStatus,
       configProfileStatus,
       configProfileUUID,
+      scriptBatchExecutionStatus,
+      scriptBatchExecutionId,
       router,
       routeTemplate,
       routeParams,
@@ -1498,6 +1571,8 @@ const ManageHostsPage = ({
       visibleColumns,
       configProfileUUID,
       configProfileStatus,
+      scriptBatchExecutionStatus,
+      scriptBatchExecutionId,
     };
 
     options = {
@@ -1734,7 +1809,8 @@ const ManageHostsPage = ({
           isLoadingHosts ||
           isLoadingHostsCount ||
           isLoadingPolicy ||
-          isLoadingConfigProfile
+          isLoadingConfigProfile ||
+          isLoadingScriptBatchSummary
         }
         manualSortBy
         defaultSortHeader={(sortBy[0] && sortBy[0].key) || DEFAULT_SORT_HEADER}
@@ -1874,6 +1950,10 @@ const ManageHostsPage = ({
               configProfileStatus,
               configProfileUUID,
               configProfile,
+              scriptBatchExecutionStatus,
+              scriptBatchExecutionId,
+              scriptBatchRanAt: scriptBatchSummary?.created_at || null,
+              scriptBatchScriptName: scriptBatchSummary?.script_name || null,
             }}
             selectedLabel={selectedLabel}
             isOnlyObserver={isOnlyObserver}
@@ -1892,6 +1972,9 @@ const ManageHostsPage = ({
               handleSoftwareInstallStatusChange
             }
             onChangeConfigProfileStatusFilter={handleConfigProfileStatusChange}
+            onChangeScriptBatchStatusFilter={
+              handleChangeScriptBatchStatusFilter
+            }
             onClickEditLabel={onEditLabelClick}
             onClickDeleteLabel={toggleDeleteLabelModal}
           />

--- a/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
@@ -16,6 +16,7 @@ import FileSaver from "file-saver";
 import scriptsAPI, {
   IScriptBatchSummaryQueryKey,
   IScriptBatchSummaryResponse,
+  ScriptBatchExecutionStatus,
 } from "services/entities/scripts";
 import enrollSecretsAPI from "services/entities/enroll_secret";
 import usersAPI from "services/entities/users";
@@ -302,7 +303,7 @@ const ManageHostsPage = ({
   const configProfileUUID = queryParams?.profile_uuid;
   const scriptBatchExecutionId =
     queryParams?.[HOSTS_QUERY_PARAMS.SCRIPT_BATCH_EXECUTION_ID];
-  const scriptBatchExecutionStatus =
+  const scriptBatchExecutionStatus: ScriptBatchExecutionStatus =
     queryParams?.[HOSTS_QUERY_PARAMS.SCRIPT_BATCH_EXECUTION_STATUS] ??
     (scriptBatchExecutionId ? "ran" : undefined);
 
@@ -917,7 +918,9 @@ const ManageHostsPage = ({
     );
   };
 
-  const handleChangeScriptBatchStatusFilter = (newStatus: string) => {
+  const handleChangeScriptBatchStatusFilter = (
+    newStatus: ScriptBatchExecutionStatus
+  ) => {
     router.replace(
       getNextLocationPath({
         pathPrefix: PATHS.MANAGE_HOSTS,

--- a/frontend/pages/hosts/ManageHostsPage/components/HostsFilterBlock/HostsFilterBlock.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/components/HostsFilterBlock/HostsFilterBlock.tsx
@@ -81,6 +81,10 @@ interface IHostsFilterBlockProps {
     configProfileStatus?: string;
     configProfileUUID?: string;
     configProfile?: IMdmProfile;
+    scriptBatchExecutionStatus?: string;
+    scriptBatchExecutionId?: string;
+    scriptBatchRanAt: string | null;
+    scriptBatchScriptName: string | null;
   };
   selectedLabel?: ILabel;
   isOnlyObserver?: boolean;
@@ -99,6 +103,7 @@ interface IHostsFilterBlockProps {
     newStatus: SoftwareAggregateStatus
   ) => void;
   onChangeConfigProfileStatusFilter: (newStatus: string) => void;
+  onChangeScriptBatchStatusFilter: (newStatus: string) => void;
   onClickEditLabel: (evt: React.MouseEvent<HTMLButtonElement>) => void;
   onClickDeleteLabel: () => void;
 }
@@ -135,6 +140,10 @@ const HostsFilterBlock = ({
     configProfileStatus,
     configProfileUUID,
     configProfile,
+    scriptBatchExecutionStatus,
+    scriptBatchExecutionId,
+    scriptBatchRanAt,
+    scriptBatchScriptName,
   },
   selectedLabel,
   isOnlyObserver,
@@ -147,6 +156,7 @@ const HostsFilterBlock = ({
   onChangeMacSettingsFilter,
   onChangeSoftwareInstallStatusFilter,
   onChangeConfigProfileStatusFilter,
+  onChangeScriptBatchStatusFilter,
   onClickEditLabel,
   onClickDeleteLabel,
 }: IHostsFilterBlockProps) => {
@@ -543,6 +553,38 @@ const HostsFilterBlock = ({
     );
   };
 
+  const renderScriptBatchExecutionBlock = () => {
+    const OPTIONS = [
+      { value: "success", label: "Ran" },
+      { value: "errored", label: "Error" },
+      { value: "pending", label: "Pending" },
+    ];
+    return (
+      <>
+        <Dropdown
+          value={scriptBatchExecutionStatus}
+          className={`${baseClass}__script-batch-status-dropdown`}
+          options={OPTIONS}
+          searchable={false}
+          onChange={onChangeScriptBatchStatusFilter}
+          iconName="filter-alt"
+        />
+        {scriptBatchScriptName && (
+          <FilterPill
+            label={scriptBatchScriptName}
+            onClear={() =>
+              handleClearFilter([
+                HOSTS_QUERY_PARAMS.SCRIPT_BATCH_EXECUTION_ID,
+                HOSTS_QUERY_PARAMS.SCRIPT_BATCH_EXECUTION_STATUS,
+              ])
+            }
+            tooltipDescription={scriptBatchRanAt}
+          />
+        )}
+      </>
+    );
+  };
+
   const showSelectedLabel = selectedLabel && selectedLabel.type !== "all";
 
   if (
@@ -563,7 +605,8 @@ const HostsFilterBlock = ({
     diskEncryptionStatus ||
     bootstrapPackageStatus ||
     vulnerability ||
-    (configProfileStatus && configProfileUUID && configProfile)
+    (configProfileStatus && configProfileUUID && configProfile) ||
+    (scriptBatchExecutionStatus && scriptBatchExecutionId)
   ) {
     const renderFilterPill = () => {
       switch (true) {
@@ -618,6 +661,8 @@ const HostsFilterBlock = ({
           return renderBootstrapPackageStatusBlock();
         case !!configProfileStatus && !!configProfileUUID && !!configProfile:
           return renderConfigProfileStatusBlock();
+        case !!scriptBatchExecutionStatus && !!scriptBatchExecutionId:
+          return renderScriptBatchExecutionBlock();
         default:
           return null;
       }

--- a/frontend/pages/hosts/ManageHostsPage/components/HostsFilterBlock/HostsFilterBlock.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/components/HostsFilterBlock/HostsFilterBlock.tsx
@@ -23,6 +23,7 @@ import {
   HOSTS_QUERY_PARAMS,
   MacSettingsStatusQueryParam,
 } from "services/entities/hosts";
+import { ScriptBatchExecutionStatus } from "services/entities/scripts";
 
 import {
   PLATFORM_LABEL_DISPLAY_NAMES,
@@ -81,7 +82,7 @@ interface IHostsFilterBlockProps {
     configProfileStatus?: string;
     configProfileUUID?: string;
     configProfile?: IMdmProfile;
-    scriptBatchExecutionStatus?: string;
+    scriptBatchExecutionStatus?: ScriptBatchExecutionStatus;
     scriptBatchExecutionId?: string;
     scriptBatchRanAt: string | null;
     scriptBatchScriptName: string | null;
@@ -103,7 +104,9 @@ interface IHostsFilterBlockProps {
     newStatus: SoftwareAggregateStatus
   ) => void;
   onChangeConfigProfileStatusFilter: (newStatus: string) => void;
-  onChangeScriptBatchStatusFilter: (newStatus: string) => void;
+  onChangeScriptBatchStatusFilter: (
+    newStatus: ScriptBatchExecutionStatus
+  ) => void;
   onClickEditLabel: (evt: React.MouseEvent<HTMLButtonElement>) => void;
   onClickDeleteLabel: () => void;
 }

--- a/frontend/pages/hosts/ManageHostsPage/components/HostsFilterBlock/HostsFilterBlock.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/components/HostsFilterBlock/HostsFilterBlock.tsx
@@ -1,6 +1,8 @@
 import React, { useContext } from "react";
 import { invert } from "lodash";
 
+import { dateAgo } from "utilities/date_format";
+
 import { AppContext } from "context/app";
 import { ILabel } from "interfaces/label";
 import {
@@ -574,7 +576,9 @@ const HostsFilterBlock = ({
                 HOSTS_QUERY_PARAMS.SCRIPT_BATCH_EXECUTION_STATUS,
               ])
             }
-            tooltipDescription={scriptBatchRanAt}
+            tooltipDescription={
+              scriptBatchRanAt ? dateAgo(scriptBatchRanAt) : null
+            }
           />
         )}
       </>

--- a/frontend/pages/hosts/ManageHostsPage/components/HostsFilterBlock/HostsFilterBlock.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/components/HostsFilterBlock/HostsFilterBlock.tsx
@@ -555,7 +555,7 @@ const HostsFilterBlock = ({
 
   const renderScriptBatchExecutionBlock = () => {
     const OPTIONS = [
-      { value: "success", label: "Ran" },
+      { value: "ran", label: "Ran" },
       { value: "errored", label: "Error" },
       { value: "pending", label: "Pending" },
     ];

--- a/frontend/services/entities/host_count.ts
+++ b/frontend/services/entities/host_count.ts
@@ -56,6 +56,8 @@ export interface IHostCountLoadOptions {
   bootstrapPackageStatus?: BootstrapPackageStatus;
   configProfileStatus?: string;
   configProfileUUID?: string;
+  scriptBatchExecutionStatus?: string;
+  scriptBatchExecutionId?: string;
 }
 
 export default {
@@ -87,6 +89,8 @@ export default {
     const bootstrapPackageStatus = options?.bootstrapPackageStatus;
     const configProfileStatus = options?.configProfileStatus;
     const configProfileUUID = options?.configProfileUUID;
+    const scriptBatchExecutionStatus = options?.scriptBatchExecutionStatus;
+    const scriptBatchExecutionId = options?.scriptBatchExecutionId;
 
     const queryParams = {
       query: globalFilter,
@@ -119,6 +123,8 @@ export default {
         bootstrapPackageStatus,
         configProfileStatus,
         configProfileUUID,
+        scriptBatchExecutionStatus,
+        scriptBatchExecutionId,
       }),
       label_id: label,
       status,

--- a/frontend/services/entities/hosts.ts
+++ b/frontend/services/entities/hosts.ts
@@ -53,6 +53,8 @@ export const HOSTS_QUERY_PARAMS = {
   OS_SETTINGS: "os_settings",
   DISK_ENCRYPTION: "os_settings_disk_encryption",
   SOFTWARE_STATUS: "software_status",
+  SCRIPT_BATCH_EXECUTION_STATUS: "script_batch_execution_status",
+  SCRIPT_BATCH_EXECUTION_ID: "script_batch_execution_id",
 } as const;
 
 export interface ILoadHostsQueryKey extends ILoadHostsOptions {
@@ -92,6 +94,8 @@ export interface ILoadHostsOptions {
   bootstrapPackageStatus?: BootstrapPackageStatus;
   configProfileStatus?: string;
   configProfileUUID?: string;
+  scriptBatchExecutionStatus?: string;
+  scriptBatchExecutionId?: string;
 }
 
 export interface IExportHostsOptions {
@@ -126,6 +130,8 @@ export interface IExportHostsOptions {
   diskEncryptionStatus?: DiskEncryptionStatus;
   configProfileUUID?: string;
   configProfileStatus?: string;
+  scriptBatchExecutionStatus?: string;
+  scriptBatchExecutionId?: string;
 }
 
 export interface IActionByFilter {
@@ -152,6 +158,8 @@ export interface IActionByFilter {
   osSettings?: MdmProfileStatus;
   diskEncryptionStatus?: DiskEncryptionStatus;
   vulnerability?: string;
+  scriptBatchExecutionStatus?: string;
+  scriptBatchExecutionId?: string;
 }
 
 export interface IGetHostSoftwareResponse {
@@ -341,6 +349,8 @@ export default {
     const vulnerability = options?.vulnerability;
     const configProfileUUID = options?.configProfileUUID;
     const configProfileStatus = options?.configProfileStatus;
+    const scriptBatchExecutionStatus = options?.scriptBatchExecutionStatus;
+    const scriptBatchExecutionId = options?.scriptBatchExecutionId;
 
     if (!sortBy.length) {
       throw Error("sortBy is a required field.");
@@ -378,6 +388,8 @@ export default {
         vulnerability,
         configProfileUUID,
         configProfileStatus,
+        scriptBatchExecutionStatus,
+        scriptBatchExecutionId,
       }),
       status,
       label_id: label,
@@ -421,6 +433,8 @@ export default {
     bootstrapPackageStatus,
     configProfileStatus,
     configProfileUUID,
+    scriptBatchExecutionStatus,
+    scriptBatchExecutionId,
   }: ILoadHostsOptions): Promise<ILoadHostsResponse> => {
     const label = getLabel(selectedLabels);
     const sortParams = getSortParams(sortBy);
@@ -461,6 +475,8 @@ export default {
         bootstrapPackageStatus,
         configProfileStatus,
         configProfileUUID,
+        scriptBatchExecutionStatus,
+        scriptBatchExecutionId,
       }),
     };
 

--- a/frontend/services/entities/hosts.ts
+++ b/frontend/services/entities/hosts.ts
@@ -26,6 +26,8 @@ import { PlatformValueOptions, PolicyResponse } from "utilities/constants";
 import { IHostCertificate } from "interfaces/certificates";
 import { IListOptions } from "interfaces/list_options";
 
+import { ScriptBatchExecutionStatus } from "./scripts";
+
 export interface ISortOption {
   key: string;
   direction: string;
@@ -94,7 +96,7 @@ export interface ILoadHostsOptions {
   bootstrapPackageStatus?: BootstrapPackageStatus;
   configProfileStatus?: string;
   configProfileUUID?: string;
-  scriptBatchExecutionStatus?: string;
+  scriptBatchExecutionStatus?: ScriptBatchExecutionStatus;
   scriptBatchExecutionId?: string;
 }
 
@@ -130,7 +132,7 @@ export interface IExportHostsOptions {
   diskEncryptionStatus?: DiskEncryptionStatus;
   configProfileUUID?: string;
   configProfileStatus?: string;
-  scriptBatchExecutionStatus?: string;
+  scriptBatchExecutionStatus?: ScriptBatchExecutionStatus;
   scriptBatchExecutionId?: string;
 }
 
@@ -158,7 +160,7 @@ export interface IActionByFilter {
   osSettings?: MdmProfileStatus;
   diskEncryptionStatus?: DiskEncryptionStatus;
   vulnerability?: string;
-  scriptBatchExecutionStatus?: string;
+  scriptBatchExecutionStatus?: ScriptBatchExecutionStatus;
   scriptBatchExecutionId?: string;
 }
 

--- a/frontend/services/entities/scripts.ts
+++ b/frontend/services/entities/scripts.ts
@@ -220,5 +220,11 @@ export default {
       "GET",
       `${endpoints.SCRIPT_RUN_BATCH_SUMMARY(batch_execution_id)}`
     );
+    // return sendRequest(
+    //   "GET",
+    //   `${endpoints.SCRIPT_RUN_BATCH_SUMMARY(batch_execution_id)}`
+    // ).then((r) => {
+    //   return { ...r, ran: 1, pending: 1, errored: 1 };
+    // });
   },
 };

--- a/frontend/services/entities/scripts.ts
+++ b/frontend/services/entities/scripts.ts
@@ -121,11 +121,15 @@ export interface IScriptBatchSummaryQueryKey extends IScriptBatchSummaryParams {
   scope: "script_batch_summary";
 }
 
-// 200 successful response
-export interface IScriptBatchSummaryResponse {
+export interface IScriptBatchExecutionStatuses {
   ran: number;
   pending: number;
   errored: number;
+}
+export type ScriptBatchExecutionStatus = keyof IScriptBatchExecutionStatuses;
+// 200 successful response
+export interface IScriptBatchSummaryResponse
+  extends IScriptBatchExecutionStatuses {
   team_id: number;
   script_name: string;
   created_at: string;

--- a/frontend/services/entities/scripts.ts
+++ b/frontend/services/entities/scripts.ts
@@ -127,11 +127,12 @@ export interface IScriptBatchSummaryResponse {
   pending: number;
   errored: number;
   team_id: number;
+  script_name: string;
+  created_at: string;
   // below fields not yet used by the UI
   canceled: number;
   targeted: number;
   script_id: number;
-  script_name: string;
 }
 export default {
   getHostScripts({ host_id, page, per_page }: IHostScriptsRequestParams) {

--- a/frontend/services/entities/scripts.ts
+++ b/frontend/services/entities/scripts.ts
@@ -220,11 +220,5 @@ export default {
       "GET",
       `${endpoints.SCRIPT_RUN_BATCH_SUMMARY(batch_execution_id)}`
     );
-    // return sendRequest(
-    //   "GET",
-    //   `${endpoints.SCRIPT_RUN_BATCH_SUMMARY(batch_execution_id)}`
-    // ).then((r) => {
-    //   return { ...r, ran: 1, pending: 1, errored: 1 };
-    // });
   },
 };

--- a/frontend/utilities/url/index.ts
+++ b/frontend/utilities/url/index.ts
@@ -48,6 +48,8 @@ interface IMutuallyExclusiveHostParams {
   bootstrapPackageStatus?: BootstrapPackageStatus;
   configProfileStatus?: string;
   configProfileUUID?: string;
+  scriptBatchExecutionStatus?: string;
+  scriptBatchExecutionId?: string;
 }
 
 export const parseQueryValueToNumberOrUndefined = (
@@ -220,6 +222,8 @@ export const reconcileMutuallyExclusiveHostParams = ({
   bootstrapPackageStatus,
   configProfileStatus,
   configProfileUUID,
+  scriptBatchExecutionStatus,
+  scriptBatchExecutionId,
 }: IMutuallyExclusiveHostParams): Record<string, unknown> => {
   if (label) {
     // backend api now allows (label + low disk space) OR (label + mdm id) OR
@@ -278,6 +282,11 @@ export const reconcileMutuallyExclusiveHostParams = ({
       return {
         profile_status: configProfileStatus,
         profile_uuid: configProfileUUID,
+      };
+    case !!scriptBatchExecutionId:
+      return {
+        [HOSTS_QUERY_PARAMS.SCRIPT_BATCH_EXECUTION_STATUS]: scriptBatchExecutionStatus,
+        [HOSTS_QUERY_PARAMS.SCRIPT_BATCH_EXECUTION_ID]: scriptBatchExecutionId,
       };
     default:
       return {};


### PR DESCRIPTION
## For #29444

- Update script batch summary modal status rows to link to the hosts page filtered by the appropriate batch script run and status
- Add above filtering capabilities to the hosts page

<img width="1912" alt="Screenshot 2025-05-30 at 12 39 54 PM" src="https://github.com/user-attachments/assets/4299ecaa-10bd-49f4-b0f8-cd0e71108e04" />

<img width="1912" alt="Screenshot 2025-05-30 at 12 40 22 PM" src="https://github.com/user-attachments/assets/8252560e-59a2-42a9-bd0c-e5ca05c53390" />


- [x] Changes file added for user-visible changes in `changes/`
- [x] Manual QA for all new/changed functionality