### PR TITLE
Bump container for fleetctl preview GH Action

### DIFF
--- a/.github/workflows/fleetctl-preview.yml
+++ b/.github/workflows/fleetctl-preview.yml
@@ -26,7 +26,7 @@ jobs:
         #   - Linux Docker containers are not supported in Windows.
         #   - Unattended installation of Docker on macOS fails. (see
         #   https://github.com/docker/for-mac/issues/6450)
-        os: ubuntu-22.04
+        os: ubuntu-24.04
     runs-on: ${{ matrix.os }}
     steps:
 

--- a/.github/workflows/fleetctl-preview.yml
+++ b/.github/workflows/fleetctl-preview.yml
@@ -20,14 +20,7 @@ permissions:
 jobs:
   test-preview:
     timeout-minutes: 60
-    strategy:
-      matrix:
-        # Only run on Linux because:
-        #   - Linux Docker containers are not supported in Windows.
-        #   - Unattended installation of Docker on macOS fails. (see
-        #   https://github.com/docker/for-mac/issues/6450)
-        os: ubuntu-24.04
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     steps:
 
     - name: Harden Runner


### PR DESCRIPTION
22.04 has been removed as of today so we're currently skipping fleetctl preview testing.