### PR TITLE
[Fleet server config] IAM authentication for MySQL and Redis 

### DIFF
--- a/docs/Configuration/fleet-server-configuration.md
+++ b/docs/Configuration/fleet-server-configuration.md
@@ -241,7 +241,7 @@ By default, this will set up a Redis pool for that configuration and execute a
 
 For the address of the Redis server that Fleet should connect to, include the hostname and port.
 
-If an AWS ElastiCache endpoint is specified and `redis_password` isn't specified, Identity and Access Management (IAM) authentication is automatically used.
+If an AWS ElastiCache endpoint is specified and `redis_password` isn't specified, Fleet will first attempt to use Identity and Access Management (IAM) authentication before falling back to authentication without a password.
 
 - Default value: `localhost:6379`
 - Environment variable: `FLEET_REDIS_ADDRESS`

--- a/docs/Configuration/fleet-server-configuration.md
+++ b/docs/Configuration/fleet-server-configuration.md
@@ -299,9 +299,7 @@ Use a TLS connection to the Redis server.
 
 ### redis_sts_assume_role_arn
 
-Amazon Resource Name (ARN) of the AWS Security Token Service (STS) role to use for Redis authentication. 
-
-If set, Fleet uses AWS Identity and Access Management (IAM) authentication instead of basic authentication set by `redis_username` and `redis_password` (optional).
+Amazon Resource Name (ARN) of the AWS Security Token Service (STS) role to assume when using Identity and Access Management (IAM) for Redis authentication.
 
 - Default value: `""`
 - Environment variable: `FLEET_REDIS_STS_ASSUME_ROLE_ARN`

--- a/docs/Configuration/fleet-server-configuration.md
+++ b/docs/Configuration/fleet-server-configuration.md
@@ -212,7 +212,7 @@ Optionally, when using Identity and Access Management (IAM) authentication, this
 
 ### mysql_sts_external_id
 
-AWS Security Token Service (STS) External ID to use for MySQL authentication. Specify this with `mysql_sts_assume_role_arn` to ensure that only the intended AWS account can assume the role.
+Optionally, if you're using a third-party to manage AWS resources, this is the AWS Security Token Service (STS) External ID to use for MySQL authentication. Specify this with `mysql_sts_assume_role_arn`.
 
 - Default value: `""`
 - Environment variable: `FLEET_MYSQL_STS_EXTERNAL_ID`

--- a/docs/Configuration/fleet-server-configuration.md
+++ b/docs/Configuration/fleet-server-configuration.md
@@ -200,7 +200,7 @@ This setting should not usually be used.
 
 ### mysql_sts_assume_role_arn
 
-Amazon Resource Name (ARN) of the AWS Security Token Service (STS) role to assume when using Identity and Access Management (IAM) for MySQL authentication.
+Optionally, when using Identity and Access Management (IAM) authentication, this is the Amazon Resource Name (ARN) of the AWS Security Token Service (STS) role to assume.
 
 - Default value: `""`
 - Environment variable: `FLEET_MYSQL_STS_ASSUME_ROLE_ARN`

--- a/docs/Configuration/fleet-server-configuration.md
+++ b/docs/Configuration/fleet-server-configuration.md
@@ -212,7 +212,7 @@ Optionally, when using Identity and Access Management (IAM) authentication, this
 
 ### mysql_sts_external_id
 
-Optionally, if you're using a third-party to manage AWS resources, this is the AWS Security Token Service (STS) External ID to use for MySQL authentication. Specify this with `mysql_sts_assume_role_arn`.
+Optionally, if you're using a third-party to manage AWS resources, this is the AWS Security Token Service (STS) External ID to use for IAM authentication. Specify this with `mysql_sts_assume_role_arn`.
 
 - Default value: `""`
 - Environment variable: `FLEET_MYSQL_STS_EXTERNAL_ID`

--- a/docs/Configuration/fleet-server-configuration.md
+++ b/docs/Configuration/fleet-server-configuration.md
@@ -200,9 +200,7 @@ This setting should not usually be used.
 
 ### mysql_sts_assume_role_arn
 
-Amazon Resource Name (ARN) of the AWS Security Token Service (STS) role to use for MySQL authentication. 
-
-If set, Fleet uses AWS Identity and Access Management (IAM) authentication instead of basic authentication set by `mysql_username` and `mysql_password` or `mysql_password_path`.
+Amazon Resource Name (ARN) of the AWS Security Token Service (STS) role to assume when using Identity and Access Management (IAM) for MySQL authentication.
 
 - Default value: `""`
 - Environment variable: `FLEET_MYSQL_STS_ASSUME_ROLE_ARN`


### PR DESCRIPTION
@noahtalerman: Closed this PR. Changes should be going into the 4.74 docs branch. Not 4.73.

DONE: @noahtalerman: Open up a new PR against 4.74: https://github.com/fleetdm/fleet/pull/32442

---

Fleet server configuration changes for the following user story:
- #1817
