### PR TITLE
Host identity SCEP rate limit.

### DIFF
--- a/cmd/fleet/serve.go
+++ b/cmd/fleet/serve.go
@@ -1206,7 +1206,7 @@ the way that the Fleet server works.
 				}
 				// Host identify SCEP feature only works if a private key has been set up
 				if len(config.Server.PrivateKey) > 0 {
-					hostIdentitySCEPDepot, err := mds.NewHostIdentitySCEPDepot(kitlog.With(logger, "component", "host-id-scep-depot"))
+					hostIdentitySCEPDepot, err := mds.NewHostIdentitySCEPDepot(kitlog.With(logger, "component", "host-id-scep-depot"), &config)
 					if err != nil {
 						initFatal(err, "setup host identity SCEP depot")
 					}

--- a/ee/server/integrationtest/hostidentity/scep_rate_limit_test.go
+++ b/ee/server/integrationtest/hostidentity/scep_rate_limit_test.go
@@ -1,0 +1,176 @@
+package hostidentity
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/fleetdm/fleet/v4/server/config"
+	"github.com/fleetdm/fleet/v4/server/datastore/mysql"
+	"github.com/fleetdm/fleet/v4/server/fleet"
+	scepclient "github.com/fleetdm/fleet/v4/server/mdm/scep/client"
+	"github.com/fleetdm/fleet/v4/server/mdm/scep/x509util"
+	"github.com/smallstep/scep"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSCEPRateLimit(t *testing.T) {
+	// Set up suite with rate limiting configuration
+	cooldown := 5 * time.Minute
+	s := SetUpSuiteWithConfig(t, "integrationtest.SCEPRateLimit", false, func(cfg *config.FleetConfig) {
+		cfg.Osquery.EnrollCooldown = cooldown
+	})
+
+	defer mysql.TruncateTables(t, s.BaseSuite.DS, []string{
+		"host_identity_scep_serials", "host_identity_scep_certificates",
+	}...)
+
+	t.Run("RateLimitSameHost", func(t *testing.T) {
+		// Create an enrollment secret
+		ctx := t.Context()
+		err := s.DS.ApplyEnrollSecrets(ctx, nil, []*fleet.EnrollSecret{
+			{
+				Secret: testEnrollmentSecret,
+			},
+		})
+		require.NoError(t, err)
+
+		// Create a unique host identifier (CN)
+		hostID := "test-host-rate-limit"
+
+		// First certificate request - should succeed
+		initialCert, err := requestSCEPCertificate(t, s, hostID)
+		require.NoError(t, err)
+		require.NotNil(t, initialCert)
+		assert.Equal(t, hostID, initialCert.Subject.CommonName)
+
+		// Second certificate request immediately after - should fail due to rate limit
+		rateLimitedCert, err := requestSCEPCertificate(t, s, hostID)
+		require.Error(t, err)
+		require.Nil(t, rateLimitedCert)
+		// The error will be a generic SCEP failure, but we can verify rate limiting is working
+		// by confirming the request fails when it should succeed without rate limiting
+
+		// Wait for a small duration (less than cooldown) and try again - should still fail
+		time.Sleep(1 * time.Second)
+		stillRateLimitedCert, err := requestSCEPCertificate(t, s, hostID)
+		require.Error(t, err)
+		require.Nil(t, stillRateLimitedCert)
+
+		// Different host should be able to get certificate
+		differentHostID := "test-host-different"
+		differentHostCert, err := requestSCEPCertificate(t, s, differentHostID)
+		require.NoError(t, err)
+		require.NotNil(t, differentHostCert)
+		assert.Equal(t, differentHostID, differentHostCert.Subject.CommonName)
+	})
+}
+
+// requestSCEPCertificate is a helper function to request a SCEP certificate for a given host identifier
+func requestSCEPCertificate(t *testing.T, s *Suite, hostIdentifier string) (*x509.Certificate, error) {
+	ctx := context.Background()
+
+	// Create ECC private key
+	eccPrivateKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return nil, err
+	}
+
+	// Create CSR
+	csrTemplate := x509util.CertificateRequest{
+		CertificateRequest: x509.CertificateRequest{
+			Subject: pkix.Name{
+				CommonName: hostIdentifier,
+			},
+			SignatureAlgorithm: x509.ECDSAWithSHA256,
+		},
+		ChallengePassword: testEnrollmentSecret,
+	}
+
+	csrDerBytes, err := x509util.CreateCertificateRequest(rand.Reader, &csrTemplate, eccPrivateKey)
+	if err != nil {
+		return nil, err
+	}
+	csr, err := x509.ParseCertificateRequest(csrDerBytes)
+	if err != nil {
+		return nil, err
+	}
+
+	// Create SCEP client
+	scepURL := s.Server.URL + "/api/fleet/orbit/host_identity/scep"
+	timeout := 30 * time.Second
+	scepClient, err := scepclient.New(scepURL, s.Logger, &timeout)
+	if err != nil {
+		return nil, err
+	}
+
+	// Get CA certificate
+	caCertsBytes, _, err := scepClient.GetCACert(ctx, "")
+	if err != nil {
+		return nil, err
+	}
+	caCerts, err := x509.ParseCertificates(caCertsBytes)
+	if err != nil {
+		return nil, err
+	}
+	if len(caCerts) == 0 {
+		return nil, fmt.Errorf("no CA certificates returned")
+	}
+
+	// Create temporary RSA key and cert for SCEP protocol
+	tempRSAKey, deviceCert := createTempRSAKeyAndCert(t, hostIdentifier)
+
+	// Create SCEP PKI message
+	pkiMsgReq := &scep.PKIMessage{
+		MessageType: scep.PKCSReq,
+		Recipients:  caCerts,
+		SignerKey:   tempRSAKey,
+		SignerCert:  deviceCert,
+	}
+
+	msg, err := scep.NewCSRRequest(csr, pkiMsgReq)
+	if err != nil {
+		return nil, err
+	}
+
+	// Send PKI operation request
+	respBytes, err := scepClient.PKIOperation(ctx, msg.Raw)
+	if err != nil {
+		return nil, err
+	}
+
+	// Parse response
+	pkiMsgResp, err := scep.ParsePKIMessage(respBytes, scep.WithCACerts(msg.Recipients))
+	if err != nil {
+		return nil, err
+	}
+
+	// Check response status
+	if pkiMsgResp.PKIStatus != scep.SUCCESS {
+		if pkiMsgResp.FailInfo != "" {
+			return nil, fmt.Errorf("SCEP request failed: %s", pkiMsgResp.FailInfo)
+		}
+		return nil, fmt.Errorf("SCEP request failed with status: %v", pkiMsgResp.PKIStatus)
+	}
+
+	// Decrypt PKI envelope
+	err = pkiMsgResp.DecryptPKIEnvelope(deviceCert, tempRSAKey)
+	if err != nil {
+		return nil, err
+	}
+
+	// Extract certificate
+	certRepMsg := pkiMsgResp.CertRepMessage
+	if certRepMsg == nil || certRepMsg.Certificate == nil {
+		return nil, fmt.Errorf("no certificate in SCEP response")
+	}
+
+	return certRepMsg.Certificate, nil
+}

