### PR TITLE
Disable service discovery for Apple account-driven enrollment to faciliate dev testing

### DIFF
--- a/cmd/fleet/cron.go
+++ b/cmd/fleet/cron.go
@@ -1284,25 +1284,26 @@ func newWindowsMDMProfileManagerSchedule(
 	return s, nil
 }
 
-func newMDMAppleServiceDiscoverySchedule(
-	ctx context.Context,
-	instanceID string,
-	ds fleet.Datastore,
-	depStorage *mysql.NanoDEPStorage,
-	logger kitlog.Logger,
-) (*schedule.Schedule, error) {
-	const name = "mdm_service_discovery"
-	interval := 1 * time.Hour
-	logger = kitlog.With(logger, "cron", name)
-	s := schedule.New(
-		ctx, name, instanceID, interval, ds, ds,
-		schedule.WithLogger(logger),
-		schedule.WithJob("mdm_apple_account_driven_enrollment_profile", func(ctx context.Context) error {
-			return service.EnsureMDMAppleServiceDiscovery(ctx, ds, depStorage, logger)
-		}),
-	)
-	return s, nil
-}
+// // TODO(BMAA): Uncomment this when ready to test Apple account-driven enrollment flow
+// func newMDMAppleServiceDiscoverySchedule(
+// 	ctx context.Context,
+// 	instanceID string,
+// 	ds fleet.Datastore,
+// 	depStorage *mysql.NanoDEPStorage,
+// 	logger kitlog.Logger,
+// ) (*schedule.Schedule, error) {
+// 	const name = "mdm_service_discovery"
+// 	interval := 1 * time.Hour
+// 	logger = kitlog.With(logger, "cron", name)
+// 	s := schedule.New(
+// 		ctx, name, instanceID, interval, ds, ds,
+// 		schedule.WithLogger(logger),
+// 		schedule.WithJob("mdm_apple_account_driven_enrollment_profile", func(ctx context.Context) error {
+// 			return service.EnsureMDMAppleServiceDiscovery(ctx, ds, depStorage, logger)
+// 		}),
+// 	)
+// 	return s, nil
+// }
 
 func newMDMAPNsPusher(
 	ctx context.Context,

--- a/cmd/fleet/serve.go
+++ b/cmd/fleet/serve.go
@@ -946,11 +946,12 @@ the way that the Fleet server works.
 				initFatal(err, "failed to register apple_mdm_dep_profile_assigner schedule")
 			}
 
-			if err := cronSchedules.StartCronSchedule(func() (fleet.CronSchedule, error) {
-				return newMDMAppleServiceDiscoverySchedule(ctx, instanceID, ds, depStorage, logger)
-			}); err != nil {
-				initFatal(err, "failed to register mdm_apple_service_discovery schedule")
-			}
+			// // TODO(BMAA): uncomment this to enable MDM Apple Service Discovery
+			// if err := cronSchedules.StartCronSchedule(func() (fleet.CronSchedule, error) {
+			// 	return newMDMAppleServiceDiscoverySchedule(ctx, instanceID, ds, depStorage, logger)
+			// }); err != nil {
+			// 	initFatal(err, "failed to register mdm_apple_service_discovery schedule")
+			// }
 
 			if err := cronSchedules.StartCronSchedule(func() (fleet.CronSchedule, error) {
 				return newAppleMDMProfileManagerSchedule(

--- a/website/config/routes.js
+++ b/website/config/routes.js
@@ -1056,6 +1056,10 @@ module.exports.routes = {
 
   // Well known resources https://datatracker.ietf.org/doc/html/rfc8615
   // =============================================================================================================
-  // Temporary enroll endpoint for https://github.com/fleetdm/fleet/issues/27390
-  'GET /.well-known/com.apple.remotemanagement': (req, res)=>{ return res.json({'Servers':[{'Version':'mdm-byod', 'BaseURL':'https://jordan-fleetdm.ngrok.app/api/mdm/apple/account_driven_enroll'}]});},
+  //
+  // Service discovery for Apple account-driven enrollment, see
+  // https://developer.apple.com/documentation/devicemanagement/implementing-the-simple-authentication-user-enrollment-flow#Send-the-well-known-request
+  //
+  // TODO(BMAA): Uncomment this when we are ready to dogfood the Apple account-driven enrollment flow.
+  // 'GET /.well-known/com.apple.remotemanagement': (req, res)=>{ return res.json({'Servers':[{'Version':'mdm-byod', 'BaseURL':'https://dogfood.fleetdm.com/api/mdm/apple/account_driven_enroll'}]});},
 };


### PR DESCRIPTION
For #30626 

Temporary changes so that developers can work on this story in parallel without overwriting each others changes in ABM.

- Update fleetdm.com routes to disable `/.well-known` resource
- Disable `mdm_apple_service_discovery` cron 
