### PR TITLE
disable uploading EULA in UI when gitops is enabled

### DIFF
--- a/changes/issue-28143-disable-ui-eula-upload-gitops
+++ b/changes/issue-28143-disable-ui-eula-upload-gitops
@@ -1,0 +1,1 @@
+- remove ability to upload a EULA in the UI if gitops is enabled

--- a/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/components/EulaSection/components/EulaUploader/EulaUploader.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/components/EulaSection/components/EulaUploader/EulaUploader.tsx
@@ -67,6 +67,7 @@ const EulaUploader = ({ onUpload }: IEulaUploaderProps) => {
         onFileUpload={onUploadFile}
         accept=".pdf"
         isLoading={showLoading}
+        gitopsCompatible
       />
     </div>
   );


### PR DESCRIPTION
Relates to #28143

remove ability to upload a EULA in the UI if gitops is enabled

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.
- [s] Manual QA for all new/changed functionality
