### PR TITLE
Update santa rules, block vulnerable version of chrome

### DIFF
--- a/it-and-security/lib/macos/configuration-profiles/santa-rules.mobileconfig
+++ b/it-and-security/lib/macos/configuration-profiles/santa-rules.mobileconfig
@@ -42,7 +42,16 @@
 										<string>BLOCKLIST</string>
 										<key>rule_type</key>
 										<string>BINARY</string>
-									</dict>									
+									</dict>
+									<dict>
+                                            					<!-- Block Chrome version with vulnerability, v137.0.7151.69 -->
+                                           					<key>identifier</key>
+                                            					<string>9e29a658cb87df522934f80bab108803b8416c61</string>
+                                            					<key>policy</key>
+                                            					<string>BLOCKLIST</string>
+                                            					<key>rule_type</key>
+                                            					<string>CDHASH</string>
+                                        				</dict>
 								</array>
 							</dict>
 						</dict>


### PR DESCRIPTION
Update santa rules to block vulnerable version of Chrome