### PR TITLE
Allow Loadtesting environment non-empty s3 bucket cleanup on terraform destroy

### DIFF
--- a/infrastructure/loadtesting/terraform/firehose.tf
+++ b/infrastructure/loadtesting/terraform/firehose.tf
@@ -1,5 +1,8 @@
 resource "aws_s3_bucket" "osquery-results" { #tfsec:ignore:aws-s3-encryption-customer-key tfsec:ignore:aws-s3-enable-bucket-logging tfsec:ignore:aws-s3-enable-versioning
   bucket = "${local.prefix}-loadtest-osquery-logs-archive"
+  
+  # Allow destroy of non-empty buckets
+  force_destroy = true
 
   #checkov:skip=CKV_AWS_18:dev env
   #checkov:skip=CKV_AWS_144:dev env
@@ -39,6 +42,9 @@ resource "aws_s3_bucket_public_access_block" "osquery-results" {
 
 resource "aws_s3_bucket" "osquery-status" { #tfsec:ignore:aws-s3-encryption-customer-key tfsec:ignore:aws-s3-enable-bucket-logging tfsec:ignore:aws-s3-enable-versioning
   bucket = "${local.prefix}-loadtest-osquery-status-archive"
+  
+  # Allow destroy of non-empty buckets
+  force_destroy = true
 
   #checkov:skip=CKV_AWS_18:dev env
   #checkov:skip=CKV_AWS_144:dev env

--- a/infrastructure/loadtesting/terraform/s3.tf
+++ b/infrastructure/loadtesting/terraform/s3.tf
@@ -26,6 +26,9 @@ resource "aws_iam_role_policy_attachment" "software_installers" {
 
 resource "aws_s3_bucket" "software_installers" { #tfsec:ignore:aws-s3-encryption-customer-key:exp:2022-07-01  #tfsec:ignore:aws-s3-enable-versioning #tfsec:ignore:aws-s3-enable-bucket-logging:exp:2022-06-15
   bucket_prefix = terraform.workspace
+  
+  # Allow destroy of non-empty buckets
+  force_destroy = true
 }
 
 resource "aws_s3_bucket_server_side_encryption_configuration" "software_installers" {


### PR DESCRIPTION
* Modified resource aws_s3_bucket blocks to include `force_destroy = true` in firehose.tf and s3.tf.