### PR TITLE
Helm Chart - MySQL Read Replica environment variable support

### DIFF
--- a/charts/fleet/Chart.yaml
+++ b/charts/fleet/Chart.yaml
@@ -4,7 +4,7 @@ name: fleet
 keywords:
   - fleet
   - osquery
-version: v6.6.6
+version: v6.6.7
 home: https://github.com/fleetdm/fleet
 sources:
   - https://github.com/fleetdm/fleet.git

--- a/charts/fleet/templates/cron-vulnprocessing.yaml
+++ b/charts/fleet/templates/cron-vulnprocessing.yaml
@@ -150,34 +150,38 @@ spec:
                     key: {{ .Values.database_read_replica.passwordKey }}
               {{- end }}
               {{- if .Values.database_read_replica.maxOpenConns }}
-              - name: FLEET_MYSQL_READ_MAX_OPEN_CONNS
+              - name: FLEET_MYSQL_READ_REPLICA_MAX_OPEN_CONNS
                 value: "{{ .Values.database_read_replica.maxOpenConns }}"
               {{- end }}
               {{- if .Values.database_read_replica.maxIdleConns }}
-              - name: FLEET_MYSQL_READ_MAX_IDLE_CONNS
+              - name: FLEET_MYSQL_READ_REPLICA_MAX_IDLE_CONNS
                 value: "{{ .Values.database_read_replica.maxIdleConns }}"
               {{- end }}
               {{- if .Values.database_read_replica.connMaxLifetime }}
-              - name: FLEET_MYSQL_READ_CONN_MAX_LIFETIME
+              - name: FLEET_MYSQL_READ_REPLICA_CONN_MAX_LIFETIME
                 value: "{{ .Values.database_read_replica.connMaxLifetime }}"
               {{- end }}
               {{- if .Values.database_read_replica.tls.enabled }}
               {{- if .Values.database_read_replica.tls.caCertKey }}
-              - name: FLEET_MYSQL_READ_TLS_CA
+              - name: FLEET_MYSQL_READ_REPLICA_TLS_CA
                 value: "/secrets/mysql/{{ .Values.database_read_replica.tls.caCertKey }}"
               {{- end }}
               {{- if .Values.database_read_replica.tls.certKey }}
-              - name: FLEET_MYSQL_READ_TLS_CERT
+              - name: FLEET_MYSQL_READ_REPLICA_TLS_CERT
                 value: "/secrets/mysql/{{ .Values.database_read_replica.tls.certKey }}"
               {{- end }}
               {{- if .Values.database_read_replica.tls.keyKey }}
-              - name: FLEET_MYSQL_READ_TLS_KEY
+              - name: FLEET_MYSQL_READ_REPLICA_TLS_KEY
                 value: "/secrets/mysql/{{ .Values.database_read_replica.tls.keyKey }}"
               {{- end }}
-              - name: FLEET_MYSQL_READ_TLS_CONFIG
+              {{- if .Values.database_read_replica.tls.config }}
+              - name: FLEET_MYSQL_READ_REPLICA_TLS_CONFIG
                 value: "{{ .Values.database_read_replica.tls.config }}"
-              - name: FLEET_MYSQL_READ_TLS_SERVER_NAME
+              {{- end }}
+              {{- if .Values.database_read_replica.tls.serverName }}
+              - name: FLEET_MYSQL_READ_REPLICA_TLS_SERVER_NAME
                 value: "{{ .Values.database_read_replica.tls.serverName }}"
+              {{- end }}
               {{- end }}
               ## END MYSQL READ REPLICA SECTION
               ## BEGIN REDIS SECTION

--- a/charts/fleet/templates/cron-vulnprocessing.yaml
+++ b/charts/fleet/templates/cron-vulnprocessing.yaml
@@ -125,61 +125,61 @@ spec:
                 value: "{{ .Values.database.tls.serverName }}"
               {{- end }}
               ## END MYSQL SECTION
