### PR TITLE
Fixes to the offline indicator

### DIFF
--- a/changes/31592-improve-offline-indicator
+++ b/changes/31592-improve-offline-indicator
@@ -1,0 +1,2 @@
+* Fixed invalid rate limiting applied on Fleet Desktop requests for which a public IP could not be determined.
+* Improved public IP extraction for Fleet Desktop requests.

--- a/orbit/changes/31592-improve-offline-indicator
+++ b/orbit/changes/31592-improve-offline-indicator
@@ -1,0 +1,1 @@
+* Fixed offline indicator to be less sensitive to transient network failures and faster recovery when connectivity is restored.

--- a/orbit/cmd/desktop/desktop.go
+++ b/orbit/cmd/desktop/desktop.go
@@ -192,8 +192,6 @@ func main() {
 		myDeviceItem.Disable()
 		myDeviceItem.Hide()
 
-		// We are doing this using two menu items because line breaks
-		// are not rendered correctly on Windows and MacOS.
 		hostOfflineItemOne := systray.AddMenuItem("🛜🚫 Your computer is not connected to Fleet.", "")
 		hostOfflineItemOne.Disable()
 

--- a/orbit/cmd/desktop/desktop.go
+++ b/orbit/cmd/desktop/desktop.go
@@ -392,6 +392,8 @@ func main() {
 					migrateMDMItem.Disable()
 					migrateMDMItem.Hide()
 					hostOfflineItemOne.Show()
+					selfServiceItem.Disable()
+					selfServiceItem.Hide()
 					offlineIndicatorDisplayed = true
 				}
 			)

