### PR TITLE
Fixed issue when host's public IP sometimes shows up as 127.0.0.1 if a local HTTP proxy is used.

### DIFF
--- a/changes/30354-public-ip
+++ b/changes/30354-public-ip
@@ -1,0 +1,1 @@
+Fixed issue when host's public IP sometimes shows up as 127.0.0.1 if a local HTTP proxy is used.

--- a/server/service/middleware/endpoint_utils/endpoint_utils_test.go
+++ b/server/service/middleware/endpoint_utils/endpoint_utils_test.go
@@ -1,0 +1,144 @@
+package endpoint_utils
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExtractIP_SkipsLocalhost(t *testing.T) {
+	tests := []struct {
+		name        string
+		remoteAddr  string
+		headers     map[string][]string
+		expectedIP  string
+		description string
+	}{
+		{
+			name:       "X-Forwarded-For with localhost first, real IP second",
+			remoteAddr: "192.168.1.100:8080",
+			headers: map[string][]string{
+				"X-Forwarded-For": {"127.0.0.1, 203.0.113.45"},
+			},
+			expectedIP:  "203.0.113.45",
+			description: "Should skip localhost and return the first non-localhost IP",
+		},
+		{
+			name:       "X-Forwarded-For with IPv6 localhost first, real IP second",
+			remoteAddr: "192.168.1.100:8080",
+			headers: map[string][]string{
+				"X-Forwarded-For": {"::1, 203.0.113.45"},
+			},
+			expectedIP:  "203.0.113.45",
+			description: "Should skip IPv6 localhost and return the first non-localhost IP",
+		},
+		{
+			name:       "X-Forwarded-For with multiple localhost IPs and one real IP",
+			remoteAddr: "192.168.1.100:8080",
+			headers: map[string][]string{
+				"X-Forwarded-For": {"127.0.0.1, ::1, 203.0.113.45, 198.51.100.22"},
+			},
+			expectedIP:  "203.0.113.45",
+			description: "Should skip all localhost IPs and return the first non-localhost IP",
+		},
+		{
+			name:       "X-Forwarded-For with only localhost IPs",
+			remoteAddr: "192.168.1.100:8080",
+			headers: map[string][]string{
+				"X-Forwarded-For": {"127.0.0.1, ::1"},
+			},
+			expectedIP:  "127.0.0.1",
+			description: "Should fallback to first IP when all are localhost",
+		},
+		{
+			name:       "X-Forwarded-For with only IPv4 localhost",
+			remoteAddr: "192.168.1.100:8080",
+			headers: map[string][]string{
+				"X-Forwarded-For": {"127.0.0.1"},
+			},
+			expectedIP:  "127.0.0.1",
+			description: "Should fallback to localhost when it's the only IP",
+		},
+		{
+			name:       "X-Forwarded-For with only IPv6 localhost",
+			remoteAddr: "192.168.1.100:8080",
+			headers: map[string][]string{
+				"X-Forwarded-For": {"::1"},
+			},
+			expectedIP:  "::1",
+			description: "Should fallback to IPv6 localhost when it's the only IP",
+		},
+		{
+			name:       "Multiple X-Forwarded-For headers with localhost in first, real IP in second",
+			remoteAddr: "192.168.1.100:8080",
+			headers: map[string][]string{
+				"X-Forwarded-For": {"127.0.0.1", "203.0.113.45"},
+			},
+			expectedIP:  "203.0.113.45",
+			description: "Should check multiple X-Forwarded-For headers and skip localhost",
+		},
+		{
+			name:       "X-Forwarded-For with whitespace around IPs",
+			remoteAddr: "192.168.1.100:8080",
+			headers: map[string][]string{
+				"X-Forwarded-For": {" 127.0.0.1 ,  203.0.113.45  "},
+			},
+			expectedIP:  "203.0.113.45",
+			description: "Should handle whitespace around IPs and skip localhost",
+		},
+		{
+			name:       "True-Client-IP with localhost (should use localhost directly)",
+			remoteAddr: "192.168.1.100:8080",
+			headers: map[string][]string{
+				"True-Client-IP": {"127.0.0.1"},
+			},
+			expectedIP:  "127.0.0.1",
+			description: "True-Client-IP header is used directly without localhost checking",
+		},
+		{
+			name:       "X-Real-IP with localhost (should use localhost directly)",
+			remoteAddr: "192.168.1.100:8080",
+			headers: map[string][]string{
+				"X-Real-IP": {"127.0.0.1"},
+			},
+			expectedIP:  "127.0.0.1",
+			description: "X-Real-IP header is used directly without localhost checking",
+		},
+		{
+			name:        "No headers, just RemoteAddr",
+			remoteAddr:  "203.0.113.45:8080",
+			headers:     map[string][]string{},
+			expectedIP:  "203.0.113.45",
+			description: "Should extract IP from RemoteAddr when no headers present",
+		},
+		{
+			name:       "Real IP first in X-Forwarded-For",
+			remoteAddr: "192.168.1.100:8080",
+			headers: map[string][]string{
+				"X-Forwarded-For": {"203.0.113.45, 127.0.0.1"},
+			},
+			expectedIP:  "203.0.113.45",
+			description: "Should return first IP when it's not localhost",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := &http.Request{
+				RemoteAddr: tt.remoteAddr,
+				Header:     make(http.Header),
+			}
+
+			// Set headers
+			for key, values := range tt.headers {
+				for _, value := range values {
+					req.Header.Add(key, value)
+				}
+			}
+
+			result := ExtractIP(req)
+			assert.Equal(t, tt.expectedIP, result, tt.description)
+		})
+	}
+}


### PR DESCRIPTION
Fixes #30354

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [ ] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.
- [ ] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [ ] Added support on fleet's osquery simulator `cmd/osquery-perf` for new osquery data ingestion features.
- [ ] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes
- [ ] If database migrations are included, checked table schema to confirm autoupdate
- For new Fleet configuration settings
  - [ ] Verified that the setting can be managed via GitOps, or confirmed that the setting is explicitly being excluded from GitOps.  If managing via Gitops:
    - [ ] Verified that the setting is exported via `fleetctl generate-gitops`
    - [ ] Added the setting to [the GitOps documentation](https://github.com/fleetdm/fleet/blob/main/docs/Configuration/yaml-files.md#L485)
    - [ ] Verified that the setting is cleared on the server if it is not supplied in a YAML file (or that it is documented as being optional)
    - [ ] Verified that any relevant UI is disabled when GitOps mode is enabled
- For database migrations:
  - [ ] Checked schema for all modified table for columns that will auto-update timestamps during migration.
  - [ ] Confirmed that updating the timestamps is acceptable, and will not cause unwanted side effects.
  - [ ] Ensured the correct collation is explicitly set for character columns (`COLLATE utf8mb4_unicode_ci`).
- [ ] Added/updated automated tests
- [ ] Manual QA for all new/changed functionality
- For Orbit and Fleet Desktop changes:
   - [ ] Make sure fleetd is compatible with the latest released version of Fleet (see [Must rule](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/workflows/fleetd-development-and-release-strategy.md)).
   - [ ] Orbit runs on macOS, Linux and Windows. Check if the orbit feature/bugfix should only apply to one platform (`runtime.GOOS`).
   - [ ] Manual QA must be performed in the three main OSs, macOS, Windows and Linux.
   - [ ] Auto-update manual QA, from released version of component to new version (see [tools/tuf/test](../tools/tuf/test/README.md)).
- [ ] For unreleased bug fixes in a release candidate, confirmed that the fix is not expected to adversely impact load test results or alerted the release DRI if additional load testing is needed.
