### PR TITLE
Fix GitOps dry run issue with validating profiles with secrets

### DIFF
--- a/changes/31477-secrets-in-macos-profiles
+++ b/changes/31477-secrets-in-macos-profiles
@@ -1,0 +1,2 @@
+- Fixed `fleetctl gitops` issue uploading an Apple configuration profile with a FLEET_SECRET in a `<data>` field.
+- Added a check to disallow FLEET_SECRET variables in Apple configuration profile `<PayloadDisplayName>` fields for security.

--- a/cmd/fleetctl/fleetctl/testdata/gitops/lib/macos-password-secret.mobileconfig
+++ b/cmd/fleetctl/fleetctl/testdata/gitops/lib/macos-password-secret.mobileconfig
@@ -6,9 +6,9 @@
 		<array>
 			<dict>
 				<key>PayloadDescription</key>
-				<string>Configures Passcode settings</string>
+				<string>Configures Passcode settings - $FLEET_SECRET_NAME</string>
 				<key>PayloadDisplayName</key>
-				<string>$FLEET_SECRET_NAME</string>
+				<string>Passcode Policy</string>
 				<key>PayloadIdentifier</key>
 				<string>com.github.erikberglund.ProfileCreator.F7CF282E-D91B-44E9-922F-A719634F9C8E.com.apple.mobiledevice.passwordpolicy.231DFC90-D5A7-41B8-9246-564056048AC5</string>
 				<key>PayloadOrganization</key>

--- a/cmd/fleetctl/integrationtest/gitops/gitops_enterprise_integration_test.go
+++ b/cmd/fleetctl/integrationtest/gitops/gitops_enterprise_integration_test.go
@@ -1402,3 +1402,227 @@ policies: []
 	}
 	assert.True(t, foundProfile, "Profile should be uploaded to the server")
 }
