### PR TITLE
pkg/open: fix launching browser in some scenarios

### DIFF
--- a/orbit/changes/19043-ubuntu-wayland-browser-snap
+++ b/orbit/changes/19043-ubuntu-wayland-browser-snap
@@ -1,0 +1,1 @@
+- Fixed Fleet Desktop failing to launch the browser, or launching the wrong browser, in Wayland sessions and/or when the browser is installed as a Flatpak or Snap.

--- a/pkg/open/open_linux.go
+++ b/pkg/open/open_linux.go
@@ -1,31 +1,49 @@
 package open
 
 import (
-	"errors"
 	"fmt"
 	"os"
 	"os/exec"
+	"path"
+	"slices"
 	"strings"
 
 	"github.com/fleetdm/fleet/v4/orbit/pkg/platform"
 	"github.com/rs/zerolog/log"
+	gopsutil_process "github.com/shirou/gopsutil/v3/process"
 )
 
-func browser(url string) error {
+var envVarsToCopy = []string{
+	// XDG_CURRENT_DESKTOP hints which xdg-desktop-portal driver to use, which is how the user's
+	// preferences are retrieved from their specific desktop environment (GNOME, MATE, KDE, etc).
+	"XDG_CURRENT_DESKTOP",
+	// XDG_RUNTIME_DIR is required for xdg-open to discover user settings via dconf.
+	"XDG_RUNTIME_DIR",
+	// Hermetic app packagers (e.g. Snap, Flatpak) tend to place `.desktop` files in alternate
+	// locations which are published in this variable.
+	"XDG_DATA_DIRS",
+	// Copying the PATH ensures that snap-installed aliases in /snap/bin are accessible to
+	// xdg-open.
+	"PATH",
 	// xdg-open requires XAUTHORITY set when running on a Wayland session (compatibility mode).
 	// We get XAUTHORITY from the Xwayland process environment.
 	//
 	// We have to do this here instead of when executing fleet-desktop because the Xwayland process
 	// may not be running yet when orbit is executing fleet-desktop.
-	xAuthority, err := getXWaylandAuthority()
-	log.Info().Str("XAUTHORITY", xAuthority).Err(err).Msg("Xwayland process")
-	if err == nil {
-		os.Setenv("XAUTHORITY", xAuthority)
-	}
+	"XAUTHORITY",
+}
+
+func browser(url string) error {
 	// xdg-open is available on most Linux-y systems
 	cmd := exec.Command("xdg-open", url)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
+	// grab environment variables necessary to determine the user's preferred browser from any
+	// running Xwayland or xdg-desktop-portal process.
+	cmd.Env = newEnvironmentWithVariablesFromNamedProcesses(
+		[]string{"xdg-desktop-portal", "Xwayland"},
+		envVarsToCopy...)
+	log.Debug().Strs("command", []string{"xdg-open", url}).Strs("env", cmd.Env).Msg("env for xdg-open cmd")
 	// Must be asynchronous (Start, not Run) because xdg-open will continue running
 	// and block this goroutine if it was the process that opened the browser.
 	if err := cmd.Start(); err != nil {
@@ -38,28 +56,116 @@ func browser(url string) error {
 	return nil
 }
 
-// getXWaylandAuthority retrieves the X authority file path from
-// the running XWayland process environment.
-func getXWaylandAuthority() (xAuthorityPath string, err error) {
-	xWaylandProcess, err := platform.GetProcessesByName("Xwayland")
+// getProcessesByName returns a list of processes matching the provided executable path running as the
+// current user.
+func getProcessesByName(exePath string) ([]*gopsutil_process.Process, error) {
+	processes, err := platform.GetProcessesByName(path.Base(exePath))
 	if err != nil {
-		return "", fmt.Errorf("get process by name: %w", err)
+		return nil, err
 	}
-	executablePath, err := xWaylandProcess[0].Exe()
-	if err != nil {
-		return "", fmt.Errorf("get executable path: %w", err)
-	}
-	if executablePath != "/usr/bin/Xwayland" {
-		return "", fmt.Errorf("invalid Xwayland path: %q", executablePath)
-	}
-	envs, err := xWaylandProcess[0].Environ()
-	if err != nil {
-		return "", fmt.Errorf("get environment: %w", err)
-	}
-	for _, env := range envs {
-		if strings.HasPrefix(env, "XAUTHORITY=") {
-			return strings.TrimPrefix(env, "XAUTHORITY="), nil
+
+	var out []*gopsutil_process.Process
+	myUid := int32(os.Getuid()) //nolint:gosec // dismiss G115
+
+	for _, p := range processes {
+		if path.IsAbs(exePath) {
+			// for absolute paths, skip if no match
+			exe, err := p.Exe()
+			if err != nil || exe != exePath {
+				if err != nil {
+					log.Debug().Err(err).Msg("p.Exe")
+				}
+				continue
+			}
+		}
+		if uids, err := p.Uids(); err == nil {
+			for _, uid := range uids {
+				if uid == myUid {
+					out = append(out, p)
+					break
+				}
+			}
+		} else {
+			log.Debug().Err(err).Msg("p.Uids")
 		}
 	}
-	return "", errors.New("XAUTHORITY not found")
+
+	return out, nil
+}
+
+func localEnv() map[string]string {
+	out := make(map[string]string)
+
+	for _, envvar := range os.Environ() {
+		if name, value, ok := strings.Cut(envvar, "="); ok {
+			out[name] = value
+		}
+	}
+
+	return out
+}
+
+// getEnvironmentVariablesFromNamedProcess retrieves the value of the requested environment variables
+// from matching processes running as the current user.
+func getEnvironmentVariablesFromNamedProcess(exePaths []string, envvars ...string) (vars map[string]string, err error) {
+	var processes []*gopsutil_process.Process
+	for _, exePath := range exePaths {
+		if p, err := getProcessesByName(exePath); err == nil {
+			processes = append(processes, p...)
+		} else {
+			log.Debug().Err(err).Msg("getProcessesByName")
+		}
+	}
+
+	log.Debug().Strs("exePaths", exePaths).Msg("spying envvars from process")
+	vars = make(map[string]string)
+
+	for _, process := range processes {
+		envs, err := process.Environ()
+		if err != nil {
+			log.Debug().Err(err).Msg("process.Environ")
+			continue
+		}
+
+		for _, env := range envs {
+			if name, value, ok := strings.Cut(env, "="); ok && slices.Contains(envvars, name) {
+				log.Debug().Str(name, value).Msg("found envvar")
+				vars[name] = value
+			}
+		}
+	}
+
+	return
+}
+
+// newEnvironmentWithVariablesFromNamedProcess copies the current environment, then looks for a
+// process running as the current user and merges the requested environment variables into the
+// local environment. The returned slice is suitable for use with (exec.Cmd).Env.
+func newEnvironmentWithVariablesFromNamedProcesses(exePaths []string, envvars ...string) []string {
+	localEnv := localEnv()
+
+	if extraVars, err := getEnvironmentVariablesFromNamedProcess(exePaths, envvars...); err == nil {
+		for k, v := range extraVars {
+			localEnv[k] = v
+		}
+
+		// log envvars that we weren't able to find in the local or examined processes
+		for _, v := range envvars {
+			if _, ok := localEnv[v]; !ok {
+				log.Debug().Str("envvar", v).Msg("unable to find envvar")
+			}
+		}
+	} else {
+		log.Debug().Err(err).Msg("getEnvironmentVariablesFromNamedProcess")
+	}
+
+	for _, k := range []string{"_", "LD_LIBRARY_PATH"} {
+		delete(localEnv, k)
+	}
+
+	var out []string
+	for k, v := range localEnv {
+		out = append(out, fmt.Sprintf("%s=%s", k, v))
+	}
+	return out
 }


### PR DESCRIPTION
Fleet Desktop may fail to launch a browser, or launch the wrong browser, in Ubuntu 24.04 LTS under some scenarios, including Wayland sessions and/or when the browser is installed as a snap or flatpak (by default, Ubuntu 24.04 LTS installs Firefox as a snap).

The previous approach of searching for an Xwayland process from which to extract environment variables is incomplete. When the browser is installed as a snap, `.desktop` files are installed by snapd into a location which is only discoverable through the `XDG_DATA_DIRS` environment variable.

To workaround this we need to change the approach in several ways:

- Look for `xdg-desktop-portal` processes, not just `Xwayland`. Both Firefox and Chrome support native operation under Wayland now, so it's not correct to rely upon the existence of an Xwayland process alone.
- Copy several more environment varibles: `XDG_CURRENT_DESKTOP`, `XDG_RUNTIME_DIR`, `XDG_DATA_DIRS`, and `PATH`, in addition to `XAUTHORITY`.

These variables allow fleet-desktop to honor the user's browser preference according to the currently running DE.

The list of variables to grab was found through trial-and-error and seems to be the minimum required for `xdg-open` to function.

Refactored and optimized the code to fetch environment variables from a running process to match only processes running as the current user and robustly handle multiple process results.

Fixes #19043, #27209.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.
- [ ] Manual QA for all new/changed functionality
- For Orbit and Fleet Desktop changes:
   - [ ] Manual QA must be performed in all relevant combinations of Linux desktop environments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility for launching browsers installed as Flatpak or Snap under Wayland sessions on Linux, resolving issues where Fleet Desktop failed to open these browsers.
  * Enhanced environment variable handling to better support browser launches in containerized and Wayland environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->