### PR TITLE
Never use gravatar for API users

### DIFF
--- a/frontend/components/Avatar/Avatar.tsx
+++ b/frontend/components/Avatar/Avatar.tsx
@@ -170,7 +170,7 @@ const Avatar = ({
 
   if (useFleetAvatar) {
     avatar = <FleetAvatar className={avatarClasses} />;
-  } else if (useApiOnlyAvatar && !gravatar_url) {
+  } else if (useApiOnlyAvatar) {
     avatar = <APIOnlyAvatar className={avatarClasses} />;
   } else {
     avatar = (


### PR DESCRIPTION
#28501

Looks like the gravatar avatar is always set above the component, so always set default API avatar instead

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved avatar rendering logic to ensure the correct avatar is displayed when the API-only option is enabled, regardless of gravatar settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->