### PR TITLE
HCA: Delete CA API endpoint

### DIFF
--- a/ee/server/service/certificate_authorities.go
+++ b/ee/server/service/certificate_authorities.go
@@ -309,3 +309,11 @@ func (svc *Service) validateCustomSCEPProxy(ctx context.Context, customSCEP *fle
 	}
 	return nil
 }
+
+func (svc *Service) DeleteCertificateAuthority(ctx context.Context, certificateAuthorityID int64) error {
+	if err := svc.authz.Authorize(ctx, &fleet.CertificateAuthority{}, fleet.ActionWrite); err != nil {
+		return err
+	}
+
+	return svc.ds.DeleteCertificateAuthority(ctx, certificateAuthorityID)
+}

--- a/ee/server/service/certificate_authorities.go
+++ b/ee/server/service/certificate_authorities.go
@@ -310,7 +310,7 @@ func (svc *Service) validateCustomSCEPProxy(ctx context.Context, customSCEP *fle
 	return nil
 }
 
-func (svc *Service) DeleteCertificateAuthority(ctx context.Context, certificateAuthorityID int64) error {
+func (svc *Service) DeleteCertificateAuthority(ctx context.Context, certificateAuthorityID uint) error {
 	if err := svc.authz.Authorize(ctx, &fleet.CertificateAuthority{}, fleet.ActionWrite); err != nil {
 		return err
 	}

--- a/ee/server/service/certificate_authorities_test.go
+++ b/ee/server/service/certificate_authorities_test.go
@@ -23,16 +23,19 @@ func TestDeleteCertificateAuthority(t *testing.T) {
 	ctx = viewer.NewContext(ctx, viewer.Viewer{User: admin})
 
 	t.Run("successfully deletes certificate", func(t *testing.T) {
-		ds.DeleteCertificateAuthorityFunc = func(ctx context.Context, certificateAuthorityID int64) error {
-			return nil
+		ds.DeleteCertificateAuthorityFunc = func(ctx context.Context, certificateAuthorityID uint) (*fleet.CertificateAuthority, error) {
+			return &fleet.CertificateAuthority{
+				Type: string(fleet.CATypeHydrant),
+				Name: "Hydrant",
+			}, nil
 		}
 		err := svc.DeleteCertificateAuthority(ctx, 1)
 		require.NoError(t, err)
 	})
 
 	t.Run("returns not found error if certificate authority does not exist", func(t *testing.T) {
-		ds.DeleteCertificateAuthorityFunc = func(ctx context.Context, certificateAuthorityID int64) error {
-			return common_mysql.NotFound("certificate authority")
+		ds.DeleteCertificateAuthorityFunc = func(ctx context.Context, certificateAuthorityID uint) (*fleet.CertificateAuthority, error) {
+			return nil, common_mysql.NotFound("certificate authority")
 		}
 		err := svc.DeleteCertificateAuthority(ctx, 999)
 		require.Error(t, err)

--- a/ee/server/service/certificate_authorities_test.go
+++ b/ee/server/service/certificate_authorities_test.go
@@ -26,7 +26,7 @@ func TestDeleteCertificateAuthority(t *testing.T) {
 	ctx = viewer.NewContext(ctx, viewer.Viewer{User: admin})
 
 	t.Run("successfully deletes certificate", func(t *testing.T) {
-		ds.DeleteCertificateAuthorityFunc = func(ctx context.Context, certificateAuthorityID uint) (*fleet.CertificateAuthority, error) {
+		ds.DeleteCertificateAuthorityFunc = func(ctx context.Context, certificateAuthorityID uint) (*fleet.CertificateAuthoritySummary, error) {
 			return nil, errors.New("forced error to short-circuit activity creation")
 		}
 		err := svc.DeleteCertificateAuthority(ctx, 1)
@@ -35,7 +35,7 @@ func TestDeleteCertificateAuthority(t *testing.T) {
 	})
 
 	t.Run("returns not found error if certificate authority does not exist", func(t *testing.T) {
-		ds.DeleteCertificateAuthorityFunc = func(ctx context.Context, certificateAuthorityID uint) (*fleet.CertificateAuthority, error) {
+		ds.DeleteCertificateAuthorityFunc = func(ctx context.Context, certificateAuthorityID uint) (*fleet.CertificateAuthoritySummary, error) {
 			return nil, common_mysql.NotFound("certificate authority")
 		}
 		err := svc.DeleteCertificateAuthority(ctx, 999)

--- a/ee/server/service/certificate_authorities_test.go
+++ b/ee/server/service/certificate_authorities_test.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/fleetdm/fleet/v4/server/contexts/viewer"
@@ -12,6 +13,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// TODO: Revisit this test, as it seems rather useless (at least the success case) due to it's simplicity
+// and not being possible atm. to mock/call free service methods.
 func TestDeleteCertificateAuthority(t *testing.T) {
 	t.Parallel()
 
@@ -24,13 +27,11 @@ func TestDeleteCertificateAuthority(t *testing.T) {
 
 	t.Run("successfully deletes certificate", func(t *testing.T) {
 		ds.DeleteCertificateAuthorityFunc = func(ctx context.Context, certificateAuthorityID uint) (*fleet.CertificateAuthority, error) {
-			return &fleet.CertificateAuthority{
-				Type: string(fleet.CATypeHydrant),
-				Name: "Hydrant",
-			}, nil
+			return nil, errors.New("forced error to short-circuit activity creation")
 		}
 		err := svc.DeleteCertificateAuthority(ctx, 1)
-		require.NoError(t, err)
+		require.Error(t, err)
+		require.Equal(t, "forced error to short-circuit activity creation", err.Error())
 	})
 
 	t.Run("returns not found error if certificate authority does not exist", func(t *testing.T) {

--- a/ee/server/service/certificate_authorities_test.go
+++ b/ee/server/service/certificate_authorities_test.go
@@ -1,0 +1,41 @@
+package service
+
+import (
+	"context"
+	"testing"
+
+	"github.com/fleetdm/fleet/v4/server/contexts/viewer"
+	"github.com/fleetdm/fleet/v4/server/datastore/mysql/common_mysql"
+	"github.com/fleetdm/fleet/v4/server/fleet"
+	"github.com/fleetdm/fleet/v4/server/mock"
+	"github.com/fleetdm/fleet/v4/server/ptr"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDeleteCertificateAuthority(t *testing.T) {
+	t.Parallel()
+
+	ds := new(mock.Store)
+	ctx := context.Background()
+	svc := newTestService(t, ds)
+
+	admin := &fleet.User{GlobalRole: ptr.String(fleet.RoleAdmin)}
+	ctx = viewer.NewContext(ctx, viewer.Viewer{User: admin})
+
+	t.Run("successfully deletes certificate", func(t *testing.T) {
+		ds.DeleteCertificateAuthorityFunc = func(ctx context.Context, certificateAuthorityID int64) error {
+			return nil
+		}
+		err := svc.DeleteCertificateAuthority(ctx, 1)
+		require.NoError(t, err)
+	})
+
+	t.Run("returns not found error if certificate authority does not exist", func(t *testing.T) {
+		ds.DeleteCertificateAuthorityFunc = func(ctx context.Context, certificateAuthorityID int64) error {
+			return common_mysql.NotFound("certificate authority")
+		}
+		err := svc.DeleteCertificateAuthority(ctx, 999)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "certificate authority was not found")
+	})
+}

--- a/server/datastore/mysql/certificate_authorities.go
+++ b/server/datastore/mysql/certificate_authorities.go
@@ -96,21 +96,22 @@ func (ds *Datastore) NewCertificateAuthority(ctx context.Context, ca *fleet.Cert
 	return ca, nil
 }
 
-func (ds *Datastore) DeleteCertificateAuthority(ctx context.Context, certificateAuthorityID uint) error {
+func (ds *Datastore) DeleteCertificateAuthority(ctx context.Context, certificateAuthorityID uint) (*fleet.CertificateAuthority, error) {
+	// TODO: Get the certificate before deleting to return it so we can create an activity event.
 	stmt := "DELETE FROM certificate_authorities WHERE id = ?"
 	result, err := ds.writer(ctx).ExecContext(ctx, stmt, certificateAuthorityID)
 	if err != nil {
-		return ctxerr.Wrap(ctx, err, fmt.Sprintf("deleting certificate authority with id %d", certificateAuthorityID))
+		return nil, ctxerr.Wrap(ctx, err, fmt.Sprintf("deleting certificate authority with id %d", certificateAuthorityID))
 	}
 
 	rowsAffected, err := result.RowsAffected()
 	if err != nil {
-		return ctxerr.Wrap(ctx, err, "getting rows affected by delete certificate authority")
+		return nil, ctxerr.Wrap(ctx, err, "getting rows affected by delete certificate authority")
 	}
 
 	if rowsAffected < 1 {
-		return common_mysql.NotFound(fmt.Sprintf("certificate authority with id %d", certificateAuthorityID))
+		return nil, common_mysql.NotFound(fmt.Sprintf("certificate authority with id %d", certificateAuthorityID))
 	}
 
-	return nil
+	return nil, nil
 }

--- a/server/datastore/mysql/certificate_authorities.go
+++ b/server/datastore/mysql/certificate_authorities.go
@@ -96,7 +96,7 @@ func (ds *Datastore) NewCertificateAuthority(ctx context.Context, ca *fleet.Cert
 	return ca, nil
 }
 
-func (ds *Datastore) DeleteCertificateAuthority(ctx context.Context, certificateAuthorityID int64) error {
+func (ds *Datastore) DeleteCertificateAuthority(ctx context.Context, certificateAuthorityID uint) error {
 	stmt := "DELETE FROM certificate_authorities WHERE id = ?"
 	result, err := ds.writer(ctx).ExecContext(ctx, stmt, certificateAuthorityID)
 	if err != nil {

--- a/server/datastore/mysql/certificate_authorities_test.go
+++ b/server/datastore/mysql/certificate_authorities_test.go
@@ -50,10 +50,10 @@ func testDeleteCertificateAuthority(t *testing.T, ds *Datastore) {
 	require.EqualValues(t, 1, count)
 	// TODO: ^END
 
-	err = ds.DeleteCertificateAuthority(ctx, ca.ID)
+	ca, err = ds.DeleteCertificateAuthority(ctx, ca.ID)
 	require.NoError(t, err)
 
-	err = ds.DeleteCertificateAuthority(ctx, ca.ID)
+	ca, err = ds.DeleteCertificateAuthority(ctx, ca.ID)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "not found")
 }

--- a/server/datastore/mysql/certificate_authorities_test.go
+++ b/server/datastore/mysql/certificate_authorities_test.go
@@ -1,0 +1,59 @@
+package mysql
+
+import (
+	"context"
+	"testing"
+
+	"github.com/fleetdm/fleet/v4/server/fleet"
+	"github.com/jmoiron/sqlx"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCertificateAuthority(t *testing.T) {
+	ds := CreateMySQLDS(t)
+
+	cases := []struct {
+		name string
+		fn   func(t *testing.T, ds *Datastore)
+	}{
+		{"Delete", testDeleteCertificateAuthority},
+	}
+
+	for _, c := range cases {
+		t.Helper()
+		t.Run(c.name, func(t *testing.T) {
+			defer TruncateTables(t, ds)
+
+			c.fn(t, ds)
+		})
+	}
+}
+
+func testDeleteCertificateAuthority(t *testing.T, ds *Datastore) {
+	ctx := context.Background()
+
+	var count int
+	// TODO: Replace with get single CA once implemented
+	err := sqlx.GetContext(ctx, ds.reader(ctx), &count, "SELECT COUNT(*) FROM certificate_authorities WHERE id = ?", 1)
+	require.NoError(t, err)
+	require.EqualValues(t, 0, count)
+	// TODO: ^END
+
+	ca, err := ds.NewCertificateAuthority(ctx, &fleet.CertificateAuthority{
+		Type: "hydrant",
+	})
+	require.NoError(t, err)
+
+	// TODO: Replace with get single CA once implemented
+	err = sqlx.GetContext(ctx, ds.reader(ctx), &count, "SELECT COUNT(*) FROM certificate_authorities WHERE id = ?", ca.ID)
+	require.NoError(t, err)
+	require.EqualValues(t, 1, count)
+	// TODO: ^END
+
+	err = ds.DeleteCertificateAuthority(ctx, ca.ID)
+	require.NoError(t, err)
+
+	err = ds.DeleteCertificateAuthority(ctx, ca.ID)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "not found")
+}

--- a/server/datastore/mysql/certificate_authorities_test.go
+++ b/server/datastore/mysql/certificate_authorities_test.go
@@ -50,10 +50,10 @@ func testDeleteCertificateAuthority(t *testing.T, ds *Datastore) {
 	require.EqualValues(t, 1, count)
 	// TODO: ^END
 
-	ca, err = ds.DeleteCertificateAuthority(ctx, ca.ID)
+	_, err = ds.DeleteCertificateAuthority(ctx, ca.ID)
 	require.NoError(t, err)
 
-	ca, err = ds.DeleteCertificateAuthority(ctx, ca.ID)
+	_, err = ds.DeleteCertificateAuthority(ctx, ca.ID)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "not found")
 }

--- a/server/fleet/activities.go
+++ b/server/fleet/activities.go
@@ -2452,6 +2452,21 @@ func (a ActivityAddedHydrant) Documentation() (activity string, details string, 
 }`
 }
 
+type ActivityDeletedHydrant struct {
+	Name string `json:"name"`
+}
+
+func (a ActivityDeletedHydrant) ActivityName() string {
+	return "deleted_hydrant"
+}
+
+func (a ActivityDeletedHydrant) Documentation() (activity string, details string, detailsExample string) {
+	return "Generated when Hydrant certificate authority configuration is deleted in Fleet.", `This activity contains the following fields:
+- "name": Name of the certificate authority.`, `{
+  "name": "HYDRANT_WIFI"
+}`
+}
+
 type ActivityTypeEnabledAndroidMDM struct{}
 
 func (a ActivityTypeEnabledAndroidMDM) ActivityName() string { return "enabled_android_mdm" }

--- a/server/fleet/certificate_authorities.go
+++ b/server/fleet/certificate_authorities.go
@@ -30,6 +30,12 @@ const (
 	CATypeHydrant         CAType = "hydrant"
 )
 
+type CertificateAuthoritySummary struct {
+	ID   uint   `json:"id"`
+	Name string `json:"name"`
+	Type string `json:"type"`
+}
+
 type CertificateAuthority struct {
 	ID   uint   `json:"id" db:"id"`
 	Type string `json:"type" db:"type"`

--- a/server/fleet/datastore.go
+++ b/server/fleet/datastore.go
@@ -2263,7 +2263,10 @@ type Datastore interface {
 
 	// /////////////////////////////////////////////////////////////////////////////
 	// Certificate Authorities
+
 	NewCertificateAuthority(ctx context.Context, ca *CertificateAuthority) (*CertificateAuthority, error)
+	// DeleteCertificateAuthority deletes the certificate authority of the provided ID, returns not found if it does not exist
+	DeleteCertificateAuthority(ctx context.Context, certificateAuthorityID int64) error
 
 	// GetCurrentTime gets the current time from the database
 	GetCurrentTime(ctx context.Context) (time.Time, error)

--- a/server/fleet/datastore.go
+++ b/server/fleet/datastore.go
@@ -2266,7 +2266,7 @@ type Datastore interface {
 
 	NewCertificateAuthority(ctx context.Context, ca *CertificateAuthority) (*CertificateAuthority, error)
 	// DeleteCertificateAuthority deletes the certificate authority of the provided ID, returns not found if it does not exist
-	DeleteCertificateAuthority(ctx context.Context, certificateAuthorityID uint) (*CertificateAuthority, error)
+	DeleteCertificateAuthority(ctx context.Context, certificateAuthorityID uint) (*CertificateAuthoritySummary, error)
 
 	// GetCurrentTime gets the current time from the database
 	GetCurrentTime(ctx context.Context) (time.Time, error)

--- a/server/fleet/datastore.go
+++ b/server/fleet/datastore.go
@@ -2266,7 +2266,7 @@ type Datastore interface {
 
 	NewCertificateAuthority(ctx context.Context, ca *CertificateAuthority) (*CertificateAuthority, error)
 	// DeleteCertificateAuthority deletes the certificate authority of the provided ID, returns not found if it does not exist
-	DeleteCertificateAuthority(ctx context.Context, certificateAuthorityID uint) error
+	DeleteCertificateAuthority(ctx context.Context, certificateAuthorityID uint) (*CertificateAuthority, error)
 
 	// GetCurrentTime gets the current time from the database
 	GetCurrentTime(ctx context.Context) (time.Time, error)

--- a/server/fleet/datastore.go
+++ b/server/fleet/datastore.go
@@ -2266,7 +2266,7 @@ type Datastore interface {
 
 	NewCertificateAuthority(ctx context.Context, ca *CertificateAuthority) (*CertificateAuthority, error)
 	// DeleteCertificateAuthority deletes the certificate authority of the provided ID, returns not found if it does not exist
-	DeleteCertificateAuthority(ctx context.Context, certificateAuthorityID int64) error
+	DeleteCertificateAuthority(ctx context.Context, certificateAuthorityID uint) error
 
 	// GetCurrentTime gets the current time from the database
 	GetCurrentTime(ctx context.Context) (time.Time, error)

--- a/server/fleet/service.go
+++ b/server/fleet/service.go
@@ -1278,11 +1278,12 @@ type Service interface {
 	// ConditionalAccessMicrosoftDelete deletes the integration and deprovisions the tenant on Entra.
 	ConditionalAccessMicrosoftDelete(ctx context.Context) error
 
-	// /////////////////////////////////////////////////////////////////////////////
+	///////////////////////////////////////////////////////////////////////////////
 	// Certificate Authorities
 
 	NewCertificateAuthority(ctx context.Context, p CertificateAuthorityPayload) (*CertificateAuthority, error)
-	DeleteCertificateAuthority(ctx context.Context, certificateAuthorityID int64) error
+	// DeleteCertificateAuthority deletes the certificate authority of the given id, returns nil if successful or not found error
+	DeleteCertificateAuthority(ctx context.Context, certificateAuthorityID uint) error
 }
 
 type KeyValueStore interface {

--- a/server/fleet/service.go
+++ b/server/fleet/service.go
@@ -1278,9 +1278,11 @@ type Service interface {
 	// ConditionalAccessMicrosoftDelete deletes the integration and deprovisions the tenant on Entra.
 	ConditionalAccessMicrosoftDelete(ctx context.Context) error
 
-	///////////////////////////////////////////////////////////////////////////////
+	// /////////////////////////////////////////////////////////////////////////////
 	// Certificate Authorities
+
 	NewCertificateAuthority(ctx context.Context, p CertificateAuthorityPayload) (*CertificateAuthority, error)
+	DeleteCertificateAuthority(ctx context.Context, certificateAuthorityID int64) error
 }
 
 type KeyValueStore interface {

--- a/server/mock/datastore_mock.go
+++ b/server/mock/datastore_mock.go
@@ -1451,7 +1451,7 @@ type UpdateHostIdentityCertHostIDBySerialFunc func(ctx context.Context, serialNu
 
 type NewCertificateAuthorityFunc func(ctx context.Context, ca *fleet.CertificateAuthority) (*fleet.CertificateAuthority, error)
 
-type DeleteCertificateAuthorityFunc func(ctx context.Context, certificateAuthorityID uint) error
+type DeleteCertificateAuthorityFunc func(ctx context.Context, certificateAuthorityID uint) (*fleet.CertificateAuthority, error)
 
 type GetCurrentTimeFunc func(ctx context.Context) (time.Time, error)
 
@@ -8605,7 +8605,7 @@ func (s *DataStore) NewCertificateAuthority(ctx context.Context, ca *fleet.Certi
 	return s.NewCertificateAuthorityFunc(ctx, ca)
 }
 
-func (s *DataStore) DeleteCertificateAuthority(ctx context.Context, certificateAuthorityID uint) error {
+func (s *DataStore) DeleteCertificateAuthority(ctx context.Context, certificateAuthorityID uint) (*fleet.CertificateAuthority, error) {
 	s.mu.Lock()
 	s.DeleteCertificateAuthorityFuncInvoked = true
 	s.mu.Unlock()

--- a/server/mock/datastore_mock.go
+++ b/server/mock/datastore_mock.go
@@ -1451,7 +1451,7 @@ type UpdateHostIdentityCertHostIDBySerialFunc func(ctx context.Context, serialNu
 
 type NewCertificateAuthorityFunc func(ctx context.Context, ca *fleet.CertificateAuthority) (*fleet.CertificateAuthority, error)
 
-type DeleteCertificateAuthorityFunc func(ctx context.Context, certificateAuthorityID uint) (*fleet.CertificateAuthority, error)
+type DeleteCertificateAuthorityFunc func(ctx context.Context, certificateAuthorityID uint) (*fleet.CertificateAuthoritySummary, error)
 
 type GetCurrentTimeFunc func(ctx context.Context) (time.Time, error)
 
@@ -8605,7 +8605,7 @@ func (s *DataStore) NewCertificateAuthority(ctx context.Context, ca *fleet.Certi
 	return s.NewCertificateAuthorityFunc(ctx, ca)
 }
 
-func (s *DataStore) DeleteCertificateAuthority(ctx context.Context, certificateAuthorityID uint) (*fleet.CertificateAuthority, error) {
+func (s *DataStore) DeleteCertificateAuthority(ctx context.Context, certificateAuthorityID uint) (*fleet.CertificateAuthoritySummary, error) {
 	s.mu.Lock()
 	s.DeleteCertificateAuthorityFuncInvoked = true
 	s.mu.Unlock()

--- a/server/mock/datastore_mock.go
+++ b/server/mock/datastore_mock.go
@@ -1451,7 +1451,7 @@ type UpdateHostIdentityCertHostIDBySerialFunc func(ctx context.Context, serialNu
 
 type NewCertificateAuthorityFunc func(ctx context.Context, ca *fleet.CertificateAuthority) (*fleet.CertificateAuthority, error)
 
-type DeleteCertificateAuthorityFunc func(ctx context.Context, certificateAuthorityID int64) error
+type DeleteCertificateAuthorityFunc func(ctx context.Context, certificateAuthorityID uint) error
 
 type GetCurrentTimeFunc func(ctx context.Context) (time.Time, error)
 
@@ -8605,7 +8605,7 @@ func (s *DataStore) NewCertificateAuthority(ctx context.Context, ca *fleet.Certi
 	return s.NewCertificateAuthorityFunc(ctx, ca)
 }
 
-func (s *DataStore) DeleteCertificateAuthority(ctx context.Context, certificateAuthorityID int64) error {
+func (s *DataStore) DeleteCertificateAuthority(ctx context.Context, certificateAuthorityID uint) error {
 	s.mu.Lock()
 	s.DeleteCertificateAuthorityFuncInvoked = true
 	s.mu.Unlock()

--- a/server/mock/datastore_mock.go
+++ b/server/mock/datastore_mock.go
@@ -1451,6 +1451,8 @@ type UpdateHostIdentityCertHostIDBySerialFunc func(ctx context.Context, serialNu
 
 type NewCertificateAuthorityFunc func(ctx context.Context, ca *fleet.CertificateAuthority) (*fleet.CertificateAuthority, error)
 
+type DeleteCertificateAuthorityFunc func(ctx context.Context, certificateAuthorityID int64) error
+
 type GetCurrentTimeFunc func(ctx context.Context) (time.Time, error)
 
 type DataStore struct {
@@ -3595,6 +3597,9 @@ type DataStore struct {
 
 	NewCertificateAuthorityFunc        NewCertificateAuthorityFunc
 	NewCertificateAuthorityFuncInvoked bool
+
+	DeleteCertificateAuthorityFunc        DeleteCertificateAuthorityFunc
+	DeleteCertificateAuthorityFuncInvoked bool
 
 	GetCurrentTimeFunc        GetCurrentTimeFunc
 	GetCurrentTimeFuncInvoked bool
@@ -8598,6 +8603,13 @@ func (s *DataStore) NewCertificateAuthority(ctx context.Context, ca *fleet.Certi
 	s.NewCertificateAuthorityFuncInvoked = true
 	s.mu.Unlock()
 	return s.NewCertificateAuthorityFunc(ctx, ca)
+}
+
+func (s *DataStore) DeleteCertificateAuthority(ctx context.Context, certificateAuthorityID int64) error {
+	s.mu.Lock()
+	s.DeleteCertificateAuthorityFuncInvoked = true
+	s.mu.Unlock()
+	return s.DeleteCertificateAuthorityFunc(ctx, certificateAuthorityID)
 }
 
 func (s *DataStore) GetCurrentTime(ctx context.Context) (time.Time, error) {

--- a/server/service/certificate_authorities.go
+++ b/server/service/certificate_authorities.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"net/http"
 
 	"github.com/fleetdm/fleet/v4/server/fleet"
 )
@@ -34,4 +35,32 @@ func (svc *Service) NewCertificateAuthority(ctx context.Context, p fleet.Certifi
 	// skipauth: No authorization check needed due to implementation returning only license error.
 	svc.authz.SkipAuthorization(ctx)
 	return nil, fleet.ErrMissingLicense
+}
+
+type deleteCertificateAuthorityRequest struct {
+	ID int64 `url:"id"`
+}
+
+type deleteCertificateAuthorityResponse struct {
+	Err error `json:"error,omitempty"`
+}
+
+func (r deleteCertificateAuthorityResponse) Error() error { return r.Err }
+func (r deleteCertificateAuthorityResponse) Status() int  { return http.StatusNoContent }
+
+func deleteCertificateAuthorityEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (fleet.Errorer, error) {
+	req := request.(*deleteCertificateAuthorityRequest)
+
+	err := svc.DeleteCertificateAuthority(ctx, req.ID)
+	if err != nil {
+		return &deleteCertificateAuthorityResponse{Err: err}, nil
+	}
+
+	return &deleteCertificateAuthorityResponse{}, nil
+}
+
+func (svc *Service) DeleteCertificateAuthority(ctx context.Context, certificateAuthorityID int64) error {
+	// skipauth: No authorization check needed due to implementation returning only license error.
+	svc.authz.SkipAuthorization(ctx)
+	return fleet.ErrMissingLicense
 }

--- a/server/service/certificate_authorities.go
+++ b/server/service/certificate_authorities.go
@@ -38,7 +38,7 @@ func (svc *Service) NewCertificateAuthority(ctx context.Context, p fleet.Certifi
 }
 
 type deleteCertificateAuthorityRequest struct {
-	ID int64 `url:"id"`
+	ID uint `url:"id"`
 }
 
 type deleteCertificateAuthorityResponse struct {
@@ -59,7 +59,7 @@ func deleteCertificateAuthorityEndpoint(ctx context.Context, request interface{}
 	return &deleteCertificateAuthorityResponse{}, nil
 }
 
-func (svc *Service) DeleteCertificateAuthority(ctx context.Context, certificateAuthorityID int64) error {
+func (svc *Service) DeleteCertificateAuthority(ctx context.Context, certificateAuthorityID uint) error {
 	// skipauth: No authorization check needed due to implementation returning only license error.
 	svc.authz.SkipAuthorization(ctx)
 	return fleet.ErrMissingLicense

--- a/server/service/handler.go
+++ b/server/service/handler.go
@@ -528,6 +528,8 @@ func attachFleetAPIRoutes(r *mux.Router, svc fleet.Service, config config.FleetC
 	ue.POST("/api/_version_/fleet/conditional-access/microsoft/confirm", conditionalAccessMicrosoftConfirmEndpoint, conditionalAccessMicrosoftConfirmRequest{})
 	ue.DELETE("/api/_version_/fleet/conditional-access/microsoft", conditionalAccessMicrosoftDeleteEndpoint, conditionalAccessMicrosoftDeleteRequest{})
 
+	// Certificate authorities
+
 	// Only Fleet MDM specific endpoints should be within the root /mdm/ path.
 	// NOTE: remember to update
 	// `service.mdmConfigurationRequiredEndpoints` when you add an
@@ -797,8 +799,9 @@ func attachFleetAPIRoutes(r *mux.Router, svc fleet.Service, config config.FleetC
 	// input to `fleetctl apply`
 	ue.POST("/api/_version_/fleet/mdm/profiles/batch", batchSetMDMProfilesEndpoint, batchSetMDMProfilesRequest{})
 
-	// Certificae Authority endpoints
+	// Certificate Authority endpoints
 	ue.POST("/api/_version_/fleet/certificate_authorities", createCertificateAuthorityEndpoint, createCertificateAuthorityRequest{})
+	ue.DELETE("/api/_version_/fleet/certificate_authorities/{id:[0-9]+}", deleteCertificateAuthorityEndpoint, deleteCertificateAuthorityRequest{})
 
 	errorLimiter := ratelimit.NewErrorMiddleware(limitStore)
 

--- a/server/service/handler.go
+++ b/server/service/handler.go
@@ -528,8 +528,6 @@ func attachFleetAPIRoutes(r *mux.Router, svc fleet.Service, config config.FleetC
 	ue.POST("/api/_version_/fleet/conditional-access/microsoft/confirm", conditionalAccessMicrosoftConfirmEndpoint, conditionalAccessMicrosoftConfirmRequest{})
 	ue.DELETE("/api/_version_/fleet/conditional-access/microsoft", conditionalAccessMicrosoftDeleteEndpoint, conditionalAccessMicrosoftDeleteRequest{})
 
-	// Certificate authorities
-
 	// Only Fleet MDM specific endpoints should be within the root /mdm/ path.
 	// NOTE: remember to update
 	// `service.mdmConfigurationRequiredEndpoints` when you add an


### PR DESCRIPTION
fixes: #30943 

Implements the new delete endpoint for the CA api story.

Copies the `CertificateAuthoritySummary` struct from the read api endpoint branch, to use it to do existence check before deleting to generate an activity.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually
