### PR TITLE
Remove unnecessary and invalid rate limit on Fleet Desktop API calls

### DIFF
--- a/changes/31890-remove-unnecessary-fleet-desktop-rate-limiting
+++ b/changes/31890-remove-unnecessary-fleet-desktop-rate-limiting
@@ -1,0 +1,1 @@
+* Removed unnecessary (and invalid) rate limitting to Fleet Desktop API requests (which was causing issues with hosts behind NATs).

--- a/server/service/handler.go
+++ b/server/service/handler.go
@@ -800,77 +800,32 @@ func attachFleetAPIRoutes(r *mux.Router, svc fleet.Service, config config.FleetC
 	// input to `fleetctl apply`
 	ue.POST("/api/_version_/fleet/mdm/profiles/batch", batchSetMDMProfilesEndpoint, batchSetMDMProfilesRequest{})
 
-	errorLimiter := ratelimit.NewErrorMiddleware(limitStore)
-
 	// device-authenticated endpoints
 	de := newDeviceAuthenticatedEndpointer(svc, logger, opts, r, apiVersions...)
-	// We allow a quota of 720 because in the onboarding of a Fleet Desktop takes a few tries until it authenticates
-	// properly
-	desktopQuota := throttled.RateQuota{MaxRate: throttled.PerHour(720), MaxBurst: desktopRateLimitMaxBurst}
-	de.WithCustomMiddleware(
-		errorLimiter.Limit("get_device_host", desktopQuota, logger),
-	).GET("/api/_version_/fleet/device/{token}", getDeviceHostEndpoint, getDeviceHostRequest{})
-	de.WithCustomMiddleware(
-		errorLimiter.Limit("get_fleet_desktop", desktopQuota, logger),
-	).GET("/api/_version_/fleet/device/{token}/desktop", getFleetDesktopEndpoint, getFleetDesktopRequest{})
-	de.WithCustomMiddleware(
-		errorLimiter.Limit("ping_device_auth", desktopQuota, logger),
-	).HEAD("/api/_version_/fleet/device/{token}/ping", devicePingEndpoint, deviceAuthPingRequest{})
-	de.WithCustomMiddleware(
-		errorLimiter.Limit("refetch_device_host", desktopQuota, logger),
-	).POST("/api/_version_/fleet/device/{token}/refetch", refetchDeviceHostEndpoint, refetchDeviceHostRequest{})
-	de.WithCustomMiddleware(
-		errorLimiter.Limit("get_device_mapping", desktopQuota, logger),
-	).GET("/api/_version_/fleet/device/{token}/device_mapping", listDeviceHostDeviceMappingEndpoint, listDeviceHostDeviceMappingRequest{})
-	de.WithCustomMiddleware(
-		errorLimiter.Limit("get_device_macadmins", desktopQuota, logger),
-	).GET("/api/_version_/fleet/device/{token}/macadmins", getDeviceMacadminsDataEndpoint, getDeviceMacadminsDataRequest{})
-	de.WithCustomMiddleware(
-		errorLimiter.Limit("get_device_policies", desktopQuota, logger),
-	).GET("/api/_version_/fleet/device/{token}/policies", listDevicePoliciesEndpoint, listDevicePoliciesRequest{})
-	de.WithCustomMiddleware(
-		errorLimiter.Limit("get_device_transparency", desktopQuota, logger),
-	).GET("/api/_version_/fleet/device/{token}/transparency", transparencyURL, transparencyURLRequest{})
-	de.WithCustomMiddleware(
-		errorLimiter.Limit("send_device_error", desktopQuota, logger),
-	).POST("/api/_version_/fleet/device/{token}/debug/errors", fleetdError, fleetdErrorRequest{})
-	de.WithCustomMiddleware(
-		errorLimiter.Limit("get_device_software", desktopQuota, logger),
-	).GET("/api/_version_/fleet/device/{token}/software", getDeviceSoftwareEndpoint, getDeviceSoftwareRequest{})
-	de.WithCustomMiddleware(
-		errorLimiter.Limit("install_self_service", desktopQuota, logger),
-	).POST("/api/_version_/fleet/device/{token}/software/install/{software_title_id}", submitSelfServiceSoftwareInstall, fleetSelfServiceSoftwareInstallRequest{})
-	de.WithCustomMiddleware(
-		errorLimiter.Limit("uninstall_self_service", desktopQuota, logger),
-	).POST("/api/_version_/fleet/device/{token}/software/uninstall/{software_title_id}", submitDeviceSoftwareUninstall, fleetDeviceSoftwareUninstallRequest{})
-	de.WithCustomMiddleware(
-		errorLimiter.Limit("get_device_software_install_results", desktopQuota, logger),
-	).GET("/api/_version_/fleet/device/{token}/software/install/{install_uuid}/results", getDeviceSoftwareInstallResultsEndpoint,
-		getDeviceSoftwareInstallResultsRequest{})
-	de.WithCustomMiddleware(
-		errorLimiter.Limit("get_device_software_uninstall_results", desktopQuota, logger),
-	).GET("/api/_version_/fleet/device/{token}/software/uninstall/{execution_id}/results", getDeviceSoftwareUninstallResultsEndpoint, getDeviceSoftwareUninstallResultsRequest{})
-	de.WithCustomMiddleware(
-		errorLimiter.Limit("get_device_certificates", desktopQuota, logger),
-	).GET("/api/_version_/fleet/device/{token}/certificates", listDeviceCertificatesEndpoint, listDeviceCertificatesRequest{})
+	de.GET("/api/_version_/fleet/device/{token}", getDeviceHostEndpoint, getDeviceHostRequest{})
+	de.GET("/api/_version_/fleet/device/{token}/desktop", getFleetDesktopEndpoint, getFleetDesktopRequest{})
+	de.HEAD("/api/_version_/fleet/device/{token}/ping", devicePingEndpoint, deviceAuthPingRequest{})
+	de.POST("/api/_version_/fleet/device/{token}/refetch", refetchDeviceHostEndpoint, refetchDeviceHostRequest{})
+	de.GET("/api/_version_/fleet/device/{token}/device_mapping", listDeviceHostDeviceMappingEndpoint, listDeviceHostDeviceMappingRequest{})
+	de.GET("/api/_version_/fleet/device/{token}/macadmins", getDeviceMacadminsDataEndpoint, getDeviceMacadminsDataRequest{})
+	de.GET("/api/_version_/fleet/device/{token}/policies", listDevicePoliciesEndpoint, listDevicePoliciesRequest{})
+	de.GET("/api/_version_/fleet/device/{token}/transparency", transparencyURL, transparencyURLRequest{})
+	de.POST("/api/_version_/fleet/device/{token}/debug/errors", fleetdError, fleetdErrorRequest{})
+	de.GET("/api/_version_/fleet/device/{token}/software", getDeviceSoftwareEndpoint, getDeviceSoftwareRequest{})
+	de.POST("/api/_version_/fleet/device/{token}/software/install/{software_title_id}", submitSelfServiceSoftwareInstall, fleetSelfServiceSoftwareInstallRequest{})
+	de.POST("/api/_version_/fleet/device/{token}/software/uninstall/{software_title_id}", submitDeviceSoftwareUninstall, fleetDeviceSoftwareUninstallRequest{})
+	de.GET("/api/_version_/fleet/device/{token}/software/install/{install_uuid}/results", getDeviceSoftwareInstallResultsEndpoint, getDeviceSoftwareInstallResultsRequest{})
+	de.GET("/api/_version_/fleet/device/{token}/software/uninstall/{execution_id}/results", getDeviceSoftwareUninstallResultsEndpoint, getDeviceSoftwareUninstallResultsRequest{})
+	de.GET("/api/_version_/fleet/device/{token}/certificates", listDeviceCertificatesEndpoint, listDeviceCertificatesRequest{})
 
 	// mdm-related endpoints available via device authentication
 	demdm := de.WithCustomMiddleware(mdmConfiguredMiddleware.VerifyAppleMDM())
-	demdm.WithCustomMiddleware(
-		errorLimiter.Limit("get_device_mdm", desktopQuota, logger),
-	).GET("/api/_version_/fleet/device/{token}/mdm/apple/manual_enrollment_profile", getDeviceMDMManualEnrollProfileEndpoint, getDeviceMDMManualEnrollProfileRequest{})
-	demdm.WithCustomMiddleware(
-		errorLimiter.Limit("get_device_software_mdm_command_results", desktopQuota, logger),
-	).GET("/api/_version_/fleet/device/{token}/software/commands/{command_uuid}/results", getDeviceMDMCommandResultsEndpoint,
-		getDeviceMDMCommandResultsRequest{})
+	demdm.GET("/api/_version_/fleet/device/{token}/mdm/apple/manual_enrollment_profile", getDeviceMDMManualEnrollProfileEndpoint, getDeviceMDMManualEnrollProfileRequest{})
+	demdm.GET("/api/_version_/fleet/device/{token}/software/commands/{command_uuid}/results", getDeviceMDMCommandResultsEndpoint, getDeviceMDMCommandResultsRequest{})
 
-	demdm.WithCustomMiddleware(
-		errorLimiter.Limit("post_device_migrate_mdm", desktopQuota, logger),
-	).POST("/api/_version_/fleet/device/{token}/migrate_mdm", migrateMDMDeviceEndpoint, deviceMigrateMDMRequest{})
+	demdm.POST("/api/_version_/fleet/device/{token}/migrate_mdm", migrateMDMDeviceEndpoint, deviceMigrateMDMRequest{})
 
-	de.WithCustomMiddleware(
-		errorLimiter.Limit("post_device_trigger_linux_escrow", desktopQuota, logger),
-	).POST("/api/_version_/fleet/device/{token}/mdm/linux/trigger_escrow", triggerLinuxDiskEncryptionEscrowEndpoint, triggerLinuxDiskEncryptionEscrowRequest{})
+	de.POST("/api/_version_/fleet/device/{token}/mdm/linux/trigger_escrow", triggerLinuxDiskEncryptionEscrowEndpoint, triggerLinuxDiskEncryptionEscrowRequest{})
 
 	// host-authenticated endpoints
 	he := newHostAuthenticatedEndpointer(svc, logger, opts, r, apiVersions...)

--- a/server/service/handler.go
+++ b/server/service/handler.go
@@ -817,15 +817,13 @@ func attachFleetAPIRoutes(r *mux.Router, svc fleet.Service, config config.FleetC
 	de.GET("/api/_version_/fleet/device/{token}/software/install/{install_uuid}/results", getDeviceSoftwareInstallResultsEndpoint, getDeviceSoftwareInstallResultsRequest{})
 	de.GET("/api/_version_/fleet/device/{token}/software/uninstall/{execution_id}/results", getDeviceSoftwareUninstallResultsEndpoint, getDeviceSoftwareUninstallResultsRequest{})
 	de.GET("/api/_version_/fleet/device/{token}/certificates", listDeviceCertificatesEndpoint, listDeviceCertificatesRequest{})
+	de.POST("/api/_version_/fleet/device/{token}/mdm/linux/trigger_escrow", triggerLinuxDiskEncryptionEscrowEndpoint, triggerLinuxDiskEncryptionEscrowRequest{})
 
 	// mdm-related endpoints available via device authentication
 	demdm := de.WithCustomMiddleware(mdmConfiguredMiddleware.VerifyAppleMDM())
 	demdm.GET("/api/_version_/fleet/device/{token}/mdm/apple/manual_enrollment_profile", getDeviceMDMManualEnrollProfileEndpoint, getDeviceMDMManualEnrollProfileRequest{})
 	demdm.GET("/api/_version_/fleet/device/{token}/software/commands/{command_uuid}/results", getDeviceMDMCommandResultsEndpoint, getDeviceMDMCommandResultsRequest{})
-
 	demdm.POST("/api/_version_/fleet/device/{token}/migrate_mdm", migrateMDMDeviceEndpoint, deviceMigrateMDMRequest{})
-
-	de.POST("/api/_version_/fleet/device/{token}/mdm/linux/trigger_escrow", triggerLinuxDiskEncryptionEscrowEndpoint, triggerLinuxDiskEncryptionEscrowRequest{})
 
 	// host-authenticated endpoints
 	he := newHostAuthenticatedEndpointer(svc, logger, opts, r, apiVersions...)

--- a/server/service/integration_core_test.go
+++ b/server/service/integration_core_test.go
@@ -5188,6 +5188,12 @@ func (s *integrationTestSuite) TestUsers() {
 	assert.Nil(t, getMeResp.User.Settings)
 	assert.Equal(t, getMeResp.Settings, &fleet.UserSettings{HiddenHostColumns: []string{}})
 
+	// Disable SMTP.
+	config, err := s.ds.AppConfig(context.Background())
+	require.NoError(s.T(), err)
+	config.SMTPSettings.SMTPConfigured = false
+	require.NoError(s.T(), s.ds.SaveAppConfig(context.Background(), config))
+
 	// create a new user
 	var createResp createUserResponse
 	userRawPwd := test.GoodPassword
@@ -5200,6 +5206,7 @@ func (s *integrationTestSuite) TestUsers() {
 	}
 	// mailer isn't set up, which fails prior to silently ignoring MFA
 	s.DoJSON("POST", "/api/latest/fleet/users/admin", params, http.StatusBadRequest, &createResp)
+
 	params.MFAEnabled = nil
 	s.DoJSON("POST", "/api/latest/fleet/users/admin", params, http.StatusOK, &createResp)
 	assert.NotZero(t, createResp.User.ID)

--- a/server/service/middleware/ratelimit/ratelimit.go
+++ b/server/service/middleware/ratelimit/ratelimit.go
@@ -7,10 +7,7 @@ import (
 
 	authz_ctx "github.com/fleetdm/fleet/v4/server/contexts/authz"
 	"github.com/fleetdm/fleet/v4/server/contexts/ctxerr"
-	"github.com/fleetdm/fleet/v4/server/contexts/publicip"
 	"github.com/go-kit/kit/endpoint"
-	"github.com/go-kit/kit/log/level"
-	kitlog "github.com/go-kit/log"
 	"github.com/throttled/throttled/v2"
 )
 
@@ -64,77 +61,6 @@ func (m *Middleware) Limit(keyName string, quota throttled.RateQuota) endpoint.M
 	}
 }
 
-// ErrorMiddleware is a rate limiter that performs limits only when there is an error in the request
-type ErrorMiddleware struct {
-	store throttled.GCRAStore
-}
-
-// NewErrorMiddleware creates a new instance of ErrorMiddleware
-func NewErrorMiddleware(store throttled.GCRAStore) *ErrorMiddleware {
-	if store == nil {
-		panic("nil store")
-	}
-
-	return &ErrorMiddleware{store: store}
-}
-
-// Limit returns a new middleware function enforcing the provided quota only when errors occur in the next middleware
-func (m *ErrorMiddleware) Limit(keyName string, quota throttled.RateQuota, logger kitlog.Logger) endpoint.Middleware {
-	return func(next endpoint.Endpoint) endpoint.Endpoint {
-		limiter, err := throttled.NewGCRARateLimiter(m.store, quota)
-		if err != nil {
-			panic(err)
-		}
-
-		return func(ctx context.Context, req interface{}) (response interface{}, err error) {
-			publicIP := publicip.FromContext(ctx)
-			if publicIP == "" {
-				level.Warn(logger).Log("msg", "missing public_ip, skipping rate limit")
-				return next(ctx, req)
-			}
-			ipKeyName := fmt.Sprintf("%s-%s", keyName, publicIP)
-
-			// RateLimit with quantity 0 will never get limited=true, so we check result.Remaining instead
-			_, result, err := limiter.RateLimit(ipKeyName, 0)
-			if err != nil {
-				// This can happen if the limit store (e.g. Redis) is unavailable.
-				//
-				// We need to set authentication as checked, otherwise we end up returning HTTP 500 errors.
-				if az, ok := authz_ctx.FromContext(ctx); ok {
-					az.SetChecked()
-				}
-				return nil, ctxerr.Wrap(ctx, err, "rate limit ErrorMiddleware: failed to check rate limit")
-			}
-			if result.Remaining == 0 {
-				// We need to set authentication as checked, otherwise we end up returning HTTP 500 errors.
-				if az, ok := authz_ctx.FromContext(ctx); ok {
-					az.SetChecked()
-				}
-				level.Warn(logger).Log(
-					"ip", publicIP,
-					"msg", "limit exceeded",
-				)
-				return nil, ctxerr.Wrap(ctx, &rateLimitError{result: result})
-			}
-
-			resp, err := next(ctx, req)
-			if err != nil {
-				_, _, rateErr := limiter.RateLimit(ipKeyName, 1)
-				if rateErr != nil {
-					// This can happen if the limit store (e.g. Redis) is unavailable.
-					//
-					// We need to set authentication as checked, otherwise we end up returning HTTP 500 errors.
-					if az, ok := authz_ctx.FromContext(ctx); ok {
-						az.SetChecked()
-					}
-					return nil, ctxerr.Wrap(ctx, err, "rate limit ErrorMiddleware: failed to increase rate limit")
-				}
-			}
-			return resp, err
-		}
-	}
-}
-
 // Error is the interface for rate limiting errors.
 type Error interface {
 	error
@@ -146,14 +72,7 @@ type rateLimitError struct {
 }
 
 func (r rateLimitError) Error() string {
-	// github.com/throttled/throttled has a bug where "peeking" with RateLimit(key, 0)
-	// always returns a RetryAfter=-1. So we just return "limit exceeded" to prevent confusing
-	// errors with "limit exceeded, retry after: 0s".
-	ra := int(r.result.RetryAfter.Seconds())
-	if ra > 0 {
-		return fmt.Sprintf("limit exceeded, retry after: %ds", ra)
-	}
-	return "limit exceeded"
+	return fmt.Sprintf("limit exceeded, retry after: %ds", r.RetryAfter())
 }
 
 func (r rateLimitError) StatusCode() int {

--- a/server/service/middleware/ratelimit/ratelimit_test.go
+++ b/server/service/middleware/ratelimit/ratelimit_test.go
@@ -7,8 +7,6 @@ import (
 	"testing"
 
 	authz_ctx "github.com/fleetdm/fleet/v4/server/contexts/authz"
-	"github.com/fleetdm/fleet/v4/server/contexts/publicip"
-	kitlog "github.com/go-kit/log"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/throttled/throttled/v2"
@@ -74,77 +72,4 @@ func TestLimit(t *testing.T) {
 	assert.True(t, authzCtx.Checked())
 
 	assert.Equal(t, uint(2), endpointCallCount) // when rate limit is exceeded, shouldn't call endpoint
-}
-
-func TestNewErrorMiddlewarePanics(t *testing.T) {
-	defer func() {
-		if r := recover(); r == nil {
-			t.Errorf("The code did not panic")
-		}
-	}()
-
-	NewErrorMiddleware(nil)
-}
-
-func TestLimitOnlyWhenError(t *testing.T) {
-	t.Parallel()
-
-	store, _ := memstore.New(1)
-	limiter := NewErrorMiddleware(store)
-	endpoint := func(context.Context, interface{}) (interface{}, error) { return struct{}{}, nil }
-	wrapped := limiter.Limit(
-		"test_limit", throttled.RateQuota{MaxRate: throttled.PerHour(1), MaxBurst: 0}, kitlog.NewNopLogger(),
-	)(endpoint)
-
-	// Does NOT hit any rate limits because the endpoint doesn't fail
-	ctx := publicip.NewContext(context.Background(), "0.0.0.0")
-	_, err := wrapped(ctx, struct{}{})
-	assert.NoError(t, err)
-	_, err = wrapped(ctx, struct{}{})
-	assert.NoError(t, err)
-
-	expectedError := errors.New("error")
-	failingEndpoint := func(context.Context, interface{}) (interface{}, error) { return nil, expectedError }
-	wrappedFailer := limiter.Limit(
-		"test_limit", throttled.RateQuota{MaxRate: throttled.PerHour(1), MaxBurst: 0}, kitlog.NewNopLogger(),
-	)(failingEndpoint)
-
-	// First request that fails should be allowed.
-	_, err = wrappedFailer(ctx, struct{}{})
-	assert.ErrorIs(t, err, expectedError)
-
-	// Second request that fails should not be allowed.
-	_, err = wrappedFailer(ctx, struct{}{})
-	assert.Error(t, err)
-	var rle Error
-	require.True(t, errors.As(err, &rle))
-	// github.com/throttled/throttled has a bug where "peeking" with RateLimit(key, 0)
-	// always returns a RetryAfter=-1. So I'll just leave this here but in the future
-	// we could return the correct Retry-After. Also, we are not making use of "Retry-After"
-	// on the agent side yet.
-	require.EqualValues(t, rle.Result().RetryAfter, -1)
-	require.Equal(t, "limit exceeded", rle.Error())
-}
-
-func TestNoRateLimitWithoutPublicIP(t *testing.T) {
-	t.Parallel()
-
-	store, _ := memstore.New(1)
-	limiter := NewErrorMiddleware(store)
-
-	expectedError := errors.New("error")
-	failingEndpoint := func(context.Context, interface{}) (interface{}, error) {
-		return nil, expectedError
-	}
-	wrappedFailer := limiter.Limit(
-		"test_limit", throttled.RateQuota{MaxRate: throttled.PerHour(1), MaxBurst: 0}, kitlog.NewNopLogger(),
-	)(failingEndpoint)
-
-	ctx := context.Background()
-
-	// Requests should not be rate limited because there's no "Public IP" identifier in the request.
-	_, err := wrappedFailer(ctx, struct{}{})
-	assert.ErrorIs(t, err, expectedError)
-	_, err = wrappedFailer(ctx, struct{}{})
-	assert.ErrorIs(t, err, expectedError)
 }


### PR DESCRIPTION
For #31890.

Some customers run all their hosts behind a NAT. 
For "Fleet Desktop" rate limiting Fleet is looking at `X-Forwarded-For` (up to 4.72.0) and recently (in v4.73.0) we added `True-Client-IP` and `X-Real-IP`.
So, the current logic for rate limiting "Fleet Desktop" requests is breaking "Fleet Desktop" for these customers because all their hosts are being rate limited "with the same IP".

This PR is removing the rate limiting logic that was put in place originally to prevent brute force attacks on Fleet Desktop tokens (UUIDs / 128 bits). Brute forcing (128 bits) is IMO an already impractical attack (requires more years than age of universe, etc.) and we would see some infrastructure logs/alerts that we could then act on (block IPs, etc.) - even less of an issue considering these UUID tokens are valid for just 1 hour.

---

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.

## Testing

- [x] QA'd all new/changed functionality manually