### PR TITLE
Add Fedora as a Linux platform

### DIFF
--- a/server/fleet/hosts.go
+++ b/server/fleet/hosts.go
@@ -973,7 +973,7 @@ func PlatformSupportsOsquery(platform string) bool {
 
 // HostLinuxOSs are the possible linux values for Host.Platform.
 var HostLinuxOSs = []string{
-	"linux", "ubuntu", "debian", "rhel", "centos", "sles", "kali", "gentoo", "amzn", "pop", "arch", "linuxmint", "void", "nixos", "endeavouros", "manjaro", "opensuse-leap", "opensuse-tumbleweed", "tuxedo", "neon",
+	"linux", "ubuntu", "debian", "rhel", "centos", "sles", "kali", "gentoo", "amzn", "pop", "arch", "linuxmint", "void", "nixos", "endeavouros", "manjaro", "opensuse-leap", "opensuse-tumbleweed", "tuxedo", "neon", "fedora",
 }
 
 // HostNeitherDebNorRpmPackageOSs are the list of known Linux platforms that support neither DEB nor RPM packages


### PR DESCRIPTION

Added "fedora" to list of supported Linux platforms.

The change adds "fedora" to the HostLinuxOSs list. This ensures Fedora hosts are correctly identified as Linux platforms.

Changes
Added "fedora" to the HostLinuxOSs array in server/fleet/hosts.go.
No structural changes.
Impact
Fedora hosts will now be correctly identified as Linux platforms, enabling label application.
No dependencies affected.
No breaking changes.
No performance implications.