### PR TITLE
Refresh story descriptions from template during design sprint kickoff

### DIFF
--- a/handbook/product-design/product-design.rituals.yml
+++ b/handbook/product-design/product-design.rituals.yml
@@ -16,7 +16,7 @@
   task: "Product design sprint kickoff" # 2024-03-06 TODO: Link to responsibility or corresponding "how to" info e.g. https://fleetdm.com/handbook/company/product-groups#making-changes
   startedOn: "2024-03-07" 
   frequency: "Triweekly" 
-  description: "Review stories (and, as needed, create engineering research stories) for feature requests prioritized during Feature fest; assign Engineering DRIs to stories; align on priorities; and create an upcoming reference docs release branch."
+  description: "Review stories (and, as needed, create engineering research stories) for feature requests prioritized during Feature fest; refresh descriptions from the latest story template; assign Engineering DRIs to stories; align on priorities; and create an upcoming reference docs release branch."
   moreInfoUrl: 
   dri: "noahtalerman"
 -


### PR DESCRIPTION
Proposing we add a ritual to refresh story descriptions based on the latest story template.  Why?  We bring in stories into the design sprint that were created before changes were made and refreshing the description ensures we don't miss important scope discussions.  This came up today during user story review where we almost missed gitops changes because the story description didn't have the associated checkboxes.

Additional question: Is there anywhere else we need to document this so we don't forget?