### PR TITLE
Make MySQL test port configurable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -520,7 +520,7 @@ binary-arch: .pre-binary-arch .pre-binary-bundle .pre-fleet
 # Drop, create, and migrate the e2e test database
 e2e-reset-db:
 	docker compose exec -T mysql_test bash -c 'echo "drop database if exists e2e; create database e2e;" | MYSQL_PWD=toor mysql -uroot'
-	./build/fleet prepare db --mysql_address=localhost:3307  --mysql_username=root --mysql_password=toor --mysql_database=e2e
+	./build/fleet prepare db --mysql_address=localhost:$${FLEET_MYSQL_TEST_PORT:-3307}  --mysql_username=root --mysql_password=toor --mysql_database=e2e
 
 e2e-setup:
 	./build/fleetctl config set --context e2e --address https://localhost:8642 --tls-skip-verify true
@@ -540,10 +540,10 @@ e2e-setup-with-software:
 	./tools/backup_db/restore_e2e_software_test.sh
 
 e2e-serve-free: e2e-reset-db
-	./build/fleet serve --mysql_address=localhost:3307 --mysql_username=root --mysql_password=toor --mysql_database=e2e --server_address=0.0.0.0:8642
+	./build/fleet serve --mysql_address=localhost:$${FLEET_MYSQL_TEST_PORT:-3307} --mysql_username=root --mysql_password=toor --mysql_database=e2e --server_address=0.0.0.0:8642
 
 e2e-serve-premium: e2e-reset-db
-	./build/fleet serve  --dev_license --mysql_address=localhost:3307 --mysql_username=root --mysql_password=toor --mysql_database=e2e --server_address=0.0.0.0:8642
+	./build/fleet serve  --dev_license --mysql_address=localhost:$${FLEET_MYSQL_TEST_PORT:-3307} --mysql_username=root --mysql_password=toor --mysql_database=e2e --server_address=0.0.0.0:8642
 
 # Associate a host with a Fleet Desktop token.
 #

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,7 +49,7 @@ services:
       ]
     environment: *mysql-default-environment
     ports:
-      - "3307:3306"
+      - "${FLEET_MYSQL_TEST_PORT:-3307}:3306"
     tmpfs:
       - /var/lib/mysql:rw,noexec,nosuid
       - /tmpfs

--- a/docs/Contributing/getting-started/testing-and-local-development.md
+++ b/docs/Contributing/getting-started/testing-and-local-development.md
@@ -163,6 +163,18 @@ To run MySQL integration tests, set environment variables as follows:
 MYSQL_TEST=1 make test-go
 ```
 
+#### Configuring MySQL test port
+
+By default, the test MySQL instance uses port 3307. You can customize this port using the `FLEET_MYSQL_TEST_PORT` environment variable.
+
+For example, to use a different port:
+
+```sh
+export FLEET_MYSQL_TEST_PORT=3327
+docker-compose up -d mysql_test
+MYSQL_TEST=1 make test-go
+```
+
 ### Email tests
 
 To run email related integration tests using MailHog set environment as follows:

--- a/server/datastore/mysql/common_mysql/testing_utils/testing_utils.go
+++ b/server/datastore/mysql/common_mysql/testing_utils/testing_utils.go
@@ -19,10 +19,22 @@ import (
 const (
 	TestUsername              = "root"
 	TestPassword              = "toor"
-	TestAddress               = "localhost:3307"
 	TestReplicaDatabaseSuffix = "_replica"
 	TestReplicaAddress        = "localhost:3310"
 )
+
+var (
+	TestAddress = getTestAddress()
+)
+
+// getTestAddress returns the MySQL test server address from environment variable
+// FLEET_MYSQL_TEST_PORT or defaults to localhost:3307
+func getTestAddress() string {
+	if port := os.Getenv("FLEET_MYSQL_TEST_PORT"); port != "" {
+		return "localhost:" + port
+	}
+	return "localhost:3307"
+}
 
 // TruncateTables truncates the specified tables, in order, using ds.writer.
 // Note that the order is typically not important because FK checks are

--- a/server/datastore/mysql/migrations/tables/migration_test.go
+++ b/server/datastore/mysql/migrations/tables/migration_test.go
@@ -20,6 +20,7 @@ package tables
 
 import (
 	"fmt"
+	"os"
 	"strconv"
 	"strings"
 	"testing"
@@ -40,8 +41,18 @@ import (
 const (
 	testUsername = "root"
 	testPassword = "toor"
-	testAddress  = "localhost:3307"
 )
+
+var (
+	testAddress = getTestAddress()
+)
+
+func getTestAddress() string {
+	if port := os.Getenv("FLEET_MYSQL_TEST_PORT"); port != "" {
+		return "localhost:" + port
+	}
+	return "localhost:3307"
+}
 
 func newDBConnForTests(t *testing.T) *sqlx.DB {
 	db, err := sqlx.Open(

--- a/tools/dbutils/schema_generator.go
+++ b/tools/dbutils/schema_generator.go
@@ -19,8 +19,18 @@ import (
 const (
 	testUsername = "root"
 	testPassword = "toor"
-	testAddress  = "localhost:3307"
 )
+
+var (
+	testAddress = getTestAddress()
+)
+
+func getTestAddress() string {
+	if port := os.Getenv("FLEET_MYSQL_TEST_PORT"); port != "" {
+		return "localhost:" + port
+	}
+	return "localhost:3307"
+}
 
 func panicif(err error) {
 	if err != nil {


### PR DESCRIPTION
Fixes #31781 

Only test-related changes.

I found this useful for agentic AI workflows. For example, you have an AI agent debugging/rerunning a test. Meanwhile, you can spin up another `mysql_test` instance in another workarea and work there in parallel.
