### PR TITLE
Website: update prefilled primaryBuyingSituation values

### DIFF
--- a/website/assets/js/pages/contact.page.js
+++ b/website/assets/js/pages/contact.page.js
@@ -53,7 +53,7 @@ parasails.registerPage('contact', {
       // Otherwise, default to the formToShow value from the page's controller.
       this.formToDisplay = this.formToShow;
     }
-    if(this.primaryBuyingSituation){ // If the user has a priamry buying situation set in their sesssion, pre-fill the form.
+    if(this.primaryBuyingSituation && !['vm', 'security-misc', 'security-vm', 'it-major-mdm', 'it-gap-filler-mdm', 'it-misc'].includes(this.primaryBuyingSituation)){ // If the user has a priamry buying situation set in their sesssion, pre-fill the form.
       // Note: this will be overriden if the user is logged in and has a primaryBuyingSituation set in the database.
       this.$set(this.formData, 'primaryBuyingSituation', this.primaryBuyingSituation);
     }

--- a/website/assets/js/pages/start.page.js
+++ b/website/assets/js/pages/start.page.js
@@ -89,7 +89,8 @@ parasails.registerPage('start', {
     }
     // If this user has not completed the 'what are you using fleet for' step, and has a primaryBuyingSituation set by an ad. prefill the formData for this step.
     if(this.primaryBuyingSituation && _.isEmpty(this.formData['what-are-you-using-fleet-for'])){
-      if(this.primaryBuyingSituation !== 'vm') {
+      // TODO: remove this once the form is updated to support the new primaryBuyingSituation values.
+      if(!['vm', 'security-misc', 'security-vm', 'it-major-mdm', 'it-gap-filler-mdm', 'it-misc'].includes(this.primaryBuyingSituation)) {
         this.formData['what-are-you-using-fleet-for'] = {primaryBuyingSituation: this.primaryBuyingSituation};
       }
     }


### PR DESCRIPTION
Closes: https://github.com/fleetdm/confidential/issues/11557

Changes:
- Updated the /start questionnaire not to prefill new primaryBuyingSituation values set by ads.
- Updated the talk to us form not to prefill new primaryBuyingSituation values set by ads.