### PR TITLE
Fleet UI: Fix os settings tooltips from flashing during refetch

### DIFF
--- a/changes/22796-tooltip-flashing
+++ b/changes/22796-tooltip-flashing
@@ -1,0 +1,1 @@
+- Fleet UI: Fixed host details > MDM OS settings tooltips from flashing during a host refetch

--- a/frontend/pages/hosts/details/OSSettingsModal/OSSettingsTable/OSSettingsTable.tsx
+++ b/frontend/pages/hosts/details/OSSettingsModal/OSSettingsTable/OSSettingsTable.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useMemo } from "react";
 import TableContainer from "components/TableContainer";
 
 import generateTableHeaders, {
@@ -20,10 +20,10 @@ const OSSettingsTable = ({
   tableData,
   onProfileResent,
 }: IOSSettingsTableProps) => {
-  const tableConfig = generateTableHeaders(
-    hostId,
-    canResendProfiles,
-    onProfileResent
+  // useMemo prevents tooltip flashing during host data refetch
+  const tableConfig = useMemo(
+    () => generateTableHeaders(hostId, canResendProfiles, onProfileResent),
+    [hostId, canResendProfiles, onProfileResent]
   );
 
   return (


### PR DESCRIPTION
## Issue
Closes #22796 

## Description
- useMemo prevent function from recalculating on every render

## Screenrecording of fix (note the tooltip doesn't flash in and out while refetching)

https://github.com/user-attachments/assets/3940559e-af2a-42af-bcc7-e03c622dabe2



# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
- [x] Added/updated automated tests
- [x] Manual QA for all new/changed functionality