### PR TITLE
[orbit] prevent deb package installs from hanging

### DIFF
--- a/orbit/changes/31269-debian-noninteractive-software-installs
+++ b/orbit/changes/31269-debian-noninteractive-software-installs
@@ -1,0 +1,2 @@
+- Orbit now sets `DEBIAN_FRONTEND=noninteractive` by default when installing Debian packages. This prevents package installation from hanging for debconf questions. Administrators may override this in install scripts if desired.
+  - Note that installs can still hang when a configuration file differs from the version originally installed by the package. You'll need to include `--force-confdef` (or `confnew` or `confold`) in the `dpkg` command (wrap with `-o Dpkg::Options='...'` if installing using `apt`) to prevent dpkg from hanging in these cases.


### PR DESCRIPTION
Some Debian packages ask the user questions during installation. This is done via the debconf mechanism [1]. When orbit installs packages, seeking user input is not possible nor desired.

Setting this variable within orbit itself, instead of in the default installation script template, accomplishes two things:

1. Accomplishes what is usually considered the desired behavior retroactively, without requiring administrators to go back and update all of their install scripts
2. Allows administrators to override the default behavior in their scripts, in case there is a need for package installation to actually prompt the currently logged-in user for information.

Note that this does NOT prevent dpkg from blocking when a conffile has been changed since the previous installation. In these cases, the administrator should include
`-o Dpkg::Options="--force-(confdef|confold|confnew)"` in the dpkg or apt command in the install script.

[1] https://wiki.debian.org/debconf