### PR TITLE
Update activity feed copy

### DIFF
--- a/frontend/pages/DashboardPage/cards/ActivityFeed/GlobalActivityItem/GlobalActivityItem.tests.tsx
+++ b/frontend/pages/DashboardPage/cards/ActivityFeed/GlobalActivityItem/GlobalActivityItem.tests.tsx
@@ -1036,7 +1036,7 @@ describe("Activity Feed", () => {
       screen.getByText((content, node) => {
         return (
           node?.innerHTML ===
-          "<b>Test User </b>Mobile device management (MDM) was turned on for <b>ABCD (manual)</b>."
+          "<b>Test User </b>MDM features were turned on for <b>ABCD</b>."
         );
       })
     ).toBeInTheDocument();

--- a/frontend/pages/DashboardPage/cards/ActivityFeed/GlobalActivityItem/GlobalActivityItem.tests.tsx
+++ b/frontend/pages/DashboardPage/cards/ActivityFeed/GlobalActivityItem/GlobalActivityItem.tests.tsx
@@ -987,15 +987,17 @@ describe("Activity Feed", () => {
       type: ActivityType.MdmEnrolled,
       details: {
         host_serial: "ABCD",
+        host_display_name: "Test Host",
       },
     });
     render(<GlobalActivityItem activity={activity} isPremiumTier />);
 
     expect(
       screen.getByText((content, node) => {
+        console.log(node?.innerHTML);
         return (
           node?.innerHTML ===
-          "<b>Test User </b>An end user turned on MDM features for a host with serial number <b>ABCD (manual)</b>."
+          "<b>Test User </b>An end user turned on MDM features on <b>Test Host</b> (serial number <b>ABCD</b>)."
         );
       })
     ).toBeInTheDocument();
@@ -1008,6 +1010,7 @@ describe("Activity Feed", () => {
         host_serial: "ABCD",
         installed_from_dep: true,
         mdm_platform: "apple",
+        host_display_name: "Test Host",
       },
     });
     render(<GlobalActivityItem activity={activity} isPremiumTier />);
@@ -1016,7 +1019,7 @@ describe("Activity Feed", () => {
       screen.getByText((content, node) => {
         return (
           node?.innerHTML ===
-          "<b>Test User </b>An end user turned on MDM features for a host with serial number <b>ABCD (automatic)</b>."
+          "<b>Test User </b>An end user turned on MDM features on<b> Test Host</b> (serial number <b>ABCD</b>)."
         );
       })
     ).toBeInTheDocument();
@@ -1034,6 +1037,7 @@ describe("Activity Feed", () => {
 
     expect(
       screen.getByText((content, node) => {
+        console.log(node?.innerHTML);
         return (
           node?.innerHTML ===
           "<b>Test User </b>MDM features were turned on for <b>ABCD</b>."

--- a/frontend/pages/DashboardPage/cards/ActivityFeed/GlobalActivityItem/GlobalActivityItem.tests.tsx
+++ b/frontend/pages/DashboardPage/cards/ActivityFeed/GlobalActivityItem/GlobalActivityItem.tests.tsx
@@ -1017,9 +1017,10 @@ describe("Activity Feed", () => {
 
     expect(
       screen.getByText((content, node) => {
+        console.log(node?.innerHTML);
         return (
           node?.innerHTML ===
-          "<b>Test User </b>An end user turned on MDM features on<b> Test Host</b> (serial number <b>ABCD</b>)."
+          "<b>Test User </b>An end user turned on MDM features on <b>Test Host</b> (serial number <b>ABCD</b>)."
         );
       })
     ).toBeInTheDocument();

--- a/frontend/pages/DashboardPage/cards/ActivityFeed/GlobalActivityItem/GlobalActivityItem.tsx
+++ b/frontend/pages/DashboardPage/cards/ActivityFeed/GlobalActivityItem/GlobalActivityItem.tsx
@@ -266,8 +266,8 @@ const TAGGED_TEMPLATES = {
     if (activity.details?.mdm_platform === "microsoft") {
       return (
         <>
-          Mobile device management (MDM) was turned on for{" "}
-          <b>{activity.details?.host_display_name} (manual)</b>.
+          MDM features were turned on for{" "}
+          <b> {activity.details?.host_display_name}</b>.
         </>
       );
     }
@@ -276,12 +276,9 @@ const TAGGED_TEMPLATES = {
     // compatibility
     return (
       <>
-        An end user turned on MDM features for a host with serial number{" "}
-        <b>
-          {activity.details?.host_serial} (
-          {activity.details?.installed_from_dep ? "automatic" : "manual"})
-        </b>
-        .
+        An end user turned on MDM features on
+        <b> {activity.details?.host_display_name}</b> (serial number{" "}
+        <b>{activity.details?.host_serial}</b>).
       </>
     );
   },

--- a/frontend/pages/DashboardPage/cards/ActivityFeed/GlobalActivityItem/GlobalActivityItem.tsx
+++ b/frontend/pages/DashboardPage/cards/ActivityFeed/GlobalActivityItem/GlobalActivityItem.tsx
@@ -266,7 +266,7 @@ const TAGGED_TEMPLATES = {
     if (activity.details?.mdm_platform === "microsoft") {
       return (
         <>
-          MDM features were turned on for{" "}
+          MDM features were turned on for
           <b> {activity.details?.host_display_name}</b>.
         </>
       );

--- a/frontend/pages/DashboardPage/cards/ActivityFeed/GlobalActivityItem/GlobalActivityItem.tsx
+++ b/frontend/pages/DashboardPage/cards/ActivityFeed/GlobalActivityItem/GlobalActivityItem.tsx
@@ -266,8 +266,8 @@ const TAGGED_TEMPLATES = {
     if (activity.details?.mdm_platform === "microsoft") {
       return (
         <>
-          MDM features were turned on for
-          <b> {activity.details?.host_display_name}</b>.
+          MDM features were turned on for{" "}
+          <b>{activity.details?.host_display_name}</b>.
         </>
       );
     }
@@ -276,8 +276,8 @@ const TAGGED_TEMPLATES = {
     // compatibility
     return (
       <>
-        An end user turned on MDM features on
-        <b> {activity.details?.host_display_name}</b> (serial number{" "}
+        An end user turned on MDM features on{" "}
+        <b>{activity.details?.host_display_name}</b> (serial number{" "}
         <b>{activity.details?.host_serial}</b>).
       </>
     );


### PR DESCRIPTION
Update copy. Figma [here](https://www.figma.com/design/5krysuQ5tk3YVhjYEU3jR2/-29729-Start-and-end-activities--macOS-setup-experience-and-MDM-migration?node-id=5364-81&t=I6TWSOxFbPFNvCcU-1).

- @noahtalerman: @gillespi314 there's a reason we didn't show serial number for Windows hosts right? Is it because we might not have it during Windows automatic enrollment?


