### PR TITLE
Prevent deadlocks by adding FOR UPDATE locks

### DIFF
--- a/changes/31173-fix-policy-deadlocks
+++ b/changes/31173-fix-policy-deadlocks
@@ -1,0 +1,1 @@
+Fix deadlocks when updating automations for 10+ policies at one time

--- a/server/datastore/mysql/hosts.go
+++ b/server/datastore/mysql/hosts.go
@@ -5749,7 +5749,8 @@ func updateHostIssuesFailingPolicies(ctx context.Context, tx sqlx.ExecerContext,
 	}
 
 	// For multiple hosts, lock policy_membership rows first to prevent deadlocks
-	lockPolicyStmt := `SELECT 1 FROM policy_membership WHERE host_id IN (?) FOR UPDATE`
+	// ORDER BY ensures locks are acquired in consistent order (host_id, then policy_id)
+	lockPolicyStmt := `SELECT 1 FROM policy_membership WHERE host_id IN (?) ORDER BY host_id, policy_id FOR UPDATE`
 
 	// Clear host_issues entries for hosts that are not in policy_membership
 	clearStmt := `

--- a/server/datastore/mysql/hosts.go
+++ b/server/datastore/mysql/hosts.go
@@ -5729,7 +5729,7 @@ func updateHostIssuesFailingPolicies(ctx context.Context, tx sqlx.ExecerContext,
 		stmt := `
 		INSERT INTO host_issues (host_id, failing_policies_count, total_issues_count)
 		SELECT host_id.id, COALESCE(SUM(!pm.passes), 0), COALESCE(SUM(!pm.passes), 0)
-			FROM policy_membership pm FOR UPDATE
+			FROM policy_membership pm
 			RIGHT JOIN (SELECT ? as id) as host_id
 			ON pm.host_id = host_id.id
 			GROUP BY host_id.id
@@ -5742,28 +5742,27 @@ func updateHostIssuesFailingPolicies(ctx context.Context, tx sqlx.ExecerContext,
 		return nil
 	}
 
+	// For multiple hosts, lock policy_membership rows first to prevent deadlocks
+	lockPolicyStmt := `SELECT 1 FROM policy_membership WHERE host_id IN (?) FOR UPDATE`
+
 	// Clear host_issues entries for hosts that are not in policy_membership
-	// Use FOR UPDATE to acquire exclusive locks on policy_membership rows early in the transaction.
-	// This prevents deadlocks by ensuring consistent lock ordering - all transactions that need
-	// to validate and update policy membership will wait in line rather than creating circular dependencies.
 	clearStmt := `
 	UPDATE host_issues
 	SET failing_policies_count = 0, total_issues_count = critical_vulnerabilities_count
 	WHERE host_id NOT IN (
 		SELECT host_id
 		FROM policy_membership
-		WHERE host_id IN (?) FOR UPDATE
+		WHERE host_id IN (?)
 	) AND host_id IN (?)`
 
 	// Insert/update host_issues entries for hosts that are in policy_membership.
 	// Initially, these two statements were combined into one statement using `SELECT ? AS id UNION ALL` approach to include the host IDs that
 	// were not in policy_membership (similar how the above query for 1 host works). However, in load testing we saw an error: Thread stack overrun: 242191 bytes used of a 262144 byte stack
