### PR TITLE
Fleet UI: Unreleased clientside pagination bug fix

### DIFF
--- a/frontend/components/TableContainer/DataTable/DataTable.tsx
+++ b/frontend/components/TableContainer/DataTable/DataTable.tsx
@@ -184,8 +184,8 @@ const DataTable = ({
         selectedRowIds: defaultSelectedRows,
       },
       // For onClientSidePaginationChange (URL-controlled mode) we inject pageIndex, otherwise leave undefined so it's internal
-      // NOTE: This specificallyprevents flickering render of incorrect page data for clientside pagination with
-      // external source of truth (URL bar) such as the self-service page
+      // NOTE: This specifically prevents quick flicker of incorrect page data for clientside pagination with
+      // external source of truth (URL bar) such as the self-service page when searching or changing categories
       // TODO: Figure out flickering on self-service page internal sort buttons
       state:
         controlledPageIndex !== undefined
@@ -363,9 +363,9 @@ const DataTable = ({
   }, [sortBy, sortHeader, onSort, sortDirection, isClientSidePagination]);
 
   /** For onClientSidePaginationChange only:
+   * Prevents bug where URL page + table page mismatch
    * Whenever defaultPageIndex (the value from props, e.g. queryParams.page) changes,
    * ensure we call gotoPage so react-table reflects the correct visible page.
-   * Prevents bug where URL + table mismatch pages
    */
   useEffect(() => {
     if (

--- a/frontend/components/TableContainer/DataTable/DataTable.tsx
+++ b/frontend/components/TableContainer/DataTable/DataTable.tsx
@@ -145,6 +145,12 @@ const DataTable = ({
     return [{ id: sortHeader, desc: sortDirection === "desc" }];
   }, [sortHeader, sortDirection]);
 
+  // Decide the page index value to pass to useTable
+  const controlledPageIndex =
+    isClientSidePagination && !!onClientSidePaginationChange
+      ? defaultPageIndex ?? 0
+      : undefined; // undefined lets react-table manage internally (Keeps internal mode working)
+
   const {
     headerGroups,
     rows,
@@ -177,6 +183,14 @@ const DataTable = ({
         pageIndex: defaultPageIndex,
         selectedRowIds: defaultSelectedRows,
       },
+      // For onClientSidePaginationChange (URL-controlled mode) we inject pageIndex, otherwise leave undefined so it's internal
+      // NOTE: This specificallyprevents flickering render of incorrect page data for clientside pagination with
+      // external source of truth (URL bar) such as the self-service page
+      // TODO: Figure out flickering on self-service page internal sort buttons
+      state:
+        controlledPageIndex !== undefined
+          ? { pageIndex: controlledPageIndex }
+          : undefined,
       disableMultiSort: true,
       disableSortRemove: true,
       manualSortBy,
@@ -347,6 +361,28 @@ const DataTable = ({
       ? { id: newId, desc: newDesc }
       : { id: undefined, desc: undefined };
   }, [sortBy, sortHeader, onSort, sortDirection, isClientSidePagination]);
+
+  /** For onClientSidePaginationChange only:
+   * Whenever defaultPageIndex (the value from props, e.g. queryParams.page) changes,
+   * ensure we call gotoPage so react-table reflects the correct visible page.
+   * Prevents bug where URL + table mismatch pages
+   */
+  useEffect(() => {
+    if (
+      isClientSidePagination &&
+      !!onClientSidePaginationChange &&
+      typeof defaultPageIndex === "number" &&
+      pageIndex !== defaultPageIndex
+    ) {
+      gotoPage(defaultPageIndex);
+    }
+  }, [
+    isClientSidePagination,
+    onClientSidePaginationChange,
+    defaultPageIndex,
+    gotoPage,
+    pageIndex,
+  ]);
 
   useEffect(() => {
     if (isAllPagesSelected) {
@@ -624,15 +660,15 @@ const DataTable = ({
               disableNext={!canNextPage}
               onPrevPage={() => {
                 toggleAllRowsSelected(false); // Resets row selection on pagination (client-side)
-                onClientSidePaginationChange &&
-                  onClientSidePaginationChange(pageIndex - 1);
-                previousPage();
+                onClientSidePaginationChange
+                  ? onClientSidePaginationChange(pageIndex - 1)
+                  : previousPage();
               }}
               onNextPage={() => {
                 toggleAllRowsSelected(false); // Resets row selection on pagination (client-side)
-                onClientSidePaginationChange &&
-                  onClientSidePaginationChange(pageIndex + 1);
-                nextPage();
+                onClientSidePaginationChange
+                  ? onClientSidePaginationChange(pageIndex + 1)
+                  : nextPage();
               }}
               hidePagination={!canPreviousPage && !canNextPage}
             />

--- a/frontend/components/TableContainer/DataTable/DataTable.tsx
+++ b/frontend/components/TableContainer/DataTable/DataTable.tsx
@@ -348,20 +348,6 @@ const DataTable = ({
       : { id: undefined, desc: undefined };
   }, [sortBy, sortHeader, onSort, sortDirection, isClientSidePagination]);
 
-  /** For clientside pagination only:
-   * Whenever defaultPageIndex (the value from props, e.g. queryParams.page) changes,
-   * ensure we call gotoPage so react-table reflects the correct visible page.
-   */
-  useEffect(() => {
-    if (
-      isClientSidePagination &&
-      typeof defaultPageIndex === "number" &&
-      pageIndex !== defaultPageIndex
-    ) {
-      gotoPage(defaultPageIndex);
-    }
-  }, [isClientSidePagination, defaultPageIndex, gotoPage, pageIndex]);
-
   useEffect(() => {
     if (isAllPagesSelected) {
       toggleAllRowsSelected(true);


### PR DESCRIPTION
## Issue
Closes #31805
Unreleased bug pushed fixing #31632

## Note
- Need to re-QA self-service pagination on this branch, which was the original fix
  - [x] Clicking on install/uninstall and ensuring pages doesn't change with various sorts already applied
  - [x] But also that pagination works as intended in general (goes to page 0 when switching category/searching/applying different sort, can paginate, etc)
  - [x] Ensure this is not broken:  /** For clientside pagination only:
   * Whenever defaultPageIndex (the value from props, e.g. queryParams.page) changes,
   * ensure we call gotoPage so react-table reflects the correct visible page.
   */

- Need to re-QA pagination of clientside tables on this branch, specifically any table that has `isClientsidePagination` was affected and should be fixed with the fix
  Examples that could be tested: 
  - [ ] Team management
  - [ ] User page
  - [x] Host policies
  - [ ] Query reports page
  - [x] Live query/policy results
  - [x] Software vulns table
  - [ ] Title versions table

## Testing

- [x] QA'd all new/changed functionality manually
