### PR TITLE
Updating CIS policies for macOS 15, 14, and 13

### DIFF
--- a/changes/31106-macos-cis-updates
+++ b/changes/31106-macos-cis-updates
@@ -1,0 +1,1 @@
+- Updated macOS 15 CIS policies to align with CIS Benchmark v1.1.0 changes from v1.0.0.

--- a/changes/31106-macos-cis-updates
+++ b/changes/31106-macos-cis-updates
@@ -1,3 +1,3 @@
-- Updated macOS 15 CIS policies to align with CIS Benchmark v1.1.0 changes from v1.0.0.
-- Updated macOS 14 CIS policies to align with CIS Benchmark v2.1.0 changes from v2.0.0.
-- Updated macOS 13 CIS policies to align with CIS Benchmark v3.1.0 changes from v3.0.0.
+- Updated macOS 15 CIS policies to align with CIS Benchmark v1.1.0 (from v1.0.0).
+- Updated macOS 14 CIS policies to align with CIS Benchmark v2.1.0 (from v2.0.0).
+- Updated macOS 13 CIS policies to align with CIS Benchmark v3.1.0 (from v3.0.0).

--- a/changes/31106-macos-cis-updates
+++ b/changes/31106-macos-cis-updates
@@ -1,1 +1,3 @@
 - Updated macOS 15 CIS policies to align with CIS Benchmark v1.1.0 changes from v1.0.0.
+- Updated macOS 14 CIS policies to align with CIS Benchmark v2.1.0 changes from v2.0.0.
+- Updated macOS 13 CIS policies to align with CIS Benchmark v3.1.0 changes from v3.0.0.

--- a/ee/cis/macos-13/cis-policy-queries.yml
+++ b/ee/cis/macos-13/cis-policy-queries.yml
@@ -2714,8 +2714,8 @@ spec:
       WHERE 
         f.path LIKE '/Library/%'
         AND f.type = 'directory'
-        AND (f.mode LIKE '%2' OR f.mode LIKE '%3' OR f.mode LIKE '%6' OR f.mode LIKE '%7')
-        AND NOT (f.mode LIKE '1%')
+        AND (CAST(SUBSTR(f.mode,-1) AS INTEGER) & 2) = 2
+        AND NOT ((CAST(f.mode AS INTEGER) & 01000) = 01000)
         AND NOT EXISTS (
           SELECT 1 FROM extended_attributes ea
           WHERE ea.path = f.path

--- a/ee/cis/macos-13/cis-policy-queries.yml
+++ b/ee/cis/macos-13/cis-policy-queries.yml
@@ -140,6 +140,7 @@ spec:
         Ask your system administrator to deploy a script that will configure:
         /usr/bin/sudo /bin/launchctl load -w /Library/Apple/System/Library/LaunchDaemons/com.apple.XProtect.daemon.scan.plist
         /usr/bin/sudo /bin/launchctl load -w /Library/Apple/System/Library/LaunchDaemons/com.apple.XprotectFramework.PluginService.plist
+        /usr/bin/sudo /usr/sbin/softwareupdate -l --background-critical
   query: |
       SELECT 1
       WHERE (
@@ -152,7 +153,7 @@ spec:
       ) = 2;
   purpose: Informational
   tags: compliance, CIS, CIS_Level1
-  contributors: defensivedepth
+  contributors: defensivedepth, getvictor
 ---
 apiVersion: v1
 kind: policy
@@ -860,8 +861,18 @@ spec:
   platform: darwin
   description: |
     Bluetooth Sharing allows files to be exchanged with Bluetooth-enabled devices.
-    Disabling Bluetooth Sharing minimizes the risk of an attacker using Bluetooth
-    to remotely attack the system.
+    This setting only disables the receiving of files and requires both devices to
+    be paired through Bluetooth as well as accepted by the receiver. This setting
+    does not disable the ability to send files from the device to another paired
+    Bluetooth device.
+    Bluetooth pairing only requires an acceptance dialog on either device attempting
+    to pair. It does require the Bluetooth pane in System Settings to be open for
+    any macOS device to be discoverable. While it does give a verification code, it
+    does not require either device to enter the code, but just accept the dialog
+    box (on either device). At that point, the two devices are paired and files can
+    be shared through Bluetooth. To receive files through Bluetooth File Exchange
+    application, the user does have to accept the file(s) through a dialog box.
+    Users should only pair to known trusted Bluetooth devices.
   resolution: |
     Graphical Method:
     1. Open System Settings
@@ -877,7 +888,7 @@ spec:
     );
   purpose: Informational
   tags: compliance, CIS, CIS_Level1, CIS-macos-13-2.3.3.11
-  contributors: artemist-work
+  contributors: artemist-work, getvictor
 ---
 apiVersion: v1
 kind: policy
@@ -1079,58 +1090,20 @@ spec:
 apiVersion: v1
 kind: policy
 spec:
-  name: CIS - Ensure Siri is enabled (Based on organization's policy) (MDM Required)
+  name: CIS - Ensure Siri is disabled (MDM required)
   platforms: macOS
   platform: darwin
   description: |
-    With macOS 10.12 Sierra, Apple has introduced Siri from iOS to macOS. While there are data spillage concerns with the use of data-gathering personal assistant software, the risk here does not seem greater in sending queries to Apple through Siri than in sending search terms in a browser to Google or Microsoft. While it is possible that Siri will be used for local actions rather than Internet searches, Siri could, in theory, tell Apple about confidential Programs and Projects that should not be revealed. This appears be a usage edge case.
+    With macOS 10.12 Sierra, Apple has introduced Siri from iOS to macOS. While there are data spillage concerns with the use of data-gathering personal assistant software, the risk here does not seem greater in sending queries to Apple through Siri than in sending search terms in a browser to Google or Microsoft. While it is possible that Siri will be used for local actions rather than Internet searches, Siri could, in theory, tell Apple about confidential Programs and Projects that should not be revealed. This appears to be a usage edge case.
     In cases where sensitive or protected data is processed and Siri could expose that information through assisting a user in navigating their machine, it should be disabled. Siri does need to phone home to Apple, so it should not be available from air-gapped networks as part of its requirements.
     Most of the use case data published has shown that Siri is a tremendous time saver on iOS where multiple screens and menus need to be navigated through. Information like sports scores, weather, movie times, and simple to-do items on existing calendars can be easily found with Siri. None of the standard use cases should be more risky than already approved activity.
+    Note: Apple has significantly improved the features of Siri, but also created a way to purchase products and services using Siri which may be unintentionally approved. The new Siri Remote application increases the risk. For more information, read the Apple Siri privacy policy.
   resolution: |
-    Automated method:
-    Ask your system administrator to deploy an MDM profile that enables the Bluetooth status in the menu bar.
-    Create or edit a configuration profile with the following information:
-    1. The `PayloadType` string is com.apple.applicationaccess.
-    2. The key to include is allowAssistant.
-    3. The key must be set to <true/>.
-  query: |
-    SELECT 1 WHERE 
-      EXISTS (
-        SELECT 1 FROM managed_policies WHERE 
-            domain='com.apple.applicationaccess' AND 
-            name='allowAssistant' AND 
-            (value = 1 OR value = 'true') AND 
-            username = ''
-        )
-      AND NOT EXISTS (
-        SELECT 1 FROM managed_policies WHERE 
-            domain='com.apple.applicationaccess' AND 
-            name='allowAssistant' AND 
-            (value != 1 AND value != 'true')
-        );  
-     /*CIS does not make a hard recommendation for this policy. Fleet has provided two policies (one failing, one succeeding). 
-      Depending on your organization's decision, you can delete this policy or its counterpart.*/
-  purpose: Informational
-  tags: compliance, CIS, CIS_Level1, CIS-macos-13-2.5.1-enabled, decision-needed
-  contributors: sharon-fdm
----
-apiVersion: v1
-kind: policy
-spec:
-  name: CIS - Ensure Siri is disabled (Based on organization's policy) (MDM Required)
-  platforms: macOS
-  platform: darwin
-  description: |
-    With macOS 10.12 Sierra, Apple has introduced Siri from iOS to macOS. While there are data spillage concerns with the use of data-gathering personal assistant software, the risk here does not seem greater in sending queries to Apple through Siri than in sending search terms in a browser to Google or Microsoft. While it is possible that Siri will be used for local actions rather than Internet searches, Siri could, in theory, tell Apple about confidential Programs and Projects that should not be revealed. This appears be a usage edge case.
-    In cases where sensitive or protected data is processed and Siri could expose that information through assisting a user in navigating their machine, it should be disabled. Siri does need to phone home to Apple, so it should not be available from air-gapped networks as part of its requirements.
-    Most of the use case data published has shown that Siri is a tremendous time saver on iOS where multiple screens and menus need to be navigated through. Information like sports scores, weather, movie times, and simple to-do items on existing calendars can be easily found with Siri. None of the standard use cases should be more risky than already approved activity.
-  resolution: |
-    Automated method:
-    Ask your system administrator to deploy an MDM profile that enables the Bluetooth status in the menu bar.
-    Create or edit a configuration profile with the following information:
-    1. The `PayloadType` string is com.apple.applicationaccess.
-    2. The key to include is allowAssistant.
-    3. The key must be set to <false/>.
+    Profile Method:
+    Ask your administrator to deploy a profile with the following configuration:
+    1. The PayloadType string is com.apple.applicationaccess
+    2. The key to include is allowAssistant
+    3. Set the key to <false/>
   query: |
     SELECT 1 WHERE 
       EXISTS (
@@ -1145,12 +1118,10 @@ spec:
             domain='com.apple.applicationaccess' AND 
             name='allowAssistant' AND 
             (value != 0 AND value != 'false')
-        );  
-    /*CIS does not make a hard recommendation for this policy. Fleet has provided two policies (one failing, one succeeding). 
-      Depending on your organization's decision, you can delete this policy or its counterpart.*/
+        );
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1, CIS-macos-13-2.5.1-disabled, decision-needed
-  contributors: sharon-fdm
+  tags: compliance, CIS, CIS_Level1, CIS-macos-13-2.5.1
+  contributors: sharon-fdm, getvictor
 ---
 apiVersion: v1
 kind: policy
@@ -2540,14 +2511,22 @@ spec:
   platforms: macOS
   platform: darwin
   description: |
-    MacOS can act as an NFS fileserver. NFS sharing could be enabled to allow someone on another computer to mount
-    shares and gain access to information from the user's computer.
+    macOS can act as an NFS fileserver. NFS sharing could be enabled to allow
+    someone on another computer to mount shares and gain access to information
+    from the user's computer. File sharing from a user endpoint has long been
+    considered questionable, and Apple has removed that capability from the GUI.
+    NFSD is still part of the Operating System and can be easily turned on to
+    export shares and provide remote connectivity to an end-user computer. The
+    etc/exports file contains the list of NFS shared directories. If the file
+    exists, it is likely that NFS sharing has been enabled in the past or may
+    be available periodically.
   resolution: |
     Automated method:
-    Ask your system administrator to deploy the following script which will disable the NFS service
-    and its directory listing:
+    Ask your system administrator to deploy the following script which will
+    disable the NFS service and its directory listing:
     /usr/bin/sudo /bin/launchctl disable system/com.apple.nfsd
-    /usr/bin/sudo /bin/rm /etc/exports
+    /usr/bin/sudo /bin/rm -rf /etc/exports
+    Note: Removing /etc/exports also stops the NFS service if it was running.
   query: |
     SELECT 1 WHERE
     NOT EXISTS(SELECT 1 FROM processes WHERE path = '/sbin/nfsd')
@@ -2555,7 +2534,7 @@ spec:
     NOT EXISTS(SELECT 1 FROM file WHERE path = '/etc/exports');
   purpose: Informational
   tags: compliance, CIS, CIS_Level1, CIS-macos-13-4.3
-  contributors: lucasmrod
+  contributors: lucasmrod, getvictor
 ---
 apiVersion: v1
 kind: policy
@@ -2702,35 +2681,50 @@ spec:
 apiVersion: v1
 kind: policy
 spec:
-  name: CIS - Ensure No World Writable Files Exist in the Library Folder
+  name: CIS - Ensure No World Writable Folders Exist in the Library Folder (Fleetd required)
   platforms: macOS
   platform: darwin
   description: |
-    Software sometimes insists on being installed in the /System/Volumes/Data/Library Directory and has inappropriate world-writable permissions.  
-    Folders in /System/Volumes/Data/Library should not be world-writable. Macs with writable files in System should be investigated forensically. 
-    A file with open writable permissions is a sign of at best a rogue application. It could also be a sign of a computer compromise and a 
-    persistent presence on the system.
-    
-    The audit check excludes the /System/Volumes/Data/Library/Caches and /System/Volumes/Data/Library/Preferences/Audio/Data folders where the sticky bit is set.
+    Software sometimes insists on being installed in the
+    /System/Volumes/Data/Library directory and has inappropriate world-writable
+    permissions. This software could be compromised with the folder(s) being
+    world-writable by unauthorized actions.
+    Folders in /System/Volumes/Data/Library should not be world-writable. The
+    audit check excludes folders where the sticky bit is set by Apple. These
+    folders are required by the operating system to run and should not be
+    modified. Some security vendors use a world-writable folder for their
+    security extension tool. This will be considered compliant due to the tools
+    themselves not allowing a user to write to their folders. This is against
+    the standard practice on POSIX systems. It is considered compliant here
+    because of additional security vendor controls that are controlled through
+    industry standard mitigations.
   resolution: |
-    Ask your system administrator to deploy a script that will ensure folders are not world-writable in the /System folder. 
+    Ask your system administrator to deploy a script that will ensure folders
+    are not world-writable in the /Library folder. 
     /usr/bin/sudo IFS=$'\n'
-    for libPermissions in $(/usr/bin/find /System/Volumes/Data/Library -type d -perm -2 | /usr/bin/grep -Ev "Caches|/Preferences/Audio/Data|locks");
-    do
+    for libPermissions in $(/usr/bin/find /Library -type d -perm -002 ! -perm -1000 ! -xattrname com.apple.rootless 2>/dev/null); do
       /bin/chmod -R o-w "$libPermissions"
     done
+    Note: Applications that are not following standard practices, and have
+    world-writable files in /System/Volumes/Data/Library may not launch or
+    operate correctly after the remediation has been run.
   query: |
     SELECT 1 WHERE NOT EXISTS (
-      SELECT 1 FROM find_cmd WHERE
-        directory = '/System/Volumes/Data/Library'
-        AND type = 'd'
-        AND perm = '-2'
-        AND path NOT LIKE '%Caches%'
-        AND path NOT LIKE '%/Preferences/Audio/Data%'
+      SELECT 1 FROM file f
+      WHERE 
+        f.path LIKE '/Library/%'
+        AND f.type = 'directory'
+        AND (f.mode LIKE '%2' OR f.mode LIKE '%3' OR f.mode LIKE '%6' OR f.mode LIKE '%7')
+        AND NOT (f.mode LIKE '1%')
+        AND NOT EXISTS (
+          SELECT 1 FROM extended_attributes ea
+          WHERE ea.path = f.path
+          AND ea.key = 'com.apple.rootless'
+        )
     );
   purpose: Informational
   tags: compliance, CIS, CIS_Level2, CIS-macos-13-5.1.7
-  contributors: sharon-fdm
+  contributors: sharon-fdm, getvictor
 ---
 apiVersion: v1
 kind: policy
@@ -2762,10 +2756,8 @@ spec:
   description: |
     A minimum password length is the fewest number of characters a password can contain to meet a system's requirements. Ensure that a minimum of a 15-character password is part of the password policy on the computer. Where the confidentiality of encrypted information in FileVault is more of a concern, requiring a longer password or passphrase may be sufficient rather than imposing additional complexity requirements that may be self-defeating.
   resolution: |
-    Automated method:
-    Ask your system administrator to deploy an MDM profile that disables Guest Account.
     Profile Method:
-    Create or edit a configuration profile with the following information:
+    Ask your administrator to deploy a profile with the following configuration:
       1. The PayloadType string is com.apple.mobiledevice.passwordpolicy 
       2. The key to include is minLength
       3. The key must be set to <integer><value≥15></integer>
@@ -2782,7 +2774,7 @@ spec:
     WHERE minlength >= 15);
   purpose: Informational
   tags: compliance, CIS, CIS_Level1, CIS-macos-13-5.2.2
