### PR TITLE
Fleet UI: Tarballz allow uninstall bug fix

### DIFF
--- a/frontend/pages/hosts/details/cards/HostSoftwareLibrary/HostInstallerActionCell/HostInstallerActionCell.tests.tsx
+++ b/frontend/pages/hosts/details/cards/HostSoftwareLibrary/HostInstallerActionCell/HostInstallerActionCell.tests.tsx
@@ -578,4 +578,102 @@ describe("HostInstallerActionCell component", () => {
     expect(screen.getByTestId("trash-icon")).toBeInTheDocument();
     expect(uninstallBtn.closest("button")).toBeDisabled();
   });
+  it("renders Reinstall and Uninstall buttons for tgz package with no installed_versions", () => {
+    render(
+      <HostInstallerActionCell
+        software={{
+          ...defaultSoftware,
+          source: "tgz_packages",
+          ui_status: "installed", // could also use "pending_uninstall" or "failed_uninstall"
+          status: "installed",
+          software_package: mockSoftwarePackage,
+          installed_versions: [], // crucial: no versions, triggers the tgzPackageDetectedAsInstalled case
+          app_store_app: null,
+        }}
+        onClickInstallAction={noop}
+        onClickUninstallAction={noop}
+        baseClass={baseClass}
+        hostScriptsEnabled
+        hostMDMEnrolled
+      />
+    );
+
+    const installBtn = screen.getByTestId(`${baseClass}__install-button--test`);
+    expect(installBtn).toHaveTextContent("Reinstall");
+    expect(screen.getByTestId("refresh-icon")).toBeInTheDocument();
+    expect(installBtn.closest("button")).toBeEnabled();
+
+    const uninstallBtn = screen.getByTestId(
+      `${baseClass}__uninstall-button--test`
+    );
+    expect(uninstallBtn).toHaveTextContent("Uninstall");
+    expect(screen.getByTestId("trash-icon")).toBeInTheDocument();
+    expect(uninstallBtn.closest("button")).toBeEnabled();
+  });
+  it("renders disabled Reinstall and disabled Uninstall buttons for tgz package with no installed_versions when uninstall pending", () => {
+    render(
+      <HostInstallerActionCell
+        software={{
+          ...defaultSoftware,
+          source: "tgz_packages",
+          ui_status: "pending_uninstall",
+          status: "pending_uninstall",
+          software_package: mockSoftwarePackage,
+          installed_versions: [], // crucial: no versions, triggers the tgzPackageDetectedAsInstalled case
+          app_store_app: null,
+        }}
+        onClickInstallAction={noop}
+        onClickUninstallAction={noop}
+        baseClass={baseClass}
+        hostScriptsEnabled
+        hostMDMEnrolled
+      />
+    );
+
+    const installBtn = screen.getByTestId(`${baseClass}__install-button--test`);
+    expect(installBtn).toHaveTextContent("Reinstall");
+    expect(screen.getByTestId("refresh-icon")).toBeInTheDocument();
+    expect(installBtn.closest("button")).toBeDisabled();
+
+    const uninstallBtn = screen.getByTestId(
+      `${baseClass}__uninstall-button--test`
+    );
+    expect(uninstallBtn).toHaveTextContent("Uninstall");
+    expect(screen.getByTestId("trash-icon")).toBeInTheDocument();
+    expect(uninstallBtn.closest("button")).toBeDisabled();
+  });
+  it("renders Reinstall and Retry uninstall buttons for tgz package with no installed_versions when uninstall failed", () => {
+    render(
+      <HostInstallerActionCell
+        software={{
+          ...defaultSoftware,
+          source: "tgz_packages",
+          ui_status: "failed_uninstall",
+          status: "failed_uninstall",
+          software_package: mockSoftwarePackage,
+          installed_versions: [], // crucial: no versions, triggers the tgzPackageDetectedAsInstalled case
+          app_store_app: null,
+        }}
+        onClickInstallAction={noop}
+        onClickUninstallAction={noop}
+        baseClass={baseClass}
+        hostScriptsEnabled
+        hostMDMEnrolled
+      />
+    );
+
+    const installBtn = screen.getByTestId(`${baseClass}__install-button--test`);
+    expect(installBtn).toHaveTextContent("Reinstall");
+    expect(installBtn.closest("button")).toBeEnabled();
+
+    const uninstallBtn = screen.getByTestId(
+      `${baseClass}__uninstall-button--test`
+    );
+    expect(uninstallBtn).toHaveTextContent("Retry uninstall");
+    expect(uninstallBtn.closest("button")).toBeEnabled();
+
+    // Both reinstall and retry uninstall have the same icon
+    const refreshIcons = screen.getAllByTestId("refresh-icon");
+    expect(refreshIcons).toHaveLength(2);
+  });
 });

