### PR TITLE
Update go to `1.24.4` and add some automation

### DIFF
--- a/Dockerfile-desktop-linux
+++ b/Dockerfile-desktop-linux
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 golang:1.24.4-bullseye@sha256:f50ff25f8331682b44c1582974eb9e620fcb08052fc6ed434f93ca24636fc4d6
+FROM --platform=linux/amd64 golang:1.24.4-bullseye@sha256:dfd72198d14bc22f270c9e000c304a2ffd19f5a5f693fad82643311afdc6b568
 LABEL maintainer="Fleet Developers"
 
 RUN mkdir -p /usr/src/fleet

--- a/Dockerfile-desktop-linux
+++ b/Dockerfile-desktop-linux
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 golang:1.24.2-bullseye@sha256:f50ff25f8331682b44c1582974eb9e620fcb08052fc6ed434f93ca24636fc4d6
+FROM --platform=linux/amd64 golang:1.24.4-bullseye@sha256:f50ff25f8331682b44c1582974eb9e620fcb08052fc6ed434f93ca24636fc4d6
 LABEL maintainer="Fleet Developers"
 
 RUN mkdir -p /usr/src/fleet

--- a/Makefile
+++ b/Makefile
@@ -836,4 +836,19 @@ vex-report:
 	sh -c 'echo "## \`fleetdm/fleetctl\` docker image\n" >> security/status.md'
 	sh -c 'go run ./tools/vex-parser ./security/vex/fleetctl >> security/status.md'
 
+# make update-go version=1.24.4
+UPDATE_GO_DOCKERFILES := ./Dockerfile-desktop-linux ./infrastructure/loadtesting/terraform/docker/loadtest.Dockerfile ./tools/mdm/migration/mdmproxy/Dockerfile
+UPDATE_GO_MODS := go.mod ./tools/mdm/windows/bitlocker/go.mod ./tools/snapshot/go.mod ./tools/terraform/go.mod
+update-go:
+	@test $(version) || (echo "Mising 'version' argument, usage: 'make update-go version=1.24.4'" ; exit 1)
+	@for dockerfile in $(UPDATE_GO_DOCKERFILES) ; do \
+		go run ./tools/tuf/replace $$dockerfile "golang:.+-" "golang:$(version)-" ; \
+		echo "Please update sha256 in $$dockerfile" ; \
+	done
+	@for gomod in $(UPDATE_GO_MODS) ; do \
+		go run ./tools/tuf/replace $$gomod "(?m)^go .+$$" "go $(version)" ; \
+	done
+	@echo "* Updated go to $(version)" > changes/update-go-$(version)
+	@cp changes/update-go-$(version) orbit/changes/update-go-$(version)
+
 include ./tools/makefile-support/helpsystem-targets

--- a/changes/update-go-1.24.4
+++ b/changes/update-go-1.24.4
@@ -1,0 +1,1 @@
+* Updated go to 1.24.4

--- a/docs/Contributing/workflows/upgrading-go-version.md
+++ b/docs/Contributing/workflows/upgrading-go-version.md
@@ -16,15 +16,7 @@ See the "Go linter" section below about upgrading the Go linter version.
 
 ### Go.mod
 
