### PR TITLE
Cherry-Pick: Bump container for fleetctl preview GH Action

### DIFF
--- a/.github/workflows/fleetctl-preview.yml
+++ b/.github/workflows/fleetctl-preview.yml
@@ -20,14 +20,7 @@ permissions:
 jobs:
   test-preview:
     timeout-minutes: 60
-    strategy:
-      matrix:
-        # Only run on Linux because:
-        #   - Linux Docker containers are not supported in Windows.
-        #   - Unattended installation of Docker on macOS fails. (see
-        #   https://github.com/docker/for-mac/issues/6450)
-        os: ubuntu-22.04
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     steps:
 
     - name: Harden Runner


### PR DESCRIPTION
Merged into `main` in #31389. No effect on RC, but cherry-picking to clean up build errors.