### PR TITLE
Merge #31387 into fleetd 1.46.0 branch

### DIFF
--- a/orbit/changes/31387-fleetdesktop-mdm-migrate
+++ b/orbit/changes/31387-fleetdesktop-mdm-migrate
@@ -1,0 +1,1 @@
+Fixed an issue where Fleet desktop would stop showing "Migrate to Fleet" for several minutes every hour after a device token refresh

--- a/orbit/cmd/desktop/desktop.go
+++ b/orbit/cmd/desktop/desktop.go
@@ -177,6 +177,9 @@ func main() {
 		migrateMDMItem.Disable()
 		// this item is only shown if certain conditions are met below.
 		migrateMDMItem.Hide()
+		// Track the current state of the MDM Migrate item so that on, e.g. token refreshes we can
+		// immediately begin showing the migrator again if we were showing it prior.
+		showMDMMigrator := false
 
 		myDeviceItem := systray.AddMenuItem("Connecting...", "")
 		myDeviceItem.Disable()
@@ -321,6 +324,11 @@ func main() {
 							selfServiceItem.Show()
 						}
 
+						if showMDMMigrator {
+							migrateMDMItem.Enable()
+							migrateMDMItem.Show()
+						}
+
 						return
 					}
 
@@ -452,6 +460,11 @@ func main() {
 						if migrationType != constant.MDMMigrationTypeADE {
 							migrateMDMItem.Enable()
 							migrateMDMItem.Show()
+							showMDMMigrator = true
+						} else {
+							migrateMDMItem.Disable()
+							migrateMDMItem.Hide()
+							showMDMMigrator = false
 						}
 
 						// if the device is unmanaged or we're in force mode and the device needs
@@ -471,10 +484,12 @@ func main() {
 						}
 						migrateMDMItem.Disable()
 						migrateMDMItem.Hide()
+						showMDMMigrator = false
 					}
 				} else {
 					migrateMDMItem.Disable()
 					migrateMDMItem.Hide()
+					showMDMMigrator = false
 				}
 			}
 		}()


### PR DESCRIPTION
Fixes #31387 in fleetd 1.46.0

This uses a boolean to track the state of the MDM migration button so that it stays visible when the host is in the migration state rather than disappearing and requiring some wait time every time the desktop token rotates.

We don't really have unit tests of any sort for fleet desktop so no tests have been added/updated here

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [x] QA'd all new/changed functionality manually

## fleetd/orbit/Fleet Desktop

- [x] Verified compatibility with the latest released version of Fleet (see [Must rule](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/workflows/fleetd-development-and-release-strategy.md))
- [x] If the change applies to only one platform, confirmed that `runtime.GOOS` is used as needed to isolate changes
- [x] Verified that fleetd runs on macOS, Linux and Windows
- [x] Verified auto-update works from the released version of component to the new version (see [tools/tuf/test](../tools/tuf/test/README.md))
