### PR TITLE
Add Github Action to create issues when there are new MS MDM Protocol Changes to Review

### DIFF
--- a/.github/workflows/check-ms-protocol-feeds.yml
+++ b/.github/workflows/check-ms-protocol-feeds.yml
@@ -4,13 +4,9 @@ name: Check Microsoft MDM related protocol specification feeds for changes
 # for changes and create a Github issue for MDM engineers to review the changes
 
 on:
-  # TODO re-enable once tested
-  # schedule:
+  schedule:
     # Daily at 8:35pm CDT (1:35am UTC) -- run during off-hours to prevent hitting GitHub API rate limit
-    # - cron: "35 1 * * *"
-  push:
-    branches:
-      - JM-mdm-rss-feed
+    - cron: "35 1 * * *"
 
 jobs:
   check-ms-mdm-protocol-docs:
@@ -39,7 +35,6 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           feed: https://winprotocoldocs-bhdugrdyduf5h2e4.b02.azurefd.net/MS-MDM/%5bMS-MDM%5d.rss
           prefix: "MDM: Review Microsoft MS-MDM Proto Change for compatibility: "
-          character-limit: 255
           dry-run: false
           max-age: 36h
           labels: "#g-mdm"

--- a/.github/workflows/check-ms-protocol-feeds.yml
+++ b/.github/workflows/check-ms-protocol-feeds.yml
@@ -30,8 +30,8 @@ jobs:
           feed: https://winprotocoldocs-bhdugrdyduf5h2e4.b02.azurefd.net/MS-MDE2/%5bMS-MDE2%5d.rss
           prefix: "MDM: Review Microsoft MS-MDE2 Protocol Changes"
           character-limit: 255
-          dry-run: false
-          max-age: 48h
+          dry-run: true
+          max-age: 365d
           labels: "#g-mdm"
           url-only: true
       - name: Check MS-MDM feed
@@ -41,7 +41,7 @@ jobs:
           feed: https://winprotocoldocs-bhdugrdyduf5h2e4.b02.azurefd.net/MS-MDM/%5bMS-MDM%5d.rss
           prefix: "MDM: Review Microsoft MS-MDM Protocol Changes"
           character-limit: 255
-          dry-run: false
-          max-age: 48h
+          dry-run: true
+          max-age: 365d
           labels: "#g-mdm"
           url-only: true

--- a/.github/workflows/check-ms-protocol-feeds.yml
+++ b/.github/workflows/check-ms-protocol-feeds.yml
@@ -1,0 +1,47 @@
+name: Check Microsoft MDM related protocol specification feeds for changes
+
+# This action will check Microsoft MDM related protocol specification feeds
+# for changes and create a Github issue for MDM engineers to review the changes
+
+on:
+  # TODO re-enable once tested
+  # schedule:
+    # Daily at 8:35pm CDT (1:35am UTC) -- run during off-hours to prevent hitting GitHub API rate limit
+    # - cron: "35 1 * * *"
+  push:
+    branches:
+      - JM-mdm-rss-feed
+
+jobs:
+  check-ms-mdm-protocol-docs:
+    if: github.event.repository.owner.login == 'fleetdm'
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@63c24ba6bd7ba022e95695ff85de572c04a18142 # v2.7.0
+        with:
+          egress-policy: audit
+      - name: Check MS-MDE2 feed
+        uses: git-for-windows/rss-to-issues@07a39c615e25aaf70dc0fd84df7345ca8941d85f # v0.0.12
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          feed: https://winprotocoldocs-bhdugrdyduf5h2e4.b02.azurefd.net/MS-MDE2/%5bMS-MDE2%5d.rss
+          prefix: "MDM: Review Microsoft MS-MDE2 Protocol Changes"
+          character-limit: 255
+          dry-run: false
+          max-age: 48h
+          labels: "#g-mdm"
+          url-only: true
+      - name: Check MS-MDM feed
+        uses: git-for-windows/rss-to-issues@07a39c615e25aaf70dc0fd84df7345ca8941d85f # v0.0.12
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          feed: https://winprotocoldocs-bhdugrdyduf5h2e4.b02.azurefd.net/MS-MDM/%5bMS-MDM%5d.rss
+          prefix: "MDM: Review Microsoft MS-MDM Protocol Changes"
+          character-limit: 255
+          dry-run: false
+          max-age: 48h
+          labels: "#g-mdm"
+          url-only: true

--- a/.github/workflows/check-ms-protocol-feeds.yml
+++ b/.github/workflows/check-ms-protocol-feeds.yml
@@ -30,7 +30,7 @@ jobs:
           feed: https://winprotocoldocs-bhdugrdyduf5h2e4.b02.azurefd.net/MS-MDE2/%5bMS-MDE2%5d.rss
           prefix: "MDM: Review Microsoft MS-MDE2 Proto Change for new Request/Enrollment Versions: "
           dry-run: false
-          max-age: 180d
+          max-age: 36h
           labels: "#g-mdm"
           url-only: true
       - name: Check MS-MDM feed
@@ -40,7 +40,7 @@ jobs:
           feed: https://winprotocoldocs-bhdugrdyduf5h2e4.b02.azurefd.net/MS-MDM/%5bMS-MDM%5d.rss
           prefix: "MDM: Review Microsoft MS-MDM Proto Change for compatibility: "
           character-limit: 255
-          dry-run: true
-          max-age: 48h
+          dry-run: false
+          max-age: 36h
           labels: "#g-mdm"
           url-only: true

--- a/.github/workflows/check-ms-protocol-feeds.yml
+++ b/.github/workflows/check-ms-protocol-feeds.yml
@@ -30,7 +30,7 @@ jobs:
           feed: https://winprotocoldocs-bhdugrdyduf5h2e4.b02.azurefd.net/MS-MDE2/%5bMS-MDE2%5d.rss
           prefix: "MDM: Review Microsoft MS-MDE2 Proto Change for new Request/Enrollment Versions: "
           dry-run: false
-          max-age: 365d
+          max-age: 180d
           labels: "#g-mdm"
           url-only: true
       - name: Check MS-MDM feed

--- a/.github/workflows/check-ms-protocol-feeds.yml
+++ b/.github/workflows/check-ms-protocol-feeds.yml
@@ -28,9 +28,8 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           feed: https://winprotocoldocs-bhdugrdyduf5h2e4.b02.azurefd.net/MS-MDE2/%5bMS-MDE2%5d.rss
-          prefix: "MDM: Review Microsoft MS-MDE2 Protocol Changes"
-          character-limit: 255
-          dry-run: true
+          prefix: "MDM: Review Microsoft MS-MDE2 Proto Change for new Request/Enrollment Versions: "
+          dry-run: false
           max-age: 365d
           labels: "#g-mdm"
           url-only: true
@@ -39,9 +38,9 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           feed: https://winprotocoldocs-bhdugrdyduf5h2e4.b02.azurefd.net/MS-MDM/%5bMS-MDM%5d.rss
-          prefix: "MDM: Review Microsoft MS-MDM Protocol Changes"
+          prefix: "MDM: Review Microsoft MS-MDM Proto Change for compatibility: "
           character-limit: 255
           dry-run: true
-          max-age: 365d
+          max-age: 48h
           labels: "#g-mdm"
           url-only: true


### PR DESCRIPTION
The impetus for this was #31232 . Some MDM migrations and enrollments broke because MDM Enrollment Protocol changes snuck in that we didn't see

Now within 24h of Microsoft publishing changes to the MDM or MDE2 protocols we will get a github issue to review them

See #31423 for an example

# Checklist for submitter

## Testing


- [x] QA'd all new/changed functionality manually

