### PR TITLE
Fix CPE/CVE validation test for iTerm2 for CVE-2024-38395

### DIFF
--- a/server/vulnerabilities/nvd/cve_test.go
+++ b/server/vulnerabilities/nvd/cve_test.go
@@ -409,8 +409,8 @@ func TestTranslateCPEToCVE(t *testing.T) {
 			excludedCVEs:      []string{"CVE-2024-37051"},
 			continuesToUpdate: true,
 		},
-		"cpe:2.3:a:iterm2:iterm2:3.5.2:*:*:*:*:*:*:*": {
-			includedCVEs: []cve{{ID: "CVE-2024-38395", resolvedInVersion: ""}},
+		"cpe:2.3:a:iterm2:iterm2:3.5.1:*:*:*:*:*:*:*": {
+			includedCVEs: []cve{{ID: "CVE-2024-38395", resolvedInVersion: "3.5.2"}},
 		},
 		"cpe:2.3:a:simple_password_store_project:simple_password_store:1.7.0:*:*:*:*:macos:*:*": {
 			includedCVEs: []cve{{ID: "CVE-2018-12356", resolvedInVersion: "1.7.2"}},


### PR DESCRIPTION
For #30118. Not sure why this worked before; CVE feeds must have been inaccurate given the CVE description.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->
- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [x] Added/updated automated tests