### PR TITLE
stop erroring if a VPP app with darwin and ios versions is added to setup experience

### DIFF
--- a/changes/29506-ios-and-darwin-vpp
+++ b/changes/29506-ios-and-darwin-vpp
@@ -1,0 +1,2 @@
+- Fixed a bug that prevented users from adding VPP apps to macOS setup experience if the iOS version
+  of the app was also added to their team software library.

--- a/server/datastore/mysql/setup_experience.go
+++ b/server/datastore/mysql/setup_experience.go
@@ -157,11 +157,12 @@ LEFT JOIN
 	ON st.id = va.title_id
 LEFT JOIN
 	vpp_apps_teams vat
-	ON va.adam_id = vat.adam_id
+	ON va.adam_id = vat.adam_id AND va.platform = vat.platform
 WHERE
 	vat.global_or_team_id = ?
 AND
 	st.id IN (%s)
+AND va.platform = 'darwin'
 `, titleIDQuestionMarks)
 
 	stmtUnsetInstallers := `


### PR DESCRIPTION
> Closes #29506

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.
- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [x] Added/updated automated tests
- [x] Manual QA for all new/changed functionality