-          ## BEGIN MYSQL READ REPLICA SECTION
-          {{- if .Values.database_read_replica.address }}
-          - name: FLEET_MYSQL_READ_REPLICA_ADDRESS
-            value: "{{ .Values.database_read_replica.address }}"
-          {{- end }}
-          {{- if .Values.database_read_replica.database }}
-          - name: FLEET_MYSQL_READ_REPLICA_DATABASE
-            value: "{{ .Values.database_read_replica.database }}"
-          {{- end }}
-          {{- if .Values.database_read_replica.username }}
-          - name: FLEET_MYSQL_READ_REPLICA_USERNAME
-            value: "{{ .Values.database_read_replica.username }}"
-          {{- end }}
-          {{- if .Values.database_read_replica.passwordPath }}
-          - name: FLEET_MYSQL_READ_REPLICA_PASSWORD_PATH
-            value: "{{ .Values.database_read_replica.passwordPath }}"
-          {{- end }}
-          {{- if .Values.database_read_replica.secretName }}
-          - name: FLEET_MYSQL_READ_REPLICA_PASSWORD
-            valueFrom:
-              secretKeyRef:
-                name: {{ .Values.database_read_replica.secretName }}
-                key: {{ .Values.database_read_replica.passwordKey }}
-          {{- end }}
-          {{- if .Values.database_read_replica.maxOpenConns }}
-          - name: FLEET_MYSQL_READ_MAX_OPEN_CONNS
-            value: "{{ .Values.database_read_replica.maxOpenConns }}"
-          {{- end }}
-          {{- if .Values.database_read_replica.maxIdleConns }}
-          - name: FLEET_MYSQL_READ_MAX_IDLE_CONNS
-            value: "{{ .Values.database_read_replica.maxIdleConns }}"
-          {{- end }}
-          {{- if .Values.database_read_replica.connMaxLifetime }}
-          - name: FLEET_MYSQL_READ_CONN_MAX_LIFETIME
-            value: "{{ .Values.database_read_replica.connMaxLifetime }}"
-          {{- end }}
-          {{- if .Values.database_read_replica.tls.enabled }}
-          {{- if .Values.database_read_replica.tls.caCertKey }}
-          - name: FLEET_MYSQL_READ_TLS_CA
-            value: "/secrets/mysql/{{ .Values.database_read_replica.tls.caCertKey }}"
-          {{- end }}
-          {{- if .Values.database_read_replica.tls.certKey }}
-          - name: FLEET_MYSQL_READ_TLS_CERT
-            value: "/secrets/mysql/{{ .Values.database_read_replica.tls.certKey }}"
-          {{- end }}
-          {{- if .Values.database_read_replica.tls.keyKey }}
-          - name: FLEET_MYSQL_READ_TLS_KEY
-            value: "/secrets/mysql/{{ .Values.database_read_replica.tls.keyKey }}"
-          {{- end }}
-          - name: FLEET_MYSQL_READ_TLS_CONFIG
-            value: "{{ .Values.database_read_replica.tls.config }}"
-          - name: FLEET_MYSQL_READ_TLS_SERVER_NAME
-            value: "{{ .Values.database_read_replica.tls.serverName }}"
-          {{- end }}
-          ## END MYSQL READ REPLICA SECTION
+              ## BEGIN MYSQL READ REPLICA SECTION
+              {{- if .Values.database_read_replica.address }}
+              - name: FLEET_MYSQL_READ_REPLICA_ADDRESS
+                value: "{{ .Values.database_read_replica.address }}"
+              {{- end }}
+              {{- if .Values.database_read_replica.database }}
+              - name: FLEET_MYSQL_READ_REPLICA_DATABASE
+                value: "{{ .Values.database_read_replica.database }}"
+              {{- end }}
+              {{- if .Values.database_read_replica.username }}
+              - name: FLEET_MYSQL_READ_REPLICA_USERNAME
+                value: "{{ .Values.database_read_replica.username }}"
+              {{- end }}
+              {{- if .Values.database_read_replica.passwordPath }}
+              - name: FLEET_MYSQL_READ_REPLICA_PASSWORD_PATH
+                value: "{{ .Values.database_read_replica.passwordPath }}"
+              {{- end }}
+              {{- if .Values.database_read_replica.secretName }}
+              - name: FLEET_MYSQL_READ_REPLICA_PASSWORD
+                valueFrom:
+                  secretKeyRef:
+                    name: {{ .Values.database_read_replica.secretName }}
+                    key: {{ .Values.database_read_replica.passwordKey }}
+              {{- end }}
+              {{- if .Values.database_read_replica.maxOpenConns }}
+              - name: FLEET_MYSQL_READ_MAX_OPEN_CONNS
+                value: "{{ .Values.database_read_replica.maxOpenConns }}"
+              {{- end }}
+              {{- if .Values.database_read_replica.maxIdleConns }}
+              - name: FLEET_MYSQL_READ_MAX_IDLE_CONNS
+                value: "{{ .Values.database_read_replica.maxIdleConns }}"
+              {{- end }}
+              {{- if .Values.database_read_replica.connMaxLifetime }}
+              - name: FLEET_MYSQL_READ_CONN_MAX_LIFETIME
+                value: "{{ .Values.database_read_replica.connMaxLifetime }}"
+              {{- end }}
+              {{- if .Values.database_read_replica.tls.enabled }}
+              {{- if .Values.database_read_replica.tls.caCertKey }}
+              - name: FLEET_MYSQL_READ_TLS_CA
+                value: "/secrets/mysql/{{ .Values.database_read_replica.tls.caCertKey }}"
+              {{- end }}
+              {{- if .Values.database_read_replica.tls.certKey }}
+              - name: FLEET_MYSQL_READ_TLS_CERT
+                value: "/secrets/mysql/{{ .Values.database_read_replica.tls.certKey }}"
+              {{- end }}
+              {{- if .Values.database_read_replica.tls.keyKey }}
+              - name: FLEET_MYSQL_READ_TLS_KEY
+                value: "/secrets/mysql/{{ .Values.database_read_replica.tls.keyKey }}"
+              {{- end }}
+              - name: FLEET_MYSQL_READ_TLS_CONFIG
+                value: "{{ .Values.database_read_replica.tls.config }}"
+              - name: FLEET_MYSQL_READ_TLS_SERVER_NAME
+                value: "{{ .Values.database_read_replica.tls.serverName }}"
+              {{- end }}
+              ## END MYSQL READ REPLICA SECTION
               ## BEGIN REDIS SECTION
               - name: FLEET_REDIS_ADDRESS
                 value: "{{ .Values.cache.address }}"

--- a/charts/fleet/templates/cron-vulnprocessing.yaml
+++ b/charts/fleet/templates/cron-vulnprocessing.yaml
@@ -229,7 +229,9 @@ spec:
               {{- if .Values.fleet.securityContext.runAsUser }}
               runAsUser: {{ int64 .Values.fleet.securityContext.runAsUser }}
               {{- end }}
-              runAsNonRoot: true
+              {{- if .Values.fleet.securityContext.runAsNonRoot }}
+              runAsNonRoot: {{ .Values.fleet.securityContext.runAsNonRoot }}
+              {{- end }}
             volumeMounts:
               - name: tmp
                 mountPath: /tmp
@@ -264,7 +266,9 @@ spec:
               {{- if .Values.fleet.securityContext.runAsUser }}
               runAsUser: {{ int64 .Values.fleet.securityContext.runAsUser }}
               {{- end }}
-              runAsNonRoot: true
+              {{- if .Values.fleet.securityContext.runAsNonRoot }}
+              runAsNonRoot: {{ .Values.fleet.securityContext.runAsNonRoot }}
+              {{- end }}
           {{- end }}
           {{- with .Values.imagePullSecrets }}
           imagePullSecrets:

--- a/charts/fleet/templates/cron-vulnprocessing.yaml
+++ b/charts/fleet/templates/cron-vulnprocessing.yaml
@@ -125,6 +125,61 @@ spec:
                 value: "{{ .Values.database.tls.serverName }}"
               {{- end }}
               ## END MYSQL SECTION
