### PR TITLE
When iterating through softwares LastOpenedAt timestamp is copied as to not modify original records

### DIFF
--- a/changes/31932-last-opened-at
+++ b/changes/31932-last-opened-at
@@ -1,0 +1,1 @@
+* When multiple version of a software are installed the last used timestamp for each version is properly returned in the host inventory

--- a/server/datastore/mysql/software.go
+++ b/server/datastore/mysql/software.go
@@ -3238,10 +3238,10 @@ func (ds *Datastore) ListHostSoftware(ctx context.Context, host *fleet.Host, opt
 	if err != nil {
 		return nil, nil, err
 	}
-	for _, origS := range hostInstalledSoftware {
-		s := *origS
-		if origS.LastOpenedAt != nil {
-			timeCopy := *origS.LastOpenedAt
+	for _, pointerToSoftware := range hostInstalledSoftware {
+		s := *pointerToSoftware
+		if pointerToSoftware.LastOpenedAt != nil {
+			timeCopy := *pointerToSoftware.LastOpenedAt
 			s.LastOpenedAt = &timeCopy
 		}
 
@@ -3264,8 +3264,8 @@ func (ds *Datastore) ListHostSoftware(ctx context.Context, host *fleet.Host, opt
 
 		hostInstalledSoftwareTitleSet[s.ID] = struct{}{}
 		if s.SoftwareID != nil {
-			bySoftwareID[*s.SoftwareID] = origS
-			hostInstalledSoftwareSet[*s.SoftwareID] = origS
+			bySoftwareID[*s.SoftwareID] = pointerToSoftware
+			hostInstalledSoftwareSet[*s.SoftwareID] = pointerToSoftware
 		}
 	}
 


### PR DESCRIPTION
fixes #31932

The problem here was that `hostInstalledSoftware` returns a slice of pointers (`[]*hostSoftware`), so when iterating through and assigning `LastOpenedAt` the original records were getting modified. This code duplicates the records being put into `bySoftwareTitleID` so that the records being stored in `bySoftwareID` are the original records. 

As a side benefit to this I modified the logic to store the most recent `LastOpenedAt` for the software title. I think we may be doing something similar to this on the front end to show the "last used" column when we have multiple version of a software installed. But this can potentially be fetched from the API now.

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [X] Added/updated automated tests
- [X] QA'd all new/changed functionality manually