### PR TITLE
Software page: Hide "Available for install / Self-service" dropdown for "All teams" and Fleet Free

### DIFF
--- a/frontend/pages/SoftwarePage/SoftwareTitles/SoftwareTable/SoftwareTable.tests.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitles/SoftwareTable/SoftwareTable.tests.tsx
@@ -54,9 +54,11 @@ describe("Software table", () => {
 
     expect(screen.getByText("Software inventory disabled")).toBeInTheDocument();
     expect(screen.queryByText("Vulnerability")).toBeNull();
+    expect(screen.queryByText("All software")).toBeNull();
+    expect(screen.queryByText("Available for install")).toBeNull();
   });
 
-  it("Renders the page-wide empty state when no software are present", () => {
+  it("Renders the page-wide empty state when no software are present hiding available for install dropdown filter", () => {
     const render = createCustomRenderer({
       context: {
         app: {
@@ -102,9 +104,11 @@ describe("Software table", () => {
     expect(screen.getByText("0 items")).toBeInTheDocument();
     expect(screen.queryByText("Search")).toBeNull();
     expect(screen.queryByText("Updated")).toBeNull();
+    expect(screen.queryByText("All software")).toBeNull();
+    expect(screen.queryByText("Available for install")).toBeNull();
   });
 
-  it("Renders the page-wide empty state when search query does not exist but versions toggle is applied", () => {
+  it("Renders the page-wide empty state hiding available for install dropdown when search query does not exist but versions toggle is applied", () => {
     const render = createCustomRenderer({
       context: {
         app: {
@@ -146,9 +150,11 @@ describe("Software table", () => {
     expect(
       screen.getByText("Expecting to see software? Check back later.")
     ).toBeInTheDocument();
+    expect(screen.queryByText("All software")).toBeNull();
+    expect(screen.queryByText("Available for install")).toBeNull();
   });
 
-  it("Renders the empty search state when search query does not exist but dropdown is applied", () => {
+  it("Renders the empty search state and 'Available for install' dropdown when search query does not exist but dropdown is applied", () => {
     const render = createCustomRenderer({
       context: {
         app: {
@@ -194,9 +200,10 @@ describe("Software table", () => {
         "Expecting to see installable software? Check back later."
       )
     ).toBeInTheDocument();
+    expect(screen.getByText("Available for install")).toBeInTheDocument();
   });
 
-  it("Renders the empty search state when search query does not exist but vulnerability filter is applied", () => {
+  it("Renders the empty search state and dropdown filter when search query does not exist but vulnerability filter is applied", () => {
     const render = createCustomRenderer({
       context: {
         app: {
@@ -242,5 +249,48 @@ describe("Software table", () => {
         "Expecting to see vulnerable software? Check back later."
       )
     ).toBeInTheDocument();
+    expect(screen.getByText("All software")).toBeInTheDocument();
+  });
+
+  it("does not render 'Available for install' dropdown filter when team id is undefined (Fleet Free/All teams)", () => {
+    const render = createCustomRenderer({
+      context: {
+        app: {
+          isGlobalAdmin: true,
+          currentUser: createMockUser(),
+        },
+      },
+    });
+
+    render(
+      <SoftwareTable
+        router={mockRouter}
+        isSoftwareEnabled
+        showVersions={false}
+        data={createMockSoftwareTitlesResponse({
+          counts_updated_at: null,
+          software_titles: [],
+        })}
+        installableSoftwareExists={false}
+        query=""
+        perPage={20}
+        orderDirection="asc"
+        orderKey="hosts_count"
+        softwareFilter="allSoftware"
+        vulnFilters={{
+          vulnerable: false,
+          exploit: false,
+          minCvssScore: undefined,
+          maxCvssScore: undefined,
+        }}
+        currentPage={0}
+        teamId={undefined} // Undefined for Fleet Free or Fleet Premium "All teams"
+        isLoading={false}
+        onAddFiltersClick={noop}
+      />
+    );
+
+    expect(screen.queryByText("All software")).toBeNull();
+    expect(screen.queryByText("Available for install")).toBeNull();
   });
 });

--- a/frontend/pages/SoftwarePage/SoftwareTitles/SoftwareTable/SoftwareTable.tests.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitles/SoftwareTable/SoftwareTable.tests.tsx
@@ -58,7 +58,7 @@ describe("Software table", () => {
     expect(screen.queryByText("Available for install")).toBeNull();
   });
 
-  it("Renders the page-wide empty state when no software are present hiding available for install dropdown filter", () => {
+  it("Renders the page-wide empty state when no software are present hiding 'Available for install' filter", () => {
     const render = createCustomRenderer({
       context: {
         app: {
@@ -108,7 +108,7 @@ describe("Software table", () => {
     expect(screen.queryByText("Available for install")).toBeNull();
   });
 
-  it("Renders the page-wide empty state hiding available for install dropdown when search query does not exist but versions toggle is applied", () => {
+  it("Renders the page-wide empty state hiding 'Available for install' filter when search query does not exist but versions toggle is applied", () => {
     const render = createCustomRenderer({
       context: {
         app: {
@@ -154,7 +154,7 @@ describe("Software table", () => {
     expect(screen.queryByText("Available for install")).toBeNull();
   });
 
-  it("Renders the empty search state and 'Available for install' dropdown when search query does not exist but dropdown is applied", () => {
+  it("Renders the empty search state and 'Available for install' filter when search query does not exist but filter is applied", () => {
     const render = createCustomRenderer({
       context: {
         app: {
@@ -203,7 +203,7 @@ describe("Software table", () => {
     expect(screen.getByText("Available for install")).toBeInTheDocument();
   });
 
-  it("Renders the empty search state and dropdown filter when search query does not exist but vulnerability filter is applied", () => {
+  it("Renders the empty search state and 'Available for install' filter when search query does not exist but vulnerability filter is applied", () => {
     const render = createCustomRenderer({
       context: {
         app: {
@@ -252,7 +252,7 @@ describe("Software table", () => {
     expect(screen.getByText("All software")).toBeInTheDocument();
   });
 
-  it("does not render 'Available for install' dropdown filter when team id is undefined (Fleet Free/All teams)", () => {
+  it("does not render 'Available for install' filter when team id is undefined (Fleet Free/All teams)", () => {
     const render = createCustomRenderer({
       context: {
         app: {

--- a/frontend/pages/SoftwarePage/SoftwareTitles/SoftwareTable/SoftwareTable.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitles/SoftwareTable/SoftwareTable.tsx
@@ -281,8 +281,9 @@ const SoftwareTable = ({
   };
 
   const renderCustomControls = () => {
-    // Hidden when viewing versions table
-    if (showVersions) {
+    // Hidden when viewing versions table or viewing "All teams" 
+    // or Fleet Free
+    if (showVersions || teamId === undefined) {
       return null;
     }
 
@@ -293,7 +294,6 @@ const SoftwareTable = ({
           value={softwareFilter}
           className={`${baseClass}__software-filter`}
           options={SOFTWARE_TITLES_DROPDOWN_OPTIONS}
-          isDisabled={teamId === undefined}
           onChange={(newValue: SingleValue<CustomOptionType>) =>
             newValue &&
             handleCustomFilterDropdownChange(

--- a/frontend/pages/SoftwarePage/SoftwareTitles/SoftwareTable/SoftwareTable.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitles/SoftwareTable/SoftwareTable.tsx
@@ -281,7 +281,7 @@ const SoftwareTable = ({
   };
 
   const renderCustomControls = () => {
-    // Hidden when viewing versions table or viewing "All teams" 
+    // Hidden when viewing versions table or viewing "All teams"
     // or Fleet Free
     if (showVersions || teamId === undefined) {
       return null;


### PR DESCRIPTION
For the following bug:
- #30273

- @noahtalerman: Heads up that I didn't get the chance to test this fix locally.