### PR TITLE
Update password requirements check when setting up

### DIFF
--- a/changes/31876-update-password-validator
+++ b/changes/31876-update-password-validator
@@ -1,0 +1,1 @@
+- Added clearer error messages when a new password doesn't meet the password criteria.

--- a/frontend/components/forms/ChangePasswordForm/validate.js
+++ b/frontend/components/forms/ChangePasswordForm/validate.js
@@ -10,8 +10,9 @@ export default (formData) => {
     new_password_confirmation: newPasswordConfirmation,
   } = formData;
 
-  if (newPassword && newPasswordConfirmation && !validPassword(newPassword)) {
-    errors.new_password = "Password must meet the criteria below";
+  const { isValid, error } = validPassword(newPassword);
+  if (newPassword && newPasswordConfirmation && !isValid) {
+    errors.new_password = error;
   }
 
   if (!oldPassword) {

--- a/frontend/components/forms/RegistrationForm/AdminDetails/AdminDetails.jsx
+++ b/frontend/components/forms/RegistrationForm/AdminDetails/AdminDetails.jsx
@@ -62,7 +62,7 @@ class AdminDetails extends Component {
           label="Password"
           type="password"
           tabIndex={tabIndex}
-          helpText="Must include 12 characters, at least 1 number (e.g. 0 - 9), and at least 1 symbol (e.g. &*#)"
+          helpText="12-48 characters, with at least 1 number (e.g. 0 - 9) and 1 symbol (e.g. &*#)."
         />
         <InputField
           {...fields.password_confirmation}

--- a/frontend/components/forms/RegistrationForm/AdminDetails/AdminDetails.tests.jsx
+++ b/frontend/components/forms/RegistrationForm/AdminDetails/AdminDetails.tests.jsx
@@ -65,6 +65,27 @@ describe("AdminDetails - form", () => {
     ).toBeInTheDocument();
   });
 
+  it("validates the password is not too long", async () => {
+    const { user } = renderWithSetup(
+      <AdminDetails handleSubmit={onSubmitSpy} currentPage />
+    );
+
+    await user.type(
+      screen.getByLabelText("Password"),
+      "asasasasasasasasasasasasasasasasasasasasasasasas1!"
+    );
+    await user.type(
+      screen.getByLabelText("Confirm password"),
+      "asasasasasasasasasasasasasasasasasasasasasasasas1!"
+    );
+    await user.click(screen.getByRole("button", { name: "Next" }));
+    // then
+    expect(onSubmitSpy).not.toHaveBeenCalled();
+    expect(
+      screen.getByText("Password is over the character limit")
+    ).toBeInTheDocument();
+  });
+
   it("validates the password field", async () => {
     const { user } = renderWithSetup(
       <AdminDetails handleSubmit={onSubmitSpy} currentPage />

--- a/frontend/components/forms/RegistrationForm/AdminDetails/AdminDetails.tests.jsx
+++ b/frontend/components/forms/RegistrationForm/AdminDetails/AdminDetails.tests.jsx
@@ -91,8 +91,11 @@ describe("AdminDetails - form", () => {
       <AdminDetails handleSubmit={onSubmitSpy} currentPage />
     );
 
-    await user.type(screen.getByLabelText("Password"), "passw0rd");
-    await user.type(screen.getByLabelText("Confirm password"), "passw0rd");
+    await user.type(screen.getByLabelText("Password"), "invalidpassw0rd");
+    await user.type(
+      screen.getByLabelText("Confirm password"),
+      "invalidpassw0rd"
+    );
     await user.click(screen.getByRole("button", { name: "Next" }));
     // then
     expect(onSubmitSpy).not.toHaveBeenCalled();

--- a/frontend/components/forms/RegistrationForm/AdminDetails/helpers.js
+++ b/frontend/components/forms/RegistrationForm/AdminDetails/helpers.js
@@ -22,8 +22,9 @@ const validate = (formData) => {
     errors.name = "Full name must be present";
   }
 
-  if (password && passwordConfirmation && !validPassword(password)) {
-    errors.password = "Password must meet the criteria below";
+  const { isValid, error } = validPassword(password);
+  if (password && passwordConfirmation && !isValid) {
+    errors.password = error;
   }
 
   if (

--- a/frontend/components/forms/ResetPasswordForm/ResetPasswordForm.tests.jsx
+++ b/frontend/components/forms/ResetPasswordForm/ResetPasswordForm.tests.jsx
@@ -89,7 +89,7 @@ describe("ResetPasswordForm - component", () => {
   });
 
   it("does not submit the form if the password is invalid", async () => {
-    const invalidPassword = "invalid";
+    const invalidPassword = "invalidpassword";
     const { user } = renderWithSetup(
       <ResetPasswordForm handleSubmit={submitSpy} />
     );

--- a/frontend/components/forms/ResetPasswordForm/ResetPasswordForm.tsx
+++ b/frontend/components/forms/ResetPasswordForm/ResetPasswordForm.tsx
@@ -50,8 +50,9 @@ const ResetPasswordForm = ({
 
     const validationErrors: { [key: string]: string } = {};
 
-    if (!validatePassword(newPassword)) {
-      validationErrors.new_password = "Password must meet the criteria below";
+    const { isValid, error } = validatePassword(newPassword);
+    if (!isValid) {
+      validationErrors.new_password = error;
     }
 
     if (!validatePresence(newPasswordConfirmation)) {

--- a/frontend/components/forms/validators/valid_password/index.ts
+++ b/frontend/components/forms/validators/valid_password/index.ts
@@ -3,10 +3,23 @@ const NUMBER_PRESENT = /[0-9]+/;
 const SYMBOL_PRESENT = /\W+/;
 
 export default (password = "") => {
-  return (
-    password.length >= 12 &&
-    LETTER_PRESENT.test(password) &&
-    NUMBER_PRESENT.test(password) &&
-    SYMBOL_PRESENT.test(password)
-  );
+  let error = "";
+  let error_code = "";
+  if (password.length < 12) {
+    error = "Password must be at least 12 characters";
+    error_code = "too_short";
+  } else if (password.length > 48) {
+    error = "Password is over the character limit";
+    error_code = "too_long";
+  } else if (
+    !(
+      LETTER_PRESENT.test(password) &&
+      NUMBER_PRESENT.test(password) &&
+      SYMBOL_PRESENT.test(password)
+    )
+  ) {
+    error = "Password must meet the criteria below";
+    error_code = "invalid_format";
+  }
+  return { isValid: !error, error, error_code };
 };

--- a/frontend/components/forms/validators/valid_password/valid_password.tests.js
+++ b/frontend/components/forms/validators/valid_password/valid_password.tests.js
@@ -1,29 +1,65 @@
 import validPassword from "components/forms/validators/valid_password";
 
 describe("validPassword", () => {
-  it("is invalid if the password is not at least 7 characters including a number and a symbol", () => {
+  it("is invalid if the password is not at least 12 characters including a number and a symbol", () => {
     const tooShort = "abc12!";
-    const noSymbols = "abc12456";
-    const noLetters = "$%#12456";
-    const noNumbers = "password$%#";
-    const allLetters = "mypassword";
-    const allNumbers = "123456789";
-    const allSymbols = "!@#$%^&*()";
+    const noSymbols = "abc12456aaaa";
+    const noLetters = "$%#12456!!!!";
+    const noNumbers = "password$%#xxx";
+    const allLetters = "mypasswordxx";
+    const allNumbers = "123456789111";
+    const allSymbols = "!@#$%^&*()!!!!";
+    const tooLong =
+      "asasasasasasasasasasasasasasasasasasasasasasasasasasasasasasasasasasasas1!";
 
     const invalidPasswords = [
-      tooShort,
-      noSymbols,
-      noLetters,
-      noNumbers,
-      allLetters,
-      allNumbers,
-      allSymbols,
+      {
+        password: tooShort,
+        error: "Password must be at least 12 characters",
+        error_code: "too_short",
+      },
+      {
+        password: noSymbols,
+        error: "Password must meet the criteria below",
+        error_code: "invalid_format",
+      },
+      {
+        password: noLetters,
+        error: "Password must meet the criteria below",
+        error_code: "invalid_format",
+      },
+      {
+        password: noNumbers,
+        error: "Password must meet the criteria below",
+        error_code: "invalid_format",
+      },
+      {
+        password: allLetters,
+        error: "Password must meet the criteria below",
+        error_code: "invalid_format",
+      },
+      {
+        password: allNumbers,
+        error: "Password must meet the criteria below",
+        error_code: "invalid_format",
+      },
+      {
+        password: allSymbols,
+        error: "Password must meet the criteria below",
+        error_code: "invalid_format",
+      },
+      {
+        password: tooLong,
+        error: "Password is over the character limit",
+        error_code: "too_long",
+      },
     ];
 
-    invalidPasswords.map((password) => {
-      return expect(validPassword(password)).toEqual(
-        false,
-        `expected ${password} to not be valid`
+    invalidPasswords.map((test) => {
+      console.log(test.password);
+      return expect(validPassword(test.password)).toEqual(
+        { isValid: false, error: test.error, error_code: test.error_code },
+        `expected ${test.password} to not be valid`
       );
     });
   });
@@ -38,7 +74,7 @@ describe("validPassword", () => {
 
     validPasswords.map((password) => {
       return expect(validPassword(password)).toEqual(
-        true,
+        { isValid: true, error: "", error_code: "" },
         `expected ${password} to be valid`
       );
     });

--- a/frontend/pages/admin/UserManagementPage/components/UserForm/UserForm.tsx
+++ b/frontend/pages/admin/UserManagementPage/components/UserForm/UserForm.tsx
@@ -122,8 +122,9 @@ const validate = (
     isExistingUserForcedToPasswordAuth ||
     (!initiallyPasswordAuth && !sso_enabled)
   ) {
-    if (password !== null && !validPassword(password)) {
-      newErrors.password = "Password must meet the criteria below";
+    const { isValid, error } = validPassword(password || "");
+    if (password !== null && !isValid) {
+      newErrors.password = error;
     }
     if (!validatePresence(password)) {
       newErrors.password = "Password field must be completed";


### PR DESCRIPTION
for #31876 

# Details

This PR updates the validation for password requirements to be consistent in all places, and to show more specific error messages when the entered password does not meet the requirements.

Previously the `valid_password` helper just returned a boolean indicating whether a password was valid. It now returns an object with `isValid`, `error` and `error_code` so that different types of password issues can be surfaced. This allows us to continue having a single source of truth for password validation, while providing more helpful error messages when a password doesn't meet our criteria.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [X] Added/updated automated tests
- [X] QA'd all new/changed functionality manually
  - [X] First time setup (adding the initial user)
  - [X] Add user in settings -> manage users
  - [X] Changer user password in settings -> manage users
  - [X] Password reset form
  
