### PR TITLE
Ability to set TPM PIN protector policy on host.

### DIFF
--- a/changes/310650-notify-orbit-when-bitlocker-pin-is-required
+++ b/changes/310650-notify-orbit-when-bitlocker-pin-is-required
@@ -1,1 +1,0 @@
-* Added new Orbit config flag, set iff Disk Encryption is enforced enabled and the require BitLocker PIN flag is set.

--- a/changes/31193-turn-on-ability-to-set-tpm-pin
+++ b/changes/31193-turn-on-ability-to-set-tpm-pin
@@ -1,0 +1,1 @@
+* Made sure that if disk encryption is enabled and a TPM PIN is required, the user is able to set a TPM PIN protector.

--- a/docs/Contributing/reference/api-for-contributors.md
+++ b/docs/Contributing/reference/api-for-contributors.md
@@ -3971,7 +3971,6 @@ Notifies the server about an agent error, resulting in two outcomes:
       "a129a440-4cfb-48af-804b-d52224a05e1b"
     ],
     "enforce_bitlocker_encryption": true,
-    "enable_bitlocker_pin_protector_config": false,
     "pending_software_installer_ids": [
       "2267a440-4cfb-48af-804b-d52224a05e1b"
     ],

--- a/orbit/changes/310650-notify-orbit-when-bitlocker-pin-is-required
+++ b/orbit/changes/310650-notify-orbit-when-bitlocker-pin-is-required
@@ -1,1 +1,0 @@
-* Added new Orbit config flag, set iff Disk Encryption is enforced enabled and the require BitLocker PIN flag is set.

