### PR TITLE
UI fixes for showing which OSs support linux kernel vulns

### DIFF
--- a/frontend/interfaces/platform.ts
+++ b/frontend/interfaces/platform.ts
@@ -207,3 +207,9 @@ export const isOsSettingsDisplayPlatform = (
   }
   return OS_SETTINGS_DISPLAY_PLATFORMS.includes(platform);
 };
+
+const VULNS_SUPPORTED_LINUX_PLATFORMS = ["ubuntu", "debian", "amzn"];
+
+export const isVulnsSupportedLinuxPlatform = (platform: string) => {
+  return VULNS_SUPPORTED_LINUX_PLATFORMS.includes(platform);
+};

--- a/frontend/interfaces/software.ts
+++ b/frontend/interfaces/software.ts
@@ -184,6 +184,7 @@ export interface ISoftwareVersion {
   generated_cpe: string;
   vulnerabilities: ISoftwareVulnerability[] | null;
   hosts_count?: number;
+  is_kernel?: boolean;
 }
 
 export const SOURCE_TYPE_CONVERSION = {
@@ -553,6 +554,10 @@ export const hasHostSoftwareAppLastInstall = (
 export const isIpadOrIphoneSoftwareSource = (source: string) =>
   ["ios_apps", "ipados_apps"].includes(source);
 
+export const isLinuxKernelThatSupportsVulns = (swVersion: ISoftwareVersion) =>
+  swVersion.is_kernel &&
+  swVersion.vendor !== "CentOS" &&
+  swVersion.vendor !== "Fedora Project";
 export interface IFleetMaintainedApp {
   id: number;
   name: string;

--- a/frontend/pages/DashboardPage/cards/OperatingSystems/OSTableConfig.tsx
+++ b/frontend/pages/DashboardPage/cards/OperatingSystems/OSTableConfig.tsx
@@ -26,7 +26,10 @@ import {
   INumberCellProps,
   IStringCellProps,
 } from "interfaces/datatable_config";
-import { isLinuxLike } from "interfaces/platform";
+import {
+  isLinuxLike,
+  isVulnsSupportedLinuxPlatform,
+} from "interfaces/platform";
 
 type ITableColumnConfig = Column<IOperatingSystemVersion>;
 
@@ -108,7 +111,7 @@ const generateDefaultTableHeaders = (
       if (
         platform !== "darwin" &&
         platform !== "windows" &&
-        !isLinuxLike(platform)
+        !isVulnsSupportedLinuxPlatform(platform)
       ) {
         return <TextCell value="Not supported" grey />;
       }

--- a/frontend/pages/SoftwarePage/SoftwareOSDetailsPage/SoftwareOSDetailsPage.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareOSDetailsPage/SoftwareOSDetailsPage.tsx
@@ -140,6 +140,7 @@ export const KernelsCard = ({
       isLoading={isLoading}
       router={router}
       teamIdForApi={teamIdForApi}
+      platform={osVersion.platform}
     />
   </Card>
 );

--- a/frontend/pages/SoftwarePage/SoftwareVersionDetailsPage/SoftwareVersionDetailsPage.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareVersionDetailsPage/SoftwareVersionDetailsPage.tsx
@@ -22,6 +22,7 @@ import {
   ISoftwareVersion,
   formatSoftwareType,
   isIpadOrIphoneSoftwareSource,
+  isLinuxKernelThatSupportsVulns,
 } from "interfaces/software";
 import { ignoreAxiosError } from "interfaces/errors";
 
@@ -118,7 +119,10 @@ const SoftwareVersionDetailsPage = ({
   );
 
   const renderVulnTable = (swVersion: ISoftwareVersion) => {
-    if (isIpadOrIphoneSoftwareSource(swVersion.source)) {
+    if (
+      isIpadOrIphoneSoftwareSource(swVersion.source) ||
+      !isLinuxKernelThatSupportsVulns(swVersion.source, swVersion.name)
+    ) {
       const platformText = swVersion.source === "ios_apps" ? "iOS" : "iPadOS";
       return <VulnsNotSupported platformText={platformText} />;
     }

--- a/frontend/pages/SoftwarePage/components/tables/OSKernelsTable/OSKernelsTable.tsx
+++ b/frontend/pages/SoftwarePage/components/tables/OSKernelsTable/OSKernelsTable.tsx
@@ -44,6 +44,7 @@ interface ISoftwareVulnerabilitiesTableProps {
   className?: string;
   router: InjectedRouter;
   teamIdForApi?: number;
+  platform: string;
 }
 
 interface IRowProps extends Row {
@@ -58,6 +59,7 @@ const OSKernelsTable = ({
   className,
   router,
   teamIdForApi,
+  platform,
 }: ISoftwareVulnerabilitiesTableProps) => {
   const classNames = classnames(baseClass, className);
 
@@ -76,7 +78,10 @@ const OSKernelsTable = ({
     }
   };
 
-  const tableHeaders = generateTableConfig({ teamId: teamIdForApi });
+  const tableHeaders = generateTableConfig({
+    teamId: teamIdForApi,
+    platform,
+  });
 
   const rendersOsKernelsVersionCount = () => (
     <TableCount name="items" count={data?.length} />

--- a/frontend/pages/SoftwarePage/components/tables/OSKernelsTable/OSKernelsTableConfig.tsx
+++ b/frontend/pages/SoftwarePage/components/tables/OSKernelsTable/OSKernelsTableConfig.tsx
@@ -17,9 +17,11 @@ import TextCell from "components/TableContainer/DataTable/TextCell";
 import LinkCell from "components/TableContainer/DataTable/LinkCell";
 import HeaderCell from "components/TableContainer/DataTable/HeaderCell";
 import VulnerabilitiesCell from "../VulnerabilitiesCell";
+import { isVulnsSupportedLinuxPlatform } from "interfaces/platform";
 
 interface IOsKernelsTableConfigProps {
   teamId?: number;
+  platform: string;
 }
 
 type IHostCountCellProps = INumberCellProps<IOperatingSystemKernels>;
@@ -27,7 +29,10 @@ type IVersionCellProps = IStringCellProps<IOperatingSystemKernels>;
 type IViewAllHostsLinkProps = CellProps<IOperatingSystemKernels>;
 type IVulnCellProps = CellProps<IOperatingSystemKernels, string[] | null>;
 
-const generateTableConfig = ({ teamId }: IOsKernelsTableConfigProps) => {
+const generateTableConfig = ({
+  teamId,
+  platform,
+}: IOsKernelsTableConfigProps) => {
   const tableHeaders = [
     {
       title: "Version",
@@ -60,6 +65,10 @@ const generateTableConfig = ({ teamId }: IOsKernelsTableConfigProps) => {
       disableSortBy: true,
       accessor: "vulnerabilities",
       Cell: (cellProps: IVulnCellProps): JSX.Element => {
+        if (!isVulnsSupportedLinuxPlatform(platform)) {
+          return <TextCell value="Not supported" grey />;
+        }
+
         return <VulnerabilitiesCell vulnerabilities={cellProps.cell.value} />;
       },
     },

--- a/frontend/pages/SoftwarePage/components/tables/SoftwareVulnerabilitiesTable/SoftwareVulnerabilitiesTable.tsx
+++ b/frontend/pages/SoftwarePage/components/tables/SoftwareVulnerabilitiesTable/SoftwareVulnerabilitiesTable.tsx
@@ -53,10 +53,10 @@ export const VulnsNotSupported = ({
   platformText,
 }: IVulnsNotSupportedProps) => (
   <EmptyTable
-    header="Vulnerabilities are not supported for this type of host"
+    header="Vulnerabilities are not supported for this software"
     info={
       <>
-        Interested in vulnerabilities in {platformText ?? "this platform"}?{" "}
+        Interested in vulnerabilities?{" "}
         <CustomLink url={CONTACT_FLEET_LINK} text="Let us know" newTab />
       </>
     }

--- a/server/datastore/mysql/software.go
+++ b/server/datastore/mysql/software.go
@@ -1664,8 +1664,10 @@ func (ds *Datastore) SoftwareByID(ctx context.Context, id uint, teamID *uint, in
 			"s.extension_id",
 			"scv.cve",
 			"scv.created_at",
+			"st.is_kernel",
 			goqu.COALESCE(goqu.I("scp.cpe"), "").As("generated_cpe"),
 		).
+		Join(goqu.I("software_titles").As("st"), goqu.On(goqu.I("st.id").Eq(goqu.I("s.title_id")))).
 		LeftJoin(
 			goqu.I("software_cpe").As("scp"),
 			goqu.On(

--- a/server/fleet/software.go
+++ b/server/fleet/software.go
@@ -94,7 +94,7 @@ type Software struct {
 	// TODO: should we create a separate type? Feels like this field shouldn't be here since it's
 	// just used for VPP install verification.
 	Installed bool `json:"-"`
-	IsKernel  bool `json:"-"`
+	IsKernel  bool `json:"is_kernel" db:"is_kernel"`
 }
 
 func (Software) AuthzType() string {


### PR DESCRIPTION
> Closes #32027

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [ ] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [ ] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes

## Testing

- [ ] Added/updated automated tests
- [ ] Where appropriate, [automated tests simulate multiple hosts and test for host isolation](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/reference/patterns-backend.md#unit-testing) (updates to one hosts's records do not affect another)

- [ ] QA'd all new/changed functionality manually

For unreleased bug fixes in a release candidate, one of:

- [ ] Confirmed that the fix is not expected to adversely impact load test results
- [ ] Alerted the release DRI if additional load testing is needed

## Database migrations

- [ ] Checked table schema to confirm autoupdate
- [ ] Checked schema for all modified table for columns that will auto-update timestamps during migration.
- [ ] Confirmed that updating the timestamps is acceptable, and will not cause unwanted side effects.
- [ ] Ensured the correct collation is explicitly set for character columns (`COLLATE utf8mb4_unicode_ci`).

## New Fleet configuration settings

- [ ] Setting(s) is/are explicitly excluded from GitOps

If you didn't check the box above, follow this checklist for GitOps-enabled settings:

- [ ] Verified that the setting is exported via `fleetctl generate-gitops`
- [ ] Verified the setting is documented in a separate PR to [the GitOps documentation](https://github.com/fleetdm/fleet/blob/main/docs/Configuration/yaml-files.md#L485)
- [ ] Verified that the setting is cleared on the server if it is not supplied in a YAML file (or that it is documented as being optional)
- [ ] Verified that any relevant UI is disabled when GitOps mode is enabled

## fleetd/orbit/Fleet Desktop

- [ ] Verified compatibility with the latest released version of Fleet (see [Must rule](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/workflows/fleetd-development-and-release-strategy.md))
- [ ] If the change applies to only one platform, confirmed that `runtime.GOOS` is used as needed to isolate changes
- [ ] Verified that fleetd runs on macOS, Linux and Windows
- [ ] Verified auto-update works from the released version of component to the new version (see [tools/tuf/test](../tools/tuf/test/README.md))
