### PR TITLE
Website: Update create-android-signup-url error handling

### DIFF
--- a/website/api/controllers/android-proxy/create-android-signup-url.js
+++ b/website/api/controllers/android-proxy/create-android-signup-url.js
@@ -18,6 +18,7 @@ module.exports = {
   exits: {
     success: { description: 'A signup URL has been sent to the requesting Fleet server.'},
     enterpriseAlreadyExists: { description: 'An Android enterprise already exists for this Fleet instance.', statusCode: 409 },
+    invalidCallbackUrl: { description: 'The provided callbackUrl could not be used to create an Android enterprise signup URL.', responseType: 'badRequest'}
   },
 
 
@@ -60,6 +61,8 @@ module.exports = {
         projectId: sails.config.custom.androidEnterpriseProjectId,
       });
       return createSignupUrlResponse.data;
+    }).intercept({status: 400}, (unusedErr)=>{
+      return {'invalidCallbackUrl': 'The provided Callback Url could not be used to create an Android enterprise signup URL.'};
     }).intercept((err)=>{
       return new Error(`When attempting to create a singup url for a new Android enterprise, an error occurred. Error: ${err}`);
     });


### PR DESCRIPTION
Closes #30935

Changes:
- Updated created-android-signup-url to return a bad request response if a provided callback URL cannot be used to create an Android Enterprise signup URL.