### PR TITLE
CIS Benchmarks: remove version note from policies YAML

### DIFF
--- a/ee/cis/macos-13/cis-policy-queries.yml
+++ b/ee/cis/macos-13/cis-policy-queries.yml
@@ -1,5 +1,4 @@
 ---
-# The latest version of CIS Benchmarks for macOS as of November 2024 was used which was benchmark 3.0.0 for macOS 13
 apiVersion: v1
 kind: policy
 spec:

--- a/ee/cis/macos-14/cis-policy-queries.yml
+++ b/ee/cis/macos-14/cis-policy-queries.yml
@@ -1,5 +1,4 @@
 ---
-# The latest version of CIS Benchmarks for macOS as of November 2024 for macOS 14.
 apiVersion: v1
 kind: policy
 spec:

--- a/ee/cis/macos-15/cis-policy-queries.yml
+++ b/ee/cis/macos-15/cis-policy-queries.yml
@@ -1,5 +1,4 @@
 ---
-# The latest version of CIS Benchmarks for macOS as of November 2024 for macOS 15.
 apiVersion: v1
 kind: policy
 spec:

--- a/ee/cis/win-10/cis-policy-queries.yml
+++ b/ee/cis/win-10/cis-policy-queries.yml
@@ -1,5 +1,4 @@
 ---
-# The latest version of CIS Benchmarks for Windows 10 Enterprise is version 1.12.0
 apiVersion: v1
 kind: policy
 spec:

--- a/ee/cis/win-11/cis-policy-queries.yml
+++ b/ee/cis/win-11/cis-policy-queries.yml
@@ -1,5 +1,4 @@
 ---
-# The latest version of CIS Benchmarks for Windows 11 Enterprise is version v3.0.0 - 02-22-2024
 apiVersion: v1
 kind: policy
 spec:


### PR DESCRIPTION
- @noahtalerman: It was out of date for Windows 11. We show the version in the READMEs. For example, here's the [Windows README](https://github.com/fleetdm/fleet/tree/main/ee/cis/win-11).
