### PR TITLE
Fix docker FMA token

### DIFF
--- a/ee/maintained-apps/inputs/homebrew/docker.json
+++ b/ee/maintained-apps/inputs/homebrew/docker.json
@@ -2,7 +2,7 @@
   "name": "Docker Desktop",
   "slug": "docker/darwin",
   "unique_identifier": "com.docker.docker",
-  "token": "docker",
+  "token": "docker-desktop",
   "installer_format": "dmg",
   "default_categories": ["Developer tools"]
 }


### PR DESCRIPTION
# Checklist for submitter

homebrew changed the cask name, breaking the github action

action result: https://github.com/fleetdm/fleet/actions/runs/15902261437/job/44847838594
successful FMA PR here: https://github.com/fleetdm/fleet/pull/30334/files


