### PR TITLE
Update FMA contributor docs

### DIFF
--- a/.github/ISSUE_TEMPLATE/fma-request.md
+++ b/.github/ISSUE_TEMPLATE/fma-request.md
@@ -2,7 +2,7 @@
 name: 📦 New Fleet-maintained app
 about: Request to add an app to the Fleet-maintained app catalog
 title: ''
-labels: ':product,#g-software,fma'
+labels: ':release,#g-software,fma'
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/fma-request.md
+++ b/.github/ISSUE_TEMPLATE/fma-request.md
@@ -14,12 +14,17 @@ assignees: 'marko-lisica'
 
 ---
 
-### Validation / QA
+### Validation
 
-- [ ] Outputs generated
+- [ ] The following outputs are generated
+        - `/outputs/<app-name>/darwin.json` created
+        - `/outputs/apps.json` updated
 - [ ] Manifest name matches osquery `app.name` (macOS) or `programs.name` (Windows)
 - [ ] Manifest version scheme matches osquery `app.short_bundle_version` (macOS) or `programs.version` (Windows) version scheme
 - [ ] Manifest `unique_identifier` matches osquery `app.bundle_identifier` (macOS only)
+
+### QA
+
 - [ ] App adds successfully to team's library
 - [ ] App installs successfully on host
 - [ ] App opens successfully on host

--- a/.github/ISSUE_TEMPLATE/fma-request.md
+++ b/.github/ISSUE_TEMPLATE/fma-request.md
@@ -1,0 +1,32 @@
+---
+name: 📦 New Fleet-maintained app
+about: Request to add an app to the Fleet-maintained app catalog
+title: ''
+labels: ':product,#g-software,fma'
+assignees: ''
+
+---
+
+### Requestor
+
+- Application name: TODO
+- Application platform: TODO (macOS/Windows)
+
+---
+
+### Validation / QA
+
+- [ ] Outputs generated
+- [ ] Manifest name matches osquery `app.name`
+- [ ] Manifest version scheme matches osquery `app.short_bundle_version` version scheme
+- [ ] Manifest `unique_identifier` matches osquery `app.bundle_identifier`
+- [ ] App adds successfully to team's library
+- [ ] App installs successfully on host
+- [ ] App opens succuessfully on host
+- [ ] App uninstalls successfully on host
+
+### Icon
+
+- [ ] Icon added to Figma
+- [ ] Icon added to Fleet
+- [ ] Correct icon appears in the app catalog

--- a/.github/ISSUE_TEMPLATE/fma-request.md
+++ b/.github/ISSUE_TEMPLATE/fma-request.md
@@ -22,7 +22,7 @@ assignees: 'marko-lisica'
 - [ ] Manifest `unique_identifier` matches osquery `app.bundle_identifier` (macOS only)
 - [ ] App adds successfully to team's library
 - [ ] App installs successfully on host
-- [ ] App opens succuessfully on host
+- [ ] App opens successfully on host
 - [ ] App uninstalls successfully on host
 
 ### Icon

--- a/.github/ISSUE_TEMPLATE/fma-request.md
+++ b/.github/ISSUE_TEMPLATE/fma-request.md
@@ -1,9 +1,9 @@
 ---
 name: 📦 New Fleet-maintained app
 about: Request to add an app to the Fleet-maintained app catalog
-title: ''
+title: 'New FMA: <App Name>'
 labels: ':release,#g-software,fma'
-assignees: ''
+assignees: 'marko-lisica'
 
 ---
 
@@ -17,9 +17,9 @@ assignees: ''
 ### Validation / QA
 
 - [ ] Outputs generated
