### PR TITLE
Change job title from 'Product Design Engineer' to 'Product Design'

### DIFF
--- a/handbook/company/open-positions.yml
+++ b/handbook/company/open-positions.yml
@@ -211,7 +211,7 @@
       - ➕ Bonus: Direct experience with Fleet, MDM, osquery or SQL query writing, and working with Client Platform Engineering, SRE, or Security Engineering teams.
 
 
-- jobTitle: 🦢 Product Design
+- jobTitle: 🦢 Product Designer
   department: Product Design
   hiringManagerName: Noah Talerman
   hiringManagerLinkedInUrl: https://www.linkedin.com/in/noah-talerman/

--- a/handbook/company/open-positions.yml
+++ b/handbook/company/open-positions.yml
@@ -211,7 +211,7 @@
       - ➕ Bonus: Direct experience with Fleet, MDM, osquery or SQL query writing, and working with Client Platform Engineering, SRE, or Security Engineering teams.
 
 
-- jobTitle: 🦢 Product Design Engineer
+- jobTitle: 🦢 Product Design
   department: Product Design
   hiringManagerName: Noah Talerman
   hiringManagerLinkedInUrl: https://www.linkedin.com/in/noah-talerman/


### PR DESCRIPTION
@noahtalerman I think we should revert this to "Product Designer" and just be clear in the job requirements and interview process that it's a heavy technical role. 

Why? Because the responsibilities of this role are the same as Rachael and Marko, who are both "Product Designer". This introduced a new "Product Design Engineer" role that is functionally no different than the existing "Product Designer" roles, so IMO it adds confusion.

