### PR TITLE
Product group handbook: speed up community PRs

### DIFF
--- a/handbook/company/product-groups.md
+++ b/handbook/company/product-groups.md
@@ -97,7 +97,9 @@ To make a change to Fleet:
 - Then, it will be [drafted](https://fleetdm.com/handbook/company/product-groups#drafting) (planned).
 - Next, it will be [implemented](https://fleetdm.com/handbook/company/product-groups#implementing) and [released](https://fleetdm.com/handbook/engineering#release-process).
 
-> Occasionally, a contributor outside of the [product groups](https://fleetdm.com/handbook/product-groups#current-product-groups) (open source contributor, member of the Customer Success team, etc.) will implement a change that was prioritized and drafted. On the user story for these changes, add the product group label (e.g. `#g-mdm`, `#g-orchestration`, `#g-software`), the `:release` label, and notify the product group's Engineer Manager to make sure the changes go through testing (QA) before release.
+Occasionally, a contributor outside of the [product groups](https://fleetdm.com/handbook/product-groups#current-product-groups) (open source contributor, member of the Customer Success team, etc.) will implement a change that was prioritized and drafted. On the user story for these changes, add the product group label (e.g. `#g-mdm`, `#g-orchestration`, `#g-software`), the `:release` label, and notify the product group's Engineer Manager to make sure the changes go through testing (QA) before release.
+
+Also, sometimes a contributor will propose a change in the form of a pull request (PR). When this happens, the PR will be [reviewed](https://fleetdm.com/handbook/engineering#review-a-community-pull-request) and then merged or closed.
 
 ### Planned and unplanned changes
 

--- a/handbook/engineering/README.md
+++ b/handbook/engineering/README.md
@@ -82,7 +82,7 @@ The PD will be the contact point for the contributor and will ensure the PR is r
 
 - Set the PR to draft.
 - Immediately decide whether to prioritize a user story and bring it through drafting or put the change to the side (not prioritize).
-- Thank the contributor for their hard work, notify them on whether their change was prioritized or put to the side. If the change was put to the side, ask the contributor to file a [feature request](https://github.com/fleetdm/fleet/issues/new?assignees=&labels=%3Aproduct&projects=&template=feature-request.md&title=) that describe the change their PR is introducing, let them know that it only means the change has been rejected _at that time_, and close the PR.
+- Thank the contributor for their hard work, notify them on whether their change was prioritized or put to the side. If the change was put to the side, ask the contributor to file a [feature request](https://github.com/fleetdm/fleet/issues/new?assignees=&labels=%3Aproduct&projects=&template=feature-request.md&title=) that describes the change, let them know that it only means the change has been rejected _at that time_, and close the PR.
 
 
 ### Merge a community pull request

--- a/handbook/engineering/README.md
+++ b/handbook/engineering/README.md
@@ -76,17 +76,13 @@ If the PR is a quick fix (i.e. typo) or obvious technical improvement that doesn
 **For PRs that change the product:**
 
 - Assign the PR to the appropriate product group EM (Engineering Manager).
-- Notify the EM in the #help-engineering Slack channel.
+- Notify the relevant Product Designer (PD) in the #g-mdm, #g-software, or #g-orchestration Slack channel.
 
-The EM will be the contact point for the contributor and will ensure the PR is reviewed by the appropriate team member when ready. The EM should:
+The PD will be the contact point for the contributor and will ensure the PR is reviewed by the appropriate team member when ready. The PD should:
 
 - Set the PR to draft.
-- Thank the contributor for their hard work, explain that all changes to the product go through Fleet's [prioritization process](https://fleetdm.com/handbook/company/product-groups#how-feature-requests-are-prioritized), and ask them to file a [feature request](https://github.com/fleetdm/fleet/issues/new?assignees=&labels=%3Aproduct&projects=&template=feature-request.md&title=) that describe the change their PR is introducing.
-
-**For PRs that will not be merged:**
-
-- Thank the contributor for their effort and explain why the changes won't be merged.
-- Close the PR.
+- Immediately decide whether to prioritize a user story and bring it through drafting or put the change to the side (not prioritize).
+- Thank the contributor for their hard work, notify them on whether their change was prioritized or put to the side. If the change was put to the side, ask the contributor to file a [feature request](https://github.com/fleetdm/fleet/issues/new?assignees=&labels=%3Aproduct&projects=&template=feature-request.md&title=) that describe the change their PR is introducing, let them know that it only means the change has been rejected _at that time_, and close the PR.
 
 
 ### Merge a community pull request

--- a/handbook/engineering/README.md
+++ b/handbook/engineering/README.md
@@ -69,14 +69,14 @@ All bug fix pull requests should reference the issue they resolve with the issue
 
 ### Review a community pull request
 
-If you're assigned a community pull request for review, it is important to keep things moving for the contributor. The goal is to not go more than one business day without following up with the contributor.
+If you're assigned a community pull request (PR) for review, it is important to keep things moving for the contributor. The goal is to not go more than one business day without following up with the contributor. This applies to PRs from Fleeties, open source contributors, member of the Customer Success team, etc.
 
 If the PR is a quick fix (i.e. typo) or obvious technical improvement that doesn't change the product, it can be merged.
 
 **For PRs that change the product:**
 
-- Assign the PR to the appropriate product group EM (Engineering Manager).
-- Notify the relevant Product Designer (PD) in the #g-mdm, #g-software, or #g-orchestration Slack channel.
+- Assign the PR to the appropriate product group Product Designer (PD).
+- Notify the relevant PD in the #g-mdm, #g-software, or #g-orchestration Slack channel.
 
 The PD will be the contact point for the contributor and will ensure the PR is reviewed by the appropriate team member when ready. The PD should:
 

--- a/handbook/engineering/README.md
+++ b/handbook/engineering/README.md
@@ -75,7 +75,7 @@ If the PR is a quick fix (i.e. typo) or obvious technical improvement that doesn
 
 **For PRs that change the product:**
 
-- Assign the PR to the appropriate product group Product Designer (PD).
+- Assign the PR to the appropriate Product Designer (PD).
 - Notify the relevant PD in the #g-mdm, #g-software, or #g-orchestration Slack channel.
 
 The PD will be the contact point for the contributor and will ensure the PR is reviewed by the appropriate team member when ready. The PD should:


### PR DESCRIPTION
Applies to PRs from Fleeties, open source contributors, member of the Customer Success team, etc.

Why? Move faster when good improvements come in the form of PRs. Examples:
- https://fleetdm.slack.com/archives/C02A8BRABB5/p1753968979427419
- https://github.com/fleetdm/fleet/pull/31075
  - @noahtalerman: We already followed this new "fast track" for this PR. User story was pulled into drafting: #1817