-  contributors: sharon-fdm
+  contributors: sharon-fdm, getvictor
 ---
 apiVersion: v1
 kind: policy
@@ -2890,21 +2882,21 @@ spec:
 apiVersion: v1
 kind: policy
 spec:
-  name: CIS - Ensure Password History Is Configured (Fleetd Required)
+  name: CIS - Ensure password history is set to at least 24 (MDM required)
   platforms: macOS
   platform: darwin
   description: |
-    Over time, passwords can be captured by third parties through mistakes, phishing attacks, third-party breaches, or merely brute-force attacks. To reduce the risk of exposure and to decrease the incentives of password reuse (passwords that are not forced to be changed periodically generally are not ever changed), users must reset passwords periodically. This control ensures that previous passwords are not reused immediately by keeping a history of previous password hashes. Ensure that password history checks are part of the password policy on the computer. This control checks whether a new password is different than the previous 15. The latest NIST guidance based on exploit research referenced in this section details how one of the greatest risks is password exposure rather than password cracking. Passwords should be changed to a new unique value whenever a password might have been exposed to anyone other than the account holder. Attackers have maintained persistent control based on predictable password change patterns and substantially different patterns should be used in case of a leak.
+    Over time, passwords can be captured by third parties through mistakes, phishing attacks, third-party breaches, or merely brute-force attacks. To reduce the risk of exposure and to decrease the incentives of password reuse (passwords that are not forced to be changed periodically generally are not ever changed), users must reset passwords periodically. This control ensures that previous passwords are not reused immediately by keeping a history of previous password hashes. Ensure that password history checks are part of the password policy on the computer. This control checks whether a new password is different than the previous 24. The latest NIST guidance based on exploit research referenced in this section details how one of the greatest risks is password exposure rather than password cracking. Passwords should be changed to a new unique value whenever a password might have been exposed to anyone other than the account holder. Attackers have maintained persistent control based on predictable password change patterns and substantially different patterns should be used in case of a leak.
   resolution: |
-    Automated method:
-    Ask your system administrator to deploy an MDM profile with the following information:
+    Profile Method:
+    Ask your administrator to deploy a profile with the following configuration:
       1. The Payload Type string is com.apple.mobiledevice.passwordpolicy 
       2. The key to include is pinHistory
-      3. The key must be set to <integer><value≥15></integer>
-  query: SELECT 1 FROM  pwd_policy where history_depth >= 15;
+      3. The key must be set to <integer><value≥24></integer>
+  query: SELECT 1 FROM pwd_policy WHERE history_depth >= 24;
   purpose: Informational
   tags: compliance, CIS, CIS_Level1, CIS-macos-13-5.2.8
-  contributors: sharon-fdm
+  contributors: sharon-fdm, getvictor
 ---
 apiVersion: v1
 kind: policy
@@ -3046,12 +3038,21 @@ spec:
   platforms: macOS
   platform: darwin
   description: |
-    Disabling the administrator's and/or user's ability to log into another user's active and locked session prevents
-    unauthorized persons from viewing potentially sensitive and/or personal information.
+    macOS has a privilege that can be granted to any user that will allow that
+    user to unlock active users' sessions. Disabling the administrator's and/or
+    user's ability to log into another user's active and locked session prevents
+    unauthorized persons from viewing potentially sensitive and/or personal
+    information.
+    Note: For organizations that are using Platform Single-Sign-On (PSSO), this
+    setting can cause issues with syncing with your PSSO. Verify if you are
+    using PSSO by running: /usr/bin/sudo app-sso platform -s
   resolution: |
     Automated method:
-    Ask your system administrator to deploy a script that runs the following:
-      /usr/bin/sudo /usr/bin/security authorizationdb write system.login.screensaver authenticate-session-owner
+    Ask your administrator to deploy a script that runs the following command:
+    /usr/bin/sudo /usr/bin/security authorizationdb write system.login.screensaver authenticate-session-owner
+    # Note: Running this command will disable Touch ID to unlock the screen
+    # saver. To re-enable Touch ID for users, run:
+    /usr/bin/sudo /usr/bin/defaults write /Library/Preferences/com.apple.loginwindow screenUnlockMode -int 1
   query: |
     SELECT 1 WHERE EXISTS (
       SELECT JSON_EXTRACT(json_result, '$.rule') AS rule
@@ -3061,7 +3062,7 @@ spec:
     );
   purpose: Informational
   tags: compliance, CIS, CIS_Level1
-  contributors: lucasmrod
+  contributors: lucasmrod, getvictor
 ---
 apiVersion: v1
 kind: policy
@@ -3143,14 +3144,20 @@ spec:
   platforms: macOS
   platform: darwin
   description: |
-    A filename extension is a suffix added to a base filename that indicates the base filename's
-    file format. Visible filename extensions allow the user to identify the file type and the
-    application it is associated with which leads to quick identification of misrepresented malicious files.
+    A filename extension is a suffix added to a base filename that indicates the
+    base filename's file format. This is intended for any user that logs into
+    the GUI and has a home folder and not for service accounts. For the audit,
+    we will continue to verify that every account with a home folder has
+    filename extensions enabled.
+    Visible filename extensions allow the user to identify the file type and the
+    application it is associated with which leads to quick identification of
+    misrepresented malicious files.
   resolution: |
     Automated method:
-    Ask your system administrator to deploy a script that will ensure Show All Filename Extensions Setting is Enabled
-        For each user run:
-        /usr/bin/sudo -u <username> /usr/bin/defaults write /Users/<username>/Library/Preferences/.GlobalPreferences.plist AppleShowAllExtensions -bool true
+    Ask your administrator to deploy a script that runs the following command
+    for each user:
+    /usr/bin/sudo -u <username> /usr/bin/defaults write \
+    /Users/<username>/Library/Preferences/.GlobalPreferences.plist AppleShowAllExtensions -bool true
   query: |
     SELECT 1 WHERE NOT EXISTS (
       SELECT 1 FROM users AS u
@@ -3165,7 +3172,7 @@ spec:
     );
   purpose: Informational
   tags: compliance, CIS, CIS_Level1, CIS-macos-13-6.1.1
-  contributors: artemist-work
+  contributors: artemist-work, getvictor
 ---
 apiVersion: v1
 kind: policy

--- a/ee/cis/macos-14/cis-policy-queries.yml
+++ b/ee/cis/macos-14/cis-policy-queries.yml
@@ -1707,7 +1707,7 @@ spec:
     WHERE
       -- Pass if not Apple Silicon
       NOT EXISTS (
-        SELECT 1 FROM system_info WHERE cpu_type = 'arm64e'
+        SELECT 1 FROM system_info WHERE cpu_type LIKE 'arm64%'
       )
       OR
       -- For Apple Silicon, check sleep settings (Battery Power if available, otherwise AC Power)
