### PR TITLE
UI: Fix tooltip logic of `FilterPill`

### DIFF
--- a/frontend/pages/hosts/ManageHostsPage/components/FilterPill/FilterPill.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/components/FilterPill/FilterPill.tsx
@@ -32,7 +32,11 @@ const FilterPill = ({
   });
 
   const pillText = useRef(null);
-  const isTuncated = useCheckTruncatedElement(pillText);
+  const isTruncated = useCheckTruncatedElement(pillText);
+
+  // if tooltipDescription not provided, behave like TooltipTruncatedText
+  const tooltipContent =
+    tooltipDescription ?? (isTruncated ? label : undefined);
 
   return (
     <div
@@ -45,7 +49,7 @@ const FilterPill = ({
           <div className={labelClasses}>
             {icon && <Icon name={icon} />}
             <span
-              data-tip={tooltipDescription}
+              data-tip={tooltipContent}
               data-for={`filter-pill-tooltip-${label}`}
               className={`${baseClass}__tooltip-text`}
               ref={pillText}
@@ -62,7 +66,7 @@ const FilterPill = ({
             </Button>
           </div>
         </span>
-        {tooltipDescription && (
+        {tooltipContent && (
           <ReactTooltip
             role="tooltip"
             place="top"
@@ -70,9 +74,8 @@ const FilterPill = ({
             backgroundColor={COLORS["tooltip-bg"]}
             id={`filter-pill-tooltip-${label}`}
             data-html
-            disable={!isTuncated}
           >
-            <span>{tooltipDescription}</span>
+            <span>{tooltipContent}</span>
           </ReactTooltip>
         )}
       </>

--- a/frontend/pages/hosts/ManageHostsPage/components/HostsFilterBlock/HostsFilterBlock.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/components/HostsFilterBlock/HostsFilterBlock.tsx
@@ -531,13 +531,6 @@ const HostsFilterBlock = ({
         <FilterPill
           label={`OS settings: ${configProfile?.name}`}
           onClear={() => handleClearFilter(["profile_status", "profile_uuid"])}
-          tooltipDescription={
-            <>
-              OS settings:
-              <br />
-              {configProfile?.name}
-            </>
-          }
         />
       </>
     );


### PR DESCRIPTION
## Closes #29613 

- Previous changes intended to add `TooltipTruncatedText`-like functionality accidentally broke existing functionality when pill content was not truncated
- This restores the previous functionality when explicit tooltip content is passed in, and adds fall back behavior to act like `TooltipTruncatedText`, where when the element content is truncated, its full content is rendered as a tooltip on hover.

### Tooltip content is explicitly passed in and rendered in the tooltip. Notice the tooltip content differs from the underlying element content:
<img width="675" alt="Screenshot 2025-05-30 at 11 21 49 AM" src="https://github.com/user-attachments/assets/b0f8e72e-9925-4844-80ca-672b6efeb443" />

### No tooltip content passed in, falls back to `TooltipTruncatedText`-like behavior. Notice the truncated element content is the prefix of the full content rendered in the tooltip:
<img width="675" alt="Screenshot 2025-05-30 at 11 21 25 AM" src="https://github.com/user-attachments/assets/e5fe7d74-3674-478c-8e33-7e84006e7390" />

- [x] Manual QA for all new/changed functionality