### PR TITLE
Fix issue saving labels

### DIFF
--- a/frontend/pages/labels/NewLabelPage/DynamicLabel/DynamicLabel.tsx
+++ b/frontend/pages/labels/NewLabelPage/DynamicLabel/DynamicLabel.tsx
@@ -7,6 +7,7 @@ import { AppContext } from "context/app";
 import { NotificationContext } from "context/notification";
 import { getPathWithQueryParams } from "utilities/url";
 import { IApiError } from "interfaces/errors";
+import { API_ALL_TEAMS_ID, APP_CONTEXT_ALL_TEAMS_ID } from "interfaces/team";
 
 import DynamicLabelForm from "pages/labels/components/DynamicLabelForm";
 import { IDynamicLabelFormData } from "pages/labels/components/DynamicLabelForm/DynamicLabelForm";
@@ -38,7 +39,10 @@ const DynamicLabel = ({
         .then((res) => {
           router.push(
             getPathWithQueryParams(PATHS.MANAGE_HOSTS_LABEL(res.label.id), {
-              team_id: currentTeam?.id,
+              team_id:
+                currentTeam?.id === APP_CONTEXT_ALL_TEAMS_ID
+                  ? API_ALL_TEAMS_ID
+                  : currentTeam?.id || API_ALL_TEAMS_ID,
             })
           );
           renderFlash("success", "Label added successfully.");

--- a/frontend/pages/labels/NewLabelPage/DynamicLabel/DynamicLabel.tsx
+++ b/frontend/pages/labels/NewLabelPage/DynamicLabel/DynamicLabel.tsx
@@ -42,7 +42,7 @@ const DynamicLabel = ({
               team_id:
                 currentTeam?.id === APP_CONTEXT_ALL_TEAMS_ID
                   ? API_ALL_TEAMS_ID
-                  : currentTeam?.id || API_ALL_TEAMS_ID,
+                  : currentTeam?.id,
             })
           );
           renderFlash("success", "Label added successfully.");

--- a/frontend/pages/labels/NewLabelPage/ManualLabel/ManualLabel.tsx
+++ b/frontend/pages/labels/NewLabelPage/ManualLabel/ManualLabel.tsx
@@ -33,7 +33,7 @@ const ManualLabel = ({ router }: IManualLabelProps) => {
               team_id:
                 currentTeam?.id === APP_CONTEXT_ALL_TEAMS_ID
                   ? API_ALL_TEAMS_ID
-                  : currentTeam?.id || API_ALL_TEAMS_ID,
+                  : currentTeam?.id,
             })
           );
           renderFlash("success", "Label added successfully.");

--- a/frontend/pages/labels/NewLabelPage/ManualLabel/ManualLabel.tsx
+++ b/frontend/pages/labels/NewLabelPage/ManualLabel/ManualLabel.tsx
@@ -7,6 +7,7 @@ import { AppContext } from "context/app";
 import { NotificationContext } from "context/notification";
 import { getPathWithQueryParams } from "utilities/url";
 import { IApiError } from "interfaces/errors";
+import { API_ALL_TEAMS_ID, APP_CONTEXT_ALL_TEAMS_ID } from "interfaces/team";
 
 import ManualLabelForm from "pages/labels/components/ManualLabelForm";
 import { IManualLabelFormData } from "pages/labels/components/ManualLabelForm/ManualLabelForm";
@@ -29,7 +30,10 @@ const ManualLabel = ({ router }: IManualLabelProps) => {
         .then((res) => {
           router.push(
             getPathWithQueryParams(PATHS.MANAGE_HOSTS_LABEL(res.label.id), {
-              team_id: currentTeam?.id,
+              team_id:
+                currentTeam?.id === APP_CONTEXT_ALL_TEAMS_ID
+                  ? API_ALL_TEAMS_ID
+                  : currentTeam?.id || API_ALL_TEAMS_ID,
             })
           );
           renderFlash("success", "Label added successfully.");


### PR DESCRIPTION
# Details 
This PR fixes an issue where the user is redirected to a 500 error page after saving a new label if they were on the All Teams host page before creating the label.  The issue was due to the redirect having `team_id=-1` in it, and the fix is to detect that All Teams is selected and, if so, not set `team_id` in the URL at all.

# Checklist
<!-- Note that API documentation changes are now addressed by the product design team. -->
- [X] Manual QA for all new/changed functionality
- [X] For unreleased bug fixes in a release candidate, confirmed that the fix is not expected to adversely impact load test results or alerted the release DRI if additional load testing is needed.

# Testing

Tested adding a new and dynamic label from All Teams, No team and a custom team.  Vids below for "All Team":

Before:
![30036-before](https://github.com/user-attachments/assets/f958f31d-9b8d-4a61-8b3d-8d55590628fe)

After:
![30036-after](https://github.com/user-attachments/assets/0b424ed7-9bab-45cd-b4e5-2a6ae4a1309a)

