### PR TITLE
Fix host certificate parsing with embedded slash

### DIFF
--- a/changes/28996-parse-cert-dn-with-slashes
+++ b/changes/28996-parse-cert-dn-with-slashes
@@ -1,0 +1,1 @@
+* Fixed bug where a certificate Distinguished Name (DN) parser did not allow forward slashes in the value which resulted in parsing error.

--- a/server/fleet/host_certificates.go
+++ b/server/fleet/host_certificates.go
@@ -216,6 +216,8 @@ type MDMAppleErrorChainItem struct {
 func ExtractDetailsFromOsqueryDistinguishedName(str string) (*HostCertificateNameDetails, error) {
 	str = strings.TrimSpace(str)
 	str = strings.Trim(str, "/")
+
+	str = strings.ReplaceAll(str, `\/`, `<<SLASH>>`) // Replace with our own "safe" sequence
 	parts := strings.Split(str, "/")
 
 	var details HostCertificateNameDetails
@@ -225,15 +227,17 @@ func ExtractDetailsFromOsqueryDistinguishedName(str string) (*HostCertificateNam
 			return nil, fmt.Errorf("invalid distinguished name, wrong key value pair format: %s", str)
 		}
 
+		value := strings.ReplaceAll(strings.Trim(kv[1], " "), `<<SLASH>>`, `/`) // Replace our "safe" sequence with forward slash
+
 		switch strings.ToUpper(kv[0]) {
 		case "C":
-			details.Country = strings.Trim(kv[1], " ")
+			details.Country = strings.Trim(value, " ")
 		case "O":
-			details.Organization = strings.Trim(kv[1], " ")
+			details.Organization = strings.Trim(value, " ")
 		case "OU":
-			details.OrganizationalUnit = strings.Trim(kv[1], " ")
+			details.OrganizationalUnit = strings.Trim(value, " ")
 		case "CN":
-			details.CommonName = strings.Trim(kv[1], " ")
+			details.CommonName = strings.Trim(value, " ")
 		}
 	}
 

--- a/server/fleet/host_certificates_test.go
+++ b/server/fleet/host_certificates_test.go
@@ -13,6 +13,12 @@ func TestExtractHostCertificateNameDetails(t *testing.T) {
 		OrganizationalUnit: "Fleet Device Management Inc.",
 		CommonName:         "FleetDM",
 	}
+	expectedWithSlash := HostCertificateNameDetails{
+		Country:            "US",
+		Organization:       "Fleet Device Management Inc.",
+		OrganizationalUnit: "Fleet Device Management Inc.",
+		CommonName:         "FleetDM/valid",
+	}
 
 	cases := []struct {
 		name     string
@@ -46,9 +52,14 @@ func TestExtractHostCertificateNameDetails(t *testing.T) {
 			expected: &expected,
 		},
 		{
-			name:  "invalid format with extra slash",
-			input: "/C=US/O=Fleet Device Management Inc./OU=Fleet Device Management Inc./CN=FleetDM/invalid",
-			err:   true,
+			name:     "valid format with extra slash",
+			input:    `/C=US/O=Fleet Device Management Inc./OU=Fleet Device Management Inc./CN=FleetDM\/valid`,
+			expected: &expectedWithSlash,
+		},
+		{
+			name:     "valid with safe escape sequence",
+			input:    `/C=US/O=Fleet Device Management Inc./OU=Fleet Device Management Inc./CN=FleetDM<<SLASH>>valid`,
+			expected: &expectedWithSlash,
 		},
 		{
 			name:  "invalid format with wrong separator",

--- a/server/fleet/host_certificates_test.go
+++ b/server/fleet/host_certificates_test.go
@@ -62,6 +62,11 @@ func TestExtractHostCertificateNameDetails(t *testing.T) {
 			expected: &expectedWithSlash,
 		},
 		{
+			name:  "invalid format with extra slash without escape",
+			input: "/C=US/O=Fleet Device Management Inc./OU=Fleet Device Management Inc./CN=FleetDM/invalid",
+			err:   true,
+		},
+		{
 			name:  "invalid format with wrong separator",
 			input: "C=US,O=Fleet Device Management Inc.,OU=Fleet Device Management Inc.,CN=FleetDM",
 			err:   true,

--- a/server/service/osquery_utils/queries_test.go
+++ b/server/service/osquery_utils/queries_test.go
@@ -2010,7 +2010,7 @@ func TestDirectIngestHostCertificates(t *testing.T) {
 		"path":              "/Users/mna/Library/Keychains/login.keychain-db",
 	}
 
-	// row2 will not be ingeted because of the issue field containing an extra /
+	// row2 will be ingested correctly with the issue field containing a / in the value
 	row2 := map[string]string{
 		"ca":                "1",
 		"common_name":       "Cert 2 Common Name",
@@ -2031,7 +2031,7 @@ func TestDirectIngestHostCertificates(t *testing.T) {
 	ds.UpdateHostCertificatesFunc = func(ctx context.Context, hostID uint, hostUUID string, certs []*fleet.HostCertificateRecord) error {
 		require.Equal(t, host.ID, hostID)
 		require.Equal(t, host.UUID, hostUUID)
-		require.Len(t, certs, 1)
+		require.Len(t, certs, 2)
 		require.Equal(t, "9c1e9c00d8120c1a9d96274d2a17c38ffa30fd31", hex.EncodeToString(certs[0].SHA1Sum))
 		require.Equal(t, "Cert 1 Common Name", certs[0].CommonName)
 		require.Equal(t, "Subject 1 Common Name", certs[0].SubjectCommonName)
@@ -2053,10 +2053,30 @@ func TestDirectIngestHostCertificates(t *testing.T) {
 		require.EqualValues(t, "user", certs[0].Source)
 		require.Equal(t, "mna", certs[0].Username)
 
+		require.Equal(t, "9c1e9c00d8120c1a9d96274d2a17c38ffa30fd32", hex.EncodeToString(certs[1].SHA1Sum))
+		require.Equal(t, "Cert 2 Common Name", certs[1].CommonName)
+		require.Equal(t, "Subject 1 Common Name", certs[1].SubjectCommonName)
+		require.Equal(t, "Subject 1 Inc.", certs[1].SubjectOrganization)
+		require.Equal(t, "Subject 1 Org Unit", certs[1].SubjectOrganizationalUnit)
+		require.Equal(t, "US", certs[1].SubjectCountry)
+		require.Equal(t, "Issuer 2 Common Name", certs[1].IssuerCommonName)
+		require.Equal(t, "Issuer 2 Inc./foobar", certs[1].IssuerOrganization)
+		require.Empty(t, certs[1].IssuerOrganizationalUnit)
+		require.Equal(t, "US", certs[1].IssuerCountry)
+		require.Equal(t, "rsaEncryption", certs[1].KeyAlgorithm)
+		require.Equal(t, 2048, certs[1].KeyStrength)
+		require.Equal(t, "Data Encipherment, Key Encipherment, Digital Signature", certs[1].KeyUsage)
+		require.Equal(t, "123abcd", certs[1].Serial)
+		require.Equal(t, "sha256WithRSAEncryption", certs[1].SigningAlgorithm)
+		require.Equal(t, int64(1822755797), certs[1].NotValidAfter.Unix())
+		require.Equal(t, int64(1770228826), certs[1].NotValidBefore.Unix())
+		require.True(t, certs[1].CertificateAuthority)
+		require.EqualValues(t, "system", certs[1].Source)
+
 		return nil
 	}
 
-	err := directIngestHostCertificates(ctx, logger, host, ds, []map[string]string{row2, row1})
+	err := directIngestHostCertificates(ctx, logger, host, ds, []map[string]string{row1, row2})
 	require.NoError(t, err)
 	require.True(t, ds.UpdateHostCertificatesFuncInvoked)
 }


### PR DESCRIPTION
Fixes: #28996 - Verified by installing the [failing certificate](https://ssl-tools.net/subjects/b0e31e6fe1b4e58b38cd4664dd9184b2eead11f6) on a local host, and then seeing the certificate appear in Fleet host details.

Opted for fixing the parsing of a `/` in the middle of a value, instead of trying to silence the error to some degree, which fixes our issue. We're missing reports from other customers facing this to be 100% certain it's the same issue for all log spamming.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.
- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [x] Added/updated automated tests
- [x] Manual QA for all new/changed functionality

