### PR TITLE
Mark ndes_scep_proxy as experimental

### DIFF
--- a/docs/Configuration/yaml-files.md
+++ b/docs/Configuration/yaml-files.md
@@ -754,6 +754,9 @@ For secrets, you can add [GitHub environment variables](https://docs.github.com/
 - `certificate_seat_id` is the ID of the DigiCert's seat. Seats are license units in DigiCert.
 
 #### ndes_scep_proxy
+
+> **Experimental feature**. This feature is undergoing rapid improvement, which may result in breaking changes to the API or configuration surface. It is not recommended for use in automated workflows.
+
 - `url` is the URL of the NDES SCEP endpoint (default: `""`).
 - `admin_url` is the URL of the NDES admin endpoint (default: `""`).
 - `username` is the username of the NDES admin endpoint (default: `""`).


### PR DESCRIPTION
Mark ndes_scep_proxy as experimental.

@rachaelshaw We already discussed this. We forgot to mark this YAML configuration as experimental, but the API is marked as experimental. We want to deprecate these and transition to new endpoints, as discussed during the MDM design review, to enable better scaling of this feature.