### PR TITLE
Remove stray Fleet Maintained App manifest location overrides

### DIFF
--- a/tools/osquery/in-a-box/docker-compose.yml
+++ b/tools/osquery/in-a-box/docker-compose.yml
@@ -59,7 +59,6 @@ services:
       # This can be configured for testing purposes but otherwise uses the
       # typical default of provided.
       FLEET_OSQUERY_HOST_IDENTIFIER: ${FLEET_OSQUERY_HOST_IDENTIFIER:-provided}
-      FLEET_DEV_MAINTAINED_APPS_BASE_URL: https://raw.githubusercontent.com/fleetdm/fleet/512cb66b456d8f5c3203a5c125d1b293dc628eaf/ee/maintained-apps/outputs
     depends_on:
       - mysql01
       - redis01
@@ -109,7 +108,6 @@ services:
       # This can be configured for testing purposes but otherwise uses the
       # typical default of provided.
       FLEET_OSQUERY_HOST_IDENTIFIER: ${FLEET_OSQUERY_HOST_IDENTIFIER:-provided}
-      FLEET_DEV_MAINTAINED_APPS_BASE_URL: https://raw.githubusercontent.com/fleetdm/fleet/512cb66b456d8f5c3203a5c125d1b293dc628eaf/ee/maintained-apps/outputs
     depends_on:
       - mysql01
       - redis01


### PR DESCRIPTION
By default, we shouldn't override FMA manifest locations, and these overrides pinned manifests to a specific, outdated commit. Stray lines added in 1353b9cbc46000cf159753872287aadcc39fa98d, merged as part of #20974.