### PR TITLE
Revert "[orbit] prevent deb package installs from hanging (#31269)"

### DIFF
--- a/orbit/changes/31269-debian-noninteractive-software-installs
+++ b/orbit/changes/31269-debian-noninteractive-software-installs
@@ -1,2 +1,0 @@
-- Orbit now sets `DEBIAN_FRONTEND=noninteractive` by default when installing Debian packages. This prevents package installation from hanging for debconf questions. Administrators may override this in install scripts if desired.
-  - Note that installs can still hang when a configuration file differs from the version originally installed by the package. You'll need to include `--force-confdef` (or `confnew` or `confold`) in the `dpkg` command (wrap with `-o Dpkg::Options='...'` if installing using `apt`) to prevent dpkg from hanging in these cases.

--- a/orbit/pkg/installer/installer.go
+++ b/orbit/pkg/installer/installer.go
@@ -322,7 +322,7 @@ func (r *Runner) installSoftware(ctx context.Context, installID string, logger z
 	if strings.HasSuffix(installerPath, ".tgz") || strings.HasSuffix(installerPath, ".tar.gz") {
 		logger.Info().Msg("detected tar.gz archive, extracting to subdirectory")
 		extractDestination := filepath.Join(tmpDir, extractionDirectoryName)
-		err := os.Mkdir(extractDestination, 0o700)
+		err := os.Mkdir(extractDestination, 0700)
 		if err != nil {
 			logger.Err(err).Msg("failed to create directory for .tar.gz extraction")
 			// Using download failed exit code here to indicate that installer extraction failed
@@ -424,12 +424,6 @@ func (r *Runner) runInstallerScript(ctx context.Context, scriptContents string, 
 	env := os.Environ()
 	installerPathEnv := fmt.Sprintf("INSTALLER_PATH=%s", installerPath)
 	env = append(env, installerPathEnv)
-	if strings.HasSuffix(installerPath, ".deb") {
-		// On Debian and Ubuntu systems, packages sometimes ask the user questions
-		// during installation. This will cause package installation to hang
-		// indefinitely. Setting this envvar prevents that.
-		env = append(env, "DEBIAN_FRONTEND=noninteractive")
-	}
 
 	output, exitCode, err := execFn(ctx, scriptPath, env)
 	if err != nil {


### PR DESCRIPTION
This reverts commit 20519adb0b8a417acece304fb6bfb5018a0540c2 so we have time to repro/QA it without blocking the fleetd release.