### PR TITLE
For 29994: Use comshim for proper COM initialization

### DIFF
--- a/changes/29994-use-comshim
+++ b/changes/29994-use-comshim
@@ -1,0 +1,1 @@
+* Fixed bug with `mdm_bridge` Orbit table that caused panics due to invalid COM initialization.


### PR DESCRIPTION
For #29994 

The `mdm_bridge` Orbit table was not using comshim for initializing the multi-threaded COM apartment which was causing panics.

# Checklist for submitter

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.
- [X] Manual QA for all new/changed functionality
- For Orbit and Fleet Desktop changes:
   - [X] Make sure fleetd is compatible with the latest released version of Fleet (see [Must rule](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/workflows/fleetd-development-and-release-strategy.md)).
   - [X] Orbit runs on macOS, Linux and Windows. Check if the orbit feature/bugfix should only apply to one platform (`runtime.GOOS`).
   - [X] Manual QA must be performed in the three main OSs, macOS, Windows and Linux.