### PR TITLE
Website: Remove account requirement for /try-fleet page.

### DIFF
--- a/website/assets/js/pages/fleetctl-preview.page.js
+++ b/website/assets/js/pages/fleetctl-preview.page.js
@@ -15,7 +15,9 @@ parasails.registerPage('fleetctl-preview', {
       linux: '~/.fleetctl/fleetctl preview',
       windows: `%USERPROFILE%\\.fleetctl\\fleetctl preview`,
       npm: 'fleetctl preview',
-    }
+    },
+    // For conditionally rendering messages based on if the user is logged in or not.
+    me: undefined,
 
   },
 

--- a/website/assets/styles/pages/entrance/signup.less
+++ b/website/assets/styles/pages/entrance/signup.less
@@ -67,6 +67,38 @@
   [purpose='signup-form'] {
     width: 528px;
   }
+  [purpose='tip'] {
+    margin: 16px 0 32px;
+    background: #F4F4FF;
+    padding: 16px;
+    border-radius: 8px;
+    display: flex;
+    img {
+      display: flex;
+      margin: 4px 12px 0 0;
+      height: 16px;
+      width: 16px;
+      padding: 0px;
+    }
+    p {
+      display: block;
+      margin-bottom: 16px;
+      line-height: 24px;
+      font-size: 16px;
+    }
+    p:last-child {
+      margin-bottom: 0px;
+    }
+    ul {
+      padding-left: 16px;
+    }
+    ul:last-child {
+      margin-bottom: 0px;
+    }
+    li:last-child {
+      padding-bottom: 0px;
+    }
+  }
   [purpose='customer-portal-form'] {
     border-radius: 16px;
     padding: 20px 32px 32px 32px;

--- a/website/assets/styles/pages/fleetctl-preview.less
+++ b/website/assets/styles/pages/fleetctl-preview.less
@@ -26,10 +26,6 @@
     display: inline-block;
     border-radius: 3px;
   }
