### PR TITLE
add and edit hydrant modal in UI

### DIFF
--- a/frontend/interfaces/integration.ts
+++ b/frontend/interfaces/integration.ts
@@ -34,6 +34,13 @@ export interface ICertificatesIntegrationDigicert {
   certificate_seat_id: string;
 }
 
+export interface ICertificatesIntegrationHydrant {
+  name: string;
+  url: string;
+  client_id: string;
+  client_secret: string;
+}
+
 export interface ICertificatesIntegrationCustomSCEP {
   name: string;
   url: string;
@@ -61,6 +68,17 @@ export const isDigicertCertIntegration = (
   );
 };
 
+export const isHydrantCertIntegration = (
+  integration: ICertificateIntegration
+): integration is ICertificatesIntegrationHydrant => {
+  return (
+    "name" in integration &&
+    "url" in integration &&
+    "client_id" in integration &&
+    "client_secret" in integration
+  );
+};
+
 export const isCustomSCEPCertIntegration = (
   integration: ICertificateIntegration
 ): integration is ICertificatesIntegrationCustomSCEP => {
@@ -69,12 +87,17 @@ export const isCustomSCEPCertIntegration = (
   );
 };
 
-export type ICertificateAuthorityType = "ndes" | "digicert" | "custom";
+export type ICertificateAuthorityType =
+  | "ndes"
+  | "digicert"
+  | "custom"
+  | "hydrant";
 
 /** all the types of certificate integrations */
 export type ICertificateIntegration =
   | ICertificatesIntegrationNDES
   | ICertificatesIntegrationDigicert
