### PR TITLE
Drop a few more font size overrides

### DIFF
--- a/frontend/components/AddHostsModal/PlatformWrapper/_styles.scss
+++ b/frontend/components/AddHostsModal/PlatformWrapper/_styles.scss
@@ -29,7 +29,6 @@
     &__textarea {
       font-family: "SourceCodePro", $monospace;
       font-weight: $bold;
-      font-size: 13px;
       color: $core-fleet-blue;
       line-height: 20px;
       line-break: anywhere;

--- a/frontend/components/SQLEditor/_styles.scss
+++ b/frontend/components/SQLEditor/_styles.scss
@@ -35,7 +35,6 @@
   .ace_placeholder {
     font-family: "SourceCodePro", $monospace;
     margin: initial;
-    font-size: 15px;
   }
 
   &__help-text {

--- a/frontend/pages/hosts/details/HostDetailsPage/modals/BootstrapPackageModal/_styles.scss
+++ b/frontend/pages/hosts/details/HostDetailsPage/modals/BootstrapPackageModal/_styles.scss
@@ -7,7 +7,6 @@
   &__details {
     background-color: $ui-fleet-blue-10;
     font-family: "SourceCodePro", $monospace;
-    font-size: 13px;
     color: $core-fleet-blue;
     padding: 10px;
     border: 1px solid $ui-fleet-black-10;


### PR DESCRIPTION
For #27951.

### Host enroll

Before:

<img width="759" alt="image" src="https://github.com/user-attachments/assets/df7aa542-724c-4e61-a4c9-49f794c470ec" />

After:

<img width="750" alt="image" src="https://github.com/user-attachments/assets/c23d6403-9c47-4af5-80f2-5fce712cec8c" />

### SQL editor (placeholder on software pre-install query in edit modal)

Before:

<img width="761" alt="image" src="https://github.com/user-attachments/assets/32218586-fe3e-4531-afad-766e659a304f" />

After:

<img width="760" alt="image" src="https://github.com/user-attachments/assets/22e3a693-e017-4f62-9f27-4f9e0747520b" />

Bootstrap package modal only shows up on failed bootstrap package loads, so rather difficult to get to where this can be tested, but other outputs are 14px so this should be fine.

- [x] Manual QA for all new/changed functionality