### PR TITLE
Avoid unnecessary prepared statements in "select config from team" uncached queries

### DIFF
--- a/changes/30199-stmt-tweak
+++ b/changes/30199-stmt-tweak
@@ -1,1 +1,1 @@
-* Improved performance when pulling team agent options on Orbit config endpoint
+* Improved performance when pulling team agent options on Orbit and osquery config endpoints

--- a/changes/30199-stmt-tweak
+++ b/changes/30199-stmt-tweak
@@ -1,1 +1,1 @@
-* Improved performance when pulling team agent options on Orbit and osquery config endpoints
+* Improved performance when pulling team settings on osquery config and distributed read endpoints

--- a/changes/30199-stmt-tweak
+++ b/changes/30199-stmt-tweak
@@ -1,0 +1,1 @@
+* Improved performance when pulling team agent options on Orbit config endpoint

--- a/server/datastore/mysql/teams.go
+++ b/server/datastore/mysql/teams.go
@@ -408,9 +408,9 @@ func (ds *Datastore) TeamFeatures(ctx context.Context, tid uint) (*fleet.Feature
 }
 
 func teamFeaturesDB(ctx context.Context, q sqlx.QueryerContext, tid uint) (*fleet.Features, error) {
-	sql := `SELECT config->'$.features' as features FROM teams WHERE id = ?`
+	stmt := fmt.Sprintf(`SELECT config->'$.features' as features FROM teams WHERE id = %d`, tid) // safe due to uint
 	var raw *json.RawMessage
-	if err := sqlx.GetContext(ctx, q, &raw, sql, tid); err != nil {
+	if err := sqlx.GetContext(ctx, q, &raw, stmt); err != nil {
 		return nil, ctxerr.Wrap(ctx, err, "get team config features")
 	}
 

--- a/server/datastore/mysql/teams.go
+++ b/server/datastore/mysql/teams.go
@@ -394,9 +394,9 @@ func amountTeamsDB(ctx context.Context, db sqlx.QueryerContext) (int, error) {
 
 // TeamAgentOptions loads the agents options of a team.
 func (ds *Datastore) TeamAgentOptions(ctx context.Context, tid uint) (*json.RawMessage, error) {
-	sql := `SELECT config->'$.agent_options' FROM teams WHERE id = ?`
+	stmt := fmt.Sprintf(`SELECT config->'$.agent_options' FROM teams WHERE id = %d`, tid) // safe because uint
 	var agentOptions *json.RawMessage
-	if err := sqlx.GetContext(ctx, ds.reader(ctx), &agentOptions, sql, tid); err != nil {
+	if err := sqlx.GetContext(ctx, ds.reader(ctx), &agentOptions, stmt); err != nil {
 		return nil, ctxerr.Wrap(ctx, err, "select team")
 	}
 	return agentOptions, nil


### PR DESCRIPTION
For #30199. This is one of a few approaches to mitigate the issue the customer is seeing.

This is SQLi-safe because we're dealing with an unsigned int parameter, sprintf'd %d. Existing tests fully cover this path.

# Checklist for submitter

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.
- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [ ] Manual QA for all new/changed functionality