### PR TITLE
Add Beekeeper Studio as new FMA

### DIFF
--- a/ee/maintained-apps/inputs/homebrew/beekeeper-studio.json
+++ b/ee/maintained-apps/inputs/homebrew/beekeeper-studio.json
@@ -4,5 +4,7 @@
    "unique_identifier": "io.beekeeperstudio.desktop",
    "token": "beekeeper-studio",
    "installer_format": "dmg",
+   "install_script_path": "ee/maintained-apps/inputs/homebrew/scripts/beekeeper_studio_install.sh",
+   "uninstall_script_path": "ee/maintained-apps/inputs/homebrew/scripts/beekeeper_studio_uninstall.sh",
    "default_categories": ["Developer tools"]
 }

--- a/ee/maintained-apps/inputs/homebrew/beekeeper-studio.json
+++ b/ee/maintained-apps/inputs/homebrew/beekeeper-studio.json
@@ -1,0 +1,8 @@
+{
+   "name": "Beekeeper Studio",
+   "slug": "beekeeper-studio/darwin",
+   "unique_identifier": "io.beekeeperstudio.desktop",
+   "token": "beekeeper-studio",
+   "installer_format": "dmg",
+   "default_categories": ["Developer tools"]
+}

--- a/ee/maintained-apps/inputs/homebrew/scripts/beekeeper_studio_install.sh
+++ b/ee/maintained-apps/inputs/homebrew/scripts/beekeeper_studio_install.sh
@@ -1,0 +1,57 @@
+#!/bin/sh
+# Script to install Beekeeper Studio on macOS
+# variables
+APPDIR="/Applications/"
+TMPDIR=$(dirname "$(realpath $INSTALLER_PATH)")
+# functions
+
+quit_application() {
+  local bundle_id="$1"
+  local timeout_duration=10
+
+  # check if the application is running
+  if ! osascript -e "application id \"$bundle_id\" is running" 2>/dev/null; then
+    return
+  fi
+
+  local console_user
+  console_user=$(stat -f "%Su" /dev/console)
+  if [[ $EUID -eq 0 && "$console_user" == "root" ]]; then
+    echo "Not logged into a non-root GUI; skipping quitting application ID '$bundle_id'."
+    return
+  fi
+
+  echo "Quitting application '$bundle_id'..."
+
+  # try to quit the application within the timeout period
+  local quit_success=false
+  SECONDS=0
+  while (( SECONDS < timeout_duration )); do
+    if osascript -e "tell application id \"$bundle_id\" to quit" >/dev/null 2>&1; then
+      if ! pgrep -f "$bundle_id" >/dev/null 2>&1; then
+        echo "Application '$bundle_id' quit successfully."
+        quit_success=true
+        break
+      fi
+    fi
+    sleep 1
+  done
+
+  if [[ "$quit_success" = false ]]; then
+    echo "Application '$bundle_id' did not quit."
+  fi
+}
+
+
+# extract contents
+MOUNT_POINT=$(mktemp -d /tmp/dmg_mount_XXXXXX)
+hdiutil attach -plist -nobrowse -readonly -mountpoint "$MOUNT_POINT" "$INSTALLER_PATH"
+sudo cp -R "$MOUNT_POINT"/* "$TMPDIR"
+hdiutil detach "$MOUNT_POINT"
+# copy to the applications folder
+quit_application 'io.beekeeperstudio.desktop'
+if [ -d "$APPDIR/Beekeeper Studio.app" ]; then
+	sudo mv "$APPDIR/Beekeeper Studio.app" "$TMPDIR/Beekeeper Studio.app.bkp"
+fi
+sudo cp -R "$TMPDIR/Beekeeper Studio.app" "$APPDIR"
+

--- a/ee/maintained-apps/inputs/homebrew/scripts/beekeeper_studio_uninstall.sh
+++ b/ee/maintained-apps/inputs/homebrew/scripts/beekeeper_studio_uninstall.sh
@@ -1,0 +1,38 @@
+#!/bin/sh
+# Script to uninstall Beekeeper Studio from macOS
+# variables
+APPDIR="/Applications/"
+LOGGED_IN_USER=$(scutil <<< "show State:/Users/ConsoleUser" | awk '/Name :/ { print $3 }')
+# functions
+
+trash() {
+  local logged_in_user="$1"
+  local target_file="$2"
+  local timestamp="$(date +%Y-%m-%d-%s)"
+  local rand="$(jot -r 1 0 99999)"
+
+  # replace ~ with /Users/$logged_in_user
+  if [[ "$target_file" == ~* ]]; then
+    target_file="/Users/$logged_in_user${target_file:1}"
+  fi
+
+  local trash="/Users/$logged_in_user/.Trash"
+  local file_name="$(basename "${target_file}")"
+
+  if [[ -e "$target_file" ]]; then
+    echo "removing $target_file."
+    mv -f "$target_file" "$trash/${file_name}_${timestamp}_${rand}"
+  else
+    echo "$target_file doesn't exist."
+  fi
+}
+
+sudo rm -rf "$APPDIR/Beekeeper Studio.app"
+trash $LOGGED_IN_USER '~/Library/Application Support/beekeeper-studio'
+trash $LOGGED_IN_USER '~/Library/Application Support/Caches/beekeeper-studio-updater'
+trash $LOGGED_IN_USER '~/Library/Caches/io.beekeeperstudio.desktop'
+trash $LOGGED_IN_USER '~/Library/Caches/io.beekeeperstudio.desktop.ShipIt'
+trash $LOGGED_IN_USER '~/Library/Preferences/ByHost/io.beekeeperstudio.desktop.ShipIt.*.plist'
+trash $LOGGED_IN_USER '~/Library/Preferences/io.beekeeperstudio.desktop.plist'
+trash $LOGGED_IN_USER '~/Library/Saved Application State/io.beekeeperstudio.desktop.savedState'
+

--- a/ee/maintained-apps/outputs/apps.json
+++ b/ee/maintained-apps/outputs/apps.json
@@ -16,6 +16,13 @@
       "description": "Adobe Acrobat Reader is the industry-standard tool for viewing, printing, and commenting on PDF documents."
     },
     {
+      "name": "Beekeeper Studio",
+      "slug": "beekeeper-studio/darwin",
+      "platform": "darwin",
+      "unique_identifier": "io.beekeeperstudio.desktop",
+      "description": ""
+    },
+    {
       "name": "Beyond Compare",
       "slug": "beyond-compare/darwin",
       "platform": "darwin",

--- a/ee/maintained-apps/outputs/beekeeper-studio/darwin.json
+++ b/ee/maintained-apps/outputs/beekeeper-studio/darwin.json
@@ -1,0 +1,21 @@
+{
+  "versions": [
+    {
+      "version": "5.2.12",
+      "queries": {
+        "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'io.beekeeperstudio.desktop';"
+      },
+      "installer_url": "https://github.com/beekeeper-studio/beekeeper-studio/releases/download/v5.2.12/Beekeeper-Studio-5.2.12-arm64.dmg",
+      "install_script_ref": "b5e1d839",
+      "uninstall_script_ref": "7f149ec7",
+      "sha256": "efd22888604fa39ed379c505fb09871e21c9addb6c8b3fefb00a63a826cac53a",
+      "default_categories": [
+        "Developer tools"
+      ]
+    }
+  ],
+  "refs": {
+    "7f149ec7": "#!/bin/sh\n# Script to uninstall Beekeeper Studio from macOS\n# variables\nAPPDIR=\"/Applications/\"\nLOGGED_IN_USER=$(scutil \u003c\u003c\u003c \"show State:/Users/ConsoleUser\" | awk '/Name :/ { print $3 }')\n# functions\n\ntrash() {\n  local logged_in_user=\"$1\"\n  local target_file=\"$2\"\n  local timestamp=\"$(date +%Y-%m-%d-%s)\"\n  local rand=\"$(jot -r 1 0 99999)\"\n\n  # replace ~ with /Users/$logged_in_user\n  if [[ \"$target_file\" == ~* ]]; then\n    target_file=\"/Users/$logged_in_user${target_file:1}\"\n  fi\n\n  local trash=\"/Users/$logged_in_user/.Trash\"\n  local file_name=\"$(basename \"${target_file}\")\"\n\n  if [[ -e \"$target_file\" ]]; then\n    echo \"removing $target_file.\"\n    mv -f \"$target_file\" \"$trash/${file_name}_${timestamp}_${rand}\"\n  else\n    echo \"$target_file doesn't exist.\"\n  fi\n}\n\nsudo rm -rf \"$APPDIR/Beekeeper Studio.app\"\ntrash $LOGGED_IN_USER '~/Library/Application Support/beekeeper-studio'\ntrash $LOGGED_IN_USER '~/Library/Application Support/Caches/beekeeper-studio-updater'\ntrash $LOGGED_IN_USER '~/Library/Caches/io.beekeeperstudio.desktop'\ntrash $LOGGED_IN_USER '~/Library/Caches/io.beekeeperstudio.desktop.ShipIt'\ntrash $LOGGED_IN_USER '~/Library/Preferences/ByHost/io.beekeeperstudio.desktop.ShipIt.*.plist'\ntrash $LOGGED_IN_USER '~/Library/Preferences/io.beekeeperstudio.desktop.plist'\ntrash $LOGGED_IN_USER '~/Library/Saved Application State/io.beekeeperstudio.desktop.savedState'\n\n",
+    "b5e1d839": "#!/bin/sh\n# Script to install Beekeeper Studio on macOS\n# variables\nAPPDIR=\"/Applications/\"\nTMPDIR=$(dirname \"$(realpath $INSTALLER_PATH)\")\n# functions\n\nquit_application() {\n  local bundle_id=\"$1\"\n  local timeout_duration=10\n\n  # check if the application is running\n  if ! osascript -e \"application id \\\"$bundle_id\\\" is running\" 2\u003e/dev/null; then\n    return\n  fi\n\n  local console_user\n  console_user=$(stat -f \"%Su\" /dev/console)\n  if [[ $EUID -eq 0 \u0026\u0026 \"$console_user\" == \"root\" ]]; then\n    echo \"Not logged into a non-root GUI; skipping quitting application ID '$bundle_id'.\"\n    return\n  fi\n\n  echo \"Quitting application '$bundle_id'...\"\n\n  # try to quit the application within the timeout period\n  local quit_success=false\n  SECONDS=0\n  while (( SECONDS \u003c timeout_duration )); do\n    if osascript -e \"tell application id \\\"$bundle_id\\\" to quit\" \u003e/dev/null 2\u003e\u00261; then\n      if ! pgrep -f \"$bundle_id\" \u003e/dev/null 2\u003e\u00261; then\n        echo \"Application '$bundle_id' quit successfully.\"\n        quit_success=true\n        break\n      fi\n    fi\n    sleep 1\n  done\n\n  if [[ \"$quit_success\" = false ]]; then\n    echo \"Application '$bundle_id' did not quit.\"\n  fi\n}\n\n\n# extract contents\nMOUNT_POINT=$(mktemp -d /tmp/dmg_mount_XXXXXX)\nhdiutil attach -plist -nobrowse -readonly -mountpoint \"$MOUNT_POINT\" \"$INSTALLER_PATH\"\nsudo cp -R \"$MOUNT_POINT\"/* \"$TMPDIR\"\nhdiutil detach \"$MOUNT_POINT\"\n# copy to the applications folder\nquit_application 'io.beekeeperstudio.desktop'\nif [ -d \"$APPDIR/Beekeeper Studio.app\" ]; then\n\tsudo mv \"$APPDIR/Beekeeper Studio.app\" \"$TMPDIR/Beekeeper Studio.app.bkp\"\nfi\nsudo cp -R \"$TMPDIR/Beekeeper Studio.app\" \"$APPDIR\"\n\n"
+  }
+}


### PR DESCRIPTION
Fixes #30884

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [ ] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.
- [ ] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [ ] Added support on fleet's osquery simulator `cmd/osquery-perf` for new osquery data ingestion features.
- [ ] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes
- [ ] If database migrations are included, checked table schema to confirm autoupdate
- For new Fleet configuration settings
  - [ ] Verified that the setting can be managed via GitOps, or confirmed that the setting is explicitly being excluded from GitOps.  If managing via Gitops:
    - [ ] Verified that the setting is exported via `fleetctl generate-gitops`
    - [ ] Added the setting to [the GitOps documentation](https://github.com/fleetdm/fleet/blob/main/docs/Configuration/yaml-files.md#L485)
    - [ ] Verified that the setting is cleared on the server if it is not supplied in a YAML file (or that it is documented as being optional)
    - [ ] Verified that any relevant UI is disabled when GitOps mode is enabled
- For database migrations:
  - [ ] Checked schema for all modified table for columns that will auto-update timestamps during migration.
  - [ ] Confirmed that updating the timestamps is acceptable, and will not cause unwanted side effects.
  - [ ] Ensured the correct collation is explicitly set for character columns (`COLLATE utf8mb4_unicode_ci`).
- [ ] Added/updated automated tests
- [ ] Manual QA for all new/changed functionality
- For Orbit and Fleet Desktop changes:
   - [ ] Make sure fleetd is compatible with the latest released version of Fleet (see [Must rule](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/workflows/fleetd-development-and-release-strategy.md)).
   - [ ] Orbit runs on macOS, Linux and Windows. Check if the orbit feature/bugfix should only apply to one platform (`runtime.GOOS`).
   - [ ] Manual QA must be performed in the three main OSs, macOS, Windows and Linux.
   - [ ] Auto-update manual QA, from released version of component to new version (see [tools/tuf/test](../tools/tuf/test/README.md)).
- [ ] For unreleased bug fixes in a release candidate, confirmed that the fix is not expected to adversely impact load test results or alerted the release DRI if additional load testing is needed.