-- [ ] Manifest name matches osquery `app.name`
-- [ ] Manifest version scheme matches osquery `app.short_bundle_version` version scheme
-- [ ] Manifest `unique_identifier` matches osquery `app.bundle_identifier`
+- [ ] Manifest name matches osquery `app.name` (macOS) or `programs.name` (Windows)
+- [ ] Manifest version scheme matches osquery `app.short_bundle_version` (macOS) or `programs.version` (Windows) version scheme
+- [ ] Manifest `unique_identifier` matches osquery `app.bundle_identifier` (macOS only)
 - [ ] App adds successfully to team's library
 - [ ] App installs successfully on host
 - [ ] App opens succuessfully on host

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -135,10 +135,5 @@ go.mod @fleetdm/go
 # 🚀 GitHub workflows
 ##############################################################################################
 /.github/workflows/ @lukeheath @georgekarrv @sharon-fdm @mostlikelee
-
-##############################################################################################
-# 🌐 Fleet-maintained apps
-##############################################################################################
-/ee/maintained-apps/outputs/apps.json @eashaw
 # ℹ️ But wait, there's more!
 # See the comments up top to learn where else DRIs and maintainers are configured.

--- a/ee/maintained-apps/README.md
+++ b/ee/maintained-apps/README.md
@@ -108,8 +108,6 @@ These are the default categories assigned to the installer in self-service if no
 - `Developer Tools`
 - `Productivity`
 
