### PR TITLE
On lock, drop GDM Ubuntu into text mode to work around blank/unresponsive screen.

### DIFF
--- a/changes/31291-linux-lock-script
+++ b/changes/31291-linux-lock-script
@@ -1,0 +1,1 @@
+Linux lock script on Ubuntu with GDM now switches UI to text mode to work around GUI issues.

--- a/ee/server/service/embedded_scripts/linux_lock.sh
+++ b/ee/server/service/embedded_scripts/linux_lock.sh
@@ -16,7 +16,7 @@ disable_autologin() {
     # Add similar cases for other display managers if needed
 }
 
-# Disable automatic login
+# Disable automatic login first
 disable_autologin
 
 # Loop through all users in /etc/passwd
@@ -37,13 +37,66 @@ for user in $logged_in; do
     pkill -KILL -u "$user"
 done
 
-# Create the pam_nologin file
+# Now that users are logged out, check if we have Ubuntu with GDM
+# Ubuntu with GDM has issues with /etc/nologin causing black/unresponsive screens
+# This issue does not occur on Fedora or other distros
+# Although we've only seen it on Ubuntu 24.04, we are doing it for all Ubuntu versions to be safe.
+NEEDS_REBOOT=0
+if [ -f /etc/os-release ] && grep -qi ubuntu /etc/os-release; then
+    if systemctl is-active --quiet gdm3 || systemctl is-active --quiet gdm; then
+        echo "Ubuntu with GDM detected - will reboot to text mode to avoid black screen issue"
+        
+        # Store current target for restoration during unlock
+        systemctl get-default > /etc/fleet.systemd-target.backup 2>/dev/null
+        
+        # Switch default to text mode for next boot
+        systemctl set-default multi-user.target
+        
+        # Mark that we switched to text mode
+        touch /etc/fleet.text-mode-lock
+        
+        # Set flag to reboot after creating lock files
+        NEEDS_REBOOT=1
+    fi
+fi
+
+# Create the pam_nologin files with our custom message
+# Both /etc/nologin and /run/nologin to ensure the message is shown
 echo "Locked by administrator" > /etc/nologin
+echo "Locked by administrator" > /run/nologin
 
 # Disable systemd-user-sessions, a service that deletes /etc/nologin
+# Although we re-create /etc/nologin in another systemd service,
+# we are doing this to prevent a race condition (security hole) where /etc/nologin is deleted
+# before we create it.
 if [ -f /usr/lib/systemd/system/systemd-user-sessions.service ]; then
     systemctl mask systemd-user-sessions
     systemctl daemon-reload
 fi
 
+# Create a systemd service to recreate nologin files on boot
+# This ensures our message persists even after systemd-user-sessions runs
+cat > /etc/systemd/system/fleet-lock-message.service << 'EOF'
+[Unit]
+Description=Fleet Lock Message
+After=systemd-user-sessions.service
+Before=getty.target gdm.service gdm3.service lightdm.service display-manager.service
+
+[Service]
+Type=oneshot
+ExecStart=/bin/sh -c 'echo "Locked by administrator" > /run/nologin; echo "Locked by administrator" > /etc/nologin'
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target graphical.target
+EOF
+
+systemctl enable fleet-lock-message.service 2>/dev/null
+
 echo "All non-root users have been logged out and their accounts locked."
+
+# Reboot if we switched Ubuntu+GDM to text mode
+if [ "$NEEDS_REBOOT" = "1" ]; then
+    echo "Rebooting to complete lock process..."
+    reboot
+fi

--- a/ee/server/service/embedded_scripts/linux_lock.sh
+++ b/ee/server/service/embedded_scripts/linux_lock.sh
@@ -65,6 +65,19 @@ fi
 echo "Locked by administrator" > /etc/nologin
 echo "Locked by administrator" > /run/nologin
 
+# Set a GDM banner for any system with GDM to make the lock visible
+# GDM GUI doesn't always display PAM nologin messages, so we need this banner
+if systemctl is-active --quiet gdm || systemctl is-active --quiet gdm3; then
+    echo "Setting GDM banner for lock notification"
+    mkdir -p /etc/dconf/db/gdm.d
+    cat > /etc/dconf/db/gdm.d/01-fleet-lock-banner << 'EOF'
+[org/gnome/login-screen]
+banner-message-enable=true
+banner-message-text='System is locked by administrator'
+EOF
+    dconf update 2>/dev/null || true
+fi
+
 # Disable systemd-user-sessions, a service that deletes /etc/nologin
 # Although we re-create /etc/nologin in another systemd service,
 # we are doing this to prevent a race condition (security hole) where /etc/nologin is deleted

