### PR TITLE
Fix issue where you cant delete a bootstrap package

### DIFF
--- a/changes/issue-30059-fix-no-delete-bootstrap
+++ b/changes/issue-30059-fix-no-delete-bootstrap
@@ -1,0 +1,1 @@
+- fix an issue where you could not delete a bootstrap package

--- a/frontend/utilities/endpoints.ts
+++ b/frontend/utilities/endpoints.ts
@@ -161,7 +161,7 @@ export default {
   MDM_APPLE_SETUP_ENROLLMENT_PROFILE: `/${API_VERSION}/fleet/mdm/apple/enrollment_profile`,
   MDM_BOOTSTRAP_PACKAGE_METADATA: (teamId: number) =>
     `/${API_VERSION}/fleet/mdm/bootstrap/${teamId}/metadata`,
-  MDM_BOOTSTRAP_PACKAGE: `/${API_VERSION}/fleet/mdm/bootstrap`,
+  MDM_BOOTSTRAP_PACKAGE: `/${API_VERSION}/fleet/bootstrap`,
   MDM_BOOTSTRAP_PACKAGE_SUMMARY: `/${API_VERSION}/fleet/mdm/bootstrap/summary`,
   MDM_SETUP: `/${API_VERSION}/fleet/mdm/apple/setup`,
   MDM_EULA: (token: string) => `/${API_VERSION}/fleet/mdm/setup/eula/${token}`,

--- a/server/service/apple_mdm.go
+++ b/server/service/apple_mdm.go
@@ -2833,7 +2833,7 @@ func (svc *Service) GetMDMAppleBootstrapPackageMetadata(ctx context.Context, tea
 
 type deleteBootstrapPackageRequest struct {
 	TeamID uint `url:"team_id"`
-	DryRun bool `json:"-" query:"dry_run,optional"` // if true, apply validation but do not delete
+	DryRun bool `query:"dry_run,optional"` // if true, apply validation but do not delete
 }
 
 type deleteBootstrapPackageResponse struct {


### PR DESCRIPTION
Fixes [#30059](https://github.com/fleetdm/fleet/issues/30059)

Fixes an issue where you couldn't delete a bootstrap package. The issue was an unused json struct tag for DryRun on the `deleteBootstrapPackageRequest` struct.

I also updated the UI to use the current endpoint to delete a bootstrap package

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
- [x] Manual QA for all new/changed functionality