### PR TITLE
Fix Microsoft UTF16 endianness.

### DIFF
--- a/changes/28488-ms-utf16-endianness
+++ b/changes/28488-ms-utf16-endianness
@@ -1,0 +1,1 @@
+Fixed issue where NDES SCEP admin page was parsed using wrong UTF16 endianness.

--- a/ee/server/service/scep_proxy.go
+++ b/ee/server/service/scep_proxy.go
@@ -239,9 +239,9 @@ func (s *SCEPConfigService) GetNDESSCEPChallenge(ctx context.Context, proxy flee
 			resp.StatusCode)})
 	}
 	// Make a transformer that converts MS-Win default to UTF8:
-	win16be := unicode.UTF16(unicode.LittleEndian, unicode.IgnoreBOM)
-	// Make a transformer that is like win16be, but abides by BOM:
-	utf16bom := unicode.BOMOverride(win16be.NewDecoder())
+	win16le := unicode.UTF16(unicode.LittleEndian, unicode.IgnoreBOM)
+	// Make a transformer that is like win16le, but abides by BOM:
+	utf16bom := unicode.BOMOverride(win16le.NewDecoder())
 
 	// Make a Reader that uses utf16bom:
 	unicodeReader := transform.NewReader(resp.Body, utf16bom)

--- a/ee/server/service/scep_proxy.go
+++ b/ee/server/service/scep_proxy.go
@@ -239,7 +239,7 @@ func (s *SCEPConfigService) GetNDESSCEPChallenge(ctx context.Context, proxy flee
 			resp.StatusCode)})
 	}
 	// Make a transformer that converts MS-Win default to UTF8:
-	win16be := unicode.UTF16(unicode.BigEndian, unicode.IgnoreBOM)
+	win16be := unicode.UTF16(unicode.LittleEndian, unicode.IgnoreBOM)
 	// Make a transformer that is like win16be, but abides by BOM:
 	utf16bom := unicode.BOMOverride(win16be.NewDecoder())
 

--- a/ee/server/service/scep_proxy_test.go
+++ b/ee/server/service/scep_proxy_test.go
@@ -70,7 +70,7 @@ func TestValidateNDESSCEPAdminURL(t *testing.T) {
 		require.NoError(t, err)
 		byteData := make([]byte, len(datUTF16)*2)
 		for i, v := range datUTF16 {
-			binary.BigEndian.PutUint16(byteData[i*2:], v)
+			binary.LittleEndian.PutUint16(byteData[i*2:], v)
 		}
 		return byteData
 	}


### PR DESCRIPTION
Fixes #28488

Microsoft uses UTF16LE and not UTF16BE

# Checklist for submitter
- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
- [x] Added/updated automated tests
- [x] Manual QA for all new/changed functionality
