### PR TITLE
Add ability to determine Bitlocker protectors

### DIFF
--- a/orbit/changes/28133-require-bitlocker-pin
+++ b/orbit/changes/28133-require-bitlocker-pin
@@ -1,0 +1,1 @@
+* Added new Fleetd table 'bitlocker_key_protectors' that returns what key protectors are setup on the system.

--- a/orbit/pkg/table/bitlocker_key_protectors/bitlocker_key_protectors.go
+++ b/orbit/pkg/table/bitlocker_key_protectors/bitlocker_key_protectors.go
@@ -1,0 +1,87 @@
+//go:build windows
+// +build windows
+
+package bitlocker_key_protectors
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"github.com/fleetdm/fleet/v4/orbit/pkg/table/tablehelpers"
+	"github.com/osquery/osquery-go/plugin/table"
+	"github.com/rs/zerolog"
+)
+
+const name = "bitlocker_key_protectors"
+
+type KeyProtector struct {
+	KeyProtector int `json:"KeyProtectorType"`
+}
+
+type BitLockerVolume struct {
+	MountPoint    string         `json:"MountPoint"`
+	KeyProtectors []KeyProtector `json:"KeyProtector"`
+}
+
+type Table struct {
+	logger zerolog.Logger
+}
+
+func TablePlugin(logger zerolog.Logger) *table.Plugin {
+	columns := []table.ColumnDefinition{
+		table.TextColumn("drive_letter"),
+		table.IntegerColumn("key_protector_type"),
+	}
+
+	t := &Table{
+		logger: logger.With().Str("table", name).Logger(),
+	}
+
+	return table.NewPlugin(name, columns, t.generate)
+}
+
+func (t *Table) generate(
+	ctx context.Context,
+	queryContext table.QueryContext,
+) ([]map[string]string, error) {
+
+	output, err := tablehelpers.Exec(
+		ctx,
+		t.logger,
+		30,
+		[]string{"powershell.exe"},
+		[]string{
+			"-NoProfile",
+			"-Command",
+			"Get-BitLockerVolume | ConvertTo-Json -Depth 5",
+		}, true)
+
+	if err != nil {
+		t.logger.Info().Err(err).Msg("failed to get BitLocker volume data")
+		return nil, fmt.Errorf("failed to get BitLocker volume data: %w", err)
+	}
+
+	return t.parseOutput(output)
+
+}
+
+func (t *Table) parseOutput(output []byte) ([]map[string]string, error) {
+	var results []map[string]string
+
+	var volumes []BitLockerVolume
+	if err := json.Unmarshal(output, &volumes); err != nil {
+		t.logger.Info().Err(err).Msg("failed to parse BitLocker volume data")
+		return nil, fmt.Errorf("failed to parse BitLocker volume data: %w", err)
+	}
+
+	for _, volume := range volumes {
+		for _, protector := range volume.KeyProtectors {
+			results = append(results, map[string]string{
+				"drive_letter":       volume.MountPoint,
+				"key_protector_type": fmt.Sprintf("%d", protector.KeyProtector),
+			})
+		}
+	}
+
+	return results, nil
+}

--- a/orbit/pkg/table/bitlocker_key_protectors/bitlocker_key_protectors_test.go
+++ b/orbit/pkg/table/bitlocker_key_protectors/bitlocker_key_protectors_test.go
@@ -1,0 +1,117 @@
+//go:build windows
+// +build windows
+
+package bitlocker_key_protectors
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/rs/zerolog"
+)
+
+func TestTable_parseOutput(t *testing.T) {
+	// Sample JSON output from Get-BitLockerVolume | ConvertTo-Json
+	jsonOutput := `
+[{
+    "ComputerName":  "WIN-VM",
+    "MountPoint":  "C:",
+    "EncryptionMethod":  6,
+    "EncryptionMethodFlags":  0,
+    "AutoUnlockEnabled":  null,
+    "AutoUnlockKeyStored":  false,
+    "MetadataVersion":  2,
+    "VolumeStatus":  1,
+    "ProtectionStatus":  1,
+    "LockStatus":  0,
+    "EncryptionPercentage":  100,
+    "WipePercentage":  0,
+    "VolumeType":  0,
+    "CapacityGB":  475.77832,
+    "KeyProtector":  [
+	 {
+		 "KeyProtectorId":  "{8A696888-99A7-4FAC-92C7-6CC497EA7BDF}",
+		 "AutoUnlockProtector":  null,
+		 "KeyProtectorType":  3,
+		 "KeyFileName":  "",
+		 "RecoveryPassword":  "254793-568007-425557-712855-251119-474815-445082-696212",
+		 "KeyCertificateType":  null,
+		 "Thumbprint":  ""
+	 },
+	 {
+		 "KeyProtectorId":  "{3B3E091C-ECB9-4B46-9FDD-A9E699EC3C8C}",
+		 "AutoUnlockProtector":  null,
+		 "KeyProtectorType":  1,
+		 "KeyFileName":  "",
+		 "RecoveryPassword":  "",
+		 "KeyCertificateType":  null,
+		 "Thumbprint":  ""
+	 }
+ ]
+}, {
+	"ComputerName":  "WIN-VM",
+	"MountPoint":  "E:",
+	"EncryptionMethod":  0,
+	"EncryptionMethodFlags":  0,
+	"AutoUnlockEnabled":  null,
+	"AutoUnlockKeyStored":  null,
+	"MetadataVersion":  0,
+	"VolumeStatus":  0,
+	"ProtectionStatus":  0,
+	"LockStatus":  0,
+	"EncryptionPercentage":  0,
+	"WipePercentage":  0,
+	"VolumeType":  1,
+	"CapacityGB":  57.7006836,
+	"KeyProtector":  []
+}]`
+	table := &Table{
+		logger: zerolog.New(zerolog.NewTestWriter(t)),
+	}
+
+	expected := []map[string]string{
+		{
+			"drive_letter":       "C:",
+			"key_protector_type": "3",
+		},
+		{
+			"drive_letter":       "C:",
+			"key_protector_type": "1",
+		},
+	}
+
+	results, err := table.parseOutput([]byte(jsonOutput))
+	if err != nil {
+		t.Fatalf("parseOutput() error = %v", err)
+	}
+
+	if !reflect.DeepEqual(results, expected) {
+		t.Errorf("parseOutput() = %v, want %v", results, expected)
+	}
+}
+
+func TestTable_parseOutput_InvalidJSON(t *testing.T) {
+	table := &Table{
+		logger: zerolog.New(zerolog.NewTestWriter(t)),
+	}
+
+	_, err := table.parseOutput([]byte(`invalid json`))
+	if err == nil {
+		t.Error("parseOutput() with invalid JSON should return error")
+	}
+}
+
+func TestTable_parseOutput_EmptyInput(t *testing.T) {
+	table := &Table{
+		logger: zerolog.New(zerolog.NewTestWriter(t)),
+	}
+
+	results, err := table.parseOutput([]byte(`[]`))
+	if err != nil {
+		t.Fatalf("parseOutput() error = %v", err)
+	}
+
+	if len(results) != 0 {
+		t.Errorf("parseOutput() with empty input should return empty results, got %v", results)
+	}
+}