--- a/server/fleet/orbit.go
+++ b/server/fleet/orbit.go
@@ -43,12 +43,6 @@ type OrbitConfigNotifications struct {
 	// enabled and the device should encrypt its disk volumes with BitLocker.
 	EnforceBitLockerEncryption bool `json:"enforce_bitlocker_encryption,omitempty"`
 
-	// EnableBitLockerPINProtectorConfig is set if Windows MDM is enabled, BitLocker encryption is
-	// enforced, and the RequireBitLockerPIN server config flag is set. If set, this will
-	// make sure that the BitLocker policy is configured correctly so that the user can configure a
-	// TPM PIN protector.
-	EnableBitLockerPINProtectorConfig bool `json:"enable_bitlocker_pin_protector_config,omitempty"`
-
 	// PendingSoftwareInstallerIDs contains a list of software install_ids queued for installation
 	PendingSoftwareInstallerIDs []string `json:"pending_software_installer_ids,omitempty"`
 

--- a/server/mdm/microsoft/bitlocker_csp.go
+++ b/server/mdm/microsoft/bitlocker_csp.go
@@ -1,0 +1,130 @@
+package microsoft_mdm
+
+import (
+	"bytes"
+	"errors"
+	"github.com/fleetdm/fleet/v4/server/fleet"
+	"text/template"
+)
+
+const (
+	PolicyOptDropdownDisallowed = iota
+	PolicyOptDropdownRequired
+	PolicyOptDropdownOptional
+)
+
+var systemDrRequiresStartupAuthTmpl = template.Must(template.New("cmd").Funcs(map[string]any{
+	"derefBool": func(val *bool) bool {
+		return val != nil && *val
+	}, "derefUint": func(val *uint) uint {
+		if val == nil {
+			// Use 'optional' as the default value.
+			return PolicyOptDropdownOptional
+		}
+		return *val
+	}}).Parse(`
+<Atomic>
+	<CmdID>{{ .CmdUUID }}-1</CmdID>
+	<Replace>
+		<CmdID>{{ .CmdUUID }}-2</CmdID>
+		<Item>
+			<Meta>
+			  <Format>chr</Format>
+			  <Type>text/plain</Type>
+			</Meta>
+			<Target>
+				<LocURI>./Device/Vendor/MSFT/BitLocker/SystemDrivesRequireStartupAuthentication</LocURI>
+			</Target>
+			<Data>
+			{{ if .Enabled }}
+			<![CDATA[
+				<enabled/>
+				<data id="ConfigureNonTPMStartupKeyUsage_Name" value="{{ derefBool .ConfigureNonTPMStartupKey }}"/>
+				<data id="ConfigureTPMStartupKeyUsageDropDown_Name" value="{{ derefUint .ConfigureTPMStartupKey }}"/>
+				<data id="ConfigurePINUsageDropDown_Name" value="{{ derefUint .ConfigurePIN }}"/>
+				<data id="ConfigureTPMPINKeyUsageDropDown_Name" value="{{ derefUint .ConfigureTPMPINKey }}"/>
+				<data id="ConfigureTPMUsageDropDown_Name" value="{{ derefUint .ConfigureTPM }}"/>
+			]]>
+			{{ else }}
+			<![CDATA[<disabled/>]]>
+			{{ end }}
+			</Data>
+		</Item>
+	</Replace>
+</Atomic>`,
+))
+
+// SystemDrRequiresStartupAuthSpec specification for the SystemDrivesRequireStartupAuthentication command.
+// uint values must be one of the PolicyOptDropdown* variants
+type SystemDrRequiresStartupAuthSpec struct {
+	CmdUUID string
+	// Enabled specifies whether the 'Require additional authentication at startup'
+	// policy setting should be enabled or not.
+	Enabled bool
+	// ConfigureNonTPMStartup allows BitLocker without a compatible TPM
+	ConfigureNonTPMStartupKey *bool
+	// ConfigureTPMStartupKey configures TPM startup key.
+	ConfigureTPMStartupKey *uint
+	// ConfigurePIN configures TPM startup PIN
+	ConfigurePIN *uint
+	// ConfigureTPMPINKey configures TPM startup key and PIN
+	ConfigureTPMPINKey *uint
+	// ConfigureTPM configures configure TPM startup
+	ConfigureTPM *uint
+}
+
+func (spec SystemDrRequiresStartupAuthSpec) validate() error {
+	if spec.CmdUUID == "" {
+		return errors.New("cmdUUID is required")
+	}
+
+	if !spec.Enabled && (spec.ConfigureNonTPMStartupKey != nil ||
+		spec.ConfigureTPMStartupKey != nil ||
+		spec.ConfigurePIN != nil ||
+		spec.ConfigureTPMPINKey != nil ||
+		spec.ConfigureTPM != nil) {
+		return errors.New("enabled must be true if any other field is set")
+	}
+
+	validateVariants := func(name string, val *uint) error {
+		if val != nil &&
+			*val != PolicyOptDropdownDisallowed &&
+			*val != PolicyOptDropdownRequired &&
+			*val != PolicyOptDropdownOptional {
+			return errors.New(name + " must be one of the PolicyOptDropdown* variants")
+		}
+		return nil
+	}
+	variantFields := map[string]*uint{
+		"ConfigureTPMStartupKey": spec.ConfigureTPMStartupKey,
+		"ConfigurePIN":           spec.ConfigurePIN,
+		"ConfigureTPMPINKey":     spec.ConfigureTPMPINKey,
+		"ConfigureTPM":           spec.ConfigureTPM,
+	}
+	for name, val := range variantFields {
+		if err := validateVariants(name, val); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// SystemDrRequiresStartupAuthCmd turns a SystemDrRequiresStartupAuthSpec into a
+// https://learn.microsoft.com/en-us/windows/client-management/mdm/bitlocker-csp#systemdrivesrequirestartupauthentication
+// CMD.
+func SystemDrRequiresStartupAuthCmd(spec SystemDrRequiresStartupAuthSpec) (*fleet.MDMWindowsCommand, error) {
+	if err := spec.validate(); err != nil {
+		return nil, err
+	}
+
+	var contents bytes.Buffer
+	if err := systemDrRequiresStartupAuthTmpl.Execute(&contents, spec); err != nil {
+		return nil, errors.New("failed to execute SystemDrRequiresStartupAuthCmd template")
+	}
+
+	return &fleet.MDMWindowsCommand{
+		CommandUUID:  spec.CmdUUID,
+		RawCommand:   contents.Bytes(),
+		TargetLocURI: "./Device/Vendor/MSFT/BitLocker/SystemDrivesRequireStartupAuthentication",
+	}, nil
+}

--- a/server/mdm/microsoft/bitlocker_csp_test.go
+++ b/server/mdm/microsoft/bitlocker_csp_test.go
@@ -1,0 +1,193 @@
+package microsoft_mdm
+
+import (
+	"github.com/fleetdm/fleet/v4/server/ptr"
+	"github.com/stretchr/testify/require"
+	"strings"
+	"testing"
+)
+
+func TestSystemDrRequiresStartupAuthSpec_validate(t *testing.T) {
+	tests := []struct {
+		name    string
+		spec    SystemDrRequiresStartupAuthSpec
+		wantErr string
+	}{
+		{
+			name:    "empty cmdUUID",
+			spec:    SystemDrRequiresStartupAuthSpec{},
+			wantErr: "cmdUUID is required",
+		},
+		{
+			name: "fields set but not enabled",
+			spec: SystemDrRequiresStartupAuthSpec{
+				CmdUUID:                "test-uuid",
+				Enabled:                false,
+				ConfigureTPMStartupKey: ptr.Uint(PolicyOptDropdownRequired),
+			},
+			wantErr: "enabled must be true if any other field is set",
+		},
+		{
+			name: "valid configuration with no fields",
+			spec: SystemDrRequiresStartupAuthSpec{
+				CmdUUID: "test-uuid",
+				Enabled: false,
+			},
+		},
+		{
+			name: "valid configuration with enabled fields",
+			spec: SystemDrRequiresStartupAuthSpec{
+				CmdUUID:                "test-uuid",
+				Enabled:                true,
+				ConfigureTPMStartupKey: ptr.Uint(PolicyOptDropdownRequired),
+				ConfigurePIN:           ptr.Uint(PolicyOptDropdownOptional),
+			},
+		},
+		{
+			name: "invalid TPMStartupKey value",
+			spec: SystemDrRequiresStartupAuthSpec{
+				CmdUUID:                "test-uuid",
+				Enabled:                true,
+				ConfigureTPMStartupKey: ptr.Uint(99),
+			},
+			wantErr: "ConfigureTPMStartupKey must be one of the PolicyOptDropdown* variants",
+		},
+		{
+			name: "invalid PIN value",
+			spec: SystemDrRequiresStartupAuthSpec{
+				CmdUUID:      "test-uuid",
+				Enabled:      true,
+				ConfigurePIN: ptr.Uint(99),
+			},
+			wantErr: "ConfigurePIN must be one of the PolicyOptDropdown* variants",
+		},
+		{
+			name: "invalid TPMPINKey value",
+			spec: SystemDrRequiresStartupAuthSpec{
+				CmdUUID:            "test-uuid",
+				Enabled:            true,
+				ConfigureTPMPINKey: ptr.Uint(99), // Invalid value
+			},
+			wantErr: "ConfigureTPMPINKey must be one of the PolicyOptDropdown* variants",
+		},
+		{
+			name: "invalid TPM value",
+			spec: SystemDrRequiresStartupAuthSpec{
+				CmdUUID:      "test-uuid",
+				Enabled:      true,
+				ConfigureTPM: ptr.Uint(99),
+			},
+			wantErr: "ConfigureTPM must be one of the PolicyOptDropdown* variants",
+		},
+		{
+			name: "all fields set with valid values",
+			spec: SystemDrRequiresStartupAuthSpec{
+				CmdUUID:                   "test-uuid",
+				Enabled:                   true,
+				ConfigureNonTPMStartupKey: ptr.Bool(true),
+				ConfigureTPMStartupKey:    ptr.Uint(PolicyOptDropdownDisallowed),
+				ConfigurePIN:              ptr.Uint(PolicyOptDropdownRequired),
+				ConfigureTPMPINKey:        ptr.Uint(PolicyOptDropdownOptional),
+				ConfigureTPM:              ptr.Uint(PolicyOptDropdownRequired),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.spec.validate()
+			if tt.wantErr == "" {
+				require.NoError(t, err)
+			} else {
+				require.Errorf(t, err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestSystemDrRequiresStartupAuthCmd_Template(t *testing.T) {
+	tests := []struct {
+		name     string
+		spec     SystemDrRequiresStartupAuthSpec
+		expected string
+	}{
+		{
+			name: "disabled",
+			spec: SystemDrRequiresStartupAuthSpec{
+				CmdUUID: "uuid-123",
+				Enabled: false,
+			},
+			expected: `
+				<Atomic>
+					<CmdID>uuid-123-1</CmdID>
+					<Replace>
+						<CmdID>uuid-123-2</CmdID>
+						<Item>
+							<Meta>
+							  <Format>chr</Format>
+							  <Type>text/plain</Type>
+							</Meta>
+							<Target>
+								<LocURI>./Device/Vendor/MSFT/BitLocker/SystemDrivesRequireStartupAuthentication</LocURI>
+							</Target>
+							<Data>
+							<![CDATA[<disabled/>]]>
+							</Data>
+						</Item>
+					</Replace>
+				</Atomic>`,
+		},
+		{
+			name: "enabled",
+			spec: SystemDrRequiresStartupAuthSpec{
+				CmdUUID:                   "uuid-789",
+				Enabled:                   true,
+				ConfigureNonTPMStartupKey: ptr.Bool(true),
+				ConfigureTPMStartupKey:    ptr.Uint(PolicyOptDropdownRequired),
+				ConfigurePIN:              ptr.Uint(PolicyOptDropdownOptional),
+				ConfigureTPMPINKey:        ptr.Uint(PolicyOptDropdownDisallowed),
+				ConfigureTPM:              ptr.Uint(PolicyOptDropdownRequired),
+			},
+			expected: `
+				<Atomic>
+					<CmdID>uuid-789-1</CmdID>
+					<Replace>
+						<CmdID>uuid-789-2</CmdID>
+						<Item>
+							<Meta>
+							  <Format>chr</Format>
+							  <Type>text/plain</Type>
+							</Meta>
+							<Target>
+								<LocURI>./Device/Vendor/MSFT/BitLocker/SystemDrivesRequireStartupAuthentication</LocURI>
+							</Target>
+							<Data>
+							<![CDATA[
+								<enabled/>
+								<data id="ConfigureNonTPMStartupKeyUsage_Name" value="true"/>
+								<data id="ConfigureTPMStartupKeyUsageDropDown_Name" value="1"/>
+								<data id="ConfigurePINUsageDropDown_Name" value="2"/>
+								<data id="ConfigureTPMPINKeyUsageDropDown_Name" value="0"/>
+								<data id="ConfigureTPMUsageDropDown_Name" value="1"/>
+							]]>
+							</Data>
+						</Item>
+					</Replace>
+				</Atomic>`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd, err := SystemDrRequiresStartupAuthCmd(tt.spec)
+			require.NoError(t, err)
+
+			got := strings.Join(strings.Fields(string(cmd.RawCommand)), " ")
+			want := strings.Join(strings.Fields(tt.expected), " ")
+
+			require.Equal(t, want, got)
+			require.Equal(t, tt.spec.CmdUUID, cmd.CommandUUID)
+			require.Equal(t, "./Device/Vendor/MSFT/BitLocker/SystemDrivesRequireStartupAuthentication", cmd.TargetLocURI)
+		})
+	}
+}

--- a/server/service/hosts_test.go
+++ b/server/service/hosts_test.go
@@ -2220,7 +2220,6 @@ func TestSetDiskEncryptionNotifications(t *testing.T) {
 		host                     *fleet.Host
 		appConfig                *fleet.AppConfig
 		diskEncryptionConfigured bool
-		requireBitLockerPIN      bool
 		isConnectedToFleetMDM    bool
 		mdmInfo                  *fleet.HostMDM
 		getHostDiskEncryptionKey func(context.Context, uint) (*fleet.HostDiskEncryptionKey, error)
@@ -2417,63 +2416,6 @@ func TestSetDiskEncryptionNotifications(t *testing.T) {
 			},
 			expectedError: false,
 		},
-		{
-			name: "windows disk encryption enabled, PIN required enabled",
-			host: &fleet.Host{ID: 1, Platform: "windows", OsqueryHostID: ptr.String("foo")},
-			appConfig: &fleet.AppConfig{
-				MDM: fleet.MDM{EnabledAndConfigured: true},
-			},
-			diskEncryptionConfigured: true,
-			requireBitLockerPIN:      true,
-			isConnectedToFleetMDM:    true,
-			mdmInfo:                  &fleet.HostMDM{IsServer: false},
-			getHostDiskEncryptionKey: func(ctx context.Context, id uint) (*fleet.HostDiskEncryptionKey, error) {
-				return nil, newNotFoundError()
-			},
-			expectedNotifications: &fleet.OrbitConfigNotifications{
-				EnforceBitLockerEncryption:        true,
-				EnableBitLockerPINProtectorConfig: true,
-			},
-			expectedError: false,
-		},
-		{
-			name: "windows disk encryption enabled, PIN required disabled",
-			host: &fleet.Host{ID: 1, Platform: "windows", OsqueryHostID: ptr.String("foo")},
-			appConfig: &fleet.AppConfig{
-				MDM: fleet.MDM{EnabledAndConfigured: true},
-			},
-			diskEncryptionConfigured: true,
-			requireBitLockerPIN:      false,
-			isConnectedToFleetMDM:    true,
-			mdmInfo:                  &fleet.HostMDM{IsServer: false},
-			getHostDiskEncryptionKey: func(ctx context.Context, id uint) (*fleet.HostDiskEncryptionKey, error) {
-				return nil, newNotFoundError()
-			},
-			expectedNotifications: &fleet.OrbitConfigNotifications{
-				EnforceBitLockerEncryption:        true,
-				EnableBitLockerPINProtectorConfig: false,
-			},
-			expectedError: false,
-		},
-		{
-			name: "windows disk encryption disabled, PIN required enabled",
-			host: &fleet.Host{ID: 1, Platform: "windows", OsqueryHostID: ptr.String("foo")},
-			appConfig: &fleet.AppConfig{
-				MDM: fleet.MDM{EnabledAndConfigured: true},
-			},
-			diskEncryptionConfigured: false,
-			requireBitLockerPIN:      true,
-			isConnectedToFleetMDM:    true,
-			mdmInfo:                  &fleet.HostMDM{IsServer: false},
-			getHostDiskEncryptionKey: func(ctx context.Context, id uint) (*fleet.HostDiskEncryptionKey, error) {
-				return nil, newNotFoundError()
-			},
-			expectedNotifications: &fleet.OrbitConfigNotifications{
-				EnforceBitLockerEncryption:        false,
-				EnableBitLockerPINProtectorConfig: false,
-			},
-			expectedError: false,
-		},
 	}
 
 	for _, tt := range tests {
@@ -2502,7 +2444,6 @@ func TestSetDiskEncryptionNotifications(t *testing.T) {
 				tt.host,
 				tt.appConfig,
 				tt.diskEncryptionConfigured,
-				tt.requireBitLockerPIN,
 				tt.isConnectedToFleetMDM,
 				tt.mdmInfo,
 			)

--- a/server/service/orbit.go
+++ b/server/service/orbit.go
@@ -397,7 +397,6 @@ func (svc *Service) GetOrbitConfig(ctx context.Context) (fleet.OrbitConfig, erro
 			host,
 			appConfig,
 			mdmConfig.EnableDiskEncryption,
-			mdmConfig.RequireBitLockerPIN,
 			isConnectedToFleetMDM,
 			mdmInfo,
 		)
@@ -473,7 +472,6 @@ func (svc *Service) GetOrbitConfig(ctx context.Context) (fleet.OrbitConfig, erro
 		host,
 		appConfig,
 		appConfig.MDM.EnableDiskEncryption.Value,
-		appConfig.MDM.RequireBitLockerPIN.Value,
 		isConnectedToFleetMDM,
 		mdmInfo,
 	)
@@ -577,7 +575,6 @@ func (svc *Service) setDiskEncryptionNotifications(
 	host *fleet.Host,
 	appConfig *fleet.AppConfig,
 	diskEncryptionConfigured bool,
-	requireBitLockerPIN bool,
 	isConnectedToFleetMDM bool,
 	mdmInfo *fleet.HostMDM,
 ) error {
@@ -618,8 +615,6 @@ func (svc *Service) setDiskEncryptionNotifications(
 		notifs.EnforceBitLockerEncryption = !isServer &&
 			mdmInfo != nil &&
 			(needsEncryption || encryptedWithoutKey)
-
-		notifs.EnableBitLockerPINProtectorConfig = !isServer && requireBitLockerPIN
 	}
 
 	return nil

--- a/server/service/osquery_utils/queries.go
+++ b/server/service/osquery_utils/queries.go
@@ -6,6 +6,7 @@ import (
 	"encoding/base64"
 	"encoding/hex"
 	"fmt"
+	"github.com/google/uuid"
 	"net"
 	"net/url"
 	"regexp"
@@ -2425,6 +2426,79 @@ var luksVerifyQueryIngester = func(decrypter func(string) (string, error)) func(
 	}
 }
 
+// tpmPINConfigVerifyQuery checks the Windows registry to verify whether the host has the proper
+// BitLocker policy for allowing the setup of a TPM PIN protector, if not properly set, the proper
+// configuration is enforced via an MDM command.
+var tpmPINConfigVerifyQuery = DetailQuery{
+	Platforms: []string{"windows"},
+	// We only want to run this query iff:
+	// - BitLocker is not an optional component (is built in) OR is an optional component and enabled.
+	// - And a TPM PIN is not yet set.
+	// - And the volume is encrypted (to avoid errors while trying to apply the policy).
+	Discovery: `
+WITH should_run(ready) AS (
+SELECT
+	(
+	    -- BitLocker is optional but enabled
+		EXISTS(SELECT 1 FROM windows_optional_features WHERE name = 'BitLocker' AND state = 1)
+	    -- BitLocker is built in, so it won't appear as an optional feature
+		OR NOT EXISTS(SELECT 1 FROM windows_optional_features WHERE name = 'BitLocker') 
+	)
+	-- PIN is already set, so regardless of the current config, we don't need to enforce it:
+	-- 4: TPM And PIN.
+	-- 6: TPM And PIN And Startup key.
+	AND NOT EXISTS(SELECT 1 FROM bitlocker_key_protectors WHERE drive_letter = 'C:' AND key_protector_type IN (4,6))
+	-- Volume is encrypted
+	AND EXISTS(SELECT 1 FROM bitlocker_info WHERE drive_letter = 'C:' AND protection_status = 1)
+)
+SELECT 1 FROM should_run WHERE ready = 1`,
+	Query: "SELECT data FROM registry WHERE path='HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\FVE\\UseTPMPIN'",
+	DirectIngestFunc: func(
+		ctx context.Context,
+		logger log.Logger,
+		host *fleet.Host,
+		ds fleet.Datastore,
+		rows []map[string]string,
+	) error {
+		if host == nil || host.UUID == "" {
+			level.Debug(logger).Log(
+				"method", "tpmPINConfigVerifyQuery",
+				"msg", "Ingestion not run, host is nil or UUID is empty",
+			)
+			return nil
+		}
+
+		if len(rows) > 1 {
+			return ctxerr.Errorf(
+				ctx,
+				"tpmPINConfigVerifyQuery invalid number of rows: %d", len(rows),
+			)
+		}
+
+		// If no results are returned, then the policy setting is in a 'Not Configured' state.
+		// If the policy is 'Enabled', we need to make sure the proper setting is not in a 'Disallowed' state.
+		if len(rows) == 0 || rows[0]["data"] == fmt.Sprintf("%d", microsoft_mdm.PolicyOptDropdownDisallowed) {
+			level.Info(logger).Log(
+				"method", "tpmPINConfigVerifyQuery",
+				"msg", "Updating TPM PIN protector configuration via MDM",
+				"host_id", host.ID,
+			)
+			cmd, err := microsoft_mdm.SystemDrRequiresStartupAuthCmd(
+				microsoft_mdm.SystemDrRequiresStartupAuthSpec{
+					CmdUUID:      uuid.NewString(),
+					Enabled:      true,
+					ConfigurePIN: ptr.Uint(microsoft_mdm.PolicyOptDropdownOptional),
+				},
+			)
+			if err != nil {
+				return err
+			}
+			return ds.MDMWindowsInsertCommandForHosts(ctx, []string{host.UUID}, cmd)
+		}
+		return nil
+	},
+}
+
 //go:generate go run gen_queries_doc.go "../../../docs/Contributing/product-groups/orchestration/understanding-host-vitals.md"
 
 type Integrations struct {
@@ -2479,6 +2553,12 @@ func GetDetailQueries(
 				continue
 			}
 			generatedMap[key] = query
+		}
+
+		if appConfig.MDM.WindowsEnabledAndConfigured &&
+			appConfig.MDM.EnableDiskEncryption.Value &&
+			appConfig.MDM.RequireBitLockerPIN.Value {
+			generatedMap["tpm_pin_config_verify"] = tpmPINConfigVerifyQuery
 		}
 	}
 


### PR DESCRIPTION
For #31193.

Added a new detail query used for determining whether the user is able to set up a TPM PIN protector, if not able, an MDM command is queued up to apply the proper policy on the host.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.
- [X] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)

## Testing

- [X] Added/updated automated tests
- [X] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced automated verification and configuration of TPM PIN protector policies for Windows hosts with BitLocker enabled.
  * Added new system queries to check and update TPM PIN settings when required.

* **Bug Fixes**
  * Improved handling and enforcement of TPM PIN configuration under specific disk encryption conditions.

* **Documentation**
  * Updated API documentation to reflect removal of BitLocker PIN protector configuration notifications.

* **Tests**
  * Added and updated tests to ensure correct validation and command generation for BitLocker and TPM PIN policies.
  * Removed outdated test cases related to BitLocker PIN requirements.

* **Chores**
  * Removed obsolete configuration flags and related logic for BitLocker PIN notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->