### PR TITLE
Enable BYOD service discovery cron

### DIFF
--- a/cmd/fleet/cron.go
+++ b/cmd/fleet/cron.go
@@ -1284,26 +1284,26 @@ func newWindowsMDMProfileManagerSchedule(
 	return s, nil
 }
 
-// // TODO(BMAA): Uncomment this when ready to test Apple account-driven enrollment flow
-// func newMDMAppleServiceDiscoverySchedule(
-// 	ctx context.Context,
-// 	instanceID string,
-// 	ds fleet.Datastore,
-// 	depStorage *mysql.NanoDEPStorage,
-// 	logger kitlog.Logger,
-// ) (*schedule.Schedule, error) {
-// 	const name = "mdm_service_discovery"
-// 	interval := 1 * time.Hour
-// 	logger = kitlog.With(logger, "cron", name)
-// 	s := schedule.New(
-// 		ctx, name, instanceID, interval, ds, ds,
-// 		schedule.WithLogger(logger),
-// 		schedule.WithJob("mdm_apple_account_driven_enrollment_profile", func(ctx context.Context) error {
-// 			return service.EnsureMDMAppleServiceDiscovery(ctx, ds, depStorage, logger)
-// 		}),
-// 	)
-// 	return s, nil
-// }
+func newMDMAppleServiceDiscoverySchedule(
+	ctx context.Context,
+	instanceID string,
+	ds fleet.Datastore,
+	depStorage *mysql.NanoDEPStorage,
+	logger kitlog.Logger,
+	urlPrefix string,
+) (*schedule.Schedule, error) {
+	const name = "mdm_service_discovery"
+	interval := 1 * time.Hour
+	logger = kitlog.With(logger, "cron", name)
+	s := schedule.New(
+		ctx, name, instanceID, interval, ds, ds,
+		schedule.WithLogger(logger),
+		schedule.WithJob("mdm_apple_account_driven_enrollment_profile", func(ctx context.Context) error {
+			return service.EnsureMDMAppleServiceDiscovery(ctx, ds, depStorage, logger, urlPrefix)
+		}),
+	)
+	return s, nil
+}
 
 func newMDMAPNsPusher(
 	ctx context.Context,

--- a/cmd/fleet/serve.go
+++ b/cmd/fleet/serve.go
@@ -946,12 +946,11 @@ the way that the Fleet server works.
 				initFatal(err, "failed to register apple_mdm_dep_profile_assigner schedule")
 			}
 
-			// // TODO(BMAA): uncomment this to enable MDM Apple Service Discovery
-			// if err := cronSchedules.StartCronSchedule(func() (fleet.CronSchedule, error) {
-			// 	return newMDMAppleServiceDiscoverySchedule(ctx, instanceID, ds, depStorage, logger)
-			// }); err != nil {
-			// 	initFatal(err, "failed to register mdm_apple_service_discovery schedule")
-			// }
+			if err := cronSchedules.StartCronSchedule(func() (fleet.CronSchedule, error) {
+				return newMDMAppleServiceDiscoverySchedule(ctx, instanceID, ds, depStorage, logger, config.Server.URLPrefix)
+			}); err != nil {
+				initFatal(err, "failed to register mdm_apple_service_discovery schedule")
+			}
 
 			if err := cronSchedules.StartCronSchedule(func() (fleet.CronSchedule, error) {
 				return newAppleMDMProfileManagerSchedule(

--- a/server/service/apple_mdm.go
+++ b/server/service/apple_mdm.go
@@ -7006,7 +7006,7 @@ func EnsureMDMAppleServiceDiscovery(ctx context.Context, ds fleet.Datastore, dep
 	if err != nil {
 		return ctxerr.Wrap(ctx, err, "checking account driven enrollment service discovery")
 	}
-	sdURL := ac.MDMUrl() + urlPrefix + "/mdm/apple/service_discovery"
+	sdURL := ac.MDMUrl() + urlPrefix + apple_mdm.ServiceDiscoveryPath
 
 	tokens, err := ds.ListABMTokens(ctx)
 	switch {

--- a/server/service/apple_mdm.go
+++ b/server/service/apple_mdm.go
@@ -6996,7 +6996,7 @@ func (svc *Service) MDMAppleProcessOTAEnrollment(
 
 // EnsureMDMAppleServiceDiscovery checks if the service discovery URL is set up correctly with Apple
 // and assigns it if necessary.
-func EnsureMDMAppleServiceDiscovery(ctx context.Context, ds fleet.Datastore, depStorage storage.AllDEPStorage, logger kitlog.Logger) error {
+func EnsureMDMAppleServiceDiscovery(ctx context.Context, ds fleet.Datastore, depStorage storage.AllDEPStorage, logger kitlog.Logger, urlPrefix string) error {
 	var depSvc *apple_mdm.DEPService
 	if depSvc == nil {
 		depSvc = apple_mdm.NewDEPService(ds, depStorage, logger)
@@ -7006,8 +7006,7 @@ func EnsureMDMAppleServiceDiscovery(ctx context.Context, ds fleet.Datastore, dep
 	if err != nil {
 		return ctxerr.Wrap(ctx, err, "checking account driven enrollment service discovery")
 	}
-	// TODO: check with lucas if we need to account for svc.config.Server.URLPrefix
-	wantURL := strings.TrimSuffix(ac.MDMUrl(), "/") + `/mdm/apple/service_discovery`
+	sdURL := ac.MDMUrl() + urlPrefix + "/mdm/apple/service_discovery"
 
 	tokens, err := ds.ListABMTokens(ctx)
 	switch {
@@ -7042,9 +7041,9 @@ func EnsureMDMAppleServiceDiscovery(ctx context.Context, ds fleet.Datastore, dep
 	}
 	level.Info(logger).Log("msg", "account driven enrollment service discovery url confirmed", "service_discovery_url", gotURL, "last_updated", lastUpdated)
 
-	if gotURL != wantURL {
+	if gotURL != sdURL {
 		// proced to assignment
-		return ctxerr.Wrap(ctx, depSvc.AssignMDMAppleServiceDiscoveryURL(ctx, orgName, wantURL),
+		return ctxerr.Wrap(ctx, depSvc.AssignMDMAppleServiceDiscoveryURL(ctx, orgName, sdURL),
 			"assigning account driven enrollment service discovery URL")
 	}
 


### PR DESCRIPTION
For #31058 

Adds back BYOD service discovery cron, to be merged only when feature is dev-complete.