### PR TITLE
Use GH API token in ingest FMA action

### DIFF
--- a/.github/workflows/ingest-maintained-apps.yml
+++ b/.github/workflows/ingest-maintained-apps.yml
@@ -48,10 +48,12 @@ jobs:
           go-version-file: 'fleet/go.mod'
 
       - name: Ingest maintained apps
+        env:
+          NETWORK_TEST_GITHUB_TOKEN: ${{ secrets.FLEET_RELEASE_GITHUB_PAT }}
         run: |
           cd fleet
           go mod download
-          NETWORK_TEST_GITHUB_TOKEN=${{ secrets.FLEET_RELEASE_GITHUB_PAT }} go run cmd/maintained-apps/main.go
+          go run cmd/maintained-apps/main.go
 
       - name: Search for Existing PRs
         id: search_pr

--- a/.github/workflows/ingest-maintained-apps.yml
+++ b/.github/workflows/ingest-maintained-apps.yml
@@ -51,7 +51,7 @@ jobs:
         run: |
           cd fleet
           go mod download
-          go run cmd/maintained-apps/main.go
+          NETWORK_TEST_GITHUB_TOKEN=${{ secrets.FLEET_RELEASE_GITHUB_PAT }} go run cmd/maintained-apps/main.go
 
       - name: Search for Existing PRs
         id: search_pr


### PR DESCRIPTION
# Checklist for submitter

Ran in to a rate limit when FMA action was pulling update metadata from winget repo:
https://github.com/fleetdm/fleet/actions/runs/16116434985

Change:
Adding our existing token to this action

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated workflow to include a GitHub token for improved authentication during automated tasks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->