### PR TITLE
change button styles for turn on mdm info banner

### DIFF
--- a/changes/issue-29410-turn-on-mdm-styles
+++ b/changes/issue-29410-turn-on-mdm-styles
@@ -1,0 +1,1 @@
+- update styles for turn on mdm info banner button

--- a/frontend/components/AddHostsModal/PlatformWrapper/PlatformWrapper.tsx
+++ b/frontend/components/AddHostsModal/PlatformWrapper/PlatformWrapper.tsx
@@ -368,7 +368,7 @@ const PlatformWrapper = ({
               This works for macOS, Windows, and Linux hosts. To add
               Chromebooks,{" "}
               <Button
-                variant="text-link"
+                variant="text-link-dark"
                 onClick={() => setSelectedTabIndex(4)}
               >
                 click here

--- a/frontend/components/buttons/Button/Button.stories.tsx
+++ b/frontend/components/buttons/Button/Button.stories.tsx
@@ -70,6 +70,7 @@ export const InverseAlertVariant = Template("inverse-alert");
 
 export const PillVariant = Template("pill");
 export const TextLinkVariant = Template("text-link");
+export const TextLinkDarkVariant = Template("text-link-dark");
 export const TextIconVariant = Template(
   "text-icon",
   <>

--- a/frontend/components/buttons/Button/Button.tsx
+++ b/frontend/components/buttons/Button/Button.tsx
@@ -10,7 +10,7 @@ export type ButtonVariant =
   | "alert"
   | "pill"
   | "text-link" // Underlines on hover
-  | "text-link-dark" // no underline on hover, dark text
+  | "text-link-dark" // underline on hover, dark text
   | "text-icon"
   | "icon" // Buttons without text
   | "inverse"

--- a/frontend/components/buttons/Button/Button.tsx
+++ b/frontend/components/buttons/Button/Button.tsx
@@ -10,6 +10,7 @@ export type ButtonVariant =
   | "alert"
   | "pill"
   | "text-link" // Underlines on hover
+  | "text-link-dark" // no underline on hover, dark text
   | "text-icon"
   | "icon" // Buttons without text
   | "inverse"

--- a/frontend/components/buttons/Button/_styles.scss
+++ b/frontend/components/buttons/Button/_styles.scss
@@ -181,6 +181,36 @@ $base-class: "button";
     }
   }
 
+  &--text-link-dark {
+    @include button-variant(transparent);
+    border: 0;
+    box-shadow: none;
+    color: $core-fleet-black;
+    font-size: $x-small;
+    cursor: pointer;
+    margin: 0;
+    padding: 0;
+    height: auto;
+    line-height: normal;
+    text-align: left;
+
+    &:focus {
+      outline: none;
+    }
+
+    &:hover,
+    &:focus {
+      background-color: transparent;
+      box-shadow: none;
+      text-decoration: underline;
+    }
+
+    &:active {
+      box-shadow: none;
+      top: 0;
+    }
+  }
+
   // &--icon is used for svg icon buttons without text
   &--text-icon,
   &--icon {

--- a/frontend/pages/hosts/details/DeviceUserPage/components/DeviceUserBanners/DeviceUserBanners.tsx
+++ b/frontend/pages/hosts/details/DeviceUserPage/components/DeviceUserBanners/DeviceUserBanners.tsx
@@ -6,7 +6,6 @@ import { MacDiskEncryptionActionRequired } from "interfaces/host";
 import { IHostBannersBaseProps } from "pages/hosts/details/HostDetailsPage/components/HostDetailsBanners/HostDetailsBanners";
 import CustomLink from "components/CustomLink";
 import { isDiskEncryptionSupportedLinuxPlatform } from "interfaces/platform";
-import { Link } from "react-router";
 
 const baseClass = "device-user-banners";
 
@@ -45,7 +44,7 @@ const DeviceUserBanners = ({
     diskEncryptionActionRequired === "rotate_key";
 
   const turnOnMdmButton = (
-    <Button variant="text-link" onClick={onTurnOnMdm}>
+    <Button variant="text-link-dark" onClick={onTurnOnMdm}>
       Turn on MDM
     </Button>
   );


### PR DESCRIPTION
fixes #29410 

quick update to the turn on mdm button in the info banner.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
- [x] QA'd all new/changed functionality manually
