### PR TITLE
Cherry-Pick: Fleet Helm Chart Updates

### DIFF
--- a/charts/fleet/Chart.yaml
+++ b/charts/fleet/Chart.yaml
@@ -4,7 +4,7 @@ name: fleet
 keywords:
   - fleet
   - osquery
-version: v6.6.6
+version: v6.6.7
 home: https://github.com/fleetdm/fleet
 sources:
   - https://github.com/fleetdm/fleet.git

--- a/charts/fleet/templates/cron-vulnprocessing.yaml
+++ b/charts/fleet/templates/cron-vulnprocessing.yaml
@@ -125,6 +125,67 @@ spec:
                 value: "{{ .Values.database.tls.serverName }}"
               {{- end }}
               ## END MYSQL SECTION
+              ## BEGIN MYSQL READ REPLICA SECTION
+              {{- if .Values.database_read_replica }}
+              {{- if .Values.database_read_replica.address }}
+              - name: FLEET_MYSQL_READ_REPLICA_ADDRESS
+                value: "{{ .Values.database_read_replica.address }}"
+              {{- end }}
+              {{- if .Values.database_read_replica.database }}
+              - name: FLEET_MYSQL_READ_REPLICA_DATABASE
+                value: "{{ .Values.database_read_replica.database }}"
+              {{- end }}
+              {{- if .Values.database_read_replica.username }}
+              - name: FLEET_MYSQL_READ_REPLICA_USERNAME
+                value: "{{ .Values.database_read_replica.username }}"
+              {{- end }}
+              {{- if .Values.database_read_replica.passwordPath }}
+              - name: FLEET_MYSQL_READ_REPLICA_PASSWORD_PATH
+                value: "{{ .Values.database_read_replica.passwordPath }}"
+              {{- end }}
+              {{- if .Values.database_read_replica.secretName }}
+              - name: FLEET_MYSQL_READ_REPLICA_PASSWORD
+                valueFrom:
+                  secretKeyRef:
+                    name: {{ .Values.database_read_replica.secretName }}
+                    key: {{ .Values.database_read_replica.passwordKey }}
+              {{- end }}
+              {{- if .Values.database_read_replica.maxOpenConns }}
+              - name: FLEET_MYSQL_READ_REPLICA_MAX_OPEN_CONNS
+                value: "{{ .Values.database_read_replica.maxOpenConns }}"
+              {{- end }}
+              {{- if .Values.database_read_replica.maxIdleConns }}
+              - name: FLEET_MYSQL_READ_REPLICA_MAX_IDLE_CONNS
+                value: "{{ .Values.database_read_replica.maxIdleConns }}"
+              {{- end }}
+              {{- if .Values.database_read_replica.connMaxLifetime }}
+              - name: FLEET_MYSQL_READ_REPLICA_CONN_MAX_LIFETIME
+                value: "{{ .Values.database_read_replica.connMaxLifetime }}"
+              {{- end }}
+              {{- if .Values.database_read_replica.tls.enabled }}
+              {{- if .Values.database_read_replica.tls.caCertKey }}
+              - name: FLEET_MYSQL_READ_REPLICA_TLS_CA
+                value: "/secrets/mysql/{{ .Values.database_read_replica.tls.caCertKey }}"
+              {{- end }}
+              {{- if .Values.database_read_replica.tls.certKey }}
+              - name: FLEET_MYSQL_READ_REPLICA_TLS_CERT
+                value: "/secrets/mysql/{{ .Values.database_read_replica.tls.certKey }}"
+              {{- end }}
+              {{- if .Values.database_read_replica.tls.keyKey }}
+              - name: FLEET_MYSQL_READ_REPLICA_TLS_KEY
+                value: "/secrets/mysql/{{ .Values.database_read_replica.tls.keyKey }}"
+              {{- end }}
+              {{- if .Values.database_read_replica.tls.config }}
+              - name: FLEET_MYSQL_READ_REPLICA_TLS_CONFIG
+                value: "{{ .Values.database_read_replica.tls.config }}"
+              {{- end }}
+              {{- if .Values.database_read_replica.tls.serverName }}
+              - name: FLEET_MYSQL_READ_REPLICA_TLS_SERVER_NAME
+                value: "{{ .Values.database_read_replica.tls.serverName }}"
+              {{- end }}
+              {{- end }}
+              {{- end }}
+              ## END MYSQL READ REPLICA SECTION
               ## BEGIN REDIS SECTION
               - name: FLEET_REDIS_ADDRESS
                 value: "{{ .Values.cache.address }}"
