### PR TITLE
UI fixes correcting links on end user auth form and showing fields in user card for ios and ipad (#32198)

### DIFF
--- a/frontend/pages/ManageControlsPage/SetupExperience/cards/EndUserAuthentication/components/EndUserAuthForm/EndUserAuthForm.tsx
+++ b/frontend/pages/ManageControlsPage/SetupExperience/cards/EndUserAuthentication/components/EndUserAuthForm/EndUserAuthForm.tsx
@@ -65,9 +65,8 @@ const EndUserAuthForm = ({
           Require end users to authenticate with your identity provider (IdP)
           and agree to an end user license agreement (EULA) when they setup
           their new macOS, iOS, iPadOS and Android hosts.{" "}
-          <Link to={PATHS.ADMIN_INTEGRATIONS_IDENTITY_PROVIDER}>
-            View IdP and EULA
-          </Link>
+          <Link to={PATHS.ADMIN_INTEGRATIONS_IDENTITY_PROVIDER}>View IdP</Link>{" "}
+          and <Link to={PATHS.ADMIN_INTEGRATIONS_MDM}>EULA</Link>.
         </p>
         <GitOpsModeTooltipWrapper
           renderChildren={(disableChildren) => (

--- a/frontend/pages/hosts/details/cards/User/User.tsx
+++ b/frontend/pages/hosts/details/cards/User/User.tsx
@@ -3,7 +3,7 @@ import classnames from "classnames";
 import { noop } from "lodash";
 
 import { IHostEndUser } from "interfaces/host";
-import { HostPlatform } from "interfaces/platform";
+import { HostPlatform, isAppleDevice } from "interfaces/platform";
 
 import Card from "components/Card";
 import CardHeader from "components/CardHeader";
@@ -50,7 +50,7 @@ const User = ({
   const otherEmailsDisplayValues = generateOtherEmailsValues(endUsers);
 
   const endUser = endUsers[0];
-  const showUsername = platform === "darwin";
+  const showUsername = isAppleDevice(platform);
   const showFullName = showUsername && userNameDisplayValues.length > 0;
   const showGroups = showUsername && userNameDisplayValues.length > 0;
   const showChromeProfiles = chromeProfilesDisplayValues.length > 0;


### PR DESCRIPTION
fixes #32135, #32132

cherry pick PR. this is two fixes for the IdP story:

1. splits out the links for the view idp and eula on the end user auth
form.
2. shows the user card fields for ios and ipad

- [x] QA'd all new/changed functionality manually

