### PR TITLE
Website: Update URL of Microsoft proxy page.

### DIFF
--- a/website/config/routes.js
+++ b/website/config/routes.js
@@ -506,7 +506,7 @@ module.exports.routes = {
     }
   },
 
-  'GET /microsoft-compliance-partner/turn-on-mdm': {
+  'GET /microsoft-compliance-partner/enroll': {
     action: 'microsoft-proxy/view-turn-on-mdm',
     locals: {
       showConfigurationProfileLayout: true,


### PR DESCRIPTION
Changes:
- Updated the URL of the "Turn on MDM" page used for the Microsoft compliance proxy to be at /microsoft-compliance-partner/enroll.