### PR TITLE
Refactor failing policies total on Host endpoint

### DIFF
--- a/changes/29795-deleted-policies-still-showing
+++ b/changes/29795-deleted-policies-still-showing
@@ -1,0 +1,1 @@
+* Refactored the way failing policies are computed on Host end-point to avoid discrepancies due to read replica delays and async computation.

--- a/server/service/hosts.go
+++ b/server/service/hosts.go
@@ -1211,13 +1211,23 @@ func (svc *Service) getHostDetails(ctx context.Context, host *fleet.Host, opts f
 		if err != nil {
 			return nil, ctxerr.Wrap(ctx, err, "get policies for host")
 		}
-
 		if hp == nil {
 			hp = []*fleet.HostPolicy{}
 		}
-
 		policies = &hp
 	}
+
+	// Calculate the number of failing policies for the host based on the returned policies to
+	// avoid discrepancies due to read replica delay.
+	var failingPolicies uint64
+	if policies != nil {
+		for _, p := range *policies {
+			if p != nil && p.Response == "fail" {
+				failingPolicies++
+			}
+		}
+	}
+	host.HostIssues.FailingPoliciesCount = failingPolicies
 
 	// If Fleet MDM is enabled and configured, we want to include MDM profiles,
 	// disk encryption status, and macOS setup details for non-linux hosts.

--- a/server/service/integration_core_test.go
+++ b/server/service/integration_core_test.go
@@ -2970,11 +2970,11 @@ func (s *integrationTestSuite) TestHostDetailsUpdatesStaleHostIssues() {
 	hosts := s.createHosts(t, "linux")
 	host := hosts[0]
 
-	stalePolicyCount, staleIssuesCount, freshPolicyCount, freshIssueCount := uint64(50), uint64(500), uint64(0), uint64(0)
+	staleIssuesCount, freshIssueCount := uint64(500), uint64(0)
 	// create host_issues for it with stale data
 	mysql.ExecAdhocSQL(t, s.ds, func(q sqlx.ExtContext) error {
 		_, err := q.ExecContext(ctx,
-			`INSERT INTO host_issues (host_id, failing_policies_count, total_issues_count) VALUES (?, ?, ?)`, host.ID, stalePolicyCount, staleIssuesCount)
+			`INSERT INTO host_issues (host_id, total_issues_count) VALUES (?, ?)`, host.ID, staleIssuesCount)
 		return err
 	})
 

--- a/server/service/integration_core_test.go
+++ b/server/service/integration_core_test.go
@@ -2982,7 +2982,6 @@ func (s *integrationTestSuite) TestHostDetailsUpdatesStaleHostIssues() {
 	hostResp := getHostResponse{}
 	s.DoJSON("GET", fmt.Sprintf("/api/v1/fleet/hosts/%d", host.ID), nil, http.StatusOK, &hostResp)
 
-	require.Equal(t, hostResp.Host.HostIssues.FailingPoliciesCount, stalePolicyCount)
 	require.Equal(t, hostResp.Host.HostIssues.TotalIssuesCount, staleIssuesCount)
 
 	// set updated_at to longer than minute ago
@@ -2993,7 +2992,6 @@ func (s *integrationTestSuite) TestHostDetailsUpdatesStaleHostIssues() {
 	})
 	// hit endpoint: should have been updated this time
 	s.DoJSON("GET", fmt.Sprintf("/api/v1/fleet/hosts/%d", host.ID), nil, http.StatusOK, &hostResp)
-	require.Equal(t, hostResp.Host.HostIssues.FailingPoliciesCount, freshPolicyCount)
 	require.Equal(t, hostResp.Host.HostIssues.TotalIssuesCount, freshIssueCount)
 }
 


### PR DESCRIPTION
For #29795

Refactored the way we compute the number of failing policies to avoid discrepancies due to either read replica delays or due to async nature of the failing policy computation stored in host issues.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [X] QA'd all new/changed functionality manually