### PR TITLE
Updated labels to no longer include unsupported platform

### DIFF
--- a/it-and-security/lib/all/labels/debian-based-linux-hosts.yml
+++ b/it-and-security/lib/all/labels/debian-based-linux-hosts.yml
@@ -2,4 +2,3 @@
   description: Linux hosts running on Debian-based operating systems
   query: SELECT 1 FROM os_version WHERE platform_like = 'debian';
   label_membership_type: dynamic
-  platform: linux

--- a/it-and-security/lib/all/labels/rpm-based-linux-hosts.yml
+++ b/it-and-security/lib/all/labels/rpm-based-linux-hosts.yml
@@ -2,4 +2,3 @@
   description: Linux hosts running on RPM-based operating systems
   query: SELECT 1 FROM os_version WHERE platform_like = 'rhel';
   label_membership_type: dynamic
-  platform: linux


### PR DESCRIPTION
- Removed `platform: linux` from a few labels since linux is not a supported platform on labels