### PR TITLE
update manage host table to not include serial number cell for personally devices enrolled in mdm

### DIFF
--- a/frontend/interfaces/mdm.ts
+++ b/frontend/interfaces/mdm.ts
@@ -272,3 +272,10 @@ export const isEnrolledInMdm = (
     hostMdmEnrollmentStatus
   );
 };
+
+/** determines if the host enrolled in mdm is a personal device */
+export const isPersonalEnrollmentInMdm = (
+  enrollmentStatus: MdmEnrollmentStatus | null
+) => {
+  return enrollmentStatus === "On (personal)";
+};

--- a/frontend/pages/hosts/ManageHostsPage/HostTableConfig.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/HostTableConfig.tsx
@@ -7,6 +7,7 @@ import ReactTooltip from "react-tooltip";
 
 import { IDeviceUser, IHost } from "interfaces/host";
 import { isAndroid, isMobilePlatform } from "interfaces/platform";
+import { isPersonalEnrollmentInMdm } from "interfaces/mdm";
 
 import Checkbox from "components/forms/fields/Checkbox";
 import DiskSpaceIndicator from "pages/hosts/components/DiskSpaceIndicator";
@@ -611,7 +612,10 @@ const allHostTableHeaders: IHostTableColumnConfig[] = [
     id: "hardware_serial",
     Cell: (cellProps: IHostTableStringCellProps) => {
       // TODO(android): is iOS/iPadOS supported?
-      if (isAndroid(cellProps.row.original.platform)) {
+      if (
+        isAndroid(cellProps.row.original.platform) ||
+        isPersonalEnrollmentInMdm(cellProps.row.original.mdm.enrollment_status)
+      ) {
         return NotSupported;
       }
       return <TextCell value={cellProps.cell.value} />;

--- a/frontend/pages/hosts/details/HostDetailsPage/HostActionsDropdown/helpers.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/HostActionsDropdown/helpers.tsx
@@ -10,7 +10,7 @@ import {
   isIPadOrIPhone,
 } from "interfaces/platform";
 import { isScriptSupportedPlatform } from "interfaces/script";
-import { MdmEnrollmentStatus } from "interfaces/mdm";
+import { isPersonalEnrollmentInMdm, MdmEnrollmentStatus } from "interfaces/mdm";
 
 import {
   HostMdmDeviceStatusUIState,
@@ -182,7 +182,8 @@ const canWipeHost = ({
   // there is a special case for iOS and iPadOS devices that are personally enrolled
   // in MDM. These hosts cannot be wiped.
   const isPersonallyEnrolledIosOrIpadDevice =
-    isIPadOrIPhone(hostPlatform) && hostMdmEnrollmentStatus === "On (personal)";
+    isIPadOrIPhone(hostPlatform) &&
+    isPersonalEnrollmentInMdm(hostMdmEnrollmentStatus);
 
   return (
     isPremiumTier &&

--- a/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
@@ -120,6 +120,7 @@ import {
   generateUsernameValues,
 } from "../cards/User/helpers";
 import HostHeader from "../cards/HostHeader";
+import { isPersonalEnrollmentInMdm } from "interfaces/mdm";
 
 const baseClass = "host-details";
 
@@ -1009,7 +1010,7 @@ const HostDetailsPage = ({
               {/* There is a special case for personally enrolled mdm hosts where we are not
                currently supporting software installs. This check should be removed
                when we add that feature. */}
-              {host.mdm.enrollment_status === "On (personal)" ? (
+              {isPersonalEnrollmentInMdm(host.mdm.enrollment_status) ? (
                 <EmptyTable
                   header="Software library is currently not supported on this host."
                   info={

--- a/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
@@ -50,6 +50,7 @@ import {
 } from "utilities/constants";
 
 import { isAndroid, isIPadOrIPhone, isLinuxLike } from "interfaces/platform";
+import { isPersonalEnrollmentInMdm } from "interfaces/mdm";
 
 import Spinner from "components/Spinner";
 import TabNav from "components/TabNav";
@@ -120,7 +121,6 @@ import {
   generateUsernameValues,
 } from "../cards/User/helpers";
 import HostHeader from "../cards/HostHeader";
-import { isPersonalEnrollmentInMdm } from "interfaces/mdm";
 
 const baseClass = "host-details";
 

--- a/frontend/pages/hosts/details/cards/About/About.tsx
+++ b/frontend/pages/hosts/details/cards/About/About.tsx
@@ -3,7 +3,10 @@ import classnames from "classnames";
 
 import { IHostMdmData, IMunkiData } from "interfaces/host";
 import { isAndroid, isIPadOrIPhone } from "interfaces/platform";
-import { MDM_ENROLLMENT_STATUS_UI_MAP } from "interfaces/mdm";
+import {
+  isPersonalEnrollmentInMdm,
+  MDM_ENROLLMENT_STATUS_UI_MAP,
+} from "interfaces/mdm";
 import {
   DEFAULT_EMPTY_CELL_VALUE,
   MDM_STATUS_TOOLTIP,
@@ -52,7 +55,7 @@ const About = ({ aboutData, munki, mdm, className }: IAboutProps) => {
     // for all host types, we show the Enrollment ID dataset if the host
     // is enrolled in MDM personally. Personal (BYOD) devices do not report
     // their serial numbers, so we show the Enrollment ID instead.
-    if (mdm && mdm.enrollment_status === "On (personal)") {
+    if (mdm && isPersonalEnrollmentInMdm(mdm.enrollment_status)) {
       deviceIdDataSet = (
         <DataSet
           title={


### PR DESCRIPTION
quick change to host table to show "Not supported" for the serial number cell for persaonl devices enrolled in mdm.

I've pulled out the check if a host is a personal device enrolled in mdm and have used this where needed.
