### PR TITLE
Add waits + norestart to MSI uninstall scripts

### DIFF
--- a/changes/31077-msi-uninstall
+++ b/changes/31077-msi-uninstall
@@ -1,0 +1,1 @@
+* Revised MSI uninstall scripts to wait for an uninstall to complete before returning and avoid restarting after an uninstall.

--- a/pkg/file/scripts/uninstall_msi.ps1
+++ b/pkg/file/scripts/uninstall_msi.ps1
@@ -1,5 +1,13 @@
 $product_code = $PACKAGE_ID
 
 # Fleet uninstalls app using product code that's extracted on upload
-msiexec /quiet /x $product_code
-Exit $LASTEXITCODE
+$process = Start-Process msiexec -ArgumentList @("/quiet", "/x", $product_code, "/norestart") -Wait -PassThru
+
+# Check exit code and output result
+if ($process.ExitCode -eq 0) {
+    Write-Output "Exit 0"
+    Exit 0
+} else {
+    Write-Output "Exit $($process.ExitCode)"
+    Exit $process.ExitCode
+}

--- a/pkg/file/scripts/uninstall_msi_with_upgrade_code.ps1
+++ b/pkg/file/scripts/uninstall_msi_with_upgrade_code.ps1
@@ -1,7 +1,14 @@
 # Fleet uninstalls app by finding all related product codes for the specified upgrade code
 $inst = New-Object -ComObject "WindowsInstaller.Installer"
 foreach ($product_code in $inst.RelatedProducts("$UPGRADE_CODE")) {
-    msiexec /quiet /x $product_code
+    $process = Start-Process msiexec -ArgumentList @("/quiet", "/x", $product_code, "/norestart") -Wait -PassThru
+
+    # If the uninstall failed, bail
+    if ($process.ExitCode -ne 0) {
+        Write-Output "Uninstall for $($product_code) exited $($process.ExitCode)"
+        Exit $process.ExitCode
+    }
 }
 
-Exit $LASTEXITCODE
+# All uninstalls succeeded; exit success
+Exit 0

--- a/pkg/file/testdata/scripts/uninstall_msi.ps1.golden
+++ b/pkg/file/testdata/scripts/uninstall_msi.ps1.golden
@@ -1,5 +1,13 @@
 $product_code = $PACKAGE_ID
 
 # Fleet uninstalls app using product code that's extracted on upload
-msiexec /quiet /x $product_code
-Exit $LASTEXITCODE
+$process = Start-Process msiexec -ArgumentList @("/quiet", "/x", $product_code, "/norestart") -Wait -PassThru
+
+# Check exit code and output result
+if ($process.ExitCode -eq 0) {
+    Write-Output "Exit 0"
+    Exit 0
+} else {
+    Write-Output "Exit $($process.ExitCode)"
+    Exit $process.ExitCode
+}


### PR DESCRIPTION
Closes #31077.

- Added logic to wait for the uninstall command to finish running before exiting the script. 
- Also added the `/norestart` flag so users who click uninstall in self-service aren't at risk of a sudden and unintentional reboot as the result of software uninstalling.


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.
