### PR TITLE
Tweak CVE feed build to avoid false positives in CVE-2024-54559

### DIFF
--- a/server/vulnerabilities/nvd/cve_test.go
+++ b/server/vulnerabilities/nvd/cve_test.go
@@ -229,6 +229,14 @@ func TestTranslateCPEToCVE(t *testing.T) {
 			},
 			continuesToUpdate: true,
 		},
+		"cpe:2.3:a:apple:garageband:10.4.11:*:*:*:*:macos:*:*": {
+			excludedCVEs:      []string{"CVE-2024-54559"},
+			continuesToUpdate: true,
+		},
+		"cpe:2.3:o:apple:macos:15.1.1:*:*:*:*:*:*:*": {
+			includedCVEs:      []cve{{ID: "CVE-2024-54559", resolvedInVersion: "15.2"}},
+			continuesToUpdate: true,
+		},
 		"cpe:2.3:a:avira:password_manager:2.18.4.38471:*:*:*:*:firefox:*:*": {
 			includedCVEs: []cve{
 				{ID: "CVE-2022-28795"},


### PR DESCRIPTION
Fixes #28207.

No changes file since this will go live once merged, and it affects the vulns feed. Tests will fail for vulns on-branch since this requires a vulns feed rebuild.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [x] Added/updated automated tests
- [x] Manual QA for all new/changed functionality