### PR TITLE
Updating Nudge configuration and policy logic

### DIFF
--- a/it-and-security/lib/all/labels/nudge-test-devices.yml
+++ b/it-and-security/lib/all/labels/nudge-test-devices.yml
@@ -6,3 +6,5 @@
     - "allens-macbook-pro.local"
     - "allens-mac-mini.local"
     - "Noah Talerman's MacBook Pro"
+    - "mitchs-macbook-pro.local"
+    - "harrisons-macbook-pro.local"

--- a/it-and-security/lib/macos/configuration-profiles/nudge-configuration.mobileconfig
+++ b/it-and-security/lib/macos/configuration-profiles/nudge-configuration.mobileconfig
@@ -56,7 +56,7 @@
 				</dict>
 				<dict>
 					<key>aboutUpdateURL</key>
-					<string>http://fleetdm.com</string>
+					<string>https://www.apple.com/os/macos</string>
 					<key>requiredMinimumOSVersion</key>
 					<string>latest-minor</string>
 					<key>targetedOSVersionsRule</key>

--- a/it-and-security/lib/macos/policies/install-nudge.yml
+++ b/it-and-security/lib/macos/policies/install-nudge.yml
@@ -1,5 +1,5 @@
 - name: macOS - Nudge installed and configured
-  query: SELECT 1 WHERE EXISTS (SELECT 1 FROM macos_profiles WHERE identifier = "com.fleetdm.nudge.managed") AND EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = "com.github.macadmins.Nudge");
+  query: SELECT 1 WHERE EXISTS (SELECT 1 FROM macos_profiles WHERE identifier = "com.fleetdm.nudge.managed") AND EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = "com.github.macadmins.Nudge" and bundle_short_version LIKE "2.%");
   critical: false
   description: This policy ensures the Nudge is installed and configured.
   resolution: "If you are failing this policy, click Refetch. If you are still failing after Refetch completes, drop a note in #help-it-and-enablement."


### PR DESCRIPTION
- Updated configuration profile to support macOS26 More info link
- Updated policy logic to account for old versions of Nudge being installed