### PR TITLE
Do not log error if missing EULA

### DIFF
--- a/changes/29833-do-not-log-error-for-missing-eula
+++ b/changes/29833-do-not-log-error-for-missing-eula
@@ -1,0 +1,1 @@
+* Do not log an error if EULA is missing for the `/setup_experience/eula/metadata` endpoint

--- a/server/service/integration_logger_test.go
+++ b/server/service/integration_logger_test.go
@@ -324,6 +324,7 @@ func (s *integrationLoggerTestSuite) TestSetupExperienceEULAMetadataDoesNotLogEr
 	appConf.MDM.WindowsEnabledAndConfigured = true
 	appConf.MDM.AppleBMEnabledAndConfigured = true
 	err = s.ds.SaveAppConfig(context.Background(), appConf)
+	require.NoError(t, err)
 
 	s.token = getTestAdminToken(t, s.server)
 	s.Do("GET", "/api/v1/fleet/setup_experience/eula/metadata", nil, http.StatusNotFound)
@@ -340,4 +341,5 @@ func (s *integrationLoggerTestSuite) TestSetupExperienceEULAMetadataDoesNotLogEr
 
 	// restore app config
 	err = s.ds.SaveAppConfig(context.Background(), &originalAppConf)
+	require.NoError(t, err)
 }

--- a/server/service/mdm.go
+++ b/server/service/mdm.go
@@ -368,8 +368,12 @@ func (r getMDMEULAMetadataResponse) Error() error { return r.Err }
 
 func getMDMEULAMetadataEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (fleet.Errorer, error) {
 	eula, err := svc.MDMGetEULAMetadata(ctx)
-	if err != nil {
+	if err != nil && !fleet.IsNotFound(err) {
 		return getMDMEULAMetadataResponse{Err: err}, nil
+	}
+
+	if eula == nil {
+		return nil, newNotFoundError()
 	}
 
 	return getMDMEULAMetadataResponse{MDMEULA: eula}, nil

--- a/server/service/mdm.go
+++ b/server/service/mdm.go
@@ -373,6 +373,7 @@ func getMDMEULAMetadataEndpoint(ctx context.Context, request interface{}, svc fl
 	}
 
 	if eula == nil {
+		// We return the error here not as part of the response object, to signal an error to the server, but avoid logging it as an error.
 		return nil, newNotFoundError()
 	}
 


### PR DESCRIPTION
fixes #29833 

Checks if the error is a not found error and then return a notFoundError that does not get logged as an error but as an info log instead.

`level=info ts=2025-08-05T10:46:06.237581Z component=http path=/api/latest/fleet/setup_experience/eula/metadata took=1.939958ms uuid=0ab0c579-07c5-48be-b6bd-5e4ebd81212d err="not found"`


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually
