### PR TITLE
Fleet UI: Remove unsupported sorting arrows from host software table

### DIFF
--- a/changes/29447-hide-broken-sort-ui
+++ b/changes/29447-hide-broken-sort-ui
@@ -1,0 +1,1 @@
+- Fleet UI: Removed sort column buttons for host software columns that do not support sorting

--- a/frontend/pages/hosts/details/cards/Software/HostSoftwareTableConfig.tsx
+++ b/frontend/pages/hosts/details/cards/Software/HostSoftwareTableConfig.tsx
@@ -217,6 +217,7 @@ export const generateSoftwareTableHeaders = ({
               Install status
             </TooltipWrapper>
           }
+          disableSortBy
         />
       ),
       disableSortBy: true,
@@ -241,6 +242,7 @@ export const generateSoftwareTableHeaders = ({
               Installed version
             </TooltipWrapper>
           }
+          disableSortBy
         />
       ),
       id: "version",


### PR DESCRIPTION
## Issue
Closes #29447 

## Description
- Note: Both install status and install version are not supported as server side sort in the API
- Remove them from the UI

## Screenshot of fix
<img width="1683" alt="Screenshot 2025-06-12 at 1 30 36 PM" src="https://github.com/user-attachments/assets/c1ad6e79-ea56-463b-b08a-b9ccd2c6b0f4" />


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [ ] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
- [x] Manual QA for all new/changed functionality