### PR TITLE
Fixed an issue where SSO URLs with trailing slashes (#31548)

### DIFF
--- a/changes/31545-fix-sso-trailing-slash
+++ b/changes/31545-fix-sso-trailing-slash
@@ -1,0 +1,1 @@
+- Fixed an issue where SSO URLs with trailing slashes would cause authentication failures due to double slashes in the ACS URL. Both regular SSO and MDM SSO URLs now properly handle trailing slashes.

--- a/ee/server/service/mdm.go
+++ b/ee/server/service/mdm.go
@@ -708,7 +708,13 @@ func (svc *Service) InitiateMDMAppleSSO(ctx context.Context) (sessionID string, 
 	}
 
 	serverURL := appConfig.MDMUrl()
-	acsURL := serverURL + svc.config.Server.URLPrefix + "/api/v1/fleet/mdm/sso/callback"
+	// Parse the URL and use JoinPath to avoid double slashes
+	parsedURL, err := url.Parse(serverURL)
+	if err != nil {
+		return "", 0, "", ctxerr.Wrap(ctx, err, "invalid MDM URL")
+	}
+	parsedURL = parsedURL.JoinPath(svc.config.Server.URLPrefix, "/api/v1/fleet/mdm/sso/callback")
+	acsURL := parsedURL.String()
 
 	samlProvider, err := sso.SAMLProviderFromConfiguredMetadata(ctx,
 		mdmSSOSettings.EntityID,

--- a/server/mdm/apple/apple_mdm.go
+++ b/server/mdm/apple/apple_mdm.go
@@ -167,7 +167,11 @@ func (d *DEPService) buildJSONProfile(ctx context.Context, setupAsstJSON json.Ra
 			endUserAuthEnabled = team.Config.MDM.MacOSSetup.EnableEndUserAuthentication
 		}
 		if endUserAuthEnabled {
-			jsonProf.ConfigurationWebURL = appCfg.MDMUrl() + "/mdm/sso"
+			mdmSSOURL, err := commonmdm.ResolveURL(appCfg.MDMUrl(), "/mdm/sso", false)
+			if err != nil {
+				return nil, fmt.Errorf("resolve MDM SSO URL: %w", err)
+			}
+			jsonProf.ConfigurationWebURL = mdmSSOURL
 		}
 	}
 

--- a/server/service/sessions_test.go
+++ b/server/service/sessions_test.go
@@ -17,6 +17,23 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// testSSOMetadata returns a valid SAML metadata XML for testing
+func testSSOMetadata() string {
+	return `<?xml version="1.0"?>
+<md:EntityDescriptor xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata" entityID="test-idp">
+  <md:IDPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
+    <md:KeyDescriptor use="signing">
+      <ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+        <ds:X509Data>
+          <ds:X509Certificate>MIIDXTCCAkWgAwIBAgIJALmVVuDWu4NYMA0GCSqGSIb3DQEBCwUAMEUxCzAJBgNVBAYTAkFVMRMwEQYDVQQIDApTb21lLVN0YXRlMSEwHwYDVQQKDBhJbnRlcm5ldCBXaWRnaXRzIFB0eSBMdGQwHhcNMTYxMjMxMTQzNDQ3WhcNNDgwNjI1MTQzNDQ3WjBFMQswCQYDVQQGEwJBVTETMBEGA1UECAwKU29tZS1TdGF0ZTEhMB8GA1UECgwYSW50ZXJuZXQgV2lkZ2l0cyBQdHkgTHRkMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAzUCFozgNb1h1M0jzNRSCjhOBnR+uVbVpaWfXYIR+AhWDdEe5ryY+CgavOg8bfLybyzFdehlYdDRgkedEB/GjG8aJw06l0qF4jDOAw0kEygWCu2mcH7XOxRt+YAH3TVHa/Hu1W3WjzkobqqqLQ8gkKWWM27fOgAZ6GieaJBN6VBSMMcPey3HWLBmc+TYJmv1dbaO2jHhKh8pfKw0W12VM8P1PIO8gv4Phu/uuJYieBWKixBEyy0lHjyixYFCR12xdh4CA47q958ZRGnnDUGFVE1QhgRacJCOZ9bd5t9mr8KLaVBYTCJo5ERE8jymab5dPqe5qKfJsCZiqWglbjUo9twIDAQABo1AwTjAdBgNVHQ4EFgQUxpuwcs/CYQOyui+r1G+3KxBNhxkwHwYDVR0jBBgwFoAUxpuwcs/CYQOyui+r1G+3KxBNhxkwDAYDVR0TBAUwAwEB/zANBgkqhkiG9w0BAQsFAAOCAQEAAiWUKs/2x/viNCKi3Y6blEuCtAGhzOOZ9EjrvJ8+COH3Rag3tVBWrcBZ3/uhhPq5gy9lqw4OkvEws99/5jFsX1FJ6MKBgqfuy7yh5s1YfM0ANHYczMmYpZeAcQf2CGAaVfwTTfSlzNLsF2lW/ly7yapFzlYSJLGoVE+OHEu8g5SlNACUEfkXw+5Eghh+KzlIN7R6Q7r2ixWNFBC/jWf7NKUfJyX8qIG5md1YUeT6GBW9Bm2/1/RiO24JTaYlfLdKK9TYb8sG5B+OLab2DImG99CJ25RkAcSobWNF5zD0O6lgOo3cEdB/ksCq3hmtlC/DlLZ/D8CJ+7VuZnS1rR2naQ==</ds:X509Certificate>
+        </ds:X509Data>
+      </ds:KeyInfo>
+    </md:KeyDescriptor>
+    <md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://idp.example.com/sso"/>
+  </md:IDPSSODescriptor>
+</md:EntityDescriptor>`
+}
+
 func TestSessionAuth(t *testing.T) {
 	ds := new(mock.Store)
 	svc, ctx := newTestService(t, ds, nil, nil)
@@ -440,7 +457,7 @@ func TestGetSSOUser(t *testing.T) {
 
 func TestInitiateSSOWithSSOServerURL(t *testing.T) {
 	ds := new(mock.Store)
-	pool := redistest.SetupRedis(t, t.Name(), false, false, false)
+	pool := redistest.NopRedis()
 
 	svc, ctx := newTestServiceWithConfig(t, ds, config.TestConfig(), nil, nil, &TestServerOpts{
 		Pool: pool,
@@ -457,19 +474,7 @@ func TestInitiateSSOWithSSOServerURL(t *testing.T) {
 			SSOProviderSettings: fleet.SSOProviderSettings{
 				EntityID: "fleet",
 				IDPName:  "TestIDP",
-				Metadata: `<?xml version="1.0"?>
-<md:EntityDescriptor xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata" entityID="test-idp">
-  <md:IDPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
-    <md:KeyDescriptor use="signing">
-      <ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
-        <ds:X509Data>
-          <ds:X509Certificate>MIIDXTCCAkWgAwIBAgIJALmVVuDWu4NYMA0GCSqGSIb3DQEBCwUAMEUxCzAJBgNVBAYTAkFVMRMwEQYDVQQIDApTb21lLVN0YXRlMSEwHwYDVQQKDBhJbnRlcm5ldCBXaWRnaXRzIFB0eSBMdGQwHhcNMTYxMjMxMTQzNDQ3WhcNNDgwNjI1MTQzNDQ3WjBFMQswCQYDVQQGEwJBVTETMBEGA1UECAwKU29tZS1TdGF0ZTEhMB8GA1UECgwYSW50ZXJuZXQgV2lkZ2l0cyBQdHkgTHRkMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAzUCFozgNb1h1M0jzNRSCjhOBnR+uVbVpaWfXYIR+AhWDdEe5ryY+CgavOg8bfLybyzFdehlYdDRgkedEB/GjG8aJw06l0qF4jDOAw0kEygWCu2mcH7XOxRt+YAH3TVHa/Hu1W3WjzkobqqqLQ8gkKWWM27fOgAZ6GieaJBN6VBSMMcPey3HWLBmc+TYJmv1dbaO2jHhKh8pfKw0W12VM8P1PIO8gv4Phu/uuJYieBWKixBEyy0lHjyixYFCR12xdh4CA47q958ZRGnnDUGFVE1QhgRacJCOZ9bd5t9mr8KLaVBYTCJo5ERE8jymab5dPqe5qKfJsCZiqWglbjUo9twIDAQABo1AwTjAdBgNVHQ4EFgQUxpuwcs/CYQOyui+r1G+3KxBNhxkwHwYDVR0jBBgwFoAUxpuwcs/CYQOyui+r1G+3KxBNhxkwDAYDVR0TBAUwAwEB/zANBgkqhkiG9w0BAQsFAAOCAQEAAiWUKs/2x/viNCKi3Y6blEuCtAGhzOOZ9EjrvJ8+COH3Rag3tVBWrcBZ3/uhhPq5gy9lqw4OkvEws99/5jFsX1FJ6MKBgqfuy7yh5s1YfM0ANHYczMmYpZeAcQf2CGAaVfwTTfSlzNLsF2lW/ly7yapFzlYSJLGoVE+OHEu8g5SlNACUEfkXw+5Eghh+KzlIN7R6Q7r2ixWNFBC/jWf7NKUfJyX8qIG5md1YUeT6GBW9Bm2/1/RiO24JTaYlfLdKK9TYb8sG5B+OLab2DImG99CJ25RkAcSobWNF5zD0O6lgOo3cEdB/ksCq3hmtlC/DlLZ/D8CJ+7VuZnS1rR2naQ==</ds:X509Certificate>
-        </ds:X509Data>
-      </ds:KeyInfo>
-    </md:KeyDescriptor>
-    <md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://idp.example.com/sso"/>
-  </md:IDPSSODescriptor>
-</md:EntityDescriptor>`,
+				Metadata: testSSOMetadata(),
 			},
 		},
 	}
@@ -487,4 +492,102 @@ func TestInitiateSSOWithSSOServerURL(t *testing.T) {
 	// The ACS URL should use the SSO server URL
 	// We can't directly test the ACS URL in the SAML request here since it's embedded in the XML,
 	// but the integration test verifies this works correctly
+}
+
+func TestInitiateSSOWithTrailingSlash(t *testing.T) {
+	ds := new(mock.Store)
+	pool := redistest.NopRedis()
+
+	svc, ctx := newTestServiceWithConfig(t, ds, config.TestConfig(), nil, nil, &TestServerOpts{
+		Pool: pool,
+	})
+
+	testCases := []struct {
+		name         string
+		serverURL    string
+		ssoServerURL string
+	}{
+		{
+			name:         "server URL with trailing slash",
+			serverURL:    "https://fleet.example.com/",
+			ssoServerURL: "",
+		},
+		{
+			name:         "SSO server URL with trailing slash",
+			serverURL:    "https://fleet.example.com",
+			ssoServerURL: "https://admin.fleet.example.com/",
+		},
+		{
+			name:         "both URLs with trailing slash",
+			serverURL:    "https://fleet.example.com/",
+			ssoServerURL: "https://admin.fleet.example.com/",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Mock app config
+			appConfig := &fleet.AppConfig{
+				ServerSettings: fleet.ServerSettings{
+					ServerURL: tc.serverURL,
+				},
+				SSOSettings: &fleet.SSOSettings{
+					EnableSSO:    true,
+					SSOServerURL: tc.ssoServerURL,
+					SSOProviderSettings: fleet.SSOProviderSettings{
+						EntityID: "fleet",
+						IDPName:  "TestIDP",
+						Metadata: testSSOMetadata(),
+					},
+				},
+			}
+
+			ds.AppConfigFunc = func(_ context.Context) (*fleet.AppConfig, error) {
+				return appConfig, nil
+			}
+
+			// Test that InitiateSSO works
+			sessionID, _, idpURL, err := svc.InitiateSSO(ctx, "/dashboard")
+			require.NoError(t, err)
+			require.NotEmpty(t, sessionID)
+			require.NotEmpty(t, idpURL)
+		})
+	}
+}
+
+func TestInitiateSSOWithInvalidURL(t *testing.T) {
+	ds := new(mock.Store)
+	pool := redistest.NopRedis()
+
+	svc, ctx := newTestServiceWithConfig(t, ds, config.TestConfig(), nil, nil, &TestServerOpts{
+		Pool: pool,
+	})
+
+	// Mock app config with invalid URL
+	appConfig := &fleet.AppConfig{
+		ServerSettings: fleet.ServerSettings{
+			ServerURL: "not-a-valid-url://%%%",
+		},
+		SSOSettings: &fleet.SSOSettings{
+			EnableSSO: true,
+			SSOProviderSettings: fleet.SSOProviderSettings{
+				EntityID: "fleet",
+				IDPName:  "TestIDP",
+				Metadata: testSSOMetadata(),
+			},
+		},
+	}
+
+	ds.AppConfigFunc = func(_ context.Context) (*fleet.AppConfig, error) {
+		return appConfig, nil
+	}
+
+	// Test that invalid URL returns bad request error
+	_, _, _, err := svc.InitiateSSO(ctx, "/dashboard")
+	require.Error(t, err)
+
+	// Verify it's a bad request error
+	var badReqErr *fleet.BadRequestError
+	require.ErrorAs(t, err, &badReqErr)
+	require.Contains(t, badReqErr.Message, "invalid SSO URL")
 }


### PR DESCRIPTION
(cherry picked from commit 030e292f30bf13a2516768b7d904eb9012d07075)

Fixes #31545

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
See [Changes
files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
* Resolved issues with Single Sign-On (SSO) and Mobile Device Management (MDM) SSO authentication failures caused by trailing slashes in URLs, ensuring proper URL formatting and preventing authentication errors.

* **Tests**
* Added tests to verify correct handling of trailing slashes in SSO URLs and to ensure errors are properly returned for invalid SSO URL configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->



