### PR TITLE
Fleet UI: Show temporary "Updated" status while waiting for software inventory update

### DIFF
--- a/frontend/interfaces/software.ts
+++ b/frontend/interfaces/software.ts
@@ -426,21 +426,31 @@ export interface IHostSoftware {
   installed_versions: ISoftwareInstallVersion[] | null;
 }
 
+/**
+ * Comprehensive list of possible UI software statuses for host > software > library/self-service.
+ *
+ * These are more detailed than the raw API `.status` and are determined by:
+ * - Whether the host is online or offline
+ * - If the fleet-installed version is newer than any in installed_versions
+ * - Special handling for tarballs (tgz_packages)
+ * - Cases where the software inventory has not yet updated to reflect a recent change
+ *   (i.e., last_install date vs host software's updated_at date)
+ */
 export type IHostSoftwareUiStatus =
-  | "installed"
-  | "uninstalled"
-  | "installing"
-  | "uninstalling"
-  | "updated"
-  | "updating"
-  | "pending_install"
-  | "pending_uninstall"
-  | "pending_update"
-  | "failed_install"
-  | "failed_install_update_available"
-  | "failed_uninstall"
-  | "failed_uninstall_update_available"
-  | "update_available";
+  | "installed" // Present in inventory; no newer fleet installer version (tarballs: successful install only)
+  | "uninstalled" // Not present in inventory (tarballs: successful uninstall or never installed)
+  | "installing" // ONLINE; fleet-initiated install in progress
+  | "uninstalling" // ONLINE; fleet-initiated uninstall in progress
+  | "updated" // Update applied (installer newer than inventory), but inventory not yet refreshed
+  | "updating" // ONLINE; update (install) in progress with newer fleet installer
+  | "pending_install" // OFFLINE; install scheduled (no newer installer version)
+  | "pending_uninstall" // OFFLINE; uninstall scheduled
+  | "pending_update" // OFFLINE; update scheduled (no newer installer version)
+  | "failed_install" // Install attempt failed
+  | "failed_install_update_available" // Install/update failed; newer installer version available
+  | "failed_uninstall" // Uninstall attempt failed
+  | "failed_uninstall_update_available" // Uninstall/update failed; newer installer version available
+  | "update_available"; // In inventory, but newer fleet installer version is available
 
 /**
  * Extends IHostSoftware with a computed `ui_status` field.

--- a/frontend/interfaces/software.ts
+++ b/frontend/interfaces/software.ts
@@ -431,6 +431,7 @@ export type IHostSoftwareUiStatus =
   | "uninstalled"
   | "installing"
   | "uninstalling"
+  | "updated"
   | "updating"
   | "pending_install"
   | "pending_uninstall"

--- a/frontend/interfaces/software.ts
+++ b/frontend/interfaces/software.ts
@@ -441,7 +441,9 @@ export type IHostSoftwareUiStatus =
   | "uninstalled" // Not present in inventory (tarballs: successful uninstall or never installed)
   | "installing" // ONLINE; fleet-initiated install in progress
   | "uninstalling" // ONLINE; fleet-initiated uninstall in progress
-  | "updated" // Update applied (installer newer than inventory), but inventory not yet refreshed
+  | "recently_updated" // Update applied (installer newer than inventory), but inventory not yet refreshed
+  | "recently_installed" // Install applied (installer NOT newer than inventory), but inventory not yet refreshed
+  | "recently_uninstalled" // Uninstall applied, but inventory not yet refreshed
   | "updating" // ONLINE; update (install) in progress with newer fleet installer
   | "pending_install" // OFFLINE; install scheduled (no newer installer version)
   | "pending_uninstall" // OFFLINE; uninstall scheduled

--- a/frontend/pages/hosts/details/DeviceUserPage/DeviceUserPage.tsx
+++ b/frontend/pages/hosts/details/DeviceUserPage/DeviceUserPage.tsx
@@ -519,6 +519,7 @@ const DeviceUserPage = ({
                       router={router}
                       refetchHostDetails={refetchHostDetails}
                       isHostDetailsPolling={showRefetchSpinner}
+                      hostSoftwareUpdatedAt={host.software_updated_at}
                       hostDisplayName={host?.hostname || ""}
                     />
                   </TabPanel>

--- a/frontend/pages/hosts/details/cards/Software/InstallStatusCell/InstallStatusCell.tsx
+++ b/frontend/pages/hosts/details/cards/Software/InstallStatusCell/InstallStatusCell.tsx
@@ -89,6 +89,29 @@ export const INSTALL_STATUS_DISPLAY_OPTIONS: Record<
       );
     },
   },
+  updated: {
+    iconName: "success",
+    displayText: "Updated",
+    tooltip: ({ isSelfService, isAppStoreApp, lastInstalledAt }) => {
+      if (!lastInstalledAt) {
+        return undefined;
+      }
+
+      return isAppStoreApp ? (
+        <>
+          The host acknowledged the MDM
+          <br />
+          command to install the app.
+        </>
+      ) : (
+        <>
+          Software was updated{" "}
+          {!isSelfService && "(install script finished with exit code 0) "}
+          {dateAgo(lastInstalledAt)}.
+        </>
+      );
+    },
+  },
   installing: {
     iconName: "pending-outline",
     displayText: ({ isSelfService, isHostOnline }) =>

--- a/frontend/pages/hosts/details/cards/Software/SelfService/SelfService.tsx
+++ b/frontend/pages/hosts/details/cards/Software/SelfService/SelfService.tsx
@@ -148,7 +148,7 @@ const SoftwareSelfService = ({
   const updateSoftware = enhancedSoftware.filter(
     (software) =>
       software.ui_status === "updating" ||
-      software.ui_status === "updated" ||
+      software.ui_status === "recently_updated" ||
       software.ui_status === "pending_update" || // Should never show as self-service = host online
       software.ui_status === "update_available" ||
       software.ui_status === "failed_install_update_available" ||
@@ -191,12 +191,13 @@ const SoftwareSelfService = ({
   };
 
   const disableUpdateAllButton = useMemo(() => {
-    // Disable if all statuses are "updating" or "updated"
+    // Disable if all statuses are "updating" or "recently_updated"
     return (
       updateSoftware.length > 0 &&
       updateSoftware.every(
         (software) =>
-          software.ui_status === "updating" || software.ui_status === "updated"
+          software.ui_status === "updating" ||
+          software.ui_status === "recently_updated"
       )
     );
   }, [updateSoftware]);

--- a/frontend/pages/hosts/details/cards/Software/SelfService/SelfService.tsx
+++ b/frontend/pages/hosts/details/cards/Software/SelfService/SelfService.tsx
@@ -87,6 +87,7 @@ export interface ISoftwareSelfServiceProps {
   router: InjectedRouter;
   refetchHostDetails: () => void;
   isHostDetailsPolling: boolean;
+  hostSoftwareUpdatedAt?: string | null;
   hostDisplayName: string;
 }
 
@@ -105,6 +106,7 @@ const SoftwareSelfService = ({
   router,
   refetchHostDetails,
   isHostDetailsPolling,
+  hostSoftwareUpdatedAt,
   hostDisplayName,
 }: ISoftwareSelfServiceProps) => {
   const { renderFlash, renderMultiFlash } = useContext(NotificationContext);
@@ -139,13 +141,14 @@ const SoftwareSelfService = ({
     if (!selfServiceData) return [];
     return selfServiceData.software.map((software) => ({
       ...software,
-      ui_status: getUiStatus(software, true),
+      ui_status: getUiStatus(software, true, hostSoftwareUpdatedAt),
     }));
-  }, [selfServiceData]);
+  }, [selfServiceData, hostSoftwareUpdatedAt]);
 
   const updateSoftware = enhancedSoftware.filter(
     (software) =>
       software.ui_status === "updating" ||
+      software.ui_status === "updated" ||
       software.ui_status === "pending_update" || // Should never show as self-service = host online
       software.ui_status === "update_available" ||
       software.ui_status === "failed_install_update_available" ||
@@ -188,10 +191,13 @@ const SoftwareSelfService = ({
   };
 
   const disableUpdateAllButton = useMemo(() => {
-    // Disable if all statuses are "updating"
+    // Disable if all statuses are "updating" or "updated"
     return (
       updateSoftware.length > 0 &&
-      updateSoftware.every((software) => software.ui_status === "updating")
+      updateSoftware.every(
+        (software) =>
+          software.ui_status === "updating" || software.ui_status === "updated"
+      )
     );
   }, [updateSoftware]);
 

--- a/frontend/pages/hosts/details/cards/Software/SelfService/UpdateSoftwareItem/UpdateSoftwareItem.tsx
+++ b/frontend/pages/hosts/details/cards/Software/SelfService/UpdateSoftwareItem/UpdateSoftwareItem.tsx
@@ -180,12 +180,18 @@ const InstallerStatusAction = ({
   return (
     <div className={`${baseClass}__item-action-status`}>
       <div className={`${baseClass}__item-action`}>
-        {ui_status === "updating" ? (
+        {ui_status === "updating" && (
           <>
             <Spinner size="x-small" includeContainer={false} centered={false} />{" "}
             Updating...{" "}
           </>
-        ) : (
+        )}
+        {ui_status === "updated" && (
+          <>
+            <Icon name="success" /> Updated
+          </>
+        )}
+        {ui_status !== "updating" && ui_status !== "updated" && (
           <HostInstallerActionButton
             baseClass={baseClass}
             disabled={false}

--- a/frontend/pages/hosts/details/cards/Software/SelfService/UpdateSoftwareItem/UpdateSoftwareItem.tsx
+++ b/frontend/pages/hosts/details/cards/Software/SelfService/UpdateSoftwareItem/UpdateSoftwareItem.tsx
@@ -18,11 +18,13 @@ import Icon from "components/Icon";
 import SoftwareIcon from "pages/SoftwarePage/components/icons/SoftwareIcon";
 import TooltipTruncatedText from "components/TooltipTruncatedText";
 import Spinner from "components/Spinner";
+import TooltipWrapper from "components/TooltipWrapper";
 
 import { HostInstallerActionButton } from "../../../HostSoftwareLibrary/HostInstallerActionCell/HostInstallerActionCell";
 import {
   InstallOrCommandUuid,
   IStatusDisplayConfig,
+  RECENT_SUCCESS_ACTION_MESSAGE,
 } from "../../InstallStatusCell/InstallStatusCell";
 
 const baseClass = "update-software-item";
@@ -177,30 +179,46 @@ const InstallerStatusAction = ({
 
   const showFailedInstallStatus = status === "failed_install";
 
+  const renderPrimaryStatusAction = () => {
+    if (ui_status === "updating") {
+      return (
+        <>
+          <Spinner size="x-small" includeContainer={false} centered={false} />{" "}
+          Updating...{" "}
+        </>
+      );
+    }
+    if (ui_status === "recently_updated") {
+      return (
+        <>
+          <Icon name="success" />
+          <TooltipWrapper
+            tipContent={RECENT_SUCCESS_ACTION_MESSAGE("updated")}
+            showArrow
+            underline={false}
+            position="top"
+          >
+            Updated
+          </TooltipWrapper>
+        </>
+      );
+    }
+    return (
+      <HostInstallerActionButton
+        baseClass={baseClass}
+        disabled={false}
+        onClick={onInstall}
+        text="Update"
+        icon="refresh"
+        testId={`${baseClass}__install-button--test`}
+      />
+    );
+  };
+
   return (
     <div className={`${baseClass}__item-action-status`}>
       <div className={`${baseClass}__item-action`}>
-        {ui_status === "updating" && (
-          <>
-            <Spinner size="x-small" includeContainer={false} centered={false} />{" "}
-            Updating...{" "}
-          </>
-        )}
-        {ui_status === "updated" && (
-          <>
-            <Icon name="success" /> Updated
-          </>
-        )}
-        {ui_status !== "updating" && ui_status !== "updated" && (
-          <HostInstallerActionButton
-            baseClass={baseClass}
-            disabled={false}
-            onClick={onInstall}
-            text="Update"
-            icon="refresh"
-            testId={`${baseClass}__install-button--test`}
-          />
-        )}
+        {renderPrimaryStatusAction()}
       </div>
       {showFailedInstallStatus && (
         <div className={`${baseClass}__item-status`}>

--- a/frontend/pages/hosts/details/cards/Software/helpers.tests.ts
+++ b/frontend/pages/hosts/details/cards/Software/helpers.tests.ts
@@ -190,19 +190,107 @@ describe("getUiStatus", () => {
     );
   });
 
-  it("returns 'updated' if last install is newer than inventory refresh (host software inventory is not up to date yet)", () => {
+  it("returns 'recently_installed' if status is installed, lastInstallDate newer than hostSoftwareUpdatedAt, and no update", () => {
     const now = new Date();
-    const lastInstallDate = new Date(now.getTime() + 60 * 1000).toISOString(); // 1 min after inventory update
+    const lastInstallDate = new Date(now.getTime() + 60 * 1000).toISOString();
     const hostSoftwareUpdatedAt = now.toISOString();
+
+    // Installed version matches installer version ⇒ not an update
+    const sw = createMockHostSoftware({
+      status: "installed",
+      software_package: createMockHostSoftwarePackage({
+        version: "1.0.0",
+        last_install: { install_uuid: "abc", installed_at: lastInstallDate },
+      }),
+      // installed_versions might still be empty if inventory hasn't updated yet
+      installed_versions: [],
+    });
+    expect(getUiStatus(sw, true, hostSoftwareUpdatedAt)).toBe(
+      "recently_installed"
+    );
+  });
+
+  it("returns 'recently_updated' if status is installed, lastInstallDate newer than hostSoftwareUpdatedAt, AND update was applied", () => {
+    const now = new Date();
+    const lastInstallDate = new Date(now.getTime() + 60 * 1000).toISOString(); // just after inventory
+    const hostSoftwareUpdatedAt = now.toISOString();
+
+    // Installer version is higher (update applied)
     const sw = createMockHostSoftware({
       status: "installed",
       software_package: createMockHostSoftwarePackage({
         version: "2.0.0",
         last_install: { install_uuid: "abc", installed_at: lastInstallDate },
-      }), // newer
+      }),
+      // installed_versions might still show lower version since inventory hasn't updated yet
     });
-    // Simulate install happened after last inventory check
-    expect(getUiStatus(sw, true, hostSoftwareUpdatedAt)).toBe("updated");
+    expect(getUiStatus(sw, true, hostSoftwareUpdatedAt)).toBe(
+      "recently_updated"
+    );
+  });
+
+  it("returns 'recently_uninstalled' if status is null and lastUninstallDate newer than hostSoftwareUpdatedAt", () => {
+    const now = new Date();
+    const lastUninstallDate = new Date(now.getTime() + 60 * 1000).toISOString();
+    const hostSoftwareUpdatedAt = now.toISOString();
+
+    const sw = createMockHostSoftware({
+      status: null,
+      software_package: createMockHostSoftwarePackage({
+        // last_uninstall must be present
+        last_uninstall: {
+          script_execution_id: "def",
+          uninstalled_at: lastUninstallDate,
+        },
+      }),
+      // installed_versions might still exist if inventory hasn't updated yet
+    });
+    expect(getUiStatus(sw, true, hostSoftwareUpdatedAt)).toBe(
+      "recently_uninstalled"
+    );
+  });
+
+  // Extra verification: recently_uninstalled takes precedence over update_available
+  it("does NOT return 'update_available' if status is null and recently uninstalled, even if update available", () => {
+    const now = new Date();
+    const lastUninstallDate = new Date(now.getTime() + 60 * 1000).toISOString();
+    const hostSoftwareUpdatedAt = now.toISOString();
+
+    // installed_versions has older version than installerVersion!
+    const sw = createMockHostSoftware({
+      status: null,
+      software_package: createMockHostSoftwarePackage({
+        version: "2.0.0",
+        last_uninstall: {
+          script_execution_id: "def",
+          uninstalled_at: lastUninstallDate,
+        },
+      }),
+    });
+    expect(getUiStatus(sw, true, hostSoftwareUpdatedAt)).toBe(
+      "recently_uninstalled"
+    );
+  });
+
+  // Extra negative case: If uninstalled, but not "recently" compared to inventory, falls back to "uninstalled"
+  it("returns 'uninstalled' if status is null, uninstall is older than inventory refresh", () => {
+    const now = new Date();
+    const lastUninstallDate = now.toISOString();
+    const hostSoftwareUpdatedAt = new Date(
+      now.getTime() + 60 * 1000
+    ).toISOString(); // Inventory more recent
+
+    const sw = createMockHostSoftware({
+      status: null,
+      software_package: createMockHostSoftwarePackage({
+        last_uninstall: {
+          script_execution_id: "def",
+          uninstalled_at: lastUninstallDate,
+        },
+      }),
+      installed_versions: [],
+    });
+    expect(getUiStatus(sw, true, hostSoftwareUpdatedAt)).toBe("uninstalled");
   });
 
   // Tarball packages (tgz_packages) are not tracked in software inventory

--- a/frontend/pages/hosts/details/cards/Software/helpers.tsx
+++ b/frontend/pages/hosts/details/cards/Software/helpers.tsx
@@ -247,10 +247,9 @@ export const getUiStatus = (
     if (!lastInstallDate) {
       return "update_available";
     }
-    const newerDate =
-      hostSoftwareUpdatedAt
-        ? getNewerDate(hostSoftwareUpdatedAt, lastInstallDate)
-        : lastInstallDate;
+    const newerDate = hostSoftwareUpdatedAt
+      ? getNewerDate(hostSoftwareUpdatedAt, lastInstallDate)
+      : lastInstallDate;
     return newerDate === lastInstallDate
       ? "recently_updated"
       : "update_available";

--- a/frontend/pages/hosts/details/cards/Software/helpers.tsx
+++ b/frontend/pages/hosts/details/cards/Software/helpers.tsx
@@ -248,7 +248,7 @@ export const getUiStatus = (
       return "update_available";
     }
     const newerDate =
-      hostSoftwareUpdatedAt && lastInstallDate
+      hostSoftwareUpdatedAt
         ? getNewerDate(hostSoftwareUpdatedAt, lastInstallDate)
         : lastInstallDate;
     return newerDate === lastInstallDate

--- a/frontend/pages/hosts/details/cards/Software/helpers.tsx
+++ b/frontend/pages/hosts/details/cards/Software/helpers.tsx
@@ -237,6 +237,14 @@ export const getUiStatus = (
       (iv) => compareVersions(iv.version, installerVersion) === -1
     )
   ) {
+    if (!lastInstallDate) {
+      return "update_available";
+    }
+
+    // Compares lastInstallDate and hostSoftwareUpdatedAt (inventory refresh)
+    // If lastInstallDate is more recent, it means the update was applied
+    // but the host's installed_versions info hasn't updated yet. In that case,
+    //  return 'updated' status in the UI. Otherwise, the update is still available.
     const newerDate =
       hostSoftwareUpdatedAt && lastInstallDate
         ? getNewerDate(hostSoftwareUpdatedAt, lastInstallDate)


### PR DESCRIPTION
## Issue
Closes #31629 

## Description 
- Added temporary "Updated" status requires a new UI status and to check refetch time stamps against `last_install` WITH updates available to ensure showing "Updated" instead of "Updates available'
- wrote tests
- Added temporary "Installed" status requires a new UI status and to check refetch time stamps against `last_install` to ensure "installed" vs. "whatever other status would show"
- wrote tests
- Added temporary "---" status requires a new UI status and to check refetch time stamps against `last_uninstall` to ensure "---" vs. "whatever other status would show"
- wrote tests
- Added tooltips to all 3 temporary statuses to ensure users know it's a temporary status "Fleet successfully [installed/uninstalled/updated] software and is fetching latest software inventory."

## Screenrecording of mini feature
It works!
https://fleetdm.zoom.us/clips/share/6EPbQs2_R4mqWaqbNpd1iQ
All 3 temporary statuses (watch in 2x)
https://fleetdm.zoom.us/clips/share/iRSdgb5HQ6uEJv3wkhmXtA

# Checklist for submitter

## Testing

- [x] Added/updated automated tests

- [x] QA'd all new/changed functionality manually