-	// Use FOR UPDATE to maintain consistent lock ordering with the clearStmt above.
 	insertStmt := `
 	INSERT INTO host_issues (host_id, failing_policies_count, total_issues_count)
 	SELECT pm.host_id, COALESCE(SUM(!pm.passes), 0), COALESCE(SUM(!pm.passes), 0)
 		FROM policy_membership pm
-		WHERE pm.host_id IN (?) FOR UPDATE
+		WHERE pm.host_id IN (?)
 		GROUP BY pm.host_id
 	ON DUPLICATE KEY UPDATE
 		failing_policies_count = VALUES(failing_policies_count),
@@ -5778,8 +5777,17 @@ func updateHostIssuesFailingPolicies(ctx context.Context, tx sqlx.ExecerContext,
 		}
 		hostIDsBatch := hostIDs[start:end]
 
+		// First lock policy_membership rows to ensure consistent lock ordering
+		stmt, args, err := sqlx.In(lockPolicyStmt, hostIDsBatch)
+		if err != nil {
+			return ctxerr.Wrap(ctx, err, "building IN statement for locking policy_membership")
+		}
+		if _, err := tx.ExecContext(ctx, stmt, args...); err != nil {
+			return ctxerr.Wrap(ctx, err, "locking policy_membership rows")
+		}
+
 		// Zero out failing policies count for hosts that are not in policy_membership
-		stmt, args, err := sqlx.In(clearStmt, hostIDsBatch, hostIDsBatch)
+		stmt, args, err = sqlx.In(clearStmt, hostIDsBatch, hostIDsBatch)
 		if err != nil {
 			return ctxerr.Wrap(ctx, err, "building IN statement for clearing host failing policy issues")
 		}

--- a/server/datastore/mysql/hosts.go
+++ b/server/datastore/mysql/hosts.go
@@ -5748,6 +5748,10 @@ func updateHostIssuesFailingPolicies(ctx context.Context, tx sqlx.ExecerContext,
 		return nil
 	}
 
+	if len(hostIDs) == 1 {
+		return updateHostIssuesFailingPoliciesForSingleHost(ctx, tx, hostIDs[0])
+	}
+
 	// For multiple hosts, lock policy_membership rows first to prevent deadlocks
 	// ORDER BY ensures locks are acquired in consistent order (host_id, then policy_id)
 	lockPolicyStmt := `SELECT 1 FROM policy_membership WHERE host_id IN (?) ORDER BY host_id, policy_id FOR UPDATE`

--- a/server/datastore/mysql/policies_test.go
+++ b/server/datastore/mysql/policies_test.go
@@ -3290,7 +3290,7 @@ func testDeleteAllPolicyMemberships(t *testing.T, ds *Datastore) {
 	require.NoError(t, ds.writer(ctx).Get(&count, "select COUNT(*) from host_issues WHERE total_issues_count > 0"))
 	assert.Equal(t, 1, count)
 
-	err = deleteAllPolicyMemberships(ctx, ds.writer(ctx), []uint{host.ID})
+	err = deleteAllPolicyMemberships(ctx, ds.writer(ctx), host.ID)
 	require.NoError(t, err)
 
 	err = ds.writer(ctx).Get(&count, "select COUNT(*) from policy_membership")

--- a/server/fleet/datastore.go
+++ b/server/fleet/datastore.go
@@ -314,6 +314,8 @@ type Datastore interface {
 	HostnamesByIdentifiers(ctx context.Context, identifiers []string) ([]string, error)
 	// UpdateHostIssuesFailingPolicies updates the failing policies count in host_issues table for the provided hosts.
 	UpdateHostIssuesFailingPolicies(ctx context.Context, hostIDs []uint) error
+	// UpdateHostIssuesFailingPoliciesForSingleHost updates the failing policies count in host_issues table for a single host.
+	UpdateHostIssuesFailingPoliciesForSingleHost(ctx context.Context, hostID uint) error
 	// Gets the last time the host's row in `host_issues` was updated
 	GetHostIssuesLastUpdated(ctx context.Context, hostId uint) (time.Time, error)
 	// UpdateHostIssuesVulnerabilities updates the critical vulnerabilities counts in host_issues.

--- a/server/service/apple_mdm_test.go
+++ b/server/service/apple_mdm_test.go
@@ -899,6 +899,9 @@ func TestHostDetailsMDMProfiles(t *testing.T) {
 	ds.UpdateHostIssuesFailingPoliciesFunc = func(ctx context.Context, hostIDs []uint) error {
 		return nil
 	}
+	ds.UpdateHostIssuesFailingPoliciesForSingleHostFunc = func(ctx context.Context, hostID uint) error {
+		return nil
+	}
 	ds.IsHostDiskEncryptionKeyArchivedFunc = func(ctx context.Context, hostID uint) (bool, error) {
 		return false, nil
 	}

--- a/server/service/hosts.go
+++ b/server/service/hosts.go
@@ -572,7 +572,7 @@ func (svc *Service) GetHost(ctx context.Context, id uint, opts fleet.HostDetailO
 		return nil, ctxerr.Wrap(ctx, err, "checking host's host_issues last updated:")
 	}
 	if time.Since(lastUpdated) > time.Minute {
-		if err := svc.ds.UpdateHostIssuesFailingPolicies(ctx, []uint{id}); err != nil {
+		if err := svc.ds.UpdateHostIssuesFailingPoliciesForSingleHost(ctx, id); err != nil {
 			return nil, ctxerr.Wrap(ctx, err, "recalculate host failing policies count:")
 		}
 	}

--- a/server/service/hosts_test.go
+++ b/server/service/hosts_test.go
@@ -826,6 +826,9 @@ func TestHostAuth(t *testing.T) {
 	ds.UpdateHostIssuesFailingPoliciesFunc = func(ctx context.Context, hostIDs []uint) error {
 		return nil
 	}
+	ds.UpdateHostIssuesFailingPoliciesForSingleHostFunc = func(ctx context.Context, hostID uint) error {
+		return nil
+	}
 	ds.GetHostIssuesLastUpdatedFunc = func(ctx context.Context, hostId uint) (time.Time, error) {
 		return time.Time{}, nil
 	}
@@ -1794,6 +1797,9 @@ func TestHostMDMProfileDetail(t *testing.T) {
 		return nil, nil, nil
 	}
 	ds.UpdateHostIssuesFailingPoliciesFunc = func(ctx context.Context, hostIDs []uint) error {
+		return nil
+	}
+	ds.UpdateHostIssuesFailingPoliciesForSingleHostFunc = func(ctx context.Context, hostID uint) error {
 		return nil
 	}
 	ds.GetHostIssuesLastUpdatedFunc = func(ctx context.Context, hostId uint) (time.Time, error) {


### PR DESCRIPTION
Fixes #31173 

Reproduced and fixed in loadtest environment. Uncovered another source of deadlocks, filed as a separate: https://github.com/fleetdm/fleet/issues/32201
- Also, still seeing some deadlocks (a lot fewer) in DB, and they are hidden from the API results by retries. They may still be happening because locks happen row by row and not all at once. A potential fix would be to lock the whole policy_membership table.

Additional frontend fix, which is needed to prevent potential timeouts: https://github.com/fleetdm/fleet/pull/32212

Backend + frontend fix should be a sufficient fix for this issue (ignoring the issue with the long software transaction).

Also, this PR contains some refactoring to split out the 1-host use case.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.

## Testing

- [x] QA'd all new/changed functionality manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Bug Fixes
  * Resolved rare deadlocks during concurrent policy updates and bulk automations.
  * Correctly clears stale MDM data and actions on host re-enrollment and platform changes.
* Performance Improvements
  * Optimized policy issue recalculation with per-host updates to reduce contention.
  * Improved concurrency handling for bulk policy updates to avoid lock contention.
* Reliability
  * More robust host enrollment: updates seen time, display name, and label membership consistently.
  * Ensures accurate policy-issue counts after membership changes and re-enrollment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->