### PR TITLE
FE: Fix FE test missing 2 props

### DIFF
--- a/frontend/pages/hosts/details/cards/Software/SelfService/SelfService.tests.tsx
+++ b/frontend/pages/hosts/details/cards/Software/SelfService/SelfService.tests.tsx
@@ -118,31 +118,7 @@ describe("SelfService", () => {
 
     const expectedUrl = "http://example.com";
 
-    render(
-      <SelfService
-        contactUrl={expectedUrl}
-        deviceToken="123-456"
-        isSoftwareEnabled
-        pathname="/test"
-        queryParams={{
-          page: 1,
-          query: "test",
-          order_key: "name",
-          order_direction: "asc",
-          per_page: 10,
-          vulnerable: true,
-          available_for_install: false,
-          min_cvss_score: undefined,
-          max_cvss_score: undefined,
-          exploit: false,
-          category_id: undefined,
-          self_service: false,
-        }}
-        router={createMockRouter()}
-        onShowInstallDetails={noop}
-        onShowUninstallDetails={noop}
-      />
-    );
+    render(<SelfService {...TEST_PROPS} />);
 
     // waiting for the device software data to render
     await screen.findByText("test-software");


### PR DESCRIPTION
## Issue
Part of #30240 

## Description
- Refetching host API added 2 props to `main` but not accounted for in 2000+ line PR with new tests approved and merged same day
- Add 2 lines of props to new test of `<SelfService/>` component
# Checklist for submitter

- [x] Added/updated automated tests

