### PR TITLE
Default to Details tab on device page

### DIFF
--- a/changes/30653-host-details-default-tab
+++ b/changes/30653-host-details-default-tab
@@ -1,0 +1,1 @@
+- Fixed Details not showing up when the device page URL was edited

--- a/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
@@ -878,10 +878,12 @@ const HostDetailsPage = ({
   ];
 
   const getTabIndex = (path: string): number => {
-    return hostDetailsSubNav.findIndex((navItem) => {
+    const selected = hostDetailsSubNav.findIndex((navItem) => {
       // tab stays highlighted for paths that ends with same pathname
       return path.startsWith(navItem.pathname);
     });
+    // If our URL doesn't match anything, return the first (Details) tab by default
+    return selected === -1 ? 0 : selected;
   };
 
   const getSoftwareTabIndex = (path: string): number => {

--- a/frontend/router/index.tsx
+++ b/frontend/router/index.tsx
@@ -252,6 +252,7 @@ const routes = (
               component={ManageHostsPage}
             />
             <Route path=":host_id" component={HostDetailsPage}>
+              <IndexRedirect to="details" />
               <Redirect from="schedule" to="queries" />
               <Route path="details" component={HostDetailsPage} />
               <Route path="scripts" component={HostDetailsPage} />


### PR DESCRIPTION
#30653

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.
- [x] Manual QA for all new/changed functionality
