### PR TITLE
Mark dep assignments as failed on certain server errors (#31523)

### DIFF
--- a/changes/31385-dep-sync-url-incorrect
+++ b/changes/31385-dep-sync-url-incorrect
@@ -1,0 +1,1 @@
+Fixed an issue during the DEP sync where errors such as 404 from the DEP API could result in devices never being assigned a cloud configuration profile

--- a/server/mdm/apple/apple_mdm_external_test.go
+++ b/server/mdm/apple/apple_mdm_external_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/fleetdm/fleet/v4/server/mdm/nanodep/godep"
 	"github.com/fleetdm/fleet/v4/server/test"
 	"github.com/go-kit/log"
+	"github.com/jmoiron/sqlx"
 	"github.com/stretchr/testify/require"
 )
 
@@ -147,7 +148,18 @@ func TestDEPService_RunAssigner(t *testing.T) {
 				require.Equal(t, assignReq.ProfileUUID, "profile123")
 				require.ElementsMatch(t, []string{"a", "c"}, assignReq.Devices)
 
-				_, _ = w.Write([]byte(`{}`))
+				apiResp := godep.ProfileResponse{
+					ProfileUUID: "profile123",
+					Devices: map[string]string{
+						"a": string(fleet.DEPAssignProfileResponseSuccess),
+						"c": string(fleet.DEPAssignProfileResponseSuccess),
+					},
+				}
+				respBytes, err := json.Marshal(&apiResp)
+				require.NoError(t, err)
+
+				_, err = w.Write(respBytes)
+				require.NoError(t, err)
 			default:
 				t.Errorf("unexpected request to %s", r.URL.Path)
 			}
@@ -178,6 +190,14 @@ func TestDEPService_RunAssigner(t *testing.T) {
 			require.Nil(t, h.TeamID, h.HardwareSerial)
 		}
 		require.ElementsMatch(t, []string{"a", "c"}, serials)
+
+		mysql.ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
+			stmt := "SELECT COUNT(*) FROM host_dep_assignments WHERE host_id IN (?, ?) AND assign_profile_response = ?"
+			var result int
+			require.NoError(t, sqlx.GetContext(ctx, q, &result, stmt, hosts[0].ID, hosts[1].ID, fleet.DEPAssignProfileResponseSuccess))
+			require.Equal(t, 2, result, "expected two successful assignments for serials a and c")
+			return nil
+		})
 	})
 
 	t.Run("a custom profile, some devices", func(t *testing.T) {
@@ -231,7 +251,18 @@ func TestDEPService_RunAssigner(t *testing.T) {
 				require.Equal(t, assignReq.ProfileUUID, "profile456")
 				require.ElementsMatch(t, []string{"a", "c"}, assignReq.Devices)
 
-				_, _ = w.Write([]byte(`{}`))
+				apiResp := godep.ProfileResponse{
+					ProfileUUID: "profile456",
+					Devices: map[string]string{
+						"a": string(fleet.DEPAssignProfileResponseSuccess),
+						"c": string(fleet.DEPAssignProfileResponseSuccess),
+					},
+				}
+				respBytes, err := json.Marshal(&apiResp)
+				require.NoError(t, err)
+
+				_, err = w.Write(respBytes)
+				require.NoError(t, err)
 			default:
 				t.Errorf("unexpected request to %s", r.URL.Path)
 			}
@@ -293,5 +324,108 @@ func TestDEPService_RunAssigner(t *testing.T) {
 			require.Equal(t, tm.ID, *h.TeamID, h.HardwareSerial)
 		}
 		require.ElementsMatch(t, []string{"a", "c"}, serials)
+
+		mysql.ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
+			stmt := "SELECT COUNT(*) FROM host_dep_assignments WHERE host_id IN (?, ?) AND assign_profile_response = ?"
+			var result int
+			require.NoError(t, sqlx.GetContext(ctx, q, &result, stmt, hosts[0].ID, hosts[1].ID, fleet.DEPAssignProfileResponseSuccess))
+			require.Equal(t, 2, result, "expected two successful assignments for serials a and c")
+			return nil
+		})
+	})
+
+	t.Run("assign returns 5xx", func(t *testing.T) {
+		start := time.Now().Truncate(time.Second)
+
+		devices := []godep.Device{
+			{SerialNumber: "a", OpType: "added"},
+			{SerialNumber: "b", OpType: "ignore"},
+			{SerialNumber: "c", OpType: ""},
+		}
+
+		var assignCalled bool
+		svc := setupTest(t, func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path == "/profile/devices" {
+				w.WriteHeader(http.StatusInternalServerError)
+			} else {
+				w.WriteHeader(http.StatusOK)
+			}
+			encoder := json.NewEncoder(w)
+			switch r.URL.Path {
+			case "/session":
+				_, _ = w.Write([]byte(`{"auth_session_token": "session123"}`))
+			case "/account":
+				_, _ = w.Write([]byte(fmt.Sprintf(`{"admin_id": "admin123", "org_name": "%s"}`, abmTokenOrgName)))
+			case "/profile":
+				err := encoder.Encode(godep.ProfileResponse{ProfileUUID: "profile123"})
+				require.NoError(t, err)
+			case "/server/devices":
+				err := encoder.Encode(godep.DeviceResponse{Devices: devices})
+				require.NoError(t, err)
+			case "/devices/sync":
+				err := encoder.Encode(godep.DeviceResponse{Devices: devices})
+				require.NoError(t, err)
+			case "/profile/devices":
+				assignCalled = true
+
+				reqBody, err := io.ReadAll(r.Body)
+				require.NoError(t, err)
+
+				var assignReq godep.Profile
+				err = json.Unmarshal(reqBody, &assignReq)
+				require.NoError(t, err)
+				require.Equal(t, assignReq.ProfileUUID, "profile123")
+				require.ElementsMatch(t, []string{"a", "c"}, assignReq.Devices)
+				apiResp := godep.ProfileResponse{
+					ProfileUUID: "profile123",
+					Devices: map[string]string{
+						"a": string(fleet.DEPAssignProfileResponseSuccess),
+						"c": string(fleet.DEPAssignProfileResponseSuccess),
+					},
+				}
+				respBytes, err := json.Marshal(&apiResp)
+				require.NoError(t, err)
+
+				_, err = w.Write(respBytes)
+				require.NoError(t, err)
+			default:
+				t.Errorf("unexpected request to %s", r.URL.Path)
+			}
+		})
+		err := svc.RunAssigner(ctx)
+		require.NoError(t, err)
+		require.True(t, assignCalled)
+
+		// the default profile was created
+		defProf, err := ds.GetMDMAppleEnrollmentProfileByType(ctx, fleet.MDMAppleEnrollmentTypeAutomatic)
+		require.NoError(t, err)
+		require.NotNil(t, defProf)
+		require.NotEmpty(t, defProf.Token)
+
+		// a profile UUID was assigned to no-team
+		profUUID, modTime, err := ds.GetMDMAppleDefaultSetupAssistant(ctx, nil, abmTokenOrgName)
+		require.NoError(t, err)
+		require.Equal(t, "profile123", profUUID)
+		require.False(t, modTime.Before(start))
+
+		// a couple hosts were created (except the op_type ignored)
+		hosts, err := ds.ListHosts(ctx, fleet.TeamFilter{User: test.UserAdmin}, fleet.HostListOptions{})
+		require.NoError(t, err)
+		require.Len(t, hosts, 2)
+		serials := make([]string, len(hosts))
+		for i, h := range hosts {
+			serials[i] = h.HardwareSerial
+			require.Nil(t, h.TeamID, h.HardwareSerial)
+		}
+		require.ElementsMatch(t, []string{"a", "c"}, serials)
+
+		// Verify that the two hosts have assignments marked failed
+		mysql.ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
+			stmt := "SELECT COUNT(*) FROM host_dep_assignments WHERE host_id IN (?, ?) AND assign_profile_response = ?"
+			var result int
+			require.NoError(t, sqlx.GetContext(ctx, q, &result, stmt, hosts[0].ID, hosts[1].ID, fleet.DEPAssignProfileResponseFailed))
+			require.Equal(t, 2, result, "expected two failed assignments for serials a and c")
+			return nil
+		})
 	})
 }

