### PR TITLE
Fleet UI: Add back uninstall script content for uninstalls with no script output

### DIFF
--- a/frontend/components/ActivityDetails/InstallDetails/SoftwareUninstallDetailsModal/SoftwareUninstallDetailsModal.tsx
+++ b/frontend/components/ActivityDetails/InstallDetails/SoftwareUninstallDetailsModal/SoftwareUninstallDetailsModal.tsx
@@ -211,7 +211,6 @@ const SoftwareUninstallDetailsModal = ({
             onClick={toggleDetails}
           />
         )}
-        {/* Tarballs only has script_contents, not output */}
         {showDetails && uninstallResult?.script_contents && (
           <Textarea label="Uninstall script content:" variant="code">
             {uninstallResult.script_contents}

--- a/frontend/components/ActivityDetails/InstallDetails/SoftwareUninstallDetailsModal/SoftwareUninstallDetailsModal.tsx
+++ b/frontend/components/ActivityDetails/InstallDetails/SoftwareUninstallDetailsModal/SoftwareUninstallDetailsModal.tsx
@@ -211,13 +211,17 @@ const SoftwareUninstallDetailsModal = ({
             onClick={toggleDetails}
           />
         )}
-        {uninstallStatus !== "pending_uninstall" &&
-          showDetails &&
-          uninstallResult?.output && (
-            <Textarea label="Uninstall script output:" variant="code">
-              {uninstallResult.output}
-            </Textarea>
-          )}
+        {/* Tarballs only has script_contents, not output */}
+        {showDetails && uninstallResult?.script_contents && (
+          <Textarea label="Uninstall script content:" variant="code">
+            {uninstallResult.script_contents}
+          </Textarea>
+        )}
+        {showDetails && uninstallResult?.output && (
+          <Textarea label="Uninstall script output:" variant="code">
+            {uninstallResult.output}
+          </Textarea>
+        )}
       </div>
     );
   };


### PR DESCRIPTION
## Issue
Closes #31660 

## Description
- Renders script content if it's returned by the API

# Checklist for submitter


## Testing

- [x] QA'd all new/changed functionality manually
