### PR TITLE
Use ASN.1 format to store TPM child key

### DIFF
--- a/ee/orbit/pkg/securehw/securehw_linux.go
+++ b/ee/orbit/pkg/securehw/securehw_linux.go
@@ -144,7 +144,7 @@ func (t *tpm2TEE) CreateKey() (Key, error) {
 
 	if err := t.saveTPMKeyFile(createKey.OutPrivate, createKey.OutPublic); err != nil {
 		cleanUpOnError()
-		return nil, fmt.Errorf("write TPM blobs to files: %w", err)
+		return nil, fmt.Errorf("write TPM keyfile to file: %w", err)
 	}
 
 	// Create and return the key
@@ -268,7 +268,7 @@ func (t *tpm2TEE) saveTPMKeyFile(privateKey tpm2.TPM2BPrivate, publicKey tpm2.TP
 		keyfile.WithDescription("fleetd httpsig key"),
 	)
 	if err := os.WriteFile(t.keyFilePath, k.Bytes(), 0o600); err != nil {
-		return fmt.Errorf("failed to save key file: %w", err)
+		return fmt.Errorf("failed to save keyfile: %w", err)
 	}
 	return nil
 }
@@ -286,11 +286,6 @@ func (t *tpm2TEE) loadTPMKeyFile() (privateKey *tpm2.TPM2BPrivate, publicKey *tp
 		return nil, nil, fmt.Errorf("failed to decode keyfile: %w", err)
 	}
 	return &k.Privkey, &k.Pubkey, nil
-}
-
-type blobs struct {
-	private *tpm2.TPM2BPrivate
-	public  *tpm2.TPM2BPublic
 }
 
 // LoadKey partially implements TEE.
@@ -340,7 +335,7 @@ func (t *tpm2TEE) LoadKey() (Key, error) {
 
 	t.logger.Info().
 		Str("handle", fmt.Sprintf("0x%x", loadedKey.ObjectHandle)).
-		Msg("key loaded from blobs successfully")
+		Msg("key loaded successfully")
 
 	return &tpm2Key{
 		tpm: t.device,

--- a/go.mod
+++ b/go.mod
@@ -231,6 +231,7 @@ require (
 	github.com/emirpasic/gods v1.18.1 // indirect
 	github.com/fatih/structs v1.1.0 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
+	github.com/foxboron/go-tpm-keyfiles v0.0.0-20250520203025-c3c3a4ec1653 // indirect
 	github.com/fsnotify/fsnotify v1.8.0 // indirect
 	github.com/garyburd/go-oauth v0.0.0-20180319155456-bca2e7f09a17 // indirect
 	github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376 // indirect

--- a/go.sum
+++ b/go.sum
@@ -344,6 +344,8 @@ github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSw
 github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568/go.mod h1:xEzjJPgXI435gkrCt3MPfRiAkVrwSbHsst4LCFVfpJc=
 github.com/fortytw2/leaktest v1.3.0 h1:u8491cBMTQ8ft8aeV+adlcytMZylmA5nnwwkRZjI8vw=
 github.com/fortytw2/leaktest v1.3.0/go.mod h1:jDsjWgpAGjm2CA7WthBh/CdZYEPF31XHquHwclZch5g=
+github.com/foxboron/go-tpm-keyfiles v0.0.0-20250520203025-c3c3a4ec1653 h1:QpQsORx5N2EwomFMgeeY2Vzjf4h3nS2XtD8ETonNJVY=
+github.com/foxboron/go-tpm-keyfiles v0.0.0-20250520203025-c3c3a4ec1653/go.mod h1:uAyTlAUxchYuiFjTHmuIEJ4nGSm7iOPaGcAyA81fJ80=
 github.com/foxcpp/go-mockdns v1.1.0 h1:jI0rD8M0wuYAxL7r/ynTrCQQq0BVqfB99Vgk7DlmewI=
 github.com/foxcpp/go-mockdns v1.1.0/go.mod h1:IhLeSFGed3mJIAXPH2aiRQB+kqz7oqu8ld2qVbOu7Wk=
 github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHkI4W8=


### PR DESCRIPTION
#31047

We were storing public key bytes and encrypted private key bytes as raw files called `tpm_cms_pub.blob` and `tpm_cms_priv.blob` respectively. This PR changes to use a better format on a single file that looks like this:
```
"-----BEGIN TSS2 PRIVATE KEY-----"
[...]
"-----END TSS2 PRIVATE KEY-----"
```

(We haven't released this feature yet so we don't need a migration.)