### PR TITLE
Fix FMA update PR name filter

### DIFF
--- a/.github/workflows/ingest-maintained-apps.yml
+++ b/.github/workflows/ingest-maintained-apps.yml
@@ -66,7 +66,7 @@ jobs:
               state: 'open',
               per_page: 100
             });
-            return pullRequests.filter(pr => pr.title.includes('Update Fleet-maintained apps') && pr.user.login === 'github-actions[bot]').map(pr => pr.number);
+            return pullRequests.filter(pr => pr.title.includes('Update Fleet-maintained apps') && pr.user.login === 'fleet-release').map(pr => pr.number);
 
       - name: Get Assignee IDs
         id: get_assignee_ids


### PR DESCRIPTION
fixing the name filter here to use the update `fleet-release` user PR to close old PRs