### PR TITLE
27905: Specify TLS Server cert path when running orbit shell

### DIFF
--- a/orbit/changes/27905-provide-tls-path-on-orbit-shell
+++ b/orbit/changes/27905-provide-tls-path-on-orbit-shell
@@ -1,0 +1,1 @@
+* Added missing --tls_server_certs when running orbit shell.

--- a/orbit/changes/27905-provide-tls-path-on-orbit-shell
+++ b/orbit/changes/27905-provide-tls-path-on-orbit-shell
@@ -1,1 +1,2 @@
 * Added missing --tls_server_certs when running orbit shell.
+* Added new flag --fleet-certificate to orbit shell command.

--- a/orbit/changes/27905-provide-tls-path-on-orbit-shell
+++ b/orbit/changes/27905-provide-tls-path-on-orbit-shell
@@ -1,2 +1,1 @@
-* Added missing --tls_server_certs when running orbit shell.
-* Added new flag --fleet-certificate to orbit shell command.
+* Added new flag `--fleet-certificate` to `sudo orbit shell` command (which sets osquery's `--tls_server_certs` flag).

--- a/orbit/cmd/orbit/orbit.go
+++ b/orbit/cmd/orbit/orbit.go
@@ -915,7 +915,6 @@ func main() {
 					log.Info().Msg("No cert chain available. Relying on system store.")
 				}
 			}
-
 		}
 
 		fleetClientCertPath := filepath.Join(c.String("root-dir"), constant.FleetTLSClientCertificateFileName)

--- a/orbit/cmd/orbit/shell.go
+++ b/orbit/cmd/orbit/shell.go
@@ -39,8 +39,9 @@ var shellCommand = &cli.Command{
 			EnvVars: []string{"ORBIT_DEBUG"},
 		},
 		&cli.StringFlag{
-			Name:   "fleet-certificate",
-			Hidden: true,
+			Name:    "fleet-certificate",
+			Hidden:  true,
+			EnvVars: []string{"ORBIT_FLEET_CERTIFICATE"},
 		},
 	},
 	Action: func(c *cli.Context) error {

--- a/orbit/cmd/orbit/shell.go
+++ b/orbit/cmd/orbit/shell.go
@@ -108,9 +108,11 @@ var shellCommand = &cli.Command{
 		certPath := getCertPath(c)
 		if exists, err := file.Exists(certPath); err == nil && exists {
 			if _, err := certificate.LoadPEM(certPath); err != nil {
-				return fmt.Errorf("load %s: %w", certPath, err)
+				return fmt.Errorf("failed to load PEM %s: %w", certPath, err)
 			}
 			opts = append(opts, osquery.WithFlags([]string{"--tls_server_certs", certPath}))
+		} else if err != nil {
+			return fmt.Errorf("failed to read file %s: %w", certPath, err)
 		}
 
 		// Detect if the additional arguments have a positional argument.

--- a/orbit/cmd/orbit/shell_test.go
+++ b/orbit/cmd/orbit/shell_test.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetCertPath(t *testing.T) {
+	validRoot := t.TempDir()
+	invalidRoot := t.TempDir()
+
+	srcCertPath := filepath.Join("..", "..", "pkg", "cryptoinfo", "testdata", "test_crt.pem")
+	srcCert, err := os.ReadFile(srcCertPath)
+	require.NoError(t, err)
+
+	validCertPath := filepath.Join(validRoot, "certs.pem")
+	require.NoError(t, os.WriteFile(validCertPath, srcCert, 0644))
+
+	invalidCertPath := filepath.Join(invalidRoot, "invalid_cert.pem")
+	require.NoError(t, os.WriteFile(invalidCertPath, []byte(`INVALID_CERT_CONTENT`), 0644))
+
+	tests := []struct {
+		name         string
+		rootDir      string
+		fleetCert    string
+		expectedPath string
+		expectError  error
+	}{
+		{
+			name:         "Default cert path exists",
+			rootDir:      validRoot,
+			fleetCert:    "",
+			expectedPath: validCertPath,
+		},
+		{
+			name:         "Provided cert path exists",
+			rootDir:      validRoot,
+			fleetCert:    srcCertPath,
+			expectedPath: srcCertPath,
+		},
+		{
+			name:         "Default cert does not exist",
+			rootDir:      invalidRoot,
+			fleetCert:    "",
+			expectedPath: "",
+			expectError:  fmt.Errorf("cert not found at %s", filepath.Join(invalidRoot, "certs.pem")),
+		},
+		{
+			name:         "Invalid cert path provided",
+			rootDir:      "",
+			fleetCert:    filepath.Join(validRoot, "blah.pem"),
+			expectedPath: "",
+			expectError:  fmt.Errorf("cert not found at %s", filepath.Join(validRoot, "blah.pem")),
+		},
+		{
+			name:         "Invalid PEM format",
+			rootDir:      "",
+			fleetCert:    invalidCertPath,
+			expectedPath: "",
+			expectError:  fmt.Errorf("invalid PEM format %s: no valid certificates found in %s", invalidCertPath, invalidCertPath),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path, err := getCertPath(tt.rootDir, tt.fleetCert)
+
+			if tt.expectError != nil {
+				require.Error(t, err)
+				require.Empty(t, path)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tt.expectedPath, path)
+			}
+		})
+	}
+}


### PR DESCRIPTION
For #27905 

Provide TLS Server cert path via --tls_server_certs flag when running orbit shell.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.
- [X] Manual QA for all new/changed functionality
- For Orbit and Fleet Desktop changes:
   - [X] Make sure fleetd is compatible with the latest released version of Fleet (see [Must rule](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/workflows/fleetd-development-and-release-strategy.md)).
   - [X] Orbit runs on macOS, Linux and Windows. Check if the orbit feature/bugfix should only apply to one platform (`runtime.GOOS`).
   - [X] Manual QA must be performed in the three main OSs, macOS, Windows and Linux.
 