### PR TITLE
Kubernetes deploy guide updates

### DIFF
--- a/articles/deploy-fleet-on-kubernetes.md
+++ b/articles/deploy-fleet-on-kubernetes.md
@@ -389,7 +389,9 @@ If your Fleet deployment was successful, you should be able to access fleet with
 
 ## Fleet Upgrades
 
-Fleet requires that there be no active connections to the MySQL Fleet database, prior to initializing a deployment, as Database migrations are often included and risk failing. Below are instructions that can be followed to Upgrade Fleet using Helm or Terraform
+>Fleet requires that there be no active connections to the MySQL Fleet database, prior to initializing a deployment, as Database migrations are often included and risk failing. 
+
+Below are instructions that can be followed to upgrade Fleet using Helm or Terraform
 
 **Helm**
 

--- a/articles/deploy-fleet-on-kubernetes.md
+++ b/articles/deploy-fleet-on-kubernetes.md
@@ -258,7 +258,7 @@ helm upgrade --install fleet fleet \
 
 Let's start by cloning the [fleet-terraform repository](https://github.com/fleetdm/fleet-terraform).
 
-To configure preferences for Fleet for use in Terraform, including secret names, including secret names, MySQL and Redis hostnames, and TLS certificates, we'll be modifying `fleet-terraform/k8s/example/main.tf`.
+To configure Fleet preferences for use in Terraform, including secret names, MySQL and Redis hostnames, and TLS certificates, we'll modify `fleet-terraform/k8s/example/main.tf`.
 
 - Update the `main.tf` to include the details for the secret you've created containing your TLS certificate information.
  - Update `hostname` to match the SAN covered by your TLS secret (configured above)

--- a/articles/deploy-fleet-on-kubernetes.md
+++ b/articles/deploy-fleet-on-kubernetes.md
@@ -140,6 +140,7 @@ data:
 If you have a Fleet premium license that you'd like to configure.
 
 - Create and apply secret for the fleet-license
+
 ```yaml
 ---
 apiVersion: v1
@@ -190,6 +191,7 @@ ingress:
 ```
 
 - Update the `values.yaml` to include the details for the secret you've created containing the Fleet Premium license.
+
 ```yaml
 ...
 fleet:
@@ -201,6 +203,7 @@ fleet:
 ```
 
 - Update `values.yaml` to include the details for MySQL
+
 ```yaml
 ...
 ## Section: database
@@ -228,6 +231,7 @@ database:
 ```
 
 - Update `values.yaml` to include the details for Redis
