### PR TITLE
Update linux-disk-encryption-end-user.md

### DIFF
--- a/articles/linux-disk-encryption-end-user.md
+++ b/articles/linux-disk-encryption-end-user.md
@@ -39,7 +39,7 @@ Follow the steps below to get set up.
 
 ## 3. Escrow your key with Fleet
 
-> Note: LUKS allows multiple passphrases for decrypting the volume. The original passphrase remains active along with the escrowed passphrase created by Fleet.
+> LUKS allows multiple passphrases for decrypting the volume. The original passphrase remains active along with the escrowed passphrase created by Fleet.
 
   - Open Fleet Desktop. If your device is encrypted, you'll see a banner prompting you to escrow the key.
   - Click **Create key**. Enter your existing encryption passphrase when prompted. 

--- a/articles/linux-disk-encryption-end-user.md
+++ b/articles/linux-disk-encryption-end-user.md
@@ -39,6 +39,8 @@ Follow the steps below to get set up.
 
 ## 3. Escrow your key with Fleet
 
+> Note: LUKS allows multiple passphrases for decrypting the volume. The original passphrase remains active along with the escrowed passphrase created by Fleet.
+
   - Open Fleet Desktop. If your device is encrypted, you'll see a banner prompting you to escrow the key.
   - Click **Create key**. Enter your existing encryption passphrase when prompted. 
   - Fleet will generate and securely store a new passphrase for recovery. This may take several minutes. A popup will appear when Fleet is done.


### PR DESCRIPTION
- Noted that Fleet generates a new encryption key and the original one does still remain under step #3 after a customer noted inconsistencies in our docs. 
- The statement was taken from our enforce-disk-encryption article.