### PR TITLE
fix truncation of mdm server url value in about card

### DIFF
--- a/changes/issue-29696-fix-truncation-mdm-server-url
+++ b/changes/issue-29696-fix-truncation-mdm-server-url
@@ -1,0 +1,1 @@
+- fix truncation of the mdm server url value on the about card on host details page

--- a/frontend/pages/hosts/details/cards/About/_styles.scss
+++ b/frontend/pages/hosts/details/cards/About/_styles.scss
@@ -57,7 +57,7 @@
 
       dd,
       .component__tooltip-wrapper__element {
-        max-width: 340px;
+        max-width: 245px;
       }
     }
 


### PR DESCRIPTION
Fixes #29696

fixes truncation of the mdm server url value on the about card.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
- [x] Manual QA for all new/changed functionality
