### PR TITLE
Cherry-pick: Fleet Helm chart updates into v4.69.0

### DIFF
--- a/charts/fleet/Chart.yaml
+++ b/charts/fleet/Chart.yaml
@@ -4,7 +4,7 @@ name: fleet
 keywords:
   - fleet
   - osquery
-version: v6.6.2
+version: v6.6.4
 home: https://github.com/fleetdm/fleet
 sources:
   - https://github.com/fleetdm/fleet.git

--- a/charts/fleet/templates/cron-vulnprocessing.yaml
+++ b/charts/fleet/templates/cron-vulnprocessing.yaml
@@ -168,8 +168,12 @@ spec:
                 {{- end }}
               privileged: false
               readOnlyRootFilesystem: true
+              {{- if .Values.fleet.securityContext.runAsGroup }}
               runAsGroup: {{ int64 .Values.fleet.securityContext.runAsGroup }}
+              {{- end }}
+              {{- if .Values.fleet.securityContext.runAsUser }}
               runAsUser: {{ int64 .Values.fleet.securityContext.runAsUser }}
+              {{- end }}
               runAsNonRoot: true
             volumeMounts:
               - name: tmp
@@ -199,8 +203,12 @@ spec:
                 drop: [ALL]
               privileged: false
               readOnlyRootFilesystem: true
+              {{- if .Values.fleet.securityContext.runAsGroup }}
               runAsGroup: {{ int64 .Values.fleet.securityContext.runAsGroup }}
+              {{- end }}
+              {{- if .Values.fleet.securityContext.runAsUser }}
               runAsUser: {{ int64 .Values.fleet.securityContext.runAsUser }}
+              {{- end }}
               runAsNonRoot: true
           {{- end }}
           {{- with .Values.imagePullSecrets }}

--- a/charts/fleet/templates/deployment.yaml
+++ b/charts/fleet/templates/deployment.yaml
@@ -304,8 +304,12 @@ spec:
             drop: [ALL]
           privileged: false
           readOnlyRootFilesystem: true
+          {{- if .Values.fleet.securityContext.runAsGroup }}
           runAsGroup: {{ int64 .Values.fleet.securityContext.runAsGroup }}
+          {{- end }}
+          {{- if .Values.fleet.securityContext.runAsUser }}
           runAsUser: {{ int64 .Values.fleet.securityContext.runAsUser }}
+          {{- end }}
           runAsNonRoot: true
         livenessProbe:
           httpGet:
@@ -363,8 +367,12 @@ spec:
             drop: [ALL]
           privileged: false
           readOnlyRootFilesystem: true
+          {{- if .Values.fleet.securityContext.runAsGroup }}
           runAsGroup: {{ int64 .Values.fleet.securityContext.runAsGroup }}
+          {{- end }}
+          {{- if .Values.fleet.securityContext.runAsUser }}
           runAsUser: {{ int64 .Values.fleet.securityContext.runAsUser }}
+          {{- end }}
           runAsNonRoot: true
       {{- end }}
       hostPID: false

--- a/charts/fleet/templates/job-migration.yaml
+++ b/charts/fleet/templates/job-migration.yaml
@@ -131,8 +131,12 @@ spec:
             {{- end }}
           privileged: false
           readOnlyRootFilesystem: true
+          {{- if .Values.fleet.securityContext.runAsGroup }}
           runAsGroup: {{ int64 .Values.fleet.securityContext.runAsGroup }}
+          {{- end }}
+          {{- if .Values.fleet.securityContext.runAsUser }}
           runAsUser: {{ int64 .Values.fleet.securityContext.runAsUser }}
+          {{- end }}
           runAsNonRoot: true
         volumeMounts:
           {{- if .Values.database.tls.enabled }}
@@ -160,8 +164,12 @@ spec:
             drop: [ALL]
           privileged: false
           readOnlyRootFilesystem: true
+          {{- if .Values.fleet.securityContext.runAsGroup }}
           runAsGroup: {{ int64 .Values.fleet.securityContext.runAsGroup }}
+          {{- end }}
+          {{- if .Values.fleet.securityContext.runAsUser }}
           runAsUser: {{ int64 .Values.fleet.securityContext.runAsUser }}
+          {{- end }}
           runAsNonRoot: true
       {{- end }}
       {{- with .Values.imagePullSecrets }}

--- a/charts/fleet/values.yaml
+++ b/charts/fleet/values.yaml
@@ -55,10 +55,10 @@ ingress:
       paths:
         - path: /
           pathType: ImplementationSpecific
-  tls:
-    - secretName: chart-example-tls
-      hosts:
-        - chart-example.local
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
 
 ## Section: Fleet
 # All of the settings relating to configuring the Fleet server

--- a/charts/tuf/Chart.yaml
+++ b/charts/tuf/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.1.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/tuf/values.yaml
+++ b/charts/tuf/values.yaml
@@ -56,11 +56,10 @@ ingress:
       paths:
         - path: /
           pathType: ImplementationSpecific
-  #tls: []
-  tls:
-    - secretName: chart-example-tls
-      hosts:
-        - chart-example.local
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
 
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious


### PR DESCRIPTION
Cherry-picked commits for:
- runAsUser/runAsGroup
- TLS secret removal on ingress
- incremented helm version