### PR TITLE
Terraform fixes for Dogfood AWS resources

### DIFF
--- a/infrastructure/dogfood/terraform/aws-tf-module/main.tf
+++ b/infrastructure/dogfood/terraform/aws-tf-module/main.tf
@@ -75,7 +75,7 @@ locals {
 }
 
 module "main" {
-  source          = "github.com/fleetdm/fleet-terraform?ref=tf-mod-root-v1.15.1"
+  source          = "github.com/fleetdm/fleet-terraform?ref=tf-mod-root-v1.15.2"
   certificate_arn = module.acm.acm_certificate_arn
   vpc = {
     name = local.customer
@@ -162,6 +162,9 @@ module "main" {
       bucket_prefix  = "${local.customer}-software-installers-"
       create_kms_key = true
       kms_alias      = "${local.customer}-software-installers"
+      enable_bucket_versioning           = true
+      expire_noncurrent_versions         = true
+      noncurrent_version_expiration_days = 30
       tags = {
         backup = "true"
       }


### PR DESCRIPTION
- Fixing software installers versioning preventing AWS Backups from completing successfully
- Bumped version of tf-mod-root from v1.15.1 -> v1.15.2