--- a/ee/server/service/embedded_scripts/linux_lock.sh
+++ b/ee/server/service/embedded_scripts/linux_lock.sh
@@ -70,7 +70,8 @@ echo "Locked by administrator" > /run/nologin
 if systemctl is-active --quiet gdm || systemctl is-active --quiet gdm3; then
     echo "Setting GDM banner for lock notification"
     mkdir -p /etc/dconf/db/gdm.d
-    cat > /etc/dconf/db/gdm.d/01-fleet-lock-banner << 'EOF'
+    # Use 99- prefix to ensure high priority (overrides lower numbers)
+    cat > /etc/dconf/db/gdm.d/99-fleet-lock-banner << 'EOF'
 [org/gnome/login-screen]
 banner-message-enable=true
 banner-message-text='System is locked by administrator'

--- a/ee/server/service/embedded_scripts/linux_unlock.sh
+++ b/ee/server/service/embedded_scripts/linux_unlock.sh
@@ -56,22 +56,10 @@ if [ -f /etc/fleet.text-mode-lock ]; then
     rm /etc/fleet.text-mode-lock
     
     # System needs reboot to properly restore GUI
-    echo "Rebooting to restore graphical interface"
-    reboot
-else
-    # For Ubuntu systems with GDM that weren't switched to text mode (older Fleet versions):
-    # When we lock a machine using /etc/nologin, GDM gets stuck with a black screen.
-    # This didn't used to be the case on Ubuntu 22.04. This bug doesn't affect other 
-    # login managers such as lightdm, and doesn't occur on Fedora.
-    #
-    # For backward compatibility with systems locked before the text-mode fix,
-    # we still need to reboot Ubuntu+GDM systems to restore the login screen.
-    if [ -f /etc/os-release ] && grep -qi ubuntu /etc/os-release; then
-        if systemctl is-active --quiet gdm3 || systemctl is-active --quiet gdm; then
-            echo "Ubuntu with GDM detected - rebooting to restore login screen"
-            reboot
-        fi
-    fi
 fi
 
 echo "All non-root users have been unlocked."
+
+# Although rebooting is not strictly necessary for all cases, we've seen some UI issues that
+# can be resolved by rebooting. For example, the password prompt is not fully visible in LightDM+Ubuntu24.04
+reboot

--- a/ee/server/service/embedded_scripts/linux_unlock.sh
+++ b/ee/server/service/embedded_scripts/linux_unlock.sh
@@ -20,8 +20,16 @@ do
     fi
 done
 
-# Remove the pam_nologin file
+# Remove the pam_nologin files
 [ -f /etc/nologin ] && rm /etc/nologin
+[ -f /run/nologin ] && rm /run/nologin
+
+# Remove our custom lock message service
+if [ -f /etc/systemd/system/fleet-lock-message.service ]; then
+    systemctl disable fleet-lock-message.service 2>/dev/null
+    rm /etc/systemd/system/fleet-lock-message.service
+    systemctl daemon-reload
+fi
 
 # Enable systemd-user-sessions, a service that deletes /etc/nologin
 if [ -f /usr/lib/systemd/system/systemd-user-sessions.service ]; then
@@ -30,14 +38,40 @@ if [ -f /usr/lib/systemd/system/systemd-user-sessions.service ]; then
     /usr/lib/systemd/systemd-user-sessions start
 fi
 
