### PR TITLE
Fleet UI: Self service dropdown bug fix

### DIFF
--- a/frontend/pages/hosts/details/cards/HostSoftwareLibrary/HostSoftwareLibraryTable/HostSoftwareLibraryTable.tsx
+++ b/frontend/pages/hosts/details/cards/HostSoftwareLibrary/HostSoftwareLibraryTable/HostSoftwareLibraryTable.tsx
@@ -82,7 +82,7 @@ const HostSoftwareLibraryTable = ({
         order_direction: newTableQuery.sortDirection,
         order_key: newTableQuery.sortHeader,
         page: changedParam === "pageIndex" ? newTableQuery.pageIndex : 0,
-        self_service: selfService ? "true" : undefined,
+        ...(selfService && { self_service: "true" }),
       };
 
       return newQueryParam;
@@ -122,7 +122,7 @@ const HostSoftwareLibraryTable = ({
       orderDirection: sortDirection,
       orderKey: sortHeader,
       page: 0, // resets page index
-      selfService: value === "selfService" || undefined,
+      ...(value === "selfService" && { selfService: true }),
     };
 
     router.replace(

--- a/frontend/pages/hosts/details/cards/HostSoftwareLibrary/HostSoftwareLibraryTable/HostSoftwareLibraryTable.tsx
+++ b/frontend/pages/hosts/details/cards/HostSoftwareLibrary/HostSoftwareLibraryTable/HostSoftwareLibraryTable.tsx
@@ -82,11 +82,12 @@ const HostSoftwareLibraryTable = ({
         order_direction: newTableQuery.sortDirection,
         order_key: newTableQuery.sortHeader,
         page: changedParam === "pageIndex" ? newTableQuery.pageIndex : 0,
+        self_service: selfService ? "true" : undefined,
       };
 
       return newQueryParam;
     },
-    []
+    [selfService]
   );
 
   // TODO: Look into useDebounceCallback with dependencies
@@ -121,7 +122,7 @@ const HostSoftwareLibraryTable = ({
       orderDirection: sortDirection,
       orderKey: sortHeader,
       page: 0, // resets page index
-      selfService: value === "selfService",
+      selfService: value === "selfService" || undefined,
     };
 
     router.replace(


### PR DESCRIPTION
## Issue
Closes #30514 (unreleased)

## Description
- `self_service` is a callback dependency because it's managed from the URL bar
- Other: Cleaned up URL params by removing `self_service` param is it is set to `false`

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Manual QA for all new/changed functionality



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of the self-service filter so that the self_service query parameter is only included when relevant, ensuring more accurate filtering based on user selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->