### PR TITLE
Allow worker to filter queue by job type

### DIFF
--- a/server/datastore/mysql/jobs.go
+++ b/server/datastore/mysql/jobs.go
@@ -56,10 +56,14 @@ ORDER BY
 LIMIT ?
 `
 
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+
 	args := []interface{}{fleet.JobStateQueued, now, maxNumJobs}
 
-	var nameClause string
 	// Add job name filter if needed
+	var nameClause string
 	if len(jobNames) > 0 {
 		clause, nameArgs, err := sqlx.In("AND name IN (?)", jobNames)
 		if err != nil {
@@ -68,11 +72,8 @@ LIMIT ?
 		nameClause = clause
 		args = append(args, nameArgs...)
 	}
-	query = fmt.Sprintf(query, nameClause)
 
-	if now.IsZero() {
-		now = time.Now().UTC()
-	}
+	query = fmt.Sprintf(query, nameClause)
 
 	var jobs []*fleet.Job
 	err := sqlx.SelectContext(ctx, ds.reader(ctx), &jobs, query, args...)

--- a/server/datastore/mysql/jobs.go
+++ b/server/datastore/mysql/jobs.go
@@ -60,7 +60,7 @@ LIMIT ?
 		now = time.Now().UTC()
 	}
 
-	args := []interface{}{fleet.JobStateQueued, now, maxNumJobs}
+	args := []interface{}{fleet.JobStateQueued, now}
 
 	// Add job name filter if needed
 	var nameClause string
@@ -74,7 +74,7 @@ LIMIT ?
 	}
 
 	query = fmt.Sprintf(query, nameClause)
-
+	args = append(args, maxNumJobs)
 	var jobs []*fleet.Job
 	err := sqlx.SelectContext(ctx, ds.reader(ctx), &jobs, query, args...)
 	if err != nil {

--- a/server/datastore/mysql/jobs.go
+++ b/server/datastore/mysql/jobs.go
@@ -2,6 +2,7 @@ package mysql
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/fleetdm/fleet/v4/server/contexts/ctxerr"
@@ -37,6 +38,10 @@ VALUES (?, ?, ?, ?, ?, COALESCE(?, NOW()))
 }
 
 func (ds *Datastore) GetQueuedJobs(ctx context.Context, maxNumJobs int, now time.Time) ([]*fleet.Job, error) {
+	return ds.GetFilteredQueuedJobs(ctx, maxNumJobs, now, nil)
+}
+
+func (ds *Datastore) GetFilteredQueuedJobs(ctx context.Context, maxNumJobs int, now time.Time, jobNames []string) ([]*fleet.Job, error) {
 	query := `
 SELECT
     id, created_at, updated_at, name, args, state, retries, error, not_before
@@ -45,17 +50,32 @@ FROM
 WHERE
     state = ? AND
     not_before <= ?
+	%s
 ORDER BY
     updated_at ASC
 LIMIT ?
 `
+
+	args := []interface{}{fleet.JobStateQueued, now, maxNumJobs}
+
+	var nameClause string
+	// Add job name filter if needed
+	if len(jobNames) > 0 {
+		clause, nameArgs, err := sqlx.In("AND name IN (?)", jobNames)
+		if err != nil {
+			return nil, err
+		}
+		nameClause = clause
+		args = append(args, nameArgs...)
+	}
+	query = fmt.Sprintf(query, nameClause)
 
 	if now.IsZero() {
 		now = time.Now().UTC()
 	}
 
 	var jobs []*fleet.Job
-	err := sqlx.SelectContext(ctx, ds.reader(ctx), &jobs, query, fleet.JobStateQueued, now, maxNumJobs)
+	err := sqlx.SelectContext(ctx, ds.reader(ctx), &jobs, query, args...)
 	if err != nil {
 		return nil, err
 	}

--- a/server/fleet/datastore.go
+++ b/server/fleet/datastore.go
@@ -1066,6 +1066,10 @@ type Datastore interface {
 	// processed. If now is the zero time, the current time will be used.
 	GetQueuedJobs(ctx context.Context, maxNumJobs int, now time.Time) ([]*Job, error)
 
+	// GetFilteredQueuedJobs gets queued jobs from the jobs table (queue) ready to be
+	// processed, filtered by job names.
+	GetFilteredQueuedJobs(ctx context.Context, maxNumJobs int, now time.Time, jobNames []string) ([]*Job, error)
+
 	// UpdateJobs updates an existing job. Call this after processing a job.
 	UpdateJob(ctx context.Context, id uint, job *Job) (*Job, error)
 

--- a/server/mock/datastore_mock.go
+++ b/server/mock/datastore_mock.go
@@ -763,6 +763,8 @@ type NewJobFunc func(ctx context.Context, job *fleet.Job) (*fleet.Job, error)
 
 type GetQueuedJobsFunc func(ctx context.Context, maxNumJobs int, now time.Time) ([]*fleet.Job, error)
 
+type GetFilteredQueuedJobsFunc func(ctx context.Context, maxNumJobs int, now time.Time, jobNames []string) ([]*fleet.Job, error)
+
 type UpdateJobFunc func(ctx context.Context, id uint, job *fleet.Job) (*fleet.Job, error)
 
 type CleanupWorkerJobsFunc func(ctx context.Context, failedSince time.Duration, completedSince time.Duration) (int64, error)
@@ -2541,6 +2543,9 @@ type DataStore struct {
 
 	GetQueuedJobsFunc        GetQueuedJobsFunc
 	GetQueuedJobsFuncInvoked bool
+
+	GetFilteredQueuedJobsFunc        GetFilteredQueuedJobsFunc
+	GetFilteredQueuedJobsFuncInvoked bool
 
 	UpdateJobFunc        UpdateJobFunc
 	UpdateJobFuncInvoked bool
@@ -6135,6 +6140,13 @@ func (s *DataStore) GetQueuedJobs(ctx context.Context, maxNumJobs int, now time.
 	s.GetQueuedJobsFuncInvoked = true
 	s.mu.Unlock()
 	return s.GetQueuedJobsFunc(ctx, maxNumJobs, now)
+}
+
+func (s *DataStore) GetFilteredQueuedJobs(ctx context.Context, maxNumJobs int, now time.Time, jobNames []string) ([]*fleet.Job, error) {
+	s.mu.Lock()
+	s.GetFilteredQueuedJobsFuncInvoked = true
+	s.mu.Unlock()
+	return s.GetFilteredQueuedJobsFunc(ctx, maxNumJobs, now, jobNames)
 }
 
 func (s *DataStore) UpdateJob(ctx context.Context, id uint, job *fleet.Job) (*fleet.Job, error) {


### PR DESCRIPTION
for #31518 

# Details

This PR updates the jobs package with a new `GetFilteredQueuedJobs` method which accepts a list of job names to return from the `jobs` table, rather than returning all jobs matching the other criteria. It also updates the `worker` package to use this new method instead of `GetQueuedJobs`.

The purpose of this update is to allow us to add multiple workers which process different kinds of jobs, while sharing the same `jobs` table and framework.

I chose to add the new `GetFilteredQueuedJobs` method rather than updating `GetQueuedJobs` because the latter is used in a bunch of tests that would need to be updated.  `GetQueuedJobs` now calls `GetFilteredQueuedJobs` with an empty list, which is interpreted as "return all jobs".  

# Checklist for submitter

## Testing

- [X] Added/updated automated tests

- [ ] QA'd all new/changed functionality manually
There shouldn't be any functional change here, but if someone has a Jira or Zendesk integration set up to easily test with, that'd be good.

