### PR TITLE
Fleet UI: Fix missing space/bullet in copy

### DIFF
--- a/frontend/pages/policies/ManagePoliciesPage/components/InstallSoftwareModal/InstallSoftwareModal.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/components/InstallSoftwareModal/InstallSoftwareModal.tsx
@@ -66,7 +66,9 @@ const generateSoftwareOptionHelpText = (title: IEnhancedSoftwareTitle) => {
 
   if (vppOption) {
     platformString = "macOS (App Store)";
-    versionString = title.app_store_app?.version || "";
+    versionString = title.app_store_app?.version
+      ? ` • ${title.app_store_app?.version}`
+      : "";
   } else {
     if (title.platform && title.extension) {
       platformString = `${PLATFORM_DISPLAY_NAMES[title.platform]} (.${


### PR DESCRIPTION
## Issue
Closes #31966 

## Description
- Add missing space and bullet in policy automation > install software > app store option (similar to line 78)

## Screenshot of fix
<img width="1222" height="545" alt="Screenshot 2025-08-18 at 3 04 43 PM" src="https://github.com/user-attachments/assets/4c2a32c5-9cee-4aa7-a2d4-e99f37c6a061" />



## Testing

- [x] QA'd all new/changed functionality manually