@@ -174,7 +235,9 @@ spec:
               {{- if .Values.fleet.securityContext.runAsUser }}
               runAsUser: {{ int64 .Values.fleet.securityContext.runAsUser }}
               {{- end }}
-              runAsNonRoot: true
+              {{- if .Values.fleet.securityContext.runAsNonRoot }}
+              runAsNonRoot: {{ .Values.fleet.securityContext.runAsNonRoot }}
+              {{- end }}
             volumeMounts:
               - name: tmp
                 mountPath: /tmp
@@ -209,7 +272,9 @@ spec:
               {{- if .Values.fleet.securityContext.runAsUser }}
               runAsUser: {{ int64 .Values.fleet.securityContext.runAsUser }}
               {{- end }}
-              runAsNonRoot: true
+              {{- if .Values.fleet.securityContext.runAsNonRoot }}
+              runAsNonRoot: {{ .Values.fleet.securityContext.runAsNonRoot }}
+              {{- end }}
           {{- end }}
           {{- with .Values.imagePullSecrets }}
           imagePullSecrets:

--- a/charts/fleet/templates/deployment.yaml
+++ b/charts/fleet/templates/deployment.yaml
@@ -143,6 +143,67 @@ spec:
             value: "{{ .Values.database.tls.serverName }}"
           {{- end }}
           ## END MYSQL SECTION
+          ## BEGIN MYSQL READ REPLICA SECTION
+          {{- if .Values.database_read_replica }}
+          {{- if .Values.database_read_replica.address }}
+          - name: FLEET_MYSQL_READ_REPLICA_ADDRESS
+            value: "{{ .Values.database_read_replica.address }}"
+          {{- end }}
+          {{- if .Values.database_read_replica.database }}
+          - name: FLEET_MYSQL_READ_REPLICA_DATABASE
+            value: "{{ .Values.database_read_replica.database }}"
+          {{- end }}
+          {{- if .Values.database_read_replica.username }}
+          - name: FLEET_MYSQL_READ_REPLICA_USERNAME
+            value: "{{ .Values.database_read_replica.username }}"
+          {{- end }}
+          {{- if .Values.database_read_replica.passwordPath }}
+          - name: FLEET_MYSQL_READ_REPLICA_PASSWORD_PATH
+            value: "{{ .Values.database_read_replica.passwordPath }}"
+          {{- end }}
+          {{- if .Values.database_read_replica.secretName }}
+          - name: FLEET_MYSQL_READ_REPLICA_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: {{ .Values.database_read_replica.secretName }}
+                key: {{ .Values.database_read_replica.passwordKey }}
+          {{- end }}
+          {{- if .Values.database_read_replica.maxOpenConns }}
+          - name: FLEET_MYSQL_READ_REPLICA_MAX_OPEN_CONNS
+            value: "{{ .Values.database_read_replica.maxOpenConns }}"
+          {{- end }}
+          {{- if .Values.database_read_replica.maxIdleConns }}
+          - name: FLEET_MYSQL_READ_REPLICA_MAX_IDLE_CONNS
+            value: "{{ .Values.database_read_replica.maxIdleConns }}"
+          {{- end }}
+          {{- if .Values.database_read_replica.connMaxLifetime }}
+          - name: FLEET_MYSQL_READ_REPLICA_CONN_MAX_LIFETIME
+            value: "{{ .Values.database_read_replica.connMaxLifetime }}"
+          {{- end }}
+          {{- if .Values.database_read_replica.tls.enabled }}
+          {{- if .Values.database_read_replica.tls.caCertKey }}
+          - name: FLEET_MYSQL_READ_REPLICA_TLS_CA
+            value: "/secrets/mysql/{{ .Values.database_read_replica.tls.caCertKey }}"
+          {{- end }}
+          {{- if .Values.database_read_replica.tls.certKey }}
+          - name: FLEET_MYSQL_READ_REPLICA_TLS_CERT
+            value: "/secrets/mysql/{{ .Values.database_read_replica.tls.certKey }}"
+          {{- end }}
+          {{- if .Values.database_read_replica.tls.keyKey }}
+          - name: FLEET_MYSQL_READ_REPLICA_TLS_KEY
+            value: "/secrets/mysql/{{ .Values.database_read_replica.tls.keyKey }}"
+          {{- end }}
+          {{- if .Values.database_read_replica.tls.config }}
+          - name: FLEET_MYSQL_READ_REPLICA_TLS_CONFIG
+            value: "{{ .Values.database_read_replica.tls.config }}"
+          {{- end }}
+          {{- if .Values.database_read_replica.tls.serverName }}
+          - name: FLEET_MYSQL_READ_REPLICA_TLS_SERVER_NAME
+            value: "{{ .Values.database_read_replica.tls.serverName }}"
+          {{- end }}
+          {{- end }}
+          {{- end }}
+          ## END MYSQL READ REPLICA SECTION
           ## BEGIN REDIS SECTION
           - name: FLEET_REDIS_ADDRESS
             value: "{{ .Values.cache.address }}"
@@ -312,7 +373,9 @@ spec:
           {{- if .Values.fleet.securityContext.runAsUser }}
           runAsUser: {{ int64 .Values.fleet.securityContext.runAsUser }}
           {{- end }}
-          runAsNonRoot: true
+          {{- if .Values.fleet.securityContext.runAsNonRoot }}
+          runAsNonRoot: {{ .Values.fleet.securityContext.runAsNonRoot }}
+          {{- end }}
         livenessProbe:
           httpGet:
             path: /healthz
@@ -375,7 +438,9 @@ spec:
           {{- if .Values.fleet.securityContext.runAsUser }}
           runAsUser: {{ int64 .Values.fleet.securityContext.runAsUser }}
           {{- end }}
-          runAsNonRoot: true
+          {{- if .Values.fleet.securityContext.runAsNonRoot }}
+          runAsNonRoot: {{ .Values.fleet.securityContext.runAsNonRoot }}
+          {{- end }}
       {{- end }}
       hostPID: false
       hostNetwork: false

--- a/charts/fleet/templates/job-migration.yaml
+++ b/charts/fleet/templates/job-migration.yaml
@@ -137,7 +137,9 @@ spec:
           {{- if .Values.fleet.securityContext.runAsUser }}
           runAsUser: {{ int64 .Values.fleet.securityContext.runAsUser }}
           {{- end }}
-          runAsNonRoot: true
+          {{- if .Values.fleet.securityContext.runAsNonRoot }}
+          runAsNonRoot: {{ .Values.fleet.securityContext.runAsNonRoot }}
+          {{- end }}
         volumeMounts:
           {{- if .Values.database.tls.enabled }}
           - name: mysql-tls
@@ -170,7 +172,9 @@ spec:
           {{- if .Values.fleet.securityContext.runAsUser }}
           runAsUser: {{ int64 .Values.fleet.securityContext.runAsUser }}
           {{- end }}
-          runAsNonRoot: true
+          {{- if .Values.fleet.securityContext.runAsNonRoot }}
+          runAsNonRoot: {{ .Values.fleet.securityContext.runAsNonRoot }}
+          {{- end }}
       {{- end }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/fleet/values.yaml
+++ b/charts/fleet/values.yaml
@@ -107,8 +107,9 @@ fleet:
     licenseKey: license-key
   extraVolumes: []
   extraVolumeMounts: []
-  # Currently only passes runAsUser and runAsGroup
+  # Currently only passes runAsNonRoot, runAsUser, runAsGroup
   securityContext:
+    runAsNonRoot: true
     runAsUser: 3333
     runAsGroup: 3333
 # Whether to make fleet vulnerability processing run in a dedicated container
@@ -202,6 +203,33 @@ database:
     # keyKey: client.key
     config: ""
     serverName: ""
+
+## Section: database_read_replica:
+# All of the connection settings for MySQL read replica
+# Commented options are optional. Uncomment to use.
+# database_read_replica:
+#  # Name of the Secret resource containing MySQL password and TLS secrets
+#  address: 127.0.0.1:3306
+#  database: fleet
+#  username: fleet-ro
+#  ## Password configuration. Pick whether you'd like to load from secret or from an accessible mount path.
+#  ## Added from Secret
+#  secretName: mysql-ro
+#  passwordKey: mysql-ro-password
+#  ## Added from Mount Path
+#  passwordPath: /path/to/password
+#  maxOpenConns: 50
+#  maxIdleConns: 50
+#  connMaxLifetime: 0
+#  tls:
+#    enabled: false
+#    ## Commented options below are optional.  Uncomment to use.
+#    # caCertKey: ca.cert
+#    ## Client certificates require both the certKey and keyKey
+#    # certKey: client.cert
+#    # keyKey: client.key
+#    config: ""
+#    serverName: ""
 
 ## Section: cache
 # All of the connection settings for Redis


### PR DESCRIPTION
- Increments Fleet Helm Chart version `6.6.6` -> `6.6.7`
- Adds support for controlling MySQL Read Replica variables from values.yaml (Section: `database_read_replica`)
- Adds support for controlling runAsNonRoot from values.yaml (Section: `fleet.securityContext`)