### PR TITLE
Remove text from remove variable dialog

### DIFF
--- a/frontend/pages/ManageControlsPage/Secrets/components/DeleteSecretModal/DeleteSecretModal.tsx
+++ b/frontend/pages/ManageControlsPage/Secrets/components/DeleteSecretModal/DeleteSecretModal.tsx
@@ -57,12 +57,6 @@ const DeleteSecretModal = ({
         <p>
           This will delete the <b>{secret?.name}</b> custom variable.
         </p>
-        <p>
-          If this custom variable is used in any configuration profiles or
-          scripts, they will fail.
-          <br />
-          To resolve, edit the configuration profile or script.
-        </p>
         <div className="modal-cta-wrap">
           <Button
             variant="alert"


### PR DESCRIPTION
Missing change from #29235.
See decision [here](https://github.com/fleetdm/fleet/issues/29235#issuecomment-3208040863).

<img width="675" height="264" alt="Screenshot 2025-08-25 at 10 14 29 AM" src="https://github.com/user-attachments/assets/0446412e-7d13-40fc-ae2c-94e8bab04b9e" />
