### PR TITLE
Update guides with new install verification and refetch behavior

### DIFF
--- a/articles/automatic-software-install-in-fleet.md
+++ b/articles/automatic-software-install-in-fleet.md
@@ -32,7 +32,7 @@ SELECT 1 FROM apps WHERE bundle_identifier = 'com.adobe.Reader' AND version_comp
 
 When a host fails the selected policy, this will trigger the software to be installed on the host.
 
-Once the software is installed, Fleet will automatically refetch the hosts vitals and update the software inventory.
+Once the software is installed, Fleet will automatically refetch the host's vitals and update the software inventory.
 
 If the software install fails, you can reset a software automation and trigger the install on all targeted hosts again. To do this, deselect the policy in the **Policies > Manage automations** modal, select **Save**, and then reselect the policy. This will reset the policy's host passing and failing host counts and retrigger the software automations.
 

--- a/articles/automatic-software-install-in-fleet.md
+++ b/articles/automatic-software-install-in-fleet.md
@@ -32,12 +32,14 @@ SELECT 1 FROM apps WHERE bundle_identifier = 'com.adobe.Reader' AND version_comp
 
 When a host fails the selected policy, this will trigger the software to be installed on the host.
 
+Once the software is installed, Fleet will automatically refetch the hosts vitals and update the software inventory.
+
 If the software install fails, you can reset a software automation and trigger the install on all targeted hosts again. To do this, deselect the policy in the **Policies > Manage automations** modal, select **Save**, and then reselect the policy. This will reset the policy's host passing and failing host counts and retrigger the software automations.
 
 ## How does it work?
 
 * After configuring Fleet to auto-install a specific software the rest will be done automatically.
-* The policy check mechanism runs on a typical one-hour cadence on all online hosts. 
+* The policy check mechanism runs on a typical one-hour cadence on all online hosts.
 * Fleet will send install requests to the hosts on the first policy failure (first "No" result for the host) or if a policy goes from "Yes" to "No". Currently, Fleet will not send an install request if a policy is already failing and continues to fail ("No" -> "No"). See the following flowchart for details.
 
 ![Flowchart](../website/assets/images/articles/automatic-software-install-workflow.png)
