### PR TITLE
Modifying cve feed for powershell version change

### DIFF
--- a/server/vulnerabilities/nvd/sync/cve_syncer.go
+++ b/server/vulnerabilities/nvd/sync/cve_syncer.go
@@ -488,6 +488,24 @@ func transformVuln(item nvdapi.CVEItem) nvdapi.CVEItem {
 		item.CVE.Configurations[0].Nodes[0].CPEMatch = item.CVE.Configurations[0].Nodes[0].CPEMatch[0:1]
 	}
 
+	// Handle PowerShell version format normalization
+	// NVD changed PowerShell 7.5.0 to 7.5
+	if item.CVE.Configurations != nil {
+		for i := range item.CVE.Configurations {
+			if item.CVE.Configurations[i].Nodes != nil {
+				for j := range item.CVE.Configurations[i].Nodes {
+					if item.CVE.Configurations[i].Nodes[j].CPEMatch != nil {
+						for k := range item.CVE.Configurations[i].Nodes[j].CPEMatch {
+							cpeMatch := &item.CVE.Configurations[i].Nodes[j].CPEMatch[k]
+							// Convert cpe:2.3:a:microsoft:powershell:7.5:* back to cpe:2.3:a:microsoft:powershell:7.5.0:*
+							cpeMatch.Criteria = strings.Replace(cpeMatch.Criteria, "microsoft:powershell:7.5:", "microsoft:powershell:7.5.0:", 1)
+						}
+					}
+				}
+			}
+		}
+	}
+
 	return item
 }
 

--- a/server/vulnerabilities/nvd/sync/cve_syncer.go
+++ b/server/vulnerabilities/nvd/sync/cve_syncer.go
@@ -16,6 +16,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"regexp"
 	"slices"
 	"sort"
 	"strconv"
@@ -488,19 +489,21 @@ func transformVuln(item nvdapi.CVEItem) nvdapi.CVEItem {
 		item.CVE.Configurations[0].Nodes[0].CPEMatch = item.CVE.Configurations[0].Nodes[0].CPEMatch[0:1]
 	}
 
-	// Handle PowerShell version format normalization
-	// NVD changed PowerShell 7.5.0 to 7.5
-	if item.CVE.Configurations != nil {
+	// Handle NVD PowerShell version format normalization
+	// 1. Version: 7.5 → 7.5.0
+	// 2. RC notation: preview1 → rc.1
+	if item.CVE.ID != nil && (*item.CVE.ID == "CVE-2025-21171" || *item.CVE.ID == "CVE-2025-30399") {
 		for i := range item.CVE.Configurations {
-			if item.CVE.Configurations[i].Nodes != nil {
-				for j := range item.CVE.Configurations[i].Nodes {
-					if item.CVE.Configurations[i].Nodes[j].CPEMatch != nil {
-						for k := range item.CVE.Configurations[i].Nodes[j].CPEMatch {
-							cpeMatch := &item.CVE.Configurations[i].Nodes[j].CPEMatch[k]
-							// Convert cpe:2.3:a:microsoft:powershell:7.5:* back to cpe:2.3:a:microsoft:powershell:7.5.0:*
-							cpeMatch.Criteria = strings.Replace(cpeMatch.Criteria, "microsoft:powershell:7.5:", "microsoft:powershell:7.5.0:", 1)
-						}
-					}
+			for j := range item.CVE.Configurations[i].Nodes {
+				for k := range item.CVE.Configurations[i].Nodes[j].CPEMatch {
+					cpeMatch := &item.CVE.Configurations[i].Nodes[j].CPEMatch[k]
+					criteria := cpeMatch.Criteria
+
+					criteria = strings.Replace(criteria, "microsoft:powershell:7.5:", "microsoft:powershell:7.5.0:", 1)
+					previewRegex := regexp.MustCompile(`:preview(\d+):`)
+					criteria = previewRegex.ReplaceAllString(criteria, ":rc.$1:")
+
+					cpeMatch.Criteria = criteria
 				}
 			}
 		}


### PR DESCRIPTION
It was modified upstream from `microsoft:powershell:7.5.0` to `microsoft:powershell:7.5`. Our current CPE to CVE does not handle this case properly.

- [x] Manual QA for all new/changed functionality

QA instructions.
Generate new `nvdcve-1.1-*.json` files.
```
$ git checkout -b powershell-feed-fix --track origin/powershell-feed-fix
$ make build
$ go run cmd/cve/generate.go
# or optionally
$ VULNCHECK_API_KEY=<...> go run cmd/cve/generate.go
```

~How do we verify the CVE actually matches? Install powershell? Run the test file pointing to the newly generated json files?~
Download powershell rc1 https://github.com/PowerShell/PowerShell/releases/tag/v7.5.0-rc.1
Install powershell rc1

Run vuln processing with custom path
```
go run ./cmd/fleet vuln-process --vulnerabilities_databases_path=/tmp/vulndbs
```

What you should see is that `CVE-2025-21171` applies to powershell 7.5.0-rc.1