+
+// TestFleetSecretInDataTag tests that FLEET_SECRET_ variables in <data> tags of Apple profiles
+// cause validation errors. This is a regression test for the issue where the XML parser
+// tries to interpret the variable name as base64 data.
+func (s *enterpriseIntegrationGitopsTestSuite) TestFleetSecretInDataTag() {
+	t := s.T()
+	tempDir := t.TempDir()
+	ctx := context.Background()
+
+	// Sample certificate in base64 format (this is a dummy test certificate)
+	testCertBase64 := `MIIDaTCCAlGgAwIBAgIUNQLezMUpmZK18DcLKt/XTRcLlK8wDQYJKoZIhvcNAQELBQAwRDEfMB0GA1UEAwwWRHVtbXkgVGVzdCBDZXJ0aWZpY2F0ZTEUMBIGA1UECgwLRXhhbXBsZSBPcmcxCzAJBgNVBAYTAlVTMB4XDTI1MDgxOTE3NDMwN1oXDTI2MDgxOTE3NDMwN1owRDEfMB0GA1UEAwwWRHVtbXkgVGVzdCBDZXJ0aWZpY2F0ZTEUMBIGA1UECgwLRXhhbXBsZSBPcmcxCzAJBgNVBAYTAlVTMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA07Np/w5WpFVLlMKX3dZSxwo+c2uwP2glTN0HA5c/6UOQRR9c91yoGGJsD4pfqhtIMSTFw7po3n/PjhGDe/WH+utK+ZIcD0nGD6SvmOggyoohHs81eIOjJAEJjxzhk7eLTVpUI2EnPe/24ei/dgkK59As9qQyH/y+CoR8JIYbNCJH5YLC2Pa44V84QWa2I5DHKUKrUXo9WsrRp1N1JjyaG/6hxLBJZ69e0QTrxxScboreRqVUR6oIEJRTchB+rDG5dxXzCQE6/F8N3qR76t23wd3CLmrcXoEc1P2P331Qzi0KXNXjdJFf0plmfRkT/IWgfM81Vfon1QwENwRSBNmPfQIDAQABo1MwUTAdBgNVHQ4EFgQU9q7SDfQRbJ31snRt2sZzx5sdEpYwHwYDVR0jBBgwFoAU9q7SDfQRbJ31snRt2sZzx5sdEpYwDwYDVR0TAQH/BAUwAwEB/zANBgkqhkiG9w0BAQsFAAOCAQEAYwH42JP45SnZejSF74OcYt8fp08jCWHOiFC3QEo3cROXVn6AWjEbzuQpOxRWF9EizNA83c4E6I+kQVztiuv9bUKGuLFeYb9lUZe8HOvH+j22MtGvZrDPygsJc8TavdkxAsu6OiNQZrYiCFzixkKS9b5p/1B93GBh62OFnV1nUBS8PzAZhOAyJ8UcEhr+GNzZG99/wOkcB0uwxmIb8x8sB3KnQ0qef/qnmgeWxlJlDc/SZ2/4PgtaluZ+noDfNPzaQn4eJNnBz0OTqZ9yuKALeE1WHk8U13zSdc1GNVLhXOrEHegPK5bBmA/lpIQ6HrkwUX7MJ3vK0AD3LjaTzXltDQ==`
+
+	// Create a test team first
+	team, err := s.DS.NewTeam(ctx, &fleet.Team{
+		Name: "Test Team for Secret in Data Tag",
+	})
+	require.NoError(t, err)
+
+	// Create a profile with $FLEET_SECRET_DUO_CERTIFICATE in a <data> tag
+	// This mimics the real-world scenario where the certificate should be base64 encoded
+	profileContent := `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+    <dict>
+        <key>PayloadContent</key>
+        <array>
+            <dict>
+                <key>PayloadType</key>
+                <string>com.apple.security.root</string>
+                <key>PayloadVersion</key>
+                <integer>1</integer>
+                <key>PayloadIdentifier</key>
+                <string>com.example.test.cert</string>
+                <key>PayloadUUID</key>
+                <string>11111111-2222-3333-4444-555555555555</string>
+                <key>PayloadDisplayName</key>
+                <string>Test Root Certificate</string>
+                <key>PayloadContent</key>
+                <data>$FLEET_SECRET_DUO_CERTIFICATE</data>
+            </dict>
+        </array>
+        <key>PayloadType</key>
+        <string>Configuration</string>
+        <key>PayloadVersion</key>
+        <integer>1</integer>
+        <key>PayloadIdentifier</key>
+        <string>com.example.test.profile</string>
+        <key>PayloadUUID</key>
+        <string>aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee</string>
+        <key>PayloadDisplayName</key>
+        <string>Test MDM Profile with Base64</string>
+    </dict>
+</plist>`
+
+	// Write the profile to a file
+	profilePath := filepath.Join(tempDir, "rootcert-secret.mobileconfig")
+	err = os.WriteFile(profilePath, []byte(profileContent), 0644)
+	require.NoError(t, err)
+
+	// Create a team GitOps config file that references the profile
+	teamConfig := fmt.Sprintf(`
+name: %s
+team_settings:
+  secrets:
+    - secret: test_secret
+agent_options:
+  config:
+    decorators:
+      load:
+        - SELECT uuid AS host_uuid FROM system_info;
+controls:
+  macos_settings:
+    custom_settings:
+      - path: %s
+queries:
+policies:
+software:
+`, team.Name, profilePath)
+
+	configPath := filepath.Join(tempDir, "team-gitops.yml")
+	err = os.WriteFile(configPath, []byte(teamConfig), 0644)
+	require.NoError(t, err)
+
+	// Create a GitOps user
+	gitOpsUser := s.createGitOpsUser(t)
+	fleetctlConfig := s.createFleetctlConfig(t, gitOpsUser)
+
+	// Set the environment variable with the base64-encoded certificate
+	t.Setenv("FLEET_SECRET_DUO_CERTIFICATE", testCertBase64)
+
+	// Run GitOps with dry-run - with the fix, this should now succeed
+	// The fix expands FLEET_SECRET_ variables for validation only, allowing the profile to be parsed
+	_, err = fleetctl.RunAppNoChecks([]string{"gitops", "--config", fleetctlConfig.Name(), "-f", configPath, "--dry-run"})
+
+	// With the fix in place:
+	// 1. The profile is loaded and FLEET_SECRET_ vars are expanded ONLY for validation
+	// 2. fleet.NewMDMAppleConfigProfile successfully validates the profile structure
+	// 3. The actual profile sent to the server still contains unexpanded $FLEET_SECRET_ variables
+	require.NoError(t, err, "GitOps dry-run should succeed with the fix")
+
+	// Also test without dry-run to confirm it works
+	_, err = fleetctl.RunAppNoChecks([]string{"gitops", "--config", fleetctlConfig.Name(), "-f", configPath})
+	require.NoError(t, err, "GitOps should succeed with the fix")
+
+	// Verify that the profile stored on the server still has the unexpanded variable
+	profiles, err := s.DS.ListMDMAppleConfigProfiles(ctx, &team.ID)
+	require.NoError(t, err)
+	require.Len(t, profiles, 1)
+	// The stored profile should still contain the unexpanded variable, not the actual secret
+	require.Contains(t, string(profiles[0].Mobileconfig), "$FLEET_SECRET_DUO_CERTIFICATE",
+		"Profile should still contain unexpanded FLEET_SECRET variable")
+}
+
+// TestFleetSecretInDataTagWorkaround tests a potential workaround where we use <string> instead of <data>
+func (s *enterpriseIntegrationGitopsTestSuite) TestFleetSecretInDataTagWorkaround() {
+	t := s.T()
+	ctx := context.Background()
+	tempDir := t.TempDir()
+
+	// Create a test team first
+	team, err := s.DS.NewTeam(ctx, &fleet.Team{
+		Name: "Test Team for Secret Workaround",
+	})
+	require.NoError(t, err)
+
+	testCertBase64 := `MIIDaTCCAlGgAwIBAgIUNQLezMUpmZK18DcLKt/XTRcLlK8wDQYJKoZIhvcNAQELBQAwRDEfMB0GA1UEAwwWRHVtbXkgVGVzdCBDZXJ0aWZpY2F0ZTEUMBIGA1UECgwLRXhhbXBsZSBPcmcxCzAJBgNVBAYTAlVTMB4XDTI1MDgxOTE3NDMwN1oXDTI2MDgxOTE3NDMwN1owRDEfMB0GA1UEAwwWRHVtbXkgVGVzdCBDZXJ0aWZpY2F0ZTEUMBIGA1UECgwLRXhhbXBsZSBPcmcxCzAJBgNVBAYTAlVTMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA07Np/w5WpFVLlMKX3dZSxwo+c2uwP2glTN0HA5c/6UOQRR9c91yoGGJsD4pfqhtIMSTFw7po3n/PjhGDe/WH+utK+ZIcD0nGD6SvmOggyoohHs81eIOjJAEJjxzhk7eLTVpUI2EnPe/24ei/dgkK59As9qQyH/y+CoR8JIYbNCJH5YLC2Pa44V84QWa2I5DHKUKrUXo9WsrRp1N1JjyaG/6hxLBJZ69e0QTrxxScboreRqVUR6oIEJRTchB+rDG5dxXzCQE6/F8N3qR76t23wd3CLmrcXoEc1P2P331Qzi0KXNXjdJFf0plmfRkT/IWgfM81Vfon1QwENwRSBNmPfQIDAQABo1MwUTAdBgNVHQ4EFgQU9q7SDfQRbJ31snRt2sZzx5sdEpYwHwYDVR0jBBgwFoAU9q7SDfQRbJ31snRt2sZzx5sdEpYwDwYDVR0TAQH/BAUwAwEB/zANBgkqhkiG9w0BAQsFAAOCAQEAYwH42JP45SnZejSF74OcYt8fp08jCWHOiFC3QEo3cROXVn6AWjEbzuQpOxRWF9EizNA83c4E6I+kQVztiuv9bUKGuLFeYb9lUZe8HOvH+j22MtGvZrDPygsJc8TavdkxAsu6OiNQZrYiCFzixkKS9b5p/1B93GBh62OFnV1nUBS8PzAZhOAyJ8UcEhr+GNzZG99/wOkcB0uwxmIb8x8sB3KnQ0qef/qnmgeWxlJlDc/SZ2/4PgtaluZ+noDfNPzaQn4eJNnBz0OTqZ9yuKALeE1WHk8U13zSdc1GNVLhXOrEHegPK5bBmA/lpIQ6HrkwUX7MJ3vK0AD3LjaTzXltDQ==`
+
+	// Using <string> instead of <data> as a workaround
+	// The certificate will need to be base64 encoded in the secret value
+	profileContent := `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+    <dict>
+        <key>PayloadContent</key>
+        <array>
+            <dict>
+                <key>PayloadType</key>
+                <string>com.apple.security.root</string>
+                <key>PayloadVersion</key>
+                <integer>1</integer>
+                <key>PayloadIdentifier</key>
+                <string>com.example.test.cert.workaround</string>
+                <key>PayloadUUID</key>
+                <string>22222222-3333-4444-5555-666666666666</string>
+                <key>PayloadDisplayName</key>
+                <string>Test Root Certificate Workaround</string>
+                <key>PayloadContent</key>
+                <string>$FLEET_SECRET_DUO_CERTIFICATE_WORKAROUND</string>
+            </dict>
+        </array>
+        <key>PayloadType</key>
+        <string>Configuration</string>
+        <key>PayloadVersion</key>
+        <integer>1</integer>
+        <key>PayloadIdentifier</key>
+        <string>com.example.test.profile.workaround</string>
+        <key>PayloadUUID</key>
+        <string>bbbbbbbb-cccc-dddd-eeee-ffffffffffff</string>
+        <key>PayloadDisplayName</key>
+        <string>Test MDM Profile Workaround</string>
+    </dict>
+</plist>`
+
+	// Write the profile to a file
+	profilePath := filepath.Join(tempDir, "rootcert-workaround.mobileconfig")
+	err = os.WriteFile(profilePath, []byte(profileContent), 0644)
+	require.NoError(t, err)
+
+	// Create a team GitOps config file that references the profile
+	teamConfig := fmt.Sprintf(`
+name: %s
+team_settings:
+  secrets:
+    - secret: test_secret
+agent_options:
+  config:
+    decorators:
+      load:
+        - SELECT uuid AS host_uuid FROM system_info;
+controls:
+  macos_settings:
+    custom_settings:
+      - path: %s
+queries:
+policies:
+software:
+`, team.Name, profilePath)
+
+	configPath := filepath.Join(tempDir, "team-gitops-workaround.yml")
+	err = os.WriteFile(configPath, []byte(teamConfig), 0644)
+	require.NoError(t, err)
+
+	// Create a GitOps user
+	gitOpsUser := s.createGitOpsUser(t)
+	fleetctlConfig := s.createFleetctlConfig(t, gitOpsUser)
+
+	// Set the environment variable with the base64-encoded certificate
+	t.Setenv("FLEET_SECRET_DUO_CERTIFICATE_WORKAROUND", testCertBase64)
+
+	// Run GitOps - this should work with the <string> tag
+	_ = fleetctl.RunAppForTest(t, []string{"gitops", "--config", fleetctlConfig.Name(), "-f", configPath})
+
+	// Verify the secret was saved
+	secrets, err := s.DS.GetSecretVariables(ctx, []string{"DUO_CERTIFICATE_WORKAROUND"})
+	require.NoError(t, err)
+	require.Len(t, secrets, 1)
+	require.Equal(t, "DUO_CERTIFICATE_WORKAROUND", secrets[0].Name)
+	require.Equal(t, testCertBase64, secrets[0].Value)
+
+	// Verify the profile was uploaded with the variable reference intact
+	profiles, err := s.DS.ListMDMAppleConfigProfiles(ctx, &team.ID)
+	require.NoError(t, err)
+
+	foundProfile := false
+	for _, profile := range profiles {
+		if profile.Identifier == "com.example.test.profile.workaround" {
+			foundProfile = true
+			// The variable should still be there, not substituted
+			require.Contains(t, string(profile.Mobileconfig), "$FLEET_SECRET_DUO_CERTIFICATE_WORKAROUND")
+			break
+		}
+	}
+	require.True(t, foundProfile, "Workaround profile should be uploaded to the server")
+}

--- a/cmd/fleetctl/integrationtest/gitops/gitops_integration_test.go
+++ b/cmd/fleetctl/integrationtest/gitops/gitops_integration_test.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/fleetdm/fleet/v4/cmd/fleetctl/fleetctl"
 	"github.com/fleetdm/fleet/v4/cmd/fleetctl/integrationtest"
-	"github.com/fleetdm/fleet/v4/pkg/spec"
 	"github.com/fleetdm/fleet/v4/server/config"
 	"github.com/fleetdm/fleet/v4/server/datastore/redis/redistest"
 	"github.com/fleetdm/fleet/v4/server/fleet"
@@ -220,106 +219,4 @@ func (s *integrationGitopsTestSuite) TestFleetGitopsWithFleetSecrets() {
 	winProfile, err := s.DS.GetMDMWindowsConfigProfile(ctx, windowsProfileUUID)
 	require.NoError(t, err)
 	assert.Contains(t, string(winProfile.SyncML), "${FLEET_SECRET_"+secretName2+"}")
-}
-
-// TestProfileValidationWithFleetSecretInDataTag directly tests that profiles with FLEET_SECRET_
-// variables in <data> tags fail validation
-func (s *integrationGitopsTestSuite) TestProfileValidationWithFleetSecretInDataTag() {
-	t := s.T()
-
-	// Create a profile with $FLEET_SECRET_DUO_CERTIFICATE in a <data> tag
-	profileContent := `<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-    <dict>
-        <key>PayloadContent</key>
-        <array>
-            <dict>
-                <key>PayloadType</key>
-                <string>com.apple.security.root</string>
-                <key>PayloadVersion</key>
-                <integer>1</integer>
-                <key>PayloadIdentifier</key>
-                <string>com.example.test.cert</string>
-                <key>PayloadUUID</key>
-                <string>11111111-2222-3333-4444-555555555555</string>
-                <key>PayloadDisplayName</key>
-                <string>Test Root Certificate</string>
-                <key>PayloadContent</key>
-                <data>$FLEET_SECRET_DUO_CERTIFICATE</data>
-            </dict>
-        </array>
-        <key>PayloadType</key>
-        <string>Configuration</string>
-        <key>PayloadVersion</key>
-        <integer>1</integer>
-        <key>PayloadIdentifier</key>
-        <string>com.example.test.profile</string>
-        <key>PayloadUUID</key>
-        <string>aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee</string>
-        <key>PayloadDisplayName</key>
-        <string>Test MDM Profile with Base64</string>
-    </dict>
-</plist>`
-
-	// Try to validate the profile - this should fail with "illegal base64 data"
-	// This is what happens in getProfilesContents at client.go:360
-	_, err := fleet.NewMDMAppleConfigProfile([]byte(profileContent), nil)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "illegal base64 data")
-}
-
-// TestProfileWithSecretInName tests that profiles with FLEET_SECRET_ variables in PayloadDisplayName are rejected
-func (s *integrationGitopsTestSuite) TestProfileWithSecretInName() {
-	t := s.T()
-
-	// Create a profile with $FLEET_SECRET_ in PayloadDisplayName - this should be rejected
-	profileContent := `<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-    <dict>
-        <key>PayloadType</key>
-        <string>Configuration</string>
-        <key>PayloadVersion</key>
-        <integer>1</integer>
-        <key>PayloadIdentifier</key>
-        <string>com.example.test.profile</string>
-        <key>PayloadUUID</key>
-        <string>aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee</string>
-        <key>PayloadDisplayName</key>
-        <string>Profile with $FLEET_SECRET_PASSWORD in name</string>
-    </dict>
-</plist>`
-
-	// This profile should parse fine without expansion
-	mc, err := fleet.NewMDMAppleConfigProfile([]byte(profileContent), nil)
-	require.NoError(t, err)
-
-	// But the name contains a FLEET_SECRET variable which should be rejected
-	require.Contains(t, mc.Name, "$FLEET_SECRET_PASSWORD")
-
-	// Verify that our validation would catch this BEFORE expansion
-	containsSecrets := len(fleet.ContainsPrefixVars(mc.Name, fleet.ServerSecretPrefix)) > 0
-	require.True(t, containsSecrets, "Name should be detected as containing secrets")
-
-	// Test the security vulnerability fix: secrets in name with expansion
-	t.Setenv("FLEET_SECRET_PASSWORD", "mysecretpassword")
-
-	// Expand the profile content to simulate what the vulnerable code would do
-	expandedContent, err := spec.ExpandEnvBytesIncludingSecrets([]byte(profileContent))
-	require.NoError(t, err)
-
-	// Parse the expanded content
-	mcExpanded, err := fleet.NewMDMAppleConfigProfile(expandedContent, nil)
-	require.NoError(t, err)
-
-	// CRITICAL: After expansion, the secret is no longer detectable in the name
-	expandedContainsSecrets := len(fleet.ContainsPrefixVars(mcExpanded.Name, fleet.ServerSecretPrefix)) > 0
-	require.False(t, expandedContainsSecrets, "Expanded name should NOT contain FLEET_SECRET_ pattern (this is the vulnerability)")
-
-	// The expanded name now contains the actual secret value
-	require.Contains(t, mcExpanded.Name, "mysecretpassword")
-	require.NotContains(t, mcExpanded.Name, "$FLEET_SECRET_PASSWORD")
-
-	// This demonstrates why we must check the ORIGINAL content before expansion
 }

