### PR TITLE
Fleet UI: Prevent scroll modal bug

### DIFF
--- a/frontend/pages/policies/ManagePoliciesPage/components/InstallSoftwareModal/_styles.scss
+++ b/frontend/pages/policies/ManagePoliciesPage/components/InstallSoftwareModal/_styles.scss
@@ -10,7 +10,7 @@
         overflow: visible;
       }
       .Select-menu-outer {
-        max-height: 240px;
+        max-height: 165px; // Prevent scrolling off modal
         overflow-y: auto;
       }
     }

--- a/frontend/pages/policies/ManagePoliciesPage/components/PolicyRunScriptModal/_styles.scss
+++ b/frontend/pages/policies/ManagePoliciesPage/components/PolicyRunScriptModal/_styles.scss
@@ -2,23 +2,28 @@
   .policy-run-script-modal {
     .form-field--dropdown {
       width: 276px;
+
       .Select-placeholder {
         color: $ui-fleet-black-50;
       }
+
       .Select-menu {
         max-height: none;
         overflow: visible;
       }
+
       .Select-menu-outer {
-        max-height: 240px;
+        max-height: 165px; // Prevent scrolling off modal
         overflow-y: auto;
       }
     }
+
     .paginated-list__row {
       height: 40px;
       padding-top: 4px;
       padding-bottom: 4px;
     }
+
     &__no-scripts {
       display: flex;
       height: 178px;
@@ -31,11 +36,13 @@
       div {
         color: $ui-fleet-black-75;
         font-size: $xx-small;
+
         a {
           font-size: inherit;
         }
       }
     }
+
     .data-error {
       padding: 78px;
     }


### PR DESCRIPTION
## Issue
Closes #30004

## Description
- Make dropdown shorter so it doesn't scroll off modal in 2 modals

## Screenrecording of 2 fixes

Only after recorded

https://github.com/user-attachments/assets/ddace042-54c0-4507-92fb-6068437e1ce3


Before and after recorded

https://github.com/user-attachments/assets/254a93c4-b5f4-405c-885b-4577eeed67b6



- [x] QA'd all new/changed functionality manually
