### PR TITLE
Added new orbit config flag.

### DIFF
--- a/changes/310650-notify-orbit-when-bitlocker-pin-is-required
+++ b/changes/310650-notify-orbit-when-bitlocker-pin-is-required
@@ -1,0 +1,1 @@
+* Added new Orbit config flag, set iff Disk Encryption is enforced enabled and the require BitLocker PIN flag is set.

--- a/docs/Contributing/reference/api-for-contributors.md
+++ b/docs/Contributing/reference/api-for-contributors.md
@@ -3914,6 +3914,7 @@ Notifies the server about an agent error, resulting in two outcomes:
       "a129a440-4cfb-48af-804b-d52224a05e1b"
     ],
     "enforce_bitlocker_encryption": true,
+    "enable_bitlocker_pin_protector_config": false,
     "pending_software_installer_ids": [
       "2267a440-4cfb-48af-804b-d52224a05e1b"
     ],

--- a/orbit/changes/310650-notify-orbit-when-bitlocker-pin-is-required
+++ b/orbit/changes/310650-notify-orbit-when-bitlocker-pin-is-required
@@ -1,0 +1,1 @@
+* Added new Orbit config flag, set iff Disk Encryption is enforced enabled and the require BitLocker PIN flag is set.

--- a/server/fleet/orbit.go
+++ b/server/fleet/orbit.go
@@ -43,6 +43,12 @@ type OrbitConfigNotifications struct {
 	// enabled and the device should encrypt its disk volumes with BitLocker.
 	EnforceBitLockerEncryption bool `json:"enforce_bitlocker_encryption,omitempty"`
 
+	// EnableBitLockerPINProtectorConfig is set if Windows MDM is enabled, BitLocker encryption is
+	// enforced, and the RequireBitLockerPIN server config flag is set. If set, this will
+	// make sure that the BitLocker policy is configured correctly so that the user can configure a
+	// TPM PIN protector.
+	EnableBitLockerPINProtectorConfig bool `json:"enable_bitlocker_pin_protector_config,omitempty"`
+
 	// PendingSoftwareInstallerIDs contains a list of software install_ids queued for installation
 	PendingSoftwareInstallerIDs []string `json:"pending_software_installer_ids,omitempty"`
 

--- a/server/service/hosts_test.go
+++ b/server/service/hosts_test.go
@@ -2220,6 +2220,7 @@ func TestSetDiskEncryptionNotifications(t *testing.T) {
 		host                     *fleet.Host
 		appConfig                *fleet.AppConfig
 		diskEncryptionConfigured bool
+		requireBitLockerPIN      bool
 		isConnectedToFleetMDM    bool
 		mdmInfo                  *fleet.HostMDM
 		getHostDiskEncryptionKey func(context.Context, uint) (*fleet.HostDiskEncryptionKey, error)
@@ -2416,6 +2417,63 @@ func TestSetDiskEncryptionNotifications(t *testing.T) {
 			},
 			expectedError: false,
 		},
+		{
+			name: "windows disk encryption enabled, PIN required enabled",
+			host: &fleet.Host{ID: 1, Platform: "windows", OsqueryHostID: ptr.String("foo")},
+			appConfig: &fleet.AppConfig{
+				MDM: fleet.MDM{EnabledAndConfigured: true},
+			},
+			diskEncryptionConfigured: true,
+			requireBitLockerPIN:      true,
+			isConnectedToFleetMDM:    true,
+			mdmInfo:                  &fleet.HostMDM{IsServer: false},
+			getHostDiskEncryptionKey: func(ctx context.Context, id uint) (*fleet.HostDiskEncryptionKey, error) {
+				return nil, newNotFoundError()
+			},
+			expectedNotifications: &fleet.OrbitConfigNotifications{
+				EnforceBitLockerEncryption:        true,
+				EnableBitLockerPINProtectorConfig: true,
+			},
+			expectedError: false,
+		},
+		{
+			name: "windows disk encryption enabled, PIN required disabled",
+			host: &fleet.Host{ID: 1, Platform: "windows", OsqueryHostID: ptr.String("foo")},
+			appConfig: &fleet.AppConfig{
+				MDM: fleet.MDM{EnabledAndConfigured: true},
+			},
+			diskEncryptionConfigured: true,
+			requireBitLockerPIN:      false,
+			isConnectedToFleetMDM:    true,
+			mdmInfo:                  &fleet.HostMDM{IsServer: false},
+			getHostDiskEncryptionKey: func(ctx context.Context, id uint) (*fleet.HostDiskEncryptionKey, error) {
+				return nil, newNotFoundError()
+			},
+			expectedNotifications: &fleet.OrbitConfigNotifications{
+				EnforceBitLockerEncryption:        true,
+				EnableBitLockerPINProtectorConfig: false,
+			},
+			expectedError: false,
+		},
+		{
+			name: "windows disk encryption disabled, PIN required enabled",
+			host: &fleet.Host{ID: 1, Platform: "windows", OsqueryHostID: ptr.String("foo")},
+			appConfig: &fleet.AppConfig{
+				MDM: fleet.MDM{EnabledAndConfigured: true},
+			},
+			diskEncryptionConfigured: false,
+			requireBitLockerPIN:      true,
+			isConnectedToFleetMDM:    true,
+			mdmInfo:                  &fleet.HostMDM{IsServer: false},
+			getHostDiskEncryptionKey: func(ctx context.Context, id uint) (*fleet.HostDiskEncryptionKey, error) {
+				return nil, newNotFoundError()
+			},
+			expectedNotifications: &fleet.OrbitConfigNotifications{
+				EnforceBitLockerEncryption:        false,
+				EnableBitLockerPINProtectorConfig: false,
+			},
+			expectedError: false,
+		},
 	}
 
 	for _, tt := range tests {
@@ -2438,7 +2496,17 @@ func TestSetDiskEncryptionNotifications(t *testing.T) {
 			}
 
 			notifs := &fleet.OrbitConfigNotifications{}
-			err := svc.setDiskEncryptionNotifications(ctx, notifs, tt.host, tt.appConfig, tt.diskEncryptionConfigured, tt.isConnectedToFleetMDM, tt.mdmInfo)
+			err := svc.setDiskEncryptionNotifications(
+				ctx,
+				notifs,
+				tt.host,
+				tt.appConfig,
+				tt.diskEncryptionConfigured,
+				tt.requireBitLockerPIN,
+				tt.isConnectedToFleetMDM,
+				tt.mdmInfo,
+			)
+
 			if tt.expectedError {
 				require.Error(t, err)
 			} else {

--- a/server/service/orbit.go
+++ b/server/service/orbit.go
@@ -397,6 +397,7 @@ func (svc *Service) GetOrbitConfig(ctx context.Context) (fleet.OrbitConfig, erro
 			host,
 			appConfig,
 			mdmConfig.EnableDiskEncryption,
+			mdmConfig.RequireBitLockerPIN,
 			isConnectedToFleetMDM,
 			mdmInfo,
 		)
@@ -472,9 +473,11 @@ func (svc *Service) GetOrbitConfig(ctx context.Context) (fleet.OrbitConfig, erro
 		host,
 		appConfig,
 		appConfig.MDM.EnableDiskEncryption.Value,
+		appConfig.MDM.RequireBitLockerPIN.Value,
 		isConnectedToFleetMDM,
 		mdmInfo,
 	)
+
 	if err != nil {
 		return fleet.OrbitConfig{}, ctxerr.Wrap(ctx, err, "setting no-team disk encryption notifications")
 	}
@@ -574,6 +577,7 @@ func (svc *Service) setDiskEncryptionNotifications(
 	host *fleet.Host,
 	appConfig *fleet.AppConfig,
 	diskEncryptionConfigured bool,
+	requireBitLockerPIN bool,
 	isConnectedToFleetMDM bool,
 	mdmInfo *fleet.HostMDM,
 ) error {
@@ -614,6 +618,8 @@ func (svc *Service) setDiskEncryptionNotifications(
 		notifs.EnforceBitLockerEncryption = !isServer &&
 			mdmInfo != nil &&
 			(needsEncryption || encryptedWithoutKey)
+
+		notifs.EnableBitLockerPINProtectorConfig = !isServer && requireBitLockerPIN
 	}
 
 	return nil


### PR DESCRIPTION
For #31065 

Added new orbit config flag 'EnableBitLockerPINProtectorConfig' set iff Disk encryption is enforced and the RequireBitLockerPIN server config flag is set.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [X] Added/updated automated tests