### PR TITLE
29762: Fixed bug with run script modal on FreeTier.

### DIFF
--- a/changes/29762-run-script-modal-free-tier
+++ b/changes/29762-run-script-modal-free-tier
@@ -1,0 +1,1 @@
+* Fixed bug with the run script modal on the Hosts page when running under FreeTier due to invalid teamId filter.

--- a/frontend/interfaces/script.ts
+++ b/frontend/interfaces/script.ts
@@ -11,6 +11,12 @@ export interface IScript {
 export const isScriptSupportedPlatform = (hostPlatform: string) =>
   ["darwin", "windows", ...HOST_LINUX_PLATFORMS].includes(hostPlatform); // excludes chrome, ios, ipados, android see also https://github.com/fleetdm/fleet/blob/5a21e2cfb029053ddad0508869eb9f1f23997bf2/server/fleet/hosts.go#L775
 
+export const addTeamIdCriteria = (
+  pred: any,
+  teamId: number,
+  isFreeTier?: boolean
+) => (isFreeTier ? { ...pred } : { ...pred, team_id: teamId });
+
 export type IScriptExecutionStatus = "ran" | "pending" | "error";
 
 export interface ILastExecution {

--- a/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
@@ -2004,18 +2004,19 @@ const ManageHostsPage = ({
         totalFilteredHostsCount !== undefined && (
           <RunScriptBatchModal
             runByFilters={isAllMatchingHostsSelected}
-            // run script batch supports only these filters, plust team id
+            // run script batch supports only these filters, plus team id
             filters={{
               query: searchQuery || undefined,
               label_id: isNaN(Number(labelID)) ? undefined : Number(labelID),
               status: status || undefined,
             }}
-            // when running by filter, modal needs this count to report number of targeted hosts
+            // when running by filter, modal needs this count to report the number of targeted hosts
             totalFilteredHostsCount={totalFilteredHostsCount}
-            // when running by selected hosts, modal can use length of this array to report number of targeted
+            // when running by selected hosts, modal can use the length of this array to report the number of targeted
             // hosts
             selectedHostIds={selectedHostIds}
             teamId={currentTeamId}
+            isFreeTier={isFreeTier}
             onCancel={toggleRunScriptBatchModal}
           />
         )}

--- a/frontend/pages/hosts/ManageHostsPage/components/RunScriptBatchPaginatedList/RunScriptBatchPaginatedList.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/components/RunScriptBatchPaginatedList/RunScriptBatchPaginatedList.tsx
@@ -3,7 +3,7 @@ import { useQueryClient } from "react-query";
 
 import scriptAPI, { IScriptsResponse } from "services/entities/scripts";
 
-import { IScript } from "interfaces/script";
+import { addTeamIdCriteria, IScript } from "interfaces/script";
 
 import PaginatedList from "components/PaginatedList";
 import Button from "components/buttons/Button";
@@ -19,6 +19,7 @@ interface IRunScriptBatchPaginatedList {
   onRunScript: (script: IPaginatedListScript) => Promise<void>;
   isUpdating: boolean;
   teamId: number;
+  isFreeTier?: boolean;
   scriptCount: number;
   setScriptForDetails: (script: IPaginatedListScript) => void;
 }
@@ -28,6 +29,7 @@ export const SCRIPT_BATCH_PAGE_SIZE = 6;
 const RunScriptBatchPaginatedList = ({
   onRunScript: _onRunScript,
   isUpdating,
+  isFreeTier,
   teamId,
   scriptCount,
   setScriptForDetails,
@@ -40,12 +42,15 @@ const RunScriptBatchPaginatedList = ({
       // scripts not supported for All teams
       const fetchPromise = queryClient.fetchQuery(
         [
-          {
-            scope: "scripts",
-            team_id: teamId,
-            page: pageNumber,
-            per_page: SCRIPT_BATCH_PAGE_SIZE,
-          },
+          addTeamIdCriteria(
+            {
+              scope: "scripts",
+              page: pageNumber,
+              per_page: SCRIPT_BATCH_PAGE_SIZE,
+            },
+            teamId,
+            isFreeTier
+          ),
         ],
         ({ queryKey }) => {
           return scriptAPI.getScripts(queryKey[0]);
@@ -56,7 +61,7 @@ const RunScriptBatchPaginatedList = ({
         return scripts || [];
       });
     },
-    [queryClient, teamId]
+    [queryClient, teamId, isFreeTier]
   );
 
   const onRunScript = useCallback(


### PR DESCRIPTION
For #29762 

When running on FreeTier do not apply teamId criteria on end-point used by the Run Script modal.

# Checklist for submitter

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.
- [X] Manual QA for all new/changed functionality