### PR TITLE
Product design rituals: Design sprint review/kickoff -> Product design sprint review/kickoff

### DIFF
--- a/handbook/product-design/product-design.rituals.yml
+++ b/handbook/product-design/product-design.rituals.yml
@@ -1,5 +1,5 @@
 -
-  task: "🦢📊 Design sprint review" # 2024-03-06 TODO: Link to responsibility or corresponding "how to" info e.g. https://fleetdm.com/handbook/company/product-groups#making-changes
+  task: "🦢📊 Product design sprint review" # 2024-03-06 TODO: Link to responsibility or corresponding "how to" info e.g. https://fleetdm.com/handbook/company/product-groups#making-changes
   startedOn: "2024-03-07" 
   frequency: "Triweekly" 
   description: "1. For all stories that are not estimated, move them on the roadmap chart and add their respective customer requests to the feature fest board. For stories that we're no longer working on, remove them from the drafting board and roadmap chart, remove their respective customer requests from the 💝 Customer requests board, and notify stakeholders. 2. Retro: What went well? What could go better? What to remember for next time?" 
@@ -13,7 +13,7 @@
   moreInfoUrl: "https://fleetdm.com/handbook/company/product-groups#feature-fest"
   dri: "noahtalerman" 
 -
-  task: "Design sprint kickoff" # 2024-03-06 TODO: Link to responsibility or corresponding "how to" info e.g. https://fleetdm.com/handbook/company/product-groups#making-changes
+  task: "Product design sprint kickoff" # 2024-03-06 TODO: Link to responsibility or corresponding "how to" info e.g. https://fleetdm.com/handbook/company/product-groups#making-changes
   startedOn: "2024-03-07" 
   frequency: "Triweekly" 
   description: "Review stories (and, as needed, create engineering research stories) for feature requests prioritized during Feature fest; assign Engineering DRIs to stories; align on priorities; and create an upcoming reference docs release branch."


### PR DESCRIPTION
Why? Because @mike-j-thomas is the DRI for the visual/brand design and it makes that distinction a bit clearer. (Basically, anything that’s heavier on the visual design and not product design, e.g. design system stuff, should involve him, and sounds like we should try to loop him in more going forward to make sure there’s not a mismatch between the product itself and the brand.)
