### PR TITLE
When MDM SSO rate limit is supplied, split rate limit bucket

### DIFF
--- a/changes/sso-ratelimit
+++ b/changes/sso-ratelimit
@@ -1,1 +1,1 @@
-* Added `FLEET_MDM_SSO_RATE_LIMIT_PER_MINUTE` environment variable to allow increasing MDM SSO endpoint rate limit from 10 per minute.
+* Added `FLEET_MDM_SSO_RATE_LIMIT_PER_MINUTE` environment variable to allow increasing MDM SSO endpoint rate limit from 10 per minute. When supplied, this parameter also splits MDM SSO into its own rate limit bucket (default is shared with login endpoints).

--- a/docs/Contributing/reference/configuration-for-contributors.md
+++ b/docs/Contributing/reference/configuration-for-contributors.md
@@ -154,6 +154,19 @@ This is the content of the PEM-encoded private key for the Apple Business Manage
       -----END RSA PRIVATE KEY-----
   ```
 
+### mdm.sso_rate_limit_per_minute
+
+The number of requests per minute allowed to [Initiate SSO during DEP enrollment](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/reference/api-for-contributors.md#initiate-sso-during-dep-enrollment) and
+[Complete SSO during DEP enrollment](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/reference/api-for-contributors.md#complete-sso-during-dep-enrollment) endpoints, combined.
+
+- Default value: 10, shared with rate limit for [Log in endpoint](https://fleetdm.com/docs/rest-api/rest-api#log-in); if overridden, a separate rate limit bucket is used for MDM SSO
+- Environment variable: `FLEET_MDM_SSO_RATE_LIMIT_PER_MINUTE`
+- Config file format:
+  ```yaml
+  mdm:
+    sso_rate_limit_per_minute: 200
+  ```
+
 ### license.enforce_host_limit
 
 Whether Fleet should enforce the host limit of the license, if true, attempting to enroll new hosts when the limit is reached will fail.

--- a/docs/Contributing/reference/configuration-for-contributors.md
+++ b/docs/Contributing/reference/configuration-for-contributors.md
@@ -159,6 +159,8 @@ This is the content of the PEM-encoded private key for the Apple Business Manage
 The number of requests per minute allowed to [Initiate SSO during DEP enrollment](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/reference/api-for-contributors.md#initiate-sso-during-dep-enrollment) and
 [Complete SSO during DEP enrollment](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/reference/api-for-contributors.md#complete-sso-during-dep-enrollment) endpoints, combined.
 
+The best practice is to set this to 3x the number of new employees (end users) that onboard at the same time (ex. `300` if 100 end users setup their Macs simultaneously).
+
 - Default value: 10, shared with rate limit for [Log in endpoint](https://fleetdm.com/docs/rest-api/rest-api#log-in); if overridden, a separate rate limit bucket is used for MDM SSO
 - Environment variable: `FLEET_MDM_SSO_RATE_LIMIT_PER_MINUTE`
 - Config file format:

--- a/docs/Contributing/reference/configuration-for-contributors.md
+++ b/docs/Contributing/reference/configuration-for-contributors.md
@@ -161,7 +161,7 @@ The number of requests per minute allowed to [Initiate SSO during DEP enrollment
 
 The best practice is to set this to 3x the number of new employees (end users) that onboard at the same time (ex. `300` if 100 end users setup their Macs simultaneously).
 
-- Default value: 10, shared with rate limit for [Log in endpoint](https://fleetdm.com/docs/rest-api/rest-api#log-in); if overridden, a separate rate limit bucket is used for MDM SSO
+- Default value: 10 (same rate limit for [Log in endpoint](https://fleetdm.com/docs/rest-api/rest-api#log-in))
 - Environment variable: `FLEET_MDM_SSO_RATE_LIMIT_PER_MINUTE`
 - Config file format:
   ```yaml

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -1407,7 +1407,7 @@ func (man Manager) addConfigs() {
 	man.addConfigString("mdm.windows_wstep_identity_key", "", "Microsoft WSTEP PEM-encoded private key path")
 	man.addConfigString("mdm.windows_wstep_identity_cert_bytes", "", "Microsoft WSTEP PEM-encoded certificate bytes")
 	man.addConfigString("mdm.windows_wstep_identity_key_bytes", "", "Microsoft WSTEP PEM-encoded private key bytes")
-	man.addConfigInt("mdm.sso_rate_limit_per_minute", 10, "Number of allowed requests per minute to MDM SSO endpoints")
+	man.addConfigInt("mdm.sso_rate_limit_per_minute", 0, "Number of allowed requests per minute to MDM SSO endpoints (default is sharing login rate limit bucket)")
 
 	// Calendar integration
 	man.addConfigDuration(

--- a/server/service/handler.go
+++ b/server/service/handler.go
@@ -221,7 +221,6 @@ func addMetrics(r *mux.Router) {
 const (
 	desktopRateLimitMaxBurst        = 100 // Max burst used for device request rate limiting.
 	forgotPasswordRateLimitMaxBurst = 9   // Max burst used for rate limiting on the the forgot_password endpoint.
-	DefaultLoginRateLimit           = 10  // Normal per-minute rate limit for logins (and MDM SSO if not overridden)
 )
 
 func attachFleetAPIRoutes(r *mux.Router, svc fleet.Service, config config.FleetConfig,
@@ -988,16 +987,19 @@ func attachFleetAPIRoutes(r *mux.Router, svc fleet.Service, config config.FleetC
 		WithCustomMiddleware(limiter.Limit("forgot_password", quota)).
 		POST("/api/_version_/fleet/forgot_password", forgotPasswordEndpoint, forgotPasswordRequest{})
 
-	loginRateLimit := throttled.PerMin(DefaultLoginRateLimit)
+	// By default, MDM SSO shares the login rate limit bucket; if MDM SSO limit is overridden, MDM SSO gets its
+	// own rate limit bucket.
+	loginRateLimit := throttled.PerMin(10)
 	if extra.loginRateLimit != nil {
 		loginRateLimit = *extra.loginRateLimit
 	}
-	mdmSsoRateLimit := loginRateLimit
+	loginLimiter := limiter.Limit("login", throttled.RateQuota{MaxRate: loginRateLimit, MaxBurst: 9})
+	mdmSsoLimiter := loginLimiter
 	if extra.mdmSsoRateLimit != nil {
-		mdmSsoRateLimit = *extra.mdmSsoRateLimit
+		mdmSsoLimiter = limiter.Limit("mdm_sso", throttled.RateQuota{MaxRate: *extra.mdmSsoRateLimit, MaxBurst: 9})
 	}
 
-	ne.WithCustomMiddleware(limiter.Limit("login", throttled.RateQuota{MaxRate: loginRateLimit, MaxBurst: 9})).
+	ne.WithCustomMiddleware(loginLimiter).
 		POST("/api/_version_/fleet/login", loginEndpoint, contract.LoginRequest{})
 	ne.WithCustomMiddleware(limiter.Limit("mfa", throttled.RateQuota{MaxRate: loginRateLimit, MaxBurst: 9})).
 		POST("/api/_version_/fleet/sessions", sessionCreateEndpoint, sessionCreateRequest{})
@@ -1009,10 +1011,9 @@ func attachFleetAPIRoutes(r *mux.Router, svc fleet.Service, config config.FleetC
 	// This is a callback endpoint for calendar integration -- it is called to notify an event change in a user calendar
 	ne.POST("/api/_version_/fleet/calendar/webhook/{event_uuid}", calendarWebhookEndpoint, calendarWebhookRequest{})
 
-	neAppleMDM.WithCustomMiddleware(limiter.Limit("login", throttled.RateQuota{MaxRate: mdmSsoRateLimit, MaxBurst: 9})).
+	neAppleMDM.WithCustomMiddleware(mdmSsoLimiter).
 		POST("/api/_version_/fleet/mdm/sso", initiateMDMAppleSSOEndpoint, initiateMDMAppleSSORequest{})
-
-	neAppleMDM.WithCustomMiddleware(limiter.Limit("login", throttled.RateQuota{MaxRate: mdmSsoRateLimit, MaxBurst: 9})).
+	neAppleMDM.WithCustomMiddleware(mdmSsoLimiter).
 		POST("/api/_version_/fleet/mdm/sso/callback", callbackMDMAppleSSOEndpoint, callbackMDMAppleSSORequest{})
 }
 


### PR DESCRIPTION
Also adds some more rate limiter tests to make sure separate rate limit buckets interact as expected.

Fixes #29614.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.
- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- For new Fleet configuration settings
  - [x] Verified that the setting can be managed via GitOps, or confirmed that the setting is explicitly being excluded from GitOps. (excluded; env var or YAML)
- [x] Added/updated automated tests
- [ ] Manual QA for all new/changed functionality