### PR TITLE
Added ability to determine if TPM PIN is set

### DIFF
--- a/changes/31180-add-ability-to-determine-pin-compliance
+++ b/changes/31180-add-ability-to-determine-pin-compliance
@@ -1,0 +1,1 @@
+* Added new detail query, only executed if TPM PIN enforcement is required, for determining whether a BitLocker PIN is set.

--- a/server/datastore/mysql/hosts.go
+++ b/server/datastore/mysql/hosts.go
@@ -4187,6 +4187,16 @@ func (ds *Datastore) SetOrUpdateHostDisksEncryption(ctx context.Context, hostID 
 	)
 }
 
+// SetOrUpdateHostDiskTpmPIN sets the host's flag indicating if the disk has a TPM PIN protector set
+func (ds *Datastore) SetOrUpdateHostDiskTpmPIN(ctx context.Context, hostID uint, pinSet bool) error {
+	return ds.updateOrInsert(
+		ctx,
+		`UPDATE host_disks SET tpm_pin_set = ?, updated_at = CURRENT_TIMESTAMP(6) WHERE host_id = ?`,
+		`INSERT INTO host_disks (tpm_pin_set, host_id) VALUES (?, ?)`,
+		pinSet, hostID,
+	)
+}
+
 func (ds *Datastore) SetOrUpdateHostOrbitInfo(
 	ctx context.Context, hostID uint, version string, desktopVersion sql.NullString, scriptsEnabled sql.NullBool,
 ) error {

--- a/server/datastore/mysql/hosts.go
+++ b/server/datastore/mysql/hosts.go
@@ -4191,7 +4191,7 @@ func (ds *Datastore) SetOrUpdateHostDisksEncryption(ctx context.Context, hostID 
 func (ds *Datastore) SetOrUpdateHostDiskTpmPIN(ctx context.Context, hostID uint, pinSet bool) error {
 	return ds.updateOrInsert(
 		ctx,
-		`UPDATE host_disks SET tpm_pin_set = ?, updated_at = CURRENT_TIMESTAMP(6) WHERE host_id = ?`,
+		`UPDATE host_disks SET tpm_pin_set = ? WHERE host_id = ?`,
 		`INSERT INTO host_disks (tpm_pin_set, host_id) VALUES (?, ?)`,
 		pinSet, hostID,
 	)

--- a/server/fleet/datastore.go
+++ b/server/fleet/datastore.go
@@ -969,6 +969,7 @@ type Datastore interface {
 	SetOrUpdateHostDisksSpace(ctx context.Context, hostID uint, gigsAvailable, percentAvailable, gigsTotal float64) error
 
 	GetConfigEnableDiskEncryption(ctx context.Context, teamID *uint) (DiskEncryptionConfig, error)
+	SetOrUpdateHostDiskTpmPIN(ctx context.Context, hostID uint, pinSet bool) error
 	SetOrUpdateHostDisksEncryption(ctx context.Context, hostID uint, encrypted bool) error
 	// SetOrUpdateHostDiskEncryptionKey sets the base64, encrypted key for
 	// a host

--- a/server/mdm/microsoft/bitlocker_csp.go
+++ b/server/mdm/microsoft/bitlocker_csp.go
@@ -13,7 +13,7 @@ const (
 	PolicyOptDropdownOptional
 )
 
-var systemDrRequiresStartupAuthTmpl = template.Must(template.New("cmd").Funcs(map[string]any{
+var systemDriveRequiresStartupAuthTmpl = template.Must(template.New("cmd").Funcs(map[string]any{
 	"derefBool": func(val *bool) bool {
 		return val != nil && *val
 	}, "derefUint": func(val *uint) uint {
@@ -54,9 +54,9 @@ var systemDrRequiresStartupAuthTmpl = template.Must(template.New("cmd").Funcs(ma
 </Atomic>`,
 ))
 
-// SystemDrRequiresStartupAuthSpec specification for the SystemDrivesRequireStartupAuthentication command.
+// SystemDriveRequiresStartupAuthSpec specification for the SystemDrivesRequireStartupAuthentication command.
 // uint values must be one of the PolicyOptDropdown* variants
-type SystemDrRequiresStartupAuthSpec struct {
+type SystemDriveRequiresStartupAuthSpec struct {
 	CmdUUID string
 	// Enabled specifies whether the 'Require additional authentication at startup'
 	// policy setting should be enabled or not.
@@ -73,7 +73,7 @@ type SystemDrRequiresStartupAuthSpec struct {
 	ConfigureTPM *uint
 }
 
-func (spec SystemDrRequiresStartupAuthSpec) validate() error {
+func (spec SystemDriveRequiresStartupAuthSpec) validate() error {
 	if spec.CmdUUID == "" {
 		return errors.New("cmdUUID is required")
 	}
@@ -109,16 +109,16 @@ func (spec SystemDrRequiresStartupAuthSpec) validate() error {
 	return nil
 }
 
-// SystemDrRequiresStartupAuthCmd turns a SystemDrRequiresStartupAuthSpec into a
+// SystemDriveRequiresStartupAuthCmd turns a SystemDrRequiresStartupAuthSpec into a
 // https://learn.microsoft.com/en-us/windows/client-management/mdm/bitlocker-csp#systemdrivesrequirestartupauthentication
 // CMD.
-func SystemDrRequiresStartupAuthCmd(spec SystemDrRequiresStartupAuthSpec) (*fleet.MDMWindowsCommand, error) {
+func SystemDriveRequiresStartupAuthCmd(spec SystemDriveRequiresStartupAuthSpec) (*fleet.MDMWindowsCommand, error) {
 	if err := spec.validate(); err != nil {
 		return nil, err
 	}
 
 	var contents bytes.Buffer
-	if err := systemDrRequiresStartupAuthTmpl.Execute(&contents, spec); err != nil {
+	if err := systemDriveRequiresStartupAuthTmpl.Execute(&contents, spec); err != nil {
 		return nil, errors.New("failed to execute SystemDrRequiresStartupAuthCmd template")
 	}
 

--- a/server/mdm/microsoft/bitlocker_csp_test.go
+++ b/server/mdm/microsoft/bitlocker_csp_test.go
@@ -7,20 +7,20 @@ import (
 	"testing"
 )
 
-func TestSystemDrRequiresStartupAuthSpec_validate(t *testing.T) {
+func TestSystemDriveRequiresStartupAuthSpec_validate(t *testing.T) {
 	tests := []struct {
 		name    string
-		spec    SystemDrRequiresStartupAuthSpec
+		spec    SystemDriveRequiresStartupAuthSpec
 		wantErr string
 	}{
 		{
 			name:    "empty cmdUUID",
-			spec:    SystemDrRequiresStartupAuthSpec{},
+			spec:    SystemDriveRequiresStartupAuthSpec{},
 			wantErr: "cmdUUID is required",
 		},
 		{
 			name: "fields set but not enabled",
-			spec: SystemDrRequiresStartupAuthSpec{
+			spec: SystemDriveRequiresStartupAuthSpec{
 				CmdUUID:                "test-uuid",
 				Enabled:                false,
 				ConfigureTPMStartupKey: ptr.Uint(PolicyOptDropdownRequired),
@@ -29,14 +29,14 @@ func TestSystemDrRequiresStartupAuthSpec_validate(t *testing.T) {
 		},
 		{
 			name: "valid configuration with no fields",
-			spec: SystemDrRequiresStartupAuthSpec{
+			spec: SystemDriveRequiresStartupAuthSpec{
 				CmdUUID: "test-uuid",
 				Enabled: false,
 			},
 		},
 		{
 			name: "valid configuration with enabled fields",
-			spec: SystemDrRequiresStartupAuthSpec{
+			spec: SystemDriveRequiresStartupAuthSpec{
 				CmdUUID:                "test-uuid",
 				Enabled:                true,
 				ConfigureTPMStartupKey: ptr.Uint(PolicyOptDropdownRequired),
@@ -45,7 +45,7 @@ func TestSystemDrRequiresStartupAuthSpec_validate(t *testing.T) {
 		},
 		{
 			name: "invalid TPMStartupKey value",
-			spec: SystemDrRequiresStartupAuthSpec{
+			spec: SystemDriveRequiresStartupAuthSpec{
 				CmdUUID:                "test-uuid",
 				Enabled:                true,
 				ConfigureTPMStartupKey: ptr.Uint(99),
@@ -54,7 +54,7 @@ func TestSystemDrRequiresStartupAuthSpec_validate(t *testing.T) {
 		},
 		{
 			name: "invalid PIN value",
-			spec: SystemDrRequiresStartupAuthSpec{
+			spec: SystemDriveRequiresStartupAuthSpec{
 				CmdUUID:      "test-uuid",
 				Enabled:      true,
 				ConfigurePIN: ptr.Uint(99),
@@ -63,7 +63,7 @@ func TestSystemDrRequiresStartupAuthSpec_validate(t *testing.T) {
 		},
 		{
 			name: "invalid TPMPINKey value",
-			spec: SystemDrRequiresStartupAuthSpec{
+			spec: SystemDriveRequiresStartupAuthSpec{
 				CmdUUID:            "test-uuid",
 				Enabled:            true,
 				ConfigureTPMPINKey: ptr.Uint(99), // Invalid value
@@ -72,7 +72,7 @@ func TestSystemDrRequiresStartupAuthSpec_validate(t *testing.T) {
 		},
 		{
 			name: "invalid TPM value",
-			spec: SystemDrRequiresStartupAuthSpec{
+			spec: SystemDriveRequiresStartupAuthSpec{
 				CmdUUID:      "test-uuid",
 				Enabled:      true,
 				ConfigureTPM: ptr.Uint(99),
@@ -81,7 +81,7 @@ func TestSystemDrRequiresStartupAuthSpec_validate(t *testing.T) {
 		},
 		{
 			name: "all fields set with valid values",
-			spec: SystemDrRequiresStartupAuthSpec{
+			spec: SystemDriveRequiresStartupAuthSpec{
 				CmdUUID:                   "test-uuid",
 				Enabled:                   true,
 				ConfigureNonTPMStartupKey: ptr.Bool(true),
@@ -108,12 +108,12 @@ func TestSystemDrRequiresStartupAuthSpec_validate(t *testing.T) {
 func TestSystemDrRequiresStartupAuthCmd_Template(t *testing.T) {
 	tests := []struct {
 		name     string
-		spec     SystemDrRequiresStartupAuthSpec
+		spec     SystemDriveRequiresStartupAuthSpec
 		expected string
 	}{
 		{
 			name: "disabled",
-			spec: SystemDrRequiresStartupAuthSpec{
+			spec: SystemDriveRequiresStartupAuthSpec{
 				CmdUUID: "uuid-123",
 				Enabled: false,
 			},
@@ -139,7 +139,7 @@ func TestSystemDrRequiresStartupAuthCmd_Template(t *testing.T) {
 		},
 		{
 			name: "enabled",
-			spec: SystemDrRequiresStartupAuthSpec{
+			spec: SystemDriveRequiresStartupAuthSpec{
 				CmdUUID:                   "uuid-789",
 				Enabled:                   true,
 				ConfigureNonTPMStartupKey: ptr.Bool(true),
@@ -179,7 +179,7 @@ func TestSystemDrRequiresStartupAuthCmd_Template(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			cmd, err := SystemDrRequiresStartupAuthCmd(tt.spec)
+			cmd, err := SystemDriveRequiresStartupAuthCmd(tt.spec)
 			require.NoError(t, err)
 
 			got := strings.Join(strings.Fields(string(cmd.RawCommand)), " ")

--- a/server/mock/datastore_mock.go
+++ b/server/mock/datastore_mock.go
@@ -699,6 +699,8 @@ type SetOrUpdateHostDisksSpaceFunc func(ctx context.Context, hostID uint, gigsAv
 
 type GetConfigEnableDiskEncryptionFunc func(ctx context.Context, teamID *uint) (fleet.DiskEncryptionConfig, error)
 
+type SetOrUpdateHostDiskTpmPINFunc func(ctx context.Context, hostID uint, pinSet bool) error
+
 type SetOrUpdateHostDisksEncryptionFunc func(ctx context.Context, hostID uint, encrypted bool) error
 
 type SetOrUpdateHostDiskEncryptionKeyFunc func(ctx context.Context, host *fleet.Host, encryptedBase64Key string, clientError string, decryptable *bool) error
@@ -2445,6 +2447,9 @@ type DataStore struct {
 
 	GetConfigEnableDiskEncryptionFunc        GetConfigEnableDiskEncryptionFunc
 	GetConfigEnableDiskEncryptionFuncInvoked bool
+
+	SetOrUpdateHostDiskTpmPINFunc        SetOrUpdateHostDiskTpmPINFunc
+	SetOrUpdateHostDiskTpmPINFuncInvoked bool
 
 	SetOrUpdateHostDisksEncryptionFunc        SetOrUpdateHostDisksEncryptionFunc
 	SetOrUpdateHostDisksEncryptionFuncInvoked bool
@@ -5911,6 +5916,13 @@ func (s *DataStore) GetConfigEnableDiskEncryption(ctx context.Context, teamID *u
 	s.GetConfigEnableDiskEncryptionFuncInvoked = true
 	s.mu.Unlock()
 	return s.GetConfigEnableDiskEncryptionFunc(ctx, teamID)
+}
+
+func (s *DataStore) SetOrUpdateHostDiskTpmPIN(ctx context.Context, hostID uint, pinSet bool) error {
+	s.mu.Lock()
+	s.SetOrUpdateHostDiskTpmPINFuncInvoked = true
+	s.mu.Unlock()
+	return s.SetOrUpdateHostDiskTpmPINFunc(ctx, hostID, pinSet)
 }
 
 func (s *DataStore) SetOrUpdateHostDisksEncryption(ctx context.Context, hostID uint, encrypted bool) error {

--- a/server/service/osquery_utils/queries.go
+++ b/server/service/osquery_utils/queries.go
@@ -2426,76 +2426,120 @@ var luksVerifyQueryIngester = func(decrypter func(string) (string, error)) func(
 	}
 }
 
-// tpmPINConfigVerifyQuery checks the Windows registry to verify whether the host has the proper
-// BitLocker policy for allowing the setup of a TPM PIN protector, if not properly set, the proper
-// configuration is enforced via an MDM command.
-var tpmPINConfigVerifyQuery = DetailQuery{
-	Platforms: []string{"windows"},
-	// We only want to run this query iff:
-	// - BitLocker is not an optional component (is built in) OR is an optional component and enabled.
-	// - And a TPM PIN is not yet set.
-	// - And the volume is encrypted (to avoid errors while trying to apply the policy).
-	Discovery: `
-WITH should_run(ready) AS (
-SELECT
-	(
-	    -- BitLocker is optional but enabled
-		EXISTS(SELECT 1 FROM windows_optional_features WHERE name = 'BitLocker' AND state = 1)
-	    -- BitLocker is built in, so it won't appear as an optional feature
-		OR NOT EXISTS(SELECT 1 FROM windows_optional_features WHERE name = 'BitLocker') 
-	)
-	-- PIN is already set, so regardless of the current config, we don't need to enforce it:
-	-- 4: TPM And PIN.
-	-- 6: TPM And PIN And Startup key.
-	AND NOT EXISTS(SELECT 1 FROM bitlocker_key_protectors WHERE drive_letter = 'C:' AND key_protector_type IN (4,6))
-	-- Volume is encrypted
-	AND EXISTS(SELECT 1 FROM bitlocker_info WHERE drive_letter = 'C:' AND protection_status = 1)
-)
-SELECT 1 FROM should_run WHERE ready = 1`,
-	Query: "SELECT data FROM registry WHERE path='HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\FVE\\UseTPMPIN'",
-	DirectIngestFunc: func(
-		ctx context.Context,
-		logger log.Logger,
-		host *fleet.Host,
-		ds fleet.Datastore,
-		rows []map[string]string,
-	) error {
-		if host == nil || host.UUID == "" {
-			level.Debug(logger).Log(
-				"method", "tpmPINConfigVerifyQuery",
-				"msg", "Ingestion not run, host is nil or UUID is empty",
+var tpmPINQueries = map[string]DetailQuery{
+	// The tpm_pin_config_verify query checks the Windows registry to verify whether the host has the proper
+	// BitLocker policy for allowing the setup of a TPM PIN protector, if not properly set, the proper
+	// configuration is enforced via an MDM command.
+	"tpm_pin_config_verify": {
+		Platforms: []string{"windows"},
+		// We only want to run this query iff:
+		// - BitLocker is not an optional component (is built in) OR is an optional component and enabled.
+		// - And a TPM PIN is not yet set.
+		// - And the volume is encrypted (to avoid errors while trying to apply the policy).
+		Discovery: `
+			WITH should_run(yes) AS (
+			SELECT
+				(
+					-- BitLocker is an optional feature but enabled
+					EXISTS(SELECT 1 FROM windows_optional_features WHERE name = 'BitLocker' AND state = 1)
+					-- BitLocker is built in, so it won't appear as an optional feature
+					OR NOT EXISTS(SELECT 1 FROM windows_optional_features WHERE name = 'BitLocker') 
+				)
+				-- PIN is already set, so regardless of the current config, we don't need to enforce it:
+				-- 4: TPM And PIN.
+				-- 6: TPM And PIN And Startup key.
+				AND NOT EXISTS(SELECT 1 FROM bitlocker_key_protectors WHERE drive_letter = 'C:' AND key_protector_type IN (4,6))
+				-- Volume is encrypted
+				AND EXISTS(SELECT 1 FROM bitlocker_info WHERE drive_letter = 'C:' AND protection_status = 1)
 			)
-			return nil
-		}
-
-		if len(rows) > 1 {
-			return ctxerr.Errorf(
-				ctx,
-				"tpmPINConfigVerifyQuery invalid number of rows: %d", len(rows),
-			)
-		}
-
-		// If no results are returned, then the policy setting is in a 'Not Configured' state.
-		// If the policy is 'Enabled', we need to make sure the proper setting is not in a 'Disallowed' state.
-		if len(rows) == 0 || rows[0]["data"] == fmt.Sprintf("%d", microsoft_mdm.PolicyOptDropdownDisallowed) {
-			level.Info(logger).Log(
-				"method", "tpmPINConfigVerifyQuery",
-				"msg", "Updating TPM PIN protector configuration via MDM",
-				"host_id", host.ID,
-			)
-			cmd, err := microsoft_mdm.SystemDrRequiresStartupAuthCmd(
-				microsoft_mdm.SystemDrRequiresStartupAuthSpec{
-					CmdUUID:      uuid.NewString(),
-					Enabled:      true,
-					ConfigurePIN: ptr.Uint(microsoft_mdm.PolicyOptDropdownOptional),
-				},
-			)
-			if err != nil {
-				return err
+			SELECT 1 FROM should_run WHERE yes = 1`,
+		Query: "SELECT data FROM registry WHERE path='HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\FVE\\UseTPMPIN'",
+		DirectIngestFunc: func(
+			ctx context.Context,
+			logger log.Logger,
+			host *fleet.Host,
+			ds fleet.Datastore,
+			rows []map[string]string,
+		) error {
+			if host == nil || host.UUID == "" {
+				level.Debug(logger).Log(
+					"query", "tpm_pin_config_verify",
+					"msg", "Ingestion not run, host is nil or UUID is empty",
+				)
+				return nil
 			}
-			return ds.MDMWindowsInsertCommandForHosts(ctx, []string{host.UUID}, cmd)
-		}
-		return nil
+
+			if len(rows) > 1 {
+				return ctxerr.Errorf(
+					ctx,
+					"tpm_pin_config_verify query: invalid number of rows: %d", len(rows),
+				)
+			}
+
+			// If no results are returned, then the policy setting is in a 'Not Configured' state.
+			// If the policy is 'Enabled', we need to make sure the proper setting is not in a 'Disallowed' state.
+			if len(rows) == 0 || rows[0]["data"] == fmt.Sprintf("%d", microsoft_mdm.PolicyOptDropdownDisallowed) {
+				level.Info(logger).Log(
+					"query", "tpm_pin_config_verify",
+					"msg", "Updating TPM PIN protector configuration via MDM",
+					"host_id", host.ID,
+				)
+				cmd, err := microsoft_mdm.SystemDriveRequiresStartupAuthCmd(
+					microsoft_mdm.SystemDriveRequiresStartupAuthSpec{
+						CmdUUID:      uuid.NewString(),
+						Enabled:      true,
+						ConfigurePIN: ptr.Uint(microsoft_mdm.PolicyOptDropdownOptional),
+					},
+				)
+				if err != nil {
+					return err
+				}
+				return ds.MDMWindowsInsertCommandForHosts(ctx, []string{host.UUID}, cmd)
+			}
+			return nil
+		},
+	},
+	"tpm_pin_set_verify": {
+		Platforms: []string{"windows"},
+		// We only want to run this query iff:
+		// - BitLocker is not an optional component (is built in) OR is an optional component and enabled.
+		Discovery: `
+			WITH should_run(yes) AS (
+			SELECT
+				(
+					-- BitLocker is an optional feature but enabled
+					EXISTS(SELECT 1 FROM windows_optional_features WHERE name = 'BitLocker' AND state = 1)
+					-- BitLocker is built in, so it won't appear as an optional feature
+					OR NOT EXISTS(SELECT 1 FROM windows_optional_features WHERE name = 'BitLocker') 
+				)
+			)
+			SELECT 1 FROM should_run WHERE yes = 1`,
+		Query: `
+			SELECT EXISTS(
+				SELECT 1 
+				FROM bitlocker_key_protectors 
+				-- 4: TPM And PIN.
+				-- 6: TPM And PIN And Startup key.
+				WHERE drive_letter = 'C:' AND key_protector_type IN (4,6)
+				LIMIT 1
+			) AS criteria
+			WHERE criteria = 1`,
+		DirectIngestFunc: func(
+			ctx context.Context,
+			logger log.Logger,
+			host *fleet.Host,
+			ds fleet.Datastore,
+			rows []map[string]string,
+		) error {
+			if host == nil || host.UUID == "" {
+				level.Debug(logger).Log(
+					"query", "tpm_pin_set_verify",
+					"msg", "Ingestion not run, host is nil or UUID is empty",
+				)
+				return nil
+			}
+			return ds.SetOrUpdateHostDiskTpmPIN(ctx, host.ID, len(rows) > 0)
+		},
 	},
 }
 
@@ -2558,7 +2602,10 @@ func GetDetailQueries(
 		if appConfig.MDM.WindowsEnabledAndConfigured &&
 			appConfig.MDM.EnableDiskEncryption.Value &&
 			appConfig.MDM.RequireBitLockerPIN.Value {
-			generatedMap["tpm_pin_config_verify"] = tpmPINConfigVerifyQuery
+
+			for key, query := range tpmPINQueries {
+				generatedMap[key] = query
+			}
 		}
 	}
 

--- a/server/service/osquery_utils/queries_test.go
+++ b/server/service/osquery_utils/queries_test.go
@@ -10,9 +10,12 @@ import (
 	"encoding/xml"
 	"errors"
 	"fmt"
+	"github.com/fleetdm/fleet/v4/pkg/optjson"
+	microsoft_mdm "github.com/fleetdm/fleet/v4/server/mdm/microsoft"
 	"regexp"
 	"slices"
 	"sort"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -366,6 +369,57 @@ func TestGetDetailQueries(t *testing.T) {
 	wantQueries = append(wantQueries, mdmQueriesWindows...)
 	require.Len(t, gotQueries, len(wantQueries))
 	sortedKeysCompare(t, gotQueries, wantQueries)
+
+	// Check that TPM PIN verify queries are only added iff RequireBitLockerPIN is set
+
+	testCases := []struct {
+		name string
+		ac   fleet.AppConfig
+		want []string
+	}{
+		{
+			name: "windows MDM not enabled",
+			ac:   fleet.AppConfig{},
+		},
+		{
+			name: "windows MDM is enabled but disk encryption is not enabled",
+			ac: fleet.AppConfig{
+				MDM: fleet.MDM{
+					WindowsEnabledAndConfigured: true,
+				},
+			},
+		},
+		{
+			name: "windows MDM is enabled with disk encryption but TPM PIN is not enforced",
+			ac: fleet.AppConfig{
+				MDM: fleet.MDM{
+					WindowsEnabledAndConfigured: true,
+					EnableDiskEncryption:        optjson.SetBool(true),
+				},
+			},
+		},
+		{
+			name: "windows MDM is enabled with disk encryption and TPM PIN is enforced",
+			ac: fleet.AppConfig{
+				MDM: fleet.MDM{
+					WindowsEnabledAndConfigured: true,
+					EnableDiskEncryption:        optjson.SetBool(true),
+					RequireBitLockerPIN:         optjson.SetBool(true),
+				},
+			},
+			want: maps.Keys(tpmPINQueries),
+		},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			got := GetDetailQueries(context.Background(), config.FleetConfig{}, &tt.ac, nil, Integrations{})
+			for _, name := range tt.want {
+				_, ok := got[name]
+				require.True(t, ok)
+			}
+		})
+	}
 }
 
 func TestDetailQueriesOSVersionUnixLike(t *testing.T) {
@@ -2534,5 +2588,178 @@ func TestWindowsLastOpenedAt(t *testing.T) {
 		if software["name"] == "Mozilla Firefox (x64 en-US)" {
 			assert.Equal(t, "1751755087", software["last_opened_at"])
 		}
+	}
+}
+
+func TestTPMPinSetVerifyIngest(t *testing.T) {
+	tests := []struct {
+		name   string
+		host   *fleet.Host
+		rows   []map[string]string
+		pinSet *bool
+	}{
+		{
+			name: "nil host",
+			host: nil,
+			rows: []map[string]string{
+				{"host": "something", "criteria": "1"}},
+		},
+		{
+			name: "empty uuid",
+			host: &fleet.Host{
+				ID: 1,
+			},
+			rows: []map[string]string{{"host": "something", "criteria": "1"}},
+		},
+		{
+			name: "no rows - pin not set",
+			host: &fleet.Host{
+				ID:   1,
+				UUID: "test-uuid",
+			},
+			rows:   []map[string]string{},
+			pinSet: ptr.Bool(false),
+		},
+		{
+			name: "with rows - pin set",
+			host: &fleet.Host{
+				ID:   1,
+				UUID: "test-uuid",
+			},
+			rows: []map[string]string{
+				{"host": "Mordor", "criteria": "1"},
+			},
+			pinSet: ptr.Bool(true),
+		},
+		{
+			name: "multiple rows - pin set",
+			host: &fleet.Host{
+				ID:   1,
+				UUID: "test-uuid",
+			},
+			rows: []map[string]string{
+				{"host": "Mordor", "criteria": "1"},
+				{"host": "Mordor", "criteria": "1"},
+			},
+			pinSet: ptr.Bool(true),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ds := new(mock.Store)
+
+			var setPinCalled bool
+			ds.SetOrUpdateHostDiskTpmPINFunc = func(ctx context.Context, hostID uint, pinSet bool) error {
+				setPinCalled = true
+				require.Equal(t, *tt.pinSet, pinSet)
+				require.Equal(t, tt.host.ID, hostID)
+				return nil
+			}
+
+			ingestFunc := tpmPINQueries["tpm_pin_set_verify"].DirectIngestFunc
+
+			require.NoError(t, ingestFunc(context.Background(), log.NewNopLogger(), tt.host, ds, tt.rows))
+			require.Equal(t, setPinCalled, tt.pinSet != nil)
+		})
+	}
+}
+
+func TestTPMPinConfigVerifyDirectIngest(t *testing.T) {
+	logger := log.NewNopLogger()
+	ctx := context.Background()
+
+	tests := []struct {
+		name      string
+		host      *fleet.Host
+		rows      []map[string]string
+		wantCmd   bool
+		wantError bool
+	}{
+		{
+			name: "nil host",
+			host: nil,
+		},
+		{
+			name: "empty UUID host",
+			host: &fleet.Host{UUID: ""},
+		},
+		{
+			name: "too many rows",
+			host: &fleet.Host{
+				UUID: "test-uuid",
+				ID:   1,
+			},
+			rows: []map[string]string{
+				{"data": strconv.Itoa(microsoft_mdm.PolicyOptDropdownOptional)},
+				{"data": strconv.Itoa(microsoft_mdm.PolicyOptDropdownOptional)},
+			},
+			wantError: true,
+		},
+		{
+			name: "no rows - requires command",
+			host: &fleet.Host{
+				UUID: "test-uuid",
+				ID:   1,
+			},
+			rows:    []map[string]string{},
+			wantCmd: true,
+		},
+		{
+			name: "disallowed state - requires command",
+			host: &fleet.Host{
+				UUID: "test-uuid",
+				ID:   1,
+			},
+			rows: []map[string]string{
+				{"data": strconv.Itoa(microsoft_mdm.PolicyOptDropdownDisallowed)},
+			},
+			wantCmd: true,
+		},
+		{
+			name: "policy set to optinal",
+			host: &fleet.Host{
+				UUID: "test-uuid",
+				ID:   1,
+			},
+			rows: []map[string]string{
+				{"data": strconv.Itoa(microsoft_mdm.PolicyOptDropdownOptional)},
+			},
+		},
+		{
+			name: "policy set to required",
+			host: &fleet.Host{
+				UUID: "test-uuid",
+				ID:   1,
+			},
+			rows: []map[string]string{
+				{"data": strconv.Itoa(microsoft_mdm.PolicyOptDropdownRequired)},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ds := new(mock.Store)
+
+			cmdInserted := false
+			if tt.wantCmd {
+				ds.MDMWindowsInsertCommandForHostsFunc = func(
+					ctx context.Context,
+					hostUUIDs []string,
+					cmd *fleet.MDMWindowsCommand,
+				) error {
+					cmdInserted = true
+					require.Equal(t, []string{tt.host.UUID}, hostUUIDs)
+					require.NotNil(t, cmd)
+					return nil
+				}
+			}
+
+			ingestFunc := tpmPINQueries["tpm_pin_config_verify"].DirectIngestFunc
+			err := ingestFunc(ctx, logger, tt.host, ds, tt.rows)
+			require.Equal(t, tt.wantError, err != nil)
+			require.Equal(t, cmdInserted, tt.wantCmd)
+		})
 	}
 }


### PR DESCRIPTION
For #31180.

Added new detail query, only executed if TPM PIN enforcement is required, for determining whether a BitLocker PIN is set. The result of the new detail query is used for setting the tpm_pin_set column on the host_disks table.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [X] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)

## Testing

- [X] Added/updated automated tests
- [X] QA'd all new/changed functionality manually