### PR TITLE
DO not review - 30692 byod idp auth poc

### DIFF
--- a/frontend/templates/enroll-ota.html
+++ b/frontend/templates/enroll-ota.html
@@ -186,6 +186,7 @@
               pop-up.
             </span>
           </p>
+          <!-- TODO IB Need to auth this request -->
           <a class="download-link" href="{{.EnrollURL}}">Download</a>
         </li>
         <li>
@@ -349,6 +350,7 @@
       };
 
       const getEnrollmentToken = async () => {
+        // TODO IB We need to pass the bearer token here
         const enrollSecret = getEnrollmentSecret();
 
         const response = await fetch(

--- a/server/mdm/android/service/service.go
+++ b/server/mdm/android/service/service.go
@@ -412,6 +412,7 @@ type enrollmentTokenResponse struct {
 	android.DefaultResponse
 }
 
+// TODO IB This endpoint should be authenticated by MDM SSO in some cases
 func enrollmentTokenEndpoint(ctx context.Context, request interface{}, svc android.Service) fleet.Errorer {
 	req := request.(*enrollmentTokenRequest)
 	token, err := svc.CreateEnrollmentToken(ctx, req.EnrollSecret)

--- a/server/service/apple_mdm.go
+++ b/server/service/apple_mdm.go
@@ -6781,6 +6781,7 @@ type getOTAProfileRequest struct {
 	EnrollSecret string `query:"enroll_secret"`
 }
 
+// TODO IB This endpoint should be authenticated in some contexts
 func getOTAProfileEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (fleet.Errorer, error) {
 	req := request.(*getOTAProfileRequest)
 	profile, err := svc.GetOTAProfile(ctx, req.EnrollSecret)

--- a/server/service/frontend.go
+++ b/server/service/frontend.go
@@ -130,7 +130,7 @@ func ServeEndUserEnrollOTA(
 				herr(w, "verify enroll secret: "+err.Error())
 				return
 			}
-			// TODO handle fleetnotfound
+			// TODO IB handle fleetnotfound
 			if foundSecret.TeamID == nil || *foundSecret.TeamID == 0 {
 				requiresEndUserAuth = appCfg.MDM.MacOSSetup.EnableEndUserAuthentication
 			} else {
@@ -151,10 +151,13 @@ func ServeEndUserEnrollOTA(
 			if bearerToken == "" {
 				serveMDMSSOPage = true
 			}
-			// Todo check if valid
+			// TODO IB check if valid
+			if bearerToken != "supersecret" {
+				serveMDMSSOPage = true
+			}
 		}
 
-		logger.Log("msg", "serving enroll page", "serve_mdm_sso_page", serveMDMSSOPage)
+		logger.Log("msg", "serving enroll page - post SSO check", "serve_mdm_sso_page", serveMDMSSOPage)
 
 		enrollURL, err := generateEnrollOTAURL(urlPrefix, enrollSecret)
 		if err != nil {
@@ -167,12 +170,16 @@ func ServeEndUserEnrollOTA(
 			AndroidMDMEnabled     bool
 			MacMDMEnabled         bool
 			AndroidFeatureEnabled bool
+			RequiresEndUserAuth   bool
+			ServeMDMSSOPage       bool
 		}{
 			URLPrefix:             urlPrefix,
 			EnrollURL:             enrollURL,
 			AndroidMDMEnabled:     appCfg.MDM.AndroidEnabledAndConfigured,
 			MacMDMEnabled:         appCfg.MDM.EnabledAndConfigured,
 			AndroidFeatureEnabled: true,
+			RequiresEndUserAuth:   requiresEndUserAuth,
+			ServeMDMSSOPage:       serveMDMSSOPage,
 		}); err != nil {
 			herr(w, "execute react template: "+err.Error())
 			return


### PR DESCRIPTION
# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [ ] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [ ] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes

## Testing

- [ ] Added/updated automated tests
- [ ] Where appropriate, [automated tests simulate multiple hosts and test for host isolation](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/reference/patterns-backend.md#unit-testing) (updates to one hosts's records do not affect another)

- [ ] QA'd all new/changed functionality manually

For unreleased bug fixes in a release candidate, one of:

- [ ] Confirmed that the fix is not expected to adversely impact load test results
- [ ] Alerted the release DRI if additional load testing is needed

## Database migrations

- [ ] Checked table schema to confirm autoupdate
- [ ] Checked schema for all modified table for columns that will auto-update timestamps during migration.
- [ ] Confirmed that updating the timestamps is acceptable, and will not cause unwanted side effects.
- [ ] Ensured the correct collation is explicitly set for character columns (`COLLATE utf8mb4_unicode_ci`).

## New Fleet configuration settings

- [ ] Setting(s) is/are explicitly excluded from GitOps

If you didn't check the box above, follow this checklist for GitOps-enabled settings:

- [ ] Verified that the setting is exported via `fleetctl generate-gitops`
- [ ] Verified the setting is documented in a separate PR to [the GitOps documentation](https://github.com/fleetdm/fleet/blob/main/docs/Configuration/yaml-files.md#L485)
- [ ] Verified that the setting is cleared on the server if it is not supplied in a YAML file (or that it is documented as being optional)
- [ ] Verified that any relevant UI is disabled when GitOps mode is enabled

## fleetd/orbit/Fleet Desktop

- [ ] Verified compatibility with the latest released version of Fleet (see [Must rule](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/workflows/fleetd-development-and-release-strategy.md))
- [ ] If the change applies to only one platform, confirmed that `runtime.GOOS` is used as needed to isolate changes
- [ ] Verified that fleetd runs on macOS, Linux and Windows
- [ ] Verified auto-update works from the released version of component to the new version (see [tools/tuf/test](../tools/tuf/test/README.md))