+          ## BEGIN MYSQL READ REPLICA SECTION
+          {{- if .Values.database_read_replica.address }}
+          - name: FLEET_MYSQL_READ_REPLICA_ADDRESS
+            value: "{{ .Values.database_read_replica.address }}"
+          {{- end }}
+          {{- if .Values.database_read_replica.database }}
+          - name: FLEET_MYSQL_READ_REPLICA_DATABASE
+            value: "{{ .Values.database_read_replica.database }}"
+          {{- end }}
+          {{- if .Values.database_read_replica.username }}
+          - name: FLEET_MYSQL_READ_REPLICA_USERNAME
+            value: "{{ .Values.database_read_replica.username }}"
+          {{- end }}
+          {{- if .Values.database_read_replica.passwordPath }}
+          - name: FLEET_MYSQL_READ_REPLICA_PASSWORD_PATH
+            value: "{{ .Values.database_read_replica.passwordPath }}"
+          {{- end }}
+          {{- if .Values.database_read_replica.secretName }}
+          - name: FLEET_MYSQL_READ_REPLICA_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: {{ .Values.database_read_replica.secretName }}
+                key: {{ .Values.database_read_replica.passwordKey }}
+          {{- end }}
+          {{- if .Values.database_read_replica.maxOpenConns }}
+          - name: FLEET_MYSQL_READ_MAX_OPEN_CONNS
+            value: "{{ .Values.database_read_replica.maxOpenConns }}"
+          {{- end }}
+          {{- if .Values.database_read_replica.maxIdleConns }}
+          - name: FLEET_MYSQL_READ_MAX_IDLE_CONNS
+            value: "{{ .Values.database_read_replica.maxIdleConns }}"
+          {{- end }}
+          {{- if .Values.database_read_replica.connMaxLifetime }}
+          - name: FLEET_MYSQL_READ_CONN_MAX_LIFETIME
+            value: "{{ .Values.database_read_replica.connMaxLifetime }}"
+          {{- end }}
+          {{- if .Values.database_read_replica.tls.enabled }}
+          {{- if .Values.database_read_replica.tls.caCertKey }}
+          - name: FLEET_MYSQL_READ_TLS_CA
+            value: "/secrets/mysql/{{ .Values.database_read_replica.tls.caCertKey }}"
+          {{- end }}
+          {{- if .Values.database_read_replica.tls.certKey }}
+          - name: FLEET_MYSQL_READ_TLS_CERT
+            value: "/secrets/mysql/{{ .Values.database_read_replica.tls.certKey }}"
+          {{- end }}
+          {{- if .Values.database_read_replica.tls.keyKey }}
+          - name: FLEET_MYSQL_READ_TLS_KEY
+            value: "/secrets/mysql/{{ .Values.database_read_replica.tls.keyKey }}"
+          {{- end }}
+          - name: FLEET_MYSQL_READ_TLS_CONFIG
+            value: "{{ .Values.database_read_replica.tls.config }}"
+          - name: FLEET_MYSQL_READ_TLS_SERVER_NAME
+            value: "{{ .Values.database_read_replica.tls.serverName }}"
+          {{- end }}
+          ## END MYSQL READ REPLICA SECTION
               ## BEGIN REDIS SECTION
               - name: FLEET_REDIS_ADDRESS
                 value: "{{ .Values.cache.address }}"

--- a/charts/fleet/templates/cron-vulnprocessing.yaml
+++ b/charts/fleet/templates/cron-vulnprocessing.yaml
@@ -126,6 +126,7 @@ spec:
               {{- end }}
               ## END MYSQL SECTION
               ## BEGIN MYSQL READ REPLICA SECTION
+              {{- if .Values.database_read_replica }}
               {{- if .Values.database_read_replica.address }}
               - name: FLEET_MYSQL_READ_REPLICA_ADDRESS
                 value: "{{ .Values.database_read_replica.address }}"
@@ -181,6 +182,7 @@ spec:
               {{- if .Values.database_read_replica.tls.serverName }}
               - name: FLEET_MYSQL_READ_REPLICA_TLS_SERVER_NAME
                 value: "{{ .Values.database_read_replica.tls.serverName }}"
+              {{- end }}
               {{- end }}
               {{- end }}
               ## END MYSQL READ REPLICA SECTION

--- a/charts/fleet/templates/deployment.yaml
+++ b/charts/fleet/templates/deployment.yaml
@@ -143,6 +143,61 @@ spec:
             value: "{{ .Values.database.tls.serverName }}"
           {{- end }}
           ## END MYSQL SECTION
