### PR TITLE
Fix NVD feed generation

### DIFF
--- a/server/vulnerabilities/nvd/sync/cve_syncer.go
+++ b/server/vulnerabilities/nvd/sync/cve_syncer.go
@@ -166,7 +166,11 @@ func (s *CVE) update(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	lastModStartDate := string(lastModStartDate_)
+	parsed, err := time.Parse(time.RFC3339Nano, strings.TrimSpace(string(lastModStartDate_)))
+	if err != nil {
+		return fmt.Errorf("invalid last_mod_start_date.txt format: %w", err)
+	}
+	lastModStartDate := parsed.UTC().Format("2006-01-02T15:04:05.000Z")
 
 	// Get the new CVE updates since the previous synchronization.
 	lastModStartDate, err = s.sync(ctx, &lastModStartDate)

--- a/server/vulnerabilities/nvd/sync/cve_syncer.go
+++ b/server/vulnerabilities/nvd/sync/cve_syncer.go
@@ -166,11 +166,7 @@ func (s *CVE) update(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	parsed, err := time.Parse(time.RFC3339Nano, strings.TrimSpace(string(lastModStartDate_)))
-	if err != nil {
-		return fmt.Errorf("invalid last_mod_start_date.txt format: %w", err)
-	}
-	lastModStartDate := parsed.UTC().Format("2006-01-02T15:04:05.000Z")
+	lastModStartDate := string(lastModStartDate_)
 
 	// Get the new CVE updates since the previous synchronization.
 	lastModStartDate, err = s.sync(ctx, &lastModStartDate)

--- a/server/vulnerabilities/nvd/sync/cve_syncer.go
+++ b/server/vulnerabilities/nvd/sync/cve_syncer.go
@@ -439,8 +439,6 @@ func (s *CVE) sync(ctx context.Context, lastModStartDate *string) (newLastModSta
 		startIndex += cveResponse.ResultsPerPage
 		newLastModStartDate = cveResponse.Timestamp
 
-		s.logger.Log("newLastModStartDate", newLastModStartDate)
-
 		// Environment variable NETWORK_TEST_NVD_CVE_END_IDX is set only in tests
 		// (to reduce test duration time).
 		if v := os.Getenv("NETWORK_TEST_NVD_CVE_END_IDX"); v != "" {

--- a/server/vulnerabilities/nvd/sync/cve_syncer.go
+++ b/server/vulnerabilities/nvd/sync/cve_syncer.go
@@ -374,7 +374,7 @@ func (s *CVE) sync(ctx context.Context, lastModStartDate *string) (newLastModSta
 		cvesByYear              = make(map[int][]nvdapi.CVEItem)
 		retryAttempts           = 0
 		lastModEndDate          *string
-		now                     = time.Now().UTC().Format("2006-01-02T15:04:05.000")
+		now                     = time.Now().UTC().Format("2006-01-02T15:04:05.000Z")
 		vulnerabilitiesReceived = 0
 	)
 	if lastModStartDate != nil {

--- a/server/vulnerabilities/nvd/sync/cve_syncer.go
+++ b/server/vulnerabilities/nvd/sync/cve_syncer.go
@@ -332,15 +332,16 @@ func (s *CVE) updateVulnCheckYearFile(year int, cves []VulnCheckCVE, modCount, a
 
 // writeLastModStartDateFile writes the lastModStartDate to a file in the local DB directory.
 func (s *CVE) writeLastModStartDateFile(lastModStartDate string) error {
-	fmt.Println("Writing lastModStartDate:", lastModStartDate)
-	if err := os.WriteFile(
-		s.lastModStartDateFilePath(),
-		[]byte(lastModStartDate),
-		constant.DefaultWorldReadableFileMode,
-	); err != nil {
+	normalized, err := parseAndFormatForNVD(lastModStartDate)
+	if err != nil {
 		return err
 	}
-	return nil
+
+	return os.WriteFile(
+		s.lastModStartDateFilePath(),
+		[]byte(normalized),
+		constant.DefaultWorldReadableFileMode,
+	)
 }
 
 // httpClient wraps an http.Client to allow for debug and setting a request context.


### PR DESCRIPTION
# Checklist for submitter

Vulnerability incremental jobs are broken.  NVD introduced a breaking change in their feed to use inconsistent time formats.

## Testing

- [ ] Added/updated automated tests
- [X] QA'd all new/changed functionality manually:
https://github.com/mostlikelee/vulnerabilities/actions/workflows/nvd.yml
