### PR TITLE
Adding/Modifying Fleet helm chart to include additional labels for deployment and selector labels for service

### DIFF
--- a/charts/fleet/templates/deployment.yaml
+++ b/charts/fleet/templates/deployment.yaml
@@ -15,6 +15,7 @@ spec:
     matchLabels:
       app: fleet
       chart: fleet
+      component: fleet-server
       heritage: {{ .Release.Service }}
       release: {{ .Release.Name }}
   template:
@@ -26,6 +27,7 @@ spec:
       labels:
         app: fleet
         chart: fleet
+        component: fleet-server
         heritage: {{ .Release.Service }}
         release: {{ .Release.Name }}
     spec:

--- a/charts/fleet/templates/service.yaml
+++ b/charts/fleet/templates/service.yaml
@@ -22,6 +22,7 @@ spec:
   selector:
     app: fleet
     chart: fleet
+    component: fleet-server
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
   ports:


### PR DESCRIPTION
Closes #29710 

- Added label `component: fleet-server` to deployment.yaml under labels and matchLabels
- Added label `component: fleet-server` to service.yaml under selector

