### PR TITLE
Rename flags and types for TPM work

### DIFF
--- a/changes/30461-fleetd-generate-tpm-key
+++ b/changes/30461-fleetd-generate-tpm-key
@@ -1,1 +1,1 @@
-* Added flag `--fleet-managed-client-certificate` to generate fleetd packages for linux that use TPMs to sign HTTP requests.
+- Added flag `--fleet-managed-host-identity-certificate` to generate fleetd packages for linux that use TPMs to sign HTTP requests.

--- a/cmd/fleetctl/fleetctl/package.go
+++ b/cmd/fleetctl/fleetctl/package.go
@@ -256,10 +256,10 @@ func packageCommand() *cli.Command {
 				Destination: &opt.CustomOutfile,
 			},
 			&cli.BoolFlag{
-				Name:        "fleet-managed-client-certificate",
+				Name:        "fleet-managed-host-identity-certificate",
 				Usage:       "Configures fleetd to use TPM-backed key to sign HTTP requests. This functionality is licensed under the Fleet EE License. Usage requires a current Fleet EE subscription.",
-				EnvVars:     []string{"FLEETCTL_FLEET_MANAGED_CLIENT_CERTIFICATE"},
-				Destination: &opt.FleetManagedClientCertificate,
+				EnvVars:     []string{"FLEETCTL_FLEET_MANAGED_HOST_IDENTITY_CERTIFICATE"},
+				Destination: &opt.FleetManagedHostIdentityCertificate,
 			},
 		},
 		Action: func(c *cli.Context) error {
@@ -291,12 +291,12 @@ func packageCommand() *cli.Command {
 				}
 			}
 