-# TODO this should be re-checked and possibly removed in the future.
-#
-# When we lock a machine using /etc/nologin, GDM seems to get stuck in
-# a state where the screen stays black. This didn't used to be the
-# case on Ubuntu 22.04. This bug doesn't affect other login managers
-# such as lightdm.
-#
-# Because of a bug, likely in GDM on Ubuntu after 22.04, we have to reboot the
-# machine to get the login screen back. Note this bug does not occur
-# in Fedora
-reboot
+# Check if we switched to text mode during lock and restore GUI if needed
+if [ -f /etc/fleet.text-mode-lock ]; then
+    echo "Restoring graphical mode"
+    
+    # Restore the original systemd target
+    if [ -f /etc/fleet.systemd-target.backup ]; then
+        TARGET=$(cat /etc/fleet.systemd-target.backup)
+        systemctl set-default "$TARGET" 2>/dev/null
+        rm /etc/fleet.systemd-target.backup
+    else
+        # Default to graphical target if no backup found
+        systemctl set-default graphical.target
+    fi
+    
+    # Clean up marker file
+    rm /etc/fleet.text-mode-lock
+    
+    # System needs reboot to properly restore GUI
+    echo "Rebooting to restore graphical interface"
+    reboot
+else
+    # For Ubuntu systems with GDM that weren't switched to text mode (older Fleet versions):
+    # When we lock a machine using /etc/nologin, GDM gets stuck with a black screen.
+    # This didn't used to be the case on Ubuntu 22.04. This bug doesn't affect other 
+    # login managers such as lightdm, and doesn't occur on Fedora.
+    #
+    # For backward compatibility with systems locked before the text-mode fix,
+    # we still need to reboot Ubuntu+GDM systems to restore the login screen.
+    if [ -f /etc/os-release ] && grep -qi ubuntu /etc/os-release; then
+        if systemctl is-active --quiet gdm3 || systemctl is-active --quiet gdm; then
+            echo "Ubuntu with GDM detected - rebooting to restore login screen"
+            reboot
+        fi
+    fi
+fi
+
+echo "All non-root users have been unlocked."

--- a/ee/server/service/embedded_scripts/linux_unlock.sh
+++ b/ee/server/service/embedded_scripts/linux_unlock.sh
@@ -24,6 +24,13 @@ done
 [ -f /etc/nologin ] && rm /etc/nologin
 [ -f /run/nologin ] && rm /run/nologin
 
+# Remove GDM banner if we set one
+if [ -f /etc/dconf/db/gdm.d/01-fleet-lock-banner ]; then
+    echo "Removing GDM lock banner"
+    rm /etc/dconf/db/gdm.d/01-fleet-lock-banner
+    dconf update 2>/dev/null || true
+fi
+
 # Remove our custom lock message service
 if [ -f /etc/systemd/system/fleet-lock-message.service ]; then
     systemctl stop fleet-lock-message.service 2>/dev/null || true

--- a/ee/server/service/embedded_scripts/linux_unlock.sh
+++ b/ee/server/service/embedded_scripts/linux_unlock.sh
@@ -26,6 +26,7 @@ done
 
 # Remove our custom lock message service
 if [ -f /etc/systemd/system/fleet-lock-message.service ]; then
+    systemctl stop fleet-lock-message.service 2>/dev/null || true
     systemctl disable fleet-lock-message.service 2>/dev/null
     rm /etc/systemd/system/fleet-lock-message.service
     systemctl daemon-reload

--- a/ee/server/service/embedded_scripts/linux_unlock.sh
+++ b/ee/server/service/embedded_scripts/linux_unlock.sh
@@ -25,9 +25,9 @@ done
 [ -f /run/nologin ] && rm /run/nologin
 
 # Remove GDM banner if we set one
-if [ -f /etc/dconf/db/gdm.d/01-fleet-lock-banner ]; then
+if [ -f /etc/dconf/db/gdm.d/99-fleet-lock-banner ]; then
     echo "Removing GDM lock banner"
-    rm /etc/dconf/db/gdm.d/01-fleet-lock-banner
+    rm /etc/dconf/db/gdm.d/99-fleet-lock-banner
     dconf update 2>/dev/null || true
 fi
 


### PR DESCRIPTION
Fixes #31291 

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing
- [x] QA'd all new/changed functionality manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Linux lock now switches Ubuntu + GDM systems to text mode to avoid GUI issues.
  - Persistent lock message is shown and survives reboots.
  - Unlock restores the original GUI mode automatically when applicable.

- Bug Fixes
  - Prevents black-screen behavior on Ubuntu + GDM after locking by rebooting to text mode.
  - Ensures lock message consistently appears across sessions.
  - Improves reliability of session handling during lock/unlock.

- Chores
  - Added change note describing the updated Linux lock behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->