### PR TITLE
Don't overwrite FMA outputs with latest manifest if input has "frozen" set to true

### DIFF
--- a/ee/maintained-apps/README.md
+++ b/ee/maintained-apps/README.md
@@ -1,5 +1,14 @@
 # Fleet-maintained apps (FMA)
 
+## Freezing an existing app
+
+Add `"frozen": true` to the appropriate input JSON file to pause automated updates to the corresponding output manifest.
+To aid in testing, manifests will still be generated for frozen inputs if the output file doesn't exist.
+
+Apps should be frozen when updating the manifest would introduce regressions on ability to install/uninstall the app.
+Frozen apps should have bugs filed, and fixes for those bugs should unfreeze the app and bump it to the latest version
+as part of the fix PR.
+
 ## Adding a new app
 
 1. Decide on a source for the app's metadata. We currently support homebrew as a source for macOS apps.

--- a/ee/maintained-apps/ingesters/homebrew/ingester.go
+++ b/ee/maintained-apps/ingesters/homebrew/ingester.go
@@ -166,6 +166,7 @@ func (i *brewIngester) ingestOne(ctx context.Context, app inputApp) (*maintained
 
 	out.UninstallScriptRef = maintained_apps.GetScriptRef(out.UninstallScript)
 	out.InstallScriptRef = maintained_apps.GetScriptRef(out.InstallScript)
+	out.Frozen = app.Frozen
 
 	return out, nil
 }
@@ -184,6 +185,7 @@ type inputApp struct {
 	PreUninstallScripts  []string `json:"pre_uninstall_scripts"`
 	PostUninstallScripts []string `json:"post_uninstall_scripts"`
 	DefaultCategories    []string `json:"default_categories"`
+	Frozen               bool     `json:"frozen"`
 }
 
 type brewCask struct {

--- a/ee/maintained-apps/ingesters/winget/ingester.go
+++ b/ee/maintained-apps/ingesters/winget/ingester.go
@@ -299,6 +299,7 @@ func (i *wingetIngester) ingestOne(ctx context.Context, input inputApp) (*mainta
 	out.UninstallScript = preProcessUninstallScript(uninstallScript, productCode)
 	out.InstallScriptRef = maintained_apps.GetScriptRef(out.InstallScript)
 	out.UninstallScriptRef = maintained_apps.GetScriptRef(out.UninstallScript)
+	out.Frozen = input.Frozen
 
 	return &out, nil
 }
@@ -354,6 +355,7 @@ type inputApp struct {
 	// Whether to use "no_check" instead of the app's hash (e.g. for non-pinned download URLs)
 	IgnoreHash        bool     `json:"ignore_hash"`
 	DefaultCategories []string `json:"default_categories"`
+	Frozen            bool     `json:"frozen"`
 }
 
 type installerManifest struct {

--- a/ee/maintained-apps/maintained_apps.go
+++ b/ee/maintained-apps/maintained_apps.go
@@ -34,6 +34,7 @@ type FMAManifestApp struct {
 	Slug               string     `json:"-"`
 	Name               string     `json:"-"`
 	DefaultCategories  []string   `json:"default_categories"`
+	Frozen             bool       `json:"-"`
 }
 
 func (a *FMAManifestApp) Platform() string {


### PR DESCRIPTION
Resolves #29218. No changes file as this is internal/FMA-related.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [x] Manual QA for all new/changed functionality