### PR TITLE
Don't require CVE-2024-38396 in iTerm2 CVE test to provide latitude for NVD flakiness

### DIFF
--- a/server/vulnerabilities/nvd/cve_test.go
+++ b/server/vulnerabilities/nvd/cve_test.go
@@ -412,7 +412,7 @@ func TestTranslateCPEToCVE(t *testing.T) {
 		"cpe:2.3:a:iterm2:iterm2:3.5.1:*:*:*:*:*:*:*": {
 			includedCVEs: []cve{
 				{ID: "CVE-2024-38395", resolvedInVersion: "3.5.2"},
-				{ID: "CVE-2024-38396", resolvedInVersion: "3.5.2"},
+				// NVD is being flakey so may not show this // {ID: "CVE-2024-38396", resolvedInVersion: "3.5.2"},
 			},
 			continuesToUpdate: true,
 		},


### PR DESCRIPTION
# Checklist for submitter

- [x] Added/updated automated tests