### PR TITLE
Bump page size to 10 for software title versions list

### DIFF
--- a/changes/30393-pagination
+++ b/changes/30393-pagination
@@ -1,0 +1,1 @@
+* Switched page size for software versions shown on the software view page from 5 to 10.

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwareSummaryCard/TitleVersionsTable/TitleVersionsTable.tests.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwareSummaryCard/TitleVersionsTable/TitleVersionsTable.tests.tsx
@@ -11,6 +11,11 @@ describe("TitleVersionsTable", () => {
     const versions = [
       { id: 10, version: "1.2.3", vulnerabilities: [] },
       { id: 11, version: "1.2.4", vulnerabilities: [] },
+      { id: 12, version: "1.2.5", vulnerabilities: [] },
+      { id: 13, version: "1.2.6", vulnerabilities: [] },
+      { id: 14, version: "1.2.7", vulnerabilities: [] },
+      { id: 15, version: "1.2.8", vulnerabilities: [] },
+      { id: 16, version: "1.2.9", vulnerabilities: [] },
     ];
 
     render(
@@ -26,12 +31,13 @@ describe("TitleVersionsTable", () => {
 
     // There should be one cell with a link for the version
     const cells = screen.getAllByRole("cell");
-    expect(cells).toHaveLength(8);
+    // Version, Vulnerabilities, Hosts, View all hosts for each row
+    expect(cells).toHaveLength(4 * 7);
     expect(screen.getByText(/1.2.3/i)).toBeInTheDocument();
-    expect(screen.getByText(/1.2.4/i)).toBeInTheDocument();
+    expect(screen.getByText(/1.2.9/i)).toBeInTheDocument(); // make sure
 
     // Version count should be shown
-    expect(screen.getByText(/2 versions/i)).toBeInTheDocument();
+    expect(screen.getByText(/7 versions/i)).toBeInTheDocument();
 
     // Last updated info should be shown
     expect(screen.getByText(/updated/i)).toBeInTheDocument();

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwareSummaryCard/TitleVersionsTable/TitleVersionsTable.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwareSummaryCard/TitleVersionsTable/TitleVersionsTable.tsx
@@ -132,7 +132,7 @@ const TitleVersionsTable = ({
       isAllPagesSelected={false}
       defaultSortHeader={DEFAULT_SORT_HEADER}
       defaultSortDirection={DEFAULT_SORT_DIRECTION}
-      pageSize={DEFAULT_PAGE_SIZE}
+      pageSize={10}
       isClientSidePagination
       disableMultiRowSelect
       onSelectSingleRow={handleRowSelect}

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwareSummaryCard/TitleVersionsTable/TitleVersionsTable.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwareSummaryCard/TitleVersionsTable/TitleVersionsTable.tsx
@@ -20,7 +20,7 @@ import generateSoftwareTitleVersionsTableConfig from "./TitleVersionsTableConfig
 
 const DEFAULT_SORT_HEADER = "hosts_count";
 const DEFAULT_SORT_DIRECTION = "desc";
-const DEFAULT_PAGE_SIZE = 5;
+const DEFAULT_PAGE_SIZE = 10;
 
 const baseClass = "software-title-versions-table";
 
@@ -132,7 +132,7 @@ const TitleVersionsTable = ({
       isAllPagesSelected={false}
       defaultSortHeader={DEFAULT_SORT_HEADER}
       defaultSortDirection={DEFAULT_SORT_DIRECTION}
-      pageSize={10}
+      pageSize={DEFAULT_PAGE_SIZE}
       isClientSidePagination
       disableMultiRowSelect
       onSelectSingleRow={handleRowSelect}


### PR DESCRIPTION
Fixes #30393.

<img width="1272" alt="image" src="https://github.com/user-attachments/assets/ba3ad58f-77ff-44a1-8587-d9fa89ff84eb" />

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.
- [x] Added/updated automated tests
- [x] Manual QA for all new/changed functionality

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Increased the number of software versions displayed per page from 5 to 10 on the software view page.

* **Tests**
  * Updated tests to reflect the increased number of displayed versions and adjusted assertions accordingly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->