### PR TITLE
Don't pass the default deb auto-install policy if install status is e.g. uninstalled

### DIFF
--- a/changes/29894-fix-deb-auto-install-query
+++ b/changes/29894-fix-deb-auto-install-query
@@ -1,0 +1,1 @@
+* Fixed cases where the default auto-install policy for .deb packages would treat installed-then-uninstalled software as still installed

--- a/pkg/automatic_policy/automatic_policy.go
+++ b/pkg/automatic_policy/automatic_policy.go
@@ -153,7 +153,7 @@ func (m FullInstallerMetadata) PolicyQuery() (string, error) {
 			`SELECT 1 WHERE EXISTS (
 	SELECT 1 WHERE (SELECT COUNT(*) FROM deb_packages) = 0
 ) OR EXISTS (
-	SELECT 1 FROM deb_packages WHERE name = '%s'
+	SELECT 1 FROM deb_packages WHERE name = '%s' AND status = 'install ok installed'
 );`, m.Title,
 		), nil
 	case "rpm":

--- a/pkg/automatic_policy/automatic_policy_test.go
+++ b/pkg/automatic_policy/automatic_policy_test.go
@@ -135,7 +135,7 @@ Software won't be installed on Linux hosts with RPM-based distributions because 
 	require.Equal(t, `SELECT 1 WHERE EXISTS (
 	SELECT 1 WHERE (SELECT COUNT(*) FROM deb_packages) = 0
 ) OR EXISTS (
-	SELECT 1 FROM deb_packages WHERE name = 'Zoobar'
+	SELECT 1 FROM deb_packages WHERE name = 'Zoobar' AND status = 'install ok installed'
 );`, policyData.Query)
 
 	policyData, err = Generate(FullInstallerMetadata{

--- a/server/datastore/mysql/software_installers_test.go
+++ b/server/datastore/mysql/software_installers_test.go
@@ -2477,7 +2477,7 @@ func testMatchOrCreateSoftwareInstallerWithAutomaticPolicies(t *testing.T, ds *D
 	require.Equal(t, `SELECT 1 WHERE EXISTS (
 	SELECT 1 WHERE (SELECT COUNT(*) FROM deb_packages) = 0
 ) OR EXISTS (
-	SELECT 1 FROM deb_packages WHERE name = 'Barfoo'
+	SELECT 1 FROM deb_packages WHERE name = 'Barfoo' AND status = 'install ok installed'
 );`, team2Policies[0].Query)
 	require.Equal(t, `Policy triggers automatic install of Barfoo on each host that's missing this software.
 Software won't be installed on Linux hosts with RPM-based distributions because this policy's query is written to always pass on these hosts.`, team2Policies[0].Description)


### PR DESCRIPTION
Fixes #29894 and probably #31980.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)

## Testing

- [x] Added/updated automated tests

- [x] QA'd all new/changed functionality manually