### PR TITLE
#314500->Fleet 4.72.0 RC Fix API errors on Wipe/Lock/Turn off MDM on Personal MDM devices

### DIFF
--- a/cmd/fleetctl/fleetctl/mdm_test.go
+++ b/cmd/fleetctl/fleetctl/mdm_test.go
@@ -1372,6 +1372,7 @@ func setupDSMocks(ds *mock.Store, hostByUUID map[string]testhost, hostsByID map[
 
 		return h.host, nil
 	}
+	ds.HostFunc = mock.HostFunc(ds.HostLiteFunc)
 	ds.GetMDMWindowsBitLockerStatusFunc = func(ctx context.Context, host *fleet.Host) (*fleet.HostMDMDiskEncryption, error) {
 		return nil, nil
 	}

--- a/server/fleet/errors.go
+++ b/server/fleet/errors.go
@@ -22,11 +22,14 @@ var (
 	ErrWindowsMDMNotConfigured = &WindowsMDMNotConfiguredError{}
 	ErrNotConfigured           = &NotConfiguredError{}
 
-	MDMNotConfiguredMessage              = "MDM features aren't turned on in Fleet. For more information about setting up MDM, please visit https://fleetdm.com/docs/using-fleet"
-	WindowsMDMNotConfiguredMessage       = "Windows MDM isn't turned on. For more information about setting up MDM, please visit https://fleetdm.com/learn-more-about/windows-mdm"
-	AppleMDMNotConfiguredMessage         = "macOS MDM isn't turned on. Visit https://fleetdm.com/docs/using-fleet to learn how to turn on MDM."
-	AppleABMDefaultTeamDeprecatedMessage = "mdm.apple_bm_default_team has been deprecated. Please use the new mdm.apple_business_manager key documented here: https://fleetdm.com/learn-more-about/apple-business-manager-gitops"
-	CantTurnOffMDMForWindowsHostsMessage = "Can't turn off MDM for Windows hosts."
+	MDMNotConfiguredMessage               = "MDM features aren't turned on in Fleet. For more information about setting up MDM, please visit https://fleetdm.com/docs/using-fleet"
+	WindowsMDMNotConfiguredMessage        = "Windows MDM isn't turned on. For more information about setting up MDM, please visit https://fleetdm.com/learn-more-about/windows-mdm"
+	AppleMDMNotConfiguredMessage          = "macOS MDM isn't turned on. Visit https://fleetdm.com/docs/using-fleet to learn how to turn on MDM."
+	AppleABMDefaultTeamDeprecatedMessage  = "mdm.apple_bm_default_team has been deprecated. Please use the new mdm.apple_business_manager key documented here: https://fleetdm.com/learn-more-about/apple-business-manager-gitops"
+	CantTurnOffMDMForWindowsHostsMessage  = "Can't turn off MDM for Windows hosts."
+	CantTurnOffMDMForPersonalHostsMessage = "Couldn't turn off MDM. This command isn't available for personal hosts."
+	CantWipePersonalHostsMessage          = "Couldn't wipe. This command isn't available for personal hosts."
+	CantLockPersonalHostsMessage          = "Couldn't lock. This command isn't available for personal hosts."
 )
 
 // ErrWithStatusCode is an interface for errors that should set a specific HTTP

--- a/server/service/apple_mdm.go
+++ b/server/service/apple_mdm.go
@@ -2241,6 +2241,11 @@ func (svc *Service) EnqueueMDMAppleCommandRemoveEnrollmentProfile(ctx context.Co
 	if nanoEnroll == nil || !nanoEnroll.Enabled {
 		return fleet.NewUserMessageError(ctxerr.New(ctx, fmt.Sprintf("mdm is not enabled for host %d", hostID)), http.StatusConflict)
 	}
+	if nanoEnroll.Type == "User Enrollment (Device)" {
+		return &fleet.BadRequestError{
+			Message: fleet.CantTurnOffMDMForPersonalHostsMessage,
+		}
+	}
 
 	cmdUUID := uuid.New().String()
 	err = svc.mdmAppleCommander.RemoveProfile(ctx, []string{nanoEnroll.ID}, apple_mdm.FleetPayloadIdentifier, cmdUUID)

--- a/server/service/hosts_test.go
+++ b/server/service/hosts_test.go
@@ -1906,12 +1906,14 @@ func TestLockUnlockWipeHostAuth(t *testing.T) {
 	ds.LockHostViaScriptFunc = func(ctx context.Context, request *fleet.HostScriptRequestPayload, platform string) error {
 		return nil
 	}
-	ds.HostLiteFunc = func(ctx context.Context, hostID uint) (*fleet.Host, error) {
+	// Some functions use Host, others HostLite. For our purposes either is fine
+	ds.HostFunc = func(ctx context.Context, hostID uint) (*fleet.Host, error) {
 		if hostID == teamHostID {
 			return teamHost, nil
 		}
 		return globalHost, nil
 	}
+	ds.HostLiteFunc = mock.HostLiteFunc(ds.HostFunc)
 	ds.GetMDMWindowsBitLockerStatusFunc = func(ctx context.Context, host *fleet.Host) (*fleet.HostMDMDiskEncryption, error) {
 		return nil, nil
 	}


### PR DESCRIPTION
Fixes #31450 in 4.72.0 RC branch

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)

## Testing

- [x] Added/updated automated tests

- [x] QA'd all new/changed functionality manually

For unreleased bug fixes in a release candidate, one of:

- [x] Confirmed that the fix is not expected to adversely impact load test results
