### PR TITLE
Prevent double banner on host details page

### DIFF
--- a/changes/29451-fix-doubled-banners
+++ b/changes/29451-fix-doubled-banners
@@ -1,0 +1,1 @@
+- Fixed an issue where two banners would sometimes be displayed on the host details page

--- a/frontend/components/MainContent/MainContent.tsx
+++ b/frontend/components/MainContent/MainContent.tsx
@@ -12,12 +12,17 @@ import AndroidEnterpriseDeletedMessage from "components/MDM/AndroidEnterpriseDel
 
 import VppRenewalMessage from "./banners/VppRenewalMessage";
 
+export interface IMainContentConfig {
+  renderedBanner: boolean;
+}
+
 interface IMainContentProps {
-  children: ReactNode;
+  children?: ReactNode;
   /** An optional classname to pass to the main content component.
    * This can be used to apply styles directly onto the main content div
    */
   className?: string;
+  renderChildren?: (mainContentConfig: IMainContentConfig) => ReactNode;
 }
 
 const baseClass = "main-content";
@@ -29,6 +34,7 @@ const baseClass = "main-content";
 const MainContent = ({
   children,
   className,
+  renderChildren,
 }: IMainContentProps): JSX.Element => {
   const classes = classnames(baseClass, className);
   const {
@@ -80,10 +86,16 @@ const MainContent = ({
 
     return null;
   };
+
+  const appWideBanner = renderAppWideBanner();
+  const mainContentConfig: IMainContentConfig = {
+    renderedBanner: !!appWideBanner,
+  };
+
   return (
     <div className={classes}>
-      {renderAppWideBanner()}
-      {children}
+      {appWideBanner}
+      {renderChildren ? renderChildren(mainContentConfig) : children}
     </div>
   );
 };

--- a/frontend/components/MainContent/MainContent.tsx
+++ b/frontend/components/MainContent/MainContent.tsx
@@ -17,12 +17,11 @@ export interface IMainContentConfig {
 }
 
 interface IMainContentProps {
-  children?: ReactNode;
+  children: ReactNode | ((mainContentConfig: IMainContentConfig) => ReactNode);
   /** An optional classname to pass to the main content component.
    * This can be used to apply styles directly onto the main content div
    */
   className?: string;
-  renderChildren?: (mainContentConfig: IMainContentConfig) => ReactNode;
 }
 
 const baseClass = "main-content";
@@ -34,7 +33,6 @@ const baseClass = "main-content";
 const MainContent = ({
   children,
   className,
-  renderChildren,
 }: IMainContentProps): JSX.Element => {
   const classes = classnames(baseClass, className);
   const {
@@ -95,7 +93,7 @@ const MainContent = ({
   return (
     <div className={classes}>
       {appWideBanner}
-      {renderChildren ? renderChildren(mainContentConfig) : children}
+      {typeof children === "function" ? children(mainContentConfig) : children}
     </div>
   );
 };

--- a/frontend/components/MainContent/index.ts
+++ b/frontend/components/MainContent/index.ts
@@ -1,1 +1,2 @@
 export { default } from "./MainContent";
+export type { IMainContentConfig } from "./MainContent";

--- a/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
@@ -1406,7 +1406,7 @@ const HostDetailsPage = ({
     );
   };
 
-  return <MainContent className={baseClass} renderChildren={renderContent} />;
+  return <MainContent className={baseClass}>{renderContent}</MainContent>;
 };
 
 export default HostDetailsPage;

--- a/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
@@ -54,7 +54,7 @@ import { isAndroid, isIPadOrIPhone, isLinuxLike } from "interfaces/platform";
 import Spinner from "components/Spinner";
 import TabNav from "components/TabNav";
 import TabText from "components/TabText";
-import MainContent from "components/MainContent";
+import MainContent, { IMainContentConfig } from "components/MainContent";
 import BackLink from "components/BackLink";
 import Card from "components/Card";
 import RunScriptDetailsModal from "pages/DashboardPage/cards/ActivityFeed/components/RunScriptDetailsModal";
@@ -1042,357 +1042,371 @@ const HostDetailsPage = ({
     );
   };
 
-  return (
-    <MainContent className={baseClass}>
+  const renderContent = (mainContentConfig: IMainContentConfig) => {
+    return (
       <>
-        <HostDetailsBanners
-          mdmEnrollmentStatus={host?.mdm.enrollment_status}
-          hostPlatform={host?.platform}
-          macDiskEncryptionStatus={host?.mdm.macos_settings?.disk_encryption}
-          connectedToFleetMdm={host?.mdm.connected_to_fleet}
-          diskEncryptionOSSetting={host?.mdm.os_settings?.disk_encryption}
-          diskIsEncrypted={host?.disk_encryption_enabled}
-          diskEncryptionKeyAvailable={host?.mdm.encryption_key_available}
-        />
-        <div className={`${baseClass}__header-links`}>
-          <BackLink
-            text="Back to all hosts"
-            path={filteredHostsPath || PATHS.MANAGE_HOSTS}
-          />
-        </div>
-        <div className={`${baseClass}__header-summary`}>
-          <HostHeader
-            summaryData={summaryData}
-            showRefetchSpinner={showRefetchSpinner}
-            onRefetchHost={onRefetchHost}
-            renderActionDropdown={renderActionDropdown}
-            hostMdmDeviceStatus={hostMdmDeviceStatus}
-          />
-        </div>
-        <TabNav className={`${baseClass}__tab-nav`}>
-          <Tabs
-            selectedIndex={getTabIndex(location.pathname)}
-            onSelect={(i) => navigateToNav(i)}
-          >
-            <TabList>
-              {hostDetailsSubNav.map((navItem) => {
-                // Bolding text when the tab is active causes a layout shift
-                // so we add a hidden pseudo element with the same text string
-                return (
-                  <Tab key={navItem.title}>
-                    <TabText count={navItem.count} isErrorCount>
-                      {navItem.name}
-                    </TabText>
-                  </Tab>
-                );
-              })}
-            </TabList>
-            <TabPanel className={`${baseClass}__details-panel`}>
-              <HostSummaryCard
-                summaryData={summaryData}
-                bootstrapPackageData={bootstrapPackageData}
-                isPremiumTier={isPremiumTier}
-                toggleOSSettingsModal={toggleOSSettingsModal}
-                toggleBootstrapPackageModal={toggleBootstrapPackageModal}
-                hostSettings={host?.mdm.profiles ?? []}
-                osSettings={host?.mdm.os_settings}
-                osVersionRequirement={getOSVersionRequirementFromMDMConfig(
-                  host.platform
-                )}
-                className={fullWidthCardClass}
-              />
-              <AboutCard
-                className={
-                  showUsersCard ? defaultCardClass : fullWidthCardClass
-                }
-                aboutData={aboutData}
-                munki={macadmins?.munki}
-                mdm={mdm}
-              />
-              {showUsersCard && (
-                <UserCard
-                  className={defaultCardClass}
-                  platform={host.platform}
-                  endUsers={host.end_users ?? []}
-                  enableAddEndUser={
-                    isDarwinHost &&
-                    generateUsernameValues(host.end_users ?? []).length === 0
-                  }
-                  onAddEndUser={() => setShowAddEndUserModal(true)}
-                />
-              )}
-              {showActivityCard && (
-                <ActivityCard
-                  className={
-                    showAgentOptionsCard
-                      ? doubleHeightCardClass
-                      : defaultCardClass
-                  }
-                  activeTab={activeActivityTab}
-                  activities={
-                    activeActivityTab === "past"
-                      ? pastActivities
-                      : upcomingActivities
-                  }
-                  isLoading={
-                    activeActivityTab === "past"
-                      ? pastActivitiesIsFetching
-                      : upcomingActivitiesIsFetching
-                  }
-                  isError={
-                    activeActivityTab === "past"
-                      ? pastActivitiesIsError
-                      : upcomingActivitiesIsError
-                  }
-                  canCancelActivities={
-                    isGlobalAdmin ||
-                    isGlobalMaintainer ||
-                    isHostTeamAdmin ||
-                    isHostTeamMaintainer
-                  }
-                  upcomingCount={upcomingActivities?.count || 0}
-                  onChangeTab={onChangeActivityTab}
-                  onNextPage={() => setActivityPage(activityPage + 1)}
-                  onPreviousPage={() => setActivityPage(activityPage - 1)}
-                  onShowDetails={onShowActivityDetails}
-                  onCancel={onCancelActivity}
-                />
-              )}
-              {showAgentOptionsCard && (
-                <AgentOptionsCard
-                  className={defaultCardClass}
-                  osqueryData={osqueryData}
-                  wrapFleetHelper={wrapFleetHelper}
-                  isChromeOS={host?.platform === "chrome"}
-                />
-              )}
-              <LabelsCard
-                className={
-                  !showActivityCard && !showAgentOptionsCard
-                    ? fullWidthCardClass
-                    : defaultCardClass
-                }
-                labels={host?.labels || []}
-                onLabelClick={onLabelClick}
-              />
-              {showLocalUserAccountsCard && (
-                <LocalUserAccountsCard
-                  className={fullWidthCardClass}
-                  users={host?.users || []}
-                  usersState={usersState}
-                  isLoading={isLoadingHost}
-                  onUsersTableSearchChange={onUsersTableSearchChange}
-                  hostUsersEnabled={featuresConfig?.enable_host_users}
-                />
-              )}
-              {showCertificatesCard && (
-                <CertificatesCard
-                  className={fullWidthCardClass}
-                  data={hostCertificates}
-                  hostPlatform={host.platform}
-                  onSelectCertificate={onSelectCertificate}
-                  isError={isErrorHostCertificates}
-                  page={certificatePage}
-                  pageSize={DEFAULT_CERTIFICATES_PAGE_SIZE}
-                  onNextPage={() => setCertificatePage(certificatePage + 1)}
-                  onPreviousPage={() => setCertificatePage(certificatePage - 1)}
-                  sortDirection={sortCerts.order_direction}
-                  sortHeader={sortCerts.order_key}
-                  onSortChange={setSortCerts}
-                />
-              )}
-            </TabPanel>
-            <TabPanel>
-              <TabNav className={`${baseClass}__software-tab-nav`}>
-                <Tabs
-                  selectedIndex={getSoftwareTabIndex(location.pathname)}
-                  onSelect={(i) => navigateToSoftwareTab(i)}
-                >
-                  {renderSoftwareCard()}
-                </Tabs>
-              </TabNav>
-            </TabPanel>
-            <TabPanel>
-              <QueriesCard
-                hostId={host.id}
-                router={router}
-                hostPlatform={host.platform}
-                schedule={schedule}
-                queryReportsDisabled={
-                  config?.server_settings?.query_reports_disabled
-                }
-              />
-              {canViewPacks && (
-                <PacksCard packsState={packsState} isLoading={isLoadingHost} />
-              )}
-            </TabPanel>
-            <TabPanel>
-              <PoliciesCard
-                policies={host?.policies || []}
-                isLoading={isLoadingHost}
-                togglePolicyDetailsModal={togglePolicyDetailsModal}
-                hostPlatform={host.platform}
-                router={router}
-                currentTeamId={currentTeam?.id}
-              />
-            </TabPanel>
-          </Tabs>
-        </TabNav>
-        {showDeleteHostModal && (
-          <DeleteHostModal
-            onCancel={() => setShowDeleteHostModal(false)}
-            onSubmit={onDestroyHost}
-            hostName={host?.display_name}
-            isUpdating={isUpdatingHost}
-          />
-        )}
-        {showSelectQueryModal && host && (
-          <SelectQueryModal
-            onCancel={() => setShowSelectQueryModal(false)}
-            isOnlyObserver={isOnlyObserver}
-            hostId={hostIdFromURL}
-            hostTeamId={host?.team_id}
-            router={router}
-            currentTeamId={currentTeam?.id}
-          />
-        )}
-        {showScriptModalGroup && (
-          <ScriptModalGroup
-            host={host}
-            currentUser={currentUser}
-            onCloseScriptModalGroup={onCloseScriptModalGroup}
-            teamIdForApi={currentTeam?.id}
-          />
-        )}
-        {!!host && showTransferHostModal && (
-          <TransferHostModal
-            onCancel={() => setShowTransferHostModal(false)}
-            onSubmit={onTransferHostSubmit}
-            teams={teams || []}
-            isGlobalAdmin={isGlobalAdmin as boolean}
-            isUpdating={isUpdatingHost}
-          />
-        )}
-        {!!host && showPolicyDetailsModal && (
-          <PolicyDetailsModal
-            onCancel={onCancelPolicyDetailsModal}
-            policy={selectedPolicy}
-          />
-        )}
-        {showOSSettingsModal && (
-          <OSSettingsModal
-            canResendProfiles={host.platform === "darwin"}
-            hostId={host.id}
-            platform={host.platform}
-            hostMDMData={host.mdm}
-            onClose={toggleOSSettingsModal}
-            onProfileResent={refetchHostDetails}
-          />
-        )}
-        {showUnenrollMdmModal && !!host && (
-          <UnenrollMdmModal
-            hostId={host.id}
-            hostPlatform={host.platform}
-            hostName={host.display_name}
-            onClose={toggleUnenrollMdmModal}
-          />
-        )}
-        {showDiskEncryptionModal && host && (
-          <DiskEncryptionKeyModal
-            platform={host.platform}
-            hostId={host.id}
-            onCancel={() => setShowDiskEncryptionModal(false)}
-          />
-        )}
-        {showBootstrapPackageModal &&
-          bootstrapPackageData.details &&
-          bootstrapPackageData.name && (
-            <BootstrapPackageModal
-              packageName={bootstrapPackageData.name}
-              details={bootstrapPackageData.details}
-              onClose={() => setShowBootstrapPackageModal(false)}
+        <>
+          {mainContentConfig.renderedBanner && (
+            <HostDetailsBanners
+              mdmEnrollmentStatus={host?.mdm.enrollment_status}
+              hostPlatform={host?.platform}
+              macDiskEncryptionStatus={
+                host?.mdm.macos_settings?.disk_encryption
+              }
+              connectedToFleetMdm={host?.mdm.connected_to_fleet}
+              diskEncryptionOSSetting={host?.mdm.os_settings?.disk_encryption}
+              diskIsEncrypted={host?.disk_encryption_enabled}
+              diskEncryptionKeyAvailable={host?.mdm.encryption_key_available}
             />
           )}
-        {scriptExecutionId && (
-          <RunScriptDetailsModal
-            scriptExecutionId={scriptExecutionId}
-            onCancel={onCancelRunScriptDetailsModal}
-          />
-        )}
-        {!!packageInstallDetails && (
-          <SoftwareInstallDetailsModal
-            details={packageInstallDetails}
-            onCancel={onCancelSoftwareInstallDetailsModal}
-          />
-        )}
-        {packageUninstallDetails && (
-          <SoftwareUninstallDetailsModal
-            details={packageUninstallDetails}
-            onCancel={() => setPackageUninstallDetails(null)}
-          />
-        )}
-        {!!appInstallDetails && (
-          <AppInstallDetailsModal
-            details={appInstallDetails}
-            onCancel={onCancelAppInstallDetailsModal}
-          />
-        )}
-        {showLockHostModal && (
-          <LockModal
-            id={host.id}
-            platform={host.platform}
-            hostName={host.display_name}
-            onSuccess={() => setHostMdmDeviceState("locking")}
-            onClose={() => setShowLockHostModal(false)}
-          />
-        )}
-        {showUnlockHostModal && (
-          <UnlockModal
-            id={host.id}
-            platform={host.platform}
-            hostName={host.display_name}
-            onSuccess={() => {
-              host.platform !== "darwin" && setHostMdmDeviceState("unlocking");
-            }}
-            onClose={() => setShowUnlockHostModal(false)}
-          />
-        )}
-        {showWipeModal && (
-          <WipeModal
-            id={host.id}
-            hostName={host.display_name}
-            onSuccess={() => setHostMdmDeviceState("wiping")}
-            onClose={() => setShowWipeModal(false)}
-          />
-        )}
-        {selectedSoftwareDetails && (
-          <SoftwareDetailsModal
-            hostDisplayName={host.display_name}
-            software={selectedSoftwareDetails}
-            onExit={() => setSelectedSoftwareDetails(null)}
-          />
-        )}
-        {selectedCancelActivity && (
-          <CancelActivityModal
-            hostId={host.id}
-            activity={selectedCancelActivity}
-            onCancelActivity={() => refetchUpcomingActivities()}
-            onSuccessCancel={onSuccessCancelActivity}
-            onExit={() => setSelectedCancelActivity(null)}
-          />
-        )}
-        {selectedCertificate && (
-          <CertificateDetailsModal
-            certificate={selectedCertificate}
-            onExit={() => setSelectedCertificate(null)}
-          />
+          <div className={`${baseClass}__header-links`}>
+            <BackLink
+              text="Back to all hosts"
+              path={filteredHostsPath || PATHS.MANAGE_HOSTS}
+            />
+          </div>
+          <div className={`${baseClass}__header-summary`}>
+            <HostHeader
+              summaryData={summaryData}
+              showRefetchSpinner={showRefetchSpinner}
+              onRefetchHost={onRefetchHost}
+              renderActionDropdown={renderActionDropdown}
+              hostMdmDeviceStatus={hostMdmDeviceStatus}
+            />
+          </div>
+          <TabNav className={`${baseClass}__tab-nav`}>
+            <Tabs
+              selectedIndex={getTabIndex(location.pathname)}
+              onSelect={(i) => navigateToNav(i)}
+            >
+              <TabList>
+                {hostDetailsSubNav.map((navItem) => {
+                  // Bolding text when the tab is active causes a layout shift
+                  // so we add a hidden pseudo element with the same text string
+                  return (
+                    <Tab key={navItem.title}>
+                      <TabText count={navItem.count} isErrorCount>
+                        {navItem.name}
+                      </TabText>
+                    </Tab>
+                  );
+                })}
+              </TabList>
+              <TabPanel className={`${baseClass}__details-panel`}>
+                <HostSummaryCard
+                  summaryData={summaryData}
+                  bootstrapPackageData={bootstrapPackageData}
+                  isPremiumTier={isPremiumTier}
+                  toggleOSSettingsModal={toggleOSSettingsModal}
+                  toggleBootstrapPackageModal={toggleBootstrapPackageModal}
+                  hostSettings={host?.mdm.profiles ?? []}
+                  osSettings={host?.mdm.os_settings}
+                  osVersionRequirement={getOSVersionRequirementFromMDMConfig(
+                    host.platform
+                  )}
+                  className={fullWidthCardClass}
+                />
+                <AboutCard
+                  className={
+                    showUsersCard ? defaultCardClass : fullWidthCardClass
+                  }
+                  aboutData={aboutData}
+                  munki={macadmins?.munki}
+                  mdm={mdm}
+                />
+                {showUsersCard && (
+                  <UserCard
+                    className={defaultCardClass}
+                    platform={host.platform}
+                    endUsers={host.end_users ?? []}
+                    enableAddEndUser={
+                      isDarwinHost &&
+                      generateUsernameValues(host.end_users ?? []).length === 0
+                    }
+                    onAddEndUser={() => setShowAddEndUserModal(true)}
+                  />
+                )}
+                {showActivityCard && (
+                  <ActivityCard
+                    className={
+                      showAgentOptionsCard
+                        ? doubleHeightCardClass
+                        : defaultCardClass
+                    }
+                    activeTab={activeActivityTab}
+                    activities={
+                      activeActivityTab === "past"
+                        ? pastActivities
+                        : upcomingActivities
+                    }
+                    isLoading={
+                      activeActivityTab === "past"
+                        ? pastActivitiesIsFetching
+                        : upcomingActivitiesIsFetching
+                    }
+                    isError={
+                      activeActivityTab === "past"
+                        ? pastActivitiesIsError
+                        : upcomingActivitiesIsError
+                    }
+                    canCancelActivities={
+                      isGlobalAdmin ||
+                      isGlobalMaintainer ||
+                      isHostTeamAdmin ||
+                      isHostTeamMaintainer
+                    }
+                    upcomingCount={upcomingActivities?.count || 0}
+                    onChangeTab={onChangeActivityTab}
+                    onNextPage={() => setActivityPage(activityPage + 1)}
+                    onPreviousPage={() => setActivityPage(activityPage - 1)}
+                    onShowDetails={onShowActivityDetails}
+                    onCancel={onCancelActivity}
+                  />
+                )}
+                {showAgentOptionsCard && (
+                  <AgentOptionsCard
+                    className={defaultCardClass}
+                    osqueryData={osqueryData}
+                    wrapFleetHelper={wrapFleetHelper}
+                    isChromeOS={host?.platform === "chrome"}
+                  />
+                )}
+                <LabelsCard
+                  className={
+                    !showActivityCard && !showAgentOptionsCard
+                      ? fullWidthCardClass
+                      : defaultCardClass
+                  }
+                  labels={host?.labels || []}
+                  onLabelClick={onLabelClick}
+                />
+                {showLocalUserAccountsCard && (
+                  <LocalUserAccountsCard
+                    className={fullWidthCardClass}
+                    users={host?.users || []}
+                    usersState={usersState}
+                    isLoading={isLoadingHost}
+                    onUsersTableSearchChange={onUsersTableSearchChange}
+                    hostUsersEnabled={featuresConfig?.enable_host_users}
+                  />
+                )}
+                {showCertificatesCard && (
+                  <CertificatesCard
+                    className={fullWidthCardClass}
+                    data={hostCertificates}
+                    hostPlatform={host.platform}
+                    onSelectCertificate={onSelectCertificate}
+                    isError={isErrorHostCertificates}
+                    page={certificatePage}
+                    pageSize={DEFAULT_CERTIFICATES_PAGE_SIZE}
+                    onNextPage={() => setCertificatePage(certificatePage + 1)}
+                    onPreviousPage={() =>
+                      setCertificatePage(certificatePage - 1)
+                    }
+                    sortDirection={sortCerts.order_direction}
+                    sortHeader={sortCerts.order_key}
+                    onSortChange={setSortCerts}
+                  />
+                )}
+              </TabPanel>
+              <TabPanel>
+                <TabNav className={`${baseClass}__software-tab-nav`}>
+                  <Tabs
+                    selectedIndex={getSoftwareTabIndex(location.pathname)}
+                    onSelect={(i) => navigateToSoftwareTab(i)}
+                  >
+                    {renderSoftwareCard()}
+                  </Tabs>
+                </TabNav>
+              </TabPanel>
+              <TabPanel>
+                <QueriesCard
+                  hostId={host.id}
+                  router={router}
+                  hostPlatform={host.platform}
+                  schedule={schedule}
+                  queryReportsDisabled={
+                    config?.server_settings?.query_reports_disabled
+                  }
+                />
+                {canViewPacks && (
+                  <PacksCard
+                    packsState={packsState}
+                    isLoading={isLoadingHost}
+                  />
+                )}
+              </TabPanel>
+              <TabPanel>
+                <PoliciesCard
+                  policies={host?.policies || []}
+                  isLoading={isLoadingHost}
+                  togglePolicyDetailsModal={togglePolicyDetailsModal}
+                  hostPlatform={host.platform}
+                  router={router}
+                  currentTeamId={currentTeam?.id}
+                />
+              </TabPanel>
+            </Tabs>
+          </TabNav>
+          {showDeleteHostModal && (
+            <DeleteHostModal
+              onCancel={() => setShowDeleteHostModal(false)}
+              onSubmit={onDestroyHost}
+              hostName={host?.display_name}
+              isUpdating={isUpdatingHost}
+            />
+          )}
+          {showSelectQueryModal && host && (
+            <SelectQueryModal
+              onCancel={() => setShowSelectQueryModal(false)}
+              isOnlyObserver={isOnlyObserver}
+              hostId={hostIdFromURL}
+              hostTeamId={host?.team_id}
+              router={router}
+              currentTeamId={currentTeam?.id}
+            />
+          )}
+          {showScriptModalGroup && (
+            <ScriptModalGroup
+              host={host}
+              currentUser={currentUser}
+              onCloseScriptModalGroup={onCloseScriptModalGroup}
+              teamIdForApi={currentTeam?.id}
+            />
+          )}
+          {!!host && showTransferHostModal && (
+            <TransferHostModal
+              onCancel={() => setShowTransferHostModal(false)}
+              onSubmit={onTransferHostSubmit}
+              teams={teams || []}
+              isGlobalAdmin={isGlobalAdmin as boolean}
+              isUpdating={isUpdatingHost}
+            />
+          )}
+          {!!host && showPolicyDetailsModal && (
+            <PolicyDetailsModal
+              onCancel={onCancelPolicyDetailsModal}
+              policy={selectedPolicy}
+            />
+          )}
+          {showOSSettingsModal && (
+            <OSSettingsModal
+              canResendProfiles={host.platform === "darwin"}
+              hostId={host.id}
+              platform={host.platform}
+              hostMDMData={host.mdm}
+              onClose={toggleOSSettingsModal}
+              onProfileResent={refetchHostDetails}
+            />
+          )}
+          {showUnenrollMdmModal && !!host && (
+            <UnenrollMdmModal
+              hostId={host.id}
+              hostPlatform={host.platform}
+              hostName={host.display_name}
+              onClose={toggleUnenrollMdmModal}
+            />
+          )}
+          {showDiskEncryptionModal && host && (
+            <DiskEncryptionKeyModal
+              platform={host.platform}
+              hostId={host.id}
+              onCancel={() => setShowDiskEncryptionModal(false)}
+            />
+          )}
+          {showBootstrapPackageModal &&
+            bootstrapPackageData.details &&
+            bootstrapPackageData.name && (
+              <BootstrapPackageModal
+                packageName={bootstrapPackageData.name}
+                details={bootstrapPackageData.details}
+                onClose={() => setShowBootstrapPackageModal(false)}
+              />
+            )}
+          {scriptExecutionId && (
+            <RunScriptDetailsModal
+              scriptExecutionId={scriptExecutionId}
+              onCancel={onCancelRunScriptDetailsModal}
+            />
+          )}
+          {!!packageInstallDetails && (
+            <SoftwareInstallDetailsModal
+              details={packageInstallDetails}
+              onCancel={onCancelSoftwareInstallDetailsModal}
+            />
+          )}
+          {packageUninstallDetails && (
+            <SoftwareUninstallDetailsModal
+              details={packageUninstallDetails}
+              onCancel={() => setPackageUninstallDetails(null)}
+            />
+          )}
+          {!!appInstallDetails && (
+            <AppInstallDetailsModal
+              details={appInstallDetails}
+              onCancel={onCancelAppInstallDetailsModal}
+            />
+          )}
+          {showLockHostModal && (
+            <LockModal
+              id={host.id}
+              platform={host.platform}
+              hostName={host.display_name}
+              onSuccess={() => setHostMdmDeviceState("locking")}
+              onClose={() => setShowLockHostModal(false)}
+            />
+          )}
+          {showUnlockHostModal && (
+            <UnlockModal
+              id={host.id}
+              platform={host.platform}
+              hostName={host.display_name}
+              onSuccess={() => {
+                host.platform !== "darwin" &&
+                  setHostMdmDeviceState("unlocking");
+              }}
+              onClose={() => setShowUnlockHostModal(false)}
+            />
+          )}
+          {showWipeModal && (
+            <WipeModal
+              id={host.id}
+              hostName={host.display_name}
+              onSuccess={() => setHostMdmDeviceState("wiping")}
+              onClose={() => setShowWipeModal(false)}
+            />
+          )}
+          {selectedSoftwareDetails && (
+            <SoftwareDetailsModal
+              hostDisplayName={host.display_name}
+              software={selectedSoftwareDetails}
+              onExit={() => setSelectedSoftwareDetails(null)}
+            />
+          )}
+          {selectedCancelActivity && (
+            <CancelActivityModal
+              hostId={host.id}
+              activity={selectedCancelActivity}
+              onCancelActivity={() => refetchUpcomingActivities()}
+              onSuccessCancel={onSuccessCancelActivity}
+              onExit={() => setSelectedCancelActivity(null)}
+            />
+          )}
+          {selectedCertificate && (
+            <CertificateDetailsModal
+              certificate={selectedCertificate}
+              onExit={() => setSelectedCertificate(null)}
+            />
+          )}
+        </>
+        {showAddEndUserModal && (
+          <AddEndUserModal onExit={() => setShowAddEndUserModal(false)} />
         )}
       </>
-      {showAddEndUserModal && (
-        <AddEndUserModal onExit={() => setShowAddEndUserModal(false)} />
-      )}
-    </MainContent>
-  );
+    );
+  };
+
+  return <MainContent className={baseClass} renderChildren={renderContent} />;
 };
 
 export default HostDetailsPage;

--- a/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
@@ -1046,7 +1046,7 @@ const HostDetailsPage = ({
     return (
       <>
         <>
-          {mainContentConfig.renderedBanner && (
+          {!mainContentConfig.renderedBanner && (
             <HostDetailsBanners
               mdmEnrollmentStatus={host?.mdm.enrollment_status}
               hostPlatform={host?.platform}

--- a/frontend/pages/hosts/details/HostDetailsPage/components/HostDetailsBanners/HostDetailsBanners.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/components/HostDetailsBanners/HostDetailsBanners.tsx
@@ -1,8 +1,6 @@
 import React, { useContext } from "react";
 import { AppContext } from "context/app";
 
-import { hasLicenseExpired } from "utilities/helpers";
-
 import { DiskEncryptionStatus, MdmEnrollmentStatus } from "interfaces/mdm";
 import { IOSSettings } from "interfaces/host";
 import {
@@ -43,46 +41,16 @@ const HostDetailsBanners = ({
   diskIsEncrypted,
   diskEncryptionKeyAvailable,
 }: IHostBannersBaseProps) => {
-  const {
-    config,
-    isPremiumTier,
-    isAppleBmExpired,
-    isApplePnsExpired,
-    isVppExpired,
-    needsAbmTermsRenewal,
-    willAppleBmExpire,
-    willApplePnsExpire,
-    willVppExpire,
-  } = useContext(AppContext);
-
-  // Checks to see if an app-wide banner is being shown (the ABM terms, ABM expiry,
-  // or APNs expiry banner) in a parent component. App-wide banners found in parent
-  // component take priority over host details page-level banners.
-  const isFleetLicenseExpired = hasLicenseExpired(
-    config?.license.expiration || ""
-  );
-
-  const showingAppWideBanner =
-    isPremiumTier &&
-    (needsAbmTermsRenewal ||
-      isApplePnsExpired ||
-      willApplePnsExpire ||
-      isAppleBmExpired ||
-      willAppleBmExpire ||
-      isVppExpired ||
-      willVppExpire ||
-      isFleetLicenseExpired);
+  const { config } = useContext(AppContext);
 
   const isMdmUnenrolled = mdmEnrollmentStatus === "Off" || !mdmEnrollmentStatus;
 
   const showTurnOnMdmInfoBanner =
-    !showingAppWideBanner &&
     hostPlatform === "darwin" &&
     isMdmUnenrolled &&
     config?.mdm.enabled_and_configured;
 
   const showMacDiskEncryptionUserActionRequired =
-    !showingAppWideBanner &&
     config?.mdm.enabled_and_configured &&
     connectedToFleetMdm &&
     macDiskEncryptionStatus === "action_required";


### PR DESCRIPTION
for #29451 

# Details

This PR does a slight refactor of the MainContent, HostDetailsBanners and HostDetailsPage components to prevent host-details-specific banner from being shown on the Host Details page if any app-wide banners are being displayed.

It does this by allowing the child of a `<MainContent>` node to be a function which takes a parameter indicating whether app-wide banners are present.  The HostDetailsPage uses this new functionality to suppress host details banners when that's the case.  The HostDetailsBanners component is updated to remove logic that previously attempted to detect app-wide banners, using similar logic to what MainContent does to decide whether to show banners.  Instead of repeating this logic in two places, HostDetailsBanners now just renders banners.

# Checklist for submitter

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.
- [X] Manual QA for all new/changed functionality

I tested this by temporarily forcing an app-wide banner (by setting [this code](https://github.com/fleetdm/fleet/blob/52cd0588b678f52c8177210c4a2eed1ae90bc5e7/frontend/components/MainContent/MainContent.tsx#L61) to `if (true)`), then similarly doing the same for host banners by changing [this code](https://github.com/fleetdm/fleet/blob/89cdf9f61a64ae7f3000cad4548adbb3763197c9/frontend/pages/hosts/details/HostDetailsPage/components/HostDetailsBanners/HostDetailsBanners.tsx#L79-L85) to always run. 

On the main branch, this shows two banners:
<img width="1142" height="186" alt="image" src="https://github.com/user-attachments/assets/30645470-d1db-476d-bb76-2b48fedcc75a" />

On this branch, only the app-wide banner is shown.

Note that this was _only_ happening in the case of the disk encryption banner, since there was logic in place in HostDetailsBanners to prevent showing host banners if an app-wide banner was present.  That logic was just missing from the disk encryption case, and we'd have to continue to keep that logic in sync with the login in MainContent any time we added a new host banner.  This refactor DRYs out the code a bit so we don't have that concern going forward.