### PR TITLE
Add arm64 support for fleetd extensions and fixes on test scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -101,8 +101,10 @@ fleetd_tables_*
 
 # Location of test extensions executables
 tools/test_extensions/hello_world/macos
-tools/test_extensions/hello_world/windows
 tools/test_extensions/hello_world/linux
+tools/test_extensions/hello_world/linux-arm64
+tools/test_extensions/hello_world/windows
+tools/test_extensions/hello_world/windows-arm64
 
 # Residual files when building fleet_tables extension.
 fleet_tables_*.ext

--- a/changes/fleetd-extensions-support-arm64
+++ b/changes/fleetd-extensions-support-arm64
@@ -1,0 +1,1 @@
+* Added support for fleetd TUF extensions on Linux arm64 and Windows arm64 devices.

--- a/docs/Configuration/agent-configuration.md
+++ b/docs/Configuration/agent-configuration.md
@@ -97,18 +97,24 @@ agent_options:
     hello_world_linux:
       channel: 'stable'
       platform: 'linux'
+    hello_world_linux_arm64:
+      channel: 'stable'
+      platform: 'linux-arm64'
     hello_world_windows:
       channel: 'stable'
       platform: 'windows'
+    hello_world_windows_arm64:
+      channel: 'stable'
+      platform: 'windows-arm64'
 ```
 
-In the above example, we are configuring our `hello_world` extensions for all the supported operating systems. We do this by creating `hello_world_{macos|linux|windows}` subkeys under `extensions`, and then specifying the `channel` and `platform` keys for each extension entry.
+In the above example, we are configuring our `hello_world` extensions for all the supported operating systems. We do this by creating `hello_world_{macos|linux|linux_arm64|windows|windows_arm64}` subkeys under `extensions`, and then specifying the `channel` and `platform` keys for each extension entry.
 
 Next, you will need to make sure to push the binary files of our `hello_world_*` extension as a target on your TUF server. This step needs to follow these conventions:
 * The binary file of the extension must have the same name as the extension, followed by `.ext` for macOS and Linux extensions and by `.ext.exe` for Windows extensions.
-In the above case, the filename for macOS should be `hello_world_macos.ext`, for Linux it should be `hello_world_linux.ext` and for Windows it should be `hello_world_windows.ext.exe`.
-* The target name for the TUF server must be named as `extensions/<extension_name>`. For the above example, this would be `extensions/hello_world_{macos|linux|windows}`
-* The `platform` field is one of `macos`, `linux`, or `windows`.
+In the above case, the filename for macOS should be `hello_world_macos.ext`, for Linux it should be `hello_world_linux.ext`, for Linux arm64 it should be `hello_world_linux_arm64.ext`, for Windows it should be `hello_world_windows.ext.exe`, and for Windows arm64 it should be `hello_world_windows_arm64.ext.exe`.
+* The target name for the TUF server must be named as `extensions/<extension_name>`. For the above example, this would be `extensions/hello_world_{macos|linux|linux_arm64|windows|windows_arm64}`
+* The `platform` field is one of `macos`, `linux`, `linux-arm64`, `windows`, or `windows-arm64`.
 
 If you are using `fleetctl` to manage your TUF server, these same conventions apply. You can run the following command to add a new target:
 ```bash
@@ -127,10 +133,24 @@ fleetctl updates add \
   --version 0.1
 
 fleetctl updates add \
+  --path /path/to/local/TUF/repo
+  --target /path/to/extensions/binary/hello_world_linux_arm64.ext \
+  --name extensions/hello_world_linux_arm64 \
+  --platform linux-arm64 \
+  --version 0.1
+
+fleetctl updates add \
   --path /path/to/local/TUF/repo \
   --target /path/to/extensions/binary/hello_world_windows.ext.exe \
   --name extensions/hello_world_windows \
   --platform windows \
