### PR TITLE
Added verification support for $FLEET_VAR_HOST_UUID

### DIFF
--- a/server/mdm/apple/mobileconfig/mobileconfig.go
+++ b/server/mdm/apple/mobileconfig/mobileconfig.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/fleetdm/fleet/v4/server/mdm"
+	"github.com/fleetdm/fleet/v4/server/variables"
 
 	// we are using this package as we were having issues with pasrsing signed apple
 	// mobileconfig profiles with the pcks7 package we were using before.
@@ -112,14 +113,14 @@ func getSignedProfileData(mc Mobileconfig) (Mobileconfig, error) {
 func (mc Mobileconfig) ParseConfigProfile() (*Parsed, error) {
 	mcBytes := mc
 	// Remove Fleet variables expected in <data> section.
-	mcBytes = mdm.ProfileDataVariableRegex.ReplaceAll(mcBytes, []byte(""))
+	mcBytes = variables.ProfileDataVariableRegex.ReplaceAll(mcBytes, []byte(""))
 	if mc.isSignedProfile() {
 		profileData, err := getSignedProfileData(mc)
 		if err != nil {
 			return nil, err
 		}
 		mcBytes = profileData
-		if mdm.ProfileVariableRegex.Match(mcBytes) {
+		if variables.FleetVariableRegex.Match(mcBytes) {
 			return nil, errors.New("a signed profile cannot contain Fleet variables ($FLEET_VAR_*)")
 		}
 	}
@@ -164,14 +165,14 @@ type payloadSummary struct {
 func (mc Mobileconfig) payloadSummary() ([]payloadSummary, error) {
 	mcBytes := mc
 	// Remove Fleet variables expected in <data> section.
-	mcBytes = mdm.ProfileDataVariableRegex.ReplaceAll(mcBytes, []byte(""))
+	mcBytes = variables.ProfileDataVariableRegex.ReplaceAll(mcBytes, []byte(""))
 	if mc.isSignedProfile() {
 		profileData, err := getSignedProfileData(mc)
 		if err != nil {
 			return nil, err
 		}
 		mcBytes = profileData
-		if mdm.ProfileVariableRegex.Match(mcBytes) {
+		if variables.FleetVariableRegex.Match(mcBytes) {
 			return nil, errors.New("a signed profile cannot contain Fleet variables ($FLEET_VAR_*)")
 		}
 	}

--- a/server/mdm/apple/mobileconfig/mobileconfig.go
+++ b/server/mdm/apple/mobileconfig/mobileconfig.go
@@ -120,7 +120,7 @@ func (mc Mobileconfig) ParseConfigProfile() (*Parsed, error) {
 			return nil, err
 		}
 		mcBytes = profileData
-		if variables.FleetVariableRegex.Match(mcBytes) {
+		if variables.Contains(string(mcBytes)) {
 			return nil, errors.New("a signed profile cannot contain Fleet variables ($FLEET_VAR_*)")
 		}
 	}
@@ -172,7 +172,7 @@ func (mc Mobileconfig) payloadSummary() ([]payloadSummary, error) {
 			return nil, err
 		}
 		mcBytes = profileData
-		if variables.FleetVariableRegex.Match(mcBytes) {
+		if variables.Contains(string(mcBytes)) {
 			return nil, errors.New("a signed profile cannot contain Fleet variables ($FLEET_VAR_*)")
 		}
 	}

--- a/server/mdm/apple/mobileconfig/mobileconfig.go
+++ b/server/mdm/apple/mobileconfig/mobileconfig.go
@@ -120,7 +120,7 @@ func (mc Mobileconfig) ParseConfigProfile() (*Parsed, error) {
 			return nil, err
 		}
 		mcBytes = profileData
-		if variables.Contains(string(mcBytes)) {
+		if variables.ContainsBytes(mcBytes) {
 			return nil, errors.New("a signed profile cannot contain Fleet variables ($FLEET_VAR_*)")
 		}
 	}
@@ -172,7 +172,7 @@ func (mc Mobileconfig) payloadSummary() ([]payloadSummary, error) {
 			return nil, err
 		}
 		mcBytes = profileData
-		if variables.Contains(string(mcBytes)) {
+		if variables.ContainsBytes(mcBytes) {
 			return nil, errors.New("a signed profile cannot contain Fleet variables ($FLEET_VAR_*)")
 		}
 	}

--- a/server/mdm/mdm.go
+++ b/server/mdm/mdm.go
@@ -10,15 +10,9 @@ import (
 	"encoding/base64"
 	"fmt"
 	"io"
-	"regexp"
 
 	"github.com/smallstep/pkcs7"
 )
-
-var ProfileVariableRegex = regexp.MustCompile(`(\$FLEET_VAR_(?P<name1>\w+))|(\${FLEET_VAR_(?P<name2>\w+)})`)
-
-// ProfileDataVariableRegex matches variables present in <data> section of Apple profile, which may cause validation issues.
-var ProfileDataVariableRegex = regexp.MustCompile(`(\$FLEET_VAR_DIGICERT_DATA_(?P<name1>\w+))|(\${FLEET_VAR_DIGICERT_DATA_(?P<name2>\w+)})`)
 
 // MaxProfileRetries is the maximum times an install profile command may be
 // retried, after which marked as failed and no further attempts will be made

--- a/server/mdm/microsoft/profile_verifier.go
+++ b/server/mdm/microsoft/profile_verifier.go
@@ -307,7 +307,7 @@ func PreprocessWindowsProfileContents(hostUUID string, profileContents string) s
 	// Process each Fleet variable
 	result := profileContents
 	for fleetVar := range fleetVars {
-		if fleetVar == "HOST_UUID" {
+		if fleetVar == string(fleet.FleetVarHostUUID) {
 			// Replace HOST_UUID with the actual host UUID
 			// Use XML escaping for the replacement value to be safe and prevent XML injection
 			b := make([]byte, 0, len(hostUUID))
@@ -315,9 +315,7 @@ func PreprocessWindowsProfileContents(hostUUID string, profileContents string) s
 			_ = xml.EscapeText(buf, []byte(hostUUID))
 			escapedUUID := buf.String()
 
-			// Replace both braced and non-braced versions
-			result = strings.ReplaceAll(result, fmt.Sprintf("$FLEET_VAR_%s", fleetVar), escapedUUID)
-			result = strings.ReplaceAll(result, fmt.Sprintf("${FLEET_VAR_%s}", fleetVar), escapedUUID)
+			result = variables.Replace(result, fleetVar, escapedUUID)
 		}
 		// Add other Fleet variables here as they are implemented
 	}

--- a/server/mdm/microsoft/profile_verifier.go
+++ b/server/mdm/microsoft/profile_verifier.go
@@ -16,6 +16,7 @@ import (
 	"github.com/fleetdm/fleet/v4/server/mdm"
 	"github.com/fleetdm/fleet/v4/server/mdm/microsoft/admx"
 	"github.com/fleetdm/fleet/v4/server/mdm/microsoft/wlanxml"
+	"github.com/fleetdm/fleet/v4/server/variables"
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 )
@@ -42,7 +43,12 @@ func LoopOverExpectedHostProfiles(
 		if err != nil {
 			return ctxerr.Wrapf(ctx, err, "expanding embedded secrets for profile %s", expectedProf.Name)
 		}
-		expectedProf.RawProfile = []byte(expanded)
+
+		// Process Fleet variables if present (similar to how it's done during profile deployment)
+		// This ensures we compare what was actually sent to the device
+		processedContent := PreprocessWindowsProfileContents(host.UUID, expanded)
+		expectedProf.RawProfile = []byte(processedContent)
+
 		var prof fleet.SyncMLCmd
 		wrappedBytes := fmt.Sprintf("<Atomic>%s</Atomic>", expectedProf.RawProfile)
 		if err := xml.Unmarshal([]byte(wrappedBytes), &prof); err != nil {
@@ -270,4 +276,51 @@ func IsWin32OrDesktopBridgeADMXCSP(locURI string) bool {
 		return strings.Contains(normalizedLocURI, "~")
 	}
 	return false
+}
+
+// PreprocessWindowsProfileContents processes Windows configuration profiles to replace Fleet variables
+// with their actual values for each host. This function is used both during profile deployment
+// and during profile verification to ensure consistency.
+//
+// The function handles XML escaping to prevent injection attacks.
+//
+// Currently supported variables:
+//   - $FLEET_VAR_HOST_UUID or ${FLEET_VAR_HOST_UUID}: Replaced with the host's UUID
+//
+// Why we don't use Go templates here:
+//  1. Error handling: Go templates don't provide fine-grained error handling for individual variable
+//     replacements. We need to handle failures per-host and per-variable gracefully.
+//  2. Variable dependencies: Some variables may be related or have dependencies on each other. With
+//     manual processing, we can control the order of variable replacement precisely.
+//  3. Performance: Templates must be compiled every time they're used, adding overhead when processing
+//     thousands of host profiles. Direct string replacement is more efficient for our use case.
+//  4. XML escaping: We need XML-specific escaping for values, which is simpler to control with direct
+//     string replacement rather than template functions.
+func PreprocessWindowsProfileContents(hostUUID string, profileContents string) string {
+	// Check if Fleet variables are present
+	fleetVars := variables.Find(profileContents)
+	if len(fleetVars) == 0 {
+		// No variables to replace, return original content
+		return profileContents
+	}
+
+	// Process each Fleet variable
+	result := profileContents
+	for fleetVar := range fleetVars {
+		if fleetVar == "HOST_UUID" {
+			// Replace HOST_UUID with the actual host UUID
+			// Use XML escaping for the replacement value to be safe and prevent XML injection
+			b := make([]byte, 0, len(hostUUID))
+			buf := bytes.NewBuffer(b)
+			_ = xml.EscapeText(buf, []byte(hostUUID))
+			escapedUUID := buf.String()
+
+			// Replace both braced and non-braced versions
+			result = strings.ReplaceAll(result, fmt.Sprintf("$FLEET_VAR_%s", fleetVar), escapedUUID)
+			result = strings.ReplaceAll(result, fmt.Sprintf("${FLEET_VAR_%s}", fleetVar), escapedUUID)
+		}
+		// Add other Fleet variables here as they are implemented
+	}
+
+	return result
 }

--- a/server/service/appconfig.go
+++ b/server/service/appconfig.go
@@ -25,6 +25,7 @@ import (
 	"github.com/fleetdm/fleet/v4/server/contexts/license"
 	"github.com/fleetdm/fleet/v4/server/contexts/viewer"
 	"github.com/fleetdm/fleet/v4/server/fleet"
+	"github.com/fleetdm/fleet/v4/server/variables"
 	"github.com/fleetdm/fleet/v4/server/version"
 	"github.com/go-kit/log/level"
 	"golang.org/x/text/unicode/norm"
@@ -1407,7 +1408,7 @@ func validateCACN(cn string, invalid *fleet.InvalidArgumentError) bool {
 		invalid.Append("integrations.digicert.certificate_common_name", "CA Common Name (CN) cannot be empty")
 		return false
 	}
-	fleetVars := findFleetVariables(cn)
+	fleetVars := variables.Find(cn)
 	for fleetVar := range fleetVars {
 		switch fleetVar {
 		case string(fleet.FleetVarHostEndUserEmailIDP), string(fleet.FleetVarHostHardwareSerial):
@@ -1425,7 +1426,7 @@ func validateSeatID(seatID string, invalid *fleet.InvalidArgumentError) bool {
 		invalid.Append("integrations.digicert.certificate_seat_id", "CA Seat ID cannot be empty")
 		return false
 	}
-	fleetVars := findFleetVariables(seatID)
+	fleetVars := variables.Find(seatID)
 	for fleetVar := range fleetVars {
 		switch fleetVar {
 		case string(fleet.FleetVarHostEndUserEmailIDP), string(fleet.FleetVarHostHardwareSerial):
@@ -1452,7 +1453,7 @@ func validateUserPrincipalNames(userPrincipalNames []string, invalid *fleet.Inva
 			"DigiCert CA certificate user principal name cannot be empty if specified")
 		return false
 	}
-	fleetVars := findFleetVariables(userPrincipalNames[0])
+	fleetVars := variables.Find(userPrincipalNames[0])
 	for fleetVar := range fleetVars {
 		switch fleetVar {
 		case string(fleet.FleetVarHostEndUserEmailIDP), string(fleet.FleetVarHostHardwareSerial):

--- a/server/service/apple_mdm.go
+++ b/server/service/apple_mdm.go
@@ -498,7 +498,7 @@ func validateConfigProfileFleetVariables(appConfig *fleet.AppConfig, contents st
 	}
 
 	// Check for premium license if the profile contains Fleet variables
-	if lic != nil && !lic.IsPremium() {
+	if lic == nil || !lic.IsPremium() {
 		return nil, fleet.ErrMissingLicense
 	}
 	var (

--- a/server/service/apple_mdm.go
+++ b/server/service/apple_mdm.go
@@ -957,7 +957,7 @@ func (svc *Service) NewMDMAppleDeclaration(ctx context.Context, teamID uint, r i
 }
 
 func validateDeclarationFleetVariables(contents string) error {
-	if len(variables.Find(contents)) > 0 {
+	if variables.Contains(contents) {
 		return &fleet.BadRequestError{Message: "Fleet variables ($FLEET_VAR_*) are not currently supported in DDM profiles"}
 	}
 	return nil

--- a/server/service/apple_mdm.go
+++ b/server/service/apple_mdm.go
@@ -53,6 +53,7 @@ import (
 	nano_service "github.com/fleetdm/fleet/v4/server/mdm/nanomdm/service"
 	"github.com/fleetdm/fleet/v4/server/ptr"
 	"github.com/fleetdm/fleet/v4/server/service/middleware/endpoint_utils"
+	"github.com/fleetdm/fleet/v4/server/variables"
 	"github.com/fleetdm/fleet/v4/server/worker"
 	kitlog "github.com/go-kit/log"
 	"github.com/go-kit/log/level"
@@ -484,7 +485,7 @@ func (svc *Service) NewMDMAppleConfigProfile(ctx context.Context, teamID uint, r
 }
 
 func validateConfigProfileFleetVariables(appConfig *fleet.AppConfig, contents string) (map[string]struct{}, error) {
-	fleetVars := findFleetVariablesKeepDuplicates(contents)
+	fleetVars := variables.FindKeepDuplicates(contents)
 	if len(fleetVars) == 0 {
 		return nil, nil
 	}
@@ -591,14 +592,19 @@ func validateConfigProfileFleetVariables(appConfig *fleet.AppConfig, contents st
 			return nil, err
 		}
 	}
-	return dedupeFleetVariables(fleetVars), nil
+	// Convert slice to map for deduplication
+	result := make(map[string]struct{}, len(fleetVars))
+	for _, v := range fleetVars {
+		result[v] = struct{}{}
+	}
+	return result, nil
 }
 
 // additionalDigiCertValidation checks that Password/ContentType fields match DigiCert Fleet variables exactly,
 // and that these variables are only present in a "com.apple.security.pkcs12" payload
 func additionalDigiCertValidation(contents string, digiCertVars *digiCertVarsFound) error {
 	// Find and replace matches in base64 encoded data contents so we can unmarshal the plist and keep the Fleet vars.
-	contents = mdm_types.ProfileDataVariableRegex.ReplaceAllStringFunc(contents, func(match string) string {
+	contents = variables.ProfileDataVariableRegex.ReplaceAllStringFunc(contents, func(match string) string {
 		return base64.StdEncoding.EncodeToString([]byte(match))
 	})
 
@@ -738,7 +744,7 @@ func checkThatOnlyOneSCEPPayloadIsPresent(scepProf SCEPProfileContent) (SCEPPayl
 
 func unmarshalSCEPProfile(contents string) (SCEPProfileContent, error) {
 	// Replace any Fleet variables in data fields. SCEP payload does not need them and we cannot unmarshal if they are present.
-	contents = mdm_types.ProfileDataVariableRegex.ReplaceAllString(contents, "")
+	contents = variables.ProfileDataVariableRegex.ReplaceAllString(contents, "")
 	var scepProf SCEPProfileContent
 	err := plist.Unmarshal([]byte(contents), &scepProf)
 	if err != nil {
@@ -951,7 +957,7 @@ func (svc *Service) NewMDMAppleDeclaration(ctx context.Context, teamID uint, r i
 }
 
 func validateDeclarationFleetVariables(contents string) error {
-	if len(findFleetVariables(contents)) > 0 {
+	if len(variables.Find(contents)) > 0 {
 		return &fleet.BadRequestError{Message: "Fleet variables ($FLEET_VAR_*) are not currently supported in DDM profiles"}
 	}
 	return nil
@@ -2595,7 +2601,7 @@ func (svc *Service) BatchSetMDMAppleProfiles(ctx context.Context, tmID *uint, tm
 		}
 
 		// check if the profile has any fleet variable, not supported by this deprecated endpoint
-		if vars := findFleetVariablesKeepDuplicates(expanded); len(vars) > 0 {
+		if vars := variables.FindKeepDuplicates(expanded); len(vars) > 0 {
 			return ctxerr.Wrap(ctx,
 				fleet.NewInvalidArgumentError(
 					fmt.Sprintf("profiles[%d]", i), "profile variables are not supported by this deprecated endpoint, use POST /api/latest/fleet/mdm/profiles/batch"))
@@ -4862,7 +4868,7 @@ func preprocessProfileContents(
 
 		// Check if Fleet variables are present.
 		contentsStr := string(contents)
-		fleetVars := findFleetVariables(contentsStr)
+		fleetVars := variables.Find(contentsStr)
 		if len(fleetVars) == 0 {
 			continue
 		}
@@ -5272,7 +5278,7 @@ func preprocessProfileContents(
 
 func replaceFleetVarInItem(ctx context.Context, ds fleet.Datastore, target *cmdTarget, hostUUID string, caVarsCache map[string]string, item *string,
 ) (bool, error) {
-	caFleetVars := findFleetVariables(*item)
+	caFleetVars := variables.Find(*item)
 	for caVar := range caFleetVars {
 		switch caVar {
 		case string(fleet.FleetVarHostEndUserEmailIDP):
@@ -5866,45 +5872,6 @@ func replaceExactFleetPrefixVariableInXML(prefix string, suffix string, contents
 		return "", err
 	}
 	return re.ReplaceAllLiteralString(contents, fmt.Sprintf(`>%s<`, buf.String())), nil
-}
-
-func findFleetVariables(contents string) map[string]struct{} {
-	resultSlice := findFleetVariablesKeepDuplicates(contents)
-	if len(resultSlice) == 0 {
-		return nil
-	}
-	return dedupeFleetVariables(resultSlice)
-}
-
-func dedupeFleetVariables(varsWithDupes []string) map[string]struct{} {
-	result := make(map[string]struct{}, len(varsWithDupes))
-	for _, v := range varsWithDupes {
-		result[v] = struct{}{}
-	}
-	return result
-}
-
-func findFleetVariablesKeepDuplicates(contents string) []string {
-	var result []string
-	matches := mdm_types.ProfileVariableRegex.FindAllStringSubmatch(contents, -1)
-	if len(matches) == 0 {
-		return nil
-	}
-	nameToIndex := make(map[string]int, 2)
-	for i, name := range mdm_types.ProfileVariableRegex.SubexpNames() {
-		if name == "" {
-			continue
-		}
-		nameToIndex[name] = i
-	}
-	for _, match := range matches {
-		for _, i := range nameToIndex {
-			if match[i] != "" {
-				result = append(result, match[i])
-			}
-		}
-	}
-	return result
 }
 
 // scepCertRenewalThresholdDays defines the number of days before a SCEP

--- a/server/service/apple_mdm_test.go
+++ b/server/service/apple_mdm_test.go
@@ -5080,9 +5080,9 @@ func TestPreprocessProfileContentsEndUserIDP(t *testing.T) {
 }
 
 func TestValidateConfigProfileFleetVariablesLicense(t *testing.T) {
-	t.Run("requires premium license", func(t *testing.T) {
-		appConfig := &fleet.AppConfig{}
-		profileWithVars := `<?xml version="1.0" encoding="UTF-8"?>
+	t.Parallel()
+	appConfig := &fleet.AppConfig{}
+	profileWithVars := `<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
@@ -5100,20 +5100,19 @@ func TestValidateConfigProfileFleetVariablesLicense(t *testing.T) {
 </dict>
 </plist>`
 
-		// Test with free license
-		freeLic := &fleet.LicenseInfo{Tier: fleet.TierFree}
-		_, err := validateConfigProfileFleetVariables(appConfig, profileWithVars, freeLic)
-		require.Error(t, err)
-		require.Equal(t, fleet.ErrMissingLicense, err)
+	// Test with free license
+	freeLic := &fleet.LicenseInfo{Tier: fleet.TierFree}
+	_, err := validateConfigProfileFleetVariables(appConfig, profileWithVars, freeLic)
+	require.ErrorIs(t, err, fleet.ErrMissingLicense)
 
-		// Test with premium license
-		premiumLic := &fleet.LicenseInfo{Tier: fleet.TierPremium}
-		vars, err := validateConfigProfileFleetVariables(appConfig, profileWithVars, premiumLic)
-		require.NoError(t, err)
-		require.Contains(t, vars, "HOST_END_USER_EMAIL_IDP")
+	// Test with premium license
+	premiumLic := &fleet.LicenseInfo{Tier: fleet.TierPremium}
+	vars, err := validateConfigProfileFleetVariables(appConfig, profileWithVars, premiumLic)
+	require.NoError(t, err)
+	require.Contains(t, vars, "HOST_END_USER_EMAIL_IDP")
 
-		// Test profile without variables (should work with free license)
-		profileNoVars := `<?xml version="1.0" encoding="UTF-8"?>
+	// Test profile without variables (should work with free license)
+	profileNoVars := `<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
@@ -5130,10 +5129,9 @@ func TestValidateConfigProfileFleetVariablesLicense(t *testing.T) {
 	</array>
 </dict>
 </plist>`
-		vars, err = validateConfigProfileFleetVariables(appConfig, profileNoVars, freeLic)
-		require.NoError(t, err)
-		require.Nil(t, vars)
-	})
+	vars, err = validateConfigProfileFleetVariables(appConfig, profileNoVars, freeLic)
+	require.NoError(t, err)
+	require.Empty(t, vars)
 }
 
 func TestValidateConfigProfileFleetVariables(t *testing.T) {

--- a/server/service/integration_mdm_profiles_test.go
+++ b/server/service/integration_mdm_profiles_test.go
@@ -7329,12 +7329,20 @@ func (s *integrationMDMTestSuite) TestWindowsProfilesFleetVariableSubstitution()
 		// Set profile timestamps to 2 hours ago
 		// IMPORTANT: uploaded_at is used as EarliestInstallDate in verification logic
 		_, err := q.ExecContext(ctx,
-			`UPDATE mdm_windows_configuration_profiles SET created_at = DATE_SUB(NOW(), INTERVAL 2 HOUR), uploaded_at = DATE_SUB(NOW(), INTERVAL 2 HOUR)`)
+			`UPDATE mdm_windows_configuration_profiles
+			 SET created_at = DATE_SUB(NOW(), INTERVAL 2 HOUR),
+			     uploaded_at = DATE_SUB(NOW(), INTERVAL 2 HOUR)
+			 WHERE name IN (?, ?, ?)`,
+			"GlobalProfileWithVar", "TeamProfileWithVar", "ProfileNoVars")
 		if err != nil {
 			return err
 		}
 		// Also update the host profile associations to have old timestamps (only created_at)
-		_, err = q.ExecContext(ctx, `UPDATE host_mdm_windows_profiles SET created_at = DATE_SUB(NOW(), INTERVAL 2 HOUR)`)
+		_, err = q.ExecContext(ctx,
+			`UPDATE host_mdm_windows_profiles
+			 SET created_at = DATE_SUB(NOW(), INTERVAL 2 HOUR)
+			 WHERE host_uuid IN (?, ?, ?, ?)`,
+			hostGlobal1.UUID, hostGlobal2.UUID, hostTeam.UUID, hostNoVars.UUID)
 		if err != nil {
 			return err
 		}

--- a/server/service/integration_mdm_profiles_test.go
+++ b/server/service/integration_mdm_profiles_test.go
@@ -7260,16 +7260,228 @@ func (s *integrationMDMTestSuite) TestWindowsProfilesFleetVariableSubstitution()
 	verifyProfileSubstitution(deviceTeam, hostTeam.UUID, "Team Device: "+hostTeam.UUID)
 
 	// Check that profile statuses are updated correctly in the database
-	checkHostProfileStatus := func(hostUUID string, expectedStatus fleet.MDMDeliveryStatus) {
+	checkHostProfileStatus := func(hostUUID string, profileName string, expectedStatus fleet.MDMDeliveryStatus) {
 		profiles, err := s.ds.GetHostMDMWindowsProfiles(ctx, hostUUID)
 		require.NoError(t, err)
-		require.Len(t, profiles, 1)
-		require.NotNil(t, profiles[0].Status)
-		require.Equal(t, expectedStatus, *profiles[0].Status)
+
+		// Find the specific profile by name
+		var foundProfile *fleet.HostMDMWindowsProfile
+		for _, p := range profiles {
+			if p.Name == profileName {
+				foundProfile = &p
+				break
+			}
+		}
+		require.NotNil(t, foundProfile, "Profile %s not found for host %s", profileName, hostUUID)
+		require.NotNil(t, foundProfile.Status, "Profile %s status is nil for host %s", profileName, hostUUID)
+		assert.Equal(t, expectedStatus, *foundProfile.Status, "Profile %s has unexpected status for host %s", profileName, hostUUID)
 	}
 
-	checkHostProfileStatus(hostGlobal1.UUID, fleet.MDMDeliveryVerifying)
-	checkHostProfileStatus(hostGlobal2.UUID, fleet.MDMDeliveryVerifying)
-	checkHostProfileStatus(hostTeam.UUID, fleet.MDMDeliveryVerifying)
+	checkHostProfileStatus(hostGlobal1.UUID, "GlobalProfileWithVar", fleet.MDMDeliveryVerifying)
+	checkHostProfileStatus(hostGlobal2.UUID, "GlobalProfileWithVar", fleet.MDMDeliveryVerifying)
+	checkHostProfileStatus(hostTeam.UUID, "TeamProfileWithVar", fleet.MDMDeliveryVerifying)
+
+	// Now let's check profile verification
+	// Also create and test a host without Fleet variables to ensure normal verification still works
+	hostNoVars, deviceNoVars := createWindowsHostThenEnrollMDM(s.ds, s.server.URL, t)
+
+	// Create a profile without variables
+	profileNoVars := syncml.ForTestWithData([]syncml.TestCommand{
+		{Verb: "Replace", LocURI: "./Device/Vendor/MSFT/DMClient/Provider/ProviderID/Static/Value", Data: "Static Value: NoSubstitution"},
+	})
+
+	// Upload profile without variables
+	s.Do("POST", "/api/v1/fleet/mdm/profiles/batch",
+		batchSetMDMProfilesRequest{Profiles: []fleet.MDMProfileBatchPayload{
+			{Name: "ProfileNoVars", Contents: profileNoVars},
+		}},
+		http.StatusNoContent)
+
+	// Let the host get the profile
+	s.awaitTriggerProfileSchedule(t)
+	cmds, err := deviceNoVars.StartManagementSession()
+	require.NoError(t, err)
+	msgID, err := deviceNoVars.GetCurrentMsgID()
+	require.NoError(t, err)
+	for _, cmd := range cmds {
+		deviceNoVars.AppendResponse(fleet.SyncMLCmd{
+			XMLName: xml.Name{Local: fleet.CmdStatus},
+			MsgRef:  &msgID,
+			CmdRef:  &cmd.Cmd.CmdID.Value,
+			Cmd:     ptr.String(cmd.Verb),
+			Data:    ptr.String(syncml.CmdStatusOK),
+			CmdID:   fleet.CmdID{Value: uuid.NewString()},
+		})
+	}
+	cmds, err = deviceNoVars.SendResponse()
+	require.NoError(t, err)
+	require.Len(t, cmds, 1) // ack
+
+	checkHostProfileStatus(hostNoVars.UUID, "ProfileNoVars", fleet.MDMDeliveryVerifying)
+
+	// To ensure any verification failures result in retry (pending) status instead of staying as verifying,
+	// we need to be outside the grace period. The grace period check is:
+	// hostDetailUpdatedAt.Before(profileEarliestInstallDate.Add(1 hour))
+	//
+	// We need to make sure the host checked in recently (detail_updated_at = now)
+	// but the profiles are old (created more than 1 hour ago)
+	mysql.ExecAdhocSQL(t, s.ds, func(q sqlx.ExtContext) error {
+		// Set profile timestamps to 2 hours ago
+		// IMPORTANT: uploaded_at is used as EarliestInstallDate in verification logic
+		_, err := q.ExecContext(ctx,
+			`UPDATE mdm_windows_configuration_profiles SET created_at = DATE_SUB(NOW(), INTERVAL 2 HOUR), uploaded_at = DATE_SUB(NOW(), INTERVAL 2 HOUR)`)
+		if err != nil {
+			return err
+		}
+		// Also update the host profile associations to have old timestamps (only created_at)
+		_, err = q.ExecContext(ctx, `UPDATE host_mdm_windows_profiles SET created_at = DATE_SUB(NOW(), INTERVAL 2 HOUR)`)
+		if err != nil {
+			return err
+		}
+		// Set host detail_updated_at to now (recent check-in)
+		_, err = q.ExecContext(ctx, `UPDATE hosts SET detail_updated_at = NOW() WHERE id IN (?, ?, ?, ?)`,
+			hostGlobal1.ID, hostGlobal2.ID, hostTeam.ID, hostNoVars.ID)
+		return err
+	})
+
+	// Helper to simulate osquery reporting back profile data
+	simulateOsqueryProfileReport := func(nodeKey string, profileName string, locURI string, reportedData string) {
+		// Build a SyncML response that osquery would send back after reading the profile from Windows
+		cmdRef := microsoft_mdm.HashLocURI(profileName, locURI)
+
+		var msg fleet.SyncML
+		msg.Xmlns = syncml.SyncCmdNamespace
+		msg.SyncHdr = fleet.SyncHdr{
+			VerDTD:    syncml.SyncMLSupportedVersion,
+			VerProto:  syncml.SyncMLVerProto,
+			SessionID: "2",
+			MsgID:     "2",
+		}
+
+		// Add status response (profile was successfully applied)
+		msg.AppendCommand(fleet.MDMRaw, fleet.SyncMLCmd{
+			XMLName: xml.Name{Local: fleet.CmdStatus},
+			CmdID:   fleet.CmdID{Value: uuid.NewString()},
+			CmdRef:  &cmdRef,
+			Data:    ptr.String("200"),
+		})
+
+		// Add results with the data that osquery read from Windows
+		msg.AppendCommand(fleet.MDMRaw, fleet.SyncMLCmd{
+			XMLName: xml.Name{Local: fleet.CmdResults},
+			CmdID:   fleet.CmdID{Value: uuid.NewString()},
+			CmdRef:  &cmdRef,
+			Items: []fleet.CmdItem{
+				{
+					Target: ptr.String(locURI),
+					Data: &fleet.RawXmlData{
+						Content: reportedData,
+					},
+				},
+			},
+		})
+
+		rawResponse, err := xml.Marshal(msg)
+		require.NoError(t, err)
+
+		// Submit the results via osquery distributed write endpoint
+		distributedReq := SubmitDistributedQueryResultsRequest{
+			NodeKey: nodeKey,
+			Results: map[string][]map[string]string{
+				"fleet_detail_query_mdm_config_profiles_windows": {
+					{"raw_mdm_command_output": string(rawResponse)},
+				},
+			},
+			Statuses: map[string]fleet.OsqueryStatus{
+				"fleet_detail_query_mdm_config_profiles_windows": 0,
+			},
+		}
+		distributedResp := submitDistributedQueryResultsResponse{}
+		s.DoJSON("POST", "/api/osquery/distributed/write", distributedReq, http.StatusOK, &distributedResp)
+	}
+
+	// First verify that normal profile (without variables) verifies correctly
+	simulateOsqueryProfileReport(
+		*hostNoVars.NodeKey,
+		"ProfileNoVars",
+		"./Device/Vendor/MSFT/DMClient/Provider/ProviderID/Static/Value",
+		"Static Value: NoSubstitution", // osquery reports exactly what was sent
+	)
+
+	// Normal profile should be verified successfully
+	checkHostProfileStatus(hostNoVars.UUID, "ProfileNoVars", fleet.MDMDeliveryVerified)
+
+	// Note: GlobalProfileWithVar was replaced by ProfileNoVars for global hosts
+	// since both are global profiles and Fleet only keeps one profile per host.
+	// So we need to simulate osquery reporting ProfileNoVars for global hosts.
+
+	// Simulate osquery reporting back for global hosts (they have ProfileNoVars)
+	simulateOsqueryProfileReport(
+		*hostGlobal1.NodeKey,
+		"ProfileNoVars",
+		"./Device/Vendor/MSFT/DMClient/Provider/ProviderID/Static/Value",
+		"Static Value: NoSubstitution", // osquery reports exactly what was sent
+	)
+
+	simulateOsqueryProfileReport(
+		*hostGlobal2.NodeKey,
+		"ProfileNoVars",
+		"./Device/Vendor/MSFT/DMClient/Provider/ProviderID/Static/Value",
+		"Static Value: NoSubstitution", // osquery reports exactly what was sent
+	)
+
+	// Simulate osquery reporting back for team host
+	simulateOsqueryProfileReport(
+		*hostTeam.NodeKey,
+		"TeamProfileWithVar",
+		"./Device/Vendor/MSFT/DMClient/Provider/ProviderID/TeamDevice/ID",
+		"Team Device: "+hostTeam.UUID, // osquery reports the substituted value
+	)
+
+	// Global hosts have ProfileNoVars (replaced GlobalProfileWithVar) and should now be verified
+	// after we simulated osquery reporting them
+	checkHostProfileStatus(hostGlobal1.UUID, "ProfileNoVars", fleet.MDMDeliveryVerified)
+	checkHostProfileStatus(hostGlobal2.UUID, "ProfileNoVars", fleet.MDMDeliveryVerified)
+
+	// Team host has TeamProfileWithVar which now correctly verifies with Fleet variables
+	// The fix has been implemented and the profile should be verified successfully
+	checkHostProfileStatus(hostTeam.UUID, "TeamProfileWithVar", fleet.MDMDeliveryVerified)
+
+	// Hit the host details API and check the status in the mdm.profiles section
+	// Verify global host 1
+	var hostResp1 getHostResponse
+	s.DoJSON("GET", fmt.Sprintf("/api/v1/fleet/hosts/%d", hostGlobal1.ID), getHostRequest{}, http.StatusOK, &hostResp1)
+	require.NotNil(t, hostResp1.Host.MDM.Profiles)
+	require.Len(t, *hostResp1.Host.MDM.Profiles, 1)
+	require.Equal(t, "ProfileNoVars", (*hostResp1.Host.MDM.Profiles)[0].Name)
+	require.Equal(t, fleet.MDMDeliveryVerified, (*hostResp1.Host.MDM.Profiles)[0].Status,
+		"Profile should be verified in host details API for global host 1")
+
+	// Verify global host 2
+	var hostResp2 getHostResponse
+	s.DoJSON("GET", fmt.Sprintf("/api/v1/fleet/hosts/%d", hostGlobal2.ID), getHostRequest{}, http.StatusOK, &hostResp2)
+	require.NotNil(t, hostResp2.Host.MDM.Profiles)
+	require.Len(t, *hostResp2.Host.MDM.Profiles, 1)
+	require.Equal(t, "ProfileNoVars", (*hostResp2.Host.MDM.Profiles)[0].Name)
+	require.Equal(t, fleet.MDMDeliveryVerified, (*hostResp2.Host.MDM.Profiles)[0].Status,
+		"Profile should be verified in host details API for global host 2")
+
+	// Verify team host
+	var hostRespTeam getHostResponse
+	s.DoJSON("GET", fmt.Sprintf("/api/v1/fleet/hosts/%d", hostTeam.ID), getHostRequest{}, http.StatusOK, &hostRespTeam)
+	require.NotNil(t, hostRespTeam.Host.MDM.Profiles)
+	require.Len(t, *hostRespTeam.Host.MDM.Profiles, 1)
+	require.Equal(t, "TeamProfileWithVar", (*hostRespTeam.Host.MDM.Profiles)[0].Name)
+	require.Equal(t, fleet.MDMDeliveryVerified, (*hostRespTeam.Host.MDM.Profiles)[0].Status,
+		"Profile should be verified in host details API for team host")
+
+	// Verify no-vars host
+	var hostRespNoVars getHostResponse
+	s.DoJSON("GET", fmt.Sprintf("/api/v1/fleet/hosts/%d", hostNoVars.ID), getHostRequest{}, http.StatusOK, &hostRespNoVars)
+	require.NotNil(t, hostRespNoVars.Host.MDM.Profiles)
+	require.Len(t, *hostRespNoVars.Host.MDM.Profiles, 1)
+	require.Equal(t, "ProfileNoVars", (*hostRespNoVars.Host.MDM.Profiles)[0].Name)
+	require.Equal(t, fleet.MDMDeliveryVerified, (*hostRespNoVars.Host.MDM.Profiles)[0].Status,
+		"Profile should be verified in host details API for no-vars host")
 
 }

--- a/server/service/integration_mdm_profiles_test.go
+++ b/server/service/integration_mdm_profiles_test.go
@@ -7454,7 +7454,7 @@ func (s *integrationMDMTestSuite) TestWindowsProfilesFleetVariableSubstitution()
 	require.NotNil(t, hostResp1.Host.MDM.Profiles)
 	require.Len(t, *hostResp1.Host.MDM.Profiles, 1)
 	require.Equal(t, "ProfileNoVars", (*hostResp1.Host.MDM.Profiles)[0].Name)
-	require.Equal(t, fleet.MDMDeliveryVerified, (*hostResp1.Host.MDM.Profiles)[0].Status,
+	require.Equal(t, fleet.MDMDeliveryVerified, *(*hostResp1.Host.MDM.Profiles)[0].Status,
 		"Profile should be verified in host details API for global host 1")
 
 	// Verify global host 2
@@ -7463,7 +7463,7 @@ func (s *integrationMDMTestSuite) TestWindowsProfilesFleetVariableSubstitution()
 	require.NotNil(t, hostResp2.Host.MDM.Profiles)
 	require.Len(t, *hostResp2.Host.MDM.Profiles, 1)
 	require.Equal(t, "ProfileNoVars", (*hostResp2.Host.MDM.Profiles)[0].Name)
-	require.Equal(t, fleet.MDMDeliveryVerified, (*hostResp2.Host.MDM.Profiles)[0].Status,
+	require.Equal(t, fleet.MDMDeliveryVerified, *(*hostResp2.Host.MDM.Profiles)[0].Status,
 		"Profile should be verified in host details API for global host 2")
 
 	// Verify team host
@@ -7472,7 +7472,7 @@ func (s *integrationMDMTestSuite) TestWindowsProfilesFleetVariableSubstitution()
 	require.NotNil(t, hostRespTeam.Host.MDM.Profiles)
 	require.Len(t, *hostRespTeam.Host.MDM.Profiles, 1)
 	require.Equal(t, "TeamProfileWithVar", (*hostRespTeam.Host.MDM.Profiles)[0].Name)
-	require.Equal(t, fleet.MDMDeliveryVerified, (*hostRespTeam.Host.MDM.Profiles)[0].Status,
+	require.Equal(t, fleet.MDMDeliveryVerified, *(*hostRespTeam.Host.MDM.Profiles)[0].Status,
 		"Profile should be verified in host details API for team host")
 
 	// Verify no-vars host
@@ -7481,7 +7481,7 @@ func (s *integrationMDMTestSuite) TestWindowsProfilesFleetVariableSubstitution()
 	require.NotNil(t, hostRespNoVars.Host.MDM.Profiles)
 	require.Len(t, *hostRespNoVars.Host.MDM.Profiles, 1)
 	require.Equal(t, "ProfileNoVars", (*hostRespNoVars.Host.MDM.Profiles)[0].Name)
-	require.Equal(t, fleet.MDMDeliveryVerified, (*hostRespNoVars.Host.MDM.Profiles)[0].Status,
+	require.Equal(t, fleet.MDMDeliveryVerified, *(*hostRespNoVars.Host.MDM.Profiles)[0].Status,
 		"Profile should be verified in host details API for no-vars host")
 
 }

--- a/server/service/mdm.go
+++ b/server/service/mdm.go
@@ -1541,7 +1541,7 @@ func validateWindowsProfileFleetVariables(contents string, lic *fleet.LicenseInf
 	}
 
 	// Check for premium license if the profile contains Fleet variables
-	if lic != nil && !lic.IsPremium() {
+	if lic == nil || !lic.IsPremium() {
 		return nil, fleet.ErrMissingLicense
 	}
 

--- a/server/service/mdm.go
+++ b/server/service/mdm.go
@@ -41,6 +41,7 @@ import (
 	nanomdm "github.com/fleetdm/fleet/v4/server/mdm/nanomdm/mdm"
 	"github.com/fleetdm/fleet/v4/server/ptr"
 	"github.com/fleetdm/fleet/v4/server/service/middleware/endpoint_utils"
+	"github.com/fleetdm/fleet/v4/server/variables"
 	"github.com/fleetdm/fleet/v4/server/worker"
 	"github.com/go-kit/log/level"
 	"github.com/go-sql-driver/mysql"
@@ -1482,7 +1483,7 @@ func (svc *Service) NewMDMWindowsConfigProfile(ctx context.Context, teamID uint,
 	}
 
 	// Collect Fleet variables used in the profile
-	foundVars := findFleetVariables(string(cp.SyncML))
+	foundVars := variables.Find(string(cp.SyncML))
 	var usesFleetVars []fleet.FleetVarName
 	for varName := range foundVars {
 		usesFleetVars = append(usesFleetVars, fleet.FleetVarName(varName))
@@ -1529,7 +1530,7 @@ var fleetVarsSupportedInWindowsProfiles = []fleet.FleetVarName{
 }
 
 func validateWindowsProfileFleetVariables(contents string) error {
-	foundVars := findFleetVariables(contents)
+	foundVars := variables.Find(contents)
 	if len(foundVars) == 0 {
 		return nil
 	}
@@ -1863,7 +1864,7 @@ func validateFleetVariables(ctx context.Context, appConfig *fleet.AppConfig, app
 			return nil, ctxerr.Wrap(ctx, err, "validating Windows profile Fleet variables")
 		}
 		// Collect Fleet variables for Windows profiles (use unique Name as identifier for Windows)
-		windowsVars := findFleetVariables(string(p.SyncML))
+		windowsVars := variables.Find(string(p.SyncML))
 		if len(windowsVars) > 0 {
 			profileVarsByProfIdentifier[p.Name] = windowsVars
 		}

--- a/server/service/mdm_test.go
+++ b/server/service/mdm_test.go
@@ -1524,7 +1524,7 @@ func TestMDMBatchSetProfiles(t *testing.T) {
 		{
 			"only macOS",
 			&fleet.User{GlobalRole: ptr.String(fleet.RoleAdmin)},
-			false,
+			true,
 			nil,
 			nil,
 			[]fleet.MDMProfileBatchPayload{

--- a/server/service/mdm_test.go
+++ b/server/service/mdm_test.go
@@ -2249,8 +2249,8 @@ func TestBatchSetMDMProfilesLabels(t *testing.T) {
 }
 
 func TestValidateWindowsProfileFleetVariablesLicense(t *testing.T) {
-	t.Run("requires premium license", func(t *testing.T) {
-		profileWithVars := `<Replace>
+	t.Parallel()
+	profileWithVars := `<Replace>
 			<Item>
 				<Target>
 					<LocURI>./Device/Vendor/MSFT/Accounts/DomainName</LocURI>
@@ -2259,20 +2259,19 @@ func TestValidateWindowsProfileFleetVariablesLicense(t *testing.T) {
 			</Item>
 		</Replace>`
 
-		// Test with free license
-		freeLic := &fleet.LicenseInfo{Tier: fleet.TierFree}
-		_, err := validateWindowsProfileFleetVariables(profileWithVars, freeLic)
-		require.Error(t, err)
-		require.Equal(t, fleet.ErrMissingLicense, err)
+	// Test with free license
+	freeLic := &fleet.LicenseInfo{Tier: fleet.TierFree}
+	_, err := validateWindowsProfileFleetVariables(profileWithVars, freeLic)
+	require.ErrorIs(t, err, fleet.ErrMissingLicense)
 
-		// Test with premium license
-		premiumLic := &fleet.LicenseInfo{Tier: fleet.TierPremium}
-		vars, err := validateWindowsProfileFleetVariables(profileWithVars, premiumLic)
-		require.NoError(t, err)
-		require.Contains(t, vars, "HOST_UUID")
+	// Test with premium license
+	premiumLic := &fleet.LicenseInfo{Tier: fleet.TierPremium}
+	vars, err := validateWindowsProfileFleetVariables(profileWithVars, premiumLic)
+	require.NoError(t, err)
+	require.Contains(t, vars, "HOST_UUID")
 
-		// Test profile without variables (should work with free license)
-		profileNoVars := `<Replace>
+	// Test profile without variables (should work with free license)
+	profileNoVars := `<Replace>
 			<Item>
 				<Target>
 					<LocURI>./Device/Vendor/MSFT/Accounts/DomainName</LocURI>
@@ -2280,10 +2279,9 @@ func TestValidateWindowsProfileFleetVariablesLicense(t *testing.T) {
 				<Data>Static Value</Data>
 			</Item>
 		</Replace>`
-		vars, err = validateWindowsProfileFleetVariables(profileNoVars, freeLic)
-		require.NoError(t, err)
-		require.Nil(t, vars)
-	})
+	vars, err = validateWindowsProfileFleetVariables(profileNoVars, freeLic)
+	require.NoError(t, err)
+	require.Nil(t, vars)
 }
 
 func TestValidateWindowsProfileFleetVariables(t *testing.T) {

--- a/server/service/mdm_test.go
+++ b/server/service/mdm_test.go
@@ -2248,6 +2248,44 @@ func TestBatchSetMDMProfilesLabels(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestValidateWindowsProfileFleetVariablesLicense(t *testing.T) {
+	t.Run("requires premium license", func(t *testing.T) {
+		profileWithVars := `<Replace>
+			<Item>
+				<Target>
+					<LocURI>./Device/Vendor/MSFT/Accounts/DomainName</LocURI>
+				</Target>
+				<Data>Host UUID: $FLEET_VAR_HOST_UUID</Data>
+			</Item>
+		</Replace>`
+
+		// Test with free license
+		freeLic := &fleet.LicenseInfo{Tier: fleet.TierFree}
+		_, err := validateWindowsProfileFleetVariables(profileWithVars, freeLic)
+		require.Error(t, err)
+		require.Equal(t, fleet.ErrMissingLicense, err)
+
+		// Test with premium license
+		premiumLic := &fleet.LicenseInfo{Tier: fleet.TierPremium}
+		vars, err := validateWindowsProfileFleetVariables(profileWithVars, premiumLic)
+		require.NoError(t, err)
+		require.Contains(t, vars, "HOST_UUID")
+
+		// Test profile without variables (should work with free license)
+		profileNoVars := `<Replace>
+			<Item>
+				<Target>
+					<LocURI>./Device/Vendor/MSFT/Accounts/DomainName</LocURI>
+				</Target>
+				<Data>Static Value</Data>
+			</Item>
+		</Replace>`
+		vars, err = validateWindowsProfileFleetVariables(profileNoVars, freeLic)
+		require.NoError(t, err)
+		require.Nil(t, vars)
+	})
+}
+
 func TestValidateWindowsProfileFleetVariables(t *testing.T) {
 	tests := []struct {
 		name        string
@@ -2346,7 +2384,9 @@ func TestValidateWindowsProfileFleetVariables(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := validateWindowsProfileFleetVariables(tt.profileXML)
+			// Pass a premium license for testing (we're not testing license validation here)
+			premiumLic := &fleet.LicenseInfo{Tier: fleet.TierPremium}
+			_, err := validateWindowsProfileFleetVariables(tt.profileXML, premiumLic)
 			if tt.wantErr {
 				require.Error(t, err)
 				if tt.errContains != "" {

--- a/server/service/microsoft_mdm.go
+++ b/server/service/microsoft_mdm.go
@@ -2301,11 +2301,7 @@ func ReconcileWindowsProfiles(ctx context.Context, ds fleet.Datastore, logger ki
 			return ctxerr.Wrapf(ctx, err, "missing profile content for profile %s", profUUID)
 		}
 
-		// Check if the profile contains Fleet variables
-		profileStr := string(p.SyncML)
-		fleetVars := variables.Find(profileStr)
-
-		if len(fleetVars) == 0 {
+		if !variables.ContainsBytes(p.SyncML) {
 			// No Fleet variables, send the same command to all hosts
 			command, err := buildCommandFromProfileBytes(p.SyncML, target.cmdUUID)
 			if err != nil {
@@ -2327,7 +2323,7 @@ func ReconcileWindowsProfiles(ctx context.Context, ds fleet.Datastore, logger ki
 				}
 
 				// Preprocess the profile content for this specific host
-				processedContent := microsoft_mdm.PreprocessWindowsProfileContents(hostUUID, profileStr)
+				processedContent := microsoft_mdm.PreprocessWindowsProfileContents(hostUUID, string(p.SyncML))
 
 				// Create a unique command UUID for this host since the content is unique
 				hostCmdUUID := uuid.New().String()

--- a/server/service/microsoft_mdm.go
+++ b/server/service/microsoft_mdm.go
@@ -29,6 +29,7 @@ import (
 	microsoft_mdm "github.com/fleetdm/fleet/v4/server/mdm/microsoft"
 	"github.com/fleetdm/fleet/v4/server/mdm/microsoft/syncml"
 	"github.com/fleetdm/fleet/v4/server/ptr"
+	"github.com/fleetdm/fleet/v4/server/variables"
 	kitlog "github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 
@@ -2212,56 +2213,6 @@ func (svc *Service) GetMDMWindowsProfilesSummary(ctx context.Context, teamID *ui
 	return ps, nil
 }
 
-// preprocessWindowsProfileContents processes Windows configuration profiles to replace Fleet variables
-// with their actual values for each host.
-//
-// Why we don't use Go templates here:
-//  1. Error handling: Go templates don't provide fine-grained error handling for individual variable
-//     replacements. We need to handle failures per-host and per-variable gracefully.
-//  2. Variable dependencies: Some variables may be related or have dependencies on each other. With
-//     manual processing, we can control the order of variable replacement precisely.
-//  3. Performance: Templates must be compiled every time they're used, adding overhead when processing
-//     thousands of host profiles. Direct string replacement is more efficient for our use case.
-//  4. XML escaping: We need XML-specific escaping for values, which is simpler to control with direct
-//     string replacement rather than template functions.
-//
-// Note: When adding support for additional variables here, consider refactoring this variable replacement logic into its own package.
-func preprocessWindowsProfileContents(
-	hostUUID string,
-	profileContents string,
-) string {
-	// Check if Fleet variables are present
-	fleetVars := findFleetVariables(profileContents)
-	if len(fleetVars) == 0 {
-		// No variables to replace, return original content
-		return profileContents
-	}
-
-	// Process each Fleet variable
-	result := profileContents
-	for fleetVar := range fleetVars {
-		switch fleetVar {
-		case string(fleet.FleetVarHostUUID):
-			// Replace HOST_UUID with the actual host UUID
-			// Use XML escaping for the replacement value to be safe and prevent XML injection
-			b := make([]byte, 0, len(hostUUID))
-			buf := bytes.NewBuffer(b)
-			_ = xml.EscapeText(buf, []byte(hostUUID))
-			escapedUUID := buf.String()
-
-			// Replace both braced and non-braced versions. We assume this variable name is unique (and not a prefix of another variable name).
-			result = strings.ReplaceAll(result, fmt.Sprintf("$FLEET_VAR_%s", fleetVar), escapedUUID)
-			result = strings.ReplaceAll(result, fmt.Sprintf("${FLEET_VAR_%s}", fleetVar), escapedUUID)
-		default:
-			// This should not happen as validation should have caught unsupported variables
-			// but we handle it gracefully by skipping the variable
-			continue
-		}
-	}
-
-	return result
-}
-
 func ReconcileWindowsProfiles(ctx context.Context, ds fleet.Datastore, logger kitlog.Logger) error {
 	appConfig, err := ds.AppConfig(ctx)
 	if err != nil {
@@ -2352,7 +2303,7 @@ func ReconcileWindowsProfiles(ctx context.Context, ds fleet.Datastore, logger ki
 
 		// Check if the profile contains Fleet variables
 		profileStr := string(p.SyncML)
-		fleetVars := findFleetVariables(profileStr)
+		fleetVars := variables.Find(profileStr)
 
 		if len(fleetVars) == 0 {
 			// No Fleet variables, send the same command to all hosts
@@ -2376,7 +2327,7 @@ func ReconcileWindowsProfiles(ctx context.Context, ds fleet.Datastore, logger ki
 				}
 
 				// Preprocess the profile content for this specific host
-				processedContent := preprocessWindowsProfileContents(hostUUID, profileStr)
+				processedContent := microsoft_mdm.PreprocessWindowsProfileContents(hostUUID, profileStr)
 
 				// Create a unique command UUID for this host since the content is unique
 				hostCmdUUID := uuid.New().String()

--- a/server/service/microsoft_mdm_test.go
+++ b/server/service/microsoft_mdm_test.go
@@ -243,62 +243,6 @@ func TestValidSyncMLCmdStatus(t *testing.T) {
 	require.Contains(t, payload, fmt.Sprintf("<Data>%s</Data>", testStatusCode))
 }
 
-func TestPreprocessWindowsProfileContents(t *testing.T) {
-	testHostUUID := "test-host-1234-uuid"
-
-	tests := []struct {
-		name            string
-		hostUUID        string
-		profileContents string
-		wantContents    string
-	}{
-		{
-			name:            "no_fleet_variables",
-			hostUUID:        testHostUUID,
-			profileContents: `<Replace><CmdID>1</CmdID><Item><Target><LocURI>./Device/Config</LocURI></Target></Item></Replace>`,
-			wantContents:    `<Replace><CmdID>1</CmdID><Item><Target><LocURI>./Device/Config</LocURI></Target></Item></Replace>`,
-		},
-		{
-			name:            "host_uuid_without_braces",
-			hostUUID:        testHostUUID,
-			profileContents: `<Replace><CmdID>1</CmdID><Item><Data>Device ID: $FLEET_VAR_HOST_UUID</Data></Item></Replace>`,
-			wantContents:    `<Replace><CmdID>1</CmdID><Item><Data>Device ID: test-host-1234-uuid</Data></Item></Replace>`,
-		},
-		{
-			name:            "host_uuid_with_braces",
-			hostUUID:        testHostUUID,
-			profileContents: `<Replace><CmdID>1</CmdID><Item><Data>Device ID: ${FLEET_VAR_HOST_UUID}</Data></Item></Replace>`,
-			wantContents:    `<Replace><CmdID>1</CmdID><Item><Data>Device ID: test-host-1234-uuid</Data></Item></Replace>`,
-		},
-		{
-			name:            "multiple_host_uuid_occurrences",
-			hostUUID:        testHostUUID,
-			profileContents: `<Replace><Data>ID1: $FLEET_VAR_HOST_UUID, ID2: ${FLEET_VAR_HOST_UUID}</Data></Replace>`,
-			wantContents:    `<Replace><Data>ID1: test-host-1234-uuid, ID2: test-host-1234-uuid</Data></Replace>`,
-		},
-		{
-			name:            "host_uuid_with_xml_special_chars",
-			hostUUID:        "test<>&\"'uuid",
-			profileContents: `<Replace><Data>ID: $FLEET_VAR_HOST_UUID</Data></Replace>`,
-			wantContents:    `<Replace><Data>ID: test&lt;&gt;&amp;&#34;&#39;uuid</Data></Replace>`,
-		},
-		{
-			name:            "unsupported_variable_ignored",
-			hostUUID:        testHostUUID,
-			profileContents: `<Replace><Data>ID: $FLEET_VAR_HOST_UUID, Other: $FLEET_VAR_UNSUPPORTED</Data></Replace>`,
-			wantContents:    `<Replace><Data>ID: test-host-1234-uuid, Other: $FLEET_VAR_UNSUPPORTED</Data></Replace>`,
-		},
-	}
-
-	for _, tt := range tests {
-		tt := tt
-		t.Run(tt.name, func(t *testing.T) {
-			gotContents := preprocessWindowsProfileContents(tt.hostUUID, tt.profileContents)
-			require.Equal(t, tt.wantContents, gotContents)
-		})
-	}
-}
-
 func TestValidNewSyncMLCmdGet(t *testing.T) {
 	testOmaURI := "testuri"
 	cmdMsg := newSyncMLNoFormat(fleet.CmdGet, testOmaURI)

--- a/server/variables/variables.go
+++ b/server/variables/variables.go
@@ -55,12 +55,6 @@ func FindKeepDuplicates(contents string) []string {
 	for _, match := range matches {
 		for _, i := range nameToIndex {
 			if match[i] != "" {
-				// Extract the variable name without the FLEET_VAR_ prefix
-				varName := strings.TrimPrefix(match[i], "FLEET_VAR_")
-				varName = strings.TrimPrefix(varName, "${FLEET_VAR_")
-				varName = strings.TrimSuffix(varName, "}")
-
-				// The regex already captures just the name part, so we can use it directly
 				result = append(result, match[i])
 			}
 		}

--- a/server/variables/variables.go
+++ b/server/variables/variables.go
@@ -1,0 +1,182 @@
+// Package variables provides functionality for handling Fleet variables,
+// which are template placeholders that can be substituted with actual values
+// in various contexts.
+package variables
+
+import (
+	"regexp"
+	"strings"
+)
+
+// FleetVariableRegex matches Fleet variables in content.
+// It supports two formats:
+//   - $FLEET_VAR_NAME - without braces
+//   - ${FLEET_VAR_NAME} - with braces
+//
+// The regex captures the variable name (without the FLEET_VAR_ prefix) in named groups.
+var FleetVariableRegex = regexp.MustCompile(`(\$FLEET_VAR_(?P<name1>\w+))|(\${FLEET_VAR_(?P<name2>\w+)})`)
+
+// ProfileDataVariableRegex matches variables present in <data> section of Apple profile, which may cause validation issues.
+// This is specific to DigiCert certificate data variables.
+var ProfileDataVariableRegex = regexp.MustCompile(`(\$FLEET_VAR_DIGICERT_DATA_(?P<name1>\w+))|(\${FLEET_VAR_DIGICERT_DATA_(?P<name2>\w+)})`)
+
+// Find finds all Fleet variables in the given content and returns them as a map
+// without the FLEET_VAR_ prefix. Returns nil if no variables are found.
+//
+// For example, if the content contains "$FLEET_VAR_HOST_UUID" and "${FLEET_VAR_HOST_EMAIL}",
+// this function will return map[string]struct{}{"HOST_UUID": {}, "HOST_EMAIL": {}}.
+func Find(contents string) map[string]struct{} {
+	resultSlice := FindKeepDuplicates(contents)
+	if len(resultSlice) == 0 {
+		return nil
+	}
+	return dedupe(resultSlice)
+}
+
+// FindKeepDuplicates finds all Fleet variables in the given content and returns them
+// as a slice without the FLEET_VAR_ prefix. Duplicates are preserved in the result.
+//
+// This is useful when you need to know the order or frequency of variable occurrences.
+func FindKeepDuplicates(contents string) []string {
+	var result []string
+	matches := FleetVariableRegex.FindAllStringSubmatch(contents, -1)
+	if len(matches) == 0 {
+		return nil
+	}
+
+	nameToIndex := make(map[string]int, 2)
+	for i, name := range FleetVariableRegex.SubexpNames() {
+		if name == "" {
+			continue
+		}
+		nameToIndex[name] = i
+	}
+
+	for _, match := range matches {
+		for _, i := range nameToIndex {
+			if match[i] != "" {
+				// Extract the variable name without the FLEET_VAR_ prefix
+				varName := strings.TrimPrefix(match[i], "FLEET_VAR_")
+				varName = strings.TrimPrefix(varName, "${FLEET_VAR_")
+				varName = strings.TrimSuffix(varName, "}")
+
+				// The regex already captures just the name part, so we can use it directly
+				result = append(result, match[i])
+			}
+		}
+	}
+	return result
+}
+
+// dedupe removes duplicates from the slice and returns a map for O(1) lookups.
+func dedupe(varsWithDupes []string) map[string]struct{} {
+	result := make(map[string]struct{}, len(varsWithDupes))
+	for _, v := range varsWithDupes {
+		result[v] = struct{}{}
+	}
+	return result
+}
+
+// Contains checks if the given content contains any Fleet variables.
+func Contains(contents string) bool {
+	return FleetVariableRegex.MatchString(contents)
+}
+
+// ContainsSpecific checks if the given content contains a specific Fleet variable.
+// The variableName should be provided without the FLEET_VAR_ prefix.
+//
+// For example, to check for $FLEET_VAR_HOST_UUID, use ContainsSpecific(content, "HOST_UUID").
+func ContainsSpecific(contents string, variableName string) bool {
+	// Check both braced and non-braced versions
+	nonBraced := "$FLEET_VAR_" + variableName
+	braced := "${FLEET_VAR_" + variableName + "}"
+
+	return strings.Contains(contents, nonBraced) || strings.Contains(contents, braced)
+}
+
+// Replace replaces all occurrences of a specific Fleet variable with the given value.
+// The variableName should be provided without the FLEET_VAR_ prefix.
+// This function replaces both braced and non-braced versions of the variable.
+//
+// For example, Replace(content, "HOST_UUID", "123-456") will replace both
+// $FLEET_VAR_HOST_UUID and ${FLEET_VAR_HOST_UUID} with "123-456".
+func Replace(contents string, variableName string, value string) string {
+	// Replace both braced and non-braced versions
+	result := strings.ReplaceAll(contents, "$FLEET_VAR_"+variableName, value)
+	result = strings.ReplaceAll(result, "${FLEET_VAR_"+variableName+"}", value)
+	return result
+}
+
+// ReplaceAll replaces all Fleet variables in the content with their corresponding values
+// from the provided map. Variables not in the map are left unchanged.
+// The map keys should be variable names without the FLEET_VAR_ prefix.
+//
+// For example, ReplaceAll(content, map[string]string{"HOST_UUID": "123", "HOST_EMAIL": "test@example.com"})
+func ReplaceAll(contents string, values map[string]string) string {
+	result := contents
+	for varName, value := range values {
+		result = Replace(result, varName, value)
+	}
+	return result
+}
+
+// Validate checks if all Fleet variables in the content are valid.
+// Returns a slice of invalid variable names (without FLEET_VAR_ prefix).
+// An empty slice means all variables are valid.
+//
+// The validVariables parameter should contain the set of allowed variable names
+// without the FLEET_VAR_ prefix.
+func Validate(contents string, validVariables map[string]struct{}) []string {
+	found := Find(contents)
+	if found == nil {
+		return nil
+	}
+
+	var invalid []string
+	for varName := range found {
+		if _, ok := validVariables[varName]; !ok {
+			invalid = append(invalid, varName)
+		}
+	}
+	return invalid
+}
+
+// ExtractVariableName extracts the variable name from a full Fleet variable string.
+// It handles both $FLEET_VAR_NAME and ${FLEET_VAR_NAME} formats.
+// Returns empty string if the input is not a valid Fleet variable.
+//
+// For example:
+//   - ExtractVariableName("$FLEET_VAR_HOST_UUID") returns "HOST_UUID"
+//   - ExtractVariableName("${FLEET_VAR_HOST_EMAIL}") returns "HOST_EMAIL"
+//   - ExtractVariableName("not a variable") returns ""
+func ExtractVariableName(variable string) string {
+	// Trim any whitespace
+	variable = strings.TrimSpace(variable)
+
+	// Check if it starts with ${FLEET_VAR_ and ends with }
+	if strings.HasPrefix(variable, "${FLEET_VAR_") && strings.HasSuffix(variable, "}") {
+		name := strings.TrimPrefix(variable, "${FLEET_VAR_")
+		name = strings.TrimSuffix(name, "}")
+		return name
+	}
+
+	// Check if it starts with $FLEET_VAR_
+	if strings.HasPrefix(variable, "$FLEET_VAR_") {
+		return strings.TrimPrefix(variable, "$FLEET_VAR_")
+	}
+
+	return ""
+}
+
+// FormatVariable formats a variable name into the standard Fleet variable format.
+// By default, it uses the non-braced format ($FLEET_VAR_NAME).
+//
+// For example:
+//   - FormatVariable("HOST_UUID", false) returns "$FLEET_VAR_HOST_UUID"
+//   - FormatVariable("HOST_UUID", true) returns "${FLEET_VAR_HOST_UUID}"
+func FormatVariable(variableName string, useBraces bool) string {
+	if useBraces {
+		return "${FLEET_VAR_" + variableName + "}"
+	}
+	return "$FLEET_VAR_" + variableName
+}

--- a/server/variables/variables.go
+++ b/server/variables/variables.go
@@ -88,3 +88,8 @@ func Replace(contents string, variableName string, value string) string {
 func Contains(contents string) bool {
 	return fleetVariableRegex.MatchString(contents)
 }
+
+// ContainsBytes checks if the given content contains any Fleet variables (bytes version).
+func ContainsBytes(contents []byte) bool {
+	return fleetVariableRegex.Match(contents)
+}

--- a/server/variables/variables_test.go
+++ b/server/variables/variables_test.go
@@ -1,12 +1,9 @@
 package variables
 
 import (
-	"reflect"
-	"sort"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestFind(t *testing.T) {
@@ -51,19 +48,17 @@ func TestFind(t *testing.T) {
 			},
 		},
 		{
-			name:    "variables in XML",
-			content: `<Replace><Data>ID: $FLEET_VAR_HOST_UUID</Data><Email>${FLEET_VAR_HOST_EMAIL}</Email></Replace>`,
+			name:    "variables in XML content",
+			content: `<Replace><Data>Device: $FLEET_VAR_HOST_UUID</Data></Replace>`,
 			expected: map[string]struct{}{
-				"HOST_UUID":  {},
-				"HOST_EMAIL": {},
+				"HOST_UUID": {},
 			},
 		},
 		{
-			name:    "variables with underscores in name",
-			content: "$FLEET_VAR_NDES_SCEP_CHALLENGE and ${FLEET_VAR_HOST_END_USER_EMAIL_IDP}",
+			name:    "mixed case sensitivity",
+			content: "Valid: $FLEET_VAR_HOST_UUID, Invalid: $fleet_var_host_uuid",
 			expected: map[string]struct{}{
-				"NDES_SCEP_CHALLENGE":     {},
-				"HOST_END_USER_EMAIL_IDP": {},
+				"HOST_UUID": {},
 			},
 		},
 	}
@@ -71,11 +66,14 @@ func TestFind(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			result := Find(tt.content)
-			if tt.expected == nil {
-				assert.Nil(t, result)
-			} else {
-				assert.Equal(t, tt.expected, result)
-			}
+			assert.Equal(t, tt.expected, result)
+
+			// Also verify that Contains returns the expected value
+			// If Find returns nil (no variables), Contains should return false
+			// If Find returns a non-nil map, Contains should return true
+			expectedContains := tt.expected != nil
+			assert.Equal(t, expectedContains, Contains(tt.content),
+				"Contains() should return %v when Find() returns %v", expectedContains, tt.expected)
 		})
 	}
 }
@@ -93,17 +91,17 @@ func TestFindKeepDuplicates(t *testing.T) {
 		},
 		{
 			name:     "single occurrence",
-			content:  "$FLEET_VAR_HOST_UUID",
+			content:  "ID: $FLEET_VAR_HOST_UUID",
 			expected: []string{"HOST_UUID"},
 		},
 		{
-			name:     "multiple occurrences of same variable",
-			content:  "First: $FLEET_VAR_HOST_UUID, Second: ${FLEET_VAR_HOST_UUID}, Third: $FLEET_VAR_HOST_UUID",
+			name:     "duplicate occurrences",
+			content:  "ID1: $FLEET_VAR_HOST_UUID, ID2: ${FLEET_VAR_HOST_UUID}, ID3: $FLEET_VAR_HOST_UUID",
 			expected: []string{"HOST_UUID", "HOST_UUID", "HOST_UUID"},
 		},
 		{
 			name:     "mixed variables with duplicates",
-			content:  "$FLEET_VAR_HOST_UUID ${FLEET_VAR_HOST_EMAIL} $FLEET_VAR_HOST_UUID",
+			content:  "$FLEET_VAR_HOST_UUID, $FLEET_VAR_HOST_EMAIL, ${FLEET_VAR_HOST_UUID}",
 			expected: []string{"HOST_UUID", "HOST_EMAIL", "HOST_UUID"},
 		},
 	}
@@ -111,83 +109,6 @@ func TestFindKeepDuplicates(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			result := FindKeepDuplicates(tt.content)
-			assert.Equal(t, tt.expected, result)
-		})
-	}
-}
-
-func TestContains(t *testing.T) {
-	tests := []struct {
-		name     string
-		content  string
-		expected bool
-	}{
-		{
-			name:     "no variables",
-			content:  "Plain text without variables",
-			expected: false,
-		},
-		{
-			name:     "contains variable without braces",
-			content:  "Device: $FLEET_VAR_HOST_UUID",
-			expected: true,
-		},
-		{
-			name:     "contains variable with braces",
-			content:  "Device: ${FLEET_VAR_HOST_UUID}",
-			expected: true,
-		},
-		{
-			name:     "partial variable name",
-			content:  "$FLEET_VAR_ or FLEET_VAR_HOST",
-			expected: false,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result := Contains(tt.content)
-			assert.Equal(t, tt.expected, result)
-		})
-	}
-}
-
-func TestContainsSpecific(t *testing.T) {
-	tests := []struct {
-		name         string
-		content      string
-		variableName string
-		expected     bool
-	}{
-		{
-			name:         "contains specific variable without braces",
-			content:      "ID: $FLEET_VAR_HOST_UUID",
-			variableName: "HOST_UUID",
-			expected:     true,
-		},
-		{
-			name:         "contains specific variable with braces",
-			content:      "ID: ${FLEET_VAR_HOST_UUID}",
-			variableName: "HOST_UUID",
-			expected:     true,
-		},
-		{
-			name:         "does not contain specific variable",
-			content:      "Email: $FLEET_VAR_HOST_EMAIL",
-			variableName: "HOST_UUID",
-			expected:     false,
-		},
-		{
-			name:         "contains both formats",
-			content:      "$FLEET_VAR_HOST_UUID and ${FLEET_VAR_HOST_UUID}",
-			variableName: "HOST_UUID",
-			expected:     true,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result := ContainsSpecific(tt.content, tt.variableName)
 			assert.Equal(t, tt.expected, result)
 		})
 	}
@@ -242,281 +163,6 @@ func TestReplace(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			result := Replace(tt.content, tt.variableName, tt.value)
 			assert.Equal(t, tt.expected, result)
-		})
-	}
-}
-
-func TestReplaceAll(t *testing.T) {
-	tests := []struct {
-		name     string
-		content  string
-		values   map[string]string
-		expected string
-	}{
-		{
-			name:    "replace multiple variables",
-			content: "Host: $FLEET_VAR_HOST_UUID, Email: ${FLEET_VAR_HOST_EMAIL}",
-			values: map[string]string{
-				"HOST_UUID":  "123-456",
-				"HOST_EMAIL": "test@example.com",
-			},
-			expected: "Host: 123-456, Email: test@example.com",
-		},
-		{
-			name:    "partial replacement",
-			content: "Host: $FLEET_VAR_HOST_UUID, Email: ${FLEET_VAR_HOST_EMAIL}, Serial: $FLEET_VAR_HOST_SERIAL",
-			values: map[string]string{
-				"HOST_UUID": "123-456",
-			},
-			expected: "Host: 123-456, Email: ${FLEET_VAR_HOST_EMAIL}, Serial: $FLEET_VAR_HOST_SERIAL",
-		},
-		{
-			name:     "empty values map",
-			content:  "Host: $FLEET_VAR_HOST_UUID",
-			values:   map[string]string{},
-			expected: "Host: $FLEET_VAR_HOST_UUID",
-		},
-		{
-			name:     "nil values map",
-			content:  "Host: $FLEET_VAR_HOST_UUID",
-			values:   nil,
-			expected: "Host: $FLEET_VAR_HOST_UUID",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result := ReplaceAll(tt.content, tt.values)
-			assert.Equal(t, tt.expected, result)
-		})
-	}
-}
-
-func TestValidate(t *testing.T) {
-	tests := []struct {
-		name            string
-		content         string
-		validVariables  map[string]struct{}
-		expectedInvalid []string
-	}{
-		{
-			name:    "all variables valid",
-			content: "Host: $FLEET_VAR_HOST_UUID, Email: ${FLEET_VAR_HOST_EMAIL}",
-			validVariables: map[string]struct{}{
-				"HOST_UUID":  {},
-				"HOST_EMAIL": {},
-			},
-			expectedInvalid: nil,
-		},
-		{
-			name:    "some variables invalid",
-			content: "Host: $FLEET_VAR_HOST_UUID, Invalid: ${FLEET_VAR_INVALID_VAR}",
-			validVariables: map[string]struct{}{
-				"HOST_UUID": {},
-			},
-			expectedInvalid: []string{"INVALID_VAR"},
-		},
-		{
-			name:            "all variables invalid",
-			content:         "Invalid1: $FLEET_VAR_INVALID1, Invalid2: ${FLEET_VAR_INVALID2}",
-			validVariables:  map[string]struct{}{},
-			expectedInvalid: []string{"INVALID1", "INVALID2"},
-		},
-		{
-			name:            "no variables in content",
-			content:         "Plain text without variables",
-			validVariables:  map[string]struct{}{"HOST_UUID": {}},
-			expectedInvalid: nil,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result := Validate(tt.content, tt.validVariables)
-
-			// Sort both slices for comparison since map iteration order is not guaranteed
-			if result != nil && tt.expectedInvalid != nil {
-				sort.Strings(result)
-				sort.Strings(tt.expectedInvalid)
-			}
-
-			if tt.expectedInvalid == nil {
-				assert.Nil(t, result)
-			} else {
-				assert.Equal(t, tt.expectedInvalid, result)
-			}
-		})
-	}
-}
-
-func TestExtractVariableName(t *testing.T) {
-	tests := []struct {
-		name     string
-		input    string
-		expected string
-	}{
-		{
-			name:     "variable without braces",
-			input:    "$FLEET_VAR_HOST_UUID",
-			expected: "HOST_UUID",
-		},
-		{
-			name:     "variable with braces",
-			input:    "${FLEET_VAR_HOST_UUID}",
-			expected: "HOST_UUID",
-		},
-		{
-			name:     "variable with whitespace",
-			input:    "  $FLEET_VAR_HOST_UUID  ",
-			expected: "HOST_UUID",
-		},
-		{
-			name:     "not a variable",
-			input:    "plain text",
-			expected: "",
-		},
-		{
-			name:     "partial variable",
-			input:    "FLEET_VAR_HOST_UUID",
-			expected: "",
-		},
-		{
-			name:     "malformed braces",
-			input:    "${FLEET_VAR_HOST_UUID",
-			expected: "",
-		},
-		{
-			name:     "variable with underscores",
-			input:    "$FLEET_VAR_HOST_END_USER_EMAIL",
-			expected: "HOST_END_USER_EMAIL",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result := ExtractVariableName(tt.input)
-			assert.Equal(t, tt.expected, result)
-		})
-	}
-}
-
-func TestFormatVariable(t *testing.T) {
-	tests := []struct {
-		name         string
-		variableName string
-		useBraces    bool
-		expected     string
-	}{
-		{
-			name:         "format without braces",
-			variableName: "HOST_UUID",
-			useBraces:    false,
-			expected:     "$FLEET_VAR_HOST_UUID",
-		},
-		{
-			name:         "format with braces",
-			variableName: "HOST_UUID",
-			useBraces:    true,
-			expected:     "${FLEET_VAR_HOST_UUID}",
-		},
-		{
-			name:         "format with underscores without braces",
-			variableName: "HOST_END_USER_EMAIL",
-			useBraces:    false,
-			expected:     "$FLEET_VAR_HOST_END_USER_EMAIL",
-		},
-		{
-			name:         "format with underscores with braces",
-			variableName: "HOST_END_USER_EMAIL",
-			useBraces:    true,
-			expected:     "${FLEET_VAR_HOST_END_USER_EMAIL}",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result := FormatVariable(tt.variableName, tt.useBraces)
-			assert.Equal(t, tt.expected, result)
-		})
-	}
-}
-
-func TestFleetVariableRegex(t *testing.T) {
-	tests := []struct {
-		name     string
-		content  string
-		expected [][]string
-	}{
-		{
-			name:    "match without braces",
-			content: "$FLEET_VAR_HOST_UUID",
-			expected: [][]string{
-				{"$FLEET_VAR_HOST_UUID", "$FLEET_VAR_HOST_UUID", "HOST_UUID", "", ""},
-			},
-		},
-		{
-			name:    "match with braces",
-			content: "${FLEET_VAR_HOST_UUID}",
-			expected: [][]string{
-				{"${FLEET_VAR_HOST_UUID}", "", "", "${FLEET_VAR_HOST_UUID}", "HOST_UUID"},
-			},
-		},
-		{
-			name:    "multiple matches",
-			content: "$FLEET_VAR_HOST_UUID and ${FLEET_VAR_HOST_EMAIL}",
-			expected: [][]string{
-				{"$FLEET_VAR_HOST_UUID", "$FLEET_VAR_HOST_UUID", "HOST_UUID", "", ""},
-				{"${FLEET_VAR_HOST_EMAIL}", "", "", "${FLEET_VAR_HOST_EMAIL}", "HOST_EMAIL"},
-			},
-		},
-		{
-			name:     "no matches",
-			content:  "plain text without variables",
-			expected: nil,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			matches := FleetVariableRegex.FindAllStringSubmatch(tt.content, -1)
-			if !reflect.DeepEqual(matches, tt.expected) {
-				t.Errorf("FleetVariableRegex.FindAllStringSubmatch() = %v, want %v", matches, tt.expected)
-			}
-		})
-	}
-}
-
-func TestProfileDataVariableRegex(t *testing.T) {
-	tests := []struct {
-		name     string
-		content  string
-		expected [][]string
-	}{
-		{
-			name:    "match DigiCert data variable without braces",
-			content: "$FLEET_VAR_DIGICERT_DATA_CERT",
-			expected: [][]string{
-				{"$FLEET_VAR_DIGICERT_DATA_CERT", "$FLEET_VAR_DIGICERT_DATA_CERT", "CERT", "", ""},
-			},
-		},
-		{
-			name:    "match DigiCert data variable with braces",
-			content: "${FLEET_VAR_DIGICERT_DATA_KEY}",
-			expected: [][]string{
-				{"${FLEET_VAR_DIGICERT_DATA_KEY}", "", "", "${FLEET_VAR_DIGICERT_DATA_KEY}", "KEY"},
-			},
-		},
-		{
-			name:     "no match for regular Fleet variable",
-			content:  "$FLEET_VAR_HOST_UUID",
-			expected: nil,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			matches := ProfileDataVariableRegex.FindAllStringSubmatch(tt.content, -1)
-			require.Equal(t, tt.expected, matches)
 		})
 	}
 }

--- a/server/variables/variables_test.go
+++ b/server/variables/variables_test.go
@@ -1,0 +1,522 @@
+package variables
+
+import (
+	"reflect"
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFind(t *testing.T) {
+	tests := []struct {
+		name     string
+		content  string
+		expected map[string]struct{}
+	}{
+		{
+			name:     "no variables",
+			content:  "This is a plain text without any variables",
+			expected: nil,
+		},
+		{
+			name:    "single variable without braces",
+			content: "Device ID: $FLEET_VAR_HOST_UUID",
+			expected: map[string]struct{}{
+				"HOST_UUID": {},
+			},
+		},
+		{
+			name:    "single variable with braces",
+			content: "Device ID: ${FLEET_VAR_HOST_UUID}",
+			expected: map[string]struct{}{
+				"HOST_UUID": {},
+			},
+		},
+		{
+			name:    "multiple different variables",
+			content: "Host: $FLEET_VAR_HOST_UUID, Email: ${FLEET_VAR_HOST_EMAIL}, Serial: $FLEET_VAR_HOST_SERIAL",
+			expected: map[string]struct{}{
+				"HOST_UUID":   {},
+				"HOST_EMAIL":  {},
+				"HOST_SERIAL": {},
+			},
+		},
+		{
+			name:    "duplicate variables",
+			content: "ID1: $FLEET_VAR_HOST_UUID, ID2: ${FLEET_VAR_HOST_UUID}, ID3: $FLEET_VAR_HOST_UUID",
+			expected: map[string]struct{}{
+				"HOST_UUID": {},
+			},
+		},
+		{
+			name:    "variables in XML",
+			content: `<Replace><Data>ID: $FLEET_VAR_HOST_UUID</Data><Email>${FLEET_VAR_HOST_EMAIL}</Email></Replace>`,
+			expected: map[string]struct{}{
+				"HOST_UUID":  {},
+				"HOST_EMAIL": {},
+			},
+		},
+		{
+			name:    "variables with underscores in name",
+			content: "$FLEET_VAR_NDES_SCEP_CHALLENGE and ${FLEET_VAR_HOST_END_USER_EMAIL_IDP}",
+			expected: map[string]struct{}{
+				"NDES_SCEP_CHALLENGE":     {},
+				"HOST_END_USER_EMAIL_IDP": {},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := Find(tt.content)
+			if tt.expected == nil {
+				assert.Nil(t, result)
+			} else {
+				assert.Equal(t, tt.expected, result)
+			}
+		})
+	}
+}
+
+func TestFindKeepDuplicates(t *testing.T) {
+	tests := []struct {
+		name     string
+		content  string
+		expected []string
+	}{
+		{
+			name:     "no variables",
+			content:  "Plain text",
+			expected: nil,
+		},
+		{
+			name:     "single occurrence",
+			content:  "$FLEET_VAR_HOST_UUID",
+			expected: []string{"HOST_UUID"},
+		},
+		{
+			name:     "multiple occurrences of same variable",
+			content:  "First: $FLEET_VAR_HOST_UUID, Second: ${FLEET_VAR_HOST_UUID}, Third: $FLEET_VAR_HOST_UUID",
+			expected: []string{"HOST_UUID", "HOST_UUID", "HOST_UUID"},
+		},
+		{
+			name:     "mixed variables with duplicates",
+			content:  "$FLEET_VAR_HOST_UUID ${FLEET_VAR_HOST_EMAIL} $FLEET_VAR_HOST_UUID",
+			expected: []string{"HOST_UUID", "HOST_EMAIL", "HOST_UUID"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := FindKeepDuplicates(tt.content)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestContains(t *testing.T) {
+	tests := []struct {
+		name     string
+		content  string
+		expected bool
+	}{
+		{
+			name:     "no variables",
+			content:  "Plain text without variables",
+			expected: false,
+		},
+		{
+			name:     "contains variable without braces",
+			content:  "Device: $FLEET_VAR_HOST_UUID",
+			expected: true,
+		},
+		{
+			name:     "contains variable with braces",
+			content:  "Device: ${FLEET_VAR_HOST_UUID}",
+			expected: true,
+		},
+		{
+			name:     "partial variable name",
+			content:  "$FLEET_VAR_ or FLEET_VAR_HOST",
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := Contains(tt.content)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestContainsSpecific(t *testing.T) {
+	tests := []struct {
+		name         string
+		content      string
+		variableName string
+		expected     bool
+	}{
+		{
+			name:         "contains specific variable without braces",
+			content:      "ID: $FLEET_VAR_HOST_UUID",
+			variableName: "HOST_UUID",
+			expected:     true,
+		},
+		{
+			name:         "contains specific variable with braces",
+			content:      "ID: ${FLEET_VAR_HOST_UUID}",
+			variableName: "HOST_UUID",
+			expected:     true,
+		},
+		{
+			name:         "does not contain specific variable",
+			content:      "Email: $FLEET_VAR_HOST_EMAIL",
+			variableName: "HOST_UUID",
+			expected:     false,
+		},
+		{
+			name:         "contains both formats",
+			content:      "$FLEET_VAR_HOST_UUID and ${FLEET_VAR_HOST_UUID}",
+			variableName: "HOST_UUID",
+			expected:     true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := ContainsSpecific(tt.content, tt.variableName)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestReplace(t *testing.T) {
+	tests := []struct {
+		name         string
+		content      string
+		variableName string
+		value        string
+		expected     string
+	}{
+		{
+			name:         "replace variable without braces",
+			content:      "Device ID: $FLEET_VAR_HOST_UUID",
+			variableName: "HOST_UUID",
+			value:        "123-456-789",
+			expected:     "Device ID: 123-456-789",
+		},
+		{
+			name:         "replace variable with braces",
+			content:      "Device ID: ${FLEET_VAR_HOST_UUID}",
+			variableName: "HOST_UUID",
+			value:        "123-456-789",
+			expected:     "Device ID: 123-456-789",
+		},
+		{
+			name:         "replace both formats",
+			content:      "ID1: $FLEET_VAR_HOST_UUID, ID2: ${FLEET_VAR_HOST_UUID}",
+			variableName: "HOST_UUID",
+			value:        "abc-def",
+			expected:     "ID1: abc-def, ID2: abc-def",
+		},
+		{
+			name:         "no replacement when variable not present",
+			content:      "Email: $FLEET_VAR_HOST_EMAIL",
+			variableName: "HOST_UUID",
+			value:        "123",
+			expected:     "Email: $FLEET_VAR_HOST_EMAIL",
+		},
+		{
+			name:         "replace with empty value",
+			content:      "ID: $FLEET_VAR_HOST_UUID",
+			variableName: "HOST_UUID",
+			value:        "",
+			expected:     "ID: ",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := Replace(tt.content, tt.variableName, tt.value)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestReplaceAll(t *testing.T) {
+	tests := []struct {
+		name     string
+		content  string
+		values   map[string]string
+		expected string
+	}{
+		{
+			name:    "replace multiple variables",
+			content: "Host: $FLEET_VAR_HOST_UUID, Email: ${FLEET_VAR_HOST_EMAIL}",
+			values: map[string]string{
+				"HOST_UUID":  "123-456",
+				"HOST_EMAIL": "test@example.com",
+			},
+			expected: "Host: 123-456, Email: test@example.com",
+		},
+		{
+			name:    "partial replacement",
+			content: "Host: $FLEET_VAR_HOST_UUID, Email: ${FLEET_VAR_HOST_EMAIL}, Serial: $FLEET_VAR_HOST_SERIAL",
+			values: map[string]string{
+				"HOST_UUID": "123-456",
+			},
+			expected: "Host: 123-456, Email: ${FLEET_VAR_HOST_EMAIL}, Serial: $FLEET_VAR_HOST_SERIAL",
+		},
+		{
+			name:     "empty values map",
+			content:  "Host: $FLEET_VAR_HOST_UUID",
+			values:   map[string]string{},
+			expected: "Host: $FLEET_VAR_HOST_UUID",
+		},
+		{
+			name:     "nil values map",
+			content:  "Host: $FLEET_VAR_HOST_UUID",
+			values:   nil,
+			expected: "Host: $FLEET_VAR_HOST_UUID",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := ReplaceAll(tt.content, tt.values)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestValidate(t *testing.T) {
+	tests := []struct {
+		name            string
+		content         string
+		validVariables  map[string]struct{}
+		expectedInvalid []string
+	}{
+		{
+			name:    "all variables valid",
+			content: "Host: $FLEET_VAR_HOST_UUID, Email: ${FLEET_VAR_HOST_EMAIL}",
+			validVariables: map[string]struct{}{
+				"HOST_UUID":  {},
+				"HOST_EMAIL": {},
+			},
+			expectedInvalid: nil,
+		},
+		{
+			name:    "some variables invalid",
+			content: "Host: $FLEET_VAR_HOST_UUID, Invalid: ${FLEET_VAR_INVALID_VAR}",
+			validVariables: map[string]struct{}{
+				"HOST_UUID": {},
+			},
+			expectedInvalid: []string{"INVALID_VAR"},
+		},
+		{
+			name:            "all variables invalid",
+			content:         "Invalid1: $FLEET_VAR_INVALID1, Invalid2: ${FLEET_VAR_INVALID2}",
+			validVariables:  map[string]struct{}{},
+			expectedInvalid: []string{"INVALID1", "INVALID2"},
+		},
+		{
+			name:            "no variables in content",
+			content:         "Plain text without variables",
+			validVariables:  map[string]struct{}{"HOST_UUID": {}},
+			expectedInvalid: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := Validate(tt.content, tt.validVariables)
+
+			// Sort both slices for comparison since map iteration order is not guaranteed
+			if result != nil && tt.expectedInvalid != nil {
+				sort.Strings(result)
+				sort.Strings(tt.expectedInvalid)
+			}
+
+			if tt.expectedInvalid == nil {
+				assert.Nil(t, result)
+			} else {
+				assert.Equal(t, tt.expectedInvalid, result)
+			}
+		})
+	}
+}
+
+func TestExtractVariableName(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "variable without braces",
+			input:    "$FLEET_VAR_HOST_UUID",
+			expected: "HOST_UUID",
+		},
+		{
+			name:     "variable with braces",
+			input:    "${FLEET_VAR_HOST_UUID}",
+			expected: "HOST_UUID",
+		},
+		{
+			name:     "variable with whitespace",
+			input:    "  $FLEET_VAR_HOST_UUID  ",
+			expected: "HOST_UUID",
+		},
+		{
+			name:     "not a variable",
+			input:    "plain text",
+			expected: "",
+		},
+		{
+			name:     "partial variable",
+			input:    "FLEET_VAR_HOST_UUID",
+			expected: "",
+		},
+		{
+			name:     "malformed braces",
+			input:    "${FLEET_VAR_HOST_UUID",
+			expected: "",
+		},
+		{
+			name:     "variable with underscores",
+			input:    "$FLEET_VAR_HOST_END_USER_EMAIL",
+			expected: "HOST_END_USER_EMAIL",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := ExtractVariableName(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestFormatVariable(t *testing.T) {
+	tests := []struct {
+		name         string
+		variableName string
+		useBraces    bool
+		expected     string
+	}{
+		{
+			name:         "format without braces",
+			variableName: "HOST_UUID",
+			useBraces:    false,
+			expected:     "$FLEET_VAR_HOST_UUID",
+		},
+		{
+			name:         "format with braces",
+			variableName: "HOST_UUID",
+			useBraces:    true,
+			expected:     "${FLEET_VAR_HOST_UUID}",
+		},
+		{
+			name:         "format with underscores without braces",
+			variableName: "HOST_END_USER_EMAIL",
+			useBraces:    false,
+			expected:     "$FLEET_VAR_HOST_END_USER_EMAIL",
+		},
+		{
+			name:         "format with underscores with braces",
+			variableName: "HOST_END_USER_EMAIL",
+			useBraces:    true,
+			expected:     "${FLEET_VAR_HOST_END_USER_EMAIL}",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := FormatVariable(tt.variableName, tt.useBraces)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestFleetVariableRegex(t *testing.T) {
+	tests := []struct {
+		name     string
+		content  string
+		expected [][]string
+	}{
+		{
+			name:    "match without braces",
+			content: "$FLEET_VAR_HOST_UUID",
+			expected: [][]string{
+				{"$FLEET_VAR_HOST_UUID", "$FLEET_VAR_HOST_UUID", "HOST_UUID", "", ""},
+			},
+		},
+		{
+			name:    "match with braces",
+			content: "${FLEET_VAR_HOST_UUID}",
+			expected: [][]string{
+				{"${FLEET_VAR_HOST_UUID}", "", "", "${FLEET_VAR_HOST_UUID}", "HOST_UUID"},
+			},
+		},
+		{
+			name:    "multiple matches",
+			content: "$FLEET_VAR_HOST_UUID and ${FLEET_VAR_HOST_EMAIL}",
+			expected: [][]string{
+				{"$FLEET_VAR_HOST_UUID", "$FLEET_VAR_HOST_UUID", "HOST_UUID", "", ""},
+				{"${FLEET_VAR_HOST_EMAIL}", "", "", "${FLEET_VAR_HOST_EMAIL}", "HOST_EMAIL"},
+			},
+		},
+		{
+			name:     "no matches",
+			content:  "plain text without variables",
+			expected: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			matches := FleetVariableRegex.FindAllStringSubmatch(tt.content, -1)
+			if !reflect.DeepEqual(matches, tt.expected) {
+				t.Errorf("FleetVariableRegex.FindAllStringSubmatch() = %v, want %v", matches, tt.expected)
+			}
+		})
+	}
+}
+
+func TestProfileDataVariableRegex(t *testing.T) {
+	tests := []struct {
+		name     string
+		content  string
+		expected [][]string
+	}{
+		{
+			name:    "match DigiCert data variable without braces",
+			content: "$FLEET_VAR_DIGICERT_DATA_CERT",
+			expected: [][]string{
+				{"$FLEET_VAR_DIGICERT_DATA_CERT", "$FLEET_VAR_DIGICERT_DATA_CERT", "CERT", "", ""},
+			},
+		},
+		{
+			name:    "match DigiCert data variable with braces",
+			content: "${FLEET_VAR_DIGICERT_DATA_KEY}",
+			expected: [][]string{
+				{"${FLEET_VAR_DIGICERT_DATA_KEY}", "", "", "${FLEET_VAR_DIGICERT_DATA_KEY}", "KEY"},
+			},
+		},
+		{
+			name:     "no match for regular Fleet variable",
+			content:  "$FLEET_VAR_HOST_UUID",
+			expected: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			matches := ProfileDataVariableRegex.FindAllStringSubmatch(tt.content, -1)
+			require.Equal(t, tt.expected, matches)
+		})
+	}
+}


### PR DESCRIPTION
Fixes #30879 

Adds verification support for Windows profiles containing $FLEET_VAR_HOST_UUID, which was missing in previous PR.

Also added a license check since Fleet variables are a premium feature.

Also includes some refactoring.

Demo video: https://www.youtube.com/watch?v=HNWlu-uA20U

# Checklist for submitter

## Testing

- [x] Added/updated automated tests
- [x] Where appropriate, [automated tests simulate multiple hosts and test for host isolation]
- [x] QA'd all new/changed functionality manually



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved detection and substitution of Fleet variables in Apple and Windows MDM profiles, supporting both braced and non-braced formats.
  * Centralized Fleet variable handling for more consistent and reliable profile processing.

* **Bug Fixes**
  * Enhanced validation ensures that Fleet variables in MDM profiles require a premium license, with clear error messaging if requirements are not met.
  * Improved variable replacement logic to ensure accurate and secure profile deployment.

* **Tests**
  * Added comprehensive tests to verify variable detection, replacement, and license enforcement in MDM profiles.
  * Expanded integration tests to cover variable substitution and profile verification scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->