### PR TITLE
Update vulnerability dashboard to deploy from a parentless commit

### DIFF
--- a/.github/workflows/deploy-vulnerability-dashboard.yml
+++ b/.github/workflows/deploy-vulnerability-dashboard.yml
@@ -29,7 +29,6 @@ jobs:
 
     - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
 
-
     # Configure our access credentials for the Heroku CLI
     - uses: akhileshns/heroku-deploy@79ef2ae4ff9b897010907016b268fd0f88561820 # v3.6.8
       with:
@@ -79,7 +78,6 @@ jobs:
     # (This commit will never be pushed to GitHub- only to Heroku.)
     # > The local config flags make this work in GitHub's environment.
     - run: git add ee/vulnerability-dashboard/.www
-    - run: git -c "user.name=GitHub" -c "user.email=github@example.com" commit -am 'AUTOMATED COMMIT - Deployed the latest, including modified HTML layouts and .sailsrc file that reference minified assets.'
 
     # Configure the Heroku app we'll be deploying to
     - run: heroku git:remote -a vulnerability-dashboard
@@ -104,7 +102,7 @@ jobs:
           -m 'AUTOMATED COMMIT - Deployed the latest, including generated collateral such as compiled documentation, modified HTML layouts, and a .sailsrc file that references minified client-side code assets.')
         # Push the parentless commit to Heroku
         # Note: The commit pushed to Heroku will not contain the full git history.
-        # This lets up deploy the website from the Fleet monorepo while working around Heroku's pack size limits. 
+        # This lets up deploy this app from the Fleet monorepo while working around Heroku's pack size limits.
         git push heroku "$COMMIT":refs/heads/master --force
     - name: 🌐 The dashboard has been deployed
       run: echo '' && echo '--' && echo 'OK, done.  It should be live momentarily.' && echo '(if you get impatient, check the Heroku dashboard for status)'

--- a/.github/workflows/deploy-vulnerability-dashboard.yml
+++ b/.github/workflows/deploy-vulnerability-dashboard.yml
@@ -29,6 +29,7 @@ jobs:
 
     - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
 
+
     # Configure our access credentials for the Heroku CLI
     - uses: akhileshns/heroku-deploy@79ef2ae4ff9b897010907016b268fd0f88561820 # v3.6.8
       with:
@@ -37,6 +38,8 @@ jobs:
         heroku_email: ${{secrets.HEROKU_EMAIL_FOR_BOT_USER}}
         justlogin: true
     - run: heroku auth:whoami
+    # Install the heroku-repo plugin in the Heroku CLI
+    - run: heroku plugins:install heroku-repo
 
     # Set the Node.js version
     - name: Use Node.js ${{ matrix.node-version }}
@@ -69,6 +72,9 @@ jobs:
     # Compile assets
     - run: cd ee/vulnerability-dashboard/ && npm run build-for-prod
 
+    # Reset the Heroku app's git repo to prevent errors when pushing to the repo. (See https://github.com/fleetdm/fleet/issues/14162 for more details)
+    - run: heroku repo:reset -a vulnerability-dashboard
+
     # Commit newly-built assets locally so we can push them to Heroku below.
     # (This commit will never be pushed to GitHub- only to Heroku.)
     # > The local config flags make this work in GitHub's environment.
@@ -83,7 +89,22 @@ jobs:
     # > Since a shallow clone was grabbed, we have to "unshallow" it before forcepushing.
     - run: echo "Unshallowing local repository…"
     - run: git fetch --prune --unshallow
+
+    # Deploy to Heroku
     - run: echo "Deploying branch '${GITHUB_REF##*/}' to Heroku…"
-    - run: git push heroku +${GITHUB_REF##*/}:master
+    - name: Deploy to Heroku
+      run: |
+        set -euo pipefail
+        git add -A
+        # Create a git tree object that contains only the changes in the /website folder.
+        TREE=$(git write-tree)
+        # Create a parentless commit from the tree object.
+        COMMIT=$(git -c "user.name=Fleetwood" -c "user.email=github@example.com" \
+          commit-tree "$TREE" \
+          -m 'AUTOMATED COMMIT - Deployed the latest, including generated collateral such as compiled documentation, modified HTML layouts, and a .sailsrc file that references minified client-side code assets.')
+        # Push the parentless commit to Heroku
+        # Note: The commit pushed to Heroku will not contain the full git history.
+        # This lets up deploy the website from the Fleet monorepo while working around Heroku's pack size limits. 
+        git push heroku "$COMMIT":refs/heads/master --force
     - name: 🌐 The dashboard has been deployed
       run: echo '' && echo '--' && echo 'OK, done.  It should be live momentarily.' && echo '(if you get impatient, check the Heroku dashboard for status)'

--- a/ee/vulnerability-dashboard/README.md
+++ b/ee/vulnerability-dashboard/README.md
@@ -50,6 +50,7 @@ To run a local vulnerability dashboard with docker, you can follow these instruc
   >
   >- Password: `abc123`
 
+
 ## How it's made
 
 This is a [Sails v1](https://sailsjs.com) application:


### PR DESCRIPTION
Changes:
- Updated the `deploy-vulnerability-dashboard` workflow to deploy the app from a parentless commit.