### PR TITLE
Website: Update receive-from-clay webhook.

### DIFF
--- a/website/api/controllers/webhooks/receive-from-clay.js
+++ b/website/api/controllers/webhooks/receive-from-clay.js
@@ -84,6 +84,11 @@ module.exports = {
       }
     });
 
+    if(!recordIds.salesforceAccountId) {
+      sails.log.warn(`When the receive-from-clay received information about a user's activity (name: ${firstName} ${lastName}), activity: ${intentSignal}). A contact was successfully updated, but the webhook is unable to continue because this contact is not associated with any Salesforce account record. Contact ID: ${recordIds.salesforceContactId}`)
+      throw 'couldNotCreateActivity';
+    }
+
     let trimmedLinkedinUrl = linkedinUrl.replace(sails.config.custom.RX_PROTOCOL_AND_COMMON_SUBDOMAINS, '');
 
     // Create the new Fleet website page view record.

--- a/website/api/controllers/webhooks/receive-from-clay.js
+++ b/website/api/controllers/webhooks/receive-from-clay.js
@@ -85,7 +85,7 @@ module.exports = {
     });
 
     if(!recordIds.salesforceAccountId) {
-      sails.log.warn(`When the receive-from-clay received information about a user's activity (name: ${firstName} ${lastName}), activity: ${intentSignal}). A contact was successfully updated, but the webhook is unable to continue because this contact is not associated with any Salesforce account record. Contact ID: ${recordIds.salesforceContactId}`)
+      sails.log.warn(`When the receive-from-clay received information about a user's activity (name: ${firstName} ${lastName}), activity: ${intentSignal}). A contact was successfully updated, but the webhook is unable to continue because this contact is not associated with any Salesforce account record. Contact ID: ${recordIds.salesforceContactId}`);
       throw 'couldNotCreateActivity';
     }
 


### PR DESCRIPTION
Closes: https://github.com/fleetdm/confidential/issues/11058

Changes:
- Updated the receive from clay webhook to log a warning and return a `couldNotCreateActivity` response if it receives information about a contact record with no account record associated with it.