### PR TITLE
Skip `CVE-2025-48734` for real

### DIFF
--- a/security/vex/fleetctl/CVE-2025-48734.vex.json
+++ b/security/vex/fleetctl/CVE-2025-48734.vex.json
@@ -15,7 +15,7 @@
           "@id": "fleetctl"
         },
         {
-          "@id": "pkg:golang/github.com/goreleaser/nfpm/v2"
+          "@id": "pkg:maven/commons-beanutils/commons-beanutils"
         }
       ],
       "status": "not_affected",


### PR DESCRIPTION
I fixed [this](https://github.com/fleetdm/fleet/pull/29692) incorrectly the first time (my trivy setup is broken on my workstation and I missed the CI check failure on the original PR).