### PR TITLE
Add null check to fix manage automations issue

### DIFF
--- a/changes/30001-fix-manage-automations-bug
+++ b/changes/30001-fix-manage-automations-bug
@@ -1,0 +1,1 @@
+- Fixed issue causing a 500 error when clicking "Manage Automations" from the Queries page when osquery logging has certain configurations

--- a/frontend/interfaces/config.ts
+++ b/frontend/interfaces/config.ts
@@ -225,7 +225,7 @@ export interface ILoggingConfig {
   json: boolean;
   result: {
     plugin: LogDestination;
-    config: {
+    config?: {
       status_log_file: string;
       result_log_file: string;
       enable_log_rotation: boolean;
@@ -234,7 +234,7 @@ export interface ILoggingConfig {
       result_url?: string;
     };
   };
-  status: {
+  status?: {
     plugin: string;
     config: {
       status_log_file: string;

--- a/frontend/pages/queries/ManageQueriesPage/ManageQueriesPage.tsx
+++ b/frontend/pages/queries/ManageQueriesPage/ManageQueriesPage.tsx
@@ -370,9 +370,9 @@ const ManageQueriesPage = ({
             availableQueries={queriesAvailableToAutomate}
             automatedQueryIds={automatedQueryIds}
             logDestination={config?.logging.result.plugin || ""}
-            webhookDestination={config?.logging.result.config.result_url}
+            webhookDestination={config?.logging.result.config?.result_url || ""}
             filesystemDestination={
-              config?.logging.result.config.result_log_file
+              config?.logging.result.config?.result_log_file
             }
           />
         )}

--- a/frontend/pages/queries/ManageQueriesPage/ManageQueriesPage.tsx
+++ b/frontend/pages/queries/ManageQueriesPage/ManageQueriesPage.tsx
@@ -370,7 +370,7 @@ const ManageQueriesPage = ({
             availableQueries={queriesAvailableToAutomate}
             automatedQueryIds={automatedQueryIds}
             logDestination={config?.logging.result.plugin || ""}
-            webhookDestination={config?.logging.result.config?.result_url || ""}
+            webhookDestination={config?.logging.result.config?.result_url}
             filesystemDestination={
               config?.logging.result.config?.result_log_file
             }

--- a/frontend/pages/queries/details/QueryDetailsPage/QueryDetailsPage.tsx
+++ b/frontend/pages/queries/details/QueryDetailsPage/QueryDetailsPage.tsx
@@ -367,7 +367,7 @@ const QueryDetailsPage = ({
                 <LogDestinationIndicator
                   logDestination={config?.logging.result.plugin || ""}
                   filesystemDestination={
-                    config?.logging.result.config.result_log_file
+                    config?.logging.result.config?.result_log_file
                   }
                 />
               </div>

--- a/frontend/pages/queries/edit/components/EditQueryForm/EditQueryForm.tsx
+++ b/frontend/pages/queries/edit/components/EditQueryForm/EditQueryForm.tsx
@@ -886,7 +886,7 @@ const EditQueryForm = ({
                       <LogDestinationIndicator
                         logDestination={config?.logging.result.plugin || ""}
                         filesystemDestination={
-                          config?.logging.result.config.result_log_file
+                          config?.logging.result.config?.result_log_file
                         }
                         excludeTooltip
                       />

--- a/frontend/pages/queries/edit/components/SaveQueryModal/SaveQueryModal.tsx
+++ b/frontend/pages/queries/edit/components/SaveQueryModal/SaveQueryModal.tsx
@@ -276,7 +276,7 @@ const SaveQueryModal = ({
                 <LogDestinationIndicator
                   logDestination={config?.logging.result.plugin || ""}
                   filesystemDestination={
-                    config?.logging.result.config.result_log_file
+                    config?.logging.result.config?.result_log_file
                   }
                   excludeTooltip
                 />


### PR DESCRIPTION
For #30001

# Details

When Fleet is started with logging configured in a way such that the logging plugin has no `config`, clicking "Manage Automations" on the manage queries page results in a 500 page.  An example config would be:

```
fdm up --server_address=localhost:8080 --dev --dev_license --logging_debug --osquery_result_log_plugin=stdout --osquery_status_log_plugin=stdout --activity_audit_log_plugin=stdout
```

This PR fixes the issue by adding null protection for cases where the `config` object is empty for the logging plugin.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.
- [X] Manual QA for all new/changed functionality
