### PR TITLE
#29721 API design (🎸 Labels page)

### DIFF
--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -5035,7 +5035,7 @@ Returns a list of all the labels in Fleet.
 | order_direction | string  | query | **Requires `order_key`**. The direction of the order given the order key. Options include `"asc"` and `"desc"`. Default is `"asc"`. |
 | page                     | integer | query | Page number of the results to fetch. |
 | per_page                 | integer | query | Results per page. |
-| query          | string | query | Search query keywords. Searchable fields include `name`. |
+| query                    | string | query | Search query keywords. Searchable fields include `name`. |
 | without_builtin          | boolean | query | If `true`, omits built-in labels (`"label_type": "builtin"`) from the response. |
 
 #### Example

--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -5035,6 +5035,7 @@ Returns a list of all the labels in Fleet.
 | order_direction | string  | query | **Requires `order_key`**. The direction of the order given the order key. Options include `"asc"` and `"desc"`. Default is `"asc"`. |
 | page                     | integer | query | Page number of the results to fetch. |
 | per_page                 | integer | query | Results per page. |
+| query          | string | query | Search query keywords. Searchable fields include `name`. |
 | without_builtin          | boolean | query | If `true`, omits built-in labels (`"label_type": "builtin"`) from the response. |
 
 #### Example

--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -5033,6 +5033,9 @@ Returns a list of all the labels in Fleet.
 | --------------- | ------- | ----- |------------------------------------- |
 | order_key       | string  | query | What to order results by. Can be any column in the labels table.                                                  |
 | order_direction | string  | query | **Requires `order_key`**. The direction of the order given the order key. Options include `"asc"` and `"desc"`. Default is `"asc"`. |
+| page                     | integer | query | Page number of the results to fetch. |
+| per_page                 | integer | query | Results per page. |
+| without_builtin          | boolean | query | If `true`, omits built-in labels (`"label_type": "builtin"`) from the response. |
 
 #### Example
 


### PR DESCRIPTION
Some changes to the "List labels" API endpoint for #29721.

Leaving as a draft PR to `main`, since this is an air guitar for a hackathon project.