### PR TITLE
30259 - fix linux uninstall script

### DIFF
--- a/changes/30259-fix-linux-uninstall
+++ b/changes/30259-fix-linux-uninstall
@@ -1,0 +1,1 @@
+* Fixed the linux uninstall script

--- a/it-and-security/lib/linux/scripts/uninstall-fleetd-linux.sh
+++ b/it-and-security/lib/linux/scripts/uninstall-fleetd-linux.sh
@@ -14,9 +14,9 @@ function remove_fleet {
     
     # Remove any package references
     if command -v dpkg > /dev/null; then
-        dpkg --purge fleetdm-orbit || true
+        dpkg --purge fleet-osquery || true
     elif command -v rpm > /dev/null; then
-        rpm -e fleetdm-orbit || true
+        rpm -e fleet-osquery || true
     fi
     
     # Kill any running Fleet processes


### PR DESCRIPTION
I tested the uninstall script by:
- Making a new agent package and installing it
- Checking with `dpkg --get-selections | grep 'fleet'` that fleet-osquery is installed
- Checking with `sudo systemctl list-units | grep 'orbit'` that orbit.service is running
- Uninstalling the package with uninstall-fleetd-linux.sh
- Checking the above commands again to see that fleet-osquery and orbit.service are uninstalled.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- For Orbit and Fleet Desktop changes:
   - [x] Manual QA done on one Linux machine (Ubuntu 24 on HP laptop).