@@ -1828,7 +1828,7 @@ spec:
           )
         ) OR EXISTS(
           SELECT 1 WHERE EXISTS(
-            SELECT 1 FROM system_info WHERE cpu_type = 'arm64e'
+            SELECT 1 FROM system_info WHERE cpu_type LIKE 'arm64%'
           ) AND EXISTS (
             SELECT
                 CAST(JSON_EXTRACT(battery, '$.standby') AS INTEGER) AS standby

--- a/ee/cis/macos-14/cis-policy-queries.yml
+++ b/ee/cis/macos-14/cis-policy-queries.yml
@@ -1714,9 +1714,9 @@ spec:
       EXISTS (
         SELECT 1
         FROM (
-          SELECT 
-            CASE 
-              WHEN JSON_EXTRACT(json_result, '$.Battery Power:') IS NOT NULL 
+          SELECT
+            CASE
+              WHEN JSON_EXTRACT(json_result, '$.Battery Power:') IS NOT NULL
               THEN JSON_EXTRACT(json_result, '$.Battery Power:')
               ELSE JSON_EXTRACT(json_result, '$.AC Power:')
             END AS power_settings
@@ -2799,8 +2799,8 @@ spec:
       WHERE 
         f.path LIKE '/Library/%'
         AND f.type = 'directory'
-        AND (f.mode LIKE '%2' OR f.mode LIKE '%3' OR f.mode LIKE '%6' OR f.mode LIKE '%7')
-        AND NOT (f.mode LIKE '1%')
+        AND (CAST(SUBSTR(f.mode,-1) AS INTEGER) & 2) = 2
+        AND NOT ((CAST(f.mode AS INTEGER) & 01000) = 01000)
         AND NOT EXISTS (
           SELECT 1 FROM extended_attributes ea
           WHERE ea.path = f.path
@@ -2989,7 +2989,7 @@ spec:
   resolution: |
     Profile method:
     Ask your administrator to deploy a profile with the following configuration:
-      1. The Payload Type string is com.apple.mobiledevice.passwordpolicy 
+      1. The Payload Type string is com.apple.mobiledevice.passwordpolicy
       2. The key to include is pinHistory
       3. The key must be set to <integer><value≥24></integer>
   query: SELECT 1 FROM pwd_policy WHERE history_depth >= 24;

--- a/ee/cis/macos-14/cis-policy-queries.yml
+++ b/ee/cis/macos-14/cis-policy-queries.yml
@@ -140,6 +140,7 @@ spec:
         Ask your system administrator to deploy a script that will configure:
         /usr/bin/sudo /bin/launchctl load -w /Library/Apple/System/Library/LaunchDaemons/com.apple.XProtect.daemon.scan.plist
         /usr/bin/sudo /bin/launchctl load -w /Library/Apple/System/Library/LaunchDaemons/com.apple.XprotectFramework.PluginService.plist
+        /usr/bin/sudo /usr/sbin/softwareupdate -l --background-critical
   query: |
       SELECT 1
       WHERE (
@@ -152,7 +153,7 @@ spec:
       ) = 2;
   purpose: Informational
   tags: compliance, CIS, CIS_Level1
-  contributors: defensivedepth
+  contributors: defensivedepth, getvictor
 ---
 apiVersion: v1
 kind: policy

--- a/ee/cis/macos-14/cis-policy-queries.yml
+++ b/ee/cis/macos-14/cis-policy-queries.yml
@@ -845,8 +845,18 @@ spec:
   platform: darwin
   description: |
     Bluetooth Sharing allows files to be exchanged with Bluetooth-enabled devices.
-    Disabling Bluetooth Sharing minimizes the risk of an attacker using Bluetooth
-    to remotely attack the system.
+    This setting only disables the receiving of files and requires both devices to
+    be paired through Bluetooth as well as accepted by the receiver. This setting
+    does not disable the ability to send files from the device to another paired
+    Bluetooth device.
+    Bluetooth pairing only requires an acceptance dialog on either device attempting
+    to pair. It does require the Bluetooth pane in System Settings to be open for
+    any macOS device to be discoverable. While it does give a verification code, it
+    does not require either device to enter the code, but just accept the dialog
+    box (on either device). At that point, the two devices are paired and files can
+    be shared through Bluetooth. To receive files through Bluetooth File Exchange
+    application, the user does have to accept the file(s) through a dialog box.
+    Users should only pair to known trusted Bluetooth devices.
   resolution: |
     Graphical Method:
     1. Open System Settings
@@ -1064,58 +1074,37 @@ spec:
 apiVersion: v1
 kind: policy
 spec:
-  name: CIS - Ensure Siri is enabled (Based on organization's policy) (MDM Required)
+  name: CIS - Ensure Siri is disabled (MDM required)
   platforms: macOS
   platform: darwin
   description: |
-    With macOS 10.12 Sierra, Apple has introduced Siri from iOS to macOS. While there are data spillage concerns with the use of data-gathering personal assistant software, the risk here does not seem greater in sending queries to Apple through Siri than in sending search terms in a browser to Google or Microsoft. While it is possible that Siri will be used for local actions rather than Internet searches, Siri could, in theory, tell Apple about confidential Programs and Projects that should not be revealed. This appears be a usage edge case.
-    In cases where sensitive or protected data is processed and Siri could expose that information through assisting a user in navigating their machine, it should be disabled. Siri does need to phone home to Apple, so it should not be available from air-gapped networks as part of its requirements.
-    Most of the use case data published has shown that Siri is a tremendous time saver on iOS where multiple screens and menus need to be navigated through. Information like sports scores, weather, movie times, and simple to-do items on existing calendars can be easily found with Siri. None of the standard use cases should be more risky than already approved activity.
+    With macOS 10.12 Sierra, Apple has introduced Siri from iOS to macOS. While
+    there are data spillage concerns with the use of data-gathering personal
+    assistant software, the risk here does not seem greater in sending queries to
+    Apple through Siri than in sending search terms in a browser to Google or
+    Microsoft. While it is possible that Siri will be used for local actions
+    rather than Internet searches, Siri could, in theory, tell Apple about
+    confidential Programs and Projects that should not be revealed. This appears
+    to be a usage edge case.
+    In cases where sensitive or protected data is processed and Siri could expose
+    that information through assisting a user in navigating their machine, it
+    should be disabled. Siri does need to phone home to Apple, so it should not
+    be available from air-gapped networks as part of its requirements.
+    Most of the use case data published has shown that Siri is a tremendous time
+    saver on iOS where multiple screens and menus need to be navigated through.
+    Information like sports scores, weather, movie times, and simple to-do items
+    on existing calendars can be easily found with Siri. None of the standard use
+    cases should be more risky than already approved activity.
+    Note: Apple has significantly improved the features of Siri, but also created
+    a way to purchase products and services using Siri which may be
+    unintentionally approved. The new Siri Remote application increases the risk.
+    For more information, read the Apple Siri privacy policy.
   resolution: |
-    Automated method:
-    Ask your system administrator to deploy an MDM profile that enables the Bluetooth status in the menu bar.
-    Create or edit a configuration profile with the following information:
-    1. The `PayloadType` string is com.apple.applicationaccess.
-    2. The key to include is allowAssistant.
-    3. The key must be set to <true/>.
-  query: |
-    SELECT 1 WHERE 
-      EXISTS (
-        SELECT 1 FROM managed_policies WHERE 
-            domain='com.apple.applicationaccess' AND 
-            name='allowAssistant' AND 
-            (value = 1 OR value = 'true') AND 
-            username = ''
-        )
-      AND NOT EXISTS (
-        SELECT 1 FROM managed_policies WHERE 
-            domain='com.apple.applicationaccess' AND 
-            name='allowAssistant' AND 
-            (value != 1 AND value != 'true')
-        );  
-     /*CIS does not make a hard recommendation for this policy. Fleet has provided two policies (one failing, one succeeding). 
-      Depending on your organization's decision, you can delete this policy or its counterpart.*/
-  purpose: Informational
-  tags: compliance, CIS, CIS_Level1
-  contributors: sharon-fdm
----
-apiVersion: v1
-kind: policy
-spec:
-  name: CIS - Ensure Siri is disabled (Based on organization's policy) (MDM Required)
-  platforms: macOS
-  platform: darwin
-  description: |
-    With macOS 10.12 Sierra, Apple has introduced Siri from iOS to macOS. While there are data spillage concerns with the use of data-gathering personal assistant software, the risk here does not seem greater in sending queries to Apple through Siri than in sending search terms in a browser to Google or Microsoft. While it is possible that Siri will be used for local actions rather than Internet searches, Siri could, in theory, tell Apple about confidential Programs and Projects that should not be revealed. This appears be a usage edge case.
-    In cases where sensitive or protected data is processed and Siri could expose that information through assisting a user in navigating their machine, it should be disabled. Siri does need to phone home to Apple, so it should not be available from air-gapped networks as part of its requirements.
-    Most of the use case data published has shown that Siri is a tremendous time saver on iOS where multiple screens and menus need to be navigated through. Information like sports scores, weather, movie times, and simple to-do items on existing calendars can be easily found with Siri. None of the standard use cases should be more risky than already approved activity.
-  resolution: |
-    Automated method:
-    Ask your system administrator to deploy an MDM profile that enables the Bluetooth status in the menu bar.
-    Create or edit a configuration profile with the following information:
-    1. The `PayloadType` string is com.apple.applicationaccess.
-    2. The key to include is allowAssistant.
-    3. The key must be set to <false/>.
+    Profile Method:
+    Ask your administrator to deploy a profile with the following configuration:
+    1. The PayloadType string is com.apple.applicationaccess
+    2. The key to include is allowAssistant
+    3. Set the key to <false/>
   query: |
     SELECT 1 WHERE 
       EXISTS (
@@ -1130,12 +1119,10 @@ spec:
             domain='com.apple.applicationaccess' AND 
             name='allowAssistant' AND 
             (value != 0 AND value != 'false')
-        );  
-    /*CIS does not make a hard recommendation for this policy. Fleet has provided two policies (one failing, one succeeding). 
-      Depending on your organization's decision, you can delete this policy or its counterpart.*/
+        );
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1, decision-needed
-  contributors: sharon-fdm
+  tags: compliance, CIS, CIS_Level1
+  contributors: sharon-fdm, getvictor
 ---
 apiVersion: v1
 kind: policy
@@ -1694,6 +1681,59 @@ spec:
   purpose: Informational
   tags: compliance, CIS, CIS_Level1
   contributors: lucasmrod
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure sleep and display sleep is enabled on Apple Silicon devices (Fleetd required)
+  platforms: macOS
+  platform: darwin
+  description: |
+    MacBooks should be set so that the sleep is 15 minutes or less and the
+    display should sleep at 10 minutes or less. This setting should allow laptop
+    users in most cases to stay within physically secured areas while going to a
+    conference room, auditorium, or other internal location without having to
+    unlock the encryption. When the user goes home at night, the laptop will
+    auto-sleep after 15 minutes and to log back into the system when it resumes.
+  resolution: |
+    Automated method:
+    Ask your system administrator to deploy a script that runs the following
+    commands to set the sleep time and display sleep:
+    /usr/bin/sudo /usr/bin/pmset -a sleep 15
+    /usr/bin/sudo /usr/bin/pmset -a displaysleep 10
+  query: |
+    SELECT 1 AS result
+    WHERE
+      -- Pass if not Apple Silicon
+      NOT EXISTS (
+        SELECT 1 FROM system_info WHERE cpu_type = 'arm64e'
+      )
+      OR
+      -- For Apple Silicon, check sleep settings (Battery Power if available, otherwise AC Power)
+      EXISTS (
+        SELECT 1
+        FROM (
+          SELECT 
+            CASE 
+              WHEN JSON_EXTRACT(json_result, '$.Battery Power:') IS NOT NULL 
+              THEN JSON_EXTRACT(json_result, '$.Battery Power:')
+              ELSE JSON_EXTRACT(json_result, '$.AC Power:')
+            END AS power_settings
+          FROM pmset
+          WHERE getting = 'custom'
+        )
+        WHERE
+          -- Require sleep setting to be 15 minutes or less
+          CAST(JSON_EXTRACT(power_settings, '$.sleep') AS INTEGER) <= 15
+          AND
+          -- Require display sleep to be 10 minutes or less AND less than or equal to sleep value
+          CAST(JSON_EXTRACT(power_settings, '$.displaysleep') AS INTEGER) <= 10
+          AND
+          CAST(JSON_EXTRACT(power_settings, '$.displaysleep') AS INTEGER) <= CAST(JSON_EXTRACT(power_settings, '$.sleep') AS INTEGER)
+      );
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level2
+  contributors: getvictor
 ---
 apiVersion: v1
 kind: policy
@@ -2555,14 +2595,22 @@ spec:
   platforms: macOS
   platform: darwin
   description: |
-    MacOS can act as an NFS fileserver. NFS sharing could be enabled to allow someone on another computer to mount
-    shares and gain access to information from the user's computer.
+    macOS can act as an NFS fileserver. NFS sharing could be enabled to allow
+    someone on another computer to mount shares and gain access to information
+    from the user's computer. File sharing from a user endpoint has long been
+    considered questionable, and Apple has removed that capability from the GUI.
+    NFSD is still part of the Operating System and can be easily turned on to
+    export shares and provide remote connectivity to an end-user computer. The
+    etc/exports file contains the list of NFS shared directories. If the file
+    exists, it is likely that NFS sharing has been enabled in the past or may
+    be available periodically.
   resolution: |
     Automated method:
-    Ask your system administrator to deploy the following script which will disable the NFS service
-    and its directory listing:
+    Ask your system administrator to deploy the following script which will
+    disable the NFS service and its directory listing:
     /usr/bin/sudo /bin/launchctl disable system/com.apple.nfsd
-    /usr/bin/sudo /bin/rm /etc/exports
+    /usr/bin/sudo /bin/rm -rf /etc/exports
+    Note: Removing /etc/exports also stops the NFS service if it was running.
   query: |
     SELECT 1 WHERE
     NOT EXISTS(SELECT 1 FROM processes WHERE path = '/sbin/nfsd')
@@ -2570,7 +2618,7 @@ spec:
     NOT EXISTS(SELECT 1 FROM file WHERE path = '/etc/exports');
   purpose: Informational
   tags: compliance, CIS, CIS_Level1
-  contributors: lucasmrod
+  contributors: lucasmrod, getvictor
 ---
 apiVersion: v1
 kind: policy
@@ -2717,31 +2765,50 @@ spec:
 apiVersion: v1
 kind: policy
 spec:
-  name: CIS - Ensure No World Writable Files Exist in the Library Folder
+  name: CIS - Ensure No World Writable Folders Exist in the Library Folder (Fleetd required)
   platforms: macOS
   platform: darwin
   description: |
-    Software sometimes insists on being installed in the /System/Volumes/Data/Library Directory and has inappropriate world-writable permissions.  
-    Folders in /System/Volumes/Data/Library should not be world-writable. The audit check excludes the /System/Volumes/Data/Library/Caches and /System/Volumes/Data/Library/Preferences/Audio/Data folders where the sticky bit is set.
+    Software sometimes insists on being installed in the
+    /System/Volumes/Data/Library directory and has inappropriate world-writable
+    permissions. This software could be compromised with the folder(s) being
+    world-writable by unauthorized actions.
+    Folders in /System/Volumes/Data/Library should not be world-writable. The
+    audit check excludes folders where the sticky bit is set by Apple. These
+    folders are required by the operating system to run and should not be
+    modified. Some security vendors use a world-writable folder for their
+    security extension tool. This will be considered compliant due to the tools
+    themselves not allowing a user to write to their folders. This is against
+    the standard practice on POSIX systems. It is considered compliant here
+    because of additional security vendor controls that are controlled through
+    industry standard mitigations.
   resolution: |
-    Ask your system administrator to deploy a script that will ensure folders are not world-writable in the /System folder. 
+    Ask your system administrator to deploy a script that will ensure folders
+    are not world-writable in the /Library folder. 
     /usr/bin/sudo IFS=$'\n'
-    for libPermissions in $( /usr/bin/find /System/Volumes/Data/Library -type d -perm -2 | /usr/bin/grep -v Caches | /usr/bin/grep -v /Preferences/Audio/Data); 
-    do
+    for libPermissions in $(/usr/bin/find /Library -type d -perm -002 ! -perm -1000 ! -xattrname com.apple.rootless 2>/dev/null); do
       /bin/chmod -R o-w "$libPermissions"
     done
+    Note: Applications that are not following standard practices, and have
+    world-writable files in /System/Volumes/Data/Library may not launch or
+    operate correctly after the remediation has been run.
   query: |
     SELECT 1 WHERE NOT EXISTS (
-      SELECT 1 FROM find_cmd WHERE
-        directory = '/System/Volumes/Data/Library'
-        AND type = 'd'
-        AND perm = '-2'
-        AND path NOT LIKE '%Caches%'
-        AND path NOT LIKE '%/Preferences/Audio/Data%'
+      SELECT 1 FROM file f
+      WHERE 
+        f.path LIKE '/Library/%'
+        AND f.type = 'directory'
+        AND (f.mode LIKE '%2' OR f.mode LIKE '%3' OR f.mode LIKE '%6' OR f.mode LIKE '%7')
+        AND NOT (f.mode LIKE '1%')
+        AND NOT EXISTS (
+          SELECT 1 FROM extended_attributes ea
+          WHERE ea.path = f.path
+          AND ea.key = 'com.apple.rootless'
+        )
     );
   purpose: Informational
   tags: compliance, CIS, CIS_Level2
-  contributors: sharon-fdm
+  contributors: getvictor
 ---
 apiVersion: v1
 kind: policy
@@ -2774,9 +2841,7 @@ spec:
     A minimum password length is the fewest number of characters a password can contain to meet a system's requirements. Ensure that a minimum of a 15-character password is part of the password policy on the computer. Where the confidentiality of encrypted information in FileVault is more of a concern, requiring a longer password or passphrase may be sufficient rather than imposing additional complexity requirements that may be self-defeating.
   resolution: |
     Automated method:
-    Ask your system administrator to deploy an MDM profile that disables Guest Account.
-    Profile Method:
-    Create or edit a configuration profile with the following information:
+    Ask your administrator to deploy a profile with the following configuration:
       1. The PayloadType string is com.apple.mobiledevice.passwordpolicy 
       2. The key to include is minLength
       3. The key must be set to <integer><value≥15></integer>
@@ -2901,21 +2966,35 @@ spec:
 apiVersion: v1
 kind: policy
 spec:
-  name: CIS - Ensure Password History Is Configured (Fleetd Required)
+  name: CIS - Ensure password history is set to at least 24 (MDM required)
   platforms: macOS
   platform: darwin
   description: |
-    Over time, passwords can be captured by third parties through mistakes, phishing attacks, third-party breaches, or merely brute-force attacks. To reduce the risk of exposure and to decrease the incentives of password reuse (passwords that are not forced to be changed periodically generally are not ever changed), users must reset passwords periodically. This control ensures that previous passwords are not reused immediately by keeping a history of previous password hashes. Ensure that password history checks are part of the password policy on the computer. This control checks whether a new password is different than the previous 15. The latest NIST guidance based on exploit research referenced in this section details how one of the greatest risks is password exposure rather than password cracking. Passwords should be changed to a new unique value whenever a password might have been exposed to anyone other than the account holder. Attackers have maintained persistent control based on predictable password change patterns and substantially different patterns should be used in case of a leak.
+    Over time, passwords can be captured by third parties through mistakes,
+    phishing attacks, third-party breaches, or merely brute-force attacks. To
+    reduce the risk of exposure and to decrease the incentives of password reuse
+    (passwords that are not forced to be changed periodically generally are not
+    ever changed), users must reset passwords periodically. This control ensures
+    that previous passwords are not reused immediately by keeping a history of
+    previous password hashes. Ensure that password history checks are part of
+    the password policy on the computer. This control checks whether a new
+    password is different than the previous 24. The latest NIST guidance based
+    on exploit research referenced in this section details how one of the
+    greatest risks is password exposure rather than password cracking. Passwords
+    should be changed to a new unique value whenever a password might have been
+    exposed to anyone other than the account holder. Attackers have maintained
+    persistent control based on predictable password change patterns and
+    substantially different patterns should be used in case of a leak.
   resolution: |
-    Automated method:
-    Ask your system administrator to deploy an MDM profile with the following information:
+    Profile method:
+    Ask your administrator to deploy a profile with the following configuration:
       1. The Payload Type string is com.apple.mobiledevice.passwordpolicy 
       2. The key to include is pinHistory
-      3. The key must be set to <integer><value≥15></integer>
-  query: SELECT 1 FROM  pwd_policy where history_depth >= 15;
+      3. The key must be set to <integer><value≥24></integer>
+  query: SELECT 1 FROM pwd_policy WHERE history_depth >= 24;
   purpose: Informational
   tags: compliance, CIS, CIS_Level1
-  contributors: sharon-fdm
+  contributors: sharon-fdm, getvictor
 ---
 apiVersion: v1
 kind: policy
@@ -3057,12 +3136,21 @@ spec:
   platforms: macOS
   platform: darwin
   description: |
-    Disabling the administrator's and/or user's ability to log into another user's active and locked session prevents
-    unauthorized persons from viewing potentially sensitive and/or personal information.
+    macOS has a privilege that can be granted to any user that will allow that
+    user to unlock active users' sessions. Disabling the administrator's and/or
+    user's ability to log into another user's active and locked session prevents
+    unauthorized persons from viewing potentially sensitive and/or personal
+    information.
+    Note: For organizations that are using Platform Single-Sign-On (PSSO), this
+    setting can cause issues with syncing with your PSSO. Verify if you are
+    using PSSO by running: /usr/bin/sudo app-sso platform -s
   resolution: |
     Automated method:
-    Ask your system administrator to deploy a script that runs the following:
-      /usr/bin/sudo /usr/bin/security authorizationdb write system.login.screensaver authenticate-session-owner
+    Ask your administrator to deploy a script that runs the following command:
+    /usr/bin/sudo /usr/bin/security authorizationdb write system.login.screensaver authenticate-session-owner
+    # Note: Running this command will disable Touch ID to unlock the screen
+    # saver. To re-enable Touch ID for users, run:
+    /usr/bin/sudo /usr/bin/defaults write /Library/Preferences/com.apple.loginwindow screenUnlockMode -int 1
   query: |
     SELECT 1 WHERE EXISTS (
       SELECT JSON_EXTRACT(json_result, '$.rule') AS rule
@@ -3072,7 +3160,7 @@ spec:
     );
   purpose: Informational
   tags: compliance, CIS, CIS_Level1
-  contributors: lucasmrod
+  contributors: lucasmrod, getvictor
 ---
 apiVersion: v1
 kind: policy
@@ -3124,14 +3212,20 @@ spec:
   platforms: macOS
   platform: darwin
   description: |
-    A filename extension is a suffix added to a base filename that indicates the base filename's
-    file format. Visible filename extensions allow the user to identify the file type and the
-    application it is associated with which leads to quick identification of misrepresented malicious files.
+    A filename extension is a suffix added to a base filename that indicates the
+    base filename's file format. This is intended for any user that logs into
+    the GUI and has a home folder and not for service accounts. For the audit,
+    we will continue to verify that every account with a home folder has
+    filename extensions enabled.
+    Visible filename extensions allow the user to identify the file type and the
+    application it is associated with which leads to quick identification of
+    misrepresented malicious files.
   resolution: |
     Automated method:
-    Ask your system administrator to deploy a script that will ensure Show All Filename Extensions Setting is Enabled
-        For each user run:
-        /usr/bin/sudo -u <username> /usr/bin/defaults write /Users/<username>/Library/Preferences/.GlobalPreferences.plist AppleShowAllExtensions -bool true
+    Ask your administrator to deploy a script that runs the following command
+    for each user:
+    /usr/bin/sudo -u <username> /usr/bin/defaults write \
+    /Users/<username>/Library/Preferences/.GlobalPreferences.plist AppleShowAllExtensions -bool true
   query: |
     SELECT 1 WHERE NOT EXISTS (
       SELECT 1 FROM users AS u
@@ -3146,7 +3240,7 @@ spec:
     );
   purpose: Informational
   tags: compliance, CIS, CIS_Level1
-  contributors: artemist-work
+  contributors: artemist-work, getvictor
 ---
 apiVersion: v1
 kind: policy

--- a/ee/cis/macos-15/cis-policy-queries.yml
+++ b/ee/cis/macos-15/cis-policy-queries.yml
@@ -3103,14 +3103,11 @@ spec:
   platforms: macOS
   platform: darwin
   description: |
-    A filename extension is a suffix added to a base filename that indicates the base filename's
-    file format. Visible filename extensions allow the user to identify the file type and the
-    application it is associated with which leads to quick identification of misrepresented malicious files.
+    A filename extension is a suffix added to a base filename that indicates the base filename's file format. This is intended for any user that logs into the GUI and has a home folder and not for service accounts. For the audit, we will continue to verify that every account with a home folder has filename extensions enabled. Visible filename extensions allow the user to identify the file type and the application it is associated with which leads to quick identification of misrepresented malicious files.
   resolution: |
     Automated method:
-    Ask your system administrator to deploy a script that will ensure Show All Filename Extensions Setting is Enabled
-        For each user run:
-        /usr/bin/sudo -u <username> /usr/bin/defaults write /Users/<username>/Library/Preferences/.GlobalPreferences.plist AppleShowAllExtensions -bool true
+    Ask your administrator to deploy a script that runs the following command for each user:
+    /usr/bin/sudo -u <username> /usr/bin/defaults write /Users/<username>/Library/Preferences/.GlobalPreferences.plist AppleShowAllExtensions -bool true
   query: |
     SELECT 1 WHERE NOT EXISTS (
       SELECT 1 FROM users AS u
@@ -3125,7 +3122,7 @@ spec:
     );
   purpose: Informational
   tags: compliance, CIS, CIS_Level1
-  contributors: artemist-work
+  contributors: artemist-work, getvictor
 ---
 apiVersion: v1
 kind: policy
@@ -3507,7 +3504,7 @@ spec:
 apiVersion: v1
 kind: policy
 spec:
-  name: CIS -  Ensure Logging Is Enabled for Sudo (MDM Required)
+  name: CIS -  Ensure Logging Is Enabled for Sudo (Fleetd Required)
   platforms: macOS
   platform: darwin
   description: |
@@ -3519,13 +3516,23 @@ spec:
     Add the line to the file: 'Defaults log_allowed'
     Note: Unlike other Unix/Linux distros, macOS will ignore configuration files in the sudoers.d folder that contain a period, so do not add a file extension to the configuration file. The 'Defaults log_allowed' line can be added to an existing configuration file or a new one.
   query: |
-    SELECT 1 WHERE EXISTS (
-      SELECT 1 FROM file_lines 
-      WHERE (path = '/etc/sudoers' OR path LIKE '/etc/sudoers.d/%')
+    SELECT 1 AS result
+    FROM (
+      SELECT 1 FROM file_lines
+      WHERE path = '/etc/sudoers'
         AND line LIKE '%Defaults%log_allowed%'
         AND line NOT LIKE '%!log_allowed%'
         AND line NOT LIKE '#%'
-    );
+  
+      UNION ALL
+  
+      SELECT 1 FROM file_lines
+      WHERE path LIKE '/etc/sudoers.d/%'
+        AND line LIKE '%Defaults%log_allowed%'
+        AND line NOT LIKE '%!log_allowed%'
+        AND line NOT LIKE '#%'
+    ) AS matches
+    LIMIT 1;
   purpose: Informational
   tags: compliance, CIS, CIS_Level1
   contributors: getvictor

--- a/ee/cis/macos-15/cis-policy-queries.yml
+++ b/ee/cis/macos-15/cis-policy-queries.yml
@@ -197,7 +197,7 @@ spec:
     This query will check for the existance of the policy not its value (That should be set per organization's decision)
   resolution: |
     The administrator should configure this via MDM profile.
-    Create or edit a configuration profile with the following information:
+    Ask your administrator to deploy a profile with the following configuration:
       1. The PayloadType string is com.apple.applicationaccess.
       2. The key to include is allowCloudDocumentSync.
       3. The key must be set to <false/>.
@@ -233,7 +233,7 @@ spec:
     This query will check for the existance of the policy not its value (That should be set per organization's decision)
   resolution: |
     The administrator should configure this via MDM profile.
-    Create or edit a configuration profile with the following information:
+    Ask your administrator to deploy a profile with the following configuration:
       1. The PayloadType string is com.apple.applicationaccess.
       2. The key to include is allowCloudDocumentSync.
       3. The key must be set to <true/>.
@@ -270,7 +270,7 @@ spec:
     Ensure that the iCloud keychain is used consistently with organizational requirements.
   resolution: |
     The administrator should configure this via MDM profile.
-    Create or edit a configuration profile with the following information:
+    Ask your administrator to deploy a profile with the following configuration:
       1. The PayloadType string is com.apple.applicationaccess.
       2. The key to include is allowCloudKeychainSync.
       3. The key must be set to <false/>.
@@ -307,7 +307,7 @@ spec:
     Ensure that the iCloud keychain is used consistently with organizational requirements.
   resolution: |
     The administrator should configure this via MDM profile.
-    Create or edit a configuration profile with the following information:
+    Ask your administrator to deploy a profile with the following configuration:
       1. The PayloadType string is com.apple.applicationaccess.
       2. The key to include is allowCloudKeychainSync.
       3. The key must be set to <true/>.
@@ -340,7 +340,7 @@ spec:
   description: Automated Document synchronization should be planned and controlled to approved storage.
   resolution: |
     The administrator should configure this via MDM profile.
-    Create or edit a configuration profile with the following information:
+    Ask your administrator to deploy a profile with the following configuration:
       1. The PayloadType string is com.apple.applicationaccess.
       2. The key to include is allowCloudDesktopAndDocuments.
       3. The key must be set to <false/>.
@@ -407,7 +407,7 @@ spec:
     Contacts Only limits may expose personal information to devices in the same area.
   resolution: |
     Ask your system administrator to deploy an MDM profile that disables AirDrop.
-    Create or edit a configuration profile with the following information:
+    Ask your administrator to deploy a profile with the following configuration:
       1. The PayloadType string is com.apple.applicationaccess
       2. The key to include is allowAirDrop
       3. The key must be set to <false/>
@@ -446,7 +446,7 @@ spec:
     information to an attacker.
   resolution: |
     The administrator should configure this via MDM profile.
-    Create or edit a configuration profile with the following information:
+    Ask your administrator to deploy a profile with the following configuration:
       1. The PayloadType string is com.apple.applicationaccess
       2. The key to include is allowAirPlayIncomingRequests
       3. The key must be set to <false/>
@@ -477,7 +477,7 @@ spec:
   description: 
   resolution: |
       The administrator should configure this via MDM profile.
-      Create or edit a configuration profile with the following information:
+      Ask your administrator to deploy a profile with the following configuration:
         1. The PayloadType string is com.apple.applicationaccess.
         2. The key to include is forceAutomaticDateAndTime.
         3. The key must be set to <true/>.
@@ -743,7 +743,7 @@ spec:
         3. SelectSharing
         4. Set Content Caching to disabled
     Profile Method:
-    Create or edit a configuration profile with the following information:
+    Ask your administrator to deploy a profile with the following configuration:
       1. The PayloadType string is com.apple.applicationaccess 
       2. The key to include is allowContentCaching
       3. The key must be set to <false/>
@@ -929,7 +929,7 @@ spec:
   resolution: |
     Automated method:
     Ask your system administrator to deploy an MDM profile that enables the Wi-Fi status in the menu bar.
-    Create or edit a configuration profile with the following information:
+    Ask your administrator to deploy a profile with the following configuration:
     1. The `PayloadType` string is `com.apple.controlcenter`.
     2. The key to include is `WiFi`.
     3. The key must be set to `<integer>18</integer>`.
@@ -964,7 +964,7 @@ spec:
   resolution: |
     Automated method:
     Ask your system administrator to deploy an MDM profile that enables the Bluetooth status in the menu bar.
-    Create or edit a configuration profile with the following information:
+    Ask your administrator to deploy a profile with the following configuration:
     1. The `PayloadType` string is `com.apple.controlcenter`.
     2. The key to include is `Bluetooth`.
     3. The key must be set to `<integer>18</integer>`.
@@ -989,7 +989,7 @@ spec:
 apiVersion: v1
 kind: policy
 spec:
-  name: CIS - Ensure external intelligence extensions is disabled
+  name: CIS - Ensure external intelligence extensions is disabled (MDM required)
   platforms: macOS
   platform: darwin
   description: |
@@ -997,7 +997,7 @@ spec:
     Organizations handling sensitive or confidential information should disable external intelligence extensions to prevent potential data leakage to third-party AI services.
   resolution: |
     Profile Method:
-    Create or edit a configuration profile with the following information:
+    Ask your administrator to deploy a profile with the following configuration:
     1. The PayloadType string is com.apple.applicationaccess
     2. The key to include is allowIntelligenceExtensions
     3. The key must be set to <false/>
@@ -1020,7 +1020,7 @@ spec:
 apiVersion: v1
 kind: policy
 spec:
-  name: CIS - Ensure writing tools is disabled
+  name: CIS - Ensure writing tools is disabled (MDM required)
   platforms: macOS
   platform: darwin
   description: |
@@ -1028,7 +1028,7 @@ spec:
     Organizations handling sensitive documents should consider disabling Writing Tools to prevent potential exposure of confidential information through AI processing.
   resolution: |
     Profile Method:
-    Create or edit a configuration profile with the following information:
+    Ask your administrator to deploy a profile with the following configuration:
     1. The PayloadType string is com.apple.applicationaccess
     2. The key to include is allowWritingTools
     3. The key must be set to <false/>
@@ -1051,7 +1051,7 @@ spec:
 apiVersion: v1
 kind: policy
 spec:
-  name: CIS - Ensure mail summarization is disabled
+  name: CIS - Ensure mail summarization is disabled (MDM required)
   platforms: macOS
   platform: darwin
   description: |
@@ -1059,7 +1059,7 @@ spec:
     Organizations should disable Mail Summarization to prevent AI processing of potentially sensitive email communications.
   resolution: |
     Profile Method:
-    Create or edit a configuration profile with the following information:
+    Ask your administrator to deploy a profile with the following configuration:
     1. The PayloadType string is com.apple.mail
     2. The key to include is allowMailIntelligence
     3. The key must be set to <false/>
@@ -1082,7 +1082,7 @@ spec:
 apiVersion: v1
 kind: policy
 spec:
-  name: CIS - Ensure notes summarization is disabled
+  name: CIS - Ensure notes summarization is disabled (MDM required)
   platforms: macOS
   platform: darwin
   description: |
@@ -1090,7 +1090,7 @@ spec:
     Organizations should disable Notes Summarization to prevent AI processing of potentially sensitive notes and documentation.
   resolution: |
     Profile Method:
-    Create or edit a configuration profile with the following information:
+    Ask your administrator to deploy a profile with the following configuration:
     1. The PayloadType string is com.apple.mobilenotes
     2. The key to include is allowNotesIntelligence
     3. The key must be set to <false/>
@@ -1109,61 +1109,22 @@ spec:
   purpose: Informational
   tags: compliance, CIS, CIS_Level1
   contributors: getvictor
----
 apiVersion: v1
 kind: policy
 spec:
-  name: CIS - Ensure Siri is enabled (Based on organization's policy) (MDM Required)
+  name: CIS - Ensure Siri is disabled (MDM required)
   platforms: macOS
   platform: darwin
   description: |
-    With macOS 10.12 Sierra, Apple has introduced Siri from iOS to macOS. While there are data spillage concerns with the use of data-gathering personal assistant software, the risk here does not seem greater in sending queries to Apple through Siri than in sending search terms in a browser to Google or Microsoft. While it is possible that Siri will be used for local actions rather than Internet searches, Siri could, in theory, tell Apple about confidential Programs and Projects that should not be revealed. This appears be a usage edge case.
+    With macOS 10.12 Sierra, Apple has introduced Siri from iOS to macOS. While there are data spillage concerns with the use of data-gathering personal assistant software, the risk here does not seem greater in sending queries to Apple through Siri than in sending search terms in a browser to Google or Microsoft. While it is possible that Siri will be used for local actions rather than Internet searches, Siri could, in theory, tell Apple about confidential Programs and Projects that should not be revealed. This appears to be a usage edge case.
     In cases where sensitive or protected data is processed and Siri could expose that information through assisting a user in navigating their machine, it should be disabled. Siri does need to phone home to Apple, so it should not be available from air-gapped networks as part of its requirements.
     Most of the use case data published has shown that Siri is a tremendous time saver on iOS where multiple screens and menus need to be navigated through. Information like sports scores, weather, movie times, and simple to-do items on existing calendars can be easily found with Siri. None of the standard use cases should be more risky than already approved activity.
   resolution: |
-    Automated method:
-    Ask your system administrator to deploy an MDM profile that enables the Bluetooth status in the menu bar.
-    Create or edit a configuration profile with the following information:
-    1. The `PayloadType` string is com.apple.applicationaccess.
-    2. The key to include is allowAssistant.
-    3. The key must be set to <true/>.
-  query: |
-    SELECT 1 WHERE 
-      EXISTS (
-        SELECT 1 FROM managed_policies WHERE 
-            domain='com.apple.applicationaccess' AND 
-            name='allowAssistant' AND 
-            (value = 1 OR value = 'true')
-        )
-      AND NOT EXISTS (
-        SELECT 1 FROM managed_policies WHERE 
-            domain='com.apple.applicationaccess' AND 
-            name='allowAssistant' AND 
-            (value != 1 AND value != 'true')
-        );  
-     /*CIS does not make a hard recommendation for this policy. Fleet has provided two policies (one failing, one succeeding). 
-      Depending on your organization's decision, you can delete this policy or its counterpart.*/
-  purpose: Informational
-  tags: compliance, CIS, CIS_Level1
-  contributors: sharon-fdm
----
-apiVersion: v1
-kind: policy
-spec:
-  name: CIS - Ensure Siri is disabled (Based on organization's policy) (MDM Required)
-  platforms: macOS
-  platform: darwin
-  description: |
-    With macOS 10.12 Sierra, Apple has introduced Siri from iOS to macOS. While there are data spillage concerns with the use of data-gathering personal assistant software, the risk here does not seem greater in sending queries to Apple through Siri than in sending search terms in a browser to Google or Microsoft. While it is possible that Siri will be used for local actions rather than Internet searches, Siri could, in theory, tell Apple about confidential Programs and Projects that should not be revealed. This appears be a usage edge case.
-    In cases where sensitive or protected data is processed and Siri could expose that information through assisting a user in navigating their machine, it should be disabled. Siri does need to phone home to Apple, so it should not be available from air-gapped networks as part of its requirements.
-    Most of the use case data published has shown that Siri is a tremendous time saver on iOS where multiple screens and menus need to be navigated through. Information like sports scores, weather, movie times, and simple to-do items on existing calendars can be easily found with Siri. None of the standard use cases should be more risky than already approved activity.
-  resolution: |
-    Automated method:
-    Ask your system administrator to deploy an MDM profile that enables the Bluetooth status in the menu bar.
-    Create or edit a configuration profile with the following information:
-    1. The `PayloadType` string is com.apple.applicationaccess.
-    2. The key to include is allowAssistant.
-    3. The key must be set to <false/>.
+    Profile Method:
+    Ask your administrator to deploy a profile with the following configuration:
+    1. The PayloadType string is com.apple.applicationaccess
+    2. The key to include is allowAssistant
+    3. Set the key to <false/>
   query: |
     SELECT 1 WHERE 
       EXISTS (
@@ -1178,11 +1139,9 @@ spec:
             name='allowAssistant' AND 
             (value != 0 AND value != 'false')
         );  
-    /*CIS does not make a hard recommendation for this policy. Fleet has provided two policies (one failing, one succeeding). 
-      Depending on your organization's decision, you can delete this policy or its counterpart.*/
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1, decision-needed
-  contributors: sharon-fdm
+  tags: compliance, CIS, CIS_Level1
+  contributors: sharon-fdm, getvictor
 ---
 apiVersion: v1
 kind: policy
@@ -1647,7 +1606,7 @@ spec:
   resolution: |
     Automated method:
     Ask your system administrator to deploy an MDM profile that enables the Bluetooth status in the menu bar.
-    Create or edit a configuration profile with the following information:
+    Ask your administrator to deploy a profile with the following configuration:
     1. The `PayloadType` string is com.apple.universalcontrol.
     2. The key to include is 'Disable'.
     3. The key must be set to <false/>.
@@ -1683,7 +1642,7 @@ spec:
   resolution: |
     Automated method:
     Ask your system administrator to deploy an MDM profile that enables the Bluetooth status in the menu bar.
-    Create or edit a configuration profile with the following information:
+    Ask your administrator to deploy a profile with the following configuration:
     1. The `PayloadType` string is com.apple.universalcontrol.
     2. The key to include is 'Disable'.
     3. The key must be set to <true/>.
@@ -2223,7 +2182,7 @@ spec:
         2. Select Users & Groups
         3. Set Automatic login in as... to Off
     Profile Method:
-        Create or edit a configuration profile with the following information:
+        Ask your administrator to deploy a profile with the following configuration:
         1. The Payload Type string is com.apple.loginwindow
         2. The key to include is com.apple.login.mcx.DisableAutoLoginClient 
         3. The key must be set to <true/>
@@ -2478,7 +2437,7 @@ spec:
     Automated method:
     Ask your system administrator to deploy an MDM profile that disables Bonjour advertising service.
     Profile Method:
-        Create or edit a configuration profile with the following information:
+        Ask your administrator to deploy a profile with the following configuration:
         1. The Payload Type string is `com.apple.mDNSResponder`.
         2. The key to include is `NoMulticastAdvertisements`.
         3. The key must be set to `<true/>`.
@@ -2726,7 +2685,7 @@ spec:
     Automated method:
     Ask your system administrator to deploy an MDM profile that Ensure Password Account Lockout Threshold.
     Profile Method:
-    Create or edit a configuration profile with the following information:
+    Ask your administrator to deploy a profile with the following configuration:
       1. The PayloadType string is com.apple.mobiledevice.passwordpolicy 
       2. The key to include is maxFailedAttempts
       3. The key must be set to <integer><value≤5></integer>
@@ -2747,7 +2706,7 @@ spec:
     Automated method:
     Ask your system administrator to deploy an MDM profile that disables Guest Account.
     Profile Method:
-    Create or edit a configuration profile with the following information:
+    Ask your administrator to deploy a profile with the following configuration:
       1. The PayloadType string is com.apple.mobiledevice.passwordpolicy 
       2. The key to include is minLength
       3. The key must be set to <integer><value≥15></integer>
@@ -2854,7 +2813,7 @@ spec:
     Automated method:
     Ask your system administrator to deploy an MDM profile that disables Guest Account.
     Profile Method:
-    Create or edit a configuration profile with the following information:
+    Ask your administrator to deploy a profile with the following configuration:
       1. The Payload Type string is com.apple.mobiledevice.passwordpolicy 
       2. The key to include is maxPINAgeInDays
       3. The key must be set to <integer><value<=365></integer>
@@ -3174,7 +3133,7 @@ spec:
   resolution: |
     Ask your system administrator to deploy an MDM profile that set the history per organization decision
     Profile Method:
-      Create or edit a configuration profile with the following information:
+      Ask your administrator to deploy a profile with the following configuration:
       1. The PayloadType string is com.apple.Safari
       2. The key to include is HistoryAgeInDaysLimit
       3. The key must be set to: <integer><1,7,14,31,365,36500></integer>
@@ -3414,7 +3373,7 @@ spec:
       5. Set Show full website address to enabled
     Automated method:
     Profile Method:
-    Create or edit a configuration profile with the following information:
+    Ask your administrator to deploy a profile with the following configuration:
       1. The PayloadType string is com.apple.Safari
       2. The key to include is ShowFullURLInSmartSearchField 
       3. The key must be set to: <true/>
@@ -3447,7 +3406,7 @@ spec:
   resolution: |
     Automated method:
     Profile Method:
-    Create or edit a configuration profile with the following information:
+    Ask your administrator to deploy a profile with the following configuration:
       1. The PayloadType string is com.apple.Safari
       2. The key to include is ShowOverlayStatusBar 
       3. The key must be set to: <true/>
@@ -3471,7 +3430,7 @@ spec:
     Enabling Secure Keyboard Entry minimizes the risk of a key logger from detecting what is entered in Terminal.
   resolution: |
     Profile Method:
-    Create or edit a configuration profile with the following information:
+    Ask your administrator to deploy a profile with the following configuration:
       1. The PayloadType string is com.apple.Terminal 
       2. The key to include is SecureKeyboardEntry
       3. The key must be set to

--- a/ee/cis/macos-15/cis-policy-queries.yml
+++ b/ee/cis/macos-15/cis-policy-queries.yml
@@ -1701,6 +1701,53 @@ spec:
 apiVersion: v1
 kind: policy
 spec:
+  name: CIS - Ensure sleep and display sleep is enabled on Apple Silicon devices (Fleetd required)
+  platforms: macOS
+  platform: darwin
+  description: |
+    MacBooks should be set so that the sleep is 15 minutes or less and the display should sleep at 10 minutes or less. This setting should allow laptop users in most cases to stay within physically secured areas while going to a conference room, auditorium, or other internal location without having to unlock the encryption. When the user goes home at night, the laptop will auto-sleep after 15 minutes and to log back into the system when it resumes.
+  resolution: |
+    Automated method:
+    Ask your system administrator to deploy a script that runs the following commands to set the sleep time and display sleep:
+    /usr/bin/sudo /usr/bin/pmset -a sleep 15
+    /usr/bin/sudo /usr/bin/pmset -a displaysleep 10
+  query: |
+    SELECT 1 AS result
+    WHERE
+      -- Pass if not Apple Silicon
+      NOT EXISTS (
+        SELECT 1 FROM system_info WHERE cpu_type = 'arm64e'
+      )
+      OR
+      -- For Apple Silicon, check sleep settings (Battery Power if available, otherwise AC Power)
+      EXISTS (
+        SELECT 1
+        FROM (
+          SELECT 
+            CASE 
+              WHEN JSON_EXTRACT(json_result, '$.Battery Power:') IS NOT NULL 
+              THEN JSON_EXTRACT(json_result, '$.Battery Power:')
+              ELSE JSON_EXTRACT(json_result, '$.AC Power:')
+            END AS power_settings
+          FROM pmset
+          WHERE getting = 'custom'
+        )
+        WHERE
+          -- Require sleep setting to be 15 minutes or less
+          CAST(JSON_EXTRACT(power_settings, '$.sleep') AS INTEGER) <= 15
+          AND
+          -- Require display sleep to be 10 minutes or less AND less than or equal to sleep value
+          CAST(JSON_EXTRACT(power_settings, '$.displaysleep') AS INTEGER) <= 10
+          AND
+          CAST(JSON_EXTRACT(power_settings, '$.displaysleep') AS INTEGER) <= CAST(JSON_EXTRACT(power_settings, '$.sleep') AS INTEGER)
+      );
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level2
+  contributors: getvictor
+---
+apiVersion: v1
+kind: policy
+spec:
   name: CIS - Ensure Wake for Network Access Is Disabled (Fleetd Required)
   platforms: macOS
   platform: darwin

--- a/ee/cis/macos-15/cis-policy-queries.yml
+++ b/ee/cis/macos-15/cis-policy-queries.yml
@@ -2751,8 +2751,6 @@ spec:
     A minimum password length is the fewest number of characters a password can contain to meet a system's requirements. Ensure that a minimum of a 15-character password is part of the password policy on the computer. Where the confidentiality of encrypted information in FileVault is more of a concern, requiring a longer password or passphrase may be sufficient rather than imposing additional complexity requirements that may be self-defeating.
   resolution: |
     Automated method:
-    Ask your system administrator to deploy an MDM profile that disables Guest Account.
-    Profile Method:
     Ask your administrator to deploy a profile with the following configuration:
       1. The PayloadType string is com.apple.mobiledevice.passwordpolicy 
       2. The key to include is minLength

--- a/ee/cis/macos-15/cis-policy-queries.yml
+++ b/ee/cis/macos-15/cis-policy-queries.yml
@@ -2878,21 +2878,21 @@ spec:
 apiVersion: v1
 kind: policy
 spec:
-  name: CIS - Ensure Password History Is Configured (Fleetd Required)
+  name: CIS - Ensure password history is set to at least 24 (MDM required)
   platforms: macOS
   platform: darwin
   description: |
-    Over time, passwords can be captured by third parties through mistakes, phishing attacks, third-party breaches, or merely brute-force attacks. To reduce the risk of exposure and to decrease the incentives of password reuse (passwords that are not forced to be changed periodically generally are not ever changed), users must reset passwords periodically. This control ensures that previous passwords are not reused immediately by keeping a history of previous password hashes. Ensure that password history checks are part of the password policy on the computer. This control checks whether a new password is different than the previous 15. The latest NIST guidance based on exploit research referenced in this section details how one of the greatest risks is password exposure rather than password cracking. Passwords should be changed to a new unique value whenever a password might have been exposed to anyone other than the account holder. Attackers have maintained persistent control based on predictable password change patterns and substantially different patterns should be used in case of a leak.
+    Over time, passwords can be captured by third parties through mistakes, phishing attacks, third-party breaches, or merely brute-force attacks. To reduce the risk of exposure and to decrease the incentives of password reuse (passwords that are not forced to be changed periodically generally are not ever changed), users must reset passwords periodically. This control ensures that previous passwords are not reused immediately by keeping a history of previous password hashes. Ensure that password history checks are part of the password policy on the computer. This control checks whether a new password is different than the previous 24. The latest NIST guidance based on exploit research referenced in this section details how one of the greatest risks is password exposure rather than password cracking. Passwords should be changed to a new unique value whenever a password might have been exposed to anyone other than the account holder. Attackers have maintained persistent control based on predictable password change patterns and substantially different patterns should be used in case of a leak.
   resolution: |
-    Automated method:
-    Ask your system administrator to deploy an MDM profile with the following information:
+    Profile method:
+    Ask your administrator to deploy a profile with the following configuration:
       1. The Payload Type string is com.apple.mobiledevice.passwordpolicy 
       2. The key to include is pinHistory
-      3. The key must be set to <integer><value≥15></integer>
-  query: SELECT 1 FROM  pwd_policy where history_depth >= 15;
+      3. The key must be set to <integer><value≥24></integer>
+  query: SELECT 1 FROM pwd_policy WHERE history_depth >= 24;
   purpose: Informational
   tags: compliance, CIS, CIS_Level1
-  contributors: sharon-fdm
+  contributors: sharon-fdm, getvictor
 ---
 apiVersion: v1
 kind: policy

--- a/ee/cis/macos-15/cis-policy-queries.yml
+++ b/ee/cis/macos-15/cis-policy-queries.yml
@@ -1601,7 +1601,7 @@ spec:
     WHERE
       -- Pass if not Apple Silicon
       NOT EXISTS (
-        SELECT 1 FROM system_info WHERE cpu_type = 'arm64e'
+        SELECT 1 FROM system_info WHERE cpu_type LIKE 'arm64%'
       )
       OR
       -- For Apple Silicon, check sleep settings (Battery Power if available, otherwise AC Power)
@@ -1722,7 +1722,7 @@ spec:
           )
         ) OR EXISTS(
           SELECT 1 WHERE EXISTS(
-            SELECT 1 FROM system_info WHERE cpu_type = 'arm64e'
+            SELECT 1 FROM system_info WHERE cpu_type LIKE 'arm64%'
           ) AND EXISTS (
             SELECT
                 CAST(JSON_EXTRACT(battery, '$.standby') AS INTEGER) AS standby

--- a/ee/cis/macos-15/cis-policy-queries.yml
+++ b/ee/cis/macos-15/cis-policy-queries.yml
@@ -19,33 +19,6 @@ spec:
   purpose: Informational
   tags: compliance, CIS, CIS_Level1
   contributors: sharon-fdm
----
-apiVersion: v1
-kind: policy
-spec:
-  name: CIS - Ensure Auto Update Is Enabled (MDM Required)
-  platforms: macOS
-  platform: darwin
-  description: Checks that the system is configured via MDM to automatically install updates.
-  resolution: "Ask your system administrator to deploy an MDM profile that enables automatic updates."
-  query: |
-    SELECT 1 WHERE 
-      EXISTS (
-        SELECT 1 FROM managed_policies WHERE 
-            domain='com.apple.SoftwareUpdate' AND 
-            name='AutomaticCheckEnabled' AND 
-            (value = 1 OR value = 'true')
-        )
-      AND NOT EXISTS (
-        SELECT 1 FROM managed_policies WHERE 
-            domain='com.apple.SoftwareUpdate' AND 
-            name='AutomaticCheckEnabled' AND 
-            (value != 1 AND value != 'true')
-        );  
-  purpose: Informational
-  tags: compliance, CIS, CIS_Level1
-  contributors: sharon-fdm
----
 apiVersion: v1
 kind: policy
 spec:
@@ -546,36 +519,6 @@ spec:
 apiVersion: v1
 kind: policy
 spec:
-  name: CIS - Ensure DVD or CD Sharing Is Disabled
-  platforms: macOS
-  platform: darwin
-  description: |
-    DVD or CD Sharing allows users to remotely access the system's optical drive.
-    Disabling DVD or CD Sharing minimizes the risk of an attacker using the optical drive as
-    a vector for attack and exposure of sensitive data.
-  resolution: |
-    Graphical Method:
-    1. Open System Settings
-    2. Select General
-    3. Select Sharing
-    4. Set CD/DVD Sharing to disabled
-  query: |
-    SELECT 1 WHERE NOT EXISTS (
-      SELECT * FROM plist WHERE
-        path = '/var/db/com.apple.xpc.launchd/disabled.plist' AND
-        key = 'com.apple.ODSAgent' AND
-        value = '0'
-    );
-  # We are not using the launchd table because it does not check if services
-  # are disabled via disabled.plist, which the preference pane uses whenever
-  # a service is disabled after it has been enabled in the past.
-  purpose: Informational
-  tags: compliance, CIS, CIS_Level1
-  contributors: artemist-work
----
-apiVersion: v1
-kind: policy
-spec:
   name: CIS - Ensure Screen Sharing Is Disabled 
   platforms: macOS
   platform: darwin
@@ -829,9 +772,18 @@ spec:
   platforms: macOS
   platform: darwin
   description: |
-    Bluetooth Sharing allows files to be exchanged with Bluetooth-enabled devices.
-    Disabling Bluetooth Sharing minimizes the risk of an attacker using Bluetooth
-    to remotely attack the system.
+    Bluetooth Sharing allows files to be exchanged with Bluetooth-enabled devices. This
+    setting only disables the receiving of files and requires both devices to be paired
+    through Bluetooth as well as accepted by the receiver. This setting does not disable the
+    ability to send files from the device to another paired Bluetooth device.
+    Bluetooth pairing only requires an acceptance dialog on either device attempting to pair.
+    It does require the Bluetooth pane in System Settings to be open for any macOS
+    device to be discoverable. While it does give a verification code, it does not require
+    either device to enter the code, but just accept the dialog box (on either device). At that
+    point, the two devices are paired and files can be shared through Bluetooth. To receive
+    files through Bluetooth File Exchange application, the user does have to accept the
+    file(s) through a dialog box.
+    Users should only pair to known trusted Bluetooth devices.
   resolution: |
     Graphical Method:
     1. Open System Settings

--- a/ee/cis/macos-15/cis-policy-queries.yml
+++ b/ee/cis/macos-15/cis-policy-queries.yml
@@ -110,6 +110,7 @@ spec:
         Ask your system administrator to deploy a script that will configure:
         /usr/bin/sudo /bin/launchctl load -w /Library/Apple/System/Library/LaunchDaemons/com.apple.XProtect.daemon.scan.plist
         /usr/bin/sudo /bin/launchctl load -w /Library/Apple/System/Library/LaunchDaemons/com.apple.XprotectFramework.PluginService.plist
+        /usr/bin/sudo /usr/bin/xprotect update
   query: |
       SELECT 1
       WHERE (
@@ -122,7 +123,7 @@ spec:
       ) = 2;
   purpose: Informational
   tags: compliance, CIS, CIS_Level1
-  contributors: defensivedepth
+  contributors: defensivedepth, getvictor
 ---
 apiVersion: v1
 kind: policy

--- a/ee/cis/macos-15/cis-policy-queries.yml
+++ b/ee/cis/macos-15/cis-policy-queries.yml
@@ -2708,13 +2708,17 @@ spec:
     Note: Applications that are not following standard practices, and have world-writable files in /System/Volumes/Data/Library may not launch or operate correctly after the remediation has been run.
   query: |
     SELECT 1 WHERE NOT EXISTS (
-      SELECT 1 FROM file 
+      SELECT 1 FROM file f
       WHERE 
-        path LIKE '/Library/%'
-        AND type = 'directory'
-        AND (mode LIKE '%2' OR mode LIKE '%3' OR mode LIKE '%6' OR mode LIKE '%7')
-        AND NOT (mode LIKE '1%')
-        AND xattr NOT LIKE '%com.apple.rootless%'
+        f.path LIKE '/Library/%'
+        AND f.type = 'directory'
+        AND (f.mode LIKE '%2' OR f.mode LIKE '%3' OR f.mode LIKE '%6' OR f.mode LIKE '%7')
+        AND NOT (f.mode LIKE '1%')
+        AND NOT EXISTS (
+          SELECT 1 FROM extended_attributes ea
+          WHERE ea.path = f.path
+          AND ea.key = 'com.apple.rootless'
+        )
     );
   purpose: Informational
   tags: compliance, CIS, CIS_Level2

--- a/ee/cis/macos-15/cis-policy-queries.yml
+++ b/ee/cis/macos-15/cis-policy-queries.yml
@@ -2532,14 +2532,14 @@ spec:
   platforms: macOS
   platform: darwin
   description: |
-    MacOS can act as an NFS fileserver. NFS sharing could be enabled to allow someone on another computer to mount
-    shares and gain access to information from the user's computer.
+    macOS can act as an NFS fileserver. NFS sharing could be enabled to allow someone on another computer to mount shares and gain access to information from the user's computer. File sharing from a user endpoint has long been considered questionable, and Apple has removed that capability from the GUI. NFSD is still part of the Operating System and can be easily turned on to export shares and provide remote connectivity to an end-user computer. The etc/exports file contains the list of NFS shared directories. If the file exists, it is likely that NFS sharing has been enabled in the past or may be available periodically.
   resolution: |
     Automated method:
     Ask your system administrator to deploy the following script which will disable the NFS service
     and its directory listing:
     /usr/bin/sudo /bin/launchctl disable system/com.apple.nfsd
-    /usr/bin/sudo /bin/rm /etc/exports
+    /usr/bin/sudo /bin/rm -rf /etc/exports
+    Note: Removing /etc/exports also stops the NFS service if it was running.
   query: |
     SELECT 1 WHERE
     NOT EXISTS(SELECT 1 FROM processes WHERE path = '/sbin/nfsd')
@@ -2547,7 +2547,7 @@ spec:
     NOT EXISTS(SELECT 1 FROM file WHERE path = '/etc/exports');
   purpose: Informational
   tags: compliance, CIS, CIS_Level1
-  contributors: lucasmrod
+  contributors: lucasmrod, getvictor
 ---
 apiVersion: v1
 kind: policy

--- a/ee/cis/macos-15/cis-policy-queries.yml
+++ b/ee/cis/macos-15/cis-policy-queries.yml
@@ -3513,30 +3513,19 @@ spec:
   description: |
     In order to properly monitor the use of the sudo command, logs events for any use of sudo should be captured in the unified log.
   resolution: |
-    Ask your system administrator to deploy a script that will configure:
-      /usr/bin/sudo /usr/sbin/visudo -f /etc/sudoers
-      Remove the line, or comment out with # before the line, 'Defaults !log_allowed'
+    Automated method:
+    Ask your administrator to deploy a script that will configure:
+    /usr/bin/sudo /usr/sbin/visudo -f /etc/sudoers.d/10_cissudoconfiguration
+    Add the line to the file: 'Defaults log_allowed'
+    Note: Unlike other Unix/Linux distros, macOS will ignore configuration files in the sudoers.d folder that contain a period, so do not add a file extension to the configuration file. The 'Defaults log_allowed' line can be added to an existing configuration file or a new one.
   query: |
-    SELECT 1 
-    FROM file_lines 
-    WHERE path = '/etc/sudoers' 
-      AND (
-          -- No matching line
-          NOT EXISTS (
-              SELECT 1 
-              FROM file_lines 
-              WHERE path = '/etc/sudoers' 
-                AND line LIKE '%!log_allowed%'
-          ) 
-          -- OR line exists but is commented
-          AND NOT EXISTS (
-              SELECT 1 
-              FROM file_lines 
-              WHERE path = '/etc/sudoers' 
-                AND line LIKE '%#%Defaults%!log_allowed%'
-          )
-      ) 
-    LIMIT 1;
+    SELECT 1 WHERE EXISTS (
+      SELECT 1 FROM file_lines 
+      WHERE (path = '/etc/sudoers' OR path LIKE '/etc/sudoers.d/%')
+        AND line LIKE '%Defaults%log_allowed%'
+        AND line NOT LIKE '%!log_allowed%'
+        AND line NOT LIKE '#%'
+    );
   purpose: Informational
   tags: compliance, CIS, CIS_Level1
-  contributors: defensivedepth
+  contributors: getvictor

--- a/ee/cis/macos-15/cis-policy-queries.yml
+++ b/ee/cis/macos-15/cis-policy-queries.yml
@@ -815,40 +815,33 @@ spec:
     Disabling Media Sharing reduces the remote attack surface of the system
   resolution: |
     Profile Method:
-    Ask your administrator to deploy a profile that sets
-    homeSharingUIStatus, legacySharingUIStatus, and mediaSharingUIStatus to 0
-    for com.apple.preferences.sharing.SharingPrefsExtension
+    Ask your administrator to deploy a profile with the following configuration:
+    1. The PayloadType string is com.apple.applicationaccess
+    2. The key to include is allowMediaSharing
+    3. The key must be set to <false/>
+    4. The key to also include is allowMediaSharingModification
+    5. The key must be set to <false/>
   query: |
     SELECT 1 WHERE EXISTS(
       SELECT 1 FROM managed_policies WHERE
-        domain = 'com.apple.preferences.sharing.SharingPrefsExtension' AND
-        name = 'homeSharingUIStatus' AND
-        value = '0'
+        domain = 'com.apple.applicationaccess' AND
+        name = 'allowMediaSharing' AND
+        (value = 0 OR value = 'false')
     ) AND EXISTS (
       SELECT 1 FROM managed_policies WHERE
-        domain = 'com.apple.preferences.sharing.SharingPrefsExtension' AND
-        name = 'legacySharingUIStatus' AND
-        value = '0'
-    ) AND EXISTS (
-      SELECT 1 FROM managed_policies WHERE
-        domain = 'com.apple.preferences.sharing.SharingPrefsExtension' AND
-        name = 'mediaSharingUIStatus' AND
-        value = '0'
+        domain = 'com.apple.applicationaccess' AND
+        name = 'allowMediaSharingModification' AND
+        (value = 0 OR value = 'false')
     ) AND NOT EXISTS (
       SELECT 1 FROM managed_policies WHERE
-        domain = 'com.apple.preferences.sharing.SharingPrefsExtension' AND
-        name = 'homeSharingUIStatus' AND
-        value != '0'
+        domain = 'com.apple.applicationaccess' AND
+        name = 'allowMediaSharing' AND
+        (value != 0 AND value != 'false')
     ) AND NOT EXISTS (
       SELECT 1 FROM managed_policies WHERE
-        domain = 'com.apple.preferences.sharing.SharingPrefsExtension' AND
-        name = 'legacySharingUIStatus' AND
-        value != '0'
-    ) AND NOT EXISTS (
-      SELECT 1 FROM managed_policies WHERE
-        domain = 'com.apple.preferences.sharing.SharingPrefsExtension' AND
-        name = 'mediaSharingUIStatus' AND
-        value != '0'
+        domain = 'com.apple.applicationaccess' AND
+        name = 'allowMediaSharingModification' AND
+        (value != 0 AND value != 'false')
     );
   purpose: Informational
   tags: compliance, CIS, CIS_Level1

--- a/ee/cis/macos-15/cis-policy-queries.yml
+++ b/ee/cis/macos-15/cis-policy-queries.yml
@@ -2694,31 +2694,31 @@ spec:
 apiVersion: v1
 kind: policy
 spec:
-  name: CIS - Ensure No World Writable Files Exist in the Library Folder
+  name: CIS - Ensure No World Writable Folders Exist in the Library Folder (Fleetd required)
   platforms: macOS
   platform: darwin
   description: |
-    Software sometimes insists on being installed in the /System/Volumes/Data/Library Directory and has inappropriate world-writable permissions.  
-    Folders in /System/Volumes/Data/Library should not be world-writable. The audit check excludes the /System/Volumes/Data/Library/Caches and /System/Volumes/Data/Library/Preferences/Audio/Data folders where the sticky bit is set.
+    Software sometimes insists on being installed in the /System/Volumes/Data/Library directory and has inappropriate world-writable permissions. This software could be compromised with the folder(s) being world-writable by unauthorized actions. Folders in /System/Volumes/Data/Library should not be world-writable. The audit check excludes folders where the sticky bit is set by Apple. These folders are required by the operating system to run and should not be modified. Some security vendors use a world-writable folder for their security extension tool. This will be considered compliant due to the tools themselves not allowing a user to write to their folders. This is against the standard practice on POSIX systems. It is considered compliant here because of additional security vendor controls that are controlled through industry standard mitigations.
   resolution: |
-    Ask your system administrator to deploy a script that will ensure folders are not world-writable in the /System folder. 
+    Ask your system administrator to deploy a script that will ensure folders are not world-writable in the /Library folder. 
     /usr/bin/sudo IFS=$'\n'
-    for libPermissions in $( /usr/bin/find /System/Volumes/Data/Library -type d -perm -2 | /usr/bin/grep -v Caches | /usr/bin/grep -v /Preferences/Audio/Data); 
-    do
+    for libPermissions in $(/usr/bin/find /Library -type d -perm -002 ! -perm -1000 ! -xattrname com.apple.rootless 2>/dev/null); do
       /bin/chmod -R o-w "$libPermissions"
     done
+    Note: Applications that are not following standard practices, and have world-writable files in /System/Volumes/Data/Library may not launch or operate correctly after the remediation has been run.
   query: |
     SELECT 1 WHERE NOT EXISTS (
-      SELECT 1 FROM find_cmd WHERE
-        directory = '/System/Volumes/Data/Library'
-        AND type = 'd'
-        AND perm = '-2'
-        AND path NOT LIKE '%Caches%'
-        AND path NOT LIKE '%/Preferences/Audio/Data%'
+      SELECT 1 FROM file 
+      WHERE 
+        path LIKE '/Library/%'
+        AND type = 'directory'
+        AND (mode LIKE '%2' OR mode LIKE '%3' OR mode LIKE '%6' OR mode LIKE '%7')
+        AND NOT (mode LIKE '1%')
+        AND xattr NOT LIKE '%com.apple.rootless%'
     );
   purpose: Informational
   tags: compliance, CIS, CIS_Level2
-  contributors: sharon-fdm
+  contributors: getvictor
 ---
 apiVersion: v1
 kind: policy

--- a/ee/cis/macos-15/cis-policy-queries.yml
+++ b/ee/cis/macos-15/cis-policy-queries.yml
@@ -3034,12 +3034,14 @@ spec:
   platforms: macOS
   platform: darwin
   description: |
-    Disabling the administrator's and/or user's ability to log into another user's active and locked session prevents
-    unauthorized persons from viewing potentially sensitive and/or personal information.
+    macOS has a privilege that can be granted to any user that will allow that user to unlock active users' sessions. Disabling the administrator's and/or user's ability to log into another user's active and locked session prevents unauthorized persons from viewing potentially sensitive and/or personal information.
+    Note: For organizations that are using Platform Single-Sign-On (PSSO), this setting can cause issues with syncing with your PSSO. Verify if you are using PSSO by running: /usr/bin/sudo app-sso platform -s
   resolution: |
     Automated method:
-    Ask your system administrator to deploy a script that runs the following:
-      /usr/bin/sudo /usr/bin/security authorizationdb write system.login.screensaver authenticate-session-owner
+    Ask your administrator to deploy a script that runs the following command:
+    /usr/bin/sudo /usr/bin/security authorizationdb write system.login.screensaver authenticate-session-owner
+    # Note: Running this command will disable Touch ID to unlock the screen saver. To re-enable Touch ID for users, run:
+    /usr/bin/sudo /usr/bin/defaults write /Library/Preferences/com.apple.loginwindow screenUnlockMode -int 1
   query: |
     SELECT 1 WHERE EXISTS (
       SELECT JSON_EXTRACT(json_result, '$.rule') AS rule
@@ -3049,7 +3051,7 @@ spec:
     );
   purpose: Informational
   tags: compliance, CIS, CIS_Level1
-  contributors: lucasmrod
+  contributors: lucasmrod, getvictor
 ---
 apiVersion: v1
 kind: policy

--- a/ee/cis/macos-15/cis-policy-queries.yml
+++ b/ee/cis/macos-15/cis-policy-queries.yml
@@ -1583,10 +1583,16 @@ spec:
   platforms: macOS
   platform: darwin
   description: |
-    MacBooks should be set so that the sleep is 15 minutes or less and the display should sleep at 10 minutes or less. This setting should allow laptop users in most cases to stay within physically secured areas while going to a conference room, auditorium, or other internal location without having to unlock the encryption. When the user goes home at night, the laptop will auto-sleep after 15 minutes and to log back into the system when it resumes.
+    MacBooks should be set so that the sleep is 15 minutes or less and the
+    display should sleep at 10 minutes or less. This setting should allow laptop
+    users in most cases to stay within physically secured areas while going to a
+    conference room, auditorium, or other internal location without having to
+    unlock the encryption. When the user goes home at night, the laptop will
+    auto-sleep after 15 minutes and to log back into the system when it resumes.
   resolution: |
     Automated method:
-    Ask your system administrator to deploy a script that runs the following commands to set the sleep time and display sleep:
+    Ask your system administrator to deploy a script that runs the following
+    commands to set the sleep time and display sleep:
     /usr/bin/sudo /usr/bin/pmset -a sleep 15
     /usr/bin/sudo /usr/bin/pmset -a displaysleep 10
   query: |
@@ -2410,11 +2416,19 @@ spec:
   platforms: macOS
   platform: darwin
   description: |
-    macOS can act as an NFS fileserver. NFS sharing could be enabled to allow someone on another computer to mount shares and gain access to information from the user's computer. File sharing from a user endpoint has long been considered questionable, and Apple has removed that capability from the GUI. NFSD is still part of the Operating System and can be easily turned on to export shares and provide remote connectivity to an end-user computer. The etc/exports file contains the list of NFS shared directories. If the file exists, it is likely that NFS sharing has been enabled in the past or may be available periodically.
+    macOS can act as an NFS fileserver. NFS sharing could be enabled to allow
+    someone on another computer to mount shares and gain access to information
+    from the user's computer. File sharing from a user endpoint has long been
+    considered questionable, and Apple has removed that capability from the GUI.
+    NFSD is still part of the Operating System and can be easily turned on to
+    export shares and provide remote connectivity to an end-user computer. The
+    etc/exports file contains the list of NFS shared directories. If the file
+    exists, it is likely that NFS sharing has been enabled in the past or may
+    be available periodically.
   resolution: |
     Automated method:
-    Ask your system administrator to deploy the following script which will disable the NFS service
-    and its directory listing:
+    Ask your system administrator to deploy the following script which will
+    disable the NFS service and its directory listing:
     /usr/bin/sudo /bin/launchctl disable system/com.apple.nfsd
     /usr/bin/sudo /bin/rm -rf /etc/exports
     Note: Removing /etc/exports also stops the NFS service if it was running.
@@ -2576,14 +2590,29 @@ spec:
   platforms: macOS
   platform: darwin
   description: |
-    Software sometimes insists on being installed in the /System/Volumes/Data/Library directory and has inappropriate world-writable permissions. This software could be compromised with the folder(s) being world-writable by unauthorized actions. Folders in /System/Volumes/Data/Library should not be world-writable. The audit check excludes folders where the sticky bit is set by Apple. These folders are required by the operating system to run and should not be modified. Some security vendors use a world-writable folder for their security extension tool. This will be considered compliant due to the tools themselves not allowing a user to write to their folders. This is against the standard practice on POSIX systems. It is considered compliant here because of additional security vendor controls that are controlled through industry standard mitigations.
+    Software sometimes insists on being installed in the
+    /System/Volumes/Data/Library directory and has inappropriate world-writable
+    permissions. This software could be compromised with the folder(s) being
+    world-writable by unauthorized actions.
+    Folders in /System/Volumes/Data/Library should not be world-writable. The
+    audit check excludes folders where the sticky bit is set by Apple. These
+    folders are required by the operating system to run and should not be
+    modified. Some security vendors use a world-writable folder for their
+    security extension tool. This will be considered compliant due to the tools
+    themselves not allowing a user to write to their folders. This is against
+    the standard practice on POSIX systems. It is considered compliant here
+    because of additional security vendor controls that are controlled through
+    industry standard mitigations.
   resolution: |
-    Ask your system administrator to deploy a script that will ensure folders are not world-writable in the /Library folder. 
+    Ask your system administrator to deploy a script that will ensure folders
+    are not world-writable in the /Library folder. 
     /usr/bin/sudo IFS=$'\n'
     for libPermissions in $(/usr/bin/find /Library -type d -perm -002 ! -perm -1000 ! -xattrname com.apple.rootless 2>/dev/null); do
       /bin/chmod -R o-w "$libPermissions"
     done
-    Note: Applications that are not following standard practices, and have world-writable files in /System/Volumes/Data/Library may not launch or operate correctly after the remediation has been run.
+    Note: Applications that are not following standard practices, and have
+    world-writable files in /System/Volumes/Data/Library may not launch or
+    operate correctly after the remediation has been run.
   query: |
     SELECT 1 WHERE NOT EXISTS (
       SELECT 1 FROM file f
@@ -2760,7 +2789,21 @@ spec:
   platforms: macOS
   platform: darwin
   description: |
-    Over time, passwords can be captured by third parties through mistakes, phishing attacks, third-party breaches, or merely brute-force attacks. To reduce the risk of exposure and to decrease the incentives of password reuse (passwords that are not forced to be changed periodically generally are not ever changed), users must reset passwords periodically. This control ensures that previous passwords are not reused immediately by keeping a history of previous password hashes. Ensure that password history checks are part of the password policy on the computer. This control checks whether a new password is different than the previous 24. The latest NIST guidance based on exploit research referenced in this section details how one of the greatest risks is password exposure rather than password cracking. Passwords should be changed to a new unique value whenever a password might have been exposed to anyone other than the account holder. Attackers have maintained persistent control based on predictable password change patterns and substantially different patterns should be used in case of a leak.
+    Over time, passwords can be captured by third parties through mistakes,
+    phishing attacks, third-party breaches, or merely brute-force attacks. To
+    reduce the risk of exposure and to decrease the incentives of password reuse
+    (passwords that are not forced to be changed periodically generally are not
+    ever changed), users must reset passwords periodically. This control ensures
+    that previous passwords are not reused immediately by keeping a history of
+    previous password hashes. Ensure that password history checks are part of
+    the password policy on the computer. This control checks whether a new
+    password is different than the previous 24. The latest NIST guidance based
+    on exploit research referenced in this section details how one of the
+    greatest risks is password exposure rather than password cracking. Passwords
+    should be changed to a new unique value whenever a password might have been
+    exposed to anyone other than the account holder. Attackers have maintained
+    persistent control based on predictable password change patterns and
+    substantially different patterns should be used in case of a leak.
   resolution: |
     Profile method:
     Ask your administrator to deploy a profile with the following configuration:
@@ -2912,13 +2955,20 @@ spec:
   platforms: macOS
   platform: darwin
   description: |
-    macOS has a privilege that can be granted to any user that will allow that user to unlock active users' sessions. Disabling the administrator's and/or user's ability to log into another user's active and locked session prevents unauthorized persons from viewing potentially sensitive and/or personal information.
-    Note: For organizations that are using Platform Single-Sign-On (PSSO), this setting can cause issues with syncing with your PSSO. Verify if you are using PSSO by running: /usr/bin/sudo app-sso platform -s
+    macOS has a privilege that can be granted to any user that will allow that
+    user to unlock active users' sessions. Disabling the administrator's and/or
+    user's ability to log into another user's active and locked session prevents
+    unauthorized persons from viewing potentially sensitive and/or personal
+    information.
+    Note: For organizations that are using Platform Single-Sign-On (PSSO), this
+    setting can cause issues with syncing with your PSSO. Verify if you are
+    using PSSO by running: /usr/bin/sudo app-sso platform -s
   resolution: |
     Automated method:
     Ask your administrator to deploy a script that runs the following command:
     /usr/bin/sudo /usr/bin/security authorizationdb write system.login.screensaver authenticate-session-owner
-    # Note: Running this command will disable Touch ID to unlock the screen saver. To re-enable Touch ID for users, run:
+    # Note: Running this command will disable Touch ID to unlock the screen
+    # saver. To re-enable Touch ID for users, run:
     /usr/bin/sudo /usr/bin/defaults write /Library/Preferences/com.apple.loginwindow screenUnlockMode -int 1
   query: |
     SELECT 1 WHERE EXISTS (
@@ -2981,11 +3031,20 @@ spec:
   platforms: macOS
   platform: darwin
   description: |
-    A filename extension is a suffix added to a base filename that indicates the base filename's file format. This is intended for any user that logs into the GUI and has a home folder and not for service accounts. For the audit, we will continue to verify that every account with a home folder has filename extensions enabled. Visible filename extensions allow the user to identify the file type and the application it is associated with which leads to quick identification of misrepresented malicious files.
+    A filename extension is a suffix added to a base filename that indicates the
+    base filename's file format. This is intended for any user that logs into
+    the GUI and has a home folder and not for service accounts. For the audit,
+    we will continue to verify that every account with a home folder has
+    filename extensions enabled.
+    Visible filename extensions allow the user to identify the file type and the
+    application it is associated with which leads to quick identification of
+    misrepresented malicious files.
   resolution: |
     Automated method:
-    Ask your administrator to deploy a script that runs the following command for each user:
-    /usr/bin/sudo -u <username> /usr/bin/defaults write /Users/<username>/Library/Preferences/.GlobalPreferences.plist AppleShowAllExtensions -bool true
+    Ask your administrator to deploy a script that runs the following command
+    for each user:
+    /usr/bin/sudo -u <username> /usr/bin/defaults write \
+    /Users/<username>/Library/Preferences/.GlobalPreferences.plist AppleShowAllExtensions -bool true
   query: |
     SELECT 1 WHERE NOT EXISTS (
       SELECT 1 FROM users AS u
@@ -3386,13 +3445,17 @@ spec:
   platforms: macOS
   platform: darwin
   description: |
-    In order to properly monitor the use of the sudo command, logs events for any use of sudo should be captured in the unified log.
+    In order to properly monitor the use of the sudo command, logs events for
+    any use of sudo should be captured in the unified log.
   resolution: |
     Automated method:
     Ask your administrator to deploy a script that will configure:
     /usr/bin/sudo /usr/sbin/visudo -f /etc/sudoers.d/10_cissudoconfiguration
     Add the line to the file: 'Defaults log_allowed'
-    Note: Unlike other Unix/Linux distros, macOS will ignore configuration files in the sudoers.d folder that contain a period, so do not add a file extension to the configuration file. The 'Defaults log_allowed' line can be added to an existing configuration file or a new one.
+    Note: Unlike other Unix/Linux distros, macOS will ignore configuration files
+    in the sudoers.d folder that contain a period, so do not add a file
+    extension to the configuration file. The 'Defaults log_allowed' line can be
+    added to an existing configuration file or a new one.
   query: |
     SELECT 1 AS result
     FROM (
@@ -3422,8 +3485,16 @@ spec:
   platforms: macOS
   platform: darwin
   description: |
-    In macOS 15.0 Sequoia, Apple has introduced what it calls Apple Intelligence, which includes new capabilities for processing language and images with AI technologies. While Apple Intelligence integrates deeply with personal context and generally runs on-device, external intelligence extensions are able to connect to external services like ChatGPT or other third-party AI providers. These external connections may send user data to third-party servers outside of Apple's control.
-    Organizations handling sensitive or confidential information should disable external intelligence extensions to prevent potential data leakage to third-party AI services.
+    In macOS 15.0 Sequoia, Apple has introduced what it calls Apple Intelligence,
+    which includes new capabilities for processing language and images with AI
+    technologies. While Apple Intelligence integrates deeply with personal context
+    and generally runs on-device, external intelligence extensions are able to
+    connect to external services like ChatGPT or other third-party AI providers.
+    These external connections may send user data to third-party servers outside
+    of Apple's control.
+    Organizations handling sensitive or confidential information should disable
+    external intelligence extensions to prevent potential data leakage to
+    third-party AI services.
   resolution: |
     Profile Method:
     Ask your administrator to deploy a profile with the following configuration:
@@ -3453,8 +3524,14 @@ spec:
   platforms: macOS
   platform: darwin
   description: |
-    Writing Tools is a feature of Apple Intelligence that provides AI-powered writing assistance including proofreading, rewriting, and summarization capabilities. While these features process text on-device when possible, they may still process sensitive or confidential information that organizations need to control.
-    Organizations handling sensitive documents should consider disabling Writing Tools to prevent potential exposure of confidential information through AI processing.
+    Writing Tools is a feature of Apple Intelligence that provides AI-powered
+    writing assistance including proofreading, rewriting, and summarization
+    capabilities. While these features process text on-device when possible,
+    they may still process sensitive or confidential information that
+    organizations need to control.
+    Organizations handling sensitive documents should consider disabling Writing
+    Tools to prevent potential exposure of confidential information through AI
+    processing.
   resolution: |
     Profile Method:
     Ask your administrator to deploy a profile with the following configuration:
@@ -3484,8 +3561,12 @@ spec:
   platforms: macOS
   platform: darwin
   description: |
-    Mail Summarization is a feature of Apple Intelligence that uses AI to automatically generate summaries of email content. This feature processes email content through AI models which may include sensitive or confidential information.
-    Organizations should disable Mail Summarization to prevent AI processing of potentially sensitive email communications.
+    Mail Summarization is a feature of Apple Intelligence that uses AI to
+    automatically generate summaries of email content. This feature processes
+    email content through AI models which may include sensitive or confidential
+    information.
+    Organizations should disable Mail Summarization to prevent AI processing of
+    potentially sensitive email communications.
   resolution: |
     Profile Method:
     Ask your administrator to deploy a profile with the following configuration:
@@ -3515,8 +3596,12 @@ spec:
   platforms: macOS
   platform: darwin
   description: |
-    Notes Summarization is a feature of Apple Intelligence that uses AI to automatically generate summaries of notes content. This feature processes notes through AI models which may include sensitive or confidential information.
-    Organizations should disable Notes Summarization to prevent AI processing of potentially sensitive notes and documentation.
+    Notes Summarization is a feature of Apple Intelligence that uses AI to
+    automatically generate summaries of notes content. This feature processes
+    notes through AI models which may include sensitive or confidential
+    information.
+    Organizations should disable Notes Summarization to prevent AI processing of
+    potentially sensitive notes and documentation.
   resolution: |
     Profile Method:
     Ask your administrator to deploy a profile with the following configuration:

--- a/ee/cis/macos-15/cis-policy-queries.yml
+++ b/ee/cis/macos-15/cis-policy-queries.yml
@@ -19,6 +19,7 @@ spec:
   purpose: Informational
   tags: compliance, CIS, CIS_Level1
   contributors: sharon-fdm
+---
 apiVersion: v1
 kind: policy
 spec:
@@ -986,129 +987,6 @@ spec:
   tags: compliance, CIS, CIS_Level1
   contributors: lucasmrod
 ---
-apiVersion: v1
-kind: policy
-spec:
-  name: CIS - Ensure external intelligence extensions is disabled (MDM required)
-  platforms: macOS
-  platform: darwin
-  description: |
-    In macOS 15.0 Sequoia, Apple has introduced what it calls Apple Intelligence, which includes new capabilities for processing language and images with AI technologies. While Apple Intelligence integrates deeply with personal context and generally runs on-device, external intelligence extensions are able to connect to external services like ChatGPT or other third-party AI providers. These external connections may send user data to third-party servers outside of Apple's control.
-    Organizations handling sensitive or confidential information should disable external intelligence extensions to prevent potential data leakage to third-party AI services.
-  resolution: |
-    Profile Method:
-    Ask your administrator to deploy a profile with the following configuration:
-    1. The PayloadType string is com.apple.applicationaccess
-    2. The key to include is allowIntelligenceExtensions
-    3. The key must be set to <false/>
-  query: |
-    SELECT 1 WHERE EXISTS(
-      SELECT 1 FROM managed_policies WHERE
-        domain = 'com.apple.applicationaccess' AND
-        name = 'allowIntelligenceExtensions' AND
-        (value = 0 OR value = 'false')
-    ) AND NOT EXISTS (
-      SELECT 1 FROM managed_policies WHERE
-        domain = 'com.apple.applicationaccess' AND
-        name = 'allowIntelligenceExtensions' AND
-        (value != 0 AND value != 'false')
-    );
-  purpose: Informational
-  tags: compliance, CIS, CIS_Level1
-  contributors: getvictor
----
-apiVersion: v1
-kind: policy
-spec:
-  name: CIS - Ensure writing tools is disabled (MDM required)
-  platforms: macOS
-  platform: darwin
-  description: |
-    Writing Tools is a feature of Apple Intelligence that provides AI-powered writing assistance including proofreading, rewriting, and summarization capabilities. While these features process text on-device when possible, they may still process sensitive or confidential information that organizations need to control.
-    Organizations handling sensitive documents should consider disabling Writing Tools to prevent potential exposure of confidential information through AI processing.
-  resolution: |
-    Profile Method:
-    Ask your administrator to deploy a profile with the following configuration:
-    1. The PayloadType string is com.apple.applicationaccess
-    2. The key to include is allowWritingTools
-    3. The key must be set to <false/>
-  query: |
-    SELECT 1 WHERE EXISTS(
-      SELECT 1 FROM managed_policies WHERE
-        domain = 'com.apple.applicationaccess' AND
-        name = 'allowWritingTools' AND
-        (value = 0 OR value = 'false')
-    ) AND NOT EXISTS (
-      SELECT 1 FROM managed_policies WHERE
-        domain = 'com.apple.applicationaccess' AND
-        name = 'allowWritingTools' AND
-        (value != 0 AND value != 'false')
-    );
-  purpose: Informational
-  tags: compliance, CIS, CIS_Level1
-  contributors: getvictor
----
-apiVersion: v1
-kind: policy
-spec:
-  name: CIS - Ensure mail summarization is disabled (MDM required)
-  platforms: macOS
-  platform: darwin
-  description: |
-    Mail Summarization is a feature of Apple Intelligence that uses AI to automatically generate summaries of email content. This feature processes email content through AI models which may include sensitive or confidential information.
-    Organizations should disable Mail Summarization to prevent AI processing of potentially sensitive email communications.
-  resolution: |
-    Profile Method:
-    Ask your administrator to deploy a profile with the following configuration:
-    1. The PayloadType string is com.apple.mail
-    2. The key to include is allowMailIntelligence
-    3. The key must be set to <false/>
-  query: |
-    SELECT 1 WHERE EXISTS(
-      SELECT 1 FROM managed_policies WHERE
-        domain = 'com.apple.mail' AND
-        name = 'allowMailIntelligence' AND
-        (value = 0 OR value = 'false')
-    ) AND NOT EXISTS (
-      SELECT 1 FROM managed_policies WHERE
-        domain = 'com.apple.mail' AND
-        name = 'allowMailIntelligence' AND
-        (value != 0 AND value != 'false')
-    );
-  purpose: Informational
-  tags: compliance, CIS, CIS_Level1
-  contributors: getvictor
----
-apiVersion: v1
-kind: policy
-spec:
-  name: CIS - Ensure notes summarization is disabled (MDM required)
-  platforms: macOS
-  platform: darwin
-  description: |
-    Notes Summarization is a feature of Apple Intelligence that uses AI to automatically generate summaries of notes content. This feature processes notes through AI models which may include sensitive or confidential information.
-    Organizations should disable Notes Summarization to prevent AI processing of potentially sensitive notes and documentation.
-  resolution: |
-    Profile Method:
-    Ask your administrator to deploy a profile with the following configuration:
-    1. The PayloadType string is com.apple.mobilenotes
-    2. The key to include is allowNotesIntelligence
-    3. The key must be set to <false/>
-  query: |
-    SELECT 1 WHERE EXISTS(
-      SELECT 1 FROM managed_policies WHERE
-        domain = 'com.apple.mobilenotes' AND
-        name = 'allowNotesIntelligence' AND
-        (value = 0 OR value = 'false')
-    ) AND NOT EXISTS (
-      SELECT 1 FROM managed_policies WHERE
-        domain = 'com.apple.mobilenotes' AND
-        name = 'allowNotesIntelligence' AND
-        (value != 0 AND value != 'false')
-    );
-  purpose: Informational
-  tags: compliance, CIS, CIS_Level1
-  contributors: getvictor
 apiVersion: v1
 kind: policy
 spec:
@@ -3533,6 +3411,130 @@ spec:
         AND line NOT LIKE '#%'
     ) AS matches
     LIMIT 1;
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1
+  contributors: getvictor
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure external intelligence extensions is disabled (MDM required)
+  platforms: macOS
+  platform: darwin
+  description: |
+    In macOS 15.0 Sequoia, Apple has introduced what it calls Apple Intelligence, which includes new capabilities for processing language and images with AI technologies. While Apple Intelligence integrates deeply with personal context and generally runs on-device, external intelligence extensions are able to connect to external services like ChatGPT or other third-party AI providers. These external connections may send user data to third-party servers outside of Apple's control.
+    Organizations handling sensitive or confidential information should disable external intelligence extensions to prevent potential data leakage to third-party AI services.
+  resolution: |
+    Profile Method:
+    Ask your administrator to deploy a profile with the following configuration:
+    1. The PayloadType string is com.apple.applicationaccess
+    2. The key to include is allowIntelligenceExtensions
+    3. The key must be set to <false/>
+  query: |
+    SELECT 1 WHERE EXISTS(
+      SELECT 1 FROM managed_policies WHERE
+        domain = 'com.apple.applicationaccess' AND
+        name = 'allowIntelligenceExtensions' AND
+        (value = 0 OR value = 'false')
+    ) AND NOT EXISTS (
+      SELECT 1 FROM managed_policies WHERE
+        domain = 'com.apple.applicationaccess' AND
+        name = 'allowIntelligenceExtensions' AND
+        (value != 0 AND value != 'false')
+    );
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1
+  contributors: getvictor
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure writing tools is disabled (MDM required)
+  platforms: macOS
+  platform: darwin
+  description: |
+    Writing Tools is a feature of Apple Intelligence that provides AI-powered writing assistance including proofreading, rewriting, and summarization capabilities. While these features process text on-device when possible, they may still process sensitive or confidential information that organizations need to control.
+    Organizations handling sensitive documents should consider disabling Writing Tools to prevent potential exposure of confidential information through AI processing.
+  resolution: |
+    Profile Method:
+    Ask your administrator to deploy a profile with the following configuration:
+    1. The PayloadType string is com.apple.applicationaccess
+    2. The key to include is allowWritingTools
+    3. The key must be set to <false/>
+  query: |
+    SELECT 1 WHERE EXISTS(
+      SELECT 1 FROM managed_policies WHERE
+        domain = 'com.apple.applicationaccess' AND
+        name = 'allowWritingTools' AND
+        (value = 0 OR value = 'false')
+    ) AND NOT EXISTS (
+      SELECT 1 FROM managed_policies WHERE
+        domain = 'com.apple.applicationaccess' AND
+        name = 'allowWritingTools' AND
+        (value != 0 AND value != 'false')
+    );
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1
+  contributors: getvictor
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure mail summarization is disabled (MDM required)
+  platforms: macOS
+  platform: darwin
+  description: |
+    Mail Summarization is a feature of Apple Intelligence that uses AI to automatically generate summaries of email content. This feature processes email content through AI models which may include sensitive or confidential information.
+    Organizations should disable Mail Summarization to prevent AI processing of potentially sensitive email communications.
+  resolution: |
+    Profile Method:
+    Ask your administrator to deploy a profile with the following configuration:
+    1. The PayloadType string is com.apple.mail
+    2. The key to include is allowMailIntelligence
+    3. The key must be set to <false/>
+  query: |
+    SELECT 1 WHERE EXISTS(
+      SELECT 1 FROM managed_policies WHERE
+        domain = 'com.apple.mail' AND
+        name = 'allowMailIntelligence' AND
+        (value = 0 OR value = 'false')
+    ) AND NOT EXISTS (
+      SELECT 1 FROM managed_policies WHERE
+        domain = 'com.apple.mail' AND
+        name = 'allowMailIntelligence' AND
+        (value != 0 AND value != 'false')
+    );
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1
+  contributors: getvictor
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure notes summarization is disabled (MDM required)
+  platforms: macOS
+  platform: darwin
+  description: |
+    Notes Summarization is a feature of Apple Intelligence that uses AI to automatically generate summaries of notes content. This feature processes notes through AI models which may include sensitive or confidential information.
+    Organizations should disable Notes Summarization to prevent AI processing of potentially sensitive notes and documentation.
+  resolution: |
+    Profile Method:
+    Ask your administrator to deploy a profile with the following configuration:
+    1. The PayloadType string is com.apple.mobilenotes
+    2. The key to include is allowNotesIntelligence
+    3. The key must be set to <false/>
+  query: |
+    SELECT 1 WHERE EXISTS(
+      SELECT 1 FROM managed_policies WHERE
+        domain = 'com.apple.mobilenotes' AND
+        name = 'allowNotesIntelligence' AND
+        (value = 0 OR value = 'false')
+    ) AND NOT EXISTS (
+      SELECT 1 FROM managed_policies WHERE
+        domain = 'com.apple.mobilenotes' AND
+        name = 'allowNotesIntelligence' AND
+        (value != 0 AND value != 'false')
+    );
   purpose: Informational
   tags: compliance, CIS, CIS_Level1
   contributors: getvictor

--- a/ee/cis/macos-15/cis-policy-queries.yml
+++ b/ee/cis/macos-15/cis-policy-queries.yml
@@ -1608,9 +1608,9 @@ spec:
       EXISTS (
         SELECT 1
         FROM (
-          SELECT 
-            CASE 
-              WHEN JSON_EXTRACT(json_result, '$.Battery Power:') IS NOT NULL 
+          SELECT
+            CASE
+              WHEN JSON_EXTRACT(json_result, '$.Battery Power:') IS NOT NULL
               THEN JSON_EXTRACT(json_result, '$.Battery Power:')
               ELSE JSON_EXTRACT(json_result, '$.AC Power:')
             END AS power_settings
@@ -2423,7 +2423,7 @@ spec:
     considered questionable, and Apple has removed that capability from the GUI.
     NFSD is still part of the Operating System and can be easily turned on to
     export shares and provide remote connectivity to an end-user computer. The
-    etc/exports file contains the list of NFS shared directories. If the file
+    /etc/exports file contains the list of NFS shared directories. If the file
     exists, it is likely that NFS sharing has been enabled in the past or may
     be available periodically.
   resolution: |
@@ -2620,8 +2620,8 @@ spec:
       WHERE 
         f.path LIKE '/Library/%'
         AND f.type = 'directory'
-        AND (f.mode LIKE '%2' OR f.mode LIKE '%3' OR f.mode LIKE '%6' OR f.mode LIKE '%7')
-        AND NOT (f.mode LIKE '1%')
+        AND (CAST(SUBSTR(f.mode,-1) AS INTEGER) & 2) = 2
+        AND NOT ((CAST(f.mode AS INTEGER) & 01000) = 01000)
         AND NOT EXISTS (
           SELECT 1 FROM extended_attributes ea
           WHERE ea.path = f.path

--- a/ee/cis/macos-15/cis-policy-queries.yml
+++ b/ee/cis/macos-15/cis-policy-queries.yml
@@ -845,7 +845,7 @@ spec:
     );
   purpose: Informational
   tags: compliance, CIS, CIS_Level1
-  contributors: artemist-work
+  contributors: getvictor
 ---
 apiVersion: v1
 kind: policy
@@ -985,6 +985,130 @@ spec:
   purpose: Informational
   tags: compliance, CIS, CIS_Level1
   contributors: lucasmrod
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure external intelligence extensions is disabled
+  platforms: macOS
+  platform: darwin
+  description: |
+    In macOS 15.0 Sequoia, Apple has introduced what it calls Apple Intelligence, which includes new capabilities for processing language and images with AI technologies. While Apple Intelligence integrates deeply with personal context and generally runs on-device, external intelligence extensions are able to connect to external services like ChatGPT or other third-party AI providers. These external connections may send user data to third-party servers outside of Apple's control.
+    Organizations handling sensitive or confidential information should disable external intelligence extensions to prevent potential data leakage to third-party AI services.
+  resolution: |
+    Profile Method:
+    Create or edit a configuration profile with the following information:
+    1. The PayloadType string is com.apple.applicationaccess
+    2. The key to include is allowIntelligenceExtensions
+    3. The key must be set to <false/>
+  query: |
+    SELECT 1 WHERE EXISTS(
+      SELECT 1 FROM managed_policies WHERE
+        domain = 'com.apple.applicationaccess' AND
+        name = 'allowIntelligenceExtensions' AND
+        (value = 0 OR value = 'false')
+    ) AND NOT EXISTS (
+      SELECT 1 FROM managed_policies WHERE
+        domain = 'com.apple.applicationaccess' AND
+        name = 'allowIntelligenceExtensions' AND
+        (value != 0 AND value != 'false')
+    );
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1
+  contributors: getvictor
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure writing tools is disabled
+  platforms: macOS
+  platform: darwin
+  description: |
+    Writing Tools is a feature of Apple Intelligence that provides AI-powered writing assistance including proofreading, rewriting, and summarization capabilities. While these features process text on-device when possible, they may still process sensitive or confidential information that organizations need to control.
+    Organizations handling sensitive documents should consider disabling Writing Tools to prevent potential exposure of confidential information through AI processing.
+  resolution: |
+    Profile Method:
+    Create or edit a configuration profile with the following information:
+    1. The PayloadType string is com.apple.applicationaccess
+    2. The key to include is allowWritingTools
+    3. The key must be set to <false/>
+  query: |
+    SELECT 1 WHERE EXISTS(
+      SELECT 1 FROM managed_policies WHERE
+        domain = 'com.apple.applicationaccess' AND
+        name = 'allowWritingTools' AND
+        (value = 0 OR value = 'false')
+    ) AND NOT EXISTS (
+      SELECT 1 FROM managed_policies WHERE
+        domain = 'com.apple.applicationaccess' AND
+        name = 'allowWritingTools' AND
+        (value != 0 AND value != 'false')
+    );
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1
+  contributors: getvictor
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure mail summarization is disabled
+  platforms: macOS
+  platform: darwin
+  description: |
+    Mail Summarization is a feature of Apple Intelligence that uses AI to automatically generate summaries of email content. This feature processes email content through AI models which may include sensitive or confidential information.
+    Organizations should disable Mail Summarization to prevent AI processing of potentially sensitive email communications.
+  resolution: |
+    Profile Method:
+    Create or edit a configuration profile with the following information:
+    1. The PayloadType string is com.apple.mail
+    2. The key to include is allowMailIntelligence
+    3. The key must be set to <false/>
+  query: |
+    SELECT 1 WHERE EXISTS(
+      SELECT 1 FROM managed_policies WHERE
+        domain = 'com.apple.mail' AND
+        name = 'allowMailIntelligence' AND
+        (value = 0 OR value = 'false')
+    ) AND NOT EXISTS (
+      SELECT 1 FROM managed_policies WHERE
+        domain = 'com.apple.mail' AND
+        name = 'allowMailIntelligence' AND
+        (value != 0 AND value != 'false')
+    );
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1
+  contributors: getvictor
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure notes summarization is disabled
+  platforms: macOS
+  platform: darwin
+  description: |
+    Notes Summarization is a feature of Apple Intelligence that uses AI to automatically generate summaries of notes content. This feature processes notes through AI models which may include sensitive or confidential information.
+    Organizations should disable Notes Summarization to prevent AI processing of potentially sensitive notes and documentation.
+  resolution: |
+    Profile Method:
+    Create or edit a configuration profile with the following information:
+    1. The PayloadType string is com.apple.mobilenotes
+    2. The key to include is allowNotesIntelligence
+    3. The key must be set to <false/>
+  query: |
+    SELECT 1 WHERE EXISTS(
+      SELECT 1 FROM managed_policies WHERE
+        domain = 'com.apple.mobilenotes' AND
+        name = 'allowNotesIntelligence' AND
+        (value = 0 OR value = 'false')
+    ) AND NOT EXISTS (
+      SELECT 1 FROM managed_policies WHERE
+        domain = 'com.apple.mobilenotes' AND
+        name = 'allowNotesIntelligence' AND
+        (value != 0 AND value != 'false')
+    );
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1
+  contributors: getvictor
 ---
 apiVersion: v1
 kind: policy


### PR DESCRIPTION
Fixes #31106 

Details of the changes done
- for macOS 15: https://github.com/fleetdm/fleet/issues/31106#issuecomment-3155384061
- for macOS 14: https://github.com/fleetdm/fleet/issues/31106#issuecomment-3155691097
- for macOS 13: https://github.com/fleetdm/fleet/issues/31106#issuecomment-3155763952

# Checklist for submitter
- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing
- [x] QA'd all new/changed functionality manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added new security policies for macOS 15, including controls for Apple Intelligence features such as external intelligence extensions, writing tools, mail summarization, and notes summarization.
  * Introduced a policy to ensure sleep and display sleep are enabled on Apple Silicon devices.

* **Improvements**
  * Enhanced and clarified descriptions for several existing macOS CIS policies, including Bluetooth Sharing, Siri, NFS Server, password policies, and filename extension visibility.
  * Updated policy queries and resolutions to align with the latest CIS Benchmark version 1.1.0 and current macOS settings.
  * Standardized resolution instructions and improved contributor attribution across policies.

* **Bug Fixes**
  * Corrected and clarified policy names and descriptions, such as renaming Siri policy to ensure it is disabled and focusing on world-writable folders instead of files.

* **Removals**
  * Removed the policy requiring auto-update to be enabled for macOS 15.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->