+
 ```yaml
 ...
 ## Section: cache
@@ -263,6 +267,7 @@ To configure preferences for Fleet for use in Terraform, including secret names,
 ```txt
 hostname = "chart-example.local"
 ```
+
 ```txt
 ingress = {
     enabled = true
@@ -286,6 +291,7 @@ ingress = {
 ```
 
 - Update the `main.tf` to include the details for the secret you've created containing the Fleet Premium license.
+
 ```txt
 ...
     fleet = {
@@ -298,6 +304,7 @@ ingress = {
 ```
 
 - Update `main.tf` to include the details for MySQL
+
 ```txt
 ...
 database = {
@@ -324,6 +331,7 @@ database = {
 ```
 
 - Update `main.tf` to include the details for Redis
+
 ```txt
 ...
   cache = {

--- a/articles/deploy-fleet-on-kubernetes.md
+++ b/articles/deploy-fleet-on-kubernetes.md
@@ -345,7 +345,7 @@ database = {
 ...
 ```
 
-Before you can leverage the Terraform module, you will need to modify the `main.tf` with your configuration preferences for Fleet and `provider.tf` with your KUBECONFIG details for authentication. The following [link to the kubernetes provider terraform docs](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/guides/getting-started.html) has examples documented for AWS EKS, GCP GKE, and Azure.
+Before you can use the Terraform module, update `main.tf` with your configuration preferences for Fleet and `provider.tf` with your KUBECONFIG details for authentication. The following [link to the Kubernetes provider terraform docs](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/guides/getting-started.html) has examples documented for AWS EKS, GCP GKE, and Azure.
 
 ```txt
 provider "kubernetes" {

--- a/articles/deploy-fleet-on-kubernetes.md
+++ b/articles/deploy-fleet-on-kubernetes.md
@@ -24,7 +24,7 @@ Additionally, ensure a namespace is created or already exists for your Fleet dep
 kubectl create ns <namespace>
 ```
 
-## Installing Infrastructure Dependencies with Helm
+## Install Infrastructure Dependencies with Helm
 
 ### MySQL
 

--- a/articles/deploy-fleet-on-kubernetes.md
+++ b/articles/deploy-fleet-on-kubernetes.md
@@ -46,7 +46,7 @@ helm install fleet-database \
 
 This helm package will create a Kubernetes `Service` which exposes the MySQL server to the rest of the cluster on the following DNS address:
 
-```
+```txt
 fleet-database-mysql:3306
 ```
 
@@ -67,7 +67,7 @@ helm install fleet-cache \
 
 This helm package will create a Kubernetes `Service` which exposes the Redis server to the rest of the cluster on the following DNS address:
 
-```
+```txt
 fleet-cache-redis-master:6379
 ```
 
@@ -201,7 +201,7 @@ fleet:
 ```
 
 - Update `values.yaml` to include the details for MySQL
-```
+```yaml
 ...
 ## Section: database
 # All of the connection settings for MySQL
@@ -260,10 +260,10 @@ To configure preferences for Fleet for use in Terraform, including secret names,
  - Update `hostname` to match the SAN covered by your TLS secret (configured above)
  - Update `ingress` to match the details of `hostname` and the name of the secret that you've configured. In the example the secret name is `chart-example-tls`
 
-```
+```txt
 hostname = "chart-example.local"
 ```
-```
+```txt
 ingress = {
     enabled = true
     class_name = ""
@@ -286,7 +286,7 @@ ingress = {
 ```
 
 - Update the `main.tf` to include the details for the secret you've created containing the Fleet Premium license.
-```
+```txt
 ...
     fleet = {
       ...
@@ -298,7 +298,7 @@ ingress = {
 ```
 
 - Update `main.tf` to include the details for MySQL
-```yaml
+```txt
 ...
 database = {
     enabled = false
@@ -324,7 +324,7 @@ database = {
 ```
 
 - Update `main.tf` to include the details for Redis
-```yaml
+```txt
 ...
   cache = {
       enabled = false
@@ -339,7 +339,7 @@ database = {
 
 Before you can leverage the Terraform module, you will need to modify the `main.tf` with your configuration preferences for Fleet and `provider.tf` with your KUBECONFIG details for authentication. The following [link to the kubernetes provider terraform docs](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/guides/getting-started.html) has examples documented for AWS EKS, GCP GKE, and Azure.
 
-```
+```txt
 provider "kubernetes" {
   # config_path = "/path/to/kubeconfig"
   config_path = ""
@@ -350,21 +350,21 @@ Once you have those configured, run the following:
 
 1. If you have not used Terraform before, you must run the following to initialize your Terraform prior to installing Fleet:
 
-  ```sh
-  terraform init
-  ```
+```sh
+terraform init
+```
 
 2. To dry-run the Terraform deployment and see resources that Terraform believes will be deployed:
 
-  ```sh
-  terraform plan
-  ```
+```sh
+terraform plan
+```
 
 3. If you're happy with the results returned by the Terraform plan, you can apply the deployment:
 
-  ```sh
-  terraform apply
-  ```
+```sh
+terraform apply
+```
 
 I have a published [README.md](https://github.com/fleetdm/fleet-terraform/blob/main/k8s/README.md) with additional information and examples related to Fleet Kubernetes deployments through Terraform.
 

--- a/articles/deploy-fleet-on-kubernetes.md
+++ b/articles/deploy-fleet-on-kubernetes.md
@@ -30,7 +30,7 @@ kubectl create ns <namespace>
 
 > Skip if you already have a MySQL database that you plan on using.
 
-The MySQL that we will use for this tutorial is not replicated and it is not highly available. If you're deploying Fleet on a Kubernetes managed by a cloud provider (GCP, Azure, AWS, etc), I suggest using their MySQL product if possible as running HA MySQL in Kubernetes can be complex. To make this tutorial cloud provider agnostic however, we will use a non-replicated instance of MySQL.
+The MySQL that we will use for this tutorial is not replicated and is not highly available. If you're deploying Fleet on a Kubernetes managed by a cloud provider (GCP, Azure, AWS, etc.), I suggest using their MySQL product if possible, as running HA MySQL in Kubernetes can be complex. To make this tutorial cloud provider agnostic, however, we will use a non-replicated instance of MySQL.
 
 To install MySQL from Helm, run the following command.
 

--- a/articles/deploy-fleet-on-kubernetes.md
+++ b/articles/deploy-fleet-on-kubernetes.md
@@ -8,7 +8,7 @@ In this guide, we will focus on deploying Fleet only on a Kubernetes cluster usi
 
 ## Getting Started
 
-> You will need to have **Helm (v3)** and/or **Terraform (v1.10.2**).
+> You will need to have [Helm (v3)](https://github.com/helm/helm/releases) and/or [Terraform (v1.10.2)](https://developer.hashicorp.com/terraform/install).
 > - If you intend to deploy using the Fleet Helm chart, you will only need to have Helm (v3).
 > - If you intend to deploy using Terraform, you will, at minimum, need Terraform installed. If you intend to deploy MySQL and/or Redis to your k8s cluster using this guide, for testing, then you will also need Helm (v3).
 

--- a/articles/deploy-fleet-on-kubernetes.md
+++ b/articles/deploy-fleet-on-kubernetes.md
@@ -30,7 +30,7 @@ kubectl create ns <namespace>
 
 > Skip if you already have a MySQL database that you plan on using.
 
-The MySQL that we will use for this tutorial is not replicated and it is not Highly Available. If you're deploying Fleet on a Kubernetes managed by a cloud provider (GCP, Azure, AWS, etc), I suggest using their MySQL product if possible as running HA MySQL in Kubernetes can be complex. To make this tutorial cloud provider agnostic however, we will use a non-replicated instance of MySQL.
+The MySQL that we will use for this tutorial is not replicated and it is not highly available. If you're deploying Fleet on a Kubernetes managed by a cloud provider (GCP, Azure, AWS, etc), I suggest using their MySQL product if possible as running HA MySQL in Kubernetes can be complex. To make this tutorial cloud provider agnostic however, we will use a non-replicated instance of MySQL.
 
 To install MySQL from Helm, run the following command.
 

--- a/articles/deploy-fleet-on-kubernetes.md
+++ b/articles/deploy-fleet-on-kubernetes.md
@@ -16,7 +16,7 @@ Before we get started with deploying Fleet through Helm or Terraform you will ne
 
 ## Installing infrastructure dependencies with Helm
 
-#### MySQL
+### MySQL
 
 > Skip if you already have a MySQL database that you plan on using.
 
@@ -44,7 +44,7 @@ We will use this address when we configure the Kubernetes deployment and databas
 - For the Fleet Helm Chart, this will be used in the `values.yaml`
 - For Terraform, in the `Terraform module/main.tf`.
 
-#### Redis
+### Redis
 
 > Skip if you already have a Redis cluster that you plan on using.
 
@@ -75,7 +75,7 @@ To apply the secrets, you can modify the examples below as necessary and deploy 
 kubectl apply -f <example-manifest.yml>
 ```
 
-#### MySQL and Redis
+### MySQL and Redis
 
 ```yaml
 ---
@@ -98,7 +98,7 @@ stringData:
   redis-password: <redis-password-here>
 ```
 
-#### TLS Certificates (nginx)
+### TLS Certificates (nginx)
 
 If you're going to be terminating TLS at your ingress (nginx) through either the Fleet Helm chart or Terraform, we'll need to create that secret.
 
@@ -120,11 +120,7 @@ data:
 
 While the examples below support ingress settings, they are limited to nginx. If you or your organization would like to use a specific ingress controller, they can be configured to handle and route traffic to the Fleet pods.
 
-#### Configuration
-
-Before attempting to deploy Fleet with Helm or Terraform, we need to edit the `values.yaml` (Helm) or `main.tf` (Terraform), we the configurations pertaining to your environment such as hostname
-
-#### Helm
+### Helm
 
 To configure preferences for Fleet for use in Helm, including secret names, MySQL and Redis hostnames, and TLS certificates, download the [values.yaml](https://raw.githubusercontent.com/fleetdm/fleet/main/charts/fleet/values.yaml) and change the settings to match your configuration.
 
@@ -139,7 +135,7 @@ helm upgrade --install fleet fleet \
   --values values.yaml
 ```
 
-#### Terraform
+### Terraform
 
 Let's start by cloning the [fleet-terraform repository](https://github.com/fleetdm/fleet-terraform).
 

--- a/articles/deploy-fleet-on-kubernetes.md
+++ b/articles/deploy-fleet-on-kubernetes.md
@@ -1,40 +1,32 @@
-# Deploy Fleet on Kubernetes with Helm
+# Deploy Fleet on Kubernetes
 
 > **Archived.** While still usable, this guide has not been updated recently. See the [Deploy Fleet](https://fleetdm.com/docs/deploy/deploy-fleet) docs for supported deployment methods.
 
+> Updated on May 8th, 2025, by [Jorge Falcon](https://github.com/BCTBB).
+
 ![Deploy Fleet on Kubernetes](../website/assets/images/articles/deploy-fleet-on-kubernetes-800x450@2x.png)
 
-> Updated on January 28, 2025, by [Noah Talerman](https://github.com/noahtalerman).
+In this guide, we will focus on deploying Fleet only on a Kubernetes cluster. This guide has been written and tested using k3s, but should function on self-hosted Kubernetes, Lightweight Kubernetes, or managed Kubernetes offerings.
 
-In this guide, we will focus on deploying Fleet only on a Kubernetes cluster. Kubernetes is a container orchestration tool that was open sourced by Google in 2014.
+## Pre-requisites
 
-## Initializing Helm
+You will need to have either Helm (v3) and/or Terraform (v1.10.2).
 
-If you have not used Helm before, you must run the following to initialize your cluster prior to installing Fleet:
+Before we can get started with deploying Fleet through Helm or Terraform, there are several pre-requisites that must exist beforehand.
 
-```sh
-helm init
-```
-
-> Note: The helm init command has been removed in Helm v3. It performed two primary functions. First, it installed Tiller which is no longer needed. Second, it set up directories and repositories where Helm configuration lived. This is now automated in Helm v3; if the directory is not present it will be created.
-
-## Deploying Fleet with Helm
-
-To configure preferences for Fleet for use in Helm, including secret names, MySQL and Redis hostnames, and TLS certificates, download the [values.yaml](https://raw.githubusercontent.com/fleetdm/fleet/main/charts/fleet/values.yaml) and change the settings to match your configuration.
-
-Please note you will need all dependencies configured prior to installing the Fleet Helm Chart as it will try and run database migrations immediately.
-
-Once you have those configured, run the following:
-
-```sh
-helm upgrade --install fleet fleet \
-  --repo https://fleetdm.github.io/fleet/charts \
-  --values values.yaml
-```
-
-The Fleet Helm Chart [README.md](https://github.com/fleetdm/fleet/blob/main/charts/fleet/README.md) also includes an example using namespaces, which is outside the scope of the examples below.
+1. Kubernetes Cluster
+2. Kubernetes Namespace
+3. MySQL database instance or MySQL database cluster
+4. MySQL secret(s) 
+5. Redis Cluster
+6. Redis secret(s)
+7. TLS secret(s)
 
 ## Installing infrastructure dependencies with Helm
+
+> If you already have a MySQL instance/cluster that you're planning on using, you can skip down to the Redis cluster Install.
+
+> If you already have a Redis cluster that you're planning on using, you can skip down the Helm or Terraform deployment.
 
 ### MySQL
 
@@ -45,17 +37,9 @@ To install MySQL from Helm, run the following command. Note that there are some 
 - There should be a `fleet` database created
 - The default user's username should be `fleet`
 
-Helm v2
-```sh
-helm install \
-  --name fleet-database \
-  --set auth.username=fleet,auth.database=fleet \
-  oci://registry-1.docker.io/bitnamicharts/mysql
-```
-
-Helm v3
 ```sh
 helm install fleet-database \
+  --namespace <namespace> \
   --set auth.username=fleet,auth.database=fleet \
   oci://registry-1.docker.io/bitnamicharts/mysql 
 ```
@@ -66,21 +50,15 @@ This helm package will create a Kubernetes `Service` which exposes the MySQL ser
 fleet-database-mysql:3306
 ```
 
-We will use this address when we configure the Kubernetes deployment and database migration job, but if you're not using a Helm-installed MySQL in your deployment, you'll have to change this in your Kubernetes config files. For the Fleet Helm Chart, this will be used in the `values.yaml`.
+We will use this address when we configure the Kubernetes deployment and database migration job, but if you're not using a Helm-installed MySQL in your deployment, you'll have to change this in your Kubernetes config files. 
+* For the Fleet Helm Chart, this will be used in the `values.yaml`
+* For Terraform, in the `Terraform module/main.tf`.
 
 ### Redis
 
-Helm v2
-```sh
-helm install \
-  --name fleet-cache \
-  --set persistence.enabled=false \
-  oci://registry-1.docker.io/bitnamicharts/redis
-```
-
-Helm v3
 ```sh
 helm install fleet-cache \
+  --namespace <namespace> \
   --set persistence.enabled=false \
   oci://registry-1.docker.io/bitnamicharts/redis
 ```
@@ -91,12 +69,114 @@ This helm package will create a Kubernetes `Service` which exposes the Redis ser
 fleet-cache-redis:6379
 ```
 
-We will use this address when we configure the Kubernetes deployment, but if you're not using a Helm-installed Redis in your deployment, you'll have to change this in your Kubernetes config files. If you are using the Fleet Helm Chart, this will also be used in the `values.yaml` file.
+We will use this address when we configure the Kubernetes deployment, but if you're not using a Helm-installed Redis in your deployment, you'll have to change this in your Kubernetes config files. 
+* For the Fleet Helm Chart, this will be used in the `values.yaml`
+* For Terraform, in the `Terraform module/main.tf`.
 
-<meta name="articleTitle" value="Deploy Fleet on Kubernetes with Helm">
-<meta name="authorGitHubUsername" value="marpaia">
-<meta name="authorFullName" value="Mike Arpaia">
+## Deployment
+
+While the examples below support ingress settings, they are limited to nginx. If you or your organization would like to use a specific ingress controller, they can be configured to handle and route traffic to the Fleet pods.
+
+### Helm
+
+To configure preferences for Fleet for use in Helm, including secret names, MySQL and Redis hostnames, and TLS certificates, download the [values.yaml](https://raw.githubusercontent.com/fleetdm/fleet/main/charts/fleet/values.yaml) and change the settings to match your configuration.
+
+Please note you will need all dependencies configured prior to installing the Fleet Helm Chart as it will try and run database migrations immediately.
+
+Once you have those configured, run the following:
+
+```sh
+helm upgrade --install fleet fleet \
+  --repo https://fleetdm.github.io/fleet/charts \
+  --namespace <namespace> \
+  --values values.yaml
+```
+
+### Terraform
+
+Let's start by cloning the [fleet-terraform repository](https://github.com/fleetdm/fleet-terraform/tree/tf-fleetk8s-support/addons).
+
+```sh
+git clone https://github.com/fleetdm/fleet-terraform.git
+```
+
+To configure preferences for Fleet for use in Terraform, including secret names, including secret names, MySQL and Redis hostnames, and TLS certificates, you'll need to create a new directory and copy over the contents of `fleet-terraform/k8s/example/`.
+
+Afterwards, you'll want to change your working directory to be the newly created directory containing the `main.tf` file. Here you will modify the `main.tf` with your configuration preferences for Fleet and `provider.tf` with your KUBECONFIG details for authentication. The following [link to the kubernetes provider terraform docs](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/guides/getting-started.html) has examples documented for AWS EKS, GCP GKE, and Azure.
+
+```
+provider "kubernetes" {
+  # config_path = "/path/to/kubeconfig"
+  config_path = ""
+}
+```
+
+Once you have those configured, run the following:
+
+1. If you have not used Terraform before, you must run the following to initialize your Terraform prior to installing Fleet:
+
+  ```sh
+  terraform init
+  ```
+
+2. To dry-run the Terraform deployment and see resources that Terraform believes will be deployed:
+
+  ```sh
+  terraform plan
+  ```
+
+3. If you're happy with the results returned by the Terraform plan, you can apply the deployment:
+
+  ```sh
+  terraform apply
+  ```
+
+I have a published [README.md](https://github.com/fleetdm/fleet-terraform/blob/tf-fleetk8s-support/k8s/README.md) with additional information and examples related to Fleet Kubernetes deployments through Terraform.
+
+## Verify the Deployment
+
+You can verify the status of your Fleet deployment, whether it was deployed with Helm or Terraform, by checking the status of the Kubernetes resources.
+
+```sh
+kubectl get deploy -n <namespace>
+kubectl get pods -n <namespace>
+```
+
+If your Fleet deployment was successful, you should be able to access fleet with the URL that you configured `https://fleet.localhost.local`.
+
+## Fleet Upgrades
+
+Fleet requires that there be no active connections to the MySQL Fleet database, prior to initializing a deployment, as Database migrations are often included and risk failing. Below are instructions that can be followed to Upgrade Fleet using Helm or Terraform
+
+### Helm
+
+If you've deployed Fleet with Helm, prior to an upgrade, you will need to update your `values.yml` to update the `imageTag` to be a newer version of a Fleet container image tag. Afterwards, you will need to make sure no Fleet pods are running.
+
+```sh
+kubectl scale -n <namespace> --replicas 0 deploy/fleet
+```
+
+When the Fleet `deployment` has been reduced to 0 running pods, you can proceed to upgrading Fleet.
+
+```sh
+helm upgrade --install fleet fleet \
+  --repo https://fleetdm.github.io/fleet/charts \ 
+  --namespace fleet2 \
+  --values ../../../values.yaml
+```
+
+### Terraform
+
+If you've deployed Fleet with Terraform, prior to an upgrade, you will need to update your `main.tf` to update the `image_tag` to be a newer version of Fleet container image tag. Afterwards, you can initiate a Terraform apply instructing Terraform to also initiate a database migration.
+
+```sh
+terraform apply -replace=module.fleet.kubernetes_deployment.fleet
+```
+
+<meta name="articleTitle" value="Deploy Fleet on Kubernetes">
+<meta name="authorGitHubUsername" value="BCTBB">
+<meta name="authorFullName" value="Jorge Falcon">
 <meta name="publishedOn" value="2017-11-18">
 <meta name="category" value="guides">
 <meta name="articleImageUrl" value="../website/assets/images/articles/deploy-fleet-on-kubernetes-800x450@2x.png">
-<meta name="description" value="Learn how to deploy Fleet on Kubernetes using Helm.">
+<meta name="description" value="Learn how to deploy Fleet on Kubernetes.">

--- a/articles/deploy-fleet-on-kubernetes.md
+++ b/articles/deploy-fleet-on-kubernetes.md
@@ -129,7 +129,7 @@ data:
 
 While the examples below support ingress settings, they are limited to nginx. If you or your organization would like to use a specific ingress controller, they can be configured to handle and route traffic to the Fleet pods.
 
-### Helm
+#### Helm
 
 To configure preferences for Fleet for use in Helm, including secret names, MySQL and Redis hostnames, and TLS certificates, download the [values.yaml](https://raw.githubusercontent.com/fleetdm/fleet/main/charts/fleet/values.yaml) and change the settings to match your configuration.
 
@@ -144,7 +144,7 @@ helm upgrade --install fleet fleet \
   --values values.yaml
 ```
 
-### Terraform
+#### Terraform
 
 Let's start by cloning the [fleet-terraform repository](https://github.com/fleetdm/fleet-terraform).
 

--- a/articles/deploy-fleet-on-kubernetes.md
+++ b/articles/deploy-fleet-on-kubernetes.md
@@ -161,7 +161,7 @@ When the Fleet `deployment` has been reduced to 0 running pods, you can proceed 
 ```sh
 helm upgrade --install fleet fleet \
   --repo https://fleetdm.github.io/fleet/charts \ 
-  --namespace fleet2 \
+  --namespace <namespace> \
   --values ../../../values.yaml
 ```
 

--- a/articles/deploy-fleet-on-kubernetes.md
+++ b/articles/deploy-fleet-on-kubernetes.md
@@ -221,10 +221,11 @@ If you've deployed Fleet with Terraform, prior to an upgrade, you will need to u
 terraform apply -replace=module.fleet.kubernetes_deployment.fleet
 ```
 
+
 <meta name="articleTitle" value="Deploy Fleet on Kubernetes">
-<meta name="authorGitHubUsername" value="BCTBB">
-<meta name="authorFullName" value="Jorge Falcon">
+<meta name="authorGitHubUsername" value="marpaia">
+<meta name="authorFullName" value="Mike Arpaia">
 <meta name="publishedOn" value="2017-11-18">
 <meta name="category" value="guides">
 <meta name="articleImageUrl" value="../website/assets/images/articles/deploy-fleet-on-kubernetes-800x450@2x.png">
-<meta name="description" value="Learn how to deploy Fleet on Kubernetes.">
+<meta name="description" value="Learn how to deploy Fleet on Kubernetes">

--- a/charts/fleet/values.yaml
+++ b/charts/fleet/values.yaml
@@ -189,7 +189,7 @@ database:
   address: 127.0.0.1:3306
   database: fleet
   username: fleet
-  passwordKey: password
+  passwordKey: mysql-password
   maxOpenConns: 50
   maxIdleConns: 50
   connMaxLifetime: 0
@@ -210,7 +210,7 @@ cache:
   database: "0"
   usePassword: false
   secretName: redis
-  passwordKey: password
+  passwordKey: redis-password
 
 ## Section: GKE
 # Settings that make running on Google Kubernetes Engine easier

--- a/charts/fleet/values.yaml
+++ b/charts/fleet/values.yaml
@@ -189,7 +189,7 @@ database:
   address: 127.0.0.1:3306
   database: fleet
   username: fleet
-  passwordKey: mysql-password
+  passwordKey: password
   maxOpenConns: 50
   maxIdleConns: 50
   connMaxLifetime: 0
@@ -210,7 +210,7 @@ cache:
   database: "0"
   usePassword: false
   secretName: redis
-  passwordKey: redis-password
+  passwordKey: password
 
 ## Section: GKE
 # Settings that make running on Google Kubernetes Engine easier


### PR DESCRIPTION
Updated Kubernetes deploy guide
- Now includes new Kubernetes deployment instructions using Helm and Terraform
- Added details for MySQL and Redis connection information when deployed with Helm
- Added details for adding your Fleet Premium license
- Added details for enabling TLS