### PR TITLE
fix windows configuration profile failing to verify if using CDATA escape

### DIFF
--- a/changes/29769-windows-profiles-with-cdata-escape-fails-to-verify
+++ b/changes/29769-windows-profiles-with-cdata-escape-fails-to-verify
@@ -1,0 +1,1 @@
+* Fixed an issue where windows configuration profiles fails to validate due to escaping data sequence with `<![CDATA[...]]>` and profile verifier not stripping this away.

--- a/server/fleet/microsoft_mdm.go
+++ b/server/fleet/microsoft_mdm.go
@@ -1418,6 +1418,7 @@ func (cmd *SyncMLCmd) GetTargetData() string {
 
 	if cmd.Items[0].Data != nil {
 		content := cmd.Items[0].Data.Content
+		content = strings.TrimSpace(content)
 		content = strings.TrimPrefix(content, "<![CDATA[")
 		content = strings.TrimSuffix(content, "]]>")
 

--- a/server/fleet/microsoft_mdm.go
+++ b/server/fleet/microsoft_mdm.go
@@ -1417,15 +1417,22 @@ func (cmd *SyncMLCmd) GetTargetData() string {
 	}
 
 	if cmd.Items[0].Data != nil {
-		content := cmd.Items[0].Data.Content
-		content = strings.TrimSpace(content)
-		content = strings.TrimPrefix(content, "<![CDATA[")
-		content = strings.TrimSuffix(content, "]]>")
-
-		return content
+		return cmd.Items[0].Data.Content
 	}
 
 	return ""
+}
+
+// GetNormalizedTargetDataForVerification returns the first protocol commands target data
+// and normalizes for verification processes
+func (cmd *SyncMLCmd) GetNormalizedTargetDataForVerification() string {
+	content := cmd.GetTargetData()
+
+	content = strings.TrimSpace(content)
+	content = strings.TrimPrefix(content, "<![CDATA[")
+	content = strings.TrimSuffix(content, "]]>")
+
+	return content
 }
 
 func (cmd *SyncMLCmd) ShouldBeTracked(cmdVerb string) bool {

--- a/server/fleet/microsoft_mdm.go
+++ b/server/fleet/microsoft_mdm.go
@@ -1417,7 +1417,11 @@ func (cmd *SyncMLCmd) GetTargetData() string {
 	}
 
 	if cmd.Items[0].Data != nil {
-		return cmd.Items[0].Data.Content
+		content := cmd.Items[0].Data.Content
+		content = strings.TrimPrefix(content, "<![CDATA[")
+		content = strings.TrimSuffix(content, "]]>")
+
+		return content
 	}
 
 	return ""

--- a/server/mdm/microsoft/profile_verifier.go
+++ b/server/mdm/microsoft/profile_verifier.go
@@ -50,13 +50,13 @@ func LoopOverExpectedHostProfiles(
 		}
 		for _, rc := range prof.ReplaceCommands {
 			locURI := rc.GetTargetURI()
-			data := rc.GetTargetData()
+			data := rc.GetNormalizedTargetDataForVerification()
 			ref := HashLocURI(expectedProf.Name, locURI)
 			fn(expectedProf, ref, locURI, data)
 		}
 		for _, ac := range prof.AddCommands {
 			locURI := ac.GetTargetURI()
-			data := ac.GetTargetData()
+			data := ac.GetNormalizedTargetDataForVerification()
 			ref := HashLocURI(expectedProf.Name, locURI)
 			fn(expectedProf, ref, locURI, data)
 		}

--- a/server/mdm/microsoft/profile_verifier_test.go
+++ b/server/mdm/microsoft/profile_verifier_test.go
@@ -294,8 +294,7 @@ func TestVerifyHostMDMProfilesHappyPaths(t *testing.T) {
 				{"N1", syncml.ForTestWithData([]syncml.TestCommand{{
 					Verb:   "Replace",
 					LocURI: "L1",
-					Data: `
-      <![CDATA[<enabled/><data id="ExecutionPolicy" value="AllSigned"/>
+					Data: `<![CDATA[<enabled/><data id="ExecutionPolicy" value="AllSigned"/>
       <data id="Listbox_ModuleNames" value="*"/>
       <data id="OutputDirectory" value="false"/>
       <data id="EnableScriptBlockInvocationLogging" value="true"/>
@@ -304,7 +303,11 @@ func TestVerifyHostMDMProfilesHappyPaths(t *testing.T) {
 			},
 			report: []osqueryReport{{
 				"N1", "200", "L1",
-				"&lt;Enabled/&gt;&lt;Data id=\"EnableScriptBlockInvocationLogging\" value=\"true\"/&gt;&lt;Data id=\"ExecutionPolicy\" value=\"AllSigned\"/&gt;&lt;Data id=\"Listbox_ModuleNames\" value=\"*\"/&gt;&lt;Data id=\"OutputDirectory\" value=\"false\"/&gt;&lt;Data id=\"SourcePathForUpdateHelp\" value=\"false\"/&gt;",
+				`<enabled/><data id="ExecutionPolicy" value="AllSigned"/>
+      <data id="Listbox_ModuleNames" value="*"/>
+      <data id="OutputDirectory" value="false"/>
+      <data id="EnableScriptBlockInvocationLogging" value="true"/>
+      <data id="SourcePathForUpdateHelp" value="false"/>`,
 			}},
 			toVerify: []string{"N1"},
 			toFail:   []string{},
@@ -318,13 +321,14 @@ func TestVerifyHostMDMProfilesHappyPaths(t *testing.T) {
 					Verb:   "Replace",
 					LocURI: "L1",
 					Data: `
-      <![CDATA[<enabled/><data id="ExecutionPolicy" value="AllSigned"/>
+<![CDATA[<enabled/><data id="ExecutionPolicy" value="AllSigned"/>
       <data id="SourcePathForUpdateHelp" value="false"/>]]>`,
 				}}), 0},
 			},
 			report: []osqueryReport{{
 				"N1", "200", "L1",
-				"&lt;Enabled/&gt;&lt;Data id=\"EnableScriptBlockInvocationLogging\" value=\"true\"/&gt;&lt;Data id=\"ExecutionPolicy\" value=\"AllSigned\"/&gt;&lt;Data id=\"Listbox_ModuleNames\" value=\"*\"/&gt;&lt;Data id=\"OutputDirectory\" value=\"false\"/&gt;&lt;Data id=\"SourcePathForUpdateHelp\" value=\"false\"/&gt;",
+				`<disabled/><data id="ExecutionPolicy" value="AllSigned"/>
+      <data id="SourcePathForUpdateHelp" value="false"/>`,
 			}},
 			toVerify: []string{},
 			toFail:   []string{},

--- a/server/mdm/microsoft/profile_verifier_test.go
+++ b/server/mdm/microsoft/profile_verifier_test.go
@@ -48,6 +48,10 @@ func TestLoopHostMDMLocURIs(t *testing.T) {
 				{Verb: "Replace", LocURI: "L3", Data: "D3"},
 				{Verb: "Add", LocURI: "L3.1", Data: "D3.1"},
 			})},
+			"N4": {Name: "N4", RawProfile: syncml.ForTestWithData([]syncml.TestCommand{
+				{Verb: "Replace", LocURI: "L4", Data: "<![CDATA[D4]]>"},
+				{Verb: "Add", LocURI: "L4.1", Data: "<![CDATA[D4.1]]>"},
+			})},
 		}, nil
 	}
 	ds.ExpandEmbeddedSecretsFunc = func(ctx context.Context, document string) (string, error) {
@@ -77,6 +81,8 @@ func TestLoopHostMDMLocURIs(t *testing.T) {
 			{"L2", "D2", "N2", "2736786183"},
 			{"L3", "D3", "N3", "894211447"},
 			{"L3.1", "D3.1", "N3", "3410477854"},
+			{"L4", "D4", "N4", "4141459399"},
+			{"L4.1", "D4.1", "N4", "236794510"},
 		},
 		got,
 	)


### PR DESCRIPTION
fixes #29769 

See comment for more context: https://github.com/fleetdm/fleet/issues/29769#issuecomment-3150798557

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually