### PR TITLE
Pin version of cloudflared to `2025.5.0`

### DIFF
--- a/.github/workflows/fleet-and-orbit.yml
+++ b/.github/workflows/fleet-and-orbit.yml
@@ -97,8 +97,12 @@ jobs:
           sudo sysctl -w net.core.rmem_max=2500000
 
           # Install cloudflared
-          wget https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-amd64.deb
+          #
+          # We pin to version 2025.5.0 because something broke with 2025.6.1.
+          # 2025.6.1 fails with "failed to create tunnel: Unknown output format 'default'"
+          wget https://github.com/cloudflare/cloudflared/releases/download/2025.5.0/cloudflared-linux-amd64.deb
           sudo dpkg -i cloudflared-linux-amd64.deb
+
           # Add secret
           echo "$CERT_PEM" | base64 -d > cert.pem
           # Start tunnel

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -63,8 +63,12 @@ jobs:
         sudo sysctl -w net.core.rmem_max=2500000
 
         # Install cloudflared
-        wget https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-amd64.deb
+        #
+        # We pin to version 2025.5.0 because something broke with 2025.6.1.
+        # 2025.6.1 fails with "failed to create tunnel: Unknown output format 'default'"
+        wget https://github.com/cloudflare/cloudflared/releases/download/2025.5.0/cloudflared-linux-amd64.deb
         sudo dpkg -i cloudflared-linux-amd64.deb
+
         # Add secret
         echo "$CERT_PEM" | base64 -d > cert.pem
         # Start tunnel


### PR DESCRIPTION
CI is failing with:
```
Selecting previously unselected package cloudflared.
(Reading database ... 219352 files and directories currently installed.)
Preparing to unpack cloudflared-linux-amd64.deb ...
Unpacking cloudflared (2025.6.1) ...
Setting up cloudflared (2025.6.1) ...
Processing triggers for man-db (2.12.0-4build2) ...
error parsing tunnel ID: fleet-test-81a7ab03-3e62-43a2-bdc0-8470dbdca600 is neither the ID nor the name of any of your tunnels
Awaiting tunnel ready...
failed to create tunnel: Unknown output format 'default'
Awaiting tunnel ready...
Awaiting tunnel ready...
[...]
```
E.g.: https://github.com/fleetdm/fleet/actions/runs/15746535584/job/44417207764?pr=30140

It's hard to troubleshoot what's going on with the latest version without good credentials, so we will pin the version for now as a workaround.