### PR TITLE
Fleet UI: Default actor to 'Fleet' for activity items with no actors …

### DIFF
--- a/changes/29897-missing-actor
+++ b/changes/29897-missing-actor
@@ -1,0 +1,1 @@
+- Fleet UI: Defaulted actor to Fleet for missing activity actor information

--- a/frontend/interfaces/activity.ts
+++ b/frontend/interfaces/activity.ts
@@ -148,9 +148,9 @@ export type IHostUpcomingActivityType =
 export interface IActivity {
   created_at: string;
   id: number;
-  actor_full_name: string;
-  actor_id: number;
-  actor_gravatar: string;
+  actor_full_name?: string; // Undefined if fleet initiated / self-service
+  actor_id?: number; // Undefined if fleet initiated / self-service
+  actor_gravatar?: string; // Undefined if fleet initiated / self-service
   actor_email?: string;
   type: ActivityType;
   fleet_initiated: boolean;

--- a/frontend/pages/DashboardPage/cards/ActivityFeed/GlobalActivityItem/GlobalActivityItem.tests.tsx
+++ b/frontend/pages/DashboardPage/cards/ActivityFeed/GlobalActivityItem/GlobalActivityItem.tests.tsx
@@ -27,6 +27,43 @@ describe("Activity Feed", () => {
     expect(screen.getByText("2 days ago")).toBeInTheDocument();
   });
 
+  it("renders 'Fleet' as actor when fleet_initiated is set to true", async () => {
+    const currentDate = new Date();
+    currentDate.setDate(currentDate.getDate() - 2);
+
+    const activity = createMockActivity({
+      fleet_initiated: true,
+    });
+
+    render(<GlobalActivityItem activity={activity} isPremiumTier />);
+
+    // waiting for the activity data to render
+    await screen.findByText("Fleet");
+
+    expect(screen.queryByText("Test User")).not.toBeInTheDocument();
+    expect(screen.getByText("Fleet")).toBeInTheDocument();
+  });
+
+  it("renders 'Fleet' as actor when no actor information and fleet_initiated is set to false", async () => {
+    const currentDate = new Date();
+    currentDate.setDate(currentDate.getDate() - 2);
+
+    const activity = createMockActivity({
+      actor_email: "",
+      actor_full_name: undefined,
+      actor_id: undefined,
+      actor_gravatar: undefined,
+    });
+
+    render(<GlobalActivityItem activity={activity} isPremiumTier />);
+
+    // waiting for the activity data to render
+    await screen.findByText("Fleet");
+
+    expect(screen.queryByText("Test User")).not.toBeInTheDocument();
+    expect(screen.getByText("Fleet")).toBeInTheDocument();
+  });
+
   it("renders a default activity for activities without a specific message", () => {
     const activity = createMockActivity({
       type: ActivityType.CreatedPack,
@@ -705,7 +742,7 @@ describe("Activity Feed", () => {
       screen.getByText((content, node) => {
         return (
           node?.innerHTML ===
-          "<b>Test User </b> changed the macOS Setup Assistant (added <b>dep-profile.json</b>) for hosts that automatically enroll to no team."
+          "<b>Test User</b> changed the macOS Setup Assistant (added <b>dep-profile.json</b>) for hosts that automatically enroll to no team."
         );
       })
     ).toBeInTheDocument();
@@ -722,7 +759,7 @@ describe("Activity Feed", () => {
       screen.getByText((content, node) => {
         return (
           node?.innerHTML ===
-          "<b>Test User </b> changed the macOS Setup Assistant (added <b>dep-profile.json</b>) for hosts  that automatically enroll to the <b>Workstations</b> team."
+          "<b>Test User</b> changed the macOS Setup Assistant (added <b>dep-profile.json</b>) for hosts  that automatically enroll to the <b>Workstations</b> team."
         );
       })
     ).toBeInTheDocument();
@@ -739,7 +776,7 @@ describe("Activity Feed", () => {
       screen.getByText((content, node) => {
         return (
           node?.innerHTML ===
-          "<b>Test User </b> changed the macOS Setup Assistant (deleted <b>dep-profile.json</b>) for hosts that automatically enroll to no team."
+          "<b>Test User</b> changed the macOS Setup Assistant (deleted <b>dep-profile.json</b>) for hosts that automatically enroll to no team."
         );
       })
     ).toBeInTheDocument();
@@ -756,7 +793,7 @@ describe("Activity Feed", () => {
       screen.getByText((content, node) => {
         return (
           node?.innerHTML ===
-          "<b>Test User </b> changed the macOS Setup Assistant (deleted <b>dep-profile.json</b>) for hosts  that automatically enroll to the <b>Workstations</b> team."
+          "<b>Test User</b> changed the macOS Setup Assistant (deleted <b>dep-profile.json</b>) for hosts  that automatically enroll to the <b>Workstations</b> team."
         );
       })
     ).toBeInTheDocument();
@@ -995,7 +1032,7 @@ describe("Activity Feed", () => {
       screen.getByText((content, node) => {
         return (
           node?.innerHTML ===
-          "<b>Test User </b>An end user turned on MDM features for a host with serial number <b>ABCD (manual)</b>."
+          "An end user turned on MDM features for a host with serial number <b>ABCD (manual)</b>."
         );
       })
     ).toBeInTheDocument();
@@ -1016,7 +1053,7 @@ describe("Activity Feed", () => {
       screen.getByText((content, node) => {
         return (
           node?.innerHTML ===
-          "<b>Test User </b>An end user turned on MDM features for a host with serial number <b>ABCD (automatic)</b>."
+          "An end user turned on MDM features for a host with serial number <b>ABCD (automatic)</b>."
         );
       })
     ).toBeInTheDocument();
@@ -1036,7 +1073,7 @@ describe("Activity Feed", () => {
       screen.getByText((content, node) => {
         return (
           node?.innerHTML ===
-          "<b>Test User </b>Mobile device management (MDM) was turned on for <b>ABCD (manual)</b>."
+          "Mobile device management (MDM) was turned on for <b>ABCD (manual)</b>."
         );
       })
     ).toBeInTheDocument();

--- a/frontend/pages/DashboardPage/cards/ActivityFeed/GlobalActivityItem/GlobalActivityItem.tsx
+++ b/frontend/pages/DashboardPage/cards/ActivityFeed/GlobalActivityItem/GlobalActivityItem.tsx
@@ -1481,32 +1481,33 @@ const GlobalActivityItem = ({
   isPremiumTier,
   onDetailsClick = noop,
 }: IActivityItemProps) => {
+  const {
+    actor_full_name: actorName,
+    actor_email: actorEmail,
+    actor_id: actorId,
+    details,
+  } = activity;
+  const { user_email: userEmail, user_id: userId, self_service: selfService } =
+    details || {};
+
   const hasDetails = ACTIVITIES_WITH_DETAILS.has(activity.type);
 
   const renderActivityPrefix = () => {
-    const DEFAULT_ACTOR_DISPLAY = (
-      <b>{activity.fleet_initiated ? "Fleet" : activity.actor_full_name} </b>
-    );
+    // Includes edge case where actor_full_name is not set and fleet_initiated is false
+    // Edge case should never happen as users searching fleet_initiated activities
+    // expect to view all "Fleet" activities.
+    const DEFAULT_ACTOR_DISPLAY = <b>{actorName || "Fleet"}</b>;
 
     switch (activity.type) {
       case ActivityType.UserLoggedIn:
-        return <b>{activity.actor_email} </b>;
+        return <b>{actorEmail} </b>;
       case ActivityType.UserChangedGlobalRole:
       case ActivityType.UserChangedTeamRole:
-        return activity.actor_id === activity.details?.user_id ? (
-          <b>{activity.details?.user_email} </b>
-        ) : (
-          DEFAULT_ACTOR_DISPLAY
-        );
+        return actorId === userId ? <b>{userEmail}</b> : DEFAULT_ACTOR_DISPLAY;
       case ActivityType.InstalledSoftware:
       case ActivityType.UninstalledSoftware:
       case ActivityType.InstalledAppStoreApp:
-        return activity.details?.self_service ? (
-          <span>An end user</span>
-        ) : (
-          DEFAULT_ACTOR_DISPLAY
-        );
-
+        return selfService ? <span>An end user</span> : DEFAULT_ACTOR_DISPLAY;
       default:
         return DEFAULT_ACTOR_DISPLAY;
     }

--- a/frontend/pages/DashboardPage/cards/ActivityFeed/GlobalActivityItem/GlobalActivityItem.tsx
+++ b/frontend/pages/DashboardPage/cards/ActivityFeed/GlobalActivityItem/GlobalActivityItem.tsx
@@ -261,6 +261,7 @@ const TAGGED_TEMPLATES = {
     );
     return <>{hostDisplayName} enrolled in Fleet.</>;
   },
+  // TODO: Look into actor inconsistency
   mdmEnrolled: (activity: IActivity) => {
     if (activity.details?.mdm_platform === "microsoft") {
       return (
@@ -1485,6 +1486,7 @@ const GlobalActivityItem = ({
     actor_full_name: actorName,
     actor_email: actorEmail,
     actor_id: actorId,
+    fleet_initiated: fleetInitiated,
     details,
   } = activity;
   const { user_email: userEmail, user_id: userId, self_service: selfService } =
@@ -1496,7 +1498,9 @@ const GlobalActivityItem = ({
     // Includes edge case where actor_full_name is not set and fleet_initiated is false
     // Edge case should never happen as users searching fleet_initiated activities
     // expect to view all "Fleet" activities.
-    const DEFAULT_ACTOR_DISPLAY = <b>{actorName || "Fleet"}</b>;
+    const DEFAULT_ACTOR_DISPLAY = (
+      <b>{fleetInitiated ? "Fleet" : actorName || "Fleet"}</b>
+    );
 
     switch (activity.type) {
       case ActivityType.UserLoggedIn:
@@ -1508,6 +1512,11 @@ const GlobalActivityItem = ({
       case ActivityType.UninstalledSoftware:
       case ActivityType.InstalledAppStoreApp:
         return selfService ? <span>An end user</span> : DEFAULT_ACTOR_DISPLAY;
+      // Does not render actor for MDM enrollments
+      // Currently uses custom actor within activity copy
+      // TODO: Look into fixing to be consistent with other activities
+      case ActivityType.MdmEnrolled:
+        return undefined;
       default:
         return DEFAULT_ACTOR_DISPLAY;
     }

--- a/frontend/pages/hosts/details/cards/Software/SelfService/SelfService.tsx
+++ b/frontend/pages/hosts/details/cards/Software/SelfService/SelfService.tsx
@@ -397,7 +397,7 @@ const SoftwareSelfService = ({
               info={
                 <>
                   Not finding what you&apos;re looking for?{" "}
-                  <CustomLink url={contactUrl} text="reach out to IT" newTab />
+                  <CustomLink url={contactUrl} text="Reach out to IT" newTab />
                 </>
               }
             />


### PR DESCRIPTION
## Issue
Closes #29897 

## Description
- Add default actor as "Fleet" whether `fleet_initiated` is set to true or not
- Random capitalization fix

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
- [ ] Added/updated automated tests
- [x] Manual QA for all new/changed functionality

