### PR TITLE
Make sure VEX report is up-to-date with a CI check

### DIFF
--- a/.github/workflows/check-automated-doc.yml
+++ b/.github/workflows/check-automated-doc.yml
@@ -46,10 +46,10 @@ jobs:
 
       - name: Verify golang generated documentation is up-to-date
         run: |
-          make doc
+          make generate-doc
           if [[ $(git diff) ]]; then
             echo "❌ fail: uncommited changes"
-            echo "please run 'make doc' and commit the changes"
+            echo "please run 'make generate-doc' and commit the changes"
             git --no-pager diff
             exit 1
           fi
@@ -62,6 +62,16 @@ jobs:
           if [[ $(git diff) ]]; then
             echo "❌ fail: uncommited changes"
             echo "please run 'cd website && npm install && ./node_modules/sails/bin/sails.js run generate-merged-schema' and commit the changes"
+            git --no-pager diff
+            exit 1
+          fi
+
+      - name: Verify VEX report is up-to-date
+        run: |
+          make vex-report
+          if [[ $(git diff) ]]; then
+            echo "❌ fail: uncommited changes"
+            echo "please run 'make vex-report' and commit the changes"
             git --no-pager diff
             exit 1
           fi

--- a/Makefile
+++ b/Makefile
@@ -412,7 +412,7 @@ doc: .prefix
 	go generate github.com/fleetdm/fleet/v4/server/fleet
 	go generate github.com/fleetdm/fleet/v4/server/service/osquery_utils
 
-generate-doc: doc vex-report
+generate-doc: doc
 
 .help-short--deps:
 	@echo "Install dependent programs and libraries"


### PR DESCRIPTION
We didn't add VEX initially to CI to reduce CI failures. But now seems VEX is not causing issues so we are now adding it to the CI check for outdated documentation.