### PR TITLE
Update vex statements for CVE-2025-49794 and CVE-2025-49796

### DIFF
--- a/security/vex/fleetctl/CVE-2025-49794.vex.json
+++ b/security/vex/fleetctl/CVE-2025-49794.vex.json
@@ -16,6 +16,9 @@
         },
         {
           "@id": "pkg:deb/debian/libxml2@2.9.14+dfsg-1.3~deb12u1"
+        },
+        {
+          "@id": "pkg:deb/debian/libxml2@2.9.14+dfsg-1.3~deb12u2"
         }
       ],
       "status": "not_affected",

--- a/security/vex/fleetctl/CVE-2025-49796.vex.json
+++ b/security/vex/fleetctl/CVE-2025-49796.vex.json
@@ -16,6 +16,9 @@
         },
         {
           "@id": "pkg:deb/debian/libxml2@2.9.14+dfsg-1.3~deb12u1"
+        },
+        {
+          "@id": "pkg:deb/debian/libxml2@2.9.14+dfsg-1.3~deb12u2"
         }
       ],
       "status": "not_affected",


### PR DESCRIPTION
Bump statement versions to match installed versions