### PR TITLE
Website: update IT comparison tables

### DIFF
--- a/website/assets/styles/pages/device-management.less
+++ b/website/assets/styles/pages/device-management.less
@@ -223,6 +223,10 @@
     justify-content: flex-start;
     align-self: center;
     min-width: 200px;
+    :has(p) {
+
+      justify-content: center;
+    }
     p {
       white-space: nowrap;
       font-size: 12px;

--- a/website/assets/styles/pages/homepage.less
+++ b/website/assets/styles/pages/homepage.less
@@ -542,7 +542,7 @@
     justify-content: flex-start;
     align-self: center;
     min-width: 200px;
-    &:has(p){
+    &:has(p) {
       justify-content: center;
     }
     p {

--- a/website/assets/styles/pages/homepage.less
+++ b/website/assets/styles/pages/homepage.less
@@ -542,6 +542,9 @@
     justify-content: flex-start;
     align-self: center;
     min-width: 200px;
+    &:has(p){
+      justify-content: center;
+    }
     p {
       white-space: nowrap;
       font-size: 12px;

--- a/website/views/pages/device-management.ejs
+++ b/website/views/pages/device-management.ejs
@@ -391,6 +391,27 @@
             </div>
 
             <div purpose="table-row">
+              <div purpose="feature-name">
+                <p>Import / export</p>
+              </div>
+              <div purpose="fleet-column">
+                <p>Interoperable</p>
+              </div>
+              <div purpose="comparison-column" v-if="comparisonMode === 'sccm'">
+                <p>Windows only</p>
+              </div>
+              <div purpose="comparison-column" v-else-if="comparisonMode === 'jamf'">
+                <p>Apple only</p>
+              </div>
+              <div purpose="comparison-column" v-else-if="['tanium', 'intune', 'omnissa'].includes(comparisonMode)">
+                <p>Proprietary</p>
+              </div>
+              <div purpose="comparison-column" v-else>
+                <img class="mx-auto" alt="checkmark" purpose="checkmark" src="/images/icon-checkmark-green-16x16@2x.png">
+              </div>
+            </div>
+
+            <div purpose="table-row">
               <div purpose="feature-name"><p>Open source</p></div>
               <div purpose="fleet-column"><p>Free and paid version</p></div>
               <div purpose="comparison-column" v-if="['puppet', 'chef', 'ansible'].includes(comparisonMode)">
@@ -739,6 +760,33 @@
               </div>
               <div purpose="feature-status" v-else>
                 <img class="mx-auto" alt="❌" purpose="red-x" src="/images/icon-emoji-x-12x12@2x.png">
+              </div>
+            </div>
+          </div>
+
+          <div purpose="feature-table">
+            <div purpose="feature-name">
+              <p>Import / export</p>
+            </div>
+            <div purpose="feature-table-row">
+              <div>Fleet</div>
+              <div purpose="feature-status">
+                <p>Interoperable</p>
+              </div>
+            </div>
+            <div purpose="feature-table-row">
+              <div>{{comparisonModeFriendlyNames[comparisonMode]}}</div>
+              <div purpose="feature-status" v-if="comparisonMode === 'sccm'">
+                <p>Windows only</p>
+              </div>
+              <div purpose="feature-status" v-else-if="comparisonMode === 'jamf'">
+                <p>Apple only</p>
+              </div>
+              <div purpose="feature-status" v-else-if="['tanium', 'intune', 'omnissa'].includes(comparisonMode)">
+                <p>Proprietary</p>
+              </div>
+              <div purpose="feature-status" v-else>
+                <img class="mx-auto" alt="checkmark" purpose="checkmark" src="/images/icon-checkmark-green-16x16@2x.png">
               </div>
             </div>
           </div>

--- a/website/views/pages/homepage.ejs
+++ b/website/views/pages/homepage.ejs
@@ -454,6 +454,27 @@
             </div>
 
             <div purpose="table-row">
+              <div purpose="feature-name">
+                <p>Import / export</p>
+              </div>
+              <div purpose="fleet-column">
+                <p>Interoperable</p>
+              </div>
+              <div purpose="comparison-column" v-if="comparisonModeForIt === 'sccm'">
+                <p>Windows only</p>
+              </div>
+              <div purpose="comparison-column" v-else-if="comparisonModeForIt === 'jamf'">
+                <p>Apple only</p>
+              </div>
+              <div purpose="comparison-column" v-else-if="['tanium', 'intune', 'omnissa'].includes(comparisonModeForIt)">
+                <p>Proprietary</p>
+              </div>
+              <div purpose="comparison-column" v-else>
+                <img class="mx-auto" alt="checkmark" purpose="checkmark" src="/images/icon-checkmark-green-16x16@2x.png">
+              </div>
+            </div>
+
+            <div purpose="table-row">
               <div purpose="feature-name"><p>Open source</p></div>
               <div purpose="fleet-column"><p>Free and paid version</p></div>
               <div purpose="comparison-column" v-if="['puppet', 'chef', 'ansible'].includes(comparisonModeForIt)">
@@ -803,6 +824,33 @@
               </div>
               <div purpose="feature-status" v-else>
                 <img class="mx-auto" alt="❌" purpose="red-x" src="/images/icon-emoji-x-12x12@2x.png">
+              </div>
+            </div>
+          </div>
+
+          <div purpose="feature-table">
+            <div purpose="feature-name">
+              <p>Import / export</p>
+            </div>
+            <div purpose="feature-table-row">
+              <div>Fleet</div>
+              <div purpose="feature-status">
+                <p>Interoperable</p>
+              </div>
+            </div>
+            <div purpose="feature-table-row">
+              <div>{{comparisonModeFriendlyNames[comparisonModeForIt]}}</div>
+              <div purpose="feature-status" v-if="comparisonModeForIt === 'sccm'">
+                <p>Windows only</p>
+              </div>
+              <div purpose="feature-status" v-else-if="comparisonModeForIt === 'jamf'">
+                <p>Apple only</p>
+              </div>
+              <div purpose="feature-status" v-else-if="['tanium', 'intune', 'omnissa'].includes(comparisonModeForIt)">
+                <p>Proprietary</p>
+              </div>
+              <div purpose="feature-status" v-else>
+                <img class="mx-auto" alt="checkmark" purpose="checkmark" src="/images/icon-checkmark-green-16x16@2x.png">
               </div>
             </div>
           </div>


### PR DESCRIPTION
Closes: https://github.com/fleetdm/confidential/issues/11003

Changes:
- Added "Import / export" to the IT comparison tables on the homepage and /device-management page