### PR TITLE
Add `encryption_key_archived` to docs for API responses

### DIFF
--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -3024,6 +3024,7 @@ Returns the information of the specified host.
     ],
     "mdm": {
       "encryption_key_available": true,
+      "encryption_key_archived": true,
       "enrollment_status": "On (manual)",
       "name": "Fleet",
       "connected_to_fleet": true,
@@ -3251,6 +3252,7 @@ If `hostname` is specified when there is more than one host with the same hostna
     ],
     "mdm": {
       "encryption_key_available": false,
+      "encryption_key_archived": false,
       "enrollment_status": null,
       "name": "",
       "server_url": null,
@@ -3445,6 +3447,7 @@ This is the API route used by the **My device** page in Fleet desktop to display
     "packs": [],
     "mdm": {
       "encryption_key_available": true,
+      "encryption_key_archived": true,
       "enrollment_status": "On (manual)",
       "name": "Fleet",
       "connected_to_fleet": true,


### PR DESCRIPTION
Proposed changes were discussed with @marko-lisica in MDM standup. 

Why do we need another field?

- Semantics of existing field `encrypton_key_available` signify that Fleet server has escrowed the _current_ encryption key (ingested via fleetd as an encrypted value) and that Fleet server is able to decode the escrowed key (as determined in the hourly cron).
- API users (in addition to the frontend) rely on the existing meaning of `encrypton_key_available`
- In addition to the current key (stored in `hosts_disk_encryption_keys`), Fleet archives prior keys in `host_disk_encryption_key_archive`, but there is no guarantee that Fleet server can still decode any of them.
- For https://github.com/fleetdm/fleet/issues/28754, the frontend needs to know when to enable the "View disk encryption key" option in the action dropdown on the host details page so we need the new field `encryption_key_archived` in order to not break the meaning of the existing `encrypton_key_available` field.

Note:
 - List hosts response also includes `encryption_key_available` and we don't want to increase the overhead to that already expensive API call by adding a new join to the archived keys table.
 - We also need error states for the "Disk encryption key" modal to cover cases where the archived key can't be decoded. 