### PR TITLE
Fixed broken macos users causing errors during query ingestion

### DIFF
--- a/changes/29632-macos-missing-uid-ingest
+++ b/changes/29632-macos-missing-uid-ingest
@@ -1,0 +1,1 @@
+- Fixed broken macos users causing errors during query ingestion

--- a/server/service/osquery_utils/queries.go
+++ b/server/service/osquery_utils/queries.go
@@ -1737,6 +1737,10 @@ func shouldRemoveSoftware(h *fleet.Host, s *fleet.Software) bool {
 func directIngestUsers(ctx context.Context, logger log.Logger, host *fleet.Host, ds fleet.Datastore, rows []map[string]string) error {
 	var users []fleet.HostUser
 	for _, row := range rows {
+		if row["uid"] == "" {
+			// Under certain circumstances, broken users can come back with empty UIDs. We don't want them
+			continue
+		}
 		uid, err := strconv.Atoi(row["uid"])
 		if err != nil {
 			// Chrome returns uids that are much larger than a 32 bit int, ignore this.


### PR DESCRIPTION
#29632

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.
- [x] Added/updated automated tests
