### PR TITLE
Fleet UI: Fix clientside url source of truth bug

### DIFF
--- a/frontend/pages/hosts/details/cards/Software/SelfService/SelfService.tsx
+++ b/frontend/pages/hosts/details/cards/Software/SelfService/SelfService.tsx
@@ -76,7 +76,7 @@ const DEFAULT_SELF_SERVICE_QUERY_PARAMS = {
   category_id: undefined,
 } as const;
 
-const DEFAULT_CLIENT_SIDE_PAGINATION = 10;
+const DEFAULT_CLIENT_SIDE_PAGINATION = 20;
 
 export interface ISoftwareSelfServiceProps {
   contactUrl: string;


### PR DESCRIPTION
## Issue
Closes #31632

## Description
- Keep page number in URL for source of truth and not change page number unless paginating

## Screenrecording of fix

https://github.com/user-attachments/assets/c21c7620-a882-4987-9226-a41fa8f4edf9



# Checklist for submitter

If some of the following don't apply, delete the relevant line.


## Testing


- [x] QA'd all new/changed functionality manually
