### PR TITLE
Fix stale pending remove apple declarations if host was offline for add and remove declaration

### DIFF
--- a/changes/29824-delete-installs-that-has-not-reached-hosts
+++ b/changes/29824-delete-installs-that-has-not-reached-hosts
@@ -1,0 +1,1 @@
+* Fix stale pending remove apple declarations, if the host was offline while adding and removing the same declaration.

--- a/server/service/integration_mdm_ddm_test.go
+++ b/server/service/integration_mdm_ddm_test.go
@@ -470,7 +470,8 @@ func (s *integrationMDMTestSuite) TestAppleDDMSecretVariables() {
 	_, mdmDevice := createHostThenEnrollMDM(s.ds, s.server.URL, t)
 
 	checkDeclarationItemsResp := func(t *testing.T, r fleet.MDMAppleDDMDeclarationItemsResponse, expectedDeclTok string,
-		expectedDeclsByToken map[string]fleet.MDMAppleDeclaration) {
+		expectedDeclsByToken map[string]fleet.MDMAppleDeclaration,
+	) {
 		require.Equal(t, expectedDeclTok, r.DeclarationsToken)
 		require.NotEmpty(t, r.Declarations.Activations)
 		require.Empty(t, r.Declarations.Assets)
@@ -1065,7 +1066,6 @@ func (s *integrationMDMTestSuite) TestAppleDDMStatusReport() {
 	require.NoError(t, err)
 	assertHostDeclarations(mdmHost.UUID, []*fleet.MDMAppleHostDeclaration{
 		{Identifier: "I1", Status: &fleet.MDMDeliveryVerified, OperationType: fleet.MDMOperationTypeInstall},
-		{Identifier: "I2", Status: &fleet.MDMDeliveryPending, OperationType: fleet.MDMOperationTypeRemove},
 	})
 
 	// host sends a report, declaration I2 is removed from the hosts_* table


### PR DESCRIPTION
Fixes: #29824 

This PR fixes a situtation where Apple Declarations could be lingering around for hosts, if they were offline when the decl. was added and removed, and no further declaration config is pushed to force a status update.

It tackles it by deleting the pending and failed installs from the table, before setting the remaining (verified and verifying) to be remove operation, as those have hit the host.

I couldn't come up with a way that would auto-fix the hosts we see in dogfood, as those have the same declaration identifier and token for both an install row and pending remove row. Those needs to manually be adjusted and then it should be good.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.
- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [x] Added/updated automated tests
- [x] Manual QA for all new/changed functionality
