### PR TITLE
[API design] Add Hydrant certificate authority (CA) and request certificate API

### DIFF
--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -842,7 +842,7 @@ Requests a base64 encoded certificate (`.pem`). Currently, this endpoint is only
 | Name     | Type    | In   | Description                                 |
 | -------- | ------- | ---- | ------------------------------------------- |
 | id   | string | path | **Required.** The certificate authority (CA) ID in Fleet. You can see your CAs IDs using the [List certificate authorities endpoint](#list-certificate-authorities-cas). |
-| csr       | string | body | The signed certificate signing request (CSR). If left unspecified, Fleet will create the CSR with a shared key.        |
+| csr       | string | body | **Required.** The signed certificate signing request (CSR). |
 | idp_oauth_url | string | body | OAuth URL from your identity provier (IdP). Required if `idp_token` is specified. |
 | idp_token | string | body | Active session token from your identity provider (IdP). Required if `idp_oauth_url` is specified.|
 


### PR DESCRIPTION
Follow up to the API design PR here: https://github.com/fleetdm/fleet/pull/30930

For the following user story:
- https://github.com/fleetdm/fleet/issues/28974

- @noahtalerman: For future iterations in which we want the IT admin to just get a certificate w/o generating a CSR, Fleet will need to know what the certificate (and what the CSR) should look like: Common Name, etc. 
  - Deciding to make the CSR field required in this iteration. Remove the requirement in a follow up iteration.
