### PR TITLE
GitOps reference: Add missing `smtp_settings`

### DIFF
--- a/docs/Configuration/yaml-files.md
+++ b/docs/Configuration/yaml-files.md
@@ -1006,7 +1006,7 @@ If you're self hosting Fleet, the `smtp_settings` section lets you configure an 
 
 If you're using Fleet's managed-cloud offering, an SMTP server is already setup for you.
 
-For possible options, see the parameters for the [smtp_settings object in the API]([https://fleetdm.com/docs/rest-api/rest-api#add-label](https://fleetdm.com/docs/rest-api/rest-api#smtp-settings)).
+For possible options, see the parameters for the [smtp_settings object in the API](https://fleetdm.com/docs/rest-api/rest-api#smtp-settings).
 
 ##### Example
 

--- a/docs/Configuration/yaml-files.md
+++ b/docs/Configuration/yaml-files.md
@@ -1000,6 +1000,30 @@ org_settings:
 Can only be configured for all teams (`org_settings`). To target rules to specific teams, target the
 queries referencing the rules to the desired teams.
 
+#### smtp_settings
+
+If you're self hosting Fleet, the `smtp_settings` section lets you configure an e-mail (SMTP) server. This enables Fleet to send user invite and password reset emails.
+
+If you're using Fleet's managed-cloud offering, an SMTP server is already setup for you.
+
+For possible options, see the parameters for the [smtp_settings object in the API]([https://fleetdm.com/docs/rest-api/rest-api#add-label](https://fleetdm.com/docs/rest-api/rest-api#smtp-settings)).
+
+##### Example
+
+```yaml
+org_settings:
+  smtp_settings:
+    enable_smtp: true
+    sender_address: organization@example.com
+    server: localhost
+    port: 1025
+    authentication_type: none
+```
+
+Can only be configured for all teams (`org_settings`).
+
+Unlike other options, ommitting `smtp_settings` or leaving it blank won't reset the values back to the default.
+
 <meta name="title" value="GitOps">
 <meta name="description" value="Reference documentation for Fleet's GitOps workflow. See examples and configuration options.">
 <meta name="pageOrderInSection" value="1500">

--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -1410,7 +1410,7 @@ Modifies the Fleet's configuration with the supplied information.
 | authentication_method             | string  | The authentication method used to make authenticate requests to SMTP server. Options include `"authmethod_plain"`, `"authmethod_cram_md5"`, and `"authmethod_login"`. |
 | domain                            | string  | The domain for the SMTP server.                                                                                                                                       |
 | verify_ssl_certs                  | boolean | Whether or not SSL certificates are verified by the SMTP server. Turn this off (not recommended) if you use a self-signed certificate.                                |
-| enabled_start_tls                 | boolean | Detects if STARTTLS is enabled in your SMTP server and starts to use it.                                                                                              |
+| enable_start_tls                 | boolean | Detects if STARTTLS is enabled in your SMTP server and starts to use it.                                                                                              |
 
 <br/>
 
@@ -1425,7 +1425,7 @@ Modifies the Fleet's configuration with the supplied information.
     "sender_address": "",
     "server": "localhost",
     "port": 1025,
-    "authentication_type": "authtype_username_none",
+    "authentication_type": "none",
     "user_name": "",
     "password": "",
     "enable_ssl_tls": true,

--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -1414,6 +1414,8 @@ Modifies the Fleet's configuration with the supplied information.
 
 <br/>
 
+> The Fleet server relies on the host operating system's trust store to validate TLS certificates. If your email server uses a private or self-signed certificate, you’ll need to add the certificate to the OS trust store on the server running Fleet. Fleet doesn't currently support uploading custom CA certificates via the UI or API.
+
 ##### Example request body
 
 ```json


### PR DESCRIPTION
Addresses this bug: https://github.com/fleetdm/fleet/issues/29815

More history/context in this PR: https://github.com/fleetdm/fleet/pull/29346
