### PR TITLE
Apply starter library during for fleetctl preview server

### DIFF
--- a/.github/workflows/fleetctl-preview-latest.yml
+++ b/.github/workflows/fleetctl-preview-latest.yml
@@ -78,8 +78,7 @@ jobs:
       run: |
         ./build/fleetctl preview \
           --disable-open-browser \
-          --preview-config-path ./tools/osquery/in-a-box \
-          --std-query-lib-file-path $(pwd)/docs/01-Using-Fleet/standard-query-library/standard-query-library.yml
+          --preview-config-path ./tools/osquery/in-a-box
         sleep 10
         ./build/fleetctl get hosts | tee hosts.txt
         [ $( cat hosts.txt | grep online | wc -l) -eq 8 ]

--- a/.github/workflows/fleetctl-preview-latest.yml
+++ b/.github/workflows/fleetctl-preview-latest.yml
@@ -1,7 +1,7 @@
 name: Test latest changes in fleetctl preview
 
 # Tests the `fleetctl preview` command with latest changes in fleetctl and
-# docs/01-Using-Fleet/standard-query-library/standard-query-library.yml
+# docs/01-Using-Fleet/starter-library/starter-library.yml
 
 on:
   push:
@@ -16,7 +16,7 @@ on:
       - 'server/context/**.go'
       - 'orbit/**.go'
       - 'ee/fleetctl/**.go'
-      - 'docs/01-Using-Fleet/standard-query-library/standard-query-library.yml'
+      - 'docs/01-Using-Fleet/starter-library/starter-library.yml'
       - '.github/workflows/fleetctl-preview-latest.yml'
       - 'tools/osquery/in-a-box'
   pull_request:
@@ -27,7 +27,7 @@ on:
       - 'server/context/**.go'
       - 'orbit/**.go'
       - 'ee/fleetctl/**.go'
-      - 'docs/01-Using-Fleet/standard-query-library/standard-query-library.yml'
+      - 'docs/01-Using-Fleet/starter-library/starter-library.yml'
       - '.github/workflows/fleetctl-preview-latest.yml'
       - 'tools/osquery/in-a-box'
   workflow_dispatch: # Manual

--- a/.github/workflows/fleetctl-preview-latest.yml
+++ b/.github/workflows/fleetctl-preview-latest.yml
@@ -78,6 +78,7 @@ jobs:
       run: |
         ./build/fleetctl preview \
           --disable-open-browser \
+          --starter-library-file-path $(pwd)/docs/01-Using-Fleet/standard-query-library/standard-query-library.yml \
           --preview-config-path ./tools/osquery/in-a-box
         sleep 10
         ./build/fleetctl get hosts | tee hosts.txt

--- a/.github/workflows/fleetctl-preview-latest.yml
+++ b/.github/workflows/fleetctl-preview-latest.yml
@@ -78,7 +78,7 @@ jobs:
       run: |
         ./build/fleetctl preview \
           --disable-open-browser \
-          --starter-library-file-path $(pwd)/docs/01-Using-Fleet/standard-query-library/standard-query-library.yml \
+          --starter-library-file-path $(pwd)/docs/01-Using-Fleet/starter-library/starter-library.yml \
           --preview-config-path ./tools/osquery/in-a-box
         sleep 10
         ./build/fleetctl get hosts | tee hosts.txt