+  --version 0.1
+
+fleetctl updates add \
+  --path /path/to/local/TUF/repo \
+  --target /path/to/extensions/binary/hello_world_windows_arm64.ext.exe \
+  --name extensions/hello_world_windows_arm64 \
+  --platform windows-arm64 \
   --version 0.1
 ```
 
@@ -255,7 +275,7 @@ agent_options:
             - /etc/%%
         auto_table_construction:
           tcc_system_entries:
-            # This query and columns are restricted for compatability.  Open TCC.db with sqlite on
+            # This query and its columns are restricted for compatibility. Open TCC.db with sqlite on
             # your endpoints to expand this out.
             query: "SELECT service, client, last_modified FROM access"
             # Note that TCC.db requires fleetd to have full-disk access, ensure that endpoints have 

--- a/orbit/changes/fleetd-extensions-support-arm64
+++ b/orbit/changes/fleetd-extensions-support-arm64
@@ -1,0 +1,1 @@
+* Added support for fleetd TUF extensions on Linux arm64 and Windows arm64 devices.

--- a/orbit/pkg/update/flag_runner.go
+++ b/orbit/pkg/update/flag_runner.go
@@ -153,7 +153,7 @@ func (r *ExtensionRunner) Run(config *fleet.OrbitConfig) error {
 	}
 
 	// Filter out extensions not targeted to this OS.
-	extensions.FilterByHostPlatform(runtime.GOOS)
+	extensions.FilterByHostPlatform(runtime.GOOS, runtime.GOARCH)
 
 	var sb strings.Builder
 	for extensionName, extensionInfo := range extensions {

--- a/server/fleet/orbit.go
+++ b/server/fleet/orbit.go
@@ -173,14 +173,20 @@ type ExtensionInfo struct {
 type Extensions map[string]ExtensionInfo
 
 // FilterByHostPlatform filters out extensions that are not targeted for hostPlatform.
-// It supports host platforms reported by osquery and by Go's runtime.GOOS.
-func (es *Extensions) FilterByHostPlatform(hostPlatform string) {
+// It supports host platforms reported by osquery (e.g. x86_64, aarch64, ARM)
+// and by Go's runtime.GOOS (arm64 and amd64).
+func (es *Extensions) FilterByHostPlatform(hostPlatform string, hostCPU string) {
 	switch {
-	case IsLinux(hostPlatform):
+	case IsLinux(hostPlatform) && (hostCPU == "x86_64" || hostCPU == "amd64"):
 		hostPlatform = "linux"
+	case IsLinux(hostPlatform) && (hostCPU == "aarch64" || hostCPU == "arm64"):
+		hostPlatform = "linux-arm64"
 	case hostPlatform == "darwin":
-		// Osquery uses "darwin", whereas the extensions feature uses "macos".
-		hostPlatform = "macos"
+		hostPlatform = "macos" // osquery uses "darwin", whereas the extensions feature uses "macos".
+	case hostPlatform == "windows" && (hostCPU == "x86_64" || hostCPU == "amd64"):
+		hostPlatform = "windows"
+	case hostPlatform == "windows" && (hostCPU == "ARM" || hostCPU == "arm64"):
+		hostPlatform = "windows-arm64"
 	}
 	for extensionName, extensionInfo := range *es {
 		if hostPlatform != extensionInfo.Platform {

--- a/server/fleet/orbit_test.go
+++ b/server/fleet/orbit_test.go
@@ -7,49 +7,68 @@ import (
 )
 
 func TestFilterByHostPlatform(t *testing.T) {
+	// Test with no extensions.
 	var extensions Extensions
-	extensions.FilterByHostPlatform("darwin")
+	extensions.FilterByHostPlatform("darwin", "x86_64")
 	require.Len(t, extensions, 0)
 
+	// Test with a macOS extension.
 	extensions = Extensions{
 		"hello_world": ExtensionInfo{
 			Platform: "macos",
 			Channel:  "stable",
 		},
 	}
-
-	extensions.FilterByHostPlatform("darwin")
+	extensions.FilterByHostPlatform("darwin", "arm64e")
 	require.Contains(t, extensions, "hello_world")
-
-	extensions.FilterByHostPlatform("macos")
+	extensions.FilterByHostPlatform("macos", "arm64")
 	require.Contains(t, extensions, "hello_world")
-
-	extensions.FilterByHostPlatform("ubuntu")
+	extensions.FilterByHostPlatform("ubuntu", "x86_64")
 	require.Len(t, extensions, 0)
 
+	//
+	// Test with Linux amd64 and arm64 extension on Ubuntu hosts.
+	//
+
+	// Linux amd64 extension on ubuntu.
 	extensions = Extensions{
 		"hello_world": ExtensionInfo{
 			Platform: "linux",
 			Channel:  "stable",
 		},
-	}
-
-	extensions.FilterByHostPlatform("ubuntu")
-	require.Contains(t, extensions, "hello_world")
-
-	extensions = Extensions{
-		"hello_world": ExtensionInfo{
-			Platform: "windows",
+		"hello_world_arm64": ExtensionInfo{
+			Platform: "linux-arm64",
 			Channel:  "stable",
 		},
-		"hello_world_2": ExtensionInfo{
-			Platform: "windows",
-			Channel:  "edge",
+	}
+	extensions.FilterByHostPlatform("ubuntu", "x86_64")
+	require.Contains(t, extensions, "hello_world")
+	extensions.FilterByHostPlatform("ubuntu", "amd64")
+	require.Contains(t, extensions, "hello_world")
+	extensions.FilterByHostPlatform("ubuntu", "arm64")
+	require.Len(t, extensions, 0)
+
+	// Linux arm64 extension on ubuntu.
+	extensions = Extensions{
+		"hello_world": ExtensionInfo{
+			Platform: "linux",
+			Channel:  "stable",
+		},
+		"hello_world_arm64": ExtensionInfo{
+			Platform: "linux-arm64",
+			Channel:  "stable",
 		},
 	}
-
-	extensions.FilterByHostPlatform("darwin")
+	extensions.FilterByHostPlatform("ubuntu", "arm64")
+	require.Contains(t, extensions, "hello_world_arm64")
+	extensions.FilterByHostPlatform("ubuntu", "aarch64")
+	require.Contains(t, extensions, "hello_world_arm64")
+	extensions.FilterByHostPlatform("ubuntu", "amd64")
 	require.Len(t, extensions, 0)
+
+	//
+	// Test with a Linux amd64 and arm64 extension on Linux hosts.
+	//
 
 	extensions = Extensions{
 		"hello_world_0": ExtensionInfo{
@@ -64,9 +83,85 @@ func TestFilterByHostPlatform(t *testing.T) {
 			Platform: "linux",
 			Channel:  "stable",
 		},
+		"hello_world_3": ExtensionInfo{
+			Platform: "linux-arm64",
+			Channel:  "stable",
+		},
 	}
 
-	extensions.FilterByHostPlatform("linux")
+	// Linux amd64
+	extensions.FilterByHostPlatform("linux", "x86_64")
 	require.Len(t, extensions, 1)
 	require.Contains(t, extensions, "hello_world_2")
+	extensions.FilterByHostPlatform("linux", "amd64")
+	require.Len(t, extensions, 1)
+	require.Contains(t, extensions, "hello_world_2")
+
+	extensions = Extensions{
+		"hello_world_0": ExtensionInfo{
+			Platform: "macos",
+			Channel:  "stable",
+		},
+		"hello_world_1": ExtensionInfo{
+			Platform: "windows",
+			Channel:  "stable",
+		},
+		"hello_world_2": ExtensionInfo{
+			Platform: "linux",
+			Channel:  "stable",
+		},
+		"hello_world_3": ExtensionInfo{
+			Platform: "linux-arm64",
+			Channel:  "stable",
+		},
+	}
+	// Linux arm64
+	extensions.FilterByHostPlatform("linux", "aarch64")
+	require.Len(t, extensions, 1)
+	require.Contains(t, extensions, "hello_world_3")
+	extensions.FilterByHostPlatform("linux", "arm64")
+	require.Len(t, extensions, 1)
+	require.Contains(t, extensions, "hello_world_3")
+
+	//
+	// Test with a Windows amd64 and arm64 extension.
+	//
+
+	extensions = Extensions{
+		"hello_world_0": ExtensionInfo{
+			Platform: "windows",
+			Channel:  "stable",
+		},
+		"hello_world_1": ExtensionInfo{
+			Platform: "windows-arm64",
+			Channel:  "stable",
+		},
+	}
+
+	// Windows arm64
+	extensions.FilterByHostPlatform("windows", "ARM")
+	require.Len(t, extensions, 1)
+	require.Contains(t, extensions, "hello_world_1")
+	extensions.FilterByHostPlatform("windows", "arm64")
+	require.Len(t, extensions, 1)
+	require.Contains(t, extensions, "hello_world_1")
+
+	extensions = Extensions{
+		"hello_world_0": ExtensionInfo{
+			Platform: "windows",
+			Channel:  "stable",
+		},
+		"hello_world_1": ExtensionInfo{
+			Platform: "windows-arm64",
+			Channel:  "stable",
+		},
+	}
+
+	// Windows amd64
+	extensions.FilterByHostPlatform("windows", "x86_64")
+	require.Len(t, extensions, 1)
+	require.Contains(t, extensions, "hello_world_0")
+	extensions.FilterByHostPlatform("windows", "amd64")
+	require.Len(t, extensions, 1)
+	require.Contains(t, extensions, "hello_world_0")
 }

--- a/server/service/orbit.go
+++ b/server/service/orbit.go
@@ -633,7 +633,7 @@ func (svc *Service) filterExtensionsForHost(ctx context.Context, extensions json
 	}
 
 	// Filter the extensions by platform.
-	extensionsInfo.FilterByHostPlatform(host.Platform)
+	extensionsInfo.FilterByHostPlatform(host.Platform, host.CPUType)
 
 	// Filter the extensions by labels (premium only feature).
 	if license, _ := license.FromContext(ctx); license != nil && license.IsPremium() {

--- a/tools/release/publish_release.sh
+++ b/tools/release/publish_release.sh
@@ -364,7 +364,7 @@ changelog_and_versions() {
         gh pr create -f -B $source_branch
         gh workflow run goreleaser-snapshot-fleet.yaml --ref $source_branch # Manually trigger workflow run
     else
-        echo "DRYRUN: Would have created Changelog / verison pr from $branch_for_changelog to $source_branch"
+        echo "DRYRUN: Would have created Changelog / version pr from $branch_for_changelog to $source_branch"
     fi
 }
 

--- a/tools/test_extensions/hello_world/build.sh
+++ b/tools/test_extensions/hello_world/build.sh
@@ -1,14 +1,33 @@
 #!/bin/bash
 
+set -x
+
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
-mkdir -p $SCRIPT_DIR/macos $SCRIPT_DIR/windows $SCRIPT_DIR/linux $SCRIPT_DIR/linux-arm64
-GOOS=darwin GOARCH=amd64 go build -o $SCRIPT_DIR/macos/hello_world_macos.ext $SCRIPT_DIR
-GOOS=windows GOARCH=amd64 go build -o $SCRIPT_DIR/windows/hello_world_windows.ext.exe $SCRIPT_DIR
-GOOS=linux GOARCH=amd64 go build -o $SCRIPT_DIR/linux/hello_world_linux.ext $SCRIPT_DIR
-GOOS=linux GOARCH=arm64 go build -o $SCRIPT_DIR/linux-arm64/hello_world_linux.ext $SCRIPT_DIR
+mkdir -p $SCRIPT_DIR/macos $SCRIPT_DIR/windows $SCRIPT_DIR/linux $SCRIPT_DIR/linux-arm64 $SCRIPT_DIR/windows-arm64
 
-GOOS=darwin GOARCH=amd64 go build -ldflags '-X "main.extensionName=test_extensions.hello_mars" -X "main.tableName=hello_mars" -X "main.columnValue=mars"' -o $SCRIPT_DIR/macos/hello_mars_macos.ext $SCRIPT_DIR
+# 1. build hello_world table extensions
+
+GOOS=darwin GOARCH=amd64 go build -o $SCRIPT_DIR/macos/hello_world_macos_amd64.ext $SCRIPT_DIR
+GOOS=darwin GOARCH=arm64 go build -o $SCRIPT_DIR/macos/hello_world_macos_arm64.ext $SCRIPT_DIR
+lipo -create $SCRIPT_DIR/macos/hello_world_macos_amd64.ext $SCRIPT_DIR/macos/hello_world_macos_arm64.ext -output $SCRIPT_DIR/macos/hello_world_macos.ext
+rm $SCRIPT_DIR/macos/hello_world_macos_amd64.ext $SCRIPT_DIR/macos/hello_world_macos_arm64.ext
+
+GOOS=windows GOARCH=amd64 go build -o $SCRIPT_DIR/windows/hello_world_windows.ext.exe $SCRIPT_DIR
+GOOS=windows GOARCH=arm64 go build -o $SCRIPT_DIR/windows-arm64/hello_world_windows_arm64.ext.exe $SCRIPT_DIR
+
+GOOS=linux GOARCH=amd64 go build -o $SCRIPT_DIR/linux/hello_world_linux.ext $SCRIPT_DIR
+GOOS=linux GOARCH=arm64 go build -o $SCRIPT_DIR/linux-arm64/hello_world_linux_arm64.ext $SCRIPT_DIR
+
+# 2. build hello_mars table extensions
+
+GOOS=darwin GOARCH=amd64 go build -ldflags '-X "main.extensionName=test_extensions.hello_mars" -X "main.tableName=hello_mars" -X "main.columnValue=mars"' -o $SCRIPT_DIR/macos/hello_mars_macos_amd64.ext $SCRIPT_DIR
+GOOS=darwin GOARCH=arm64 go build -ldflags '-X "main.extensionName=test_extensions.hello_mars" -X "main.tableName=hello_mars" -X "main.columnValue=mars"' -o $SCRIPT_DIR/macos/hello_mars_macos_arm64.ext $SCRIPT_DIR
+lipo -create $SCRIPT_DIR/macos/hello_mars_macos_amd64.ext $SCRIPT_DIR/macos/hello_mars_macos_arm64.ext -output $SCRIPT_DIR/macos/hello_mars_macos.ext
+rm $SCRIPT_DIR/macos/hello_mars_macos_amd64.ext $SCRIPT_DIR/macos/hello_mars_macos_arm64.ext
+
 GOOS=windows GOARCH=amd64 go build -ldflags '-X "main.extensionName=test_extensions.hello_mars" -X "main.tableName=hello_mars" -X "main.columnValue=mars"' -o $SCRIPT_DIR/windows/hello_mars_windows.ext.exe $SCRIPT_DIR
+GOOS=windows GOARCH=arm64 go build -ldflags '-X "main.extensionName=test_extensions.hello_mars" -X "main.tableName=hello_mars" -X "main.columnValue=mars"' -o $SCRIPT_DIR/windows-arm64/hello_mars_windows_arm64.ext.exe $SCRIPT_DIR
+
 GOOS=linux GOARCH=amd64 go build -ldflags '-X "main.extensionName=test_extensions.hello_mars" -X "main.tableName=hello_mars" -X "main.columnValue=mars"' -o $SCRIPT_DIR/linux/hello_mars_linux.ext $SCRIPT_DIR
-GOOS=linux GOARCH=arm64 go build -ldflags '-X "main.extensionName=test_extensions.hello_mars" -X "main.tableName=hello_mars" -X "main.columnValue=mars"' -o $SCRIPT_DIR/linux-arm64/hello_mars_linux.ext $SCRIPT_DIR
+GOOS=linux GOARCH=arm64 go build -ldflags '-X "main.extensionName=test_extensions.hello_mars" -X "main.tableName=hello_mars" -X "main.columnValue=mars"' -o $SCRIPT_DIR/linux-arm64/hello_mars_linux_arm64.ext $SCRIPT_DIR

--- a/tools/tuf/test/Nudge-auto-update-test-guide.md
+++ b/tools/tuf/test/Nudge-auto-update-test-guide.md
@@ -39,7 +39,7 @@ Next, edit your Fleet server configuration to set `app_config.mdm.macos_updates.
 valid (i.e. mimumum version follows the "13.0.1" pattern and deadline follows the "2023-12-31" pattern).
 
 At the next update interval, Orbit should download and install Nudge. After 30-60 seconds, try again
