### PR TITLE
28342: Do not report error if host already escrowed

### DIFF
--- a/changes/28342-linux-escrow-error-report
+++ b/changes/28342-linux-escrow-error-report
@@ -1,0 +1,1 @@
+* Fixed error when trying to escrow a linux disk key multiple times.

--- a/ee/server/service/devices.go
+++ b/ee/server/service/devices.go
@@ -170,6 +170,10 @@ func (svc *Service) TriggerLinuxDiskEncryptionEscrow(ctx context.Context, host *
 		return nil
 	}
 
+	if err := svc.ds.AssertHasNoEncryptionKeyStored(ctx, host.ID); err != nil {
+		return err
+	}
+
 	if err := svc.validateReadyForLinuxEscrow(ctx, host); err != nil {
 		_ = svc.ds.ReportEscrowError(ctx, host.ID, err.Error())
 		return err
@@ -216,5 +220,5 @@ func (svc *Service) validateReadyForLinuxEscrow(ctx context.Context, host *fleet
 		return &fleet.BadRequestError{Message: "Your version of fleetd does not support creating disk encryption keys on Linux. Please upgrade fleetd, then click Refetch, then try again."}
 	}
 
-	return svc.ds.AssertHasNoEncryptionKeyStored(ctx, host.ID)
+	return nil
 }


### PR DESCRIPTION
For #28342 

Do not report escrow error on a host page if the user clicks multiple times on the 'Create key' CTA on the 'My Device' page.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.
- [X] Added/updated automated tests
- [X] Manual QA for all new/changed functionality


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue where attempting to escrow a Linux disk key multiple times could result in an error.

* **Tests**
  * Added a dedicated test to verify correct error handling when a Linux disk encryption key is already escrowed.
  * Improved test coverage and organization for Linux disk encryption escrow scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->