### PR TITLE
Update 1Password macOS version number to 8.11.0

### DIFF
--- a/it-and-security/lib/macos/policies/update-1password.yml
+++ b/it-and-security/lib/macos/policies/update-1password.yml
@@ -1,5 +1,5 @@
 - name: macOS - 1Password up to date
-  query: SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE name = '1Password.app') OR EXISTS (SELECT 1 FROM apps WHERE name = '1Password.app' AND version_compare(bundle_short_version, '8.10.82') >= 0);
+  query: SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE name = '1Password.app') OR EXISTS (SELECT 1 FROM apps WHERE name = '1Password.app' AND version_compare(bundle_short_version, '8.11.0') >= 0);
   critical: false
   description: The host may have an outdated version of 1Password, potentially risking security vulnerabilities or compatibility issues.
   resolution: Check for updates using 1Password's built-in update functionality or download the latest version from self-service. 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the minimum required version of 1Password for macOS to 8.11.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->