### PR TITLE
Use PAT to trigger tests

### DIFF
--- a/.github/workflows/ingest-maintained-apps.yml
+++ b/.github/workflows/ingest-maintained-apps.yml
@@ -85,6 +85,7 @@ jobs:
         id: create-pr
         uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e #v7.0.8
         with:
+          token: ${{ secrets.FLEET_RELEASE_GITHUB_PAT }}
           base: main
           path: fleet
           branch: fma-${{ steps.date.outputs.date }}


### PR DESCRIPTION
FMA generated update PRs aren't triggering tests because they are generated using GITHUB_TOKEN.  Attempting to use a PAT here assuming it has the correct repo permissions. 