### PR TITLE
21979: Extended wipe end-point to allow for doWipe Win CMD

### DIFF
--- a/changes/21979-do-wipe-command
+++ b/changes/21979-do-wipe-command
@@ -1,0 +1,1 @@
+* Extended `POST /api/v1/fleet/hosts/:id/wipe` endpoint to allow users to specify the type of remote wipe for windows hosts.

--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -4458,7 +4458,7 @@ To wipe a macOS, iOS, iPadOS, or Windows host, the host must have MDM turned on.
 | Name     | Type              | In   | Description                                                                                                                                                                                                          |
 |----------| ----------------- | ---- |----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | id       | integer | path | **Required**. ID of the host to be wiped.                                                                                                                                                                            |
-| windows  | object | body | Optional metadata used when wiping Windows hosts. The object includes a `wipe_type` property that can be used for specifying what type of remote wipe to perform, allowed values are `doWipe` and `doWipeProtected`. |
+| windows  | object | body | Optional metadata used when wiping Windows hosts. The object includes a `wipe_type` property that can be used for specifying what type of remote wipe to perform. Allowed values are `"doWipe"` and `"doWipeProtected"`. |
 
 #### Example
 

--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -4455,9 +4455,10 @@ To wipe a macOS, iOS, iPadOS, or Windows host, the host must have MDM turned on.
 
 #### Parameters
 
-| Name       | Type              | In   | Description                                                                   |
-| ---------- | ----------------- | ---- | ----------------------------------------------------------------------------- |
-| id | integer | path | **Required**. ID of the host to be wiped. |
+| Name     | Type              | In   | Description                                                                                                                                                                                                          |
+|----------| ----------------- | ---- |----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| id       | integer | path | **Required**. ID of the host to be wiped.                                                                                                                                                                            |
+| windows  | object | body | Optional metadata used when wiping Windows hosts. The object includes a `wipe_type` property that can be used for specifying what type of remote wipe to perform, allowed values are `doWipe` and `doWipeProtected`. |
 
 #### Example
 

