### PR TITLE
Allow configuring SSO timeout (both standard and MDM SSO), replacing hard-coded 5-minute validity period

### DIFF
--- a/changes/29614-sso-timeout
+++ b/changes/29614-sso-timeout
@@ -1,0 +1,1 @@
+* Added `FLEET_AUTH_SSO_SESSION_VALIDITY_PERIOD` environment variable for overriding how long end users have to complete SSO.

--- a/ee/server/service/mdm.go
+++ b/ee/server/service/mdm.go
@@ -702,6 +702,7 @@ func (svc *Service) InitiateMDMAppleSSO(ctx context.Context) (string, error) {
 		Metadata:                    metadata,
 		AssertionConsumerServiceURL: appConfig.MDMUrl() + svc.config.Server.URLPrefix + "/api/v1/fleet/mdm/sso/callback",
 		SessionStore:                svc.ssoSessionStore,
+		SessionTTL:                  uint(svc.config.Auth.SsoSessionValidityPeriod.Seconds()),
 		OriginalURL:                 "/api/v1/fleet/mdm/sso/callback",
 	}
 

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -137,8 +137,9 @@ func (s *ServerConfig) DefaultHTTPServer(ctx context.Context, handler http.Handl
 
 // AuthConfig defines configs related to user authorization
 type AuthConfig struct {
-	BcryptCost  int `yaml:"bcrypt_cost"`
-	SaltKeySize int `yaml:"salt_key_size"`
+	BcryptCost               int           `yaml:"bcrypt_cost"`
+	SaltKeySize              int           `yaml:"salt_key_size"`
+	SsoSessionValidityPeriod time.Duration `yaml:"sso_session_validity_period"`
 }
 
 // AppConfig defines configs related to HTTP
@@ -1085,6 +1086,8 @@ func (man Manager) addConfigs() {
 		"Bcrypt iterations")
 	man.addConfigInt("auth.salt_key_size", 24,
 		"Size of salt for passwords")
+	man.addConfigDuration("auth.sso_session_validity_period", 5*time.Minute,
+		"Timeout from SSO start to SSO callback")
 
 	// App
 	man.addConfigString("app.token_key", "CHANGEME",
@@ -1495,8 +1498,9 @@ func (man Manager) LoadConfig() FleetConfig {
 			PrivateKey:                  man.getConfigString("server.private_key"),
 		},
 		Auth: AuthConfig{
-			BcryptCost:  man.getConfigInt("auth.bcrypt_cost"),
-			SaltKeySize: man.getConfigInt("auth.salt_key_size"),
+			BcryptCost:               man.getConfigInt("auth.bcrypt_cost"),
+			SaltKeySize:              man.getConfigInt("auth.salt_key_size"),
+			SsoSessionValidityPeriod: man.getConfigDuration("auth.sso_session_validity_period"),
 		},
 		App: AppConfig{
 			TokenKeySize:              man.getConfigInt("app.token_key_size"),
@@ -2024,8 +2028,9 @@ func TestConfig() FleetConfig {
 			InviteTokenValidityPeriod: 5 * 24 * time.Hour,
 		},
 		Auth: AuthConfig{
-			BcryptCost:  6, // Low cost keeps tests fast
-			SaltKeySize: 24,
+			BcryptCost:               6, // Low cost keeps tests fast
+			SaltKeySize:              24,
+			SsoSessionValidityPeriod: 5 * time.Minute,
 		},
 		Session: SessionConfig{
 			KeySize:  64,

--- a/server/service/sessions.go
+++ b/server/service/sessions.go
@@ -411,6 +411,7 @@ func (svc *Service) InitiateSSO(ctx context.Context, redirectURL string) (string
 		AssertionConsumerServiceURL: serverURL + svc.config.Server.URLPrefix + "/api/v1/fleet/sso/callback",
 		SessionStore:                svc.ssoSessionStore,
 		OriginalURL:                 redirectURL,
+		SessionTTL:                  uint(svc.config.Auth.SsoSessionValidityPeriod.Seconds()),
 	}
 
 	// If issuer is not explicitly set, default to host name.

--- a/server/sso/authorization_request.go
+++ b/server/sso/authorization_request.go
@@ -14,7 +14,7 @@ import (
 
 const (
 	samlVersion   = "2.0"
-	cacheLifetime = 300 // five minutes
+	cacheLifetime = uint(300) // in seconds (5 minutes)
 )
 
 // RelayState sets optional relay state
@@ -74,12 +74,13 @@ func CreateAuthorizationRequest(settings *Settings, issuer string, options ...fu
 		return "", fmt.Errorf("encoding metadata creating auth request: %w", err)
 	}
 
+	sessionLifetime := cacheLifetime
+	if settings.SessionTTL > 0 {
+		sessionLifetime = settings.SessionTTL
+	}
+
 	// cache metadata so we can check the signatures on the response we get from the IDP
-	err = settings.SessionStore.create(requestID,
-		settings.OriginalURL,
-		metadataWriter.String(),
-		cacheLifetime,
-	)
+	err = settings.SessionStore.create(requestID, settings.OriginalURL, metadataWriter.String(), sessionLifetime)
 	if err != nil {
 		return "", fmt.Errorf("caching metadata while creating auth request: %w", err)
 	}

--- a/server/sso/settings.go
+++ b/server/sso/settings.go
@@ -54,7 +54,9 @@ type Settings struct {
 	// to the IDP
 	AssertionConsumerServiceURL string
 	SessionStore                SessionStore
-	OriginalURL                 string
+	// SessionTTL determines how long (in seconds) a user has to complete SSO before the session is purged from Fleet
+	SessionTTL  uint
+	OriginalURL string
 }
 
 func GetMetadata(config *fleet.SSOProviderSettings) (*Metadata, error) {


### PR DESCRIPTION
For #29614.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.
- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- For new Fleet configuration settings
  - [x] Verified that the setting can be managed via GitOps, or confirmed that the setting is explicitly being excluded from GitOps. - Excluded from GitOps (env var)
- [x] Added/updated automated tests
- [x] Manual QA for all new/changed functionality