### PR TITLE
Website: update deliver-apple-csr exits

### DIFF
--- a/website/api/controllers/deliver-apple-csr.js
+++ b/website/api/controllers/deliver-apple-csr.js
@@ -37,6 +37,21 @@ module.exports = {
       responseType: 'badRequest'
     },
 
+    csrMissingOrg: {
+      description: 'The provided unsigned CSR did not contain a required "org" value',
+      responseType: 'badRequest'
+    },
+
+    csrMissingEmail: {
+      description: 'The provided unsigned CSR did not contain a required "email" value',
+      responseType: 'badRequest'
+    },
+
+    csrMissingRequest: {
+      description: 'The provided unsigned CSR did not contain a required "request" value',
+      responseType: 'badRequest'
+    },
+
     badRequest: {
       responseType: 'badRequest'
     }
@@ -83,17 +98,18 @@ module.exports = {
 
     // Parse the JSON result from the mdm-gen-cert command
     let generateCertificateResult = JSON.parse(generateCertificateCommand.stdout);
-    // Throw an error if the result from the mdm-gen-cert command is missing an email value.
+
+    // return a csrMissingEmail response if the result from the mdm-gen-cert command is missing an email value.
     if(!generateCertificateResult.email) {
-      throw new Error('When trying to generate a signed CSR for a user, the result from the mdm-gen-cert command did not contain a email.');
+      throw 'csrMissingEmail';
     }
-    // Throw an error if the result from the mdm-gen-cert command is missing an org value.
+    // return a csrMissingOrg response if the result from the mdm-gen-cert command is missing an org value.
     if(!generateCertificateResult.org) {
-      throw new Error('When trying to generate a signed CSR for a user, the result from the mdm-gen-cert command did not contain an organization name');
+      throw 'csrMissingOrg';
     }
-    // Throw an error if the result from the mdm-gen-cert command is missing an request value.
+    // return a csrMissingRequest response if the result from the mdm-gen-cert command is missing an request value.
     if(!generateCertificateResult.request) {
-      throw new Error('When trying to generate a signed CSR for a user, the result from the mdm-gen-cert command did not contain a certificate');
+      throw 'csrMissingRequest';
     }
 
     // Check to make sure that the email included in the result is a valid email address.

--- a/website/api/controllers/deliver-apple-csr.js
+++ b/website/api/controllers/deliver-apple-csr.js
@@ -39,7 +39,6 @@ module.exports = {
 
     csrMissingRequiredValue: {
       description: 'The provided unsigned CSR did not contain a required value',
-      responseType: 'badRequest'
     },
 
     badRequest: {
@@ -91,15 +90,15 @@ module.exports = {
 
     // return a csrMissingRequiredValue response if the result from the mdm-gen-cert command is missing an email value.
     if(!generateCertificateResult.email) {
-      throw {'csrMissingRequiredValue': 'The provided unsigned CSR did not contain a required "email" value'};
+      throw {'csrMissingRequiredValue': 'The provided unsigned CSR data is missing an "email" value'};
     }
     // return a csrMissingRequiredValue response if the result from the mdm-gen-cert command is missing an org value.
     if(!generateCertificateResult.org) {
-      throw {'csrMissingRequiredValue': 'The provided unsigned CSR did not contain a required "org" value'};
+      throw {'csrMissingRequiredValue': 'The provided unsigned CSR data is missing an "org" value'};
     }
     // return a csrMissingRequiredValue response if the result from the mdm-gen-cert command is missing an request value.
     if(!generateCertificateResult.request) {
-      throw {'csrMissingRequiredValue': 'The provided unsigned CSR did not contain a required "request" value'};
+      throw {'csrMissingRequiredValue': 'The provided unsigned CSR data is missing a "request" value'};
     }
 
     // Check to make sure that the email included in the result is a valid email address.

--- a/website/api/controllers/deliver-apple-csr.js
+++ b/website/api/controllers/deliver-apple-csr.js
@@ -37,18 +37,8 @@ module.exports = {
       responseType: 'badRequest'
     },
 
-    csrMissingOrg: {
-      description: 'The provided unsigned CSR did not contain a required "org" value',
-      responseType: 'badRequest'
-    },
-
-    csrMissingEmail: {
-      description: 'The provided unsigned CSR did not contain a required "email" value',
-      responseType: 'badRequest'
-    },
-
-    csrMissingRequest: {
-      description: 'The provided unsigned CSR did not contain a required "request" value',
+    csrMissingRequiredValue: {
+      description: 'The provided unsigned CSR did not contain a required value',
       responseType: 'badRequest'
     },
 
@@ -99,17 +89,17 @@ module.exports = {
     // Parse the JSON result from the mdm-gen-cert command
     let generateCertificateResult = JSON.parse(generateCertificateCommand.stdout);
 
-    // return a csrMissingEmail response if the result from the mdm-gen-cert command is missing an email value.
+    // return a csrMissingRequiredValue response if the result from the mdm-gen-cert command is missing an email value.
     if(!generateCertificateResult.email) {
-      throw 'csrMissingEmail';
+      throw {'csrMissingRequiredValue': 'The provided unsigned CSR did not contain a required "email" value'};
     }
-    // return a csrMissingOrg response if the result from the mdm-gen-cert command is missing an org value.
+    // return a csrMissingRequiredValue response if the result from the mdm-gen-cert command is missing an org value.
     if(!generateCertificateResult.org) {
-      throw 'csrMissingOrg';
+      throw {'csrMissingRequiredValue': 'The provided unsigned CSR did not contain a required "org" value'};
     }
-    // return a csrMissingRequest response if the result from the mdm-gen-cert command is missing an request value.
+    // return a csrMissingRequiredValue response if the result from the mdm-gen-cert command is missing an request value.
     if(!generateCertificateResult.request) {
-      throw 'csrMissingRequest';
+      throw {'csrMissingRequiredValue': 'The provided unsigned CSR did not contain a required "request" value'};
     }
 
     // Check to make sure that the email included in the result is a valid email address.


### PR DESCRIPTION
Closes: https://github.com/fleetdm/fleet/issues/30914

Changes:
- Updated the `deliver-apple-csr` endpoint to return a `csrMissingRequiredValue ` response when the provided unsigned CSR data does not contain a required value.