### PR TITLE
21277: Keep fleet desktop running when host is offline

### DIFF
--- a/orbit/changes/21277-offline-indicator
+++ b/orbit/changes/21277-offline-indicator
@@ -1,1 +1,1 @@
-* Added feature for showing the informational message on fleet desktop if host becomes offline.
+* Added feature for showing an informational message on fleet desktop if host becomes offline.

--- a/orbit/changes/21277-offline-indicator
+++ b/orbit/changes/21277-offline-indicator
@@ -1,0 +1,1 @@
+* Show offline message on fleet desktop if host becomes offline.

--- a/orbit/changes/21277-offline-indicator
+++ b/orbit/changes/21277-offline-indicator
@@ -1,1 +1,1 @@
-* Show offline message on fleet desktop if host becomes offline.
+* Added feature for showing the informational message on fleet desktop if host becomes offline.

--- a/orbit/cmd/desktop/desktop.go
+++ b/orbit/cmd/desktop/desktop.go
@@ -180,7 +180,7 @@ func main() {
 		hostOfflineItem := systray.AddMenuItem(
 			`🛜🚫 Your computer is offline.
 
-It might take up to 5 minutes to reconnect to the Fleet.`,
+It might take up to 5 minutes to reconnect to Fleet.`,
 			"")
 		hostOfflineItem.Disable()
 


### PR DESCRIPTION
For #21277 

Show offline message on Fleet Desktop if host is offline.

# Checklist for submitter

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.
- [X] Manual QA for all new/changed functionality