-to launch Nudge in demo mode and check the verison by clicking the info icon in the upper left
+to launch Nudge in demo mode and check the version by clicking the info icon in the upper left
 corner of the Nudge window. 
 
 ## Logs 
@@ -63,7 +63,7 @@ order for it to work with version 1.1.7.81411.
 	tar czf $(out-path)/nudge.app.tar.gz -C $(TMP_DIR)/nudge_pkg_payload_expanded/Applications/Utilities/ Nudge.app
 ```
 
-The change above was observered to work with several other prior versions tested as well. In other
+The change above was observed to work with several other prior versions tested as well. In other
 cases, you may need to inspect the directory structure of the expanded package and tweak the script
 accordingly. 
 

--- a/tools/tuf/test/README.md
+++ b/tools/tuf/test/README.md
@@ -54,7 +54,9 @@ Here's a sample to use the `hello_world` and `hello_mars` test extensions:
 [...]
 MACOS_TEST_EXTENSIONS="./tools/test_extensions/hello_world/macos/hello_world_macos.ext,./tools/test_extensions/hello_world/macos/hello_mars_macos.ext" \
 WINDOWS_TEST_EXTENSIONS="./tools/test_extensions/hello_world/windows/hello_world_windows.ext.exe,./tools/test_extensions/hello_world/windows/hello_mars_windows.ext.exe" \
+WINDOWS_ARM64_TEST_EXTENSIONS="./tools/test_extensions/hello_world/windows-arm64/hello_world_windows_arm64.ext.exe,./tools/test_extensions/hello_world/windows-arm64/hello_mars_windows_arm64.ext.exe" \
 LINUX_TEST_EXTENSIONS="./tools/test_extensions/hello_world/linux/hello_world_linux.ext,./tools/test_extensions/hello_world/linux/hello_mars_linux.ext" \
+LINUX_ARM64_TEST_EXTENSIONS="./tools/test_extensions/hello_world/linux-arm64/hello_world_linux_arm64.ext,./tools/test_extensions/hello_world/linux-arm64/hello_mars_linux_arm64.ext" \
 [...]
 ./tools/tuf/test/main.sh
 ```

