### PR TITLE
Fleet UI: Re-add missing tarballs summary card

### DIFF
--- a/changes/31721-missing-tar-summary-card
+++ b/changes/31721-missing-tar-summary-card
@@ -1,0 +1,1 @@
+* Remove `DeferForceAtUserLoginMaxBypassAttempts` from FileVault profile, to use default value of 0 to indicate the FileVault enforcement can not be deferred on next login.

--- a/changes/31721-missing-tar-summary-card
+++ b/changes/31721-missing-tar-summary-card
@@ -1,1 +1,1 @@
-* Remove `DeferForceAtUserLoginMaxBypassAttempts` from FileVault profile, to use default value of 0 to indicate the FileVault enforcement can not be deferred on next login.
+- Fleet UI: Re-added tarballs summary card

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwareSummaryCard/SoftwareSummaryCard.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwareSummaryCard/SoftwareSummaryCard.tsx
@@ -33,8 +33,8 @@ const SoftwareSummaryCard = ({
   isLoading = false,
   router,
 }: ISoftwareSummaryCard) => {
-  // Hide versions card for tgz_packages only
-  if (title.source === "tgz_packages") return null;
+  // Hide versions table for tgz_packages only
+  const showVersionsTable = title.source !== "tgz_packages";
 
   return (
     <Card borderRadiusSize="xxlarge" includeShadow className={baseClass}>
@@ -52,15 +52,17 @@ const SoftwareSummaryCard = ({
         source={title.source}
         iconUrl={title.app_store_app ? title.app_store_app.icon_url : undefined}
       />
-      <TitleVersionsTable
-        router={router}
-        data={title.versions ?? []}
-        isLoading={isLoading}
-        teamIdForApi={teamId}
-        isIPadOSOrIOSApp={isIpadOrIphoneSoftwareSource(title.source)}
-        isAvailableForInstall={isAvailableForInstall}
-        countsUpdatedAt={title.counts_updated_at}
-      />
+      {showVersionsTable && (
+        <TitleVersionsTable
+          router={router}
+          data={title.versions ?? []}
+          isLoading={isLoading}
+          teamIdForApi={teamId}
+          isIPadOSOrIOSApp={isIpadOrIphoneSoftwareSource(title.source)}
+          isAvailableForInstall={isAvailableForInstall}
+          countsUpdatedAt={title.counts_updated_at}
+        />
+      )}
     </Card>
   );
 };


### PR DESCRIPTION
## Issue
Closes #31546 (number in branch name is incorrect)

## Description
- Missing for 3 months >.<

## Screenshot of fix

<img width="1214" height="663" alt="Screenshot 2025-08-18 at 1 46 45 PM" src="https://github.com/user-attachments/assets/0564c40c-92c5-45ac-bdfb-000960a0e210" />


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing
- [x] QA'd all new/changed functionality manually
