### PR TITLE
disable deletion of EULA from UI when gitops mode enabled

### DIFF
--- a/frontend/components/GitOpsModeTooltipWrapper/GitOpsModeTooltipWrapper.tests.tsx
+++ b/frontend/components/GitOpsModeTooltipWrapper/GitOpsModeTooltipWrapper.tests.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 
-import { noop } from "lodash";
 import { screen } from "@testing-library/react";
 import { createCustomRenderer } from "test/test-utils";
 

--- a/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/components/EulaSection/components/EulaListItem/EulaListItem.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/components/EulaSection/components/EulaListItem/EulaListItem.tsx
@@ -7,6 +7,7 @@ import { IEulaMetadataResponse } from "services/entities/mdm";
 import Icon from "components/Icon";
 import Button from "components/buttons/Button";
 import Graphic from "components/Graphic";
+import GitOpsModeTooltipWrapper from "components/GitOpsModeTooltipWrapper";
 
 const baseClass = "eula-list-item";
 
@@ -51,13 +52,18 @@ const EulaListItem = ({ eulaData, onDelete }: IEulaListItemProps) => {
             color="ui-fleet-black-75"
           />
         </Button>
-        <Button
-          className={`${baseClass}__list-item-button`}
-          variant="text-icon"
-          onClick={() => onDelete()}
-        >
-          <Icon name="trash" color="ui-fleet-black-75" />
-        </Button>
+        <GitOpsModeTooltipWrapper
+          renderChildren={(disableChildren) => (
+            <Button
+              className={`${baseClass}__list-item-button`}
+              variant="text-icon"
+              onClick={() => onDelete()}
+              disabled={disableChildren}
+            >
+              <Icon name="trash" color="ui-fleet-black-75" />
+            </Button>
+          )}
+        />
       </div>
     </div>
   );


### PR DESCRIPTION
relates to [#28143](https://github.com/fleetdm/fleet/issues/28143)

quick fix to not allow deleting EULA when gitops mode is enabled.

- [x] Manual QA for all new/changed functionality


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The delete button in the EULA list is now conditionally disabled based on GitOps mode, with an explanatory tooltip.

* **Chores**
  * Removed an unused import from a test file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->