### PR TITLE
Added auth.require_http_message_signature server option.

### DIFF
--- a/cmd/fleet/serve.go
+++ b/cmd/fleet/serve.go
@@ -1076,7 +1076,7 @@ the way that the Fleet server works.
 
 			var httpSigVerifier func(http.Handler) http.Handler
 			if license.IsPremium() {
-				httpSigVerifier, err = httpsig.Middleware(ds, kitlog.With(logger, "component", "http-sig-verifier"))
+				httpSigVerifier, err = httpsig.Middleware(ds, config.Auth.RequireHTTPMessageSignature, kitlog.With(logger, "component", "http-sig-verifier"))
 				if err != nil {
 					initFatal(err, "initializing HTTP signature verifier")
 				}

--- a/ee/server/integrationtest/hostidentity/hostidentity_requiresig_test.go
+++ b/ee/server/integrationtest/hostidentity/hostidentity_requiresig_test.go
@@ -1,0 +1,142 @@
+package hostidentity
+
+import (
+	"bytes"
+	"crypto/elliptic"
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/fleetdm/fleet/v4/pkg/fleethttp"
+	"github.com/fleetdm/fleet/v4/server/datastore/mysql"
+	"github.com/fleetdm/fleet/v4/server/service/contract"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHostIdentityRequireSignature(t *testing.T) {
+	// Set up suite with requireSignature = true
+	s := SetUpSuite(t, "integrationtest.HostIdentityRequireSignature", true)
+
+	cases := []struct {
+		name string
+		fn   func(t *testing.T, s *Suite)
+	}{
+		{"OrbitEnrollAndConfig", testOrbitEnrollAndConfigWithRequiredSignature},
+		{"OsqueryEnrollFailsWithoutSignature", testOsqueryEnrollFailsWithoutSignature},
+		{"OrbitEnrollFailsWithoutSignature", testOrbitEnrollFailsWithoutSignature},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			defer mysql.TruncateTables(t, s.BaseSuite.DS, []string{
+				"host_identity_scep_serials", "host_identity_scep_certificates",
+			}...)
+			c.fn(t, s)
+		})
+	}
+}
+
+func testOrbitEnrollAndConfigWithRequiredSignature(t *testing.T, s *Suite) {
+	// Get certificate using shared function from hostidentity_test.go
+	cert, eccPrivateKey := testGetCertWithCurve(t, s, elliptic.P384())
+
+	// Test enrollment first WITHOUT signature (should fail)
+	enrollRequest := contract.EnrollOrbitRequest{
+		EnrollSecret:      testEnrollmentSecret,
+		HardwareUUID:      "test-uuid-" + cert.Subject.CommonName,
+		HardwareSerial:    "test-serial-" + cert.Subject.CommonName,
+		Hostname:          "test-hostname-" + cert.Subject.CommonName,
+		OsqueryIdentifier: cert.Subject.CommonName,
+	}
+
+	// Test without signature first (should fail)
+	s.Do(t, "POST", "/api/fleet/orbit/enroll", enrollRequest, http.StatusUnauthorized)
+
+	// Now test with signature (should succeed)
+	reqBody, err := json.Marshal(enrollRequest)
+	require.NoError(t, err)
+
+	req, err := http.NewRequest("POST", s.Server.URL+"/api/fleet/orbit/enroll", bytes.NewReader(reqBody))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+
+	// Create signer using the shared helper from hostidentity_test.go
+	signer := createHTTPSigner(t, eccPrivateKey, cert)
+
+	// Sign the request
+	err = signer.Sign(req)
+	require.NoError(t, err)
+
+	// Send the signed request
+	client := fleethttp.NewClient()
+	httpResp, err := client.Do(req)
+	require.NoError(t, err)
+	defer httpResp.Body.Close()
+
+	// The request with a valid HTTP signature should succeed
+	require.Equal(t, http.StatusOK, httpResp.StatusCode, "Orbit enrollment with HTTP signature should succeed")
+
+	// Parse the response
+	var enrollResp enrollOrbitResponse
+	err = json.NewDecoder(httpResp.Body).Decode(&enrollResp)
+	require.NoError(t, err)
+	require.NotEmpty(t, enrollResp.OrbitNodeKey, "Should receive orbit node key")
+	require.NoError(t, enrollResp.Err)
+
+	// Test config endpoint without signature (should fail)
+	configReq := orbitConfigRequest{OrbitNodeKey: enrollResp.OrbitNodeKey}
+	s.Do(t, "POST", "/api/fleet/orbit/config", configReq, http.StatusUnauthorized)
+
+	// Test config endpoint with signature (should succeed)
+	reqBody, err = json.Marshal(configReq)
+	require.NoError(t, err)
+
+	req, err = http.NewRequest("POST", s.Server.URL+"/api/fleet/orbit/config", bytes.NewReader(reqBody))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+
+	err = signer.Sign(req)
+	require.NoError(t, err)
+
+	httpResp, err = client.Do(req)
+	require.NoError(t, err)
+	defer httpResp.Body.Close()
+
+	require.Equal(t, http.StatusOK, httpResp.StatusCode, "Config request with HTTP signature should succeed")
+}
+
+func testOsqueryEnrollFailsWithoutSignature(t *testing.T, s *Suite) {
+	// Test osquery enrollment without signature (should fail)
+	enrollRequest := contract.EnrollOsqueryAgentRequest{
+		EnrollSecret:   testEnrollmentSecret,
+		HostIdentifier: "osquery-enroll-without-signature-test",
+		HostDetails: map[string]map[string]string{
+			"osquery_info": {
+				"version": "5.0.0",
+			},
+		},
+	}
+
+	// Send request without HTTP signature (should fail)
+	// Use Do instead of DoJSON since the server returns HTML error pages
+	s.Do(t, "POST", "/api/v1/osquery/enroll", enrollRequest, http.StatusUnauthorized)
+
+	// Also test the alternative osquery enroll endpoint
+	s.Do(t, "POST", "/api/osquery/enroll", enrollRequest, http.StatusUnauthorized)
+}
+
+func testOrbitEnrollFailsWithoutSignature(t *testing.T, s *Suite) {
+	identifier := "orbit-enroll-without-signature-test"
+	// Test orbit enrollment without signature (should fail)
+	enrollRequest := contract.EnrollOrbitRequest{
+		EnrollSecret:      testEnrollmentSecret,
+		HardwareUUID:      "test-uuid-" + identifier,
+		HardwareSerial:    "test-serial-" + identifier,
+		Hostname:          "test-hostname-" + identifier,
+		OsqueryIdentifier: identifier,
+	}
+
+	// Send request without HTTP signature (should fail)
+	// Use Do instead of DoJSON since the server returns HTML error pages
+	s.Do(t, "POST", "/api/fleet/orbit/enroll", enrollRequest, http.StatusUnauthorized)
+}

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -137,11 +137,12 @@ func (s *ServerConfig) DefaultHTTPServer(ctx context.Context, handler http.Handl
 	return server
 }
 
