### PR TITLE
Document binary hash visibility in host software API endpoint

### DIFF
--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -4117,7 +4117,7 @@ On macOS hosts, `last_opened_at` represents the last open time of the most recen
             {
               "installed_path": "/Applications/Google Chrome.app",
               "team_identifier": "EQHXZ8M8AV",
-              "hash_sha256": "a45d00ac9bf21e108fa8e452fabe4d9e05e6765b",
+              "hash_sha256": "a45d00ac9bf21e108fa8e452fabe4d9e05e6765b"
             }
           ]
         }
@@ -4169,7 +4169,7 @@ On macOS hosts, `last_opened_at` represents the last open time of the most recen
             {
               "installed_path": "/Applications/Logic Pro.app",
               "team_identifier": "",
-              "hash_sha256": null,
+              "hash_sha256": null
             }
           ]
         }

--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -4116,7 +4116,8 @@ On macOS hosts, `last_opened_at` represents the last open time of the most recen
           "signature_information": [
             {
               "installed_path": "/Applications/Google Chrome.app",
-              "team_identifier": "EQHXZ8M8AV"
+              "team_identifier": "EQHXZ8M8AV",
+              "hash_sha256": "a45d00ac9bf21e108fa8e452fabe4d9e05e6765b",
             }
           ]
         }
@@ -4167,7 +4168,8 @@ On macOS hosts, `last_opened_at` represents the last open time of the most recen
           "signature_information": [
             {
               "installed_path": "/Applications/Logic Pro.app",
-              "team_identifier": ""
+              "team_identifier": "",
+              "hash_sha256": null,
             }
           ]
         }


### PR DESCRIPTION
This was added a few fleetd/Fleet server releases ago; lack of docs was an oversight at that point.