### PR TITLE
Update well-known to serve jordan ngrok URL

### DIFF
--- a/website/config/routes.js
+++ b/website/config/routes.js
@@ -1049,6 +1049,6 @@ module.exports.routes = {
 
   // Well known resources https://datatracker.ietf.org/doc/html/rfc8615
   // =============================================================================================================
-  // Temporary enroll endpoint for https://github.com/fleetdm/fleet/issues/27391
-  'GET /.well-known/com.apple.remotemanagement': (req, res)=>{ return res.json({'Servers':[{'Version':'mdm-byod', 'BaseURL':'https://https://jordan-fleetdm.ngrok.app/api/mdm/apple/account_driven_enrollment'}]});},
+  // Temporary enroll endpoint for https://github.com/fleetdm/fleet/issues/27390
+  'GET /.well-known/com.apple.remotemanagement': (req, res)=>{ return res.json({'Servers':[{'Version':'mdm-byod', 'BaseURL':'https://jordan-fleetdm.ngrok.app/api/mdm/apple/account_driven_enrollment'}]});},
 };

--- a/website/config/routes.js
+++ b/website/config/routes.js
@@ -1050,5 +1050,5 @@ module.exports.routes = {
   // Well known resources https://datatracker.ietf.org/doc/html/rfc8615
   // =============================================================================================================
   // Temporary enroll endpoint for https://github.com/fleetdm/fleet/issues/27390
-  'GET /.well-known/com.apple.remotemanagement': (req, res)=>{ return res.json({'Servers':[{'Version':'mdm-byod', 'BaseURL':'https://jordan-fleetdm.ngrok.app/api/mdm/apple/account_driven_enrollment'}]});},
+  'GET /.well-known/com.apple.remotemanagement': (req, res)=>{ return res.json({'Servers':[{'Version':'mdm-byod', 'BaseURL':'https://jordan-fleetdm.ngrok.app/api/mdm/apple/account_driven_enroll'}]});},
 };

--- a/website/config/routes.js
+++ b/website/config/routes.js
@@ -1050,5 +1050,5 @@ module.exports.routes = {
   // Well known resources https://datatracker.ietf.org/doc/html/rfc8615
   // =============================================================================================================
   // Temporary enroll endpoint for https://github.com/fleetdm/fleet/issues/27391
-  'GET /.well-known/com.apple.remotemanagement': (req, res)=>{ return res.json({'Servers':[{'Version':'mdm-byod', 'BaseURL':'https://getvictor.ngrok.io/api/mdm/apple/enroll?token=bozo'}]});},
+  'GET /.well-known/com.apple.remotemanagement': (req, res)=>{ return res.json({'Servers':[{'Version':'mdm-byod', 'BaseURL':'https://https://jordan-fleetdm.ngrok.app/api/mdm/apple/account_driven_enrollment'}]});},
 };


### PR DESCRIPTION
Updates the well-known URL for apple MDM account driven enrollment to point to my ngrok URL for dev purposes. Was previously pointing to victor's due to prior POC

For this user story: https://github.com/fleetdm/fleet/issues/27390

and this subtask: https://github.com/fleetdm/fleet/issues/30636