### PR TITLE
Enabling .well-known resource to test #27390

### DIFF
--- a/website/config/routes.js
+++ b/website/config/routes.js
@@ -1057,5 +1057,5 @@ module.exports.routes = {
   // https://developer.apple.com/documentation/devicemanagement/implementing-the-simple-authentication-user-enrollment-flow#Send-the-well-known-request
   //
   // TODO(BMAA): Uncomment this when we are ready to dogfood the Apple account-driven enrollment flow.
-  // 'GET /.well-known/com.apple.remotemanagement': (req, res)=>{ return res.json({'Servers':[{'Version':'mdm-byod', 'BaseURL':'https://dogfood.fleetdm.com/api/mdm/apple/account_driven_enroll'}]});},
+  'GET /.well-known/com.apple.remotemanagement': (req, res)=>{ return res.json({'Servers':[{'Version':'mdm-byod', 'BaseURL':'https://andrey.ngrok.app/api/mdm/apple/account_driven_enroll'}]});},
 };


### PR DESCRIPTION
**Test in question:** 
- [ ] Make sure that if the user hosts service discovery JSON (.well-known resource) on their own, on domain used for work email and JSON is proper format, that BYOD enrollment still works. https://github.com/fleetdm/fleet/issues/27390

More info in this thread: https://fleetdm.slack.com/archives/C03C41L5YEL/p1753819470745979

Will disable it back once I'm done testing 