### PR TITLE
Website: Update `create-android-enterprise` exits

### DIFF
--- a/website/api/controllers/android-proxy/create-android-enterprise.js
+++ b/website/api/controllers/android-proxy/create-android-enterprise.js
@@ -153,7 +153,8 @@ module.exports = {
       pubsubTopicName: fullPubSubTopicName,
       pubsubSubscriptionName: newSubscriptionName,
       fleetServerSecret: newFleetServerSecret,
-    });
+    })
+    .intercept('E_UNIQUE', 'enterpriseAlreadyExists');
 
 
 


### PR DESCRIPTION
Closes: https://github.com/fleetdm/fleet/issues/31506

Changes:
- Updated the `create-android-enterprise` action to return a 409 response if a database record already exists for the Android enterprise.