### PR TITLE
Revise generated CPE for Docker Desktop for macOS to match more recent CVEs, make Docker CVE CPEs consistent

### DIFF
--- a/cmd/cve/validate/main.go
+++ b/cmd/cve/validate/main.go
@@ -84,6 +84,16 @@ func checkNVDVulnerabilities(vulnPath string, logger log.Logger) {
 	if vulns["CVE-2024-0540"].CVSSv3BaseScore() != 9.8 { // primary source CVSS score
 		panic(errors.New("cvss v3 spot-check failed for CVE-2024-0540"))
 	}
+
+	vulns, err = cvefeed.LoadJSONDictionary(filepath.Join(vulnPath, "nvdcve-1.1-2023.json.gz"))
+	if err != nil {
+		panic(err)
+	}
+
+	// make sure we're rewriting docker_desktop to docker
+	if vulns["CVE-2023-0626"].Config()[0].Product != "desktop" {
+		panic(errors.New("docker_desktop spot-check failed for CVE-2023-0626"))
+	}
 }
 
 func checkGovalDictionaryVulnerabilities(vulnPath string) {

--- a/server/vulnerabilities/nvd/cpe_test.go
+++ b/server/vulnerabilities/nvd/cpe_test.go
@@ -1313,7 +1313,7 @@ func TestCPEFromSoftwareIntegration(t *testing.T) {
 				Source:           "apps",
 				Version:          "4.7.1",
 				BundleIdentifier: "com.docker.docker",
-			}, cpe: "cpe:2.3:a:docker:docker_desktop:4.7.1:*:*:*:*:macos:*:*",
+			}, cpe: "cpe:2.3:a:docker:desktop:4.7.1:*:*:*:*:macos:*:*",
 		},
 		{
 			software: fleet.Software{
@@ -1321,7 +1321,7 @@ func TestCPEFromSoftwareIntegration(t *testing.T) {
 				Source:           "apps",
 				Version:          "4.16.2",
 				BundleIdentifier: "com.electron.dockerdesktop",
-			}, cpe: "cpe:2.3:a:docker:docker_desktop:4.16.2:*:*:*:*:macos:*:*",
+			}, cpe: "cpe:2.3:a:docker:desktop:4.16.2:*:*:*:*:macos:*:*",
 		},
 		{
 			software: fleet.Software{
@@ -1329,7 +1329,7 @@ func TestCPEFromSoftwareIntegration(t *testing.T) {
 				Source:           "apps",
 				Version:          "3.5.0",
 				BundleIdentifier: "com.electron.docker-frontend",
-			}, cpe: "cpe:2.3:a:docker:docker_desktop:3.5.0:*:*:*:*:macos:*:*",
+			}, cpe: "cpe:2.3:a:docker:desktop:3.5.0:*:*:*:*:macos:*:*",
 		},
 		// 2023-03-06: there are no entries for the docker python package at the NVD dataset.
 		{

--- a/server/vulnerabilities/nvd/cpe_translations.json
+++ b/server/vulnerabilities/nvd/cpe_translations.json
@@ -118,7 +118,7 @@
       "source": ["apps"]
     },
     "filter": {
-      "product": ["docker_desktop"],
+      "product": ["desktop"],
       "vendor": ["docker"]
     }
   },

--- a/server/vulnerabilities/nvd/cve_test.go
+++ b/server/vulnerabilities/nvd/cve_test.go
@@ -574,6 +574,14 @@ func TestTranslateCPEToCVE(t *testing.T) {
 			excludedCVEs:      []string{"CVE-2025-6554"},
 			continuesToUpdate: true,
 		},
