### PR TITLE
Handbook: Update section about actions taken when a bug is in drafting

### DIFF
--- a/handbook/company/product-groups.md
+++ b/handbook/company/product-groups.md
@@ -498,9 +498,17 @@ Remove the “:reproduce” label, add the following labels:
 
 #### In product drafting
 
-After reproduction, all released bugs go through drafting to validate that it is not expected behavior, it requires a code change to fix, and the bug report is fully populated.
+After reproduction, all released bugs go through drafting to validate that it is not expected behavior, it requires a code change to fix, and the bug report is fully populated. During drafting, product design will take any of the following actions:
 
-It will stay in this state until product design closes the bug, updates it to a feature request by removing all bug labels and leaving the issue in the "New requests" column, assigns it to a non-engineering team, or moves it to the "Ready to estimate" column of the drafting board for engineering review and estimation.
++ Close the bug
++ Update it to a feature request
+  - Remove all bug labels
+  - Leave the issue in the "New requests" column
++ Assign it to a non-engineering team
++ Prepare the bug for engineering review and estimation
+  - Specify a fix or a timebox
+  - Update the issue title, if it no longer matches our understanding of the issue
+  - Move it to the "Ready to estimate" column of the drafting board
 
 If a bug meets the criteria for a [critical bug](https://fleetdm.com/handbook/company/product-groups#release-testing), the `~critical bug` label is added, and product design follows the [critical bug notification process](https://fleetdm.com/handbook/company/product-groups#notify-the-community-about-a-critical-bug).
 

--- a/handbook/company/product-groups.md
+++ b/handbook/company/product-groups.md
@@ -498,17 +498,17 @@ Remove the “:reproduce” label, add the following labels:
 
 #### In product drafting
 
-After reproduction, all released bugs go through drafting to validate that it is not expected behavior, it requires a code change to fix, and the bug report is fully populated. During drafting, product design will take any of the following actions:
+After reproduction, all released bugs go through drafting to validate that it is not expected behavior, it requires a code change to fix, and the bug report is fully populated. During drafting, product design will take one of the following actions:
 
-+ Close the bug
-+ Update it to a feature request
-  - Remove all bug labels
-  - Leave the issue in the "New requests" column
-+ Assign it to a non-engineering team
-+ Prepare the bug for engineering review and estimation
++ Prepare for engineering review and estimation
   - Specify a fix or a timebox
   - Update the issue title, if it no longer matches our understanding of the issue
   - Move it to the "Ready to estimate" column of the drafting board
++ Convert to a feature request
+  - Remove all bug labels
+  - Leave the issue in the "New requests" column
++ Assign to a non-engineering team
++ Close, if determined to be expected behavior
 
 If a bug meets the criteria for a [critical bug](https://fleetdm.com/handbook/company/product-groups#release-testing), the `~critical bug` label is added, and product design follows the [critical bug notification process](https://fleetdm.com/handbook/company/product-groups#notify-the-community-about-a-critical-bug).
 


### PR DESCRIPTION
+ Updated the section about bugs in drafting to make it a little easier to see the steps to take for converting to a feature request or preparing for estimation
+ Added a note about updating the issue titles (can cause confusion in estimation if it doesn't reflect the specified fix)