### PR TITLE
Add VEX for CVE-2025-22874 and generate report

### DIFF
--- a/security/status.md
+++ b/security/status.md
@@ -43,6 +43,14 @@ Following is the vulnerability report of Fleet and its dependencies.
 - **Justification:** `vulnerable_code_not_in_execute_path`
 - **Timestamp:** 2025-04-14 16:30:01
 
+### [CVE-2025-22874](https://nvd.nist.gov/vuln/detail/CVE-2025-22874)
+- **Author:** @lucasmrod
+- **Status:** `not_affected`
+- **Status notes:** Fleet does not perform any verification of policies in client certificates (CertificatePolicies not set in VerifyOptions).
+- **Products:**: `fleet`,`pkg:golang/stdlib@1.24.2`
+- **Justification:** `vulnerable_code_cannot_be_controlled_by_adversary`
+- **Timestamp:** 2025-06-23 16:48:42
+
 ### [CVE-2025-21614](https://nvd.nist.gov/vuln/detail/CVE-2025-21614)
 - **Author:** @lucasmrod
 - **Status:** `not_affected`

--- a/security/vex/fleet/CVE-2025-22874.vex.json
+++ b/security/vex/fleet/CVE-2025-22874.vex.json
@@ -1,0 +1,26 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://openvex.dev/docs/public/vex-884858bd8439aa35a1ed9b844ed7d2ff8e1adb3f811c99662fde8eaac5b40475",
+  "author": "@lucasmrod",
+  "timestamp": "2025-06-23T16:48:42.096441-03:00",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2025-22874"
+      },
+      "timestamp": "2025-06-23T16:48:42.096442-03:00",
+      "products": [
+        {
+          "@id": "fleet"
+        },
+        {
+          "@id": "pkg:golang/stdlib@1.24.2"
+        }
+      ],
+      "status": "not_affected",
+      "status_notes": "Fleet does not perform any verification of policies in client certificates (CertificatePolicies not set in VerifyOptions)",
+      "justification": "vulnerable_code_cannot_be_controlled_by_adversary"
+    }
+  ]
+}


### PR DESCRIPTION
We missed to add this when we upgraded Go to 1.24.4.
Report https://github.com/fleetdm/fleet/actions/runs/15626203997/job/44020838145 

How to test (with and without the new VEX file):
```
docker scout cves --only-fixed --vex-location=./security/vex/fleet --only-vex-affected --only-severity high,critical fleetdm/fleet:v4.69.0
```