+          ## BEGIN MYSQL READ REPLICA SECTION
+          {{- if .Values.database_read_replica.address }}
+          - name: FLEET_MYSQL_READ_REPLICA_ADDRESS
+            value: "{{ .Values.database_read_replica.address }}"
+          {{- end }}
+          {{- if .Values.database_read_replica.database }}
+          - name: FLEET_MYSQL_READ_REPLICA_DATABASE
+            value: "{{ .Values.database_read_replica.database }}"
+          {{- end }}
+          {{- if .Values.database_read_replica.username }}
+          - name: FLEET_MYSQL_READ_REPLICA_USERNAME
+            value: "{{ .Values.database_read_replica.username }}"
+          {{- end }}
+          {{- if .Values.database_read_replica.passwordPath }}
+          - name: FLEET_MYSQL_READ_REPLICA_PASSWORD_PATH
+            value: "{{ .Values.database_read_replica.passwordPath }}"
+          {{- end }}
+          {{- if .Values.database_read_replica.secretName }}
+          - name: FLEET_MYSQL_READ_REPLICA_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: {{ .Values.database_read_replica.secretName }}
+                key: {{ .Values.database_read_replica.passwordKey }}
+          {{- end }}
+          {{- if .Values.database_read_replica.maxOpenConns }}
+          - name: FLEET_MYSQL_READ_MAX_OPEN_CONNS
+            value: "{{ .Values.database_read_replica.maxOpenConns }}"
+          {{- end }}
+          {{- if .Values.database_read_replica.maxIdleConns }}
+          - name: FLEET_MYSQL_READ_MAX_IDLE_CONNS
+            value: "{{ .Values.database_read_replica.maxIdleConns }}"
+          {{- end }}
+          {{- if .Values.database_read_replica.connMaxLifetime }}
+          - name: FLEET_MYSQL_READ_CONN_MAX_LIFETIME
+            value: "{{ .Values.database_read_replica.connMaxLifetime }}"
+          {{- end }}
+          {{- if .Values.database_read_replica.tls.enabled }}
+          {{- if .Values.database_read_replica.tls.caCertKey }}
+          - name: FLEET_MYSQL_READ_TLS_CA
+            value: "/secrets/mysql/{{ .Values.database_read_replica.tls.caCertKey }}"
+          {{- end }}
+          {{- if .Values.database_read_replica.tls.certKey }}
+          - name: FLEET_MYSQL_READ_TLS_CERT
+            value: "/secrets/mysql/{{ .Values.database_read_replica.tls.certKey }}"
+          {{- end }}
+          {{- if .Values.database_read_replica.tls.keyKey }}
+          - name: FLEET_MYSQL_READ_TLS_KEY
+            value: "/secrets/mysql/{{ .Values.database_read_replica.tls.keyKey }}"
+          {{- end }}
+          - name: FLEET_MYSQL_READ_TLS_CONFIG
+            value: "{{ .Values.database_read_replica.tls.config }}"
+          - name: FLEET_MYSQL_READ_TLS_SERVER_NAME
+            value: "{{ .Values.database_read_replica.tls.serverName }}"
+          {{- end }}
+          ## END MYSQL READ REPLICA SECTION
           ## BEGIN REDIS SECTION
           - name: FLEET_REDIS_ADDRESS
             value: "{{ .Values.cache.address }}"

--- a/charts/fleet/templates/deployment.yaml
+++ b/charts/fleet/templates/deployment.yaml
@@ -144,6 +144,7 @@ spec:
           {{- end }}
           ## END MYSQL SECTION
           ## BEGIN MYSQL READ REPLICA SECTION
+          {{- if .Values.database_read_replica }}
           {{- if .Values.database_read_replica.address }}
           - name: FLEET_MYSQL_READ_REPLICA_ADDRESS
             value: "{{ .Values.database_read_replica.address }}"
@@ -199,6 +200,7 @@ spec:
           {{- if .Values.database_read_replica.tls.serverName }}
           - name: FLEET_MYSQL_READ_REPLICA_TLS_SERVER_NAME
             value: "{{ .Values.database_read_replica.tls.serverName }}"
+          {{- end }}
           {{- end }}
           {{- end }}
           ## END MYSQL READ REPLICA SECTION

--- a/charts/fleet/templates/deployment.yaml
+++ b/charts/fleet/templates/deployment.yaml
@@ -168,34 +168,38 @@ spec:
                 key: {{ .Values.database_read_replica.passwordKey }}
           {{- end }}
           {{- if .Values.database_read_replica.maxOpenConns }}
-          - name: FLEET_MYSQL_READ_MAX_OPEN_CONNS
+          - name: FLEET_MYSQL_READ_REPLICA_MAX_OPEN_CONNS
             value: "{{ .Values.database_read_replica.maxOpenConns }}"
           {{- end }}
           {{- if .Values.database_read_replica.maxIdleConns }}
