### PR TITLE
Increase timeouts for mdm profiles batch -> 4.72.0

### DIFF
--- a/changes/31591-mdm-batch-timeouts
+++ b/changes/31591-mdm-batch-timeouts
@@ -1,0 +1,1 @@
+Increased timeouts on /fleet/mdm/profiles/batch to better support customer workflows with large numbers of profiles

--- a/cmd/fleet/serve.go
+++ b/cmd/fleet/serve.go
@@ -1327,6 +1327,30 @@ the way that the Fleet server works.
 					}
 				}
 
+				if req.Method == http.MethodPost && strings.HasSuffix(req.URL.Path, "/fleet/mdm/profiles/batch") {
+					// For customers using large profiles and/or large numbers of profiles, the
+					// server needs time to completely read the request body and also to process
+					// all the side effects of a potentially large number of profiles being changed
+					// across a large number of hosts, so set the timeouts a bit higher than default
+					rc := http.NewResponseController(rw)
+					if err := rc.SetWriteDeadline(time.Now().Add(5 * time.Minute)); err != nil {
+						level.Error(logger).Log(
+							"msg", "http middleware failed to override endpoint write timeout for MDM profiles batch endpoint",
+							"response_writer_type", fmt.Sprintf("%T", rw),
+							"response_writer", fmt.Sprintf("%+v", rw),
+							"err", err,
+						)
+					}
+					if err := rc.SetReadDeadline(time.Now().Add(5 * time.Minute)); err != nil {
+						level.Error(logger).Log(
+							"msg", "http middleware failed to override endpoint read timeout for MDM profiles batch endpoint",
+							"response_writer_type", fmt.Sprintf("%T", rw),
+							"response_writer", fmt.Sprintf("%+v", rw),
+							"err", err,
+						)
+					}
+				}
+
 				apiHandler.ServeHTTP(rw, req)
 			})
 			// The `/api/{version}/fleet/scim` base path is used by SCIM handler. In order to route the `details` route to the apiHandler,


### PR DESCRIPTION
Fixes #31591 by increasing the timeout to better support `customer-numa` github workflow

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [x] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes

- [x] QA'd all new/changed functionality manually