### PR TITLE
Fix STS assume role in `aws-sdk-go` v2

### DIFF
--- a/docs/Contributing/getting-started/testing-and-local-development.md
+++ b/docs/Contributing/getting-started/testing-and-local-development.md
@@ -649,6 +649,9 @@ Similarly, create a `firehose_skeleton_status.json` file to create the delivery 
   ]
 }
 ```
+```sh
+awslocal firehose create-delivery-stream --cli-input-json file://$(pwd)/firehose_skeleton_status.json
+```
 
 After applying such configuration, "result" logs will be stored under the `results/` prefix and "status" logs will be stored under `status/` prefix (both on the `s3-firehose` bucket).
 

--- a/server/aws_common/aws_common.go
+++ b/server/aws_common/aws_common.go
@@ -1,0 +1,40 @@
+// Package aws_common contains common functionality used
+// by packages that use AWS features (kinesis, firehose, ses, lambda, s3)
+package aws_common
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	aws_config "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials/stscreds"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
+)
+
+// ConfigureAssumeRoleProvider configures the credential provider with a "Assume Role"
+// provider and returns a new aws.Config.
+//
+// It overrides any aws_config.WithCredentialsProvider set in opts.
+func ConfigureAssumeRoleProvider(
+	conf aws.Config,
+	opts []func(*aws_config.LoadOptions) error,
+	stsAssumeRoleARN,
+	stsExternalID string,
+) (aws.Config, error) {
+	stsClient := sts.NewFromConfig(conf)
+	credsProvider := stscreds.NewAssumeRoleProvider(stsClient, stsAssumeRoleARN, func(r *stscreds.AssumeRoleOptions) {
+		if stsExternalID != "" {
+			r.ExternalID = &stsExternalID
+		}
+	})
+	// Overrides any previous aws_config.WithCredentialsProvider set in opts.
+	opts = append(opts,
+		aws_config.WithCredentialsProvider(credsProvider),
+	)
+	conf, err := aws_config.LoadDefaultConfig(context.Background(), opts...)
+	if err != nil {
+		return aws.Config{}, fmt.Errorf("failed to create default config with sts assume role: %w", err)
+	}
+	return conf, nil
+}

--- a/server/mail/ses.go
+++ b/server/mail/ses.go
@@ -9,9 +9,9 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	aws_config "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/credentials"
-	"github.com/aws/aws-sdk-go-v2/credentials/stscreds"
 	"github.com/aws/aws-sdk-go-v2/service/ses"
 	"github.com/aws/aws-sdk-go-v2/service/ses/types"
+	"github.com/fleetdm/fleet/v4/server/aws_common"
 	"github.com/fleetdm/fleet/v4/server/fleet"
 )
 
@@ -70,20 +70,17 @@ func NewSESSender(region, endpointURL, id, secret, stsAssumeRoleArn, stsExternal
 		)
 	}
 
-	// cfg.StsAssumeRoleArn has been marked as deprecated, but we still set it in case users are using it.
-	if stsAssumeRoleArn != "" {
-		opts = append(opts, aws_config.WithAssumeRoleCredentialOptions(func(r *stscreds.AssumeRoleOptions) {
-			r.RoleARN = stsAssumeRoleArn
-			if stsExternalID != "" {
-				r.ExternalID = &stsExternalID
-			}
-		}))
-	}
-
 	opts = append(opts, aws_config.WithRegion(region))
 	conf, err := aws_config.LoadDefaultConfig(context.Background(), opts...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create default config: %w", err)
+	}
+
+	if stsAssumeRoleArn != "" {
+		conf, err = aws_common.ConfigureAssumeRoleProvider(conf, opts, stsAssumeRoleArn, stsExternalID)
+		if err != nil {
+			return nil, fmt.Errorf("failed to configure assume role provider: %w", err)
+		}
 	}
 
 	sesClient := ses.NewFromConfig(conf)


### PR DESCRIPTION
Fix unreleased bug #30693.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated testing documentation to include a missing command for creating the Firehose delivery stream for "status" logs.
* **Refactor**
  * Centralized AWS STS Assume Role credential configuration across multiple AWS integrations (S3, Firehose, Kinesis, Lambda, SES) to use a shared helper, improving maintainability and consistency.
  * Removed deprecated inline credential configuration logic in favor of the new centralized approach.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->