### PR TITLE
Update release notes template

### DIFF
--- a/docs/Contributing/workflows/releasing-fleet.md
+++ b/docs/Contributing/workflows/releasing-fleet.md
@@ -141,17 +141,15 @@ When the Actions Workflow has been completed, [publish the new version of Fleet]
 (replace items in <> with the appropriate values):
    
 ```md
-### Changes
+### Security Engineers
 
 <COPY FROM CHANGELOG>
 
-### Upgrading
+### IT Admins
 
-Please visit our [update guide](https://fleetdm.com/docs/deploying/upgrading-fleet) for upgrade instructions.
+<COPY FROM CHANGELOG>
 
-### Documentation
-
-Documentation for Fleet is available at [fleetdm.com/docs](https://fleetdm.com/docs).
+> Fleet-maintained app updates and vulnerability fixes are applied, whether or not you upgrade.
 
 ### Fleet's agent
 
@@ -163,6 +161,14 @@ The following version of Fleet's agent (`fleetd`) support the latest changes to 
 3. [fleetd-chrome-v1.x.x](https://github.com/fleetdm/fleet/releases/tag/fleetd-chrome-v1.x.x)
 
 > While newer versions of `fleetd` still function with older versions of the Fleet server (and vice versa), Fleet does not actively test these scenarios and some newer features won't be available.
+
+### Upgrading
+
+Please visit our [upgrade guide](https://fleetdm.com/docs/deploying/upgrading-fleet) for upgrade instructions.
+
+### Documentation
+
+Documentation for Fleet is available at [fleetdm.com/docs](https://fleetdm.com/docs).
 
 ### Binary Checksum
 

--- a/handbook/engineering/README.md
+++ b/handbook/engineering/README.md
@@ -202,7 +202,7 @@ If code changes are found for any `fleetd` components, create a new release QA i
 
 ### Indicate your product group is release-ready
 
-Once a product group completes its QA process during the release candidate period, its QA lead moves the smoke testing ticket to the "Ready for release" column on their GitHub board. They then notify the release ritual DRI by tagging them in a comment, indicating that their group is prepared for release. The release ritual DRI starts the [release process](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/releasing-fleet.md) after all QA leads have made these updates and confirmed their readiness for release.
+Once a product group completes its QA process during the release candidate period, its QA lead moves the smoke testing ticket to the "Ready for release" column on their GitHub board. They then notify the release ritual DRI by tagging them in a comment, indicating that their group is prepared for release. The release ritual DRI starts the [release process](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/workflows/releasing-fleet.md) after all QA leads have made these updates and confirmed their readiness for release.
 
 
 ### Prepare Fleet release


### PR DESCRIPTION
- @mostlikelee: Currently customers can view Fleet release notes to see what FMAs (and some vulnerability fixes) have been released.  This can cause customer confusion as they may think that they need to update to the latest Fleet version to get these changes when they don't.
- Fix broken link in handbook
- Also, moved "Upgrading" and "Documentation" below "Fleet's agent" because that's what we're doing today (for example, [see 4.67.0](https://github.com/fleetdm/fleet/releases/tag/fleet-v4.67.0)):

<img width="942" height="552" alt="Screenshot 2025-07-17 at 3 07 19 PM" src="https://github.com/user-attachments/assets/7165c28b-289d-42e9-912f-6e991560f683" />
