### PR TITLE
Fleet UI: Add truncation to versions cell for 1 version

### DIFF
--- a/frontend/pages/SoftwarePage/components/tables/VersionCell/VersionCell.tsx
+++ b/frontend/pages/SoftwarePage/components/tables/VersionCell/VersionCell.tsx
@@ -1,16 +1,8 @@
 import React from "react";
-
 import TextCell from "components/TableContainer/DataTable/TextCell";
 import TooltipWrapper from "components/TooltipWrapper";
-
-const generateText = <T extends { version: string }>(versions: T[] | null) => {
-  if (!versions) {
-    return <TextCell value="---" grey />;
-  }
-  const text =
-    versions.length !== 1 ? `${versions.length} versions` : versions[0].version;
-  return <TextCell value={text} italic={versions.length !== 1} />;
-};
+import TooltipTruncatedTextCell from "components/TableContainer/DataTable/TooltipTruncatedTextCell";
+import { DEFAULT_EMPTY_CELL_VALUE } from "utilities/constants";
 
 interface IVersionCellProps<T extends { version: string }> {
   versions: T[] | null;
@@ -19,12 +11,15 @@ interface IVersionCellProps<T extends { version: string }> {
 const VersionCell = <T extends { version: string }>({
   versions,
 }: IVersionCellProps<T>) => {
-  // only one version, no need for tooltip
-  const cellText = generateText(versions);
-  if (!versions || versions.length <= 1) {
-    return <>{cellText}</>;
+  if (!versions || versions.length === 0) {
+    return <TextCell value={DEFAULT_EMPTY_CELL_VALUE} grey />;
   }
 
+  if (versions.length === 1) {
+    return <TooltipTruncatedTextCell value={versions[0].version} />;
+  }
+
+  // Multiple versions: show count, tooltip with versions list
   return (
     <TooltipWrapper
       tipContent={<>{versions.map((version) => version.version).join(", ")}</>}
@@ -33,7 +28,7 @@ const VersionCell = <T extends { version: string }>({
       showArrow
       underline={false}
     >
-      {cellText}
+      <TextCell value={`${versions.length} versions`} italic />
     </TooltipWrapper>
   );
 };


### PR DESCRIPTION
## Issue
Request from spec in #29728 

## Description
- Add truncation to version cell when single version length is too long
- 5 instances are updated in the UI: 
  - fleet desktop > software > version
  - host details > inventory > version
  - host details > library > installed version
  - host details > library > library version
  - software page > version
- Cleaned up code

## Screenshots of all instances updated
<img width="1192" height="733" alt="Screenshot 2025-07-10 at 11 47 43 AM" src="https://github.com/user-attachments/assets/330a1efb-b210-4398-949f-c239c1d680cc" />
<img width="802" height="650" alt="Screenshot 2025-07-10 at 11 45 21 AM" src="https://github.com/user-attachments/assets/ca82d595-013f-438a-94b1-f74ce4de123b" />
<img width="800" height="702" alt="Screenshot 2025-07-10 at 11 44 58 AM" src="https://github.com/user-attachments/assets/beda06c9-9288-47fc-86ae-4f517604a9f3" />
<img width="802" height="722" alt="Screenshot 2025-07-10 at 11 44 30 AM" src="https://github.com/user-attachments/assets/50298f34-8215-4175-b6af-f44cb0255a62" />


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Manual QA for all new/changed functionality