### PR TITLE
Use proper prefix for user_failed_login activity

### DIFF
--- a/changes/31343-blank-email-on-failed-login-activity
+++ b/changes/31343-blank-email-on-failed-login-activity
@@ -1,0 +1,1 @@
+* Fixed the message rendered from user_failed_login global activities on the Activity feed if the email is not specified.

--- a/frontend/pages/DashboardPage/cards/ActivityFeed/GlobalActivityItem/GlobalActivityItem.tests.tsx
+++ b/frontend/pages/DashboardPage/cards/ActivityFeed/GlobalActivityItem/GlobalActivityItem.tests.tsx
@@ -276,7 +276,21 @@ describe("Activity Feed", () => {
       })
     ).toBeInTheDocument();
     expect(
-      screen.getByText("foo@example.com", { exact: false })
+      screen.getByText("foo@example.com", {
+        exact: false,
+      })
+    ).toBeInTheDocument();
+  });
+
+  it("renders a user_failed_login without an email", () => {
+    const activity = createMockActivity({
+      type: ActivityType.UserFailedLogin,
+      details: { email: "", public_ip: "192.168.0.1" },
+    });
+    render(<GlobalActivityItem activity={activity} isPremiumTier />);
+
+    expect(
+      screen.getByText("Somebody failed", { exact: false })
     ).toBeInTheDocument();
   });
 

--- a/frontend/pages/DashboardPage/cards/ActivityFeed/GlobalActivityItem/GlobalActivityItem.tsx
+++ b/frontend/pages/DashboardPage/cards/ActivityFeed/GlobalActivityItem/GlobalActivityItem.tsx
@@ -173,10 +173,19 @@ const TAGGED_TEMPLATES = {
     );
   },
   userFailedLogin: (activity: IActivity) => {
+    const { email, public_ip } = activity.details || {};
+
+    const actor = email ? (
+      <>
+        Somebody using <b>{email}</b>
+      </>
+    ) : (
+      <>Somebody</>
+    );
+
     return (
       <>
-        Somebody using <b>{activity.details?.email}</b> failed to log in from
-        public IP {activity.details?.public_ip}.
+        {actor} failed to log in from public IP {public_ip}.
       </>
     );
   },


### PR DESCRIPTION
For #31343

Fixed the message rendered from user_failed_login global activities on the Activity feed if the email is not specified.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [X] Added/updated automated tests
- [X] QA'd all new/changed functionality manually