### PR TITLE
Move software self-service, labels, categories, and setup experience to team level in GitOps

### DIFF
--- a/changes/30095-gitops
+++ b/changes/30095-gitops
@@ -1,0 +1,1 @@
+* Moved self-service, labels, categories, and setup experience declarations to team level for software in GitOps

--- a/changes/31164-gitops-generate
+++ b/changes/31164-gitops-generate
@@ -1,1 +1,0 @@
-* Gitops generate outputs categories, self_service, and setup_experience at team level

--- a/cmd/fleetctl/fleetctl/gitops.go
+++ b/cmd/fleetctl/fleetctl/gitops.go
@@ -469,47 +469,47 @@ func getLabelUsage(config *spec.GitOps) (map[string][]LabelUsage, error) {
 	}
 
 	// Get software package installer label usage
-	for _, setting := range config.Software.Packages {
+	for _, softwarePackage := range config.Software.Packages {
 		var labels []string
-		if len(setting.LabelsIncludeAny) > 0 {
-			labels = setting.LabelsIncludeAny
+		if len(softwarePackage.LabelsIncludeAny) > 0 {
+			labels = softwarePackage.LabelsIncludeAny
 		}
-		if len(setting.LabelsExcludeAny) > 0 {
+		if len(softwarePackage.LabelsExcludeAny) > 0 {
 			if len(labels) > 0 {
-				return nil, fmt.Errorf("Software package '%s' has multiple label keys; please choose one of `labels_include_any`, `labels_exclude_any`.", setting.URL)
+				return nil, fmt.Errorf("Software package '%s' has multiple label keys; please choose one of `labels_include_any`, `labels_exclude_any`.", softwarePackage.URL)
 			}
-			labels = setting.LabelsExcludeAny
+			labels = softwarePackage.LabelsExcludeAny
 		}
-		updateLabelUsage(labels, setting.URL, "Software Package", result)
+		updateLabelUsage(labels, softwarePackage.URL, "Software Package", result)
 	}
 
 	// Get app store app installer label usage
-	for _, setting := range config.Software.AppStoreApps {
+	for _, vppApp := range config.Software.AppStoreApps {
 		var labels []string
-		if len(setting.LabelsIncludeAny) > 0 {
-			labels = setting.LabelsIncludeAny
+		if len(vppApp.LabelsIncludeAny) > 0 {
+			labels = vppApp.LabelsIncludeAny
 		}
-		if len(setting.LabelsExcludeAny) > 0 {
+		if len(vppApp.LabelsExcludeAny) > 0 {
 			if len(labels) > 0 {
-				return nil, fmt.Errorf("App Store App '%s' has multiple label keys; please choose one of `labels_include_any`, `labels_exclude_any`.", setting.AppStoreID)
+				return nil, fmt.Errorf("App Store App '%s' has multiple label keys; please choose one of `labels_include_any`, `labels_exclude_any`.", vppApp.AppStoreID)
 			}
-			labels = setting.LabelsExcludeAny
+			labels = vppApp.LabelsExcludeAny
 		}
-		updateLabelUsage(labels, setting.AppStoreID, "App Store App", result)
+		updateLabelUsage(labels, vppApp.AppStoreID, "App Store App", result)
 	}
 
-	for _, setting := range config.Software.FleetMaintainedApps {
+	for _, maintainedApp := range config.Software.FleetMaintainedApps {
 		var labels []string
-		if len(setting.LabelsIncludeAny) > 0 {
-			labels = setting.LabelsIncludeAny
+		if len(maintainedApp.LabelsIncludeAny) > 0 {
+			labels = maintainedApp.LabelsIncludeAny
 		}
-		if len(setting.LabelsExcludeAny) > 0 {
+		if len(maintainedApp.LabelsExcludeAny) > 0 {
 			if len(labels) > 0 {
-				return nil, fmt.Errorf("Fleet Maintained App '%s' has multiple label keys; please choose one of `labels_include_any`, `labels_exclude_any`.", setting.Slug)
+				return nil, fmt.Errorf("Fleet Maintained App '%s' has multiple label keys; please choose one of `labels_include_any`, `labels_exclude_any`.", maintainedApp.Slug)
 			}
-			labels = setting.LabelsExcludeAny
+			labels = maintainedApp.LabelsExcludeAny
 		}
-		updateLabelUsage(labels, setting.Slug, "Fleet Maintained App", result)
+		updateLabelUsage(labels, maintainedApp.Slug, "Fleet Maintained App", result)
 	}
 
 	// Get query label usage

--- a/cmd/fleetctl/fleetctl/testdata/gitops/lib/software_other.yml
+++ b/cmd/fleetctl/fleetctl/testdata/gitops/lib/software_other.yml
@@ -1,2 +1,1 @@
 url: ${SOFTWARE_INSTALLER_URL}/other.deb
-self_service: true

--- a/cmd/fleetctl/fleetctl/testdata/gitops/no_team_setup_software_invalid_script.yml
+++ b/cmd/fleetctl/fleetctl/testdata/gitops/no_team_setup_software_invalid_script.yml
@@ -7,3 +7,4 @@ software:
   packages:
     - path: lib/software_ruby.yml
     - path: lib/software_other.yml
+      self_service: true

--- a/cmd/fleetctl/fleetctl/testdata/gitops/no_team_setup_software_invalid_software_package.yml
+++ b/cmd/fleetctl/fleetctl/testdata/gitops/no_team_setup_software_invalid_software_package.yml
@@ -8,3 +8,4 @@ software:
   packages:
     - path: lib/software_ruby.yml
     - path: lib/software_other.yml
+      self_service: true

--- a/cmd/fleetctl/fleetctl/testdata/gitops/no_team_setup_software_invalid_vpp_app.yml
+++ b/cmd/fleetctl/fleetctl/testdata/gitops/no_team_setup_software_invalid_vpp_app.yml
@@ -12,3 +12,4 @@ software:
   packages:
     - path: lib/software_ruby.yml
     - path: lib/software_other.yml
+      self_service: true

--- a/cmd/fleetctl/fleetctl/testdata/gitops/no_team_setup_software_valid.yml
+++ b/cmd/fleetctl/fleetctl/testdata/gitops/no_team_setup_software_valid.yml
@@ -13,3 +13,4 @@ software:
   packages:
     - path: lib/software_ruby.yml
     - path: lib/software_other.yml
+      self_service: true

--- a/cmd/fleetctl/fleetctl/testdata/gitops/team_setup_software_defined_in_conflicting_places.yml
+++ b/cmd/fleetctl/fleetctl/testdata/gitops/team_setup_software_defined_in_conflicting_places.yml
@@ -1,0 +1,27 @@
+name: "${TEST_TEAM_NAME}"
+team_settings:
+  secrets:
+    - secret: "ABC"
+  features:
+    enable_host_users: true
+    enable_software_inventory: true
+  host_expiry_settings:
+    host_expiry_enabled: true
+    host_expiry_window: 30
+agent_options:
+controls:
+  macos_setup:
+    script: lib/setup_script.sh
+    software:
+      - app_store_id: "1"
+policies:
+queries:
+software:
+  app_store_apps:
+    - app_store_id: "1"
+  packages:
+    - path: lib/software_ruby.yml
+      setup_experience: true
+    - path: lib/software_other.yml
+      self_service: true
+      setup_experience: false

--- a/cmd/fleetctl/fleetctl/testdata/gitops/team_setup_software_defined_in_conflicting_places_vpp.yml
+++ b/cmd/fleetctl/fleetctl/testdata/gitops/team_setup_software_defined_in_conflicting_places_vpp.yml
@@ -1,0 +1,26 @@
+name: "${TEST_TEAM_NAME}"
+team_settings:
+  secrets:
+    - secret: "ABC"
+  features:
+    enable_host_users: true
+    enable_software_inventory: true
+  host_expiry_settings:
+    host_expiry_enabled: true
+    host_expiry_window: 30
+agent_options:
+controls:
+  macos_setup:
+    script: lib/setup_script.sh
+    software:
+      - app_store_id: "1"
+policies:
+queries:
+software:
+  app_store_apps:
+    - app_store_id: "1"
+      setup_experience: true
+  packages:
+    - path: lib/software_ruby.yml
+    - path: lib/software_other.yml
+      self_service: true

--- a/cmd/fleetctl/fleetctl/testdata/gitops/team_setup_software_on_package.yml
+++ b/cmd/fleetctl/fleetctl/testdata/gitops/team_setup_software_on_package.yml
@@ -1,0 +1,26 @@
+name: "${TEST_TEAM_NAME}"
+team_settings:
+  secrets:
+    - secret: "ABC"
+  features:
+    enable_host_users: true
+    enable_software_inventory: true
+  host_expiry_settings:
+    host_expiry_enabled: true
+    host_expiry_window: 30
+agent_options:
+controls:
+  macos_setup:
+    script: lib/setup_script.sh
+policies:
+queries:
+software:
+  app_store_apps:
+    - app_store_id: "1"
+      setup_experience: true
+  packages:
+    - path: lib/software_ruby.yml
+      setup_experience: true
+    - path: lib/software_other.yml
+      self_service: true
+      setup_experience: false

--- a/cmd/fleetctl/fleetctl/testdata/gitops/team_setup_software_valid.yml
+++ b/cmd/fleetctl/fleetctl/testdata/gitops/team_setup_software_valid.yml
@@ -23,3 +23,4 @@ software:
   packages:
     - path: lib/software_ruby.yml
     - path: lib/software_other.yml
+      self_service: true

--- a/cmd/fleetctl/integrationtest/gitops/software_test.go
+++ b/cmd/fleetctl/integrationtest/gitops/software_test.go
@@ -58,6 +58,9 @@ func TestGitOpsTeamSofwareInstallers(t *testing.T) {
 			"Please create the missing labels, or update your settings to not refer to these labels."},
 		// team tests for setup experience software/script
 		{"testdata/gitops/team_setup_software_valid.yml", ""},
+		{"testdata/gitops/team_setup_software_on_package.yml", ""},
+		{"testdata/gitops/team_setup_software_defined_in_conflicting_places.yml", " Setup experience may only be specified directly on software or within macos_setup, but not both."},
+		{"testdata/gitops/team_setup_software_defined_in_conflicting_places_vpp.yml", " Setup experience may only be specified directly on software or within macos_setup, but not both."},
 		{"testdata/gitops/team_setup_software_invalid_script.yml", "no_such_script.sh: no such file"},
 		{"testdata/gitops/team_setup_software_invalid_software_package.yml", "no_such_software.yml\" does not exist for that team"},
 		{"testdata/gitops/team_setup_software_invalid_vpp_app.yml", "\"no_such_app\" does not exist for that team"},

--- a/pkg/spec/gitops.go
+++ b/pkg/spec/gitops.go
@@ -1094,7 +1094,6 @@ func parseSoftware(top map[string]json.RawMessage, result *GitOps, baseDir strin
 		result.Software.AppStoreApps = append(result.Software.AppStoreApps, &item)
 	}
 	for _, maintainedAppSpec := range software.FleetMaintainedApps {
-		maintainedAppSpec := maintainedAppSpec
 		if maintainedAppSpec.Slug == "" {
 			multiError = multierror.Append(multiError, errors.New("fleet maintained app slug is required"))
 			continue

--- a/pkg/spec/gitops.go
+++ b/pkg/spec/gitops.go
@@ -161,6 +161,16 @@ type SoftwarePackage struct {
 	fleet.SoftwarePackageSpec
 }
 
+func (spec SoftwarePackage) HydrateToPackageLevel(packageLevel fleet.SoftwarePackageSpec) fleet.SoftwarePackageSpec {
+	packageLevel.Categories = spec.Categories
+	packageLevel.LabelsIncludeAny = spec.LabelsIncludeAny
+	packageLevel.LabelsExcludeAny = spec.LabelsExcludeAny
+	packageLevel.InstallDuringSetup = spec.InstallDuringSetup
+	packageLevel.SelfService = spec.SelfService
+
+	return packageLevel
+}
+
 type Software struct {
 	Packages            []SoftwarePackage           `json:"packages"`
 	AppStoreApps        []fleet.TeamSpecAppStoreApp `json:"app_store_apps"`
@@ -1083,65 +1093,72 @@ func parseSoftware(top map[string]json.RawMessage, result *GitOps, baseDir strin
 
 		result.Software.AppStoreApps = append(result.Software.AppStoreApps, &item)
 	}
-	for _, item := range software.FleetMaintainedApps {
-		item := item
-		if item.Slug == "" {
+	for _, maintainedAppSpec := range software.FleetMaintainedApps {
+		maintainedAppSpec := maintainedAppSpec
+		if maintainedAppSpec.Slug == "" {
 			multiError = multierror.Append(multiError, errors.New("fleet maintained app slug is required"))
 			continue
 		}
 
-		if len(item.LabelsExcludeAny) > 0 && len(item.LabelsIncludeAny) > 0 {
-			multiError = multierror.Append(multiError, fmt.Errorf(`only one of "labels_exclude_any" or "labels_include_any" can be specified for fleet maintained app %q`, item.Slug))
+		if len(maintainedAppSpec.LabelsExcludeAny) > 0 && len(maintainedAppSpec.LabelsIncludeAny) > 0 {
+			multiError = multierror.Append(multiError, fmt.Errorf(`only one of "labels_exclude_any" or "labels_include_any" can be specified for fleet maintained app %q`, maintainedAppSpec.Slug))
 			continue
 		}
 
-		item = item.ResolveSoftwarePackagePaths(baseDir)
+		maintainedAppSpec = maintainedAppSpec.ResolveSoftwarePackagePaths(baseDir)
 
 		// handle secrets
-		if item.InstallScript.Path != "" {
-			if err := gatherFileSecrets(result, item.InstallScript.Path); err != nil {
+		if maintainedAppSpec.InstallScript.Path != "" {
+			if err := gatherFileSecrets(result, maintainedAppSpec.InstallScript.Path); err != nil {
 				multiError = multierror.Append(multiError, err)
 				continue
 			}
 		}
-		if item.PostInstallScript.Path != "" {
-			if err := gatherFileSecrets(result, item.PostInstallScript.Path); err != nil {
+		if maintainedAppSpec.PostInstallScript.Path != "" {
+			if err := gatherFileSecrets(result, maintainedAppSpec.PostInstallScript.Path); err != nil {
 				multiError = multierror.Append(multiError, err)
 				continue
 			}
 		}
-		if item.UninstallScript.Path != "" {
-			if err := gatherFileSecrets(result, item.UninstallScript.Path); err != nil {
+		if maintainedAppSpec.UninstallScript.Path != "" {
+			if err := gatherFileSecrets(result, maintainedAppSpec.UninstallScript.Path); err != nil {
 				multiError = multierror.Append(multiError, err)
 				continue
 			}
 		}
 
-		result.Software.FleetMaintainedApps = append(result.Software.FleetMaintainedApps, &item)
+		result.Software.FleetMaintainedApps = append(result.Software.FleetMaintainedApps, &maintainedAppSpec)
 	}
-	for _, item := range software.Packages {
+	for _, teamLevelPackage := range software.Packages {
 		var softwarePackageSpec fleet.SoftwarePackageSpec
-		if item.Path != nil {
-			softwarePackageSpec.ReferencedYamlPath = resolveApplyRelativePath(baseDir, *item.Path)
+		if teamLevelPackage.Path != nil {
+			softwarePackageSpec.ReferencedYamlPath = resolveApplyRelativePath(baseDir, *teamLevelPackage.Path)
 			fileBytes, err := os.ReadFile(softwarePackageSpec.ReferencedYamlPath)
 			if err != nil {
-				multiError = multierror.Append(multiError, fmt.Errorf("failed to read software package file %s: %v", *item.Path, err))
+				multiError = multierror.Append(multiError, fmt.Errorf("failed to read software package file %s: %v", *teamLevelPackage.Path, err))
 				continue
 			}
 			// Replace $var and ${var} with env values.
 			fileBytes, err = ExpandEnvBytes(fileBytes)
 			if err != nil {
-				multiError = multierror.Append(multiError, fmt.Errorf("failed to expand environmet in file %s: %v", *item.Path, err))
+				multiError = multierror.Append(multiError, fmt.Errorf("failed to expand environmet in file %s: %v", *teamLevelPackage.Path, err))
 				continue
 			}
 			if err := YamlUnmarshal(fileBytes, &softwarePackageSpec); err != nil {
-				multiError = multierror.Append(multiError, MaybeParseTypeError(*item.Path, []string{"software", "packages"}, err))
+				multiError = multierror.Append(multiError, MaybeParseTypeError(*teamLevelPackage.Path, []string{"software", "packages"}, err))
 				continue
 			}
 
 			softwarePackageSpec = softwarePackageSpec.ResolveSoftwarePackagePaths(filepath.Dir(softwarePackageSpec.ReferencedYamlPath))
+
+			if softwarePackageSpec.IncludesFieldsDisallowedInPackageFile() {
+				multiError = multierror.Append(multiError, fmt.Errorf("labels, categories, setup_experience, and self_service values must be specified at the team level; package-level specified in %s", *teamLevelPackage.Path))
+				continue
+			}
+
+			softwarePackageSpec = teamLevelPackage.HydrateToPackageLevel(softwarePackageSpec)
 		} else {
-			softwarePackageSpec = item.SoftwarePackageSpec.ResolveSoftwarePackagePaths(baseDir)
+			softwarePackageSpec = teamLevelPackage.SoftwarePackageSpec.ResolveSoftwarePackagePaths(baseDir)
 		}
 		if softwarePackageSpec.InstallScript.Path != "" {
 			if err := gatherFileSecrets(result, softwarePackageSpec.InstallScript.Path); err != nil {

--- a/pkg/spec/gitops.go
+++ b/pkg/spec/gitops.go
@@ -1135,13 +1135,13 @@ func parseSoftware(top map[string]json.RawMessage, result *GitOps, baseDir strin
 			softwarePackageSpec.ReferencedYamlPath = resolveApplyRelativePath(baseDir, *teamLevelPackage.Path)
 			fileBytes, err := os.ReadFile(softwarePackageSpec.ReferencedYamlPath)
 			if err != nil {
-				multiError = multierror.Append(multiError, fmt.Errorf("failed to read software package file %s: %v", *teamLevelPackage.Path, err))
+				multiError = multierror.Append(multiError, fmt.Errorf("failed to read software package file %s: %w", *teamLevelPackage.Path, err))
 				continue
 			}
 			// Replace $var and ${var} with env values.
 			fileBytes, err = ExpandEnvBytes(fileBytes)
 			if err != nil {
-				multiError = multierror.Append(multiError, fmt.Errorf("failed to expand environmet in file %s: %v", *teamLevelPackage.Path, err))
+				multiError = multierror.Append(multiError, fmt.Errorf("failed to expand environmet in file %s: %w", *teamLevelPackage.Path, err))
 				continue
 			}
 			if err := YamlUnmarshal(fileBytes, &softwarePackageSpec); err != nil {

--- a/pkg/spec/gitops_test.go
+++ b/pkg/spec/gitops_test.go
@@ -201,8 +201,11 @@ func TestValidGitOpsYaml(t *testing.T) {
 					for _, pkg := range gitops.Software.Packages {
 						if strings.Contains(pkg.URL, "MicrosoftTeams") {
 							assert.Equal(t, "testdata/lib/uninstall.sh", pkg.UninstallScript.Path)
+							assert.Contains(t, pkg.LabelsIncludeAny, "a")
+							assert.Contains(t, pkg.Categories, "Communication")
 						} else {
 							assert.Empty(t, pkg.UninstallScript.Path)
+							assert.Contains(t, pkg.LabelsExcludeAny, "a")
 						}
 					}
 					require.Len(t, gitops.Software.FleetMaintainedApps, 2)
@@ -314,6 +317,8 @@ func TestValidGitOpsYaml(t *testing.T) {
 					require.Len(t, gitops.Software.Packages, 2)
 					if name == "team_config_with_paths_and_only_sha256" {
 						require.Empty(t, gitops.Software.Packages[0].URL)
+						require.True(t, gitops.Software.Packages[0].InstallDuringSetup.Value)
+						require.True(t, gitops.Software.Packages[1].InstallDuringSetup.Value)
 					} else {
 						require.Equal(t, "https://statics.teams.cdn.office.net/production-osx/enterprise/webview2/lkg/MicrosoftTeams.pkg", gitops.Software.Packages[0].URL)
 					}

--- a/pkg/spec/testdata/microsoft-teams.nourl.pkg.software.yml
+++ b/pkg/spec/testdata/microsoft-teams.nourl.pkg.software.yml
@@ -1,5 +1,1 @@
 hash_sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-self_service: false
-categories:
-  - Communication
-  - Productivity

--- a/pkg/spec/testdata/microsoft-teams.pkg.software.yml
+++ b/pkg/spec/testdata/microsoft-teams.pkg.software.yml
@@ -1,8 +1,5 @@
 url: https://statics.teams.cdn.office.net/production-osx/enterprise/webview2/lkg/MicrosoftTeams.pkg
 hash_sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-self_service: false
 uninstall_script:
   path: ./lib/uninstall.sh
-categories:
-  - Communication
-  - Productivity
+

--- a/pkg/spec/testdata/team_config.yml
+++ b/pkg/spec/testdata/team_config.yml
@@ -5,6 +5,11 @@ agent_options:
   path: ./agent-options.yml
 controls:
   path: ./controls.yml
+labels:
+  - name: a
+    description: A cool global label
+    query: SELECT 1 FROM osquery_info
+    label_membership_type: dynamic
 queries:
   - path: ./top.queries.yml
   - path: ./empty.yml
@@ -43,8 +48,15 @@ software:
     - app_store_id: "123456"
   packages:
     - path: ./microsoft-teams.pkg.software.yml
+      labels_include_any:
+        - a
+      categories:
+        - Productivity
+        - Communication
     - url: https://ftp.mozilla.org/pub/firefox/releases/129.0.2/mac/en-US/Firefox%20129.0.2.pkg
       self_service: true
+      labels_exclude_any:
+        - a
   fleet_maintained_apps:
     - slug: slack/darwin
       self_service: true

--- a/pkg/spec/testdata/team_config_no_paths.yml
+++ b/pkg/spec/testdata/team_config_no_paths.yml
@@ -62,6 +62,11 @@ controls:
     webhook_url: ""
   windows_enabled_and_configured: true
   windows_migration_enabled: false
+labels:
+  - name: a
+    description: A cool global label
+    query: SELECT 1 FROM osquery_info
+    label_membership_type: dynamic
 queries:
   - name: Scheduled query stats
     description: Collect osquery performance stats directly from osquery
@@ -145,8 +150,15 @@ software:
     - app_store_id: "123456"
   packages:
     - path: ./microsoft-teams.pkg.software.yml
+      labels_include_any:
+        - a
+      categories:
+        - Communication
+        - Productivity
     - url: https://ftp.mozilla.org/pub/firefox/releases/129.0.2/mac/en-US/Firefox%20129.0.2.pkg
       self_service: true
+      labels_exclude_any:
+        - a
   fleet_maintained_apps:
     - slug: slack/darwin
       self_service: true

--- a/pkg/spec/testdata/team_config_only_sha256.yml
+++ b/pkg/spec/testdata/team_config_only_sha256.yml
@@ -5,6 +5,11 @@ agent_options:
   path: ./agent-options.yml
 controls:
   path: ./controls.yml
+labels:
+  - name: a
+    description: A cool global label
+    query: SELECT 1 FROM osquery_info
+    label_membership_type: dynamic
 queries:
   - path: ./top.queries.yml
   - path: ./empty.yml
@@ -41,10 +46,17 @@ policies:
 software:
   app_store_apps:
     - app_store_id: "123456"
+      setup_experience: true
   packages:
     - path: ./microsoft-teams.nourl.pkg.software.yml
+      labels_exclude_any:
+        - a
+      setup_experience: true
     - url: https://ftp.mozilla.org/pub/firefox/releases/129.0.2/mac/en-US/Firefox%20129.0.2.pkg
       self_service: true
+      labels_exclude_any:
+        - a
+      setup_experience: true
   fleet_maintained_apps:
     - slug: slack/darwin
       self_service: true

--- a/server/fleet/software_installer.go
+++ b/server/fleet/software_installer.go
@@ -583,7 +583,7 @@ func (spec SoftwarePackageSpec) ResolveSoftwarePackagePaths(baseDir string) Soft
 
 func (spec SoftwarePackageSpec) IncludesFieldsDisallowedInPackageFile() bool {
 	return len(spec.LabelsExcludeAny) > 0 || len(spec.LabelsIncludeAny) > 0 || len(spec.Categories) > 0 ||
-		spec.SelfService || spec.InstallDuringSetup.Set
+		spec.SelfService || spec.InstallDuringSetup.Valid
 }
 
 func resolveApplyRelativePath(baseDir string, path string) string {

--- a/server/fleet/software_installer.go
+++ b/server/fleet/software_installer.go
@@ -546,14 +546,15 @@ type SoftwarePackageOrApp struct {
 }
 
 type SoftwarePackageSpec struct {
-	URL               string                `json:"url"`
-	SelfService       bool                  `json:"self_service"`
-	PreInstallQuery   TeamSpecSoftwareAsset `json:"pre_install_query"`
-	InstallScript     TeamSpecSoftwareAsset `json:"install_script"`
-	PostInstallScript TeamSpecSoftwareAsset `json:"post_install_script"`
-	UninstallScript   TeamSpecSoftwareAsset `json:"uninstall_script"`
-	LabelsIncludeAny  []string              `json:"labels_include_any"`
-	LabelsExcludeAny  []string              `json:"labels_exclude_any"`
+	URL                string                `json:"url"`
+	SelfService        bool                  `json:"self_service"`
+	PreInstallQuery    TeamSpecSoftwareAsset `json:"pre_install_query"`
+	InstallScript      TeamSpecSoftwareAsset `json:"install_script"`
+	PostInstallScript  TeamSpecSoftwareAsset `json:"post_install_script"`
+	UninstallScript    TeamSpecSoftwareAsset `json:"uninstall_script"`
+	LabelsIncludeAny   []string              `json:"labels_include_any"`
+	LabelsExcludeAny   []string              `json:"labels_exclude_any"`
+	InstallDuringSetup optjson.Bool          `json:"setup_experience"`
 
 	// FMA
 	Slug *string `json:"slug"`
@@ -580,6 +581,11 @@ func (spec SoftwarePackageSpec) ResolveSoftwarePackagePaths(baseDir string) Soft
 	return spec
 }
 
+func (spec SoftwarePackageSpec) IncludesFieldsDisallowedInPackageFile() bool {
+	return len(spec.LabelsExcludeAny) > 0 || len(spec.LabelsIncludeAny) > 0 || len(spec.Categories) > 0 ||
+		spec.SelfService || spec.InstallDuringSetup.Set
+}
+
 func resolveApplyRelativePath(baseDir string, path string) string {
 	if path != "" && baseDir != "" && !filepath.IsAbs(path) {
 		return filepath.Join(baseDir, path)
@@ -589,27 +595,29 @@ func resolveApplyRelativePath(baseDir string, path string) string {
 }
 
 type MaintainedAppSpec struct {
-	Slug              string                `json:"slug"`
-	SelfService       bool                  `json:"self_service"`
-	PreInstallQuery   TeamSpecSoftwareAsset `json:"pre_install_query"`
-	InstallScript     TeamSpecSoftwareAsset `json:"install_script"`
-	PostInstallScript TeamSpecSoftwareAsset `json:"post_install_script"`
-	UninstallScript   TeamSpecSoftwareAsset `json:"uninstall_script"`
-	LabelsIncludeAny  []string              `json:"labels_include_any"`
-	LabelsExcludeAny  []string              `json:"labels_exclude_any"`
-	Categories        []string              `json:"categories"`
+	Slug               string                `json:"slug"`
+	SelfService        bool                  `json:"self_service"`
+	PreInstallQuery    TeamSpecSoftwareAsset `json:"pre_install_query"`
+	InstallScript      TeamSpecSoftwareAsset `json:"install_script"`
+	PostInstallScript  TeamSpecSoftwareAsset `json:"post_install_script"`
+	UninstallScript    TeamSpecSoftwareAsset `json:"uninstall_script"`
+	LabelsIncludeAny   []string              `json:"labels_include_any"`
+	LabelsExcludeAny   []string              `json:"labels_exclude_any"`
+	Categories         []string              `json:"categories"`
+	InstallDuringSetup optjson.Bool          `json:"setup_experience"`
 }
 
 func (spec MaintainedAppSpec) ToSoftwarePackageSpec() SoftwarePackageSpec {
 	return SoftwarePackageSpec{
-		Slug:              &spec.Slug,
-		PreInstallQuery:   spec.PreInstallQuery,
-		InstallScript:     spec.InstallScript,
-		PostInstallScript: spec.PostInstallScript,
-		UninstallScript:   spec.UninstallScript,
-		SelfService:       spec.SelfService,
-		LabelsIncludeAny:  spec.LabelsIncludeAny,
-		LabelsExcludeAny:  spec.LabelsExcludeAny,
+		Slug:               &spec.Slug,
+		PreInstallQuery:    spec.PreInstallQuery,
+		InstallScript:      spec.InstallScript,
+		PostInstallScript:  spec.PostInstallScript,
+		UninstallScript:    spec.UninstallScript,
+		SelfService:        spec.SelfService,
+		LabelsIncludeAny:   spec.LabelsIncludeAny,
+		LabelsExcludeAny:   spec.LabelsExcludeAny,
+		InstallDuringSetup: spec.InstallDuringSetup,
 	}
 }
 

--- a/server/fleet/teams.go
+++ b/server/fleet/teams.go
@@ -191,7 +191,8 @@ type TeamSpecAppStoreApp struct {
 	LabelsIncludeAny []string `json:"labels_include_any"`
 	LabelsExcludeAny []string `json:"labels_exclude_any"`
 	// Categories is the list of names of software categories associated with this VPP app.
-	Categories []string `json:"categories"`
+	Categories         []string     `json:"categories"`
+	InstallDuringSetup optjson.Bool `json:"setup_experience"`
 }
 
 type TeamMDM struct {

--- a/server/service/client.go
+++ b/server/service/client.go
@@ -766,7 +766,7 @@ func (c *Client) ApplyGroup(
 			appPayloads := make([]fleet.VPPBatchPayload, 0, len(apps))
 			for _, app := range apps {
 				var installDuringSetup *bool
-				if app.InstallDuringSetup.Set {
+				if app.InstallDuringSetup.Valid {
 					if len(installDuringSetupKeys) > 0 {
 						return nil, nil, nil, nil, errors.New("Couldn't edit app store apps. Setup experience may only be specified directly on software or within macos_setup, but not both. See https://fleetdm.com/learn-more-about/yaml-software-setup-experience.")
 					}
@@ -1103,7 +1103,7 @@ func buildSoftwarePackagesPayload(specs []fleet.SoftwarePackageSpec, installDuri
 		}
 
 		var installDuringSetup *bool
-		if si.InstallDuringSetup.Set {
+		if si.InstallDuringSetup.Valid {
 			if len(installDuringSetupKeys) > 0 {
 				return nil, fmt.Errorf("Couldn't edit software (%s). Setup experience may only be specified directly on software or within macos_setup, but not both. See https://fleetdm.com/learn-more-about/yaml-software-setup-experience.", si.URL)
 			}
@@ -2173,7 +2173,7 @@ func (c *Client) doGitOpsNoTeamSetupAndSoftware(
 			appsByAppID[vppApp.AppStoreID] = *vppApp
 
 			_, installDuringSetup := noTeamSoftwareMacOSSetup[fleet.MacOSSetupSoftware{AppStoreID: vppApp.AppStoreID}]
-			if vppApp.InstallDuringSetup.Set {
+			if vppApp.InstallDuringSetup.Valid {
 				if len(noTeamSoftwareMacOSSetup) > 0 {
 					return nil, nil, errors.New("Couldn't edit app store apps. Setup experience may only be specified directly on software or within macos_setup, but not both. See https://fleetdm.com/learn-more-about/yaml-software-setup-experience.")
 				}

--- a/server/service/client.go
+++ b/server/service/client.go
@@ -1622,7 +1622,7 @@ func (c *Client) DoGitOps(
 	dryRun bool,
 	teamDryRunAssumptions *fleet.TeamSpecsDryRunAssumptions,
 	appConfig *fleet.EnrichedAppConfig,
-// pass-by-ref to build lists
+	// pass-by-ref to build lists
 	teamsSoftwareInstallers map[string][]fleet.SoftwarePackageResponse,
 	teamsVPPApps map[string][]fleet.VPPAppResponse,
 	teamsScripts map[string][]fleet.ScriptResponse,

--- a/server/service/integration_enterprise_test.go
+++ b/server/service/integration_enterprise_test.go
@@ -11687,26 +11687,30 @@ func (s *integrationEnterpriseTestSuite) TestApplyTeamsSoftwareConfig() {
 
 	wantSoftwarePackages := []fleet.SoftwarePackageSpec{
 		{
-			URL:               "http://foo.com",
-			SelfService:       true,
-			InstallScript:     fleet.TeamSpecSoftwareAsset{Path: "./foo/install-script.sh"},
-			PostInstallScript: fleet.TeamSpecSoftwareAsset{Path: "./foo/post-install-script.sh"},
-			PreInstallQuery:   fleet.TeamSpecSoftwareAsset{Path: "./foo/query.yaml"},
+			URL:                "http://foo.com",
+			SelfService:        true,
+			InstallScript:      fleet.TeamSpecSoftwareAsset{Path: "./foo/install-script.sh"},
+			PostInstallScript:  fleet.TeamSpecSoftwareAsset{Path: "./foo/post-install-script.sh"},
+			PreInstallQuery:    fleet.TeamSpecSoftwareAsset{Path: "./foo/query.yaml"},
+			InstallDuringSetup: optjson.Bool{Set: true},
 		},
 		{
-			URL:               "http://bar.com",
-			SelfService:       false,
-			InstallScript:     fleet.TeamSpecSoftwareAsset{Path: "./bar/install-script.sh"},
-			PostInstallScript: fleet.TeamSpecSoftwareAsset{Path: "./bar/post-install-script.sh"},
-			PreInstallQuery:   fleet.TeamSpecSoftwareAsset{Path: "./bar/query.yaml"},
+			URL:                "http://bar.com",
+			SelfService:        false,
+			InstallScript:      fleet.TeamSpecSoftwareAsset{Path: "./bar/install-script.sh"},
+			PostInstallScript:  fleet.TeamSpecSoftwareAsset{Path: "./bar/post-install-script.sh"},
+			PreInstallQuery:    fleet.TeamSpecSoftwareAsset{Path: "./bar/query.yaml"},
+			InstallDuringSetup: optjson.Bool{Set: true},
 		},
 	}
 	wantAppStoreApps := []fleet.TeamSpecAppStoreApp{
 		{
-			AppStoreID: "1234",
+			AppStoreID:         "1234",
+			InstallDuringSetup: optjson.Bool{Set: true},
 		},
 		{
-			AppStoreID: "5678",
+			AppStoreID:         "5678",
+			InstallDuringSetup: optjson.Bool{Set: true},
 		},
 	}
 


### PR DESCRIPTION
Fixes #31163.

This also enables setup experience inclusion for FMAs. Includes checks and errors for invalid states.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)

## Testing

- [x] Added/updated automated tests

- [x] QA'd all new/changed functionality manually

## New Fleet configuration settings
- [x] Verified that the setting is exported via `fleetctl generate-gitops`
- [x] Verified the setting is documented in a separate PR to [the GitOps documentation](https://github.com/fleetdm/fleet/blob/main/docs/Configuration/yaml-files.md#L485)
- [x] Verified that the setting is cleared on the server if it is not supplied in a YAML file (or that it is documented as being optional)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Team-level control of software settings in GitOps: setup experience (install during setup), self-service, labels (include/exclude), and categories for packages and App Store apps.
  - Team-level settings are applied to individual packages automatically.
- Validation
  - Clear errors when setup experience is defined in multiple places (software/app vs. macOS setup).
- Documentation
  - Removed outdated note about GitOps-generated outputs.
- Tests
  - Added test cases covering valid team-level configuration and conflicting placement scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->