### PR TITLE
Fix handling of software policy automations when a hash is specified inside a software file

### DIFF
--- a/changes/30435-hash-for-policy-in-software-path
+++ b/changes/30435-hash-for-policy-in-software-path
@@ -1,0 +1,1 @@
+* Fixed specification of policy software automations via GitOps when referring to software by hash from a software YAML file

--- a/pkg/spec/gitops.go
+++ b/pkg/spec/gitops.go
@@ -867,15 +867,21 @@ func parsePolicyInstallSoftware(baseDir string, teamName *string, policy *Policy
 		}
 		installerOnTeamFound := false
 		for _, pkg := range packages {
-			if pkg.URL == policyInstallSoftwareSpec.URL {
+			if (pkg.URL != "" && pkg.URL == policyInstallSoftwareSpec.URL) || (pkg.SHA256 != "" && pkg.SHA256 == policyInstallSoftwareSpec.SHA256) {
 				installerOnTeamFound = true
 				break
 			}
 		}
 		if !installerOnTeamFound {
-			return fmt.Errorf("install_software.package_path URL %s not found on team: %s", policyInstallSoftwareSpec.URL, policy.InstallSoftware.PackagePath)
+			if policyInstallSoftwareSpec.URL != "" {
+				return fmt.Errorf("install_software.package_path URL %s not found on team: %s", policyInstallSoftwareSpec.URL, policy.InstallSoftware.PackagePath)
+			} else {
+				return fmt.Errorf("install_software.package_path SHA256 %s not found on team: %s", policyInstallSoftwareSpec.SHA256, policy.InstallSoftware.PackagePath)
+			}
 		}
+
 		policy.InstallSoftwareURL = policyInstallSoftwareSpec.URL
+		policy.InstallSoftware.HashSHA256 = policyInstallSoftwareSpec.SHA256
 	}
 
 	if policy.InstallSoftware.AppStoreID != "" {

--- a/pkg/spec/gitops.go
+++ b/pkg/spec/gitops.go
@@ -875,9 +875,8 @@ func parsePolicyInstallSoftware(baseDir string, teamName *string, policy *Policy
 		if !installerOnTeamFound {
 			if policyInstallSoftwareSpec.URL != "" {
 				return fmt.Errorf("install_software.package_path URL %s not found on team: %s", policyInstallSoftwareSpec.URL, policy.InstallSoftware.PackagePath)
-			} else {
-				return fmt.Errorf("install_software.package_path SHA256 %s not found on team: %s", policyInstallSoftwareSpec.SHA256, policy.InstallSoftware.PackagePath)
 			}
+			return fmt.Errorf("install_software.package_path SHA256 %s not found on team: %s", policyInstallSoftwareSpec.SHA256, policy.InstallSoftware.PackagePath)
 		}
 
 		policy.InstallSoftwareURL = policyInstallSoftwareSpec.URL

--- a/pkg/spec/testdata/microsoft-teams.nourl.pkg.software.yml
+++ b/pkg/spec/testdata/microsoft-teams.nourl.pkg.software.yml
@@ -1,0 +1,5 @@
+hash_sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+self_service: false
+categories:
+  - Communication
+  - Productivity

--- a/pkg/spec/testdata/team_config_only_sha256.yml
+++ b/pkg/spec/testdata/team_config_only_sha256.yml
@@ -1,0 +1,58 @@
+name: Team1
+team_settings:
+  path: ./team-settings.yml
+agent_options:
+  path: ./agent-options.yml
+controls:
+  path: ./controls.yml
+queries:
+  - path: ./top.queries.yml
+  - path: ./empty.yml
+  - name: osquery_info
+    query: SELECT * from osquery_info;
+    interval: 604800 # 1 week
+    platform: darwin,linux,windows,chrome
+    min_osquery_version: all
+    observer_can_run: false
+    automations_enabled: true
+    logging: snapshot
+policies:
+  - path: ./policies/policies.yml
+  - path: ./policies/policies2.yml
+  - path: ./empty.yml
+  - name: 😊😊 Failing $POLICY
+    platform: linux
+    description: This policy should always fail.
+    resolution: There is no resolution for this policy.
+    query: SELECT 1 FROM osquery_info WHERE start_time < 0;
+  - path: ./team_install_software.nourl.policies.yml
+  - name: Slack on macOS is installed
+    platform: darwin
+    query: SELECT 1 FROM apps WHERE name = 'Slack.app';
+    install_software:
+      app_store_id: "123456"
+  - name: Script run policy
+    platform: linux
+    description: This should run a script on failure
+    query: SELECT * from osquery_info;
+    run_script:
+      path: ./lib/collect-fleetd-logs.sh
+  - path: ./policies/script-policy.yml
+software:
+  app_store_apps:
+    - app_store_id: "123456"
+  packages:
+    - path: ./microsoft-teams.nourl.pkg.software.yml
+    - url: https://ftp.mozilla.org/pub/firefox/releases/129.0.2/mac/en-US/Firefox%20129.0.2.pkg
+      self_service: true
+  fleet_maintained_apps:
+    - slug: slack/darwin
+      self_service: true
+      categories:
+        - Productivity
+        - Communication
+    - slug: box-drive/windows
+      self_service: true
+      categories:
+        - Productivity
+        - Developer tools

--- a/pkg/spec/testdata/team_install_software.nourl.policies.yml
+++ b/pkg/spec/testdata/team_install_software.nourl.policies.yml
@@ -1,0 +1,5 @@
+- name: Microsoft Teams on macOS installed and up to date
+  platform: darwin
+  query: SELECT 1 FROM apps WHERE name = 'Microsoft Teams.app' AND version_compare(bundle_short_version, '24193.1707.3028.4282') >= 0;
+  install_software:
+    package_path: ./microsoft-teams.nourl.pkg.software.yml


### PR DESCRIPTION
Fixes #30435.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.
- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [x] Added/updated automated tests
- [x] Manual QA for all new/changed functionality