### PR TITLE
Generate SHA from file if FMA sha is no_check

### DIFF
--- a/changes/30325-gitops-fma-sha
+++ b/changes/30325-gitops-fma-sha
@@ -1,1 +1,1 @@
-* Use SHA256 of installer file if installer SHA is "no_check" during software batch upload
+* Fixed a bug where Fleet-maintained app updates via GitOps wouldn't pull the latest version of Google Chrome on each run, and would display an invalid SHA256 hash in the UI and API

--- a/changes/30325-gitops-fma-sha
+++ b/changes/30325-gitops-fma-sha
@@ -1,0 +1,1 @@
+* Use SHA256 of installer file if installer SHA is "no_check" during software batch upload

--- a/ee/server/service/maintained_apps.go
+++ b/ee/server/service/maintained_apps.go
@@ -82,7 +82,10 @@ func (svc *Service) AddFleetMaintainedApp(
 	}
 	defer installerTFR.Close()
 
-	gotHash := maintained_apps.SHA256FromInstallerFile(installerTFR)
+	gotHash, err := maintained_apps.SHA256FromInstallerFile(installerTFR)
+	if err != nil {
+		return 0, ctxerr.Wrap(ctx, err, "calculating SHA256 hash")
+	}
 
 	// Validate the bytes we got are what we expected, if a valid SHA is supplied
 	if app.SHA256 != noCheckHash {
@@ -93,9 +96,6 @@ func (svc *Service) AddFleetMaintainedApp(
 		app.SHA256 = gotHash
 	}
 
-	if err := installerTFR.Rewind(); err != nil {
-		return 0, ctxerr.Wrap(ctx, err, "rewind installer reader")
-	}
 	extension := strings.TrimLeft(filepath.Ext(filename), ".")
 
 	installScript = file.Dos2UnixNewlines(installScript)

--- a/ee/server/service/maintained_apps.go
+++ b/ee/server/service/maintained_apps.go
@@ -2,10 +2,7 @@ package service
 
 import (
 	"context"
-	"crypto/sha256"
-	"encoding/hex"
 	"fmt"
-	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -85,9 +82,7 @@ func (svc *Service) AddFleetMaintainedApp(
 	}
 	defer installerTFR.Close()
 
-	h := sha256.New()
-	_, _ = io.Copy(h, installerTFR) // writes to a Hash can never fail
-	gotHash := hex.EncodeToString(h.Sum(nil))
+	gotHash := maintained_apps.SHA256FromInstallerFile(installerTFR)
 
 	// Validate the bytes we got are what we expected, if a valid SHA is supplied
 	if app.SHA256 != noCheckHash {

--- a/ee/server/service/software_installers.go
+++ b/ee/server/service/software_installers.go
@@ -1678,6 +1678,9 @@ func (svc *Service) softwareInstallerPayloadFromSlug(ctx context.Context, payloa
 	}
 
 	payload.URL = app.InstallerURL
+	if app.SHA256 != noCheckHash {
+		payload.SHA256 = app.SHA256
+	}
 	payload.InstallScript = app.InstallScript
 	payload.UninstallScript = app.UninstallScript
 	payload.FleetMaintained = true

--- a/ee/server/service/software_installers.go
+++ b/ee/server/service/software_installers.go
@@ -1950,6 +1950,16 @@ func (svc *Service) softwareBatchUpload(
 					}
 					installer.Filename = path.Base(parsedURL.Path)
 				}
+				// noCheckHash is used by homebrew to signal that a hash shouldn't be checked
+				// This comes from the manifest and is a special case for maintained apps
+				// we need to generate the SHA256 from the installer file
+				if p.MaintainedApp.SHA256 == noCheckHash {
+					// generate the SHA256 from the installer file
+					if installer.InstallerFile == nil {
+						return fmt.Errorf("maintained app %s requires hash to be generated but no installer file found", p.MaintainedApp.UniqueIdentifier)
+					}
+					p.MaintainedApp.SHA256 = maintained_apps.SHA256FromInstallerFile(installer.InstallerFile)
+				}
 				extension := strings.TrimLeft(filepath.Ext(installer.Filename), ".")
 				installer.AutomaticInstallQuery = p.MaintainedApp.AutomaticInstallQuery
 				installer.Title = appName

--- a/ee/server/service/software_installers.go
+++ b/ee/server/service/software_installers.go
@@ -1958,7 +1958,10 @@ func (svc *Service) softwareBatchUpload(
 					if installer.InstallerFile == nil {
 						return fmt.Errorf("maintained app %s requires hash to be generated but no installer file found", p.MaintainedApp.UniqueIdentifier)
 					}
-					p.MaintainedApp.SHA256 = maintained_apps.SHA256FromInstallerFile(installer.InstallerFile)
+					p.MaintainedApp.SHA256, err = maintained_apps.SHA256FromInstallerFile(installer.InstallerFile)
+					if err != nil {
+						return fmt.Errorf("maintained app %s error generating hash: %w", p.MaintainedApp.UniqueIdentifier, err)
+					}
 				}
 				extension := strings.TrimLeft(filepath.Ext(installer.Filename), ".")
 				installer.AutomaticInstallQuery = p.MaintainedApp.AutomaticInstallQuery

--- a/ee/server/service/software_installers.go
+++ b/ee/server/service/software_installers.go
@@ -1678,7 +1678,6 @@ func (svc *Service) softwareInstallerPayloadFromSlug(ctx context.Context, payloa
 	}
 
 	payload.URL = app.InstallerURL
-	payload.SHA256 = app.SHA256
 	payload.InstallScript = app.InstallScript
 	payload.UninstallScript = app.UninstallScript
 	payload.FleetMaintained = true

--- a/ee/server/service/software_installers_test.go
+++ b/ee/server/service/software_installers_test.go
@@ -219,6 +219,25 @@ func TestSoftwareInstallerPayloadFromSlug(t *testing.T) {
 	assert.NotEmpty(t, payload.UninstallScript)
 	assert.True(t, payload.FleetMaintained)
 
+	// when SHA256 is no_check
+	ds.GetMaintainedAppBySlugFunc = func(ctx context.Context, slug string, teamID *uint) (*fleet.MaintainedApp, error) {
+		return &fleet.MaintainedApp{
+			ID:               1,
+			Name:             "Google Chrome",
+			Platform:         "darwin",
+			UniqueIdentifier: "com.google.Chrome",
+			Slug:             "google-chrome/darwin",
+		}, nil
+	}
+	payload = fleet.SoftwareInstallerPayload{Slug: ptr.String("google-chrome/darwin")}
+	err = svc.softwareInstallerPayloadFromSlug(context.Background(), &payload, nil)
+	require.NoError(t, err)
+	assert.Contains(t, payload.URL, "google.com")
+	assert.Empty(t, payload.SHA256)
+	assert.NotEmpty(t, payload.InstallScript)
+	assert.NotEmpty(t, payload.UninstallScript)
+	assert.True(t, payload.FleetMaintained)
+
 	// when a slug empty, we no-op and return the payload as is
 	payload = fleet.SoftwareInstallerPayload{URL: "https://fleetdm.com"}
 	err = svc.softwareInstallerPayloadFromSlug(context.Background(), &payload, nil)

--- a/server/mdm/maintainedapps/installers.go
+++ b/server/mdm/maintainedapps/installers.go
@@ -2,7 +2,10 @@ package maintained_apps
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
+	"io"
 	"mime"
 	"net/http"
 	"net/url"
@@ -90,4 +93,10 @@ func FilenameFromResponse(resp *http.Response) string {
 	}
 
 	return filename
+}
+
+func SHA256FromInstallerFile(installerTFR *fleet.TempFileReader) string {
+	h := sha256.New()
+	_, _ = io.Copy(h, installerTFR) // writes to a Hash can never fail
+	return hex.EncodeToString(h.Sum(nil))
 }

--- a/server/mdm/maintainedapps/installers.go
+++ b/server/mdm/maintainedapps/installers.go
@@ -95,8 +95,14 @@ func FilenameFromResponse(resp *http.Response) string {
 	return filename
 }
 
-func SHA256FromInstallerFile(installerTFR *fleet.TempFileReader) string {
+func SHA256FromInstallerFile(installerTFR *fleet.TempFileReader) (string, error) {
 	h := sha256.New()
 	_, _ = io.Copy(h, installerTFR) // writes to a Hash can never fail
-	return hex.EncodeToString(h.Sum(nil))
+	gotHash := hex.EncodeToString(h.Sum(nil))
+
+	if err := installerTFR.Rewind(); err != nil {
+		return "", fmt.Errorf("rewind installer reader: %w", err)
+	}
+
+	return gotHash, nil
 }

--- a/server/mdm/maintainedapps/installers_test.go
+++ b/server/mdm/maintainedapps/installers_test.go
@@ -4,10 +4,12 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/fleetdm/fleet/v4/pkg/fleethttp"
+	"github.com/fleetdm/fleet/v4/server/fleet"
 	"github.com/stretchr/testify/require"
 )
 
@@ -46,4 +48,15 @@ func TestInstallerFilenameExtraction(t *testing.T) {
 	_, filename, err = DownloadInstaller(context.Background(), srv.URL+"/not_compliant", client)
 	require.NoError(t, err)
 	require.Equal(t, "not_compliant.pkg", filename)
+}
+
+func TestSHA256FromInstallerFile(t *testing.T) {
+	tmpFileReader := func(ident string) *fleet.TempFileReader {
+		tfr, err := fleet.NewTempFileReader(strings.NewReader(ident), t.TempDir)
+		require.NoError(t, err)
+		return tfr
+	}
+
+	sha256 := SHA256FromInstallerFile(tmpFileReader("installer1"))
+	require.Equal(t, "026ac8ee705035f2422eeba7fdea15df563e4f4687ce3abc9a306d2de261f8de", sha256)
 }

--- a/server/mdm/maintainedapps/installers_test.go
+++ b/server/mdm/maintainedapps/installers_test.go
@@ -57,6 +57,7 @@ func TestSHA256FromInstallerFile(t *testing.T) {
 		return tfr
 	}
 
-	sha256 := SHA256FromInstallerFile(tmpFileReader("installer1"))
+	sha256, err := SHA256FromInstallerFile(tmpFileReader("installer1"))
+	require.NoError(t, err)
 	require.Equal(t, "026ac8ee705035f2422eeba7fdea15df563e4f4687ce3abc9a306d2de261f8de", sha256)
 }


### PR DESCRIPTION
fixes: #30325

Related to incorrect behavior introduced at https://github.com/fleetdm/fleet/pull/28945

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.
- [x] Added/updated automated tests
- [x] Manual QA for all new/changed functionality


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * When uploading software batches, if the installer SHA is set to "no_check," the system will now automatically generate and use the SHA256 checksum of the installer file.
* **Bug Fixes**
  * Fixed an issue ensuring the latest Google Chrome version is pulled during Fleet-maintained app updates.
  * Corrected the display of the SHA256 hash in the UI and API to show valid values.
  * Improved handling of installer uploads to ensure a valid SHA256 checksum is always applied, even when "no_check" is specified.
* **Tests**
  * Added a test to verify correct SHA256 hash calculation for installer files.
  * Extended integration tests to validate batch software installer operations for maintained apps with SHA256 hash checks.
  * Added tests covering behavior when SHA256 checksum is marked as "no_check" for maintained apps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->