### PR TITLE
add columns to host details and my device certificates table

### DIFF
--- a/changes/issue-27467-add-cells-to-cert-table
+++ b/changes/issue-27467-add-cells-to-cert-table
@@ -1,0 +1,1 @@
+- add issuer and issued cells to the host details and my device page certificates table

--- a/frontend/components/TableContainer/DataTable/TooltipTruncatedTextCell/TooltipTruncatedTextCell.tsx
+++ b/frontend/components/TableContainer/DataTable/TooltipTruncatedTextCell/TooltipTruncatedTextCell.tsx
@@ -52,7 +52,10 @@ const TooltipTruncatedTextCell = ({
   // End
 
   const tooltipId = uniqueId();
-  value = !value ? DEFAULT_EMPTY_CELL_VALUE : value;
+  value =
+    value === null || value === undefined || value === ""
+      ? DEFAULT_EMPTY_CELL_VALUE
+      : value;
   const isDefaultValue = value === DEFAULT_EMPTY_CELL_VALUE;
 
   return (

--- a/frontend/components/TableContainer/DataTable/TooltipTruncatedTextCell/TooltipTruncatedTextCell.tsx
+++ b/frontend/components/TableContainer/DataTable/TooltipTruncatedTextCell/TooltipTruncatedTextCell.tsx
@@ -52,6 +52,7 @@ const TooltipTruncatedTextCell = ({
   // End
 
   const tooltipId = uniqueId();
+  value = !value ? DEFAULT_EMPTY_CELL_VALUE : value;
   const isDefaultValue = value === DEFAULT_EMPTY_CELL_VALUE;
 
   return (

--- a/frontend/pages/hosts/details/cards/Certificates/CertificatesTable/CertificatesTableConfig.tsx
+++ b/frontend/pages/hosts/details/cards/Certificates/CertificatesTable/CertificatesTableConfig.tsx
@@ -12,8 +12,10 @@ import StatusIndicator from "components/StatusIndicator";
 import { IIndicatorValue } from "components/StatusIndicator/StatusIndicator";
 import TooltipTruncatedTextCell from "components/TableContainer/DataTable/TooltipTruncatedTextCell";
 import TooltipWrapper from "components/TooltipWrapper";
+import { IStringCellProps } from "interfaces/datatable_config";
 
 type IHostCertificatesTableConfig = Column<IHostCertificate>;
+type IIssuerCellProps = IStringCellProps<IHostCertificate>;
 
 const generateTableConfig = (): IHostCertificatesTableConfig[] => {
   return [
@@ -23,6 +25,22 @@ const generateTableConfig = (): IHostCertificatesTableConfig[] => {
         <HeaderCell value="Name" isSortedDesc={cellProps.column.isSortedDesc} />
       ),
       Cell: (cellProps) => <TextCell value={cellProps.cell.value} />,
+    },
+    {
+      accessor: (data) => data.issuer.common_name,
+      id: "issuer",
+      Header: (cellProps) => (
+        <HeaderCell
+          value="Issuer"
+          isSortedDesc={cellProps.column.isSortedDesc}
+        />
+      ),
+      Cell: (cellProps: IIssuerCellProps) => (
+        <TooltipTruncatedTextCell
+          value={cellProps.cell.value}
+          tooltip={cellProps.cell.value}
+        />
+      ),
     },
     {
       accessor: "source",

--- a/frontend/pages/hosts/details/cards/Certificates/CertificatesTable/CertificatesTableConfig.tsx
+++ b/frontend/pages/hosts/details/cards/Certificates/CertificatesTable/CertificatesTableConfig.tsx
@@ -29,12 +29,8 @@ const generateTableConfig = (): IHostCertificatesTableConfig[] => {
     {
       accessor: (data) => data.issuer.common_name,
       id: "issuer",
-      Header: (cellProps) => (
-        <HeaderCell
-          value="Issuer"
-          isSortedDesc={cellProps.column.isSortedDesc}
-        />
-      ),
+      disableSortBy: true,
+      Header: "Issuer",
       Cell: (cellProps: IIssuerCellProps) => (
         <TooltipTruncatedTextCell
           value={cellProps.cell.value}
@@ -60,6 +56,19 @@ const generateTableConfig = (): IHostCertificatesTableConfig[] => {
       },
     },
     {
+      accessor: "not_valid_before",
+      disableSortBy: true,
+      Header: "Issued",
+      Cell: (cellProps) => {
+        return (
+          <TextCell
+            value={monthDayYearFormat(cellProps.value)}
+            className="text-nowrap"
+          />
+        );
+      },
+    },
+    {
       accessor: "not_valid_after",
       Header: (cellProps) => (
         <HeaderCell
@@ -76,6 +85,7 @@ const generateTableConfig = (): IHostCertificatesTableConfig[] => {
         }
         return (
           <StatusIndicator
+            className="cert-table__status-indicator"
             value={monthDayYearFormat(cellProps.value)}
             indicator={status}
           />

--- a/frontend/pages/hosts/details/cards/Certificates/CertificatesTable/_styles.scss
+++ b/frontend/pages/hosts/details/cards/Certificates/CertificatesTable/_styles.scss
@@ -1,3 +1,9 @@
 .certificates-table {
+  .data-table-block .data-table__wrapper {
+    overflow-x: auto;
+  }
 
+  .cert-table__status-indicator {
+    min-width: 160px;
+  }
 }


### PR DESCRIPTION
relates to #27567

this adds two columns to the certificates table on host details and my device pages; the issuer cell and the issued cell.

This also makes a change to TooltipTruncateTextCell that set the value as `---` if the provided value is undefined, null, or empty string. This still allows the number `0` to be provided 

<img width="1205" height="540" alt="image" src="https://github.com/user-attachments/assets/b712ccda-b5be-422d-9489-612ccdacab79" />

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
- [x] QA'd all new/changed functionality manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Issuer" and "Issued" columns to the certificates table on host details and my device pages, providing more certificate information.
* **Style**
  * Improved table styling with horizontal scrolling for overflowing content and consistent sizing for status indicators.
* **Bug Fixes**
  * Ensured empty or missing table cell values are consistently displayed with a default placeholder.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->