### PR TITLE
Handbook: core v. context

### DIFF
--- a/handbook/company/product-groups.md
+++ b/handbook/company/product-groups.md
@@ -376,9 +376,9 @@ To prioritize a new feature, it must meet one of these criteria:
 
 1. Bug
 2. Small UX improvement that isn't quite a bug but it's so small that it's worthwhile
-3. Contributes to Fleet's [quarterly key results (KRs)](https://docs.google.com/spreadsheets/d/1Hso0LxqwrRVINCyW_n436bNHmoqhoLhC8bcbvLPOs9A/edit?gid=1846478041#gid=1846478041&range=A1)
-4. High priority customer request (customer request, workflow blocking, etc.)
-5. Prospect request in an order form
+3. Contributes to Fleet's [Product roadmap] (found in the [🎯 Key results (OKRs) spreadsheet](https://docs.google.com/spreadsheets/d/1Hso0LxqwrRVINCyW_n436bNHmoqhoLhC8bcbvLPOs9A/edit?gid=1846478041#gid=1846478041))
+4. Core: a feature that accentuates and directly assists in the core purpose of the company: to guide people out of the thicket through the gift of openness. It's what differentiates us.
+5. Context: a feature that customers consider mission critical for their particular buying situation. Can either be an existing customer request or a prospect request in an order form.
 
 If an issue has the `~feature fest` label, then it's a new feature request that will be weighed at the next 🎁🗣 Feature Fest meeting.
 


### PR DESCRIPTION
- At Fleet, we features we prioritize are either [core or context](https://www.linkedin.com/pulse/core-vs-context-trap-how-product-teams-business-can-stay-bahrenburg-d5qzc/). 
  - We also added `~core` and `~context` labels because it’s important for the business to know which features fall under which bucket so we allocate resources efficiently. We want to spend more time on core features. These are what make Fleet, Fleet. We guide people out of the thicket through openness.
  - Core and context definitions are from the now archived [Why Fleet Google doc](https://docs.google.com/document/d/1Vr0F218Acr69eAgaD38zsyUUQ3Ik9HDEAlitT911BzU/edit?tab=t.0.).
