### PR TITLE
Update foreign-vitals-map-idp-users-to-hosts.md

### DIFF
--- a/articles/foreign-vitals-map-idp-users-to-hosts.md
+++ b/articles/foreign-vitals-map-idp-users-to-hosts.md
@@ -8,7 +8,7 @@ Fleet currently gathers your end user's IdP username when [end users log in](htt
 
 By connecting Fleet to your IdP to sync user data, you can add additional information, like the end user's groups and full name to your host data in Fleet. This allows you to leverage IdP information as variables in macOS configuration profiles to, for example, [deploy a WiFi certificate](https://fleetdm.com/guides/connect-end-user-to-wifi-with-certificate#step-4-add-pkcs-12-configuration-profile-to-fleet).
 
-Fleet currently supports syncing data with [Okta](#okta). [Microsoft Active Directory (AD) / Entra ID](#microsoft-entra-id), [Google Workspace](#google-workspace), and [authentik](#google-workspace), more are coming soon.
+Fleet currently supports syncing data with [Okta](#okta), [Microsoft Active Directory (AD) / Entra ID](#microsoft-entra-id), [Google Workspace](#google-workspace), and [authentik](#google-workspace), with support for more idPs coming soon.
 
 ## Okta
 

--- a/articles/foreign-vitals-map-idp-users-to-hosts.md
+++ b/articles/foreign-vitals-map-idp-users-to-hosts.md
@@ -4,10 +4,11 @@
 
 _Available in Fleet Premium._
 
-To add IdP host vitals, like the end user's groups and full name, follow steps for your IdP. 
+Fleet currently gathers your end user's IdP username when [end users log in](https://fleetdm.com/guides/macos-setup-experience#end-user-authentication) during the automatic enrollment (DEP) setup process.  
 
-Fleet currently supports [Okta](#okta). [Microsoft Active Directory (AD) / Entra ID](#microsoft-entra-id), [Google Workspace](#google-workspace), and [authentik](#google-workspace), more are coming soon.
+By connecting Fleet to your IdP to sync user data, you can add additional information, like the end user's groups and full name to your host data in Fleet. This allows you to leverage IdP information as variables in macOS configuration profiles. See [this guide](https://fleetdm.com/guides/connect-end-user-to-wifi-with-certificate#step-4-add-pkcs-12-configuration-profile-to-fleet) for deploying a wifi certificate for an example. 
 
+Fleet currently supports syncing data with [Okta](#okta). [Microsoft Active Directory (AD) / Entra ID](#microsoft-entra-id), [Google Workspace](#google-workspace), and [authentik](#google-workspace), more are coming soon.
 
 ## Okta
 
@@ -251,8 +252,6 @@ To map users from Google Workspace to hosts in Fleet, we'll do the following ste
 After following the steps above, you should be able to see the latest requests from your IdP to Fleet if you navigate to **Settings > Integrations > Identity Provider (IdP)**. 
 
 To verify that user information is added to a host, go to the host that has IdP username assigned, and verify that **Full name (IdP)** and **Groups (IdP)** are populated correctly.
-
-> Currently, the IdP username is only supported on macOS hosts. It's collected once, during automatic enrollment (DEP), only if the [end user authenticates](https://fleetdm.com/docs/rest-api/rest-api#mdm-macos-setup) with the IdP and the DEP profile has `await_device_configured` set to `true` (default in the [automatic enrollment profile](https://fleetdm.com/guides/macos-setup-experience#step-1-create-an-automatic-enrollment-profile)).
 
 ### Troubleshooting
 

--- a/articles/foreign-vitals-map-idp-users-to-hosts.md
+++ b/articles/foreign-vitals-map-idp-users-to-hosts.md
@@ -6,7 +6,7 @@ _Available in Fleet Premium._
 
 Fleet currently gathers your end user's IdP username when [end users log in](https://fleetdm.com/guides/macos-setup-experience#end-user-authentication) during the automatic enrollment (DEP) setup process.  
 
-By connecting Fleet to your IdP to sync user data, you can add additional information, like the end user's groups and full name to your host data in Fleet. This allows you to leverage IdP information as variables in macOS configuration profiles. See [this guide](https://fleetdm.com/guides/connect-end-user-to-wifi-with-certificate#step-4-add-pkcs-12-configuration-profile-to-fleet) for deploying a wifi certificate for an example. 
+By connecting Fleet to your IdP to sync user data, you can add additional information, like the end user's groups and full name to your host data in Fleet. This allows you to leverage IdP information as variables in macOS configuration profiles to, for example, [deploy a WiFi certificate](https://fleetdm.com/guides/connect-end-user-to-wifi-with-certificate#step-4-add-pkcs-12-configuration-profile-to-fleet).
 
 Fleet currently supports syncing data with [Okta](#okta). [Microsoft Active Directory (AD) / Entra ID](#microsoft-entra-id), [Google Workspace](#google-workspace), and [authentik](#google-workspace), more are coming soon.
 

--- a/articles/foreign-vitals-map-idp-users-to-hosts.md
+++ b/articles/foreign-vitals-map-idp-users-to-hosts.md
@@ -8,7 +8,7 @@ Fleet currently gathers your end user's IdP username when [end users log in](htt
 
 By connecting Fleet to your IdP to sync user data, you can add additional information, like the end user's groups and full name to your host data in Fleet. This allows you to leverage IdP information as variables in macOS configuration profiles to, for example, [deploy a WiFi certificate](https://fleetdm.com/guides/connect-end-user-to-wifi-with-certificate#step-4-add-pkcs-12-configuration-profile-to-fleet).
 
-Fleet currently supports syncing data with [Okta](#okta), [Microsoft Active Directory (AD) / Entra ID](#microsoft-entra-id), [Google Workspace](#google-workspace), and [authentik](#google-workspace), with support for more idPs coming soon.
+Fleet currently supports syncing data with [Okta](#okta), [Microsoft Active Directory (AD) / Entra ID](#microsoft-entra-id), [Google Workspace](#google-workspace), and [authentik](#google-workspace), with support for more IdPs coming soon.
 
 ## Okta
 


### PR DESCRIPTION
Brought information about when Fleet gathers IdP info to the top of the page. Added context about how this data can be used in Fleet.

# Checklist for submitter

Documentation change