### PR TITLE
Fix OS vulnerability expiration due to avoiding updating updated_at, while avoiding test flakiness

### DIFF
--- a/changes/29988-os-vulns-flakiness
+++ b/changes/29988-os-vulns-flakiness
@@ -1,0 +1,1 @@
+* Fixed cases where valid operating system vulnerabilities would be periodically incorrectly purged


### PR DESCRIPTION
Merged into `main` in #30713.