### PR TITLE
Properly filter host certificates by host on update when multiple hosts share the same certificate

### DIFF
--- a/changes/30574-confused-certs
+++ b/changes/30574-confused-certs
@@ -1,0 +1,1 @@
+* Fixed host certificate source recording (including associated performance/database load issues) when multiple hosts share the same certificate on user keychains with differing usernames

--- a/server/datastore/mysql/host_certificates.go
+++ b/server/datastore/mysql/host_certificates.go
@@ -77,6 +77,17 @@ func (ds *Datastore) UpdateHostCertificates(ctx context.Context, hostID uint, ho
 	for sha1, incoming := range incomingBySHA1 {
 		incomingSources := incomingSourcesBySHA1[sha1]
 		existingSources := existingSourcesBySHA1[sha1]
+
+		// sort by keychain (user/system) and username to ensure consistent ordering
+		sliceSortFunc := func(a, b certSourceToSet) int {
+			if a.Source != b.Source {
+				return strings.Compare(string(a.Source), string(b.Source))
+			}
+			return strings.Compare(a.Username, b.Username)
+		}
+		slices.SortFunc(incomingSources, sliceSortFunc)
+		slices.SortFunc(existingSources, sliceSortFunc)
+
 		if !slices.Equal(incomingSources, existingSources) {
 			toSetSourcesBySHA1[sha1] = incomingSources
 		}

--- a/server/datastore/mysql/host_certificates_test.go
+++ b/server/datastore/mysql/host_certificates_test.go
@@ -4,18 +4,15 @@ import (
 	"context"
 	"crypto/x509"
 	"crypto/x509/pkix"
-	"encoding/hex"
 	"encoding/pem"
 	"fmt"
 	"math/big"
 	"math/rand/v2"
-	"strings"
 	"testing"
 	"time"
 
 	"github.com/fleetdm/fleet/v4/server/fleet"
 	"github.com/fleetdm/fleet/v4/server/ptr"
-	"github.com/jmoiron/sqlx"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -30,7 +27,6 @@ func TestHostCertificates(t *testing.T) {
 		{"UpdateAndList", testUpdateAndListHostCertificates},
 		{"Update with host_mdm_managed_certificates to update", testUpdatingHostMDMManagedCertificates},
 		{"Update certificate sources isolation", testUpdateHostCertificatesSourcesIsolation},
-		{"loadHostCertIDsForSHA1DB isolation", testLoadHostCertIDsForSHA1DBIsolation},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
@@ -325,27 +321,9 @@ func generateTestHostCertificateRecord(t *testing.T, hostID uint, template *x509
 }
 
 func testUpdateHostCertificatesSourcesIsolation(t *testing.T, ds *Datastore) {
-	// This test verifies the fix for commit 4726d838848aa294aca1036c8376d69f27f5f1e0
-	// "Don't look at other hosts' certs when deciding what to replace"
-	//
-	// The bug was in loadHostCertIDsForSHA1DB function which was querying:
-	//   SELECT ... FROM host_certificates WHERE sha1_sum IN (?)
-	// instead of:
-	//   SELECT ... FROM host_certificates WHERE sha1_sum IN (?) AND host_id = ?
-	//
-	// This caused certificate sources to be updated for the wrong host when
-	// multiple hosts had certificates with the same SHA1 sum.
-	//
-	// Test Coverage:
-	// 1. Creates two hosts with identical certificates (same SHA1)
-	// 2. Updates certificate sources for one host
-	// 3. Verifies the other host's certificate sources remain unchanged
-	// 4. Tests bidirectional isolation (host2 -> host1)
-	// 5. Tests multiple sources for same certificate on same host
-
+	// regression test for #30574
 	ctx := context.Background()
 
-	// Create two hosts
 	host1, err := ds.NewHost(ctx, &fleet.Host{
 		DetailUpdatedAt: time.Now(),
 		LabelUpdatedAt:  time.Now(),
@@ -405,214 +383,89 @@ func testUpdateHostCertificatesSourcesIsolation(t *testing.T, ds *Datastore) {
 	require.NoError(t, err)
 
 	host1Cert := fleet.NewHostCertificateRecord(host1.ID, parsed)
-	host1Cert.Source = fleet.SystemHostCertificate
-	host1Cert.Username = ""
+	host1Cert.Source = fleet.UserHostCertificate
+	host1Cert.Username = "jdoe"
 
 	host2Cert := fleet.NewHostCertificateRecord(host2.ID, parsed)
-	host2Cert.Source = fleet.SystemHostCertificate
-	host2Cert.Username = ""
+	host2Cert.Source = fleet.UserHostCertificate
+	host2Cert.Username = "jsmith"
 
-	// Verify both certificates have the same SHA1 sum (critical for reproducing the bug)
-	require.Equal(t, host1Cert.SHA1Sum, host2Cert.SHA1Sum,
-		"Both certificates must have the same SHA1 sum to reproduce the bug")
+	// Add the same certificate to both hosts
+	require.NoError(t, ds.UpdateHostCertificates(ctx, host1.ID, host1.UUID, []*fleet.HostCertificateRecord{host1Cert}))
+	require.NoError(t, ds.UpdateHostCertificates(ctx, host2.ID, host2.UUID, []*fleet.HostCertificateRecord{host2Cert}))
 
-	// Initial setup: Add the same certificate to both hosts
-	err = ds.UpdateHostCertificates(ctx, host1.ID, host1.UUID, []*fleet.HostCertificateRecord{host1Cert})
-	require.NoError(t, err)
-
-	err = ds.UpdateHostCertificates(ctx, host2.ID, host2.UUID, []*fleet.HostCertificateRecord{host2Cert})
-	require.NoError(t, err)
-
-	// Verify both hosts have the certificate with SystemHostCertificate source
+	// Verify both hosts have the correct certs, with the correct sources
 	host1Certs, _, err := ds.ListHostCertificates(ctx, host1.ID, fleet.ListOptions{})
 	require.NoError(t, err)
 	require.Len(t, host1Certs, 1)
-	require.Equal(t, fleet.SystemHostCertificate, host1Certs[0].Source)
-	require.Equal(t, "", host1Certs[0].Username)
+	require.Equal(t, fleet.UserHostCertificate, host1Certs[0].Source)
+	require.Equal(t, "jdoe", host1Certs[0].Username)
 
 	host2Certs, _, err := ds.ListHostCertificates(ctx, host2.ID, fleet.ListOptions{})
 	require.NoError(t, err)
 	require.Len(t, host2Certs, 1)
-	require.Equal(t, fleet.SystemHostCertificate, host2Certs[0].Source)
-	require.Equal(t, "", host2Certs[0].Username)
+	require.Equal(t, fleet.UserHostCertificate, host2Certs[0].Source)
+	require.Equal(t, "jsmith", host2Certs[0].Username)
 
-	// THE CRITICAL TEST CASE:
-	// Update host1's certificate to have a different source (UserHostCertificate)
-	// Before the fix, this would incorrectly update host2's certificate source as well
-	// because loadHostCertIDsForSHA1DB would find both certificates (same SHA1) and
-	// return the first one found, which could be from either host.
-	host1CertUpdated := fleet.NewHostCertificateRecord(host1.ID, parsed)
-	host1CertUpdated.Source = fleet.UserHostCertificate
-	host1CertUpdated.Username = "testuser"
+	// Trigger a change in host 2's cert sources to force delete/recreate of source records. Prior to the fix this
+	// wouldn't modify the correct certs because the DB query would return host 1's cert for the given hash.
+	host2CertUpdated := fleet.NewHostCertificateRecord(host2.ID, parsed)
+	host2CertUpdated.Source = fleet.UserHostCertificate
+	host2CertUpdated.Username = "janesmith"
 
-	err = ds.UpdateHostCertificates(ctx, host1.ID, host1.UUID, []*fleet.HostCertificateRecord{host1CertUpdated})
-	require.NoError(t, err)
+	require.NoError(t, ds.UpdateHostCertificates(ctx, host2.ID, host2.UUID, []*fleet.HostCertificateRecord{host2CertUpdated}))
 
-	// Verify host1's certificate source was updated
+	// Verify host1's certificate source was *not* updated
 	host1CertsAfter, _, err := ds.ListHostCertificates(ctx, host1.ID, fleet.ListOptions{})
 	require.NoError(t, err)
 	require.Len(t, host1CertsAfter, 1)
-	require.Equal(t, fleet.UserHostCertificate, host1CertsAfter[0].Source)
-	require.Equal(t, "testuser", host1CertsAfter[0].Username)
+	require.Equal(t, "jdoe", host1CertsAfter[0].Username)
 
-	// THE KEY ASSERTION: host2's certificate source should NOT have changed
-	// This would fail before the fix because loadHostCertIDsForSHA1DB would
-	// incorrectly match certificates from both hosts
+	// Verify host2's certificate source *was* updated
 	host2CertsAfter, _, err := ds.ListHostCertificates(ctx, host2.ID, fleet.ListOptions{})
 	require.NoError(t, err)
 	require.Len(t, host2CertsAfter, 1)
-	require.Equal(t, fleet.SystemHostCertificate, host2CertsAfter[0].Source,
-		"host2's certificate source should remain unchanged when host1's certificate is updated")
-	require.Equal(t, "", host2CertsAfter[0].Username)
+	require.Equal(t, "janesmith", host2CertsAfter[0].Username)
 
-	// Additional verification: Update host2's certificate to a different source
-	// and verify that host1's certificate remains unchanged
-	host2CertUpdated := fleet.NewHostCertificateRecord(host2.ID, parsed)
-	host2CertUpdated.Source = fleet.UserHostCertificate
-	host2CertUpdated.Username = "anotheruser"
-
+	// Verify no-op case
 	err = ds.UpdateHostCertificates(ctx, host2.ID, host2.UUID, []*fleet.HostCertificateRecord{host2CertUpdated})
 	require.NoError(t, err)
 
 	// Verify host2's certificate source was updated
-	host2CertsFinal, _, err := ds.ListHostCertificates(ctx, host2.ID, fleet.ListOptions{})
+	host2CertsNoop, _, err := ds.ListHostCertificates(ctx, host2.ID, fleet.ListOptions{})
 	require.NoError(t, err)
-	require.Len(t, host2CertsFinal, 1)
-	require.Equal(t, fleet.UserHostCertificate, host2CertsFinal[0].Source)
-	require.Equal(t, "anotheruser", host2CertsFinal[0].Username)
+	require.Len(t, host2CertsNoop, 1)
+	require.Equal(t, fleet.UserHostCertificate, host2CertsNoop[0].Source)
+	require.Equal(t, "janesmith", host2CertsNoop[0].Username)
 
-	// Verify host1's certificate source was NOT changed by host2's update
-	host1CertsFinal, _, err := ds.ListHostCertificates(ctx, host1.ID, fleet.ListOptions{})
+	// Confirm that adding the cert to the system store gets picked up properly
+	systemCertOnHost2 := fleet.NewHostCertificateRecord(host2.ID, parsed)
+	systemCertOnHost2.Source = fleet.SystemHostCertificate
+
+	require.NoError(t, ds.UpdateHostCertificates(ctx, host2.ID, host2.UUID, []*fleet.HostCertificateRecord{host2CertUpdated, systemCertOnHost2}))
+
+	// Verify host2 now has the certificate with both sources
+	host2CertsMultiSource, _, err := ds.ListHostCertificates(ctx, host2.ID, fleet.ListOptions{})
 	require.NoError(t, err)
-	require.Len(t, host1CertsFinal, 1)
-	require.Equal(t, fleet.UserHostCertificate, host1CertsFinal[0].Source,
-		"host1's certificate source should remain unchanged when host2's certificate is updated")
-	require.Equal(t, "testuser", host1CertsFinal[0].Username)
-
-	// Test edge case: Multiple certificate sources for the same certificate on the same host
-	// This ensures the fix handles the more complex case where a single host has multiple
-	// sources for the same certificate
-	host1CertMultiSource1 := fleet.NewHostCertificateRecord(host1.ID, parsed)
-	host1CertMultiSource1.Source = fleet.SystemHostCertificate
-	host1CertMultiSource1.Username = ""
-
-	host1CertMultiSource2 := fleet.NewHostCertificateRecord(host1.ID, parsed)
-	host1CertMultiSource2.Source = fleet.UserHostCertificate
-	host1CertMultiSource2.Username = "multiuser"
-
-	err = ds.UpdateHostCertificates(ctx, host1.ID, host1.UUID, []*fleet.HostCertificateRecord{host1CertMultiSource1, host1CertMultiSource2})
-	require.NoError(t, err)
-
-	// Verify host1 now has the certificate with both sources
-	host1CertsMulti, _, err := ds.ListHostCertificates(ctx, host1.ID, fleet.ListOptions{})
-	require.NoError(t, err)
-	require.Len(t, host1CertsMulti, 2)
-
-	// Verify host2 still has only its original certificate source
-	host2CertsMulti, _, err := ds.ListHostCertificates(ctx, host2.ID, fleet.ListOptions{})
-	require.NoError(t, err)
-	require.Len(t, host2CertsMulti, 1)
-	require.Equal(t, fleet.UserHostCertificate, host2CertsMulti[0].Source)
-	require.Equal(t, "anotheruser", host2CertsMulti[0].Username)
-}
-
-func testLoadHostCertIDsForSHA1DBIsolation(t *testing.T, ds *Datastore) {
-	// This test directly tests the loadHostCertIDsForSHA1DB function to ensure
-	// it only returns certificate IDs for the specified host, not all hosts
-	//
-	// Test Coverage:
-	// 1. Creates two hosts with identical certificates (same SHA1)
-	// 2. Directly calls loadHostCertIDsForSHA1DB for each host
-	// 3. Verifies each host only gets its own certificate IDs
-	// 4. Verifies certificate IDs are different even with same SHA1
-	// 5. Tests that non-existent hosts return no results
-	ctx := context.Background()
-
-	// Create two hosts
-	host1, err := ds.NewHost(ctx, &fleet.Host{
-		DetailUpdatedAt: time.Now(),
-		LabelUpdatedAt:  time.Now(),
-		PolicyUpdatedAt: time.Now(),
-		SeenTime:        time.Now(),
-		OsqueryHostID:   ptr.String("unit-test-host1"),
-		NodeKey:         ptr.String("unit-test-host1-key"),
-		UUID:            "unit-test-host1-uuid",
-		Hostname:        "unit-test-host1",
-	})
-	require.NoError(t, err)
-
-	host2, err := ds.NewHost(ctx, &fleet.Host{
-		DetailUpdatedAt: time.Now(),
-		LabelUpdatedAt:  time.Now(),
-		PolicyUpdatedAt: time.Now(),
-		SeenTime:        time.Now(),
-		OsqueryHostID:   ptr.String("unit-test-host2"),
-		NodeKey:         ptr.String("unit-test-host2-key"),
-		UUID:            "unit-test-host2-uuid",
-		Hostname:        "unit-test-host2",
-	})
-	require.NoError(t, err)
-
-	// Create a certificate
-	cert := x509.Certificate{
-		Subject: pkix.Name{
-			Country:    []string{"US"},
-			CommonName: "unit-test.example.com",
-		},
-		SerialNumber:          big.NewInt(99999),
-		SignatureAlgorithm:    x509.SHA256WithRSA,
-		NotBefore:             time.Now().Add(-time.Hour).UTC(),
-		NotAfter:              time.Now().Add(24 * time.Hour).UTC(),
-		BasicConstraintsValid: true,
+	require.Len(t, host2CertsMultiSource, 2)
+	var hasUserCert, hasSystemCert bool
+	for _, cert := range host2CertsMultiSource {
+		if cert.Source == fleet.UserHostCertificate {
+			require.Equal(t, "janesmith", cert.Username)
+			hasUserCert = true
+		} else {
+			require.Empty(t, cert.Username)
+			require.Equal(t, fleet.SystemHostCertificate, cert.Source)
+			hasSystemCert = true
+		}
 	}
+	require.True(t, hasUserCert)
+	require.True(t, hasSystemCert)
 
-	// Generate certificate data
-	certBytes, _, err := GenerateTestCertBytes(&cert)
+	// Verify host1 still has only its original certificate source
+	host1CertsMultiSource, _, err := ds.ListHostCertificates(ctx, host1.ID, fleet.ListOptions{})
 	require.NoError(t, err)
-
-	block, _ := pem.Decode(certBytes)
-	parsed, err := x509.ParseCertificate(block.Bytes)
-	require.NoError(t, err)
-
-	// Create certificate records for both hosts
-	host1Cert := fleet.NewHostCertificateRecord(host1.ID, parsed)
-	host2Cert := fleet.NewHostCertificateRecord(host2.ID, parsed)
-
-	// Insert certificates for both hosts
-	err = ds.UpdateHostCertificates(ctx, host1.ID, host1.UUID, []*fleet.HostCertificateRecord{host1Cert})
-	require.NoError(t, err)
-
-	err = ds.UpdateHostCertificates(ctx, host2.ID, host2.UUID, []*fleet.HostCertificateRecord{host2Cert})
-	require.NoError(t, err)
-
-	// Get the SHA1 sum
-	sha1String := strings.ToUpper(hex.EncodeToString(host1Cert.SHA1Sum))
-
-	// Test loadHostCertIDsForSHA1DB function directly
-	err = ds.withRetryTxx(ctx, func(tx sqlx.ExtContext) error {
-		// Test that querying for host1 returns only host1's certificate ID
-		certIDsHost1, err := loadHostCertIDsForSHA1DB(ctx, tx, host1.ID, []string{sha1String})
-		require.NoError(t, err)
-		require.Len(t, certIDsHost1, 1)
-		require.Contains(t, certIDsHost1, sha1String)
-
-		// Test that querying for host2 returns only host2's certificate ID
-		certIDsHost2, err := loadHostCertIDsForSHA1DB(ctx, tx, host2.ID, []string{sha1String})
-		require.NoError(t, err)
-		require.Len(t, certIDsHost2, 1)
-		require.Contains(t, certIDsHost2, sha1String)
-
-		// The certificate IDs should be different even though the SHA1 is the same
-		require.NotEqual(t, certIDsHost1[sha1String], certIDsHost2[sha1String],
-			"Certificate IDs should be different for different hosts even with same SHA1")
-
-		// Test that querying for a non-existent host returns no results
-		host3ID := uint(99999)
-		certIDsHost3, err := loadHostCertIDsForSHA1DB(ctx, tx, host3ID, []string{sha1String})
-		require.NoError(t, err)
-		require.Len(t, certIDsHost3, 0)
-
-		return nil
-	})
-	require.NoError(t, err)
+	require.Len(t, host1CertsMultiSource, 1)
+	require.Equal(t, fleet.UserHostCertificate, host1CertsMultiSource[0].Source)
+	require.Equal(t, "jdoe", host1CertsMultiSource[0].Username)
 }


### PR DESCRIPTION
Fixes #30574.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.
- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [x] Added/updated automated tests
- [x] Manual QA for all new/changed functionality

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved issues with recording host certificate sources when multiple hosts share the same certificate but have different usernames, improving accuracy and performance.
  * Addressed related performance and database load problems for these scenarios.

* **Tests**
  * Added new tests to ensure certificate source records remain properly isolated per host, even when certificates are shared across hosts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->