### PR TITLE
Move Google Chrome to FMA versions

### DIFF
--- a/it-and-security/teams/workstations-canary.yml
+++ b/it-and-security/teams/workstations-canary.yml
@@ -165,7 +165,7 @@ queries:
 software:
   packages:
     - path: ../lib/macos/software/mozilla-firefox.yml # Mozilla Firefox for MacOS (universal)
-    - path: ../lib/macos/software/google-chrome.yml # Google Chrome for macOS
+    # - path: ../lib/macos/software/google-chrome.yml # Google Chrome for macOS
     - path: ../lib/macos/software/1password.yml # 1Password for macOS
     - path: ../lib/macos/software/santa.yml # Santa for macOS
     - path: ../lib/macos/software/zoom.yml # Zoom for macOS
@@ -177,8 +177,8 @@ software:
     - path: ../lib/windows/software/slack.yml # Slack for Windows
     - path: ../lib/windows/software/zoom-arm.yml # Zoom for Windows (ARM)
     - path: ../lib/windows/software/zoom.yml # Zoom for Windows (x86)
-    - path: ../lib/windows/software/google-chrome.yml # Google Chrome for Windows
-    - path: ../lib/windows/software/google-chrome-arm.yml # Google Chrome for Windows (ARM)
+    # - path: ../lib/windows/software/google-chrome.yml # Google Chrome for Windows
+    # - path: ../lib/windows/software/google-chrome-arm.yml # Google Chrome for Windows (ARM)
     - path: ../lib/windows/software/1password.yml # 1Password for Windows
   app_store_apps:
     - app_store_id: '803453959' # Slack Desktop
@@ -189,7 +189,7 @@ software:
     - app_store_id: '409183694' # Keynote
       self_service: true
   fleet_maintained_apps:
-    # macOS apps
+    ### macOS apps ###
     - slug: brave-browser/darwin # Brave for macOS (ARM)
       self_service: true
       labels_include_any:
@@ -198,6 +198,8 @@ software:
       self_service: true
       labels_include_any:
         - Apple Silicon macOS hosts
+    - slug: google-chrome/darwin # Google Chrome for macOS
+      self_service: true
     - slug: microsoft-edge/darwin # Microsoft Edge for macOS
       self_service: true
     - slug: visual-studio-code/darwin # Microsoft Visual Studio for macOS (ARM)
@@ -206,8 +208,10 @@ software:
         - Apple Silicon macOS hosts
     - slug: microsoft-teams/darwin # Microsoft Teams for macOS
       self_service: true
-    # Windows apps
+    ### Windows apps ###
     - slug: brave-browser/windows # Brave for Windows
+      self_service: true
+    - slug: google-chrome/windows # Google Chrome for Windows
       self_service: true
     - slug: visual-studio-code/windows # Microsoft Visual Studio for Windows
       self_service: true

--- a/it-and-security/teams/workstations.yml
+++ b/it-and-security/teams/workstations.yml
@@ -123,7 +123,7 @@ queries:
 software:
   packages:
     - path: ../lib/macos/software/mozilla-firefox.yml # Mozilla Firefox for MacOS (universal)
-    - path: ../lib/macos/software/google-chrome.yml # Google Chrome for macOS
+    # - path: ../lib/macos/software/google-chrome.yml # Google Chrome for macOS
     - path: ../lib/macos/software/1password.yml # 1Password for macOS
     - path: ../lib/macos/software/santa.yml # Santa for macOS
     - path: ../lib/macos/software/zoom.yml # Zoom for macOS
@@ -135,8 +135,8 @@ software:
     - path: ../lib/windows/software/slack.yml # Slack for Windows
     - path: ../lib/windows/software/zoom-arm.yml # Zoom for Windows (ARM)
     - path: ../lib/windows/software/zoom.yml # Zoom for Windows (x86)
-    - path: ../lib/windows/software/google-chrome.yml # Google Chrome for Windows
-    - path: ../lib/windows/software/google-chrome-arm.yml # Google Chrome for Windows (ARM)
+    # - path: ../lib/windows/software/google-chrome.yml # Google Chrome for Windows
+    # - path: ../lib/windows/software/google-chrome-arm.yml # Google Chrome for Windows (ARM)
     - path: ../lib/windows/software/1password.yml # 1Password for Windows
   app_store_apps:
     - app_store_id: '803453959' # Slack Desktop
@@ -147,7 +147,7 @@ software:
     - app_store_id: '409183694' # Keynote
       self_service: true
   fleet_maintained_apps:
-    # macOS apps
+    ### macOS apps ###
     - slug: brave-browser/darwin # Brave for macOS (ARM)
       self_service: true
       labels_include_any:
@@ -156,6 +156,8 @@ software:
       self_service: true
       labels_include_any:
         - Apple Silicon macOS hosts
+    - slug: google-chrome/darwin # Google Chrome for macOS
+      self_service: true
     - slug: microsoft-edge/darwin # Microsoft Edge for macOS
       self_service: true
     - slug: visual-studio-code/darwin # Microsoft Visual Studio for macOS (ARM)
@@ -164,8 +166,10 @@ software:
         - Apple Silicon macOS hosts
     - slug: microsoft-teams/darwin # Microsoft Teams for macOS
       self_service: true
-    # Windows apps
+    ### Windows apps ###
     - slug: brave-browser/windows # Brave for Windows
+      self_service: true
+    - slug: google-chrome/windows # Google Chrome for Windows
       self_service: true
     - slug: visual-studio-code/windows # Microsoft Visual Studio for Windows
       self_service: true


### PR DESCRIPTION
- Updated Google Chrome for macOS and Windows to the Fleet-maintained app versions