### PR TITLE
Fixed panic caused by missing SSO settings in gitops generate

### DIFF
--- a/changes/30621-generate-gitops-no-sso
+++ b/changes/30621-generate-gitops-no-sso
@@ -1,0 +1,1 @@
+- Fixed fleetctl panic caused by missing SSO settings during gitops generate

--- a/cmd/fleetctl/fleetctl/generate_gitops.go
+++ b/cmd/fleetctl/fleetctl/generate_gitops.go
@@ -628,10 +628,15 @@ func (cmd *GenerateGitopsCommand) generateOrgSettings() (orgSettings map[string]
 	if (orgSettings)[jsonFieldName(t, "SSOSettings")], err = cmd.generateSSOSettings(cmd.AppConfig.SSOSettings); err != nil {
 		return nil, err
 	}
+
 	return orgSettings, nil
 }
 
 func (cmd *GenerateGitopsCommand) generateSSOSettings(ssoSettings *fleet.SSOSettings) (map[string]interface{}, error) {
+	if ssoSettings == nil {
+		return map[string]any{}, nil
+	}
+
 	t := reflect.TypeOf(fleet.SSOSettings{})
 	result := map[string]interface{}{
 		jsonFieldName(t, "EnableSSO"):         ssoSettings.EnableSSO,

--- a/cmd/fleetctl/fleetctl/generate_gitops_test.go
+++ b/cmd/fleetctl/fleetctl/generate_gitops_test.go
@@ -591,6 +591,36 @@ func TestGenerateOrgSettings(t *testing.T) {
 	require.Equal(t, expectedAppConfig, orgSettings)
 }
 
+func TestGeneratedOrgSettingsNoSSO(t *testing.T) {
+	// Get the test app config.
+	fleetClient := &MockClient{}
+	appConfig, err := fleetClient.GetAppConfig()
+	require.NoError(t, err)
+
+	appConfig.SSOSettings = nil
+
+	// Create the command.
+	cmd := &GenerateGitopsCommand{
+		Client:       fleetClient,
+		CLI:          cli.NewContext(&cli.App{}, nil, nil),
+		Messages:     Messages{},
+		FilesToWrite: make(map[string]interface{}),
+		AppConfig:    appConfig,
+	}
+
+	// Generate the org settings.
+	// Note that nested keys here may be strings,
+	// so we'll JSON marshal and unmarshal to a map for comparison.
+	orgSettingsRaw, err := cmd.generateOrgSettings()
+	require.NoError(t, err)
+	require.NotNil(t, orgSettingsRaw)
+	var orgSettings map[string]any
+	b, err := yaml.Marshal(orgSettingsRaw)
+	require.NoError(t, err)
+	err = yaml.Unmarshal(b, &orgSettings)
+	require.NoError(t, err)
+}
+
 func TestGenerateOrgSettingsInsecure(t *testing.T) {
 	// Get the test app config.
 	fleetClient := &MockClient{}


### PR DESCRIPTION
#30621 

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.
- [x] Added/updated automated tests
- [x] Manual QA for all new/changed functionality


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue where generating GitOps configurations without Single Sign-On (SSO) settings could cause the tool to crash.

* **Tests**
  * Added a test to ensure GitOps configuration generation works correctly when SSO settings are missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->