### PR TITLE
Downgrade "denylisted" error to warning

### DIFF
--- a/changes/32274-denylisted-error
+++ b/changes/32274-denylisted-error
@@ -1,0 +1,1 @@
+Downgraded "distributed query is denylisted" error to a warning on the Fleet server since this message indicates a likely issue on the host and not the server. We will surface this issue in the UI in the future.

--- a/server/service/osquery.go
+++ b/server/service/osquery.go
@@ -1043,9 +1043,10 @@ func (svc *Service) SubmitDistributedQueryResults(
 		failed := ok && status != fleet.StatusOK
 		if failed && messages[query] != "" && !noSuchTableRegexp.MatchString(messages[query]) {
 			ll := level.Debug(svc.logger)
-			// We'd like to log these as error for troubleshooting and improving of distributed queries.
+			// We'd like to log these as warning for troubleshooting and improving of distributed queries.
+			// We have multiple feature requests filed to expose this information in the UI, including https://github.com/fleetdm/fleet/issues/18004
 			if messages[query] == "distributed query is denylisted" {
-				ll = level.Error(svc.logger)
+				ll = level.Warn(svc.logger)
 			}
 			ll.Log("query", query, "message", messages[query], "hostID", host.ID)
 		}


### PR DESCRIPTION
Fixes #32274 

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.

## Testing

- [x] QA'd all new/changed functionality manually

Used this query for QA. Got denylisted eventually.
```sql
SELECT * FROM time WHERE unix_time = unix_time AND sleep(300) = 0;
```
