### PR TITLE
Wesbite: Update homepage ticker styles

### DIFF
--- a/website/assets/styles/pages/homepage.less
+++ b/website/assets/styles/pages/homepage.less
@@ -1461,9 +1461,7 @@
         display: block;
       }
     }
-    [purpose='option-container'] {
-      height: 33.6px;
-    }
+
     [purpose='feature-table'] {
       [purpose='feature-name'] {
         height: unset;
@@ -1478,6 +1476,9 @@
       padding-right: 17px;
       padding-bottom: 187px;
       height: 520px;
+      [purpose='option-container'] {
+        height: 33.6px;
+      }
     }
 
     [purpose='hero-background-image'] {


### PR DESCRIPTION
Closes: https://github.com/fleetdm/fleet/issues/30235

Changes:
- Updated the max height of the bottom ticker on the homepage to prevent it from being cut off vertically on smaller screens.