### PR TITLE
Fleet UI: Better responsive breakpoints, truncate software name cell

### DIFF
--- a/frontend/components/TableContainer/DataTable/SoftwareNameCell/SoftwareNameCell.tsx
+++ b/frontend/components/TableContainer/DataTable/SoftwareNameCell/SoftwareNameCell.tsx
@@ -8,6 +8,7 @@ import Icon from "components/Icon";
 import { IconNames } from "components/icons";
 import SoftwareIcon from "pages/SoftwarePage/components/icons/SoftwareIcon";
 import LinkCell from "../LinkCell";
+import TooltipTruncatedTextCell from "../TooltipTruncatedTextCell";
 
 const baseClass = "software-name-cell";
 
@@ -167,8 +168,11 @@ const SoftwareNameCell = ({
   if (!router || !path) {
     return (
       <div className={baseClass}>
-        <SoftwareIcon name={name} source={source} url={iconUrl} />
-        <span className="software-name">{name}</span>
+        <TooltipTruncatedTextCell
+          prefix={<SoftwareIcon name={name} source={source} url={iconUrl} />}
+          value={name}
+          className="software-name"
+        />
       </div>
     );
   }

--- a/frontend/pages/hosts/details/cards/Software/InstallStatusCell/_styles.scss
+++ b/frontend/pages/hosts/details/cards/Software/InstallStatusCell/_styles.scss
@@ -1,5 +1,5 @@
 .install-status-cell {
-  width: 140px; // Prevent status change from installer action from changing cell width while maintaining tooltip centering
+  width: 142px; // Prevent status change from installer action from changing cell width while maintaining tooltip centering
 
   &__tooltip-wrapper {
     .component__tooltip-wrapper__element {

--- a/frontend/pages/hosts/details/cards/Software/SelfService/SelfService.tests.tsx
+++ b/frontend/pages/hosts/details/cards/Software/SelfService/SelfService.tests.tsx
@@ -56,12 +56,12 @@ describe("SelfService", () => {
     render(<SelfService {...TEST_PROPS} />);
 
     // waiting for the device software data to render
-    await screen.findByText("test1");
+    await screen.findAllByText("test1");
 
-    expect(true).toBe(true);
-    expect(screen.getByText("test1")).toBeInTheDocument();
-    expect(screen.getByText("test2")).toBeInTheDocument();
-    expect(screen.getByText("test3")).toBeInTheDocument();
+    // Truncated tooltip causes multiple text rendering
+    expect(screen.getAllByText("test1")).toHaveLength(2);
+    expect(screen.getAllByText("test2")).toHaveLength(2);
+    expect(screen.getAllByText("test3")).toHaveLength(2);
   });
 
   it("should render the contact link text for self-service section if contact url is provided", () => {
@@ -93,7 +93,7 @@ describe("SelfService", () => {
     render(<SelfService {...TEST_PROPS} />);
 
     // waiting for the device software data to render
-    await screen.findByText("test-software");
+    await screen.findAllByText("test-software");
 
     expect(
       screen.getByTestId("install-status-cell__status--test")
@@ -121,7 +121,7 @@ describe("SelfService", () => {
     render(<SelfService {...TEST_PROPS} />);
 
     // waiting for the device software data to render
-    await screen.findByText("test-software");
+    await screen.findAllByText("test-software");
 
     expect(
       screen.getByTestId("install-status-cell__status--test")
@@ -147,7 +147,7 @@ describe("SelfService", () => {
     render(<SelfService {...TEST_PROPS} />);
 
     // waiting for the device software data to render
-    await screen.findByText("test-software");
+    await screen.findAllByText("test-software");
 
     expect(
       screen.getByTestId("install-status-cell__status--test")
@@ -176,7 +176,7 @@ describe("SelfService", () => {
     render(<SelfService {...TEST_PROPS} />);
 
     // waiting for the device software data to render
-    await screen.findByText("test-software");
+    await screen.findAllByText("test-software");
 
     expect(
       screen.getByTestId("install-status-cell__status--test")

--- a/frontend/pages/hosts/details/cards/Software/SelfService/SelfService.tsx
+++ b/frontend/pages/hosts/details/cards/Software/SelfService/SelfService.tsx
@@ -92,7 +92,7 @@ export interface ISoftwareSelfServiceProps {
 
 const getUpdatesPageSize = (width: number): number => {
   if (width >= 1400) return 4;
-  if (width >= 768) return 3;
+  if (width >= 880) return 3;
   return 2;
 };
 

--- a/frontend/pages/hosts/details/cards/Software/SelfService/_styles.scss
+++ b/frontend/pages/hosts/details/cards/Software/SelfService/_styles.scss
@@ -91,6 +91,34 @@
     }
   }
 
+  /* Ensures table doesn't bleed over 100% */
+  .data-table__table {
+    table-layout: fixed;
+    width: 100%;
+  }
+
+  /* Override any defaults for fixed column width */
+  .data-table__table th.ui_status__header,
+  .data-table__table td.ui_status__cell {
+    width: 140px;
+    max-width: 140px;
+    min-width: 140px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  /* Override any defaults for fixed column width */
+  .data-table__table th.status__header,
+  .data-table__table td.status__cell {
+    width: 230px;
+    max-width: 230px;
+    min-width: 230px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
   .data-table-block .data-table tbody {
     .self-service-table__item-action {
       min-width: 82px; // Second action buttons align between rows

--- a/frontend/pages/hosts/details/cards/Software/SelfService/_styles.scss
+++ b/frontend/pages/hosts/details/cards/Software/SelfService/_styles.scss
@@ -12,6 +12,7 @@
     display: flex;
     align-items: center;
     justify-content: space-between;
+    gap: $pad-medium;
 
     .button {
       margin-bottom: $pad-large;
@@ -29,18 +30,28 @@
 
   &__items {
     display: grid;
+
+    // Small screens (default)
     grid-template-columns: repeat(
       2,
-      1fr
-    ); // default: 2 cards (smallest screens)
+      minmax(250px, 1fr)
+    ); // 2 cards, max ensures long name truncation
     gap: $pad-large;
 
+    // Medium screens
     @media (min-width: $break-sm) {
-      grid-template-columns: repeat(3, 1fr); // 3 cards (medium screens)
+      grid-template-columns: repeat(
+        3,
+        minmax(220px, 1fr)
+      ); // 3 cards, max ensures long name truncation
     }
 
+    // Large screens
     @media (min-width: $break-lg) {
-      grid-template-columns: repeat(4, 1fr); // 4 cards (large screens)
+      grid-template-columns: repeat(
+        4,
+        minmax(250px, 1fr)
+      ); // 4 cards, max ensures long name truncation
     }
   }
 
@@ -95,7 +106,7 @@
   }
 
   // Custom breakpoint to fit table with categories
-  @media (min-width: 1050px) {
+  @media (min-width: 1070px) {
     .categories-menu {
       display: flex;
     }

--- a/frontend/pages/hosts/details/cards/Software/SelfService/_styles.scss
+++ b/frontend/pages/hosts/details/cards/Software/SelfService/_styles.scss
@@ -35,7 +35,7 @@
     ); // default: 2 cards (smallest screens)
     gap: $pad-large;
 
-    @media (min-width: $break-xs) {
+    @media (min-width: $break-sm) {
       grid-template-columns: repeat(3, 1fr); // 3 cards (medium screens)
     }
 
@@ -47,7 +47,6 @@
   &__table {
     display: flex;
     flex-direction: row;
-    gap: $pad-large;
 
     > *:nth-child(2) {
       flex-grow: 1;
@@ -95,7 +94,8 @@
     display: none;
   }
 
-  @media (min-width: $break-md) {
+  // Custom breakpoint to fit table with categories
+  @media (min-width: 1050px) {
     .categories-menu {
       display: flex;
     }


### PR DESCRIPTION
## Issue
Closes #31621

## Description
- Better responsive breakpoints to fit long software name
- Add software name truncation
- Remove extra gap between categories menu and table

## Screenshot of tweaks
Watch in 2x
https://fleetdm.zoom.us/clips/share/3Wx7tA_VTi6FVcNOkqzLzQ




## Testing

- [x] QA'd all new/changed functionality manually