-// AuthConfig defines configs related to user authorization
+// AuthConfig defines configs related to user or host authorization
 type AuthConfig struct {
-	BcryptCost               int           `yaml:"bcrypt_cost"`
-	SaltKeySize              int           `yaml:"salt_key_size"`
-	SsoSessionValidityPeriod time.Duration `yaml:"sso_session_validity_period"`
+	BcryptCost                  int           `yaml:"bcrypt_cost"`
+	SaltKeySize                 int           `yaml:"salt_key_size"`
+	SsoSessionValidityPeriod    time.Duration `yaml:"sso_session_validity_period"`
+	RequireHTTPMessageSignature bool          `yaml:"require_http_message_signature"`
 }
 
 // AppConfig defines configs related to HTTP
@@ -1112,6 +1113,8 @@ func (man Manager) addConfigs() {
 		"Size of salt for passwords")
 	man.addConfigDuration("auth.sso_session_validity_period", 5*time.Minute,
 		"Timeout from SSO start to SSO callback")
+	man.addConfigBool("auth.require_http_message_signature", false,
+		"Require HTTP message signatures for fleetd requests (Premium feature)")
 
 	// App
 	man.addConfigString("app.token_key", "CHANGEME",
@@ -1531,9 +1534,10 @@ func (man Manager) LoadConfig() FleetConfig {
 			VPPVerifyRequestDelay:       man.getConfigDuration("server.vpp_verify_request_delay"),
 		},
 		Auth: AuthConfig{
-			BcryptCost:               man.getConfigInt("auth.bcrypt_cost"),
-			SaltKeySize:              man.getConfigInt("auth.salt_key_size"),
-			SsoSessionValidityPeriod: man.getConfigDuration("auth.sso_session_validity_period"),
+			BcryptCost:                  man.getConfigInt("auth.bcrypt_cost"),
+			SaltKeySize:                 man.getConfigInt("auth.salt_key_size"),
+			SsoSessionValidityPeriod:    man.getConfigDuration("auth.sso_session_validity_period"),
+			RequireHTTPMessageSignature: man.getConfigBool("auth.require_http_message_signature"),
 		},
 		App: AppConfig{
 			TokenKeySize:              man.getConfigInt("app.token_key_size"),
@@ -2050,9 +2054,10 @@ func TestConfig() FleetConfig {
 			InviteTokenValidityPeriod: 5 * 24 * time.Hour,
 		},
 		Auth: AuthConfig{
-			BcryptCost:               6, // Low cost keeps tests fast
-			SaltKeySize:              24,
-			SsoSessionValidityPeriod: 5 * time.Minute,
+			BcryptCost:                  6, // Low cost keeps tests fast
+			SaltKeySize:                 24,
+			SsoSessionValidityPeriod:    5 * time.Minute,
+			RequireHTTPMessageSignature: false,
 		},
 		Session: SessionConfig{
 			KeySize:  64,

--- a/server/service/testing_utils.go
+++ b/server/service/testing_utils.go
@@ -331,6 +331,12 @@ func (svc *mockMailService) CanSendEmail(smtpSettings fleet.SMTPSettings) bool {
 
 type TestNewScheduleFunc func(ctx context.Context, ds fleet.Datastore) fleet.NewCronScheduleFunc
 
+// HostIdentity combines host identity-related test options
+type HostIdentity struct {
+	SCEPStorage                 scep_depot.Depot
+	RequireHTTPMessageSignature bool
+}
+
 type TestServerOpts struct {
 	Logger                          kitlog.Logger
 	License                         *fleet.LicenseInfo
@@ -365,7 +371,7 @@ type TestServerOpts struct {
 	DigiCertService                 fleet.DigiCertService
 	EnableSCIM                      bool
 	ConditionalAccessMicrosoftProxy ConditionalAccessMicrosoftProxy
-	HostIdentitySCEPStorage         scep_depot.Depot
+	HostIdentity                    *HostIdentity
 }
 
 func RunServerForTestsWithDS(t *testing.T, ds fleet.Datastore, opts ...*TestServerOpts) (map[string]fleet.User, *httptest.Server) {
@@ -460,10 +466,10 @@ func RunServerForTestsWithServiceWithDS(t *testing.T, ctx context.Context, ds fl
 	var extra []ExtraHandlerOption
 	extra = append(extra, WithLoginRateLimit(throttled.PerMin(1000)))
 
-	if len(opts) > 0 && opts[0].HostIdentitySCEPStorage != nil {
-		require.NoError(t, hostidentity.RegisterSCEP(rootMux, opts[0].HostIdentitySCEPStorage, ds, logger))
+	if len(opts) > 0 && opts[0].HostIdentity != nil {
+		require.NoError(t, hostidentity.RegisterSCEP(rootMux, opts[0].HostIdentity.SCEPStorage, ds, logger))
 		var httpSigVerifier func(http.Handler) http.Handler
-		httpSigVerifier, err := httpsig.Middleware(ds, kitlog.With(logger, "component", "http-sig-verifier"))
+		httpSigVerifier, err := httpsig.Middleware(ds, opts[0].HostIdentity.RequireHTTPMessageSignature, kitlog.With(logger, "component", "http-sig-verifier"))
 		require.NoError(t, err)
 		extra = append(extra, WithHTTPSigVerifier(httpSigVerifier))
 	}


### PR DESCRIPTION
For #30947 

# Checklist for submitter

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [x] Added/updated automated tests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for requiring HTTP message signatures for fleetd requests, configurable via a new setting.
  * Enhanced middleware to enforce HTTP message signature requirements when enabled.

* **Tests**
  * Introduced integration tests to verify host identity endpoints enforce HTTP message signature requirements.
  * Updated test utilities and suite setup to support configurable signature enforcement.

* **Chores**
  * Refactored configuration and test server options to support the new signature enforcement feature.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->