### PR TITLE
Fix installer tarball extraction in fleetd for archives with unknown header flags/files declared before parent dirs

### DIFF
--- a/orbit/changes/31338-31525-tarball-install
+++ b/orbit/changes/31338-31525-tarball-install
@@ -1,0 +1,2 @@
+* Fixed tarball extraction failures due to unknown TAR headers
+* Fixed tarball extraction failures on archives that don't include a parent directory header before files in that directory

--- a/orbit/pkg/installer/installer.go
+++ b/orbit/pkg/installer/installer.go
@@ -334,7 +334,7 @@ func (r *Runner) installSoftware(ctx context.Context, installID string, logger z
 		extractFn := r.extractTarGzFn
 		if extractFn == nil {
 			extractFn = func(path string, destDir string) error {
-				return file.ExtractTarGz(path, destDir, 2*1024*1024*1024*1024) // 2 TiB limit per extracted file
+				return file.ExtractTarGz(path, destDir, 2*1024*1024*1024*1024, logger) // 2 TiB limit per extracted file
 			}
 		}
 

--- a/pkg/file/file.go
+++ b/pkg/file/file.go
@@ -246,6 +246,11 @@ func ExtractTarGz(path string, destDir string, maxFileSize int64) error {
 			}
 		case tar.TypeReg:
 			err := func() error {
+				// Make sure parent directory exists
+				if err := os.MkdirAll(filepath.Dir(targetPath), constant.DefaultDirMode); err != nil {
+					return fmt.Errorf("ensure parent dir exists %q: %w", header.Name, err)
+				}
+
 				outFile, err := os.OpenFile(targetPath, os.O_CREATE|os.O_WRONLY, header.FileInfo().Mode())
 				if err != nil {
 					return fmt.Errorf("failed to create %q: %w", header.Name, err)

--- a/pkg/file/file.go
+++ b/pkg/file/file.go
@@ -19,6 +19,7 @@ import (
 	"github.com/fleetdm/fleet/v4/orbit/pkg/constant"
 	"github.com/fleetdm/fleet/v4/pkg/secure"
 	"github.com/fleetdm/fleet/v4/server/fleet"
+	"github.com/rs/zerolog"
 )
 
 var ErrUnsupportedType = errors.New("unsupported file type")
@@ -205,7 +206,7 @@ func ExtractFilenameFromURLPath(p string, defaultExtension string) string {
 // a package. destDir should be provided by the code rather than user input to
 // avoid directory traversal attacks. maxFileSize indicates how large we want
 // to allow the max file size to be when decompressing, as a zip bomb mitigation.
-func ExtractTarGz(path string, destDir string, maxFileSize int64) error {
+func ExtractTarGz(path string, destDir string, maxFileSize int64, logger zerolog.Logger) error {
 	tarGzFile, err := os.Open(path)
 	if err != nil {
 		return fmt.Errorf("open %q: %w", path, err)
@@ -282,7 +283,7 @@ func ExtractTarGz(path string, destDir string, maxFileSize int64) error {
 				return err
 			}
 		default:
-			return fmt.Errorf("unknown flag type %q: %d", header.Name, header.Typeflag)
+			logger.Warn().Msgf("skipping unknown tar header flag type %d: %q", header.Typeflag, header.Name)
 		}
 	}
 }


### PR DESCRIPTION
Fixes #31338, #31525.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [s] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)

## Testing

- [x] QA'd all new/changed functionality manually


## fleetd/orbit/Fleet Desktop

- [x] Verified compatibility with the latest released version of Fleet (see [Must rule](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/workflows/fleetd-development-and-release-strategy.md))
- [x] If the change applies to only one platform, confirmed that `runtime.GOOS` is used as needed to isolate changes
- [ ] Verified that fleetd runs on macOS, Linux and Windows
- [ ] Verified auto-update works from the released version of component to the new version (see [tools/tuf/test](../tools/tuf/test/README.md))