### PR TITLE
[Docs update] Enroll/unenroll hosts

### DIFF
--- a/articles/enroll-hosts.md
+++ b/articles/enroll-hosts.md
@@ -135,19 +135,17 @@ In the Google Admin console:
 
 ### Unenroll
 
-How to unenroll a host from Fleet:
+You can unenroll a macOS, Windows, or Linux host from Fleet (iOS, iPadOS, and Android hosts coming soon).
 
 1. Determine if your host has MDM features turned on by looking at the **MDM status** on the host's **Host details** page. 
 
 2. For macOS hosts with MDM turned on, select **Actions > Turn off MDM** to turn MDM off. For Windows hosts with MDM turned on, follow the [instructions for turning off MDM](https://fleetdm.com/guides/windows-mdm-setup#turn-off-windows-mdm). For iOS, iPadOS hosts with MDM turned on, select **Actions > Turn off MDM**.
 
-4. For macOS, Windows, and Linux hosts [uninstall fleetd](https://fleetdm.com/guides/how-to-uninstall-fleetd).
+4. For macOS, Windows, and Linux hosts [uninstall fleetd](https://fleetdm.com/guides/how-to-uninstall-fleetd). 
 
-6. Select **Actions > Delete** to delete the host from Fleet.
+5. Select **Actions > Delete** to delete the host from Fleet.
 
 > If an end user wants to switch their workstation's operating system (e.g. Windows to Linux), before they switch, delete the host from Fleet. Then, re-enroll the host.
-
-> Unenroll feature for personal (BYOD) iOS, iPadOS, and Android hosts is coming soon. For more information see [#26010](https://github.com/fleetdm/fleet/issues/26010) and [#31584](https://github.com/fleetdm/fleet/issues/31584).
 
 ## Advanced
 

--- a/articles/enroll-hosts.md
+++ b/articles/enroll-hosts.md
@@ -2,7 +2,15 @@
 
 Fleet gathers information from an [osquery](https://github.com/osquery/osquery) agent installed on each of your hosts. The recommended way to install osquery is using fleetd.
 
-You can enroll macOS, Windows or Linux hosts via the [CLI](#cli) or [UI](#ui). To learn how to enroll Chromebooks, see [Enroll Chromebooks](#enroll-chromebooks).
+Fleet creates a host record when a device is enrolled. Note that “enrolled” and “MDM turned on” are not always the same action.
+
+- For macOS, Windows, and Linux: installing Fleet’s agent (fleetd) creates the host record in Fleet (enrollment). Turning on MDM is a separate step that can be performed after fleetd is installed.
+ - For iOS, iPadOS, and Android: hosts enroll into Fleet through the MDM enrollment. In other words, enrollment and enabling MDM happen at the same time — when the host is enrolled into MDM, the host record is created in Fleet, and MDM is turned on.
+
+
+You can enroll macOS, Windows, and Linux hosts via the [CLI](#cli) or [UI](#ui). You can enroll iOS, iPadOS, and Android hostsvia the [UI](#ui).
+
+To learn how to enroll Chromebooks, see [Enroll Chromebooks](#enroll-chromebooks).
 
 ### Supported osquery versions
 
@@ -41,21 +49,28 @@ Tip: To see all options for `fleetctl package` command, run `fleetctl package -h
 
 ## UI
 
-To generate Fleet's agent (fleetd) in Fleet UI:
+To enroll macOS, Windows, or Linux hosts, generate Fleet's agent (fleetd) through Fleet UI:
 
-1. Go to the **Hosts** page, and select **Add hosts**.
+1. Go to the **Hosts** page, select team, and select **Add hosts**.
 2. Select the tab for your desired platform (e.g. macOS).
 3. A CLI command with all necessary flags to generate an install package will be generated. Copy and run the command with [fleetctl](https://fleetdm.com/docs/using-fleet/fleetctl-cli) installed.
 
+To enroll iOS, iPadOS, or Android hosts, send link to the end user, following the steps below:
+
+1. Go to the **Hosts** page, select team, and select **Add hosts**.
+2. Select the tab for your desired platform (e.g. iOS).
+3. Copy the link from the UI and share it with your end user.
+4. Once they visit the link and follow the steps provided on the enrollment web page, their host will get enrolled.
+
 ### Install fleetd
 
-You can use your tool of choice, like [Munki](https://www.munki.org/munki/) on macOS or a package manager ([APT](https://en.wikipedia.org/wiki/APT_(software)) or [DNF](https://en.wikipedia.org/wiki/DNF_(software))) on Linux, to install fleetd. 
+You can use your tool of choice, like [Munki](https://www.munki.org/munki/) on macOS or a package manager ([APT](https://en.wikipedia.org/wiki/APT_(software)) or [DNF](https://en.wikipedia.org/wiki/DNF_(software))) on Linux, to install fleetd.
 
 ### Enroll hosts to a team
 
 With hosts segmented into teams, you can apply unique queries and give users access to only the hosts in specific teams. [Learn more about teams](https://fleetdm.com/docs/using-fleet/segment-hosts).
 
-To enroll to a specific team: from the **Hosts** page, select the desired team from the menu at the top of the screen, then follow the instructions above for generating Fleet's agent (fleetd). The team's enroll secret will be included in the generated command.
+To enroll to a specific team: from the **Hosts** page, select the desired team from the menu at the top of the screen, then follow the instructions above for generating Fleet's agent (fleetd). The team's enrollment secret will be included in the generated command or on the enrollment web page for iOS, iPadOS, and Android hosts.
 
 ### Fleet Desktop
 
@@ -129,13 +144,15 @@ How to unenroll a host from Fleet:
 
 1. Determine if your host has MDM features turned on by looking at the **MDM status** on the host's **Host details** page. 
 
-2. For macOS hosts with MDM turned on, select **Actions > Turn off MDM** to turn MDM off. Instructions for turning off MDM on Windows hosts coming soon.
+2. For macOS hosts with MDM turned on, select **Actions > Turn off MDM** to turn MDM off. For Windows hosts with MDM turned on, follow the [instructions for turning off MDM](https://fleetdm.com/guides/windows-mdm-setup#turn-off-windows-mdm). For iOS, iPadOS hosts with MDM turned on, select **Actions > Turn off MDM**.
 
-3. Determine the platform of the host you're trying to unenroll, then follow the [uninstall instructions](https://fleetdm.com/guides/how-to-uninstall-fleetd) for that platform.
+4. For macOS, Windows, and Linux hosts [uninstall fleetd](https://fleetdm.com/guides/how-to-uninstall-fleetd).
 
-4. Select **Actions > Delete** to delete the host from Fleet.
+6. Select **Actions > Delete** to delete the host from Fleet.
 
 > If an end user wants to switch their workstation's operating system (e.g. Windows to Linux), before they switch, delete the host from Fleet. Then, re-enroll the host.
+
+> Unenroll feature for personal (BYOD) iOS, iPadOS, and Android hosts is coming soon. For more information see [#26010](https://github.com/fleetdm/fleet/issues/26010) and [#31584](https://github.com/fleetdm/fleet/issues/31584).
 
 ## Advanced
 

--- a/articles/enroll-hosts.md
+++ b/articles/enroll-hosts.md
@@ -5,8 +5,7 @@ Fleet gathers information from an [osquery](https://github.com/osquery/osquery) 
 Fleet creates a host record when a device is enrolled. Note that “enrolled” and “MDM turned on” are not always the same action.
 
 - For macOS, Windows, and Linux: installing Fleet’s agent (fleetd) creates the host record in Fleet (enrollment). Turning on MDM is a separate step that can be performed after fleetd is installed.
- - For iOS, iPadOS, and Android: hosts enroll into Fleet through the MDM enrollment. In other words, enrollment and enabling MDM happen at the same time — when the host is enrolled into MDM, the host record is created in Fleet, and MDM is turned on.
-
+- For iOS, iPadOS, and Android: hosts enroll into Fleet through the MDM enrollment. In other words, enrollment and enabling MDM happen at the same time — when the host is enrolled into MDM, the host record is created in Fleet, and MDM is turned on.
 
 You can enroll macOS, Windows, and Linux hosts via the [CLI](#cli) or [UI](#ui). You can enroll iOS, iPadOS, and Android hostsvia the [UI](#ui).
 

--- a/articles/enroll-hosts.md
+++ b/articles/enroll-hosts.md
@@ -1,19 +1,30 @@
 # Enroll hosts
 
-Fleet gathers information from an [osquery](https://github.com/osquery/osquery) agent installed on each of your hosts. The recommended way to install osquery is using fleetd.
+You can enroll macOS, Windows, Linux, iOS, iPadOS, Android, and ChromeOS hosts to Fleet.
 
-Fleet creates a host record when a device is enrolled. Note that “enrolled” and “MDM turned on” are not always the same action.
+To manually enroll macOS, Windows, and Linux hosts, install Fleet’s agent (fleetd). You can generate fleetd via the [UI](#ui) or [CLI](#cli). 
 
-- For macOS, Windows, and Linux: installing Fleet’s agent (fleetd) creates the host record in Fleet (enrollment). Turning on MDM is a separate step that can be performed after fleetd is installed.
-- For iOS, iPadOS, and Android: hosts enroll into Fleet through the MDM enrollment. In other words, enrollment and enabling MDM happen at the same time — when the host is enrolled into MDM, the host record is created in Fleet, and MDM is turned on.
+For iOS, iPadOS, and Android hosts, share the enrollment link from the [Fleet UI](#ui) with your end users.
 
-You can enroll macOS, Windows, and Linux hosts via the [CLI](#cli) or [UI](#ui). You can enroll iOS, iPadOS, and Android hostsvia the [UI](#ui).
+You can also automatically enroll macOS, Windows, iOS, and iPadOS hosts. To automatically enroll Apple (macOS, iOS, and iPadOS) hosts, [connect Fleet to Apple Business Manager (ABM)](https://fleetdm.com/guides/macos-mdm-setup#apple-business-manager-abm). To automatically enroll Windows hosts, [connect Fleet to Microsoft Entra](https://fleetdm.com/guides/windows-mdm-setup#automatic-enrollment).
 
-To learn how to enroll Chromebooks, see [Enroll Chromebooks](#enroll-chromebooks).
+To learn how to enroll Chromebooks, see the [Enroll Chromebooks guide](#enroll-chromebooks).
 
-### Supported osquery versions
+## UI
 
-Fleet supports the [latest version of osquery](https://github.com/osquery/osquery/tags). 
+To manually enroll macOS, Windows, or Linux hosts, generate Fleet's agent (fleetd) through Fleet UI:
+
+1. Go to the **Hosts** page, select the team you want your host(s) to enroll to, and select **Add hosts**.
+2. Select the tab for your desired platform (e.g. **macOS**).
+3. Copy the command to generate fleetd and run the command with [fleetctl](https://fleetdm.com/docs/using-fleet/fleetctl-cli) installed.
+4. Install fleetd on your host(s) to enroll it to Fleet.
+
+To manually enroll iOS, iPadOS, or Android hosts, follow the steps below:
+
+1. Go to the **Hosts** page, select the team you want your host(s) to enroll to, and select **Add hosts**.
+2. Select the tab for your desired platform (e.g. **iOS**).
+3. Copy the enrollment link from the UI and share it with your end users.
+4. When your end users visit the link and follow the steps provided on the enrollment page, their host will be enrolled.
 
 ## CLI
 
@@ -45,21 +56,6 @@ fleetctl package --type pkg --fleet-url=example.fleetinstance.com --enroll-secre
 ```
 
 Tip: To see all options for `fleetctl package` command, run `fleetctl package -h` in your Terminal.
-
-## UI
-
-To enroll macOS, Windows, or Linux hosts, generate Fleet's agent (fleetd) through Fleet UI:
-
-1. Go to the **Hosts** page, select team, and select **Add hosts**.
-2. Select the tab for your desired platform (e.g. macOS).
-3. A CLI command with all necessary flags to generate an install package will be generated. Copy and run the command with [fleetctl](https://fleetdm.com/docs/using-fleet/fleetctl-cli) installed.
-
-To enroll iOS, iPadOS, or Android hosts, send link to the end user, following the steps below:
-
-1. Go to the **Hosts** page, select team, and select **Add hosts**.
-2. Select the tab for your desired platform (e.g. iOS).
-3. Copy the link from the UI and share it with your end user.
-4. Once they visit the link and follow the steps provided on the enrollment web page, their host will get enrolled.
 
 ### Install fleetd
 
@@ -155,6 +151,7 @@ How to unenroll a host from Fleet:
 
 ## Advanced
 
+- [Supported osquery versions](#supported-osquery-versions)
 - [Best practice for dual-boot workstations](#best-partice-for-dual-boot-workstations)
 - [Fleet agent (fleetd) components](#fleetd-components)
 - [Signing fleetd](#signing-fleetd)
@@ -168,6 +165,10 @@ How to unenroll a host from Fleet:
 - [Generating fleetd for Windows using local WiX toolset](#generating-fleetd-for-windows-using-local-wix-toolset)
 - [Config-less fleetd agent deployment](#config-less-fleetd-agent-deployment)
 - [Experimental features](#experimental-features)
+
+### Supported osquery versions
+
+Fleet supports the [latest version of osquery](https://github.com/osquery/osquery/tags). 
 
 ### Best practice for dual-boot workstations
 

--- a/articles/enroll-hosts.md
+++ b/articles/enroll-hosts.md
@@ -43,7 +43,7 @@ The `--type` flag is used to specify the fleetd installer type.
 
 > `fleetctl` on Windows can only generate MSI packages.
 
-A `--fleet-url` (Fleet instance URL) and `--enroll-secret` (Fleet enrollment secret) must be specified in order to communicate with Fleet instance.
+A `--fleet-url` (Fleet instance URL) and `--enroll-secret` (Fleet enroll secret) must be specified in order to communicate with Fleet instance.
 
 To generate fleetd for an Arm Linux or Windows host, use the `--arch=arm64` flag.
 
@@ -65,7 +65,7 @@ You can use your tool of choice, like [Munki](https://www.munki.org/munki/) on m
 
 With hosts segmented into teams, you can apply unique queries and give users access to only the hosts in specific teams. [Learn more about teams](https://fleetdm.com/docs/using-fleet/segment-hosts).
 
-To enroll to a specific team: from the **Hosts** page, select the desired team from the menu at the top of the screen, then follow the instructions above for generating Fleet's agent (fleetd). The team's enrollment secret will be included in the generated command or on the enrollment web page for iOS, iPadOS, and Android hosts.
+To enroll to a specific team: from the **Hosts** page, select the desired team from the menu at the top of the screen, then follow the instructions above for generating Fleet's agent (fleetd). The team's enroll secret will be included in the generated command or on the enrollment page for iOS, iPadOS, and Android hosts.
 
 ### Fleet Desktop
 
@@ -203,7 +203,7 @@ The `fleetctl package` command supports signing and notarizing macOS fleetd via 
 Check out the example below:
 
 ```sh
-  AC_USERNAME=appleid@example.com AC_PASSWORD=app-specific-password fleetctl package --type pkg --sign-identity=[PATH TO SIGN IDENTITY] --notarize --fleet-url=[YOUR FLEET URL] --enroll-secret=[YOUR ENROLLMENT SECRET]
+  AC_USERNAME=appleid@example.com AC_PASSWORD=app-specific-password fleetctl package --type pkg --sign-identity=[PATH TO SIGN IDENTITY] --notarize --fleet-url=[YOUR FLEET URL] --enroll-secret=[YOUR ENROLL SECRET]
 ```
 
 The above command must be run on a macOS device, as the notarizing and signing of macOS fleetd can only be done on macOS devices.
@@ -423,7 +423,7 @@ so:
   3. Run `fleetctl package`, and pass the absolute path above as the string argument to the
      `--local-wix-dir` flag. For example:
      ```
-      fleetctl package --type msi --fleet-url=[YOUR FLEET URL] --enroll-secret=[YOUR ENROLLMENT SECRET] --local-wix-dir "\Users\me\AppData\Local\Temp\wix311-binaries"
+      fleetctl package --type msi --fleet-url=[YOUR FLEET URL] --enroll-secret=[YOUR ENROLL SECRET] --local-wix-dir "\Users\me\AppData\Local\Temp\wix311-binaries"
      ```
      If the provided path doesn't contain all 3 binaries, the command will fail.
 
@@ -431,7 +431,7 @@ so:
 
 ### Config-less fleetd agent deployment
 
-Config-less deployment allows for Fleet's agent (fleetd) to be installed without embedding configuration settings directly into the package. This approach is ideal for environments requiring flexibility in managing enrollment secrets and server URLs. For detailed instructions, visit the [Config-less fleetd agent deployment guide](https://fleetdm.com/guides/config-less-fleetd-agent-deployment).
+Config-less deployment allows for Fleet's agent (fleetd) to be installed without embedding configuration settings directly into the package. This approach is ideal for environments requiring flexibility in managing enroll secrets and server URLs. For detailed instructions, visit the [Config-less fleetd agent deployment guide](https://fleetdm.com/guides/config-less-fleetd-agent-deployment).
 
 >**Warning:** If you remove the configuration profile with the settings from macOS, `fleetd` won't work anymore until a similar profile is installed again. If the profile is delivered via MDM, and MDM is turned off, you might face this scenario.
 


### PR DESCRIPTION
- Simplify top section
- Added explanation on what enroll means for different platforms and how to unenroll different platforms + callout that unenroll feature for personal (BYOD) iOS/iPadOS and Android is coming soon.
- Fleet says "enroll secret"
- Move "Supported osquery version" to "Advanced"