-These are the default categories assigned to the installer in self-service if no categories are specified when it is added to a team's library.  Categories can contain any of these values:
-
 ### Validating new additions to the FMA catalog
 
 1. When a pull request (PR) is opened containing changes to `ee/maintained-apps/inputs/`, the [#g-software Product Designer (PD)](https://fleetdm.com/handbook/company/product-groups#software-group) is automatically added as reviewer and is responsible for approving the PR if the FMA name is user-friendly.

--- a/ee/maintained-apps/README.md
+++ b/ee/maintained-apps/README.md
@@ -111,7 +111,7 @@ These are the default categories assigned to the installer in [self-service](htt
 
 8. @eashaw is notified in the issue to add the icon to the website [fleetdm.com/app-library](https://fleetdm.com/app-library).
 
-#### Testing FMA catalog additions (no icon)
+#### Testing additions to Fleet-maintained apps (no icon)
 
 Use the `FLEET_DEV_MAINTAINED_APPS_BASE_URL` environment variable with the following value:
 
@@ -137,7 +137,7 @@ If testing fails:
 
 - Remove issue from the `g-software` release board, and add issue to the `Drafting` board. Remove the `:release` tag and add the `:product` tag.
 
-## Updating existing apps in the FMA catalog
+## Updating existing Fleet-maintained apps
 
 Fleet-maintained apps need to be updated as frequently as possible while maintaining reliability.  This is currently a balancing act as both scenarios below result in customer workflow blocking bugs:
 
@@ -161,7 +161,7 @@ If an app does not pass test criteria:
 - [Freeze the app](#freezing-an-existing-app)
 - File a bug for tracking
 
-## Freezing an existing app
+## Freezing an existing Fleet-maintained app
 
 If any app fails validation:
 

--- a/ee/maintained-apps/README.md
+++ b/ee/maintained-apps/README.md
@@ -39,7 +39,7 @@ as part of the fix PR.
 5. Run the following command to generate output data:
 
     ```bash
-   go run cmd/maintained-apps/main.go -slug="box-drive/darwin" -debug
+   go run cmd/maintained-apps/main.go --slug="box-drive/darwin" --debug
    ```
 
 6. Open a PR to the `fleet` repository with the above changes

--- a/ee/maintained-apps/README.md
+++ b/ee/maintained-apps/README.md
@@ -3,7 +3,7 @@
 ## Adding a new app (macOS)
 
 1. Create a new issue using the `New Fleet-maintained app` issue template
-2. Find the app's metadata in it's [Homebrew formulae](https://formulae.brew.sh/)
+2. Find the app's metadata in its [Homebrew formulae](https://formulae.brew.sh/)
 3. Create a new mainfiest file called `$YOUR_APP_NAME.json` in the `inputs/homebrew/` directory. For
    example, if you wanted to add Box Drive, create the file `inputs/homebrew/box-drive.json`.
 4. Fill out the file according to the [input schema below](#input-file-schema). For our example Box Drive app, it would look like this:

--- a/ee/maintained-apps/README.md
+++ b/ee/maintained-apps/README.md
@@ -14,15 +14,7 @@
       "slug": "box-drive/darwin",
       "unique_identifier": "com.box.desktop",
       "token": "box-drive",
-      "installer_format": "pkg",
-      "pre_uninstall_scripts": [
-         "(cd /Users/$LOGGED_IN_USER; sudo -u $LOGGED_IN_USER fileproviderctl domain remove -A com.box.desktop.boxfileprovider)",
-         "(cd /Users/$LOGGED_IN_USER; sudo -u $LOGGED_IN_USER /Applications/Box.app/Contents/MacOS/fpe/streem --remove-fpe-domain-and-archive-unsynced-content Box)",
-         "(cd /Users/$LOGGED_IN_USER; sudo -u $LOGGED_IN_USER /Applications/Box.app/Contents/MacOS/fpe/streem --remove-fpe-domain-and-preserve-unsynced-content Box)",
-         "(cd /Users/$LOGGED_IN_USER; defaults delete com.box.desktop)",
-         "echo \"${LOGGED_IN_USER} ALL = (root) NOPASSWD: /Library/Application\\ Support/Box/uninstall_box_drive_r\" >> /etc/sudoers.d/box_uninstall"
-      ],
-      "post_uninstall_scripts": ["rm /etc/sudoers.d/box_uninstall"]
+      "installer_format": "pkg"
    }
    ```
 
@@ -78,11 +70,11 @@ Use `darwin` as the platform part.  For example, use a `slug` of `box-drive/darw
 
 #### `pre_uninstall_scripts` (optional)
 
-These are command lines that will be run _before_ the generated uninstall script is executed.
+These are command lines that will be run _before_ the generated uninstall script is executed, e.g. for [Box](inputs/homebrew/box-drive.json).
 
 #### `post_uninstall_scripts` (optional)
 
-These are command lines that will be run _after_ the generated uninstall script is executed.
+These are command lines that will be run _after_ the generated uninstall script is executed, e.g. for [Box](inputs/homebrew/box-drive.json).
 
 #### `default_categories` (required)
 
@@ -119,7 +111,7 @@ These are the default categories assigned to the installer in [self-service](htt
 
 5. Product designer is notified in the issue to add this icon to Fleet's [design system in Figma](https://www.figma.com/design/8oXlYXpgCV1Sn4ek7OworP/%F0%9F%A7%A9-Design-system?node-id=264-2671) and publish the icon as a part of the Software icon Figma component.
 
-6. The validator is responsible for adding the icon to Fleet
+6. The validator is responsible for adding the icon to Fleet (e.g. the TypeScript components of [#29175](https://github.com/fleetdm/fleet/pull/29175/files))
 
 7. QA ensures the icon is added to Fleet
 

--- a/ee/maintained-apps/README.md
+++ b/ee/maintained-apps/README.md
@@ -31,7 +31,7 @@
    1. Review the PR and test the app.  Contributors should be aware of the validation requirements below.
    2. If validation requirements cannot be met in this PR, the PR will be closed and the associated issue will be prioritized in the g-software group backlog.
 
-8. If the app passes testing, it is approved and merged.  The app should appear shortly in the Fleet-maintained apps section when adding new software to Fleet.  The app icon will not appear in Fleet until a following release.  App icon progress is tracked in the issue.  An FMA addition is not considered "Done" until the icon is added in a Fleet release. This behavior will be [improved](https://github.com/fleetdm/fleet/issues/29177) in a future release.
+8. If the app passes testing, it is approved and merged. The app should appear shortly in the Fleet-maintained apps section when adding new software to Fleet. The app icon will not appear in Fleet until the following release. App icon progress is tracked in the issue. An addition to Fleet-maintained apps is not considered "Done" until the icon is added in a Fleet release. This behavior will be [improved](https://github.com/fleetdm/fleet/issues/29177) in a future release.
 
 ### Input file schema
 

--- a/ee/maintained-apps/README.md
+++ b/ee/maintained-apps/README.md
@@ -141,7 +141,7 @@ If the tests pass:
 
 If testing fails:
 
-- Remove issue from the `g-software` board, and add issue to the `Drafting` board
+- Remove issue from the `g-software` release board, and add issue to the `Drafting` board. Remove the `:release` tag and add the `:product` tag.
 
 ## Updating existing apps in the FMA catalog
 

--- a/ee/maintained-apps/README.md
+++ b/ee/maintained-apps/README.md
@@ -19,7 +19,7 @@
    }
    ```
 
-5. Run the following command from the root of the fleet repo to generate the app's output data:
+5. Run the following command from the root of the Fleet repo to generate the app's output data:
 
     ```bash
    go run cmd/maintained-apps/main.go --slug="<slug-name>" --debug

--- a/ee/maintained-apps/README.md
+++ b/ee/maintained-apps/README.md
@@ -86,7 +86,7 @@ These are the default categories assigned to the installer in [self-service](htt
 - `Developer Tools`
 - `Productivity`
 
-### Validating new additions to the FMA catalog
+### Validating new additions to the Fleet-maintained apps
 
 1. When a pull request (PR) is opened containing changes to `ee/maintained-apps/inputs/`, the [#g-software Product Designer (PD) and Engineering Manager (EM)](https://fleetdm.com/handbook/company/product-groups#software-group) are automatically added as reviewers.
    1. The PD is responsible for approving the name and default category

--- a/ee/maintained-apps/README.md
+++ b/ee/maintained-apps/README.md
@@ -2,7 +2,7 @@
 
 ## Adding a new app (macOS)
 
-1. Create a new issue using the `New Fleet-maintained app` issue template
+1. Create a new issue using the [New Fleet-maintained app](https://github.com/fleetdm/fleet/issues/new?template=fma-request.md) issue template
 2. Find the app's metadata in its [Homebrew formulae](https://formulae.brew.sh/)
 3. Create a new mainfiest file called `$YOUR_APP_NAME.json` in the `inputs/homebrew/` directory. For
    example, if you wanted to add Box Drive, create the file `inputs/homebrew/box-drive.json`.

--- a/ee/maintained-apps/README.md
+++ b/ee/maintained-apps/README.md
@@ -14,7 +14,8 @@
       "slug": "box-drive/darwin",
       "unique_identifier": "com.box.desktop",
       "token": "box-drive",
-      "installer_format": "pkg"
+      "installer_format": "pkg",
+      "default_categories": ["Productivity"]
    }
    ```
 
@@ -91,23 +92,16 @@ These are the default categories assigned to the installer in [self-service](htt
    1. The PD is responsible for approving the name and default category
    2. The EM is repsonsible for validating or assigning a validator
 
-2. Ensure an associate issue exists for the PR.  If not create one using the `Add Fleet-maintained app` issue template, move the issue to the `g-software` project and set the status to `In Review`.  Ensure the PR is linked to the issue.
+2. Ensure an associated issue exists for the PR.  If not create one using the `Add Fleet-maintained app` issue template, move the issue to the `g-software` project and set the status to `In Review`.  Ensure the PR is linked to the issue.
 
 3. Validate the PR:
 
    1. Find the app in [Homebrew's GitHub casks](https://github.com/Homebrew/homebrew-cask/tree/main/Casks) and download it locally using `cask.url`.
-
    2. Install it on a host and run a live query on the host: `SELECT * FROM apps WHERE name LIKE '%App Name%';`
-   3. Validate:
+   3. Validate and check off items in the `Validation` section of the issue.
 
-      - `name` in the inputs manifest matches `app.name`
-      - `unique_identifier` in the inputs manifest matches `app.bundle_identifier`
-      - The version scheme in the homebrew recipe matches `app.bundle_short_version`
-      - Ensure associated outputs were generated in the PR
-        - `/outputs/<app-name>/darwin.json` created
-        - `/outputs/apps.json` updated
 
-4. If the PR passes validation set the issue status to `Awaiting QA`.  The validator will perform the test criteria.  If tests fail, add feedback in the PR comments.  The test failure can be addressed in the PR or closed.  If tests pass, the PR is approved and merged.
+4. If the PR passes validation, set the issue status to `Awaiting QA`.  The validator will also perform the test criteria and check off QA tasks in the issue.  If tests fail, add feedback in the PR comments.  If the test failure(s) cannot be addressed by the contributor, close the PR and move the issue to the Drafting board for prioritization.  If tests pass, the PR is approved and merged.
 
 5. Product designer is notified in the issue to add this icon to Fleet's [design system in Figma](https://www.figma.com/design/8oXlYXpgCV1Sn4ek7OworP/%F0%9F%A7%A9-Design-system?node-id=264-2671) and publish the icon as a part of the Software icon Figma component.
 

--- a/ee/maintained-apps/README.md
+++ b/ee/maintained-apps/README.md
@@ -32,7 +32,7 @@
    go run cmd/maintained-apps/main.go --slug="<slug-name>" --debug
    ```
 
-6. Open a PR to the `fleet` repository with the above changes.  Connect it to the issue by adding `For #ISSUE_NUMBER` in the description.
+6. Open a PR to the `fleet` repository with the above changes.  Connect it to the issue by adding `Fixes #ISSUE_NUMBER` in the description.
 
 7. The [#g-software product group](https://fleetdm.com/handbook/company/product-groups#software-group) will:
    1. Review the PR and test the app.  Contributors should be aware of the validation requirements below.
@@ -147,7 +147,7 @@ If the tests pass:
 - Move issue to `Ready` (icon addition still needed)
 - Approve and merge PR
 
-If the test fail:
+If testing fails:
 
 - Remove issue from the `g-software` board, and add issue to the `Drafting` board
 

--- a/ee/maintained-apps/README.md
+++ b/ee/maintained-apps/README.md
@@ -101,7 +101,7 @@ These are command lines that will be run _after_ the generated uninstall script 
 
 #### `default_categories` (required)
 
-These are the default categories assigned to the installer in self-service if no categories are specified when it is added to a team's library.  Categories can contain any of these values:
+These are the default categories assigned to the installer in [self-service](https://fleetdm.com/guides/software-self-service) if no categories are specified when it is added to a team's library.  Categories can contain any of these values:
 
 - `Browsers`
 - `Communication`

--- a/ee/maintained-apps/README.md
+++ b/ee/maintained-apps/README.md
@@ -101,7 +101,7 @@ These are command lines that will be run _after_ the generated uninstall script 
 
 #### `default_categories` (required)
 
-These are the default categories assigned to the installer in [self-service](https://fleetdm.com/guides/software-self-service) if no categories are specified when it is added to a team's library.  Categories can contain any of these values:
+These are the default categories assigned to the installer in [self-service](https://fleetdm.com/guides/software-self-service) if no categories are specified when it is added to a team's library.  Categories must be one or more of these values:
 
 - `Browsers`
 - `Communication`

--- a/ee/maintained-apps/README.md
+++ b/ee/maintained-apps/README.md
@@ -19,7 +19,7 @@
    }
    ```
 
-5. Run the following command to generate the app's output data:
+5. Run the following command from the root of the fleet repo to generate the app's output data:
 
     ```bash
    go run cmd/maintained-apps/main.go --slug="<slug-name>" --debug

--- a/website/config/custom.js
+++ b/website/config/custom.js
@@ -189,7 +189,7 @@ module.exports.custom = {
     '.github/ISSUE_TEMPLATE': 'sampfluger88',
 
     // 💝 Fleet-maintained apps
-    'ee/maintained-apps/inputs': 'rachelelysia',
+    'ee/maintained-apps/inputs': 'mostlikelee',
   },
 
   // FUTURE: Support DRIs for confidential and other repos (except see other note above about a consolidated way to do it, to reduce these 4-6 config keys into one)


### PR DESCRIPTION
Updating FMA process for adding new apps by internal and external contributors.  Goals:
- A fast-track experience for contributors if the app does not have complications (don't need to wait for issue prioritization)
- As few handoffs as possible