### PR TITLE
API for contributors

### DIFF
--- a/docs/Contributing/reference/api-for-contributors.md
+++ b/docs/Contributing/reference/api-for-contributors.md
@@ -1,5 +1,11 @@
 # API for contributors
 
+This document includes the internal (service) Fleet API routes that are helpful when developing or contributing to Fleet.
+
+These endpoints are used by the Fleet UI, Fleet Desktop, and `fleetctl` clients and frequently change to reflect current functionality. 
+
+If you are interested in gathering information from Fleet in a production environment, please see the [public Fleet REST API documentation](https://fleetdm.com/docs/using-fleet/rest-api).
+
 - [Authentication](#authentication)
 - [Packs](#packs)
 - [Mobile device management (MDM)](#mobile-device-management-mdm)
@@ -15,12 +21,6 @@
 - [Users](#users)
 - [Conditional access](#conditional-access)
 - [Host identity](#host-identity)
-
-> These endpoints are used by the Fleet UI, Fleet Desktop, and `fleetctl` clients and frequently change to reflect current functionality.
-
-This document includes the internal Fleet API routes that are helpful when developing or contributing to Fleet.
-
-If you are interested in gathering information from Fleet in a production environment, please see the [public Fleet REST API documentation](https://fleetdm.com/docs/using-fleet/rest-api).
 
 ## Authentication
 


### PR DESCRIPTION
- Make the callout about these endpoints being internal (UI/fleetctl/Fleet Desktop uses them) more prominent.
  - Why? So customers/users that find themselves in this doc have hard a time missing it.
