### PR TITLE
Cherry pick offline indicator fixes

### DIFF
--- a/changes/31592-improve-offline-indicator
+++ b/changes/31592-improve-offline-indicator
@@ -1,0 +1,2 @@
+* Fixed invalid rate limiting applied on Fleet Desktop requests for which a public IP could not be determined.
+* Improved public IP extraction for Fleet Desktop requests.

--- a/cmd/osquery-perf/agent.go
+++ b/cmd/osquery-perf/agent.go
@@ -852,6 +852,8 @@ func (a *agent) runOrbitLoop() {
 	capabilitiesCheckerTicker := time.Tick(5 * time.Minute)
 	// fleet desktop polls for policy compliance every 5 minutes
 	fleetDesktopPolicyTicker := time.Tick(5 * time.Minute)
+	// fleet desktop pings every 10s for connectivity check.
+	fleetDesktopConnectivityCheck := time.Tick(10 * time.Second)
 
 	const windowsMDMEnrollmentAttemptFrequency = time.Hour
 	var lastEnrollAttempt time.Time
@@ -918,6 +920,14 @@ func (a *agent) runOrbitLoop() {
 				if _, err := deviceClient.DesktopSummary(*a.deviceAuthToken); err != nil {
 					a.stats.IncrementDesktopErrors()
 					log.Println("deviceClient.NumberOfFailingPolicies: ", err)
+					continue
+				}
+			}
+		case <-fleetDesktopConnectivityCheck:
+			if !a.disableFleetDesktop {
+				if err := deviceClient.Ping(); err != nil {
+					a.stats.IncrementDesktopErrors()
+					log.Println("deviceClient.Ping: ", err)
 					continue
 				}
 			}

--- a/orbit/changes/31592-improve-offline-indicator
+++ b/orbit/changes/31592-improve-offline-indicator
@@ -1,0 +1,1 @@
+* Fixed offline indicator to be less sensitive to transient network failures and faster recovery when connectivity is restored.

--- a/orbit/cmd/orbit/orbit.go
+++ b/orbit/cmd/orbit/orbit.go
@@ -1242,9 +1242,9 @@ func main() {
 				// This is better than using a ticker that ticks every hour because the
 				// we can't ensure the tick actually runs every hour (eg: the computer is
 				// asleep).
-				rotationDuration := 30 * time.Second
-				rotationTicker := time.NewTicker(rotationDuration)
-				defer rotationTicker.Stop()
+				localCheckDuration := 30 * time.Second
+				localCheckTicker := time.NewTicker(localCheckDuration)
+				defer localCheckTicker.Stop()
 
 				// This timer is used to periodically check if the token is valid. The
 				// server might deem a toked as invalid for reasons out of our control,
@@ -1256,10 +1256,10 @@ func main() {
 
 				for {
 					select {
-					case <-rotationTicker.C:
-						rotationTicker.Reset(rotationDuration)
+					case <-localCheckTicker.C:
+						localCheckTicker.Reset(localCheckDuration)
 
-						log.Debug().Msgf("checking if token has changed or expired, cached mtime: %s", trw.GetMtime())
+						log.Debug().Msgf("initiating local token check, cached mtime: %s", trw.GetMtime())
 						hasChanged, err := trw.HasChanged()
 						if err != nil {
 							log.Error().Err(err).Msg("error checking if token has changed")
@@ -1275,10 +1275,10 @@ func main() {
 							if err := trw.Rotate(); err != nil {
 								log.Error().Err(err).Msg("error rotating token")
 							}
-						} else if remain > 0 && remain < rotationDuration {
+						} else if remain > 0 && remain < localCheckDuration {
 							// check again when the token will expire, which will happen
 							// before the next rotation check
-							rotationTicker.Reset(remain)
+							localCheckTicker.Reset(remain)
 							log.Debug().Msgf("token will expire soon, checking again in: %s", remain)
 						}
 

--- a/server/service/handler.go
+++ b/server/service/handler.go
@@ -801,68 +801,68 @@ func attachFleetAPIRoutes(r *mux.Router, svc fleet.Service, config config.FleetC
 	// properly
 	desktopQuota := throttled.RateQuota{MaxRate: throttled.PerHour(720), MaxBurst: desktopRateLimitMaxBurst}
 	de.WithCustomMiddleware(
-		errorLimiter.Limit("get_device_host", desktopQuota),
+		errorLimiter.Limit("get_device_host", desktopQuota, logger),
 	).GET("/api/_version_/fleet/device/{token}", getDeviceHostEndpoint, getDeviceHostRequest{})
 	de.WithCustomMiddleware(
-		errorLimiter.Limit("get_fleet_desktop", desktopQuota),
+		errorLimiter.Limit("get_fleet_desktop", desktopQuota, logger),
 	).GET("/api/_version_/fleet/device/{token}/desktop", getFleetDesktopEndpoint, getFleetDesktopRequest{})
 	de.WithCustomMiddleware(
-		errorLimiter.Limit("ping_device_auth", desktopQuota),
+		errorLimiter.Limit("ping_device_auth", desktopQuota, logger),
 	).HEAD("/api/_version_/fleet/device/{token}/ping", devicePingEndpoint, deviceAuthPingRequest{})
 	de.WithCustomMiddleware(
-		errorLimiter.Limit("refetch_device_host", desktopQuota),
+		errorLimiter.Limit("refetch_device_host", desktopQuota, logger),
 	).POST("/api/_version_/fleet/device/{token}/refetch", refetchDeviceHostEndpoint, refetchDeviceHostRequest{})
 	de.WithCustomMiddleware(
-		errorLimiter.Limit("get_device_mapping", desktopQuota),
+		errorLimiter.Limit("get_device_mapping", desktopQuota, logger),
 	).GET("/api/_version_/fleet/device/{token}/device_mapping", listDeviceHostDeviceMappingEndpoint, listDeviceHostDeviceMappingRequest{})
 	de.WithCustomMiddleware(
-		errorLimiter.Limit("get_device_macadmins", desktopQuota),
+		errorLimiter.Limit("get_device_macadmins", desktopQuota, logger),
 	).GET("/api/_version_/fleet/device/{token}/macadmins", getDeviceMacadminsDataEndpoint, getDeviceMacadminsDataRequest{})
 	de.WithCustomMiddleware(
-		errorLimiter.Limit("get_device_policies", desktopQuota),
+		errorLimiter.Limit("get_device_policies", desktopQuota, logger),
 	).GET("/api/_version_/fleet/device/{token}/policies", listDevicePoliciesEndpoint, listDevicePoliciesRequest{})
 	de.WithCustomMiddleware(
-		errorLimiter.Limit("get_device_transparency", desktopQuota),
+		errorLimiter.Limit("get_device_transparency", desktopQuota, logger),
 	).GET("/api/_version_/fleet/device/{token}/transparency", transparencyURL, transparencyURLRequest{})
 	de.WithCustomMiddleware(
-		errorLimiter.Limit("send_device_error", desktopQuota),
+		errorLimiter.Limit("send_device_error", desktopQuota, logger),
 	).POST("/api/_version_/fleet/device/{token}/debug/errors", fleetdError, fleetdErrorRequest{})
 	de.WithCustomMiddleware(
-		errorLimiter.Limit("get_device_software", desktopQuota),
+		errorLimiter.Limit("get_device_software", desktopQuota, logger),
 	).GET("/api/_version_/fleet/device/{token}/software", getDeviceSoftwareEndpoint, getDeviceSoftwareRequest{})
 	de.WithCustomMiddleware(
-		errorLimiter.Limit("install_self_service", desktopQuota),
+		errorLimiter.Limit("install_self_service", desktopQuota, logger),
 	).POST("/api/_version_/fleet/device/{token}/software/install/{software_title_id}", submitSelfServiceSoftwareInstall, fleetSelfServiceSoftwareInstallRequest{})
 	de.WithCustomMiddleware(
-		errorLimiter.Limit("uninstall_self_service", desktopQuota),
+		errorLimiter.Limit("uninstall_self_service", desktopQuota, logger),
 	).POST("/api/_version_/fleet/device/{token}/software/uninstall/{software_title_id}", submitDeviceSoftwareUninstall, fleetDeviceSoftwareUninstallRequest{})
 	de.WithCustomMiddleware(
-		errorLimiter.Limit("get_device_software_install_results", desktopQuota),
+		errorLimiter.Limit("get_device_software_install_results", desktopQuota, logger),
 	).GET("/api/_version_/fleet/device/{token}/software/install/{install_uuid}/results", getDeviceSoftwareInstallResultsEndpoint,
 		getDeviceSoftwareInstallResultsRequest{})
 	de.WithCustomMiddleware(
-		errorLimiter.Limit("get_device_software_uninstall_results", desktopQuota),
+		errorLimiter.Limit("get_device_software_uninstall_results", desktopQuota, logger),
 	).GET("/api/_version_/fleet/device/{token}/software/uninstall/{execution_id}/results", getDeviceSoftwareUninstallResultsEndpoint, getDeviceSoftwareUninstallResultsRequest{})
 	de.WithCustomMiddleware(
-		errorLimiter.Limit("get_device_certificates", desktopQuota),
+		errorLimiter.Limit("get_device_certificates", desktopQuota, logger),
 	).GET("/api/_version_/fleet/device/{token}/certificates", listDeviceCertificatesEndpoint, listDeviceCertificatesRequest{})
 
 	// mdm-related endpoints available via device authentication
 	demdm := de.WithCustomMiddleware(mdmConfiguredMiddleware.VerifyAppleMDM())
 	demdm.WithCustomMiddleware(
-		errorLimiter.Limit("get_device_mdm", desktopQuota),
+		errorLimiter.Limit("get_device_mdm", desktopQuota, logger),
 	).GET("/api/_version_/fleet/device/{token}/mdm/apple/manual_enrollment_profile", getDeviceMDMManualEnrollProfileEndpoint, getDeviceMDMManualEnrollProfileRequest{})
 	demdm.WithCustomMiddleware(
-		errorLimiter.Limit("get_device_software_mdm_command_results", desktopQuota),
+		errorLimiter.Limit("get_device_software_mdm_command_results", desktopQuota, logger),
 	).GET("/api/_version_/fleet/device/{token}/software/commands/{command_uuid}/results", getDeviceMDMCommandResultsEndpoint,
 		getDeviceMDMCommandResultsRequest{})
 
 	demdm.WithCustomMiddleware(
-		errorLimiter.Limit("post_device_migrate_mdm", desktopQuota),
+		errorLimiter.Limit("post_device_migrate_mdm", desktopQuota, logger),
 	).POST("/api/_version_/fleet/device/{token}/migrate_mdm", migrateMDMDeviceEndpoint, deviceMigrateMDMRequest{})
 
 	de.WithCustomMiddleware(
-		errorLimiter.Limit("post_device_trigger_linux_escrow", desktopQuota),
+		errorLimiter.Limit("post_device_trigger_linux_escrow", desktopQuota, logger),
 	).POST("/api/_version_/fleet/device/{token}/mdm/linux/trigger_escrow", triggerLinuxDiskEncryptionEscrowEndpoint, triggerLinuxDiskEncryptionEscrowRequest{})
 
 	// host-authenticated endpoints


### PR DESCRIPTION
Cherrypick for #31592 into fleetd 1.46.0's RC branch.

This is also adding server changes but it's probably a-ok given this RC branch will only be used to release fleetd.
However, I'm interested on adding the osquery-perf changes for load-testing this change.