### PR TITLE
[Docs] Remove hydrant certificate data fleet variable

### DIFF
--- a/docs/Configuration/yaml-files.md
+++ b/docs/Configuration/yaml-files.md
@@ -396,7 +396,6 @@ In Fleet Premium, you can use reserved variables beginning with `$FLEET_VAR_` (c
 - `$FLEET_VAR_CUSTOM_SCEP_PROXY_URL_<CA_NAME>`
 - `$FLEET_VAR_DIGICERT_PASSWORD_<CA_NAME>` (`<CA_NAME>` should be replaced with name of the certificate authority configured in [digicert](#digicert).)
 - `$FLEET_VAR_DIGICERT_DATA_<CA_NAME>`
-- `$FLEET_VAR_HYDRANT_DATA_<CA_NAME>` (`<CA_NAME>` should be replaced with name of the certificate authority configured in [hydrant](#hydrant).)
 
 The dollar sign (`$`) can be escaped so it's not considered a variable by using a backslash (e.g. `\$100`). Additionally, `MY${variable}HERE` syntax can be used to put strings around the variable.
 


### PR DESCRIPTION
As discussed in MDM standup: https://us-65885.app.gong.io/call?id=747420323001114250&highlights=%5B%7B%22type%22%3A%22SHARE%22%2C%22from%22%3A897%2C%22to%22%3A1240%7D%5D

We decided to remove the fleet variable support for hydrant certificate data, as we won't craft certificates for hosts, but rather get a CSR when requested, so this will come down the line.