### PR TITLE
Fixed potential panic in error handler when Redis is down.

### DIFF
--- a/changes/30455-errorstore-panic
+++ b/changes/30455-errorstore-panic
@@ -1,0 +1,1 @@
+Fixed potential panic in error handler when Redis is down.

--- a/server/errorstore/errors.go
+++ b/server/errorstore/errors.go
@@ -208,6 +208,14 @@ func (h *Handler) storeError(ctx context.Context, err error) {
 		return
 	}
 
+	// Check if pool is nil to prevent panic
+	if h.pool == nil {
+		if h.testOnStore != nil {
+			h.testOnStore(fmt.Errorf("redis pool is nil"))
+		}
+		return
+	}
+
 	// not using a connection that follows redirections here
 	// in order to do pipeline commands
 	conn := h.pool.Get()

--- a/server/errorstore/errors.go
+++ b/server/errorstore/errors.go
@@ -12,6 +12,7 @@ import (
 	"crypto/sha256"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"strconv"
@@ -211,7 +212,7 @@ func (h *Handler) storeError(ctx context.Context, err error) {
 	// Check if pool is nil to prevent panic
 	if h.pool == nil {
 		if h.testOnStore != nil {
-			h.testOnStore(fmt.Errorf("redis pool is nil"))
+			h.testOnStore(errors.New("redis pool is nil"))
 		}
 		return
 	}


### PR DESCRIPTION
Fixes #30455 
Fixed flaky TestErrorHandler test.

Root Cause: The test was experiencing a nil pointer dereference panic in the storeError method. When the test creates a handler with a nil Redis pool (to test behavior when the error handler is down), there was a race condition between:

  1. The handleErrors goroutine checking the cancelled context and exiting
  2. The Store method successfully sending an error to the buffered channel

  Even though cancel() was called before Store(), the handleErrors goroutine might not have started executing yet (goroutines are only scheduled, not immediately running). When it eventually starts, Go's select statement with multiple ready channels (both ctx.Done() and h.errCh have messages) randomly chooses which one to process. If it chooses to process the error from h.errCh first, it calls storeError which attempts to call h.pool.Get() on a nil pool, causing a panic.

  The race is fundamentally between:
  - The test's expectation that a cancelled context will prevent error processing
  - The reality that a buffered channel can accept messages before any receiver is ready, and select's random choice when multiple cases are available

  This made the test intermittently fail based on goroutine scheduling timing and select's pseudo-random case selection.


# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.

## Testing

- [x] QA'd all new/changed functionality manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling to prevent application crashes when Redis is unavailable. The system now handles Redis outages gracefully without causing unexpected panics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->