### PR TITLE
Fleet UI: Remove unintended broken sort on type column

### DIFF
--- a/changes/30746-remove-unintended-broken-sort
+++ b/changes/30746-remove-unintended-broken-sort
@@ -1,0 +1,1 @@
+* Fleet UI: Removed unintended broken sort on Fleet Desktop > Software > type column

--- a/frontend/pages/hosts/details/cards/Software/DeviceSoftwareTableConfig.tsx
+++ b/frontend/pages/hosts/details/cards/Software/DeviceSoftwareTableConfig.tsx
@@ -72,10 +72,8 @@ export const generateSoftwareTableHeaders = (): ISoftwareTableConfig[] => {
       },
     },
     {
-      Header: (cellProps: ITableHeaderProps) => (
-        <HeaderCell value="Type" isSortedDesc={cellProps.column.isSortedDesc} />
-      ),
-      disableSortBy: false,
+      Header: "Type",
+      disableSortBy: true,
       disableGlobalFilter: true,
       accessor: "source",
       Cell: (cellProps: ITableStringCellProps) => (


### PR DESCRIPTION
## Issue
Closes #30746

## Description
XXS fix trying to get in release

## Screenshot of fix
<img width="1602" height="698" alt="Screenshot 2025-07-25 at 9 34 53 AM" src="https://github.com/user-attachments/assets/7e2f04f7-0905-4fcf-b201-c01a0342e7c3" />



# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [x] QA'd all new/changed functionality manually
