### PR TITLE
Allow vulnerability webhook to run without license

### DIFF
--- a/changes/30869-vulnerability-webhook-free
+++ b/changes/30869-vulnerability-webhook-free
@@ -1,0 +1,1 @@
+* Allow vulnerability webhook to run without license


### PR DESCRIPTION
When no license is provided, skip the vulnerabilities filtering based on CVE metadata, which aren't populated, and trigger the webhook for all vulnerabilities.

Closes #29076

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.
- [ ] Added/updated automated tests
- [ ] Manual QA for all new/changed functionality