### PR TITLE
When updating multiple policies in the UI, the policies are now updated in series to reduce server/DB load.

### DIFF
--- a/changes/31173-fix-policy-deadlocks-frontend
+++ b/changes/31173-fix-policy-deadlocks-frontend
@@ -1,0 +1,1 @@
+When updating multiple policies in the UI, the policies are now updated in series to reduce server/DB load.


### PR DESCRIPTION
Fixes #31173 

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.

## Testing

- [x] QA'd all new/changed functionality manually
