### PR TITLE
[Activity changes] Enroll personally owned (BYOD) iOS/iPadOS devices with work email (Managed Apple Account)

### DIFF
--- a/docs/Contributing/reference/audit-logs.md
+++ b/docs/Contributing/reference/audit-logs.md
@@ -560,7 +560,7 @@ This activity contains the following fields:
   "enrollment_id": null,
   "host_display_name": "MacBookPro16,1 (C08VQ2AXHT96)",
   "installed_from_dep": true,
-  "personal": false,
+  "personal_host": false,
   "mdm_platform": "apple"
 }
 ```

--- a/docs/Contributing/reference/audit-logs.md
+++ b/docs/Contributing/reference/audit-logs.md
@@ -545,18 +545,22 @@ This activity contains the following fields:
 Generated when a host is enrolled in Fleet's MDM.
 
 This activity contains the following fields:
-- "host_serial": Serial number of the host (Apple enrollments only, always empty for Microsoft).
+- "host_serial": Serial number of the host (Apple enrollments only, always empty for Microsoft). Only for company-owned hosts.
+- "enrollment_id": Enrollment identifier of the personal (BYOD) host (iPhone, iPad and Android enrollments only, `null` for other platforms).
 - "host_display_name": Display name of the host.
+- "personal_host": Whether the host is personal or company-owned.
 - "installed_from_dep": Whether the host was enrolled via DEP (Apple enrollments only, always false for Microsoft).
-- "mdm_platform": Used to distinguish between Apple and Microsoft enrollments. Can be "apple", "microsoft" or not present. If missing, this value is treated as "apple" for backwards compatibility.
+- "mdm_platform": Used to distinguish between Apple and Microsoft enrollments. Can be "apple", "Microsoft", "android", or not present. If missing, this value is treated as "apple" for backwards compatibility.
 
 #### Example
 
 ```json
 {
   "host_serial": "C08VQ2AXHT96",
+  "enrollment_id": null,
   "host_display_name": "MacBookPro16,1 (C08VQ2AXHT96)",
   "installed_from_dep": true,
+  "personal": false,
   "mdm_platform": "apple"
 }
 ```

--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -489,8 +489,12 @@ Returns a list of the activities that have been performed in Fleet. For a compre
 |:--------------- |:------- |:----- |:------------------------------------------------------------|
 | page            | integer | query | Page number of the results to fetch.                                                                                          |
 | per_page        | integer | query | Results per page.                                                                                                             |
-| order_key       | string  | query | What to order results by. Can be any column in the `activites` table.                                                         |
+| order_key       | string  | query | What to order results by. Can be any column in the `activities` table.                                                         |
 | order_direction | string  | query | **Requires `order_key`**. The direction of the order given the order key. Options include `"asc"` and `"desc"`. Default is `"asc"`. |
+| query | string | query | Search query keywords. Searchable fields include `user_name` and `user_email`.
+| activity_type | string | query | Indicates the activity `type` to filter by. See available activity types on the [Audit logs page](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/reference/audit-logs.md).
+| start_created_at | string | query | Filters to include only activities that happened after this date. If not specified, set to the earliest possible date.
+| end_created_at | string | query | Filters to include only activities that happened before this date. If not specified, set to now.
 
 #### Example
 

--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -6634,14 +6634,6 @@ None.
       "name": "🔳🏢 Company-owned iPads",
       "id": 3
     },
-    "ios_team_personal_hosts": {
-      "name": "📱🔐 Personal mobile devices",
-      "id": 1
-    },
-    "ipados_team_personal_hosts": {
-      "name": "📱🔐 Personal mobile devices",
-      "id": 1
-    },
   }
 ]
 ```

--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -6633,7 +6633,15 @@ None.
     "ipados_team": {
       "name": "🔳🏢 Company-owned iPads",
       "id": 3
-    }
+    },
+    "ios_team_personal_hosts": {
+      "name": "📱🔐 Personal mobile devices",
+      "id": 1
+    },
+    "ipados_team_personal_hosts": {
+      "name": "📱🔐 Personal mobile devices",
+      "id": 1
+    },
   }
 ]
 ```


### PR DESCRIPTION
UPDATE: @noahtalerman: We decided to add `enrollment_id`. We decided not to add `personal_host` (PR [here](https://github.com/fleetdm/fleet/pull/31191)). `enrollment_id` which is `null` except for personal enrollments where it has a value.

Closing this PR. Won't merge PRs to the `audit-logs.md` file. This file is edited during development.

---

Related to:

- #27390