### PR TITLE
Sort package ids to ensure consistent uninstall script generation

### DIFF
--- a/changes/29286-sort-package-ids
+++ b/changes/29286-sort-package-ids
@@ -1,0 +1,1 @@
+* Fixed issue with package ids ordering causing software installers' scripts to be inconsistently generated

--- a/pkg/file/xar.go
+++ b/pkg/file/xar.go
@@ -30,6 +30,7 @@ import (
 	"io"
 	"path/filepath"
 	"slices"
+	"sort"
 	"strings"
 
 	"github.com/fleetdm/fleet/v4/server/fleet"
@@ -462,6 +463,11 @@ func getDistributionInfo(d *distributionXML) (name string, identifier string, ve
 		packageIDs = append(packageIDs, identifier)
 	}
 
+	// Sorting package IDs to ensure consistent order
+	// Ex: the uninstall_pkg.sh uses this slice and we want it to
+	// remain consistent/deterministic across generations
+	sort.Strings(packageIDs)
+
 	// for the name, try to use the title and fallback to the bundle
 	// identifier
 	if name == "" && d.Title != "" {
@@ -583,6 +589,11 @@ func getPackageInfo(p *packageInfoXML) (name string, identifier string, version 
 	if len(packageIDs) == 0 && identifier != "" {
 		packageIDs = append(packageIDs, identifier)
 	}
+
+	// Sorting package IDs to ensure consistent order
+	// Ex: the uninstall_pkg.sh uses this slice and we want it to
+	// remain consistent/deterministic across generations
+	sort.Strings(packageIDs)
 
 	return name, identifier, version, packageIDs
 }

--- a/pkg/file/xar_test.go
+++ b/pkg/file/xar_test.go
@@ -109,8 +109,8 @@ func TestParseRealDistributionFiles(t *testing.T) {
 			expectedVersion:  "24124.1412.2911.3341",
 			expectedBundleID: "com.microsoft.teams2",
 			expectedPackageIDs: []string{
-				"com.microsoft.teams2", "com.microsoft.package.Microsoft_AutoUpdate.app",
-				"com.microsoft.MSTeamsAudioDevice",
+				"com.microsoft.MSTeamsAudioDevice", "com.microsoft.package.Microsoft_AutoUpdate.app",
+				"com.microsoft.teams2",
 			},
 		},
 		{
@@ -143,8 +143,8 @@ func TestParseRealDistributionFiles(t *testing.T) {
 			expectedVersion:  "2.38.173",
 			expectedBundleID: "com.box.desktop",
 			expectedPackageIDs: []string{
-				"com.box.desktop.installer.desktop", "com.box.desktop.installer.local.appsupport",
-				"com.box.desktop.installer.autoupdater", "com.box.desktop.installer.osxfuse",
+				"com.box.desktop.installer.autoupdater", "com.box.desktop.installer.desktop",
+				"com.box.desktop.installer.local.appsupport", "com.box.desktop.installer.osxfuse",
 			},
 		},
 		{
@@ -154,7 +154,7 @@ func TestParseRealDistributionFiles(t *testing.T) {
 			expectedBundleID: "com.iriun.macwebcam",
 			// Note: "com.iriun.pkg.multicam" is part of the installer package, but it is not actually installed by default.
 			// We can't reliably determine which packages are installed by the installer, so we just list all of them.
-			expectedPackageIDs: []string{"com.iriun.pkg.webcam.tmp", "com.iriun.pkg.multicam"},
+			expectedPackageIDs: []string{"com.iriun.pkg.multicam", "com.iriun.pkg.webcam.tmp"},
 		},
 		{
 			file:             "distribution-microsoftexcel.xml",
@@ -162,7 +162,7 @@ func TestParseRealDistributionFiles(t *testing.T) {
 			expectedVersion:  "16.86",
 			expectedBundleID: "com.microsoft.Excel",
 			expectedPackageIDs: []string{
-				"com.microsoft.package.Microsoft_Excel.app", "com.microsoft.package.Microsoft_AutoUpdate.app",
+				"com.microsoft.package.Microsoft_AutoUpdate.app", "com.microsoft.package.Microsoft_Excel.app",
 				"com.microsoft.pkg.licensing",
 			},
 		},
@@ -172,7 +172,7 @@ func TestParseRealDistributionFiles(t *testing.T) {
 			expectedVersion:  "16.86",
 			expectedBundleID: "com.microsoft.Word",
 			expectedPackageIDs: []string{
-				"com.microsoft.package.Microsoft_Word.app", "com.microsoft.package.Microsoft_AutoUpdate.app",
+				"com.microsoft.package.Microsoft_AutoUpdate.app", "com.microsoft.package.Microsoft_Word.app",
 				"com.microsoft.pkg.licensing",
 			},
 		},
@@ -182,7 +182,7 @@ func TestParseRealDistributionFiles(t *testing.T) {
 			expectedVersion:  "16.86",
 			expectedBundleID: "com.microsoft.Powerpoint",
 			expectedPackageIDs: []string{
-				"com.microsoft.package.Microsoft_PowerPoint.app", "com.microsoft.package.Microsoft_AutoUpdate.app",
+				"com.microsoft.package.Microsoft_AutoUpdate.app", "com.microsoft.package.Microsoft_PowerPoint.app",
 				"com.microsoft.pkg.licensing",
 			},
 		},
@@ -215,11 +215,14 @@ func TestParseRealDistributionFiles(t *testing.T) {
 			expectedPackageIDs: []string{"com.sentinelone.pkg.sentinel-agent", "com.sentinelone.sentinel-agent"},
 		},
 		{
-			file:               "distribution-cold-turkey.xml",
-			expectedName:       "Cold Turkey Blocker",
-			expectedVersion:    "4.5",
-			expectedBundleID:   "com.getcoldturkey.coldturkeyblocker",
-			expectedPackageIDs: []string{"com.getcoldturkey.coldturkeyblocker", "com.getcoldturkey.blocker-firefox-ext", "com.getcoldturkey.blocker-edge-ext", "com.getcoldturkey.blocker-chrome-ext"},
+			file:             "distribution-cold-turkey.xml",
+			expectedName:     "Cold Turkey Blocker",
+			expectedVersion:  "4.5",
+			expectedBundleID: "com.getcoldturkey.coldturkeyblocker",
+			expectedPackageIDs: []string{
+				"com.getcoldturkey.blocker-chrome-ext", "com.getcoldturkey.blocker-edge-ext",
+				"com.getcoldturkey.blocker-firefox-ext", "com.getcoldturkey.coldturkeyblocker",
+			},
 		},
 	}
 
@@ -229,7 +232,7 @@ func TestParseRealDistributionFiles(t *testing.T) {
 			require.NoError(t, err)
 			metadata, err := parseDistributionFile(rawXML)
 			require.NoError(t, err)
-			assert.ElementsMatch(t, tt.expectedPackageIDs, metadata.PackageIDs)
+			assert.Equal(t, tt.expectedPackageIDs, metadata.PackageIDs)
 			require.Equal(t, tt.expectedName, metadata.Name)
 			require.Equal(t, tt.expectedVersion, metadata.Version)
 			require.Equal(t, tt.expectedBundleID, metadata.BundleIdentifier)
@@ -259,8 +262,8 @@ func TestParsePackageInfoFiles(t *testing.T) {
 			expectedVersion:  "2.8.10",
 			expectedBundleID: "com.iriun.macwebcam",
 			expectedPackageIDs: []string{
-				"com.iriun.macwebcam", "com.iriun.macwebcam.extension4", "com.iriun.macwebcam.extension",
-				"com.iriun.mic",
+				"com.iriun.macwebcam", "com.iriun.macwebcam.extension",
+				"com.iriun.macwebcam.extension4", "com.iriun.mic",
 			},
 		},
 		{
@@ -282,14 +285,14 @@ func TestParsePackageInfoFiles(t *testing.T) {
 			expectedName:       "",
 			expectedVersion:    "",
 			expectedBundleID:   "",
-			expectedPackageIDs: []string{},
+			expectedPackageIDs: []string(nil),
 		},
 		{
 			file:               "packageInfo-versionOnly.xml",
 			expectedName:       "",
 			expectedVersion:    "test-version",
 			expectedBundleID:   "",
-			expectedPackageIDs: []string{},
+			expectedPackageIDs: []string(nil),
 		},
 	}
 
@@ -299,7 +302,7 @@ func TestParsePackageInfoFiles(t *testing.T) {
 			require.NoError(t, err)
 			metadata, err := parsePackageInfoFile(rawXML)
 			require.NoError(t, err)
-			assert.ElementsMatch(t, tt.expectedPackageIDs, metadata.PackageIDs)
+			assert.Equal(t, tt.expectedPackageIDs, metadata.PackageIDs)
 			assert.Equal(t, tt.expectedName, metadata.Name)
 			assert.Equal(t, tt.expectedVersion, metadata.Version)
 			assert.Equal(t, tt.expectedBundleID, metadata.BundleIdentifier)


### PR DESCRIPTION
Fixes #29286

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.
- [x] Added/updated automated tests
- [x] Manual QA for all new/changed functionality