-			if opt.FleetManagedClientCertificate {
+			if opt.FleetManagedHostIdentityCertificate {
 				if c.String("type") != "deb" && c.String("type") != "rpm" {
-					return errors.New("--fleet-managed-client-certificate is only supported for deb/rpm packages")
+					return errors.New("--fleet-managed-host-identity-certificate is only supported for deb/rpm packages")
 				}
 				if opt.FleetTLSClientCertificate != "" {
-					return errors.New("--fleet-managed-client-certificate and --fleet-tls-client-certificate may not be provided together")
+					return errors.New("--fleet-managed-host-identity-certificate and --fleet-tls-client-certificate may not be provided together")
 				}
 			}
 

--- a/ee/orbit/pkg/hostidentity/host_identity.go
+++ b/ee/orbit/pkg/hostidentity/host_identity.go
@@ -25,7 +25,7 @@ type Credentials struct {
 	// CertificatePath is the file path to the public certificate issued via SCEP.
 	CertificatePath string
 
-	secureHW securehw.TEE
+	secureHW securehw.SecureHW
 }
 
 // Close releases key resources.
@@ -33,7 +33,7 @@ func (c *Credentials) Close() {
 	c.secureHW.Close()
 }
 
-// Setup creates a private key using a TEE and generates a new client
+// Setup creates a private key using a SecureHW and generates a new client
 // certificate using SCEP.
 // If there's already a key and certificate in the metadata directory it will return them.
 // The returned Credentials needs to be closed after its use.
@@ -49,7 +49,7 @@ func Setup(
 ) (*Credentials, error) {
 	teeDevice, err := securehw.New(metadataDir, logger)
 	if err != nil {
-		return nil, fmt.Errorf("failed to initialize TEE device: %w", err)
+		return nil, fmt.Errorf("failed to initialize secure hardware device: %w", err)
 	}
 	secureHWKey, err := teeDevice.LoadKey()
 	switch {
@@ -59,10 +59,10 @@ func Setup(
 		// Key doesn't exist yet, let's create it.
 		secureHWKey, err = teeDevice.CreateKey()
 		if err != nil {
-			return nil, fmt.Errorf("failed to create TEE key: %w", err)
+			return nil, fmt.Errorf("failed to create secure hardware key: %w", err)
 		}
 	default:
-		return nil, fmt.Errorf("failed to load TEE key: %w", err)
+		return nil, fmt.Errorf("failed to load secure hardware key: %w", err)
 	}
 
 	clientCert, err := loadSCEPClientCert(metadataDir)

--- a/ee/orbit/pkg/scep/scep_test.go
+++ b/ee/orbit/pkg/scep/scep_test.go
@@ -65,7 +65,7 @@ func TestNewClientValidation(t *testing.T) {
 			errorMsg:    "should fail with empty URL",
 		},
 		{
-			name: "missing TEE",
+			name: "missing SecureHW",
 			options: []Option{
 				WithURL("https://example.com/scep"),
 				WithChallenge("test-challenge"),
@@ -73,7 +73,7 @@ func TestNewClientValidation(t *testing.T) {
 				WithTimeout(ptr.Duration(5 * time.Second)),
 			},
 			expectError: true,
-			errorMsg:    "should fail without TEE",
+			errorMsg:    "should fail without SecureHW",
 		},
 		{
 			name: "all required parameters",
@@ -115,7 +115,7 @@ func TestClient_FetchCert(t *testing.T) {
 
 	t.Run("successful fetch", func(t *testing.T) {
 		signingKey, err := newSigningKey()
-		require.NoError(t, err, "Failed to create test TEE")
+		require.NoError(t, err, "Failed to create test SecureHW")
 
 		// Create a SCEP client with all required parameters
 		client, err := NewClient(
@@ -149,7 +149,7 @@ func TestClient_FetchCert(t *testing.T) {
 
 	t.Run("bad challenge password", func(t *testing.T) {
 		signingKey, err := newSigningKey()
-		require.NoError(t, err, "Failed to create test TEE")
+		require.NoError(t, err, "Failed to create test SecureHW")
 
 		// Create a SCEP client with all required parameters
 		client, err := NewClient(

--- a/ee/orbit/pkg/securehw/example_linux_test.go
+++ b/ee/orbit/pkg/securehw/example_linux_test.go
@@ -29,11 +29,11 @@ func TestExampleTPM20Linux(t *testing.T) {
 	t.Run("CreateKey", func(t *testing.T) {
 		teeDevice, err := securehw.New(tmpDir, logger)
 		if err != nil {
-			log.Fatalf("Failed to initialize TEE: %v", err)
+			log.Fatalf("Failed to initialize SecureHW: %v", err)
 		}
 		defer teeDevice.Close()
 
-		// Create an ECC key in the TEE (automatically selects best curve)
+		// Create an ECC key in the SecureHW (automatically selects best curve)
 		key, err := teeDevice.CreateKey()
 		if err != nil {
 			log.Fatalf("Failed to create key: %v", err)
@@ -47,7 +47,7 @@ func TestExampleTPM20Linux(t *testing.T) {
 		}
 
 		// Sign some data
-		message := []byte("Hello, TEE!")
+		message := []byte("Hello, SecureHW!")
 		hash := sha256.Sum256(message)
 		signature, err := signer.Sign(rand.Reader, hash[:], crypto.SHA256)
 		if err != nil {
@@ -60,7 +60,7 @@ func TestExampleTPM20Linux(t *testing.T) {
 	t.Run("LoadKey", func(t *testing.T) {
 		teeDevice, err := securehw.New(tmpDir, logger)
 		if err != nil {
-			log.Fatalf("Failed to initialize TEE: %v", err)
+			log.Fatalf("Failed to initialize SecureHW: %v", err)
 		}
 		defer teeDevice.Close()
 
@@ -80,7 +80,7 @@ func TestExampleTPM20Linux(t *testing.T) {
 		}
 
 		// Sign some data
-		message := []byte("Hello, TEE!")
+		message := []byte("Hello, SecureHW!")
 		hash := sha256.Sum256(message)
 		signature, err := signer.Sign(rand.Reader, hash[:], crypto.SHA256)
 		if err != nil {

--- a/ee/orbit/pkg/securehw/securehw.go
+++ b/ee/orbit/pkg/securehw/securehw.go
@@ -7,25 +7,25 @@ import (
 	"github.com/rs/zerolog"
 )
 
-// TEE (Trusted Execution Environment) provides an interface for hardware-based
+// SecureHW provides an interface for hardware-based
 // cryptographic operations, such as those performed by a TPM (Trusted Platform Module).
-type TEE interface {
-	// CreateKey creates a new key in the TEE and returns a handle to it.
+type SecureHW interface {
+	// CreateKey creates a new key in the SecureHW and returns a handle to it.
 	// The implementation will automatically choose the best available key type,
 	// preferring ECC P-384 if supported, otherwise falling back to ECC P-256.
 	// Returns a Key interface that can be used for cryptographic operations.
 	CreateKey() (Key, error)
 
 	// LoadKey loads a previously created key from the public and private blobs saved to files.
-	// The blobs are read from the file paths configured when creating the TEE instance.
+	// The blobs are read from the file paths configured when creating the SecureHW instance.
 	// The parent key is the hardcoded Storage Root Key (SRK) handle.
 	LoadKey() (Key, error)
 
-	// Close releases any resources held by the TEE.
+	// Close releases any resources held by the SecureHW.
 	Close() error
 }
 
-// Key represents a key stored in a TEE that can perform cryptographic operations.
+// Key represents a key stored in a SecureHW that can perform cryptographic operations.
 type Key interface {
 	// Signer returns a crypto.Signer that uses this key for signing operations.
 	// The returned Signer is safe for concurrent use.
@@ -35,7 +35,7 @@ type Key interface {
 	// The returned Signer produces fixed-width r||s format signatures.
 	HTTPSigner() (HTTPSigner, error)
 
-	// Public returns the public key associated with this TEE key.
+	// Public returns the public key associated with this SecureHW key.
 	Public() (crypto.PublicKey, error)
 
 	// Close releases any resources associated with this key.
@@ -54,9 +54,9 @@ const (
 	ECCAlgorithmP384
 )
 
-func New(metadataDir string, logger zerolog.Logger) (TEE, error) {
+func New(metadataDir string, logger zerolog.Logger) (SecureHW, error) {
 	logger = logger.With().Str("component", "securehw").Logger()
-	return newTEE(metadataDir, logger)
+	return newSecureHW(metadataDir, logger)
 }
 
 // ErrKeyNotFound is returned when attempting to load a key that doesn't exist.
@@ -68,15 +68,15 @@ func (e ErrKeyNotFound) Error() string {
 	if e.Message != "" {
 		return e.Message
 	}
-	return "key not found in TPM/TEE"
+	return "key not found in secure hardware"
 }
 
-// ErrTEEUnavailable is returned when the TEE hardware is not available.
-type ErrTEEUnavailable struct {
+// ErrSecureHWUnavailable is returned when the SecureHW hardware is not available.
+type ErrSecureHWUnavailable struct {
 	Message string
 }
 
-func (e ErrTEEUnavailable) Error() string {
+func (e ErrSecureHWUnavailable) Error() string {
 	if e.Message != "" {
 		return e.Message
 	}

--- a/ee/orbit/pkg/securehw/securehw_stub.go
+++ b/ee/orbit/pkg/securehw/securehw_stub.go
@@ -9,6 +9,6 @@ import (
 	"github.com/rs/zerolog"
 )
 
-func newTEE(string, zerolog.Logger) (TEE, error) {
+func newSecureHW(string, zerolog.Logger) (SecureHW, error) {
 	return nil, errors.New("not implemented")
 }

--- a/orbit/cmd/orbit/orbit.go
+++ b/orbit/cmd/orbit/orbit.go
@@ -237,9 +237,9 @@ func main() {
 			EnvVars: []string{"ORBIT_OSQUERY_DB"},
 		},
 		&cli.BoolFlag{
-			Name:    "fleet-managed-client-certificate",
+			Name:    "fleet-managed-host-identity-certificate",
 			Usage:   "Configures fleetd to use TPM-backed key to sign HTTP requests. This functionality is licensed under the Fleet EE License. Usage requires a current Fleet EE subscription.",
-			EnvVars: []string{"ORBIT_FLEET_MANAGED_CLIENT_CERTIFICATE"},
+			EnvVars: []string{"ORBIT_FLEET_MANAGED_HOST_IDENTITY_CERTIFICATE"},
 		},
 	}
 	app.Before = func(c *cli.Context) error {
@@ -832,10 +832,10 @@ func main() {
 
 		var certPath string
 
-		// Both options --fleet-managed-client-certificate and --insecure make use of a local HTTPS proxy.
-		// If the user sets both --fleet-managed-client-certificate and --insecure then only the proxy
+		// Both options --fleet-managed-host-identity-certificate and --insecure make use of a local HTTPS proxy.
+		// If the user sets both --fleet-managed-host-identity-certificate and --insecure then only the proxy
 		// for the fleet managed client certificate will be executed.
-		if fleetURL != "https://" && c.Bool("insecure") && !c.Bool("fleet-managed-client-certificate") {
+		if fleetURL != "https://" && c.Bool("insecure") && !c.Bool("fleet-managed-host-identity-certificate") {
 			proxy, err := insecure.NewTLSProxy(fleetURL)
 			if err != nil {
 				return fmt.Errorf("create TLS proxy: %w", err)
@@ -939,12 +939,12 @@ func main() {
 			return fmt.Errorf("error loading fleet client certificate: %w", err)
 		}
 
-		if c.Bool("fleet-managed-client-certificate") {
+		if c.Bool("fleet-managed-host-identity-certificate") {
 			if runtime.GOOS != "linux" {
-				return errors.New("fleet-managed-client-certificate is only supported on Linux")
+				return errors.New("fleet-managed-host-identity-certificate is only supported on Linux")
 			}
 			if fleetClientCrt != nil {
-				return errors.New("fleet-managed-client-certificate for HTTP signing, and TLS client certificates may not be specified together")
+				return errors.New("fleet-managed-host-identity-certificate for HTTP signing, and TLS client certificates may not be specified together")
 			}
 		}
 
@@ -962,7 +962,7 @@ func main() {
 			signerWrapper               func(*http.Client) *http.Client
 			hostIdentityCertificatePath string
 		)
-		if c.Bool("fleet-managed-client-certificate") {
+		if c.Bool("fleet-managed-host-identity-certificate") {
 			commonName := osqueryHostInfo.HardwareUUID
 			if c.String("host-identifier") == "instance" {
 				commonName = osqueryHostInfo.InstanceID

--- a/orbit/pkg/packaging/linux_shared.go
+++ b/orbit/pkg/packaging/linux_shared.go
@@ -333,7 +333,7 @@ ORBIT_FLEET_DESKTOP_ALTERNATIVE_BROWSER_HOST={{ .FleetDesktopAlternativeBrowserH
 {{ if and (ne .HostIdentifier "") (ne .HostIdentifier "uuid") }}ORBIT_HOST_IDENTIFIER={{.HostIdentifier}}{{ end }}
 {{ if .OsqueryDB }}ORBIT_OSQUERY_DB={{.OsqueryDB}}{{ end }}
 {{ if .EndUserEmail }}ORBIT_END_USER_EMAIL={{.EndUserEmail}}{{ end }}
-{{ if .FleetManagedClientCertificate }}ORBIT_FLEET_MANAGED_CLIENT_CERTIFICATE=true{{ end }}
+{{ if .FleetManagedHostIdentityCertificate }}ORBIT_FLEET_MANAGED_HOST_IDENTITY_CERTIFICATE=true{{ end }}
 `))
 
 func writeEnvFile(opt Options, rootPath string) error {

--- a/orbit/pkg/packaging/packaging.go
+++ b/orbit/pkg/packaging/packaging.go
@@ -133,8 +133,8 @@ type Options struct {
 	NativePlatform string
 	// CustomOutfile is the custom output file name for the package.
 	CustomOutfile string
-	// FleetManagedClientCertificate configures fleetd to use TPM-backed key to sign HTTP requests.
-	FleetManagedClientCertificate bool
+	// FleetManagedHostIdentityCertificate configures fleetd to use TPM-backed key to sign HTTP requests.
+	FleetManagedHostIdentityCertificate bool
 }
 
 const (

--- a/tools/tuf/test/gen_pkgs.sh
+++ b/tools/tuf/test/gen_pkgs.sh
@@ -82,7 +82,7 @@ if [ -n "$GENERATE_DEB" ]; then
         ${USE_UPDATE_CLIENT_CERTIFICATE:+--update-tls-client-key=./tools/test-orbit-mtls/client.key} \
         ${FLEET_DESKTOP_ALTERNATIVE_BROWSER_HOST:+--fleet-desktop-alternative-browser-host=$FLEET_DESKTOP_ALTERNATIVE_BROWSER_HOST} \
         ${ENABLE_SCRIPTS:+--enable-scripts} \
-        ${FLEET_MANAGED_CLIENT_CERTIFICATE:+--fleet-managed-client-certificate} \
+        ${FLEET_MANAGED_CLIENT_CERTIFICATE:+--fleet-managed-host-identity-certificate} \
         --update-url=$DEB_TUF_URL
 fi
 
@@ -107,7 +107,7 @@ if [ -n "$GENERATE_DEB_ARM64" ]; then
         ${USE_UPDATE_CLIENT_CERTIFICATE:+--update-tls-client-key=./tools/test-orbit-mtls/client.key} \
         ${FLEET_DESKTOP_ALTERNATIVE_BROWSER_HOST:+--fleet-desktop-alternative-browser-host=$FLEET_DESKTOP_ALTERNATIVE_BROWSER_HOST} \
         ${ENABLE_SCRIPTS:+--enable-scripts} \
-        ${FLEET_MANAGED_CLIENT_CERTIFICATE:+--fleet-managed-client-certificate} \
+        ${FLEET_MANAGED_CLIENT_CERTIFICATE:+--fleet-managed-host-identity-certificate} \
         --update-url=$DEB_TUF_URL
 fi
 
@@ -132,7 +132,7 @@ if [ -n "$GENERATE_RPM" ]; then
         ${USE_UPDATE_CLIENT_CERTIFICATE:+--update-tls-client-key=./tools/test-orbit-mtls/client.key} \
         ${FLEET_DESKTOP_ALTERNATIVE_BROWSER_HOST:+--fleet-desktop-alternative-browser-host=$FLEET_DESKTOP_ALTERNATIVE_BROWSER_HOST} \
         ${ENABLE_SCRIPTS:+--enable-scripts} \
-        ${FLEET_MANAGED_CLIENT_CERTIFICATE:+--fleet-managed-client-certificate} \
+        ${FLEET_MANAGED_CLIENT_CERTIFICATE:+--fleet-managed-host-identity-certificate} \
         --update-url=$RPM_TUF_URL
 fi
 
@@ -157,7 +157,7 @@ if [ -n "$GENERATE_RPM_ARM64" ]; then
         ${USE_UPDATE_CLIENT_CERTIFICATE:+--update-tls-client-key=./tools/test-orbit-mtls/client.key} \
         ${FLEET_DESKTOP_ALTERNATIVE_BROWSER_HOST:+--fleet-desktop-alternative-browser-host=$FLEET_DESKTOP_ALTERNATIVE_BROWSER_HOST} \
         ${ENABLE_SCRIPTS:+--enable-scripts} \
-        ${FLEET_MANAGED_CLIENT_CERTIFICATE:+--fleet-managed-client-certificate} \
+        ${FLEET_MANAGED_CLIENT_CERTIFICATE:+--fleet-managed-host-identity-certificate} \
         --update-url=$RPM_TUF_URL
 fi
 


### PR DESCRIPTION
Victor suggested the following renames on previous PRs:

- Consider updating TEE terminology to SecureHW or TPM.
- https://fleetdm.slack.com/archives/C084F4MKYSJ/p1752834365688019?thread_ts=1752600813.175889&cid=C084F4MKYSJ

