### PR TITLE
Cherry pick for fix `fleetctl generate-gitops` when MDM is turned off (#30677)

### DIFF
--- a/cmd/fleetctl/fleetctl/generate_gitops.go
+++ b/cmd/fleetctl/fleetctl/generate_gitops.go
@@ -801,10 +801,14 @@ func (cmd *GenerateGitopsCommand) generateMDM(mdm *fleet.MDM) (map[string]interf
 		result[jsonFieldName(t, "AppleBusinessManager")] = mdm.AppleBusinessManager
 		result[jsonFieldName(t, "VolumePurchasingProgram")] = mdm.VolumePurchasingProgram
 
-		eulaPath, err := cmd.generateEULA()
-		if err != nil {
-			fmt.Fprintf(cmd.CLI.App.ErrWriter, "Error generating EULA: %s\n", err)
-			return nil, err
+		var eulaPath string
+		if cmd.AppConfig.MDM.EnabledAndConfigured {
+			var err error
+			eulaPath, err = cmd.generateEULA()
+			if err != nil {
+				fmt.Fprintf(cmd.CLI.App.ErrWriter, "Error generating EULA: %s\n", err)
+				return nil, err
+			}
 		}
 		result[jsonFieldName(t, "EndUserLicenseAgreement")] = eulaPath
 	}
@@ -879,20 +883,22 @@ func (cmd *GenerateGitopsCommand) generateControls(teamId *uint, teamName string
 		result[jsonFieldName(t, "Scripts")] = scripts
 	}
 
-	profiles, err := cmd.generateProfiles(teamId, teamName)
-	if err != nil {
-		fmt.Fprintf(cmd.CLI.App.ErrWriter, "Error generating profiles: %s\n", err)
-		return nil, err
-	}
-	if profiles != nil {
-		if len(profiles["apple_profiles"].([]map[string]interface{})) > 0 {
-			result[jsonFieldName(t, "MacOSSettings")] = map[string]interface{}{
-				"custom_settings": profiles["apple_profiles"],
-			}
+	if cmd.AppConfig.MDM.EnabledAndConfigured {
+		profiles, err := cmd.generateProfiles(teamId, teamName)
+		if err != nil {
+			fmt.Fprintf(cmd.CLI.App.ErrWriter, "Error generating profiles: %s\n", err)
+			return nil, err
 		}
-		if len(profiles["windows_profiles"].([]map[string]interface{})) > 0 {
-			result[jsonFieldName(t, "WindowsSettings")] = map[string]interface{}{
-				"custom_settings": profiles["windows_profiles"],
+		if profiles != nil {
+			if len(profiles["apple_profiles"].([]map[string]interface{})) > 0 {
+				result[jsonFieldName(t, "MacOSSettings")] = map[string]interface{}{
+					"custom_settings": profiles["apple_profiles"],
+				}
+			}
+			if len(profiles["windows_profiles"].([]map[string]interface{})) > 0 {
+				result[jsonFieldName(t, "WindowsSettings")] = map[string]interface{}{
+					"custom_settings": profiles["windows_profiles"],
+				}
 			}
 		}
 	}
@@ -917,7 +923,7 @@ func (cmd *GenerateGitopsCommand) generateControls(teamId *uint, teamName string
 			result["windows_enabled_and_configured"] = cmd.AppConfig.MDM.WindowsEnabledAndConfigured
 		}
 
-		if teamId != nil {
+		if teamId != nil && cmd.AppConfig.MDM.EnabledAndConfigured {
 			// See if the team has macOS setup software configured.
 			setupSoftware, err := cmd.Client.GetSetupExperienceSoftware(*teamId)
 			if err != nil {
@@ -975,10 +981,6 @@ func (cmd *GenerateGitopsCommand) generateProfiles(teamId *uint, teamName string
 	// Get profiles.
 	profiles, err := cmd.Client.ListConfigurationProfiles(teamId)
 	if err != nil {
-		if strings.Contains(err.Error(), fleet.MDMNotConfiguredMessage) {
-			return nil, nil
-		}
-
 		fmt.Fprintf(cmd.CLI.App.ErrWriter, "Error getting profiles: %v\n", err)
 		return nil, err
 	}


### PR DESCRIPTION
For unreleased bug #30656.

- [X] Added/updated automated tests
- [X] Manual QA for all new/changed functionality
- [X] For unreleased bug fixes in a release candidate, confirmed that the fix is not expected to adversely impact load test results or alerted the release DRI if additional load testing is needed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
* Improved handling to ensure MDM-related data is only generated when MDM is enabled and properly configured.
* Errors related to MDM configuration are now surfaced instead of being silently ignored.

* **Tests**
* Added new tests to verify correct behavior when MDM is disabled and not configured, ensuring empty or minimal outputs for MDM-related data in this scenario.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->