### PR TITLE
4.73 Fleet UI: Add vuln tooltip

### DIFF
--- a/frontend/pages/DashboardPage/cards/OperatingSystems/OSTableConfig.tsx
+++ b/frontend/pages/DashboardPage/cards/OperatingSystems/OSTableConfig.tsx
@@ -19,6 +19,7 @@ import TextCell from "components/TableContainer/DataTable/TextCell";
 import HeaderCell from "components/TableContainer/DataTable/HeaderCell";
 import ViewAllHostsLink from "components/ViewAllHostsLink";
 import LinkCell from "components/TableContainer/DataTable/LinkCell";
+import TooltipWrapper from "components/TooltipWrapper";
 
 import VulnerabilitiesCell from "pages/SoftwarePage/components/tables/VulnerabilitiesCell";
 import OSIcon from "pages/SoftwarePage/components/icons/OSIcon";
@@ -100,7 +101,25 @@ const generateDefaultTableHeaders = (
     ),
   },
   {
-    Header: "Vulnerabilities",
+    Header: (): JSX.Element => {
+      const titleWithTooltip = (
+        <TooltipWrapper
+          tipContent={
+            <>
+              Vulnerabilities on Linux are currently supported <br />
+              for Ubuntu, Debian, and Amazon Linux.
+            </>
+          }
+        >
+          Vulnerabilities
+        </TooltipWrapper>
+      );
+      return (
+        <>
+          <HeaderCell value={titleWithTooltip} disableSortBy />
+        </>
+      );
+    },
     disableSortBy: true,
     accessor: "vulnerabilities",
     Cell: (cellProps: IVulnCellProps) => {


### PR DESCRIPTION
## Issue
Closes #32255 

## Description
- unreleased missing tooltip

## Screenshot of fix
<img width="1092" height="599" alt="Screenshot 2025-08-25 at 11 49 12 AM" src="https://github.com/user-attachments/assets/5204e570-9a08-4e8a-af98-526f7ccedb0d" />

> Note: We try to avoid tooltips longer than 2 lines tall in table headers as they have overflow issues for tables that only have 1 item. Switched to 2 lines tall instead of 3


# Checklist for submitter


## Testing

- [x] QA'd all new/changed functionality manually
