### PR TITLE
UI: `InventoryVersions` component

### DIFF
--- a/frontend/pages/hosts/details/components/InventoryVersions/InventoryVersions.tsx
+++ b/frontend/pages/hosts/details/components/InventoryVersions/InventoryVersions.tsx
@@ -1,0 +1,134 @@
+import Card from "components/Card";
+import DataSet from "components/DataSet";
+import {
+  formatSoftwareType,
+  IHostSoftware,
+  ISoftwareInstallVersion,
+  SoftwareSource,
+} from "interfaces/software";
+import React from "react";
+import { dateAgo } from "utilities/date_format";
+
+const generateVulnerabilitiesValue = (vulnerabilities: string[]) => {
+  const first3 = vulnerabilities.slice(0, 3);
+  const rest = vulnerabilities.slice(3);
+
+  const first3Text = first3.join(", ");
+  const restText = `, +${rest.length} more`;
+
+  return (
+    <>
+      <span>{`${first3Text}${rest.length > 0 ? restText : ""}`}</span>
+    </>
+  );
+};
+
+const baseClass = "inventory-versions";
+
+interface IInventoryVersionProps {
+  version: ISoftwareInstallVersion;
+  source: SoftwareSource;
+  bundleIdentifier?: string;
+}
+
+const InventoryVersion = ({
+  version,
+  source,
+  bundleIdentifier,
+}: IInventoryVersionProps) => {
+  const {
+    vulnerabilities,
+    installed_paths: installedPaths,
+    signature_information: signatureInformation,
+  } = version;
+
+  return (
+    <Card
+      className={`${baseClass}__version`}
+      color="grey"
+      borderRadiusSize="medium"
+    >
+      <div className={`${baseClass}__row`}>
+        <DataSet title="Version" value={version.version} />
+        <DataSet title="Type" value={formatSoftwareType({ source })} />
+        {bundleIdentifier && (
+          <DataSet title="Bundle identifier" value={bundleIdentifier} />
+        )}
+        {version.last_opened_at && (
+          <DataSet title="Last used" value={dateAgo(version.last_opened_at)} />
+        )}
+      </div>
+      {vulnerabilities && vulnerabilities.length !== 0 && (
+        <div className={`${baseClass}__row`}>
+          <DataSet
+            title="Vulnerabilities"
+            value={generateVulnerabilitiesValue(vulnerabilities)}
+          />
+        </div>
+      )}
+      {!!installedPaths?.length &&
+        installedPaths.map((path) => {
+          // Find the signature info for this path
+          const sigInfo = signatureInformation?.find(
+            (info) => info.installed_path === path
+          );
+
+          return (
+            <div className={`${baseClass}__sig-info`}>
+              <DataSet orientation="horizontal" title="Path" value={path} />
+              {sigInfo?.hash_sha256 && (
+                <DataSet
+                  orientation="horizontal"
+                  title="Hash"
+                  value={sigInfo.hash_sha256}
+                />
+              )}
+            </div>
+          );
+        })}
+    </Card>
+  );
+};
+
+interface IInventoryVersionsProps {
+  hostSoftware: IHostSoftware;
+}
+const InventoryVersions = ({ hostSoftware }: IInventoryVersionsProps) => {
+  const installedVersions = hostSoftware.installed_versions;
+
+  if (!installedVersions || installedVersions.length === 0) {
+    return (
+      <div className={`${baseClass}__software-details`}>
+        <Card
+          className={`${baseClass}__version-details`}
+          color="grey"
+          borderRadiusSize="medium"
+        >
+          <div className={`${baseClass}__row`}>
+            <DataSet
+              title="Type"
+              value={formatSoftwareType({ source: hostSoftware.source })}
+            />
+          </div>
+        </Card>
+      </div>
+    );
+  }
+
+  return (
+    <div className={baseClass}>
+      {installedVersions.map((installedVersion) => {
+        return (
+          <InventoryVersion
+            key={installedVersion.version}
+            version={installedVersion}
+            source={hostSoftware.source}
+            bundleIdentifier={hostSoftware.bundle_identifier}
+          />
+        );
+      })}
+    </div>
+  );
+};
+
+export default InventoryVersions;

--- a/frontend/pages/hosts/details/components/InventoryVersions/InventoryVersions.tsx
+++ b/frontend/pages/hosts/details/components/InventoryVersions/InventoryVersions.tsx
@@ -1,13 +1,16 @@
-import Card from "components/Card";
-import DataSet from "components/DataSet";
+import React from "react";
+
+import { dateAgo } from "utilities/date_format";
+
 import {
   formatSoftwareType,
   IHostSoftware,
   ISoftwareInstallVersion,
   SoftwareSource,
 } from "interfaces/software";
-import React from "react";
-import { dateAgo } from "utilities/date_format";
+
+import Card from "components/Card";
+import DataSet from "components/DataSet";
 
 const generateVulnerabilitiesValue = (vulnerabilities: string[]) => {
   const first3 = vulnerabilities.slice(0, 3);

--- a/frontend/pages/hosts/details/components/InventoryVersions/_styles.scss
+++ b/frontend/pages/hosts/details/components/InventoryVersions/_styles.scss
@@ -1,0 +1,28 @@
+.inventory-versions {
+  display: flex;
+  flex-direction: column;
+  gap: $pad-medium;
+
+  .data-set dd {
+    white-space: initial;
+  }
+
+  &__version {
+    display: flex;
+    flex-direction: column;
+    gap: $pad-large;
+  }
+  &__row {
+    display: flex;
+    gap: $pad-xxlarge;
+  }
+
+  &__sig-info {
+    display: flex;
+    flex-direction: column;
+
+    dt {
+      min-width: 40px;
+    }
+  }
+}

--- a/frontend/pages/hosts/details/components/InventoryVersions/index.ts
+++ b/frontend/pages/hosts/details/components/InventoryVersions/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./InventoryVersions";


### PR DESCRIPTION
## This is a foundational UI component shared between my current dev work and @RachelElysia's. This PR is to share that component while we are both developing on top of it.


Much of this logic exists in the current `SoftwareDetailsModal` (under the hosts details page, not the identically named Activity feed component - will be clarifying that naming in an upcoming PR). This PR is the first step in a reorganization of much of these abstractions to better suit the desired UX around software modals. Much more detail to come shortly in actual feature work in upcoming PRs from both Rachel and I.