### PR TITLE
Add caching to package generation

### DIFF
--- a/changes/hackathon-cacheing-package-generation
+++ b/changes/hackathon-cacheing-package-generation
@@ -1,0 +1,1 @@
+- Added caching to package generation

--- a/orbit/pkg/packaging/packaging.go
+++ b/orbit/pkg/packaging/packaging.go
@@ -299,6 +299,10 @@ func InitializeUpdates(updateOpt update.Options) (*UpdatesData, error) {
 		return nil, fmt.Errorf("failed to create %s copy: %w", oldMetadataPath, err)
 	}
 
+	if err := CopyCacheToPackage(cacheDir, newMetadataPath, originalUpdateRootDirectory); err != nil {
+		return nil, fmt.Errorf("failed to copy cached package file: %s: %w", osquerydPath, err)
+	}
+
 	return &UpdatesData{
 		OrbitPath:    orbitPath,
 		OrbitVersion: orbitCustom.Version,

--- a/orbit/pkg/packaging/packaging.go
+++ b/orbit/pkg/packaging/packaging.go
@@ -197,6 +197,7 @@ func CopyCacheToPackage(cacheDir, cachedFile, rootDir string) error {
 		return fmt.Errorf("creating package directory for cache copy: %w", err)
 	}
 
+	// Hardlink instead of copying, faster and reduces waste
 	if err := os.Link(cachedFile, packageFile); err != nil {
 		return fmt.Errorf("linking cached file into package directory: %w", err)
 	}

--- a/orbit/pkg/update/update.go
+++ b/orbit/pkg/update/update.go
@@ -439,6 +439,8 @@ func (u *Updater) get(target string) (*LocalTarget, error) {
 		return nil, errors.New("target is required")
 	}
 
+	fmt.Printf("u.opt.RootDirectory: %v\n", u.opt.RootDirectory)
+
 	localTarget, err := u.localTarget(target)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load local path for target %s: %w", target, err)
@@ -528,18 +530,18 @@ func (u *Updater) download(target, repoPath, localPath string, customCheckExec f
 		return err
 	}
 
+	downloadFilePath := filepath.Join(staging, filepath.Base(localPath))
+	fmt.Printf("downloadFilePath: %v\n", downloadFilePath)
+
 	tmp, err := secure.OpenFile(
-		filepath.Join(staging, filepath.Base(localPath)),
+		downloadFilePath,
 		os.O_CREATE|os.O_WRONLY,
 		constant.DefaultExecutableMode,
 	)
 	if err != nil {
 		return fmt.Errorf("open temp file for download: %w", err)
 	}
-	defer func() {
-		tmp.Close()
-		os.Remove(tmp.Name())
-	}()
+
 	if err := platform.ChmodExecutable(tmp.Name()); err != nil {
 		return fmt.Errorf("chmod download: %w", err)
 	}

--- a/orbit/pkg/update/update.go
+++ b/orbit/pkg/update/update.go
@@ -439,8 +439,6 @@ func (u *Updater) get(target string) (*LocalTarget, error) {
 		return nil, errors.New("target is required")
 	}
 
-	fmt.Printf("u.opt.RootDirectory: %v\n", u.opt.RootDirectory)
-
 	localTarget, err := u.localTarget(target)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load local path for target %s: %w", target, err)

--- a/orbit/pkg/update/update.go
+++ b/orbit/pkg/update/update.go
@@ -529,7 +529,6 @@ func (u *Updater) download(target, repoPath, localPath string, customCheckExec f
 	}
 
 	downloadFilePath := filepath.Join(staging, filepath.Base(localPath))
-	fmt.Printf("downloadFilePath: %v\n", downloadFilePath)
 
 	tmp, err := secure.OpenFile(
 		downloadFilePath,


### PR DESCRIPTION
For #29765.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.
- [x] Manual QA for all new/changed functionality
