### PR TITLE
Fleet UI: Hide unusable dropdown from fleet free (4.70)

### DIFF
--- a/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
@@ -511,9 +511,11 @@ const HostDetailsPage = ({
     }
   );
 
-  const featuresConfig = host?.team_id
-    ? teams?.find((t) => t.id === host.team_id)?.features
-    : config?.features;
+  // Ensure using global config if team_id is stored but downgrade to fleet free
+  const featuresConfig =
+    host?.team_id && isPremiumTier
+      ? teams?.find((t) => t.id === host.team_id)?.features
+      : config?.features;
 
   const getOSVersionRequirementFromMDMConfig = (hostPlatform: string) => {
     const mdmConfig = host?.team_id

--- a/frontend/pages/hosts/details/cards/Software/HostSoftwareTable/HostSoftwareTable.tsx
+++ b/frontend/pages/hosts/details/cards/Software/HostSoftwareTable/HostSoftwareTable.tsx
@@ -1,4 +1,5 @@
-import React, { useCallback } from "react";
+import React, { useCallback, useContext } from "react";
+import { AppContext } from "context/app";
 import { InjectedRouter } from "react-router";
 
 import { IGetHostSoftwareResponse } from "services/entities/hosts";
@@ -100,6 +101,8 @@ const HostSoftwareTable = ({
   isMyDevicePage,
   onShowSoftwareDetails,
 }: IHostSoftwareTableProps) => {
+  const { isPremiumTier } = useContext(AppContext);
+
   const handleFilterDropdownChange = useCallback(
     (selectedFilter: SingleValue<CustomOptionType>) => {
       const newParams: QueryParams = {
@@ -308,7 +311,7 @@ const HostSoftwareTable = ({
         onQueryChange={onQueryChange}
         emptyComponent={memoizedEmptyComponent}
         customControl={
-          !isMyDevicePage && showFilterHeaders
+          isPremiumTier && !isMyDevicePage && showFilterHeaders
             ? memoizedFilterDropdown
             : undefined
         }


### PR DESCRIPTION
## Issue
Part of #30273 

## Note
- This dropdown is already removed in 4.71 with #29728 hence no cherry-pick from main
- This PR is to be consistent in 4.70 with #30274 work hiding unusual dropdown in Fleet Free

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

~~- [ ] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.~~ On other PR
- [x] Manual QA for all new/changed functionality