--- a/server/service/handler.go
+++ b/server/service/handler.go
@@ -801,68 +801,68 @@ func attachFleetAPIRoutes(r *mux.Router, svc fleet.Service, config config.FleetC
 	// properly
 	desktopQuota := throttled.RateQuota{MaxRate: throttled.PerHour(720), MaxBurst: desktopRateLimitMaxBurst}
 	de.WithCustomMiddleware(
-		errorLimiter.Limit("get_device_host", desktopQuota),
+		errorLimiter.Limit("get_device_host", desktopQuota, logger),
 	).GET("/api/_version_/fleet/device/{token}", getDeviceHostEndpoint, getDeviceHostRequest{})
 	de.WithCustomMiddleware(
-		errorLimiter.Limit("get_fleet_desktop", desktopQuota),
+		errorLimiter.Limit("get_fleet_desktop", desktopQuota, logger),
 	).GET("/api/_version_/fleet/device/{token}/desktop", getFleetDesktopEndpoint, getFleetDesktopRequest{})
 	de.WithCustomMiddleware(
-		errorLimiter.Limit("ping_device_auth", desktopQuota),
+		errorLimiter.Limit("ping_device_auth", desktopQuota, logger),
 	).HEAD("/api/_version_/fleet/device/{token}/ping", devicePingEndpoint, deviceAuthPingRequest{})
 	de.WithCustomMiddleware(
-		errorLimiter.Limit("refetch_device_host", desktopQuota),
+		errorLimiter.Limit("refetch_device_host", desktopQuota, logger),
 	).POST("/api/_version_/fleet/device/{token}/refetch", refetchDeviceHostEndpoint, refetchDeviceHostRequest{})
 	de.WithCustomMiddleware(
-		errorLimiter.Limit("get_device_mapping", desktopQuota),
+		errorLimiter.Limit("get_device_mapping", desktopQuota, logger),
 	).GET("/api/_version_/fleet/device/{token}/device_mapping", listDeviceHostDeviceMappingEndpoint, listDeviceHostDeviceMappingRequest{})
 	de.WithCustomMiddleware(
-		errorLimiter.Limit("get_device_macadmins", desktopQuota),
+		errorLimiter.Limit("get_device_macadmins", desktopQuota, logger),
 	).GET("/api/_version_/fleet/device/{token}/macadmins", getDeviceMacadminsDataEndpoint, getDeviceMacadminsDataRequest{})
 	de.WithCustomMiddleware(
-		errorLimiter.Limit("get_device_policies", desktopQuota),
+		errorLimiter.Limit("get_device_policies", desktopQuota, logger),
 	).GET("/api/_version_/fleet/device/{token}/policies", listDevicePoliciesEndpoint, listDevicePoliciesRequest{})
 	de.WithCustomMiddleware(
-		errorLimiter.Limit("get_device_transparency", desktopQuota),
+		errorLimiter.Limit("get_device_transparency", desktopQuota, logger),
 	).GET("/api/_version_/fleet/device/{token}/transparency", transparencyURL, transparencyURLRequest{})
 	de.WithCustomMiddleware(
-		errorLimiter.Limit("send_device_error", desktopQuota),
+		errorLimiter.Limit("send_device_error", desktopQuota, logger),
 	).POST("/api/_version_/fleet/device/{token}/debug/errors", fleetdError, fleetdErrorRequest{})
 	de.WithCustomMiddleware(
-		errorLimiter.Limit("get_device_software", desktopQuota),
+		errorLimiter.Limit("get_device_software", desktopQuota, logger),
 	).GET("/api/_version_/fleet/device/{token}/software", getDeviceSoftwareEndpoint, getDeviceSoftwareRequest{})
 	de.WithCustomMiddleware(
-		errorLimiter.Limit("install_self_service", desktopQuota),
+		errorLimiter.Limit("install_self_service", desktopQuota, logger),
 	).POST("/api/_version_/fleet/device/{token}/software/install/{software_title_id}", submitSelfServiceSoftwareInstall, fleetSelfServiceSoftwareInstallRequest{})
 	de.WithCustomMiddleware(
-		errorLimiter.Limit("uninstall_self_service", desktopQuota),
+		errorLimiter.Limit("uninstall_self_service", desktopQuota, logger),
 	).POST("/api/_version_/fleet/device/{token}/software/uninstall/{software_title_id}", submitDeviceSoftwareUninstall, fleetDeviceSoftwareUninstallRequest{})
 	de.WithCustomMiddleware(
-		errorLimiter.Limit("get_device_software_install_results", desktopQuota),
+		errorLimiter.Limit("get_device_software_install_results", desktopQuota, logger),
 	).GET("/api/_version_/fleet/device/{token}/software/install/{install_uuid}/results", getDeviceSoftwareInstallResultsEndpoint,
 		getDeviceSoftwareInstallResultsRequest{})
 	de.WithCustomMiddleware(
-		errorLimiter.Limit("get_device_software_uninstall_results", desktopQuota),
+		errorLimiter.Limit("get_device_software_uninstall_results", desktopQuota, logger),
 	).GET("/api/_version_/fleet/device/{token}/software/uninstall/{execution_id}/results", getDeviceSoftwareUninstallResultsEndpoint, getDeviceSoftwareUninstallResultsRequest{})
 	de.WithCustomMiddleware(
-		errorLimiter.Limit("get_device_certificates", desktopQuota),
+		errorLimiter.Limit("get_device_certificates", desktopQuota, logger),
 	).GET("/api/_version_/fleet/device/{token}/certificates", listDeviceCertificatesEndpoint, listDeviceCertificatesRequest{})
 
 	// mdm-related endpoints available via device authentication
 	demdm := de.WithCustomMiddleware(mdmConfiguredMiddleware.VerifyAppleMDM())
 	demdm.WithCustomMiddleware(
-		errorLimiter.Limit("get_device_mdm", desktopQuota),
+		errorLimiter.Limit("get_device_mdm", desktopQuota, logger),
 	).GET("/api/_version_/fleet/device/{token}/mdm/apple/manual_enrollment_profile", getDeviceMDMManualEnrollProfileEndpoint, getDeviceMDMManualEnrollProfileRequest{})
 	demdm.WithCustomMiddleware(
-		errorLimiter.Limit("get_device_software_mdm_command_results", desktopQuota),
+		errorLimiter.Limit("get_device_software_mdm_command_results", desktopQuota, logger),
 	).GET("/api/_version_/fleet/device/{token}/software/commands/{command_uuid}/results", getDeviceMDMCommandResultsEndpoint,
 		getDeviceMDMCommandResultsRequest{})
 
 	demdm.WithCustomMiddleware(
-		errorLimiter.Limit("post_device_migrate_mdm", desktopQuota),
+		errorLimiter.Limit("post_device_migrate_mdm", desktopQuota, logger),
 	).POST("/api/_version_/fleet/device/{token}/migrate_mdm", migrateMDMDeviceEndpoint, deviceMigrateMDMRequest{})
 
 	de.WithCustomMiddleware(
-		errorLimiter.Limit("post_device_trigger_linux_escrow", desktopQuota),
+		errorLimiter.Limit("post_device_trigger_linux_escrow", desktopQuota, logger),
 	).POST("/api/_version_/fleet/device/{token}/mdm/linux/trigger_escrow", triggerLinuxDiskEncryptionEscrowEndpoint, triggerLinuxDiskEncryptionEscrowRequest{})
 
 	// host-authenticated endpoints


### PR DESCRIPTION
#31592

There's still some QA to be done for edge cases and re-connects, but this is ready for review.

<img width="341" height="103" alt="Screenshot 2025-08-07 at 11 19 33 AM" src="https://github.com/user-attachments/assets/01e48ca2-8ab1-412c-be01-8e806a5a8b1c" /> 

Changes:
- To improve UX I'm now using `HEAD /api/fleet/device/ping` API every 10 seconds for connectivity/offline check (instead of the expensive DesktopSummary one every 5 minutes). This is to address feedback from a customer:
  > "If the internet is not connected and we reconnect with an ethernet connection for example, it would be good to try to see if we can refresh it text from the offline indicator given that's not the case anymore. 
- It might take up to 1m for Fleet Desktop to show the offline indicator (we check every 10s with ping and now we are adding 6 more requests in 1 minute to make sure just one bad request doesn't unnecessarily display the offline indicator).
- Requests without proper public IP were being incorrectly rate limited (all under the same bucket). So we will now not make these requests and instead log a WARNING. This is a-ok as the recommended approach to deploy Fleet is with a TLS terminator that will add the public IP of the request before sending it to Fleet.

---

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [X] Added/updated automated tests

- [X] QA'd all new/changed functionality manually

## fleetd/orbit/Fleet Desktop

- [x] Verified compatibility with the latest released version of Fleet (see [Must rule](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/workflows/fleetd-development-and-release-strategy.md))
- [x] Verified that fleetd runs on macOS, Linux and Windows
- [x] Verified auto-update works from the released version of component to the new version (see [tools/tuf/test](../tools/tuf/test/README.md))


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy in identifying client public IP addresses, reducing incorrect rate limiting for Fleet Desktop users.
  * Offline indicator is now less sensitive to brief network interruptions, reducing false offline signals and allowing faster recovery when connectivity is restored.
  * Updated offline message for clearer status communication.

* **New Features**
  * Enhanced error messages and logging for rate limiting events, providing clearer feedback when limits are reached.

* **Tests**
  * Expanded test coverage for rate limiting, including scenarios with missing public IPs and improved assertions for error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->