-          - name: FLEET_MYSQL_READ_MAX_IDLE_CONNS
+          - name: FLEET_MYSQL_READ_REPLICA_MAX_IDLE_CONNS
             value: "{{ .Values.database_read_replica.maxIdleConns }}"
           {{- end }}
           {{- if .Values.database_read_replica.connMaxLifetime }}
-          - name: FLEET_MYSQL_READ_CONN_MAX_LIFETIME
+          - name: FLEET_MYSQL_READ_REPLICA_CONN_MAX_LIFETIME
             value: "{{ .Values.database_read_replica.connMaxLifetime }}"
           {{- end }}
           {{- if .Values.database_read_replica.tls.enabled }}
           {{- if .Values.database_read_replica.tls.caCertKey }}
-          - name: FLEET_MYSQL_READ_TLS_CA
+          - name: FLEET_MYSQL_READ_REPLICA_TLS_CA
             value: "/secrets/mysql/{{ .Values.database_read_replica.tls.caCertKey }}"
           {{- end }}
           {{- if .Values.database_read_replica.tls.certKey }}
-          - name: FLEET_MYSQL_READ_TLS_CERT
+          - name: FLEET_MYSQL_READ_REPLICA_TLS_CERT
             value: "/secrets/mysql/{{ .Values.database_read_replica.tls.certKey }}"
           {{- end }}
           {{- if .Values.database_read_replica.tls.keyKey }}
-          - name: FLEET_MYSQL_READ_TLS_KEY
+          - name: FLEET_MYSQL_READ_REPLICA_TLS_KEY
             value: "/secrets/mysql/{{ .Values.database_read_replica.tls.keyKey }}"
           {{- end }}
-          - name: FLEET_MYSQL_READ_TLS_CONFIG
+          {{- if .Values.database_read_replica.tls.config }}
+          - name: FLEET_MYSQL_READ_REPLICA_TLS_CONFIG
             value: "{{ .Values.database_read_replica.tls.config }}"
-          - name: FLEET_MYSQL_READ_TLS_SERVER_NAME
+          {{- end }}
+          {{- if .Values.database_read_replica.tls.serverName }}
+          - name: FLEET_MYSQL_READ_REPLICA_TLS_SERVER_NAME
             value: "{{ .Values.database_read_replica.tls.serverName }}"
+          {{- end }}
           {{- end }}
           ## END MYSQL READ REPLICA SECTION
           ## BEGIN REDIS SECTION

--- a/charts/fleet/templates/deployment.yaml
+++ b/charts/fleet/templates/deployment.yaml
@@ -367,7 +367,9 @@ spec:
           {{- if .Values.fleet.securityContext.runAsUser }}
           runAsUser: {{ int64 .Values.fleet.securityContext.runAsUser }}
           {{- end }}
-          runAsNonRoot: true
+          {{- if .Values.fleet.securityContext.runAsNonRoot }}
+          runAsNonRoot: {{ .Values.fleet.securityContext.runAsNonRoot }}
+          {{- end }}
         livenessProbe:
           httpGet:
             path: /healthz
@@ -430,7 +432,9 @@ spec:
           {{- if .Values.fleet.securityContext.runAsUser }}
           runAsUser: {{ int64 .Values.fleet.securityContext.runAsUser }}
           {{- end }}
-          runAsNonRoot: true
+          {{- if .Values.fleet.securityContext.runAsNonRoot }}
+          runAsNonRoot: {{ .Values.fleet.securityContext.runAsNonRoot }}
+          {{- end }}
       {{- end }}
       hostPID: false
       hostNetwork: false

--- a/charts/fleet/templates/job-migration.yaml
+++ b/charts/fleet/templates/job-migration.yaml
@@ -137,7 +137,9 @@ spec:
           {{- if .Values.fleet.securityContext.runAsUser }}
           runAsUser: {{ int64 .Values.fleet.securityContext.runAsUser }}
           {{- end }}
-          runAsNonRoot: true
+          {{- if .Values.fleet.securityContext.runAsNonRoot }}
+          runAsNonRoot: {{ .Values.fleet.securityContext.runAsNonRoot }}
+          {{- end }}
         volumeMounts:
           {{- if .Values.database.tls.enabled }}
           - name: mysql-tls
@@ -170,7 +172,9 @@ spec:
           {{- if .Values.fleet.securityContext.runAsUser }}
           runAsUser: {{ int64 .Values.fleet.securityContext.runAsUser }}
           {{- end }}
-          runAsNonRoot: true
+          {{- if .Values.fleet.securityContext.runAsNonRoot }}
+          runAsNonRoot: {{ .Values.fleet.securityContext.runAsNonRoot }}
+          {{- end }}
       {{- end }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/fleet/values.yaml
+++ b/charts/fleet/values.yaml
@@ -210,7 +210,7 @@ database:
 #  # Name of the Secret resource containing MySQL password and TLS secrets
 #  address: 127.0.0.1:3306
 #  database: fleet
-#  username: fleet
+#  username: fleet-ro
 #  ## Password configuration. Pick whether you'd like to load from secret or from an accessible mount path.
 #  ## Added from Secret
 #  secretName: mysql-ro

--- a/charts/fleet/values.yaml
+++ b/charts/fleet/values.yaml
@@ -107,8 +107,9 @@ fleet:
     licenseKey: license-key
   extraVolumes: []
   extraVolumeMounts: []
-  # Currently only passes runAsUser and runAsGroup
+  # Currently only passes runAsNonRoot, runAsUser, runAsGroup
   securityContext:
+    runAsNonRoot: true
     runAsUser: 3333
     runAsGroup: 3333
 # Whether to make fleet vulnerability processing run in a dedicated container

--- a/charts/fleet/values.yaml
+++ b/charts/fleet/values.yaml
@@ -203,26 +203,32 @@ database:
     config: ""
     serverName: ""
 
-database_read_replica:
-  # Name of the Secret resource containing MySQL password and TLS secrets
-  address: 127.0.0.1:3306
-  database: fleet
-  username: fleet
-  secretName: mysql-ro
-  passwordKey: mysql-ro-password
-  passwordPath: /path/to/password
-  maxOpenConns: 50
-  maxIdleConns: 50
-  connMaxLifetime: 0
-  tls:
-    enabled: false
-    ## Commented options below are optional.  Uncomment to use.
-    # caCertKey: ca.cert
-    ## Client certificates require both the certKey and keyKey
-    # certKey: client.cert
-    # keyKey: client.key
-    config: ""
-    serverName: ""
+## Section: database_read_replica:
+# All of the connection settings for MySQL read replica
+# Commented options are optional. Uncomment to use.
+# database_read_replica:
+#  # Name of the Secret resource containing MySQL password and TLS secrets
+#  address: 127.0.0.1:3306
+#  database: fleet
+#  username: fleet
+#  ## Password configuration. Pick whether you'd like to load from secret or from an accessible mount path.
+#  ## Added from Secret
+#  secretName: mysql-ro
+#  passwordKey: mysql-ro-password
+#  ## Added from Mount Path
+#  passwordPath: /path/to/password
+#  maxOpenConns: 50
+#  maxIdleConns: 50
+#  connMaxLifetime: 0
+#  tls:
+#    enabled: false
+#    ## Commented options below are optional.  Uncomment to use.
+#    # caCertKey: ca.cert
+#    ## Client certificates require both the certKey and keyKey
+#    # certKey: client.cert
+#    # keyKey: client.key
+#    config: ""
+#    serverName: ""
 
 ## Section: cache
 # All of the connection settings for Redis

--- a/charts/fleet/values.yaml
+++ b/charts/fleet/values.yaml
@@ -203,6 +203,27 @@ database:
     config: ""
     serverName: ""
 
+database_read_replica:
+  # Name of the Secret resource containing MySQL password and TLS secrets
+  address: 127.0.0.1:3306
+  database: fleet
+  username: fleet
+  secretName: mysql-ro
+  passwordKey: mysql-ro-password
+  passwordPath: /path/to/password
+  maxOpenConns: 50
+  maxIdleConns: 50
+  connMaxLifetime: 0
+  tls:
+    enabled: false
+    ## Commented options below are optional.  Uncomment to use.
+    # caCertKey: ca.cert
+    ## Client certificates require both the certKey and keyKey
+    # certKey: client.cert
+    # keyKey: client.key
+    config: ""
+    serverName: ""
+
 ## Section: cache
 # All of the connection settings for Redis
 cache:


### PR DESCRIPTION
- Added support for configuring read only replicas via values.yaml
- Added support for read only replica environment variables in deployment.yaml and cron-vulnprocessing.yaml