### PR TITLE
Set empty TLS secrets by default instead of referencing non-existent ones from the config

### DIFF
--- a/charts/fleet/values.yaml
+++ b/charts/fleet/values.yaml
@@ -55,10 +55,10 @@ ingress:
       paths:
         - path: /
           pathType: ImplementationSpecific
-  tls:
-    - secretName: chart-example-tls
-      hosts:
-        - chart-example.local
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
 
 ## Section: Fleet
 # All of the settings relating to configuring the Fleet server

--- a/charts/tuf/values.yaml
+++ b/charts/tuf/values.yaml
@@ -56,11 +56,10 @@ ingress:
       paths:
         - path: /
           pathType: ImplementationSpecific
-  #tls: []
-  tls:
-    - secretName: chart-example-tls
-      hosts:
-        - chart-example.local
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
 
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious


### PR DESCRIPTION
This change fixes nginx errors regarding non-existent config:

e.g.:
```
W0602 09:49:37.725821       7 controller.go:1720] Error getting SSL certificate "fleetdm/chart-example-tls": local SSL certificate fleetdm/chart-example-tls was not found
```

```
➜  ~ k describe ingress fleetdm -n fleetdm
Name:             fleetdm
....
Ingress Class:    nginx
Default backend:  <default>
TLS:
  chart-example-tls terminates chart-example.local
Rules:
```

This approach is simpler than requiring everyone to set tls: [] in their values file.