### PR TITLE
Add permanent errors to Fleet Desktop for TPM-backed httpsig work

### DIFF
--- a/ee/orbit/pkg/hostidentity/host_identity.go
+++ b/ee/orbit/pkg/hostidentity/host_identity.go
@@ -57,6 +57,15 @@ func Setup(
 		// OK
 	case errors.As(err, &securehw.ErrKeyNotFound{}):
 		// Key doesn't exist yet, let's create it.
+
+		// First let's clear any existing certificate in
+		// case a user or process deleted the keyfile but not
+		// the issued-via-SCEP certificate.
+		certPath := filepath.Join(metadataDir, constant.FleetHTTPSignatureCertificateFileName)
+		if err := os.RemoveAll(certPath); err != nil {
+			return nil, fmt.Errorf("failed to clear the host identity certificate: %w", err)
+		}
+
 		secureHWKey, err = teeDevice.CreateKey()
 		if err != nil {
 			return nil, fmt.Errorf("failed to create secure hardware key: %w", err)

--- a/orbit/changes/fleetd-tpm-key
+++ b/orbit/changes/fleetd-tpm-key
@@ -1,1 +1,1 @@
-* Added support to generate a TPM 2.0 private key and issue a SCEP certificate for signing of HTTP requests (via new environment variable `ORBIT_FLEET_MANAGED_CLIENT_CERTIFICATE`).
+- Added support to generate a TPM 2.0 private key and issue a SCEP certificate for signing of HTTP requests (via new environment variable `ORBIT_FLEET_MANAGED_HOST_IDENTITY_CERTIFICATE`).

--- a/orbit/cmd/desktop/desktop.go
+++ b/orbit/cmd/desktop/desktop.go
@@ -9,6 +9,7 @@ import (
 	"os/signal"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"syscall"
 	"time"
 
@@ -85,6 +86,10 @@ func main() {
 		return
 	}
 	log.Info().Msgf("fleet-desktop version=%s", version)
+
+	if permanentError := os.Getenv("FLEET_DESKTOP_PERMANENT_ERROR"); permanentError != "" {
+		runWithPermanentError(permanentError)
+	}
 
 	identifierPath := os.Getenv("FLEET_DESKTOP_DEVICE_IDENTIFIER_PATH")
 	if identifierPath == "" {
@@ -788,4 +793,32 @@ func mdmMigrationSetup(ctx context.Context, tufUpdateRoot, fleetURL string, clie
 	offlineWatcher := useraction.StartMDMMigrationOfflineWatcher(ctx, client, swiftDialogPath, swiftDialogCh, migration.FileWatcher(mrw))
 
 	return mdmMigrator, swiftDialogCh, offlineWatcher, nil
+}
+
+func runWithPermanentError(errorMessage string) {
+	onReady := func() {
+		log.Info().Msg("ready")
+
+		systray.SetTooltip("Fleet Desktop")
+
+		// Default to dark theme icon because this seems to be a better fit on Linux (Ubuntu at
+		// least). On macOS this is used as a template icon anyway.
+		systray.SetTemplateIcon(iconDark, iconDark)
+
+		// Add a disabled menu item with the current version
+		versionItem := systray.AddMenuItem(fmt.Sprintf("Fleet Desktop v%s", version), "")
+		versionItem.Disable()
+		systray.AddSeparator()
+
+		// We are doing this using two menu items because line breaks
+		// are not rendered correctly on Windows and MacOS.
+		for errorMessageLine := range strings.SplitSeq(errorMessage, "\n") {
+			item := systray.AddMenuItem(strings.TrimSpace(errorMessageLine), "")
+			item.Disable()
+		}
+	}
+
+	systray.Run(onReady, func() {
+		log.Info().Msg("exit")
+	})
 }

--- a/orbit/cmd/orbit/orbit.go
+++ b/orbit/cmd/orbit/orbit.go
@@ -978,6 +978,17 @@ func main() {
 				log.Logger,
 			)
 			if err != nil {
+				if c.Bool("fleet-desktop") {
+					// Generic error for when the TPM-backed certificate could not be generated.
+					// (e.g. invalid enroll secret, server down).
+					errorMessage := "🔒🚫 Missing Fleet certificate.\nPlease contact your IT admin."
+					if errors.As(err, &securehw.ErrSecureHWUnavailable{}) {
+						errorMessage = "🔒🚫 TPM 2.0 device unavailable.\nPlease contact your IT admin."
+					}
+					if err := executeFleetDesktopWithPermanentError(desktopPath, errorMessage); err != nil {
+						log.Error().Err(err).Msg("failed to launch Fleet Desktop with permanent error")
+					}
+				}
 				return fmt.Errorf("failed to create or load client certificate: %w", err)
 			}
 			defer hostIdentityCredentials.Close()
@@ -2284,4 +2295,49 @@ func (w *wrapSubsystem) Execute() error {
 // Interrupt partially implements subSystem.
 func (w *wrapSubsystem) Interrupt(err error) {
 	w.interrupt(err)
+}
+
+// executeFleetDesktopWithPermanentError attempts to execute a Fleet Desktop instance
+// with a permanent error. The routine sleeps for 5 minutes to give some time for the message
+// to be seen by the end-user.
+func executeFleetDesktopWithPermanentError(desktopPath string, errorMessage string) error {
+	loggedInUser, err := user.UserLoggedInViaGui()
+	if err != nil {
+		return fmt.Errorf("failed to get logged in GUI user: %w", err)
+	}
+	if loggedInUser == nil {
+		log.Debug().Msg("No GUI user found, skipping fleet-desktop start")
+		return nil
+	}
+	log.Debug().Msg(fmt.Sprintf("Found GUI user: %v, attempting fleet-desktop start", loggedInUser))
+
+	log.Info().Msg("killing any pre-existing fleet-desktop instances")
+	if err := platform.SignalProcessBeforeTerminate(constant.DesktopAppExecName); err != nil &&
+		!errors.Is(err, platform.ErrProcessNotFound) &&
+		!errors.Is(err, platform.ErrComChannelNotFound) {
+		return fmt.Errorf("pre-existing desktop terminate: %w", err)
+	}
+
+	log.Debug().Msg("opening Fleet Desktop with permantent error")
+
+	opts := []execuser.Option{
+		execuser.WithEnv("FLEET_DESKTOP_PERMANENT_ERROR", errorMessage),
+	}
+
+	if *loggedInUser != "" {
+		opts = append(opts, execuser.WithUser(*loggedInUser))
+	}
+
+	// Orbit runs as root user on Unix and as SYSTEM (Windows Service) user on Windows.
+	// To be able to run the desktop application (mostly to register the icon in the system tray)
+	// we need to run the application as the login user.
+	// Package execuser provides multi-platform support for this.
+	if lastLogs, err := execuser.Run(desktopPath, opts...); err != nil {
+		return fmt.Errorf("failed to run Fleet Desktop: %w, logs: %q", err, lastLogs)
+	}
+
+	// We give enough time to display the permanent error.
+	time.Sleep(5 * time.Minute)
+
+	return nil
 }

--- a/tools/tuf/test/gen_pkgs.sh
+++ b/tools/tuf/test/gen_pkgs.sh
@@ -27,7 +27,7 @@ set -ex
 # FLEET_DESKTOP: Whether to build with Fleet Desktop support.
 # INSECURE: Whether to use the --insecure flag.
 # USE_FLEET_SERVER_CERTIFICATE: Whether to use a custom certificate bundle.
-# FLEET_MANAGED_CLIENT_CERTIFICATE: Whether to use TPM-backed key for HTTP signing.
+# FLEET_MANAGED_HOST_IDENTITY_CERTIFICATE: Whether to use TPM-backed key for HTTP signing (Linux only).
 # USE_UPDATE_SERVER_CERTIFICATE: Whether to use a custom certificate bundle.
 # FLEET_DESKTOP_ALTERNATIVE_BROWSER_HOST: Alternative host:port to use for the Fleet Desktop browser URLs.
 # DEBUG: Whether or not to build the package with --debug.
@@ -82,7 +82,7 @@ if [ -n "$GENERATE_DEB" ]; then
         ${USE_UPDATE_CLIENT_CERTIFICATE:+--update-tls-client-key=./tools/test-orbit-mtls/client.key} \
         ${FLEET_DESKTOP_ALTERNATIVE_BROWSER_HOST:+--fleet-desktop-alternative-browser-host=$FLEET_DESKTOP_ALTERNATIVE_BROWSER_HOST} \
         ${ENABLE_SCRIPTS:+--enable-scripts} \
-        ${FLEET_MANAGED_CLIENT_CERTIFICATE:+--fleet-managed-host-identity-certificate} \
+        ${FLEET_MANAGED_HOST_IDENTITY_CERTIFICATE:+--fleet-managed-host-identity-certificate} \
         --update-url=$DEB_TUF_URL
 fi
 
@@ -107,7 +107,7 @@ if [ -n "$GENERATE_DEB_ARM64" ]; then
         ${USE_UPDATE_CLIENT_CERTIFICATE:+--update-tls-client-key=./tools/test-orbit-mtls/client.key} \
         ${FLEET_DESKTOP_ALTERNATIVE_BROWSER_HOST:+--fleet-desktop-alternative-browser-host=$FLEET_DESKTOP_ALTERNATIVE_BROWSER_HOST} \
         ${ENABLE_SCRIPTS:+--enable-scripts} \
-        ${FLEET_MANAGED_CLIENT_CERTIFICATE:+--fleet-managed-host-identity-certificate} \
+        ${FLEET_MANAGED_HOST_IDENTITY_CERTIFICATE:+--fleet-managed-host-identity-certificate} \
         --update-url=$DEB_TUF_URL
 fi
 
@@ -132,7 +132,7 @@ if [ -n "$GENERATE_RPM" ]; then
         ${USE_UPDATE_CLIENT_CERTIFICATE:+--update-tls-client-key=./tools/test-orbit-mtls/client.key} \
         ${FLEET_DESKTOP_ALTERNATIVE_BROWSER_HOST:+--fleet-desktop-alternative-browser-host=$FLEET_DESKTOP_ALTERNATIVE_BROWSER_HOST} \
         ${ENABLE_SCRIPTS:+--enable-scripts} \
-        ${FLEET_MANAGED_CLIENT_CERTIFICATE:+--fleet-managed-host-identity-certificate} \
+        ${FLEET_MANAGED_HOST_IDENTITY_CERTIFICATE:+--fleet-managed-host-identity-certificate} \
         --update-url=$RPM_TUF_URL
 fi
 
@@ -157,7 +157,7 @@ if [ -n "$GENERATE_RPM_ARM64" ]; then
         ${USE_UPDATE_CLIENT_CERTIFICATE:+--update-tls-client-key=./tools/test-orbit-mtls/client.key} \
         ${FLEET_DESKTOP_ALTERNATIVE_BROWSER_HOST:+--fleet-desktop-alternative-browser-host=$FLEET_DESKTOP_ALTERNATIVE_BROWSER_HOST} \
         ${ENABLE_SCRIPTS:+--enable-scripts} \
-        ${FLEET_MANAGED_CLIENT_CERTIFICATE:+--fleet-managed-host-identity-certificate} \
+        ${FLEET_MANAGED_HOST_IDENTITY_CERTIFICATE:+--fleet-managed-host-identity-certificate} \
         --update-url=$RPM_TUF_URL
 fi
 


### PR DESCRIPTION
For #30478.

Figma: https://www.figma.com/design/qBsJ8Qpz0ZSCASbLBYL59v/-28818-Verify-identity-of-Linux-hosts-when-talking-to-Fleet--ala-Apple-MDM-?node-id=5301-90&t=t9Kuq7QUXOJkhaff-1

When the host doesn't have a TPM 2.0 device:
<img width="309" height="220" alt="Screenshot 2025-07-24 at 9 35 38 AM" src="https://github.com/user-attachments/assets/ded83fb6-5de2-482c-9975-c4984e3a54c9" />

When the host was installed with an invalid enroll secret (which means it cannot generate a certificate):
<img width="418" height="216" alt="Screenshot from 2025-07-24 10-00-01" src="https://github.com/user-attachments/assets/ba16781e-e56f-44cd-b574-1f293305b1a1" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Fleet Desktop now displays a permanent error message in the system tray if a critical error is detected, preventing normal app startup and informing the user of the issue.

* **Bug Fixes**
  * Improved handling of missing or outdated host identity certificates to ensure proper cleanup before generating new keys.

* **Documentation**
  * Updated environment variable names in documentation and scripts for clarity and accuracy regarding TPM-backed certificate usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->