### PR TITLE
Fleet UI: Allow software + os filter onto manage host page

### DIFF
--- a/frontend/pages/SoftwarePage/SoftwareOSDetailsPage/SoftwareOSDetailsPage.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareOSDetailsPage/SoftwareOSDetailsPage.tsx
@@ -39,6 +39,7 @@ import SoftwareVulnerabilitiesTable from "../components/tables/SoftwareVulnerabi
 import DetailsNoHosts from "../components/cards/DetailsNoHosts";
 import { VulnsNotSupported } from "../components/tables/SoftwareVulnerabilitiesTable/SoftwareVulnerabilitiesTable";
 import OSKernelsTable from "../components/tables/OSKernelsTable";
+import { createMockLinuxOSVersion } from "__mocks__/operatingSystemsMock";
 
 const baseClass = "software-os-details-page";
 
@@ -136,6 +137,8 @@ export const KernelsCard = ({
   >
     <CardHeader header="Kernels" />
     <OSKernelsTable
+      osName={osVersion.name_only}
+      osVersion={osVersion.version}
       data={osVersion.kernels}
       isLoading={isLoading}
       router={router}
@@ -177,7 +180,7 @@ const SoftwareOSDetailsPage = ({
   });
 
   const {
-    data: { os_version: osVersionDetails, counts_updated_at } = {},
+    data: { os_version: osVersionDetails2, counts_updated_at } = {},
     isLoading,
     isError: isOsVersionError,
   } = useQuery<
@@ -210,6 +213,9 @@ const SoftwareOSDetailsPage = ({
     }
   );
 
+  const osVersionDetails = createMockLinuxOSVersion();
+
+  console.log("osVersionDetails", osVersionDetails);
   const onTeamChange = useCallback(
     (teamId: number) => {
       handleTeamChange(teamId);

--- a/frontend/pages/SoftwarePage/SoftwareOSDetailsPage/SoftwareOSDetailsPage.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareOSDetailsPage/SoftwareOSDetailsPage.tsx
@@ -39,7 +39,6 @@ import SoftwareVulnerabilitiesTable from "../components/tables/SoftwareVulnerabi
 import DetailsNoHosts from "../components/cards/DetailsNoHosts";
 import { VulnsNotSupported } from "../components/tables/SoftwareVulnerabilitiesTable/SoftwareVulnerabilitiesTable";
 import OSKernelsTable from "../components/tables/OSKernelsTable";
-import { createMockLinuxOSVersion } from "__mocks__/operatingSystemsMock";
 
 const baseClass = "software-os-details-page";
 

--- a/frontend/pages/SoftwarePage/SoftwareOSDetailsPage/SoftwareOSDetailsPage.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareOSDetailsPage/SoftwareOSDetailsPage.tsx
@@ -180,7 +180,7 @@ const SoftwareOSDetailsPage = ({
   });
 
   const {
-    data: { os_version: osVersionDetails2, counts_updated_at } = {},
+    data: { os_version: osVersionDetails, counts_updated_at } = {},
     isLoading,
     isError: isOsVersionError,
   } = useQuery<
@@ -213,9 +213,6 @@ const SoftwareOSDetailsPage = ({
     }
   );
 
-  const osVersionDetails = createMockLinuxOSVersion();
-
-  console.log("osVersionDetails", osVersionDetails);
   const onTeamChange = useCallback(
     (teamId: number) => {
       handleTeamChange(teamId);

--- a/frontend/pages/SoftwarePage/components/cards/SoftwareDetailsSummary/SoftwareDetailsSummary.tsx
+++ b/frontend/pages/SoftwarePage/components/cards/SoftwareDetailsSummary/SoftwareDetailsSummary.tsx
@@ -47,6 +47,7 @@ const SoftwareDetailsSummary = ({
   isOperatingSystem,
 }: ISoftwareDetailsSummaryProps) => {
   const hostCountPath = getPathWithQueryParams(paths.MANAGE_HOSTS, queryParams);
+  console.log("queryPArams", queryParams);
   // Remove host count for tgz_packages only
   const showHostCount = source !== "tgz_packages";
 

--- a/frontend/pages/SoftwarePage/components/cards/SoftwareDetailsSummary/SoftwareDetailsSummary.tsx
+++ b/frontend/pages/SoftwarePage/components/cards/SoftwareDetailsSummary/SoftwareDetailsSummary.tsx
@@ -47,7 +47,6 @@ const SoftwareDetailsSummary = ({
   isOperatingSystem,
 }: ISoftwareDetailsSummaryProps) => {
   const hostCountPath = getPathWithQueryParams(paths.MANAGE_HOSTS, queryParams);
-  console.log("queryPArams", queryParams);
   // Remove host count for tgz_packages only
   const showHostCount = source !== "tgz_packages";
 

--- a/frontend/pages/SoftwarePage/components/tables/OSKernelsTable/OSKernelsTable.tsx
+++ b/frontend/pages/SoftwarePage/components/tables/OSKernelsTable/OSKernelsTable.tsx
@@ -39,6 +39,8 @@ const NoKernelsDetected = (): JSX.Element => {
 };
 
 interface ISoftwareVulnerabilitiesTableProps {
+  osName: string;
+  osVersion: string;
   data: IOperatingSystemKernels[];
   isLoading: boolean;
   className?: string;
@@ -53,6 +55,8 @@ interface IRowProps extends Row {
 }
 
 const OSKernelsTable = ({
+  osName,
+  osVersion,
   data,
   isLoading,
   className,
@@ -76,7 +80,11 @@ const OSKernelsTable = ({
     }
   };
 
-  const tableHeaders = generateTableConfig({ teamId: teamIdForApi });
+  const tableHeaders = generateTableConfig({
+    teamId: teamIdForApi,
+    osName,
+    osVersion,
+  });
 
   const rendersOsKernelsVersionCount = () => (
     <TableCount name="items" count={data?.length} />

--- a/frontend/pages/SoftwarePage/components/tables/OSKernelsTable/OSKernelsTableConfig.tsx
+++ b/frontend/pages/SoftwarePage/components/tables/OSKernelsTable/OSKernelsTableConfig.tsx
@@ -20,6 +20,8 @@ import VulnerabilitiesCell from "../VulnerabilitiesCell";
 
 interface IOsKernelsTableConfigProps {
   teamId?: number;
+  osName: string;
+  osVersion: string;
 }
 
 type IHostCountCellProps = INumberCellProps<IOperatingSystemKernels>;
@@ -27,7 +29,11 @@ type IVersionCellProps = IStringCellProps<IOperatingSystemKernels>;
 type IViewAllHostsLinkProps = CellProps<IOperatingSystemKernels>;
 type IVulnCellProps = CellProps<IOperatingSystemKernels, string[] | null>;
 
-const generateTableConfig = ({ teamId }: IOsKernelsTableConfigProps) => {
+const generateTableConfig = ({
+  teamId,
+  osName,
+  osVersion,
+}: IOsKernelsTableConfigProps) => {
   const tableHeaders = [
     {
       title: "Version",
@@ -101,6 +107,8 @@ const generateTableConfig = ({ teamId }: IOsKernelsTableConfigProps) => {
                 queryParams={{
                   software_version_id: cellProps.row.original.id,
                   team_id: teamId,
+                  os_name: osName,
+                  os_version: osVersion,
                 }}
                 className="software-link"
                 rowHover

--- a/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
@@ -1044,6 +1044,13 @@ const ManageHostsPage = ({
         newQueryParams.software_id = softwareId;
       } else if (softwareVersionId) {
         newQueryParams.software_version_id = softwareVersionId;
+        // Software version can be combined with os name and os version
+        // e.g. Kernel version 6.8.0-71.71 (software version) on Ubuntu 24.04.2LTS (os name and os version)
+        if (osVersionId || (osName && osVersion)) {
+          newQueryParams.os_version_id = osVersionId;
+          newQueryParams.os_name = osName;
+          newQueryParams.os_version = osVersion;
+        }
       } else if (softwareTitleId) {
         newQueryParams.software_title_id = softwareTitleId;
         if (softwareStatus && teamIdForApi !== API_ALL_TEAMS_ID) {

--- a/frontend/pages/hosts/ManageHostsPage/components/HostsFilterBlock/HostsFilterBlock.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/components/HostsFilterBlock/HostsFilterBlock.tsx
@@ -652,6 +652,17 @@ const HostsFilterBlock = ({
         case !!softwareStatus:
           return renderSoftwareInstallStatusBlock();
         case !!softwareId || !!softwareVersionId || !!softwareTitleId:
+          // Software version can be combined with os name and os version
+          // e.g. Kernel version 6.8.0-71.71 (software version) on Ubuntu 24.04.2LTS (os name and os version)
+          // Note: This is our only double filter available in the UI, are there others?
+          if (!!osVersionId || (!!osName && !!osVersion)) {
+            return (
+              <div className={`${baseClass}__multi-filter`}>
+                {renderSoftwareFilterBlock()}
+                {renderOSFilterBlock()}
+              </div>
+            );
+          }
           return renderSoftwareFilterBlock();
         case !!mdmId:
           return renderMDMSolutionFilterBlock();

--- a/frontend/pages/hosts/ManageHostsPage/components/HostsFilterBlock/_styles.scss
+++ b/frontend/pages/hosts/ManageHostsPage/components/HostsFilterBlock/_styles.scss
@@ -36,4 +36,9 @@
       width: 150px; // Fits all dropdown options without resizing
     }
   }
+
+  &__multi-filter {
+    display: flex;
+    gap: $pad-small;
+  }
 }

--- a/frontend/utilities/url/index.ts
+++ b/frontend/utilities/url/index.ts
@@ -252,18 +252,24 @@ export const reconcileMutuallyExclusiveHostParams = ({
     case !!softwareStatus ||
       !!softwareTitleId ||
       !!softwareVersionId ||
-      !!softwareId:
-      return reconcileSoftwareParams({
+      !!softwareId: {
+      const params: Record<string, unknown> = reconcileSoftwareParams({
         teamId,
         softwareId,
         softwareVersionId,
         softwareTitleId,
         softwareStatus,
       });
-    case !!softwareVersionId:
-      return { software_version_id: softwareVersionId };
-    case !!softwareId:
-      return { software_id: softwareId };
+      // Software version can be combined with os name and os version
+      // e.g. Kernel version 6.8.0-71.71 (software version) on Ubuntu 24.04.2LTS (os name and os version)
+      if (osVersionId) {
+        params.os_version_id = osVersionId;
+      } else if (osName && osVersion) {
+        params.os_name = osName;
+        params.os_version = osVersion;
+      }
+      return params;
+    }
     case !!osVersionId:
       return { os_version_id: osVersionId };
     case !!osName && !!osVersion:


### PR DESCRIPTION
## Issue
Closes #32259 

## Description
- Allow multi filters for only software + os name/version on the manage host table

> Note: this is our first double pill in the host table UI

## Screen recording of FE making the correct call
https://fleetdm.zoom.us/clips/share/qy1oN6ePRAWu8PlLONJEZA

~~Need E2E QA with a dev environment that has this instance~~

Screenshot of QA <3
<img width="1363" height="499" alt="Screenshot 2025-08-27 at 3 35 59 PM" src="https://github.com/user-attachments/assets/68b7728b-eeb9-4306-a054-ca2dfda7cb70" />


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

## Testing

- [x] QA'd all new/changed functionality manually
