### PR TITLE
Disallow lock request for unenrolled macOS hosts

### DIFF
--- a/changes/30192-lock-unenrolled-host
+++ b/changes/30192-lock-unenrolled-host
@@ -1,0 +1,2 @@
+- Fixed issue where attempting to lock an MDM-unenrolled macOS host was not returning the expected
+  error.

--- a/ee/server/service/hosts.go
+++ b/ee/server/service/hosts.go
@@ -75,11 +75,9 @@ func (svc *Service) LockHost(ctx context.Context, hostID uint, viewPIN bool) (un
 			return "", ctxerr.Wrap(ctx, err, "checking if host is connected to Fleet")
 		}
 		if !connected {
-			if fleet.IsNotFound(err) {
-				return "", ctxerr.Wrap(
-					ctx, fleet.NewInvalidArgumentError("host_id", "Can't lock the host because it doesn't have MDM turned on."),
-				)
-			}
+			return "", ctxerr.Wrap(
+				ctx, fleet.NewInvalidArgumentError("host_id", "Can't lock the host because it doesn't have MDM turned on."),
+			)
 		}
 
 	case "windows", "linux":


### PR DESCRIPTION
For #30192 

# Checklist for submitter
- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
- [x] Added/updated automated tests

