### PR TITLE
Fleet UI: Fix vulns from being counted multiple times in vuln count

### DIFF
--- a/changes/25025-dedup-vuln-count
+++ b/changes/25025-dedup-vuln-count
@@ -1,0 +1,1 @@
+- Fleet UI: Fixed bug deduplicating to only count unique vulns when counting software title vulnerabilities across versions in various software title vulnerabilities count, and host software title vulnerabilities count

--- a/frontend/pages/SoftwarePage/SoftwareTitles/SoftwareTable/SoftwareTitlesTableConfig.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitles/SoftwareTable/SoftwareTitlesTableConfig.tsx
@@ -20,6 +20,7 @@ import SoftwareNameCell from "components/TableContainer/DataTable/SoftwareNameCe
 
 import VersionCell from "../../components/tables/VersionCell";
 import VulnerabilitiesCell from "../../components/tables/VulnerabilitiesCell";
+import { getVulnerabilities } from "./helpers";
 
 // NOTE: cellProps come from react-table
 // more info here https://react-table.tanstack.com/docs/api/useTable#cell-properties
@@ -35,26 +36,6 @@ type IHostCountCellProps = CellProps<
 type IViewAllHostsLinkProps = CellProps<ISoftwareTitle>;
 
 type ITableHeaderProps = IHeaderProps<ISoftwareTitle>;
-
-export const getVulnerabilities = <
-  T extends { vulnerabilities: string[] | null }
->(
-  versions: T[]
-) => {
-  if (!versions) {
-    return [];
-  }
-  const vulnerabilities = versions.reduce((acc: string[], currentVersion) => {
-    if (
-      currentVersion.vulnerabilities &&
-      currentVersion.vulnerabilities.length !== 0
-    ) {
-      acc.push(...currentVersion.vulnerabilities);
-    }
-    return acc;
-  }, []);
-  return vulnerabilities;
-};
 
 /**
  * Gets the data needed to render the software name cell.

--- a/frontend/pages/SoftwarePage/SoftwareTitles/SoftwareTable/helpers.tests.ts
+++ b/frontend/pages/SoftwarePage/SoftwareTitles/SoftwareTable/helpers.tests.ts
@@ -1,4 +1,4 @@
-import { isValidNumber } from "./helpers";
+import { isValidNumber, getVulnerabilities } from "./helpers";
 
 describe("isValidNumber", () => {
   // Test valid numbers
@@ -45,5 +45,56 @@ describe("isValidNumber", () => {
     expect(isValidNumber(10, 0, 10)).toBe(true);
     expect(isValidNumber(-1, 0, 10)).toBe(false);
     expect(isValidNumber(11, 0, 10)).toBe(false);
+  });
+});
+
+const versions = [
+  {
+    id: 531270,
+    version: "131.0.6778.86",
+    vulnerabilities: ["CVE-2024-12053", "CVE-2024-12381", "CVE-2025-0444"],
+  },
+  {
+    id: 538184,
+    version: "132.0.6834.160",
+    vulnerabilities: ["CVE-2025-0444", "CVE-2025-0445"], // 0444 is duplicate
+  },
+  {
+    id: 541233,
+    version: "133.0.6943.53",
+    vulnerabilities: ["CVE-2025-0995", "CVE-2025-0996"],
+  },
+  {
+    id: 572993,
+    version: "139.0.7258.127",
+    vulnerabilities: null, // should be ignored
+  },
+];
+
+describe("getVulnerabilities", () => {
+  it("returns a unique list of vulnerabilities across all versions", () => {
+    const result = getVulnerabilities(versions);
+
+    // Expect no duplicates
+    expect(new Set(result).size).toBe(result.length);
+
+    // Expect specific vulns present
+    expect(result).toEqual(
+      expect.arrayContaining([
+        "CVE-2024-12053",
+        "CVE-2024-12381",
+        "CVE-2025-0444",
+        "CVE-2025-0445",
+        "CVE-2025-0995",
+        "CVE-2025-0996",
+      ])
+    );
+
+    // Should not contain unintended values
+    expect(result).not.toContain("CVE-DOES-NOT-EXIST");
+  });
+
+  it("returns an empty array if no versions are given", () => {
+    expect(getVulnerabilities([])).toEqual([]);
   });
 });

--- a/frontend/pages/SoftwarePage/SoftwareTitles/SoftwareTable/helpers.ts
+++ b/frontend/pages/SoftwarePage/SoftwareTitles/SoftwareTable/helpers.ts
@@ -239,3 +239,22 @@ export const getVulnFilterRenderDetails = (
     tooltipText: tooltipTextWithLineBreaks(tooltipText),
   };
 };
+
+export const getVulnerabilities = <
+  T extends { vulnerabilities: string[] | null }
+>(
+  versions: T[]
+): string[] => {
+  if (!versions) {
+    return [];
+  }
+
+  const vulnerabilities = versions.reduce((acc, current) => {
+    if (current.vulnerabilities?.length) {
+      current.vulnerabilities.forEach((vuln) => acc.add(vuln));
+    }
+    return acc;
+  }, new Set<string>());
+
+  return [...vulnerabilities];
+};

--- a/frontend/pages/hosts/details/cards/Software/DeviceSoftwareTableConfig.tsx
+++ b/frontend/pages/hosts/details/cards/Software/DeviceSoftwareTableConfig.tsx
@@ -13,7 +13,7 @@ import TextCell from "components/TableContainer/DataTable/TextCell";
 
 import VulnerabilitiesCell from "pages/SoftwarePage/components/tables/VulnerabilitiesCell";
 import VersionCell from "pages/SoftwarePage/components/tables/VersionCell";
-import { getVulnerabilities } from "pages/SoftwarePage/SoftwareTitles/SoftwareTable/SoftwareTitlesTableConfig";
+import { getVulnerabilities } from "pages/SoftwarePage/SoftwareTitles/SoftwareTable/helpers";
 import SoftwareNameCell from "components/TableContainer/DataTable/SoftwareNameCell";
 
 type ISoftwareTableConfig = Column<IHostSoftware>;

--- a/frontend/pages/hosts/details/cards/Software/HostSoftwareTableConfig.tsx
+++ b/frontend/pages/hosts/details/cards/Software/HostSoftwareTableConfig.tsx
@@ -22,7 +22,7 @@ import { HumanTimeDiffWithDateTip } from "components/HumanTimeDiffWithDateTip";
 
 import VulnerabilitiesCell from "pages/SoftwarePage/components/tables/VulnerabilitiesCell";
 import VersionCell from "pages/SoftwarePage/components/tables/VersionCell";
-import { getVulnerabilities } from "pages/SoftwarePage/SoftwareTitles/SoftwareTable/SoftwareTitlesTableConfig";
+import { getVulnerabilities } from "pages/SoftwarePage/SoftwareTitles/SoftwareTable/helpers";
 import { getAutomaticInstallPoliciesCount } from "pages/SoftwarePage/helpers";
 import { sourcesWithLastOpenedTime } from "pages/hosts/details/components/InventoryVersions/InventoryVersions";
 


### PR DESCRIPTION
## Issue
Closes #32025 

## Description
- Don't count the same vuln multiple times
- Use set
- Add test

## Screen recording of fix

Before (`main`) and after (dev branch) in recording

https://github.com/user-attachments/assets/885acb8f-6681-4693-bcc6-1e53178faa00



# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually
