### PR TITLE
fix: Include Software URLs in fleet generate-gitops when software has URL

### DIFF
--- a/changes/29617-software-url-gitops
+++ b/changes/29617-software-url-gitops
@@ -1,0 +1,1 @@
+* Added missing "url" parameter when exporting YAML on software packages that have a URL specified (thanks @drvcodenta!)

--- a/cmd/fleetctl/fleetctl/generate_gitops.go
+++ b/cmd/fleetctl/fleetctl/generate_gitops.go
@@ -1207,6 +1207,10 @@ func (cmd *GenerateGitopsCommand) generateSoftware(filePath string, teamId uint,
 			if softwareTitle.SoftwarePackage.SelfService {
 				softwareSpec["self_service"] = softwareTitle.SoftwarePackage.SelfService
 			}
+
+			if softwareTitle.SoftwarePackage.URL != "" {
+				softwareSpec["url"] = softwareTitle.SoftwarePackage.URL
+			}
 		}
 
 		if cmd.AppConfig.License.IsPremium() {

--- a/cmd/fleetctl/fleetctl/generate_gitops_test.go
+++ b/cmd/fleetctl/fleetctl/generate_gitops_test.go
@@ -340,6 +340,7 @@ func (MockClient) GetSoftwareTitleByID(ID uint, teamID *uint) (*fleet.SoftwareTi
 				UninstallScript:   "baz",
 				SelfService:       true,
 				Platform:          "darwin",
+				URL:               "https://example.com/download/my-software.pkg",
 			},
 		}, nil
 	case 2:

--- a/cmd/fleetctl/fleetctl/testdata/generateGitops/expectedTeamSoftware.yaml
+++ b/cmd/fleetctl/fleetctl/testdata/generateGitops/expectedTeamSoftware.yaml
@@ -12,6 +12,7 @@ packages:
     self_service: true
     uninstall_script:
       path: ../lib/some-team/scripts/my-software-package-darwin-uninstall
+    url: https://example.com/download/my-software.pkg
 app_store_apps:
   - app_store_id: com.example.team-software
     labels_exclude_any:


### PR DESCRIPTION
fixes: https://github.com/fleetdm/fleet/issues/29617
# Checklist for submitter

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [x] Manual QA for all new/changed functionality


I implemented support for exporting the url field in fleetctl generate-gitops when it's available in the software installer metadata. During testing, I found that although some Fleet-maintained apps (like Brave and Cloudflare WARP) show URLs in the UI, those URLs are not persisted to the database—hence they don’t appear in the generated YAML unless added manually. I confirmed the url field is supported in the database and properly handled in the insertion logic. The version field does get populated when the software is installed on a host. This patch completes the GitOps export part, but the root issue may lie in the ingestion flow of the url.

![image](https://github.com/user-attachments/assets/422c04cc-26f8-4607-83e0-b1772b8d81cf)
