### PR TITLE
Website: Update policy and query library pages.

### DIFF
--- a/website/api/controllers/view-policy-library.js
+++ b/website/api/controllers/view-policy-library.js
@@ -24,19 +24,19 @@ module.exports = {
     }
     let policies = _.where(sails.config.builtStaticContent.policies, {kind: 'policy'});
     let macOsPolicies = _.filter(policies, (policy)=>{
-      let platformsForThisPolicy = policy.platform.split(',');
+      let platformsForThisPolicy = policy.platform.split(', ');
       return _.includes(platformsForThisPolicy, 'darwin');
     });
     let windowsPolicies = _.filter(policies, (policy)=>{
-      let platformsForThisPolicy = policy.platform.split(',');
+      let platformsForThisPolicy = policy.platform.split(', ');
       return _.includes(platformsForThisPolicy, 'windows');
     });
     let linuxPolicies = _.filter(policies, (policy)=>{
-      let platformsForThisPolicy = policy.platform.split(',');
+      let platformsForThisPolicy = policy.platform.split(', ');
       return _.includes(platformsForThisPolicy, 'linux');
     });
     let chromePolicies = _.filter(policies, (policy)=>{
-      let platformsForThisPolicy = policy.platform.split(',');
+      let platformsForThisPolicy = policy.platform.split(', ');
       return _.includes(platformsForThisPolicy, 'chrome');
     });
     // Respond with view.

--- a/website/api/controllers/view-query-library.js
+++ b/website/api/controllers/view-query-library.js
@@ -20,15 +20,15 @@ module.exports = {
     }
     let policies = _.where(sails.config.builtStaticContent.queries, {kind: 'query'});
     let macOsQueries = _.filter(policies, (policy)=>{
-      let platformsForThisPolicy = policy.platform.split(',');
+      let platformsForThisPolicy = policy.platform.split(', ');
       return _.includes(platformsForThisPolicy, 'darwin');
     });
     let windowsQueries = _.filter(policies, (policy)=>{
-      let platformsForThisPolicy = policy.platform.split(',');
+      let platformsForThisPolicy = policy.platform.split(', ');
       return _.includes(platformsForThisPolicy, 'windows');
     });
     let linuxQueries = _.filter(policies, (policy)=>{
-      let platformsForThisPolicy = policy.platform.split(',');
+      let platformsForThisPolicy = policy.platform.split(', ');
       return _.includes(platformsForThisPolicy, 'linux');
     });
     // Respond with view.


### PR DESCRIPTION
Closes: https://github.com/fleetdm/fleet/issues/30714


Changes:
- Fixed a bug in the policy and query library pages that prevented multi-platform queries and policies from being displayed in every platform they are supported on.