### PR TITLE
#31474 MSRC has incorrectly named CVEs. This PR removes them from the generated file.

### DIFF
--- a/changes/31474-remove-incorrect-cves
+++ b/changes/31474-remove-incorrect-cves
@@ -1,0 +1,1 @@
+* Fixed a bug where incorrect CVEs were received from MSRC feed.

--- a/cmd/msrc/generate.go
+++ b/cmd/msrc/generate.go
@@ -59,8 +59,16 @@ func main() {
 		panicif(err)
 	}
 
+	knownVulnsToRemove := map[string]struct{}{
+		"CVE-2025-36350": {},
+		"CVE-2025-36357": {},
+	}
+
 	fmt.Println("Saving bulletins...")
 	for _, b := range bulletins {
+		for cve := range knownVulnsToRemove {
+			delete(b.Vulnerabities, cve)
+		}
 		err := serialize(b, now, outPath)
 		panicif(err)
 	}

--- a/cmd/msrc/generate.go
+++ b/cmd/msrc/generate.go
@@ -22,7 +22,7 @@ func panicif(err error) {
 	}
 }
 
-var cleanEnvVar = "MSRC_CLEAN"
+const cleanEnvVar = "MSRC_CLEAN"
 
 func main() {
 	wd, err := os.Getwd()


### PR DESCRIPTION
Fixes: #31474 

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.
## Testing

- [x] QA'd all new/changed functionality manually

### How I tested it
- Ran the unmodified script with `go run cmd/msrc/generate.go`
- Checked the the file `msrc_out/fleet_msrc_Windows_11-2025_08_12.json` contains CVE-2025-36350 and CVE-2025-36357

I tested the next situations with the feed existing and deleted
- Ran the new code with `go run cmd/msrc/generate.go` 
- Checked same file and the two CVE's were not present.

Tested in fleet ui by
- Set up a host with Windows 11 Pro 24H2 10.0.26100.4061 so CVE-2025-3635(0/7) will show up.
- Manually changed the msrc_Windows11... file in /tmp/vulndbs to the one generated with the fix.
- Searched in Software > Vulnerabilities and could not find CVE-2025-3635(0/7) anymore.