### PR TITLE
Fix flaky UI test for custom variables list

### DIFF
--- a/frontend/pages/ManageControlsPage/Secrets/Secrets.tests.tsx
+++ b/frontend/pages/ManageControlsPage/Secrets/Secrets.tests.tsx
@@ -60,7 +60,7 @@ describe("Custom variables", () => {
       },
       {
         name: "SECRET_DOS",
-        id: 1,
+        id: 2,
         created_at: new Date().toISOString(),
         updated_at: new Date().toISOString(),
       },
@@ -255,13 +255,14 @@ describe("Custom variables", () => {
           })
         ).toBeInTheDocument();
       });
+      await new Promise((resolve) => setTimeout(resolve, 250));
       await user.click(screen.getByRole("button", { name: "Delete" }));
       await waitFor(() => {
         expect(
           screen.queryByText(/Delete custom variable\?/)
         ).not.toBeInTheDocument();
         expect(screen.queryByText("SECRET_UNO")).not.toBeInTheDocument();
-        expect(screen.queryByText("SECRET_DOS")).not.toBeInTheDocument();
+        expect(screen.queryByText("SECRET_DOS")).toBeInTheDocument();
       });
     });
   });


### PR DESCRIPTION
for #32113 

# Details

Fixes a flaky UI test introduced with the Secrets page. The failure was due to some bugs in the test code (see comments).

