### PR TITLE
Renew TPM-backed host identity certificates

### DIFF
--- a/ee/server/service/hostidentity/depot/depot.go
+++ b/ee/server/service/hostidentity/depot/depot.go
@@ -78,8 +78,8 @@ func (d *HostIdentitySCEPDepot) Serial() (*big.Int, error) {
 }
 
 // HasCN returns whether the given certificate exists in the depot.
-func (d *HostIdentitySCEPDepot) HasCN(cn string, allowTime int, cert *x509.Certificate, revokeOldCertificate bool) (bool, error) {
-	// Not used right now. May be used for renewal in the future.
+func (d *HostIdentitySCEPDepot) HasCN(_ string, _ int, _ *x509.Certificate, _ bool) (bool, error) {
+	// We do not use this method. Certificate existence check and revocation are done in the Put method in a single transaction.
 	return false, nil
 }
 

--- a/ee/server/service/hostidentity/scep_test.go
+++ b/ee/server/service/hostidentity/scep_test.go
@@ -150,47 +150,6 @@ func TestChallengeMiddleware_Renewal(t *testing.T) {
 		require.NotNil(t, cert)
 	})
 
-	t.Run("renewal with expired certificate", func(t *testing.T) {
-		// Create a test key pair
-		priv, err := rsa.GenerateKey(rand.Reader, 2048)
-		require.NoError(t, err)
-
-		// Create an expired certificate
-		existingCert := &x509.Certificate{
-			SerialNumber: big.NewInt(1),
-			Subject: pkix.Name{
-				CommonName: "test-host",
-			},
-			NotBefore: time.Now().Add(-48 * time.Hour),
-			NotAfter:  time.Now().Add(-24 * time.Hour), // Expired
-			PublicKey: priv.Public(),
-		}
-
-		// Create a CSR with the same public key
-		template := x509.CertificateRequest{
-			Subject: pkix.Name{
-				CommonName: "test-host",
-			},
-		}
-		csrDER, err := x509.CreateCertificateRequest(rand.Reader, &template, priv)
-		require.NoError(t, err)
-
-		csr, err := x509.ParseCertificateRequest(csrDER)
-		require.NoError(t, err)
-
-		m := &scep.CSRReqMessage{
-			CSR: csr,
-		}
-
-		// Put the renewal cert in context
-		ctx := context.WithValue(context.Background(), renewalCertKey, existingCert)
-
-		cert, err := middleware(ctx, m)
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "signer certificate is not valid")
-		require.Nil(t, cert)
-	})
-
 	t.Run("renewal with different public key", func(t *testing.T) {
 		// Create two different key pairs
 		priv1, err := rsa.GenerateKey(rand.Reader, 2048)

--- a/ee/server/service/hostidentity/scep_test.go
+++ b/ee/server/service/hostidentity/scep_test.go
@@ -1,0 +1,249 @@
+package hostidentity
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/fleetdm/fleet/v4/server/fleet"
+	"github.com/fleetdm/fleet/v4/server/mock"
+	"github.com/smallstep/scep"
+	"github.com/stretchr/testify/require"
+)
+
+// notFoundError implements fleet.NotFoundError for testing
+type notFoundError struct{}
+
+func (e *notFoundError) Error() string    { return "not found" }
+func (e *notFoundError) IsNotFound() bool { return true }
+
+func TestChallengeMiddleware_Renewal(t *testing.T) {
+	ctx := t.Context()
+
+	// Create a mock datastore
+	ds := new(mock.Store)
+
+	// Create a mock signer that just returns a test certificate
+	mockSigner := &mockCSRSigner{
+		signFunc: func(_ context.Context, m *scep.CSRReqMessage) (*x509.Certificate, error) {
+			return &x509.Certificate{
+				SerialNumber: big.NewInt(1),
+				Subject:      m.CSR.Subject,
+				NotBefore:    time.Now(),
+				NotAfter:     time.Now().Add(365 * 24 * time.Hour),
+			}, nil
+		},
+	}
+
+	// Create the middleware
+	middleware := challengeMiddleware(ds, mockSigner)
+
+	t.Run("initial enrollment with valid challenge", func(t *testing.T) {
+		// Create a test CSR
+		priv, err := rsa.GenerateKey(rand.Reader, 2048)
+		require.NoError(t, err)
+
+		template := x509.CertificateRequest{
+			Subject: pkix.Name{
+				CommonName: "test-host",
+			},
+		}
+		csrDER, err := x509.CreateCertificateRequest(rand.Reader, &template, priv)
+		require.NoError(t, err)
+
+		csr, err := x509.ParseCertificateRequest(csrDER)
+		require.NoError(t, err)
+
+		m := &scep.CSRReqMessage{
+			CSR:               csr,
+			ChallengePassword: "valid-secret",
+		}
+
+		// Set up mock to accept the enrollment secret
+		ds.VerifyEnrollSecretFunc = func(_ context.Context, secret string) (*fleet.EnrollSecret, error) {
+			if secret == "valid-secret" {
+				return &fleet.EnrollSecret{Secret: secret}, nil
+			}
+			return nil, &notFoundError{}
+		}
+
+		cert, err := middleware(ctx, m)
+		require.NoError(t, err)
+		require.NotNil(t, cert)
+	})
+
+	t.Run("initial enrollment with invalid challenge", func(t *testing.T) {
+		// Create a test CSR
+		priv, err := rsa.GenerateKey(rand.Reader, 2048)
+		require.NoError(t, err)
+
+		template := x509.CertificateRequest{
+			Subject: pkix.Name{
+				CommonName: "test-host",
+			},
+		}
+		csrDER, err := x509.CreateCertificateRequest(rand.Reader, &template, priv)
+		require.NoError(t, err)
+
+		csr, err := x509.ParseCertificateRequest(csrDER)
+		require.NoError(t, err)
+
+		m := &scep.CSRReqMessage{
+			CSR:               csr,
+			ChallengePassword: "invalid-secret",
+		}
+
+		// Set up mock to reject the enrollment secret
+		ds.VerifyEnrollSecretFunc = func(ctx context.Context, secret string) (*fleet.EnrollSecret, error) {
+			return nil, &notFoundError{}
+		}
+
+		cert, err := middleware(ctx, m)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "invalid challenge")
+		require.Nil(t, cert)
+	})
+
+	t.Run("renewal with valid certificate", func(t *testing.T) {
+		// Create a test key pair
+		priv, err := rsa.GenerateKey(rand.Reader, 2048)
+		require.NoError(t, err)
+
+		// Create a valid certificate (not expired)
+		existingCert := &x509.Certificate{
+			SerialNumber: big.NewInt(1),
+			Subject: pkix.Name{
+				CommonName: "test-host",
+			},
+			NotBefore: time.Now().Add(-24 * time.Hour),
+			NotAfter:  time.Now().Add(24 * time.Hour),
+			PublicKey: priv.Public(),
+		}
+
+		// Create a CSR with the same public key
+		template := x509.CertificateRequest{
+			Subject: pkix.Name{
+				CommonName: "test-host",
+			},
+		}
+		csrDER, err := x509.CreateCertificateRequest(rand.Reader, &template, priv)
+		require.NoError(t, err)
+
+		csr, err := x509.ParseCertificateRequest(csrDER)
+		require.NoError(t, err)
+
+		m := &scep.CSRReqMessage{
+			CSR: csr,
+			// No challenge password for renewal
+		}
+
+		// Put the renewal cert in context
+		ctx := context.WithValue(context.Background(), renewalCertKey, existingCert)
+
+		cert, err := middleware(ctx, m)
+		require.NoError(t, err)
+		require.NotNil(t, cert)
+	})
+
+	t.Run("renewal with expired certificate", func(t *testing.T) {
+		// Create a test key pair
+		priv, err := rsa.GenerateKey(rand.Reader, 2048)
+		require.NoError(t, err)
+
+		// Create an expired certificate
+		existingCert := &x509.Certificate{
+			SerialNumber: big.NewInt(1),
+			Subject: pkix.Name{
+				CommonName: "test-host",
+			},
+			NotBefore: time.Now().Add(-48 * time.Hour),
+			NotAfter:  time.Now().Add(-24 * time.Hour), // Expired
+			PublicKey: priv.Public(),
+		}
+
+		// Create a CSR with the same public key
+		template := x509.CertificateRequest{
+			Subject: pkix.Name{
+				CommonName: "test-host",
+			},
+		}
+		csrDER, err := x509.CreateCertificateRequest(rand.Reader, &template, priv)
+		require.NoError(t, err)
+
+		csr, err := x509.ParseCertificateRequest(csrDER)
+		require.NoError(t, err)
+
+		m := &scep.CSRReqMessage{
+			CSR: csr,
+		}
+
+		// Put the renewal cert in context
+		ctx := context.WithValue(context.Background(), renewalCertKey, existingCert)
+
+		cert, err := middleware(ctx, m)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "signer certificate is not valid")
+		require.Nil(t, cert)
+	})
+
+	t.Run("renewal with different public key", func(t *testing.T) {
+		// Create two different key pairs
+		priv1, err := rsa.GenerateKey(rand.Reader, 2048)
+		require.NoError(t, err)
+
+		priv2, err := rsa.GenerateKey(rand.Reader, 2048)
+		require.NoError(t, err)
+
+		// Create a certificate with the first key
+		existingCert := &x509.Certificate{
+			SerialNumber: big.NewInt(1),
+			Subject: pkix.Name{
+				CommonName: "test-host",
+			},
+			NotBefore: time.Now().Add(-24 * time.Hour),
+			NotAfter:  time.Now().Add(24 * time.Hour),
+			PublicKey: priv1.Public(),
+		}
+
+		// Create a CSR with the second key (different from cert)
+		template := x509.CertificateRequest{
+			Subject: pkix.Name{
+				CommonName: "test-host",
+			},
+		}
+		csrDER, err := x509.CreateCertificateRequest(rand.Reader, &template, priv2)
+		require.NoError(t, err)
+
+		csr, err := x509.ParseCertificateRequest(csrDER)
+		require.NoError(t, err)
+
+		m := &scep.CSRReqMessage{
+			CSR: csr,
+		}
+
+		// Put the renewal cert in context
+		ctx := context.WithValue(context.Background(), renewalCertKey, existingCert)
+
+		cert, err := middleware(ctx, m)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "CSR public key does not match signer certificate")
+		require.Nil(t, cert)
+	})
+}
+
+// mockCSRSigner implements scepserver.CSRSignerContext for testing
+type mockCSRSigner struct {
+	signFunc func(ctx context.Context, m *scep.CSRReqMessage) (*x509.Certificate, error)
+}
+
+func (m *mockCSRSigner) SignCSRContext(ctx context.Context, csr *scep.CSRReqMessage) (*x509.Certificate, error) {
+	if m.signFunc != nil {
+		return m.signFunc(ctx, csr)
+	}
+	return nil, nil
+}

