### PR TITLE
Fleet UI: Pending install/uninstall decrease > refetch host data > finish host data polling > refetch host software data

### DIFF
--- a/frontend/pages/hosts/details/DeviceUserPage/DeviceUserPage.tsx
+++ b/frontend/pages/hosts/details/DeviceUserPage/DeviceUserPage.tsx
@@ -531,6 +531,7 @@ const DeviceUserPage = ({
                       onShowInstallDetails={onShowInstallDetails}
                       onShowUninstallDetails={onShowUninstallDetails}
                       refetchHostDetails={refetchHostDetails}
+                      isRefetchHostPolling={showRefetchSpinner}
                     />
                   </TabPanel>
                 )}

--- a/frontend/pages/hosts/details/DeviceUserPage/DeviceUserPage.tsx
+++ b/frontend/pages/hosts/details/DeviceUserPage/DeviceUserPage.tsx
@@ -531,7 +531,7 @@ const DeviceUserPage = ({
                       onShowInstallDetails={onShowInstallDetails}
                       onShowUninstallDetails={onShowUninstallDetails}
                       refetchHostDetails={refetchHostDetails}
-                      isRefetchHostPolling={showRefetchSpinner}
+                      isHostDetailsPolling={showRefetchSpinner}
                     />
                   </TabPanel>
                 )}

--- a/frontend/pages/hosts/details/DeviceUserPage/DeviceUserPage.tsx
+++ b/frontend/pages/hosts/details/DeviceUserPage/DeviceUserPage.tsx
@@ -530,6 +530,7 @@ const DeviceUserPage = ({
                       router={router}
                       onShowInstallDetails={onShowInstallDetails}
                       onShowUninstallDetails={onShowUninstallDetails}
+                      refetchHostDetails={refetchHostDetails}
                     />
                   </TabPanel>
                 )}

