### PR TITLE
UI: Fix inclusion condition for 'Other workflows' policy automation

### DIFF
--- a/frontend/pages/policies/ManagePoliciesPage/ManagePoliciesPage.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/ManagePoliciesPage.tsx
@@ -139,6 +139,7 @@ const ManagePolicyPage = ({
     currentTeamName,
     currentTeamSummary,
     isAllTeamsSelected,
+    isAnyTeamSelected,
     isTeamAdmin,
     isTeamMaintainer,
     isRouteOk,
@@ -1235,7 +1236,9 @@ const ManagePolicyPage = ({
           placeholder="Manage automations"
           options={
             hasPoliciesToAutomate
-              ? getAutomationsDropdownOptions(isAllTeamsSelected || isPrimoMode) // include "Other workflows" when all teams is selected and when in Primo mode
+              ? getAutomationsDropdownOptions(
+                  isAllTeamsSelected || isAnyTeamSelected || isPrimoMode
+                ) // include "Other workflows" when all teams is selected, when a team other than No team is selected, and when in Primo mode (No team will be selected)
               : []
           }
           variant="button"


### PR DESCRIPTION
## #31333

- Include the "Other workflows" Policy automation option for all team scenarios _except_ No team in regular (non-Primo) mode
- Manually confirmed this option is present in the intended situations
- Manually confirmed that Primo mode still does contain this option
![ezgif-3c63270745ec61](https://github.com/user-attachments/assets/3f2e8f6f-1b4a-4d88-9147-d013e7efcd7f)

- [x] QA'd all new/changed functionality manually

For unreleased bug fixes in a release candidate, one of:
- [x] Confirmed that the fix is not expected to adversely impact load test results