### PR TITLE
[gitops] support multiple SoftwarePackageSpecs in one yaml file

### DIFF
--- a/changes/30790-gitops-software-multiple-packages-in-path
+++ b/changes/30790-gitops-software-multiple-packages-in-path
@@ -1,0 +1,1 @@
+- [GitOps Software] Support writing multiple packages in a single file included under `software.packages`.

--- a/pkg/spec/testdata/software/multiple-packages.yml
+++ b/pkg/spec/testdata/software/multiple-packages.yml
@@ -1,0 +1,2 @@
+- hash_sha256: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+- hash_sha256: bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb

--- a/pkg/spec/testdata/software/single-package.yml
+++ b/pkg/spec/testdata/software/single-package.yml
@@ -1,0 +1,1 @@
+hash_sha256: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa


### PR DESCRIPTION
The list of software configured via GitOps might be dynamic, for example if the GitOps pipeline builds and pushes packages just before fleet gitops is called, or if partial package lists are shared between teams.

In these cases, it's useful to be able to include one file containing multiple packages. This PR refactors `parseSoftware` to support that use case.

This remains backward compatible with the old style of using one package per included file. This is verified by a new test, `TestSoftwarePackagesUnmarshalMulti`.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.
- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [x] Added/updated automated tests
