### PR TITLE
#31474 Skip incorrect CVEs from msrc feed

### DIFF
--- a/changes/31474-skip-incorrect-cves
+++ b/changes/31474-skip-incorrect-cves
@@ -1,0 +1,1 @@
+* Fixed a bug where incorrect CVEs were received from MSRC feed.

--- a/server/vulnerabilities/msrc/parser.go
+++ b/server/vulnerabilities/msrc/parser.go
@@ -51,7 +51,17 @@ func mapToSecurityBulletins(rXML *msrcxml.FeedResult) (map[string]*parsed.Securi
 		pIDToPName[pID] = name
 	}
 
+	knownVulnsToIgnore := map[string]struct{}{
+		"CVE-2025-36350": {},
+		"CVE-2025-36357": {},
+	}
+
 	for _, v := range rXML.WinVulnerabities {
+		// skip broken CVE's
+		if _, bad := knownVulnsToIgnore[v.CVE]; bad {
+			continue
+		}
+
 		for _, rem := range v.Remediations {
 			// We will only be able to detect vulns for which they are vendor fixes.
 			if !rem.IsVendorFix() {

--- a/server/vulnerabilities/msrc/parser_test.go
+++ b/server/vulnerabilities/msrc/parser_test.go
@@ -1540,6 +1540,7 @@ func TestParser(t *testing.T) {
 }
 
 func Test_ignoreKnownBadCVEs(t *testing.T) {
+	t.Errorf("Fail deliberately to make sure the ci runs this function")
 	full := "Windows 10 Version 22H2 for x64-based Systems"
 	require.NotEmpty(t, parsed.NewProductFromFullName(full).Name(), "parsed didn’t recognize product full name: %q", full)
 

--- a/server/vulnerabilities/msrc/parser_test.go
+++ b/server/vulnerabilities/msrc/parser_test.go
@@ -1540,7 +1540,6 @@ func TestParser(t *testing.T) {
 }
 
 func Test_ignoreKnownBadCVEs(t *testing.T) {
-	t.Errorf("Fail deliberately to make sure the ci runs this function")
 	full := "Windows 10 Version 22H2 for x64-based Systems"
 	require.NotEmpty(t, parsed.NewProductFromFullName(full).Name(), "parsed didn’t recognize product full name: %q", full)
 


### PR DESCRIPTION
# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.
## Testing

- [x] Added/updated automated tests

- [ ] QA'd all new/changed functionality manually

For unreleased bug fixes in a release candidate, one of:

- [ ] Confirmed that the fix is not expected to adversely impact load test results
- [ ] Alerted the release DRI if additional load testing is needed