### PR TITLE
Website: add missing redirect

### DIFF
--- a/website/config/routes.js
+++ b/website/config/routes.js
@@ -935,6 +935,7 @@ module.exports.routes = {
   'GET /learn-more-about/request-hydrant-certificate': '/docs/rest-api#request-certificate',
   'GET /learn-more-about/yaml-software-setup-experience': '/docs/configuration/yaml-files#self-service-labels-categories-and-setup-experience',
   'GET /learn-more-about/microsoft-compliance-partner': '/guides/entra-conditional-access-integration',
+  'GET /learn-more-about/conditional-access': '/guides/entra-conditional-access-integration',
 
   // Sitemap
   // =============================================================================================================


### PR DESCRIPTION
We were still missing `/learn-more-about/conditional-access`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new shortcut URL (/learn-more-about/conditional-access) that directs users to the Entra Conditional Access Integration guide.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->