### PR TITLE
Website: Fix ad attribution when creating historical event records

### DIFF
--- a/website/api/hooks/custom/index.js
+++ b/website/api/hooks/custom/index.js
@@ -342,7 +342,7 @@ will be disabled and/or hidden in the UI.
                       contactSource: 'Website - Sign up',// Note: this is only set on new contacts.
                     });
                     let websiteVisitReason;
-                    if(req.session.adAttributionString && this.req.session.visitedSiteFromAdAt) {
+                    if(req.session.adAttributionString && req.session.visitedSiteFromAdAt) {
                       let thirtyMinutesAgoAt = Date.now() - (1000 * 60 * 30);
                       // If this user visited the website from an ad, set the websiteVisitReason to be the adAttributionString stored in their session.
                       if(req.session.visitedSiteFromAdAt > thirtyMinutesAgoAt) {


### PR DESCRIPTION
Changes:
- Updated the custom hook to check the correct value when determining if a website page view can be attributed to an ad.