### PR TITLE
Add software sanitation on ingest back, use it to fix DCV Viewer versions

### DIFF
--- a/changes/31123-dcv-viewer-fix
+++ b/changes/31123-dcv-viewer-fix
@@ -1,0 +1,1 @@
+* Added back software mutation on ingestion to fix non-semver-compliant software versions, starting with DCV Viewer.

--- a/server/service/osquery_utils/queries_test.go
+++ b/server/service/osquery_utils/queries_test.go
@@ -33,6 +33,35 @@ import (
 	"golang.org/x/exp/maps"
 )
 
+func TestSoftwareIngestionMutations(t *testing.T) {
+	dcvViewer := &fleet.Software{
+		BundleIdentifier: "com.nicesoftware.dcvviewer",
+		Source:           "apps",
+		Version:          "2024.0 (r8004)",
+	}
+
+	MutateSoftwareOnIngestion(dcvViewer, log.NewNopLogger())
+	assert.Equal(t, "2024.0.8004", dcvViewer.Version)
+
+	noOp := &fleet.Software{
+		BundleIdentifier: "com.nicesoftware.dcvviewer",
+		Source:           "apps",
+		Version:          "2024",
+	}
+
+	MutateSoftwareOnIngestion(dcvViewer, log.NewNopLogger())
+	assert.Equal(t, "2024", noOp.Version)
+
+	noMatch := &fleet.Software{
+		BundleIdentifier: "com.google.chrome",
+		Source:           "apps",
+		Version:          "2024.0 (r8004)",
+	}
+
+	MutateSoftwareOnIngestion(noMatch, log.NewNopLogger())
+	assert.Equal(t, "2024.0 (r8004)", noMatch.Version)
+}
+
 func TestDetailQueryNetworkInterfaces(t *testing.T) {
 	var initialHost fleet.Host
 	host := initialHost


### PR DESCRIPTION
We'll want to pull this into a feed so fixes don't take a Fleet release to propagate, and some fixes currently in the vulns mutations list should probably move over here (as they're also dealing with non-semver versions), but that's out of scope for this particular fix.

Fixes #31123.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

<!-- Note that API documentation changes are now addressed by the product design team. -->

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.
- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [x] Added/updated automated tests
- [x] Manual QA for all new/changed functionality