### PR TITLE
Setup experience flag for InstalledSoftware activity

### DIFF
--- a/changes/29897-setup-experience-flag
+++ b/changes/29897-setup-experience-flag
@@ -1,0 +1,1 @@
+* Software installed activities created during setup experience correctly categorized as from automation

--- a/ee/server/service/orbit.go
+++ b/ee/server/service/orbit.go
@@ -177,13 +177,14 @@ func (svc *Service) failCancelledSetupExperienceInstalls(ctx context.Context, ho
 				softwarePackage = installerMeta.Name
 			}
 			activity := fleet.ActivityTypeInstalledSoftware{
-				HostID:          host.ID,
-				HostDisplayName: host.DisplayName(),
-				SoftwareTitle:   r.Name,
-				SoftwarePackage: softwarePackage,
-				InstallUUID:     *r.HostSoftwareInstallsExecutionID,
-				Status:          "failed",
-				SelfService:     false,
+				HostID:              host.ID,
+				HostDisplayName:     host.DisplayName(),
+				SoftwareTitle:       r.Name,
+				SoftwarePackage:     softwarePackage,
+				InstallUUID:         *r.HostSoftwareInstallsExecutionID,
+				Status:              "failed",
+				SelfService:         false,
+				FromSetupExperience: true,
 			}
 			err = svc.NewActivity(ctx, nil, activity)
 			if err != nil {

--- a/server/fleet/activities.go
+++ b/server/fleet/activities.go
@@ -1737,15 +1737,16 @@ func (a ActivityTypeResentConfigurationProfileBatch) Documentation() (activity s
 }
 
 type ActivityTypeInstalledSoftware struct {
-	HostID          uint    `json:"host_id"`
-	HostDisplayName string  `json:"host_display_name"`
-	SoftwareTitle   string  `json:"software_title"`
-	SoftwarePackage string  `json:"software_package"`
-	SelfService     bool    `json:"self_service"`
-	InstallUUID     string  `json:"install_uuid"`
-	Status          string  `json:"status"`
-	PolicyID        *uint   `json:"policy_id"`
-	PolicyName      *string `json:"policy_name"`
+	HostID              uint    `json:"host_id"`
+	HostDisplayName     string  `json:"host_display_name"`
+	SoftwareTitle       string  `json:"software_title"`
+	SoftwarePackage     string  `json:"software_package"`
+	SelfService         bool    `json:"self_service"`
+	InstallUUID         string  `json:"install_uuid"`
+	Status              string  `json:"status"`
+	PolicyID            *uint   `json:"policy_id"`
+	PolicyName          *string `json:"policy_name"`
+	FromSetupExperience bool    `json:"-"`
 }
 
 func (a ActivityTypeInstalledSoftware) ActivityName() string {
@@ -1757,7 +1758,7 @@ func (a ActivityTypeInstalledSoftware) HostIDs() []uint {
 }
 
 func (a ActivityTypeInstalledSoftware) WasFromAutomation() bool {
-	return a.PolicyID != nil
+	return a.PolicyID != nil || a.FromSetupExperience
 }
 
 func (a ActivityTypeInstalledSoftware) Documentation() (activity, details, detailsExample string) {

--- a/server/fleet/activities.go
+++ b/server/fleet/activities.go
@@ -1362,13 +1362,14 @@ func (a ActivityTypeDisabledWindowsMDMMigration) Documentation() (activity, deta
 }
 
 type ActivityTypeRanScript struct {
-	HostID            uint    `json:"host_id"`
-	HostDisplayName   string  `json:"host_display_name"`
-	ScriptExecutionID string  `json:"script_execution_id"`
-	ScriptName        string  `json:"script_name"`
-	Async             bool    `json:"async"`
-	PolicyID          *uint   `json:"policy_id"`
-	PolicyName        *string `json:"policy_name"`
+	HostID              uint    `json:"host_id"`
+	HostDisplayName     string  `json:"host_display_name"`
+	ScriptExecutionID   string  `json:"script_execution_id"`
+	ScriptName          string  `json:"script_name"`
+	Async               bool    `json:"async"`
+	PolicyID            *uint   `json:"policy_id"`
+	PolicyName          *string `json:"policy_name"`
+	FromSetupExperience bool    `json:"-"`
 }
 
 func (a ActivityTypeRanScript) ActivityName() string {
@@ -1380,7 +1381,7 @@ func (a ActivityTypeRanScript) HostIDs() []uint {
 }
 
 func (a ActivityTypeRanScript) WasFromAutomation() bool {
-	return a.PolicyID != nil
+	return a.PolicyID != nil || a.FromSetupExperience
 }
 
 func (a ActivityTypeRanScript) Documentation() (activity, details, detailsExample string) {
@@ -2155,15 +2156,16 @@ func (a ActivityDeletedAppStoreApp) Documentation() (activity string, details st
 }
 
 type ActivityInstalledAppStoreApp struct {
-	HostID          uint    `json:"host_id"`
-	HostDisplayName string  `json:"host_display_name"`
-	SoftwareTitle   string  `json:"software_title"`
-	AppStoreID      string  `json:"app_store_id"`
-	CommandUUID     string  `json:"command_uuid"`
-	Status          string  `json:"status,omitempty"`
-	SelfService     bool    `json:"self_service"`
-	PolicyID        *uint   `json:"policy_id"`
-	PolicyName      *string `json:"policy_name"`
+	HostID              uint    `json:"host_id"`
+	HostDisplayName     string  `json:"host_display_name"`
+	SoftwareTitle       string  `json:"software_title"`
+	AppStoreID          string  `json:"app_store_id"`
+	CommandUUID         string  `json:"command_uuid"`
+	Status              string  `json:"status,omitempty"`
+	SelfService         bool    `json:"self_service"`
+	PolicyID            *uint   `json:"policy_id"`
+	PolicyName          *string `json:"policy_name"`
+	FromSetupExperience bool    `json:"-"`
 }
 
 func (a ActivityInstalledAppStoreApp) HostIDs() []uint {
@@ -2175,7 +2177,7 @@ func (a ActivityInstalledAppStoreApp) ActivityName() string {
 }
 
 func (a ActivityInstalledAppStoreApp) WasFromAutomation() bool {
-	return a.PolicyID != nil
+	return a.PolicyID != nil || a.FromSetupExperience
 }
 
 func (a ActivityInstalledAppStoreApp) Documentation() (string, string, string) {

--- a/server/service/apple_mdm.go
+++ b/server/service/apple_mdm.go
@@ -3493,6 +3493,7 @@ func (svc *MDMAppleCheckinAndCommandService) CommandAndReportResults(r *mdm.Requ
 	case "InstallApplication":
 		// this might be a setup experience VPP install, so we'll try to update setup experience status
 		// TODO: consider limiting this to only macOS hosts
+		var fromSetupExperience bool
 		if updated, err := maybeUpdateSetupExperienceStatus(r.Context, svc.ds, fleet.SetupExperienceVPPInstallResult{
 			HostUUID:      cmdResult.UDID,
 			CommandUUID:   cmdResult.CommandUUID,
@@ -3501,6 +3502,7 @@ func (svc *MDMAppleCheckinAndCommandService) CommandAndReportResults(r *mdm.Requ
 			return nil, ctxerr.Wrap(r.Context, err, "updating setup experience status from VPP install result")
 		} else if updated {
 			// TODO: call next step of setup experience?
+			fromSetupExperience = true
 			level.Debug(svc.logger).Log("msg", "setup experience script result updated", "host_uuid", cmdResult.UDID, "execution_id", cmdResult.CommandUUID)
 		}
 
@@ -3516,7 +3518,7 @@ func (svc *MDMAppleCheckinAndCommandService) CommandAndReportResults(r *mdm.Requ
 
 				return nil, ctxerr.Wrap(r.Context, err, "fetching data for installed app store app activity")
 			}
-
+			act.FromSetupExperience = fromSetupExperience
 			if err := newActivity(r.Context, user, act, svc.ds, svc.logger); err != nil {
 				return nil, ctxerr.Wrap(r.Context, err, "creating activity for installed app store app")
 			}
@@ -3824,6 +3826,7 @@ func NewInstalledApplicationListResultsHandler(
 			}
 
 			// this might be a setup experience VPP install, so we'll try to update setup experience status
+			var fromSetupExperience bool
 			if updated, err := maybeUpdateSetupExperienceStatus(ctx, ds, fleet.SetupExperienceVPPInstallResult{
 				HostUUID:      installedAppResult.HostUUID(),
 				CommandUUID:   install.InstallCommandUUID,
@@ -3831,6 +3834,7 @@ func NewInstalledApplicationListResultsHandler(
 			}, true); err != nil {
 				return ctxerr.Wrap(ctx, err, "updating setup experience status from VPP install result")
 			} else if updated {
+				fromSetupExperience = true
 				level.Debug(logger).Log("msg", "setup experience script result updated", "host_uuid", installedAppResult.HostUUID(), "execution_id", install.InstallCommandUUID)
 			}
 
@@ -3844,7 +3848,7 @@ func NewInstalledApplicationListResultsHandler(
 
 				return ctxerr.Wrap(ctx, err, "fetching data for installed app store app activity")
 			}
-
+			act.FromSetupExperience = fromSetupExperience
 			if err := newActivity(ctx, user, act, ds, logger); err != nil {
 				return ctxerr.Wrap(ctx, err, "creating activity for installed app store app")
 			}

--- a/server/service/integration_mdm_dep_test.go
+++ b/server/service/integration_mdm_dep_test.go
@@ -2385,7 +2385,7 @@ func (s *integrationMDMTestSuite) TestSetupExperienceFlowWithSoftwareAndScriptAu
 }
 	`, enrolledHost.ID, getHostResp.Host.DisplayName, statusResp.Results.Software[0].Name, getSoftwareTitleResp.SoftwareTitle.SoftwarePackage.Name, installUUID)
 
-	s.lastActivityMatches(fleet.ActivityTypeInstalledSoftware{}.ActivityName(), expectedActivityDetail, 0)
+	s.lastActivityMatchesExtended(fleet.ActivityTypeInstalledSoftware{}.ActivityName(), expectedActivityDetail, 0, ptr.Bool(true))
 
 	// Validate upcoming activity for the script
 	s.DoJSON("GET", fmt.Sprintf("/api/latest/fleet/hosts/%d/activities/upcoming", enrolledHost.ID),

--- a/server/service/orbit.go
+++ b/server/service/orbit.go
@@ -1291,7 +1291,7 @@ func (svc *Service) SaveHostSoftwareInstallResult(ctx context.Context, result *f
 	if err != nil {
 		return ctxerr.Wrap(ctx, err, "save host software installation result")
 	}
-
+	var fromSetupExperience bool
 	if fleet.IsSetupExperienceSupported(host.Platform) {
 		// this might be a setup experience software install result
 		if updated, err := maybeUpdateSetupExperienceStatus(ctx, svc.ds, fleet.SetupExperienceSoftwareInstallResult{
@@ -1302,6 +1302,7 @@ func (svc *Service) SaveHostSoftwareInstallResult(ctx context.Context, result *f
 			return ctxerr.Wrap(ctx, err, "update setup experience status")
 		} else if updated {
 			// TODO: call next step of setup experience?
+			fromSetupExperience = true
 			level.Debug(svc.logger).Log("msg", "setup experience script result updated", "host_uuid", host.UUID, "execution_id", result.InstallUUID)
 		}
 	}
@@ -1334,15 +1335,16 @@ func (svc *Service) SaveHostSoftwareInstallResult(ctx context.Context, result *f
 			ctx,
 			user,
 			fleet.ActivityTypeInstalledSoftware{
-				HostID:          host.ID,
-				HostDisplayName: host.DisplayName(),
-				SoftwareTitle:   hsi.SoftwareTitle,
-				SoftwarePackage: hsi.SoftwarePackage,
-				InstallUUID:     result.InstallUUID,
-				Status:          string(status),
-				SelfService:     hsi.SelfService,
-				PolicyID:        hsi.PolicyID,
-				PolicyName:      policyName,
+				HostID:              host.ID,
+				HostDisplayName:     host.DisplayName(),
+				SoftwareTitle:       hsi.SoftwareTitle,
+				SoftwarePackage:     hsi.SoftwarePackage,
+				InstallUUID:         result.InstallUUID,
+				Status:              string(status),
+				SelfService:         hsi.SelfService,
+				PolicyID:            hsi.PolicyID,
+				PolicyName:          policyName,
+				FromSetupExperience: fromSetupExperience,
 			},
 		); err != nil {
 			return ctxerr.Wrap(ctx, err, "create activity for software installation")


### PR DESCRIPTION
Since setup experience triggered acitivites do not have a policy id, add an additional boolean that can be set and checked in the `WasFromAutomation` method.

https://github.com/fleetdm/fleet/issues/29897

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.
- [x] Added/updated automated tests
- [ ] Manual QA for all new/changed functionality