### PR TITLE
Fix pending unlock not going away after canceling unlock script

### DIFF
--- a/changes/30857-pending-script-unlock-cancellation-not-respected
+++ b/changes/30857-pending-script-unlock-cancellation-not-respected
@@ -1,0 +1,1 @@
+* Fixed an issue where a host could be stuck with a "Unlock Pending" label even if the unlock script was canceled.

--- a/server/fleet/scripts.go
+++ b/server/fleet/scripts.go
@@ -504,8 +504,8 @@ func (s *HostLockWipeStatus) IsPendingLock() bool {
 		// pending lock if an MDM command is queued but no result received yet
 		return s.LockMDMCommand != nil && s.LockMDMCommandResult == nil
 	}
-	// pending lock if script execution request is queued but no result yet
-	return s.LockScript != nil && s.LockScript.ExitCode == nil
+	// pending lock if script execution request is queued but no result yet and not canceled
+	return s.LockScript != nil && s.LockScript.ExitCode == nil && !s.LockScript.Canceled
 }
 
 func (s HostLockWipeStatus) IsPendingUnlock() bool {
@@ -513,14 +513,14 @@ func (s HostLockWipeStatus) IsPendingUnlock() bool {
 		// Apple MDM does not have a concept of pending unlock.
 		return false
 	}
-	// pending unlock if script execution request is queued but no result yet
-	return s.UnlockScript != nil && s.UnlockScript.ExitCode == nil
+	// pending unlock if script execution request is queued but no result yet and not canceled
+	return s.UnlockScript != nil && s.UnlockScript.ExitCode == nil && !s.UnlockScript.Canceled
 }
 
 func (s HostLockWipeStatus) IsPendingWipe() bool {
 	if s.HostFleetPlatform == "linux" {
-		// pending wipe if script execution request is queued but no result yet
-		return s.WipeScript != nil && s.WipeScript.ExitCode == nil
+		// pending wipe if script execution request is queued but no result yet and not canceled
+		return s.WipeScript != nil && s.WipeScript.ExitCode == nil && !s.WipeScript.Canceled
 	}
 	// pending wipe if an MDM command is queued but no result received yet
 	return s.WipeMDMCommand != nil && s.WipeMDMCommandResult == nil


### PR DESCRIPTION
fixes: #30857 

This PR also adds the canceled check for Lock and Wipe scripts, even though they can not be canceled as it stands today.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually
