### PR TITLE
Host API: Return empty array instead of 404 for software filter not found

### DIFF
--- a/changes/29823-26258-empty-host
+++ b/changes/29823-26258-empty-host
@@ -1,0 +1,1 @@
+- Fixed host API to returns empty array (instead of 404) if software title or version is not found on hosts on that team consistent with other host filters

--- a/server/service/hosts.go
+++ b/server/service/hosts.go
@@ -102,7 +102,7 @@ func listHostsEndpoint(ctx context.Context, request interface{}, svc fleet.Servi
 			id = req.Opts.SoftwareIDFilter
 		}
 		software, err = svc.SoftwareByID(ctx, *id, req.Opts.TeamFilter, false)
-		if err != nil {
+		if err != nil && !fleet.IsNotFound(err) { // ignore not found, just return nil for the software in that case
 			return listHostsResponse{Err: err}, nil
 		}
 	}
@@ -112,7 +112,7 @@ func listHostsEndpoint(ctx context.Context, request interface{}, svc fleet.Servi
 		var err error
 
 		softwareTitle, err = svc.SoftwareTitleByID(ctx, *req.Opts.SoftwareTitleIDFilter, req.Opts.TeamFilter)
-		if err != nil {
+		if err != nil && !fleet.IsNotFound(err) { // ignore not found, just return nil for the software title in that case
 			return listHostsResponse{Err: err}, nil
 		}
 	}

--- a/server/service/integration_core_test.go
+++ b/server/service/integration_core_test.go
@@ -1788,11 +1788,19 @@ func (s *integrationTestSuite) TestListHosts() {
 
 	// Filter by inexistent software.
 	resp = listHostsResponse{}
-	s.DoJSON("GET", "/api/latest/fleet/hosts", nil, http.StatusNotFound, &resp, "software_id", fmt.Sprint(9999))
+	s.DoJSON("GET", "/api/latest/fleet/hosts", nil, http.StatusOK, &resp, "software_id", fmt.Sprint(9999))
+	require.Len(t, resp.Hosts, 0)
+	assert.Nil(t, resp.Software)
+
 	resp = listHostsResponse{}
-	s.DoJSON("GET", "/api/latest/fleet/hosts", nil, http.StatusNotFound, &resp, "software_version_id", fmt.Sprint(9999))
+	s.DoJSON("GET", "/api/latest/fleet/hosts", nil, http.StatusOK, &resp, "software_version_id", fmt.Sprint(9999))
+	require.Len(t, resp.Hosts, 0)
+	assert.Nil(t, resp.Software)
+
 	resp = listHostsResponse{}
-	s.DoJSON("GET", "/api/latest/fleet/hosts", nil, http.StatusNotFound, &resp, "software_title_id", fmt.Sprint(9999))
+	s.DoJSON("GET", "/api/latest/fleet/hosts", nil, http.StatusOK, &resp, "software_title_id", fmt.Sprint(9999))
+	require.Len(t, resp.Hosts, 0)
+	assert.Nil(t, resp.SoftwareTitle)
 
 	// Filter by non-existent team.
 	resp = listHostsResponse{}


### PR DESCRIPTION
## Issue
Closes #29823 
Closes #26258

## Description
Similar to missing a policy on a team, mdm solution on a team or any other filter on a team, filtering a team by a specific software title or version will return an empty array instead of a 404.

## Screenrecording of fix


https://github.com/user-attachments/assets/62e55aed-35fd-467d-8b0f-2e0553aff39d


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.
- [x] Manual QA for all new/changed functionality

