### PR TITLE
Add new expected CVE to iTerm2, don't fail tests if additional CVEs are found

### DIFF
--- a/server/vulnerabilities/nvd/cve_test.go
+++ b/server/vulnerabilities/nvd/cve_test.go
@@ -410,7 +410,11 @@ func TestTranslateCPEToCVE(t *testing.T) {
 			continuesToUpdate: true,
 		},
 		"cpe:2.3:a:iterm2:iterm2:3.5.1:*:*:*:*:*:*:*": {
-			includedCVEs: []cve{{ID: "CVE-2024-38395", resolvedInVersion: "3.5.2"}},
+			includedCVEs: []cve{
+				{ID: "CVE-2024-38395", resolvedInVersion: "3.5.2"},
+				{ID: "CVE-2024-38396", resolvedInVersion: "3.5.2"},
+			},
+			continuesToUpdate: true,
 		},
 		"cpe:2.3:a:simple_password_store_project:simple_password_store:1.7.0:*:*:*:*:macos:*:*": {
 			includedCVEs: []cve{{ID: "CVE-2018-12356", resolvedInVersion: "1.7.2"}},


### PR DESCRIPTION
Confirmed that both CVEs apply to this version by checking against NVD.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Added/updated automated tests