### PR TITLE
Fix Entra ID SCIM URL documentation

### DIFF
--- a/articles/foreign-vitals-map-idp-users-to-hosts.md
+++ b/articles/foreign-vitals-map-idp-users-to-hosts.md
@@ -77,7 +77,7 @@ To map users from Entra ID to hosts in Fleet, we'll do the following steps:
 
 1. From the side menu, select **Provisioning**.
 2. In **Get started with application provisioning** section, select **Connect your application**.
-3. For the **Tenant URL**, enter `https://<your_fleet_server_url>/api/v1/fleet/scim`.
+3. For the **Tenant URL**, enter `https://<your_fleet_server_url>/api/v1/fleet/scim?aadOptscim062020`.
 4. [Create a Fleet API-only user](https://fleetdm.com/guides/fleetctl#create-api-only-user) with maintainer permissions and copy API token for that user. Paste your API token in the **Secret token** field.
 5. Select the **Test connection** button. You should see success message.
 6. Select **Create** and, after successful creation, you'll be redirected to the overview page.


### PR DESCRIPTION
Fix Entra ID SCIM URL documentation to match contributor docs: https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/integrations/scim-integration.md#entra-id-integration