### PR TITLE
Fleet-maintained app contribution: add step about app description in output file

### DIFF
--- a/ee/maintained-apps/README.md
+++ b/ee/maintained-apps/README.md
@@ -25,13 +25,15 @@
    go run cmd/maintained-apps/main.go --slug="<slug-name>" --debug
    ```
 
-6. Open a PR to the `fleet` repository with the above changes.  Connect it to the issue by adding `Fixes #ISSUE_NUMBER` in the description.
+6. Add a description for the app in `outputs/apps.json` file. You can use descriptions from [Homebrew formulae](https://formulae.brew.sh/).
 
-7. The [#g-software product group](https://fleetdm.com/handbook/company/product-groups#software-group) will:
+7. Open a PR to the `fleet` repository with the above changes.  Connect it to the issue by adding `Fixes #ISSUE_NUMBER` in the description.
+
+8. The [#g-software product group](https://fleetdm.com/handbook/company/product-groups#software-group) will:
    1. Review the PR and test the app.  Contributors should be aware of the validation requirements below.
    2. If validation requirements cannot be met in this PR, the PR will be closed and the associated issue will be prioritized in the g-software group backlog.
 
-8. If the app passes testing, it is approved and merged. The app should appear shortly in the Fleet-maintained apps section when adding new software to Fleet. The app icon will not appear in Fleet until the following release. App icon progress is tracked in the issue. An addition to Fleet-maintained apps is not considered "Done" until the icon is added in a Fleet release. This behavior will be [improved](https://github.com/fleetdm/fleet/issues/29177) in a future release.
+9. If the app passes testing, it is approved and merged. The app should appear shortly in the Fleet-maintained apps section when adding new software to Fleet. The app icon will not appear in Fleet until the following release. App icon progress is tracked in the issue. An addition to Fleet-maintained apps is not considered "Done" until the icon is added in a Fleet release. This behavior will be [improved](https://github.com/fleetdm/fleet/issues/29177) in a future release.
 
 ### Input file schema
 


### PR DESCRIPTION
I think we should document this, as this is required to display a description on the website. I think we want contributors to add this, and PD/EM can review.