### PR TITLE
Touch software updated at timestamp if software inventory causes a no-op

### DIFF
--- a/changes/31721-noop-touches-sw-updated-timestamp
+++ b/changes/31721-noop-touches-sw-updated-timestamp
@@ -1,0 +1,1 @@
+* Fixed a bug where a host's software_updated_at timestamp wouldn't be bumped if a successful refetch detected no software changes

--- a/server/datastore/mysql/software.go
+++ b/server/datastore/mysql/software.go
@@ -364,7 +364,10 @@ func (ds *Datastore) applyChangesForNewSoftwareDB(
 
 	current, incoming, notChanged := nothingChanged(currentSoftware, software, ds.minLastOpenedAtDiff)
 	if notChanged {
-		return r, nil
+		// still touch software last updated timestamp; caveat here is that we'll show a no-op if last-opened-at diff
+		// is less than a specified amount (see defaultMinLastOpenedAtDiff) on all inventoried software and there are
+		// no other changes
+		return r, updateSoftwareUpdatedAt(ctx, ds.writer(ctx), hostID)
 	}
 
 	existingSoftware, incomingByChecksum, existingTitlesForNewSoftware, existingBundleIDsToUpdate, err := ds.getExistingSoftware(ctx, current, incoming)


### PR DESCRIPTION
For #31721. Unsure if this is the right fix because we no-op when last opened time hasn't changed by more than (by default) an hour, and touching the timestamp would remove any sign that data is potentially stale.

Alternate solution of "have the frontend use the details updated timestamp" doesn't feel great either though.

Also found a likely more straightforward repro of #28584 while writing tests for this, or at least what feels like a more straightforward repro of that bug, but fixing that bug is out of scope for fixing this one.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)

## Testing

- [x] Added/updated automated tests

- [ ] QA'd all new/changed functionality manually