### PR TITLE
Update Go to 1.24.6 (#31784)

### DIFF
--- a/.github/workflows/fleet-and-orbit.yml
+++ b/.github/workflows/fleet-and-orbit.yml
@@ -13,10 +13,12 @@ on:
     paths:
       - "orbit/**.go"
       - ".github/workflows/fleet-and-orbit.yml"
+      - "Dockerfile-desktop-linux"
   pull_request:
     paths:
       - "orbit/**.go"
       - ".github/workflows/fleet-and-orbit.yml"
+      - "Dockerfile-desktop-linux"
   workflow_dispatch: # Manual
 
 # This allows a subsequently queued workflow run to interrupt previous runs

--- a/Dockerfile-desktop-linux
+++ b/Dockerfile-desktop-linux
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 golang:1.24.5-bullseye@sha256:254c0d1f13aad57bb210caa9e049deaee17ab7b8a976dba755cba1adf3fbe291
+FROM --platform=linux/amd64 golang:1.24.6-bullseye@sha256:637f45ef9f8fb4228406268d544df3f1251703cda025f706902c3627fa621c54
 LABEL maintainer="Fleet Developers"
 
 RUN mkdir -p /usr/src/fleet

--- a/changes/update-go-1.24.6
+++ b/changes/update-go-1.24.6
@@ -1,0 +1,1 @@
+* Updated go to 1.24.6

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/fleetdm/fleet/v4
 
-go 1.24.5
+go 1.24.6
 
 require (
 	cloud.google.com/go/pubsub v1.45.1

--- a/infrastructure/loadtesting/terraform/docker/loadtest.Dockerfile
+++ b/infrastructure/loadtesting/terraform/docker/loadtest.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24.5-alpine3.21@sha256:933e5a0829a1f97cc99917e3b799ebe450af30236f5a023a3583d26b5ef9166f
+FROM golang:1.24.6-alpine3.21@sha256:50f8a10a46c0c26b5b816a80314f1999196c44c3e3571f41026b061339c29db6
 ARG TAG
 RUN apk add git
 RUN git clone -b $TAG --depth=1 --no-tags --progress --no-recurse-submodules https://github.com/fleetdm/fleet.git && cd /go/fleet/cmd/osquery-perf/ && go build .

--- a/orbit/changes/update-go-1.24.6
+++ b/orbit/changes/update-go-1.24.6
@@ -1,0 +1,1 @@
+* Updated go to 1.24.6

--- a/tools/mdm/migration/mdmproxy/Dockerfile
+++ b/tools/mdm/migration/mdmproxy/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24.5-alpine3.21@sha256:933e5a0829a1f97cc99917e3b799ebe450af30236f5a023a3583d26b5ef9166f
+FROM golang:1.24.6-alpine3.21@sha256:50f8a10a46c0c26b5b816a80314f1999196c44c3e3571f41026b061339c29db6
 ARG TAG
 RUN apk update && apk add --no-cache git
 RUN git clone -b $TAG --depth=1 --no-tags --progress --no-recurse-submodules https://github.com/fleetdm/fleet.git && cd /go/fleet/tools/mdm/migration/mdmproxy && go build .

--- a/tools/mdm/windows/bitlocker/go.mod
+++ b/tools/mdm/windows/bitlocker/go.mod
@@ -1,6 +1,6 @@
 module bitlocker
 
-go 1.24.5
+go 1.24.6
 
 require github.com/go-ole/go-ole v1.3.0
 

--- a/tools/snapshot/go.mod
+++ b/tools/snapshot/go.mod
@@ -1,6 +1,6 @@
 module github.com/fleetdm/fleet/v4/tools/snapshot
 
-go 1.24.5
+go 1.24.6
 
 require (
 	github.com/manifoldco/promptui v0.9.0

--- a/tools/terraform/go.mod
+++ b/tools/terraform/go.mod
@@ -1,6 +1,6 @@
 module terraform-provider-fleetdm
 
-go 1.24.5
+go 1.24.6
 
 require (
 	github.com/hashicorp/terraform-plugin-framework v1.7.0


### PR DESCRIPTION
Cherry pick for https://github.com/fleetdm/fleet/pull/31784.

We decided to patch it because 1.24.6 contains a fix for a HIGH CVE: [CVE-2025-47907](https://nvd.nist.gov/vuln/detail/CVE-2025-47907)
```
Cancelling a query (e.g. by cancelling the context passed to one of the query methods) during a call
to the Scan method of the returned Rows can result in unexpected results if other queries are being
made in parallel. This can result in a race condition that may overwrite the expected results with those
of another query, causing the call to Scan to return either unexpected results from the other
query or an error.
```