### PR TITLE
Add `.well-known` BYOD route to dogfood

### DIFF
--- a/website/config/routes.js
+++ b/website/config/routes.js
@@ -1061,6 +1061,5 @@ module.exports.routes = {
   // Service discovery for Apple account-driven enrollment, see
   // https://developer.apple.com/documentation/devicemanagement/implementing-the-simple-authentication-user-enrollment-flow#Send-the-well-known-request
   //
-  // TODO(BMAA): Uncomment this when we are ready to dogfood the Apple account-driven enrollment flow.
-  // 'GET /.well-known/com.apple.remotemanagement': (req, res)=>{ return res.json({'Servers':[{'Version':'mdm-byod', 'BaseURL':'https://dogfood.fleetdm.com/api/mdm/apple/account_driven_enroll'}]});},
+  'GET /.well-known/com.apple.remotemanagement': (req, res)=>{ return res.json({'Servers':[{'Version':'mdm-byod', 'BaseURL':'https://dogfood.fleetdm.com/api/mdm/apple/account_driven_enroll'}]});},
 };


### PR DESCRIPTION
For #31058 

- Adds back `/.well-known/com.apple.remotemanagement` route to dogfood for Apple BYOD feature
- NOTE: only merge this PR after feature is dev-complete