### PR TITLE
Cherry-Pick: Fleet helm updates into v4.68.1 and Increment Helm Chart Version

### DIFF
--- a/charts/fleet/Chart.yaml
+++ b/charts/fleet/Chart.yaml
@@ -4,7 +4,7 @@ name: fleet
 keywords:
   - fleet
   - osquery
-version: v6.6.4
+version: v6.6.5
 home: https://github.com/fleetdm/fleet
 sources:
   - https://github.com/fleetdm/fleet.git

--- a/charts/fleet/values.yaml
+++ b/charts/fleet/values.yaml
@@ -55,10 +55,10 @@ ingress:
       paths:
         - path: /
           pathType: ImplementationSpecific
-  tls:
-    - secretName: chart-example-tls
-      hosts:
-        - chart-example.local
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
 
 ## Section: Fleet
 # All of the settings relating to configuring the Fleet server

--- a/charts/tuf/Chart.yaml
+++ b/charts/tuf/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.1.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/tuf/values.yaml
+++ b/charts/tuf/values.yaml
@@ -56,11 +56,10 @@ ingress:
       paths:
         - path: /
           pathType: ImplementationSpecific
-  #tls: []
-  tls:
-    - secretName: chart-example-tls
-      hosts:
-        - chart-example.local
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
 
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious


### PR DESCRIPTION
- Cherry-picked commits for: 
  - TLS secret removal on ingress
  - incremented helm version
- Incremented Fleet Helm chart version `6.6.4` -> `6.6.5`