### PR TITLE
Update how deleted hosts show in batch scripts

### DIFF
--- a/server/datastore/mysql/scripts.go
+++ b/server/datastore/mysql/scripts.go
@@ -2310,13 +2310,13 @@ FROM (
 
   -- If batch is not finished, calculate the host result counts live.
   SELECT
-    COUNT(*)                                AS num_targeted,
+    COUNT(bahr.host_id)                     AS num_targeted,
     COUNT(bahr.error)                       AS num_incompatible,
     COUNT(IF(hsr.exit_code = 0, 1, NULL))   AS num_ran,
     COUNT(IF(hsr.exit_code > 0, 1, NULL))   AS num_errored,
     COUNT(IF(hsr.canceled = 1 AND hsr.exit_code IS NULL, 1, NULL)) AS num_canceled,
     (
-      COUNT(*)
+      COUNT(bahr.host_id)
       - COUNT(bahr.error)
       - COUNT(IF(hsr.exit_code = 0, 1, NULL))
       - COUNT(IF(hsr.exit_code > 0, 1, NULL))
@@ -2333,11 +2333,11 @@ FROM (
     ba.created_at                           AS created_at,
     j.not_before                            AS not_before,
     ba.id                                   AS id
-  FROM batch_activity_host_results bahr
+  FROM batch_activities ba 
+  LEFT JOIN batch_activity_host_results bahr
+         ON ba.execution_id = bahr.batch_execution_id
   LEFT JOIN host_script_results hsr
          ON bahr.host_execution_id = hsr.execution_id
-  JOIN batch_activities ba
-         ON ba.execution_id = bahr.batch_execution_id
   JOIN scripts s
          ON ba.script_id = s.id
   LEFT JOIN jobs j


### PR DESCRIPTION
for #32231

# Details

This PR adjusts the queries for listing batch scripts slightly to count _every_ row in `batch_activities` matching the filters, regardless of whether any `batch_activity_host_results` rows exist for it. This handles the edge case of a batch script where all the hosts have been deleted.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [X] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)

## Testing

- [ ] Added/updated automated tests
I didn't add tests for this because these tests have already changed quite a bit in https://github.com/fleetdm/fleet/pull/32174.  I can add tests in there when this merges.

- [X] QA'd all new/changed functionality manually

* Select a host in Manage Hosts, click Run Script, select a script and do Run Now
* Delete that host
* Go to the batch scripts list (Controls -> Scripts -> Batch Progress)
* Verify that the batch script is still listed.

We don't have clear expectations for what numbers should be displayed for the progress of a batch like this, but this PR at least ensures the batch doesn't disappear.

For unreleased bug fixes in a release candidate, one of:

- [X] Confirmed that the fix is not expected to adversely impact load test results

