### PR TITLE
Add VEX statements for libxml2 CVEs

### DIFF
--- a/security/status.md
+++ b/security/status.md
@@ -85,6 +85,30 @@ Following is the vulnerability report of Fleet and its dependencies.
 
 ## `fleetdm/fleetctl` docker image
 
+### [CVE-2025-49796](https://nvd.nist.gov/vuln/detail/CVE-2025-49796)
+- **Author:** @sgress454
+- **Status:** `not_affected`
+- **Status notes:** The affected dependency (libxml2) is not utilized by fleetctl itself, but by Apple’s iTMSTransporter tool, which is included in the Docker image for code signing purposes. fleetctl does not process untrusted XML input. Additionally, this CVE describes a denial-of-service (DoS) vulnerability, and fleetctl is a CLI tool, not a long-running service, and therefore is not susceptible to DoS-style exploitation.
+- **Products:**: `fleetctl`,`pkg:deb/debian/libxml2@2.9.14+dfsg-1.3~deb12u1`
+- **Justification:** `vulnerable_code_cannot_be_controlled_by_adversary`
+- **Timestamp:** 2025-06-13 15:57:38
+
+### [CVE-2025-49795](https://nvd.nist.gov/vuln/detail/CVE-2025-49795)
+- **Author:** @sgress454
+- **Status:** `not_affected`
+- **Status notes:** The affected dependency (libxml2) is not utilized by fleetctl itself, but by Apple’s iTMSTransporter tool, which is included in the Docker image for code signing purposes. fleetctl does not process untrusted XML input. Additionally, this CVE describes a denial-of-service (DoS) vulnerability, and fleetctl is a CLI tool, not a long-running service, and therefore is not susceptible to DoS-style exploitation.
+- **Products:**: `fleetctl`,`pkg:deb/debian/libxml2@2.9.14+dfsg-1.3~deb12u1`
+- **Justification:** `vulnerable_code_cannot_be_controlled_by_adversary`
+- **Timestamp:** 2025-06-13 15:57:25
+
+### [CVE-2025-49794](https://nvd.nist.gov/vuln/detail/CVE-2025-49794)
+- **Author:** @sgress454
+- **Status:** `not_affected`
+- **Status notes:** The affected dependency (libxml2) is not utilized by fleetctl itself, but by Apple’s iTMSTransporter tool, which is included in the Docker image for code signing purposes. fleetctl does not process untrusted XML input. Additionally, this CVE describes a denial-of-service (DoS) vulnerability, and fleetctl is a CLI tool, not a long-running service, and therefore is not susceptible to DoS-style exploitation.
+- **Products:**: `fleetctl`,`pkg:deb/debian/libxml2@2.9.14+dfsg-1.3~deb12u1`
+- **Justification:** `vulnerable_code_cannot_be_controlled_by_adversary`
+- **Timestamp:** 2025-06-13 15:56:50
+
 ### [CVE-2025-48734](https://nvd.nist.gov/vuln/detail/CVE-2025-48734)
 - **Author:** @lucasmrod
 - **Status:** `not_affected`

--- a/security/vex/fleetctl/CVE-2025-49794.vex.json
+++ b/security/vex/fleetctl/CVE-2025-49794.vex.json
@@ -1,0 +1,26 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://openvex.dev/docs/public/vex-0d76bd54f63d6d91f27e0e2fbf7f7214f9d7ef7b9930b1fbd177ae7a37d51a24",
+  "author": "@sgress454",
+  "timestamp": "2025-06-13T15:56:50.936171-05:00",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2025-49794"
+      },
+      "timestamp": "2025-06-13T15:56:50.936172-05:00",
+      "products": [
+        {
+          "@id": "fleetctl"
+        },
+        {
+          "@id": "pkg:deb/debian/libxml2@2.9.14+dfsg-1.3~deb12u1"
+        }
+      ],
+      "status": "not_affected",
+      "status_notes": "The affected dependency (libxml2) is not utilized by fleetctl itself, but by Apple’s iTMSTransporter tool, which is included in the Docker image for code signing purposes. fleetctl does not process untrusted XML input. Additionally, this CVE describes a denial-of-service (DoS) vulnerability, and fleetctl is a CLI tool, not a long-running service, and therefore is not susceptible to DoS-style exploitation.",
+      "justification": "vulnerable_code_cannot_be_controlled_by_adversary"
+    }
+  ]
+}

