### PR TITLE
keep "migrate to fleet" around, but disabled, during token refresh

### DIFF
--- a/orbit/cmd/desktop/desktop.go
+++ b/orbit/cmd/desktop/desktop.go
@@ -402,6 +402,7 @@ func main() {
 					transparencyItem.Disable()
 					transparencyItem.Hide()
 					migrateMDMItem.Disable()
+					migrateMDMItem.Hide()
 					hostOfflineItemOne.Show()
 					hostOfflineItemTwo.Show()
 					log.Error().Err(err).Msg("get desktop summary")

--- a/orbit/cmd/desktop/desktop.go
+++ b/orbit/cmd/desktop/desktop.go
@@ -245,7 +245,11 @@ func main() {
 			selfServiceItem.Hide()
 
 			migrateMDMItem.Disable()
-			migrateMDMItem.Hide()
+			if showMDMMigrator {
+				migrateMDMItem.Show()
+			} else {
+				migrateMDMItem.Hide()
+			}
 
 			hostOfflineItemOne.Hide()
 			hostOfflineItemTwo.Hide()
@@ -397,6 +401,7 @@ func main() {
 					myDeviceItem.Hide()
 					transparencyItem.Disable()
 					transparencyItem.Hide()
+					migrateMDMItem.Disable()
 					hostOfflineItemOne.Show()
 					hostOfflineItemTwo.Show()
 					log.Error().Err(err).Msg("get desktop summary")


### PR DESCRIPTION
Followup PR to further address #31387 by closing the small gap that exists during the token refresh and disabling but otherwise keeping "migrate to fleet" in the tray app.


- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [x] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes

## Testing

- [x] QA'd all new/changed functionality manually

## fleetd/orbit/Fleet Desktop

- [x] Verified compatibility with the latest released version of Fleet (see [Must rule](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/workflows/fleetd-development-and-release-strategy.md))
- [x] If the change applies to only one platform, confirmed that `runtime.GOOS` is used as needed to isolate changes
- [x] Verified that fleetd runs on macOS, Linux and Windows
- [x] Verified auto-update works from the released version of component to the new version (see [tools/tuf/test](../tools/tuf/test/README.md))