--- a/server/service/integration_mdm_test.go
+++ b/server/service/integration_mdm_test.go
@@ -6174,11 +6174,17 @@ func (s *integrationMDMTestSuite) setUpEndUserAuthentication(t *testing.T, lastS
 			err = encoder.Encode(godep.ProfileResponse{ProfileUUID: "abc"})
 			require.NoError(t, err)
 		case "/profile/devices":
+			b, err := io.ReadAll(r.Body)
+			require.NoError(t, err)
+			var prof profileAssignmentReq
+			require.NoError(t, json.Unmarshal(b, &prof))
+			var resp godep.ProfileResponse
+			resp.ProfileUUID = prof.ProfileUUID
+			resp.Devices = map[string]string{
+				prof.Devices[0]: string(fleet.DEPAssignProfileResponseSuccess),
+			}
 			encoder := json.NewEncoder(w)
-			err := encoder.Encode(godep.ProfileResponse{
-				ProfileUUID: "abc",
-				Devices:     map[string]string{},
-			})
+			err = encoder.Encode(resp)
 			require.NoError(t, err)
 		case "/server/devices", "/devices/sync":
 			// This endpoint  is used to get an initial list of
@@ -9953,6 +9959,19 @@ func (s *integrationMDMTestSuite) TestCustomConfigurationWebURL() {
 				assert.Equal(t, lastSubmittedProfile.URL, lastSubmittedProfile.ConfigurationWebURL)
 			}
 			err = encoder.Encode(godep.ProfileResponse{ProfileUUID: uuid.New().String()})
+			require.NoError(t, err)
+		case "/profile/devices":
+			b, err := io.ReadAll(r.Body)
+			require.NoError(t, err)
+			var prof profileAssignmentReq
+			require.NoError(t, json.Unmarshal(b, &prof))
+			var resp godep.ProfileResponse
+			resp.ProfileUUID = prof.ProfileUUID
+			resp.Devices = map[string]string{
+				prof.Devices[0]: string(fleet.DEPAssignProfileResponseSuccess),
+			}
+			encoder := json.NewEncoder(w)
+			err = encoder.Encode(resp)
 			require.NoError(t, err)
 		default:
 			_, _ = w.Write([]byte(`{"auth_session_token": "xyz"}`))


### PR DESCRIPTION
Merge to 4.72.0 for the following change

On certain errors(like a network error, perhaps even Apple ratelimiting) we previously would drop assignments during the DEP sync and leave the host_dep_assignments row null and the assignment unset on the Apple side. Because of how the sync works it is entirely possible when this happens that we would happily go along, update the cursor and never return to resync these devices unless and until the admin did something that forced a resync like changing something about the cloud config profile.

Now any devices that for any reason don't get returned by the response get marked as failed so that our logic for retrying and processing cooldowns picks them up for later retry.

Explanation here as far as what I think is going wrong: https://github.com/fleetdm/fleet/issues/31385#issuecomment-3145117080

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
See [Changes
files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [x] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes

## Testing

- [x] Added/updated automated tests
- [x] Where appropriate, [automated tests simulate multiple hosts and test for host
isolation](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/reference/patterns-backend.md#unit-testing) (updates to one hosts's records do not affect another)

- [x] QA'd all new/changed functionality manually
