### PR TITLE
Fleet UI: Refetch polling reset timeout reset after every new poll (4.72 Unreleased bug fix)

### DIFF
--- a/frontend/pages/hosts/details/DeviceUserPage/DeviceUserPage.tsx
+++ b/frontend/pages/hosts/details/DeviceUserPage/DeviceUserPage.tsx
@@ -225,9 +225,6 @@ const DeviceUserPage = ({
   const resetHostRefetchStates = () => {
     setShowRefetchSpinner(false);
     setRefetchStartTime(null);
-    console.log(
-      "Host Details Page > resetHostRefetchState called which sets setRefetchStartTime(null)"
-    );
   };
 
   const isRefetching = ({
@@ -306,9 +303,8 @@ const DeviceUserPage = ({
               );
             }
           }
-          // Don't update refetch state below here; exit early if we're polling
         } else {
-          // Not refetching—reset spinner and timer
+          // Not refetching: reset spinner and timer
           resetHostRefetchStates();
         }
       },

--- a/frontend/pages/hosts/details/DeviceUserPage/DeviceUserPage.tsx
+++ b/frontend/pages/hosts/details/DeviceUserPage/DeviceUserPage.tsx
@@ -79,6 +79,7 @@ import {
 import HostHeader from "../cards/HostHeader/HostHeader";
 import { InstallOrCommandUuid } from "../cards/Software/InstallStatusCell/InstallStatusCell";
 import { AppInstallDetailsModal } from "../../../../components/ActivityDetails/InstallDetails/AppInstallDetails";
+import { REFETCH_HOST_DETAILS_POLLING_INTERVAL } from "../HostDetailsPage/HostDetailsPage";
 
 const baseClass = "device-user";
 
@@ -267,7 +268,7 @@ const DeviceUserPage = ({
               setTimeout(() => {
                 refetchHostDetails();
                 refetchExtensions();
-              }, 1000);
+              }, REFETCH_HOST_DETAILS_POLLING_INTERVAL);
             } else {
               setShowRefetchSpinner(false);
             }
@@ -278,7 +279,7 @@ const DeviceUserPage = ({
                 setTimeout(() => {
                   refetchHostDetails();
                   refetchExtensions();
-                }, 1000);
+                }, REFETCH_HOST_DETAILS_POLLING_INTERVAL);
               } else {
                 renderFlash(
                   "error",
@@ -369,7 +370,7 @@ const DeviceUserPage = ({
         setTimeout(() => {
           refetchHostDetails();
           refetchExtensions();
-        }, 1000);
+        }, REFETCH_HOST_DETAILS_POLLING_INTERVAL);
       } catch (error) {
         renderFlash("error", getErrorMessage(error, host.display_name));
         setShowRefetchSpinner(false);

--- a/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
@@ -238,7 +238,6 @@ const HostDetailsPage = ({
     setSelectedCancelActivity,
   ] = useState<IHostUpcomingActivity | null>(null);
 
-  console.log("HostDetailsPage.tsx > refetchStartTime", refetchStartTime);
   // activity states
   const [activeActivityTab, setActiveActivityTab] = useState<
     "past" | "upcoming"
@@ -345,9 +344,6 @@ const HostDetailsPage = ({
   const resetHostRefetchStates = () => {
     setShowRefetchSpinner(false);
     setRefetchStartTime(null);
-    console.log(
-      "Host Details Page > resetHostRefetchState called which sets setRefetchStartTime(null)"
-    );
   };
 
   const {
@@ -417,12 +413,10 @@ const HostDetailsPage = ({
               );
               resetHostRefetchStates();
             }
-            return; // exit early so rest doesn't run
           }
         } else {
-          // No refetch requested—reset spinner and timer
-          setShowRefetchSpinner(false);
-          setRefetchStartTime(null);
+          // Not refetching: reset spinner and timer
+          resetHostRefetchStates();
         }
 
         setHostMdmDeviceState(


### PR DESCRIPTION
## Issue
Story #30240 
Unreleased of subtask #30861

## Description
- Found this unreleased bug pairing with @jmwatts on my race condition intel bug
- Unified refetch/polling logic for host details pages (HostDetailsPage and DeviceUserPage) to ensure the "refetch vitals" polling timer is started only at the proper moment.
- Added correct handling so the refetch polling timer (refetchStartTime and showRefetchSpinner) is:
  - Started only at the beginning of a new refetch window—either when a user explicitly triggers a refetch, or the backend signals a transition to refetch_requested: true.
  - Not reset on every background poll where the backend still returns refetch_requested: true, avoiding an endless "sliding" polling window.
  - **BUG FIXED:** Properly ended when either the polling window expires (default: 60 seconds), the host goes offline, or the backend signals the refetch is complete.
- Cleaned up some code for readability 
- Updated polling interval from 1 second to 2 seconds to reduce API calls
  - Pro: Will hit host details API 1/2 as many times
  - Con: A user may need to wait up to 1 extra second for fresh data (e.g. user who once waited 31 seconds for fresh data may have to wait 32 seconds for fresh data)

## Screenrecording
Hopefully this clears up any ambiguity of the bug/solution
https://fleetdm.zoom.us/clips/share/YXlKDuwWRI-r03H644zq2w
  
# Checklist for submitter

## Testing

- [x] QA'd all new/changed functionality manually
