### PR TITLE
Cherry-Pick: Fleet Helm chart updates into v4.69.0 and incremented chart version

### DIFF
--- a/charts/fleet/Chart.yaml
+++ b/charts/fleet/Chart.yaml
@@ -4,7 +4,7 @@ name: fleet
 keywords:
   - fleet
   - osquery
-version: v6.6.4
+version: v6.6.6
 home: https://github.com/fleetdm/fleet
 sources:
   - https://github.com/fleetdm/fleet.git

--- a/charts/fleet/templates/deployment.yaml
+++ b/charts/fleet/templates/deployment.yaml
@@ -15,6 +15,7 @@ spec:
     matchLabels:
       app: fleet
       chart: fleet
+      component: fleet-server
       heritage: {{ .Release.Service }}
       release: {{ .Release.Name }}
   template:
@@ -26,6 +27,7 @@ spec:
       labels:
         app: fleet
         chart: fleet
+        component: fleet-server
         heritage: {{ .Release.Service }}
         release: {{ .Release.Name }}
     spec:

--- a/charts/fleet/templates/service.yaml
+++ b/charts/fleet/templates/service.yaml
@@ -22,6 +22,7 @@ spec:
   selector:
     app: fleet
     chart: fleet
+    component: fleet-server
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
   ports:


### PR DESCRIPTION
- Added label `component: fleet-server` to deployment.yaml under labels and matchLabels
- Added label `component: fleet-server` to service.yaml under selector
- Incremented chart version from 6.6.5 -> 6.6.6