+  | ICertificatesIntegrationHydrant
   | ICertificatesIntegrationCustomSCEP;
 
 export interface IIntegration {

--- a/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/AddCertAuthorityModal/AddCertAuthorityModal.tests.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/AddCertAuthorityModal/AddCertAuthorityModal.tests.tsx
@@ -27,7 +27,7 @@ describe("AddCertAuthorityModal", () => {
     await user.click(screen.getByRole("combobox"));
     await user.click(
       screen.getByRole("option", {
-        name: "Custom (SCEP: Simple Certificate Enrollment Protocol)",
+        name: "Custom SCEP (Simple Certificate Enrollment Protocol)",
       })
     );
 

--- a/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/AddCertAuthorityModal/AddCertAuthorityModal.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/AddCertAuthorityModal/AddCertAuthorityModal.tsx
@@ -18,9 +18,12 @@ import NDESForm from "../NDESForm";
 import { INDESFormData } from "../NDESForm/NDESForm";
 import CustomSCEPForm from "../CustomSCEPForm";
 import { ICustomSCEPFormData } from "../CustomSCEPForm/CustomSCEPForm";
+import HydrantForm from "../HydrantForm";
+import { IHydrantFormData } from "../HydrantForm/HydrantForm";
 
 export type ICertFormData =
   | IDigicertFormData
+  | IHydrantFormData
   | INDESFormData
   | ICustomSCEPFormData;
 
@@ -46,6 +49,12 @@ const AddCertAuthorityModal = ({ onExit }: IAddCertAuthorityModalProps) => {
     commonName: "",
     userPrincipalName: "",
     certificateSeatId: "",
+  });
+  const [hydrantFormData, setHydrantFormData] = useState({
+    name: "",
+    url: "",
+    clientId: "",
+    clientSecret: "",
   });
   const [ndesFormData, setNDESFormData] = useState<INDESFormData>({
     scepURL: "",
@@ -78,6 +87,10 @@ const AddCertAuthorityModal = ({ onExit }: IAddCertAuthorityModalProps) => {
         setFormData = setDigicertFormData;
         formData = digicertFormData;
         break;
+      case "hydrant":
+        setFormData = setHydrantFormData;
+        formData = hydrantFormData;
+        break;
       case "ndes":
         setFormData = setNDESFormData;
         formData = ndesFormData;
@@ -101,6 +114,9 @@ const AddCertAuthorityModal = ({ onExit }: IAddCertAuthorityModalProps) => {
     switch (certAuthorityType) {
       case "digicert":
         formData = digicertFormData;
+        break;
+      case "hydrant":
+        formData = hydrantFormData;
         break;
       case "ndes":
         formData = ndesFormData;
@@ -139,6 +155,17 @@ const AddCertAuthorityModal = ({ onExit }: IAddCertAuthorityModalProps) => {
         return (
           <DigicertForm
             formData={digicertFormData}
+            submitBtnText={submitBtnText}
+            isSubmitting={isAdding}
+            onChange={onChangeForm}
+            onSubmit={onAddCertAuthority}
+            onCancel={onExit}
+          />
+        );
+      case "hydrant":
+        return (
+          <HydrantForm
+            formData={hydrantFormData}
             submitBtnText={submitBtnText}
             isSubmitting={isAdding}
             onChange={onChangeForm}

--- a/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/AddCertAuthorityModal/helpers.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/AddCertAuthorityModal/helpers.tsx
@@ -9,11 +9,15 @@ import CustomLink from "components/CustomLink";
 const DEFAULT_CERT_AUTHORITY_OPTIONS: IDropdownOption[] = [
   { label: "DigiCert", value: "digicert" },
   {
+    label: "Hydrant EST (Enrollment Over Secure Transport)",
+    value: "hydrant",
+  },
+  {
     label: "Microsoft NDES (Network Device Enrollment Service)",
     value: "ndes",
   },
   {
-    label: "Custom (SCEP: Simple Certificate Enrollment Protocol)",
+    label: "Custom SCEP (Simple Certificate Enrollment Protocol)",
     value: "custom",
   },
 ];
@@ -23,9 +27,15 @@ export const generateDropdownOptions = (hasNDESCert: boolean) => {
     return DEFAULT_CERT_AUTHORITY_OPTIONS;
   }
 
-  const ndesOption = DEFAULT_CERT_AUTHORITY_OPTIONS[1];
-  ndesOption.disabled = true;
-  ndesOption.tooltipContent = "Only one NDES can be added.";
+  // We only allow one NDES configuration, if ones exists disable the option and
+  // add a tooltip.
+  const ndesOption = DEFAULT_CERT_AUTHORITY_OPTIONS.find((option) => {
+    return option.value === "ndes";
+  });
+  if (ndesOption) {
+    ndesOption.disabled = true;
+    ndesOption.tooltipContent = "Only one NDES can be added.";
+  }
 
   return DEFAULT_CERT_AUTHORITY_OPTIONS;
 };

--- a/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/DeleteCertificateAuthorityModal/helpers.ts
+++ b/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/DeleteCertificateAuthorityModal/helpers.ts
@@ -5,6 +5,7 @@ import {
   ICertificateIntegration,
   ICertificatesIntegrationCustomSCEP,
   ICertificatesIntegrationDigicert,
+  ICertificatesIntegrationHydrant,
   IGlobalIntegrations,
 } from "interfaces/integration";
 import { useCallback, useContext } from "react";
@@ -248,6 +249,8 @@ export const generateCertAuthorityDisplayName = (
       return (certAuthority as ICertificatesIntegrationDigicert).name;
     case "custom":
       return (certAuthority as ICertificatesIntegrationCustomSCEP).name;
+    case "hydrant":
+      return (certAuthority as ICertificatesIntegrationHydrant).name;
     default:
       return "";
   }

--- a/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/EditCertAuthorityModal/EditCertAuthorityModal.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/EditCertAuthorityModal/EditCertAuthorityModal.tsx
@@ -5,6 +5,7 @@ import { AppContext } from "context/app";
 import {
   ICertificateIntegration,
   isDigicertCertIntegration,
+  isHydrantCertIntegration,
   isNDESCertIntegration,
 } from "interfaces/integration";
 import certificatesAPI from "services/entities/certificates";
@@ -23,6 +24,7 @@ import { ICertFormData } from "../AddCertAuthorityModal/AddCertAuthorityModal";
 import { useCertAuthorityDataGenerator } from "../DeleteCertificateAuthorityModal/helpers";
 import NDESForm from "../NDESForm";
 import CustomSCEPForm from "../CustomSCEPForm";
+import HydrantForm from "../HydrantForm";
 
 const baseClass = "edit-cert-authority-modal";
 
@@ -76,6 +78,9 @@ const EditCertAuthorityModal = ({
     }
     if (isDigicertCertIntegration(certAuthority)) {
       return DigicertForm;
+    }
+    if (isHydrantCertIntegration(certAuthority)) {
+      return HydrantForm;
     }
     return CustomSCEPForm;
   };

--- a/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/EditCertAuthorityModal/helpers.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/EditCertAuthorityModal/helpers.tsx
@@ -4,6 +4,7 @@ import {
   ICertificatesIntegrationCustomSCEP,
   isCustomSCEPCertIntegration,
   isDigicertCertIntegration,
+  isHydrantCertIntegration,
   isNDESCertIntegration,
 } from "interfaces/integration";
 
@@ -12,6 +13,7 @@ import { getDisplayErrMessage } from "../AddCertAuthorityModal/helpers";
 import { IDigicertFormData } from "../DigicertForm/DigicertForm";
 import { INDESFormData } from "../NDESForm/NDESForm";
 import { ICustomSCEPFormData } from "../CustomSCEPForm/CustomSCEPForm";
+import { IHydrantFormData } from "../HydrantForm/HydrantForm";
 
 export const getCertificateAuthorityType = (
   certAuthority: ICertificateIntegration
@@ -41,6 +43,13 @@ export const generateDefaultFormData = (
       userPrincipalName:
         certAuthority.certificate_user_principal_names?.[0] ?? "",
       certificateSeatId: certAuthority.certificate_seat_id,
+    };
+  } else if (isHydrantCertIntegration(certAuthority)) {
+    return {
+      name: certAuthority.name,
+      url: certAuthority.url,
+      clientId: certAuthority.client_id,
+      clientSecret: certAuthority.client_secret,
     };
   }
 
@@ -89,6 +98,22 @@ export const updateFormData = (
       return {
         ...newData,
         challenge: formData.challenge === "********" ? "" : formData.challenge,
+      };
+    }
+  } else if (isHydrantCertIntegration(certAuthority)) {
+    // for Hydrant, we reset clientId and clientSecret if name or url changes
+    // and the fields have not been updated. We do this to force users to send
+    // the correct clientId and clientSecret for the new name or url.
+    const formData = prevFormData as IHydrantFormData;
+    if (update.name === "name" || update.name === "url") {
+      return {
+        ...newData,
+        clientId:
+          formData.clientId === certAuthority.client_id
+            ? ""
+            : formData.clientId,
+        clientSecret:
+          formData.clientSecret === "********" ? "" : formData.clientSecret,
       };
     }
   }

--- a/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/HydrantForm/HydrantForm.tests.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/HydrantForm/HydrantForm.tests.tsx
@@ -1,0 +1,66 @@
+import React from "react";
+import { noop } from "lodash";
+import { render, screen } from "@testing-library/react";
+import { renderWithSetup } from "test/test-utils";
+
+import HydrantForm, { IHydrantFormData } from "./HydrantForm";
+
+const createTestFormData = (overrides?: Partial<IHydrantFormData>) => ({
+  name: "TEST_NAME",
+  url: "https://test.com",
+  clientId: "123",
+  clientSecret: "test secret",
+  ...overrides,
+});
+
+describe("HydrantForm", () => {
+  it("render the custom button text", () => {
+    render(
+      <HydrantForm
+        formData={createTestFormData()}
+        isSubmitting={false}
+        submitBtnText="Submit"
+        onChange={noop}
+        onSubmit={noop}
+        onCancel={noop}
+      />
+    );
+
+    expect(screen.getByRole("button", { name: "Submit" })).toBeVisible();
+  });
+
+  it("enables and disables form submission depending on the form validation", async () => {
+    const { user } = renderWithSetup(
+      <HydrantForm
+        formData={createTestFormData()}
+        isSubmitting={false}
+        submitBtnText="Submit"
+        onChange={noop}
+        onSubmit={noop}
+        onCancel={noop}
+      />
+    );
+
+    // data is valid, submit should be enabled
+    expect(screen.getByRole("button", { name: "Submit" })).toBeEnabled();
+
+    // name input is invalidated, submit should be disabled
+    await user.clear(screen.getByLabelText("Name"));
+    expect(screen.getByRole("button", { name: "Submit" })).toBeDisabled();
+  });
+
+  it("disables submit when isSubmitting is set to true", () => {
+    render(
+      <HydrantForm
+        formData={createTestFormData()}
+        isSubmitting
+        submitBtnText="Submit"
+        onChange={noop}
+        onSubmit={noop}
+        onCancel={noop}
+      />
+    );
+
+    expect(screen.getByRole("button", { name: "Submit" })).toBeDisabled();
+  });
+});

--- a/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/HydrantForm/HydrantForm.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/HydrantForm/HydrantForm.tsx
@@ -1,0 +1,137 @@
+import React, { useContext, useMemo, useState } from "react";
+
+import { AppContext } from "context/app";
+
+// @ts-ignore
+import InputField from "components/forms/fields/InputField";
+import Button from "components/buttons/Button";
+import TooltipWrapper from "components/TooltipWrapper";
+import {
+  validateFormData,
+  IHydrantFormValidation,
+  generateFormValidations,
+} from "./helpers";
+
+const baseClass = "hydrant-form";
+
+export interface IHydrantFormData {
+  name: string;
+  url: string;
+  clientId: string;
+  clientSecret: string;
+}
+
+interface IHydrantFormProps {
+  formData: IHydrantFormData;
+  submitBtnText: string;
+  isSubmitting: boolean;
+  isEditing?: boolean;
+  onChange: (update: { name: string; value: string }) => void;
+  onSubmit: () => void;
+  onCancel: () => void;
+}
+
+const HydrantForm = ({
+  formData,
+  submitBtnText,
+  isSubmitting,
+  isEditing = false,
+  onChange,
+  onSubmit,
+  onCancel,
+}: IHydrantFormProps) => {
+  const { config } = useContext(AppContext);
+  const validations = useMemo(
+    () =>
+      // @ts-ignore
+      // ignore for now as this will be changing with the API update PR
+      generateFormValidations(config?.integrations.digicert ?? [], isEditing),
+    [config?.integrations.digicert, isEditing]
+  );
+
+  const [formValidation, setFormValidation] = useState<IHydrantFormValidation>(
+    () => validateFormData(formData, validations)
+  );
+
+  const { name, url, clientId, clientSecret } = formData;
+
+  const onSubmitForm = (evt: React.FormEvent<HTMLFormElement>) => {
+    evt.preventDefault();
+    onSubmit();
+  };
+
+  const onInputChange = (update: { name: string; value: string }) => {
+    setFormValidation(
+      validateFormData(
+        { ...formData, [update.name]: update.value },
+        validations
+      )
+    );
+    onChange(update);
+  };
+
+  return (
+    <form className={baseClass} onSubmit={onSubmitForm}>
+      <div className={`${baseClass}__fields`}>
+        <InputField
+          name="name"
+          label="Name"
+          value={name}
+          onChange={onInputChange}
+          error={formValidation.name?.message}
+          helpText="Letters, numbers, and underscores only. Fleet will create configuration profile variables with the name as suffix (e.g. $FLEET_VAR_HYDRANT_DATA_WIFI_CERTIFICATE)."
+          parseTarget
+          placeholder="WIFI_CERTIFICATE"
+        />
+        <InputField
+          name="url"
+          label="URL"
+          value={url}
+          onChange={onInputChange}
+          error={formValidation.url?.message}
+          parseTarget
+          helpText="EST endpoint provided by Hydrant."
+          placeholder="https://example.hydrantid.com/.well-known/est/abc123"
+        />
+        <InputField
+          name="clientId"
+          label="Client ID"
+          value={clientId}
+          onChange={onInputChange}
+          parseTarget
+          helpText="Client ID provided by Hydrant."
+        />
+        <InputField
+          name="clientSecret"
+          label="Client secret"
+          value={clientSecret}
+          onChange={onInputChange}
+          parseTarget
+          helpText="Client secret provided by Hydrant."
+        />
+      </div>
+      <div className={`${baseClass}__cta`}>
+        <TooltipWrapper
+          tipContent="Complete all required fields to save."
+          underline={false}
+          position="top"
+          disableTooltip={formValidation.isValid}
+          showArrow
+        >
+          <Button
+            isLoading={isSubmitting}
+            disabled={!formValidation.isValid || isSubmitting}
+            type="submit"
+          >
+            {submitBtnText}
+          </Button>
+        </TooltipWrapper>
+        <Button variant="inverse" onClick={onCancel}>
+          Cancel
+        </Button>
+      </div>
+    </form>
+  );
+};
+
+export default HydrantForm;

--- a/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/HydrantForm/_styles.scss
+++ b/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/HydrantForm/_styles.scss
@@ -1,0 +1,13 @@
+.hydrant-form {
+  &__fields {
+    display: flex;
+    flex-direction: column;
+    gap: $pad-large;
+  }
+
+  &__cta {
+    display: flex;
+    flex-direction: row-reverse;
+    gap: $pad-medium;
+  }
+}

--- a/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/HydrantForm/helpers.ts
+++ b/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/HydrantForm/helpers.ts
@@ -1,0 +1,149 @@
+import { ICertificatesIntegrationHydrant } from "interfaces/integration";
+
+import valid_url from "components/forms/validators/valid_url";
+
+import { IHydrantFormData } from "./HydrantForm";
+
+// TODO: create a validator abstraction for this and the other form validation files
+
+export interface IHydrantFormValidation {
+  isValid: boolean;
+  name?: { isValid: boolean; message?: string };
+  url?: { isValid: boolean; message?: string };
+  clientId?: {
+    isValid: boolean;
+    message?: string;
+  };
+  clientSecret?: { isValid: boolean; message?: string };
+}
+
+type IMessageFunc = (formData: IHydrantFormData) => string;
+type IValidationMessage = string | IMessageFunc;
+type IFormValidationKey = keyof Omit<IHydrantFormData, "isValid">;
+
+interface IValidation {
+  name: string;
+  isValid: (formData: IHydrantFormData) => boolean;
+  message?: IValidationMessage;
+}
+
+type IFormValidations = Record<
+  IFormValidationKey,
+  { validations: IValidation[] }
+>;
+
+export const generateFormValidations = (
+  hydrantIntegrations: ICertificatesIntegrationHydrant[],
+  isEditing: boolean
+) => {
+  const FORM_VALIDATIONS: IFormValidations = {
+    name: {
+      validations: [
+        {
+          name: "required",
+          isValid: (formData: IHydrantFormData) => {
+            return formData.name.length > 0;
+          },
+        },
+        {
+          name: "invalidCharacters",
+          isValid: (formData: IHydrantFormData) => {
+            return /^[a-zA-Z0-9_]+$/.test(formData.name);
+          },
+          message:
+            "Invalid characters. Only letters, numbers and underscores allowed.",
+        },
+        {
+          name: "unique",
+          isValid: (formData: IHydrantFormData) => {
+            return (
+              isEditing ||
+              hydrantIntegrations.find(
+                (cert) => cert.name === formData.name
+              ) === undefined
+            );
+          },
+          message: "Name is already used by another Hydrant CA.",
+        },
+      ],
+    },
+    url: {
+      validations: [
+        {
+          name: "required",
+          isValid: (formData: IHydrantFormData) => {
+            return formData.url.length > 0;
+          },
+        },
+        {
+          name: "validUrl",
+          isValid: (formData: IHydrantFormData) => {
+            return valid_url({ url: formData.url });
+          },
+          message: "Must be a valid URL.",
+        },
+      ],
+    },
+    clientId: {
+      validations: [
+        {
+          name: "required",
+          isValid: (formData: IHydrantFormData) => {
+            return formData.clientId.length > 0;
+          },
+        },
+      ],
+    },
+    clientSecret: {
+      validations: [
+        {
+          name: "required",
+          isValid: (formData: IHydrantFormData) => {
+            return formData.clientSecret.length > 0;
+          },
+        },
+      ],
+    },
+  };
+  return FORM_VALIDATIONS;
+};
+
+const getErrorMessage = (
+  formData: IHydrantFormData,
+  message?: IValidationMessage
+) => {
+  if (message === undefined || typeof message === "string") {
+    return message;
+  }
+  return message(formData);
+};
+
+export const validateFormData = (
+  formData: IHydrantFormData,
+  validationConfig: IFormValidations
+) => {
+  const formValidation: IHydrantFormValidation = {
+    isValid: true,
+  };
+
+  Object.keys(validationConfig).forEach((key) => {
+    const objKey = key as keyof typeof validationConfig;
+    const failedValidation = validationConfig[objKey].validations.find(
+      (validation) => !validation.isValid(formData)
+    );
+
+    if (!failedValidation) {
+      formValidation[objKey] = {
+        isValid: true,
+      };
+    } else {
+      formValidation.isValid = false;
+      formValidation[objKey] = {
+        isValid: false,
+        message: getErrorMessage(formData, failedValidation.message),
+      };
+    }
+  });
+
+  return formValidation;
+};

--- a/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/HydrantForm/index.ts
+++ b/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/HydrantForm/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./HydrantForm";


### PR DESCRIPTION
relates to #29426, #29427

adding in UI for add and edit hydrant CA form. This adds these to
AddCertAuthorityModal and EditCertAuthority

This does not include the API bit which will be a separate PR as it
changes all certificates integration with the APIs.

<img width="821" height="728" alt="image"
src="https://github.com/user-attachments/assets/bf40425c-ceb9-45b9-a7b4-8f6ce28efec4"
/>
