### PR TITLE
to RC - UI: handle `null` response from batch script summary endpoint (#32106)

### DIFF
--- a/frontend/pages/ManageControlsPage/Scripts/cards/ScriptBatchProgress/ScriptBatchProgress.tsx
+++ b/frontend/pages/ManageControlsPage/Scripts/cards/ScriptBatchProgress/ScriptBatchProgress.tsx
@@ -92,7 +92,7 @@ const ScriptBatchProgress = ({
             .getRunScriptBatchSummaries(queryKey[0])
             .then((r) => {
               setBatchCount(r.count);
-              return r.batch_executions;
+              return r.batch_executions ?? [];
             })
             .finally(() => {
               setUpdating(false);

--- a/frontend/services/entities/scripts.ts
+++ b/frontend/services/entities/scripts.ts
@@ -182,7 +182,7 @@ export interface IScriptBatchSummariesQueryKey
 }
 
 export interface IScriptBatchSummariesResponse {
-  batch_executions: IScriptBatchSummaryV2[];
+  batch_executions: IScriptBatchSummaryV2[] | null; // should not return `null`, but API currently does sometimes. Remove this option when it's fixed.
   meta: PaginationMeta;
   count: number;
 }


### PR DESCRIPTION
See #32106 