### PR TITLE
Fix Docker setup: Enable database table creation on first run

### DIFF
--- a/ee/vulnerability-dashboard/docker-compose.yml
+++ b/ee/vulnerability-dashboard/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       sails_datastores__default__adapter: sails-postgresql
       sails_sockets__url: redis://redis:6379
       sails_session__url: redis://redis:6379
-      sails_models__migrate: safe
+      sails_models__migrate: alter
       sails_custom__fleetBaseUrl: '' #Add the base url of your Fleet instance: ex: https://fleet.example.com
       sails_custom__fleetApiToken: '' # Add the API token of an API-only user [?] Here's how you get one: https://fleetdm.com/docs/using-fleet/fleetctl-cli#get-the-api-token-of-an-api-only-user
       sails_custom__fleetApiOptionalCookie: ''  # If your fleet instance requires optional cookies, use this to interact with the APIs


### PR DESCRIPTION
 ## Problem
  The Docker setup fails to start because the database migration setting prevents table creation. The application crashes with "relation does not exist" errors when trying to access tables that were never created.

  ## Root Cause
  The `sails_models__migrate: safe` setting in docker-compose.yml prevents Sails.js from creating database tables, but the README documentation states that the database will be "initialized" on first run.

  ## Solution
  Change the migration setting from `safe` to `alter` to allow automatic table creation during development setup.

  ## Testing
  - Verified that `docker-compose up --build` now works without errors
  - Tables are created automatically on first run as documented
  - Application starts successfully and is accessible at localhost:1337
  
  Let me know if you have questions, or if I'm misunderstanding the intention of the current configuration. Thanks!
