### PR TITLE
Fixed typo for step 4 of "Running the vulnerability dashboard with Docker."

### DIFF
--- a/ee/vulnerability-dashboard/README.md
+++ b/ee/vulnerability-dashboard/README.md
@@ -38,7 +38,7 @@ To run a local vulnerability dashboard with docker, you can follow these instruc
   2. `sails_custom__fleetApiToken`: An API token for an [API-only user](https://fleetdm.com/docs/using-fleet/fleetctl-cli#create-api-only-user) on your Fleet instance.
 
 3. Open the `ee/vulnerability-dashboard/` folder in your terminal
-4. Run `docker compose up --build` to build the vulnerability dashboard's Docker image.
+4. Run `docker-compose up --build` to build the vulnerability dashboard's Docker image.
 
   > The first time the vulnerability dashboard starts it will Initalize the database and run the `update-reports` script before the server starts.
 


### PR DESCRIPTION
Changed `docker compose up --build` to `docker-compose up --build`