### PR TITLE
Remove unneeded exposed ports on osquery-in-a-box minio to avoid host-port conflicts

### DIFF
--- a/.github/workflows/test-go.yaml
+++ b/.github/workflows/test-go.yaml
@@ -11,6 +11,8 @@ on:
       - 'go.mod'
       - 'go.sum'
       - '.github/workflows/test-go.yaml'
+      - 'tools/osquery/in-a-box/docker-compose.yml'
+      - 'tools/osquery/in-a-box/osquery/docker-compose.yml'
       - 'server/authz/policy.rego'
       - 'docker-compose.yml'
   pull_request:
@@ -19,6 +21,8 @@ on:
       - 'go.mod'
       - 'go.sum'
       - '.github/workflows/test-go.yaml'
+      - 'tools/osquery/in-a-box/docker-compose.yml'
+      - 'tools/osquery/in-a-box/osquery/docker-compose.yml'
       - 'server/authz/policy.rego'
       - 'docker-compose.yml'
   workflow_dispatch: # Manual

--- a/tools/osquery/in-a-box/docker-compose.yml
+++ b/tools/osquery/in-a-box/docker-compose.yml
@@ -139,9 +139,6 @@ services:
     image: quay.io/minio/minio
     entrypoint: sh
     command: -c 'mkdir -p /data/software-installers-preview && /usr/bin/minio server /data --console-address ":9001"'
-    ports:
-      - "9000:9000"
-      - "9001:9001"
     environment:
       MINIO_ROOT_USER: minio
       MINIO_ROOT_PASSWORD: minio123!


### PR DESCRIPTION
Also ensures we run integration tests when docker-compose files used by `fleetctl preview` are changed, so we don't merge any more test failures due to those.