### PR TITLE
Expand scope of `macos_compatibility` extension

### DIFF
--- a/it-and-security/default.yml
+++ b/it-and-security/default.yml
@@ -85,6 +85,7 @@ queries:
   - path: ./lib/all/queries/collect-operating-system-information.yml
   - path: ./lib/all/queries/collect-known-vulnerable-chrome-extensions.yml
   - path: ./lib/macos/queries/detect-apns-certificate.yml
+  - path: ./lib/macos/queries/collect-macos-compatibility-data.yml
 controls: 
   enable_disk_encryption: true
   macos_migration:

--- a/it-and-security/lib/all/labels/macos-compatibility-extension-installed.yml
+++ b/it-and-security/lib/all/labels/macos-compatibility-extension-installed.yml
@@ -1,0 +1,5 @@
+- name: macOS compatibility extension installed
+  description: macOS hosts that have the macOS compatibility extension installed
+  query: SELECT 1 WHERE EXISTS (SELECT * FROM file_lines WHERE path = "/var/osquery/extensions.load" AND line = "/var/fleet/extensions/macos_compatibility_universal.ext");
+  label_membership_type: dynamic
+  platform: darwin

--- a/it-and-security/lib/macos/policies/install-macos-compatibility-extension.yml
+++ b/it-and-security/lib/macos/policies/install-macos-compatibility-extension.yml
@@ -6,5 +6,3 @@
   run_script:
     path: ../scripts/install-macos-compatibility-extension.sh
   platform: darwin
-  labels_include_any:
-    - Santa test devices

--- a/it-and-security/lib/macos/queries/collect-macos-compatibility-data.yml
+++ b/it-and-security/lib/macos/queries/collect-macos-compatibility-data.yml
@@ -8,4 +8,3 @@
   platform: "darwin"
   query: SELECT * FROM macos_compatibility;
   labels_include_any:
-    - macOS compatibility extension installed

--- a/it-and-security/lib/macos/queries/collect-macos-compatibility-data.yml
+++ b/it-and-security/lib/macos/queries/collect-macos-compatibility-data.yml
@@ -8,4 +8,4 @@
   platform: "darwin"
   query: SELECT * FROM macos_compatibility;
   labels_include_any:
-    - Santa test devices
+    - macOS compatibility extension installed

--- a/it-and-security/teams/workstations-canary.yml
+++ b/it-and-security/teams/workstations-canary.yml
@@ -162,7 +162,6 @@ policies:
 queries:
   - path: ../lib/macos/queries/detect-apple-intelligence.yml
   - path: ../lib/macos/queries/collect-santa-denied-logs.yml
-  - path: ../lib/macos/queries/collect-macos-compatibility-data.yml
 software:
   packages:
     - path: ../lib/macos/software/mozilla-firefox.yml # Mozilla Firefox for MacOS (universal)

--- a/it-and-security/teams/workstations.yml
+++ b/it-and-security/teams/workstations.yml
@@ -100,6 +100,7 @@ controls:
     - path: ../lib/windows/scripts/turn-off-mdm.ps1
     - path: ../lib/windows/scripts/create-admin-user.ps1
     - path: ../lib/linux/scripts/uninstall-fleetd-linux.sh
+    - path: ../lib/macos/scripts/install-macos-compatibility-extension.sh
 policies:
   - path: ../lib/macos/policies/1password-emergency-kit-check.yml
   - path: ../lib/macos/policies/update-firefox.yml
@@ -116,6 +117,7 @@ policies:
   - path: ../lib/windows/policies/1password-installed.yml
   - path: ../lib/windows/policies/update-1password.yml
   - path: ../lib/linux/policies/disk-encryption-check.yml
+  - path: ../lib/macos/policies/install-macos-compatibility-extension.yml
 queries:
   - path: ../lib/macos/queries/detect-apple-intelligence.yml
 software:


### PR DESCRIPTION
- Expanded scope of deployment to more than just our test devices
- Created label for scoped query reporting