### PR TITLE
Website: Update deploy workflow to remove `website/assets` folder from website's build slug.

### DIFF
--- a/.github/workflows/deploy-fleet-website.yml
+++ b/.github/workflows/deploy-fleet-website.yml
@@ -106,6 +106,8 @@ jobs:
     # > The local config flags make this work in GitHub's environment.
     - run: git add website/.www
     - run: git add website/.tools
+    # Remove the website/assets folder
+    - run: git rm -rf --cached website/assets
     - run: git add -f website/views/partials/built-from-markdown  > /dev/null 2>&1 || echo '* * * WARNING - Silently ignoring the fact that there are no HTML partials generated from markdown to include in automated commit...'
     - run: git -c "user.name=Fleetwood" -c "user.email=github@example.com" commit -am 'AUTOMATED COMMIT - Deployed the latest, including generated collateral such as compiled documentation, modified HTML layouts, and a .sailsrc file that references minified client-side code assets.'
 


### PR DESCRIPTION
Related to: #31753

Changes:
- Updated the "Deploy Fleet website" workflow to remove the `website/assets` folder from the website's build slug when the website deploys.