### PR TITLE
Reload view after canceling script, and update time validation

### DIFF
--- a/frontend/pages/ManageControlsPage/Scripts/cards/ScriptBatchProgress/ScriptBatchProgress.tsx
+++ b/frontend/pages/ManageControlsPage/Scripts/cards/ScriptBatchProgress/ScriptBatchProgress.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from "react";
+import React, { useCallback, useEffect, useRef, useState } from "react";
 import { useQueryClient } from "react-query";
 import { Tab, TabList, TabPanel, Tabs } from "react-tabs";
 
@@ -17,7 +17,7 @@ import ProgressBar from "components/ProgressBar";
 import SectionHeader from "components/SectionHeader";
 import TabNav from "components/TabNav";
 import TabText from "components/TabText";
-import PaginatedList from "components/PaginatedList";
+import PaginatedList, { IPaginatedListHandle } from "components/PaginatedList";
 import { HumanTimeDiffWithFleetLaunchCutoff } from "components/HumanTimeDiffWithDateTip";
 import Icon from "components/Icon/Icon";
 
@@ -67,6 +67,10 @@ const ScriptBatchProgress = ({
   ] = useState<IScriptBatchDetailsForSummary | null>(null);
   const [batchCount, setBatchCount] = useState<number | null>(null);
   const [updating, setUpdating] = useState(false);
+
+  const paginatedListRef = useRef<IPaginatedListHandle<IScriptBatchSummaryV2>>(
+    null
+  );
 
   const statusParam = location?.query.status;
 
@@ -288,6 +292,7 @@ const ScriptBatchProgress = ({
           </div>
         )}
         <PaginatedList<IScriptBatchSummaryV2>
+          ref={paginatedListRef}
           count={batchCount || 0}
           fetchPage={fetchPage}
           onClickRow={onClickRow}
@@ -329,7 +334,7 @@ const ScriptBatchProgress = ({
           scriptBatchExecutionDetails={{ ...batchDetailsForSummary }}
           onCancel={() => {
             setShowBatchDetailsForSummary(null);
-            handleTabChange(2);
+            paginatedListRef.current?.reload();
           }}
           router={router}
         />

--- a/frontend/pages/ManageControlsPage/Scripts/cards/ScriptBatchProgress/ScriptBatchProgress.tsx
+++ b/frontend/pages/ManageControlsPage/Scripts/cards/ScriptBatchProgress/ScriptBatchProgress.tsx
@@ -329,6 +329,7 @@ const ScriptBatchProgress = ({
           scriptBatchExecutionDetails={{ ...batchDetailsForSummary }}
           onCancel={() => {
             setShowBatchDetailsForSummary(null);
+            handleTabChange(2);
           }}
           router={router}
         />

--- a/frontend/pages/hosts/ManageHostsPage/components/RunScriptBatchModal/helpers.ts
+++ b/frontend/pages/hosts/ManageHostsPage/components/RunScriptBatchModal/helpers.ts
@@ -98,8 +98,8 @@ const FORM_VALIDATIONS: IFormValidations = {
             return true; // If date is invalid, skip time validation
           }
           const parsedDate = parse(
-            `${formData.date} ${formData.time}`,
-            "yyyy-MM-dd HH:mm",
+            `${formData.date} ${formData.time}:00.000Z`,
+            "yyyy-MM-dd HH:mm:ss.SSSX",
             new Date()
           );
           return parsedDate >= new Date();


### PR DESCRIPTION
for #32238

# Details

* After a script is canceled, refresh the current tab to show that the canceled script is no longer there
* When scheduling a script, check the specified time against UTC, not current timezone time of day.

# Checklist for submitter

## Testing

- [X] QA'd all new/changed functionality manually

For unreleased bug fixes in a release candidate, one of:

- [X] Confirmed that the fix is not expected to adversely impact load test results
