### PR TITLE
Specify binary-identifier when signing fleetctl for macOS

### DIFF
--- a/changes/issue-30352-add-fleetctl-binary-identifier
+++ b/changes/issue-30352-add-fleetctl-binary-identifier
@@ -1,0 +1,1 @@
+- Fixes an issue where the fleetctl codesignature requirements couldn't be used to verify the codesignature of fleetctl.

--- a/tools/sign-fleetctl/main.sh
+++ b/tools/sign-fleetctl/main.sh
@@ -30,6 +30,7 @@ echo "Signing binary..."
 printf "%s" "$APPLE_APPLICATION_CERTIFICATE" | base64 --decode > certificate.p12
 rcodesign sign --p12-file certificate.p12 \
                --p12-password "$APPLE_APPLICATION_CERTIFICATE_PASSWORD" \
+               --binary-identifier com.fleetdm.fleetctl \
                --for-notarization "$FLEETCTL_BINARY_PATH"
 
 echo "Notarizing binary..."


### PR DESCRIPTION
This PR specifies a binary identifier for `fleetctl` on macOS, which resolves the codesignature testing issue from #30352.

# Tests
To test this, I unsigned an affected version of `fleetctl`:
```shell
codesign --remove-signature fleetctl
```

I then installed `rcodesign` 0.29.0, and signed the binary myself, with the added `--binary-identifier` flag:
```shell
./rcodesign sign --p12-file Certificates.p12 --p12-password-file=.p12_password --for-notarization --binary-identifier com.fleetdm.fleetctl fleetctl
```

Then, I obtained the codesigning requirement from my newly signed binary:
```shell
$ codesign -d -r- fleetctl                                                                   
Executable=/Users/jacob.burley/Downloads/fleetctl_v4.67.3_macos/fleetctl
designated => identifier "com.fleetdm.fleetctl" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "XXXXXXXXXX"
```

I then tested the code signature with the designated requirement given:
```shell
$ codesign --test-requirement='=identifier "com.fleetdm.fleetctl" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "XXXXXXXXXX"' --verbose=2 --verify fleetctl
fleetctl: valid on disk
fleetctl: satisfies its Designated Requirement
fleetctl: explicit requirement satisfied
```

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.
