### PR TITLE
Fixed issue due to UUID mistmatch on BitLocker CSP cmd.

### DIFF
--- a/server/datastore/mysql/microsoft_mdm.go
+++ b/server/datastore/mysql/microsoft_mdm.go
@@ -468,7 +468,11 @@ func updateMDMWindowsHostProfileStatusFromResponseDB(
 		sb.WriteString("(?, ?, ?, ?, ?, command_uuid, ?),")
 	}
 
-	stmt = fmt.Sprintf(updateHostProfilesStmt, strings.TrimSuffix(sb.String(), ","))
+	values := strings.TrimSuffix(sb.String(), ",")
+	if len(values) == 0 {
+		return nil
+	}
+	stmt = fmt.Sprintf(updateHostProfilesStmt, values)
 	_, err = tx.ExecContext(ctx, stmt, args...)
 	return ctxerr.Wrap(ctx, err, "updating host profiles")
 }

--- a/server/mdm/microsoft/bitlocker_csp.go
+++ b/server/mdm/microsoft/bitlocker_csp.go
@@ -3,8 +3,9 @@ package microsoft_mdm
 import (
 	"bytes"
 	"errors"
-	"github.com/fleetdm/fleet/v4/server/fleet"
 	"text/template"
+
+	"github.com/fleetdm/fleet/v4/server/fleet"
 )
 
 const (
@@ -24,9 +25,9 @@ var systemDriveRequiresStartupAuthTmpl = template.Must(template.New("cmd").Funcs
 		return *val
 	}}).Parse(`
 <Atomic>
-	<CmdID>{{ .CmdUUID }}-1</CmdID>
+	<CmdID>{{ .CmdUUID }}</CmdID>
 	<Replace>
-		<CmdID>{{ .CmdUUID }}-2</CmdID>
+		<CmdID>{{ .CmdUUID }}-1</CmdID>
 		<Item>
 			<Meta>
 			  <Format>chr</Format>

--- a/server/mdm/microsoft/bitlocker_csp_test.go
+++ b/server/mdm/microsoft/bitlocker_csp_test.go
@@ -1,10 +1,11 @@
 package microsoft_mdm
 
 import (
-	"github.com/fleetdm/fleet/v4/server/ptr"
-	"github.com/stretchr/testify/require"
 	"strings"
 	"testing"
+
+	"github.com/fleetdm/fleet/v4/server/ptr"
+	"github.com/stretchr/testify/require"
 )
 
 func TestSystemDriveRequiresStartupAuthSpec_validate(t *testing.T) {
@@ -105,7 +106,7 @@ func TestSystemDriveRequiresStartupAuthSpec_validate(t *testing.T) {
 	}
 }
 
-func TestSystemDrRequiresStartupAuthCmd_Template(t *testing.T) {
+func TestSystemDriveRequiresStartupAuthCmd_Template(t *testing.T) {
 	tests := []struct {
 		name     string
 		spec     SystemDriveRequiresStartupAuthSpec
@@ -119,9 +120,9 @@ func TestSystemDrRequiresStartupAuthCmd_Template(t *testing.T) {
 			},
 			expected: `
 				<Atomic>
-					<CmdID>uuid-123-1</CmdID>
+					<CmdID>uuid-123</CmdID>
 					<Replace>
-						<CmdID>uuid-123-2</CmdID>
+						<CmdID>uuid-123-1</CmdID>
 						<Item>
 							<Meta>
 							  <Format>chr</Format>
@@ -150,9 +151,9 @@ func TestSystemDrRequiresStartupAuthCmd_Template(t *testing.T) {
 			},
 			expected: `
 				<Atomic>
-					<CmdID>uuid-789-1</CmdID>
+					<CmdID>uuid-789</CmdID>
 					<Replace>
-						<CmdID>uuid-789-2</CmdID>
+						<CmdID>uuid-789-1</CmdID>
 						<Item>
 							<Meta>
 							  <Format>chr</Format>


### PR DESCRIPTION
For #28133.

When generating the payload for the BitLocker CSP used for setting the TPM PIN policy, make sure the UUID used in the Atomic enclousure matches the UUID used for the whole command.

# Checklist for submitter

## Testing

- [X] QA'd all new/changed functionality manually

For unreleased bug fixes in a release candidate, one of:

- [X] Confirmed that the fix is not expected to adversely impact load test results