### PR TITLE
UI: Make teams dropdowns searchable

### DIFF
--- a/changes/28822-teams-dropdown-search
+++ b/changes/28822-teams-dropdown-search
@@ -1,0 +1,1 @@
+* Implement searching the teams dropdown

--- a/frontend/components/TeamsDropdown/TeamsDropdown.tsx
+++ b/frontend/components/TeamsDropdown/TeamsDropdown.tsx
@@ -122,6 +122,11 @@ const TeamsDropdown = ({
 
   // see https://react-select.com/styles#the-styles-prop
   const customStyles: StylesConfig<INumberDropdownOption, false> = {
+    // container: (baseStyles) => ({
+    //   ...baseStyles,
+    //   width: "100%",
+    //   overflow: "hidden",
+    // }),
     control: (baseStyles, state) => ({
       ...baseStyles,
       display: "flex",
@@ -219,6 +224,17 @@ const TeamsDropdown = ({
     valueContainer: (baseStyles) => ({
       ...baseStyles,
       padding: 0,
+      // overflow: "hidden",
+    }),
+    input: (baseStyles) => ({
+      ...baseStyles,
+      overflow: "hidden",
+      textOverflow: "ellipsis",
+      whiteSpace: "nowrap",
+      // Ensure the cursor remains visible during typing
+      // caretColor: COLORS["core-fleet-black"],
+      // Prevent the input from expanding beyond its container
+      // maxWidth: "100%",
     }),
     option: (baseStyles, state) => ({
       ...baseStyles,

--- a/frontend/components/TeamsDropdown/TeamsDropdown.tsx
+++ b/frontend/components/TeamsDropdown/TeamsDropdown.tsx
@@ -122,11 +122,6 @@ const TeamsDropdown = ({
 
   // see https://react-select.com/styles#the-styles-prop
   const customStyles: StylesConfig<INumberDropdownOption, false> = {
-    // container: (baseStyles) => ({
-    //   ...baseStyles,
-    //   width: "100%",
-    //   overflow: "hidden",
-    // }),
     control: (baseStyles, state) => ({
       ...baseStyles,
       display: "flex",
@@ -224,17 +219,12 @@ const TeamsDropdown = ({
     valueContainer: (baseStyles) => ({
       ...baseStyles,
       padding: 0,
-      // overflow: "hidden",
     }),
     input: (baseStyles) => ({
       ...baseStyles,
       overflow: "hidden",
       textOverflow: "ellipsis",
       whiteSpace: "nowrap",
-      // Ensure the cursor remains visible during typing
-      // caretColor: COLORS["core-fleet-black"],
-      // Prevent the input from expanding beyond its container
-      // maxWidth: "100%",
     }),
     option: (baseStyles, state) => ({
       ...baseStyles,

--- a/frontend/components/TeamsDropdown/TeamsDropdown.tsx
+++ b/frontend/components/TeamsDropdown/TeamsDropdown.tsx
@@ -9,6 +9,8 @@ import Select, {
 
 import { COLORS } from "styles/var/colors";
 import { PADDING } from "styles/var/padding";
+import { FONT_SIZES, FONT_WEIGHTS } from "styles/var/fonts";
+
 import classnames from "classnames";
 
 import { IDropdownOption } from "interfaces/dropdownOption";
@@ -119,10 +121,9 @@ const TeamsDropdown = ({
   };
 
   // see https://react-select.com/styles#the-styles-prop
-  // `provided` here corresponds to `baseStyles` in the docs
   const customStyles: StylesConfig<INumberDropdownOption, false> = {
-    control: (provided, state) => ({
-      ...provided,
+    control: (baseStyles, state) => ({
+      ...baseStyles,
       display: "flex",
       flexDirection: "row",
       padding: "8px 0",
@@ -171,8 +172,8 @@ const TeamsDropdown = ({
         },
       }),
     }),
-    singleValue: (provided) => ({
-      ...provided,
+    singleValue: (baseStyles) => ({
+      ...baseStyles,
       fontSize: "24px",
       lineHeight: "normal",
       paddingLeft: 0,
@@ -181,8 +182,8 @@ const TeamsDropdown = ({
       // omit grid-column-end for automatic width
       gridArea: "1/1/2",
     }),
-    dropdownIndicator: (provided) => ({
-      ...provided,
+    dropdownIndicator: (baseStyles) => ({
+      ...baseStyles,
       display: "flex",
       padding: "2px",
       margin: "0 5px",
@@ -190,8 +191,8 @@ const TeamsDropdown = ({
         transition: "transform 0.25s ease",
       },
     }),
-    menu: (provided) => ({
-      ...provided,
+    menu: (baseStyles) => ({
+      ...baseStyles,
       boxShadow: "0 2px 6px rgba(0, 0, 0, 0.1)",
       borderRadius: "4px",
       zIndex: 6,
@@ -205,16 +206,22 @@ const TeamsDropdown = ({
       animation: "fade-in 150ms ease-out",
     }),
     // Placeholder is never shown on teams dropdown
-    menuList: (provided) => ({
-      ...provided,
+    menuList: (baseStyles) => ({
+      ...baseStyles,
       padding: PADDING["pad-small"],
+      ".team-dropdown__menu-notice--no-options": {
+        textAlign: "left",
+        color: COLORS["ui-fleet-black-50"],
+        fontSize: FONT_SIZES["xx-small"],
+        fontWeight: FONT_WEIGHTS.regular,
+      },
     }),
-    valueContainer: (provided) => ({
-      ...provided,
+    valueContainer: (baseStyles) => ({
+      ...baseStyles,
       padding: 0,
     }),
-    option: (provided, state) => ({
-      ...provided,
+    option: (baseStyles, state) => ({
+      ...baseStyles,
       padding: "10px 8px",
       fontSize: "14px",
       borderRadius: "4px",
@@ -251,7 +258,8 @@ const TeamsDropdown = ({
             // If newValue is null or undefined, we don't call onChange
           }}
           isDisabled={isDisabled}
-          isSearchable={false}
+          isSearchable
+          noOptionsMessage={() => "No matching teams"}
           styles={customStyles}
           components={{
             DropdownIndicator: CustomDropdownIndicator,

--- a/frontend/components/TeamsDropdown/TeamsDropdown.tsx
+++ b/frontend/components/TeamsDropdown/TeamsDropdown.tsx
@@ -143,9 +143,6 @@ const TeamsDropdown = ({
       // When tabbing
       // Relies on --is-focused for styling as &:focus-visible cannot be applied
       "&.team-dropdown__control--is-focused": {
-        ".team-dropdown__single-value": {
-          color: COLORS["core-vibrant-blue-over"],
-        },
         ".team-dropdown__indicator path": {
           stroke: COLORS["core-vibrant-blue-over"],
         },

--- a/frontend/pages/queries/ManageQueriesPage/_styles.scss
+++ b/frontend/pages/queries/ManageQueriesPage/_styles.scss
@@ -12,6 +12,10 @@
     }
   }
 
+  &__manage-automations {
+    white-space: nowrap;
+  }
+
   &__text {
     margin-right: $pad-large;
   }

--- a/frontend/styles/var/fonts.ts
+++ b/frontend/styles/var/fonts.ts
@@ -1,0 +1,16 @@
+import pxToRem from "./helpers";
+
+export const FONT_SIZES = {
+  "xxx-small": pxToRem(10),
+  "xx-small": pxToRem(12),
+  "x-small": pxToRem(14),
+  small: pxToRem(16),
+  medium: pxToRem(20),
+  large: pxToRem(24),
+  "x-large": pxToRem(28),
+};
+
+export const FONT_WEIGHTS = {
+  regular: 400,
+  bold: 700,
+};

--- a/frontend/styles/var/helpers.ts
+++ b/frontend/styles/var/helpers.ts
@@ -1,0 +1,6 @@
+const pxToRem = (px: number): string => {
+  const baseSize = 16; // Assuming the base font size is 16px
+  return `${px / baseSize}rem`;
+};
+
+export default pxToRem;

--- a/frontend/styles/var/padding.ts
+++ b/frontend/styles/var/padding.ts
@@ -1,7 +1,4 @@
-const pxToRem = (px: number): string => {
-  const baseSize = 16; // Assuming the base font size is 16px
-  return `${px / baseSize}rem`;
-};
+import pxToRem from "./helpers";
 
 export const PADDING = {
   "pad-auto": "auto",

--- a/todo
+++ b/todo
@@ -1,0 +1,2 @@
+- Ensure as input scrolls other element take priority, and input text is hidden on left side, as
+  normal form input

--- a/todo
+++ b/todo
@@ -1,3 +1,0 @@
-- Dial in "manage automations" button
-- Confirm in all instances of `TeamsDropdown`, `TeamsHeader`, `TeamDetailsWeapper`. The last two
-  wrap the first.

--- a/todo
+++ b/todo
@@ -1,2 +1,3 @@
-- Ensure as input scrolls other element take priority, and input text is hidden on left side, as
-  normal form input
+- Dial in "manage automations" button
+- Confirm in all instances of `TeamsDropdown`, `TeamsHeader`, `TeamDetailsWeapper`. The last two
+  wrap the first.


### PR DESCRIPTION
## For #28822 

- Enable searching the teams dropdown
- Ensure right-scrolling per usual text input fields when search text is long
- Ensure neighboring elements are not moved when search text is long

![ezgif-5b014b0a03dc31](https://github.com/user-attachments/assets/30f98ea6-c7f8-4566-bfef-4e1a6eb0b55d)

- [x] Changes file added for user-visible changes in `changes/`
- [x] Manual QA for all new/changed functionality