### PR TITLE
Custom installers translate no team to team_id 0

### DIFF
--- a/ee/server/service/software_installers.go
+++ b/ee/server/service/software_installers.go
@@ -146,7 +146,11 @@ func (svc *Service) UploadSoftwareInstaller(ctx context.Context, payload *fleet.
 	}
 
 	// get values for response object
-	addedInstaller, err := svc.ds.GetSoftwareInstallerMetadataByTeamAndTitleID(ctx, payload.TeamID, titleID, true)
+	var tmID uint
+	if payload.TeamID != nil {
+		tmID = *payload.TeamID
+	}
+	addedInstaller, err := svc.ds.GetSoftwareInstallerMetadataByTeamAndTitleID(ctx, &tmID, titleID, true)
 	if err != nil {
 		return nil, ctxerr.Wrap(ctx, err, "getting added software installer")
 	}

--- a/server/service/integration_enterprise_test.go
+++ b/server/service/integration_enterprise_test.go
@@ -9303,18 +9303,21 @@ func (s *integrationEnterpriseTestSuite) TestAllSoftwareTitles() {
 	s.uploadSoftwareInstallerWithErrorNameReason(t, payloadEmacsMissingUnSecret, http.StatusUnprocessableEntity, "$FLEET_SECRET_INVALID",
 		"uninstall script")
 
+	// not specifiying a team_id translates to "no team" or team_id of 0
 	payloadEmacs := &fleet.UploadSoftwareInstallerPayload{
-		InstallScript: "install",
-		Filename:      "emacs.deb",
-		SelfService:   true,
+		InstallScript:    "install",
+		Filename:         "emacs.deb",
+		SelfService:      true,
+		AutomaticInstall: true,
 	}
 	s.uploadSoftwareInstaller(t, payloadEmacs, http.StatusOK, "")
 
 	payloadVim := &fleet.UploadSoftwareInstallerPayload{
-		InstallScript: "install",
-		Filename:      "vim.deb",
-		SelfService:   true,
-		TeamID:        ptr.Uint(0),
+		InstallScript:    "install",
+		Filename:         "vim.deb",
+		SelfService:      true,
+		TeamID:           ptr.Uint(0),
+		AutomaticInstall: true,
 	}
 	s.uploadSoftwareInstaller(t, payloadVim, http.StatusOK, "")
 


### PR DESCRIPTION
Custom installers for no team pass null for team_id. This needs to get translated to 0 for `getPoliciesBySoftwareTitleIDs`

patch for https://github.com/fleetdm/fleet/pull/31746
For #31571