### PR TITLE
add basic handling for vpp app installs on osquery perf

### DIFF
--- a/cmd/osquery-perf/agent.go
+++ b/cmd/osquery-perf/agent.go
@@ -226,11 +226,30 @@ func (a *mdmAgent) CachedString(key string) string {
 	return val
 }
 
+// adamIDsToSoftware is
 var adamIDsToSoftware = map[int]*fleet.Software{
 	406056744: {
 		Name:             "Evernote",
 		BundleIdentifier: "com.evernote.Evernote",
 		Version:          "10.147.1",
+		Installed:        false,
+	},
+	1091189122: {
+		Name:             "Bear: Markdown Notes",
+		BundleIdentifier: "net.shinyfrog.bear",
+		Version:          "2.4.5",
+		Installed:        false,
+	},
+	1487937127: {
+		Name:             "Craft: Write docs, AI editing",
+		BundleIdentifier: "com.lukilabs.lukiapp",
+		Version:          "3.1.7",
+		Installed:        false,
+	},
+	1444383602: {
+		Name:             "Goodnotes 6: AI Notes & Docs",
+		BundleIdentifier: "com.goodnotesapp.x",
+		Version:          "6.7.2",
 		Installed:        false,
 	},
 }
@@ -959,6 +978,10 @@ func (a *agent) runMacosMDMLoop() {
 				mdmCommandPayload = nextMdmCommandPayload
 			case "InstalledApplicationList":
 				var installedVPPSoftware []fleet.Software
+				// Our mock VPP apps start off as "not installed".
+				// The first time we get a verification command, we flip the flag to "installed",
+				// but don't include the software in the response.
+				// This ensures that 2 verification commands will be sent per VPP install.
 				for _, adamID := range a.installedAdamIDs {
 					if sw, ok := adamIDsToSoftware[adamID]; ok && sw != nil {
 						if sw.Installed {
@@ -985,7 +1008,6 @@ func (a *agent) runMacosMDMLoop() {
 					Command map[string]any `plist:"Command"`
 				}
 
-				log.Printf("command raw: %s", string(mdmCommandPayload.Raw))
 				plist.Unmarshal(mdmCommandPayload.Raw, &appRequest)
 				if err != nil {
 					log.Printf("parsing InstallApplication request: %s", err)

--- a/cmd/osquery-perf/agent.go
+++ b/cmd/osquery-perf/agent.go
@@ -1008,13 +1008,13 @@ func (a *agent) runMacosMDMLoop() {
 					Command map[string]any `plist:"Command"`
 				}
 
-				plist.Unmarshal(mdmCommandPayload.Raw, &appRequest)
+				err = plist.Unmarshal(mdmCommandPayload.Raw, &appRequest)
 				if err != nil {
 					log.Printf("parsing InstallApplication request: %s", err)
 					a.stats.IncrementMDMErrors()
 					break INNER_FOR_LOOP
 				}
-				log.Printf("got install application command for %s", appRequest.Command["iTunesStoreID"])
+				log.Printf("got install application command for %d", appRequest.Command["iTunesStoreID"])
 
 				if adamID, ok := appRequest.Command["iTunesStoreID"].(uint64); ok {
 					a.installedAdamIDs = append(a.installedAdamIDs, int(adamID))

--- a/cmd/osquery-perf/agent.go
+++ b/cmd/osquery-perf/agent.go
@@ -226,7 +226,7 @@ func (a *mdmAgent) CachedString(key string) string {
 	return val
 }
 
-// adamIDsToSoftware is
+// adamIDsToSoftware is the set of VPP apps that we support in our mock VPP install flow.
 var adamIDsToSoftware = map[int]*fleet.Software{
 	406056744: {
 		Name:             "Evernote",


### PR DESCRIPTION
# Checklist for submitter

Adds some very basic VPP app install functionality to osquery-perf.

When one of the supported apps (in this rev: Evernote, Bear, Craft, Goodnotes) is installed, then OSQP

- Handles the `InstallApplication` command and responds with an Ack
- Handles the first verification `InstalledApplicationList` command and marks the app as "installed" internally, but does not return the app in the response
- Handles the second verification `InstalledApplicationList` and returns the app in the response. This should verify it as installed on the Fleet side.

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Manual QA for all new/changed functionality