### PR TITLE
add docs for batch script execution

### DIFF
--- a/articles/scripts.md
+++ b/articles/scripts.md
@@ -49,7 +49,7 @@ Fleet UI (multiple hosts):
 
 Scripts run from the Fleet UI will run the next time your host checks in with Fleet. You can view the status of the script execution as well as the output in the target host's activity feed.
 
-When executing a script on more than one host, you can view the status of the batch of hosts by clicking on the related item in the global feed.
+When executing a script on more than one host, you can view the status of the batch of hosts by clicking on the related item in the global activity feed.
 
 Fleet API: See our [REST API documentation](https://fleetdm.com/docs/rest-api/rest-api#run-script)
 

--- a/articles/scripts.md
+++ b/articles/scripts.md
@@ -25,7 +25,7 @@ Learn more about generating a fleetd agent and deploying it [here](https://fleet
 
 You can run a script in the Fleet UI, with Fleet API, or with the fleetctl command-line interface (CLI).
 
-Fleet UI:
+Fleet UI (single host):
 
 1. In Fleet, head to the **Controls > Scripts** tab and upload your script.
 
@@ -35,7 +35,21 @@ Fleet UI:
 
 4. In the **Run Script** menu, select the **Actions** dropdown for the script you'd like to execute and choose the **Run** option.
 
+Fleet UI (multiple hosts):
+
+1. In Fleet, head to the **Controls > Scripts** tab and upload your script.
+
+2. Head to the **Hosts** page. If you're on Fleet Premium, select a team (or "no team").
+
+3. Click the checkbox next to one or more hosts you want to run the script on.
+
+4. Click "Run script" in the table header.
+
+5. In the popup modal, find the script you'd like to run, move the mouse pointer to that item in the list and click the "Run script" button that appears.
+
 Scripts run from the Fleet UI will run the next time your host checks in with Fleet. You can view the status of the script execution as well as the output in the target host's activity feed.
+
+When executing a script on more than one host, you can view the status of the batch of hosts by clicking on the related item in the global feed.
 
 Fleet API: See our [REST API documentation](https://fleetdm.com/docs/rest-api/rest-api#run-script)
 


### PR DESCRIPTION
Updates the Scripts guide to include info about running a script on multiple hosts at once.