### PR TITLE
Skip software_id=0 and log, but otherwise complete counts, when counting host software on a host_software table including rows with software ID zero

### DIFF
--- a/changes/30522-zero-software-id-counts
+++ b/changes/30522-zero-software-id-counts
@@ -1,0 +1,1 @@
+* Fixed a case where host software counts wouldn't be updated if the host_software database table included one or more rows with a zero software_id

--- a/cmd/fleet/vuln_process.go
+++ b/cmd/fleet/vuln_process.go
@@ -52,7 +52,7 @@ by an exit code of zero.`,
 				fleet.WriteExpiredLicenseBanner(os.Stderr)
 			}
 
-			ds, err := mysql.New(cfg.Mysql, clock.C)
+			ds, err := mysql.New(cfg.Mysql, clock.C, mysql.Logger(logger))
 			if err != nil {
 				return err
 			}

--- a/server/datastore/mysql/software.go
+++ b/server/datastore/mysql/software.go
@@ -1865,6 +1865,10 @@ func (ds *Datastore) SyncHostsSoftware(ctx context.Context, updatedAt time.Time)
 	if err != nil {
 		return ctxerr.Wrap(ctx, err, "get min/max software_id")
 	}
+	if minMax.Min == 0 {
+		minMax.Min = 1
+		level.Warn(ds.logger).Log("msg", "software_id 0 found in host_software table; performing counts without those entries")
+	}
 
 	for minSoftwareID, maxSoftwareID := minMax.Min-1, minMax.Min-1+countHostSoftwareBatchSize; minSoftwareID < minMax.Max; minSoftwareID, maxSoftwareID = maxSoftwareID, maxSoftwareID+countHostSoftwareBatchSize {
 


### PR DESCRIPTION
Fixes #30522.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.
- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [x] Added/updated automated tests
- [ ] Manual QA for all new/changed functionality

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue where host software counts were not updated if the database contained rows with a zero software ID.

* **Tests**
  * Enhanced tests to verify correct handling of host software records with a zero software ID.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->