### PR TITLE
Fleet UI: Add 24px gap between banner text and CTA

### DIFF
--- a/frontend/components/InfoBanner/_styles.scss
+++ b/frontend/components/InfoBanner/_styles.scss
@@ -2,6 +2,7 @@
   display: flex;
   justify-content: space-between;
   padding: $pad-medium;
+  gap: $pad-large; // Between text and CTA
   font-size: $x-small;
   font-weight: $regular;
   color: $core-fleet-black;


### PR DESCRIPTION
## Issue
Closes #29448 

## Description
- Add 24px gap

## Screenrecording of fix

https://github.com/user-attachments/assets/7c36ec3b-c9b9-49bf-a92b-c0e8f1197125



# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Manual QA for all new/changed functionality