--- a/pkg/spec/spec.go
+++ b/pkg/spec/spec.go
@@ -260,6 +260,7 @@ func ExpandEnvBytesIgnoreSecrets(b []byte) ([]byte, error) {
 // ExpandEnvBytesIncludingSecrets expands environment variables including FLEET_SECRET_ variables.
 // This should only be used for client-side validation where the actual secrets are needed temporarily.
 // The expanded secrets are never sent to the server.
+// Missing FLEET_SECRET_ variables do not fail the method; they are just not expanded.
 func ExpandEnvBytesIncludingSecrets(b []byte) ([]byte, error) {
 	s, err := expandEnv(string(b), secretsExpand)
 	if err != nil {

--- a/server/fleet/apple_mdm.go
+++ b/server/fleet/apple_mdm.go
@@ -271,7 +271,7 @@ func ValidateNoSecretsInProfileName(xmlContent []byte) error {
 		if len(match) > 1 {
 			displayName := string(match[1])
 			if len(ContainsPrefixVars(displayName, ServerSecretPrefix)) > 0 {
-				return errors.New("PayloadDisplayName cannot contain FLEET_SECRET variables")
+				return errors.New("PayloadDisplayName cannot contain FLEET_SECRET_ variables")
 			}
 		}
 	}

--- a/server/fleet/apple_mdm.go
+++ b/server/fleet/apple_mdm.go
@@ -271,7 +271,7 @@ func ValidateNoSecretsInProfileName(xmlContent []byte) error {
 		if len(match) > 1 {
 			displayName := string(match[1])
 			if len(ContainsPrefixVars(displayName, ServerSecretPrefix)) > 0 {
-				return errors.New("PayloadDisplayName cannot contain FLEET_SECRET_ variables")
+				return errors.New("PayloadDisplayName cannot contain FLEET_SECRET variables")
 			}
 		}
 	}

--- a/server/fleet/apple_mdm.go
+++ b/server/fleet/apple_mdm.go
@@ -5,6 +5,7 @@ import (
 	"crypto/md5" // nolint: gosec
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -270,7 +271,7 @@ func ValidateNoSecretsInProfileName(xmlContent []byte) error {
 		if len(match) > 1 {
 			displayName := string(match[1])
 			if len(ContainsPrefixVars(displayName, ServerSecretPrefix)) > 0 {
-				return fmt.Errorf("PayloadDisplayName cannot contain FLEET_SECRET variables")
+				return errors.New("PayloadDisplayName cannot contain FLEET_SECRET variables")
 			}
 		}
 	}

--- a/server/fleet/apple_mdm_test.go
+++ b/server/fleet/apple_mdm_test.go
@@ -654,3 +654,100 @@ func TestConfigurationProfileLabelEqual(t *testing.T) {
 		"Does cmp.Equal for ConfigurationProfileLabel needs to be updated for new/updated field(s)?")
 	assert.True(t, cmp.Equal(items[0], items[1]))
 }
+
+func TestValidateNoSecretsInProfileName(t *testing.T) {
+	testCases := []struct {
+		name       string
+		xmlContent string
+		expectErr  bool
+		errMsg     string
+	}{
+		{
+			name: "no secrets",
+			xmlContent: `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>PayloadDisplayName</key>
+    <string>Test Profile</string>
+    <key>PayloadIdentifier</key>
+    <string>com.test.profile</string>
+</dict>
+</plist>`,
+			expectErr: false,
+		},
+		{
+			name: "secret in PayloadDisplayName",
+			xmlContent: `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>PayloadDisplayName</key>
+    <string>Test $FLEET_SECRET_PASSWORD Profile</string>
+    <key>PayloadIdentifier</key>
+    <string>com.test.profile</string>
+</dict>
+</plist>`,
+			expectErr: true,
+			errMsg:    "PayloadDisplayName cannot contain FLEET_SECRET variables",
+		},
+		{
+			name: "multiple PayloadDisplayNames with secret in one",
+			xmlContent: `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>PayloadDisplayName</key>
+    <string>Main Profile</string>
+    <key>PayloadContent</key>
+    <array>
+        <dict>
+            <key>PayloadDisplayName</key>
+            <string>Sub Profile $FLEET_SECRET_KEY</string>
+        </dict>
+    </array>
+</dict>
+</plist>`,
+			expectErr: true,
+			errMsg:    "PayloadDisplayName cannot contain FLEET_SECRET variables",
+		},
+		{
+			name: "secret in other field not PayloadDisplayName",
+			xmlContent: `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>PayloadDisplayName</key>
+    <string>Test Profile</string>
+    <key>PayloadDescription</key>
+    <string>Description with $FLEET_SECRET_VALUE</string>
+</dict>
+</plist>`,
+			expectErr: false,
+		},
+		{
+			name: "whitespace in PayloadDisplayName value",
+			xmlContent: `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>PayloadDisplayName</key>
+    <string>   Test Profile   </string>
+</dict>
+</plist>`,
+			expectErr: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateNoSecretsInProfileName([]byte(tc.xmlContent))
+			if tc.expectErr {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tc.errMsg)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/server/service/apple_mdm.go
+++ b/server/service/apple_mdm.go
@@ -390,6 +390,11 @@ func (svc *Service) NewMDMAppleConfigProfile(ctx context.Context, teamID uint, r
 		})
 	}
 
+	// Check for secrets in profile name before expansion
+	if err := fleet.ValidateNoSecretsInProfileName(b); err != nil {
+		return nil, ctxerr.Wrap(ctx, fleet.NewInvalidArgumentError("profile", err.Error()))
+	}
+
 	// Expand and validate secrets in profile
 	expanded, secretsUpdatedAt, err := svc.ds.ExpandEmbeddedSecretsAndUpdatedAt(ctx, string(b))
 	if err != nil {
@@ -2593,6 +2598,11 @@ func (svc *Service) BatchSetMDMAppleProfiles(ctx context.Context, tmID *uint, tm
 			return ctxerr.Wrap(ctx,
 				fleet.NewInvalidArgumentError(fmt.Sprintf("profiles[%d]", i), "maximum configuration profile file size is 1 MB"),
 			)
+		}
+		// Check for secrets in profile name before expansion
+		if err := fleet.ValidateNoSecretsInProfileName(prof); err != nil {
+			return ctxerr.Wrap(ctx,
+				fleet.NewInvalidArgumentError(fmt.Sprintf("profiles[%d]", i), err.Error()))
 		}
 		// Expand profile for validation
 		expanded, secretsUpdatedAt, err := svc.ds.ExpandEmbeddedSecretsAndUpdatedAt(ctx, string(prof))

--- a/server/service/client_test.go
+++ b/server/service/client_test.go
@@ -720,6 +720,165 @@ func TestGetProfilesContents(t *testing.T) {
 			expectError: true,
 			wantErr:     "Couldn't edit macos_settings.custom_settings (bar.cfg): macOS configuration profiles must be .mobileconfig or .json files",
 		},
+		{
+			name:    "with FLEET_SECRET in data tag",
+			baseDir: tempDir,
+			macSetupFiles: [][2]string{
+				{"cert.mobileconfig", `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>PayloadContent</key>
+	<array>
+		<dict>
+			<key>PayloadType</key>
+			<string>com.apple.security.root</string>
+			<key>PayloadVersion</key>
+			<integer>1</integer>
+			<key>PayloadIdentifier</key>
+			<string>com.example.cert</string>
+			<key>PayloadUUID</key>
+			<string>11111111-2222-3333-4444-555555555555</string>
+			<key>PayloadDisplayName</key>
+			<string>Test Certificate</string>
+			<key>PayloadContent</key>
+			<data>$FLEET_SECRET_CERT_DATA</data>
+		</dict>
+	</array>
+	<key>PayloadType</key>
+	<string>Configuration</string>
+	<key>PayloadVersion</key>
+	<integer>1</integer>
+	<key>PayloadIdentifier</key>
+	<string>com.example.profile</string>
+	<key>PayloadUUID</key>
+	<string>aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee</string>
+	<key>PayloadDisplayName</key>
+	<string>Certificate Profile</string>
+</dict>
+</plist>`},
+			},
+			environment: map[string]string{
+				"FLEET_SECRET_CERT_DATA": "VGVzdENlcnREYXRhQmFzZTY0", // "TestCertDataBase64" in base64
+			},
+			expandEnv:   true,
+			expectError: false,
+			want: []fleet.MDMProfileBatchPayload{
+				{
+					Name: "Certificate Profile",
+					Contents: []byte(`<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>PayloadContent</key>
+	<array>
+		<dict>
+			<key>PayloadType</key>
+			<string>com.apple.security.root</string>
+			<key>PayloadVersion</key>
+			<integer>1</integer>
+			<key>PayloadIdentifier</key>
+			<string>com.example.cert</string>
+			<key>PayloadUUID</key>
+			<string>11111111-2222-3333-4444-555555555555</string>
+			<key>PayloadDisplayName</key>
+			<string>Test Certificate</string>
+			<key>PayloadContent</key>
+			<data>$FLEET_SECRET_CERT_DATA</data>
+		</dict>
+	</array>
+	<key>PayloadType</key>
+	<string>Configuration</string>
+	<key>PayloadVersion</key>
+	<integer>1</integer>
+	<key>PayloadIdentifier</key>
+	<string>com.example.profile</string>
+	<key>PayloadUUID</key>
+	<string>aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee</string>
+	<key>PayloadDisplayName</key>
+	<string>Certificate Profile</string>
+</dict>
+</plist>`),
+				},
+			},
+		},
+		{
+			name:    "with FLEET_SECRET in PayloadDisplayName - should reject",
+			baseDir: tempDir,
+			macSetupFiles: [][2]string{
+				{"secret_name.mobileconfig", `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>PayloadType</key>
+	<string>Configuration</string>
+	<key>PayloadVersion</key>
+	<integer>1</integer>
+	<key>PayloadIdentifier</key>
+	<string>com.example.profile</string>
+	<key>PayloadUUID</key>
+	<string>aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee</string>
+	<key>PayloadDisplayName</key>
+	<string>Profile $FLEET_SECRET_NAME</string>
+</dict>
+</plist>`},
+			},
+			environment: map[string]string{
+				"FLEET_SECRET_NAME": "SecretProfileName",
+			},
+			expandEnv:   true,
+			expectError: true,
+			wantErr:     "PayloadDisplayName cannot contain FLEET_SECRET variables",
+		},
+		{
+			name:    "with FLEET_VAR in profile - should not expand",
+			baseDir: tempDir,
+			macSetupFiles: [][2]string{
+				{"fleet_var.mobileconfig", `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>PayloadType</key>
+	<string>Configuration</string>
+	<key>PayloadVersion</key>
+	<integer>1</integer>
+	<key>PayloadIdentifier</key>
+	<string>com.example.profile</string>
+	<key>PayloadUUID</key>
+	<string>aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee</string>
+	<key>PayloadDisplayName</key>
+	<string>Profile with FLEET_VAR</string>
+	<key>SomeValue</key>
+	<string>$FLEET_VAR_HOST_END_USER_IDP_USERNAME</string>
+</dict>
+</plist>`},
+			},
+			expandEnv:   true,
+			expectError: false,
+			want: []fleet.MDMProfileBatchPayload{
+				{
+					Name: "Profile with FLEET_VAR",
+					Contents: []byte(`<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>PayloadType</key>
+	<string>Configuration</string>
+	<key>PayloadVersion</key>
+	<integer>1</integer>
+	<key>PayloadIdentifier</key>
+	<string>com.example.profile</string>
+	<key>PayloadUUID</key>
+	<string>aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee</string>
+	<key>PayloadDisplayName</key>
+	<string>Profile with FLEET_VAR</string>
+	<key>SomeValue</key>
+	<string>$FLEET_VAR_HOST_END_USER_IDP_USERNAME</string>
+</dict>
+</plist>`),
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/server/service/integration_mdm_profiles_test.go
+++ b/server/service/integration_mdm_profiles_test.go
@@ -93,9 +93,9 @@ func (s *integrationMDMTestSuite) TestAppleProfileManagement() {
 	<key>PayloadContent</key>
 	<array/>
 	<key>PayloadDisplayName</key>
-	<string>$FLEET_SECRET_INVALID</string>
+	<string>My profile</string>
 	<key>PayloadIdentifier</key>
-	<string>N3</string>
+	<string>$FLEET_SECRET_INVALID</string>
 	<key>PayloadType</key>
 	<string>Configuration</string>
 	<key>PayloadUUID</key>
@@ -109,6 +109,31 @@ func (s *integrationMDMTestSuite) TestAppleProfileManagement() {
 	res := s.Do("POST", "/api/v1/fleet/mdm/apple/profiles/batch", batchSetMDMAppleProfilesRequest{Profiles: [][]byte{invalidSecretsProfile}}, http.StatusUnprocessableEntity)
 	errMsg := extractServerErrorText(res.Body)
 	require.Contains(t, errMsg, "$FLEET_SECRET_INVALID")
+
+	invalidSecretsProfile = []byte(`
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>PayloadContent</key>
+	<array/>
+	<key>PayloadDisplayName</key>
+	<string>$FLEET_SECRET_INVALID</string>
+	<key>PayloadIdentifier</key>
+	<string>N3</string>
+	<key>PayloadType</key>
+	<string>Configuration</string>
+	<key>PayloadUUID</key>
+	<string>601E0B42-0989-4FAD-A61B-18656BA3670E</string>
+	<key>PayloadVersion</key>
+	<integer>1</integer>
+</dict>
+</plist>
+`)
+
+	res = s.Do("POST", "/api/v1/fleet/mdm/apple/profiles/batch", batchSetMDMAppleProfilesRequest{Profiles: [][]byte{invalidSecretsProfile}}, http.StatusUnprocessableEntity)
+	errMsg = extractServerErrorText(res.Body)
+	require.Contains(t, errMsg, "PayloadDisplayName cannot contain FLEET_SECRET variables")
 
 	// create a new team
 	tm, err := s.ds.NewTeam(ctx, &fleet.Team{Name: "batch_set_mdm_profiles"})
@@ -204,7 +229,6 @@ func (s *integrationMDMTestSuite) TestAppleProfileManagement() {
 	// Use secret variables in a profile
 	secretIdentifier := "secret-identifier-1"
 	secretType := "secret.type.1"
-	secretName := "secretName"
 	secretProfile := string(mobileconfigForTest("NS1", "IS1"))
 	req := createSecretVariablesRequest{
 		SecretVariables: []fleet.SecretVariable{
@@ -215,10 +239,6 @@ func (s *integrationMDMTestSuite) TestAppleProfileManagement() {
 			{
 				Name:  "FLEET_SECRET_TYPE",
 				Value: secretType,
-			},
-			{
-				Name:  "FLEET_SECRET_NAME",
-				Value: secretName,
 			},
 			{
 				Name:  "FLEET_SECRET_PROFILE",
@@ -233,7 +253,7 @@ func (s *integrationMDMTestSuite) TestAppleProfileManagement() {
 	teamProfiles = [][]byte{
 		mobileconfigForTest("N4", "I4"),
 		mobileconfigForTestWithContent("N5", "I5", "$FLEET_SECRET_IDENTIFIER", "${FLEET_SECRET_TYPE}",
-			"$FLEET_SECRET_NAME"),
+			"InnerName5"),
 		// The whole profile is one big secret.
 		[]byte("$FLEET_SECRET_PROFILE"),
 	}
@@ -253,7 +273,6 @@ func (s *integrationMDMTestSuite) TestAppleProfileManagement() {
 	// Manually replace the expected secret variables in the profile
 	wantTeamProfiles[1] = []byte(strings.ReplaceAll(string(wantTeamProfiles[1]), "$FLEET_SECRET_IDENTIFIER", secretIdentifier))
 	wantTeamProfiles[1] = []byte(strings.ReplaceAll(string(wantTeamProfiles[1]), "${FLEET_SECRET_TYPE}", secretType))
-	wantTeamProfiles[1] = []byte(strings.ReplaceAll(string(wantTeamProfiles[1]), "$FLEET_SECRET_NAME", secretName))
 	wantTeamProfiles[2] = []byte(secretProfile)
 	// verify that we should install the team profiles
 	s.signedProfilesMatch(wantTeamProfiles, installs)
@@ -272,12 +291,16 @@ func (s *integrationMDMTestSuite) TestAppleProfileManagement() {
 	require.Empty(t, removes)
 
 	// Change the secret variable and upload the profiles again. We should see the profile with updated secret installed.
-	secretName = "newSecretName"
+	secretType = "new.secret.type.1"
 	req = createSecretVariablesRequest{
 		SecretVariables: []fleet.SecretVariable{
 			{
-				Name:  "FLEET_SECRET_NAME",
-				Value: secretName, // changed
+				Name:  "FLEET_SECRET_IDENTIFIER",
+				Value: secretIdentifier, // did not change
+			},
+			{
+				Name:  "FLEET_SECRET_TYPE",
+				Value: secretType, // changed
 			},
 			{
 				Name:  "FLEET_SECRET_PROFILE",
@@ -297,7 +320,6 @@ func (s *integrationMDMTestSuite) TestAppleProfileManagement() {
 	wantTeamProfilesChanged[0] = []byte(strings.ReplaceAll(string(wantTeamProfilesChanged[0]), "$FLEET_SECRET_IDENTIFIER",
 		secretIdentifier))
 	wantTeamProfilesChanged[0] = []byte(strings.ReplaceAll(string(wantTeamProfilesChanged[0]), "${FLEET_SECRET_TYPE}", secretType))
-	wantTeamProfilesChanged[0] = []byte(strings.ReplaceAll(string(wantTeamProfilesChanged[0]), "$FLEET_SECRET_NAME", secretName))
 	// verify that we should install the team profiles
 	s.signedProfilesMatch(wantTeamProfilesChanged, installs)
 	wantTeamProfiles[1] = wantTeamProfilesChanged[0]
@@ -343,12 +365,16 @@ func (s *integrationMDMTestSuite) TestAppleProfileManagement() {
 	require.Empty(t, removes)
 
 	// Change the secret variable and upload the profiles again. We should see the profile with updated secret installed.
-	secretName = "new2SecretName"
+	secretType = "new2.secret.type.1"
 	req = createSecretVariablesRequest{
 		SecretVariables: []fleet.SecretVariable{
 			{
-				Name:  "FLEET_SECRET_NAME",
-				Value: secretName, // changed
+				Name:  "FLEET_SECRET_IDENTIFIER",
+				Value: secretIdentifier, // did not change
+			},
+			{
+				Name:  "FLEET_SECRET_TYPE",
+				Value: secretType, // changed
 			},
 			{
 				Name:  "FLEET_SECRET_PROFILE",
@@ -368,7 +394,6 @@ func (s *integrationMDMTestSuite) TestAppleProfileManagement() {
 	wantTeamProfilesChanged[0] = []byte(strings.ReplaceAll(string(wantTeamProfilesChanged[0]), "$FLEET_SECRET_IDENTIFIER",
 		secretIdentifier))
 	wantTeamProfilesChanged[0] = []byte(strings.ReplaceAll(string(wantTeamProfilesChanged[0]), "${FLEET_SECRET_TYPE}", secretType))
-	wantTeamProfilesChanged[0] = []byte(strings.ReplaceAll(string(wantTeamProfilesChanged[0]), "$FLEET_SECRET_NAME", secretName))
 	// verify that we should install the team profiles
 	s.signedProfilesMatch(wantTeamProfilesChanged, installs)
 	wantTeamProfiles[1] = wantTeamProfilesChanged[0]


### PR DESCRIPTION
Fixes #31477 

Docs PR: https://github.com/fleetdm/fleet/pull/32116

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - GitOps now supports FLEET_SECRET_ placeholders in macOS (.mobileconfig/.xml) profiles. Secrets are expanded only for validation, while remaining unexpanded in uploaded content.
  - Improved environment variable handling: non-secret vars expand as before; server-side secrets are preserved.
  - Validation enforces that profile display names cannot contain FLEET_SECRET_ values.

- Bug Fixes
  - Resolves validation issues when FLEET_SECRET_ appears in <data> tags by performing safe client-side expansion for validation.
  - More accurate error reporting during profile parsing and validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->