### PR TITLE
Use install path on packageInfo XML if it's a .app before falling back to bundle ID for PKG name extraction

### DIFF
--- a/changes/25587-pkg-name-extraction
+++ b/changes/25587-pkg-name-extraction
@@ -1,0 +1,1 @@
+* Added a fallback to package install path for extracting app names from uploaded PKG packages

--- a/pkg/file/testdata/packageInfo/packageinfo-subEthaEdit-modded.xml
+++ b/pkg/file/testdata/packageInfo/packageinfo-subEthaEdit-modded.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="utf-8"?>
+<pkg-info overwrite-permissions="true" relocatable="false" identifier="de.codingmonkeys.SubEthaEdit.MacFULL" postinstall-action="none" version="5.2.4" format-version="2" generator-version="InstallCmds-860 (24B91)" install-location="/Applications/SubEthaEdit.app" auth="root">
+</pkg-info>

--- a/pkg/file/xar.go
+++ b/pkg/file/xar.go
@@ -565,6 +565,12 @@ func getPackageInfo(p *packageInfoXML) (name string, identifier string, version 
 		identifier = fleet.Preprocess(p.Identifier)
 	}
 
+	// if we didn't find a name and the install path looks like a .app, try using that
+	if name == "" && strings.HasSuffix(p.InstallLocation, ".app") {
+		pathParts := strings.Split(p.InstallLocation, "/")
+		name = strings.TrimSuffix(pathParts[len(pathParts)-1], ".app")
+	}
+
 	// if we didn't find a name, grab the name from the identifier
 	if name == "" {
 		idParts := strings.Split(identifier, ".")

--- a/pkg/file/xar_test.go
+++ b/pkg/file/xar_test.go
@@ -264,6 +264,13 @@ func TestParsePackageInfoFiles(t *testing.T) {
 			},
 		},
 		{
+			file:               "packageInfo-subEthaEdit-modded.xml",
+			expectedName:       "SubEthaEdit",
+			expectedVersion:    "5.2.4",
+			expectedBundleID:   "de.codingmonkeys.SubEthaEdit.MacFULL",
+			expectedPackageIDs: []string{"de.codingmonkeys.SubEthaEdit.MacFULL"},
+		},
+		{
 			file:               "packageInfo-scriptOnly.xml",
 			expectedName:       "HelloWorld",
 			expectedVersion:    "1.2.3",

--- a/pkg/file/xar_test.go
+++ b/pkg/file/xar_test.go
@@ -264,7 +264,7 @@ func TestParsePackageInfoFiles(t *testing.T) {
 			},
 		},
 		{
-			file:               "packageInfo-subEthaEdit-modded.xml",
+			file:               "packageinfo-subEthaEdit-modded.xml",
 			expectedName:       "SubEthaEdit",
 			expectedVersion:    "5.2.4",
 			expectedBundleID:   "de.codingmonkeys.SubEthaEdit.MacFULL",


### PR DESCRIPTION
Fixes #25587. SubEthaEdit packgeInfo file is a bit bigger, but the only thing different is the list of package IDs included, and that's not what was broken/fixed here, so went with an abbreviated version that better demonstrates what got fixed here.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.
- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [x] Added/updated automated tests
- [x] Manual QA for all new/changed functionality

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved extraction of application names from uploaded PKG packages by using the install path as a fallback method.

* **Tests**
  * Added a new test case to verify correct name extraction from PKG packages using the install path.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->