### PR TITLE
29619: Validate required default.yml on gitops run

### DIFF
--- a/changes/29619-validate-required-default-gitops
+++ b/changes/29619-validate-required-default-gitops
@@ -1,0 +1,1 @@
+* Fixed bug present on gitops cmd when importing no-team.yml with scripts without default.yml.

--- a/cmd/fleetctl/fleetctl/gitops.go
+++ b/cmd/fleetctl/fleetctl/gitops.go
@@ -160,8 +160,8 @@ func gitopsCommand() *cli.Command {
 			}
 
 			// fail if scripts are supplied on no-team and global config is missing
-			if noTeamPresent && !globalConfigLoaded && len(noTeamControls.Scripts) > 0 {
-				return errors.New("global config must be provided when scripts are supplied in no-team.yml")
+			if noTeamPresent && !globalConfigLoaded {
+				return errors.New("global config must be provided alongside no-team.yml")
 			}
 
 			for _, configFile := range configs {

--- a/cmd/fleetctl/fleetctl/gitops.go
+++ b/cmd/fleetctl/fleetctl/gitops.go
@@ -159,6 +159,11 @@ func gitopsCommand() *cli.Command {
 				}
 			}
 
+			// fail if scripts are supplied on no-team and global config is missing
+			if noTeamPresent && !globalConfigLoaded && len(noTeamControls.Scripts) > 0 {
+				return errors.New("global config must be provided when scripts are supplied in no-team.yml")
+			}
+
 			for _, configFile := range configs {
 				config := configFile.Config
 				flFilename := configFile.Filename

--- a/cmd/fleetctl/fleetctl/gitops_test.go
+++ b/cmd/fleetctl/fleetctl/gitops_test.go
@@ -2265,6 +2265,11 @@ software:
 		_, err = scriptFile.WriteString(`echo "Hello, world!"`)
 		require.NoError(t, err)
 
+		// Validate that global config is required when running noTeam
+		_, err = RunAppNoChecks(
+			[]string{"gitops", "-f", noTeamFile.Name(), "--dry-run"})
+		assert.Error(t, err)
+
 		// Dry run
 		ds.SaveAppConfigFuncInvoked = false
 		ds.BatchSetScriptsFuncInvoked = false

--- a/cmd/fleetctl/integrationtest/gitops/gitops_enterprise_integration_test.go
+++ b/cmd/fleetctl/integrationtest/gitops/gitops_enterprise_integration_test.go
@@ -222,7 +222,12 @@ team_settings:
 	// Dry run
 	_ = fleetctl.RunAppForTest(t, []string{"gitops", "--config", fleetctlConfig.Name(), "-f", globalFile, "--dry-run"})
 	for _, fileName := range teamFileNames {
-		_ = fleetctl.RunAppForTest(t, []string{"gitops", "--config", fleetctlConfig.Name(), "-f", fileName, "--dry-run"})
+		// When running no-teams, global config must also be provided ...
+		if strings.Contains(fileName, "no-team.yml") {
+			_ = fleetctl.RunAppForTest(t, []string{"gitops", "--config", fleetctlConfig.Name(), "-f", fileName, "-f", globalFile, "--dry-run"})
+		} else {
+			_ = fleetctl.RunAppForTest(t, []string{"gitops", "--config", fleetctlConfig.Name(), "-f", fileName, "--dry-run"})
+		}
 	}
 
 	// Dry run with all the files
@@ -258,7 +263,12 @@ team_settings:
 	// Real run with one file at a time
 	_ = fleetctl.RunAppForTest(t, []string{"gitops", "--config", fleetctlConfig.Name(), "-f", globalFile})
 	for _, fileName := range teamFileNames {
-		_ = fleetctl.RunAppForTest(t, []string{"gitops", "--config", fleetctlConfig.Name(), "-f", fileName})
+		// When running no-teams, global config must also be provided ...
+		if strings.Contains(fileName, "no-team.yml") {
+			_ = fleetctl.RunAppForTest(t, []string{"gitops", "--config", fleetctlConfig.Name(), "-f", fileName, "-f", globalFile})
+		} else {
+			_ = fleetctl.RunAppForTest(t, []string{"gitops", "--config", fleetctlConfig.Name(), "-f", fileName})
+		}
 	}
 }
 


### PR DESCRIPTION
For #29619 

When running gitops validate that default.yml is provided if scripts are specified in the no-team.yml artifact.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.
- [X] Manual QA for all new/changed functionality