### PR TITLE
Fix macos_setup not always being exported correctly by generate-gitops

### DIFF
--- a/changes/30502-fix-macos-setup-generation
+++ b/changes/30502-fix-macos-setup-generation
@@ -1,0 +1,1 @@
+- Fixed an issue where macos_setup would not always be exported by `fleetctl generate-gitops` when it should have been

--- a/cmd/fleetctl/fleetctl/generate_gitops.go
+++ b/cmd/fleetctl/fleetctl/generate_gitops.go
@@ -897,14 +897,16 @@ func (cmd *GenerateGitopsCommand) generateControls(teamId *uint, teamName string
 		}
 	}
 
-	if teamMdm != nil && cmd.AppConfig.License.IsPremium() {
+	if cmd.AppConfig.License.IsPremium() {
 		mdmT := reflect.TypeOf(fleet.TeamMDM{})
 
-		result[jsonFieldName(mdmT, "EnableDiskEncryption")] = teamMdm.EnableDiskEncryption
-		result[jsonFieldName(mdmT, "MacOSUpdates")] = teamMdm.MacOSUpdates
-		result[jsonFieldName(mdmT, "IOSUpdates")] = teamMdm.IOSUpdates
-		result[jsonFieldName(mdmT, "IPadOSUpdates")] = teamMdm.IPadOSUpdates
-		result[jsonFieldName(mdmT, "WindowsUpdates")] = teamMdm.WindowsUpdates
+		if teamMdm != nil {
+			result[jsonFieldName(mdmT, "EnableDiskEncryption")] = teamMdm.EnableDiskEncryption
+			result[jsonFieldName(mdmT, "MacOSUpdates")] = teamMdm.MacOSUpdates
+			result[jsonFieldName(mdmT, "IOSUpdates")] = teamMdm.IOSUpdates
+			result[jsonFieldName(mdmT, "IPadOSUpdates")] = teamMdm.IPadOSUpdates
+			result[jsonFieldName(mdmT, "WindowsUpdates")] = teamMdm.WindowsUpdates
+		}
 
 		if teamId == nil || *teamId == 0 {
 			mdmT := reflect.TypeOf(fleet.MDM{})
@@ -915,13 +917,55 @@ func (cmd *GenerateGitopsCommand) generateControls(teamId *uint, teamName string
 			result["windows_enabled_and_configured"] = cmd.AppConfig.MDM.WindowsEnabledAndConfigured
 		}
 
-		// TODO -- add an IsSet() method to MacOSSSetup to encapsulate this logic.
-		if teamMdm.MacOSSetup.BootstrapPackage.Value != "" || teamMdm.MacOSSetup.EnableEndUserAuthentication || teamMdm.MacOSSetup.MacOSSetupAssistant.Value != "" || teamMdm.MacOSSetup.Script.Value != "" || (teamMdm.MacOSSetup.Software.Valid && len(teamMdm.MacOSSetup.Software.Value) > 0) {
-			result[jsonFieldName(mdmT, "MacOSSetup")] = "TODO: update with your macos_setup configuration"
-			cmd.Messages.Notes = append(cmd.Messages.Notes, Note{
-				Filename: teamName,
-				Note:     "The macos_setup configuration is not supported by this tool yet.  To configure it, please follow the Fleet documentation at https://fleetdm.com/docs/configuration/yaml-files#macos-setup",
-			})
+		if teamId != nil {
+			// See if the team has macOS setup software configured.
+			setupSoftware, err := cmd.Client.GetSetupExperienceSoftware(*teamId)
+			if err != nil {
+				fmt.Fprintf(cmd.CLI.App.ErrWriter, "Error getting setup software: %s\n", err)
+				return nil, err
+			}
+			hasSetupSoftware := false
+			if setupSoftware != nil {
+				for _, software := range setupSoftware {
+					if software.SoftwarePackage.InstallDuringSetup != nil && *software.SoftwarePackage.InstallDuringSetup {
+						hasSetupSoftware = true
+						break
+					}
+				}
+			}
+
+			// See if the team has macOS bootstrap package configured.
+			bootstrapPackage, err := cmd.Client.GetBootstrapPackageMetadata(*teamId, false)
+			if err != nil {
+				fmt.Fprintf(cmd.CLI.App.ErrWriter, "Error getting bootstrap package metadata: %s\n", err)
+				return nil, err
+			}
+			hasBootstrapPackage := bootstrapPackage != nil
+
+			// See if the team has a macOS setup scripts configured.
+			setupScript, err := cmd.Client.GetSetupExperienceScript(*teamId)
+			if err != nil {
+				fmt.Fprintf(cmd.CLI.App.ErrWriter, "Error getting setup script: %s\n", err)
+				return nil, err
+			}
+			hasSetupScript := setupScript != nil
+
+			// See if the team has a macOS enrollment profile configured.
+			enrollmentProfile, err := cmd.Client.GetAppleMDMEnrollmentProfile(*teamId)
+			if err != nil {
+				fmt.Fprintf(cmd.CLI.App.ErrWriter, "Error getting enrollment profile: %s\n", err)
+				return nil, err
+			}
+			hasEnrollmentProfile := enrollmentProfile != nil
+
+			// If the team has any of these configured, we need to generate the macos_setup section.
+			if hasSetupSoftware || hasBootstrapPackage || hasSetupScript || hasEnrollmentProfile || (teamMdm != nil && teamMdm.MacOSSetup.EnableEndUserAuthentication) {
+				result[jsonFieldName(mdmT, "MacOSSetup")] = "TODO: update with your macos_setup configuration"
+				cmd.Messages.Notes = append(cmd.Messages.Notes, Note{
+					Filename: teamName,
+					Note:     "The macos_setup configuration is not supported by this tool yet.  To configure it, please follow the Fleet documentation at https://fleetdm.com/docs/configuration/yaml-files#macos-setup",
+				})
+			}
 		}
 	}
 

--- a/cmd/fleetctl/fleetctl/generate_gitops.go
+++ b/cmd/fleetctl/fleetctl/generate_gitops.go
@@ -72,6 +72,10 @@ type generateGitopsClient interface {
 	GetQueries(teamID *uint, name *string) ([]fleet.Query, error)
 	GetLabels() ([]*fleet.LabelSpec, error)
 	Me() (*fleet.User, error)
+	GetSetupExperienceSoftware(teamID uint) ([]fleet.SoftwareTitleListResult, error)
+	GetBootstrapPackageMetadata(teamID uint, forUpdate bool) (*fleet.MDMAppleBootstrapPackage, error)
+	GetSetupExperienceScript(teamID uint) (*fleet.Script, error)
+	GetAppleMDMEnrollmentProfile(teamID uint) (*fleet.MDMAppleSetupAssistant, error)
 }
 
 // Given a struct type and a field name, return the JSON field name.

--- a/cmd/fleetctl/fleetctl/generate_gitops.go
+++ b/cmd/fleetctl/fleetctl/generate_gitops.go
@@ -925,12 +925,10 @@ func (cmd *GenerateGitopsCommand) generateControls(teamId *uint, teamName string
 				return nil, err
 			}
 			hasSetupSoftware := false
-			if setupSoftware != nil {
-				for _, software := range setupSoftware {
-					if software.SoftwarePackage.InstallDuringSetup != nil && *software.SoftwarePackage.InstallDuringSetup {
-						hasSetupSoftware = true
-						break
-					}
+			for _, software := range setupSoftware {
+				if software.SoftwarePackage.InstallDuringSetup != nil && *software.SoftwarePackage.InstallDuringSetup {
+					hasSetupSoftware = true
+					break
 				}
 			}
 

--- a/cmd/fleetctl/fleetctl/generate_gitops.go
+++ b/cmd/fleetctl/fleetctl/generate_gitops.go
@@ -936,7 +936,7 @@ func (cmd *GenerateGitopsCommand) generateControls(teamId *uint, teamName string
 
 			// See if the team has macOS bootstrap package configured.
 			bootstrapPackage, err := cmd.Client.GetBootstrapPackageMetadata(*teamId, false)
-			if err != nil {
+			if err != nil && !strings.Contains(err.Error(), "bootstrap package for this team does not exist") {
 				fmt.Fprintf(cmd.CLI.App.ErrWriter, "Error getting bootstrap package metadata: %s\n", err)
 				return nil, err
 			}

--- a/cmd/fleetctl/fleetctl/generate_gitops_test.go
+++ b/cmd/fleetctl/fleetctl/generate_gitops_test.go
@@ -92,6 +92,10 @@ func (MockClient) ListScripts(query string) ([]*fleet.Script, error) {
 			Name:            "Script Z.ps1",
 			ScriptContentID: 3,
 		}}, nil
+	case "team_id=2":
+		return nil, nil
+	case "team_id=3":
+		return nil, nil
 	default:
 		return nil, fmt.Errorf("unexpected query: %s", query)
 	}
@@ -142,6 +146,12 @@ func (MockClient) ListConfigurationProfiles(teamID *uint) ([]*fleet.MDMConfigPro
 		}, nil
 	}
 	if *teamID == 0 {
+		return nil, nil
+	}
+	if *teamID == 2 {
+		return nil, nil
+	}
+	if *teamID == 3 {
 		return nil, nil
 	}
 	return nil, fmt.Errorf("unexpected team ID: %v", *teamID)
@@ -387,6 +397,121 @@ func (MockClient) GetEULAMetadata() (*fleet.MDMEULA, error) {
 
 func (MockClient) GetEULAContent(token string) ([]byte, error) {
 	return []byte("This is the EULA content."), nil
+}
+
+func (MockClient) GetSetupExperienceSoftware(teamID uint) ([]fleet.SoftwareTitleListResult, error) {
+	if teamID == 1 {
+		return []fleet.SoftwareTitleListResult{
+			{
+				ID:         1,
+				Name:       "My Software Package",
+				HashSHA256: ptr.String("software-package-hash"),
+				SoftwarePackage: &fleet.SoftwarePackageOrApp{
+					InstallDuringSetup: ptr.Bool(true),
+					Name:               "my-software.pkg",
+					Platform:           "darwin",
+					Version:            "13.37",
+				},
+			},
+		}, nil
+	}
+	if teamID == 2 {
+		return []fleet.SoftwareTitleListResult{
+			{
+				ID:         1,
+				Name:       "My Software Package",
+				HashSHA256: ptr.String("software-package-hash"),
+				SoftwarePackage: &fleet.SoftwarePackageOrApp{
+					InstallDuringSetup: ptr.Bool(false),
+					Name:               "my-software.pkg",
+					Platform:           "darwin",
+					Version:            "13.37",
+				},
+			},
+		}, nil
+	}
+	if teamID == 0 {
+		return nil, nil
+	}
+	if teamID == 3 {
+		return nil, nil
+	}
+	if teamID == 4 {
+		return nil, nil
+	}
+	if teamID == 5 {
+		return nil, nil
+	}
+	return nil, fmt.Errorf("unexpected team ID: %d", teamID)
+}
+
+func (MockClient) GetBootstrapPackageMetadata(teamID uint, forUpdate bool) (*fleet.MDMAppleBootstrapPackage, error) {
+	if teamID == 3 {
+		return &fleet.MDMAppleBootstrapPackage{
+			Name: "Bootstrap Package for Team 1",
+		}, nil
+	}
+	if teamID == 0 {
+		return nil, nil
+	}
+	if teamID == 1 {
+		return nil, nil
+	}
+	if teamID == 4 {
+		return nil, nil
+	}
+	if teamID == 5 {
+		return nil, nil
+	}
+	return nil, fmt.Errorf("unexpected team ID: %d", teamID)
+}
+
+func (MockClient) GetSetupExperienceScript(teamID uint) (*fleet.Script, error) {
+	if teamID == 4 {
+		return &fleet.Script{
+			Name: "Setup Experience Script for Team 1",
+		}, nil
+	}
+	if teamID == 0 {
+		return nil, nil
+	}
+	if teamID == 1 {
+		return nil, nil
+	}
+	if teamID == 2 {
+		return nil, nil
+	}
+	if teamID == 3 {
+		return nil, nil
+	}
+	if teamID == 5 {
+		return nil, nil
+	}
+	return nil, fmt.Errorf("unexpected team ID: %d", teamID)
+}
+
+func (MockClient) GetAppleMDMEnrollmentProfile(teamID uint) (*fleet.MDMAppleSetupAssistant, error) {
+	if teamID == 5 {
+		return &fleet.MDMAppleSetupAssistant{
+			Name: "Apple MDM Enrollment Profile for Team 1",
+		}, nil
+	}
+	if teamID == 0 {
+		return nil, nil
+	}
+	if teamID == 1 {
+		return nil, nil
+	}
+	if teamID == 2 {
+		return nil, nil
+	}
+	if teamID == 3 {
+		return nil, nil
+	}
+	if teamID == 4 {
+		return nil, nil
+	}
+	return nil, fmt.Errorf("unexpected team ID: %d", teamID)
 }
 
 func compareDirs(t *testing.T, sourceDir, targetDir string) {
@@ -679,24 +804,6 @@ func TestGenerateControls(t *testing.T) {
 	// Compare.
 	require.Equal(t, expectedControls, controls)
 
-	// Generate controls for a team.
-	// Note that nested keys here may be strings,
-	// so we'll JSON marshal and unmarshal to a map for comparison.
-	controlsRaw, err = cmd.generateControls(ptr.Uint(1), "some_team", nil)
-	require.NoError(t, err)
-	require.NotNil(t, controlsRaw)
-	b, err = yaml.Marshal(controlsRaw)
-	require.NoError(t, err)
-	fmt.Println("Controls raw:\n", string(b)) // Debugging line
-	err = yaml.Unmarshal(b, &controls)
-	require.NoError(t, err)
-
-	// Get the expected org settings YAML.
-	b, err = os.ReadFile("./testdata/generateGitops/expectedTeamControls.yaml")
-	require.NoError(t, err)
-	err = yaml.Unmarshal(b, &expectedControls)
-	require.NoError(t, err)
-
 	if fileContents, ok := cmd.FilesToWrite["lib/profiles/global-macos-mobileconfig-profile.mobileconfig"]; ok {
 		require.Equal(t, "<xml>global macos mobileconfig profile</xml>", fileContents)
 	} else {
@@ -715,6 +822,50 @@ func TestGenerateControls(t *testing.T) {
 		t.Fatalf("Expected file not found")
 	}
 
+	// Generate controls for no-team, sending in an MDM config with "EndUserAuthentication" disabled.
+	// Mocks for no team don't return any scripts, bootstrap, software, or profiles,
+	// so it should _not_ generate a macos_setup config.
+	mdmConfig = fleet.TeamMDM{
+		MacOSSetup: fleet.MacOSSetup{
+			EnableEndUserAuthentication: false,
+		},
+	}
+	controlsRaw, err = cmd.generateControls(ptr.Uint(0), "no_team", &mdmConfig)
+	require.NoError(t, err)
+	// Check that the controls do not contain a macos_setup section
+	_, ok := controlsRaw["macos_setup"]
+	require.False(t, ok, "Expected no macos_setup section for no-team controls")
+
+	// Try that again, but with an MDM config that has "EndUserAuthentication" enabled.
+	mdmConfig = fleet.TeamMDM{
+		MacOSSetup: fleet.MacOSSetup{
+			EnableEndUserAuthentication: true,
+		},
+	}
+	controlsRaw, err = cmd.generateControls(ptr.Uint(0), "no_team", &mdmConfig)
+	require.NoError(t, err)
+	// Check that the controls do contain a macos_setup section
+	verifyControlsHasMacosSetup(t, controlsRaw)
+
+	// Generate controls for a team.
+	// Note that nested keys here may be strings,
+	// so we'll JSON marshal and unmarshal to a map for comparison.
+	// Note that this team has setup experience software, so we expect a macos_setup section.
+	controlsRaw, err = cmd.generateControls(ptr.Uint(1), "some_team", nil)
+	require.NoError(t, err)
+	require.NotNil(t, controlsRaw)
+	b, err = yaml.Marshal(controlsRaw)
+	require.NoError(t, err)
+	fmt.Println("Controls raw:\n", string(b)) // Debugging line
+	err = yaml.Unmarshal(b, &controls)
+	require.NoError(t, err)
+
+	// Get the expected controls YAML.
+	b, err = os.ReadFile("./testdata/generateGitops/expectedTeamControls.yaml")
+	require.NoError(t, err)
+	err = yaml.Unmarshal(b, &expectedControls)
+	require.NoError(t, err)
+
 	if fileContents, ok := cmd.FilesToWrite["lib/some_team/profiles/team-macos-mobileconfig-profile.mobileconfig"]; ok {
 		require.Equal(t, "<xml>test mobileconfig profile</xml>", fileContents)
 	} else {
@@ -729,6 +880,24 @@ func TestGenerateControls(t *testing.T) {
 
 	// Compare.
 	require.Equal(t, expectedControls, controls)
+
+	// Generate controls for a team with software but none that installs during setup.
+	controlsRaw, err = cmd.generateControls(ptr.Uint(2), "some_team", nil)
+	require.NoError(t, err)
+	require.NotNil(t, controlsRaw)
+	require.False(t, ok, "Expected no macos_setup section for no-team controls")
+
+	// Generate controls for a team with a bootstrap pacakge.
+	controlsRaw, err = cmd.generateControls(ptr.Uint(3), "some_team", nil)
+	verifyControlsHasMacosSetup(t, controlsRaw)
+
+	// Generate controls for a team with a setup experience script.
+	controlsRaw, err = cmd.generateControls(ptr.Uint(4), "some_team", nil)
+	verifyControlsHasMacosSetup(t, controlsRaw)
+
+	// Generate controls for a team with a setup experience profile.
+	controlsRaw, err = cmd.generateControls(ptr.Uint(5), "some_team", nil)
+	verifyControlsHasMacosSetup(t, controlsRaw)
 }
 
 func TestGenerateSoftware(t *testing.T) {
@@ -951,4 +1120,15 @@ func TestGenerateLabels(t *testing.T) {
 
 	// Compare.
 	require.Equal(t, expectedlabels, labels)
+}
+
+func verifyControlsHasMacosSetup(t *testing.T, controlsRaw map[string]interface{}) {
+	_, ok := controlsRaw["macos_setup"]
+	require.True(t, ok, "Expected macos_setup section for no-team controls with EndUserAuthentication enabled")
+	// Check that macos_setup.enable_end_user_authentication is true
+	macosSetup, ok := controlsRaw["macos_setup"].(map[string]interface{})
+	require.True(t, ok, "Expected macos_setup to be a map")
+	enableEndUserAuth, ok := macosSetup["enable_end_user_authentication"].(bool)
+	require.True(t, ok, "Expected macos_setup.enable_end_user_authentication to be a boolean")
+	require.True(t, enableEndUserAuth, "Expected macos_setup.enable_end_user_authentication to be true")
 }

--- a/cmd/fleetctl/fleetctl/generate_gitops_test.go
+++ b/cmd/fleetctl/fleetctl/generate_gitops_test.go
@@ -707,6 +707,12 @@ func TestGenerateTeamSettingsInsecure(t *testing.T) {
 	require.Equal(t, expectedAppConfig, TeamSettings)
 }
 
+// For the purpose of testing macos_setup generation,
+// Team 1 has setup experience software with InstallDuringSetup enabled,
+// Team 2 has setup experience software with InstallDuringSetup disabled,
+// Team 3 has a bootstrap package,
+// Team 4 has a setup experience script,
+// Team 5 has an Apple MDM enrollment profile.
 func TestGenerateControls(t *testing.T) {
 	// Get the test app config.
 	fleetClient := &MockClient{}

--- a/cmd/fleetctl/fleetctl/generate_gitops_test.go
+++ b/cmd/fleetctl/fleetctl/generate_gitops_test.go
@@ -845,14 +845,17 @@ func TestGenerateControls(t *testing.T) {
 
 	// Generate controls for a team with a bootstrap pacakge.
 	controlsRaw, err = cmd.generateControls(ptr.Uint(3), "some_team", nil)
+	require.NoError(t, err)
 	verifyControlsHasMacosSetup(t, controlsRaw)
 
 	// Generate controls for a team with a setup experience script.
 	controlsRaw, err = cmd.generateControls(ptr.Uint(4), "some_team", nil)
+	require.NoError(t, err)
 	verifyControlsHasMacosSetup(t, controlsRaw)
 
 	// Generate controls for a team with a setup experience profile.
 	controlsRaw, err = cmd.generateControls(ptr.Uint(5), "some_team", nil)
+	require.NoError(t, err)
 	verifyControlsHasMacosSetup(t, controlsRaw)
 }
 

--- a/cmd/fleetctl/fleetctl/generate_gitops_test.go
+++ b/cmd/fleetctl/fleetctl/generate_gitops_test.go
@@ -92,9 +92,7 @@ func (MockClient) ListScripts(query string) ([]*fleet.Script, error) {
 			Name:            "Script Z.ps1",
 			ScriptContentID: 3,
 		}}, nil
-	case "team_id=2":
-		return nil, nil
-	case "team_id=3":
+	case "team_id=2", "team_id=3", "team_id=4", "team_id=5":
 		return nil, nil
 	default:
 		return nil, fmt.Errorf("unexpected query: %s", query)
@@ -145,13 +143,7 @@ func (MockClient) ListConfigurationProfiles(teamID *uint) ([]*fleet.MDMConfigPro
 			},
 		}, nil
 	}
-	if *teamID == 0 {
-		return nil, nil
-	}
-	if *teamID == 2 {
-		return nil, nil
-	}
-	if *teamID == 3 {
+	if *teamID == 0 || *teamID == 2 || *teamID == 3 || *teamID == 4 || *teamID == 5 {
 		return nil, nil
 	}
 	return nil, fmt.Errorf("unexpected team ID: %v", *teamID)
@@ -430,16 +422,7 @@ func (MockClient) GetSetupExperienceSoftware(teamID uint) ([]fleet.SoftwareTitle
 			},
 		}, nil
 	}
-	if teamID == 0 {
-		return nil, nil
-	}
-	if teamID == 3 {
-		return nil, nil
-	}
-	if teamID == 4 {
-		return nil, nil
-	}
-	if teamID == 5 {
+	if teamID == 0 || teamID == 3 || teamID == 4 || teamID == 5 {
 		return nil, nil
 	}
 	return nil, fmt.Errorf("unexpected team ID: %d", teamID)
@@ -451,16 +434,7 @@ func (MockClient) GetBootstrapPackageMetadata(teamID uint, forUpdate bool) (*fle
 			Name: "Bootstrap Package for Team 1",
 		}, nil
 	}
-	if teamID == 0 {
-		return nil, nil
-	}
-	if teamID == 1 {
-		return nil, nil
-	}
-	if teamID == 4 {
-		return nil, nil
-	}
-	if teamID == 5 {
+	if teamID == 0 || teamID == 1 || teamID == 2 || teamID == 4 || teamID == 5 {
 		return nil, nil
 	}
 	return nil, fmt.Errorf("unexpected team ID: %d", teamID)
@@ -472,19 +446,7 @@ func (MockClient) GetSetupExperienceScript(teamID uint) (*fleet.Script, error) {
 			Name: "Setup Experience Script for Team 1",
 		}, nil
 	}
-	if teamID == 0 {
-		return nil, nil
-	}
-	if teamID == 1 {
-		return nil, nil
-	}
-	if teamID == 2 {
-		return nil, nil
-	}
-	if teamID == 3 {
-		return nil, nil
-	}
-	if teamID == 5 {
+	if teamID == 0 || teamID == 1 || teamID == 2 || teamID == 3 || teamID == 5 {
 		return nil, nil
 	}
 	return nil, fmt.Errorf("unexpected team ID: %d", teamID)
@@ -496,19 +458,7 @@ func (MockClient) GetAppleMDMEnrollmentProfile(teamID uint) (*fleet.MDMAppleSetu
 			Name: "Apple MDM Enrollment Profile for Team 1",
 		}, nil
 	}
-	if teamID == 0 {
-		return nil, nil
-	}
-	if teamID == 1 {
-		return nil, nil
-	}
-	if teamID == 2 {
-		return nil, nil
-	}
-	if teamID == 3 {
-		return nil, nil
-	}
-	if teamID == 4 {
+	if teamID == 0 || teamID == 1 || teamID == 2 || teamID == 3 || teamID == 4 {
 		return nil, nil
 	}
 	return nil, fmt.Errorf("unexpected team ID: %d", teamID)
@@ -1123,12 +1073,7 @@ func TestGenerateLabels(t *testing.T) {
 }
 
 func verifyControlsHasMacosSetup(t *testing.T, controlsRaw map[string]interface{}) {
-	_, ok := controlsRaw["macos_setup"]
-	require.True(t, ok, "Expected macos_setup section for no-team controls with EndUserAuthentication enabled")
-	// Check that macos_setup.enable_end_user_authentication is true
-	macosSetup, ok := controlsRaw["macos_setup"].(map[string]interface{})
-	require.True(t, ok, "Expected macos_setup to be a map")
-	enableEndUserAuth, ok := macosSetup["enable_end_user_authentication"].(bool)
-	require.True(t, ok, "Expected macos_setup.enable_end_user_authentication to be a boolean")
-	require.True(t, enableEndUserAuth, "Expected macos_setup.enable_end_user_authentication to be true")
+	macosSetup, ok := controlsRaw["macos_setup"].(string)
+	require.True(t, ok, "Expected macos_setup section to be a string")
+	require.Equal(t, macosSetup, "TODO: update with your macos_setup configuration")
 }

--- a/cmd/fleetctl/fleetctl/testdata/generateGitops/appConfig.json
+++ b/cmd/fleetctl/fleetctl/testdata/generateGitops/appConfig.json
@@ -262,7 +262,6 @@
             "custom_settings": null
         },
         "macos_setup": {
-            "bootstrap_package": "some-bootstrap-package",
             "enable_end_user_authentication": true,
             "macos_setup_assistant": "",
             "enable_release_device_manually": false,

--- a/cmd/fleetctl/fleetctl/testdata/generateGitops/expectedGlobalControls.yaml
+++ b/cmd/fleetctl/fleetctl/testdata/generateGitops/expectedGlobalControls.yaml
@@ -27,7 +27,6 @@ windows_updates:
 windows_enabled_and_configured: true
 windows_migration_enabled: true
 enable_disk_encryption: true
-macos_setup: "TODO: update with your macos_setup configuration"
 macos_migration: # Available in Fleet Premium
   enable: true
   mode: voluntary

--- a/cmd/fleetctl/fleetctl/testdata/generateGitops/expectedTeamControls.yaml
+++ b/cmd/fleetctl/fleetctl/testdata/generateGitops/expectedTeamControls.yaml
@@ -3,3 +3,4 @@ macos_settings:
   - path: ../lib/some_team/profiles/team-macos-mobileconfig-profile.mobileconfig
 scripts:
 - path: ../lib/some_team/scripts/Script B.ps1
+macos_setup: 'TODO: update with your macos_setup configuration'

--- a/cmd/fleetctl/fleetctl/testdata/generateGitops/test_dir_premium/teams/team-a.yml
+++ b/cmd/fleetctl/fleetctl/testdata/generateGitops/test_dir_premium/teams/team-a.yml
@@ -27,6 +27,7 @@ controls:
   macos_settings:
     custom_settings:
     - path: ../lib/team-a/profiles/team-macos-mobileconfig-profile.mobileconfig
+  macos_setup: 'TODO: update with your macos_setup configuration'
   macos_updates:
     deadline: "2020-12-31"
     minimum_version: "95.1"

--- a/server/service/client_profiles.go
+++ b/server/service/client_profiles.go
@@ -146,3 +146,20 @@ func (c *Client) GetConfigProfilesSummary(teamID *uint) (*fleet.MDMProfilesSumma
 	}
 	return &responseBody.MDMProfilesSummary, nil
 }
+
+func (c *Client) GetAppleMDMEnrollmentProfile(teamID uint) (*fleet.MDMAppleSetupAssistant, error) {
+	verb, path := "GET", "/api/latest/fleet/mdm/enrollment_profiles/automatic"
+	var query string
+	if teamID != 0 {
+		query = fmt.Sprintf("team_id=%d", teamID)
+	}
+	var responseBody createMDMAppleSetupAssistantResponse
+	if err := c.authenticatedRequestWithQuery(nil, verb, path, &responseBody, query); err != nil {
+		if fleet.IsNotFound(err) {
+			// If the profile is not found, return nil instead of an error.
+			return nil, nil
+		}
+		return nil, err
+	}
+	return &responseBody.MDMAppleSetupAssistant, nil
+}

--- a/server/service/client_profiles.go
+++ b/server/service/client_profiles.go
@@ -148,14 +148,15 @@ func (c *Client) GetConfigProfilesSummary(teamID *uint) (*fleet.MDMProfilesSumma
 }
 
 func (c *Client) GetAppleMDMEnrollmentProfile(teamID uint) (*fleet.MDMAppleSetupAssistant, error) {
-	verb, path := "GET", "/api/latest/fleet/mdm/enrollment_profiles/automatic"
+	verb, path := "GET", "/api/latest/fleet/enrollment_profiles/automatic"
 	var query string
 	if teamID != 0 {
 		query = fmt.Sprintf("team_id=%d", teamID)
 	}
 	var responseBody createMDMAppleSetupAssistantResponse
 	if err := c.authenticatedRequestWithQuery(nil, verb, path, &responseBody, query); err != nil {
-		if fleet.IsNotFound(err) {
+		var notFoundErr notFoundErr
+		if errors.As(err, &notFoundErr) {
 			// If the profile is not found, return nil instead of an error.
 			return nil, nil
 		}

--- a/server/service/client_profiles.go
+++ b/server/service/client_profiles.go
@@ -147,6 +147,7 @@ func (c *Client) GetConfigProfilesSummary(teamID *uint) (*fleet.MDMProfilesSumma
 	return &responseBody.MDMProfilesSummary, nil
 }
 
+// Get the Apple setup assistant profile for the given team, if any.
 func (c *Client) GetAppleMDMEnrollmentProfile(teamID uint) (*fleet.MDMAppleSetupAssistant, error) {
 	verb, path := "GET", "/api/latest/fleet/enrollment_profiles/automatic"
 	var query string

--- a/server/service/client_scripts.go
+++ b/server/service/client_scripts.go
@@ -251,3 +251,22 @@ func (c *Client) GetScriptContents(scriptID uint) ([]byte, error) {
 	}
 	return nil, nil
 }
+
+// GetSetupExperienceScript retrieves the setup script for the given team, if any.
+func (c *Client) GetSetupExperienceScript(teamID uint) (*fleet.Script, error) {
+	verb, path := "GET", "/api/latest/fleet/setup_experience/script"
+	var query string
+	if teamID != 0 {
+		query = fmt.Sprintf("team_id=%d", teamID)
+	}
+	var responseBody getSetupExperienceScriptResponse
+	err := c.authenticatedRequestWithQuery(nil, verb, path, &responseBody, query)
+	if err != nil {
+		if fleet.IsNotFound(err) {
+			// If the script is not found, we return nil instead of an error.
+			return nil, nil
+		}
+		return nil, err
+	}
+	return responseBody.Script, nil
+}

--- a/server/service/client_scripts.go
+++ b/server/service/client_scripts.go
@@ -262,7 +262,8 @@ func (c *Client) GetSetupExperienceScript(teamID uint) (*fleet.Script, error) {
 	var responseBody getSetupExperienceScriptResponse
 	err := c.authenticatedRequestWithQuery(nil, verb, path, &responseBody, query)
 	if err != nil {
-		if fleet.IsNotFound(err) {
+		var notFoundErr notFoundErr
+		if errors.As(err, &notFoundErr) {
 			// If the script is not found, we return nil instead of an error.
 			return nil, nil
 		}

--- a/server/service/client_software.go
+++ b/server/service/client_software.go
@@ -31,7 +31,7 @@ func (c *Client) ListSoftwareTitles(query string) ([]fleet.SoftwareTitleListResu
 	return responseBody.SoftwareTitles, nil
 }
 
-// ListSoftwareTitles retrieves the software titles installed on hosts.
+// Get the software titles available for the setup experience.
 func (c *Client) GetSetupExperienceSoftware(teamID uint) ([]fleet.SoftwareTitleListResult, error) {
 	verb, path := "GET", "/api/latest/fleet/setup_experience/software"
 	var responseBody getSetupExperienceSoftwareResponse

--- a/server/service/client_software.go
+++ b/server/service/client_software.go
@@ -31,6 +31,18 @@ func (c *Client) ListSoftwareTitles(query string) ([]fleet.SoftwareTitleListResu
 	return responseBody.SoftwareTitles, nil
 }
 
+// ListSoftwareTitles retrieves the software titles installed on hosts.
+func (c *Client) GetSetupExperienceSoftware(teamID uint) ([]fleet.SoftwareTitleListResult, error) {
+	verb, path := "GET", "/api/latest/fleet/setup_experience/software"
+	var responseBody getSetupExperienceSoftwareResponse
+	query := fmt.Sprintf("team_id=%d", teamID)
+	err := c.authenticatedRequestWithQuery(nil, verb, path, &responseBody, query)
+	if err != nil {
+		return nil, err
+	}
+	return responseBody.SoftwareTitles, nil
+}
+
 // GetSoftwareTitleByID retrieves a software title by ID.
 //
 //nolint:gocritic // ignore captLocal


### PR DESCRIPTION
for #30502

# Details

This PR fixes an issue where `fleetctl generate-gitops` would not always add a `macos_setup` setting to a .yml file even if the team had a setup experience configured.  This was due to relying on the `MacOSSetup` config returned by app/team config APIs to have this data populated, which turned out to be an incorrect assumption.  Instead, we now utilize various APIs to check for the presence of setup software, scripts, bootstrap packages and profiles.

Note that for now, `generate-gitops` will only output a `TODO` line if setup experience is detected; https://github.com/fleetdm/fleet/issues/30210 is open to flesh this out.  In the meantime `fleetctl gitops` will fail if this TODO is inserted, so that the user must go and fix it manually.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
- [X] Added/updated automated tests
- [X] Manual QA for all new/changed functionality

# Testing

I set up MDM on a local instance and tried the following both on No Team and a regular team:

* Turned "End user authentication on", verified that `fleetctl generate-gitops` output a `macos_setup` setting for the team.  Turned it back off and verified that `macos_setup` was no longer exported by `fleetctl generate-gitops`.
* Did the same for bootstrap package.
* Did the same for install software, and additionally verified that having software available but _not_ selected did not cause `macos_setup` to be exported.  Same for teams with no software available at all.
* Did the same for setup assistant.

I also tested that changes to No Team didn't affect the output when exporting a regular team.
