### PR TITLE
For R.C. - Software page: Hide "Available for install / Self-service" dropdown f…

### DIFF
--- a/changes/30273-remove-useless-dropdowns
+++ b/changes/30273-remove-useless-dropdowns
@@ -1,0 +1,1 @@
+* Fleet Free: Removed the installer dropdown (Premium-only) from the Software page and Host details > Software tab as installer filtering isn’t applicable on the Free tier

--- a/frontend/pages/SoftwarePage/SoftwareTitles/SoftwareTable/SoftwareTable.tests.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitles/SoftwareTable/SoftwareTable.tests.tsx
@@ -65,9 +65,11 @@ describe("Software table", () => {
 
     expect(screen.getByText("Software inventory disabled")).toBeInTheDocument();
     expect(screen.queryByText("Vulnerability")).toBeNull();
+    expect(screen.queryByText("All software")).toBeNull();
+    expect(screen.queryByText("Available for install")).toBeNull();
   });
 
-  it("Renders the page-wide empty state when no software are present", () => {
+  it("Renders the page-wide empty state when no software are present hiding 'Available for install' filter", () => {
     const render = createCustomRenderer({
       context: {
         app: {
@@ -113,9 +115,11 @@ describe("Software table", () => {
     expect(screen.getByText("0 items")).toBeInTheDocument();
     expect(screen.queryByText("Search")).toBeNull();
     expect(screen.queryByText("Updated")).toBeNull();
+    expect(screen.queryByText("All software")).toBeNull();
+    expect(screen.queryByText("Available for install")).toBeNull();
   });
 
-  it("Renders the page-wide empty state when search query does not exist but versions toggle is applied", () => {
+  it("Renders the page-wide empty state hiding 'Available for install' filter when search query does not exist but versions toggle is applied", () => {
     const render = createCustomRenderer({
       context: {
         app: {
@@ -157,9 +161,11 @@ describe("Software table", () => {
     expect(
       screen.getByText("Expecting to see software? Check back later.")
     ).toBeInTheDocument();
+    expect(screen.queryByText("All software")).toBeNull();
+    expect(screen.queryByText("Available for install")).toBeNull();
   });
 
-  it("Renders the empty search state when search query does not exist but dropdown is applied", () => {
+  it("Renders the empty search state and 'Available for install' filter when search query does not exist but filter is applied", () => {
     const render = createCustomRenderer({
       context: {
         app: {
@@ -205,9 +211,10 @@ describe("Software table", () => {
         "Expecting to see installable software? Check back later."
       )
     ).toBeInTheDocument();
+    expect(screen.getByText("Available for install")).toBeInTheDocument();
   });
 
-  it("Renders the empty search state when search query does not exist but vulnerability filter is applied", () => {
+  it("Renders the empty search state and 'Available for install' filter when search query does not exist but vulnerability filter is applied", () => {
     const render = createCustomRenderer({
       context: {
         app: {
@@ -253,5 +260,48 @@ describe("Software table", () => {
         "Expecting to see vulnerable software? Check back later."
       )
     ).toBeInTheDocument();
+    expect(screen.getByText("All software")).toBeInTheDocument();
+  });
+
+  it("does not render 'Available for install' filter when team id is undefined (Fleet Free/All teams)", () => {
+    const render = createCustomRenderer({
+      context: {
+        app: {
+          isGlobalAdmin: true,
+          currentUser: createMockUser(),
+        },
+      },
+    });
+
+    render(
+      <SoftwareTable
+        router={mockRouter}
+        isSoftwareEnabled
+        showVersions={false}
+        data={createMockSoftwareTitlesResponse({
+          counts_updated_at: null,
+          software_titles: [],
+        })}
+        installableSoftwareExists={false}
+        query=""
+        perPage={20}
+        orderDirection="asc"
+        orderKey="hosts_count"
+        softwareFilter="allSoftware"
+        vulnFilters={{
+          vulnerable: false,
+          exploit: false,
+          minCvssScore: undefined,
+          maxCvssScore: undefined,
+        }}
+        currentPage={0}
+        teamId={undefined} // Undefined for Fleet Free or Fleet Premium "All teams"
+        isLoading={false}
+        onAddFiltersClick={noop}
+      />
+    );
+
+    expect(screen.queryByText("All software")).toBeNull();
+    expect(screen.queryByText("Available for install")).toBeNull();
   });
 });

--- a/frontend/pages/SoftwarePage/SoftwareTitles/SoftwareTable/SoftwareTable.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitles/SoftwareTable/SoftwareTable.tsx
@@ -281,8 +281,9 @@ const SoftwareTable = ({
   };
 
   const renderCustomControls = () => {
-    // Hidden when viewing versions table
-    if (showVersions) {
+    // Hidden when viewing versions table or viewing "All teams"
+    // or Fleet Free
+    if (showVersions || teamId === undefined) {
       return null;
     }
 
@@ -293,7 +294,6 @@ const SoftwareTable = ({
           value={softwareFilter}
           className={`${baseClass}__software-filter`}
           options={SOFTWARE_TITLES_DROPDOWN_OPTIONS}
-          isDisabled={teamId === undefined}
           onChange={(newValue: SingleValue<CustomOptionType>) =>
             newValue &&
             handleCustomFilterDropdownChange(


### PR DESCRIPTION
## Issue
Closes #30273 

> Note: Previously merged into `main` with #30274. This is for R.C. 4.70.0

```
 1568  git checkout fleetdm/rc-minor-fleet-v4.70.0
 1569  git log main
 1570  git cherry-pick a51f074ecfd39804b6d1206aeb8b72b322fa9bd0 
 1571  git checkout -b hide-dropdown-rc
 1572  git push -u fleetdm hide-dropdown-rc
```