### PR TITLE
Reference docs: what happens when you change the Fleet web address

### DIFF
--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -1354,7 +1354,7 @@ Modifies the Fleet's configuration with the supplied information.
 | ai_features_disabled              | boolean | Whether AI features are disabled.                                                           |
 | query_report_cap                  | integer | The maximum number of results to store per query report before the report is clipped. If increasing this cap, we recommend enabling reports for one query at time and monitoring your infrastructure. (Default: `1000`) |
 
-> Note: If `server_url` changes hosts already are already enrolled will no longer communicate with Fleet. They need to be re-enrolled. Also, if you're using Android MDM, you have to turn Android MDM on and back off to point Google to the new `server_url`.
+> Note: If `server_url` changes hosts already are already enrolled will no longer communicate with Fleet. They need to be re-enrolled. Also, if you're using Android MDM, you have to turn Android MDM off and back on to point Google to the new `server_url`.
 
 <br/>
 

--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -1354,6 +1354,8 @@ Modifies the Fleet's configuration with the supplied information.
 | ai_features_disabled              | boolean | Whether AI features are disabled.                                                           |
 | query_report_cap                  | integer | The maximum number of results to store per query report before the report is clipped. If increasing this cap, we recommend enabling reports for one query at time and monitoring your infrastructure. (Default: `1000`) |
 
+> Note: If `server_url` changes hosts already are already enrolled will no longer communicate with Fleet. They need to be re-enrolled.
+
 <br/>
 
 ##### Example request body

--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -1354,7 +1354,7 @@ Modifies the Fleet's configuration with the supplied information.
 | ai_features_disabled              | boolean | Whether AI features are disabled.                                                           |
 | query_report_cap                  | integer | The maximum number of results to store per query report before the report is clipped. If increasing this cap, we recommend enabling reports for one query at time and monitoring your infrastructure. (Default: `1000`) |
 
-> Note: If `server_url` changes hosts already are already enrolled will no longer communicate with Fleet. They need to be re-enrolled. If you're using Android MDM, before you re-enroll Android hosts, you have to turn Android MDM off and back on to point Google to the new `server_url`.
+> Note: If `server_url` changes, hosts that enrolled to the old URL will need to re-enroll, or they will no longer communicate with Fleet. Before re-enrolling Android hosts, you'll need to turn Android MDM off and back on to point Google to the new `server_url`.
 
 <br/>
 

--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -1354,7 +1354,7 @@ Modifies the Fleet's configuration with the supplied information.
 | ai_features_disabled              | boolean | Whether AI features are disabled.                                                           |
 | query_report_cap                  | integer | The maximum number of results to store per query report before the report is clipped. If increasing this cap, we recommend enabling reports for one query at time and monitoring your infrastructure. (Default: `1000`) |
 
-> Note: If `server_url` changes hosts already are already enrolled will no longer communicate with Fleet. They need to be re-enrolled. Also, if you're using Android MDM, you have to turn Android MDM off and back on to point Google to the new `server_url`.
+> Note: If `server_url` changes hosts already are already enrolled will no longer communicate with Fleet. They need to be re-enrolled. If you're using Android MDM, before you re-enroll Android hosts, you have to turn Android MDM off and back on to point Google to the new `server_url`.
 
 <br/>
 

--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -1354,7 +1354,7 @@ Modifies the Fleet's configuration with the supplied information.
 | ai_features_disabled              | boolean | Whether AI features are disabled.                                                           |
 | query_report_cap                  | integer | The maximum number of results to store per query report before the report is clipped. If increasing this cap, we recommend enabling reports for one query at time and monitoring your infrastructure. (Default: `1000`) |
 
-> Note: If `server_url` changes hosts already are already enrolled will no longer communicate with Fleet. They need to be re-enrolled.
+> Note: If `server_url` changes hosts already are already enrolled will no longer communicate with Fleet. They need to be re-enrolled. Also, if you're using Android MDM, you have to turn Android MDM on and back off to point Google to the new `server_url`.
 
 <br/>
 


### PR DESCRIPTION
- @noahtalerman: I think changing the Fleet web address means you'll have to re-enroll all your hosts.
  - We have a [feature request](https://github.com/fleetdm/fleet/issues/29878) to add this copy to the UI but I think we want to get this in the docs ASAP
