### PR TITLE
Prevent tampering of the Fleet Article and support files

### DIFF
--- a/assets/configuration-profiles/BlockMDMUnenrollment.xml
+++ b/assets/configuration-profiles/BlockMDMUnenrollment.xml
@@ -1,0 +1,13 @@
+<Replace>
+  <CmdID>25</CmdID>
+  <Item>
+    <Target>
+      <LocURI>./Device/Vendor/MSFT/Policy/Config/Experience/AllowManualMDMUnenrollment</LocURI>
+    </Target>
+    <Meta>
+      <Format xmlns="syncml:metinf">int</Format>
+      <Type>text/plain</Type>
+    </Meta>
+    <Data>0</Data>
+  </Item>
+</Replace>

--- a/assets/windows-fleet-hardening.ps1
+++ b/assets/windows-fleet-hardening.ps1
@@ -1,0 +1,27 @@
+# Prevents uninstall/change of Fleet osquery via Windows UI.
+# Sets NoRemove and NoModify = 1 under Fleet osquery uninstall entry.
+# Hides uninstall/change options across Control Panel and Settings > Apps.
+# Works on all Windows editions.
+
+$UninstallPaths = @(
+    "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\*",
+    "HKLM:\SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall\*"
+)
+
+$FleetEntry = Get-ItemProperty -Path $UninstallPaths -ErrorAction SilentlyContinue |
+              Where-Object { $_.DisplayName -like "Fleet osquery*" }
+
+if ($FleetEntry) {
+    Write-Output "[INFO] Fleet osquery found: $($FleetEntry.DisplayName)"
+    $RegKeyPath = $FleetEntry.PSPath
+
+    New-ItemProperty -Path $RegKeyPath -Name "NoRemove" -Value 1 -PropertyType DWord -Force | Out-Null
+    Write-Output "[SET] NoRemove = 1"
+
+    New-ItemProperty -Path $RegKeyPath -Name "NoModify" -Value 1 -PropertyType DWord -Force | Out-Null
+    Write-Output "[SET] NoModify = 1"
+
+    Write-Output "[DONE] Fleet osquery uninstall options hardened."
+} else {
+    Write-Output "[WARN] Fleet osquery not found. Nothing changed."
+}


### PR DESCRIPTION
# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [ ] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [ ] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes

## Testing

- [ ] Added/updated automated tests
- [ ] Where appropriate, [automated tests simulate multiple hosts and test for host isolation](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/reference/patterns-backend.md#unit-testing) (updates to one hosts's records do not affect another)

- [ ] QA'd all new/changed functionality manually

For unreleased bug fixes in a release candidate, one of:

- [ ] Confirmed that the fix is not expected to adversely impact load test results
- [ ] Alerted the release DRI if additional load testing is needed

## Database migrations

- [ ] Checked table schema to confirm autoupdate
- [ ] Checked schema for all modified table for columns that will auto-update timestamps during migration.
- [ ] Confirmed that updating the timestamps is acceptable, and will not cause unwanted side effects.
- [ ] Ensured the correct collation is explicitly set for character columns (`COLLATE utf8mb4_unicode_ci`).

## New Fleet configuration settings

- [ ] Setting(s) is/are explicitly excluded from GitOps

If you didn't check the box above, follow this checklist for GitOps-enabled settings:

- [ ] Verified that the setting is exported via `fleetctl generate-gitops`
- [ ] Verified the setting is documented in a separate PR to [the GitOps documentation](https://github.com/fleetdm/fleet/blob/main/docs/Configuration/yaml-files.md#L485)
- [ ] Verified that the setting is cleared on the server if it is not supplied in a YAML file (or that it is documented as being optional)
- [ ] Verified that any relevant UI is disabled when GitOps mode is enabled

## fleetd/orbit/Fleet Desktop

- [ ] Verified compatibility with the latest released version of Fleet (see [Must rule](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/workflows/fleetd-development-and-release-strategy.md))
- [ ] If the change applies to only one platform, confirmed that `runtime.GOOS` is used as needed to isolate changes
- [ ] Verified that fleetd runs on macOS, Linux and Windows
- [ ] Verified auto-update works from the released version of component to the new version (see [tools/tuf/test](../tools/tuf/test/README.md))