--- a/frontend/pages/hosts/details/cards/HostSoftwareLibrary/HostInstallerActionCell/HostInstallerActionCell.tests.tsx
+++ b/frontend/pages/hosts/details/cards/HostSoftwareLibrary/HostInstallerActionCell/HostInstallerActionCell.tests.tsx
@@ -584,10 +584,10 @@ describe("HostInstallerActionCell component", () => {
         software={{
           ...defaultSoftware,
           source: "tgz_packages",
-          ui_status: "installed", // could also use "pending_uninstall" or "failed_uninstall"
+          ui_status: "installed",
           status: "installed",
           software_package: mockSoftwarePackage,
-          installed_versions: [], // crucial: no versions, triggers the tgzPackageDetectedAsInstalled case
+          installed_versions: [], // no versions ever show for tgz packages
           app_store_app: null,
         }}
         onClickInstallAction={noop}
@@ -619,7 +619,7 @@ describe("HostInstallerActionCell component", () => {
           ui_status: "pending_uninstall",
           status: "pending_uninstall",
           software_package: mockSoftwarePackage,
-          installed_versions: [], // crucial: no versions, triggers the tgzPackageDetectedAsInstalled case
+          installed_versions: [], // no versions ever show for tgz packages
           app_store_app: null,
         }}
         onClickInstallAction={noop}
@@ -651,7 +651,7 @@ describe("HostInstallerActionCell component", () => {
           ui_status: "failed_uninstall",
           status: "failed_uninstall",
           software_package: mockSoftwarePackage,
-          installed_versions: [], // crucial: no versions, triggers the tgzPackageDetectedAsInstalled case
+          installed_versions: [], // no versions ever show for tgz packages
           app_store_app: null,
         }}
         onClickInstallAction={noop}

--- a/frontend/pages/hosts/details/cards/HostSoftwareLibrary/HostInstallerActionCell/HostInstallerActionCell.tsx
+++ b/frontend/pages/hosts/details/cards/HostSoftwareLibrary/HostInstallerActionCell/HostInstallerActionCell.tsx
@@ -208,6 +208,7 @@ export const HostInstallerActionCell = ({
     software.source === "tgz_packages" &&
     (ui_status === "installed" ||
       ui_status === "pending_uninstall" ||
+      ui_status === "uninstalling" ||
       ui_status === "failed_uninstall");
 
   const canUninstallSoftware =

--- a/frontend/pages/hosts/details/cards/HostSoftwareLibrary/HostInstallerActionCell/HostInstallerActionCell.tsx
+++ b/frontend/pages/hosts/details/cards/HostSoftwareLibrary/HostInstallerActionCell/HostInstallerActionCell.tsx
@@ -201,11 +201,19 @@ export const HostInstallerActionCell = ({
     }
   }, [status, ui_status]);
 
+  const installedVersionsDetected =
+    installed_versions && installed_versions.length > 0;
+
+  const installedTgzPackageDetected =
+    software.source === "tgz_packages" &&
+    (ui_status === "installed" ||
+      ui_status === "pending_uninstall" ||
+      ui_status === "failed_uninstall");
+
   const canUninstallSoftware =
     !app_store_app &&
     !!software_package &&
-    installed_versions &&
-    installed_versions.length > 0;
+    (installedVersionsDetected || installedTgzPackageDetected);
 
   return (
     <div className={`${baseClass}__item-actions`}>


### PR DESCRIPTION
## Issue
Closes #31578 

## Description
- Tarballs cannot use `installed_versions` array as source of truth whether software can be uninstalled
- Use ui_status of "installed", "uninstalling", "pending_uninstall", and "failed_uninstall" as source of truth to show Uninstall button (disabled or enabled based on pending state)

# Checklist for submitter

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually
Note: I don't have an actual Linux machine to test this
