### PR TITLE
Refactor EnrollOrbit/EnrollHost

### DIFF
--- a/server/datastore/mysql/apple_mdm_test.go
+++ b/server/datastore/mysql/apple_mdm_test.go
@@ -4595,7 +4595,11 @@ func TestHostDEPAssignments(t *testing.T) {
 		require.Equal(t, *depAssignment.ABMTokenID, abmToken.ID)
 
 		// simulate initial osquery enrollment via Orbit
-		testHost, err := ds.EnrollOrbit(ctx, true, fleet.OrbitHostInfo{HardwareSerial: depSerial, Platform: "darwin", HardwareUUID: depUUID, Hostname: "dep-host"}, depOrbitNodeKey, nil)
+		testHost, err := ds.EnrollOrbit(ctx,
+			fleet.WithOrbitEnrollMDMEnabled(true),
+			fleet.WithOrbitEnrollHostInfo(fleet.OrbitHostInfo{HardwareSerial: depSerial, Platform: "darwin", HardwareUUID: depUUID, Hostname: "dep-host"}),
+			fleet.WithOrbitEnrollNodeKey(depOrbitNodeKey),
+		)
 		require.NoError(t, err)
 		require.NotNil(t, testHost)
 
@@ -4744,7 +4748,11 @@ func TestHostDEPAssignments(t *testing.T) {
 		require.Nil(t, hdepa)
 
 		// simulate initial osquery enrollment via Orbit
-		manualHost, err := ds.EnrollOrbit(ctx, true, fleet.OrbitHostInfo{HardwareSerial: manualSerial, Platform: "darwin", HardwareUUID: manualUUID, Hostname: "maunual-host"}, manualOrbitNodeKey, nil)
+		manualHost, err := ds.EnrollOrbit(ctx,
+			fleet.WithOrbitEnrollMDMEnabled(true),
+			fleet.WithOrbitEnrollHostInfo(fleet.OrbitHostInfo{HardwareSerial: manualSerial, Platform: "darwin", HardwareUUID: manualUUID, Hostname: "maunual-host"}),
+			fleet.WithOrbitEnrollNodeKey(manualOrbitNodeKey),
+		)
 		require.NoError(t, err)
 		require.Equal(t, manualHostID, manualHost.ID)
 
@@ -5852,12 +5860,16 @@ func TestRestorePendingDEPHost(t *testing.T) {
 			require.WithinDuration(t, time.Now(), depAssignment.AddedAt, 5*time.Second)
 
 			// simulate initial osquery enrollment via Orbit
-			h, err := ds.EnrollOrbit(ctx, true, fleet.OrbitHostInfo{
-				HardwareSerial: depSerial,
-				Platform:       "darwin",
-				HardwareUUID:   depUUID,
-				Hostname:       "dep-host",
-			}, depOrbitNodeKey, nil)
+			h, err := ds.EnrollOrbit(ctx,
+				fleet.WithOrbitEnrollMDMEnabled(true),
+				fleet.WithOrbitEnrollHostInfo(fleet.OrbitHostInfo{
+					HardwareSerial: depSerial,
+					Platform:       "darwin",
+					HardwareUUID:   depUUID,
+					Hostname:       "dep-host",
+				}),
+				fleet.WithOrbitEnrollNodeKey(depOrbitNodeKey),
+			)
 			require.NoError(t, err)
 			require.NotNil(t, h)
 			require.Equal(t, depHostID, h.ID)

--- a/server/datastore/mysql/apple_mdm_test.go
+++ b/server/datastore/mysql/apple_mdm_test.go
@@ -4596,9 +4596,9 @@ func TestHostDEPAssignments(t *testing.T) {
 
 		// simulate initial osquery enrollment via Orbit
 		testHost, err := ds.EnrollOrbit(ctx,
-			fleet.WithOrbitEnrollMDMEnabled(true),
-			fleet.WithOrbitEnrollHostInfo(fleet.OrbitHostInfo{HardwareSerial: depSerial, Platform: "darwin", HardwareUUID: depUUID, Hostname: "dep-host"}),
-			fleet.WithOrbitEnrollNodeKey(depOrbitNodeKey),
+			fleet.WithEnrollOrbitMDMEnabled(true),
+			fleet.WithEnrollOrbitHostInfo(fleet.OrbitHostInfo{HardwareSerial: depSerial, Platform: "darwin", HardwareUUID: depUUID, Hostname: "dep-host"}),
+			fleet.WithEnrollOrbitNodeKey(depOrbitNodeKey),
 		)
 		require.NoError(t, err)
 		require.NotNil(t, testHost)
@@ -4749,9 +4749,9 @@ func TestHostDEPAssignments(t *testing.T) {
 
 		// simulate initial osquery enrollment via Orbit
 		manualHost, err := ds.EnrollOrbit(ctx,
-			fleet.WithOrbitEnrollMDMEnabled(true),
-			fleet.WithOrbitEnrollHostInfo(fleet.OrbitHostInfo{HardwareSerial: manualSerial, Platform: "darwin", HardwareUUID: manualUUID, Hostname: "maunual-host"}),
-			fleet.WithOrbitEnrollNodeKey(manualOrbitNodeKey),
+			fleet.WithEnrollOrbitMDMEnabled(true),
+			fleet.WithEnrollOrbitHostInfo(fleet.OrbitHostInfo{HardwareSerial: manualSerial, Platform: "darwin", HardwareUUID: manualUUID, Hostname: "maunual-host"}),
+			fleet.WithEnrollOrbitNodeKey(manualOrbitNodeKey),
 		)
 		require.NoError(t, err)
 		require.Equal(t, manualHostID, manualHost.ID)
@@ -5861,14 +5861,14 @@ func TestRestorePendingDEPHost(t *testing.T) {
 
 			// simulate initial osquery enrollment via Orbit
 			h, err := ds.EnrollOrbit(ctx,
-				fleet.WithOrbitEnrollMDMEnabled(true),
-				fleet.WithOrbitEnrollHostInfo(fleet.OrbitHostInfo{
+				fleet.WithEnrollOrbitMDMEnabled(true),
+				fleet.WithEnrollOrbitHostInfo(fleet.OrbitHostInfo{
 					HardwareSerial: depSerial,
 					Platform:       "darwin",
 					HardwareUUID:   depUUID,
 					Hostname:       "dep-host",
 				}),
-				fleet.WithOrbitEnrollNodeKey(depOrbitNodeKey),
+				fleet.WithEnrollOrbitNodeKey(depOrbitNodeKey),
 			)
 			require.NoError(t, err)
 			require.NotNil(t, h)

--- a/server/datastore/mysql/hosts.go
+++ b/server/datastore/mysql/hosts.go
@@ -2189,7 +2189,20 @@ func (ds *Datastore) EnrollOrbit(ctx context.Context, opts ...fleet.DatastoreEnr
 }
 
 // EnrollHost enrolls the osquery agent to Fleet.
-func (ds *Datastore) EnrollHost(ctx context.Context, isMDMEnabled bool, osqueryHostID, hardwareUUID, hardwareSerial, nodeKey string, teamID *uint, cooldown time.Duration) (*fleet.Host, error) {
+func (ds *Datastore) EnrollHost(ctx context.Context, opts ...fleet.DatastoreEnrollHostOption) (*fleet.Host, error) {
+	enrollConfig := &fleet.DatastoreEnrollHostConfig{}
+	for _, opt := range opts {
+		opt(enrollConfig)
+	}
+
+	isMDMEnabled := enrollConfig.IsMDMEnabled
+	osqueryHostID := enrollConfig.OsqueryHostID
+	hardwareUUID := enrollConfig.HardwareUUID
+	hardwareSerial := enrollConfig.HardwareSerial
+	nodeKey := enrollConfig.NodeKey
+	teamID := enrollConfig.TeamID
+	cooldown := enrollConfig.Cooldown
+
 	if osqueryHostID == "" {
 		return nil, ctxerr.New(ctx, "missing osquery host identifier")
 	}

--- a/server/datastore/mysql/hosts.go
+++ b/server/datastore/mysql/hosts.go
@@ -2024,7 +2024,17 @@ func matchHostDuringEnrollment(
 	}, nil
 }
 
-func (ds *Datastore) EnrollOrbit(ctx context.Context, isMDMEnabled bool, hostInfo fleet.OrbitHostInfo, orbitNodeKey string, teamID *uint) (*fleet.Host, error) {
+func (ds *Datastore) EnrollOrbit(ctx context.Context, opts ...fleet.DatastoreEnrollOrbitOption) (*fleet.Host, error) {
+	orbitConfig := &fleet.DatastoreEnrollOrbitConfig{}
+	for _, opt := range opts {
+		opt(orbitConfig)
+	}
+
+	isMDMEnabled := orbitConfig.IsMDMEnabled
+	hostInfo := orbitConfig.HostInfo
+	orbitNodeKey := orbitConfig.OrbitNodeKey
+	teamID := orbitConfig.TeamID
+
 	if orbitNodeKey == "" {
 		return nil, ctxerr.New(ctx, "orbit node key is empty")
 	}

--- a/server/datastore/mysql/hosts_test.go
+++ b/server/datastore/mysql/hosts_test.go
@@ -8351,11 +8351,11 @@ func testHostsLoadHostByOrbitNodeKey(t *testing.T, ds *Datastore) {
 		// on orbit enrollment, the "hardware UUID" is matched with the osquery
 		// host ID to identify the host being enrolled
 		_, err = ds.EnrollOrbit(ctx,
-			fleet.WithOrbitEnrollHostInfo(fleet.OrbitHostInfo{
+			fleet.WithEnrollOrbitHostInfo(fleet.OrbitHostInfo{
 				HardwareUUID:   *h.OsqueryHostID,
 				HardwareSerial: h.HardwareSerial,
 			}),
-			fleet.WithOrbitEnrollNodeKey(orbitKey),
+			fleet.WithEnrollOrbitNodeKey(orbitKey),
 		)
 		require.NoError(t, err)
 
@@ -8393,11 +8393,11 @@ func testHostsLoadHostByOrbitNodeKey(t *testing.T, ds *Datastore) {
 
 		orbitKey := uuid.New().String()
 		_, err = ds.EnrollOrbit(ctx,
-			fleet.WithOrbitEnrollHostInfo(fleet.OrbitHostInfo{
+			fleet.WithEnrollOrbitHostInfo(fleet.OrbitHostInfo{
 				HardwareUUID:   *h.OsqueryHostID,
 				HardwareSerial: h.HardwareSerial,
 			}),
-			fleet.WithOrbitEnrollNodeKey(orbitKey),
+			fleet.WithEnrollOrbitNodeKey(orbitKey),
 		)
 		require.NoError(t, err)
 		h.OrbitNodeKey = &orbitKey
@@ -8874,12 +8874,12 @@ func testHostsEnrollOrbit(t *testing.T, ds *Datastore) {
 	// create and enroll a host with just an osquery ID, no serial
 	hOsqueryNoSerial := createHost(uuid.New().String(), "")
 	h, err := ds.EnrollOrbit(ctx,
-		fleet.WithOrbitEnrollMDMEnabled(true),
-		fleet.WithOrbitEnrollHostInfo(fleet.OrbitHostInfo{
+		fleet.WithEnrollOrbitMDMEnabled(true),
+		fleet.WithEnrollOrbitHostInfo(fleet.OrbitHostInfo{
 			HardwareUUID:   *hOsqueryNoSerial.OsqueryHostID,
 			HardwareSerial: hOsqueryNoSerial.HardwareSerial,
 		}),
-		fleet.WithOrbitEnrollNodeKey(uuid.New().String()),
+		fleet.WithEnrollOrbitNodeKey(uuid.New().String()),
 	)
 	require.NoError(t, err)
 	require.Equal(t, hOsqueryNoSerial.ID, h.ID)
@@ -8895,12 +8895,12 @@ func testHostsEnrollOrbit(t *testing.T, ds *Datastore) {
 	// ID)
 	hSerialNoOsquery := createHost("", uuid.New().String())
 	h, err = ds.EnrollOrbit(ctx,
-		fleet.WithOrbitEnrollMDMEnabled(true),
-		fleet.WithOrbitEnrollHostInfo(fleet.OrbitHostInfo{
+		fleet.WithEnrollOrbitMDMEnabled(true),
+		fleet.WithEnrollOrbitHostInfo(fleet.OrbitHostInfo{
 			HardwareUUID:   uuid.New().String(),
 			HardwareSerial: hSerialNoOsquery.HardwareSerial,
 		}),
-		fleet.WithOrbitEnrollNodeKey(uuid.New().String()),
+		fleet.WithEnrollOrbitNodeKey(uuid.New().String()),
 	)
 	require.NoError(t, err)
 	require.Equal(t, hSerialNoOsquery.ID, h.ID)
@@ -8909,14 +8909,14 @@ func testHostsEnrollOrbit(t *testing.T, ds *Datastore) {
 	// create and enroll a host with both
 	hBoth := createHost(uuid.New().String(), uuid.New().String())
 	h, err = ds.EnrollOrbit(ctx,
-		fleet.WithOrbitEnrollMDMEnabled(true),
-		fleet.WithOrbitEnrollHostInfo(fleet.OrbitHostInfo{
+		fleet.WithEnrollOrbitMDMEnabled(true),
+		fleet.WithEnrollOrbitHostInfo(fleet.OrbitHostInfo{
 			HardwareUUID:   *hBoth.OsqueryHostID,
 			HardwareSerial: hBoth.HardwareSerial,
 			ComputerName:   hBoth.ComputerName,
 			HardwareModel:  hBoth.HardwareModel,
 		}),
-		fleet.WithOrbitEnrollNodeKey(uuid.New().String()),
+		fleet.WithEnrollOrbitNodeKey(uuid.New().String()),
 	)
 	require.NoError(t, err)
 	require.Equal(t, hBoth.ID, h.ID)
@@ -8932,12 +8932,12 @@ func testHostsEnrollOrbit(t *testing.T, ds *Datastore) {
 	// enroll with osquery id from hBoth and serial from hSerialNoOsquery (should
 	// use the osquery match)
 	h, err = ds.EnrollOrbit(ctx,
-		fleet.WithOrbitEnrollMDMEnabled(true),
-		fleet.WithOrbitEnrollHostInfo(fleet.OrbitHostInfo{
+		fleet.WithEnrollOrbitMDMEnabled(true),
+		fleet.WithEnrollOrbitHostInfo(fleet.OrbitHostInfo{
 			HardwareUUID:   *hBoth.OsqueryHostID,
 			HardwareSerial: hSerialNoOsquery.HardwareSerial,
 		}),
-		fleet.WithOrbitEnrollNodeKey(uuid.New().String()),
+		fleet.WithEnrollOrbitNodeKey(uuid.New().String()),
 	)
 	require.NoError(t, err)
 	require.Equal(t, hBoth.ID, h.ID)
@@ -8946,8 +8946,8 @@ func testHostsEnrollOrbit(t *testing.T, ds *Datastore) {
 	// enroll with no match, will create a new one
 	newSerial := uuid.NewString()
 	h, err = ds.EnrollOrbit(ctx,
-		fleet.WithOrbitEnrollMDMEnabled(true),
-		fleet.WithOrbitEnrollHostInfo(fleet.OrbitHostInfo{
+		fleet.WithEnrollOrbitMDMEnabled(true),
+		fleet.WithEnrollOrbitHostInfo(fleet.OrbitHostInfo{
 			HardwareUUID:   uuid.New().String(),
 			HardwareSerial: newSerial,
 			Hostname:       "foo2",
@@ -8955,7 +8955,7 @@ func testHostsEnrollOrbit(t *testing.T, ds *Datastore) {
 			ComputerName:   "New computer",
 			HardwareModel:  "ABC-3000",
 		}),
-		fleet.WithOrbitEnrollNodeKey(uuid.New().String()),
+		fleet.WithEnrollOrbitNodeKey(uuid.New().String()),
 	)
 	require.NoError(t, err)
 	require.Greater(t, h.ID, hBoth.ID)
@@ -8974,12 +8974,12 @@ func testHostsEnrollOrbit(t *testing.T, ds *Datastore) {
 	hDupSerial2 := createHost("", hDupSerial1.HardwareSerial)
 	require.Greater(t, hDupSerial2.ID, hDupSerial1.ID)
 	h, err = ds.EnrollOrbit(ctx,
-		fleet.WithOrbitEnrollMDMEnabled(true),
-		fleet.WithOrbitEnrollHostInfo(fleet.OrbitHostInfo{
+		fleet.WithEnrollOrbitMDMEnabled(true),
+		fleet.WithEnrollOrbitHostInfo(fleet.OrbitHostInfo{
 			HardwareUUID:   uuid.New().String(),
 			HardwareSerial: hDupSerial1.HardwareSerial,
 		}),
-		fleet.WithOrbitEnrollNodeKey(uuid.New().String()),
+		fleet.WithEnrollOrbitNodeKey(uuid.New().String()),
 	)
 	require.NoError(t, err)
 	require.Equal(t, hDupSerial1.ID, h.ID)
@@ -8987,12 +8987,12 @@ func testHostsEnrollOrbit(t *testing.T, ds *Datastore) {
 	// enroll with osquery ID from hOsqueryNoSerial and the duplicate serial,
 	// will always match osquery ID
 	h, err = ds.EnrollOrbit(ctx,
-		fleet.WithOrbitEnrollMDMEnabled(true),
-		fleet.WithOrbitEnrollHostInfo(fleet.OrbitHostInfo{
+		fleet.WithEnrollOrbitMDMEnabled(true),
+		fleet.WithEnrollOrbitHostInfo(fleet.OrbitHostInfo{
 			HardwareUUID:   *hOsqueryNoSerial.OsqueryHostID,
 			HardwareSerial: hDupSerial1.HardwareSerial,
 		}),
-		fleet.WithOrbitEnrollNodeKey(uuid.New().String()),
+		fleet.WithEnrollOrbitNodeKey(uuid.New().String()),
 	)
 	require.NoError(t, err)
 	require.Equal(t, hOsqueryNoSerial.ID, h.ID)
@@ -9009,13 +9009,13 @@ func testHostsEnrollOrbit(t *testing.T, ds *Datastore) {
 		randomIdentifierH1 := uuid.New().String()
 
 		h1Orbit, err := ds.EnrollOrbit(ctx,
-			fleet.WithOrbitEnrollHostInfo(fleet.OrbitHostInfo{
+			fleet.WithEnrollOrbitHostInfo(fleet.OrbitHostInfo{
 				HardwareUUID:      dupUUID,
 				HardwareSerial:    dupHWSerial,
 				OsqueryIdentifier: randomIdentifierH1,
 				Platform:          platform,
 			}),
-			fleet.WithOrbitEnrollNodeKey(uuid.New().String()),
+			fleet.WithEnrollOrbitNodeKey(uuid.New().String()),
 		)
 		require.NoError(t, err)
 		h1Osquery, err := ds.EnrollHost(ctx, false, randomIdentifierH1, dupUUID, dupHWSerial, uuid.New().String(), nil, 0)
@@ -9023,13 +9023,13 @@ func testHostsEnrollOrbit(t *testing.T, ds *Datastore) {
 		require.Equal(t, h1Orbit.ID, h1Osquery.ID)
 		randomIdentifierH2 := uuid.New().String()
 		h2Orbit, err := ds.EnrollOrbit(ctx,
-			fleet.WithOrbitEnrollHostInfo(fleet.OrbitHostInfo{
+			fleet.WithEnrollOrbitHostInfo(fleet.OrbitHostInfo{
 				HardwareUUID:      dupUUID,
 				HardwareSerial:    dupHWSerial,
 				OsqueryIdentifier: randomIdentifierH2,
 				Platform:          platform,
 			}),
-			fleet.WithOrbitEnrollNodeKey(uuid.New().String()),
+			fleet.WithEnrollOrbitNodeKey(uuid.New().String()),
 		)
 		require.NoError(t, err)
 		h2Osquery, err := ds.EnrollHost(ctx, false, randomIdentifierH2, dupUUID, dupHWSerial, uuid.New().String(), nil, 0)
@@ -9062,24 +9062,24 @@ func testHostsEnrollOrbit(t *testing.T, ds *Datastore) {
 		randomIdentifierH2 := uuid.New().String()
 		// Then orbit of the second host enrolls.
 		h2Orbit, err := ds.EnrollOrbit(ctx,
-			fleet.WithOrbitEnrollHostInfo(fleet.OrbitHostInfo{
+			fleet.WithEnrollOrbitHostInfo(fleet.OrbitHostInfo{
 				HardwareUUID:      dupUUID,
 				HardwareSerial:    dupHWSerial,
 				OsqueryIdentifier: randomIdentifierH2,
 				Platform:          platform,
 			}),
-			fleet.WithOrbitEnrollNodeKey(uuid.New().String()),
+			fleet.WithEnrollOrbitNodeKey(uuid.New().String()),
 		)
 		require.NoError(t, err)
 		// Then orbit of the first host enrolls.
 		h1Orbit, err := ds.EnrollOrbit(ctx,
-			fleet.WithOrbitEnrollHostInfo(fleet.OrbitHostInfo{
+			fleet.WithEnrollOrbitHostInfo(fleet.OrbitHostInfo{
 				HardwareUUID:      dupUUID,
 				HardwareSerial:    dupHWSerial,
 				OsqueryIdentifier: randomIdentifierH1,
 				Platform:          platform,
 			}),
-			fleet.WithOrbitEnrollNodeKey(uuid.New().String()),
+			fleet.WithEnrollOrbitNodeKey(uuid.New().String()),
 		)
 		require.NoError(t, err)
 		require.Equal(t, h1Orbit.ID, h1Osquery.ID)
@@ -9116,14 +9116,14 @@ func testHostsEnrollOrbit(t *testing.T, ds *Datastore) {
 		randomIdentifierH2 := uuid.New().String()
 
 		h1Orbit, err := ds.EnrollOrbit(ctx,
-			fleet.WithOrbitEnrollMDMEnabled(true),
-			fleet.WithOrbitEnrollHostInfo(fleet.OrbitHostInfo{
+			fleet.WithEnrollOrbitMDMEnabled(true),
+			fleet.WithEnrollOrbitHostInfo(fleet.OrbitHostInfo{
 				HardwareUUID:      dupUUID,
 				HardwareSerial:    dupHWSerial,
 				OsqueryIdentifier: randomIdentifierH1,
 				Platform:          platform,
 			}),
-			fleet.WithOrbitEnrollNodeKey(uuid.New().String()),
+			fleet.WithEnrollOrbitNodeKey(uuid.New().String()),
 		)
 		require.NoError(t, err)
 		h1Osquery, err := ds.EnrollHost(ctx, true, randomIdentifierH1, dupUUID, dupHWSerial, uuid.New().String(), nil, 0)
@@ -9134,14 +9134,14 @@ func testHostsEnrollOrbit(t *testing.T, ds *Datastore) {
 		h2Osquery, err := ds.EnrollHost(ctx, true, randomIdentifierH2, dupUUID, dupHWSerial, uuid.New().String(), nil, 0)
 		require.NoError(t, err)
 		h2Orbit, err := ds.EnrollOrbit(ctx,
-			fleet.WithOrbitEnrollMDMEnabled(true),
-			fleet.WithOrbitEnrollHostInfo(fleet.OrbitHostInfo{
+			fleet.WithEnrollOrbitMDMEnabled(true),
+			fleet.WithEnrollOrbitHostInfo(fleet.OrbitHostInfo{
 				HardwareUUID:      dupUUID,
 				HardwareSerial:    dupHWSerial,
 				OsqueryIdentifier: randomIdentifierH2,
 				Platform:          platform,
 			}),
-			fleet.WithOrbitEnrollNodeKey(uuid.New().String()),
+			fleet.WithEnrollOrbitNodeKey(uuid.New().String()),
 		)
 		require.NoError(t, err)
 		require.Equal(t, h2Orbit.ID, h2Osquery.ID)
@@ -9172,12 +9172,12 @@ func testHostsEnrollOrbit(t *testing.T, ds *Datastore) {
 		dupHWSerial := uuid.New().String()
 
 		h1Orbit, err := ds.EnrollOrbit(ctx,
-			fleet.WithOrbitEnrollHostInfo(fleet.OrbitHostInfo{
+			fleet.WithEnrollOrbitHostInfo(fleet.OrbitHostInfo{
 				HardwareUUID:   dupUUID,
 				HardwareSerial: dupHWSerial,
 				Platform:       platform,
 			}),
-			fleet.WithOrbitEnrollNodeKey(uuid.New().String()),
+			fleet.WithEnrollOrbitNodeKey(uuid.New().String()),
 		)
 		require.NoError(t, err)
 		h1OrbitFetched, err := ds.Host(ctx, h1Orbit.ID)
@@ -9191,12 +9191,12 @@ func testHostsEnrollOrbit(t *testing.T, ds *Datastore) {
 		require.Equal(t, h1Orbit.ID, h1Osquery.ID)
 		time.Sleep(1 * time.Second) // to test the update of last_enrolled_at
 		h2Orbit, err := ds.EnrollOrbit(ctx,
-			fleet.WithOrbitEnrollHostInfo(fleet.OrbitHostInfo{
+			fleet.WithEnrollOrbitHostInfo(fleet.OrbitHostInfo{
 				HardwareUUID:   dupUUID,
 				HardwareSerial: dupHWSerial,
 				Platform:       platform,
 			}),
-			fleet.WithOrbitEnrollNodeKey(uuid.New().String()),
+			fleet.WithEnrollOrbitNodeKey(uuid.New().String()),
 		)
 		require.NoError(t, err)
 		h2OrbitFetched, err := ds.Host(ctx, h2Orbit.ID)
@@ -9238,12 +9238,12 @@ func testHostsEnrollOrbit(t *testing.T, ds *Datastore) {
 		dupHWSerial := uuid.New().String()
 
 		h1Orbit, err := ds.EnrollOrbit(ctx,
-			fleet.WithOrbitEnrollHostInfo(fleet.OrbitHostInfo{
+			fleet.WithEnrollOrbitHostInfo(fleet.OrbitHostInfo{
 				HardwareUUID:   dupUUID,
 				HardwareSerial: dupHWSerial,
 				Platform:       fromPlatform,
 			}),
-			fleet.WithOrbitEnrollNodeKey(uuid.New().String()),
+			fleet.WithEnrollOrbitNodeKey(uuid.New().String()),
 		)
 		require.NoError(t, err)
 		h1OrbitFetched, err := ds.Host(ctx, h1Orbit.ID)
@@ -9268,12 +9268,12 @@ func testHostsEnrollOrbit(t *testing.T, ds *Datastore) {
 		require.NotNil(t, h1WithMdmFetched.MDM.EnrollmentStatus)
 
 		h2Orbit, err := ds.EnrollOrbit(ctx,
-			fleet.WithOrbitEnrollHostInfo(fleet.OrbitHostInfo{
+			fleet.WithEnrollOrbitHostInfo(fleet.OrbitHostInfo{
 				HardwareUUID:   dupUUID,
 				HardwareSerial: dupHWSerial,
 				Platform:       toPlatform,
 			}),
-			fleet.WithOrbitEnrollNodeKey(uuid.New().String()),
+			fleet.WithEnrollOrbitNodeKey(uuid.New().String()),
 		)
 		require.NoError(t, err)
 		h2OrbitFetched, err := ds.Host(ctx, h2Orbit.ID)
@@ -9339,12 +9339,12 @@ func testHostsEnrollUpdatesMissingInfo(t *testing.T, ds *Datastore) {
 
 	// enroll with orbit and a uuid (will match on serial)
 	_, err = ds.EnrollOrbit(ctx,
-		fleet.WithOrbitEnrollMDMEnabled(true),
-		fleet.WithOrbitEnrollHostInfo(fleet.OrbitHostInfo{
+		fleet.WithEnrollOrbitMDMEnabled(true),
+		fleet.WithEnrollOrbitHostInfo(fleet.OrbitHostInfo{
 			HardwareUUID:   "uuid",
 			HardwareSerial: "serial",
 		}),
-		fleet.WithOrbitEnrollNodeKey("orbit"),
+		fleet.WithEnrollOrbitNodeKey("orbit"),
 	)
 	require.NoError(t, err)
 	got, err := ds.LoadHostByOrbitNodeKey(ctx, "orbit")

--- a/server/datastore/mysql/labels_test.go
+++ b/server/datastore/mysql/labels_test.go
@@ -115,7 +115,10 @@ func testLabelsAddAllHosts(deferred bool, t *testing.T, db *Datastore) {
 	var host *fleet.Host
 	var err error
 	for i := 0; i < 10; i++ {
-		host, err = db.EnrollHost(context.Background(), false, fmt.Sprint(i), "", "", fmt.Sprint(i), nil, 0)
+		host, err = db.EnrollHost(context.Background(),
+			fleet.WithEnrollHostOsqueryHostID(fmt.Sprint(i)),
+			fleet.WithEnrollHostNodeKey(fmt.Sprint(i)),
+		)
 		require.Nil(t, err, "enrollment should succeed")
 		hosts = append(hosts, *host)
 	}
@@ -922,7 +925,10 @@ func testLabelsSave(t *testing.T, db *Datastore) {
 }
 
 func testLabelsQueriesForCentOSHost(t *testing.T, db *Datastore) {
-	host, err := db.EnrollHost(context.Background(), false, "0", "", "", "0", nil, 0)
+	host, err := db.EnrollHost(context.Background(),
+		fleet.WithEnrollHostOsqueryHostID("0"),
+		fleet.WithEnrollHostNodeKey("0"),
+	)
 	require.NoError(t, err, "enrollment should succeed")
 
 	host.Platform = "rhel"

--- a/server/datastore/mysql/policies_test.go
+++ b/server/datastore/mysql/policies_test.go
@@ -521,11 +521,23 @@ func testPoliciesMembershipView(deferred bool, t *testing.T, ds *Datastore) {
 	require.NoError(t, err)
 
 	// create hosts in each team
-	host3, err := ds.EnrollHost(ctx, false, "3", "", "", "3", &team1.ID, 0)
+	host3, err := ds.EnrollHost(ctx,
+		fleet.WithEnrollHostOsqueryHostID("3"),
+		fleet.WithEnrollHostNodeKey("3"),
+		fleet.WithEnrollHostTeamID(&team1.ID),
+	)
 	require.NoError(t, err)
-	host4, err := ds.EnrollHost(ctx, false, "4", "", "", "4", &team2.ID, 0)
+	host4, err := ds.EnrollHost(ctx,
+		fleet.WithEnrollHostOsqueryHostID("4"),
+		fleet.WithEnrollHostNodeKey("4"),
+		fleet.WithEnrollHostTeamID(&team2.ID),
+	)
 	require.NoError(t, err)
-	host5, err := ds.EnrollHost(ctx, false, "5", "", "", "5", &team2.ID, 0)
+	host5, err := ds.EnrollHost(ctx,
+		fleet.WithEnrollHostOsqueryHostID("5"),
+		fleet.WithEnrollHostNodeKey("5"),
+		fleet.WithEnrollHostTeamID(&team2.ID),
+	)
 	require.NoError(t, err)
 
 	// create some policy results
@@ -1570,7 +1582,11 @@ func testTeamPolicyTransfer(t *testing.T, ds *Datastore) {
 		Hostname:        "foo.local",
 	})
 	require.NoError(t, err)
-	host2, err := ds.EnrollHost(ctx, false, "2", "", "", "2", &team1.ID, 0)
+	host2, err := ds.EnrollHost(ctx,
+		fleet.WithEnrollHostOsqueryHostID("2"),
+		fleet.WithEnrollHostNodeKey("2"),
+		fleet.WithEnrollHostTeamID(&team1.ID),
+	)
 	require.NoError(t, err)
 
 	require.NoError(t, ds.AddHostsToTeam(ctx, &team1.ID, []uint{host1.ID}))
@@ -1641,12 +1657,20 @@ func testTeamPolicyTransfer(t *testing.T, ds *Datastore) {
 	checkPassingCount(1, 1, 1, 2)
 
 	// all host policies are removed when a host is enrolled in the same team
-	_, err = ds.EnrollHost(ctx, false, "2", "", "", "2", &team1.ID, 0)
+	_, err = ds.EnrollHost(ctx,
+		fleet.WithEnrollHostOsqueryHostID("2"),
+		fleet.WithEnrollHostNodeKey("2"),
+		fleet.WithEnrollHostTeamID(&team1.ID),
+	)
 	require.NoError(t, err)
 	checkPassingCount(0, 0, 1, 1)
 
 	// team policies are removed if the host is enrolled in a different team
-	_, err = ds.EnrollHost(ctx, false, "2", "", "", "2", &team2.ID, 0)
+	_, err = ds.EnrollHost(ctx,
+		fleet.WithEnrollHostOsqueryHostID("2"),
+		fleet.WithEnrollHostNodeKey("2"),
+		fleet.WithEnrollHostTeamID(&team2.ID),
+	)
 	require.NoError(t, err)
 	// both hosts are now in team2
 	checkPassingCount(0, 0, 1, 1)
@@ -1656,7 +1680,10 @@ func testTeamPolicyTransfer(t *testing.T, ds *Datastore) {
 	checkPassingCount(1, 0, 2, 2)
 
 	// all host policies are removed when a host is re-enrolled
-	_, err = ds.EnrollHost(ctx, false, "2", "", "", "2", nil, 0)
+	_, err = ds.EnrollHost(ctx,
+		fleet.WithEnrollHostOsqueryHostID("2"),
+		fleet.WithEnrollHostNodeKey("2"),
+	)
 	require.NoError(t, err)
 	checkPassingCount(0, 0, 1, 1)
 }

--- a/server/datastore/mysql/targets_test.go
+++ b/server/datastore/mysql/targets_test.go
@@ -282,7 +282,10 @@ func testTargetsHostStatus(t *testing.T, ds *Datastore) {
 
 	mockClock := clock.NewMockClock()
 
-	h, err := ds.EnrollHost(context.Background(), false, "1", "", "", "key1", nil, 0)
+	h, err := ds.EnrollHost(context.Background(),
+		fleet.WithEnrollHostOsqueryHostID("1"),
+		fleet.WithEnrollHostNodeKey("key1"),
+	)
 	require.NoError(t, err)
 
 	user := &fleet.User{GlobalRole: ptr.String(fleet.RoleAdmin)}

--- a/server/datastore/mysqlredis/hosts.go
+++ b/server/datastore/mysqlredis/hosts.go
@@ -134,8 +134,8 @@ func (d *Datastore) NewHost(ctx context.Context, host *fleet.Host) (*fleet.Host,
 	return h, err
 }
 
-func (d *Datastore) EnrollHost(ctx context.Context, isMDMEnabled bool, osqueryHostID, hardwareUUID, hardwareSerial, nodeKey string, teamID *uint, cooldown time.Duration) (*fleet.Host, error) {
-	h, err := d.Datastore.EnrollHost(ctx, isMDMEnabled, osqueryHostID, hardwareUUID, hardwareSerial, nodeKey, teamID, cooldown)
+func (d *Datastore) EnrollHost(ctx context.Context, opts ...fleet.DatastoreEnrollHostOption) (*fleet.Host, error) {
+	h, err := d.Datastore.EnrollHost(ctx, opts...)
 	if err == nil && d.enforceHostLimit > 0 {
 		if err := addHosts(ctx, d.pool, h.ID); err != nil {
 			logging.WithErr(ctx, err)

--- a/server/datastore/mysqlredis/hosts_test.go
+++ b/server/datastore/mysqlredis/hosts_test.go
@@ -26,10 +26,14 @@ func TestEnforceHostLimit(t *testing.T) {
 
 		ctx := context.Background()
 		ds := new(mock.Store)
-		ds.EnrollHostFunc = func(ctx context.Context, isMDMEnabled bool, osqueryHostId, hUUID, hSerial, nodeKey string, teamID *uint, cooldown time.Duration) (*fleet.Host, error) {
+		ds.EnrollHostFunc = func(_ context.Context, opts ...fleet.DatastoreEnrollHostOption) (*fleet.Host, error) {
+			config := &fleet.DatastoreEnrollHostConfig{}
+			for _, opt := range opts {
+				opt(config)
+			}
 			hostIDSeq++
 			return &fleet.Host{
-				ID: hostIDSeq, OsqueryHostID: &osqueryHostId, NodeKey: &nodeKey,
+				ID: hostIDSeq, OsqueryHostID: &config.OsqueryHostID, NodeKey: &config.NodeKey,
 			}, nil
 		}
 		ds.NewHostFunc = func(ctx context.Context, host *fleet.Host) (*fleet.Host, error) {
@@ -68,12 +72,20 @@ func TestEnforceHostLimit(t *testing.T) {
 		require.NotNil(t, h1)
 		requireInvokedAndReset(&ds.NewHostFuncInvoked)
 		requireCanEnroll(true)
-		h2, err := wrappedDS.EnrollHost(ctx, false, "osquery-2", "", "", "node-2", nil, time.Second)
+		h2, err := wrappedDS.EnrollHost(ctx,
+			fleet.WithEnrollHostOsqueryHostID("osquery-2"),
+			fleet.WithEnrollHostNodeKey("node-2"),
+			fleet.WithEnrollHostCooldown(time.Second),
+		)
 		require.NoError(t, err)
 		require.NotNil(t, h2)
 		requireInvokedAndReset(&ds.EnrollHostFuncInvoked)
 		requireCanEnroll(true)
-		h3, err := wrappedDS.EnrollHost(ctx, false, "osquery-3", "", "", "node-3", nil, time.Second)
+		h3, err := wrappedDS.EnrollHost(ctx,
+			fleet.WithEnrollHostOsqueryHostID("osquery-3"),
+			fleet.WithEnrollHostNodeKey("node-3"),
+			fleet.WithEnrollHostCooldown(time.Second),
+		)
 		require.NoError(t, err)
 		require.NotNil(t, h3)
 		requireInvokedAndReset(&ds.EnrollHostFuncInvoked)
@@ -83,7 +95,11 @@ func TestEnforceHostLimit(t *testing.T) {
 		err = wrappedDS.DeleteHost(ctx, h1.ID)
 		require.NoError(t, err)
 		requireCanEnroll(true)
-		h4, err := wrappedDS.EnrollHost(ctx, false, "osquery-4", "", "", "node-4", nil, time.Second)
+		h4, err := wrappedDS.EnrollHost(ctx,
+			fleet.WithEnrollHostOsqueryHostID("osquery-4"),
+			fleet.WithEnrollHostNodeKey("node-4"),
+			fleet.WithEnrollHostCooldown(time.Second),
+		)
 		require.NoError(t, err)
 		require.NotNil(t, h4)
 		requireInvokedAndReset(&ds.EnrollHostFuncInvoked)
@@ -93,7 +109,11 @@ func TestEnforceHostLimit(t *testing.T) {
 		err = wrappedDS.DeleteHosts(ctx, []uint{h1.ID, h2.ID, h3.ID})
 		require.NoError(t, err)
 		requireCanEnroll(true)
-		h5, err := wrappedDS.EnrollHost(ctx, false, "osquery-5", "", "", "node-5", nil, time.Second)
+		h5, err := wrappedDS.EnrollHost(ctx,
+			fleet.WithEnrollHostOsqueryHostID("osquery-5"),
+			fleet.WithEnrollHostNodeKey("node-5"),
+			fleet.WithEnrollHostCooldown(time.Second),
+		)
 		require.NoError(t, err)
 		require.NotNil(t, h5)
 		requireInvokedAndReset(&ds.EnrollHostFuncInvoked)
@@ -116,7 +136,11 @@ func TestEnforceHostLimit(t *testing.T) {
 		requireCanEnroll(true)
 
 		// can now create 2 more
-		h7, err := wrappedDS.EnrollHost(ctx, false, "osquery-7", "", "", "node-7", nil, time.Second)
+		h7, err := wrappedDS.EnrollHost(ctx,
+			fleet.WithEnrollHostOsqueryHostID("osquery-7"),
+			fleet.WithEnrollHostNodeKey("node-7"),
+			fleet.WithEnrollHostCooldown(time.Second),
+		)
 		require.NoError(t, err)
 		require.NotNil(t, h7)
 		requireInvokedAndReset(&ds.EnrollHostFuncInvoked)

--- a/server/fleet/datastore.go
+++ b/server/fleet/datastore.go
@@ -1044,7 +1044,7 @@ type Datastore interface {
 	// EnrollHost will enroll a new host with the given identifier, setting the node key, and team. Implementations of
 	// this method should respect the provided host enrollment cooldown, by returning an error if the host has enrolled
 	// within the cooldown period.
-	EnrollHost(ctx context.Context, isMDMEnabled bool, osqueryHostId, hardwareUUID, hardwareSerial, nodeKey string, teamID *uint, cooldown time.Duration) (*Host, error)
+	EnrollHost(ctx context.Context, opts ...DatastoreEnrollHostOption) (*Host, error)
 
 	// EnrollOrbit will enroll a new orbit instance.
 	//	- If an entry for the host exists (osquery enrolled first) then it will update the host's orbit node key and team.

--- a/server/fleet/datastore.go
+++ b/server/fleet/datastore.go
@@ -1049,7 +1049,7 @@ type Datastore interface {
 	// EnrollOrbit will enroll a new orbit instance.
 	//	- If an entry for the host exists (osquery enrolled first) then it will update the host's orbit node key and team.
 	//	- If an entry for the host doesn't exist (osquery enrolls later) then it will create a new entry in the hosts table.
-	EnrollOrbit(ctx context.Context, isMDMEnabled bool, hostInfo OrbitHostInfo, orbitNodeKey string, teamID *uint) (*Host, error)
+	EnrollOrbit(ctx context.Context, opts ...DatastoreEnrollOrbitOption) (*Host, error)
 
 	SerialUpdateHost(ctx context.Context, host *Host) error
 

--- a/server/fleet/orbit.go
+++ b/server/fleet/orbit.go
@@ -108,6 +108,45 @@ type OrbitHostInfo struct {
 	HardwareModel string
 }
 
+// DatastoreEnrollOrbitConfig holds the configuration for datastore Orbit enrollment
+type DatastoreEnrollOrbitConfig struct {
+	IsMDMEnabled bool
+	HostInfo     OrbitHostInfo
+	OrbitNodeKey string
+	TeamID       *uint
+}
+
+// DatastoreEnrollOrbitOption is a functional option for configuring datastore Orbit enrollment
+type DatastoreEnrollOrbitOption func(*DatastoreEnrollOrbitConfig)
+
+// WithOrbitEnrollMDMEnabled sets the MDM enabled flag for datastore Orbit enrollment
+func WithOrbitEnrollMDMEnabled(enabled bool) DatastoreEnrollOrbitOption {
+	return func(c *DatastoreEnrollOrbitConfig) {
+		c.IsMDMEnabled = enabled
+	}
+}
+
+// WithOrbitEnrollHostInfo sets the host information for datastore Orbit enrollment
+func WithOrbitEnrollHostInfo(hostInfo OrbitHostInfo) DatastoreEnrollOrbitOption {
+	return func(c *DatastoreEnrollOrbitConfig) {
+		c.HostInfo = hostInfo
+	}
+}
+
+// WithOrbitEnrollNodeKey sets the orbit node key for datastore Orbit enrollment
+func WithOrbitEnrollNodeKey(nodeKey string) DatastoreEnrollOrbitOption {
+	return func(c *DatastoreEnrollOrbitConfig) {
+		c.OrbitNodeKey = nodeKey
+	}
+}
+
+// WithOrbitEnrollTeamID sets the team ID for datastore Orbit enrollment
+func WithOrbitEnrollTeamID(teamID *uint) DatastoreEnrollOrbitOption {
+	return func(c *DatastoreEnrollOrbitConfig) {
+		c.TeamID = teamID
+	}
+}
+
 // ExtensionInfo holds the data of a osquery extension to apply to an Orbit client.
 type ExtensionInfo struct {
 	// Platform is one of "windows", "linux" or "macos".

--- a/server/fleet/orbit.go
+++ b/server/fleet/orbit.go
@@ -119,29 +119,29 @@ type DatastoreEnrollOrbitConfig struct {
 // DatastoreEnrollOrbitOption is a functional option for configuring datastore Orbit enrollment
 type DatastoreEnrollOrbitOption func(*DatastoreEnrollOrbitConfig)
 
-// WithOrbitEnrollMDMEnabled sets the MDM enabled flag for datastore Orbit enrollment
-func WithOrbitEnrollMDMEnabled(enabled bool) DatastoreEnrollOrbitOption {
+// WithEnrollOrbitMDMEnabled sets the MDM enabled flag for datastore Orbit enrollment
+func WithEnrollOrbitMDMEnabled(enabled bool) DatastoreEnrollOrbitOption {
 	return func(c *DatastoreEnrollOrbitConfig) {
 		c.IsMDMEnabled = enabled
 	}
 }
 
-// WithOrbitEnrollHostInfo sets the host information for datastore Orbit enrollment
-func WithOrbitEnrollHostInfo(hostInfo OrbitHostInfo) DatastoreEnrollOrbitOption {
+// WithEnrollOrbitHostInfo sets the host information for datastore Orbit enrollment
+func WithEnrollOrbitHostInfo(hostInfo OrbitHostInfo) DatastoreEnrollOrbitOption {
 	return func(c *DatastoreEnrollOrbitConfig) {
 		c.HostInfo = hostInfo
 	}
 }
 
-// WithOrbitEnrollNodeKey sets the orbit node key for datastore Orbit enrollment
-func WithOrbitEnrollNodeKey(nodeKey string) DatastoreEnrollOrbitOption {
+// WithEnrollOrbitNodeKey sets the orbit node key for datastore Orbit enrollment
+func WithEnrollOrbitNodeKey(nodeKey string) DatastoreEnrollOrbitOption {
 	return func(c *DatastoreEnrollOrbitConfig) {
 		c.OrbitNodeKey = nodeKey
 	}
 }
 
-// WithOrbitEnrollTeamID sets the team ID for datastore Orbit enrollment
-func WithOrbitEnrollTeamID(teamID *uint) DatastoreEnrollOrbitOption {
+// WithEnrollOrbitTeamID sets the team ID for datastore Orbit enrollment
+func WithEnrollOrbitTeamID(teamID *uint) DatastoreEnrollOrbitOption {
 	return func(c *DatastoreEnrollOrbitConfig) {
 		c.TeamID = teamID
 	}

--- a/server/fleet/osquery.go
+++ b/server/fleet/osquery.go
@@ -1,6 +1,9 @@
 package fleet
 
-import "errors"
+import (
+	"errors"
+	"time"
+)
 
 // OsqueryDistributedQueryResults represents the format of the results of an
 // osquery distributed query.
@@ -69,3 +72,66 @@ type PermissivePackContent struct {
 type Packs map[string]PackContent
 
 type PermissivePacks map[string]PermissivePackContent
+
+// DatastoreEnrollHostConfig holds the configuration for datastore Host enrollment
+type DatastoreEnrollHostConfig struct {
+	IsMDMEnabled   bool
+	OsqueryHostID  string
+	HardwareUUID   string
+	HardwareSerial string
+	NodeKey        string
+	TeamID         *uint
+	Cooldown       time.Duration
+}
+
+// DatastoreEnrollHostOption is a functional option for configuring datastore Host enrollment
+type DatastoreEnrollHostOption func(*DatastoreEnrollHostConfig)
+
+// WithEnrollHostMDMEnabled sets the MDM enabled flag for datastore Host enrollment
+func WithEnrollHostMDMEnabled(enabled bool) DatastoreEnrollHostOption {
+	return func(c *DatastoreEnrollHostConfig) {
+		c.IsMDMEnabled = enabled
+	}
+}
+
+// WithEnrollHostOsqueryHostID sets the osquery host ID for datastore Host enrollment
+func WithEnrollHostOsqueryHostID(osqueryHostID string) DatastoreEnrollHostOption {
+	return func(c *DatastoreEnrollHostConfig) {
+		c.OsqueryHostID = osqueryHostID
+	}
+}
+
+// WithEnrollHostHardwareUUID sets the hardware UUID for datastore Host enrollment
+func WithEnrollHostHardwareUUID(hardwareUUID string) DatastoreEnrollHostOption {
+	return func(c *DatastoreEnrollHostConfig) {
+		c.HardwareUUID = hardwareUUID
+	}
+}
+
+// WithEnrollHostHardwareSerial sets the hardware serial for datastore Host enrollment
+func WithEnrollHostHardwareSerial(hardwareSerial string) DatastoreEnrollHostOption {
+	return func(c *DatastoreEnrollHostConfig) {
+		c.HardwareSerial = hardwareSerial
+	}
+}
+
+// WithEnrollHostNodeKey sets the node key for datastore Host enrollment
+func WithEnrollHostNodeKey(nodeKey string) DatastoreEnrollHostOption {
+	return func(c *DatastoreEnrollHostConfig) {
+		c.NodeKey = nodeKey
+	}
+}
+
+// WithEnrollHostTeamID sets the team ID for datastore Host enrollment
+func WithEnrollHostTeamID(teamID *uint) DatastoreEnrollHostOption {
+	return func(c *DatastoreEnrollHostConfig) {
+		c.TeamID = teamID
+	}
+}
+
+// WithEnrollHostCooldown sets the cooldown duration for datastore Host enrollment
+func WithEnrollHostCooldown(cooldown time.Duration) DatastoreEnrollHostOption {
+	return func(c *DatastoreEnrollHostConfig) {
+		c.Cooldown = cooldown
+	}
+}

--- a/server/mock/datastore.go
+++ b/server/mock/datastore.go
@@ -22,7 +22,7 @@ type Store struct {
 	DataStore
 }
 
-func (m *Store) EnrollOrbit(ctx context.Context, isMDMEnabled bool, orbitHostInfo fleet.OrbitHostInfo, orbitNodeKey string, teamID *uint) (*fleet.Host, error) {
+func (m *Store) EnrollOrbit(ctx context.Context, opts ...fleet.DatastoreEnrollOrbitOption) (*fleet.Host, error) {
 	return nil, nil
 }
 

--- a/server/mock/datastore_mock.go
+++ b/server/mock/datastore_mock.go
@@ -753,7 +753,7 @@ type IsEnrollSecretAvailableFunc func(ctx context.Context, secret string, isNew 
 
 type EnrollHostFunc func(ctx context.Context, isMDMEnabled bool, osqueryHostId string, hardwareUUID string, hardwareSerial string, nodeKey string, teamID *uint, cooldown time.Duration) (*fleet.Host, error)
 
-type EnrollOrbitFunc func(ctx context.Context, isMDMEnabled bool, hostInfo fleet.OrbitHostInfo, orbitNodeKey string, teamID *uint) (*fleet.Host, error)
+type EnrollOrbitFunc func(ctx context.Context, opts ...fleet.DatastoreEnrollOrbitOption) (*fleet.Host, error)
 
 type SerialUpdateHostFunc func(ctx context.Context, host *fleet.Host) error
 
@@ -6062,11 +6062,11 @@ func (s *DataStore) EnrollHost(ctx context.Context, isMDMEnabled bool, osqueryHo
 	return s.EnrollHostFunc(ctx, isMDMEnabled, osqueryHostId, hardwareUUID, hardwareSerial, nodeKey, teamID, cooldown)
 }
 
-func (s *DataStore) EnrollOrbit(ctx context.Context, isMDMEnabled bool, hostInfo fleet.OrbitHostInfo, orbitNodeKey string, teamID *uint) (*fleet.Host, error) {
+func (s *DataStore) EnrollOrbit(ctx context.Context, opts ...fleet.DatastoreEnrollOrbitOption) (*fleet.Host, error) {
 	s.mu.Lock()
 	s.EnrollOrbitFuncInvoked = true
 	s.mu.Unlock()
-	return s.EnrollOrbitFunc(ctx, isMDMEnabled, hostInfo, orbitNodeKey, teamID)
+	return s.EnrollOrbitFunc(ctx, opts...)
 }
 
 func (s *DataStore) SerialUpdateHost(ctx context.Context, host *fleet.Host) error {

--- a/server/mock/datastore_mock.go
+++ b/server/mock/datastore_mock.go
@@ -751,7 +751,7 @@ type VerifyEnrollSecretFunc func(ctx context.Context, secret string) (*fleet.Enr
 
 type IsEnrollSecretAvailableFunc func(ctx context.Context, secret string, isNew bool, teamID *uint) (bool, error)
 
-type EnrollHostFunc func(ctx context.Context, isMDMEnabled bool, osqueryHostId string, hardwareUUID string, hardwareSerial string, nodeKey string, teamID *uint, cooldown time.Duration) (*fleet.Host, error)
+type EnrollHostFunc func(ctx context.Context, opts ...fleet.DatastoreEnrollHostOption) (*fleet.Host, error)
 
 type EnrollOrbitFunc func(ctx context.Context, opts ...fleet.DatastoreEnrollOrbitOption) (*fleet.Host, error)
 
@@ -6055,11 +6055,11 @@ func (s *DataStore) IsEnrollSecretAvailable(ctx context.Context, secret string, 
 	return s.IsEnrollSecretAvailableFunc(ctx, secret, isNew, teamID)
 }
 
-func (s *DataStore) EnrollHost(ctx context.Context, isMDMEnabled bool, osqueryHostId string, hardwareUUID string, hardwareSerial string, nodeKey string, teamID *uint, cooldown time.Duration) (*fleet.Host, error) {
+func (s *DataStore) EnrollHost(ctx context.Context, opts ...fleet.DatastoreEnrollHostOption) (*fleet.Host, error) {
 	s.mu.Lock()
 	s.EnrollHostFuncInvoked = true
 	s.mu.Unlock()
-	return s.EnrollHostFunc(ctx, isMDMEnabled, osqueryHostId, hardwareUUID, hardwareSerial, nodeKey, teamID, cooldown)
+	return s.EnrollHostFunc(ctx, opts...)
 }
 
 func (s *DataStore) EnrollOrbit(ctx context.Context, opts ...fleet.DatastoreEnrollOrbitOption) (*fleet.Host, error) {

--- a/server/service/integration_core_test.go
+++ b/server/service/integration_core_test.go
@@ -10283,10 +10283,14 @@ type validationErrResp struct {
 
 func setOrbitEnrollment(t *testing.T, h *fleet.Host, ds fleet.Datastore) string {
 	orbitKey := uuid.New().String()
-	_, err := ds.EnrollOrbit(context.Background(), false, fleet.OrbitHostInfo{
-		HardwareUUID:   *h.OsqueryHostID,
-		HardwareSerial: h.HardwareSerial,
-	}, orbitKey, h.TeamID)
+	_, err := ds.EnrollOrbit(context.Background(),
+		fleet.WithOrbitEnrollHostInfo(fleet.OrbitHostInfo{
+			HardwareUUID:   *h.OsqueryHostID,
+			HardwareSerial: h.HardwareSerial,
+		}),
+		fleet.WithOrbitEnrollNodeKey(orbitKey),
+		fleet.WithOrbitEnrollTeamID(h.TeamID),
+	)
 	require.NoError(t, err)
 	err = ds.SetOrUpdateHostOrbitInfo(
 		context.Background(), h.ID, "1.22.0", sql.NullString{String: "42", Valid: true}, sql.NullBool{Bool: true, Valid: true},

--- a/server/service/integration_core_test.go
+++ b/server/service/integration_core_test.go
@@ -10284,12 +10284,12 @@ type validationErrResp struct {
 func setOrbitEnrollment(t *testing.T, h *fleet.Host, ds fleet.Datastore) string {
 	orbitKey := uuid.New().String()
 	_, err := ds.EnrollOrbit(context.Background(),
-		fleet.WithOrbitEnrollHostInfo(fleet.OrbitHostInfo{
+		fleet.WithEnrollOrbitHostInfo(fleet.OrbitHostInfo{
 			HardwareUUID:   *h.OsqueryHostID,
 			HardwareSerial: h.HardwareSerial,
 		}),
-		fleet.WithOrbitEnrollNodeKey(orbitKey),
-		fleet.WithOrbitEnrollTeamID(h.TeamID),
+		fleet.WithEnrollOrbitNodeKey(orbitKey),
+		fleet.WithEnrollOrbitTeamID(h.TeamID),
 	)
 	require.NoError(t, err)
 	err = ds.SetOrUpdateHostOrbitInfo(

--- a/server/service/integration_mdm_test.go
+++ b/server/service/integration_mdm_test.go
@@ -9670,12 +9670,12 @@ func (s *integrationMDMTestSuite) TestLockUnlockWipeWindowsLinux() {
 			// re-enroll the host, simulating that another user received the wiped host
 			newOrbitKey := uuid.New().String()
 			newHost, err := s.ds.EnrollOrbit(ctx,
-				fleet.WithOrbitEnrollMDMEnabled(true),
-				fleet.WithOrbitEnrollHostInfo(fleet.OrbitHostInfo{
+				fleet.WithEnrollOrbitMDMEnabled(true),
+				fleet.WithEnrollOrbitHostInfo(fleet.OrbitHostInfo{
 					HardwareUUID:   *host.OsqueryHostID,
 					HardwareSerial: host.HardwareSerial,
 				}),
-				fleet.WithOrbitEnrollNodeKey(newOrbitKey),
+				fleet.WithEnrollOrbitNodeKey(newOrbitKey),
 			)
 			require.NoError(t, err)
 			// it re-enrolled using the same host record

--- a/server/service/integration_mdm_test.go
+++ b/server/service/integration_mdm_test.go
@@ -9669,10 +9669,14 @@ func (s *integrationMDMTestSuite) TestLockUnlockWipeWindowsLinux() {
 
 			// re-enroll the host, simulating that another user received the wiped host
 			newOrbitKey := uuid.New().String()
-			newHost, err := s.ds.EnrollOrbit(ctx, true, fleet.OrbitHostInfo{
-				HardwareUUID:   *host.OsqueryHostID,
-				HardwareSerial: host.HardwareSerial,
-			}, newOrbitKey, nil)
+			newHost, err := s.ds.EnrollOrbit(ctx,
+				fleet.WithOrbitEnrollMDMEnabled(true),
+				fleet.WithOrbitEnrollHostInfo(fleet.OrbitHostInfo{
+					HardwareUUID:   *host.OsqueryHostID,
+					HardwareSerial: host.HardwareSerial,
+				}),
+				fleet.WithOrbitEnrollNodeKey(newOrbitKey),
+			)
 			require.NoError(t, err)
 			// it re-enrolled using the same host record
 			require.Equal(t, host.ID, newHost.ID)

--- a/server/service/orbit.go
+++ b/server/service/orbit.go
@@ -166,10 +166,10 @@ func (svc *Service) EnrollOrbit(ctx context.Context, hostInfo fleet.OrbitHostInf
 	}
 
 	host, err := svc.ds.EnrollOrbit(ctx,
-		fleet.WithOrbitEnrollMDMEnabled(appConfig.MDM.EnabledAndConfigured),
-		fleet.WithOrbitEnrollHostInfo(hostInfo),
-		fleet.WithOrbitEnrollNodeKey(orbitNodeKey),
-		fleet.WithOrbitEnrollTeamID(secret.TeamID),
+		fleet.WithEnrollOrbitMDMEnabled(appConfig.MDM.EnabledAndConfigured),
+		fleet.WithEnrollOrbitHostInfo(hostInfo),
+		fleet.WithEnrollOrbitNodeKey(orbitNodeKey),
+		fleet.WithEnrollOrbitTeamID(secret.TeamID),
 	)
 	if err != nil {
 		return "", fleet.OrbitError{Message: "failed to enroll " + err.Error()}

--- a/server/service/orbit.go
+++ b/server/service/orbit.go
@@ -165,7 +165,12 @@ func (svc *Service) EnrollOrbit(ctx context.Context, hostInfo fleet.OrbitHostInf
 		return "", fleet.OrbitError{Message: "app config load failed: " + err.Error()}
 	}
 
-	host, err := svc.ds.EnrollOrbit(ctx, appConfig.MDM.EnabledAndConfigured, hostInfo, orbitNodeKey, secret.TeamID)
+	host, err := svc.ds.EnrollOrbit(ctx,
+		fleet.WithOrbitEnrollMDMEnabled(appConfig.MDM.EnabledAndConfigured),
+		fleet.WithOrbitEnrollHostInfo(hostInfo),
+		fleet.WithOrbitEnrollNodeKey(orbitNodeKey),
+		fleet.WithOrbitEnrollTeamID(secret.TeamID),
+	)
 	if err != nil {
 		return "", fleet.OrbitError{Message: "failed to enroll " + err.Error()}
 	}

--- a/server/service/osquery.go
+++ b/server/service/osquery.go
@@ -140,7 +140,15 @@ func (svc *Service) EnrollAgent(ctx context.Context, enrollSecret, hostIdentifie
 		return "", newOsqueryErrorWithInvalidNode("app config load failed: " + err.Error())
 	}
 
-	host, err := svc.ds.EnrollHost(ctx, appConfig.MDM.EnabledAndConfigured, hostIdentifier, hardwareUUID, hardwareSerial, nodeKey, secret.TeamID, svc.config.Osquery.EnrollCooldown)
+	host, err := svc.ds.EnrollHost(ctx,
+		fleet.WithEnrollHostMDMEnabled(appConfig.MDM.EnabledAndConfigured),
+		fleet.WithEnrollHostOsqueryHostID(hostIdentifier),
+		fleet.WithEnrollHostHardwareUUID(hardwareUUID),
+		fleet.WithEnrollHostHardwareSerial(hardwareSerial),
+		fleet.WithEnrollHostNodeKey(nodeKey),
+		fleet.WithEnrollHostTeamID(secret.TeamID),
+		fleet.WithEnrollHostCooldown(svc.config.Osquery.EnrollCooldown),
+	)
 	if err != nil {
 		return "", newOsqueryErrorWithInvalidNode("save enroll failed: " + err.Error())
 	}

--- a/server/service/osquery_test.go
+++ b/server/service/osquery_test.go
@@ -286,10 +286,14 @@ func TestEnrollAgent(t *testing.T) {
 			return nil, errors.New("not found")
 		}
 	}
-	ds.EnrollHostFunc = func(ctx context.Context, isMDMEnabled bool, osqueryHostId, hUUID, hSerial, nodeKey string, teamID *uint, cooldown time.Duration) (*fleet.Host, error) {
-		assert.Equal(t, ptr.Uint(3), teamID)
+	ds.EnrollHostFunc = func(ctx context.Context, opts ...fleet.DatastoreEnrollHostOption) (*fleet.Host, error) {
+		enrollConfig := &fleet.DatastoreEnrollHostConfig{}
+		for _, opt := range opts {
+			opt(enrollConfig)
+		}
+		assert.Equal(t, ptr.Uint(3), enrollConfig.TeamID)
 		return &fleet.Host{
-			OsqueryHostID: &osqueryHostId, NodeKey: &nodeKey,
+			OsqueryHostID: &enrollConfig.OsqueryHostID, NodeKey: &enrollConfig.NodeKey,
 		}, nil
 	}
 	ds.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {
@@ -317,10 +321,14 @@ func TestEnrollAgentEnforceLimit(t *testing.T) {
 				return nil, errors.New("not found")
 			}
 		}
-		ds.EnrollHostFunc = func(ctx context.Context, isMDMEnabled bool, osqueryHostId, hUUID, hSerial, nodeKey string, teamID *uint, cooldown time.Duration) (*fleet.Host, error) {
+		ds.EnrollHostFunc = func(ctx context.Context, opts ...fleet.DatastoreEnrollHostOption) (*fleet.Host, error) {
+			enrollConfig := &fleet.DatastoreEnrollHostConfig{}
+			for _, opt := range opts {
+				opt(enrollConfig)
+			}
 			hostIDSeq++
 			return &fleet.Host{
-				ID: hostIDSeq, OsqueryHostID: &osqueryHostId, NodeKey: &nodeKey,
+				ID: hostIDSeq, OsqueryHostID: &enrollConfig.OsqueryHostID, NodeKey: &enrollConfig.NodeKey,
 			}, nil
 		}
 		ds.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {
@@ -401,9 +409,13 @@ func TestEnrollAgentDetails(t *testing.T) {
 	ds.VerifyEnrollSecretFunc = func(ctx context.Context, secret string) (*fleet.EnrollSecret, error) {
 		return &fleet.EnrollSecret{}, nil
 	}
-	ds.EnrollHostFunc = func(ctx context.Context, isMDMEnabled bool, osqueryHostId, hUUID, hSerial, nodeKey string, teamID *uint, cooldown time.Duration) (*fleet.Host, error) {
+	ds.EnrollHostFunc = func(ctx context.Context, opts ...fleet.DatastoreEnrollHostOption) (*fleet.Host, error) {
+		config := &fleet.DatastoreEnrollHostConfig{}
+		for _, opt := range opts {
+			opt(config)
+		}
 		return &fleet.Host{
-			OsqueryHostID: &osqueryHostId, NodeKey: &nodeKey,
+			OsqueryHostID: &config.OsqueryHostID, NodeKey: &config.NodeKey,
 		}, nil
 	}
 	var gotHost *fleet.Host

--- a/server/test/enrollment.go
+++ b/server/test/enrollment.go
@@ -13,12 +13,12 @@ import (
 func SetOrbitEnrollment(t *testing.T, h *fleet.Host, ds fleet.Datastore) string {
 	orbitKey := uuid.New().String()
 	_, err := ds.EnrollOrbit(context.Background(),
-		fleet.WithOrbitEnrollHostInfo(fleet.OrbitHostInfo{
+		fleet.WithEnrollOrbitHostInfo(fleet.OrbitHostInfo{
 			HardwareUUID:   *h.OsqueryHostID,
 			HardwareSerial: h.HardwareSerial,
 		}),
-		fleet.WithOrbitEnrollNodeKey(orbitKey),
-		fleet.WithOrbitEnrollTeamID(h.TeamID),
+		fleet.WithEnrollOrbitNodeKey(orbitKey),
+		fleet.WithEnrollOrbitTeamID(h.TeamID),
 	)
 	require.NoError(t, err)
 	err = ds.SetOrUpdateHostOrbitInfo(

--- a/server/test/enrollment.go
+++ b/server/test/enrollment.go
@@ -12,10 +12,14 @@ import (
 
 func SetOrbitEnrollment(t *testing.T, h *fleet.Host, ds fleet.Datastore) string {
 	orbitKey := uuid.New().String()
-	_, err := ds.EnrollOrbit(context.Background(), false, fleet.OrbitHostInfo{
-		HardwareUUID:   *h.OsqueryHostID,
-		HardwareSerial: h.HardwareSerial,
-	}, orbitKey, h.TeamID)
+	_, err := ds.EnrollOrbit(context.Background(),
+		fleet.WithOrbitEnrollHostInfo(fleet.OrbitHostInfo{
+			HardwareUUID:   *h.OsqueryHostID,
+			HardwareSerial: h.HardwareSerial,
+		}),
+		fleet.WithOrbitEnrollNodeKey(orbitKey),
+		fleet.WithOrbitEnrollTeamID(h.TeamID),
+	)
 	require.NoError(t, err)
 	err = ds.SetOrUpdateHostOrbitInfo(
 		context.Background(), h.ID, "1.22.0", sql.NullString{String: "42", Valid: true}, sql.NullBool{Bool: true, Valid: true},


### PR DESCRIPTION
Fixes #30473 

Refactore Datastore.EnrollHost and Datastore.EnrollOrbit methods to use functional options. Doing this refactor before adding new options to those methods. This should make the code more maintainable and easier to understand.

No functional changes here. Just refactoring.

# Checklist for submitter

- [x] Added/updated automated tests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined host and Orbit enrollment methods to use a flexible options-based pattern instead of fixed parameter lists.
  * Updated related tests and service logic to use the new options approach, improving clarity and extensibility for enrollment operations.

* **New Features**
  * Introduced configuration options for host and Orbit enrollment, allowing more explicit and customizable parameter setting during enrollment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->