### PR TITLE
Removing status from Figma cover page

### DIFF
--- a/handbook/product-design/README.md
+++ b/handbook/product-design/README.md
@@ -49,7 +49,7 @@ At Fleet, like [GitLab](https://about.gitlab.com/handbook/product-development-fl
 1. Take the top user story that is assigned to you in the "Ready" column of the [drafting board](https://github.com/orgs/fleetdm/projects/67) and move it to "In progress."
   
 2. Create a new file inside the [Fleet product](https://www.figma.com/files/project/17318630/%F0%9F%94%9C%F0%9F%93%A6-Fleet-EE%C2%AE-(product)?fuid=1234929285759903870) Figma project by duplicating "\[TEMPLATE\] Starter file" (pinned to the top of the project). The starter file includes three predefined pages: "Cover," "Ready," and "Scratchpad."
-   -  **Cover**: This page has a component with issue number, issue name, and status fields. There are three statuses: "Work In Progress (WIP)," "Approved," and "Released" (the drafting board is still the source of truth).
+   -  **Cover**: This page has a component with the issue number and issue name.
    -  **Ready**: Use this page to communicate design reviews and development.
    -  **Scratchpad**: Use this page to keep "work in progress" designs that might be useful in the future.
 
@@ -100,7 +100,7 @@ Additionally:
 
 ### Ensure story drafting is complete
 
-Once a story is approved in [design review](https://fleetdm.com/handbook/company/product-groups#design-reviews), the Product Designer is responsible for moving the user story to the "Ready to spec" column, assigning the appropriate Engineering Manager (EM), adding a product group label, and changing the status on the cover page of the relevant Figma file to "Approved".
+Once a story is approved in [design review](https://fleetdm.com/handbook/company/product-groups#design-reviews), the Product Designer is responsible for moving the user story to the "Ready to spec" column, assigning the appropriate Engineering Manager (EM), and adding a product group label.
 
 The EM is responsible for moving the user story to the "Specified" and "Estimated" columns.
 


### PR DESCRIPTION
We decided to remove status from Figma cover page, because it's hard to maintain and often status doesn't reflect real state of the issue.

Before:
<img width="754" height="492" alt="Screenshot 2025-07-15 at 11 57 14" src="https://github.com/user-attachments/assets/f9600095-526a-4c7b-811b-3dcdf00f64dc" />

After:
<img width="710" height="470" alt="Screenshot 2025-07-15 at 11 57 34" src="https://github.com/user-attachments/assets/849922a0-5cfe-4644-990d-5c4112ed2b14" />
