### PR TITLE
Fleet UI: VPP command copy includes command verification nuance

### DIFF
--- a/changes/29893-verify-vpp-apps-installed
+++ b/changes/29893-verify-vpp-apps-installed
@@ -1,0 +1,1 @@
+- Fleet UI: Surfaced whether VPP apps are installs on a host after command is acknowledged.

--- a/frontend/components/ActivityDetails/InstallDetails/AppInstallDetails/AppInstallDetails.tests.tsx
+++ b/frontend/components/ActivityDetails/InstallDetails/AppInstallDetails/AppInstallDetails.tests.tsx
@@ -1,0 +1,83 @@
+import { render, screen } from "@testing-library/react";
+import { getStatusMessage } from "./AppInstallDetails";
+
+describe("getStatusMessage helper function", () => {
+  it("shows NotNow message when isStatusNotNow is true", () => {
+    render(
+      getStatusMessage({
+        displayStatus: "pending",
+        isStatusNotNow: true,
+        software_title: "Logic Pro",
+        host_display_name: "Marko's MacBook Pro",
+      })
+    );
+    expect(screen.getByText(/Fleet tried to install/i)).toBeInTheDocument();
+    expect(screen.getByText(/Marko's MacBook Pro/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        /but couldn't because the host was locked or was running on battery power while in Power Nap/i
+      )
+    ).toBeInTheDocument();
+  });
+
+  it("shows pending_install message", () => {
+    render(
+      getStatusMessage({
+        displayStatus: "pending_install",
+        isStatusNotNow: false,
+        software_title: "Logic Pro",
+        host_display_name: "Marko's MacBook Pro",
+      })
+    );
+    expect(
+      screen.getByText(/The MDM command \(request\) to install/i)
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        /was acknowledged but the installation has not been verified/i
+      )
+    ).toBeInTheDocument();
+    expect(screen.getByText(/Refetch/i)).toBeInTheDocument();
+  });
+
+  it("shows failed_install message", () => {
+    render(
+      getStatusMessage({
+        displayStatus: "failed_install",
+        isStatusNotNow: false,
+        software_title: "Logic Pro",
+        host_display_name: "Marko's MacBook Pro",
+      })
+    );
+    expect(
+      screen.getByText(/failed. Please re-attempt this installation/i)
+    ).toBeInTheDocument();
+  });
+
+  it("shows default message for installed status", () => {
+    render(
+      getStatusMessage({
+        displayStatus: "installed",
+        isStatusNotNow: false,
+        software_title: "Logic Pro",
+        host_display_name: "Marko's MacBook Pro",
+      })
+    );
+    expect(screen.getByText(/Fleet installed/i)).toBeInTheDocument();
+    expect(screen.getByText(/Logic Pro/i)).toBeInTheDocument();
+    expect(screen.getByText(/Marko's MacBook Pro/i)).toBeInTheDocument();
+  });
+
+  it("shows default message with 'the host' if host_display_name is empty", () => {
+    render(
+      getStatusMessage({
+        displayStatus: "installed",
+        isStatusNotNow: false,
+        software_title: "Logic Pro",
+        host_display_name: "",
+      })
+    );
+    expect(screen.getByText(/Fleet installed/i)).toBeInTheDocument();
+    expect(screen.getByText(/the host/i)).toBeInTheDocument();
+  });
+});

--- a/frontend/components/ActivityDetails/InstallDetails/AppInstallDetails/AppInstallDetails.tests.tsx
+++ b/frontend/components/ActivityDetails/InstallDetails/AppInstallDetails/AppInstallDetails.tests.tsx
@@ -7,6 +7,7 @@ describe("getStatusMessage helper function", () => {
       getStatusMessage({
         displayStatus: "pending",
         isStatusNotNow: true,
+        isStatusAcknowledged: false,
         software_title: "Logic Pro",
         host_display_name: "Marko's MacBook Pro",
       })
@@ -20,11 +21,12 @@ describe("getStatusMessage helper function", () => {
     ).toBeInTheDocument();
   });
 
-  it("shows pending_install message", () => {
+  it("shows pending acknowledged message", () => {
     render(
       getStatusMessage({
         displayStatus: "pending_install",
         isStatusNotNow: false,
+        isStatusAcknowledged: true,
         software_title: "Logic Pro",
         host_display_name: "Marko's MacBook Pro",
       })
@@ -45,6 +47,7 @@ describe("getStatusMessage helper function", () => {
       getStatusMessage({
         displayStatus: "failed_install",
         isStatusNotNow: false,
+        isStatusAcknowledged: false,
         software_title: "Logic Pro",
         host_display_name: "Marko's MacBook Pro",
       })
@@ -59,6 +62,7 @@ describe("getStatusMessage helper function", () => {
       getStatusMessage({
         displayStatus: "installed",
         isStatusNotNow: false,
+        isStatusAcknowledged: true,
         software_title: "Logic Pro",
         host_display_name: "Marko's MacBook Pro",
       })
@@ -73,6 +77,7 @@ describe("getStatusMessage helper function", () => {
       getStatusMessage({
         displayStatus: "installed",
         isStatusNotNow: false,
+        isStatusAcknowledged: false,
         software_title: "Logic Pro",
         host_display_name: "",
       })

--- a/frontend/components/ActivityDetails/InstallDetails/AppInstallDetails/AppInstallDetails.tsx
+++ b/frontend/components/ActivityDetails/InstallDetails/AppInstallDetails/AppInstallDetails.tsx
@@ -27,6 +27,7 @@ import {
 interface IGetStatusMessageProps {
   displayStatus: SoftwareInstallStatus | "pending";
   isStatusNotNow: boolean;
+  isStatusAcknowledged: boolean;
   software_title: string;
   host_display_name: string;
 }
@@ -34,6 +35,7 @@ interface IGetStatusMessageProps {
 export const getStatusMessage = ({
   displayStatus,
   isStatusNotNow,
+  isStatusAcknowledged,
   software_title,
   host_display_name,
 }: IGetStatusMessageProps) => {
@@ -55,7 +57,7 @@ export const getStatusMessage = ({
   }
 
   // VPP Verify command pending state
-  if (displayStatus === "pending_install") {
+  if (displayStatus === "pending_install" && isStatusAcknowledged) {
     return (
       <>
         The MDM command (request) to install <b>{software_title}</b> on{" "}
@@ -183,10 +185,13 @@ export const AppInstallDetails = ({
   // from the MDM protocol, e.g., "NotNow" or "Acknowledged". We need to display some special
   // messaging for the "NotNow" status, which otherwise would be treated as "pending".
   const isStatusNotNow = result?.status === "NotNow";
+  const isStatusAcknowledged =
+    result?.status === "Acknowledged" && !!result?.result;
 
   const statusMessage = getStatusMessage({
     displayStatus,
     isStatusNotNow,
+    isStatusAcknowledged,
     software_title,
     host_display_name,
   });

--- a/frontend/components/ActivityDetails/InstallDetails/AppInstallDetails/AppInstallDetails.tsx
+++ b/frontend/components/ActivityDetails/InstallDetails/AppInstallDetails/AppInstallDetails.tsx
@@ -78,21 +78,11 @@ export const getStatusMessage = ({
   }
 
   // Create predicate and subordinate for other statuses
-  let predicate: string;
-  let subordinate: string;
-  if (isStatusNotNow) {
-    predicate = "tried to install";
-    subordinate =
-      " but couldn’t because the host was locked or was running on battery power while in Power Nap. Fleet will try again";
-  } else {
-    predicate = getInstallDetailsStatusPredicate(displayStatus);
-    subordinate = displayStatus === "pending" ? " when it comes online" : "";
-  }
-
   return (
     <>
-      Fleet {predicate} <b>{software_title}</b> on {formattedHost}
-      {subordinate}.
+      Fleet {getInstallDetailsStatusPredicate(displayStatus)}{" "}
+      <b>{software_title}</b> on {formattedHost}
+      {displayStatus === "pending" ? " when it comes online" : ""}.
     </>
   );
 };
@@ -185,8 +175,7 @@ export const AppInstallDetails = ({
   // from the MDM protocol, e.g., "NotNow" or "Acknowledged". We need to display some special
   // messaging for the "NotNow" status, which otherwise would be treated as "pending".
   const isStatusNotNow = result?.status === "NotNow";
-  const isStatusAcknowledged =
-    result?.status === "Acknowledged" && !!result?.result;
+  const isStatusAcknowledged = result?.status === "Acknowledged";
 
   const statusMessage = getStatusMessage({
     displayStatus,


### PR DESCRIPTION
## Issue
Closes #29893 

## Description
- Update text for VPP command for pending_install and failed_install to include verification nuance
- Add related tests

## Note
- Original PR pointing to `vpp-verify-followup` but should be repointed to `main` once that branch is merged in


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
- [x] Added/updated automated tests
- [ ] Manual QA for all new/changed functionality