-Update the Go version in [the main go.mod file in Fleet](https://github.com/fleetdm/fleet/blob/main/go.mod) to the new version.
-
-Also update the version in the go.mod files of compiled tools including:
-
-  * [Bitlocker manager](https://github.com/fleetdm/fleet/blob/main/tools/mdm/windows/bitlocker/go.mod)
-  * [DB snapshot](https://github.com/fleetdm/fleet/blob/main/tools/snapshot/go.mod)
-  * [Fleet teams terraform provider](https://github.com/fleetdm/fleet/blob/main/tools/terraform/go.mod)
-
-Do a search for go.mod files to find others that may need updating!
+Run `make update-go version=1.24.4` and update the SHA256 of the updated Dockerfiles manually.
 
 ### Go Linter
 

--- a/docs/Contributing/workflows/upgrading-go-version.md
+++ b/docs/Contributing/workflows/upgrading-go-version.md
@@ -12,9 +12,7 @@ go install github.com/golangci/golangci-lint/cmd/golangci-lint@<your golangci-li
 
 See the "Go linter" section below about upgrading the Go linter version.
 
-## Files to update
-
-### Go.mod
+## Upgrading go for all Fleet
 
 Run `make update-go version=1.24.4` and update the SHA256 of the updated Dockerfiles manually.
 
@@ -23,14 +21,6 @@ Run `make update-go version=1.24.4` and update the SHA256 of the updated Dockerf
 The golangci-lint linter used in the [golangci-lint](https://github.com/fleetdm/fleet/actions/workflows/golangci-lint.yml) Github action needs to support the new version of Go.  The linter typically keeps up with Go versions so that the latest version of golangci-lint should support the latest version of Go, but it's worth checking the [changelog](https://github.com/golangci/golangci-lint/blob/main/CHANGELOG.md) to see if it's time for an upgrade. If so, get the commit SHA of the version you'd like to use by finding [its tag on Github](https://github.com/golangci/golangci-lint/tags), clicking on the commit link under the tag name, and copying the full SHA from the URL.  Update the current `go install github.com/golangci/golangci-lint/cmd/golangci-lint` line in the .yml file with the new SHA, and update the comment to indicate the new version. 
 
 Update the instructions in the [Testing and local development doc](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/getting-started/testing-and-local-development.md#test-suite) to reflect the new version of golangci-lint.
-
-### Docker files
-
-Find the `bullseye` and `alpine` variants of the Docker images for the new Go version on [Dockerhub](https://hub.docker.com/_/golang).  Then update any Dockerfiles to pull the new images, including:
-
-  * [Dockerfile-desktop-linux](https://github.com/fleetdm/fleet/blob/main/Dockerfile-desktop-linux)
-  * [loadtest.Dockerfile](https://github.com/fleetdm/fleet/blob/main/infrastructure/loadtesting/terraform/docker/loadtest.Dockerfile_)
-  * [mdmproxy/Dockerfile](https://github.com/fleetdm/fleet/blob/main/tools/mdm/migration/mdmproxy/Dockerfile)
 
 ## Smoke-testing the new version locally
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/fleetdm/fleet/v4
 
-go 1.24.2
+go 1.24.4
 
 require (
 	cloud.google.com/go/pubsub v1.45.1

--- a/infrastructure/loadtesting/terraform/docker/loadtest.Dockerfile
+++ b/infrastructure/loadtesting/terraform/docker/loadtest.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24.4-alpine3.21@sha256:7772cb5322baa875edd74705556d08f0eeca7b9c4b5367754ce3f2f00041ccee
+FROM golang:1.24.4-alpine3.21@sha256:56a23791af0f77c87b049230ead03bd8c3ad41683415ea4595e84ce7eada121a
 ARG TAG
 RUN apk add git
 RUN git clone -b $TAG --depth=1 --no-tags --progress --no-recurse-submodules https://github.com/fleetdm/fleet.git && cd /go/fleet/cmd/osquery-perf/ && go build .

--- a/infrastructure/loadtesting/terraform/docker/loadtest.Dockerfile
+++ b/infrastructure/loadtesting/terraform/docker/loadtest.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24.2-alpine3.21@sha256:7772cb5322baa875edd74705556d08f0eeca7b9c4b5367754ce3f2f00041ccee
+FROM golang:1.24.4-alpine3.21@sha256:7772cb5322baa875edd74705556d08f0eeca7b9c4b5367754ce3f2f00041ccee
 ARG TAG
 RUN apk add git
 RUN git clone -b $TAG --depth=1 --no-tags --progress --no-recurse-submodules https://github.com/fleetdm/fleet.git && cd /go/fleet/cmd/osquery-perf/ && go build .

--- a/orbit/changes/update-go-1.24.4
+++ b/orbit/changes/update-go-1.24.4
@@ -1,0 +1,1 @@
+* Updated go to 1.24.4

--- a/tools/mdm/migration/mdmproxy/Dockerfile
+++ b/tools/mdm/migration/mdmproxy/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24.4-alpine3.21@sha256:7772cb5322baa875edd74705556d08f0eeca7b9c4b5367754ce3f2f00041ccee
+FROM golang:1.24.4-alpine3.21@sha256:56a23791af0f77c87b049230ead03bd8c3ad41683415ea4595e84ce7eada121a
 ARG TAG
 RUN apk update && apk add --no-cache git
 RUN git clone -b $TAG --depth=1 --no-tags --progress --no-recurse-submodules https://github.com/fleetdm/fleet.git && cd /go/fleet/tools/mdm/migration/mdmproxy && go build .

--- a/tools/mdm/migration/mdmproxy/Dockerfile
+++ b/tools/mdm/migration/mdmproxy/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24.2-alpine3.21@sha256:7772cb5322baa875edd74705556d08f0eeca7b9c4b5367754ce3f2f00041ccee
+FROM golang:1.24.4-alpine3.21@sha256:7772cb5322baa875edd74705556d08f0eeca7b9c4b5367754ce3f2f00041ccee
 ARG TAG
 RUN apk update && apk add --no-cache git
 RUN git clone -b $TAG --depth=1 --no-tags --progress --no-recurse-submodules https://github.com/fleetdm/fleet.git && cd /go/fleet/tools/mdm/migration/mdmproxy && go build .

--- a/tools/mdm/windows/bitlocker/go.mod
+++ b/tools/mdm/windows/bitlocker/go.mod
@@ -1,6 +1,6 @@
 module bitlocker
 
-go 1.24.2
+go 1.24.4
 
 require github.com/go-ole/go-ole v1.3.0
 

--- a/tools/snapshot/go.mod
+++ b/tools/snapshot/go.mod
@@ -1,6 +1,6 @@
 module github.com/fleetdm/fleet/v4/tools/snapshot
 
-go 1.24.2
+go 1.24.4
 
 require (
 	github.com/manifoldco/promptui v0.9.0

--- a/tools/terraform/go.mod
+++ b/tools/terraform/go.mod
@@ -1,6 +1,6 @@
 module terraform-provider-fleetdm
 
-go 1.24.2
+go 1.24.4
 
 require (
 	github.com/hashicorp/terraform-plugin-framework v1.7.0


### PR DESCRIPTION
Fixes CVE-2025-22874 reported by https://github.com/fleetdm/fleet/actions/runs/15601368321/job/43941793647.

(IMO not a critical CVE, so it doesn't need to be cherry-picked into v4.69.0.)

Added automation to make this easier next time.