### PR TITLE
Add missing webhook tooltip URL

### DIFF
--- a/changes/29848-tooltip-missing-webhook-url
+++ b/changes/29848-tooltip-missing-webhook-url
@@ -1,0 +1,1 @@
+- Fixed missing webhook url in automations tooltip

--- a/frontend/pages/queries/details/QueryDetailsPage/QueryDetailsPage.tsx
+++ b/frontend/pages/queries/details/QueryDetailsPage/QueryDetailsPage.tsx
@@ -369,6 +369,7 @@ const QueryDetailsPage = ({
                   filesystemDestination={
                     config?.logging.result.config?.result_log_file
                   }
+                  webhookDestination={config?.logging.result.config?.result_url}
                 />
               </div>
             </div>

--- a/frontend/pages/queries/edit/components/EditQueryForm/EditQueryForm.tsx
+++ b/frontend/pages/queries/edit/components/EditQueryForm/EditQueryForm.tsx
@@ -776,6 +776,9 @@ const EditQueryForm = ({
                         filesystemDestination={
                           config?.logging.result.config?.result_log_file
                         }
+                        webhookDestination={
+                          config?.logging.result.config?.result_url
+                        }
                         excludeTooltip
                       />
                     </b>

--- a/frontend/pages/queries/edit/components/SaveNewQueryModal/SaveNewQueryModal.tsx
+++ b/frontend/pages/queries/edit/components/SaveNewQueryModal/SaveNewQueryModal.tsx
@@ -278,6 +278,7 @@ const SaveNewQueryModal = ({
                   filesystemDestination={
                     config?.logging.result.config?.result_log_file
                   }
+                  webhookDestination={config?.logging.result.config?.result_url}
                   excludeTooltip
                 />
               </b>


### PR DESCRIPTION
#29848

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.
- [x] Manual QA for all new/changed functionality


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where the webhook URL was missing from the automations tooltip, ensuring it is now properly displayed in relevant tooltips and sections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->