@@ -45,7 +47,7 @@ If the software install fails, you can reset a software automation and trigger t
 
 App Store (VPP) apps won't be installed if a host has MDM turned off or if you run out of licenses (purchased in Apple Business Manager). Currently, these errors aren't surfaced in Fleet. After turning MDM on for a host or purchasing more licenses, you can retry [installing the app on the host's **Host details** page](https://fleetdm.com/guides/deploy-software-packages#install-the-package). To retry on multiple hosts at once, head to **Policies > Manage Automations** in Fleet and turn the app's policy automation off and back on.
 
-Currently, App Store apps (VPP) are not installed as [Managed Apps](https://support.apple.com/guide/deployment/distribute-managed-apps-dep575bfed86/web). Uninstalling VPP apps is [coming soon](https://github.com/fleetdm/fleet/issues/25497).
+Uninstalling VPP apps is [coming soon](https://github.com/fleetdm/fleet/issues/25497).
 
 ## Templates for policy queries
 

--- a/articles/deploy-software-packages.md
+++ b/articles/deploy-software-packages.md
@@ -24,7 +24,7 @@ Learn more about automatically installing software [the Automatically install so
 
 > Software cannot be added to "All teams."
 
-* Click the “Add Software” button in the top right corner. 
+* Click the “Add Software” button in the top right corner.
 
 * Select the "Custom package" tab.
 
@@ -50,7 +50,7 @@ Software installer uploads will fail if Fleet can't extract this metadata and ve
 - [.msi extractor code](https://github.com/fleetdm/fleet/blob/main/pkg/file/msi.go#:~:text=func%20ExtractMSIMetadata)
 - [.exe extractor code](https://github.com/fleetdm/fleet/blob/main/pkg/file/pe.go#:~:text=func%20ExtractPEMetadata)
 - [.deb extractor code](https://github.com/fleetdm/fleet/blob/main/pkg/file/deb.go#:~:text=func%20ExtractDebMetadata)
-- [.rpm extractor code](https://github.com/fleetdm/fleet/blob/main/pkg/file/rpm.go#:~:text=func%20ExtractRPMMetadata) 
+- [.rpm extractor code](https://github.com/fleetdm/fleet/blob/main/pkg/file/rpm.go#:~:text=func%20ExtractRPMMetadata)
 
 .tar.gz archives are uploaded as-is without attempting to pull metadata, and will be added successfully as long as they are valid archives.
 
@@ -97,6 +97,8 @@ After a software package is added to a team, it can be installed on hosts via th
     * Checking the status column in the host software table.
 
     * Navigate to the “Details” tab on the host details page and check the activity log.
+
+Once the package is installed, Fleet will automatically refetch the host's vitals and update the software inventory.
 
 ## Edit the package
 

--- a/articles/install-vpp-apps-on-macos-using-fleet.md
+++ b/articles/install-vpp-apps-on-macos-using-fleet.md
@@ -67,13 +67,15 @@ To add apps to Fleet, you must first purchase them through Apple Business Manage
 
 2. **Go to the host's detail page**: Click the "Hosts" tab in the main navigation menu. Filter the hosts by the team, and click the host's name to see its details page.
 
-3. **Find the app**: Click the **Software** -> **Library** tab on the host details page. Search for the software you added in the software table's search bar. Instead of searching, you can also filter software by clicking the **All software** dropdown and selecting **Available for install.**
+3. **Find the app**: Click the **Software** > **Library** tab on the host details page. Search for the software you added in the software table's search bar. Instead of searching, you can also filter software by clicking the **All software** dropdown and selecting **Available for install.**
 
 4. **Install the app**: Click the "Actions" dropdown on the far right of the app's entry in the
    table. Click "Install" to trigger an install. This action will send an MDM command to the host
    instructing it to install the app. If the host is offline, the upcoming install will show up in
-   the **Details** -> **Activity** -> **Upcoming** tab of this page. Once Fleet has verified
-   that the app is on the host, the app will show up as **Installed** in the **Software** -> **Library** tab.
+   the **Details** > **Activity** > **Upcoming** tab of this page. Once Fleet has verified
+   that the app is on the host, the app will show up as **Installed** in the **Software** > **Library** tab.
+   After the app is installed, Fleet will automatically refetch the host vitals, which will update the
+   software inventory.
 
 > Currently, VPP apps can't be uninstalled from devices via Fleet. Please see: [Uninstall App Store apps #20729](https://github.com/fleetdm/fleet/issues/20729).
 

--- a/articles/install-vpp-apps-on-macos-using-fleet.md
+++ b/articles/install-vpp-apps-on-macos-using-fleet.md
@@ -74,7 +74,7 @@ To add apps to Fleet, you must first purchase them through Apple Business Manage
    instructing it to install the app. If the host is offline, the upcoming install will show up in
    the **Details** > **Activity** > **Upcoming** tab of this page. Once Fleet has verified
    that the app is on the host, the app will show up as **Installed** in the **Software** > **Library** tab.
-   After the app is installed, Fleet will automatically refetch the host vitals, which will update the
+   After the app is installed, Fleet will automatically refetch the host's vitals, which will update the
    software inventory.
 
 > Currently, VPP apps can't be uninstalled from devices via Fleet. Please see: [Uninstall App Store apps #20729](https://github.com/fleetdm/fleet/issues/20729).

--- a/articles/install-vpp-apps-on-macos-using-fleet.md
+++ b/articles/install-vpp-apps-on-macos-using-fleet.md
@@ -100,7 +100,7 @@ banner at the top of page reminding you to renew your token. You can do this wit
 
 To remove VPP tokens from Fleet:
 
-1. **Navigate to the MDM integration settings page**: Click your avatar on the far right of the main navigation menu, and then **Settings > Integrations > "Mobile device management (MDM)"** Scroll to the "Volume Purchasing Program (VPP)" section, and click "Edit".
+1. **Navigate to the MDM integration settings page**: Click your avatar on the far right of the main navigation menu, and then **Settings > Integrations > "Mobile device management (MDM)"**. Scroll to the "Volume Purchasing Program (VPP)" section, and click "Edit".
 
 2. **Delete the token**: Find the VPP token that you want to delete in the table. Click the "Actions" dropdown for that token, and then click "Delete". Click "Delete" in the confirmation modal to finish deleting the token.
 

--- a/articles/install-vpp-apps-on-macos-using-fleet.md
+++ b/articles/install-vpp-apps-on-macos-using-fleet.md
@@ -67,15 +67,15 @@ To add apps to Fleet, you must first purchase them through Apple Business Manage
 
 2. **Go to the host's detail page**: Click the "Hosts" tab in the main navigation menu. Filter the hosts by the team, and click the host's name to see its details page.
 
-3. **Find the app**: Click the "Software" tab on the host details page. Search for the software you added in the software table's search bar. Instead of searching, you can also filter software by clicking the **All software** dropdown and selecting **Available for install.**
+3. **Find the app**: Click the **Software** -> **Library** tab on the host details page. Search for the software you added in the software table's search bar. Instead of searching, you can also filter software by clicking the **All software** dropdown and selecting **Available for install.**
 
 4. **Install the app**: Click the "Actions" dropdown on the far right of the app's entry in the
    table. Click "Install" to trigger an install. This action will send an MDM command to the host
    instructing it to install the app. If the host is offline, the upcoming install will show up in
-   the **Details** -> **Activity** -> **Upcoming** tab of this page. After the app is installed and
-   the host details are refetched, the app will show up as **Installed** in the **Software** tab.
+   the **Details** -> **Activity** -> **Upcoming** tab of this page. Once Fleet has verified
+   that the app is on the host, the app will show up as **Installed** in the **Software** -> **Library** tab.
 
-> Currently, VPP apps are installed as unmanaged, and can't be uninstalled from devices via Fleet. Please see: [Uninstall App Store apps #20729](https://github.com/fleetdm/fleet/issues/20729).
+> Currently, VPP apps can't be uninstalled from devices via Fleet. Please see: [Uninstall App Store apps #20729](https://github.com/fleetdm/fleet/issues/20729).
 
 ## Install an app via self-service
 
@@ -98,7 +98,7 @@ banner at the top of page reminding you to renew your token. You can do this wit
 
 To remove VPP tokens from Fleet:
 
-1. **Navigate to the MDM integration settings page**: Click your avatar on the far right of the main navigation menu, and then **Settings > Integrations > "Mobile device management (MDM)"** Scroll to the "Volume Purchasing Program (VPP)" section, and click "Edit". 
+1. **Navigate to the MDM integration settings page**: Click your avatar on the far right of the main navigation menu, and then **Settings > Integrations > "Mobile device management (MDM)"** Scroll to the "Volume Purchasing Program (VPP)" section, and click "Edit".
 
 2. **Delete the token**: Find the VPP token that you want to delete in the table. Click the "Actions" dropdown for that token, and then click "Delete". Click "Delete" in the confirmation modal to finish deleting the token.
 


### PR DESCRIPTION
# Checklist for submitter

> Closes #29896 
> Closes #30038

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Manual QA must be performed in the three main OSs, macOS, Windows and Linux.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated instructions to clarify that VPP apps appear in the **Software > Library** tab.
  * Improved descriptions regarding app installation status and uninstallation limitations for VPP apps.
  * Added notes that Fleet automatically refetches host vitals and updates software inventory after installations.
  * Made minor formatting and trailing whitespace adjustments for clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->