### PR TITLE
Added/updated host identity contributor docs.

### DIFF
--- a/docs/Contributing/reference/api-for-contributors.md
+++ b/docs/Contributing/reference/api-for-contributors.md
@@ -14,6 +14,7 @@
 - [Software](#software)
 - [Users](#users)
 - [Conditional access](#conditional-access)
+- [Host identity](#host-identity)
 
 > These endpoints are used by the Fleet UI, Fleet Desktop, and `fleetctl` clients and frequently change to reflect current functionality.
 
@@ -4988,3 +4989,21 @@ See the [Google documentation for enterprises.delete](https://developers.google.
 ```json
 {}
 ```
+
+---
+
+## Host identity
+
+### SCEP
+
+`/api/fleet/orbit/host_identity/scep`
+
+This endpoint is used to retrieve a host identity certificate. It uses the [SCEP protocol](https://datatracker.ietf.org/doc/html/rfc8894).
+
+Supported certificate algorithms are:
+- ECC NIST P-384
+- ECC NIST P-256
+
+The common name (CN) of the certificate must be either the hardware UUID or osquery identity. Only one valid certificate can exist matching the host identifier.
+
+The SCEP challenge password must be the enrollment secret.


### PR DESCRIPTION
Fixes #30458 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated terminology and clarified details for TPM-backed HTTP signing, including alternate names, TPM ECC curve selection, and file naming conventions.
  * Added documentation for a new API endpoint to retrieve host identity certificates via SCEP, specifying supported algorithms and usage requirements.
  * Improved configuration guidance, troubleshooting steps, and expanded the list of planned future enhancements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->