### PR TITLE
Filter out DEB/RPM installers in ListHostSoftware when they're incompatible with the target host's distro

### DIFF
--- a/changes/29849-filter-linux-installers
+++ b/changes/29849-filter-linux-installers
@@ -1,0 +1,1 @@
+* Removed DEB and RPM installers from installable software lists on hosts with incompatible Linux distributions (e.g. Ubuntu for an RPM)

--- a/server/datastore/mysql/software.go
+++ b/server/datastore/mysql/software.go
@@ -3150,18 +3150,35 @@ func (ds *Datastore) ListHostSoftware(ctx context.Context, host *fleet.Host, opt
 	if host.TeamID != nil {
 		globalOrTeamID = *host.TeamID
 	}
+
+	// By default, installer platform takes care of omitting incompatible packages, but for Linux platforms the installer
+	// type is a bit too broad, so we filter further here. Note that we do *not* enforce this on installations, in case
+	// an admin knows that e.g. alien is installed and wants to push a package anyway. We also don't check software
+	// inventory for deb/rpm to match that way; this differs from the logic we use for auto-install queries for rpm/deb
+	// packages.
+	incompatibleExtensions := []string{"noop"}
+	if fleet.IsLinux(host.Platform) {
+		if !host.PlatformSupportsDebPackages() {
+			incompatibleExtensions = append(incompatibleExtensions, "deb")
+		}
+		if !host.PlatformSupportsRpmPackages() {
+			incompatibleExtensions = append(incompatibleExtensions, "rpm")
+		}
+	}
+
 	namedArgs := map[string]any{
-		"host_id":               host.ID,
-		"host_platform":         host.FleetPlatform(),
-		"global_or_team_id":     globalOrTeamID,
-		"is_mdm_enrolled":       opts.IsMDMEnrolled,
-		"host_label_updated_at": host.LabelUpdatedAt,
-		"avail":                 opts.OnlyAvailableForInstall,
-		"self_service":          opts.SelfServiceOnly,
-		"min_cvss":              opts.MinimumCVSS,
-		"max_cvss":              opts.MaximumCVSS,
-		"vpp_apps_platforms":    fleet.VPPAppsPlatforms,
-		"known_exploit":         1,
+		"host_id":                 host.ID,
+		"host_platform":           host.FleetPlatform(),
+		"incompatible_extensions": incompatibleExtensions,
+		"global_or_team_id":       globalOrTeamID,
+		"is_mdm_enrolled":         opts.IsMDMEnrolled,
+		"host_label_updated_at":   host.LabelUpdatedAt,
+		"avail":                   opts.OnlyAvailableForInstall,
+		"self_service":            opts.SelfServiceOnly,
+		"min_cvss":                opts.MinimumCVSS,
+		"max_cvss":                opts.MaximumCVSS,
+		"vpp_apps_platforms":      fleet.VPPAppsPlatforms,
+		"known_exploit":           1,
 	}
 	var hasCVEMetaFilters bool
 	if opts.KnownExploit || opts.MinimumCVSS > 0 || opts.MaximumCVSS > 0 {
@@ -3349,7 +3366,7 @@ func (ds *Datastore) ListHostSoftware(ctx context.Context, host *fleet.Host, opt
 				software_titles st
 			LEFT OUTER JOIN
 				-- filter out software that is not available for install on the host's platform
-				software_installers si ON st.id = si.title_id AND si.platform = :host_compatible_platforms AND si.global_or_team_id = :global_or_team_id
+				software_installers si ON st.id = si.title_id AND si.platform = :host_compatible_platforms AND si.extension NOT IN (:incompatible_extensions) AND si.global_or_team_id = :global_or_team_id
 			LEFT OUTER JOIN
 				-- include VPP apps only if the host is on a supported platform
 				vpp_apps vap ON st.id = vap.title_id AND :host_platform IN (:vpp_apps_platforms)

--- a/server/datastore/mysql/software_test.go
+++ b/server/datastore/mysql/software_test.go
@@ -4729,7 +4729,8 @@ func testListLinuxHostSoftware(t *testing.T, ds *Datastore) {
 	rpmHost := test.NewHost(t, ds, "RHEL", "", "host1key", "host1uuid", time.Now(), test.WithPlatform("rhel"))
 	debHost := test.NewHost(t, ds, "Ubuntu", "", "host2key", "host2uuid", time.Now(), test.WithPlatform("pop"))
 	archHost := test.NewHost(t, ds, "Arch", "", "host3key", "host3uuid", time.Now(), test.WithPlatform("arch"))
-	macHost := test.NewHost(t, ds, "Mac", "", "host4key", "host4uuid", time.Now(), test.WithPlatform("darwin"))
+	genericLinuxHost := test.NewHost(t, ds, "Vanilla Linux", "", "host4key", "host4uuid", time.Now(), test.WithPlatform("linux"))
+	macHost := test.NewHost(t, ds, "Mac", "", "host5key", "host5uuid", time.Now(), test.WithPlatform("darwin"))
 
 	// Add titles and installers for deb (visible on deb host), rpm (visible on rpm host), tarball (visible on non-Mac hosts)
 	type installerInfo struct {
@@ -4768,10 +4769,11 @@ func testListLinuxHostSoftware(t *testing.T, ds *Datastore) {
 		opts := fleet.HostSoftwareTitleListOptions{OnlyAvailableForInstall: true, ListOptions: fleet.ListOptions{OrderKey: "name"}}
 
 		for host, expectedInstallers := range map[*fleet.Host][]installerInfo{
-			rpmHost:  {installers["rpm_packages"], installers["tgz_packages"]},
-			debHost:  {installers["deb_packages"], installers["tgz_packages"]},
-			archHost: {installers["tgz_packages"]},
-			macHost:  {},
+			rpmHost:          {installers["rpm_packages"], installers["tgz_packages"]},
+			debHost:          {installers["deb_packages"], installers["tgz_packages"]},
+			archHost:         {installers["tgz_packages"]},
+			genericLinuxHost: {installers["deb_packages"], installers["rpm_packages"], installers["tgz_packages"]},
+			macHost:          {},
 		} {
 			t.Run(host.Hostname, func(t *testing.T) {
 				sw, _, err := ds.ListHostSoftware(ctx, host, opts)

--- a/server/datastore/mysql/software_test.go
+++ b/server/datastore/mysql/software_test.go
@@ -4750,7 +4750,8 @@ func testListLinuxHostSoftware(t *testing.T, ds *Datastore) {
 		scriptContentID, _ := res.LastInsertId()
 
 		for source, installer := range installers {
-			res, err := q.ExecContext(ctx, `INSERT INTO software_titles (name, source) VALUES (?, ?)`, source, source)
+			res, err = q.ExecContext(ctx, `INSERT INTO software_titles (name, source) VALUES (?, ?)`, source, source)
+			require.NoError(t, err)
 			titleID, _ := res.LastInsertId()
 
 			_, err = q.ExecContext(ctx, `
@@ -4761,9 +4762,7 @@ func testListLinuxHostSoftware(t *testing.T, ds *Datastore) {
 				nil, 0, titleID, installer.Filename, installer.Extension, "2.0.0",
 				scriptContentID, scriptContentID,
 				hex.EncodeToString([]byte("test")), "linux", true)
-			if err != nil {
-				return err
-			}
+			require.NoError(t, err)
 		}
 
 		opts := fleet.HostSoftwareTitleListOptions{OnlyAvailableForInstall: true, ListOptions: fleet.ListOptions{OrderKey: "name"}}

--- a/server/fleet/hosts.go
+++ b/server/fleet/hosts.go
@@ -979,6 +979,7 @@ var HostNeitherDebNorRpmPackageOSs = map[string]struct{}{
 
 // HostDebPackageOSs are the list of known Linux platforms that support DEB packages
 var HostDebPackageOSs = map[string]struct{}{
+	"linux":     {}, // let DEBs through if we're looking at a generic Linux host
 	"ubuntu":    {},
 	"debian":    {},
 	"kali":      {},
@@ -990,6 +991,7 @@ var HostDebPackageOSs = map[string]struct{}{
 
 // HostRpmPackageOSs are the list of known Linux platforms that support RPM packages
 var HostRpmPackageOSs = map[string]struct{}{
+	"linux":               {}, // let RPMs through if we're looking at a generic Linux host
 	"rhel":                {},
 	"centos":              {},
 	"sles":                {},

--- a/server/fleet/hosts.go
+++ b/server/fleet/hosts.go
@@ -942,6 +942,16 @@ func (h *Host) FleetPlatform() string {
 	return PlatformFromHost(h.Platform)
 }
 
+func (h *Host) PlatformSupportsRpmPackages() bool {
+	_, ok := HostRpmPackageOSs[h.Platform]
+	return ok
+}
+
+func (h *Host) PlatformSupportsDebPackages() bool {
+	_, ok := HostDebPackageOSs[h.Platform]
+	return ok
+}
+
 // SupportsOsquery returns whether the device runs osquery.
 func (h *Host) SupportsOsquery() bool {
 	return PlatformSupportsOsquery(h.Platform)
@@ -955,6 +965,37 @@ func PlatformSupportsOsquery(platform string) bool {
 // HostLinuxOSs are the possible linux values for Host.Platform.
 var HostLinuxOSs = []string{
 	"linux", "ubuntu", "debian", "rhel", "centos", "sles", "kali", "gentoo", "amzn", "pop", "arch", "linuxmint", "void", "nixos", "endeavouros", "manjaro", "opensuse-leap", "opensuse-tumbleweed", "tuxedo", "neon",
+}
+
+// HostNeitherDebNorRpmPackageOSs are the list of known Linux platforms that support neither DEB nor RPM packages
+var HostNeitherDebNorRpmPackageOSs = map[string]struct{}{
+	"arch":        {},
+	"gentoo":      {},
+	"void":        {},
+	"nixos":       {},
+	"endeavouros": {},
+	"manjaro":     {},
+}
+
+// HostDebPackageOSs are the list of known Linux platforms that support DEB packages
+var HostDebPackageOSs = map[string]struct{}{
+	"ubuntu":    {},
+	"debian":    {},
+	"kali":      {},
+	"pop":       {},
+	"linuxmint": {},
+	"tuxedo":    {},
+	"neon":      {},
+}
+
+// HostRpmPackageOSs are the list of known Linux platforms that support RPM packages
+var HostRpmPackageOSs = map[string]struct{}{
+	"rhel":                {},
+	"centos":              {},
+	"sles":                {},
+	"amzn":                {},
+	"opensuse-leap":       {},
+	"opensuse-tumbleweed": {},
 }
 
 func IsLinux(hostPlatform string) bool {

--- a/server/fleet/hosts_test.go
+++ b/server/fleet/hosts_test.go
@@ -11,6 +11,22 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// ensure all Linuxes are in one of the three package support groups
+func TestHostLinuxPlatformPackageCompatibility(t *testing.T) {
+	for _, os := range HostLinuxOSs {
+		if os == "linux" {
+			continue
+		}
+		h := &Host{Platform: os}
+		_, isNeitherDebNorRpm := HostNeitherDebNorRpmPackageOSs[h.Platform]
+		if isNeitherDebNorRpm {
+			continue
+		}
+
+		require.True(t, h.PlatformSupportsDebPackages() || h.PlatformSupportsRpmPackages())
+	}
+}
+
 func TestHostStatus(t *testing.T) {
 	mockClock := clock.NewMockClock()
 

--- a/server/fleet/hosts_test.go
+++ b/server/fleet/hosts_test.go
@@ -14,9 +14,6 @@ import (
 // ensure all Linuxes are in one of the three package support groups
 func TestHostLinuxPlatformPackageCompatibility(t *testing.T) {
 	for _, os := range HostLinuxOSs {
-		if os == "linux" {
-			continue
-		}
 		h := &Host{Platform: os}
 		_, isNeitherDebNorRpm := HostNeitherDebNorRpmPackageOSs[h.Platform]
 		if isNeitherDebNorRpm {

--- a/server/service/integration_enterprise_test.go
+++ b/server/service/integration_enterprise_test.go
@@ -12024,7 +12024,7 @@ func (s *integrationEnterpriseTestSuite) TestBatchSetSoftwareInstallersSideEffec
 		OsqueryHostID:   ptr.String(t.Name() + uuid.New().String()),
 		NodeKey:         ptr.String(t.Name() + uuid.New().String()),
 		Hostname:        fmt.Sprintf("%sfoo.local", t.Name()),
-		Platform:        "linux",
+		Platform:        "ubuntu",
 	})
 	require.NoError(t, err)
 	err = s.ds.AddHostsToTeam(context.Background(), &tm.ID, []uint{h.ID})
@@ -12044,7 +12044,7 @@ func (s *integrationEnterpriseTestSuite) TestBatchSetSoftwareInstallersSideEffec
 		OsqueryHostID:   ptr.String(t.Name() + uuid.New().String()),
 		NodeKey:         ptr.String(t.Name() + uuid.New().String()),
 		Hostname:        fmt.Sprintf("%sbar.local", t.Name()),
-		Platform:        "linux",
+		Platform:        "ubuntu",
 	})
 	require.NoError(t, err)
 	err = s.ds.AddHostsToTeam(context.Background(), &tm.ID, []uint{h2.ID})
@@ -12487,7 +12487,7 @@ func (s *integrationEnterpriseTestSuite) TestSoftwareInstallerHostRequests() {
 		OsqueryHostID:   ptr.String(t.Name() + uuid.New().String()),
 		NodeKey:         ptr.String(t.Name() + uuid.New().String()),
 		Hostname:        fmt.Sprintf("%sfoo.local", t.Name()),
-		Platform:        "linux",
+		Platform:        "ubuntu",
 	})
 	require.NoError(t, err)
 	err = s.ds.AddHostsToTeam(context.Background(), teamID, []uint{h.ID})
@@ -12581,9 +12581,9 @@ func (s *integrationEnterpriseTestSuite) TestSoftwareInstallerHostRequests() {
 
 	// create 3 more hosts, will have statuses installed, failed and one with two
 	// install requests - one failed and the latest install pending
-	h2 := createOrbitEnrolledHost(t, "linux", "host2", s.ds)
-	h3 := createOrbitEnrolledHost(t, "linux", "host3", s.ds)
-	h4 := createOrbitEnrolledHost(t, "linux", "host4", s.ds)
+	h2 := createOrbitEnrolledHost(t, "linuxmint", "host2", s.ds)
+	h3 := createOrbitEnrolledHost(t, "debian", "host3", s.ds)
+	h4 := createOrbitEnrolledHost(t, "tuxedo", "host4", s.ds)
 	err = s.ds.AddHostsToTeam(context.Background(), teamID, []uint{h2.ID, h3.ID, h4.ID})
 	require.NoError(t, err)
 
@@ -12978,11 +12978,11 @@ func (s *integrationEnterpriseTestSuite) TestSoftwareInstallerHostRequests() {
 func (s *integrationEnterpriseTestSuite) TestSelfServiceSoftwareInstallUninstall() {
 	t := s.T()
 
-	host1 := createOrbitEnrolledHost(t, "linux", "", s.ds)
+	host1 := createOrbitEnrolledHost(t, "ubuntu", "", s.ds)
 	token := "secret_token"
 	createDeviceTokenForHost(t, s.ds, host1.ID, token)
 
-	host2 := createOrbitEnrolledHost(t, "linux", "2", s.ds)
+	host2 := createOrbitEnrolledHost(t, "ubuntu", "2", s.ds)
 	token2 := "secret_token2"
 	createDeviceTokenForHost(t, s.ds, host2.ID, token2)
 


### PR DESCRIPTION
Fixes #29849.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.
- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [x] Added/updated automated tests
- [x] Manual QA for all new/changed functionality