### PR TITLE
Fleet UI: Follow up for GitOps YAML

### DIFF
--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/DeleteSoftwareModal/DeleteSoftwareModal.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/DeleteSoftwareModal/DeleteSoftwareModal.tsx
@@ -65,7 +65,7 @@ const DeleteSoftwareModal = ({
     >
       <>
         {gitOpsModeEnabled && (
-          <InfoBanner color="purple" className={`${baseClass}__gitops-warning`}>
+          <InfoBanner className={`${baseClass}__gitops-warning`}>
             You are currently in GitOps mode. If the package is defined in
             GitOps, it will reappear when GitOps runs.
           </InfoBanner>

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/DeleteSoftwareModal/DeleteSoftwareModal.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/DeleteSoftwareModal/DeleteSoftwareModal.tsx
@@ -7,6 +7,7 @@ import { getErrorReason } from "interfaces/errors";
 
 import Modal from "components/Modal";
 import Button from "components/buttons/Button";
+import InfoBanner from "components/InfoBanner";
 
 const baseClass = "delete-software-modal";
 
@@ -21,6 +22,7 @@ interface IDeleteSoftwareModalProps {
   softwareInstallerName?: string;
   onExit: () => void;
   onSuccess: () => void;
+  gitOpsModeEnabled?: boolean;
 }
 
 const DeleteSoftwareModal = ({
@@ -29,6 +31,7 @@ const DeleteSoftwareModal = ({
   softwareInstallerName,
   onExit,
   onSuccess,
+  gitOpsModeEnabled,
 }: IDeleteSoftwareModalProps) => {
   const { renderFlash } = useContext(NotificationContext);
   const [isDeleting, setIsDeleting] = useState(false);
@@ -61,6 +64,12 @@ const DeleteSoftwareModal = ({
       isContentDisabled={isDeleting}
     >
       <>
+        {gitOpsModeEnabled && (
+          <InfoBanner color="purple" className={`${baseClass}__gitops-warning`}>
+            You are currently in GitOps mode. If the package is defined in
+            GitOps, it will reappear when GitOps runs.
+          </InfoBanner>
+        )}
         <p>
           Software won&apos;t be uninstalled from existing hosts, but any
           pending installs and uninstalls{" "}

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/EditSoftwareModal/EditSoftwareModal.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/EditSoftwareModal/EditSoftwareModal.tsx
@@ -56,6 +56,7 @@ interface IEditSoftwareModalProps {
   installerType: "package" | "vpp";
   router: InjectedRouter;
   gitOpsModeEnabled?: boolean;
+  openViewYamlModal: () => void;
 }
 
 const EditSoftwareModal = ({
@@ -67,6 +68,7 @@ const EditSoftwareModal = ({
   installerType,
   router,
   gitOpsModeEnabled = false,
+  openViewYamlModal,
 }: IEditSoftwareModalProps) => {
   const { renderFlash } = useContext(NotificationContext);
 
@@ -197,16 +199,7 @@ const EditSoftwareModal = ({
         gitOpsModeEnabled
       ) {
         // No longer flash message, we open YAML modal if editing with gitOpsModeEnabled
-        const newQueryParams: QueryParams = {
-          team_id: teamId,
-          gitops_yaml: "true",
-        };
-        router.push(
-          getPathWithQueryParams(
-            paths.SOFTWARE_TITLE_DETAILS(software.title_id.toString()),
-            newQueryParams
-          )
-        );
+        openViewYamlModal();
       } else {
         renderFlash(
           "success",

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwareInstallerCard/SoftwareInstallerCard.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwareInstallerCard/SoftwareInstallerCard.tsx
@@ -101,15 +101,17 @@ interface IActionsDropdownProps {
   onEditSoftwareClick: () => void;
   gitOpsModeEnabled?: boolean;
   repoURL?: string;
+  isFMA?: boolean;
 }
 
-const SoftwareActionButtons = ({
+export const SoftwareActionButtons = ({
   installerType,
   onDownloadClick,
   onDeleteClick,
   onEditSoftwareClick,
   gitOpsModeEnabled,
   repoURL,
+  isFMA,
 }: IActionsDropdownProps) => {
   let options =
     installerType === "package"
@@ -136,10 +138,10 @@ const SoftwareActionButtons = ({
     );
     options = options.map((option) => {
       // edit is disabled in gitOpsMode for VPP only
-      // delete is disabled in gitOpsMode for all installers (FMA, VPP, & custom packages)
+      // delete is disabled in gitOpsMode for FMA and VPP onlu
       if (
         (option.value === "edit" && installerType === "vpp") ||
-        option.value === "delete"
+        (option.value === "delete" && (installerType === "vpp" || isFMA))
       ) {
         return {
           ...option,
@@ -263,6 +265,9 @@ const SoftwareInstallerCard = ({
 
   const { renderFlash } = useContext(NotificationContext);
 
+  // gitOpsYamlParam URL Param controls whether the View Yaml modal is opened on page refresh
+  // as it automatically opens from adding/editing flow of custom software in gitOps mode
+  const [showViewYamlModal, setShowViewYamlModal] = useState(gitOpsYamlParam);
   const [showEditSoftwareModal, setShowEditSoftwareModal] = useState(false);
   const [showDeleteModal, setShowDeleteModal] = useState(false);
 
@@ -274,20 +279,8 @@ const SoftwareInstallerCard = ({
     setShowDeleteModal(true);
   };
 
-  // gitOpsYamlParam URL Param controls whether the View Yaml modal is opened
-  // as it automatically opens from adding/editing flow of custom software in gitOps mode
   const onToggleViewYaml = () => {
-    const newQueryParams: QueryParams = {
-      team_id: teamId,
-      gitops_yaml: !gitOpsYamlParam ? "true" : undefined,
-    };
-
-    router.push(
-      getPathWithQueryParams(
-        PATHS.SOFTWARE_TITLE_DETAILS(softwareId.toString()),
-        newQueryParams
-      )
-    );
+    setShowViewYamlModal(!showViewYamlModal);
   };
 
   const onDeleteSuccess = useCallback(() => {
@@ -399,6 +392,7 @@ const SoftwareInstallerCard = ({
                 onEditSoftwareClick={onEditSoftwareClick}
                 gitOpsModeEnabled={gitOpsModeEnabled}
                 repoURL={repoURL}
+                isFMA={isFleetMaintainedApp}
               />
             )}
           </div>
@@ -442,6 +436,7 @@ const SoftwareInstallerCard = ({
       )}
       {showDeleteModal && (
         <DeleteSoftwareModal
+          gitOpsModeEnabled={gitOpsModeEnabled}
           softwareId={softwareId}
           softwareInstallerName={softwareInstaller?.name}
           teamId={teamId}
@@ -449,7 +444,7 @@ const SoftwareInstallerCard = ({
           onSuccess={onDeleteSuccess}
         />
       )}
-      {gitOpsYamlParam && isCustomPackage && (
+      {showViewYamlModal && isCustomPackage && (
         <ViewYamlModal
           softwareTitleName={softwareTitleName}
           softwarePackage={softwareInstaller as ISoftwarePackage}

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwareInstallerCard/SoftwareInstallerCard.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwareInstallerCard/SoftwareInstallerCard.tsx
@@ -265,8 +265,8 @@ const SoftwareInstallerCard = ({
 
   const { renderFlash } = useContext(NotificationContext);
 
-  // gitOpsYamlParam URL Param controls whether the View Yaml modal is opened on page refresh
-  // as it automatically opens from adding/editing flow of custom software in gitOps mode
+  // gitOpsYamlParam URL Param controls whether the View Yaml modal is opened on page load
+  // as it automatically opens from adding flow of custom software in gitOps mode
   const [showViewYamlModal, setShowViewYamlModal] = useState(gitOpsYamlParam);
   const [showEditSoftwareModal, setShowEditSoftwareModal] = useState(false);
   const [showDeleteModal, setShowDeleteModal] = useState(false);
@@ -432,6 +432,7 @@ const SoftwareInstallerCard = ({
           onExit={() => setShowEditSoftwareModal(false)}
           refetchSoftwareTitle={refetchSoftwareTitle}
           installerType={installerType}
+          openViewYamlModal={onToggleViewYaml}
         />
       )}
       {showDeleteModal && (

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwareInstallerCard/SoftwareInstallerCard.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwareInstallerCard/SoftwareInstallerCard.tsx
@@ -138,7 +138,7 @@ export const SoftwareActionButtons = ({
     );
     options = options.map((option) => {
       // edit is disabled in gitOpsMode for VPP only
-      // delete is disabled in gitOpsMode for FMA and VPP onlu
+      // delete is disabled in gitOpsMode for software types that can't be added in GitOps mode (FMA, VPP)
       if (
         (option.value === "edit" && installerType === "vpp") ||
         (option.value === "delete" && (installerType === "vpp" || isFMA))

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/ViewYamlModal/ViewYamlModal.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/ViewYamlModal/ViewYamlModal.tsx
@@ -4,6 +4,7 @@ import { AppContext } from "context/app";
 import { NotificationContext } from "context/notification";
 
 import { LEARN_MORE_ABOUT_BASE_LINK } from "utilities/constants";
+import { getExtensionFromFileName } from "utilities/file/fileUtils";
 import FileSaver from "file-saver";
 import { ISoftwarePackage } from "interfaces/software";
 
@@ -87,10 +88,13 @@ const ViewYamlModal = ({
   const hyphenatedSoftwareTitle = hyphenateString(softwareTitleName);
 
   const onDownloadPreInstallQuery = (evt: React.MouseEvent) => {
+    const softwareExtension = getExtensionFromFileName(name);
+    const preInstallQueryContent = `- name: "[Pre-install software] ${softwareTitleName} (${softwareExtension})"\n  query: ${preInstallQuery}`;
+
     handleDownload({
       evt,
-      content: preInstallQuery,
-      filename: `pre-install-query-${hyphenatedSoftwareTitle}.sh`,
+      content: preInstallQueryContent,
+      filename: `pre-install-query-${hyphenatedSoftwareTitle}.yml`,
       filetype: "text/yml",
       errorMsg:
         "Your pre-install query could not be downloaded. Please create YAML file (.yml) manually.",
@@ -158,7 +162,6 @@ const ViewYamlModal = ({
           <InputField
             enableCopy
             readOnly
-            inputWrapperClass
             name="filename"
             label="Filename"
             value={`${hyphenatedSoftwareTitle}.yml`}

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/ViewYamlModal/ViewYamlModal.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/ViewYamlModal/ViewYamlModal.tsx
@@ -144,7 +144,7 @@ const ViewYamlModal = ({
             the next GitOps run, and edited installers will cause the GitOps run
             to fail.&nbsp;
             <CustomLink
-              url={`${LEARN_MORE_ABOUT_BASE_LINK}/yaml-software`}
+              url={`${LEARN_MORE_ABOUT_BASE_LINK}/yaml-packages`}
               text="How to use YAML"
               newTab
               multiline

--- a/frontend/pages/hosts/details/DeviceUserPage/AutoEnrollMdmModal/AutoEnrollMdmModal.tsx
+++ b/frontend/pages/hosts/details/DeviceUserPage/AutoEnrollMdmModal/AutoEnrollMdmModal.tsx
@@ -50,7 +50,6 @@ const AutoEnrollMdmModal = ({
             <InputField
               enableCopy
               readOnly
-              inputWrapperClass
               name="profiles-renew-command"
               value="sudo profiles renew -type enrollment"
             />
@@ -90,7 +89,6 @@ const AutoEnrollMdmModal = ({
             <InputField
               enableCopy
               readOnly
-              inputWrapperClass
               name="profiles-renew-command"
               value="sudo profiles renew -type enrollment"
             />


### PR DESCRIPTION
## Issue
For #28110 
For #29509 (followup unreleased delete in gitops request)

## Description
- Allow delete in gitops mode for custom package (fix for #29509)
- Add `<InfoBanner/>` to delete modal only in gitops mode for custom package (fix for #29509)
- `gitops_yaml` query param is set to true to open YAML modal on first load only, when closing the modal, it will not update the url param and therefore fixes any "Click back" issues that reopens the modal (fix for https://github.com/fleetdm/fleet/issues/28110#issuecomment-2920560947)
- Fix pre install query download:  (fix for https://github.com/fleetdm/fleet/issues/28110#issuecomment-2920560947)
  - to be `.yml` not `.sh`
  - to have both `name` and `query` field in the YAML file
  - to have the autogenerated query name be similar to the auto generated policy name for auto-install policies 
- Fix URL back wonkines
- Fix "How to use YAML" link from learn more about `/yaml-software` to the correct learn more about `/yaml-packages` 

## Screen recording of changes

### Allow delete and delete banner
https://github.com/user-attachments/assets/57c2f3f7-1f02-4f9b-9bc8-c2fa7075fffd

### Fix pre-install query YAML download file type and format
https://github.com/user-attachments/assets/3925d1ed-de7b-41df-a5ac-4e89cdf6ac71

### Fix pressing back reopens modal wonkiness

https://github.com/user-attachments/assets/dfaef67f-d7c6-4bd8-8b12-01645d7ebe8d



### Correct YAML link

https://github.com/user-attachments/assets/8110e8f4-fb93-494d-84fe-5cab3a48f1e5



# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Added/updated automated tests (Should create a new 4.70 ticket and point out for a followup PR to ensure better test coverage)
- [x] Manual QA for all new/changed functionality
