### PR TITLE
Remove `pull_request` from `check-vulnerabilities-in-released-docker-images.yml`

### DIFF
--- a/.github/workflows/check-vulnerabilities-in-released-docker-images.yml
+++ b/.github/workflows/check-vulnerabilities-in-released-docker-images.yml
@@ -2,7 +2,6 @@ name: Check critical vulnerabilities in released docker images
 
 on:
   workflow_dispatch:
-  pull_request:
   schedule:
     - cron: "0 6 * * *"
 


### PR DESCRIPTION
It triggered on a UI change, which doesn't make sense.
https://github.com/fleetdm/fleet/actions/runs/17164572704/job/48701807667?pr=32232

This should run in a schedule and manually only, not on pull requests.