### PR TITLE
Add reference docs: escaping Fleet variables (`$`)

### DIFF
--- a/articles/secrets-in-scripts-and-configuration-profiles.md
+++ b/articles/secrets-in-scripts-and-configuration-profiles.md
@@ -77,10 +77,6 @@ On subsequent GitOps syncs, if a secret variable used by a configuration profile
 
 > Profiles with secret variables are not entirely validated during a GitOps dry run because secret variables may not be present/correct in the database during the dry run. Hence, there is an increased chance of GitOps non-dry run failure when using a profile with a secret variable. Try uploading this profile to a test team first.
 
-## Escaping and interpolation
-
-The dollar sign (`$`) can be escaped so it's not considered a variable by using a backslash (e.g. `\$100`). Additionally, `MY${variable}HERE` syntax can be used to put strings around the variable.
-
 ## Known limitations and issues
 
 - After changing a secret used by a Windows profile, that profile is currently not re-sent to the device when the GitHub action (or GitLab pipeline) runs: [story #27351](https://github.com/fleetdm/fleet/issues/27351)

--- a/docs/Configuration/yaml-files.md
+++ b/docs/Configuration/yaml-files.md
@@ -382,6 +382,8 @@ In Fleet Premium, you can use reserved variables beginning with `$FLEET_VAR_` (c
 - `$FLEET_VAR_DIGICERT_PASSWORD_<CA_NAME>` (`<CA_NAME>` should be replaced with name of the certificate authority configured in [digicert](#digicert).)
 - `$FLEET_VAR_DIGICERT_DATA_<CA_NAME>`
 
+The dollar sign (`$`) can be escaped so it's not considered a variable by using a backslash (e.g. `\$100`). Additionally, `MY${variable}HERE` syntax can be used to put strings around the variable.
+
 ### macos_setup
 
 The `macos_setup` section lets you control the out-of-the-box macOS [setup experience](https://fleetdm.com/guides/macos-setup-experience) for hosts that use Automated Device Enrollment (ADE).
@@ -722,8 +724,6 @@ At the team level, there is the additional option to enable conditional access, 
 integrations:
   conditional_access_enabled: true
 ```
-
-For secrets, you can add [GitHub environment variables](https://docs.github.com/en/actions/learn-github-actions/variables#defining-environment-variables-for-a-single-workflow)
 
 #### google_calendar
 


### PR DESCRIPTION
Move instructions for escaping to the GitOps (YAML) reference docs instead of the guide (harder to find).

Part of the following bug here:
- #30006
