### PR TITLE
Disable storybook steps in website-related GH workflows

### DIFF
--- a/.github/workflows/deploy-fleet-website.yml
+++ b/.github/workflows/deploy-fleet-website.yml
@@ -66,8 +66,9 @@ jobs:
       with:
         go-version-file: 'go.mod'
 
-    # Download top-level dependencies and build Storybook in the website's assets/ folder
-    - run: npm install --legacy-peer-deps && npm run build-storybook -- -o ./website/assets/storybook --loglevel verbose
+    # 2025-08-07: The Storybook steps in website workflows have been temporarily disabled until a compatability issue with the @storybook/test-runner has been resolved. See https://github.com/fleetdm/fleet/issues/31720 for more information.
+    # # Download top-level dependencies and build Storybook in the website's assets/ folder
+    # - run: npm install --legacy-peer-deps && npm run build-storybook -- -o ./website/assets/storybook --loglevel verbose
 
     # Now start building!
     # > …but first, get a little crazy for a sec and delete the top-level package.json file

--- a/.github/workflows/test-website.yml
+++ b/.github/workflows/test-website.yml
@@ -45,8 +45,9 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
 
-      # Download top-level dependencies and build Storybook in the website's assets/ folder.
-      - run: npm install --legacy-peer-deps && npm run build-storybook -- -o ./website/assets/storybook --loglevel verbose
+      # 2025-08-07: The Storybook steps in website workflows have been temporarily disabled until a compatability issue with the @storybook/test-runner has been resolved. See https://github.com/fleetdm/fleet/issues/31720 for more information.
+      # # Download top-level dependencies and build Storybook in the website's assets/ folder.
+      # - run: npm install --legacy-peer-deps && npm run build-storybook -- -o ./website/assets/storybook --loglevel verbose
 
       # Now start building!
       # > …but first, get a little crazy for a sec and delete the top-level package.json file


### PR DESCRIPTION
Related to: https://github.com/fleetdm/fleet/issues/31720

Changes:
- Commented out the step that builds Storybook in the "Test Fleet website" and "Deploy Fleet website" workflows. There is an error caused by an incompatible version of a Storybook dependency that is preventing these workflows from running.