### PR TITLE
remove feature flag from bitlocker

### DIFF
--- a/frontend/pages/ManageControlsPage/OSSettings/cards/DiskEncryption/DiskEncryption.tsx
+++ b/frontend/pages/ManageControlsPage/OSSettings/cards/DiskEncryption/DiskEncryption.tsx
@@ -227,44 +227,42 @@ const DiskEncryption = ({
                   newTab
                 />
               </p>
-              {diskEncryptionEnabled && featureFlags.showBitLockerPINOption && (
-                <div>
-                  <RevealButton
-                    className={`${baseClass}__accordion-title`}
-                    isShowing={showAdvancedOptions}
-                    showText="Advanced options"
-                    hideText="Advanced options"
-                    caretPosition="after"
-                    onClick={() => setShowAdvancedOptions(!showAdvancedOptions)}
-                  />
-                  {showAdvancedOptions && (
-                    <Checkbox
-                      disabled={config?.gitops.gitops_mode_enabled}
-                      onChange={onToggleRequireBitLockerPIN}
-                      value={requireBitLockerPIN}
-                      className={`${baseClass}__checkbox`}
+              <div>
+                <RevealButton
+                  className={`${baseClass}__accordion-title`}
+                  isShowing={showAdvancedOptions}
+                  showText="Advanced options"
+                  hideText="Advanced options"
+                  caretPosition="after"
+                  onClick={() => setShowAdvancedOptions(!showAdvancedOptions)}
+                />
+                {showAdvancedOptions && (
+                  <Checkbox
+                    disabled={config?.gitops.gitops_mode_enabled}
+                    onChange={onToggleRequireBitLockerPIN}
+                    value={requireBitLockerPIN}
+                    className={`${baseClass}__checkbox`}
+                  >
+                    <TooltipWrapper
+                      tipContent={
+                        <div>
+                          <p>
+                            If enabled, end users on Windows hosts will be
+                            required to set a BitLocker PIN.
+                          </p>
+                          <br />
+                          <p>
+                            When the PIN is set, it&rsquo;s required to unlock
+                            Windows hosts during startup.
+                          </p>
+                        </div>
+                      }
                     >
-                      <TooltipWrapper
-                        tipContent={
-                          <div>
-                            <p>
-                              If enabled, end users on Windows hosts will be
-                              required to set a BitLocker PIN.
-                            </p>
-                            <br />
-                            <p>
-                              When the PIN is set, it&rsquo;s required to unlock
-                              Windows hosts during startup.
-                            </p>
-                          </div>
-                        }
-                      >
-                        Require BitLocker PIN
-                      </TooltipWrapper>
-                    </Checkbox>
-                  )}
-                </div>
-              )}
+                      Require BitLocker PIN
+                    </TooltipWrapper>
+                  </Checkbox>
+                )}
+              </div>
               <GitOpsModeTooltipWrapper
                 tipOffset={-12}
                 renderChildren={(d) => (

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -27,9 +27,6 @@ let plugins = [
   new webpack.DefinePlugin({
     featureFlags: {
       // e.g.: allowGitOpsMode: JSON.stringify(process.env.ALLOW_GITOPS_MODE),
-      showBitLockerPINOption: JSON.stringify(
-        process.env.SHOW_BITLOCKER_PIN_OPTION
-      ),
     },
   }),
 ];


### PR DESCRIPTION
# Details

Realized we left the feature flag in for BitLocker, so this PR removes it.  We also discussed during the last demo that "Advanced" should always be visible, even when the "Turn on disk encryption" is not checked.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.
n/a

## Testing

- [ ] Added/updated automated tests
- [ ] Where appropriate, [automated tests simulate multiple hosts and test for host isolation](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/reference/patterns-backend.md#unit-testing) (updates to one hosts's records do not affect another)

- [X] QA'd all new/changed functionality manually
