### PR TITLE
use upgrade code to improve auto install query

### DIFF
--- a/pkg/automatic_policy/automatic_policy.go
+++ b/pkg/automatic_policy/automatic_policy.go
@@ -139,7 +139,7 @@ func (m FullInstallerMetadata) PolicyQuery() (string, error) {
 		if len(m.PackageIDs) == 0 || m.PackageIDs[0] == "" {
 			return "", ErrMissingProductCode
 		}
-		return fmt.Sprintf("SELECT 1 FROM programs WHERE identifying_number = '%s';", m.PackageIDs[0]), nil
+		return fmt.Sprintf("SELECT 1 FROM programs WHERE upgrade_code = '%s';", m.PackageIDs[0]), nil
 	case "deb":
 		return fmt.Sprintf(
 			// First inner SELECT will mark the policies as successful on non-DEB-based hosts.

--- a/pkg/automatic_policy/automatic_policy.go
+++ b/pkg/automatic_policy/automatic_policy.go
@@ -137,7 +137,7 @@ func (m FullInstallerMetadata) PolicyQuery() (string, error) {
 		return fmt.Sprintf("SELECT 1 FROM apps WHERE bundle_identifier = '%s';", m.BundleIdentifier), nil
 	case "msi":
 		if len(m.PackageIDs) == 0 || m.PackageIDs[0] == "" {
-			return "", ErrMissingProductCode
+			return "", ErrMissingUpgradeCode
 		}
 		return fmt.Sprintf("SELECT 1 FROM programs WHERE upgrade_code = '%s';", m.PackageIDs[0]), nil
 	case "deb":
@@ -182,8 +182,8 @@ var (
 	ErrExtensionNotSupported = errors.New("extension not supported")
 	// ErrMissingBundleIdentifier is returned if the software extension is "pkg" and a bundle identifier was not extracted from the installer.
 	ErrMissingBundleIdentifier = errors.New("missing bundle identifier")
-	// ErrMissingProductCode is returned if the software extension is "msi" and a product code was not extracted from the installer.
-	ErrMissingProductCode = errors.New("missing product code")
+	// ErrMissingUpgradeCode is returned if the software extension is "msi" and an upgrade code was not extracted from the installer.
+	ErrMissingUpgradeCode = errors.New("missing upgrade code")
 	// ErrMissingTitle is returned if a title was not extracted from the installer.
 	ErrMissingTitle = errors.New("missing title")
 )

--- a/pkg/automatic_policy/automatic_policy.go
+++ b/pkg/automatic_policy/automatic_policy.go
@@ -95,7 +95,7 @@ type FullInstallerMetadata struct {
 	// Extension is the extension of the software package.
 	Extension string
 
-	// PackageIDs contains the product code for 'msi' packages.
+	// PackageIDs contains the upgrade code for 'msi' packages.
 	PackageIDs []string
 }
 

--- a/pkg/automatic_policy/automatic_policy_test.go
+++ b/pkg/automatic_policy/automatic_policy_test.go
@@ -24,14 +24,14 @@ func TestGenerateErrors(t *testing.T) {
 		BundleIdentifier: "",
 		PackageIDs:       []string{""},
 	})
-	require.ErrorIs(t, err, ErrMissingProductCode)
+	require.ErrorIs(t, err, ErrMissingUpgradeCode)
 	_, err = Generate(FullInstallerMetadata{
 		Title:            "Foobar",
 		Extension:        "msi",
 		BundleIdentifier: "",
 		PackageIDs:       []string{},
 	})
-	require.ErrorIs(t, err, ErrMissingProductCode)
+	require.ErrorIs(t, err, ErrMissingUpgradeCode)
 
 	_, err = Generate(MacInstallerMetadata{
 		Title:            "Foobar",

--- a/pkg/automatic_policy/automatic_policy_test.go
+++ b/pkg/automatic_policy/automatic_policy_test.go
@@ -104,7 +104,7 @@ func TestGenerate(t *testing.T) {
 	require.Equal(t, "[Install software] Barfoo (msi)", policyData.Name)
 	require.Equal(t, "Policy triggers automatic install of Barfoo on each host that's missing this software.", policyData.Description)
 	require.Equal(t, "windows", policyData.Platform)
-	require.Equal(t, "SELECT 1 FROM programs WHERE identifying_number = 'foo';", policyData.Query)
+	require.Equal(t, "SELECT 1 FROM programs WHERE upgrade_code = 'foo';", policyData.Query)
 
 	policyData, err = Generate(FullInstallerMetadata{
 		Title:            "Zoobar",

--- a/pkg/file/msi.go
+++ b/pkg/file/msi.go
@@ -88,7 +88,7 @@ func ExtractMSIMetadata(tfr *fleet.TempFileReader) (*InstallerMetadata, error) {
 	return &InstallerMetadata{
 		Name:       strings.TrimSpace(productName),
 		Version:    strings.TrimSpace(props["ProductVersion"]),
-		PackageIDs: []string{strings.TrimSpace(props["ProductCode"])},
+		PackageIDs: []string{strings.TrimSpace(props["UpgradeCode"])},
 		SHASum:     h.Sum(nil),
 	}, nil
 }


### PR DESCRIPTION
# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [ ] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.
- [ ] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [ ] Added support on fleet's osquery simulator `cmd/osquery-perf` for new osquery data ingestion features.
- [ ] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes
- [ ] If database migrations are included, checked table schema to confirm autoupdate
- For new Fleet configuration settings
  - [ ] Verified that the setting can be managed via GitOps, or confirmed that the setting is explicitly being excluded from GitOps.  If managing via Gitops:
    - [ ] Verified that the setting is exported via `fleetctl generate-gitops`
    - [ ] Added the setting to [the GitOps documentation](https://github.com/fleetdm/fleet/blob/main/docs/Configuration/yaml-files.md#L485)
    - [ ] Verified that the setting is cleared on the server if it is not supplied in a YAML file (or that it is documented as being optional)
    - [ ] Verified that any relevant UI is disabled when GitOps mode is enabled
- For database migrations:
  - [ ] Checked schema for all modified table for columns that will auto-update timestamps during migration.
  - [ ] Confirmed that updating the timestamps is acceptable, and will not cause unwanted side effects.
  - [ ] Ensured the correct collation is explicitly set for character columns (`COLLATE utf8mb4_unicode_ci`).
- [ ] Added/updated automated tests
  - [ ] Where appropriate, automated tests simulate multiple hosts and test for host isolation (updates to one hosts's records do not affect another.)
- [ ] Manual QA for all new/changed functionality
- For Orbit and Fleet Desktop changes:
   - [ ] Make sure fleetd is compatible with the latest released version of Fleet (see [Must rule](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/workflows/fleetd-development-and-release-strategy.md)).
   - [ ] Orbit runs on macOS, Linux and Windows. Check if the orbit feature/bugfix should only apply to one platform (`runtime.GOOS`).
   - [ ] Manual QA must be performed in the three main OSs, macOS, Windows and Linux.
   - [ ] Auto-update manual QA, from released version of component to new version (see [tools/tuf/test](../tools/tuf/test/README.md)).
- [ ] For unreleased bug fixes in a release candidate, confirmed that the fix is not expected to adversely impact load test results or alerted the release DRI if additional load testing is needed.
