### PR TITLE
Moving categories, setup_experience and self_service up to team yml

### DIFF
--- a/changes/31164-gitops-generate
+++ b/changes/31164-gitops-generate
@@ -1,1 +1,1 @@
-* Gitops generate outputs categories, self_service, and install_during_setup at team level
+* Gitops generate outputs categories, self_service, and setup_experience at team level

--- a/changes/31164-gitops-generate
+++ b/changes/31164-gitops-generate
@@ -1,0 +1,1 @@
+* Gitops generate outputs categories, self_service, and install_during_setup at team level

--- a/cmd/fleetctl/fleetctl/generate_gitops.go
+++ b/cmd/fleetctl/fleetctl/generate_gitops.go
@@ -1344,7 +1344,7 @@ func (cmd *GenerateGitopsCommand) generateSoftware(filePath string, teamId uint,
 					labelKey = "labels_exclude_any"
 				}
 				if _, exists := setupSoftwareBySoftwareTitle[softwareTitle.ID]; exists {
-					softwareSpec["install_during_setup"] = true
+					softwareSpec["setup_experience"] = true
 				}
 			} else {
 				if len(softwareTitle.AppStoreApp.LabelsIncludeAny) > 0 {
@@ -1356,7 +1356,7 @@ func (cmd *GenerateGitopsCommand) generateSoftware(filePath string, teamId uint,
 					labelKey = "labels_exclude_any"
 				}
 				if _, exists := setupSoftwareByVppApp[softwareTitle.AppStoreApp.AdamID]; exists {
-					softwareSpec["install_during_setup"] = true
+					softwareSpec["setup_experience"] = true
 				}
 			}
 			if len(labels) > 0 {

--- a/cmd/fleetctl/fleetctl/generate_gitops.go
+++ b/cmd/fleetctl/fleetctl/generate_gitops.go
@@ -932,21 +932,6 @@ func (cmd *GenerateGitopsCommand) generateControls(teamId *uint, teamName string
 		}
 
 		if teamId != nil && cmd.AppConfig.MDM.EnabledAndConfigured {
-			// See if the team has macOS setup software configured.
-			setupSoftware, err := cmd.Client.GetSetupExperienceSoftware(*teamId)
-			if err != nil {
-				fmt.Fprintf(cmd.CLI.App.ErrWriter, "Error getting setup software: %s\n", err)
-				return nil, err
-			}
-			hasSetupSoftware := false
-			for _, software := range setupSoftware {
-				pkg := software.SoftwarePackage
-				if pkg != nil && pkg.InstallDuringSetup != nil && *pkg.InstallDuringSetup {
-					hasSetupSoftware = true
-					break
-				}
-			}
-
 			// See if the team has macOS bootstrap package configured.
 			bootstrapPackage, err := cmd.Client.GetBootstrapPackageMetadata(*teamId, false)
 			if err != nil && !strings.Contains(err.Error(), "bootstrap package for this team does not exist") {
@@ -972,7 +957,7 @@ func (cmd *GenerateGitopsCommand) generateControls(teamId *uint, teamName string
 			hasEnrollmentProfile := enrollmentProfile != nil
 
 			// If the team has any of these configured, we need to generate the macos_setup section.
-			if hasSetupSoftware || hasBootstrapPackage || hasSetupScript || hasEnrollmentProfile || (teamMdm != nil && teamMdm.MacOSSetup.EnableEndUserAuthentication) {
+			if hasBootstrapPackage || hasSetupScript || hasEnrollmentProfile || (teamMdm != nil && teamMdm.MacOSSetup.EnableEndUserAuthentication) {
 				result[jsonFieldName(mdmT, "MacOSSetup")] = "TODO: update with your macos_setup configuration"
 				cmd.Messages.Notes = append(cmd.Messages.Notes, Note{
 					Filename: teamName,
@@ -1219,6 +1204,28 @@ func (cmd *GenerateGitopsCommand) generateSoftware(filePath string, teamId uint,
 	if len(software) == 0 {
 		return nil, nil
 	}
+
+	setupSoftwareBySoftwareTitle := make(map[uint]struct{})
+	setupSoftwareByVppApp := make(map[string]struct{})
+	if cmd.AppConfig.MDM.EnabledAndConfigured {
+		// See if the team has macOS setup software configured.
+		setupSoftware, err := cmd.Client.GetSetupExperienceSoftware(teamId)
+		if err != nil {
+			fmt.Fprintf(cmd.CLI.App.ErrWriter, "Error getting setup software: %s\n", err)
+			return nil, err
+		}
+		for _, software := range setupSoftware {
+			pkg := software.SoftwarePackage
+			if pkg != nil && pkg.InstallDuringSetup != nil && *pkg.InstallDuringSetup {
+				setupSoftwareBySoftwareTitle[software.ID] = struct{}{}
+			}
+			appStoreApp := software.AppStoreApp
+			if appStoreApp != nil && appStoreApp.InstallDuringSetup != nil && *appStoreApp.InstallDuringSetup {
+				setupSoftwareByVppApp[appStoreApp.AppStoreID] = struct{}{}
+			}
+		}
+	}
+
 	result := make(map[string]interface{})
 	packages := make([]map[string]interface{}, 0)
 	appStoreApps := make([]map[string]interface{}, 0)
@@ -1308,6 +1315,20 @@ func (cmd *GenerateGitopsCommand) generateSoftware(filePath string, teamId uint,
 			if softwareTitle.SoftwarePackage.URL != "" {
 				softwareSpec["url"] = softwareTitle.SoftwarePackage.URL
 			}
+
+			if softwareTitle.SoftwarePackage.Categories != nil {
+				softwareSpec["categories"] = softwareTitle.SoftwarePackage.Categories
+			}
+		}
+
+		if softwareTitle.AppStoreApp != nil {
+			if softwareTitle.AppStoreApp.SelfService {
+				softwareSpec["self_service"] = softwareTitle.AppStoreApp.SelfService
+			}
+
+			if softwareTitle.AppStoreApp.Categories != nil {
+				softwareSpec["categories"] = softwareTitle.AppStoreApp.Categories
+			}
 		}
 
 		if cmd.AppConfig.License.IsPremium() {
@@ -1322,6 +1343,9 @@ func (cmd *GenerateGitopsCommand) generateSoftware(filePath string, teamId uint,
 					labels = softwareTitle.SoftwarePackage.LabelsExcludeAny
 					labelKey = "labels_exclude_any"
 				}
+				if _, exists := setupSoftwareBySoftwareTitle[softwareTitle.ID]; exists {
+					softwareSpec["install_during_setup"] = true
+				}
 			} else {
 				if len(softwareTitle.AppStoreApp.LabelsIncludeAny) > 0 {
 					labels = softwareTitle.AppStoreApp.LabelsIncludeAny
@@ -1330,6 +1354,9 @@ func (cmd *GenerateGitopsCommand) generateSoftware(filePath string, teamId uint,
 				if len(softwareTitle.AppStoreApp.LabelsExcludeAny) > 0 {
 					labels = softwareTitle.AppStoreApp.LabelsExcludeAny
 					labelKey = "labels_exclude_any"
+				}
+				if _, exists := setupSoftwareByVppApp[softwareTitle.AppStoreApp.AdamID]; exists {
+					softwareSpec["install_during_setup"] = true
 				}
 			}
 			if len(labels) > 0 {

--- a/cmd/fleetctl/fleetctl/generate_gitops_test.go
+++ b/cmd/fleetctl/fleetctl/generate_gitops_test.go
@@ -333,6 +333,7 @@ func (MockClient) GetSoftwareTitleByID(ID uint, teamID *uint) (*fleet.SoftwareTi
 				SelfService:       true,
 				Platform:          "darwin",
 				URL:               "https://example.com/download/my-software.pkg",
+				Categories:        []string{"Browsers"},
 			},
 		}, nil
 	case 2:
@@ -347,6 +348,8 @@ func (MockClient) GetSoftwareTitleByID(ID uint, teamID *uint) (*fleet.SoftwareTi
 				}, {
 					LabelName: "Label D",
 				}},
+				Categories:  []string{"Productivity", "Utilities"},
+				SelfService: true,
 			},
 		}, nil
 	default:

--- a/cmd/fleetctl/fleetctl/testdata/generateGitops/expectedTeamControls.yaml
+++ b/cmd/fleetctl/fleetctl/testdata/generateGitops/expectedTeamControls.yaml
@@ -3,4 +3,3 @@ macos_settings:
   - path: ../lib/some_team/profiles/team-macos-mobileconfig-profile.mobileconfig
 scripts:
 - path: ../lib/some_team/scripts/Script B.ps1
-macos_setup: 'TODO: update with your macos_setup configuration'

--- a/cmd/fleetctl/fleetctl/testdata/generateGitops/expectedTeamSoftware.yaml
+++ b/cmd/fleetctl/fleetctl/testdata/generateGitops/expectedTeamSoftware.yaml
@@ -1,5 +1,8 @@
 packages:
-  - hash_sha256: software-package-hash ___GITOPS_COMMENT_0___
+  - categories:
+    - Browsers
+    hash_sha256: software-package-hash ___GITOPS_COMMENT_0___
+    install_during_setup: true
     install_script:
       path: ../lib/some-team/scripts/my-software-package-darwin-install
     labels_include_any:
@@ -18,3 +21,7 @@ app_store_apps:
     labels_exclude_any:
      - Label C
      - Label D
+    categories:
+    - Productivity
+    - Utilities
+    self_service: true

--- a/cmd/fleetctl/fleetctl/testdata/generateGitops/expectedTeamSoftware.yaml
+++ b/cmd/fleetctl/fleetctl/testdata/generateGitops/expectedTeamSoftware.yaml
@@ -2,7 +2,7 @@ packages:
   - categories:
     - Browsers
     hash_sha256: software-package-hash ___GITOPS_COMMENT_0___
-    install_during_setup: true
+    setup_experience: true
     install_script:
       path: ../lib/some-team/scripts/my-software-package-darwin-install
     labels_include_any:

--- a/cmd/fleetctl/fleetctl/testdata/generateGitops/test_dir_premium/teams/team-a.yml
+++ b/cmd/fleetctl/fleetctl/testdata/generateGitops/test_dir_premium/teams/team-a.yml
@@ -72,7 +72,6 @@ software:
   - categories:
     - Browsers
     hash_sha256: software-package-hash # My Software Package (my-software.pkg) version 13.37
-    setup_experience: true
     install_script:
       path: ../lib/team-a/scripts/my-software-package-darwin-install
     labels_include_any:
@@ -83,6 +82,7 @@ software:
     pre_install_query:
       path: ../lib/team-a/queries/my-software-package-darwin-preinstallquery.yml
     self_service: true
+    setup_experience: true
     uninstall_script:
       path: ../lib/team-a/scripts/my-software-package-darwin-uninstall
     url: https://example.com/download/my-software.pkg

--- a/cmd/fleetctl/fleetctl/testdata/generateGitops/test_dir_premium/teams/team-a.yml
+++ b/cmd/fleetctl/fleetctl/testdata/generateGitops/test_dir_premium/teams/team-a.yml
@@ -27,7 +27,6 @@ controls:
   macos_settings:
     custom_settings:
     - path: ../lib/team-a/profiles/team-macos-mobileconfig-profile.mobileconfig
-  macos_setup: 'TODO: update with your macos_setup configuration'
   macos_updates:
     deadline: "2020-12-31"
     minimum_version: "95.1"
@@ -62,11 +61,18 @@ queries:
 software:
   app_store_apps:
   - app_store_id: com.example.team-software
+    categories:
+    - Productivity
+    - Utilities
     labels_exclude_any:
     - Label C
     - Label D
+    self_service: true
   packages:
-  - hash_sha256: software-package-hash # My Software Package (my-software.pkg) version 13.37
+  - categories:
+    - Browsers
+    hash_sha256: software-package-hash # My Software Package (my-software.pkg) version 13.37
+    install_during_setup: true
     install_script:
       path: ../lib/team-a/scripts/my-software-package-darwin-install
     labels_include_any:

--- a/cmd/fleetctl/fleetctl/testdata/generateGitops/test_dir_premium/teams/team-a.yml
+++ b/cmd/fleetctl/fleetctl/testdata/generateGitops/test_dir_premium/teams/team-a.yml
@@ -72,7 +72,7 @@ software:
   - categories:
     - Browsers
     hash_sha256: software-package-hash # My Software Package (my-software.pkg) version 13.37
-    install_during_setup: true
+    setup_experience: true
     install_script:
       path: ../lib/team-a/scripts/my-software-package-darwin-install
     labels_include_any:


### PR DESCRIPTION
Fixes #31164

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually

- [X] Verified that the setting is exported via `fleetctl generate-gitops`
- [X] Verified the setting is documented in a separate PR to [the GitOps documentation](https://github.com/fleetdm/fleet/blob/main/docs/Configuration/yaml-files.md#L485)
- [X] Verified that the setting is cleared on the server if it is not supplied in a YAML file (or that it is documented as being optional)