### PR TITLE
Update calendar event text to match recent changes to "My device" page

### DIFF
--- a/frontend/pages/policies/ManagePoliciesPage/components/CalendarEventPreviewModal/CalendarEventPreviewModal.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/components/CalendarEventPreviewModal/CalendarEventPreviewModal.tsx
@@ -100,7 +100,7 @@ const CalendarEventPreviewModal = ({
                     </li>
                     <li>
                       Follow instructions to resolve any policies marked{" "}
-                      {`"No"`}
+                      {`"Fail"`}
                     </li>
                     <li>
                       Click <b>Refetch</b>

--- a/server/fleet/calendar.go
+++ b/server/fleet/calendar.go
@@ -15,7 +15,7 @@ const (
 	CalendarDefaultDescription = "needs to make sure your device meets the organization's requirements."
 	CalendarDefaultResolution  = (`• Click the <a href="https://fleetdm.com/better" rel="noreferrer" target="_blank" >Fleet</a> icon in your computer&apos;s menu and<br />&nbsp;&nbsp;&nbsp;select <b>My device</b>
 • Navigate to the <b>Policies</b> tab
-• Follow instructions to resolve any policies marked "No"
+• Follow instructions to resolve any policies marked "Fail"
 • Click <b>Refetch</b>`)
 )
 


### PR DESCRIPTION
We changed "No" to "Fail" as part of the conditional access story.