### PR TITLE
Add note to macOS MDM setup about failures during Setup Assistant

### DIFF
--- a/articles/macos-mdm-setup.md
+++ b/articles/macos-mdm-setup.md
@@ -106,7 +106,7 @@ The acquisitions's VPP token will be assigned to the above teams.
 Fleet uses SCEP certificates (1 year expiry) to authenticate the requests hosts make to Fleet. Fleet
 renews each host's SCEP certificates automatically every 180 days.
 
-## Automatic Enrollment Failures
+## Troubleshooting failed enrollments
 
 If a host is turned off due to user action or a low battery during the Setup Assistant, it may fail to enroll. This can also happen if your Fleet instance is down for maintenance when a host tries to enroll automatically during the Setup Assistant. In these cases, hosts usually restart after the user attempts to get past the “Welcome to Mac" screen. The best practice in this situation is to wipe the host with Fleet if it has network connectivity or to [reinstall macOS from Recovery](https://support.apple.com/en-us/102655).
 

--- a/articles/macos-mdm-setup.md
+++ b/articles/macos-mdm-setup.md
@@ -108,13 +108,7 @@ renews each host's SCEP certificates automatically every 180 days.
 
 ## Automatic Enrollment Failures
 
-If your Fleet instance is down for maintenance when a host attempts to automatically enroll during
-the Setup Assistant process, this may result in a failed enrollment. Alternatively, if a host powers
-down  due to user actions or a low battery during Setup Assistant this may also result in a failed
-enrollment. In these instances hosts exhibit a variety of behaviors based on the exact timing of the
-failure but commonly will attempt to restart the macOS Setup Assistant and display "Welcome to Mac"
-after the user next reboots the host. When this occurs the best course of action is to Wipe the host via
-Fleet if the host has network connectivity or reinstall macOS from Recovery.
+If a host is turned off due to user action or a low battery during the Setup Assistant, it may fail to enroll. This can also happen if your Fleet instance is down for maintenance when a host tries to enroll automatically during the Setup Assistant. In these cases, hosts usually restart after the user attempts to get past the “Welcome to Mac" screen. The best practice in this situation is to wipe the host with Fleet if it has network connectivity or to [reinstall macOS from Recovery](https://support.apple.com/en-us/102655).
 
 <meta name="category" value="guides">
 <meta name="authorGitHubUsername" value="zhumo">

--- a/articles/macos-mdm-setup.md
+++ b/articles/macos-mdm-setup.md
@@ -103,7 +103,18 @@ The acquisitions's VPP token will be assigned to the above teams.
 
 ## Simple Certificate Enrollment Protocol (SCEP)
 
-Fleet uses SCEP certificates (1 year expiry) to authenticate the requests hosts make to Fleet. Fleet renews each host's SCEP certificates automatically every 180 days.
+Fleet uses SCEP certificates (1 year expiry) to authenticate the requests hosts make to Fleet. Fleet
+renews each host's SCEP certificates automatically every 180 days.
+
+## Automatic Enrollment Failures
+
+If your Fleet instance is down for maintenance when a host attempts to automatically enroll during
+the Setup Assistant process, this may result in a failed enrollment. Alternatively, if a host powers
+down  due to user actions or a low battery during Setup Assistant this may also result in a failed
+enrollment. In these instances hosts exhibit a variety of behaviors based on the exact timing of the
+failure but commonly will attempt to restart the macOS Setup Assistant and display "Welcome to Mac"
+after the user next reboots the host. When this occurs the best course of action is to Wipe the host via
+Fleet if the host has network connectivity or reinstall macOS from Recovery.
 
 <meta name="category" value="guides">
 <meta name="authorGitHubUsername" value="zhumo">


### PR DESCRIPTION
For #30089 . This behavior appears to be an Apple bug, or at least an unsupported usecase(rebooting while at the Remote Management screen, before the DeviceConfigured is sent) and thus our best course of action is to document that a user should Wipe/Reset the device when this happens unless we learn more about how to prevent this which seems unlikely.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new section detailing potential causes and recovery steps for automatic enrollment failures during macOS MDM setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->