--- a/tools/tuf/test/create_repository.sh
+++ b/tools/tuf/test/create_repository.sh
@@ -151,7 +151,7 @@ for system in $SYSTEMS; do
         --version $ORBIT_VERSION -t $ORBIT_MAJOR.$ORBIT_MINOR -t $ORBIT_MAJOR -t stable
     rm $orbit_target
 
-    # Add Fleet Desktop application on macos (if enabled).
+    # Add Fleet Desktop application on macOS (if enabled).
     if [[ $system == "macos" && -n "$FLEET_DESKTOP" ]]; then
         if [[ -z "$MACOS_USE_PREBUILT_DESKTOP_APP_TAR_GZ" ]]; then
             FLEET_DESKTOP_VERBOSE=1 \
@@ -208,7 +208,7 @@ for system in $SYSTEMS; do
     fi
 
 
-    # Add Fleet Desktop application on indows (if enabled).
+    # Add Fleet Desktop application on windows (if enabled).
     if [[ $system == "windows" && -n "$FLEET_DESKTOP" ]]; then
         FLEET_DESKTOP_VERSION=$ORBIT_VERSION \
         make desktop-windows
@@ -290,9 +290,9 @@ for system in $SYSTEMS; do
         done
     fi
 
-    # Add extensions on linux (if set).
-    if [[ $system == "linux-arm64" && -n "$LINUX_TEST_EXTENSIONS" ]]; then
-        for extension in ${LINUX_TEST_EXTENSIONS//,/ }
+    # Add extensions on linux-arm64 (if set).
+    if [[ $system == "linux-arm64" && -n "$LINUX_ARM64_TEST_EXTENSIONS" ]]; then
+        for extension in ${LINUX_ARM64_TEST_EXTENSIONS//,/ }
         do
             extensionName=$(basename $extension)
             extensionName=$(echo "$extensionName" | cut -d'.' -f1)
@@ -316,6 +316,22 @@ for system in $SYSTEMS; do
                 --path $TUF_PATH \
                 --target $extension \
                 --platform windows \
+                --name "extensions/$extensionName" \
+                --version $ORBIT_VERSION -t $ORBIT_MAJOR.$ORBIT_MINOR -t $ORBIT_MAJOR -t stable
+        done
+    fi
+
+    # Add extensions on windows-arm64 (if set).
+    if [[ $system == "windows-arm64" && -n "$WINDOWS_ARM64_TEST_EXTENSIONS" ]]; then
+        for extension in ${WINDOWS_ARM64_TEST_EXTENSIONS//,/ }
+        do
+            extensionName=$(basename $extension)
+            extensionName=$(echo "$extensionName" | cut -d'.' -f1)
+            echo "$FILE" | cut -d'.' -f2
+            ./build/fleetctl updates add \
+                --path $TUF_PATH \
+                --target $extension \
+                --platform windows-arm64 \
                 --name "extensions/$extensionName" \
                 --version $ORBIT_VERSION -t $ORBIT_MAJOR.$ORBIT_MINOR -t $ORBIT_MAJOR -t stable
         done


### PR DESCRIPTION
This was required to test https://github.com/fleetdm/fleet/pull/30864 on Apple Silicon.

I've created https://github.com/fleetdm/fleet/issues/31092 for tracking purposes.

Fixes:
- Build univeral binary extension on macOS to test on VMs without Rosetta.
- Add support for linux and Windows arm64. Which is also needed to test Linux and Windows on UTM on Apple Silicon.
- Add Linux arm64 & Windows arm64 to the test scripts.

---

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.
- [X] Added/updated automated tests
- [X] Manual QA for all new/changed functionality
- For Orbit and Fleet Desktop changes:
   - [X] Make sure fleetd is compatible with the latest released version of Fleet (see [Must rule](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/workflows/fleetd-development-and-release-strategy.md)).
   - [x] Orbit runs on macOS, Linux and Windows. Check if the orbit feature/bugfix should only apply to one platform (`runtime.GOOS`).
   - [x] Manual QA must be performed in the three main OSs, macOS, Windows and Linux.
   - [x] Auto-update manual QA, from released version of component to new version (see [tools/tuf/test](../tools/tuf/test/README.md)).