### PR TITLE
Add retry mechanism to SavePolicy to reduce/eliminate deadlock errors…

### DIFF
--- a/changes/29400-fix-policy-deadlock
+++ b/changes/29400-fix-policy-deadlock
@@ -1,0 +1,1 @@
+* Added retries in `PATCH` policies API requests to fix deadlock errors in "Manage automations" page.

--- a/server/datastore/mysql/policies.go
+++ b/server/datastore/mysql/policies.go
@@ -298,7 +298,7 @@ func (ds *Datastore) PolicyLite(ctx context.Context, id uint) (*fleet.PolicyLite
 //
 // Currently, SavePolicy does not allow updating the team of an existing policy.
 func (ds *Datastore) SavePolicy(ctx context.Context, p *fleet.Policy, shouldRemoveAllPolicyMemberships bool, removePolicyStats bool) error {
-	if err := ds.withTx(ctx, func(tx sqlx.ExtContext) error {
+	if err := ds.withRetryTxx(ctx, func(tx sqlx.ExtContext) error {
 		return savePolicy(ctx, tx, ds.logger, p, shouldRemoveAllPolicyMemberships, removePolicyStats)
 	}); err != nil {
 		return ctxerr.Wrap(ctx, err, "updating policy")


### PR DESCRIPTION
For #29400.

Added test fails without the change to retry upon deadlocks.

How to reproduce in UI:
1. Create 10 policies on a team.
2. Refetch host to have results for the policies.
3. Add (could be the same) or update the installer associated to the 10 policies in "Manage automations" > "Software".
4. Hit `Save`.

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.
- [X] Added/updated automated tests
- [X] Manual QA for all new/changed functionality

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the reliability of policy updates on the "Manage automations" page by automatically retrying requests in case of deadlock errors.

* **Tests**
  * Added a test to verify that concurrent policy updates handle deadlocks correctly and complete without errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->