### PR TITLE
Fleet API: Return 0 hosts instead of 404 when filtering hosts by team x software non existent on that team

### DIFF
--- a/changes/26258-empty-host-software-filters
+++ b/changes/26258-empty-host-software-filters
@@ -1,0 +1,1 @@
+- Fixed software title id installer status filters to return empty array with 0 count instead of 404 when an installer is not present on a team

--- a/changes/26258-empty-host-software-filters
+++ b/changes/26258-empty-host-software-filters
@@ -1,1 +1,1 @@
-- Fixed software title id installer status filters to return empty array with 0 count instead of 404 when an installer is not present on a team
+- Fixed software title ID + installer status filters to return an empty array with 0 count instead of 404 when an installer is not present on a team

--- a/server/datastore/mysql/hosts.go
+++ b/server/datastore/mysql/hosts.go
@@ -1101,7 +1101,11 @@ func (ds *Datastore) applyHostFilters(
 			switch {
 			case fleet.IsNotFound(err):
 				vppApp, err := ds.GetVPPAppByTeamAndTitleID(ctx, opt.TeamFilter, *opt.SoftwareTitleIDFilter)
-				if err != nil {
+				if fleet.IsNotFound(err) {
+					// Neither installer nor VPP app exists → immediately return 0 hosts safelysts
+					softwareFilter = "FALSE"
+					break
+				} else if err != nil {
 					return "", nil, ctxerr.Wrap(ctx, err, "get vpp app by team and title id")
 				}
 				vppAppJoin, vppAppParams, err := ds.vppAppJoin(vppApp.VPPAppID, *opt.SoftwareStatusFilter)

--- a/server/service/software_titles.go
+++ b/server/service/software_titles.go
@@ -177,9 +177,6 @@ func (svc *Service) SoftwareTitleByID(ctx context.Context, id uint, teamID *uint
 
 			return nil, fleet.NewPermissionError("Error: You don't have permission to view specified software. It is installed on hosts that belong to team you don't have permissions to view.")
 		}
-		if fleet.IsNotFound(err) {
-			return nil, err // return unwrapped so the caller can check IsNotFound when doing the host software filter
-		}
 		return nil, ctxerr.Wrap(ctx, err, "getting software title by id")
 	}
 

--- a/server/service/software_titles.go
+++ b/server/service/software_titles.go
@@ -177,6 +177,9 @@ func (svc *Service) SoftwareTitleByID(ctx context.Context, id uint, teamID *uint
 
 			return nil, fleet.NewPermissionError("Error: You don't have permission to view specified software. It is installed on hosts that belong to team you don't have permissions to view.")
 		}
+		if fleet.IsNotFound(err) {
+			return nil, err // return unwrapped so the caller can check IsNotFound when doing the host software filter
+		}
 		return nil, ctxerr.Wrap(ctx, err, "getting software title by id")
 	}
 


### PR DESCRIPTION
## Issue
Closes #26258 

## Description
Returns 0 hosts instead of some random VPP error when software_status is valid but software_title_id doesn't exist on that team

## Screenshot of fix
<img width="1186" alt="Screenshot 2025-06-23 at 2 04 52 PM" src="https://github.com/user-attachments/assets/577cc05a-c8e4-4aaf-85c4-38ab9403018b" />


## Screenshot of before

<img width="1176" alt="Screenshot 2025-06-23 at 1 50 40 PM" src="https://github.com/user-attachments/assets/cb0b6ccd-79dd-4309-ae5d-c1c1b938292d" />

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Added/updated automated tests
- [x] Manual QA for all new/changed functionality
