### PR TITLE
Making a request: Fast track for Fleeties

### DIFF
--- a/handbook/company/product-groups.md
+++ b/handbook/company/product-groups.md
@@ -384,6 +384,8 @@ To make a feature request or advocate for a feature request from a customer or c
 
 New requests are reviewed daily by the Head of Product Design and a former IT admin during the ["Unpacking the why"](https://fleetdm.com/handbook/product-design#unpacking-the-why) call. If the request meets the [criteria for prioritization](#criteria-for-prioritization), the request will be added to the upcoming feature fest (`~feature fest` label). If it doesn't, the request will be put to the side and the requester will be notified.
 
+> **Fast track for Fleeties:** Fleeties do not have to wait for "Unpacking the why" to add a request to feature fest. If you think Fleet is missing something and have described in detail what you already tried, it can be moved directly to the [🎁 Feature fest board](https://github.com/orgs/fleetdm/projects/72). Just add the `~feature fest` label.
+
 
 ### Criteria for prioritization
 


### PR DESCRIPTION
Why? 
- Fleetie feature requests are creating a bottleneck during the [Unpacking the why](https://fleetdm.com/handbook/product-design#unpacking-the-why) stage in the new feature request pipeline. 
- Most, if not all, Fleetie feature requests don't need to be unpacked. They come from dogfooding use cases that don't require a former IT admin to understand.
