### PR TITLE
Suppress unneeded react tooltip test warning and update lib to latest version

### DIFF
--- a/frontend/test/test-setup.ts
+++ b/frontend/test/test-setup.ts
@@ -13,3 +13,19 @@ global.ResizeObserver = jest.fn().mockImplementation(() => ({
 beforeAll(() => mockServer.listen());
 afterEach(() => mockServer.resetHandlers());
 afterAll(() => mockServer.close());
+
+// suppress the opacity console warnings for react-tooltip. The code for assigning the
+// opacity is correct but there is still an unnecessary warning in the console when
+// the jest tests are run. This may be react-tooltip and JSdom not playing well together.
+beforeAll(() => {
+  const originalConsoleWarning = console.warn;
+  console.warn = (...args) => {
+    if (
+      args[0]?.includes("[react-tooltip]") &&
+      args[0]?.includes("is not a valid `opacity`")
+    ) {
+      return;
+    }
+    originalConsoleWarning(...args);
+  };
+});

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "react-table": "7.7.0",
     "react-tabs": "3.2.3",
     "react-tooltip": "4.2.21",
-    "react-tooltip-5": "npm:react-tooltip@5.21.3",
+    "react-tooltip-5": "npm:react-tooltip@5.29.1",
     "remark-gfm": "3.0.1",
     "sass": "1.83.4",
     "select": "1.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2054,25 +2054,25 @@
     "@figspec/components" "^1.0.1"
     "@lit-labs/react" "^1.0.2"
 
-"@floating-ui/core@^1.4.2":
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/@floating-ui/core/-/core-1.5.0.tgz#5c05c60d5ae2d05101c3021c1a2a350ddc027f8c"
-  integrity sha512-kK1h4m36DQ0UHGj5Ah4db7R0rHemTqqO0QLvUqi1/mUUp3LuAWbWxdxSIf/XsnH9VS6rRVPLJCncjRzUvyCLXg==
+"@floating-ui/core@^1.7.2":
+  version "1.7.2"
+  resolved "https://registry.yarnpkg.com/@floating-ui/core/-/core-1.7.2.tgz#3d1c35263950b314b6d5a72c8bfb9e3c1551aefd"
+  integrity sha512-wNB5ooIKHQc+Kui96jE/n69rHFWAVoxn5CAzL1Xdd8FG03cgY3MLO+GF9U3W737fYDSgPWA6MReKhBQBop6Pcw==
   dependencies:
-    "@floating-ui/utils" "^0.1.3"
+    "@floating-ui/utils" "^0.2.10"
 
-"@floating-ui/dom@^1.0.0":
-  version "1.5.3"
-  resolved "https://registry.yarnpkg.com/@floating-ui/dom/-/dom-1.5.3.tgz#54e50efcb432c06c23cd33de2b575102005436fa"
-  integrity sha512-ClAbQnEqJAKCJOEbbLo5IUlZHkNszqhuxS4fHAVxRPXPya6Ysf2G8KypnYcOTpx6I8xcgF9bbHb6g/2KpbV8qA==
+"@floating-ui/dom@^1.6.1":
+  version "1.7.2"
+  resolved "https://registry.yarnpkg.com/@floating-ui/dom/-/dom-1.7.2.tgz#3540b051cf5ce0d4f4db5fb2507a76e8ea5b4a45"
+  integrity sha512-7cfaOQuCS27HD7DX+6ib2OrnW+b4ZBwDNnCcT0uTyidcmyWb03FnQqJybDBoCnpdxwBSfA94UAYlRCt7mV+TbA==
   dependencies:
-    "@floating-ui/core" "^1.4.2"
-    "@floating-ui/utils" "^0.1.3"
+    "@floating-ui/core" "^1.7.2"
+    "@floating-ui/utils" "^0.2.10"
 
-"@floating-ui/utils@^0.1.3":
-  version "0.1.6"
-  resolved "https://registry.yarnpkg.com/@floating-ui/utils/-/utils-0.1.6.tgz#22958c042e10b67463997bd6ea7115fe28cbcaf9"
-  integrity sha512-OfX7E2oUDYxtBvsuS4e/jSn4Q9Qb6DzgeYtsAdkPZ47znpoNsMgZw0+tVijiv3uGNR6dgNlty6r9rzIzHjtd/A==
+"@floating-ui/utils@^0.2.10":
+  version "0.2.10"
+  resolved "https://registry.yarnpkg.com/@floating-ui/utils/-/utils-0.2.10.tgz#a2a1e3812d14525f725d011a73eceb41fef5bc1c"
+  integrity sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==
 
 "@hapi/hoek@^9.0.0", "@hapi/hoek@^9.3.0":
   version "9.3.0"
@@ -11910,12 +11910,12 @@ react-tabs@3.2.3:
     clsx "^1.1.0"
     prop-types "^15.5.0"
 
-"react-tooltip-5@npm:react-tooltip@5.21.3":
-  version "5.21.3"
-  resolved "https://registry.yarnpkg.com/react-tooltip/-/react-tooltip-5.21.3.tgz#131d578c7ea69f96c65dbd09f071880c34b4f83d"
-  integrity sha512-z3Q+Uka4D6uYxfsssPqfx1W8vw7NIHyC2ZMq+NJkWg4EpUD3w7Fwz/o+dezyUQMCHL7nO/2sFbtWIrkyxktq2Q==
+"react-tooltip-5@npm:react-tooltip@5.29.1":
+  version "5.29.1"
+  resolved "https://registry.yarnpkg.com/react-tooltip/-/react-tooltip-5.29.1.tgz#ba0b80b04d66822590976d2a32f47544fd9feee2"
+  integrity sha512-rmJmEb/p99xWhwmVT7F7riLG08wwKykjHiMGbDPloNJk3tdI73oHsVOwzZ4SRjqMdd5/xwb/4nmz0RcoMfY7Bw==
   dependencies:
-    "@floating-ui/dom" "^1.0.0"
+    "@floating-ui/dom" "^1.6.1"
     classnames "^2.3.0"
 
 react-tooltip@*, react-tooltip@4.2.21:


### PR DESCRIPTION
This suppresses an unneeded react-tooltip opacity warning when the tests are run. The code is correct when assigning the opacity and this may just be an issue with react-tooltip and jsdom not working nicely together. This was causing to much noise in the console.

We've also updated react-tooltip 5 to the latest version

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the react-tooltip-5 dependency to a newer version.
  * Suppressed specific harmless warnings related to react-tooltip during test runs for cleaner test output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->