### PR TITLE
Remove experimental note from "Enroll hosts" guide

### DIFF
--- a/articles/enroll-hosts.md
+++ b/articles/enroll-hosts.md
@@ -29,8 +29,6 @@ A `--fleet-url` (Fleet instance URL) and `--enroll-secret` (Fleet enrollment sec
 
 To generate fleetd for an Arm Linux or Windows host, use the `--arch=arm64` flag.
 
-> **Fleetd for Arm Windows is an experimental feature**. This feature is undergoing rapid improvement, which may result in breaking changes to the API or configuration surface. It is not recommended for use in automated workflows.
-
 #### Example
 
 Generate fleetd on macOS (.pkg)


### PR DESCRIPTION
https://github.com/fleetdm/fleet/issues/28714 specifies removing this as part of the doc changes.