### PR TITLE
[orbit] install missing extensions upon startup

### DIFF
--- a/orbit/changes/30863-install-missing-extensions-on-startup
+++ b/orbit/changes/30863-install-missing-extensions-on-startup
@@ -1,0 +1,1 @@
+- Orbit now installs any missing extensions configured via `agent_options` when it first starts, instead of waiting for the next update cycle.


### PR DESCRIPTION
osquery extensions configured via `agent_options` aren't currently installed when orbit starts, due to a race between orbit's own self-update and the fetching of the agent configuration.

To workaround this, check if the local hash is stored immediately after calling `StoreLocalHash` while enumerating extensions from the agent config. If any are missing, trigger an updater run prior to starting osqueryd.

Closes #30863

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.
- [x] Manual QA for all new/changed functionality
- For Orbit and Fleet Desktop changes:
   - [ ] Manual QA must be performed in the three main OSs, macOS, Windows and Linux.
   - [ ] Auto-update manual QA, from released version of component to new version (see [tools/tuf/test](../tools/tuf/test/README.md)).