### PR TITLE
Fleet UI copy change: "Fleet app URL" => URL

### DIFF
--- a/frontend/pages/admin/OrgSettingsPage/cards/WebAddress/WebAddress.tsx
+++ b/frontend/pages/admin/OrgSettingsPage/cards/WebAddress/WebAddress.tsx
@@ -99,7 +99,7 @@ const WebAddress = ({
         <SectionHeader title="Fleet web address" />
         <form onSubmit={onFormSubmit} autoComplete="off">
           <InputField
-            label="Fleet app URL"
+            label="URL"
             helpText={
               <>
                 Include base path only (eg. no <code>/latest</code>)


### PR DESCRIPTION
UPDATE: @noahtalerman: Filed a bug so this change goes through QA: https://github.com/fleetdm/fleet/issues/31046

---

- @noahtalerman: UI already shows "Fleet web address" as the section header. Why call it a different name, "Fleet app URL", in the field header? I think we simplify this to URL:

<img width="1261" height="490" alt="Screenshot 2025-07-17 at 11 22 18 AM" src="https://github.com/user-attachments/assets/d50c426a-922a-4002-9990-fd0de931eda5" />