--- a/cmd/fleetctl/fleetctl/preview.go
+++ b/cmd/fleetctl/fleetctl/preview.go
@@ -36,7 +36,6 @@ import (
 type dockerComposeVersion int
 
 const (
-	standardQueryLibraryUrl   = "https://raw.githubusercontent.com/fleetdm/fleet/main/docs/01-Using-Fleet/standard-query-library/standard-query-library.yml"
 	licenseKeyFlagName        = "license-key"
 	tagFlagName               = "tag"
 	previewConfigFlagName     = "preview-config"
@@ -45,7 +44,6 @@ const (
 	osquerydChannel           = "osqueryd-channel"
 	updateURL                 = "update-url"
 	updateRootKeys            = "update-roots"
-	stdQueryLibFilePath       = "std-query-lib-file-path"
 	previewConfigPathFlagName = "preview-config-path"
 	disableOpenBrowser        = "disable-open-browser"
 
@@ -142,11 +140,6 @@ Use the stop and reset subcommands to manage the server and dependencies once st
 			&cli.StringFlag{
 				Name:  updateRootKeys,
 				Usage: "Use custom update TUF root keys",
-				Value: "",
-			},
-			&cli.StringFlag{
-				Name:  stdQueryLibFilePath,
-				Usage: "Use custom standard query library yml file (used for development/testing)",
 				Value: "",
 			},
 			&cli.StringFlag{
@@ -378,7 +371,8 @@ Use the stop and reset subcommands to manage the server and dependencies once st
 				kitlog.NewLogfmtLogger(os.Stderr),
 				fleethttp.NewClient,
 				service.NewClient,
-				nil, // No mock ApplyGroup for production code
+				nil,  // No mock ApplyGroup for production code
+				true, // Skip teams on free license for preview
 			); err != nil {
 				return fmt.Errorf("failed to apply starter library: %w", err)
 			}
@@ -552,21 +546,6 @@ func downloadFromFleetRepo(
 		}
 	}
 	return nil
-}
-
-func downloadStandardQueryLibrary() ([]byte, error) {
-	resp, err := http.Get(standardQueryLibraryUrl)
-	if err != nil {
-		return nil, err
-	}
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("status: %d", resp.StatusCode)
-	}
-	buf, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, fmt.Errorf("read response body: %w", err)
-	}
-	return buf, nil
 }
 
 func waitStartup() error {

--- a/cmd/fleetctl/fleetctl/preview.go
+++ b/cmd/fleetctl/fleetctl/preview.go
@@ -44,6 +44,7 @@ const (
 	osquerydChannel           = "osqueryd-channel"
 	updateURL                 = "update-url"
 	updateRootKeys            = "update-roots"
+	starterLibraryFilePath    = "starter-library-file-path"
 	previewConfigPathFlagName = "preview-config-path"
 	disableOpenBrowser        = "disable-open-browser"
 
@@ -140,6 +141,11 @@ Use the stop and reset subcommands to manage the server and dependencies once st
 			&cli.StringFlag{
 				Name:  updateRootKeys,
 				Usage: "Use custom update TUF root keys",
+				Value: "",
+			},
+			&cli.StringFlag{
+				Name:  starterLibraryFilePath,
+				Usage: "Use custom starter library yml file (used for development/testing)",
 				Value: "",
 			},
 			&cli.StringFlag{
@@ -371,8 +377,7 @@ Use the stop and reset subcommands to manage the server and dependencies once st
 				kitlog.NewLogfmtLogger(os.Stderr),
 				fleethttp.NewClient,
 				service.NewClient,
-				nil,  // No mock ApplyGroup for production code
-				true, // Skip teams on free license for preview
+				nil, // No mock ApplyGroup for production code
 			); err != nil {
 				return fmt.Errorf("failed to apply starter library: %w", err)
 			}

--- a/cmd/fleetctl/integrationtest/preview/preview_test.go
+++ b/cmd/fleetctl/integrationtest/preview/preview_test.go
@@ -1,7 +1,6 @@
 package preview
 
 import (
-	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
@@ -19,11 +18,6 @@ func TestPreviewFailsOnInvalidLicenseKey(t *testing.T) {
 
 func TestIntegrationsPreview(t *testing.T) {
 	nettest.Run(t)
-
-	// Skip the test if FULL_INTEGRATION_TEST is not set to avoid Docker dependency
-	if os.Getenv("FULL_INTEGRATION_TEST") != "1" {
-		t.Skip("Skipping full integration test that requires Docker. Set FULL_INTEGRATION_TEST=1 to run.")
-	}
 
 	t.Setenv("FLEET_SERVER_ADDRESS", "https://localhost:8412")
 	fleetctl.TestOverridePreviewDirectory = t.TempDir()

--- a/cmd/fleetctl/integrationtest/preview/preview_test.go
+++ b/cmd/fleetctl/integrationtest/preview/preview_test.go
@@ -50,7 +50,7 @@ func TestIntegrationsPreview(t *testing.T) {
 
 	// run some sanity checks on the preview environment
 
-	// standard queries must have been loaded
+	// starter library queries must have been loaded
 	queries := fleetctl.RunAppForTest(t, []string{"get", "queries", "--config", configPath, "--json"})
 	n := strings.Count(queries, `"kind":"query"`)
 	require.Greater(t, n, 10)

--- a/cmd/fleetctl/integrationtest/preview/preview_test.go
+++ b/cmd/fleetctl/integrationtest/preview/preview_test.go
@@ -44,7 +44,7 @@ func TestIntegrationsPreview(t *testing.T) {
 	// starter library queries must have been loaded
 	queries := fleetctl.RunAppForTest(t, []string{"get", "queries", "--config", configPath, "--json"})
 	n := strings.Count(queries, `"kind":"query"`)
-	require.Greater(t, n, 10)
+	require.Greater(t, n, 0)
 
 	// app configuration must disable analytics
 	appConf := fleetctl.RunAppForTest(t, []string{"get", "config", "--include-server-config", "--config", configPath, "--yaml"})

--- a/server/service/endpoint_setup.go
+++ b/server/service/endpoint_setup.go
@@ -95,7 +95,7 @@ func makeSetupEndpoint(svc fleet.Service, logger kitlog.Logger) endpoint.Endpoin
 
 			// Apply starter library using the admin token we just created
 			if req.ServerURL != nil {
-				if err := applyStarterLibrary(
+				if err := ApplyStarterLibrary(
 					ctx,
 					*req.ServerURL,
 					session.Key,
@@ -121,11 +121,11 @@ func makeSetupEndpoint(svc fleet.Service, logger kitlog.Logger) endpoint.Endpoin
 	}
 }
 
-// applyStarterLibrary downloads the starter library from GitHub
+// ApplyStarterLibrary downloads the starter library from GitHub
 // and applies it to the Fleet server using an authenticated client.
 // TODO: Move the apply starter library logic to use the serve command as an entry point to simplify and leverage the entire fleet.Service.
 // Entry point: https://github.com/fleetdm/fleet/blob/2dfadc0971c6ba45c19dad2f5f1f4cd0f1b89b20/cmd/fleet/serve.go#L1099-L1100
-func applyStarterLibrary(
+func ApplyStarterLibrary(
 	ctx context.Context,
 	serverURL string,
 	token string,
@@ -176,12 +176,12 @@ func applyStarterLibrary(
 	}
 
 	// Find all script references in the YAML and download them
-	scriptNames := extractScriptNames(specs)
+	scriptNames := ExtractScriptNames(specs)
 	level.Debug(logger).Log("msg", "Found script references in starter library", "count", len(scriptNames))
 
 	// Download scripts and update references in specs
 	if len(scriptNames) > 0 {
-		err = downloadAndUpdateScripts(ctx, specs, scriptNames, tempDir, logger)
+		err = DownloadAndUpdateScripts(ctx, specs, scriptNames, tempDir, logger)
 		if err != nil {
 			return fmt.Errorf("failed to download and update scripts: %w", err)
 		}
@@ -231,8 +231,8 @@ func applyStarterLibrary(
 	return nil
 }
 
-// extractScriptNames extracts all script names from the specs
-func extractScriptNames(specs *spec.Group) []string {
+// ExtractScriptNames extracts all script names from the specs
+func ExtractScriptNames(specs *spec.Group) []string {
 	var scriptNames []string
 	scriptMap := make(map[string]bool) // Use a map to deduplicate script names
 
@@ -256,8 +256,8 @@ func extractScriptNames(specs *spec.Group) []string {
 	return scriptNames
 }
 
-// downloadAndUpdateScripts downloads scripts from URLs and updates the specs to reference local files
-func downloadAndUpdateScripts(ctx context.Context, specs *spec.Group, scriptNames []string, tempDir string, logger kitlog.Logger) error {
+// DownloadAndUpdateScripts downloads scripts from URLs and updates the specs to reference local files
+func DownloadAndUpdateScripts(ctx context.Context, specs *spec.Group, scriptNames []string, tempDir string, logger kitlog.Logger) error {
 	// Create a single HTTP client to be reused for all requests
 	httpClient := fleethttp.NewClient(fleethttp.WithTimeout(5 * time.Second))
 

--- a/server/service/endpoint_setup.go
+++ b/server/service/endpoint_setup.go
@@ -201,7 +201,10 @@ func ApplyStarterLibrary(
 	if skipTeamsOnFreeLicense {
 		// Check if license is free
 		appConfig, err := client.GetAppConfig()
-		if err == nil && (appConfig.License == nil || !appConfig.License.IsPremium()) {
+		if err != nil {
+			level.Debug(logger).Log("msg", "Error getting app config", "err", err)
+			// Continue even if there's an error getting the app config
+		} else if appConfig.License == nil || !appConfig.License.IsPremium() {
 			// Remove teams from specs to avoid applying them
 			level.Debug(logger).Log("msg", "Free license detected, skipping teams and team-related content in starter library")
 			specs.Teams = nil

--- a/server/service/endpoint_setup_test.go
+++ b/server/service/endpoint_setup_test.go
@@ -482,7 +482,6 @@ func TestApplyStarterLibraryWithMockClient(t *testing.T) {
 		httpClientFactory,
 		clientFactory,
 		mockApplyGroup,
-		false, // Don't skip teams on free license for this test
 	)
 
 	// Verify results
@@ -577,7 +576,6 @@ func TestApplyStarterLibraryWithMalformedYAML(t *testing.T) {
 		httpClientFactory,
 		clientFactory,
 		mockApplyGroup,
-		false, // Don't skip teams on free license for this test
 	)
 
 	// Verify results
@@ -675,7 +673,7 @@ func TestApplyStarterLibraryWithFreeLicense(t *testing.T) {
 		return nil
 	}
 
-	// Call the function under test with skipTeamsOnFreeLicense=true
+	// Call the function under test - teams will be skipped automatically for free license
 	testErr := ApplyStarterLibrary(
 		context.Background(),
 		"https://example.com",
@@ -684,7 +682,6 @@ func TestApplyStarterLibraryWithFreeLicense(t *testing.T) {
 		httpClientFactory,
 		clientFactory,
 		mockApplyGroup,
-		true, // Skip teams on free license
 	)
 
 	// Verify results

--- a/server/service/endpoint_setup_test.go
+++ b/server/service/endpoint_setup_test.go
@@ -1,12 +1,14 @@
 package service
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -15,6 +17,7 @@ import (
 
 	"github.com/fleetdm/fleet/v4/pkg/fleethttp"
 	"github.com/fleetdm/fleet/v4/pkg/spec"
+	"github.com/fleetdm/fleet/v4/server/fleet"
 	kitlog "github.com/go-kit/log"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -113,7 +116,7 @@ func TestExtractScriptNames(t *testing.T) {
 			specs := &spec.Group{Teams: teams}
 
 			// Call the function
-			scriptNames := extractScriptNames(specs)
+			scriptNames := ExtractScriptNames(specs)
 
 			// Verify the results
 			assert.Len(t, scriptNames, len(tt.expected))
@@ -188,7 +191,7 @@ func TestDownloadAndUpdateScripts(t *testing.T) {
 			}
 
 			// Call the actual production function
-			err = downloadAndUpdateScripts(context.Background(), specs, tt.scriptNames, tempDir, kitlog.NewNopLogger())
+			err = DownloadAndUpdateScripts(context.Background(), specs, tt.scriptNames, tempDir, kitlog.NewNopLogger())
 			require.NoError(t, err)
 
 			// Verify the scripts were downloaded
@@ -285,7 +288,7 @@ func TestDownloadAndUpdateScriptsWithInvalidPaths(t *testing.T) {
 			}
 
 			// Call the actual production function
-			err = downloadAndUpdateScripts(context.Background(), specs, tt.scriptNames, tempDir, kitlog.NewNopLogger())
+			err = DownloadAndUpdateScripts(context.Background(), specs, tt.scriptNames, tempDir, kitlog.NewNopLogger())
 			require.Error(t, err)
 			assert.Contains(t, err.Error(), tt.errorMsg)
 		})
@@ -408,7 +411,7 @@ func TestDownloadAndUpdateScriptsTimeout(t *testing.T) {
 			defer cancel()
 
 			// Call the actual production function
-			err = downloadAndUpdateScripts(ctx, specs, scriptNames, tempDir, kitlog.NewNopLogger())
+			err = DownloadAndUpdateScripts(ctx, specs, scriptNames, tempDir, kitlog.NewNopLogger())
 
 			if tt.expectError {
 				require.Error(t, err)
@@ -471,7 +474,7 @@ func TestApplyStarterLibraryWithMockClient(t *testing.T) {
 	}
 
 	// Call the function under test
-	testErr := applyStarterLibrary(
+	testErr := ApplyStarterLibrary(
 		context.Background(),
 		"https://example.com",
 		"test-token",
@@ -479,6 +482,7 @@ func TestApplyStarterLibraryWithMockClient(t *testing.T) {
 		httpClientFactory,
 		clientFactory,
 		mockApplyGroup,
+		false, // Don't skip teams on free license for this test
 	)
 
 	// Verify results
@@ -565,7 +569,7 @@ func TestApplyStarterLibraryWithMalformedYAML(t *testing.T) {
 	}()
 
 	// Call the function under test
-	testErr := applyStarterLibrary(
+	testErr := ApplyStarterLibrary(
 		context.Background(),
 		"https://example.com",
 		"test-token",
@@ -573,6 +577,7 @@ func TestApplyStarterLibraryWithMalformedYAML(t *testing.T) {
 		httpClientFactory,
 		clientFactory,
 		mockApplyGroup,
+		false, // Don't skip teams on free license for this test
 	)
 
 	// Verify results
@@ -584,4 +589,139 @@ func TestApplyStarterLibraryWithMalformedYAML(t *testing.T) {
 	assert.Contains(t, mockRT.calls, starterLibraryURL, "The starter library URL should have been requested")
 
 	// If we reach here, no panic occurred and the setup flow was not interrupted
+}
+
+func TestApplyStarterLibraryWithFreeLicense(t *testing.T) {
+	// Read the real production starter library YAML file
+	starterLibraryPath := "../../docs/01-Using-Fleet/starter-library/starter-library.yml"
+	starterLibraryContent, err := os.ReadFile(starterLibraryPath)
+	require.NoError(t, err, "Should be able to read starter library YAML file")
+
+	// Create mock HTTP client for downloading the starter library and scripts
+	mockRT := &testRoundTripper2{
+		calls: []string{},
+		RoundTripFunc: func(req *http.Request) (*http.Response, error) {
+			switch {
+			case req.URL.String() == starterLibraryURL:
+				// Return the real starter library content
+				return createTestResponse(200, string(starterLibraryContent)), nil
+			case strings.Contains(req.URL.String(), "uninstall-fleetd"):
+				// Return a simple script for any script URL
+				return createTestResponse(200, "#!/bin/bash\necho ok"), nil
+			default:
+				// For any other URL, return a 404
+				return createTestResponse(404, "Not found"), nil
+			}
+		},
+	}
+
+	httpClientFactory := func(opts ...fleethttp.ClientOpt) *http.Client {
+		client := fleethttp.NewClient(opts...)
+		client.Transport = mockRT
+		return client
+	}
+
+	// Create a mock client that returns a free license
+	// Create a properly structured EnrichedAppConfig
+	mockEnrichedAppConfig := &fleet.EnrichedAppConfig{}
+	// Set the License field using json marshaling/unmarshaling to bypass unexported field access
+	configJSON := []byte(`{"license":{"tier":"free"}}`)
+	if err := json.Unmarshal(configJSON, mockEnrichedAppConfig); err != nil {
+		t.Fatal("Failed to unmarshal mock config:", err)
+	}
+
+	// Create a mock client factory
+	clientFactory := func(serverURL string, insecureSkipVerify bool, rootCA, urlPrefix string, options ...ClientOption) (*Client, error) {
+		mockClient := &Client{}
+
+		// Override the baseClient with a mock implementation
+		// Create a mock HTTP client
+		mockHTTPClient := &mockHTTPClient{
+			DoFunc: func(req *http.Request) (*http.Response, error) {
+				// Mock the GetAppConfig response
+				if req.URL.Path == "/api/v1/fleet/config" && req.Method == http.MethodGet {
+					respBody, _ := json.Marshal(mockEnrichedAppConfig)
+					return &http.Response{
+						StatusCode: http.StatusOK,
+						Body:       io.NopCloser(bytes.NewBuffer(respBody)),
+						Header:     make(http.Header),
+					}, nil
+				}
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(strings.NewReader("{}")),
+					Header:     make(http.Header),
+				}, nil
+			},
+		}
+
+		// Set up the baseClient with the mock HTTP client and a valid baseURL
+		baseURL, _ := url.Parse(serverURL)
+		mockClient.baseClient = &baseClient{
+			http:    mockHTTPClient,
+			baseURL: baseURL,
+		}
+
+		return mockClient, nil
+	}
+
+	// Track if ApplyGroup was called and capture the specs
+	applyGroupCalled := false
+	var capturedSpecs *spec.Group
+	// Create a mock ApplyGroup function
+	mockApplyGroup := func(ctx context.Context, specs *spec.Group) error {
+		applyGroupCalled = true
+		capturedSpecs = specs
+		return nil
+	}
+
+	// Call the function under test with skipTeamsOnFreeLicense=true
+	testErr := ApplyStarterLibrary(
+		context.Background(),
+		"https://example.com",
+		"test-token",
+		kitlog.NewNopLogger(),
+		httpClientFactory,
+		clientFactory,
+		mockApplyGroup,
+		true, // Skip teams on free license
+	)
+
+	// Verify results
+	require.NoError(t, testErr)
+	assert.True(t, applyGroupCalled, "ApplyGroup should have been called")
+
+	// Verify that the specs were correctly parsed
+	require.NotNil(t, capturedSpecs, "Specs should not be nil")
+
+	// Verify that teams were removed
+	require.Empty(t, capturedSpecs.Teams, "Teams should be empty for free license")
+
+	// Verify that policies referencing teams were filtered out
+	if capturedSpecs.Policies != nil {
+		for _, policy := range capturedSpecs.Policies {
+			assert.Empty(t, policy.Team, "Policies should not reference teams for free license")
+		}
+	}
+
+	// Verify that scripts were removed from AppConfig
+	if capturedSpecs.AppConfig != nil {
+		appConfigMap, ok := capturedSpecs.AppConfig.(map[string]interface{})
+		if ok {
+			_, hasScripts := appConfigMap["scripts"]
+			assert.False(t, hasScripts, "AppConfig should not contain scripts for free license")
+		}
+	}
+
+	// Verify that the starter library URL was requested
+	assert.Contains(t, mockRT.calls, starterLibraryURL, "The starter library URL should have been requested")
+}
+
+// mockHTTPClient is a mock implementation of the http.Client
+type mockHTTPClient struct {
+	DoFunc func(req *http.Request) (*http.Response, error)
+}
+
+func (m *mockHTTPClient) Do(req *http.Request) (*http.Response, error) {
+	return m.DoFunc(req)
 }


### PR DESCRIPTION
For #29741

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved handling of starter library queries, with license-aware filtering to skip team-related content for free licenses.
  * Enhanced script management to support scripts referenced in configuration sections.

* **Bug Fixes**
  * Ensured that only appropriate content is applied based on license type, preventing errors for free license users.

* **Tests**
  * Added comprehensive tests to verify correct behavior when applying the starter library with a free license.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->