### PR TITLE
Fleet UI: Fix VPP pending bugs

### DIFF
--- a/frontend/components/ActivityDetails/InstallDetails/VppInstallDetailsModal/VppInstallDetailsModal.tsx
+++ b/frontend/components/ActivityDetails/InstallDetails/VppInstallDetailsModal/VppInstallDetailsModal.tsx
@@ -255,7 +255,7 @@ export const VppInstallDetailsModal = ({
 
   const excludeVersions =
     !deviceAuthToken &&
-    ["pending_install", "failed_install"].includes(displayStatus);
+    ["pending_install", "failed_install", "pending"].includes(displayStatus);
 
   const isInstalledByFleet = hostSoftware
     ? !!hostSoftware.app_store_app?.last_install
@@ -342,7 +342,7 @@ export const VppInstallDetailsModal = ({
           <span>{statusMessage}</span>
         </div>
         {hostSoftware && !excludeVersions && renderInventoryVersionsSection()}
-        {displayStatus !== "pending_install" &&
+        {!isPendingInstall &&
           isInstalledByFleet &&
           renderInstallDetailsSection()}
       </div>

--- a/frontend/components/ActivityDetails/InstallDetails/VppInstallDetailsModal/VppInstallDetailsModal.tsx
+++ b/frontend/components/ActivityDetails/InstallDetails/VppInstallDetailsModal/VppInstallDetailsModal.tsx
@@ -151,7 +151,8 @@ export const getStatusMessage = ({
 const baseClass = "vpp-install-details-modal";
 
 export type IVppInstallDetails = {
-  fleetInstallStatus: SoftwareInstallStatus;
+  /** Status: null when a host manually installed not using Fleet */
+  fleetInstallStatus: SoftwareInstallStatus | null;
   hostDisplayName: string;
   appName: string;
   commandUuid?: string;
@@ -233,10 +234,16 @@ export const VppInstallDetailsModal = ({
     }
   );
 
-  // Fallback to "installed" if no status is provided as Installed
-  const displayStatus =
-    (fleetInstallStatus as SoftwareInstallStatus) || "installed";
+  // Fallback to "installed" if no status is provided
+  const displayStatus = fleetInstallStatus ?? "installed";
   const iconName = INSTALL_DETAILS_STATUS_ICONS[displayStatus];
+
+  // Handles "pending" value prior to 4.57 AND never shows error state on pending_install
+  // as some cases have command results not available for pending_installs
+  // which we don't want to show a UI error state for
+  const isPendingInstall = ["pending_install", "pending"].includes(
+    displayStatus
+  );
 
   // Note: We need to reconcile status values from two different sources. From props, we
   // get the status of the Fleet install operation (which can be "failed", "pending", or
@@ -248,7 +255,7 @@ export const VppInstallDetailsModal = ({
 
   const excludeVersions =
     !deviceAuthToken &&
-    ["pending_install", "failed_install"].includes(fleetInstallStatus);
+    ["pending_install", "failed_install"].includes(displayStatus);
 
   const isInstalledByFleet = hostSoftware
     ? !!hostSoftware.app_store_app?.last_install
@@ -304,7 +311,7 @@ export const VppInstallDetailsModal = ({
       return <Spinner />;
     }
 
-    if (isErrorVPPCommandResult) {
+    if (isErrorVPPCommandResult && !isPendingInstall) {
       if (errorVPPCommandResult?.status === 404) {
         return deviceAuthToken ? (
           <DeviceUserError />
@@ -335,7 +342,7 @@ export const VppInstallDetailsModal = ({
           <span>{statusMessage}</span>
         </div>
         {hostSoftware && !excludeVersions && renderInventoryVersionsSection()}
-        {fleetInstallStatus !== "pending_install" &&
+        {displayStatus !== "pending_install" &&
           isInstalledByFleet &&
           renderInstallDetailsSection()}
       </div>
@@ -343,7 +350,7 @@ export const VppInstallDetailsModal = ({
   };
 
   const renderCta = () => {
-    if (deviceAuthToken && fleetInstallStatus === "failed_install") {
+    if (deviceAuthToken && displayStatus === "failed_install") {
       return (
         <div className="modal-cta-wrap">
           <Button type="submit" onClick={onClickRetry}>

--- a/frontend/pages/hosts/details/cards/HostSoftwareLibrary/HostSoftwareLibrary.tsx
+++ b/frontend/pages/hosts/details/cards/HostSoftwareLibrary/HostSoftwareLibrary.tsx
@@ -576,8 +576,7 @@ const HostSoftwareLibrary = ({
       {selectedVPPInstallDetails && (
         <VppInstallDetailsModal
           details={{
-            fleetInstallStatus:
-              selectedVPPInstallDetails.status || "pending_install",
+            fleetInstallStatus: selectedVPPInstallDetails.status,
             hostDisplayName,
             appName: selectedVPPInstallDetails.name,
             commandUuid: selectedVPPInstallDetails.commandUuid,

--- a/frontend/pages/hosts/details/cards/Software/SelfService/SelfService.tsx
+++ b/frontend/pages/hosts/details/cards/Software/SelfService/SelfService.tsx
@@ -887,7 +887,7 @@ const SoftwareSelfService = ({
         <VppInstallDetailsModal
           deviceAuthToken={deviceToken}
           details={{
-            fleetInstallStatus: selectedVPPInstallDetails.status || "installed",
+            fleetInstallStatus: selectedVPPInstallDetails.status,
             hostDisplayName,
             appName: selectedVPPInstallDetails.name,
             commandUuid: selectedVPPInstallDetails.commandUuid,

--- a/frontend/pages/hosts/details/cards/Software/SelfService/SelfService.tsx
+++ b/frontend/pages/hosts/details/cards/Software/SelfService/SelfService.tsx
@@ -887,8 +887,7 @@ const SoftwareSelfService = ({
         <VppInstallDetailsModal
           deviceAuthToken={deviceToken}
           details={{
-            fleetInstallStatus:
-              selectedVPPInstallDetails.status || "pending_install",
+            fleetInstallStatus: selectedVPPInstallDetails.status || "installed",
             hostDisplayName,
             appName: selectedVPPInstallDetails.name,
             commandUuid: selectedVPPInstallDetails.commandUuid,


### PR DESCRIPTION
## Issue
Closes #31652 

## Description
- Fixes 2 bugs
  - Bug 1: Andre found, self-installed apps that are also available via fleet were showing as pending
  - Bug 2: While QAing, I realized some pending_installs had command results 404 (if I called the command while my ipad was offline) looks like it just shows an error instead of pending modal

## Screen recording of fixes
Watch in 2x, scroll to comments
https://fleetdm.zoom.us/clips/share/gPlz_jiXSEaTlfkouV_sAQ

# Checklist for submitter

If some of the following don't apply, delete the relevant line.



## Testing

- [x] QA'd all new/changed functionality manually

