### PR TITLE
Cherry-Pick: Add new expected CVE to iTerm2, don't fail tests if additional CVEs are found

### DIFF
--- a/server/vulnerabilities/nvd/cve_test.go
+++ b/server/vulnerabilities/nvd/cve_test.go
@@ -409,8 +409,12 @@ func TestTranslateCPEToCVE(t *testing.T) {
 			excludedCVEs:      []string{"CVE-2024-37051"},
 			continuesToUpdate: true,
 		},
-		"cpe:2.3:a:iterm2:iterm2:3.5.2:*:*:*:*:*:*:*": {
-			includedCVEs: []cve{{ID: "CVE-2024-38395", resolvedInVersion: ""}},
+		"cpe:2.3:a:iterm2:iterm2:3.5.1:*:*:*:*:*:*:*": {
+			includedCVEs: []cve{
+				{ID: "CVE-2024-38395", resolvedInVersion: "3.5.2"},
+				{ID: "CVE-2024-38396", resolvedInVersion: "3.5.2"},
+			},
+			continuesToUpdate: true,
 		},
 		"cpe:2.3:a:simple_password_store_project:simple_password_store:1.7.0:*:*:*:*:macos:*:*": {
 			includedCVEs: []cve{{ID: "CVE-2018-12356", resolvedInVersion: "1.7.2"}},


### PR DESCRIPTION
Merged into `main` in #30225. Merging to RC to avoid vulns test failures.