--- a/server/fleet/mdm.go
+++ b/server/fleet/mdm.go
@@ -1008,5 +1008,5 @@ type MDMConfigProfileStatus struct {
 
 // MDMWipeMetadata specifies optional metadata for the remote wipe command
 type MDMWipeMetadata struct {
-	Windows *MDMWindowsWipeMetadata `json:"windows"`
+	Windows *MDMWindowsWipeMetadata
 }

--- a/server/fleet/mdm.go
+++ b/server/fleet/mdm.go
@@ -1005,3 +1005,8 @@ type MDMConfigProfileStatus struct {
 	Pending   uint `json:"pending" db:"pending"`
 	Failed    uint `json:"failed" db:"failed"`
 }
+
+// MDMWipeMetadata specifies optional metadata for the remote wipe command
+type MDMWipeMetadata struct {
+	Windows *MDMWindowsWipeMetadata `json:"windows"`
+}

--- a/server/fleet/service.go
+++ b/server/fleet/service.go
@@ -1186,7 +1186,7 @@ type Service interface {
 	// Script-based methods (at least for some platforms, MDM-based for others)
 	LockHost(ctx context.Context, hostID uint, viewPIN bool) (unlockPIN string, err error)
 	UnlockHost(ctx context.Context, hostID uint) (unlockPIN string, err error)
-	WipeHost(ctx context.Context, hostID uint) error
+	WipeHost(ctx context.Context, hostID uint, metadata *MDMWipeMetadata) error
 
 	///////////////////////////////////////////////////////////////////////////////
 	// Software installers

--- a/server/fleet/windows_mdm.go
+++ b/server/fleet/windows_mdm.go
@@ -2,6 +2,7 @@ package fleet
 
 import (
 	"bytes"
+	"encoding/json"
 	"encoding/xml"
 	"errors"
 	"fmt"
@@ -210,4 +211,43 @@ type MDMWindowsBulkUpsertHostProfilePayload struct {
 type MDMWindowsProfileContents struct {
 	SyncML   []byte `db:"syncml"`
 	Checksum []byte `db:"checksum"`
+}
+
+// MDMWindowsWipeType specifies what type of remote wipe we want
+// to perform.
+type MDMWindowsWipeType int
+
+const (
+	MDMWindowsWipeTypeDoWipe MDMWindowsWipeType = iota
+	MDMWindowsWipeTypeDoWipeProtected
+)
+
+var wipeTypeVariants = map[MDMWindowsWipeType]string{
+	MDMWindowsWipeTypeDoWipe:          "doWipe",
+	MDMWindowsWipeTypeDoWipeProtected: "doWipeProtected",
+}
+
+func (wt *MDMWindowsWipeType) String() string {
+	if wt == nil {
+		return "<nil>"
+	}
+	return wipeTypeVariants[*wt]
+}
+
+func (wt *MDMWindowsWipeType) UnmarshalJSON(b []byte) error {
+	var s string
+	if err := json.Unmarshal(b, &s); err != nil {
+		return err
+	}
+	for k, v := range wipeTypeVariants {
+		if v == s {
+			*wt = k
+			return nil
+		}
+	}
+	return fmt.Errorf("invalid WipeType: %s", s)
+}
+
+type MDMWindowsWipeMetadata struct {
+	WipeType MDMWindowsWipeType `json:"wipe_type"`
 }

--- a/server/service/hosts_test.go
+++ b/server/service/hosts_test.go
@@ -2002,9 +2002,9 @@ func TestLockUnlockWipeHostAuth(t *testing.T) {
 				return &fleet.HostLockWipeStatus{}, nil
 			}
 
-			err = svc.WipeHost(ctx, globalHostID)
+			err = svc.WipeHost(ctx, globalHostID, nil)
 			checkAuthErr(t, tt.shouldFailGlobalWrite, err)
-			err = svc.WipeHost(ctx, teamHostID)
+			err = svc.WipeHost(ctx, teamHostID, nil)
 			checkAuthErr(t, tt.shouldFailTeamWrite, err)
 		})
 	}

--- a/server/service/integration_mdm_lifecycle_test.go
+++ b/server/service/integration_mdm_lifecycle_test.go
@@ -289,7 +289,7 @@ func (s *integrationMDMTestSuite) TestTurnOnLifecycleEventsWindows() {
 				s.Do(
 					"POST",
 					fmt.Sprintf("/api/latest/fleet/hosts/%d/wipe", host.ID),
-					nil,
+					json.RawMessage(`{ "windows": {"wipe_type": "doWipe"}}`),
 					http.StatusOK,
 				)
 
@@ -305,7 +305,7 @@ func (s *integrationMDMTestSuite) TestTurnOnLifecycleEventsWindows() {
 				require.NotNil(t, wipeCmd)
 				require.Equal(t, wipeCmd.Verb, fleet.CmdExec)
 				require.Len(t, wipeCmd.Cmd.Items, 1)
-				require.EqualValues(t, "./Device/Vendor/MSFT/RemoteWipe/doWipeProtected", *wipeCmd.Cmd.Items[0].Target)
+				require.EqualValues(t, "./Device/Vendor/MSFT/RemoteWipe/doWipe", *wipeCmd.Cmd.Items[0].Target)
 
 				msgID, err := device.GetCurrentMsgID()
 				require.NoError(t, err)

--- a/server/service/scripts.go
+++ b/server/service/scripts.go
@@ -1313,15 +1313,24 @@ func (svc *Service) UnlockHost(ctx context.Context, hostID uint) (string, error)
 // //////////////////////////////////////////////////////////////////////////////
 
 func (req *wipeHostRequest) DecodeBody(ctx context.Context, r io.Reader, u url.Values, c []*x509.Certificate) error {
+	if r == nil {
+		return nil
+	}
+
 	decoder := json.NewDecoder(io.LimitReader(r, 100*1024))
 	metadata := fleet.MDMWipeMetadata{}
 	if err := decoder.Decode(&metadata); err != nil {
+		if err == io.EOF {
+			// OK ... body is optional
+			return nil
+		}
 		return &fleet.BadRequestError{
 			Message:     "failed to unmarshal request body",
 			InternalErr: err,
 		}
 	}
 	req.Metadata = &metadata
+
 	return nil
 }
 

--- a/server/service/scripts.go
+++ b/server/service/scripts.go
@@ -1320,9 +1320,8 @@ func (req *wipeHostRequest) DecodeBody(ctx context.Context, r io.Reader, u url.V
 			Message:     "failed to unmarshal request body",
 			InternalErr: err,
 		}
-	} else {
-		req.Metadata = &metadata
 	}
+	req.Metadata = &metadata
 	return nil
 }
 

--- a/server/service/scripts_test.go
+++ b/server/service/scripts_test.go
@@ -980,6 +980,13 @@ func TestWipeHostRequestDecodeBody(t *testing.T) {
 		expectation   func(t *testing.T, req *wipeHostRequest)
 	}{
 		{
+			name: "empty body",
+			body: strings.NewReader(""),
+			expectation: func(t *testing.T, req *wipeHostRequest) {
+				require.Nil(t, req.Metadata)
+			},
+		},
+		{
 			name: "doWipe",
 			body: strings.NewReader(`{"windows": {"wipe_type": "doWipe"}}`),
 			expectation: func(t *testing.T, req *wipeHostRequest) {

--- a/server/service/scripts_test.go
+++ b/server/service/scripts_test.go
@@ -3,6 +3,10 @@ package service
 import (
 	"context"
 	"errors"
+	"fmt"
+	"github.com/gorilla/mux"
+	"io"
+	"net/http/httptest"
 	"strings"
 	"testing"
 	"time"
@@ -967,4 +971,110 @@ func TestBatchScriptExecute(t *testing.T) {
 		require.ErrorContains(t, err, "ok")
 		require.Equal(t, []uint{3, 4}, requestedHostIds)
 	})
+}
+
+func TestWipeHostRequestDecode(t *testing.T) {
+	sut := wipeHostRequest{}
+	ctx := context.Background()
+
+	validHostIDExp := func(t *testing.T, req *wipeHostRequest) {
+		require.NotNil(t, req)
+		require.Equal(t, uint(123), req.HostID)
+	}
+
+	testCases := []struct {
+		name          string
+		params        map[string]string
+		body          io.Reader
+		expectedError string
+		expectation   func(t *testing.T, req *wipeHostRequest)
+	}{
+		{
+			name:          "HostID missing",
+			expectedError: "bad route",
+		},
+		{
+			name:          "HostID non-numeric",
+			params:        map[string]string{"id": "abc"},
+			expectedError: "invalid syntax",
+		},
+		{
+			name:        "HostID valid",
+			params:      map[string]string{"id": "123"},
+			expectation: validHostIDExp,
+		},
+		{
+			name:   "doWipe",
+			params: map[string]string{"id": "123"},
+			body:   strings.NewReader(`{"windows": {"wipe_type": "doWipe"}}`),
+			expectation: func(t *testing.T, req *wipeHostRequest) {
+				validHostIDExp(t, req)
+				require.NotNil(t, req.Metadata)
+				require.NotNil(t, req.Metadata.Windows)
+				require.Equal(t, fleet.MDMWindowsWipeTypeDoWipe, req.Metadata.Windows.WipeType)
+			},
+		},
+		{
+			name:   "doWipeProtected",
+			params: map[string]string{"id": "123"},
+			body:   strings.NewReader(`{"windows": {"wipe_type": "doWipeProtected"}}`),
+			expectation: func(t *testing.T, req *wipeHostRequest) {
+				validHostIDExp(t, req)
+				require.NotNil(t, req.Metadata)
+				require.NotNil(t, req.Metadata.Windows)
+				require.Equal(t, fleet.MDMWindowsWipeTypeDoWipeProtected, req.Metadata.Windows.WipeType)
+			},
+		},
+		{
+			name:          "invalid wipe type",
+			params:        map[string]string{"id": "123"},
+			body:          strings.NewReader(`{"windows": {"wipe_type": "doWipeProtectedII"}}`),
+			expectedError: "failed to unmarshal request body",
+		},
+		{
+			name:   "empty payload",
+			params: map[string]string{"id": "123"},
+			body:   strings.NewReader(`{}`),
+			expectation: func(t *testing.T, req *wipeHostRequest) {
+				validHostIDExp(t, req)
+				require.NotNil(t, req.Metadata)
+				require.Nil(t, req.Metadata.Windows)
+			},
+		},
+		{
+			name:   "windows field is null",
+			params: map[string]string{"id": "123"},
+			body:   strings.NewReader(`{"windows": null}`),
+			expectation: func(t *testing.T, req *wipeHostRequest) {
+				validHostIDExp(t, req)
+				require.NotNil(t, req.Metadata)
+				require.Nil(t, req.Metadata.Windows)
+			},
+		},
+		{
+			name:          "empty wipe type",
+			params:        map[string]string{"id": "123"},
+			body:          strings.NewReader(`{"windows": {"wipe_type": null}}`),
+			expectedError: "failed to unmarshal request body",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			url := fmt.Sprintf("/api/v1/fleet/hosts/%s/wipe", tc.params["id"])
+			req := httptest.NewRequest("POST", url, tc.body)
+			req = mux.SetURLVars(req, tc.params)
+
+			result, err := sut.DecodeRequest(ctx, req)
+
+			if tc.expectedError != "" {
+				require.ErrorContains(t, err, tc.expectedError)
+			} else {
+				require.NoError(t, err)
+				decodedReq, ok := result.(*wipeHostRequest)
+				require.True(t, ok)
+				tc.expectation(t, decodedReq)
+			}
+		})
+	}
 }


### PR DESCRIPTION
For #21979

Extended POST /api/v1/fleet/hosts/:id/wipe end-point to allow users to specify an optional payload for specifying what type of remote wipe to perform on Win hosts.

# Checklist for submitter

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.
- [X] Added/updated automated tests
- [X] Manual QA for all new/changed functionality