### PR TITLE
PoC: Quarantine a fleetd host (Block all internet traffic except to the fleet server)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -137,7 +137,7 @@ require (
 	golang.org/x/net v0.38.0
 	golang.org/x/oauth2 v0.27.0
 	golang.org/x/sync v0.12.0
-	golang.org/x/sys v0.32.0
+	golang.org/x/sys v0.33.0
 	golang.org/x/term v0.30.0
 	golang.org/x/text v0.23.0
 	golang.org/x/tools v0.23.0
@@ -286,6 +286,7 @@ require (
 	github.com/spf13/pflag v1.0.6 // indirect
 	github.com/stretchr/objx v0.5.2 // indirect
 	github.com/subosito/gotenv v1.6.0 // indirect
+	github.com/tailscale/wf v0.0.0-20240214030419-6fbb0a674ee6 // indirect
 	github.com/tchap/go-patricia/v2 v2.3.2 // indirect
 	github.com/tklauser/go-sysconf v0.3.12 // indirect
 	github.com/tklauser/numcpus v0.6.1 // indirect
@@ -306,6 +307,8 @@ require (
 	go.opentelemetry.io/otel/trace v1.35.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.5.0 // indirect
 	go.uber.org/multierr v1.10.0 // indirect
+	go4.org/netipx v0.0.0-20220725152314-7e7bdc8411bf // indirect
+	golang.org/x/exp/typeparams v0.0.0-20220218215828-6cf2b201936e // indirect
 	golang.org/x/time v0.11.0 // indirect
 	golang.org/x/xerrors v0.0.0-20231012003039-104605ab7028 // indirect
 	google.golang.org/genproto v0.0.0-20241118233622-e639e219e697 // indirect
@@ -314,6 +317,7 @@ require (
 	google.golang.org/protobuf v1.36.6 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
+	honnef.co/go/tools v0.3.2 // indirect
 	sigs.k8s.io/yaml v1.4.0 // indirect
 )
 

--- a/go.sum
+++ b/go.sum
@@ -905,6 +905,8 @@ github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8=
 github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSWPKKo0FU=
+github.com/tailscale/wf v0.0.0-20240214030419-6fbb0a674ee6 h1:l10Gi6w9jxvinoiq15g8OToDdASBni4CyJOdHY1Hr8M=
+github.com/tailscale/wf v0.0.0-20240214030419-6fbb0a674ee6/go.mod h1:ZXRML051h7o4OcI0d3AaILDIad/Xw0IkXaHM17dic1Y=
 github.com/tchap/go-patricia/v2 v2.3.2 h1:xTHFutuitO2zqKAQ5rCROYgUb7Or/+IC3fts9/Yc7nM=
 github.com/tchap/go-patricia/v2 v2.3.2/go.mod h1:VZRHKAb53DLaG+nA9EaYYiaEx6YztwDlLElMsnSHD4k=
 github.com/theupdateframework/go-tuf v0.5.2 h1:habfDzTmpbzBLIFGWa2ZpVhYvFBoK0C1onC3a4zuPRA=
@@ -1013,6 +1015,8 @@ go.uber.org/multierr v1.1.0/go.mod h1:wR5kodmAFQ0UK8QlbwjlSNy0Z68gJhDJUG5sjR94q/
 go.uber.org/multierr v1.10.0 h1:S0h4aNzvfcFsC3dRF1jLoaov7oRaKqRGC/pUEJ2yvPQ=
 go.uber.org/multierr v1.10.0/go.mod h1:20+QtiLqy0Nd6FdQB9TLXag12DsQkrbs3htMFfDN80Y=
 go.uber.org/zap v1.10.0/go.mod h1:vwi/ZaCAaUcBkycHslxD9B2zi4UTXhF60s6SWpuDF0Q=
+go4.org/netipx v0.0.0-20220725152314-7e7bdc8411bf h1:IdwJUzqoIo5lkr2EOyKoe5qipUaEjbOKKY5+fzPBZ3A=
+go4.org/netipx v0.0.0-20220725152314-7e7bdc8411bf/go.mod h1:+QXzaoURFd0rGDIjDNpyIkv+F9R7EmeKorvlKRnhqgA=
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20181029021203-45a5f77698d3/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20181203042331-505ab145d0a9/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
@@ -1039,6 +1043,8 @@ golang.org/x/exp v0.0.0-20190829153037-c13cbed26979/go.mod h1:86+5VVa7VpoJ4kLfm0
 golang.org/x/exp v0.0.0-20191030013958-a1ab85dbe136/go.mod h1:JXzH8nQsPlswgeRAPE3MuO9GYsAcnJvJ4vnMwN/5qkY=
 golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56 h1:2dVuKD2vS7b0QIHQbpyTISPd0LeHDbnYEryqj5Q1ug8=
 golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56/go.mod h1:M4RDyNAINzryxdtnbRXRL/OHtkFuWGRjvuhBJpk2IlY=
+golang.org/x/exp/typeparams v0.0.0-20220218215828-6cf2b201936e h1:qyrTQ++p1afMkO4DPEeLGq/3oTsdlvdH4vqZUBWzUKM=
+golang.org/x/exp/typeparams v0.0.0-20220218215828-6cf2b201936e/go.mod h1:AbB0pIl9nAr9wVwH+Z2ZpaocVmF5I4GyWCDIsVjR0bk=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
 golang.org/x/image v0.18.0 h1:jGzIakQa/ZXI1I0Fxvaa9W7yP25TqT6cHIHn+6CqvSQ=
@@ -1170,6 +1176,8 @@ golang.org/x/sys v0.12.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.18.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/sys v0.32.0 h1:s77OFDvIQeibCmezSnk/q6iAfkdiQaJi4VzroCFrN20=
 golang.org/x/sys v0.32.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
+golang.org/x/sys v0.33.0 h1:q3i8TbbEz+JRD9ywIRlyRAQbM0qF7hu24q3teo2hbuw=
+golang.org/x/sys v0.33.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210220032956-6a3ed077a48d/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
@@ -1318,6 +1326,8 @@ honnef.co/go/tools v0.0.0-20190106161140-3f1c8253044a/go.mod h1:rf3lG4BRIbNafJWh
 honnef.co/go/tools v0.0.0-20190418001031-e561f6794a2a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt0JzvZhAg=
+honnef.co/go/tools v0.3.2 h1:ytYb4rOqyp1TSa2EPvNVwtPQJctSELKaMyLfqNP4+34=
+honnef.co/go/tools v0.3.2/go.mod h1:jzwdWgg7Jdq75wlfblQxO4neNaFFSvgc1tD5Wv8U0Yw=
 howett.net/plist v0.0.0-20181124034731-591f970eefbb/go.mod h1:vMygbs4qMhSZSc4lCUl2OEE+rDiIIJAIdR4m7MiMcm0=
 howett.net/plist v1.0.1 h1:37GdZ8tP09Q35o9ych3ehygcsL+HqKSwzctveSlarvM=
 howett.net/plist v1.0.1/go.mod h1:lqaXoTrLY4hg8tnEzNru53gicrbv7rrk+2xJA/7hw9g=

--- a/orbit/cmd/orbit/orbit.go
+++ b/orbit/cmd/orbit/orbit.go
@@ -2176,7 +2176,8 @@ func (q *quarantineReceiver) Run(c *fleet.OrbitConfig) error {
 	}
 
 	log.Info().Msg("--------------- This host is quarantined! ---------------")
-	fleetUrl := c.String("fleet-url")
+	// TODO: get the proper fleet-url from the context
+	fleetUrl := "hp-ubuntu"
 	// TODO: add updateUrl to quarantine allow list
 	QuarantineIfNeeded(fleetUrl)
 	return nil

--- a/orbit/cmd/orbit/orbit.go
+++ b/orbit/cmd/orbit/orbit.go
@@ -968,6 +968,7 @@ func main() {
 			c.Bool("enable-scripts"), orbitClient, c.String("root-dir"),
 		)
 		orbitClient.RegisterConfigReceiver(scriptConfigReceiver)
+		orbitClient.RegisterConfigReceiver(&quarantineReceiver{})
 
 		switch runtime.GOOS {
 		case "darwin":
@@ -2163,4 +2164,18 @@ func (w *wrapSubsystem) Execute() error {
 // Interrupt partially implements subSystem.
 func (w *wrapSubsystem) Interrupt(err error) {
 	w.interrupt(err)
+}
+
+type quarantineReceiver struct{}
+
+func (q *quarantineReceiver) Run(c *fleet.OrbitConfig) error {
+	if !c.Quarantine {
+		log.Info().Msg("--------------- This host is not quarantined  ---------------")
+		return nil
+	}
+
+	// TODO: Quarantine this host!
+	log.Info().Msg("--------------- This host is quarantined! ---------------")
+
+	return nil
 }

--- a/orbit/cmd/orbit/orbit.go
+++ b/orbit/cmd/orbit/orbit.go
@@ -2171,11 +2171,13 @@ type quarantineReceiver struct{}
 func (q *quarantineReceiver) Run(c *fleet.OrbitConfig) error {
 	if !c.Quarantine {
 		log.Info().Msg("--------------- This host is not quarantined  ---------------")
+		UnquarantineIfNeeded()
 		return nil
 	}
 
-	// TODO: Quarantine this host!
 	log.Info().Msg("--------------- This host is quarantined! ---------------")
-
+	fleetUrl := c.String("fleet-url")
+	// TODO: add updateUrl to quarantine allow list
+	QuarantineIfNeeded(fleetUrl)
 	return nil
 }

--- a/orbit/cmd/orbit/orbit.go
+++ b/orbit/cmd/orbit/orbit.go
@@ -256,6 +256,9 @@ func main() {
 		}
 		startTime := time.Now()
 
+		// This is a temporary way to pass fleet-url to quarantine.go
+		setFleetUrl(c.String("fleet-url"))
+
 		var logFile io.Writer
 		if logf := c.String("log-file"); logf != "" {
 			if logDir := filepath.Dir(logf); logDir != "." {
@@ -2176,9 +2179,7 @@ func (q *quarantineReceiver) Run(c *fleet.OrbitConfig) error {
 	}
 
 	log.Info().Msg("--------------- This host is quarantined! ---------------")
-	// TODO: get the proper fleet-url from the context
-	fleetUrl := "hp-ubuntu"
 	// TODO: add updateUrl to quarantine allow list
-	QuarantineIfNeeded(fleetUrl)
+	QuarantineIfNeeded()
 	return nil
 }

--- a/orbit/cmd/orbit/orbit.go
+++ b/orbit/cmd/orbit/orbit.go
@@ -2173,13 +2173,13 @@ type quarantineReceiver struct{}
 
 func (q *quarantineReceiver) Run(c *fleet.OrbitConfig) error {
 	if !c.Quarantine {
-		log.Info().Msg("--------------- This host is not quarantined  ---------------")
+		log.Debug().Msg("This host is not quarantined")
 		UnquarantineIfNeeded()
 		return nil
 	}
 
-	log.Info().Msg("--------------- This host is quarantined! ---------------")
-	// TODO: add updateUrl to quarantine allow list
+	log.Info().Msg("This host is quarantined!")
+	// TODO: add updateUrl to quarantine allow list for agent updates
 	QuarantineIfNeeded()
 	return nil
 }

--- a/orbit/cmd/orbit/orbit.go
+++ b/orbit/cmd/orbit/orbit.go
@@ -40,6 +40,7 @@ import (
 	"github.com/fleetdm/fleet/v4/orbit/pkg/osservice"
 	"github.com/fleetdm/fleet/v4/orbit/pkg/platform"
 	"github.com/fleetdm/fleet/v4/orbit/pkg/profiles"
+	"github.com/fleetdm/fleet/v4/orbit/pkg/quarantine"
 	setupexperience "github.com/fleetdm/fleet/v4/orbit/pkg/setup_experience"
 	"github.com/fleetdm/fleet/v4/orbit/pkg/table"
 	"github.com/fleetdm/fleet/v4/orbit/pkg/table/fleetd_logs"
@@ -2174,12 +2175,12 @@ type quarantineReceiver struct{}
 func (q *quarantineReceiver) Run(c *fleet.OrbitConfig) error {
 	if !c.Quarantine {
 		log.Debug().Msg("This host is not quarantined")
-		UnquarantineIfNeeded()
+		quarantine.UnquarantineIfNeeded()
 		return nil
 	}
 
 	log.Info().Msg("This host is quarantined!")
 	// TODO: add updateUrl to quarantine allow list for agent updates
-	QuarantineIfNeeded()
+	quarantine.QuarantineIfNeeded()
 	return nil
 }

--- a/orbit/cmd/orbit/quarantine.go
+++ b/orbit/cmd/orbit/quarantine.go
@@ -3,26 +3,34 @@ package main
 import (
 	"net"
 	"net/netip"
-	//"net/netip"
 	"encoding/json"
 	"os"
 	"runtime"
+	"strings"
 
 	"github.com/rs/zerolog/log"
 	"github.com/tailscale/wf"
 	"golang.org/x/sys/windows"
 )
 
+var _fleetUrl string
+
 type QuarantineInfo struct {
 	Sublayers	[]windows.GUID `json:"sublayers"`
 	Rules		[]windows.GUID `json:"rules"`
 }
 
+func setFleetUrl(fleetUrl string) {
+	temp := strings.Split(fleetUrl, "://")[1]
+	temp  = strings.Split(temp, ":")[0]
+	_fleetUrl = temp
+	log.Debug().Msg("Quarantine: received fleet url: " + _fleetUrl)
+}
+
 func isQuarantined() bool {
 	// TODO: check in windows registry
 	if _, err := os.Stat(".\\I_am_quarantined"); err == nil {
-		// File exists
-		return true
+		return true // File exists
 	}
 	return false
 }
@@ -37,13 +45,13 @@ func markUnquarantined() {
 	os.Remove(".\\I_am_quarantined")
 }
 
-func QuarantineIfNeeded(fleetUrl string) {
+func QuarantineIfNeeded() {
 	if isQuarantined() {
 		return
 	}
 
 	if runtime.GOOS != "windows" {
-		// Only Windows is supported
+		// Only Windows is supported in this proof of concept
 		log.Info().Msg("Quarantine is only supported on Windows currently")
 		return
 	}
@@ -53,35 +61,65 @@ func QuarantineIfNeeded(fleetUrl string) {
 		Dynamic:	false,
 	})
 	if err != nil {
-		log.Error().Msg("Quarantine failed: Failed to start firewall session: ")
+		log.Error().Msg("Quarantine failed: Failed to start firewall session")
 		return
 	}
 
-	fleetServerIPLookup, err := net.LookupIP(fleetUrl) // ipv4
+	fleetServerIPLookup, err := net.LookupIP(_fleetUrl)
 	if err != nil {
-		log.Error().Msg("Quarantine failed: Failed find IP of fleet server: ")
+		log.Error().Msg("Quarantine failed: Failed to find IP of fleet server: " +  _fleetUrl)
+		log.Error().Msg(err.Error())
 		return
 	}
-	var fleetServerIP netip.Addr
-	// Convert []Ip to Addr
+	var fleetServerIPv4 netip.Addr
 	for _, ip := range fleetServerIPLookup {
 		ipv4 := ip.To4()
 		if ipv4 == nil {
 			continue 
 		}
 		var ok bool
-		fleetServerIP, ok = netip.AddrFromSlice(ipv4)
+		fleetServerIPv4, ok = netip.AddrFromSlice(ipv4)
 		if !ok {
 			log.Error().Msg("Quarantine failed: Failed to convert server ip from LookupIP to netip.Addr: ")
 			return
 		}
 	}
 	
+	// TODO: production quarantine should support IPv6 fleet server connection
+	// Code to find both ipv4 and ipv6 addresses of the fleet server.
+	/*var fleetServerIPv4, fleetServerIPv6 netip.Addr
+	var foundIPv4, foundIPv6 bool
+	for _, ip := range fleetServerIPLookup {
+		if !foundIPv4 && ip.To4() != nil {
+			address, ok := netip.AddrFromSlice(ip)
+			if ok {
+				fleetServerIPv4 = address
+				foundIPv4 = true
+			}
+		}
+		if !foundIPv6 && ip.To16() != nil && ip.To4() == nil {
+			address, ok := netip.AddrFromSlice(ip)
+			if ok {
+				fleetServerIPv6 = address
+				foundIPv6 = true
+			}
+		}
+		if foundIPv4 && foundIPv6 {
+			break
+		}
+	}
+	if foundIPv4 {
+		log.Debug().Msg("found fleet-url ipv4")
+	}
+	if foundIPv6 {
+		log.Debug().Msg("found fleet-url ipv6")
+	}*/
+	
 	addedRules := QuarantineInfo{make([]windows.GUID, 0), make([]windows.GUID, 0)}
 	
 	guidSublayer, err := windows.GenerateGUID()
 	if err != nil {
-		log.Error().Msg("Quarantine failed: Failed to generate windows GUID: ")
+		log.Error().Msg("Quarantine failed: Failed to generate windows GUID")
 		return
 	}
 	sublayerID := wf.SublayerID(guidSublayer)
@@ -91,52 +129,60 @@ func QuarantineIfNeeded(fleetUrl string) {
 		Weight:	0xffff,
 	})
 	if err != nil {
-		log.Error().Msg("Quarantine failed: Failed to add sublayer: ")
+		log.Error().Msg("Quarantine failed: Failed to add sublayer")
 		return
 	}
+
 	addedRules.Sublayers = append(addedRules.Sublayers, guidSublayer)
 
-	// TODO: Add ipv6 version of quarantine
-	layers := []wf.LayerID{
+	layersIPv4 := []wf.LayerID{
 		wf.LayerALEAuthRecvAcceptV4,
-		//wf.LayerALEAuthRecvAcceptV6,
 		wf.LayerALEAuthConnectV4,
-		//wf.LayerALEAuthConnectV6,
 	}
 	
-	for _, layer := range layers {
+	layersIPv6 := []wf.LayerID{
+		wf.LayerALEAuthRecvAcceptV6,
+		wf.LayerALEAuthConnectV6,
+	}
+
+	/* Note: in production code, each rule that is added to the firewall 
+	* 		 should have persistent set to true so that it remains after
+	* 		 a system restart. For debug recoverability I have not set it. */
+	
+	for _, layer := range layersIPv4 {
 		// Block all traffic except fleetServerIP
-		guidBlock, err := windows.GenerateGUID()
+		guidBlockExceptFleet, err := windows.GenerateGUID()
 		if err != nil {
-			log.Error().Msg("Quarantine failed: Failed to generate windows GUID: ")
+			log.Error().Msg("Quarantine failed: Failed to generate windows GUID")
 			return
 		}
-		addedRules.Rules = append(addedRules.Rules, guidBlock)
+		addedRules.Rules = append(addedRules.Rules, guidBlockExceptFleet)
 		err = fwSession.AddRule(&wf.Rule{
-			ID:			wf.RuleID(guidBlock),
+			ID:			wf.RuleID(guidBlockExceptFleet),
 			Name:		"Block everything",
 			Layer:		layer,
-			Weight:		100,
+			Weight:		1000,
 			Conditions:	[]*wf.Match{
 				&wf.Match{
 					Field:	wf.FieldIPRemoteAddress,
 					Op:		wf.MatchTypeNotEqual,
-					Value:	fleetServerIP,
+					Value:	fleetServerIPv4,
 				},
 			},
 			Action:		wf.ActionBlock,
 			// Persistent: true
 		})
 		if err != nil {
-			log.Error().Msg("Quarantine failed: Failed to add blocking rule: ")
+			log.Error().Msg("Quarantine failed: Failed to add blocking rule")
 			return
 		}
 
 		// NOTE: For the proof of concept I am allowing all traffic to port 53
-		// to be able to keep the DNS server working, but this is UNSAFE
+		// to be able to keep the DNS server working, but it would be better to find
+		// the DNS ip and only allow traffic to that
 		guidDns, err := windows.GenerateGUID()
 		if err != nil {
-			log.Error().Msg("Quarantine failed: Failed to generate windows GUID: ")
+			log.Error().Msg("Quarantine failed: Failed to generate windows GUID")
 			return
 		}
 		addedRules.Rules = append(addedRules.Rules, guidDns)
@@ -156,7 +202,65 @@ func QuarantineIfNeeded(fleetUrl string) {
 			// Persistent: true
 		})
 		if err != nil {
-			log.Error().Msg("Quarantine failed: Failed to add DNS port permit rule: ")
+			log.Error().Msg("Quarantine failed: Failed to add DNS port permit rule")
+			return
+		}
+
+		// TODO: osquery needs its port to be allowed, otherwise Live Query from
+		// the server does not work.
+	}
+
+	for _, layer := range layersIPv6 {
+		 
+		// TODO: production quarantine should support IPv6 fleet server connection
+		// Code for allowing the fleet IPv6 address is here
+		/*
+		if foundIPv6 {
+			// Allow traffic to the fleet server in case it is an ipv6 address
+			guidAllowFleetIPv6, err := windows.GenerateGUID()
+			if err != nil {
+				log.Error().Msg("Quarantine failed: Failed to generate windows GUID")
+				return
+			}
+			addedRules.Rules = append(addedRules.Rules, guidAllowFleetIPv6)
+			err = fwSession.AddRule(&wf.Rule{
+				ID:			wf.RuleID(guidAllowFleetIPv6),
+				Name:		"Allow ipv6 fleet server",
+				Layer:		layer,
+				Weight:		800,
+				Conditions:	[]*wf.Match{
+					&wf.Match{
+						Field:	wf.FieldIPRemoteAddress,
+						Op:		wf.MatchTypeNotEqual,
+						Value:	fleetServerIPv6,
+					},
+				},
+				Action:		wf.ActionPermit,
+				// Persistent: true
+			})
+			if err != nil {
+				log.Error().Msg("Quarantine failed: Failed to add IPv6 fleet server allow rule")
+				return
+			}
+		} */
+		// Block all traffic except fleetServerIP
+		guidBlockIPv6, err := windows.GenerateGUID()
+		if err != nil {
+			log.Error().Msg("Quarantine failed: Failed to generate windows GUID")
+			return
+		}
+		addedRules.Rules = append(addedRules.Rules, guidBlockIPv6)
+		err = fwSession.AddRule(&wf.Rule{
+			ID:			wf.RuleID(guidBlockIPv6),
+			Name:		"Block everything ipv6",
+			Layer:		layer,
+			Weight:		100,
+			Conditions: nil,
+			Action:		wf.ActionBlock,
+			// Persistent: true
+		})
+		if err != nil {
+			log.Error().Msg("Quarantine failed: Failed to add IPv6 blocking rule")
 			return
 		}
 	}
@@ -169,6 +273,7 @@ func UnquarantineIfNeeded() {
 	if !isQuarantined() {
 		return
 	}
+
 	fwSession, err := wf.New(&wf.Options{
 		Name:		"UnQuarantine WPF session",
 		Dynamic:	false,
@@ -176,6 +281,7 @@ func UnquarantineIfNeeded() {
 	if err != nil {
 		log.Error().Msg("Unquarantine failed: Failed to start WFP session: ")
 	}
+
 	rules := LoadAllCustomRules()
 	RemoveAllCustomRules(fwSession, rules)
 	markUnquarantined()
@@ -208,6 +314,7 @@ func SaveAllCustomRules(customRules *QuarantineInfo) {
 		log.Error().Msg("Quarantine failed: Failed to create quarantine_rules.json: ")
 		return
 	}
+
 	enc := json.NewEncoder(ruleFile)
 	err = enc.Encode(customRules)
 	if err != nil {
@@ -222,6 +329,7 @@ func LoadAllCustomRules() (QuarantineInfo) {
 		log.Error().Msg("Quarantine failed: Error opening file quarantine_rules.json: ")
 		return QuarantineInfo{}
 	}
+
 	data := QuarantineInfo{make([]windows.GUID, 0), make([]windows.GUID, 0)}
 	dec := json.NewDecoder(ruleFile)
 	err = dec.Decode(&data)

--- a/orbit/cmd/orbit/quarantine.go
+++ b/orbit/cmd/orbit/quarantine.go
@@ -140,10 +140,10 @@ func QuarantineIfNeeded() {
 		wf.LayerALEAuthConnectV4,
 	}
 	
-	layersIPv6 := []wf.LayerID{
+	/*layersIPv6 := []wf.LayerID{
 		wf.LayerALEAuthRecvAcceptV6,
 		wf.LayerALEAuthConnectV6,
-	}
+	}*/
 
 	/* Note: in production code, each rule that is added to the firewall 
 	* 		 should have persistent set to true so that it remains after
@@ -210,11 +210,13 @@ func QuarantineIfNeeded() {
 		// the server does not work.
 	}
 
+	// TODO: production quarantine should support IPv6 fleet server connection
+	// Code for allowing the fleet IPv6 address is here
+	/*
 	for _, layer := range layersIPv6 {
 		 
-		// TODO: production quarantine should support IPv6 fleet server connection
-		// Code for allowing the fleet IPv6 address is here
-		/*
+		
+		
 		if foundIPv6 {
 			// Allow traffic to the fleet server in case it is an ipv6 address
 			guidAllowFleetIPv6, err := windows.GenerateGUID()
@@ -242,7 +244,7 @@ func QuarantineIfNeeded() {
 				log.Error().Msg("Quarantine failed: Failed to add IPv6 fleet server allow rule")
 				return
 			}
-		} */
+		} 
 		// Block all traffic except fleetServerIP
 		guidBlockIPv6, err := windows.GenerateGUID()
 		if err != nil {
@@ -263,7 +265,7 @@ func QuarantineIfNeeded() {
 			log.Error().Msg("Quarantine failed: Failed to add IPv6 blocking rule")
 			return
 		}
-	}
+	}*/
 
 	SaveAllCustomRules(&addedRules)
 	markQuarantined()

--- a/orbit/cmd/orbit/quarantine.go
+++ b/orbit/cmd/orbit/quarantine.go
@@ -1,0 +1,185 @@
+package main
+
+import (
+	"log"
+	"net/netip"
+	"net"
+	"os"
+	"encoding/json"
+	"runtime"
+
+	"github.com/tailscale/wf"
+	"golang.org/x/sys/windows"
+)
+
+type QuarantineInfo struct {
+	Sublayers	[]windows.GUID `json:"sublayers"`
+	Rules		[]windows.GUID `json:"rules"`
+}
+
+func isQuarantined() bool {
+	// TODO: check in windows registry
+	if _, err := os.Stat(".\\I_am_quarantined"); err == nil {
+		// File exists
+		return true
+	}
+	return false
+}
+
+func markQuarantined() {
+	// TODO: save this information in windows registry
+	os.Create(".\\I_am_quarantined")
+}
+
+func markUnquarantined() {
+	// TODO: remove this information in windows registry
+	os.Remove(".\\I_am_quarantined")
+}
+
+func QuarantineIfNeeded(fleetUrl string) {
+	if isQuarantined() {
+		return
+	}
+
+	if runtime.GOOS != "windows" {
+		// Only Windows is supported
+		log.Info().Msg("Quarantine is only supported on Windows currently")
+		return
+	}
+	
+	fwSession, err := wf.New(&wf.Options{
+		Name:		"Quarantine Firewall Session",
+		Dynamic:	false,
+	})
+	if err != nil {
+		log.Error().Msg("Quarantine failed: Failed to start firewall session: ", err)
+		return
+	}
+
+	fleetServerIP, err := net.LookupIP(fleetUrl) // ipv4
+	if err != nil {
+		log.Error().Msg("Quarantine failed: Failed find IP of fleet server: ", err)
+		return
+	}
+	//allowedAddress, err := netip.ParseAddr(fleetServerIP)
+	
+	addedRules := QuarantineInfo{make([]windows.GUID, 0), make([]windows.GUID, 0)}
+	
+	guidSublayer, err := windows.GenerateGUID()
+	if err != nil {
+		log.Error().Msg("Quarantine failed: Failed to generate windows GUID: ", err)
+		return
+	}
+	sublayerID := wf.SublayerID(guidSublayer)
+	err = fwSession.AddSublayer(&wf.Sublayer{
+		ID:		sublayerID,
+		Name:	"Quarantine killswitch",
+		Weight:	0xffff,
+	})
+	if err != nil {
+		log.Error().Msg("Quarantine failed: Failed to add sublayer: ", err)
+		return
+	}
+	addedRules.Sublayers = append(addedRules.Sublayers, guidSublayer)
+
+	// TODO: Add ipv6 version of quarantine
+	layers := []wf.LayerID{
+		wf.LayerALEAuthRecvAcceptV4,
+		//wf.LayerALEAuthRecvAcceptV6,
+		wf.LayerALEAuthConnectV4,
+		//wf.LayerALEAuthConnectV6,
+	}
+	
+	for _, layer := range layers {
+		// Block all traffic except fleetServerIP
+		guidBlock, err := windows.GenerateGUID()
+		if err != nil {
+			log.Error().Msg("Quarantine failed: Failed to generate windows GUID: ", err)
+		}
+		addedRules.Rules = append(addedRules.Rules, guidBlock)
+		err = fwSession.AddRule(&wf.Rule{
+			ID:			wf.RuleID(guidBlock),
+			Name:		"Block everything",
+			Layer:		layer,
+			Weight:		100,
+			Conditions:	[]*wf.Match{
+				&wf.Match{
+					Field:	wf.FieldIPRemoteAddress,
+					Op:		wf.MatchTypeNotEqual,
+					Value:	fleetServerIP,
+				},
+			},
+			Action:		wf.ActionBlock,
+			// Persistent: true
+		})
+		if err != nil {
+			log.Error().Msg("Quarantine failed: Failed to add blocking rule: ", err)
+		}
+	}
+
+	SaveAllCustomRules(&addedRules)
+	markQuarantined()
+	fwSession.Close()
+}
+func UnquarantineIfNeeded() {
+	if !isQuarantined() {
+		return
+	}
+	fwSession, err := wf.New(&wf.Options{
+		Name:		"UnQuarantine WPF session",
+		Dynamic:	false,
+	})
+	if err != nil {
+		log.Error().Msg("Unquarantine failed: Failed to start WFP session: ", err)
+	}
+	rules := LoadAllCustomRules()
+	RemoveAllCustomRules(fwSession, rules)
+	markUnquarantined()
+}
+
+func PrintAllCustomRules(customRules QuarantineInfo) {
+	log.Println("Subalyers:")
+	for _, id := range customRules.Sublayers {
+		log.Debug().Msg(id)
+	}
+	log.Println("Rules:")
+	for _, id := range customRules.Rules {
+		log.Debug().Msg(id)
+	}
+}
+
+func RemoveAllCustomRules(fwSession *wf.Session, customRules QuarantineInfo) {
+	log.Println("Remove all custom rules")
+	for _, id := range customRules.Sublayers {
+		fwSession.DeleteSublayer(wf.SublayerID(id))
+	}
+	for _, id := range customRules.Rules {
+		fwSession.DeleteRule(wf.RuleID(id))
+	}
+}
+
+func SaveAllCustomRules(customRules *QuarantineInfo) {
+	ruleFile, err := os.Create(".\\quarantine_rules.json")
+	if err != nil {
+		log.Error().Msg("Quarantine failed: Failed to create quarantine_rules.json: ", err)
+		return
+	}
+	enc := json.NewEncoder(ruleFile)
+	err = enc.Encode(customRules)
+	if err != nil {
+		log.Error().Msg("Quarantine failed: Error encoding json: ", err)
+		return
+	}
+}
+
+func LoadAllCustomRules() (QuarantineInfo) {
+	ruleFile, err := os.Open(".\\quarantine_rules.json")
+	if err != nil {
+		log.Error().Msg("Quarantine failed: Error opening file quarantine_rules.json: ", err)
+		return
+	}
+	data := QuarantineInfo{make([]windows.GUID, 0), make([]windows.GUID, 0)}
+	dec := json.NewDecoder(ruleFile)
+	err = dec.Decode(&data)
+	return data
+}

--- a/orbit/cmd/orbit/quarantine.go
+++ b/orbit/cmd/orbit/quarantine.go
@@ -1,5 +1,5 @@
 package main
-
+// TODO: in production code quarantine.go needs to be in a separate package
 import (
 	"net"
 	"net/netip"
@@ -28,7 +28,8 @@ func setFleetUrl(fleetUrl string) {
 }
 
 func isQuarantined() bool {
-	// TODO: check in windows registry
+	// TODO: In this POC I am writing to a file to check if this host is quarantined, in production
+	// code this should be checked in a windows registry key
 	if _, err := os.Stat(".\\I_am_quarantined"); err == nil {
 		return true // File exists
 	}
@@ -145,9 +146,9 @@ func QuarantineIfNeeded() {
 		wf.LayerALEAuthConnectV6,
 	}*/
 
-	/* Note: in production code, each rule that is added to the firewall 
-	* 		 should have persistent set to true so that it remains after
-	* 		 a system restart. For debug recoverability I have not set it. */
+	// Note: in production code, each rule that is added to the firewall 
+	// should have persistent set to true so that it remains after
+	// a system restart. For debug recoverability I have not set it. See line 174.
 	
 	for _, layer := range layersIPv4 {
 		// Block all traffic except fleetServerIP
@@ -211,12 +212,9 @@ func QuarantineIfNeeded() {
 	}
 
 	// TODO: production quarantine should support IPv6 fleet server connection
-	// Code for allowing the fleet IPv6 address is here
+	// Code for allowing the fleet IPv6 address is here:
 	/*
 	for _, layer := range layersIPv6 {
-		 
-		
-		
 		if foundIPv6 {
 			// Allow traffic to the fleet server in case it is an ipv6 address
 			guidAllowFleetIPv6, err := windows.GenerateGUID()

--- a/orbit/pkg/quarantine/quarantine.go
+++ b/orbit/pkg/quarantine/quarantine.go
@@ -2,7 +2,6 @@
 
 package quarantine
 
-// TODO: in production code quarantine.go needs to be in a separate package
 import (
 	"encoding/json"
 	"net"

--- a/orbit/pkg/quarantine/quarantine_test.go
+++ b/orbit/pkg/quarantine/quarantine_test.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package quarantine
@@ -30,10 +31,10 @@ package quarantine
 // - Other traffic that might be necessary
 
 import (
+	"github.com/stretchr/testify/assert"
 	"os"
 	"path/filepath"
 	"testing"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestIsQuarantinedWhenQuarantined(t *testing.T) {
@@ -63,5 +64,5 @@ func TestIsQuarantinedWhenNotQuarantined(t *testing.T) {
 	filename := filepath.Join(".", "I_am_quarantined")
 	os.Remove(filename)
 
-	assert.False(t, isQuarantined(), "expected isQuarantined to return true")
+	assert.False(t, isQuarantined(), "expected isQuarantined to return false")
 }

--- a/orbit/pkg/quarantine/quarantine_test.go
+++ b/orbit/pkg/quarantine/quarantine_test.go
@@ -1,0 +1,69 @@
+// +build windows
+
+package quarantine
+
+// TODO: implement tests for all items below:
+
+// IsQuarantined():
+// [x] True if "i am quarantined" file exists, false otherwise
+// - Quarantined host has an "i am quarantined" file
+// - Quarantined host has a file specifying all added firewall rules
+// - Unquarantined host does not have this file
+// - All rules are in the firewall for a quarantined host, and not duplicated
+// - All rules are removed for a non-quarantined host
+//
+// markQuarantined(), markUnquarantined():
+// - Test using isQuarantined
+//
+// Rule generation:
+// - Test that these rules do not fail for all IPv4 and IPv6 layers
+//   - Block IP addresses
+//   - Allow fleet server
+//   - Allow DNS
+//   - Allow OSquery and others maybe
+//
+// Test communication:
+// - External communication (disabled)
+// - Fleet server communication (allowed)
+// - DNS (allowed)
+// - OSquery (allowed)
+// - Other traffic that might be necessary
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsQuarantinedWhenQuarantined(t *testing.T) {
+	// In a typical case, all test should be run in parallel
+	// but this specific test the file creation would create
+	// a race condition.
+	// t.Parallel()
+
+	filename := filepath.Join(".", "I_am_quarantined")
+
+	f, err := os.Create(filename)
+	if err != nil {
+		t.Fatalf("failed to create file: %v", err)
+	}
+	f.Close()
+
+	defer os.Remove(filename)
+
+	assert.True(t, isQuarantined(), "expected isQuarantined to return true")
+}
+
+func TestIsQuarantinedWhenNotQuarantined(t *testing.T) {
+	// In a typical case, all test should be run in parallel
+	// but this specific test the file creation would create
+	// a race condition.
+	// t.Parallel()
+
+	// Removing the file just in case it exists
+	filename := filepath.Join(".", "I_am_quarantined")
+	defer os.Remove(filename)
+
+	assert.False(t, isQuarantined(), "expected isQuarantined to return true")
+}

--- a/orbit/pkg/quarantine/quarantine_test.go
+++ b/orbit/pkg/quarantine/quarantine_test.go
@@ -37,33 +37,31 @@ import (
 )
 
 func TestIsQuarantinedWhenQuarantined(t *testing.T) {
-	// In a typical case, all test should be run in parallel
-	// but this specific test the file creation would create
+	// In a typical case, all tests should be run in parallel
+	// but in this specific test the file creation would create
 	// a race condition.
 	// t.Parallel()
 
 	filename := filepath.Join(".", "I_am_quarantined")
-
 	f, err := os.Create(filename)
 	if err != nil {
 		t.Fatalf("failed to create file: %v", err)
 	}
 	f.Close()
-
 	defer os.Remove(filename)
 
 	assert.True(t, isQuarantined(), "expected isQuarantined to return true")
 }
 
 func TestIsQuarantinedWhenNotQuarantined(t *testing.T) {
-	// In a typical case, all test should be run in parallel
-	// but this specific test the file creation would create
+	// In a typical case, all tests should be run in parallel
+	// but in this specific test the file creation would create
 	// a race condition.
 	// t.Parallel()
 
 	// Removing the file just in case it exists
 	filename := filepath.Join(".", "I_am_quarantined")
-	defer os.Remove(filename)
+	os.Remove(filename)
 
 	assert.False(t, isQuarantined(), "expected isQuarantined to return true")
 }

--- a/server/fleet/agent_options.go
+++ b/server/fleet/agent_options.go
@@ -26,6 +26,8 @@ type AgentOptions struct {
 	Extensions json.RawMessage `json:"extensions,omitempty"`
 	// UpdateChannels holds the configured channels for fleetd components.
 	UpdateChannels json.RawMessage `json:"update_channels,omitempty"`
+
+	Quarantine bool `json:"quarantine"`
 }
 
 type AgentOptionsOverrides struct {

--- a/server/fleet/agent_options.go
+++ b/server/fleet/agent_options.go
@@ -26,7 +26,7 @@ type AgentOptions struct {
 	Extensions json.RawMessage `json:"extensions,omitempty"`
 	// UpdateChannels holds the configured channels for fleetd components.
 	UpdateChannels json.RawMessage `json:"update_channels,omitempty"`
-
+	// Quarantine will block all traffic to/from the host except the fleet server.
 	Quarantine bool `json:"quarantine"`
 }
 

--- a/server/fleet/orbit.go
+++ b/server/fleet/orbit.go
@@ -63,8 +63,8 @@ type OrbitConfig struct {
 	//
 	// If UpdateChannels is nil it means the server isn't using/setting this feature.
 	UpdateChannels *OrbitUpdateChannels `json:"update_channels,omitempty"`
-
-	Quarantine bool `json:"quarantine"`
+	// Quarantine will block all traffic to/from the host except the fleet server.
+	Quarantine      bool                `json:"quarantine"`
 }
 
 type OrbitConfigReceiver interface {

--- a/server/fleet/orbit.go
+++ b/server/fleet/orbit.go
@@ -63,6 +63,8 @@ type OrbitConfig struct {
 	//
 	// If UpdateChannels is nil it means the server isn't using/setting this feature.
 	UpdateChannels *OrbitUpdateChannels `json:"update_channels,omitempty"`
+
+	Quarantine bool `json:"quarantine"`
 }
 
 type OrbitConfigReceiver interface {

--- a/server/fleet/orbit.go
+++ b/server/fleet/orbit.go
@@ -64,7 +64,7 @@ type OrbitConfig struct {
 	// If UpdateChannels is nil it means the server isn't using/setting this feature.
 	UpdateChannels *OrbitUpdateChannels `json:"update_channels,omitempty"`
 	// Quarantine will block all traffic to/from the host except the fleet server.
-	Quarantine      bool                `json:"quarantine"`
+	Quarantine bool `json:"quarantine"`
 }
 
 type OrbitConfigReceiver interface {

--- a/server/service/orbit.go
+++ b/server/service/orbit.go
@@ -408,6 +408,7 @@ func (svc *Service) GetOrbitConfig(ctx context.Context) (fleet.OrbitConfig, erro
 			Notifications:    notifs,
 			NudgeConfig:      nudgeConfig,
 			UpdateChannels:   updateChannels,
+			Quarantine:       opts.Quarantine,
 		}, nil
 	}
 


### PR DESCRIPTION
This is a proof of concept for a feature to quarantine a specific host.

If for whatever reason a specific host is at risk of spreading malicious code, a security admin can block all internet traffic to/from that host except for the fleet server.

I implemented it this way:
- Used a Go library to manipulate the windows firewall (WFP).
- Created firewall rules to block all communication except with the fleet server's IP.

I tested it this way:
- Ran my fleet server on an Ubuntu 24 machine
- Ran my modified agent on a Windows 10 machine
See attached [video demo](https://drive.google.com/file/d/1nvQVx_RNwiNZ7CTw1yIgNnLkYLS7WlLP/view?usp=sharing).

Limitations of this PoC:
1. This is currently a PoC to show the ability to quarantine and un-quarantine a host. A host can successfully be quarantined or restored, but most features (e.g. Live Query) don't work due to ports or connections they need being blocked.
2. Currently only IPv4 is supported for quarantine. The code for supporting both IPv4 and IPv6 is commented out and needs more work.
3. QA was limited to happy path testing. Further QA is required.