### PR TITLE
Update changelog for fleetd 1.45.0 release

### DIFF
--- a/orbit/CHANGELOG.md
+++ b/orbit/CHANGELOG.md
@@ -1,15 +1,14 @@
 ## Orbit 1.45.0 (Jul 09, 2025)
 
-* Added feature for showing an informational message on fleet desktop if host becomes offline.
+* Added feature for showing an informational message on Fleet Desktop if the host cannot connect to Fleet.
 
 * Added new flag `--fleet-certificate` to `sudo orbit shell` command (which sets osquery's `--tls_server_certs` flag).
 
-* Fixed issue with macOS MDM migration where fleetd did not fallback to parsing the
-  `ConfigurationURL` when `ConfigurationWebURL` was not set in the MDM enrollment profile.
+* Fixed issue with macOS MDM migration where fleetd did not fallback to parsing the `ConfigurationURL` when `ConfigurationWebURL` was not set in the MDM enrollment profile.
 
 * Added the `macos_user_profiles` osquery extension table on darwin.
 
-* Fixed an issue where Orbit would attempt to launch Fleet Desktop on Linux systems without a logged-in GUI user
+* Fixed an issue where Orbit would attempt to launch Fleet Desktop on Linux systems without a logged-in GUI user.
 
 ## Orbit 1.44.0 (Jun 26, 2025)
 

--- a/orbit/CHANGELOG.md
+++ b/orbit/CHANGELOG.md
@@ -1,3 +1,16 @@
+## Orbit 1.45.0 (Jul 09, 2025)
+
+* Added feature for showing an informational message on fleet desktop if host becomes offline.
+
+* Added new flag `--fleet-certificate` to `sudo orbit shell` command (which sets osquery's `--tls_server_certs` flag).
+
+* Fixed issue with macOS MDM migration where fleetd did not fallback to parsing the
+  `ConfigurationURL` when `ConfigurationWebURL` was not set in the MDM enrollment profile.
+
+* Added the `macos_user_profiles` osquery extension table on darwin.
+
+* Fixed an issue where Orbit would attempt to launch Fleet Desktop on Linux systems without a logged-in GUI user
+
 ## Orbit 1.44.0 (Jun 26, 2025)
 
 * Added `app_sso_platform` table to get Platform SSO extensions state information.

--- a/orbit/changes/21277-offline-indicator
+++ b/orbit/changes/21277-offline-indicator
@@ -1,1 +1,0 @@
-* Added feature for showing an informational message on fleet desktop if host becomes offline.

--- a/orbit/changes/27905-provide-tls-path-on-orbit-shell
+++ b/orbit/changes/27905-provide-tls-path-on-orbit-shell
@@ -1,1 +1,0 @@
-* Added new flag `--fleet-certificate` to `sudo orbit shell` command (which sets osquery's `--tls_server_certs` flag).

--- a/orbit/changes/29869-add-macos-user-profiles-extension-table
+++ b/orbit/changes/29869-add-macos-user-profiles-extension-table
@@ -1,1 +1,0 @@
-* Added the `macos_user_profiles` osquery extension table on darwin.

--- a/orbit/changes/29942-dont-launch-desktop-on-linux-incorrectly
+++ b/orbit/changes/29942-dont-launch-desktop-on-linux-incorrectly
@@ -1,1 +1,0 @@
-- Fixed an issue where Orbit would attempt to launch Fleet Desktop on Linux systems without a logged-in GUI user

--- a/orbit/changes/30372-darwin-profiles-parser
+++ b/orbit/changes/30372-darwin-profiles-parser
@@ -1,2 +1,0 @@
-- Fixed issue with macOS MDM migration where fleetd did not fallback to parsing the
-  `ConfigurationURL` when `ConfigurationWebURL` was not set in the MDM enrollment profile.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * None

* **Bug Fixes**
  * None

* **Removals**
  * Removed the offline status message on Fleet Desktop.
  * Removed the --fleet-certificate flag from the sudo orbit shell command.
  * Removed the macos_user_profiles osquery extension table for macOS.
  * Removed the fix preventing Fleet Desktop from launching incorrectly on Linux without a logged-in GUI user.
  * Removed the macOS MDM migration fallback for ConfigurationURL parsing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->