### PR TITLE
Show 'About Fleet' menu item when host becomes online

### DIFF
--- a/orbit/changes/30955-fixed-bug-with-about-fleet
+++ b/orbit/changes/30955-fixed-bug-with-about-fleet
@@ -1,0 +1,1 @@
+* Fixed bug on Fleet Desktop, 'About Fleet' menu item was not showing after the host is back online.

--- a/orbit/cmd/desktop/desktop.go
+++ b/orbit/cmd/desktop/desktop.go
@@ -394,6 +394,9 @@ func main() {
 				myDeviceItem.Enable()
 				myDeviceItem.Show()
 
+				transparencyItem.Enable()
+				transparencyItem.Show()
+
 				// Check our file to see if we should migrate
 				var migrationType string
 				if runtime.GOOS == "darwin" {


### PR DESCRIPTION
For [#30955](https://github.com/fleetdm/fleet/issues/30955)

Fixed bug with Fleet desktop. The 'About Fleet' menu item was not shown when the host becomes online.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [X] QA'd all new/changed functionality manually

## fleetd/orbit/Fleet Desktop

- [X] Verified that fleetd runs on macOS, Linux and Windows
- [X] Verified auto-update works from the released version of component to the new version (see [tools/tuf/test](../tools/tuf/test/README.md))
