### PR TITLE
Allow canceling batch script from popup

### DIFF
--- a/changes/31567-allow-canceling-from-modal
+++ b/changes/31567-allow-canceling-from-modal
@@ -1,0 +1,1 @@
+- Added the ability to cancel batch script runs directly from the summary modal

--- a/frontend/pages/DashboardPage/cards/ActivityFeed/components/ScriptBatchStatusTable/ScriptBatchStatusTableConfig.tsx
+++ b/frontend/pages/DashboardPage/cards/ActivityFeed/components/ScriptBatchStatusTable/ScriptBatchStatusTableConfig.tsx
@@ -16,7 +16,7 @@ interface IRowData {
   hosts: number;
 }
 
-const STATUS_ORDER = ["ran", "pending", "errored"];
+const STATUS_ORDER = ["ran", "pending", "errored", "canceled"];
 
 export interface IStatusCellValue {
   displayName: string;
@@ -36,6 +36,10 @@ const STATUS_DISPLAY_OPTIONS = {
   errored: {
     displayName: "Error",
     indicatorStatus: "error",
+  },
+  canceled: {
+    displayName: "Canceled",
+    indicatorStatus: "failure",
   },
 } as const;
 

--- a/frontend/pages/DashboardPage/cards/ActivityFeed/components/ScriptBatchSummaryModal/ScriptBatchSummaryModal.tsx
+++ b/frontend/pages/DashboardPage/cards/ActivityFeed/components/ScriptBatchSummaryModal/ScriptBatchSummaryModal.tsx
@@ -1,12 +1,11 @@
-import React, { useState } from "react";
+import React, { useCallback, useContext, useState } from "react";
 import { InjectedRouter } from "react-router";
 
 import classnames from "classnames";
 
 import { IActivityDetails } from "interfaces/activity";
-import { API_NO_TEAM_ID, APP_CONTEXT_NO_TEAM_ID } from "interfaces/team";
 
-import paths from "router/paths";
+import { NotificationContext } from "context/notification";
 
 import Modal from "components/Modal";
 import DataSet from "components/DataSet";
@@ -45,6 +44,7 @@ const ScriptBatchSummaryModal = ({
   router,
 }: IScriptBatchSummaryModal) => {
   const [showCancelModal, setShowCancelModal] = useState(false);
+  const [isCanceling, setIsCanceling] = useState(false);
 
   const { data: statusData, isLoading, isError } = useQuery<
     IScriptBatchSummaryResponseV1,
@@ -69,8 +69,14 @@ const ScriptBatchSummaryModal = ({
   const toggleCancelModal = () => {
     setShowCancelModal(!showCancelModal);
   };
+
   const renderTable = () => {
-    if (!details.batch_execution_id || isLoading || !statusData) {
+    if (
+      !details.batch_execution_id ||
+      isLoading ||
+      !statusData ||
+      isCanceling
+    ) {
       return <Spinner />;
     }
     if (isError) {
@@ -105,6 +111,31 @@ incompatible or cancelled."
     </TooltipWrapper>
   );
 
+  const { renderFlash } = useContext(NotificationContext);
+
+  const onConfirmCancel = useCallback(
+    async (batchExecutionId: string) => {
+      setIsCanceling(true);
+
+      try {
+        await scriptsAPI.cancelScriptBatch(batchExecutionId);
+        renderFlash(
+          "success",
+          <span className={`${baseClass}__success-message`}>
+            <span>Successfully canceled script.</span>
+          </span>
+        );
+        setShowCancelModal(false);
+        onCancel();
+      } catch (error) {
+        renderFlash("error", "Could not cancel script. Please try again.");
+      } finally {
+        setIsCanceling(false);
+      }
+    },
+    [renderFlash]
+  );
+
   const renderCancelModal = () => {
     const cancelBaseClass = "script-batch-cancel-modal";
     if (!statusData) {
@@ -115,7 +146,7 @@ incompatible or cancelled."
 
     return (
       <Modal
-        title="Cancel script"
+        title="Cancel script?"
         onExit={toggleCancelModal}
         onEnter={toggleCancelModal}
         className={cancelBaseClass}
@@ -123,27 +154,25 @@ incompatible or cancelled."
         <>
           <div className={`${cancelBaseClass}__content`}>
             <p>
-              To cancel all pending runs of this script, edit or delete the
-              script.
+              This will cancel any pending script runs for{" "}
+              <b>{details?.script_name || "this script"}</b>.
             </p>
+            <p>
+              If this script is currently running on a host, it will complete,
+              but results won&rsquo;t appear in Fleet.
+            </p>
+            <p>You cannot undo this action.</p>
             <div className="modal-cta-wrap">
-              <Button onClick={toggleCancelModal}>Done</Button>
               <Button
                 onClick={() =>
-                  router.push(
-                    `${paths.CONTROLS_SCRIPTS}/?team_id=${
-                      // as of this writing, API_NO_TEAM_ID and APP_CONTEXT_NO_TEAM_ID are both 0.
-                      // It's still good to explicitly differentiate them like this since there are sometime
-                      // discrepancies between API and UI-logic team IDs
-                      statusData.team_id === API_NO_TEAM_ID
-                        ? APP_CONTEXT_NO_TEAM_ID
-                        : statusData.team_id
-                    }`
-                  )
+                  onConfirmCancel(details.batch_execution_id || "")
                 }
-                variant="inverse"
+                variant="alert"
               >
-                Go to scripts
+                Cancel script
+              </Button>
+              <Button variant="inverse-alert" onClick={toggleCancelModal}>
+                Back
               </Button>
             </div>
           </div>

--- a/frontend/services/entities/scripts.ts
+++ b/frontend/services/entities/scripts.ts
@@ -262,6 +262,10 @@ export default {
     const { SCRIPT_RUN_BATCH } = endpoints;
     return sendRequest("POST", SCRIPT_RUN_BATCH, request);
   },
+  cancelScriptBatch(batchExecutionId: string) {
+    const { SCRIPT_CANCEL_BATCH } = endpoints;
+    return sendRequest("POST", SCRIPT_CANCEL_BATCH(batchExecutionId));
+  },
   /** calls the deprecated endpoint */
   getRunScriptBatchSummary({
     batch_execution_id,

--- a/frontend/utilities/endpoints.ts
+++ b/frontend/utilities/endpoints.ts
@@ -274,6 +274,8 @@ export default {
     `/${API_VERSION}/fleet/scripts/results/${executionId}`,
   SCRIPT_RUN: `/${API_VERSION}/fleet/scripts/run`,
   SCRIPT_RUN_BATCH: `/${API_VERSION}/fleet/scripts/run/batch`,
+  SCRIPT_CANCEL_BATCH: (executionId: string) =>
+    `/${API_VERSION}/fleet/scripts/batch/${executionId}/cancel`,
   SCRIPT_RUN_BATCH_SUMMARY: (id: string) =>
     `/${API_VERSION}/fleet/scripts/batch/summary/${id}`,
   SCRIPT_RUN_BATCH_SUMMARIES: `/${API_VERSION}/fleet/scripts/batch`,


### PR DESCRIPTION
# Details

This PR updates the current "batch script summary" modal to allow canceling the script directly from the modal.  This is a first iteration of the cancelation feature which will be replaced by [the "batch script details" page](https://www.figma.com/design/Q18CcrFKmgOp0f5slpH35T/-28390-Schedule-scripts-to-run-at-a-specific-time?node-id=5861-25818&t=knTGlZtgFTj4NIUK-0). 

It also updates the modal to display the # of canceled items in the batch.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [X] QA'd all new/changed functionality manually

