### PR TITLE
Handle null HostID on calendar webhook endpoint

### DIFF
--- a/changes/10744-calendar-webhook-deleted-hosts
+++ b/changes/10744-calendar-webhook-deleted-hosts
@@ -1,0 +1,1 @@
+* Fixed bug with calendar/webhook endpoint that caused an error if the calendar event related to a deleted host.

--- a/changes/10744-calendar-webhook-deleted-hosts
+++ b/changes/10744-calendar-webhook-deleted-hosts
@@ -1,1 +1,1 @@
-* Fixed bug with calendar/webhook endpoint that caused an error if the calendar event related to a deleted host.
+* Fixed bug with calendar/webhook endpoint that caused an error if the calendar event relates to a deleted host.

--- a/server/datastore/mysql/calendar_events_test.go
+++ b/server/datastore/mysql/calendar_events_test.go
@@ -83,7 +83,7 @@ func testUpdateCalendarEvent(t *testing.T, ds *Datastore) {
 	require.NoError(t, err)
 	assert.Equal(t, strings.ToUpper(eventUUIDNew), eventDetails.UUID)
 	assert.Equal(t, *calendarEvent, eventDetails.CalendarEvent)
-	assert.Equal(t, host.ID, eventDetails.HostID)
+	assert.Equal(t, host.ID, *eventDetails.HostID)
 	assert.Nil(t, eventDetails.TeamID)
 
 	// TODO(lucas): Add more tests here.

--- a/server/fleet/calendar_events.go
+++ b/server/fleet/calendar_events.go
@@ -60,7 +60,7 @@ func (ce *CalendarEvent) SaveDataItems(keysAndValues ...string) error {
 type CalendarEventDetails struct {
 	CalendarEvent
 	TeamID *uint `db:"team_id"` // Should not be nil, but is nullable in the database
-	HostID uint  `db:"host_id"`
+	HostID *uint `db:"host_id"`
 }
 
 type CalendarWebhookStatus int

--- a/server/service/integration_enterprise_test.go
+++ b/server/service/integration_enterprise_test.go
@@ -14399,6 +14399,14 @@ func (s *integrationEnterpriseTestSuite) TestCalendarCallback() {
 	require.Len(t, team1CalendarEvents, 1)
 	assert.Equal(t, previousEvent, team1CalendarEvents[0])
 
+	err = s.ds.DeleteHost(ctx, host1Team1.ID)
+	require.NoError(t, err)
+	_ = s.DoRawWithHeaders("POST", "/api/v1/fleet/calendar/webhook/"+eventRecreated.UUID, []byte(""), http.StatusOK,
+		map[string]string{
+			"X-Goog-Channel-Id":     details.ChannelID,
+			"X-Goog-Resource-State": "exists",
+		})
+
 	// Trigger calendar should cleanup the events
 	triggerAndWait(ctx, t, s.ds, s.calendarSchedule, 5*time.Second)
 	assert.Equal(t, 0, calendar.MockChannelsCount())


### PR DESCRIPTION
For 10744

When making a POST request to the calendar/webhook endpoint, do not error out if host record does not exists.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.
- [x] Added/updated automated tests
- [ ] Manual QA for all new/changed functionality