--- a/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
@@ -1009,6 +1009,7 @@ const HostDetailsPage = ({
                 hostMDMEnrolled={host.mdm.connected_to_fleet}
                 isHostOnline={host.status === "online"}
                 refetchHostDetails={refetchHostDetails}
+                isRefetchHostPolling={showRefetchSpinner}
               />
             </TabPanel>
           </>

--- a/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
@@ -1008,6 +1008,7 @@ const HostDetailsPage = ({
                 hostName={host.display_name}
                 hostMDMEnrolled={host.mdm.connected_to_fleet}
                 isHostOnline={host.status === "online"}
+                refetchHostDetails={refetchHostDetails}
               />
             </TabPanel>
           </>

--- a/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
@@ -1009,7 +1009,7 @@ const HostDetailsPage = ({
                 hostMDMEnrolled={host.mdm.connected_to_fleet}
                 isHostOnline={host.status === "online"}
                 refetchHostDetails={refetchHostDetails}
-                isRefetchHostPolling={showRefetchSpinner}
+                isHostDetailsPolling={showRefetchSpinner}
               />
             </TabPanel>
           </>

--- a/frontend/pages/hosts/details/cards/HostSoftwareLibrary/HostSoftwareLibrary.tsx
+++ b/frontend/pages/hosts/details/cards/HostSoftwareLibrary/HostSoftwareLibrary.tsx
@@ -57,6 +57,7 @@ interface IHostInstallersProps {
   hostScriptsEnabled?: boolean;
   hostMDMEnrolled?: boolean;
   isHostOnline?: boolean;
+  refetchHostDetails: () => void;
 }
 
 const DEFAULT_SEARCH_QUERY = "";
@@ -107,6 +108,7 @@ const HostSoftwareLibrary = ({
   isSoftwareEnabled = false,
   hostMDMEnrolled,
   isHostOnline = false,
+  refetchHostDetails,
 }: IHostInstallersProps) => {
   const { renderFlash } = useContext(NotificationContext);
   const {
@@ -177,6 +179,12 @@ const HostSoftwareLibrary = ({
             )
             .map((software) => String(software.id))
         );
+
+        // Refresh host details if the number of pending installs or uninstalls has decreased
+        // To update the software library information of the newly installed/uninstalled software
+        if (newPendingSet.size < pendingSoftwareSetRef.current.size) {
+          refetchHostDetails();
+        }
 
         // Compare new set with the previous set
         const setsAreEqual =

--- a/frontend/pages/hosts/details/cards/HostSoftwareLibrary/HostSoftwareLibrary.tsx
+++ b/frontend/pages/hosts/details/cards/HostSoftwareLibrary/HostSoftwareLibrary.tsx
@@ -131,7 +131,7 @@ const HostSoftwareLibrary = ({
 
   const pendingSoftwareSetRef = useRef<Set<string>>(new Set()); // Track for polling
   const pollingTimeoutIdRef = useRef<NodeJS.Timeout | null>(null);
-  const pendingRefetchHost = useRef(isHostDetailsPolling);
+  const isAwaitingHostDetailsPolling = useRef(isHostDetailsPolling);
 
   const queryKey = useMemo<IHostSoftwareQueryKey[]>(() => {
     return [
@@ -166,12 +166,12 @@ const HostSoftwareLibrary = ({
   // After host details polling (in parent) finishes, refetch software data.
   // Ensures self service data reflects updates to installed_versions from the latest host details.
   useEffect(() => {
-    // Detect transition the entire host being refetched to the entire host refetch being completed
-    // Once entire host refetch polling ends, refetch software data to get updated installed_versions keyed from host data
-    if (pendingRefetchHost.current && !isHostDetailsPolling) {
+    // Detect completion of the host details polling (in parent)
+    // Once host details polling completes, refetch software data to retreive updated installed_versions keyed from host details data
+    if (isAwaitingHostDetailsPolling.current && !isHostDetailsPolling) {
       refetchHostSoftwareLibrary();
     }
-    pendingRefetchHost.current = isHostDetailsPolling;
+    isAwaitingHostDetailsPolling.current = isHostDetailsPolling;
   }, [isHostDetailsPolling, refetchHostSoftwareLibrary]);
 
   // Poll for pending installs/uninstalls

--- a/frontend/pages/hosts/details/cards/HostSoftwareLibrary/HostSoftwareLibrary.tsx
+++ b/frontend/pages/hosts/details/cards/HostSoftwareLibrary/HostSoftwareLibrary.tsx
@@ -58,7 +58,7 @@ interface IHostInstallersProps {
   hostMDMEnrolled?: boolean;
   isHostOnline?: boolean;
   refetchHostDetails: () => void;
-  isRefetchHostPolling: boolean;
+  isHostDetailsPolling: boolean;
 }
 
 const DEFAULT_SEARCH_QUERY = "";
@@ -110,7 +110,7 @@ const HostSoftwareLibrary = ({
   hostMDMEnrolled,
   isHostOnline = false,
   refetchHostDetails,
-  isRefetchHostPolling,
+  isHostDetailsPolling,
 }: IHostInstallersProps) => {
   const { renderFlash } = useContext(NotificationContext);
   const {
@@ -131,7 +131,7 @@ const HostSoftwareLibrary = ({
 
   const pendingSoftwareSetRef = useRef<Set<string>>(new Set()); // Track for polling
   const pollingTimeoutIdRef = useRef<NodeJS.Timeout | null>(null);
-  const pendingRefetchHost = useRef(isRefetchHostPolling);
+  const pendingRefetchHost = useRef(isHostDetailsPolling);
 
   const queryKey = useMemo<IHostSoftwareQueryKey[]>(() => {
     return [
@@ -163,14 +163,16 @@ const HostSoftwareLibrary = ({
     },
   });
 
+  // After host details polling (in parent) finishes, refetch software data.
+  // Ensures self service data reflects updates to installed_versions from the latest host details.
   useEffect(() => {
     // Detect transition the entire host being refetched to the entire host refetch being completed
     // Once entire host refetch polling ends, refetch software data to get updated installed_versions keyed from host data
-    if (pendingRefetchHost.current && !isRefetchHostPolling) {
+    if (pendingRefetchHost.current && !isHostDetailsPolling) {
       refetchHostSoftwareLibrary();
     }
-    pendingRefetchHost.current = isRefetchHostPolling;
-  }, [isRefetchHostPolling, refetchHostSoftwareLibrary]);
+    pendingRefetchHost.current = isHostDetailsPolling;
+  }, [isHostDetailsPolling, refetchHostSoftwareLibrary]);
 
   // Poll for pending installs/uninstalls
   const { refetch: refetchForPendingInstallsOrUninstalls } = useQuery<

--- a/frontend/pages/hosts/details/cards/Software/SelfService/SelfService.tests.tsx
+++ b/frontend/pages/hosts/details/cards/Software/SelfService/SelfService.tests.tsx
@@ -32,7 +32,7 @@ const TEST_PROPS: ISoftwareSelfServiceProps = {
   onShowInstallDetails: noop,
   onShowUninstallDetails: noop,
   refetchHostDetails: noop,
-  isRefetchHostPolling: false,
+  isHostDetailsPolling: false,
 };
 
 describe("SelfService", () => {

--- a/frontend/pages/hosts/details/cards/Software/SelfService/SelfService.tests.tsx
+++ b/frontend/pages/hosts/details/cards/Software/SelfService/SelfService.tests.tsx
@@ -31,6 +31,8 @@ const TEST_PROPS: ISoftwareSelfServiceProps = {
   router: createMockRouter(),
   onShowInstallDetails: noop,
   onShowUninstallDetails: noop,
+  refetchHostDetails: noop,
+  isRefetchHostPolling: false,
 };
 
 describe("SelfService", () => {
@@ -86,33 +88,7 @@ describe("SelfService", () => {
 
     const render = createCustomRenderer({ withBackendMock: true });
 
-    const expectedUrl = "http://example.com";
-
-    render(
-      <SelfService
-        contactUrl={expectedUrl}
-        deviceToken="123-456"
-        isSoftwareEnabled
-        pathname="/test"
-        queryParams={{
-          page: 1,
-          query: "test",
-          order_key: "name",
-          order_direction: "asc",
-          per_page: 10,
-          vulnerable: true,
-          available_for_install: false,
-          min_cvss_score: undefined,
-          max_cvss_score: undefined,
-          exploit: false,
-          category_id: undefined,
-          self_service: false,
-        }}
-        router={createMockRouter()}
-        onShowInstallDetails={noop}
-        onShowUninstallDetails={noop}
-      />
-    );
+    render(<SelfService {...TEST_PROPS} />);
 
     // waiting for the device software data to render
     await screen.findByText("test-software");

--- a/frontend/pages/hosts/details/cards/Software/SelfService/SelfService.tsx
+++ b/frontend/pages/hosts/details/cards/Software/SelfService/SelfService.tsx
@@ -69,7 +69,7 @@ export interface ISoftwareSelfServiceProps {
   onShowInstallDetails: (uuid?: InstallOrCommandUuid) => void;
   onShowUninstallDetails: (details?: ISoftwareUninstallDetails) => void;
   refetchHostDetails: () => void;
-  isRefetchHostPolling: boolean;
+  isHostDetailsPolling: boolean;
 }
 
 const SoftwareSelfService = ({
@@ -82,7 +82,7 @@ const SoftwareSelfService = ({
   onShowInstallDetails,
   onShowUninstallDetails,
   refetchHostDetails,
-  isRefetchHostPolling,
+  isHostDetailsPolling,
 }: ISoftwareSelfServiceProps) => {
   const { renderFlash } = useContext(NotificationContext);
 
@@ -102,7 +102,7 @@ const SoftwareSelfService = ({
 
   const pendingSoftwareSetRef = useRef<Set<string>>(new Set()); // Track for polling
   const pollingTimeoutIdRef = useRef<NodeJS.Timeout | null>(null);
-  const pendingRefetchHost = useRef(isRefetchHostPolling);
+  const pendingRefetchHost = useRef(isHostDetailsPolling);
 
   const queryKey = useMemo<IDeviceSoftwareQueryKey[]>(() => {
     return [
@@ -136,14 +136,16 @@ const SoftwareSelfService = ({
     },
   });
 
+  // After host details polling (in parent) finishes, refetch software data.
+  // Ensures self service data reflects updates to installed_versions from the latest host details.
   useEffect(() => {
     // Detect transition the entire host being refetched to the entire host refetch being completed
     // Once entire host refetch polling ends, refetch software data to get updated installed_versions keyed from host data
-    if (pendingRefetchHost.current && !isRefetchHostPolling) {
+    if (pendingRefetchHost.current && !isHostDetailsPolling) {
       refetchSelfServiceData();
     }
-    pendingRefetchHost.current = isRefetchHostPolling;
-  }, [isRefetchHostPolling, refetchSelfServiceData]);
+    pendingRefetchHost.current = isHostDetailsPolling;
+  }, [isHostDetailsPolling, refetchSelfServiceData]);
 
   // Poll for pending installs/uninstalls
   const { refetch: refetchForPendingInstallsOrUninstalls } = useQuery<

--- a/frontend/pages/hosts/details/cards/Software/SelfService/SelfService.tsx
+++ b/frontend/pages/hosts/details/cards/Software/SelfService/SelfService.tsx
@@ -68,6 +68,7 @@ export interface ISoftwareSelfServiceProps {
   router: InjectedRouter;
   onShowInstallDetails: (uuid?: InstallOrCommandUuid) => void;
   onShowUninstallDetails: (details?: ISoftwareUninstallDetails) => void;
+  refetchHostDetails: () => void;
 }
 
 const SoftwareSelfService = ({
@@ -79,6 +80,7 @@ const SoftwareSelfService = ({
   router,
   onShowInstallDetails,
   onShowUninstallDetails,
+  refetchHostDetails,
 }: ISoftwareSelfServiceProps) => {
   const { renderFlash } = useContext(NotificationContext);
 
@@ -146,6 +148,12 @@ const SoftwareSelfService = ({
             )
             .map((software) => String(software.id))
         );
+
+        // Refresh host details if the number of pending installs or uninstalls has decreased
+        // To update the software library information
+        if (newPendingSet.size < pendingSoftwareSetRef.current.size) {
+          refetchHostDetails();
+        }
 
         // Compare new set with the previous set
         const setsAreEqual =

--- a/frontend/pages/hosts/details/cards/Software/SelfService/SelfService.tsx
+++ b/frontend/pages/hosts/details/cards/Software/SelfService/SelfService.tsx
@@ -102,7 +102,7 @@ const SoftwareSelfService = ({
 
   const pendingSoftwareSetRef = useRef<Set<string>>(new Set()); // Track for polling
   const pollingTimeoutIdRef = useRef<NodeJS.Timeout | null>(null);
-  const pendingRefetchHost = useRef(isHostDetailsPolling);
+  const isAwaitingHostDetailsPolling = useRef(isHostDetailsPolling);
 
   const queryKey = useMemo<IDeviceSoftwareQueryKey[]>(() => {
     return [
@@ -139,12 +139,12 @@ const SoftwareSelfService = ({
   // After host details polling (in parent) finishes, refetch software data.
   // Ensures self service data reflects updates to installed_versions from the latest host details.
   useEffect(() => {
-    // Detect transition the entire host being refetched to the entire host refetch being completed
-    // Once entire host refetch polling ends, refetch software data to get updated installed_versions keyed from host data
-    if (pendingRefetchHost.current && !isHostDetailsPolling) {
+    // Detect completion of the host details polling (in parent)
+    // Once host details polling completes, refetch software data to retreive updated installed_versions keyed from host details data
+    if (isAwaitingHostDetailsPolling.current && !isHostDetailsPolling) {
       refetchSelfServiceData();
     }
-    pendingRefetchHost.current = isHostDetailsPolling;
+    isAwaitingHostDetailsPolling.current = isHostDetailsPolling;
   }, [isHostDetailsPolling, refetchSelfServiceData]);
 
   // Poll for pending installs/uninstalls


### PR DESCRIPTION
## Issue
Precursor to #30240 and #27983

## Description
- Because the new feature relies on `installed_versions` as source of truth for what the UI shows as installed software status and software actions from `GET hosts/:id/software`, that key must be updated **immediately** after a `software.status` change to show updated `installed_versions`
- How?
  - Added behavior: Once a `software.status` changes from a pending status (`pending_install`, `pending_uninstall`) to not pending status, kick off `hostDetailsRefetch`
  - Current behavior: Host details refetch has a polling mechanism and immediately updates the host details page, however, for software data to be updated, the software API needs to be refetched
  - Added behavior: Once the polling of `hostDetailsRefetch` ends (trigger is from `showRefetchSpinner` going from `true` > `false`), then `refetchSelfServiceData` if on self-service page or `refetchHostSoftwareLibrary` on host details > software > library

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [ ] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
- [ ] Added/updated automated tests
- [ ] Manual QA for all new/changed functionality