--- a/server/fleet/datastore.go
+++ b/server/fleet/datastore.go
@@ -2225,6 +2225,8 @@ type Datastore interface {
 	GetHostIdentityCertBySerialNumber(ctx context.Context, serialNumber uint64) (*types.HostIdentityCertificate, error)
 	// GetHostIdentityCertByName gets the unrevoked valid cert corresponding to the provided name (CN).
 	GetHostIdentityCertByName(ctx context.Context, name string) (*types.HostIdentityCertificate, error)
+	// GetHostIdentityCertByPublicKey gets the unrevoked valid cert corresponding to the provided public key.
+	GetHostIdentityCertByPublicKey(ctx context.Context, publicKeyDER []byte) (*types.HostIdentityCertificate, error)
 	// UpdateHostIdentityCertHostIDBySerial updates the host ID associated with a certificate using its serial number.
 	UpdateHostIdentityCertHostIDBySerial(ctx context.Context, serialNumber uint64, hostID uint) error
 }

--- a/server/mock/datastore_mock.go
+++ b/server/mock/datastore_mock.go
@@ -1427,6 +1427,8 @@ type GetHostIdentityCertBySerialNumberFunc func(ctx context.Context, serialNumbe
 
 type GetHostIdentityCertByNameFunc func(ctx context.Context, name string) (*types.HostIdentityCertificate, error)
 
+type GetHostIdentityCertByPublicKeyFunc func(ctx context.Context, publicKeyDER []byte) (*types.HostIdentityCertificate, error)
+
 type UpdateHostIdentityCertHostIDBySerialFunc func(ctx context.Context, serialNumber uint64, hostID uint) error
 
 type DataStore struct {
@@ -3535,6 +3537,9 @@ type DataStore struct {
 
 	GetHostIdentityCertByNameFunc        GetHostIdentityCertByNameFunc
 	GetHostIdentityCertByNameFuncInvoked bool
+
+	GetHostIdentityCertByPublicKeyFunc        GetHostIdentityCertByPublicKeyFunc
+	GetHostIdentityCertByPublicKeyFuncInvoked bool
 
 	UpdateHostIdentityCertHostIDBySerialFunc        UpdateHostIdentityCertHostIDBySerialFunc
 	UpdateHostIdentityCertHostIDBySerialFuncInvoked bool
@@ -8454,6 +8459,13 @@ func (s *DataStore) GetHostIdentityCertByName(ctx context.Context, name string) 
 	s.GetHostIdentityCertByNameFuncInvoked = true
 	s.mu.Unlock()
 	return s.GetHostIdentityCertByNameFunc(ctx, name)
+}
+
+func (s *DataStore) GetHostIdentityCertByPublicKey(ctx context.Context, publicKeyDER []byte) (*types.HostIdentityCertificate, error) {
+	s.mu.Lock()
+	s.GetHostIdentityCertByPublicKeyFuncInvoked = true
+	s.mu.Unlock()
+	return s.GetHostIdentityCertByPublicKeyFunc(ctx, publicKeyDER)
 }
 
 func (s *DataStore) UpdateHostIdentityCertHostIDBySerial(ctx context.Context, serialNumber uint64, hostID uint) error {


### PR DESCRIPTION
For #30476 

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [ ] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [ ] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes

## Testing

- [ ] Added/updated automated tests
- [ ] Where appropriate, [automated tests simulate multiple hosts and test for host isolation](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/reference/patterns-backend.md#unit-testing) (updates to one hosts's records do not affect another)

- [ ] QA'd all new/changed functionality manually

For unreleased bug fixes in a release candidate, one of:

- [ ] Confirmed that the fix is not expected to adversely impact load test results
- [ ] Alerted the release DRI if additional load testing is needed

## Database migrations

- [ ] Checked table schema to confirm autoupdate
- [ ] Checked schema for all modified table for columns that will auto-update timestamps during migration.
- [ ] Confirmed that updating the timestamps is acceptable, and will not cause unwanted side effects.
- [ ] Ensured the correct collation is explicitly set for character columns (`COLLATE utf8mb4_unicode_ci`).

## New Fleet configuration settings

- [ ] Setting(s) is/are explicitly excluded from GitOps

If you didn't check the box above, follow this checklist for GitOps-enabled settings:

- [ ] Verified that the setting is exported via `fleetctl generate-gitops`
- [ ] Verified the setting is documented in a separate PR to [the GitOps documentation](https://github.com/fleetdm/fleet/blob/main/docs/Configuration/yaml-files.md#L485)
- [ ] Verified that the setting is cleared on the server if it is not supplied in a YAML file (or that it is documented as being optional)
- [ ] Verified that any relevant UI is disabled when GitOps mode is enabled

## fleetd/orbit/Fleet Desktop

- [ ] Verified compatibility with the latest released version of Fleet (see [Must rule](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/workflows/fleetd-development-and-release-strategy.md))
- [ ] If the change applies to only one platform, confirmed that `runtime.GOOS` is used as needed to isolate changes
- [ ] Verified that fleetd runs on macOS, Linux and Windows
- [ ] Verified auto-update works from the released version of component to the new version (see [tools/tuf/test](../tools/tuf/test/README.md))
