### PR TITLE
Fix `fleetctl generate-gitops` when MDM is turned off

### DIFF
--- a/cmd/fleetctl/fleetctl/generate_gitops.go
+++ b/cmd/fleetctl/fleetctl/generate_gitops.go
@@ -806,10 +806,14 @@ func (cmd *GenerateGitopsCommand) generateMDM(mdm *fleet.MDM) (map[string]interf
 		result[jsonFieldName(t, "AppleBusinessManager")] = mdm.AppleBusinessManager
 		result[jsonFieldName(t, "VolumePurchasingProgram")] = mdm.VolumePurchasingProgram
 
-		eulaPath, err := cmd.generateEULA()
-		if err != nil {
-			fmt.Fprintf(cmd.CLI.App.ErrWriter, "Error generating EULA: %s\n", err)
-			return nil, err
+		var eulaPath string
+		if cmd.AppConfig.MDM.EnabledAndConfigured {
+			var err error
+			eulaPath, err = cmd.generateEULA()
+			if err != nil {
+				fmt.Fprintf(cmd.CLI.App.ErrWriter, "Error generating EULA: %s\n", err)
+				return nil, err
+			}
 		}
 		result[jsonFieldName(t, "EndUserLicenseAgreement")] = eulaPath
 	}
@@ -884,20 +888,22 @@ func (cmd *GenerateGitopsCommand) generateControls(teamId *uint, teamName string
 		result[jsonFieldName(t, "Scripts")] = scripts
 	}
 
-	profiles, err := cmd.generateProfiles(teamId, teamName)
-	if err != nil {
-		fmt.Fprintf(cmd.CLI.App.ErrWriter, "Error generating profiles: %s\n", err)
-		return nil, err
-	}
-	if profiles != nil {
-		if len(profiles["apple_profiles"].([]map[string]interface{})) > 0 {
-			result[jsonFieldName(t, "MacOSSettings")] = map[string]interface{}{
-				"custom_settings": profiles["apple_profiles"],
-			}
+	if cmd.AppConfig.MDM.EnabledAndConfigured {
+		profiles, err := cmd.generateProfiles(teamId, teamName)
+		if err != nil {
+			fmt.Fprintf(cmd.CLI.App.ErrWriter, "Error generating profiles: %s\n", err)
+			return nil, err
 		}
-		if len(profiles["windows_profiles"].([]map[string]interface{})) > 0 {
-			result[jsonFieldName(t, "WindowsSettings")] = map[string]interface{}{
-				"custom_settings": profiles["windows_profiles"],
+		if profiles != nil {
+			if len(profiles["apple_profiles"].([]map[string]interface{})) > 0 {
+				result[jsonFieldName(t, "MacOSSettings")] = map[string]interface{}{
+					"custom_settings": profiles["apple_profiles"],
+				}
+			}
+			if len(profiles["windows_profiles"].([]map[string]interface{})) > 0 {
+				result[jsonFieldName(t, "WindowsSettings")] = map[string]interface{}{
+					"custom_settings": profiles["windows_profiles"],
+				}
 			}
 		}
 	}
@@ -922,7 +928,7 @@ func (cmd *GenerateGitopsCommand) generateControls(teamId *uint, teamName string
 			result["windows_enabled_and_configured"] = cmd.AppConfig.MDM.WindowsEnabledAndConfigured
 		}
 
-		if teamId != nil {
+		if teamId != nil && cmd.AppConfig.MDM.EnabledAndConfigured {
 			// See if the team has macOS setup software configured.
 			setupSoftware, err := cmd.Client.GetSetupExperienceSoftware(*teamId)
 			if err != nil {
@@ -980,10 +986,6 @@ func (cmd *GenerateGitopsCommand) generateProfiles(teamId *uint, teamName string
 	// Get profiles.
 	profiles, err := cmd.Client.ListConfigurationProfiles(teamId)
 	if err != nil {
-		if strings.Contains(err.Error(), fleet.MDMNotConfiguredMessage) {
-			return nil, nil
-		}
-
 		fmt.Fprintf(cmd.CLI.App.ErrWriter, "Error getting profiles: %v\n", err)
 		return nil, err
 	}

--- a/cmd/fleetctl/fleetctl/generate_gitops_test.go
+++ b/cmd/fleetctl/fleetctl/generate_gitops_test.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/fleetdm/fleet/v4/pkg/optjson"
 	"github.com/fleetdm/fleet/v4/server/fleet"
 	"github.com/fleetdm/fleet/v4/server/ptr"
 	"github.com/ghodss/yaml"
@@ -93,6 +94,8 @@ func (MockClient) ListScripts(query string) ([]*fleet.Script, error) {
 			ScriptContentID: 3,
 		}}, nil
 	case "team_id=2", "team_id=3", "team_id=4", "team_id=5":
+		return nil, nil
+	case "team_id=6":
 		return nil, nil
 	default:
 		return nil, fmt.Errorf("unexpected query: %s", query)
@@ -1120,4 +1123,49 @@ func verifyControlsHasMacosSetup(t *testing.T, controlsRaw map[string]interface{
 	macosSetup, ok := controlsRaw["macos_setup"].(string)
 	require.True(t, ok, "Expected macos_setup section to be a string")
 	require.Equal(t, macosSetup, "TODO: update with your macos_setup configuration")
+}
+
+func TestGenerateControlsAndMDMWithoutMDMEnabledAndConfigured(t *testing.T) {
+	// Get the test app config.
+	fleetClient := &MockClient{}
+	appConfig, err := fleetClient.GetAppConfig()
+	require.NoError(t, err)
+	appConfig.MDM.EnabledAndConfigured = false
+	appConfig.MDM.WindowsEnabledAndConfigured = false
+	appConfig.MDM.AppleBusinessManager = optjson.Slice[fleet.MDMAppleABMAssignmentInfo]{}
+	appConfig.MDM.AppleServerURL = ""
+	appConfig.MDM.EndUserAuthentication = fleet.MDMEndUserAuthentication{}
+	appConfig.MDM.VolumePurchasingProgram = optjson.Slice[fleet.MDMAppleVolumePurchasingProgramInfo]{}
+
+	// Create the command.
+	cmd := &GenerateGitopsCommand{
+		Client:       fleetClient,
+		CLI:          cli.NewContext(cli.NewApp(), nil, nil),
+		Messages:     Messages{},
+		FilesToWrite: make(map[string]interface{}),
+		AppConfig:    appConfig,
+		ScriptList:   make(map[uint]string),
+	}
+	// teamId=6 is unhandled for MDM APIs to make sure the APIs to get MDM stuff
+	// aren't called if MDM is not enabled and configured.
+	controlsRaw, err := cmd.generateControls(ptr.Uint(6), "some_team", nil)
+	require.NoError(t, err)
+	require.Contains(t, controlsRaw, "scripts") // Uploading scripts does not require MDM turned on.
+	require.Empty(t, controlsRaw["scripts"])
+
+	// teamId=6 is unhandled for MDM APIs to make sure the APIs to get MDM stuff
+	// aren't called if MDM is not enabled and configured.
+	mdmRaw, err := cmd.generateMDM(&appConfig.MDM)
+	require.NoError(t, err)
+	// Verify all keys are set to empty.
+	for _, key := range []string{
+		"apple_business_manager",
+		"apple_server_url",
+		"end_user_authentication",
+		"end_user_license_agreement",
+		"volume_purchasing_program",
+	} {
+		require.Contains(t, mdmRaw, key)
+		require.Empty(t, mdmRaw[key])
+	}
 }


### PR DESCRIPTION
For unreleased bug #30656.

- [X] Added/updated automated tests
- [X] Manual QA for all new/changed functionality
- [X] For unreleased bug fixes in a release candidate, confirmed that the fix is not expected to adversely impact load test results or alerted the release DRI if additional load testing is needed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling to ensure MDM-related data is only generated when MDM is enabled and properly configured.
  * Errors related to MDM configuration are now surfaced instead of being silently ignored.

* **Tests**
  * Added new tests to verify correct behavior when MDM is disabled and not configured, ensuring empty or minimal outputs for MDM-related data in this scenario.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->