-  a {
-    color: @core-vibrant-blue;
-    line-height: @text-lineheight;
-  }
   p {
     font-size: 16px;
     line-height: @text-lineheight;

--- a/website/views/pages/entrance/signup.ejs
+++ b/website/views/pages/entrance/signup.ejs
@@ -49,10 +49,18 @@
             <cloud-error v-if="cloudError==='emailAlreadyInUse'">
               <p>This email is already linked to a Fleet account.<br> Please <a href="/login">sign in</a> with your email and password.</p>
             </cloud-error>
-            <cloud-error v-else-if="cloudError === 'invalidEmailDomain'">
-              <p>Please enter your work or school email address</p>
+            <cloud-error v-if="cloudError === 'invalidEmailDomain'">
+              <p>
+                Please enter your work or school email address.
+              </p>
             </cloud-error>
-            <cloud-error purpose="cloud-error" v-else-if="cloudError"></cloud-error>
+            <blockquote purpose="tip" v-if="cloudError === 'invalidEmailDomain'">
+              <img src="/images/icon-info-16x16@2x.png" alt="An icon indicating that this section has important information">
+              <div class="d-block">
+                <p>Don’t want have a work email? Try a local demo of <a href="/try-fleet">Fleet Free</a> instead.</p>
+              </div>
+            </blockquote>
+            <cloud-error purpose="cloud-error" v-if="cloudError && !['emailAlreadyInUse', 'invalidEmailDomain'].includes(cloudError)"></cloud-error>
             <p class="small">By signing up you agree to our <a href="/legal/privacy">privacy policy</a> and <a href="/terms">terms of service</a>.</p>
             <ajax-button tabindex="6" purpose="submit-button" spinner="true" type="submit" :syncing="syncing" class="btn btn-block btn-lg btn-primary mt-4" v-if="!cloudError">Agree and continue</ajax-button>
             <ajax-button tabindex="7" purpose="submit-button" type="button" :syncing="syncing" class="btn btn-block btn-lg btn-primary mt-4" v-if="cloudError" @click="clickResetForm()">Try again</ajax-button>

--- a/website/views/pages/fleetctl-preview.ejs
+++ b/website/views/pages/fleetctl-preview.ejs
@@ -38,18 +38,24 @@
             <p>Run a local demo of the Fleet server:</p>
             <div purpose="terminal-commands">
               <div purpose="command-container">
-                <code v-if="trialLicenseKey && !userHasExpiredTrialLicense">{{fleetctlPreviewTerminalCommand[selectedPlatform]}} --license-key {{trialLicenseKey}}</code>
+                <code v-if="userHasTrialLicense && !userHasExpiredTrialLicense">{{fleetctlPreviewTerminalCommand[selectedPlatform]}} --license-key {{trialLicenseKey}}</code>
                 <code v-else>{{fleetctlPreviewTerminalCommand[selectedPlatform]}}</code>
               </div>
               <a purpose="command-copy-button" @click="clickCopyTerminalCommand(selectedPlatform)"></a>
             </div>
+            <blockquote purpose="tip" v-if="!userHasTrialLicense && !me">
+              <img src="/images/icon-info-16x16@2x.png" alt="An icon indicating that this section has important information">
+              <div class="d-block">
+                <p>To demo Fleet Premium features, <a href="/login">log in</a> or <a href="/register">create an account</a> to get your trial license key.</p>
+              </div>
+            </blockquote>
             <blockquote purpose="tip" v-if="userHasExpiredTrialLicense">
               <img src="/images/icon-info-16x16@2x.png" alt="An icon indicating that this section has important information">
               <div class="d-block">
                 <p>Your Fleet Premium trial license has expired. You can still run the free version of Fleet locally.</p>
               </div>
             </blockquote>
-            <blockquote purpose="tip" v-if="trialLicenseKey && !userHasExpiredTrialLicense">
+            <blockquote purpose="tip" v-if="userHasTrialLicense && !userHasExpiredTrialLicense">
               <img src="/images/icon-info-16x16@2x.png" alt="An icon indicating that this section has important information">
               <div class="d-block">
                 <p>This license key is valid for 30 days.</p>
@@ -79,18 +85,24 @@
             <p>Run a local demo of the Fleet server:</p>
             <div purpose="terminal-commands">
               <div purpose="command-container">
-                <code v-if="trialLicenseKey && !userHasExpiredTrialLicense">{{fleetctlPreviewTerminalCommand[selectedPlatform]}} --license-key {{trialLicenseKey}}</code>
+                <code v-if="userHasTrialLicense && !userHasExpiredTrialLicense">{{fleetctlPreviewTerminalCommand[selectedPlatform]}} --license-key {{trialLicenseKey}}</code>
                 <code v-else>{{fleetctlPreviewTerminalCommand[selectedPlatform]}}</code>
               </div>
               <a purpose="copy-button" @click="clickCopyTerminalCommand(selectedPlatform)"></a>
             </div>
+            <blockquote purpose="tip" v-if="!userHasTrialLicense">
+              <img src="/images/icon-info-16x16@2x.png" alt="An icon indicating that this section has important information">
+              <div class="d-block">
+                <p>To demo Fleet Premium features, <a href="/login">log in</a> or <a href="/register">create an account</a> to get your trial license key.</p>
+              </div>
+            </blockquote>
             <blockquote purpose="tip" v-if="userHasExpiredTrialLicense">
               <img src="/images/icon-info-16x16@2x.png" alt="An icon indicating that this section has important information">
               <div class="d-block">
                 <p>Your Fleet Premium trial license has expired. You can still run the free version of Fleet locally.</p>
               </div>
             </blockquote>
-            <blockquote purpose="tip" v-if="trialLicenseKey && !userHasExpiredTrialLicense">
+            <blockquote purpose="tip" v-if="userHasTrialLicense && !userHasExpiredTrialLicense">
               <img src="/images/icon-info-16x16@2x.png" alt="An icon indicating that this section has important information">
               <div class="d-block">
                 <p>This license key is valid for 30 days.</p>
@@ -120,18 +132,24 @@
             <p>Run a local demo of the Fleet server:</p>
             <div purpose="terminal-commands">
               <div purpose="command-container">
-                <code v-if="trialLicenseKey && !userHasExpiredTrialLicense">{{fleetctlPreviewTerminalCommand[selectedPlatform]}} --license-key {{trialLicenseKey}}</code>
+                <code v-if="userHasTrialLicense && !userHasExpiredTrialLicense">{{fleetctlPreviewTerminalCommand[selectedPlatform]}} --license-key {{trialLicenseKey}}</code>
                 <code v-else>{{fleetctlPreviewTerminalCommand[selectedPlatform]}}</code>
               </div>
               <a purpose="command-copy-button" @click="clickCopyTerminalCommand(selectedPlatform)"></a>
             </div>
+            <blockquote purpose="tip" v-if="!userHasTrialLicense">
+              <img src="/images/icon-info-16x16@2x.png" alt="An icon indicating that this section has important information">
+              <div class="d-block">
+                <p>To demo Fleet Premium features, <a href="/login">log in</a> or <a href="/register">create an account</a> to get your trial license key.</p>
+              </div>
+            </blockquote>
             <blockquote purpose="tip" v-if="userHasExpiredTrialLicense">
               <img src="/images/icon-info-16x16@2x.png" alt="An icon indicating that this section has important information">
               <div class="d-block">
                 <p>Your Fleet Premium trial license has expired. You can still run the free version of Fleet locally.</p>
               </div>
             </blockquote>
-            <blockquote purpose="tip" v-if="trialLicenseKey && !userHasExpiredTrialLicense">
+            <blockquote purpose="tip" v-if="userHasTrialLicense && !userHasExpiredTrialLicense">
               <img src="/images/icon-info-16x16@2x.png" alt="An icon indicating that this section has important information">
               <div class="d-block">
                 <p>This license key is valid for 30 days.</p>
@@ -168,18 +186,24 @@
             <p>Run a local demo of the Fleet server:</p>
             <div purpose="terminal-commands">
               <div purpose="command-container">
-                <code v-if="trialLicenseKey && !userHasExpiredTrialLicense">{{fleetctlPreviewTerminalCommand[selectedPlatform]}} --license-key {{trialLicenseKey}}</code>
+                <code v-if="userHasTrialLicense && !userHasExpiredTrialLicense">{{fleetctlPreviewTerminalCommand[selectedPlatform]}} --license-key {{trialLicenseKey}}</code>
                 <code v-else>{{fleetctlPreviewTerminalCommand[selectedPlatform]}}</code>
               </div>
               <a purpose="command-copy-button" @click="clickCopyTerminalCommand(selectedPlatform)"></a>
             </div>
+            <blockquote purpose="tip" v-if="!userHasTrialLicense">
+              <img src="/images/icon-info-16x16@2x.png" alt="An icon indicating that this section has important information">
+              <div class="d-block">
+                <p>To demo Fleet Premium features, <a href="/login">log in</a> or <a href="/register">create an account</a> to get your trial license key.</p>
+              </div>
+            </blockquote>
             <blockquote purpose="tip" v-if="userHasExpiredTrialLicense">
               <img src="/images/icon-info-16x16@2x.png" alt="An icon indicating that this section has important information">
               <div class="d-block">
                 <p>Your Fleet Premium trial license has expired. You can still run the free version of Fleet locally.</p>
               </div>
             </blockquote>
-            <blockquote purpose="tip" v-if="trialLicenseKey && !userHasExpiredTrialLicense">
+            <blockquote purpose="tip" v-if="userHasTrialLicense && !userHasExpiredTrialLicense">
               <img src="/images/icon-info-16x16@2x.png" alt="An icon indicating that this section has important information">
               <div class="d-block">
                 <p>This license key is valid for 30 days.</p>
@@ -192,21 +216,6 @@
             <p class="mb-0"><strong>Password</strong>: preview1337#</p>
           </div>
         </div>
-      </div>
-    </div>
-    <div v-if="me">
-      <h2 class="pt-0">Need help?</h2>
-      <p><a purpose="contact-link" href="/contact">Get in touch</a> with us.</p>
-    </div>
-    <div v-else>
-      <h2 class="pt-0">Next steps</h2>
-      <div purpose="next-steps" class="d-flex flex-sm-row flex-column align-items-center">
-        <a purpose="docs-button" href="/docs" class="btn btn-primary">
-          Read the docs
-        </a>
-        <animated-arrow-button href="/docs/deploying" class="d-flex">
-          Deploy to production
-        </animated-arrow-button>
       </div>
     </div>
   </div>

--- a/website/views/pages/fleetctl-preview.ejs
+++ b/website/views/pages/fleetctl-preview.ejs
@@ -90,7 +90,7 @@
               </div>
               <a purpose="copy-button" @click="clickCopyTerminalCommand(selectedPlatform)"></a>
             </div>
-            <blockquote purpose="tip" v-if="!userHasTrialLicense">
+            <blockquote purpose="tip" v-if="!userHasTrialLicense && !me">
               <img src="/images/icon-info-16x16@2x.png" alt="An icon indicating that this section has important information">
               <div class="d-block">
                 <p>To demo Fleet Premium features, <a href="/login">log in</a> or <a href="/register">create an account</a> to get your trial license key.</p>
@@ -137,7 +137,7 @@
               </div>
               <a purpose="command-copy-button" @click="clickCopyTerminalCommand(selectedPlatform)"></a>
             </div>
-            <blockquote purpose="tip" v-if="!userHasTrialLicense">
+            <blockquote purpose="tip" v-if="!userHasTrialLicense && !me">
               <img src="/images/icon-info-16x16@2x.png" alt="An icon indicating that this section has important information">
               <div class="d-block">
                 <p>To demo Fleet Premium features, <a href="/login">log in</a> or <a href="/register">create an account</a> to get your trial license key.</p>
@@ -191,7 +191,7 @@
               </div>
               <a purpose="command-copy-button" @click="clickCopyTerminalCommand(selectedPlatform)"></a>
             </div>
-            <blockquote purpose="tip" v-if="!userHasTrialLicense">
+            <blockquote purpose="tip" v-if="!userHasTrialLicense && !me">
               <img src="/images/icon-info-16x16@2x.png" alt="An icon indicating that this section has important information">
               <div class="d-block">
                 <p>To demo Fleet Premium features, <a href="/login">log in</a> or <a href="/register">create an account</a> to get your trial license key.</p>


### PR DESCRIPTION
Closes: https://github.com/fleetdm/confidential/issues/10921

Changes:
- Updated the registration form to direct users who don't have a work email or don't want to create an account to the /try-fleet page.
- Updated the try-fleet page to have a box directing users who want to demo Fleet Premium features to sign up for an account.
- Updated the try-fleet page's view action to generate trial licenses for logged-in users who do not have a trial license key.