### PR TITLE
Ensure a host vitals refetch is queued when installs/uninstalls are successful

### DIFF
--- a/changes/29916-refetch
+++ b/changes/29916-refetch
@@ -1,0 +1,1 @@
+* Added automatic host vitals refetch when a software install or uninstall is successful

--- a/server/service/integration_enterprise_test.go
+++ b/server/service/integration_enterprise_test.go
@@ -13196,10 +13196,6 @@ func (s *integrationEnterpriseTestSuite) TestHostSoftwareInstallResult() {
 		}`, *host.OrbitNodeKey, installUUIDs[0])),
 		http.StatusNoContent)
 
-	// Verify refetch requested is NOT set after failed install
-	var hostRespFailedInstall getHostResponse
-	s.DoJSON("GET", fmt.Sprintf("/api/latest/fleet/hosts/%d", host.ID), nil, http.StatusOK, &hostRespFailedInstall)
-	require.False(t, hostRespFailedInstall.Host.RefetchRequested, "RefetchRequested should be false after failed software install")
 	checkResults(result{
 		HostID:                host.ID,
 		InstallUUID:           installUUIDs[0],
@@ -13225,10 +13221,6 @@ func (s *integrationEnterpriseTestSuite) TestHostSoftwareInstallResult() {
 		}`, *host.OrbitNodeKey, installUUIDs[1])),
 		http.StatusNoContent)
 
-	// Verify refetch requested is NOT set for failed pre-install condition
-	var hostRespFailedPreInstall getHostResponse
-	s.DoJSON("GET", fmt.Sprintf("/api/latest/fleet/hosts/%d", host.ID), nil, http.StatusOK, &hostRespFailedPreInstall)
-	require.False(t, hostRespFailedPreInstall.Host.RefetchRequested, "RefetchRequested should be false after failed pre-install condition")
 	checkResults(result{
 		HostID:                host.ID,
 		InstallUUID:           installUUIDs[1],
@@ -13257,10 +13249,6 @@ func (s *integrationEnterpriseTestSuite) TestHostSoftwareInstallResult() {
 		}`, *host.OrbitNodeKey, installUUIDs[2])),
 		http.StatusNoContent)
 
-	// Verify refetch requested is set after successful install
-	var hostResp getHostResponse
-	s.DoJSON("GET", fmt.Sprintf("/api/latest/fleet/hosts/%d", host.ID), nil, http.StatusOK, &hostResp)
-	require.True(t, hostResp.Host.RefetchRequested, "RefetchRequested should be true after successful software install")
 	checkResults(result{
 		HostID:                  host.ID,
 		InstallUUID:             installUUIDs[2],

--- a/server/service/integration_enterprise_test.go
+++ b/server/service/integration_enterprise_test.go
@@ -12833,7 +12833,7 @@ func (s *integrationEnterpriseTestSuite) TestSoftwareInstallerHostRequests() {
 	require.Len(t, orbitResp.Notifications.PendingScriptExecutionIDs, 1)
 	require.Equal(t, uninstallExecutionID, orbitResp.Notifications.PendingScriptExecutionIDs[0])
 
-	// Verify refetch requested is set after successful uninstall
+	// Refetch should not be requested yet as the uninstall is still pending
 	s.DoJSON("GET", fmt.Sprintf("/api/latest/fleet/hosts/%d", h.ID), nil, http.StatusOK, &hostResp)
 	require.False(t, hostResp.Host.RefetchRequested, "RefetchRequested should not be true yet")
 


### PR DESCRIPTION
Fixes #29916.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.
- [x] Added/updated automated tests
- [x] Manual QA for all new/changed functionality

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Host vitals data now refreshes automatically after successful software installation or uninstallation, ensuring up-to-date status information.

* **Tests**
  * Enhanced tests to verify that host vitals are only refreshed after successful software changes, improving reliability and accuracy of the system’s behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->