### PR TITLE
Website: Update supported article categories

### DIFF
--- a/website/api/controllers/articles/view-basic-article.js
+++ b/website/api/controllers/articles/view-basic-article.js
@@ -69,6 +69,7 @@ module.exports = {
       'announcements': 'Announcements',
       'podcasts': 'Podcasts',
       'report': 'Reports',
+      'articles': 'Articles',
     };
     let categoryFriendlyName = categoryFriendlyNamesByCategorySlug[articleCategorySlug];
     // Set a currentSection variable for the website header based on how the articles category page is linked to in the header navigation dropdown menus.

--- a/website/config/routes.js
+++ b/website/config/routes.js
@@ -103,6 +103,14 @@ module.exports.routes = {
     }
   },
 
+  'GET /articles/*': {
+    skipAssets: false,
+    action: 'articles/view-basic-article',// Meta title and description set in view action
+    locals: {
+      currentSection: 'community',
+    }
+  },
+
   'GET /success-stories': {
     skipAssets: false,
     action: 'articles/view-articles',// Meta title and description set in view action

--- a/website/scripts/build-static-content.js
+++ b/website/scripts/build-static-content.js
@@ -648,7 +648,7 @@ module.exports = {
                   throw new Error(`Failed compiling markdown content: An article page is missing a category meta tag (<meta name="category" value="guides">) at "${path.join(topLvlRepoPath, pageSourcePath)}".  To resolve, add a meta tag with the category of the article`);
                 } else {
                   // Throwing an error if the article has an invalid category.
-                  let validArticleCategories = ['deploy', 'security', 'engineering', 'success stories', 'announcements', 'guides', 'releases', 'podcasts', 'report' ];
+                  let validArticleCategories = ['deploy', 'articles', 'security', 'engineering', 'success stories', 'announcements', 'guides', 'releases', 'podcasts', 'report' ];
                   if(!validArticleCategories.includes(embeddedMetadata.category)) {
                     throw new Error(`Failed compiling markdown content: An article page has an invalid category meta tag (<meta name="category" value="${embeddedMetadata.category}">) at "${path.join(topLvlRepoPath, pageSourcePath)}". To resolve, change the meta tag to a valid category, one of: ${validArticleCategories}`);
                   }


### PR DESCRIPTION
Changes:

- Added `articles` to the list of supported article categories in the build-static-content script.
- Added a route for articles in the articles category.
- Updated the `view-basic-article` action to support the new `articles` category.