### PR TITLE
[API changes] Apple (macOS, iOS, and iPadOS) configuration profiles: surface which local user account gets user scoped profiles

### DIFF
--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -3052,7 +3052,7 @@ Returns the information of the specified host.
           "status": "verifying",
           "operation_type": "install",
           "scope": "device",
-          "users": [],
+          "managed_local_user": "[]",
           "detail": ""
         }
       ]
@@ -3279,7 +3279,7 @@ If `hostname` is specified when there is more than one host with the same hostna
           "status": "verifying",
           "operation_type": "install",
           "scope": "device",
-          "users": [],
+          "managed_local_user": "",
           "detail": ""
         }
       ]
@@ -3475,7 +3475,7 @@ This is the API route used by the **My device** page in Fleet desktop to display
           "status": "verifying",
           "operation_type": "install",
           "scope": "device",
-          "users": [],
+          "managed_local_user": "",
           "detail": ""
         }
       ]

--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -3051,7 +3051,8 @@ Returns the information of the specified host.
           "name": "profile1",
           "status": "verifying",
           "operation_type": "install",
-          "scioe": "device",
+          "scope": "device",
+          "users": [],
           "detail": ""
         }
       ]

--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -3277,6 +3277,7 @@ If `hostname` is specified when there is more than one host with the same hostna
           "name": "profile1",
           "status": "verifying",
           "operation_type": "install",
+          "scope": "device",
           "detail": ""
         }
       ]
@@ -3471,6 +3472,7 @@ This is the API route used by the **My device** page in Fleet desktop to display
           "name": "profile1",
           "status": "verifying",
           "operation_type": "install",
+          "scope": "device",
           "detail": ""
         }
       ]

--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -3475,6 +3475,7 @@ This is the API route used by the **My device** page in Fleet desktop to display
           "status": "verifying",
           "operation_type": "install",
           "scope": "device",
+          "users": [],
           "detail": ""
         }
       ]

--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -3051,6 +3051,7 @@ Returns the information of the specified host.
           "name": "profile1",
           "status": "verifying",
           "operation_type": "install",
+          "scioe": "device",
           "detail": ""
         }
       ]

--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -3052,7 +3052,7 @@ Returns the information of the specified host.
           "status": "verifying",
           "operation_type": "install",
           "scope": "device",
-          "managed_local_user": "[]",
+          "managed_local_user": "",
           "detail": ""
         }
       ]

--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -3279,6 +3279,7 @@ If `hostname` is specified when there is more than one host with the same hostna
           "status": "verifying",
           "operation_type": "install",
           "scope": "device",
+          "users": [],
           "detail": ""
         }
       ]


### PR DESCRIPTION
UPDATE: Closed [old PR](https://github.com/fleetdm/fleet/pull/30275) against `docs-v4.72.0`, and opened this one against `docs-v4.73.0`.

---

Related to:

- #29792