### PR TITLE
Document restriction on using `$FLEET_SECRET_*` variables in `PayloadDisplayName` for Apple MDM profiles.

### DIFF
--- a/articles/secrets-in-scripts-and-configuration-profiles.md
+++ b/articles/secrets-in-scripts-and-configuration-profiles.md
@@ -39,6 +39,7 @@ For macOS and Linux scripts, if a secret doesn't have the `$FLEET_SECRET_` prefi
 <plist version="1.0">
 <dict>
     <key>PayloadDisplayName</key>
+    <!-- Note: Do not use $FLEET_SECRET_ variables in PayloadDisplayName -->
     <string>Certificate PKCS12</string>
     <key>PayloadIdentifier</key>
     <string>com.example.certificate</string>
@@ -79,6 +80,7 @@ On subsequent GitOps syncs, if a secret variable used by a configuration profile
 
 ## Known limitations and issues
 
+- **Apple MDM profiles**: Fleet secret variables (`$FLEET_SECRET_*`) cannot be used in the `PayloadDisplayName` field of Apple configuration profiles. This field becomes the visible name of the profile and using secrets here could expose sensitive information. Place secrets in other fields like `PayloadDescription`, `Password`, or `PayloadContent` instead.
 - After changing a secret used by a Windows profile, that profile is currently not re-sent to the device when the GitHub action (or GitLab pipeline) runs: [story #27351](https://github.com/fleetdm/fleet/issues/27351)
 - Fleet does not hide the secret in script results. DO NOT print/echo your secrets to the console output.
 - There is no way to explicitly delete a secret variable. Instead, you can overwrite it with any value.

--- a/docs/Configuration/yaml-files.md
+++ b/docs/Configuration/yaml-files.md
@@ -384,6 +384,10 @@ For macOS configuration profiles, you can use any of Apple's [built-in variables
 
 Fleet also supports adding [GitHub](https://docs.github.com/en/actions/learn-github-actions/variables#defining-environment-variables-for-a-single-workflow) or [GitLab](https://docs.gitlab.com/ci/variables/) environment variables in your configuration profiles. Use `$ENV_VARIABLE` format. 
 
+Fleet also supports [Fleet secret variables](https://fleetdm.com/guides/secrets-in-scripts-and-configuration-profiles) (`$FLEET_SECRET_*`) in configuration profiles. These allow you to securely store sensitive values like API tokens or certificates. See the [secrets guide](https://fleetdm.com/guides/secrets-in-scripts-and-configuration-profiles) for detailed usage.
+
+> **Important for Apple profiles:** Fleet secret variables (`$FLEET_SECRET_*`) cannot be used in the `PayloadDisplayName` field. This field becomes the visible name of the profile and could expose sensitive information. Use secrets in other fields like `PayloadDescription`, `Password`, or `PayloadContent` instead.
+
 In Fleet Premium, you can use reserved variables beginning with `$FLEET_VAR_` (currently available only for Apple profiles). Fleet will populate these variables when profiles are sent to hosts. Supported variables are:
 
 - `$FLEET_VAR_NDES_SCEP_CHALLENGE`


### PR DESCRIPTION
Fixes #31477 