+		"cpe:2.3:a:docker:desktop:4.43.2:*:*:*:*:macos:*:*": {
+			includedCVEs:      []cve{{ID: "CVE-2025-9074", resolvedInVersion: "4.44.3"}},
+			continuesToUpdate: true,
+		},
+		"cpe:2.3:a:docker:desktop:4.39.0:*:*:*:*:windows:*:*": {
+			includedCVEs:      []cve{{ID: "CVE-2025-9074", resolvedInVersion: "4.44.3"}},
+			continuesToUpdate: true,
+		},
 	}
 
 	cveOSTests := []struct {

--- a/server/vulnerabilities/nvd/sync/cve_syncer.go
+++ b/server/vulnerabilities/nvd/sync/cve_syncer.go
@@ -526,15 +526,14 @@ func transformVuln(year int, item nvdapi.CVEItem) nvdapi.CVEItem {
 		(year == 2021 && slices.Contains(dockerDesktopCVEs2021, *item.CVE.ID)) ||
 		(year == 2020 && slices.Contains(dockerDesktopCVEs2020, *item.CVE.ID)) {
 
-		for configID, _ := range item.CVE.Configurations {
-			for nodeID, _ := range item.CVE.Configurations[configID].Nodes {
-				for matchID, _ := range item.CVE.Configurations[configID].Nodes[nodeID].CPEMatch {
+		for configID := range item.CVE.Configurations {
+			for nodeID := range item.CVE.Configurations[configID].Nodes {
+				for matchID := range item.CVE.Configurations[configID].Nodes[nodeID].CPEMatch {
 					item.CVE.Configurations[configID].Nodes[nodeID].CPEMatch[matchID].Criteria =
-						strings.Replace(
+						strings.ReplaceAll(
 							item.CVE.Configurations[configID].Nodes[nodeID].CPEMatch[matchID].Criteria,
 							"docker_desktop",
 							"desktop",
-							-1,
 						)
 				}
 			}

--- a/server/vulnerabilities/nvd/sync/cve_syncer.go
+++ b/server/vulnerabilities/nvd/sync/cve_syncer.go
@@ -455,7 +455,7 @@ func (s *CVE) sync(ctx context.Context, lastModStartDate *string) (newLastModSta
 				return "", err
 			}
 			vulnerabilitiesReceived++
-			cvesByYear[year] = append(cvesByYear[year], transformVuln(vuln))
+			cvesByYear[year] = append(cvesByYear[year], transformVuln(year, vuln))
 		}
 
 		// Dump vulnerabilities to the year files to reduce memory footprint.
@@ -503,11 +503,42 @@ func (s *CVE) sync(ctx context.Context, lastModStartDate *string) (newLastModSta
 	return newLastModStartDate, nil
 }
 
+var (
+	dockerDesktopCVEs2023 = []string{
+		"CVE-2023-0627", "CVE-2023-0629", "CVE-2023-5165", "CVE-2023-5166", "CVE-2023-0633", "CVE-2023-0628",
+		"CVE-2023-0626", "CVE-2023-0625",
+	}
+	dockerDesktopCVEs2022 = []string{"CVE-2022-26659", "CVE-2022-23774"}
+	dockerDesktopCVEs2021 = []string{"CVE-2021-45449", "CVE-2021-44719"}
+	dockerDesktopCVEs2020 = []string{"CVE-2020-11492", "CVE-2020-15360"}
+)
+
 // cleans up vulnerability feed entries that are incorrect from NVD, allowing fixing bugged NVD rules without needing
 // to update Fleet server
-func transformVuln(item nvdapi.CVEItem) nvdapi.CVEItem {
+func transformVuln(year int, item nvdapi.CVEItem) nvdapi.CVEItem {
 	if item.CVE.ID != nil && *item.CVE.ID == "CVE-2024-54559" {
 		item.CVE.Configurations[0].Nodes[0].CPEMatch = item.CVE.Configurations[0].Nodes[0].CPEMatch[0:1]
+	}
+
+	// Docker Desktop CVEs prior to 2024 have the wrong CPE in NVD's database
+	if (year == 2023 && slices.Contains(dockerDesktopCVEs2023, *item.CVE.ID)) ||
+		(year == 2022 && slices.Contains(dockerDesktopCVEs2022, *item.CVE.ID)) ||
+		(year == 2021 && slices.Contains(dockerDesktopCVEs2021, *item.CVE.ID)) ||
+		(year == 2020 && slices.Contains(dockerDesktopCVEs2020, *item.CVE.ID)) {
+
+		for configID, _ := range item.CVE.Configurations {
+			for nodeID, _ := range item.CVE.Configurations[configID].Nodes {
+				for matchID, _ := range item.CVE.Configurations[configID].Nodes[nodeID].CPEMatch {
+					item.CVE.Configurations[configID].Nodes[nodeID].CPEMatch[matchID].Criteria =
+						strings.Replace(
+							item.CVE.Configurations[configID].Nodes[nodeID].CPEMatch[matchID].Criteria,
+							"docker_desktop",
+							"desktop",
+							-1,
+						)
+				}
+			}
+		}
 	}
 
 	return item


### PR DESCRIPTION
Fixes #32323. 

# Checklist for submitter

## Testing

- [x] Added/updated automated tests

- [ ] QA'd all new/changed functionality manually