--- a/orbit/pkg/table/extension_windows.go
+++ b/orbit/pkg/table/extension_windows.go
@@ -4,7 +4,7 @@ package table
 
 import (
 	"fmt"
-
+	"github.com/fleetdm/fleet/v4/orbit/pkg/table/bitlocker_key_protectors"
 	cisaudit "github.com/fleetdm/fleet/v4/orbit/pkg/table/cis_audit"
 	mdmbridge "github.com/fleetdm/fleet/v4/orbit/pkg/table/mdm"
 	"github.com/fleetdm/fleet/v4/orbit/pkg/table/windowsupdatetable"
@@ -19,6 +19,8 @@ func PlatformTables(_ PluginOpts) ([]osquery.OsqueryPlugin, error) {
 	plugins := []osquery.OsqueryPlugin{
 		// Fleet tables
 		table.NewPlugin("cis_audit", cisaudit.Columns(), cisaudit.Generate),
+
+		bitlocker_key_protectors.TablePlugin(log.Logger),
 
 		windowsupdatetable.TablePlugin(windowsupdatetable.UpdatesTable, log.Logger), // table name is "windows_updates"
 	}

--- a/schema/osquery_fleet_schema.json
+++ b/schema/osquery_fleet_schema.json
@@ -2420,6 +2420,32 @@
     "fleetRepoUrl": "https://github.com/fleetdm/fleet/blob/main/schema/tables/bitlocker_info.yml"
   },
   {
+    "name": "bitlocker_key_protectors",
+    "description": "Returns what BitLocker key protectors are setup on the system.",
+    "evented": false,
+    "notes": "This table is not a core osquery table. It is included as part of Fleet's agent ([fleetd](https://fleetdm.com/docs/get-started/anatomy#fleetd)).",
+    "platforms": [
+      "windows"
+    ],
+    "columns": [
+      {
+        "name": "drive_letter",
+        "description": "The drive letter of the volume.",
+        "required": false,
+        "type": "text"
+      },
+      {
+        "name": "key_protector_type",
+        "required": false,
+        "type": "integer",
+        "description": "An unsigned integer that specifies the type of key protector.\nSee https://learn.microsoft.com/en-us/windows/win32/secprov/getkeyprotectors-win32-encryptablevolume#parameters\nfor a list of possible values.\n"
+      }
+    ],
+    "examples": "Determine whether 'C:' encryption key is protected by TPM and PIN\n```\nSELECT 1 FROM bitlocker_key_protectors WHERE drive_letter = 'C:' AND key_protector_type = 4;\n```",
+    "url": "https://fleetdm.com/tables/bitlocker_key_protectors",
+    "fleetRepoUrl": "https://github.com/fleetdm/fleet/blob/main/schema/tables/bitlocker_key_protectors.yml"
+  },
+  {
     "name": "block_devices",
     "description": "Block (buffered access) device file nodes: disks, ramdisks, and DMG containers.",
     "url": "https://fleetdm.com/tables/block_devices",

--- a/schema/tables/bitlocker_key_protectors.yml
+++ b/schema/tables/bitlocker_key_protectors.yml
@@ -1,0 +1,23 @@
+name: bitlocker_key_protectors
+description: Returns what BitLocker key protectors are setup on the system.
+evented: false
+notes: This table is not a core osquery table. It is included as part of Fleet's agent ([fleetd](https://fleetdm.com/docs/get-started/anatomy#fleetd)).
+platforms:
+  - windows
+columns:
+  - name: drive_letter
+    description: The drive letter of the volume.
+    required: false
+    type: text
+  - name: key_protector_type
+    required: false
+    type: integer
+    description: |
+      An unsigned integer that specifies the type of key protector.
+      See https://learn.microsoft.com/en-us/windows/win32/secprov/getkeyprotectors-win32-encryptablevolume#parameters
+      for a list of possible values.
+examples: |-
+  Determine whether 'C:' encryption key is protected by TPM and PIN
+  ```
+  SELECT 1 FROM bitlocker_key_protectors WHERE drive_letter = 'C:' AND key_protector_type = 4;
+  ```


### PR DESCRIPTION
For #31062:

Added new Fleetd table 'bitlocker_key_protectors' that can be used for determining whether a TPM PIN protector is setup in a volume.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.
- [X] Manual QA for all new/changed functionality