### PR TITLE
BMAA API Contributor docs WIP

### DIFF
--- a/docs/Contributing/reference/api-for-contributors.md
+++ b/docs/Contributing/reference/api-for-contributors.md
@@ -1046,7 +1046,7 @@ If no team (id or name) is provided, the profiles are applied for all hosts (for
 
 `204`
 
-### Initiate SSO during DEP enrollment
+### Initiate SSO during DEP or Account Driven MDM enrollment
 
 This endpoint initiates the SSO flow, the response contains an URL that the client can use to redirect the user to initiate the SSO flow in the configured IdP.
 
@@ -1054,7 +1054,9 @@ This endpoint initiates the SSO flow, the response contains an URL that the clie
 
 #### Parameters
 
-None.
+| Name | Type | In | Description |
+| ---- | ---- | -- | ----------- |
+| initiator | string | body | Used to differentiate between account driven enrollment and DEP or other flows for SSO callback purposes. The callback will use the Account Driven Enrollment behavior if `account_driven_enroll` is passed as the value of this parameter |
 
 #### Example
 
@@ -1068,7 +1070,7 @@ None.
 }
 ```
 
-### Complete SSO during DEP enrollment
+### Complete SSO during DEP or Account Driven enrollment
 
 This is the callback endpoint that the identity provider will use to send security assertions to Fleet. This is where Fleet receives and processes the response from the identify provider.
 
@@ -1096,11 +1098,22 @@ This is the callback endpoint that the identity provider will use to send securi
 
 `Status: 302`
 
-If the credentials are valid, the server redirects the client to the Fleet UI. The URL contains the following query parameters that can be used to complete the DEP enrollment flow:
+If the credentials are valid and no value was passed for the `initiator` parameter during initiation
+of SSO, the server redirects the client to the Fleet UI. The URL contains the
+following query parameters that can be used to complete the DEP enrollment flow:
 
 - `enrollment_reference` a reference that must be passed along with `profile_token` to the endpoint to download an enrollment profile.
 - `profile_token` is a token that can be used to download an enrollment profile (.mobileconfig).
 - `eula_token` (optional) if an EULA was uploaded, this contains a token that can be used to view the EULA document.
+
+If the credentials are valid and `account_driven_enroll` was passed for the `initiator` parameter
+during initiation of SSO, the server redirects the client to
+apple-remotemanagement-user-login://authentication-results . The URL contains the following query
+parameter which is used by the Apple MDM client on the device to complete the account driven
+enrollment flow:
+
+ - `access-token` a token that is passed by the device in the Authorization header on the second call to the Account Driven
+   Enrollment endpoint to download an enrollment profile.
 
 ### Over the air enrollment
 
@@ -1415,6 +1428,24 @@ Android Enterprise successfully connected
 This endpoint is used by Google Pub/Sub subscription to push messages to Fleet.
 
 `POST /api/v1/fleet/android_enterprise/pubsub`
+
+### Get Apple Account Driven User Enrollment Profile
+
+This endpoint initiates Account Driven User Enrollment on iOS and iPadOS devices and is used by the
+Apple. Devices are directed to this endpoint via Apple Account Driven Enrollment service discovery.
+The first request made to this endpoint is unauthenticated and will return a 401 Unauthorized
+including a Www-Authenticate header with a URL redirecting them to /mdm/sso. After authentication,
+the client will return to this endpoint and make a second request including the returned token in
+the Authorization header and an enrollment profile will be returned. Devices that fail to identify
+via plist or that identify as other than iPhone or iPad will return a 400 Bad Request.
+
+`POST /api/mdm/apple/account_driven_enroll`
+
+#### Parameters
+
+A plist including LANGUAGE, VERSION, PRODUCT, SOFTWARE_UPDATE_DEVICE_ID, SUPPLEMENTAL_BUILD_VERSION
+and VERSION
+
 
 
 ## Get or apply configuration files


### PR DESCRIPTION
relates to #31058 


API doc updates BMAA feature

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [ ] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.
- [ ] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [ ] Added support on fleet's osquery simulator `cmd/osquery-perf` for new osquery data ingestion features.
- [ ] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes
- [ ] If database migrations are included, checked table schema to confirm autoupdate
- For new Fleet configuration settings
  - [ ] Verified that the setting can be managed via GitOps, or confirmed that the setting is explicitly being excluded from GitOps.  If managing via Gitops:
    - [ ] Verified that the setting is exported via `fleetctl generate-gitops`
    - [ ] Added the setting to [the GitOps documentation](https://github.com/fleetdm/fleet/blob/main/docs/Configuration/yaml-files.md#L485)
    - [ ] Verified that the setting is cleared on the server if it is not supplied in a YAML file (or that it is documented as being optional)
    - [ ] Verified that any relevant UI is disabled when GitOps mode is enabled
- For database migrations:
  - [ ] Checked schema for all modified table for columns that will auto-update timestamps during migration.
  - [ ] Confirmed that updating the timestamps is acceptable, and will not cause unwanted side effects.
  - [ ] Ensured the correct collation is explicitly set for character columns (`COLLATE utf8mb4_unicode_ci`).
- [ ] Added/updated automated tests
  - [ ] Where appropriate, automated tests simulate multiple hosts and test for host isolation (updates to one hosts's records do not affect another.)
- [ ] Manual QA for all new/changed functionality
- For Orbit and Fleet Desktop changes:
   - [ ] Make sure fleetd is compatible with the latest released version of Fleet (see [Must rule](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/workflows/fleetd-development-and-release-strategy.md)).
   - [ ] Orbit runs on macOS, Linux and Windows. Check if the orbit feature/bugfix should only apply to one platform (`runtime.GOOS`).
   - [ ] Manual QA must be performed in the three main OSs, macOS, Windows and Linux.
   - [ ] Auto-update manual QA, from released version of component to new version (see [tools/tuf/test](../tools/tuf/test/README.md)).
- [ ] For unreleased bug fixes in a release candidate, confirmed that the fix is not expected to adversely impact load test results or alerted the release DRI if additional load testing is needed.