--- a/security/vex/fleetctl/CVE-2025-49795.vex.json
+++ b/security/vex/fleetctl/CVE-2025-49795.vex.json
@@ -1,0 +1,26 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://openvex.dev/docs/public/vex-c1cf95164110186b3a59e9e45be982301ad580c2d950b33d2537cb4461ab9bf1",
+  "author": "@sgress454",
+  "timestamp": "2025-06-13T15:57:25.659708-05:00",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2025-49795"
+      },
+      "timestamp": "2025-06-13T15:57:25.659709-05:00",
+      "products": [
+        {
+          "@id": "fleetctl"
+        },
+        {
+          "@id": "pkg:deb/debian/libxml2@2.9.14+dfsg-1.3~deb12u1"
+        }
+      ],
+      "status": "not_affected",
+      "status_notes": "The affected dependency (libxml2) is not utilized by fleetctl itself, but by Apple’s iTMSTransporter tool, which is included in the Docker image for code signing purposes. fleetctl does not process untrusted XML input. Additionally, this CVE describes a denial-of-service (DoS) vulnerability, and fleetctl is a CLI tool, not a long-running service, and therefore is not susceptible to DoS-style exploitation.",
+      "justification": "vulnerable_code_cannot_be_controlled_by_adversary"
+    }
+  ]
+}

--- a/security/vex/fleetctl/CVE-2025-49796.vex.json
+++ b/security/vex/fleetctl/CVE-2025-49796.vex.json
@@ -1,0 +1,26 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://openvex.dev/docs/public/vex-15a003ae60b35f7662908bba842052a293f1bbc468353ec52419d0137556c0d3",
+  "author": "@sgress454",
+  "timestamp": "2025-06-13T15:57:38.413521-05:00",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2025-49796"
+      },
+      "timestamp": "2025-06-13T15:57:38.413522-05:00",
+      "products": [
+        {
+          "@id": "fleetctl"
+        },
+        {
+          "@id": "pkg:deb/debian/libxml2@2.9.14+dfsg-1.3~deb12u1"
+        }
+      ],
+      "status": "not_affected",
+      "status_notes": "The affected dependency (libxml2) is not utilized by fleetctl itself, but by Apple’s iTMSTransporter tool, which is included in the Docker image for code signing purposes. fleetctl does not process untrusted XML input. Additionally, this CVE describes a denial-of-service (DoS) vulnerability, and fleetctl is a CLI tool, not a long-running service, and therefore is not susceptible to DoS-style exploitation.",
+      "justification": "vulnerable_code_cannot_be_controlled_by_adversary"
+    }
+  ]
+}


### PR DESCRIPTION
This PR adds VEX statement files for three vulverabilities:

```
┌─────────┬────────────────┬──────────┬──────────┬─────────────────────────┬───────────────┬──────────────────────────────────────────────────────────────┐
│ Library │ Vulnerability  │ Severity │  Status  │    Installed Version    │ Fixed Version │                            Title                             │
├─────────┼────────────────┼──────────┼──────────┼─────────────────────────┼───────────────┼──────────────────────────────────────────────────────────────┤
│ libxml2 │ CVE-2025-49794 │ CRITICAL │ affected │ 2.9.14+dfsg-1.3~deb12u1 │               │ libxml: Heap use after free (UAF) leads to Denial of service │
│         │                │          │          │                         │               │ (DoS)...                                                     │
│         │                │          │          │                         │               │ https://avd.aquasec.com/nvd/cve-2025-49794                   │
│         ├────────────────┤          │          │                         ├───────────────┼──────────────────────────────────────────────────────────────┤
│         │ CVE-2025-49795 │          │          │                         │               │ libxml: Null pointer dereference leads to Denial of service  │
│         │                │          │          │                         │               │ (DoS)                                                        │
│         │                │          │          │                         │               │ https://avd.aquasec.com/nvd/cve-2025-49795                   │
│         ├────────────────┤          │          │                         ├───────────────┼──────────────────────────────────────────────────────────────┤
│         │ CVE-2025-49796 │          │          │                         │               │ libxml: Type confusion leads to Denial of service (DoS)      │
│         │                │          │          │                         │               │ https://avd.aquasec.com/nvd/cve-2025-49796                   │
└─────────┴────────────────┴──────────┴──────────┴─────────────────────────┴───────────────┴──────────────────────────────────────────────────────────────┘
```

the vulnerabilities in libxml2 do not affect fleetctl, since the attack vector is DoS and fleetctl is not a server tool.  Additionally the libxml2 package isn't used by fleetctl directly, but by the tools it uses for code signing, which don't parse untrusted XML.