### PR TITLE
Remove five character requirement for entity id in SSO and IdP settings 

### DIFF
--- a/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/AppleMdmPage/components/content/ApplePushCertSetup.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/AppleMdmPage/components/content/ApplePushCertSetup.tsx
@@ -89,6 +89,7 @@ const ApplePushCertSetup = ({
                 newTab
               />
               <br />
+              <br />
               If you don&apos;t have an Apple ID, select <b>Create yours now</b>
               .
             </span>

--- a/frontend/pages/admin/IntegrationsPage/cards/Sso/Sso.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/Sso/Sso.tsx
@@ -69,10 +69,6 @@ const validate = (formData: ISsoFormData) => {
       errors.entity_id = "Entity ID must be present";
     }
 
-    if (typeof entityId === "string" && entityId.length < 5) {
-      errors.entity_id = "Entity ID must be 5 or more characters";
-    }
-
     if (!idpName) {
       errors.idp_name = "Identity provider name must be present";
     }

--- a/frontend/utilities/date_format/index.ts
+++ b/frontend/utilities/date_format/index.ts
@@ -1,4 +1,5 @@
-import { format, formatDistanceToNow } from "date-fns";
+import { format, formatDistanceToNow, parseISO } from "date-fns";
+import { formatInTimeZone } from "date-fns-tz";
 
 /** Utility to create a string from a date in this format:
   `Uploaded .... ago`
@@ -30,5 +31,5 @@ export const dateAgo = (date: string | Date) => {
  * @example "January 01, 2024"
  */
 export const monthDayYearFormat = (date: string) => {
-  return format(date, "MMMM d, yyyy");
+  return formatInTimeZone(parseISO(date), "UTC", "MMMM d, yyyy");
 };

--- a/server/service/appconfig.go
+++ b/server/service/appconfig.go
@@ -1941,8 +1941,6 @@ func validateSSOProviderSettings(incoming, existing fleet.SSOProviderSettings, i
 		if existing.EntityID == "" {
 			invalid.Append("entity_id", "required")
 		}
-	} else if len(incoming.EntityID) < 5 {
-		invalid.Append("entity_id", "must be 5 or more characters")
 	}
 	if incoming.IDPName == "" {
 		if existing.IDPName == "" {

--- a/server/service/appconfig_test.go
+++ b/server/service/appconfig_test.go
@@ -1120,6 +1120,7 @@ func TestMDMAppleConfig(t *testing.T) {
 				WindowsSettings: fleet.WindowsSettings{
 					CustomSettings: optjson.Slice[fleet.MDMProfileSpec]{Set: true, Value: []fleet.MDMProfileSpec{}},
 				},
+				RequireBitLockerPIN: optjson.Bool{Set: true, Value: false},
 			},
 		}, {
 			name:        "ssoMissingMetadata",

--- a/server/service/appconfig_test.go
+++ b/server/service/appconfig_test.go
@@ -1097,7 +1097,30 @@ func TestMDMAppleConfig(t *testing.T) {
 				MetadataURL: "http://isser.metadata.com",
 				IDPName:     "onelogin",
 			}}},
-			expectedError: "validation failed: entity_id must be 5 or more characters",
+			expectedMDM: fleet.MDM{
+				AppleBusinessManager: optjson.Slice[fleet.MDMAppleABMAssignmentInfo]{Set: true, Value: []fleet.MDMAppleABMAssignmentInfo{}},
+				EndUserAuthentication: fleet.MDMEndUserAuthentication{SSOProviderSettings: fleet.SSOProviderSettings{
+					EntityID:    "f",
+					MetadataURL: "http://isser.metadata.com",
+					IDPName:     "onelogin",
+				}},
+				MacOSSetup: fleet.MacOSSetup{
+					BootstrapPackage:            optjson.String{Set: true},
+					MacOSSetupAssistant:         optjson.String{Set: true},
+					EnableReleaseDeviceManually: optjson.SetBool(false),
+					Software:                    optjson.Slice[*fleet.MacOSSetupSoftware]{Set: true, Value: []*fleet.MacOSSetupSoftware{}},
+					Script:                      optjson.String{Set: true},
+					ManualAgentInstall:          optjson.Bool{Set: true},
+				},
+				MacOSUpdates:            fleet.AppleOSUpdateSettings{MinimumVersion: optjson.String{Set: true}, Deadline: optjson.String{Set: true}},
+				IOSUpdates:              fleet.AppleOSUpdateSettings{MinimumVersion: optjson.String{Set: true}, Deadline: optjson.String{Set: true}},
+				IPadOSUpdates:           fleet.AppleOSUpdateSettings{MinimumVersion: optjson.String{Set: true}, Deadline: optjson.String{Set: true}},
+				VolumePurchasingProgram: optjson.Slice[fleet.MDMAppleVolumePurchasingProgramInfo]{Set: true, Value: []fleet.MDMAppleVolumePurchasingProgramInfo{}},
+				WindowsUpdates:          fleet.WindowsUpdates{DeadlineDays: optjson.Int{Set: true}, GracePeriodDays: optjson.Int{Set: true}},
+				WindowsSettings: fleet.WindowsSettings{
+					CustomSettings: optjson.Slice[fleet.MDMProfileSpec]{Set: true, Value: []fleet.MDMProfileSpec{}},
+				},
+			},
 		}, {
 			name:        "ssoMissingMetadata",
 			licenseTier: "premium",


### PR DESCRIPTION
For #29512

- **Remove length validation for entity id input**
- **Remove unneeded test**
- **Remove backend character validation, remove from SSO form**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed the minimum length requirement for the "Entity ID" field in SSO configuration forms and validation. Only presence is now required.
  * Updated related error messages and validation behaviors to reflect this change.

* **Style**
  * Adjusted spacing in Apple MDM push certificate setup instructions for improved readability.

* **Tests**
  * Updated and removed tests related to the "Entity ID" minimum length validation to align with new validation rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->