--- a/ee/server/integrationtest/hostidentity/suite.go
+++ b/ee/server/integrationtest/hostidentity/suite.go
@@ -41,7 +41,7 @@ func SetUpSuite(t *testing.T, uniqueTestName string, requireSignature bool) *Sui
 		License: license,
 	})
 	logger := log.NewLogfmtLogger(os.Stdout)
-	hostIdentitySCEPDepot, err := ds.NewHostIdentitySCEPDepot(kitlog.With(logger, "component", "host-id-scep-depot"))
+	hostIdentitySCEPDepot, err := ds.NewHostIdentitySCEPDepot(kitlog.With(logger, "component", "host-id-scep-depot"), &fleetCfg)
 	require.NoError(t, err)
 	users, server := service.RunServerForTestsWithServiceWithDS(t, ctx, ds, fleetSvc, &service.TestServerOpts{
 		License:     license,

--- a/ee/server/service/hostidentity/depot/depot.go
+++ b/ee/server/service/hostidentity/depot/depot.go
@@ -8,9 +8,13 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
+	"time"
 
+	"github.com/cenkalti/backoff/v4"
 	"github.com/fleetdm/fleet/v4/ee/server/service/hostidentity/types"
 	"github.com/fleetdm/fleet/v4/pkg/certificate"
+	"github.com/fleetdm/fleet/v4/server/config"
+	"github.com/fleetdm/fleet/v4/server/contexts/ctxerr"
 	"github.com/fleetdm/fleet/v4/server/datastore/mysql/common_mysql"
 	"github.com/fleetdm/fleet/v4/server/fleet"
 	"github.com/fleetdm/fleet/v4/server/mdm/assets"
@@ -26,12 +30,13 @@ type HostIdentitySCEPDepot struct {
 	db     *sqlx.DB
 	ds     fleet.Datastore
 	logger log.Logger
+	config *config.FleetConfig
 }
 
 var _ depot.Depot = (*HostIdentitySCEPDepot)(nil)
 
 // NewHostIdentitySCEPDepot creates and returns a *HostIdentitySCEPDepot.
-func NewHostIdentitySCEPDepot(db *sqlx.DB, ds fleet.Datastore, logger log.Logger) (*HostIdentitySCEPDepot, error) {
+func NewHostIdentitySCEPDepot(db *sqlx.DB, ds fleet.Datastore, logger log.Logger, cfg *config.FleetConfig) (*HostIdentitySCEPDepot, error) {
 	if err := db.Ping(); err != nil {
 		return nil, err
 	}
@@ -39,6 +44,7 @@ func NewHostIdentitySCEPDepot(db *sqlx.DB, ds fleet.Datastore, logger log.Logger
 		db:     db,
 		ds:     ds,
 		logger: logger,
+		config: cfg,
 	}, nil
 }
 
@@ -102,6 +108,22 @@ func (d *HostIdentitySCEPDepot) Put(name string, crt *x509.Certificate) error {
 		return fmt.Errorf("creating public key raw: %w", err)
 	}
 	certPEM := certificate.EncodeCertPEM(crt)
+
+	// Apply rate limiting if configured
+	cooldown := d.config.Osquery.EnrollCooldown
+	if cooldown > 0 {
+		existingCert, err := d.ds.GetHostIdentityCertByName(context.Background(), name)
+		switch {
+		case err != nil && !fleet.IsNotFound(err):
+			return fmt.Errorf("checking existing certificate: %w", err)
+		case err == nil:
+			// Certificate exists, check if rate limit applies
+			if time.Since(existingCert.CreatedAt) < cooldown {
+				return backoff.Permanent(ctxerr.Errorf(context.Background(), "host identified by %s requesting certificates too often", name))
+			}
+		}
+		// If certificate doesn't exist or rate limit doesn't apply, continue
+	}
 
 	return common_mysql.WithRetryTxx(context.Background(), d.db, func(tx sqlx.ExtContext) error {
 		// Revoke existing certs for this host id.

--- a/ee/server/service/hostidentity/types/host_identity_certificates.go
+++ b/ee/server/service/hostidentity/types/host_identity_certificates.go
@@ -15,6 +15,7 @@ type HostIdentityCertificate struct {
 	HostID        *uint     `db:"host_id"`
 	NotValidAfter time.Time `db:"not_valid_after"`
 	PublicKeyRaw  []byte    `db:"public_key_raw"`
+	CreatedAt     time.Time `db:"created_at"`
 }
 
 func (h *HostIdentityCertificate) UnmarshalPublicKey() (*ecdsa.PublicKey, error) {

--- a/server/datastore/mysql/host_identity_scep.go
+++ b/server/datastore/mysql/host_identity_scep.go
@@ -47,7 +47,7 @@ func updateHostIdentityCertHostIDBySerial(ctx context.Context, tx sqlx.ExtContex
 func (ds *Datastore) GetHostIdentityCertByName(ctx context.Context, name string) (*types.HostIdentityCertificate, error) {
 	var hostIdentityCert types.HostIdentityCertificate
 	err := sqlx.GetContext(ctx, ds.reader(ctx), &hostIdentityCert, `
-		SELECT serial, host_id, name, not_valid_after, public_key_raw
+		SELECT serial, host_id, name, not_valid_after, public_key_raw, created_at
 		FROM host_identity_scep_certificates
 		WHERE name = ?
 			AND not_valid_after > NOW()

--- a/server/datastore/mysql/mysql.go
+++ b/server/datastore/mysql/mysql.go
@@ -192,8 +192,8 @@ func (ds *Datastore) NewSCEPDepot() (scep_depot.Depot, error) {
 
 // NewHostIdentitySCEPDepot returns a scep_depot.Depot for host identity certs that uses the Datastore
 // underlying MySQL writer *sql.DB.
-func (ds *Datastore) NewHostIdentitySCEPDepot(logger log.Logger) (scep_depot.Depot, error) {
-	return hostidscepdepot.NewHostIdentitySCEPDepot(ds.primary, ds, logger)
+func (ds *Datastore) NewHostIdentitySCEPDepot(logger log.Logger, cfg *config.FleetConfig) (scep_depot.Depot, error) {
+	return hostidscepdepot.NewHostIdentitySCEPDepot(ds.primary, ds, logger, cfg)
 }
 
 type entity struct {


### PR DESCRIPTION
Fixes #30989 

# Checklist for submitter

- [x] Added/updated automated tests
  - [x] Where appropriate, automated tests simulate multiple hosts and test for host isolation (updates to one hosts's records do not affect another.)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added rate limiting to SCEP certificate enrollment, returning a "Too Many Requests" (HTTP 429) response if hosts request certificates too frequently.

* **Bug Fixes**
  * Improved error handling for rate-limited SCEP requests, providing clear feedback when rate limits are exceeded.

* **Tests**
  * Introduced integration tests to verify SCEP rate limiting behavior.

* **Chores**
  * Enhanced internal configuration handling for SCEP certificate management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->