### PR TITLE
Clear label membership when label platform changes.

### DIFF
--- a/changes/29596-labels-platform-change
+++ b/changes/29596-labels-platform-change
@@ -1,0 +1,1 @@
+Clear label membership when label platform changes (via GitOps).


### PR DESCRIPTION
Fixes #29596 

Related, new issue filed: https://github.com/fleetdm/fleet/issues/31727

# Checklist for submitter
- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.

## Testing

- [x] Added/updated automated tests
- [x] Where appropriate, [automated tests simulate multiple hosts and test for host isolation]
- [x] QA'd all new/changed functionality manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured that label memberships are cleared and recalculated when the platform associated with a label changes, maintaining accurate host-label associations.

* **Tests**
  * Added new tests to verify that label memberships are properly reset when a label's platform is updated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->