### PR TITLE
Updates across UI to support personal devices enrolled  in MDM

### DIFF
--- a/changes/issue-30782-updates-to-UI-for-personally-enrolled-devices
+++ b/changes/issue-30782-updates-to-UI-for-personally-enrolled-devices
@@ -1,0 +1,1 @@
+- update UI to support personally enrolled MDM devices

--- a/frontend/interfaces/mdm.ts
+++ b/frontend/interfaces/mdm.ts
@@ -47,6 +47,7 @@ export const getMdmServerUrl = ({ server_url }: IConfigServerSettings) => {
 export const MDM_ENROLLMENT_STATUS = {
   "On (manual)": "manual",
   "On (automatic)": "automatic",
+  "On (personal)": "personal",
   Off: "unenrolled",
   Pending: "pending",
 };
@@ -81,6 +82,7 @@ export interface IMdmSummaryMdmSolution extends IMdmSolution {
 interface IMdmStatus {
   enrolled_manual_hosts_count: number;
   enrolled_automated_hosts_count: number;
+  enrolled_personal_hosts_count: number;
   unenrolled_hosts_count: number;
   pending_hosts_count?: number;
   hosts_count: number;

--- a/frontend/interfaces/mdm.ts
+++ b/frontend/interfaces/mdm.ts
@@ -52,18 +52,17 @@ export type MdmEnrollmentStatus =
   | "Off"
   | "Pending";
 
-export const MDM_ENROLLMENT_STATUS: Record<MdmEnrollmentStatus, string> = {
-  "On (manual)": "manual",
-  "On (automatic)": "automatic",
-  "On (personal)": "personal",
-  Off: "unenrolled",
-  Pending: "pending",
-};
+/** This is the filter value used for query string parameters */
+export type MdmEnrollmentFilterValue =
+  | "manual"
+  | "automatic"
+  | "personal"
+  | "unenrolled"
+  | "pending";
 
 interface IMdmEnrollmentStatusUIData {
   displayName: string;
-  /** This is the filter value used for query string parameters */
-  filterValue: string;
+  filterValue: MdmEnrollmentFilterValue;
 }
 
 /** This maps the MdmEnrollmentStatus to the various data needed in the UI.

--- a/frontend/interfaces/mdm.ts
+++ b/frontend/interfaces/mdm.ts
@@ -44,7 +44,15 @@ export const getMdmServerUrl = ({ server_url }: IConfigServerSettings) => {
   return server_url.concat("/mdm/apple/mdm");
 };
 
-export const MDM_ENROLLMENT_STATUS = {
+/** These are the values the API will send back to the UI for mdm enrollment status */
+export type MdmEnrollmentStatus =
+  | "On (manual)"
+  | "On (automatic)"
+  | "On (personal)"
+  | "Off"
+  | "Pending";
+
+export const MDM_ENROLLMENT_STATUS: Record<MdmEnrollmentStatus, string> = {
   "On (manual)": "manual",
   "On (automatic)": "automatic",
   "On (personal)": "personal",
@@ -52,11 +60,47 @@ export const MDM_ENROLLMENT_STATUS = {
   Pending: "pending",
 };
 
-export type MdmEnrollmentStatus = keyof typeof MDM_ENROLLMENT_STATUS;
+interface IMdmEnrollmentStatusUIData {
+  displayName: string;
+  /** This is the filter value used for query string parameters */
+  filterValue: string;
+}
+
+/** This maps the MdmEnrollmentStatus to the various data needed in the UI.
+ * This include the display name, and the filter values.
+ */
+export const MDM_ENROLLMENT_STATUS_UI_MAP: Record<
+  MdmEnrollmentStatus,
+  IMdmEnrollmentStatusUIData
+> = {
+  "On (manual)": {
+    displayName: "On (manual)",
+    filterValue: "manual",
+  },
+  "On (automatic)": {
+    // This is the new name for "On (automatic)". The API will still return
+    // "On (automatic)" for backwards compatibility.
+    displayName: "On (company-owned)",
+    filterValue: "automatic",
+  },
+  "On (personal)": {
+    displayName: "On (personal)",
+    filterValue: "personal",
+  },
+  Off: {
+    displayName: "Off",
+    filterValue: "unenrolled",
+  },
+  Pending: {
+    displayName: "Pending",
+    filterValue: "pending",
+  },
+};
 
 export interface IMdmStatusCardData {
   status: MdmEnrollmentStatus;
   hosts: number;
+  selectedPlatformLabelId?: number;
 }
 
 export interface IMdmAggregateStatus {

--- a/frontend/pages/DashboardPage/DashboardPage.tsx
+++ b/frontend/pages/DashboardPage/DashboardPage.tsx
@@ -397,6 +397,7 @@ const DashboardPage = ({ router, location }: IDashboardProps): JSX.Element => {
         mobile_device_management_enrollment_status: {
           enrolled_automated_hosts_count,
           enrolled_manual_hosts_count,
+          enrolled_personal_hosts_count,
           unenrolled_hosts_count,
           pending_hosts_count,
           hosts_count,
@@ -421,6 +422,10 @@ const DashboardPage = ({ router, location }: IDashboardProps): JSX.Element => {
           {
             status: "On (automatic)",
             hosts: enrolled_automated_hosts_count,
+          },
+          {
+            status: "On (personal)",
+            hosts: enrolled_personal_hosts_count,
           },
           { status: "Off", hosts: unenrolled_hosts_count },
         ];

--- a/frontend/pages/DashboardPage/cards/MDM/MDM.tests.tsx
+++ b/frontend/pages/DashboardPage/cards/MDM/MDM.tests.tsx
@@ -43,6 +43,7 @@ describe("MDM Card", () => {
         mdmStatusData={[
           { status: "On (automatic)", hosts: 10 },
           { status: "On (manual)", hosts: 5 },
+          { status: "On (personal)", hosts: 3 },
           { status: "Off", hosts: 1 },
           { status: "Pending", hosts: 3 },
         ]}
@@ -54,7 +55,7 @@ describe("MDM Card", () => {
 
     expect(
       screen.getByRole("row", {
-        name: /On \(automatic\)(.*?)10 view all hosts/i,
+        name: /On \(company-owned\)(.*?)10 view all hosts/i,
       })
     ).toBeInTheDocument();
     expect(
@@ -62,6 +63,12 @@ describe("MDM Card", () => {
         name: /On \(manual\)(.*?)5 view all hosts/i,
       })
     ).toBeInTheDocument();
+    expect(
+      screen.getByRole("row", {
+        name: /On \(personal\)(.*?)3 view all hosts/i,
+      })
+    ).toBeInTheDocument();
+
     expect(
       screen.getByRole("row", {
         name: /Off(.*?)1 view all hosts/i,

--- a/frontend/pages/DashboardPage/cards/MDM/MDMStatusTableConfig.tsx
+++ b/frontend/pages/DashboardPage/cards/MDM/MDMStatusTableConfig.tsx
@@ -1,86 +1,62 @@
 import React from "react";
 
-import { IMdmStatusCardData, MDM_ENROLLMENT_STATUS } from "interfaces/mdm";
+import {
+  IMdmStatusCardData,
+  MDM_ENROLLMENT_STATUS_UI_MAP,
+} from "interfaces/mdm";
 
 import TextCell from "components/TableContainer/DataTable/TextCell";
 import TooltipWrapper from "components/TooltipWrapper";
 import ViewAllHostsLink from "components/ViewAllHostsLink";
 import { MDM_STATUS_TOOLTIP } from "utilities/constants";
+import { CellProps, Column } from "react-table";
+import { INumberCellProps } from "interfaces/datatable_config";
 
-interface IMdmStatusData extends IMdmStatusCardData {
-  selectedPlatformLabelId?: number;
-}
+type IMdmStatusTableConfig = Column<IMdmStatusCardData>;
+type IMdmStatusCellProps = CellProps<
+  IMdmStatusCardData,
+  IMdmStatusCardData["status"]
+>;
+type IHostCountCellProps = INumberCellProps<IMdmStatusCardData>;
+type IViewAllHostsLinkProps = CellProps<IMdmStatusCardData>;
 
-// NOTE: cellProps come from react-table
-// more info here https://react-table.tanstack.com/docs/api/useTable#cell-properties
-interface ICellProps {
-  cell: {
-    value: string;
-  };
-  row: {
-    original: IMdmStatusData;
-  };
-}
-
-interface IHeaderProps {
-  column: {
-    title: string;
-    isSortedDesc: boolean;
-  };
-}
-
-interface IStringCellProps extends ICellProps {
-  cell: {
-    value: string;
-  };
-}
-
-interface IDataColumn {
-  title: string;
-  Header: ((props: IHeaderProps) => JSX.Element) | string;
-  accessor: string;
-  Cell: (props: ICellProps) => JSX.Element;
-  disableGlobalFilter?: boolean;
-  disableHidden?: boolean;
-  disableSortBy?: boolean;
-  sortType?: string;
-}
-
-export const generateStatusTableHeaders = (teamId?: number): IDataColumn[] => [
+export const generateStatusTableHeaders = (
+  teamId?: number
+): IMdmStatusTableConfig[] => [
   {
-    title: "Status",
     Header: "Status",
     disableSortBy: true,
     accessor: "status",
-    Cell: ({ cell: { value: status } }: IStringCellProps) =>
+    Cell: ({ cell: { value: status } }: IMdmStatusCellProps) =>
       !MDM_STATUS_TOOLTIP[status] ? (
         <TextCell value={status} />
       ) : (
         <TooltipWrapper tipContent={MDM_STATUS_TOOLTIP[status]}>
-          {status}
+          {MDM_ENROLLMENT_STATUS_UI_MAP[status].displayName}
         </TooltipWrapper>
       ),
     sortType: "hasLength",
   },
   {
-    title: "Hosts",
     Header: "Hosts",
     disableSortBy: true,
     accessor: "hosts",
-    Cell: (cellProps: ICellProps) => <TextCell value={cellProps.cell.value} />,
+    Cell: (cellProps: IHostCountCellProps) => (
+      <TextCell value={cellProps.cell.value} />
+    ),
   },
   {
-    title: "",
     Header: "",
+    id: "view-all-hosts",
     disableSortBy: true,
     disableGlobalFilter: true,
-    accessor: "linkToFilteredHosts",
-    Cell: (cellProps: IStringCellProps) => {
+    Cell: (cellProps: IViewAllHostsLinkProps) => {
       return (
         <ViewAllHostsLink
           queryParams={{
             mdm_enrollment_status:
-              MDM_ENROLLMENT_STATUS[cellProps.row.original.status],
+              MDM_ENROLLMENT_STATUS_UI_MAP[cellProps.row.original.status]
+                .filterValue,
             team_id: teamId,
           }}
           className="mdm-solution-link"
@@ -89,14 +65,13 @@ export const generateStatusTableHeaders = (teamId?: number): IDataColumn[] => [
         />
       );
     },
-    disableHidden: true,
   },
 ];
 
 const enhanceStatusData = (
   statusData: IMdmStatusCardData[],
   selectedPlatformLabelId?: number
-): IMdmStatusData[] => {
+): IMdmStatusCardData[] => {
   return Object.values(statusData).map((data) => {
     return {
       ...data,
@@ -108,7 +83,7 @@ const enhanceStatusData = (
 export const generateStatusDataSet = (
   statusData: IMdmStatusCardData[] | null,
   selectedPlatformLabelId?: number
-): IMdmStatusData[] => {
+): IMdmStatusCardData[] => {
   if (!statusData) {
     return [];
   }

--- a/frontend/pages/hosts/ManageHostsPage/components/HostsFilterBlock/HostsFilterBlock.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/components/HostsFilterBlock/HostsFilterBlock.tsx
@@ -1,5 +1,4 @@
 import React, { useContext } from "react";
-import { invert } from "lodash";
 
 import { dateAgo } from "utilities/date_format";
 
@@ -13,9 +12,10 @@ import {
   DiskEncryptionStatus,
   BootstrapPackageStatus,
   IMdmSolution,
-  MDM_ENROLLMENT_STATUS,
+  MDM_ENROLLMENT_STATUS_UI_MAP,
   MdmProfileStatus,
   IMdmProfile,
+  MdmEnrollmentFilterValue,
 } from "interfaces/mdm";
 import { IMunkiIssuesAggregate } from "interfaces/macadmins";
 import { IPolicy } from "interfaces/policy";
@@ -67,7 +67,7 @@ interface IHostsFilterBlockProps {
     softwareTitleId?: number;
     softwareVersionId?: number;
     mdmId?: number;
-    mdmEnrollmentStatus?: any;
+    mdmEnrollmentStatus?: MdmEnrollmentFilterValue;
     lowDiskSpaceHosts?: number;
     osVersionId?: string;
     osName?: string;
@@ -377,7 +377,9 @@ const HostsFilterBlock = ({
     if (!mdmEnrollmentStatus) return null;
 
     const label = `MDM status: ${
-      invert(MDM_ENROLLMENT_STATUS)[mdmEnrollmentStatus]
+      Object.values(MDM_ENROLLMENT_STATUS_UI_MAP).find(
+        (status) => status.filterValue === mdmEnrollmentStatus
+      )?.displayName
     }`;
 
     // More narrow tooltip than other MDM tooltip

--- a/frontend/pages/hosts/details/HostDetailsPage/HostActionsDropdown/HostActionsDropdown.tests.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/HostActionsDropdown/HostActionsDropdown.tests.tsx
@@ -370,7 +370,7 @@ describe("Host Actions Dropdown", () => {
         },
       });
 
-      const { user, debug } = render(
+      const { user } = render(
         <HostActionsDropdown
           hostTeamId={null}
           onSelect={noop}
@@ -384,8 +384,6 @@ describe("Host Actions Dropdown", () => {
       );
 
       await user.click(screen.getByText("Actions"));
-
-      debug();
 
       expect(screen.getByText("Turn off MDM").parentElement).toHaveClass(
         "actions-dropdown-select__option--is-disabled"
@@ -1270,6 +1268,91 @@ describe("Host Actions Dropdown", () => {
         screen.queryByText("Show disk encryption key")
       ).not.toBeInTheDocument();
       expect(screen.queryByText("Lock")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("personally enrolled hosts (e.g. enrollment status => On (personal)", () => {
+    it("render only the Transfer and Delete options for personally enrolled ios host", async () => {
+      const render = createCustomRenderer({
+        context: {
+          app: {
+            isMacMdmEnabledAndConfigured: true,
+            isPremiumTier: true,
+            isGlobalAdmin: true,
+            currentUser: createMockUser(),
+          },
+        },
+      });
+
+      const { user } = render(
+        <HostActionsDropdown
+          hostTeamId={null}
+          onSelect={noop}
+          hostStatus="online"
+          hostMdmEnrollmentStatus={"On (personal)"}
+          hostMdmDeviceStatus="unlocked"
+          isConnectedToFleetMdm
+          hostScriptsEnabled
+          hostPlatform="ios"
+        />
+      );
+
+      await user.click(screen.getByText("Actions"));
+
+      screen.debug();
+
+      expect(screen.getByText("Transfer")).toBeInTheDocument();
+      expect(screen.getByText("Delete")).toBeInTheDocument();
+      expect(screen.queryByText("Query")).not.toBeInTheDocument();
+      expect(screen.queryByText("Run script")).not.toBeInTheDocument();
+      expect(screen.queryByText("Wipe")).not.toBeInTheDocument();
+      expect(screen.queryByText("Lock")).not.toBeInTheDocument();
+      expect(screen.queryByText("Unlock")).not.toBeInTheDocument();
+      expect(screen.queryByText("Turn off MDM")).not.toBeInTheDocument();
+      expect(
+        screen.queryByText("Show disk encryption key")
+      ).not.toBeInTheDocument();
+    });
+
+    it("render only the Transfer and Delete options for personally enrolled ipad host", async () => {
+      const render = createCustomRenderer({
+        context: {
+          app: {
+            isPremiumTier: true,
+            isGlobalAdmin: true,
+            currentUser: createMockUser(),
+          },
+        },
+      });
+
+      const { user } = render(
+        <HostActionsDropdown
+          hostTeamId={null}
+          onSelect={noop}
+          hostStatus="online"
+          hostMdmEnrollmentStatus={"On (personal)"}
+          isConnectedToFleetMdm
+          hostMdmDeviceStatus="unlocked"
+          hostScriptsEnabled
+          hostPlatform="ipados"
+        />
+      );
+
+      await user.click(screen.getByText("Actions"));
+
+      screen.debug();
+
+      expect(screen.getByText("Transfer")).toBeInTheDocument();
+      expect(screen.getByText("Delete")).toBeInTheDocument();
+      expect(screen.queryByText("Query")).not.toBeInTheDocument();
+      expect(screen.queryByText("Run script")).not.toBeInTheDocument();
+      expect(screen.queryByText("Wipe")).not.toBeInTheDocument();
+      expect(screen.queryByText("Lock")).not.toBeInTheDocument();
+      expect(screen.queryByText("Unlock")).not.toBeInTheDocument();
+      expect(screen.queryByText("Turn off MDM")).not.toBeInTheDocument();
+      expect(
+        screen.queryByText("Show disk encryption key")
+      ).not.toBeInTheDocument();
     });
   });
 });

--- a/frontend/pages/hosts/details/HostDetailsPage/HostActionsDropdown/HostActionsDropdown.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/HostActionsDropdown/HostActionsDropdown.tsx
@@ -65,9 +65,11 @@ const HostActionsDropdown = ({
     isTeamMaintainer,
     isTeamObserver,
     isHostOnline: hostStatus === "online",
-    isEnrolledInMdm: ["On (automatic)", "On (manual)"].includes(
-      hostMdmEnrollmentStatus ?? ""
-    ),
+    isEnrolledInMdm: [
+      "On (automatic)",
+      "On (manual)",
+      "On (personal)",
+    ].includes(hostMdmEnrollmentStatus ?? ""),
     isConnectedToFleetMdm,
     isMacMdmEnabledAndConfigured,
     isWindowsMdmEnabledAndConfigured,
@@ -75,6 +77,7 @@ const HostActionsDropdown = ({
     hostMdmDeviceStatus,
     hostScriptsEnabled,
     isPrimoMode: globalConfig?.partnerships?.enable_primo ?? false,
+    hostMdmEnrollmentStatus,
   });
 
   // No options to render. Exit early

--- a/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
@@ -935,8 +935,6 @@ const HostDetailsPage = ({
     name: host?.mdm.macos_setup?.bootstrap_package_name,
   };
 
-  // host.platform = "windows";
-
   const isDarwinHost = host.platform === "darwin";
   const isIosOrIpadosHost = isIPadOrIPhone(host.platform);
   const isAndroidHost = isAndroid(host.platform);

--- a/frontend/pages/hosts/details/cards/About/About.tests.tsx
+++ b/frontend/pages/hosts/details/cards/About/About.tests.tsx
@@ -1,0 +1,238 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+
+import createMockHost from "__mocks__/hostMock";
+import { createMockHostMdmData } from "__mocks__/mdmMock";
+
+import About from "./About";
+
+describe("About Card component", () => {
+  it("renders only the device Hardware model for Android hosts that were not enrolled in MDM personally", () => {
+    const mockHost = createMockHost({
+      platform: "android",
+      hardware_model: "Pixel 6",
+      hardware_serial: "",
+    });
+
+    render(<About aboutData={mockHost} mdm={mockHost.mdm} />);
+
+    expect(screen.getByText("Hardware model")).toBeInTheDocument();
+    expect(screen.getByText("Pixel 6")).toBeInTheDocument();
+    expect(screen.queryByText("Serial number")).not.toBeInTheDocument();
+    expect(screen.queryByText("Enrollment ID")).not.toBeInTheDocument();
+    expect(screen.queryByText("Private IP address")).not.toBeInTheDocument();
+    expect(screen.queryByText("Public IP address")).not.toBeInTheDocument();
+  });
+
+  it("renders device Hardware model and Enrollment ID for Android hosts enrolled in MDM personally", () => {
+    const mockHost = createMockHost({
+      platform: "android",
+      hardware_model: "Pixel 6",
+      hardware_serial: "",
+      uuid: "enrollment-id-12345",
+      mdm: createMockHostMdmData({
+        enrollment_status: "On (personal)",
+      }),
+    });
+
+    render(<About aboutData={mockHost} mdm={mockHost.mdm} />);
+
+    expect(screen.getByText("Hardware model")).toBeInTheDocument();
+    expect(screen.getByText("Pixel 6")).toBeInTheDocument();
+    expect(screen.queryByText("Enrollment ID")).toBeInTheDocument();
+    expect(screen.getAllByText("enrollment-id-12345")[0]).toBeInTheDocument();
+    expect(screen.queryByText("Serial number")).not.toBeInTheDocument();
+    expect(screen.queryByText("Private IP address")).not.toBeInTheDocument();
+    expect(screen.queryByText("Public IP address")).not.toBeInTheDocument();
+  });
+
+  it("renders Enrollment ID and Hardware model for personally enrolled iOS hosts", () => {
+    const mockHost = createMockHost({
+      platform: "ios",
+      hardware_model: "iPhone 12",
+      hardware_serial: "",
+      uuid: "enrollment-id-12345",
+      mdm: createMockHostMdmData({
+        enrollment_status: "On (personal)",
+      }),
+    });
+
+    render(<About aboutData={mockHost} mdm={mockHost.mdm} />);
+
+    expect(screen.getByText("Enrollment ID")).toBeInTheDocument();
+    expect(screen.getAllByText("enrollment-id-12345")[0]).toBeInTheDocument();
+    expect(screen.getByText("Hardware model")).toBeInTheDocument();
+    expect(screen.getByText("iPhone 12")).toBeInTheDocument();
+    expect(screen.queryByText("Serial number")).not.toBeInTheDocument();
+    expect(screen.queryByText("Private IP address")).not.toBeInTheDocument();
+    expect(screen.queryByText("Public IP address")).not.toBeInTheDocument();
+  });
+
+  it("renders Enrollment ID and Hardware model for personally enrolled iPad hosts", () => {
+    const mockHost = createMockHost({
+      platform: "ipados",
+      hardware_model: "IPad Pro",
+      hardware_serial: "",
+      uuid: "enrollment-id-12345",
+      mdm: createMockHostMdmData({
+        enrollment_status: "On (personal)",
+      }),
+    });
+
+    render(<About aboutData={mockHost} mdm={mockHost.mdm} />);
+
+    expect(screen.getByText("Enrollment ID")).toBeInTheDocument();
+    expect(screen.getAllByText("enrollment-id-12345")[0]).toBeInTheDocument();
+    expect(screen.getByText("Hardware model")).toBeInTheDocument();
+    expect(screen.getByText("IPad Pro")).toBeInTheDocument();
+    expect(screen.queryByText("Serial number")).not.toBeInTheDocument();
+    expect(screen.queryByText("Private IP address")).not.toBeInTheDocument();
+    expect(screen.queryByText("Public IP address")).not.toBeInTheDocument();
+  });
+
+  it("renders Serial number and Hardware model for non-personally enrolled iOS hosts", () => {
+    const mockHost = createMockHost({
+      platform: "ios",
+      hardware_model: "iPhone 12",
+      hardware_serial: "123-456-789",
+      uuid: "enrollment-id-12345",
+      mdm: createMockHostMdmData({
+        enrollment_status: "On (manual)",
+      }),
+    });
+
+    render(<About aboutData={mockHost} mdm={mockHost.mdm} />);
+
+    expect(screen.getByText("Hardware model")).toBeInTheDocument();
+    expect(screen.getByText("iPhone 12")).toBeInTheDocument();
+    expect(screen.getByText("Serial number")).toBeInTheDocument();
+    expect(screen.getAllByText("123-456-789")[0]).toBeInTheDocument();
+    expect(screen.queryByText("Enrollment ID")).not.toBeInTheDocument();
+    expect(screen.queryByText("Private IP address")).not.toBeInTheDocument();
+    expect(screen.queryByText("Public IP address")).not.toBeInTheDocument();
+  });
+
+  it("renders Enrollment ID and Hardware model for non-personally enrolled iPad hosts", () => {
+    const mockHost = createMockHost({
+      platform: "ipados",
+      hardware_model: "IPad Pro",
+      hardware_serial: "123-456-789",
+      uuid: "enrollment-id-12345",
+      mdm: createMockHostMdmData({
+        enrollment_status: "On (automatic)",
+      }),
+    });
+
+    render(<About aboutData={mockHost} mdm={mockHost.mdm} />);
+
+    expect(screen.getByText("Hardware model")).toBeInTheDocument();
+    expect(screen.getByText("IPad Pro")).toBeInTheDocument();
+    expect(screen.getByText("Serial number")).toBeInTheDocument();
+    expect(screen.getAllByText("123-456-789")[0]).toBeInTheDocument();
+    expect(screen.queryByText("Enrollment ID")).not.toBeInTheDocument();
+    expect(screen.queryByText("Private IP address")).not.toBeInTheDocument();
+    expect(screen.queryByText("Public IP address")).not.toBeInTheDocument();
+  });
+
+  it("render Hardware model, IP addresses, and EnrollmentID for all non android and ios/ipad hosts that have enrolled their personal mdm devices", () => {
+    const mockHost = createMockHost({
+      platform: "darwin",
+      hardware_model: "MacBook Pro",
+      hardware_serial: "",
+      primary_ip: "192.168.1.1",
+      public_ip: "203.0.113.1",
+      uuid: "enrollment-id-12345",
+      mdm: createMockHostMdmData({
+        enrollment_status: "On (personal)",
+      }),
+    });
+
+    render(<About aboutData={mockHost} mdm={mockHost.mdm} />);
+
+    expect(screen.getByText("Enrollment ID")).toBeInTheDocument();
+    expect(screen.getAllByText("enrollment-id-12345")[0]).toBeInTheDocument();
+    expect(screen.getByText("Hardware model")).toBeInTheDocument();
+    expect(screen.getByText("MacBook Pro")).toBeInTheDocument();
+    expect(screen.getByText("Private IP address")).toBeInTheDocument();
+    expect(screen.getAllByText("192.168.1.1")[0]).toBeInTheDocument();
+    expect(screen.getByText("Public IP address")).toBeInTheDocument();
+    expect(screen.getAllByText("203.0.113.1")[0]).toBeInTheDocument();
+    expect(screen.queryByText("Serial number")).not.toBeInTheDocument();
+  });
+
+  it("render Hardware model, IP addresses, and Serial number for all non android and ios/ipad hosts that have enrolled not enrolled in MDM", () => {
+    const mockHost = createMockHost({
+      platform: "darwin",
+      hardware_model: "MacBook Pro",
+      hardware_serial: "test-serial-number",
+      primary_ip: "192.168.1.1",
+      public_ip: "203.0.113.1",
+      uuid: "enrollment-id-12345",
+      mdm: undefined,
+    });
+
+    render(<About aboutData={mockHost} mdm={mockHost.mdm} />);
+
+    expect(screen.getByText("Hardware model")).toBeInTheDocument();
+    expect(screen.getByText("MacBook Pro")).toBeInTheDocument();
+    expect(screen.getByText("Private IP address")).toBeInTheDocument();
+    expect(screen.getAllByText("192.168.1.1")[0]).toBeInTheDocument();
+    expect(screen.getByText("Public IP address")).toBeInTheDocument();
+    expect(screen.getAllByText("203.0.113.1")[0]).toBeInTheDocument();
+    expect(screen.getByText("Serial number")).toBeInTheDocument();
+    expect(screen.getAllByText("test-serial-number")[0]).toBeInTheDocument();
+    expect(screen.queryByText("Enrollment ID")).not.toBeInTheDocument();
+  });
+
+  it("render Hardware model, IP addresses, and Serial number for all non android and ios/ipad hosts that have manually enrolled in MDM", () => {
+    const mockHost = createMockHost({
+      platform: "darwin",
+      hardware_model: "MacBook Pro",
+      hardware_serial: "test-serial-number",
+      primary_ip: "192.168.1.1",
+      public_ip: "203.0.113.1",
+      uuid: "enrollment-id-12345",
+      mdm: createMockHostMdmData({
+        enrollment_status: "On (manual)",
+      }),
+    });
+
+    render(<About aboutData={mockHost} mdm={mockHost.mdm} />);
+
+    expect(screen.getByText("Hardware model")).toBeInTheDocument();
+    expect(screen.getByText("MacBook Pro")).toBeInTheDocument();
+    expect(screen.getByText("Private IP address")).toBeInTheDocument();
+    expect(screen.getAllByText("192.168.1.1")[0]).toBeInTheDocument();
+    expect(screen.getByText("Public IP address")).toBeInTheDocument();
+    expect(screen.getAllByText("203.0.113.1")[0]).toBeInTheDocument();
+    expect(screen.getByText("Serial number")).toBeInTheDocument();
+    expect(screen.getAllByText("test-serial-number")[0]).toBeInTheDocument();
+    expect(screen.queryByText("Enrollment ID")).not.toBeInTheDocument();
+  });
+
+  it("render Hardware model, IP addresses, and Serial number for all non android and ios/ipad hosts that have automatically enrolled in MDM", () => {
+    const mockHost = createMockHost({
+      platform: "darwin",
+      hardware_model: "MacBook Pro",
+      hardware_serial: "test-serial-number",
+      primary_ip: "192.168.1.1",
+      public_ip: "203.0.113.1",
+      uuid: "enrollment-id-12345",
+      mdm: createMockHostMdmData({
+        enrollment_status: "On (automatic)",
+      }),
+    });
+
+    render(<About aboutData={mockHost} mdm={mockHost.mdm} />);
+
+    expect(screen.getByText("Hardware model")).toBeInTheDocument();
+    expect(screen.getByText("MacBook Pro")).toBeInTheDocument();
+    expect(screen.getByText("Private IP address")).toBeInTheDocument();
+    expect(screen.getAllByText("192.168.1.1")[0]).toBeInTheDocument();
+    expect(screen.getByText("Public IP address")).toBeInTheDocument();
+    expect(screen.getAllByText("203.0.113.1")[0]).toBeInTheDocument();
+    expect(screen.getByText("Serial number")).toBeInTheDocument();
+    expect(screen.getAllByText("test-serial-number")[0]).toBeInTheDocument();
+    expect(screen.queryByText("Enrollment ID")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/pages/hosts/details/cards/About/About.tsx
+++ b/frontend/pages/hosts/details/cards/About/About.tsx
@@ -26,41 +26,78 @@ interface IAboutProps {
 
 const baseClass = "about-card";
 
-const About = ({
-  aboutData,
-  munki,
-  mdm,
-  className,
-}: IAboutProps): JSX.Element => {
+const About = ({ aboutData, munki, mdm, className }: IAboutProps) => {
   const isIosOrIpadosHost = isIPadOrIPhone(aboutData.platform);
   const isAndroidHost = isAndroid(aboutData.platform);
 
+  // Generate the device ID data set based on MDM enrollment status. This is
+  // either the Enrollment ID for personal (BYOD) devices or the Serial number
+  // for business owned devices.
+  const generateDeviceIdDataSet = () => {
+    // we will default to showing the Serial number dataset. If the below consitions
+    // evaludate to true, we will instead show the Enrollment ID dataset.
+    let deviceIdDataSet = (
+      <DataSet
+        title="Serial number"
+        value={<TooltipTruncatedText value={aboutData.hardware_serial} />}
+      />
+    );
+
+    // if the host is an Android host and it is not enrolled in MDM personally,
+    // we do not show the device ID dataset at all.
+    if (isAndroidHost && mdm && mdm.enrollment_status !== "On (personal)") {
+      return null;
+    }
+
+    // for all host types, we show the Enrollment ID dataset if the host
+    // is enrolled in MDM personally. Personal (BYOD) devices do not report
+    // their serial numbers, so we show the Enrollment ID instead.
+    if (mdm && mdm.enrollment_status === "On (personal)") {
+      deviceIdDataSet = (
+        <DataSet
+          title={
+            <TooltipWrapper tipContent="Enrollment ID is a unique identifier for personal hosts. Personal (BYOD) devices don't report their serial numbers. The Enrollment ID changes with each enrollment.">
+              Enrollment ID
+            </TooltipWrapper>
+          }
+          value={<TooltipTruncatedText value={aboutData.uuid} />}
+        />
+      );
+    }
+    return deviceIdDataSet;
+  };
+
   const renderHardwareSerialAndIPs = () => {
-    if (isIosOrIpadosHost) {
+    const DeviceIdDataSet = generateDeviceIdDataSet();
+
+    // for an Android host, we show the either only the Hardware model or
+    // Hardware model and Enrollment ID dataset.
+    if (isAndroidHost) {
       return (
         <>
-          <DataSet
-            title="Serial number"
-            value={<TooltipTruncatedText value={aboutData.hardware_serial} />}
-          />
+          {DeviceIdDataSet}
           <DataSet title="Hardware model" value={aboutData.hardware_model} />
         </>
       );
     }
 
-    if (isAndroidHost) {
+    // for iOS and iPadOS hosts, we show to show a device ID dataset
+    // (either Serial number or Enrollment ID) and the hardware model.
+    if (isIosOrIpadosHost) {
       return (
-        <DataSet title="Hardware model" value={aboutData.hardware_model} />
+        <>
+          {DeviceIdDataSet}
+          <DataSet title="Hardware model" value={aboutData.hardware_model} />
+        </>
       );
     }
 
+    // all other hosts will show the Hardware model, IP addresses, and a device ID dataset
+    // (either Serial number or Enrollment ID).
     return (
       <>
         <DataSet title="Hardware model" value={aboutData.hardware_model} />
-        <DataSet
-          title="Serial number"
-          value={<TooltipTruncatedText value={aboutData.hardware_serial} />}
-        />
+        {DeviceIdDataSet}
         <DataSet
           title="Private IP address"
           value={<TooltipTruncatedText value={aboutData.primary_ip} />}

--- a/frontend/pages/hosts/details/cards/About/About.tsx
+++ b/frontend/pages/hosts/details/cards/About/About.tsx
@@ -1,18 +1,19 @@
 import React from "react";
 import classnames from "classnames";
 
-import { HumanTimeDiffWithFleetLaunchCutoff } from "components/HumanTimeDiffWithDateTip";
-import TooltipWrapper from "components/TooltipWrapper";
-import TooltipTruncatedText from "components/TooltipTruncatedText";
-import Card from "components/Card";
-
 import { IHostMdmData, IMunkiData } from "interfaces/host";
 import { isAndroid, isIPadOrIPhone } from "interfaces/platform";
+import { MDM_ENROLLMENT_STATUS_UI_MAP } from "interfaces/mdm";
 import {
   DEFAULT_EMPTY_CELL_VALUE,
   MDM_STATUS_TOOLTIP,
   BATTERY_TOOLTIP,
 } from "utilities/constants";
+
+import { HumanTimeDiffWithFleetLaunchCutoff } from "components/HumanTimeDiffWithDateTip";
+import TooltipWrapper from "components/TooltipWrapper";
+import TooltipTruncatedText from "components/TooltipTruncatedText";
+import Card from "components/Card";
 import DataSet from "components/DataSet";
 import CardHeader from "components/CardHeader";
 
@@ -96,15 +97,12 @@ const About = ({
         <DataSet
           title="MDM status"
           value={
-            !MDM_STATUS_TOOLTIP[mdm.enrollment_status] ? (
-              mdm.enrollment_status
-            ) : (
-              <TooltipWrapper
-                tipContent={MDM_STATUS_TOOLTIP[mdm.enrollment_status]}
-              >
-                {mdm.enrollment_status}
-              </TooltipWrapper>
-            )
+            <TooltipWrapper
+              tipContent={MDM_STATUS_TOOLTIP[mdm.enrollment_status]}
+              underline={mdm.enrollment_status !== "Off"}
+            >
+              {MDM_ENROLLMENT_STATUS_UI_MAP[mdm.enrollment_status].displayName}
+            </TooltipWrapper>
           }
         />
         <DataSet

--- a/frontend/utilities/constants.tsx
+++ b/frontend/utilities/constants.tsx
@@ -346,8 +346,15 @@ export const MDM_STATUS_TOOLTIP: Record<string, string | React.ReactNode> = {
   ),
   "On (manual)": (
     <span>
-      MDM was turned on manually (macOS), or hosts were automatically migrated
-      with fleetd (Windows). End users can turn MDM off.
+      MDM was turned on manually, by installing fleetd on macOS and Windows, or
+      by installing enrollment profile on macOS. End user can turn MDM off.
+    </span>
+  ),
+  "On (personal)": (
+    <span>
+      End user turned on MDM on personal (BYOD) host, by signing in with Managed
+      Apple Account on iPhone/iPad, or by enrolling Android via enrollment link
+      or by signing in with Google account. End user can turn MDM off.
     </span>
   ),
   Off: undefined, // no tooltip specified

--- a/frontend/utilities/constants.tsx
+++ b/frontend/utilities/constants.tsx
@@ -437,6 +437,7 @@ export const HOST_ABOUT_DATA = [
   "detail_updated_at",
   "last_restarted_at",
   "platform",
+  "uuid",
 ];
 
 export const HOST_OSQUERY_DATA = [

--- a/frontend/utilities/constants.tsx
+++ b/frontend/utilities/constants.tsx
@@ -4,6 +4,7 @@ import { ISchedulableQuery } from "interfaces/schedulable_query";
 import React from "react";
 import { IDropdownOption } from "interfaces/dropdownOption";
 import { ICampaign } from "interfaces/campaign";
+import { MdmEnrollmentStatus } from "interfaces/mdm";
 
 const { origin } = global.window.location;
 export const BASE_URL = `${origin}${URL_PREFIX}/api`;
@@ -336,7 +337,10 @@ export const VULNERABILITIES_SEARCH_BOX_TOOLTIP =
   'To search for an exact CVE, surround the string in double quotes (e.g. "CVE-2024-1234")';
 
 // Keys from API
-export const MDM_STATUS_TOOLTIP: Record<string, string | React.ReactNode> = {
+export const MDM_STATUS_TOOLTIP: Record<
+  MdmEnrollmentStatus,
+  React.ReactNode
+> = {
   "On (automatic)": (
     <span>
       MDM was turned on automatically using Apple Automated Device Enrollment


### PR DESCRIPTION
For [#30782](https://github.com/fleetdm/fleet/issues/30782)

This contains UI wide updates to support personal devices enrolled into MDM. This includes:

**host details about card updates**

<img width="536" height="169" alt="image" src="https://github.com/user-attachments/assets/a6e608e2-28b3-4bcc-ac03-4c45128bae66" />

**host details host actions dropdown updates (we will only show transfer and delete for host
personal devices enrolled into MDM**

<img width="217" height="193" alt="image" src="https://github.com/user-attachments/assets/7295e91a-7ceb-49f9-8351-5f2f4de7c450" />

**dashboard page MDM card updates. We've added a new row for personal devices enrolled in mdm**

<img width="775" height="448" alt="image" src="https://github.com/user-attachments/assets/ee819f16-faa4-437f-a6e8-2f6f8e6535dc" />

## NOTE

**We've also changed all instances of `On (automatic)` to `On (company-owned)`. The API still returns `On (automatic)` so this is done on the client side.**

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
- [x] Added/updated automated tests
- [x] Manual QA for all new/changed functionality
