### PR TITLE
Cherry-pick: Fix server panic with all teams software titles

### DIFF
--- a/changes/31571-fix-panic-all-teams-software
+++ b/changes/31571-fix-panic-all-teams-software
@@ -1,0 +1,1 @@
+* Fixed server panic when listing software titles for "All teams" with page that contains a software title with a policy automation in "No team".

--- a/server/datastore/mysql/policies.go
+++ b/server/datastore/mysql/policies.go
@@ -2116,11 +2116,14 @@ func (ds *Datastore) GetTeamHostsPolicyMemberships(
 	return hosts, nil
 }
 
-// GetPoliciesBySoftwareTitleID returns the policies that are associated with a set of software titles.
+// getPoliciesBySoftwareTitleIDs returns the policies that are associated with a set of software titles.
+//
+// Takes a uint teamID (and not a *uint) because it should only be used when querying team and "No team"
+// policies ("All teams" cannot be associated to packages/VPP-apps).
 func (ds *Datastore) getPoliciesBySoftwareTitleIDs(
 	ctx context.Context,
 	softwareTitleIDs []uint,
-	teamID *uint,
+	teamID uint,
 ) ([]fleet.AutomaticInstallPolicy, error) {
 	if len(softwareTitleIDs) == 0 {
 		return nil, nil
@@ -2138,15 +2141,10 @@ func (ds *Datastore) getPoliciesBySoftwareTitleIDs(
 	WHERE (va.title_id IN (?) OR si.title_id IN (?)) AND p.team_id = ?
 `
 
-	var tmID uint
-	if teamID != nil {
-		tmID = *teamID
-	}
-
 	batchSize := 32000 // see https://github.com/fleetdm/fleet/issues/26753 on the math behind this number
 	var policies []fleet.AutomaticInstallPolicy
 	err := common_mysql.BatchProcessSimple(softwareTitleIDs, batchSize, func(softwareTitleIDsToProcess []uint) error {
-		query, args, err := sqlx.In(baseQuery, softwareTitleIDsToProcess, softwareTitleIDsToProcess, tmID)
+		query, args, err := sqlx.In(baseQuery, softwareTitleIDsToProcess, softwareTitleIDsToProcess, teamID)
 		if err != nil {
 			return ctxerr.Wrap(ctx, err, "build select get policies by software id query")
 		}

--- a/server/datastore/mysql/policies_test.go
+++ b/server/datastore/mysql/policies_test.go
@@ -4618,7 +4618,7 @@ func testTeamPoliciesWithVPP(t *testing.T, ds *Datastore) {
 	}, &team1.ID)
 	require.NoError(t, err)
 
-	automaticPolicies, err := ds.getPoliciesBySoftwareTitleIDs(ctx, []uint{team1App3.TitleID}, &team1.ID)
+	automaticPolicies, err := ds.getPoliciesBySoftwareTitleIDs(ctx, []uint{team1App3.TitleID}, team1.ID)
 	require.NoError(t, err)
 	require.Len(t, automaticPolicies, 1)
 
@@ -5728,7 +5728,7 @@ func testPoliciesBySoftwareTitleID(t *testing.T, ds *Datastore) {
 	policy2 := newTestPolicy(t, ds, user1, "policy 2", "darwin", &team2.ID)
 
 	// Get policies for an invalid title ID
-	policies, err := ds.getPoliciesBySoftwareTitleIDs(ctx, []uint{999}, &team1.ID)
+	policies, err := ds.getPoliciesBySoftwareTitleIDs(ctx, []uint{999}, team1.ID)
 	require.NoError(t, err)
 	require.Empty(t, policies)
 
@@ -5784,31 +5784,31 @@ func testPoliciesBySoftwareTitleID(t *testing.T, ds *Datastore) {
 	require.NotNil(t, installer2.TitleID)
 
 	// software title 1 should have policy 1 when filtering by team 1
-	policies, err = ds.getPoliciesBySoftwareTitleIDs(ctx, []uint{*installer1.TitleID}, &team1.ID)
+	policies, err = ds.getPoliciesBySoftwareTitleIDs(ctx, []uint{*installer1.TitleID}, team1.ID)
 	require.NoError(t, err)
 	require.Len(t, policies, 1)
 	require.Equal(t, policy1.ID, policies[0].ID)
 	require.Equal(t, policy1.Name, policies[0].Name)
 
 	// software title 1 should not have any policies when filtering by team 2
-	policies, err = ds.getPoliciesBySoftwareTitleIDs(ctx, []uint{*installer1.TitleID}, &team2.ID)
+	policies, err = ds.getPoliciesBySoftwareTitleIDs(ctx, []uint{*installer1.TitleID}, team2.ID)
 	require.NoError(t, err)
 	require.Len(t, policies, 0)
 
 	// software title 2 should have policy 2 when filtering by team 2
-	policies, err = ds.getPoliciesBySoftwareTitleIDs(ctx, []uint{*installer2.TitleID}, &team2.ID)
+	policies, err = ds.getPoliciesBySoftwareTitleIDs(ctx, []uint{*installer2.TitleID}, team2.ID)
 	require.NoError(t, err)
 	require.Len(t, policies, 1)
 	require.Equal(t, policy2.ID, policies[0].ID)
 	require.Equal(t, policy2.Name, policies[0].Name)
 
 	// software title 2 should not have any policies when filtering by team 1
-	policies, err = ds.getPoliciesBySoftwareTitleIDs(ctx, []uint{*installer2.TitleID}, &team1.ID)
+	policies, err = ds.getPoliciesBySoftwareTitleIDs(ctx, []uint{*installer2.TitleID}, team1.ID)
 	require.NoError(t, err)
 	require.Len(t, policies, 0)
 
 	// software title 2 should not have any policies when filtering by no team
-	policies, err = ds.getPoliciesBySoftwareTitleIDs(ctx, []uint{*installer2.TitleID}, nil)
+	policies, err = ds.getPoliciesBySoftwareTitleIDs(ctx, []uint{*installer2.TitleID}, 0)
 	require.NoError(t, err)
 	require.Len(t, policies, 0)
 
@@ -5863,7 +5863,7 @@ func testPoliciesBySoftwareTitleID(t *testing.T, ds *Datastore) {
 	require.NoError(t, err)
 	require.NotNil(t, installer3.TitleID)
 
-	policies, err = ds.getPoliciesBySoftwareTitleIDs(ctx, []uint{*installer3.TitleID, *installer4.TitleID}, nil)
+	policies, err = ds.getPoliciesBySoftwareTitleIDs(ctx, []uint{*installer3.TitleID, *installer4.TitleID}, 0)
 	require.NoError(t, err)
 	require.Len(t, policies, 2)
 	expected := map[uint]fleet.AutomaticInstallPolicy{
@@ -5882,12 +5882,12 @@ func testPoliciesBySoftwareTitleID(t *testing.T, ds *Datastore) {
 		megaTitleIDs = append(megaTitleIDs, *installer4.TitleID+i+1)
 	}
 	megaTitleIDs = append(megaTitleIDs, *installer4.TitleID)
-	policies, err = ds.getPoliciesBySoftwareTitleIDs(ctx, megaTitleIDs, nil)
+	policies, err = ds.getPoliciesBySoftwareTitleIDs(ctx, megaTitleIDs, 0)
 	require.NoError(t, err)
 	require.Len(t, policies, 2)
 
 	// "No team" titles should not have any policies when filtering by team 1
-	policies, err = ds.getPoliciesBySoftwareTitleIDs(ctx, []uint{*installer3.TitleID, *installer4.TitleID}, ptr.Uint(1))
+	policies, err = ds.getPoliciesBySoftwareTitleIDs(ctx, []uint{*installer3.TitleID, *installer4.TitleID}, 1)
 	require.NoError(t, err)
 	require.Len(t, policies, 0)
 }

--- a/server/datastore/mysql/software_installers.go
+++ b/server/datastore/mysql/software_installers.go
@@ -738,11 +738,13 @@ WHERE
 		dest.Categories = categories
 	}
 
-	policies, err := ds.getPoliciesBySoftwareTitleIDs(ctx, []uint{titleID}, teamID)
-	if err != nil {
-		return nil, ctxerr.Wrap(ctx, err, "get policies by software title ID")
+	if teamID != nil {
+		policies, err := ds.getPoliciesBySoftwareTitleIDs(ctx, []uint{titleID}, *teamID)
+		if err != nil {
+			return nil, ctxerr.Wrap(ctx, err, "get policies by software title ID")
+		}
+		dest.AutomaticInstallPolicies = policies
 	}
-	dest.AutomaticInstallPolicies = policies
 
 	return &dest, nil
 }

--- a/server/datastore/mysql/software_titles_test.go
+++ b/server/datastore/mysql/software_titles_test.go
@@ -14,12 +14,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/jmoiron/sqlx"
-	"github.com/stretchr/testify/assert"
-
 	"github.com/fleetdm/fleet/v4/server/fleet"
 	"github.com/fleetdm/fleet/v4/server/ptr"
 	"github.com/fleetdm/fleet/v4/server/test"
+	"github.com/jmoiron/sqlx"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -41,6 +40,7 @@ func TestSoftwareTitles(t *testing.T) {
 		{"ListSoftwareTitlesVulnerabilityFilters", testListSoftwareTitlesVulnerabilityFilters},
 		{"UpdateSoftwareTitleName", testUpdateSoftwareTitleName},
 		{"ListSoftwareTitlesDoesnotIncludeDuplicates", testListSoftwareTitlesDoesnotIncludeDuplicates},
+		{"ListSoftwareTitlesAllTeamsWithAutomaticInstallersInNoTeam", testListSoftwareTitlesAllTeamsWithAutomaticInstallersInNoTeam},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
@@ -2011,4 +2011,65 @@ func generateSoftwareTitleListOptionsCombinations(
 		generateSoftwareTitleListOptionsCombinations(v, currentValues, combinations)
 	}
 	delete(currentValues, field.Name)
+}
+
+func testListSoftwareTitlesAllTeamsWithAutomaticInstallersInNoTeam(t *testing.T, ds *Datastore) {
+	ctx := context.Background()
+
+	user1 := test.NewUser(t, ds, "Alice", "alice@example.com", true)
+
+	// Create a macOS software foobar installer on "No team".
+	_, _, err := ds.MatchOrCreateSoftwareInstaller(ctx, &fleet.UploadSoftwareInstallerPayload{
+		Title:            "foobar",
+		BundleIdentifier: "com.foo.bar",
+		Source:           "apps",
+		InstallScript:    "echo",
+		Filename:         "foobar.pkg",
+		TeamID:           ptr.Uint(0), // "No team"
+		ValidatedLabels:  &fleet.LabelIdentsWithScope{},
+		UserID:           user1.ID,
+		StorageID:        "abc123",
+		Extension:        "pkg",
+		AutomaticInstall: true,
+	})
+	require.NoError(t, err)
+
+	// List titles for "No team" should return the software title.
+	noTeamTitles, _, _, err := ds.ListSoftwareTitles(ctx, fleet.SoftwareTitleListOptions{
+		TeamID: ptr.Uint(0),
+	}, fleet.TeamFilter{
+		User: &fleet.User{
+			GlobalRole: ptr.String(fleet.RoleAdmin),
+		},
+	})
+	require.NoError(t, err)
+	require.Len(t, noTeamTitles, 1)
+
+	// Simulate the host installing the software.
+	host1 := test.NewHost(t, ds, "host1", "", "host1key", "host1uuid", time.Now())
+	_, err = ds.UpdateHostSoftware(ctx, host1.ID, []fleet.Software{
+		{
+			Name:             "foobar",
+			BundleIdentifier: "com.foo.bar",
+			Version:          "v1.0.0",
+			Source:           "apps",
+		},
+	})
+	require.NoError(t, err)
+
+	// Update hosts software title counts so that it shows up at the "All teams" view.
+	require.NoError(t, ds.SyncHostsSoftwareTitles(ctx, time.Now()))
+
+	// List titles for "All teams" should return the one title without any installer associated to it.
+	allTeamsTitles, _, _, err := ds.ListSoftwareTitles(ctx, fleet.SoftwareTitleListOptions{
+		TeamID: nil,
+	}, fleet.TeamFilter{
+		User: &fleet.User{
+			GlobalRole: ptr.String(fleet.RoleAdmin),
+		},
+	},
+	)
+	require.NoError(t, err)
+	require.Len(t, allTeamsTitles, 1)
+	require.Nil(t, allTeamsTitles[0].SoftwarePackage)
 }

--- a/server/datastore/mysql/vpp.go
+++ b/server/datastore/mysql/vpp.go
@@ -84,11 +84,13 @@ WHERE
 	}
 	app.Categories = categories
 
-	policies, err := ds.getPoliciesBySoftwareTitleIDs(ctx, []uint{titleID}, teamID)
-	if err != nil {
-		return nil, ctxerr.Wrap(ctx, err, "get policies by software title ID")
+	if teamID != nil {
+		policies, err := ds.getPoliciesBySoftwareTitleIDs(ctx, []uint{titleID}, *teamID)
+		if err != nil {
+			return nil, ctxerr.Wrap(ctx, err, "get policies by software title ID")
+		}
+		app.AutomaticInstallPolicies = policies
 	}
-	app.AutomaticInstallPolicies = policies
 
 	return &app, nil
 }


### PR DESCRIPTION
For #31571
Original PR:
https://github.com/fleetdm/fleet/pull/31746

Caveat, had to remove changes in `server/datastore/mysql/software.go`. Automatic install policies were added in  https://github.com/fleetdm/fleet/pull/31469, which is slated for release as post 4.72+.