### PR TITLE
Fix OS vulnerability expiration due to avoiding updating updated_at, while avoiding test flakiness

### DIFF
--- a/changes/29988-os-vulns-flakiness
+++ b/changes/29988-os-vulns-flakiness
@@ -1,0 +1,1 @@
+* Fixed cases where valid operating system vulnerabilities would be periodically incorrectly purged


### PR DESCRIPTION
Fixes #29988.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.
- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [x] Added/updated automated tests
- [x] Manual QA for all new/changed functionality