### PR TITLE
Handbook: add digital experience ritual for checking for new osquery schema versions

### DIFF
--- a/handbook/digital-experience/README.md
+++ b/handbook/digital-experience/README.md
@@ -178,6 +178,12 @@ To generate a new page, you'll need:
 6. Replace the lorum ipsum and placeholder images on the generated page with the page's real content, and add a meta description and title by changing the `pageTitleForMeta` and `pageDescriptionForMeta in the page's `locals` in `website/config/routes.js`.
 -->
 
+### Check for new versions of osquery schema
+
+When a new version of osquery is released, the Fleet website needs to be updated to use the latest version of the osquery schema. To do this, we update the website's `versionOfOsquerySchemaToUseWhenGeneratingDocumentation` configuration variable in [website/config/custom.js](https://github.com/fleetdm/fleet/blob/6eb6884c4f02dc24b49f394abe9dde5fd1875c55/website/config/custom.js#L327). The osquery schema is combined with Fleet's [YAML overrides](https://github.com/fleetdm/fleet/tree/main/schema/tables) to generate the [JSON schema](https://github.com/fleetdm/fleet/blob/main/schema/osquery_fleet_schema.json) used by the query side panel in Fleet, as well as Fleetdm.com's [osquery table documentation](/tables).
+
+> Note: The version number used in the `versionOfOsquerySchemaToUseWhenGeneratingDocumentation` variable must correspond to a version of the JSON osquery schema in the [osquery/osquery-site repo](https://github.com/osquery/osquery-site/tree/main/src/data/osquery_schema_versions).
+
 
 ### Restart Algolia manually
 

--- a/handbook/digital-experience/digital-experience.rituals.yml
+++ b/handbook/digital-experience/digital-experience.rituals.yml
@@ -253,4 +253,14 @@
   autoIssue:  
     labels: [ "#g-digital-experience" ] 
     repo: "confidential"
+-
+  task: "Check for new versions of osquery schema"
+  startedOn: "2025-06-03"
+  frequency: "Monthly"
+  description: "Make sure the website is using the latest version of the osquery schema."
+  moreInfoUrl: "https://fleetdm.com/handbook/digital-experience#check-for-new-versions-of-osquery-schema"
+  dri: "eashaw"
+  autoIssue:  
+    labels: [ "#g-digital-experience" ] 
+    repo: "fleet"
 


### PR DESCRIPTION
Closes: #29425

Changes:
- Added a digital experience ritual to make sure the website is using the latest version of the osquery schema.