### PR TITLE
UI: In Primo mode, enforce `No team` or `All teams`, depending on the page, to preserve premium functionality

### DIFF
--- a/changes/30198-handle-nuances-of-team-id-for-primo-mode
+++ b/changes/30198-handle-nuances-of-team-id-for-primo-mode
@@ -1,0 +1,2 @@
+- In Primo mode, push to `No team` when page supports it, otherwise `All teams`
+- Update UI in those cases

--- a/frontend/components/EnrollSecrets/EnrollSecretModal/EnrollSecretModal.tsx
+++ b/frontend/components/EnrollSecrets/EnrollSecretModal/EnrollSecretModal.tsx
@@ -10,7 +10,8 @@ import Icon from "components/Icon/Icon";
 import EnrollSecretTable from "../EnrollSecretTable";
 
 interface IEnrollSecretModal {
-  selectedTeam: number;
+  selectedTeamId: number;
+  primoMode: boolean;
   onReturnToApp: () => void;
   teams: ITeam[];
   toggleSecretEditorModal: () => void;
@@ -25,29 +26,23 @@ const baseClass = "enroll-secret-modal";
 
 const EnrollSecretModal = ({
   onReturnToApp,
-  selectedTeam,
+  selectedTeamId,
+  primoMode,
   teams,
   toggleSecretEditorModal,
   toggleDeleteSecretModal,
   setSelectedSecret,
   globalSecrets,
 }: IEnrollSecretModal): JSX.Element => {
-  const renderTeam = () => {
-    if (typeof selectedTeam === "string") {
-      selectedTeam = parseInt(selectedTeam, 10);
-    }
-
-    if (selectedTeam <= 0) {
-      return { name: "No team", secrets: globalSecrets }; // TODO: Should "No team" be "Fleet" for free tier?
-    }
-    return teams.find((team) => team.id === selectedTeam);
-  };
+  const teamInfo =
+    selectedTeamId <= 0
+      ? { name: "No team", secrets: globalSecrets }
+      : teams.find((team) => team.id === selectedTeamId);
 
   const addNewSecretClick = () => {
     setSelectedSecret(undefined);
     toggleSecretEditorModal();
   };
-  const team = renderTeam();
   return (
     <Modal
       onExit={onReturnToApp}
@@ -56,14 +51,22 @@ const EnrollSecretModal = ({
       className={baseClass}
     >
       <div className={`${baseClass} form`}>
-        {team?.secrets?.length ? (
+        {teamInfo?.secrets?.length ? (
           <>
             <div className={`${baseClass}__description`}>
-              Use these secret(s) to enroll hosts to <b>{renderTeam()?.name}</b>
+              Use these secret(s) to enroll hosts
+              {primoMode ? (
+                ""
+              ) : (
+                <>
+                  {" "}
+                  to <b>{teamInfo?.name}</b>
+                </>
+              )}
               :
             </div>
             <EnrollSecretTable
-              secrets={team?.secrets}
+              secrets={teamInfo?.secrets}
               toggleSecretEditorModal={toggleSecretEditorModal}
               toggleDeleteSecretModal={toggleDeleteSecretModal}
               setSelectedSecret={setSelectedSecret}
@@ -76,7 +79,16 @@ const EnrollSecretModal = ({
                 <b>You have no enroll secrets.</b>
               </p>
               <p>
-                Add secret(s) to enroll hosts to <b>{renderTeam()?.name}</b>.
+                Add secret(s) to enroll hosts
+                {primoMode ? (
+                  ""
+                ) : (
+                  <>
+                    {" "}
+                    to <b>{teamInfo?.name}</b>
+                  </>
+                )}
+                .
               </p>
             </div>
           </>

--- a/frontend/hooks/useTeamIdParam.ts
+++ b/frontend/hooks/useTeamIdParam.ts
@@ -268,7 +268,7 @@ const isValidTeamId = ({
     if (includeAllTeams) {
       return teamId === APP_CONTEXT_ALL_TEAMS_ID;
     }
-    // neither includeNoTeam nor includeAllTeam error state handled at top of hook
+    // neither included - this is the case in a number of settings pages
   }
   if (
     (teamId === APP_CONTEXT_ALL_TEAMS_ID && !includeAllTeams) ||
@@ -417,10 +417,6 @@ export const useTeamIdParam = ({
     ]
   );
 
-  if (!includeAllTeams && !includeNoTeam) {
-    // fail loudly
-    throw new Error("All pages should include All teams and/or No team");
-  }
   // reconcile router location and redirect to default team as applicable
   let isRouteOk = false;
   if (isFreeTier) {

--- a/frontend/hooks/useTeamIdParam.ts
+++ b/frontend/hooks/useTeamIdParam.ts
@@ -201,9 +201,9 @@ const getDefaultTeam = ({
       } else if (includeAllTeams) {
         defaultTeam = userTeams.find((t) => t.id === APP_CONTEXT_ALL_TEAMS_ID);
       } else {
-        // this case should never be reached, there are no pages that support neither "All teams"
-        // nor "No team"
-        return undefined;
+        // neither All teams nor No team included on the page, as is the case for a few settings
+        // pages. Default to "All teams"
+        defaultTeam = userTeams.find((t) => t.id === APP_CONTEXT_ALL_TEAMS_ID);
       }
     } else {
       // normally "All teams" takes precedence
@@ -268,7 +268,9 @@ const isValidTeamId = ({
     if (includeAllTeams) {
       return teamId === APP_CONTEXT_ALL_TEAMS_ID;
     }
-    // neither included - this is the case in a number of settings pages
+    // neither included - this is the case in a number of settings pages. Consider valid to allow
+    // editing teams
+    return true;
   }
   if (
     (teamId === APP_CONTEXT_ALL_TEAMS_ID && !includeAllTeams) ||

--- a/frontend/hooks/useTeamIdParam.ts
+++ b/frontend/hooks/useTeamIdParam.ts
@@ -181,7 +181,7 @@ const getDefaultTeam = ({
       } else if (includeAllTeams) {
         defaultTeam = userTeams.find((t) => t.id === APP_CONTEXT_ALL_TEAMS_ID);
       } else {
-        // this case should never be reached, there are no pages that support neighther "All teams"
+        // this case should never be reached, there are no pages that support neither "All teams"
         // nor "No team"
         return undefined;
       }
@@ -242,15 +242,15 @@ const isValidTeamId = ({
 }) => {
   if (isPrimoMode) {
     // teamId at this point for all teams will be coerced to -1
-    if (
-      (includeNoTeam && teamId !== APP_CONTEXT_NO_TEAM_ID) ||
-      (includeAllTeams && teamId !== APP_CONTEXT_ALL_TEAMS_ID)
-    ) {
-      return false;
+    if (includeNoTeam) {
+      return teamId === APP_CONTEXT_NO_TEAM_ID;
     }
-    // not handling the case where neither All teams nor No teams included, which doesn't exist in
-    // the app
-  } else if (
+    if (includeAllTeams) {
+      return teamId === APP_CONTEXT_ALL_TEAMS_ID;
+    }
+    // neither includeNoTeam nor includeAllTeam error state handled at top of hook
+  }
+  if (
     (teamId === APP_CONTEXT_ALL_TEAMS_ID && !includeAllTeams) ||
     (teamId === APP_CONTEXT_NO_TEAM_ID && !includeNoTeam) ||
     !userTeams?.find((t) => t.id === teamId)
@@ -395,10 +395,14 @@ export const useTeamIdParam = ({
     ]
   );
 
+  if (!includeAllTeams && !includeNoTeam) {
+    // fail loudly
+    throw new Error("All pages should include All teams and/or No team");
+  }
   // reconcile router location and redirect to default team as applicable
   let isRouteOk = false;
   if (isFreeTier) {
-    // free tier should never have team_id param - change to "All teams"
+    // free tier should never have team_id param, so change to "All teams"
     if (query.team_id) {
       handleTeamChange(-1); // -1 because all pages on Free actually function as if on "All teams", even when not supported e.g. Controls
     } else {

--- a/frontend/hooks/useTeamIdParam.ts
+++ b/frontend/hooks/useTeamIdParam.ts
@@ -232,13 +232,25 @@ const isValidTeamId = ({
   includeAllTeams,
   includeNoTeam,
   teamId,
+  isPrimoMode,
 }: {
   userTeams: ITeamSummary[];
   includeAllTeams: boolean;
   includeNoTeam: boolean;
   teamId: number;
+  isPrimoMode: boolean;
 }) => {
-  if (
+  if (isPrimoMode) {
+    // teamId at this point for all teams will be coerced to -1
+    if (
+      (includeNoTeam && teamId !== APP_CONTEXT_NO_TEAM_ID) ||
+      (includeAllTeams && teamId !== APP_CONTEXT_ALL_TEAMS_ID)
+    ) {
+      return false;
+    }
+    // not handling the case where neither All teams nor No teams included, which doesn't exist in
+    // the app
+  } else if (
     (teamId === APP_CONTEXT_ALL_TEAMS_ID && !includeAllTeams) ||
     (teamId === APP_CONTEXT_NO_TEAM_ID && !includeNoTeam) ||
     !userTeams?.find((t) => t.id === teamId)
@@ -260,11 +272,13 @@ const shouldRedirectToDefaultTeam = ({
   includeAllTeams,
   includeNoTeam,
   query,
+  isPrimoMode,
 }: {
   userTeams: ITeamSummary[];
   includeAllTeams: boolean;
   includeNoTeam: boolean;
   query: { team_id?: string };
+  isPrimoMode: boolean;
 }) => {
   const teamIdString = query?.team_id || "";
   const parsedTeamId = parseInt(teamIdString, 10);
@@ -283,6 +297,7 @@ const shouldRedirectToDefaultTeam = ({
     includeAllTeams,
     includeNoTeam,
     teamId: coerceAllTeamsId(teamIdString),
+    isPrimoMode,
   });
 };
 
@@ -396,6 +411,7 @@ export const useTeamIdParam = ({
         includeNoTeam,
         query,
         userTeams,
+        isPrimoMode,
       })
     ) {
       handleTeamChange(defaultTeam.id);

--- a/frontend/pages/SoftwarePage/SoftwarePage.tsx
+++ b/frontend/pages/SoftwarePage/SoftwarePage.tsx
@@ -353,7 +353,10 @@ const SoftwarePage = ({ children, router, location }: ISoftwarePageProps) => {
   );
 
   const renderPageActions = () => {
-    const canManageAutomations = isGlobalAdmin && isPremiumTier;
+    const canManageAutomations =
+      isGlobalAdmin &&
+      isPremiumTier &&
+      !globalConfig?.partnerships?.enable_primo; // Primo mode defaults to No team to allow adding software - if they also want to manage software automations we will need to consider more broadly how to go about this, since SW automations are managed from "All teams". For now, hiding this button which matches Free tier behavior.
 
     const canAddSoftware =
       isGlobalAdmin || isGlobalMaintainer || isTeamAdmin || isTeamMaintainer;

--- a/frontend/pages/SoftwarePage/SoftwarePage.tsx
+++ b/frontend/pages/SoftwarePage/SoftwarePage.tsx
@@ -411,10 +411,14 @@ const SoftwarePage = ({ children, router, location }: ISoftwarePageProps) => {
   };
 
   const renderHeaderDescription = () => {
+    let suffix;
+    if (!globalConfig?.partnerships?.enable_primo) {
+      suffix = isAllTeamsSelected ? "for all hosts" : "on this team";
+    }
     return (
       <p>
         Manage software and search for installed software, OS, and
-        vulnerabilities {isAllTeamsSelected ? "for all hosts" : "on this team"}.
+        vulnerabilities{suffix}.
       </p>
     );
   };

--- a/frontend/pages/admin/TeamManagementPage/TeamDetailsWrapper/TeamDetailsWrapper.tsx
+++ b/frontend/pages/admin/TeamManagementPage/TeamDetailsWrapper/TeamDetailsWrapper.tsx
@@ -100,6 +100,7 @@ const TeamDetailsWrapper = ({
     setAvailableTeams,
     setUserSettings,
     setCurrentUser,
+    config,
   } = useContext(AppContext);
 
   const {
@@ -483,7 +484,8 @@ const TeamDetailsWrapper = ({
         )}
         {showManageEnrollSecretsModal && (
           <EnrollSecretModal
-            selectedTeam={teamIdForApi || 0} // TODO: confirm teamIdForApi vs currentTeamId throughout
+            selectedTeamId={teamIdForApi || 0} // TODO: confirm teamIdForApi vs currentTeamId throughout
+            primoMode={config?.partnerships?.enable_primo || false}
             teams={teams || []} // TODO: confirm teams vs available teams throughout
             onReturnToApp={toggleManageEnrollSecretsModal}
             toggleSecretEditorModal={toggleSecretEditorModal}

--- a/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
@@ -167,6 +167,7 @@ const ManageHostsPage = ({
     setFilteredQueriesPath,
     setFilteredSoftwarePath,
   } = useContext(AppContext);
+  const primoMode = config?.partnerships?.enable_primo;
   const { renderFlash } = useContext(NotificationContext);
 
   const { setResetSelectedRows } = useContext(TableContext);
@@ -1440,7 +1441,8 @@ const ManageHostsPage = ({
 
   const renderEnrollSecretModal = () => (
     <EnrollSecretModal
-      selectedTeam={teamIdForApi || 0}
+      selectedTeamId={teamIdForApi || 0}
+      primoMode={primoMode || false}
       teams={teams || []}
       onReturnToApp={() => setShowEnrollSecretModal(false)}
       toggleSecretEditorModal={toggleSecretEditorModal}
@@ -1503,7 +1505,7 @@ const ManageHostsPage = ({
   );
 
   const renderHeaderContent = () => {
-    if (isPremiumTier && !config?.partnerships?.enable_primo && userTeams) {
+    if (isPremiumTier && !primoMode && userTeams) {
       if (userTeams.length > 1 || isOnGlobalTeam) {
         return (
           <TeamsDropdown

--- a/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
@@ -171,6 +171,11 @@ const ManageHostsPage = ({
 
   const { setResetSelectedRows } = useContext(TableContext);
 
+  const shouldStripScriptBatchExecParamOnTeamChange = (
+    newTeamId?: number,
+    curTeamId?: number
+  ) => newTeamId !== curTeamId;
+
   const {
     currentTeamId,
     isAllTeamsSelected,
@@ -193,11 +198,8 @@ const ManageHostsPage = ({
       [HOSTS_QUERY_PARAMS.SOFTWARE_STATUS]: (newTeamId?: number) =>
         newTeamId === API_ALL_TEAMS_ID,
       // remove batch script summary results filters on team change
-      [HOSTS_QUERY_PARAMS.SCRIPT_BATCH_EXECUTION_ID]: (newTeamId?: number) =>
-        newTeamId !== currentTeamId,
-      [HOSTS_QUERY_PARAMS.SCRIPT_BATCH_EXECUTION_STATUS]: (
-        newTeamId?: number
-      ) => newTeamId !== currentTeamId,
+      [HOSTS_QUERY_PARAMS.SCRIPT_BATCH_EXECUTION_ID]: shouldStripScriptBatchExecParamOnTeamChange,
+      [HOSTS_QUERY_PARAMS.SCRIPT_BATCH_EXECUTION_STATUS]: shouldStripScriptBatchExecParamOnTeamChange,
     },
   });
 

--- a/frontend/pages/policies/ManagePoliciesPage/ManagePoliciesPage.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/ManagePoliciesPage.tsx
@@ -1172,7 +1172,9 @@ const ManagePolicyPage = ({
     );
     if (!hasPoliciesToAutomateOrDelete) {
       const tipContent =
-        isPremiumTier && currentTeamId !== APP_CONTEXT_ALL_TEAMS_ID ? (
+        isPremiumTier &&
+        currentTeamId !== APP_CONTEXT_ALL_TEAMS_ID &&
+        !globalConfigFromContext?.partnerships?.enable_primo ? (
           <div className={`${baseClass}__header__tooltip`}>
             To manage automations add a policy to this team.
             <br />
@@ -1223,8 +1225,11 @@ const ManagePolicyPage = ({
 
   let teamsDropdownHelpText: string;
   if (teamIdForApi === API_NO_TEAM_ID) {
-    teamsDropdownHelpText =
-      "Detect device health issues for hosts that are not on a team.";
+    teamsDropdownHelpText = `Detect device health issues${
+      globalConfigFromContext?.partnerships?.enable_primo
+        ? ""
+        : " for hosts that are not on a team"
+    }.`;
   } else if (teamIdForApi === API_ALL_TEAMS_ID) {
     teamsDropdownHelpText = "Detect device health issues for all hosts.";
   } else {

--- a/frontend/pages/policies/ManagePoliciesPage/components/PoliciesTable/PoliciesTable.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/components/PoliciesTable/PoliciesTable.tsx
@@ -65,7 +65,7 @@ const PoliciesTable = ({
       "Add policies to detect device health issues and trigger automations.",
   };
 
-  if (isPremiumTier) {
+  if (isPremiumTier && !config?.partnerships?.enable_primo) {
     if (
       currentTeam?.id === null ||
       currentTeam?.id === APP_CONTEXT_ALL_TEAMS_ID

--- a/frontend/pages/queries/ManageQueriesPage/ManageQueriesPage.tsx
+++ b/frontend/pages/queries/ManageQueriesPage/ManageQueriesPage.tsx
@@ -391,6 +391,15 @@ const ManageQueriesPage = ({
     isTeamMaintainer ||
     isObserverPlus; // isObserverPlus checks global and selected team
 
+  let dropdownHelpText: string;
+  if (isAnyTeamSelected) {
+    dropdownHelpText = "Gather data about all hosts assigned to this team.";
+  } else if (config?.partnerships?.enable_primo) {
+    dropdownHelpText = "Gather data about your hosts.";
+  } else {
+    dropdownHelpText = "Gather data about all hosts.";
+  }
+
   return (
     <MainContent className={baseClass}>
       <div className={`${baseClass}__wrapper`}>
@@ -425,11 +434,7 @@ const ManageQueriesPage = ({
           )}
         </div>
         <div className={`${baseClass}__description`}>
-          <p>
-            {isAnyTeamSelected
-              ? "Gather data about all hosts assigned to this team."
-              : "Gather data about all hosts."}
-          </p>
+          <p>{dropdownHelpText}</p>
         </div>
         {renderQueriesTable()}
         {renderModals()}

--- a/frontend/pages/queries/ManageQueriesPage/components/QueriesTable/QueriesTable.tsx
+++ b/frontend/pages/queries/ManageQueriesPage/components/QueriesTable/QueriesTable.tsx
@@ -96,7 +96,7 @@ const QueriesTable = ({
   currentTeamId,
   isPremiumTier,
 }: IQueriesTableProps): JSX.Element | null => {
-  const { currentUser } = useContext(AppContext);
+  const { currentUser, config } = useContext(AppContext);
 
   // Functions to avoid race conditions
   // TODO - confirm these are still necessary
@@ -176,7 +176,7 @@ const QueriesTable = ({
     header: "You don't have any queries",
   };
 
-  if (isPremiumTier) {
+  if (isPremiumTier && !config?.partnerships?.enable_primo) {
     if (
       typeof currentTeamId === "undefined" ||
       currentTeamId === null ||


### PR DESCRIPTION
## #30198 

[Video demo](https://drive.google.com/file/d/1RBk5QNQdQvXTHJveCNkIeMXj5hWFA5Ft/view?usp=sharing)

Follow-up to https://github.com/fleetdm/fleet/pull/30218


- Implement the following logic for `teamId` in the UI when in Primo mode:
<img width="870" alt="Screenshot 2025-06-24 at 12 47 48 PM" src="https://github.com/user-attachments/assets/8ae81c3f-223f-4dda-954d-c42c7008de45" />
- Above logic is enforced - if trying to change/add/remove `team_id`, automatically pushed to appropriate team

- Fixes originally reported issue - user in Primo mode can access installable software (on the hidden "No team" which is now enforced):
  - Software page on No team
    - Update header help text 
![ezgif-49ce1977ab6474](https://github.com/user-attachments/assets/0d011f94-7c90-4d42-92ec-135baafe7927)


- Handle UI edge cases the above surfaces:
  - Queries page on All teams (No team not supported):
<img width="1624" alt="Screenshot 2025-06-24 at 1 10 40 PM" src="https://github.com/user-attachments/assets/84bb2ca0-b8e7-44e8-9bf5-9f8f243d5584" />

  - Policies page on No team:
<img width="1624" alt="Screenshot 2025-06-24 at 1 10 53 PM" src="https://github.com/user-attachments/assets/144d745f-e9b0-4933-be45-2db4fe428cfe" />

 - update `useTeamIdParam` hook's strip query params on change team logic to optionally also consider the current team

**Important notes**
  - Software page: Software automations are only accessible via All teams, while Add software is only accessible on a team, including No team. In lieu of specs around this, I decided to favor Add software functionality over Software automations functionality, aka, push to "No team" on this page. Enabling _both_ functionalities would be a very large ticket and need to go through a proper drafting process, since Fleet doesn't currently support both in any state.
- Policies page:
  - "Other workflows" (tickets and webhooks) is available on All Teams and specific teams, but not on No Team, so "Other workflows" is currently unavailable in Primo mode
  - If any of the Primo customers have created policies on All Teams already, they won't be able to manage automations on them anymore.  All Teams policies can only have ticket/webhook workflows


- [x] Changes file added for user-visible changes in `changes/`
- [x] Manual QA for all new/changed functionality
