### PR TITLE
Dogfood - Fix error in log on empty cert.00.pem, when retrieving rds tls certificate

### DIFF
--- a/infrastructure/dogfood/terraform/aws-tf-module/templates/mysql_ca_tls_retrieval.sh.tpl
+++ b/infrastructure/dogfood/terraform/aws-tf-module/templates/mysql_ca_tls_retrieval.sh.tpl
@@ -2,7 +2,7 @@
 apk add coreutils openssl
         
 wget --quiet  https://truststore.pki.rds.amazonaws.com/${aws_region}/${aws_region}-bundle.pem -O ${aws_region}-bundle.dl.pem
-csplit -k -f cert. -b '%02d.pem' ${aws_region}-bundle.dl.pem '/-----BEGIN CERTIFICATE-----/' '{*}'
+csplit -z -k -f cert. -b '%02d.pem' ${aws_region}-bundle.dl.pem '/-----BEGIN CERTIFICATE-----/' '{*}'
 
 for filename in cert.*;
 do 


### PR DESCRIPTION
Fix for error log that is generated by csplit when determining the correct certificate to use.

```
Could not find certificate from cert.00.pem
```