### PR TITLE
[fleetctl] fail api command when args present after uri

### DIFF
--- a/cmd/fleetctl/fleetctl/api.go
+++ b/cmd/fleetctl/fleetctl/api.go
@@ -256,6 +256,9 @@ func apiCommand() *cli.Command {
 
 			if uriString == "" {
 				return errors.New("must provide uri first argument")
+			} else if c.Args().Len() > 1 {
+				return fmt.Errorf("extra arguments: %s\nEnsure any flags are before the URL",
+					strings.Join(c.Args().Slice()[1:], " "))
 			}
 
 			flField = c.StringSlice("F")

--- a/cmd/fleetctl/fleetctl/api_test.go
+++ b/cmd/fleetctl/fleetctl/api_test.go
@@ -105,6 +105,11 @@ func TestRunApiCommand(t *testing.T) {
 			args:         []string{"vresion"},
 			expectErrMsg: "Got non 2XX return of 404",
 		},
+		{
+			name:         "flags after args",
+			args:         []string{"scripts", "-F", "team_id=1"},
+			expectErrMsg: "extra arguments: -F team_id=1",
+		},
 	}
 
 	setupDS := func(t *testing.T, c testCase) {


### PR DESCRIPTION
github.com/urfave/cli/v2 doesn't parse flags after it encounters the first argument. This left me very confused when trying to call `fleetctl api some/route -F arg=value` and the query string wasn't being updated.

Make this an error case to prevent future confusion.

Note that v3 of `urfave/cli` [supports arguments](https://pkg.go.dev/github.com/urfave/cli/v3#Argument), so the right thing to do in the long term is upgrade this library to v3.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [x] Added/updated automated tests
- [x] Manual QA for all new/changed functionality
