### PR TITLE
FE: Cleanup lint warnings

### DIFF
--- a/frontend/components/ActivityDetails/InstallDetails/SoftwareInstallDetailsModal/SoftwareInstallDetailsModal.tsx
+++ b/frontend/components/ActivityDetails/InstallDetails/SoftwareInstallDetailsModal/SoftwareInstallDetailsModal.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useState } from "react";
+import React, { useState } from "react";
 import { useQuery } from "react-query";
 import { formatDistanceToNow } from "date-fns";
 import { AxiosError } from "axios";

--- a/frontend/components/FlashMessage/FlashMessage.stories.tsx
+++ b/frontend/components/FlashMessage/FlashMessage.stories.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { Meta, StoryObj } from "@storybook/react";
 
 import FlashMessage from ".";

--- a/frontend/components/MainContent/MainContent.tsx
+++ b/frontend/components/MainContent/MainContent.tsx
@@ -38,7 +38,6 @@ const MainContent = ({
   const {
     config,
     isPremiumTier,
-    isAndroidEnterpriseDeleted,
     isApplePnsExpired,
     isAppleBmExpired,
     isVppExpired,

--- a/frontend/components/TableContainer/DataTable/HeaderCell/HeaderCell.tsx
+++ b/frontend/components/TableContainer/DataTable/HeaderCell/HeaderCell.tsx
@@ -6,14 +6,12 @@ interface IHeaderCellProps {
   value: ReactNode;
   isSortedDesc?: boolean;
   disableSortBy?: boolean;
-  tootip?: ReactNode;
 }
 
 const HeaderCell = ({
   value,
   isSortedDesc,
   disableSortBy,
-  tootip,
 }: IHeaderCellProps): JSX.Element => {
   let sortArrowClass = "";
   if (isSortedDesc === undefined) {

--- a/frontend/components/forms/validators/validate_query/index.js
+++ b/frontend/components/forms/validators/validate_query/index.js
@@ -1,5 +1,4 @@
 import { Parser } from "utilities/node-sql-parser/sqlite";
-import { includes, some } from "lodash";
 
 const invalidQueryResponse = (message) => {
   return { valid: false, error: message };

--- a/frontend/pages/DashboardPage/cards/HostCountCard/HostCountCard.tests.tsx
+++ b/frontend/pages/DashboardPage/cards/HostCountCard/HostCountCard.tests.tsx
@@ -4,8 +4,6 @@ import { fireEvent, render, screen } from "@testing-library/react";
 import paths from "router/paths";
 import HostCountCard from "./HostCountCard";
 
-const LOADING_OPACITY = 0.4;
-
 describe("HostCountCard - component", () => {
   it("renders title, count, and image based on the information and data passed in", () => {
     render(

--- a/frontend/pages/DashboardPage/cards/Munki/MunkiVersionsTableConfig.tsx
+++ b/frontend/pages/DashboardPage/cards/Munki/MunkiVersionsTableConfig.tsx
@@ -22,15 +22,6 @@ interface IHeaderProps {
   };
 }
 
-interface IDataColumn {
-  title: string;
-  Header: ((props: IHeaderProps) => JSX.Element) | string;
-  accessor: string;
-  Cell: (props: ICellProps) => JSX.Element;
-  disableHidden?: boolean;
-  disableSortBy?: boolean;
-}
-
 const munkiVersionsTableHeaders = [
   {
     title: "Version",

--- a/frontend/pages/DashboardPage/sections/PlatformHostCounts/PlatformHostCounts.tsx
+++ b/frontend/pages/DashboardPage/sections/PlatformHostCounts/PlatformHostCounts.tsx
@@ -6,8 +6,6 @@ import { PLATFORM_NAME_TO_LABEL_NAME } from "pages/DashboardPage/helpers";
 
 import { IHostSummary } from "interfaces/host_summary";
 import { PlatformValueOptions } from "utilities/constants";
-import DataError from "components/DataError";
-import Card from "components/Card";
 
 import HostCountCard from "../../cards/HostCountCard";
 

--- a/frontend/pages/ManageControlsPage/OSSettings/cards/CustomSettings/CustomSettings.tsx
+++ b/frontend/pages/ManageControlsPage/OSSettings/cards/CustomSettings/CustomSettings.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useContext, useRef, useState } from "react";
-import { InjectedRouter } from "react-router";
+
 import { useQuery } from "react-query";
 import PATHS from "router/paths";
 

--- a/frontend/pages/RegistrationPage/Breadcrumbs/Breadcrumbs.tests.tsx
+++ b/frontend/pages/RegistrationPage/Breadcrumbs/Breadcrumbs.tests.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { fireEvent, render, screen } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import { noop } from "lodash";
 
 import Breadcrumbs from "pages/RegistrationPage/Breadcrumbs";

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/EditSoftwareModal/EditSoftwareModal.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/EditSoftwareModal/EditSoftwareModal.tsx
@@ -1,7 +1,6 @@
 import React, { useContext, useState, useEffect } from "react";
 import { InjectedRouter } from "react-router";
 import { useQuery } from "react-query";
-import paths from "router/paths";
 import classnames from "classnames";
 
 import { ILabelSummary } from "interfaces/label";
@@ -22,7 +21,6 @@ import labelsAPI, { getCustomLabels } from "services/entities/labels";
 import { DEFAULT_USE_QUERY_OPTIONS } from "utilities/constants";
 import deepDifference from "utilities/deep_difference";
 import { getFileDetails } from "utilities/file/fileUtils";
-import { getPathWithQueryParams, QueryParams } from "utilities/url";
 
 import Modal from "components/Modal";
 import FileProgressModal from "components/FileProgressModal";

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwareInstallerCard/InstallerDetailsWidget/InstallerDetailsWidget.tests.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwareInstallerCard/InstallerDetailsWidget/InstallerDetailsWidget.tests.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { render, screen } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
+
 import InstallerDetailsWidget from "./InstallerDetailsWidget";
 
 // Mock current time for time stamp test

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwareInstallerCard/SoftwareInstallerCard.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwareInstallerCard/SoftwareInstallerCard.tsx
@@ -11,7 +11,6 @@ import {
   isSoftwarePackage,
 } from "interfaces/software";
 import softwareAPI from "services/entities/software";
-import PATHS from "router/paths";
 
 import { SELF_SERVICE_TOOLTIP } from "pages/SoftwarePage/helpers";
 
@@ -22,13 +21,11 @@ import Icon from "components/Icon";
 import Tag from "components/Tag";
 import Button from "components/buttons/Button";
 
-import { getPathWithQueryParams, QueryParams } from "utilities/url";
 import endpoints from "utilities/endpoints";
 import URL_PREFIX from "router/url_prefix";
 import { LEARN_MORE_ABOUT_BASE_LINK } from "utilities/constants";
 import CustomLink from "components/CustomLink";
 import InstallerDetailsWidget from "pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwareInstallerCard/InstallerDetailsWidget";
-import CategoriesEndUserExperienceModal from "pages/SoftwarePage/components/modals/CategoriesEndUserExperienceModal";
 
 import DeleteSoftwareModal from "../DeleteSoftwareModal";
 import EditSoftwareModal from "../EditSoftwareModal";
@@ -49,50 +46,6 @@ interface IStatusDisplayOption {
   iconName: "success" | "pending-outline" | "error";
   tooltip: React.ReactNode;
 }
-
-// "pending" and "failed" each encompass both "_install" and "_uninstall" sub-statuses
-type SoftwareInstallDisplayStatus = "installed" | "pending" | "failed";
-
-const STATUS_DISPLAY_OPTIONS: Record<
-  SoftwareInstallDisplayStatus,
-  IStatusDisplayOption
-> = {
-  installed: {
-    displayName: "Installed",
-    iconName: "success",
-    tooltip: (
-      <>
-        Software was installed on these hosts (install script finished
-        <br />
-        with exit code 0). Currently, if the software is uninstalled, the
-        <br />
-        &quot;Installed&quot; status won&apos;t be updated.
-      </>
-    ),
-  },
-  pending: {
-    displayName: "Pending",
-    iconName: "pending-outline",
-    tooltip: (
-      <>
-        Fleet is installing/uninstalling or will
-        <br />
-        do so when the host comes online.
-      </>
-    ),
-  },
-  failed: {
-    displayName: "Failed",
-    iconName: "error",
-    tooltip: (
-      <>
-        These hosts failed to install/uninstall software.
-        <br />
-        Click on a host to view error(s).
-      </>
-    ),
-  },
-};
 
 interface IActionsDropdownProps {
   installerType: "package" | "vpp";

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwareSummaryCard/TitleVersionsTable/TitleVersionsTableConfig.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwareSummaryCard/TitleVersionsTable/TitleVersionsTableConfig.tsx
@@ -1,9 +1,6 @@
 import React from "react";
 
-import {
-  ISoftwareTitleVersion,
-  ISoftwareVulnerability,
-} from "interfaces/software";
+import { ISoftwareTitleVersion } from "interfaces/software";
 import PATHS from "router/paths";
 import { getPathWithQueryParams } from "utilities/url";
 

--- a/frontend/pages/SoftwarePage/components/forms/PackageForm/PackageForm.tsx
+++ b/frontend/pages/SoftwarePage/components/forms/PackageForm/PackageForm.tsx
@@ -11,7 +11,7 @@ import {
 import getDefaultInstallScript from "utilities/software_install_scripts";
 import getDefaultUninstallScript from "utilities/software_uninstall_scripts";
 import { ILabelSummary } from "interfaces/label";
-import { PackageType } from "interfaces/package_type";
+
 import { SoftwareCategory } from "interfaces/software";
 
 import Button from "components/buttons/Button";

--- a/frontend/pages/SoftwarePage/components/icons/Icon.stories.tsx
+++ b/frontend/pages/SoftwarePage/components/icons/Icon.stories.tsx
@@ -12,7 +12,7 @@ type IconWrapperProps = Pick<ISoftware, "name" | "source"> & {
   selection?: string;
 };
 
-const IconWrapper: React.FC<IconWrapperProps> = ({ selection, ...props }) => {
+const IconWrapper: React.FC<IconWrapperProps> = ({ ...props }) => {
   const Icon = getMatchedSoftwareIcon(props);
   return <Icon />;
 };

--- a/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/AppleBusinessManagerPage/components/DeleteAbmModal/DeleteAbmModal.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/AppleBusinessManagerPage/components/DeleteAbmModal/DeleteAbmModal.tsx
@@ -1,7 +1,6 @@
 import React, { useCallback, useContext, useState } from "react";
 
 import mdmAbmAPI from "services/entities/mdm_apple_bm";
-import { IMdmAbmToken } from "interfaces/mdm";
 import { NotificationContext } from "context/notification";
 
 import Button from "components/buttons/Button";

--- a/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/AppleMdmPage/components/content/ApplePushCertInfo.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/AppleMdmPage/components/content/ApplePushCertInfo.tsx
@@ -5,7 +5,6 @@ import { IMdmApple } from "interfaces/mdm";
 import { readableDate } from "utilities/helpers";
 
 import Button from "components/buttons/Button";
-import GitOpsModeTooltipWrapper from "components/GitOpsModeTooltipWrapper";
 
 interface IApplePushCertInfoProps {
   baseClass: string;

--- a/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/VppPage/components/AddVppModal/AddVppModal.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/VppPage/components/AddVppModal/AddVppModal.tsx
@@ -6,7 +6,6 @@ import mdmAppleAPI from "services/entities/mdm_apple";
 import Modal from "components/Modal";
 import Button from "components/buttons/Button";
 import FileUploader from "components/FileUploader";
-import GitOpsModeTooltipWrapper from "components/GitOpsModeTooltipWrapper";
 
 import VppSetupSteps from "../VppSetupSteps";
 import { getErrorMessage } from "./helpers";

--- a/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/VppPage/components/RenewVppModal/RenewVppModal.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/VppPage/components/RenewVppModal/RenewVppModal.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useContext, useCallback } from "react";
 
 import { NotificationContext } from "context/notification";
-import { getErrorReason } from "interfaces/errors";
+
 import mdmAppleAPI from "services/entities/mdm_apple";
 
 import Button from "components/buttons/Button";

--- a/frontend/pages/admin/OrgSettingsPage/cards/Advanced/Advanced.tsx
+++ b/frontend/pages/admin/OrgSettingsPage/cards/Advanced/Advanced.tsx
@@ -83,8 +83,6 @@ const Advanced = ({
   handleSubmit,
   isUpdatingSettings,
 }: IAppConfigFormProps): JSX.Element => {
-  const gitOpsModeEnabled = appConfig.gitops.gitops_mode_enabled;
-
   const [formData, setFormData] = useState<IAdvancedConfigFormData>({
     ssoUserURL: appConfig.sso_settings?.sso_server_url || "",
     mdmAppleServerURL: appConfig.mdm?.apple_server_url || "",

--- a/frontend/pages/hosts/details/cards/Software/SelfService/SelfService.tsx
+++ b/frontend/pages/hosts/details/cards/Software/SelfService/SelfService.tsx
@@ -861,8 +861,6 @@ const SoftwareSelfService = ({
         <UninstallSoftwareModal
           softwareId={selectedSoftware.current.softwareId}
           softwareName={selectedSoftware.current.softwareName}
-          softwareInstallerType={selectedSoftware.current.softwareInstallerType}
-          version={selectedSoftware.current.version}
           token={deviceToken}
           onExit={onExitUninstallSoftwareModal}
           onSuccess={onSuccessUninstallSoftwareModal}

--- a/frontend/pages/hosts/details/cards/Software/SelfService/UninstallSoftwareModal/UninstallSoftwareModal.tsx
+++ b/frontend/pages/hosts/details/cards/Software/SelfService/UninstallSoftwareModal/UninstallSoftwareModal.tsx
@@ -2,19 +2,15 @@ import React, { useCallback, useContext, useState } from "react";
 
 import deviceUserAPI from "services/entities/device_user";
 import { NotificationContext } from "context/notification";
-import { LEARN_MORE_ABOUT_BASE_LINK } from "utilities/constants";
 
 import Modal from "components/Modal";
 import Button from "components/buttons/Button";
-import CustomLink from "components/CustomLink";
 
 const baseClass = "uninstall-software-modal";
 
 interface IUninstallSoftwareModalProps {
   softwareId: number;
   softwareName?: string;
-  softwareInstallerType?: string;
-  version?: string;
   token: string;
   onExit: () => void;
   onSuccess: () => void;
@@ -23,8 +19,6 @@ interface IUninstallSoftwareModalProps {
 const UninstallSoftwareModal = ({
   softwareId,
   softwareName,
-  softwareInstallerType,
-  version,
   token,
   onExit,
   onSuccess,

--- a/frontend/pages/policies/ManagePoliciesPage/components/CalendarEventsModal/CalendarEventsModal.tests.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/components/CalendarEventsModal/CalendarEventsModal.tests.tsx
@@ -2,7 +2,7 @@ import React from "react";
 
 import { http, HttpResponse } from "msw";
 import { noop } from "lodash";
-import { fireEvent, screen } from "@testing-library/react";
+import { screen } from "@testing-library/react";
 import { baseUrl, createCustomRenderer } from "test/test-utils";
 import createMockPolicy from "__mocks__/policyMock";
 import mockServer from "test/mock-server";

--- a/frontend/pages/policies/PolicyPage/components/PolicyErrorsTable/PolicyErrorsTable.tsx
+++ b/frontend/pages/policies/PolicyPage/components/PolicyErrorsTable/PolicyErrorsTable.tsx
@@ -16,14 +16,12 @@ interface IPolicyErrorsTableProps {
   errorsList: ICampaignError[];
   isLoading: boolean;
   resultsTitle?: string;
-  canAddOrDeletePolicy?: boolean;
 }
 
 const PolicyErrorsTable = ({
   errorsList,
   isLoading,
   resultsTitle,
-  canAddOrDeletePolicy,
 }: IPolicyErrorsTableProps): JSX.Element => {
   return (
     <div className={baseClass}>

--- a/frontend/pages/policies/PolicyPage/components/PolicyResultsTable/PolicyResultsTable.tsx
+++ b/frontend/pages/policies/PolicyPage/components/PolicyResultsTable/PolicyResultsTable.tsx
@@ -16,14 +16,12 @@ interface IPolicyResultsTableProps {
   hostResponses: IPolicyHostResponse[];
   isLoading: boolean;
   resultsTitle?: string;
-  canAddOrDeletePolicy?: boolean;
 }
 
 const PolicyResultsTable = ({
   hostResponses,
   isLoading,
   resultsTitle,
-  canAddOrDeletePolicy,
 }: IPolicyResultsTableProps): JSX.Element => {
   return (
     <div className={baseClass}>

--- a/frontend/pages/policies/PolicyPage/components/SaveNewPolicyModal/SaveNewPolicyModal.tests.tsx
+++ b/frontend/pages/policies/PolicyPage/components/SaveNewPolicyModal/SaveNewPolicyModal.tests.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 import { screen, waitFor } from "@testing-library/react";
 import { createCustomRenderer } from "test/test-utils";
-import createMockQuery from "__mocks__/queryMock";
 import createMockUser from "__mocks__/userMock";
 import createMockConfig from "__mocks__/configMock";
 import userEvent from "@testing-library/user-event";

--- a/frontend/pages/queries/ManageQueriesPage/components/QueriesTable/QueriesTable.tests.tsx
+++ b/frontend/pages/queries/ManageQueriesPage/components/QueriesTable/QueriesTable.tests.tsx
@@ -408,7 +408,7 @@ describe("QueriesTable", () => {
       },
     });
 
-    const { container, user } = render(
+    const { user } = render(
       <QueriesTable
         queries={[...testTeamQueries, ...testGlobalQueries]}
         totalQueriesCount={4}

--- a/frontend/pages/queries/details/components/QueryReport/QueryReport.tsx
+++ b/frontend/pages/queries/details/components/QueryReport/QueryReport.tsx
@@ -45,7 +45,7 @@ const QueryReport = ({
   queryReport,
   isClipped,
 }: IQueryReportProps): JSX.Element => {
-  const { lastEditedQueryName, lastEditedQueryBody } = useContext(QueryContext);
+  const { lastEditedQueryName } = useContext(QueryContext);
 
   const [filteredResults, setFilteredResults] = useState<Row[]>(
     flattenResults(queryReport?.results || [])

--- a/frontend/pages/queries/edit/components/DiscardDataOption/DiscardDataOption.tsx
+++ b/frontend/pages/queries/edit/components/DiscardDataOption/DiscardDataOption.tsx
@@ -1,4 +1,3 @@
-import Card from "components/Card";
 import Checkbox from "components/forms/fields/Checkbox";
 import Icon from "components/Icon";
 import InfoBanner from "components/InfoBanner";

--- a/frontend/pages/queries/edit/components/EditQueryForm/EditQueryForm.tests.tsx
+++ b/frontend/pages/queries/edit/components/EditQueryForm/EditQueryForm.tests.tsx
@@ -14,7 +14,6 @@ import createMockQuery from "__mocks__/queryMock";
 import createMockUser from "__mocks__/userMock";
 import createMockConfig from "__mocks__/configMock";
 
-import queryAPI from "services/entities/queries";
 import EditQueryForm from "./EditQueryForm";
 
 jest.mock("services/entities/queries");

--- a/frontend/services/entities/scripts.ts
+++ b/frontend/services/entities/scripts.ts
@@ -1,8 +1,6 @@
 import { IHostScript, IScript, ScriptBatchStatus } from "interfaces/script";
 import sendRequest from "services";
 
-import { createMockBatchScriptSummary } from "__mocks__/scriptMock";
-
 import endpoints from "utilities/endpoints";
 import { buildQueryStringFromParams } from "utilities/url";
 import { PaginationMeta } from "./common";

--- a/frontend/utilities/date_format/index.ts
+++ b/frontend/utilities/date_format/index.ts
@@ -1,4 +1,4 @@
-import { format, formatDistanceToNow, parseISO } from "date-fns";
+import { formatDistanceToNow, parseISO } from "date-fns";
 import { formatInTimeZone } from "date-fns-tz";
 
 /** Utility to create a string from a date in this format:


### PR DESCRIPTION
## Description
- Clean up 41 low hanging fruit lint js warnings, all unused variables

## Screenshot of fixes
run `make lint-js`
Before:
<img width="545" height="231" alt="Screenshot 2025-08-19 at 12 42 38 PM" src="https://github.com/user-attachments/assets/c48c37dd-31a6-4b22-bef7-5639e876a255" />

After:
<img width="544" height="340" alt="Screenshot 2025-08-19 at 12 46 37 PM" src="https://github.com/user-attachments/assets/0ebed954-2183-444a-9df5-9a1c8a1f650e" />
