### PR TITLE
Enable Enterprise deletion banner

### DIFF
--- a/frontend/components/App/App.tsx
+++ b/frontend/components/App/App.tsx
@@ -98,10 +98,7 @@ const App = ({ children, location }: IAppProps): JSX.Element => {
   useQuery(["android_enterprise"], () => mdmAndroidAPI.getAndroidEnterprise(), {
     ...DEFAULT_USE_QUERY_OPTIONS,
     retry: false,
-    enabled:
-      false && // TODO: reenable when the BE is completed
-      !!isGlobalAdmin &&
-      !!config?.mdm.android_enabled_and_configured,
+    enabled: !!isGlobalAdmin && !!config?.mdm.android_enabled_and_configured,
     onSuccess: () => {
       setAndroidEnterpriseDeleted(false);
     },

--- a/frontend/components/MDM/AndroidEnterpriseDeletedMessage/AndroidEnterpriseDeletedMessage.tsx
+++ b/frontend/components/MDM/AndroidEnterpriseDeletedMessage/AndroidEnterpriseDeletedMessage.tsx
@@ -12,7 +12,7 @@ const AndroidEnterpriseDeletedMessage = () => {
       color="yellow"
       cta={
         <CustomLink
-          url="https://business.apple.com/" // TODO: get this link
+          url="https://fleetdm.com/learn-more-about/how-to-connect-android-enterprise"
           text="Learn more"
           className={baseClass}
           newTab
@@ -21,7 +21,7 @@ const AndroidEnterpriseDeletedMessage = () => {
       }
     >
       Android MDM is off because Android Enterprise was deleted in Google
-      Workspace. Please turn on Android MDM again.
+      Console. Please reconnect Android Enterprise.
     </InfoBanner>
   );
 };

--- a/frontend/components/MainContent/MainContent.tsx
+++ b/frontend/components/MainContent/MainContent.tsx
@@ -38,6 +38,7 @@ const MainContent = ({
   const {
     config,
     isPremiumTier,
+    isAndroidEnterpriseDeleted,
     isApplePnsExpired,
     isAppleBmExpired,
     isVppExpired,
@@ -59,8 +60,7 @@ const MainContent = ({
     if (isPremiumTier) {
       if (isApplePnsExpired || willApplePnsExpire) {
         banner = <ApplePNCertRenewalMessage expired={isApplePnsExpired} />;
-      } else if (false) {
-        // TODO: remove this when API is ready
+      } else if (isAndroidEnterpriseDeleted) {
         banner = <AndroidEnterpriseDeletedMessage />;
       } else if (isAppleBmExpired || willAppleBmExpire) {
         banner = <AppleBMRenewalMessage expired={isAppleBmExpired} />;


### PR DESCRIPTION
Implements #26756; see also #26868

 ## Summary
  - Shows a banner message in UI when an Enterprise has been deleted

  ## Test plan
  - [x] Frontend linting and formatting passes
  - [x] TypeScript compilation successful
  - [x] All existing component tests continue passing
  - [x] No new runtime errors or regressions introduced
  - [x] Build verification successful