### PR TITLE
Fix URL under Spending Company Money

### DIFF
--- a/handbook/company/communications.md
+++ b/handbook/company/communications.md
@@ -587,7 +587,7 @@ In brief, this means that as a Fleet team member, you may:
 - [Spend less](https://fleetdm.com/handbook/company/why-this-way#why-spend-less).  Purchase what you need to do your job effectively.
 - Feel free to make purchases __in the company's interest__ without asking for permission beforehand (when in doubt, do __inform__ your manager prior to purchase or as soon as possible after the purchase).
 
-For more developed thoughts about __spending guidelines and limits__, please read [GitLab's open expense policy](https://about.gitlab.com/handbook/spending-company-money/).
+For more developed thoughts about __spending guidelines and limits__, please read [GitLab's open expense policy](https://about.gitlab.com/handbook/finance/spending-company-money/).
 
 
 ### Coworking


### PR DESCRIPTION
The URL was incorrect for the closing line for GitLabs spending company money policy.
