### PR TITLE
Add service discovery API endpoint

### DIFF
--- a/cmd/fleet/serve.go
+++ b/cmd/fleet/serve.go
@@ -1206,6 +1206,7 @@ the way that the Fleet server works.
 					mdmCheckinAndCommandService,
 					ddmService,
 					commander,
+					appCfg.ServerSettings.ServerURL,
 				); err != nil {
 					initFatal(err, "setup mdm apple services")
 				}

--- a/server/mdm/apple/apple_mdm.go
+++ b/server/mdm/apple/apple_mdm.go
@@ -36,6 +36,8 @@ const (
 	SCEPPath = "/mdm/apple/scep"
 	// MDMPath is Fleet's HTTP path for the core MDM service.
 	MDMPath = "/mdm/apple/mdm"
+	// MDMServiceDiscoveryPath is Fleet's HTTP path for the MDM service discovery service.
+	ServiceDiscoveryPath = "/mdm/apple/service_discovery"
 
 	// EnrollPath is the HTTP path that serves the mobile profile to devices when enrolling.
 	EnrollPath = "/api/mdm/apple/enroll"

--- a/server/service/handler.go
+++ b/server/service/handler.go
@@ -1138,15 +1138,14 @@ func RegisterAppleMDMProtocolServices(
 	if err := registerMDM(mux, mdmStorage, checkinAndCommandService, ddmService, profileService, logger); err != nil {
 		return fmt.Errorf("mdm: %w", err)
 	}
-	if err := registerServiceDiscovery(mux, mdmStorage, logger, serverURLPrefix); err != nil {
+	if err := registerMDMServiceDiscovery(mux, logger, serverURLPrefix); err != nil {
 		return fmt.Errorf("service discovery: %w", err)
 	}
 	return nil
 }
 
-func registerServiceDiscovery(
+func registerMDMServiceDiscovery(
 	mux *http.ServeMux,
-	mdmStorage fleet.MDMAppleStore,
 	logger kitlog.Logger,
 	serverURLPrefix string,
 ) error {

--- a/server/service/handler.go
+++ b/server/service/handler.go
@@ -1150,7 +1150,7 @@ func registerMDMServiceDiscovery(
 	serverURLPrefix string,
 ) error {
 	serviceDiscoveryLogger := kitlog.With(logger, "component", "mdm-apple-service-discovery")
-	fullMDMEnrollmentURL := fmt.Sprintf("%s%s", serverURLPrefix, apple_mdm.EnrollPath)
+	fullMDMEnrollmentURL := fmt.Sprintf("%s%s", serverURLPrefix, apple_mdm.AccountDrivenEnrollPath)
 	serviceDiscoveryHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		serviceDiscoveryLogger.Log("msg", "serving MDM service discovery response", "url", fullMDMEnrollmentURL)
 		w.Header().Set("Content-Type", "application/json")

--- a/server/service/handler.go
+++ b/server/service/handler.go
@@ -1155,7 +1155,7 @@ func registerMDMServiceDiscovery(
 		serviceDiscoveryLogger.Log("msg", "serving MDM service discovery response", "url", fullMDMEnrollmentURL)
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		_, err := w.Write([]byte(fmt.Sprintf(`{"Servers":[{"Version": "mdm-byod", "BaseURL": "%s"}]}`, fullMDMEnrollmentURL)))
+		_, err := fmt.Fprintf(w, `{"Servers":[{"Version": "mdm-byod", "BaseURL": "%s"}]}`, fullMDMEnrollmentURL)
 		if err != nil {
 			serviceDiscoveryLogger.Log("err", "error writing service discovery response", "err", err)
 			http.Error(w, "Internal Server Error", http.StatusInternalServerError)

--- a/server/service/handler.go
+++ b/server/service/handler.go
@@ -1150,10 +1150,10 @@ func registerServiceDiscovery(
 	logger kitlog.Logger,
 	serverURLPrefix string,
 ) error {
-	fmt.Println("Registering service discovery handler for Apple MDM")
+	serviceDiscoveryLogger := kitlog.With(logger, "component", "mdm-apple-service-discovery")
 	fullMDMEnrollmentURL := fmt.Sprintf("%s%s", serverURLPrefix, apple_mdm.EnrollPath)
-	fmt.Println("Full MDM Enrollment URL:", fullMDMEnrollmentURL)
 	serviceDiscoveryHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		serviceDiscoveryLogger.Log("msg", "serving MDM service discovery response", "url", fullMDMEnrollmentURL)
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 		w.Write([]byte(fmt.Sprintf(`{"Servers":[{"Version": "mdm-byod", "BaseURL": "%s"}]}`, fullMDMEnrollmentURL)))

--- a/server/service/testing_utils.go
+++ b/server/service/testing_utils.go
@@ -429,6 +429,7 @@ func RunServerForTestsWithServiceWithDS(t *testing.T, ctx context.Context, ds fl
 					logger: logger,
 				},
 				commander,
+				"https://test-url.com",
 			)
 			require.NoError(t, err)
 		}


### PR DESCRIPTION
relates to #31057 

adds an endpoint to expose the fleet handled service discovery endpoint.

> NOTE: test will be done in a follow up PR

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.