### PR TITLE
Website: Update CRM helper to handle duplicate record errors.

### DIFF
--- a/website/api/helpers/salesforce/update-or-create-contact-and-account.js
+++ b/website/api/helpers/salesforce/update-or-create-contact-and-account.js
@@ -310,7 +310,7 @@ module.exports = {
         }
         // If a contact souce was provided, since we found an existing contact when trying to create one, remove it from the valuesToSet.
         if(contactSource) {
-          delete valuesToSet.Contact_source__c;// eslint-disable-line camelcase
+          delete valuesToSet.Contact_source__c;
         }
 
       }

--- a/website/api/helpers/salesforce/update-or-create-contact-and-account.js
+++ b/website/api/helpers/salesforce/update-or-create-contact-and-account.js
@@ -71,6 +71,10 @@ module.exports = {
       }
     },
 
+    couldNotCreateorUpdateContact: {
+      description: 'A Contact record could not be updated in the CRM for this user.',
+    }
+
   },
 
   fn: async function ({emailAddress, linkedinUrl, firstName, lastName, organization, jobTitle, primaryBuyingSituation, psychologicalStage, psychologicalStageChangeReason, contactSource, description, getStartedResponses, intentSignal}) {
@@ -93,6 +97,10 @@ module.exports = {
       throw new Error('UsageError: when updating or creating a contact and account in salesforce, either an email or linkedInUrl is required.');
     }
 
+    //
+    //  ╦  ╔═╗╔═╗╦╔╗╔  ╔╦╗╔═╗  ╔═╗╔═╗╦  ╔═╗╔═╗╔═╗╔═╗╦═╗╔═╗╔═╗
+    //  ║  ║ ║║ ╦║║║║   ║ ║ ║  ╚═╗╠═╣║  ║╣ ╚═╗╠╣ ║ ║╠╦╝║  ║╣
+    //  ╩═╝╚═╝╚═╝╩╝╚╝   ╩ ╚═╝  ╚═╝╩ ╩╩═╝╚═╝╚═╝╚  ╚═╝╩╚═╚═╝╚═╝
     // Log in to Salesforce.
     let jsforce = require('jsforce');
     let salesforceConnection = new jsforce.Connection({
@@ -103,6 +111,10 @@ module.exports = {
     let salesforceContactId;
     let salesforceAccountId;
 
+
+    //  ╔╗ ╦ ╦╦╦  ╔╦╗  ╦  ╦╔═╗╦  ╦ ╦╔═╗╔═╗  ╔╦╗╔═╗  ╔═╗╔═╗╔╦╗
+    //  ╠╩╗║ ║║║   ║║  ╚╗╔╝╠═╣║  ║ ║║╣ ╚═╗   ║ ║ ║  ╚═╗║╣  ║
+    //  ╚═╝╚═╝╩╩═╝═╩╝   ╚╝ ╩ ╩╩═╝╚═╝╚═╝╚═╝   ╩ ╚═╝  ╚═╝╚═╝ ╩
     // Build a dictionary of values we'll update/create a contact record with.
     let valuesToSet = {};
     if(emailAddress){
@@ -127,20 +139,186 @@ module.exports = {
       valuesToSet.Title = jobTitle;
     }
 
-    let existingContactRecord;
+    //  ╦  ╔═╗╔═╗╦╔═  ╔═╗╔═╗╦═╗  ╔═╗═╗ ╦╦╔═╗╔╦╗╦╔╗╔╔═╗  ╔═╗╔═╗╔╗╔╔╦╗╔═╗╔═╗╔╦╗
+    //  ║  ║ ║║ ║╠╩╗  ╠╣ ║ ║╠╦╝  ║╣ ╔╩╦╝║╚═╗ ║ ║║║║║ ╦  ║  ║ ║║║║ ║ ╠═╣║   ║
+    //  ╩═╝╚═╝╚═╝╩ ╩  ╚  ╚═╝╩╚═  ╚═╝╩ ╚═╩╚═╝ ╩ ╩╝╚╝╚═╝  ╚═╝╚═╝╝╚╝ ╩ ╩ ╩╚═╝ ╩
     // Search for an existing Contact record using the provided email address or linkedIn profile URL.
+    let existingContactRecord;
     if(emailAddress) {
       existingContactRecord = await salesforceConnection.sobject('Contact')
       .findOne({
         Email:  emailAddress,
       });
+      if(!existingContactRecord){
+        // If no contacts are found when searching by the provided email address, look for existing contact records that have a "last email associated by fleetdm.com" set to the providded email address.
+        existingContactRecord = await salesforceConnection.sobject('Contact')
+        .findOne({
+          Last_email_associated_by_fleetdm_com__c:  emailAddress, // eslint-disable-line camelcase
+        });
+      }
     } else if(linkedinUrl) {
       existingContactRecord = await salesforceConnection.sobject('Contact')
       .findOne({
         LinkedIn_profile__c: linkedinUrl // eslint-disable-line camelcase
       });
+      if(!existingContactRecord){
+        // If no contacts are found when searching by the provided linkedIn url, look for an existing contact records that have a modified linkedIn profile url.
+        existingContactRecord = await salesforceConnection.sobject('Contact')
+        .findOne({
+          LinkedIn_profile__c: linkedinUrl.replace(sails.config.custom.RX_PROTOCOL_AND_COMMON_SUBDOMAINS, '') // eslint-disable-line camelcase
+        });
+      }
     }
+    //  ╔╗╔╔═╗  ╔═╗╔═╗╔╗╔╔╦╗╔═╗╔═╗╔╦╗  ╔═╗╔═╗╦ ╦╔╗╔╔╦╗
+    //  ║║║║ ║  ║  ║ ║║║║ ║ ╠═╣║   ║   ╠╣ ║ ║║ ║║║║ ║║
+    //  ╝╚╝╚═╝  ╚═╝╚═╝╝╚╝ ╩ ╩ ╩╚═╝ ╩   ╚  ╚═╝╚═╝╝╚╝═╩╝
+    if(!existingContactRecord) {
+      // Otherwise, we'll enrich the information we have, and check for an existing account.
+      if(linkedinUrl){
+        // If linkedinUrl was provided, strip the protocol and subdomain from the URL.
+        linkedinUrl = linkedinUrl.replace(sails.config.custom.RX_PROTOCOL_AND_COMMON_SUBDOMAINS, '');
+      }
+      // Send the information we have to the enrichment helper.
+      let enrichmentData = await sails.helpers.iq.getEnriched(emailAddress, linkedinUrl, firstName, lastName, organization);
+      // Add information from the enrichmentData to the values to set on the new Contact record.
+      if(enrichmentData.person && enrichmentData.person.linkedinUrl){
+        valuesToSet.LinkedIn_profile__c = enrichmentData.person.linkedinUrl;// eslint-disable-line camelcase
+      }
+      if(enrichmentData.person && enrichmentData.person.title){
+        valuesToSet.Title = enrichmentData.person.title;
+      }
+      let salesforceAccountOwnerId;
+      if(!enrichmentData.employer || !enrichmentData.employer.emailDomain || !enrichmentData.employer.organization) {
+        // Special sacrificial meat cave where the contacts with no organization go.
+        // https://fleetdm.lightning.force.com/lightning/r/Account/0014x000025JC8DAAW/view
+        salesforceAccountId = '0014x000025JC8DAAW';
+        salesforceAccountOwnerId = '0054x00000735wDAAQ';// « "Integrations admin" user.
+      } else {
+        //
+        //  ╦  ╔═╗╔═╗╦╔═  ╔═╗╔═╗╦═╗  ╔═╗═╗ ╦╦╔═╗╔╦╗╦╔╗╔╔═╗  ╔═╗╔═╗╔═╗╔═╗╦ ╦╔╗╔╔╦╗
+        //  ║  ║ ║║ ║╠╩╗  ╠╣ ║ ║╠╦╝  ║╣ ╔╩╦╝║╚═╗ ║ ║║║║║ ╦  ╠═╣║  ║  ║ ║║ ║║║║ ║
+        //  ╩═╝╚═╝╚═╝╩ ╩  ╚  ╚═╝╩╚═  ╚═╝╩ ╚═╩╚═╝ ╩ ╩╝╚╝╚═╝  ╩ ╩╚═╝╚═╝╚═╝╚═╝╝╚╝ ╩
+        // Search for an existing Account record by the organization returned from the getEnriched helper.
+        let existingAccountRecord = await salesforceConnection.sobject('Account')
+        .findOne({
+          'Name':  enrichmentData.employer.organization,
+          // 'LinkedIn_company_URL__c': enrichmentData.employer.linkedinCompanyPageUrl // TODO: if this information is not present on an existing account, nothing will be returned.
+        });
+        // If we didn't find an account that's name exaclty matches, we'll do another search using the provided email domain.
+        if(!existingAccountRecord){
+          existingAccountRecord = await salesforceConnection.sobject('Account')
+          .findOne({
+            'Website':  enrichmentData.employer.emailDomain,
+            // 'LinkedIn_company_URL__c': enrichmentData.employer.linkedinCompanyPageUrl // TODO: if this information is not present on an existing account, nothing will be returned.
+          });
+        }
+        // console.log(existingAccountRecord);
+        // If we found an exisitng account, we'll assign the new contact to the account owner.
+        if(existingAccountRecord) {
+          // Store the ID of the Account record we found.
+          salesforceAccountId = existingAccountRecord.Id;
+          salesforceAccountOwnerId = existingAccountRecord.OwnerId;
+          // console.log('exising account found!', salesforceAccountId);
+        } else {
+          //  ╔═╗╦═╗╔═╗╔═╗╔╦╗╔═╗  ╔╗╔╔═╗╦ ╦  ╔═╗╔═╗╔═╗╔═╗╦ ╦╔╗╔╔╦╗
+          //  ║  ╠╦╝║╣ ╠═╣ ║ ║╣   ║║║║╣ ║║║  ╠═╣║  ║  ║ ║║ ║║║║ ║
+          //  ╚═╝╩╚═╚═╝╩ ╩ ╩ ╚═╝  ╝╚╝╚═╝╚╩╝  ╩ ╩╚═╝╚═╝╚═╝╚═╝╝╚╝ ╩
+          // If no existing account record was found, create a new one, and assign it to the "Integrations Admin" user.
+          salesforceAccountOwnerId = '0054x00000735wDAAQ';// « "Integrations admin" user.
+          // Create a timestamp to use for the new account's assigned date.
+          let today = new Date();
+          let nowOn = today.toISOString().replace('Z', '+0000');
+          require('assert')(typeof enrichmentData.employer.numberOfEmployees === 'number');
+          let newAccountRecord = await salesforceConnection.sobject('Account')
+          .create({
+            Account_Assigned_date__c: nowOn,// eslint-disable-line camelcase
+            // eslint-disable-next-line camelcase
+            Current_Assignment_Reason__c: 'Inbound Lead',// TODO verify that this matters. if not, do not set it.
+            Prospect_Status__c: 'Assigned',// eslint-disable-line camelcase
 
+            Name: enrichmentData.employer.organization,// IFWMIH: We know organization exists
+            Website: enrichmentData.employer.emailDomain,
+            LinkedIn_company_URL__c: enrichmentData.employer.linkedinCompanyPageUrl,// eslint-disable-line camelcase
+            NumberOfEmployees: enrichmentData.employer.numberOfEmployees,
+            OwnerId: salesforceAccountOwnerId
+          });
+          salesforceAccountId = newAccountRecord.id;
+        }//ﬁ
+        // console.log('New account created!', salesforceAccountId);
+      }//ﬁ
+
+      // Only add contactSource to valuesToSet if we're creating a new contact record.
+      if(contactSource) {
+        valuesToSet.Contact_source__c = contactSource;// eslint-disable-line camelcase
+      }
+
+      // console.log(`creating new Contact record.`)
+      //  ╔═╗╦═╗╔═╗╔═╗╔╦╗╔═╗  ╔╗╔╔═╗╦ ╦  ╔═╗╔═╗╔╗╔╔╦╗╔═╗╔═╗╔╦╗
+      //  ║  ╠╦╝║╣ ╠═╣ ║ ║╣   ║║║║╣ ║║║  ║  ║ ║║║║ ║ ╠═╣║   ║
+      //  ╚═╝╩╚═╚═╝╩ ╩ ╩ ╚═╝  ╝╚╝╚═╝╚╩╝  ╚═╝╚═╝╝╚╝ ╩ ╩ ╩╚═╝ ╩
+      let duplicateContactWasFound = false;
+      let newContactRecord = await sails.helpers.flow.build(async ()=>{
+        return await salesforceConnection.sobject('Contact')
+        .create({
+          AccountId: salesforceAccountId,
+          OwnerId: salesforceAccountOwnerId,
+          FirstName: firstName ? firstName : '?',
+          LastName: lastName ? lastName : '?',
+          ...valuesToSet,
+        });
+      })// If Salesforce returns a duplicates_detected error message, use the first duplicate record returned in the error.
+      .tolerate({errorCode: 'DUPLICATES_DETECTED'}, (err)=>{
+        // Get the first matched duplicate record returned in the error returned by Salesforce.
+        let firstContactRecordMatchedByDuplicateRule = _.get(err, 'duplicateResult.matchResults[0].matchRecords[0].record.Id');
+        if(firstContactRecordMatchedByDuplicateRule) {
+          duplicateContactWasFound = true;
+          return {id: firstContactRecordMatchedByDuplicateRule};
+        } else {
+          // If the error returned from Salesforce does not contain a list of matched records (TODO: Why would this ever happen?), log a warning to alert us, and return undefined.
+          sails.log.warn(`When trying to create a new Contact record (email: ${emailAddress}), the CRM returned a DUPLICATES_DETECTED error, but returned no list of potential duplicate records. Full error: ${require('util').inspect(err, {depth: null})}`);
+          return;
+        }
+      });
+
+      // Throw a couldNotCreateOrUpdateContact response if no duplicate records were returned in the error from Salesforce. (I'm not sure why/if this would ever happen)
+      if(!newContactRecord) {
+        throw 'couldNotCreateorUpdateContact';
+      }
+
+      salesforceContactId = newContactRecord.id;
+      if(!duplicateContactWasFound) {
+        // Since we've created a new contact, we'll update the psychological stage to be either '2 - Aware', or whatever psystage was provided.
+        // This causes it to appear as an edit in our CRM and helps reporting.
+        await salesforceConnection.sobject('Contact')
+        .update({
+          Id: salesforceContactId,
+          Stage__c: psychologicalStage ? psychologicalStage : '2 - Aware',// eslint-disable-line camelcase
+          Psystage_change_reason__c: psychologicalStageChangeReason ? psychologicalStageChangeReason : null,// eslint-disable-line camelcase
+        });
+        // console.log(`Created ${newContactRecord.id}`);
+      } else {
+        // If we found a duplicate record when trying to create a new contact, we'll proceed as if we had found an existing contact and we'll update
+        // that contact so the next time this helper runs for this user, it will find the correct contact without attempting to create a new one.
+        existingContactRecord = await salesforceConnection.sobject('Contact')
+        .findOne({
+          Id: salesforceContactId,
+        });
+        // If an email address was provided, and the existing contact has an email address set, remove it from the ValuesToSet dictionairy and set it as the "last email associated by fleetdm.com"
+        if(emailAddress && existingContactRecord.Email){
+          delete valuesToSet.Email;
+          valuesToSet.Last_email_associated_by_fleetdm_com__c =  emailAddress;// eslint-disable-line camelcase
+        }
+        // If a contact souce was provided, since we found an existing contact when trying to create one, remove it from the valuesToSet.
+        if(contactSource) {
+          delete valuesToSet.Contact_source__c;// eslint-disable-line camelcase
+        }
+
+      }
+    }//ﬁ
+
+    //  ╦ ╦╔═╗╔╦╗╔═╗╔╦╗╔═╗  ╔═╗═╗ ╦╦╔═╗╔╦╗╦╔╗╔╔═╗  ╔═╗╔═╗╔╗╔╔╦╗╔═╗╔═╗╔╦╗
+    //  ║ ║╠═╝ ║║╠═╣ ║ ║╣   ║╣ ╔╩╦╝║╚═╗ ║ ║║║║║ ╦  ║  ║ ║║║║ ║ ╠═╣║   ║
+    //  ╚═╝╩  ═╩╝╩ ╩ ╩ ╚═╝  ╚═╝╩ ╚═╩╚═╝ ╩ ╩╝╚╝╚═╝  ╚═╝╚═╝╝╚╝ ╩ ╩ ╩╚═╝ ╩
     if(existingContactRecord) {
       // If a description was provided and the contact has a description, append the new description to it.
       if(description && existingContactRecord.Description) {
@@ -194,102 +372,7 @@ module.exports = {
       });
       salesforceAccountId = existingContactRecord.AccountId;
       // console.log(`${salesforceContactId} updated!`);
-    } else {
-      // Otherwise, we'll enrich the information we have, and check for an existing account.
-      if(linkedinUrl){
-        // If linkedinUrl was provided, strip the protocol and subdomain from the URL.
-        linkedinUrl = linkedinUrl.replace(sails.config.custom.RX_PROTOCOL_AND_COMMON_SUBDOMAINS, '');
-      }
-      // Send the information we have to the enrichment helper.
-      let enrichmentData = await sails.helpers.iq.getEnriched(emailAddress, linkedinUrl, firstName, lastName, organization);
-      // console.log(enrichmentData);
-      // Add information from the enrichmentData to the values to set on the new Contact record.
-      if(enrichmentData.person && enrichmentData.person.linkedinUrl){
-        valuesToSet.LinkedIn_profile__c = enrichmentData.person.linkedinUrl;// eslint-disable-line camelcase
-      }
-      if(enrichmentData.person && enrichmentData.person.title){
-        valuesToSet.Title = enrichmentData.person.title;
-      }
-      let salesforceAccountOwnerId;
-      if(!enrichmentData.employer || !enrichmentData.employer.emailDomain || !enrichmentData.employer.organization) {
-        // Special sacrificial meat cave where the contacts with no organization go.
-        // https://fleetdm.lightning.force.com/lightning/r/Account/0014x000025JC8DAAW/view
-        salesforceAccountId = '0014x000025JC8DAAW';
-        salesforceAccountOwnerId = '0054x00000735wDAAQ';// « "Integrations admin" user.
-      } else {
-        // Search for an existing Account record by the organization returned from the getEnriched helper.
-        let existingAccountRecord = await salesforceConnection.sobject('Account')
-        .findOne({
-          'Name':  enrichmentData.employer.organization,
-          // 'LinkedIn_company_URL__c': enrichmentData.employer.linkedinCompanyPageUrl // TODO: if this information is not present on an existing account, nothing will be returned.
-        });
-        // If we didn't find an account that's name exaclty matches, we'll do another search using the provided email domain.
-        if(!existingAccountRecord){
-          existingAccountRecord = await salesforceConnection.sobject('Account')
-          .findOne({
-            'Website':  enrichmentData.employer.emailDomain,
-            // 'LinkedIn_company_URL__c': enrichmentData.employer.linkedinCompanyPageUrl // TODO: if this information is not present on an existing account, nothing will be returned.
-          });
-        }
-        // console.log(existingAccountRecord);
-        // If we found an exisitng account, we'll assign the new contact to the account owner.
-        if(existingAccountRecord) {
-          // Store the ID of the Account record we found.
-          salesforceAccountId = existingAccountRecord.Id;
-          salesforceAccountOwnerId = existingAccountRecord.OwnerId;
-          // console.log('exising account found!', salesforceAccountId);
-        } else {
-          // If no existing account record was found, create a new one, and assign it to the "Integrations Admin" user.
-          salesforceAccountOwnerId = '0054x00000735wDAAQ';// « "Integrations admin" user.
-          // Create a timestamp to use for the new account's assigned date.
-          let today = new Date();
-          let nowOn = today.toISOString().replace('Z', '+0000');
-          require('assert')(typeof enrichmentData.employer.numberOfEmployees === 'number');
-          let newAccountRecord = await salesforceConnection.sobject('Account')
-          .create({
-            Account_Assigned_date__c: nowOn,// eslint-disable-line camelcase
-            // eslint-disable-next-line camelcase
-            Current_Assignment_Reason__c: 'Inbound Lead',// TODO verify that this matters. if not, do not set it.
-            Prospect_Status__c: 'Assigned',// eslint-disable-line camelcase
-
-            Name: enrichmentData.employer.organization,// IFWMIH: We know organization exists
-            Website: enrichmentData.employer.emailDomain,
-            LinkedIn_company_URL__c: enrichmentData.employer.linkedinCompanyPageUrl,// eslint-disable-line camelcase
-            NumberOfEmployees: enrichmentData.employer.numberOfEmployees,
-            OwnerId: salesforceAccountOwnerId
-          });
-          salesforceAccountId = newAccountRecord.id;
-        }//ﬁ
-        // console.log('New account created!', salesforceAccountId);
-      }//ﬁ
-
-      // Only add contactSource to valuesToSet if we're creating a new contact record.
-      if(contactSource) {
-        valuesToSet.Contact_source__c = contactSource;// eslint-disable-line camelcase
-      }
-      // console.log(`creating new Contact record.`)
-      // Create a new Contact record for this person.
-
-      let newContactRecord = await salesforceConnection.sobject('Contact')
-      .create({
-        AccountId: salesforceAccountId,
-        OwnerId: salesforceAccountOwnerId,
-        FirstName: firstName ? firstName : '?',
-        LastName: lastName ? lastName : '?',
-        ...valuesToSet,
-      });
-      salesforceContactId = newContactRecord.id;
-
-      // Since we've created a new contact, we'll update the psychological stage to be either '2 - Aware', or whatever psystage was provided.
-      // This causes it to appear as an edit in our CRM and helps reporting.
-      await salesforceConnection.sobject('Contact')
-      .update({
-        Id: salesforceContactId,
-        Stage__c: psychologicalStage ? psychologicalStage : '2 - Aware',// eslint-disable-line camelcase
-        Psystage_change_reason__c: psychologicalStageChangeReason ? psychologicalStageChangeReason : null,// eslint-disable-line camelcase
-      });
-      // console.log(`Created ${newContactRecord.id}`);
-    }//ﬁ
+    }
 
     return {
       salesforceAccountId,


### PR DESCRIPTION
Closes: https://github.com/fleetdm/confidential/issues/10697

Changes:
- Updated the update-or-create-contact-and-account helper to handle duplicate record errors returned from the CRM. It will now use the first duplicate record returned by the CRM and update it so it will be correctly matched on subsequent runs of the helper.