### PR TITLE
Fleet UI: Stop propogation of clickable parent on a custom link

### DIFF
--- a/frontend/components/CustomLink/CustomLink.tsx
+++ b/frontend/components/CustomLink/CustomLink.tsx
@@ -52,6 +52,12 @@ const CustomLink = ({
     [`${baseClass}--multiline`]: multiline,
   });
 
+  // Needed to not trigger clickable parent elements
+  // e.g. cell/row handlers with a tooltip that has a custom link inside
+  const handleClick = (e: React.MouseEvent) => {
+    e.stopPropagation();
+  };
+
   const target = newTab ? "_blank" : "";
 
   const multilineText = text.substring(0, text.lastIndexOf(" ") + 1);
@@ -91,6 +97,7 @@ const CustomLink = ({
       rel="noopener noreferrer"
       className={customLinkClass}
       tabIndex={disableKeyboardNavigation ? -1 : 0}
+      onClick={handleClick}
     >
       {content}
     </a>


### PR DESCRIPTION
## Issue
Closes #31630 

## Description
- Sleeper bug, CustomLink within a LinkCell will be overridden by the parent LinkCell's link
- Solution: Stop propagation for CustomLink on click

## Screen recording of fix


https://github.com/user-attachments/assets/c1794850-2e16-4748-9c68-78302f23543d


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] QA'd all new/changed functionality manually
