### PR TITLE
Update conditional-access-test-group.yml

### DIFF
--- a/it-and-security/lib/all/labels/conditional-access-test-group.yml
+++ b/it-and-security/lib/all/labels/conditional-access-test-group.yml
@@ -7,3 +7,4 @@
     - "allens-mac-mini.local"
     - "Mitchs-MBP"
     - "MacBookPro.lan"
+    - "Mac.attlocal.net"


### PR DESCRIPTION
- @noahtalerman: Adding @rachaelshaw. Looks like this will include a couple more Macs than intended...

<img width="448" height="314" alt="Screenshot 2025-08-01 at 2 07 31 PM" src="https://github.com/user-attachments/assets/0cf2b088-9796-4ed0-89ad-8aff550f3f35" />

  - @allenhouchins: Only end users with this label that are in the canary team will be bothered with pop ups.

- @noahtalerman: Guess we really need #28116


