### PR TITLE
IB: Support IDP for OTA generation and association.

### DIFF
--- a/pkg/mdm/constants.go
+++ b/pkg/mdm/constants.go
@@ -1,0 +1,5 @@
+package mdm
+
+const (
+	BYODIdpCookieName = "__Host-FLEETBYODIDP"
+)

--- a/pkg/mdm/mdmtest/apple.go
+++ b/pkg/mdm/mdmtest/apple.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/fleetdm/fleet/v4/pkg/fleethttp"
+	sharedMdm "github.com/fleetdm/fleet/v4/pkg/mdm"
 	"github.com/fleetdm/fleet/v4/server/datastore/mysql"
 	"github.com/fleetdm/fleet/v4/server/fleet"
 	apple_mdm "github.com/fleetdm/fleet/v4/server/mdm/apple"
@@ -371,7 +372,7 @@ func (c *TestAppleMDMClient) fetchOTAProfile(url string) error {
 
 	if c.otaIdpUUID != "" {
 		request.AddCookie(&http.Cookie{
-			Name:  "__Host-FLEETBOYDIDP",
+			Name:  sharedMdm.BYODIdpCookieName,
 			Value: c.otaIdpUUID,
 		})
 	}

--- a/pkg/mdm/mdmtest/apple.go
+++ b/pkg/mdm/mdmtest/apple.go
@@ -22,7 +22,7 @@ import (
 	"time"
 
 	"github.com/fleetdm/fleet/v4/pkg/fleethttp"
-	sharedMdm "github.com/fleetdm/fleet/v4/pkg/mdm"
+	shared_mdm "github.com/fleetdm/fleet/v4/pkg/mdm"
 	"github.com/fleetdm/fleet/v4/server/datastore/mysql"
 	"github.com/fleetdm/fleet/v4/server/fleet"
 	apple_mdm "github.com/fleetdm/fleet/v4/server/mdm/apple"
@@ -372,7 +372,7 @@ func (c *TestAppleMDMClient) fetchOTAProfile(url string) error {
 
 	if c.otaIdpUUID != "" {
 		request.AddCookie(&http.Cookie{
-			Name:  sharedMdm.BYODIdpCookieName,
+			Name:  shared_mdm.BYODIdpCookieName,
 			Value: c.otaIdpUUID,
 		})
 	}

--- a/server/datastore/mysql/android.go
+++ b/server/datastore/mysql/android.go
@@ -43,7 +43,8 @@ func (ds *Datastore) NewAndroidHost(ctx context.Context, host *fleet.AndroidHost
 			hardware_model,
 			hardware_vendor,
 			detail_updated_at,
-			label_updated_at
+			label_updated_at,
+			uuid
 		) VALUES (
 			:node_key,
 			:hostname,
@@ -58,7 +59,8 @@ func (ds *Datastore) NewAndroidHost(ctx context.Context, host *fleet.AndroidHost
 			:hardware_model,
 			:hardware_vendor,
 			:detail_updated_at,
-			:label_updated_at
+			:label_updated_at,
+			:uuid
 		) ON DUPLICATE KEY UPDATE
 			hostname = VALUES(hostname),
 			computer_name = VALUES(computer_name),
@@ -72,7 +74,8 @@ func (ds *Datastore) NewAndroidHost(ctx context.Context, host *fleet.AndroidHost
 			hardware_model = VALUES(hardware_model),
 			hardware_vendor = VALUES(hardware_vendor),
 			detail_updated_at = VALUES(detail_updated_at),
-			label_updated_at = VALUES(label_updated_at)
+			label_updated_at = VALUES(label_updated_at),
+			uuid = VALUES(uuid)
 		`
 		result, err := sqlx.NamedExecContext(ctx, tx, stmt, map[string]interface{}{
 			"node_key":          host.NodeKey,
@@ -89,6 +92,7 @@ func (ds *Datastore) NewAndroidHost(ctx context.Context, host *fleet.AndroidHost
 			"hardware_vendor":   host.HardwareVendor,
 			"detail_updated_at": host.DetailUpdatedAt,
 			"label_updated_at":  host.LabelUpdatedAt,
+			"uuid":              host.UUID,
 		})
 		if err != nil {
 			return ctxerr.Wrap(ctx, err, "new Android host")

--- a/server/datastore/mysql/apple_mdm.go
+++ b/server/datastore/mysql/apple_mdm.go
@@ -1518,6 +1518,8 @@ type hostToCreateFromMDM struct {
 	// - contains "ipad" the platform is "ipados"
 	// - otherwise the platform is "darwin"
 	PlatformHint string
+	// Optional UUID to be set before authenticate mdm
+	UUID *string
 }
 
 func createHostFromMDMDB(
@@ -1580,6 +1582,28 @@ func createHostFromMDMDB(
 		parts = append(parts, "?")
 	}
 
+	var whenCases []string
+	var whenArgs []interface{}
+	updateUUIDHosts := map[string]string{}
+	for _, d := range devices {
+		if d.UUID != nil {
+			whenCases = append(whenCases, "WHEN hardware_serial = ? THEN ?")
+			whenArgs = append(whenArgs, d.HardwareSerial, d.UUID)
+			updateUUIDHosts[d.HardwareSerial] = *d.UUID
+		}
+	}
+
+	for serial := range updateUUIDHosts {
+		whenArgs = append(whenArgs, serial)
+	}
+
+	stmt = fmt.Sprintf(`
+UPDATE hosts
+SET uuid = CASE %s ELSE uuid END
+WHERE hardware_serial IN (%s)
+	`, strings.Join(whenCases, " "), strings.Repeat("?", len(updateUUIDHosts)))
+	_, err = tx.ExecContext(ctx, stmt, whenArgs...)
+
 	var hostsWithEnrolled []struct {
 		fleet.Host
 		Enrolled *bool `db:"enrolled"`
@@ -1591,7 +1615,8 @@ func createHostFromMDMDB(
 				h.hardware_model,
 				h.hardware_serial,
 				h.hostname,
-				COALESCE(hmdm.enrolled, 0) as enrolled
+				COALESCE(hmdm.enrolled, 0) as enrolled,
+				h.uuid
 			FROM hosts h
 			LEFT JOIN host_mdm hmdm ON hmdm.host_id = h.id
 			WHERE h.hardware_serial IN(%s)`,
@@ -1647,6 +1672,7 @@ func createHostFromMDMDB(
 func (ds *Datastore) IngestMDMAppleDeviceFromOTAEnrollment(
 	ctx context.Context,
 	teamID *uint,
+	idpUUID string,
 	deviceInfo fleet.MDMAppleMachineInfo,
 ) error {
 	return ds.withRetryTxx(ctx, func(tx sqlx.ExtContext) error {
@@ -1655,9 +1681,19 @@ func (ds *Datastore) IngestMDMAppleDeviceFromOTAEnrollment(
 				HardwareSerial: deviceInfo.Serial,
 				PlatformHint:   deviceInfo.Product,
 				HardwareModel:  deviceInfo.Product,
+				UUID:           &deviceInfo.UDID,
 			},
 		}
-		_, _, err := createHostFromMDMDB(ctx, tx, ds.logger, toInsert, false, teamID, teamID, teamID)
+		_, hosts, err := createHostFromMDMDB(ctx, tx, ds.logger, toInsert, false, teamID, teamID, teamID)
+		if idpUUID != "" {
+			host := hosts[0]
+			level.Info(ds.logger).Log("msg", fmt.Sprintf("associating host %s with idp account %s", host.UUID, idpUUID))
+			err = associateHostMDMIdPAccountDB(ctx, tx, host.UUID, idpUUID)
+			if err != nil {
+				return ctxerr.Wrap(ctx, err, "associating host with idp account")
+			}
+		}
+
 		return ctxerr.Wrap(ctx, err, "creating host from OTA enrollment")
 	})
 }

--- a/server/datastore/mysql/apple_mdm_test.go
+++ b/server/datastore/mysql/apple_mdm_test.go
@@ -7498,7 +7498,7 @@ func testIngestMDMAppleDeviceFromOTAEnrollment(t *testing.T, ds *Datastore) {
 	wantSerials = append(wantSerials, "abc", "xyz", "ijk", "tuv")
 
 	for _, d := range otaDevices {
-		err := ds.IngestMDMAppleDeviceFromOTAEnrollment(ctx, nil, d)
+		err := ds.IngestMDMAppleDeviceFromOTAEnrollment(ctx, nil, "", d)
 		require.NoError(t, err)
 	}
 

--- a/server/fleet/datastore.go
+++ b/server/fleet/datastore.go
@@ -2273,6 +2273,7 @@ type AndroidDatastore interface {
 	UpdateAndroidHost(ctx context.Context, host *AndroidHost, fromEnroll bool) error
 	UserOrDeletedUserByID(ctx context.Context, id uint) (*User, error)
 	VerifyEnrollSecret(ctx context.Context, secret string) (*EnrollSecret, error)
+	AssociateHostMDMIdPAccount(ctx context.Context, hostUUID, idpAcctUUID string) error
 }
 
 // MDMAppleStore wraps nanomdm's storage and adds methods to deal with

--- a/server/fleet/datastore.go
+++ b/server/fleet/datastore.go
@@ -1236,7 +1236,7 @@ type Datastore interface {
 
 	// IngestMDMAppleDeviceFromOTAEnrollment creates new host records for
 	// MDM-enrolled devices via OTA that are not already enrolled in Fleet.
-	IngestMDMAppleDeviceFromOTAEnrollment(ctx context.Context, teamID *uint, deviceInfo MDMAppleMachineInfo) error
+	IngestMDMAppleDeviceFromOTAEnrollment(ctx context.Context, teamID *uint, idpUUID string, deviceInfo MDMAppleMachineInfo) error
 
 	// MDMAppleUpsertHost creates or matches a Fleet host record for an
 	// MDM-enrolled device.

--- a/server/fleet/datastore.go
+++ b/server/fleet/datastore.go
@@ -2273,6 +2273,7 @@ type AndroidDatastore interface {
 	UpdateAndroidHost(ctx context.Context, host *AndroidHost, fromEnroll bool) error
 	UserOrDeletedUserByID(ctx context.Context, id uint) (*User, error)
 	VerifyEnrollSecret(ctx context.Context, secret string) (*EnrollSecret, error)
+	GetMDMIdPAccountByUUID(ctx context.Context, uuid string) (*MDMIdPAccount, error)
 	AssociateHostMDMIdPAccount(ctx context.Context, hostUUID, idpAcctUUID string) error
 }
 

--- a/server/fleet/service.go
+++ b/server/fleet/service.go
@@ -730,7 +730,7 @@ type Service interface {
 	// number and hardware uuid to perform operations before the host even
 	// enrolls in MDM. Currently, this method creates a host records and
 	// assigns a pre-defined team (based on the enrollSecret provided) to
-	// the host, and associates the host if boyd idp was enabled.
+	// the host, and associates the host if byod idp was enabled.
 	//
 	// [1]: https://developer.apple.com/library/archive/documentation/NetworkingInternet/Conceptual/iPhoneOTAConfiguration/Introduction/Introduction.html#//apple_ref/doc/uid/TP40009505-CH1-SW1
 	MDMAppleProcessOTAEnrollment(ctx context.Context, certificates []*x509.Certificate, rootSigner *x509.Certificate, enrollSecret, idpUUID string, deviceInfo MDMAppleMachineInfo) ([]byte, error)
@@ -1024,7 +1024,7 @@ type Service interface {
 	CheckMDMAppleEnrollmentWithMinimumOSVersion(ctx context.Context, m *MDMAppleMachineInfo) (*MDMAppleSoftwareUpdateRequired, error)
 
 	// GetOTAProfile gets the OTA (over-the-air) profile for a given team based on the enroll secret provided.
-	GetOTAProfile(ctx context.Context, enrollSecret, boydIdpUUID string) ([]byte, error)
+	GetOTAProfile(ctx context.Context, enrollSecret, idpUUID string) ([]byte, error)
 
 	///////////////////////////////////////////////////////////////////////////////
 	// CronSchedulesService

--- a/server/fleet/service.go
+++ b/server/fleet/service.go
@@ -730,10 +730,10 @@ type Service interface {
 	// number and hardware uuid to perform operations before the host even
 	// enrolls in MDM. Currently, this method creates a host records and
 	// assigns a pre-defined team (based on the enrollSecret provided) to
-	// the host.
+	// the host, and associates the host if boyd idp was enabled.
 	//
 	// [1]: https://developer.apple.com/library/archive/documentation/NetworkingInternet/Conceptual/iPhoneOTAConfiguration/Introduction/Introduction.html#//apple_ref/doc/uid/TP40009505-CH1-SW1
-	MDMAppleProcessOTAEnrollment(ctx context.Context, certificates []*x509.Certificate, rootSigner *x509.Certificate, enrollSecret string, deviceInfo MDMAppleMachineInfo) ([]byte, error)
+	MDMAppleProcessOTAEnrollment(ctx context.Context, certificates []*x509.Certificate, rootSigner *x509.Certificate, enrollSecret, idpUUID string, deviceInfo MDMAppleMachineInfo) ([]byte, error)
 
 	// /////////////////////////////////////////////////////////////////////////////
 	// Vulnerabilities
@@ -1024,7 +1024,7 @@ type Service interface {
 	CheckMDMAppleEnrollmentWithMinimumOSVersion(ctx context.Context, m *MDMAppleMachineInfo) (*MDMAppleSoftwareUpdateRequired, error)
 
 	// GetOTAProfile gets the OTA (over-the-air) profile for a given team based on the enroll secret provided.
-	GetOTAProfile(ctx context.Context, enrollSecret string) ([]byte, error)
+	GetOTAProfile(ctx context.Context, enrollSecret, boydIdpUUID string) ([]byte, error)
 
 	///////////////////////////////////////////////////////////////////////////////
 	// CronSchedulesService

--- a/server/mdm/android/service.go
+++ b/server/mdm/android/service.go
@@ -12,7 +12,7 @@ type Service interface {
 	EnterpriseSignupSSE(ctx context.Context) (chan string, error)
 
 	// CreateEnrollmentToken creates an enrollment token for a new Android device.
-	CreateEnrollmentToken(ctx context.Context, enrollSecret string) (*EnrollmentToken, error)
+	CreateEnrollmentToken(ctx context.Context, enrollSecret, idpUUID string) (*EnrollmentToken, error)
 	ProcessPubSubPush(ctx context.Context, token string, message *PubSubMessage) error
 }
 

--- a/server/mdm/android/service.go
+++ b/server/mdm/android/service.go
@@ -34,3 +34,8 @@ type EnterpriseSignupResponse struct {
 	Url string `json:"android_enterprise_signup_url"`
 	DefaultResponse
 }
+
+type EnrollmentTokenResponse struct {
+	*EnrollmentToken
+	DefaultResponse
+}

--- a/server/mdm/android/service/enterprises_test.go
+++ b/server/mdm/android/service/enterprises_test.go
@@ -104,7 +104,6 @@ func TestEnterprisesAuth(t *testing.T) {
 			defer cancel()
 			_, err = svc.EnterpriseSignupSSE(ctx)
 			checkAuthErr(t, tt.shouldFailRead, err)
-
 		})
 	}
 
@@ -127,7 +126,7 @@ func checkAuthErr(t *testing.T, shouldFail bool, err error) {
 	}
 }
 
-func InitCommonDSMocks() fleet.AndroidDatastore {
+func InitCommonDSMocks() *AndroidMockDS {
 	ds := AndroidMockDS{}
 	ds.Datastore.InitCommonMocks()
 
@@ -141,7 +140,8 @@ func InitCommonDSMocks() fleet.AndroidDatastore {
 		return &fleet.User{ID: id}, nil
 	}
 	ds.Store.GetAllMDMConfigAssetsByNameFunc = func(ctx context.Context, assetNames []fleet.MDMAssetName,
-		queryerContext sqlx.QueryerContext) (map[fleet.MDMAssetName]fleet.MDMConfigAsset, error) {
+		queryerContext sqlx.QueryerContext,
+	) (map[fleet.MDMAssetName]fleet.MDMConfigAsset, error) {
 		result := make(map[fleet.MDMAssetName]fleet.MDMConfigAsset, len(assetNames))
 		for _, name := range assetNames {
 			result[name] = fleet.MDMConfigAsset{Value: []byte("value")}

--- a/server/mdm/android/service/handler.go
+++ b/server/mdm/android/service/handler.go
@@ -17,7 +17,6 @@ func GetRoutes(fleetSvc fleet.Service, svc android.Service) endpoint_utils.Handl
 const pubSubPushPath = "/api/v1/fleet/android_enterprise/pubsub"
 
 func attachFleetAPIRoutes(r *mux.Router, fleetSvc fleet.Service, svc android.Service, opts []kithttp.ServerOption) {
-
 	// //////////////////////////////////////////
 	// User-authenticated endpoints
 	ue := newUserAuthenticatedEndpointer(fleetSvc, svc, opts, r, apiVersions()...)
@@ -35,7 +34,6 @@ func attachFleetAPIRoutes(r *mux.Router, fleetSvc fleet.Service, svc android.Ser
 	ne.GET("/api/_version_/fleet/android_enterprise/connect/{token}", enterpriseSignupCallbackEndpoint, enterpriseSignupCallbackRequest{})
 	ne.GET("/api/_version_/fleet/android_enterprise/enrollment_token", enrollmentTokenEndpoint, enrollmentTokenRequest{})
 	ne.POST(pubSubPushPath, pubSubPushEndpoint, pubSubPushRequest{})
-
 }
 
 func apiVersions() []string {

--- a/server/mdm/android/service/pubsub.go
+++ b/server/mdm/android/service/pubsub.go
@@ -287,13 +287,6 @@ func (svc *Service) addNewHost(ctx context.Context, device *androidmanagement.De
 		return ctxerr.Wrap(ctx, err, "verifying enroll secret")
 	}
 
-	if enrollmentTokenRequest.IdpUUID != "" {
-		_, err := svc.ds.GetMDMIdPAccountByUUID(ctx, enrollmentTokenRequest.IdpUUID)
-		if err != nil {
-			return ctxerr.Wrap(ctx, err, "validating idp account existence")
-		}
-	}
-
 	deviceID, err := svc.getDeviceID(ctx, device)
 	if err != nil {
 		return ctxerr.Wrap(ctx, err, "getting device ID")

--- a/server/mdm/android/service/pubsub.go
+++ b/server/mdm/android/service/pubsub.go
@@ -287,6 +287,13 @@ func (svc *Service) addNewHost(ctx context.Context, device *androidmanagement.De
 		return ctxerr.Wrap(ctx, err, "verifying enroll secret")
 	}
 
+	if enrollmentTokenRequest.IdpUUID != "" {
+		_, err := svc.ds.GetMDMIdPAccountByUUID(ctx, enrollmentTokenRequest.IdpUUID)
+		if err != nil {
+			return ctxerr.Wrap(ctx, err, "validating idp account existence")
+		}
+	}
+
 	deviceID, err := svc.getDeviceID(ctx, device)
 	if err != nil {
 		return ctxerr.Wrap(ctx, err, "getting device ID")

--- a/server/mdm/android/service/pubsub_test.go
+++ b/server/mdm/android/service/pubsub_test.go
@@ -1,0 +1,227 @@
+package service
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/fleetdm/fleet/v4/server/datastore/mysql/common_mysql"
+	"github.com/fleetdm/fleet/v4/server/fleet"
+	"github.com/fleetdm/fleet/v4/server/mdm/android"
+	android_mock "github.com/fleetdm/fleet/v4/server/mdm/android/mock"
+	kitlog "github.com/go-kit/log"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/api/androidmanagement/v1"
+)
+
+func createAndroidService(t *testing.T) (android.Service, *AndroidMockDS) {
+	androidAPIClient := android_mock.Client{}
+	androidAPIClient.InitCommonMocks()
+	logger := kitlog.NewLogfmtLogger(os.Stdout)
+	mockDS := InitCommonDSMocks()
+	fleetSvc := mockService{}
+	svc, err := NewServiceWithClient(logger, mockDS, &androidAPIClient, &fleetSvc)
+	require.NoError(t, err)
+
+	return svc, mockDS
+}
+
+func TestPubSubEnrollment(t *testing.T) {
+	svc, mockDS := createAndroidService(t)
+
+	globalSecret := "global"
+	teamSecret := "team"
+	teamID := uint(1)
+
+	mockDS.VerifyEnrollSecretFunc = func(ctx context.Context, secret string) (*fleet.EnrollSecret, error) {
+		switch secret {
+		case globalSecret:
+			return &fleet.EnrollSecret{
+				Secret: globalSecret,
+				TeamID: nil,
+			}, nil
+		case teamSecret:
+			return &fleet.EnrollSecret{
+				Secret: teamSecret,
+				TeamID: &teamID, // Remember to create the team in each test that uses it.
+			}, nil
+		}
+
+		return nil, common_mysql.NotFound("enroll secret")
+	}
+
+	mockDS.AndroidHostLiteFunc = func(ctx context.Context, enterpriseSpecificID string) (*fleet.AndroidHost, error) {
+		return nil, common_mysql.NotFound("android host lite mock")
+	}
+
+	t.Run("errors", func(t *testing.T) {
+		t.Run("if android mdm is not configured", func(t *testing.T) {
+			mockDS.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {
+				return &fleet.AppConfig{
+					MDM: fleet.MDM{
+						AndroidEnabledAndConfigured: false,
+					},
+				}, nil
+			}
+
+			enrollmentToken := enrollmentTokenRequest{
+				EnrollSecret: "invalid",
+			}
+			enrollTokenData, err := json.Marshal(enrollmentToken)
+			require.NoError(t, err)
+			enrollmentMessage := createEnrollmentMessage(t, androidmanagement.Device{
+				Name:                createAndroidDeviceId("test-android"),
+				EnrollmentTokenData: string(enrollTokenData),
+			})
+			err = svc.ProcessPubSubPush(context.Background(), "invalid", enrollmentMessage)
+			require.Error(t, err)
+			require.Equal(t, "validation failed: android Android MDM is NOT configured", err.Error())
+		})
+
+		t.Run("if android token is invalid", func(t *testing.T) {
+			mockDS.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {
+				return &fleet.AppConfig{
+					MDM: fleet.MDM{
+						AndroidEnabledAndConfigured: true,
+					},
+				}, nil
+			}
+
+			enrollmentToken := enrollmentTokenRequest{
+				EnrollSecret: "invalid",
+			}
+			enrollTokenData, err := json.Marshal(enrollmentToken)
+			require.NoError(t, err)
+			enrollmentMessage := createEnrollmentMessage(t, androidmanagement.Device{
+				Name:                createAndroidDeviceId("test-android"),
+				EnrollmentTokenData: string(enrollTokenData),
+			})
+			err = svc.ProcessPubSubPush(context.Background(), "invalid", enrollmentMessage)
+			require.Error(t, err)
+			require.Equal(t, "Authentication failed", err.Error())
+		})
+
+		t.Run("if enroll secret is invalid", func(t *testing.T) {
+			mockDS.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {
+				return &fleet.AppConfig{
+					MDM: fleet.MDM{
+						AndroidEnabledAndConfigured: true,
+					},
+				}, nil
+			}
+
+			enrollmentToken := enrollmentTokenRequest{
+				EnrollSecret: "invalid",
+			}
+			enrollTokenData, err := json.Marshal(enrollmentToken)
+			require.NoError(t, err)
+			enrollmentMessage := createEnrollmentMessage(t, androidmanagement.Device{
+				Name:                createAndroidDeviceId("test-android"),
+				EnrollmentTokenData: string(enrollTokenData),
+			})
+			err = svc.ProcessPubSubPush(context.Background(), "value", enrollmentMessage)
+			require.Error(t, err)
+		})
+	})
+
+	t.Run("successfully enrolls", func(t *testing.T) {
+		t.Run("device into a team with valid enroll secret", func(t *testing.T) {
+			mockDS.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {
+				return &fleet.AppConfig{
+					MDM: fleet.MDM{
+						AndroidEnabledAndConfigured: true,
+					},
+				}, nil
+			}
+
+			mockDS.NewAndroidHostFunc = func(ctx context.Context, host *fleet.AndroidHost) (*fleet.AndroidHost, error) {
+				return nil, nil // We do not care about return value here
+			}
+
+			enrollmentToken := enrollmentTokenRequest{
+				EnrollSecret: "global",
+			}
+			enrollTokenData, err := json.Marshal(enrollmentToken)
+			require.NoError(t, err)
+			enrollmentMessage := createEnrollmentMessage(t, androidmanagement.Device{
+				Name:                createAndroidDeviceId("test-android"),
+				EnrollmentTokenData: string(enrollTokenData),
+			})
+			err = svc.ProcessPubSubPush(context.Background(), "value", enrollmentMessage)
+			require.NoError(t, err)
+
+			require.False(t, mockDS.AssociateHostMDMIdPAccountFuncInvoked)
+			require.True(t, mockDS.NewAndroidHostFuncInvoked)
+		})
+
+		t.Run("device into a team and associates idp if byod idp id is set", func(t *testing.T) {
+			mockDS.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {
+				return &fleet.AppConfig{
+					MDM: fleet.MDM{
+						AndroidEnabledAndConfigured: true,
+					},
+				}, nil
+			}
+
+			mockDS.NewAndroidHostFunc = func(ctx context.Context, host *fleet.AndroidHost) (*fleet.AndroidHost, error) {
+				return nil, nil // We do not care about return value here
+			}
+			mockDS.AssociateHostMDMIdPAccountFunc = func(ctx context.Context, hostUUID, accountUUID string) error {
+				return nil
+			}
+
+			enrollmentToken := enrollmentTokenRequest{
+				EnrollSecret: "global",
+				IdpUUID:      "mock-id",
+			}
+			enrollTokenData, err := json.Marshal(enrollmentToken)
+			require.NoError(t, err)
+			enrollmentMessage := createEnrollmentMessage(t, androidmanagement.Device{
+				Name:                createAndroidDeviceId("test-android"),
+				EnrollmentTokenData: string(enrollTokenData),
+			})
+			err = svc.ProcessPubSubPush(context.Background(), "value", enrollmentMessage)
+			require.NoError(t, err)
+
+			require.True(t, mockDS.AssociateHostMDMIdPAccountFuncInvoked)
+			require.True(t, mockDS.NewAndroidHostFuncInvoked)
+		})
+	})
+}
+
+func createEnrollmentMessage(t *testing.T, deviceInfo androidmanagement.Device) *android.PubSubMessage {
+	deviceInfo.HardwareInfo = &androidmanagement.HardwareInfo{
+		EnterpriseSpecificId: strings.ToUpper(uuid.New().String()),
+		Brand:                "TestBrand",
+		Model:                "TestModel",
+		SerialNumber:         "test-serial",
+		Hardware:             "test-hardware",
+	}
+	deviceInfo.SoftwareInfo = &androidmanagement.SoftwareInfo{
+		AndroidBuildNumber: "test-build",
+		AndroidVersion:     "1",
+	}
+	deviceInfo.MemoryInfo = &androidmanagement.MemoryInfo{
+		TotalRam: 1000,
+	}
+
+	data, err := json.Marshal(deviceInfo)
+	require.NoError(t, err)
+
+	encodedData := base64.StdEncoding.EncodeToString(data)
+
+	return &android.PubSubMessage{
+		Attributes: map[string]string{
+			"notificationType": string(android.PubSubEnrollment),
+		},
+		Data: encodedData,
+	}
+}
+
+func createAndroidDeviceId(name string) string {
+	return "enterprises/mock-enterprise-id/devices/" + name
+}

--- a/server/mdm/android/service/pubsub_test.go
+++ b/server/mdm/android/service/pubsub_test.go
@@ -126,42 +126,9 @@ func TestPubSubEnrollment(t *testing.T) {
 			err = svc.ProcessPubSubPush(context.Background(), "value", enrollmentMessage)
 			require.Error(t, err)
 		})
-
-		t.Run("idp uuid does not match any account", func(t *testing.T) {
-			mockDS.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {
-				return &fleet.AppConfig{
-					MDM: fleet.MDM{
-						AndroidEnabledAndConfigured: true,
-					},
-				}, nil
-			}
-			mockDS.GetMDMIdPAccountByUUIDFunc = func(ctx context.Context, uuid string) (*fleet.MDMIdPAccount, error) {
-				return nil, common_mysql.NotFound("mdm idp account")
-			}
-
-			enrollmentToken := enrollmentTokenRequest{
-				EnrollSecret: "global",
-				IdpUUID:      uuid.NewString(),
-			}
-			enrollTokenData, err := json.Marshal(enrollmentToken)
-			require.NoError(t, err)
-			enrollmentMessage := createEnrollmentMessage(t, androidmanagement.Device{
-				Name:                createAndroidDeviceId("test-android"),
-				EnrollmentTokenData: string(enrollTokenData),
-			})
-			err = svc.ProcessPubSubPush(context.Background(), "value", enrollmentMessage)
-			require.Error(t, err)
-
-			require.True(t, mockDS.GetMDMIdPAccountByUUIDFuncInvoked)
-			mockDS.GetMDMIdPAccountByUUIDFuncInvoked = false
-		})
 	})
 
 	t.Run("successfully enrolls", func(t *testing.T) {
-		mockDS.GetMDMIdPAccountByUUIDFunc = func(ctx context.Context, uuid string) (*fleet.MDMIdPAccount, error) {
-			return nil, nil
-		}
-
 		t.Run("device into a team with valid enroll secret", func(t *testing.T) {
 			mockDS.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {
 				return &fleet.AppConfig{
@@ -187,13 +154,8 @@ func TestPubSubEnrollment(t *testing.T) {
 			err = svc.ProcessPubSubPush(context.Background(), "value", enrollmentMessage)
 			require.NoError(t, err)
 
-			require.True(t, mockDS.NewAndroidHostFuncInvoked)
-			require.False(t, mockDS.GetMDMIdPAccountByUUIDFuncInvoked)
 			require.False(t, mockDS.AssociateHostMDMIdPAccountFuncInvoked)
-
-			mockDS.GetMDMIdPAccountByUUIDFuncInvoked = false
-			mockDS.NewAndroidHostFuncInvoked = false
-			mockDS.AssociateHostMDMIdPAccountFuncInvoked = false
+			require.True(t, mockDS.NewAndroidHostFuncInvoked)
 		})
 
 		t.Run("device into a team and associates idp if byod idp id is set", func(t *testing.T) {
@@ -225,13 +187,8 @@ func TestPubSubEnrollment(t *testing.T) {
 			err = svc.ProcessPubSubPush(context.Background(), "value", enrollmentMessage)
 			require.NoError(t, err)
 
-			require.True(t, mockDS.GetMDMIdPAccountByUUIDFuncInvoked)
 			require.True(t, mockDS.AssociateHostMDMIdPAccountFuncInvoked)
 			require.True(t, mockDS.NewAndroidHostFuncInvoked)
-
-			mockDS.GetMDMIdPAccountByUUIDFuncInvoked = false
-			mockDS.NewAndroidHostFuncInvoked = false
-			mockDS.AssociateHostMDMIdPAccountFuncInvoked = false
 		})
 	})
 }

--- a/server/mdm/android/service/service.go
+++ b/server/mdm/android/service/service.go
@@ -410,11 +410,6 @@ type enrollmentTokenRequest struct {
 	IdpUUID      string // The UUID of the mdm_idp_account that was used if any, can be empty, will be taken from cookies
 }
 
-type enrollmentTokenResponse struct {
-	*android.EnrollmentToken
-	android.DefaultResponse
-}
-
 func (enrollmentTokenRequest) DecodeRequest(ctx context.Context, r *http.Request) (interface{}, error) {
 	enrollSecret := r.URL.Query().Get("enroll_secret")
 	if enrollSecret == "" {
@@ -459,7 +454,7 @@ func enrollmentTokenEndpoint(ctx context.Context, request interface{}, svc andro
 	if err != nil {
 		return android.DefaultResponse{Err: err}
 	}
-	return enrollmentTokenResponse{EnrollmentToken: token}
+	return android.EnrollmentTokenResponse{EnrollmentToken: token}
 }
 
 func (svc *Service) CreateEnrollmentToken(ctx context.Context, enrollSecret, idpUUID string) (*android.EnrollmentToken, error) {

--- a/server/mdm/android/service/service.go
+++ b/server/mdm/android/service/service.go
@@ -475,6 +475,15 @@ func (svc *Service) CreateEnrollmentToken(ctx context.Context, enrollSecret, idp
 		return nil, ctxerr.Wrap(ctx, err, "verifying enroll secret")
 	}
 
+	if idpUUID != "" {
+		_, err := svc.ds.GetMDMIdPAccountByUUID(ctx, idpUUID)
+		if err != nil {
+			iae := &fleet.InvalidArgumentError{}
+			iae.Append("IDP UUID", "Failed validating IDP account existence")
+			return nil, ctxerr.Wrap(ctx, iae)
+		}
+	}
+
 	enterprise, err := svc.ds.GetEnterprise(ctx)
 	if err != nil {
 		return nil, ctxerr.Wrap(ctx, err, "getting enterprise")

--- a/server/mdm/android/service/service.go
+++ b/server/mdm/android/service/service.go
@@ -3,6 +3,7 @@ package service
 import (
 	"context"
 	_ "embed"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -10,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/fleetdm/fleet/v4/pkg/mdm"
 	"github.com/fleetdm/fleet/v4/server"
 	"github.com/fleetdm/fleet/v4/server/authz"
 	"github.com/fleetdm/fleet/v4/server/contexts/ctxerr"
@@ -405,6 +407,7 @@ func (svc *Service) DeleteEnterprise(ctx context.Context) error {
 
 type enrollmentTokenRequest struct {
 	EnrollSecret string `query:"enroll_secret"`
+	IdpUUID      string // The UUID of the mdm_idp_account that was used if any, can be empty, will be taken from cookies
 }
 
 type enrollmentTokenResponse struct {
@@ -412,16 +415,54 @@ type enrollmentTokenResponse struct {
 	android.DefaultResponse
 }
 
+func (enrollmentTokenRequest) DecodeRequest(ctx context.Context, r *http.Request) (interface{}, error) {
+	enrollSecret := r.URL.Query().Get("enroll_secret")
+	if enrollSecret == "" {
+		return nil, &fleet.BadRequestError{
+			Message: "enroll_secret is required",
+		}
+	}
+
+	byodIdpCookie, err := r.Cookie(mdm.BYODIdpCookieName)
+
+	if err == http.ErrNoCookie {
+		// We do not fail here if no cookie is found, we validate later down the line if it's required
+		return &enrollmentTokenRequest{
+			EnrollSecret: enrollSecret,
+			IdpUUID:      "",
+		}, nil
+	}
+
+	if err != nil {
+		return nil, &fleet.BadRequestError{
+			Message:     "something went wrong parsing the boyd idp cookie",
+			InternalErr: err,
+		}
+	}
+
+	if err = byodIdpCookie.Valid(); err != nil {
+		return nil, &fleet.BadRequestError{
+			Message:     "boyd idp cookie is not valid",
+			InternalErr: err,
+		}
+	}
+
+	return &enrollmentTokenRequest{
+		EnrollSecret: enrollSecret,
+		IdpUUID:      byodIdpCookie.Value,
+	}, nil
+}
+
 func enrollmentTokenEndpoint(ctx context.Context, request interface{}, svc android.Service) fleet.Errorer {
 	req := request.(*enrollmentTokenRequest)
-	token, err := svc.CreateEnrollmentToken(ctx, req.EnrollSecret)
+	token, err := svc.CreateEnrollmentToken(ctx, req.EnrollSecret, req.IdpUUID)
 	if err != nil {
 		return android.DefaultResponse{Err: err}
 	}
 	return enrollmentTokenResponse{EnrollmentToken: token}
 }
 
-func (svc *Service) CreateEnrollmentToken(ctx context.Context, enrollSecret string) (*android.EnrollmentToken, error) {
+func (svc *Service) CreateEnrollmentToken(ctx context.Context, enrollSecret, idpUUID string) (*android.EnrollmentToken, error) {
 	// Authorization is done by VerifyEnrollSecret below.
 	// We call SkipAuthorization here to avoid explicitly calling it when errors occur.
 	svc.authz.SkipAuthorization(ctx)
@@ -450,10 +491,18 @@ func (svc *Service) CreateEnrollmentToken(ctx context.Context, enrollSecret stri
 	}
 	_ = svc.androidAPIClient.SetAuthenticationSecret(secret)
 
+	enrollmentTokenRequest, err := json.Marshal(enrollmentTokenRequest{
+		EnrollSecret: enrollSecret,
+		IdpUUID:      idpUUID,
+	})
+	if err != nil {
+		return nil, ctxerr.Wrap(ctx, err, "marshalling enrollment token request")
+	}
+
 	token := &androidmanagement.EnrollmentToken{
 		// Default duration is 1 hour
 
-		AdditionalData:     enrollSecret,
+		AdditionalData:     string(enrollmentTokenRequest),
 		AllowPersonalUsage: "PERSONAL_USAGE_ALLOWED",
 		PolicyName:         fmt.Sprintf("%s/policies/%d", enterprise.Name(), +defaultAndroidPolicyID),
 		OneTimeOnly:        true,

--- a/server/mdm/android/tests/testing_utils.go
+++ b/server/mdm/android/tests/testing_utils.go
@@ -90,7 +90,8 @@ func (ts *WithServer) CreateCommonDSMocks() {
 		return &fleet.User{ID: id}, nil
 	}
 	ts.DS.GetAllMDMConfigAssetsByNameFunc = func(ctx context.Context, assetNames []fleet.MDMAssetName,
-		queryerContext sqlx.QueryerContext) (map[fleet.MDMAssetName]fleet.MDMConfigAsset, error) {
+		queryerContext sqlx.QueryerContext,
+	) (map[fleet.MDMAssetName]fleet.MDMConfigAsset, error) {
 		result := make(map[fleet.MDMAssetName]fleet.MDMConfigAsset, len(assetNames))
 		for _, name := range assetNames {
 			result[name] = fleet.MDMConfigAsset{Value: []byte("value")}
@@ -155,7 +156,6 @@ func (m *mockService) NewActivity(ctx context.Context, user *fleet.User, details
 }
 
 func runServerForTests(t *testing.T, logger kitlog.Logger, fleetSvc fleet.Service, androidSvc android.Service) *httptest.Server {
-
 	fleetAPIOptions := []kithttp.ServerOption{
 		kithttp.ServerBefore(
 			kithttp.PopulateRequestContext,

--- a/server/mdm/apple/apple_mdm.go
+++ b/server/mdm/apple/apple_mdm.go
@@ -1452,7 +1452,7 @@ func IOSiPadOSRefetch(ctx context.Context, ds fleet.Datastore, commander *MDMApp
 	return nil
 }
 
-func GenerateOTAEnrollmentProfileMobileconfig(orgName, fleetURL, enrollSecret string) ([]byte, error) {
+func GenerateOTAEnrollmentProfileMobileconfig(orgName, fleetURL, enrollSecret, boydIdpUUID string) ([]byte, error) {
 	path, err := url.JoinPath(fleetURL, "/api/v1/fleet/ota_enrollment")
 	if err != nil {
 		return nil, fmt.Errorf("creating path for ota enrollment url: %w", err)
@@ -1465,7 +1465,10 @@ func GenerateOTAEnrollmentProfileMobileconfig(orgName, fleetURL, enrollSecret st
 
 	q := enrollURL.Query()
 	q.Set("enroll_secret", enrollSecret)
-	enrollURL.RawQuery = q.Encode()
+	if boydIdpUUID != "" {
+		q.Set("idp_uuid", boydIdpUUID)
+	}
+	enrollURL.RawQuery = strings.ReplaceAll(q.Encode(), "&", "&amp;") // Only encode & in URL to escape it in XML
 
 	var profileBuf bytes.Buffer
 	tmplArgs := struct {

--- a/server/mdm/apple/apple_mdm.go
+++ b/server/mdm/apple/apple_mdm.go
@@ -1452,7 +1452,7 @@ func IOSiPadOSRefetch(ctx context.Context, ds fleet.Datastore, commander *MDMApp
 	return nil
 }
 
-func GenerateOTAEnrollmentProfileMobileconfig(orgName, fleetURL, enrollSecret, boydIdpUUID string) ([]byte, error) {
+func GenerateOTAEnrollmentProfileMobileconfig(orgName, fleetURL, enrollSecret, idpUUID string) ([]byte, error) {
 	path, err := url.JoinPath(fleetURL, "/api/v1/fleet/ota_enrollment")
 	if err != nil {
 		return nil, fmt.Errorf("creating path for ota enrollment url: %w", err)
@@ -1465,8 +1465,8 @@ func GenerateOTAEnrollmentProfileMobileconfig(orgName, fleetURL, enrollSecret, b
 
 	q := enrollURL.Query()
 	q.Set("enroll_secret", enrollSecret)
-	if boydIdpUUID != "" {
-		q.Set("idp_uuid", boydIdpUUID)
+	if idpUUID != "" {
+		q.Set("idp_uuid", idpUUID)
 	}
 	enrollURL.RawQuery = strings.ReplaceAll(q.Encode(), "&", "&amp;") // Only encode & in URL to escape it in XML
 

--- a/server/mdm/apple/apple_mdm.go
+++ b/server/mdm/apple/apple_mdm.go
@@ -1468,7 +1468,7 @@ func GenerateOTAEnrollmentProfileMobileconfig(orgName, fleetURL, enrollSecret, i
 	if idpUUID != "" {
 		q.Set("idp_uuid", idpUUID)
 	}
-	enrollURL.RawQuery = strings.ReplaceAll(q.Encode(), "&", "&amp;") // Only encode & in URL to escape it in XML
+	enrollURL.RawQuery = q.Encode()
 
 	var profileBuf bytes.Buffer
 	tmplArgs := struct {

--- a/server/mdm/apple/mobileconfig/profiles.go
+++ b/server/mdm/apple/mobileconfig/profiles.go
@@ -123,7 +123,7 @@ var OTAMobileConfigTemplate = template.Must(template.New("").Funcs(funcMap).Opti
     <key>PayloadContent</key>
     <dict>
       <key>URL</key>
-      <string>{{ .URL }}</string>
+      <string>{{ xml .URL }}</string>
       <key>DeviceAttributes</key>
       <array>
         <string>UDID</string>

--- a/server/mock/datastore_mock.go
+++ b/server/mock/datastore_mock.go
@@ -863,7 +863,7 @@ type UpsertMDMAppleHostDEPAssignmentsFunc func(ctx context.Context, hosts []flee
 
 type IngestMDMAppleDevicesFromDEPSyncFunc func(ctx context.Context, devices []godep.Device, abmTokenID uint, macOSTeam *fleet.Team, iosTeam *fleet.Team, ipadTeam *fleet.Team) (int64, error)
 
-type IngestMDMAppleDeviceFromOTAEnrollmentFunc func(ctx context.Context, teamID *uint, deviceInfo fleet.MDMAppleMachineInfo) error
+type IngestMDMAppleDeviceFromOTAEnrollmentFunc func(ctx context.Context, teamID *uint, idpUUID string, deviceInfo fleet.MDMAppleMachineInfo) error
 
 type MDMAppleUpsertHostFunc func(ctx context.Context, mdmHost *fleet.Host, fromPersonalEnrollment bool) error
 
@@ -6527,11 +6527,11 @@ func (s *DataStore) IngestMDMAppleDevicesFromDEPSync(ctx context.Context, device
 	return s.IngestMDMAppleDevicesFromDEPSyncFunc(ctx, devices, abmTokenID, macOSTeam, iosTeam, ipadTeam)
 }
 
-func (s *DataStore) IngestMDMAppleDeviceFromOTAEnrollment(ctx context.Context, teamID *uint, deviceInfo fleet.MDMAppleMachineInfo) error {
+func (s *DataStore) IngestMDMAppleDeviceFromOTAEnrollment(ctx context.Context, teamID *uint, idpUUID string, deviceInfo fleet.MDMAppleMachineInfo) error {
 	s.mu.Lock()
 	s.IngestMDMAppleDeviceFromOTAEnrollmentFuncInvoked = true
 	s.mu.Unlock()
-	return s.IngestMDMAppleDeviceFromOTAEnrollmentFunc(ctx, teamID, deviceInfo)
+	return s.IngestMDMAppleDeviceFromOTAEnrollmentFunc(ctx, teamID, idpUUID, deviceInfo)
 }
 
 func (s *DataStore) MDMAppleUpsertHost(ctx context.Context, mdmHost *fleet.Host, fromPersonalEnrollment bool) error {

--- a/server/service/apple_mdm.go
+++ b/server/service/apple_mdm.go
@@ -29,7 +29,7 @@ import (
 	eeservice "github.com/fleetdm/fleet/v4/ee/server/service"
 	"github.com/fleetdm/fleet/v4/ee/server/service/digicert"
 	"github.com/fleetdm/fleet/v4/pkg/file"
-	sharedMdm "github.com/fleetdm/fleet/v4/pkg/mdm"
+	shared_mdm "github.com/fleetdm/fleet/v4/pkg/mdm"
 	"github.com/fleetdm/fleet/v4/pkg/optjson"
 	"github.com/fleetdm/fleet/v4/server"
 	"github.com/fleetdm/fleet/v4/server/authz"
@@ -6787,21 +6787,15 @@ func (getOTAProfileRequest) DecodeRequest(ctx context.Context, r *http.Request) 
 		}
 	}
 
-	boydIdpCookie, err := r.Cookie(sharedMdm.BYODIdpCookieName)
+	boydIdpCookie, err := r.Cookie(shared_mdm.BYODIdpCookieName)
+	if err != nil {
+		// r.Cookie only return ErrNoCookie and no other errors.
 
-	if err == http.ErrNoCookie {
 		// We do not fail here if no cookie is found, we validate later down the line if it's required
 		return &getOTAProfileRequest{
 			EnrollSecret: enrollSecret,
 			IdpUUID:      "",
 		}, nil
-	}
-
-	if err != nil {
-		return nil, &fleet.BadRequestError{
-			Message:     "something went wrong parsing the boyd idp cookie",
-			InternalErr: err,
-		}
 	}
 
 	if err = boydIdpCookie.Valid(); err != nil {
@@ -6965,8 +6959,6 @@ func (svc *Service) MDMAppleProcessOTAEnrollment(
 
 		return nil, ctxerr.Wrap(ctx, err, "validating enroll secret")
 	}
-
-	// TODO(IB): Should we verify SSO check here, since this URL could be manually crafted and tampered.
 
 	assets, err := svc.ds.GetAllMDMConfigAssetsByName(ctx, []fleet.MDMAssetName{
 		fleet.MDMAssetSCEPChallenge,

--- a/server/service/apple_mdm.go
+++ b/server/service/apple_mdm.go
@@ -7018,6 +7018,13 @@ func (svc *Service) MDMAppleProcessOTAEnrollment(
 		return nil, ctxerr.Wrap(ctx, err, "generating manual enrollment profile")
 	}
 
+	if idpUUID != "" {
+		_, err := svc.ds.GetMDMIdPAccountByUUID(ctx, idpUUID)
+		if err != nil {
+			return nil, ctxerr.Wrap(ctx, err, "validating idp account existence")
+		}
+	}
+
 	// before responding, create a host record, and assign the host to the
 	// team that matches the enroll secret provided.
 	err = svc.ds.IngestMDMAppleDeviceFromOTAEnrollment(ctx, enrollSecretInfo.TeamID, idpUUID, deviceInfo)

--- a/server/service/devices.go
+++ b/server/service/devices.go
@@ -603,7 +603,8 @@ func (svc *Service) GetDeviceMDMAppleEnrollmentProfile(ctx context.Context) ([]b
 	}
 
 	enrollSecret := tmSecrets[0].Secret
-	profBytes, err := apple_mdm.GenerateOTAEnrollmentProfileMobileconfig(cfg.OrgInfo.OrgName, cfg.MDMUrl(), enrollSecret)
+	// IB: We skip IDP association here, since it's not part of the spec
+	profBytes, err := apple_mdm.GenerateOTAEnrollmentProfileMobileconfig(cfg.OrgInfo.OrgName, cfg.MDMUrl(), enrollSecret, "")
 	if err != nil {
 		return nil, ctxerr.Wrap(ctx, err, "generating ota mobileconfig file for manual enrollment")
 	}

--- a/server/service/integration_mdm_profiles_test.go
+++ b/server/service/integration_mdm_profiles_test.go
@@ -16,6 +16,7 @@ import (
 	"testing"
 	"time"
 
+	sharedMdm "github.com/fleetdm/fleet/v4/pkg/mdm"
 	"github.com/fleetdm/fleet/v4/pkg/mdm/mdmtest"
 	"github.com/fleetdm/fleet/v4/pkg/optjson"
 	"github.com/fleetdm/fleet/v4/server/datastore/mysql"
@@ -5617,12 +5618,13 @@ func (s *integrationMDMTestSuite) TestOTAProfile() {
 
 		idpUUID := uuid.New()
 		resp := s.DoRawWithHeaders("GET", "/api/latest/fleet/enrollment_profiles/ota", j, http.StatusOK, map[string]string{
-			"Cookie": fmt.Sprintf("%s=%s", BOYDIdpCookieName, idpUUID.String()),
+			"Cookie": fmt.Sprintf("%s=%s", sharedMdm.BYODIdpCookieName, idpUUID.String()),
 		}, "enroll_secret", globalEnrollSec)
 		require.NotZero(t, resp.ContentLength)
 		require.Contains(t, resp.Header.Get("Content-Disposition"), `attachment;filename="fleet-mdm-enrollment-profile.mobileconfig"`)
 		require.Contains(t, resp.Header.Get("Content-Type"), "application/x-apple-aspen-config")
 		require.Contains(t, resp.Header.Get("X-Content-Type-Options"), "nosniff")
+		defer resp.Body.Close()
 		b, err := io.ReadAll(resp.Body)
 		require.NoError(t, err)
 		require.Equal(t, resp.ContentLength, int64(len(b)))

--- a/server/service/integration_mdm_profiles_test.go
+++ b/server/service/integration_mdm_profiles_test.go
@@ -7474,5 +7474,4 @@ func (s *integrationMDMTestSuite) TestWindowsProfilesFleetVariableSubstitution()
 	require.Equal(t, "ProfileNoVars", (*hostRespNoVars.Host.MDM.Profiles)[0].Name)
 	require.Equal(t, fleet.MDMDeliveryVerified, *(*hostRespNoVars.Host.MDM.Profiles)[0].Status,
 		"Profile should be verified in host details API for no-vars host")
-
 }

--- a/server/service/integration_mdm_profiles_test.go
+++ b/server/service/integration_mdm_profiles_test.go
@@ -5610,18 +5610,41 @@ func (s *integrationMDMTestSuite) TestOTAProfile() {
 	cfg, err := s.ds.AppConfig(ctx)
 	require.NoError(t, err)
 
-	// Get profile with that enroll secret
-	resp := s.Do("GET", "/api/latest/fleet/enrollment_profiles/ota", getOTAProfileRequest{}, http.StatusOK, "enroll_secret", globalEnrollSec)
-	require.NotZero(t, resp.ContentLength)
-	require.Contains(t, resp.Header.Get("Content-Disposition"), `attachment;filename="fleet-mdm-enrollment-profile.mobileconfig"`)
-	require.Contains(t, resp.Header.Get("Content-Type"), "application/x-apple-aspen-config")
-	require.Contains(t, resp.Header.Get("X-Content-Type-Options"), "nosniff")
-	b, err := io.ReadAll(resp.Body)
-	require.NoError(t, err)
-	require.Equal(t, resp.ContentLength, int64(len(b)))
-	require.Contains(t, string(b), "com.fleetdm.fleet.mdm.apple.ota")
-	require.Contains(t, string(b), fmt.Sprintf("%s/api/v1/fleet/ota_enrollment?enroll_secret=%s", cfg.ServerSettings.ServerURL, escSec))
-	require.Contains(t, string(b), cfg.OrgInfo.OrgName)
+	t.Run("gets profile with idp uuid included if boyd cookie is set", func(t *testing.T) {
+		// Get profile with that enroll secret
+		j, err := json.Marshal(getOTAProfileRequest{})
+		require.NoError(t, err)
+
+		idpUUID := uuid.New()
+		resp := s.DoRawWithHeaders("GET", "/api/latest/fleet/enrollment_profiles/ota", j, http.StatusOK, map[string]string{
+			"Cookie": fmt.Sprintf("%s=%s", BOYDIdpCookieName, idpUUID.String()),
+		}, "enroll_secret", globalEnrollSec)
+		require.NotZero(t, resp.ContentLength)
+		require.Contains(t, resp.Header.Get("Content-Disposition"), `attachment;filename="fleet-mdm-enrollment-profile.mobileconfig"`)
+		require.Contains(t, resp.Header.Get("Content-Type"), "application/x-apple-aspen-config")
+		require.Contains(t, resp.Header.Get("X-Content-Type-Options"), "nosniff")
+		b, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+		require.Equal(t, resp.ContentLength, int64(len(b)))
+		require.Contains(t, string(b), "com.fleetdm.fleet.mdm.apple.ota")
+		require.Contains(t, string(b), fmt.Sprintf("%s/api/v1/fleet/ota_enrollment?enroll_secret=%s&amp;idp_uuid=%s", cfg.ServerSettings.ServerURL, escSec, idpUUID.String()))
+		require.Contains(t, string(b), cfg.OrgInfo.OrgName)
+	})
+
+	t.Run("does not include idp_uuid in the url if cookie is not set", func(t *testing.T) {
+		resp := s.Do("GET", "/api/latest/fleet/enrollment_profiles/ota", &getOTAProfileRequest{}, http.StatusOK, "enroll_secret", globalEnrollSec)
+		require.NotZero(t, resp.ContentLength)
+		require.Contains(t, resp.Header.Get("Content-Disposition"), `attachment;filename="fleet-mdm-enrollment-profile.mobileconfig"`)
+		require.Contains(t, resp.Header.Get("Content-Type"), "application/x-apple-aspen-config")
+		require.Contains(t, resp.Header.Get("X-Content-Type-Options"), "nosniff")
+		b, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+		require.Equal(t, resp.ContentLength, int64(len(b)))
+		require.Contains(t, string(b), "com.fleetdm.fleet.mdm.apple.ota")
+		require.Contains(t, string(b), fmt.Sprintf("%s/api/v1/fleet/ota_enrollment?enroll_secret=%s", cfg.ServerSettings.ServerURL, escSec))
+		require.NotContains(t, string(b), "idp_uuid=")
+		require.Contains(t, string(b), cfg.OrgInfo.OrgName)
+	})
 }
 
 // TestAppleDDMSecretVariablesUpload tests uploading DDM profiles with secrets via the /configuration_profiles endpoint

--- a/server/service/integration_mdm_profiles_test.go
+++ b/server/service/integration_mdm_profiles_test.go
@@ -16,7 +16,7 @@ import (
 	"testing"
 	"time"
 
-	sharedMdm "github.com/fleetdm/fleet/v4/pkg/mdm"
+	shared_mdm "github.com/fleetdm/fleet/v4/pkg/mdm"
 	"github.com/fleetdm/fleet/v4/pkg/mdm/mdmtest"
 	"github.com/fleetdm/fleet/v4/pkg/optjson"
 	"github.com/fleetdm/fleet/v4/server/datastore/mysql"
@@ -5618,7 +5618,7 @@ func (s *integrationMDMTestSuite) TestOTAProfile() {
 
 		idpUUID := uuid.New()
 		resp := s.DoRawWithHeaders("GET", "/api/latest/fleet/enrollment_profiles/ota", j, http.StatusOK, map[string]string{
-			"Cookie": fmt.Sprintf("%s=%s", sharedMdm.BYODIdpCookieName, idpUUID.String()),
+			"Cookie": fmt.Sprintf("%s=%s", shared_mdm.BYODIdpCookieName, idpUUID.String()),
 		}, "enroll_secret", globalEnrollSec)
 		require.NotZero(t, resp.ContentLength)
 		require.Contains(t, resp.Header.Get("Content-Disposition"), `attachment;filename="fleet-mdm-enrollment-profile.mobileconfig"`)

--- a/server/service/integration_mdm_test.go
+++ b/server/service/integration_mdm_test.go
@@ -13753,24 +13753,7 @@ func (s *integrationMDMTestSuite) TestOTAEnrollment() {
 </dict>
 </plist>`)
 
-	// request with no enroll secret
-	httpResp := s.DoRawNoAuth("POST", "/api/latest/fleet/ota_enrollment", reqBody, http.StatusForbidden)
-	errMsg := extractServerErrorText(httpResp.Body)
-	require.Contains(t, errMsg, "Couldn't install the profile. Invalid enroll secret. Please contact your IT admin.")
-	require.NoError(t, httpResp.Body.Close())
-
-	// request with no body
-	httpResp = s.DoRawNoAuth("POST", "/api/latest/fleet/ota_enrollment?enroll_secret=foo", nil, http.StatusBadRequest)
-	errMsg = extractServerErrorText(httpResp.Body)
-	require.Contains(t, errMsg, "invalid request body")
-	require.NoError(t, httpResp.Body.Close())
-
-	// request with unsigned body
-	httpResp = s.DoRawNoAuth("POST", "/api/latest/fleet/ota_enrollment?enroll_secret=foo", reqBody, http.StatusBadRequest)
-	errMsg = extractServerErrorText(httpResp.Body)
-	require.Contains(t, errMsg, "invalid request body")
-	require.NoError(t, httpResp.Body.Close())
-
+	// Setup signed req body, but also verify we can sign it.
 	cert, key, err := apple_mdm.NewSCEPCACertKey()
 	require.NoError(t, err)
 	signedData, err := pkcs7.NewSignedData(reqBody)
@@ -13779,21 +13762,45 @@ func (s *integrationMDMTestSuite) TestOTAEnrollment() {
 	signedReqBody, err := signedData.Finish()
 	require.NoError(t, err)
 
-	// request with invalid apple signature
-	httpResp = s.DoRawNoAuth("POST", "/api/latest/fleet/ota_enrollment?enroll_secret=foo", signedReqBody, http.StatusForbidden)
-	errMsg = extractServerErrorText(httpResp.Body)
-	require.Contains(t, errMsg, "Couldn't install the profile. Invalid enroll secret. Please contact your IT admin.")
-	require.NoError(t, httpResp.Body.Close())
+	t.Run("errors", func(t *testing.T) {
+		t.Run("if no enroll secret is provided", func(t *testing.T) {
+			httpResp := s.DoRawNoAuth("POST", "/api/latest/fleet/ota_enrollment", reqBody, http.StatusForbidden)
+			errMsg := extractServerErrorText(httpResp.Body)
+			require.Contains(t, errMsg, "Couldn't install the profile. Invalid enroll secret. Please contact your IT admin.")
+			require.NoError(t, httpResp.Body.Close())
+		})
 
-	// request with invalid device signature
-	os.Setenv("FLEET_DEV_MDM_APPLE_DISABLE_DEVICE_INFO_CERT_VERIFY", "1")
-	httpResp = s.DoRawNoAuth("POST", "/api/latest/fleet/ota_enrollment?enroll_secret=foo", signedReqBody, http.StatusForbidden)
-	errMsg = extractServerErrorText(httpResp.Body)
-	require.Contains(t, errMsg, "Couldn't install the profile. Invalid enroll secret. Please contact your IT admin.")
-	require.NoError(t, httpResp.Body.Close())
+		t.Run("if no body is provided", func(t *testing.T) {
+			httpResp := s.DoRawNoAuth("POST", "/api/latest/fleet/ota_enrollment?enroll_secret=foo", nil, http.StatusBadRequest)
+			errMsg := extractServerErrorText(httpResp.Body)
+			require.Contains(t, errMsg, "invalid request body")
+			require.NoError(t, httpResp.Body.Close())
+		})
 
-	// request without serial number
-	signedData, err = pkcs7.NewSignedData([]byte(`<?xml version="1.0" encoding="UTF-8"?>
+		t.Run("if body is unsigned", func(t *testing.T) {
+			httpResp := s.DoRawNoAuth("POST", "/api/latest/fleet/ota_enrollment?enroll_secret=foo", reqBody, http.StatusBadRequest)
+			errMsg := extractServerErrorText(httpResp.Body)
+			require.Contains(t, errMsg, "invalid request body")
+			require.NoError(t, httpResp.Body.Close())
+		})
+
+		t.Run("if invalid apple signature", func(t *testing.T) {
+			httpResp := s.DoRawNoAuth("POST", "/api/latest/fleet/ota_enrollment?enroll_secret=foo", signedReqBody, http.StatusForbidden)
+			errMsg := extractServerErrorText(httpResp.Body)
+			require.Contains(t, errMsg, "Couldn't install the profile. Invalid enroll secret. Please contact your IT admin.")
+			require.NoError(t, httpResp.Body.Close())
+		})
+
+		t.Run("if invalid device signature", func(t *testing.T) {
+			os.Setenv("FLEET_DEV_MDM_APPLE_DISABLE_DEVICE_INFO_CERT_VERIFY", "1")
+			httpResp := s.DoRawNoAuth("POST", "/api/latest/fleet/ota_enrollment?enroll_secret=foo", signedReqBody, http.StatusForbidden)
+			errMsg := extractServerErrorText(httpResp.Body)
+			require.Contains(t, errMsg, "Couldn't install the profile. Invalid enroll secret. Please contact your IT admin.")
+			require.NoError(t, httpResp.Body.Close())
+		})
+
+		t.Run("if serial is missing", func(t *testing.T) {
+			signedData, err = pkcs7.NewSignedData([]byte(`<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
@@ -13801,81 +13808,145 @@ func (s *integrationMDMTestSuite) TestOTAEnrollment() {
 	<string></string>
 </dict>
 </plist>`))
-	require.NoError(t, err)
-	require.NoError(t, signedData.AddSigner(cert, key, pkcs7.SignerInfoConfig{}))
-	signedReqBody, err = signedData.Finish()
-	require.NoError(t, err)
-	httpResp = s.DoRawNoAuth("POST", "/api/latest/fleet/ota_enrollment?enroll_secret=foo", signedReqBody, http.StatusBadRequest)
-	errMsg = extractServerErrorText(httpResp.Body)
-	require.Contains(t, errMsg, "SERIAL is required")
-	require.NoError(t, httpResp.Body.Close())
-
-	checkInstallFleetdCommandSent := func(mdmDevice *mdmtest.TestAppleMDMClient, wantCommand bool) {
-		foundInstallFleetdCommand := false
-		cmd, err := mdmDevice.Idle()
-		require.NoError(t, err)
-		for cmd != nil {
-			var fullCmd micromdm.CommandPayload
-			require.NoError(t, plist.Unmarshal(cmd.Raw, &fullCmd))
-			if manifest := fullCmd.Command.InstallEnterpriseApplication.ManifestURL; manifest != nil {
-				foundInstallFleetdCommand = true
-				require.Equal(t, "InstallEnterpriseApplication", cmd.Command.RequestType)
-				require.Contains(t, *fullCmd.Command.InstallEnterpriseApplication.ManifestURL, fleetdbase.GetPKGManifestURL())
-			}
-			cmd, err = mdmDevice.Acknowledge(cmd.CommandUUID)
 			require.NoError(t, err)
+			require.NoError(t, signedData.AddSigner(cert, key, pkcs7.SignerInfoConfig{}))
+			signedReqBody, err = signedData.Finish()
+			require.NoError(t, err)
+			httpResp := s.DoRawNoAuth("POST", "/api/latest/fleet/ota_enrollment?enroll_secret=foo", signedReqBody, http.StatusBadRequest)
+			errMsg := extractServerErrorText(httpResp.Body)
+			require.Contains(t, errMsg, "SERIAL is required")
+			require.NoError(t, httpResp.Body.Close())
+		})
+	})
+
+	t.Run("succeeds", func(t *testing.T) {
+		checkInstallFleetdCommandSent := func(mdmDevice *mdmtest.TestAppleMDMClient, wantCommand bool) {
+			foundInstallFleetdCommand := false
+			cmd, err := mdmDevice.Idle()
+			require.NoError(t, err)
+			for cmd != nil {
+				var fullCmd micromdm.CommandPayload
+				require.NoError(t, plist.Unmarshal(cmd.Raw, &fullCmd))
+				if manifest := fullCmd.Command.InstallEnterpriseApplication.ManifestURL; manifest != nil {
+					foundInstallFleetdCommand = true
+					require.Equal(t, "InstallEnterpriseApplication", cmd.Command.RequestType)
+					require.Contains(t, *fullCmd.Command.InstallEnterpriseApplication.ManifestURL, fleetdbase.GetPKGManifestURL())
+				}
+				cmd, err = mdmDevice.Acknowledge(cmd.CommandUUID)
+				require.NoError(t, err)
+			}
+			require.Equal(t, wantCommand, foundInstallFleetdCommand)
 		}
-		require.Equal(t, wantCommand, foundInstallFleetdCommand)
-	}
 
-	hwModel := "MacBookPro16,1"
-	mdmDevice := mdmtest.NewTestMDMClientAppleOTA(
-		s.server.URL,
-		globalSecret,
-		hwModel,
-	)
-	enrollTime := time.Now().UTC().Truncate(time.Second)
-	require.NoError(t, mdmDevice.Enroll())
-	s.runWorker()
-	checkInstallFleetdCommandSent(mdmDevice, true)
+		verifySuccessfulOTAEnrollment := func(mdmDevice *mdmtest.TestAppleMDMClient, hwModel, platform string, enrollTime time.Time) getHostResponse {
+			var hostByIdentifierResp getHostResponse
+			s.DoJSON("GET", fmt.Sprintf("/api/latest/fleet/hosts/identifier/%s", mdmDevice.UUID), nil, http.StatusOK, &hostByIdentifierResp)
+			require.Equal(t, hwModel, hostByIdentifierResp.Host.HardwareModel)
+			require.Equal(t, platform, hostByIdentifierResp.Host.Platform)
+			require.NotNil(t, hostByIdentifierResp.Host.LastMDMEnrolledAt)
+			assert.GreaterOrEqual(t, *hostByIdentifierResp.Host.LastMDMEnrolledAt, enrollTime)
+			require.NotNil(t, hostByIdentifierResp.Host.LastMDMCheckedInAt)
+			assert.GreaterOrEqual(t, *hostByIdentifierResp.Host.LastMDMCheckedInAt, enrollTime)
 
-	var hostByIdentifierResp getHostResponse
-	s.DoJSON("GET", fmt.Sprintf("/api/latest/fleet/hosts/identifier/%s", mdmDevice.UUID), nil, http.StatusOK, &hostByIdentifierResp)
-	require.Equal(t, hwModel, hostByIdentifierResp.Host.HardwareModel)
-	require.Equal(t, "darwin", hostByIdentifierResp.Host.Platform)
-	require.Nil(t, hostByIdentifierResp.Host.TeamID)
-	require.NotNil(t, hostByIdentifierResp.Host.LastMDMEnrolledAt)
-	assert.GreaterOrEqual(t, *hostByIdentifierResp.Host.LastMDMEnrolledAt, enrollTime)
-	require.NotNil(t, hostByIdentifierResp.Host.LastMDMCheckedInAt)
-	assert.GreaterOrEqual(t, *hostByIdentifierResp.Host.LastMDMCheckedInAt, enrollTime)
+			return hostByIdentifierResp
+		}
 
-	// create a team with a different enroll secret
-	var specResp applyTeamSpecsResponse
-	teamSecret := "team_secret"
-	teamSpecs := applyTeamSpecsRequest{Specs: []*fleet.TeamSpec{{Name: "newteam", Secrets: &[]fleet.EnrollSecret{{Secret: teamSecret}}}}}
-	s.DoJSON("POST", "/api/latest/fleet/spec/teams", teamSpecs, http.StatusOK, &specResp)
+		verifySuccessfulIdpAssociation := func(hostUUID, idpUUID string) {
+			hostToIdpMap, err := s.ds.GetMDMIdPAccountsByHostUUIDs(context.Background(), []string{hostUUID})
+			require.NoError(t, err)
+			idpAccount := hostToIdpMap[hostUUID]
+			require.NotNil(t, idpAccount)
+			require.Equal(t, idpUUID, idpAccount.UUID)
+		}
 
-	hwModel = "iPad13,16"
-	mdmDevice = mdmtest.NewTestMDMClientAppleOTA(
-		s.server.URL,
-		teamSecret,
-		hwModel,
-	)
-	enrollTime = time.Now().UTC().Truncate(time.Second)
-	require.NoError(t, mdmDevice.Enroll())
-	s.runWorker()
-	checkInstallFleetdCommandSent(mdmDevice, false)
+		t.Run("ota enrolling a macbook", func(t *testing.T) {
+			hwModel := "MacBookPro16,1"
+			mdmDevice := mdmtest.NewTestMDMClientAppleOTA(
+				s.server.URL,
+				globalSecret,
+				hwModel,
+			)
+			enrollTime := time.Now().UTC().Truncate(time.Second)
+			require.NoError(t, mdmDevice.Enroll())
+			s.runWorker()
+			checkInstallFleetdCommandSent(mdmDevice, true)
 
-	hostByIdentifierResp = getHostResponse{}
-	s.DoJSON("GET", fmt.Sprintf("/api/latest/fleet/hosts/identifier/%s", mdmDevice.UUID), nil, http.StatusOK, &hostByIdentifierResp)
-	require.Equal(t, hwModel, hostByIdentifierResp.Host.HardwareModel)
-	require.Equal(t, "ipados", hostByIdentifierResp.Host.Platform)
-	require.NotNil(t, hostByIdentifierResp.Host.TeamID)
-	require.Equal(t, specResp.TeamIDsByName["newteam"], *hostByIdentifierResp.Host.TeamID)
-	require.NotNil(t, hostByIdentifierResp.Host.LastMDMEnrolledAt)
-	assert.GreaterOrEqual(t, *hostByIdentifierResp.Host.LastMDMEnrolledAt, enrollTime)
-	require.NotNil(t, hostByIdentifierResp.Host.LastMDMCheckedInAt)
-	assert.GreaterOrEqual(t, *hostByIdentifierResp.Host.LastMDMCheckedInAt, enrollTime)
+			hostByIdentifierResp := verifySuccessfulOTAEnrollment(mdmDevice, hwModel, "darwin", enrollTime)
+			require.Nil(t, hostByIdentifierResp.Host.TeamID)
+		})
+
+		t.Run("ota enrolling an ipad", func(t *testing.T) {
+			var specResp applyTeamSpecsResponse
+			teamSecret := "team_secret"
+			teamSpecs := applyTeamSpecsRequest{Specs: []*fleet.TeamSpec{{Name: "newteam", Secrets: &[]fleet.EnrollSecret{{Secret: teamSecret}}}}}
+			s.DoJSON("POST", "/api/latest/fleet/spec/teams", teamSpecs, http.StatusOK, &specResp)
+
+			hwModel := "iPad13,16"
+			mdmDevice := mdmtest.NewTestMDMClientAppleOTA(
+				s.server.URL,
+				teamSecret,
+				hwModel,
+			)
+			enrollTime := time.Now().UTC().Truncate(time.Second)
+			require.NoError(t, mdmDevice.Enroll())
+			s.runWorker()
+			checkInstallFleetdCommandSent(mdmDevice, false)
+
+			hostByIdentifierResp := verifySuccessfulOTAEnrollment(mdmDevice, hwModel, "ipados", enrollTime)
+			require.NotNil(t, hostByIdentifierResp.Host.TeamID)
+			require.Equal(t, specResp.TeamIDsByName["newteam"], *hostByIdentifierResp.Host.TeamID)
+		})
+
+		t.Run("ota enrollment if idp_uuid is not set does not associate host with idp account", func(t *testing.T) {
+			hwModel := "MacBookPro16,1"
+			mdmDevice := mdmtest.NewTestMDMClientAppleOTA(
+				s.server.URL,
+				globalSecret,
+				hwModel,
+			)
+			enrollTime := time.Now().UTC().Truncate(time.Second)
+			require.NoError(t, mdmDevice.Enroll())
+			s.runWorker()
+			checkInstallFleetdCommandSent(mdmDevice, true)
+
+			resp := verifySuccessfulOTAEnrollment(mdmDevice, hwModel, "darwin", enrollTime)
+			account, err := s.ds.GetMDMIdPAccountByHostUUID(context.Background(), resp.Host.UUID)
+			require.NoError(t, err)
+			require.Nil(t, account) // We do not fail but return nil for both if not found, and we do not expect an entry here.
+		})
+
+		t.Run("ota enrollment if idp_uuid is set associates host with idp account", func(t *testing.T) {
+			idpEmail := "test@example.com"
+			err := s.ds.InsertMDMIdPAccount(context.Background(), &fleet.MDMIdPAccount{
+				Username: "test",
+				Email:    idpEmail,
+			})
+			require.NoError(t, err)
+			idpAccount, err := s.ds.GetMDMIdPAccountByEmail(context.Background(), idpEmail)
+			require.NoError(t, err)
+
+			hwModel := "MacBookPro16,1"
+			mdmDevice := mdmtest.NewTestMDMClientAppleOTA(
+				s.server.URL,
+				globalSecret,
+				hwModel,
+				mdmtest.WithOTAIdpUUID(idpAccount.UUID),
+			)
+			enrollTime := time.Now().UTC().Truncate(time.Second)
+			require.NoError(t, mdmDevice.Enroll())
+			s.runWorker()
+			checkInstallFleetdCommandSent(mdmDevice, true)
+
+			resp := verifySuccessfulOTAEnrollment(mdmDevice, hwModel, "darwin", enrollTime)
+			mysql.ExecAdhocSQL(t, s.ds, func(q sqlx.ExtContext) error {
+				mysql.DumpTable(t, q, "hosts")
+				mysql.DumpTable(t, q, "mdm_idp_accounts")
+				mysql.DumpTable(t, q, "host_mdm_idp_accounts")
+				return nil
+			})
+			verifySuccessfulIdpAssociation(resp.Host.UUID, idpAccount.UUID)
+		})
+	})
 }
 
 func (s *integrationMDMTestSuite) TestAppleMDMAccountDrivenUserEnrollment() {

--- a/server/service/integration_mdm_test.go
+++ b/server/service/integration_mdm_test.go
@@ -13817,6 +13817,19 @@ func (s *integrationMDMTestSuite) TestOTAEnrollment() {
 			require.Contains(t, errMsg, "SERIAL is required")
 			require.NoError(t, httpResp.Body.Close())
 		})
+
+		t.Run("if idp uuid does not match an account", func(t *testing.T) {
+			hwModel := "MacBookPro16,1"
+			mdmDevice := mdmtest.NewTestMDMClientAppleOTA(
+				s.server.URL,
+				globalSecret,
+				hwModel,
+				mdmtest.WithOTAIdpUUID(uuid.New().String()),
+			)
+			err := mdmDevice.Enroll()
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "404 Not Found")
+		})
 	})
 
 	t.Run("succeeds", func(t *testing.T) {

--- a/server/service/integration_mdm_test.go
+++ b/server/service/integration_mdm_test.go
@@ -13792,7 +13792,7 @@ func (s *integrationMDMTestSuite) TestOTAEnrollment() {
 		})
 
 		t.Run("if invalid device signature", func(t *testing.T) {
-			os.Setenv("FLEET_DEV_MDM_APPLE_DISABLE_DEVICE_INFO_CERT_VERIFY", "1")
+			t.Setenv("FLEET_DEV_MDM_APPLE_DISABLE_DEVICE_INFO_CERT_VERIFY", "1")
 			httpResp := s.DoRawNoAuth("POST", "/api/latest/fleet/ota_enrollment?enroll_secret=foo", signedReqBody, http.StatusForbidden)
 			errMsg := extractServerErrorText(httpResp.Body)
 			require.Contains(t, errMsg, "Couldn't install the profile. Invalid enroll secret. Please contact your IT admin.")
@@ -13938,12 +13938,6 @@ func (s *integrationMDMTestSuite) TestOTAEnrollment() {
 			checkInstallFleetdCommandSent(mdmDevice, true)
 
 			resp := verifySuccessfulOTAEnrollment(mdmDevice, hwModel, "darwin", enrollTime)
-			mysql.ExecAdhocSQL(t, s.ds, func(q sqlx.ExtContext) error {
-				mysql.DumpTable(t, q, "hosts")
-				mysql.DumpTable(t, q, "mdm_idp_accounts")
-				mysql.DumpTable(t, q, "host_mdm_idp_accounts")
-				return nil
-			})
 			verifySuccessfulIdpAssociation(resp.Host.UUID, idpAccount.UUID)
 		})
 	})

--- a/server/service/integrationtest/android/android_test.go
+++ b/server/service/integrationtest/android/android_test.go
@@ -2,12 +2,22 @@ package android
 
 import (
 	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
 	"net/http"
 	"testing"
 
+	shared_mdm "github.com/fleetdm/fleet/v4/pkg/mdm"
+	"github.com/fleetdm/fleet/v4/server"
 	"github.com/fleetdm/fleet/v4/server/datastore/mysql"
+	"github.com/fleetdm/fleet/v4/server/fleet"
 	"github.com/fleetdm/fleet/v4/server/mdm/android"
+	"github.com/fleetdm/fleet/v4/server/service/middleware/endpoint_utils"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/api/androidmanagement/v1"
 )
 
 func TestAndroid(t *testing.T) {
@@ -18,6 +28,7 @@ func TestAndroid(t *testing.T) {
 		fn   func(t *testing.T, s *Suite)
 	}{
 		{"HappyPath", testHappyPath},
+		{"CreateEnrollmentToken", testCreateEnrollmentToken},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
@@ -34,6 +45,158 @@ func testHappyPath(t *testing.T, s *Suite) {
 	assert.Equal(t, signupURL.Url, signupDetails.Url)
 }
 
+type enrollmentTokenRequest struct {
+	EnrollSecret string
+	IdpUUID      string
+}
+
+func testCreateEnrollmentToken(t *testing.T, s *Suite) {
+	appCfg := &fleet.AppConfig{
+		MDM: fleet.MDM{
+			AndroidEnabledAndConfigured: true,
+		},
+		ServerSettings: fleet.ServerSettings{
+			ServerURL: "http://localhost",
+		},
+	}
+	enableAndroidMDM := func() {
+		_, err := s.DS.NewAppConfig(t.Context(), appCfg)
+		require.NoError(t, err)
+	}
+
+	createTeamAndSecret := func(name, secret string) {
+		team, err := s.DS.NewTeam(t.Context(), &fleet.Team{
+			Name: name,
+		})
+		require.NoError(t, err)
+		err = s.DS.ApplyEnrollSecrets(t.Context(), &team.ID, []*fleet.EnrollSecret{
+			{
+				Secret: secret,
+				TeamID: &team.ID,
+			},
+		})
+		require.NoError(t, err)
+	}
+
+	setupAndroidEnterprise := func() {
+		admin := s.Users["admin1"]
+		enterpriseID, err := s.DS.CreateEnterprise(t.Context(), admin.ID)
+		require.NoError(t, err)
+
+		// signupToken is used to authenticate the signup callback URL -- to ensure that the callback came from our Android enterprise signup flow
+		signupToken, err := server.GenerateRandomURLSafeText(32)
+		require.NoError(t, err)
+
+		callbackURL := fmt.Sprintf("%s/api/v1/fleet/android_enterprise/connect/%s", appCfg.ServerSettings.ServerURL, signupToken)
+		signupDetails := android.SignupDetails{
+			Name: "test",
+			Url:  callbackURL,
+		}
+
+		err = s.DS.UpdateEnterprise(t.Context(), &android.EnterpriseDetails{
+			Enterprise: android.Enterprise{
+				ID:           enterpriseID,
+				EnterpriseID: "test",
+			},
+			SignupName:  signupDetails.Name,
+			SignupToken: signupToken,
+		})
+		require.NoError(t, err)
+	}
+
+	s.AndroidProxy.EnterprisesEnrollmentTokensCreateFunc = func(ctx context.Context, enterpriseName string, token *androidmanagement.EnrollmentToken) (*androidmanagement.EnrollmentToken, error) {
+		// For ease of testing and validating, we base64 the json input as the output value
+
+		jsonString, err := json.Marshal(token)
+		require.NoError(t, err)
+		base64Encoded := base64.StdEncoding.EncodeToString(jsonString)
+
+		return &androidmanagement.EnrollmentToken{
+			Value: base64Encoded,
+		}, nil
+	}
+
+	t.Run("fails", func(t *testing.T) {
+		t.Run("if enroll_secret query param is missing", func(t *testing.T) {
+			s.Do(t, "GET", "/api/v1/fleet/android_enterprise/enrollment_token", nil, http.StatusBadRequest)
+		})
+
+		t.Run("if android MDM is not configured", func(t *testing.T) {
+			s.Do(t, "GET", "/api/v1/fleet/android_enterprise/enrollment_token", nil, http.StatusConflict, "enroll_secret", "secret")
+		})
+
+		t.Run("if enroll secret is invalid", func(t *testing.T) {
+			enableAndroidMDM()
+			s.Do(t, "GET", "/api/v1/fleet/android_enterprise/enrollment_token", nil, http.StatusUnauthorized, "enroll_secret", "secret")
+		})
+
+		t.Run("if android enterprise is missing", func(t *testing.T) {
+			enableAndroidMDM()
+			secret := "global"
+			createTeamAndSecret("global", secret)
+			resp := s.Do(t, "GET", "/api/v1/fleet/android_enterprise/enrollment_token", nil, http.StatusNotFound, "enroll_secret", secret)
+			je := decodeJsonError(t, resp)
+
+			require.Contains(t, "Android enterprise", je.Errors[0]["base"])
+		})
+
+		t.Cleanup(func() {
+			mysql.TruncateTables(t, s.DS)
+		})
+	})
+
+	t.Run("succeeds", func(t *testing.T) {
+		enableAndroidMDM()
+		globalSecret := "global"
+		createTeamAndSecret("global", globalSecret)
+		setupAndroidEnterprise()
+
+		t.Run("when enroll secret is passed", func(t *testing.T) {
+			var resp android.EnrollmentTokenResponse
+			s.DoJSON(t, "GET", "/api/v1/fleet/android_enterprise/enrollment_token", nil, http.StatusOK, &resp, "enroll_secret", globalSecret)
+
+			decoded, err := base64.StdEncoding.DecodeString(resp.EnrollmentToken.EnrollmentToken)
+			require.NoError(t, err)
+			var et androidmanagement.EnrollmentToken
+			err = json.Unmarshal(decoded, &et)
+			require.NoError(t, err)
+
+			var enrollmentRequest enrollmentTokenRequest
+			err = json.Unmarshal([]byte(et.AdditionalData), &enrollmentRequest)
+			require.NoError(t, err)
+
+			require.Equal(t, globalSecret, enrollmentRequest.EnrollSecret)
+			require.Equal(t, "", enrollmentRequest.IdpUUID)
+		})
+
+		t.Run("when enroll and idp uuid is set", func(t *testing.T) {
+			idpUUID := "idp-uuid"
+			resp := s.DoRawWithHeaders(t, "GET", "/api/v1/fleet/android_enterprise/enrollment_token", nil, http.StatusOK, map[string]string{
+				"Cookie": fmt.Sprintf("%s=%s", shared_mdm.BYODIdpCookieName, idpUUID),
+			}, "enroll_secret", globalSecret)
+
+			bodyBytes, err := io.ReadAll(resp.Body)
+			require.NoError(t, err)
+			var etr android.EnrollmentTokenResponse
+			err = json.Unmarshal(bodyBytes, &etr)
+			require.NoError(t, err)
+
+			decoded, err := base64.StdEncoding.DecodeString(etr.EnrollmentToken.EnrollmentToken)
+			require.NoError(t, err)
+			var et androidmanagement.EnrollmentToken
+			err = json.Unmarshal(decoded, &et)
+			require.NoError(t, err)
+
+			var enrollmentRequest enrollmentTokenRequest
+			err = json.Unmarshal([]byte(et.AdditionalData), &enrollmentRequest)
+			require.NoError(t, err)
+
+			require.Equal(t, globalSecret, enrollmentRequest.EnrollSecret)
+			require.Equal(t, idpUUID, enrollmentRequest.IdpUUID)
+		})
+	})
+}
+
 func expectSignupDetails(t *testing.T, s *Suite) *android.SignupDetails {
 	signupDetails := &android.SignupDetails{
 		Url:  "URL",
@@ -46,4 +209,15 @@ func expectSignupDetails(t *testing.T, s *Suite) *android.SignupDetails {
 		return signupDetails, nil
 	}
 	return signupDetails
+}
+
+func decodeJsonError(t *testing.T, response *http.Response) endpoint_utils.JsonError {
+	bodyBytes, err := io.ReadAll(response.Body)
+	require.NoError(t, err)
+
+	var je endpoint_utils.JsonError
+	err = json.Unmarshal(bodyBytes, &je)
+	require.NoError(t, err)
+
+	return je
 }


### PR DESCRIPTION
fixes: #30661 

- Android tests
- Adding UUID to both Ios/ipad from OTA enrollment before first authenticate
- Android: Using `EnterpriseSpecificId` as the UUID.

Went with the name of the cookie: `__Host-FLEETBOYDIDP`

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [ ] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [ ] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes

## Testing

- [ ] Added/updated automated tests
- [ ] Where appropriate, [automated tests simulate multiple hosts and test for host isolation](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/reference/patterns-backend.md#unit-testing) (updates to one hosts's records do not affect another)

- [ ] QA'd all new/changed functionality manually

For unreleased bug fixes in a release candidate, one of:

- [ ] Confirmed that the fix is not expected to adversely impact load test results
- [ ] Alerted the release DRI if additional load testing is needed

## Database migrations

- [ ] Checked table schema to confirm autoupdate
- [ ] Checked schema for all modified table for columns that will auto-update timestamps during migration.
- [ ] Confirmed that updating the timestamps is acceptable, and will not cause unwanted side effects.
- [ ] Ensured the correct collation is explicitly set for character columns (`COLLATE utf8mb4_unicode_ci`).

## New Fleet configuration settings

- [ ] Setting(s) is/are explicitly excluded from GitOps

If you didn't check the box above, follow this checklist for GitOps-enabled settings:

- [ ] Verified that the setting is exported via `fleetctl generate-gitops`
- [ ] Verified the setting is documented in a separate PR to [the GitOps documentation](https://github.com/fleetdm/fleet/blob/main/docs/Configuration/yaml-files.md#L485)
- [ ] Verified that the setting is cleared on the server if it is not supplied in a YAML file (or that it is documented as being optional)
- [ ] Verified that any relevant UI is disabled when GitOps mode is enabled

## fleetd/orbit/Fleet Desktop

- [ ] Verified compatibility with the latest released version of Fleet (see [Must rule](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/workflows/fleetd-development-and-release-strategy.md))
- [ ] If the change applies to only one platform, confirmed that `runtime.GOOS` is used as needed to isolate changes
- [ ] Verified that fleetd runs on macOS, Linux and Windows
- [ ] Verified auto-update works from the released version of component to the new version (see [tools/tuf/test](../tools/tuf/test/README.md))


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for associating device enrollments (Apple and Android) with an Identity Provider (IdP) account during OTA enrollment, using a new UUID parameter.
  * OTA enrollment profiles now optionally include an IdP UUID when provided, and the system can associate hosts with IdP accounts.

* **Bug Fixes**
  * Improved handling and validation of enrollment secrets and IdP UUIDs in device enrollment flows.

* **Tests**
  * Expanded and refactored integration and unit tests to cover IdP association scenarios and error handling for OTA enrollments.

* **Documentation**
  * Updated comments and method signatures to reflect new IdP UUID parameters in enrollment-related APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->