### PR TITLE
Update website to deploy from a parentless commit.

### DIFF
--- a/.github/workflows/deploy-fleet-website.yml
+++ b/.github/workflows/deploy-fleet-website.yml
@@ -107,17 +107,22 @@ jobs:
     - run: git add website/.www
     - run: git add website/.tools
     - run: git add -f website/views/partials/built-from-markdown  > /dev/null 2>&1 || echo '* * * WARNING - Silently ignoring the fact that there are no HTML partials generated from markdown to include in automated commit...'
-    - run: git -c "user.name=Fleetwood" -c "user.email=github@example.com" commit -am 'AUTOMATED COMMIT - Deployed the latest, including generated collateral such as compiled documentation, modified HTML layouts, and a .sailsrc file that references minified client-side code assets.'
 
     # Configure the Heroku app we'll be deploying to
     - run: heroku git:remote -a production-fleetdm-website
     - run: git remote -v
 
-    # Deploy to Heroku (by pushing)
-    # > Since a shallow clone was grabbed, we have to "unshallow" it before forcepushing.
-    - run: echo "Unshallowing local repository…"
-    - run: git fetch --prune --unshallow
+    # Deploy to Heroku
     - run: echo "Deploying branch '${GITHUB_REF##*/}' to Heroku…"
-    - run: git push heroku +${GITHUB_REF##*/}:master  # note that Heroku, at least as of Jun 10 2021, still uses "master" on their end
+    # Create a git tree of the staged changes
+    - run: echo "TREE_SHA=$(git write-tree)" >> "$GITHUB_ENV"
+    # Create a parentless commit from the git tree that only contains the files in the website/ folder.
+    # This lets up deploy the website from the Fleet monorepo while working around Heroku's pack size limits. 
+    - run: |
+        COMMIT_SHA=$(echo 'AUTOMATED COMMIT - Deployed the latest, including generated collateral such as compiled documentation, modified HTML layouts, and a .sailsrc file that references minified client-side code assets.' \
+          | git -c "user.name=Fleetwood" -c "user.email=github@example.com" commit-tree "$TREE_SHA")
+        echo "COMMIT_SHA=$COMMIT_SHA" >> "$GITHUB_ENV"
+    # Push the parentless commit to Heroku
+    - run: git push heroku "$COMMIT_SHA":master --force
     - name: 🌐 https://fleetdm.com
       run: echo '' && echo '--' && echo 'OK, done.  It should be live momentarily.' && echo '(if you get impatient, check the Heroku dashboard for status)' && echo && echo ' 🌐–•  https://fleetdm.com'

--- a/.github/workflows/deploy-fleet-website.yml
+++ b/.github/workflows/deploy-fleet-website.yml
@@ -114,15 +114,18 @@ jobs:
 
     # Deploy to Heroku
     - run: echo "Deploying branch '${GITHUB_REF##*/}' to Heroku…"
-    # Create a git tree of the staged changes
-    - run: echo "TREE_SHA=$(git write-tree)" >> "$GITHUB_ENV"
-    # Create a parentless commit from the git tree that only contains the files in the website/ folder.
-    # This lets up deploy the website from the Fleet monorepo while working around Heroku's pack size limits. 
-    - run: |
-        COMMIT_SHA=$(echo 'AUTOMATED COMMIT - Deployed the latest, including generated collateral such as compiled documentation, modified HTML layouts, and a .sailsrc file that references minified client-side code assets.' \
-          | git -c "user.name=Fleetwood" -c "user.email=github@example.com" commit-tree "$TREE_SHA")
-        echo "COMMIT_SHA=$COMMIT_SHA" >> "$GITHUB_ENV"
-    # Push the parentless commit to Heroku
-    - run: git push heroku "$COMMIT_SHA":master --force
+    - name: Deploy to Heroku
+        set -euo pipefail
+        git add -A
+        # Create a git tree object that contains only the changes in the /website folder.
+        TREE=$(git write-tree)
+        # Create a parentless commit from the tree object.
+        COMMIT=$(git -c "user.name=Fleetwood" -c "user.email=github@example.com" \
+          commit-tree "$TREE" \
+          -m 'AUTOMATED COMMIT - Deployed the latest, including generated collateral such as compiled documentation, modified HTML layouts, and a .sailsrc file that references minified client-side code assets.')
+        # Push the parentless commit to Heroku
+        # Note: The commit pushed to Heroku will not contain the full git history.
+        # This lets up deploy the website from the Fleet monorepo while working around Heroku's pack size limits. 
+        git push heroku "$COMMIT":master --force
     - name: 🌐 https://fleetdm.com
       run: echo '' && echo '--' && echo 'OK, done.  It should be live momentarily.' && echo '(if you get impatient, check the Heroku dashboard for status)' && echo && echo ' 🌐–•  https://fleetdm.com'

--- a/website/views/pages/integrations.ejs
+++ b/website/views/pages/integrations.ejs
@@ -22,6 +22,7 @@
           </div>
         </div>
       </div>
+
       <div purpose="integration-card" class="card">
         <div purpose="integration-logo">
           <img src="/images/logo-snowflake-color-117x28@2x.png" alt="Snowflake logo">


### PR DESCRIPTION
Related to: [#31753](https://github.com/fleetdm/fleet/issues/31753)

Changes:
- Updated the "Deploy Fleet website" workflow to push to the Heroku git repo from a parentless commit that does not contain the full git history.