### PR TITLE
We have migrated from aws-sdk-go v1 to v2, remove scanner skip

### DIFF
--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -2,9 +2,5 @@
 # https://google.github.io/osv-scanner/configuration/
 
 [[IgnoredVulns]]
-id = "GO-2022-0646"
-reason = "2024/04/02 - This project does not use github.com/aws/aws-sdk-go/service/s3/s3crypto. Reference: https://osv.dev/vulnerability/GO-2022-0646"
-
-[[IgnoredVulns]]
 id = "GO-2023-1788"
 reason = "2024/04/02 - When packaging linux files, we do not use global permissions. Manually verified that packed fleet-osquery files do not have group/global write permissions. Reference: https://osv.dev/vulnerability/GO-2023-1788"


### PR DESCRIPTION
Missing removal from the aws-sdk-go migration from v1 to v2.