### PR TITLE
Test for false positive for CVE-2025-6554 on mac and linux

### DIFF
--- a/server/vulnerabilities/nvd/cve_test.go
+++ b/server/vulnerabilities/nvd/cve_test.go
@@ -553,6 +553,14 @@ func TestTranslateCPEToCVE(t *testing.T) {
 			},
 			continuesToUpdate: true,
 		},
+		"cpe:2.3:a:google:chrome:138.0.7204.91:*:*:*:*:linux:*:*": {
+			excludedCVEs:      []string{"CVE-2025-6554"},
+			continuesToUpdate: true,
+		},
+		"cpe:2.3:a:google:chrome:138.0.7204.92:*:*:*:*:macos:*:*": {
+			excludedCVEs:      []string{"CVE-2025-6554"},
+			continuesToUpdate: true,
+		},
 	}
 
 	cveOSTests := []struct {


### PR DESCRIPTION
fixes #30682

If some of the following don't apply, delete the relevant line.

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually