### PR TITLE
SLSA attestation updates

### DIFF
--- a/.github/workflows/code-sign-windows.yml
+++ b/.github/workflows/code-sign-windows.yml
@@ -1,4 +1,4 @@
-name: Code sign Windows binaries with DigiCert KeyLocker KSP
+name: Code sign Windows binaries with DigiCert KeyLocker KSP, optionally attest
 
 on:
   workflow_call:
@@ -17,6 +17,11 @@ on:
         required: false
         default: 'signed-windows'
         type: string
+      attest:
+        description: 'Whether to run attestation on the signed binary'
+        required: false
+        type: boolean
+        default: false
     secrets:
       DIGICERT_KEYLOCKER_CERTIFICATE:
         required: true
@@ -31,6 +36,8 @@ on:
 
 permissions:
   contents: read
+  id-token: write # required for attestations
+  attestations: write # required for attestations
 
 jobs:
   code-sign-windows:
@@ -89,6 +96,13 @@ jobs:
           copy unsigned.exe signed.exe
           signtool.exe verify /v /pa ${{ inputs.filename }}
         shell: cmd
+
+      - name: Attest binary
+        if: ${{ inputs.attest == 'true' }}
+        continue-on-error: true
+        uses: actions/attest-build-provenance@619dbb2e03e0189af0c55118e7d3c5e129e99726 # v2.0
+        with:
+          subject-path: ${{ inputs.filename }}
 
       - name: Upload signed artifact
         uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # 4.3.3

--- a/.github/workflows/generate-desktop-targets.yml
+++ b/.github/workflows/generate-desktop-targets.yml
@@ -78,11 +78,21 @@ jobs:
           FLEET_DESKTOP_VERSION=${{ needs.set-version.outputs.FLEET_DESKTOP_VERSION }} \
           make desktop-app-tar-gz
 
+      - name: Extract archive for attestation
+        run: |
+          mkdir -p extracted
+          tar -xzf desktop.app.tar.gz -C extracted
+
       - name: Attest binary
         continue-on-error: true
         uses: actions/attest-build-provenance@619dbb2e03e0189af0c55118e7d3c5e129e99726 # v2.0
         with:
-          subject-path: "desktop.app.tar.gz"
+          subject-path: "extracted/*.pkg"
+
+      - name: Repackage archive
+        run: |
+          cd extracted
+          tar -czf ../desktop.app.tar.gz ./*
 
       - name: Upload desktop.app.tar.gz
         uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # 4.3.3
@@ -112,12 +122,6 @@ jobs:
           FLEET_DESKTOP_VERSION=${{ needs.set-version.outputs.FLEET_DESKTOP_VERSION }} \
           make desktop-windows
 
-      - name: Attest binary
-        continue-on-error: true
-        uses: actions/attest-build-provenance@619dbb2e03e0189af0c55118e7d3c5e129e99726 # v2.0
-        with:
-          subject-path: "fleet-desktop.exe"
-
       - name: Upload fleet-desktop.exe
         uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # 4.3.3
         with:
@@ -128,6 +132,7 @@ jobs:
     needs: desktop-windows
     uses: ./.github/workflows/code-sign-windows.yml
     with:
+      attest: "true"
       filename: fleet-desktop.exe
       upload_name: fleet-desktop.exe
     secrets:
@@ -159,12 +164,6 @@ jobs:
           FLEET_DESKTOP_VERSION=${{ needs.set-version.outputs.FLEET_DESKTOP_VERSION }} \
           make desktop-windows-arm64
 
-      - name: Attest binary
-        continue-on-error: true
-        uses: actions/attest-build-provenance@619dbb2e03e0189af0c55118e7d3c5e129e99726 # v2.0
-        with:
-          subject-path: "fleet-desktop.exe"
-
       - name: Upload fleet-desktop.exe
         uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # 4.3.3
         with:
@@ -175,6 +174,7 @@ jobs:
     needs: desktop-windows-arm64
     uses: ./.github/workflows/code-sign-windows.yml
     with:
+      attest: "true"
       filename: fleet-desktop.exe
       upload_name: fleet-desktop-arm64.exe
       download_name: unsigned-windows-arm64

--- a/.github/workflows/generate-desktop-targets.yml
+++ b/.github/workflows/generate-desktop-targets.yml
@@ -87,7 +87,7 @@ jobs:
         continue-on-error: true
         uses: actions/attest-build-provenance@619dbb2e03e0189af0c55118e7d3c5e129e99726 # v2.0
         with:
-          subject-path: "extracted/*.pkg"
+          subject-path: "extracted/Fleet\ Desktop.app/Contents/MacOS/*"
 
       - name: Repackage archive
         run: |

--- a/.github/workflows/generate-osqueryd-targets.yml
+++ b/.github/workflows/generate-osqueryd-targets.yml
@@ -55,7 +55,7 @@ jobs:
         continue-on-error: true
         uses: actions/attest-build-provenance@619dbb2e03e0189af0c55118e7d3c5e129e99726 # v2.0
         with:
-          subject-path: "extracted/*.pkg"
+          subject-path: "extracted/osquery.app/Contents/MacOS/*"
 
       - name: Repackage archive
         run: |

--- a/.github/workflows/generate-osqueryd-targets.yml
+++ b/.github/workflows/generate-osqueryd-targets.yml
@@ -46,11 +46,21 @@ jobs:
         run: |
           make osqueryd-app-tar-gz out-path=. version=$OSQUERY_VERSION
 
+      - name: Extract archive for attestation
+        run: |
+          mkdir -p extracted
+          tar -xzf osqueryd.app.tar.gz -C extracted
+
       - name: Attest binary
         continue-on-error: true
         uses: actions/attest-build-provenance@619dbb2e03e0189af0c55118e7d3c5e129e99726 # v2.0
         with:
-          subject-path: "osqueryd.app.tar.gz"
+          subject-path: "extracted/*.pkg"
+
+      - name: Repackage archive
+        run: |
+          cd extracted
+          tar -czf ../osqueryd.app.tar.gz ./*
 
       - name: Upload osqueryd.app.tar.gz
         uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b # v4.5.0

--- a/.github/workflows/goreleaser-orbit.yaml
+++ b/.github/workflows/goreleaser-orbit.yaml
@@ -194,12 +194,6 @@ jobs:
       - name: Run GoReleaser
         run: go run github.com/goreleaser/goreleaser/v2@606c0e724fe9b980cd01090d08cbebff63cd0f72 release --verbose --clean --skip=publish -f orbit/goreleaser-windows.yml # v2.4.4
 
-      - name: Attest binary
-        continue-on-error: true
-        uses: actions/attest-build-provenance@619dbb2e03e0189af0c55118e7d3c5e129e99726 # v2.0
-        with:
-          subject-path: "dist/orbit_windows_amd64_v1/orbit.exe"
-
       - name: Upload
         uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # 4.3.3
         with:
@@ -249,12 +243,6 @@ jobs:
 
       - name: Run GoReleaser
         run: go run github.com/goreleaser/goreleaser/v2@606c0e724fe9b980cd01090d08cbebff63cd0f72 release --verbose --clean --skip=publish -f orbit/goreleaser-windows-arm64.yml # v2.4.4
-
-      - name: Attest binary
-        continue-on-error: true
-        uses: actions/attest-build-provenance@619dbb2e03e0189af0c55118e7d3c5e129e99726 # v2.0
-        with:
-          subject-path: "dist/orbit_windows_arm64_v8.0/orbit.exe"
 
       - name: Upload
         uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # 4.3.3

--- a/.github/workflows/goreleaser-orbit.yaml
+++ b/.github/workflows/goreleaser-orbit.yaml
@@ -210,6 +210,7 @@ jobs:
     needs: goreleaser-windows
     uses: ./.github/workflows/code-sign-windows.yml
     with:
+      attest: 'true'
       filename: orbit.exe
       upload_name: orbit-windows
     secrets:
@@ -265,6 +266,7 @@ jobs:
     needs: goreleaser-windows-arm64
     uses: ./.github/workflows/code-sign-windows.yml
     with:
+      attest: 'true'
       filename: orbit.exe
       upload_name: orbit-windows-arm64
       download_name: unsigned-windows-arm64

--- a/changes/26382-slsa-attestation-updates
+++ b/changes/26382-slsa-attestation-updates
@@ -1,0 +1,3 @@
+* Attested the signed Windows Orbit binary instead of the unsigned one.
+* For both Fleet desktop and Osquery for macOS and Windows artifacts,
+  attested the binaries inside archives.


### PR DESCRIPTION
For #26382

- Attested the signed Windows Orbit binary instead of the unsigned one.
- For both Fleet desktop and Osquery for macOS and Windows artifacts, attested the binaries inside archives.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [ ] QA'd all new/changed functionality manually